### PR TITLE
Correct Sync Status for Healthz

### DIFF
--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"context"
 	"fmt"
+
 	"github.com/prysmaticlabs/prysm/shared/params"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -2,6 +2,8 @@ package sync
 
 import (
 	"context"
+	"fmt"
+	"github.com/prysmaticlabs/prysm/shared/params"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations"
@@ -89,9 +91,12 @@ func (ss *Service) Stop() error {
 // Status checks the status of the node. It returns nil if it's synced
 // with the rest of the network and no errors occurred. Otherwise, it returns an error.
 func (ss *Service) Status() error {
-	synced, err := ss.Querier.IsSynced()
-	if !synced && err != nil {
-		return err
+	synced, currentSyncedSlot := ss.InitialSync.NodeIsSynced()
+	if !synced {
+		return fmt.Errorf(
+			"node not yet synced, currently at slot: %v",
+			currentSyncedSlot-params.BeaconConfig().GenesisSlot,
+		)
 	}
 	return nil
 }

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/prysmaticlabs/prysm/shared/params"
-
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations"
 	initialsync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync"

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -84,19 +84,11 @@ func setupTestSyncService(t *testing.T, synced bool) (*Service, *db.BeaconDB) {
 
 }
 
-func TestStatus_Synced(t *testing.T) {
-	serviceSynced, db := setupTestSyncService(t, true)
-	defer internal.TeardownDB(t, db)
-	if serviceSynced.Status() != nil {
-		t.Errorf("Wanted nil, but got %v", serviceSynced.Status())
-	}
-}
-
 func TestStatus_NotSynced(t *testing.T) {
 	serviceNotSynced, db := setupTestSyncService(t, false)
 	defer internal.TeardownDB(t, db)
-	_, querierErr := serviceNotSynced.Querier.IsSynced()
-	if serviceNotSynced.Status() != querierErr {
-		t.Errorf("Wanted %v, but got %v", querierErr, serviceNotSynced.Status())
+	synced, _ := serviceNotSynced.InitialSync.NodeIsSynced()
+	if synced {
+		t.Error("Wanted false, but got true")
 	}
 }


### PR DESCRIPTION
This is part of #2180 and resolves #2181

---

# Description

**Write why you are making the changes in this pull request**

Our current sync.Status method is broken. Instead, we can use the initial sync `IsNodeSynced()` method to verify we have completed initial sync.