### PR TITLE
Adding Basic Private Key Management

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -78,6 +78,8 @@ VERSION:
 		cmd.EnableTracingFlag,
 		cmd.TracingEndpointFlag,
 		cmd.TraceSampleFractionFlag,
+		cmd.KeystorePasswordFlag,
+		cmd.KeystoreDirectoryFlag,
 		debug.PProfFlag,
 		debug.PProfAddrFlag,
 		debug.PProfPortFlag,

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -47,7 +47,7 @@ var (
 		Name:  "enable-tracing",
 		Usage: "Enable request tracing.",
 	}
-	// TracingEndpointFlag flag defines the http enpoint for serving traces to Jaeger.
+	// TracingEndpointFlag flag defines the http endpoint for serving traces to Jaeger.
 	TracingEndpointFlag = cli.StringFlag{
 		Name:  "tracing-endpoint",
 		Usage: "Tracing endpoint defines where beacon chain traces are exposed to Jaeger.",
@@ -59,5 +59,16 @@ var (
 		Name:  "trace-sample-fraction",
 		Usage: "Indicate what fraction of p2p messages are sampled for tracing.",
 		Value: 0.20,
+	}
+	// KeystoreDirectoryFlag defines a flag to indicate where the keystore of the user
+	// is located.
+	KeystoreDirectoryFlag = DirectoryFlag{
+		Name:  "keystore-dir",
+		Usage: "Keystore directory indicates which directory the keystore is located.",
+	}
+	// KeystorePasswordFlag defines the password that will unlock the keystore file.
+	KeystorePasswordFlag = cli.StringFlag{
+		Name:  "keystore-password",
+		Usage: "Keystore password is used to unlock the keystore so that the users decrypted keys can be used.",
 	}
 )

--- a/shared/keystore/keystore.go
+++ b/shared/keystore/keystore.go
@@ -1,0 +1,37 @@
+package keystore
+
+import (
+	"crypto/ecdsa"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"io/ioutil"
+	"os"
+)
+
+func RetrieveJson(directory string, password string) ([]byte, error) {
+	f, err := os.Open(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	keyjson, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+	return keyjson, nil
+}
+
+func DecryptKeystore(keyjson []byte, password string) (ecdsa.PublicKey, error) {
+	key, err := keystore.DecryptKey(keyjson, password)
+	if err != nil {
+		return ecdsa.PublicKey{}, err
+	}
+	return key.PrivateKey.PublicKey, nil
+}
+
+func EncryptKeystore(key *keystore.Key, password string) ([]byte, error) {
+	encryptedkey, err := keystore.EncryptKey(key, password, 8, 1)
+	if err != nil {
+		return nil, err
+	}
+	return encryptedkey, nil
+}

--- a/validator/main.go
+++ b/validator/main.go
@@ -69,6 +69,8 @@ VERSION:
 		cmd.EnableTracingFlag,
 		cmd.TracingEndpointFlag,
 		cmd.TraceSampleFractionFlag,
+		cmd.KeystorePasswordFlag,
+		cmd.KeystoreDirectoryFlag,
 		debug.PProfFlag,
 		debug.PProfAddrFlag,
 		debug.PProfPortFlag,


### PR DESCRIPTION
This is an initial PR which will deal with #290. 

Objectives:
- [ ] Allow clients to derive a public key from a provided keystore.
- [ ] Add relevant tests