### PR TITLE
Use HTTP for On Demand Block Requests

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -263,11 +263,11 @@ func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
 	}
 	powClient := ethclient.NewClient(rpcClient)
 
-	logRPCClient, err := gethRPC.Dial(cliCtx.GlobalString(utils.HTTPWeb3ProviderFlag.Name))
+	httpRPCClient, err := gethRPC.Dial(cliCtx.GlobalString(utils.HTTPWeb3ProviderFlag.Name))
 	if err != nil {
 		log.Fatalf("Access to PoW chain is required for validator. Unable to connect to Geth node: %v", err)
 	}
-	pastLogHTTPClient := ethclient.NewClient(logRPCClient)
+	httpClient := ethclient.NewClient(httpRPCClient)
 
 	ctx := context.Background()
 	cfg := &powchain.Web3ServiceConfig{
@@ -276,8 +276,8 @@ func (b *BeaconNode) registerPOWChainService(cliCtx *cli.Context) error {
 		Client:          powClient,
 		Reader:          powClient,
 		Logger:          powClient,
-		HTTPLogger:      pastLogHTTPClient,
-		BlockFetcher:    powClient,
+		HTTPLogger:      httpClient,
+		BlockFetcher:    httpClient,
 		ContractBackend: powClient,
 		BeaconDB:        b.db,
 	}

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -198,7 +198,7 @@ func (w *Web3Service) requestBatchedLogs() error {
 		FromBlock: w.lastRequestedBlock.Add(w.lastRequestedBlock, big.NewInt(1)),
 		ToBlock:   requestedBlock,
 	}
-	logs, err := w.logger.FilterLogs(w.ctx, query)
+	logs, err := w.httpLogger.FilterLogs(w.ctx, query)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolves #2401
----------------

# Description

Currently, websockets from geth are unstable and lead to many errors or frame payload exceeded in our runtime. This causes forked blocks as perhaps 1 node is not able to process a block while the others can. HTTP is more stable and we can replace on demand requests for blocks by hash by http.