### PR TITLE
Fixed GetShardAndCommitteesForSlot index out of range

### DIFF
--- a/beacon-chain/casper/sharding_test.go
+++ b/beacon-chain/casper/sharding_test.go
@@ -24,14 +24,14 @@ func TestGetShardAndCommitteesForSlots(t *testing.T) {
 	if _, err := GetShardAndCommitteesForSlot(state.ShardAndCommitteesForSlots, state.LastStateRecalculationSlot, 1000); err == nil {
 		t.Error("getShardAndCommitteesForSlot should have failed with invalid slot")
 	}
-	committee, err := GetShardAndCommitteesForSlot(state.ShardAndCommitteesForSlots, state.LastStateRecalculationSlot, 0)
+	committee, err := GetShardAndCommitteesForSlot(state.ShardAndCommitteesForSlots, state.LastStateRecalculationSlot, 1)
 	if err != nil {
 		t.Errorf("getShardAndCommitteesForSlot failed: %v", err)
 	}
 	if committee.ArrayShardAndCommittee[0].Shard != 1 {
 		t.Errorf("getShardAndCommitteesForSlot returns Shard should be 1, got: %v", committee.ArrayShardAndCommittee[0].Shard)
 	}
-	committee, _ = GetShardAndCommitteesForSlot(state.ShardAndCommitteesForSlots, state.LastStateRecalculationSlot, 1)
+	committee, _ = GetShardAndCommitteesForSlot(state.ShardAndCommitteesForSlots, state.LastStateRecalculationSlot, 2)
 	if committee.ArrayShardAndCommittee[0].Shard != 3 {
 		t.Errorf("getShardAndCommitteesForSlot returns Shard should be 3, got: %v", committee.ArrayShardAndCommittee[0].Shard)
 	}

--- a/beacon-chain/casper/validator.go
+++ b/beacon-chain/casper/validator.go
@@ -64,13 +64,11 @@ func GetShardAndCommitteesForSlot(shardCommittees []*pb.ShardAndCommitteeArray, 
 
 	// If in the previous or current cycle, simply calculate offset
 	if slot < lastStateRecalc+2*cycleLength {
-		log.Errorf("First loop %d", slot-lowerBound)
 		return shardCommittees[slot-lowerBound], nil
 	}
 
 	// Otherwise, use the 3rd cycle
 	index := lowerBound + 2*cycleLength + slot%cycleLength
-	log.Errorf("Second loop %d", index)
 	return shardCommittees[index], nil
 }
 

--- a/beacon-chain/casper/validator.go
+++ b/beacon-chain/casper/validator.go
@@ -51,7 +51,7 @@ func GetShardAndCommitteesForSlot(shardCommittees []*pb.ShardAndCommitteeArray, 
 
 	var lowerBound uint64
 	if lastStateRecalc >= cycleLength {
-		lowerBound = lastStateRecalc - cycleLength
+		lowerBound = lastStateRecalc - cycleLength + 1
 	}
 	upperBound := lastStateRecalc + 2*cycleLength
 	if slot < lowerBound || slot >= upperBound {
@@ -64,11 +64,13 @@ func GetShardAndCommitteesForSlot(shardCommittees []*pb.ShardAndCommitteeArray, 
 
 	// If in the previous or current cycle, simply calculate offset
 	if slot < lastStateRecalc+2*cycleLength {
+		log.Errorf("First loop %d", slot-lowerBound)
 		return shardCommittees[slot-lowerBound], nil
 	}
 
 	// Otherwise, use the 3rd cycle
 	index := lowerBound + 2*cycleLength + slot%cycleLength
+	log.Errorf("Second loop %d", index)
 	return shardCommittees[index], nil
 }
 

--- a/beacon-chain/casper/validator_test.go
+++ b/beacon-chain/casper/validator_test.go
@@ -132,15 +132,15 @@ func TestProposerShardAndIndex(t *testing.T) {
 	if _, _, err := ProposerShardAndIndex(shardCommittees, 100, 0); err == nil {
 		t.Error("ProposerShardAndIndex should have failed with invalid lcs")
 	}
-	shard, index, err := ProposerShardAndIndex(shardCommittees, 128, 64)
+	shard, index, err := ProposerShardAndIndex(shardCommittees, 128, 65)
 	if err != nil {
 		t.Fatalf("ProposerShardAndIndex failed with %v", err)
 	}
 	if shard != 0 {
 		t.Errorf("Invalid shard ID. Wanted 0, got %d", shard)
 	}
-	if index != 4 {
-		t.Errorf("Invalid proposer index. Wanted 4, got %d", index)
+	if index != 0 {
+		t.Errorf("Invalid proposer index. Wanted 0, got %d", index)
 	}
 }
 


### PR DESCRIPTION
The master is broken due to an "index out of range" panic from `GetShardAndCommitteesForSlot` while syncing slot 10.

Problem Description:

- Given we have 10 shards, the ShardCommitteees array is sized 10 from index [0-9]
- Each cycle length is 5, every 5 slots, state recalculation happens
- At slot 10, Sync calls GetShardCommitteees for [10], but it really should be [9]
- From config's point of view, we start at 1 but ShardCommitteees slice starts at 0. I added a +1 to lower bound calculation for offset
- With this, I was able to advance beacon node to slot 100+

