### PR TITLE
Add missing dep to the docker image

### DIFF
--- a/contracts/deposit-contract/deployContract/BUILD.bazel
+++ b/contracts/deposit-contract/deployContract/BUILD.bazel
@@ -42,6 +42,7 @@ go_image(
         "//shared/version:go_default_library",
         "@com_github_ethereum_go_ethereum//accounts/abi/bind:go_default_library",
         "@com_github_ethereum_go_ethereum//accounts/keystore:go_default_library",
+        "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//crypto:go_default_library",
         "@com_github_ethereum_go_ethereum//ethclient:go_default_library",
         "@com_github_ethereum_go_ethereum//rpc:go_default_library",


### PR DESCRIPTION
I've also added changes to buildkite to build the images as part of the presubmit so this shouldn't happen again. 