### PR TITLE
Refactor State Gen To Take Input Slot

### DIFF
--- a/beacon-chain/blockchain/fork_choice.go
+++ b/beacon-chain/blockchain/fork_choice.go
@@ -50,12 +50,13 @@ func (c *ChainService) updateFFGCheckPts(state *pb.BeaconState) error {
 		if err != nil {
 			return err
 		}
-		if err := c.beaconDB.SaveJustifiedBlock(newJustifiedBlock); err != nil {
+
+		// Generate the new justified state with using new justified block and save it.
+		newJustifiedState, err := stategenerator.GenerateStateFromBlock(c.ctx, c.beaconDB, lastJustifiedSlot)
+		if err != nil {
 			return err
 		}
-		// Generate the new justified state with using new justified block and save it.
-		newJustifiedState, err := stategenerator.GenerateStateFromBlock(c.ctx, c.beaconDB, newJustifiedBlock)
-		if err != nil {
+		if err := c.beaconDB.SaveJustifiedBlock(newJustifiedBlock); err != nil {
 			return err
 		}
 		if err := c.beaconDB.SaveJustifiedState(newJustifiedState); err != nil {
@@ -87,12 +88,13 @@ func (c *ChainService) updateFFGCheckPts(state *pb.BeaconState) error {
 				return err
 			}
 		}
-		if err := c.beaconDB.SaveFinalizedBlock(newFinalizedBlock); err != nil {
+
+		// Generate the new finalized state with using new finalized block and save it.
+		newFinalizedState, err := stategenerator.GenerateStateFromBlock(c.ctx, c.beaconDB, lastFinalizedSlot)
+		if err != nil {
 			return err
 		}
-		// Generate the new finalized state with using new finalized block and save it.
-		newFinalizedState, err := stategenerator.GenerateStateFromBlock(c.ctx, c.beaconDB, newFinalizedBlock)
-		if err != nil {
+		if err := c.beaconDB.SaveFinalizedBlock(newFinalizedBlock); err != nil {
 			return err
 		}
 		if err := c.beaconDB.SaveFinalizedState(newFinalizedState); err != nil {

--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -1202,7 +1202,7 @@ func TestUpdateFFGCheckPts_NewFinalizedSlot(t *testing.T) {
 			})
 		validatorBalances = append(validatorBalances, params.BeaconConfig().MaxDepositAmount)
 	}
-	gBlock := &pb.BeaconBlock{Slot: genesisSlot}
+	gBlock := &pb.BeaconBlock{Slot: genesisSlot, ParentRootHash32: params.BeaconConfig().ZeroHash[:]}
 	if err := chainSvc.beaconDB.SaveBlock(gBlock); err != nil {
 		t.Fatal(err)
 	}
@@ -1235,7 +1235,7 @@ func TestUpdateFFGCheckPts_NewFinalizedSlot(t *testing.T) {
 
 	// Last finalized check point happened at slot 0.
 	if err := chainSvc.beaconDB.SaveFinalizedBlock(
-		&pb.BeaconBlock{Slot: genesisSlot}); err != nil {
+		gBlock); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1268,6 +1268,7 @@ func TestUpdateFFGCheckPts_NewFinalizedSlot(t *testing.T) {
 		RandaoReveal:     epochSignature.Marshal(),
 		ParentRootHash32: gBlockRoot[:],
 		Body:             &pb.BeaconBlockBody{}}
+
 	if err := chainSvc.beaconDB.SaveBlock(block); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -1118,8 +1118,7 @@ func TestUpdateFFGCheckPts_NewJustifiedSlot(t *testing.T) {
 	}
 
 	// Also saved finalized block to slot 0 to test justification case only.
-	if err := chainSvc.beaconDB.SaveFinalizedBlock(
-		&pb.BeaconBlock{Slot: genesisSlot}); err != nil {
+	if err := chainSvc.beaconDB.SaveFinalizedBlock(&pb.BeaconBlock{Slot: genesisSlot}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/beacon-chain/blockchain/stategenerator/BUILD.bazel
+++ b/beacon-chain/blockchain/stategenerator/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     deps = [
         "//beacon-chain/chaintest/backend:go_default_library",
         "//beacon-chain/db:go_default_library",
+        "//shared/params:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],
 )

--- a/beacon-chain/blockchain/stategenerator/state_generator.go
+++ b/beacon-chain/blockchain/stategenerator/state_generator.go
@@ -44,7 +44,6 @@ func GenerateStateFromBlock(ctx context.Context, db *db.BeaconDB, slot uint64) (
 	if err != nil {
 		return nil, err
 	}
-
 	fRoot, err := hashutil.HashBeaconBlock(fBlock)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get block root %v", err)
@@ -55,6 +54,7 @@ func GenerateStateFromBlock(ctx context.Context, db *db.BeaconDB, slot uint64) (
 	if err != nil {
 		return nil, err
 	}
+
 	// if the most recent block is a skip block, we get its parent block.
 	// ex:
 	// 	1A - 2B - 3C - 4 - 5 (letters mean there's a block)
@@ -79,7 +79,6 @@ func GenerateStateFromBlock(ctx context.Context, db *db.BeaconDB, slot uint64) (
 	root := fRoot
 	for i := len(blocks); i > 0; i-- {
 		block := blocks[i-1]
-
 		if block.Slot <= postState.Slot {
 			continue
 		}
@@ -99,7 +98,6 @@ func GenerateStateFromBlock(ctx context.Context, db *db.BeaconDB, slot uint64) (
 				return nil, fmt.Errorf("could not execute state transition %v", err)
 			}
 		}
-
 		postState, err = state.ExecuteStateTransition(
 			ctx,
 			postState,
@@ -119,7 +117,6 @@ func GenerateStateFromBlock(ctx context.Context, db *db.BeaconDB, slot uint64) (
 			return nil, fmt.Errorf("unable to get block root %v", err)
 		}
 	}
-
 	log.Debugf("Finished recompute state with slot %d and finalized epoch %d",
 		postState.Slot, postState.FinalizedEpoch)
 
@@ -137,7 +134,6 @@ func blocksSinceFinalized(db *db.BeaconDB, block *pb.BeaconBlock,
 
 	blockAncestors := make([]*pb.BeaconBlock, 0)
 	blockAncestors = append(blockAncestors, block)
-
 	parentRoot := bytesutil.ToBytes32(block.ParentRootHash32)
 	// looking up ancestors, until the finalized block.
 	for parentRoot != finalizedBlockRoot {
@@ -148,6 +144,5 @@ func blocksSinceFinalized(db *db.BeaconDB, block *pb.BeaconBlock,
 		blockAncestors = append(blockAncestors, retblock)
 		parentRoot = bytesutil.ToBytes32(retblock.ParentRootHash32)
 	}
-
 	return blockAncestors, nil
 }

--- a/beacon-chain/blockchain/stategenerator/state_generator.go
+++ b/beacon-chain/blockchain/stategenerator/state_generator.go
@@ -14,49 +14,80 @@ import (
 
 var log = logrus.WithField("prefix", "stategenerator")
 
-// GenerateStateFromBlock generates state from the historical state at the
-// given block's slot.
-func GenerateStateFromBlock(ctx context.Context, db *db.BeaconDB, block *pb.BeaconBlock) (*pb.BeaconState, error) {
-	hState, err := db.HistoricalStateFromSlot(block.Slot)
+// GenerateStateFromBlock generates state from the last finalized state to the input slot.
+// Ex:
+// 	1A - 2B(finalized) - 3C - 4 - 5D - 6 - 7F
+//  Input: slot 6
+//	Output: resulting state of state transition function after applying block C and D
+//  	along with skipped slot 4 and 6.
+func GenerateStateFromBlock(ctx context.Context, db *db.BeaconDB, slot uint64) (*pb.BeaconState, error) {
+	fState, err := db.FinalizedState()
 	if err != nil {
 		return nil, err
 	}
 
-	if hState.Slot == block.Slot {
-		return hState, nil
+	// return finalized state if it's the same as input slot.
+	if fState.Slot == slot {
+		return fState, nil
 	}
 
-	if hState.Slot > block.Slot {
+	// input slot can't be smaller than last finalized state's slot.
+	if fState.Slot > slot {
 		return nil, fmt.Errorf(
-			"requested slot %d < current slot %d in the historical beacon state",
-			hState.Slot,
-			block,
+			"requested slot %d < current slot %d in the finalized beacon state",
+			fState.Slot,
+			slot,
 		)
 	}
 
-	root, err := hashutil.HashBeaconBlock(hState.LatestBlock)
+	fBlock, err := db.FinalizedBlock()
+	if err != nil {
+		return nil, err
+	}
+
+	fRoot, err := hashutil.HashBeaconBlock(fBlock)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get block root %v", err)
 	}
 
-	ancestorSet, err := ancestersToLastFinalizedBlock(db, block, root)
+	// from input slot, retrieve its corresponding block and call that the most recent block.
+	mostRecentBlock, err := db.BlockBySlot(slot)
+	if err != nil {
+		return nil, err
+	}
+	// if the most recent block is a skip block, we get its parent block.
+	// ex:
+	// 	1A - 2B - 3C - 4 - 5
+	//  input slot is 5, but slots 4 and 5 are skipped, we get block C from slot 3.
+	for mostRecentBlock == nil {
+		slot--
+		mostRecentBlock, err = db.BlockBySlot(slot)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// retrieve the block list to recompute state for the input slot.
+	blocks, err := recentToFinalizedBlocks(db, mostRecentBlock, fRoot)
 	if err != nil {
 		return nil, fmt.Errorf("unable to look up block ancestors %v", err)
 	}
 
-	log.Debugf("Start: Current slot %d and Finalized Epoch %d", hState.Slot, hState.FinalizedEpoch)
+	log.Debugf("Recompute state starting last finalized slot %d and ending slot %d",
+		fState.Slot, slot)
+	postState := fState
+	root := fRoot
+	for i := len(blocks); i > 0; i-- {
+		block := blocks[i-1]
 
-	for i := len(ancestorSet); i > 0; i-- {
-		block := ancestorSet[i-1]
-
-		if block.Slot <= hState.Slot {
+		if block.Slot <= postState.Slot {
 			continue
 		}
 		// Running state transitions for skipped slots.
-		for block.Slot != hState.Slot+1 {
-			hState, err = state.ExecuteStateTransition(
+		for block.Slot != fState.Slot+1 {
+			postState, err = state.ExecuteStateTransition(
 				ctx,
-				hState,
+				postState,
 				nil,
 				root,
 				&state.TransitionConfig{
@@ -69,9 +100,9 @@ func GenerateStateFromBlock(ctx context.Context, db *db.BeaconDB, block *pb.Beac
 			}
 		}
 
-		hState, err = state.ExecuteStateTransition(
+		postState, err = state.ExecuteStateTransition(
 			ctx,
-			hState,
+			postState,
 			block,
 			root,
 			&state.TransitionConfig{
@@ -89,22 +120,26 @@ func GenerateStateFromBlock(ctx context.Context, db *db.BeaconDB, block *pb.Beac
 		}
 	}
 
-	log.Debugf("End: Current slot %d and Finalized Epoch %d", hState.Slot, hState.FinalizedEpoch)
+	log.Debugf("Finished recompute state with slot %d and finalized epoch %d",
+		postState.Slot, postState.FinalizedEpoch)
 
-	return hState, nil
+	return postState, nil
 }
 
-// ancestersToLastFinalizedBlock will return a list of all block ancesters
-// between the given block and the most recent finalized block in the db.
-// The given block is also returned in the list of ancesters.
-func ancestersToLastFinalizedBlock(db *db.BeaconDB, block *pb.BeaconBlock,
+// recentToFinalizedBlocks will return a list of linked blocks that's
+// between the input block and the last finalized block in the db.
+// The input block is also returned in the list.
+// Ex:
+// 	A -> B(finalized) -> C -> D -> E -> D
+// 	Input: E, output: [E, D, C, B]
+func recentToFinalizedBlocks(db *db.BeaconDB, block *pb.BeaconBlock,
 	finalizedBlockRoot [32]byte) ([]*pb.BeaconBlock, error) {
 
 	blockAncestors := make([]*pb.BeaconBlock, 0)
 	blockAncestors = append(blockAncestors, block)
 
 	parentRoot := bytesutil.ToBytes32(block.ParentRootHash32)
-	// looking up ancestors, till it gets the last finalized block.
+	// looking up ancestors, until the finalized block.
 	for parentRoot != finalizedBlockRoot {
 		retblock, err := db.Block(parentRoot)
 		if err != nil {

--- a/beacon-chain/blockchain/stategenerator/state_generator_test.go
+++ b/beacon-chain/blockchain/stategenerator/state_generator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain/stategenerator"
 	"github.com/prysmaticlabs/prysm/beacon-chain/chaintest/backend"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
+	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
 func TestGenerateState_OK(t *testing.T) {
@@ -37,6 +38,9 @@ func TestGenerateState_OK(t *testing.T) {
 		if err := beaconDb.UpdateChainHead(inMemBlocks[len(inMemBlocks)-1], bd.State()); err != nil {
 			t.Fatalf("Unable to save block %v", err)
 		}
+		if err := beaconDb.SaveFinalizedBlock(inMemBlocks[len(inMemBlocks)-1]); err != nil {
+			t.Fatalf("Unable to save finalized state: %v", err)
+		}
 	}
 
 	if err := beaconDb.SaveFinalizedState(bd.State()); err != nil {
@@ -57,9 +61,9 @@ func TestGenerateState_OK(t *testing.T) {
 		}
 	}
 
-	inMemBlocks := bd.InMemoryBlocks()
-	blockToGenerateTill := inMemBlocks[len(inMemBlocks)-1]
-	newState, err := stategenerator.GenerateStateFromBlock(context.Background(), beaconDb, blockToGenerateTill)
+	// Ran 30 slots to save finalized slot then ran another 30 slots.
+	slotToGenerateTill := params.BeaconConfig().GenesisSlot + slotLimit * 2
+	newState, err := stategenerator.GenerateStateFromBlock(context.Background(), beaconDb, slotToGenerateTill)
 	if err != nil {
 		t.Fatalf("Unable to generate new state from previous finalized state %v", err)
 	}
@@ -101,6 +105,9 @@ func TestGenerateState_WithNilBlocksOK(t *testing.T) {
 		if err := beaconDb.UpdateChainHead(inMemBlocks[len(inMemBlocks)-1], bd.State()); err != nil {
 			t.Fatalf("Unable to save block %v", err)
 		}
+		if err := beaconDb.SaveFinalizedBlock(inMemBlocks[len(inMemBlocks)-1]); err != nil {
+			t.Fatalf("Unable to save finalized state: %v", err)
+		}
 	}
 
 	if err := beaconDb.SaveFinalizedState(bd.State()); err != nil {
@@ -129,9 +136,9 @@ func TestGenerateState_WithNilBlocksOK(t *testing.T) {
 		}
 	}
 
-	inMemBlocks := bd.InMemoryBlocks()
-	blockToGenerateTill := inMemBlocks[len(inMemBlocks)-1]
-	newState, err := stategenerator.GenerateStateFromBlock(context.Background(), beaconDb, blockToGenerateTill)
+	// Ran 30 slots to save finalized slot then ran another 10 slots w/o blocks and 20 slots w/ blocks.
+	slotToGenerateTill := params.BeaconConfig().GenesisSlot + slotLimit * 2
+	newState, err := stategenerator.GenerateStateFromBlock(context.Background(), beaconDb, slotToGenerateTill)
 	if err != nil {
 		t.Fatalf("Unable to generate new state from previous finalized state %v", err)
 	}

--- a/beacon-chain/blockchain/stategenerator/state_generator_test.go
+++ b/beacon-chain/blockchain/stategenerator/state_generator_test.go
@@ -62,7 +62,7 @@ func TestGenerateState_OK(t *testing.T) {
 	}
 
 	// Ran 30 slots to save finalized slot then ran another 30 slots.
-	slotToGenerateTill := params.BeaconConfig().GenesisSlot + slotLimit * 2
+	slotToGenerateTill := params.BeaconConfig().GenesisSlot + slotLimit*2
 	newState, err := stategenerator.GenerateStateFromBlock(context.Background(), beaconDb, slotToGenerateTill)
 	if err != nil {
 		t.Fatalf("Unable to generate new state from previous finalized state %v", err)
@@ -137,7 +137,7 @@ func TestGenerateState_WithNilBlocksOK(t *testing.T) {
 	}
 
 	// Ran 30 slots to save finalized slot then ran another 10 slots w/o blocks and 20 slots w/ blocks.
-	slotToGenerateTill := params.BeaconConfig().GenesisSlot + slotLimit * 2
+	slotToGenerateTill := params.BeaconConfig().GenesisSlot + slotLimit*2
 	newState, err := stategenerator.GenerateStateFromBlock(context.Background(), beaconDb, slotToGenerateTill)
 	if err != nil {
 		t.Fatalf("Unable to generate new state from previous finalized state %v", err)


### PR DESCRIPTION
State Gen previously take input block which doesn't account for skip slot. This PR updates state gen with more comments and allows state gen to take input slot instead of input block