### PR TITLE
Poll for Headers Instead of Using Websockets in Powchain

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -48,7 +48,6 @@ func main() {
 		utils.NoCustomConfigFlag,
 		utils.DepositContractFlag,
 		utils.Web3ProviderFlag,
-		utils.HTTPWeb3ProviderFlag,
 		utils.RPCPort,
 		utils.CertFlag,
 		utils.KeyFlag,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -270,7 +270,7 @@ func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
 		log.Fatalf("Invalid deposit contract address given: %s", depAddress)
 	}
 
-	rpcClient, err := gethRPC.Dial(cliCtx.GlobalString(utils.HTTPWeb3ProviderFlag.Name))
+	rpcClient, err := gethRPC.Dial(cliCtx.GlobalString(utils.Web3ProviderFlag.Name))
 	if err != nil {
 		log.Fatalf("Access to PoW chain is required for validator. Unable to connect to Geth node: %v", err)
 	}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -270,17 +270,11 @@ func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
 		log.Fatalf("Invalid deposit contract address given: %s", depAddress)
 	}
 
-	rpcClient, err := gethRPC.Dial(cliCtx.GlobalString(utils.Web3ProviderFlag.Name))
+	rpcClient, err := gethRPC.Dial(cliCtx.GlobalString(utils.HTTPWeb3ProviderFlag.Name))
 	if err != nil {
 		log.Fatalf("Access to PoW chain is required for validator. Unable to connect to Geth node: %v", err)
 	}
 	powClient := ethclient.NewClient(rpcClient)
-
-	logRPCClient, err := gethRPC.Dial(cliCtx.GlobalString(utils.HTTPWeb3ProviderFlag.Name))
-	if err != nil {
-		log.Fatalf("Access to PoW chain is required for validator. Unable to connect to Geth node: %v", err)
-	}
-	pastLogHTTPClient := ethclient.NewClient(logRPCClient)
 
 	ctx := context.Background()
 	cfg := &powchain.Web3ServiceConfig{
@@ -289,7 +283,6 @@ func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
 		Client:          powClient,
 		Reader:          powClient,
 		Logger:          powClient,
-		HTTPLogger:      pastLogHTTPClient,
 		BlockFetcher:    powClient,
 		ContractBackend: powClient,
 		BeaconDB:        b.db,

--- a/beacon-chain/powchain/block_reader_test.go
+++ b/beacon-chain/powchain/block_reader_test.go
@@ -40,21 +40,13 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 	}
 	testAcc.backend.Commit()
 
-	exitRoutine := make(chan bool)
-
-	go func() {
-		web3Service.run(web3Service.ctx.Done())
-		<-exitRoutine
-	}()
+	web3Service.blockHeight = big.NewInt(0)
 
 	header := &gethTypes.Header{
 		Number: big.NewInt(42),
 		Time:   308534400,
 	}
-
-	web3Service.headerChan <- header
-	web3Service.cancel()
-	exitRoutine <- true
+	web3Service.processHeader(header)
 
 	if web3Service.blockHeight.Cmp(header.Number) != 0 {
 		t.Errorf("block number not set, expected %v, got %v", header.Number, web3Service.blockHeight)

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -164,7 +164,7 @@ func (w *Web3Service) processPastLogs() error {
 		},
 	}
 
