### PR TITLE
Fix Hashing Errors in Sync

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -279,7 +279,10 @@ func (c *ChainService) ApplyForkChoiceRule(block *pb.BeaconBlock, computedState 
 	if block.Slot%params.BeaconConfig().SlotsPerEpoch == 0 {
 		c.canonicalStateFeed.Send(computedState)
 	}
-	c.canonicalBlockFeed.Send(block)
+	c.canonicalBlockFeed.Send(&pb.BeaconBlockAnnounce{
+		Hash:       h[:],
+		SlotNumber: block.Slot,
+	})
 	return nil
 }
 

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -91,7 +91,7 @@ func ProcessBlock(
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock")
 	defer span.End()
 
-	r, err := hashutil.HashProto(block)
+	r, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		return nil, fmt.Errorf("could not hash block: %v", err)
 	}


### PR DESCRIPTION
We use `hashProto` instead of `hashBeaconBlock` which leads to an incorrect hash being announced. This PR fixes that by instead sending only the `blockAnnounce` data needed to be broadcasted from chain service and also  removing any other references to using HashProto for a block