### PR TITLE
Add nginx proxy caching in front of SSR

### DIFF
--- a/k8s/beacon-chain/contract-address.yaml
+++ b/k8s/beacon-chain/contract-address.yaml
@@ -25,6 +25,16 @@ spec:
       containers:
       - name: site
         image: gcr.io/prysmaticlabs/prysm/contract-addr:latest
+        readinessProbe:
+          httpGet:
+            path: /contract
+            port: 8080
+          initialDelaySeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /contract
+            port: 8080 
+          initialDelaySeconds: 10
         args:
           - --address-path=/etc/address/DEPOSIT_CONTRACT_ADDRESS
         ports: 
@@ -37,6 +47,24 @@ spec:
       - name: config-volume
         configMap:
           name: beacon-config
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: contract-address-http
+  namespace: beacon-chain
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: contract-address-http
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 80
 ---
 kind: Service
 apiVersion: v1

--- a/k8s/beacon-chain/testnet-site.yaml
+++ b/k8s/beacon-chain/testnet-site.yaml
@@ -23,6 +23,20 @@ spec:
     spec:
       priorityClassName: best-effort-priority
       containers:
+      - name: proxy-cache
+        image: gcr.io/prysmaticlabs/prysm/testnet-proxy-cache:latest
+        ports:
+        - containerPort: 80
+          name: http-cache
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 4000
+          initialDelaySeconds: 3
+          periodSeconds: 15
+        resources:
+          requests:
+            cpu: "100m"
       - name: site
         image: gcr.io/prysmaticlabs/prysm-testnet-site:latest
         ports:
@@ -67,8 +81,11 @@ spec:
     component: testnet-site
     version: alpha
   ports:
-  - port: 80
+  - port: 4000
     targetPort: 4000
+    name: http-ng
+  - port: 80
+    targetPort: 80
     name: http-nginx
   type: ClusterIP
 ---
@@ -88,7 +105,7 @@ spec:
         prefix: /
     route:
     - destination:
-        port: 
+        port:
           number: 80
         host: testnet-site-alpha.beacon-chain.svc.cluster.local
 ---


### PR DESCRIPTION
This hopefully saves a bit of resources when the server side rendering is under heavy load. The rendered page never changes so we can cache it in nginx reverse proxy. 

Also add liveness probs to contract service.