### PR TITLE
Support Encode/Decode of Nil Pointer

### DIFF
--- a/shared/ssz/decode.go
+++ b/shared/ssz/decode.go
@@ -277,26 +277,27 @@ func makeStructDecoder(typ reflect.Type) (decoder, error) {
 	return decoder, nil
 }
 
-// Notice: Currently we don't support nil pointer:
-// - Input for encoding must not contain nil pointer
-// - Output for decoding will never contain nil pointer
-// (Not to be confused with empty slice. Empty slice is supported)
 func makePtrDecoder(typ reflect.Type) (decoder, error) {
 	elemType := typ.Elem()
 	elemSSZUtils, err := cachedSSZUtilsNoAcquireLock(elemType)
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO(1461): The decoding of nil pointer isn't defined in the spec.
+	// After considered the use case in Prysm, we've decided that:
+	// - We assume we will only encode/decode pointer to array, slice or struct.
+	// - The encoding for such nil pointer shall be 0x00000000.
+
 	decoder := func(r io.Reader, val reflect.Value) (uint32, error) {
-		newVal := val
-		if val.IsNil() {
-			newVal = reflect.New(elemType)
-		}
+		newVal := reflect.New(elemType)
 		elemDecodeSize, err := elemSSZUtils.decoder(r, newVal.Elem())
 		if err != nil {
 			return 0, fmt.Errorf("failed to decode to object pointed by pointer: %v", err)
 		}
-		val.Set(newVal)
+		if elemDecodeSize != lengthBytes {
+			val.Set(newVal)
+		} // Else we leave val to its default value which is nil
 		return elemDecodeSize, nil
 	}
 	return decoder, nil

--- a/shared/ssz/decode.go
+++ b/shared/ssz/decode.go
@@ -284,10 +284,10 @@ func makePtrDecoder(typ reflect.Type) (decoder, error) {
 		return nil, err
 	}
 
-	// TODO(1461): The decoding of nil pointer isn't defined in the spec.
+	// TODO(1461): The encoding of nil pointer isn't defined in the spec.
 	// After considered the use case in Prysm, we've decided that:
-	// - We assume we will only encode/decode pointer to array, slice or struct.
-	// - The encoding for such nil pointer shall be 0x00000000.
+	// - We assume we will only encode/decode pointer of array, slice or struct.
+	// - The encoding for nil pointer shall be 0x00000000.
 
 	decoder := func(r io.Reader, val reflect.Value) (uint32, error) {
 		newVal := reflect.New(elemType)
@@ -297,7 +297,7 @@ func makePtrDecoder(typ reflect.Type) (decoder, error) {
 		}
 		if elemDecodeSize != lengthBytes {
 			val.Set(newVal)
-		} // Else we leave val to its default value which is nil
+		} // Else we leave val to its default value which is nil.
 		return elemDecodeSize, nil
 	}
 	return decoder, nil

