### PR TITLE
Add method in validator RPC to filter active public keys

### DIFF
--- a/beacon-chain/db/validator_test.go
+++ b/beacon-chain/db/validator_test.go
@@ -35,6 +35,14 @@ func TestSaveAndRetrieveValidatorIndex_OK(t *testing.T) {
 	if index2 != 2 {
 		t.Fatalf("Saved index and retrieved index are not equal: %#x and %#x", 2, index2)
 	}
+
+	m, err := db.ValidatorIndices([][]byte{p1, p2, []byte("bogus")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m) != 2 {
+		t.Error("Expected 2 entries in the map of indices")
+	}
 }
 
 func TestSaveAndDeleteValidatorIndex_OK(t *testing.T) {

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -252,3 +252,25 @@ func (vs *ValidatorServer) retrieveActiveValidator(beaconState *pbp2p.BeaconStat
 	}
 	return beaconState.ValidatorRegistry[validatorIdx], nil
 }
+
+// filterActivePublicKeys takes a list of validator public keys and returns
+// the list of active public keys.
+func (vs *ValidatorServer) filterActivePublicKeys(beaconState *pbp2p.BeaconState, pubkeys [][]byte) ([][]byte, error) {
+	if beaconState == nil {
+		return nil, errors.New("cannot determine active validators; state is nil")
+	}
+
+	m, err := vs.beaconDB.ValidatorIndices(pubkeys)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve validators indexes: %v", err)
+	}
+	activeIndices := helpers.ActiveValidatorIndices(beaconState.ValidatorRegistry, beaconState.Slot)
+	v := make([][]byte, 0, len(m))
+	for _, ai := range activeIndices {
+		if val, ok := m[ai]; ok {
+			v = append(v, val)
+		}
+
+	}
+	return v, nil
+}


### PR DESCRIPTION
Splitting up #2069, includes #2247 so please review and merge #2247 before merging this PR.

This method is necessary for an upcoming change to the WaitForActivation where we wait for any validator key to the be activated then we return the public keys of the active validators.