### PR TITLE
Use infura for now for Goerli

### DIFF
--- a/k8s/beacon-chain/beacon-chain.deploy.yaml
+++ b/k8s/beacon-chain/beacon-chain.deploy.yaml
@@ -43,7 +43,7 @@ spec:
         - name: beacon-chain
           image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
           args: 
-            - --web3provider=ws://public-rpc-nodes.pow.svc.cluster.local:8546
+            - --web3provider=wss://goerli.infura.io/ws/v3/be3fb7ed377c418087602876a40affa1
             #- --verbosity=debug
             - --deposit-contract=$(DEPOSIT_CONTRACT_ADDRESS)
             - --rpc-port=4000

--- a/k8s/beacon-chain/infura.yaml
+++ b/k8s/beacon-chain/infura.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: goerli-infura-ext
+  namespace: beacon-chain
+spec:
+  hosts:
+  - goerli.infura.io
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  - number: 443
+    name: https
+    protocol: HTTPS
+  resolution: DNS
+  location: MESH_EXTERNAL


### PR DESCRIPTION
Our Goerli nodes seem to be unstable and cannot sync well.

We should ultimately have a failover from our own nodes to infura if issues are not resolved. 
Temporarily using infura nodes for goerli communication. 