### PR TITLE
Fix attestations again

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -457,7 +457,7 @@ func verifyAttestation(beaconState *pb.BeaconState, att *pb.Attestation, verifyS
 			beaconState.Slot-params.BeaconConfig().GenesisSlot,
 		)
 	}
-	if att.Data.Slot+params.BeaconConfig().SlotsPerEpoch < beaconState.Slot {
+	if att.Data.Slot+params.BeaconConfig().SlotsPerEpoch <= beaconState.Slot {
 		return fmt.Errorf(
 			"attestation slot (slot %d) + epoch length (%d) less than current beacon state slot (%d)",
 			att.Data.Slot-params.BeaconConfig().GenesisSlot,

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -78,15 +78,14 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 	// Remove any attestation from the list if their slot is before the start of
 	// the previous epoch. This should be handled in the operationService cleanup
 	// method, but we should filter here in case it wasn't yet processed.
-	beaconState.Slot++
-	lastEpochStartSlot := helpers.StartSlot(helpers.PrevEpoch(beaconState))
-	attsSinceLastEpoch := make([]*pbp2p.Attestation, 0, len(atts))
+	boundary := beaconState.Slot - params.BeaconConfig().SlotsPerEpoch
+	attsWithinBoundary := make([]*pbp2p.Attestation, 0, len(atts))
 	for _, att := range atts {
-		if att.Data.Slot >= lastEpochStartSlot {
-			attsSinceLastEpoch = append(attsSinceLastEpoch, att)
+		if att.Data.Slot > boundary {
+			attsWithinBoundary = append(attsWithinBoundary, att)
 		}
 	}
-	atts = attsSinceLastEpoch
+	atts = attsWithinBoundary
 
 	if req.FilterReadyForInclusion {
 		var attsReadyForInclusion []*pbp2p.Attestation


### PR DESCRIPTION
So the actual desired behavior is that we want the attestations that are between `MinAttestationInclusionDelay` (4) and `SlotsPerEpoch` (64) slots behind the slot of the propose block slot.

