### PR TITLE
Move Deposit Encoding to Helpers Package

### DIFF
--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -31,7 +31,7 @@ func generateTestGenesisStateAndBlock(
 			Pubkey: pubkey,
 		}
 		balance := params.BeaconConfig().MaxDepositAmount
-		depositData, err := b.EncodeDepositData(depositInput, balance, time.Now().Unix())
+		depositData, err := helpers.EncodeDepositData(depositInput, balance, time.Now().Unix())
 		if err != nil {
 			t.Fatalf("Could not encode deposit: %v", err)
 		}

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -130,7 +132,7 @@ func setupInitialDeposits(t *testing.T) []*pb.Deposit {
 func createPreChainStartDeposit(t *testing.T, pk []byte) *pb.Deposit {
 	depositInput := &pb.DepositInput{Pubkey: pk}
 	balance := params.BeaconConfig().MaxDepositAmount
-	depositData, err := b.EncodeDepositData(depositInput, balance, time.Now().Unix())
+	depositData, err := helpers.EncodeDepositData(depositInput, balance, time.Now().Unix())
 	if err != nil {
 		t.Fatalf("Cannot encode data: %v", err)
 	}

--- a/beacon-chain/chaintest/backend/BUILD.bazel
+++ b/beacon-chain/chaintest/backend/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//beacon-chain/blockchain:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/utils:go_default_library",

--- a/beacon-chain/chaintest/backend/helpers.go
+++ b/beacon-chain/chaintest/backend/helpers.go
@@ -5,9 +5,10 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+
 	"github.com/prysmaticlabs/prysm/shared/ssz"
 
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
@@ -51,7 +52,7 @@ func generateSimulatedBlock(
 			ProofOfPossession:           make([]byte, 96),
 		}
 
-		data, err := b.EncodeDepositData(depositInput, simObjects.simDeposit.Amount, time.Now().Unix())
+		data, err := helpers.EncodeDepositData(depositInput, simObjects.simDeposit.Amount, time.Now().Unix())
 		if err != nil {
 			return nil, [32]byte{}, fmt.Errorf("could not encode deposit data: %v", err)
 		}
@@ -126,7 +127,7 @@ func generateInitialSimulatedDeposits(numDeposits uint64) ([]*pb.Deposit, error)
 			WithdrawalCredentialsHash32: make([]byte, 32),
 			ProofOfPossession:           make([]byte, 96),
 		}
-		depositData, err := b.EncodeDepositData(
+		depositData, err := helpers.EncodeDepositData(
 			depositInput,
 			params.BeaconConfig().MaxDepositAmount,
 			genesisTime,

--- a/beacon-chain/core/blocks/block.go
+++ b/beacon-chain/core/blocks/block.go
@@ -5,7 +5,6 @@ package blocks
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/utils"
@@ -77,76 +76,6 @@ func ProcessBlockRoots(state *pb.BeaconState, prevBlockRoot [32]byte) *pb.Beacon
 		state.BatchedBlockRootHash32S = append(state.BatchedBlockRootHash32S, merkleRoot)
 	}
 	return state
-}
-
-// EncodeDepositData converts a deposit input proto into an a byte slice
-// of Simple Serialized deposit input followed by 8 bytes for a deposit value
-// and 8 bytes for a unix timestamp, all in LittleEndian format.
-func EncodeDepositData(
-	depositInput *pb.DepositInput,
-	depositValue uint64,
-	depositTimestamp int64,
-) ([]byte, error) {
-	wBuf := new(bytes.Buffer)
-	if err := ssz.Encode(wBuf, depositInput); err != nil {
-		return nil, fmt.Errorf("failed to encode deposit input: %v", err)
-	}
-	encodedInput := wBuf.Bytes()
-	depositData := make([]byte, 0, 512)
-	value := make([]byte, 8)
-	binary.LittleEndian.PutUint64(value, depositValue)
-	timestamp := make([]byte, 8)
-	binary.LittleEndian.PutUint64(timestamp, uint64(depositTimestamp))
-
-	depositData = append(depositData, value...)
-	depositData = append(depositData, timestamp...)
-	depositData = append(depositData, encodedInput...)
-
-	return depositData, nil
-}
-
-// DecodeDepositInput unmarshals a depositData byte slice into
-// a proto *pb.DepositInput by using the Simple Serialize (SSZ)
-// algorithm.
-// TODO(#1253): Do not assume we will receive serialized proto objects - instead,
-// replace completely by a common struct which can be simple serialized.
-func DecodeDepositInput(depositData []byte) (*pb.DepositInput, error) {
-	if len(depositData) < 16 {
-		return nil, fmt.Errorf(
-			"deposit data slice too small: len(depositData) = %d",
-			len(depositData),
-		)
-	}
-	depositInput := new(pb.DepositInput)
-	// Since the value deposited and the timestamp are both 8 bytes each,
-	// the deposit data is the chunk after the first 16 bytes.
-	depositInputBytes := depositData[16:]
-	rBuf := bytes.NewReader(depositInputBytes)
-	if err := ssz.Decode(rBuf, depositInput); err != nil {
-		return nil, fmt.Errorf("ssz decode failed: %v", err)
-	}
-	return depositInput, nil
-}
-
-// DecodeDepositAmountAndTimeStamp extracts the deposit amount and timestamp
-// from the given deposit data.
-func DecodeDepositAmountAndTimeStamp(depositData []byte) (uint64, int64, error) {
-	// Last 16 bytes of deposit data are 8 bytes for value
-	// and 8 bytes for timestamp. Everything before that is a
-	// Simple Serialized deposit input value.
-	if len(depositData) < 16 {
-		return 0, 0, fmt.Errorf(
-			"deposit data slice too small: len(depositData) = %d",
-			len(depositData),
-		)
-	}
-
-	// the amount occupies the first 8 bytes while the
-	// timestamp occupies the next 8 bytes.
-	amount := binary.LittleEndian.Uint64(depositData[:8])
-	timestamp := binary.LittleEndian.Uint64(depositData[8:16])
-
-	return amount, int64(timestamp), nil
 }
 
 // BlockChildren obtains the blocks in a list of observed blocks which have the current

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -527,7 +527,7 @@ func ProcessValidatorDeposits(
 	validatorIndexMap := stateutils.ValidatorIndexMap(beaconState)
 	for idx, deposit := range deposits {
 		depositData := deposit.DepositData
-		depositInput, err = DecodeDepositInput(depositData)
+		depositInput, err = helpers.DecodeDepositInput(depositData)
 		if err != nil {
 			return nil, fmt.Errorf("could not decode deposit input: %v", err)
 		}

--- a/beacon-chain/core/blocks/block_test.go
+++ b/beacon-chain/core/blocks/block_test.go
@@ -3,9 +3,10 @@ package blocks
 import (
 	"bytes"
 	"fmt"
-	"github.com/prysmaticlabs/prysm/shared/ssz"
 	"reflect"
 	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/ssz"
 
 	"github.com/gogo/protobuf/proto"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"

--- a/beacon-chain/core/blocks/block_test.go
+++ b/beacon-chain/core/blocks/block_test.go
@@ -3,11 +3,9 @@ package blocks
 import (
 	"bytes"
 	"fmt"
+	"github.com/prysmaticlabs/prysm/shared/ssz"
 	"reflect"
 	"testing"
-	"time"
-
-	"github.com/prysmaticlabs/prysm/shared/ssz"
 
 	"github.com/gogo/protobuf/proto"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -173,79 +171,6 @@ func TestProcessBlockRoots(t *testing.T) {
 	}
 }
 
-func TestDecodeDepositAmountAndTimeStamp(t *testing.T) {
-
-	tests := []struct {
-		depositData *pb.DepositInput
-		amount      uint64
-		timestamp   int64
-	}{
-		{
-			depositData: &pb.DepositInput{
-				Pubkey:                      []byte("testing"),
-				ProofOfPossession:           []byte("pop"),
-				WithdrawalCredentialsHash32: []byte("withdraw"),
-			},
-			amount:    8749343850,
-			timestamp: 458739850,
-		},
-		{
-			depositData: &pb.DepositInput{
-				Pubkey:                      []byte("testing"),
-				ProofOfPossession:           []byte("pop"),
-				WithdrawalCredentialsHash32: []byte("withdraw"),
-			},
-			amount:    657660,
-			timestamp: 67750,
-		},
-		{
-			depositData: &pb.DepositInput{
-				Pubkey:                      []byte("testing"),
-				ProofOfPossession:           []byte("pop"),
-				WithdrawalCredentialsHash32: []byte("withdraw"),
-			},
-			amount:    5445540,
-			timestamp: 34340,
-		}, {
-			depositData: &pb.DepositInput{
-				Pubkey:                      []byte("testing"),
-				ProofOfPossession:           []byte("pop"),
-				WithdrawalCredentialsHash32: []byte("withdraw"),
-			},
-			amount:    4545,
-			timestamp: 4343,
-		}, {
-			depositData: &pb.DepositInput{
-				Pubkey:                      []byte("testing"),
-				ProofOfPossession:           []byte("pop"),
-				WithdrawalCredentialsHash32: []byte("withdraw"),
-			},
-			amount:    76706966,
-			timestamp: 34394393,
-		},
-	}
-
-	for _, tt := range tests {
-		data, err := EncodeDepositData(tt.depositData, tt.amount, tt.timestamp)
-		if err != nil {
-			t.Fatalf("could not encode data %v", err)
-		}
-
-		decAmount, decTimestamp, err := DecodeDepositAmountAndTimeStamp(data)
-		if err != nil {
-			t.Fatalf("could not decode data %v", err)
-		}
-
-		if tt.amount != decAmount {
-			t.Errorf("decoded amount not equal to given amount, %d : %d", decAmount, tt.amount)
-		}
-
-		if tt.timestamp != decTimestamp {
-			t.Errorf("decoded timestamp not equal to given timestamp, %d : %d", decTimestamp, tt.timestamp)
-		}
-	}
-}
-
 func TestBlockChildren(t *testing.T) {
 	genesisBlock := NewGenesisBlock([]byte{})
 	genesisRoot, err := ssz.TreeHash(genesisBlock)
@@ -272,38 +197,5 @@ func TestBlockChildren(t *testing.T) {
 	}
 	if len(children) != 2 {
 		t.Errorf("Expected %d children, received %d", 2, len(children))
-	}
-}
-
-func TestEncodeDecodeDepositInput_Ok(t *testing.T) {
-	input := &pb.DepositInput{
-		Pubkey:                      []byte("key"),
-		WithdrawalCredentialsHash32: []byte("withdraw"),
-		ProofOfPossession:           []byte("pop"),
-	}
-	depositTime := time.Now().Unix()
-	enc, err := EncodeDepositData(input, params.BeaconConfig().MaxDepositAmount, depositTime)
-	if err != nil {
-		t.Errorf("Could not encode deposit input: %v", err)
-	}
-	dec, err := DecodeDepositInput(enc)
-	if err != nil {
-		t.Errorf("Could not decode deposit input: %v", err)
-	}
-	if !proto.Equal(input, dec) {
-		t.Errorf("Original and decoded messages do not match, wanted %v, received %v", input, dec)
-	}
-	value, timestamp, err := DecodeDepositAmountAndTimeStamp(enc)
-	if err != nil {
-		t.Errorf("Could not decode amount and timestamp: %v", err)
-	}
-	if value != params.BeaconConfig().MaxDepositAmount || timestamp != depositTime {
-		t.Errorf(
-			"Expected value to match, received %d == %d, expected timestamp to match received %d == %d",
-			value,
-			params.BeaconConfig().MaxDepositAmount,
-			timestamp,
-			depositTime,
-		)
 	}
 }

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "committee.go",
+        "deposits.go",
         "randao.go",
         "rewards_penalties.go",
         "signature.go",
@@ -20,6 +21,7 @@ go_library(
         "//shared/hashutil:go_default_library",
         "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/ssz:go_default_library",
     ],
 )
 
@@ -27,6 +29,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "committee_test.go",
+        "deposits_test.go",
         "randao_test.go",
         "rewards_penalties_test.go",
         "signature_test.go",
@@ -37,5 +40,6 @@ go_test(
     deps = [
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/params:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
     ],
 )

--- a/beacon-chain/core/helpers/deposits.go
+++ b/beacon-chain/core/helpers/deposits.go
@@ -1,0 +1,80 @@
+package helpers
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/ssz"
+)
+
+// EncodeDepositData converts a deposit input proto into an a byte slice
+// of Simple Serialized deposit input followed by 8 bytes for a deposit value
+// and 8 bytes for a unix timestamp, all in LittleEndian format.
+func EncodeDepositData(
+	depositInput *pb.DepositInput,
+	depositValue uint64,
+	depositTimestamp int64,
+) ([]byte, error) {
+	wBuf := new(bytes.Buffer)
+	if err := ssz.Encode(wBuf, depositInput); err != nil {
+		return nil, fmt.Errorf("failed to encode deposit input: %v", err)
+	}
+	encodedInput := wBuf.Bytes()
+	depositData := make([]byte, 0, 512)
+	value := make([]byte, 8)
+	binary.LittleEndian.PutUint64(value, depositValue)
+	timestamp := make([]byte, 8)
+	binary.LittleEndian.PutUint64(timestamp, uint64(depositTimestamp))
+
+	depositData = append(depositData, value...)
+	depositData = append(depositData, timestamp...)
+	depositData = append(depositData, encodedInput...)
+
+	return depositData, nil
+}
+
+// DecodeDepositInput unmarshals a depositData byte slice into
+// a proto *pb.DepositInput by using the Simple Serialize (SSZ)
+// algorithm.
+// TODO(#1253): Do not assume we will receive serialized proto objects - instead,
+// replace completely by a common struct which can be simple serialized.
+func DecodeDepositInput(depositData []byte) (*pb.DepositInput, error) {
+	if len(depositData) < 16 {
+		return nil, fmt.Errorf(
+			"deposit data slice too small: len(depositData) = %d",
+			len(depositData),
+		)
+	}
+	depositInput := new(pb.DepositInput)
+	// Since the value deposited and the timestamp are both 8 bytes each,
+	// the deposit data is the chunk after the first 16 bytes.
+	depositInputBytes := depositData[16:]
+	rBuf := bytes.NewReader(depositInputBytes)
+	if err := ssz.Decode(rBuf, depositInput); err != nil {
+		return nil, fmt.Errorf("ssz decode failed: %v", err)
+	}
+	return depositInput, nil
+}
+
+// DecodeDepositAmountAndTimeStamp extracts the deposit amount and timestamp
+// from the given deposit data.
+func DecodeDepositAmountAndTimeStamp(depositData []byte) (uint64, int64, error) {
+	// Last 16 bytes of deposit data are 8 bytes for value
+	// and 8 bytes for timestamp. Everything before that is a
+	// Simple Serialized deposit input value.
+	if len(depositData) < 16 {
+		return 0, 0, fmt.Errorf(
+			"deposit data slice too small: len(depositData) = %d",
+			len(depositData),
+		)
+	}
+
+	// the amount occupies the first 8 bytes while the
+	// timestamp occupies the next 8 bytes.
+	amount := binary.LittleEndian.Uint64(depositData[:8])
+	timestamp := binary.LittleEndian.Uint64(depositData[8:16])
+
+	return amount, int64(timestamp), nil
+}

--- a/beacon-chain/core/helpers/deposits_test.go
+++ b/beacon-chain/core/helpers/deposits_test.go
@@ -1,0 +1,116 @@
+package helpers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/params"
+)
+
+func TestEncodeDecodeDepositInput_Ok(t *testing.T) {
+	input := &pb.DepositInput{
+		Pubkey:                      []byte("key"),
+		WithdrawalCredentialsHash32: []byte("withdraw"),
+		ProofOfPossession:           []byte("pop"),
+	}
+	depositTime := time.Now().Unix()
+	enc, err := EncodeDepositData(input, params.BeaconConfig().MaxDepositAmount, depositTime)
+	if err != nil {
+		t.Errorf("Could not encode deposit input: %v", err)
+	}
+	dec, err := DecodeDepositInput(enc)
+	if err != nil {
+		t.Errorf("Could not decode deposit input: %v", err)
+	}
+	if !proto.Equal(input, dec) {
+		t.Errorf("Original and decoded messages do not match, wanted %v, received %v", input, dec)
+	}
+	value, timestamp, err := DecodeDepositAmountAndTimeStamp(enc)
+	if err != nil {
+		t.Errorf("Could not decode amount and timestamp: %v", err)
+	}
+	if value != params.BeaconConfig().MaxDepositAmount || timestamp != depositTime {
+		t.Errorf(
+			"Expected value to match, received %d == %d, expected timestamp to match received %d == %d",
+			value,
+			params.BeaconConfig().MaxDepositAmount,
+			timestamp,
+			depositTime,
+		)
+	}
+}
+
+func TestDecodeDepositAmountAndTimeStamp(t *testing.T) {
+
+	tests := []struct {
+		depositData *pb.DepositInput
+		amount      uint64
+		timestamp   int64
+	}{
+		{
+			depositData: &pb.DepositInput{
+				Pubkey:                      []byte("testing"),
+				ProofOfPossession:           []byte("pop"),
+				WithdrawalCredentialsHash32: []byte("withdraw"),
+			},
+			amount:    8749343850,
+			timestamp: 458739850,
+		},
+		{
+			depositData: &pb.DepositInput{
+				Pubkey:                      []byte("testing"),
+				ProofOfPossession:           []byte("pop"),
+				WithdrawalCredentialsHash32: []byte("withdraw"),
+			},
+			amount:    657660,
+			timestamp: 67750,
+		},
+		{
+			depositData: &pb.DepositInput{
+				Pubkey:                      []byte("testing"),
+				ProofOfPossession:           []byte("pop"),
+				WithdrawalCredentialsHash32: []byte("withdraw"),
+			},
+			amount:    5445540,
+			timestamp: 34340,
+		}, {
+			depositData: &pb.DepositInput{
+				Pubkey:                      []byte("testing"),
+				ProofOfPossession:           []byte("pop"),
+				WithdrawalCredentialsHash32: []byte("withdraw"),
+			},
+			amount:    4545,
+			timestamp: 4343,
+		}, {
+			depositData: &pb.DepositInput{
+				Pubkey:                      []byte("testing"),
+				ProofOfPossession:           []byte("pop"),
+				WithdrawalCredentialsHash32: []byte("withdraw"),
+			},
+			amount:    76706966,
+			timestamp: 34394393,
+		},
+	}
+
+	for _, tt := range tests {
+		data, err := EncodeDepositData(tt.depositData, tt.amount, tt.timestamp)
+		if err != nil {
+			t.Fatalf("could not encode data %v", err)
+		}
+
+		decAmount, decTimestamp, err := DecodeDepositAmountAndTimeStamp(data)
+		if err != nil {
+			t.Fatalf("could not decode data %v", err)
+		}
+
+		if tt.amount != decAmount {
+			t.Errorf("decoded amount not equal to given amount, %d : %d", decAmount, tt.amount)
+		}
+
+		if tt.timestamp != decTimestamp {
+			t.Errorf("decoded timestamp not equal to given timestamp, %d : %d", decTimestamp, tt.timestamp)
+		}
+	}
+}

--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -29,7 +29,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/ssz"
 
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -61,7 +60,7 @@ func GenesisBeaconState(
 	validatorRegistry := make([]*pb.Validator, len(genesisValidatorDeposits))
 	latestBalances := make([]uint64, len(genesisValidatorDeposits))
 	for i, d := range genesisValidatorDeposits {
-		depositInput, err := b.DecodeDepositInput(d.DepositData)
+		depositInput, err := helpers.DecodeDepositInput(d.DepositData)
 		if err != nil {
 			return nil, fmt.Errorf("could decode deposit input %v", err)
 		}
@@ -131,11 +130,11 @@ func GenesisBeaconState(
 	validatorMap := stateutils.ValidatorIndexMap(state)
 	for _, deposit := range genesisValidatorDeposits {
 		depositData := deposit.DepositData
-		depositInput, err := b.DecodeDepositInput(depositData)
+		depositInput, err := helpers.DecodeDepositInput(depositData)
 		if err != nil {
 			return nil, fmt.Errorf("could not decode deposit input: %v", err)
 		}
-		value, _, err := b.DecodeDepositAmountAndTimeStamp(depositData)
+		value, _, err := helpers.DecodeDepositAmountAndTimeStamp(depositData)
 		if err != nil {
 			return nil, fmt.Errorf("could not decode deposit value and timestamp: %v", err)
 		}

--- a/beacon-chain/core/state/state_test.go
+++ b/beacon-chain/core/state/state_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/ssz"
 
-	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
@@ -63,7 +62,7 @@ func TestGenesisBeaconState_Ok(t *testing.T) {
 	maxDeposit := params.BeaconConfig().MaxDepositAmount
 	var deposits []*pb.Deposit
 	for i := 0; i < depositsForChainStart; i++ {
-		depositData, err := b.EncodeDepositData(
+		depositData, err := helpers.EncodeDepositData(
 			&pb.DepositInput{
 				Pubkey:                      []byte(strconv.Itoa(i)),
 				ProofOfPossession:           []byte{'B'},

--- a/beacon-chain/db/BUILD.bazel
+++ b/beacon-chain/db/BUILD.bazel
@@ -43,7 +43,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/hashutil:go_default_library",

--- a/beacon-chain/db/state_test.go
+++ b/beacon-chain/db/state_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+
 	"github.com/gogo/protobuf/proto"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -20,7 +21,7 @@ func setupInitialDeposits(t *testing.T) []*pb.Deposit {
 			Pubkey: genesisValidatorRegistry[i].Pubkey,
 		}
 		balance := params.BeaconConfig().MaxDepositAmount
-		depositData, err := blocks.EncodeDepositData(depositInput, balance, time.Now().Unix())
+		depositData, err := helpers.EncodeDepositData(depositInput, balance, time.Now().Unix())
 		if err != nil {
 			t.Fatalf("Cannot encode data: %v", err)
 		}

--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/powchain",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//contracts/deposit-contract:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
@@ -29,7 +29,7 @@ go_test(
     srcs = ["service_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//contracts/deposit-contract:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -11,13 +11,14 @@ import (
 	"strings"
 	"time"
 
-	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	contracts "github.com/prysmaticlabs/prysm/contracts/deposit-contract"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -259,7 +260,7 @@ func (w *Web3Service) ProcessDepositLog(depositLog gethTypes.Log) {
 		return
 	}
 	w.lastReceivedMerkleIndex = int64(index)
-	depositInput, err := blocks.DecodeDepositInput(depositData)
+	depositInput, err := helpers.DecodeDepositInput(depositData)
 	if err != nil {
 		log.Errorf("Could not decode deposit input  %v", err)
 		return

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -12,14 +12,15 @@ import (
 	"testing"
 	"time"
 
-	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	contracts "github.com/prysmaticlabs/prysm/contracts/deposit-contract"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -651,7 +652,7 @@ func TestUnpackDepositLogs(t *testing.T) {
 		t.Errorf("Retrieved merkle tree index is incorrect %d", index)
 	}
 
-	deserializeData, err := blocks.DecodeDepositInput(depositData)
+	deserializeData, err := helpers.DecodeDepositInput(depositData)
 	if err != nil {
 		t.Fatalf("Unable to decode deposit input %v", err)
 	}
@@ -706,8 +707,6 @@ func TestProcessChainStartLog(t *testing.T) {
 	if err := ssz.Encode(serializedData, data); err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
-
-	blocks.EncodeDepositData(data, amount32Eth.Uint64(), time.Now().Unix())
 
 	// 8 Validators are used as size required for beacon-chain to start. This number
 	// is defined in the deposit contract as the number required for the testnet. The actual number

--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/core/blocks:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/internal:go_default_library",

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/internal"
@@ -25,7 +27,7 @@ func TestProposeBlock(t *testing.T) {
 
 	deposits := make([]*pbp2p.Deposit, params.BeaconConfig().DepositsForChainStart)
 	for i := 0; i < len(deposits); i++ {
-		depositData, err := b.EncodeDepositData(
+		depositData, err := helpers.EncodeDepositData(
 			&pbp2p.DepositInput{
 				Pubkey: []byte(strconv.Itoa(i)),
 			},
@@ -76,7 +78,7 @@ func TestComputeStateRoot(t *testing.T) {
 
 	deposits := make([]*pbp2p.Deposit, params.BeaconConfig().DepositsForChainStart)
 	for i := 0; i < len(deposits); i++ {
-		depositData, err := b.EncodeDepositData(
+		depositData, err := helpers.EncodeDepositData(
 			&pbp2p.DepositInput{
 				Pubkey: []byte(strconv.Itoa(i)),
 			},

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/internal"
@@ -25,7 +27,7 @@ func TestValidatorIndex_Ok(t *testing.T) {
 		t.Fatalf("Could not save genesis block: %v", err)
 	}
 
-	depositData, err := b.EncodeDepositData(
+	depositData, err := helpers.EncodeDepositData(
 		&pbp2p.DepositInput{
 			Pubkey: []byte{'A'},
 		},
@@ -75,7 +77,7 @@ func TestValidatorEpochAssignments_Ok(t *testing.T) {
 		depositInput := &pbp2p.DepositInput{
 			Pubkey: pubKey[:],
 		}
-		depositData, err := b.EncodeDepositData(
+		depositData, err := helpers.EncodeDepositData(
 			depositInput,
 			params.BeaconConfig().MaxDepositAmount,
 			genesisTime,
@@ -159,7 +161,7 @@ func TestValidatorCommitteeAtSlot_CrosslinkCommitteesFailure(t *testing.T) {
 		depositInput := &pbp2p.DepositInput{
 			Pubkey: pubKey[:],
 		}
-		depositData, err := b.EncodeDepositData(
+		depositData, err := helpers.EncodeDepositData(
 			depositInput,
 			params.BeaconConfig().MaxDepositAmount,
 			genesisTime,
@@ -205,7 +207,7 @@ func TestValidatorCommitteeAtSlot_Ok(t *testing.T) {
 		depositInput := &pbp2p.DepositInput{
 			Pubkey: pubKey[:],
 		}
-		depositData, err := b.EncodeDepositData(
+		depositData, err := helpers.EncodeDepositData(
 			depositInput,
 			params.BeaconConfig().MaxDepositAmount,
 			genesisTime,

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -34,7 +34,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/internal:go_default_library",

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -8,8 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+
 	"github.com/gogo/protobuf/proto"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/internal"
@@ -65,7 +66,7 @@ func setupInitialDeposits(t *testing.T) []*pb.Deposit {
 			Pubkey: genesisValidatorRegistry[i].Pubkey,
 		}
 		balance := params.BeaconConfig().MaxDepositAmount
-		depositData, err := blocks.EncodeDepositData(depositInput, balance, time.Now().Unix())
+		depositData, err := helpers.EncodeDepositData(depositInput, balance, time.Now().Unix())
 		if err != nil {
 			t.Fatalf("Cannot encode data: %v", err)
 		}


### PR DESCRIPTION
# Description

**Write why you are making the changes in this pull request**

Currently, encoding of deposits is in the `blocks` package, which led to a lot of import cycles when building out the RANDAO functionality. Instead, we move this logic to the helpers package to prevent import cycles in the future as there are pretty much pure functions that should live alongside other pure utilities such as the ones found in helpers.
