### PR TITLE
Block caching for ETH1Data (includes #1760)

### DIFF
--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_client_go//tools/cache:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
     ],
 )
@@ -35,6 +36,7 @@ go_test(
         "//contracts/deposit-contract:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/params:go_default_library",
         "//shared/ssz:go_default_library",
         "//shared/testutil:go_default_library",
         "//shared/trieutil:go_default_library",

--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["service.go"],
+    srcs = [
+        "block_cache.go",
+        "service.go",
+    ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/powchain",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
@@ -28,7 +31,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["service_test.go"],
+    srcs = [
+        "block_cache_test.go",
+        "service_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
@@ -36,7 +42,6 @@ go_test(
         "//contracts/deposit-contract:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/event:go_default_library",
-        "//shared/params:go_default_library",
         "//shared/ssz:go_default_library",
         "//shared/testutil:go_default_library",
         "//shared/trieutil:go_default_library",

--- a/beacon-chain/powchain/block_cache.go
+++ b/beacon-chain/powchain/block_cache.go
@@ -1,0 +1,176 @@
+package powchain
+
+import (
+	"errors"
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	// NotABlockInfoErr will be returned when a cache object is not a pointer to
+	// a blockInfo struct.
+	NotABlockInfoErr = errors.New("object is not a block info")
+
+	// maxCacheSize is 2x of the follow distance for additional cache padding.
+	// Requests should be only accessing blocks within recent blocks within the
+	// Eth1FollowDistance.
+	maxCacheSize = int(2 * params.BeaconConfig().Eth1FollowDistance)
+
+	// Metrics
+	blockCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "powchain_block_cache_miss",
+		Help: "The number of block requests that aren't present in the cache.",
+	})
+	blockCacheHit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "powchain_block_cache_hit",
+		Help: "The number of block requests that are present in the cache.",
+	})
+	blockCacheSize = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "powchain_block_cache_size",
+		Help: "The number of blocks in the block cache",
+	})
+)
+
+// blockInfo specifies the block information in the ETH 1.0 chain.
+type blockInfo struct {
+	Number *big.Int
+	Hash   common.Hash
+}
+
+// hashKeyFn takes the hex string representation as the key for a blockInfo.
+func hashKeyFn(obj interface{}) (string, error) {
+	bInfo, ok := obj.(*blockInfo)
+	if !ok {
+		return "", NotABlockInfoErr
+	}
+
+	return bInfo.Hash.Hex(), nil
+}
+
+// heightKeyFn takes the string representation of the block number as the key
+// for a blockInfo.
+func heightKeyFn(obj interface{}) (string, error) {
+	bInfo, ok := obj.(*blockInfo)
+	if !ok {
+		return "", NotABlockInfoErr
+	}
+
+	return bInfo.Number.String(), nil
+}
+
+// blockCache struct with two queues for looking up by hash or by block height.
+type blockCache struct {
+	hashCache   *cache.FIFO
+	heightCache *cache.FIFO
+	lock        sync.RWMutex
+}
+
+// NewBlockCache creates a new block cache for storing/accessing blockInfo from
+// memory.
+func NewBlockCache() *blockCache {
+	return &blockCache{
+		hashCache:   cache.NewFIFO(hashKeyFn),
+		heightCache: cache.NewFIFO(heightKeyFn),
+	}
+}
+
+// BlockInfoByHash fetches blockInfo by its block hash. Returns true with a
+// reference to the block info, if exists. Otherwise returns false, nil.
+func (b *blockCache) BlockInfoByHash(hash common.Hash) (bool, *blockInfo, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	obj, exists, err := b.hashCache.GetByKey(hash.Hex())
+	if err != nil {
+		return false, nil, err
+	}
+
+	if exists {
+		blockCacheHit.Inc()
+	} else {
+		blockCacheMiss.Inc()
+		return false, nil, nil
+	}
+
+	bInfo, ok := obj.(*blockInfo)
+	if !ok {
+		return false, nil, NotABlockInfoErr
+	}
+
+	return true, bInfo, nil
+}
+
+// BlockInfoByHeight fetches blockInfo by its block number. Returns true with a
+// reference to the block info, if exists. Otherwise returns false, nil.
+func (b *blockCache) BlockInfoByHeight(height *big.Int) (bool, *blockInfo, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	obj, exists, err := b.heightCache.GetByKey(height.String())
+	if err != nil {
+		return false, nil, err
+	}
+
+	if exists {
+		blockCacheHit.Inc()
+	} else {
+		blockCacheMiss.Inc()
+		return false, nil, nil
+	}
+
+	bInfo, ok := obj.(*blockInfo)
+	if !ok {
+		return false, nil, NotABlockInfoErr
+	}
+
+	return exists, bInfo, nil
+}
+
+// AddBlock adds a blockInfo object to the cache. This method also trims the
+// least recently added block info if the cache size has reached the max cache
+// size limit. This method should be called in sequential block number order if
+// the desired behavior is that the blocks with the highest block number should
+// be present in the cache.
+func (b *blockCache) AddBlock(blk *gethTypes.Block) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	bInfo := &blockInfo{
+		Hash:   blk.Hash(),
+		Number: blk.Number(),
+	}
+
+	if err := b.hashCache.AddIfNotPresent(bInfo); err != nil {
+		return err
+	}
+	if err := b.heightCache.AddIfNotPresent(bInfo); err != nil {
+		return err
+	}
+
+	trim(b.hashCache, maxCacheSize)
+	trim(b.heightCache, maxCacheSize)
+
+	blockCacheSize.Set(float64(len(b.hashCache.ListKeys())))
+
+	return nil
+}
+
+// trim the FIFO queue to the maxSize.
+func trim(queue *cache.FIFO, maxSize int) {
+	for s := len(queue.ListKeys()); s > maxSize; s-- {
+		// #nosec G104 popProcessNoopFunc never returns an error
+		_, _ = queue.Pop(popProcessNoopFunc)
+	}
+}
+
+// popProcessNoopFunc is a no-op function that never returns an error.
+func popProcessNoopFunc(obj interface{}) error {
+	return nil
+}

