### PR TITLE
Attestation Justified Slot Validation Per Spec

### DIFF
--- a/beacon-chain/types/attestation.go
+++ b/beacon-chain/types/attestation.go
@@ -94,7 +94,7 @@ func (a *Attestation) ShardBlockHash() []byte {
 
 // JustifiedSlotNumber of the attestation should be earlier than the last justified slot in crystallized state.
 func (a *Attestation) JustifiedSlotNumber() uint64 {
-	return a.data.Slot
+	return a.data.JustifiedSlot
 }
 
 // JustifiedBlockHash should be in the chain of the block being processed.

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -218,12 +218,12 @@ func (b *Block) isAttestationValid(attestationIndex int, chain chainSearchServic
 	blockInChain, err := chain.ContainsBlock(hash)
 	if err != nil {
 		//need to figure out what would be the "correct" way of going about a database error, how should we terminate?
-		log.Debugf("unable to determine if attestation justified block is in the DB: %s", err)
+		log.Errorf("unable to determine if attestation justified block is in the DB: %s", err)
 		return false
 	}
 
 	if !blockInChain {
-		log.Debugf("attestation's justified block hash has to be in the current chain.  Justified block hash: %v",
+		log.Debugf("The attestion's justifed block hash has to be in the current chain, but was not found.  Justified block hash: %v",
 			attestation.JustifiedBlockHash)
 		return false
 	}

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -217,7 +217,6 @@ func (b *Block) isAttestationValid(attestationIndex int, chain chainSearchServic
 	copy(attestation.JustifiedBlockHash[:], hash[:32])
 	blockInChain, err := chain.ContainsBlock(hash)
 	if err != nil {
-		//need to figure out what would be the "correct" way of going about a database error, how should we terminate?
 		log.Errorf("unable to determine if attestation justified block is in the DB: %s", err)
 		return false
 	}

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -206,7 +206,7 @@ func (b *Block) isAttestationValid(attestationIndex int, chain chainSearchServic
 		return false
 	}
 
-	if (attestation.JustifiedSlot <= cState.LastJustifiedSlot()) == false {
+	if !(attestation.JustifiedSlot <= cState.LastJustifiedSlot()) {
 		log.Debugf("attestation's justified slot has to be earlier or equal to crystallied state's last justified slot. Found: %d. Want <=: %d",
 			attestation.JustifiedSlot,
 			cState.LastJustifiedSlot())
@@ -218,7 +218,7 @@ func (b *Block) isAttestationValid(attestationIndex int, chain chainSearchServic
 	blockInChain, err := chain.ContainsBlock(hash)
 	if err != nil {
 		//need to figure out what would be the "correct" way of going about a database error, how should we terminate?
-		log.Debugf("unable to determine if attestation's justified block hash is in the current chain: %s", err)
+		log.Debugf("unable to determine if attestation justified block is in the DB: %s", err)
 		return false
 	}
 

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -207,7 +207,7 @@ func (b *Block) isAttestationValid(attestationIndex int, chain chainSearchServic
 	}
 
 	if attestation.JustifiedSlot > cState.LastJustifiedSlot() {
-		log.Debugf("attestation's justified slot has to be earlier or equal to crystallied state's last justified slot. Found: %d. Want <=: %d",
+		log.Debugf("attestation's justified slot has to be earlier or equal to crystallized state's last justified slot. Found: %d. Want <=: %d",
 			attestation.JustifiedSlot,
 			cState.LastJustifiedSlot())
 		return false

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -206,7 +206,7 @@ func (b *Block) isAttestationValid(attestationIndex int, chain chainSearchServic
 		return false
 	}
 
-	if !(attestation.JustifiedSlot <= cState.LastJustifiedSlot()) {
+	if attestation.JustifiedSlot > cState.LastJustifiedSlot() {
 		log.Debugf("attestation's justified slot has to be earlier or equal to crystallied state's last justified slot. Found: %d. Want <=: %d",
 			attestation.JustifiedSlot,
 			cState.LastJustifiedSlot())

--- a/beacon-chain/types/block_test.go
+++ b/beacon-chain/types/block_test.go
@@ -12,6 +12,12 @@ func init() {
 	logrus.SetLevel(logrus.DebugLevel)
 }
 
+type mockChainService struct{}
+
+func (f *mockChainService) ContainsBlock(h [32]byte) (bool, error) {
+	return true, nil
+}
+
 func TestGenesisBlock(t *testing.T) {
 	b1, err1 := NewGenesisBlock()
 	b2, err2 := NewGenesisBlock()
@@ -62,6 +68,7 @@ func TestGenesisBlock(t *testing.T) {
 
 func TestBlockValidity(t *testing.T) {
 	cState, err := NewGenesisCrystallizedState()
+
 	if err != nil {
 		t.Fatalf("failed to generate crystallized state: %v", err)
 	}
@@ -87,11 +94,13 @@ func TestBlockValidity(t *testing.T) {
 	})
 
 	parentSlot := uint64(1)
-	if !b.isAttestationValid(0, aState, cState, parentSlot) {
+	chainService := &mockChainService{}
+
+	if !b.isAttestationValid(0, chainService, aState, cState, parentSlot) {
 		t.Fatalf("failed attestation validation")
 	}
 
-	if !b.IsValid(aState, cState, parentSlot) {
+	if !b.IsValid(chainService, aState, cState, parentSlot) {
 		t.Fatalf("failed block validation")
 	}
 }


### PR DESCRIPTION
This addresses #468 

Verifying a valid `Attestation`'s `JustifiedHash` is in the current chain and the `JustifiedSlot` is earlier or equal to the `CrystalizedState.LastJustifiedSlot`.

I think there is a chance of optimization and reducing database load by instead of checking the database for the block belonging to the current chain, only checking `ActiveState.RecentBlockHashes` - what do you think? 