### PR TITLE
Return loopback address when disconnected from network

### DIFF
--- a/shared/iputils/BUILD.bazel
+++ b/shared/iputils/BUILD.bazel
@@ -11,4 +11,5 @@ go_test(
     name = "go_default_test",
     srcs = ["external_ip_test.go"],
     embed = [":go_default_library"],
+    tags = ["requires-network"],
 )

--- a/shared/iputils/external_ip.go
+++ b/shared/iputils/external_ip.go
@@ -1,7 +1,7 @@
 package iputils
 
 import (
-	"errors"
+	"fmt"
 	"net"
 )
 
@@ -11,6 +11,7 @@ func ExternalIPv4() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	for _, iface := range ifaces {
 		if iface.Flags&net.FlagUp == 0 {
 			continue // interface down
@@ -30,6 +31,7 @@ func ExternalIPv4() (string, error) {
 			case *net.IPAddr:
 				ip = v.IP
 			}
+			fmt.Print(ip)
 			if ip == nil || ip.IsLoopback() {
 				continue
 			}
@@ -40,5 +42,5 @@ func ExternalIPv4() (string, error) {
 			return ip.String(), nil
 		}
 	}
-	return "", errors.New("are you connected to the network?")
+	return "127.0.0.1", nil
 }

--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "service_test.go",
     ],
     embed = [":go_default_library"],
+    tags = ["block-network"],
     deps = [
         "//proto/sharding/p2p/v1:go_default_library",
         "//proto/testing:go_default_library",
@@ -89,6 +90,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     race = "off",  # TODO(#377): fix issues with race detection testing.
+    tags = ["requires-network"],
     deps = [
         "@com_github_libp2p_go_libp2p//p2p/host/basic:go_default_library",
         "@com_github_libp2p_go_libp2p_swarm//testing:go_default_library",

--- a/shared/p2p/discovery_norace_test.go
+++ b/shared/p2p/discovery_norace_test.go
@@ -25,7 +25,7 @@ func expectPeers(t *testing.T, h *bhost.BasicHost, n int) {
 }
 
 func TestStartDiscovery_PeerFound(t *testing.T) {
-	discoveryInterval = 50 * time.Millisecond // Short interval for testing.
+	discoveryInterval = 100 * time.Millisecond // Short interval for testing.
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()

--- a/shared/p2p/discovery_norace_test.go
+++ b/shared/p2p/discovery_norace_test.go
@@ -25,7 +25,7 @@ func expectPeers(t *testing.T, h *bhost.BasicHost, n int) {
 }
 
 func TestStartDiscovery_PeerFound(t *testing.T) {
-	discoveryInterval = 100 * time.Millisecond // Short interval for testing.
+	discoveryInterval = 50 * time.Millisecond // Short interval for testing.
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()


### PR DESCRIPTION
Resolves #1524. The discovery tests require some network attached device, as far as I can tell. 

I've added `requires-network` tag to p2p tests to indicate it is required