### PR TITLE
Update Attestation Target for AttestHead

### DIFF
--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -34,6 +35,22 @@ func (as *AttesterServer) AttestHead(ctx context.Context, att *pbp2p.Attestation
 	if err := as.operationService.HandleAttestations(ctx, att); err != nil {
 		return nil, err
 	}
+
+	// Update attestation target for RPC server to run necessary fork choice.
+	// We need to retrieve the head block to get its parent root.
+	blk, err := as.beaconDB.Block(bytesutil.ToBytes32(att.Data.BeaconBlockRootHash32))
+	if err != nil {
+		return nil, err
+	}
+	attTarget := &pbp2p.AttestationTarget{
+		Slot:       att.Data.Slot,
+		BlockRoot:  att.Data.BeaconBlockRootHash32,
+		ParentRoot: blk.ParentRootHash32,
+	}
+	if err := as.beaconDB.SaveAttestationTarget(ctx, attTarget); err != nil {
+		return nil, fmt.Errorf("could not save attestation target")
+	}
+
 	as.p2p.Broadcast(ctx, &pbp2p.AttestationAnnounce{
 		Hash: h[:],
 	})


### PR DESCRIPTION
We don't update attestation target when attester calls `AttestHead`, this will cause asymmetry issue when proposer submits head block and run fork choice.

This PR updates attestation target in DB when we call `AttestHead`