### PR TITLE
Fix Attestation Verification

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -442,7 +442,7 @@ func VerifyAttestation(beaconState *pb.BeaconState, att *pb.Attestation, verifyS
 			beaconState.Slot-params.BeaconConfig().GenesisSlot,
 		)
 	}
-	if att.Data.Slot+params.BeaconConfig().SlotsPerEpoch <= beaconState.Slot {
+	if att.Data.Slot+params.BeaconConfig().SlotsPerEpoch < beaconState.Slot {
 		return fmt.Errorf(
 			"attestation slot (slot %d) + epoch length (%d) less than current beacon state slot (%d)",
 			att.Data.Slot-params.BeaconConfig().GenesisSlot,

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -119,9 +119,9 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 	beaconState.Slot++
 
 	var attsReadyForInclusion []*pbp2p.Attestation
-	for _, val := range atts {
-		if val.Data.Slot+params.BeaconConfig().MinAttestationInclusionDelay <= beaconState.Slot {
-			attsReadyForInclusion = append(attsReadyForInclusion, val)
+	for _, att := range atts {
+		if att.Data.Slot+params.BeaconConfig().MinAttestationInclusionDelay <= beaconState.Slot {
+			attsReadyForInclusion = append(attsReadyForInclusion, att)
 		}
 	}
 


### PR DESCRIPTION
To [process attestation](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#attestations), one of the assertion is defined as the following:
```python
assert attestation_slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot <= attestation_slot + SLOTS_PER_EPOCH
```
We previous had:
`if att.Data.Slot+params.BeaconConfig().SlotsPerEpoch <= beaconState.Slot`
which should have been
`if att.Data.Slot+params.BeaconConfig().SlotsPerEpoch < beaconState.Slot`