### PR TITLE
Revert "Allow Client to Retrieve Multiple Validator Statuses"

### DIFF
--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
-        "//beacon-chain/core/state/stateutils:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -10,7 +10,6 @@ import (
 
 	ptypes "github.com/gogo/protobuf/types"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/keystore"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
@@ -88,6 +87,7 @@ func (v *validator) WaitForActivation(ctx context.Context) error {
 	}
 	var validatorActivatedRecords [][]byte
 	for {
+		log.Info("Waiting for validator to be activated in the beacon chain")
 		res, err := stream.Recv()
 		// If the stream is closed, we stop the loop.
 		if err == io.EOF {
@@ -100,11 +100,8 @@ func (v *validator) WaitForActivation(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("could not receive validator activation from stream: %v", err)
 		}
-		log.Info("Waiting for validator to be activated in the beacon chain")
-		activatedKeys := v.checkAndLogValidatorStatus(res.Statuses)
-
-		if len(activatedKeys) > 0 {
-			validatorActivatedRecords = activatedKeys
+		if len(res.ActivatedPublicKeys) > 0 {
+			validatorActivatedRecords = res.ActivatedPublicKeys
 			break
 		}
 	}
@@ -114,39 +111,6 @@ func (v *validator) WaitForActivation(ctx context.Context) error {
 		}).Info("Validator activated")
 	}
 	return nil
-}
-
-func (v *validator) checkAndLogValidatorStatus(validatorStatuses []*pb.ValidatorActivationResponse_Status) [][]byte {
-	var activatedKeys [][]byte
-	for _, status := range validatorStatuses {
-		if status.Status.Status == pb.ValidatorStatus_ACTIVE {
-			activatedKeys = append(activatedKeys, status.PublicKey)
-		}
-		if status.Status.DepositInclusionSlot == 0 {
-			log.WithFields(logrus.Fields{
-				"PublicKey": fmt.Sprintf("%#x", bytesutil.Trunc(status.PublicKey)),
-				"Status":    fmt.Sprintf("%s", status.Status.Status.String()),
-			}).Info("Not Deposited Yet")
-			continue
-		}
-		if status.Status.ActivationEpoch == (params.BeaconConfig().FarFutureEpoch - params.BeaconConfig().GenesisEpoch) {
-			log.WithFields(logrus.Fields{
-				"PublicKey":                 fmt.Sprintf("%#x", bytesutil.Trunc(status.PublicKey)),
-				"Status":                    status.Status.Status.String(),
-				"DepositInclusionSlot":      status.Status.DepositInclusionSlot,
-				"PositionInActivationQueue": status.Status.PositionInActivationQueue,
-			}).Info("Waiting to be Activated")
-			continue
-		}
-		log.WithFields(logrus.Fields{
-			"PublicKey":                 fmt.Sprintf("%#x", bytesutil.Trunc(status.PublicKey)),
-			"Status":                    status.Status.Status.String(),
-			"DepositInclusionSlot":      status.Status.DepositInclusionSlot,
-			"ActivationEpoch":           status.Status.ActivationEpoch,
-			"PositionInActivationQueue": status.Status.PositionInActivationQueue,
-		}).Info("Validator Status")
-	}
-	return activatedKeys
 }
 
 // CanonicalHeadSlot returns the slot of canonical block currently found in the


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#2474. The PR causes a fatal error: time="2019-05-03 20:00:54" level=fatal msg="Could not wait for validator activation: could not receive validator activation from stream: rpc error: code = Unknown desc = could not decode deposit input: ssz decode failed: decode error: failed to decode field of slice: can only read 0 bytes while expected to read 4 bytes for output type ethereum_beacon_p2p_v1.DepositInput" prefix=validator