### PR TITLE
Do not panic when the beacon node is shut down.

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -343,8 +343,10 @@ func (w *Web3Service) run(done <-chan struct{}) {
 		case w.runError = <-headSub.Err():
 			log.Debugf("Unsubscribed to head events, exiting goroutine: %v", w.runError)
 			return
-		case header := <-w.headerChan:
-			w.processSubscribedHeaders(header)
+		case header, ok := <-w.headerChan:
+			if ok {
+				w.processSubscribedHeaders(header)
+			}
 		case <-ticker.C:
 			w.handleDelayTicker()
 		}


### PR DESCRIPTION
Resolves #2282

---

This fixes a panic when the beacon node is shut down.

The panic was because there was no check for the channel being closed when receiving from it.  This is now checked for using the appropriate receive semantics as per https://golang.org/ref/spec#Receive_operator

I considered logging if the channel was closed (the !ok branch) but ultimately decided the information would not be a lot of use as the only time headerChan should be closed is during shutdown.  If there is a concern this could be silently swallowing errors I could log in this branch as an error, but in that case should also add a flag to Web3Service that would be set in Stop() to avoid reporting said errors when shutting down cleanly.

Unfortunately no easy way to add tests for this change.