### PR TITLE
Eliminate test only methods on types.Block

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//beacon-chain/powchain:go_default_library",
         "//beacon-chain/types:go_default_library",
         "//beacon-chain/utils:go_default_library",
+        "//proto/sharding/v1:go_default_library",
         "//shared/database:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",

--- a/beacon-chain/blockchain/core.go
+++ b/beacon-chain/blockchain/core.go
@@ -140,6 +140,10 @@ func (b *BeaconChain) CanProcessBlock(fetcher types.POWBlockFetcher, block *type
 		return false, err
 	}
 
+	if time.Now().Before(genesisTime.Add(slotDuration)) {
+		return false, nil
+	}
+
 	// Verify state hashes from the block are correct
 	hash, err := hashActiveState(b.ActiveState())
 	if err != nil {
@@ -163,9 +167,7 @@ func (b *BeaconChain) CanProcessBlock(fetcher types.POWBlockFetcher, block *type
 		return false, fmt.Errorf("crystallized state hash mismatched, wanted: %v, got: %v", blockCrystallizedStateHash, hash)
 	}
 
-	validTime := time.Now().After(genesisTime.Add(slotDuration))
-
-	return validTime, nil
+	return true, nil
 }
 
 // RotateValidatorSet is called  every dynasty transition. It's primary function is

--- a/beacon-chain/blockchain/core_test.go
+++ b/beacon-chain/blockchain/core_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/utils"
 	"github.com/prysmaticlabs/prysm/shared/database"
