### PR TITLE
Encoding/Decoding Deposit Data Fix

### DIFF
--- a/beacon-chain/core/blocks/block.go
+++ b/beacon-chain/core/blocks/block.go
@@ -180,6 +180,8 @@ func DecodeDepositInput(depositData []byte) (*pb.DepositInput, error) {
 		)
 	}
 	depositInput := new(pb.DepositInput)
+	// Since the value deposited and the timestamp are both 8 bytes each,
+	// the deposit data is the chunk after the first 16 bytes.
 	depositInputBytes := depositData[16:]
 	rBuf := bytes.NewReader(depositInputBytes)
 	if err := ssz.Decode(rBuf, depositInput); err != nil {
@@ -201,6 +203,8 @@ func DecodeDepositAmountAndTimeStamp(depositData []byte) (uint64, int64, error) 
 		)
 	}
 
+	// the amount occupies the first 8 bytes while the
+	// timestamp occupies the next 8 bytes.
 	amount := binary.BigEndian.Uint64(depositData[:8])
 	timestamp := binary.BigEndian.Uint64(depositData[8:16])
 

--- a/beacon-chain/core/blocks/block.go
+++ b/beacon-chain/core/blocks/block.go
@@ -157,9 +157,10 @@ func EncodeDepositData(
 	timestamp := make([]byte, 8)
 	binary.BigEndian.PutUint64(timestamp, uint64(depositTimestamp))
 
-	depositData = append(depositData, encodedInput...)
 	depositData = append(depositData, value...)
 	depositData = append(depositData, timestamp...)
+	depositData = append(depositData, encodedInput...)
+
 	return depositData, nil
 }
 
@@ -179,7 +180,7 @@ func DecodeDepositInput(depositData []byte) (*pb.DepositInput, error) {
 		)
 	}
 	depositInput := new(pb.DepositInput)
-	depositInputBytes := depositData[:len(depositData)-16]
+	depositInputBytes := depositData[16:]
 	rBuf := bytes.NewReader(depositInputBytes)
 	if err := ssz.Decode(rBuf, depositInput); err != nil {
 		return nil, fmt.Errorf("ssz decode failed: %v", err)
@@ -199,9 +200,9 @@ func DecodeDepositAmountAndTimeStamp(depositData []byte) (uint64, int64, error) 
 			len(depositData),
 		)
 	}
-	length := len(depositData)
-	amount := binary.BigEndian.Uint64(depositData[length-16 : length-8])
-	timestamp := binary.BigEndian.Uint64(depositData[length-8:])
+
+	amount := binary.BigEndian.Uint64(depositData[:8])
+	timestamp := binary.BigEndian.Uint64(depositData[8:16])
 
 	return amount, int64(timestamp), nil
 }

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -564,9 +564,9 @@ func ProcessValidatorDeposits(
 		if err = verifyDeposit(beaconState, deposit); err != nil {
 			return nil, fmt.Errorf("could not verify deposit #%d: %v", idx, err)
 		}
-		// depositData consists of depositInput []byte + depositValue [8]byte +
-		// depositTimestamp [8]byte.
-		depositValue := depositData[len(depositData)-16 : len(depositData)-8]
+		// depositData consists of depositValue [8]byte +
+		// depositTimestamp [8]byte + depositInput []byte .
+		depositValue := depositData[:8]
 		// We then mutate the beacon state with the verified validator deposit.
 		beaconState, err = v.ProcessDeposit(
 			beaconState,

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -9,11 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prysmaticlabs/prysm/shared/trie"
-
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/ssz"
+	"github.com/prysmaticlabs/prysm/shared/trie"
 )
 
 func TestProcessPOWReceiptRoots_SameRootHash(t *testing.T) {
@@ -1280,9 +1279,9 @@ func TestProcessValidatorDeposits_ProcessDepositHelperFuncFails(t *testing.T) {
 
 	// We then create a serialized deposit data slice of type []byte
 	// by appending all 3 items above together.
-	data = append(data, encodedInput...)
 	data = append(data, value...)
 	data = append(data, timestamp...)
+	data = append(data, encodedInput...)
 
 	// We then create a merkle branch for the test.
 	depositTrie := trie.NewDepositTrie()
@@ -1359,9 +1358,9 @@ func TestProcessValidatorDeposits_ProcessCorrectly(t *testing.T) {
 
 	// We then create a serialized deposit data slice of type []byte
 	// by appending all 3 items above together.
-	data = append(data, encodedInput...)
 	data = append(data, value...)
 	data = append(data, timestamp...)
+	data = append(data, encodedInput...)
 
 	// We then create a merkle branch for the test.
 	depositTrie := trie.NewDepositTrie()


### PR DESCRIPTION
How we encoded and decoded deposit data , was wrong as it followed the wrong ordering as compared to how the VRC concatenates the data. This caused bugs when trying to test for logs emitted from the VRC, as the decoding was incorrect. This PR fixes that.