### PR TITLE
Prevent Validator Exit Re-entance

### DIFF
--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -206,11 +206,10 @@ func InitiateValidatorExit(state *pb.BeaconState, idx uint64) *pb.BeaconState {
 func ExitValidator(state *pb.BeaconState, idx uint64) *pb.BeaconState {
 	validator := state.ValidatorRegistry[idx]
 
-	exitEpoch := entryExitEffectEpoch(helpers.CurrentEpoch(state))
-	if validator.ExitEpoch <= exitEpoch {
+	if validator.ExitEpoch != params.BeaconConfig().FarFutureEpoch {
 		return state
 	}
-	validator.ExitEpoch = exitEpoch
+	validator.ExitEpoch = entryExitEffectEpoch(helpers.CurrentEpoch(state))
 	return state
 }
 

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -430,14 +430,14 @@ func TestExitValidator_OK(t *testing.T) {
 
 func TestExitValidator_AlreadyExited(t *testing.T) {
 	state := &pb.BeaconState{
-		Slot: 1,
+		Slot: params.BeaconConfig().GenesisEpoch + 1000,
 		ValidatorRegistry: []*pb.Validator{
 			{ExitEpoch: params.BeaconConfig().ActivationExitDelay},
 		},
 	}
 	state = ExitValidator(state, 0)
-	if len(state.ValidatorRegistry) != 1 {
-		t.Error("Expected validator to have failed exiting")
+	if state.ValidatorRegistry[0].ExitEpoch != params.BeaconConfig().ActivationExitDelay {
+		t.Error("Expected exited validator to stay exited")
 	}
 }
 


### PR DESCRIPTION
Kudos to @shayzluf for pointing this out!

There's a bug on the old `ExitValidator` spec, where a validator can exit but re-exit again within `entryExitEffectEpoch` period. This prevents the bug by not letting validator exit again if the exit epoch is no longer set `FarFutureEpoch` so the validator can only get exited/slashed/ejected once