### PR TITLE
Use Network, not Peerstore for peer logging

### DIFF
--- a/shared/p2p/discovery.go
+++ b/shared/p2p/discovery.go
@@ -73,6 +73,6 @@ func (d *discovery) HandlePeerFound(pi ps.PeerInfo) {
 	}
 
 	log.WithFields(logrus.Fields{
-		"peers": d.host.Peerstore().Peers(),
+		"peers": d.host.Network().Peers(),
 	}).Debug("Peers are now")
 }


### PR DESCRIPTION
The API is not intuitive, but we should be using `Network()` for listing the current peers. 