### PR TITLE
Fix missing import in validator image

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -18,4 +18,3 @@ build --test_output=errors
 build --flaky_test_attempts=5
 # Disabled race detection due to unstable test results under constrained environment build kite
 # build --features=race
-build --build_manual_tests

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -18,3 +18,4 @@ build --test_output=errors
 build --flaky_test_attempts=5
 # Disabled race detection due to unstable test results under constrained environment build kite
 # build --features=race
+build --build_manual_tests

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -33,6 +33,7 @@ go_image(
         "//shared/version:go_default_library",
         "//shared/cmd:go_default_library",
         "//shared/debug:go_default_library",
+        "//validator/accounts:go_default_library",
         "//validator/node:go_default_library",
         "//validator/types:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",


### PR DESCRIPTION
We probably should enforce these builds in buildkite. They are currently not selected in `//...` since they have the manual tag.

Edit: Added `--build_manual_tests` to build all manual targets. 
Edit2: `--build_manual_tests` doesn't work because the buildkite runners don't have access to the secrets in k8s. Will look alternative solutions later...