### PR TITLE
Add Cache For ETH1 Block Information

### DIFF
--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_client_go//tools/cache:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
     ],
 )
@@ -35,6 +36,7 @@ go_test(
         "//contracts/deposit-contract:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/params:go_default_library",
         "//shared/ssz:go_default_library",
         "//shared/testutil:go_default_library",
         "//shared/trieutil:go_default_library",

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -1032,6 +1032,11 @@ func TestBlockCache_OK(t *testing.T) {
 
 	web3Service.addToCache(blk)
 
+	exists, _ = web3Service.checkCache(blk.Hash())
+	if !exists {
+		t.Fatalf("Block with hash %#x doesn't exist in cache", blk.Hash())
+	}
+
 	exists, info2 := web3Service.checkCache(blk.Number().Uint64())
 	if !exists {
 		t.Fatalf("Block with number %d doesn't exist in cache", blk.Number().Uint64())


### PR DESCRIPTION
Part of #1753 

---
# Description

**Write why you are making the changes in this pull request.**

Adding a block cache to the POW chain service. This is so as to reduce unecessary calls
to the ETH 1.0 chain to get the relevant block information.

**Write a summary of the changes you are making.**

- [x] The PR implements a  hash map, which will map both the block hash and block number to a 
shared `blockInfo` struct that will save relevant information about the block in it. 
- [x] Added new methods for the cache. Using that we can save any information that we already have retrieved from the main chain. Also this allows us to add new fields to the struct in the future, if we want to cache any other relevant information. 
- [x] Relevant tests also have been added
