### PR TITLE
Remove Function to Add SpecialRecord to ActiveState

### DIFF
--- a/beacon-chain/types/active_state.go
+++ b/beacon-chain/types/active_state.go
@@ -133,13 +133,6 @@ func (a *ActiveState) UpdateAttestations(attestations []*pb.AggregatedAttestatio
 	return newState
 }
 
-// appendNewSpecialObject appends new special record object from block in to active state.
-// this is called during block processing.
-func (a *ActiveState) appendNewSpecialObject(record *pb.SpecialRecord) []*pb.SpecialRecord {
-	existing := a.data.PendingSpecials
-	return append(existing, record)
-}
-
 // clearAttestations removes attestations older than last state recalc slot.
 func (a *ActiveState) clearAttestations(lastStateRecalc uint64) {
 	existing := a.data.PendingAttestations

--- a/beacon-chain/types/active_state_test.go
+++ b/beacon-chain/types/active_state_test.go
@@ -71,18 +71,6 @@ func TestCopyActiveState(t *testing.T) {
 		)
 	}
 
-	newSpecial := &pb.SpecialRecord{
-		Kind: 323,
-		Data: [][]byte{{10}},
-	}
-	aState1.data.PendingSpecials = aState1.appendNewSpecialObject(newSpecial)
-	if len(aState1.PendingSpecials()) == len(aState2.PendingSpecials()) {
-		t.Fatalf("The PendingSpecials should not equal each other %d, %d",
-			len(aState1.PendingSpecials()),
-			len(aState2.PendingSpecials()),
-		)
-	}
-
 	aState1.data.RandaoMix = []byte{22, 21}
 	aState2.data.RandaoMix = []byte{40, 31}
 	if aState1.data.RandaoMix[0] == aState2.data.RandaoMix[0] {


### PR DESCRIPTION
This fixes #961

in that latest spec, special record object can be processed during block interval, we no longer need to store them to state object