### PR TITLE
Fix ActiveValidatorIndices use slot

### DIFF
--- a/beacon-chain/core/balances/rewards_penalties.go
+++ b/beacon-chain/core/balances/rewards_penalties.go
@@ -46,8 +46,8 @@ func ExpectedFFGSource(
 				justifiedAttestingBalance /
 				totalBalance
 	}
-
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, state.Slot)
+	currentEpoch := helpers.CurrentEpoch(state)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
 	didNotAttestIndices := sliceutil.Not(justifiedAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -87,8 +87,8 @@ func ExpectedFFGTarget(
 				boundaryAttestingBalance /
 				totalBalance
 	}
-
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, state.Slot)
+	currentEpoch := helpers.CurrentEpoch(state)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
 	didNotAttestIndices := sliceutil.Not(boundaryAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -128,8 +128,8 @@ func ExpectedBeaconChainHead(
 				headAttestingBalance /
 				totalBalance
 	}
-
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, state.Slot)
+	currentEpoch := helpers.CurrentEpoch(state)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
 	didNotAttestIndices := sliceutil.Not(headAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -192,7 +192,8 @@ func InactivityFFGSource(
 	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, state.Slot)
+	currentEpoch := helpers.CurrentEpoch(state)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
 	didNotAttestIndices := sliceutil.Not(justifiedAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -220,7 +221,8 @@ func InactivityFFGTarget(
 	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, state.Slot)
+	currentEpoch := helpers.CurrentEpoch(state)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
 	didNotAttestIndices := sliceutil.Not(boundaryAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -247,7 +249,8 @@ func InactivityChainHead(
 	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, state.Slot)
+	currentEpoch := helpers.CurrentEpoch(state)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
 	didNotAttestIndices := sliceutil.Not(headAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -274,7 +277,8 @@ func InactivityExitedPenalties(
 	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, state.Slot)
+	currentEpoch := helpers.CurrentEpoch(state)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
 
 	for _, index := range activeValidatorIndices {
 		if state.ValidatorRegistry[index].SlashedEpoch <= helpers.CurrentEpoch(state) {

--- a/beacon-chain/core/balances/rewards_penalties.go
+++ b/beacon-chain/core/balances/rewards_penalties.go
@@ -46,8 +46,7 @@ func ExpectedFFGSource(
 				justifiedAttestingBalance /
 				totalBalance
 	}
-	currentEpoch := helpers.CurrentEpoch(state)
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, helpers.CurrentEpoch(state))
 	didNotAttestIndices := sliceutil.Not(justifiedAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -87,8 +86,7 @@ func ExpectedFFGTarget(
 				boundaryAttestingBalance /
 				totalBalance
 	}
-	currentEpoch := helpers.CurrentEpoch(state)
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, helpers.CurrentEpoch(state))
 	didNotAttestIndices := sliceutil.Not(boundaryAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -128,8 +126,7 @@ func ExpectedBeaconChainHead(
 				headAttestingBalance /
 				totalBalance
 	}
-	currentEpoch := helpers.CurrentEpoch(state)
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, helpers.CurrentEpoch(state))
 	didNotAttestIndices := sliceutil.Not(headAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -192,8 +189,7 @@ func InactivityFFGSource(
 	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
-	currentEpoch := helpers.CurrentEpoch(state)
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, helpers.CurrentEpoch(state))
 	didNotAttestIndices := sliceutil.Not(justifiedAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -221,8 +217,7 @@ func InactivityFFGTarget(
 	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
-	currentEpoch := helpers.CurrentEpoch(state)
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, helpers.CurrentEpoch(state))
 	didNotAttestIndices := sliceutil.Not(boundaryAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -249,8 +244,7 @@ func InactivityChainHead(
 	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
-	currentEpoch := helpers.CurrentEpoch(state)
-	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
+	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, helpers.CurrentEpoch(state))
 	didNotAttestIndices := sliceutil.Not(headAttesterIndices, activeValidatorIndices)
 
 	for _, index := range didNotAttestIndices {
@@ -281,7 +275,7 @@ func InactivityExitedPenalties(
 	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
 
 	for _, index := range activeValidatorIndices {
-		if state.ValidatorRegistry[index].SlashedEpoch <= helpers.CurrentEpoch(state) {
+		if state.ValidatorRegistry[index].SlashedEpoch <= currentEpoch {
 			state.ValidatorBalances[index] -=
 				2*helpers.InactivityPenalty(state, index, baseRewardQuotient, epochsSinceFinality) +
 					helpers.BaseReward(state, index, baseRewardQuotient)


### PR DESCRIPTION
`ActiveValidatorIndices` was suppose to use `epoch` as input but `slot` was passed in when we calculate rewards and penalties. 

This was the reason why post pending registered validators were losing balances 