### PR TITLE
Align Initial Beacon State to Latest Spec

### DIFF
--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//shared/trieutil:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/beacon-chain/core/blocks/block.go
+++ b/beacon-chain/core/blocks/block.go
@@ -27,6 +27,10 @@ func NewGenesisBlock(stateRoot []byte) *pb.BeaconBlock {
 		StateRootHash32:    stateRoot,
 		RandaoRevealHash32: params.BeaconConfig().ZeroHash[:],
 		Signature:          params.BeaconConfig().EmptySignature,
+		Eth1Data: &pb.Eth1Data{
+			DepositRootHash32: params.BeaconConfig().ZeroHash[:],
+			BlockHash32:       params.BeaconConfig().ZeroHash[:],
+		},
 		Body: &pb.BeaconBlockBody{
 			ProposerSlashings: []*pb.ProposerSlashing{},
 			AttesterSlashings: []*pb.AttesterSlashing{},

--- a/beacon-chain/core/blocks/block_test.go
+++ b/beacon-chain/core/blocks/block_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -28,6 +29,13 @@ func TestGenesisBlock(t *testing.T) {
 
 	if !bytes.Equal(b1.StateRootHash32, stateHash) {
 		t.Error("genesis block StateRootHash32 isn't initialized correctly")
+	}
+	expectedEth1 := &pb.Eth1Data{
+		DepositRootHash32: params.BeaconConfig().ZeroHash[:],
+		BlockHash32:       params.BeaconConfig().ZeroHash[:],
+	}
+	if !proto.Equal(b1.Eth1Data, expectedEth1) {
+		t.Error("genesis block Eth1Data isn't initialized correctly")
 	}
 
 	rd := []byte{}

--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/ssz:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],
 )
@@ -32,10 +33,12 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/core/blocks:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/ssz:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],
 )

--- a/beacon-chain/core/state/state_test.go
+++ b/beacon-chain/core/state/state_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/shared/ssz"
+
 	"github.com/gogo/protobuf/proto"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -147,6 +150,24 @@ func TestInitialBeaconState_Ok(t *testing.T) {
 	}
 	if !reflect.DeepEqual(state.BatchedBlockRootHash32S, [][]byte{}) {
 		t.Error("BatchedBlockRootHash32S was not correctly initialized")
+	}
+	activeValidators := helpers.ActiveValidatorIndices(state.ValidatorRegistry, params.BeaconConfig().GenesisEpoch)
+	genesisActiveIndexRoot, err := ssz.TreeHash(activeValidators)
+	if err != nil {
+		t.Fatalf("Could not determine genesis active index root: %v", err)
+	}
+	if !bytes.Equal(state.LatestIndexRootHash32S[0], genesisActiveIndexRoot[:]) {
+		t.Errorf(
+			"Expected index roots to be the tree hash root of active validator indices, received %#x",
+			state.LatestIndexRootHash32S[0],
+		)
+	}
+	seed, err := helpers.GenerateSeed(state, params.BeaconConfig().GenesisEpoch)
+	if err != nil {
+		t.Fatalf("Could not generate initial seed: %v", err)
+	}
+	if !bytes.Equal(seed[:], state.CurrentEpochSeedHash32) {
+		t.Errorf("Expected current epoch seed to be %#x, received %#x", seed[:], state.CurrentEpochSeedHash32)
 	}
 
 	// deposit root checks.


### PR DESCRIPTION
No tracking issue for this PR.

---

# Description

This PR implements the last lines of the on_startup routine for the beacon chain as defined in the spec at commit hash [190d9d288736ec43b833eb32ba8fb4b7aee1046c](https://github.com/ethereum/eth2.0-specs/tree/190d9d288736ec43b833eb32ba8fb4b7aee1046c) which are missing from our current master branch.

```python
genesis_active_index_root = hash_tree_root(get_active_validator_indices(state, GENESIS_EPOCH))
for index in range(LATEST_INDEX_ROOTS_LENGTH):
    state.latest_index_roots[index] = genesis_active_index_root
state.current_epoch_seed = generate_seed(state, GENESIS_EPOCH)
```
This PR also adds ETH1Data to our genesis block function as:
```python
eth1_data=Eth1Data(
    deposit_root=ZERO_HASH,
    block_hash=ZERO_HASH
),
```