### PR TITLE
Disable race detection on go docker images

### DIFF
--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -36,6 +36,7 @@ go_image(
         "@com_github_urfave_cli//:go_default_library",
         "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",
     ],
+    race = "off",
 )
 
 container_push(

--- a/contracts/validator-registration-contract/deployVRC/BUILD.bazel
+++ b/contracts/validator-registration-contract/deployVRC/BUILD.bazel
@@ -46,6 +46,7 @@ go_image(
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
     ],
+    race = "off",
 )
 
 container_push(

--- a/tools/bootnode/BUILD.bazel
+++ b/tools/bootnode/BUILD.bazel
@@ -36,6 +36,8 @@ go_image(
         "@com_github_libp2p_go_libp2p_kad_dht//:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
     ],
+    race = "off",
+    pure = "on",
 )
 
 container_push(

--- a/tools/relaynode/BUILD.bazel
+++ b/tools/relaynode/BUILD.bazel
@@ -32,6 +32,8 @@ go_image(
         "@com_github_libp2p_go_libp2p_crypto//:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
     ],
+    race = "off",
+    pure = "on",
 )
 
 container_push(

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -36,6 +36,7 @@ go_image(
         "@com_github_urfave_cli//:go_default_library",
         "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",
     ],
+    race = "off",
 )
 
 container_push(


### PR DESCRIPTION
I ran into an issue with a minimal deployment if `build --features=race` is present. 
Since this is how the CI pushes the images, we should not build docker images with the race detection.
I think that race detection would also unnecessarily inflate the image size. 

Edit: Yes, this is about a 7mb savings. 49Mb -> 42Mb for beacon-chain. 