### PR TITLE
Revert go-bls

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,15 +15,15 @@ http_archive(
 
 http_archive(
     name = "bazel_gazelle",
-    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
     sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
 )
 
 http_archive(
     name = "com_github_atlassian_bazel_tools",
+    sha256 = "e7d0c0e2963a7f9cb2c377e241502119dae24909708adef1918e8dcb70ae9e8c",
     strip_prefix = "bazel-tools-6fef37f33dfa0189be9df4d3d60e6291bfe71177",
     urls = ["https://github.com/atlassian/bazel-tools/archive/6fef37f33dfa0189be9df4d3d60e6291bfe71177.tar.gz"],
-    sha256 = "e7d0c0e2963a7f9cb2c377e241502119dae24909708adef1918e8dcb70ae9e8c",
 )
 
 http_archive(
@@ -35,15 +35,15 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.18.5/rules_nodejs-0.18.5.tar.gz"],
-    sha256 = "c8cd6a77433f7d3bb1f4ac87f15822aa102989f8e9eb1907ca0cad718573985b",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.18.6/rules_nodejs-0.18.6.tar.gz"],
+    sha256 = "1416d03823fed624b49a0abbd9979f7c63bbedfd37890ddecedd2fe25cccebc6",
 )
 
 http_archive(
     name = "io_bazel_rules_k8s",
-    url = "https://github.com/bazelbuild/rules_k8s/archive/2206972072d64e5d2d966d81cc6c5fb77fd58dcb.tar.gz",
-    strip_prefix = "rules_k8s-2206972072d64e5d2d966d81cc6c5fb77fd58dcb",
     sha256 = "828fb1ac4c44280be95306b885a326e40110eeba50bffa05e72ddd3b5cdc5d33",
+    strip_prefix = "rules_k8s-2206972072d64e5d2d966d81cc6c5fb77fd58dcb",
+    url = "https://github.com/bazelbuild/rules_k8s/archive/2206972072d64e5d2d966d81cc6c5fb77fd58dcb.tar.gz",
 )
 
 load(
@@ -109,9 +109,9 @@ _go_image_repos()
 
 http_archive(
     name = "io_kubernetes_build",
-    url = "https://github.com/kubernetes/repo-infra/archive/4ce715fbe67d8fbed05ec2bb47a148e754100a4b.tar.gz",
-    strip_prefix = "repo-infra-4ce715fbe67d8fbed05ec2bb47a148e754100a4b",
     sha256 = "b4e7819861f2ec89b7309bd0c44fb3348c3a4a8ee494ec7668edb3960ff11814",
+    strip_prefix = "repo-infra-4ce715fbe67d8fbed05ec2bb47a148e754100a4b",
+    url = "https://github.com/kubernetes/repo-infra/archive/4ce715fbe67d8fbed05ec2bb47a148e754100a4b.tar.gz",
 )
 
 go_repository(
@@ -124,6 +124,7 @@ go_repository(
 
 go_repository(
     name = "com_github_ethereum_go_ethereum",
+    commit = "2ed4a57e9522dc2a023577f0b92ff623c3412303",
     importpath = "github.com/ethereum/go-ethereum",
     # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
     # a fork that has resolved these issues by disabling HID/USB support and
@@ -132,25 +133,24 @@ go_repository(
     # code.
     remote = "https://github.com/prysmaticlabs/bazel-go-ethereum",
     vcs = "git",
-    commit = "ec3d1d97a481e6cba542751a6defae7c76e322f1",
 )
 
 go_repository(
     name = "com_github_urfave_cli",
-    tag = "v1.20.0",
     importpath = "github.com/urfave/cli",
+    tag = "v1.20.0",
 )
 
 go_repository(
     name = "com_github_go_yaml_yaml",
-    tag = "v2.2.2",
     importpath = "github.com/go-yaml/yaml",
+    tag = "v2.2.2",
 )
 
 go_repository(
     name = "com_github_x_cray_logrus_prefixed_formatter",
-    tag = "v0.5.2",
     importpath = "github.com/x-cray/logrus-prefixed-formatter",
+    tag = "v0.5.2",
 )
 
 go_repository(
@@ -167,14 +167,14 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_libp2p",
-    tag = "v6.0.29",
     importpath = "github.com/libp2p/go-libp2p",
+    tag = "v6.0.29",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_peer",
-    tag = "v2.4.0",
     importpath = "github.com/libp2p/go-libp2p-peer",
+    tag = "v2.4.0",
 )
 
 go_repository(
@@ -192,74 +192,74 @@ go_repository(
 
 go_repository(
     name = "com_github_ipfs_go_log",
-    tag = "v1.5.7",
     importpath = "github.com/ipfs/go-log",
+    tag = "v1.5.7",
 )
 
 go_repository(
     name = "com_github_multiformats_go_multihash",
-    tag = "v1.0.8",
     importpath = "github.com/multiformats/go-multihash",
+    tag = "v1.0.8",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_swarm",
-    tag = "v3.0.22",
     importpath = "github.com/libp2p/go-libp2p-swarm",
+    tag = "v3.0.22",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_host",
-    tag = "v3.0.15",
     importpath = "github.com/libp2p/go-libp2p-host",
+    tag = "v3.0.15",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_peerstore",
-    tag = "v2.0.6",
     importpath = "github.com/libp2p/go-libp2p-peerstore",
+    tag = "v2.0.6",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_circuit",
-    tag = "v2.3.2",
     importpath = "github.com/libp2p/go-libp2p-circuit",
+    tag = "v2.3.2",
 )
 
 go_repository(
     name = "com_github_coreos_go_semver",
-    tag = "v0.2.0",
     importpath = "github.com/coreos/go-semver",
+    tag = "v0.2.0",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_interface_connmgr",
-    tag = "v0.0.21",
     importpath = "github.com/libp2p/go-libp2p-interface-connmgr",
+    tag = "v0.0.21",
 )
 
 go_repository(
     name = "com_github_libp2p_go_conn_security_multistream",
-    tag = "v0.1.15",
     importpath = "github.com/libp2p/go-conn-security-multistream",
+    tag = "v0.1.15",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_metrics",
-    tag = "v2.1.7",
     importpath = "github.com/libp2p/go-libp2p-metrics",
+    tag = "v2.1.7",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_net",
-    tag = "v3.0.15",
     importpath = "github.com/libp2p/go-libp2p-net",
+    tag = "v3.0.15",
 )
 
 go_repository(
     name = "com_github_whyrusleeping_mafmt",
-    tag = "v1.2.8",
     importpath = "github.com/whyrusleeping/mafmt",
+    tag = "v1.2.8",
 )
 
 go_repository(
@@ -300,7 +300,7 @@ go_repository(
 
 go_repository(
     name = "com_github_btcsuite_btcd",
-    commit = "12ce2fc7d32197bf00739e4167128285ae250124",
+    commit = "306aecffea325e97f513b3ff0cf7895a5310651d",
     importpath = "github.com/btcsuite/btcd",
 )
 
@@ -312,33 +312,33 @@ go_repository(
 
 go_repository(
     name = "com_github_mr_tron_base58",
-    tag = "v1.1.0",
     importpath = "github.com/mr-tron/base58",
+    tag = "v1.1.0",
 )
 
 go_repository(
     name = "com_github_whyrusleeping_go_smux_yamux",
-    tag = "v2.0.8",
     importpath = "github.com/whyrusleeping/go-smux-yamux",
+    tag = "v2.0.8",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_secio",
     build_file_proto_mode = "disable_global",
-    tag = "v2.0.17",
     importpath = "github.com/libp2p/go-libp2p-secio",
+    tag = "v2.0.17",
 )
 
 go_repository(
     name = "com_github_libp2p_go_tcp_transport",
-    tag = "v2.0.16",
     importpath = "github.com/libp2p/go-tcp-transport",
+    tag = "v2.0.16",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_protocol",
-    tag = "v1.0.0",
     importpath = "github.com/libp2p/go-libp2p-protocol",
+    tag = "v1.0.0",
 )
 
 go_repository(
@@ -355,26 +355,26 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_loggables",
-    tag = "v1.1.24",
     importpath = "github.com/libp2p/go-libp2p-loggables",
+    tag = "v1.1.24",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_nat",
-    tag = "v0.8.8",
     importpath = "github.com/libp2p/go-libp2p-nat",
+    tag = "v0.8.8",
 )
 
 go_repository(
     name = "com_github_multiformats_go_multiaddr_dns",
-    tag = "v0.2.5",
     importpath = "github.com/multiformats/go-multiaddr-dns",
+    tag = "v0.2.5",
 )
 
 go_repository(
     name = "com_github_fd_go_nat",
-    tag = "v1.0.0",
     importpath = "github.com/fd/go-nat",
+    tag = "v1.0.0",
 )
 
 go_repository(
@@ -385,62 +385,62 @@ go_repository(
 
 go_repository(
     name = "com_github_mattn_go_isatty",
-    tag = "v0.0.4",
     importpath = "github.com/mattn/go-isatty",
+    tag = "v0.0.4",
 )
 
 go_repository(
     name = "com_github_libp2p_go_stream_muxer",
-    tag = "v3.0.1",
     importpath = "github.com/libp2p/go-stream-muxer",
+    tag = "v3.0.1",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_transport_upgrader",
-    tag = "v0.1.16",
     importpath = "github.com/libp2p/go-libp2p-transport-upgrader",
+    tag = "v0.1.16",
 )
 
 go_repository(
     name = "com_github_libp2p_go_testutil",
-    tag = "v1.2.10",
     importpath = "github.com/libp2p/go-testutil",
+    tag = "v1.2.10",
 )
 
 go_repository(
     name = "com_github_whyrusleeping_go_smux_multistream",
-    tag = "v2.0.2",
     importpath = "github.com/whyrusleeping/go-smux-multistream",
+    tag = "v2.0.2",
 )
 
 go_repository(
     name = "com_github_libp2p_go_maddr_filter",
-    tag = "v1.1.10",
     importpath = "github.com/libp2p/go-maddr-filter",
+    tag = "v1.1.10",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_transport",
-    tag = "v3.0.15",
     importpath = "github.com/libp2p/go-libp2p-transport",
+    tag = "v3.0.15",
 )
 
 go_repository(
     name = "com_github_libp2p_go_addr_util",
-    tag = "v2.0.7",
     importpath = "github.com/libp2p/go-addr-util",
+    tag = "v2.0.7",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_interface_pnet",
-    tag = "v3.0.0",
     importpath = "github.com/libp2p/go-libp2p-interface-pnet",
+    tag = "v3.0.0",
 )
 
 go_repository(
     name = "com_github_libp2p_go_conn_security",
-    tag = "v0.1.15",
     importpath = "github.com/libp2p/go-conn-security",
+    tag = "v0.1.15",
 )
 
 go_repository(
@@ -457,20 +457,20 @@ go_repository(
 
 go_repository(
     name = "com_github_opentracing_opentracing_go",
-    tag = "v1.0.2",
     importpath = "github.com/opentracing/opentracing-go",
+    tag = "v1.0.2",
 )
 
 go_repository(
     name = "com_github_libp2p_go_reuseport",
-    tag = "v0.2.0",
     importpath = "github.com/libp2p/go-reuseport",
+    tag = "v0.2.0",
 )
 
 go_repository(
     name = "com_github_huin_goupnp",
-    tag = "v1.0.0",
     importpath = "github.com/huin/goupnp",
+    tag = "v1.0.0",
 )
 
 go_repository(
@@ -487,19 +487,19 @@ go_repository(
 
 go_repository(
     name = "com_github_satori_go_uuid",
-    tag = "v1.2.0",
     importpath = "github.com/satori/go.uuid",
+    tag = "v1.2.0",
 )
 
 go_repository(
     name = "com_github_sirupsen_logrus",
-    tag = "v1.3.0",
     importpath = "github.com/sirupsen/logrus",
+    tag = "v1.3.0",
 )
 
 go_repository(
     name = "org_golang_x_sys",
-    commit = "3b5209105503162ded1863c307ac66fec31120dd",
+    commit = "983097b1a8a340cd1cc7df17d735154d89e10b1a",
     importpath = "golang.org/x/sys",
 )
 
@@ -511,20 +511,20 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_flow_metrics",
-    tag = "v0.2.0",
     importpath = "github.com/libp2p/go-flow-metrics",
+    tag = "v0.2.0",
 )
 
 go_repository(
     name = "com_github_libp2p_go_msgio",
-    tag = "v0.0.6",
     importpath = "github.com/libp2p/go-msgio",
+    tag = "v0.0.6",
 )
 
 go_repository(
     name = "com_github_jackpal_gateway",
-    tag = "v1.0.5",
     importpath = "github.com/jackpal/gateway",
+    tag = "v1.0.5",
 )
 
 go_repository(
@@ -535,32 +535,32 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_ws_transport",
-    tag = "v2.0.15",
     importpath = "github.com/libp2p/go-ws-transport",
+    tag = "v2.0.15",
 )
 
 go_repository(
     name = "org_golang_x_crypto",
-    commit = "193df9c0f06f8bb35fba505183eaf0acc0136505",
+    commit = "74369b46fc6756741c016591724fd1cb8e26845f",
     importpath = "golang.org/x/crypto",
 )
 
 go_repository(
     name = "com_github_jackpal_go_nat_pmp",
-    tag = "v1.0.1",
     importpath = "github.com/jackpal/go-nat-pmp",
+    tag = "v1.0.1",
 )
 
 go_repository(
     name = "com_github_libp2p_go_reuseport_transport",
-    tag = "v0.2.0",
     importpath = "github.com/libp2p/go-reuseport-transport",
+    tag = "v0.2.0",
 )
 
 go_repository(
     name = "com_github_libp2p_go_sockaddr",
-    tag = "v1.0.3",
     importpath = "github.com/libp2p/go-sockaddr",
+    tag = "v1.0.3",
 )
 
 go_repository(
@@ -571,14 +571,14 @@ go_repository(
 
 go_repository(
     name = "com_github_gorilla_websocket",
-    tag = "v1.4.0",
     importpath = "github.com/gorilla/websocket",
+    tag = "v1.4.0",
 )
 
 go_repository(
     name = "com_github_whyrusleeping_go_smux_multiplex",
-    tag = "v3.0.16",
     importpath = "github.com/whyrusleeping/go-smux-multiplex",
+    tag = "v3.0.16",
 )
 
 go_repository(
@@ -601,26 +601,26 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_blankhost",
-    tag = "v0.3.15",
     importpath = "github.com/libp2p/go-libp2p-blankhost",
+    tag = "v0.3.15",
 )
 
 go_repository(
     name = "com_github_steakknife_hamming",
-    tag = "0.2.5",
     importpath = "github.com/steakknife/hamming",
+    tag = "0.2.5",
 )
 
 go_repository(
     name = "io_opencensus_go",
-    tag = "v0.19.0",
     importpath = "go.opencensus.io",
+    tag = "v0.19.0",
 )
 
 go_repository(
     name = "org_golang_google_api",
-    tag = "v0.1.0",
     importpath = "google.golang.org/api",
+    tag = "v0.1.0",
 )
 
 go_repository(
@@ -643,14 +643,14 @@ go_repository(
 
 go_repository(
     name = "com_github_aristanetworks_goarista",
-    commit = "2166578f34481200ec14ddd6b9c4115db36c7b62",
+    commit = "c1e4b37418775d8f5e0c0c1a68766d321b32d6ca",
     importpath = "github.com/aristanetworks/goarista",
 )
 
 go_repository(
     name = "com_github_prometheus_client_golang",
-    tag = "v0.9.2",
     importpath = "github.com/prometheus/client_golang",
+    tag = "v0.9.2",
 )
 
 go_repository(
@@ -685,20 +685,20 @@ go_repository(
 
 go_repository(
     name = "com_github_matttproud_golang_protobuf_extensions",
-    tag = "v1.0.1",
     importpath = "github.com/matttproud/golang_protobuf_extensions",
+    tag = "v1.0.1",
 )
 
 go_repository(
     name = "com_github_boltdb_bolt",
-    tag = "v1.3.1",
     importpath = "github.com/boltdb/bolt",
+    tag = "v1.3.1",
 )
 
 go_repository(
     name = "com_github_pborman_uuid",
-    tag = "v1.2.0",
     importpath = "github.com/pborman/uuid",
+    tag = "v1.2.0",
 )
 
 go_repository(
@@ -709,40 +709,40 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_mplex",
-    tag = "v0.2.30",
     importpath = "github.com/libp2p/go-mplex",
+    tag = "v0.2.30",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_pubsub",
     build_file_proto_mode = "disable_global",
-    tag = "v0.11.10",
     importpath = "github.com/libp2p/go-libp2p-pubsub",
+    tag = "v0.11.10",
 )
 
 go_repository(
     name = "com_github_ipfs_go_ipfs_util",
-    tag = "v1.2.8",
     importpath = "github.com/ipfs/go-ipfs-util",
+    tag = "v1.2.8",
 )
 
 go_repository(
     name = "com_github_google_uuid",
-    tag = "v1.1.0",
     importpath = "github.com/google/uuid",
+    tag = "v1.1.0",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_kad_dht",
     build_file_proto_mode = "disable_global",
-    tag = "v4.4.12",
     importpath = "github.com/libp2p/go-libp2p-kad-dht",
+    tag = "v4.4.12",
 )
 
 go_repository(
     name = "com_github_ipfs_go_datastore",
-    tag = "v3.2.0",
     importpath = "github.com/ipfs/go-datastore",
+    tag = "v3.2.0",
 )
 
 go_repository(
@@ -753,27 +753,27 @@ go_repository(
 
 go_repository(
     name = "com_github_ipfs_go_cid",
-    tag = "v0.9.0",
     importpath = "github.com/ipfs/go-cid",
+    tag = "v0.9.0",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_record",
     build_file_proto_mode = "disable_global",
-    tag = "v4.1.7",
     importpath = "github.com/libp2p/go-libp2p-record",
+    tag = "v4.1.7",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_routing",
-    tag = "v2.7.1",
     importpath = "github.com/libp2p/go-libp2p-routing",
+    tag = "v2.7.1",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_kbucket",
-    tag = "v2.2.12",
     importpath = "github.com/libp2p/go-libp2p-kbucket",
+    tag = "v2.2.12",
 )
 
 go_repository(
@@ -784,8 +784,8 @@ go_repository(
 
 go_repository(
     name = "com_github_ipfs_go_todocounter",
-    tag = "v1.0.1",
     importpath = "github.com/ipfs/go-todocounter",
+    tag = "v1.0.1",
 )
 
 go_repository(
@@ -796,25 +796,25 @@ go_repository(
 
 go_repository(
     name = "com_github_multiformats_go_multibase",
-    tag = "v0.3.0",
     importpath = "github.com/multiformats/go-multibase",
+    tag = "v0.3.0",
 )
 
 go_repository(
     name = "com_github_hashicorp_golang_lru",
-    tag = "v0.5.0",
     importpath = "github.com/hashicorp/golang-lru",
+    tag = "v0.5.0",
 )
 
 go_repository(
     name = "com_github_ipfs_go_ipfs_addr",
-    tag = "v0.1.25",
     importpath = "github.com/ipfs/go-ipfs-addr",
+    tag = "v0.1.25",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_discovery",
-    commit = "a666b9cafd4cd3c35405896c2121951c749979ea",
+    commit = "ececb851d1718b7bc3d734009f156d4f38ec420d",
     importpath = "github.com/libp2p/go-libp2p-discovery",
 )
 
@@ -826,8 +826,8 @@ go_repository(
 
 go_repository(
     name = "com_github_konsorten_go_windows_terminal_sequences",
-    tag = "v1.0.1",
     importpath = "github.com/konsorten/go-windows-terminal-sequences",
+    tag = "v1.0.1",
 )
 
 go_repository(
@@ -876,26 +876,26 @@ go_repository(
 
 go_repository(
     name = "in_gopkg_yaml_v2",
-    tag = "v2.2.2",
     importpath = "gopkg.in/yaml.v2",
+    tag = "v2.2.2",
 )
 
 go_repository(
     name = "com_github_spf13_pflag",
-    tag = "v1.0.3",
     importpath = "github.com/spf13/pflag",
+    tag = "v1.0.3",
 )
 
 go_repository(
     name = "com_github_spf13_cobra",
-    tag = "v0.0.3",
     importpath = "github.com/spf13/cobra",
+    tag = "v0.0.3",
 )
 
 go_repository(
     name = "com_github_aws_aws_sdk_go",
-    tag = "v1.16.9",
     importpath = "github.com/aws/aws-sdk-go",
+    tag = "v1.16.9",
 )
 
 go_repository(
@@ -908,20 +908,20 @@ go_repository(
 
 go_repository(
     name = "org_golang_x_oauth2",
-    commit = "99b60b757ec124ebb7d6b7e97f153b19c10ce163",
+    commit = "3e8b2be1363542a95c52ea0796d4a40dacfb5b95",
     importpath = "golang.org/x/oauth2",
 )
 
 go_repository(
     name = "com_github_hashicorp_go_multierror",
-    tag = "v1.0.0",
     importpath = "github.com/hashicorp/go-multierror",
+    tag = "v1.0.0",
 )
 
 go_repository(
     name = "com_github_hashicorp_errwrap",
-    tag = "v1.0.0",
     importpath = "github.com/hashicorp/errwrap",
+    tag = "v1.0.0",
 )
 
 go_repository(
@@ -932,26 +932,26 @@ go_repository(
 
 go_repository(
     name = "com_github_inconshreveable_mousetrap",
-    tag = "v1.0.0",
     importpath = "github.com/inconshreveable/mousetrap",
+    tag = "v1.0.0",
 )
 
 go_repository(
     name = "com_github_deckarep_golang_set",
-    tag = "v1.7.1",
     importpath = "github.com/deckarep/golang-set",
+    tag = "v1.7.1",
 )
 
 go_repository(
     name = "com_github_go_stack_stack",
-    tag = "v1.8.0",
     importpath = "github.com/go-stack/stack",
+    tag = "v1.8.0",
 )
 
 go_repository(
     name = "com_github_rs_cors",
-    tag = "v1.6.0",
     importpath = "github.com/rs/cors",
+    tag = "v1.6.0",
 )
 
 go_repository(
@@ -962,26 +962,26 @@ go_repository(
 
 go_repository(
     name = "in_gopkg_urfave_cli_v1",
-    tag = "v1.20.0",
     importpath = "gopkg.in/urfave/cli.v1",
+    tag = "v1.20.0",
 )
 
 go_repository(
     name = "com_github_rjeczalik_notify",
-    tag = "v0.9.2",
     importpath = "github.com/rjeczalik/notify",
+    tag = "v0.9.2",
 )
 
 go_repository(
     name = "com_github_edsrzf_mmap_go",
-    tag = "v1.0.0",
     importpath = "github.com/edsrzf/mmap-go",
+    tag = "v1.0.0",
 )
 
 go_repository(
     name = "com_github_pkg_errors",
-    tag = "v0.8.1",
     importpath = "github.com/pkg/errors",
+    tag = "v0.8.1",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,15 +15,15 @@ http_archive(
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
     urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz"],
+    sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
 )
 
 http_archive(
     name = "com_github_atlassian_bazel_tools",
-    sha256 = "e7d0c0e2963a7f9cb2c377e241502119dae24909708adef1918e8dcb70ae9e8c",
     strip_prefix = "bazel-tools-6fef37f33dfa0189be9df4d3d60e6291bfe71177",
     urls = ["https://github.com/atlassian/bazel-tools/archive/6fef37f33dfa0189be9df4d3d60e6291bfe71177.tar.gz"],
+    sha256 = "e7d0c0e2963a7f9cb2c377e241502119dae24909708adef1918e8dcb70ae9e8c",
 )
 
 http_archive(
@@ -35,15 +35,15 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.18.6/rules_nodejs-0.18.6.tar.gz"],
-    sha256 = "1416d03823fed624b49a0abbd9979f7c63bbedfd37890ddecedd2fe25cccebc6",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.18.5/rules_nodejs-0.18.5.tar.gz"],
+    sha256 = "c8cd6a77433f7d3bb1f4ac87f15822aa102989f8e9eb1907ca0cad718573985b",
 )
 
 http_archive(
     name = "io_bazel_rules_k8s",
-    sha256 = "828fb1ac4c44280be95306b885a326e40110eeba50bffa05e72ddd3b5cdc5d33",
-    strip_prefix = "rules_k8s-2206972072d64e5d2d966d81cc6c5fb77fd58dcb",
     url = "https://github.com/bazelbuild/rules_k8s/archive/2206972072d64e5d2d966d81cc6c5fb77fd58dcb.tar.gz",
+    strip_prefix = "rules_k8s-2206972072d64e5d2d966d81cc6c5fb77fd58dcb",
+    sha256 = "828fb1ac4c44280be95306b885a326e40110eeba50bffa05e72ddd3b5cdc5d33",
 )
 
 load(
@@ -109,9 +109,9 @@ _go_image_repos()
 
 http_archive(
     name = "io_kubernetes_build",
-    sha256 = "b4e7819861f2ec89b7309bd0c44fb3348c3a4a8ee494ec7668edb3960ff11814",
-    strip_prefix = "repo-infra-4ce715fbe67d8fbed05ec2bb47a148e754100a4b",
     url = "https://github.com/kubernetes/repo-infra/archive/4ce715fbe67d8fbed05ec2bb47a148e754100a4b.tar.gz",
+    strip_prefix = "repo-infra-4ce715fbe67d8fbed05ec2bb47a148e754100a4b",
+    sha256 = "b4e7819861f2ec89b7309bd0c44fb3348c3a4a8ee494ec7668edb3960ff11814",
 )
 
 go_repository(
@@ -124,7 +124,6 @@ go_repository(
 
 go_repository(
     name = "com_github_ethereum_go_ethereum",
-    commit = "2ed4a57e9522dc2a023577f0b92ff623c3412303",
     importpath = "github.com/ethereum/go-ethereum",
     # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
     # a fork that has resolved these issues by disabling HID/USB support and
@@ -133,24 +132,25 @@ go_repository(
     # code.
     remote = "https://github.com/prysmaticlabs/bazel-go-ethereum",
     vcs = "git",
+    commit = "ec3d1d97a481e6cba542751a6defae7c76e322f1",
 )
 
 go_repository(
     name = "com_github_urfave_cli",
-    importpath = "github.com/urfave/cli",
     tag = "v1.20.0",
+    importpath = "github.com/urfave/cli",
 )
 
 go_repository(
     name = "com_github_go_yaml_yaml",
-    importpath = "github.com/go-yaml/yaml",
     tag = "v2.2.2",
+    importpath = "github.com/go-yaml/yaml",
 )
 
 go_repository(
     name = "com_github_x_cray_logrus_prefixed_formatter",
-    importpath = "github.com/x-cray/logrus-prefixed-formatter",
     tag = "v0.5.2",
+    importpath = "github.com/x-cray/logrus-prefixed-formatter",
 )
 
 go_repository(
@@ -167,14 +167,14 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_libp2p",
-    importpath = "github.com/libp2p/go-libp2p",
     tag = "v6.0.29",
+    importpath = "github.com/libp2p/go-libp2p",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_peer",
-    importpath = "github.com/libp2p/go-libp2p-peer",
     tag = "v2.4.0",
+    importpath = "github.com/libp2p/go-libp2p-peer",
 )
 
 go_repository(
@@ -192,74 +192,74 @@ go_repository(
 
 go_repository(
     name = "com_github_ipfs_go_log",
-    importpath = "github.com/ipfs/go-log",
     tag = "v1.5.7",
+    importpath = "github.com/ipfs/go-log",
 )
 
 go_repository(
     name = "com_github_multiformats_go_multihash",
-    importpath = "github.com/multiformats/go-multihash",
     tag = "v1.0.8",
+    importpath = "github.com/multiformats/go-multihash",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_swarm",
-    importpath = "github.com/libp2p/go-libp2p-swarm",
     tag = "v3.0.22",
+    importpath = "github.com/libp2p/go-libp2p-swarm",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_host",
-    importpath = "github.com/libp2p/go-libp2p-host",
     tag = "v3.0.15",
+    importpath = "github.com/libp2p/go-libp2p-host",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_peerstore",
-    importpath = "github.com/libp2p/go-libp2p-peerstore",
     tag = "v2.0.6",
+    importpath = "github.com/libp2p/go-libp2p-peerstore",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_circuit",
-    importpath = "github.com/libp2p/go-libp2p-circuit",
     tag = "v2.3.2",
+    importpath = "github.com/libp2p/go-libp2p-circuit",
 )
 
 go_repository(
     name = "com_github_coreos_go_semver",
-    importpath = "github.com/coreos/go-semver",
     tag = "v0.2.0",
+    importpath = "github.com/coreos/go-semver",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_interface_connmgr",
-    importpath = "github.com/libp2p/go-libp2p-interface-connmgr",
     tag = "v0.0.21",
+    importpath = "github.com/libp2p/go-libp2p-interface-connmgr",
 )
 
 go_repository(
     name = "com_github_libp2p_go_conn_security_multistream",
-    importpath = "github.com/libp2p/go-conn-security-multistream",
     tag = "v0.1.15",
+    importpath = "github.com/libp2p/go-conn-security-multistream",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_metrics",
-    importpath = "github.com/libp2p/go-libp2p-metrics",
     tag = "v2.1.7",
+    importpath = "github.com/libp2p/go-libp2p-metrics",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_net",
-    importpath = "github.com/libp2p/go-libp2p-net",
     tag = "v3.0.15",
+    importpath = "github.com/libp2p/go-libp2p-net",
 )
 
 go_repository(
     name = "com_github_whyrusleeping_mafmt",
-    importpath = "github.com/whyrusleeping/mafmt",
     tag = "v1.2.8",
+    importpath = "github.com/whyrusleeping/mafmt",
 )
 
 go_repository(
@@ -300,7 +300,7 @@ go_repository(
 
 go_repository(
     name = "com_github_btcsuite_btcd",
-    commit = "306aecffea325e97f513b3ff0cf7895a5310651d",
+    commit = "12ce2fc7d32197bf00739e4167128285ae250124",
     importpath = "github.com/btcsuite/btcd",
 )
 
@@ -312,33 +312,33 @@ go_repository(
 
 go_repository(
     name = "com_github_mr_tron_base58",
-    importpath = "github.com/mr-tron/base58",
     tag = "v1.1.0",
+    importpath = "github.com/mr-tron/base58",
 )
 
 go_repository(
     name = "com_github_whyrusleeping_go_smux_yamux",
-    importpath = "github.com/whyrusleeping/go-smux-yamux",
     tag = "v2.0.8",
+    importpath = "github.com/whyrusleeping/go-smux-yamux",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_secio",
     build_file_proto_mode = "disable_global",
-    importpath = "github.com/libp2p/go-libp2p-secio",
     tag = "v2.0.17",
+    importpath = "github.com/libp2p/go-libp2p-secio",
 )
 
 go_repository(
     name = "com_github_libp2p_go_tcp_transport",
-    importpath = "github.com/libp2p/go-tcp-transport",
     tag = "v2.0.16",
+    importpath = "github.com/libp2p/go-tcp-transport",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_protocol",
-    importpath = "github.com/libp2p/go-libp2p-protocol",
     tag = "v1.0.0",
+    importpath = "github.com/libp2p/go-libp2p-protocol",
 )
 
 go_repository(
@@ -355,26 +355,26 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_loggables",
-    importpath = "github.com/libp2p/go-libp2p-loggables",
     tag = "v1.1.24",
+    importpath = "github.com/libp2p/go-libp2p-loggables",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_nat",
-    importpath = "github.com/libp2p/go-libp2p-nat",
     tag = "v0.8.8",
+    importpath = "github.com/libp2p/go-libp2p-nat",
 )
 
 go_repository(
     name = "com_github_multiformats_go_multiaddr_dns",
-    importpath = "github.com/multiformats/go-multiaddr-dns",
     tag = "v0.2.5",
+    importpath = "github.com/multiformats/go-multiaddr-dns",
 )
 
 go_repository(
     name = "com_github_fd_go_nat",
-    importpath = "github.com/fd/go-nat",
     tag = "v1.0.0",
+    importpath = "github.com/fd/go-nat",
 )
 
 go_repository(
@@ -385,62 +385,62 @@ go_repository(
 
 go_repository(
     name = "com_github_mattn_go_isatty",
-    importpath = "github.com/mattn/go-isatty",
     tag = "v0.0.4",
+    importpath = "github.com/mattn/go-isatty",
 )
 
 go_repository(
     name = "com_github_libp2p_go_stream_muxer",
-    importpath = "github.com/libp2p/go-stream-muxer",
     tag = "v3.0.1",
+    importpath = "github.com/libp2p/go-stream-muxer",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_transport_upgrader",
-    importpath = "github.com/libp2p/go-libp2p-transport-upgrader",
     tag = "v0.1.16",
+    importpath = "github.com/libp2p/go-libp2p-transport-upgrader",
 )
 
 go_repository(
     name = "com_github_libp2p_go_testutil",
-    importpath = "github.com/libp2p/go-testutil",
     tag = "v1.2.10",
+    importpath = "github.com/libp2p/go-testutil",
 )
 
 go_repository(
     name = "com_github_whyrusleeping_go_smux_multistream",
-    importpath = "github.com/whyrusleeping/go-smux-multistream",
     tag = "v2.0.2",
+    importpath = "github.com/whyrusleeping/go-smux-multistream",
 )
 
 go_repository(
     name = "com_github_libp2p_go_maddr_filter",
-    importpath = "github.com/libp2p/go-maddr-filter",
     tag = "v1.1.10",
+    importpath = "github.com/libp2p/go-maddr-filter",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_transport",
-    importpath = "github.com/libp2p/go-libp2p-transport",
     tag = "v3.0.15",
+    importpath = "github.com/libp2p/go-libp2p-transport",
 )
 
 go_repository(
     name = "com_github_libp2p_go_addr_util",
-    importpath = "github.com/libp2p/go-addr-util",
     tag = "v2.0.7",
+    importpath = "github.com/libp2p/go-addr-util",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_interface_pnet",
-    importpath = "github.com/libp2p/go-libp2p-interface-pnet",
     tag = "v3.0.0",
+    importpath = "github.com/libp2p/go-libp2p-interface-pnet",
 )
 
 go_repository(
     name = "com_github_libp2p_go_conn_security",
-    importpath = "github.com/libp2p/go-conn-security",
     tag = "v0.1.15",
+    importpath = "github.com/libp2p/go-conn-security",
 )
 
 go_repository(
@@ -457,20 +457,20 @@ go_repository(
 
 go_repository(
     name = "com_github_opentracing_opentracing_go",
-    importpath = "github.com/opentracing/opentracing-go",
     tag = "v1.0.2",
+    importpath = "github.com/opentracing/opentracing-go",
 )
 
 go_repository(
     name = "com_github_libp2p_go_reuseport",
-    importpath = "github.com/libp2p/go-reuseport",
     tag = "v0.2.0",
+    importpath = "github.com/libp2p/go-reuseport",
 )
 
 go_repository(
     name = "com_github_huin_goupnp",
-    importpath = "github.com/huin/goupnp",
     tag = "v1.0.0",
+    importpath = "github.com/huin/goupnp",
 )
 
 go_repository(
@@ -487,19 +487,19 @@ go_repository(
 
 go_repository(
     name = "com_github_satori_go_uuid",
-    importpath = "github.com/satori/go.uuid",
     tag = "v1.2.0",
+    importpath = "github.com/satori/go.uuid",
 )
 
 go_repository(
     name = "com_github_sirupsen_logrus",
-    importpath = "github.com/sirupsen/logrus",
     tag = "v1.3.0",
+    importpath = "github.com/sirupsen/logrus",
 )
 
 go_repository(
     name = "org_golang_x_sys",
-    commit = "983097b1a8a340cd1cc7df17d735154d89e10b1a",
+    commit = "3b5209105503162ded1863c307ac66fec31120dd",
     importpath = "golang.org/x/sys",
 )
 
@@ -511,20 +511,20 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_flow_metrics",
-    importpath = "github.com/libp2p/go-flow-metrics",
     tag = "v0.2.0",
+    importpath = "github.com/libp2p/go-flow-metrics",
 )
 
 go_repository(
     name = "com_github_libp2p_go_msgio",
-    importpath = "github.com/libp2p/go-msgio",
     tag = "v0.0.6",
+    importpath = "github.com/libp2p/go-msgio",
 )
 
 go_repository(
     name = "com_github_jackpal_gateway",
-    importpath = "github.com/jackpal/gateway",
     tag = "v1.0.5",
+    importpath = "github.com/jackpal/gateway",
 )
 
 go_repository(
@@ -535,32 +535,32 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_ws_transport",
-    importpath = "github.com/libp2p/go-ws-transport",
     tag = "v2.0.15",
+    importpath = "github.com/libp2p/go-ws-transport",
 )
 
 go_repository(
     name = "org_golang_x_crypto",
-    commit = "74369b46fc6756741c016591724fd1cb8e26845f",
+    commit = "193df9c0f06f8bb35fba505183eaf0acc0136505",
     importpath = "golang.org/x/crypto",
 )
 
 go_repository(
     name = "com_github_jackpal_go_nat_pmp",
-    importpath = "github.com/jackpal/go-nat-pmp",
     tag = "v1.0.1",
+    importpath = "github.com/jackpal/go-nat-pmp",
 )
 
 go_repository(
     name = "com_github_libp2p_go_reuseport_transport",
-    importpath = "github.com/libp2p/go-reuseport-transport",
     tag = "v0.2.0",
+    importpath = "github.com/libp2p/go-reuseport-transport",
 )
 
 go_repository(
     name = "com_github_libp2p_go_sockaddr",
-    importpath = "github.com/libp2p/go-sockaddr",
     tag = "v1.0.3",
+    importpath = "github.com/libp2p/go-sockaddr",
 )
 
 go_repository(
@@ -571,14 +571,14 @@ go_repository(
 
 go_repository(
     name = "com_github_gorilla_websocket",
-    importpath = "github.com/gorilla/websocket",
     tag = "v1.4.0",
+    importpath = "github.com/gorilla/websocket",
 )
 
 go_repository(
     name = "com_github_whyrusleeping_go_smux_multiplex",
-    importpath = "github.com/whyrusleeping/go-smux-multiplex",
     tag = "v3.0.16",
+    importpath = "github.com/whyrusleeping/go-smux-multiplex",
 )
 
 go_repository(
@@ -601,26 +601,26 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_blankhost",
-    importpath = "github.com/libp2p/go-libp2p-blankhost",
     tag = "v0.3.15",
+    importpath = "github.com/libp2p/go-libp2p-blankhost",
 )
 
 go_repository(
     name = "com_github_steakknife_hamming",
-    importpath = "github.com/steakknife/hamming",
     tag = "0.2.5",
+    importpath = "github.com/steakknife/hamming",
 )
 
 go_repository(
     name = "io_opencensus_go",
-    importpath = "go.opencensus.io",
     tag = "v0.19.0",
+    importpath = "go.opencensus.io",
 )
 
 go_repository(
     name = "org_golang_google_api",
-    importpath = "google.golang.org/api",
     tag = "v0.1.0",
+    importpath = "google.golang.org/api",
 )
 
 go_repository(
@@ -643,14 +643,14 @@ go_repository(
 
 go_repository(
     name = "com_github_aristanetworks_goarista",
-    commit = "c1e4b37418775d8f5e0c0c1a68766d321b32d6ca",
+    commit = "2166578f34481200ec14ddd6b9c4115db36c7b62",
     importpath = "github.com/aristanetworks/goarista",
 )
 
 go_repository(
     name = "com_github_prometheus_client_golang",
-    importpath = "github.com/prometheus/client_golang",
     tag = "v0.9.2",
+    importpath = "github.com/prometheus/client_golang",
 )
 
 go_repository(
@@ -685,20 +685,20 @@ go_repository(
 
 go_repository(
     name = "com_github_matttproud_golang_protobuf_extensions",
-    importpath = "github.com/matttproud/golang_protobuf_extensions",
     tag = "v1.0.1",
+    importpath = "github.com/matttproud/golang_protobuf_extensions",
 )
 
 go_repository(
     name = "com_github_boltdb_bolt",
-    importpath = "github.com/boltdb/bolt",
     tag = "v1.3.1",
+    importpath = "github.com/boltdb/bolt",
 )
 
 go_repository(
     name = "com_github_pborman_uuid",
-    importpath = "github.com/pborman/uuid",
     tag = "v1.2.0",
+    importpath = "github.com/pborman/uuid",
 )
 
 go_repository(
@@ -709,40 +709,40 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_mplex",
-    importpath = "github.com/libp2p/go-mplex",
     tag = "v0.2.30",
+    importpath = "github.com/libp2p/go-mplex",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_pubsub",
     build_file_proto_mode = "disable_global",
-    importpath = "github.com/libp2p/go-libp2p-pubsub",
     tag = "v0.11.10",
+    importpath = "github.com/libp2p/go-libp2p-pubsub",
 )
 
 go_repository(
     name = "com_github_ipfs_go_ipfs_util",
-    importpath = "github.com/ipfs/go-ipfs-util",
     tag = "v1.2.8",
+    importpath = "github.com/ipfs/go-ipfs-util",
 )
 
 go_repository(
     name = "com_github_google_uuid",
-    importpath = "github.com/google/uuid",
     tag = "v1.1.0",
+    importpath = "github.com/google/uuid",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_kad_dht",
     build_file_proto_mode = "disable_global",
-    importpath = "github.com/libp2p/go-libp2p-kad-dht",
     tag = "v4.4.12",
+    importpath = "github.com/libp2p/go-libp2p-kad-dht",
 )
 
 go_repository(
     name = "com_github_ipfs_go_datastore",
-    importpath = "github.com/ipfs/go-datastore",
     tag = "v3.2.0",
+    importpath = "github.com/ipfs/go-datastore",
 )
 
 go_repository(
@@ -753,27 +753,27 @@ go_repository(
 
 go_repository(
     name = "com_github_ipfs_go_cid",
-    importpath = "github.com/ipfs/go-cid",
     tag = "v0.9.0",
+    importpath = "github.com/ipfs/go-cid",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_record",
     build_file_proto_mode = "disable_global",
-    importpath = "github.com/libp2p/go-libp2p-record",
     tag = "v4.1.7",
+    importpath = "github.com/libp2p/go-libp2p-record",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_routing",
-    importpath = "github.com/libp2p/go-libp2p-routing",
     tag = "v2.7.1",
+    importpath = "github.com/libp2p/go-libp2p-routing",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_kbucket",
-    importpath = "github.com/libp2p/go-libp2p-kbucket",
     tag = "v2.2.12",
+    importpath = "github.com/libp2p/go-libp2p-kbucket",
 )
 
 go_repository(
@@ -784,8 +784,8 @@ go_repository(
 
 go_repository(
     name = "com_github_ipfs_go_todocounter",
-    importpath = "github.com/ipfs/go-todocounter",
     tag = "v1.0.1",
+    importpath = "github.com/ipfs/go-todocounter",
 )
 
 go_repository(
@@ -796,25 +796,25 @@ go_repository(
 
 go_repository(
     name = "com_github_multiformats_go_multibase",
-    importpath = "github.com/multiformats/go-multibase",
     tag = "v0.3.0",
+    importpath = "github.com/multiformats/go-multibase",
 )
 
 go_repository(
     name = "com_github_hashicorp_golang_lru",
-    importpath = "github.com/hashicorp/golang-lru",
     tag = "v0.5.0",
+    importpath = "github.com/hashicorp/golang-lru",
 )
 
 go_repository(
     name = "com_github_ipfs_go_ipfs_addr",
-    importpath = "github.com/ipfs/go-ipfs-addr",
     tag = "v0.1.25",
+    importpath = "github.com/ipfs/go-ipfs-addr",
 )
 
 go_repository(
     name = "com_github_libp2p_go_libp2p_discovery",
-    commit = "ececb851d1718b7bc3d734009f156d4f38ec420d",
+    commit = "a666b9cafd4cd3c35405896c2121951c749979ea",
     importpath = "github.com/libp2p/go-libp2p-discovery",
 )
 
@@ -826,8 +826,8 @@ go_repository(
 
 go_repository(
     name = "com_github_konsorten_go_windows_terminal_sequences",
-    importpath = "github.com/konsorten/go-windows-terminal-sequences",
     tag = "v1.0.1",
+    importpath = "github.com/konsorten/go-windows-terminal-sequences",
 )
 
 go_repository(
@@ -876,26 +876,26 @@ go_repository(
 
 go_repository(
     name = "in_gopkg_yaml_v2",
-    importpath = "gopkg.in/yaml.v2",
     tag = "v2.2.2",
+    importpath = "gopkg.in/yaml.v2",
 )
 
 go_repository(
     name = "com_github_spf13_pflag",
-    importpath = "github.com/spf13/pflag",
     tag = "v1.0.3",
+    importpath = "github.com/spf13/pflag",
 )
 
 go_repository(
     name = "com_github_spf13_cobra",
-    importpath = "github.com/spf13/cobra",
     tag = "v0.0.3",
+    importpath = "github.com/spf13/cobra",
 )
 
 go_repository(
     name = "com_github_aws_aws_sdk_go",
-    importpath = "github.com/aws/aws-sdk-go",
     tag = "v1.16.9",
+    importpath = "github.com/aws/aws-sdk-go",
 )
 
 go_repository(
@@ -908,20 +908,20 @@ go_repository(
 
 go_repository(
     name = "org_golang_x_oauth2",
-    commit = "3e8b2be1363542a95c52ea0796d4a40dacfb5b95",
+    commit = "99b60b757ec124ebb7d6b7e97f153b19c10ce163",
     importpath = "golang.org/x/oauth2",
 )
 
 go_repository(
     name = "com_github_hashicorp_go_multierror",
-    importpath = "github.com/hashicorp/go-multierror",
     tag = "v1.0.0",
+    importpath = "github.com/hashicorp/go-multierror",
 )
 
 go_repository(
     name = "com_github_hashicorp_errwrap",
-    importpath = "github.com/hashicorp/errwrap",
     tag = "v1.0.0",
+    importpath = "github.com/hashicorp/errwrap",
 )
 
 go_repository(
@@ -932,26 +932,26 @@ go_repository(
 
 go_repository(
     name = "com_github_inconshreveable_mousetrap",
-    importpath = "github.com/inconshreveable/mousetrap",
     tag = "v1.0.0",
+    importpath = "github.com/inconshreveable/mousetrap",
 )
 
 go_repository(
     name = "com_github_deckarep_golang_set",
-    importpath = "github.com/deckarep/golang-set",
     tag = "v1.7.1",
+    importpath = "github.com/deckarep/golang-set",
 )
 
 go_repository(
     name = "com_github_go_stack_stack",
-    importpath = "github.com/go-stack/stack",
     tag = "v1.8.0",
+    importpath = "github.com/go-stack/stack",
 )
 
 go_repository(
     name = "com_github_rs_cors",
-    importpath = "github.com/rs/cors",
     tag = "v1.6.0",
+    importpath = "github.com/rs/cors",
 )
 
 go_repository(
@@ -962,26 +962,26 @@ go_repository(
 
 go_repository(
     name = "in_gopkg_urfave_cli_v1",
-    importpath = "gopkg.in/urfave/cli.v1",
     tag = "v1.20.0",
+    importpath = "gopkg.in/urfave/cli.v1",
 )
 
 go_repository(
     name = "com_github_rjeczalik_notify",
-    importpath = "github.com/rjeczalik/notify",
     tag = "v0.9.2",
+    importpath = "github.com/rjeczalik/notify",
 )
 
 go_repository(
     name = "com_github_edsrzf_mmap_go",
-    importpath = "github.com/edsrzf/mmap-go",
     tag = "v1.0.0",
+    importpath = "github.com/edsrzf/mmap-go",
 )
 
 go_repository(
     name = "com_github_pkg_errors",
-    importpath = "github.com/pkg/errors",
     tag = "v0.8.1",
+    importpath = "github.com/pkg/errors",
 )
 
 go_repository(
@@ -989,39 +989,3 @@ go_repository(
     commit = "c1b8fa8bdccecb0b8db834ee0b92fdbcfa606dd6",
     importpath = "gopkg.in/natefinch/npipe.v2",
 )
-
-go_repository(
-    name = "com_github_prysmaticlabs_go_bls",
-    commit = "0e61c30f21878172d57549ea1733c9808157ef08",
-    importpath = "github.com/prysmaticlabs/go-bls",
-)
-
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "herumi_mcl",
-    commit = "79b3a33e21072712f00985ed2adf34b3bcf0d74e",
-    remote = "https://github.com/prysmaticlabs/mcl",
-)
-
-git_repository(
-    name = "bazelify_gmp",
-    commit = "bb4881b35e6864c90493980d035e1d984cafd093",
-    remote = "https://github.com/robin-thomas/bazelify-gmp",
-)
-
-git_repository(
-    name = "boringssl",
-    commit = "fafc4482e85c09e7af5f71b2eb287b73ccd1020a",
-    remote = "https://github.com/google/boringssl",
-)
-
-git_repository(
-    name = "io_bazel_rules_m4",
-    commit = "2bf69df77dfb6b3ba6b7fc95c304b0dc279375bc",
-    remote = "https://github.com/jmillikin/rules_m4",
-)
-
-load("@io_bazel_rules_m4//:m4.bzl", "m4_register_toolchains")
-
-m4_register_toolchains()

--- a/shared/bls/BUILD.bazel
+++ b/shared/bls/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["bls.go"],
+    importpath = "github.com/prysmaticlabs/prysm/shared/bls",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["bls_test.go"],
+    embed = [":go_default_library"],
+)

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -1,0 +1,88 @@
+// Package bls implements a go-wrapper around a C BLS library leveraging
+// the BLS12-381 curve. This package exposes a public API for verifying and
+// aggregating BLS signatures used by Ethereum Serenity.
+package bls
+
+import (
+	"fmt"
+	"math/big"
+)
+
+// Signature used in the BLS signature scheme.
+type Signature struct{}
+
+// SecretKey used in the BLS scheme.
+type SecretKey struct {
+	K *big.Int
+}
+
+// PublicKey corresponding to secret key used in the BLS scheme.
+type PublicKey struct{}
+
+// PublicKey returns the corresponding public key for the
+// Secret Key
+func (s *SecretKey) PublicKey() (*PublicKey, error) {
+	return &PublicKey{}, nil
+}
+
+// BufferedSecretKey returns the secret key in a byte format.
+func (s *SecretKey) BufferedSecretKey() []byte {
+	return s.K.Bytes()
+}
+
+// BufferedPublicKey returns the public key in a byte format.
+func (p *PublicKey) BufferedPublicKey() []byte {
+	return []byte{}
+}
+
+// UnBufferSecretKey takes the byte representation of a secret key
+// and sets it to a big int of the underlying secret key object.
+func (s *SecretKey) UnBufferSecretKey(bufferedKey []byte) {
+	s.K = big.NewInt(0).SetBytes(bufferedKey)
+
+}
+
+// UnBufferPublicKey takes the byte representation of a public key
+// and sets it to a big int of the underlying public key object.
+func (p *PublicKey) UnBufferPublicKey(bufferedKey []byte) {
+
+}
+
+// GenerateKey generates a new secret key using a seed.
+func GenerateKey(seed []byte) *SecretKey {
+	return &SecretKey{
+		K: big.NewInt(0).SetBytes(seed),
+	}
+}
+
+// Sign a message using a secret key - in a beacon/validator client,
+// this key will come from and be unlocked from the account keystore.
+func Sign(sec *SecretKey, msg []byte) (*Signature, error) {
+	return &Signature{}, nil
+}
+
+// VerifySig against a public key.
+func VerifySig(pub *PublicKey, msg []byte, sig *Signature) (bool, error) {
+	return true, nil
+}
+
+// VerifyAggregateSig created using the underlying BLS signature
+// aggregation scheme.
+func VerifyAggregateSig(pubs []*PublicKey, msg []byte, asig *Signature) (bool, error) {
+	return true, nil
+}
+
+// BatchVerify a list of individual signatures by aggregating them.
+func BatchVerify(pubs []*PublicKey, msg []byte, sigs []*Signature) (bool, error) {
+	asigs, err := AggregateSigs(sigs)
+	if err != nil {
+		return false, fmt.Errorf("could not aggregate signatures: %v", err)
+	}
+	return VerifyAggregateSig(pubs, msg, asigs)
+}
+
+// AggregateSigs puts multiple signatures into one using the underlying
+// BLS sum functions.
+func AggregateSigs(sigs []*Signature) (*Signature, error) {
+	return &Signature{}, nil
+}

--- a/shared/bls/bls_test.go
+++ b/shared/bls/bls_test.go
@@ -1,0 +1,54 @@
+package bls
+
+import (
+	"testing"
+)
+
+func TestSign(t *testing.T) {
+	sk := &SecretKey{}
+	msg := []byte{}
+	if _, err := Sign(sk, msg); err != nil {
+		t.Errorf("Expected nil error, received %v", err)
+	}
+}
+
+func TestPublicKey(t *testing.T) {
+	sk := &SecretKey{}
+	if _, err := sk.PublicKey(); err != nil {
+		t.Errorf("Expected nil error, received %v", err)
+	}
+}
+
+func TestVerifySig(t *testing.T) {
+	pk := &PublicKey{}
+	msg := []byte{}
+	sig := &Signature{}
+	if _, err := VerifySig(pk, msg, sig); err != nil {
+		t.Errorf("Expected nil error, received %v", err)
+	}
+}
+
+func TestVerifyAggregateSig(t *testing.T) {
+	pk := &PublicKey{}
+	msg := []byte{}
+	asig := &Signature{}
+	if _, err := VerifyAggregateSig([]*PublicKey{pk}, msg, asig); err != nil {
+		t.Errorf("Expected nil error, received %v", err)
+	}
+}
+
+func TestBatchVerify(t *testing.T) {
+	pk := &PublicKey{}
+	msg := []byte{}
+	sig := &Signature{}
+	if _, err := BatchVerify([]*PublicKey{pk}, msg, []*Signature{sig}); err != nil {
+		t.Errorf("Expected nil error, received %v", err)
+	}
+}
+
+func TestAggregateSigs(t *testing.T) {
+	sig := &Signature{}
+	if _, err := AggregateSigs([]*Signature{sig}); err != nil {
+		t.Errorf("Expected nil error, received %v", err)
+	}
+}

--- a/shared/keystore/BUILD.bazel
+++ b/shared/keystore/BUILD.bazel
@@ -10,9 +10,10 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/shared/keystore",
     visibility = ["//visibility:public"],
     deps = [
+        "//shared/bls:go_default_library",
+        "@com_github_ethereum_go_ethereum//common/math:go_default_library",
         "@com_github_ethereum_go_ethereum//crypto:go_default_library",
         "@com_github_pborman_uuid//:go_default_library",
-        "@com_github_prysmaticlabs_go_bls//:go_default_library",
         "@org_golang_x_crypto//pbkdf2:go_default_library",
         "@org_golang_x_crypto//scrypt:go_default_library",
     ],
@@ -26,8 +27,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//shared/testutil:go_default_library",
+        "//shared/bls:go_default_library",
         "@com_github_pborman_uuid//:go_default_library",
-        "@com_github_prysmaticlabs_go_bls//:go_default_library",
     ],
 )

--- a/shared/keystore/key.go
+++ b/shared/keystore/key.go
@@ -28,7 +28,7 @@ import (
 	"path/filepath"
 
 	"github.com/pborman/uuid"
-	bls "github.com/prysmaticlabs/go-bls"
+	"github.com/prysmaticlabs/prysm/shared/bls"
 )
 
 const (
@@ -100,8 +100,8 @@ type cipherparamsJSON struct {
 // MarshalJSON marshalls a key struct into a JSON blob.
 func (k *Key) MarshalJSON() (j []byte, err error) {
 	jStruct := plainKeyJSON{
-		hex.EncodeToString(k.PublicKey.Serialize()),
-		hex.EncodeToString(k.SecretKey.LittleEndian()),
+		hex.EncodeToString(k.PublicKey.BufferedPublicKey()),
+		hex.EncodeToString(k.SecretKey.BufferedSecretKey()),
 		k.ID.String(),
 	}
 	j, err = json.Marshal(jStruct)
@@ -128,26 +128,24 @@ func (k *Key) UnmarshalJSON(j []byte) (err error) {
 		return err
 	}
 
-	if err := k.PublicKey.Deserialize(pubkey); err != nil {
-		return fmt.Errorf("unable to deserialize public key: %v", err)
-	}
-	if err := k.SecretKey.SetLittleEndian(seckey); err != nil {
-		return fmt.Errorf("unable to generate key in little endian format: %v", err)
-	}
+	k.PublicKey.UnBufferPublicKey(pubkey)
+	k.SecretKey.UnBufferSecretKey(seckey)
 
 	return nil
 }
 
-func newKeyFromBLS(blsKey *bls.SecretKey) *Key {
+func newKeyFromBLS(blsKey *bls.SecretKey) (*Key, error) {
 	id := uuid.NewRandom()
-	pubkey := blsKey.GetPublicKey()
-
+	pubkey, err := blsKey.PublicKey()
+	if err != nil {
+		return nil, err
+	}
 	key := &Key{
 		ID:        id,
 		PublicKey: pubkey,
 		SecretKey: blsKey,
 	}
-	return key
+	return key, nil
 }
 
 // NewKey generates a new random key.
@@ -157,10 +155,9 @@ func NewKey(rand io.Reader) (*Key, error) {
 	if err != nil {
 		return nil, fmt.Errorf("key generation: could not read from random source: %v", err)
 	}
-	secretKey := &bls.SecretKey{}
-	secretKey.SetByCSPRNG()
+	secretKey := bls.GenerateKey(randBytes)
 
-	return newKeyFromBLS(secretKey), nil
+	return newKeyFromBLS(secretKey)
 }
 
 func storeNewRandomKey(ks keyStore, rand io.Reader, password string) error {

--- a/shared/keystore/utils.go
+++ b/shared/keystore/utils.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"time"
 
-	bls "github.com/prysmaticlabs/go-bls"
+	"github.com/prysmaticlabs/prysm/shared/bls"
 )
 
 func aesCTRXOR(key, inText, iv []byte) ([]byte, error) {
@@ -50,11 +50,9 @@ func ensureInt(x interface{}) int {
 
 // keyFileName implements the naming convention for keyfiles:
 // UTC--<created_at UTC ISO8601>-<address hex>
-// Note: the address hex is truncated to the first 16 characters to avoid OS
-// filename length issues.
 func keyFileName(pubkey *bls.PublicKey) string {
 	ts := time.Now().UTC()
-	return fmt.Sprintf("UTC--%s--%s", toISO8601(ts), hex.EncodeToString(pubkey.Serialize())[16])
+	return fmt.Sprintf("UTC--%s--%s", toISO8601(ts), hex.EncodeToString(pubkey.BufferedPublicKey()))
 }
 
 func toISO8601(t time.Time) string {
@@ -70,7 +68,7 @@ func toISO8601(t time.Time) string {
 
 // zeroKey zeroes a private key in memory.
 func zeroKey(k *bls.SecretKey) {
-	b := k.LittleEndian()
+	b := k.K.Bits()
 	for i := range b {
 		b[i] = 0
 	}

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -27,7 +27,7 @@ go_image(
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/validator",
     race = "off",
-    # static = "on", # TODO(1582): Reenable static linking for docker images.
+    static = "on",
     tags = ["manual"],
     visibility = ["//visibility:private"],
     deps = [

--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -74,7 +74,7 @@ func NewValidatorAccount(directory string, password string) error {
 	).Info("Keystore generated for validator signatures at path")
 
 	data := &pb.DepositInput{
-		Pubkey:                      validatorKey.SecretKey.GetPublicKey().Serialize(),
+		Pubkey:                      validatorKey.SecretKey.K.Bytes(), // TODO(#1367): Use real BLS public key here.
 		ProofOfPossession:           []byte("pop"),
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}

--- a/validator/accounts/account_test.go
+++ b/validator/accounts/account_test.go
@@ -48,7 +48,7 @@ func TestNewValidatorAccount_PrintsDepositData(t *testing.T) {
 		t.Fatalf("Could not retrieve key: %v", err)
 	}
 	data := &pb.DepositInput{
-		Pubkey:                      valKey.SecretKey.GetPublicKey().Serialize(),
+		Pubkey:                      valKey.SecretKey.K.Bytes(), // TODO(#1367): Use real BLS public key here.
 		ProofOfPossession:           []byte("pop"),
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -114,7 +114,7 @@ func (v *validator) UpdateAssignments(ctx context.Context, slot uint64) error {
 
 	req := &pb.ValidatorEpochAssignmentsRequest{
 		EpochStart: slot,
-		PublicKey:  v.key.PublicKey.Serialize(),
+		PublicKey:  v.key.PublicKey.BufferedPublicKey(),
 	}
 
 	resp, err := v.validatorClient.ValidatorEpochAssignments(ctx, req)

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -31,7 +31,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64) {
 	// We fetch the validator index as it is necessary to generate the aggregation
 	// bitfield of the attestation itself.
 	idxReq := &pb.ValidatorIndexRequest{
-		PublicKey: v.key.PublicKey.Serialize(),
+		PublicKey: v.key.PublicKey.BufferedPublicKey(),
 	}
 	validatorIndexRes, err := v.validatorClient.ValidatorIndex(ctx, idxReq)
 	if err != nil {


### PR DESCRIPTION
Reverts commit bc2afa04c6aa870225f72ff1ec40941335afd9dd

This isn't a clean revert; had many conflicts so please review.

Tests pass, but `BufferedPublicKey` returns an empty byte array so I doubt that the validator epoch assignment requests are going to work...

Resolves #1582 since bls/mcl are no longer present. 