### PR TITLE
Update Jaeger Export Tracing

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -633,9 +633,11 @@ go_repository(
  )
 
 go_repository(
-    name = "io_opencensus_go_contrib",
-    commit = "5b8293c22f362562285c2acbc52f4a1870a47a33",  # v0.21.0
-    importpath = "contrib.go.opencensus.io",
+    name = "io_opencensus_go_contrib_exporter_jaeger",
+    commit = "5b8293c22f362562285c2acbc52f4a1870a47a33",
+    importpath = "contrib.go.opencensus.io/exporter/jaeger",
+    remote = "http://github.com/census-ecosystem/opencensus-go-exporter-jaeger",
+    vcs = "git",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -627,9 +627,15 @@ go_repository(
 )
 
 go_repository(
-    name = "io_opencensus_go",
-    commit = "bd64e5eff7498c1c67eba74dc87ad96aa525bf28",  # v0.20.2
-    importpath = "go.opencensus.io",
+     name = "io_opencensus_go",
+     commit = "bd64e5eff7498c1c67eba74dc87ad96aa525bf28",  # v0.20.2
+     importpath = "go.opencensus.io",
+ )
+
+go_repository(
+    name = "io_opencensus_go_contrib",
+    commit = "5b8293c22f362562285c2acbc52f4a1870a47a33",  # v0.21.0
+    importpath = "contrib.go.opencensus.io",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -627,10 +627,10 @@ go_repository(
 )
 
 go_repository(
-     name = "io_opencensus_go",
-     commit = "bd64e5eff7498c1c67eba74dc87ad96aa525bf28",  # v0.20.2
-     importpath = "go.opencensus.io",
- )
+    name = "io_opencensus_go",
+    commit = "bd64e5eff7498c1c67eba74dc87ad96aa525bf28",  # v0.20.2
+    importpath = "go.opencensus.io",
+)
 
 go_repository(
     name = "io_opencensus_go_contrib_exporter_jaeger",

--- a/shared/tracing/BUILD.bazel
+++ b/shared/tracing/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_opencensus_go//exporter/jaeger:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
+        "@io_opencensus_go_contrib//exporter/jaeger:go_default_library",
     ],
 )

--- a/shared/tracing/BUILD.bazel
+++ b/shared/tracing/BUILD.bazel
@@ -8,6 +8,6 @@ go_library(
     deps = [
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
-        "@io_opencensus_go_contrib//exporter/jaeger:go_default_library",
+        "@io_opencensus_go_contrib_exporter_jaeger//:go_default_library",
     ],
 )

--- a/shared/tracing/tracer.go
+++ b/shared/tracing/tracer.go
@@ -3,8 +3,8 @@ package tracing
 import (
 	"errors"
 
-	"github.com/sirupsen/logrus"
 	"contrib.go.opencensus.io/exporter/jaeger"
+	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
 

--- a/shared/tracing/tracer.go
+++ b/shared/tracing/tracer.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/sirupsen/logrus"
-	"go.opencensus.io/exporter/jaeger"
+	"contrib.go.opencensus.io/exporter/jaeger"
 	"go.opencensus.io/trace"
 )
 


### PR DESCRIPTION
No tracking issue - this simply updates the go.opencensus.io package based on tag https://github.com/census-instrumentation/opencensus-go/releases/tag/v0.21.0