### PR TITLE
Optimize block fetch with attestation target fetch

### DIFF
--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -126,18 +126,11 @@ func (a *Service) LatestAttestationTarget(ctx context.Context, index uint64) (*p
 		return nil, nil
 	}
 	targetRoot := bytesutil.ToBytes32(attestation.Data.BeaconBlockRootHash32)
-	targetBlock, err := a.beaconDB.Block(targetRoot)
-	if err != nil {
-		return nil, fmt.Errorf("could not get target block: %v", err)
-	}
-	if targetBlock == nil {
+	if !a.beaconDB.HasBlock(targetRoot) {
 		return nil, nil
 	}
-	return &pb.AttestationTarget{
-		Slot:       targetBlock.Slot,
-		BlockRoot:  targetRoot[:],
-		ParentRoot: targetBlock.ParentRootHash32,
-	}, nil
+
+	return a.beaconDB.AttestationTarget(targetRoot)
 }
 
 // attestationPool takes an newly received attestation from sync service

--- a/beacon-chain/attestation/service_test.go
+++ b/beacon-chain/attestation/service_test.go
@@ -235,6 +235,13 @@ func TestLatestAttestationTarget_ReturnsLatestAttestedBlock(t *testing.T) {
 	if err != nil {
 		log.Fatalf("could not hash block: %v", err)
 	}
+	if err := beaconDB.SaveAttestationTarget(ctx, &pb.AttestationTarget{
+		Slot:       block.Slot,
+		BlockRoot:  blockRoot[:],
+		ParentRoot: []byte{},
+	}); err != nil {
+		log.Fatalf("could not save att target: %v", err)
+	}
 
 	service := NewAttestationService(context.Background(), &Config{BeaconDB: beaconDB})
 
@@ -249,6 +256,7 @@ func TestLatestAttestationTarget_ReturnsLatestAttestedBlock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not get latest attestation: %v", err)
 	}
+
 	if !bytes.Equal(blockRoot[:], latestAttestedTarget.BlockRoot) {
 		t.Errorf("Wanted: %v, got: %v", blockRoot[:], latestAttestedTarget.BlockRoot)
 	}

