### PR TITLE
Handle skip slots for FFG check points

### DIFF
--- a/beacon-chain/blockchain/fork_choice.go
+++ b/beacon-chain/blockchain/fork_choice.go
@@ -32,12 +32,12 @@ func (c *ChainService) updateFFGCheckPts(state *pb.BeaconState) error {
 	// the slot of justified block saved in DB.
 	if lastJustifiedSlot > savedJustifiedBlock.Slot {
 		// Retrieve the new justified block from DB using the new justified slot and save it.
-		// If the last justified slot is a skip slot then we take it's ancestor until we can get
-		// a block.
 		newJustifiedBlock, err := c.beaconDB.BlockBySlot(lastJustifiedSlot)
 		if err != nil {
 			return err
 		}
+		// If the new justified slot is a skip slot in db then we keep getting it's ancestors
+		// until we can get a block.
 		for newJustifiedBlock == nil {
 			log.Debugf("Saving new justified block, no block with slot %d in db, trying slot %d",
 				lastJustifiedSlot, lastJustifiedSlot-1)
@@ -76,8 +76,10 @@ func (c *ChainService) updateFFGCheckPts(state *pb.BeaconState) error {
 		if err != nil {
 			return err
 		}
+		// If the new finalized slot is a skip slot in db then we keep getting it's ancestors
+		// until we can get a block.
 		for newFinalizedBlock == nil {
-			log.Debugf("Saving new justified block, no block with slot %d in db, trying slot %d",
+			log.Debugf("Saving new finalized block, no block with slot %d in db, trying slot %d",
 				lastFinalizedSlot, lastFinalizedSlot-1)
 			lastFinalizedSlot--
 			newFinalizedBlock, err = c.beaconDB.BlockBySlot(lastFinalizedSlot)


### PR DESCRIPTION
Do not merge, I'm still working on regression test.

**Background:**
Slots: 1 2 3 4 5 6 7 **8** 9 10 11 12 13 14 15 **16** 17 18 19 20 21 22 23 **24** 25 26 27 28 29 30 31 (each epoch is 8 slots)
Let’s say at the end of 31 we start epoch processing, and we find there's a new justified epoch (epoch 2,
because there's a new justified epoch, we replace the new justified block (the one at the boundary slot 16) with the existing one in DB, but slot 16 happens to be a skip slot, in this case we should just take its ancestor slot 15.

This PR implements the behavior

More info: https://github.com/ethereum/eth2.0-specs/issues/768