### PR TITLE
Fix Validator Slashed Epoch Calculation

### DIFF
--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -227,7 +227,7 @@ func SlashValidator(state *pb.BeaconState, idx uint64) (*pb.BeaconState, error) 
 	state.ValidatorBalances[whistleblowerIdx] += whistleblowerReward
 	state.ValidatorBalances[idx] -= whistleblowerReward
 
-	state.ValidatorRegistry[idx].SlashedEpoch = helpers.CurrentEpoch(state)
+	state.ValidatorRegistry[idx].SlashedEpoch = helpers.CurrentEpoch(state) + params.BeaconConfig().LatestSlashedExitLength
 	return state, nil
 }
 


### PR DESCRIPTION
This is part of #1707

The validator's slashed epoch calculation was incorrect. We forgot to add `LatestSlashedExitLength` to it.

Reference: https://github.com/ethereum/eth2.0-specs/pull/656/files