### PR TITLE
Proposer Service: Only return attestations within the last epoch

### DIFF
--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -74,17 +74,18 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve pending attestations from operations service: %v", err)
 	}
+
 	// Remove any attestation from the list if their slot is before the start of
 	// the previous epoch. This should be handled in the operationService cleanup
 	// method, but we should filter here in case it wasn't yet processed.
-	boundary := helpers.StartSlot(helpers.PrevEpoch(beaconState))
-	attsInBoundary := make([]*pbp2p.Attestation, 0, len(atts))
+	lastEpochStartSlot := helpers.StartSlot(helpers.PrevEpoch(beaconState))
+	attsSinceLastEpoch := make([]*pbp2p.Attestation, 0, len(atts))
 	for _, att := range atts {
-		if att.Data.Slot >= boundary {
-			attsInBoundary = append(attsInBoundary, att)
+		if att.Data.Slot >= lastEpochStartSlot {
+			attsSinceLastEpoch = append(attsSinceLastEpoch, att)
 		}
 	}
-	atts = attsInBoundary
+	atts = attsSinceLastEpoch
 
 	if req.FilterReadyForInclusion {
 		var attsReadyForInclusion []*pbp2p.Attestation

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -78,7 +78,7 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 	// the previous epoch. This should be handled in the operationService cleanup
 	// method, but we should filter here in case it wasn't yet processed.
 	boundary := helpers.StartSlot(helpers.PrevEpoch(beaconState))
-	var attsInBoundary []*pbp2p.Attestation
+	attsInBoundary := make([]*pbp2p.Attestation, 0, len(atts))
 	for _, att := range atts {
 		if att.Data.Slot >= boundary {
 			attsInBoundary = append(attsInBoundary, att)

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -74,6 +74,18 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve pending attestations from operations service: %v", err)
 	}
+	// Remove any attestation from the list if their slot is before the start of
+	// the previous epoch. This should be handled in the operationService cleanup
+	// method, but we should filter here in case it wasn't yet processed.
+	boundary := helpers.StartSlot(helpers.PrevEpoch(beaconState))
+	var attsInBoundary []*pbp2p.Attestation
+	for _, att := range atts {
+		if att.Data.Slot >= boundary {
+			attsInBoundary = append(attsInBoundary, att)
+		}
+	}
+	atts = attsInBoundary
+
 	if req.FilterReadyForInclusion {
 		var attsReadyForInclusion []*pbp2p.Attestation
 		for _, val := range atts {

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -29,7 +29,9 @@ func (t *TestLogger) Errorf(format string, args ...interface{}) {
 	t.testMap["error"] = true
 }
 
-type mockOperationService struct{}
+type mockOperationService struct {
+	pendingAttestations []*pb.Attestation
+}
 
 func (ms *mockOperationService) IncomingAttFeed() *event.Feed {
 	return new(event.Feed)
@@ -40,6 +42,9 @@ func (ms *mockOperationService) IncomingExitFeed() *event.Feed {
 }
 
 func (ms *mockOperationService) PendingAttestations() ([]*pb.Attestation, error) {
+	if ms.pendingAttestations != nil {
+		return ms.pendingAttestations, nil
+	}
 	return []*pb.Attestation{
 		{
 			AggregationBitfield: []byte("A"),


### PR DESCRIPTION
There were issues where blocks included expired attestations from proposers, these changes filter out attestations from before the previous epoch. 