### PR TITLE
Allow Client to Retrieve Multiple Validator Statuses

### DIFF
--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
+        "//beacon-chain/core/state/stateutils:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -279,6 +279,8 @@ func (vs *ValidatorServer) ValidatorStatus(
 	return res, nil
 }
 
+// MultipleValidatorStatus returns the validator status response for the set of validators
+// requested by their pubkeys.
 func (vs *ValidatorServer) MultipleValidatorStatus(
 	ctx context.Context,
 	pubkeys [][]byte) (bool, []*pb.ValidatorActivationResponse_Status, error) {

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -364,7 +364,8 @@ func (vs *ValidatorServer) MultipleValidatorStatus(
 
 		// If the validator has deposited and has been added to the state:
 		if validatorInState {
-			// Our position in the activation queue is the above index - our validator index.
+			// Our position in the activation queue is our previous position added with the
+			// difference between the last added validator and the last activated validator.
 			positionInQueue += uint64(lastValidatorIndex) - lastActivatedValidatorIdx
 		}
 

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -287,7 +287,7 @@ func (vs *ValidatorServer) MultipleValidatorStatus(
 
 	beaconState, err := vs.beaconDB.HeadState(ctx)
 	if err != nil {
-		return activeValidatorExists, nil, fmt.Errorf("could not fetch beacon state: %v", err)
+		return false, nil, fmt.Errorf("could not fetch beacon state: %v", err)
 	}
 
 	validatorMap := stateutils.ValidatorIndexMap(beaconState)

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -80,6 +80,8 @@ func (vs *ValidatorServer) WaitForActivation(req *pb.ValidatorActivationRequest,
 				continue
 			}
 			return reply()
+		case <-stream.Context().Done():
+			return errors.New("stream context closed,exiting gorutine")
 		case <-vs.ctx.Done():
 			return errors.New("rpc context closed, exiting goroutine")
 		}

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -36,12 +36,12 @@ type ValidatorServer struct {
 // beacon state, if not, then it creates a stream which listens for canonical states which contain
 // the validator with the public key as an active validator record.
 func (vs *ValidatorServer) WaitForActivation(req *pb.ValidatorActivationRequest, stream pb.ValidatorService_WaitForActivationServer) error {
-	activeValidatorExists, validatorStatus, err := vs.MultipleValidatorStatus(stream.Context(), req.PublicKeys)
+	activeValidatorExists, validatorStatuses, err := vs.MultipleValidatorStatus(stream.Context(), req.PublicKeys)
 	if err != nil {
 		return err
 	}
 	res := &pb.ValidatorActivationResponse{
-		Statuses: validatorStatus,
+		Statuses: validatorStatuses,
 	}
 	if activeValidatorExists {
 		return stream.Send(res)
@@ -53,12 +53,12 @@ func (vs *ValidatorServer) WaitForActivation(req *pb.ValidatorActivationRequest,
 	for {
 		select {
 		case <-time.After(6 * time.Second):
-			activeValidatorExists, validatorStatus, err := vs.MultipleValidatorStatus(stream.Context(), req.PublicKeys)
+			activeValidatorExists, validatorStatuses, err := vs.MultipleValidatorStatus(stream.Context(), req.PublicKeys)
 			if err != nil {
 				return err
 			}
 			res := &pb.ValidatorActivationResponse{
-				Statuses: validatorStatus,
+				Statuses: validatorStatuses,
 			}
 			if activeValidatorExists {
 				return stream.Send(res)

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -87,7 +87,6 @@ func (v *validator) WaitForActivation(ctx context.Context) error {
 		return fmt.Errorf("could not setup validator WaitForActivation streaming client: %v", err)
 	}
 	var validatorActivatedRecords [][]byte
-	log.Info("Waiting for validator to be activated in the beacon chain")
 	for {
 		res, err := stream.Recv()
 		// If the stream is closed, we stop the loop.
@@ -101,7 +100,7 @@ func (v *validator) WaitForActivation(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("could not receive validator activation from stream: %v", err)
 		}
-
+		log.Info("Waiting for validator to be activated in the beacon chain")
 		activatedKeys := v.checkAndLogValidatorStatus(res.Statuses)
 
 		if len(activatedKeys) > 0 {

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -132,18 +132,18 @@ func (v *validator) checkAndLogValidatorStatus(validatorStatuses []*pb.Validator
 		if status.Status.ActivationEpoch == (params.BeaconConfig().FarFutureEpoch - params.BeaconConfig().GenesisEpoch) {
 			log.WithFields(logrus.Fields{
 				"PublicKey":                 fmt.Sprintf("%#x", bytesutil.Trunc(status.PublicKey)),
-				"Status":                    fmt.Sprintf("%s", status.Status.Status.String()),
-				"DepositInclusionSlot":      fmt.Sprintf("%d", status.Status.DepositInclusionSlot),
-				"PositionInActivationQueue": fmt.Sprintf("%d", status.Status.PositionInActivationQueue),
+				"Status":                    status.Status.Status.String(),
+				"DepositInclusionSlot":      status.Status.DepositInclusionSlot,
+				"PositionInActivationQueue": status.Status.PositionInActivationQueue,
 			}).Info("Waiting to be Activated")
 			continue
 		}
 		log.WithFields(logrus.Fields{
 			"PublicKey":                 fmt.Sprintf("%#x", bytesutil.Trunc(status.PublicKey)),
-			"Status":                    fmt.Sprintf("%s", status.Status.Status.String()),
-			"DepositInclusionSlot":      fmt.Sprintf("%d", status.Status.DepositInclusionSlot),
-			"ActivationEpoch":           fmt.Sprintf("%d", status.Status.ActivationEpoch),
-			"PositionInActivationQueue": fmt.Sprintf("%d", status.Status.PositionInActivationQueue),
+			"Status":                    status.Status.Status.String(),
+			"DepositInclusionSlot":      status.Status.DepositInclusionSlot,
+			"ActivationEpoch":           status.Status.ActivationEpoch,
+			"PositionInActivationQueue": status.Status.PositionInActivationQueue,
 		}).Info("Validator Status")
 	}
 	return activatedKeys

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -100,6 +100,9 @@ func (v *validator) WaitForActivation(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("could not receive validator activation from stream: %v", err)
 		}
+
+		v.logValidatorStatus(res.Statuses)
+
 		if len(res.ActivatedPublicKeys) > 0 {
 			validatorActivatedRecords = res.ActivatedPublicKeys
 			break
@@ -111,6 +114,18 @@ func (v *validator) WaitForActivation(ctx context.Context) error {
 		}).Info("Validator activated")
 	}
 	return nil
+}
+
+func (v *validator) logValidatorStatus(validatorStatuses []*pb.ValidatorActivationResponse_Status) {
+	for _, status := range validatorStatuses {
+		log.WithFields(logrus.Fields{
+			"PublicKey":                 fmt.Sprintf("%#x", status.PublicKey),
+			"Status":                    fmt.Sprintf("%s", status.Status.Status.String()),
+			"DepositInclusionSlot":      fmt.Sprintf("%d", status.Status.DepositInclusionSlot),
+			"ActivationEpoch":           fmt.Sprintf("%d", status.Status.ActivationEpoch),
+			"PositionInActivationQueue": fmt.Sprintf("%d", status.Status.PositionInActivationQueue),
+		}).Info("Validator Status")
+	}
 }
 
 // CanonicalHeadSlot returns the slot of canonical block currently found in the


### PR DESCRIPTION
- [x] Allow the grpc Server to return the validator statuses at regular intervals
- [x] Allow the validator clients to log their Validator statuses.
- [x] Add tests for new Method and fix failing tests