### PR TITLE
Fix off by one edge case for pending attestations

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -457,7 +457,7 @@ func verifyAttestation(beaconState *pb.BeaconState, att *pb.Attestation, verifyS
 			beaconState.Slot-params.BeaconConfig().GenesisSlot,
 		)
 	}
-	if att.Data.Slot+params.BeaconConfig().SlotsPerEpoch <= beaconState.Slot {
+	if att.Data.Slot+params.BeaconConfig().SlotsPerEpoch < beaconState.Slot {
 		return fmt.Errorf(
 			"attestation slot (slot %d) + epoch length (%d) less than current beacon state slot (%d)",
 			att.Data.Slot-params.BeaconConfig().GenesisSlot,

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -78,7 +78,8 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 	// Remove any attestation from the list if their slot is before the start of
 	// the previous epoch. This should be handled in the operationService cleanup
 	// method, but we should filter here in case it wasn't yet processed.
-	lastEpochStartSlot := helpers.StartSlot(helpers.PrevEpoch(beaconState) + 1)
+	beaconState.Slot += 1
+	lastEpochStartSlot := helpers.StartSlot(helpers.PrevEpoch(beaconState))
 	attsSinceLastEpoch := make([]*pbp2p.Attestation, 0, len(atts))
 	for _, att := range atts {
 		if att.Data.Slot >= lastEpochStartSlot {

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -78,7 +78,7 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 	// Remove any attestation from the list if their slot is before the start of
 	// the previous epoch. This should be handled in the operationService cleanup
 	// method, but we should filter here in case it wasn't yet processed.
-	lastEpochStartSlot := helpers.StartSlot(helpers.PrevEpoch(beaconState))
+	lastEpochStartSlot := helpers.StartSlot(helpers.PrevEpoch(beaconState) + 1)
 	attsSinceLastEpoch := make([]*pbp2p.Attestation, 0, len(atts))
 	for _, att := range atts {
 		if att.Data.Slot >= lastEpochStartSlot {

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -78,7 +78,7 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 	// Remove any attestation from the list if their slot is before the start of
 	// the previous epoch. This should be handled in the operationService cleanup
 	// method, but we should filter here in case it wasn't yet processed.
-	beaconState.Slot += 1
+	beaconState.Slot++
 	lastEpochStartSlot := helpers.StartSlot(helpers.PrevEpoch(beaconState))
 	attsSinceLastEpoch := make([]*pbp2p.Attestation, 0, len(atts))
 	for _, att := range atts {

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -49,19 +49,19 @@ func (ms *mockOperationService) PendingAttestations() ([]*pb.Attestation, error)
 		{
 			AggregationBitfield: []byte("A"),
 			Data: &pb.AttestationData{
-				Slot: params.BeaconConfig().GenesisSlot,
+				Slot: params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch,
 			},
 		},
 		{
 			AggregationBitfield: []byte("B"),
 			Data: &pb.AttestationData{
-				Slot: params.BeaconConfig().GenesisSlot,
+				Slot: params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch,
 			},
 		},
 		{
 			AggregationBitfield: []byte("C"),
 			Data: &pb.AttestationData{
-				Slot: params.BeaconConfig().GenesisSlot,
+				Slot: params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch,
 			},
 		},
 	}, nil


### PR DESCRIPTION
Scenario:

- The current slot in the beacon chain is last slot in an epoch
- A validator is requesting attestations to include in a the next block (which will be in the next epoch)
- The pending attestations, which were valid for the current slot, may not be valid for the next epoch

Solution:

- Increment the beacon slot before determining the boundary. If the current slot isn't the last slot in an epoch, this has no effect. If it is the last slot in an epoch, it correctly changes the boundary window for the proposer inclusion of attestations. 