--- a/beacon-chain/powchain/block_cache.go
+++ b/beacon-chain/powchain/block_cache.go
@@ -14,9 +14,9 @@ import (
 )
 
 var (
-	// NotABlockInfoErr will be returned when a cache object is not a pointer to
+	// ErrNotABlockInfo will be returned when a cache object is not a pointer to
 	// a blockInfo struct.
-	NotABlockInfoErr = errors.New("object is not a block info")
+	ErrNotABlockInfo = errors.New("object is not a block info")
 
 	// maxCacheSize is 2x of the follow distance for additional cache padding.
 	// Requests should be only accessing blocks within recent blocks within the
@@ -48,7 +48,7 @@ type blockInfo struct {
 func hashKeyFn(obj interface{}) (string, error) {
 	bInfo, ok := obj.(*blockInfo)
 	if !ok {
-		return "", NotABlockInfoErr
+		return "", ErrNotABlockInfo
 	}
 
 	return bInfo.Hash.Hex(), nil
@@ -59,7 +59,7 @@ func hashKeyFn(obj interface{}) (string, error) {
 func heightKeyFn(obj interface{}) (string, error) {
 	bInfo, ok := obj.(*blockInfo)
 	if !ok {
-		return "", NotABlockInfoErr
+		return "", ErrNotABlockInfo
 	}
 
 	return bInfo.Number.String(), nil
@@ -72,9 +72,9 @@ type blockCache struct {
 	lock        sync.RWMutex
 }
 
-// NewBlockCache creates a new block cache for storing/accessing blockInfo from
+// newBlockCache creates a new block cache for storing/accessing blockInfo from
 // memory.
-func NewBlockCache() *blockCache {
+func newBlockCache() *blockCache {
 	return &blockCache{
 		hashCache:   cache.NewFIFO(hashKeyFn),
 		heightCache: cache.NewFIFO(heightKeyFn),
@@ -101,7 +101,7 @@ func (b *blockCache) BlockInfoByHash(hash common.Hash) (bool, *blockInfo, error)
 
 	bInfo, ok := obj.(*blockInfo)
 	if !ok {
-		return false, nil, NotABlockInfoErr
+		return false, nil, ErrNotABlockInfo
 	}
 
 	return true, bInfo, nil
@@ -127,7 +127,7 @@ func (b *blockCache) BlockInfoByHeight(height *big.Int) (bool, *blockInfo, error
 
 	bInfo, ok := obj.(*blockInfo)
 	if !ok {
-		return false, nil, NotABlockInfoErr
+		return false, nil, ErrNotABlockInfo
 	}
 
 	return exists, bInfo, nil

--- a/beacon-chain/powchain/block_cache_test.go
+++ b/beacon-chain/powchain/block_cache_test.go
@@ -24,8 +24,8 @@ func TestHashKeyFn_OK(t *testing.T) {
 
 func TestHashKeyFn_InvalidObj(t *testing.T) {
 	_, err := hashKeyFn("bad")
-	if err != NotABlockInfoErr {
-		t.Errorf("Expected error %v, got %v", NotABlockInfoErr, err)
+	if err != ErrNotABlockInfo {
+		t.Errorf("Expected error %v, got %v", ErrNotABlockInfo, err)
 	}
 }
 
@@ -45,13 +45,13 @@ func TestHeightKeyFn_OK(t *testing.T) {
 
 func TestHeightKeyFn_InvalidObj(t *testing.T) {
 	_, err := heightKeyFn("bad")
-	if err != NotABlockInfoErr {
-		t.Errorf("Expected error %v, got %v", NotABlockInfoErr, err)
+	if err != ErrNotABlockInfo {
+		t.Errorf("Expected error %v, got %v", ErrNotABlockInfo, err)
 	}
 }
 
 func TestBlockCache_byHash(t *testing.T) {
-	cache := NewBlockCache()
+	cache := newBlockCache()
 
 	header := &gethTypes.Header{
 		ParentHash: common.HexToHash("0x12345"),
@@ -94,7 +94,7 @@ func TestBlockCache_byHash(t *testing.T) {
 }
 
 func TestBlockCache_byHeight(t *testing.T) {
-	cache := NewBlockCache()
+	cache := newBlockCache()
 
 	header := &gethTypes.Header{
 		ParentHash: common.HexToHash("0x12345"),
@@ -137,7 +137,7 @@ func TestBlockCache_byHeight(t *testing.T) {
 }
 
 func TestBlockCache_maxSize(t *testing.T) {
-	cache := NewBlockCache()
+	cache := newBlockCache()
 
 	for i := int64(0); i < int64(maxCacheSize+10); i++ {
 		header := &gethTypes.Header{

--- a/beacon-chain/powchain/block_cache_test.go
+++ b/beacon-chain/powchain/block_cache_test.go
@@ -1,0 +1,165 @@
+package powchain
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
+)
+
+func TestHashKeyFn_OK(t *testing.T) {
+	bInfo := &blockInfo{
+		Hash: common.HexToHash("0x0123456"),
+	}
+
+	key, err := hashKeyFn(bInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key != bInfo.Hash.Hex() {
+		t.Errorf("Incorrect hash key: %s, expected %s", key, bInfo.Hash.Hex())
+	}
+}
+
+func TestHashKeyFn_InvalidObj(t *testing.T) {
+	_, err := hashKeyFn("bad")
+	if err != NotABlockInfoErr {
+		t.Errorf("Expected error %v, got %v", NotABlockInfoErr, err)
+	}
+}
+
+func TestHeightKeyFn_OK(t *testing.T) {
+	bInfo := &blockInfo{
+		Number: big.NewInt(555),
+	}
+
+	key, err := heightKeyFn(bInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key != bInfo.Number.String() {
+		t.Errorf("Incorrect height key: %s, expected %s", key, bInfo.Number.String())
+	}
+}
+
+func TestHeightKeyFn_InvalidObj(t *testing.T) {
+	_, err := heightKeyFn("bad")
+	if err != NotABlockInfoErr {
+		t.Errorf("Expected error %v, got %v", NotABlockInfoErr, err)
+	}
+}
+
+func TestBlockCache_byHash(t *testing.T) {
+	cache := NewBlockCache()
+
+	header := &gethTypes.Header{
+		ParentHash: common.HexToHash("0x12345"),
+		Number:     big.NewInt(55),
+	}
+
+	exists, _, err := cache.BlockInfoByHash(header.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("Expected block info not to exist in empty cache")
+	}
+
+	if err := cache.AddBlock(gethTypes.NewBlockWithHeader(header)); err != nil {
+		t.Fatal(err)
+	}
+
+	exists, fetchedInfo, err := cache.BlockInfoByHash(header.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("Expected blockInfo to exist")
+	}
+	if fetchedInfo.Number.Cmp(header.Number) != 0 {
+		t.Errorf(
+			"Expected fetched info number to be %v, got %v",
+			header.Number,
+			fetchedInfo.Number,
+		)
+	}
+	if fetchedInfo.Hash != header.Hash() {
+		t.Errorf(
+			"Expected fetched info hash to be %v, got %v",
+			header.Hash(),
+			fetchedInfo.Hash,
+		)
+	}
+}
+
+func TestBlockCache_byHeight(t *testing.T) {
+	cache := NewBlockCache()
+
+	header := &gethTypes.Header{
+		ParentHash: common.HexToHash("0x12345"),
+		Number:     big.NewInt(55),
+	}
+
+	exists, _, err := cache.BlockInfoByHeight(header.Number)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("Expected block info not to exist in empty cache")
+	}
+
+	if err := cache.AddBlock(gethTypes.NewBlockWithHeader(header)); err != nil {
+		t.Fatal(err)
+	}
+
+	exists, fetchedInfo, err := cache.BlockInfoByHeight(header.Number)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("Expected blockInfo to exist")
+	}
+	if fetchedInfo.Number.Cmp(header.Number) != 0 {
+		t.Errorf(
+			"Expected fetched info number to be %v, got %v",
+			header.Number,
+			fetchedInfo.Number,
+		)
+	}
+	if fetchedInfo.Hash != header.Hash() {
+		t.Errorf(
+			"Expected fetched info hash to be %v, got %v",
+			header.Hash(),
+			fetchedInfo.Hash,
+		)
+	}
+}
+
+func TestBlockCache_maxSize(t *testing.T) {
+	cache := NewBlockCache()
+
+	for i := int64(0); i < int64(maxCacheSize+10); i++ {
+		header := &gethTypes.Header{
+			Number: big.NewInt(i),
+		}
+		if err := cache.AddBlock(gethTypes.NewBlockWithHeader(header)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if len(cache.hashCache.ListKeys()) != maxCacheSize {
+		t.Errorf(
+			"Expected hash cache key size to be %d, got %d",
+			maxCacheSize,
+			len(cache.hashCache.ListKeys()),
+		)
+	}
+	if len(cache.heightCache.ListKeys()) != maxCacheSize {
+		t.Errorf(
+			"Expected height cache key size to be %d, got %d",
+			maxCacheSize,
+			len(cache.heightCache.ListKeys()),
+		)
+	}
+}

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -139,7 +139,7 @@ func NewWeb3Service(ctx context.Context, config *Web3ServiceConfig) (*Web3Servic
 		endpoint:                config.Endpoint,
 		blockHeight:             nil,
 		blockHash:               common.BytesToHash([]byte{}),
-		blockCache:              NewBlockCache(),
+		blockCache:              newBlockCache(),
 		depositContractAddress:  config.DepositContract,
 		chainStartFeed:          new(event.Feed),
 		client:                  config.Client,

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -416,6 +416,21 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 	if web3Service.blockHash.Hex() != header.Hash().Hex() {
 		t.Errorf("block hash not set, expected %v, got %v", header.Hash().Hex(), web3Service.blockHash.Hex())
 	}
+
+	blockInfoExistsInCache, info, err := web3Service.blockCache.BlockInfoByHash(web3Service.blockHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !blockInfoExistsInCache {
+		t.Error("Expected block info to exist in cache")
+	}
+	if info.Hash != web3Service.blockHash {
+		t.Errorf(
+			"Expected block info hash to be %v, got %v",
+			web3Service.blockHash,
+			info.Hash,
+		)
+	}
 }
 
 func TestProcessDepositLog_OK(t *testing.T) {
@@ -942,6 +957,14 @@ func TestBlockHashByHeight_ReturnsHash(t *testing.T) {
 	if !bytes.Equal(hash.Bytes(), wanted.Bytes()) {
 		t.Fatalf("Block hash did not equal expected hash, expected: %v, got: %v", wanted, hash)
 	}
+
+	exists, _, err := web3Service.blockCache.BlockInfoByHash(wanted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("Expected block info to be cached")
+	}
 }
 
 func TestBlockExists_ValidHash(t *testing.T) {
@@ -974,6 +997,14 @@ func TestBlockExists_ValidHash(t *testing.T) {
 	if height.Cmp(block.Number()) != 0 {
 		t.Fatalf("Block height did not equal expected height, expected: %v, got: %v", big.NewInt(42), height)
 	}
+
+	exists, _, err = web3Service.blockCache.BlockInfoByHeight(height)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("Expected block to be cached")
+	}
 }
 
 func TestBlockExists_InvalidHash(t *testing.T) {
@@ -989,5 +1020,41 @@ func TestBlockExists_InvalidHash(t *testing.T) {
 	_, _, err = web3Service.BlockExists(context.Background(), common.BytesToHash([]byte{0}))
 	if err == nil {
 		t.Fatal("Expected BlockExists to error with invalid hash")
+	}
+}
+
+func TestBlockExists_UsesCachedBlockInfo(t *testing.T) {
+	endpoint := "ws://127.0.0.1"
+	web3Service, err := NewWeb3Service(context.Background(), &Web3ServiceConfig{
+		Endpoint:     endpoint,
+		BlockFetcher: nil, // nil blockFetcher would panic if cached value not used
+	})
+	if err != nil {
+		t.Fatalf("unable to setup web3 ETH1.0 chain service: %v", err)
+	}
+
+	block := gethTypes.NewBlock(
+		&gethTypes.Header{
+			Number: big.NewInt(0),
+		},
+		[]*gethTypes.Transaction{},
+		[]*gethTypes.Header{},
+		[]*gethTypes.Receipt{},
+	)
+
+	if err := web3Service.blockCache.AddBlock(block); err != nil {
+		t.Fatal(err)
+	}
+
+	exists, height, err := web3Service.BlockExists(context.Background(), block.Hash())
+	if err != nil {
+		t.Fatalf("Could not get block hash with given height %v", err)
+	}
+
+	if !exists {
+		t.Fatal("Expected BlockExists to return true.")
+	}
+	if height.Cmp(block.Number()) != 0 {
+		t.Fatalf("Block height did not equal expected height, expected: %v, got: %v", big.NewInt(42), height)
 	}
 }

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -1032,6 +1032,11 @@ func TestBlockCache_OK(t *testing.T) {
 
 	web3Service.addToCache(blk)
 
+	exists, _ = web3Service.checkCache(blk.Hash())
+	if !exists {
+		t.Fatalf("Block with hash %#x doesn't exist in cache", blk.Hash())
+	}
+
 	exists, info2 := web3Service.checkCache(blk.Number().Uint64())
 	if !exists {
 		t.Fatalf("Block with number %d doesn't exist in cache", blk.Number().Uint64())

--- a/beacon-chain/rpc/beacon_server.go
+++ b/beacon-chain/rpc/beacon_server.go
@@ -123,7 +123,7 @@ func (bs *BeaconServer) Eth1Data(ctx context.Context, _ *ptypes.Empty) (*pb.Eth1
 	stateLatestEth1Hash := bytesutil.ToBytes32(beaconState.LatestEth1Data.BlockHash32)
 	// If latest ETH1 block hash is empty, send a default response
 	if stateLatestEth1Hash == [32]byte{} {
-		return bs.defaultDataResponse(currentHeight, eth1FollowDistance)
+		return bs.defaultDataResponse(ctx, currentHeight, eth1FollowDistance)
 	}
 	// Fetch the height of the block pointed to by the beacon state's latest_eth1_data.block_hash
 	// in the canonical, eth1.0 chain.
@@ -190,7 +190,7 @@ func (bs *BeaconServer) Eth1Data(ctx context.Context, _ *ptypes.Empty) (*pb.Eth1
 	// Let deposit_root be the deposit root of the eth1.0 deposit contract in the
 	// post-state of the block referenced by block_hash.
 	if len(dataVotes) == 0 {
-		return bs.defaultDataResponse(currentHeight, eth1FollowDistance)
+		return bs.defaultDataResponse(ctx, currentHeight, eth1FollowDistance)
 	}
 
 	return &pb.Eth1DataResponse{
@@ -213,9 +213,9 @@ func (bs *BeaconServer) PendingDeposits(ctx context.Context, _ *ptypes.Empty) (*
 	return &pb.PendingDepositsResponse{PendingDeposits: bs.beaconDB.PendingDeposits(ctx, bNum)}, nil
 }
 
-func (bs *BeaconServer) defaultDataResponse(currentHeight *big.Int, eth1FollowDistance int64) (*pb.Eth1DataResponse, error) {
+func (bs *BeaconServer) defaultDataResponse(ctx context.Context, currentHeight *big.Int, eth1FollowDistance int64) (*pb.Eth1DataResponse, error) {
 	ancestorHeight := currentHeight.Sub(currentHeight, big.NewInt(eth1FollowDistance))
-	blockHash, err := bs.powChainService.BlockHashByHeight(ancestorHeight)
+	blockHash, err := bs.powChainService.BlockHashByHeight(ctx, ancestorHeight)
 	if err != nil {
 		return nil, fmt.Errorf("could not fetch ETH1_FOLLOW_DISTANCE ancestor: %v", err)
 	}

--- a/beacon-chain/rpc/beacon_server_test.go
+++ b/beacon-chain/rpc/beacon_server_test.go
@@ -50,7 +50,7 @@ func (f *faultyPOWChainService) BlockExists(_ context.Context, hash common.Hash)
 	return true, big.NewInt(1), nil
 }
 
-func (f *faultyPOWChainService) BlockHashByHeight(height *big.Int) (common.Hash, error) {
+func (f *faultyPOWChainService) BlockHashByHeight(_ context.Context, height *big.Int) (common.Hash, error) {
 	return [32]byte{}, errors.New("failed")
 }
 
@@ -88,7 +88,7 @@ func (m *mockPOWChainService) BlockExists(_ context.Context, hash common.Hash) (
 	return true, big.NewInt(int64(val)), nil
 }
 
-func (m *mockPOWChainService) BlockHashByHeight(height *big.Int) (common.Hash, error) {
+func (m *mockPOWChainService) BlockHashByHeight(_ context.Context, height *big.Int) (common.Hash, error) {
 	k := int(height.Int64())
 	val, ok := m.hashesByHeight[k]
 	if !ok {

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -48,7 +48,7 @@ type powChainService interface {
 	ChainStartFeed() *event.Feed
 	LatestBlockHeight() *big.Int
 	BlockExists(ctx context.Context, hash common.Hash) (bool, *big.Int, error)
-	BlockHashByHeight(height *big.Int) (common.Hash, error)
+	BlockHashByHeight(ctx context.Context, height *big.Int) (common.Hash, error)
 	DepositRoot() [32]byte
 }
 


### PR DESCRIPTION
Includes #1760, see that PR for a more detailed description.

This PR started out as some minor suggestions to #1760, but I ended up with some slight refactoring and added metrics to understand cache misses/hits.

Additions to #1760:
- Prometheus metrics
- Two FIFO (one per key type pointing to the same underlying blockInfoObj)
- Refactored out of service.go into block_cache.go