### PR TITLE
Issue warn log on disconnecting peer instead of error

### DIFF
--- a/shared/p2p/negotiation.go
+++ b/shared/p2p/negotiation.go
@@ -43,7 +43,7 @@ func setupPeerNegotiation(h host.Host, contractAddress string, exclusions []peer
 					log.WithError(err).WithFields(logrus.Fields{
 						"peer":    conn.RemotePeer(),
 						"address": conn.RemoteMultiaddr(),
-					}).Error("Failed to open stream with newly connected peer")
+					}).Warn("Failed to open stream with newly connected peer")
 
 					log.Warn("Temporarily disabled -- not disconnecting peer. See https://github.com/prysmaticlabs/prysm/issues/2408")
 					//	if err := h.Network().ClosePeer(conn.RemotePeer()); err != nil {


### PR DESCRIPTION
Part of #1586, this gives a better UX to the the user that a warning occurred instead of a scary error log which makes it seem as if the node died or failed when disconnecting a peer