### PR TITLE
Check Parent Hash in Block Processing Function

### DIFF
--- a/beacon-chain/blockchain/core.go
+++ b/beacon-chain/blockchain/core.go
@@ -127,7 +127,16 @@ func (b *BeaconChain) CanProcessBlock(fetcher types.POWBlockFetcher, block *type
 	if _, err := fetcher.BlockByHash(context.Background(), block.MainChainRef()); err != nil {
 		return false, fmt.Errorf("fetching PoW block corresponding to mainchain reference failed: %v", err)
 	}
-	// TODO: check if the parentHash pointed by the beacon block is in the beaconDB.
+
+	// Check if the parentHash pointed by the beacon block is in the beaconDB.
+	parentHash := block.ParentHash()
+	val, err := b.db.Get(parentHash[:])
+	if err != nil {
+		return false, err
+	}
+	if val == nil {
+		return false, errors.New("parent hash points to nil in beaconDB")
+	}
 
 	// Calculate the timestamp validity condition.
 	slotDuration := time.Duration(block.SlotNumber()*params.SlotDuration) * time.Second

--- a/beacon-chain/simulator/service.go
+++ b/beacon-chain/simulator/service.go
@@ -100,6 +100,7 @@ func (sim *Simulator) run(delayChan <-chan time.Time, done <-chan struct{}) {
 				MainChainRef:          sim.web3Service.LatestBlockHash().Bytes(),
 				ActiveStateHash:       activeStateHash[:],
 				CrystallizedStateHash: crystallizedStateHash[:],
+				ParentHash:            make([]byte, 32),
 			})
 			if err != nil {
 				log.Errorf("Could not create simulated block: %v", err)

--- a/beacon-chain/simulator/service_test.go
+++ b/beacon-chain/simulator/service_test.go
@@ -98,7 +98,7 @@ func TestBlockRequestResponse(t *testing.T) {
 		<-exitRoutine
 	}()
 
-	block, err := types.NewBlock(&pb.BeaconBlockResponse{})
+	block, err := types.NewBlock(&pb.BeaconBlockResponse{ParentHash: make([]byte, 32)})
 	if err != nil {
 		t.Fatalf("Could not instantiate new block from proto: %v", err)
 	}

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -103,6 +103,7 @@ func TestProcessBlock(t *testing.T) {
 
 	blockResponse := &pb.BeaconBlockResponse{
 		MainChainRef: []byte{1, 2, 3, 4, 5},
+		ParentHash:   make([]byte, 32),
 	}
 
 	msg := p2p.Message{
@@ -145,6 +146,7 @@ func TestProcessMultipleBlocks(t *testing.T) {
 
 	blockResponse1 := &pb.BeaconBlockResponse{
 		MainChainRef: []byte{1, 2, 3, 4, 5},
+		ParentHash:   make([]byte, 32),
 	}
 
 	msg1 := p2p.Message{
@@ -154,6 +156,7 @@ func TestProcessMultipleBlocks(t *testing.T) {
 
 	blockResponse2 := &pb.BeaconBlockResponse{
 		MainChainRef: []byte{6, 7, 8, 9, 10},
+		ParentHash:   make([]byte, 32),
 	}
 
 	msg2 := p2p.Message{
@@ -211,6 +214,7 @@ func TestProcessSameBlock(t *testing.T) {
 
 	blockResponse := &pb.BeaconBlockResponse{
 		MainChainRef: []byte{1, 2, 3},
+		ParentHash:   make([]byte, 32),
 	}
 
 	msg := p2p.Message{

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -26,6 +27,10 @@ type AggregateVote struct {
 
 // NewBlock explicitly sets the data field of a block.
 func NewBlock(data *pb.BeaconBlockResponse) (*Block, error) {
+	if len(data.ParentHash) != 32 {
+		return nil, errors.New("invalid block data, parent hash should be 32 bytes")
+	}
+
 	return &Block{data}, nil
 }
 


### PR DESCRIPTION
This PR adds an additional condition in the beacon chain's block processing function, to verify that the block has a parent hash, and that this parent hash is stored in the db.

Furthermore it modifies existing test cases by setting parent hash, and adds a new test to ensure blocks with invalid parent hashes won't be processed.

This is my first PR; sorry in advance if the PR doesn't satisfy the requirements :) I will be happy to modify if anything's missing or should be changed.

Fixes #324