### PR TITLE
Use imported interfaces in sync package

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/db:go_default_library",
+        "//beacon-chain/operations:go_default_library",
         "//beacon-chain/powchain:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",

--- a/beacon-chain/blockchain/block_processing.go
+++ b/beacon-chain/blockchain/block_processing.go
@@ -11,10 +11,16 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"go.opencensus.io/trace"
 )
+
+type BlockProcessor interface {
+	CanonicalBlockFeed() *event.Feed
+	ReceiveBlock(ctx context.Context, block *pb.BeaconBlock) (*pb.BeaconState, error)
+}
 
 // ReceiveBlock is a function that defines the operations that are preformed on
 // any block that is received from p2p layer or rpc. It checks the block to see

--- a/beacon-chain/blockchain/block_processing.go
+++ b/beacon-chain/blockchain/block_processing.go
@@ -17,6 +17,8 @@ import (
 	"go.opencensus.io/trace"
 )
 
+// BlockProcessor interface defines the methods in the blockchain service which
+// handle new block operations.
 type BlockProcessor interface {
 	CanonicalBlockFeed() *event.Feed
 	ReceiveBlock(ctx context.Context, block *pb.BeaconBlock) (*pb.BeaconState, error)

--- a/beacon-chain/blockchain/block_processing_test.go
+++ b/beacon-chain/blockchain/block_processing_test.go
@@ -19,6 +19,9 @@ import (
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
+// Ensure ChainService implements interfaces.
+var _ = BlockProcessor(&ChainService{})
+
 func TestReceiveBlock_FaultyPOWChain(t *testing.T) {
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)

--- a/beacon-chain/blockchain/fork_choice.go
+++ b/beacon-chain/blockchain/fork_choice.go
@@ -13,6 +13,10 @@ import (
 	"go.opencensus.io/trace"
 )
 
+type ForkChoice interface {
+	ApplyForkChoiceRule(ctx context.Context, block *pb.BeaconBlock, computedState *pb.BeaconState) error
+}
+
 // updateFFGCheckPts checks whether the existing FFG check points saved in DB
 // are not older than the ones just processed in state. If it's older, we update
 // the db with the latest FFG check points, both justification and finalization.

--- a/beacon-chain/blockchain/fork_choice.go
+++ b/beacon-chain/blockchain/fork_choice.go
@@ -13,6 +13,8 @@ import (
 	"go.opencensus.io/trace"
 )
 
+// ForkChoice interface defines the methods for applying fork choice rule
+// operations to the blockchain.
 type ForkChoice interface {
 	ApplyForkChoiceRule(ctx context.Context, block *pb.BeaconBlock, computedState *pb.BeaconState) error
 }

--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -26,6 +26,9 @@ import (
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
+// Ensure ChainService implements interfaces.
+var _ = ForkChoice(&ChainService{})
+
 // Generates an initial genesis block and state using a custom number of initial
 // deposits as a helper function for LMD Ghost fork-choice testing.
 func generateTestGenesisStateAndBlock(

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -22,6 +22,8 @@ import (
 
 var log = logrus.WithField("prefix", "blockchain")
 
+// ChainFeeds interface defines the methods of the ChainService which provide
+// information feeds.
 type ChainFeeds interface {
 	StateInitializedFeed() *event.Feed
 }

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/attestation"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
+	"github.com/prysmaticlabs/prysm/beacon-chain/operations"
 	"github.com/prysmaticlabs/prysm/beacon-chain/powchain"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/event"
@@ -21,8 +22,8 @@ import (
 
 var log = logrus.WithField("prefix", "blockchain")
 
-type operationService interface {
-	IncomingProcessedBlockFeed() *event.Feed
+type ChainFeeds interface {
+	StateInitializedFeed() *event.Feed
 }
 
 // ChainService represents a service that handles the internal
@@ -33,7 +34,7 @@ type ChainService struct {
 	beaconDB             *db.BeaconDB
 	web3Service          *powchain.Web3Service
 	attsService          *attestation.Service
-	opsPoolService       operationService
+	opsPoolService       operations.OperationFeeds
 	chainStartChan       chan time.Time
 	canonicalBlockChan   chan *pb.BeaconBlock
 	canonicalBlockFeed   *event.Feed
@@ -50,7 +51,7 @@ type Config struct {
 	Web3Service    *powchain.Web3Service
 	AttsService    *attestation.Service
 	BeaconDB       *db.BeaconDB
-	OpsPoolService operationService
+	OpsPoolService operations.OperationFeeds
 	DevMode        bool
 	EnablePOWChain bool
 	P2p            p2p.Broadcaster

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -44,6 +44,14 @@ func (ms *mockOperationService) IncomingProcessedBlockFeed() *event.Feed {
 	return new(event.Feed)
 }
 
+func (ms *mockOperationService) IncomingAttFeed() *event.Feed {
+	return nil
+}
+
+func (ms *mockOperationService) IncomingExitFeed() *event.Feed {
+	return nil
+}
+
 type mockClient struct{}
 
 func (m *mockClient) SubscribeNewHead(ctx context.Context, ch chan<- *gethTypes.Header) (ethereum.Subscription, error) {

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -33,6 +33,9 @@ import (
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
+// Ensure ChainService implements interfaces.
+var _ = ChainFeeds(&ChainService{})
+
 func init() {
 	logrus.SetLevel(logrus.DebugLevel)
 	logrus.SetOutput(ioutil.Discard)

--- a/beacon-chain/operations/service.go
+++ b/beacon-chain/operations/service.go
@@ -19,6 +19,12 @@ import (
 
 var log = logrus.WithField("prefix", "operation")
 
+type OperationFeeds interface {
+	IncomingAttFeed() *event.Feed
+	IncomingExitFeed() *event.Feed
+	IncomingProcessedBlockFeed() *event.Feed
+}
+
 // Service represents a service that handles the internal
 // logic of beacon block operations.
 type Service struct {

--- a/beacon-chain/operations/service.go
+++ b/beacon-chain/operations/service.go
@@ -19,6 +19,8 @@ import (
 
 var log = logrus.WithField("prefix", "operation")
 
+// OperationFeeds inteface defines the informational feeds from the operations
+// service.
 type OperationFeeds interface {
 	IncomingAttFeed() *event.Feed
 	IncomingExitFeed() *event.Feed

--- a/beacon-chain/operations/service_test.go
+++ b/beacon-chain/operations/service_test.go
@@ -16,6 +16,9 @@ import (
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
+// Ensure operations service implements intefaces.
+var _ = OperationFeeds(&Service{})
+
 func init() {
 	logrus.SetLevel(logrus.DebugLevel)
 }

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -11,7 +11,9 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/sync",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
+        "//beacon-chain/blockchain:go_default_library",
         "//beacon-chain/db:go_default_library",
+        "//beacon-chain/operations:go_default_library",
         "//beacon-chain/sync/initial-sync:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",

--- a/beacon-chain/sync/regular_sync.go
+++ b/beacon-chain/sync/regular_sync.go
@@ -307,7 +307,7 @@ func (rs *RegularSync) receiveBlock(msg p2p.Message) {
 		return
 	}
 
-	beaconState, err := rs.db.State(msg.Ctx)
+	beaconState, err := rs.db.State(ctx)
 	if err != nil {
 		log.Errorf("Failed to get beacon state: %v", err)
 		return
@@ -519,7 +519,7 @@ func (rs *RegularSync) receiveAttestation(msg p2p.Message) {
 	}
 
 	// Skip if attestation slot is older than last finalized slot in state.
-	beaconState, err := rs.db.State(msg.Ctx)
+	beaconState, err := rs.db.State(ctx)
 	if err != nil {
 		log.Errorf("Failed to get beacon state: %v", err)
 		return

--- a/beacon-chain/sync/regular_sync.go
+++ b/beacon-chain/sync/regular_sync.go
@@ -531,7 +531,7 @@ func (rs *RegularSync) receiveAttestation(msg p2p.Message) {
 		return
 	}
 
-	_, sendAttestationSpan := trace.StartSpan(ctx, "beacon-chain.sync.sendAttestation")
+	ctx, sendAttestationSpan := trace.StartSpan(ctx, "beacon-chain.sync.sendAttestation")
 	log.WithField("attestationHash", fmt.Sprintf("%#x", attestationRoot)).Debug("Sending newly received attestation to subscribers")
 	rs.operationsService.IncomingAttFeed().Send(attestation)
 	sentAttestation.Inc()
@@ -556,7 +556,7 @@ func (rs *RegularSync) receiveExitRequest(msg p2p.Message) {
 		log.Debugf("Received, skipping exit request #%x", h)
 		return
 	}
-	_, sendExitReqSpan := trace.StartSpan(ctx, "sendExitRequest")
+	ctx, sendExitReqSpan := trace.StartSpan(ctx, "sendExitRequest")
 	log.WithField("exitReqHash", fmt.Sprintf("%#x", h)).
 		Debug("Forwarding validator exit request to subscribed services")
 	rs.operationsService.IncomingExitFeed().Send(exit)
@@ -713,12 +713,9 @@ func (rs *RegularSync) handleUnseenAttestationsRequest(msg p2p.Message) {
 }
 
 func (rs *RegularSync) broadcastCanonicalBlock(ctx context.Context, announce *pb.BeaconBlockAnnounce) {
-	_, span := trace.StartSpan(ctx, "beacon-chain.sync.broadcastCanonicalBlock")
+	ctx, span := trace.StartSpan(ctx, "beacon-chain.sync.sendBlockAnnounce")
 	defer span.End()
-
-	_, sendBlockAnnounceSpan := trace.StartSpan(ctx, "beacon-chain.sync.sendBlockAnnounce")
 	log.Debugf("Announcing canonical block %#x", announce.Hash)
 	rs.p2p.Broadcast(ctx, announce)
 	sentBlockAnnounce.Inc()
-	sendBlockAnnounceSpan.End()
 }

--- a/beacon-chain/sync/regular_sync.go
+++ b/beacon-chain/sync/regular_sync.go
@@ -713,7 +713,7 @@ func (rs *RegularSync) handleUnseenAttestationsRequest(msg p2p.Message) {
 }
 
 func (rs *RegularSync) broadcastCanonicalBlock(ctx context.Context, announce *pb.BeaconBlockAnnounce) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.sync.sendBlockAnnounce")
+	ctx, span := trace.StartSpan(ctx, "beacon-chain.sync.broadcastCanonicalBlock")
 	defer span.End()
 	log.Debugf("Announcing canonical block %#x", announce.Hash)
 	rs.p2p.Broadcast(ctx, announce)

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -71,6 +71,10 @@ func (ms *mockChainService) ApplyForkChoiceRule(ctx context.Context, block *pb.B
 
 type mockOperationService struct{}
 
+func (ms *mockOperationService) IncomingProcessedBlockFeed() *event.Feed {
+	return nil
+}
+
 func (ms *mockOperationService) IncomingAttFeed() *event.Feed {
 	return new(event.Feed)
 }

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
+	"github.com/prysmaticlabs/prysm/beacon-chain/operations"
 	initialsync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync"
 	"github.com/sirupsen/logrus"
 )
@@ -22,7 +23,7 @@ type Config struct {
 	ChainService     chainService
 	BeaconDB         *db.BeaconDB
 	P2P              p2pAPI
-	OperationService operationService
+	OperationService operations.OperationFeeds
 	PowChainService  powChainService
 }
 

--- a/shared/p2p/interfaces.go
+++ b/shared/p2p/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prysmaticlabs/prysm/shared/event"
 )
 
 // Broadcaster represents a subset of the p2p.Server. This interface is useful
@@ -11,4 +12,11 @@ import (
 // method.
 type Broadcaster interface {
 	Broadcast(context.Context, proto.Message)
+}
+
+// Subscriber represents a subset of the p2p.Server. This interface is useful
+// for testing or when the calling code only needs access to the subscribe
+// method.
+type Subscriber interface {
+	Subscribe(msg proto.Message, channel chan Message) event.Subscription
 }


### PR DESCRIPTION
Using imported interfaces and composition makes it easier to locate the actual definition of the method. 