### PR TITLE
Use justified state as start state for running fork choice

### DIFF
--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -529,7 +529,7 @@ func TestLMDGhost_TrivialHeadUpdate(t *testing.T) {
 	voteTargets[0] = block2
 
 	// LMDGhost should pick block 2.
-	head, err := chainService.lmdGhost(block1, state, voteTargets)
+	head, err := chainService.lmdGhost(block1, state, state, voteTargets)
 	if err != nil {
 		t.Fatalf("Could not run LMD GHOST: %v", err)
 	}
@@ -613,7 +613,7 @@ func TestLMDGhost_3WayChainSplitsSameHeight(t *testing.T) {
 	voteTargets[2] = block4
 	voteTargets[3] = block4
 	// LMDGhost should pick block 4.
-	head, err := chainService.lmdGhost(block1, state, voteTargets)
+	head, err := chainService.lmdGhost(block1, state, state, voteTargets)
 	if err != nil {
 		t.Fatalf("Could not run LMD GHOST: %v", err)
 	}
@@ -729,7 +729,7 @@ func TestLMDGhost_2WayChainSplitsDiffHeight(t *testing.T) {
 	voteTargets[1] = block5
 	voteTargets[2] = block5
 	// LMDGhost should pick block 5.
-	head, err := chainService.lmdGhost(block1, state, voteTargets)
+	head, err := chainService.lmdGhost(block1, state, state, voteTargets)
 	if err != nil {
 		t.Fatalf("Could not run LMD GHOST: %v", err)
 	}
@@ -799,7 +799,7 @@ func BenchmarkLMDGhost_8Slots_8Validators(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		_, err := chainService.lmdGhost(genesis, state, voteTargets)
+		_, err := chainService.lmdGhost(genesis, state, state, voteTargets)
 		if err != nil {
 			b.Fatalf("Could not run LMD GHOST: %v", err)
 		}
@@ -869,7 +869,7 @@ func BenchmarkLMDGhost_32Slots_8Validators(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		_, err := chainService.lmdGhost(genesis, state, voteTargets)
+		_, err := chainService.lmdGhost(genesis, state, state, voteTargets)
 		if err != nil {
 			b.Fatalf("Could not run LMD GHOST: %v", err)
 		}
@@ -937,7 +937,7 @@ func BenchmarkLMDGhost_32Slots_64Validators(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		_, err := chainService.lmdGhost(genesis, state, voteTargets)
+		_, err := chainService.lmdGhost(genesis, state, state, voteTargets)
 		if err != nil {
 			b.Fatalf("Could not run LMD GHOST: %v", err)
 		}
@@ -1005,7 +1005,7 @@ func BenchmarkLMDGhost_64Slots_16384Validators(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		_, err := chainService.lmdGhost(genesis, state, voteTargets)
+		_, err := chainService.lmdGhost(genesis, state, state, voteTargets)
 		if err != nil {
 			b.Fatalf("Could not run LMD GHOST: %v", err)
 		}

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -162,12 +162,12 @@ func TestProcessBlock_OK(t *testing.T) {
 	cfg := &RegularSyncConfig{
 		BlockAnnounceBufferSize: 0,
 		BlockBufferSize:         0,
-		ChainService:            &mockChainService{
+		ChainService: &mockChainService{
 			db: db,
 		},
-		P2P:                     &mockP2P{},
-		BeaconDB:                db,
-		OperationService:        &mockOperationService{},
+		P2P:              &mockP2P{},
+		BeaconDB:         db,
+		OperationService: &mockOperationService{},
 	}
 	ss := NewRegularSyncService(context.Background(), cfg)
 
@@ -237,12 +237,12 @@ func TestProcessBlock_MultipleBlocksProcessedOK(t *testing.T) {
 	cfg := &RegularSyncConfig{
 		BlockAnnounceBufferSize: 0,
 		BlockBufferSize:         0,
-		ChainService:            &mockChainService{
+		ChainService: &mockChainService{
 			db: db,
 		},
-		P2P:                     &mockP2P{},
-		BeaconDB:                db,
-		OperationService:        &mockOperationService{},
+		P2P:              &mockP2P{},
+		BeaconDB:         db,
+		OperationService: &mockOperationService{},
 	}
 	ss := NewRegularSyncService(context.Background(), cfg)
 

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -72,7 +72,7 @@ func setupTestSyncService(t *testing.T, synced bool) (*Service, *db.BeaconDB) {
 	}
 
 	cfg := &Config{
-		ChainService:     &mockChainService{
+		ChainService: &mockChainService{
 			db: db,
 		},
 		P2P:              &mockP2P{},

--- a/beacon-chain/sync/simulated_sync_test.go
+++ b/beacon-chain/sync/simulated_sync_test.go
@@ -114,7 +114,7 @@ func setUpSyncedService(numOfBlocks int, simP2P *simulatedP2P, t *testing.T) (*S
 		bFeed: new(event.Feed),
 		sFeed: new(event.Feed),
 		cFeed: new(event.Feed),
-		db: bd.DB(),
+		db:    bd.DB(),
 	}
 
 	cfg := &Config{
@@ -161,7 +161,7 @@ func setUpUnSyncedService(simP2P *simulatedP2P, stateRoot [32]byte, t *testing.T
 		bFeed: new(event.Feed),
 		sFeed: new(event.Feed),
 		cFeed: new(event.Feed),
-		db: bd.DB(),
+		db:    bd.DB(),
 	}
 
 	// we add in 2 blocks to the unsynced node so that, we dont request the beacon state from the


### PR DESCRIPTION
Before when we compute fork choice we always use **current state** as **start state**, this changes to use **justified state** as **start state**