### PR TITLE
Fix Validator Assignment

### DIFF
--- a/beacon-chain/params/config.go
+++ b/beacon-chain/params/config.go
@@ -44,7 +44,7 @@ var defaultConfig = &Config{
 }
 
 var demoConfig = &Config{
-	GenesisTime:        time.Now().Add(-8 * time.Second),
+	GenesisTime:        time.Now(),
 	CycleLength:        uint64(5),
 	ShardCount:         3,
 	DefaultBalance:     new(big.Int).Div(big.NewInt(32), big.NewInt(int64(1e18))),

--- a/beacon-chain/simulator/service.go
+++ b/beacon-chain/simulator/service.go
@@ -181,8 +181,16 @@ func (sim *Simulator) run(delayChan <-chan time.Time, done <-chan struct{}) {
 				powChainRef = []byte{byte(sim.slotNum)}
 			}
 
+			var blockSlot uint64
+			if sim.chainService.CurrentBeaconSlot() == 0 {
+				// cannot process a genesis block, so we start from 1
+				blockSlot = 1
+			} else {
+				blockSlot = sim.chainService.CurrentBeaconSlot()
+			}
+
 			block := types.NewBlock(&pb.BeaconBlock{
-				SlotNumber:            sim.chainService.CurrentBeaconSlot(),
+				SlotNumber:            blockSlot,
 				Timestamp:             ptypes.TimestampNow(),
 				PowChainRef:           powChainRef,
 				ActiveStateHash:       activeStateHash[:],

--- a/beacon-chain/types/crystallized_state.go
+++ b/beacon-chain/types/crystallized_state.go
@@ -210,10 +210,10 @@ func (c *CrystallizedState) Validators() []*pb.ValidatorRecord {
 // IsCycleTransition checks if a new cycle has been reached. At that point,
 // a new crystallized state and active state transition will occur.
 func (c *CrystallizedState) IsCycleTransition(slotNumber uint64) bool {
-	if c.LastStateRecalc() == 0 && slotNumber == params.GetConfig().CycleLength {
+	if c.LastStateRecalc() == 0 && slotNumber == params.GetConfig().CycleLength-1 {
 		return true
 	}
-	return slotNumber >= c.LastStateRecalc()+params.GetConfig().CycleLength
+	return slotNumber >= c.LastStateRecalc()+params.GetConfig().CycleLength-1
 }
 
 // isDynastyTransition checks if a dynasty transition can be processed. At that point,

--- a/beacon-chain/types/crystallized_state.go
+++ b/beacon-chain/types/crystallized_state.go
@@ -210,6 +210,9 @@ func (c *CrystallizedState) Validators() []*pb.ValidatorRecord {
 // IsCycleTransition checks if a new cycle has been reached. At that point,
 // a new crystallized state and active state transition will occur.
 func (c *CrystallizedState) IsCycleTransition(slotNumber uint64) bool {
+	if c.LastStateRecalc() == 0 && slotNumber == params.GetConfig().CycleLength {
+		return true
+	}
 	return slotNumber >= c.LastStateRecalc()+params.GetConfig().CycleLength
 }
 


### PR DESCRIPTION
No tracking issue here.

---

# Description

This PR fixes validator assignments such that cycles happen at exactly the right time and beacon node always starts from slot 0.