### PR TITLE
Bitfield Fix Again

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -271,7 +271,7 @@ func AttestationParticipants(
 		}
 	}
 
-	if isValidated, err := VerifyBitfield(bitfield, len(committee)); !isValidated || err != nil {
+	if isValidated, err := VerifyBitfield(bitfield, mathutil.CeilDiv8(len(committee))); !isValidated || err != nil {
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Uses `CeilDiv8` for length of Committee in `AttestationParticipants`