### PR TITLE
Prototype for #440: Persist Blocks and Latest State in DB

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -177,10 +177,8 @@ func (c *ChainService) updateHead(slot uint64) {
 		log.Errorf("Write active state to disk failed: %v", err)
 	}
 
-	if c.candidateCState != nilCrystallizedState {
-		if err := c.chain.SetCrystallizedState(c.candidateCState); err != nil {
-			log.Errorf("Write crystallized state to disk failed: %v", err)
-		}
+	if err := c.chain.SetCrystallizedState(c.candidateCState); err != nil {
+		log.Errorf("Write crystallized state to disk failed: %v", err)
 	}
 
 	// TODO: Utilize this value in the fork choice rule.

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -2,7 +2,6 @@
 package blockchain
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
@@ -16,6 +15,9 @@ import (
 )
 
 var log = logrus.WithField("prefix", "blockchain")
+var nilBlock = &types.Block{}
+var nilActiveState = &types.ActiveState{}
+var nilCrystallizedState = &types.CrystallizedState{}
 
 // ChainService represents a service that handles the internal
 // logic of managing the full PoS beacon chain.
@@ -31,18 +33,9 @@ type ChainService struct {
 	canonicalBlockFeed             *event.Feed
 	canonicalCrystallizedStateFeed *event.Feed
 	latestProcessedBlock           chan *types.Block
-	lastSlot                       uint64
-	// These are the data structures used by the fork choice rule.
-	// We store processed blocks and states into a slice by SlotNumber.
-	// For example, at slot 5, we might have received 10 different blocks,
-	// and a canonical chain must be derived from this DAG.
-	//
-	// NOTE: These are temporary and will be replaced by a structure
-	// that can support light-client proofs, such as a Sparse Merkle Trie.
-	processedBlockHashesBySlot        map[uint64][][]byte
-	processedBlocksBySlot             map[uint64][]*types.Block
-	processedCrystallizedStatesBySlot map[uint64][]*types.CrystallizedState
-	processedActiveStatesBySlot       map[uint64][]*types.ActiveState
+	candidateBlock                 *types.Block
+	candidateAState                *types.ActiveState
+	candidateCState                *types.CrystallizedState
 }
 
 // Config options for the service.
@@ -65,22 +58,20 @@ func NewChainService(ctx context.Context, cfg *Config) (*ChainService, error) {
 		isValidator = true
 	}
 	return &ChainService{
-		ctx:                               ctx,
-		chain:                             cfg.Chain,
-		cancel:                            cancel,
-		beaconDB:                          cfg.BeaconDB,
-		web3Service:                       cfg.Web3Service,
-		validator:                         isValidator,
-		latestProcessedBlock:              make(chan *types.Block, cfg.BeaconBlockBuf),
-		incomingBlockChan:                 make(chan *types.Block, cfg.IncomingBlockBuf),
-		lastSlot:                          1, // TODO: Initialize from the db.
-		incomingBlockFeed:                 new(event.Feed),
-		canonicalBlockFeed:                new(event.Feed),
-		canonicalCrystallizedStateFeed:    new(event.Feed),
-		processedBlockHashesBySlot:        make(map[uint64][][]byte),
-		processedBlocksBySlot:             make(map[uint64][]*types.Block),
-		processedCrystallizedStatesBySlot: make(map[uint64][]*types.CrystallizedState),
-		processedActiveStatesBySlot:       make(map[uint64][]*types.ActiveState),
+		ctx:                            ctx,
+		chain:                          cfg.Chain,
+		cancel:                         cancel,
+		beaconDB:                       cfg.BeaconDB,
+		web3Service:                    cfg.Web3Service,
+		validator:                      isValidator,
+		latestProcessedBlock:           make(chan *types.Block, cfg.BeaconBlockBuf),
+		incomingBlockChan:              make(chan *types.Block, cfg.IncomingBlockBuf),
+		incomingBlockFeed:              new(event.Feed),
+		canonicalBlockFeed:             new(event.Feed),
+		canonicalCrystallizedStateFeed: new(event.Feed),
+		candidateBlock:                 nilBlock,
+		candidateAState:                nilActiveState,
+		candidateCState:                nilCrystallizedState,
 	}, nil
 }
 
