### PR TITLE
Add SSL support for prylabs.net, support opengraph on alpha.prylabs.net

### DIFF
--- a/k8s/beacon-chain/testnet-site.yaml
+++ b/k8s/beacon-chain/testnet-site.yaml
@@ -91,4 +91,24 @@ spec:
         port: 
           number: 80
         host: testnet-site-alpha.beacon-chain.svc.cluster.local
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: prylabs-net
+  namespace: istio-system
+spec:
+  hosts:
+  - prylabs.net
+  gateways:
+  - prylabs-wildcard-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /assets
+    route:
+    - destination:
+        port: 
+          number: 80
+        host: testnet-site-alpha.beacon-chain.svc.cluster.local
 

--- a/k8s/letsencrypt-issuer.yaml
+++ b/k8s/letsencrypt-issuer.yaml
@@ -29,10 +29,11 @@ spec:
   issuerRef:
     name: letsencrypt-prod
   commonName: "*.prylabs.net"
+  dnsNames: 
+    - "prylabs.net"
   acme:
     config:
     - dns01:
         provider: cloud-dns
       domains:
-      - "*.prylabs.net"
       - "prylabs.net"

--- a/k8s/prylabs-wildcard-gateway.yaml
+++ b/k8s/prylabs-wildcard-gateway.yaml
@@ -16,6 +16,7 @@ spec:
       protocol: HTTP
     hosts:
     - "*.prylabs.net"
+    - "prylabs.net"
     tls:
       httpsRedirect: false
   - port:
@@ -24,6 +25,7 @@ spec:
       protocol: HTTPS
     hosts:
     - "*.prylabs.net"
+    - "prylabs.net"
     tls:
       mode: SIMPLE
       privateKey: /etc/istio/ingressgateway-certs/tls.key


### PR DESCRIPTION
Two changes here:
- Support SSL certificates for prylabs.net & *.prylabs.net
- Temporarily serve prylabs.net/assets from the alpha binary (needed for social sharing of alpha.prylabs.net)