### PR TITLE
Add method to return multiple validator indices

### DIFF
--- a/beacon-chain/db/validator_test.go
+++ b/beacon-chain/db/validator_test.go
@@ -35,6 +35,14 @@ func TestSaveAndRetrieveValidatorIndex_OK(t *testing.T) {
 	if index2 != 2 {
 		t.Fatalf("Saved index and retrieved index are not equal: %#x and %#x", 2, index2)
 	}
+
+	m, err := db.ValidatorIndices([][]byte{p1, p2, []byte("bogus")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m) != 2 {
+		t.Error("Expected 2 entries in the map of indices")
+	}
 }
 
 func TestSaveAndDeleteValidatorIndex_OK(t *testing.T) {


### PR DESCRIPTION
In an effort to split up #2069, I have added the database methods to query for multiple validator indices in a single database method. 