### PR TITLE
Validator Fix

### DIFF
--- a/beacon-chain/types/BUILD.bazel
+++ b/beacon-chain/types/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//beacon-chain/utils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bitutil:go_default_library",
-        "//shared/bytes:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",

--- a/beacon-chain/types/active_state.go
+++ b/beacon-chain/types/active_state.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gogo/protobuf/proto"
-	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	b "github.com/prysmaticlabs/prysm/shared/bytes"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
@@ -212,29 +210,8 @@ func (a *ActiveState) CalculateNewActiveState(
 
 	log.Debugf("Calculating new active state. Crystallized state lastStateRecalc is %d", cState.LastStateRecalculationSlot())
 
-	_, proposerIndex, err := v.ProposerShardAndIndex(
-		cState.ShardAndCommitteesForSlots(),
-		cState.LastStateRecalculationSlot(),
-		parentSlot)
-	if err != nil {
-		return nil, fmt.Errorf("could not get proposer index %v", err)
-	}
-
 	newRandao := setRandaoMix(block.RandaoReveal(), a.RandaoMix())
 	newState.data.RandaoMix = newRandao[:]
-
-	specialRecordData := make([][]byte, 2)
-	for i := range specialRecordData {
-		specialRecordData[i] = make([]byte, 32)
-	}
-	blockRandao := block.RandaoReveal()
-	proposerIndexBytes := b.Bytes8(proposerIndex)
-	specialRecordData[0] = proposerIndexBytes
-	specialRecordData[1] = blockRandao[:]
-
-	newState.data.PendingSpecials = a.appendNewSpecialObject(&pb.SpecialRecord{
-		Data: specialRecordData,
-	})
 
 	return newState, nil
 }


### PR DESCRIPTION
Resolves #903

This PR resolves the error by completely removing any appending of the specials records that occured when a new active state was calculated. Due to appending of 2 new special records each cycle transition, the first two active validators were logged out due to the following function in `Casper` 
```go
func ProcessSpecialRecords(slotNumber uint64, validators []*pb.ValidatorRecord, pendingSpecials []*pb.SpecialRecord) ([]*pb.ValidatorRecord, error) {
	// For each special record object in active state.
	for _, specialRecord := range pendingSpecials {

		// Covers validators submitted logouts from last cycle.
		if specialRecord.Kind == uint32(params.Logout) {
			validatorIndex := binary.BigEndian.Uint64(specialRecord.Data[0])
			exitedValidator := v.ExitValidator(validators[validatorIndex], slotNumber, false)
			validators[validatorIndex] = exitedValidator
			// TODO(#633): Verify specialRecord.Data[1] as signature. BLSVerify(pubkey=validator.pubkey, msg=hash(LOGOUT_MESSAGE + bytes8(version))
		}

	}
	return validators, nil
}
```
With special records added whenever `CalculateNewActiveState` was run, the following lines were removed to stop that from occuring 
```go
	_, proposerIndex, err := v.ProposerShardAndIndex(
		cState.ShardAndCommitteesForSlots(),
		cState.LastStateRecalculationSlot(),
		parentSlot)
	if err != nil {
		return nil, fmt.Errorf("could not get proposer index %v", err)
	}
```

```go 
	specialRecordData := make([][]byte, 2)
	for i := range specialRecordData {
		specialRecordData[i] = make([]byte, 32)
	}
	blockRandao := block.RandaoReveal()
	proposerIndexBytes := b.Bytes8(proposerIndex)
	specialRecordData[0] = proposerIndexBytes
	specialRecordData[1] = blockRandao[:]
 	newState.data.PendingSpecials = a.appendNewSpecialObject(&pb.SpecialRecord{
		Data: specialRecordData,
	})
```