### PR TITLE
Add GCP test configuration and p2p-host-ip flag

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -56,6 +56,7 @@ func main() {
 		cmd.BootstrapNode,
 		cmd.RelayNode,
 		cmd.P2PPort,
+		cmd.P2PHost,
 		cmd.DataDirFlag,
 		cmd.VerbosityFlag,
 		cmd.EnableTracingFlag,

--- a/beacon-chain/node/p2p_config.go
+++ b/beacon-chain/node/p2p_config.go
@@ -41,6 +41,7 @@ func configureP2P(ctx *cli.Context) (*p2p.Server, error) {
 		NoDiscovery:            ctx.GlobalBool(cmd.NoDiscovery.Name),
 		BootstrapNodeAddr:      ctx.GlobalString(cmd.BootstrapNode.Name),
 		RelayNodeAddr:          ctx.GlobalString(cmd.RelayNode.Name),
+		HostAddress:            ctx.GlobalString(cmd.P2PHost.Name),
 		Port:                   ctx.GlobalInt(cmd.P2PPort.Name),
 		DepositContractAddress: contractAddress,
 	})

--- a/scripts/gcp_startup_script.sh
+++ b/scripts/gcp_startup_script.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+: '
+# *** Instructions ***
+
+# Build beacon chain
+bazel build //beacon-chain
+
+# Tar the binary
+tar czvf /tmp/beacon-chain.tar.gz --directory=bazel-bin/beacon-chain/$(echo `uname` | tr '[A-Z]' '[a-z]')_amd64_stripped beacon-chain
+
+# Copy to cloud storage
+gsutil cp /tmp/beacon-chain.tar.gz gs://prysmaticlabs/beacon-chain-deployment.tar.gz
+
+# Deploy template instance
+gcloud compute instance-templates create beacon-chain \
+    --project=prysmaticlabs \
+    --image-family=debian-9 \
+    --image-project=debian-cloud \
+    --machine-type=g1-small \
+    --preemptible \
+    --scopes userinfo-email,cloud-platform \
+    --metadata app-location=gs://prysmaticlabs/beacon-chain-deployment.tar.gz \
+    --metadata-from-file startup-script=scripts/gcp_startup_script.sh \
+    --tags beacon-chain
+
+# Navigate to https://console.cloud.google.com/compute/instanceTemplates/list?project=prysmaticlabs
+# and create a new instance group with the template.
+'
+
+
+
+set -ex
+
+# Talk to the metadata server to get the project id and location of application binary.
+PROJECTID=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
+DEPLOY_LOCATION=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/attributes/app-location" -H "Metadata-Flavor: Google")
+EXTERNAL_IP=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip" -H "Metadata-Flavor: Google")
+
+# Install logging monitor. The monitor will automatically pickup logs send to
+# syslog.
+curl -s "https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh" | bash
+service google-fluentd restart &
+
+# Install dependencies from apt
+apt-get update
+apt-get install -yq ca-certificates supervisor
+
+# Get the application tar from the GCS bucket.
+gsutil cp $DEPLOY_LOCATION /app.tar
+mkdir -p /app
+tar xvzf /app.tar -C /app
+chmod +x /app/beacon-chain
+
+# Create a goapp user. The application will run as this user.
+getent passwd goapp || useradd -m -d /home/goapp goapp
+chown -R goapp:goapp /app
+
+# Configure supervisor to run the Go app.
+cat >/etc/supervisor/conf.d/goapp.conf << EOF
+[program:goapp]
+directory=/app
+command=/app/beacon-chain --p2p-host-ip=${EXTERNAL_IP} --clear-db
+autostart=true
+autorestart=true
+user=goapp
+environment=HOME="/home/goapp",USER="goapp"
+stdout_logfile=syslog
+stderr_logfile=syslog
+EOF
+
+supervisorctl reread
+supervisorctl update
+
+# Application should now be running under supervisor

--- a/scripts/gcp_startup_script.sh
+++ b/scripts/gcp_startup_script.sh
@@ -11,7 +11,7 @@ tar czvf /tmp/beacon-chain.tar.gz --directory=bazel-bin/beacon-chain/linux_amd64
 # Copy to cloud storage
 gsutil cp /tmp/beacon-chain.tar.gz gs://prysmaticlabs/beacon-chain-deployment.tar.gz
 
-# Deploy template instance
+# Create template instance
 gcloud compute instance-templates create beacon-chain \
     --project=prysmaticlabs \
     --image-family=debian-9 \

--- a/scripts/gcp_startup_script.sh
+++ b/scripts/gcp_startup_script.sh
@@ -2,11 +2,11 @@
 : '
 # *** Instructions ***
 
-# Build beacon chain
-bazel build //beacon-chain
+# Build beacon chain for linux
+bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //beacon-chain
 
 # Tar the binary
-tar czvf /tmp/beacon-chain.tar.gz --directory=bazel-bin/beacon-chain/$(echo `uname` | tr '[A-Z]' '[a-z]')_amd64_stripped beacon-chain
+tar czvf /tmp/beacon-chain.tar.gz --directory=bazel-bin/beacon-chain/linux_amd64_stripped beacon-chain
 
 # Copy to cloud storage
 gsutil cp /tmp/beacon-chain.tar.gz gs://prysmaticlabs/beacon-chain-deployment.tar.gz

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -72,6 +72,12 @@ var (
 		Usage: "The port used by libp2p.",
 		Value: 12000,
 	}
+	// P2PHost defines the host IP to be used by libp2p.
+	P2PHost = cli.StringFlag{
+		Name: "p2p-host-ip",
+		Usage: "The IP address advertised by libp2p. This may be used to advertise an external IP.",
+		Value: "",
+	}
 	// ClearDB tells the beacon node to remove any previously stored data at the data directory.
 	ClearDB = cli.BoolFlag{
 		Name:  "clear-db",

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -74,7 +74,7 @@ var (
 	}
 	// P2PHost defines the host IP to be used by libp2p.
 	P2PHost = cli.StringFlag{
-		Name: "p2p-host-ip",
+		Name:  "p2p-host-ip",
 		Usage: "The IP address advertised by libp2p. This may be used to advertise an external IP.",
 		Value: "",
 	}


### PR DESCRIPTION
`--p2p-host-ip` flag was necessary to broadcast an external IP address.

`scripts/gcp_startup_script.sh` has instructions on how to create a GCP binary and instance template. 