### PR TITLE
Move Inclusion Maps to Epoch Processing

### DIFF
--- a/beacon-chain/core/balances/BUILD.bazel
+++ b/beacon-chain/core/balances/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/core/balances",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
-        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/epoch:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",

--- a/beacon-chain/core/balances/rewards_penalties_test.go
+++ b/beacon-chain/core/balances/rewards_penalties_test.go
@@ -188,10 +188,15 @@ func TestInclusionDistRewards_AccurateRewards(t *testing.T) {
 		if _, err := blocks.ProcessBlockAttestations(state, block, false /* verify sig */); err != nil {
 			t.Fatal(err)
 		}
+		inclusionMap := make(map[uint64]uint64)
+		for _, voted := range tt.voted {
+			inclusionMap[voted] = state.Slot
+		}
 		state, err := InclusionDistance(
 			state,
 			tt.voted,
-			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount)
+			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount,
+			inclusionMap)
 		if err != nil {
 			t.Fatalf("could not execute InclusionDistRewards:%v", err)
 		}
@@ -231,7 +236,8 @@ func TestInclusionDistRewards_OutOfBounds(t *testing.T) {
 			ValidatorRegistry:  validators,
 			LatestAttestations: attestation,
 		}
-		_, err := InclusionDistance(state, tt.voted, 0)
+		inclusionMap := make(map[uint64]uint64)
+		_, err := InclusionDistance(state, tt.voted, 0, inclusionMap)
 		if err == nil {
 			t.Fatal("InclusionDistRewards should have failed")
 		}
@@ -422,10 +428,15 @@ func TestInactivityInclusionPenalty_AccuratePenalties(t *testing.T) {
 			ValidatorBalances:  validatorBalances,
 			LatestAttestations: attestation,
 		}
