### PR TITLE
Removed unused doesParentExist

### DIFF
--- a/beacon-chain/sync/initial-sync/helpers.go
+++ b/beacon-chain/sync/initial-sync/helpers.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
@@ -31,11 +30,6 @@ func (s *InitialSync) checkBlockValidity(ctx context.Context, block *pb.BeaconBl
 	// Attestation from proposer not verified as, other nodes only store blocks not proposer
 	// attestations.
 	return nil
-}
-
-func (s *InitialSync) doesParentExist(block *pb.BeaconBlock) bool {
-	parentHash := bytesutil.ToBytes32(block.ParentRootHash32)
-	return s.db.HasBlock(parentHash)
 }
 
 // safelyHandleMessage will recover and log any panic that occurs from the


### PR DESCRIPTION
#2532 was merged with the following Travis failure:
`beacon-chain/sync/initial-sync/helpers.go:36:23: U1000: func `(*InitialSync).doesParentExist` is unused (unused)`

This PR fixed the travis failure so we can be green again :) 