### PR TITLE
Update deposits processing v0.6  - Draft PR

### DIFF
--- a/beacon-chain/blockchain/block_processing_test.go
+++ b/beacon-chain/blockchain/block_processing_test.go
@@ -58,7 +58,7 @@ func TestReceiveBlock_FaultyPOWChain(t *testing.T) {
 	chainService := setupBeaconChain(t, db, nil)
 	unixTime := uint64(time.Now().Unix())
 	deposits, _ := setupInitialDeposits(t, 100)
-	if err := db.InitializeState(context.Background(), unixTime, deposits, &pb.Eth1Data{}); err != nil {
+	if err := db.InitializeState(context.Background(), unixTime, deposits, &pb.Eth1Data{},); err != nil {
 		t.Fatalf("Could not initialize beacon state to disk: %v", err)
 	}
 

--- a/beacon-chain/blockchain/block_processing_test.go
+++ b/beacon-chain/blockchain/block_processing_test.go
@@ -58,7 +58,7 @@ func TestReceiveBlock_FaultyPOWChain(t *testing.T) {
 	chainService := setupBeaconChain(t, db, nil)
 	unixTime := uint64(time.Now().Unix())
 	deposits, _ := setupInitialDeposits(t, 100)
-	if err := db.InitializeState(context.Background(), unixTime, deposits, &pb.Eth1Data{},); err != nil {
+	if err := db.InitializeState(context.Background(), unixTime, deposits, &pb.Eth1Data{}); err != nil {
 		t.Fatalf("Could not initialize beacon state to disk: %v", err)
 	}
 

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
-        "//beacon-chain/core/state/stateutils:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/utils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -679,13 +679,20 @@ func ProcessValidatorDeposits(
 			params.BeaconConfig().MaxDeposits,
 		)
 	}
-	var err error
+	
 	for idx, deposit := range deposits {
-		if err = verifyDeposit(beaconState, deposit); err != nil {
+		depositData := deposit.DepositData
+		if _, err := helpers.DecodeDepositInput(depositData);err != nil {
+			return nil, fmt.Errorf("could not decode deposit input: %v", err)
+		}
+		if _, _, err := helpers.DecodeDepositAmountAndTimeStamp(depositData);err != nil {
+			return nil, fmt.Errorf("could not decode deposit value and timestamp: %v", err)
+		}
+		if err := verifyDeposit(beaconState, deposit); err != nil {
 			return nil, fmt.Errorf("could not verify deposit #%d: %v", idx, err)
 		}
 		// We then mutate the beacon state with the verified validator deposit.
-		beaconState, err = v.ProcessDeposit(
+		beaconState, err := v.ProcessDeposit(
 			beaconState,
 			deposit,
 		)

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -681,11 +681,6 @@ func ProcessValidatorDeposits(
 	}
 	var err error
 	for idx, deposit := range deposits {
-		if err != nil {
-			beaconState = processInvalidDeposit(beaconState)
-			log.Errorf("could not decode deposit input: %v", err)
-			continue
-		}
 		if err = verifyDeposit(beaconState, deposit); err != nil {
 			return nil, fmt.Errorf("could not verify deposit #%d: %v", idx, err)
 		}

--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/epoch:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
-        "//beacon-chain/core/state/stateutils:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
+
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
@@ -149,25 +149,8 @@ func GenesisBeaconState(
 
 	// Process initial deposits.
 	var err error
-	validatorMap := stateutils.ValidatorIndexMap(state)
 	for _, deposit := range genesisValidatorDeposits {
-		depositData := deposit.DepositData
-		depositInput, err := helpers.DecodeDepositInput(depositData)
-		if err != nil {
-			return nil, fmt.Errorf("could not decode deposit input: %v", err)
-		}
-		value, _, err := helpers.DecodeDepositAmountAndTimeStamp(depositData)
-		if err != nil {
-			return nil, fmt.Errorf("could not decode deposit value and timestamp: %v", err)
-		}
-		state, err = v.ProcessDeposit(
-			state,
-			validatorMap,
-			depositInput.Pubkey,
-			value,
-			depositInput.ProofOfPossession,
-			depositInput.WithdrawalCredentialsHash32,
-		)
+		state, err = v.ProcessDeposit(state, deposit)
 		if err != nil {
 			return nil, fmt.Errorf("could not process validator deposit: %v", err)
 		}

--- a/beacon-chain/core/validators/BUILD.bazel
+++ b/beacon-chain/core/validators/BUILD.bazel
@@ -8,9 +8,10 @@ go_library(
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
-        "//shared/bytesutil:go_default_library",
+        "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/sliceutil:go_default_library",
+        "//shared/trieutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
@@ -21,7 +22,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
-        "//beacon-chain/core/state/stateutils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bitutil:go_default_library",
         "//shared/params:go_default_library",

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -169,13 +169,8 @@ func ProcessDeposit(state *pb.BeaconState, deposit *pb.Deposit) (*pb.BeaconState
   
 	pubKey := deposit.Data.Pubkey
 	amount := deposit.Data.Amount
-	validatorsPubKeys := make([][]byte, 0, len(state.ValidatorRegistry))
-	for _, v := range state.ValidatorRegistry {
-		validatorsPubKeys = append(validatorsPubKeys, v.Pubkey)
-	}
-  
-	for index, pk := range validatorsPubKeys {
-		if bytes.Equal(pk, pubKey) {
+	for index, v := range state.ValidatorRegistry {
+		if bytes.Equal(v.Pubkey, pubKey) {
 			return helpers.IncreaseBalance(state, uint64(index), amount), nil
 		} 
 	}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
@@ -146,17 +145,10 @@ func AttestingValidatorIndices(
 //         index = validator_pubkeys.index(pubkey)
 //         increase_balance(state, index, amount)
 func ProcessDeposit(state *pb.BeaconState, deposit *pb.Deposit) (*pb.BeaconState, error) {
-	depositDataBuf32, err := hashutil.HashProto(deposit.Data)
-	if err != nil {
-		return  nil, fmt.Errorf("Hashing of deposit.Data failed")
-	}
-  
-	depositDataBuf := make([]byte, 0, len(depositDataBuf32))
-	copy(depositDataBuf, depositDataBuf32[:])
-  
+	
 	if !trieutil.VerifyMerkleProof(
 		state.LatestEth1Data.DepositRoot,
-		depositDataBuf,
+		deposit.Data,
 		int(deposit.Index),
 		deposit.Proof) {
 		return nil, fmt.Errorf("merkle proof verification failed")


### PR DESCRIPTION
This PR updates [deposits processing](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#deposits)

Changed:
1)Updated ProcessDeposit  in validator.go
2)Added tests for ProcessDeposit in validator_test.go:  
TestProcessDeposit_DepositIndexNotMatchStateDepositIndex
TestProcessDeposit_DepositPublicKeyNotInValidatorsPubKeys
TestProcessDeposit_DepositPublicKeyInValidatorsPubKeys

[Part of] #2307

---
Need help

Issues:

1.[verify_merkle_branch](https://github.com/prysmaticlabs/prysm/blob/c33575d51dc4ee1ac5fb830af16c467b950590bd/beacon-chain/core/validators/validator.go#L154) in spec  does not match [VerifyMerkleProof implementation](https://github.com/prysmaticlabs/prysm/blob/spec-v0.6/shared/trieutil/sparse_merkle.go#L49)

2. [bls_verify](https://github.com/prysmaticlabs/prysm/blob/c33575d51dc4ee1ac5fb830af16c467b950590bd/beacon-chain/core/validators/validator.go#L191) in spec does not match [bls.Verify implementation](https://github.com/prysmaticlabs/prysm/blob/spec-v0.6/shared/bls/bls.go#L98)

3. bazel test output "/beacon-chain/core/validators/validator.go:161:15: multiple-value ssz.TreeHash() in single-value context". What method should be used to compute  leaf=hash_tree_root(deposit.data) ?

4. bazel test output "/beacon-chain/core/validators/validator.go:188:6: undefined: "github.com/prysmaticlabs/prysm/shared/bls".Verify" . How to invoke bls.Verify() method properly?



