### PR TITLE
Prevent Canceling Goroutines in Validator Client

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -68,7 +68,7 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/pkgfact:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/nilness:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/nilfunc:go_tool_library",
-        "@org_golang_x_tools//go/analysis/passes/lostcancel:go_tool_library",
+        # "@org_golang_x_tools//go/analysis/passes/lostcancel:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/loopclosure:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/httpresponse:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/findcall:go_tool_library",

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -10,6 +10,11 @@
       "external/*": "Unreachable third party code"
     }
   },
+  "lostcancel": {
+    "exclude_files": {
+      "validator/client/runner.go": "No need to cancel right when goroutines begin"
+    }
+  },
   "nilness": {
     "exclude_files": {
       "external/*": "Third party code"
@@ -44,6 +49,5 @@
     "exclude_files": {
       "external/*": "Third party code"
     }
-
   }
 }

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -62,7 +62,7 @@ func run(ctx context.Context, v Validator) {
 			return // Exit if context is canceled.
 		case slot := <-v.NextSlot():
 			span.AddAttributes(trace.Int64Attribute("slot", int64(slot)))
-			slotCtx, cancel := context.WithDeadline(ctx, v.SlotDeadline(slot))
+			slotCtx, cancel := context.WithDeadline(context.Background(), v.SlotDeadline(slot))
 			// Report this validator client's rewards and penalties throughout its lifecycle.
 			if err := v.LogValidatorGainsAndLosses(slotCtx, slot); err != nil {
 				log.Errorf("Could not report validator's rewards/penalties for slot %d: %v",
@@ -100,7 +100,6 @@ func run(ctx context.Context, v Validator) {
 
 				}(role, id)
 			}
-			cancel()
 		}
 	}
 }

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -62,7 +62,7 @@ func run(ctx context.Context, v Validator) {
 			return // Exit if context is canceled.
 		case slot := <-v.NextSlot():
 			span.AddAttributes(trace.Int64Attribute("slot", int64(slot)))
-			slotCtx, cancel := context.WithDeadline(context.Background(), v.SlotDeadline(slot))
+			slotCtx, cancel := context.WithDeadline(ctx, v.SlotDeadline(slot))
 			// Report this validator client's rewards and penalties throughout its lifecycle.
 			if err := v.LogValidatorGainsAndLosses(slotCtx, slot); err != nil {
 				log.Errorf("Could not report validator's rewards/penalties for slot %d: %v",


### PR DESCRIPTION
Follow up to #2317 

---

# Description

**Write why you are making the changes in this pull request**

We were canceling the context to each of the goroutines in the block of code in validator/runner.go:
```go
 for id, role := range v.RolesAt(slot) {
                go func(role pb.ValidatorRole, id string) {
                    switch role {
                    case pb.ValidatorRole_ATTESTER:
                        v.AttestToBlockHead(slotCtx, slot, id)
                 ...
}
cancel()
```

**Write a summary of the changes you are making**

This PR removes the cancel call.