### PR TITLE
Increase ejection to 3.175

### DIFF
--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -216,7 +216,7 @@ func DemoBeaconConfig() *BeaconChainConfig {
 	demoConfig.GenesisEpoch = demoConfig.GenesisSlot / 8
 	demoConfig.MinDepositAmount = 100
 	demoConfig.MaxDepositAmount = 3.2 * 1e9
-	demoConfig.EjectionBalance = 3.15 * 1e9
+	demoConfig.EjectionBalance = 3.175 * 1e9
 	demoConfig.SyncPollingInterval = 1 * 10 // Query nodes over the network every slot.
 	demoConfig.Eth1FollowDistance = 5
 	demoConfig.EpochsPerEth1VotingPeriod = 1


### PR DESCRIPTION
Increase proposer ejection to 3.175.
Currently set at 3.15 takes a while to reach (a day and half) considering we envision a lot of participation in the beginning, we don't want active validator size to grow become untenable