### PR TITLE
Use RegistryChanged Flag in CrosslinkCommitteesAtSlot Everywhere

### DIFF
--- a/beacon-chain/core/balances/rewards_penalties.go
+++ b/beacon-chain/core/balances/rewards_penalties.go
@@ -345,7 +345,12 @@ func Crosslinks(
 	endSlot := helpers.StartSlot(currentEpoch)
 
 	for i := startSlot; i < endSlot; i++ {
-		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, false)
+		var registryChange bool
+		if state.ValidatorRegistryUpdateEpoch == i-1 &&
+			state.ValidatorRegistryUpdateEpoch != params.BeaconConfig().GenesisEpoch {
+			registryChange = true
+		}
+		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, registryChange)
 		if err != nil {
 			return nil, fmt.Errorf("could not get shard committees for slot %d: %v",
 				i-params.BeaconConfig().GenesisSlot, err)

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -190,7 +190,12 @@ func ProcessCrosslinks(
 	endSlot := helpers.StartSlot(nextEpoch)
 
 	for i := startSlot; i < endSlot; i++ {
-		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, false)
+		var registryChange bool
+		if state.ValidatorRegistryUpdateEpoch == i-1 &&
+			state.ValidatorRegistryUpdateEpoch != params.BeaconConfig().GenesisEpoch {
+			registryChange = true
+		}
+		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, registryChange)
 		if err != nil {
 			return nil, fmt.Errorf("could not get committees for slot %d: %v", i-params.BeaconConfig().GenesisSlot, err)
 		}

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -339,7 +339,12 @@ func AttestationParticipants(
 	bitfield []byte) ([]uint64, error) {
 
 	// Find the relevant committee.
-	crosslinkCommittees, err := CrosslinkCommitteesAtSlot(state, attestationData.Slot, false)
+	var registryChanged bool
+	if state.ValidatorRegistryUpdateEpoch == SlotToEpoch(attestationData.Slot)-1 &&
+		state.ValidatorRegistryUpdateEpoch != params.BeaconConfig().GenesisEpoch {
+		registryChanged = true
+	}
+	crosslinkCommittees, err := CrosslinkCommitteesAtSlot(state, attestationData.Slot, registryChanged)
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -470,7 +470,6 @@ func (w *Web3Service) processPastLogs() error {
 // requestBatchedLogs requests and processes all the logs from the period
 // last polled to now.
 func (w *Web3Service) requestBatchedLogs() error {
-
 	// We request for the nth block behind the current head, in order to have
 	// stabilised logs when we retrieve it from the 1.0 chain.
 	requestedBlock := big.NewInt(0).Sub(w.blockHeight, big.NewInt(params.BeaconConfig().LogBlockDelay))


### PR DESCRIPTION
Previously, we weren't using the registryChange bool flag when calling `CrosslinkCommitteesAtSlot`, which could have caused failures at epoch boundaries. This PR addresses this bug.