### PR TITLE
Update .travis.yml to use go1.11 to run coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
         - 
           go get github.com/alecthomas/gometalinter && gometalinter --install && gometalinter ./...
     - os: linux
+      go: 1.11.x
       env:
         - coverage
       script:


### PR DESCRIPTION
https://github.com/libp2p/go-reuseport/issues/58