### PR TITLE
Delete Failed Pending Atts for Proposer Server

### DIFF
--- a/beacon-chain/db/attestation.go
+++ b/beacon-chain/db/attestation.go
@@ -55,7 +55,6 @@ func (db *BeaconDB) DeleteAttestation(attestation *pb.Attestation) error {
 
 	return db.update(func(tx *bolt.Tx) error {
 		a := tx.Bucket(attestationBucket)
-
 		return a.Delete(hash[:])
 	})
 }

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/sirupsen/logrus"
 )
 
 // ProposerServer defines a server implementation of the gRPC Proposer service,
@@ -128,9 +129,13 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 	validAtts := make([]*pbp2p.Attestation, 0, len(attsReadyForInclusion))
 	for _, att := range attsReadyForInclusion {
 		if err := blocks.VerifyAttestation(beaconState, att, false); err != nil {
-			log.WithError(err).WithField(
-				"slot", att.Data.Slot-params.BeaconConfig().GenesisSlot).Warn(
-				"Skipping, pending attestation failed verification")
+			log.WithError(err).WithFields(logrus.Fields{
+				"slot":     att.Data.Slot - params.BeaconConfig().GenesisSlot,
+				"headRoot": bytesutil.Trunc(att.Data.BeaconBlockRootHash32)}).Warn(
+				"Deleting failed pending attestation from DB")
+			if err := ps.beaconDB.DeleteAttestation(att); err != nil {
+				return nil, fmt.Errorf("could not delete failed attestation: %v", err)
+			}
 			continue
 		}
 		validAtts = append(validAtts, att)


### PR DESCRIPTION
It's proposer server's duty to respond valid attestations, but proposer server does not delete failed attestation as it detects them. This issue was amplified in test net where we saw attestations from 80 epochs ago were trying to get included.

`time="2019-05-07 22:15:12" level=warning msg="Skipping, pending attestation failed verification" error="expected attestation.JustifiedEpoch == state.JustifiedEpoch, received 14514 == 14571" prefix=rpc slot=116579`

As an enhancement, when proposer server detects an attestation can no longer be valid, it should just delete it from the DB