--- a/beacon-chain/blockchain/block_processing.go
+++ b/beacon-chain/blockchain/block_processing.go
@@ -215,6 +215,13 @@ func (c *ChainService) SaveAndBroadcastBlock(ctx context.Context, block *pb.Beac
 	if err := c.beaconDB.SaveBlock(block); err != nil {
 		return fmt.Errorf("failed to save block: %v", err)
 	}
+	if err := c.beaconDB.SaveAttestationTarget(ctx, &pb.AttestationTarget{
+		Slot:       block.Slot,
+		BlockRoot:  blockRoot[:],
+		ParentRoot: block.ParentRootHash32,
+	}); err != nil {
+		return fmt.Errorf("failed to save attestation target: %v", err)
+	}
 	// Announce the new block to the network.
 	c.p2p.Broadcast(ctx, &pb.BeaconBlockAnnounce{
 		Hash:       blockRoot[:],

--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -240,6 +240,13 @@ func TestAttestationTargets_RetrieveWorks(t *testing.T) {
 	if err != nil {
 		log.Fatalf("could not hash block: %v", err)
 	}
+	if err := beaconDB.SaveAttestationTarget(ctx, &pb.AttestationTarget{
+		Slot:       block.Slot,
+		BlockRoot:  blockRoot[:],
+		ParentRoot: []byte{},
+	}); err != nil {
+		log.Fatalf("could not save att tgt: %v", err)
+	}
 
 	attsService := attestation.NewAttestationService(
 		context.Background(),

--- a/beacon-chain/db/attestation.go
+++ b/beacon-chain/db/attestation.go
@@ -106,7 +106,7 @@ func (db *BeaconDB) Attestations() ([]*pb.Attestation, error) {
 func (db *BeaconDB) AttestationTarget(hash [32]byte) (*pb.AttestationTarget, error) {
 	var attTgt *pb.AttestationTarget
 	err := db.view(func(tx *bolt.Tx) error {
-		a := tx.Bucket(attestationBucket)
+		a := tx.Bucket(attestationTargetBucket)
 
 		enc := a.Get(hash[:])
 		if enc == nil {

--- a/beacon-chain/db/attestation.go
+++ b/beacon-chain/db/attestation.go
@@ -16,16 +16,33 @@ func (db *BeaconDB) SaveAttestation(ctx context.Context, attestation *pb.Attesta
 	ctx, span := trace.StartSpan(ctx, "beaconDB.SaveAttestation")
 	defer span.End()
 
-	encodedState, err := proto.Marshal(attestation)
+	encodedAtt, err := proto.Marshal(attestation)
 	if err != nil {
 		return err
 	}
-	hash := hashutil.Hash(encodedState)
+	hash := hashutil.Hash(encodedAtt)
 
 	return db.update(func(tx *bolt.Tx) error {
 		a := tx.Bucket(attestationBucket)
 
-		return a.Put(hash[:], encodedState)
+		return a.Put(hash[:], encodedAtt)
+	})
+}
+
+// SaveAttestationTarget puts the attestation target record into the beacon chain db.
+func (db *BeaconDB) SaveAttestationTarget(ctx context.Context, attTarget *pb.AttestationTarget) error {
+	ctx, span := trace.StartSpan(ctx, "beaconDB.SaveAttestationTarget")
+	defer span.End()
+
+	encodedAttTgt, err := proto.Marshal(attTarget)
+	if err != nil {
+		return err
+	}
+
+	return db.update(func(tx *bolt.Tx) error {
+		a := tx.Bucket(attestationTargetBucket)
+
+		return a.Put(attTarget.BlockRoot, encodedAttTgt)
 	})
 }
 
@@ -85,6 +102,25 @@ func (db *BeaconDB) Attestations() ([]*pb.Attestation, error) {
 	return attestations, err
 }
 
+// AttestationTarget retrieves an attestation target record from the db using its hash.
+func (db *BeaconDB) AttestationTarget(hash [32]byte) (*pb.AttestationTarget, error) {
+	var attTgt *pb.AttestationTarget
+	err := db.view(func(tx *bolt.Tx) error {
+		a := tx.Bucket(attestationBucket)
+
+		enc := a.Get(hash[:])
+		if enc == nil {
+			return nil
+		}
+
+		var err error
+		attTgt, err = createAttestationTarget(enc)
+		return err
+	})
+
+	return attTgt, err
+}
+
 // HasAttestation checks if the attestation exists.
 func (db *BeaconDB) HasAttestation(hash [32]byte) bool {
 	exists := false
@@ -104,4 +140,12 @@ func createAttestation(enc []byte) (*pb.Attestation, error) {
 		return nil, fmt.Errorf("failed to unmarshal encoding: %v", err)
 	}
 	return protoAttestation, nil
+}
+
+func createAttestationTarget(enc []byte) (*pb.AttestationTarget, error) {
+	protoAttTgt := &pb.AttestationTarget{}
+	if err := proto.Unmarshal(enc, protoAttTgt); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal encoding: %v", err)
+	}
+	return protoAttTgt, nil
 }

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -85,8 +85,8 @@ func NewDB(dirPath string) (*BeaconDB, error) {
 	db := &BeaconDB{db: boltDB, DatabasePath: dirPath}
 
 	if err := db.update(func(tx *bolt.Tx) error {
-		return createBuckets(tx, blockBucket, attestationBucket, mainChainBucket, histStateBucket,
-			chainInfoBucket, cleanupHistoryBucket, blockOperationsBucket, validatorBucket)
+		return createBuckets(tx, blockBucket, attestationBucket, attestationTargetBucket, mainChainBucket,
+			histStateBucket, chainInfoBucket, cleanupHistoryBucket, blockOperationsBucket, validatorBucket)
 	}); err != nil {
 		return nil, err
 	}

--- a/beacon-chain/db/schema.go
+++ b/beacon-chain/db/schema.go
@@ -15,13 +15,14 @@ import (
 
 // The fields below define the suffix of keys in the db.
 var (
-	attestationBucket     = []byte("attestation-bucket")
-	blockOperationsBucket = []byte("block-operations-bucket")
-	blockBucket           = []byte("block-bucket")
-	mainChainBucket       = []byte("main-chain-bucket")
-	histStateBucket       = []byte("historical-state-bucket")
-	chainInfoBucket       = []byte("chain-info")
-	validatorBucket       = []byte("validator")
+	attestationBucket       = []byte("attestation-bucket")
+	attestationTargetBucket = []byte("attestation-target-bucket")
+	blockOperationsBucket   = []byte("block-operations-bucket")
+	blockBucket             = []byte("block-bucket")
+	mainChainBucket         = []byte("main-chain-bucket")
+	histStateBucket         = []byte("historical-state-bucket")
+	chainInfoBucket         = []byte("chain-info")
+	validatorBucket         = []byte("validator")
 
 	mainChainHeightKey      = []byte("chain-height")
 	stateLookupKey          = []byte("state")

--- a/beacon-chain/sync/initial-sync/sync_blocks.go
+++ b/beacon-chain/sync/initial-sync/sync_blocks.go
@@ -165,6 +165,13 @@ func (s *InitialSync) validateAndSaveNextBlock(ctx context.Context, block *pb.Be
 	if err := s.db.SaveBlock(block); err != nil {
 		return err
 	}
+	if err := s.db.SaveAttestationTarget(ctx, &pb.AttestationTarget{
+		Slot:       block.Slot,
+		BlockRoot:  root[:],
+		ParentRoot: block.ParentRootHash32,
+	}); err != nil {
+		return fmt.Errorf("could not to save attestation target: %v", err)
+	}
 	state, err = s.chainService.ApplyBlockStateTransition(ctx, block, state)
 	if err != nil {
 		return fmt.Errorf("could not apply block state transition: %v", err)

--- a/beacon-chain/sync/initial-sync/sync_state.go
+++ b/beacon-chain/sync/initial-sync/sync_state.go
@@ -3,6 +3,8 @@ package initialsync
 import (
 	"context"
 
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -35,6 +37,20 @@ func (s *InitialSync) processState(msg p2p.Message) {
 
 	if err := s.db.SaveBlock(finalizedState.LatestBlock); err != nil {
 		log.Errorf("Could not save block %v", err)
+		return
+	}
+
+	root, err := hashutil.HashBeaconBlock(finalizedState.LatestBlock)
+	if err != nil {
+		log.Errorf("Could not hash finalized block %v", err)
+		return
+	}
+	if err := s.db.SaveAttestationTarget(ctx, &pb.AttestationTarget{
+		Slot:       finalizedState.LatestBlock.Slot,
+		BlockRoot:  root[:],
+		ParentRoot: finalizedState.LatestBlock.ParentRootHash32,
+	}); err != nil {
+		log.Errorf("Could not to save attestation target: %v", err)
 		return
 	}
 

--- a/shared/ssz/hash_cache.go
+++ b/shared/ssz/hash_cache.go
@@ -84,7 +84,7 @@ func (b *hashCacheS) TrieRootCached(val interface{}) ([32]byte, error) {
 	rval := reflect.ValueOf(val)
 	hs, err := hashedEncoding(rval)
 	if err != nil {
-		return [32]byte{}, newHashError(error.Error(err), rval.Type())
+		return [32]byte{}, newHashError(fmt.Sprint(err), rval.Type())
 	}
 	exists, fetchedInfo, err := b.RootByEncodedHash(bytesutil.ToBytes32(hs))
 	if err != nil {


### PR DESCRIPTION
Instead of using block fetch in retrieving latest attestation target, we use attestation target fetch. This is an improvement because it's a smaller data structure comparing to unmarshaling blocks with great #s of attestations. (versus something small that's just `pb.AttestationTarget{BlockRoot: blockRoot, ParentRoot: block.ParentRootHash32, Slot: block.Slot}`) 

Changed:
- when we save a block we also save attestation target to its own bucket using block root as key
- fetch for attestation target instead of block in `LatestAttestationTarget`