### PR TITLE
P2P: Message Metadata Support

### DIFF
--- a/proto/beacon/p2p/v1/messages.pb.go
+++ b/proto/beacon/p2p/v1/messages.pb.go
@@ -3,10 +3,12 @@
 
 package ethereum_beacon_p2p_v1
 
-import proto "github.com/golang/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import timestamp "github.com/golang/protobuf/ptypes/timestamp"
+import (
+	fmt "fmt"
+	proto "github.com/golang/protobuf/proto"
+	timestamp "github.com/golang/protobuf/ptypes/timestamp"
+	math "math"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -48,6 +50,7 @@ var Topic_name = map[int32]string{
 	9:  "ACTIVE_STATE_REQUEST",
 	10: "ACTIVE_STATE_RESPONSE",
 }
+
 var Topic_value = map[string]int32{
 	"UNKNOWN":                             0,
 	"BEACON_BLOCK_HASH_ANNOUNCE":          1,
@@ -65,8 +68,723 @@ var Topic_value = map[string]int32{
 func (x Topic) String() string {
 	return proto.EnumName(Topic_name, int32(x))
 }
+
 func (Topic) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{0}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{0}
+}
+
+type Message struct {
+	Metadata map[string][]byte `protobuf:"bytes,1,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// Types that are valid to be assigned to Payload:
+	//	*Message_BeaconBlockHashAnnounce
+	//	*Message_BeaconBlockRequest
+	//	*Message_BeaconBlockRequestBySlotNumber
+	//	*Message_BeaconBlockResponse
+	//	*Message_BeaconBlock
+	//	*Message_CrystallizedStateHashAnnounce
+	//	*Message_CrystallizedStateRequest
+	//	*Message_CrystallizedStateResponse
+	//	*Message_CrystallizedState
+	//	*Message_ShardAndCommitteeArray
+	//	*Message_ActiveStateHashAnnounce
+	//	*Message_ActiveStateRequest
+	//	*Message_ShardAndCommittee
+	//	*Message_ActiveStateResponse
+	//	*Message_ActiveState
+	//	*Message_ValidatorRecord
+	//	*Message_AggregatedAttestation
+	//	*Message_CrosslinkRecord
+	//	*Message_AttestationHashes
+	Payload              isMessage_Payload `protobuf_oneof:"payload"`
+	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
+	XXX_sizecache        int32             `json:"-"`
+}
+
+func (m *Message) Reset()         { *m = Message{} }
+func (m *Message) String() string { return proto.CompactTextString(m) }
+func (*Message) ProtoMessage()    {}
+func (*Message) Descriptor() ([]byte, []int) {
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{0}
+}
+func (m *Message) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Message.Unmarshal(m, b)
+}
+func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Message.Marshal(b, m, deterministic)
+}
+func (m *Message) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Message.Merge(m, src)
+}
+func (m *Message) XXX_Size() int {
+	return xxx_messageInfo_Message.Size(m)
+}
+func (m *Message) XXX_DiscardUnknown() {
+	xxx_messageInfo_Message.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Message proto.InternalMessageInfo
+
+func (m *Message) GetMetadata() map[string][]byte {
+	if m != nil {
+		return m.Metadata
+	}
+	return nil
+}
+
+type isMessage_Payload interface {
+	isMessage_Payload()
+}
+
+type Message_BeaconBlockHashAnnounce struct {
+	BeaconBlockHashAnnounce *BeaconBlockHashAnnounce `protobuf:"bytes,2,opt,name=beaconBlockHashAnnounce,proto3,oneof"`
+}
+
+type Message_BeaconBlockRequest struct {
+	BeaconBlockRequest *BeaconBlockRequest `protobuf:"bytes,3,opt,name=beaconBlockRequest,proto3,oneof"`
+}
+
+type Message_BeaconBlockRequestBySlotNumber struct {
+	BeaconBlockRequestBySlotNumber *BeaconBlockRequestBySlotNumber `protobuf:"bytes,4,opt,name=beaconBlockRequestBySlotNumber,proto3,oneof"`
+}
+
+type Message_BeaconBlockResponse struct {
+	BeaconBlockResponse *BeaconBlockResponse `protobuf:"bytes,5,opt,name=beaconBlockResponse,proto3,oneof"`
+}
+
+type Message_BeaconBlock struct {
+	BeaconBlock *BeaconBlock `protobuf:"bytes,6,opt,name=beaconBlock,proto3,oneof"`
+}
+
+type Message_CrystallizedStateHashAnnounce struct {
+	CrystallizedStateHashAnnounce *CrystallizedStateHashAnnounce `protobuf:"bytes,7,opt,name=crystallizedStateHashAnnounce,proto3,oneof"`
+}
+
+type Message_CrystallizedStateRequest struct {
+	CrystallizedStateRequest *CrystallizedStateRequest `protobuf:"bytes,8,opt,name=crystallizedStateRequest,proto3,oneof"`
+}
+
+type Message_CrystallizedStateResponse struct {
+	CrystallizedStateResponse *CrystallizedStateResponse `protobuf:"bytes,9,opt,name=crystallizedStateResponse,proto3,oneof"`
+}
+
+type Message_CrystallizedState struct {
+	CrystallizedState *CrystallizedState `protobuf:"bytes,10,opt,name=crystallizedState,proto3,oneof"`
+}
+
+type Message_ShardAndCommitteeArray struct {
+	ShardAndCommitteeArray *ShardAndCommitteeArray `protobuf:"bytes,11,opt,name=shardAndCommitteeArray,proto3,oneof"`
+}
+
+type Message_ActiveStateHashAnnounce struct {
+	ActiveStateHashAnnounce *ActiveStateHashAnnounce `protobuf:"bytes,12,opt,name=activeStateHashAnnounce,proto3,oneof"`
+}
+
+type Message_ActiveStateRequest struct {
+	ActiveStateRequest *ActiveStateRequest `protobuf:"bytes,13,opt,name=activeStateRequest,proto3,oneof"`
+}
+
+type Message_ShardAndCommittee struct {
+	ShardAndCommittee *ShardAndCommittee `protobuf:"bytes,14,opt,name=shardAndCommittee,proto3,oneof"`
+}
+
+type Message_ActiveStateResponse struct {
+	ActiveStateResponse *ActiveStateResponse `protobuf:"bytes,15,opt,name=activeStateResponse,proto3,oneof"`
+}
+
+type Message_ActiveState struct {
+	ActiveState *ActiveState `protobuf:"bytes,16,opt,name=activeState,proto3,oneof"`
+}
+
+type Message_ValidatorRecord struct {
+	ValidatorRecord *ValidatorRecord `protobuf:"bytes,17,opt,name=validatorRecord,proto3,oneof"`
+}
+
+type Message_AggregatedAttestation struct {
+	AggregatedAttestation *AggregatedAttestation `protobuf:"bytes,18,opt,name=aggregatedAttestation,proto3,oneof"`
+}
+
+type Message_CrosslinkRecord struct {
+	CrosslinkRecord *CrosslinkRecord `protobuf:"bytes,19,opt,name=crosslinkRecord,proto3,oneof"`
+}
+
+type Message_AttestationHashes struct {
+	AttestationHashes *AttestationHashes `protobuf:"bytes,20,opt,name=attestationHashes,proto3,oneof"`
+}
+
+func (*Message_BeaconBlockHashAnnounce) isMessage_Payload() {}
+
+func (*Message_BeaconBlockRequest) isMessage_Payload() {}
+
+func (*Message_BeaconBlockRequestBySlotNumber) isMessage_Payload() {}
+
+func (*Message_BeaconBlockResponse) isMessage_Payload() {}
+
+func (*Message_BeaconBlock) isMessage_Payload() {}
+
+func (*Message_CrystallizedStateHashAnnounce) isMessage_Payload() {}
+
+func (*Message_CrystallizedStateRequest) isMessage_Payload() {}
+
+func (*Message_CrystallizedStateResponse) isMessage_Payload() {}
+
+func (*Message_CrystallizedState) isMessage_Payload() {}
+
+func (*Message_ShardAndCommitteeArray) isMessage_Payload() {}
+
+func (*Message_ActiveStateHashAnnounce) isMessage_Payload() {}
+
+func (*Message_ActiveStateRequest) isMessage_Payload() {}
+
+func (*Message_ShardAndCommittee) isMessage_Payload() {}
+
+func (*Message_ActiveStateResponse) isMessage_Payload() {}
+
+func (*Message_ActiveState) isMessage_Payload() {}
+
+func (*Message_ValidatorRecord) isMessage_Payload() {}
+
+func (*Message_AggregatedAttestation) isMessage_Payload() {}
+
+func (*Message_CrosslinkRecord) isMessage_Payload() {}
+
+func (*Message_AttestationHashes) isMessage_Payload() {}
+
+func (m *Message) GetPayload() isMessage_Payload {
+	if m != nil {
+		return m.Payload
+	}
+	return nil
+}
+
+func (m *Message) GetBeaconBlockHashAnnounce() *BeaconBlockHashAnnounce {
+	if x, ok := m.GetPayload().(*Message_BeaconBlockHashAnnounce); ok {
+		return x.BeaconBlockHashAnnounce
+	}
+	return nil
+}
+
+func (m *Message) GetBeaconBlockRequest() *BeaconBlockRequest {
+	if x, ok := m.GetPayload().(*Message_BeaconBlockRequest); ok {
+		return x.BeaconBlockRequest
+	}
+	return nil
+}
+
+func (m *Message) GetBeaconBlockRequestBySlotNumber() *BeaconBlockRequestBySlotNumber {
+	if x, ok := m.GetPayload().(*Message_BeaconBlockRequestBySlotNumber); ok {
+		return x.BeaconBlockRequestBySlotNumber
+	}
+	return nil
+}
+
+func (m *Message) GetBeaconBlockResponse() *BeaconBlockResponse {
+	if x, ok := m.GetPayload().(*Message_BeaconBlockResponse); ok {
+		return x.BeaconBlockResponse
+	}
+	return nil
+}
+
+func (m *Message) GetBeaconBlock() *BeaconBlock {
+	if x, ok := m.GetPayload().(*Message_BeaconBlock); ok {
+		return x.BeaconBlock
+	}
+	return nil
+}
+
+func (m *Message) GetCrystallizedStateHashAnnounce() *CrystallizedStateHashAnnounce {
+	if x, ok := m.GetPayload().(*Message_CrystallizedStateHashAnnounce); ok {
+		return x.CrystallizedStateHashAnnounce
+	}
+	return nil
+}
+
+func (m *Message) GetCrystallizedStateRequest() *CrystallizedStateRequest {
+	if x, ok := m.GetPayload().(*Message_CrystallizedStateRequest); ok {
+		return x.CrystallizedStateRequest
+	}
+	return nil
+}
+
+func (m *Message) GetCrystallizedStateResponse() *CrystallizedStateResponse {
+	if x, ok := m.GetPayload().(*Message_CrystallizedStateResponse); ok {
+		return x.CrystallizedStateResponse
+	}
+	return nil
+}
+
+func (m *Message) GetCrystallizedState() *CrystallizedState {
+	if x, ok := m.GetPayload().(*Message_CrystallizedState); ok {
+		return x.CrystallizedState
+	}
+	return nil
+}
+
+func (m *Message) GetShardAndCommitteeArray() *ShardAndCommitteeArray {
+	if x, ok := m.GetPayload().(*Message_ShardAndCommitteeArray); ok {
+		return x.ShardAndCommitteeArray
+	}
+	return nil
+}
+
+func (m *Message) GetActiveStateHashAnnounce() *ActiveStateHashAnnounce {
+	if x, ok := m.GetPayload().(*Message_ActiveStateHashAnnounce); ok {
+		return x.ActiveStateHashAnnounce
+	}
+	return nil
+}
+
+func (m *Message) GetActiveStateRequest() *ActiveStateRequest {
+	if x, ok := m.GetPayload().(*Message_ActiveStateRequest); ok {
+		return x.ActiveStateRequest
+	}
+	return nil
+}
+
+func (m *Message) GetShardAndCommittee() *ShardAndCommittee {
+	if x, ok := m.GetPayload().(*Message_ShardAndCommittee); ok {
+		return x.ShardAndCommittee
+	}
+	return nil
+}
+
+func (m *Message) GetActiveStateResponse() *ActiveStateResponse {
+	if x, ok := m.GetPayload().(*Message_ActiveStateResponse); ok {
+		return x.ActiveStateResponse
+	}
+	return nil
+}
+
+func (m *Message) GetActiveState() *ActiveState {
+	if x, ok := m.GetPayload().(*Message_ActiveState); ok {
+		return x.ActiveState
+	}
+	return nil
+}
+
+func (m *Message) GetValidatorRecord() *ValidatorRecord {
+	if x, ok := m.GetPayload().(*Message_ValidatorRecord); ok {
+		return x.ValidatorRecord
+	}
+	return nil
+}
+
+func (m *Message) GetAggregatedAttestation() *AggregatedAttestation {
+	if x, ok := m.GetPayload().(*Message_AggregatedAttestation); ok {
+		return x.AggregatedAttestation
+	}
+	return nil
+}
+
+func (m *Message) GetCrosslinkRecord() *CrosslinkRecord {
+	if x, ok := m.GetPayload().(*Message_CrosslinkRecord); ok {
+		return x.CrosslinkRecord
+	}
+	return nil
+}
+
+func (m *Message) GetAttestationHashes() *AttestationHashes {
+	if x, ok := m.GetPayload().(*Message_AttestationHashes); ok {
+		return x.AttestationHashes
+	}
+	return nil
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*Message) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
+	return _Message_OneofMarshaler, _Message_OneofUnmarshaler, _Message_OneofSizer, []interface{}{
+		(*Message_BeaconBlockHashAnnounce)(nil),
+		(*Message_BeaconBlockRequest)(nil),
+		(*Message_BeaconBlockRequestBySlotNumber)(nil),
+		(*Message_BeaconBlockResponse)(nil),
+		(*Message_BeaconBlock)(nil),
+		(*Message_CrystallizedStateHashAnnounce)(nil),
+		(*Message_CrystallizedStateRequest)(nil),
+		(*Message_CrystallizedStateResponse)(nil),
+		(*Message_CrystallizedState)(nil),
+		(*Message_ShardAndCommitteeArray)(nil),
+		(*Message_ActiveStateHashAnnounce)(nil),
+		(*Message_ActiveStateRequest)(nil),
+		(*Message_ShardAndCommittee)(nil),
+		(*Message_ActiveStateResponse)(nil),
+		(*Message_ActiveState)(nil),
+		(*Message_ValidatorRecord)(nil),
+		(*Message_AggregatedAttestation)(nil),
+		(*Message_CrosslinkRecord)(nil),
+		(*Message_AttestationHashes)(nil),
+	}
+}
+
+func _Message_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
+	m := msg.(*Message)
+	// payload
+	switch x := m.Payload.(type) {
+	case *Message_BeaconBlockHashAnnounce:
+		b.EncodeVarint(2<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.BeaconBlockHashAnnounce); err != nil {
+			return err
+		}
+	case *Message_BeaconBlockRequest:
+		b.EncodeVarint(3<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.BeaconBlockRequest); err != nil {
+			return err
+		}
+	case *Message_BeaconBlockRequestBySlotNumber:
+		b.EncodeVarint(4<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.BeaconBlockRequestBySlotNumber); err != nil {
+			return err
+		}
+	case *Message_BeaconBlockResponse:
+		b.EncodeVarint(5<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.BeaconBlockResponse); err != nil {
+			return err
+		}
+	case *Message_BeaconBlock:
+		b.EncodeVarint(6<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.BeaconBlock); err != nil {
+			return err
+		}
+	case *Message_CrystallizedStateHashAnnounce:
+		b.EncodeVarint(7<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.CrystallizedStateHashAnnounce); err != nil {
+			return err
+		}
+	case *Message_CrystallizedStateRequest:
+		b.EncodeVarint(8<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.CrystallizedStateRequest); err != nil {
+			return err
+		}
+	case *Message_CrystallizedStateResponse:
+		b.EncodeVarint(9<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.CrystallizedStateResponse); err != nil {
+			return err
+		}
+	case *Message_CrystallizedState:
+		b.EncodeVarint(10<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.CrystallizedState); err != nil {
+			return err
+		}
+	case *Message_ShardAndCommitteeArray:
+		b.EncodeVarint(11<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ShardAndCommitteeArray); err != nil {
+			return err
+		}
+	case *Message_ActiveStateHashAnnounce:
+		b.EncodeVarint(12<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ActiveStateHashAnnounce); err != nil {
+			return err
+		}
+	case *Message_ActiveStateRequest:
+		b.EncodeVarint(13<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ActiveStateRequest); err != nil {
+			return err
+		}
+	case *Message_ShardAndCommittee:
+		b.EncodeVarint(14<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ShardAndCommittee); err != nil {
+			return err
+		}
+	case *Message_ActiveStateResponse:
+		b.EncodeVarint(15<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ActiveStateResponse); err != nil {
+			return err
+		}
+	case *Message_ActiveState:
+		b.EncodeVarint(16<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ActiveState); err != nil {
+			return err
+		}
+	case *Message_ValidatorRecord:
+		b.EncodeVarint(17<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.ValidatorRecord); err != nil {
+			return err
+		}
+	case *Message_AggregatedAttestation:
+		b.EncodeVarint(18<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AggregatedAttestation); err != nil {
+			return err
+		}
+	case *Message_CrosslinkRecord:
+		b.EncodeVarint(19<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.CrosslinkRecord); err != nil {
+			return err
+		}
+	case *Message_AttestationHashes:
+		b.EncodeVarint(20<<3 | proto.WireBytes)
+		if err := b.EncodeMessage(x.AttestationHashes); err != nil {
+			return err
+		}
+	case nil:
+	default:
+		return fmt.Errorf("Message.Payload has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _Message_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
+	m := msg.(*Message)
+	switch tag {
+	case 2: // payload.beaconBlockHashAnnounce
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(BeaconBlockHashAnnounce)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_BeaconBlockHashAnnounce{msg}
+		return true, err
+	case 3: // payload.beaconBlockRequest
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(BeaconBlockRequest)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_BeaconBlockRequest{msg}
+		return true, err
+	case 4: // payload.beaconBlockRequestBySlotNumber
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(BeaconBlockRequestBySlotNumber)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_BeaconBlockRequestBySlotNumber{msg}
+		return true, err
+	case 5: // payload.beaconBlockResponse
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(BeaconBlockResponse)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_BeaconBlockResponse{msg}
+		return true, err
+	case 6: // payload.beaconBlock
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(BeaconBlock)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_BeaconBlock{msg}
+		return true, err
+	case 7: // payload.crystallizedStateHashAnnounce
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(CrystallizedStateHashAnnounce)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_CrystallizedStateHashAnnounce{msg}
+		return true, err
+	case 8: // payload.crystallizedStateRequest
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(CrystallizedStateRequest)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_CrystallizedStateRequest{msg}
+		return true, err
+	case 9: // payload.crystallizedStateResponse
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(CrystallizedStateResponse)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_CrystallizedStateResponse{msg}
+		return true, err
+	case 10: // payload.crystallizedState
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(CrystallizedState)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_CrystallizedState{msg}
+		return true, err
+	case 11: // payload.shardAndCommitteeArray
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ShardAndCommitteeArray)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_ShardAndCommitteeArray{msg}
+		return true, err
+	case 12: // payload.activeStateHashAnnounce
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ActiveStateHashAnnounce)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_ActiveStateHashAnnounce{msg}
+		return true, err
+	case 13: // payload.activeStateRequest
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ActiveStateRequest)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_ActiveStateRequest{msg}
+		return true, err
+	case 14: // payload.shardAndCommittee
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ShardAndCommittee)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_ShardAndCommittee{msg}
+		return true, err
+	case 15: // payload.activeStateResponse
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ActiveStateResponse)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_ActiveStateResponse{msg}
+		return true, err
+	case 16: // payload.activeState
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ActiveState)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_ActiveState{msg}
+		return true, err
+	case 17: // payload.validatorRecord
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(ValidatorRecord)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_ValidatorRecord{msg}
+		return true, err
+	case 18: // payload.aggregatedAttestation
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AggregatedAttestation)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_AggregatedAttestation{msg}
+		return true, err
+	case 19: // payload.crosslinkRecord
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(CrosslinkRecord)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_CrosslinkRecord{msg}
+		return true, err
+	case 20: // payload.attestationHashes
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		msg := new(AttestationHashes)
+		err := b.DecodeMessage(msg)
+		m.Payload = &Message_AttestationHashes{msg}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _Message_OneofSizer(msg proto.Message) (n int) {
+	m := msg.(*Message)
+	// payload
+	switch x := m.Payload.(type) {
+	case *Message_BeaconBlockHashAnnounce:
+		s := proto.Size(x.BeaconBlockHashAnnounce)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_BeaconBlockRequest:
+		s := proto.Size(x.BeaconBlockRequest)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_BeaconBlockRequestBySlotNumber:
+		s := proto.Size(x.BeaconBlockRequestBySlotNumber)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_BeaconBlockResponse:
+		s := proto.Size(x.BeaconBlockResponse)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_BeaconBlock:
+		s := proto.Size(x.BeaconBlock)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_CrystallizedStateHashAnnounce:
+		s := proto.Size(x.CrystallizedStateHashAnnounce)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_CrystallizedStateRequest:
+		s := proto.Size(x.CrystallizedStateRequest)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_CrystallizedStateResponse:
+		s := proto.Size(x.CrystallizedStateResponse)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_CrystallizedState:
+		s := proto.Size(x.CrystallizedState)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_ShardAndCommitteeArray:
+		s := proto.Size(x.ShardAndCommitteeArray)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_ActiveStateHashAnnounce:
+		s := proto.Size(x.ActiveStateHashAnnounce)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_ActiveStateRequest:
+		s := proto.Size(x.ActiveStateRequest)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_ShardAndCommittee:
+		s := proto.Size(x.ShardAndCommittee)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_ActiveStateResponse:
+		s := proto.Size(x.ActiveStateResponse)
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_ActiveState:
+		s := proto.Size(x.ActiveState)
+		n += 2 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_ValidatorRecord:
+		s := proto.Size(x.ValidatorRecord)
+		n += 2 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_AggregatedAttestation:
+		s := proto.Size(x.AggregatedAttestation)
+		n += 2 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_CrosslinkRecord:
+		s := proto.Size(x.CrosslinkRecord)
+		n += 2 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case *Message_AttestationHashes:
+		s := proto.Size(x.AttestationHashes)
+		n += 2 // tag and wire
+		n += proto.SizeVarint(uint64(s))
+		n += s
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
 }
 
 type BeaconBlockHashAnnounce struct {
@@ -80,7 +798,7 @@ func (m *BeaconBlockHashAnnounce) Reset()         { *m = BeaconBlockHashAnnounce
 func (m *BeaconBlockHashAnnounce) String() string { return proto.CompactTextString(m) }
 func (*BeaconBlockHashAnnounce) ProtoMessage()    {}
 func (*BeaconBlockHashAnnounce) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{0}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{1}
 }
 func (m *BeaconBlockHashAnnounce) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BeaconBlockHashAnnounce.Unmarshal(m, b)
@@ -88,8 +806,8 @@ func (m *BeaconBlockHashAnnounce) XXX_Unmarshal(b []byte) error {
 func (m *BeaconBlockHashAnnounce) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BeaconBlockHashAnnounce.Marshal(b, m, deterministic)
 }
-func (dst *BeaconBlockHashAnnounce) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BeaconBlockHashAnnounce.Merge(dst, src)
+func (m *BeaconBlockHashAnnounce) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BeaconBlockHashAnnounce.Merge(m, src)
 }
 func (m *BeaconBlockHashAnnounce) XXX_Size() int {
 	return xxx_messageInfo_BeaconBlockHashAnnounce.Size(m)
@@ -118,7 +836,7 @@ func (m *BeaconBlockRequest) Reset()         { *m = BeaconBlockRequest{} }
 func (m *BeaconBlockRequest) String() string { return proto.CompactTextString(m) }
 func (*BeaconBlockRequest) ProtoMessage()    {}
 func (*BeaconBlockRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{1}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{2}
 }
 func (m *BeaconBlockRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BeaconBlockRequest.Unmarshal(m, b)
@@ -126,8 +844,8 @@ func (m *BeaconBlockRequest) XXX_Unmarshal(b []byte) error {
 func (m *BeaconBlockRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BeaconBlockRequest.Marshal(b, m, deterministic)
 }
-func (dst *BeaconBlockRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BeaconBlockRequest.Merge(dst, src)
+func (m *BeaconBlockRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BeaconBlockRequest.Merge(m, src)
 }
 func (m *BeaconBlockRequest) XXX_Size() int {
 	return xxx_messageInfo_BeaconBlockRequest.Size(m)
@@ -156,7 +874,7 @@ func (m *BeaconBlockRequestBySlotNumber) Reset()         { *m = BeaconBlockReque
 func (m *BeaconBlockRequestBySlotNumber) String() string { return proto.CompactTextString(m) }
 func (*BeaconBlockRequestBySlotNumber) ProtoMessage()    {}
 func (*BeaconBlockRequestBySlotNumber) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{2}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{3}
 }
 func (m *BeaconBlockRequestBySlotNumber) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BeaconBlockRequestBySlotNumber.Unmarshal(m, b)
@@ -164,8 +882,8 @@ func (m *BeaconBlockRequestBySlotNumber) XXX_Unmarshal(b []byte) error {
 func (m *BeaconBlockRequestBySlotNumber) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BeaconBlockRequestBySlotNumber.Marshal(b, m, deterministic)
 }
-func (dst *BeaconBlockRequestBySlotNumber) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BeaconBlockRequestBySlotNumber.Merge(dst, src)
+func (m *BeaconBlockRequestBySlotNumber) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BeaconBlockRequestBySlotNumber.Merge(m, src)
 }
 func (m *BeaconBlockRequestBySlotNumber) XXX_Size() int {
 	return xxx_messageInfo_BeaconBlockRequestBySlotNumber.Size(m)
@@ -195,7 +913,7 @@ func (m *BeaconBlockResponse) Reset()         { *m = BeaconBlockResponse{} }
 func (m *BeaconBlockResponse) String() string { return proto.CompactTextString(m) }
 func (*BeaconBlockResponse) ProtoMessage()    {}
 func (*BeaconBlockResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{3}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{4}
 }
 func (m *BeaconBlockResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BeaconBlockResponse.Unmarshal(m, b)
@@ -203,8 +921,8 @@ func (m *BeaconBlockResponse) XXX_Unmarshal(b []byte) error {
 func (m *BeaconBlockResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BeaconBlockResponse.Marshal(b, m, deterministic)
 }
-func (dst *BeaconBlockResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BeaconBlockResponse.Merge(dst, src)
+func (m *BeaconBlockResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BeaconBlockResponse.Merge(m, src)
 }
 func (m *BeaconBlockResponse) XXX_Size() int {
 	return xxx_messageInfo_BeaconBlockResponse.Size(m)
@@ -247,7 +965,7 @@ func (m *BeaconBlock) Reset()         { *m = BeaconBlock{} }
 func (m *BeaconBlock) String() string { return proto.CompactTextString(m) }
 func (*BeaconBlock) ProtoMessage()    {}
 func (*BeaconBlock) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{4}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{5}
 }
 func (m *BeaconBlock) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BeaconBlock.Unmarshal(m, b)
@@ -255,8 +973,8 @@ func (m *BeaconBlock) XXX_Unmarshal(b []byte) error {
 func (m *BeaconBlock) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_BeaconBlock.Marshal(b, m, deterministic)
 }
-func (dst *BeaconBlock) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BeaconBlock.Merge(dst, src)
+func (m *BeaconBlock) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BeaconBlock.Merge(m, src)
 }
 func (m *BeaconBlock) XXX_Size() int {
 	return xxx_messageInfo_BeaconBlock.Size(m)
@@ -334,7 +1052,7 @@ func (m *CrystallizedStateHashAnnounce) Reset()         { *m = CrystallizedState
 func (m *CrystallizedStateHashAnnounce) String() string { return proto.CompactTextString(m) }
 func (*CrystallizedStateHashAnnounce) ProtoMessage()    {}
 func (*CrystallizedStateHashAnnounce) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{5}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{6}
 }
 func (m *CrystallizedStateHashAnnounce) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CrystallizedStateHashAnnounce.Unmarshal(m, b)
@@ -342,8 +1060,8 @@ func (m *CrystallizedStateHashAnnounce) XXX_Unmarshal(b []byte) error {
 func (m *CrystallizedStateHashAnnounce) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CrystallizedStateHashAnnounce.Marshal(b, m, deterministic)
 }
-func (dst *CrystallizedStateHashAnnounce) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CrystallizedStateHashAnnounce.Merge(dst, src)
+func (m *CrystallizedStateHashAnnounce) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CrystallizedStateHashAnnounce.Merge(m, src)
 }
 func (m *CrystallizedStateHashAnnounce) XXX_Size() int {
 	return xxx_messageInfo_CrystallizedStateHashAnnounce.Size(m)
@@ -372,7 +1090,7 @@ func (m *CrystallizedStateRequest) Reset()         { *m = CrystallizedStateReque
 func (m *CrystallizedStateRequest) String() string { return proto.CompactTextString(m) }
 func (*CrystallizedStateRequest) ProtoMessage()    {}
 func (*CrystallizedStateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{6}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{7}
 }
 func (m *CrystallizedStateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CrystallizedStateRequest.Unmarshal(m, b)
@@ -380,8 +1098,8 @@ func (m *CrystallizedStateRequest) XXX_Unmarshal(b []byte) error {
 func (m *CrystallizedStateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CrystallizedStateRequest.Marshal(b, m, deterministic)
 }
-func (dst *CrystallizedStateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CrystallizedStateRequest.Merge(dst, src)
+func (m *CrystallizedStateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CrystallizedStateRequest.Merge(m, src)
 }
 func (m *CrystallizedStateRequest) XXX_Size() int {
 	return xxx_messageInfo_CrystallizedStateRequest.Size(m)
@@ -410,7 +1128,7 @@ func (m *CrystallizedStateResponse) Reset()         { *m = CrystallizedStateResp
 func (m *CrystallizedStateResponse) String() string { return proto.CompactTextString(m) }
 func (*CrystallizedStateResponse) ProtoMessage()    {}
 func (*CrystallizedStateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{7}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{8}
 }
 func (m *CrystallizedStateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CrystallizedStateResponse.Unmarshal(m, b)
@@ -418,8 +1136,8 @@ func (m *CrystallizedStateResponse) XXX_Unmarshal(b []byte) error {
 func (m *CrystallizedStateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CrystallizedStateResponse.Marshal(b, m, deterministic)
 }
-func (dst *CrystallizedStateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CrystallizedStateResponse.Merge(dst, src)
+func (m *CrystallizedStateResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CrystallizedStateResponse.Merge(m, src)
 }
 func (m *CrystallizedStateResponse) XXX_Size() int {
 	return xxx_messageInfo_CrystallizedStateResponse.Size(m)
@@ -458,7 +1176,7 @@ func (m *CrystallizedState) Reset()         { *m = CrystallizedState{} }
 func (m *CrystallizedState) String() string { return proto.CompactTextString(m) }
 func (*CrystallizedState) ProtoMessage()    {}
 func (*CrystallizedState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{8}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{9}
 }
 func (m *CrystallizedState) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CrystallizedState.Unmarshal(m, b)
@@ -466,8 +1184,8 @@ func (m *CrystallizedState) XXX_Unmarshal(b []byte) error {
 func (m *CrystallizedState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CrystallizedState.Marshal(b, m, deterministic)
 }
-func (dst *CrystallizedState) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CrystallizedState.Merge(dst, src)
+func (m *CrystallizedState) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CrystallizedState.Merge(m, src)
 }
 func (m *CrystallizedState) XXX_Size() int {
 	return xxx_messageInfo_CrystallizedState.Size(m)
@@ -566,7 +1284,7 @@ func (m *ShardAndCommitteeArray) Reset()         { *m = ShardAndCommitteeArray{}
 func (m *ShardAndCommitteeArray) String() string { return proto.CompactTextString(m) }
 func (*ShardAndCommitteeArray) ProtoMessage()    {}
 func (*ShardAndCommitteeArray) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{9}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{10}
 }
 func (m *ShardAndCommitteeArray) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ShardAndCommitteeArray.Unmarshal(m, b)
@@ -574,8 +1292,8 @@ func (m *ShardAndCommitteeArray) XXX_Unmarshal(b []byte) error {
 func (m *ShardAndCommitteeArray) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ShardAndCommitteeArray.Marshal(b, m, deterministic)
 }
-func (dst *ShardAndCommitteeArray) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ShardAndCommitteeArray.Merge(dst, src)
+func (m *ShardAndCommitteeArray) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ShardAndCommitteeArray.Merge(m, src)
 }
 func (m *ShardAndCommitteeArray) XXX_Size() int {
 	return xxx_messageInfo_ShardAndCommitteeArray.Size(m)
@@ -604,7 +1322,7 @@ func (m *ActiveStateHashAnnounce) Reset()         { *m = ActiveStateHashAnnounce
 func (m *ActiveStateHashAnnounce) String() string { return proto.CompactTextString(m) }
 func (*ActiveStateHashAnnounce) ProtoMessage()    {}
 func (*ActiveStateHashAnnounce) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{10}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{11}
 }
 func (m *ActiveStateHashAnnounce) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ActiveStateHashAnnounce.Unmarshal(m, b)
@@ -612,8 +1330,8 @@ func (m *ActiveStateHashAnnounce) XXX_Unmarshal(b []byte) error {
 func (m *ActiveStateHashAnnounce) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ActiveStateHashAnnounce.Marshal(b, m, deterministic)
 }
-func (dst *ActiveStateHashAnnounce) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ActiveStateHashAnnounce.Merge(dst, src)
+func (m *ActiveStateHashAnnounce) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ActiveStateHashAnnounce.Merge(m, src)
 }
 func (m *ActiveStateHashAnnounce) XXX_Size() int {
 	return xxx_messageInfo_ActiveStateHashAnnounce.Size(m)
@@ -642,7 +1360,7 @@ func (m *ActiveStateRequest) Reset()         { *m = ActiveStateRequest{} }
 func (m *ActiveStateRequest) String() string { return proto.CompactTextString(m) }
 func (*ActiveStateRequest) ProtoMessage()    {}
 func (*ActiveStateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{11}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{12}
 }
 func (m *ActiveStateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ActiveStateRequest.Unmarshal(m, b)
@@ -650,8 +1368,8 @@ func (m *ActiveStateRequest) XXX_Unmarshal(b []byte) error {
 func (m *ActiveStateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ActiveStateRequest.Marshal(b, m, deterministic)
 }
-func (dst *ActiveStateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ActiveStateRequest.Merge(dst, src)
+func (m *ActiveStateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ActiveStateRequest.Merge(m, src)
 }
 func (m *ActiveStateRequest) XXX_Size() int {
 	return xxx_messageInfo_ActiveStateRequest.Size(m)
@@ -681,7 +1399,7 @@ func (m *ShardAndCommittee) Reset()         { *m = ShardAndCommittee{} }
 func (m *ShardAndCommittee) String() string { return proto.CompactTextString(m) }
 func (*ShardAndCommittee) ProtoMessage()    {}
 func (*ShardAndCommittee) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{12}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{13}
 }
 func (m *ShardAndCommittee) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ShardAndCommittee.Unmarshal(m, b)
@@ -689,8 +1407,8 @@ func (m *ShardAndCommittee) XXX_Unmarshal(b []byte) error {
 func (m *ShardAndCommittee) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ShardAndCommittee.Marshal(b, m, deterministic)
 }
-func (dst *ShardAndCommittee) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ShardAndCommittee.Merge(dst, src)
+func (m *ShardAndCommittee) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ShardAndCommittee.Merge(m, src)
 }
 func (m *ShardAndCommittee) XXX_Size() int {
 	return xxx_messageInfo_ShardAndCommittee.Size(m)
@@ -726,7 +1444,7 @@ func (m *ActiveStateResponse) Reset()         { *m = ActiveStateResponse{} }
 func (m *ActiveStateResponse) String() string { return proto.CompactTextString(m) }
 func (*ActiveStateResponse) ProtoMessage()    {}
 func (*ActiveStateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{13}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{14}
 }
 func (m *ActiveStateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ActiveStateResponse.Unmarshal(m, b)
@@ -734,8 +1452,8 @@ func (m *ActiveStateResponse) XXX_Unmarshal(b []byte) error {
 func (m *ActiveStateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ActiveStateResponse.Marshal(b, m, deterministic)
 }
-func (dst *ActiveStateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ActiveStateResponse.Merge(dst, src)
+func (m *ActiveStateResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ActiveStateResponse.Merge(m, src)
 }
 func (m *ActiveStateResponse) XXX_Size() int {
 	return xxx_messageInfo_ActiveStateResponse.Size(m)
@@ -765,7 +1483,7 @@ func (m *ActiveState) Reset()         { *m = ActiveState{} }
 func (m *ActiveState) String() string { return proto.CompactTextString(m) }
 func (*ActiveState) ProtoMessage()    {}
 func (*ActiveState) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{14}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{15}
 }
 func (m *ActiveState) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ActiveState.Unmarshal(m, b)
@@ -773,8 +1491,8 @@ func (m *ActiveState) XXX_Unmarshal(b []byte) error {
 func (m *ActiveState) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ActiveState.Marshal(b, m, deterministic)
 }
-func (dst *ActiveState) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ActiveState.Merge(dst, src)
+func (m *ActiveState) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ActiveState.Merge(m, src)
 }
 func (m *ActiveState) XXX_Size() int {
 	return xxx_messageInfo_ActiveState.Size(m)
@@ -816,7 +1534,7 @@ func (m *ValidatorRecord) Reset()         { *m = ValidatorRecord{} }
 func (m *ValidatorRecord) String() string { return proto.CompactTextString(m) }
 func (*ValidatorRecord) ProtoMessage()    {}
 func (*ValidatorRecord) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{15}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{16}
 }
 func (m *ValidatorRecord) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ValidatorRecord.Unmarshal(m, b)
@@ -824,8 +1542,8 @@ func (m *ValidatorRecord) XXX_Unmarshal(b []byte) error {
 func (m *ValidatorRecord) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_ValidatorRecord.Marshal(b, m, deterministic)
 }
-func (dst *ValidatorRecord) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ValidatorRecord.Merge(dst, src)
+func (m *ValidatorRecord) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ValidatorRecord.Merge(m, src)
 }
 func (m *ValidatorRecord) XXX_Size() int {
 	return xxx_messageInfo_ValidatorRecord.Size(m)
@@ -903,7 +1621,7 @@ func (m *AggregatedAttestation) Reset()         { *m = AggregatedAttestation{} }
 func (m *AggregatedAttestation) String() string { return proto.CompactTextString(m) }
 func (*AggregatedAttestation) ProtoMessage()    {}
 func (*AggregatedAttestation) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{16}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{17}
 }
 func (m *AggregatedAttestation) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AggregatedAttestation.Unmarshal(m, b)
@@ -911,8 +1629,8 @@ func (m *AggregatedAttestation) XXX_Unmarshal(b []byte) error {
 func (m *AggregatedAttestation) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_AggregatedAttestation.Marshal(b, m, deterministic)
 }
-func (dst *AggregatedAttestation) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AggregatedAttestation.Merge(dst, src)
+func (m *AggregatedAttestation) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AggregatedAttestation.Merge(m, src)
 }
 func (m *AggregatedAttestation) XXX_Size() int {
 	return xxx_messageInfo_AggregatedAttestation.Size(m)
@@ -992,7 +1710,7 @@ func (m *CrosslinkRecord) Reset()         { *m = CrosslinkRecord{} }
 func (m *CrosslinkRecord) String() string { return proto.CompactTextString(m) }
 func (*CrosslinkRecord) ProtoMessage()    {}
 func (*CrosslinkRecord) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{17}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{18}
 }
 func (m *CrosslinkRecord) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CrosslinkRecord.Unmarshal(m, b)
@@ -1000,8 +1718,8 @@ func (m *CrosslinkRecord) XXX_Unmarshal(b []byte) error {
 func (m *CrosslinkRecord) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CrosslinkRecord.Marshal(b, m, deterministic)
 }
-func (dst *CrosslinkRecord) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CrosslinkRecord.Merge(dst, src)
+func (m *CrosslinkRecord) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CrosslinkRecord.Merge(m, src)
 }
 func (m *CrosslinkRecord) XXX_Size() int {
 	return xxx_messageInfo_CrosslinkRecord.Size(m)
@@ -1044,7 +1762,7 @@ func (m *AttestationHashes) Reset()         { *m = AttestationHashes{} }
 func (m *AttestationHashes) String() string { return proto.CompactTextString(m) }
 func (*AttestationHashes) ProtoMessage()    {}
 func (*AttestationHashes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_messages_facf6369f1deca1c, []int{18}
+	return fileDescriptor_4dc296cbfe5ffcd5, []int{19}
 }
 func (m *AttestationHashes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AttestationHashes.Unmarshal(m, b)
@@ -1052,8 +1770,8 @@ func (m *AttestationHashes) XXX_Unmarshal(b []byte) error {
 func (m *AttestationHashes) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_AttestationHashes.Marshal(b, m, deterministic)
 }
-func (dst *AttestationHashes) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AttestationHashes.Merge(dst, src)
+func (m *AttestationHashes) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_AttestationHashes.Merge(m, src)
 }
 func (m *AttestationHashes) XXX_Size() int {
 	return xxx_messageInfo_AttestationHashes.Size(m)
@@ -1072,6 +1790,8 @@ func (m *AttestationHashes) GetAttestationHash() [][]byte {
 }
 
 func init() {
+	proto.RegisterType((*Message)(nil), "ethereum.beacon.p2p.v1.Message")
+	proto.RegisterMapType((map[string][]byte)(nil), "ethereum.beacon.p2p.v1.Message.MetadataEntry")
 	proto.RegisterType((*BeaconBlockHashAnnounce)(nil), "ethereum.beacon.p2p.v1.BeaconBlockHashAnnounce")
 	proto.RegisterType((*BeaconBlockRequest)(nil), "ethereum.beacon.p2p.v1.BeaconBlockRequest")
 	proto.RegisterType((*BeaconBlockRequestBySlotNumber)(nil), "ethereum.beacon.p2p.v1.BeaconBlockRequestBySlotNumber")
@@ -1094,91 +1814,116 @@ func init() {
 	proto.RegisterEnum("ethereum.beacon.p2p.v1.Topic", Topic_name, Topic_value)
 }
 
-func init() { proto.RegisterFile("messages.proto", fileDescriptor_messages_facf6369f1deca1c) }
+func init() { proto.RegisterFile("messages.proto", fileDescriptor_4dc296cbfe5ffcd5) }
 
-var fileDescriptor_messages_facf6369f1deca1c = []byte{
-	// 1315 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x56, 0x5f, 0x73, 0xd3, 0xc6,
-	0x16, 0xbf, 0xfe, 0x13, 0x9c, 0x1c, 0x3b, 0x89, 0xbd, 0x21, 0xa0, 0xe4, 0x5e, 0x48, 0xae, 0xb8,
-	0x0c, 0x09, 0x0c, 0xe6, 0x16, 0x66, 0x3a, 0xed, 0x4b, 0x67, 0x64, 0x63, 0x0a, 0x25, 0xb5, 0x41,
-	0x72, 0x68, 0xe9, 0x0c, 0xa3, 0xae, 0xa5, 0xb5, 0x2d, 0x22, 0x6b, 0xcd, 0xee, 0x3a, 0x19, 0xf7,
-	0xa1, 0xef, 0xfd, 0x04, 0x7d, 0xec, 0xf4, 0x0b, 0xb5, 0x9f, 0xa6, 0xef, 0x9d, 0x5d, 0xad, 0x64,
-	0xf9, 0x4f, 0x42, 0xdb, 0x37, 0xe9, 0x77, 0x7e, 0xe7, 0xec, 0xf9, 0xbf, 0x0b, 0x5b, 0x23, 0xc2,
-	0x39, 0x1e, 0x10, 0x5e, 0x1f, 0x33, 0x2a, 0x28, 0xba, 0x41, 0xc4, 0x90, 0x30, 0x32, 0x19, 0xd5,
-	0x7b, 0x04, 0x7b, 0x34, 0xaa, 0x8f, 0x1f, 0x8f, 0xeb, 0xe7, 0x9f, 0xec, 0x1f, 0x0c, 0x28, 0x1d,
-	0x84, 0xe4, 0x91, 0x62, 0xf5, 0x26, 0xfd, 0x47, 0x22, 0x18, 0x11, 0x2e, 0xf0, 0x68, 0x1c, 0x2b,
-	0x9a, 0x0f, 0xe1, 0x66, 0x43, 0x69, 0x34, 0x42, 0xea, 0x9d, 0x3d, 0xc7, 0x7c, 0x68, 0x45, 0x11,
-	0x9d, 0x44, 0x1e, 0x41, 0x08, 0x8a, 0x43, 0xcc, 0x87, 0x46, 0xee, 0x30, 0x77, 0x54, 0xb1, 0xd5,
-	0xb7, 0x79, 0x04, 0x28, 0x43, 0xb7, 0xc9, 0x87, 0x09, 0xe1, 0x62, 0x25, 0xd3, 0x82, 0xdb, 0xcb,
-	0xcc, 0xc6, 0xd4, 0x09, 0xa9, 0x68, 0x4f, 0x46, 0x3d, 0xc2, 0xd0, 0x01, 0x94, 0x79, 0x48, 0x85,
-	0x1b, 0xa9, 0x5f, 0xa5, 0x5c, 0xb4, 0x81, 0xa7, 0x04, 0xf3, 0xd7, 0x1c, 0xec, 0xcc, 0xd9, 0xe0,
-	0x63, 0x1a, 0x71, 0x82, 0x3e, 0x87, 0xb5, 0x9e, 0x04, 0x94, 0x4a, 0xf9, 0xf1, 0x9d, 0xfa, 0xea,
-	0xe0, 0xeb, 0x59, 0xdd, 0x58, 0x03, 0x75, 0xa0, 0x8c, 0x85, 0x90, 0x19, 0x10, 0x01, 0x8d, 0x8c,
-	0xbc, 0x32, 0xf0, 0xf0, 0x32, 0x03, 0xd6, 0x60, 0xc0, 0xc8, 0x00, 0x0b, 0xe2, 0x5b, 0x33, 0x25,
-	0x3b, 0x6b, 0xc1, 0xfc, 0xa9, 0x00, 0xe5, 0xcc, 0x39, 0x32, 0xa8, 0x31, 0x66, 0x24, 0x12, 0x6e,
-	0x26, 0x23, 0x10, 0x43, 0x32, 0xbb, 0x8b, 0x51, 0xe7, 0x17, 0xa3, 0x46, 0x77, 0x60, 0x93, 0xe1,
-	0xc8, 0xc7, 0xd4, 0x65, 0xe4, 0x9c, 0xe0, 0xd0, 0x28, 0x28, 0x1b, 0x95, 0x18, 0xb4, 0x15, 0x86,
-	0x4c, 0xd8, 0x1c, 0xd3, 0x0b, 0xd7, 0x1b, 0xe2, 0x20, 0x72, 0x19, 0xe9, 0x1b, 0x45, 0x45, 0x2a,
-	0x8f, 0xe9, 0x45, 0x53, 0x62, 0x36, 0xe9, 0xa3, 0xfb, 0x50, 0xc3, 0x9e, 0x08, 0xce, 0x89, 0x2b,
-	0x9d, 0x25, 0xb1, 0x43, 0x6b, 0x8a, 0xb7, 0x1d, 0x0b, 0x1c, 0x89, 0x2b, 0xaf, 0x3e, 0x85, 0x9b,
-	0x1e, 0x9b, 0x72, 0x81, 0xc3, 0x30, 0xf8, 0x81, 0xf8, 0x59, 0x8d, 0x6b, 0x4a, 0x63, 0x37, 0x2b,
-	0x9e, 0xe9, 0x7d, 0x06, 0x1b, 0x69, 0x47, 0x19, 0x25, 0x95, 0xcd, 0xfd, 0x7a, 0xdc, 0x73, 0xf5,
-	0xa4, 0xe7, 0xea, 0xdd, 0x84, 0x61, 0xcf, 0xc8, 0xe8, 0x35, 0x54, 0x32, 0x79, 0xe4, 0xc6, 0xfa,
-	0x61, 0xe1, 0xef, 0x97, 0x62, 0xce, 0x84, 0xf9, 0x04, 0x6e, 0x35, 0x57, 0x79, 0x79, 0x65, 0x47,
-	0xd7, 0xc1, 0x58, 0x52, 0xba, 0xaa, 0xaf, 0x27, 0xb0, 0xb7, 0x82, 0xaf, 0x3b, 0xf3, 0x5b, 0x40,
-	0xcb, 0x69, 0xd4, 0x6d, 0x7a, 0x7c, 0x59, 0x68, 0xcb, 0xe6, 0x6a, 0x4b, 0xc9, 0x36, 0xff, 0x28,
-	0x42, 0x6d, 0x89, 0x28, 0x4b, 0x1c, 0x62, 0x2e, 0x74, 0xb9, 0x18, 0xf1, 0x70, 0xe8, 0xe9, 0x41,
-	0xda, 0x96, 0x02, 0xed, 0x9d, 0x84, 0xd1, 0x31, 0x54, 0xdf, 0x4f, 0xb8, 0x08, 0xfa, 0x81, 0x72,
-	0x8c, 0x11, 0x7c, 0xa6, 0xbb, 0x6f, 0x3b, 0xc5, 0x1d, 0x05, 0xa3, 0x3a, 0xec, 0x28, 0xb3, 0x19,
-	0x7e, 0x48, 0x85, 0x6a, 0xc4, 0xa2, 0xad, 0x4e, 0xfc, 0x2a, 0xd5, 0x08, 0xa9, 0x48, 0xf9, 0xfd,
-	0x20, 0xc2, 0x3a, 0x70, 0xc9, 0x2f, 0xce, 0xf8, 0xcf, 0x12, 0x89, 0xe2, 0xdf, 0x83, 0x6d, 0x6f,
-	0xc2, 0xd4, 0x94, 0xf8, 0xd3, 0x08, 0x73, 0x31, 0x55, 0x7d, 0x59, 0xb4, 0xb7, 0x34, 0xfc, 0x34,
-	0x46, 0xd1, 0x5d, 0xd8, 0x12, 0x54, 0xe0, 0xd0, 0xf5, 0xc9, 0x98, 0xf2, 0x40, 0x70, 0xd5, 0x8d,
-	0x45, 0x7b, 0x53, 0xa1, 0x4f, 0x35, 0x88, 0xfe, 0x0b, 0x15, 0x6d, 0xc7, 0xe5, 0x84, 0xf8, 0xaa,
-	0x11, 0x2b, 0x76, 0x59, 0x63, 0x0e, 0x21, 0xbe, 0x9c, 0xaa, 0x94, 0x22, 0x30, 0x13, 0xc6, 0xba,
-	0x32, 0x94, 0xe8, 0x39, 0x12, 0x43, 0x5d, 0xa8, 0x79, 0x8c, 0x72, 0x1e, 0x06, 0xd1, 0x99, 0xcc,
-	0x26, 0x65, 0x3e, 0x37, 0x36, 0x54, 0x63, 0xde, 0xbb, 0xbc, 0x7a, 0x5a, 0xc1, 0x56, 0x7c, 0xbb,
-	0xea, 0xcd, 0x03, 0x1c, 0x7d, 0x09, 0x70, 0x8e, 0xc3, 0xc0, 0xc7, 0x82, 0x32, 0x6e, 0xc0, 0xd5,
-	0xe6, 0xde, 0x24, 0x4c, 0x6d, 0x2e, 0xa3, 0x8a, 0x18, 0xdc, 0xe6, 0x43, 0xcc, 0x7c, 0x17, 0x47,
-	0xbe, 0xeb, 0xd1, 0xd1, 0x28, 0x10, 0x82, 0x10, 0xee, 0xf6, 0x29, 0x53, 0x09, 0xe7, 0x46, 0x59,
-	0x19, 0xaf, 0x5f, 0x66, 0xdc, 0x91, 0xda, 0x56, 0xe4, 0x37, 0x13, 0x5d, 0x8b, 0x31, 0x3c, 0xb5,
-	0xf7, 0xf9, 0x22, 0xce, 0x9f, 0x51, 0x26, 0x2b, 0xc5, 0xcd, 0x1f, 0xe1, 0xc6, 0x6a, 0x2d, 0xe4,
-	0xc3, 0x1e, 0x96, 0x1f, 0xee, 0x0a, 0x9f, 0x8c, 0x9c, 0x72, 0xe4, 0xf8, 0x2f, 0x3b, 0x62, 0xdf,
-	0x50, 0xb6, 0x96, 0x70, 0x79, 0x3f, 0x59, 0xf3, 0xbb, 0xea, 0x63, 0xf7, 0x53, 0x86, 0x7e, 0xd5,
-	0x1c, 0x9f, 0x40, 0x6d, 0xe9, 0x34, 0xb4, 0x07, 0xeb, 0x71, 0x34, 0x81, 0xaf, 0xc7, 0xa8, 0xa4,
-	0xfe, 0x5f, 0xf8, 0xe8, 0x3f, 0xb0, 0x31, 0x0b, 0x2f, 0x7f, 0x58, 0x38, 0xda, 0xb4, 0x67, 0x80,
-	0xf9, 0x0e, 0x76, 0xe6, 0xce, 0xd5, 0xfb, 0xe0, 0x19, 0x54, 0xb2, 0x2b, 0xf8, 0x63, 0x17, 0x56,
-	0xd6, 0x44, 0x39, 0xb3, 0xa2, 0xcd, 0x5f, 0x72, 0x50, 0xce, 0x08, 0xd1, 0xf7, 0x70, 0x7d, 0x4c,
-	0x22, 0x3f, 0x88, 0x06, 0xee, 0xdc, 0x12, 0xcd, 0xfd, 0x93, 0x25, 0xba, 0xa3, 0x4d, 0x65, 0x30,
-	0x2e, 0x47, 0x9a, 0x11, 0x4f, 0x4e, 0xa8, 0xba, 0x38, 0xd5, 0x55, 0x40, 0xb8, 0x0a, 0xbc, 0x62,
-	0xd7, 0x62, 0x51, 0xfa, 0x64, 0x20, 0xdc, 0xfc, 0x39, 0x0f, 0xdb, 0x0b, 0xbd, 0x8b, 0x6e, 0x01,
-	0x8c, 0x27, 0xbd, 0x30, 0xf0, 0xdc, 0x33, 0x32, 0xd5, 0xf9, 0xdc, 0x88, 0x91, 0x97, 0x64, 0x2a,
-	0x17, 0xd2, 0x45, 0x20, 0x86, 0x3e, 0xc3, 0x17, 0x38, 0x8c, 0xbb, 0x28, 0x59, 0x48, 0x33, 0x5c,
-	0xd5, 0x08, 0x3d, 0x04, 0x94, 0xa1, 0x62, 0xdf, 0x67, 0x84, 0x73, 0x7d, 0x31, 0xd6, 0x66, 0x12,
-	0x2b, 0x16, 0xa0, 0x07, 0x50, 0xd3, 0x57, 0x68, 0x5c, 0xa1, 0x11, 0x89, 0x84, 0xbe, 0x21, 0xab,
-	0xb1, 0xa0, 0x99, 0xe2, 0xc8, 0x80, 0x52, 0x0f, 0x87, 0x38, 0xf2, 0x88, 0x5e, 0x42, 0xc9, 0xaf,
-	0xdc, 0x19, 0x6a, 0x57, 0xa4, 0x4b, 0x2a, 0x5e, 0x3e, 0x15, 0x05, 0x26, 0x2b, 0xea, 0x00, 0xca,
-	0x24, 0xf2, 0x53, 0x4a, 0x29, 0xbe, 0xcf, 0x49, 0xe4, 0x6b, 0x82, 0xf9, 0x7b, 0x1e, 0x76, 0x57,
-	0x26, 0x5e, 0xb6, 0xa5, 0xda, 0x93, 0x71, 0x66, 0xd4, 0xf7, 0x5c, 0x07, 0xe6, 0xe7, 0x3b, 0xf0,
-	0x2e, 0x6c, 0xad, 0x5c, 0xc8, 0x9b, 0xef, 0xe7, 0x96, 0xf1, 0xff, 0xe1, 0xfa, 0x8c, 0x36, 0x2b,
-	0x9e, 0x8e, 0x1f, 0xa5, 0xb2, 0xb4, 0x7a, 0xe8, 0x08, 0xaa, 0xf1, 0x99, 0x19, 0x76, 0xfc, 0x4e,
-	0xd8, 0x52, 0xf8, 0x8c, 0xf9, 0x00, 0x6a, 0x71, 0xbf, 0x11, 0xe6, 0xf6, 0x02, 0xd1, 0x0f, 0x48,
-	0xe8, 0xeb, 0x07, 0x42, 0x35, 0x11, 0x34, 0x34, 0x8e, 0x1e, 0xc3, 0x2e, 0xed, 0x85, 0xc1, 0x87,
-	0x09, 0x71, 0x33, 0x4f, 0x22, 0xc2, 0x8d, 0x92, 0x6a, 0xa2, 0x1d, 0x2d, 0x7c, 0x95, 0xbe, 0x8d,
-	0x08, 0x97, 0x29, 0xc7, 0x49, 0xae, 0x5c, 0x1e, 0x0c, 0xd4, 0xb3, 0xa0, 0x68, 0x57, 0x52, 0xd0,
-	0x09, 0x06, 0xe6, 0x3b, 0xd8, 0x5e, 0xd8, 0xba, 0xb2, 0x88, 0x49, 0x05, 0xf4, 0xdc, 0xea, 0x5f,
-	0x39, 0xb7, 0x2a, 0x2c, 0x15, 0x55, 0x5e, 0xb9, 0x3a, 0x03, 0xd2, 0x12, 0x14, 0x66, 0x25, 0x30,
-	0xbf, 0x80, 0x5a, 0xa6, 0x4a, 0xda, 0xb1, 0x63, 0xa8, 0x66, 0x26, 0x2d, 0x79, 0xdc, 0x15, 0xd4,
-	0x5b, 0x6a, 0x9e, 0x7c, 0xff, 0xb7, 0x3c, 0xac, 0x75, 0xe9, 0x38, 0xf0, 0x50, 0x19, 0x4a, 0xa7,
-	0xed, 0x97, 0xed, 0xce, 0x37, 0xed, 0xea, 0xbf, 0xd0, 0x6d, 0xd8, 0x6f, 0xb4, 0xac, 0x66, 0xa7,
-	0xed, 0x36, 0x4e, 0x3a, 0xcd, 0x97, 0xee, 0x73, 0xcb, 0x79, 0xee, 0x5a, 0xed, 0x76, 0xe7, 0xb4,
-	0xdd, 0x6c, 0x55, 0x73, 0xc8, 0x80, 0xeb, 0x73, 0x72, 0xbb, 0xf5, 0xfa, 0xb4, 0xe5, 0x74, 0xab,
-	0x79, 0x74, 0x0f, 0xee, 0xac, 0x92, 0xb8, 0x8d, 0xb7, 0xae, 0x73, 0xd2, 0xe9, 0xba, 0xed, 0xd3,
-	0xaf, 0x1b, 0x2d, 0xbb, 0x5a, 0x40, 0x7b, 0xb0, 0xbb, 0x40, 0x74, 0x5e, 0x75, 0xda, 0x4e, 0xab,
-	0x5a, 0x44, 0xff, 0x83, 0xc3, 0xa6, 0xfd, 0xd6, 0xe9, 0x5a, 0x27, 0x27, 0x2f, 0xbe, 0x6b, 0x3d,
-	0x75, 0x9d, 0xae, 0xd5, 0x6d, 0x2d, 0xf8, 0xb0, 0x26, 0x7d, 0x5c, 0xc1, 0x4a, 0x3c, 0xb9, 0x86,
-	0x0e, 0xe0, 0xdf, 0x2b, 0xe5, 0xfa, 0x98, 0x92, 0x34, 0x60, 0x35, 0xbb, 0x2f, 0xde, 0xb4, 0x56,
-	0x1e, 0xb0, 0x2e, 0x83, 0x9c, 0x93, 0x27, 0xa6, 0x37, 0xa4, 0xef, 0x0b, 0x12, 0x6d, 0x14, 0x7a,
-	0xd7, 0xd4, 0x4b, 0xf2, 0xc9, 0x9f, 0x01, 0x00, 0x00, 0xff, 0xff, 0xdc, 0x69, 0x3b, 0xfd, 0xf5,
-	0x0c, 0x00, 0x00,
+var fileDescriptor_4dc296cbfe5ffcd5 = []byte{
+	// 1727 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x9c, 0x57, 0x6f, 0x6f, 0x1a, 0xc9,
+	0x19, 0xe7, 0x9f, 0x83, 0x79, 0xc0, 0x06, 0xc6, 0x76, 0xb2, 0x76, 0x1b, 0xdb, 0x25, 0x3d, 0xc5,
+	0x97, 0x28, 0xe4, 0xce, 0xa7, 0x9e, 0xae, 0xad, 0x54, 0x69, 0x21, 0xe4, 0x70, 0xe3, 0xe0, 0xbb,
+	0x01, 0x5f, 0x9b, 0xaa, 0xa7, 0xed, 0xc0, 0x8e, 0x61, 0xcf, 0xcb, 0x2e, 0xd9, 0x19, 0x6c, 0x51,
+	0xa9, 0x55, 0xdf, 0xf6, 0x13, 0xf4, 0x65, 0xd5, 0x2f, 0xd4, 0x7e, 0x9a, 0xaa, 0x6f, 0xab, 0x99,
+	0x9d, 0x5d, 0x16, 0x76, 0x21, 0xe4, 0xde, 0xb1, 0xcf, 0x9f, 0xdf, 0x33, 0x33, 0xcf, 0xbf, 0x1f,
+	0xb0, 0x3b, 0xa6, 0x8c, 0x91, 0x21, 0x65, 0xf5, 0x89, 0xe7, 0x72, 0x17, 0x3d, 0xa4, 0x7c, 0x44,
+	0x3d, 0x3a, 0x1d, 0xd7, 0xfb, 0x94, 0x0c, 0x5c, 0xa7, 0x3e, 0x39, 0x9f, 0xd4, 0xef, 0x3e, 0x3f,
+	0x3a, 0x19, 0xba, 0xee, 0xd0, 0xa6, 0x2f, 0xa5, 0x55, 0x7f, 0x7a, 0xf3, 0x92, 0x5b, 0x63, 0xca,
+	0x38, 0x19, 0x4f, 0x7c, 0xc7, 0xda, 0xff, 0xca, 0x90, 0x7f, 0xeb, 0x63, 0xa1, 0x0b, 0xd8, 0x1e,
+	0x53, 0x4e, 0x4c, 0xc2, 0x89, 0x96, 0x3e, 0xcd, 0x9e, 0x15, 0xcf, 0x5f, 0xd4, 0x93, 0x71, 0xeb,
+	0xca, 0xa5, 0xfe, 0x56, 0xd9, 0xb7, 0x1c, 0xee, 0xcd, 0x70, 0xe8, 0x8e, 0x6e, 0xe1, 0x91, 0xef,
+	0xd0, 0xb0, 0xdd, 0xc1, 0x6d, 0x9b, 0xb0, 0x91, 0xee, 0x38, 0xee, 0xd4, 0x19, 0x50, 0x2d, 0x73,
+	0x9a, 0x3e, 0x2b, 0x9e, 0xbf, 0x5c, 0x85, 0xdc, 0x48, 0x76, 0x6b, 0xa7, 0xf0, 0x2a, 0x44, 0xf4,
+	0x47, 0x40, 0x11, 0x15, 0xa6, 0xef, 0xa7, 0x94, 0x71, 0x2d, 0x2b, 0xe3, 0x3c, 0xdb, 0x20, 0x8e,
+	0xf2, 0x68, 0xa7, 0x70, 0x02, 0x0e, 0xfa, 0x5b, 0x1a, 0x8e, 0xe3, 0xe2, 0xc6, 0xac, 0x6b, 0xbb,
+	0xbc, 0x33, 0x1d, 0xf7, 0xa9, 0xa7, 0xe5, 0x64, 0xa8, 0x2f, 0x37, 0x0f, 0x15, 0xf5, 0x6e, 0xa7,
+	0xf0, 0x07, 0xf0, 0x91, 0x01, 0x7b, 0x0b, 0x16, 0x6c, 0xe2, 0x3a, 0x8c, 0x6a, 0x5b, 0x32, 0xec,
+	0xf3, 0x8d, 0xc2, 0xfa, 0x2e, 0xed, 0x14, 0x4e, 0x42, 0x42, 0x5f, 0x43, 0x31, 0x22, 0xd6, 0x1e,
+	0x48, 0xe0, 0x27, 0x9b, 0xa4, 0x28, 0x85, 0xa3, 0x9e, 0xe8, 0x2f, 0xf0, 0x78, 0xe0, 0xcd, 0x18,
+	0x27, 0xb6, 0x6d, 0xfd, 0x99, 0x9a, 0x5d, 0x4e, 0x38, 0x5d, 0xc8, 0x7e, 0x5e, 0x42, 0xff, 0x62,
+	0x15, 0x74, 0x73, 0x9d, 0x73, 0x3b, 0x85, 0xd7, 0xa3, 0x23, 0x07, 0xb4, 0x98, 0x41, 0x50, 0x0f,
+	0xdb, 0x32, 0xf2, 0x67, 0x1b, 0x47, 0x9e, 0x57, 0xc5, 0x4a, 0x4c, 0xf4, 0x1e, 0x0e, 0x13, 0x74,
+	0x2a, 0x3d, 0x05, 0x19, 0xf0, 0xf3, 0x8f, 0x08, 0x18, 0x26, 0x69, 0x35, 0x2a, 0x7a, 0x07, 0xd5,
+	0x98, 0x52, 0x03, 0x19, 0xea, 0xd3, 0xcd, 0x5f, 0x35, 0x85, 0xe3, 0x28, 0x68, 0x04, 0x0f, 0xd9,
+	0x88, 0x78, 0xa6, 0xee, 0x98, 0x4d, 0x77, 0x3c, 0xb6, 0x38, 0xa7, 0x54, 0xf7, 0x3c, 0x32, 0xd3,
+	0x8a, 0x12, 0xbf, 0xbe, 0x0a, 0xbf, 0x9b, 0xe8, 0xd5, 0x4e, 0xe1, 0x15, 0x78, 0x62, 0x3c, 0x90,
+	0x01, 0xb7, 0xee, 0x68, 0xbc, 0x40, 0x4a, 0xeb, 0xc7, 0x83, 0x9e, 0xec, 0x26, 0xc6, 0xc3, 0x0a,
+	0x44, 0x31, 0x1e, 0x22, 0xaa, 0xa0, 0x1c, 0x76, 0xd6, 0x8f, 0x07, 0x3d, 0xe6, 0x21, 0xc6, 0x43,
+	0x1c, 0x47, 0xe4, 0x23, 0x76, 0x49, 0x6d, 0x77, 0x7d, 0x3e, 0x62, 0xef, 0x25, 0xf2, 0x11, 0x43,
+	0x11, 0x6d, 0xbf, 0x10, 0x50, 0xd5, 0x55, 0x79, 0x7d, 0xdb, 0xeb, 0x71, 0x17, 0xd1, 0xf6, 0x09,
+	0x48, 0xa2, 0xed, 0x23, 0x62, 0xad, 0xb2, 0xbe, 0xed, 0xa3, 0x4f, 0x9f, 0xc2, 0x51, 0x4f, 0xd4,
+	0x85, 0xf2, 0x1d, 0xb1, 0x2d, 0x93, 0x70, 0xd7, 0xc3, 0x74, 0xe0, 0x7a, 0xa6, 0x56, 0x95, 0x60,
+	0x4f, 0x57, 0x81, 0x7d, 0xb7, 0x68, 0xde, 0x4e, 0xe1, 0x65, 0x04, 0x44, 0xe1, 0x80, 0x0c, 0x87,
+	0x1e, 0x1d, 0x12, 0x4e, 0x4d, 0x9d, 0x73, 0xb1, 0xb7, 0xb8, 0xe5, 0x3a, 0x1a, 0x92, 0xd0, 0x2b,
+	0x77, 0x93, 0x9e, 0xe4, 0xd4, 0x4e, 0xe1, 0x64, 0x34, 0x71, 0xf6, 0x81, 0xe7, 0x32, 0x66, 0x5b,
+	0xce, 0xad, 0x3a, 0xfb, 0xde, 0xfa, 0xb3, 0x37, 0x17, 0xcd, 0xc5, 0xd9, 0x97, 0x10, 0x44, 0x55,
+	0x90, 0x48, 0x70, 0xc2, 0x46, 0x94, 0x69, 0xfb, 0xeb, 0xab, 0x42, 0x5f, 0x76, 0x10, 0x55, 0x11,
+	0x43, 0x39, 0xfa, 0x35, 0xec, 0x2c, 0x6c, 0x5d, 0x54, 0x81, 0xec, 0x2d, 0x9d, 0x69, 0xe9, 0xd3,
+	0xf4, 0x59, 0x01, 0x8b, 0x9f, 0x68, 0x1f, 0xb6, 0xee, 0x88, 0x3d, 0xf5, 0x77, 0x6d, 0x09, 0xfb,
+	0x1f, 0xbf, 0xca, 0x7c, 0x95, 0x6e, 0x14, 0x20, 0x3f, 0x21, 0x33, 0xdb, 0x25, 0x66, 0xed, 0x05,
+	0x3c, 0x5a, 0xb1, 0x6b, 0x11, 0x82, 0xdc, 0x88, 0xb0, 0x91, 0x84, 0x2c, 0x61, 0xf9, 0xbb, 0x76,
+	0x06, 0x28, 0xbe, 0xc7, 0x12, 0x2d, 0x75, 0x38, 0x5e, 0xbf, 0xf1, 0xd0, 0x09, 0x14, 0x99, 0xed,
+	0x72, 0xc3, 0xf1, 0xd7, 0xa7, 0x70, 0xce, 0x61, 0x60, 0xa1, 0x41, 0xed, 0x5f, 0x69, 0xd8, 0x4b,
+	0x58, 0x5f, 0xe8, 0x97, 0xb0, 0xd5, 0x97, 0x1b, 0x2a, 0xbd, 0xf1, 0x86, 0xc2, 0xbe, 0x07, 0xba,
+	0x82, 0x62, 0xe4, 0x2d, 0x15, 0x0b, 0xf9, 0xb8, 0x1a, 0xc2, 0x51, 0x84, 0xda, 0xdf, 0xb3, 0x50,
+	0x8c, 0xc4, 0x11, 0x97, 0x9a, 0x10, 0x8f, 0x3a, 0xdc, 0x88, 0xbc, 0x08, 0xf8, 0x22, 0xf1, 0xba,
+	0xcb, 0xb7, 0xce, 0x2c, 0xdf, 0x1a, 0x3d, 0x81, 0x1d, 0x8f, 0x38, 0x26, 0x71, 0x0d, 0x8f, 0xde,
+	0x51, 0x62, 0x4b, 0x0a, 0x53, 0xc2, 0x25, 0x5f, 0x88, 0xa5, 0x0c, 0xd5, 0x60, 0x67, 0xe2, 0xde,
+	0x1b, 0x83, 0x11, 0xb1, 0x1c, 0xc3, 0xa3, 0x37, 0x92, 0x7c, 0x94, 0x70, 0x71, 0xe2, 0xde, 0x37,
+	0x85, 0x0c, 0xd3, 0x1b, 0xf4, 0x0c, 0xaa, 0x7e, 0x77, 0x1a, 0xe2, 0xb0, 0xd4, 0x3f, 0xd0, 0x96,
+	0xb4, 0x2b, 0x2f, 0x4d, 0x49, 0xf4, 0x25, 0x3c, 0x8a, 0x6e, 0x82, 0xa8, 0xc7, 0x03, 0xe9, 0x71,
+	0x90, 0xb8, 0x72, 0xd1, 0x57, 0x50, 0x08, 0xb9, 0xa4, 0xda, 0xea, 0x47, 0x75, 0x9f, 0x6d, 0xd6,
+	0x03, 0xb6, 0x59, 0xef, 0x05, 0x16, 0x78, 0x6e, 0x8c, 0xbe, 0x85, 0x52, 0xe4, 0x1d, 0x99, 0xb6,
+	0xbd, 0x9e, 0x6a, 0x26, 0xa7, 0x62, 0x01, 0xa2, 0xf6, 0x05, 0x3c, 0x5e, 0xcb, 0x1c, 0x12, 0xeb,
+	0xb4, 0x0e, 0xda, 0xaa, 0xa5, 0x9f, 0x68, 0x3f, 0x85, 0xc3, 0x95, 0x3b, 0x1b, 0xfd, 0x1e, 0x50,
+	0xfc, 0x19, 0x55, 0x99, 0x6e, 0xbe, 0x97, 0x13, 0xb6, 0x72, 0xed, 0xbf, 0x39, 0xa8, 0xc6, 0x0c,
+	0x45, 0x8a, 0x6d, 0xc2, 0xb8, 0x4a, 0x97, 0x47, 0x07, 0xc4, 0x1e, 0xa8, 0x46, 0x2a, 0x0b, 0x85,
+	0x3a, 0x9d, 0x10, 0xa3, 0x4f, 0xa1, 0xf2, 0xc3, 0x94, 0x71, 0xeb, 0xc6, 0x92, 0x07, 0xf3, 0x28,
+	0xb9, 0x55, 0xd5, 0x57, 0x0e, 0xe5, 0x5d, 0x29, 0x46, 0x75, 0xd8, 0x93, 0xb0, 0x11, 0x7b, 0xdb,
+	0xf5, 0xb9, 0x74, 0x0e, 0xcb, 0x88, 0xbf, 0x0d, 0x3d, 0x6c, 0x97, 0x87, 0xf6, 0x37, 0x96, 0x43,
+	0xd4, 0xc5, 0x85, 0x7d, 0x6e, 0x6e, 0xff, 0x3a, 0xd0, 0x48, 0xfb, 0xa7, 0x50, 0x1e, 0x4c, 0x3d,
+	0xd9, 0x25, 0xe6, 0xcc, 0x21, 0x8c, 0xcf, 0x64, 0x5d, 0xe6, 0xf0, 0xae, 0x12, 0xbf, 0xf2, 0xa5,
+	0xe8, 0x13, 0xd8, 0xe5, 0x2e, 0x27, 0xb6, 0x61, 0xd2, 0x89, 0xcb, 0x2c, 0xce, 0x64, 0x35, 0xe6,
+	0xf0, 0x8e, 0x94, 0xbe, 0x52, 0x42, 0xf4, 0x33, 0x28, 0x29, 0x1c, 0x83, 0x51, 0x6a, 0xca, 0x42,
+	0x2c, 0xe1, 0xa2, 0x92, 0x75, 0x29, 0x35, 0x45, 0x57, 0x85, 0x26, 0x9c, 0x78, 0x3e, 0x11, 0xcc,
+	0xe1, 0xc0, 0xaf, 0x2b, 0x64, 0xa8, 0x27, 0x58, 0x95, 0x1a, 0xe1, 0xe2, 0x35, 0x5d, 0xcf, 0x64,
+	0x5a, 0x41, 0x16, 0xe6, 0xa6, 0x6b, 0x00, 0x57, 0x96, 0x96, 0x00, 0x43, 0x5f, 0x03, 0x84, 0x4b,
+	0x8d, 0x69, 0xb0, 0x1e, 0x6e, 0x69, 0x23, 0xe2, 0x88, 0x2b, 0xf2, 0xe0, 0x58, 0xd2, 0x03, 0x83,
+	0x38, 0xa6, 0x31, 0x08, 0x08, 0x02, 0x33, 0x6e, 0x5c, 0x4f, 0x3e, 0x38, 0xd3, 0x8a, 0x12, 0xfc,
+	0x23, 0x19, 0x1a, 0x3e, 0x8a, 0x91, 0x0e, 0xf6, 0xda, 0xf5, 0x44, 0xa6, 0x58, 0xed, 0xaf, 0xf0,
+	0x30, 0xd9, 0x0b, 0x99, 0x70, 0x48, 0xc4, 0x0f, 0x23, 0xe1, 0x4c, 0xea, 0x8f, 0xe3, 0xe6, 0xd4,
+	0x07, 0x3f, 0x94, 0x58, 0x31, 0xb9, 0xd8, 0x4f, 0x2b, 0xc8, 0xde, 0xaa, 0xfd, 0x14, 0xe7, 0x6c,
+	0x89, 0x96, 0x97, 0x50, 0x8d, 0x45, 0x43, 0x87, 0xb0, 0xed, 0xdf, 0xc6, 0x32, 0x55, 0x1b, 0xe5,
+	0xe5, 0xf7, 0x85, 0x89, 0x7e, 0x0a, 0x85, 0xf9, 0xf5, 0x32, 0xa7, 0xd9, 0xb3, 0x1d, 0x3c, 0x17,
+	0xd4, 0xbe, 0x87, 0xbd, 0x04, 0xc6, 0x85, 0x5e, 0x43, 0x29, 0x3a, 0x82, 0x3f, 0xb4, 0xb0, 0xa2,
+	0x10, 0x51, 0x66, 0x55, 0xfb, 0x67, 0x1a, 0x8a, 0x11, 0x25, 0xfa, 0x13, 0xec, 0x4f, 0xa8, 0x63,
+	0x5a, 0xce, 0xd0, 0x58, 0x18, 0xa2, 0xe9, 0x1f, 0x33, 0x44, 0xf7, 0x14, 0x54, 0x44, 0xc6, 0x44,
+	0x4b, 0x7b, 0x74, 0x20, 0x3a, 0x54, 0x2e, 0x4e, 0xb9, 0x0a, 0x28, 0x93, 0x17, 0x2f, 0xe1, 0xaa,
+	0xaf, 0x0a, 0x29, 0x03, 0x65, 0xb5, 0x7f, 0x64, 0xa0, 0xbc, 0x54, 0xbb, 0xe8, 0x31, 0xc0, 0x64,
+	0xda, 0xb7, 0xad, 0x81, 0x11, 0x30, 0x93, 0x1c, 0x2e, 0xf8, 0x92, 0x37, 0x74, 0x26, 0x06, 0xd2,
+	0xbd, 0xc5, 0x47, 0xa6, 0x47, 0xee, 0x89, 0xed, 0x57, 0x51, 0x30, 0x90, 0xe6, 0x72, 0x99, 0x23,
+	0xf4, 0x02, 0x50, 0xc4, 0x94, 0x98, 0xa6, 0x47, 0x19, 0x53, 0x8b, 0xb1, 0x3a, 0xd7, 0xe8, 0xbe,
+	0x02, 0x3d, 0x87, 0xaa, 0x5a, 0xa1, 0x7e, 0x86, 0xc6, 0xd4, 0xe1, 0x6a, 0x43, 0x56, 0x7c, 0x45,
+	0x33, 0x94, 0x23, 0x0d, 0xf2, 0x7d, 0x62, 0x13, 0xf1, 0xaf, 0xc3, 0x1f, 0x42, 0xc1, 0xa7, 0x98,
+	0x19, 0x72, 0x56, 0x84, 0x43, 0xca, 0x1f, 0x3e, 0x25, 0x29, 0x0c, 0x46, 0xd4, 0x09, 0x14, 0xa9,
+	0x63, 0x86, 0x26, 0x79, 0x7f, 0x9f, 0x53, 0xc7, 0x54, 0x06, 0xb5, 0xff, 0x64, 0xe0, 0x20, 0xf1,
+	0xe1, 0x45, 0x59, 0xca, 0x39, 0xe9, 0xbf, 0x8c, 0xfc, 0xbd, 0x50, 0x81, 0x99, 0xc5, 0x0a, 0xfc,
+	0x04, 0x76, 0x13, 0x07, 0xf2, 0xce, 0x0f, 0x0b, 0xc3, 0xf8, 0x33, 0xd8, 0x9f, 0x9b, 0xcd, 0x93,
+	0xa7, 0xee, 0x8f, 0x42, 0x5d, 0x98, 0x3d, 0x74, 0x06, 0x15, 0x3f, 0x66, 0xc4, 0xda, 0xe7, 0x09,
+	0xbb, 0x52, 0x3e, 0xb7, 0x7c, 0x1e, 0x10, 0x5a, 0xea, 0x19, 0x7d, 0x8b, 0xdf, 0x58, 0xd4, 0x36,
+	0x15, 0x41, 0xa8, 0x04, 0x8a, 0x86, 0x92, 0xa3, 0x73, 0x38, 0x70, 0xfb, 0xb6, 0xf5, 0x7e, 0x4a,
+	0x8d, 0x08, 0x25, 0xa2, 0x4c, 0xcb, 0xcb, 0x22, 0xda, 0x53, 0xca, 0x6f, 0x42, 0x6e, 0x44, 0x99,
+	0x78, 0xf2, 0x90, 0x9f, 0x1b, 0xcc, 0x1a, 0x4a, 0x5a, 0x90, 0xc3, 0xa5, 0x50, 0xd8, 0xb5, 0x86,
+	0xb5, 0xef, 0xa1, 0xbc, 0x34, 0x75, 0x45, 0x12, 0x83, 0x0c, 0xa8, 0xbe, 0x55, 0x9f, 0xa2, 0x6f,
+	0xe5, 0xb5, 0xe4, 0xad, 0x7c, 0x26, 0x3c, 0x17, 0x84, 0x29, 0xc8, 0xce, 0x53, 0x50, 0xfb, 0x0d,
+	0x54, 0x63, 0x24, 0x5c, 0x14, 0x6b, 0xa4, 0xd3, 0x02, 0x72, 0x97, 0x95, 0x5c, 0x6a, 0xd1, 0xf8,
+	0xd9, 0xbf, 0x33, 0xb0, 0xd5, 0x73, 0x27, 0xd6, 0x00, 0x15, 0x21, 0x7f, 0xdd, 0x79, 0xd3, 0xb9,
+	0xfa, 0x5d, 0xa7, 0x92, 0x42, 0xc7, 0x70, 0xd4, 0x68, 0xe9, 0xcd, 0xab, 0x8e, 0xd1, 0xb8, 0xbc,
+	0x6a, 0xbe, 0x31, 0xda, 0x7a, 0xb7, 0x6d, 0xe8, 0x9d, 0xce, 0xd5, 0x75, 0xa7, 0xd9, 0xaa, 0xa4,
+	0x91, 0x06, 0xfb, 0x0b, 0x7a, 0xdc, 0xfa, 0xf6, 0xba, 0xd5, 0xed, 0x55, 0x32, 0xe8, 0x29, 0x3c,
+	0x49, 0xd2, 0x18, 0x8d, 0x77, 0x46, 0xf7, 0xf2, 0xaa, 0x67, 0x74, 0xae, 0xdf, 0x36, 0x5a, 0xb8,
+	0x92, 0x45, 0x87, 0x70, 0xb0, 0x64, 0xd8, 0xfd, 0xe6, 0xaa, 0xd3, 0x6d, 0x55, 0x72, 0xe8, 0xe7,
+	0x70, 0xda, 0xc4, 0xef, 0xba, 0x3d, 0xfd, 0xf2, 0xf2, 0xe2, 0x0f, 0xad, 0x57, 0x46, 0xb7, 0xa7,
+	0xf7, 0x5a, 0x4b, 0x67, 0xd8, 0x12, 0x67, 0x4c, 0xb0, 0x0a, 0x4e, 0xf2, 0x00, 0x9d, 0xc0, 0x4f,
+	0x12, 0xf5, 0x2a, 0x4c, 0x5e, 0x00, 0xe8, 0xcd, 0xde, 0xc5, 0x77, 0xad, 0xc4, 0x00, 0xdb, 0xe2,
+	0x92, 0x0b, 0xfa, 0x00, 0xba, 0x20, 0xce, 0xbe, 0xa4, 0x51, 0xa0, 0xd0, 0x7f, 0x20, 0x99, 0xe4,
+	0x17, 0xff, 0x0f, 0x00, 0x00, 0xff, 0xff, 0x67, 0xa2, 0x78, 0x5e, 0xef, 0x14, 0x00, 0x00,
 }

--- a/proto/beacon/p2p/v1/messages.proto
+++ b/proto/beacon/p2p/v1/messages.proto
@@ -18,6 +18,31 @@ enum Topic {
   ACTIVE_STATE_RESPONSE = 10;
 }
 
+message Message {
+  map<string, bytes> metadata = 1;
+  oneof payload {
+    BeaconBlockHashAnnounce beaconBlockHashAnnounce = 2;
+    BeaconBlockRequest beaconBlockRequest = 3;
+    BeaconBlockRequestBySlotNumber beaconBlockRequestBySlotNumber = 4;
+    BeaconBlockResponse beaconBlockResponse = 5;
+    BeaconBlock beaconBlock = 6;
+    CrystallizedStateHashAnnounce crystallizedStateHashAnnounce = 7;
+    CrystallizedStateRequest crystallizedStateRequest = 8;
+    CrystallizedStateResponse crystallizedStateResponse = 9;
+    CrystallizedState crystallizedState = 10;
+    ShardAndCommitteeArray shardAndCommitteeArray = 11;
+    ActiveStateHashAnnounce activeStateHashAnnounce = 12;
+    ActiveStateRequest activeStateRequest = 13;
+    ShardAndCommittee shardAndCommittee = 14;
+    ActiveStateResponse activeStateResponse = 15;
+    ActiveState activeState = 16;
+    ValidatorRecord validatorRecord = 17;
+    AggregatedAttestation aggregatedAttestation = 18;
+    CrosslinkRecord crosslinkRecord = 19;
+    AttestationHashes attestationHashes = 20;
+  }
+}
+
 message BeaconBlockHashAnnounce {
   bytes hash = 1;
 }


### PR DESCRIPTION
Wanted early feedback on this protobuf change. The motivation is to support passing around trace information for distributed tracing of p2p messages. Discussion on #438.

The idea is to pass around the message defined in this PR through the pub-sub system. Message type can be asserted by doing something like:

```go
var msg pb.Message
switch payload := msg.Payload.(type) {
case *pb.Message_BeaconBlockRequest:
	log.Infof("%v", payload.BeaconBlockRequest)
case *pb.Message_BeaconBlockResponse:
	log.Infof("%v", payload.BeaconBlockResponse)
}
```