### PR TITLE
Use HTTP RPC Endpoint for Logger to Fetch Past Logs

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -259,7 +259,7 @@ func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
 	}
 	powClient := ethclient.NewClient(rpcClient)
 
-	logRPCClient, err := gethRPC.Dial("https://goerli.prylabs.net")
+	logRPCClient, err := gethRPC.Dial(cliCtx.GlobalString(utils.HTTPWeb3ProviderFlag.Name))
 	if err != nil {
 		log.Fatalf("Access to PoW chain is required for validator. Unable to connect to Geth node: %v", err)
 	}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -259,6 +259,12 @@ func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
 	}
 	powClient := ethclient.NewClient(rpcClient)
 
+	logRPCClient, err := gethRPC.Dial("https://goerli.prylabs.net")
+	if err != nil {
+		log.Fatalf("Access to PoW chain is required for validator. Unable to connect to Geth node: %v", err)
+	}
+	pastLogHTTPClient := ethclient.NewClient(logRPCClient)
+
 	ctx := context.Background()
 	cfg := &powchain.Web3ServiceConfig{
 		Endpoint:        cliCtx.GlobalString(utils.Web3ProviderFlag.Name),
@@ -266,6 +272,7 @@ func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
 		Client:          powClient,
 		Reader:          powClient,
 		Logger:          powClient,
+		HTTPLogger:      pastLogHTTPClient,
 		BlockFetcher:    powClient,
 		ContractBackend: powClient,
 		BeaconDB:        b.db,

--- a/beacon-chain/powchain/block_reader_test.go
+++ b/beacon-chain/powchain/block_reader_test.go
@@ -29,6 +29,7 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
 		BlockFetcher:    &goodFetcher{},
 		ContractBackend: testAcc.backend,
 		BeaconDB:        beaconDB,

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -164,7 +164,7 @@ func (w *Web3Service) processPastLogs() error {
 		},
 	}
 
-	logs, err := w.logger.FilterLogs(w.ctx, query)
+	logs, err := w.httpLogger.FilterLogs(w.ctx, query)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -31,6 +31,7 @@ func TestProcessDepositLog_OK(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
 		ContractBackend: testAcc.backend,
 		BeaconDB:        &db.BeaconDB{},
 	})
@@ -93,6 +94,7 @@ func TestProcessDepositLog_InsertsPendingDeposit(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
 		ContractBackend: testAcc.backend,
 		BeaconDB:        &db.BeaconDB{},
 	})
@@ -154,6 +156,7 @@ func TestUnpackDepositLogData_OK(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
 		ContractBackend: testAcc.backend,
 	})
 	if err != nil {
@@ -237,6 +240,7 @@ func TestProcessChainStartLog_8DuplicatePubkeys(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
 		ContractBackend: testAcc.backend,
 		BeaconDB:        &db.BeaconDB{},
 	})
@@ -322,6 +326,7 @@ func TestProcessChainStartLog_8UniquePubkeys(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
 		ContractBackend: testAcc.backend,
 		BeaconDB:        &db.BeaconDB{},
 	})
@@ -406,6 +411,7 @@ func TestUnpackChainStartLogData_OK(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
 		ContractBackend: testAcc.backend,
 	})
 	if err != nil {
@@ -474,6 +480,7 @@ func TestHasChainStartLogOccurred_OK(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          testAcc.backend,
+		HTTPLogger:      &goodLogger{},
 		ContractBackend: testAcc.backend,
 	})
 	if err != nil {
@@ -534,6 +541,7 @@ func TestETH1DataGenesis_OK(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          testAcc.backend,
+		HTTPLogger:      &goodLogger{},
 		ContractBackend: testAcc.backend,
 		BeaconDB:        &db.BeaconDB{},
 	})

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -79,6 +79,7 @@ type Web3Service struct {
 	chainStartFeed          *event.Feed
 	reader                  Reader
 	logger                  bind.ContractFilterer
+	httpLogger              bind.ContractFilterer
 	blockFetcher            POWBlockFetcher
 	blockHeight             *big.Int    // the latest ETH1.0 chain blockHeight.
 	blockHash               common.Hash // the latest ETH1.0 chain blockHash.
@@ -104,6 +105,7 @@ type Web3ServiceConfig struct {
 	Client          Client
 	Reader          Reader
 	Logger          bind.ContractFilterer
+	HTTPLogger      bind.ContractFilterer
 	BlockFetcher    POWBlockFetcher
 	ContractBackend bind.ContractBackend
 	BeaconDB        *db.BeaconDB
@@ -143,6 +145,7 @@ func NewWeb3Service(ctx context.Context, config *Web3ServiceConfig) (*Web3Servic
 		depositTrie:             depositTrie,
 		reader:                  config.Reader,
 		logger:                  config.Logger,
+		httpLogger:              config.HTTPLogger,
 		blockFetcher:            config.BlockFetcher,
 		depositContractCaller:   depositContractCaller,
 		chainStartDeposits:      [][]byte{},

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -213,6 +213,7 @@ func TestStart_OK(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
 		BlockFetcher:    &goodFetcher{},
 		ContractBackend: testAcc.backend,
 		BeaconDB:        beaconDB,
@@ -283,6 +284,7 @@ func TestInitDataFromContract_OK(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &goodReader{},
 		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
 		ContractBackend: testAcc.backend,
 	})
 	if err != nil {
@@ -312,6 +314,7 @@ func TestWeb3Service_BadReader(t *testing.T) {
 		DepositContract: testAcc.contractAddr,
 		Reader:          &badReader{},
 		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
 		ContractBackend: testAcc.backend,
 	})
 	if err != nil {

--- a/beacon-chain/utils/flags.go
+++ b/beacon-chain/utils/flags.go
@@ -10,6 +10,12 @@ var (
 		Name:  "no-custom-config",
 		Usage: "Run the beacon chain with the real parameters from phase 0.",
 	}
+	// HTTPWeb3ProviderFlag provides an HTTP access endpoint to an ETH 1.0 RPC.
+	HTTPWeb3ProviderFlag = cli.StringFlag{
+		Name:  "http-web3provider",
+		Usage: "A mainchain web3 provider string http endpoint",
+		Value: "https://goerli.prylabs.net",
+	}
 	// Web3ProviderFlag defines a flag for a mainchain RPC endpoint.
 	Web3ProviderFlag = cli.StringFlag{
 		Name:  "web3provider",


### PR DESCRIPTION
This resolves #2295 

---

# Description

**Write why you are making the changes in this pull request**

Using websocket to fetch all historical contract logs would give us message size limit responses.

**Write a summary of the changes you are making**

This PR uses our goerli HTTP endpoint for fetching past logs when a node first starts up. All other future logs will continue to be done via websocket.

**Link anything that would be helpful or relevant to the reviewers**
