### PR TITLE
Refactor Casper Incentives Into Core/Incentives Stateless Package

### DIFF
--- a/beacon-chain/casper/BUILD.bazel
+++ b/beacon-chain/casper/BUILD.bazel
@@ -3,7 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
-        "incentives.go",
         "sharding.go",
         "state_transition.go",
         "validator.go",
@@ -16,10 +15,8 @@ go_library(
         "//proto/beacon/rpc/v1:go_default_library",
         "//shared/bitutil:go_default_library",
         "//shared/hashutil:go_default_library",
-        "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 
@@ -28,7 +25,6 @@ go_test(
     size = "large",
     timeout = "short",
     srcs = [
-        "incentives_test.go",
         "sharding_test.go",
         "state_transition_test.go",
         "validator_test.go",
@@ -40,7 +36,6 @@ go_test(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bitutil:go_default_library",
         "//shared/bytes:go_default_library",
-        "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
     ],

--- a/beacon-chain/core/incentives/BUILD.bazel
+++ b/beacon-chain/core/incentives/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["incentives.go"],
+    importpath = "github.com/prysmaticlabs/prysm/beacon-chain/core/incentives",
+    visibility = ["//beacon-chain:__subpackages__"],
+    deps = [
+        "//proto/beacon/p2p/v1:go_default_library",
+        "//shared/mathutil:go_default_library",
+        "//shared/params:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["incentives_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//proto/beacon/p2p/v1:go_default_library",
+        "//shared/mathutil:go_default_library",
+        "//shared/params:go_default_library",
+    ],
+)

--- a/beacon-chain/core/incentives/incentives.go
+++ b/beacon-chain/core/incentives/incentives.go
@@ -1,13 +1,10 @@
-package casper
+package incentives
 
 import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/mathutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"github.com/sirupsen/logrus"
 )
-
-var log = logrus.WithField("prefix", "casper")
 
 // CalculateRewards adjusts validators balances by applying rewards or penalties
 // based on FFG incentive structure.
@@ -16,25 +13,27 @@ var log = logrus.WithField("prefix", "casper")
 func CalculateRewards(
 	slot uint64,
 	voterIndices []uint32,
+	activeValidatorIndices []uint32,
 	validators []*pb.ValidatorRecord,
+	totalActiveValidatorDeposit uint64,
 	totalParticipatedDeposit uint64,
-	timeSinceFinality uint64) []*pb.ValidatorRecord {
-	totalDeposit := TotalActiveValidatorDeposit(validators)
-	activeValidators := ActiveValidatorIndices(validators)
-	rewardQuotient := RewardQuotient(validators)
-	penaltyQuotient := quadraticPenaltyQuotient()
+	timeSinceFinality uint64,
+) []*pb.ValidatorRecord {
 
-	log.Debugf("Applying rewards and penalties for the validators for slot %d", slot)
+	// Calculate the reward and penalty quotients for the validator set.
+	rewardQuotient := RewardQuotient(totalActiveValidatorDeposit)
+	penaltyQuotient := QuadraticPenaltyQuotient()
+
 	if timeSinceFinality <= 3*params.BeaconConfig().CycleLength {
-		for _, validatorIndex := range activeValidators {
+		for _, validatorIndex := range activeValidatorIndices {
 			var voted bool
 
 			for _, voterIndex := range voterIndices {
 				if voterIndex == validatorIndex {
 					voted = true
 					balance := validators[validatorIndex].GetBalance()
-					newbalance := int64(balance) + int64(balance/rewardQuotient)*(2*int64(totalParticipatedDeposit)-int64(totalDeposit))/int64(totalDeposit)
-					validators[validatorIndex].Balance = uint64(newbalance)
+					newBalance := calculateBalance(balance, rewardQuotient, totalParticipatedDeposit, totalActiveValidatorDeposit)
+					validators[validatorIndex].Balance = uint64(newBalance)
 					break
 				}
 			}
@@ -47,7 +46,7 @@ func CalculateRewards(
 		}
 
 	} else {
-		for _, validatorIndex := range activeValidators {
+		for _, validatorIndex := range activeValidatorIndices {
 			var voted bool
 
 			for _, voterIndex := range voterIndices {
@@ -71,14 +70,14 @@ func CalculateRewards(
 
 // RewardQuotient returns the reward quotient for validators which will be used to
 // reward validators for voting on blocks, or penalise them for being offline.
-func RewardQuotient(validators []*pb.ValidatorRecord) uint64 {
-	totalDepositETH := TotalActiveValidatorDepositInEth(validators)
+func RewardQuotient(totalActiveValidatorDeposit uint64) uint64 {
+	totalDepositETH := totalActiveValidatorDeposit / params.BeaconConfig().Gwei
 	return params.BeaconConfig().BaseRewardQuotient * mathutil.IntegerSquareRoot(totalDepositETH)
 }
 
-// quadraticPenaltyQuotient is the quotient that will be used to apply penalties to offline
+// QuadraticPenaltyQuotient is the quotient that will be used to apply penalties to offline
 // validators.
-func quadraticPenaltyQuotient() uint64 {
+func QuadraticPenaltyQuotient() uint64 {
 	dropTimeFactor := params.BeaconConfig().SqrtExpDropTime
 	return dropTimeFactor * dropTimeFactor
 }
@@ -87,7 +86,7 @@ func quadraticPenaltyQuotient() uint64 {
 // based on the number of slots that they are offline.
 func QuadraticPenalty(numberOfSlots uint64) uint64 {
 	slotFactor := (numberOfSlots * numberOfSlots) / 2
-	penaltyQuotient := quadraticPenaltyQuotient()
+	penaltyQuotient := QuadraticPenaltyQuotient()
 	return slotFactor / penaltyQuotient
 }
 
@@ -102,7 +101,19 @@ func RewardValidatorCrosslink(totalDeposit uint64, participatedDeposits uint64, 
 // PenaliseValidatorCrosslink applies penalties to validators part of a shard committee for not voting on a shard.
 func PenaliseValidatorCrosslink(timeSinceLastConfirmation uint64, rewardQuotient uint64, validator *pb.ValidatorRecord) {
 	newBalance := validator.Balance
-	quadraticQuotient := quadraticPenaltyQuotient()
+	quadraticQuotient := QuadraticPenaltyQuotient()
 	newBalance -= newBalance/rewardQuotient + newBalance*timeSinceLastConfirmation/quadraticQuotient
 	validator.Balance = newBalance
+}
+
+// calculateBalance applies the Casper FFG reward calculation based on reward quotients
+// and total deposits from validators.
+func calculateBalance(
+	balance uint64,
+	rewardQuotient uint64,
+	totalParticipatedDeposit uint64,
+	totalActiveValidatorDeposit uint64,
+) uint64 {
+	participationNumerator := 2*int64(totalParticipatedDeposit) - int64(totalActiveValidatorDeposit)
+	return uint64(int64(balance) + int64(balance/rewardQuotient)*participationNumerator/int64(totalActiveValidatorDeposit))
 }

--- a/beacon-chain/core/incentives/incentives_test.go
+++ b/beacon-chain/core/incentives/incentives_test.go
@@ -1,4 +1,4 @@
-package casper
+package incentives
 
 import (
 	"math"
@@ -9,9 +9,8 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
-func NewValidators() []*pb.ValidatorRecord {
+func newValidators() []*pb.ValidatorRecord {
 	var validators []*pb.ValidatorRecord
-
 	for i := 0; i < 10; i++ {
 		validator := &pb.ValidatorRecord{Balance: 32 * 1e9, Status: uint64(params.Active)}
 		validators = append(validators, validator)
@@ -20,13 +19,13 @@ func NewValidators() []*pb.ValidatorRecord {
 }
 
 func TestComputeValidatorRewardsAndPenalties(t *testing.T) {
-	validators := NewValidators()
+	validators := newValidators()
 	defaultBalance := uint64(32 * 1e9)
 
-	rewQuotient := RewardQuotient(validators)
 	participatedDeposit := 4 * defaultBalance
 	totalDeposit := 10 * defaultBalance
-	penaltyQuotient := quadraticPenaltyQuotient()
+	rewQuotient := RewardQuotient(totalDeposit)
+	penaltyQuotient := QuadraticPenaltyQuotient()
 	timeSinceFinality := uint64(5)
 
 	data := &pb.CrystallizedState{
@@ -36,12 +35,22 @@ func TestComputeValidatorRewardsAndPenalties(t *testing.T) {
 		LastFinalizedSlot:      3,
 	}
 
+	activeValidatorIndices := make([]uint32, 0, len(validators))
+	for i, v := range validators {
+		if v.Status == uint64(params.Active) {
+			activeValidatorIndices = append(activeValidatorIndices, uint32(i))
+		}
+	}
+
 	rewardedValidators := CalculateRewards(
 		5,
 		[]uint32{2, 3, 6, 9},
+		activeValidatorIndices,
 		data.Validators,
+		totalDeposit,
 		participatedDeposit,
-		timeSinceFinality)
+		timeSinceFinality,
+	)
 
 	expectedBalance := defaultBalance - defaultBalance/uint64(rewQuotient)
 
@@ -49,7 +58,7 @@ func TestComputeValidatorRewardsAndPenalties(t *testing.T) {
 		t.Fatalf("validator balance not updated correctly: %d, %d", rewardedValidators[0].Balance, expectedBalance)
 	}
 
-	expectedBalance = uint64(int64(defaultBalance) + int64(defaultBalance/rewQuotient)*int64(2*uint64(participatedDeposit)-uint64(totalDeposit))/int64(totalDeposit))
+	expectedBalance = calculateBalance(defaultBalance, rewQuotient, participatedDeposit, totalDeposit)
 
 	if rewardedValidators[6].Balance != expectedBalance {
 		t.Fatalf("validator balance not updated correctly: %d, %d", rewardedValidators[6].Balance, expectedBalance)
@@ -59,13 +68,22 @@ func TestComputeValidatorRewardsAndPenalties(t *testing.T) {
 		t.Fatalf("validator balance not updated correctly: %d, %d", rewardedValidators[9].Balance, expectedBalance)
 	}
 
-	validators = NewValidators()
+	validators = newValidators()
 	timeSinceFinality = 200
+
+	activeValidatorIndices = make([]uint32, 0, len(validators))
+	for i, v := range validators {
+		if v.Status == uint64(params.Active) {
+			activeValidatorIndices = append(activeValidatorIndices, uint32(i))
+		}
+	}
 
 	rewardedValidators = CalculateRewards(
 		5,
 		[]uint32{1, 2, 7, 8},
+		activeValidatorIndices,
 		validators,
+		totalDeposit,
 		participatedDeposit,
 		timeSinceFinality)
 
@@ -90,10 +108,9 @@ func TestComputeValidatorRewardsAndPenalties(t *testing.T) {
 }
 
 func TestRewardQuotient(t *testing.T) {
-	validators := []*pb.ValidatorRecord{
-		{Balance: 1e9, Status: uint64(params.Active)},
-	}
-	rewQuotient := RewardQuotient(validators)
+	defaultBalance := uint64(2 * 1e9)
+	totalDeposit := defaultBalance
+	rewQuotient := RewardQuotient(totalDeposit)
 
 	if rewQuotient != params.BeaconConfig().BaseRewardQuotient {
 		t.Errorf("incorrect reward quotient: %d", rewQuotient)
@@ -101,7 +118,7 @@ func TestRewardQuotient(t *testing.T) {
 }
 
 func TestQuadraticPenaltyQuotient(t *testing.T) {
-	penaltyQuotient := quadraticPenaltyQuotient()
+	penaltyQuotient := QuadraticPenaltyQuotient()
 	if penaltyQuotient != uint64(math.Pow(2, 32)) {
 		t.Errorf("incorrect penalty quotient %d", penaltyQuotient)
 	}
@@ -144,7 +161,7 @@ func TestPenaltyCrosslink(t *testing.T) {
 		Balance: 1e18,
 	}
 	timeSinceConfirmation := uint64(10)
-	quadraticQuotient := quadraticPenaltyQuotient()
+	quadraticQuotient := QuadraticPenaltyQuotient()
 
 	PenaliseValidatorCrosslink(timeSinceConfirmation, rewardQuotient, validator)
 	expectedBalance := 1e18 - (1e18/rewardQuotient + 1e18*timeSinceConfirmation/quadraticQuotient)


### PR DESCRIPTION
This is part of #781

---

# Description

This PR extracts the FFG incentive functions into their own stateless, pure package within `beacon-chain/core/incentives/`.