### PR TITLE
Integrate Chia-Network's BLS12-381 C++ Library Into Prysm

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,7 +121,7 @@ go_repository(
 git_repository(
     name = "bls",
     remote = "https://github.com/prysmaticlabs/bls-signatures",
-    commit = "be8d1e9df2b7c1242440593075088c90efabefdc",
+    commit = "7d0373db956b156e1742b255a75b46ac8ecfa7f4",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -118,6 +118,12 @@ go_repository(
 
 # External dependencies
 
+git_repository(
+    name = "bls",
+    remote = "https://github.com/prysmaticlabs/bls-signatures",
+    commit = "be8d1e9df2b7c1242440593075088c90efabefdc",
+)
+
 go_repository(
     name = "com_github_ethereum_go_ethereum",
     importpath = "github.com/ethereum/go-ethereum",

--- a/shared/bls/BUILD.bazel
+++ b/shared/bls/BUILD.bazel
@@ -3,6 +3,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["bls.go"],
+    cdeps = ["@bls//:bls-signatures-lib"],
+    cgo = True,
     importpath = "github.com/prysmaticlabs/prysm/shared/bls",
     visibility = ["//visibility:public"],
 )

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -5,11 +5,12 @@ package bls
 
 /*
 #cgo LDFLAGS: -lstdc++
-#include "external/bls/src/bls.hpp"
+#include "external/bls/src/cgo_interface.h"
 */
-
-import "C"
-import "fmt"
+import (
+	"C"
+	"fmt"
+)
 
 // Signature used in the BLS signature scheme.
 type Signature struct{}
@@ -23,6 +24,7 @@ type PublicKey struct{}
 // Sign a message using a secret key - in a beacon/validator client,
 // this key will come from and be unlocked from the account keystore.
 func Sign(sec *SecretKey, msg []byte) (*Signature, error) {
+	C.createPrivateKey()
 	return &Signature{}, nil
 }
 

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -3,6 +3,12 @@
 // aggregating BLS signatures used by Ethereum 2.0.
 package bls
 
+/*
+#cgo LDFLAGS: -lstdc++
+#include "external/bls/src/bls.hpp"
+*/
+
+import "C"
 import "fmt"
 
 // Signature used in the BLS signature scheme.


### PR DESCRIPTION
Hi all, this PR resolves #633

---

# Description

This PR includes a forked version of Chia-Network's BLS12-381 C++ library into Prysm. After an initial mention of the library by @djrtwo, the project was forked and converted into a bazel project under Prysmatic Labs [here](https://github.com/prysmaticlabs/bls-signatures). We include it as a workspace rule in Prysm and start importing the cgo "bls.hpp" file in `shared/bls/bls.go`.

## Requirements for Merge

- [ ] Successfully run at least one of the C++ functions from the chia library.