### PR TITLE
Misc Fixes for Epoch Processing

### DIFF
--- a/beacon-chain/core/epoch/epoch_operations.go
+++ b/beacon-chain/core/epoch/epoch_operations.go
@@ -237,11 +237,12 @@ func InclusionDistance(state *pb.BeaconState, validatorIndex uint64) (uint64, er
 // AttestingValidators returns the validators of the winning root.
 //
 // Spec pseudocode definition:
-//    Let `attesting_validators(shard_committee)` be equal to
-//    `attesting_validator_indices(shard_committee, winning_root(shard_committee))` for convenience
+//    Let `attesting_validators(crosslink_committee)` be equal to
+//    `attesting_validator_indices(crosslink_committee, winning_root(crosslink_committee))` for convenience
 func AttestingValidators(
 	state *pb.BeaconState,
-	shard uint64, currentEpochAttestations []*pb.PendingAttestation,
+	shard uint64,
+	currentEpochAttestations []*pb.PendingAttestation,
 	prevEpochAttestations []*pb.PendingAttestation) ([]uint64, error) {
 
 	root, err := winningRoot(
@@ -270,8 +271,8 @@ func AttestingValidators(
 // attested to the winning root.
 //
 // Spec pseudocode definition:
-//    Let total_balance(shard_committee) =
-//    sum([get_effective_balance(state, i) for i in shard_committee.committee])
+//    Let total_balance(crosslink_committee) =
+//    sum([get_effective_balance(state, i) for i in crosslink_committee.committee])
 func TotalAttestingBalance(
 	state *pb.BeaconState,
 	shard uint64,
@@ -295,9 +296,9 @@ func TotalAttestingBalance(
 // a finalized slot.
 //
 // Spec pseudocode definition:
-//    epochs_since_finality = slot_to_epoch(state.slot)  - state.finalized_epoch)
+//    epochs_since_finality = next_epoch - state.finalized_epoch
 func SinceFinality(state *pb.BeaconState) uint64 {
-	return helpers.CurrentEpoch(state) - state.FinalizedEpoch
+	return helpers.NextEpoch(state) - state.FinalizedEpoch
 }
 
 // winningRoot returns the shard block root with the most combined validator

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -79,7 +79,7 @@ func CanProcessValidatorRegistry(state *pb.BeaconState) bool {
 //
 func ProcessEth1Data(state *pb.BeaconState) *pb.BeaconState {
 	for _, eth1DataVote := range state.Eth1DataVotes {
-		if eth1DataVote.VoteCount*2 > params.BeaconConfig().SlotsPerEpoch *
+		if eth1DataVote.VoteCount*2 > params.BeaconConfig().SlotsPerEpoch*
 			params.BeaconConfig().EpochsPerEth1VotingPeriod {
 			state.LatestEth1Data = eth1DataVote.Eth1Data
 		}

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -202,7 +202,7 @@ func ProcessCrosslinks(
 				return nil, fmt.Errorf("could not get attesting balance for shard committee %d: %v", shard, err)
 			}
 			totalBalance := TotalBalance(state, committee)
-			if attestingBalance*3 > totalBalance*2 {
+			if attestingBalance*3 >= totalBalance*2 {
 				winningRoot, err := winningRoot(state, shard, thisEpochAttestations, prevEpochAttestations)
 				if err != nil {
 					return nil, fmt.Errorf("could not get winning root: %v", err)

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -245,7 +245,7 @@ func ProcessEjections(state *pb.BeaconState) (*pb.BeaconState, error) {
 //
 // Spec pseudocode definition:
 //	Set state.previous_epoch_randao_mix = state.current_epoch_randao_mix
-//	Set state.previous_calculation_epoch = state.current_calculation_epoch
+//	Set state.previous_shuffling_start_shard = state.current_shuffling_start_shard
 //  Set state.previous_shuffling_seed = state.current_shuffling_seed.
 func ProcessPrevSlotShardSeed(state *pb.BeaconState) *pb.BeaconState {
 	state.PreviousShufflingEpoch = state.CurrentShufflingEpoch
@@ -279,7 +279,7 @@ func ProcessCurrSlotShardSeed(state *pb.BeaconState) (*pb.BeaconState, error) {
 //	Let epochs_since_last_registry_change = current_epoch -
 //		state.validator_registry_update_epoch
 //	If epochs_since_last_registry_update > 1 and
-//		epochs_since_last_registry_change is an exact power of 2:
+//		is_power_of_two(epochs_since_last_registry_update):
 // 			set state.current_calculation_epoch = next_epoch
 // 			set state.current_shuffling_seed = generate_seed(
 // 				state, state.current_calculation_epoch)

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -71,7 +71,6 @@ func CanProcessValidatorRegistry(state *pb.BeaconState) bool {
 // marks the voted Eth1 data as the latest data set.
 //
 // Official spec definition:
-//   if next_epoch % EPOCHS_PER_ETH1_VOTING_PERIOD == 0:
 //     if eth1_data_vote.vote_count * 2 > EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH for
 //       some eth1_data_vote in state.eth1_data_votes.
 //       (ie. more than half the votes in this voting period were for that value)
@@ -79,15 +78,13 @@ func CanProcessValidatorRegistry(state *pb.BeaconState) bool {
 //		 Set state.eth1_data_votes = [].
 //
 func ProcessEth1Data(state *pb.BeaconState) *pb.BeaconState {
-	if helpers.NextEpoch(state)%params.BeaconConfig().EpochsPerEth1VotingPeriod == 0 {
-		for _, eth1DataVote := range state.Eth1DataVotes {
-			if eth1DataVote.VoteCount*2 > params.BeaconConfig().EpochsPerEth1VotingPeriod {
-				state.LatestEth1Data.DepositRootHash32 = eth1DataVote.Eth1Data.DepositRootHash32
-				state.LatestEth1Data.BlockHash32 = eth1DataVote.Eth1Data.BlockHash32
-			}
+	for _, eth1DataVote := range state.Eth1DataVotes {
+		if eth1DataVote.VoteCount*2 > params.BeaconConfig().SlotsPerEpoch *
+			params.BeaconConfig().EpochsPerEth1VotingPeriod {
+			state.LatestEth1Data = eth1DataVote.Eth1Data
 		}
-		state.Eth1DataVotes = make([]*pb.Eth1DataVote, 0)
 	}
+	state.Eth1DataVotes = make([]*pb.Eth1DataVote, 0)
 	return state
 }
 

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -120,15 +120,16 @@ func ProcessJustification(
 	currentEpoch := helpers.CurrentEpoch(state)
 	// Shifts all the bits over one to create a new bit for the recent epoch.
 	state.JustificationBitfield = state.JustificationBitfield << 1
-	log.Infof("Total Balance: %d", totalBalance)
+	log.Infof("Processing Total Balance: %d", totalBalance)
 	// If prev prev epoch was justified then we ensure the 2nd bit in the bitfield is set,
 	// assign new justified slot to 2 * SLOTS_PER_EPOCH before.
-	log.Infof("Previous Epoch Attesting Balance: %d", prevEpochBoundaryAttestingBalance)
+	log.Infof("Previous Epoch Boundary Attesting Balance: %d", prevEpochBoundaryAttestingBalance)
 	if 3*prevEpochBoundaryAttestingBalance >= 2*prevTotalBalance {
 		state.JustificationBitfield |= 2
 		newJustifiedEpoch = prevEpoch
+		log.Infof("Previous epoch %d was justified", newJustifiedEpoch-params.BeaconConfig().GenesisEpoch)
 	}
-	log.Infof("Current Epoch Attesting Balance: %d", thisEpochBoundaryAttestingBalance)
+	log.Infof("Current Epoch Boundary Attesting Balance: %d", thisEpochBoundaryAttestingBalance)
 	// If this epoch was justified then we ensure the 1st bit in the bitfield is set,
 	// assign new justified slot to 1 * SLOTS_PER_EPOCH before.
 	if 3*thisEpochBoundaryAttestingBalance >= 2*totalBalance {
@@ -173,7 +174,7 @@ func ProcessJustification(
 // 	let `crosslink_committees_at_slot = get_crosslink_committees_at_slot(state, slot)`.
 // 		For every `(crosslink_committee, shard)` in `crosslink_committees_at_slot`, compute:
 // 			Set state.latest_crosslinks[shard] = Crosslink(
-// 			epoch=current_epoch, shard_block_root=winning_root(crosslink_committee))
+// 			epoch=slot_to_epoch(slot), crosslink_data_root=winning_root(crosslink_committee))
 // 			if 3 * total_attesting_balance(crosslink_committee) >= 2 * total_balance(crosslink_committee)
 func ProcessCrosslinks(
 	state *pb.BeaconState,

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -102,7 +102,8 @@ func TestCanProcessEth1Data_TrueOnVotingPeriods(t *testing.T) {
 }
 
 func TestProcessEth1Data_UpdatesStateAndCleans(t *testing.T) {
-	requiredVoteCount := params.BeaconConfig().EpochsPerEth1VotingPeriod
+	requiredVoteCount := params.BeaconConfig().EpochsPerEth1VotingPeriod *
+		params.BeaconConfig().SlotsPerEpoch
 	state := &pb.BeaconState{
 		Slot: 15 * params.BeaconConfig().SlotsPerEpoch,
 		LatestEth1Data: &pb.Eth1Data{

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -360,11 +360,11 @@ func ProcessEpoch(state *pb.BeaconState) (*pb.BeaconState, error) {
 	if e.CanProcessValidatorRegistry(state) {
 		state, err = v.UpdateRegistry(state)
 		if err != nil {
-			return nil, fmt.Errorf("can not update validator registry: %v", err)
+			return nil, fmt.Errorf("could not update validator registry: %v", err)
 		}
 		state, err = e.ProcessCurrSlotShardSeed(state)
 		if err != nil {
-			return nil, fmt.Errorf("can not update current shard shuffling seeds: %v", err)
+			return nil, fmt.Errorf("could not update current shard shuffling seeds: %v", err)
 		}
 	} else {
 		state, err = e.ProcessPartialValidatorRegistry(state)
@@ -380,6 +380,10 @@ func ProcessEpoch(state *pb.BeaconState) (*pb.BeaconState, error) {
 		return nil, fmt.Errorf("could not update latest index roots: %v", err)
 	}
 
+	// TODO(1763): Implement process_slashings from ETH2.0 beacon chain spec.
+
+	// TODO(1764): Implement process_exit_queue from ETH2.0 beacon chain spec.
+
 	// Update accumulated slashed balances from current epoch to next epoch.
 	state = e.UpdateLatestSlashedBalances(state)
 
@@ -391,6 +395,7 @@ func ProcessEpoch(state *pb.BeaconState) (*pb.BeaconState, error) {
 
 	// Clean up processed attestations.
 	state = e.CleanupAttestations(state)
+
 	log.WithField(
 		"PreviousJustifiedEpoch", state.PreviousJustifiedEpoch-params.BeaconConfig().GenesisEpoch,
 	).Info("Previous justified epoch")

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -164,18 +164,19 @@ func ProcessBlock(state *pb.BeaconState, block *pb.BeaconBlock, verifySignatures
 // 	 update_validator_registry(state)
 // 	 final_book_keeping(state)
 func ProcessEpoch(state *pb.BeaconState) (*pb.BeaconState, error) {
-	// Calculate total balances of active validators of the current state.
 	currentEpoch := helpers.CurrentEpoch(state)
 	prevEpoch := helpers.PrevEpoch(state)
+
+	// Calculate total balances of active validators of the current epoch.
 	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
 	totalBalance := e.TotalBalance(state, activeValidatorIndices)
 
 	// Calculate the attesting balances of validators that justified the
 	// epoch boundary block at the start of the current epoch.
-	currentAttestations := e.CurrentAttestations(state)
-	log.Infof("Number of current epoch attestations: %d", len(currentAttestations))
+	currentEpochAttestations := e.CurrentAttestations(state)
+	log.Infof("Number of current epoch attestations: %d", len(currentEpochAttestations))
 
-	currentEpochBoundaryAttestations, err := e.CurrentEpochBoundaryAttestations(state, currentAttestations)
+	currentEpochBoundaryAttestations, err := e.CurrentEpochBoundaryAttestations(state, currentEpochAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not get current boundary attestations: %v", err)
 	}
@@ -184,20 +185,22 @@ func ProcessEpoch(state *pb.BeaconState) (*pb.BeaconState, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get current boundary attester indices: %v", err)
 	}
-	log.Infof("Current epoch attester indices: %v", currentBoundaryAttesterIndices)
+	log.Infof("Current epoch boundary attester indices: %v", currentBoundaryAttesterIndices)
 
 	currentBoundaryAttestingBalances := e.TotalBalance(state, currentBoundaryAttesterIndices)
 
+	// Calculate the attesting balances of validators from previous epoch.
 	previousActiveValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, prevEpoch)
 	prevTotalBalance := e.TotalBalance(state, previousActiveValidatorIndices)
-	// Calculate the attesting balances of validators that made an attestation
-	// during previous epoch.
+
 	prevEpochAttestations := e.PrevAttestations(state)
 	log.Infof("Number of prev epoch attestations: %d", len(prevEpochAttestations))
 	prevEpochAttesterIndices, err := v.ValidatorIndices(state, prevEpochAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not get prev epoch attester indices: %v", err)
 	}
+	log.Infof("Previous epoch attester indices: %v", prevEpochAttesterIndices)
+
 	prevEpochAttestingBalance := e.TotalBalance(state, prevEpochAttesterIndices)
 
 	// Calculate the attesting balances of validator justifying epoch boundary block
@@ -206,12 +209,13 @@ func ProcessEpoch(state *pb.BeaconState) (*pb.BeaconState, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get prev boundary attestations: %v", err)
 	}
+	log.Infof("Number of prev epoch boundary attestations: %d", len(prevEpochAttestations))
 
 	prevEpochBoundaryAttesterIndices, err := v.ValidatorIndices(state, prevEpochBoundaryAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not get prev boundary attester indices: %v", err)
 	}
-	log.Infof("Previous epoch attester indices: %v", prevEpochBoundaryAttesterIndices)
+	log.Infof("Previous epoch boundary attester indices: %v", prevEpochBoundaryAttesterIndices)
 
 	prevEpochBoundaryAttestingBalances := e.TotalBalance(state, prevEpochBoundaryAttesterIndices)
 
@@ -244,7 +248,7 @@ func ProcessEpoch(state *pb.BeaconState) (*pb.BeaconState, error) {
 	// Process crosslinks records.
 	state, err = e.ProcessCrosslinks(
 		state,
-		currentAttestations,
+		currentEpochAttestations,
 		prevEpochAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not process crosslink records: %v", err)

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -342,7 +342,7 @@ func ProcessEpoch(state *pb.BeaconState) (*pb.BeaconState, error) {
 	// Process crosslink rewards and penalties.
 	state, err = bal.Crosslinks(
 		state,
-		currentAttestations,
+		currentEpochAttestations,
 		prevEpochAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not process crosslink rewards and penalties: %v", err)

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -432,7 +432,7 @@ func TestProcessEpoch_PassesProcessingConditions(t *testing.T) {
 		randaoHashes = append(randaoHashes, []byte{byte(i)})
 	}
 
-	crosslinkRecord := []*pb.Crosslink{{}, {}}
+	crosslinkRecord := make([]*pb.Crosslink, 64)
 	newState := &pb.BeaconState{
 		Slot:                   params.BeaconConfig().SlotsPerEpoch + params.BeaconConfig().GenesisSlot + 1,
 		LatestAttestations:     attestations,
@@ -491,7 +491,7 @@ func TestProcessEpoch_InactiveConditions(t *testing.T) {
 		randaoHashes = append(randaoHashes, []byte{byte(i)})
 	}
 
-	crosslinkRecord := []*pb.Crosslink{{}, {}}
+	crosslinkRecord := make([]*pb.Crosslink, 64)
 
 	newState := &pb.BeaconState{
 		Slot:                   params.BeaconConfig().SlotsPerEpoch + params.BeaconConfig().GenesisSlot + 1,

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -420,7 +420,7 @@ func allValidatorsIndices(state *pb.BeaconState) []uint64 {
 // in and out of the validator pool.
 // Spec pseudocode definition:
 //     max_balance_churn = max(
-//        MAX_DEPOSIT * GWEI_PER_ETH,
+//        MAX_DEPOSIT_AMOUNT,
 //        total_balance // (2 * MAX_BALANCE_CHURN_QUOTIENT))
 func maxBalanceChurn(totalBalance uint64) uint64 {
 	maxBalanceChurn := totalBalance / 2 * params.BeaconConfig().MaxBalanceChurnQuotient


### PR DESCRIPTION
This PR aims to be align current epoch processing to spec and see if there's any last min bug that we miss.

Key changes:
- `ProcessEth1Data` doesn't need to pre condition check, it's already done in `CanProcessEth1Data`
- `ProcessEth1Data` has an incorrect condition check for best ETH1Data
- Added logging for prev boundary attestations, attester indices and balances