### PR TITLE
Update CheckBit for Small Endian

### DIFF
--- a/beacon-chain/attestation/service_test.go
+++ b/beacon-chain/attestation/service_test.go
@@ -32,7 +32,7 @@ func TestUpdateLatestAttestation_Ok(t *testing.T) {
 	service := NewAttestationService(context.Background(), &Config{BeaconDB: beaconDB})
 
 	attestation := &pb.Attestation{
-		AggregationBitfield: []byte{0x80},
+		AggregationBitfield: []byte{0x01},
 		Data: &pb.AttestationData{
 			Slot: 5,
 		},
@@ -71,7 +71,7 @@ func TestAttestationPool_Ok(t *testing.T) {
 
 	service := NewAttestationService(context.Background(), &Config{BeaconDB: beaconDB})
 	attestation := &pb.Attestation{
-		AggregationBitfield: []byte{0x80},
+		AggregationBitfield: []byte{0x01},
 		Data:                &pb.AttestationData{},
 	}
 

--- a/beacon-chain/core/epoch/epoch_operations_test.go
+++ b/beacon-chain/core/epoch/epoch_operations_test.go
@@ -372,7 +372,7 @@ func TestAttestingValidatorsOk(t *testing.T) {
 			Data: &pb.AttestationData{
 				ShardBlockRootHash32: []byte{byte(i + 100)},
 			},
-			AggregationBitfield: []byte{0xC0},
+			AggregationBitfield: []byte{0x03},
 		}
 		attestations = append(attestations, attestation)
 	}
@@ -420,7 +420,7 @@ func TestTotalAttestingBalanceOk(t *testing.T) {
 				ShardBlockRootHash32: []byte{byte(i + 100)},
 			},
 			// All validators attested to the above roots.
-			AggregationBitfield: []byte{0xc0},
+			AggregationBitfield: []byte{0x03},
 		}
 		attestations = append(attestations, attestation)
 	}

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -257,35 +257,35 @@ func TestAttestationParticipants_ok(t *testing.T) {
 			attestationSlot: 2,
 			stateSlot:       5,
 			shard:           2,
-			bitfield:        []byte{0xC0},
+			bitfield:        []byte{0x03},
 			wanted:          []uint64{11, 121},
 		},
 		{
 			attestationSlot: 1,
 			stateSlot:       10,
 			shard:           1,
-			bitfield:        []byte{0x80},
+			bitfield:        []byte{0x01},
 			wanted:          []uint64{4},
 		},
 		{
 			attestationSlot: 10,
 			stateSlot:       20,
 			shard:           10,
-			bitfield:        []byte{0xC0},
+			bitfield:        []byte{0x03},
 			wanted:          []uint64{14, 30},
 		},
 		{
 			attestationSlot: 64,
 			stateSlot:       100,
 			shard:           0,
-			bitfield:        []byte{0xC0},
+			bitfield:        []byte{0x03},
 			wanted:          []uint64{109, 97},
 		},
 		{
 			attestationSlot: 999,
 			stateSlot:       1000,
 			shard:           39,
-			bitfield:        []byte{0x80},
+			bitfield:        []byte{0x01},
 			wanted:          []uint64{6},
 		},
 	}
@@ -345,9 +345,7 @@ func TestVerifyBitfield(t *testing.T) {
 		t.Error("bitfield is not validated when it was supposed to be")
 	}
 
-	// The second byte is represented as 01000000 , however we could only represent numbers as big endian
-	// so the bitwise operation is used here.
-	bitfield = []byte{0xff, 0xbf ^ 0xff}
+	bitfield = []byte{0xff, 0x80}
 	committeeSize = 9
 
 	isValidated, err = VerifyBitfield(bitfield, committeeSize)
@@ -359,8 +357,8 @@ func TestVerifyBitfield(t *testing.T) {
 		t.Error("bitfield is validated when it was supposed to be")
 	}
 
+	bitfield = []byte{0xff, 0x01}
 	committeeSize = 10
-
 	isValidated, err = VerifyBitfield(bitfield, committeeSize)
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -24,15 +24,14 @@ func TestHasVoted(t *testing.T) {
 		if err != nil {
 			t.Errorf("checking bit failed at index: %d with : %v", i, err)
 		}
-
 		if !voted {
 			t.Error("validator voted but received didn't vote")
 		}
 	}
 
