### PR TITLE
Fix Hashing of Beacon Blocks

### DIFF
--- a/shared/hashutil/beacon_block.go
+++ b/shared/hashutil/beacon_block.go
@@ -1,6 +1,8 @@
 package hashutil
 
 import (
+	"reflect"
+
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 
@@ -8,6 +10,10 @@ import (
 // The proposer signature is ignored in order obtain the same block hash used
 // as the "block_root" property in the proposer signature data.
 func HashBeaconBlock(bb *pb.BeaconBlock) ([32]byte, error) {
+
+	if bb == nil || reflect.ValueOf(bb).IsNil() {
+		return [32]byte{}, ErrNilProto
+	}
 	// Ignore the proposer signature by temporarily deleting it.
 	sig := bb.Signature
 	bb.Signature = nil

--- a/shared/hashutil/beacon_block.go
+++ b/shared/hashutil/beacon_block.go
@@ -10,7 +10,6 @@ import (
 // The proposer signature is ignored in order obtain the same block hash used
 // as the "block_root" property in the proposer signature data.
 func HashBeaconBlock(bb *pb.BeaconBlock) ([32]byte, error) {
-
 	if bb == nil || reflect.ValueOf(bb).IsNil() {
 		return [32]byte{}, ErrNilProto
 	}

--- a/shared/hashutil/beacon_block_test.go
+++ b/shared/hashutil/beacon_block_test.go
@@ -33,3 +33,11 @@ func TestHashBeaconBlock_doesntMutate(t *testing.T) {
 		t.Error("Protos are not equal!")
 	}
 }
+
+func TestHashBeaconBlock_nil(t *testing.T) {
+	var blk *pb.BeaconBlock
+	_, err := hashutil.HashBeaconBlock(blk)
+	if err != hashutil.ErrNilProto {
+		t.Fatalf("Error from hashing nil block is not the correct type, instead it is: %v", err)
+	}
+}


### PR DESCRIPTION
This returns an error if we are about to hash a nil block instead of marshaling it and panicking.