### PR TITLE
Minor fixes to beaconchain service

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -276,10 +276,14 @@ func (c *ChainService) ApplyForkChoiceRule(block *pb.BeaconBlock, computedState 
 	// server to stream these events to beacon clients.
 	// When the transition is a cycle transition, we stream the state containing the new validator
 	// assignments to clients.
-	if block.Slot%params.BeaconConfig().SlotsPerEpoch == 0 {
-		c.canonicalStateFeed.Send(computedState)
+	if helpers.IsEpochStart(block.Slot) {
+		if c.canonicalStateFeed.Send(computedState) == 0 {
+			log.Error("Sent canonical state to no subscribers")
+		}
 	}
-	c.canonicalBlockFeed.Send(block)
+	if c.canonicalBlockFeed.Send(block) == 0 {
+		log.Error("Sent canonical block to no subscribers")
+	}
 	return nil
 }
 
@@ -332,6 +336,7 @@ func (c *ChainService) ReceiveBlock(block *pb.BeaconBlock, beaconState *pb.Beaco
 		"Executing state transition")
 
 	// Check for skipped slots.
+	numSkippedSlots := 0
 	for beaconState.Slot < block.Slot-1 {
 		beaconState, err = state.ExecuteStateTransition(
 			c.ctx,
@@ -346,6 +351,10 @@ func (c *ChainService) ReceiveBlock(block *pb.BeaconBlock, beaconState *pb.Beaco
 		log.WithField(
 			"slotsSinceGenesis", beaconState.Slot-params.BeaconConfig().GenesisSlot,
 		).Info("Slot transition successfully processed")
+		numSkippedSlots++
+	}
+	if numSkippedSlots > 0 {
+		log.Warnf("Processed %d skipped slots", numSkippedSlots)
 	}
 
 	beaconState, err = state.ExecuteStateTransition(
@@ -364,7 +373,7 @@ func (c *ChainService) ReceiveBlock(block *pb.BeaconBlock, beaconState *pb.Beaco
 	log.WithField(
 		"slotsSinceGenesis", beaconState.Slot-params.BeaconConfig().GenesisSlot,
 	).Info("Block transition successfully processed")
-	if (beaconState.Slot+1)%params.BeaconConfig().SlotsPerEpoch == 0 {
+	if helpers.IsEpochEnd(beaconState.Slot) {
 		// Save activated validators of this epoch to public key -> index DB.
 		if err := c.saveValidatorIdx(beaconState); err != nil {
 			return nil, fmt.Errorf("could not save validator index: %v", err)

--- a/beacon-chain/core/blocks/validity_conditions.go
+++ b/beacon-chain/core/blocks/validity_conditions.go
@@ -72,9 +72,10 @@ func IsSlotValid(slot uint64, genesisTime time.Time) bool {
 	secondsPerSlot := time.Duration((slot-params.BeaconConfig().GenesisSlot)*params.BeaconConfig().SecondsPerSlot) * time.Second
 	validTimeThreshold := genesisTime.Add(secondsPerSlot)
 	now := clock.Now()
-	if !now.After(validTimeThreshold) {
+	isValid := now.After(validTimeThreshold)
+	if !isValid {
 		log.Infof("Waiting for slot to be valid. local clock: %v, genesis+slot: %v",
 			now, validTimeThreshold)
 	}
-	return now.After(validTimeThreshold)
+	return isValid
 }

--- a/beacon-chain/core/helpers/slot_epoch.go
+++ b/beacon-chain/core/helpers/slot_epoch.go
@@ -60,3 +60,15 @@ func StartSlot(epoch uint64) uint64 {
 func AttestationCurrentEpoch(att *pb.AttestationData) uint64 {
 	return SlotToEpoch(att.Slot)
 }
+
+// IsEpochStart returns true if the given slot number is an epoch starting slot
+// number.
+func IsEpochStart(slot uint64) bool {
+	return slot%params.BeaconConfig().SlotsPerEpoch == 0
+}
+
+// IsEpochEnd returns true if the given slot number is an epoch ending slot
+// number.
+func IsEpochEnd(slot uint64) bool {
+	return IsEpochStart(slot + 1)
+}

--- a/beacon-chain/core/helpers/slot_epoch_test.go
+++ b/beacon-chain/core/helpers/slot_epoch_test.go
@@ -113,3 +113,63 @@ func TestAttestationCurrentEpoch_OK(t *testing.T) {
 		}
 	}
 }
+
+func TestIsEpochStart(t *testing.T) {
+	epochLength := params.BeaconConfig().SlotsPerEpoch
+
+	tests := []struct {
+		slot   uint64
+		result bool
+	}{
+		{
+			slot:   epochLength + 1,
+			result: false,
+		},
+		{
+			slot:   epochLength - 1,
+			result: false,
+		},
+		{
+			slot:   epochLength,
+			result: true,
+		},
+		{
+			slot:   epochLength * 2,
+			result: true,
+		},
+	}
+
+	for _, tt := range tests {
+		if IsEpochStart(tt.slot) != tt.result {
+			t.Errorf("IsEpochStart(%d) = %v, wanted %v", tt.slot, IsEpochStart(tt.slot), tt.result)
+		}
+	}
+}
+
+func TestIsEpochEnd(t *testing.T) {
+	epochLength := params.BeaconConfig().SlotsPerEpoch
+
+	tests := []struct {
+		slot   uint64
+		result bool
+	}{
+		{
+			slot:   epochLength + 1,
+			result: false,
+		},
+		{
+			slot:   epochLength,
+			result: false,
+		},
+		{
+			slot:   epochLength - 1,
+			result: true,
+		},
+	}
+
+	for _, tt := range tests {
+		if IsEpochEnd(tt.slot) != tt.result {
+			t.Errorf("IsEpochEnd(%d) = %v, wanted %v", tt.slot, IsEpochEnd(tt.slot), tt.result)
+		}
+	}
+}

--- a/k8s/beacon-chain/beacon-chain.deploy.yaml
+++ b/k8s/beacon-chain/beacon-chain.deploy.yaml
@@ -36,7 +36,7 @@ spec:
                 topologyKey: failure-domain.beta.kubernetes.io/zone
       containers:
         - name: beacon-chain
-          image: gcr.io/prysmaticlabs/prysm/beacon-chain@sha256:a8f6acb67d0eaf0c5f4a118bd65fb411cf11f71e02f9912893a4540daa678417
+          image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
           args: 
             - --web3provider=ws://public-rpc-nodes.pow.svc.cluster.local:8546
             #- --verbosity=debug


### PR DESCRIPTION
- [x] Add helpers.IsEpochStart for readability
- [x] Add helpers.IsEpochEnd for readability
- [x] Log an error if the canonical block/state feeds ever send a message to no subscribers
- [x] Log a warning any time there are skipped blocks in block processing 
- [x] Remove redundant calculation of now.After(validTimeThreshold)
- [x] Revert a change I made to the beacon-chain k8s image tag back to latest