### PR TITLE
Implement PoW Chain Deposit Trie in Go

### DIFF
--- a/shared/trie/deposit_trie.go
+++ b/shared/trie/deposit_trie.go
@@ -1,0 +1,33 @@
+package trie
+
+import (
+	"math"
+
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
+	"github.com/prysmaticlabs/prysm/shared/params"
+)
+
+type DepositTrie struct {
+	depositCount uint64
+	hashList     [][32]byte
+}
+
+// UpdateDepositTrie updates the Merkle trie representing deposits on
+// the ETH 1.0 PoW chain contract.
+func (d *DepositTrie) UpdateDepositTrie(depositData []byte) {
+	twoToPowerOfTreeDepth := math.Pow(2, float64(params.BeaconConfig().POWContractMerkleTreeDepth))
+	index := d.depositCount + uint64(twoToPowerOfTreeDepth)
+	d.hashList[index] = hashutil.Hash(depositData)
+	for i := uint64(0); i < params.BeaconConfig().POWContractMerkleTreeDepth; i++ {
+		index := index / 2
+		left := d.hashList[index*2]
+		right := d.hashList[index*2+1]
+		d.hashList[index] = hashutil.Hash(append(left[:], right[:]...))
+	}
+	d.depositCount++
+}
+
+// Root returns the merkle root of the calculated deposit trie.
+func (d *DepositTrie) Root() [32]byte {
+	return d.hashList[0]
+}

--- a/shared/trie/deposit_trie_test.go
+++ b/shared/trie/deposit_trie_test.go
@@ -1,0 +1,1 @@
+package trie


### PR DESCRIPTION
This PR is part of #1284
---

# Description

This PR implements the PoW Chain deposit contract trie in Go for our beacon node to keep track of receipt roots locally for verification. This also includes utilities to save the trie in the database. This PR will be very useful for simulating block deposits through e2e tests as in #1276.

TODO: Add more information to PR description and requirements for merge.