### PR TITLE
Disable gcc warnings for geth

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -124,7 +124,7 @@ go_repository(
 
 go_repository(
     name = "com_github_ethereum_go_ethereum",
-    commit = "ec3d1d97a481e6cba542751a6defae7c76e322f1",
+    commit = "2ed4a57e9522dc2a023577f0b92ff623c3412303",
     importpath = "github.com/ethereum/go-ethereum",
     # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
     # a fork that has resolved these issues by disabling HID/USB support and


### PR DESCRIPTION
Added a flag to disable / ignore all of the gcc warnings from sepc265k. This will make the CI runs less verbose. 