### PR TITLE
Fixed HasAnyValidators to Fallback to Looking Into the BeaconState

### DIFF
--- a/beacon-chain/db/validator.go
+++ b/beacon-chain/db/validator.go
@@ -107,7 +107,7 @@ func (db *BeaconDB) HasValidator(pubKey []byte) bool {
 func (db *BeaconDB) HasAnyValidators(state *pb.BeaconState, pubKeys [][]byte) (bool, error) {
 	exists := false
 	// #nosec G104, similar to HasBlock, HasAttestation... etc
-	_ := db.view(func(tx *bolt.Tx) error {
+	db.view(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(validatorBucket)
 		for _, pk := range pubKeys {
 			h := hashutil.Hash(pk)

--- a/beacon-chain/db/validator.go
+++ b/beacon-chain/db/validator.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/boltdb/bolt"
-	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
 
 // SaveValidatorIndex accepts a public key and validator index and writes them to disk.
@@ -125,7 +125,7 @@ func (db *BeaconDB) HasAnyValidators(state *pb.BeaconState, pubKeys [][]byte) (b
 					if err := db.SaveValidatorIndex(pubKey, i); err != nil {
 						return false, err
 					}
-					return true, nil
+					exists = true
 				}
 			}
 		}

--- a/beacon-chain/db/validator.go
+++ b/beacon-chain/db/validator.go
@@ -118,7 +118,7 @@ func (db *BeaconDB) HasAnyValidators(state *pb.BeaconState, pubKeys [][]byte) (b
 	})
 
 	if !exists {
-		for pubKey := range pubKeys {
+		for _, pubKey := range pubKeys {
 			for i := 0; i < len(state.ValidatorRegistry); i++ {
 				v := state.ValidatorRegistry[i]
 				if bytes.Equal(v.Pubkey, pubKey) {

--- a/beacon-chain/db/validator_test.go
+++ b/beacon-chain/db/validator_test.go
@@ -96,43 +96,6 @@ func TestHasValidator(t *testing.T) {
 	}
 }
 
-func TestHasAllValidators(t *testing.T) {
-	db := setupDB(t)
-	defer teardownDB(t, db)
-
-	knownPubKeys := [][]byte{
-		[]byte("pk1"),
-		[]byte("pk2"),
-	}
-	unknownPubKeys := [][]byte{
-		[]byte("pk3"),
-		[]byte("pk4"),
-	}
-
-	// Populate the db with some public key
-	if err := db.db.Update(func(tx *bolt.Tx) error {
-		bkt := tx.Bucket(validatorBucket)
-		for _, pk := range knownPubKeys {
-			h := hashutil.Hash(pk)
-			if err := bkt.Put(h[:], []byte("data")); err != nil {
-				return err
-			}
-		}
-
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	if !db.HasAllValidators(knownPubKeys) {
-		t.Error("Database did not have expected validators")
-	}
-
-	if db.HasAllValidators(append(knownPubKeys, unknownPubKeys...)) {
-		t.Error("Database returned true when there are pubkeys that did not exist")
-	}
-}
-
 func TestHasAnyValidator(t *testing.T) {
 	db := setupDB(t)
 	defer teardownDB(t, db)
@@ -161,11 +124,23 @@ func TestHasAnyValidator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !db.HasAnyValidators(append(knownPubKeys, unknownPubKeys...)) {
+	beaconState := &pb.BeaconState{
+		ValidatorRegistry: []*pb.Validator{},
+	}
+
+	has, err := db.HasAnyValidators(beaconState, append(knownPubKeys, unknownPubKeys...))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has {
 		t.Error("Database did not have expected validators")
 	}
 
-	if db.HasAnyValidators(unknownPubKeys) {
+	has, err = db.HasAnyValidators(beaconState, unknownPubKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has {
 		t.Error("Database returned true when there are only pubkeys that did not exist")
 	}
 }

--- a/beacon-chain/db/validator_test.go
+++ b/beacon-chain/db/validator_test.go
@@ -140,7 +140,7 @@ func TestHasAnyValidator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !has {
+	if has {
 		t.Error("Database returned true when there are only pubkeys that did not exist")
 	}
 }

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -574,7 +574,7 @@ func TestWaitForActivation_ContextClosed(t *testing.T) {
 	ctx := context.Background()
 
 	beaconState := &pbp2p.BeaconState{
-		Slot: params.BeaconConfig().GenesisSlot,
+		Slot:              params.BeaconConfig().GenesisSlot,
 		ValidatorRegistry: []*pbp2p.Validator{},
 	}
 	if err := db.SaveState(ctx, beaconState); err != nil {

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -575,6 +575,7 @@ func TestWaitForActivation_ContextClosed(t *testing.T) {
 
 	beaconState := &pbp2p.BeaconState{
 		Slot: params.BeaconConfig().GenesisSlot,
+		ValidatorRegistry: []*pbp2p.Validator{},
 	}
 	if err := db.SaveState(ctx, beaconState); err != nil {
 		t.Fatalf("could not save state: %v", err)
@@ -594,6 +595,7 @@ func TestWaitForActivation_ContextClosed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockStream := internal.NewMockValidatorService_WaitForActivationServer(ctrl)
+	mockStream.EXPECT().Context().Return(context.Background())
 	exitRoutine := make(chan bool)
 	go func(tt *testing.T) {
 		want := "context closed"
@@ -653,6 +655,7 @@ func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 
 	defer ctrl.Finish()
 	mockStream := internal.NewMockValidatorService_WaitForActivationServer(ctrl)
+	mockStream.EXPECT().Context().Return(context.Background())
 	mockStream.EXPECT().Context().Return(context.Background())
 	mockStream.EXPECT().Send(
 		&pb.ValidatorActivationResponse{


### PR DESCRIPTION
Part of #1586 

---

# Description

**Write why you are making the changes in this pull request**

If we clear the db and restart our active validator, it will forever be stuck on waiting for activation. Underneath the hood, it calls HasAnyValidators, which should fallback to looking into the state and repopulating the db accordingly.

**Write a summary of the changes you are making**

This PR repopulates the db and falls back to looking into the state if a validator index is in there.
