### PR TITLE
Fix P2P Linter Error

### DIFF
--- a/client/p2p/service_test.go
+++ b/client/p2p/service_test.go
@@ -38,14 +38,14 @@ func TestLifecycle(t *testing.T) {
 	s.Start()
 	msg := hook.Entries[0]
 	want := "Starting shardp2p server"
-	if msg == nil || msg.Message != want {
+	if msg.Message != want {
 		t.Errorf("incorrect log. wanted: %s. got: %v", want, msg)
 	}
 
 	s.Stop()
 	msg = hook.LastEntry()
 	want = "Stopping shardp2p server"
-	if msg == nil || msg.Message != want {
+	if msg.Message != want {
 		t.Errorf("incorrect log. wanted: %s. got: %v", want, msg)
 	}
 

--- a/client/p2p/service_test.go
+++ b/client/p2p/service_test.go
@@ -36,16 +36,16 @@ func TestLifecycle(t *testing.T) {
 	}
 
 	s.Start()
-	msg := hook.Entries[0]
+	msg := hook.Entries[0].Message
 	want := "Starting shardp2p server"
-	if msg.Message != want {
+	if msg != want {
 		t.Errorf("incorrect log. wanted: %s. got: %v", want, msg)
 	}
 
 	s.Stop()
-	msg = hook.LastEntry()
+	msg = hook.LastEntry().Message
 	want = "Stopping shardp2p server"
-	if msg.Message != want {
+	if msg != want {
 		t.Errorf("incorrect log. wanted: %s. got: %v", want, msg)
 	}
 


### PR DESCRIPTION
This PR is a quick fix to a linter error in the p2p service_test which gives us an incorrect type conversion linter message.