### PR TITLE
Only Update Head of Chain with Child Blocks

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//shared/hashutil:go_default_library",
         "//shared/p2p:go_default_library",
         "//shared/params:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/blockchain/fork_choice.go
+++ b/beacon-chain/blockchain/fork_choice.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
@@ -341,15 +342,8 @@ func VoteCount(block *pb.BeaconBlock, state *pb.BeaconState, targets map[uint64]
 		if ancestor == nil {
 			continue
 		}
-		ancestorRoot, err := hashutil.HashBeaconBlock(ancestor)
-		if err != nil {
-			return 0, err
-		}
-		blockRoot, err := hashutil.HashBeaconBlock(block)
-		if err != nil {
-			return 0, err
-		}
-		if blockRoot == ancestorRoot {
+
+		if proto.Equal(ancestor, block) {
 			balances += int(helpers.EffectiveBalance(state, validatorIndex))
 		}
 	}

--- a/beacon-chain/blockchain/fork_choice.go
+++ b/beacon-chain/blockchain/fork_choice.go
@@ -235,7 +235,7 @@ func (c *ChainService) lmdGhost(
 		if err != nil {
 			return nil, fmt.Errorf("unable to determine vote count for block: %v", err)
 		}
-		for i := 0; i < len(children); i++ {
+		for i := 1; i < len(children); i++ {
 			candidateChildVotes, err := VoteCount(children[i], startState, voteTargets, c.beaconDB)
 			if err != nil {
 				return nil, fmt.Errorf("unable to determine vote count for block: %v", err)

--- a/beacon-chain/sync/receive_block_test.go
+++ b/beacon-chain/sync/receive_block_test.go
@@ -118,6 +118,9 @@ func TestReceiveBlock_RecursivelyProcessesChildren(t *testing.T) {
 	if err := db.SaveState(ctx, genesisState); err != nil {
 		t.Fatal(err)
 	}
+	if err := db.UpdateChainHead(ctx, genesisBlock, genesisState); err != nil {
+		t.Fatal(err)
+	}
 
 	parents, parentRoots := setupBlockParents(t, genesisRoot)
 	blocksMissingParent := setupBlocksMissingParent(parents, parentRoots)

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/libp2p/go-libp2p-peer"
+	peer "github.com/libp2p/go-libp2p-peer"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/internal"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"


### PR DESCRIPTION
- [x] This wraps our `UpdateChainHead` call with a conditional that only processes a block if it is a child of the current chainhead. 

- [x] Minor changes to fork choice, to reduce redundant computation.