### PR TITLE
Validator Attester Rewrite

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -136,10 +136,3 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64) {
 	defer span.Finish()
 }
 
-// AttestToBlockHead
-//
-// WIP - not done.
-func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "validator.AttestToBlockHead")
-	defer span.Finish()
-}

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"context"
+	"github.com/opentracing/opentracing-go"
+)
+
+// AttestToBlockHead
+//
+// WIP - not done.
+func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "validator.AttestToBlockHead")
+	defer span.Finish()
+	// First the validator should construct attestation_data, an AttestationData
+	// object based upon the state at the assigned slot.
+}


### PR DESCRIPTION
Part of #1486 

---

# Description

This PR writes most of the attester responsibility for a validator client as defined in the validator spec [here](https://github.com/ethereum/eth2.0-specs/blob/master/specs/validator/0_beacon-chain-validator.md).

- Similar to @prestonvanloon's changes for proposals, this moves the attestation logic to its own file
- This does not include BLS signature verification until #1367 is merged, which can be done in a separate PR
- This PR does not implement broadcasting the attestation to the network, which may be done by the beacon node's sync service
