### PR TITLE
Fix Bitfield in Attestations

### DIFF
--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -315,6 +315,7 @@ func (a *Service) updateAttestation(ctx context.Context, headRoot [32]byte, beac
 
 		if int(committee[i]) >= len(beaconState.ValidatorRegistry) {
 			log.Errorf("Index doesn't exist in validator registry: index %d", committee[i])
+			continue
 		}
 
 		// If the attestation came from this attester. We use the slot committee to find the

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -659,3 +659,23 @@ func ToCommitteeCache(slot uint64, crosslinkCommittees []*CrosslinkCommittee) *c
 
 	return committees
 }
+
+// VerifyAttestationBitfield verifies that an attestations bitfield is valid in respect
+// to the committees at that slot.
+func VerifyAttestationBitfield(bState *pb.BeaconState, att *pb.Attestation) (bool, error) {
+	var committee []uint64
+	committees, err := CrosslinkCommitteesAtSlot(bState, att.Data.Slot, false)
+	if err != nil {
+		return false, fmt.Errorf("could not retrieve crosslink committees at slot: %v", err)
+	}
+	for _, com := range committees {
+		if com.Shard == att.Data.Shard {
+			committee = com.Committee
+			break
+		}
+	}
+	if committee == nil {
+		return false, fmt.Errorf("no committee exist for shard in the attestation")
+	}
+	return VerifyBitfield(att.AggregationBitfield, len(committee))
+}

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -155,7 +155,22 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 			}
 			continue
 		}
