### PR TITLE
Add in Committee size to Set Bitfield

### DIFF
--- a/shared/bitutil/BUILD.bazel
+++ b/shared/bitutil/BUILD.bazel
@@ -15,4 +15,5 @@ go_test(
     name = "go_default_test",
     srcs = ["bit_test.go"],
     embed = [":go_default_library"],
+    deps = ["//shared/mathutil:go_default_library"],
 )

--- a/shared/bitutil/bit.go
+++ b/shared/bitutil/bit.go
@@ -4,9 +4,26 @@ import (
 	"fmt"
 
 	"github.com/prysmaticlabs/prysm/shared/mathutil"
-
 	"github.com/steakknife/hamming"
 )
+
+// SetBitfield takes an index and returns bitfield with the index flipped.
+func SetBitfield(index int, committeeSize int) []byte {
+	chunkLocation := index / 8
+	indexLocation := mathutil.PowerOf2(uint64(7 - (index % 8)))
+	var bitfield []byte
+
+	for i := 0; i < chunkLocation; i++ {
+		bitfield = append(bitfield, byte(0))
+	}
+	bitfield = append(bitfield, byte(indexLocation))
+
+	for len(bitfield) < committeeSize {
+		bitfield = append(bitfield, byte(0))
+	}
+
+	return bitfield
+}
 
 // CheckBit checks if a bit in a bit field (small endian) is one.
 func CheckBit(bitfield []byte, index int) (bool, error) {
@@ -36,20 +53,6 @@ func BitSetCount(b []byte) int {
 // BitLength returns the length of the bitfield in bytes.
 func BitLength(b int) int {
 	return (b + 7) / 8
-}
-
-// SetBitfield takes an index and returns bitfield with the index flipped.
-func SetBitfield(index int) []byte {
-	chunkLocation := index / 8
-	indexLocation := mathutil.PowerOf2(uint64(7 - (index % 8)))
-	var bitfield []byte
-
-	for i := 0; i < chunkLocation; i++ {
-		bitfield = append(bitfield, byte(0))
-	}
-	bitfield = append(bitfield, byte(indexLocation))
-
-	return bitfield
 }
 
 // FillBitfield returns a bitfield of length `count`, all set to true.

--- a/shared/bitutil/bit.go
+++ b/shared/bitutil/bit.go
@@ -18,7 +18,7 @@ func SetBitfield(index int, committeeLength int) []byte {
 	}
 	bitfield = append(bitfield, byte(indexLocation))
 
-	for len(bitfield) < committeeSize {
+	for len(bitfield) < committeeLength {
 		bitfield = append(bitfield, byte(0))
 	}
 

--- a/shared/bitutil/bit_test.go
+++ b/shared/bitutil/bit_test.go
@@ -85,3 +85,26 @@ func TestBitSet(t *testing.T) {
 		}
 	}
 }
+
+func TestRoundtripBitSetAndCheck(t *testing.T) {
+	tests := []struct {
+		a int
+		b []byte
+	}{
+		{a: 300, b: []byte{128}},   //10000000
+		{a: 10000, b: []byte{64}},  //01000000
+		{a: 800, b: []byte{4}},     //00000100
+		{a: 809, b: []byte{0, 32}}, //00000000 00100000
+		{a: 100, b: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8}},
+	}
+	for _, tt := range tests {
+		bfield := SetBitfield(tt.a)
+		indexExists, err := CheckBit(bfield, tt.a)
+		if err != nil {
+			t.Errorf("checking bit for index %d leads to : %v", tt.a, err)
+		}
+		if !indexExists {
+			t.Errorf("Index %d has a malformed bitfield %v", tt.a, bfield)
+		}
+	}
+}

--- a/shared/bitutil/bit_test.go
+++ b/shared/bitutil/bit_test.go
@@ -104,7 +104,7 @@ func TestSetBitfield_LargerCommitteesThanIndex(t *testing.T) {
 		bfield := SetBitfield(tt.a, tt.c)
 
 		if len(bfield) != tt.c {
-			t.Errorf("Length of bitfield doesnt match inputted committe size, got: %d but expected: %d", len(bfield), tt.c)
+			t.Errorf("Length of bitfield doesnt match the inputted committee size, got: %d but expected: %d", len(bfield), tt.c)
 		}
 
 	}

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//shared/forkutil:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/keystore:go_default_library",
+        "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/slotutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//shared:go_default_library",
         "//shared/bitutil:go_default_library",
         "//shared/keystore:go_default_library",
