### PR TITLE
Implement AttestationTargets for ForkChoice

### DIFF
--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -87,14 +87,14 @@ func (a *Service) IncomingAttestationFeed() *event.Feed {
 //	Let `get_latest_attestation(store: Store, validator_index: ValidatorIndex) ->
 //		Attestation` be the attestation with the highest slot number in `store`
 //		from the validator with the given `validator_index`
-func (a *Service) LatestAttestation(ctx context.Context, index int) (*pb.Attestation, error) {
+func (a *Service) LatestAttestation(ctx context.Context, index uint64) (*pb.Attestation, error) {
 	state, err := a.beaconDB.State(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// return error if it's an invalid validator index.
-	if index >= len(state.ValidatorRegistry) {
+	if index >= uint64(len(state.ValidatorRegistry)) {
 		return nil, fmt.Errorf("invalid validator index %d", index)
 	}
 	pubKey := bytesutil.ToBytes48(state.ValidatorRegistry[index].Pubkey)
@@ -114,7 +114,7 @@ func (a *Service) LatestAttestation(ctx context.Context, index int) (*pb.Attesta
 //	Let `get_latest_attestation_target(store: Store, validator_index: ValidatorIndex) ->
 //		BeaconBlock` be the target block in the attestation
 //		`get_latest_attestation(store, validator_index)`.
-func (a *Service) LatestAttestationTarget(ctx context.Context, index int) (*pb.BeaconBlock, error) {
+func (a *Service) LatestAttestationTarget(ctx context.Context, index uint64) (*pb.BeaconBlock, error) {
 	attestation, err := a.LatestAttestation(ctx, index)
 	if err != nil {
 		return nil, fmt.Errorf("could not get attestation: %v", err)

--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -29,7 +29,7 @@ type Service struct {
 	incomingChan  chan *pb.Attestation
 	// store is the mapping of individual
 	// validator's public key to it's latest attestation.
-	store map[[48]byte]*pb.Attestation
+	Store map[[48]byte]*pb.Attestation
 }
 
 // Config options for the service.
@@ -51,7 +51,7 @@ func NewAttestationService(ctx context.Context, cfg *Config) *Service {
 		broadcastChan: make(chan *pb.Attestation, cfg.BroadcastAttestationBuf),
 		incomingFeed:  new(event.Feed),
 		incomingChan:  make(chan *pb.Attestation, cfg.ReceiveAttestationBuf),
-		store:         make(map[[48]byte]*pb.Attestation),
+		Store:         make(map[[48]byte]*pb.Attestation),
 	}
 }
 
@@ -100,11 +100,11 @@ func (a *Service) LatestAttestation(ctx context.Context, index uint64) (*pb.Atte
 	pubKey := bytesutil.ToBytes48(state.ValidatorRegistry[index].Pubkey)
 
 	// return error if validator has no attestation.
-	if _, exists := a.store[pubKey]; !exists {
+	if _, exists := a.Store[pubKey]; !exists {
 		return nil, fmt.Errorf("validator index %d does not have an attestation", index)
 	}
 
-	return a.store[pubKey], nil
+	return a.Store[pubKey], nil
 }
 
 // LatestAttestationTarget returns the target block the validator index attested to,
@@ -187,12 +187,12 @@ func (a *Service) updateLatestAttestation(ctx context.Context, attestation *pb.A
 		pubkey := bytesutil.ToBytes48(state.ValidatorRegistry[i].Pubkey)
 		newAttestationSlot := attestation.Data.Slot
 		currentAttestationSlot := uint64(0)
-		if _, exists := a.store[pubkey]; exists {
-			currentAttestationSlot = a.store[pubkey].Data.Slot
+		if _, exists := a.Store[pubkey]; exists {
+			currentAttestationSlot = a.Store[pubkey].Data.Slot
 		}
 		// If the attestation is newer than this attester's one in pool.
 		if newAttestationSlot > currentAttestationSlot {
-			a.store[pubkey] = attestation
+			a.Store[pubkey] = attestation
 		}
 	}
 	return nil

--- a/beacon-chain/attestation/service_test.go
+++ b/beacon-chain/attestation/service_test.go
@@ -127,7 +127,7 @@ func TestLatestAttestation_InvalidIndex(t *testing.T) {
 	}
 	service := NewAttestationService(context.Background(), &Config{BeaconDB: beaconDB})
 
-	index := 0
+	index := uint64(0)
 	want := fmt.Sprintf("invalid validator index %d", index)
 	if _, err := service.LatestAttestation(ctx, index); !strings.Contains(err.Error(), want) {
 		t.Errorf("Wanted error to contain %s, received %v", want, err)
@@ -148,7 +148,7 @@ func TestLatestAttestation_NoAttestation(t *testing.T) {
 
 	index := 0
 	want := fmt.Sprintf("validator index %d does not have an attestation", index)
-	if _, err := service.LatestAttestation(ctx, index); !strings.Contains(err.Error(), want) {
+	if _, err := service.LatestAttestation(ctx, uint64(index)); !strings.Contains(err.Error(), want) {
 		t.Errorf("Wanted error to contain %s, received %v", want, err)
 	}
 }
@@ -165,7 +165,7 @@ func TestLatestAttestationTarget_CantGetAttestation(t *testing.T) {
 	}
 	service := NewAttestationService(context.Background(), &Config{BeaconDB: beaconDB})
 
-	index := 100
+	index := uint64(100)
 	want := fmt.Sprintf("could not get attestation: invalid validator index %d", index)
 	if _, err := service.LatestAttestationTarget(ctx, index); !strings.Contains(err.Error(), want) {
 		t.Errorf("Wanted error to contain %s, received %v", want, err)

--- a/beacon-chain/attestation/service_test.go
+++ b/beacon-chain/attestation/service_test.go
@@ -43,20 +43,20 @@ func TestUpdateLatestAttestation_UpdatesLatest(t *testing.T) {
 		t.Fatalf("could not update latest attestation: %v", err)
 	}
 	pubkey := bytesutil.ToBytes48([]byte{'A'})
-	if service.store[pubkey].Data.Slot !=
+	if service.Store[pubkey].Data.Slot !=
 		attestation.Data.Slot {
 		t.Errorf("Incorrect slot stored, wanted: %d, got: %d",
-			attestation.Data.Slot, service.store[pubkey].Data.Slot)
+			attestation.Data.Slot, service.Store[pubkey].Data.Slot)
 	}
 
 	attestation.Data.Slot = 100
 	if err := service.updateLatestAttestation(ctx, attestation); err != nil {
 		t.Fatalf("could not update latest attestation: %v", err)
 	}
-	if service.store[pubkey].Data.Slot !=
+	if service.Store[pubkey].Data.Slot !=
 		attestation.Data.Slot {
 		t.Errorf("Incorrect slot stored, wanted: %d, got: %d",
-			attestation.Data.Slot, service.store[pubkey].Data.Slot)
+			attestation.Data.Slot, service.Store[pubkey].Data.Slot)
 	}
 }
 
@@ -104,7 +104,7 @@ func TestLatestAttestation_ReturnsLatestAttestation(t *testing.T) {
 	service := NewAttestationService(context.Background(), &Config{BeaconDB: beaconDB})
 	pubKey48 := bytesutil.ToBytes48(pubKey)
 	attestation := &pb.Attestation{AggregationBitfield: []byte{'B'}}
-	service.store[pubKey48] = attestation
+	service.Store[pubKey48] = attestation
 
 	latestAttestation, err := service.LatestAttestation(ctx, 0)
 	if err != nil {
@@ -200,7 +200,7 @@ func TestLatestAttestationTarget_ReturnsLatestAttestedBlock(t *testing.T) {
 			BeaconBlockRootHash32: blockRoot[:],
 		}}
 	pubKey48 := bytesutil.ToBytes48(pubKey)
-	service.store[pubKey48] = attestation
+	service.Store[pubKey48] = attestation
 
 	latestAttestedBlock, err := service.LatestAttestationTarget(ctx, 0)
 	if err != nil {

--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/blockchain",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
+        "//beacon-chain/attestation:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",

--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//beacon-chain/attestation:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/attestation"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
@@ -36,6 +37,7 @@ type ChainService struct {
 	cancel               context.CancelFunc
 	beaconDB             *db.BeaconDB
 	web3Service          *powchain.Web3Service
+	attsService          *attestation.Service
 	opsPoolService       operationService
 	incomingBlockFeed    *event.Feed
 	incomingBlockChan    chan *pb.BeaconBlock
@@ -52,10 +54,18 @@ type Config struct {
 	BeaconBlockBuf   int
 	IncomingBlockBuf int
 	Web3Service      *powchain.Web3Service
+	AttsService      *attestation.Service
 	BeaconDB         *db.BeaconDB
 	OpsPoolService   operationService
 	DevMode          bool
 	EnablePOWChain   bool
+}
+
+// attestationTarget consists of validator index and block, it's
+// used to represent which validator index has voted which block.
+type attestationTarget struct {
+	validatorIndex uint64
+	block          *pb.BeaconBlock
 }
 
 // NewChainService instantiates a new service instance that will
@@ -68,6 +78,7 @@ func NewChainService(ctx context.Context, cfg *Config) (*ChainService, error) {
 		beaconDB:             cfg.BeaconDB,
 		web3Service:          cfg.Web3Service,
 		opsPoolService:       cfg.OpsPoolService,
+		attsService:          cfg.AttsService,
 		incomingBlockChan:    make(chan *pb.BeaconBlock, cfg.IncomingBlockBuf),
 		chainStartChan:       make(chan time.Time),
 		incomingBlockFeed:    new(event.Feed),
@@ -419,4 +430,23 @@ func (c *ChainService) deleteValidatorIdx(state *pb.BeaconState) error {
 	}
 	delete(validators.ExitedValidators, helpers.CurrentEpoch(state))
 	return nil
+}
+
+// attestationTargets retrieves the list of attestation targets since last finalized epoch,
+// each attestation target consists of validator index and its attestation target (i.e. the block
+// which the validator attested to)
+func (c *ChainService) attestationTargets(state *pb.BeaconState, beaconDB *db.BeaconDB) ([]*attestationTarget, error) {
+	indices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, state.FinalizedEpoch)
+	attestationTargets := make([]*attestationTarget, len(indices))
+	for i, index := range indices {
+		block, err := c.attsService.LatestAttestationTarget(c.ctx, index)
+		if err != nil {
+			return nil, fmt.Errorf("could not retrieve attestation target: %v", err)
+		}
+		attestationTargets[i] = &attestationTarget{
+			validatorIndex: index,
+			block:          block,
+		}
+	}
+	return attestationTargets, nil
 }

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -435,7 +435,7 @@ func (c *ChainService) deleteValidatorIdx(state *pb.BeaconState) error {
 // attestationTargets retrieves the list of attestation targets since last finalized epoch,
 // each attestation target consists of validator index and its attestation target (i.e. the block
 // which the validator attested to)
-func (c *ChainService) attestationTargets(state *pb.BeaconState, beaconDB *db.BeaconDB) ([]*attestationTarget, error) {
+func (c *ChainService) attestationTargets(state *pb.BeaconState) ([]*attestationTarget, error) {
 	indices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, state.FinalizedEpoch)
 	attestationTargets := make([]*attestationTarget, len(indices))
 	for i, index := range indices {

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/attestation"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
@@ -189,7 +190,7 @@ func setupGenesisBlock(t *testing.T, cs *ChainService, beaconState *pb.BeaconSta
 	return parentHash, genesis
 }
 
-func setupBeaconChain(t *testing.T, faultyPoWClient bool, beaconDB *db.BeaconDB, enablePOWChain bool) *ChainService {
+func setupBeaconChain(t *testing.T, faultyPoWClient bool, beaconDB *db.BeaconDB, enablePOWChain bool, attsService *attestation.Service) *ChainService {
 	endpoint := "ws://127.0.0.1"
 	ctx := context.Background()
 	var web3Service *powchain.Web3Service
@@ -225,6 +226,7 @@ func setupBeaconChain(t *testing.T, faultyPoWClient bool, beaconDB *db.BeaconDB,
 		Web3Service:    web3Service,
 		OpsPoolService: &mockOperationService{},
 		EnablePOWChain: enablePOWChain,
+		AttsService:    attsService,
 	}
 	if err != nil {
 		t.Fatalf("could not register blockchain service: %v", err)
@@ -251,7 +253,7 @@ func TestChainStartStop_Uninitialized(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
-	chainService := setupBeaconChain(t, false, db, true)
+	chainService := setupBeaconChain(t, false, db, true, nil)
 
 	chainService.IncomingBlockFeed()
 
@@ -286,7 +288,7 @@ func TestChainStartStop_UninitializedAndNoPOWChain(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
-	chainService := setupBeaconChain(t, false, db, false)
+	chainService := setupBeaconChain(t, false, db, false, nil)
 
 	origExitFunc := logrus.StandardLogger().ExitFunc
 	defer func() { logrus.StandardLogger().ExitFunc = origExitFunc }()
@@ -307,7 +309,7 @@ func TestChainStartStop_Initialized(t *testing.T) {
 	defer internal.TeardownDB(t, db)
 	ctx := context.Background()
 
-	chainService := setupBeaconChain(t, false, db, true)
+	chainService := setupBeaconChain(t, false, db, true, nil)
 
 	unixTime := uint64(time.Now().Unix())
 	deposits, _ := setupInitialDeposits(t, 100)
@@ -337,7 +339,7 @@ func TestChainService_FaultyPOWChain(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
-	chainService := setupBeaconChain(t, true, db, true)
+	chainService := setupBeaconChain(t, true, db, true, nil)
 	unixTime := uint64(time.Now().Unix())
 	deposits, _ := setupInitialDeposits(t, 100)
 	if err := db.InitializeState(unixTime, deposits, &pb.Eth1Data{}); err != nil {
@@ -391,7 +393,7 @@ func TestChainService_Starts(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
-	chainService := setupBeaconChain(t, false, db, true)
+	chainService := setupBeaconChain(t, false, db, true, nil)
 	deposits, privKeys := setupInitialDeposits(t, 100)
 	eth1Data := &pb.Eth1Data{
 		DepositRootHash32: []byte{},
@@ -450,7 +452,7 @@ func TestReceiveBlock_RemovesPendingDeposits(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
-	chainService := setupBeaconChain(t, false, db, true)
+	chainService := setupBeaconChain(t, false, db, true, nil)
 	deposits, privKeys := setupInitialDeposits(t, 100)
 	eth1Data := &pb.Eth1Data{
 		DepositRootHash32: []byte{},
@@ -527,7 +529,7 @@ func TestPOWBlockExists_UsingDepositRootHash(t *testing.T) {
 	defer internal.TeardownDB(t, db)
 	ctx := context.Background()
 
-	chainService := setupBeaconChain(t, true, db, true)
+	chainService := setupBeaconChain(t, true, db, true, nil)
 	unixTime := uint64(time.Now().Unix())
 	deposits, _ := setupInitialDeposits(t, 10)
 	eth1Data := &pb.Eth1Data{
@@ -600,7 +602,7 @@ func TestUpdateHead_SavesBlock(t *testing.T) {
 		hook := logTest.NewGlobal()
 		db := internal.SetupDB(t)
 		defer internal.TeardownDB(t, db)
-		chainService := setupBeaconChain(t, false, db, true)
+		chainService := setupBeaconChain(t, false, db, true, nil)
 		unixTime := uint64(time.Now().Unix())
 		deposits, _ := setupInitialDeposits(t, 100)
 		if err := db.InitializeState(unixTime, deposits, &pb.Eth1Data{}); err != nil {
@@ -640,7 +642,7 @@ func TestIsBlockReadyForProcessing_ValidBlock(t *testing.T) {
 	defer internal.TeardownDB(t, db)
 	ctx := context.Background()
 
-	chainService := setupBeaconChain(t, false, db, true)
+	chainService := setupBeaconChain(t, false, db, true, nil)
 	unixTime := uint64(time.Now().Unix())
 	deposits, privKeys := setupInitialDeposits(t, 100)
 	if err := db.InitializeState(unixTime, deposits, &pb.Eth1Data{}); err != nil {
@@ -729,7 +731,7 @@ func TestDeleteValidatorIdx_DeleteWorks(t *testing.T) {
 		ValidatorRegistry: validators,
 		Slot:              epoch * params.BeaconConfig().SlotsPerEpoch,
 	}
-	chainService := setupBeaconChain(t, false, db, true)
+	chainService := setupBeaconChain(t, false, db, true, nil)
 	if err := chainService.saveValidatorIdx(state); err != nil {
 		t.Fatalf("Could not save validator idx: %v", err)
 	}
@@ -772,7 +774,7 @@ func TestSaveValidatorIdx_SaveRetrieveWorks(t *testing.T) {
 		ValidatorRegistry: validators,
 		Slot:              epoch * params.BeaconConfig().SlotsPerEpoch,
 	}
-	chainService := setupBeaconChain(t, false, db, true)
+	chainService := setupBeaconChain(t, false, db, true, nil)
 	if err := chainService.saveValidatorIdx(state); err != nil {
 		t.Fatalf("Could not save validator idx: %v", err)
 	}
@@ -788,5 +790,53 @@ func TestSaveValidatorIdx_SaveRetrieveWorks(t *testing.T) {
 
 	if _, ok := v.ActivatedValidators[epoch]; ok {
 		t.Errorf("Activated validators mapping for epoch %d still there", epoch)
+	}
+}
+
+func TestAttestationTargets_RetrieveWorks(t *testing.T) {
+	beaconDB := internal.SetupDB(t)
+	defer internal.TeardownDB(t, beaconDB)
+
+	pubKey := []byte{'A'}
+	state := &pb.BeaconState{
+		ValidatorRegistry: []*pb.Validator{{
+			Pubkey:    pubKey,
+			ExitEpoch: params.BeaconConfig().FarFutureEpoch}},
+	}
+
+	if err := beaconDB.SaveState(state); err != nil {
+		t.Fatalf("could not save state: %v", err)
+	}
+
+	block := &pb.BeaconBlock{Slot: 100}
+	if err := beaconDB.SaveBlock(block); err != nil {
+		t.Fatalf("could not save block: %v", err)
+	}
+	blockRoot, err := hashutil.HashBeaconBlock(block)
+	if err != nil {
+		log.Fatalf("could not hash block: %v", err)
+	}
+
+	attsService := attestation.NewAttestationService(
+		context.Background(),
+		&attestation.Config{BeaconDB: beaconDB})
+
+	atts := &pb.Attestation{
+		Data: &pb.AttestationData{
+			BeaconBlockRootHash32: blockRoot[:],
+		}}
+	pubKey48 := bytesutil.ToBytes48(pubKey)
+	attsService.Store[pubKey48] = atts
+
+	chainService := setupBeaconChain(t, false, beaconDB, true, attsService)
+	attestationTargets, err := chainService.attestationTargets(state)
+	if err != nil {
+		t.Fatalf("Could not get attestation targets: %v", err)
+	}
+	if attestationTargets[0].validatorIndex != 0 {
+		t.Errorf("Wanted validator index 0, got %d", attestationTargets[0].validatorIndex)
+	}
+	if attestationTargets[0].block.Slot != block.Slot {
+		t.Errorf("Wanted attested slot %d, got %d", block.Slot, attestationTargets[0].block.Slot)
 	}
 }

--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/node",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
+        "//beacon-chain/attestation:go_default_library",
         "//beacon-chain/blockchain:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/operations:go_default_library",


### PR DESCRIPTION
This PR implements attestation targets for fork choice, attestation targets a list of `validator index` and its `latest attested block` struct and they are tracked up to the last finalized epoch:

`[(V1 attested block2),(V2 attested block 3),(V3 attested block1)...]`

This was missing before and it is needed to calculate vote count to find fork choice head 

