### PR TITLE
Implemented the flag grouping logic

### DIFF
--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -4,7 +4,10 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go", 
+        "usage.go",
+    ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
@@ -21,7 +24,10 @@ go_library(
 
 go_image(
     name = "image",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go",
+        "usage.go",
+    ],
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain",

--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -5,7 +5,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 go_library(
     name = "go_default_library",
     srcs = [
-        "main.go", 
+        "main.go",
         "usage.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain",

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -38,24 +38,6 @@ func main() {
 	logrus.SetFormatter(customFormatter)
 	log := logrus.WithField("prefix", "main")
 	app := cli.NewApp()
-	cli.AppHelpTemplate = `NAME:
-   {{.Name}} - {{.Usage}}
-USAGE:
-   {{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}
-   {{if len .Authors}}
-AUTHOR:
-   {{range .Authors}}{{ . }}{{end}}
-   {{end}}{{if .Commands}}
-GLOBAL OPTIONS:
-   {{range .VisibleFlags}}{{.}}
-   {{end}}{{end}}{{if .Copyright }}
-COPYRIGHT:
-   {{.Copyright}}
-   {{end}}{{if .Version}}
-VERSION:
-   {{.Version}}
-   {{end}}
-`
 	app.Name = "beacon-chain"
 	app.Usage = "this is a beacon chain implementation for Ethereum 2.0"
 	app.Action = startNode

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -1,0 +1,104 @@
+// This code was adapted from https://github.com/ethereum/go-ethereum/blob/master/cmd/geth/usage.go
+package main
+
+import (
+	"io"
+	"sort"
+	"github.com/urfave/cli"
+	"github.com/prysmaticlabs/prysm/beacon-chain/utils"
+	"github.com/prysmaticlabs/prysm/shared/cmd"
+	"github.com/prysmaticlabs/prysm/shared/debug"
+)
+
+var AppHelpTemplate = `NAME:
+   {{.App.Name}} - {{.App.Usage}}
+USAGE:
+   {{.App.HelpName}} [options]{{if .App.Commands}} command [command options]{{end}} {{if .App.ArgsUsage}}{{.App.ArgsUsage}}{{else}}[arguments...]{{end}}
+   {{if .App.Version}}
+AUTHOR:
+   {{range .App.Authors}}{{ . }}{{end}}
+   {{end}}{{if .App.Commands}}
+GLOBAL OPTIONS:
+   {{range .App.Commands}}{{join .Names ", "}}{{ "\t" }}{{.Usage}}
+   {{end}}{{end}}{{if .FlagGroups}}
+{{range .FlagGroups}}{{.Name}} OPTIONS:
+  {{range .Flags}}{{.}}
+  {{end}}
+{{end}}{{end}}{{if .App.Copyright }}
+COPYRIGHT:
+   {{.App.Copyright}}
+VERSION:
+   {{.App.Version}}
+   {{end}}{{if len .App.Authors}}
+   {{end}}
+`
+
+type flagGroup struct {
+	Name string
+	Flags []cli.Flag
+}
+
+var AppHelpFlagGroups = []flagGroup {
+	{
+		Name: "cmd",
+			Flags: []cli.Flag {
+				cmd.BootstrapNode,
+				cmd.RelayNode,
+				cmd.P2PPort,
+				cmd.DataDirFlag,
+				cmd.VerbosityFlag,
+				cmd.EnableTracingFlag,
+				cmd.TracingEndpointFlag,
+				cmd.TraceSampleFractionFlag,
+				cmd.MonitoringPortFlag,
+				cmd.DisableMonitoringFlag,
+			},
+		},
+	{
+		Name: "debug",
+		Flags: []cli.Flag {
+			debug.PProfFlag,
+			debug.PProfAddrFlag,
+			debug.PProfPortFlag,
+			debug.MemProfileRateFlag,
+			debug.CPUProfileFlag,
+			debug.TraceFlag,
+		},
+	},
+	{
+		Name: "utils",
+		Flags: []cli.Flag {
+			utils.DemoConfigFlag,
+			utils.DepositContractFlag,
+			utils.Web3ProviderFlag,
+			utils.RPCPort,
+			utils.CertFlag,
+			utils.KeyFlag,
+			utils.GenesisJSON,
+			utils.EnablePOWChain,
+			utils.EnableDBCleanup,
+			utils.ChainStartDelay,
+		},
+	},
+}
+
+func init() {
+	cli.AppHelpTemplate = AppHelpTemplate
+
+	type helpData struct {
+		App        interface{} 
+		FlagGroups []flagGroup
+	}
+
+	originalHelpPrinter := cli.HelpPrinter
+	cli.HelpPrinter = func(w io.Writer, tmpl string, data interface{}) {
+		if (tmpl == AppHelpTemplate) {
+			for _, group := range AppHelpFlagGroups {
+				sort.Sort(cli.FlagsByName(group.Flags))
+			}
+			originalHelpPrinter(w, tmpl, helpData{data, AppHelpFlagGroups})
+		} else {
+			originalHelpPrinter(w, tmpl, data)
+		}
+	}
+}

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -5,7 +5,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 go_library(
     name = "go_default_library",
     srcs = [
-        "main.go", 
+        "main.go",
         "usage.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/validator",

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -4,7 +4,10 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go", 
+        "usage.go",
+    ],
     importpath = "github.com/prysmaticlabs/prysm/validator",
     visibility = ["//validator:__subpackages__"],
     deps = [
@@ -22,7 +25,10 @@ go_library(
 
 go_image(
     name = "image",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go",
+        "usage.go",
+    ],
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/validator",

--- a/validator/main.go
+++ b/validator/main.go
@@ -55,33 +55,12 @@ func main() {
 	customFormatter.FullTimestamp = true
 	logrus.SetFormatter(customFormatter)
 	log := logrus.WithField("prefix", "main")
-
-	cli.AppHelpTemplate = `NAME:
-   {{.Name}} - {{.Usage}}
-USAGE:
-   {{.HelpName}} {{if .VisibleFlags}}[global options]{{end}}
-   {{if len .Authors}}
-AUTHOR:
-   {{range .Authors}}{{ . }}{{end}}
-   {{end}}{{if .Commands}}
-GLOBAL OPTIONS:
-   {{range .VisibleFlags}}{{.}}
-   {{end}}{{end}}{{if .Copyright }}
-COPYRIGHT:
-   {{.Copyright}}
-   {{end}}{{if .Version}}
-VERSION:
-   {{.Version}}
-   {{end}}
-`
-
 	app := cli.NewApp()
 	app.Name = "validator"
 	app.Usage = `launches an Ethereum Serenity validator client that interacts with a beacon chain, 
 				 starts proposer services, shardp2p connections, and more`
 	app.Version = version.GetVersion()
 	app.Action = startNode
-
 	app.Commands = []cli.Command{
 		{
 			Name:     "accounts",
@@ -102,7 +81,6 @@ contract in order to activate the validator client`,
 			},
 		},
 	}
-
 	app.Flags = []cli.Flag{
 		types.DemoConfigFlag,
 		types.BeaconRPCProviderFlag,

--- a/validator/usage.go
+++ b/validator/usage.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"sort"
 
-	"github.com/prysmaticlabs/prysm/beacon-chain/utils"
 	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/debug"
+	"github.com/prysmaticlabs/prysm/validator/types"
 	"github.com/urfave/cli"
 )
 
@@ -43,16 +43,13 @@ var appHelpFlagGroups = []flagGroup{
 	{
 		Name: "cmd",
 		Flags: []cli.Flag{
-			cmd.BootstrapNode,
-			cmd.RelayNode,
-			cmd.P2PPort,
-			cmd.DataDirFlag,
 			cmd.VerbosityFlag,
+			cmd.DataDirFlag,
 			cmd.EnableTracingFlag,
 			cmd.TracingEndpointFlag,
 			cmd.TraceSampleFractionFlag,
+			cmd.BootstrapNode,
 			cmd.MonitoringPortFlag,
-			cmd.DisableMonitoringFlag,
 		},
 	},
 	{
@@ -67,18 +64,12 @@ var appHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
-		Name: "utils",
+		Name: "types",
 		Flags: []cli.Flag{
-			utils.DemoConfigFlag,
-			utils.DepositContractFlag,
-			utils.Web3ProviderFlag,
-			utils.RPCPort,
-			utils.CertFlag,
-			utils.KeyFlag,
-			utils.GenesisJSON,
-			utils.EnablePOWChain,
-			utils.EnableDBCleanup,
-			utils.ChainStartDelay,
+			types.DemoConfigFlag,
+			types.BeaconRPCProviderFlag,
+			types.KeystorePathFlag,
+			types.PasswordFlag,
 		},
 	},
 }


### PR DESCRIPTION
Resolves #1595 

---

# Description

These changes are being made so that (1) the flags are grouped in a different file and grouped into distinct groups with sorted elements in each group, (2) the main file doesn't implement redundant logic, and (3) the project builds. 

The changes I made consisted of changing the usage template so that it would use flag groups rather than printing all of the global options. The `cli.HelpPrinter` value was overwritten so that this custom template would be rendered correctly and within this overwritten `HelpPrinter` function I sort the flags in a particular group. Additionally, I removed the old template from the **main.go** file and updated the **beacon-chain** directory so that the project would build properly. 

The **usage.go** file that I created is based off of geth's [usage file](https://github.com/ethereum/go-ethereum/blob/master/cmd/geth/usage.go)