### PR TITLE
Bootnode query tool

### DIFF
--- a/shared/p2p/dial_relay_node.go
+++ b/shared/p2p/dial_relay_node.go
@@ -8,7 +8,8 @@ import (
 	"github.com/multiformats/go-multiaddr"
 )
 
-func makePeer(addr string) (*peerstore.PeerInfo, error) {
+// MakePeer from multiaddress string.
+func MakePeer(addr string) (*peerstore.PeerInfo, error) {
 	maddr, err := multiaddr.NewMultiaddr(addr)
 	if err != nil {
 		return nil, err
@@ -17,7 +18,7 @@ func makePeer(addr string) (*peerstore.PeerInfo, error) {
 }
 
 func dialRelayNode(ctx context.Context, h host.Host, relayAddr string) error {
-	p, err := makePeer(relayAddr)
+	p, err := MakePeer(relayAddr)
 	if err != nil {
 		return err
 	}

--- a/shared/p2p/dial_relay_node_test.go
+++ b/shared/p2p/dial_relay_node_test.go
@@ -10,14 +10,14 @@ import (
 )
 
 func TestMakePeerFails(t *testing.T) {
-	_, err := makePeer("/ip4")
+	_, err := MakePeer("/ip4")
 	if err == nil {
 		t.Error("Expect error when invalid multiaddress was provided")
 	}
 }
 
 func TestMakePeerSucceeds(t *testing.T) {
-	a, err := makePeer("/ip4/127.0.0.1/tcp/5678/p2p/QmUn6ycS8Fu6L462uZvuEfDoSgYX6kqP4aSZWMa7z1tWAX")
+	a, err := MakePeer("/ip4/127.0.0.1/tcp/5678/p2p/QmUn6ycS8Fu6L462uZvuEfDoSgYX6kqP4aSZWMa7z1tWAX")
 	if err != nil {
 		t.Fatalf("Unexpected error when making a valid peer: %v", err)
 	}

--- a/tools/bootnode-query/BUILD.bazel
+++ b/tools/bootnode-query/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/prysmaticlabs/prysm/tools/bootnode-query",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//shared/p2p:go_default_library",
+        "@com_github_gogo_protobuf//io:go_default_library",
+        "@com_github_libp2p_go_libp2p//:go_default_library",
+        "@com_github_libp2p_go_libp2p_host//:go_default_library",
+        "@com_github_libp2p_go_libp2p_kad_dht//opts:go_default_library",
+        "@com_github_libp2p_go_libp2p_kad_dht//pb:go_default_library",
+        "@com_github_libp2p_go_libp2p_net//:go_default_library",
+        "@com_github_libp2p_go_libp2p_peerstore//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "bootnode-query",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/bootnode-query/BUILD.bazel
+++ b/tools/bootnode-query/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "@com_github_libp2p_go_libp2p_kad_dht//opts:go_default_library",
         "@com_github_libp2p_go_libp2p_kad_dht//pb:go_default_library",
         "@com_github_libp2p_go_libp2p_net//:go_default_library",
-        "@com_github_libp2p_go_libp2p_peerstore//:go_default_library",
     ],
 )
 

--- a/tools/bootnode-query/main.go
+++ b/tools/bootnode-query/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	ggio "github.com/gogo/protobuf/io"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-host"
+	dhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
+	dhtpb "github.com/libp2p/go-libp2p-kad-dht/pb"
+	"github.com/libp2p/go-libp2p-net"
+	"github.com/prysmaticlabs/prysm/shared/p2p"
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		log.Fatal("Error: Bootnode address not provided.")
+	}
+
+	ctx := context.Background()
+	h, err := libp2p.New(ctx)
+	if err != nil {
+		panic(err)
+	}
+
+	addr := os.Args[1]
+	pi, err := p2p.MakePeer(addr)
+	if err != nil {
+		log.Fatalf("Error: Failed to make peer from string: %v", err)
+	}
+	if err := h.Connect(ctx, *pi); err != nil {
+		log.Fatalf("Error: Failed to create peer from string: %v", err)
+	}
+
+	s, err := h.NewStream(ctx, pi.ID, dhtopts.ProtocolDHT)
+	if err != nil {
+		log.Fatalf("Error: Failed to create ProtocolDHT stream")
+	}
+
+	resp := sendMessageAndWait(s, dhtpb.NewMessage(dhtpb.Message_FIND_NODE, []byte{}, 0))
+
+	log.Printf("Bootstrap DHT node has %d peers\n", len(resp.GetCloserPeers()))
+	for i, p := range resp.GetCloserPeers() {
+		log.Printf("Dialing peer %d: %+v\n", i, p.Addresses())
+
+		if err := pingPeer(ctx, h, p); err != nil {
+			log.Printf("Error: unable to ping peer %v\n", err)
+		} else {
+			log.Println("OK")
+		}
+	}
+}
+
+func pingPeer(ctx context.Context, h host.Host, p *dhtpb.Message_Peer) error {
+	pi := dhtpb.PBPeerToPeerInfo(p)
+	if err := h.Connect(ctx, *pi); err != nil {
+		return err
+	}
+
+	s, err := h.NewStream(ctx, pi.ID, dhtopts.ProtocolDHT)
+	if err != nil {
+		return err
+	}
+
+	resp := sendMessageAndWait(s, dhtpb.NewMessage(dhtpb.Message_PING, []byte{}, 0))
+
+	_ = resp
+
+	return nil
+}
+
+func sendMessageAndWait(s net.Stream, msg *dhtpb.Message) dhtpb.Message {
+	r := ggio.NewDelimitedReader(s, 2000000)
+	w := ggio.NewDelimitedWriter(s)
+
+	if err := w.WriteMsg(msg); err != nil {
+		log.Fatalf("Error: failed to write message: %v", err)
+	}
+
+	var resp dhtpb.Message
+	if err := r.ReadMsg(&resp); err != nil {
+		log.Fatalf("Error: failed to read message: %v", err)
+	}
+
+	return resp
+}

--- a/tools/bootnode-query/main.go
+++ b/tools/bootnode-query/main.go
@@ -1,3 +1,9 @@
+// Bootstrap / DHT query tool
+//
+// Usage: bazel run //tools/boostrap-query -- $RELAY_ADDRESS
+//
+// This tool queries the bootstrap / DHT node for peers then attempts to dial
+// and ping each of them.
 package main
 
 import (

--- a/tools/bootnode-query/main.go
+++ b/tools/bootnode-query/main.go
@@ -1,6 +1,6 @@
 // Bootstrap / DHT query tool
 //
-// Usage: bazel run //tools/boostrap-query -- $RELAY_ADDRESS
+// Usage: bazel run //tools/boostrap-query -- $BOOTNODE_ADDRESS
 //
 // This tool queries the bootstrap / DHT node for peers then attempts to dial
 // and ping each of them.
@@ -70,10 +70,8 @@ func pingPeer(ctx context.Context, h host.Host, p *dhtpb.Message_Peer) error {
 		return err
 	}
 
-	resp := sendMessageAndWait(s, dhtpb.NewMessage(dhtpb.Message_PING, []byte{}, 0))
-
-	_ = resp
-
+	// Any response is OK
+	_ := sendMessageAndWait(s, dhtpb.NewMessage(dhtpb.Message_PING, []byte{}, 0))
 	return nil
 }
 

--- a/tools/bootnode-query/main.go
+++ b/tools/bootnode-query/main.go
@@ -71,7 +71,7 @@ func pingPeer(ctx context.Context, h host.Host, p *dhtpb.Message_Peer) error {
 	}
 
 	// Any response is OK
-	_ := sendMessageAndWait(s, dhtpb.NewMessage(dhtpb.Message_PING, []byte{}, 0))
+	_ = sendMessageAndWait(s, dhtpb.NewMessage(dhtpb.Message_PING, []byte{}, 0))
 	return nil
 }
 


### PR DESCRIPTION
This tool can be used to query the peers of a DHT / bootstrap node. 