+        "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
         "//validator/accounts:go_default_library",

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/shared/mathutil"
+
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/prysmaticlabs/prysm/shared/bitutil"
@@ -60,6 +62,9 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64) {
 			slot-params.BeaconConfig().GenesisSlot, err)
 		return
 	}
+
+	lengthOfCommitte := mathutil.CeilDiv8(len(v.assignment.Assignment[0].Committee))
+
 	// Set the attestation data's slot to head_state.slot where the slot
 	// is the canonical head of the beacon chain.
 	attData.Slot = infoRes.HeadSlot
@@ -89,7 +94,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64) {
 
 	// We set the custody bitfield to an slice of zero values as a stub for phase 0
 	// of length len(committee)+7 // 8.
-	attestation.CustodyBitfield = make([]byte, (len(v.assignment.Assignment[0].Committee)+7)/8)
+	attestation.CustodyBitfield = make([]byte, lengthOfCommitte)
 
 	// Find the index in committee to be used for
 	// the aggregation bitfield
@@ -101,7 +106,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64) {
 		}
 	}
 
-	aggregationBitfield := bitutil.SetBitfield(indexInCommittee)
+	aggregationBitfield := bitutil.SetBitfield(indexInCommittee, lengthOfCommitte)
 	attestation.AggregationBitfield = aggregationBitfield
 
 	// TODO(#1366): Use BLS to generate an aggregate signature.

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -93,7 +93,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64) {
 
 	// We set the custody bitfield to an slice of zero values as a stub for phase 0
 	// of length len(committee)+7 // 8.
-	attestation.CustodyBitfield = make([]byte, lengthOfCommitte)
+	attestation.CustodyBitfield = make([]byte, committeeLength)
 
 	// Find the index in committee to be used for
 	// the aggregation bitfield
@@ -105,7 +105,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64) {
 		}
 	}
 
-	aggregationBitfield := bitutil.SetBitfield(indexInCommittee, lengthOfCommitte)
+	aggregationBitfield := bitutil.SetBitfield(indexInCommittee, committeeLength)
 	attestation.AggregationBitfield = aggregationBitfield
 
 	// TODO(#1366): Use BLS to generate an aggregate signature.

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/prysmaticlabs/prysm/shared/mathutil"
-
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/prysmaticlabs/prysm/shared/bitutil"
+	"github.com/prysmaticlabs/prysm/shared/mathutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prysmaticlabs/prysm/shared/mathutil"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/mock/gomock"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/prysmaticlabs/prysm/shared/bitutil"
+	"github.com/prysmaticlabs/prysm/shared/mathutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/shared/mathutil"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/mock/gomock"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -144,7 +146,7 @@ func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
 		CustodyBitfield:    make([]byte, (len(committee)+7)/8),
 		AggregateSignature: []byte("signed"),
 	}
-	aggregationBitfield := bitutil.SetBitfield(4, (len(committee)+7)/8)
+	aggregationBitfield := bitutil.SetBitfield(4, mathutil.CeilDiv8(len(committee)))
 	expectedAttestation.AggregationBitfield = aggregationBitfield
 	if !proto.Equal(generatedAttestation, expectedAttestation) {
 		t.Errorf("Incorrectly attested head, wanted %v, received %v", expectedAttestation, generatedAttestation)

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -144,7 +144,7 @@ func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
 		CustodyBitfield:    make([]byte, (len(committee)+7)/8),
 		AggregateSignature: []byte("signed"),
 	}
-	aggregationBitfield := bitutil.SetBitfield(4, len(committee)+7/8)
+	aggregationBitfield := bitutil.SetBitfield(4, (len(committee)+7)/8)
 	expectedAttestation.AggregationBitfield = aggregationBitfield
 	if !proto.Equal(generatedAttestation, expectedAttestation) {
 		t.Errorf("Incorrectly attested head, wanted %v, received %v", expectedAttestation, generatedAttestation)


### PR DESCRIPTION
This resolves #2224, where bitfields were being constructed with smaller committee sizes, which failed verification. So this PR adds in the committee size when constructing a bitfield to mitigate that