-	// Setting bit field to 01010101.
+	// Setting bit field to 10101000.
 	pendingAttestation = &pb.Attestation{
-		AggregationBitfield: []byte{85},
+		AggregationBitfield: []byte{84},
 	}
 
 	for i := 0; i < len(pendingAttestation.AggregationBitfield); i++ {
@@ -40,7 +39,6 @@ func TestHasVoted(t *testing.T) {
 		if err != nil {
 			t.Errorf("checking bit failed at index: %d : %v", i, err)
 		}
-
 		if i%2 == 0 && voted {
 			t.Error("validator didn't vote but received voted")
 		}
@@ -93,8 +91,8 @@ func TestBoundaryAttesterIndices(t *testing.T) {
 	}
 
 	boundaryAttestations := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{}, AggregationBitfield: []byte{0xC0}}, // returns indices 242
-		{Data: &pb.AttestationData{}, AggregationBitfield: []byte{0xC0}}, // returns indices 237,224,2
+		{Data: &pb.AttestationData{}, AggregationBitfield: []byte{0x03}}, // returns indices 242
+		{Data: &pb.AttestationData{}, AggregationBitfield: []byte{0x03}}, // returns indices 237,224,2
 	}
 
 	attesterIndices, err := ValidatorIndices(state, boundaryAttestations)
@@ -144,9 +142,9 @@ func TestAttestingValidatorIndices_Ok(t *testing.T) {
 		t.Fatalf("Could not execute AttestingValidatorIndices: %v", err)
 	}
 
-	if !reflect.DeepEqual(indices, []uint64{1141, 688}) {
+	if !reflect.DeepEqual(indices, []uint64{1117, 333}) {
 		t.Errorf("Could not get incorrect validator indices. Wanted: %v, got: %v",
-			[]uint64{1141, 688}, indices)
+			[]uint64{1117, 333}, indices)
 	}
 }
 

--- a/shared/bitutil/bit.go
+++ b/shared/bitutil/bit.go
@@ -7,22 +7,22 @@ import (
 	"github.com/steakknife/hamming"
 )
 
-// CheckBit checks if a bit in a bit field is one.
+// CheckBit checks if a bit in a bit field (small endian) is one.
 func CheckBit(bitfield []byte, index int) (bool, error) {
 	chunkLocation := (index + 1) / 8
 	indexLocation := (index + 1) % 8
+
 	if indexLocation == 0 {
 		indexLocation = 8
 	} else {
 		chunkLocation++
 	}
-
 	if chunkLocation > len(bitfield) {
 		return false, fmt.Errorf("index out of range for bitfield: length: %d, position: %d ",
 			len(bitfield), chunkLocation-1)
 	}
 
-	field := bitfield[chunkLocation-1] >> (8 - uint(indexLocation))
+	field := bitfield[chunkLocation-1] >> uint(indexLocation-1)
 	return field%2 != 0, nil
 }
 

--- a/shared/bitutil/bit_test.go
+++ b/shared/bitutil/bit_test.go
@@ -11,11 +11,11 @@ func TestCheckBit(t *testing.T) {
 		b int
 		c bool
 	}{
-		{a: []byte{200}, b: 4, c: true},   //11001000
-		{a: []byte{148}, b: 5, c: true},   //10010100
-		{a: []byte{146}, b: 4, c: false},  //10010010
-		{a: []byte{179}, b: 7, c: true},   //10110011
-		{a: []byte{49}, b: 6, c: false},   //00110001
+		{a: []byte{200}, b: 3, c: true},   //11001000
+		{a: []byte{148}, b: 2, c: true},   //10010100
+		{a: []byte{146}, b: 3, c: false},  //10010010
+		{a: []byte{179}, b: 0, c: true},   //10110011
+		{a: []byte{49}, b: 1, c: false},   //00110001
 		{a: []byte{49}, b: 100, c: false}, //00110001
 
 	}


### PR DESCRIPTION
This is part of #1621 

Key changes:
* Updated `CheckBit` to work with small endian
* Fixed tests