### PR TITLE
Fixed Validator Shuffling

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -413,7 +413,7 @@ func (c *ChainService) calculateNewBlockVotes(block *types.Block, aState *types.
 			}
 		}
 
-		// Write updated block vote cache back to DB
+		// Write updated block vote cache back to DB.
 		if err = c.beaconDB.WriteBlockVoteCache(blockVoteCache); err != nil {
 			return err
 		}

--- a/beacon-chain/types/active_state.go
+++ b/beacon-chain/types/active_state.go
@@ -78,8 +78,8 @@ func (a *ActiveState) CopyState() *ActiveState {
 	}
 
 	recentBlockHashes := make([][]byte, len(a.RecentBlockHashes()))
-	for r, hash := range a.RecentBlockHashes() {
-		recentBlockHashes[r] = hash[:]
+	for r, hash := range a.data.RecentBlockHashes {
+		recentBlockHashes[r] = hash
 	}
 
 	pendingSpecials := make([]*pb.SpecialRecord, len(a.PendingSpecials()))
@@ -91,7 +91,7 @@ func (a *ActiveState) CopyState() *ActiveState {
 	}
 	randaoMix := a.RandaoMix()
 
-	newC := ActiveState{
+	newA := ActiveState{
 		data: &pb.ActiveState{
 			PendingAttestations: pendingAttestations,
 			RecentBlockHashes:   recentBlockHashes,
@@ -100,7 +100,7 @@ func (a *ActiveState) CopyState() *ActiveState {
 		},
 	}
 
-	return &newC
+	return &newA
 }
 
 // PendingAttestations returns attestations that have not yet been processed.

--- a/beacon-chain/types/active_state.go
+++ b/beacon-chain/types/active_state.go
@@ -63,8 +63,8 @@ func (a *ActiveState) Hash() ([32]byte, error) {
 
 // CopyState returns a deep copy of the current active state.
 func (a *ActiveState) CopyState() *ActiveState {
-	pendingAttestations := make([]*pb.AggregatedAttestation, len(a.PendingAttestations()))
-	for index, pendingAttestation := range a.PendingAttestations() {
+	pendingAttestations := make([]*pb.AggregatedAttestation, len(a.data.PendingAttestations))
+	for index, pendingAttestation := range a.data.PendingAttestations {
 		pendingAttestations[index] = &pb.AggregatedAttestation{
 			Slot:                pendingAttestation.GetSlot(),
 			Shard:               pendingAttestation.GetShard(),
@@ -77,13 +77,13 @@ func (a *ActiveState) CopyState() *ActiveState {
 		}
 	}
 
-	recentBlockHashes := make([][]byte, len(a.RecentBlockHashes()))
+	recentBlockHashes := make([][]byte, len(a.data.RecentBlockHashes))
 	for r, hash := range a.data.RecentBlockHashes {
 		recentBlockHashes[r] = hash
 	}
 
-	pendingSpecials := make([]*pb.SpecialRecord, len(a.PendingSpecials()))
-	for index, pendingSpecial := range a.PendingSpecials() {
+	pendingSpecials := make([]*pb.SpecialRecord, len(a.data.PendingSpecials))
+	for index, pendingSpecial := range a.data.PendingSpecials {
 		pendingSpecials[index] = &pb.SpecialRecord{
 			Kind: pendingSpecial.GetKind(),
 			Data: pendingSpecial.GetData(),


### PR DESCRIPTION
This fixes #748. With the ability to advance beacon chain w/ justified slot and finalized slot working, we finally got the validators to shuffle during set change!