### PR TITLE
Raise Ejection Balance to 3.15ETH

### DIFF
--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -214,7 +214,7 @@ func DemoBeaconConfig() *BeaconChainConfig {
 	demoConfig.GenesisEpoch = demoConfig.GenesisSlot / 8
 	demoConfig.MinDepositAmount = 100
 	demoConfig.MaxDepositAmount = 3.2 * 1e9
-	demoConfig.EjectionBalance = 3 * 1e9
+	demoConfig.EjectionBalance = 3.15 * 1e9
 	demoConfig.SyncPollingInterval = 1 * 10 // Query nodes over the network every slot.
 	demoConfig.Eth1FollowDistance = 5
 	demoConfig.EpochsPerEth1VotingPeriod = 1


### PR DESCRIPTION
Raising ejection balance to 3.15ETH for test net stability. Due to shorter epoch length (8 slots) we don't want too many offline validators in our 1st iteration of single client test net