### PR TITLE
Refactor hashing of beaconblock to shared

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//beacon-chain/powchain:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/powchain"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/event"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
 )
@@ -143,7 +144,7 @@ func (c *ChainService) updateHead(processedBlock <-chan *pb.BeaconBlock) {
 				continue
 			}
 
-			h, err := b.Hash(block)
+			h, err := hashutil.HashBeaconBlock(block)
 			if err != nil {
 				log.Errorf("Could not hash incoming block: %v", err)
 				continue
@@ -288,7 +289,7 @@ func (c *ChainService) blockProcessing(processedBlock chan<- *pb.BeaconBlock) {
 //
 func (c *ChainService) receiveBlock(block *pb.BeaconBlock, beaconState *pb.BeaconState) error {
 
-	blockhash, err := b.Hash(block)
+	blockhash, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		return fmt.Errorf("could not hash incoming block: %v", err)
 	}
@@ -309,7 +310,7 @@ func (c *ChainService) receiveBlock(block *pb.BeaconBlock, beaconState *pb.Beaco
 	}
 
 	// TODO(#716):Replace with tree-hashing algorithm.
-	blockRoot, err := b.Hash(prevBlock)
+	blockRoot, err := hashutil.HashBeaconBlock(prevBlock)
 	if err != nil {
 		return fmt.Errorf("could not hash block %v", err)
 	}

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -20,12 +20,12 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/internal"
 	"github.com/prysmaticlabs/prysm/beacon-chain/powchain"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/sirupsen/logrus"
 	logTest "github.com/sirupsen/logrus/hooks/test"
-	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
 )
 
 func init() {
@@ -164,7 +164,7 @@ func TestRunningChainServiceFaultyPOWChain(t *testing.T) {
 		Slot: 1,
 	}
 
-	parentHash, err := b.Hash(parentBlock)
+	parentHash, err := hashutil.HashBeaconBlock(parentBlock)
 	if err != nil {
 		t.Fatalf("Unable to hash block %v", err)
 	}
@@ -234,7 +234,7 @@ func TestRunningChainService(t *testing.T) {
 	if err := chainService.beaconDB.SaveBlock(genesis); err != nil {
 		t.Fatalf("could not save block to db: %v", err)
 	}
-	parentHash, err := b.Hash(genesis)
+	parentHash, err := hashutil.HashBeaconBlock(genesis)
 	if err != nil {
 		t.Fatalf("unable to get hash of canonical head: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestUpdateHead(t *testing.T) {
 	stateRoot := hashutil.Hash(enc)
 
 	genesis := b.NewGenesisBlock(stateRoot[:])
-	genesisHash, err := b.Hash(genesis)
+	genesisHash, err := hashutil.HashBeaconBlock(genesis)
 	if err != nil {
 		t.Fatalf("Could not get genesis block hash: %v", err)
 	}
@@ -389,7 +389,7 @@ func TestUpdateHead(t *testing.T) {
 			ParentRootHash32:  genesisHash[:],
 			DepositRootHash32: []byte("a"),
 		}
-		h, err := b.Hash(block)
+		h, err := hashutil.HashBeaconBlock(block)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -443,7 +443,7 @@ func TestIsBlockReadyForProcessing(t *testing.T) {
 	if err := chainService.beaconDB.SaveBlock(genesis); err != nil {
 		t.Fatalf("cannot save block: %v", err)
 	}
-	parentHash, err := b.Hash(genesis)
+	parentHash, err := hashutil.HashBeaconBlock(genesis)
 	if err != nil {
 		t.Fatalf("unable to get hash of canonical head: %v", err)
 	}

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
         "//shared/trie:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
-        "@com_github_gogo_protobuf//proto:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/blocks/block.go
+++ b/beacon-chain/core/blocks/block.go
@@ -10,26 +10,15 @@ import (
 	"math"
 	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/prysmaticlabs/prysm/beacon-chain/utils"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/ssz"
-	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
-
 )
 
 var clock utils.Clock = &utils.RealClock{}
-
-// Hash a beacon block data structure.
-func Hash(block *pb.BeaconBlock) ([32]byte, error) {
-	data, err := proto.Marshal(block)
-	if err != nil {
-		return [32]byte{}, fmt.Errorf("could not marshal block proto data: %v", err)
-	}
-	return hashutil.Hash(data), nil
-}
 
 // NewGenesisBlock returns the canonical, genesis block for the beacon chain protocol.
 func NewGenesisBlock(stateRoot []byte) *pb.BeaconBlock {

--- a/beacon-chain/db/BUILD.bazel
+++ b/beacon-chain/db/BUILD.bazel
@@ -43,9 +43,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/core/attestations:go_default_library",
-        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/utils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
+        "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],

--- a/beacon-chain/db/block.go
+++ b/beacon-chain/db/block.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/gogo/protobuf/proto"
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
 
 func createBlock(enc []byte) (*pb.BeaconBlock, error) {
@@ -56,7 +56,7 @@ func (db *BeaconDB) HasBlock(hash [32]byte) bool {
 
 // SaveBlock accepts a block and writes it to disk.
 func (db *BeaconDB) SaveBlock(block *pb.BeaconBlock) error {
-	hash, err := b.Hash(block)
+	hash, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		return fmt.Errorf("failed to hash block: %v", err)
 	}
@@ -106,7 +106,7 @@ func (db *BeaconDB) GetChainHead() (*pb.BeaconBlock, error) {
 // UpdateChainHead atomically updates the head of the chain as well as the corresponding state changes
 // Including a new crystallized state is optional.
 func (db *BeaconDB) UpdateChainHead(block *pb.BeaconBlock, beaconState *pb.BeaconState) error {
-	blockHash, err := b.Hash(block)
+	blockHash, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		return fmt.Errorf("unable to get the block hash: %v", err)
 	}

--- a/beacon-chain/db/block_test.go
+++ b/beacon-chain/db/block_test.go
@@ -3,8 +3,8 @@ package db
 import (
 	"testing"
 
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
@@ -13,7 +13,7 @@ func TestNilDB(t *testing.T) {
 	defer teardownDB(t, db)
 
 	block := &pb.BeaconBlock{}
-	h, _ := b.Hash(block)
+	h, _ := hashutil.HashBeaconBlock(block)
 
 	hasBlock := db.HasBlock(h)
 	if hasBlock {
@@ -34,7 +34,7 @@ func TestSave(t *testing.T) {
 	defer teardownDB(t, db)
 
 	block1 := &pb.BeaconBlock{}
-	h1, _ := b.Hash(block1)
+	h1, _ := hashutil.HashBeaconBlock(block1)
 
 	err := db.SaveBlock(block1)
 	if err != nil {
@@ -45,7 +45,7 @@ func TestSave(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get block: %v", err)
 	}
-	h1Prime, _ := b.Hash(b1Prime)
+	h1Prime, _ := hashutil.HashBeaconBlock(b1Prime)
 
 	if b1Prime == nil || h1 != h1Prime {
 		t.Fatalf("get should return b1: %x", h1)
@@ -54,7 +54,7 @@ func TestSave(t *testing.T) {
 	block2 := &pb.BeaconBlock{
 		Slot: 0,
 	}
-	h2, _ := b.Hash(block2)
+	h2, _ := hashutil.HashBeaconBlock(block2)
 
 	err = db.SaveBlock(block2)
 	if err != nil {
@@ -65,7 +65,7 @@ func TestSave(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get block: %v", err)
 	}
-	h2Prime, _ := b.Hash(b2Prime)
+	h2Prime, _ := hashutil.HashBeaconBlock(b2Prime)
 	if b2Prime == nil || h2 != h2Prime {
 		t.Fatalf("get should return b2: %x", h2)
 	}
@@ -116,7 +116,7 @@ func TestUpdateChainHead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get genesis block: %v", err)
 	}
-	bHash, err := b.Hash(block)
+	bHash, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		t.Fatalf("failed to get hash of b: %v", err)
 	}
@@ -130,7 +130,7 @@ func TestUpdateChainHead(t *testing.T) {
 		Slot:             1,
 		ParentRootHash32: bHash[:],
 	}
-	b2Hash, err := b.Hash(block2)
+	b2Hash, err := hashutil.HashBeaconBlock(block2)
 	if err != nil {
 		t.Fatalf("failed to hash b2: %v", err)
 	}
@@ -150,11 +150,11 @@ func TestUpdateChainHead(t *testing.T) {
 		t.Fatalf("failed to retrieve head: %v", err)
 	}
 
-	b2PrimeHash, err := b.Hash(b2Prime)
+	b2PrimeHash, err := hashutil.HashBeaconBlock(b2Prime)
 	if err != nil {
 		t.Fatalf("failed to hash b2Prime: %v", err)
 	}
-	b2SigmaHash, err := b.Hash(b2Sigma)
+	b2SigmaHash, err := hashutil.HashBeaconBlock(b2Sigma)
 	if err != nil {
 		t.Fatalf("failed to hash b2Sigma: %v", err)
 	}

--- a/beacon-chain/db/state.go
+++ b/beacon-chain/db/state.go
@@ -42,7 +42,7 @@ func (db *BeaconDB) InitializeState() error {
 	stateHash := hashutil.Hash(stateEnc)
 	genesisBlock := b.NewGenesisBlock(stateHash[:])
 	// #nosec G104
-	blockHash, _ := b.Hash(genesisBlock)
+	blockHash, _ := hashutil.HashBeaconBlock(genesisBlock)
 	// #nosec G104
 	blockEnc, _ := proto.Marshal(genesisBlock)
 	zeroBinary := encodeSlotNumber(0)

--- a/beacon-chain/dbcleanup/BUILD.bazel
+++ b/beacon-chain/dbcleanup/BUILD.bazel
@@ -6,10 +6,10 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/dbcleanup",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/hashutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
@@ -19,12 +19,12 @@ go_test(
     srcs = ["service_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/internal:go_default_library",
         "//beacon-chain/utils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/hashutil:go_default_library",
         "//shared/testutil:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],

--- a/beacon-chain/dbcleanup/service.go
+++ b/beacon-chain/dbcleanup/service.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"fmt"
 
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/event"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/sirupsen/logrus"
 )
 
@@ -107,7 +107,7 @@ func (d *CleanupService) cleanBlockVoteCache(latestFinalizedSlot uint64) error {
 		}
 		if block != nil {
 			var blockHash [32]byte
-			blockHash, err = b.Hash(block)
+			blockHash, err = hashutil.HashBeaconBlock(block)
 			if err != nil {
 				return fmt.Errorf("failed to get hash of block: %v", err)
 			}

--- a/beacon-chain/dbcleanup/service_test.go
+++ b/beacon-chain/dbcleanup/service_test.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"testing"
 
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/internal"
 	"github.com/prysmaticlabs/prysm/beacon-chain/utils"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/event"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
@@ -67,7 +67,7 @@ func TestCleanBlockVoteCache(t *testing.T) {
 		t.Fatalf("failed to initialize DB: %v", err)
 	}
 	oldBlock := &pb.BeaconBlock{Slot: 1}
-	oldBlockHash, _ := b.Hash(oldBlock)
+	oldBlockHash, _ := hashutil.HashBeaconBlock(oldBlock)
 	if err = beaconDB.SaveBlock(oldBlock); err != nil {
 		t.Fatalf("failed to write block int DB: %v", err)
 	}

--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/rpc",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/db:go_default_library",

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gogo/protobuf/proto"
 	ptypes "github.com/gogo/protobuf/types"
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
@@ -210,7 +209,7 @@ func (s *Service) CurrentAssignmentsAndGenesisTime(
 // sends the request into a beacon block that can then be included in a canonical chain.
 func (s *Service) ProposeBlock(ctx context.Context, blk *pbp2p.BeaconBlock) (*pb.ProposeResponse, error) {
 
-	h, err := b.Hash(blk)
+	h, err := hashutil.HashBeaconBlock(blk)
 	if err != nil {
 		return nil, fmt.Errorf("could not hash block: %v", err)
 	}

--- a/beacon-chain/simulator/BUILD.bazel
+++ b/beacon-chain/simulator/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/simulator",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/db:go_default_library",
@@ -14,6 +13,7 @@ go_library(
         "//shared/bitutil:go_default_library",
         "//shared/bytes:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/hashutil:go_default_library",
         "//shared/p2p:go_default_library",
         "//shared/params:go_default_library",
         "//shared/slotticker:go_default_library",

--- a/beacon-chain/simulator/service.go
+++ b/beacon-chain/simulator/service.go
@@ -8,19 +8,19 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gogo/protobuf/proto"
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bitutil"
+	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
 	"github.com/prysmaticlabs/prysm/shared/event"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/slotticker"
 	"github.com/sirupsen/logrus"
-	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
-	)
+)
 
 var log = logrus.WithField("prefix", "simulator")
 
@@ -153,7 +153,7 @@ func (sim *Simulator) run(slotInterval <-chan uint64) {
 		return
 	}
 
-	lastHash, err := b.Hash(lastBlock)
+	lastHash, err := hashutil.HashBeaconBlock(lastBlock)
 	if err != nil {
 		log.Errorf("Could not get hash of the latest block: %v", err)
 	}
@@ -177,7 +177,7 @@ func (sim *Simulator) run(slotInterval <-chan uint64) {
 				continue
 			}
 
-			hash, err := b.Hash(block)
+			hash, err := hashutil.HashBeaconBlock(block)
 			if err != nil {
 				log.Errorf("Could not hash simulated block: %v", err)
 				continue
@@ -393,7 +393,7 @@ func (sim *Simulator) SendChainHead(peer p2p.Peer) error {
 		return err
 	}
 
-	hash, err := b.Hash(block)
+	hash, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytes:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/hashutil:go_default_library",
         "//shared/p2p:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -33,7 +34,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/internal:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -6,12 +6,12 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytes:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/hashutil:go_default_library",
         "//shared/p2p:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -19,14 +19,14 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 
 	"github.com/gogo/protobuf/proto"
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
 	"github.com/prysmaticlabs/prysm/shared/event"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
-	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
 )
 
 var log = logrus.WithField("prefix", "initial-sync")
@@ -337,7 +337,7 @@ func (s *InitialSync) requestStateFromPeer(block *pb.BeaconBlock, peer p2p.Peer)
 // setBlockForInitialSync sets the first received block as the base finalized
 // block for initial sync.
 func (s *InitialSync) setBlockForInitialSync(block *pb.BeaconBlock) error {
-	h, err := b.Hash(block)
+	h, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		return err
 	}
@@ -377,7 +377,7 @@ func (s *InitialSync) requestBatchedBlocks(endSlot uint64) {
 // routine can be added to the chain.
 func (s *InitialSync) validateAndSaveNextBlock(block *pb.BeaconBlock) error {
 
-	h, err := b.Hash(block)
+	h, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		return err
 	}
@@ -408,7 +408,7 @@ func (s *InitialSync) validateAndSaveNextBlock(block *pb.BeaconBlock) error {
 
 func (s *InitialSync) checkBlockValidity(block *pb.BeaconBlock) error {
 
-	blockHash, err := b.Hash(block)
+	blockHash, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		return fmt.Errorf("could not hash received block: %v", err)
 	}

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -7,16 +7,15 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/internal"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"
-	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
 )
 
 type mockP2P struct {
@@ -102,7 +101,7 @@ func TestSetBlockForInitialSync(t *testing.T) {
 	<-exitRoutine
 
 	stateHash := bytesutil.ToBytes32(blockResponse.Block.StateRootHash32)
-	
+
 	if stateHash != ss.initialStateRootHash32 {
 		t.Fatalf("Beacon state hash not updated: %#x", blockResponse.Block.StateRootHash32)
 	}
@@ -364,7 +363,7 @@ func TestRequestBlocksBySlot(t *testing.T) {
 			Block: block,
 		}
 
-		hash, err := b.Hash(block)
+		hash, err := hashutil.HashBeaconBlock(block)
 		if err != nil {
 			t.Fatalf("unable to hash block %v", err)
 		}

--- a/beacon-chain/sync/regular_sync.go
+++ b/beacon-chain/sync/regular_sync.go
@@ -7,15 +7,15 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	att "github.com/prysmaticlabs/prysm/beacon-chain/core/attestations"
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
 	"github.com/prysmaticlabs/prysm/shared/event"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
-	bytesutil "github.com/prysmaticlabs/prysm/shared/bytes"
 )
 
 var log = logrus.WithField("prefix", "regular-sync")
@@ -205,7 +205,7 @@ func (rs *RegularSync) receiveBlock(msg p2p.Message) {
 
 	response := msg.Data.(*pb.BeaconBlockResponse)
 	block := response.Block
-	blockHash, err := b.Hash(block)
+	blockHash, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		log.Errorf("Could not hash received block: %v", err)
 	}
@@ -295,7 +295,7 @@ func (rs *RegularSync) handleChainHeadRequest(msg p2p.Message) {
 		return
 	}
 
-	hash, err := b.Hash(block)
+	hash, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		log.Errorf("Could not hash block %v", err)
 		return

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/internal"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -144,7 +143,7 @@ func TestProcessBlock(t *testing.T) {
 	if err := db.SaveBlock(parentBlock); err != nil {
 		t.Fatalf("failed to save block: %v", err)
 	}
-	parentHash, err := b.Hash(parentBlock)
+	parentHash, err := hashutil.HashBeaconBlock(parentBlock)
 	if err != nil {
 		t.Fatalf("failed to get parent hash: %v", err)
 	}
@@ -223,7 +222,7 @@ func TestProcessMultipleBlocks(t *testing.T) {
 	if err := db.SaveBlock(parentBlock); err != nil {
 		t.Fatalf("failed to save block: %v", err)
 	}
-	parentHash, err := b.Hash(parentBlock)
+	parentHash, err := hashutil.HashBeaconBlock(parentBlock)
 	if err != nil {
 		t.Fatalf("failed to get parent hash: %v", err)
 	}

--- a/shared/hashutil/BUILD.bazel
+++ b/shared/hashutil/BUILD.bazel
@@ -3,20 +3,30 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "beacon_block.go",
         "hash.go",
         "merkleRoot.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/shared/hashutil",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_crypto//sha3:go_default_library"],
+    deps = [
+        "//proto/beacon/p2p/v1:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@org_golang_x_crypto//sha3:go_default_library",
+    ],
 )
 
 go_test(
     name = "go_default_test",
     srcs = [
+        "beacon_block_test.go",
         "hash_test.go",
         "merkleRoot_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["//shared/bytes:go_default_library"],
+    deps = [
+        "//proto/beacon/p2p/v1:go_default_library",
+        "//shared/bytes:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+    ],
 )

--- a/shared/hashutil/beacon_block.go
+++ b/shared/hashutil/beacon_block.go
@@ -1,0 +1,24 @@
+package hashutil
+
+import (
+	"github.com/gogo/protobuf/proto"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+)
+
+// HashBeaconBlock hashes the full block without the proposer signature.
+// The proposer signature is ignored in order obtain the same block hash used
+// as the "block_root" property in the proposer signature data.
+func HashBeaconBlock(bb *pb.BeaconBlock) ([32]byte, error) {
+	// Ignore the proposer signature by temporarily deleting it.
+	sig := bb.Signature
+	bb.Signature = nil
+	defer func() { bb.Signature = sig }()
+
+	// TODO(#1253): Use SSZ instead of proto marshal.
+	data, err := proto.Marshal(bb)
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	return Hash(data), nil
+}

--- a/shared/hashutil/beacon_block_test.go
+++ b/shared/hashutil/beacon_block_test.go
@@ -1,0 +1,35 @@
+package hashutil_test
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
+)
+
+func TestHashBeaconBlock_doesntMutate(t *testing.T) {
+	a := &pb.BeaconBlock{
+		Body: &pb.BeaconBlockBody{
+			Attestations: []*pb.Attestation{
+				&pb.Attestation{
+					Data: &pb.AttestationData{
+						Slot:  123,
+						Shard: 456,
+					},
+				},
+			},
+		},
+		Signature: [][]byte{[]byte{'S', 'I', 'G'}},
+	}
+	b := proto.Clone(a).(*pb.BeaconBlock)
+
+	_, err := hashutil.HashBeaconBlock(b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !proto.Equal(a, b) {
+		t.Error("Protos are not equal!")
+	}
+}

--- a/validator/proposer/service.go
+++ b/validator/proposer/service.go
@@ -205,12 +205,10 @@ func (p *Proposer) computeBlockToBeProposed(latestBlock *pbp2p.BeaconBlock,
 
 	}
 
-	// TODO(#1253): Change this to be serialized using SSZ instead of protobufs.
-	data, err := proto.Marshal(latestBlock)
+	latestBlockHash, err := hashutil.HashBeaconBlock(latestBlock)
 	if err != nil {
-		return nil, fmt.Errorf("could not marshal latest beacon block: %v", err)
+		return nil, fmt.Errorf("could not hash latest beacon block: %v", err)
 	}
-	latestBlockHash := hashutil.Hash(data)
 
 	powChainHashRes, err := client.LatestPOWChainBlockHash(p.ctx, nil)
 	if err != nil {


### PR DESCRIPTION
Two pieces to this PR:

- Refactor / move the hash method for beacon block to shared directory so that the validator can use it. 
- Ignore the proposer signature when hashing the block. This is necessary to verify the proposer signature as the `block_root` property. 