### PR TITLE
Enforce Max Committee Size and Remove Multiple Slots Per Committee 

### DIFF
--- a/beacon-chain/casper/sharding.go
+++ b/beacon-chain/casper/sharding.go
@@ -59,8 +59,14 @@ func splitBySlotShard(shuffledValidators []uint32, crosslinkStartShard uint64) [
 // to attest the same shard.
 func getCommitteeParams(numValidators int) (committeesPerSlot, slotsPerCommittee int) {
 	if numValidators >= int(params.GetConfig().CycleLength*params.GetConfig().MinCommiteeSize) {
-		committeesPerSlot := numValidators/int(params.GetConfig().CycleLength*params.GetConfig().MinCommiteeSize*2) + 1
-		return committeesPerSlot, 1
+		cycleLength := int(params.GetConfig().CycleLength)
+		boundOnAVS := numValidators / cycleLength / (int(params.GetConfig().MinCommiteeSize*2) + 1)
+		boundOnShardCount := params.GetConfig().ShardCount / cycleLength
+		if boundOnAVS > boundOnShardCount {
+			return boundOnShardCount, 1
+		} else {
+			return boundOnAVS, 1
+		}
 	}
 
 	slotsPerCommittee = 1

--- a/beacon-chain/casper/sharding.go
+++ b/beacon-chain/casper/sharding.go
@@ -53,10 +53,11 @@ func splitBySlotShard(shuffledValidators []uint32, crosslinkStartShard uint64) [
 
 // getCommitteeParams calculates the parameters for ShuffleValidatorsToCommittees.
 // If numActiveValidators > CycleLength * MinCommitteeSize, committees are based off a max amount
-// of len(avs) // CYCLE_LENGTH // (MIN_COMMITTEE_SIZE * 2) + 1 or SHARD_COUNT // CYCLE_LENGTH
-func getCommitteeParams(numValidators int) (committeesPerSlot int) {
+// from either numActiveValidators / CycleLength /  MinCommitteeSize or
+// it is decided from the ShardCount / CycleLength.
+func getCommitteeParams(numActiveValidators int) (committeesPerSlot int) {
 	cycleLength := int(params.GetConfig().CycleLength)
-	boundOnAVS := numValidators/cycleLength/int(params.GetConfig().MinCommiteeSize*2) + 1
+	boundOnAVS := numActiveValidators/cycleLength/int(params.GetConfig().MinCommiteeSize*2) + 1
 	boundOnShardCount := params.GetConfig().ShardCount / cycleLength
 	if boundOnAVS > boundOnShardCount {
 		return boundOnShardCount

--- a/beacon-chain/casper/sharding_test.go
+++ b/beacon-chain/casper/sharding_test.go
@@ -102,39 +102,27 @@ func TestSmallSampleValidators(t *testing.T) {
 func TestGetCommitteeParamsSmallValidatorSet(t *testing.T) {
 	numValidators := int(params.GetConfig().CycleLength * params.GetConfig().MinCommiteeSize / 4)
 
-	committesPerSlot, slotsPerCommittee := getCommitteeParams(numValidators)
+	committesPerSlot := getCommitteeParams(numValidators)
 	if committesPerSlot != 1 {
 		t.Fatalf("Expected committeesPerSlot to equal %d: got %d", 1, committesPerSlot)
-	}
-
-	if slotsPerCommittee != 4 {
-		t.Fatalf("Expected slotsPerCommittee to equal %d: got %d", 4, slotsPerCommittee)
 	}
 }
 
 func TestGetCommitteeParamsRegularValidatorSet(t *testing.T) {
 	numValidators := int(params.GetConfig().CycleLength * params.GetConfig().MinCommiteeSize)
 
-	committesPerSlot, slotsPerCommittee := getCommitteeParams(numValidators)
+	committesPerSlot := getCommitteeParams(numValidators)
 	if committesPerSlot != 1 {
 		t.Fatalf("Expected committeesPerSlot to equal %d: got %d", 1, committesPerSlot)
-	}
-
-	if slotsPerCommittee != 1 {
-		t.Fatalf("Expected slotsPerCommittee to equal %d: got %d", 1, slotsPerCommittee)
 	}
 }
 
 func TestGetCommitteeParamsLargeValidatorSet(t *testing.T) {
 	numValidators := int(params.GetConfig().CycleLength*params.GetConfig().MinCommiteeSize) * 8
 
-	committesPerSlot, slotsPerCommittee := getCommitteeParams(numValidators)
+	committesPerSlot := getCommitteeParams(numValidators)
 	if committesPerSlot != 5 {
 		t.Fatalf("Expected committeesPerSlot to equal %d: got %d", 5, committesPerSlot)
-	}
-
-	if slotsPerCommittee != 1 {
-		t.Fatalf("Expected slotsPerCommittee to equal %d: got %d", 1, slotsPerCommittee)
 	}
 }
 


### PR DESCRIPTION
This is to enforce the max committee size as per the spec as of 2.1 and to remove multiple slots per committee as they aren't a benefit to security.

resolves #579 
resolves #639