### PR TITLE
Apply Fork Choice at End of Ancestor Block Fetching

### DIFF
--- a/beacon-chain/sync/receive_block.go
+++ b/beacon-chain/sync/receive_block.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"

--- a/beacon-chain/sync/receive_block.go
+++ b/beacon-chain/sync/receive_block.go
@@ -142,10 +142,6 @@ func (rs *RegularSync) validateAndProcessBlock(
 		log.Errorf("Could not process beacon block: %v", err)
 		return nil, nil, false, err
 	}
-	if err := rs.chainService.ApplyForkChoiceRule(ctx, block, beaconState); err != nil {
-		log.Errorf("Could not apply fork choice rule: %v", err)
-		return nil, nil, false, err
-	}
 	if err := rs.db.UpdateChainHead(ctx, block, beaconState); err != nil {
 		log.Errorf("Could not update chain head: %v", err)
 		return nil, nil, false, err


### PR DESCRIPTION
This is part of #1586 

---

# Description

**Write why you are making the changes in this pull request**

Right now, we have a lot of calls to apply fork choice and a high possibility of creating a ton of goroutines in our receive block function in regular sync. The way it works is as follows:

See a block, do we have its parent?
    - **No**: store it in a map of pending child blocks, and issue a call for a parent request.
    - **Yes**: Does the block have pending children we put in the prior map? Then call receiveBlock recursively and apply fork choice on the block and all its children. If the block does not have pending children at the end of the recursive call, end.

This creates a lot of calls to ApplyForkChoice and also a lot of calls to Jaeger spans, which do not end until the child span returns, which can lead to tons of goroutines. Applying fork choice at every step instead of the very last block might be leading to dozens of reorgs and a broken chain upon a restart.

**Write a summary of the changes you are making**

This abstracts the recursive logic into its own function that does not spawns tons of jaeger calls, and applies fork choice only at the very end of the receiveBlock function call once all recursive calls have ended. This should help our runtime and hopefully solve the many reorgs problem.

**Link anything that would be helpful or relevant to the reviewers**