--- a/shared/ssz/decode.go
+++ b/shared/ssz/decode.go
@@ -295,7 +295,7 @@ func makePtrDecoder(typ reflect.Type) (decoder, error) {
 		if err != nil {
 			return 0, fmt.Errorf("failed to decode to object pointed by pointer: %v", err)
 		}
-		if elemDecodeSize != lengthBytes {
+		if elemDecodeSize > lengthBytes {
 			val.Set(newVal)
 		} // Else we leave val to its default value which is nil.
 		return elemDecodeSize, nil

--- a/shared/ssz/decode_test.go
+++ b/shared/ssz/decode_test.go
@@ -132,6 +132,12 @@ var decodeTests = []decodeTest{
 		},
 	},
 
+	// nil pointer
+	{input: "00000000", ptr: new(*[]uint8), value: (*[]uint8)(nil)},
+	{input: "05000000 00000000 00", ptr: new(pointerStruct), value: pointerStruct{}},
+	{input: "05000000 00000000 00", ptr: new(*pointerStruct), value: &pointerStruct{}},
+	{input: "08000000 00000000 00000000", ptr: new([]*pointerStruct), value: []*pointerStruct{nil, nil}},
+
 	// error: nil target
 	{input: "00", ptr: nil, value: nil, error: "decode error: cannot decode into nil for output type <nil>"},
 

--- a/shared/ssz/encode.go
+++ b/shared/ssz/encode.go
@@ -38,7 +38,7 @@ type encbuf struct {
 
 func (w *encbuf) encode(val interface{}) error {
 	if val == nil {
-		return newEncodeError("nil is not supported", nil)
+		return newEncodeError("untyped nil is not supported", nil)
 	}
 	rval := reflect.ValueOf(val)
 	sszUtils, err := cachedSSZUtils(rval.Type())
@@ -53,7 +53,7 @@ func (w *encbuf) encode(val interface{}) error {
 
 func encodeSize(val interface{}) (uint32, error) {
 	if val == nil {
-		return 0, newEncodeError("nil is not supported", nil)
+		return 0, newEncodeError("untyped nil is not supported", nil)
 	}
 	rval := reflect.ValueOf(val)
 	sszUtils, err := cachedSSZUtils(rval.Type())
@@ -261,26 +261,29 @@ func makeStructEncoder(typ reflect.Type) (encoder, encodeSizer, error) {
 	return encoder, encodeSizer, nil
 }
 
-// Notice: Currently we don't support nil pointer:
-// - Input for encoding must not contain nil pointer
-// - Output for decoding will never contain nil pointer
-// (Not to be confused with empty slice. Empty slice is supported)
 func makePtrEncoder(typ reflect.Type) (encoder, encodeSizer, error) {
 	elemSSZUtils, err := cachedSSZUtilsNoAcquireLock(typ.Elem())
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// TODO(1461): The encoding of nil pointer isn't defined in the spec.
+	// After considered the use case in Prysm, we've decided that:
+	// - We assume we will only encode/decode pointer to array, slice or struct.
+	// - The encoding for such nil pointer shall be 0x00000000.
+
 	encoder := func(val reflect.Value, w *encbuf) error {
 		if val.IsNil() {
-			return errors.New("nil is not supported")
+			totalSizeEnc := make([]byte, lengthBytes)
+			w.str = append(w.str, totalSizeEnc...)
+			return nil
 		}
 		return elemSSZUtils.encoder(val.Elem(), w)
 	}
 
 	encodeSizer := func(val reflect.Value) (uint32, error) {
 		if val.IsNil() {
-			return 0, errors.New("nil is not supported")
+			return lengthBytes, nil
 		}
 		return elemSSZUtils.encodeSizer(val.Elem())
 	}

--- a/shared/ssz/encode.go
+++ b/shared/ssz/encode.go
@@ -269,8 +269,8 @@ func makePtrEncoder(typ reflect.Type) (encoder, encodeSizer, error) {
 
 	// TODO(1461): The encoding of nil pointer isn't defined in the spec.
 	// After considered the use case in Prysm, we've decided that:
-	// - We assume we will only encode/decode pointer to array, slice or struct.
-	// - The encoding for such nil pointer shall be 0x00000000.
+	// - We assume we will only encode/decode pointer of array, slice or struct.
+	// - The encoding for nil pointer shall be 0x00000000.
 
 	encoder := func(val reflect.Value, w *encbuf) error {
 		if val.IsNil() {

--- a/shared/ssz/encode_test.go
+++ b/shared/ssz/encode_test.go
@@ -122,10 +122,14 @@ var encodeTests = []encTest{
 		{P: &simpleStruct{B: 4, A: 3}, V: 1},
 	}, output: "18000000 08000000 03000000 0200 01 00 08000000 03000000 0400 03 01"},
 
-	// error: nil pointer
-	{val: nil, error: "encode error: nil is not supported for input type <nil>"},
-	{val: (*[]uint8)(nil), error: "encode error: nil is not supported for input type *[]uint8"},
-	{val: pointerStruct{P: nil, V: 0}, error: "encode error: failed to encode field of struct: nil is not supported for input type ssz.pointerStruct"},
+	// nil pointer (not defined in spec)
+	{val: (*[]uint8)(nil), output: "00000000"},
+	{val: pointerStruct{}, output: "05000000 00000000 00"},
+	{val: &pointerStruct{}, output: "05000000 00000000 00"},
+	{val: []*pointerStruct{nil, nil}, output: "08000000 00000000 00000000"},
+
+	// error: untyped nil pointer
+	{val: nil, error: "encode error: untyped nil is not supported for input type <nil>"},
 
 	// error: unsupported type
 	{val: string("abc"), error: "encode error: type string is not serializable for input type string"},
@@ -210,10 +214,14 @@ var encodeSizeTests = []encSizeTest{
 		{P: &simpleStruct{B: 4, A: 3}, V: 1},
 	}, size: 28},
 
-	// error: nil pointer
-	{val: nil, error: "encode error: nil is not supported for input type <nil>"},
-	{val: (*[]uint8)(nil), error: "encode error: nil is not supported for input type *[]uint8"},
-	{val: pointerStruct{P: nil, V: 0}, error: "encode error: failed to get encode size for field of struct: nil is not supported for input type ssz.pointerStruct"},
+	// nil pointer (not defined in spec)
+	{val: (*[]uint8)(nil), size: 4},
+	{val: pointerStruct{}, size: 9},
+	{val: &pointerStruct{}, size: 9},
+	{val: []*pointerStruct{nil, nil}, size: 12},
+
+	// error: untyped nil pointer
+	{val: nil, error: "encode error: untyped nil is not supported for input type <nil>"},
 
 	// error: unsupported type
 	{val: string("abc"), error: "encode error: type string is not serializable for input type string"},


### PR DESCRIPTION
This solves the issue #1461 

Since the encoding/decoding is not defined in the spec:
- We assume we will only encode/decode pointer of array, slice or struct.
- The encoding for nil pointer shall be `0x00000000`.

This introduces our custom logic and it might lead to issues when communicating between clients, so this is only a short-term walk-around. 