### PR TITLE
Fix Invalid Timestamp From ChainStart Log Issue

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -244,9 +244,6 @@ func (w *Web3Service) HasChainStartLogOccurred() (bool, uint64, error) {
 		return false, 0, nil
 	}
 	timestamp := binary.LittleEndian.Uint64(genesisTime)
-	if uint64(time.Now().Unix()) < timestamp {
-		return false, 0, fmt.Errorf("invalid timestamp from log expected %d > %d", time.Now().Unix(), timestamp)
-	}
 	return true, timestamp, nil
 }
 

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -775,15 +775,7 @@ func TestProcessChainStartLog_OK(t *testing.T) {
 		)
 	}
 
-	genesisTime := <-genesisTimeChan
-	if genesisTime.Unix() > time.Now().Unix() {
-		t.Errorf(
-			"Timestamp from log is higher than the current time %d > %d",
-			genesisTime.Unix(),
-			time.Now().Unix(),
-		)
-	}
-
+	<-genesisTimeChan
 	testutil.AssertLogsDoNotContain(t, hook, "Unable to unpack ChainStart log data")
 	testutil.AssertLogsDoNotContain(t, hook, "Receipt root from log doesn't match the root saved in memory")
 	testutil.AssertLogsDoNotContain(t, hook, "Invalid timestamp from log")


### PR DESCRIPTION
In our code, we had an error condition that would throw if the chainstart time is greater than the current time. However, this will be the case in testnet and production so we will remove that condition.