### PR TITLE
More fixes to bazel buildkite and update rules_go

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -1,12 +1,10 @@
-startup --host_jvm_args=-Xmx500m --host_jvm_args=-Xms500m
-
-build --local_resources=3072,1,1
-build --spawn_strategy=standalone --genrule_strategy=standalone
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
 build --noshow_progress
 build --verbose_failures
+build --announce_rc
+build --show_progress_rate_limit=5
+build --curses=yes --color=yes
 build --test_output=errors
 build --flaky_test_attempts=5
 build --features=race
-test --test_strategy=standalone

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -1,3 +1,9 @@
+build:remote --remote_max_connections=200
+build:remote --disk_cache=
+build:remote --remote_http_cache=https://storage.googleapis.com/prysmatic-bazel-cache
+build:remote --google_default_credentials
+build:remote --remote_timeout=10
+
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
 build --noshow_progress
@@ -5,6 +11,7 @@ build --verbose_failures
 build --announce_rc
 build --show_progress_rate_limit=5
 build --curses=yes --color=yes
+build --keep_going
 build --test_output=errors
 build --flaky_test_attempts=5
 build --features=race

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -3,10 +3,12 @@ build:remote --disk_cache=
 build:remote --remote_http_cache=https://storage.googleapis.com/prysmatic-bazel-cache
 build:remote --google_default_credentials
 build:remote --remote_timeout=10
+build:remote --experimental_guard_against_concurrent_changes
 
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
-build --noshow_progress
+build --experimental_multi_threaded_digest
+build --sandbox_tmpfs_path=/tmp
 build --verbose_failures
 build --announce_rc
 build --show_progress_rate_limit=5

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.15.3/rules_go-0.15.3.tar.gz"],
-    sha256 = "97cf62bdef33519412167fd1e4b0810a318a7c234f5f8dc4f53e2da86241c492",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.15.4/rules_go-0.15.4.tar.gz",
+    sha256 = "7519e9e1c716ae3c05bd2d984a42c3b02e690c5df728dc0a84b23f90c355c5a1",
 )
 
 http_archive(


### PR DESCRIPTION
This is reducing clean builds with zero cache to about 3 minutes with the 2 CPU 3.75Mb ram machine.

Adding a remote config there to test out, but there are some issues with go stdlib failing to cache properly/quickly. (bazelbuild/rules_go#1531)

Updating rules_go since I think there is a bit of a performance improvement when building cgo targets.