### PR TITLE
Allow pubkeys to be defined without trailing zeros

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -125,11 +125,10 @@ func (w *Web3Service) run(done <-chan struct{}) {
 			}).Debug("Latest web3 chain event")
 		case VRClog := <-w.logChan:
 			// public key is the second topic from validatorRegistered log
-			pubKeyLog := VRClog.Topics[1].Hex()
-			// Support user pubKeys with or without the leading 0x
-			if pubKeyLog == w.pubKey || pubKeyLog[2:] == w.pubKey {
+			pubKeyLog := VRClog.Topics[1]
+			if pubKeyLog == common.HexToHash(w.pubKey) {
 				log.WithFields(logrus.Fields{
-					"publicKey": pubKeyLog,
+					"publicKey": pubKeyLog.Hex(),
 				}).Info("Validator registered in VRC with public key")
 				w.validatorRegistered = true
 				w.logChan = nil

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -124,9 +124,10 @@ func (w *Web3Service) run(done <-chan struct{}) {
 				"blockHash":   w.blockHash.Hex(),
 			}).Debug("Latest web3 chain event")
 		case VRClog := <-w.logChan:
-			// public key is the second topic from validatorRegistered log and strip off 0x
-			pubKeyLog := VRClog.Topics[1].Hex()[2:]
-			if pubKeyLog == w.pubKey {
+			// public key is the second topic from validatorRegistered log
+			pubKeyLog := VRClog.Topics[1].Hex()
+			// Support user pubKeys with or without the leading 0x
+			if pubKeyLog == w.pubKey || pubKeyLog[2:] == w.pubKey {
 				log.WithFields(logrus.Fields{
 					"publicKey": pubKeyLog,
 				}).Info("Validator registered in VRC with public key")

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -125,14 +125,8 @@ func (w *Web3Service) run(done <-chan struct{}) {
 			}).Debug("Latest web3 chain event")
 		case VRClog := <-w.logChan:
 			// public key is the second topic from validatorRegistered log
-<<<<<<< HEAD
 			pubKeyLog := VRClog.Topics[1]
 			if pubKeyLog == common.HexToHash(w.pubKey) {
-=======
-			pubKeyLog := VRClog.Topics[1].Hex()
-			// Support user pubKeys with or without the leading 0x
-			if pubKeyLog == w.pubKey || pubKeyLog[2:] == w.pubKey {
->>>>>>> master
 				log.WithFields(logrus.Fields{
 					"publicKey": pubKeyLog.Hex(),
 				}).Info("Validator registered in VRC with public key")

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -216,10 +216,13 @@ func TestGoodLogger(t *testing.T) {
 }
 
 func TestHeaderAfterValidation(t *testing.T) {
-	// User pubkeys with or without 0x should be OK.
 	testPubKeys := []string{
+		// User pubkeys with or without 0x should be OK.
 		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
 		"0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		// byte32 without the trailing zeros should be OK.
+		"0x04c4ed707d713d98bd9d8271f330afc9ab905806",
+		"04c4ed707d713d98bd9d8271f330afc9ab905806",
 	}
 
 	for _, tt := range testPubKeys {


### PR DESCRIPTION
This allows users to define their pubkey without padding it unnecessarily with zeros to make it 32 length.

I.e. this comparison is true: 0x04c4ed707d713d98bd9d8271f330afc9ab905806 == 0x04c4ed707d713d98bd9d8271f330afc9ab905806000000000000000000000000