### PR TITLE
Clear validator assignments on failure

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -139,6 +139,7 @@ func (v *validator) UpdateAssignments(ctx context.Context, slot uint64) error {
 
 	resp, err := v.validatorClient.CommitteeAssignment(ctx, req)
 	if err != nil {
+		v.assignment = nil // Clear assignments so we know to retry the request.
 		return err
 	}
 

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -283,6 +283,7 @@ func TestUpdateAssignments_ReturnsError(t *testing.T) {
 	v := validator{
 		key:             validatorKey,
 		validatorClient: client,
+		assignment:      &pb.CommitteeAssignmentResponse{Shard: 1},
 	}
 
 	expected := errors.New("bad")
@@ -294,6 +295,9 @@ func TestUpdateAssignments_ReturnsError(t *testing.T) {
 
 	if err := v.UpdateAssignments(context.Background(), params.BeaconConfig().SlotsPerEpoch); err != expected {
 		t.Errorf("Bad error; want=%v got=%v", expected, err)
+	}
+	if v.assignment != nil {
+		t.Error("Assignments should have been cleared on failure")
 	}
 }
 


### PR DESCRIPTION
Otherwise the validator will wait until the next epoch to ask for assignments.

This probably can be improved further with retry, but it's better than it was. 