### PR TITLE
Don't Log Old Peers

### DIFF
--- a/beacon-chain/sync/querier.go
+++ b/beacon-chain/sync/querier.go
@@ -59,6 +59,7 @@ type Querier struct {
 	chainStarted              bool
 	atGenesis                 bool
 	bestPeer                  peer.ID
+	peerMap                   map[peer.ID]uint64
 }
 
 // NewQuerierService constructs a new Sync Querier Service.
@@ -81,6 +82,7 @@ func NewQuerierService(ctx context.Context,
 		chainStarted:    false,
 		powchain:        cfg.PowChain,
 		chainStartBuf:   make(chan time.Time, 1),
+		peerMap:         make(map[peer.ID]uint64),
 	}
 }
 
@@ -181,12 +183,14 @@ func (q *Querier) run() {
 				hasReceivedResponse = true
 			}
 			response := msg.Data.(*pb.ChainHeadResponse)
-			queryLog.WithFields(logrus.Fields{
-				"peerID":      msg.Peer.Pretty(),
-				"highestSlot": response.CanonicalSlot - params.BeaconConfig().GenesisSlot,
-			}).Info("Received chain head from peer")
+			if _, ok := q.peerMap[msg.Peer]; !ok {
+				queryLog.WithFields(logrus.Fields{
+					"peerID":      msg.Peer.Pretty(),
+					"highestSlot": response.CanonicalSlot - params.BeaconConfig().GenesisSlot,
+				}).Info("Received chain head from peer")
+				q.peerMap[msg.Peer] = response.CanonicalSlot
+			}
 			if response.CanonicalSlot > q.currentHeadSlot {
-				q.currentHeadSlot = response.CanonicalSlot
 				q.bestPeer = msg.Peer
 				q.currentHeadSlot = response.CanonicalSlot
 				q.currentStateRoot = response.CanonicalStateRootHash32


### PR DESCRIPTION
When the querier runs, it logs peers again from  already whom we have received a response. This prevent relogging of those peers