### PR TITLE
Remote caching with GCP

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -1,15 +1,9 @@
-# The following flags enable the remote cache so action results can be shared
-# across machines, developers, and workspaces.
-# 
-# This config is loaded from https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/latest.bazelrc
-build:remote-cache --remote_cache=remotebuildexecution.googleapis.com
-build:remote-cache --tls_enabled=true
-build:remote-cache --remote_timeout=3600
-build:remote-cache --auth_enabled=true
-build:remote-cache --spawn_strategy=standalone
-build:remote-cache --strategy=Javac=standalone
-build:remote-cache --strategy=Closure=standalone
-build:remote-cache --strategy=Genrule=standalone
+build:remote --remote_max_connections=200
+build:remote --disk_cache=
+build:remote --remote_http_cache=https://storage.googleapis.com/prysmatic-bazel-cache
+build:remote --google_default_credentials
+build:remote --remote_timeout=10
+build:remote --experimental_guard_against_concurrent_changes
 
 # Use the credentials on the machine for auth.
 build:remote-cache --google_default_credentials

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -1,9 +1,15 @@
-build:remote --remote_max_connections=200
-build:remote --disk_cache=
-build:remote --remote_http_cache=https://storage.googleapis.com/prysmatic-bazel-cache
-build:remote --google_default_credentials
-build:remote --remote_timeout=10
-build:remote --experimental_guard_against_concurrent_changes
+# The following flags enable the remote cache so action results can be shared
+# across machines, developers, and workspaces.
+# 
+# This config is loaded from https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/latest.bazelrc
+build:remote-cache --remote_cache=remotebuildexecution.googleapis.com
+build:remote-cache --tls_enabled=true
+build:remote-cache --remote_timeout=3600
+build:remote-cache --auth_enabled=true
+build:remote-cache --spawn_strategy=standalone
+build:remote-cache --strategy=Javac=standalone
+build:remote-cache --strategy=Closure=standalone
+build:remote-cache --strategy=Genrule=standalone
 
 # Use the credentials on the machine for auth.
 build:remote-cache --google_default_credentials

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -11,6 +11,9 @@ build:remote-cache --strategy=Javac=standalone
 build:remote-cache --strategy=Closure=standalone
 build:remote-cache --strategy=Genrule=standalone
 
+# Use the credentials on the machine for auth.
+build:remote-cache --google_default_credentials
+
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
 build --experimental_multi_threaded_digest

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -11,9 +11,6 @@ build:remote-cache --strategy=Javac=standalone
 build:remote-cache --strategy=Closure=standalone
 build:remote-cache --strategy=Genrule=standalone
 
-# Use the credentials on the machine for auth.
-build:remote-cache --google_default_credentials
-
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
 build --experimental_multi_threaded_digest

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -11,6 +11,10 @@ build:remote-cache --strategy=Javac=standalone
 build:remote-cache --strategy=Closure=standalone
 build:remote-cache --strategy=Genrule=standalone
 
+# Prysm specific remote-cache properties.
+build:remote-cache --host_platform_remote_properties_override='properties:{name:\"cache-silo-key\" value:\"prysm\"}' 
+build:remote-cache --remote_instance_name=projects/prysmaticlabs/instances/default_instance
+
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
 build --experimental_multi_threaded_digest

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -12,6 +12,7 @@ build:remote-cache --strategy=Closure=standalone
 build:remote-cache --strategy=Genrule=standalone
 
 # Prysm specific remote-cache properties.
+build:remote-cache --disk_cache=
 build:remote-cache --host_platform_remote_properties_override='properties:{name:\"cache-silo-key\" value:\"prysm\"}' 
 build:remote-cache --remote_instance_name=projects/prysmaticlabs/instances/default_instance
 

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -13,6 +13,7 @@ build:remote-cache --strategy=Genrule=standalone
 
 # Prysm specific remote-cache properties.
 build:remote-cache --disk_cache=
+build:remote-cache --jobs=50
 build:remote-cache --host_platform_remote_properties_override='properties:{name:\"cache-silo-key\" value:\"prysm\"}' 
 build:remote-cache --remote_instance_name=projects/prysmaticlabs/instances/default_instance
 

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -1,9 +1,15 @@
-build:remote --remote_max_connections=200
-build:remote --disk_cache=
-build:remote --remote_http_cache=https://storage.googleapis.com/prysmatic-bazel-cache
-build:remote --google_default_credentials
-build:remote --remote_timeout=10
-build:remote --experimental_guard_against_concurrent_changes
+# The following flags enable the remote cache so action results can be shared
+# across machines, developers, and workspaces.
+# 
+# This config is loaded from https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/latest.bazelrc
+build:remote-cache --remote_cache=remotebuildexecution.googleapis.com
+build:remote-cache --tls_enabled=true
+build:remote-cache --remote_timeout=3600
+build:remote-cache --auth_enabled=true
+build:remote-cache --spawn_strategy=standalone
+build:remote-cache --strategy=Javac=standalone
+build:remote-cache --strategy=Closure=standalone
+build:remote-cache --strategy=Genrule=standalone
 
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds


### PR DESCRIPTION
Google's remote caching API is in alpha and we are whitelisted.

This adds the config to support remote caching for our CI builds. 