### PR TITLE
Skips Attestation Older than Finalized Slot

### DIFF
--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -323,7 +323,6 @@ func CleanupAttestations(state *pb.BeaconState) *pb.BeaconState {
 //
 // Spec pseudocode definition:
 // Let e = state.slot // EPOCH_LENGTH.
-<<<<<<< HEAD
 // Set state.latest_index_roots[(next_epoch + ENTRY_EXIT_DELAY) %
 // 	LATEST_INDEX_ROOTS_LENGTH] =
 // 	hash_tree_root(get_active_validator_indices(state,

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -323,6 +323,7 @@ func CleanupAttestations(state *pb.BeaconState) *pb.BeaconState {
 //
 // Spec pseudocode definition:
 // Let e = state.slot // EPOCH_LENGTH.
+<<<<<<< HEAD
 // Set state.latest_index_roots[(next_epoch + ENTRY_EXIT_DELAY) %
 // 	LATEST_INDEX_ROOTS_LENGTH] =
 // 	hash_tree_root(get_active_validator_indices(state,

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/sync",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
-        "//beacon-chain/core/attestations:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/sync/initial-sync:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -2,13 +2,11 @@ package sync
 
 import (
 	"context"
-	"github.com/prysmaticlabs/prysm/bazel-prysm/external/go_sdk/src/fmt"
+	"fmt"
 	"io/ioutil"
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/prysmaticlabs/prysm/shared/ssz"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
@@ -20,6 +18,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/ssz"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/sirupsen/logrus"
 	logTest "github.com/sirupsen/logrus/hooks/test"


### PR DESCRIPTION
This is an enhancement to #1565.

To prevent spamming attacks, the sync service should drop attestations with `slot < state's last finalized slot` and not pass the attestation to operation service (attestation pool)
