### PR TITLE
Fix Estimation of Deposit Inclusion Slot in ValidatorActivationStatus

### DIFF
--- a/beacon-chain/powchain/block_reader.go
+++ b/beacon-chain/powchain/block_reader.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"go.opencensus.io/trace"
 )
 
@@ -58,13 +57,13 @@ func (w *Web3Service) BlockHashByHeight(ctx context.Context, height *big.Int) (c
 	return block.Hash(), nil
 }
 
-// BlockByHeight fetches an eth1.0 block by its height.
-func (w *Web3Service) BlockByHeight(ctx context.Context, height *big.Int) (*gethTypes.Block, error) {
+// BlockTimeByHeight fetches an eth1.0 block timestamp by its height.
+func (w *Web3Service) BlockTimeByHeight(ctx context.Context, height *big.Int) (uint64, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.web3service.BlockByHeight")
 	defer span.End()
 	block, err := w.blockFetcher.BlockByNumber(w.ctx, height)
 	if err != nil {
-		return nil, fmt.Errorf("could not query block with given height: %v", err)
+		return 0, fmt.Errorf("could not query block with given height: %v", err)
 	}
-	return block, nil
+	return block.Time(), nil
 }

--- a/beacon-chain/powchain/block_reader.go
+++ b/beacon-chain/powchain/block_reader.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"go.opencensus.io/trace"
 )
 
@@ -55,4 +56,15 @@ func (w *Web3Service) BlockHashByHeight(ctx context.Context, height *big.Int) (c
 		return [32]byte{}, err
 	}
 	return block.Hash(), nil
+}
+
+// BlockByHeight fetches an eth1.0 block by its height.
+func (w *Web3Service) BlockByHeight(ctx context.Context, height *big.Int) (*gethTypes.Block, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-chain.web3service.BlockByHeight")
+	defer span.End()
+	block, err := w.blockFetcher.BlockByNumber(w.ctx, height)
+	if err != nil {
+		return nil, fmt.Errorf("could not query block with given height: %v", err)
+	}
+	return block, nil
 }

--- a/beacon-chain/rpc/beacon_server_test.go
+++ b/beacon-chain/rpc/beacon_server_test.go
@@ -53,6 +53,10 @@ func (f *faultyPOWChainService) BlockHashByHeight(_ context.Context, height *big
 	return [32]byte{}, errors.New("failed")
 }
 
+func (f *faultyPOWChainService) BlockTimeByHeight(_ context.Context, height *big.Int) (uint64, error) {
+	return 0, errors.New("failed")
+}
+
 func (f *faultyPOWChainService) DepositRoot() [32]byte {
 	return [32]byte{}
 }
