### PR TITLE
Exclude Protos from Gometalinter in Travis

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,15 +1,6 @@
 {
-  "Enable": [
-    "gofmt",
-    "deadcode",
-    "misspell",
-    "goimports",
-    "nakedret",
-    "unparam",
-    "megacheck",
-    "gosec",
-    "varcheck",
-    "structcheck",
-    "golint"
-  ]
+  "Deadline": "10m",
+  "Exclude": [
+        "^proto/"
+    ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
         - lint
       script:
         - 
-          go get github.com/alecthomas/gometalinter && gometalinter --install && gometalinter ./... --deadline=10m --exclude=client/internal/client_helper.go
+          go get github.com/alecthomas/gometalinter && gometalinter --install && gometalinter ./... --deadline=10m --exclude=.*\.pb\.go
     - os: linux
       env:
         - coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
         - lint
       script:
         - 
-          go get github.com/alecthomas/gometalinter && gometalinter --install && gometalinter ./... --deadline=10m --exclude=.*\.pb\.go
+          go get github.com/alecthomas/gometalinter && gometalinter --install && gometalinter ./...
     - os: linux
       env:
         - coverage


### PR DESCRIPTION
This is a quick PR to update .travis.yml to exclude proto generated files from gometalinter in our CI pipeline
