### PR TITLE
Fixed Duplicated Flag and PubKey Empty Issues

### DIFF
--- a/validator/main.go
+++ b/validator/main.go
@@ -64,7 +64,6 @@ VERSION:
 	app.Flags = []cli.Flag{
 		types.BeaconRPCProviderFlag,
 		types.PubKeyFlag,
-		types.BeaconRPCProviderFlag,
 		cmd.VerbosityFlag,
 		cmd.DataDirFlag,
 		cmd.EnableTracingFlag,

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -70,6 +70,8 @@ func NewValidatorClient(ctx *cli.Context) (*ValidatorClient, error) {
 		}
 
 		pubKey = blspubkey.BufferedPublicKey()
+	} else {
+		pubKey = []byte(ctx.GlobalString(types.PubKeyFlag.Name))
 	}
 
 	if err := ValidatorClient.startDB(ctx); err != nil {


### PR DESCRIPTION
This fixed the following errors when launching a validator client

`ERROR beacon: unable to assign a role: validator role was not assigned for key:`

and 

`panic: validator flag redefined: beacon-rpc-provider`