### PR TITLE
Allows Nodes to Resume Regular Sync

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -147,6 +147,7 @@ func (s *InitialSync) run(delaychan <-chan time.Time) {
 		case <-delaychan:
 			if highestObservedSlot == s.currentSlotNumber {
 				log.Info("Exiting initial sync and starting normal sync")
+				s.syncService.Start()
 				// TODO: Resume sync after completion of initial sync.
 				// See comment in Sync service's Start function for explanation.
 				return


### PR DESCRIPTION
This deals with #427 and also #426 , which will allow nodes to resume normal sync after they are in sync with the network. In order do this to work the simulator will be modified so that it can respond to requests for blocks by slot number
- [ ] Simulator responds to requests for blocks by slot number
- [ ] Simulator can allow a new node to sync upto the current chain head
- [ ] Resume Sync after Initial Sync
- [ ] Make sync polling interval dependent on number of connected peers
- [ ] Add tests to ensure sync runs as expected