### PR TITLE
Use Single Code Path for Receiving Blocks and Fork Choice

### DIFF
--- a/beacon-chain/blockchain/block_processing.go
+++ b/beacon-chain/blockchain/block_processing.go
@@ -28,7 +28,6 @@ type BlockReceiver interface {
 	ReceiveBlock(ctx context.Context, block *pb.BeaconBlock) (*pb.BeaconState, error)
 	IsCanonical(slot uint64, hash []byte) bool
 	CanonicalBlock(slot uint64) (*pb.BeaconBlock, error)
-	InsertsCanonical(slot uint64, hash []byte)
 	RecentCanonicalRoots(count uint64) []*pbrpc.BlockRoot
 }
 

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -280,11 +280,3 @@ func (c *ChainService) RecentCanonicalRoots(count uint64) []*pbrpc.BlockRoot {
 	}
 	return blockRoots
 }
-
-// InsertsCanonical inserts a canonical block hash to its corresponding slot.
-// This is used for testing purpose.
-func (c *ChainService) InsertsCanonical(slot uint64, hash []byte) {
-	c.canonicalBlocksLock.Lock()
-	defer c.canonicalBlocksLock.Unlock()
-	c.canonicalBlocks[slot] = hash
-}

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -92,6 +92,8 @@ func (ps *ProposerServer) ProposeBlock(ctx context.Context, blk *pbp2p.BeaconBlo
 	if err := ps.beaconDB.SaveHistoricalState(ctx, beaconState); err != nil {
 		log.Errorf("Could not save new historical state: %v", err)
 	}
+
+	ps.chainService.InsertsCanonical(blk.Slot, h[:])
 	return &pb.ProposeResponse{BlockRootHash32: h[:]}, nil
 }
 

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -36,6 +36,7 @@ func init() {
 type chainService interface {
 	StateInitializedFeed() *event.Feed
 	blockchain.BlockReceiver
+	blockchain.ForkChoice
 }
 
 type operationService interface {

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -109,10 +109,6 @@ func (m mockChainService) IsCanonical(slot uint64, hash []byte) bool {
 	return bytes.Equal(m.canonicalBlocks[slot], hash)
 }
 
-func (m mockChainService) InsertsCanonical(slot uint64, hash []byte) {
-	m.canonicalBlocks[slot] = hash
-}
-
 func (m mockChainService) RecentCanonicalRoots(count uint64) []*pbrpc.BlockRoot {
 	return nil
 }

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -104,10 +104,6 @@ func (ms *mockChainService) RecentCanonicalRoots(count uint64) []*pbrpc.BlockRoo
 	return nil
 }
 
-func (ms mockChainService) InsertsCanonical(slot uint64, hash []byte) {
-	ms.canonicalBlocks[slot] = hash
-}
-
 type mockOperationService struct{}
 
 func (ms *mockOperationService) IncomingProcessedBlockFeed() *event.Feed {

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -52,7 +52,6 @@ type mockChainService struct {
 	sFeed           *event.Feed
 	cFeed           *event.Feed
 	db              *db.BeaconDB
-	canonicalBlocks map[uint64][]byte
 }
 
 func (ms *mockChainService) StateInitializedFeed() *event.Feed {

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -49,9 +49,9 @@ func (mp *mockP2P) Send(ctx context.Context, msg proto.Message, peerID peer.ID) 
 }
 
 type mockChainService struct {
-	sFeed           *event.Feed
-	cFeed           *event.Feed
-	db              *db.BeaconDB
+	sFeed *event.Feed
+	cFeed *event.Feed
+	db    *db.BeaconDB
 }
 
 func (ms *mockChainService) StateInitializedFeed() *event.Feed {


### PR DESCRIPTION
This PR also inserts canonical blocks when a chain head is updated via RPC into the canonical block roots map of a node