### PR TITLE
Add example encoding for godoc ssz

### DIFF
--- a/shared/ssz/BUILD.bazel
+++ b/shared/ssz/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "decode_test.go",
         "encode_test.go",
         "example_and_test.go",
+        "example_encode_test.go",
         "hash_test.go",
     ],
     embed = [":go_default_library"],

--- a/shared/ssz/example_encode_test.go
+++ b/shared/ssz/example_encode_test.go
@@ -7,23 +7,30 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/ssz"
 )
 
+// SSZ encoding takes a given data object to the given io.Writer. The most
+// common use case is to use bytes.Buffer to collect the results to a buffer
+// and consume the result.
 func ExampleEncode() {
+	// Given a data structure like this.
 	type data struct {
 		Field1 uint8
 		Field2 []byte
 	}
 
+	// And some basic data.
 	d := data{
 		Field1: 10,
 		Field2: []byte{1, 2, 3, 4},
 	}
 
+	// We use a bytes.Buffer as our io.Writer.
 	buffer := new(bytes.Buffer)
+	// ssz.Encode writes the encoded data to the buffer.
 	if err := ssz.Encode(buffer, d); err != nil {
 		// There was some failure with encoding SSZ.
 		panic(err)
 	}
+	// And we can return the bytes from the buffer.
 	encodedBytes := buffer.Bytes()
-
 	fmt.Printf("ssz.Encode(%v) = %#x", d, encodedBytes)
 }

--- a/shared/ssz/example_encode_test.go
+++ b/shared/ssz/example_encode_test.go
@@ -1,0 +1,29 @@
+package ssz_test
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/prysmaticlabs/prysm/shared/ssz"
+)
+
+func ExampleEncode() {
+	type data struct {
+		Field1 uint8
+		Field2 []byte
+	}
+
+	d := data{
+		Field1: 10,
+		Field2: []byte{1, 2, 3, 4},
+	}
+
+	buffer := new(bytes.Buffer)
+	if err := ssz.Encode(buffer, d); err != nil {
+		// There was some failure with encoding SSZ.
+		panic(err)
+	}
+	encodedBytes := buffer.Bytes()
+
+	fmt.Printf("ssz.Encode(%v) = %#x", d, encodedBytes)
+}

--- a/shared/ssz/example_encode_test.go
+++ b/shared/ssz/example_encode_test.go
@@ -28,6 +28,7 @@ func ExampleEncode() {
 	// ssz.Encode writes the encoded data to the buffer.
 	if err := ssz.Encode(buffer, d); err != nil {
 		// There was some failure with encoding SSZ.
+		// You should probably handle this error in a non-fatal way.
 		panic(err)
 	}
 	// And we can return the bytes from the buffer.


### PR DESCRIPTION
I wasn't satisfied with the docs on how to ssz.Encode something so here's an example.