### PR TITLE
Shorten keystore filename

### DIFF
--- a/shared/keystore/utils.go
+++ b/shared/keystore/utils.go
@@ -49,10 +49,10 @@ func ensureInt(x interface{}) int {
 }
 
 // keyFileName implements the naming convention for keyfiles:
-// UTC--<created_at UTC ISO8601>-<address hex>
+// UTC--<created_at UTC ISO8601>-<first 8 character of address hex>
 func keyFileName(pubkey *bls.PublicKey) string {
 	ts := time.Now().UTC()
-	return fmt.Sprintf("UTC--%s--%s", toISO8601(ts), hex.EncodeToString(pubkey.Marshal()))
+	return fmt.Sprintf("UTC--%s--%s", toISO8601(ts), hex.EncodeToString(pubkey.Marshal())[:8])
 }
 
 func toISO8601(t time.Time) string {


### PR DESCRIPTION
Before:
```
.UTC--2019-02-19T20-47-33.890586363Z--8e28ead22989a939fd6a8e770c290e67a738c44c530ab00ac5e5104c7da3e60c91b1b6e8d48316eb036c637ad2c639110803f2cd329ad9e75a9fc0cdab7e05906931faab788586cb4ad8079afa66b44c8564b14ec998b91211cc205e8232ff2e.tmp909348847
```

After 
```
.UTC--2019-02-19T20-47-33.890586363Z--8e28ead2.tmp909348847
```

Why? On some systems, this creates a filename/path that is too long. Particularly in tests.