### PR TITLE
Implemented Shuffle Function for Beacon State

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -10,11 +10,14 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/database:go_default_library",
+        "//beacon-chain/params:go_default_library",
         "//beacon-chain/types:go_default_library",
+        "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//ethdb:go_default_library",
         "@com_github_ethereum_go_ethereum//rlp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_syndtr_goleveldb//leveldb/errors:go_default_library",
+        "@org_golang_x_crypto//blake2s:go_default_library",
     ],
 )
 
@@ -27,6 +30,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/database:go_default_library",
+        "//beacon-chain/params:go_default_library",
         "//beacon-chain/types:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",

--- a/beacon-chain/blockchain/core.go
+++ b/beacon-chain/blockchain/core.go
@@ -90,10 +90,10 @@ func (b *BeaconChain) persist() error {
 	return b.db.Put([]byte(stateLookupKey), encodedState)
 }
 
-// shuffle returns a list of pseudorandomly sampled
+// Shuffle returns a list of pseudorandomly sampled
 // indices to use to select attesters and proposers.
-func shuffle(seed common.Hash, validatorCount int) ([]int, error) {
-	if validatorCount >= params.MaxValidators {
+func Shuffle(seed common.Hash, validatorCount int) ([]int, error) {
+	if validatorCount > params.MaxValidators {
 		return nil, errors.New("Validator count has exceeded MaxValidator Count")
 	}
 
@@ -103,13 +103,17 @@ func shuffle(seed common.Hash, validatorCount int) ([]int, error) {
 		validatorList[i] = i
 	}
 
-	hashSeed, _ := blake2s.New256(seed[:])
+	hashSeed, err := blake2s.New256(seed[:])
+	if err != nil {
+		return nil, err
+	}
+
 	hashSeedByte := hashSeed.Sum(nil)
 
 	// shuffle stops at the second to last index
 	for i := 0; i < validatorCount-1; i++ {
 		// convert every 3 bytes to random number, replace validator index with that number
-		for j := 0; j+3 < len(hashSeedByte); j = j + 3 {
+		for j := 0; j+3 < len(hashSeedByte); j += 3 {
 			swapNum := int(hashSeedByte[j] + hashSeedByte[j+1] + hashSeedByte[j+2])
 			remaining := validatorCount - i
 			swapPos := swapNum%remaining + i

--- a/beacon-chain/blockchain/core.go
+++ b/beacon-chain/blockchain/core.go
@@ -1,14 +1,18 @@
 package blockchain
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/prysmaticlabs/prysm/beacon-chain/params"
 	"github.com/prysmaticlabs/prysm/beacon-chain/types"
 	log "github.com/sirupsen/logrus"
 	leveldberrors "github.com/syndtr/goleveldb/leveldb/errors"
+	"golang.org/x/crypto/blake2s"
 )
 
 var stateLookupKey = "beaconchainstate"
@@ -84,4 +88,33 @@ func (b *BeaconChain) persist() error {
 		return err
 	}
 	return b.db.Put([]byte(stateLookupKey), encodedState)
+}
+
+// shuffle returns a list of pseudorandomly sampled
+// indices to use to select attesters and proposers.
+func shuffle(seed common.Hash, validatorCount int) ([]int, error) {
+	if validatorCount >= params.MaxValidators {
+		return nil, errors.New("Validator count has exceeded MaxValidator Count")
+	}
+
+	// construct a list of indices up to MaxValidators
+	validatorList := make([]int, validatorCount)
+	for i := range validatorList {
+		validatorList[i] = i
+	}
+
+	hashSeed, _ := blake2s.New256(seed[:])
+	hashSeedByte := hashSeed.Sum(nil)
+
+	// shuffle stops at the second to last index
+	for i := 0; i < validatorCount-1; i++ {
+		// convert every 3 bytes to random number, replace validator index with that number
+		for j := 0; j+3 < len(hashSeedByte); j = j + 3 {
+			swapNum := int(hashSeedByte[j] + hashSeedByte[j+1] + hashSeedByte[j+2])
+			remaining := validatorCount - i
+			swapPos := swapNum%remaining + i
+			validatorList[i], validatorList[swapPos] = validatorList[swapPos], validatorList[i]
+		}
+	}
+	return validatorList, nil
 }

--- a/beacon-chain/blockchain/core_test.go
+++ b/beacon-chain/blockchain/core_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prysmaticlabs/prysm/beacon-chain/database"
+	"github.com/prysmaticlabs/prysm/beacon-chain/params"
 	"github.com/prysmaticlabs/prysm/beacon-chain/types"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
@@ -117,5 +118,29 @@ func TestMutateCrystallizedState(t *testing.T) {
 	}
 	if crystallized.CurrentCheckpoint.Hex() != newBeaconChain.state.CrystallizedState.CurrentCheckpoint.Hex() {
 		t.Errorf("crystallized state current checkpoint incorrect. wanted %v, got %v", crystallized.CurrentCheckpoint.Hex(), newBeaconChain.state.CrystallizedState.CurrentCheckpoint.Hex())
+	}
+}
+
+func TestFaultyShuffle(t *testing.T) {
+	if _, err := shuffle(common.Hash{'a'}, params.MaxValidators); err == nil {
+		t.Error("Shuffle should have failed when validator count exceeds MaxValidators")
+	}
+}
+
+func TestShuffle(t *testing.T) {
+	hash1 := common.BytesToHash([]byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'a', 'b', 'c', 'd', 'e', 'f', 'g'})
+	hash2 := common.BytesToHash([]byte{'1', '2', '3', '4', '5', '6', '7', '1', '2', '3', '4', '5', '6', '7', '1', '2', '3', '4', '5', '6', '7', '1', '2', '3', '4', '5', '6', '7', '1', '2', '3', '4', '5', '6', '7'})
+
+	list1, err := shuffle(hash1, 100)
+	if err != nil {
+		t.Errorf("Shuffle failed with: %v", err)
+	}
+
+	list2, err := shuffle(hash2, 100)
+	if err != nil {
+		t.Errorf("Shuffle failed with: %v", err)
+	}
+	if reflect.DeepEqual(list1, list2) {
+		t.Errorf("2 shuffled lists shouldn't be equal")
 	}
 }

--- a/beacon-chain/blockchain/core_test.go
+++ b/beacon-chain/blockchain/core_test.go
@@ -122,7 +122,7 @@ func TestMutateCrystallizedState(t *testing.T) {
 }
 
 func TestFaultyShuffle(t *testing.T) {
-	if _, err := shuffle(common.Hash{'a'}, params.MaxValidators); err == nil {
+	if _, err := Shuffle(common.Hash{'a'}, params.MaxValidators+1); err == nil {
 		t.Error("Shuffle should have failed when validator count exceeds MaxValidators")
 	}
 }
@@ -131,12 +131,12 @@ func TestShuffle(t *testing.T) {
 	hash1 := common.BytesToHash([]byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'a', 'b', 'c', 'd', 'e', 'f', 'g'})
 	hash2 := common.BytesToHash([]byte{'1', '2', '3', '4', '5', '6', '7', '1', '2', '3', '4', '5', '6', '7', '1', '2', '3', '4', '5', '6', '7', '1', '2', '3', '4', '5', '6', '7', '1', '2', '3', '4', '5', '6', '7'})
 
-	list1, err := shuffle(hash1, 100)
+	list1, err := Shuffle(hash1, 100)
 	if err != nil {
 		t.Errorf("Shuffle failed with: %v", err)
 	}
 
-	list2, err := shuffle(hash2, 100)
+	list2, err := Shuffle(hash2, 100)
 	if err != nil {
 		t.Errorf("Shuffle failed with: %v", err)
 	}

--- a/beacon-chain/params/config.go
+++ b/beacon-chain/params/config.go
@@ -14,7 +14,7 @@ const (
 	// DefaultSwitchDynasty value.
 	DefaultSwitchDynasty = 9999999999999999999
 	// MaxValidators in the protocol.
-	MaxValidators = 2 ^ 24
+	MaxValidators = 4194304
 	// NotariesPerCrosslink fixed to 100.
 	NotariesPerCrosslink = 100
 )


### PR DESCRIPTION
To kick off on the beacon state transition function, we first implement a pure function to shuffle validator indices. This function simply shuffles an array of indices based on a random seed. For example:
```
validatorCount := 5
preShuffle := [0,1,2,3,4]
postShuffle: = [1,0,4,2,3]
```
Later, `getAttesters` and `getProposer` functions will use this shuffle function to return the list of validators.

References:
https://notes.ethereum.org/SCIg8AH5SA-O4C1G1LYZHQ?view#Helper-functions
https://github.com/ethereum/beacon_chain/blob/master/beacon_chain/state/state_transition.py#L43