### PR TITLE
Ignore XXX Fields in XXX SSZ Encoding

### DIFF
--- a/shared/ssz/encoder_decoder_lib.go
+++ b/shared/ssz/encoder_decoder_lib.go
@@ -90,14 +90,15 @@ type field struct {
 func sortedStructFields(typ reflect.Type) (fields []field, err error) {
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
+		if strings.Contains(f.Name, "XXX") {
+			continue
+		}
 		encDec, err := cachedEncoderDecoderNoAcquireLock(f.Type)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get encoder/decoder: %v", err)
 		}
 		name := f.Name
-		if !strings.Contains(name, "XXX") {
-			fields = append(fields, field{i, name, encDec})
-		}
+		fields = append(fields, field{i, name, encDec})
 	}
 	sort.SliceStable(fields, func(i, j int) bool {
 		return fields[i].name < fields[j].name

--- a/shared/ssz/encoder_decoder_lib.go
+++ b/shared/ssz/encoder_decoder_lib.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 )
 
@@ -94,7 +95,9 @@ func sortedStructFields(typ reflect.Type) (fields []field, err error) {
 			return nil, fmt.Errorf("failed to get encoder/decoder: %v", err)
 		}
 		name := f.Name
-		fields = append(fields, field{i, name, encDec})
+		if !strings.Contains(name, "XXX") {
+			fields = append(fields, field{i, name, encDec})
+		}
 	}
 	sort.SliceStable(fields, func(i, j int) bool {
 		return fields[i].name < fields[j].name


### PR DESCRIPTION
Resolves #1194.

# Description

This PR ignores struct fields beginning with XXX (proto internal fields) when SSZ encoding.