### PR TITLE
Disable RPC while Syncing

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -344,6 +344,11 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 		return err
 	}
 
+	var syncService *rbcsync.Service
+	if err := b.services.FetchService(&syncService); err != nil {
+		return err
+	}
+
 	port := ctx.GlobalString(utils.RPCPort.Name)
 	cert := ctx.GlobalString(utils.CertFlag.Name)
 	key := ctx.GlobalString(utils.KeyFlag.Name)
@@ -355,6 +360,7 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 		ChainService:     chainService,
 		OperationService: operationService,
 		POWChainService:  web3Service,
+		SyncService:      syncService,
 	})
 
 	return b.services.RegisterService(rpcService)

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -55,6 +55,10 @@ type powChainService interface {
 	ChainStartDeposits() [][]byte
 }
 
+type syncService interface {
+	Status() error
+}
+
 // Service defining an RPC server for a beacon node.
 type Service struct {
 	ctx                 context.Context
@@ -63,6 +67,7 @@ type Service struct {
 	chainService        chainService
 	powChainService     powChainService
 	operationService    operationService
+	syncService         syncService
 	port                string
 	listener            net.Listener
 	withCert            string
@@ -82,6 +87,7 @@ type Config struct {
 	ChainService     chainService
 	POWChainService  powChainService
 	OperationService operationService
+	SyncService      syncService
 }
 
 // NewRPCService creates a new instance of a struct implementing the BeaconServiceServer
@@ -95,6 +101,7 @@ func NewRPCService(ctx context.Context, cfg *Config) *Service {
 		chainService:        cfg.ChainService,
 		powChainService:     cfg.POWChainService,
 		operationService:    cfg.OperationService,
+		syncService:         cfg.SyncService,
 		port:                cfg.Port,
 		withCert:            cfg.CertFlag,
 		withKey:             cfg.KeyFlag,
@@ -174,6 +181,10 @@ func (s *Service) Start() {
 	reflection.Register(s.grpcServer)
 
 	go func() {
+		for s.syncService.Status() != nil {
+			time.Sleep(time.Second * params.BeaconConfig().RPCSyncCheck)
+		}
+		log.Error("Starting RPC")
 		if s.listener != nil {
 			if err := s.grpcServer.Serve(s.listener); err != nil {
 				log.Errorf("Could not serve gRPC: %v", err)

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -184,7 +184,6 @@ func (s *Service) Start() {
 		for s.syncService.Status() != nil {
 			time.Sleep(time.Second * params.BeaconConfig().RPCSyncCheck)
 		}
-		log.Error("Starting RPC")
 		if s.listener != nil {
 			if err := s.grpcServer.Serve(s.listener); err != nil {
 				log.Errorf("Could not serve gRPC: %v", err)

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -121,12 +121,20 @@ func newMockChainService() *mockChainService {
 	}
 }
 
+type mockSyncService struct {
+}
+
+func (ms *mockSyncService) Status() error {
+	return nil
+}
+
 func TestLifecycle_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
 	rpcService := NewRPCService(context.Background(), &Config{
-		Port:     "7348",
-		CertFlag: "alice.crt",
-		KeyFlag:  "alice.key",
+		Port:        "7348",
+		CertFlag:    "alice.crt",
+		KeyFlag:     "alice.key",
+		SyncService: &mockSyncService{},
 	})
 
 	rpcService.Start()
@@ -150,7 +158,8 @@ func TestRPC_BadEndpoint(t *testing.T) {
 	hook := logTest.NewLocal(fl.Logger)
 
 	rpcService := NewRPCService(context.Background(), &Config{
-		Port: "ralph merkle!!!",
+		Port:        "ralph merkle!!!",
+		SyncService: &mockSyncService{},
 	})
 
 	if val, ok := log.(*TestLogger).testMap["error"]; ok {
@@ -179,7 +188,8 @@ func TestStatus_CredentialError(t *testing.T) {
 func TestRPC_InsecureEndpoint(t *testing.T) {
 	hook := logTest.NewGlobal()
 	rpcService := NewRPCService(context.Background(), &Config{
-		Port: "7777",
+		Port:        "7777",
+		SyncService: &mockSyncService{},
 	})
 
 	rpcService.Start()

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
@@ -101,6 +102,9 @@ func (ss *Service) Status() error {
 	blk, err := ss.Querier.db.ChainHead()
 	if err != nil {
 		return fmt.Errorf("could not retrieve chain head %v", err)
+	}
+	if blk == nil {
+		return errors.New("no chain head exists in db")
 	}
 	if blk.Slot < ss.InitialSync.HighestObservedSlot() {
 		return fmt.Errorf("node is not synced as the current chain head is at slot %d", blk.Slot-params.BeaconConfig().GenesisSlot)

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -21,7 +21,6 @@ type Service struct {
 	InitialSync     *initialsync.InitialSync
 	Querier         *Querier
 	querierFinished bool
-	synced          bool
 }
 
 // Config defines the configured services required for sync to work.

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -4,6 +4,7 @@ package params
 
 import (
 	"math/big"
+	"time"
 )
 
 // BeaconChainConfig contains constant configs for node to participate in beacon chain.
@@ -77,13 +78,14 @@ type BeaconChainConfig struct {
 	MaxAttesterSlashings uint64 // MaxAttesterSlashings defines the maximum number of casper FFG slashings possible in a block.
 
 	// Prysm constants.
-	DepositsForChainStart uint64 // DepositsForChainStart defines how many validator deposits needed to kick off beacon chain.
-	RandBytes             uint64 // RandBytes is the number of bytes used as entropy to shuffle validators.
-	SyncPollingInterval   int64  // SyncPollingInterval queries network nodes for sync status.
-	BatchBlockLimit       uint64 // BatchBlockLimit is maximum number of blocks that can be requested for initial sync.
-	SyncEpochLimit        uint64 // SyncEpochLimit is the number of epochs the current node can be behind before it requests for the latest state.
-	MaxNumLog2Validators  uint64 // MaxNumLog2Validators is the Max number of validators in Log2 exists given total ETH supply.
-	LogBlockDelay         int64  // Number of blocks to wait from the current head before processing logs from the deposit contract.
+	DepositsForChainStart uint64        // DepositsForChainStart defines how many validator deposits needed to kick off beacon chain.
+	RandBytes             uint64        // RandBytes is the number of bytes used as entropy to shuffle validators.
+	SyncPollingInterval   int64         // SyncPollingInterval queries network nodes for sync status.
+	BatchBlockLimit       uint64        // BatchBlockLimit is maximum number of blocks that can be requested for initial sync.
+	SyncEpochLimit        uint64        // SyncEpochLimit is the number of epochs the current node can be behind before it requests for the latest state.
+	MaxNumLog2Validators  uint64        // MaxNumLog2Validators is the Max number of validators in Log2 exists given total ETH supply.
+	LogBlockDelay         int64         // Number of blocks to wait from the current head before processing logs from the deposit contract.
+	RPCSyncCheck          time.Duration // Number of seconds to query the sync service, to find out if the node is synced or not.
 }
 
 // DepositContractConfig contains the deposits for
@@ -172,6 +174,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	BatchBlockLimit:       64 * 4, // Process blocks in batches of 4 epochs of blocks (threshold before casper penalties).
 	MaxNumLog2Validators:  24,
 	LogBlockDelay:         2, //
+	RPCSyncCheck:          1,
 }
 
 var defaultShardConfig = &ShardChainConfig{


### PR DESCRIPTION
This resolves #2222, it continuously checks the status of the sync service before serving RPC requests. If the node is not synced RPC will be disabled