### PR TITLE
Remove too many spans in block/slot/epoch processing

### DIFF
--- a/beacon-chain/core/balances/BUILD.bazel
+++ b/beacon-chain/core/balances/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/params:go_default_library",
         "//shared/sliceutil:go_default_library",
-        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/balances/rewards_penalties.go
+++ b/beacon-chain/core/balances/rewards_penalties.go
@@ -14,7 +14,6 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
-	"go.opencensus.io/trace"
 )
 
 // ExpectedFFGSource applies rewards or penalties
@@ -30,15 +29,11 @@ import (
 //	  Any active validator v not in previous_epoch_justified_attester_indices
 //	  loses base_reward(state, index).
 func ExpectedFFGSource(
-	ctx context.Context,
 	state *pb.BeaconState,
 	justifiedAttesterIndices []uint64,
 	justifiedAttestingBalance uint64,
 	totalBalance uint64) *pb.BeaconState {
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ExpectedFFGSourceRewards")
-	defer span.End()
 
 	for _, index := range justifiedAttesterIndices {
 		state.ValidatorBalances[index] +=
@@ -69,14 +64,10 @@ func ExpectedFFGSource(
 //	  Any active validator index not in previous_epoch_boundary_attester_indices loses
 //	  base_reward(state, index).
 func ExpectedFFGTarget(
-	ctx context.Context,
 	state *pb.BeaconState,
 	boundaryAttesterIndices []uint64,
 	boundaryAttestingBalance uint64,
 	totalBalance uint64) *pb.BeaconState {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ExpectedFFGTargetRewards")
-	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
 
@@ -109,14 +100,10 @@ func ExpectedFFGTarget(
 //    Any active validator index not in previous_epoch_head_attester_indices loses
 //    base_reward(state, index).
 func ExpectedBeaconChainHead(
-	ctx context.Context,
 	state *pb.BeaconState,
 	headAttesterIndices []uint64,
 	headAttestingBalance uint64,
 	totalBalance uint64) *pb.BeaconState {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ExpectedBeaconChainHeadRewards")
-	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
 
@@ -150,9 +137,6 @@ func InclusionDistance(
 	attesterIndices []uint64,
 	totalBalance uint64) (*pb.BeaconState, error) {
 
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ExpectedInclusionDistanceRewards")
-	defer span.End()
-
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
 
 	for _, index := range attesterIndices {
@@ -179,14 +163,10 @@ func InclusionDistance(
 //    Any active validator index not in previous_epoch_justified_attester_indices,
 //    loses inactivity_penalty(state, index, epochs_since_finality)
 func InactivityFFGSource(
-	ctx context.Context,
 	state *pb.BeaconState,
 	justifiedAttesterIndices []uint64,
 	totalBalance uint64,
 	epochsSinceFinality uint64) *pb.BeaconState {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.InactivityFFGSourcePenalties")
-	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
 	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, helpers.CurrentEpoch(state))
@@ -207,14 +187,10 @@ func InactivityFFGSource(
 //    Any active validator index not in previous_epoch_boundary_attester_indices,
 // 	  loses inactivity_penalty(state, index, epochs_since_finality)
 func InactivityFFGTarget(
-	ctx context.Context,
 	state *pb.BeaconState,
 	boundaryAttesterIndices []uint64,
 	totalBalance uint64,
 	epochsSinceFinality uint64) *pb.BeaconState {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.InactivityFFGTargetPenalties")
-	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
 	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, helpers.CurrentEpoch(state))
@@ -235,13 +211,9 @@ func InactivityFFGTarget(
 //    Any active validator index not in previous_epoch_head_attester_indices,
 // 	  loses base_reward(state, index)
 func InactivityChainHead(
-	ctx context.Context,
 	state *pb.BeaconState,
 	headAttesterIndices []uint64,
 	totalBalance uint64) *pb.BeaconState {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.InactivityChainHeadPenalties")
-	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
 	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, helpers.CurrentEpoch(state))
@@ -262,13 +234,9 @@ func InactivityChainHead(
 //    loses 2 * inactivity_penalty(state, index, epochs_since_finality) +
 //    base_reward(state, index).
 func InactivityExitedPenalties(
-	ctx context.Context,
 	state *pb.BeaconState,
 	totalBalance uint64,
 	epochsSinceFinality uint64) *pb.BeaconState {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.InactivityExitedPenalties")
-	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
 	currentEpoch := helpers.CurrentEpoch(state)
@@ -292,13 +260,9 @@ func InactivityExitedPenalties(
 //    base_reward(state, index) - base_reward(state, index) *
 //    MIN_ATTESTATION_INCLUSION_DELAY // inclusion_distance(state, index)
 func InactivityInclusionDistance(
-	ctx context.Context,
 	state *pb.BeaconState,
 	attesterIndices []uint64,
 	totalBalance uint64) (*pb.BeaconState, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.InactivityInclusionDistancePenalties")
-	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
 
@@ -325,13 +289,9 @@ func InactivityInclusionDistance(
 //    and set state.validator_balances[proposer_index] +=
 //    base_reward(state, index) // ATTESTATION_INCLUSION_REWARD_QUOTIENT
 func AttestationInclusion(
-	ctx context.Context,
 	state *pb.BeaconState,
 	totalBalance uint64,
 	prevEpochAttesterIndices []uint64) (*pb.BeaconState, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.AttestationInclusion")
-	defer span.End()
 
 	baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
 	for _, index := range prevEpochAttesterIndices {
@@ -365,13 +325,9 @@ func AttestationInclusion(
 //			If index not in attesting_validators(crosslink_committee),
 //			state.validator_balances[index] -= base_reward(state, index).
 func Crosslinks(
-	ctx context.Context,
 	state *pb.BeaconState,
 	thisEpochAttestations []*pb.PendingAttestation,
 	prevEpochAttestations []*pb.PendingAttestation) (*pb.BeaconState, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.CrosslinkBalances")
-	defer span.End()
 
 	prevEpoch := helpers.PrevEpoch(state)
 	currentEpoch := helpers.CurrentEpoch(state)
@@ -390,16 +346,15 @@ func Crosslinks(
 			shard := crosslinkCommittee.Shard
 			committee := crosslinkCommittee.Committee
 			totalAttestingBalance, err :=
-				epoch.TotalAttestingBalance(ctx, state, shard, thisEpochAttestations, prevEpochAttestations)
+				epoch.TotalAttestingBalance(state, shard, thisEpochAttestations, prevEpochAttestations)
 			if err != nil {
 				return nil,
 					fmt.Errorf("could not get attesting balance for shard committee %d: %v", shard, err)
 			}
-			totalBalance := epoch.TotalBalance(ctx, state, committee)
+			totalBalance := epoch.TotalBalance(state, committee)
 			baseRewardQuotient := helpers.BaseRewardQuotient(totalBalance)
 
 			attestingIndices, err := epoch.AttestingValidators(
-				ctx,
 				state,
 				shard,
 				thisEpochAttestations,

--- a/beacon-chain/core/balances/rewards_penalties_test.go
+++ b/beacon-chain/core/balances/rewards_penalties_test.go
@@ -43,7 +43,6 @@ func TestFFGSrcRewardsPenalties_AccurateBalances(t *testing.T) {
 			ValidatorBalances: validatorBalances,
 		}
 		state = ExpectedFFGSource(
-			context.Background(),
 			state,
 			tt.voted,
 			uint64(len(tt.voted))*params.BeaconConfig().MaxDepositAmount,
@@ -83,7 +82,6 @@ func TestFFGTargetRewardsPenalties_AccurateBalances(t *testing.T) {
 			ValidatorBalances: validatorBalances,
 		}
 		state = ExpectedFFGTarget(
-			context.Background(),
 			state,
 			tt.voted,
 			uint64(len(tt.voted))*params.BeaconConfig().MaxDepositAmount,
@@ -123,7 +121,6 @@ func TestChainHeadRewardsPenalties_AccuratePenalties(t *testing.T) {
 			ValidatorBalances: validatorBalances,
 		}
 		state = ExpectedBeaconChainHead(
-			context.Background(),
 			state,
 			tt.voted,
 			uint64(len(tt.voted))*params.BeaconConfig().MaxDepositAmount,
@@ -251,7 +248,6 @@ func TestInactivityFFGSrcPenalty_AccuratePenalties(t *testing.T) {
 			ValidatorBalances: validatorBalances,
 		}
 		state = InactivityFFGSource(
-			context.Background(),
 			state,
 			tt.voted,
 			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount,
@@ -291,7 +287,6 @@ func TestInactivityFFGTargetPenalty_AccuratePenalties(t *testing.T) {
 			ValidatorBalances: validatorBalances,
 		}
 		state = InactivityFFGTarget(
-			context.Background(),
 			state,
 			tt.voted,
 			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount,
@@ -328,7 +323,6 @@ func TestInactivityHeadPenalty_AccuratePenalties(t *testing.T) {
 			ValidatorBalances: validatorBalances,
 		}
 		state = InactivityChainHead(
-			context.Background(),
 			state,
 			tt.voted,
 			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount)
@@ -363,7 +357,6 @@ func TestInactivityExitedPenality_AccuratePenalties(t *testing.T) {
 			ValidatorBalances: validatorBalances,
 		}
 		state = InactivityExitedPenalties(
-			context.Background(),
 			state,
 			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount,
 			tt.epochsSinceFinality,
@@ -413,7 +406,6 @@ func TestInactivityInclusionPenalty_AccuratePenalties(t *testing.T) {
 			LatestAttestations: attestation,
 		}
 		state, err := InactivityInclusionDistance(
-			context.Background(),
 			state,
 			tt.voted,
 			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount)
@@ -455,7 +447,7 @@ func TestInactivityInclusionPenalty_OutOfBounds(t *testing.T) {
 			ValidatorRegistry:  validators,
 			LatestAttestations: attestation,
 		}
-		_, err := InactivityInclusionDistance(context.Background(), state, tt.voted, 0)
+		_, err := InactivityInclusionDistance(state, tt.voted, 0)
 		if err == nil {
 			t.Fatal("InclusionDistRewards should have failed")
 		}
@@ -499,7 +491,6 @@ func TestAttestationInclusionRewards_AccurateRewards(t *testing.T) {
 			LatestAttestations: attestation,
 		}
 		state, err := AttestationInclusion(
-			context.Background(),
 			state,
 			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount,
 			tt.voted)
@@ -541,7 +532,7 @@ func TestAttestationInclusionRewards_NoInclusionSlot(t *testing.T) {
 			ValidatorRegistry: validators,
 			ValidatorBalances: validatorBalances,
 		}
-		if _, err := AttestationInclusion(context.Background(), state, 0, tt.voted); err == nil {
+		if _, err := AttestationInclusion(state, 0, tt.voted); err == nil {
 			t.Fatal("AttestationInclusionRewards should have failed with no inclusion slot")
 		}
 	}
@@ -577,7 +568,7 @@ func TestAttestationInclusionRewards_NoProposerIndex(t *testing.T) {
 			ValidatorBalances:  validatorBalances,
 			LatestAttestations: attestation,
 		}
-		if _, err := AttestationInclusion(context.Background(), state, 0, tt.voted); err == nil {
+		if _, err := AttestationInclusion(state, 0, tt.voted); err == nil {
 			t.Fatal("AttestationInclusionRewards should have failed with no proposer index")
 		}
 	}
@@ -620,7 +611,6 @@ func TestCrosslinksRewardsPenalties_AccurateBalances(t *testing.T) {
 			LatestAttestations: attestation,
 		}
 		state, err := Crosslinks(
-			context.Background(),
 			state,
 			attestation,
 			nil)

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/blocks/block.go
+++ b/beacon-chain/core/blocks/block.go
@@ -4,14 +4,12 @@
 package blocks
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/utils"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"go.opencensus.io/trace"
 )
 
 var clock utils.Clock = &utils.RealClock{}
@@ -72,9 +70,7 @@ func BlockRoot(state *pb.BeaconState, slot uint64) ([]byte, error) {
 //  Let previous_block_root be the tree_hash_root of the previous beacon block processed in the chain.
 //	Set state.latest_block_roots[(state.slot - 1) % LATEST_BLOCK_ROOTS_LENGTH] = previous_block_root.
 //	If state.slot % LATEST_BLOCK_ROOTS_LENGTH == 0 append merkle_root(state.latest_block_roots) to state.batched_block_roots.
-func ProcessBlockRoots(ctx context.Context, state *pb.BeaconState, parentRoot [32]byte) *pb.BeaconState {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.ProcessSlot.ProcessBlockRoots")
-	defer span.End()
+func ProcessBlockRoots(state *pb.BeaconState, parentRoot [32]byte) *pb.BeaconState {
 	state.LatestBlockRootHash32S[(state.Slot-1)%params.BeaconConfig().LatestBlockRootsLength] = parentRoot[:]
 	if state.Slot%params.BeaconConfig().LatestBlockRootsLength == 0 {
 		merkleRoot := hashutil.MerkleRoot(state.LatestBlockRootHash32S)

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -5,7 +5,6 @@ package blocks
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -22,7 +21,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
 	"github.com/sirupsen/logrus"
-	"go.opencensus.io/trace"
 )
 
 // VerifyProposerSignature uses BLS signature verification to ensure
@@ -31,11 +29,8 @@ import (
 //
 // WIP - this is stubbed out until BLS is integrated into Prysm.
 func VerifyProposerSignature(
-	ctx context.Context,
 	_ *pb.BeaconBlock,
 ) error {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock.VerifyProposerSignature")
-	defer span.End()
 
 	return nil
 }
@@ -48,10 +43,7 @@ func VerifyProposerSignature(
 //   If block.eth1_data equals eth1_data_vote.eth1_data for some eth1_data_vote
 //   in state.eth1_data_votes, set eth1_data_vote.vote_count += 1.
 //   Otherwise, append to state.eth1_data_votes a new Eth1DataVote(eth1_data=block.eth1_data, vote_count=1).
-func ProcessEth1DataInBlock(ctx context.Context, beaconState *pb.BeaconState, block *pb.BeaconBlock) *pb.BeaconState {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock.ProcessEth1DataInBlock")
-	defer span.End()
-
+func ProcessEth1DataInBlock(beaconState *pb.BeaconState, block *pb.BeaconBlock) *pb.BeaconState {
 	var eth1DataVoteAdded bool
 
 	for idx := range beaconState.Eth1DataVotes {
@@ -86,14 +78,11 @@ func ProcessEth1DataInBlock(ctx context.Context, beaconState *pb.BeaconState, bl
 //   Set state.latest_randao_mixes[get_current_epoch(state) % LATEST_RANDAO_MIXES_LENGTH] =
 //     xor(get_randao_mix(state, get_current_epoch(state)), hash(block.randao_reveal))
 func ProcessBlockRandao(
-	ctx context.Context,
 	beaconState *pb.BeaconState,
 	block *pb.BeaconBlock,
 	verifySignatures bool,
 	enableLogging bool,
 ) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock.ProcessBlockRandao")
-	defer span.End()
 
 	proposerIdx, err := helpers.BeaconProposerIndex(beaconState, beaconState.Slot)
 	if err != nil {
@@ -166,13 +155,10 @@ func verifyBlockRandao(beaconState *pb.BeaconState, block *pb.BeaconBlock, propo
 //       domain=get_domain(state.fork, slot_to_epoch(proposer_slashing.proposal_data_2.slot), DOMAIN_PROPOSAL)).
 //     Run slash_validator(state, proposer_slashing.proposer_index).
 func ProcessProposerSlashings(
-	ctx context.Context,
 	beaconState *pb.BeaconState,
 	block *pb.BeaconBlock,
 	verifySignatures bool,
 ) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock.ProcessProposerSlashings")
-	defer span.End()
 
 	body := block.Body
 	registry := beaconState.ValidatorRegistry
@@ -256,14 +242,10 @@ func verifyProposerSlashing(
 //     Verify that len(slashable_indices) >= 1.
 //     Run slash_validator(state, index) for each index in slashable_indices.
 func ProcessAttesterSlashings(
-	ctx context.Context,
 	beaconState *pb.BeaconState,
 	block *pb.BeaconBlock,
 	verifySignatures bool,
 ) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock.ProcessAttesterSlashings")
-	defer span.End()
-
 	body := block.Body
 	if uint64(len(body.AttesterSlashings)) > params.BeaconConfig().MaxAttesterSlashings {
 		return nil, fmt.Errorf(
@@ -413,14 +395,10 @@ func isSurroundVote(data1 *pb.AttestationData, data2 *pb.AttestationData) bool {
 //     Append PendingAttestation(data=attestation.data, aggregation_bitfield=attestation.aggregation_bitfield,
 //       custody_bitfield=attestation.custody_bitfield, inclusion_slot=state.slot) to state.latest_attestations
 func ProcessBlockAttestations(
-	ctx context.Context,
 	beaconState *pb.BeaconState,
 	block *pb.BeaconBlock,
 	verifySignatures bool,
 ) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock.ProcessBlockAttestations")
-	defer span.End()
-
 	atts := block.Body.Attestations
 	if uint64(len(atts)) > params.BeaconConfig().MaxAttestations {
 		return nil, fmt.Errorf(
@@ -579,12 +557,9 @@ func verifyAttestation(beaconState *pb.BeaconState, att *pb.Attestation, verifyS
 //       withdrawal_credentials=deposit.deposit_data.deposit_input.withdrawal_credentials,
 //     )
 func ProcessValidatorDeposits(
-	ctx context.Context,
 	beaconState *pb.BeaconState,
 	block *pb.BeaconBlock,
 ) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock.ProcessValidatorDeposits")
-	defer span.End()
 
 	deposits := block.Body.Deposits
 	if uint64(len(deposits)) > params.BeaconConfig().MaxDeposits {
@@ -662,13 +637,10 @@ func verifyDeposit(beaconState *pb.BeaconState, deposit *pb.Deposit) error {
 //       signature=exit.signature, domain=get_domain(state.fork, exit.epoch, DOMAIN_EXIT)).
 //     Run initiate_validator_exit(state, exit.validator_index).
 func ProcessValidatorExits(
-	ctx context.Context,
 	beaconState *pb.BeaconState,
 	block *pb.BeaconBlock,
 	verifySignatures bool,
 ) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock.ProcessValidatorExits")
-	defer span.End()
 
 	exits := block.Body.VoluntaryExits
 	if uint64(len(exits)) > params.BeaconConfig().MaxVoluntaryExits {

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -2,7 +2,6 @@ package blocks_test
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
@@ -68,7 +67,7 @@ func TestProcessBlockRandao_IncorrectProposerFailsVerification(t *testing.T) {
 
 	want := "block randao reveal signature did not verify"
 	if _, err := blocks.ProcessBlockRandao(
-		context.Background(),
+
 		beaconState,
 		block,
 		true,  /* verify signatures */
@@ -100,7 +99,7 @@ func TestProcessBlockRandao_SignatureVerifiesAndUpdatesLatestStateMixes(t *testi
 	}
 
 	newState, err := blocks.ProcessBlockRandao(
-		context.Background(),
+
 		beaconState,
 		block,
 		true,  /* verify signatures */
@@ -138,7 +137,7 @@ func TestProcessEth1Data_SameRootHash(t *testing.T) {
 			BlockHash32:       []byte{2},
 		},
 	}
-	beaconState = blocks.ProcessEth1DataInBlock(context.Background(), beaconState, block)
+	beaconState = blocks.ProcessEth1DataInBlock(beaconState, block)
 	newETH1DataVotes := beaconState.Eth1DataVotes
 	if newETH1DataVotes[0].VoteCount != 6 {
 		t.Errorf("expected votes to increase from 5 to 6, received %d", newETH1DataVotes[0].VoteCount)
@@ -165,7 +164,7 @@ func TestProcessEth1Data_NewDepositRootHash(t *testing.T) {
 		},
 	}
 
-	beaconState = blocks.ProcessEth1DataInBlock(context.Background(), beaconState, block)
+	beaconState = blocks.ProcessEth1DataInBlock(beaconState, block)
 	newETH1DataVotes := beaconState.Eth1DataVotes
 	if len(newETH1DataVotes) <= 1 {
 		t.Error("expected new ETH1 data votes to have length > 1")
@@ -206,7 +205,7 @@ func TestProcessProposerSlashings_ThresholdReached(t *testing.T) {
 	}
 
 	if _, err := blocks.ProcessProposerSlashings(
-		context.Background(),
+
 		beaconState,
 		block,
 		false,
@@ -241,7 +240,7 @@ func TestProcessProposerSlashings_UnmatchedSlotNumbers(t *testing.T) {
 	}
 	want := "slashing proposal data slots do not match: 1, 0"
 	if _, err := blocks.ProcessProposerSlashings(
-		context.Background(),
+
 		beaconState,
 		block,
 		false,
@@ -278,7 +277,7 @@ func TestProcessProposerSlashings_UnmatchedShards(t *testing.T) {
 	}
 	want := "slashing proposal data shards do not match: 0, 1"
 	if _, err := blocks.ProcessProposerSlashings(
-		context.Background(),
+
 		beaconState,
 		block,
 		false,
@@ -321,7 +320,6 @@ func TestProcessProposerSlashings_UnmatchedBlockRoots(t *testing.T) {
 	)
 
 	if _, err := blocks.ProcessProposerSlashings(
-		context.Background(),
 		beaconState,
 		block,
 		false,
@@ -376,7 +374,6 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 	}
 
 	newState, err := blocks.ProcessProposerSlashings(
-		context.Background(),
 		beaconState,
 		block,
 		false,
@@ -413,7 +410,6 @@ func TestProcessAttesterSlashings_ThresholdReached(t *testing.T) {
 	)
 
 	if _, err := blocks.ProcessAttesterSlashings(
-		context.Background(),
 		beaconState,
 		block,
 		false,
@@ -462,7 +458,6 @@ func TestProcessAttesterSlashings_EmptyCustodyFields(t *testing.T) {
 	want := fmt.Sprint("custody bit field can't all be 0")
 
 	if _, err := blocks.ProcessAttesterSlashings(
-		context.Background(),
 		beaconState,
 		block,
 		false,
@@ -505,7 +500,6 @@ func TestProcessAttesterSlashings_EmptyCustodyFields(t *testing.T) {
 		},
 	}
 	if _, err := blocks.ProcessAttesterSlashings(
-		context.Background(),
 		beaconState,
 		block,
 		false,
@@ -551,7 +545,6 @@ func TestProcessAttesterSlashings_UnmatchedAttestations(t *testing.T) {
 	)
 
 	if _, err := blocks.ProcessAttesterSlashings(
-		context.Background(),
 		beaconState,
 		block,
 		false,
@@ -597,7 +590,6 @@ func TestProcessAttesterSlashings_EmptyVoteIndexIntersection(t *testing.T) {
 	}
 	want := "expected a non-empty list"
 	if _, err := blocks.ProcessAttesterSlashings(
-		context.Background(),
 		beaconState,
 		block,
 		false,
@@ -659,7 +651,6 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 		},
 	}
 	newState, err := blocks.ProcessAttesterSlashings(
-		context.Background(),
 		beaconState,
 		block,
 		false,
@@ -699,7 +690,6 @@ func TestProcessBlockAttestations_ThresholdReached(t *testing.T) {
 	)
 
 	if _, err := blocks.ProcessBlockAttestations(
-		context.Background(),
 		state,
 		block,
 		false,
@@ -732,7 +722,6 @@ func TestProcessBlockAttestations_InclusionDelayFailure(t *testing.T) {
 		5,
 	)
 	if _, err := blocks.ProcessBlockAttestations(
-		context.Background(),
 		state,
 		block,
 		false,
@@ -765,7 +754,6 @@ func TestProcessBlockAttestations_EpochDistanceFailure(t *testing.T) {
 		5+2*params.BeaconConfig().SlotsPerEpoch,
 	)
 	if _, err := blocks.ProcessBlockAttestations(
-		context.Background(),
 		state,
 		block,
 		false,
@@ -799,7 +787,6 @@ func TestProcessBlockAttestations_JustifiedEpochVerificationFailure(t *testing.T
 		1,
 	)
 	if _, err := blocks.ProcessBlockAttestations(
-		context.Background(),
 		state,
 		block,
 		false,
@@ -833,7 +820,6 @@ func TestProcessBlockAttestations_PreviousJustifiedEpochVerificationFailure(t *t
 		2,
 	)
 	if _, err := blocks.ProcessBlockAttestations(
-		context.Background(),
 		state,
 		block,
 		false,
@@ -886,7 +872,7 @@ func TestProcessBlockAttestations_CrosslinkRootFailure(t *testing.T) {
 		attestations[0].Data.Shard,
 	)
 	if _, err := blocks.ProcessBlockAttestations(
-		context.Background(),
+
 		state,
 		block,
 		false,
@@ -935,7 +921,7 @@ func TestProcessBlockAttestations_ShardBlockRootEqualZeroHashFailure(t *testing.
 		[]byte{1},
 	)
 	if _, err := blocks.ProcessBlockAttestations(
-		context.Background(),
+
 		state,
 		block,
 		false,
@@ -980,7 +966,7 @@ func TestProcessBlockAttestations_CreatePendingAttestations(t *testing.T) {
 		},
 	}
 	newState, err := blocks.ProcessBlockAttestations(
-		context.Background(),
+
 		state,
 		block,
 		false,
@@ -1014,7 +1000,7 @@ func TestProcessValidatorDeposits_ThresholdReached(t *testing.T) {
 	beaconState := &pb.BeaconState{}
 	want := "exceeds allowed threshold"
 	if _, err := blocks.ProcessValidatorDeposits(
-		context.Background(),
+
 		beaconState,
 		block,
 	); !strings.Contains(err.Error(), want) {
@@ -1035,7 +1021,7 @@ func TestProcessValidatorDeposits_DepositDataSizeTooSmall(t *testing.T) {
 	beaconState := &pb.BeaconState{}
 	want := "deposit data slice too small"
 	if _, err := blocks.ProcessValidatorDeposits(
-		context.Background(),
+
 		beaconState,
 		block,
 	); !strings.Contains(err.Error(), want) {
@@ -1056,7 +1042,7 @@ func TestProcessValidatorDeposits_DepositInputDecodingFails(t *testing.T) {
 	beaconState := &pb.BeaconState{}
 	want := "ssz decode failed"
 	if _, err := blocks.ProcessValidatorDeposits(
-		context.Background(),
+
 		beaconState,
 		block,
 	); !strings.Contains(err.Error(), want) {
@@ -1109,7 +1095,7 @@ func TestProcessValidatorDeposits_MerkleBranchFailsVerification(t *testing.T) {
 	}
 	want := "merkle branch of deposit root did not verify"
 	if _, err := blocks.ProcessValidatorDeposits(
-		context.Background(),
+
 		beaconState,
 		block,
 	); !strings.Contains(err.Error(), want) {
@@ -1196,7 +1182,7 @@ func TestProcessValidatorDeposits_ProcessDepositHelperFuncFails(t *testing.T) {
 	}
 	want := "expected withdrawal credentials to match"
 	if _, err := blocks.ProcessValidatorDeposits(
-		context.Background(),
+
 		beaconState,
 		block,
 	); !strings.Contains(err.Error(), want) {
@@ -1279,7 +1265,7 @@ func TestProcessValidatorDeposits_ProcessCorrectly(t *testing.T) {
 		GenesisTime: uint64(genesisTime),
 	}
 	newState, err := blocks.ProcessValidatorDeposits(
-		context.Background(),
+
 		beaconState,
 		block,
 	)
@@ -1314,7 +1300,7 @@ func TestProcessValidatorExits_ThresholdReached(t *testing.T) {
 	)
 
 	if _, err := blocks.ProcessValidatorExits(
-		context.Background(),
+
 		state,
 		block,
 		false,
@@ -1346,7 +1332,7 @@ func TestProcessValidatorExits_ValidatorNotActive(t *testing.T) {
 	want := "validator exit epoch should be > entry_exit_effect_epoch"
 
 	if _, err := blocks.ProcessValidatorExits(
-		context.Background(),
+
 		state,
 		block,
 		false,
@@ -1379,7 +1365,7 @@ func TestProcessValidatorExits_InvalidExitEpoch(t *testing.T) {
 	want := "expected current epoch >= exit.epoch"
 
 	if _, err := blocks.ProcessValidatorExits(
-		context.Background(),
+
 		state,
 		block,
 		false,
@@ -1412,7 +1398,7 @@ func TestProcessValidatorExits_InvalidStatusChangeSlot(t *testing.T) {
 
 	want := "exit epoch should be > entry_exit_effect_epoch"
 	if _, err := blocks.ProcessValidatorExits(
-		context.Background(),
+
 		state,
 		block,
 		false,
@@ -1442,7 +1428,7 @@ func TestProcessValidatorExits_AppliesCorrectStatus(t *testing.T) {
 			VoluntaryExits: exits,
 		},
 	}
-	newState, err := blocks.ProcessValidatorExits(context.Background(), state, block, false)
+	newState, err := blocks.ProcessValidatorExits(state, block, false)
 	if err != nil {
 		t.Fatalf("Could not process exits: %v", err)
 	}

--- a/beacon-chain/core/blocks/block_test.go
+++ b/beacon-chain/core/blocks/block_test.go
@@ -2,7 +2,6 @@ package blocks
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -150,7 +149,7 @@ func TestProcessBlockRoots_AccurateMerkleTree(t *testing.T) {
 
 	testRoot := [32]byte{'a'}
 
-	newState := ProcessBlockRoots(context.Background(), state, testRoot)
+	newState := ProcessBlockRoots(state, testRoot)
 	if !bytes.Equal(newState.LatestBlockRootHash32S[0], testRoot[:]) {
 		t.Fatalf("Latest Block root hash not saved."+
 			" Supposed to get %#x , but got %#x", testRoot, newState.LatestBlockRootHash32S[0])
@@ -158,7 +157,7 @@ func TestProcessBlockRoots_AccurateMerkleTree(t *testing.T) {
 
 	newState.Slot = newState.Slot - 1
 
-	newState = ProcessBlockRoots(context.Background(), newState, testRoot)
+	newState = ProcessBlockRoots(newState, testRoot)
 	expectedHashes := make([][]byte, params.BeaconConfig().LatestBlockRootsLength)
 	expectedHashes[0] = testRoot[:]
 	expectedHashes[params.BeaconConfig().LatestBlockRootsLength-1] = testRoot[:]

--- a/beacon-chain/core/epoch/BUILD.bazel
+++ b/beacon-chain/core/epoch/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/epoch/epoch_operations.go
+++ b/beacon-chain/core/epoch/epoch_operations.go
@@ -6,7 +6,6 @@ package epoch
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"math"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	b "github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"go.opencensus.io/trace"
 )
 
 // CurrentAttestations returns the pending attestations from current epoch.
@@ -26,10 +24,7 @@ import (
 //  (Note: this is the set of attestations of slots in the epoch
 //  current_epoch, not attestations that got included in the chain
 //  during the epoch current_epoch.)
-func CurrentAttestations(ctx context.Context, state *pb.BeaconState) []*pb.PendingAttestation {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.CurrentAttestations")
-	defer span.End()
-
+func CurrentAttestations(state *pb.BeaconState) []*pb.PendingAttestation {
 	var currentEpochAttestations []*pb.PendingAttestation
 	currentEpoch := helpers.CurrentEpoch(state)
 
@@ -48,14 +43,9 @@ func CurrentAttestations(ctx context.Context, state *pb.BeaconState) []*pb.Pendi
 //   return [a for a in current_epoch_attestations if a.data.epoch_boundary_root ==
 //   	get_block_root(state, get_epoch_start_slot(current_epoch))
 func CurrentEpochBoundaryAttestations(
-	ctx context.Context,
 	state *pb.BeaconState,
 	currentEpochAttestations []*pb.PendingAttestation,
 ) ([]*pb.PendingAttestation, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.CurrentEpochBoundaryAttestations")
-	defer span.End()
-
 	var boundaryAttestations []*pb.PendingAttestation
 	for _, attestation := range currentEpochAttestations {
 		boundaryBlockRoot, err := block.BlockRoot(state, helpers.StartSlot(helpers.CurrentEpoch(state)))
@@ -78,11 +68,7 @@ func CurrentEpochBoundaryAttestations(
 // Spec pseudocode definition:
 //   return [a for a in state.latest_attestations if
 //   	previous_epoch == slot_to_epoch(a.data.slot)].
-func PrevAttestations(ctx context.Context, state *pb.BeaconState) []*pb.PendingAttestation {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.PrevAttestations")
-	defer span.End()
-
+func PrevAttestations(state *pb.BeaconState) []*pb.PendingAttestation {
 	var prevEpochAttestations []*pb.PendingAttestation
 	prevEpoch := helpers.PrevEpoch(state)
 
@@ -102,14 +88,9 @@ func PrevAttestations(ctx context.Context, state *pb.BeaconState) []*pb.PendingA
 //   return [a for a in previous_epoch_attestations
 // 	 if a.epoch_boundary_root == get_block_root(state, get_epoch_start_slot(previous_epoch)]
 func PrevEpochBoundaryAttestations(
-	ctx context.Context,
 	state *pb.BeaconState,
 	prevEpochAttestations []*pb.PendingAttestation,
 ) ([]*pb.PendingAttestation, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.PrevEpochBoundaryAttestations")
-	defer span.End()
-
 	var prevEpochBoundaryAttestations []*pb.PendingAttestation
 
 	prevBoundaryBlockRoot, err := block.BlockRoot(state,
@@ -133,13 +114,9 @@ func PrevEpochBoundaryAttestations(
 //   return [a for a in previous_epoch_attestations
 //   if a.data.beacon_block_root == get_block_root(state, a.data.slot)]
 func PrevHeadAttestations(
-	ctx context.Context,
 	state *pb.BeaconState,
 	prevEpochAttestations []*pb.PendingAttestation,
 ) ([]*pb.PendingAttestation, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.PrevHeadAttestations")
-	defer span.End()
 
 	var headAttestations []*pb.PendingAttestation
 	for _, attestation := range prevEpochAttestations {
@@ -166,12 +143,8 @@ func PrevHeadAttestations(
 //    """
 //    return sum([get_effective_balance(state, i) for i in validators])
 func TotalBalance(
-	ctx context.Context,
 	state *pb.BeaconState,
 	activeValidatorIndices []uint64) uint64 {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.TotalBalance")
-	defer span.End()
 
 	var totalBalance uint64
 	for _, index := range activeValidatorIndices {
@@ -240,14 +213,12 @@ func InclusionDistance(state *pb.BeaconState, validatorIndex uint64) (uint64, er
 //    Let `attesting_validators(crosslink_committee)` be equal to
 //    `attesting_validator_indices(crosslink_committee, winning_root(crosslink_committee))` for convenience
 func AttestingValidators(
-	ctx context.Context,
 	state *pb.BeaconState,
 	shard uint64,
 	currentEpochAttestations []*pb.PendingAttestation,
 	prevEpochAttestations []*pb.PendingAttestation) ([]uint64, error) {
 
 	root, err := winningRoot(
-		ctx,
 		state,
 		shard,
 		currentEpochAttestations,
@@ -276,14 +247,13 @@ func AttestingValidators(
 //    Let total_balance(crosslink_committee) =
 //    sum([get_effective_balance(state, i) for i in crosslink_committee.committee])
 func TotalAttestingBalance(
-	ctx context.Context,
 	state *pb.BeaconState,
 	shard uint64,
 	currentEpochAttestations []*pb.PendingAttestation,
 	prevEpochAttestations []*pb.PendingAttestation) (uint64, error) {
 
 	var totalBalance uint64
-	attestedValidatorIndices, err := AttestingValidators(ctx, state, shard, currentEpochAttestations, prevEpochAttestations)
+	attestedValidatorIndices, err := AttestingValidators(state, shard, currentEpochAttestations, prevEpochAttestations)
 	if err != nil {
 		return 0, fmt.Errorf("could not get attesting validator indices: %v", err)
 	}
@@ -312,14 +282,10 @@ func SinceFinality(state *pb.BeaconState) uint64 {
 //   such that get_total_balance(state, attesting_validator_indices(crosslink_committee, crosslink_data_root))
 //   is maximized (ties broken by favoring lexicographically smallest crosslink_data_root).
 func winningRoot(
-	ctx context.Context,
 	state *pb.BeaconState,
 	shard uint64,
 	currentEpochAttestations []*pb.PendingAttestation,
 	prevEpochAttestations []*pb.PendingAttestation) ([]byte, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.CalculateWinningRoot")
-	defer span.End()
 
 	var winnerBalance uint64
 	var winnerRoot []byte

--- a/beacon-chain/core/epoch/epoch_operations_test.go
+++ b/beacon-chain/core/epoch/epoch_operations_test.go
@@ -2,7 +2,6 @@ package epoch
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -73,11 +72,11 @@ func TestEpochAttestations_AttestationSlotValid(t *testing.T) {
 	for _, tt := range tests {
 		state.Slot = tt.stateSlot
 
-		if CurrentAttestations(context.Background(), state)[0].Data.Slot != tt.firstAttestationSlot {
+		if CurrentAttestations(state)[0].Data.Slot != tt.firstAttestationSlot {
 			t.Errorf(
 				"Result slot was an unexpected value. Wanted %d, got %d",
 				tt.firstAttestationSlot,
-				CurrentAttestations(context.Background(), state)[0].Data.Slot,
+				CurrentAttestations(state)[0].Data.Slot,
 			)
 		}
 	}
@@ -126,12 +125,12 @@ func TestEpochBoundaryAttestations_AccurateAttestationData(t *testing.T) {
 		JustifiedEpoch:         params.BeaconConfig().GenesisEpoch,
 	}
 
-	if _, err := CurrentEpochBoundaryAttestations(context.Background(), state, epochAttestations); err == nil {
+	if _, err := CurrentEpochBoundaryAttestations(state, epochAttestations); err == nil {
 		t.Fatal("CurrentEpochBoundaryAttestations should have failed with empty block root hash")
 	}
 
 	state.Slot = params.BeaconConfig().SlotsPerEpoch + params.BeaconConfig().GenesisSlot + 1
-	epochBoundaryAttestation, err := CurrentEpochBoundaryAttestations(context.Background(), state, epochAttestations)
+	epochBoundaryAttestation, err := CurrentEpochBoundaryAttestations(state, epochAttestations)
 	if err != nil {
 		t.Fatalf("CurrentEpochBoundaryAttestations failed: %v", err)
 	}
@@ -202,11 +201,11 @@ func TestPrevEpochAttestations_AccurateAttestationSlots(t *testing.T) {
 	for _, tt := range tests {
 		state.Slot = tt.stateSlot
 
-		if PrevAttestations(context.Background(), state)[0].Data.Slot != tt.firstAttestationSlot {
+		if PrevAttestations(state)[0].Data.Slot != tt.firstAttestationSlot {
 			t.Errorf(
 				"Result slot was an unexpected value. Wanted %d, got %d",
 				tt.firstAttestationSlot,
-				PrevAttestations(context.Background(), state)[0].Data.Slot,
+				PrevAttestations(state)[0].Data.Slot,
 			)
 		}
 	}
@@ -236,7 +235,7 @@ func TestPrevEpochBoundaryAttestations_AccurateAttestationData(t *testing.T) {
 		JustifiedEpoch:         params.BeaconConfig().GenesisEpoch,
 	}
 
-	prevEpochBoundaryAttestation, err := PrevEpochBoundaryAttestations(context.Background(), state, epochAttestations)
+	prevEpochBoundaryAttestation, err := PrevEpochBoundaryAttestations(state, epochAttestations)
 	if err != nil {
 		t.Fatalf("EpochBoundaryAttestations failed: %v", err)
 	}
@@ -274,7 +273,7 @@ func TestHeadAttestations_AccurateHeadData(t *testing.T) {
 		LatestBlockRootHash32S: latestBlockRootHash,
 		JustifiedEpoch:         params.BeaconConfig().GenesisEpoch}
 
-	headAttestations, err := PrevHeadAttestations(context.Background(), state, prevAttestations)
+	headAttestations, err := PrevHeadAttestations(state, prevAttestations)
 	if err != nil {
 		t.Fatalf("PrevHeadAttestations failed with %v", err)
 	}
@@ -304,7 +303,7 @@ func TestHeadAttestations_InvalidRange(t *testing.T) {
 
 	state := &pb.BeaconState{Slot: 0}
 
-	if _, err := PrevHeadAttestations(context.Background(), state, prevAttestations); err == nil {
+	if _, err := PrevHeadAttestations(state, prevAttestations); err == nil {
 		t.Fatal("PrevHeadAttestations should have failed with invalid range")
 	}
 }
@@ -330,7 +329,6 @@ func TestWinningRoot_AccurateRoot(t *testing.T) {
 	// Since all 10 roots have the balance of 64 ETHs
 	// winningRoot chooses the lowest hash: []byte{100}
 	winnerRoot, err := winningRoot(
-		context.Background(),
 		state,
 		0,
 		attestations,
@@ -356,7 +354,7 @@ func TestWinningRoot_EmptyParticipantBitfield(t *testing.T) {
 	}
 
 	want := fmt.Sprintf("wanted participants bitfield length %d, got: %d", 16, 0)
-	if _, err := winningRoot(context.Background(), state, 0, attestations, nil); !strings.Contains(err.Error(), want) {
+	if _, err := winningRoot(state, 0, attestations, nil); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
@@ -377,7 +375,6 @@ func TestAttestingValidators_MatchActive(t *testing.T) {
 	}
 
 	attestedValidators, err := AttestingValidators(
-		context.Background(),
 		state,
 		0,
 		attestations,
@@ -404,7 +401,7 @@ func TestAttestingValidators_EmptyWinningRoot(t *testing.T) {
 	}
 
 	want := fmt.Sprintf("wanted participants bitfield length %d, got: %d", 16, 0)
-	if _, err := AttestingValidators(context.Background(), state, 0, []*pb.PendingAttestation{attestation}, nil); !strings.Contains(err.Error(), want) {
+	if _, err := AttestingValidators(state, 0, []*pb.PendingAttestation{attestation}, nil); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
@@ -428,7 +425,6 @@ func TestTotalAttestingBalance_CorrectBalance(t *testing.T) {
 	}
 
 	attestedBalance, err := TotalAttestingBalance(
-		context.Background(),
 		state,
 		0,
 		attestations,
@@ -454,7 +450,7 @@ func TestTotalAttestingBalance_EmptyWinningRoot(t *testing.T) {
 	}
 
 	want := fmt.Sprintf("wanted participants bitfield length %d, got: %d", 16, 0)
-	if _, err := TotalAttestingBalance(context.Background(), state, 0, []*pb.PendingAttestation{attestation}, nil); !strings.Contains(err.Error(), want) {
+	if _, err := TotalAttestingBalance(state, 0, []*pb.PendingAttestation{attestation}, nil); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
@@ -468,7 +464,7 @@ func TestTotalBalance_CorrectBalance(t *testing.T) {
 	}
 
 	// 20 + 25 + 30 + 30 + 32 + 32 + 32 + 32 = 233
-	totalBalance := TotalBalance(context.Background(), state, []uint64{0, 1, 2, 3, 4, 5, 6, 7})
+	totalBalance := TotalBalance(state, []uint64{0, 1, 2, 3, 4, 5, 6, 7})
 	if totalBalance != 233*1e9 {
 		t.Errorf("Incorrect total balance. Wanted: 233*1e9, got: %d", totalBalance)
 	}

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -5,7 +5,6 @@
 package epoch
 
 import (
-	"context"
 	"encoding/binary"
 	"fmt"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/mathutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
-	"go.opencensus.io/trace"
 )
 
 var log = logrus.WithField("prefix", "core/state")
@@ -54,10 +52,7 @@ func CanProcessEth1Data(state *pb.BeaconState) bool {
 // 			for every shard number shard in [(state.current_epoch_start_shard + i) %
 //	 			SHARD_COUNT for i in range(get_current_epoch_committee_count(state) *
 //	 			SLOTS_PER_EPOCH)] (that is, for every shard in the current committees)
-func CanProcessValidatorRegistry(ctx context.Context, state *pb.BeaconState) bool {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.CanProcessValidatorRegistry")
-	defer span.End()
-
+func CanProcessValidatorRegistry(state *pb.BeaconState) bool {
 	if state.FinalizedEpoch <= state.ValidatorRegistryUpdateEpoch {
 		return false
 	}
@@ -85,10 +80,7 @@ func CanProcessValidatorRegistry(ctx context.Context, state *pb.BeaconState) boo
 //       Set state.latest_eth1_data = eth1_data_vote.eth1_data.
 //		 Set state.eth1_data_votes = [].
 //
-func ProcessEth1Data(ctx context.Context, state *pb.BeaconState) *pb.BeaconState {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ProcessEth1Data")
-	defer span.End()
-
+func ProcessEth1Data(state *pb.BeaconState) *pb.BeaconState {
 	for _, eth1DataVote := range state.Eth1DataVotes {
 		if eth1DataVote.VoteCount*2 > params.BeaconConfig().SlotsPerEpoch*
 			params.BeaconConfig().EpochsPerEth1VotingPeriod {
@@ -121,15 +113,12 @@ func ProcessEth1Data(ctx context.Context, state *pb.BeaconState) *pb.BeaconState
 //     Set state.previous_justified_epoch = state.justified_epoch.
 //     Set state.justified_epoch = new_justified_epoch
 func ProcessJustificationAndFinalization(
-	ctx context.Context,
 	state *pb.BeaconState,
 	thisEpochBoundaryAttestingBalance uint64,
 	prevEpochBoundaryAttestingBalance uint64,
 	prevTotalBalance uint64,
 	totalBalance uint64,
 ) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ProcessJustificationAndFinalization")
-	defer span.End()
 
 	newJustifiedEpoch := state.JustifiedEpoch
 	newFinalizedEpoch := state.FinalizedEpoch
@@ -209,13 +198,9 @@ func ProcessJustificationAndFinalization(
 // 			epoch=slot_to_epoch(slot), crosslink_data_root=winning_root(crosslink_committee))
 // 			if 3 * total_attesting_balance(crosslink_committee) >= 2 * total_balance(crosslink_committee)
 func ProcessCrosslinks(
-	ctx context.Context,
 	state *pb.BeaconState,
 	thisEpochAttestations []*pb.PendingAttestation,
 	prevEpochAttestations []*pb.PendingAttestation) (*pb.BeaconState, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ProcessCrosslinks")
-	defer span.End()
 
 	prevEpoch := helpers.PrevEpoch(state)
 	currentEpoch := helpers.CurrentEpoch(state)
@@ -233,13 +218,13 @@ func ProcessCrosslinks(
 		for _, crosslinkCommittee := range crosslinkCommittees {
 			shard := crosslinkCommittee.Shard
 			committee := crosslinkCommittee.Committee
-			attestingBalance, err := TotalAttestingBalance(ctx, state, shard, thisEpochAttestations, prevEpochAttestations)
+			attestingBalance, err := TotalAttestingBalance(state, shard, thisEpochAttestations, prevEpochAttestations)
 			if err != nil {
 				return nil, fmt.Errorf("could not get attesting balance for shard committee %d: %v", shard, err)
 			}
-			totalBalance := TotalBalance(ctx, state, committee)
+			totalBalance := TotalBalance(state, committee)
 			if attestingBalance*3 >= totalBalance*2 {
-				winningRoot, err := winningRoot(ctx, state, shard, thisEpochAttestations, prevEpochAttestations)
+				winningRoot, err := winningRoot(state, shard, thisEpochAttestations, prevEpochAttestations)
 				if err != nil {
 					return nil, fmt.Errorf("could not get winning root: %v", err)
 				}
@@ -265,11 +250,7 @@ func ProcessCrosslinks(
 //    for index in get_active_validator_indices(state.validator_registry, current_epoch(state)):
 //        if state.validator_balances[index] < EJECTION_BALANCE:
 //            exit_validator(state, index)
-func ProcessEjections(ctx context.Context, state *pb.BeaconState, enableLogging bool) (*pb.BeaconState, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ProcessEjections")
-	defer span.End()
-
+func ProcessEjections(state *pb.BeaconState, enableLogging bool) (*pb.BeaconState, error) {
 	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, helpers.CurrentEpoch(state))
 	for _, index := range activeValidatorIndices {
 		if state.ValidatorBalances[index] < params.BeaconConfig().EjectionBalance {
@@ -324,10 +305,7 @@ func ProcessCurrSlotShardSeed(state *pb.BeaconState) (*pb.BeaconState, error) {
 // 			set state.current_calculation_epoch = next_epoch
 // 			set state.current_shuffling_seed = generate_seed(
 // 				state, state.current_calculation_epoch)
-func ProcessPartialValidatorRegistry(ctx context.Context, state *pb.BeaconState) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ProcessPartialValidatorRegistry")
-	defer span.End()
-
+func ProcessPartialValidatorRegistry(state *pb.BeaconState) (*pb.BeaconState, error) {
 	epochsSinceLastRegistryChange := helpers.CurrentEpoch(state) -
 		state.ValidatorRegistryUpdateEpoch
 	if epochsSinceLastRegistryChange > 1 &&
@@ -344,10 +322,7 @@ func ProcessPartialValidatorRegistry(ctx context.Context, state *pb.BeaconState)
 // Spec pseudocode definition:
 // 		Remove any attestation in state.latest_attestations such
 // 		that slot_to_epoch(att.data.slot) < slot_to_epoch(state) - 1
-func CleanupAttestations(ctx context.Context, state *pb.BeaconState) *pb.BeaconState {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.CleanupAttestations")
-	defer span.End()
-
+func CleanupAttestations(state *pb.BeaconState) *pb.BeaconState {
 	currEpoch := helpers.CurrentEpoch(state)
 
 	var latestAttestations []*pb.PendingAttestation
@@ -369,10 +344,7 @@ func CleanupAttestations(ctx context.Context, state *pb.BeaconState) *pb.BeaconS
 // 	LATEST_INDEX_ROOTS_LENGTH] =
 // 	hash_tree_root(get_active_validator_indices(state,
 // 	next_epoch + ACTIVATION_EXIT_DELAY))
-func UpdateLatestActiveIndexRoots(ctx context.Context, state *pb.BeaconState) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.UpdateLatestActiveIndexRoots")
-	defer span.End()
-
+func UpdateLatestActiveIndexRoots(state *pb.BeaconState) (*pb.BeaconState, error) {
 	nextEpoch := helpers.NextEpoch(state) + params.BeaconConfig().ActivationExitDelay
 	validatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, nextEpoch)
 	indicesBytes := []byte{}
@@ -393,10 +365,7 @@ func UpdateLatestActiveIndexRoots(ctx context.Context, state *pb.BeaconState) (*
 // Spec pseudocode definition:
 // Set state.latest_slashed_balances[(next_epoch) % LATEST_PENALIZED_EXIT_LENGTH] =
 // 	state.latest_slashed_balances[current_epoch % LATEST_PENALIZED_EXIT_LENGTH].
-func UpdateLatestSlashedBalances(ctx context.Context, state *pb.BeaconState) *pb.BeaconState {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.UpdateLatestSlashedBalances")
-	defer span.End()
-
+func UpdateLatestSlashedBalances(state *pb.BeaconState) *pb.BeaconState {
 	currentEpoch := helpers.CurrentEpoch(state) % params.BeaconConfig().LatestSlashedExitLength
 	nextEpoch := helpers.NextEpoch(state) % params.BeaconConfig().LatestSlashedExitLength
 	state.LatestSlashedBalances[nextEpoch] = state.LatestSlashedBalances[currentEpoch]
@@ -409,10 +378,7 @@ func UpdateLatestSlashedBalances(ctx context.Context, state *pb.BeaconState) *pb
 // Spec pseudocode definition:
 // Set state.latest_randao_mixes[next_epoch % LATEST_RANDAO_MIXES_LENGTH] =
 // 	get_randao_mix(state, current_epoch).
-func UpdateLatestRandaoMixes(ctx context.Context, state *pb.BeaconState) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.UpdateLatestRandaoMixes")
-	defer span.End()
-
+func UpdateLatestRandaoMixes(state *pb.BeaconState) (*pb.BeaconState, error) {
 	nextEpoch := helpers.NextEpoch(state) % params.BeaconConfig().LatestRandaoMixesLength
 	randaoMix, err := helpers.RandaoMix(state, helpers.CurrentEpoch(state))
 	if err != nil {

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -55,6 +55,8 @@ func ExecuteStateTransition(
 	headRoot [32]byte,
 	config *TransitionConfig,
 ) (*pb.BeaconState, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.StateTransition")
+	defer span.End()
 	var err error
 
 	// Execute per slot transition.
@@ -92,7 +94,7 @@ func ProcessSlot(ctx context.Context, state *pb.BeaconState, headRoot [32]byte) 
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessSlot")
 	defer span.End()
 	state.Slot++
-	state = b.ProcessBlockRoots(ctx, state, headRoot)
+	state = b.ProcessBlockRoots(state, headRoot)
 	return state
 }
 
@@ -127,7 +129,7 @@ func ProcessBlock(
 	// Verify block signature.
 	if config.VerifySignatures {
 		// TODO(#781): Verify Proposer Signature.
-		if err := b.VerifyProposerSignature(ctx, block); err != nil {
+		if err := b.VerifyProposerSignature(block); err != nil {
 			return nil, fmt.Errorf("could not verify proposer signature: %v", err)
 		}
 	}
@@ -136,33 +138,33 @@ func ProcessBlock(
 	state.LatestBlock = block
 
 	// Verify block RANDAO.
-	state, err = b.ProcessBlockRandao(ctx, state, block, config.VerifySignatures, config.Logging)
+	state, err = b.ProcessBlockRandao(state, block, config.VerifySignatures, config.Logging)
 	if err != nil {
 		return nil, fmt.Errorf("could not verify and process block randao: %v", err)
 	}
 
 	// Process ETH1 data.
-	state = b.ProcessEth1DataInBlock(ctx, state, block)
-	state, err = b.ProcessAttesterSlashings(ctx, state, block, config.VerifySignatures)
+	state = b.ProcessEth1DataInBlock(state, block)
+	state, err = b.ProcessAttesterSlashings(state, block, config.VerifySignatures)
 	if err != nil {
 		return nil, fmt.Errorf("could not verify block attester slashings: %v", err)
 	}
 
-	state, err = b.ProcessProposerSlashings(ctx, state, block, config.VerifySignatures)
+	state, err = b.ProcessProposerSlashings(state, block, config.VerifySignatures)
 	if err != nil {
 		return nil, fmt.Errorf("could not verify block proposer slashings: %v", err)
 	}
 
-	state, err = b.ProcessBlockAttestations(ctx, state, block, config.VerifySignatures)
+	state, err = b.ProcessBlockAttestations(state, block, config.VerifySignatures)
 	if err != nil {
 		return nil, fmt.Errorf("could not process block attestations: %v", err)
 	}
 
-	state, err = b.ProcessValidatorDeposits(ctx, state, block)
+	state, err = b.ProcessValidatorDeposits(state, block)
 	if err != nil {
 		return nil, fmt.Errorf("could not process block validator deposits: %v", err)
 	}
-	state, err = b.ProcessValidatorExits(ctx, state, block, config.VerifySignatures)
+	state, err = b.ProcessValidatorExits(state, block, config.VerifySignatures)
 	if err != nil {
 		return nil, fmt.Errorf("could not process validator exits: %v", err)
 	}
@@ -202,66 +204,65 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 
 	// Calculate total balances of active validators of the current epoch.
 	activeValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, currentEpoch)
-	totalBalance := e.TotalBalance(ctx, state, activeValidatorIndices)
+	totalBalance := e.TotalBalance(state, activeValidatorIndices)
 
 	// Calculate the attesting balances of validators that justified the
 	// epoch boundary block at the start of the current epoch.
-	currentEpochAttestations := e.CurrentAttestations(ctx, state)
-	currentEpochBoundaryAttestations, err := e.CurrentEpochBoundaryAttestations(ctx, state, currentEpochAttestations)
+	currentEpochAttestations := e.CurrentAttestations(state)
+	currentEpochBoundaryAttestations, err := e.CurrentEpochBoundaryAttestations(state, currentEpochAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not get current boundary attestations: %v", err)
 	}
 
-	currentBoundaryAttesterIndices, err := v.ValidatorIndices(ctx, state, currentEpochBoundaryAttestations)
+	currentBoundaryAttesterIndices, err := v.ValidatorIndices(state, currentEpochBoundaryAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not get current boundary attester indices: %v", err)
 	}
-	currentBoundaryAttestingBalances := e.TotalBalance(ctx, state, currentBoundaryAttesterIndices)
+	currentBoundaryAttestingBalances := e.TotalBalance(state, currentBoundaryAttesterIndices)
 
 	// Calculate the attesting balances of validators from previous epoch.
 	previousActiveValidatorIndices := helpers.ActiveValidatorIndices(state.ValidatorRegistry, prevEpoch)
-	prevTotalBalance := e.TotalBalance(ctx, state, previousActiveValidatorIndices)
+	prevTotalBalance := e.TotalBalance(state, previousActiveValidatorIndices)
 
-	prevEpochAttestations := e.PrevAttestations(ctx, state)
-	prevEpochAttesterIndices, err := v.ValidatorIndices(ctx, state, prevEpochAttestations)
+	prevEpochAttestations := e.PrevAttestations(state)
+	prevEpochAttesterIndices, err := v.ValidatorIndices(state, prevEpochAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not get prev epoch attester indices: %v", err)
 	}
-	prevEpochAttestingBalance := e.TotalBalance(ctx, state, prevEpochAttesterIndices)
+	prevEpochAttestingBalance := e.TotalBalance(state, prevEpochAttesterIndices)
 
 	// Calculate the attesting balances of validator justifying epoch boundary block
 	// at the start of previous epoch.
-	prevEpochBoundaryAttestations, err := e.PrevEpochBoundaryAttestations(ctx, state, prevEpochAttestations)
+	prevEpochBoundaryAttestations, err := e.PrevEpochBoundaryAttestations(state, prevEpochAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not get prev boundary attestations: %v", err)
 	}
 
-	prevEpochBoundaryAttesterIndices, err := v.ValidatorIndices(ctx, state, prevEpochBoundaryAttestations)
+	prevEpochBoundaryAttesterIndices, err := v.ValidatorIndices(state, prevEpochBoundaryAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not get prev boundary attester indices: %v", err)
 	}
-	prevEpochBoundaryAttestingBalances := e.TotalBalance(ctx, state, prevEpochBoundaryAttesterIndices)
+	prevEpochBoundaryAttestingBalances := e.TotalBalance(state, prevEpochBoundaryAttesterIndices)
 
 	// Calculate attesting balances of validator attesting to expected beacon chain head
 	// during previous epoch.
-	prevEpochHeadAttestations, err := e.PrevHeadAttestations(ctx, state, prevEpochAttestations)
+	prevEpochHeadAttestations, err := e.PrevHeadAttestations(state, prevEpochAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not get prev head attestations: %v", err)
 	}
-	prevEpochHeadAttesterIndices, err := v.ValidatorIndices(ctx, state, prevEpochHeadAttestations)
+	prevEpochHeadAttesterIndices, err := v.ValidatorIndices(state, prevEpochHeadAttestations)
 	if err != nil {
 		return nil, fmt.Errorf("could not get prev head attester indices: %v", err)
 	}
-	prevEpochHeadAttestingBalances := e.TotalBalance(ctx, state, prevEpochHeadAttesterIndices)
+	prevEpochHeadAttestingBalances := e.TotalBalance(state, prevEpochHeadAttesterIndices)
 
 	// Process eth1 data.
 	if e.CanProcessEth1Data(state) {
-		state = e.ProcessEth1Data(ctx, state)
+		state = e.ProcessEth1Data(state)
 	}
 
 	// Update justification and finality.
 	state, err = e.ProcessJustificationAndFinalization(
-		ctx,
 		state,
 		currentBoundaryAttestingBalances,
 		prevEpochAttestingBalance,
@@ -276,7 +277,6 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 	// TODO(#2072): Include an optimized process crosslinks version.
 	if featureconfig.FeatureConfig().EnableCrosslinks {
 		state, err = e.ProcessCrosslinks(
-			ctx,
 			state,
 			currentEpochAttestations,
 			prevEpochAttestations)
@@ -292,7 +292,6 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 		// Apply rewards/penalties to validators for attesting
 		// expected FFG source.
 		state = bal.ExpectedFFGSource(
-			ctx,
 			state,
 			prevEpochAttesterIndices,
 			prevEpochAttestingBalance,
@@ -303,7 +302,6 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 		// Apply rewards/penalties to validators for attesting
 		// expected FFG target.
 		state = bal.ExpectedFFGTarget(
-			ctx,
 			state,
 			prevEpochBoundaryAttesterIndices,
 			prevEpochBoundaryAttestingBalances,
@@ -314,7 +312,6 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 		// Apply rewards/penalties to validators for attesting
 		// expected beacon chain head.
 		state = bal.ExpectedBeaconChainHead(
-			ctx,
 			state,
 			prevEpochHeadAttesterIndices,
 			prevEpochHeadAttestingBalances,
@@ -337,17 +334,15 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 		}
 
 	case epochsSinceFinality > 4:
-		log.Infof("Applying more penalties. ESF %d greater than 4", epochsSinceFinality)
+		log.Infof("Applying more penalties. Epochs since finality %d greater than 4", epochsSinceFinality)
 		// Apply penalties for long inactive FFG source participants.
 		state = bal.InactivityFFGSource(
-			ctx,
 			state,
 			prevEpochAttesterIndices,
 			totalBalance,
 			epochsSinceFinality)
 		// Apply penalties for long inactive FFG target participants.
 		state = bal.InactivityFFGTarget(
-			ctx,
 			state,
 			prevEpochBoundaryAttesterIndices,
 			totalBalance,
@@ -355,21 +350,18 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 		// Apply penalties for long inactive validators who didn't
 		// attest to head canonical chain.
 		state = bal.InactivityChainHead(
-			ctx,
 			state,
 			prevEpochHeadAttesterIndices,
 			totalBalance)
 		// Apply penalties for long inactive validators who also
 		// exited with penalties.
 		state = bal.InactivityExitedPenalties(
-			ctx,
 			state,
 			totalBalance,
 			epochsSinceFinality)
 		// Apply penalties for long inactive validators that
 		// don't include attestations.
 		state, err = bal.InactivityInclusionDistance(
-			ctx,
 			state,
 			prevEpochAttesterIndices,
 			totalBalance)
@@ -380,7 +372,6 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 
 	// Process Attestation Inclusion Rewards.
 	state, err = bal.AttestationInclusion(
-		ctx,
 		state,
 		totalBalance,
 		prevEpochAttesterIndices)
@@ -392,7 +383,6 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 	// TODO(#2072): Optimize crosslinks.
 	if featureconfig.FeatureConfig().EnableCrosslinks {
 		state, err = bal.Crosslinks(
-			ctx,
 			state,
 			currentEpochAttestations,
 			prevEpochAttestations)
@@ -402,16 +392,16 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 	}
 
 	// Process ejections.
-	state, err = e.ProcessEjections(ctx, state, config.Logging)
+	state, err = e.ProcessEjections(state, config.Logging)
 	if err != nil {
 		return nil, fmt.Errorf("could not process ejections: %v", err)
 	}
 
 	// Process validator registry.
 	state = e.ProcessPrevSlotShardSeed(state)
-	state = v.ProcessPenaltiesAndExits(ctx, state)
-	if e.CanProcessValidatorRegistry(ctx, state) {
-		state, err = v.UpdateRegistry(ctx, state)
+	state = v.ProcessPenaltiesAndExits(state)
+	if e.CanProcessValidatorRegistry(state) {
+		state, err = v.UpdateRegistry(state)
 		if err != nil {
 			return nil, fmt.Errorf("could not update validator registry: %v", err)
 		}
@@ -420,7 +410,7 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 			return nil, fmt.Errorf("could not update current shard shuffling seeds: %v", err)
 		}
 	} else {
-		state, err = e.ProcessPartialValidatorRegistry(ctx, state)
+		state, err = e.ProcessPartialValidatorRegistry(state)
 		if err != nil {
 			return nil, fmt.Errorf("could not process partial validator registry: %v", err)
 		}
@@ -428,7 +418,7 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 
 	// Final housekeeping updates.
 	// Update index roots from current epoch to next epoch.
-	state, err = e.UpdateLatestActiveIndexRoots(ctx, state)
+	state, err = e.UpdateLatestActiveIndexRoots(state)
 	if err != nil {
 		return nil, fmt.Errorf("could not update latest index roots: %v", err)
 	}
@@ -438,16 +428,16 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, config *Transition
 	// TODO(1764): Implement process_exit_queue from ETH2.0 beacon chain spec.
 
 	// Update accumulated slashed balances from current epoch to next epoch.
-	state = e.UpdateLatestSlashedBalances(ctx, state)
+	state = e.UpdateLatestSlashedBalances(state)
 
 	// Update current epoch's randao seed to next epoch.
-	state, err = e.UpdateLatestRandaoMixes(ctx, state)
+	state, err = e.UpdateLatestRandaoMixes(state)
 	if err != nil {
 		return nil, fmt.Errorf("could not update latest randao mixes: %v", err)
 	}
 
 	// Clean up processed attestations.
-	state = e.CleanupAttestations(ctx, state)
+	state = e.CleanupAttestations(state)
 
 	if config.Logging {
 		log.WithField("currentEpochAttestations", len(currentEpochAttestations)).Info("Number of current epoch attestations")

--- a/beacon-chain/core/validators/BUILD.bazel
+++ b/beacon-chain/core/validators/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//shared/params:go_default_library",
         "//shared/sliceutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -6,7 +6,6 @@ package validators
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"sync"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
 	"github.com/sirupsen/logrus"
-	"go.opencensus.io/trace"
 )
 
 var log = logrus.WithField("prefix", "powchain")
@@ -42,13 +40,9 @@ var vStore = validatorStore{
 //   index sets given by [get_attestation_participants(state, a.data, a.aggregation_bitfield)
 //   for a in attestations]
 func ValidatorIndices(
-	ctx context.Context,
 	state *pb.BeaconState,
 	attestations []*pb.PendingAttestation,
 ) ([]uint64, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ValidatorIndices")
-	defer span.End()
 
 	var attesterIndicesIntersection []uint64
 	for _, attestation := range attestations {
@@ -307,11 +301,7 @@ func SlashValidator(state *pb.BeaconState, idx uint64) (*pb.BeaconState, error) 
 //            exit_validator(state, index)
 //
 //    state.validator_registry_update_epoch = current_epoch
-func UpdateRegistry(ctx context.Context, state *pb.BeaconState) (*pb.BeaconState, error) {
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.UpdateRegistry")
-	defer span.End()
-
+func UpdateRegistry(state *pb.BeaconState) (*pb.BeaconState, error) {
 	currentEpoch := helpers.CurrentEpoch(state)
 	updatedEpoch := helpers.EntryExitEffectEpoch(currentEpoch)
 	activeValidatorIndices := helpers.ActiveValidatorIndices(
@@ -410,10 +400,7 @@ func UpdateRegistry(ctx context.Context, state *pb.BeaconState) (*pb.BeaconState
 //        withdrawn_so_far += 1
 //        if withdrawn_so_far >= MAX_EXIT_DEQUEUES_PER_EPOCH:
 //            break
-func ProcessPenaltiesAndExits(ctx context.Context, state *pb.BeaconState) *pb.BeaconState {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessEpoch.ProcessPenaltiesAndExits")
-	defer span.End()
-
+func ProcessPenaltiesAndExits(state *pb.BeaconState) *pb.BeaconState {
 	currentEpoch := helpers.CurrentEpoch(state)
 	activeValidatorIndices := helpers.ActiveValidatorIndices(
 		state.ValidatorRegistry, currentEpoch)

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -1,7 +1,6 @@
 package validators
 
 import (
-	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -79,7 +78,7 @@ func TestBoundaryAttesterIndices_OK(t *testing.T) {
 			AggregationBitfield: []byte{0xC0}}, // returns indices 237,224,2
 	}
 
-	attesterIndices, err := ValidatorIndices(context.Background(), state, boundaryAttestations)
+	attesterIndices, err := ValidatorIndices(state, boundaryAttestations)
 	if err != nil {
 		t.Fatalf("Failed to run BoundaryAttesterIndices: %v", err)
 	}
@@ -469,11 +468,11 @@ func TestProcessPenaltiesExits_NothingHappened(t *testing.T) {
 			{ExitEpoch: params.BeaconConfig().FarFutureEpoch},
 		},
 	}
-	if ProcessPenaltiesAndExits(context.Background(), state).ValidatorBalances[0] !=
+	if ProcessPenaltiesAndExits(state).ValidatorBalances[0] !=
 		params.BeaconConfig().MaxDepositAmount {
 		t.Errorf("wanted validator balance %d, got %d",
 			params.BeaconConfig().MaxDepositAmount,
-			ProcessPenaltiesAndExits(context.Background(), state).ValidatorBalances[0])
+			ProcessPenaltiesAndExits(state).ValidatorBalances[0])
 	}
 }
 
@@ -497,7 +496,7 @@ func TestProcessPenaltiesExits_ValidatorSlashed(t *testing.T) {
 		helpers.EffectiveBalance(state, 0) /
 		params.BeaconConfig().MaxDepositAmount
 
-	newState := ProcessPenaltiesAndExits(context.Background(), state)
+	newState := ProcessPenaltiesAndExits(state)
 	if newState.ValidatorBalances[0] != params.BeaconConfig().MaxDepositAmount-penalty {
 		t.Errorf("wanted validator balance %d, got %d",
 			params.BeaconConfig().MaxDepositAmount-penalty,
@@ -546,7 +545,7 @@ func TestUpdateRegistry_NoRotation(t *testing.T) {
 			params.BeaconConfig().MaxDepositAmount,
 		},
 	}
-	newState, err := UpdateRegistry(context.Background(), state)
+	newState, err := UpdateRegistry(state)
 	if err != nil {
 		t.Fatalf("could not update validator registry:%v", err)
 	}
@@ -576,7 +575,7 @@ func TestUpdateRegistry_Activations(t *testing.T) {
 			params.BeaconConfig().MaxDepositAmount,
 		},
 	}
-	newState, err := UpdateRegistry(context.Background(), state)
+	newState, err := UpdateRegistry(state)
 	if err != nil {
 		t.Fatalf("could not update validator registry:%v", err)
 	}
@@ -610,7 +609,7 @@ func TestUpdateRegistry_Exits(t *testing.T) {
 			params.BeaconConfig().MaxDepositAmount,
 		},
 	}
-	newState, err := UpdateRegistry(context.Background(), state)
+	newState, err := UpdateRegistry(state)
 	if err != nil {
 		t.Fatalf("could not update validator registry:%v", err)
 	}


### PR DESCRIPTION
I suspect this causes a surge of goroutines when creating many short spans very quickly, so I have removed many of the spans. 