### PR TITLE
Update bitfield helpers v0.6

### DIFF
--- a/beacon-chain/attestation/service_test.go
+++ b/beacon-chain/attestation/service_test.go
@@ -55,7 +55,7 @@ func TestUpdateLatestAttestation_UpdatesLatest(t *testing.T) {
 	service := NewAttestationService(context.Background(), &Config{BeaconDB: beaconDB})
 
 	attestation := &pb.Attestation{
-		AggregationBitfield: []byte{0x80},
+		AggregationBitfield: []byte{0x01},
 		Data: &pb.AttestationData{
 			Slot:  params.BeaconConfig().GenesisSlot + 1,
 			Shard: 1,
@@ -239,7 +239,7 @@ func TestUpdateLatestAttestation_CacheEnabledAndMiss(t *testing.T) {
 	service := NewAttestationService(context.Background(), &Config{BeaconDB: beaconDB})
 
 	attestation := &pb.Attestation{
-		AggregationBitfield: []byte{0x80},
+		AggregationBitfield: []byte{0x01},
 		Data: &pb.AttestationData{
 			Slot:  params.BeaconConfig().GenesisSlot + 1,
 			Shard: 1,
@@ -326,7 +326,7 @@ func TestUpdateLatestAttestation_CacheEnabledAndHit(t *testing.T) {
 	shard := uint64(3)
 	index := uint64(4)
 	attestation := &pb.Attestation{
-		AggregationBitfield: []byte{0x80},
+		AggregationBitfield: []byte{0x01},
 		Data: &pb.AttestationData{
 			Slot:  slot,
 			Shard: shard,

--- a/beacon-chain/core/epoch/epoch_operations_test.go
+++ b/beacon-chain/core/epoch/epoch_operations_test.go
@@ -33,7 +33,7 @@ func buildState(slot uint64, validatorCount uint64) *pb.BeaconState {
 func TestWinningRoot_AccurateRoot(t *testing.T) {
 	state := buildState(params.BeaconConfig().GenesisSlot, 100)
 	var participationBitfield []byte
-	participationBitfield = append(participationBitfield, byte(0x80))
+	participationBitfield = append(participationBitfield, byte(0x01))
 
 	// Generate 10 roots ([]byte{100}...[]byte{110})
 	var attestations []*pb.PendingAttestation

--- a/beacon-chain/core/epoch/epoch_operations_test.go
+++ b/beacon-chain/core/epoch/epoch_operations_test.go
@@ -93,7 +93,7 @@ func TestAttestingValidators_MatchActive(t *testing.T) {
 				Slot:                    params.BeaconConfig().GenesisSlot,
 				CrosslinkDataRootHash32: []byte{byte(i + 100)},
 			},
-			AggregationBitfield: []byte{0xC0},
+			AggregationBitfield: []byte{0x03},
 		}
 		attestations = append(attestations, attestation)
 	}
@@ -147,7 +147,7 @@ func TestTotalAttestingBalance_CorrectBalance(t *testing.T) {
 				CrosslinkDataRootHash32: []byte{byte(i + 100)},
 			},
 			// All validators attested to the above roots.
-			AggregationBitfield: []byte{0xC0},
+			AggregationBitfield: []byte{0x03},
 		}
 		attestations = append(attestations, attestation)
 	}

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -346,6 +346,38 @@ func VerifyBitfield(bitfield []byte, committeeSize int) (bool, error) {
 	return true, nil
 }
 
+// VerifyBitfieldNew Verify ``bitfield`` against the ``committee_size``.
+//
+// Spec pseudocode definition:
+//   def verify_bitfield(bitfield: bytes, committee_size: int) -> bool:
+//     """
+//     Verify ``bitfield`` against the ``committee_size``.
+//     """
+//     if len(bitfield) != (committee_size + 7) // 8:
+//         return False
+//     # Check `bitfield` is padded with zero bits only
+//     for i in range(committee_size, len(bitfield) * 8):
+//         if get_bitfield_bit(bitfield, i) == 0b1:
+//             return False
+//     return True
+func VerifyBitfieldNew(bitfield []byte, committeeSize int) (bool, error) {
+	if len(bitfield) != (committeeSize+7)>>3 {
+		return false, fmt.Errorf(
+			"wanted participants bitfield length %d, got: %d",
+			(committeeSize+7)>>3,
+			len(bitfield))
+	}
+
+	for i := committeeSize; i < len(bitfield)<<3; i++ {
+		by := bitutil.BitfieldBit(bitfield, i)
+		if by == 1 {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
 // CommitteeAssignment is used to query committee assignment from
 // current and previous epoch.
 //

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -307,46 +307,7 @@ func AttestationParticipants(
 	return participants, nil
 }
 
-// VerifyBitfield validates a bitfield with a given committee size.
-//
-// Spec pseudocode:
-//
-// def verify_bitfield(bitfield: bytes, committee_size: int) -> bool:
-// """
-// Verify ``bitfield`` against the ``committee_size``.
-// """
-// if len(bitfield) != (committee_size + 7) // 8:
-// return False
-//
-// # Check `bitfield` is padded with zero bits only
-// for i in range(committee_size, len(bitfield) * 8):
-// if get_bitfield_bit(bitfield, i) == 0b1:
-// return False
-//
-// return True
-func VerifyBitfield(bitfield []byte, committeeSize int) (bool, error) {
-	if len(bitfield) != mathutil.CeilDiv8(committeeSize) {
-		return false, fmt.Errorf(
-			"wanted participants bitfield length %d, got: %d",
-			mathutil.CeilDiv8(committeeSize),
-			len(bitfield))
-	}
-
-	for i := committeeSize; i < len(bitfield)*8; i++ {
-		bitSet, err := bitutil.CheckBit(bitfield, i)
-		if err != nil {
-			return false, fmt.Errorf("unable to check bit in bitfield %v", err)
-		}
-
-		if bitSet {
-			return false, nil
-		}
-	}
-
-	return true, nil
-}
-
-// VerifyBitfieldNew Verify ``bitfield`` against the ``committee_size``.
+// VerifyBitfield Verify ``bitfield`` against the ``committee_size``.
 //
 // Spec pseudocode definition:
 //   def verify_bitfield(bitfield: bytes, committee_size: int) -> bool:
@@ -360,7 +321,7 @@ func VerifyBitfield(bitfield []byte, committeeSize int) (bool, error) {
 //         if get_bitfield_bit(bitfield, i) == 0b1:
 //             return False
 //     return True
-func VerifyBitfieldNew(bitfield []byte, committeeSize int) (bool, error) {
+func VerifyBitfield(bitfield []byte, committeeSize int) (bool, error) {
 	if len(bitfield) != (committeeSize+7)>>3 {
 		return false, fmt.Errorf(
 			"wanted participants bitfield length %d, got: %d",
@@ -369,12 +330,10 @@ func VerifyBitfieldNew(bitfield []byte, committeeSize int) (bool, error) {
 	}
 
 	for i := committeeSize; i < len(bitfield)<<3; i++ {
-		by := bitutil.BitfieldBit(bitfield, i)
-		if by == 1 {
+		if bitutil.BitfieldBit(bitfield, i) == 1 {
 			return false, nil
 		}
 	}
-
 	return true, nil
 }
 

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -396,7 +396,7 @@ func TestVerifyBitfield_OK(t *testing.T) {
 		t.Error("bitfield is not validated when it was supposed to be")
 	}
 
-	bitfield = []byte{0xff, 0x01}
+	bitfield = []byte{0xff, 0x80}
 	committeeSize = 9
 
 	isValidated, err = VerifyBitfield(bitfield, committeeSize)
@@ -408,46 +408,9 @@ func TestVerifyBitfield_OK(t *testing.T) {
 		t.Error("bitfield is validated when it was supposed to be")
 	}
 
-	bitfield = []byte{0xff, 0x80}
+	bitfield = []byte{0xff, 0x03}
 	committeeSize = 10
 	isValidated, err = VerifyBitfield(bitfield, committeeSize)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !isValidated {
-		t.Error("bitfield is not validated when it was supposed to be")
-	}
-}
-
-func TestVerifyBitfieldNew_OK(t *testing.T) {
-	bitfield := []byte{0xFF}
-	committeeSize := 8
-
-	isValidated, err := VerifyBitfieldNew(bitfield, committeeSize)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !isValidated {
-		t.Error("bitfield is not validated when it was supposed to be")
-	}
-
-	bitfield = []byte{0xff, 0x80}
-	committeeSize = 9
-
-	isValidated, err = VerifyBitfieldNew(bitfield, committeeSize)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if isValidated {
-		t.Error("bitfield is validated when it was supposed to be")
-	}
-
-	bitfield = []byte{0xff, 0x01}
-	committeeSize = 10
-	isValidated, err = VerifyBitfieldNew(bitfield, committeeSize)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -322,21 +322,21 @@ func TestAttestationParticipants_NoCommitteeCache(t *testing.T) {
 			attestationSlot: params.BeaconConfig().GenesisSlot + 2,
 			stateSlot:       params.BeaconConfig().GenesisSlot + 5,
 			shard:           2,
-			bitfield:        []byte{0xC0},
+			bitfield:        []byte{0x03},
 			wanted:          []uint64{11, 14},
 		},
 		{
 			attestationSlot: params.BeaconConfig().GenesisSlot + 1,
 			stateSlot:       params.BeaconConfig().GenesisSlot + 10,
 			shard:           1,
-			bitfield:        []byte{0x80},
+			bitfield:        []byte{0x01},
 			wanted:          []uint64{5},
 		},
 		{
 			attestationSlot: params.BeaconConfig().GenesisSlot + 10,
 			stateSlot:       params.BeaconConfig().GenesisSlot + 10,
 			shard:           10,
-			bitfield:        []byte{0xC0},
+			bitfield:        []byte{0x03},
 			wanted:          []uint64{55, 105},
 		},
 	}
@@ -527,7 +527,7 @@ func TestAttestationParticipants_CommitteeCacheHit(t *testing.T) {
 		Shard: 234,
 		Slot:  params.BeaconConfig().GenesisSlot + uint64(slotOffset),
 	}
-	result, err := AttestationParticipants(&pb.BeaconState{}, attestationData, []byte{0xC0})
+	result, err := AttestationParticipants(&pb.BeaconState{}, attestationData, []byte{0x03})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -561,7 +561,7 @@ func TestAttestationParticipants_CommitteeCacheMissSaved(t *testing.T) {
 		Slot:  params.BeaconConfig().GenesisSlot + slotOffset,
 	}
 
-	result, err := AttestationParticipants(state, attestationData, []byte{0xC0})
+	result, err := AttestationParticipants(state, attestationData, []byte{0x03})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -419,6 +419,44 @@ func TestVerifyBitfield_OK(t *testing.T) {
 		t.Error("bitfield is not validated when it was supposed to be")
 	}
 }
+
+func TestVerifyBitfieldNew_OK(t *testing.T) {
+	bitfield := []byte{0xFF}
+	committeeSize := 8
+
+	isValidated, err := VerifyBitfieldNew(bitfield, committeeSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !isValidated {
+		t.Error("bitfield is not validated when it was supposed to be")
+	}
+
+	bitfield = []byte{0xff, 0x80}
+	committeeSize = 9
+
+	isValidated, err = VerifyBitfieldNew(bitfield, committeeSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if isValidated {
+		t.Error("bitfield is validated when it was supposed to be")
+	}
+
+	bitfield = []byte{0xff, 0x01}
+	committeeSize = 10
+	isValidated, err = VerifyBitfieldNew(bitfield, committeeSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !isValidated {
+		t.Error("bitfield is not validated when it was supposed to be")
+	}
+}
+
 func TestCommitteeAssignment_CanRetrieve(t *testing.T) {
 	// Initialize test with 128 validators, each slot and each shard gets 2 validators.
 	validators := make([]*pb.Validator, 2*params.BeaconConfig().SlotsPerEpoch)

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -67,9 +67,9 @@ func TestBoundaryAttesterIndices_OK(t *testing.T) {
 
 	boundaryAttestations := []*pb.PendingAttestation{
 		{Data: &pb.AttestationData{Slot: params.BeaconConfig().GenesisSlot},
-			AggregationBitfield: []byte{0xC0}}, // returns indices 242
+			AggregationBitfield: []byte{0x03}}, // returns indices 242
 		{Data: &pb.AttestationData{Slot: params.BeaconConfig().GenesisSlot},
-			AggregationBitfield: []byte{0xC0}}, // returns indices 237,224,2
+			AggregationBitfield: []byte{0x03}}, // returns indices 237,224,2
 	}
 
 	attesterIndices, err := ValidatorIndices(state, boundaryAttestations)
@@ -119,9 +119,9 @@ func TestAttestingValidatorIndices_OK(t *testing.T) {
 		t.Fatalf("Could not execute AttestingValidatorIndices: %v", err)
 	}
 
-	if !reflect.DeepEqual(indices, []uint64{1134, 1150}) {
+	if !reflect.DeepEqual(indices, []uint64{1131, 1015}) {
 		t.Errorf("Could not get incorrect validator indices. Wanted: %v, got: %v",
-			[]uint64{1134, 1150}, indices)
+			[]uint64{1131, 1015}, indices)
 	}
 }
 

--- a/shared/bitutil/bit.go
+++ b/shared/bitutil/bit.go
@@ -83,3 +83,15 @@ func fillBit(target byte, index uint64) byte {
 	bitShift := 7 - index
 	return target ^ (1 << bitShift)
 }
+
+// BitfieldBit Extract the bit in `bitfield` at position `i`.
+// Spec pseudocode definition:
+//   def get_bitfield_bit(bitfield: bytes, i: int) -> int:
+//     """
+//     Extract the bit in ``bitfield`` at position ``i``.
+//     """
+//     return (bitfield[i // 8] >> (i % 8)) % 2
+func BitfieldBit(bitfield []byte, i int) byte {
+	by := (bitfield[i>>3] >> (uint(i) & 0x7)) & 0x1
+	return by
+}

--- a/shared/bitutil/bit.go
+++ b/shared/bitutil/bit.go
@@ -27,21 +27,16 @@ func SetBitfield(index int, committeeLength int) []byte {
 
 // CheckBit checks if a bit in a bit field (small endian) is one.
 func CheckBit(bitfield []byte, index int) (bool, error) {
-	chunkLocation := (index + 1) / 8
-	indexLocation := (index + 1) % 8
-
-	if indexLocation == 0 {
-		indexLocation = 8
-	} else {
-		chunkLocation++
+	if len(bitfield) < (index+7)>>3 {
+		return false, fmt.Errorf(
+			"wanted index is out of bound of bitfield length %d, got: %d",
+			(index+7)>>3,
+			len(bitfield))
 	}
-	if chunkLocation > len(bitfield) {
-		return false, fmt.Errorf("index out of range for bitfield: length: %d, position: %d ",
-			len(bitfield), chunkLocation-1)
+	if BitfieldBit(bitfield, index) == 1 {
+		return true, nil
 	}
-
-	field := bitfield[chunkLocation-1] >> (7 - uint(indexLocation-1))
-	return field%2 != 0, nil
+	return false, nil
 }
 
 // BitSetCount counts the number of 1s in a byte using Hamming weight.

--- a/shared/bitutil/bit.go
+++ b/shared/bitutil/bit.go
@@ -27,10 +27,10 @@ func SetBitfield(index int, committeeLength int) []byte {
 
 // CheckBit checks if a bit in a bit field (small endian) is one.
 func CheckBit(bitfield []byte, index int) (bool, error) {
-	if len(bitfield) < (index+7)>>3 {
+	if len(bitfield) < mathutil.CeilDiv8(index) {
 		return false, fmt.Errorf(
 			"wanted index is out of bound of bitfield length %d, got: %d",
-			(index+7)>>3,
+			mathutil.CeilDiv8(index),
 			len(bitfield))
 	}
 	if BitfieldBit(bitfield, index) == 1 {
@@ -79,7 +79,7 @@ func fillBit(target byte, index uint64) byte {
 	return target ^ (1 << bitShift)
 }
 
-// BitfieldBit Extract the bit in `bitfield` at position `i`.
+// BitfieldBit extracts the bit in bitfield at position i.
 // Spec pseudocode definition:
 //   def get_bitfield_bit(bitfield: bytes, i: int) -> int:
 //     """
@@ -87,6 +87,11 @@ func fillBit(target byte, index uint64) byte {
 //     """
 //     return (bitfield[i // 8] >> (i % 8)) % 2
 func BitfieldBit(bitfield []byte, i int) byte {
-	by := (bitfield[i>>3] >> (uint(i) & 0x7)) & 0x1
-	return by
+	//take the relevant byte in bitfield in order to get i value
+	rb := bitfield[i>>3]
+	//shift the byte till i is its first bit
+	fb := rb >> (uint(i) & 0x7)
+	//zero the byte value except its first bit
+	b := fb & 0x1
+	return b
 }

--- a/shared/bitutil/bit.go
+++ b/shared/bitutil/bit.go
@@ -33,10 +33,8 @@ func CheckBit(bitfield []byte, index int) (bool, error) {
 			mathutil.CeilDiv8(index),
 			len(bitfield))
 	}
-	if BitfieldBit(bitfield, index) == 1 {
-		return true, nil
-	}
-	return false, nil
+	bitExists := BitfieldBit(bitfield, index) == 1
+	return bitExists, nil
 }
 
 // BitSetCount counts the number of 1s in a byte using Hamming weight.

--- a/shared/bitutil/bit_test.go
+++ b/shared/bitutil/bit_test.go
@@ -13,12 +13,17 @@ func TestCheckBit(t *testing.T) {
 		b int
 		c bool
 	}{
-		{a: []byte{200}, b: 4, c: true},   //11001000
-		{a: []byte{148}, b: 3, c: true},   //10010100
-		{a: []byte{146}, b: 7, c: false},  //10010010
-		{a: []byte{179}, b: 0, c: true},   //10110011
-		{a: []byte{49}, b: 1, c: false},   //00110001
-		{a: []byte{49}, b: 100, c: false}, //00110001
+		{a: []byte{200}, b: 3, c: true},        //11001000
+		{a: []byte{148}, b: 2, c: true},        //10010100
+		{a: []byte{146}, b: 0, c: false},       //10010010
+		{a: []byte{179}, b: 0, c: true},        //10110011
+		{a: []byte{49}, b: 7, c: false},        //00110001
+		{a: []byte{179}, b: 7, c: true},        //10110011
+		{a: []byte{179, 179}, b: 8, c: true},   //10110011
+		{a: []byte{179, 179}, b: 9, c: true},   //10110011
+		{a: []byte{179, 179}, b: 10, c: false}, //10110011
+		{a: []byte{179, 179}, b: 15, c: true},  //10110011
+		{a: []byte{179, 179}, b: 14, c: false}, //10110011
 
 	}
 	for _, tt := range tests {

--- a/shared/bitutil/bit_test.go
+++ b/shared/bitutil/bit_test.go
@@ -34,6 +34,33 @@ func TestCheckBit(t *testing.T) {
 	}
 }
 
+func TestBitfieldBit(t *testing.T) {
+	tests := []struct {
+		a []byte
+		b int
+		c byte
+	}{
+		{a: []byte{200}, b: 3, c: 1},       //11001000
+		{a: []byte{148}, b: 2, c: 1},       //10010100
+		{a: []byte{146}, b: 0, c: 0},       //10010010
+		{a: []byte{179}, b: 0, c: 1},       //10110011
+		{a: []byte{49}, b: 7, c: 0},        //00110001
+		{a: []byte{179}, b: 7, c: 1},       //10110011
+		{a: []byte{179, 179}, b: 8, c: 1},  //10110011
+		{a: []byte{179, 179}, b: 9, c: 1},  //10110011
+		{a: []byte{179, 179}, b: 10, c: 0}, //10110011
+		{a: []byte{179, 179}, b: 15, c: 1}, //10110011
+		{a: []byte{179, 179}, b: 14, c: 0}, //10110011
+
+	}
+	for _, tt := range tests {
+		set := BitfieldBit(tt.a, tt.b)
+		if set != tt.c {
+			t.Errorf("Test check bit set failed with %08b and location %v", tt.a, tt.b)
+		}
+	}
+}
+
 func TestBitSetCount(t *testing.T) {
 	tests := []struct {
 		a byte

--- a/shared/testutil/checkbit.go
+++ b/shared/testutil/checkbit.go
@@ -1,28 +1,5 @@
 package testutil
 
-import (
-	"fmt"
-)
-
-// CheckBit checks if a bit in a bit field is one.
-func CheckBit(bitfield []byte, index int) (bool, error) {
-	chunkLocation := (index + 1) / 8
-	indexLocation := (index + 1) % 8
-	if indexLocation == 0 {
-		indexLocation = 8
-	} else {
-		chunkLocation++
-	}
-
-	if chunkLocation > len(bitfield) {
-		return false, fmt.Errorf("index out of range for bitfield: length: %d, position: %d ",
-			len(bitfield), chunkLocation-1)
-	}
-
-	field := bitfield[chunkLocation-1] >> (8 - uint(indexLocation))
-	return field%2 != 0, nil
-}
-
 // BitSetCount counts the number of 1s in a byte using the following algo:
 // https://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
 func BitSetCount(bytes []byte) int {


### PR DESCRIPTION
[Part of] #2307 

---

# Update bitfield helpers v0.6

**Write why you are making the changes in this pull request**
to sync with the new spec

**Write a summary of the changes you are making**
added methods:
VerifyBitfieldNew (replacing caused all the tests to fail)
BitfieldBit


**Link anything that would be helpful or relevant to the reviewers**
https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#get_bitfield_bit
https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#verify_bitfield