### PR TITLE
Remove Next Epoch Registry Change Checks

### DIFF
--- a/beacon-chain/core/balances/rewards_penalties.go
+++ b/beacon-chain/core/balances/rewards_penalties.go
@@ -345,12 +345,9 @@ func Crosslinks(
 	endSlot := helpers.StartSlot(currentEpoch)
 
 	for i := startSlot; i < endSlot; i++ {
-		var registryChange bool
-		if state.ValidatorRegistryUpdateEpoch == i-1 &&
-			state.ValidatorRegistryUpdateEpoch != params.BeaconConfig().GenesisEpoch {
-			registryChange = true
-		}
-		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, registryChange)
+		// RegistryChange is a no-op when requesting slot in current and previous epoch.
+		// Process crosslinks rewards will never request crosslink committees of next epoch.
+		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, false) //registryChange = false
 		if err != nil {
 			return nil, fmt.Errorf("could not get shard committees for slot %d: %v",
 				i-params.BeaconConfig().GenesisSlot, err)

--- a/beacon-chain/core/balances/rewards_penalties.go
+++ b/beacon-chain/core/balances/rewards_penalties.go
@@ -347,7 +347,7 @@ func Crosslinks(
 	for i := startSlot; i < endSlot; i++ {
 		// RegistryChange is a no-op when requesting slot in current and previous epoch.
 		// Process crosslinks rewards will never request crosslink committees of next epoch.
-		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, false) //registryChange = false
+		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, false /* registryChange */)
 		if err != nil {
 			return nil, fmt.Errorf("could not get shard committees for slot %d: %v",
 				i-params.BeaconConfig().GenesisSlot, err)

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -190,12 +190,9 @@ func ProcessCrosslinks(
 	endSlot := helpers.StartSlot(nextEpoch)
 
 	for i := startSlot; i < endSlot; i++ {
-		var registryChange bool
-		if state.ValidatorRegistryUpdateEpoch == i-1 &&
-			state.ValidatorRegistryUpdateEpoch != params.BeaconConfig().GenesisEpoch {
-			registryChange = true
-		}
-		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, registryChange)
+		// RegistryChange is a no-op when requesting slot in current and previous epoch.
+		// ProcessCrosslinks will never ask for slot in next epoch.
+		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, false) //registryChange = false
 		if err != nil {
 			return nil, fmt.Errorf("could not get committees for slot %d: %v", i-params.BeaconConfig().GenesisSlot, err)
 		}

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -192,7 +192,7 @@ func ProcessCrosslinks(
 	for i := startSlot; i < endSlot; i++ {
 		// RegistryChange is a no-op when requesting slot in current and previous epoch.
 		// ProcessCrosslinks will never ask for slot in next epoch.
-		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, false) //registryChange = false
+		crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(state, i, false /* registryChange */)
 		if err != nil {
 			return nil, fmt.Errorf("could not get committees for slot %d: %v", i-params.BeaconConfig().GenesisSlot, err)
 		}

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -349,8 +349,8 @@ func AttestationParticipants(
 	// Find the relevant committee.
 	// RegistryChange is a no-op when requesting slot in current and previous epoch.
 	// AttestationParticipants is used to calculate justification and finality hence won't be used
-	// to request crosslink committees of future epoch.
-	crosslinkCommittees, err := CrosslinkCommitteesAtSlot(state, i, false /* registryChange */)
+	// to request crosslink commitees of future epoch.
+	crosslinkCommittees, err := CrosslinkCommitteesAtSlot(state, attestationData.Slot, false /* registryChange */)
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -347,12 +347,10 @@ func AttestationParticipants(
 	bitfield []byte) ([]uint64, error) {
 
 	// Find the relevant committee.
-	var registryChanged bool
-	if state.ValidatorRegistryUpdateEpoch == SlotToEpoch(attestationData.Slot)-1 &&
-		state.ValidatorRegistryUpdateEpoch != params.BeaconConfig().GenesisEpoch {
-		registryChanged = true
-	}
-	crosslinkCommittees, err := CrosslinkCommitteesAtSlot(state, attestationData.Slot, registryChanged)
+	// RegistryChange is a no-op when requesting slot in current and previous epoch.
+	// AttestationParticipants is used to calculate justification and finality hence won't be used
+	// to request crosslink committees of future epoch.
+	crosslinkCommittees, err := CrosslinkCommitteesAtSlot(state, attestationData.Slot, false) //registryChange = false
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -350,7 +350,7 @@ func AttestationParticipants(
 	// RegistryChange is a no-op when requesting slot in current and previous epoch.
 	// AttestationParticipants is used to calculate justification and finality hence won't be used
 	// to request crosslink committees of future epoch.
-	crosslinkCommittees, err := CrosslinkCommitteesAtSlot(state, attestationData.Slot, false) //registryChange = false
+	crosslinkCommittees, err := CrosslinkCommitteesAtSlot(state, i, false /* registryChange */)
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -69,7 +69,7 @@ func BeaconProposerIndex(state *pb.BeaconState, slot uint64) (uint64, error) {
 	// RegistryChange is false because BeaconProposerIndex is only written
 	// to be able to get proposers from current and previous epoch following
 	// ETH2.0 beacon chain spec.
-	committeeArray, err := CrosslinkCommitteesAtSlot(state, i, false /* registryChange */)
+	committeeArray, err := CrosslinkCommitteesAtSlot(state, slot, false /* registryChange */)
 	if err != nil {
 		return 0, err
 	}

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -66,12 +66,10 @@ func EntryExitEffectEpoch(epoch uint64) uint64 {
 //    first_committee, _ = get_crosslink_committees_at_slot(state, slot)[0]
 //    return first_committee[slot % len(first_committee)]
 func BeaconProposerIndex(state *pb.BeaconState, slot uint64) (uint64, error) {
-	var registryChanged bool
-	if state.ValidatorRegistryUpdateEpoch == SlotToEpoch(slot)-1 &&
-		state.ValidatorRegistryUpdateEpoch != params.BeaconConfig().GenesisEpoch {
-		registryChanged = true
-	}
-	committeeArray, err := CrosslinkCommitteesAtSlot(state, slot, registryChanged)
+	// RegistryChange is false because BeaconProposerIndex is only written
+	// to be able to get proposers from current and previous epoch following
+	// ETH2.0 beacon chain spec.
+	committeeArray, err := CrosslinkCommitteesAtSlot(state, slot, false) //registryChange = false
 	if err != nil {
 		return 0, err
 	}

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -69,7 +69,7 @@ func BeaconProposerIndex(state *pb.BeaconState, slot uint64) (uint64, error) {
 	// RegistryChange is false because BeaconProposerIndex is only written
 	// to be able to get proposers from current and previous epoch following
 	// ETH2.0 beacon chain spec.
-	committeeArray, err := CrosslinkCommitteesAtSlot(state, slot, false) //registryChange = false
+	committeeArray, err := CrosslinkCommitteesAtSlot(state, i, false /* registryChange */)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
We previously added a next epoch check (if requesting slot for next epoch, set `registryChange` = true), this is not necessary for the following processing function because they will never request slot of next epoch. Reverted back to what we had before with explicit comments. Confirmed with Danny on this.

* Process crosslinks justifications don't process cross link of future slot
* Process crosslinks rewards don't process cross link of future slot
* Getting beacon proposer and attestation participants from beacon node's perspectives won't request slot of next epoch
