### PR TITLE
Added kubernetes config map update for deployvrc

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -657,7 +657,7 @@ go_repository(
 
 go_repository(
     name = "com_github_prometheus_common",
-    commit = "1f2c4f3cd6db5fd6f68f36af6b6d5d936fd93c4e",
+    commit = "4724e9255275ce38f7179b2478abeae4e28c904f",
     importpath = "github.com/prometheus/common",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -831,3 +831,35 @@ go_repository(
     commit = "c7cda99284db0bea441058da8fd1f1373c763ed6",
     importpath = "github.com/libp2p/go-libp2p-interface-conn",
 )
+
+go_repository(
+    name = "io_k8s_client_go",
+    commit = "8abb21031259350aad0799bb42ba213ee8bb3399",
+    importpath = "k8s.io/client-go",
+)
+
+go_repository(
+    name = "io_k8s_apimachinery",
+    build_file_proto_mode = "disable_global",
+    commit = "4a9a8137c0a17bc4594f544987b3f0d48b2e3d3a",
+    importpath = "k8s.io/apimachinery",
+)
+
+go_repository(
+    name = "io_k8s_klog",
+    commit = "9be023858d57e1beb4d7c29fa54093cea2cf9583",
+    importpath = "k8s.io/klog",
+)
+
+go_repository(
+    name = "com_github_google_gofuzz",
+    commit = "24818f796faf91cd76ec7bddd72458fbced7a6c1",
+    importpath = "github.com/google/gofuzz",
+)
+
+go_repository(
+    name = "io_k8s_api",
+    build_file_proto_mode = "disable_global",
+    commit = "b7bd5f2d334ce968edc54f5fdb2ac67ce39c56d5",
+    importpath = "k8s.io/api",
+)

--- a/contracts/validator-registration-contract/deployVRC/BUILD.bazel
+++ b/contracts/validator-registration-contract/deployVRC/BUILD.bazel
@@ -1,4 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
 go_library(
     name = "go_default_library",
@@ -15,7 +17,46 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
         "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
     ],
+)
+
+go_image(
+    name = "image",
+    srcs = ["deployVRC.go"],
+    importpath = "github.com/prysmaticlabs/prysm/contracts/validator-registration-contract/deployVRC",
+    visibility = ["//visibility:private"],
+    static = "on",
+    tags = ["manual"],
+    goarch = "amd64",
+    goos = "linux",
+    deps = [
+        "//contracts/validator-registration-contract:go_default_library",
+        "@com_github_ethereum_go_ethereum//accounts/abi/bind:go_default_library",
+        "@com_github_ethereum_go_ethereum//accounts/keystore:go_default_library",
+        "@com_github_ethereum_go_ethereum//crypto:go_default_library",
+        "@com_github_ethereum_go_ethereum//ethclient:go_default_library",
+        "@com_github_ethereum_go_ethereum//rpc:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_urfave_cli//:go_default_library",
+        "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+    ],
+)
+
+container_push(
+    name = "push_image",
+    format = "Docker",
+    image = ":image",
+    registry = "gcr.io",
+    repository = "prysmaticlabs/prysm/deployvrc",
+    tag = "latest",
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
 )
 
 go_binary(

--- a/contracts/validator-registration-contract/deployVRC/deployVRC.go
+++ b/contracts/validator-registration-contract/deployVRC/deployVRC.go
@@ -149,7 +149,7 @@ func main() {
 
 		if k8sConfigMapName != "" {
 			if err := updateKubernetesConfigMap(k8sConfigMapName, addr.Hex()); err != nil {
-				log.Errorf("Failed to update kubernetes config map: %v", err)
+				log.Fatalf("Failed to update kubernetes config map: %v", err)
 			} else {
 				log.Printf("Updated config map %s", k8sConfigMapName)
 			}


### PR DESCRIPTION
This bit of functionality allows the `deployVRC` tool to update a kubernetes config map. 
The config map is then consumed by beacon-chain nodes, and potentially other services within the cluster. 