### PR TITLE
Reformat Configs for Readability 

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -207,7 +207,7 @@ func (c *ChainService) updateHead(processedBlock <-chan *pb.BeaconBlock) {
 			// server to stream these events to beacon clients.
 			// When the transition is a cycle transition, we stream the state containing the new validator
 			// assignments to clients.
-			if block.Slot%params.BeaconConfig().CycleLength == 0 {
+			if block.Slot%params.BeaconConfig().EpochLength == 0 {
 				c.canonicalStateFeed.Send(newState)
 			}
 			c.canonicalBlockFeed.Send(newHead)
@@ -333,10 +333,6 @@ func (c *ChainService) receiveBlock(block *pb.BeaconBlock) error {
 	beaconState, err = state.ExecuteStateTransition(beaconState, block, blockRoot)
 	if err != nil {
 		return fmt.Errorf("could not execute state transition %v", err)
-	}
-
-	if state.IsValidatorSetChange(beaconState, block.Slot) {
-		log.WithField("slotNumber", block.Slot).Info("Validator set rotation occurred")
 	}
 
 	// TODO(#1074): Verify block.state_root == hash_tree_root(state)

--- a/beacon-chain/chaintest/backend/simulated_backend.go
+++ b/beacon-chain/chaintest/backend/simulated_backend.go
@@ -59,7 +59,7 @@ func (sb *SimulatedBackend) RunChainTest(testCase *ChainTestCase) error {
 	// test language specification.
 	c := params.BeaconConfig()
 	c.ShardCount = testCase.Config.ShardCount
-	c.CycleLength = testCase.Config.CycleLength
+	c.EpochLength = testCase.Config.CycleLength
 	c.TargetCommitteeSize = testCase.Config.MinCommitteeSize
 	params.OverrideBeaconConfig(c)
 

--- a/beacon-chain/core/attestations/attestation.go
+++ b/beacon-chain/core/attestations/attestation.go
@@ -20,7 +20,7 @@ func CreateAttestationMsg(
 ) [32]byte {
 	msg := make([]byte, binary.MaxVarintLen64)
 	binary.BigEndian.PutUint64(msg, forkVersion)
-	binary.PutUvarint(msg, slot%params.BeaconConfig().CycleLength)
+	binary.PutUvarint(msg, slot%params.BeaconConfig().EpochLength)
 	binary.PutUvarint(msg, shardID)
 	msg = append(msg, blockHash...)
 	binary.PutUvarint(msg, justifiedSlot)

--- a/beacon-chain/core/balances/rewards_penalties_test.go
+++ b/beacon-chain/core/balances/rewards_penalties_test.go
@@ -42,7 +42,7 @@ func TestBaseReward(t *testing.T) {
 		b uint64
 	}{
 		{0, 0},
-		{params.BeaconConfig().MinOnlineDepositSize * params.BeaconConfig().Gwei, 988},
+		{params.BeaconConfig().MinDepositinGwei, 61},
 		{30 * 1e9, 1853},
 		{params.BeaconConfig().MaxDepositInGwei, 1976},
 		{40 * 1e9, 1976},

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -528,8 +528,6 @@ func verifyAttestation(beaconState *pb.BeaconState, att *pb.Attestation) error {
 //
 //     Verify deposit merkle_branch, setting leaf=serialized_deposit_data,
 //     depth=DEPOSIT_CONTRACT_TREE_DEPTH and root=state.processed_pow_receipt_root:
-//     Verify that state.slot - (deposit.deposit_data.timestamp -
-//     state.genesis_time)  SLOT_DURATION < ZERO_BALANCE_VALIDATOR_TTL.
 //
 //     Run the following:
 //     process_deposit(
@@ -627,24 +625,6 @@ func verifyDeposit(beaconState *pb.BeaconState, deposit *pb.Deposit) error {
 		)
 	}
 
-	// We unmarshal the timestamp bytes into a time.Time value for us to use.
-	depositTimestampBytes := depositData[len(depositData)-8:]
-	depositUnixTime := int64(binary.BigEndian.Uint64(depositTimestampBytes))
-
-	// Parse beacon state's genesis time from a uint32 into a unix timestamp.
-	genesisUnixTime := int64(beaconState.GenesisTime)
-	depositGenesisTimeDifference := depositUnixTime - genesisUnixTime
-	timeToLive := uint64(depositGenesisTimeDifference) / params.BeaconConfig().SlotDuration
-
-	// Verify current slot slot - allowed validator TTL is within the allowed boundary.
-	if beaconState.Slot-timeToLive < params.BeaconConfig().ZeroBalanceValidatorTTL {
-		return fmt.Errorf(
-			"want state.slot - (deposit.time - genesis_time) // SLOT_DURATION > %d, received %d < %d",
-			params.BeaconConfig().ZeroBalanceValidatorTTL,
-			beaconState.Slot-timeToLive,
-			params.BeaconConfig().ZeroBalanceValidatorTTL,
-		)
-	}
 	return nil
 }
 

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -177,34 +177,8 @@ func CalculateNewBlockHashes(state *pb.BeaconState, block *pb.BeaconBlock, paren
 	distance := block.Slot - parentSlot
 	existing := state.LatestBlockRootHash32S
 	update := existing[distance:]
-	for len(update) < 2*int(params.BeaconConfig().CycleLength) {
+	for len(update) < 2*int(params.BeaconConfig().EpochLength) {
 		update = append(update, block.ParentRootHash32)
 	}
 	return update, nil
-}
-
-// IsValidatorSetChange checks if a validator set change transition can be processed. At that point,
-// validator shuffle will occur.
-func IsValidatorSetChange(state *pb.BeaconState, slotNumber uint64) bool {
-	if state.FinalizedSlot <= state.ValidatorRegistryLastChangeSlot {
-		return false
-	}
-	if slotNumber-state.ValidatorRegistryLastChangeSlot < params.BeaconConfig().MinValidatorSetChangeInterval {
-		return false
-	}
-
-	shardProcessed := map[uint64]bool{}
-	for _, shardAndCommittee := range state.ShardAndCommitteesAtSlots {
-		for _, committee := range shardAndCommittee.ArrayShardAndCommittee {
-			shardProcessed[committee.Shard] = true
-		}
-	}
-
-	crosslinks := state.LatestCrosslinks
-	for shard := range shardProcessed {
-		if state.ValidatorRegistryLastChangeSlot >= crosslinks[shard].Slot {
-			return false
-		}
-	}
-	return true
 }

--- a/beacon-chain/core/state/state_test.go
+++ b/beacon-chain/core/state/state_test.go
@@ -23,12 +23,12 @@ func TestInitialBeaconState_Ok(t *testing.T) {
 	if params.BeaconConfig().GenesisSlot != 0 {
 		t.Error("GenesisSlot should be 0 for these tests to pass")
 	}
-	initialSlotNumber := params.BeaconConfig().InitialForkSlot
+	initialSlotNumber := params.BeaconConfig().GenesisSlot
 
-	if params.BeaconConfig().InitialForkSlot != 0 {
+	if params.BeaconConfig().GenesisForkVersion != 0 {
 		t.Error("InitialForkSlot should be 0 for these tests to pass")
 	}
-	initialForkVersion := params.BeaconConfig().InitialForkSlot
+	initialForkVersion := params.BeaconConfig().GenesisForkVersion
 
 	if params.BeaconConfig().ZeroHash != [32]byte{} {
 		t.Error("ZeroHash should be all 0s for these tests to pass")
@@ -230,8 +230,8 @@ func TestUpdateLatestBlockHashes(t *testing.T) {
 		ParentRootHash32: []byte{'A'},
 	}
 
-	recentBlockHashes := make([][]byte, 2*int(params.BeaconConfig().CycleLength))
-	for i := 0; i < 2*int(params.BeaconConfig().CycleLength); i++ {
+	recentBlockHashes := make([][]byte, 2*int(params.BeaconConfig().EpochLength))
+	for i := 0; i < 2*int(params.BeaconConfig().EpochLength); i++ {
 		recentBlockHashes[i] = []byte{0}
 	}
 
@@ -244,8 +244,8 @@ func TestUpdateLatestBlockHashes(t *testing.T) {
 		t.Fatalf("failed to update recent blockhashes: %v", err)
 	}
 
-	if len(updated) != 2*int(params.BeaconConfig().CycleLength) {
-		t.Fatalf("length of updated recent blockhashes should be %d: found %d", params.BeaconConfig().CycleLength, len(updated))
+	if len(updated) != 2*int(params.BeaconConfig().EpochLength) {
+		t.Fatalf("length of updated recent blockhashes should be %d: found %d", params.BeaconConfig().EpochLength, len(updated))
 	}
 
 	for i := 0; i < len(updated); i++ {

--- a/beacon-chain/core/validators/committees.go
+++ b/beacon-chain/core/validators/committees.go
@@ -34,7 +34,7 @@ func splitBySlotShard(shuffledValidatorRegistry []uint32, crosslinkStartShard ui
 	committeBySlotAndShard := []*pb.ShardAndCommitteeArray{}
 
 	// split the validator indices by slot.
-	validatorsBySlot := utils.SplitIndices(shuffledValidatorRegistry, params.BeaconConfig().CycleLength)
+	validatorsBySlot := utils.SplitIndices(shuffledValidatorRegistry, params.BeaconConfig().EpochLength)
 	for i, validatorsForSlot := range validatorsBySlot {
 		shardCommittees := []*pb.ShardAndCommittee{}
 		validatorsByShard := utils.SplitIndices(validatorsForSlot, committeesPerSlot)
@@ -61,7 +61,7 @@ func splitBySlotShard(shuffledValidatorRegistry []uint32, crosslinkStartShard ui
 // numActiveValidatorRegistry / CycleLength /  (MinCommitteeSize*2) + 1 or
 // ShardCount / CycleLength.
 func getCommitteesPerSlot(numActiveValidatorRegistry uint64) uint64 {
-	cycleLength := params.BeaconConfig().CycleLength
+	cycleLength := params.BeaconConfig().EpochLength
 	boundOnValidatorRegistry := numActiveValidatorRegistry/cycleLength/(params.BeaconConfig().TargetCommitteeSize*2) + 1
 	boundOnShardCount := params.BeaconConfig().ShardCount / cycleLength
 	// Ensure that comitteesPerSlot is at least 1.

--- a/beacon-chain/core/validators/committees_test.go
+++ b/beacon-chain/core/validators/committees_test.go
@@ -81,8 +81,8 @@ func TestShuffleActiveValidatorRegistry(t *testing.T) {
 	if err != nil {
 		t.Errorf("validatorsBySlotShard failed with %v:", err)
 	}
-	if len(indices) != int(params.BeaconConfig().CycleLength) {
-		t.Errorf("incorret length for validator indices. Want: %d. Got: %v", params.BeaconConfig().CycleLength, len(indices))
+	if len(indices) != int(params.BeaconConfig().EpochLength) {
+		t.Errorf("incorret length for validator indices. Want: %d. Got: %v", params.BeaconConfig().EpochLength, len(indices))
 	}
 }
 
@@ -98,13 +98,13 @@ func TestSmallSampleValidatorRegistry(t *testing.T) {
 	if err != nil {
 		t.Errorf("validatorsBySlotShard failed with %v:", err)
 	}
-	if len(indices) != int(params.BeaconConfig().CycleLength) {
-		t.Errorf("incorret length for validator indices. Want: %d. Got: %d", params.BeaconConfig().CycleLength, len(indices))
+	if len(indices) != int(params.BeaconConfig().EpochLength) {
+		t.Errorf("incorret length for validator indices. Want: %d. Got: %d", params.BeaconConfig().EpochLength, len(indices))
 	}
 }
 
 func TestGetCommitteesPerSlotSmallValidatorSet(t *testing.T) {
-	numValidatorRegistry := params.BeaconConfig().CycleLength * params.BeaconConfig().TargetCommitteeSize / 4
+	numValidatorRegistry := params.BeaconConfig().EpochLength * params.BeaconConfig().TargetCommitteeSize / 4
 
 	committesPerSlot := getCommitteesPerSlot(numValidatorRegistry)
 	if committesPerSlot != 1 {
@@ -113,7 +113,7 @@ func TestGetCommitteesPerSlotSmallValidatorSet(t *testing.T) {
 }
 
 func TestGetCommitteesPerSlotRegularValidatorSet(t *testing.T) {
-	numValidatorRegistry := params.BeaconConfig().CycleLength * params.BeaconConfig().TargetCommitteeSize
+	numValidatorRegistry := params.BeaconConfig().EpochLength * params.BeaconConfig().TargetCommitteeSize
 
 	committesPerSlot := getCommitteesPerSlot(numValidatorRegistry)
 	if committesPerSlot != 1 {
@@ -122,7 +122,7 @@ func TestGetCommitteesPerSlotRegularValidatorSet(t *testing.T) {
 }
 
 func TestGetCommitteesPerSlotLargeValidatorSet(t *testing.T) {
-	numValidatorRegistry := params.BeaconConfig().CycleLength * params.BeaconConfig().TargetCommitteeSize * 8
+	numValidatorRegistry := params.BeaconConfig().EpochLength * params.BeaconConfig().TargetCommitteeSize * 8
 
 	committesPerSlot := getCommitteesPerSlot(numValidatorRegistry)
 	if committesPerSlot != 5 {
@@ -133,9 +133,9 @@ func TestGetCommitteesPerSlotLargeValidatorSet(t *testing.T) {
 func TestGetCommitteesPerSlotSmallShardCount(t *testing.T) {
 	config := params.BeaconConfig()
 	oldShardCount := config.ShardCount
-	config.ShardCount = config.CycleLength - 1
+	config.ShardCount = config.EpochLength - 1
 
-	numValidatorRegistry := params.BeaconConfig().CycleLength * params.BeaconConfig().TargetCommitteeSize
+	numValidatorRegistry := params.BeaconConfig().EpochLength * params.BeaconConfig().TargetCommitteeSize
 
 	committesPerSlot := getCommitteesPerSlot(numValidatorRegistry)
 	if committesPerSlot != 1 {
@@ -147,15 +147,15 @@ func TestGetCommitteesPerSlotSmallShardCount(t *testing.T) {
 
 func TestValidatorRegistryBySlotShardRegularValidatorSet(t *testing.T) {
 	validatorIndices := []uint32{}
-	numValidatorRegistry := int(params.BeaconConfig().CycleLength * params.BeaconConfig().TargetCommitteeSize)
+	numValidatorRegistry := int(params.BeaconConfig().EpochLength * params.BeaconConfig().TargetCommitteeSize)
 	for i := 0; i < numValidatorRegistry; i++ {
 		validatorIndices = append(validatorIndices, uint32(i))
 	}
 
 	shardAndCommitteeArray := splitBySlotShard(validatorIndices, 0)
 
-	if len(shardAndCommitteeArray) != int(params.BeaconConfig().CycleLength) {
-		t.Fatalf("Expected length %d: got %d", params.BeaconConfig().CycleLength, len(shardAndCommitteeArray))
+	if len(shardAndCommitteeArray) != int(params.BeaconConfig().EpochLength) {
+		t.Fatalf("Expected length %d: got %d", params.BeaconConfig().EpochLength, len(shardAndCommitteeArray))
 	}
 
 	for i := 0; i < len(shardAndCommitteeArray); i++ {
@@ -173,15 +173,15 @@ func TestValidatorRegistryBySlotShardRegularValidatorSet(t *testing.T) {
 
 func TestValidatorRegistryBySlotShardLargeValidatorSet(t *testing.T) {
 	validatorIndices := []uint32{}
-	numValidatorRegistry := int(params.BeaconConfig().CycleLength*params.BeaconConfig().TargetCommitteeSize) * 2
+	numValidatorRegistry := int(params.BeaconConfig().EpochLength*params.BeaconConfig().TargetCommitteeSize) * 2
 	for i := 0; i < numValidatorRegistry; i++ {
 		validatorIndices = append(validatorIndices, uint32(i))
 	}
 
 	shardAndCommitteeArray := splitBySlotShard(validatorIndices, 0)
 
-	if len(shardAndCommitteeArray) != int(params.BeaconConfig().CycleLength) {
-		t.Fatalf("Expected length %d: got %d", params.BeaconConfig().CycleLength, len(shardAndCommitteeArray))
+	if len(shardAndCommitteeArray) != int(params.BeaconConfig().EpochLength) {
+		t.Fatalf("Expected length %d: got %d", params.BeaconConfig().EpochLength, len(shardAndCommitteeArray))
 	}
 
 	for i := 0; i < len(shardAndCommitteeArray); i++ {
@@ -205,15 +205,15 @@ func TestValidatorRegistryBySlotShardLargeValidatorSet(t *testing.T) {
 
 func TestValidatorRegistryBySlotShardSmallValidatorSet(t *testing.T) {
 	validatorIndices := []uint32{}
-	numValidatorRegistry := int(params.BeaconConfig().CycleLength*params.BeaconConfig().TargetCommitteeSize) / 2
+	numValidatorRegistry := int(params.BeaconConfig().EpochLength*params.BeaconConfig().TargetCommitteeSize) / 2
 	for i := 0; i < numValidatorRegistry; i++ {
 		validatorIndices = append(validatorIndices, uint32(i))
 	}
 
 	shardAndCommitteeArray := splitBySlotShard(validatorIndices, 0)
 
-	if len(shardAndCommitteeArray) != int(params.BeaconConfig().CycleLength) {
-		t.Fatalf("Expected length %d: got %d", params.BeaconConfig().CycleLength, len(shardAndCommitteeArray))
+	if len(shardAndCommitteeArray) != int(params.BeaconConfig().EpochLength) {
+		t.Fatalf("Expected length %d: got %d", params.BeaconConfig().EpochLength, len(shardAndCommitteeArray))
 	}
 
 	for i := 0; i < len(shardAndCommitteeArray); i++ {

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -24,8 +24,8 @@ func InitialValidatorRegistry() []*pb.ValidatorRecord {
 	config := params.BeaconConfig()
 	randaoPreCommit := [32]byte{}
 	randaoReveal := hashutil.Hash(randaoPreCommit[:])
-	validators := make([]*pb.ValidatorRecord, config.BootstrappedValidatorsCount)
-	for i := uint64(0); i < config.BootstrappedValidatorsCount; i++ {
+	validators := make([]*pb.ValidatorRecord, config.DepositsForChainStart)
+	for i := uint64(0); i < config.DepositsForChainStart; i++ {
 		validators[i] = &pb.ValidatorRecord{
 			ExitSlot:               params.BeaconConfig().FarFutureSlot,
 			Balance:                config.MaxDeposit * config.Gwei,

--- a/beacon-chain/db/block_test.go
+++ b/beacon-chain/db/block_test.go
@@ -180,7 +180,7 @@ func TestChainProgress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get beacon state: %v", err)
 	}
-	cycleLength := params.BeaconConfig().CycleLength
+	cycleLength := params.BeaconConfig().EpochLength
 
 	block1 := &pb.BeaconBlock{Slot: 1}
 	if err := db.SaveBlock(block1); err != nil {

--- a/beacon-chain/utils/shuffle_test.go
+++ b/beacon-chain/utils/shuffle_test.go
@@ -61,14 +61,14 @@ func TestSplitIndices(t *testing.T) {
 	for i := 0; i < validators; i++ {
 		l = append(l, uint32(i))
 	}
-	split := SplitIndices(l, params.BeaconConfig().CycleLength)
-	if len(split) != int(params.BeaconConfig().CycleLength) {
-		t.Errorf("Split list failed due to incorrect length, wanted:%v, got:%v", params.BeaconConfig().CycleLength, len(split))
+	split := SplitIndices(l, params.BeaconConfig().EpochLength)
+	if len(split) != int(params.BeaconConfig().EpochLength) {
+		t.Errorf("Split list failed due to incorrect length, wanted:%v, got:%v", params.BeaconConfig().EpochLength, len(split))
 	}
 
 	for _, s := range split {
-		if len(s) != validators/int(params.BeaconConfig().CycleLength) {
-			t.Errorf("Split list failed due to incorrect length, wanted:%v, got:%v", validators/int(params.BeaconConfig().CycleLength), len(s))
+		if len(s) != validators/int(params.BeaconConfig().EpochLength) {
+			t.Errorf("Split list failed due to incorrect length, wanted:%v, got:%v", validators/int(params.BeaconConfig().EpochLength), len(s))
 		}
 	}
 }

--- a/shared/params/BUILD.bazel
+++ b/shared/params/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     srcs = ["config.go"],
     importpath = "github.com/prysmaticlabs/prysm/shared/params",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_ethereum_go_ethereum//common:go_default_library"],
 )
 
 go_test(

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -4,8 +4,6 @@ package params
 
 import (
 	"time"
-
-	"github.com/ethereum/go-ethereum/common"
 )
 
 func makeEmptySignature() [][]byte {
@@ -15,72 +13,67 @@ func makeEmptySignature() [][]byte {
 	return signature
 }
 
-// ValidatorStatusCode defines which stage a validator is in.
-type ValidatorStatusCode int
-
-// SpecialRecordType defines type of special record this message represents.
-type SpecialRecordType int
-
-// ValidatorSetDeltaFlags is used for light client to track validator entries.
-type ValidatorSetDeltaFlags int
-
-// BeaconChainConfig contains configs for node to participate in beacon chain.
+// BeaconChainConfig contains constant configs for node to participate in beacon chain.
 type BeaconChainConfig struct {
-	DepositContractTreeDepth                uint64         // Depth of the Merkle trie of deposits in the validator deposit contract on the PoW chain.
-	ZeroBalanceValidatorTTL                 uint64         // ZeroBalanceValidatorTTL specifies the allowed number of slots a validator with 0 balance can live in the state.
-	LatestBlockRootsLength                  uint64         // LatestBlockRootsLength is the number of block roots kept in the beacon state.
-	LatestRandaoMixesLength                 uint64         // LatestRandaoMixesLength is the number of randao mixes kept in the beacon state.
-	MaxExits                                uint64         // MaxExits determines the maximum number of validator exits in a block.
-	MaxDeposits                             uint64         // MaxExits determines the maximum number of validator deposits in a block.
-	MaxAttestations                         uint64         // MaxAttestations defines the maximum allowed attestations in a beacon block.
-	MaxProposerSlashings                    uint64         // MaxProposerSlashing defines the maximum number of slashings of proposers possible in a block.
-	MaxCasperSlashings                      uint64         // MaxCasperSlashings defines the maximum number of casper FFG slashings possible in a block.
-	MaxCasperVotes                          uint64         // MaxCasperVotes defines the maximum number of casper FFG votes possible in a block.
-	ShardCount                              uint64         // ShardCount is the fixed number of shards in Ethereum 2.0.
-	MaxDeposit                              uint64         // MaxDeposit is the max balance a validator can have at stake.
-	MinTopUpSize                            uint64         // MinTopUpSize is the minimal amount of Ether a validator can top up.
-	MinOnlineDepositSize                    uint64         // MinOnlineDepositSize is the minimal amount of Ether a validator needs to participate.
-	Gwei                                    uint64         // Gwei is the denomination of Gwei in Ether.
-	MaxDepositInGwei                        uint64         // MaxDepositInGwei is the max balance in Gwei a validator can have at stake.
-	DepositContractAddress                  common.Address // DepositContractAddress is the address of validator registration contract in PoW chain.
-	DepositsForChainStart                   uint64         // DepositsForChainStart defines how many deposits needed to start off beacon chain.
-	TargetCommitteeSize                     uint64         // TargetCommitteeSize is the minimal number of validator needs to be in a committee.
-	SlotDuration                            uint64         // SlotDuration is how many seconds are in a single slot.
-	CycleLength                             uint64         // CycleLength is one beacon chain cycle length in slots.
-	MinValidatorSetChangeInterval           uint64         // MinValidatorSetChangeInterval is the slots needed before validator set changes.
-	ShardPersistentCommitteeChangePeriod    uint64         // ShardPersistentCommitteeChangePeriod defines how often shard committee gets shuffled.
-	MinAttestationInclusionDelay            uint64         // MinAttestationInclusionDelay defines how long validator has to wait to include attestation for beacon block.
-	SqrtExpDropTime                         uint64         // SqrtEDropTime is a constant to reflect time it takes to cut offline validators’ deposits by 39.4%.
-	WithdrawalsPerCycle                     uint64         // WithdrawalsPerCycle defines how many withdrawals can go through per cycle.
-	MinWithdrawalPeriod                     uint64         // MinWithdrawalPeriod defines the slots between a validator exit and validator balance being withdrawable.
-	DeletionPeriod                          uint64         // DeletionPeriod define the period length of when validator is deleted from the pool.
-	CollectivePenaltyCalculationPeriod      uint64         // CollectivePenaltyCalculationPeriod defines the period length for an aggregated penalty amount.
-	PowReceiptRootVotingPeriod              uint64         // PowReceiptRootVotingPeriod defines how often PoW hash gets updated in beacon node.
-	SlashingWhistlerBlowerRewardDenominator uint64         // SlashingWhistlerBlowerRewardDenominator defines how the reward denominator of whistler blower.
-	BaseRewardQuotient                      uint64         // BaseRewardQuotient is used to calculate validator per-slot interest rate.
-	IncluderRewardQuotient                  uint64         // IncluderRewardQuotient defines the reward quotient of proposer for including attestations..
-	MaxValidatorChurnQuotient               uint64         // MaxValidatorChurnQuotient defines the quotient how many validators can change each time.
-	POWContractMerkleTreeDepth              uint64         // POWContractMerkleTreeDepth defines the depth of PoW contract merkle tree.
-	GenesisForkVersion                      uint64         // GenesisForkVersion is used to track fork version between state transitions.
-	InitialForkSlot                         uint64         // InitialForkSlot is used to initialize the fork slot in the initial Beacon state.
-	GenesisSlot                             uint64         // GenesisSlot is used to initialize the slot number of the genesis block.
-	SimulatedBlockRandao                    [32]byte       // SimulatedBlockRandao is a RANDAO seed stubbed in side simulated block to advance local beacon chain.
-	RandBytes                               uint64         // RandBytes is the number of bytes used as entropy to shuffle validators.
-	BootstrappedValidatorsCount             uint64         // BootstrappedValidatorsCount is the number of validators we seed to start beacon chain.
-	SyncPollingInterval                     int64          // SyncPollingInterval queries network nodes for sync status.
-	GenesisTime                             time.Time      // GenesisTime used by the protocol.
-	MaxNumLog2Validators                    uint64         // Max number of validators in Log2 can exist given total ETH supply.
-	EpochLength                             uint64         // Number of slots that define an Epoch.
-	InactivityPenaltyQuotient               uint64         // InactivityPenaltyQuotient defines how much validator leaks out balances for offline.
-	EjectionBalance                         uint64         // EjectionBalance is the minimal balance a validator needs before ejected.
-	EjectionBalanceInGwei                   uint64         // EjectionBalanceInGwei is the minimal balance in Gwei a validator needs before ejected.
-	ZeroHash                                [32]byte       // ZeroHash is used to represent a zeroed out 32 byte array.
-	EmptySignature                          [][]byte       // EmptySignature is used to represent a zeroed out BLS Signature.
-	FarFutureSlot                           uint64         // FarFutureSlot is the last slot based on uint64 type.
-	EntryExitDelay                          uint64         // EntryExitDelay is the duration of the day for entry exit.
-	LatestPenalizedExitLength               uint64         // LatestPenalizedExitLength represents withdrawal time when a validator is penalized.
-	WhistlerBlowerRewardQuotient            uint64         // WhistlerBlowerRewardQuotient defines how the reward denominator of whistler blower.
-	SeedLookahead                           uint64         // SeedLookahead is the duration of the look ahead seed.
+	// Misc constants.
+	ShardCount                uint64 // ShardCount is the number of shard chains in Ethereum 2.0.
+	TargetCommitteeSize       uint64 // TargetCommitteeSize is the number of validators in a committee when the chain is healthy.
+	EjectionBalance           uint64 // EjectionBalance is the minimal ETH a validator needs to have before ejected.
+	EjectionBalanceInGwei     uint64 // EjectionBalance is the minimal GWei a validator needs to have before ejected.
+	MaxBalanceChurnQuotient   uint64 // MaxBalanceChurnQuotient is used to determine how many validators can rotate per epoch.
+	Gwei                      uint64 // Gwei is the denomination of Gwei in Ether.
+	BeaconChainShardNumber    uint64 // BeaconChainShardNumber is the shard number of the beacon chain.
+	MaxCasperVotes            uint64 // MaxCasperVotes is used to verify slashable Casper vote data.
+	LatestBlockRootsLength    uint64 // LatestBlockRootsLength is the number of block roots kept in the beacon state.
+	LatestRandaoMixesLength   uint64 // LatestRandaoMixesLength is the number of randao mixes kept in the beacon state.
+	LatestPenalizedExitLength uint64 // LatestPenalizedExitLength is used to track penalized exit balances per time interval.
+
+	// Deposit contract constants.
+	DepositContractAddress   []byte // DepositContractAddress is the address of the deposit contract in PoW chain.
+	DepositContractTreeDepth uint64 // Depth of the Merkle trie of deposits in the validator deposit contract on the PoW chain.
+	MaxDeposit               uint64 // MaxDeposit is the maximal amount of ETH a validator can send to the deposit contract at once.
+	MaxDepositInGwei         uint64 // MaxDepositInGwei is the maximal amount of Gwei a validator can send to the deposit contract at once.
+	MinDeposit               uint64 // MinDeposit is the minimal amount of ETH a validator can send to the deposit contract at once.
+	MinDepositinGwei         uint64 // MinDepositinGwei is the maximal amount of Gwei a validator can send to the deposit contract at once.
+
+	// Initial value constants.
+	GenesisForkVersion      uint64   // GenesisForkVersion is used to track fork version between state transitions.
+	GenesisSlot             uint64   // GenesisSlot is used to initialize the genesis state fields..
+	FarFutureSlot           uint64   // FarFutureSlot is used to track validator exit. Currently default to 2^64-1.
+	ZeroHash                [32]byte // ZeroHash is used to represent a zeroed out 32 byte array.
+	EmptySignature          [][]byte // EmptySignature is used to represent a zeroed out BLS Signature.
+	BLSWithdrawalPrefixByte byte     // BLSWithdrawalPrefixByte is used for BLS withdrawal and it's the first byte.
+
+	// Time parameters constants.
+	SlotDuration                 uint64 // SlotDuration is how many seconds are in a single slot.
+	MinAttestationInclusionDelay uint64 // MinAttestationInclusionDelay defines how long validator has to wait to include attestation for beacon block.
+	EpochLength                  uint64 // EpochLength is the number of slots in an epoch.
+	SeedLookahead                uint64 // SeedLookahead is the duration of randao look ahead seed.
+	EntryExitDelay               uint64 // EntryExitDelay is the duration a validator has to wait for entry and exit.
+	PowReceiptRootVotingPeriod   uint64 // PowReceiptRootVotingPeriod defines how often PoW hash gets updated in beacon node.
+	MinValidatorWithdrawalTime   uint64 // MinValidatorWithdrawalTime is the shortest amount of time a validator can get the deposit out.
+
+	// Reward and penalty quotients constants.
+	BaseRewardQuotient           uint64 // BaseRewardQuotient is used to calculate validator per-slot interest rate.
+	WhistlerBlowerRewardQuotient uint64 // WhistlerBlowerRewardQuotient is used to calculate whistler blower reward.
+	IncluderRewardQuotient       uint64 // IncluderRewardQuotient defines the reward quotient of proposer for including attestations..
+	InactivityPenaltyQuotient    uint64 // InactivityPenaltyQuotient defines how much validator leaks out balances for offline.
+
+	// Max operations per block constants.
+	MaxExits             uint64 // MaxExits determines the maximum number of validator exits in a block.
+	MaxDeposits          uint64 // MaxExits determines the maximum number of validator deposits in a block.
+	MaxAttestations      uint64 // MaxAttestations defines the maximum allowed attestations in a beacon block.
+	MaxProposerSlashings uint64 // MaxProposerSlashings defines the maximum number of slashings of proposers possible in a block.
+	MaxCasperSlashings   uint64 // MaxCasperSlashings defines the maximum number of casper FFG slashings possible in a block.
+
+	// Prysm constants.
+	DepositsForChainStart      uint64    // DepositsForChainStart defines how many validator deposits needed to kick off beacon chain.
+	POWContractMerkleTreeDepth uint64    // POWContractMerkleTreeDepth defines the depth of PoW contract merkle tree.
+	SimulatedBlockRandao       [32]byte  // SimulatedBlockRandao is a RANDAO seed stubbed in simulated block for advancing local beacon chain.
+	RandBytes                  uint64    // RandBytes is the number of bytes used as entropy to shuffle validators.
+	SyncPollingInterval        int64     // SyncPollingInterval queries network nodes for sync status.
+	GenesisTime                time.Time // GenesisTime used by the protocol.
+	MaxNumLog2Validators       uint64    // MaxNumLog2Validators is the Max number of validators in Log2 exists given total ETH supply.
 }
 
 // ShardChainConfig contains configs for node to participate in shard chains.
@@ -90,124 +83,121 @@ type ShardChainConfig struct {
 }
 
 var defaultBeaconConfig = &BeaconChainConfig{
-	ZeroBalanceValidatorTTL:            4194304,
-	DepositContractTreeDepth:           32,
-	LatestRandaoMixesLength:            8192,
-	LatestBlockRootsLength:             8192,
-	MaxExits:                           16,
-	MaxAttestations:                    128,
-	MaxProposerSlashings:               16,
-	MaxCasperSlashings:                 16,
-	MaxCasperVotes:                     1024,
-	ShardCount:                         1024,
-	MaxDeposit:                         32,
-	MaxDeposits:                        16,
-	MinTopUpSize:                       1,
-	MinOnlineDepositSize:               16,
-	Gwei:                               1e9,
-	MaxDepositInGwei:                   32 * 1e9,
-	DepositsForChainStart:              16384,
-	TargetCommitteeSize:                uint64(256),
-	SlotDuration:                       uint64(16),
-	CycleLength:                        uint64(64),
-	MinValidatorSetChangeInterval:      uint64(256),
-	MinAttestationInclusionDelay:       uint64(4),
-	SqrtExpDropTime:                    uint64(65536),
-	MinWithdrawalPeriod:                uint64(4096),
-	WithdrawalsPerCycle:                uint64(4),
-	BaseRewardQuotient:                 uint64(1024),
-	MaxValidatorChurnQuotient:          uint64(32),
-	GenesisForkVersion:                 0,
-	InitialForkSlot:                    0,
-	GenesisSlot:                        0,
-	RandBytes:                          3,
-	BootstrappedValidatorsCount:        16384,
-	SyncPollingInterval:                16 * 4, // Query nodes over the network every 4 slots for sync status.
-	GenesisTime:                        time.Date(2018, 9, 0, 0, 0, 0, 0, time.UTC),
-	MaxNumLog2Validators:               24,
-	EpochLength:                        64,
-	ZeroHash:                           [32]byte{},
-	EmptySignature:                     makeEmptySignature(),
-	PowReceiptRootVotingPeriod:         1024,
-	InactivityPenaltyQuotient:          1 << 24,
-	CollectivePenaltyCalculationPeriod: 1 << 20,
-	IncluderRewardQuotient:             8,
-	EjectionBalance:                    16,
-	EjectionBalanceInGwei:              16 * 1e9,
-	FarFutureSlot:                      1<<64 - 1,
-	EntryExitDelay:                     256,
-	LatestPenalizedExitLength:          8192,
-	WhistlerBlowerRewardQuotient:       512,
-	SeedLookahead:                      64,
+	// Misc constant.
+	ShardCount:                1024,
+	TargetCommitteeSize:       256,
+	EjectionBalance:           16,
+	EjectionBalanceInGwei:     16 * 1e9,
+	Gwei:                      1e9,
+	BeaconChainShardNumber:    1<<64 - 1,
+	MaxCasperVotes:            1024,
+	LatestBlockRootsLength:    8192,
+	LatestRandaoMixesLength:   8192,
+	LatestPenalizedExitLength: 8192,
+
+	// Deposit contract constants.
+	DepositContractTreeDepth: 32,
+	MaxDeposit:               32,
+	MaxDepositInGwei:         32 * 1e9,
+	MinDeposit:               1,
+	MinDepositinGwei:         1 * 1e9,
+
+	// Initial value constants.
+	GenesisForkVersion: 0,
+	GenesisSlot:        0,
+	FarFutureSlot:      1<<64 - 1,
+	ZeroHash:           [32]byte{},
+	EmptySignature:     makeEmptySignature(),
+
+	// Time parameter constants.
+	SlotDuration:                 16,
+	MinAttestationInclusionDelay: 4,
+	EpochLength:                  64,
+	SeedLookahead:                64,
+	EntryExitDelay:               256,
+	PowReceiptRootVotingPeriod:   1024,
+
+	// Reward and penalty quotients constants.
+	BaseRewardQuotient:           1024,
+	WhistlerBlowerRewardQuotient: 512,
+	IncluderRewardQuotient:       8,
+	InactivityPenaltyQuotient:    1 << 24,
+
+	// Max operations per block constants.
+	MaxExits:             16,
+	MaxDeposits:          16,
+	MaxAttestations:      128,
+	MaxProposerSlashings: 16,
+	MaxCasperSlashings:   16,
+
+	// Prysm constants.
+	DepositsForChainStart: 16384,
+	RandBytes:             3,
+	SyncPollingInterval:   16 * 4, // Query nodes over the network every 4 slots for sync status.
+	GenesisTime:           time.Date(2018, 9, 0, 0, 0, 0, 0, time.UTC),
+	MaxNumLog2Validators:  24,
 }
 
 var demoBeaconConfig = &BeaconChainConfig{
-	LatestRandaoMixesLength:       defaultBeaconConfig.LatestRandaoMixesLength,
-	LatestBlockRootsLength:        defaultBeaconConfig.LatestBlockRootsLength,
-	MaxExits:                      defaultBeaconConfig.MaxExits,
-	MaxAttestations:               defaultBeaconConfig.MaxAttestations,
-	MaxProposerSlashings:          defaultBeaconConfig.MaxProposerSlashings,
-	MaxCasperSlashings:            defaultBeaconConfig.MaxCasperSlashings,
-	ShardCount:                    5,
-	MaxDeposit:                    defaultBeaconConfig.MaxDeposit,
-	MinTopUpSize:                  defaultBeaconConfig.MinTopUpSize,
-	MinOnlineDepositSize:          defaultBeaconConfig.MinOnlineDepositSize,
-	Gwei:                          defaultBeaconConfig.Gwei,
-	MaxDepositInGwei:              defaultBeaconConfig.MaxDepositInGwei,
-	DepositsForChainStart:         defaultBeaconConfig.DepositsForChainStart,
-	TargetCommitteeSize:           uint64(3),
-	SlotDuration:                  uint64(2),
-	CycleLength:                   uint64(5),
-	MinValidatorSetChangeInterval: uint64(15),
-	MinAttestationInclusionDelay:  defaultBeaconConfig.MinAttestationInclusionDelay,
-	SqrtExpDropTime:               defaultBeaconConfig.SqrtExpDropTime,
-	MinWithdrawalPeriod:           uint64(20),
-	WithdrawalsPerCycle:           uint64(2),
-	BaseRewardQuotient:            defaultBeaconConfig.BaseRewardQuotient,
-	MaxValidatorChurnQuotient:     defaultBeaconConfig.MaxValidatorChurnQuotient,
-	GenesisForkVersion:            defaultBeaconConfig.GenesisForkVersion,
-	GenesisSlot:                   defaultBeaconConfig.GenesisSlot,
-	RandBytes:                     defaultBeaconConfig.RandBytes,
-	InitialForkSlot:               defaultBeaconConfig.InitialForkSlot,
-	SimulatedBlockRandao:          [32]byte{'S', 'I', 'M', 'U', 'L', 'A', 'T', 'E', 'R'},
-	SyncPollingInterval:           2 * 4, // Query nodes over the network every 4 slots for sync status.
-	GenesisTime:                   time.Now(),
-	MaxNumLog2Validators:          defaultBeaconConfig.MaxNumLog2Validators,
-	EpochLength:                   defaultBeaconConfig.EpochLength,
-	PowReceiptRootVotingPeriod:    defaultBeaconConfig.PowReceiptRootVotingPeriod,
-	InactivityPenaltyQuotient:     defaultBeaconConfig.InactivityPenaltyQuotient,
-	ZeroHash:                      defaultBeaconConfig.ZeroHash,
-	EmptySignature:                makeEmptySignature(),
-	IncluderRewardQuotient:        defaultBeaconConfig.IncluderRewardQuotient,
-	EjectionBalance:               defaultBeaconConfig.EjectionBalance,
-	EjectionBalanceInGwei:         defaultBeaconConfig.EjectionBalanceInGwei,
-	LatestPenalizedExitLength:     defaultBeaconConfig.LatestPenalizedExitLength,
-	WhistlerBlowerRewardQuotient:  defaultBeaconConfig.WhistlerBlowerRewardQuotient,
+	// Misc constant.
+	ShardCount:                5,
+	TargetCommitteeSize:       3,
+	EjectionBalance:           defaultBeaconConfig.EjectionBalance,
+	EjectionBalanceInGwei:     defaultBeaconConfig.EjectionBalanceInGwei,
+	Gwei:                      defaultBeaconConfig.Gwei,
+	BeaconChainShardNumber:    defaultBeaconConfig.BeaconChainShardNumber,
+	MaxCasperVotes:            defaultBeaconConfig.MaxCasperVotes,
+	LatestBlockRootsLength:    defaultBeaconConfig.LatestBlockRootsLength,
+	LatestRandaoMixesLength:   defaultBeaconConfig.LatestRandaoMixesLength,
+	LatestPenalizedExitLength: defaultBeaconConfig.LatestPenalizedExitLength,
+
+	// Deposit contract constants.
+	DepositContractTreeDepth: defaultBeaconConfig.DepositContractTreeDepth,
+	MaxDeposit:               defaultBeaconConfig.MaxDeposit,
+	MaxDepositInGwei:         defaultBeaconConfig.MaxDepositInGwei,
+	MinDeposit:               defaultBeaconConfig.MinDeposit,
+
+	// Initial value constants.
+	GenesisForkVersion: defaultBeaconConfig.GenesisForkVersion,
+	GenesisSlot:        defaultBeaconConfig.GenesisSlot,
+	FarFutureSlot:      defaultBeaconConfig.FarFutureSlot,
+	ZeroHash:           defaultBeaconConfig.ZeroHash,
+	EmptySignature:     defaultBeaconConfig.EmptySignature,
+
+	// Time parameter constants.
+	SlotDuration:                 2,
+	MinAttestationInclusionDelay: defaultBeaconConfig.MinAttestationInclusionDelay,
+	EpochLength:                  defaultBeaconConfig.EpochLength,
+	SeedLookahead:                defaultBeaconConfig.SeedLookahead,
+	EntryExitDelay:               defaultBeaconConfig.EntryExitDelay,
+	PowReceiptRootVotingPeriod:   defaultBeaconConfig.PowReceiptRootVotingPeriod,
+
+	// Reward and penalty quotients constants.
+	BaseRewardQuotient:           defaultBeaconConfig.BaseRewardQuotient,
+	WhistlerBlowerRewardQuotient: defaultBeaconConfig.WhistlerBlowerRewardQuotient,
+	IncluderRewardQuotient:       defaultBeaconConfig.IncluderRewardQuotient,
+	InactivityPenaltyQuotient:    defaultBeaconConfig.InactivityPenaltyQuotient,
+
+	// Max operations per block constants.
+	MaxExits:             defaultBeaconConfig.MaxExits,
+	MaxDeposits:          defaultBeaconConfig.MaxDeposit,
+	MaxAttestations:      defaultBeaconConfig.MaxAttestations,
+	MaxProposerSlashings: defaultBeaconConfig.MaxProposerSlashings,
+	MaxCasperSlashings:   defaultBeaconConfig.MaxCasperSlashings,
+
+	// Prysm constants.
+	DepositsForChainStart: defaultBeaconConfig.DepositsForChainStart,
+	RandBytes:             defaultBeaconConfig.RandBytes,
+	SyncPollingInterval:   2 * 4, // Query nodes over the network every 4 slots for sync status.
+	GenesisTime:           time.Now(),
+	MaxNumLog2Validators:  defaultBeaconConfig.MaxNumLog2Validators,
+	SimulatedBlockRandao:  [32]byte{'S', 'I', 'M', 'U', 'L', 'A', 'T', 'E', 'R'},
 }
 
 var defaultShardConfig = &ShardChainConfig{
 	ChunkSize:         uint64(256),
 	MaxShardBlockSize: uint64(32768),
 }
-
-const (
-	// Logout means a validator is requesting to exit the validator pool.
-	Logout SpecialRecordType = iota
-	// CasperSlashing means a attester has committed slashing penalty which a surround vote was made.
-	CasperSlashing
-	// ProposerSlashing means a proposer has violated a slashing condition which 2 identical blocks were proposed
-	// same height.
-	ProposerSlashing
-	// DepositProof means a validator has submitted a deposit and the data is the proof.
-	DepositProof
-)
-
-const (
-	// Entry means this is an entry message for light client to track overall validator status.
-	Entry ValidatorSetDeltaFlags = iota
-	// Exit means this is an exit message for light client to track overall validator status.
-	Exit
-)
 
 var beaconConfig = defaultBeaconConfig
 var shardConfig = defaultShardConfig

--- a/shared/params/config_test.go
+++ b/shared/params/config_test.go
@@ -4,38 +4,6 @@ import (
 	"testing"
 )
 
-func TestSpecialRecordTypes(t *testing.T) {
-	tests := []struct {
-		a SpecialRecordType
-		b int
-	}{
-		{a: Logout, b: 0},
-		{a: CasperSlashing, b: 1},
-		{a: ProposerSlashing, b: 2},
-		{a: DepositProof, b: 3},
-	}
-	for _, tt := range tests {
-		if int(tt.a) != tt.b {
-			t.Errorf("Incorrect special record types. Wanted: %d, Got: %d", int(tt.a), tt.b)
-		}
-	}
-}
-
-func TestValidatorSetDeltaFlags(t *testing.T) {
-	tests := []struct {
-		a ValidatorSetDeltaFlags
-		b int
-	}{
-		{a: Entry, b: 0},
-		{a: Exit, b: 1},
-	}
-	for _, tt := range tests {
-		if int(tt.a) != tt.b {
-			t.Errorf("Incorrect validator set delta flags. Wanted: %d, Got: %d", int(tt.a), tt.b)
-		}
-	}
-}
-
 func TestOverrideBeaconConfig(t *testing.T) {
 	cfg := BeaconConfig()
 	cfg.ShardCount = 5

--- a/validator/beacon/service.go
+++ b/validator/beacon/service.go
@@ -242,9 +242,9 @@ func (s *Service) listenForProcessedAttestations(client pb.BeaconServiceClient) 
 // startSlot returns the first slot of the given slot's cycle.
 func (s *Service) startSlot() uint64 {
 	duration := params.BeaconConfig().SlotDuration
-	cycleLength := params.BeaconConfig().CycleLength
+	epochLength := params.BeaconConfig().EpochLength
 	slot := slotticker.CurrentSlot(s.genesisTimestamp, duration, time.Since)
-	return slot - slot%cycleLength
+	return slot - slot%epochLength
 }
 
 func (s *Service) assignRole(assignments []*pb.Assignment, startSlot uint64) error {


### PR DESCRIPTION
Code clean up. This PR reformats config constants into sections, updates the descriptions and deletes deprecated code.


What changes in this PR:

- Reformated configs with sections, aligned with the format in [spec](https://github.com/ethereum/eth2.0-specs/blob/fd2cc6956fa15c98a4a3a0cb1ab9c478584ef2ea/specs/core/0_beacon-chain.md#constants)
- `IsValidatorSetChange` is deprecated and no longer needed. The validator set change logic is now part of epoch processing in `transition.go`
- `ZeroBalanceValidatorTTL` is deprecated, I removed it from `ProcessDeposits`