### PR TITLE
Align getSignedParentHashes With Spec Implementation Example

### DIFF
--- a/beacon-chain/types/active_state.go
+++ b/beacon-chain/types/active_state.go
@@ -242,7 +242,7 @@ func (a *ActiveState) getBlockHash(currentBlock *Block, slot uint64) ([32]byte, 
 }
 
 // getSignedParentHashes returns all the parent hashes stored in active state up to last cycle length.
-func (a *ActiveState) getSignedParentHashes(block *Block, attestation *pb.AttestationRecord) (signedParentHashes [params.CycleLength][32]byte, err error) {
+func (a *ActiveState) getSignedParentHashes(block *Block, attestation *pb.AggregatedAttestation) (signedParentHashes [params.CycleLength][32]byte, err error) {
 	loc := 0
 
 	for i := 1; i <= (params.CycleLength - len(attestation.ObliqueParentHashes)); i++ {

--- a/beacon-chain/types/active_state.go
+++ b/beacon-chain/types/active_state.go
@@ -155,7 +155,7 @@ func (a *ActiveState) calculateNewVoteCache(block *Block, cState *CrystallizedSt
 		if err != nil {
 			return nil, err
 		}
-		
+
 		attesterIndices, err := cState.getAttesterIndices(attestation)
 		if err != nil {
 			return nil, err
@@ -227,14 +227,15 @@ func (a *ActiveState) CalculateNewActiveState(block *Block, cState *Crystallized
 	}, newBlockVoteCache), nil
 }
 
-func (a *ActiveState) getBlockHash(block *Block, slot uint64) ([32]byte, error) {
+// getBlockHash by looking at the current block and returning the block hash at the given slot number. If the slot number is not within the cycleLength*2 range, then this method returns an error.
+func (a *ActiveState) getBlockHash(currentBlock *Block, slot uint64) ([32]byte, error) {
 	//hashes are filled from the end of the array backwards towards the beginning
-	relativeSlotPosition := slot - (block.SlotNumber() - (params.CycleLength * 2))
+	relativeSlotPosition := slot - (currentBlock.SlotNumber() - (params.CycleLength * 2))
 
-	if (relativeSlotPosition < 0 || relativeSlotPosition > params.CycleLength * 2) {
+	if relativeSlotPosition < 0 || relativeSlotPosition > params.CycleLength*2 {
 		return [32]byte{}, fmt.Errorf("requested slot hash is out of recent hashes bounds in ActiveState: Requested: %d Currnt Slot Number: %d",
 			slot,
-			block.SlotNumber())
+			currentBlock.SlotNumber())
 	}
 
 	return a.RecentBlockHashes()[relativeSlotPosition], nil

--- a/beacon-chain/types/active_state_test.go
+++ b/beacon-chain/types/active_state_test.go
@@ -267,3 +267,39 @@ func TestCalculateNewActiveState(t *testing.T) {
 		t.Fatalf("incorrect number of items in RecentBlockHashes: %d", len(aState.RecentBlockHashes()))
 	}
 }
+
+
+func TestGetSignedParentHashes(t *testing.T) {
+	block := NewBlock(&pb.BeaconBlock{
+		SlotNumber: 129,
+	})
+
+	recentBlockHashes := [][]byte{}
+	for i := 0; i < 2*params.CycleLength; i++ {
+		recentBlockHashes = append(recentBlockHashes, []byte{0})
+	}
+
+	aState := NewActiveState(&pb.ActiveState{
+		PendingAttestations: []*pb.AggregatedAttestation{
+			{
+				Slot:    0,
+				ShardId: 0,
+			},
+			{
+				Slot:    0,
+				ShardId: 1,
+			},
+		},
+		RecentBlockHashes: recentBlockHashes,
+	}, nil)
+
+	hashes, err := aState.getSignedParentHashes(block, aState.data.PendingAttestations[0])
+	if err != nil {
+		t.Fatalf("failed to get back expected parent hashes")
+	}
+
+	if !reflect.DeepEqual(hashes, recentBlockHashes) {
+		t.Fatalf("returned parent hashes from getSignedParentHashes are not what we expected")
+	}
+
+}

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -240,7 +240,7 @@ func (b *Block) isAttestationValid(attestationIndex int, chain chainSearchServic
 	// TODO(#258): Generate validators aggregated pub key.
 
 	attestationMsg := AttestationMsg(
-		parentHashes,
+		parentHashes[:],
 		attestation.ShardBlockHash,
 		attestation.Slot,
 		attestation.ShardId,

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -220,7 +220,12 @@ func (b *Block) isAttestationValid(attestationIndex int, chain chainSearchServic
 	}
 
 	// Get all the block hashes up to cycle length.
-	parentHashes := aState.getSignedParentHashes(b, attestation)
+	parentHashes, err := aState.getSignedParentHashes(b, attestation)
+	if err != nil {
+		log.Errorf(err.Error())
+		return false
+	}
+
 	attesterIndices, err := cState.getAttesterIndices(attestation)
 	if err != nil {
 		log.Debugf("Unable to get validator committee: %v", attesterIndices)


### PR DESCRIPTION
This addresses #463 

~~1) We should decide what to do when an error is thrown from `getBlockHash`~~
2) Wasn't sure if `common.BytesToHash` was needed in `getBlockHash`
3) Need to decide if we want to build a special test for this