### PR TITLE
Fix WaitForActivation Race Condition

### DIFF
--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
@@ -45,6 +46,7 @@ func (vs *ValidatorServer) WaitForActivation(req *pb.ValidatorActivationRequest,
 	defer sub.Unsubscribe()
 	for {
 		select {
+		case <-time.After(3*time.Second):
 		case beaconState := <-vs.canonicalStateChan:
 			if !vs.beaconDB.HasValidator(req.Pubkey) {
 				continue


### PR DESCRIPTION
No tracking issue.

---

# Description

**Write why you are making the changes in this pull request**

This PR fixes a problem we had in that wait for activation would sometimes get stuck waiting for a canonical state. What we do instead is to trigger a time.After channel that reattempts verifying activation every 3 seconds in case the system gets stuck.
