### PR TITLE
k8s: --enable-committees-cache as default for beacon-chain

### DIFF
--- a/k8s/beacon-chain/beacon-chain.deploy.yaml
+++ b/k8s/beacon-chain/beacon-chain.deploy.yaml
@@ -55,6 +55,7 @@ spec:
             - --tracing-endpoint=http://jaeger-collector.istio-system.svc.cluster.local:14268
             - --trace-sample-fraction=1.0
             - --datadir=/data
+            - --enable-committees-cache 
           resources:
             requests:
               memory: "100Mi"


### PR DESCRIPTION
As title describes