### PR TITLE
Update rules_go, bazel_gazelle, and go-ethereum to Support Go 1.11

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,17 +2,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    # in order to be able to enable race detection we need to use a version
-    # < 0.13.0 until this bug is fixed: https://github.com/bazelbuild/rules_go/issues/1592
-    # We are using 0.12 here until bazelbuild/bazel-gazelle#272 is resolved, as we cannot import
-    # protobuf/ptypes normally until this issue is fixed
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.12.1/rules_go-0.12.1.tar.gz"],
-    sha256 = "8b68d0630d63d95dacc0016c3bb4b76154fe34fca93efd65d1c366de3fcb4294",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.15.3/rules_go-0.15.3.tar.gz"],
+    sha256 = "97cf62bdef33519412167fd1e4b0810a318a7c234f5f8dc4f53e2da86241c492",
 )
 
 http_archive(
     name = "bazel_gazelle",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.12.0/bazel-gazelle-0.12.0.tar.gz"],
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.14.0/bazel-gazelle-0.14.0.tar.gz"],
+    sha256 = "c0a5739d12c6d05b6c1ad56f2200cb0b57c5a70e03ebd2f7b87ce88cabf09c7b",
 )
 
 git_repository(
@@ -95,8 +92,8 @@ go_repository(
     # code.
     remote = "https://github.com/prysmaticlabs/bazel-go-ethereum",
     vcs = "git",
-    # Last updated August 15, 2018
-    commit = "c169d4b64d5360f5c1220a148c4438f7c90c8c96",
+    # Last updated September 09, 2018
+    commit = "f4b3f83362a4cf2928e57914af040aea76c8a7d6",
 )
 
 go_repository(

--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -29,7 +29,7 @@ go_test(
         "//shared/testutil:go_default_library",
         "@com_github_ethereum_go_ethereum//event:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",

--- a/beacon-chain/simulator/BUILD.bazel
+++ b/beacon-chain/simulator/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "//shared/p2p:go_default_library",
         "@com_github_ethereum_go_ethereum//ethdb:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/beacon-chain/types/BUILD.bazel
+++ b/beacon-chain/types/BUILD.bazel
@@ -21,7 +21,7 @@ go_library(
         "@com_github_ethereum_go_ethereum//event:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@org_golang_x_crypto//blake2b:go_default_library",
     ],
 )

--- a/validator/proposer/BUILD.bazel
+++ b/validator/proposer/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
         "//proto/beacon/rpc/v1:go_default_library",
         "@com_github_ethereum_go_ethereum//event:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_minio_blake2b_simd//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],


### PR DESCRIPTION
The latest version of rules_go and bazel_gazelle support go 1.11 which has a lot of nice features.

I don't foresee any issues, but please checkout this branch and build it on your local machine before clicking approve.

Need

- [x] Approval build from MacOS
- [x] Approval build from Linux

I've built and ran tests for ubuntu, but I haven't tested on MacOS.