### PR TITLE
Serenity Design Specs have been moved

### DIFF
--- a/validator/README.md
+++ b/validator/README.md
@@ -7,6 +7,6 @@ Before you begin, check out our main [README](https://github.com/prysmaticlabs/p
 [![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://discord.gg/KSA7rPr)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/prysmaticlabs/prysm?badge&utm_medium=badge&utm_campaign=pr-badge)
 
-Also, read the latest sharding + casper [design spec](https://notes.ethereum.org/SCIg8AH5SA-O4C1G1LYZHQ), this design spec serves as a source of truth for the beacon chain implementation we follow at prysmatic labs.
+Also, read the latest sharding + casper [design spec](https://github.com/ethereum/eth2.0-specs), this design spec serves as a source of truth for the beacon chain implementation we follow at prysmatic labs.
 Check out the [FAQs](https://notes.ethereum.org/9MMuzWeFTTSg-3Tz_YeiBA?view). Refer this page on [why](http://email.mg2.substack.com/c/eJwlj9GOhCAMRb9G3jRQQPGBh5mM8xsbhKrsDGIAM9m_X9xN2qZtbpt7rCm4xvSjj5gLOTOmL-809CMbKXFaOKakIl4DZYr2AGyQIGjHOnWH22OiYnoIxmDijaBhhS6fcy7GvjobA9m0mSXOcnZq5GBqLkilXBZhBsus5ZK89VbKkRt-a-BZI6DzZ7iur1lQ953KJ9bemnxgahuQU9XJu6pFPdu8meT8vragzEjpMCwMGLlgLo6h5z1JumQTu4IJd4v15xqMf_8ZLP_Y1bSLdbnrD-LL71i2Kj7DLxaWWF4)
 we are combining sharding and casper together.


### PR DESCRIPTION
[Resolves] #958

Description:

Ethereum Serenity Design Specs have been moved from:
(https://notes.ethereum.org/SCIg8AH5SA-O4C1G1LYZHQ) --->(https://github.com/ethereum/eth2.0-specs)
