### PR TITLE
Implement GHOST Beacon Chain Fork Choice Rule

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -142,82 +142,121 @@ func (c *ChainService) updateHead(slotInterval <-chan uint64) {
 			log.WithField("slotNumber", slot).Info("New beacon slot")
 
 			// First, we check if there were any blocks processed in the previous slot.
-			// If there is, we fetch the first one from the DB.
 			if len(c.blocksPendingProcessing) == 0 {
 				continue
 			}
 
-			// Naive fork choice rule: we pick the first block we processed for the previous slot
-			// as canonical.
-			block, err := c.beaconDB.GetBlock(c.blocksPendingProcessing[0])
-			if err != nil {
-				log.Errorf("Could not get block: %v", err)
-				continue
-			}
+			// We keep track of the highest scoring received block and its associated
+			// states.
+			var highestScoringBlock *types.Block
+			var highestScoringCrystallizedState *types.CrystallizedState
+			var highestScoringActiveState *types.ActiveState
+			var highestScore uint64
 
-			h, err := block.Hash()
-			if err != nil {
-				log.Errorf("Could not hash incoming block: %v", err)
-				continue
-			}
+			// We detect if this there is a cycle transition.
+			var cycleTransitioned bool
 
 			log.Info("Applying fork choice rule")
 
-			parentBlock, err := c.beaconDB.GetBlock(block.ParentHash())
-			if err != nil {
-				log.Errorf("Failed to get parent of block %x", h)
-				continue
-			}
+			currentCanonicalCrystallizedState := c.beaconDB.GetCrystallizedState()
+			currentCanonicalActiveState := c.beaconDB.GetActiveState()
 
-			cState := c.beaconDB.GetCrystallizedState()
-			aState := c.beaconDB.GetActiveState()
-			var stateTransitioned bool
-
-			for cState.IsCycleTransition(parentBlock.SlotNumber()) {
-				cState, aState, err = cState.NewStateRecalculations(
-					aState,
-					block,
-					c.enableCrossLinks,
-					c.enableRewardChecking,
-				)
+			// We loop over every block pending processing in order to determine
+			// the highest scoring one.
+			for i := 0; i < len(c.blocksPendingProcessing); i++ {
+				block, err := c.beaconDB.GetBlock(c.blocksPendingProcessing[i])
 				if err != nil {
-					log.Errorf("Initialize new cycle transition failed: %v", err)
+					log.Errorf("Could not get block: %v", err)
 					continue
 				}
-				stateTransitioned = true
+
+				h, err := block.Hash()
+				if err != nil {
+					log.Errorf("Could not hash incoming block: %v", err)
+					continue
+				}
+
+				parentBlock, err := c.beaconDB.GetBlock(block.ParentHash())
+				if err != nil {
+					log.Errorf("Failed to get parent of block %x", h)
+					continue
+				}
+
+				cState := currentCanonicalCrystallizedState
+				aState := currentCanonicalActiveState
+
+				for cState.IsCycleTransition(parentBlock.SlotNumber()) {
+					cState, aState, err = cState.NewStateRecalculations(
+						aState,
+						block,
+						c.enableCrossLinks,
+						c.enableRewardChecking,
+					)
+					if err != nil {
+						log.Errorf("Initialize new cycle transition failed: %v", err)
+						continue
+					}
+					cycleTransitioned = true
+				}
+
+				aState, err = aState.CalculateNewActiveState(
+					block,
+					cState,
+					parentBlock.SlotNumber(),
+					c.enableAttestationValidity,
+				)
+				if err != nil {
+					log.Errorf("Compute active state failed: %v", err)
+					continue
+				}
+
+				// Initially, we set the highest scoring block to the first value in the
+				// processed blocks list.
+				if i == 0 {
+					highestScoringBlock = block
+					highestScoringCrystallizedState = cState
+					highestScoringActiveState = aState
+					continue
+				}
+				// Score the block and determine if its score is greater than the previously computed one.
+				if block.Score(cState.LastFinalizedSlot(), cState.LastJustifiedSlot()) > highestScore {
+					highestScoringBlock = block
+					highestScoringCrystallizedState = cState
+					highestScoringActiveState = aState
+				}
 			}
 
-			aState, err = aState.CalculateNewActiveState(
-				block,
-				cState,
-				parentBlock.SlotNumber(),
-				c.enableAttestationValidity,
-			)
-			if err != nil {
-				log.Errorf("Compute active state failed: %v", err)
+			// If no highest scoring block was determined, we do not update the head of the chain.
+			if highestScoringBlock == nil {
 				continue
 			}
 
-			if err := c.beaconDB.SaveActiveState(aState); err != nil {
+			if err := c.beaconDB.SaveActiveState(highestScoringActiveState); err != nil {
 				log.Errorf("Write active state to disk failed: %v", err)
 				continue
 			}
 
-			if stateTransitioned {
-				if err := c.beaconDB.SaveCrystallizedState(cState); err != nil {
+			if cycleTransitioned {
+				if err := c.beaconDB.SaveCrystallizedState(highestScoringCrystallizedState); err != nil {
 					log.Errorf("Write crystallized state to disk failed: %v", err)
 					continue
 				}
 			}
 
+			h, err := highestScoringBlock.Hash()
+			if err != nil {
+				log.Errorf("Could not hash highest scoring block: %v", err)
+				continue
+			}
+
 			// Save canonical block hash with slot number to DB.
-			if err := c.beaconDB.SaveCanonicalSlotNumber(block.SlotNumber(), h); err != nil {
+			if err := c.beaconDB.SaveCanonicalSlotNumber(highestScoringBlock.SlotNumber(), h); err != nil {
 				log.Errorf("Unable to save slot number to db: %v", err)
 				continue
 			}
 
 			// Save canonical block to DB.
-			if err := c.beaconDB.SaveCanonicalBlock(block); err != nil {
+			if err := c.beaconDB.SaveCanonicalBlock(highestScoringBlock); err != nil {
 				log.Errorf("Unable to save block to db: %v", err)
 				continue
 			}
@@ -227,10 +266,10 @@ func (c *ChainService) updateHead(slotInterval <-chan uint64) {
 			// We fire events that notify listeners of a new block (or crystallized state in
 			// the case of a state transition). This is useful for the beacon node's gRPC
 			// server to stream these events to beacon clients.
-			if stateTransitioned {
-				c.canonicalCrystallizedStateFeed.Send(cState)
+			if cycleTransitioned {
+				c.canonicalCrystallizedStateFeed.Send(highestScoringCrystallizedState)
 			}
-			c.canonicalBlockFeed.Send(block)
+			c.canonicalBlockFeed.Send(highestScoringBlock)
 
 			// Clear the blocks pending processing, mutex lock for thread safety
 			// in updating this slice.

--- a/beacon-chain/types/block.go
+++ b/beacon-chain/types/block.go
@@ -3,6 +3,7 @@ package types
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -137,6 +138,15 @@ func (b *Block) Attestations() []*pb.AggregatedAttestation {
 // Timestamp returns the Go type time.Time from the protobuf type contained in the block.
 func (b *Block) Timestamp() (time.Time, error) {
 	return ptypes.Timestamp(b.data.Timestamp)
+}
+
+// Score determines the weighted block score utilized by the fork choice rule of the beacon chain.
+// This score currently depends on the last finalized and last justified slots of the
+// block's associated crystallized state as well as the block's slot number.
+// Currently, this uses the block's slot number as a factor in the calculations but the final, production
+// fork choice scoring rule may utilize the number of votes in the block.
+func (b *Block) Score(lastFinalizedSlot uint64, lastJustifiedSlot uint64) uint64 {
+	return lastFinalizedSlot*uint64(math.Pow(10, 20)) + lastJustifiedSlot*uint64(math.Pow(10, 10)) + b.SlotNumber()
 }
 
 // isSlotValid compares the slot to the system clock to determine if the block is valid.


### PR DESCRIPTION
This resolves #255.

---

# Description

This PR introduces the first version of the GHOST Fork Choice Rule for the ETH2.0 Beacon Chain in Prysm. It encompasses the following:

- A `block.Score()` function that creates a weighted score value based on the block's crystallized state's `LastFinalizedSlot` and `LastJustifiedSlot` as well as the block's slot number
- A refactor of our `updateHead` routine in `blockchain/service.go` which loops through the blocks pending processing at the end of every slot and determines the one with the maximum score to set as canonical

- [ ] Tests For Fork-Choice Scenarios

# Missing

Benchmarks for fork-choice at scale have yet to be implemented.
