### PR TITLE
Fix State Recalc in Slot Assignment

### DIFF
--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -103,7 +103,7 @@ func (a *Service) aggregateAttestations() {
 				continue
 			}
 
-			log.Info("Forwarding aggregated attestation 0x%v to proposers through grpc", h)
+			log.Infof("Forwarding aggregated attestation 0x%x to proposers through grpc", h)
 		}
 	}
 }

--- a/validator/beacon/service.go
+++ b/validator/beacon/service.go
@@ -135,7 +135,7 @@ func (s *Service) fetchCurrentAssignmentsAndGenesisTime(client pb.BeaconServiceC
 	for _, assign := range res.Assignments {
 		if bytes.Equal(assign.PublicKey.PublicKey, s.pubKey) {
 			s.role = assign.Role
-			s.assignedSlot = assign.AssignedSlot
+			s.assignedSlot = s.CurrentCycleStartSlot() + assign.AssignedSlot
 			s.shardID = assign.ShardId
 
 			log.Infof("Validator shuffled. Pub key 0x%s re-assigned to shard ID %d for %v duty at slot %d",
@@ -176,7 +176,7 @@ func (s *Service) listenForAssignmentChange(client pb.BeaconServiceClient) {
 		for _, assign := range assignment.Assignments {
 			if bytes.Equal(assign.PublicKey.PublicKey, s.pubKey) {
 				s.role = assign.Role
-				s.assignedSlot = assign.AssignedSlot
+				s.assignedSlot = s.CurrentCycleStartSlot() + assign.AssignedSlot
 				s.shardID = assign.ShardId
 
 				log.Infof("Validator with pub key 0x%s re-assigned to shard ID %d for %v duty at slot %d",

--- a/validator/beacon/service.go
+++ b/validator/beacon/service.go
@@ -130,7 +130,7 @@ func (s *Service) fetchCurrentAssignmentsAndGenesisTime(client pb.BeaconServiceC
 		log.Fatalf("cannot compute genesis timestamp: %v", err)
 	}
 
-	log.Infof("Setting validator genesis time to %d", genesisTimestamp.Unix())
+	log.Infof("Setting validator genesis time to %s", genesisTimestamp)
 	s.genesisTimestamp = genesisTimestamp
 	for _, assign := range res.Assignments {
 		if bytes.Equal(assign.PublicKey.PublicKey, s.pubKey) {

--- a/validator/beacon/service.go
+++ b/validator/beacon/service.go
@@ -130,7 +130,7 @@ func (s *Service) fetchCurrentAssignmentsAndGenesisTime(client pb.BeaconServiceC
 		log.Fatalf("cannot compute genesis timestamp: %v", err)
 	}
 
-	log.Infof("Setting validator genesis time to %s", genesisTimestamp)
+	log.Infof("Setting validator genesis time to %s", genesisTimestamp.Format(time.UnixDate))
 	s.genesisTimestamp = genesisTimestamp
 	for _, assign := range res.Assignments {
 		if bytes.Equal(assign.PublicKey.PublicKey, s.pubKey) {

--- a/validator/beacon/service.go
+++ b/validator/beacon/service.go
@@ -140,7 +140,7 @@ func (s *Service) fetchCurrentAssignmentsAndGenesisTime(client pb.BeaconServiceC
 
 			log.Infof("Validator shuffled. Pub key 0x%s re-assigned to shard ID %d for %v duty at slot %d",
 				string(s.pubKey),
-				s.assignedSlot,
+				s.shardID,
 				s.role,
 				s.assignedSlot)
 		}
@@ -181,7 +181,7 @@ func (s *Service) listenForAssignmentChange(client pb.BeaconServiceClient) {
 
 				log.Infof("Validator with pub key 0x%s re-assigned to shard ID %d for %v duty at slot %d",
 					string(s.pubKey),
-					s.assignedSlot,
+					s.shardID,
 					s.role,
 					s.assignedSlot)
 			}

--- a/validator/beacon/service_test.go
+++ b/validator/beacon/service_test.go
@@ -301,10 +301,11 @@ func TestListenForAssignmentProposer(t *testing.T) {
 	stream := internal.NewMockBeaconService_ValidatorAssignmentsClient(ctrl)
 
 	// Testing proposer assignment.
+	assignedSlot := b.CurrentCycleStartSlot() + 2
 	stream.EXPECT().Recv().Return(&pb.ValidatorAssignmentResponse{Assignments: []*pb.Assignment{{
 		PublicKey:    &pb.PublicKey{PublicKey: []byte{'A'}},
 		ShardId:      2,
-		AssignedSlot: 2,
+		AssignedSlot: assignedSlot,
 		Role:         pb.ValidatorRole_PROPOSER}}}, nil)
 	stream.EXPECT().Recv().Return(&pb.ValidatorAssignmentResponse{}, io.EOF)
 
@@ -316,7 +317,7 @@ func TestListenForAssignmentProposer(t *testing.T) {
 
 	b.listenForAssignmentChange(mockServiceValidator)
 
-	testutil.AssertLogsContain(t, hook, "Validator with pub key 0xA re-assigned to shard ID 2 for PROPOSER duty at slot 2")
+	testutil.AssertLogsContain(t, hook, "Validator with pub key 0xA re-assigned to shard ID 2 for PROPOSER duty")
 
 	// Testing an error coming from the stream.
 	stream = internal.NewMockBeaconService_ValidatorAssignmentsClient(ctrl)


### PR DESCRIPTION
No tracking issue, quick fix

---

# Description

Slot assignments are in the range [0, params.CycleLength]. However, current beacon slot can be some big number such as 10929039023. In this case, we want to calculate the start of the current cycle and set the assignment to be CYCLE_START_SLOT + assignedSlot. This PR fixes that issue in the validator client.
