### PR TITLE
Remove Use of Proto .GetX for Value Getters

### DIFF
--- a/beacon-chain/attestation/service_test.go
+++ b/beacon-chain/attestation/service_test.go
@@ -27,7 +27,9 @@ func TestIncomingAttestations(t *testing.T) {
 		<-exitRoutine
 	}()
 
-	service.incomingChan <- &pb.Attestation{}
+	service.incomingChan <- &pb.Attestation{
+		Data: &pb.AttestationData{},
+	}
 	service.cancel()
 	exitRoutine <- true
 

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -312,7 +312,7 @@ func TestDoesPOWBlockExist(t *testing.T) {
 
 	// Using a faulty client should throw error.
 	var powHash [32]byte
-	copy(powHash[:], beaconState.GetProcessedPowReceiptRootHash32())
+	copy(powHash[:], beaconState.ProcessedPowReceiptRootHash32)
 	exists := chainService.doesPoWBlockExist(powHash)
 	if exists {
 		t.Error("Block corresponding to nil powchain reference should not exist")
@@ -460,7 +460,7 @@ func TestIsBlockReadyForProcessing(t *testing.T) {
 
 	currentSlot := uint64(1)
 	attestationSlot := uint64(0)
-	shard := beaconState.GetShardAndCommitteesAtSlots()[attestationSlot].ArrayShardAndCommittee[0].Shard
+	shard := beaconState.ShardAndCommitteesAtSlots[attestationSlot].ArrayShardAndCommittee[0].Shard
 
 	block3 := &pb.BeaconBlock{
 		Slot:                          currentSlot,

--- a/beacon-chain/core/attestations/attestation.go
+++ b/beacon-chain/core/attestations/attestation.go
@@ -32,9 +32,9 @@ func CreateAttestationMsg(
 // This is used for attestation table look up in localDB.
 func Key(att *pb.AttestationData) [32]byte {
 	key := make([]byte, binary.MaxVarintLen64)
-	binary.PutUvarint(key, att.GetSlot())
-	binary.PutUvarint(key, att.GetShard())
-	key = append(key, att.GetShardBlockRootHash32()...)
+	binary.PutUvarint(key, att.Slot)
+	binary.PutUvarint(key, att.Shard)
+	key = append(key, att.ShardBlockRootHash32...)
 	return hashutil.Hash(key)
 }
 
@@ -44,10 +44,10 @@ func VerifyProposerAttestation(att *pb.AttestationData, pubKey [32]byte, propose
 	// Verify the attestation attached with block response.
 	// Get proposer index and shardID.
 	attestationMsg := CreateAttestationMsg(
-		att.GetShardBlockRootHash32(),
-		att.GetSlot(),
+		att.ShardBlockRootHash32,
+		att.Slot,
 		proposerShardID,
-		att.GetJustifiedSlot(),
+		att.JustifiedSlot,
 		params.BeaconConfig().InitialForkVersion,
 	)
 	_ = attestationMsg

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -24,9 +24,9 @@ func TestProcessPOWReceiptRoots_SameRootHash(t *testing.T) {
 		CandidatePowReceiptRootHash32: []byte{1},
 	}
 	beaconState = ProcessPOWReceiptRoots(beaconState, block)
-	newRoots := beaconState.GetCandidatePowReceiptRoots()
-	if newRoots[0].GetVoteCount() != 6 {
-		t.Errorf("expected votes to increase from 5 to 6, received %d", newRoots[0].GetVoteCount())
+	newRoots := beaconState.CandidatePowReceiptRoots
+	if newRoots[0].VoteCount != 6 {
+		t.Errorf("expected votes to increase from 5 to 6, received %d", newRoots[0].VoteCount)
 	}
 }
 
@@ -43,14 +43,14 @@ func TestProcessPOWReceiptRoots_NewCandidateRecord(t *testing.T) {
 		CandidatePowReceiptRootHash32: []byte{1},
 	}
 	beaconState = ProcessPOWReceiptRoots(beaconState, block)
-	newRoots := beaconState.GetCandidatePowReceiptRoots()
+	newRoots := beaconState.CandidatePowReceiptRoots
 	if len(newRoots) == 1 {
 		t.Error("expected new receipt roots to have length > 1")
 	}
-	if newRoots[1].GetVoteCount() != 1 {
+	if newRoots[1].VoteCount != 1 {
 		t.Errorf(
 			"expected new receipt roots to have a new element with votes = 1, received votes = %d",
-			newRoots[1].GetVoteCount(),
+			newRoots[1].VoteCount,
 		)
 	}
 	if !bytes.Equal(newRoots[1].CandidatePowReceiptRootHash32, []byte{1}) {
@@ -155,15 +155,15 @@ func TestProcessBlockRandao_CreateRandaoMixAndUpdateProposer(t *testing.T) {
 	}
 
 	xorRandao := [32]byte{1}
-	updatedLatestMix := newState.LatestRandaoMixesHash32S[newState.GetSlot()%params.BeaconConfig().LatestRandaoMixesLength]
+	updatedLatestMix := newState.LatestRandaoMixesHash32S[newState.Slot%params.BeaconConfig().LatestRandaoMixesLength]
 	if !bytes.Equal(updatedLatestMix, xorRandao[:]) {
 		t.Errorf("Expected randao mix to XOR correctly: wanted %#x, received %#x", xorRandao[:], updatedLatestMix)
 	}
-	if !bytes.Equal(newState.GetValidatorRegistry()[0].GetRandaoCommitmentHash32(), []byte{1}) {
+	if !bytes.Equal(newState.ValidatorRegistry[0].RandaoCommitmentHash32, []byte{1}) {
 		t.Errorf(
 			"Expected proposer at index 0 to update randao commitment to block randao reveal = %#x, received %#x",
 			[]byte{1},
-			newState.GetValidatorRegistry()[0].GetRandaoCommitmentHash32(),
+			newState.ValidatorRegistry[0].RandaoCommitmentHash32,
 		)
 	}
 }
@@ -348,7 +348,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 		beaconState,
 		block,
 	)
-	registry = newState.GetValidatorRegistry()
+	registry = newState.ValidatorRegistry
 	if err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
@@ -693,7 +693,7 @@ func TestProcessCasperSlashings_AppliesCorrectStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	newRegistry := newState.GetValidatorRegistry()
+	newRegistry := newState.ValidatorRegistry
 
 	// Given the intersection of slashable indices is [1], only validator
 	// at index 1 should be penalized and change Status. We confirm this below.
@@ -1074,22 +1074,22 @@ func TestProcessBlockAttestations_CreatePendingAttestations(t *testing.T) {
 		state,
 		block,
 	)
-	pendingAttestations := newState.GetLatestAttestations()
+	pendingAttestations := newState.LatestAttestations
 	if err != nil {
 		t.Fatalf("Could not produce pending attestations: %v", err)
 	}
-	if !reflect.DeepEqual(pendingAttestations[0].GetData(), att1.GetData()) {
+	if !reflect.DeepEqual(pendingAttestations[0].Data, att1.Data) {
 		t.Errorf(
 			"Did not create pending attestation correctly with inner data, wanted %v, received %v",
-			att1.GetData(),
-			pendingAttestations[0].GetData(),
+			att1.Data,
+			pendingAttestations[0].Data,
 		)
 	}
-	if pendingAttestations[0].GetSlotIncluded() != 64 {
+	if pendingAttestations[0].SlotIncluded != 64 {
 		t.Errorf(
 			"Pending attestation not included at correct slot: wanted %v, received %v",
 			64,
-			pendingAttestations[0].GetSlotIncluded(),
+			pendingAttestations[0].SlotIncluded,
 		)
 	}
 }
@@ -1246,7 +1246,7 @@ func TestProcessValidatorExits_AppliesCorrectStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not process exits: %v", err)
 	}
-	newRegistry := newState.GetValidatorRegistry()
+	newRegistry := newState.ValidatorRegistry
 	if newRegistry[0].Status == pb.ValidatorRecord_ACTIVE {
 		t.Error("Expected validator status to change, remained ACTIVE")
 	}

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -398,6 +398,16 @@ func TestProcessCasperSlashings_VoteThresholdReached(t *testing.T) {
 					params.BeaconConfig().MaxCasperVotes,
 				),
 			},
+			Votes_2: &pb.SlashableVoteData{
+				AggregateSignaturePoc_0Indices: make(
+					[]uint32,
+					params.BeaconConfig().MaxCasperVotes,
+				),
+				AggregateSignaturePoc_1Indices: make(
+					[]uint32,
+					params.BeaconConfig().MaxCasperVotes,
+				),
+			},
 		},
 	}
 	registry := []*pb.ValidatorRecord{}
@@ -428,6 +438,16 @@ func TestProcessCasperSlashings_VoteThresholdReached(t *testing.T) {
 	// Perform the same check for Votes_2.
 	slashings = []*pb.CasperSlashing{
 		{
+			Votes_1: &pb.SlashableVoteData{
+				AggregateSignaturePoc_0Indices: make(
+					[]uint32,
+					params.BeaconConfig().MaxCasperVotes,
+				),
+				AggregateSignaturePoc_1Indices: make(
+					[]uint32,
+					params.BeaconConfig().MaxCasperVotes,
+				),
+			},
 			Votes_2: &pb.SlashableVoteData{
 				AggregateSignaturePoc_0Indices: make(
 					[]uint32,

--- a/beacon-chain/core/blocks/block_test.go
+++ b/beacon-chain/core/blocks/block_test.go
@@ -15,24 +15,24 @@ func TestGenesisBlock(t *testing.T) {
 	stateHash := []byte{0}
 	b1 := NewGenesisBlock(stateHash)
 
-	if b1.GetParentRootHash32() == nil {
+	if b1.ParentRootHash32 == nil {
 		t.Error("genesis block missing ParentHash field")
 	}
 
-	if !reflect.DeepEqual(b1.GetBody().GetAttestations(), []*pb.Attestation{}) {
+	if !reflect.DeepEqual(b1.Body.Attestations, []*pb.Attestation{}) {
 		t.Errorf("genesis block should have 0 attestations")
 	}
 
-	if !bytes.Equal(b1.GetRandaoRevealHash32(), params.BeaconConfig().ZeroHash[:]) {
+	if !bytes.Equal(b1.RandaoRevealHash32, params.BeaconConfig().ZeroHash[:]) {
 		t.Error("genesis block missing RandaoRevealHash32 field")
 	}
 
-	if !bytes.Equal(b1.GetStateRootHash32(), stateHash) {
+	if !bytes.Equal(b1.StateRootHash32, stateHash) {
 		t.Error("genesis block StateRootHash32 isn't initialized correctly")
 	}
 
 	rd := []byte{}
-	if IsRandaoValid(b1.GetRandaoRevealHash32(), rd) {
+	if IsRandaoValid(b1.RandaoRevealHash32, rd) {
 		t.Error("RANDAO should be empty")
 	}
 

--- a/beacon-chain/core/blocks/validity_conditions.go
+++ b/beacon-chain/core/blocks/validity_conditions.go
@@ -29,7 +29,7 @@ func IsValidBlock(
 	// Pre-Processing Condition 1:
 	// Check that the parent Block has been processed and saved.
 	var parentRoot [32]byte
-	copy(parentRoot[:], block.GetParentRootHash32())
+	copy(parentRoot[:], block.ParentRootHash32)
 	parentBlock := HasBlock(parentRoot)
 	if !parentBlock {
 		return fmt.Errorf("unprocessed parent block as it is not saved in the db: %#x", parentRoot)
@@ -38,13 +38,13 @@ func IsValidBlock(
 	// Pre-Processing Condition 2:
 	// The state is updated up to block.slot -1.
 
-	if state.GetSlot() != block.GetSlot()-1 {
+	if state.Slot != block.Slot-1 {
 		return fmt.Errorf(
-			"block slot is not valid %d as it is supposed to be %d", block.GetSlot(), state.GetSlot()+1)
+			"block slot is not valid %d as it is supposed to be %d", block.Slot, state.Slot+1)
 	}
 
 	if enablePOWChain {
-		h := common.BytesToHash(state.GetProcessedPowReceiptRootHash32())
+		h := common.BytesToHash(state.ProcessedPowReceiptRootHash32)
 		powBlock, err := GetPOWBlock(ctx, h)
 		if err != nil {
 			return fmt.Errorf("unable to retrieve POW chain reference block %v", err)
@@ -54,15 +54,15 @@ func IsValidBlock(
 		// The block pointed to by the state in state.processed_pow_receipt_root has
 		// been processed in the ETH 1.0 chain.
 		if powBlock == nil {
-			return fmt.Errorf("proof-of-Work chain reference in state does not exist %#x", state.GetProcessedPowReceiptRootHash32())
+			return fmt.Errorf("proof-of-Work chain reference in state does not exist %#x", state.ProcessedPowReceiptRootHash32)
 		}
 	}
 
 	// Pre-Processing Condition 4:
 	// The node's local time is greater than or equal to
 	// state.genesis_time + block.slot * SLOT_DURATION.
-	if !IsSlotValid(block.GetSlot(), genesisTime) {
-		return fmt.Errorf("slot of block is too high: %d", block.GetSlot())
+	if !IsSlotValid(block.Slot, genesisTime) {
+		return fmt.Errorf("slot of block is too high: %d", block.Slot)
 	}
 
 	return nil

--- a/beacon-chain/core/blocks/validity_conditions_test.go
+++ b/beacon-chain/core/blocks/validity_conditions_test.go
@@ -69,7 +69,7 @@ func TestBadBlock(t *testing.T) {
 
 	if err := IsValidBlock(ctx, beaconState, block, true,
 		db.HasBlock, powClient.BlockByHash, genesisTime); err == nil {
-		t.Fatalf("block is valid despite having an invalid slot %d", block.GetSlot())
+		t.Fatalf("block is valid despite having an invalid slot %d", block.Slot)
 	}
 
 	block.Slot = 4

--- a/beacon-chain/core/epoch/epoch_operations.go
+++ b/beacon-chain/core/epoch/epoch_operations.go
@@ -32,7 +32,7 @@ func Attestations(state *pb.BeaconState) []*pb.PendingAttestationRecord {
 			earliestSlot = state.Slot - epochLength
 		}
 
-		if earliestSlot <= attestation.GetData().GetSlot() && attestation.GetData().GetSlot() < state.Slot {
+		if earliestSlot <= attestation.Data.Slot && attestation.Data.Slot < state.Slot {
 			thisEpochAttestations = append(thisEpochAttestations, attestation)
 		}
 	}
@@ -60,7 +60,7 @@ func BoundaryAttestations(
 			return nil, err
 		}
 
-		attestationData := attestation.GetData()
+		attestationData := attestation.Data
 		sameRoot := bytes.Equal(attestationData.JustifiedBlockRootHash32, boundaryBlockRoot)
 		sameSlotNum := attestationData.JustifiedSlot == state.JustifiedSlot
 		if sameRoot && sameSlotNum {
@@ -90,8 +90,8 @@ func PrevAttestations(state *pb.BeaconState) []*pb.PendingAttestationRecord {
 			earliestSlot = state.Slot - 2*epochLength
 		}
 
-		if earliestSlot <= attestation.GetData().GetSlot() &&
-			attestation.GetData().GetSlot() < state.Slot-epochLength {
+		if earliestSlot <= attestation.Data.Slot &&
+			attestation.Data.Slot < state.Slot-epochLength {
 			prevEpochAttestations = append(prevEpochAttestations, attestation)
 		}
 	}
@@ -114,7 +114,7 @@ func PrevJustifiedAttestations(
 	epochAttestations := append(thisEpochAttestations, prevEpochAttestations...)
 
 	for _, attestation := range epochAttestations {
-		if attestation.GetData().GetJustifiedSlot() == state.PreviousJustifiedSlot {
+		if attestation.Data.JustifiedSlot == state.PreviousJustifiedSlot {
 			prevJustifiedAttestations = append(prevJustifiedAttestations, attestation)
 		}
 	}
@@ -134,12 +134,12 @@ func PrevHeadAttestations(
 
 	var headAttestations []*pb.PendingAttestationRecord
 	for _, attestation := range prevEpochAttestations {
-		canonicalBlockRoot, err := block.BlockRoot(state, attestation.GetData().GetSlot())
+		canonicalBlockRoot, err := block.BlockRoot(state, attestation.Data.Slot)
 		if err != nil {
 			return nil, err
 		}
 
-		attestationData := attestation.GetData()
+		attestationData := attestation.Data
 		if bytes.Equal(attestationData.BeaconBlockRootHash32, canonicalBlockRoot) {
 			headAttestations = append(headAttestations, attestation)
 		}
@@ -167,8 +167,8 @@ func WinningRoot(
 	attestations := append(thisEpochAttestations, prevEpochAttestations...)
 
 	for _, attestation := range attestations {
-		if attestation.GetData().GetShard() == shardCommittee.Shard {
-			candidateRoots = append(candidateRoots, attestation.GetData().ShardBlockRootHash32)
+		if attestation.Data.Shard == shardCommittee.Shard {
+			candidateRoots = append(candidateRoots, attestation.Data.ShardBlockRootHash32)
 		}
 	}
 
@@ -283,7 +283,7 @@ func TotalBalance(
 func InclusionSlot(state *pb.BeaconState, validatorIndex uint32) (uint64, error) {
 
 	for _, attestation := range state.LatestAttestations {
-		participatedValidators, err := validators.AttestationParticipants(state, attestation.GetData(), attestation.ParticipationBitfield)
+		participatedValidators, err := validators.AttestationParticipants(state, attestation.Data, attestation.ParticipationBitfield)
 		if err != nil {
 			return 0, fmt.Errorf("could not get attestation participants: %v", err)
 		}
@@ -307,14 +307,14 @@ func InclusionSlot(state *pb.BeaconState, validatorIndex uint32) (uint64, error)
 func InclusionDistance(state *pb.BeaconState, validatorIndex uint32) (uint64, error) {
 
 	for _, attestation := range state.LatestAttestations {
-		participatedValidators, err := validators.AttestationParticipants(state, attestation.GetData(), attestation.ParticipationBitfield)
+		participatedValidators, err := validators.AttestationParticipants(state, attestation.Data, attestation.ParticipationBitfield)
 		if err != nil {
 			return 0, fmt.Errorf("could not get attestation participants: %v", err)
 		}
 
 		for _, index := range participatedValidators {
 			if index == validatorIndex {
-				return attestation.SlotIncluded - attestation.GetData().GetSlot(), nil
+				return attestation.SlotIncluded - attestation.Data.Slot, nil
 			}
 		}
 	}
@@ -332,8 +332,8 @@ func InclusionDistance(state *pb.BeaconState, validatorIndex uint32) (uint64, er
 //    (the longer, the lower the reward). Returns a value between ``0`` and ``magnitude``.
 //    ""
 //    return magnitude // 2 + (magnitude // 2) * MIN_ATTESTATION_INCLUSION_DELAY // distance
-func AdjustForInclusionDistance(magniture uint64, distance uint64) uint64 {
-	return magniture/2 + (magniture/2)*
+func AdjustForInclusionDistance(magnitude uint64, distance uint64) uint64 {
+	return magnitude/2 + (magnitude/2)*
 		params.BeaconConfig().MinAttestationInclusionDelay/distance
 }
 

--- a/beacon-chain/core/epoch/epoch_operations_test.go
+++ b/beacon-chain/core/epoch/epoch_operations_test.go
@@ -52,11 +52,11 @@ func TestEpochAttestations(t *testing.T) {
 	for _, tt := range tests {
 		state.Slot = tt.stateSlot
 
-		if Attestations(state)[0].GetData().GetSlot() != tt.firstAttestationSlot {
+		if Attestations(state)[0].Data.Slot != tt.firstAttestationSlot {
 			t.Errorf(
 				"Result slot was an unexpected value. Wanted %d, got %d",
 				tt.firstAttestationSlot,
-				Attestations(state)[0].GetData().GetSlot(),
+				Attestations(state)[0].Data.Slot,
 			)
 		}
 	}
@@ -95,13 +95,13 @@ func TestEpochBoundaryAttestations(t *testing.T) {
 		t.Fatalf("EpochBoundaryAttestations failed: %v", err)
 	}
 
-	if epochBoundaryAttestation[0].GetData().GetJustifiedSlot() != 0 {
-		t.Errorf("Wanted justified slot 0 for epoch boundary attestation, got: %d", epochBoundaryAttestation[0].GetData().GetJustifiedSlot())
+	if epochBoundaryAttestation[0].Data.JustifiedSlot != 0 {
+		t.Errorf("Wanted justified slot 0 for epoch boundary attestation, got: %d", epochBoundaryAttestation[0].Data.JustifiedSlot)
 	}
 
-	if !bytes.Equal(epochBoundaryAttestation[0].GetData().GetJustifiedBlockRootHash32(), []byte{0}) {
+	if !bytes.Equal(epochBoundaryAttestation[0].Data.JustifiedBlockRootHash32, []byte{0}) {
 		t.Errorf("Wanted justified block hash [0] for epoch boundary attestation, got: %v",
-			epochBoundaryAttestation[0].GetData().GetJustifiedBlockRootHash32())
+			epochBoundaryAttestation[0].Data.JustifiedBlockRootHash32)
 	}
 }
 
@@ -150,11 +150,11 @@ func TestPrevEpochAttestations(t *testing.T) {
 	for _, tt := range tests {
 		state.Slot = tt.stateSlot
 
-		if PrevAttestations(state)[0].GetData().GetSlot() != tt.firstAttestationSlot {
+		if PrevAttestations(state)[0].Data.Slot != tt.firstAttestationSlot {
 			t.Errorf(
 				"Result slot was an unexpected value. Wanted %d, got %d",
 				tt.firstAttestationSlot,
-				Attestations(state)[0].GetData().GetSlot(),
+				Attestations(state)[0].Data.Slot,
 			)
 		}
 	}
@@ -184,11 +184,11 @@ func TestPrevJustifiedAttestations(t *testing.T) {
 	prevJustifiedAttestations := PrevJustifiedAttestations(state, thisEpochAttestations, prevEpochAttestations)
 
 	for i, attestation := range prevJustifiedAttestations {
-		if attestation.GetData().Shard != uint64(i) {
-			t.Errorf("Wanted shard %d, got %d", i, attestation.GetData().Shard)
+		if attestation.Data.Shard != uint64(i) {
+			t.Errorf("Wanted shard %d, got %d", i, attestation.Data.Shard)
 		}
-		if attestation.GetData().GetJustifiedSlot() != 100 {
-			t.Errorf("Wanted justified slot 100, got %d", attestation.GetData().GetJustifiedSlot())
+		if attestation.Data.JustifiedSlot != 100 {
+			t.Errorf("Wanted justified slot 100, got %d", attestation.Data.JustifiedSlot)
 		}
 	}
 }
@@ -212,19 +212,19 @@ func TestHeadAttestations_Ok(t *testing.T) {
 		t.Fatalf("PrevHeadAttestations failed with %v", err)
 	}
 
-	if headAttestations[0].GetData().GetSlot() != 1 {
-		t.Errorf("headAttestations[0] wanted slot 1, got slot %d", headAttestations[0].GetData().GetSlot())
+	if headAttestations[0].Data.Slot != 1 {
+		t.Errorf("headAttestations[0] wanted slot 1, got slot %d", headAttestations[0].Data.Slot)
 	}
-	if headAttestations[1].GetData().GetSlot() != 3 {
-		t.Errorf("headAttestations[1] wanted slot 3, got slot %d", headAttestations[1].GetData().GetSlot())
+	if headAttestations[1].Data.Slot != 3 {
+		t.Errorf("headAttestations[1] wanted slot 3, got slot %d", headAttestations[1].Data.Slot)
 	}
-	if !bytes.Equal([]byte{'A'}, headAttestations[0].GetData().GetBeaconBlockRootHash32()) {
+	if !bytes.Equal([]byte{'A'}, headAttestations[0].Data.BeaconBlockRootHash32) {
 		t.Errorf("headAttestations[0] wanted hash [A], got slot %v",
-			headAttestations[0].GetData().GetBeaconBlockRootHash32())
+			headAttestations[0].Data.BeaconBlockRootHash32)
 	}
-	if !bytes.Equal([]byte{'C'}, headAttestations[1].GetData().GetBeaconBlockRootHash32()) {
+	if !bytes.Equal([]byte{'C'}, headAttestations[1].Data.BeaconBlockRootHash32) {
 		t.Errorf("headAttestations[1] wanted hash [C], got slot %v",
-			headAttestations[1].GetData().GetBeaconBlockRootHash32())
+			headAttestations[1].Data.BeaconBlockRootHash32)
 	}
 }
 

--- a/beacon-chain/core/randao/randao.go
+++ b/beacon-chain/core/randao/randao.go
@@ -11,7 +11,7 @@ import (
 
 // UpdateRandaoLayers increments the randao layer of the block proposer at the given slot.
 func UpdateRandaoLayers(state *pb.BeaconState, slot uint64) (*pb.BeaconState, error) {
-	vreg := state.GetValidatorRegistry()
+	vreg := state.ValidatorRegistry
 
 	proposerIndex, err := v.BeaconProposerIndex(state, slot)
 	if err != nil {
@@ -28,7 +28,7 @@ func UpdateRandaoLayers(state *pb.BeaconState, slot uint64) (*pb.BeaconState, er
 func UpdateRandaoMixes(state *pb.BeaconState) *pb.BeaconState {
 	newState := proto.Clone(state).(*pb.BeaconState)
 	latestMixesLength := params.BeaconConfig().LatestRandaoMixesLength
-	prevMixes := state.LatestRandaoMixesHash32S[(newState.GetSlot()-1)%latestMixesLength]
-	newState.LatestRandaoMixesHash32S[state.GetSlot()%latestMixesLength] = prevMixes
+	prevMixes := state.LatestRandaoMixesHash32S[(newState.Slot-1)%latestMixesLength]
+	newState.LatestRandaoMixesHash32S[state.Slot%latestMixesLength] = prevMixes
 	return newState
 }

--- a/beacon-chain/core/randao/randao_test.go
+++ b/beacon-chain/core/randao/randao_test.go
@@ -30,15 +30,15 @@ func TestUpdateRandaoLayers(t *testing.T) {
 		t.Fatalf("failed to update randao layers: %v", err)
 	}
 
-	vreg := newState.GetValidatorRegistry()
+	vreg := newState.ValidatorRegistry
 
 	// Since slot 1 has proposer index 8
-	if vreg[8].GetRandaoLayers() != 1 {
-		t.Fatalf("randao layers not updated %d", vreg[9].GetRandaoLayers())
+	if vreg[8].RandaoLayers != 1 {
+		t.Fatalf("randao layers not updated %d", vreg[9].RandaoLayers)
 	}
 
-	if vreg[9].GetRandaoLayers() != 0 {
-		t.Errorf("randao layers updated when they were not supposed to %d", vreg[9].GetRandaoLayers())
+	if vreg[9].RandaoLayers != 0 {
+		t.Errorf("randao layers updated when they were not supposed to %d", vreg[9].RandaoLayers)
 	}
 }
 

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -170,11 +170,11 @@ func Hash(state *pb.BeaconState) ([32]byte, error) {
 //
 //   [0xF, 0x7, 0x5, 0x5, 0x5]
 func CalculateNewBlockHashes(state *pb.BeaconState, block *pb.BeaconBlock, parentSlot uint64) ([][]byte, error) {
-	distance := block.GetSlot() - parentSlot
-	existing := state.GetLatestBlockRootHash32S()
+	distance := block.Slot - parentSlot
+	existing := state.LatestBlockRootHash32S
 	update := existing[distance:]
 	for len(update) < 2*int(params.BeaconConfig().CycleLength) {
-		update = append(update, block.GetParentRootHash32())
+		update = append(update, block.ParentRootHash32)
 	}
 	return update, nil
 }
@@ -182,23 +182,23 @@ func CalculateNewBlockHashes(state *pb.BeaconState, block *pb.BeaconBlock, paren
 // IsValidatorSetChange checks if a validator set change transition can be processed. At that point,
 // validator shuffle will occur.
 func IsValidatorSetChange(state *pb.BeaconState, slotNumber uint64) bool {
-	if state.GetFinalizedSlot() <= state.GetValidatorRegistryLastChangeSlot() {
+	if state.FinalizedSlot <= state.ValidatorRegistryLastChangeSlot {
 		return false
 	}
-	if slotNumber-state.GetValidatorRegistryLastChangeSlot() < params.BeaconConfig().MinValidatorSetChangeInterval {
+	if slotNumber-state.ValidatorRegistryLastChangeSlot < params.BeaconConfig().MinValidatorSetChangeInterval {
 		return false
 	}
 
 	shardProcessed := map[uint64]bool{}
-	for _, shardAndCommittee := range state.GetShardAndCommitteesAtSlots() {
+	for _, shardAndCommittee := range state.ShardAndCommitteesAtSlots {
 		for _, committee := range shardAndCommittee.ArrayShardAndCommittee {
 			shardProcessed[committee.Shard] = true
 		}
 	}
 
-	crosslinks := state.GetLatestCrosslinks()
+	crosslinks := state.LatestCrosslinks
 	for shard := range shardProcessed {
-		if state.GetValidatorRegistryLastChangeSlot() >= crosslinks[shard].Slot {
+		if state.ValidatorRegistryLastChangeSlot >= crosslinks[shard].Slot {
 			return false
 		}
 	}

--- a/beacon-chain/core/state/state_test.go
+++ b/beacon-chain/core/state/state_test.go
@@ -191,17 +191,17 @@ func TestGenesisState_HashEquality(t *testing.T) {
 
 func TestGenesisState_InitializesLatestBlockHashes(t *testing.T) {
 	s, _ := InitialBeaconState(nil, 0, nil)
-	want, got := len(s.GetLatestBlockRootHash32S()), int(params.BeaconConfig().LatestBlockRootsLength)
+	want, got := len(s.LatestBlockRootHash32S), int(params.BeaconConfig().LatestBlockRootsLength)
 	if want != got {
 		t.Errorf("Wrong number of recent block hashes. Got: %d Want: %d", got, want)
 	}
 
-	want = cap(s.GetLatestBlockRootHash32S())
+	want = cap(s.LatestBlockRootHash32S)
 	if want != got {
 		t.Errorf("The slice underlying array capacity is wrong. Got: %d Want: %d", got, want)
 	}
 
-	for _, h := range s.GetLatestBlockRootHash32S() {
+	for _, h := range s.LatestBlockRootHash32S {
 		if !bytes.Equal(h, params.BeaconConfig().ZeroHash[:]) {
 			t.Errorf("Unexpected non-zero hash data: %v", h)
 		}
@@ -237,8 +237,8 @@ func TestUpdateLatestBlockHashes(t *testing.T) {
 			if !bytes.Equal(updated[i], []byte{0}) {
 				t.Fatalf("update failed: expected %#x got %#x", []byte{0}, updated[i])
 			}
-		} else if !bytes.Equal(updated[i], block.GetParentRootHash32()) {
-			t.Fatalf("update failed: expected %#x got %#x", block.GetParentRootHash32(), updated[i])
+		} else if !bytes.Equal(updated[i], block.ParentRootHash32) {
+			t.Fatalf("update failed: expected %#x got %#x", block.ParentRootHash32, updated[i])
 		}
 	}
 }
@@ -256,7 +256,7 @@ func TestCalculateNewBlockHashes_DoesNotMutateData(t *testing.T) {
 	original := make([][]byte, params.BeaconConfig().LatestBlockRootsLength)
 	copy(original, s.LatestBlockRootHash32S)
 
-	if !reflect.DeepEqual(s.GetLatestBlockRootHash32S(), original) {
+	if !reflect.DeepEqual(s.LatestBlockRootHash32S, original) {
 		t.Fatal("setup data should be equal!")
 	}
 
@@ -267,7 +267,7 @@ func TestCalculateNewBlockHashes_DoesNotMutateData(t *testing.T) {
 
 	result, _ := CalculateNewBlockHashes(s, block, 0 /*parentSlot*/)
 
-	if !reflect.DeepEqual(s.GetLatestBlockRootHash32S(), original) {
+	if !reflect.DeepEqual(s.LatestBlockRootHash32S, original) {
 		t.Error("data has mutated from the original")
 	}
 

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -27,11 +27,10 @@ func ExecuteStateTransition(
 	var err error
 
 	newState := proto.Clone(beaconState).(*pb.BeaconState)
-
-	currentSlot := newState.GetSlot()
+	currentSlot := newState.Slot
 	newState.Slot = currentSlot + 1
 
-	newState, err = randao.UpdateRandaoLayers(newState, newState.GetSlot())
+	newState, err = randao.UpdateRandaoLayers(newState, newState.Slot)
 	if err != nil {
 		return nil, fmt.Errorf("unable to update randao layer %v", err)
 	}
@@ -51,7 +50,7 @@ func ExecuteStateTransition(
 		if err != nil {
 			return nil, fmt.Errorf("unable to process block: %v", err)
 		}
-		if newState.GetSlot()%params.BeaconConfig().EpochLength == 0 {
+		if newState.Slot%params.BeaconConfig().EpochLength == 0 {
 			newState = NewEpochTransition(newState)
 		}
 	}
@@ -64,11 +63,11 @@ func ExecuteStateTransition(
 // processing block attestations, and more.
 func ProcessBlock(state *pb.BeaconState, block *pb.BeaconBlock) (*pb.BeaconState, error) {
 	newState := proto.Clone(state).(*pb.BeaconState)
-	if block.GetSlot() != state.GetSlot() {
+	if block.Slot != state.Slot {
 		return nil, fmt.Errorf(
 			"block.slot != state.slot, block.slot = %d, state.slot = %d",
-			block.GetSlot(),
-			newState.GetSlot(),
+			block.Slot,
+			newState.Slot,
 		)
 	}
 	// TODO(#781): Verify Proposer Signature.

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -116,7 +116,7 @@ func BeaconProposerIndex(state *pb.BeaconState, slot uint64) (uint32, error) {
 	if err != nil {
 		return 0, err
 	}
-	firstCommittee := committeeArray.GetArrayShardAndCommittee()[0].Committee
+	firstCommittee := committeeArray.ArrayShardAndCommittee[0].Committee
 
 	return firstCommittee[slot%uint64(len(firstCommittee))], nil
 }
@@ -231,7 +231,7 @@ func VotedBalanceInAttestation(validators []*pb.ValidatorRecord, indices []uint3
 	var voteBalance uint64
 	for index, attesterIndex := range indices {
 		// find balance of validators who voted.
-		bitCheck, err := bitutil.CheckBit(attestation.GetParticipationBitfield(), index)
+		bitCheck, err := bitutil.CheckBit(attestation.ParticipationBitfield, index)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -466,7 +466,7 @@ func ProcessDeposit(
 	var publicKeyExists bool
 	var existingValidatorIndex int
 	for idx, val := range state.ValidatorRegistry {
-		if bytes.Equal(val.GetPubkey(), pubkey) {
+		if bytes.Equal(val.Pubkey, pubkey) {
 			publicKeyExists = true
 			existingValidatorIndex = idx
 		}
@@ -479,7 +479,7 @@ func ProcessDeposit(
 			RandaoCommitmentHash32:  randaoCommitment,
 			RandaoLayers:            0,
 			Status:                  pb.ValidatorRecord_PENDING_ACTIVATION,
-			LatestStatusChangeSlot:  state.GetSlot(),
+			LatestStatusChangeSlot:  state.Slot,
 			ExitCount:               0,
 			PocCommitmentHash32:     pocCommitment,
 			LastPocChangeSlot:       0,
@@ -488,7 +488,7 @@ func ProcessDeposit(
 		idx, ok := minEmptyValidatorIndex(
 			state.ValidatorRegistry,
 			state.ValidatorBalances,
-			state.GetSlot(),
+			state.Slot,
 		)
 		// In the case there is no empty validator index in the state,
 		// we append an entirely new record to the validator registry and list
@@ -527,7 +527,7 @@ func minEmptyValidatorIndex(
 	currentSlot uint64,
 ) (int, bool) {
 	for i := range validators {
-		lastStatusChange := validators[i].GetLatestStatusChangeSlot()
+		lastStatusChange := validators[i].LatestStatusChangeSlot
 		ttlWindow := lastStatusChange + params.BeaconConfig().ZeroBalanceValidatorTTL
 		if balances[i] == 0 && ttlWindow <= currentSlot {
 			return i, true

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -18,8 +18,8 @@ func TestHasVoted(t *testing.T) {
 		ParticipationBitfield: []byte{255},
 	}
 
-	for i := 0; i < len(pendingAttestation.GetParticipationBitfield()); i++ {
-		voted, err := bitutil.CheckBit(pendingAttestation.GetParticipationBitfield(), i)
+	for i := 0; i < len(pendingAttestation.ParticipationBitfield); i++ {
+		voted, err := bitutil.CheckBit(pendingAttestation.ParticipationBitfield, i)
 		if err != nil {
 			t.Errorf("checking bit failed at index: %d with : %v", i, err)
 		}
@@ -34,8 +34,8 @@ func TestHasVoted(t *testing.T) {
 		ParticipationBitfield: []byte{85},
 	}
 
-	for i := 0; i < len(pendingAttestation.GetParticipationBitfield()); i++ {
-		voted, err := bitutil.CheckBit(pendingAttestation.GetParticipationBitfield(), i)
+	for i := 0; i < len(pendingAttestation.ParticipationBitfield); i++ {
+		voted, err := bitutil.CheckBit(pendingAttestation.ParticipationBitfield, i)
 		if err != nil {
 			t.Errorf("checking bit failed at index: %d : %v", i, err)
 		}
@@ -52,8 +52,8 @@ func TestHasVoted(t *testing.T) {
 func TestInitialValidatorRegistry(t *testing.T) {
 	validators := InitialValidatorRegistry()
 	for _, validator := range validators {
-		if validator.GetStatus() != pb.ValidatorRecord_ACTIVE {
-			t.Errorf("validator status is not active: %d", validator.GetStatus())
+		if validator.Status != pb.ValidatorRecord_ACTIVE {
+			t.Errorf("validator status is not active: %d", validator.Status)
 		}
 	}
 }

--- a/beacon-chain/db/attestation.go
+++ b/beacon-chain/db/attestation.go
@@ -11,7 +11,7 @@ import (
 
 // SaveAttestation puts the attestation record into the beacon chain db.
 func (db *BeaconDB) SaveAttestation(attestation *pb.Attestation) error {
-	hash := att.Key(attestation.GetData())
+	hash := att.Key(attestation.Data)
 	encodedState, err := proto.Marshal(attestation)
 	if err != nil {
 		return err

--- a/beacon-chain/db/block_test.go
+++ b/beacon-chain/db/block_test.go
@@ -193,8 +193,8 @@ func TestChainProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get chain head: %v", err)
 	}
-	if heighestBlock.GetSlot() != block1.GetSlot() {
-		t.Fatalf("expected height to equal %d, got %d", block1.GetSlot(), heighestBlock.GetSlot())
+	if heighestBlock.Slot != block1.Slot {
+		t.Fatalf("expected height to equal %d, got %d", block1.Slot, heighestBlock.Slot)
 	}
 
 	block2 := &pb.BeaconBlock{Slot: cycleLength}
@@ -208,8 +208,8 @@ func TestChainProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get block: %v", err)
 	}
-	if heighestBlock.GetSlot() != block2.GetSlot() {
-		t.Fatalf("expected height to equal %d, got %d", block2.GetSlot(), heighestBlock.GetSlot())
+	if heighestBlock.Slot != block2.Slot {
+		t.Fatalf("expected height to equal %d, got %d", block2.Slot, heighestBlock.Slot)
 	}
 
 	block3 := &pb.BeaconBlock{Slot: 3}
@@ -223,7 +223,7 @@ func TestChainProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get chain head: %v", err)
 	}
-	if heighestBlock.GetSlot() != block3.GetSlot() {
-		t.Fatalf("expected height to equal %d, got %d", block3.GetSlot(), heighestBlock.GetSlot())
+	if heighestBlock.Slot != block3.Slot {
+		t.Fatalf("expected height to equal %d, got %d", block3.Slot, heighestBlock.Slot)
 	}
 }

--- a/beacon-chain/dbcleanup/service.go
+++ b/beacon-chain/dbcleanup/service.go
@@ -79,7 +79,7 @@ func (d *CleanupService) cleanDB() {
 			log.Debug("Cleanup service context closed, exiting goroutine")
 			return
 		case cState := <-d.canonicalStateChan:
-			if err := d.cleanBlockVoteCache(cState.GetFinalizedSlot()); err != nil {
+			if err := d.cleanBlockVoteCache(cState.FinalizedSlot); err != nil {
 				log.Errorf("Failed to clean block vote cache: %v", err)
 			}
 		}

--- a/beacon-chain/dbcleanup/service_test.go
+++ b/beacon-chain/dbcleanup/service_test.go
@@ -97,7 +97,7 @@ func TestCleanBlockVoteCache(t *testing.T) {
 	// Now let the cleanup service do its job
 	cleanupService := createCleanupService(beaconDB)
 	state := &pb.BeaconState{FinalizedSlot: 1}
-	if err = cleanupService.cleanBlockVoteCache(state.GetFinalizedSlot()); err != nil {
+	if err = cleanupService.cleanBlockVoteCache(state.FinalizedSlot); err != nil {
 		t.Fatalf("failed to clean block vote cache")
 	}
 

--- a/beacon-chain/simulator/service.go
+++ b/beacon-chain/simulator/service.go
@@ -233,7 +233,7 @@ func (sim *Simulator) processBlockReqByHash(msg p2p.Message) {
 	res := &pb.BeaconBlockResponse{Block: block, Attestation: &pb.Attestation{
 		ParticipationBitfield: []byte{byte(255)},
 		Data: &pb.AttestationData{
-			Slot: block.GetSlot(),
+			Slot: block.Slot,
 		},
 	}}
 	sim.p2p.Send(res, msg.Peer)
@@ -242,23 +242,23 @@ func (sim *Simulator) processBlockReqByHash(msg p2p.Message) {
 func (sim *Simulator) processBlockReqBySlot(msg p2p.Message) {
 	data := msg.Data.(*pb.BeaconBlockRequestBySlotNumber)
 
-	block := sim.broadcastedBlocksBySlot[data.GetSlotNumber()]
+	block := sim.broadcastedBlocksBySlot[data.SlotNumber]
 	if block == nil {
 		log.WithFields(logrus.Fields{
-			"slot": fmt.Sprintf("%d", data.GetSlotNumber()),
+			"slot": fmt.Sprintf("%d", data.SlotNumber),
 		}).Debug("Requested block not found:")
 		return
 	}
 
 	log.WithFields(logrus.Fields{
-		"slot": fmt.Sprintf("%d", data.GetSlotNumber()),
+		"slot": fmt.Sprintf("%d", data.SlotNumber),
 	}).Debug("Responding to full block request")
 
 	// Sends the full block body to the requester.
 	res := &pb.BeaconBlockResponse{Block: block, Attestation: &pb.Attestation{
 		ParticipationBitfield: []byte{byte(255)},
 		Data: &pb.AttestationData{
-			Slot: block.GetSlot(),
+			Slot: block.Slot,
 		},
 	}}
 	sim.p2p.Send(res, msg.Peer)
@@ -279,9 +279,9 @@ func (sim *Simulator) processStateRequest(msg p2p.Message) {
 		return
 	}
 
-	if !bytes.Equal(data.GetHash(), hash[:]) {
+	if !bytes.Equal(data.Hash, hash[:]) {
 		log.WithFields(logrus.Fields{
-			"hash": fmt.Sprintf("%#x", data.GetHash()),
+			"hash": fmt.Sprintf("%#x", data.Hash),
 		}).Debug("Requested beacon state is of a different hash")
 		return
 	}
@@ -300,8 +300,8 @@ func (sim *Simulator) processStateRequest(msg p2p.Message) {
 
 func (sim *Simulator) processBatchRequest(msg p2p.Message) {
 	data := msg.Data.(*pb.BatchedBeaconBlockRequest)
-	startSlot := data.GetStartSlot()
-	endSlot := data.GetEndSlot()
+	startSlot := data.StartSlot
+	endSlot := data.EndSlot
 
 	if endSlot <= startSlot {
 		log.Debugf("invalid batch request: end slot <= start slot, received %d < %d", endSlot, startSlot)
@@ -401,7 +401,7 @@ func (sim *Simulator) SendChainHead(peer p2p.Peer) error {
 
 	res := &pb.ChainHeadResponse{
 		Hash:  hash[:],
-		Slot:  block.GetSlot(),
+		Slot:  block.Slot,
 		Block: block,
 	}
 

--- a/beacon-chain/simulator/service_test.go
+++ b/beacon-chain/simulator/service_test.go
@@ -32,7 +32,7 @@ func (mp *mockP2P) Subscribe(msg proto.Message, channel chan p2p.Message) event.
 }
 
 func (mp *mockP2P) Broadcast(msg proto.Message) {
-	mp.broadcastHash = msg.(*pb.BeaconBlockAnnounce).GetHash()
+	mp.broadcastHash = msg.(*pb.BeaconBlockAnnounce).Hash
 }
 
 func (mp *mockP2P) Send(msg proto.Message, peer p2p.Peer) {}

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -213,8 +213,8 @@ func TestSavingBlocksInSync(t *testing.T) {
 	msg1 = getBlockResponseMsg(30)
 	ss.blockBuf <- msg1
 
-	if stateResponse.BeaconState.GetFinalizedSlot() != ss.currentSlot {
-		t.Fatalf("Slot saved when it was not supposed too: %v", stateResponse.BeaconState.GetFinalizedSlot())
+	if stateResponse.BeaconState.FinalizedSlot != ss.currentSlot {
+		t.Fatalf("Slot saved when it was not supposed too: %v", stateResponse.BeaconState.FinalizedSlot)
 	}
 
 	msg1 = getBlockResponseMsg(100)
@@ -224,7 +224,7 @@ func TestSavingBlocksInSync(t *testing.T) {
 	<-exitRoutine
 
 	br := msg1.Data.(*pb.BeaconBlockResponse)
-	if br.Block.GetSlot() != ss.currentSlot {
+	if br.Block.Slot != ss.currentSlot {
 		t.Fatalf("Slot not updated despite receiving a valid block: %v", ss.currentSlot)
 	}
 

--- a/beacon-chain/sync/querier.go
+++ b/beacon-chain/sync/querier.go
@@ -119,7 +119,7 @@ func (q *Querier) IsSynced() (bool, error) {
 		return false, err
 	}
 
-	if block.GetSlot() >= q.curentHeadSlot {
+	if block.Slot >= q.curentHeadSlot {
 		return true, nil
 	}
 

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -235,8 +235,14 @@ func TestProcessMultipleBlocks(t *testing.T) {
 	}
 
 	responseBlock1 := &pb.BeaconBlockResponse{
-		Block:       data1,
-		Attestation: &pb.Attestation{},
+		Block: data1,
+		Attestation: &pb.Attestation{
+			Data: &pb.AttestationData{
+				ShardBlockRootHash32: []byte{},
+				Slot:                 0,
+				JustifiedSlot:        0,
+			},
+		},
 	}
 
 	msg1 := p2p.Message{
@@ -252,8 +258,14 @@ func TestProcessMultipleBlocks(t *testing.T) {
 	}
 
 	responseBlock2 := &pb.BeaconBlockResponse{
-		Block:       data2,
-		Attestation: &pb.Attestation{},
+		Block: data2,
+		Attestation: &pb.Attestation{
+			Data: &pb.AttestationData{
+				ShardBlockRootHash32: []byte{},
+				Slot:                 0,
+				JustifiedSlot:        0,
+			},
+		},
 	}
 
 	msg2 := p2p.Message{

--- a/shared/prometheus/service.go
+++ b/shared/prometheus/service.go
@@ -51,7 +51,10 @@ func (s *Service) healthzHandler(w http.ResponseWriter, r *http.Request) {
 			hasError = true
 			status = "ERROR " + v.Error()
 		}
-		buf.WriteString(fmt.Sprintf("%s: %s\n", k, status))
+		if _, err := buf.WriteString(fmt.Sprintf("%s: %s\n", k, status)); err != nil {
+			hasError = true
+			status = "ERROR " + err.Error()
+		}
 	}
 
 	// Write status header

--- a/validator/attester/service.go
+++ b/validator/attester/service.go
@@ -129,7 +129,7 @@ func (a *Attester) run(attester pb.AttesterServiceClient, validator pb.Validator
 					ParticipationBitfield: attesterBitfield,
 					AggregateSignature:    []byte{}, // TODO(258): Need Signature verification scheme/library
 					Data: &pbp2p.AttestationData{
-						Slot:                 latestBeaconBlock.GetSlot(),
+						Slot:                 latestBeaconBlock.Slot,
 						Shard:                a.shardID,
 						ShardBlockRootHash32: latestBlockHash[:],
 					},

--- a/validator/beacon/service.go
+++ b/validator/beacon/service.go
@@ -126,7 +126,7 @@ func (s *Service) fetchCurrentAssignmentsAndGenesisTime(client pb.BeaconServiceC
 
 	// Determine what slot the beacon node is in by checking the number of seconds
 	// since the genesis block.
-	genesisTimestamp, err := ptypes.TimestampFromProto(res.GetGenesisTimestamp())
+	genesisTimestamp, err := ptypes.TimestampFromProto(res.GenesisTimestamp)
 	if err != nil {
 		return fmt.Errorf("could not compute genesis timestamp: %v", err)
 	}
@@ -234,7 +234,7 @@ func (s *Service) listenForProcessedAttestations(client pb.BeaconServiceClient) 
 			continue
 		}
 
-		log.WithField("slotNumber", attestation.GetData().GetSlot()).Info("Latest attestation slot number")
+		log.WithField("slotNumber", attestation.Data.Slot).Info("Latest attestation slot number")
 		s.processedAttestationFeed.Send(attestation)
 	}
 }

--- a/validator/proposer/service.go
+++ b/validator/proposer/service.go
@@ -97,7 +97,7 @@ func (p *Proposer) Status() error {
 func (p *Proposer) DoesAttestationExist(attestation *pbp2p.Attestation) bool {
 	exists := false
 	for _, record := range p.pendingAttestation {
-		if bytes.Equal(record.GetParticipationBitfield(), attestation.GetParticipationBitfield()) {
+		if bytes.Equal(record.ParticipationBitfield, attestation.ParticipationBitfield) {
 			exists = true
 			break
 		}

--- a/validator/proposer/service_test.go
+++ b/validator/proposer/service_test.go
@@ -174,8 +174,8 @@ func TestProposerProcessAttestation(t *testing.T) {
 	testutil.AssertLogsContain(t, hook, "Attestation stored in memory")
 	testutil.AssertLogsContain(t, hook, "Proposer context closed")
 
-	if !bytes.Equal(p.pendingAttestation[2].GetParticipationBitfield(), []byte{'c'}) {
-		t.Errorf("attestation was unable to be saved %v", p.pendingAttestation[2].GetParticipationBitfield())
+	if !bytes.Equal(p.pendingAttestation[2].ParticipationBitfield, []byte{'c'}) {
+		t.Errorf("attestation was unable to be saved %v", p.pendingAttestation[2].ParticipationBitfield)
 	}
 }
 


### PR DESCRIPTION
This resolves #1234.

---

# Description

This PR removes usage of proto's generated `.GetX` functions, which copy data and lead to inefficiencies where we could just access the real pointer value directly. This removes all instances across Prysm's core code.
