### PR TITLE
take first validator key

### DIFF
--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -48,12 +48,18 @@ func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, e
 	if err != nil {
 		return nil, fmt.Errorf("could not get private key: %v", err)
 	}
+	var key *keystore.Key
+	for _, v := range keys {
+		key = v
+		break
+	}
 	return &ValidatorService{
 		ctx:      ctx,
 		cancel:   cancel,
 		endpoint: cfg.Endpoint,
 		withCert: cfg.CertFlag,
 		keys:     keys,
+		key:      key,
 	}, nil
 }
 


### PR DESCRIPTION
Part of #2025
Obsolete in #2069 

This is temporary fix to take the first validator key so that validators can perform their behavior until multikey support actions are supported in #2069. 