### PR TITLE
Add Mutex on Top of p2p Feeds Map

### DIFF
--- a/.travis-bazelrc
+++ b/.travis-bazelrc
@@ -10,9 +10,9 @@ build --spawn_strategy=standalone --genrule_strategy=standalone
 #build:remote --google_credentials=/tmp/service-account.json
 
 # Set some build options for travis container.
-build --local_resources=1536,1.5,0.5
+build --local_resources=2048,1.5,1
 build --noshow_progress
-build --verbose_failures 
+build --verbose_failures
 build --sandbox_debug
 build --test_output=errors
 build --flaky_test_attempts=5

--- a/.travis-bazelrc
+++ b/.travis-bazelrc
@@ -1,9 +1,5 @@
 startup --host_jvm_args=-Xmx500m --host_jvm_args=-Xms500m
 
-# Disable sandboxing since it may fail inside of Travis' containers because the
-# mount system call is not permitted.
-build --spawn_strategy=standalone --genrule_strategy=standalone
-
 # Remote caching over Google Cloud Storage
 # TODO(#282): Enable remote caching/execution
 #build:remote --remote_http_cache=https://storage.googleapis.com/prysmatic-bazel-cache

--- a/.travis-bazelrc
+++ b/.travis-bazelrc
@@ -10,7 +10,7 @@ build --spawn_strategy=standalone --genrule_strategy=standalone
 #build:remote --google_credentials=/tmp/service-account.json
 
 # Set some build options for travis container.
-build --local_resources=2048,1.5,1
+build --local_resources=1536,1.5,0.5
 build --noshow_progress
 build --verbose_failures
 build --sandbox_debug

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.13.0/rules_go-0.13.0.tar.gz"],
-    sha256 = "ba79c532ac400cefd1859cbc8a9829346aa69e3b99482cd5a54432092cbc3933",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.12.1/rules_go-0.12.1.tar.gz"],
+    sha256 = "8b68d0630d63d95dacc0016c3bb4b76154fe34fca93efd65d1c366de3fcb4294",
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    # in order to be able to enable race detecto we need to use a version
+    # in order to be able to enable race detection we need to use a version
     # < 0.13.0 until this bug is fixed: https://github.com/bazelbuild/rules_go/issues/1592
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.12.1/rules_go-0.12.1.tar.gz"],
     sha256 = "8b68d0630d63d95dacc0016c3bb4b76154fe34fca93efd65d1c366de3fcb4294",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
+    # in order to be able to enable race detecto we need to use a version
+    # < 0.13.0 until this bug is fixed: https://github.com/bazelbuild/rules_go/issues/1592
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.12.1/rules_go-0.12.1.tar.gz"],
     sha256 = "8b68d0630d63d95dacc0016c3bb4b76154fe34fca93efd65d1c366de3fcb4294",
 )

