### PR TITLE
Complain if contract address changes

### DIFF
--- a/beacon-chain/db/BUILD.bazel
+++ b/beacon-chain/db/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "setup_db.go",
         "state.go",
         "validator.go",
+        "verify_contract.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/db",
     visibility = ["//beacon-chain:__subpackages__"],
@@ -23,6 +24,7 @@ go_library(
         "//shared/bytesutil:go_default_library",
         "//shared/hashutil:go_default_library",
         "@com_github_boltdb_bolt//:go_default_library",
+        "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_opentracing_opentracing_go//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
@@ -42,6 +44,7 @@ go_test(
         "pending_deposits_test.go",
         "state_test.go",
         "validator_test.go",
+        "verify_contract_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
@@ -51,6 +54,7 @@ go_test(
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
+        "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],
 )

--- a/beacon-chain/db/verify_contract.go
+++ b/beacon-chain/db/verify_contract.go
@@ -12,6 +12,10 @@ import (
 
 var depositContractAddressKey = []byte("deposit-contract")
 
+// VerifyContractAddress that represents the data in this database. The
+// contract address is the address of the deposit contract on the proof of work
+// Ethereum chain. This value will never change or all of the data in the
+// database would be made invalid.
 func (db *BeaconDB) VerifyContractAddress(ctx context.Context, addr common.Address) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "BeaconDB.VerifyContractAddress")
 	defer span.Finish()

--- a/beacon-chain/db/verify_contract.go
+++ b/beacon-chain/db/verify_contract.go
@@ -1,0 +1,33 @@
+package db
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/boltdb/bolt"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/opentracing/opentracing-go"
+)
+
+var depositContractAddressKey = []byte("deposit-contract")
+
+func (db *BeaconDB) VerifyContractAddress(ctx context.Context, addr common.Address) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "BeaconDB.VerifyContractAddress")
+	defer span.Finish()
+
+	return db.update(func(tx *bolt.Tx) error {
+		chainInfo := tx.Bucket(chainInfoBucket)
+
+		expectedAddress := chainInfo.Get(depositContractAddressKey)
+		if expectedAddress == nil {
+			return chainInfo.Put(depositContractAddressKey, addr.Bytes())
+		}
+
+		if !bytes.Equal(expectedAddress, addr.Bytes()) {
+			return fmt.Errorf("invalid deposit contract address, expected %#x", expectedAddress)
+		}
+
+		return nil
+	})
+}

--- a/beacon-chain/db/verify_contract_test.go
+++ b/beacon-chain/db/verify_contract_test.go
@@ -1,0 +1,31 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestVerifyContractAddress(t *testing.T) {
+	db := setupDB(t)
+	defer teardownDB(t, db)
+
+	ctx := context.Background()
+
+	address := common.HexToAddress("0x0cd549b4abcbc0cb63012ea7de6fd34ebdccfd45")
+	// There should be no error the first time.
+	if err := db.VerifyContractAddress(ctx, address); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	// There should be no error the second time.
+	if err := db.VerifyContractAddress(ctx, address); err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	// But there should be an error with a different address.
+	otherAddr := common.HexToAddress("0x247b06d9890ab9b032ec318ca436aef262d0f08a")
+	if err := db.VerifyContractAddress(ctx, otherAddr); err == nil {
+		t.Fatal("Expected error, but didn't receive one")
+	}
+
+}


### PR DESCRIPTION
Forget to clear your datadir? No problem! Now you get a wonderful red error.

Example error:
```
[2019-02-26 12:23:08] ERROR main: invalid deposit contract address, expected 0x247b06d9890ab9b032ec318ca436aef262d0f08a
```