### PR TITLE
Avoid Logging Block Processing for RPC call

### DIFF
--- a/beacon-chain/blockchain/block_processing.go
+++ b/beacon-chain/blockchain/block_processing.go
@@ -127,7 +127,8 @@ func (c *ChainService) runStateTransition(
 		beaconState,
 		block,
 		headRoot,
-		true, /* sig verify */
+		true,  /* sig verify */
+		false, /* rpc calls */
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not execute state transition %v", err)

--- a/beacon-chain/blockchain/stategenerator/state_generator.go
+++ b/beacon-chain/blockchain/stategenerator/state_generator.go
@@ -44,6 +44,7 @@ func GenerateStateFromSlot(ctx context.Context, db *db.BeaconDB, slot uint64) (*
 				nil,
 				root,
 				true, /* sig verify */
+				true, /* rpc calls */
 			)
 			if err != nil {
 				return nil, fmt.Errorf("could not execute state transition %v", err)
@@ -57,6 +58,7 @@ func GenerateStateFromSlot(ctx context.Context, db *db.BeaconDB, slot uint64) (*
 			blk,
 			root,
 			true, /* sig verify */
+			true, /* rpc calls */
 		)
 		if err != nil {
 			return nil, fmt.Errorf("could not execute state transition %v", err)

--- a/beacon-chain/chaintest/backend/simulated_backend.go
+++ b/beacon-chain/chaintest/backend/simulated_backend.go
@@ -110,6 +110,7 @@ func (sb *SimulatedBackend) GenerateBlockAndAdvanceChain(objects *SimulatedObjec
 		newBlock,
 		prevBlockRoot,
 		false, /*  no sig verify */
+		false, /* rpc calls */
 	)
 	if err != nil {
 		return fmt.Errorf("could not execute state transition: %v", err)
@@ -134,6 +135,7 @@ func (sb *SimulatedBackend) GenerateNilBlockAndAdvanceChain() error {
 		nil,
 		prevBlockRoot,
 		false, /* no sig verify */
+		false, /* rpc calls */
 	)
 	if err != nil {
 		return fmt.Errorf("could not execute state transition: %v", err)

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -67,7 +67,7 @@ func TestProcessBlock_IncorrectSlot(t *testing.T) {
 		4,
 		5,
 	)
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false); !strings.Contains(err.Error(), want) {
+	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false, true); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
@@ -95,7 +95,7 @@ func TestProcessBlock_IncorrectProposerSlashing(t *testing.T) {
 		},
 	}
 	want := "could not verify block proposer slashing"
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false); !strings.Contains(err.Error(), want) {
+	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false, true); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
@@ -139,7 +139,7 @@ func TestProcessBlock_IncorrectAttesterSlashing(t *testing.T) {
 		},
 	}
 	want := "could not verify block attester slashing"
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false); !strings.Contains(err.Error(), want) {
+	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false, true); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
@@ -207,7 +207,7 @@ func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 		},
 	}
 	want := "could not process block attestations"
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false); !strings.Contains(err.Error(), want) {
+	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false, true); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
@@ -299,7 +299,7 @@ func TestProcessBlock_IncorrectProcessExits(t *testing.T) {
 		},
 	}
 	want := "could not process validator exits"
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false); !strings.Contains(err.Error(), want) {
+	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false, true); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
@@ -392,7 +392,7 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 			VoluntaryExits:    exits,
 		},
 	}
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false); err != nil {
+	if _, err := state.ProcessBlock(context.Background(), beaconState, block, false, true); err != nil {
 		t.Errorf("Expected block to pass processing conditions: %v", err)
 	}
 }

--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -53,7 +53,12 @@ func (as *AttesterServer) AttestationDataAtSlot(ctx context.Context, req *pb.Att
 	}
 	for beaconState.Slot < req.Slot {
 		beaconState, err = state.ExecuteStateTransition(
-			ctx, beaconState, nil /* block */, blockRoot, false, /* verify signatures */
+			ctx,
+			beaconState,
+			nil, /* block */
+			blockRoot,
+			false, /* verify signatures */
+			true,  /* rpc calls */
 		)
 		if err != nil {
 			return nil, fmt.Errorf("could not execute head transition: %v", err)

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -132,6 +132,7 @@ func (ps *ProposerServer) ComputeStateRoot(ctx context.Context, req *pbp2p.Beaco
 			nil,
 			parentHash,
 			false, /* no sig verify */
+			true,  /* rpc calls */
 		)
 		if err != nil {
 			return nil, fmt.Errorf("could not execute state transition %v", err)
@@ -143,6 +144,7 @@ func (ps *ProposerServer) ComputeStateRoot(ctx context.Context, req *pbp2p.Beaco
 		req,
 		parentHash,
 		false, /* no sig verification */
+		true,  /* rpc calls */
 	)
 	if err != nil {
 		return nil, fmt.Errorf("could not execute state transition %v", err)


### PR DESCRIPTION
To avoid further confusion, this PR prevents beacon node logging block processing related data when it's getting called via RPC