+		inclusionMap := make(map[uint64]uint64)
+		for _, voted := range tt.voted {
+			inclusionMap[voted] = state.Slot + 1
+		}
 		state, err := InactivityInclusionDistance(
 			state,
 			tt.voted,
-			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount)
+			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount,
+			inclusionMap)
 
 		for _, i := range tt.voted {
 			validatorBalances[i] = 32000055555
@@ -464,7 +475,8 @@ func TestInactivityInclusionPenalty_OutOfBounds(t *testing.T) {
 			ValidatorRegistry:  validators,
 			LatestAttestations: attestation,
 		}
-		_, err := InactivityInclusionDistance(state, tt.voted, 0)
+		inclusionMap := make(map[uint64]uint64)
+		_, err := InactivityInclusionDistance(state, tt.voted, 0, inclusionMap)
 		if err == nil {
 			t.Fatal("InclusionDistRewards should have failed")
 		}
@@ -522,10 +534,16 @@ func TestAttestationInclusionRewards_AccurateRewards(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		inclusionMap := make(map[uint64]uint64)
+		for _, voted := range tt.voted {
+			inclusionMap[voted] = state.Slot
+		}
+
 		state, err = AttestationInclusion(
 			state,
 			uint64(len(validatorBalances))*params.BeaconConfig().MaxDepositAmount,
-			tt.voted)
+			tt.voted,
+			inclusionMap)
 
 		for _, i := range tt.voted {
 			validatorBalances[i] = 32000008680
@@ -564,7 +582,8 @@ func TestAttestationInclusionRewards_NoInclusionSlot(t *testing.T) {
 			ValidatorRegistry: validators,
 			ValidatorBalances: validatorBalances,
 		}
-		if _, err := AttestationInclusion(state, 0, tt.voted); err == nil {
+		inclusionMap := make(map[uint64]uint64)
+		if _, err := AttestationInclusion(state, 0, tt.voted, inclusionMap); err == nil {
 			t.Fatal("AttestationInclusionRewards should have failed with no inclusion slot")
 		}
 	}
@@ -600,7 +619,8 @@ func TestAttestationInclusionRewards_NoProposerIndex(t *testing.T) {
 			ValidatorBalances:  validatorBalances,
 			LatestAttestations: attestation,
 		}
-		if _, err := AttestationInclusion(state, 0, tt.voted); err == nil {
+		inclusionMap := make(map[uint64]uint64)
+		if _, err := AttestationInclusion(state, 0, tt.voted, inclusionMap); err == nil {
 			t.Fatal("AttestationInclusionRewards should have failed with no proposer index")
 		}
 	}

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
-        "//beacon-chain/cache:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state/stateutils:go_default_library",
         "//beacon-chain/core/validators:go_default_library",

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -9,10 +9,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sync"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
@@ -24,24 +22,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
 	"github.com/sirupsen/logrus"
 )
-
-var committeeCache = cache.NewCommitteesCache()
-
-type attesterInclusionStore struct {
-	slotLock sync.RWMutex
-	distLock sync.RWMutex
-	// attesterInclusion is a mapping that tracks when an attester's attestation
-	// last get included in beacon chain.
-	attesterInclusionSlot map[uint64]uint64
-	// attesterInclusion is a mapping that tracks the difference in slot number
-	// of when attestation gets submitted and when it gets included.
-	attesterInclusionDist map[uint64]uint64
-}
-
-var attsInclStore = attesterInclusionStore{
-	attesterInclusionSlot: make(map[uint64]uint64),
-	attesterInclusionDist: make(map[uint64]uint64),
-}
 
 // VerifyProposerSignature uses BLS signature verification to ensure
 // the correct proposer created an incoming beacon block during state
@@ -433,38 +413,6 @@ func ProcessBlockAttestations(
 			return nil, fmt.Errorf("could not verify attestation at index %d in block: %v", idx, err)
 		}
 
-		var IndicesInCommittee []uint64
-		// get the validator indices from the attestation using committees info cache.
-		cachedCommittees, err := committeeCache.CommitteesInfoBySlot(attestation.Data.Slot)
-		if err != nil {
-			return nil, err
-		}
-		if cachedCommittees == nil {
-			crosslinkCommittees, err := helpers.CrosslinkCommitteesAtSlot(beaconState, attestation.Data.Slot, false /* registryChange */)
-			if err != nil {
-				return nil, err
-			}
-			cachedCommittees = helpers.ToCommitteeCache(attestation.Data.Slot, crosslinkCommittees)
-			if err := committeeCache.AddCommittees(cachedCommittees); err != nil {
-				return nil, err
-			}
-		}
-		for _, v := range cachedCommittees.Committees {
-			if v.Shard == attestation.Data.Shard {
-				IndicesInCommittee = v.Committee
-				break
-			}
-		}
-
-		attsInclStore.slotLock.Lock()
-		attsInclStore.distLock.Lock()
-		defer attsInclStore.slotLock.Unlock()
-		defer attsInclStore.distLock.Unlock()
-		for _, index := range IndicesInCommittee {
-			attsInclStore.attesterInclusionSlot[index] = beaconState.Slot
-			attsInclStore.attesterInclusionDist[index] = beaconState.Slot - attestation.Data.Slot
-		}
-
 		beaconState.LatestAttestations = append(beaconState.LatestAttestations, &pb.PendingAttestation{
 			Data:                attestation.Data,
 			AggregationBitfield: attestation.AggregationBitfield,
@@ -753,26 +701,4 @@ func verifyExit(beaconState *pb.BeaconState, exit *pb.VoluntaryExit, verifySigna
 		return nil
 	}
 	return nil
-}
-
-// AttsInclusionSlot returns the slot of when an attestator's attestation last gets included
-// in the beacon chain by a proposer.
-func AttsInclusionSlot(index uint64) (uint64, error) {
-	attsInclStore.slotLock.RLock()
-	attsInclStore.slotLock.RUnlock()
-	if slot, ok := attsInclStore.attesterInclusionSlot[index]; ok {
-		return slot, nil
-	}
-	return 0, fmt.Errorf("no inclusion slot for attestor %d", index)
-}
-
-// AttsInclusionDistance returns diff in slot of when an attestator's attestation gets submitted
-// and included.
-func AttsInclusionDistance(index uint64) (uint64, error) {
-	attsInclStore.distLock.RLock()
-	attsInclStore.distLock.RUnlock()
-	if slot, ok := attsInclStore.attesterInclusionDist[index]; ok {
-		return slot, nil
-	}
-	return 0, fmt.Errorf("no inclusion distance for attestor %d", index)
 }


### PR DESCRIPTION
This is a follow-up to #2346 
---

# Description

**Write why you are making the changes in this pull request**

We only need the inclusion maps in epoch processing, eliminating the need to use mutexes and other complex operations outside of the state transition function. This PR moves the maps there and resolved the problems this caused with initial sync.
