### PR TITLE
Allow for CLI Subcommands Validator Client

### DIFF
--- a/validator/main.go
+++ b/validator/main.go
@@ -22,12 +22,17 @@ func startNode(ctx *cli.Context) error {
 	}
 	logrus.SetLevel(level)
 
-	shardingNode, err := node.NewValidatorClient(ctx)
+	validatorClient, err := node.NewValidatorClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	shardingNode.Start()
+	validatorClient.Start()
+	return nil
+}
+
+// TODO(#1436): Initialize validator secrets.
+func createValidatorAccount(ctx *cli.Context) error {
 	return nil
 }
 
@@ -59,13 +64,33 @@ VERSION:
 
 	app := cli.NewApp()
 	app.Name = "validator"
-	app.Usage = `launches an Ethereum Serenity validator client that interacts with a beacon chain, starts proposer services, shardp2p connections, and more
-`
+	app.Usage = `launches an Ethereum Serenity validator client that interacts with a beacon chain, 
+				 starts proposer services, shardp2p connections, and more`
 	app.Version = version.GetVersion()
 	app.Action = startNode
+
+	app.Commands = []cli.Command{
+		{
+			Name:     "accounts",
+			Category: "accounts",
+			Usage:    "defines useful functions for interacting with the validator client's account",
+			Subcommands: cli.Commands{
+				cli.Command{
+					Name: "create",
+					Description: `creates a new validator account keystore containing private keys for Ethereum Serenity - 
+this command outputs a deposit data string which can be used to deposit Ether into the ETH1.0 deposit 
+contract in order to activate the validator client`,
+					Flags: []cli.Flag{
+						types.KeystorePathFlag,
+					},
+					Action: createValidatorAccount,
+				},
+			},
+		},
+	}
+
 	app.Flags = []cli.Flag{
 		types.BeaconRPCProviderFlag,
-		types.PubKeyFlag,
 		cmd.VerbosityFlag,
 		cmd.DataDirFlag,
 		cmd.EnableTracingFlag,

--- a/validator/types/flags.go
+++ b/validator/types/flags.go
@@ -11,14 +11,14 @@ var (
 		Usage: "Beacon node RPC provider endpoint",
 		Value: "localhost:4000",
 	}
-	// PubKeyFlag defines a flag for validator's public key on the mainchain
-	PubKeyFlag = cli.StringFlag{
-		Name:  "pubkey",
-		Usage: "Validator's public key. The public key will be used to identify the validator to the beacon-node",
-	}
 	// CertFlag defines a flag for the node's TLS certificate.
 	CertFlag = cli.StringFlag{
 		Name:  "tls-cert",
 		Usage: "Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.",
+	}
+	// KeystorePathFlag defines the location of the keystore directory for a validator's account.
+	KeystorePathFlag = cli.StringFlag{
+		Name:  "keystore-path",
+		Usage: "path to the desired keystore directory",
 	}
 )


### PR DESCRIPTION
This is a pre-req to #1436. This PR incorporates the structure used by geth for subcommands such as

```
geth accounts new
```

into our validator client. Now, we can create a new validator client account with the command:
```
bazel run //validator -- accounts create
```
This will be a pre-requisite to launching a validator client as the client would expect the user to have created a new private key and keystore to use in the system.