+		if valid, err := helpers.VerifyAttestationBitfield(beaconState, att); err != nil || !valid {
+			if err != nil {
+				log.WithError(err)
+			} else {
+				log.Error("invalid attestation bitfield")
+			}
 
+			log.WithFields(logrus.Fields{
+				"slot":     att.Data.Slot - params.BeaconConfig().GenesisSlot,
+				"headRoot": fmt.Sprintf("%#x", bytesutil.Trunc(att.Data.BeaconBlockRootHash32))}).Info(
+				"Deleting failed pending attestation from DB")
+			if err := ps.beaconDB.DeleteAttestation(att); err != nil {
+				return nil, fmt.Errorf("could not delete failed attestation: %v", err)
+			}
+			continue
+		}
 		if featureconfig.FeatureConfig().EnableCanonicalAttestationFilter {
 			canonical, err := ps.operationService.IsAttCanonical(ctx, att)
 			if err != nil {

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -389,12 +389,26 @@ func TestPendingAttestations_OK(t *testing.T) {
 		chainService:     &mockChainService{},
 		beaconDB:         db,
 	}
+
+	validators := make([]*pbp2p.Validator, 2*params.BeaconConfig().SlotsPerEpoch)
+	for i := 0; i < len(validators); i++ {
+		validators[i] = &pbp2p.Validator{
+			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+		}
+	}
+	crosslinks := make([]*pbp2p.Crosslink, 2*params.BeaconConfig().SlotsPerEpoch)
+	for i := range crosslinks {
+		crosslinks[i] = &pbp2p.Crosslink{
+			Epoch:                   params.BeaconConfig().GenesisEpoch + 1,
+			CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:],
+		}
+	}
 	beaconState := &pbp2p.BeaconState{
 		Slot: params.BeaconConfig().GenesisSlot +
 			params.BeaconConfig().SlotsPerEpoch +
 			params.BeaconConfig().MinAttestationInclusionDelay,
-		LatestCrosslinks: []*pbp2p.Crosslink{{Epoch: params.BeaconConfig().GenesisEpoch + 1,
-			CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:]}},
+		LatestCrosslinks:  crosslinks,
+		ValidatorRegistry: validators,
 	}
 	if err := db.SaveState(ctx, beaconState); err != nil {
 		t.Fatal(err)

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -57,21 +57,22 @@ func (ms *mockOperationService) PendingAttestations(_ context.Context) ([]*pb.At
 	}
 	return []*pb.Attestation{
 		{
-			AggregationBitfield: []byte("A"),
+			AggregationBitfield: []byte{0xC0},
+			Data: &pb.AttestationData{
+				Slot:                    params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch,
+				CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:],
+				Shard:                   0,
+			},
+		},
+		{
+			AggregationBitfield: []byte{0xC1},
 			Data: &pb.AttestationData{
 				Slot:                    params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch,
 				CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:],
 			},
 		},
 		{
-			AggregationBitfield: []byte("B"),
-			Data: &pb.AttestationData{
-				Slot:                    params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch,
-				CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:],
-			},
-		},
-		{
-			AggregationBitfield: []byte("C"),
+			AggregationBitfield: []byte{0xC2},
 			Data: &pb.AttestationData{
 				Slot:                    params.BeaconConfig().GenesisSlot + params.BeaconConfig().SlotsPerEpoch,
 				CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:],

--- a/shared/bitutil/bit.go
+++ b/shared/bitutil/bit.go
@@ -8,7 +8,11 @@ import (
 )
 
 // SetBitfield takes an index and returns bitfield with the index flipped.
-func SetBitfield(index int, committeeLength int) []byte {
+func SetBitfield(index int, committeeLength int) ([]byte, error) {
+	if index >= committeeLength {
+		return nil, fmt.Errorf("invalid index, as index %d is more than"+
+			" or equal to committee length %d", index, committeeLength)
+	}
 	chunkLocation := index / 8
 	indexLocation := mathutil.PowerOf2(uint64(7 - (index % 8)))
 	var bitfield []byte
@@ -18,11 +22,11 @@ func SetBitfield(index int, committeeLength int) []byte {
 	}
 	bitfield = append(bitfield, byte(indexLocation))
 
-	for len(bitfield) < committeeLength {
+	for len(bitfield) < mathutil.CeilDiv8(committeeLength) {
 		bitfield = append(bitfield, byte(0))
 	}
 
-	return bitfield
+	return bitfield, nil
 }
 
 // CheckBit checks if a bit in a bit field (small endian) is one.

--- a/shared/bitutil/bit_test.go
+++ b/shared/bitutil/bit_test.go
@@ -3,8 +3,6 @@ package bitutil
 import (
 	"bytes"
 	"testing"
-
-	"github.com/prysmaticlabs/prysm/shared/mathutil"
 )
 
 func TestCheckBit(t *testing.T) {
@@ -82,8 +80,12 @@ func TestBitSet(t *testing.T) {
 		{a: 100, b: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8}},
 	}
 	for _, tt := range tests {
-		if !bytes.Equal(SetBitfield(tt.a, mathutil.CeilDiv8(len(tt.b))), tt.b) {
-			t.Errorf("SetBitfield(%v) = %d, want = %v", tt.a, SetBitfield(tt.a, mathutil.CeilDiv8(len(tt.b))), tt.b)
+		bField, err := SetBitfield(tt.a, len(tt.b)*8)
+		if err != nil {
+			t.Error(err)
+		}
+		if !bytes.Equal(bField, tt.b) {
+			t.Errorf("SetBitfield(%v) = %d, want = %v", tt.a, bField, tt.b)
 		}
 	}
 }
@@ -94,14 +96,18 @@ func TestSetBitfield_LargerCommitteesThanIndex(t *testing.T) {
 		b []byte
 		c int
 	}{
-		{a: 300, b: []byte{128}, c: 40},    //10000000
+		{a: 0, b: []byte{128}, c: 2},       //10000000
 		{a: 10000, b: []byte{64}, c: 2000}, //01000000
 		{a: 800, b: []byte{4}, c: 120},     //00000100
 		{a: 809, b: []byte{0, 32}, c: 130}, //00000000 00100000
 		{a: 100, b: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8}, c: 14},
 	}
 	for _, tt := range tests {
-		bfield := SetBitfield(tt.a, tt.c)
+		bfield, err := SetBitfield(tt.a, tt.c)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
 
 		if len(bfield) != tt.c {
 			t.Errorf("Length of bitfield doesnt match the inputted committee size, got: %d but expected: %d", len(bfield), tt.c)

--- a/shared/bitutil/bit_test.go
+++ b/shared/bitutil/bit_test.go
@@ -117,21 +117,3 @@ func TestSetBitfield_LargerCommitteesThanIndex(t *testing.T) {
 
 	}
 }
-
-func TestStuff(t *testing.T) {
-	for i := 0; i < 2000; i++ {
-		bfield, err := SetBitfield(i, 100)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-		bitset, err := CheckBit(bfield, i)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-		if !bitset {
-			t.Error("Bit not set")
-		}
-	}
-}

--- a/shared/bitutil/bit_test.go
+++ b/shared/bitutil/bit_test.go
@@ -3,6 +3,8 @@ package bitutil
 import (
 	"bytes"
 	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/mathutil"
 )
 
 func TestCheckBit(t *testing.T) {
@@ -97,10 +99,10 @@ func TestSetBitfield_LargerCommitteesThanIndex(t *testing.T) {
 		c int
 	}{
 		{a: 0, b: []byte{128}, c: 2},       //10000000
-		{a: 10000, b: []byte{64}, c: 2000}, //01000000
-		{a: 800, b: []byte{4}, c: 120},     //00000100
-		{a: 809, b: []byte{0, 32}, c: 130}, //00000000 00100000
-		{a: 100, b: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8}, c: 14},
+		{a: 100, b: []byte{64}, c: 2000},   //01000000
+		{a: 119, b: []byte{4}, c: 120},     //00000100
+		{a: 129, b: []byte{0, 32}, c: 130}, //00000000 00100000
+		{a: 12, b: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8}, c: 14},
 	}
 	for _, tt := range tests {
 		bfield, err := SetBitfield(tt.a, tt.c)
@@ -109,9 +111,27 @@ func TestSetBitfield_LargerCommitteesThanIndex(t *testing.T) {
 			continue
 		}
 
-		if len(bfield) != tt.c {
+		if len(bfield) != mathutil.CeilDiv8(tt.c) {
 			t.Errorf("Length of bitfield doesnt match the inputted committee size, got: %d but expected: %d", len(bfield), tt.c)
 		}
 
+	}
+}
+
+func TestStuff(t *testing.T) {
+	for i := 0; i < 2000; i++ {
+		bfield, err := SetBitfield(i, 100)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		bitset, err := CheckBit(bfield, i)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if !bitset {
+			t.Error("Bit not set")
+		}
 	}
 }

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -54,7 +54,6 @@ go_test(
         "//shared/bitutil:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/keystore:go_default_library",
-        "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
         "//validator/accounts:go_default_library",

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -122,7 +122,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, idx stri
 		}
 	}
 
-	aggregationBitfield, err := bitutil.SetBitfield(indexInCommittee, committeeLength)
+	aggregationBitfield, err := bitutil.SetBitfield(indexInCommittee, len(assignment.Committee))
 	if err != nil {
 		log.Errorf("Could not set bitfield: %v", err)
 	}

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -51,6 +51,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, idx stri
 	for _, amnt := range v.assignments.Assignment {
 		if bytes.Equal(pubKey, amnt.PublicKey) {
 			assignment = amnt
+			break
 		}
 	}
 	idxReq := &pb.ValidatorIndexRequest{
@@ -121,7 +122,10 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, idx stri
 		}
 	}
 
