### PR TITLE
k8s: Fix podManagementPolicy for beacon-chain

### DIFF
--- a/k8s/beacon-chain/beacon-chain.deploy.yaml
+++ b/k8s/beacon-chain/beacon-chain.deploy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   replicas: 3
   serviceName: beacon-chain
+  podManagementPolicy: Parallel
   selector:
     matchLabels:
       component: beacon-chain


### PR DESCRIPTION
This allows all of the beacon-chain nodes to start at once or be torn down at once rather that in a sequence. 