### PR TITLE
Remove some redundant fetches from DB for the beacon state

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -246,7 +246,7 @@ func (c *ChainService) blockProcessing(processedBlock chan<- *pb.BeaconBlock) {
 			}
 
 			if currentSlot+1 == block.Slot {
-				if err := c.receiveBlock(block); err != nil {
+				if err := c.receiveBlock(block, beaconState); err != nil {
 					log.Error(err)
 					processedBlock <- nil
 					continue
@@ -257,7 +257,7 @@ func (c *ChainService) blockProcessing(processedBlock chan<- *pb.BeaconBlock) {
 				log.Debugf(
 					"Block slot number is lower than the current slot in the beacon state %d",
 					block.Slot)
-				c.sendAndDeleteCachedBlocks(currentSlot)
+				c.sendAndDeleteCachedBlocks(currentSlot, beaconState)
 			}
 		}
 	}
@@ -286,16 +286,11 @@ func (c *ChainService) blockProcessing(processedBlock chan<- *pb.BeaconBlock) {
 //		else:
 //			return False  # or throw or whatever
 //
-func (c *ChainService) receiveBlock(block *pb.BeaconBlock) error {
+func (c *ChainService) receiveBlock(block *pb.BeaconBlock, beaconState *pb.BeaconState) error {
 
 	blockhash, err := b.Hash(block)
 	if err != nil {
 		return fmt.Errorf("could not hash incoming block: %v", err)
-	}
-
-	beaconState, err := c.beaconDB.GetState()
-	if err != nil {
-		return fmt.Errorf("failed to get beacon state: %v", err)
 	}
 
 	if block.Slot == 0 {
@@ -303,7 +298,7 @@ func (c *ChainService) receiveBlock(block *pb.BeaconBlock) error {
 	}
 
 	// Save blocks with higher slot numbers in cache.
-	if err := c.isBlockReadyForProcessing(block); err != nil {
+	if err := c.isBlockReadyForProcessing(block, beaconState); err != nil {
 		log.Debugf("block with hash %#x is not ready for processing: %v", blockhash, err)
 		return nil
 	}
@@ -358,11 +353,7 @@ func (c *ChainService) receiveBlock(block *pb.BeaconBlock) error {
 	return nil
 }
 
-func (c *ChainService) isBlockReadyForProcessing(block *pb.BeaconBlock) error {
-	beaconState, err := c.beaconDB.GetState()
-	if err != nil {
-		return fmt.Errorf("failed to get beacon state: %v", err)
-	}
+func (c *ChainService) isBlockReadyForProcessing(block *pb.BeaconBlock, beaconState *pb.BeaconState) error {
 
 	var powBlockFetcher func(ctx context.Context, hash common.Hash) (*gethTypes.Block, error)
 	if c.enablePOWChain {
@@ -378,9 +369,9 @@ func (c *ChainService) isBlockReadyForProcessing(block *pb.BeaconBlock) error {
 // sendAndDeleteCachedBlocks checks if there is any block saved in the cache with a
 // slot number equivalent to the current slot. If there is then the block is
 // sent to the incoming block channel and deleted from the cache.
-func (c *ChainService) sendAndDeleteCachedBlocks(currentSlot uint64) {
+func (c *ChainService) sendAndDeleteCachedBlocks(currentSlot uint64, beaconState *pb.BeaconState) {
 	if block, ok := c.unProcessedBlocks[currentSlot+1]; ok {
-		if err := c.isBlockReadyForProcessing(block); err == nil {
+		if err := c.isBlockReadyForProcessing(block, beaconState); err == nil {
 			c.incomingBlockChan <- block
 			delete(c.unProcessedBlocks, currentSlot)
 		}

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -428,14 +428,11 @@ func TestIsBlockReadyForProcessing(t *testing.T) {
 		ParentRootHash32: []byte{'a'},
 	}
 
-	if err := chainService.isBlockReadyForProcessing(block); err == nil {
+	if err := chainService.isBlockReadyForProcessing(block, beaconState); err == nil {
 		t.Fatal("block processing succeeded despite block having no parent saved")
 	}
 
 	beaconState.Slot = 10
-	if err := chainService.beaconDB.SaveState(beaconState); err != nil {
-		t.Fatalf("cannot save state: %v", err)
-	}
 
 	enc, _ := proto.Marshal(beaconState)
 	stateRoot := hashutil.Hash(enc)
@@ -453,7 +450,7 @@ func TestIsBlockReadyForProcessing(t *testing.T) {
 		Slot:             10,
 	}
 
-	if err := chainService.isBlockReadyForProcessing(block2); err == nil {
+	if err := chainService.isBlockReadyForProcessing(block2, beaconState); err == nil {
 		t.Fatal("block processing succeeded despite block slot being invalid")
 	}
 
@@ -461,9 +458,6 @@ func TestIsBlockReadyForProcessing(t *testing.T) {
 	copy(h[:], []byte("a"))
 	beaconState.ProcessedPowReceiptRootHash32 = h[:]
 	beaconState.Slot = 0
-	if err := chainService.beaconDB.SaveState(beaconState); err != nil {
-		t.Fatalf("cannot save state: %v", err)
-	}
 
 	currentSlot := uint64(1)
 	attestationSlot := uint64(0)
@@ -489,7 +483,7 @@ func TestIsBlockReadyForProcessing(t *testing.T) {
 
 	chainService.enablePOWChain = true
 
-	if err := chainService.isBlockReadyForProcessing(block3); err != nil {
+	if err := chainService.isBlockReadyForProcessing(block3, beaconState); err != nil {
 		t.Fatalf("block processing failed despite being a valid block: %v", err)
 	}
 }


### PR DESCRIPTION
As part of the block processing routine, I found that there were 3 DB fetches for the beacon state. This PR passes a reference to the same state object from the caller. 