### PR TITLE
Handle Panics In Attestation and Disable Logging

### DIFF
--- a/beacon-chain/attestation/BUILD.bazel
+++ b/beacon-chain/attestation/BUILD.bazel
@@ -38,6 +38,8 @@ go_test(
         "//shared/bytesutil:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/testutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
 )

--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -3,7 +3,6 @@ package attestation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -290,8 +289,13 @@ func (a *Service) updateAttestation(ctx context.Context, headRoot [32]byte, beac
 			continue
 		}
 
+		if i >= len(committee) {
+			log.Errorf("Bitfield points to an invalid index in the committee: bitfield %08b", bitfield)
+			continue
+		}
+
 		if int(committee[i]) >= len(beaconState.ValidatorRegistry) {
-			return errors.New("index doesn't exist in validator registry")
+			log.Errorf("Index doesn't exist in validator registry: index %d", committee[i])
 		}
 
 		// If the attestation came from this attester. We use the slot committee to find the

--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -3,6 +3,7 @@ package attestation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -287,6 +288,10 @@ func (a *Service) updateAttestation(ctx context.Context, headRoot [32]byte, beac
 		}
 		if !bitSet {
 			continue
+		}
+
+		if int(committee[i]) >= len(beaconState.ValidatorRegistry) {
+			return errors.New("index doesn't exist in validator registry")
 		}
 
 		// If the attestation came from this attester. We use the slot committee to find the

--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -95,17 +95,12 @@ func (a *Service) IncomingAttestationFeed() *event.Feed {
 //		Attestation` be the attestation with the highest slot number in `store`
 //		from the validator with the given `validator_index`
 func (a *Service) LatestAttestation(ctx context.Context, index uint64) (*pb.Attestation, error) {
-	bState, err := a.beaconDB.HeadState(ctx)
+	validator, err := a.beaconDB.ValidatorFromState(ctx, index)
 	if err != nil {
 		return nil, err
 	}
 
-	// return error if it's an invalid validator index.
-	if index >= uint64(len(bState.ValidatorRegistry)) {
-		return nil, fmt.Errorf("invalid validator index %d", index)
-	}
-
-	pubKey := bytesutil.ToBytes48(bState.ValidatorRegistry[index].Pubkey)
+	pubKey := bytesutil.ToBytes48(validator.Pubkey)
 	a.store.RLock()
 	defer a.store.RUnlock()
 	if _, exists := a.store.m[pubKey]; !exists {

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -376,7 +376,9 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, block *pb.BeaconBl
 		}
 
 	case epochsSinceFinality > 4:
-		log.WithField("epochSinceFinality", epochsSinceFinality).Info("Applying quadratic leak penalties")
+		if config.Logging {
+			log.WithField("epochSinceFinality", epochsSinceFinality).Info("Applying quadratic leak penalties")
+		}
 		// Apply penalties for long inactive FFG source participants.
 		state = bal.InactivityFFGSource(
 			state,


### PR DESCRIPTION
- [x] Reverts #2372
- [x] Handle invalid indexes in `updateAttestation`
- [x] Don't log quadratic leak log when performing state transitions in unimportant
state transitions
