### PR TITLE
Enable POW chain by default

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -51,7 +51,6 @@ func main() {
 		utils.CertFlag,
 		utils.KeyFlag,
 		utils.GenesisJSON,
-		utils.EnablePOWChain,
 		utils.EnableDBCleanup,
 		utils.ChainStartDelay,
 		cmd.BootstrapNode,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -179,7 +179,7 @@ func (b *BeaconNode) registerP2P(ctx *cli.Context) error {
 	return b.services.RegisterService(beaconp2p)
 }
 
-func (b *BeaconNode) registerBlockchainService(ctx *cli.Context) error {
+func (b *BeaconNode) registerBlockchainService(_ *cli.Context) error {
 	var web3Service *powchain.Web3Service
 	if err := b.services.FetchService(&web3Service); err != nil {
 		return err
@@ -257,7 +257,7 @@ func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
 	return b.services.RegisterService(web3Service)
 }
 
-func (b *BeaconNode) registerSyncService(ctx *cli.Context) error {
+func (b *BeaconNode) registerSyncService(_ *cli.Context) error {
 	var chainService *blockchain.ChainService
 	if err := b.services.FetchService(&chainService); err != nil {
 		return err

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -33,7 +33,9 @@ import (
 )
 
 var log = logrus.WithField("prefix", "node")
-var beaconChainDBName = "beaconchaindata"
+
+const beaconChainDBName = "beaconchaindata"
+const testSkipPowFlag = "test-skip-pow"
 
 // BeaconNode defines a struct that handles the services running a random beacon chain
 // full PoS node. It handles the lifecycle of the entire system and registers
@@ -209,6 +211,10 @@ func (b *BeaconNode) registerOperationService() error {
 }
 
 func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
+	if b.ctx.GlobalBool(testSkipPowFlag) {
+		return b.services.RegisterService(&powchain.Web3Service{})
+	}
+
 	depAddress := b.ctx.GlobalString(utils.DepositContractFlag.Name)
 
 	if depAddress == "" {

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -179,11 +179,8 @@ func (b *BeaconNode) registerP2P(ctx *cli.Context) error {
 
 func (b *BeaconNode) registerBlockchainService(ctx *cli.Context) error {
 	var web3Service *powchain.Web3Service
-	enablePOWChain := ctx.GlobalBool(utils.EnablePOWChain.Name)
-	if enablePOWChain {
-		if err := b.services.FetchService(&web3Service); err != nil {
-			return err
-		}
+	if err := b.services.FetchService(&web3Service); err != nil {
+		return err
 	}
 	var opsService *operations.Service
 	if err := b.services.FetchService(&opsService); err != nil {
@@ -212,11 +209,11 @@ func (b *BeaconNode) registerOperationService() error {
 }
 
 func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
-	if !cliCtx.GlobalBool(utils.EnablePOWChain.Name) {
-		return nil
-	}
-
 	depAddress := b.ctx.GlobalString(utils.DepositContractFlag.Name)
+
+	if depAddress == "" {
+		log.Fatal("No deposit contract specified. Add --deposit-contract with a valud deposit contract address to start.")
+	}
 
 	if !common.IsHexAddress(depAddress) {
 		log.Fatalf("Invalid deposit contract address given: %s", depAddress)
@@ -271,11 +268,8 @@ func (b *BeaconNode) registerSyncService(ctx *cli.Context) error {
 	}
 
 	var web3Service *powchain.Web3Service
-	var enablePOWChain = ctx.GlobalBool(utils.EnablePOWChain.Name)
-	if enablePOWChain {
-		if err := b.services.FetchService(&web3Service); err != nil {
-			return err
-		}
+	if err := b.services.FetchService(&web3Service); err != nil {
+		return err
 	}
 
 	cfg := &rbcsync.Config{
@@ -302,11 +296,8 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 	}
 
 	var web3Service *powchain.Web3Service
-	var enablePOWChain = ctx.GlobalBool(utils.EnablePOWChain.Name)
-	if enablePOWChain {
-		if err := b.services.FetchService(&web3Service); err != nil {
-			return err
-		}
+	if err := b.services.FetchService(&web3Service); err != nil {
+		return err
 	}
 
 	port := ctx.GlobalString(utils.RPCPort.Name)

--- a/beacon-chain/node/node_test.go
+++ b/beacon-chain/node/node_test.go
@@ -4,46 +4,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/urfave/cli"
 )
-
-// Test that the beacon chain validator node build fails without PoW service.
-func TestNodeValidator_NoPOWService(t *testing.T) {
-	tmp := fmt.Sprintf("%s/datadirtest1", testutil.TempDir())
-	os.RemoveAll(tmp)
-
-	if os.Getenv("TEST_NODE_PANIC") == "1" {
-		app := cli.NewApp()
-		set := flag.NewFlagSet("test", 0)
-		set.String("web3provider", "ws//127.0.0.1:8546", "web3 provider ws or IPC endpoint")
-		tmp := fmt.Sprintf("%s/datadirtest1", testutil.TempDir())
-		set.String("datadir", tmp, "node data directory")
-		set.Bool("enable-powchain", true, "enable powchain")
-
-		context := cli.NewContext(app, set, nil)
-
-		NewBeaconNode(context)
-	}
-
-	// Start a subprocess to test beacon node crashes.
-	cmd := exec.Command(os.Args[0], "-test.run=TestNodeValidator_NoPOWService")
-	cmd.Env = append(os.Environ(), "TEST_NODE_PANIC=1")
-	if err := cmd.Start(); err != nil {
-		t.Fatal(err)
-	}
-
-	// Check beacon node program exited.
-	err := cmd.Wait()
-	if e, ok := err.(*exec.ExitError); !ok || e.Success() {
-		t.Fatalf("Process ran with err %v, want exit status 1", err)
-	}
-	os.RemoveAll(tmp)
-}
 
 // Test that beacon chain node can close.
 func TestNodeClose_OK(t *testing.T) {
@@ -55,8 +21,10 @@ func TestNodeClose_OK(t *testing.T) {
 	app := cli.NewApp()
 	set := flag.NewFlagSet("test", 0)
 	set.String("web3provider", "ws//127.0.0.1:8546", "web3 provider ws or IPC endpoint")
+	set.Bool("test-skip-pow", true, "skip pow dial")
 	set.String("datadir", tmp, "node data directory")
 	set.Bool("demo-config", true, "demo configuration")
+	set.String("deposit-contract", "0x0000000000000000000000000000000000000000", "deposit contract address")
 
 	context := cli.NewContext(app, set, nil)
 

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -170,8 +170,12 @@ func (w *Web3Service) Start() {
 
 // Stop the web3 service's main event loop and associated goroutines.
 func (w *Web3Service) Stop() error {
-	defer w.cancel()
-	defer close(w.headerChan)
+	if w.cancel != nil {
+		defer w.cancel()
+	}
+	if w.headerChan != nil {
+		defer close(w.headerChan)
+	}
 	log.Info("Stopping service")
 	return nil
 }

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -76,7 +76,6 @@ var appHelpFlagGroups = []flagGroup{
 			utils.CertFlag,
 			utils.KeyFlag,
 			utils.GenesisJSON,
-			utils.EnablePOWChain,
 			utils.EnableDBCleanup,
 			utils.ChainStartDelay,
 		},

--- a/beacon-chain/utils/flags.go
+++ b/beacon-chain/utils/flags.go
@@ -14,8 +14,8 @@ var (
 	// Web3ProviderFlag defines a flag for a mainchain RPC endpoint.
 	Web3ProviderFlag = cli.StringFlag{
 		Name:  "web3provider",
-		Usage: "A mainchain web3 provider string endpoint. Can either be an IPC file string or a WebSocket endpoint. Uses WebSockets by default at ws://127.0.0.1:8546. Cannot be an HTTP endpoint.",
-		Value: "ws://127.0.0.1:8546",
+		Usage: "A mainchain web3 provider string endpoint. Can either be an IPC file string or a WebSocket endpoint. Cannot be an HTTP endpoint.",
+		Value: "wss://goerli.prylabs.net/websocket",
 	}
 	// DepositContractFlag defines a flag for the deposit contract address.
 	DepositContractFlag = cli.StringFlag{
@@ -43,11 +43,6 @@ var (
 	GenesisJSON = cli.StringFlag{
 		Name:  "genesis-json",
 		Usage: "Beacon node will bootstrap genesis state defined in genesis.json",
-	}
-	// EnablePOWChain tells the beacon node to use a real web3 endpoint. Disabled by default.
-	EnablePOWChain = cli.BoolFlag{
-		Name:  "enable-powchain",
-		Usage: "Enable a real, web3 proof-of-work chain endpoint in the beacon node",
 	}
 	// EnableDBCleanup tells the beacon node to automatically clean DB content such as block vote cache.
 	EnableDBCleanup = cli.BoolFlag{


### PR DESCRIPTION
Since connecting to POW chain is required to run beacon-chain, remove this flag.

Also sets the default provider to goerli and adds better logging if the user doesnt provide a deposit contract address 