### PR TITLE
Separate Registry and Balances

### DIFF
--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -92,16 +92,16 @@ func (a *Service) IncomingAttestationFeed() *event.Feed {
 //		Attestation` be the attestation with the highest slot number in `store`
 //		from the validator with the given `validator_index`
 func (a *Service) LatestAttestation(ctx context.Context, index uint64) (*pb.Attestation, error) {
-	state, err := a.beaconDB.HeadState(ctx)
+	validatorRegistry, err := a.beaconDB.ValidatorRegistry(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// return error if it's an invalid validator index.
-	if index >= uint64(len(state.ValidatorRegistry)) {
+	if index >= uint64(len(validatorRegistry)) {
 		return nil, fmt.Errorf("invalid validator index %d", index)
 	}
-	pubKey := bytesutil.ToBytes48(state.ValidatorRegistry[index].Pubkey)
+	pubKey := bytesutil.ToBytes48(validatorRegistry[index].Pubkey)
 
 	a.store.RLock()
 	defer a.store.RUnlock()

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -22,6 +22,7 @@ var log = logrus.WithField("prefix", "beacondb")
 type BeaconDB struct {
 	stateLock    sync.RWMutex
 	currentState *pb.BeaconState
+	stateHash    [32]byte
 	db           *bolt.DB
 	DatabasePath string
 

--- a/beacon-chain/db/state.go
+++ b/beacon-chain/db/state.go
@@ -126,8 +126,8 @@ func (db *BeaconDB) HeadState(ctx context.Context) (*pb.BeaconState, error) {
 	return beaconState, err
 }
 
-// StateHash returns the hash of the current state from the db.
-func (db *BeaconDB) StateHash() [32]byte {
+// HeadStateRoot returns the root of the current state from the db.
+func (db *BeaconDB) HeadStateRoot() [32]byte {
 	return db.stateHash
 }
 

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -81,21 +81,25 @@ func (vs *ValidatorServer) ValidatorPerformance(
 	if err != nil {
 		return nil, fmt.Errorf("could not get validator index: %v", err)
 	}
-	beaconState, err := vs.beaconDB.HeadState(ctx)
+	validatorRegistry, err := vs.beaconDB.ValidatorRegistry(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve beacon state: %v", err)
 	}
+	validatorBalances, err := vs.beaconDB.ValidatorBalances(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Could not retrieve validator balances %v", err)
+	}
 	totalBalance := float32(0)
-	for _, val := range beaconState.ValidatorBalances {
+	for _, val := range validatorBalances {
 		totalBalance += float32(val)
 	}
-	avgBalance := totalBalance / float32(len(beaconState.ValidatorBalances))
-	balance := beaconState.ValidatorBalances[index]
-	activeIndices := helpers.ActiveValidatorIndices(beaconState.ValidatorRegistry, helpers.SlotToEpoch(req.Slot))
+	avgBalance := totalBalance / float32(len(validatorBalances))
+	balance := validatorBalances[index]
+	activeIndices := helpers.ActiveValidatorIndices(validatorRegistry, helpers.SlotToEpoch(req.Slot))
 	return &pb.ValidatorPerformanceResponse{
 		Balance:                 balance,
 		AverageValidatorBalance: avgBalance,
-		TotalValidators:         uint64(len(beaconState.ValidatorRegistry)),
+		TotalValidators:         uint64(len(validatorRegistry)),
 		TotalActiveValidators:   uint64(len(activeIndices)),
 	}, nil
 }

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -87,7 +87,7 @@ func (vs *ValidatorServer) ValidatorPerformance(
 	}
 	validatorBalances, err := vs.beaconDB.ValidatorBalances(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("Could not retrieve validator balances %v", err)
+		return nil, fmt.Errorf("could not retrieve validator balances %v", err)
 	}
 	totalBalance := float32(0)
 	for _, val := range validatorBalances {

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -223,7 +223,7 @@ func (s *InitialSync) exitInitialSync(ctx context.Context, block *pb.BeaconBlock
 		return err
 	}
 
-	stateRoot := s.db.StateHash()
+	stateRoot := s.db.HeadStateRoot()
 
 	if stateRoot != s.highestObservedRoot {
 		// TODO(#2155): Instead of a fatal call, drop the peer and restart the initial sync service.

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -23,7 +23,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/event"
-	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
@@ -224,14 +223,8 @@ func (s *InitialSync) exitInitialSync(ctx context.Context, block *pb.BeaconBlock
 		return err
 	}
 
-	canonicalState, err := s.db.HeadState(ctx)
-	if err != nil {
-		return fmt.Errorf("could not get state: %v", err)
-	}
-	stateRoot, err := hashutil.HashProto(canonicalState)
-	if err != nil {
-		return fmt.Errorf("could not hash state: %v", err)
-	}
+	stateRoot := s.db.StateHash()
+
 	if stateRoot != s.highestObservedRoot {
 		// TODO(#2155): Instead of a fatal call, drop the peer and restart the initial sync service.
 		log.Fatalf(
@@ -240,7 +233,7 @@ func (s *InitialSync) exitInitialSync(ctx context.Context, block *pb.BeaconBlock
 			s.highestObservedRoot,
 		)
 	}
-	log.WithField("canonicalStateSlot", canonicalState.Slot-params.BeaconConfig().GenesisSlot).Info("Exiting init sync and starting regular sync")
+	log.WithField("canonicalStateSlot", state.Slot-params.BeaconConfig().GenesisSlot).Info("Exiting init sync and starting regular sync")
 	s.syncService.ResumeSync()
 	s.cancel()
 	s.nodeIsSynced = true

--- a/beacon-chain/sync/regular_sync.go
+++ b/beacon-chain/sync/regular_sync.go
@@ -375,7 +375,7 @@ func (rs *RegularSync) handleChainHeadRequest(msg p2p.Message) error {
 		return err
 	}
 
-	stateRoot := rs.db.StateHash()
+	stateRoot := rs.db.HeadStateRoot()
 	finalizedState, err := rs.db.FinalizedState()
 	if err != nil {
 		log.Errorf("Could not retrieve finalized state %v", err)

--- a/beacon-chain/sync/regular_sync.go
+++ b/beacon-chain/sync/regular_sync.go
@@ -374,18 +374,8 @@ func (rs *RegularSync) handleChainHeadRequest(msg p2p.Message) error {
 		log.Errorf("Could not retrieve chain head %v", err)
 		return err
 	}
-	currentState, err := rs.db.HeadState(ctx)
-	if err != nil {
-		log.Errorf("Could not retrieve current state %v", err)
-		return err
-	}
 
-	stateRoot, err := hashutil.HashProto(currentState)
-	if err != nil {
-		log.Errorf("Could not tree hash state %v", err)
-		return err
-	}
-
+	stateRoot := rs.db.StateHash()
 	finalizedState, err := rs.db.FinalizedState()
 	if err != nil {
 		log.Errorf("Could not retrieve finalized state %v", err)


### PR DESCRIPTION
This PR adds new getters for Validator Registry and Balances, so that they can be retrieved quickly instead of cloning the whole state. This also adds a getter for the canonical state hash, so that hashing doesnt need to be repeated