### PR TITLE
Add support to pass in TLS key/crt to use gRPC securely

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -58,7 +58,23 @@ VERSION:
 	app.Usage = "this is a beacon chain implementation for Ethereum 2.0"
 	app.Action = startNode
 
-	app.Flags = []cli.Flag{utils.SimulatorFlag, utils.VrcContractFlag, utils.PubKeyFlag, utils.Web3ProviderFlag, utils.RPCPort, cmd.DataDirFlag, cmd.VerbosityFlag, debug.PProfFlag, debug.PProfAddrFlag, debug.PProfPortFlag, debug.MemProfileRateFlag, debug.CPUProfileFlag, debug.TraceFlag}
+	app.Flags = []cli.Flag{
+		utils.SimulatorFlag,
+		utils.VrcContractFlag,
+		utils.PubKeyFlag,
+		utils.Web3ProviderFlag,
+		utils.RPCPort,
+		utils.CertFlag,
+		utils.KeyFlag,
+		cmd.DataDirFlag,
+		cmd.VerbosityFlag,
+		debug.PProfFlag,
+		debug.PProfAddrFlag,
+		debug.PProfPortFlag,
+		debug.MemProfileRateFlag,
+		debug.CPUProfileFlag,
+		debug.TraceFlag,
+	}
 
 	app.Before = func(ctx *cli.Context) error {
 		runtime.GOMAXPROCS(runtime.NumCPU())

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -209,8 +209,12 @@ func (b *BeaconNode) registerSimulatorService(ctx *cli.Context) error {
 
 func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 	port := ctx.GlobalString(utils.RPCPort.Name)
+	cert := ctx.GlobalString(utils.CertFlag.Name)
+	key := ctx.GlobalString(utils.KeyFlag.Name)
 	rpcService := rpc.NewRPCService(context.TODO(), &rpc.Config{
-		Port: port,
+		Port:     port,
+		CertFlag: cert,
+		KeyFlag:  key,
 	})
 	return b.services.RegisterService(rpcService)
 }

--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//proto/beacon/rpc/v1:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
     ],
 )
 

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -56,15 +56,15 @@ func (s *Service) Start() {
 
 	var grpcServer *grpc.Server
 	if s.withCert != "" && s.withKey != "" {
-		// Create the TLS credentials
+		// Create the TLS credentials.
 		creds, err := credentials.NewServerTLSFromFile(s.withCert, s.withKey)
 		if err != nil {
 			log.Errorf("could not load TLS keys: %s", err)
 		}
-		// Create the gRPC server with the credentials
+		// Create the gRPC server with the credentials.
 		grpcServer = grpc.NewServer(grpc.Creds(creds))
 	} else {
-		log.Warnf("You are on an insecure gRPC connection, please provide a certificate and key to use a secure connection.")
+		log.Warn("You're on an insecure gRPC connection! Please provide a certificate and key to use a secure connection.")
 		grpcServer = grpc.NewServer()
 	}
 

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -56,12 +56,10 @@ func (s *Service) Start() {
 
 	var grpcServer *grpc.Server
 	if s.withCert != "" && s.withKey != "" {
-		// Create the TLS credentials.
 		creds, err := credentials.NewServerTLSFromFile(s.withCert, s.withKey)
 		if err != nil {
 			log.Errorf("could not load TLS keys: %s", err)
 		}
-		// Create the gRPC server with the credentials.
 		grpcServer = grpc.NewServer(grpc.Creds(creds))
 	} else {
 		log.Warn("You're on an insecure gRPC connection! Please provide a certificate and key to use a secure connection.")

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -8,6 +8,7 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 var log = logrus.WithField("prefix", "rpc")
@@ -18,11 +19,15 @@ type Service struct {
 	cancel   context.CancelFunc
 	port     string
 	listener net.Listener
+	withCert string
+	withKey  string
 }
 
 // Config options for the beacon node RPC server.
 type Config struct {
-	Port string
+	Port     string
+	CertFlag string
+	KeyFlag  string
 }
 
 // NewRPCService creates a new instance of a struct implementing the BeaconServiceServer
@@ -30,9 +35,11 @@ type Config struct {
 func NewRPCService(ctx context.Context, cfg *Config) *Service {
 	ctx, cancel := context.WithCancel(ctx)
 	return &Service{
-		ctx:    ctx,
-		cancel: cancel,
-		port:   cfg.Port,
+		ctx:      ctx,
+		cancel:   cancel,
+		port:     cfg.Port,
+		withCert: cfg.CertFlag,
+		withKey:  cfg.KeyFlag,
 	}
 }
 
@@ -47,7 +54,20 @@ func (s *Service) Start() {
 	s.listener = lis
 	log.Infof("RPC server listening on port :%s", s.port)
 
-	grpcServer := grpc.NewServer()
+	var grpcServer *grpc.Server
+	if s.withCert != "" && s.withKey != "" {
+		// Create the TLS credentials
+		creds, err := credentials.NewServerTLSFromFile(s.withCert, s.withKey)
+		if err != nil {
+			log.Errorf("could not load TLS keys: %s", err)
+		}
+		// Create the gRPC server with the credentials
+		grpcServer = grpc.NewServer(grpc.Creds(creds))
+	} else {
+		log.Warnf("You are on an insecure gRPC connection, please provide a certificate and key to use a secure connection.")
+		grpcServer = grpc.NewServer()
+	}
+
 	pb.RegisterBeaconServiceServer(grpcServer, s)
 	go func() {
 		err = grpcServer.Serve(lis)

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestLifecycle(t *testing.T) {
 	hook := logTest.NewGlobal()
-	rpcService := NewRPCService(context.Background(), &Config{Port: "9999"})
+	rpcService := NewRPCService(context.Background(), &Config{Port: "9999", CertFlag: "alice.crt", KeyFlag: "alice.key"})
 
 	rpcService.Start()
 

--- a/beacon-chain/utils/flags.go
+++ b/beacon-chain/utils/flags.go
@@ -32,4 +32,14 @@ var (
 		Usage: "RPC port exposed by a beacon node",
 		Value: "4000",
 	}
+	// CertFlag defines a flag for the node's TLS certificate
+	CertFlag = cli.StringFlag{
+		Name:  "tls-cert",
+		Usage: "Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.",
+	}
+	// KeyFlag defines a flag for the node's TLS key
+	KeyFlag = cli.StringFlag{
+		Name:  "tls-key",
+		Usage: "Key for secure gRPC. Pass this and the tls-cert flag in order to use gRPC securely.",
+	}
 )

--- a/beacon-chain/utils/flags.go
+++ b/beacon-chain/utils/flags.go
@@ -32,12 +32,12 @@ var (
 		Usage: "RPC port exposed by a beacon node",
 		Value: "4000",
 	}
-	// CertFlag defines a flag for the node's TLS certificate
+	// CertFlag defines a flag for the node's TLS certificate.
 	CertFlag = cli.StringFlag{
 		Name:  "tls-cert",
 		Usage: "Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.",
 	}
-	// KeyFlag defines a flag for the node's TLS key
+	// KeyFlag defines a flag for the node's TLS key.
 	KeyFlag = cli.StringFlag{
 		Name:  "tls-key",
 		Usage: "Key for secure gRPC. Pass this and the tls-cert flag in order to use gRPC securely.",

--- a/client/rpcclient/BUILD.bazel
+++ b/client/rpcclient/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//proto/beacon/rpc/v1:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
     ],
 )
 

--- a/client/rpcclient/service.go
+++ b/client/rpcclient/service.go
@@ -49,7 +49,7 @@ func (s *Service) Start() {
 		server = grpc.WithTransportCredentials(creds)
 	} else {
 		server = grpc.WithInsecure()
-		log.Warnf("Your gRPC connection is insecure!")
+		log.Warn("You're on an insecure gRPC connection! Please provide a certificate and key to use a secure connection.")
 	}
 	conn, err := grpc.Dial(s.endpoint, server)
 	if err != nil {

--- a/client/rpcclient/service.go
+++ b/client/rpcclient/service.go
@@ -2,6 +2,7 @@ package rpcclient
 
 import (
 	"context"
+
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"

--- a/client/rpcclient/service.go
+++ b/client/rpcclient/service.go
@@ -2,10 +2,10 @@ package rpcclient
 
 import (
 	"context"
-
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 var log = logrus.WithField("prefix", "rpc-client")
@@ -16,11 +16,13 @@ type Service struct {
 	cancel   context.CancelFunc
 	conn     *grpc.ClientConn
 	endpoint string
+	withCert string
 }
 
 // Config for the RPCClient service.
 type Config struct {
 	Endpoint string
+	CertFlag string
 }
 
 // NewRPCClient sets up a new beacon node RPC client connection.
@@ -30,13 +32,26 @@ func NewRPCClient(ctx context.Context, cfg *Config) *Service {
 		ctx:      ctx,
 		cancel:   cancel,
 		endpoint: cfg.Endpoint,
+		withCert: cfg.CertFlag,
 	}
 }
 
 // Start the grpc connection.
 func (s *Service) Start() {
 	log.Info("Starting service")
-	conn, err := grpc.Dial(s.endpoint, grpc.WithInsecure())
+	var server grpc.DialOption
+	if s.withCert != "" {
+		creds, err := credentials.NewClientTLSFromFile(s.withCert, "")
+		if err != nil {
+			log.Errorf("Could not get valid credentials: %v", err)
+			return
+		}
+		server = grpc.WithTransportCredentials(creds)
+	} else {
+		server = grpc.WithInsecure()
+		log.Warnf("Your gRPC connection is insecure!")
+	}
+	conn, err := grpc.Dial(s.endpoint, server)
 	if err != nil {
 		log.Errorf("Could not connect to beacon node via RPC endpoint: %s: %v", s.endpoint, err)
 		return

--- a/client/rpcclient/service_test.go
+++ b/client/rpcclient/service_test.go
@@ -10,12 +10,15 @@ import (
 
 func TestLifecycle(t *testing.T) {
 	hook := logTest.NewGlobal()
-	rpcClientService := NewRPCClient(context.Background(), &Config{Endpoint: "merkle tries"})
-
+	rpcClientService := NewRPCClient(
+		context.Background(),
+		&Config{
+			Endpoint: "merkle tries",
+			CertFlag: "alice.crt",
+		},
+	)
 	rpcClientService.Start()
-
 	testutil.AssertLogsContain(t, hook, "Starting service")
-
 	rpcClientService.Stop()
 	testutil.AssertLogsContain(t, hook, "Stopping service")
 }

--- a/client/types/flags.go
+++ b/client/types/flags.go
@@ -29,4 +29,9 @@ var (
 		Usage: "Beacon node RPC provider endpoint",
 		Value: "http://localhost:4000/",
 	}
+	// CertFlag defines a flag for the node's TLS certificate
+	CertFlag = cli.StringFlag{
+		Name:  "tls-cert",
+		Usage: "Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.",
+	}
 )

--- a/client/types/flags.go
+++ b/client/types/flags.go
@@ -29,7 +29,7 @@ var (
 		Usage: "Beacon node RPC provider endpoint",
 		Value: "http://localhost:4000/",
 	}
-	// CertFlag defines a flag for the node's TLS certificate
+	// CertFlag defines a flag for the node's TLS certificate.
 	CertFlag = cli.StringFlag{
 		Name:  "tls-cert",
 		Usage: "Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.",


### PR DESCRIPTION
This is for #366

It originally said to use gRPC securely by default but that would be unfeasible since node's need their own certs/keys.