### PR TITLE
Fix Error Logs in Validator Client

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -113,6 +113,8 @@ func (v *validator) WaitForActivation(ctx context.Context) error {
 			"publicKey": fmt.Sprintf("%#x", pk),
 		}).Info("Validator activated")
 	}
+	v.ticker = slotutil.GetSlotTicker(time.Unix(int64(v.genesisTime), 0), params.BeaconConfig().SecondsPerSlot)
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes error logs in validator client by setting the ticker only  after activation and not chainstart