### PR TITLE
Bootstrap the DHT service

### DIFF
--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "@com_github_multiformats_go_multiaddr//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/shared/p2p/dial_relay_node.go
+++ b/shared/p2p/dial_relay_node.go
@@ -6,6 +6,7 @@ import (
 	"github.com/libp2p/go-libp2p-host"
 	"github.com/libp2p/go-libp2p-peerstore"
 	"github.com/multiformats/go-multiaddr"
+	"go.opencensus.io/trace"
 )
 
 // MakePeer from multiaddress string.
@@ -18,6 +19,9 @@ func MakePeer(addr string) (*peerstore.PeerInfo, error) {
 }
 
 func dialRelayNode(ctx context.Context, h host.Host, relayAddr string) error {
+	ctx, span := trace.StartSpan(ctx, "p2p_dialRelayNode")
+	defer span.End()
+
 	p, err := MakePeer(relayAddr)
 	if err != nil {
 		return err

--- a/shared/p2p/dial_relay_node_test.go
+++ b/shared/p2p/dial_relay_node_test.go
@@ -28,7 +28,7 @@ func TestMakePeerSucceeds(t *testing.T) {
 }
 
 func TestDialRelayNodeFailsInvalidPeerString(t *testing.T) {
-	if err := dialRelayNode(nil, nil, "/ip4"); err == nil {
+	if err := dialRelayNode(context.Background(), nil, "/ip4"); err == nil {
 		t.Fatal("Expected to fail with invalid peer string, but there was no error")
 	}
 }

--- a/shared/p2p/discovery.go
+++ b/shared/p2p/discovery.go
@@ -9,6 +9,7 @@ import (
 	ps "github.com/libp2p/go-libp2p-peerstore"
 	mdns "github.com/libp2p/go-libp2p/p2p/discovery"
 	"github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
 )
 
 var log = logrus.WithField("prefix", "p2p")
@@ -33,6 +34,9 @@ func startmDNSDiscovery(ctx context.Context, host host.Host) error {
 
 // startDHTDiscovery supports discovery via DHT.
 func startDHTDiscovery(ctx context.Context, host host.Host, bootstrapAddr string) error {
+	ctx, span := trace.StartSpan(ctx, "p2p_startDHTDiscovery")
+	defer span.End()
+
 	addr, err := iaddr.ParseString(bootstrapAddr)
 	if err != nil {
 		return err

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -94,7 +94,9 @@ func (s *Server) Start() {
 		if err := startDHTDiscovery(ctx, s.host, s.bootstrapNode); err != nil {
 			log.Errorf("Could not start peer discovery via DHT: %v", err)
 		}
-		s.dht.Bootstrap(ctx)
+		if err := s.dht.Bootstrap(ctx); err != nil {
+			log.Errorf("Failed to bootstrap DHT: %v", err)
+		}
 	}
 
 	if s.relayNodeAddr != "" {

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -86,7 +86,7 @@ func NewServer(cfg *ServerConfig) (*Server, error) {
 
 // Start the main routine for an p2p server.
 func (s *Server) Start() {
-	ctx, span = trace.StartSpan(s.ctx, "p2p_server_start")
+	ctx, span := trace.StartSpan(s.ctx, "p2p_server_start")
 	defer span.End()
 	log.Info("Starting service")
 


### PR DESCRIPTION
The `dht.Bootstrap()` method is the key part of the DHT service for discovering peers. 

I've also added some tracing spans to inspect how long things take in the future.