### PR TITLE
Lower the p2p peer count minimum for a successful status

### DIFF
--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -164,8 +164,8 @@ func (s *Server) Stop() error {
 
 // Status returns an error if the p2p service does not have sufficient peers.
 func (s *Server) Status() error {
-	if peerCount(s.host) < 5 {
-		return errors.New("less than 5 peers")
+	if peerCount(s.host) < 3 {
+		return errors.New("less than 3 peers")
 	}
 	return nil
 }

--- a/shared/p2p/service_test.go
+++ b/shared/p2p/service_test.go
@@ -418,14 +418,14 @@ func TestRegisterTopic_HandlesPanic(t *testing.T) {
 }
 
 func TestStatus_MinimumPeers(t *testing.T) {
-	minPeers := 5
+	minPeers := 3
 
 	ctx := context.Background()
 	h := bhost.NewBlankHost(swarmt.GenSwarm(t, ctx))
 	s := Server{host: h}
 
 	err := s.Status()
-	if err == nil || err.Error() != "less than 5 peers" {
+	if err == nil || err.Error() != "less than 3 peers" {
 		t.Errorf("p2p server did not return expected status, instead returned %v", err)
 	}
 


### PR DESCRIPTION
Given that a node has at least 3 peers, rather than 5, it should be adequate to serve requests to validators. 