### PR TITLE
Suggest to ClearDB if Contract Mismatches Cluster

### DIFF
--- a/beacon-chain/db/verify_contract.go
+++ b/beacon-chain/db/verify_contract.go
@@ -29,7 +29,7 @@ func (db *BeaconDB) VerifyContractAddress(ctx context.Context, addr common.Addre
 		}
 
 		if !bytes.Equal(expectedAddress, addr.Bytes()) {
-			return fmt.Errorf("invalid deposit contract address, expected %#x", expectedAddress)
+			return fmt.Errorf("invalid deposit contract address, expected %#x - try running with --clear-db", expectedAddress)
 		}
 
 		return nil

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -63,7 +63,7 @@ func main() {
 		cmd.TraceSampleFractionFlag,
 		cmd.MonitoringPortFlag,
 		cmd.DisableMonitoringFlag,
-		cmd.ClearDBFlag,
+		cmd.PersistDB,
 		debug.PProfFlag,
 		debug.PProfAddrFlag,
 		debug.PProfPortFlag,

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -63,7 +63,7 @@ func main() {
 		cmd.TraceSampleFractionFlag,
 		cmd.MonitoringPortFlag,
 		cmd.DisableMonitoringFlag,
-		cmd.PersistDB,
+		cmd.ClearDB,
 		debug.PProfFlag,
 		debug.PProfAddrFlag,
 		debug.PProfPortFlag,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -168,7 +168,7 @@ func (b *BeaconNode) Close() {
 func (b *BeaconNode) startDB(ctx *cli.Context) error {
 	baseDir := ctx.GlobalString(cmd.DataDirFlag.Name)
 	dbPath := path.Join(baseDir, beaconChainDBName)
-	if !b.ctx.GlobalBool(cmd.PersistDB.Name) {
+	if b.ctx.GlobalBool(cmd.ClearDB.Name) {
 		if err := db.ClearDB(dbPath); err != nil {
 			return err
 		}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -168,7 +168,7 @@ func (b *BeaconNode) Close() {
 func (b *BeaconNode) startDB(ctx *cli.Context) error {
 	baseDir := ctx.GlobalString(cmd.DataDirFlag.Name)
 	dbPath := path.Join(baseDir, beaconChainDBName)
-	if b.ctx.GlobalBool(cmd.ClearDBFlag.Name) {
+	if !b.ctx.GlobalBool(cmd.PersistDB.Name) {
 		if err := db.ClearDB(dbPath); err != nil {
 			return err
 		}

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -64,9 +64,9 @@ var (
 		Usage: "The port used by libp2p.",
 		Value: 12000,
 	}
-	// PersistDB tells the beacon node to keep any previously stored data at the data directory between runs.
-	PersistDB = cli.BoolFlag{
-		Name:  "persist-db",
-		Usage: "Persists any previously stored data at the data directory",
+	// ClearDB tells the beacon node to remove any previously stored data at the data directory.
+	ClearDB = cli.BoolFlag{
+		Name:  "clear-db",
+		Usage: "Clears any previously stored data at the data directory",
 	}
 )

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -47,16 +47,24 @@ var (
 		Usage: "Port used to listening and respond metrics for prometheus.",
 		Value: 8080,
 	}
+	// LocalNetwork specifies whether we are running a local network and have no need for connecting
+	// to the bootstrap nodes in the cloud
+	LocalNetwork = cli.BoolFlag{
+		Name:  "local-network",
+		Usage: "Enable only local network p2p and do not connect to cloud bootstrap nodes.",
+	}
 	// BootstrapNode tells the beacon node which bootstrap node to connect to
 	BootstrapNode = cli.StringFlag{
 		Name:  "bootstrap-node",
 		Usage: "The address of bootstrap node. Beacon node will connect for peer discovery via DHT",
+		Value: "/ip4/35.224.249.2/tcp/30001/p2p/QmQEe7o6hKJdGdSkJRh7WJzS6xrex5f4w2SPR6oWbJNriw",
 	}
 	// RelayNode tells the beacon node which relay node to connect to.
 	RelayNode = cli.StringFlag{
 		Name: "relay-node",
 		Usage: "The address of relay node. The beacon node will connect to the " +
 			"relay node and advertise their address via the relay node to other peers",
+		Value: "/ip4/35.224.249.2/tcp/30000/p2p/QmfAgkmjiZNZhr2wFN9TwaRgHouMTBT6HELyzE5A3BT2wK",
 	}
 	// P2PPort defines the port to be used by libp2p.
 	P2PPort = cli.IntFlag{
@@ -64,9 +72,9 @@ var (
 		Usage: "The port used by libp2p.",
 		Value: 12000,
 	}
-	// ClearDBFlag tells the beacon node to remove any previously stored data at the data directory.
-	ClearDBFlag = cli.BoolFlag{
-		Name:  "clear-db",
-		Usage: "Clears any previously stored data at the data directory",
+	// PersistDBFlag tells the beacon node to keep any previously stored data at the data directory between runs.
+	PersistDB = cli.BoolFlag{
+		Name:  "persist-db",
+		Usage: "Persists any previously stored data at the data directory",
 	}
 )

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -64,7 +64,7 @@ var (
 		Usage: "The port used by libp2p.",
 		Value: 12000,
 	}
-	// PersistDBFlag tells the beacon node to keep any previously stored data at the data directory between runs.
+	// PersistDB tells the beacon node to keep any previously stored data at the data directory between runs.
 	PersistDB = cli.BoolFlag{
 		Name:  "persist-db",
 		Usage: "Persists any previously stored data at the data directory",

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -47,24 +47,16 @@ var (
 		Usage: "Port used to listening and respond metrics for prometheus.",
 		Value: 8080,
 	}
-	// LocalNetwork specifies whether we are running a local network and have no need for connecting
-	// to the bootstrap nodes in the cloud
-	LocalNetwork = cli.BoolFlag{
-		Name:  "local-network",
-		Usage: "Enable only local network p2p and do not connect to cloud bootstrap nodes.",
-	}
 	// BootstrapNode tells the beacon node which bootstrap node to connect to
 	BootstrapNode = cli.StringFlag{
 		Name:  "bootstrap-node",
 		Usage: "The address of bootstrap node. Beacon node will connect for peer discovery via DHT",
-		Value: "/ip4/35.224.249.2/tcp/30001/p2p/QmQEe7o6hKJdGdSkJRh7WJzS6xrex5f4w2SPR6oWbJNriw",
 	}
 	// RelayNode tells the beacon node which relay node to connect to.
 	RelayNode = cli.StringFlag{
 		Name: "relay-node",
 		Usage: "The address of relay node. The beacon node will connect to the " +
 			"relay node and advertise their address via the relay node to other peers",
-		Value: "/ip4/35.224.249.2/tcp/30000/p2p/QmfAgkmjiZNZhr2wFN9TwaRgHouMTBT6HELyzE5A3BT2wK",
 	}
 	// P2PPort defines the port to be used by libp2p.
 	P2PPort = cli.IntFlag{


### PR DESCRIPTION
Part of #1586 

---

# Description

**Write why you are making the changes in this pull request**

As we are planning on doing short-lived testnets, it will make for a bad user experience if someone keeps using the same persistent db between runs as initial sync will fail and users might not know why. For now, we are disabling the use of a persistent DB between runs, making the default behavior to clear the db upon startup.
