### PR TITLE
Change Validator Log

### DIFF
--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -70,7 +70,7 @@ func run(ctx context.Context, v Validator) {
 				log.WithFields(logrus.Fields{
 					"slot": slot - params.BeaconConfig().GenesisSlot,
 					"role": role,
-				}).Warn("Unknown role, doing nothing")
+				}).Info("Unknown role, doing nothing")
 			default:
 				// Do nothing :)
 			}


### PR DESCRIPTION
This makes the log an `Info` log instead of a `Warn` log, when the validator is standing by, since its not really something that is worrying.