### PR TITLE
Use a prysm specific DHT protocol

### DIFF
--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "@com_github_libp2p_go_libp2p_connmgr//:go_default_library",
         "@com_github_libp2p_go_libp2p_host//:go_default_library",
         "@com_github_libp2p_go_libp2p_kad_dht//:go_default_library",
+        "@com_github_libp2p_go_libp2p_kad_dht//opts:go_default_library",
         "@com_github_libp2p_go_libp2p_net//:go_default_library",
         "@com_github_libp2p_go_libp2p_peer//:go_default_library",
         "@com_github_libp2p_go_libp2p_peerstore//:go_default_library",

--- a/shared/p2p/connection_manager.go
+++ b/shared/p2p/connection_manager.go
@@ -26,7 +26,7 @@ func optionConnectionManager(maxPeers int) libp2p.Option {
 		maxPeers = 5
 	}
 	minPeers := int(math.Max(5, float64(maxPeers-5)))
-	cm := connmgr.NewConnManager(minPeers, maxPeers, 5*time.Minute)
+	cm := connmgr.NewConnManager(minPeers, maxPeers, 20*time.Second)
 
 	return libp2p.ConnectionManager(cm)
 }

--- a/shared/p2p/negotiation.go
+++ b/shared/p2p/negotiation.go
@@ -43,12 +43,9 @@ func setupPeerNegotiation(h host.Host, contractAddress string, exclusions []peer
 					log.WithError(err).WithFields(logrus.Fields{
 						"peer":    conn.RemotePeer(),
 						"address": conn.RemoteMultiaddr(),
-					}).Warn("Failed to open stream with newly connected peer")
+					}).Debug("Failed to open stream with newly connected peer")
 
-					log.Warn("Temporarily disabled -- not disconnecting peer. See https://github.com/prysmaticlabs/prysm/issues/2408")
-					//	if err := h.Network().ClosePeer(conn.RemotePeer()); err != nil {
-					//		log.WithError(err).Error("failed to disconnect peer")
-					//	}
+					h.ConnManager().TagPeer(conn.RemotePeer(), "handshake", -10000)
 					return
 				}
 				defer s.Close()
@@ -88,6 +85,9 @@ func setupPeerNegotiation(h host.Host, contractAddress string, exclusions []peer
 					if err := h.Network().ClosePeer(conn.RemotePeer()); err != nil {
 						log.WithError(err).Error("failed to disconnect peer")
 					}
+					h.ConnManager().TagPeer(conn.RemotePeer(), "ContractAddress", -5000)
+				} else {
+					h.ConnManager().TagPeer(conn.RemotePeer(), "ContractAddress", 10000)
 				}
 			}()
 		},

--- a/tools/bootnode-query/BUILD.bazel
+++ b/tools/bootnode-query/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "@com_github_gogo_protobuf//io:go_default_library",
         "@com_github_libp2p_go_libp2p//:go_default_library",
         "@com_github_libp2p_go_libp2p_host//:go_default_library",
-        "@com_github_libp2p_go_libp2p_kad_dht//opts:go_default_library",
         "@com_github_libp2p_go_libp2p_kad_dht//pb:go_default_library",
         "@com_github_libp2p_go_libp2p_net//:go_default_library",
     ],

--- a/tools/bootnode-query/main.go
+++ b/tools/bootnode-query/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/libp2p/go-libp2p-host"
 	dhtpb "github.com/libp2p/go-libp2p-kad-dht/pb"
 	"github.com/libp2p/go-libp2p-net"
-
 	"github.com/prysmaticlabs/prysm/shared/p2p"
 )
 

--- a/tools/bootnode-query/main.go
+++ b/tools/bootnode-query/main.go
@@ -13,12 +13,14 @@ import (
 
 	ggio "github.com/gogo/protobuf/io"
 	"github.com/libp2p/go-libp2p"
-	host "github.com/libp2p/go-libp2p-host"
-	dhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
+	"github.com/libp2p/go-libp2p-host"
 	dhtpb "github.com/libp2p/go-libp2p-kad-dht/pb"
-	net "github.com/libp2p/go-libp2p-net"
+	"github.com/libp2p/go-libp2p-net"
+
 	"github.com/prysmaticlabs/prysm/shared/p2p"
 )
+
+const dhtProtocol = "/prysm/0.0.0/dht"
 
 func main() {
 	if len(os.Args) == 1 {
@@ -40,9 +42,9 @@ func main() {
 		log.Fatalf("Error: Failed to create peer from string: %v", err)
 	}
 
-	s, err := h.NewStream(ctx, pi.ID, dhtopts.ProtocolDHT)
+	s, err := h.NewStream(ctx, pi.ID, dhtProtocol)
 	if err != nil {
-		log.Printf("proto = %s", dhtopts.ProtocolDHT)
+		log.Printf("proto = %s", dhtProtocol)
 		log.Fatalf("Error: Failed to create ProtocolDHT stream: %v", err)
 	}
 
@@ -66,7 +68,7 @@ func pingPeer(ctx context.Context, h host.Host, p *dhtpb.Message_Peer) error {
 		return err
 	}
 
-	s, err := h.NewStream(ctx, pi.ID, dhtopts.ProtocolDHT)
+	s, err := h.NewStream(ctx, pi.ID, dhtProtocol)
 	if err != nil {
 		return err
 	}

--- a/tools/bootnode/BUILD.bazel
+++ b/tools/bootnode/BUILD.bazel
@@ -15,6 +15,8 @@ go_library(
         "@com_github_libp2p_go_libp2p//:go_default_library",
         "@com_github_libp2p_go_libp2p_crypto//:go_default_library",
         "@com_github_libp2p_go_libp2p_kad_dht//:go_default_library",
+        "@com_github_libp2p_go_libp2p_kad_dht//opts:go_default_library",
+        "@com_github_libp2p_go_libp2p_protocol//:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
     ],
 )
@@ -22,12 +24,14 @@ go_library(
 go_image(
     name = "image",
     srcs = ["bootnode.go"],
-    importpath = "github.com/prysmaticlabs/prysm/tools/bootnode",
-    visibility = ["//visibility:private"],
-    static = "on",
-    tags = ["manual"],
     goarch = "amd64",
     goos = "linux",
+    importpath = "github.com/prysmaticlabs/prysm/tools/bootnode",
+    pure = "on",
+    race = "off",
+    static = "on",
+    tags = ["manual"],
+    visibility = ["//visibility:private"],
     deps = [
         "//shared/version:go_default_library",
         "@com_github_ipfs_go_datastore//:go_default_library",
@@ -36,10 +40,10 @@ go_image(
         "@com_github_libp2p_go_libp2p//:go_default_library",
         "@com_github_libp2p_go_libp2p_crypto//:go_default_library",
         "@com_github_libp2p_go_libp2p_kad_dht//:go_default_library",
+        "@com_github_libp2p_go_libp2p_kad_dht//opts:go_default_library",
+        "@com_github_libp2p_go_libp2p_protocol//:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
     ],
-    race = "off",
-    pure = "on",
 )
 
 container_push(


### PR DESCRIPTION
Resolves #2408 due to the connection manager penalty for peers that can't handshake.

This updated bootstrap node only supports the prysm DHT protocol instead of the default IFPS DHT protocol ID.