### PR TITLE
Deprecate Old Configuration Flags

### DIFF
--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -12,34 +12,11 @@ var (
 		Usage: "Logging verbosity (debug, info=default, warn, error, fatal, panic)",
 		Value: "info",
 	}
-	// IPCPathFlag defines the filename of a pipe within the datadir.
-	IPCPathFlag = DirectoryFlag{
-		Name:  "ipcpath",
-		Usage: "Filename for IPC socket/pipe within the datadir (explicit paths escape it)",
-	}
 	// DataDirFlag defines a path on disk.
 	DataDirFlag = DirectoryFlag{
 		Name:  "datadir",
 		Usage: "Data directory for the databases and keystore",
 		Value: DirectoryString{DefaultDataDir()},
-	}
-	// NetworkIDFlag defines the specific network identifier.
-	NetworkIDFlag = cli.Uint64Flag{
-		Name:  "networkid",
-		Usage: "Network identifier (integer, 1=Frontier, 2=Morden (disused), 3=Ropsten, 4=Rinkeby)",
-		Value: 1,
-	}
-	// PasswordFileFlag defines the path to the user's account password file.
-	PasswordFileFlag = cli.StringFlag{
-		Name:  "password",
-		Usage: "Password file to use for non-interactive password input",
-		Value: "",
-	}
-	// RPCProviderFlag defines a http endpoint flag to connect to mainchain.
-	RPCProviderFlag = cli.StringFlag{
-		Name:  "rpc",
-		Usage: "HTTP-RPC server end point to use to connect to mainchain.",
-		Value: "http://localhost:8545/",
 	}
 	// EnableTracingFlag defines a flag to enable p2p message tracing.
 	EnableTracingFlag = cli.BoolFlag{
@@ -70,24 +47,17 @@ var (
 		Usage: "Port used to listening and respond metrics for prometheus.",
 		Value: 8080,
 	}
-	// KeystorePasswordFlag defines the password that will unlock the keystore file.
-	KeystorePasswordFlag = cli.StringFlag{
-		Name:  "keystore-password",
-		Usage: "Keystore password is used to unlock the keystore so that the users decrypted keys can be used.",
-	}
 	// BootstrapNode tells the beacon node which bootstrap node to connect to
 	BootstrapNode = cli.StringFlag{
 		Name:  "bootstrap-node",
 		Usage: "The address of bootstrap node. Beacon node will connect for peer discovery via DHT",
 	}
-
 	// RelayNode tells the beacon node which relay node to connect to.
 	RelayNode = cli.StringFlag{
 		Name: "relay-node",
 		Usage: "The address of relay node. The beacon node will connect to the " +
 			"relay node and advertise their address via the relay node to other peers",
 	}
-
 	// P2PPort defines the port to be used by libp2p.
 	P2PPort = cli.IntFlag{
 		Name:  "p2p-port",

--- a/validator/main.go
+++ b/validator/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -21,12 +20,7 @@ import (
 
 func startNode(ctx *cli.Context) error {
 	keystoreDirectory := ctx.String(types.KeystorePathFlag.Name)
-	keystorePasswordPath := ctx.String(types.PasswordPathFlag.Name)
-	content, err := ioutil.ReadFile(keystorePasswordPath)
-	if err != nil {
-        return fmt.Errorf("couldn not read password file: %v", err)
-	}
-	keystorePassword := string(content)
+	keystorePassword := ctx.String(types.PasswordFlag.Name)
 	if err := accounts.VerifyAccountNotExists(keystoreDirectory, keystorePassword); err == nil {
 		return errors.New("no account found, use `validator accounts create` to generate a new keystore")
 	}
@@ -49,12 +43,7 @@ func startNode(ctx *cli.Context) error {
 
 func createValidatorAccount(ctx *cli.Context) error {
 	keystoreDirectory := ctx.String(types.KeystorePathFlag.Name)
-	keystorePasswordPath := ctx.String(types.PasswordPathFlag.Name)
-	content, err := ioutil.ReadFile(keystorePasswordPath)
-	if err != nil {
-		return fmt.Errorf("couldn not read password file: %v", err)
-	}
-	keystorePassword := string(content)
+	keystorePassword := ctx.String(types.PasswordFlag.Name)
 	if err := accounts.NewValidatorAccount(keystoreDirectory, keystorePassword); err != nil {
 		return fmt.Errorf("could not initialize validator account: %v", err)
 	}

--- a/validator/main.go
+++ b/validator/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -20,7 +21,12 @@ import (
 
 func startNode(ctx *cli.Context) error {
 	keystoreDirectory := ctx.String(types.KeystorePathFlag.Name)
-	keystorePassword := ctx.String(types.PasswordFlag.Name)
+	keystorePasswordPath := ctx.String(types.PasswordPathFlag.Name)
+	content, err := ioutil.ReadFile(keystorePasswordPath)
+	if err != nil {
+        return fmt.Errorf("couldn not read password file: %v", err)
+	}
+	keystorePassword := string(content)
 	if err := accounts.VerifyAccountNotExists(keystoreDirectory, keystorePassword); err == nil {
 		return errors.New("no account found, use `validator accounts create` to generate a new keystore")
 	}
@@ -43,7 +49,12 @@ func startNode(ctx *cli.Context) error {
 
 func createValidatorAccount(ctx *cli.Context) error {
 	keystoreDirectory := ctx.String(types.KeystorePathFlag.Name)
-	keystorePassword := ctx.String(types.PasswordFlag.Name)
+	keystorePasswordPath := ctx.String(types.PasswordPathFlag.Name)
+	content, err := ioutil.ReadFile(keystorePasswordPath)
+	if err != nil {
+		return fmt.Errorf("couldn not read password file: %v", err)
+	}
+	keystorePassword := string(content)
 	if err := accounts.NewValidatorAccount(keystoreDirectory, keystorePassword); err != nil {
 		return fmt.Errorf("could not initialize validator account: %v", err)
 	}
@@ -96,7 +107,7 @@ this command outputs a deposit data string which can be used to deposit Ether in
 contract in order to activate the validator client`,
 					Flags: []cli.Flag{
 						types.KeystorePathFlag,
-						types.PasswordFlag,
+						types.PasswordPathFlag,
 					},
 					Action: createValidatorAccount,
 				},
@@ -107,13 +118,12 @@ contract in order to activate the validator client`,
 	app.Flags = []cli.Flag{
 		types.BeaconRPCProviderFlag,
 		types.KeystorePathFlag,
-		types.PasswordFlag,
+		types.PasswordPathFlag,
 		cmd.VerbosityFlag,
 		cmd.DataDirFlag,
 		cmd.EnableTracingFlag,
 		cmd.TracingEndpointFlag,
 		cmd.TraceSampleFractionFlag,
-		cmd.KeystorePasswordFlag,
 		cmd.BootstrapNode,
 		cmd.MonitoringPortFlag,
 		debug.PProfFlag,

--- a/validator/main.go
+++ b/validator/main.go
@@ -96,7 +96,7 @@ this command outputs a deposit data string which can be used to deposit Ether in
 contract in order to activate the validator client`,
 					Flags: []cli.Flag{
 						types.KeystorePathFlag,
-						types.PasswordPathFlag,
+						types.PasswordFlag,
 					},
 					Action: createValidatorAccount,
 				},
@@ -107,7 +107,7 @@ contract in order to activate the validator client`,
 	app.Flags = []cli.Flag{
 		types.BeaconRPCProviderFlag,
 		types.KeystorePathFlag,
-		types.PasswordPathFlag,
+		types.PasswordFlag,
 		cmd.VerbosityFlag,
 		cmd.DataDirFlag,
 		cmd.EnableTracingFlag,

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -5,6 +5,7 @@ package node
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"sync"
@@ -111,7 +112,12 @@ func (s *ValidatorClient) registerPrometheusService(ctx *cli.Context) error {
 func (s *ValidatorClient) registerClientService(ctx *cli.Context) error {
 	endpoint := ctx.GlobalString(types.BeaconRPCProviderFlag.Name)
 	keystoreDirectory := ctx.GlobalString(types.KeystorePathFlag.Name)
-	keystorePassword := ctx.GlobalString(types.PasswordFlag.Name)
+	keystorePasswordPath := ctx.String(types.PasswordPathFlag.Name)
+	content, err := ioutil.ReadFile(keystorePasswordPath)
+	if err != nil {
+		return fmt.Errorf("couldn not read password file: %v", err)
+	}
+	keystorePassword := string(content)
 	v, err := client.NewValidatorService(context.TODO(), &client.Config{
 		Endpoint:     endpoint,
 		KeystorePath: keystoreDirectory,

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -5,7 +5,6 @@ package node
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"sync"
@@ -112,12 +111,7 @@ func (s *ValidatorClient) registerPrometheusService(ctx *cli.Context) error {
 func (s *ValidatorClient) registerClientService(ctx *cli.Context) error {
 	endpoint := ctx.GlobalString(types.BeaconRPCProviderFlag.Name)
 	keystoreDirectory := ctx.GlobalString(types.KeystorePathFlag.Name)
-	keystorePasswordPath := ctx.String(types.PasswordPathFlag.Name)
-	content, err := ioutil.ReadFile(keystorePasswordPath)
-	if err != nil {
-		return fmt.Errorf("couldn not read password file: %v", err)
-	}
-	keystorePassword := string(content)
+	keystorePassword := ctx.String(types.PasswordFlag.Name)
 	v, err := client.NewValidatorService(context.TODO(), &client.Config{
 		Endpoint:     endpoint,
 		KeystorePath: keystoreDirectory,

--- a/validator/types/flags.go
+++ b/validator/types/flags.go
@@ -21,9 +21,9 @@ var (
 		Name:  "keystore-path",
 		Usage: "path to the desired keystore directory",
 	}
-	// PasswordPathFlag defines the password for storing and retrieving validator private keys from the keystore.
-	PasswordPathFlag = cli.StringFlag{
-		Name:  "password-path",
-		Usage: "path to the password to your validator private keys",
+	// PasswordFlag defines the password value for storing and retrieving validator private keys from the keystore.
+	PasswordFlag = cli.StringFlag{
+		Name:  "password",
+		Usage: "string value of the password for your validator private keys",
 	}
 )

--- a/validator/types/flags.go
+++ b/validator/types/flags.go
@@ -21,9 +21,9 @@ var (
 		Name:  "keystore-path",
 		Usage: "path to the desired keystore directory",
 	}
-	// PasswordFlag defines the password for storing and retrieving validator private keys from the keystore.
-	PasswordFlag = cli.StringFlag{
-		Name:  "password",
-		Usage: "password to your validator private keys",
+	// PasswordPathFlag defines the password for storing and retrieving validator private keys from the keystore.
+	PasswordPathFlag = cli.StringFlag{
+		Name:  "password-path",
+		Usage: "path to the password to your validator private keys",
 	}
 )


### PR DESCRIPTION
This PR removes ambiguous or old flags used from previous iterations of our binaries and favors keeping a `--password` flag which allows the user to supply the string value of a password directly when running a validator client.
