### PR TITLE
Fixed Validator's Pubkey in Genesis.json

### DIFF
--- a/genesis.json
+++ b/genesis.json
@@ -37,13 +37,13 @@
       "status": "1"
     },
     {
-      "pubkey": "RkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZG",
+      "pubkey": "R0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dHR0dH",
       "balance": "32000000000",
       "exitSlot": "999999999999999999",
       "status": "1"
     },
     {
-      "pubkey": "RkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZGRkZG",
+      "pubkey": "SEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhI",
       "balance": "32000000000",
       "exitSlot": "999999999999999999",
       "status": "1"


### PR DESCRIPTION
Updated Validator's pubkey in genesis.json, the last 3 pub keys were the same. Now starting from the top
```
AA..
BB..
CC..
DD..
EE..
FF..
GG..
HH..
```