### PR TITLE
Use DNS resolution and istio for redialing bootnode

### DIFF
--- a/k8s/beacon-chain/beacon-chain.deploy.yaml
+++ b/k8s/beacon-chain/beacon-chain.deploy.yaml
@@ -18,7 +18,6 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9090'
-        sidecar.istio.io/inject: 'false' # istio breaks local peer connections
     spec:
       priorityClassName: production-priority
       affinity:
@@ -44,7 +43,7 @@ spec:
             - --deposit-contract=$(DEPOSIT_CONTRACT_ADDRESS)
             - --rpc-port=4000
             - --monitoring-port=9090
-            - --bootstrap-node=/ip4/$(BOOTNODE_SERVICE_HOST)/tcp/$(BOOTNODE_SERVICE_PORT)/p2p/QmQEe7o6hKJdGdSkJRh7WJzS6xrex5f4w2SPR6oWbJNriw
+            - --bootstrap-node=/dns4/bootnode/tcp/$(BOOTNODE_SERVICE_PORT)/p2p/QmQEe7o6hKJdGdSkJRh7WJzS6xrex5f4w2SPR6oWbJNriw
             - --relay-node=/ip4/35.224.249.2/tcp/30000/p2p/QmfAgkmjiZNZhr2wFN9TwaRgHouMTBT6HELyzE5A3BT2wK
             - --p2p-port=5000
             - --enable-tracing

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -130,7 +130,9 @@ func (s *Server) Start() {
 		if err := startDHTDiscovery(ctx, s.host, s.bootstrapNode); err != nil {
 			log.Errorf("Could not start peer discovery via DHT: %v", err)
 		}
-		if err := s.dht.Bootstrap(ctx); err != nil {
+		bcfg := kaddht.DefaultBootstrapConfig
+		bcfg.Period = time.Duration(30 * time.Second)
+		if err := s.dht.BootstrapWithConfig(ctx, bcfg); err != nil {
 			log.Errorf("Failed to bootstrap DHT: %v", err)
 		}
 	}


### PR DESCRIPTION
Problem: when a bootnode pod is rescheduled, it is assigned a new IP. Passing the IP statically by environment variable doesn't update this flag value.

Solution: Use istio sidecar to have a proper headless service. Additionally use DNS resolution in the mulitaddr. Also, use faster queries with DHT lookup. 

I've tested this and it seems to be working well, reconnecting to the bootnode without issue. 