### PR TITLE
Fix Randao Reveal Bug

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"reflect"
 
 	"github.com/sirupsen/logrus"
@@ -94,7 +95,8 @@ func ProcessBlockRandao(beaconState *pb.BeaconState, block *pb.BeaconBlock, veri
 	latestMixesLength := params.BeaconConfig().LatestRandaoMixesLength
 	currentEpoch := helpers.CurrentEpoch(beaconState)
 	latestMixSlice := beaconState.LatestRandaoMixes[currentEpoch%latestMixesLength]
-	for i, x := range block.RandaoReveal {
+	blockRandaoReveal := hashutil.Hash(block.RandaoReveal)
+	for i, x := range blockRandaoReveal {
 		latestMixSlice[i] ^= x
 	}
 	beaconState.LatestRandaoMixes[currentEpoch%latestMixesLength] = latestMixSlice

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"reflect"
 
 	"github.com/sirupsen/logrus"
@@ -21,6 +20,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/forkutils"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
 )

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -106,9 +106,7 @@ func TestProcessBlockRandao_SignatureVerifiesAndUpdatesLatestStateMixes(t *testi
 	}
 	currentEpoch := helpers.CurrentEpoch(beaconState)
 	mix := newState.LatestRandaoMixes[currentEpoch%params.BeaconConfig().LatestRandaoMixesLength]
-	t.Log(params.BeaconConfig().ZeroHash[:])
-	t.Log(params.BeaconConfig().EmptySignature)
-	t.Log(mix)
+
 	if bytes.Equal(mix, params.BeaconConfig().ZeroHash[:]) {
 		t.Errorf(
 			"Expected empty signature to be overwritten by randao reveal, received %v",

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -106,7 +106,10 @@ func TestProcessBlockRandao_SignatureVerifiesAndUpdatesLatestStateMixes(t *testi
 	}
 	currentEpoch := helpers.CurrentEpoch(beaconState)
 	mix := newState.LatestRandaoMixes[currentEpoch%params.BeaconConfig().LatestRandaoMixesLength]
-	if bytes.Equal(mix, params.BeaconConfig().EmptySignature[:]) {
+	t.Log(params.BeaconConfig().ZeroHash[:])
+	t.Log(params.BeaconConfig().EmptySignature)
+	t.Log(mix)
+	if bytes.Equal(mix, params.BeaconConfig().ZeroHash[:]) {
 		t.Errorf(
 			"Expected empty signature to be overwritten by randao reveal, received %v",
 			params.BeaconConfig().EmptySignature,

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -23,16 +23,14 @@ func GenesisBeaconState(
 	genesisTime uint64,
 	processedPowReceiptRoot []byte,
 ) (*pb.BeaconState, error) {
+	zeroHash := params.BeaconConfig().ZeroHash[:]
 	latestRandaoMixes := make(
 		[][]byte,
 		params.BeaconConfig().LatestRandaoMixesLength,
 	)
 	for i := 0; i < len(latestRandaoMixes); i++ {
-		emptySig := params.BeaconConfig().EmptySignature
-		latestRandaoMixes[i] = emptySig[:]
+		latestRandaoMixes[i] = zeroHash
 	}
-
-	zeroHash := params.BeaconConfig().ZeroHash[:]
 
 	latestActiveIndexRoots := make(
 		[][]byte,

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -23,14 +23,15 @@ func GenesisBeaconState(
 	genesisTime uint64,
 	processedPowReceiptRoot []byte,
 ) (*pb.BeaconState, error) {
-	zeroHash := params.BeaconConfig().ZeroHash[:]
 	latestRandaoMixes := make(
 		[][]byte,
 		params.BeaconConfig().LatestRandaoMixesLength,
 	)
 	for i := 0; i < len(latestRandaoMixes); i++ {
-		latestRandaoMixes[i] = zeroHash
+		latestRandaoMixes[i] = make([]byte, 32)
 	}
+
+	zeroHash := params.BeaconConfig().ZeroHash[:]
 
 	latestActiveIndexRoots := make(
 		[][]byte,


### PR DESCRIPTION
Found a bug via: https://github.com/ethereum/eth2.0-specs/pull/713

We are suppose to xor `hash(block.randao_reveal)` not `block.randao_reveal`, therefore it's 32 bytes entropy not 96 bytes entropy