-	logs, err := w.httpLogger.FilterLogs(w.ctx, query)
+	logs, err := w.logger.FilterLogs(w.ctx, query)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -325,7 +325,7 @@ func (w *Web3Service) run(done <-chan struct{}) {
 
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()
-	headRequestTicker := time.NewTicker(3*time.Second)
+	headRequestTicker := time.NewTicker(3 * time.Second)
 	defer headRequestTicker.Stop()
 
 	for {

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -290,37 +290,6 @@ func TestInitDataFromContract_OK(t *testing.T) {
 	}
 }
 
-func TestWeb3Service_BadReader(t *testing.T) {
-	hook := logTest.NewGlobal()
-
-	testAcc, err := setup()
-	if err != nil {
-		t.Fatalf("Unable to set up simulated backend %v", err)
-	}
-	web3Service, err := NewWeb3Service(context.Background(), &Web3ServiceConfig{
-		Endpoint:        endpoint,
-		DepositContract: testAcc.contractAddr,
-		Reader:          &badReader{},
-		Logger:          &goodLogger{},
-		HTTPLogger:      &goodLogger{},
-		ContractBackend: testAcc.backend,
-	})
-	if err != nil {
-		t.Fatalf("unable to setup web3 ETH1.0 chain service: %v", err)
-	}
-
-	testAcc.backend.Commit()
-	web3Service.reader = &badReader{}
-	web3Service.logger = &goodLogger{}
-	web3Service.run(web3Service.ctx.Done())
-	msg := hook.LastEntry().Message
-	want := "Unable to subscribe to incoming ETH1.0 chain headers: subscription has failed"
-	if msg != want {
-		t.Errorf("incorrect log, expected %s, got %s", want, msg)
-	}
-	hook.Reset()
-}
-
 func TestStatus(t *testing.T) {
 	now := time.Now()
 
@@ -364,6 +333,6 @@ func TestHandlePanic_OK(t *testing.T) {
 		t.Fatalf("unable to setup web3 ETH1.0 chain service: %v", err)
 	}
 
-	web3Service.processSubscribedHeaders(nil)
+	web3Service.processHeader(nil)
 	testutil.AssertLogsContain(t, hook, "Panicked when handling data from ETH 1.0 Chain!")
 }

--- a/beacon-chain/utils/flags.go
+++ b/beacon-chain/utils/flags.go
@@ -10,17 +10,11 @@ var (
 		Name:  "no-custom-config",
 		Usage: "Run the beacon chain with the real parameters from phase 0.",
 	}
-	// HTTPWeb3ProviderFlag provides an HTTP access endpoint to an ETH 1.0 RPC.
-	HTTPWeb3ProviderFlag = cli.StringFlag{
-		Name:  "http-web3provider",
-		Usage: "A mainchain web3 provider string http endpoint",
-		Value: "https://goerli.prylabs.net",
-	}
 	// Web3ProviderFlag defines a flag for a mainchain RPC endpoint.
 	Web3ProviderFlag = cli.StringFlag{
 		Name:  "web3provider",
-		Usage: "A mainchain web3 provider string endpoint. Can either be an IPC file string or a WebSocket endpoint. Cannot be an HTTP endpoint.",
-		Value: "wss://goerli.prylabs.net/websocket",
+		Usage: "A mainchain web3 provider string http endpoint.",
+		Value: "https://goerli.prylabs.net",
 	}
 	// DepositContractFlag defines a flag for the deposit contract address.
 	DepositContractFlag = cli.StringFlag{

--- a/k8s/beacon-chain/beacon-chain.deploy.yaml
+++ b/k8s/beacon-chain/beacon-chain.deploy.yaml
@@ -43,8 +43,7 @@ spec:
         - name: beacon-chain
           image: gcr.io/prysmaticlabs/prysm/beacon-chain:latest
           args: 
-            - --web3provider=wss://goerli.infura.io/ws/v3/be3fb7ed377c418087602876a40affa1
-            - --http-web3provider=https://goerli.infura.io/v3/be3fb7ed377c418087602876a40affa1
+            - --web3provider=https://goerli.infura.io/v3/be3fb7ed377c418087602876a40affa1
             #- --verbosity=debug
             - --deposit-contract=$(DEPOSIT_CONTRACT_ADDRESS)
             - --rpc-port=4000


### PR DESCRIPTION
Resolves #2401 

---

# Description

**Write why you are making the changes in this pull request**

Currently, websockets from geth are unstable and lead to many errors or frame payload exceeded in our runtime. This causes forked blocks as perhaps 1 node is not able to process a block while the others can. HTTP is more stable and we can replace our subscription to wss by an http connection.

