### PR TITLE
Revive Our Demo Config for Local Testing

### DIFF
--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -37,7 +37,7 @@ func generateTestGenesisStateAndBlock(
 		}
 		deposits[i] = &pb.Deposit{DepositData: depositData}
 	}
-	genesisTime := uint64(params.BeaconConfig().GenesisTime.Unix())
+	genesisTime := uint64(time.Unix(0, 0).Unix())
 	beaconState, err := state.InitialBeaconState(deposits, genesisTime, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/chaintest/backend/helpers.go
+++ b/beacon-chain/chaintest/backend/helpers.go
@@ -118,7 +118,7 @@ func generateSimulatedBlock(
 // Generates initial deposits for creating a beacon state in the simulated
 // backend based on the yaml configuration.
 func generateInitialSimulatedDeposits(numDeposits uint64) ([]*pb.Deposit, error) {
-	genesisTime := time.Unix(0, 0).Unix()
+	genesisTime := time.Date(2018, 9, 0, 0, 0, 0, 0, time.UTC).Unix()
 	deposits := make([]*pb.Deposit, numDeposits)
 	for i := 0; i < len(deposits); i++ {
 		depositInput := &pb.DepositInput{

--- a/beacon-chain/chaintest/backend/helpers.go
+++ b/beacon-chain/chaintest/backend/helpers.go
@@ -26,7 +26,7 @@ func generateSimulatedBlock(
 	if err != nil {
 		return nil, [32]byte{}, fmt.Errorf("could not tree hash state: %v", err)
 	}
-	randaoReveal := params.BeaconConfig().SimulatedBlockRandao
+	randaoReveal := [32byte{}
 	block := &pb.BeaconBlock{
 		Slot:               beaconState.Slot + 1,
 		RandaoRevealHash32: randaoReveal[:],
@@ -118,7 +118,7 @@ func generateSimulatedBlock(
 // Generates initial deposits for creating a beacon state in the simulated
 // backend based on the yaml configuration.
 func generateInitialSimulatedDeposits(numDeposits uint64) ([]*pb.Deposit, error) {
-	genesisTime := params.BeaconConfig().GenesisTime.Unix()
+	genesisTime := time.Unix(0, 0).Unix()
 	deposits := make([]*pb.Deposit, numDeposits)
 	for i := 0; i < len(deposits); i++ {
 		depositInput := &pb.DepositInput{

--- a/beacon-chain/chaintest/backend/helpers.go
+++ b/beacon-chain/chaintest/backend/helpers.go
@@ -26,7 +26,7 @@ func generateSimulatedBlock(
 	if err != nil {
 		return nil, [32]byte{}, fmt.Errorf("could not tree hash state: %v", err)
 	}
-	randaoReveal := [32byte{}
+	randaoReveal := [32]byte{}
 	block := &pb.BeaconBlock{
 		Slot:               beaconState.Slot + 1,
 		RandaoRevealHash32: randaoReveal[:],

--- a/beacon-chain/chaintest/backend/simulated_backend.go
+++ b/beacon-chain/chaintest/backend/simulated_backend.go
@@ -240,7 +240,7 @@ func (sb *SimulatedBackend) initializeStateTest(testCase *StateTestCase) error {
 // proceed with the test.
 func (sb *SimulatedBackend) setupBeaconStateAndGenesisBlock(initialDeposits []*pb.Deposit) error {
 	var err error
-	genesisTime := params.BeaconConfig().GenesisTime.Unix()
+	genesisTime := time.Unix(0, 0).Unix()
 	sb.state, err = state.InitialBeaconState(initialDeposits, uint64(genesisTime), nil)
 	if err != nil {
 		return fmt.Errorf("could not initialize simulated beacon state: %v", err)

--- a/beacon-chain/chaintest/backend/simulated_backend.go
+++ b/beacon-chain/chaintest/backend/simulated_backend.go
@@ -240,7 +240,7 @@ func (sb *SimulatedBackend) initializeStateTest(testCase *StateTestCase) error {
 // proceed with the test.
 func (sb *SimulatedBackend) setupBeaconStateAndGenesisBlock(initialDeposits []*pb.Deposit) error {
 	var err error
-	genesisTime := time.Unix(0, 0).Unix()
+	genesisTime := time.Date(2018, 9, 0, 0, 0, 0, 0, time.UTC).Unix()
 	sb.state, err = state.InitialBeaconState(initialDeposits, uint64(genesisTime), nil)
 	if err != nil {
 		return fmt.Errorf("could not initialize simulated beacon state: %v", err)

--- a/beacon-chain/core/blocks/validity_conditions_test.go
+++ b/beacon-chain/core/blocks/validity_conditions_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
 )
 
@@ -49,7 +48,7 @@ func TestBadBlock(t *testing.T) {
 		Slot: 4,
 	}
 
-	genesisTime := time.Unix(0, 0).Unix()
+	genesisTime := time.Unix(0, 0)
 
 	db.hasBlock = false
 

--- a/beacon-chain/core/blocks/validity_conditions_test.go
+++ b/beacon-chain/core/blocks/validity_conditions_test.go
@@ -49,7 +49,7 @@ func TestBadBlock(t *testing.T) {
 		Slot: 4,
 	}
 
-	genesisTime := params.BeaconConfig().GenesisTime
+	genesisTime := time.Unix(0, 0).Unix()
 
 	db.hasBlock = false
 
@@ -102,7 +102,7 @@ func TestValidBlock(t *testing.T) {
 		Slot: 4,
 	}
 
-	genesisTime := params.BeaconConfig().GenesisTime
+	genesisTime := time.Unix(0, 0)
 	powClient.blockExists = true
 
 	beaconState.LatestEth1Data = &pb.Eth1Data{

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -67,7 +67,7 @@ func TestValidatorEpochAssignments_Ok(t *testing.T) {
 		t.Fatalf("Could not save genesis block: %v", err)
 	}
 
-	genesisTime := time.Unix(0, 0).Un
+	genesisTime := time.Unix(0, 0).Unix()
 	deposits := make([]*pbp2p.Deposit, params.BeaconConfig().DepositsForChainStart)
 	for i := 0; i < len(deposits); i++ {
 		var pubKey [96]byte

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -67,7 +67,7 @@ func TestValidatorEpochAssignments_Ok(t *testing.T) {
 		t.Fatalf("Could not save genesis block: %v", err)
 	}
 
-	genesisTime := params.BeaconConfig().GenesisTime.Unix()
+	genesisTime := time.Unix(0, 0).Un
 	deposits := make([]*pbp2p.Deposit, params.BeaconConfig().DepositsForChainStart)
 	for i := 0; i < len(deposits); i++ {
 		var pubKey [96]byte
@@ -151,7 +151,7 @@ func TestValidatorCommitteeAtSlot_CrosslinkCommitteesFailure(t *testing.T) {
 		t.Fatalf("Could not save genesis block: %v", err)
 	}
 
-	genesisTime := params.BeaconConfig().GenesisTime.Unix()
+	genesisTime := time.Unix(0, 0).Unix()
 	deposits := make([]*pbp2p.Deposit, params.BeaconConfig().DepositsForChainStart)
 	for i := 0; i < len(deposits); i++ {
 		var pubKey [96]byte
@@ -197,7 +197,7 @@ func TestValidatorCommitteeAtSlot_Ok(t *testing.T) {
 		t.Fatalf("Could not save genesis block: %v", err)
 	}
 
-	genesisTime := params.BeaconConfig().GenesisTime.Unix()
+	genesisTime := time.Unix(0, 0).Unix()
 	deposits := make([]*pbp2p.Deposit, params.BeaconConfig().DepositsForChainStart)
 	for i := 0; i < len(deposits); i++ {
 		var pubKey [96]byte

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -74,10 +74,10 @@ type BeaconChainConfig struct {
 	MaxAttesterSlashings uint64 // MaxAttesterSlashings defines the maximum number of casper FFG slashings possible in a block.
 
 	// Prysm constants.
-	DepositsForChainStart uint64    // DepositsForChainStart defines how many validator deposits needed to kick off beacon chain.
-	RandBytes             uint64    // RandBytes is the number of bytes used as entropy to shuffle validators.
-	SyncPollingInterval   int64     // SyncPollingInterval queries network nodes for sync status.
-	MaxNumLog2Validators  uint64    // MaxNumLog2Validators is the Max number of validators in Log2 exists given total ETH supply.
+	DepositsForChainStart uint64 // DepositsForChainStart defines how many validator deposits needed to kick off beacon chain.
+	RandBytes             uint64 // RandBytes is the number of bytes used as entropy to shuffle validators.
+	SyncPollingInterval   int64  // SyncPollingInterval queries network nodes for sync status.
+	MaxNumLog2Validators  uint64 // MaxNumLog2Validators is the Max number of validators in Log2 exists given total ETH supply.
 }
 
 // DepositContractConfig contains the deposits for

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -4,7 +4,6 @@ package params
 
 import (
 	"math/big"
-	"time"
 )
 
 func makeEmptySignature() [][]byte {
@@ -76,10 +75,8 @@ type BeaconChainConfig struct {
 
 	// Prysm constants.
 	DepositsForChainStart uint64    // DepositsForChainStart defines how many validator deposits needed to kick off beacon chain.
-	SimulatedBlockRandao  [32]byte  // SimulatedBlockRandao is a RANDAO seed stubbed in simulated block for advancing local beacon chain.
 	RandBytes             uint64    // RandBytes is the number of bytes used as entropy to shuffle validators.
 	SyncPollingInterval   int64     // SyncPollingInterval queries network nodes for sync status.
-	GenesisTime           time.Time // GenesisTime used by the protocol.
 	MaxNumLog2Validators  uint64    // MaxNumLog2Validators is the Max number of validators in Log2 exists given total ETH supply.
 }
 
@@ -156,7 +153,6 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	DepositsForChainStart: 16384,
 	RandBytes:             3,
 	SyncPollingInterval:   6 * 4, // Query nodes over the network every 4 slots for sync status.
-	GenesisTime:           time.Date(2018, 9, 0, 0, 0, 0, 0, time.UTC),
 	MaxNumLog2Validators:  24,
 }
 
@@ -183,12 +179,15 @@ func BeaconConfig() *BeaconChainConfig {
 // DemoBeaconConfig retrieves the demo beacon chain config.
 func DemoBeaconConfig() *BeaconChainConfig {
 	demoConfig := *defaultBeaconConfig
-	demoConfig.ShardCount = 5
-	demoConfig.TargetCommitteeSize = 3
-	demoConfig.SlotDuration = 2
+	demoConfig.ShardCount = 1
+	demoConfig.TargetCommitteeSize = 2
+	demoConfig.DepositsForChainStart = 8
+	demoConfig.EpochLength = 4
+	demoConfig.GenesisEpoch = demoConfig.GenesisSlot / 4
+	demoConfig.SlotDuration = 10
+	demoConfig.MinDepositAmount = 100
+	demoConfig.MaxDepositAmount = 3200
 	demoConfig.SyncPollingInterval = 2 * 4 // Query nodes over the network every 4 slots for sync status.
-	demoConfig.GenesisTime = time.Now()
-	demoConfig.SimulatedBlockRandao = [32]byte{'S', 'I', 'M', 'U', 'L', 'A', 'T', 'O', 'R'}
 
 	return &demoConfig
 }


### PR DESCRIPTION
Part of #1565 

---

# Description

This PR revives our --demo-config flag so we can test a system of 8 local validators without having to remember what values to use for global parameters. The changes are:

```go
demoConfig.ShardCount = 1
demoConfig.TargetCommitteeSize = 2
demoConfig.DepositsForChainStart = 8
demoConfig.EpochLength = 4
demoConfig.GenesisEpoch = demoConfig.GenesisSlot / 4
demoConfig.SlotDuration = 10
demoConfig.MinDepositAmount = 100
demoConfig.MaxDepositAmount = 3200
```

This PR also eliminates two unnecessary and unused fields in our config, GenesisTime and SimulatedBlockRandao, as they are no longer relevant.