--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "topics_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
     deps = [
         "//proto/sharding/v1:go_default_library",
         "//shared:go_default_library",

--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# gazelle:exclude feed_concurrent_test.go
+
 go_library(
     name = "go_default_library",
     srcs = [
@@ -57,9 +59,7 @@ go_test(
 
 go_test(
     name = "go_feed_concurrent_write_test",
-    srcs = [
-        "feed_concurrent_test.go",
-    ],
+    srcs = ["feed_concurrent_test.go"],
     embed = [":go_default_library"],
     race = "on",
 )

--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -29,10 +29,6 @@ go_library(
     ],
 )
 
-# by default gazelle tries to add all the test files to the  first
-# go_test; we want to treat feed_concurrent_test.go differently
-# gazelle:exclude feed_concurrent_test.go
-
 go_test(
     name = "go_default_test",
     srcs = [
@@ -58,6 +54,10 @@ go_test(
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
 )
+
+# by default gazelle tries to add all the test files to the  first
+# go_test; we want to treat feed_concurrent_test.go differently
+# gazelle:exclude feed_concurrent_test.go
 
 go_test(
     name = "go_feed_concurrent_write_test",

--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
-# gazelle:exclude feed_concurrent_test.go
-
 go_library(
     name = "go_default_library",
     srcs = [
@@ -30,6 +28,10 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
+
+# by default gazelle tries to add all the test files to the  first
+# go_test; we want to treat feed_concurrent_test.go differently
+# gazelle:exclude feed_concurrent_test.go
 
 go_test(
     name = "go_default_test",

--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -40,7 +40,6 @@ go_test(
         "topics_test.go",
     ],
     embed = [":go_default_library"],
-    race = "on",
     deps = [
         "//proto/sharding/v1:go_default_library",
         "//shared:go_default_library",
@@ -54,4 +53,13 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_feed_concurrent_write_test",
+    srcs = [
+        "feed_concurrent_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
 )

--- a/shared/p2p/feed.go
+++ b/shared/p2p/feed.go
@@ -36,6 +36,8 @@ func (s *Server) Feed(msg interface{}) *event.Feed {
 	}
 
 	if s.feeds[t] == nil {
+		s.mutex.Lock()
+		defer s.mutex.Unlock()
 		s.feeds[t] = new(event.Feed)
 	}
 	return s.feeds[t]

--- a/shared/p2p/feed.go
+++ b/shared/p2p/feed.go
@@ -35,10 +35,10 @@ func (s *Server) Feed(msg interface{}) *event.Feed {
 		t = reflect.TypeOf(msg)
 	}
 
+	s.mutex.Lock()
 	if s.feeds[t] == nil {
-		s.mutex.Lock()
-		defer s.mutex.Unlock()
 		s.feeds[t] = new(event.Feed)
 	}
+	s.mutex.Unlock()
 	return s.feeds[t]
 }

--- a/shared/p2p/feed.go
+++ b/shared/p2p/feed.go
@@ -36,9 +36,10 @@ func (s *Server) Feed(msg interface{}) *event.Feed {
 	}
 
 	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	if s.feeds[t] == nil {
 		s.feeds[t] = new(event.Feed)
 	}
-	s.mutex.Unlock()
+
 	return s.feeds[t]
 }

--- a/shared/p2p/feed_concurrent_test.go
+++ b/shared/p2p/feed_concurrent_test.go
@@ -1,0 +1,14 @@
+package p2p
+
+import "testing"
+
+func TestFeed_ConcurrentWrite(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatalf("could not create server %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		go s.Feed("a")
+	}
+}

--- a/shared/p2p/feed_test.go
+++ b/shared/p2p/feed_test.go
@@ -35,3 +35,14 @@ func TestFeed_ReturnsSameFeed(t *testing.T) {
 		}
 	}
 }
+
+func TestFeed_ConcurrentWrite(t *testing.T) {
+	s, err := NewServer()
+	if err != nil {
+		t.Fatalf("could not create server %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		go s.Feed("a")
+	}
+}

--- a/shared/p2p/feed_test.go
+++ b/shared/p2p/feed_test.go
@@ -35,14 +35,3 @@ func TestFeed_ReturnsSameFeed(t *testing.T) {
 		}
 	}
 }
-
-func TestFeed_ConcurrentWrite(t *testing.T) {
-	s, err := NewServer()
-	if err != nil {
-		t.Fatalf("could not create server %v", err)
-	}
-
-	for i := 0; i < 5; i++ {
-		go s.Feed("a")
-	}
-}

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -12,6 +12,7 @@ package p2p
 import (
 	"context"
 	"reflect"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/golang/protobuf/proto"
@@ -33,6 +34,7 @@ type Sender interface {
 type Server struct {
 	ctx    context.Context
 	cancel context.CancelFunc
+	mutex  *sync.Mutex
 	feeds  map[reflect.Type]*event.Feed
 	host   host.Host
 	gsub   *floodsub.PubSub
@@ -60,6 +62,7 @@ func NewServer() (*Server, error) {
 		feeds:  make(map[reflect.Type]*event.Feed),
 		host:   host,
 		gsub:   gsub,
+		mutex:  &sync.Mutex{},
 	}, nil
 }
 

--- a/shared/p2p/service_test.go
+++ b/shared/p2p/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -82,6 +83,7 @@ func TestSubscribeToTopic(t *testing.T) {
 		gsub:  gsub,
 		host:  h,
 		feeds: make(map[reflect.Type]*event.Feed),
+		mutex: &sync.Mutex{},
 	}
 
 	feed := s.Feed(pb.CollationBodyRequest{})


### PR DESCRIPTION
While working on #316, after enabling the commented proposer tests I'm eventually getting:
```
fatal error: concurrent map writes

goroutine 96 [running]:
runtime.throw(0xe5e088, 0x15)
	GOROOT/src/runtime/panic.go:616 +0x81 fp=0xc4204a9c50 sp=0xc4204a9c30 pc=0x42e1e1
runtime.mapassign(0xcf8760, 0xc420313620, 0xc4204a9d48, 0x171bd00)
	GOROOT/src/runtime/hashmap.go:607 +0x553 fp=0xc4204a9ce0 sp=0xc4204a9c50 pc=0x40b113
github.com/prysmaticlabs/prysm/shared/p2p.(*Server).Feed(0xc42004ccc0, 0xe25860, 0xdd11e0, 0x0)
	shared/p2p/feed.go:41 +0x176 fp=0xc4204a9d78 sp=0xc4204a9ce0 pc=0xb66ef6
github.com/prysmaticlabs/prysm/shared/p2p.(*Server).subscribeToTopic(0xc42004ccc0, 0x1, 0x10659c0, 0xdd11e0)
	shared/p2p/service.go:141 +0x17f fp=0xc4204a9fc0 sp=0xc4204a9d78 pc=0xb6800f
runtime.goexit()
	bazel-out/k8-fastbuild/bin/external/io_bazel_rules_go/linux_amd64_stripped/stdlib~/src/runtime/asm_amd64.s:2361 +0x1 fp=0xc4204a9fc8 sp=0xc4204a9fc0 pc=0x45d491
created by github.com/prysmaticlabs/prysm/shared/p2p.(*Server).Start
	shared/p2p/service.go:82 +0x1dc
```
These changes aim to fix this problem by adding a mutex to prevent concurrent writes to the feeds map. With them in place no more issues of this kind are reported.