### PR TITLE
Add metric for correctly attested rate

### DIFF
--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -21,6 +21,8 @@ go_library(
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/sliceutil:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
     ],

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -7,7 +7,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	bal "github.com/prysmaticlabs/prysm/beacon-chain/core/balances"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	e "github.com/prysmaticlabs/prysm/beacon-chain/core/epoch"
@@ -24,6 +27,15 @@ import (
 )
 
 var log = logrus.WithField("prefix", "core/state")
+
+var (
+	correctAttestedValidatorGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "correct_attested_validator_rate",
+		Help: "The % of validators correctly attested for source and target",
+	}, []string{
+		"epoch",
+	})
+)
 
 // TransitionConfig defines important configuration options
 // for executing a state transition, which can have logging and signature
@@ -487,6 +499,11 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, block *pb.BeaconBl
 
 	// Clean up processed attestations.
 	state = e.CleanupAttestations(state)
+
+	// Log the useful metrics via prometheus.
+	correctAttestedValidatorGauge.WithLabelValues(
+		strconv.Itoa(int(currentEpoch)),
+	).Set(float64(len(currentBoundaryAttesterIndices) / len(activeValidatorIndices)))
 
 	if config.Logging {
 		log.WithField("currentEpochAttestations", len(currentEpochAttestations)).Info("Number of current epoch attestations")


### PR DESCRIPTION
One of the initial test net feedback is to see the percent of validators that correctly participated in the most recent epoch. This adds metrics to do that