### PR TITLE
Handle skip blocks when fetching justified block for producing attestations

### DIFF
--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -90,10 +90,14 @@ func (as *AttesterServer) AttestationDataAtSlot(ctx context.Context, req *pb.Att
 	lastJustifiedSlot := helpers.StartSlot(beaconState.JustifiedEpoch)
 	justifiedBlockRoot := make([]byte, 32)
 	if lastJustifiedSlot != beaconState.Slot {
-		justifiedBlock, err := as.beaconDB.BlockBySlot(lastJustifiedSlot)
-		if err != nil {
-			return nil, fmt.Errorf("could not get justified block: %v", err)
+		var justifiedBlock *pbp2p.BeaconBlock
+		for i := uint64(0); justifiedBlock == nil && i < params.BeaconConfig().SlotsPerEpoch; i++ {
+			justifiedBlock, err = as.beaconDB.BlockBySlot(lastJustifiedSlot - i)
+			if err != nil {
+				return nil, fmt.Errorf("could not get justified block: %v", err)
+			}
 		}
+
 		justifiedBlockRoot32, err := hashutil.HashBeaconBlock(justifiedBlock)
 		if err != nil {
 			return nil, fmt.Errorf("could not get justified block: %v", err)

--- a/beacon-chain/rpc/attester_server_test.go
+++ b/beacon-chain/rpc/attester_server_test.go
@@ -202,7 +202,7 @@ func TestAttestationDataAtSlot_handlesFarAwayJustifiedEpoch(t *testing.T) {
 		Slot: helpers.StartSlot(helpers.SlotToEpoch(10000 + params.BeaconConfig().GenesisSlot)),
 	}
 	justifiedBlock := &pbp2p.BeaconBlock{
-		Slot: helpers.StartSlot(helpers.SlotToEpoch(1500 + params.BeaconConfig().GenesisSlot)),
+		Slot: helpers.StartSlot(helpers.SlotToEpoch(1500+params.BeaconConfig().GenesisSlot)) - 2, // Imagine two skip blocks
 	}
 	blockRoot, err := hashutil.HashBeaconBlock(block)
 	if err != nil {


### PR DESCRIPTION
Like #2154, could not produce attestations when justification slot was too far away, but could not resolve skip blocks. 