### PR TITLE
Override reasonable defaults for bazel test timeout

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -16,5 +16,6 @@ build --curses=yes --color=yes
 build --keep_going
 build --test_output=errors
 build --flaky_test_attempts=5
+build --test_timeout=5,60,-1,-1
 # Disabled race detection due to unstable test results under constrained environment build kite
 # build --features=race


### PR DESCRIPTION
This sets the timeout for short tests to 5 seconds, medium tests to 60 seconds, and the long or enormous tests will use their default timeout values.  

This is needed because the default test size is medium which has a timeout of 5 minutes. The test runner will run the test 5 times for flakiness which means the runner is bogged down for 25 minutes. 