### PR TITLE
If At Genesis or !ChainStarted, Return Healthy Sync Status

### DIFF
--- a/beacon-chain/sync/querier.go
+++ b/beacon-chain/sync/querier.go
@@ -186,7 +186,10 @@ func (q *Querier) RequestLatestHead() {
 // IsSynced checks if the node is currently synced with the
 // rest of the network.
 func (q *Querier) IsSynced() (bool, error) {
-	if q.chainStarted && q.atGenesis {
+	if !q.chainStarted  {
+		return true, nil
+	}
+	if q.atGenesis {
 		return true, nil
 	}
 	block, err := q.db.ChainHead()

--- a/beacon-chain/sync/querier.go
+++ b/beacon-chain/sync/querier.go
@@ -186,7 +186,7 @@ func (q *Querier) RequestLatestHead() {
 // IsSynced checks if the node is currently synced with the
 // rest of the network.
 func (q *Querier) IsSynced() (bool, error) {
-	if !q.chainStarted  {
+	if !q.chainStarted {
 		return true, nil
 	}
 	if q.atGenesis {

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations"
 	initialsync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
 )
 

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -91,6 +91,12 @@ func (ss *Service) Stop() error {
 // Status checks the status of the node. It returns nil if it's synced
 // with the rest of the network and no errors occurred. Otherwise, it returns an error.
 func (ss *Service) Status() error {
+	if !ss.Querier.chainStarted {
+		return nil
+	}
+	if ss.Querier.atGenesis {
+		return nil
+	}
 	synced, currentSyncedSlot := ss.InitialSync.NodeIsSynced()
 	if !synced {
 		return fmt.Errorf(

--- a/beacon-chain/sync/simulated_sync_test.go
+++ b/beacon-chain/sync/simulated_sync_test.go
@@ -223,6 +223,8 @@ func setUpUnSyncedService(simP2P *simulatedP2P, stateRoot [32]byte, t *testing.T
 	ss := NewSyncService(context.Background(), cfg)
 
 	go ss.run()
+	ss.Querier.chainStarted = true
+	ss.Querier.atGenesis = false
 
 	for ss.Querier.currentHeadSlot == 0 {
 		simP2P.Send(simP2P.ctx, &pb.ChainHeadResponse{


### PR DESCRIPTION
Follow up to #2182 
Resolves #2181 

---

# Description

**Write why you are making the changes in this pull request**

If the node is at genesis, return healthy sync status. If prechainstart, return healthy status as well.