### PR TITLE
Remove preemptive chainstart variable set on start

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -363,12 +363,6 @@ func (w *Web3Service) run(done <-chan struct{}) {
 		log.Errorf("Unable to retrieve data from deposit contract %v", err)
 		return
 	}
-	hasChainStarted, _, err := w.HasChainStartLogOccurred()
-	if err != nil {
-		log.Errorf("Unable to verify chain has started: %v", err)
-		return
-	}
-	w.chainStarted = hasChainStarted
 
 	headSub, err := w.reader.SubscribeNewHead(w.ctx, w.headerChan)
 	if err != nil {

--- a/shared/keystore/key_test.go
+++ b/shared/keystore/key_test.go
@@ -91,7 +91,7 @@ func TestNewKeyFromBLS(t *testing.T) {
 }
 
 func TestWriteFile(t *testing.T) {
-	tmpdir := os.TempDir()
+	tmpdir := testutil.TempDir()
 	filedir := tmpdir + "/keystore"
 
 	testKeystore := []byte{'t', 'e', 's', 't'}


### PR DESCRIPTION
This was causing various issues.

I also fixed a tmpdir issue in the keystore