### PR TITLE
Log the DB path

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -164,19 +164,19 @@ func (b *BeaconNode) Close() {
 
 func (b *BeaconNode) startDB(ctx *cli.Context) error {
 	baseDir := ctx.GlobalString(cmd.DataDirFlag.Name)
-
+	dbPath := path.Join(baseDir, beaconChainDBName)
 	if b.ctx.GlobalBool(cmd.ClearDBFlag.Name) {
-		if err := db.ClearDB(path.Join(baseDir, beaconChainDBName)); err != nil {
+		if err := db.ClearDB(dbPath); err != nil {
 			return err
 		}
 	}
 
-	db, err := db.NewDB(path.Join(baseDir, beaconChainDBName))
+	db, err := db.NewDB(dbPath)
 	if err != nil {
 		return err
 	}
 
-	log.Info("checking db")
+	log.Infof("Checking db at %s", dbPath)
 	b.db = db
 	return nil
 }


### PR DESCRIPTION
Slight UX improvement to log the path of DB instead of just `checking db...`

It took me a while to locate where the DB was stored hopefully it helps other people