### PR TITLE
Fix Gitter Link

### DIFF
--- a/beacon-chain/README.md
+++ b/beacon-chain/README.md
@@ -2,7 +2,7 @@
 
 This is the main project folder for the beacon chain implementation of Ethereum 2.0 in Golang by [Prysmatic Labs](https://prysmaticlabs.com). Before you begin, check out our [Contribution Guidelines](#contribution-guidelines) and join our active chat room on Gitter below:
 
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/prysmaticlabs/prysm=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/prysmaticlabs/prysm?badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Also, read the latest sharding + casper [design spec](https://ethresear.ch/t/convenience-link-to-full-casper-chain-v2-spec/2332), this design spec serves as a source of truth for the beacon chain implementation we follow at prysmatic labs.
 Refer this page on [why](http://email.mg2.substack.com/c/eJwlj9GOhCAMRb9G3jRQQPGBh5mM8xsbhKrsDGIAM9m_X9xN2qZtbpt7rCm4xvSjj5gLOTOmL-809CMbKXFaOKakIl4DZYr2AGyQIGjHOnWH22OiYnoIxmDijaBhhS6fcy7GvjobA9m0mSXOcnZq5GBqLkilXBZhBsus5ZK89VbKkRt-a-BZI6DzZ7iur1lQ953KJ9bemnxgahuQU9XJu6pFPdu8meT8vragzEjpMCwMGLlgLo6h5z1JumQTu4IJd4v15xqMf_8ZLP_Y1bSLdbnrD-LL71i2Kj7DLxaWWF4)


### PR DESCRIPTION
Was getting 404 for the gitter link in Beacon Chain readme, now working.