### PR TITLE
Blacklist Bad Block Hashes

### DIFF
--- a/beacon-chain/blockchain/block_processing_test.go
+++ b/beacon-chain/blockchain/block_processing_test.go
@@ -285,6 +285,10 @@ func TestReceiveBlock_DeletesBadBlock(t *testing.T) {
 	if savedBlock != nil {
 		t.Errorf("Expected bad block to have been deleted, received: %v", savedBlock)
 	}
+	// We also verify the block has been blacklisted.
+	if !db.IsEvilBlockHash(blockRoot) {
+		t.Error("Expected block root to have been blacklisted")
+	}
 }
 
 func TestReceiveBlock_CheckBlockStateRoot_GoodState(t *testing.T) {

--- a/beacon-chain/db/block.go
+++ b/beacon-chain/db/block.go
@@ -58,7 +58,7 @@ func (db *BeaconDB) HasBlock(root [32]byte) bool {
 	return hasBlock
 }
 
-// IsEvilBlockhash determines if a certain block root has been blacklisted
+// IsEvilBlockHash determines if a certain block root has been blacklisted
 // due to failing to process core state transitions.
 func (db *BeaconDB) IsEvilBlockHash(root [32]byte) bool {
 	db.badBlocksLock.Lock()

--- a/beacon-chain/db/block.go
+++ b/beacon-chain/db/block.go
@@ -63,7 +63,11 @@ func (db *BeaconDB) HasBlock(root [32]byte) bool {
 func (db *BeaconDB) IsEvilBlockHash(root [32]byte) bool {
 	db.badBlocksLock.Lock()
 	defer db.badBlocksLock.Unlock()
-	return db.badBlockHashes[root]
+	if db.badBlockHashes != nil {
+		return db.badBlockHashes[root]
+	}
+	db.badBlockHashes = make(map[[32]byte]bool)
+	return false
 }
 
 // MarkEvilBlockHash makes a block hash as tainted because it corresponds
@@ -71,6 +75,9 @@ func (db *BeaconDB) IsEvilBlockHash(root [32]byte) bool {
 func (db *BeaconDB) MarkEvilBlockHash(root [32]byte) {
 	db.badBlocksLock.Lock()
 	defer db.badBlocksLock.Unlock()
+	if db.badBlockHashes == nil {
+		db.badBlockHashes = make(map[[32]byte]bool)
+	}
 	db.badBlockHashes[root] = true
 }
 

--- a/beacon-chain/db/block.go
+++ b/beacon-chain/db/block.go
@@ -58,6 +58,22 @@ func (db *BeaconDB) HasBlock(root [32]byte) bool {
 	return hasBlock
 }
 
+// IsEvilBlockhash determines if a certain block root has been blacklisted
+// due to failing to process core state transitions.
+func (db *BeaconDB) IsEvilBlockHash(root [32]byte) bool {
+	db.badBlocksLock.Lock()
+	defer db.badBlocksLock.Unlock()
+	return db.badBlockHashes[root]
+}
+
+// MarkEvilBlockHash makes a block hash as tainted because it corresponds
+// to a block which fails core state transition processing.
+func (db *BeaconDB) MarkEvilBlockHash(root [32]byte) {
+	db.badBlocksLock.Lock()
+	defer db.badBlocksLock.Unlock()
+	db.badBlockHashes[root] = true
+}
+
 // SaveBlock accepts a block and writes it to disk.
 func (db *BeaconDB) SaveBlock(block *pb.BeaconBlock) error {
 	root, err := hashutil.HashBeaconBlock(block)

--- a/beacon-chain/db/block.go
+++ b/beacon-chain/db/block.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	badBlockCount = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "bad_block_counter",
+		Name: "bad_blocks",
 		Help: "Number of bad, blacklisted blocks received",
 	})
 )

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -25,8 +25,11 @@ type BeaconDB struct {
 	db           *bolt.DB
 	DatabasePath string
 
-	// Beacon block info in memory
+	// Beacon block info in memory.
 	highestBlockSlot uint64
+	// We keep a map of hashes of blocks which failed processing for blacklisting.
+	badBlockHashes map[[32]byte]bool
+	badBlocksLock sync.RWMutex
 
 	// Beacon chain deposits in memory.
 	pendingDeposits       []*depositContainer

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -29,7 +29,7 @@ type BeaconDB struct {
 	highestBlockSlot uint64
 	// We keep a map of hashes of blocks which failed processing for blacklisting.
 	badBlockHashes map[[32]byte]bool
-	badBlocksLock sync.RWMutex
+	badBlocksLock  sync.RWMutex
 
 	// Beacon chain deposits in memory.
 	pendingDeposits       []*depositContainer

--- a/beacon-chain/sync/receive_block.go
+++ b/beacon-chain/sync/receive_block.go
@@ -23,6 +23,14 @@ func (rs *RegularSync) receiveBlockAnnounce(msg p2p.Message) error {
 	data := msg.Data.(*pb.BeaconBlockAnnounce)
 	h := bytesutil.ToBytes32(data.Hash[:32])
 
+	isEvilBlock := rs.db.IsEvilBlockHash(h)
+	span.AddAttributes(trace.BoolAttribute("isEvilBlock", isEvilBlock))
+
+	if isEvilBlock {
+		log.Debugf("Received a blacklisted block hash: %#x", h)
+		return nil
+	}
+
 	// This prevents us from processing a block announcement we have already received.
 	// TODO(#2072): If the peer failed to give the block, broadcast request to the whole network.
 	rs.blockAnnouncementsLock.Lock()
@@ -76,6 +84,11 @@ func (rs *RegularSync) processBlockAndFetchAncestors(ctx context.Context, msg p2
 	blockRoot, err := hashutil.HashBeaconBlock(block)
 	if err != nil {
 		return err
+	}
+
+	if rs.db.IsEvilBlockHash(blockRoot) {
+		log.Debugf("Skipping blacklisted block hash: %#x", blockRoot)
+		return nil
 	}
 
 	// If the block has a child, we then clear it from the blocks pending processing
@@ -174,6 +187,10 @@ func (rs *RegularSync) validateAndProcessBlock(
 func (rs *RegularSync) insertPendingBlock(ctx context.Context, blockRoot [32]byte, blockMsg p2p.Message) {
 	rs.blocksAwaitingProcessingLock.Lock()
 	defer rs.blocksAwaitingProcessingLock.Unlock()
+	// Do not reinsert into the map if block root was previously added.
+	if _, ok := rs.blocksAwaitingProcessing[blockRoot]; ok {
+		return
+	}
 	rs.blocksAwaitingProcessing[blockRoot] = blockMsg
 	blocksAwaitingProcessingGauge.Inc()
 	rs.p2p.Broadcast(ctx, &pb.BeaconBlockRequest{Hash: blockRoot[:]})

--- a/beacon-chain/sync/receive_block.go
+++ b/beacon-chain/sync/receive_block.go
@@ -87,7 +87,7 @@ func (rs *RegularSync) processBlockAndFetchAncestors(ctx context.Context, msg p2
 	}
 
 	if rs.db.IsEvilBlockHash(blockRoot) {
-		log.Debugf("Skipping blacklisted block hash: %#x", blockRoot)
+		log.WithField("blockHash", blockRoot).Debug("Skipping blacklisted block")
 		return nil
 	}
 

--- a/beacon-chain/sync/receive_block_test.go
+++ b/beacon-chain/sync/receive_block_test.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/internal"
@@ -86,7 +85,7 @@ func TestReceiveBlockAnnounce_SkipsBlacklistedBlock(t *testing.T) {
 	if err := rs.receiveBlockAnnounce(msg); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	testutil.AssertLogsContain(t, hook, fmt.Sprintf("Received a blacklisted block hash: %#x", blockRoot))
+	testutil.AssertLogsContain(t, hook, "Received a blacklisted block hash")
 	hook.Reset()
 }
 


### PR DESCRIPTION
This is part of #1586 

---

# Description

**Write why you are making the changes in this pull request**

Previously, if we deleted a block, we might get an infinite ping pong of block requests in regular sync when we listen for block announcements. Additionally, we should blacklist block hashes in our db package as an in-memory map that we use to prevent spam requests or duplicate bad blocks received eternally.