+	pb "github.com/prysmaticlabs/prysm/proto/sharding/v1"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
@@ -166,7 +167,8 @@ func TestCanProcessBlock(t *testing.T) {
 	beaconChain, db := startInMemoryBeaconChain(t)
 	defer db.Close()
 
-	block := types.NewBlock(1)
+	block := NewBlockWithSlotNumber(t, 1)
+
 	// Using a faulty fetcher should throw an error.
 	if _, err := beaconChain.CanProcessBlock(&faultyFetcher{}, block); err == nil {
 		t.Errorf("Using a faulty fetcher should throw an error, received nil")
@@ -178,13 +180,13 @@ func TestCanProcessBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Cannot hash active state: %v", err)
 	}
-	block.InsertActiveHash(activeHash)
 
 	crystallizedHash, err := hashCrystallizedState(&types.CrystallizedState{})
 	if err != nil {
 		t.Fatalf("Compute crystallized state hash failed: %v", err)
 	}
-	block.InsertCrystallizedHash(crystallizedHash)
+
+	block = NewBlock(t, 1, activeHash, crystallizedHash)
 
 	canProcess, err := beaconChain.CanProcessBlock(&mockFetcher{}, block)
 	if err != nil {
@@ -194,11 +196,8 @@ func TestCanProcessBlock(t *testing.T) {
 		t.Errorf("Should be able to process block, could not")
 	}
 
-	// Attempting to try a block with that fails the timestamp validity
-	// condition.
-	block = types.NewBlock(1000000)
-	block.InsertActiveHash(activeHash)
-	block.InsertCrystallizedHash(crystallizedHash)
+	// Test timestamp validity condition
+	block = NewBlock(t, 1000000, activeHash, crystallizedHash)
 	canProcess, err = beaconChain.CanProcessBlock(&mockFetcher{}, block)
 	if err != nil {
 		t.Fatalf("CanProcessBlocks failed: %v", err)
@@ -212,15 +211,19 @@ func TestProcessBlockWithBadHashes(t *testing.T) {
 	beaconChain, db := startInMemoryBeaconChain(t)
 	defer db.Close()
 
-	// Test negative scenario where active state hash is different than node's compute
-	block := types.NewBlock(1)
 	activeState := &types.ActiveState{TotalAttesterDeposits: 10000}
-	stateHash, err := hashActiveState(activeState)
+	activeStateHash, err := hashActiveState(activeState)
 	if err != nil {
 		t.Fatalf("Cannot hash active state: %v", err)
 	}
-	block.InsertActiveHash(stateHash)
+	crystallizedState := &types.CrystallizedState{CurrentEpoch: 10000}
+	crystallizedStateHash, err := hashCrystallizedState(crystallizedState)
+	if err != nil {
+		t.Fatalf("Cannot hash crystallized state: %v", err)
+	}
+	block := NewBlock(t, 1, activeStateHash, crystallizedStateHash)
 
+	// Test negative scenario where active state hash is different than node's compute
 	beaconChain.state.ActiveState = &types.ActiveState{TotalAttesterDeposits: 9999}
 
 	canProcess, err := beaconChain.CanProcessBlock(&mockFetcher{}, block)
@@ -232,13 +235,6 @@ func TestProcessBlockWithBadHashes(t *testing.T) {
 	}
 
 	// Test negative scenario where crystallized state hash is different than node's compute
-	crystallizedState := &types.CrystallizedState{CurrentEpoch: 10000}
-	stateHash, err = hashCrystallizedState(crystallizedState)
-	if err != nil {
-		t.Fatalf("Cannot hash crystallized state: %v", err)
-	}
-	block.InsertCrystallizedHash(stateHash)
-
 	beaconChain.state.CrystallizedState = &types.CrystallizedState{CurrentEpoch: 9999}
 
 	canProcess, err = beaconChain.CanProcessBlock(&mockFetcher{}, block)
@@ -485,9 +481,7 @@ func TestResetAttesterBitfields(t *testing.T) {
 		if !bytes.Equal(beaconChain.state.ActiveState.AttesterBitfields, make([]byte, bitfieldLength)) {
 			t.Fatalf("attester bitfields are not zeroed out: %v", beaconChain.state.ActiveState.AttesterBitfields)
 		}
-
 	}
-
 }
 
 func TestResetTotalAttesterDeposit(t *testing.T) {
@@ -708,4 +702,30 @@ func unique(ints []int) []int {
 	}
 	return list
 
+}
+
+func NewBlockWithSlotNumber(t *testing.T, slotNumber uint64) *types.Block {
+	b, err := types.NewBlock(&pb.BeaconBlockResponse{
+		SlotNumber: slotNumber,
+	})
+
+	if err != nil {
+		t.Fatalf("failed to instantiate block with slot number: %d", slotNumber)
+	}
+
+	return b
+}
+
+func NewBlock(t *testing.T, slotNumber uint64, activeStateHash [32]byte, crystallizedStateHash [32]byte) *types.Block {
+	b, err := types.NewBlock(&pb.BeaconBlockResponse{
+		SlotNumber: slotNumber,
+		ActiveStateHash: activeStateHash[:],
+		CrystallizedStateHash: crystallizedStateHash[:],
+	})
+
+	if err != nil {
+		t.Fatalf("failed to instantiate block with slot number: %d", slotNumber)
+	}
+
+	return b
 }

--- a/beacon-chain/blockchain/core_test.go
+++ b/beacon-chain/blockchain/core_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/params"
 	"github.com/prysmaticlabs/prysm/beacon-chain/types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/utils"
-	"github.com/prysmaticlabs/prysm/shared/database"
 	pb "github.com/prysmaticlabs/prysm/proto/sharding/v1"
+	"github.com/prysmaticlabs/prysm/shared/database"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
@@ -718,8 +718,8 @@ func NewBlockWithSlotNumber(t *testing.T, slotNumber uint64) *types.Block {
 
 func NewBlock(t *testing.T, slotNumber uint64, activeStateHash [32]byte, crystallizedStateHash [32]byte) *types.Block {
 	b, err := types.NewBlock(&pb.BeaconBlockResponse{
-		SlotNumber: slotNumber,
-		ActiveStateHash: activeStateHash[:],
+		SlotNumber:            slotNumber,
+		ActiveStateHash:       activeStateHash[:],
 		CrystallizedStateHash: crystallizedStateHash[:],
 	})
 

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -87,7 +87,7 @@ func (ss *Service) ReceiveBlockHash(data *pb.BeaconBlockHashAnnounce) error {
 // ReceiveBlock accepts a block to potentially be included in the local chain.
 // The service will filter blocks that have not been requested (unimplemented).
 func (ss *Service) ReceiveBlock(data *pb.BeaconBlockResponse) error {
-	block, err := types.NewBlockWithData(data)
+	block, err := types.NewBlock(data)
 	if err != nil {
 		return fmt.Errorf("could not instantiate new block from proto: %v", err)
 	}

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -113,7 +113,7 @@ func TestProcessBlock(t *testing.T) {
 	ss.cancel()
 	<-exitRoutine
 
-	block, err := types.NewBlockWithData(&blockResponse)
+	block, err := types.NewBlock(&blockResponse)
 	if err != nil {
 		t.Fatalf("Could not instantiate new block from proto: %v", err)
 	}
@@ -168,7 +168,7 @@ func TestProcessMultipleBlocks(t *testing.T) {
 	ss.cancel()
 	<-exitRoutine
 
-	block1, err := types.NewBlockWithData(&blockResponse1)
+	block1, err := types.NewBlock(&blockResponse1)
 	if err != nil {
 		t.Fatalf("Could not instantiate new block from proto: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestProcessMultipleBlocks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	block2, err := types.NewBlockWithData(&blockResponse2)
+	block2, err := types.NewBlock(&blockResponse2)
 	if err != nil {
 		t.Fatalf("Could not instantiate new block from proto: %v", err)
 	}
@@ -226,7 +226,7 @@ func TestProcessSameBlock(t *testing.T) {
 	ss.cancel()
 	<-exitRoutine
 
-	block, err := types.NewBlockWithData(&blockResponse)
+	block, err := types.NewBlock(&blockResponse)
 	if err != nil {
 		t.Fatalf("Could not instantiate new block from proto: %v", err)
 	}

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -24,14 +24,8 @@ type AggregateVote struct {
 	AggregateSig   []uint // AggregateSig is the aggregated signatures of individual shard.
 }
 
-// NewBlock creates a new beacon block given certain arguments.
-func NewBlock(slotNumber uint64) *Block {
-	data := &pb.BeaconBlockResponse{Timestamp: ptypes.TimestampNow(), SlotNumber: slotNumber}
-	return &Block{data: data}
-}
-
-// NewBlockWithData explicitly sets the data field of a block.
-func NewBlockWithData(data *pb.BeaconBlockResponse) (*Block, error) {
+// NewBlock explicitly sets the data field of a block.
+func NewBlock(data *pb.BeaconBlockResponse) (*Block, error) {
 	return &Block{data}, nil
 }
 
@@ -96,14 +90,4 @@ func (b *Block) CrystallizedStateHash() [32]byte {
 // Timestamp returns the Go type time.Time from the protobuf type contained in the block.
 func (b *Block) Timestamp() (time.Time, error) {
 	return ptypes.Timestamp(b.data.Timestamp)
-}
-
-// InsertActiveHash updates the activeStateHash property in the data of a beacon block.
-func (b *Block) InsertActiveHash(h [32]byte) {
-	b.data.ActiveStateHash = h[:]
-}
-
-// InsertCrystallizedHash updates the crystallizedStateHash property in the data of a beacon block.
-func (b *Block) InsertCrystallizedHash(h [32]byte) {
-	b.data.CrystallizedStateHash = h[:]
 }


### PR DESCRIPTION
Noticed that there were a couple of methods on `types.Block` that were only being used to facilitate testing. These methods shouldn't be exposed to prod, so I moved them into the test file.