### PR TITLE
Proposal to upgrade to 1.11 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 matrix:
   include:
     - os: linux
-      go: 1.10.x
+      go: 1.11.x
       env:
         - lint
       script:

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -71,9 +71,9 @@ func TestSetBlockForInitialSync(t *testing.T) {
 	genericHash[0] = 'a'
 
 	block := &pb.BeaconBlock{
-		PowChainRef:    []byte{1, 2, 3},
-		AncestorHashes: [][]byte{genericHash},
-		Slot:           uint64(20),
+		PowChainRef:           []byte{1, 2, 3},
+		AncestorHashes:        [][]byte{genericHash},
+		Slot:                  uint64(20),
 		CrystallizedStateRoot: genericHash,
 	}
 
@@ -149,9 +149,9 @@ func TestSavingBlocksInSync(t *testing.T) {
 
 	getBlockResponseMsg := func(Slot uint64) p2p.Message {
 		block := &pb.BeaconBlock{
-			PowChainRef:    []byte{1, 2, 3},
-			AncestorHashes: [][]byte{genericHash},
-			Slot:           Slot,
+			PowChainRef:           []byte{1, 2, 3},
+			AncestorHashes:        [][]byte{genericHash},
+			Slot:                  Slot,
 			CrystallizedStateRoot: crystallizedStateRoot[:],
 		}
 
@@ -248,9 +248,9 @@ func TestDelayChan(t *testing.T) {
 	}
 
 	block := &pb.BeaconBlock{
-		PowChainRef:    []byte{1, 2, 3},
-		AncestorHashes: [][]byte{genericHash},
-		Slot:           uint64(20),
+		PowChainRef:           []byte{1, 2, 3},
+		AncestorHashes:        [][]byte{genericHash},
+		Slot:                  uint64(20),
 		CrystallizedStateRoot: crystallizedStateRoot[:],
 	}
 


### PR DESCRIPTION
Discrepancy in `gofmt` between 1.10 and 1.11 was causing linting to fail when using 1.11. This change upgrades Travis' go version to 1.11

Note: All devs will have to upgrade to 1.11 after this merge.