### PR TITLE
Enable Ancestor Cache By Default

### DIFF
--- a/beacon-chain/blockchain/fork_choice.go
+++ b/beacon-chain/blockchain/fork_choice.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
@@ -329,17 +328,9 @@ func VoteCount(block *pb.BeaconBlock, state *pb.BeaconState, targets map[uint64]
 	}
 
 	for validatorIndex, target := range targets {
-		if featureconfig.FeatureConfig().EnableBlockAncestorCache {
-			ancestorRoot, err = cachedAncestor(target, block.Slot, beaconDB)
-			if err != nil {
-				return 0, err
-			}
-		} else {
-			// if block ancestor cache was not enabled, retrieve the ancestor recursively.
-			ancestorRoot, err = BlockAncestor(target, block.Slot, beaconDB)
-			if err != nil {
-				return 0, err
-			}
+		ancestorRoot, err = cachedAncestor(target, block.Slot, beaconDB)
+		if err != nil {
+			return 0, err
 		}
 		// This covers the following case, we start at B5, and want to process B6 and B7
 		// B6 can be processed, B7 can not be processed because it's pointed to the

--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -20,7 +20,6 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/forkutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -1443,10 +1442,6 @@ func setupFFGTest(t *testing.T) ([32]byte, *pb.BeaconBlock, *pb.BeaconState, []*
 }
 
 func TestVoteCount_CacheEnabledAndMiss(t *testing.T) {
-	featureconfig.InitFeatureConfig(&featureconfig.FeatureFlagConfig{
-		EnableBlockAncestorCache: true,
-	})
-
 	beaconDB := internal.SetupDB(t)
 	defer internal.TeardownDB(t, beaconDB)
 	genesisBlock := b.NewGenesisBlock([]byte("stateroot"))
@@ -1514,10 +1509,6 @@ func TestVoteCount_CacheEnabledAndMiss(t *testing.T) {
 }
 
 func TestVoteCount_CacheEnabledAndHit(t *testing.T) {
-	featureconfig.InitFeatureConfig(&featureconfig.FeatureFlagConfig{
-		EnableBlockAncestorCache: true,
-	})
-
 	genesisBlock := b.NewGenesisBlock([]byte("stateroot"))
 	genesisRoot, err := hashutil.HashBeaconBlock(genesisBlock)
 	if err != nil {

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -30,7 +30,6 @@ type FeatureFlagConfig struct {
 	EnableCrosslinks             bool // EnableCrosslinks in epoch processing.
 	EnableCheckBlockStateRoot    bool // EnableCheckBlockStateRoot in block processing.
 	EnableHistoricalStatePruning bool // EnableHistoricalStatePruning when updating finalized states.
-	EnableBlockAncestorCache     bool //EnableBlockAncestorCache for fork choice optimization.
 	DisableGossipSub             bool // DisableGossipSub in p2p messaging.
 }
 
@@ -72,10 +71,6 @@ func ConfigureBeaconFeatures(ctx *cli.Context) {
 	if ctx.GlobalBool(EnableHistoricalStatePruningFlag.Name) {
 		log.Info("Enabled historical state pruning")
 		cfg.EnableHistoricalStatePruning = true
-	}
-	if ctx.GlobalBool(EnableBlockAncestorCacheFlag.Name) {
-		log.Info("Enabled block ancestor cache")
-		cfg.EnableBlockAncestorCache = true
 	}
 	if ctx.GlobalBool(DisableGossipSubFlag.Name) {
 		log.Info("Disabled gossipsub, using floodsub")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -51,6 +51,5 @@ var BeaconChainFlags = []cli.Flag{
 	EnableCrosslinksFlag,
 	EnableCheckBlockStateRootFlag,
 	EnableHistoricalStatePruningFlag,
-	EnableBlockAncestorCacheFlag,
 	DisableGossipSubFlag,
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -25,12 +25,6 @@ var (
 		Name:  "enable-crosslinks",
 		Usage: "Enable crosslinks in epoch processing, default is disabled.",
 	}
-	// EnableBlockAncestorCacheFlag enables block ancestor cache for LMD GHOST fork choice optimization. I
-	// it is disabled by default.
-	EnableBlockAncestorCacheFlag = cli.BoolFlag{
-		Name:  "enable-block-ancestor-cache",
-		Usage: "Enable block ancestor cache for fork choice optimization, default is disabled.",
-	}
 	// EnableCheckBlockStateRootFlag check block state root in block processing. It is disabled by default.
 	EnableCheckBlockStateRootFlag = cli.BoolFlag{
 		Name:  "enable-check-block-state-root",


### PR DESCRIPTION
This is part of #1586 

---

# Description

**Write why you are making the changes in this pull request**

Our block ancestor cache has been working well and offers significant improvements in fork choice. However, it is still hidden behind a feature flag.

**Write a summary of the changes you are making**

This PR makes the ancestor cache enabled the default behavior and removes the feature flag for it.
