### PR TITLE
Beacon Node Determines Slot From Genesis Block if ChainState Detected

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -381,7 +381,14 @@ func (c *ChainService) blockProcessing() {
 			aState := c.chain.ActiveState()
 			cState := c.chain.CrystallizedState()
 
-			if valid := block.IsValid(c, aState, cState, parent.SlotNumber(), c.enableAttestationValidity); !valid {
+			if valid := block.IsValid(
+				c,
+				aState,
+				cState,
+				parent.SlotNumber(),
+				c.enableAttestationValidity,
+				c.genesisTimestamp,
+			); !valid {
 				log.Debugf("Block failed validity conditions: %v", err)
 				continue
 			}

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -61,7 +61,6 @@ func NewChainService(ctx context.Context, cfg *Config) (*ChainService, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	return &ChainService{
 		ctx:                            ctx,
-		genesisTimestamp:               params.GetConfig().GenesisTime,
 		chain:                          cfg.Chain,
 		cancel:                         cancel,
 		beaconDB:                       cfg.BeaconDB,
@@ -84,6 +83,15 @@ func (c *ChainService) Start() {
 	// TODO(#474): Fetch the slot: (block, state) DAGs from persistent storage
 	// to truly continue across sessions.
 	log.Info("Starting service")
+
+	genesis, err := c.GenesisBlock()
+	if err != nil {
+		log.Fatalf("Could not get genesis block: %v", err)
+	}
+	c.genesisTimestamp, err = genesis.Timestamp()
+	if err != nil {
+		log.Fatalf("Could not get genesis timestamp: %v", err)
+	}
 
 	// If the genesis time was at 12:00:00PM and the current time is 12:00:03PM,
 	// the next slot should tick at 12:00:08PM. We can accomplish this

--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//proto/beacon/rpc/v1:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//event:go_default_library",
-        "@com_github_golang_protobuf//ptypes:go_default_library_gen",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
         "@org_golang_google_grpc//:go_default_library",

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/prysmaticlabs/prysm/beacon-chain/casper"
 	"github.com/prysmaticlabs/prysm/beacon-chain/params"
@@ -46,6 +45,7 @@ type canonicalFetcher interface {
 type chainService interface {
 	IncomingBlockFeed() *event.Feed
 	CurrentCrystallizedState() *types.CrystallizedState
+	GenesisBlock() (*types.Block, error)
 }
 
 type attestationService interface {
@@ -178,8 +178,12 @@ func (s *Service) CurrentAssignmentsAndGenesisTime(ctx context.Context, req *pb.
 	// This error is safe to ignore as we are initializing a proto timestamp
 	// from a constant value (genesis time is constant in the protocol
 	// and defined in the params.GetConfig().package).
-	// #nosec G104
-	protoGenesis, _ := ptypes.TimestampProto(params.GetConfig().GenesisTime)
+	// Get the genesis timestamp from persistent storage.
+	genesis, err := s.chainService.GenesisBlock()
+	if err != nil {
+		return nil, fmt.Errorf("could not get genesis block: %v", err)
+	}
+
 	cState := s.chainService.CurrentCrystallizedState()
 	var keys []*pb.PublicKey
 	if req.AllValidators {
@@ -198,7 +202,7 @@ func (s *Service) CurrentAssignmentsAndGenesisTime(ctx context.Context, req *pb.
 	}
 
 	return &pb.CurrentAssignmentsResponse{
-		GenesisTimestamp: protoGenesis,
+		GenesisTimestamp: genesis.Proto().GetTimestamp(),
 		Assignments:      assignments,
 	}, nil
 }

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -50,6 +50,10 @@ func (f *faultyChainService) CanonicalCrystallizedStateFeed() *event.Feed {
 	return nil
 }
 
+func (f *faultyChainService) GenesisBlock() (*types.Block, error) {
+	return nil, errors.New("failed")
+}
+
 type mockChainService struct {
 	blockFeed       *event.Feed
 	stateFeed       *event.Feed
@@ -94,6 +98,10 @@ func (m *mockChainService) CanonicalHead() (*types.Block, error) {
 func (m *mockChainService) CanonicalCrystallizedState() *types.CrystallizedState {
 	data := &pbp2p.CrystallizedState{}
 	return types.NewCrystallizedState(data)
+}
+
+func (m *mockChainService) GenesisBlock() (*types.Block, error) {
+	return types.NewGenesisBlock([32]byte{}, [32]byte{}), nil
 }
 
 func newMockChainService() *mockChainService {

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -138,9 +138,9 @@ func (b *Block) Timestamp() (time.Time, error) {
 }
 
 // isSlotValid compares the slot to the system clock to determine if the block is valid.
-func (b *Block) isSlotValid() bool {
+func (b *Block) isSlotValid(genesisTimestamp time.Time) bool {
 	slotDuration := time.Duration(b.SlotNumber()*params.GetConfig().SlotDuration) * time.Second
-	validTimeThreshold := params.GetConfig().GenesisTime.Add(slotDuration)
+	validTimeThreshold := genesisTimestamp.Add(slotDuration)
 	return clock.Now().After(validTimeThreshold)
 }
 
@@ -152,7 +152,8 @@ func (b *Block) IsValid(
 	aState *ActiveState,
 	cState *CrystallizedState,
 	parentSlot uint64,
-	enableAttestationValidity bool) bool {
+	enableAttestationValidity bool,
+	genesisTimestamp time.Time) bool {
 	_, err := b.Hash()
 	if err != nil {
 		log.Errorf("Could not hash incoming block: %v", err)
@@ -164,7 +165,7 @@ func (b *Block) IsValid(
 		return false
 	}
 
-	if !b.isSlotValid() {
+	if !b.isSlotValid(genesisTimestamp) {
 		log.Errorf("Slot of block is too high: %d", b.SlotNumber())
 		return false
 	}

--- a/beacon-chain/types/block_test.go
+++ b/beacon-chain/types/block_test.go
@@ -107,10 +107,11 @@ func TestBlockValidity(t *testing.T) {
 		t.Fatalf("failed attestation validation")
 	}
 
-	if !b.IsValid(chainService, aState, cState, parentSlot, false) {
+	genesisTime := params.GetConfig().GenesisTime
+	if !b.IsValid(chainService, aState, cState, parentSlot, false, genesisTime) {
 		t.Fatalf("failed block validation")
 	}
-	if !b.IsValid(chainService, aState, cState, parentSlot, true) {
+	if !b.IsValid(chainService, aState, cState, parentSlot, true, genesisTime) {
 		t.Fatalf("failed block validation")
 	}
 }


### PR DESCRIPTION
This resolves #605.

---

## What Was Wrong?

Beacon node was unable to start from where it left off. That is, if in one session the chain advanced to slot 13, when the system restarts it would go back from slot 0 rather than starting from the current slot based on the persisted genesis timestamp.

## How It Was Fixed

We start the system by fetching the persisted genesis block's timestamp instead of using the params default GenesisTimestamp.