@@ -69,6 +73,7 @@ type mockPOWChainService struct {
 	chainStartFeed    *event.Feed
 	latestBlockNumber *big.Int
 	hashesByHeight    map[int][]byte
+	blockTimeByHeight map[int]uint64
 }
 
 func (m *mockPOWChainService) HasChainStartLogOccurred() (bool, uint64, error) {
@@ -106,6 +111,11 @@ func (m *mockPOWChainService) BlockHashByHeight(_ context.Context, height *big.I
 		return [32]byte{}, fmt.Errorf("could not fetch hash for height: %v", height)
 	}
 	return bytesutil.ToBytes32(val), nil
+}
+
+func (m *mockPOWChainService) BlockTimeByHeight(_ context.Context, height *big.Int) (uint64, error) {
+	h := int(height.Int64())
+	return m.blockTimeByHeight[h], nil
 }
 
 func (m *mockPOWChainService) DepositRoot() [32]byte {

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
+	gethTypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 var log logrus.FieldLogger
@@ -50,6 +51,7 @@ type powChainService interface {
 	LatestBlockHeight() *big.Int
 	BlockExists(ctx context.Context, hash common.Hash) (bool, *big.Int, error)
 	BlockHashByHeight(ctx context.Context, height *big.Int) (common.Hash, error)
+	BlockByHeight(ctx context.Context, height *big.Int) (*gethTypes.Block, error)
 	DepositRoot() [32]byte
 	DepositTrie() *trieutil.MerkleTrie
 	ChainStartDeposits() [][]byte

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
-	gethTypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 var log logrus.FieldLogger
@@ -51,7 +50,7 @@ type powChainService interface {
 	LatestBlockHeight() *big.Int
 	BlockExists(ctx context.Context, hash common.Hash) (bool, *big.Int, error)
 	BlockHashByHeight(ctx context.Context, height *big.Int) (common.Hash, error)
-	BlockByHeight(ctx context.Context, height *big.Int) (*gethTypes.Block, error)
+	BlockTimeByHeight(ctx context.Context, height *big.Int) (uint64, error)
 	DepositRoot() [32]byte
 	DepositTrie() *trieutil.MerkleTrie
 	ChainStartDeposits() [][]byte
@@ -173,6 +172,7 @@ func (s *Service) Start() {
 		beaconDB:           s.beaconDB,
 		chainService:       s.chainService,
 		canonicalStateChan: s.canonicalStateChan,
+		powChainService:    s.powChainService,
 	}
 	pb.RegisterBeaconServiceServer(s.grpcServer, beaconServer)
 	pb.RegisterProposerServiceServer(s.grpcServer, proposerServer)

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -230,7 +230,7 @@ func (vs *ValidatorServer) ValidatorStatus(
 	}
 
 	eth1BlockNum := eth1BlockNumBigInt.Uint64()
-	addFollowDistance := (eth1BlockNum + params.BeaconConfig().Eth1FollowDistance)
+	addFollowDistance := eth1BlockNum + params.BeaconConfig().Eth1FollowDistance
 	eth1Timestamp, err := vs.powChainService.BlockTimeByHeight(ctx, big.NewInt(int64(addFollowDistance)))
 	if err != nil {
 		return nil, err

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -274,7 +274,11 @@ func (vs *ValidatorServer) filterActivePublicKeys(beaconState *pbp2p.BeaconState
 	return activeKeys
 }
 
-func (vs *ValidatorServer) addNonActivePublicKeysAssignmentStatus(beaconState *pbp2p.BeaconState, pubkeys [][]byte, assignments []*pb.CommitteeAssignmentResponse_CommitteeAssignment) []*pb.CommitteeAssignmentResponse_CommitteeAssignment {
+func (vs *ValidatorServer) addNonActivePublicKeysAssignmentStatus(
+	beaconState *pbp2p.BeaconState,
+	pubkeys [][]byte,
+	assignments []*pb.CommitteeAssignmentResponse_CommitteeAssignment,
+) []*pb.CommitteeAssignmentResponse_CommitteeAssignment {
 	// Generate a map for O(1) lookup of existence of pub keys in request.
 	validatorMap := make(map[string]*pbp2p.Validator)
 	for _, v := range beaconState.ValidatorRegistry {

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -230,8 +230,8 @@ func (vs *ValidatorServer) ValidatorStatus(
 	}
 
 	eth1BlockNum := eth1BlockNumBigInt.Uint64()
-	blocksToInclusion := (eth1BlockNum + params.BeaconConfig().Eth1FollowDistance)
-	eth1Timestamp, err := vs.powChainService.BlockTimeByHeight(ctx, big.NewInt(int64(blocksToInclusion)))
+	addFollowDistance := (eth1BlockNum + params.BeaconConfig().Eth1FollowDistance)
+	eth1Timestamp, err := vs.powChainService.BlockTimeByHeight(ctx, big.NewInt(int64(addFollowDistance)))
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -340,8 +340,14 @@ func TestValidatorStatus_PendingActive(t *testing.T) {
 	}
 	db.InsertDeposit(ctx, deposit, big.NewInt(0))
 
+	height := time.Unix(int64(params.BeaconConfig().Eth1FollowDistance), 0).Unix()
 	vs := &ValidatorServer{
 		beaconDB: db,
+		powChainService: &mockPOWChainService{
+			blockTimeByHeight: map[int]uint64{
+				0: uint64(height),
+			},
+		},
 	}
 	req := &pb.ValidatorIndexRequest{
 		PublicKey: pubKey,
@@ -382,7 +388,8 @@ func TestValidatorStatus_Active(t *testing.T) {
 
 	// Active because activation epoch <= current epoch < exit epoch.
 	if err := db.SaveState(ctx, &pbp2p.BeaconState{
-		Slot: params.BeaconConfig().GenesisSlot,
+		GenesisTime: uint64(time.Unix(0, 0).Unix()),
+		Slot:        params.BeaconConfig().GenesisSlot,
 		ValidatorRegistry: []*pbp2p.Validator{{
 			ActivationEpoch: params.BeaconConfig().GenesisEpoch,
 			ExitEpoch:       params.BeaconConfig().FarFutureEpoch,
@@ -391,8 +398,14 @@ func TestValidatorStatus_Active(t *testing.T) {
 		t.Fatalf("could not save state: %v", err)
 	}
 
+	timestamp := time.Unix(int64(params.BeaconConfig().Eth1FollowDistance), 0).Unix()
 	vs := &ValidatorServer{
 		beaconDB: db,
+		powChainService: &mockPOWChainService{
+			blockTimeByHeight: map[int]uint64{
+				int(params.BeaconConfig().Eth1FollowDistance): uint64(timestamp),
+			},
+		},
 	}
 	req := &pb.ValidatorIndexRequest{
 		PublicKey: pubKey,
@@ -402,10 +415,7 @@ func TestValidatorStatus_Active(t *testing.T) {
 		t.Fatalf("Could not get validator status %v", err)
 	}
 
-	timeToInclusion := params.BeaconConfig().Eth1FollowDistance * params.BeaconConfig().GoerliBlockTime
-	votingPeriodSlots := helpers.StartSlot(params.BeaconConfig().EpochsPerEth1VotingPeriod)
-	depositBlockSlot := (timeToInclusion / params.BeaconConfig().SecondsPerSlot) + votingPeriodSlots
-
+	depositBlockSlot := uint64(1194)
 	expected := &pb.ValidatorStatusResponse{
 		Status:                 pb.ValidatorStatus_ACTIVE,
 		ActivationEpoch:        params.BeaconConfig().GenesisEpoch,
@@ -415,10 +425,6 @@ func TestValidatorStatus_Active(t *testing.T) {
 	if !proto.Equal(resp, expected) {
 		t.Errorf("Wanted %v, got %v", expected, resp)
 	}
-}
-
-func TestValidatorStatus_PendingStateActivation(t *testing.T) {
-
 }
 
 func TestValidatorStatus_InitiatedExit(t *testing.T) {
@@ -454,8 +460,14 @@ func TestValidatorStatus_InitiatedExit(t *testing.T) {
 		DepositData: depData,
 	}
 	db.InsertDeposit(ctx, deposit, big.NewInt(0))
+	height := time.Unix(int64(params.BeaconConfig().Eth1FollowDistance), 0).Unix()
 	vs := &ValidatorServer{
 		beaconDB: db,
+		powChainService: &mockPOWChainService{
+			blockTimeByHeight: map[int]uint64{
+				0: uint64(height),
+			},
+		},
 	}
 	req := &pb.ValidatorIndexRequest{
 		PublicKey: pubKey,
@@ -502,8 +514,14 @@ func TestValidatorStatus_Withdrawable(t *testing.T) {
 		DepositData: depData,
 	}
 	db.InsertDeposit(ctx, deposit, big.NewInt(0))
+	height := time.Unix(int64(params.BeaconConfig().Eth1FollowDistance), 0).Unix()
 	vs := &ValidatorServer{
 		beaconDB: db,
+		powChainService: &mockPOWChainService{
+			blockTimeByHeight: map[int]uint64{
+				0: uint64(height),
+			},
+		},
 	}
 	req := &pb.ValidatorIndexRequest{
 		PublicKey: pubKey,
@@ -549,8 +567,14 @@ func TestValidatorStatus_ExitedSlashed(t *testing.T) {
 		DepositData: depData,
 	}
 	db.InsertDeposit(ctx, deposit, big.NewInt(0))
+	height := time.Unix(int64(params.BeaconConfig().Eth1FollowDistance), 0).Unix()
 	vs := &ValidatorServer{
 		beaconDB: db,
+		powChainService: &mockPOWChainService{
+			blockTimeByHeight: map[int]uint64{
+				0: uint64(height),
+			},
+		},
 	}
 	req := &pb.ValidatorIndexRequest{
 		PublicKey: pubKey,
@@ -597,8 +621,14 @@ func TestValidatorStatus_Exited(t *testing.T) {
 		DepositData: depData,
 	}
 	db.InsertDeposit(ctx, deposit, big.NewInt(0))
+	height := time.Unix(int64(params.BeaconConfig().Eth1FollowDistance), 0).Unix()
 	vs := &ValidatorServer{
 		beaconDB: db,
+		powChainService: &mockPOWChainService{
+			blockTimeByHeight: map[int]uint64{
+				0: uint64(height),
+			},
+		},
 	}
 	req := &pb.ValidatorIndexRequest{
 		PublicKey: pubKey,
@@ -646,8 +676,14 @@ func TestValidatorStatus_UnknownStatus(t *testing.T) {
 		DepositData: depData,
 	}
 	db.InsertDeposit(ctx, deposit, big.NewInt(0))
+	height := time.Unix(int64(params.BeaconConfig().Eth1FollowDistance), 0).Unix()
 	vs := &ValidatorServer{
 		beaconDB: db,
+		powChainService: &mockPOWChainService{
+			blockTimeByHeight: map[int]uint64{
+				0: uint64(height),
+			},
+		},
 	}
 	req := &pb.ValidatorIndexRequest{
 		PublicKey: pubKey,


### PR DESCRIPTION
Follow up to #2469 

---

# Description

**Write a summary of the changes you are making**

This PR estimates the deposit inclusion slot as follows:
1. Obtain the eth1 height of when the deposit occurred from the db
2. Add eth1height + ETH1_FOLLOW_DISTANCE and fetch the block timestamp at that height
3. Add voting period seconds to that timestamp
4. Get the eth2 genesis time
5. Subtract the result of 3 from the eth2 genesis time
6. Convert that result to slots
