### PR TITLE
Remove Incorrect Error Logs in Sync

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 )
 
 var log = logrus.WithField("prefix", "initial-sync")
+var debugError = "debug:"
 
 // Config defines the configurable properties of InitialSync.
 //
@@ -322,6 +324,11 @@ func (s *InitialSync) processBlock(ctx context.Context, block *pb.BeaconBlock, p
 		// if parent exists we validate the block.
 		if s.doesParentExist(block) {
 			if err := s.validateAndSaveNextBlock(ctx, block); err != nil {
+				// Debug error so as not to have noisy error logs
+				if strings.HasPrefix(err.Error(), debugError) {
+					log.Debug(strings.TrimPrefix(err.Error(), debugError))
+					return
+				}
 				log.Errorf("Unable to save block: %v", err)
 			}
 			return
@@ -335,6 +342,11 @@ func (s *InitialSync) processBlock(ctx context.Context, block *pb.BeaconBlock, p
 	}
 
 	if err := s.validateAndSaveNextBlock(ctx, block); err != nil {
+		// Debug error so as not to have noisy error logs
+		if strings.HasPrefix(err.Error(), debugError) {
+			log.Debug(strings.TrimPrefix(err.Error(), debugError))
+			return
+		}
 		log.Errorf("Unable to save block: %v", err)
 	}
 }
@@ -483,9 +495,8 @@ func (s *InitialSync) checkBlockValidity(ctx context.Context, block *pb.BeaconBl
 		return fmt.Errorf("could not tree hash received block: %v", err)
 	}
 
-	log.Debugf("Processing response to block request: %#x", blockRoot)
 	if s.db.HasBlock(blockRoot) {
-		return errors.New("received a block that already exists. Exiting")
+		return errors.New(debugError + "received a block that already exists. Exiting")
 	}
 
 	beaconState, err := s.db.State(ctx)
@@ -494,7 +505,7 @@ func (s *InitialSync) checkBlockValidity(ctx context.Context, block *pb.BeaconBl
 	}
 
 	if block.Slot < beaconState.FinalizedEpoch*params.BeaconConfig().SlotsPerEpoch {
-		return errors.New("discarding received block with a slot number smaller than the last finalized slot")
+		return errors.New(debugError + "discarding received block with a slot number smaller than the last finalized slot")
 	}
 	// Attestation from proposer not verified as, other nodes only store blocks not proposer
 	// attestations.

--- a/validator/client/validator_propose_test.go
+++ b/validator/client/validator_propose_test.go
@@ -265,13 +265,10 @@ func TestProposeBlock_PendingAttestations_UsesCurrentSlot(t *testing.T) {
 		StateRoot: []byte{'F'},
 	}, nil /*err*/)
 
-	var broadcastedBlock *pbp2p.BeaconBlock
 	m.proposerClient.EXPECT().ProposeBlock(
 		gomock.Any(), // context
 		gomock.AssignableToTypeOf(&pbp2p.BeaconBlock{}),
-	).Do(func(_ context.Context, blk *pbp2p.BeaconBlock) {
-		broadcastedBlock = blk
-	}).Return(&pb.ProposeResponse{}, nil /*error*/)
+	).Return(&pb.ProposeResponse{}, nil /*error*/)
 
 	validator.ProposeBlock(context.Background(), 55)
 	if req.ProposalBlockSlot != 55 {


### PR DESCRIPTION
This changes the error logs to a debug log by adding a debug prefix