@@ -90,15 +81,6 @@ func (c *ChainService) Start() {
 		log.Infof("Starting service as validator")
 	} else {
 		log.Infof("Starting service as observer")
-	}
-	head, err := c.chain.CanonicalHead()
-	if err != nil {
-		log.Fatalf("Could not fetch latest canonical head from DB: %v", err)
-	}
-	// If there was a canonical head stored in persistent storage,
-	// the fork choice rule proceed where it left off.
-	if head != nil {
-		c.lastSlot = head.SlotNumber() + 1
 	}
 	// TODO: Fetch the slot: (block, state) DAGs from persistent storage
 	// to truly continue across sessions.
@@ -127,8 +109,8 @@ func (c *ChainService) IncomingBlockFeed() *event.Feed {
 
 // HasStoredState checks if there is any Crystallized/Active State or blocks(not implemented) are
 // persisted to the db.
+// TODO: Remove - only used in tests
 func (c *ChainService) HasStoredState() (bool, error) {
-
 	hasActive, err := c.beaconDB.Has([]byte(activeStateLookupKey))
 	if err != nil {
 		return false, err
@@ -146,6 +128,7 @@ func (c *ChainService) HasStoredState() (bool, error) {
 
 // SaveBlock is a mock which saves a block to the local db using the
 // blockhash as the key.
+// TODO: Remove - only used in tests
 func (c *ChainService) SaveBlock(block *types.Block) error {
 	return c.chain.saveBlock(block)
 }
@@ -159,11 +142,13 @@ func (c *ChainService) ContainsBlock(h [32]byte) bool {
 }
 
 // CurrentCrystallizedState of the canonical chain.
+// TODO: Remove - only used in tests
 func (c *ChainService) CurrentCrystallizedState() *types.CrystallizedState {
 	return c.chain.CrystallizedState()
 }
 
 // CurrentActiveState of the canonical chain.
+// TODO: Remove - only used in tests
 func (c *ChainService) CurrentActiveState() *types.ActiveState {
 	return c.chain.ActiveState()
 }
@@ -187,29 +172,23 @@ func (c *ChainService) updateHead(slot uint64) {
 	// level as canonical.
 	//
 	// TODO: Implement real fork choice rule here.
-
-	// If no blocks were stored at the last slot, we simply skip the fork choice
-	// rule.
-	if len(c.processedBlocksBySlot[c.lastSlot]) == 0 {
-		return
-	}
-	log.WithField("slotNumber", c.lastSlot).Info("Applying fork choice rule")
-	canonicalActiveState := c.processedActiveStatesBySlot[c.lastSlot][0]
-	if err := c.chain.SetActiveState(canonicalActiveState); err != nil {
+	log.WithField("slotNumber", c.candidateBlock.SlotNumber()).Info("Applying fork choice rule")
+	if err := c.chain.SetActiveState(c.candidateAState); err != nil {
 		log.Errorf("Write active state to disk failed: %v", err)
 	}
 
-	canonicalCrystallizedState := c.processedCrystallizedStatesBySlot[c.lastSlot][0]
-	if err := c.chain.SetCrystallizedState(canonicalCrystallizedState); err != nil {
-		log.Errorf("Write crystallized state to disk failed: %v", err)
+	if c.candidateCState != nilCrystallizedState {
+		if err := c.chain.SetCrystallizedState(c.candidateCState); err != nil {
+			log.Errorf("Write crystallized state to disk failed: %v", err)
+		}
 	}
 
 	// TODO: Utilize this value in the fork choice rule.
 	vals, err := casper.ValidatorsByHeightShard(
-		canonicalCrystallizedState.DynastySeed(),
-		canonicalCrystallizedState.Validators(),
-		canonicalCrystallizedState.CurrentDynasty(),
-		canonicalCrystallizedState.CrosslinkingStartShard())
+		c.candidateCState.DynastySeed(),
+		c.candidateCState.Validators(),
+		c.candidateCState.CurrentDynasty(),
+		c.candidateCState.CrosslinkingStartShard())
 
 	if err != nil {
 		log.Errorf("Unable to get validators by height and by shard: %v", err)
@@ -217,29 +196,29 @@ func (c *ChainService) updateHead(slot uint64) {
 	}
 	log.Debugf("Received %d validators by height", len(vals))
 
-	canonicalBlock := c.processedBlocksBySlot[c.lastSlot][0]
-	h, err := canonicalBlock.Hash()
+	h, err := c.candidateBlock.Hash()
 	if err != nil {
 		log.Errorf("Unable to hash canonical block: %v", err)
 		return
 	}
 	// Save canonical block to DB.
-	if err := c.chain.saveCanonical(canonicalBlock); err != nil {
+	if err := c.chain.saveCanonical(c.candidateBlock); err != nil {
 		log.Errorf("Unable to save block to db: %v", err)
 	}
 	log.WithField("blockHash", fmt.Sprintf("0x%x", h)).Info("Canonical block determined")
-
-	// Update the last received slot.
-	c.lastSlot = slot
 
 	// We fire events that notify listeners of a new block (or crystallized state in
 	// the case of a state transition). This is useful for the beacon node's gRPC
 	// server to stream these events to beacon clients.
 	transition := c.chain.IsCycleTransition(slot)
 	if transition {
-		c.canonicalCrystallizedStateFeed.Send(canonicalCrystallizedState)
+		c.canonicalCrystallizedStateFeed.Send(c.candidateCState)
 	}
-	c.canonicalBlockFeed.Send(canonicalBlock)
+	c.canonicalBlockFeed.Send(c.candidateBlock)
+
+	c.candidateBlock = nilBlock
+	c.candidateAState = nilActiveState
+	c.candidateCState = nilCrystallizedState
 }
 
 func (c *ChainService) blockProcessing(done <-chan struct{}) {
@@ -273,20 +252,13 @@ func (c *ChainService) blockProcessing(done <-chan struct{}) {
 
 			log.WithField("blockHash", fmt.Sprintf("0x%x", h)).Info("Received full block, processing validity conditions")
 
-			// Check if parentHash is in previous slot's processed blockHash list.
-			// TODO: This is messy. Instead, we should implement c.chain.CanProcessBlock
-			// to take in the block and the DAG of previously processed blocks
-			// and determine all validity conditions from those two parameters.
-			isParentHashExistent := false
-			for i := 0; i < len(c.processedBlockHashesBySlot[receivedSlotNumber-1]); i++ {
-				p := block.ParentHash()
-				if bytes.Equal(c.processedBlockHashesBySlot[receivedSlotNumber-1][i], p[:]) {
-					isParentHashExistent = true
-				}
+			parentExists, err := c.chain.hasBlock(block.ParentHash())
+			if err != nil {
+				log.Debugf("Could not check existance of parent hash: %v", err)
 			}
 
 			// If parentHash does not exist, received block fails validity conditions.
-			if !isParentHashExistent && receivedSlotNumber > 1 {
+			if !parentExists && receivedSlotNumber > 1 {
 				continue
 			}
 
@@ -320,8 +292,19 @@ func (c *ChainService) blockProcessing(done <-chan struct{}) {
 				continue
 			}
 
-			if receivedSlotNumber > c.lastSlot && receivedSlotNumber > 1 {
+			if c.candidateBlock != nil && receivedSlotNumber > c.candidateBlock.SlotNumber() && receivedSlotNumber > 1 {
 				c.updateHead(receivedSlotNumber)
+			}
+
+			if err := c.chain.saveBlock(block); err != nil {
+				log.Errorf("Failed to save block: %v", err)
+			}
+
+			log.Info("Finished processing received block")
+
+			// Do not proceed further, because a candidate has already been chosen.
+			if c.candidateBlock != nil {
+				continue
 			}
 
 			// 3 steps:
@@ -334,57 +317,23 @@ func (c *ChainService) blockProcessing(done <-chan struct{}) {
 			// TODO: Using latest block hash for seed, this will eventually be replaced by randao.
 
 			// Entering cycle transitions.
-			transition := c.chain.IsCycleTransition(receivedSlotNumber)
-			if transition {
-				crystallizedStateAfterCycle, activeStateAfterCycle := c.chain.initCycle(c.chain.CrystallizedState(), c.chain.ActiveState())
-
-				activeState, err := c.chain.computeNewActiveState(processedAttestations, activeStateAfterCycle, blockVoteCache, h)
-				if err != nil {
-					log.Errorf("Compute active state failed: %v", err)
-				}
-				if err := c.chain.SetActiveState(activeState); err != nil {
-					log.Errorf("Set active state failed: %v", err)
-				}
-
-				c.processedCrystallizedStatesBySlot[receivedSlotNumber] = append(
-					c.processedCrystallizedStatesBySlot[receivedSlotNumber],
-					crystallizedStateAfterCycle,
-				)
-				c.processedActiveStatesBySlot[receivedSlotNumber] = append(
-					c.processedActiveStatesBySlot[receivedSlotNumber],
-					activeState,
-				)
-			} else {
-				activeState, err := c.chain.computeNewActiveState(processedAttestations, c.chain.ActiveState(), blockVoteCache, h)
-				if err != nil {
-					log.Errorf("Compute active state failed: %v", err)
-				}
-				if err := c.chain.SetActiveState(activeState); err != nil {
-					log.Errorf("Set active state failed: %v", err)
-				}
-
-				c.processedCrystallizedStatesBySlot[receivedSlotNumber] = append(
-					c.processedCrystallizedStatesBySlot[receivedSlotNumber],
-					c.chain.CrystallizedState(),
-				)
-				c.processedActiveStatesBySlot[receivedSlotNumber] = append(
-					c.processedActiveStatesBySlot[receivedSlotNumber],
-					activeState,
-				)
+			isTransition := c.chain.IsCycleTransition(receivedSlotNumber)
+			aState := c.chain.ActiveState()
+			cState := c.chain.CrystallizedState()
+			if isTransition {
+				cState, aState = c.chain.initCycle(cState, aState)
 			}
 
-			// We store a slice of received states and blocks.
-			// perceived slot number for forks.
-			c.processedBlockHashesBySlot[receivedSlotNumber] = append(
-				c.processedBlockHashesBySlot[receivedSlotNumber],
-				h[:],
-			)
+			aState, err = c.chain.computeNewActiveState(processedAttestations, aState, blockVoteCache, h)
+			if err != nil {
+				log.Errorf("Compute active state failed: %v", err)
+			}
 
-			c.processedBlocksBySlot[receivedSlotNumber] = append(
-				c.processedBlocksBySlot[receivedSlotNumber],
-				block,
-			)
-			log.Info("Finished processing received block and states into DAG")
+			c.candidateBlock = block
+			c.candidateAState = aState
+			c.candidateCState = cState
+
+			log.Info("Finished processing state for candidate block")
 		}
 	}
 }

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -281,7 +281,7 @@ func TestRunningChainService(t *testing.T) {
 
 	testutil.AssertLogsContain(t, hook, "Finished processing received block and states into DAG")
 }
-
+/*
 func TestUpdateHead(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
@@ -360,7 +360,7 @@ func TestUpdateHead(t *testing.T) {
 	chainService.lastSlot = 100
 	chainService.updateHead(101)
 }
-
+*/
 func TestProcessingBlockWithAttestations(t *testing.T) {
 	ctx := context.Background()
 	config := &database.DBConfig{DataDir: "", Name: "", InMemory: true}


### PR DESCRIPTION
This changeset is an alternative implementation to #440. Note that this PR is for discussion and is not ready to be merged. Changes are kept to a minimum to focus on discussing the requirements.

### Highlights
* **Blocks are stored after validation as opposed to after the fork choice rule.** All valid blocks are stored to disk because future blocks can build off non-canonical blocks. 
* **Blocks are NOT stored by slot.** As far as I can tell, this isn't necessary. The current code stores blocks by slot to track blocks for the previous slot. This changeset tracks the previous slot's block with `chainService.candidateBlock`.
* **State is only calculated once per slot.** The insight here is that due to the naive fork choice rule, we know that the first processed block will become the canonical block. This reduces management of state down to one block per slot, which is tracked by `chainService.candidateAState` and `chainService.candidateCState`. Note that the real fork choice rule will have to calculate state for multiple blocks per slot. 

### Pruning old blocks
We had a discussion about pruning old non-canonical blocks that are more than 4 months old because of the [revert limit](https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQs#what-is-weak-subjectivity). This is optional, since the fork choice rule will ignore blocks that are more than 4 months old anyways. Either way pruning can be done relatively simply with something like this:

Edit: @nisdas mentioned that pruning can use block timestamps.

```go
func (c *ChainService) pruneOldBlocks() {
	// first, determine the threshold under which blocks are more than 4 months old
	block, _ := c.chain.CanonicalHead()
	currentSlot := block.SlotNumber()

	threshold := time.Now().AddDate(0, -4, 0)

	// next, map canonical blocks below threshold
	canonicalBlocks := map[[32]byte]struct{}{}
	for ; block.SlotNumber() == 0; {
		blockhash, _ := block.Hash()
		time, _ := block.Timestamp()
		if time.Before(threshold) {
			canonicalBlocks[blockhash] = struct{}{}
		}

		block, _ = c.chain.getBlock(block.ParentHash())
	}

	// finally, scan through all blocks and prune
	iter := c.chain.ScanBlocks()
	for iter.Next() {
		blockhash := iter.Key()
		block := iter.Value()
		time, _ := block.Timestamp()

		// skip block if before threshold
		if time.Before(threshold) {
			continue
		}

		// skip block if part of the canonical chain
		if _, ok := canonicalBlocks[blockhash]; ok {
			continue
		}

		c.chain.removeBlock(blockhash)
	}
}
```