### PR TITLE
Remove Proto Clone from State Reads

### DIFF
--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -20,11 +20,12 @@ var log = logrus.WithField("prefix", "beacondb")
 // For example, instead of defining get, put, remove
 // This defines methods such as getBlock, saveBlocksAndAttestations, etc.
 type BeaconDB struct {
-	stateLock    sync.RWMutex
-	currentState *pb.BeaconState
-	stateHash    [32]byte
-	db           *bolt.DB
-	DatabasePath string
+	stateLock       sync.RWMutex
+	currentState    *pb.BeaconState
+	serializedState []byte
+	stateHash       [32]byte
+	db              *bolt.DB
+	DatabasePath    string
 
 	// Beacon block info in memory.
 	highestBlockSlot uint64

--- a/beacon-chain/db/state.go
+++ b/beacon-chain/db/state.go
@@ -179,16 +179,9 @@ func (db *BeaconDB) SaveState(ctx context.Context, beaconState *pb.BeaconState) 
 	return db.update(func(tx *bolt.Tx) error {
 		chainInfo := tx.Bucket(chainInfoBucket)
 
-		_, marshalSpan := trace.StartSpan(ctx, "proto.Marshal")
-		beaconStateEnc, err := proto.Marshal(beaconState)
-		if err != nil {
-			return err
-		}
-		marshalSpan.End()
-
-		stateBytes.Set(float64(len(beaconStateEnc)))
+		stateBytes.Set(float64(len(enc)))
 		reportStateMetrics(beaconState)
-		return chainInfo.Put(stateLookupKey, beaconStateEnc)
+		return chainInfo.Put(stateLookupKey, enc)
 	})
 }
 


### PR DESCRIPTION
This removes proto clone from state reads, and just ensures the cached state has not been corrupted