### PR TITLE
Fixes Error on Startup for Validator Client

### DIFF
--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -66,7 +66,7 @@ type Service struct {
 	grpcServer          *grpc.Server
 	canonicalBlockChan  chan *types.Block
 	canonicalStateChan  chan *types.CrystallizedState
-	incomingAttestation chan *pbp2p.AggregatedAttestation
+	incomingAttestation chan *types.Attestation
 	devMode             bool
 }
 
@@ -99,7 +99,7 @@ func NewRPCService(ctx context.Context, cfg *Config) *Service {
 		withKey:             cfg.KeyFlag,
 		canonicalBlockChan:  make(chan *types.Block, cfg.SubscriptionBuf),
 		canonicalStateChan:  make(chan *types.CrystallizedState, cfg.SubscriptionBuf),
-		incomingAttestation: make(chan *pbp2p.AggregatedAttestation, cfg.SubscriptionBuf),
+		incomingAttestation: make(chan *types.Attestation, cfg.SubscriptionBuf),
 		devMode:             cfg.DevMode,
 	}
 }
@@ -310,7 +310,7 @@ func (s *Service) LatestAttestation(req *empty.Empty, stream pb.BeaconService_La
 		select {
 		case attestation := <-s.incomingAttestation:
 			log.Info("Sending attestation to RPC clients")
-			if err := stream.Send(attestation); err != nil {
+			if err := stream.Send(attestation.Proto()); err != nil {
 				return err
 			}
 		case <-sub.Err():


### PR DESCRIPTION
The attestation feed was subscribing to `protobuf` for aggregated attestation instead of `types` which led to the beacon-node throwing a panic when the validator client was connected. This PR fixes that