### PR TITLE
Remove Marshaling of Public Key

### DIFF
--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -66,7 +66,7 @@ func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, e
 // Start the validator service. Launches the main go routine for the validator
 // client.
 func (v *ValidatorService) Start() {
-	log.WithField("publicKey", fmt.Sprintf("%#x", v.key.PublicKey.Marshal())).Info("Initializing new validator service")
+	log.Info("Initializing new validator service")
 
 	var dialOpt grpc.DialOption
 	if v.withCert != "" {


### PR DESCRIPTION
Removes marshaling of key at the start of the validator service to prevent panics.