### PR TITLE
Fix State Reads

### DIFF
--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -94,17 +94,12 @@ func (a *Service) IncomingAttestationFeed() *event.Feed {
 //		Attestation` be the attestation with the highest slot number in `store`
 //		from the validator with the given `validator_index`
 func (a *Service) LatestAttestation(ctx context.Context, index uint64) (*pb.Attestation, error) {
-	validatorRegistry, err := a.beaconDB.ValidatorRegistry(ctx)
+	validator, err := a.beaconDB.ValidatorFromState(ctx, index)
 	if err != nil {
 		return nil, err
 	}
 
-	// return error if it's an invalid validator index.
-	if index >= uint64(len(validatorRegistry)) {
-		return nil, fmt.Errorf("invalid validator index %d", index)
-	}
-	pubKey := bytesutil.ToBytes48(validatorRegistry[index].Pubkey)
-
+	pubKey := bytesutil.ToBytes48(validator.Pubkey)
 	a.store.RLock()
 	defer a.store.RUnlock()
 	if _, exists := a.store.m[pubKey]; !exists {

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -20,12 +20,14 @@ var log = logrus.WithField("prefix", "beacondb")
 // For example, instead of defining get, put, remove
 // This defines methods such as getBlock, saveBlocksAndAttestations, etc.
 type BeaconDB struct {
-	stateLock       sync.RWMutex
-	currentState    *pb.BeaconState
-	serializedState []byte
-	stateHash       [32]byte
-	db              *bolt.DB
-	DatabasePath    string
+	// state objects and caches
+	stateLock         sync.RWMutex
+	serializedState   []byte
+	stateHash         [32]byte
+	validatorRegistry []*pb.Validator
+	validatorBalances []uint64
+	db                *bolt.DB
+	DatabasePath      string
 
 	// Beacon block info in memory.
 	highestBlockSlot uint64

--- a/beacon-chain/db/state.go
+++ b/beacon-chain/db/state.go
@@ -105,7 +105,9 @@ func (db *BeaconDB) HeadState(ctx context.Context) (*pb.BeaconState, error) {
 		defer span.End()
 		newState := &pb.BeaconState{}
 		// For each READ we unmarshal the serialized state into a new state struct and return that.
-		proto.Unmarshal(db.serializedState, newState)
+		if err := proto.Unmarshal(db.serializedState, newState); err != nil {
+			return nil, err
+		}
 		return newState, nil
 	}
 

--- a/beacon-chain/db/state.go
+++ b/beacon-chain/db/state.go
@@ -356,7 +356,7 @@ func (db *BeaconDB) ValidatorRegistry(ctx context.Context) ([]*pb.Validator, err
 	return beaconState.ValidatorRegistry, err
 }
 
-// ValidatorRegistry fetches the current validator registry stored in state.
+// ValidatorFromState fetches the validator with the desired index from the cached registry.
 func (db *BeaconDB) ValidatorFromState(ctx context.Context, index uint64) (*pb.Validator, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.ValidatorFromState")
 	defer span.End()

--- a/beacon-chain/db/state_test.go
+++ b/beacon-chain/db/state_test.go
@@ -138,7 +138,10 @@ func BenchmarkState_ReadingFromCache(b *testing.B) {
 		b.Fatalf("Could not save beacon state to cache from DB: %v", err)
 	}
 
-	if db.currentState.Slot != params.BeaconConfig().GenesisSlot+1 {
+	savedState := &pb.BeaconState{}
+	savedState.Unmarshal(db.serializedState)
+
+	if savedState.Slot != params.BeaconConfig().GenesisSlot+1 {
 		b.Fatal("cache should be prepared on state after saving to DB")
 	}
 


### PR DESCRIPTION
Our current pattern of reading and writing state, led to nodes not ever being able to sync with the cluster. This was because the cached state didn't handle concurrent operations utilizing it well. What would be regarded as 'corrupted' when used by one function would be regarded as the canonical one when used by another function, since they were both referring to the same state.

- [x] This PR changes that by storing a serialized copy instead in the db, and unmarshaling that to get the state.
- [x] Instead of cloning the whole validator registry everytime, we can just retrieve the desired validator.