### PR TITLE
Fatal if ChainStart Receiving Fails

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -277,15 +277,15 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 	key := ctx.GlobalString(utils.KeyFlag.Name)
 	chainStartDelayFlag := ctx.GlobalUint64(utils.ChainStartDelay.Name)
 	rpcService := rpc.NewRPCService(context.TODO(), &rpc.Config{
-		Port:             port,
-		CertFlag:         cert,
-		KeyFlag:          key,
+		Port:                port,
+		CertFlag:            cert,
+		KeyFlag:             key,
 		ChainStartDelayFlag: chainStartDelayFlag,
-		SubscriptionBuf:  100,
-		BeaconDB:         b.db,
-		ChainService:     chainService,
-		OperationService: operationService,
-		POWChainService:  web3Service,
+		SubscriptionBuf:     100,
+		BeaconDB:            b.db,
+		ChainService:        chainService,
+		OperationService:    operationService,
+		POWChainService:     web3Service,
 	})
 
 	return b.services.RegisterService(rpcService)

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -275,10 +275,12 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 	port := ctx.GlobalString(utils.RPCPort.Name)
 	cert := ctx.GlobalString(utils.CertFlag.Name)
 	key := ctx.GlobalString(utils.KeyFlag.Name)
+	chainStartDelayFlag := ctx.GlobalUint64(utils.ChainStartDelay.Name)
 	rpcService := rpc.NewRPCService(context.TODO(), &rpc.Config{
 		Port:             port,
 		CertFlag:         cert,
 		KeyFlag:          key,
+		ChainStartDelayFlag: chainStartDelayFlag,
 		SubscriptionBuf:  100,
 		BeaconDB:         b.db,
 		ChainService:     chainService,

--- a/beacon-chain/rpc/beacon_server_test.go
+++ b/beacon-chain/rpc/beacon_server_test.go
@@ -98,7 +98,6 @@ func (m *mockPOWChainService) DepositRoot() [32]byte {
 }
 
 func TestWaitForChainStart_ContextClosed(t *testing.T) {
-	hook := logTest.NewGlobal()
 	ctx, cancel := context.WithCancel(context.Background())
 	beaconServer := &BeaconServer{
 		ctx: ctx,
@@ -112,14 +111,14 @@ func TestWaitForChainStart_ContextClosed(t *testing.T) {
 	defer ctrl.Finish()
 	mockStream := internal.NewMockBeaconService_WaitForChainStartServer(ctrl)
 	go func(tt *testing.T) {
-		if err := beaconServer.WaitForChainStart(&ptypes.Empty{}, mockStream); err != nil {
+		want := "context closed"
+		if err := beaconServer.WaitForChainStart(&ptypes.Empty{}, mockStream); !strings.Contains(err.Error(), want) {
 			tt.Errorf("Could not call RPC method: %v", err)
 		}
 		<-exitRoutine
 	}(t)
 	cancel()
 	exitRoutine <- true
-	testutil.AssertLogsContain(t, hook, "RPC context closed, exiting goroutine")
 }
 
 func TestWaitForChainStart_AlreadyStarted(t *testing.T) {

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -61,6 +61,7 @@ type Service struct {
 	powChainService       powChainService
 	operationService      operationService
 	port                  string
+	chainStartDelayFlag uint64
 	listener              net.Listener
 	withCert              string
 	withKey               string
@@ -77,6 +78,7 @@ type Config struct {
 	Port             string
 	CertFlag         string
 	KeyFlag          string
+	ChainStartDelayFlag uint64
 	SubscriptionBuf  int
 	BeaconDB         *db.BeaconDB
 	ChainService     chainService
@@ -98,6 +100,7 @@ func NewRPCService(ctx context.Context, cfg *Config) *Service {
 		port:                  cfg.Port,
 		withCert:              cfg.CertFlag,
 		withKey:               cfg.KeyFlag,
+		chainStartDelayFlag: cfg.ChainStartDelayFlag,
 		slotAlignmentDuration: time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
 		canonicalBlockChan:    make(chan *pbp2p.BeaconBlock, cfg.SubscriptionBuf),
 		canonicalStateChan:    make(chan *pbp2p.BeaconState, cfg.SubscriptionBuf),
@@ -137,6 +140,7 @@ func (s *Service) Start() {
 		operationService:    s.operationService,
 		incomingAttestation: s.incomingAttestation,
 		canonicalStateChan:  s.canonicalStateChan,
+		chainStartDelayFlag: s.chainStartDelayFlag,
 		chainStartChan:      make(chan time.Time, 1),
 	}
 	proposerServer := &ProposerServer{

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -61,7 +61,7 @@ type Service struct {
 	powChainService       powChainService
 	operationService      operationService
 	port                  string
-	chainStartDelayFlag uint64
+	chainStartDelayFlag   uint64
 	listener              net.Listener
 	withCert              string
 	withKey               string
@@ -75,15 +75,15 @@ type Service struct {
 
 // Config options for the beacon node RPC server.
 type Config struct {
-	Port             string
-	CertFlag         string
-	KeyFlag          string
+	Port                string
+	CertFlag            string
+	KeyFlag             string
 	ChainStartDelayFlag uint64
-	SubscriptionBuf  int
-	BeaconDB         *db.BeaconDB
-	ChainService     chainService
-	POWChainService  powChainService
-	OperationService operationService
+	SubscriptionBuf     int
+	BeaconDB            *db.BeaconDB
+	ChainService        chainService
+	POWChainService     powChainService
+	OperationService    operationService
 }
 
 // NewRPCService creates a new instance of a struct implementing the BeaconServiceServer
@@ -100,7 +100,7 @@ func NewRPCService(ctx context.Context, cfg *Config) *Service {
 		port:                  cfg.Port,
 		withCert:              cfg.CertFlag,
 		withKey:               cfg.KeyFlag,
-		chainStartDelayFlag: cfg.ChainStartDelayFlag,
+		chainStartDelayFlag:   cfg.ChainStartDelayFlag,
 		slotAlignmentDuration: time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
 		canonicalBlockChan:    make(chan *pbp2p.BeaconBlock, cfg.SubscriptionBuf),
 		canonicalStateChan:    make(chan *pbp2p.BeaconState, cfg.SubscriptionBuf),

--- a/validator/client/fake_validator_test.go
+++ b/validator/client/fake_validator_test.go
@@ -30,8 +30,9 @@ func (fv *fakeValidator) Done() {
 	fv.DoneCalled = true
 }
 
-func (fv *fakeValidator) WaitForChainStart(_ context.Context) {
+func (fv *fakeValidator) WaitForChainStart(_ context.Context) error {
 	fv.WaitForChainStartCalled = true
+	return nil
 }
 
 func (fv *fakeValidator) WaitForActivation(_ context.Context) {

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -13,7 +13,7 @@ import (
 // Validator interface defines the primary methods of a validator client.
 type Validator interface {
 	Done()
-	WaitForChainStart(ctx context.Context)
+	WaitForChainStart(ctx context.Context) error
 	WaitForActivation(ctx context.Context)
 	NextSlot() <-chan uint64
 	UpdateAssignments(ctx context.Context, slot uint64) error
@@ -34,7 +34,9 @@ type Validator interface {
 // 6 - Perform assigned role, if any
 func run(ctx context.Context, v Validator) {
 	defer v.Done()
-	v.WaitForChainStart(ctx)
+	if err := v.WaitForChainStart(ctx); err != nil {
+		log.Fatalf("Could not determine if beacon chain started: %v", err)
+	}
 	v.WaitForActivation(ctx)
 	if err := v.UpdateAssignments(ctx, params.BeaconConfig().GenesisSlot); err != nil {
 		log.WithField("error", err).Error("Failed to update assignments")

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -53,8 +53,7 @@ func (v *validator) WaitForChainStart(ctx context.Context) {
 	// First, check if the beacon chain has started.
 	stream, err := v.beaconClient.WaitForChainStart(ctx, &ptypes.Empty{})
 	if err != nil {
-		log.Errorf("Could not setup beacon chain ChainStart streaming client: %v", err)
-		return
+		log.Fatalf("Could not setup beacon chain ChainStart streaming client: %v", err)
 	}
 	for {
 		log.Info("Waiting for beacon chain start log from the ETH 1.0 deposit contract...")
@@ -65,12 +64,10 @@ func (v *validator) WaitForChainStart(ctx context.Context) {
 		}
 		// If context is canceled we stop the loop.
 		if ctx.Err() == context.Canceled {
-			log.Debugf("Context has been canceled so shutting down the loop: %v", ctx.Err())
-			break
+			log.Fatalf("Context has been canceled so shutting down the loop: %v", ctx.Err())
 		}
 		if err != nil {
-			log.Errorf("Could not receive ChainStart from stream: %v", err)
-			continue
+			log.Fatalf("Could not receive ChainStart from stream: %v", err)
 		}
 		v.genesisTime = chainStartRes.GenesisTime
 		break

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -3,6 +3,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -47,13 +48,13 @@ func (v *validator) Done() {
 // it calls to the beacon node which then verifies the ETH1.0 deposit contract logs to check
 // for the ChainStart log to have been emitted. If so, it starts a ticker based on the ChainStart
 // unix timestamp which will be used to keep track of time within the validator client.
-func (v *validator) WaitForChainStart(ctx context.Context) {
+func (v *validator) WaitForChainStart(ctx context.Context) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "validator.WaitForChainStart")
 	defer span.Finish()
 	// First, check if the beacon chain has started.
 	stream, err := v.beaconClient.WaitForChainStart(ctx, &ptypes.Empty{})
 	if err != nil {
-		log.Fatalf("Could not setup beacon chain ChainStart streaming client: %v", err)
+		return fmt.Errorf("could not setup beacon chain ChainStart streaming client: %v", err)
 	}
 	for {
 		log.Info("Waiting for beacon chain start log from the ETH 1.0 deposit contract...")
@@ -64,10 +65,10 @@ func (v *validator) WaitForChainStart(ctx context.Context) {
 		}
 		// If context is canceled we stop the loop.
 		if ctx.Err() == context.Canceled {
-			log.Fatalf("Context has been canceled so shutting down the loop: %v", ctx.Err())
+			return fmt.Errorf("context has been canceled so shutting down the loop: %v", ctx.Err())
 		}
 		if err != nil {
-			log.Fatalf("Could not receive ChainStart from stream: %v", err)
+			return fmt.Errorf("could not receive ChainStart from stream: %v", err)
 		}
 		v.genesisTime = chainStartRes.GenesisTime
 		break
@@ -76,6 +77,7 @@ func (v *validator) WaitForChainStart(ctx context.Context) {
 	// Once the ChainStart log is received, we update the genesis time of the validator client
 	// and begin a slot ticker used to track the current slot the beacon node is in.
 	v.ticker = slotutil.GetSlotTicker(time.Unix(int64(v.genesisTime), 0), params.BeaconConfig().SecondsPerSlot)
+	return nil
 }
 
 // WaitForActivation checks whether the validator pubkey is in the active

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -3,12 +3,11 @@ package client
 import (
 	"context"
 	"errors"
-	"io"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/sirupsen/logrus"
 
 	ptypes "github.com/gogo/protobuf/types"
@@ -17,7 +16,6 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/validator/internal"
-	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func init() {
@@ -49,7 +47,9 @@ func TestWaitForChainStart_SetsChainStartGenesisTime(t *testing.T) {
 		},
 		nil,
 	)
-	v.WaitForChainStart(context.Background())
+	if err := v.WaitForChainStart(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	if v.genesisTime != genesis {
 		t.Errorf("Expected chain start time to equal %d, received %d", genesis, v.genesisTime)
 	}
@@ -59,7 +59,6 @@ func TestWaitForChainStart_SetsChainStartGenesisTime(t *testing.T) {
 }
 
 func TestWaitForChainStart_ContextCanceled(t *testing.T) {
-	hook := logTest.NewGlobal()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := internal.NewMockBeaconServiceClient(ctrl)
@@ -83,12 +82,14 @@ func TestWaitForChainStart_ContextCanceled(t *testing.T) {
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	v.WaitForChainStart(ctx)
-	testutil.AssertLogsContain(t, hook, "Context has been canceled")
+	err := v.WaitForChainStart(ctx)
+	want := "context has been canceled"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("Expected %v, received %v", want, err)
+	}
 }
 
 func TestWaitForChainStart_StreamSetupFails(t *testing.T) {
-	hook := logTest.NewGlobal()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := internal.NewMockBeaconServiceClient(ctrl)
@@ -102,12 +103,14 @@ func TestWaitForChainStart_StreamSetupFails(t *testing.T) {
 		gomock.Any(),
 		&ptypes.Empty{},
 	).Return(clientStream, errors.New("failed stream"))
-	v.WaitForChainStart(context.Background())
-	testutil.AssertLogsContain(t, hook, "Could not setup beacon chain ChainStart streaming client")
+	err := v.WaitForChainStart(context.Background())
+	want := "could not setup beacon chain ChainStart streaming client"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("Expected %v, received %v", want, err)
+	}
 }
 
 func TestWaitForChainStart_ReceiveErrorFromStream(t *testing.T) {
-	hook := logTest.NewGlobal()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := internal.NewMockBeaconServiceClient(ctrl)
@@ -116,7 +119,6 @@ func TestWaitForChainStart_ReceiveErrorFromStream(t *testing.T) {
 		key:          validatorKey,
 		beaconClient: client,
 	}
-	genesis := uint64(time.Unix(0, 0).Unix())
 	clientStream := internal.NewMockBeaconService_WaitForChainStartClient(ctrl)
 	client.EXPECT().WaitForChainStart(
 		gomock.Any(),
@@ -126,15 +128,11 @@ func TestWaitForChainStart_ReceiveErrorFromStream(t *testing.T) {
 		nil,
 		errors.New("fails"),
 	)
-	clientStream.EXPECT().Recv().Return(
-		&pb.ChainStartResponse{
-			Started:     true,
-			GenesisTime: genesis,
-		},
-		io.EOF,
-	)
-	v.WaitForChainStart(context.Background())
-	testutil.AssertLogsContain(t, hook, "Could not receive ChainStart from stream")
+	err := v.WaitForChainStart(context.Background())
+	want := "could not receive ChainStart from stream"
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("Expected %v, received %v", want, err)
+	}
 }
 
 func TestUpdateAssignments_DoesNothingWhenNotEpochStartAndAlreadyExistingAssignments(t *testing.T) {


### PR DESCRIPTION
Currently, if our beacon node shuts down while validators are connected to it and waiting for chainstart to occur, they will believe chainstart was time.Unix(0, 0) and begin performing their responsibilities. This is due to not properly handling the errors on both the beacon node and validator rpc server and client. Additionally, if --chain-start-delay was on in the beacon node, a validator client would panic as it would request epoch assignments even though the chain has technically not started due to the flag. This PR fixes these two bugs.