### PR TITLE
Sort list before processing batched blocks

### DIFF
--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -128,6 +128,9 @@ func TestProcessingBatchedBlocks_OK(t *testing.T) {
 			Slot: params.BeaconConfig().GenesisSlot + uint64(i),
 		}
 	}
+	// edge case: handle out of order block list. Specifically with the highest
+	// block first. This is swapping the first and last blocks in the list.
+	batchedBlocks[0], batchedBlocks[batchSize-1] = batchedBlocks[batchSize-1], batchedBlocks[0]
 
 	msg := p2p.Message{
 		Ctx: context.Background(),

--- a/beacon-chain/sync/initial-sync/sync_blocks.go
+++ b/beacon-chain/sync/initial-sync/sync_blocks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -67,6 +68,10 @@ func (s *InitialSync) processBatchedBlocks(msg p2p.Message) {
 	}
 
 	log.Debug("Processing batched block response")
+	// Sort batchBlocks in ascending order.
+	sort.Slice(batchedBlocks, func(i, j int) bool {
+		return batchedBlocks[i].Slot < batchedBlocks[j].Slot
+	})
 	for _, block := range batchedBlocks {
 		s.processBlock(ctx, block)
 	}


### PR DESCRIPTION
I believe this solves an issue where we are prematurely exiting initial sync. 