### PR TITLE
Update Committee Helpers 

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -448,6 +448,20 @@ func CommitteeAssignment(
 	return []uint64{}, 0, 0, false, status.Error(codes.NotFound, "validator not found found in assignments")
 }
 
+// ShardDelta returns the minimum number of shards get processed in one epoch.
+//
+// Spec pseudocode definition:
+// 	def get_shard_delta(state: BeaconState, epoch: Epoch) -> int:
+//    return min(get_epoch_committee_count(state, epoch), SHARD_COUNT - SHARD_COUNT // SLOTS_PER_EPOCH)
+func ShardDelta(beaconState *pb.BeaconState, epoch uint64) uint64 {
+	shardCount := params.BeaconConfig().ShardCount
+	minShardDelta := shardCount - shardCount/params.BeaconConfig().SlotsPerEpoch
+	if EpochCommitteeCount(beaconState, epoch) < minShardDelta {
+		return EpochCommitteeCount(beaconState, epoch)
+	}
+	return minShardDelta
+}
+
 // prevEpochCommitteesAtSlot returns a list of crosslink committees of the previous epoch.
 //
 // Spec pseudocode definition:

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -41,9 +41,18 @@ func TestEpochCommitteeCount_OK(t *testing.T) {
 		{32 * validatorsPerEpoch, 16 * params.BeaconConfig().SlotsPerEpoch},
 	}
 	for _, test := range tests {
-		if test.committeeCount != EpochCommitteeCount(test.validatorCount) {
+		vals := make([]*pb.Validator, test.validatorCount)
+		for i := 0; i < len(vals); i++ {
+			vals[i] = &pb.Validator{
+				ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+			}
+		}
+		s := &pb.BeaconState{
+			ValidatorRegistry: vals,
+		}
+		if test.committeeCount != EpochCommitteeCount(s, 1) {
 			t.Errorf("wanted: %d, got: %d",
-				test.committeeCount, EpochCommitteeCount(test.validatorCount))
+				test.committeeCount, EpochCommitteeCount(s, 1))
 		}
 	}
 }
@@ -57,9 +66,18 @@ func TestEpochCommitteeCount_LessShardsThanEpoch(t *testing.T) {
 		TargetCommitteeSize: 2,
 	}
 	params.OverrideBeaconConfig(testConfig)
-	if EpochCommitteeCount(validatorCount) != validatorCount/testConfig.TargetCommitteeSize {
+	vals := make([]*pb.Validator, validatorCount)
+	for i := 0; i < len(vals); i++ {
+		vals[i] = &pb.Validator{
+			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+		}
+	}
+	s := &pb.BeaconState{
+		ValidatorRegistry: vals,
+	}
+	if EpochCommitteeCount(s, 1) != validatorCount/testConfig.TargetCommitteeSize {
 		t.Errorf("wanted: %d, got: %d",
-			validatorCount/testConfig.TargetCommitteeSize, EpochCommitteeCount(validatorCount))
+			validatorCount/testConfig.TargetCommitteeSize, EpochCommitteeCount(s, 1))
 	}
 	params.OverrideBeaconConfig(productionConfig)
 }
@@ -136,6 +154,9 @@ func TestShuffling_OK(t *testing.T) {
 			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
 		}
 	}
+	state := &pb.BeaconState{
+		ValidatorRegistry: validators,
+	}
 
 	randaoSeed := [32]byte{'A'}
 	slot := uint64(10)
@@ -145,7 +166,7 @@ func TestShuffling_OK(t *testing.T) {
 	}
 
 	// Verify shuffled list is correctly split into committees_per_slot pieces.
-	committeesPerEpoch = EpochCommitteeCount(uint64(len(validators)))
+	committeesPerEpoch = EpochCommitteeCount(state, 1)
 	committeesPerSlot := committeesPerEpoch / params.BeaconConfig().SlotsPerEpoch
 	if committeesPerSlot != committeesPerSlot {
 		t.Errorf("Incorrect committee count after splitting. Wanted: %d, got: %d",


### PR DESCRIPTION
Part of #2307 

This PR is temporally blocked by #2350. To wrap up `compute_committee ` I'll need `get_permuted_index`

What changes in this PR:
- [x] Update `get_epoch_committee_count`
- [x] Update `get_shard_delta`
- [ ] Update `compute_committee`
- [ ] Update `get_crosslink_committees_at_slot`