### PR TITLE
Remove Old Timestamp Error Log

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -355,9 +355,6 @@ func (w *Web3Service) ProcessChainStartLog(depositLog gethTypes.Log) {
 	}
 
 	timestamp := binary.LittleEndian.Uint64(timestampData)
-	if uint64(time.Now().Unix()) < timestamp {
-		log.Errorf("Invalid timestamp from log expected %d > %d", time.Now().Unix(), timestamp)
-	}
 	w.chainStarted = true
 	chainStartTime := time.Unix(int64(timestamp), 0)
 	log.WithFields(logrus.Fields{


### PR DESCRIPTION
This removes an old timestamp error log which would throw if the chainstart time was found to be greater than time.Now(). This is not an error in our current system because in production we expect chainstart to be in the future.