### PR TITLE
Update processEth1Data for v0.6

### DIFF
--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -664,7 +664,7 @@ func CrosslinkFromAttsData(state *pb.BeaconState, attData *pb.AttestationData) *
 		epoch = state.CurrentCrosslinks[attData.Shard].Epoch + params.BeaconConfig().MaxCrosslinkEpochs
 	}
 	return &pb.Crosslink{
-		Epoch:                       epoch,
+		Epoch: epoch,
 		CrosslinkDataRootHash32:     attData.CrosslinkDataRoot,
 		PreviousCrosslinkRootHash32: attData.PreviousCrosslinkRoot,
 	}
@@ -728,7 +728,7 @@ func WinningCrosslink(state *pb.BeaconState, shard uint64, epoch uint64) (*pb.Cr
 
 	if len(candidateCrosslinks) == 0 {
 		return &pb.Crosslink{
-			Epoch:                       params.BeaconConfig().GenesisEpoch,
+			Epoch: params.BeaconConfig().GenesisEpoch,
 			CrosslinkDataRootHash32:     params.BeaconConfig().ZeroHash[:],
 			PreviousCrosslinkRootHash32: params.BeaconConfig().ZeroHash[:],
 		}, nil

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -85,25 +85,28 @@ func CanProcessValidatorRegistry(state *pb.BeaconState) bool {
 	return true
 }
 
-// ProcessEth1Data processes eth1 block deposit roots by checking its vote count.
-// With sufficient votes (>2*EPOCHS_PER_ETH1_VOTING_PERIOD), it then
-// marks the voted Eth1 data as the latest data set.
+// ProcessEth1Data processes eth1 block deposit roots by checking how many times
+// state.eth1_data_votes contains body.eth1_data.
+// With sufficient number of times (>2*SLOTS_PER_ETH1_VOTING_PERIOD), it then
+// marks the body Eth1 data as the latest data set.
 //
-// Official spec definition:
-//     if eth1_data_vote.vote_count * 2 > EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH for
-//       some eth1_data_vote in state.eth1_data_votes.
-//       (ie. more than half the votes in this voting period were for that value)
-//       Set state.latest_eth1_data = eth1_data_vote.eth1_data.
-//		 Set state.eth1_data_votes = [].
-//
-func ProcessEth1Data(state *pb.BeaconState) *pb.BeaconState {
+// Spec pseudocode definition:
+// def process_eth1_data(state: BeaconState, body: BeaconBlockBody) -> None:
+//     state.eth1_data_votes.append(body.eth1_data)
+//     if state.eth1_data_votes.count(body.eth1_data) * 2 > SLOTS_PER_ETH1_VOTING_PERIOD:
+//         state.latest_eth1_data = body.eth1_data
+func ProcessEth1Data(state *pb.BeaconState, body *pb.BeaconBlockBody) *pb.BeaconState {
+	eth1DataBlockVote := &pb.Eth1DataVote{Eth1Data: body.Eth1Data}
+	state.Eth1DataVotes = append(state.Eth1DataVotes, eth1DataBlockVote)
+	var count uint64
 	for _, eth1DataVote := range state.Eth1DataVotes {
-		if eth1DataVote.VoteCount*2 > params.BeaconConfig().SlotsPerEpoch*
-			params.BeaconConfig().EpochsPerEth1VotingPeriod {
-			state.LatestEth1Data = eth1DataVote.Eth1Data
+		if eth1DataVote.Eth1Data == body.Eth1Data {
+			count++
 		}
 	}
-	state.Eth1DataVotes = make([]*pb.Eth1DataVote, 0)
+	if count*2 > params.BeaconConfig().SlotsPerEth1VotingPeriod {
+		state.LatestEth1Data = body.Eth1Data
+	}
 	return state
 }
 

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -293,7 +293,7 @@ func TestUpdateLatestSlashedBalances_UpdatesBalances(t *testing.T) {
 			params.BeaconConfig().LatestSlashedExitLength)
 		latestSlashedExitBalances[epoch] = tt.balances
 		state := &pb.BeaconState{
-			Slot:                  tt.epoch * params.BeaconConfig().SlotsPerEpoch,
+			Slot: tt.epoch * params.BeaconConfig().SlotsPerEpoch,
 			LatestSlashedBalances: latestSlashedExitBalances}
 		newState := UpdateLatestSlashedBalances(state)
 		if newState.LatestSlashedBalances[epoch+1] !=
@@ -358,7 +358,7 @@ func TestUpdateLatestActiveIndexRoots_UpdatesActiveIndexRoots(t *testing.T) {
 	latestActiveIndexRoots := make([][]byte,
 		params.BeaconConfig().LatestActiveIndexRootsLength)
 	state := &pb.BeaconState{
-		Slot:                   epoch * params.BeaconConfig().SlotsPerEpoch,
+		Slot: epoch * params.BeaconConfig().SlotsPerEpoch,
 		LatestActiveIndexRoots: latestActiveIndexRoots}
 	newState, err := UpdateLatestActiveIndexRoots(state)
 	if err != nil {
@@ -626,7 +626,7 @@ func TestMatchAttestations_PrevEpoch(t *testing.T) {
 		blockRoots[i] = []byte{byte(i + 1)}
 	}
 	state := &pb.BeaconState{
-		Slot:                      s + e + 2,
+		Slot: s + e + 2,
 		CurrentEpochAttestations:  currentAtts,
 		PreviousEpochAttestations: prevAtts,
 		LatestBlockRoots:          blockRoots,
@@ -700,7 +700,7 @@ func TestMatchAttestations_CurrentEpoch(t *testing.T) {
 		blockRoots[i] = []byte{byte(i + 1)}
 	}
 	state := &pb.BeaconState{
-		Slot:                      s + e + 2,
+		Slot: s + e + 2,
 		CurrentEpochAttestations:  currentAtts,
 		PreviousEpochAttestations: prevAtts,
 		LatestBlockRoots:          blockRoots,
@@ -758,7 +758,7 @@ func TestCrosslinkFromAttsData_CanGetCrosslink(t *testing.T) {
 		PreviousCrosslinkRoot: []byte{'B'},
 	}
 	if !proto.Equal(CrosslinkFromAttsData(s, a), &pb.Crosslink{
-		Epoch:                       params.BeaconConfig().GenesisEpoch + params.BeaconConfig().MaxCrosslinkEpochs,
+		Epoch: params.BeaconConfig().GenesisEpoch + params.BeaconConfig().MaxCrosslinkEpochs,
 		CrosslinkDataRootHash32:     []byte{'A'},
 		PreviousCrosslinkRootHash32: []byte{'B'},
 	}) {
@@ -792,8 +792,8 @@ func TestCrosslinkAttestingIndices_CanGetIndices(t *testing.T) {
 	for i := 0; i < len(atts); i++ {
 		atts[i] = &pb.PendingAttestation{
 			Data: &pb.AttestationData{
-				Slot:                  params.BeaconConfig().GenesisSlot + uint64(i),
-				Shard:                 uint64(i + 2),
+				Slot:  params.BeaconConfig().GenesisSlot + uint64(i),
+				Shard: uint64(i + 2),
 				PreviousCrosslinkRoot: []byte{'E'},
 				TargetEpoch:           params.BeaconConfig().GenesisEpoch,
 			},
@@ -822,7 +822,7 @@ func TestCrosslinkAttestingIndices_CanGetIndices(t *testing.T) {
 		LatestActiveIndexRoots: make([][]byte, params.BeaconConfig().LatestActiveIndexRootsLength),
 	}
 	c := &pb.Crosslink{
-		Epoch:                       params.BeaconConfig().GenesisEpoch,
+		Epoch: params.BeaconConfig().GenesisEpoch,
 		PreviousCrosslinkRootHash32: []byte{'E'},
 	}
 	indices, err := CrosslinkAttestingIndices(s, c, atts)
@@ -856,14 +856,14 @@ func TestWinningCrosslink_ReturnGensisCrosslink(t *testing.T) {
 	ge := params.BeaconConfig().GenesisEpoch
 
 	state := &pb.BeaconState{
-		Slot:                      gs + e + 2,
+		Slot: gs + e + 2,
 		PreviousEpochAttestations: []*pb.PendingAttestation{},
 		LatestBlockRoots:          make([][]byte, 128),
 		CurrentCrosslinks:         []*pb.Crosslink{{Epoch: ge}},
 	}
 
 	gCrosslink := &pb.Crosslink{
-		Epoch:                       params.BeaconConfig().GenesisEpoch,
+		Epoch: params.BeaconConfig().GenesisEpoch,
 		CrosslinkDataRootHash32:     params.BeaconConfig().ZeroHash[:],
 		PreviousCrosslinkRootHash32: params.BeaconConfig().ZeroHash[:],
 	}
@@ -913,7 +913,7 @@ func TestWinningCrosslink_CanGetWinningRoot(t *testing.T) {
 	currentCrosslinks := make([]*pb.Crosslink, params.BeaconConfig().ShardCount)
 	currentCrosslinks[3] = &pb.Crosslink{Epoch: ge, CrosslinkDataRootHash32: []byte{'B'}}
 	state := &pb.BeaconState{
-		Slot:                      gs + e + 2,
+		Slot: gs + e + 2,
 		PreviousEpochAttestations: atts,
 		LatestBlockRoots:          blockRoots,
 		CurrentCrosslinks:         currentCrosslinks,
@@ -975,7 +975,7 @@ func TestProcessJustificationFinalization_CantJustifyFinalize(t *testing.T) {
 	e := params.BeaconConfig().FarFutureEpoch
 	a := params.BeaconConfig().MaxDepositAmount
 	state := &pb.BeaconState{
-		Slot:                   params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch*2,
+		Slot: params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch*2,
 		PreviousJustifiedEpoch: params.BeaconConfig().GenesisEpoch,
 		PreviousJustifiedRoot:  params.BeaconConfig().ZeroHash[:],
 		CurrentJustifiedEpoch:  params.BeaconConfig().GenesisEpoch,
@@ -1001,7 +1001,7 @@ func TestProcessJustificationFinalization_NoBlockRootCurrentEpoch(t *testing.T) 
 		blockRoots[i] = []byte{byte(i)}
 	}
 	state := &pb.BeaconState{
-		Slot:                   params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch*2,
+		Slot: params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch*2,
 		PreviousJustifiedEpoch: params.BeaconConfig().GenesisEpoch,
 		PreviousJustifiedRoot:  params.BeaconConfig().ZeroHash[:],
 		CurrentJustifiedEpoch:  params.BeaconConfig().GenesisEpoch,
@@ -1027,7 +1027,7 @@ func TestProcessJustificationFinalization_JustifyCurrentEpoch(t *testing.T) {
 		blockRoots[i] = []byte{byte(i)}
 	}
 	state := &pb.BeaconState{
-		Slot:                   params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch*2 + 1,
+		Slot: params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch*2 + 1,
 		PreviousJustifiedEpoch: params.BeaconConfig().GenesisEpoch,
 		PreviousJustifiedRoot:  params.BeaconConfig().ZeroHash[:],
 		CurrentJustifiedEpoch:  params.BeaconConfig().GenesisEpoch,
@@ -1068,7 +1068,7 @@ func TestProcessJustificationFinalization_JustifyPrevEpoch(t *testing.T) {
 		blockRoots[i] = []byte{byte(i)}
 	}
 	state := &pb.BeaconState{
-		Slot:                   params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch*2 + 1,
+		Slot: params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch*2 + 1,
 		PreviousJustifiedEpoch: params.BeaconConfig().GenesisEpoch,
 		PreviousJustifiedRoot:  params.BeaconConfig().ZeroHash[:],
 		CurrentJustifiedEpoch:  params.BeaconConfig().GenesisEpoch,

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -107,108 +107,44 @@ func TestCanProcessEth1Data_TrueOnVotingPeriods(t *testing.T) {
 	}
 }
 
-func TestProcessEth1Data_UpdatesStateAndCleans(t *testing.T) {
-	requiredVoteCount := params.BeaconConfig().EpochsPerEth1VotingPeriod *
-		params.BeaconConfig().SlotsPerEpoch
+func TestProcessEth1Data_UpdatesStateAndNoCleans(t *testing.T) {
+	requiredVoteCount := int(params.BeaconConfig().SlotsPerEth1VotingPeriod)
 	state := &pb.BeaconState{
 		Slot: 15 * params.BeaconConfig().SlotsPerEpoch,
 		LatestEth1Data: &pb.Eth1Data{
-			DepositRoot: nil,
-			BlockRoot:   nil,
-		},
-		Eth1DataVotes: []*pb.Eth1DataVote{
-			{
-				Eth1Data: &pb.Eth1Data{
-					DepositRoot: []byte{'A'},
-					BlockRoot:   []byte{'B'},
-				},
-				VoteCount: 0,
-			},
-			// DepositRoot ['B'] gets to process with sufficient vote count.
-			{
-				Eth1Data: &pb.Eth1Data{
-					DepositRoot: []byte{'C'},
-					BlockRoot:   []byte{'D'},
-				},
-				VoteCount: requiredVoteCount/2 + 1,
-			},
-			{
-				Eth1Data: &pb.Eth1Data{
-					DepositRoot: []byte{'E'},
-					BlockRoot:   []byte{'F'},
-				},
-				VoteCount: requiredVoteCount / 2,
-			},
+			DepositRoot: []byte{'C'},
+			BlockRoot:   []byte{'D'},
 		},
 	}
+	body := &pb.BeaconBlockBody{
+		Eth1Data: &pb.Eth1Data{
+			DepositRoot: []byte{'A'},
+			BlockRoot:   []byte{'B'},
+		},
+	}
+	eth1DataBlockVote := &pb.Eth1DataVote{
+		Eth1Data: body.Eth1Data,
+	}
 
-	newState := ProcessEth1Data(state)
+	for i := 0; i < requiredVoteCount/2-1; i++ {
+		state.Eth1DataVotes = append(state.Eth1DataVotes, eth1DataBlockVote)
+	}
+
+	newState := ProcessEth1Data(state, body)
 	if !bytes.Equal(newState.LatestEth1Data.DepositRoot, []byte{'C'}) {
 		t.Errorf("Incorrect DepositRoot. Wanted: %v, got: %v",
 			[]byte{'C'}, newState.LatestEth1Data.DepositRoot)
 	}
 
-	// Adding a new receipt root ['D'] which should be the new processed receipt root.
-	state.Eth1DataVotes = append(state.Eth1DataVotes,
-		&pb.Eth1DataVote{
-			Eth1Data: &pb.Eth1Data{
-				DepositRoot: []byte{'G'},
-				BlockRoot:   []byte{'H'},
-			},
-			VoteCount: requiredVoteCount,
-		},
-	)
-	newState = ProcessEth1Data(state)
-	if !bytes.Equal(newState.LatestEth1Data.DepositRoot, []byte{'G'}) {
-		t.Errorf("Incorrect DepositRoot. Wanted: %v, got: %v",
-			[]byte{'G'}, newState.LatestEth1Data.DepositRoot)
-	}
+	// append 1 more eth1DataBlockVote to state.Eth1DataVotes to update state
+	newState.Eth1DataVotes = append(newState.Eth1DataVotes, eth1DataBlockVote)
 
-	if len(newState.Eth1DataVotes) != 0 {
-		t.Errorf("Failed to clean up Eth1DataVotes slice. Length: %d",
-			len(newState.Eth1DataVotes))
-	}
-}
-
-func TestProcessEth1Data_InactionSlot(t *testing.T) {
-	requiredVoteCount := params.BeaconConfig().EpochsPerEth1VotingPeriod
-	state := &pb.BeaconState{
-		Slot: 4,
-		LatestEth1Data: &pb.Eth1Data{
-			DepositRoot: []byte{'A'},
-			BlockRoot:   []byte{'B'},
-		},
-		Eth1DataVotes: []*pb.Eth1DataVote{
-			{
-				Eth1Data: &pb.Eth1Data{
-					DepositRoot: []byte{'C'},
-					BlockRoot:   []byte{'D'},
-				},
-				VoteCount: requiredVoteCount/2 + 1,
-			},
-			{
-				Eth1Data: &pb.Eth1Data{
-					DepositRoot: []byte{'E'},
-					BlockRoot:   []byte{'F'},
-				},
-				VoteCount: requiredVoteCount / 2,
-			},
-			{
-				Eth1Data: &pb.Eth1Data{
-					DepositRoot: []byte{'G'},
-					BlockRoot:   []byte{'H'},
-				},
-				VoteCount: requiredVoteCount,
-			},
-		},
-	}
-
-	// Adding a new receipt root ['D'] which should be the new processed receipt root.
-	newState := ProcessEth1Data(state)
+	newState = ProcessEth1Data(newState, body)
 	if !bytes.Equal(newState.LatestEth1Data.DepositRoot, []byte{'A'}) {
 		t.Errorf("Incorrect DepositRoot. Wanted: %v, got: %v",
 			[]byte{'A'}, newState.LatestEth1Data.DepositRoot)
 	}
+
 }
 
 func TestCanProcessValidatorRegistry_OnFarEpoch(t *testing.T) {

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -314,7 +314,7 @@ func ProcessEpoch(ctx context.Context, state *pb.BeaconState, block *pb.BeaconBl
 
 	// Process eth1 data.
 	if e.CanProcessEth1Data(state) {
-		state = e.ProcessEth1Data(state)
+		state = e.ProcessEth1Data(state, block.Body)
 	}
 
 	// Update justification and finality.


### PR DESCRIPTION

This PR updates [process_eth1_data](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#eth1-data)

Part of #2307

Description:

- Updated ProcessEth1Data in epoch_processing.go
- Modified tests for ProcessEth1Data in epoch_processing_test.go
- Changed invocation of ProcessEth1Data in transition.go
