### PR TITLE
Add RPC Support to Client

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -54,7 +54,7 @@ VERSION:
 	app.Usage = `launches a sharding client that interacts with a beacon chain, starts proposer services, shardp2p connections, and more
 `
 	app.Action = startNode
-	app.Flags = []cli.Flag{utils.ActorFlag, cmd.VerbosityFlag, cmd.DataDirFlag, cmd.PasswordFileFlag, cmd.NetworkIdFlag, cmd.IPCPathFlag, utils.DepositFlag, utils.ShardIDFlag, debug.PProfFlag, debug.PProfAddrFlag, debug.PProfPortFlag, debug.MemProfileRateFlag, debug.CPUProfileFlag, debug.TraceFlag}
+	app.Flags = []cli.Flag{utils.ActorFlag, cmd.VerbosityFlag, cmd.DataDirFlag, cmd.PasswordFileFlag, cmd.NetworkIdFlag, cmd.IPCPathFlag, cmd.RPCProviderFlag, utils.DepositFlag, utils.ShardIDFlag, debug.PProfFlag, debug.PProfAddrFlag, debug.PProfPortFlag, debug.MemProfileRateFlag, debug.CPUProfileFlag, debug.TraceFlag}
 
 	app.Before = func(ctx *cli.Context) error {
 		runtime.GOMAXPROCS(runtime.NumCPU())

--- a/client/node/backend.go
+++ b/client/node/backend.go
@@ -164,7 +164,9 @@ func (s *ShardEthereum) registerMainchainClient(ctx *cli.Context) error {
 	if endpoint == "" {
 		endpoint = fmt.Sprintf("%s/%s.ipc", path, mainchain.ClientIdentifier)
 	}
-	if ctx.GlobalIsSet(cmd.IPCPathFlag.Name) {
+	if ctx.GlobalIsSet(cmd.RPCProviderFlag.Name) {
+		endpoint = ctx.GlobalString(cmd.RPCProviderFlag.Name)
+	} else if ctx.GlobalIsSet(cmd.IPCPathFlag.Name) {
 		endpoint = ctx.GlobalString(cmd.IPCPathFlag.Name)
 	}
 	passwordFile := ctx.GlobalString(cmd.PasswordFileFlag.Name)

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -35,4 +35,10 @@ var (
 		Usage: "Password file to use for non-interactive password input",
 		Value: "",
 	}
+	// RPCProviderFlag defines a http endpoint flag to connect to mainchain.
+	RPCProviderFlag = cli.StringFlag{
+		Name:  "rpc",
+		Usage: "HTTP-RPC server end point to use to connect to mainchain.",
+		Value: "http://localhost:8545/",
+	}
 )


### PR DESCRIPTION
Currently sharding client only supports IPC interface to a main chain node. In this PR, we added RPC interface support so multiple processes can work together.

`--rpc` is the flag name, Example:
`--rpc http://localhost:8545/ --password ./password.txt --datadir ./data`
