### PR TITLE
Avoid logging large number when justified epochs don't match

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -472,16 +472,16 @@ func verifyAttestation(beaconState *pb.BeaconState, att *pb.Attestation, verifyS
 		if att.Data.JustifiedEpoch != beaconState.JustifiedEpoch {
 			return fmt.Errorf(
 				"expected attestation.JustifiedEpoch == state.JustifiedEpoch, received %d == %d",
-				att.Data.JustifiedEpoch,
-				beaconState.JustifiedEpoch,
+				att.Data.JustifiedEpoch - params.BeaconConfig().GenesisEpoch,
+				beaconState.JustifiedEpoch - params.BeaconConfig().GenesisEpoch,
 			)
 		}
 	} else {
 		if att.Data.JustifiedEpoch != beaconState.PreviousJustifiedEpoch {
 			return fmt.Errorf(
 				"expected attestation.JustifiedEpoch == state.PreviousJustifiedEpoch, received %d == %d",
-				att.Data.JustifiedEpoch,
-				beaconState.PreviousJustifiedEpoch,
+				att.Data.JustifiedEpoch - params.BeaconConfig().GenesisEpoch,
+				beaconState.PreviousJustifiedEpoch - params.BeaconConfig().GenesisEpoch,
 			)
 		}
 	}

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -776,7 +776,7 @@ func TestProcessBlockAttestations_JustifiedEpochVerificationFailure(t *testing.T
 		{
 			Data: &pb.AttestationData{
 				Slot:           params.BeaconConfig().GenesisSlot + 152,
-				JustifiedEpoch: 2,
+				JustifiedEpoch: params.BeaconConfig().GenesisEpoch + 2,
 			},
 		},
 	}
@@ -787,7 +787,7 @@ func TestProcessBlockAttestations_JustifiedEpochVerificationFailure(t *testing.T
 	}
 	state := &pb.BeaconState{
 		Slot:           params.BeaconConfig().GenesisSlot + 158,
-		JustifiedEpoch: 1,
+		JustifiedEpoch: params.BeaconConfig().GenesisEpoch + 1,
 	}
 
 	want := fmt.Sprintf(
@@ -810,7 +810,7 @@ func TestProcessBlockAttestations_PreviousJustifiedEpochVerificationFailure(t *t
 		{
 			Data: &pb.AttestationData{
 				Slot:           params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch + 1,
-				JustifiedEpoch: 3,
+				JustifiedEpoch: params.BeaconConfig().GenesisEpoch + 3,
 			},
 		},
 	}
@@ -821,7 +821,7 @@ func TestProcessBlockAttestations_PreviousJustifiedEpochVerificationFailure(t *t
 	}
 	state := &pb.BeaconState{
 		Slot:                   params.BeaconConfig().GenesisSlot + 2*params.BeaconConfig().SlotsPerEpoch,
-		PreviousJustifiedEpoch: 2,
+		PreviousJustifiedEpoch: params.BeaconConfig().GenesisEpoch + 2,
 	}
 
 	want := fmt.Sprintf(


### PR DESCRIPTION
Log `JustifiedEpoch - params.BeaconConfig().GenesisEpoch` instead of `JustifiedEpoch`