### PR TITLE
Avoid Logging Large Slot Numbers

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -286,7 +286,8 @@ func (c *ChainService) ReceiveBlock(block *pb.BeaconBlock, beaconState *pb.Beaco
 	}
 
 	if block.Slot == params.BeaconConfig().GenesisSlot {
-		return nil, fmt.Errorf("cannot process a genesis block: received block with slot %d", params.BeaconConfig().GenesisSlot)
+		return nil, fmt.Errorf("cannot process a genesis block: received block with slot %d",
+			block.Slot - params.BeaconConfig().GenesisSlot)
 	}
 
 	// Save blocks with higher slot numbers in cache.
@@ -300,7 +301,8 @@ func (c *ChainService) ReceiveBlock(block *pb.BeaconBlock, beaconState *pb.Beaco
 		return nil, fmt.Errorf("could not retrieve chain head root: %v", err)
 	}
 
-	log.WithField("slotNumber", block.Slot).Info("Executing state transition")
+	log.WithField("slotNumber", block.Slot - params.BeaconConfig().GenesisSlot).Info(
+		"Executing state transition")
 
 	// Check for skipped slots and update the corresponding proposers
 	// randao layer.

--- a/beacon-chain/core/balances/rewards_penalties.go
+++ b/beacon-chain/core/balances/rewards_penalties.go
@@ -347,7 +347,8 @@ func Crosslinks(
 	for i := startSlot; i < endSlot; i++ {
 		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, false)
 		if err != nil {
-			return nil, fmt.Errorf("could not get shard committees for slot %d: %v", i, err)
+			return nil, fmt.Errorf("could not get shard committees for slot %d: %v",
+				i - params.BeaconConfig().GenesisSlot, err)
 		}
 		for _, crosslinkCommittee := range crosslinkCommittees {
 			shard := crosslinkCommittee.Shard

--- a/beacon-chain/core/blocks/block.go
+++ b/beacon-chain/core/blocks/block.go
@@ -53,10 +53,13 @@ func BlockRoot(state *pb.BeaconState, slot uint64) ([]byte, error) {
 	earliestSlot := state.Slot - params.BeaconConfig().LatestBlockRootsLength
 
 	if slot < earliestSlot || slot >= state.Slot {
+		if earliestSlot < params.BeaconConfig().GenesisSlot {
+			earliestSlot = 0
+		}
 		return []byte{}, fmt.Errorf("slot %d is not within expected range of %d to %d",
-			slot,
-			earliestSlot,
-			state.Slot,
+			slot - params.BeaconConfig().GenesisSlot,
+			earliestSlot - params.BeaconConfig().GenesisSlot,
+			state.Slot - params.BeaconConfig().GenesisSlot,
 		)
 	}
 

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -187,7 +187,8 @@ func verifyProposerSlashing(
 	root1 := slashing.ProposalData_1.BlockRootHash32
 	root2 := slashing.ProposalData_2.BlockRootHash32
 	if slot1 != slot2 {
-		return fmt.Errorf("slashing proposal data slots do not match: %d, %d", slot1, slot2)
+		return fmt.Errorf("slashing proposal data slots do not match: %d, %d",
+			slot1 - params.BeaconConfig().GenesisSlot, slot2  - params.BeaconConfig().GenesisSlot )
 	}
 	if shard1 != shard2 {
 		return fmt.Errorf("slashing proposal data shards do not match: %d, %d", shard1, shard2)

--- a/beacon-chain/core/blocks/validity_conditions.go
+++ b/beacon-chain/core/blocks/validity_conditions.go
@@ -59,7 +59,7 @@ func IsValidBlock(
 	// The node's local time is greater than or equal to
 	// state.genesis_time + (block.slot-GENESIS_SLOT)* SECONDS_PER_SLOT.
 	if !IsSlotValid(block.Slot, genesisTime) {
-		return fmt.Errorf("slot of block is too high: %d", block.Slot)
+		return fmt.Errorf("slot of block is too high: %d", block.Slot - params.BeaconConfig().GenesisSlot)
 	}
 
 	return nil

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -177,7 +177,7 @@ func ProcessCrosslinks(
 	for i := startSlot; i < endSlot; i++ {
 		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, false)
 		if err != nil {
-			return nil, fmt.Errorf("could not get committees for slot %d: %v", i, err)
+			return nil, fmt.Errorf("could not get committees for slot %d: %v", i - params.BeaconConfig().GenesisSlot, err)
 		}
 		for _, crosslinkCommittee := range crosslinkCommittees {
 			shard := crosslinkCommittee.Shard

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -73,7 +73,8 @@ func BeaconProposerIndex(state *pb.BeaconState, slot uint64) (uint64, error) {
 	firstCommittee := committeeArray[0].Committee
 
 	if len(firstCommittee) == 0 {
-		return 0, fmt.Errorf("empty first committee at slot %d", slot)
+		return 0, fmt.Errorf("empty first committee at slot %d",
+			slot - params.BeaconConfig().GenesisSlot)
 	}
 
 	return firstCommittee[slot%uint64(len(firstCommittee))], nil

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -69,7 +69,7 @@ func ExecuteStateTransition(
 func ProcessSlot(state *pb.BeaconState, headRoot [32]byte) *pb.BeaconState {
 	state.Slot++
 	state = b.ProcessBlockRoots(state, headRoot)
-	log.Info("Slot transition successfully processed slot %d", state.Slot)
+	log.Infof("Slot transition successfully processed slot %d", state.Slot)
 	return state
 }
 
@@ -116,7 +116,7 @@ func ProcessBlock(state *pb.BeaconState, block *pb.BeaconBlock, verifySignatures
 	if err != nil {
 		return nil, fmt.Errorf("could not process validator exits: %v", err)
 	}
-	log.Info("Block transition successfully processed slot %d", state.Slot)
+	log.Infof("Block transition successfully processed slot %d", state.Slot)
 	return state, nil
 }
 
@@ -346,6 +346,6 @@ func ProcessEpoch(state *pb.BeaconState) (*pb.BeaconState, error) {
 
 	// Clean up processed attestations.
 	state = e.CleanupAttestations(state)
-	log.Info("Epoch transition successfully processed slot %d", state.Slot)
+	log.Infof("Epoch transition successfully processed slot %d", state.Slot)
 	return state, nil
 }

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -510,9 +510,9 @@ func TestProcessEpoch_CantGetBoundaryAttestation(t *testing.T) {
 
 	want := fmt.Sprintf(
 		"could not get current boundary attestations: slot %d is not within expected range of %d to %d",
-		newState.Slot,
+		newState.Slot - params.BeaconConfig().GenesisSlot,
 		newState.Slot-params.BeaconConfig().LatestBlockRootsLength,
-		newState.Slot,
+		newState.Slot - params.BeaconConfig().GenesisSlot,
 	)
 	if _, err := state.ProcessEpoch(newState); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected: %s, received: %v", want, err)

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -101,7 +101,7 @@ func (vs *ValidatorServer) ValidatorCommitteeAtSlot(ctx context.Context, req *pb
 	}
 	crossLinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(beaconState, req.Slot, false /* registry change */)
 	if err != nil {
-		return nil, fmt.Errorf("could not get crosslink committees at slot %d: %v", req.Slot, err)
+		return nil, fmt.Errorf("could not get crosslink committees at slot %d: %v", req.Slot - params.BeaconConfig().GenesisSlot, err)
 	}
 	var committee []uint64
 	var shard uint64

--- a/beacon-chain/sync/regular_sync.go
+++ b/beacon-chain/sync/regular_sync.go
@@ -281,7 +281,8 @@ func (rs *RegularSync) handleBlockRequestBySlot(msg p2p.Message) {
 	}
 
 	_, sendBlockSpan := trace.StartSpan(ctx, "sendBlock")
-	log.WithField("slotNumber", fmt.Sprintf("%d", request.SlotNumber)).Debug("Sending requested block to peer")
+	log.WithField("slotNumber",
+		fmt.Sprintf("%d", request.SlotNumber - params.BeaconConfig().GenesisSlot)).Debug("Sending requested block to peer")
 	rs.p2p.Send(&pb.BeaconBlockResponse{
 		Block: block,
 	}, msg.Peer)

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -6,10 +6,8 @@ import (
 	"time"
 
 	"github.com/prysmaticlabs/prysm/shared/params"
-
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
-
 	"github.com/opentracing/opentracing-go"
 )
 
@@ -44,7 +42,8 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64) {
 	}
 	resp, err := v.validatorClient.ValidatorCommitteeAtSlot(ctx, req)
 	if err != nil {
-		log.Errorf("Could not fetch crosslink committees at slot %d: %v", slot, err)
+		log.Errorf("Could not fetch crosslink committees at slot %d: %v",
+			slot - params.BeaconConfig().GenesisSlot, err)
 		return
 	}
 	// Set the attestation data's shard as the shard associated with the validator's
@@ -58,7 +57,8 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64) {
 	}
 	infoRes, err := v.attesterClient.AttestationInfoAtSlot(ctx, infoReq)
 	if err != nil {
-		log.Errorf("Could not fetch necessary info to produce attestation at slot %d: %v", slot, err)
+		log.Errorf("Could not fetch necessary info to produce attestation at slot %d: %v",
+			slot - params.BeaconConfig().GenesisSlot, err)
 		return
 	}
 	// Set the attestation data's beacon block root = hash_tree_root(head) where head


### PR DESCRIPTION
Not done. Still fixing tests.

Avoid logging these large slot numbers. 
For debug/info logs,  it's always going to be `slot_number - genesis_slot`