### PR TITLE
Improve state transition CPU & memory time

### DIFF
--- a/beacon-chain/chaintest/BUILD.bazel
+++ b/beacon-chain/chaintest/BUILD.bazel
@@ -24,5 +24,8 @@ go_test(
     srcs = ["yaml_test.go"],
     data = glob(["tests/**"]),
     embed = [":go_default_library"],
-    deps = ["//beacon-chain/chaintest/backend:go_default_library"],
+    deps = [
+        "//beacon-chain/chaintest/backend:go_default_library",
+        "@com_github_go_yaml_yaml//:go_default_library",
+    ],
 )

--- a/beacon-chain/chaintest/backend/simulated_backend.go
+++ b/beacon-chain/chaintest/backend/simulated_backend.go
@@ -158,10 +158,10 @@ func (sb *SimulatedBackend) RunStateTransitionTest(testCase *StateTestCase) erro
 	}
 	endTime := time.Now()
 	log.Infof(
-		"%d state transitions with %d deposits finished in %v seconds",
+		"%d state transitions with %d deposits finished in %v",
 		testCase.Config.NumSlots,
 		testCase.Config.DepositsForChainStart,
-		endTime.Sub(startTime).Seconds(),
+		endTime.Sub(startTime),
 	)
 
 	if beaconState.GetSlot() != testCase.Results.Slot {

--- a/beacon-chain/chaintest/main.go
+++ b/beacon-chain/chaintest/main.go
@@ -31,7 +31,7 @@ func readTestsFromYaml(yamlDir string) ([]interface{}, error) {
 		}
 		for _, file := range files {
 			filePath := path.Join(yamlDir, dir.Name(), file.Name())
-			data, err := ioutil.ReadFile(filePath) // #nosec
+			data, err := ioutil.ReadFile(filePath)
 			if err != nil {
 				return nil, fmt.Errorf("could not read yaml file: %v", err)
 			}
@@ -133,5 +133,5 @@ func main() {
 	}
 
 	endTime := time.Now()
-	log.Infof("Test Runs Finished In: %v Seconds", endTime.Sub(startTime).Seconds())
+	log.Infof("Test Runs Finished In: %v", endTime.Sub(startTime))
 }

--- a/beacon-chain/chaintest/yaml_test.go
+++ b/beacon-chain/chaintest/yaml_test.go
@@ -1,22 +1,52 @@
 package main
 
 import (
+	"io/ioutil"
 	"testing"
 
+	"github.com/go-yaml/yaml"
 	"github.com/prysmaticlabs/prysm/beacon-chain/chaintest/backend"
 )
 
-// TestReadTestsFromYaml tests constructing test cases from yaml file.
-func TestReadTestsFromYaml(t *testing.T) {
-	tests, err := readTestsFromYaml(string("./tests"))
+func TestFromYaml(t *testing.T) {
+	tests, err := readTestsFromYaml("./tests")
 	if err != nil {
 		t.Fatalf("Failed to read yaml files: %v", err)
 	}
+
 	sb, err := backend.NewSimulatedBackend()
 	if err != nil {
 		t.Fatalf("Could not create backend: %v", err)
 	}
+
 	if err := runTests(tests, sb); err != nil {
-		t.Errorf("Failed to run yaml tests")
+		t.Errorf("Failed to run yaml tests %v", err)
 	}
+}
+
+func BenchmarkStateTestFromYaml(b *testing.B) {
+	file, err := ioutil.ReadFile("./tests/state-tests/no-blocks.yaml")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	test := &backend.StateTest{}
+	if err := yaml.Unmarshal(file, test); err != nil {
+		b.Fatal(err)
+	}
+
+	sb, err := backend.NewSimulatedBackend()
+	if err != nil {
+		b.Fatalf("Failed to setup simulated backend: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, testCase := range test.TestCases {
+			if err := sb.RunStateTransitionTest(testCase); err != nil {
+				b.Error(err)
+			}
+		}
+	}
+
 }

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
+        "//beacon-chain/core/state/stateutils:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/utils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
@@ -569,6 +570,7 @@ func ProcessBlockValidatorDeposits(
 	}
 	var err error
 	var depositInput *pb.DepositInput
+	validatorIndexMap := stateutils.ValidatorIndexMap(beaconState)
 	for idx, deposit := range deposits {
 		depositData := deposit.GetDepositData()
 		depositInput, err = DecodeDepositInput(depositData)
@@ -584,6 +586,7 @@ func ProcessBlockValidatorDeposits(
 		// We then mutate the beacon state with the verified validator deposit.
 		beaconState, _, err = v.ProcessDeposit(
 			beaconState,
+			validatorIndexMap,
 			depositInput.GetPubkey(),
 			binary.BigEndian.Uint64(depositValue),
 			depositInput.GetProofOfPossession(),

--- a/beacon-chain/core/randao/BUILD.bazel
+++ b/beacon-chain/core/randao/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//beacon-chain/core/validators:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/params:go_default_library",
-        "@com_github_gogo_protobuf//proto:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/randao/randao.go
+++ b/beacon-chain/core/randao/randao.go
@@ -3,7 +3,6 @@ package randao
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -26,9 +25,8 @@ func UpdateRandaoLayers(state *pb.BeaconState, slot uint64) (*pb.BeaconState, er
 // UpdateRandaoMixes sets the beacon state's latest randao mixes according to the latest
 // beacon slot.
 func UpdateRandaoMixes(state *pb.BeaconState) *pb.BeaconState {
-	newState := proto.Clone(state).(*pb.BeaconState)
 	latestMixesLength := params.BeaconConfig().LatestRandaoMixesLength
-	prevMixes := state.LatestRandaoMixesHash32S[(newState.GetSlot()-1)%latestMixesLength]
-	newState.LatestRandaoMixesHash32S[state.GetSlot()%latestMixesLength] = prevMixes
-	return newState
+	prevMixes := state.LatestRandaoMixesHash32S[(state.GetSlot()-1)%latestMixesLength]
+	state.LatestRandaoMixesHash32S[state.GetSlot()%latestMixesLength] = prevMixes
+	return state
 }

--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/randao:go_default_library",
+        "//beacon-chain/core/state/stateutils:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/utils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	"github.com/prysmaticlabs/prysm/beacon-chain/utils"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -98,6 +99,7 @@ func InitialBeaconState(
 	// Set initial deposits and activations.
 	var validatorIndex uint32
 	var err error
+	validatorMap := stateutils.ValidatorIndexMap(state)
 	for _, deposit := range initialValidatorDeposits {
 		depositData := deposit.GetDepositData()
 		depositInput, err := b.DecodeDepositInput(depositData)
@@ -109,6 +111,7 @@ func InitialBeaconState(
 		depositValue := depositData[len(depositData)-16 : len(depositData)-8]
 		state, validatorIndex, err = v.ProcessDeposit(
 			state,
+			validatorMap,
 			depositInput.GetPubkey(),
 			binary.BigEndian.Uint64(depositValue),
 			depositInput.GetProofOfPossession(),

--- a/beacon-chain/core/state/stateutils/BUILD.bazel
+++ b/beacon-chain/core/state/stateutils/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["validator_index_map.go"],
+    importpath = "github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils",
+    visibility = ["//visibility:public"],
+    deps = ["//proto/beacon/p2p/v1:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["validator_index_map_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//proto/beacon/p2p/v1:go_default_library"],
+)

--- a/beacon-chain/core/state/stateutils/validator_index_map.go
+++ b/beacon-chain/core/state/stateutils/validator_index_map.go
@@ -1,0 +1,19 @@
+package stateutils
+
+import pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+
+func ValidatorIndexMap(state *pb.BeaconState) map[[32]byte]int {
+	m := make(map[[32]byte]int)
+	for idx, record := range state.ValidatorRegistry {
+		var key [32]byte
+		copy(key[:], record.Pubkey)
+		m[key] = idx
+	}
+	return m
+}
+
+func BytesToBytes32(a []byte) [32]byte {
+	var b [32]byte
+	copy(b[:], a)
+	return b
+}

--- a/beacon-chain/core/state/stateutils/validator_index_map_test.go
+++ b/beacon-chain/core/state/stateutils/validator_index_map_test.go
@@ -1,0 +1,52 @@
+package stateutils_test
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+)
+
+func TestValidatorIndexMap(t *testing.T) {
+	state := &pb.BeaconState{
+		ValidatorRegistry: []*pb.ValidatorRecord{
+			&pb.ValidatorRecord{
+				Pubkey: []byte("zero"),
+			},
+			&pb.ValidatorRecord{
+				Pubkey: []byte("one"),
+			},
+		},
+	}
+
+	tests := []struct {
+		key [32]byte
+		val int
+		ok  bool
+	}{
+		{
+			key: stateutils.BytesToBytes32([]byte("zero")),
+			val: 0,
+			ok:  true,
+		}, {
+			key: stateutils.BytesToBytes32([]byte("one")),
+			val: 1,
+			ok:  true,
+		}, {
+			key: stateutils.BytesToBytes32([]byte("no")),
+			val: 0,
+			ok:  false,
+		},
+	}
+
+	m := stateutils.ValidatorIndexMap(state)
+	for _, tt := range tests {
+		result, ok := m[tt.key]
+		if result != tt.val {
+			t.Errorf("Expected m[%s] = %d, got %d", tt.key, tt.val, result)
+		}
+		if ok != tt.ok {
+			t.Errorf("Expected ok=%v, got %v", tt.ok, ok)
+		}
+	}
+}

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -3,7 +3,6 @@ package state
 import (
 	"fmt"
 
-	"github.com/gogo/protobuf/proto"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/randao"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -23,69 +22,66 @@ func ExecuteStateTransition(
 	block *pb.BeaconBlock,
 	prevBlockRoot [32]byte,
 ) (*pb.BeaconState, error) {
-
 	var err error
-	newState := proto.Clone(beaconState).(*pb.BeaconState)
 
-	currentSlot := newState.GetSlot()
-	newState.Slot = currentSlot + 1
+	currentSlot := beaconState.Slot
+	beaconState.Slot = currentSlot + 1
 
-	newState, err = randao.UpdateRandaoLayers(newState, newState.GetSlot())
+	beaconState, err = randao.UpdateRandaoLayers(beaconState, beaconState.Slot)
 	if err != nil {
 		return nil, fmt.Errorf("unable to update randao layer %v", err)
 	}
-	newState = randao.UpdateRandaoMixes(newState)
-	newState = b.ProcessBlockRoots(newState, prevBlockRoot)
+	beaconState = randao.UpdateRandaoMixes(beaconState)
+	beaconState = b.ProcessBlockRoots(beaconState, prevBlockRoot)
 	if block != nil {
-		newState, err = ProcessBlock(newState, block)
+		beaconState, err = ProcessBlock(beaconState, block)
 		if err != nil {
 			return nil, fmt.Errorf("unable to process block: %v", err)
 		}
-		if newState.GetSlot()%params.BeaconConfig().EpochLength == 0 {
-			newState = NewEpochTransition(newState)
+		if beaconState.Slot%params.BeaconConfig().EpochLength == 0 {
+			beaconState = NewEpochTransition(beaconState)
 		}
 	}
 
-	return newState, nil
+	return beaconState, nil
 }
 
 // ProcessBlock creates a new, modified beacon state by applying block operation
 // transformations as defined in the Ethereum Serenity specification, including processing proposer slashings,
 // processing block attestations, and more.
 func ProcessBlock(state *pb.BeaconState, block *pb.BeaconBlock) (*pb.BeaconState, error) {
-	newState := proto.Clone(state).(*pb.BeaconState)
-	if block.GetSlot() != state.GetSlot() {
+	if block.Slot != state.Slot {
 		return nil, fmt.Errorf(
 			"block.slot != state.slot, block.slot = %d, state.slot = %d",
 			block.GetSlot(),
-			newState.GetSlot(),
+			state.GetSlot(),
 		)
 	}
 	// TODO(#781): Verify Proposer Signature.
 	var err error
-	newState = b.ProcessPOWReceiptRoots(newState, block)
-	newState, err = b.ProcessBlockRandao(newState, block)
+	state = b.ProcessPOWReceiptRoots(state, block)
+	state, err = b.ProcessBlockRandao(state, block)
 	if err != nil {
 		return nil, fmt.Errorf("could not verify and process block randao: %v", err)
 	}
-	newState, err = b.ProcessProposerSlashings(newState, block)
+	state, err = b.ProcessProposerSlashings(state, block)
 	if err != nil {
 		return nil, fmt.Errorf("could not verify block proposer slashings: %v", err)
 	}
-	newState, err = b.ProcessCasperSlashings(newState, block)
+	state, err = b.ProcessCasperSlashings(state, block)
 	if err != nil {
 		return nil, fmt.Errorf("could not verify block casper slashings: %v", err)
 	}
-	newState, err = b.ProcessBlockAttestations(newState, block)
+	state, err = b.ProcessBlockAttestations(state, block)
 	if err != nil {
 		return nil, fmt.Errorf("could not process block attestations: %v", err)
 	}
 	// TODO(#781): Process block validator deposits.
-	newState, err = b.ProcessValidatorExits(newState, block)
+	state, err = b.ProcessValidatorExits(state, block)
 	if err != nil {
 		return nil, fmt.Errorf("could not process validator exits: %v", err)
 	}
-	return newState, nil
+	return state, nil
 }
 
 // NewEpochTransition describes the per epoch operations that are performed on the

--- a/beacon-chain/core/validators/BUILD.bazel
+++ b/beacon-chain/core/validators/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/core/validators",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
+        "//beacon-chain/core/state/stateutils:go_default_library",
         "//beacon-chain/utils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",
@@ -29,6 +30,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//beacon-chain/core/state/stateutils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/common:go_default_library",
         "//shared/bitutil:go_default_library",

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	pbrpc "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/prysmaticlabs/prysm/shared/bitutil"
@@ -487,6 +488,7 @@ func AllValidatorsIndices(state *pb.BeaconState) []uint32 {
 // deposit.
 func ProcessDeposit(
 	state *pb.BeaconState,
+	validatorIndexMap map[[32]byte]int,
 	pubkey []byte,
 	deposit uint64,
 	proofOfPossession []byte,
@@ -497,12 +499,15 @@ func ProcessDeposit(
 	// TODO(#258): Validate proof of possession using BLS.
 	var publicKeyExists bool
 	var existingValidatorIndex int
-	for idx, val := range state.ValidatorRegistry {
-		if bytes.Equal(val.GetPubkey(), pubkey) {
-			publicKeyExists = true
-			existingValidatorIndex = idx
-		}
-	}
+
+	existingValidatorIndex, publicKeyExists = validatorIndexMap[stateutils.BytesToBytes32(pubkey)]
+
+	//for idx, val := range state.ValidatorRegistry {
+	//	if bytes.Equal(val.Pubkey, pubkey) {
+	//		publicKeyExists = true
+	//		existingValidatorIndex = idx
+	//	}
+	//}
 	if !publicKeyExists {
 		// If public key does not exist in the registry, we add a new validator
 		// to the beacon state.
@@ -511,7 +516,7 @@ func ProcessDeposit(
 			RandaoCommitmentHash32:  randaoCommitment,
 			RandaoLayers:            0,
 			Status:                  pb.ValidatorRecord_PENDING_ACTIVATION,
-			LatestStatusChangeSlot:  state.GetSlot(),
+			LatestStatusChangeSlot:  state.Slot,
 			ExitCount:               0,
 			PocCommitmentHash32:     pocCommitment,
 			LastPocChangeSlot:       0,
@@ -520,7 +525,7 @@ func ProcessDeposit(
 		idx, ok := minEmptyValidatorIndex(
 			state.ValidatorRegistry,
 			state.ValidatorBalances,
-			state.GetSlot(),
+			state.Slot,
 		)
 		// In the case there is no empty validator index in the state,
 		// we append an entirely new record to the validator registry and list

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/proto/common"
 	"github.com/prysmaticlabs/prysm/shared/bitutil"
@@ -657,6 +658,7 @@ func TestProcessDeposit_PublicKeyExistsBadWithdrawalCredentials(t *testing.T) {
 	want := "expected withdrawal credentials to match"
 	if _, _, err := ProcessDeposit(
 		beaconState,
+		stateutils.ValidatorIndexMap(beaconState),
 		pubkey,
 		deposit,
 		proofOfPossession,
@@ -692,6 +694,7 @@ func TestProcessDeposit_PublicKeyExistsGoodWithdrawalCredentials(t *testing.T) {
 
 	newState, _, err := ProcessDeposit(
 		beaconState,
+		stateutils.ValidatorIndexMap(beaconState),
 		pubkey,
 		deposit,
 		proofOfPossession,
@@ -732,6 +735,7 @@ func TestProcessDeposit_PublicKeyDoesNotExistNoEmptyValidator(t *testing.T) {
 
 	newState, _, err := ProcessDeposit(
 		beaconState,
+		stateutils.ValidatorIndexMap(beaconState),
 		pubkey,
 		deposit,
 		proofOfPossession,
@@ -778,6 +782,7 @@ func TestProcessDeposit_PublicKeyDoesNotExistEmptyValidatorExists(t *testing.T) 
 
 	newState, _, err := ProcessDeposit(
 		beaconState,
+		stateutils.ValidatorIndexMap(beaconState),
 		pubkey,
 		deposit,
 		proofOfPossession,


### PR DESCRIPTION
## Memory

### Before 

```
(pprof) top5
Showing nodes accounting for 3124.27MB, 95.75% of 3262.91MB total
Dropped 67 nodes (cum <= 16.31MB)
Showing top 5 nodes out of 27
      flat  flat%   sum%        cum   cum%
 1860.29MB 57.01% 57.01%  1860.29MB 57.01%  github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func25
  924.16MB 28.32% 85.34%   924.16MB 28.32%  reflect.New
  184.79MB  5.66% 91.00%  1263.99MB 38.74%  github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func28
     106MB  3.25% 94.25%      106MB  3.25%  github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func26
   49.04MB  1.50% 95.75%    49.04MB  1.50%  github.com/gogo/protobuf/proto.(*mergeInfo).computeMergeInfo.func7
```

### After 

```
Showing nodes accounting for 204.59MB, 60.45% of 338.44MB total
Dropped 22 nodes (cum <= 1.69MB)
Showing top 5 nodes out of 38
      flat  flat%   sum%        cum   cum%
   52.02MB 15.37% 15.37%    52.02MB 15.37%  golang.org/x/crypto/sha3.(*state).clone (inline)
   50.02MB 14.78% 30.15%    50.02MB 14.78%  golang.org/x/crypto/sha3.NewLegacyKeccak256 (inline)
   36.77MB 10.86% 41.01%   334.74MB 98.91%  github.com/prysmaticlabs/prysm/beacon-chain/chaintest/backend.(*SimulatedBackend).RunStateTransitionTest
      36MB 10.64% 51.65%    56.50MB 16.70%  github.com/prysmaticlabs/prysm/beacon-chain/core/blocks.EncodeBlockDepositData
   29.77MB  8.80% 60.45%    29.77MB  8.80%  github.com/prysmaticlabs/prysm/beacon-chain/core/validators.ProcessDeposit
```

## CPU

### Before

```
Showing nodes accounting for 2330ms, 31.61% of 7370ms total
Dropped 88 nodes (cum <= 36.85ms)
Showing top 5 nodes out of 125
      flat  flat%   sum%        cum   cum%
     550ms  7.46%  7.46%      550ms  7.46%  github.com/prysmaticlabs/prysm/beacon-chain/core/validators.minEmptyValidatorIndex
     540ms  7.33% 14.79%     2100ms 28.49%  github.com/prysmaticlabs/prysm/beacon-chain/core/validators.ProcessDeposit
     430ms  5.83% 20.62%      430ms  5.83%  github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1.(*ValidatorRecord).GetPubkey (inline)
     430ms  5.83% 26.46%     1100ms 14.93%  runtime.scanobject
     380ms  5.16% 31.61%     1690ms 22.93%  runtime.mallocgc
```

### After 

```
Showing nodes accounting for 2070ms, 80.23% of 2580ms total
Dropped 65 nodes (cum <= 12.90ms)
Showing top 5 nodes out of 64
      flat  flat%   sum%        cum   cum%
    1680ms 65.12% 65.12%     1790ms 69.38%  github.com/prysmaticlabs/prysm/beacon-chain/core/validators.minEmptyValidatorIndex
     150ms  5.81% 70.93%      150ms  5.81%  golang.org/x/crypto/sha3.keccakF1600
     110ms  4.26% 75.19%      110ms  4.26%  github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1.(*ValidatorRecord).GetLatestStatusChangeSlot (inline)
      80ms  3.10% 78.29%      230ms  8.91%  runtime.mallocgc
      50ms  1.94% 80.23%       50ms  1.94%  runtime.memmove
```

github.com/prysmaticlabs/prysm/beacon-chain/core/validators.minEmptyValidatorIndex is still a bit slow, but I am not sure we can do better than linear time to find the lowest value in an unsorted array. 