### PR TITLE
Querier Polls Forever Until 1st Response

### DIFF
--- a/beacon-chain/sync/querier.go
+++ b/beacon-chain/sync/querier.go
@@ -174,7 +174,7 @@ func (q *Querier) run() {
 			q.cancel()
 		case msg := <-q.responseBuf:
 			// If this is the first response a node receives, we start
-			// a timeout that will keep listening for more respones over a
+			// a timeout that will keep listening for more responses over a
 			// certain time interval to ensure we get the best head from our peers.
 			if !hasReceivedResponse {
 				timeout = time.After(10 * time.Second)


### PR DESCRIPTION
This is part of #2457 

---

# Description

**Write why you are making the changes in this pull request**

Right now, if we do not receive a chain head response within 5 seconds, our chain head querier exits context after a timeout and our node cannot sync.

**Write a summary of the changes you are making**

This PR polls forever until the first response, _then_ starts a 10 seconds timeout to keep receiving responses from peers before starting initial sync.