-	aggregationBitfield := bitutil.SetBitfield(indexInCommittee, committeeLength)
+	aggregationBitfield, err := bitutil.SetBitfield(indexInCommittee, committeeLength)
+	if err != nil {
+		log.Errorf("Could not set bitfield: %v", err)
+	}
 	attestation.AggregationBitfield = aggregationBitfield
 
 	// TODO(#1366): Use BLS to generate an aggregate signature.

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -13,7 +13,6 @@ import (
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/prysmaticlabs/prysm/shared/bitutil"
-	"github.com/prysmaticlabs/prysm/shared/mathutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"
@@ -149,7 +148,7 @@ func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
 		CustodyBitfield:    make([]byte, (len(committee)+7)/8),
 		AggregateSignature: []byte("signed"),
 	}
-	aggregationBitfield, err := bitutil.SetBitfield(4, mathutil.CeilDiv8(len(committee)))
+	aggregationBitfield, err := bitutil.SetBitfield(4, len(committee))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -149,7 +149,10 @@ func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
 		CustodyBitfield:    make([]byte, (len(committee)+7)/8),
 		AggregateSignature: []byte("signed"),
 	}
-	aggregationBitfield := bitutil.SetBitfield(4, mathutil.CeilDiv8(len(committee)))
+	aggregationBitfield, err := bitutil.SetBitfield(4, mathutil.CeilDiv8(len(committee)))
+	if err != nil {
+		t.Fatal(err)
+	}
 	expectedAttestation.AggregationBitfield = aggregationBitfield
 	if !proto.Equal(generatedAttestation, expectedAttestation) {
 		t.Errorf("Incorrectly attested head, wanted %v, received %v", expectedAttestation, generatedAttestation)


### PR DESCRIPTION
- [x] Validate an attestation's bitfield before packaging it.
- [x] Fix bug in set bitfield where we didnt divide the committee size, when generating new bitfields.
- [x] Fix tests