### PR TITLE
Add Clear DB Flag

### DIFF
--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -82,3 +82,11 @@ func NewDB(dirPath string) (*BeaconDB, error) {
 
 	return db, err
 }
+
+// ClearDB removes the previously stored directory at the data directory.
+func ClearDB(dirPath string) error {
+	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
+		return nil
+	}
+	return os.RemoveAll(dirPath)
+}

--- a/beacon-chain/db/db_test.go
+++ b/beacon-chain/db/db_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/testutil"
@@ -35,5 +36,17 @@ func teardownDB(t testing.TB, db *BeaconDB) {
 	}
 	if err := os.RemoveAll(db.DatabasePath); err != nil {
 		t.Fatalf("Failed to remove directory: %v", err)
+	}
+}
+
+func TestClearDB(t *testing.T) {
+	beaconDB := setupDB(t)
+	path := strings.TrimSuffix(beaconDB.DatabasePath, "beaconchain.db")
+	if err := ClearDB(path); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(beaconDB.DatabasePath); !os.IsNotExist(err) {
+		t.Fatalf("db wasnt cleared %v", err)
 	}
 }

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -63,6 +63,7 @@ func main() {
 		cmd.TraceSampleFractionFlag,
 		cmd.MonitoringPortFlag,
 		cmd.DisableMonitoringFlag,
+		cmd.ClearDBFlag,
 		debug.PProfFlag,
 		debug.PProfAddrFlag,
 		debug.PProfPortFlag,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -166,6 +166,12 @@ func (b *BeaconNode) Close() {
 func (b *BeaconNode) startDB(ctx *cli.Context) error {
 	baseDir := ctx.GlobalString(cmd.DataDirFlag.Name)
 
+	if b.ctx.GlobalBool(cmd.ClearDBFlag.Name) {
+		if err := db.ClearDB(path.Join(baseDir, beaconChainDBName)); err != nil {
+			return err
+		}
+	}
+
 	db, err := db.NewDB(path.Join(baseDir, beaconChainDBName))
 	if err != nil {
 		return err

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -64,7 +64,7 @@ var (
 		Usage: "The port used by libp2p.",
 		Value: 12000,
 	}
-	// ClearDB tells the beacon node to remove any previously stored data at the data directory.
+	// ClearDBFlag tells the beacon node to remove any previously stored data at the data directory.
 	ClearDBFlag = cli.BoolFlag{
 		Name:  "clear-db",
 		Usage: "Clears any previously stored data at the data directory",

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -64,4 +64,9 @@ var (
 		Usage: "The port used by libp2p.",
 		Value: 12000,
 	}
+	// ClearDB tells the beacon node to remove any previously stored data at the data directory.
+	ClearDBFlag = cli.BoolFlag{
+		Name:  "clear-db",
+		Usage: "Clears any previously stored data at the data directory",
+	}
 )


### PR DESCRIPTION
This adds a Clear DB flag, which cleans the data directory before we start the beacon node. We don't have to clear the data directory manually now whenever we test out a new contract