### PR TITLE
Add script to ensure visibility is OK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,11 @@ matrix:
             test \
             //... $REMOTE_FLAGS
         
-        # Check that BUILD files are formatted  correctly.
+        # Check that BUILD files are formatted correctly.
         - ./check_gazelle.sh
+
+        # Check that target visibility is correct..
+        - ./check_visibility.sh
 
         # Shutdown must be last.
         - bazel shutdown 

--- a/beacon-chain/network/BUILD.bazel
+++ b/beacon-chain/network/BUILD.bazel
@@ -4,7 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = ["service.go"],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/network",
-    visibility = ["//visibility:public"],
+    visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/types:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -4,7 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = ["service.go"],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/sync",
-    visibility = ["//visibility:public"],
+    visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/types:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/check_visibility.sh
+++ b/check_visibility.sh
@@ -23,7 +23,7 @@ then
   exit 0
 else
   echo "FAIL: The above targets belong to protected packages and the targets \
-are visibile outside of their package!"
+are visible outside of their package!"
   echo "Please run reduce the target visibility."
   exit 1
 fi

--- a/check_visibility.sh
+++ b/check_visibility.sh
@@ -24,6 +24,6 @@ then
 else
   echo "FAIL: The above targets belong to protected packages and the targets \
 are visible outside of their package!"
-  echo "Please run reduce the target visibility."
+  echo "Please reduce the target visibility."
   exit 1
 fi

--- a/check_visibility.sh
+++ b/check_visibility.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Continous Integration script to check that BUILD.bazel files have the correct
+# visibility.
+
+# Protected packages are:
+#   //beacon-chain/...
+#   //client/...
+
+# Duplicate redirect 5 to stdout so that it can be captured, but still printed
+# nicely.
+exec 5>&1
+
+# Run gazelle while piping a copy of the output to stdout via 5.
+changes=$(
+bazel query 'visible(//... except (//beacon-chain/... union //client/...), (//beacon-chain/... union //client/...))' | tee >(cat - >&5)
+)
+
+# If the captured stdout is not empty then targets are exposed!
+if [ -z "$changes" ]
+then
+  echo "OK: Visibility is good."
+  exit 0
+else
+  echo "FAIL: The above targets belong to protected packages and the targets \
+are visibile outside of their package!"
+  echo "Please run reduce the target visibility."
+  exit 1
+fi


### PR DESCRIPTION
Example with failing visibility (fixed in this PR):

```text
//beacon-chain/sync:go_default_library
//beacon-chain/network:go_default_library
FAIL: The above targets belong to protected packages and the targets are visible outside of their package!
Please reduce the target visibility.
```

Otherwise you should see this:

```text
INFO: Empty results
OK: Visibility is good.
```