### PR TITLE
Add reflection gRPC service to beacon-chain gRPC server

### DIFF
--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
+        "@org_golang_google_grpc//reflection:go_default_library",
     ],
 )
 

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -125,14 +125,15 @@ func (s *Service) Start() {
 		log.Warn("You are using an insecure gRPC connection! Provide a certificate and key to connect securely")
 		s.grpcServer = grpc.NewServer()
 	}
-
-	// Register reflection service on gRPC server.
-	reflection.Register(s.grpcServer)
-
+	
 	pb.RegisterBeaconServiceServer(s.grpcServer, s)
 	pb.RegisterValidatorServiceServer(s.grpcServer, s)
 	pb.RegisterProposerServiceServer(s.grpcServer, s)
 	pb.RegisterAttesterServiceServer(s.grpcServer, s)
+	
+	// Register reflection service on gRPC server.
+	reflection.Register(s.grpcServer)
+	
 	go func() {
 		err = s.grpcServer.Serve(lis)
 		if err != nil {

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/reflection"
 )
 
 var log = logrus.WithField("prefix", "rpc")
@@ -124,6 +125,9 @@ func (s *Service) Start() {
 		log.Warn("You are using an insecure gRPC connection! Provide a certificate and key to connect securely")
 		s.grpcServer = grpc.NewServer()
 	}
+
+	// Register reflection service on gRPC server.
+	reflection.Register(s.grpcServer)
 
 	pb.RegisterBeaconServiceServer(s.grpcServer, s)
 	pb.RegisterValidatorServiceServer(s.grpcServer, s)


### PR DESCRIPTION
> Server Reflection provides information about publicly-accessible gRPC services on a server, and assists clients at runtime to construct RPC requests and responses without precompiled service information. It is used by gRPC CLI, which can be used to introspect server protos and send/receive test RPCs.

