### PR TITLE
Avoid using service context in blockchain package

### DIFF
--- a/beacon-chain/blockchain/block_processing_test.go
+++ b/beacon-chain/blockchain/block_processing_test.go
@@ -262,7 +262,7 @@ func TestIsBlockReadyForProcessing_ValidBlock(t *testing.T) {
 		ParentRootHash32: []byte{'a'},
 	}
 
-	if err := chainService.VerifyBlockValidity(block, beaconState); err == nil {
+	if err := chainService.VerifyBlockValidity(ctx, block, beaconState); err == nil {
 		t.Fatal("block processing succeeded despite block having no parent saved")
 	}
 
@@ -312,7 +312,7 @@ func TestIsBlockReadyForProcessing_ValidBlock(t *testing.T) {
 		},
 	}
 
-	if err := chainService.VerifyBlockValidity(block2, beaconState); err != nil {
+	if err := chainService.VerifyBlockValidity(ctx, block2, beaconState); err != nil {
 		t.Fatalf("block processing failed despite being a valid block: %v", err)
 	}
 }

--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -227,7 +227,7 @@ func TestAttestationTargets_RetrieveWorks(t *testing.T) {
 	attsService.InsertAttestationIntoStore(pubKey48, att)
 
 	chainService := setupBeaconChain(t, beaconDB, attsService)
-	attestationTargets, err := chainService.attestationTargets(state)
+	attestationTargets, err := chainService.attestationTargets(ctx, state)
 	if err != nil {
 		t.Fatalf("Could not get attestation targets: %v", err)
 	}
@@ -1078,7 +1078,7 @@ func TestUpdateFFGCheckPts_NewJustifiedSlot(t *testing.T) {
 	if err := chainSvc.beaconDB.UpdateChainHead(ctx, block, gState); err != nil {
 		t.Fatal(err)
 	}
-	if err := chainSvc.updateFFGCheckPts(gState); err != nil {
+	if err := chainSvc.updateFFGCheckPts(ctx, gState); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1161,7 +1161,7 @@ func TestUpdateFFGCheckPts_NewFinalizedSlot(t *testing.T) {
 	if err := chainSvc.beaconDB.UpdateChainHead(ctx, block, gState); err != nil {
 		t.Fatal(err)
 	}
-	if err := chainSvc.updateFFGCheckPts(gState); err != nil {
+	if err := chainSvc.updateFFGCheckPts(ctx, gState); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1239,7 +1239,7 @@ func TestUpdateFFGCheckPts_NewJustifiedSkipSlot(t *testing.T) {
 	if err := chainSvc.beaconDB.UpdateChainHead(ctx, block, gState); err != nil {
 		t.Fatal(err)
 	}
-	if err := chainSvc.updateFFGCheckPts(gState); err != nil {
+	if err := chainSvc.updateFFGCheckPts(ctx, gState); err != nil {
 		t.Fatal(err)
 	}
 

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -74,7 +74,9 @@ func (ms *mockChainService) ApplyBlockStateTransition(
 }
 
 func (ms *mockChainService) VerifyBlockValidity(
-	block *pb.BeaconBlock, beaconState *pb.BeaconState,
+	ctx context.Context,
+	block *pb.BeaconBlock,
+	beaconState *pb.BeaconState,
 ) error {
 	return nil
 }

--- a/beacon-chain/sync/initial-sync/sync_blocks.go
+++ b/beacon-chain/sync/initial-sync/sync_blocks.go
@@ -155,7 +155,7 @@ func (s *InitialSync) validateAndSaveNextBlock(ctx context.Context, block *pb.Be
 	if err != nil {
 		return err
 	}
-	if err := s.chainService.VerifyBlockValidity(block, state); err != nil {
+	if err := s.chainService.VerifyBlockValidity(ctx, block, state); err != nil {
 		return err
 	}
 	if err := s.db.SaveBlock(block); err != nil {

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -76,7 +76,7 @@ func (ms *mockChainService) ApplyBlockStateTransition(ctx context.Context, block
 	return &pb.BeaconState{}, nil
 }
 
-func (ms *mockChainService) VerifyBlockValidity(block *pb.BeaconBlock, beaconState *pb.BeaconState) error {
+func (ms *mockChainService) VerifyBlockValidity(ctx context.Context, block *pb.BeaconBlock, beaconState *pb.BeaconState) error {
 	return nil
 }
 


### PR DESCRIPTION
We should be using an argument ctx so that the span can be followed from the originating request. 