### PR TITLE
Fixed hang when multiple processes open same DB

### DIFF
--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -50,7 +50,7 @@ func NewDB(dirPath string) (*BeaconDB, error) {
 	boltDB, err := bolt.Open(datafile, 0600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		if err == bolt.ErrTimeout {
-			return nil, errors.New("cannot obtain database lock, database may be in use by another process.")
+			return nil, errors.New("cannot obtain database lock, database may be in use by another process")
 		}
 		return nil, err
 	}

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -5,7 +5,6 @@ import (
 	"path"
 	"time"
 	"github.com/boltdb/bolt"
-	"strings"
 	"errors"
 )
 
@@ -50,8 +49,8 @@ func NewDB(dirPath string) (*BeaconDB, error) {
 	datafile := path.Join(dirPath, "beaconchain.db")
 	boltDB, err := bolt.Open(datafile, 0600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
-		if strings.Contains(err.Error(), "timeout") {
-			return nil, errors.New("DB locked by another process")
+		if err == bolt.ErrTimeout {
+			return nil, errors.New("cannot obtain database lock, database may be in use by another process.")
 		}
 		return nil, err
 	}

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -3,8 +3,10 @@ package db
 import (
 	"os"
 	"path"
-
+	"time"
 	"github.com/boltdb/bolt"
+	"strings"
+	"errors"
 )
 
 // BeaconDB manages the data layer of the beacon chain implementation.
@@ -46,8 +48,11 @@ func NewDB(dirPath string) (*BeaconDB, error) {
 		return nil, err
 	}
 	datafile := path.Join(dirPath, "beaconchain.db")
-	boltDB, err := bolt.Open(datafile, 0600, nil)
+	boltDB, err := bolt.Open(datafile, 0600, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
+		if strings.Contains(err.Error(), "timeout") {
+			return nil, errors.New("DB locked by another process")
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
Resolves #1112  

---

# Description

Previously, the database package would hang when two processes tried to access the same datadir simultaneously. Now, there is a one second timeout and an error returned if two processes access simultaneously. 