### PR TITLE
RPC Validator Index Lookup Failover

### DIFF
--- a/beacon-chain/db/validator_test.go
+++ b/beacon-chain/db/validator_test.go
@@ -1,11 +1,13 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/boltdb/bolt"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
 
@@ -47,11 +49,14 @@ func TestSaveAndDeleteValidatorIndex_OK(t *testing.T) {
 	p1 := []byte{'1', '2', '3'}
 
 	if err := db.SaveValidatorIndex(p1, 3); err != nil {
-		t.Fatalf("Failed to save vallidator index: %v", err)
+		t.Fatalf("Failed to save validator index: %v", err)
+	}
+	if err := db.SaveState(context.Background(), &pb.BeaconState{}); err != nil {
+		t.Fatalf("Failed to save state: %v", err)
 	}
 	index, err := db.ValidatorIndex(p1)
 	if err != nil {
-		t.Fatalf("Failed to call Attestation: %v", err)
+		t.Fatalf("Failed to call validator Index: %v", err)
 	}
 	if index != 3 {
 		t.Fatalf("Saved index and retrieved index are not equal: %#x and %#x", 3, index)

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -288,9 +288,9 @@ func (vs *ValidatorServer) addNonActivePublicKeysAssignmentStatus(beaconState *p
 	return assignments
 }
 
-// valIdxLookup is a wrapper to RPC server for looking up validator index using public key.
-// If the validator index is not in the DB, as a fail over it searches in the state then
-// saves it to the DB when found. It returns an error if index is not found in both DB and state.
+// valIdxLookup is a wrapper for RPC server for looking up validator index using public key.
+// If the validator index is not found in DB, as a fail over, it searches the state and
+// saves it to the DB when found. Returns an error if index is not found in both DB and state.
 func (vs *ValidatorServer) valIdxLookup(ctx context.Context, pubkey []byte) (uint64, error) {
 	idx, err := vs.beaconDB.ValidatorIndex(pubkey)
 	if err != nil {

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -299,6 +299,8 @@ func (vs *ValidatorServer) valIdxLookup(ctx context.Context, pubkey []byte) (uin
 			if err != nil {
 				return 0, fmt.Errorf("could not fetch beacon state: %v", err)
 			}
+
+			// Checking if validator exists in state. Returns and saves index in DB when found.
 			for i := 0; i < len(beaconState.ValidatorRegistry); i++ {
 				v := beaconState.ValidatorRegistry[i]
 				if bytes.Equal(v.Pubkey, pubkey) {

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -1,10 +1,12 @@
 package rpc
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
@@ -64,12 +66,12 @@ func (vs *ValidatorServer) WaitForActivation(req *pb.ValidatorActivationRequest,
 // ValidatorIndex is called by a validator to get its index location that corresponds
 // to the attestation bit fields.
 func (vs *ValidatorServer) ValidatorIndex(ctx context.Context, req *pb.ValidatorIndexRequest) (*pb.ValidatorIndexResponse, error) {
-	index, err := vs.beaconDB.ValidatorIndex(req.PublicKey)
+	idx, err := vs.valIdxLookup(ctx, req.PublicKey)
 	if err != nil {
-		return nil, fmt.Errorf("could not get validator index: %v", err)
+		return nil, err
 	}
 
-	return &pb.ValidatorIndexResponse{Index: uint64(index)}, nil
+	return &pb.ValidatorIndexResponse{Index: uint64(idx)}, nil
 }
 
 // ValidatorPerformance reports the validator's latest balance along with other important metrics on
@@ -77,9 +79,9 @@ func (vs *ValidatorServer) ValidatorIndex(ctx context.Context, req *pb.Validator
 func (vs *ValidatorServer) ValidatorPerformance(
 	ctx context.Context, req *pb.ValidatorPerformanceRequest,
 ) (*pb.ValidatorPerformanceResponse, error) {
-	index, err := vs.beaconDB.ValidatorIndex(req.PublicKey)
+	idx, err := vs.valIdxLookup(ctx, req.PublicKey)
 	if err != nil {
-		return nil, fmt.Errorf("could not get validator index: %v", err)
+		return nil, err
 	}
 	validatorRegistry, err := vs.beaconDB.ValidatorRegistry(ctx)
 	if err != nil {
@@ -94,7 +96,7 @@ func (vs *ValidatorServer) ValidatorPerformance(
 		totalBalance += float32(val)
 	}
 	avgBalance := totalBalance / float32(len(validatorBalances))
-	balance := validatorBalances[index]
+	balance := validatorBalances[idx]
 	activeIndices := helpers.ActiveValidatorIndices(validatorRegistry, helpers.SlotToEpoch(req.Slot))
 	return &pb.ValidatorPerformanceResponse{
 		Balance:                 balance,
@@ -164,9 +166,9 @@ func (vs *ValidatorServer) assignment(
 		)
 	}
 
-	idx, err := vs.beaconDB.ValidatorIndex(pubkey)
+	idx, err := vs.valIdxLookup(context.Background(), pubkey)
 	if err != nil {
-		return nil, fmt.Errorf("could not get active validator index: %v", err)
+		return nil, err
 	}
 
 	committee, shard, slot, isProposer, err :=
@@ -216,9 +218,9 @@ func (vs *ValidatorServer) ValidatorStatus(
 }
 
 func (vs *ValidatorServer) validatorStatus(pubkey []byte, beaconState *pbp2p.BeaconState) (pb.ValidatorStatus, error) {
-	idx, err := vs.beaconDB.ValidatorIndex(pubkey)
+	idx, err := vs.valIdxLookup(context.Background(), pubkey)
 	if err != nil {
-		return pb.ValidatorStatus_UNKNOWN_STATUS, fmt.Errorf("could not get active validator index: %v", err)
+		return pb.ValidatorStatus_UNKNOWN_STATUS, err
 	}
 
 	var status pb.ValidatorStatus
@@ -284,4 +286,30 @@ func (vs *ValidatorServer) addNonActivePublicKeysAssignmentStatus(beaconState *p
 		}
 	}
 	return assignments
+}
+
+// valIdxLookup is a wrapper to RPC server for looking up validator index using public key.
+// If the validator index is not in the DB, as a fail over it searches in the state then
+// saves it to the DB when found. It returns an error if index is not found in both DB and state.
+func (vs *ValidatorServer) valIdxLookup(ctx context.Context, pubkey []byte) (uint64, error) {
+	idx, err := vs.beaconDB.ValidatorIndex(pubkey)
+	if err != nil {
+		if strings.Contains(err.Error(), fmt.Sprintf("validator %#x does not exist", pubkey)) {
+			beaconState, err := vs.beaconDB.HeadState(ctx)
+			if err != nil {
+				return 0, fmt.Errorf("could not fetch beacon state: %v", err)
+			}
+			for i := 0; i < len(beaconState.ValidatorRegistry); i++ {
+				v := beaconState.ValidatorRegistry[i]
+				if bytes.Equal(v.Pubkey, pubkey) {
+					if err := vs.beaconDB.SaveValidatorIndex(pubkey, i); err != nil {
+						return 0, fmt.Errorf("could not save validator idx in DB: %v", err)
+					}
+					return uint64(i), nil
+				}
+			}
+		}
+		return 0, err
+	}
+	return idx, nil
 }

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -96,14 +96,14 @@ func TestValidatorIndex_InStateNotInDB(t *testing.T) {
 		t.Errorf("Wanted index 1 got %d", res.Index)
 	}
 
-	//// Verify index is also saved in DB.
-	//idx, err := validatorServer.beaconDB.ValidatorIndex(pubKey)
-	//if err != nil {
-	//	t.Fatal(err)
-	//}
-	//if idx != 1 {
-	//	t.Errorf("Wanted index 1 in DB got %d", res.Index)
-	//}
+	// Verify index is also saved in DB.
+	idx, err := validatorServer.beaconDB.ValidatorIndex(pubKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if idx != 1 {
+		t.Errorf("Wanted index 1 in DB got %d", res.Index)
+	}
 }
 
 func TestNextEpochCommitteeAssignment_WrongPubkeyLength(t *testing.T) {

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -96,14 +96,14 @@ func TestValidatorIndex_InStateNotInDB(t *testing.T) {
 		t.Errorf("Wanted index 1 got %d", res.Index)
 	}
 
-	// Verify index is also saved in DB.
-	idx, err := validatorServer.beaconDB.ValidatorIndex(pubKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if idx != 1 {
-		t.Errorf("Wanted index 1 in DB got %d", res.Index)
-	}
+	//// Verify index is also saved in DB.
+	//idx, err := validatorServer.beaconDB.ValidatorIndex(pubKey)
+	//if err != nil {
+	//	t.Fatal(err)
+	//}
+	//if idx != 1 {
+	//	t.Errorf("Wanted index 1 in DB got %d", res.Index)
+	//}
 }
 
 func TestNextEpochCommitteeAssignment_WrongPubkeyLength(t *testing.T) {


### PR DESCRIPTION
This PR implements the following failover, when looking up validator index in DB, If the validator index is not in the DB, as a secondary fail over it will search in the state and then save index to the DB when found in state.

Changed:
- [x] Implemented `ValIdxLookup` wrapper
- [x] Updated current test and add a new test for above