### PR TITLE
Delete DB Files Before Running Node Tests

### DIFF
--- a/beacon-chain/node/node_test.go
+++ b/beacon-chain/node/node_test.go
@@ -14,6 +14,9 @@ import (
 
 // Test that the beacon chain validator node build fails without PoW service.
 func TestNodeValidator_Builds(t *testing.T) {
+	tmp := fmt.Sprintf("%s/datadirtest1", os.TempDir())
+	os.RemoveAll(tmp)
+
 	if os.Getenv("TEST_NODE_PANIC") == "1" {
 		app := cli.NewApp()
 		set := flag.NewFlagSet("test", 0)
@@ -39,17 +42,19 @@ func TestNodeValidator_Builds(t *testing.T) {
 	if e, ok := err.(*exec.ExitError); !ok || e.Success() {
 		t.Fatalf("Process ran with err %v, want exit status 1", err)
 	}
-	tmp := fmt.Sprintf("%s/datadirtest1", os.TempDir())
 	os.RemoveAll(tmp)
 }
 
 // Test that beacon chain node can close.
 func TestNodeClose(t *testing.T) {
 	hook := logTest.NewGlobal()
+
+	tmp := fmt.Sprintf("%s/datadirtest2", os.TempDir())
+	os.RemoveAll(tmp)
+
 	app := cli.NewApp()
 	set := flag.NewFlagSet("test", 0)
 	set.String("web3provider", "ws//127.0.0.1:8546", "web3 provider ws or IPC endpoint")
-	tmp := fmt.Sprintf("%s/datadirtest2", os.TempDir())
 	set.String("datadir", tmp, "node data directory")
 	set.Bool("enable-powchain", false, "no powchain service")
 	set.Bool("demo-config", true, "demo configuration")


### PR DESCRIPTION
If a test fails, the database isn't cleaned up, causing the next test run to always fail. This ensures that the database is empty when the test runs.

This addresses #720