### PR TITLE
Fix Beacon Block Response in Simulator

### DIFF
--- a/beacon-chain/simulator/service.go
+++ b/beacon-chain/simulator/service.go
@@ -175,7 +175,8 @@ func (sim *Simulator) run(delayChan <-chan time.Time, done <-chan struct{}) {
 			}
 			log.Infof("Responding to full block request for hash: 0x%x", h)
 			// Sends the full block body to the requester.
-			sim.p2p.Send(block.Proto(), msg.Peer)
+			res := &pb.BeaconBlockResponse{BeaconBlock: block.Proto()}
+			sim.p2p.Send(res, msg.Peer)
 
 		case msg := <-sim.crystallizedStateRequestChan:
 			data, ok := msg.Data.(*pb.CrystallizedStateRequest)

--- a/beacon-chain/simulator/service.go
+++ b/beacon-chain/simulator/service.go
@@ -175,7 +175,7 @@ func (sim *Simulator) run(delayChan <-chan time.Time, done <-chan struct{}) {
 			}
 			log.Infof("Responding to full block request for hash: 0x%x", h)
 			// Sends the full block body to the requester.
-			res := &pb.BeaconBlockResponse{BeaconBlock: block.Proto()}
+			res := &pb.BeaconBlockResponse{Block: block.Proto()}
 			sim.p2p.Send(res, msg.Peer)
 
 		case msg := <-sim.crystallizedStateRequestChan:


### PR DESCRIPTION
This is a fix to a bug in the beacon block response in the simulator package.

### What Was Wrong?

Simulator was sending the beacon block's proto over p2p by itself instead of wrapping it in a `&pb.BeaconBlockResponse{BeaconBlock: block.Proto()}` call. P2P was complaining that we were sending over an unknown topic, so this PR fixes that issue.

Now, the only issue is that syncer does not find a parent hash corresponding to the received block, but this makes sense as simulator is basically generating fake, test blocks and broadcasting them at the moment.