### PR TITLE
Standardize Slot Numbers in Validator Status Response

### DIFF
--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -224,7 +224,7 @@ func (vs *ValidatorServer) ValidatorStatus(
 	if eth1BlockNumBigInt == nil {
 		return &pb.ValidatorStatusResponse{
 			Status:                 pb.ValidatorStatus_UNKNOWN_STATUS,
-			ActivationEpoch:        params.BeaconConfig().FarFutureEpoch,
+			ActivationEpoch:        params.BeaconConfig().FarFutureEpoch - params.BeaconConfig().GenesisEpoch,
 			Eth1DepositBlockNumber: eth1BlockNumBigInt.Uint64(),
 		}, nil
 	}
@@ -254,7 +254,7 @@ func (vs *ValidatorServer) ValidatorStatus(
 			if helpers.IsActiveValidator(val, currEpoch) {
 				return &pb.ValidatorStatusResponse{
 					Status:                 pb.ValidatorStatus_ACTIVE,
-					ActivationEpoch:        val.ActivationEpoch,
+					ActivationEpoch:        val.ActivationEpoch - params.BeaconConfig().GenesisEpoch,
 					Eth1DepositBlockNumber: eth1BlockNum,
 					DepositInclusionSlot:   depositBlockSlot,
 				}, nil
@@ -288,7 +288,7 @@ func (vs *ValidatorServer) ValidatorStatus(
 		Eth1DepositBlockNumber:    eth1BlockNum,
 		PositionInActivationQueue: positionInQueue,
 		DepositInclusionSlot:      depositBlockSlot,
-		ActivationEpoch:           params.BeaconConfig().FarFutureEpoch,
+		ActivationEpoch:           params.BeaconConfig().FarFutureEpoch - params.BeaconConfig().GenesisEpoch,
 	}
 
 	return res, nil

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -418,7 +418,7 @@ func TestValidatorStatus_Active(t *testing.T) {
 	depositBlockSlot := uint64(1194)
 	expected := &pb.ValidatorStatusResponse{
 		Status:                 pb.ValidatorStatus_ACTIVE,
-		ActivationEpoch:        params.BeaconConfig().GenesisEpoch,
+		ActivationEpoch:        0,
 		DepositInclusionSlot:   depositBlockSlot,
 		Eth1DepositBlockNumber: 0,
 	}


### PR DESCRIPTION
No tracking issue - this standardizes returned values from the validator status response to be in terms of slotsSinceGenesis or epochsSinceGenesis (that is, starting from a genesis of 0) for greater readability and aligned with v0.6 of the spec.