### PR TITLE
Do Not Throw Error in Fetching Deposit By Pubkey

### DIFF
--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -216,10 +216,7 @@ func (vs *ValidatorServer) ValidatorStatus(
 		return nil, fmt.Errorf("could not fetch beacon state: %v", err)
 	}
 
-	_, eth1BlockNumBigInt, err := vs.beaconDB.DepositByPubkey(ctx, req.PublicKey)
-	if err != nil {
-		return nil, err
-	}
+	_, eth1BlockNumBigInt := vs.beaconDB.DepositByPubkey(ctx, req.PublicKey)
 	if eth1BlockNumBigInt == nil {
 		return &pb.ValidatorStatusResponse{
 			Status:                 pb.ValidatorStatus_UNKNOWN_STATUS,
@@ -300,10 +297,7 @@ func (vs *ValidatorServer) MultipleValidatorStatus(
 			PublicKey: key,
 			Status:    &pb.ValidatorStatusResponse{},
 		}
-		dep, eth1BlockNumBigInt, err := vs.beaconDB.DepositByPubkey(ctx, key)
-		if err != nil {
-			return activeValidatorExists, nil, err
-		}
+		dep, eth1BlockNumBigInt := vs.beaconDB.DepositByPubkey(ctx, key)
 		if eth1BlockNumBigInt == nil {
 			statusResponses[i].Status = &pb.ValidatorStatusResponse{
 				Status:                 pb.ValidatorStatus_UNKNOWN_STATUS,
@@ -352,10 +346,7 @@ func (vs *ValidatorServer) MultipleValidatorStatus(
 		}
 
 		lastValidator := beaconState.ValidatorRegistry[lastValidatorIndex]
-		lastValidatorDeposit, _, err := vs.beaconDB.DepositByPubkey(ctx, lastValidator.Pubkey)
-		if err != nil {
-			return activeValidatorExists, nil, err
-		}
+		lastValidatorDeposit, _ := vs.beaconDB.DepositByPubkey(ctx, lastValidator.Pubkey)
 
 		var positionInQueue uint64
 		if dep.MerkleTreeIndex > lastValidatorDeposit.MerkleTreeIndex {


### PR DESCRIPTION
No tracking issue.

We had a problem in our code that fetches a deposit by pubkey:
```go
func (db *BeaconDB) DepositByPubkey(ctx context.Context, pubKey []byte) (*pb.Deposit, *big.Int, error) {
	ctx, span := trace.StartSpan(ctx, "BeaconDB.DepositByPubkey")
	defer span.End()
	db.depositsLock.RLock()
	defer db.depositsLock.RUnlock()

	var deposit *pb.Deposit
	var blockNum *big.Int
	for _, ctnr := range db.deposits {
		depositInput, err := helpers.DecodeDepositInput(ctnr.deposit.DepositData)
		if err != nil {
			return nil, nil, fmt.Errorf("could not decode deposit input: %v", err)
		}
		if bytes.Equal(depositInput.Pubkey, pubKey) {
			deposit = ctnr.deposit
			blockNum = ctnr.block
			break
		}
	}
	return deposit, blockNum, nil
}
```
the above will fail if there was ever a faulty deposit, but it should not.