### PR TITLE
Modify p2p Allowed Buffer Size & Batch Block Limit

### DIFF
--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -31,7 +31,9 @@ import (
 )
 
 const prysmProtocolPrefix = "/prysm/0.0.0"
-const maxMessageSize = 1 << 20
+// We accommodate p2p message sizes as large as ~17Mb as we are transmitting
+// full beacon states over the wire for our current implementation.
+const maxMessageSize = 1 << 24
 
 // Sender represents a struct that is able to relay information via p2p.
 // Server implements this interface.

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -31,6 +31,7 @@ import (
 )
 
 const prysmProtocolPrefix = "/prysm/0.0.0"
+
 // We accommodate p2p message sizes as large as ~17Mb as we are transmitting
 // full beacon states over the wire for our current implementation.
 const maxMessageSize = 1 << 24

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -169,7 +169,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	// Prysm constants.
 	DepositsForChainStart: 16384,
 	RandBytes:             3,
-	SyncPollingInterval:   6 * 1, // Query nodes over the network every slot for sync status.
+	SyncPollingInterval:   6 * 1,  // Query nodes over the network every slot for sync status.
 	BatchBlockLimit:       64 * 4, // Process blocks in batches of 4 epochs of blocks (threshold before casper penalties).
 	SyncEpochLimit:        4,
 	MaxNumLog2Validators:  24,

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -170,7 +170,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	DepositsForChainStart: 16384,
 	RandBytes:             3,
 	SyncPollingInterval:   6 * 1, // Query nodes over the network every slot for sync status.
-	BatchBlockLimit:       50,
+	BatchBlockLimit:       64 * 4, // Process blocks in batches of 4 epochs of blocks (threshold before casper penalties).
 	SyncEpochLimit:        4,
 	MaxNumLog2Validators:  24,
 	LogBlockDelay:         2, //


### PR DESCRIPTION
No tracking issue.

---

# Description

**Write why you are making the changes in this pull request**

Given we are transmitting state over the wire, we should make our p2p buffer sizes large enough to accommodate this. Additionally, we should set our batch block limit to something reasonable like 4 epochs worth of blocks, as that is the number of epochs since finality that will kick in Casper penalties. 
