### PR TITLE
Adding Proposer Index to block

### DIFF
--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"time"
 
@@ -212,12 +213,34 @@ func (s *Service) ProposeBlock(ctx context.Context, req *pb.ProposeRequest) (*pb
 	} else {
 		powChainHash = s.powChainService.LatestBlockHash()
 	}
-	data := &pbp2p.BeaconBlock{
-		SlotNumber:  req.GetSlotNumber(),
-		PowChainRef: powChainHash[:],
-		ParentHash:  req.GetParentHash(),
-		Timestamp:   req.GetTimestamp(),
+
+	//TODO(#589) The attestation should be aggregated in the validator client side not in the beacon node.
+	parentSlot := req.GetSlotNumber() - 1
+	cState := s.chainService.CurrentCrystallizedState()
+
+	_, prevProposerIndex, err := casper.ProposerShardAndIndex(
+		cState.ShardAndCommitteesForSlots(),
+		cState.LastStateRecalc(),
+		parentSlot,
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf("could not get index of previous proposer: %v", err)
 	}
+
+	proposerBitfield := uint64(math.Pow(2, (7 - float64(prevProposerIndex))))
+	attestation := &pbp2p.AggregatedAttestation{
+		AttesterBitfield: []byte{byte(proposerBitfield)},
+	}
+
+	data := &pbp2p.BeaconBlock{
+		SlotNumber:   req.GetSlotNumber(),
+		PowChainRef:  powChainHash[:],
+		ParentHash:   req.GetParentHash(),
+		Timestamp:    req.GetTimestamp(),
+		Attestations: []*pbp2p.AggregatedAttestation{attestation},
+	}
+
 	block := types.NewBlock(data)
 	h, err := block.Hash()
 	if err != nil {


### PR DESCRIPTION
This allows for a block proposed by a proposer to be processed by the beacon node successfully and not panic. This is a temporary solution to allow the demo to function smoothly , ultimately #589 will move this to be done in the validator client instead of the beacon node.