### PR TITLE
Make ChainHeadQuerier's Select Cases Concurrent

### DIFF
--- a/beacon-chain/sync/querier.go
+++ b/beacon-chain/sync/querier.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	queryLog = logrus.WithField("prefix", "syncQuerier")
-	chainHeadPollingInterval = 5*time.Second
+	queryLog                 = logrus.WithField("prefix", "syncQuerier")
+	chainHeadPollingInterval = 5 * time.Second
 )
 
 type powChainService interface {

--- a/beacon-chain/sync/querier.go
+++ b/beacon-chain/sync/querier.go
@@ -15,7 +15,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var queryLog = logrus.WithField("prefix", "syncQuerier")
+var (
+	queryLog = logrus.WithField("prefix", "syncQuerier")
+	chainHeadPollingInterval = 5*time.Second
+)
 
 type powChainService interface {
 	HasChainStartLogOccurred() (bool, uint64, error)
@@ -142,7 +145,7 @@ func (q *Querier) run() {
 	responseSub := q.p2p.Subscribe(&pb.ChainHeadResponse{}, q.responseBuf)
 	// Ticker so that service will keep on requesting for chain head
 	// until they get a response.
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(chainHeadPollingInterval)
 
 	defer func() {
 		responseSub.Unsubscribe()

--- a/beacon-chain/sync/querier.go
+++ b/beacon-chain/sync/querier.go
@@ -175,7 +175,7 @@ func (q *Querier) RequestLatestHead() {
 	q.p2p.Broadcast(context.Background(), request)
 }
 
-func (q *Querier) handleLatestHeadResponse(msg p2p.Message, ticker time.Ticker, sub event.Subscription) {
+func (q *Querier) handleLatestHeadResponse(msg p2p.Message, ticker *time.Ticker, sub event.Subscription) {
 	response := msg.Data.(*pb.ChainHeadResponse)
 	queryLog.Infof(
 		"Latest chain head is at slot: %d and state root: %#x",

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -135,9 +135,9 @@ func (s *Server) Start() {
 		}
 		bcfg := kaddht.DefaultBootstrapConfig
 		bcfg.Period = time.Duration(30 * time.Second)
-		//if err := s.dht.BootstrapWithConfig(ctx, bcfg); err != nil {
-		//	log.Errorf("Failed to bootstrap DHT: %v", err)
-		//}
+		if err := s.dht.BootstrapWithConfig(ctx, bcfg); err != nil {
+			log.Errorf("Failed to bootstrap DHT: %v", err)
+		}
 	}
 
 	if s.relayNodeAddr != "" {


### PR DESCRIPTION
No tracking issue for this PR.

---

# Description

**Write why you are making the changes in this pull request**

Before initial sync, we send our chain head requests to nodes in a `for select` block that works as follows:
```go
for {
	select {
	case <-q.ctx.Done():
		queryLog.Info("Exiting goroutine")
		return
	case <-ticker.C:
		q.RequestLatestHead()
	case msg := <-q.responseBuf:
		q.handleLatestHeadResponse(msg, ticker, responseSub)
	}
}
```

This is problematic because we're spamming messages every second and we are not handling responses concurrently.

**Write a summary of the changes you are making**

Similar to how we made regular sync concurrent, we spin off every case into its own goroutine. Additionally, we only send chain head queries every 5 seconds to not spam the network.

```go
for {
	select {
	case <-q.ctx.Done():
		queryLog.Info("Exiting goroutine")
		return
	case <-ticker.C:
		go q.RequestLatestHead()
	case msg := <-q.responseBuf:
		go q.handleLatestHeadResponse(msg, ticker, responseSub)
	}
}
```

**Link anything that would be helpful or relevant to the reviewers**
