### PR TITLE
Update config for deposits processing

### DIFF
--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -52,8 +52,8 @@ func TestCanProcessEpoch(t *testing.T) {
 }
 
 func TestCanProcessEth1Data(t *testing.T) {
-	if config.Eth1DataVotingPeriod != 1024 {
-		t.Errorf("Eth1DataVotingPeriod should be 1024 for these tests to pass")
+	if config.Eth1DataVotingPeriod != 16 {
+		t.Errorf("Eth1DataVotingPeriod should be 16 for these tests to pass")
 	}
 	tests := []struct {
 		slot               uint64
@@ -64,15 +64,15 @@ func TestCanProcessEth1Data(t *testing.T) {
 			canProcessEth1Data: false,
 		},
 		{
-			slot:               1022,
+			slot:               15,
 			canProcessEth1Data: false,
 		},
 		{
-			slot:               1024,
+			slot:               16,
 			canProcessEth1Data: true,
 		},
 		{
-			slot:               4096,
+			slot:               32,
 			canProcessEth1Data: true,
 		},
 		{
@@ -94,9 +94,6 @@ func TestCanProcessEth1Data(t *testing.T) {
 }
 
 func TestProcessEth1Data(t *testing.T) {
-	if config.Eth1DataVotingPeriod != 1024 {
-		t.Errorf("Eth1DataVotingPeriod should be 1024 for these tests to pass")
-	}
 	requiredVoteCount := config.Eth1DataVotingPeriod
 	state := &pb.BeaconState{
 		LatestEth1Data: &pb.Eth1Data{
@@ -157,9 +154,6 @@ func TestProcessEth1Data(t *testing.T) {
 }
 
 func TestProcessEth1Data_InactionSlot(t *testing.T) {
-	if config.Eth1DataVotingPeriod != 1024 {
-		t.Errorf("Eth1DataVotingPeriod should be 1024 for these tests to pass")
-	}
 	requiredVoteCount := config.Eth1DataVotingPeriod
 	state := &pb.BeaconState{
 		Slot: 4,

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -50,7 +50,8 @@ type BeaconChainConfig struct {
 	EpochLength                  uint64 // EpochLength is the number of slots in an epoch.
 	SeedLookahead                uint64 // SeedLookahead is the duration of randao look ahead seed.
 	EntryExitDelay               uint64 // EntryExitDelay is the duration a validator has to wait for entry and exit.
-	Eth1DataVotingPeriod         uint64 // Eth1DataVotingPeriod defines how often the merkle root of deposit receipts get updated in beacon node.
+	Eth1DataVotingPeriod         uint64 // Eth1DataVotingPeriod defines how often (epochs) the merkle root of deposit receipts get updated in beacon node.
+	Eth1FollowDistance           uint64 // Eth1FollowDistance is the number of eth1.0 blocks to wait before considering a new deposit for voting. This only applies after the chain as been started.
 	MinValidatorWithdrawalTime   uint64 // MinValidatorWithdrawalTime is the shortest amount of time a validator can get the deposit out.
 	FarFutureSlot                uint64 // FarFutureSlot represents a slot extremely far away in the future used as the default penalization slot for validators.
 
@@ -122,7 +123,8 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	EpochLength:                  64,
 	SeedLookahead:                64,
 	EntryExitDelay:               256,
-	Eth1DataVotingPeriod:         1024,
+	Eth1DataVotingPeriod:         16,
+	Eth1FollowDistance:           1024,
 
 	// Reward and penalty quotients constants.
 	BaseRewardQuotient:           32,
@@ -179,6 +181,7 @@ var demoBeaconConfig = &BeaconChainConfig{
 	SeedLookahead:                defaultBeaconConfig.SeedLookahead,
 	EntryExitDelay:               defaultBeaconConfig.EntryExitDelay,
 	Eth1DataVotingPeriod:         defaultBeaconConfig.Eth1DataVotingPeriod,
+	Eth1FollowDistance:           defaultBeaconConfig.Eth1FollowDistance,
 
 	// Reward and penalty quotients constants.
 	BaseRewardQuotient:           defaultBeaconConfig.BaseRewardQuotient,


### PR DESCRIPTION
Part of #1449

Updates ETH1_DATA_VOTING_PERIOD and ETH1_FOLLOW_DISTANCE as of v0.1.

The deposit flow is (after chainstart):
1. Validator makes deposit
1. Deposit log is emitted 
1. The beacon chain stores this in a queue
1. After ETH1_FOLLOW_DISTANCE, the deposit is eligible for voting / block inclusion as block.body.deposits[] 
1. After ETH1_DATA_VOTING_PERIOD, the deposit is finalized and the validator joins the active set