### PR TITLE
Only run renovate on Mondays

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-    "schedule:daily"
+    "schedule:earlyMondays"
   ],
   "ignoreDeps": [
     "com_github_aws_aws_sdk_go" 


### PR DESCRIPTION
This runs on Mondays before 3am. ~I think~ this is in ~CET or~ UTC.

Preset: https://github.com/renovatebot/presets/blob/e42344569d441ce90962da73a5bf6fd43e378448/packages/renovate-config-schedule/package.json#L12

