### PR TITLE
k8s: Use infura for http provider

### DIFF
--- a/k8s/beacon-chain/beacon-chain.deploy.yaml
+++ b/k8s/beacon-chain/beacon-chain.deploy.yaml
@@ -44,6 +44,7 @@ spec:
           image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
           args: 
             - --web3provider=wss://goerli.infura.io/ws/v3/be3fb7ed377c418087602876a40affa1
+            - --http-web3provider=https://goerli.infura.io/v3/be3fb7ed377c418087602876a40affa1
             #- --verbosity=debug
             - --deposit-contract=$(DEPOSIT_CONTRACT_ADDRESS)
             - --rpc-port=4000


### PR DESCRIPTION
Our goerli node is not reliable enough at the moment. 