### PR TITLE
Canonical Blocks for Batch Block Request

### DIFF
--- a/beacon-chain/blockchain/block_processing.go
+++ b/beacon-chain/blockchain/block_processing.go
@@ -27,6 +27,7 @@ type BlockReceiver interface {
 	CanonicalBlockFeed() *event.Feed
 	ReceiveBlock(ctx context.Context, block *pb.BeaconBlock) (*pb.BeaconState, error)
 	IsCanonical(slot uint64, hash []byte) bool
+	CanonicalBlock(slot uint64) (*pb.BeaconBlock, error)
 	InsertsCanonical(slot uint64, hash []byte)
 	RecentCanonicalRoots(count uint64) []*pbrpc.BlockRoot
 }

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/powchain"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	pbrpc "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"
@@ -236,6 +237,18 @@ func (c *ChainService) IsCanonical(slot uint64, hash []byte) bool {
 		return bytes.Equal(canonicalHash, hash)
 	}
 	return false
+}
+
+// CanonicalBlock returns canonical block of a given slot, it returns nil
+// if there's no canonical block saved of a given slot.
+func (c *ChainService) CanonicalBlock(slot uint64) (*pb.BeaconBlock, error) {
+	c.canonicalBlocksLock.RLock()
+	defer c.canonicalBlocksLock.RUnlock()
+	root, exists := c.canonicalBlocks[slot]
+	if !exists {
+		return nil, nil
+	}
+	return c.beaconDB.Block(bytesutil.ToBytes32(root))
 }
 
 // RecentCanonicalRoots returns the latest block slot and root of the canonical block chain,

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -374,3 +374,53 @@ func TestRecentCanonicalRoots_CanFilter(t *testing.T) {
 	}
 
 }
+
+func TestCanonicalBlock_CanGet(t *testing.T) {
+	db := internal.SetupDB(t)
+	defer internal.TeardownDB(t, db)
+	service := setupBeaconChain(t, db, nil)
+
+	blk1 := &pb.BeaconBlock{Slot: 500}
+	blk1Root, err := hashutil.HashBeaconBlock(blk1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveBlock(blk1); err != nil {
+		t.Fatal(err)
+	}
+	blk2 := &pb.BeaconBlock{Slot: 600}
+	blk2Root, _ := hashutil.HashBeaconBlock(blk2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveBlock(blk2); err != nil {
+		t.Fatal(err)
+	}
+	cMap := map[uint64][]byte{
+		blk1.Slot: blk1Root[:],
+		blk2.Slot: blk2Root[:],
+		700:       {'A'},
+	}
+	service.canonicalBlocks = cMap
+	blk1Db, err := service.CanonicalBlock(blk1.Slot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(blk1, blk1Db) {
+		t.Error("block 1 don't match")
+	}
+	blk2Db, err := service.CanonicalBlock(blk2.Slot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(blk2, blk2Db) {
+		t.Error("block 2 don't match")
+	}
+	blk3Db, err := service.CanonicalBlock(999)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if blk3Db != nil {
+		t.Error("block 3 is suppose to be nil")
+	}
+}

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -117,6 +117,10 @@ func (m mockChainService) RecentCanonicalRoots(count uint64) []*pbrpc.BlockRoot 
 	return nil
 }
 
+func (m *mockChainService) CanonicalBlock(slot uint64) (*pb.BeaconBlock, error) {
+	return nil, nil
+}
+
 func newMockChainService() *mockChainService {
 	return &mockChainService{
 		blockFeed:            new(event.Feed),

--- a/beacon-chain/sync/regular_sync.go
+++ b/beacon-chain/sync/regular_sync.go
@@ -557,13 +557,14 @@ func (rs *RegularSync) handleBatchedBlockRequest(msg p2p.Message) error {
 
 	response := make([]*pb.BeaconBlock, 0, blockRange)
 	for i := startSlot; i <= endSlot; i++ {
-		retBlock, err := rs.db.BlockBySlot(ctx, i)
+		retBlock, err := rs.chainService.CanonicalBlock(i)
 		if err != nil {
-			log.Errorf("Unable to retrieve block from db %v", err)
+			log.Errorf("Unable to retrieve canonical block %v", err)
 			continue
 		}
 		if retBlock == nil {
-			log.Debug("Block does not exist in db")
+			log.WithField("slot", i).
+				Debug("Canonical block does not exist")
 			continue
 		}
 		response = append(response, retBlock)

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -96,7 +96,7 @@ func (ms *mockChainService) IsCanonical(slot uint64, hash []byte) bool {
 	return true
 }
 
-func (m *mockChainService) CanonicalBlock(slot uint64) (*pb.BeaconBlock, error) {
+func (ms *mockChainService) CanonicalBlock(slot uint64) (*pb.BeaconBlock, error) {
 	return nil, nil
 }
 

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -96,6 +96,10 @@ func (ms *mockChainService) IsCanonical(slot uint64, hash []byte) bool {
 	return true
 }
 
+func (m *mockChainService) CanonicalBlock(slot uint64) (*pb.BeaconBlock, error) {
+	return nil, nil
+}
+
 func (ms *mockChainService) RecentCanonicalRoots(count uint64) []*pbrpc.BlockRoot {
 	return nil
 }


### PR DESCRIPTION
This PR handles return of canonical blocks (ONLY) for batch block request in regular sync.
Previously we would return any blocks of a saved slot which could include forked blocks