### PR TITLE
Remove Struct Fields Ordering for SSZ Encoding/Decoding

### DIFF
--- a/shared/ssz/decode.go
+++ b/shared/ssz/decode.go
@@ -242,7 +242,7 @@ func makeArrayDecoder(typ reflect.Type) (decoder, error) {
 }
 
 func makeStructDecoder(typ reflect.Type) (decoder, error) {
-	fields, err := sortedStructFields(typ)
+	fields, err := structFields(typ)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/ssz/decode_test.go
+++ b/shared/ssz/decode_test.go
@@ -84,48 +84,48 @@ var decodeTests = []decodeTest{
 
 	// struct
 	{input: "00000003 00 0000", ptr: new(simpleStruct), value: simpleStruct{}},
-	{input: "00000003 01 0002", ptr: new(simpleStruct), value: simpleStruct{B: 2, A: 1}},
-	{input: "00000007 00000002 0006 03", ptr: new(outerStruct),
+	{input: "00000003 0002 01", ptr: new(simpleStruct), value: simpleStruct{B: 2, A: 1}},
+	{input: "00000007 03 00000002 0006", ptr: new(outerStruct),
 		value: outerStruct{
 			V:    3,
 			SubV: innerStruct{6},
 		}},
 
 	// slice + struct
-	{input: "00000012 0000000E 00000003 010002 00000003 030004", ptr: new(arrayStruct),
+	{input: "00000012 0000000E 00000003 000201 00000003 000403", ptr: new(arrayStruct),
 		value: arrayStruct{
 			V: []simpleStruct{
 				{B: 2, A: 1},
 				{B: 4, A: 3},
 			},
 		}},
-	{input: "00000016 00000007 00000002 0006 03 00000007 00000002 0007 05", ptr: new([]outerStruct),
+	{input: "00000016 00000007 03 00000002 0006 00000007 05 00000002 0007", ptr: new([]outerStruct),
 		value: []outerStruct{
 			{V: 3, SubV: innerStruct{V: 6}},
 			{V: 5, SubV: innerStruct{V: 7}},
 		}},
 
 	// pointer
-	{input: "00000003 01 0002", ptr: new(*simpleStruct), value: &simpleStruct{B: 2, A: 1}},
-	{input: "00000008 00000003 01 0002 03", ptr: new(pointerStruct),
+	{input: "00000003 0002 01", ptr: new(*simpleStruct), value: &simpleStruct{B: 2, A: 1}},
+	{input: "00000008 00000003 0002 01 03", ptr: new(pointerStruct),
 		value: pointerStruct{P: &simpleStruct{B: 2, A: 1}, V: 3}},
-	{input: "00000008 00000003 01 0002 03", ptr: new(*pointerStruct),
+	{input: "00000008 00000003 0002 01 03", ptr: new(*pointerStruct),
 		value: &pointerStruct{P: &simpleStruct{B: 2, A: 1}, V: 3}},
 	{input: "00000004 01020304", ptr: new(*[]uint8), value: &[]uint8{1, 2, 3, 4}},
 	{input: "00000010 0000000000000001 0000000000000002", ptr: new(*[]uint64), value: &[]uint64{1, 2}},
-	{input: "0000000E 00000003 01 0002 00000003 03 0004", ptr: new([]*simpleStruct),
+	{input: "0000000E 00000003 0002 01 00000003 0004 03", ptr: new([]*simpleStruct),
 		value: []*simpleStruct{
 			{B: 2, A: 1},
 			{B: 4, A: 3},
 		},
 	},
-	{input: "0000000E 00000003 01 0002 00000003 03 0004", ptr: new([2]*simpleStruct),
+	{input: "0000000E 00000003 0002 01 00000003 0004 03", ptr: new([2]*simpleStruct),
 		value: [2]*simpleStruct{
 			{B: 2, A: 1},
 			{B: 4, A: 3},
 		},
 	},
-	{input: "00000018 00000008 00000003 01 0002 00 00000008 00000003 03 0004 01", ptr: new([]*pointerStruct),
+	{input: "00000018 00000008 00000003 0002 01 00 00000008 00000003 0004 03 01", ptr: new([]*pointerStruct),
 		value: []*pointerStruct{
 			{P: &simpleStruct{B: 2, A: 1}, V: 0},
 			{P: &simpleStruct{B: 4, A: 3}, V: 1},
@@ -169,7 +169,7 @@ var decodeTests = []decodeTest{
 	{input: "000001", ptr: new(simpleStruct), error: "decode error: failed to decode header of struct: can only read 3 bytes while expected to read 4 bytes for output type ssz.simpleStruct"},
 
 	// error: struct: wrong input
-	{input: "00000003 01 02", ptr: new(simpleStruct), error: "decode error: failed to decode field of slice: can only read 1 bytes while expected to read 2 bytes for output type ssz.simpleStruct"},
+	{input: "00000003 01 02", ptr: new(simpleStruct), error: "decode error: failed to decode field of slice: can only read 0 bytes while expected to read 1 bytes for output type ssz.simpleStruct"},
 }
 
 func runTests(t *testing.T, decode func([]byte, interface{}) error) {

--- a/shared/ssz/encode.go
+++ b/shared/ssz/encode.go
@@ -226,7 +226,7 @@ func makeSliceEncoder(typ reflect.Type) (encoder, encodeSizer, error) {
 }
 
 func makeStructEncoder(typ reflect.Type) (encoder, encodeSizer, error) {
-	fields, err := sortedStructFields(typ)
+	fields, err := structFields(typ)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/shared/ssz/encode_test.go
+++ b/shared/ssz/encode_test.go
@@ -85,11 +85,11 @@ var encodeTests = []encTest{
 
 	// struct
 	{val: simpleStruct{}, output: "00000003 00 0000"},
-	{val: simpleStruct{B: 2, A: 1}, output: "00000003 01 0002"},
+	{val: simpleStruct{B: 2, A: 1}, output: "00000003 0002 01"},
 	{val: outerStruct{
 		V:    3,
 		SubV: innerStruct{V: 6},
-	}, output: "00000007 00000002 0006 03"},
+	}, output: "00000007 03 00000002 0006"},
 
 	// slice + struct
 	{val: arrayStruct{
@@ -97,30 +97,30 @@ var encodeTests = []encTest{
 			{B: 2, A: 1},
 			{B: 4, A: 3},
 		},
-	}, output: "00000012 0000000E 00000003 010002 00000003 030004"},
+	}, output: "00000012 0000000E 00000003 000201 00000003 000403"},
 	{val: []outerStruct{
 		{V: 3, SubV: innerStruct{V: 6}},
 		{V: 5, SubV: innerStruct{V: 7}},
-	}, output: "00000016 00000007 00000002 0006 03 00000007 00000002 0007 05"},
+	}, output: "00000016 00000007 03 00000002 0006 00000007 05 00000002 0007"},
 
 	// pointer
-	{val: &simpleStruct{B: 2, A: 1}, output: "00000003 01 0002"},
-	{val: pointerStruct{P: &simpleStruct{B: 2, A: 1}, V: 3}, output: "00000008 00000003 01 0002 03"},
-	{val: &pointerStruct{P: &simpleStruct{B: 2, A: 1}, V: 3}, output: "00000008 00000003 01 0002 03"},
+	{val: &simpleStruct{B: 2, A: 1}, output: "00000003 0002 01"},
+	{val: pointerStruct{P: &simpleStruct{B: 2, A: 1}, V: 3}, output: "00000008 00000003 0002 01 03"},
+	{val: &pointerStruct{P: &simpleStruct{B: 2, A: 1}, V: 3}, output: "00000008 00000003 0002 01 03"},
 	{val: &[]uint8{1, 2, 3, 4}, output: "00000004 01020304"},
 	{val: &[]uint64{1, 2}, output: "00000010 0000000000000001 0000000000000002"},
 	{val: []*simpleStruct{
 		{B: 2, A: 1},
 		{B: 4, A: 3},
-	}, output: "0000000E 00000003 01 0002 00000003 03 0004"},
+	}, output: "0000000E 00000003 0002 01 00000003 0004 03"},
 	{val: [2]*simpleStruct{
 		{B: 2, A: 1},
 		{B: 4, A: 3},
-	}, output: "0000000E 00000003 01 0002 00000003 03 0004"},
+	}, output: "0000000E 00000003 0002 01 00000003 0004 03"},
 	{val: []*pointerStruct{
 		{P: &simpleStruct{B: 2, A: 1}, V: 0},
 		{P: &simpleStruct{B: 4, A: 3}, V: 1},
-	}, output: "00000018 00000008 00000003 01 0002 00 00000008 00000003 03 0004 01"},
+	}, output: "00000018 00000008 00000003 0002 01 00 00000008 00000003 0004 03 01"},
 
 	// error: nil pointer
 	{val: nil, error: "encode error: nil is not supported for input type <nil>"},

--- a/shared/ssz/encoder_decoder_lib.go
+++ b/shared/ssz/encoder_decoder_lib.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"reflect"
-	"sort"
 	"strings"
 	"sync"
 )
@@ -87,7 +86,7 @@ type field struct {
 	encDec *encoderDecoder
 }
 
-func sortedStructFields(typ reflect.Type) (fields []field, err error) {
+func structFields(typ reflect.Type) (fields []field, err error) {
 	for i := 0; i < typ.NumField(); i++ {
 		f := typ.Field(i)
 		if strings.Contains(f.Name, "XXX") {
@@ -100,8 +99,5 @@ func sortedStructFields(typ reflect.Type) (fields []field, err error) {
 		name := f.Name
 		fields = append(fields, field{i, name, encDec})
 	}
-	sort.SliceStable(fields, func(i, j int) bool {
-		return fields[i].name < fields[j].name
-	})
 	return fields, nil
 }


### PR DESCRIPTION
Resolves #1189 

---

# Description

Removed the sorting of struct when encoding/decoding.
