### PR TITLE
Handle race condition in progress

### DIFF
--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -35,6 +35,8 @@ var (
 	})
 )
 
+const ErrAlreadyInProgress = errors.New("already in progress")
+
 // AttestationCache is used to store the cached results of an AttestationData request.
 type AttestationCache struct {
 	cache      *cache.FIFO
@@ -108,7 +110,7 @@ func (c *AttestationCache) MarkInProgress(req *pb.AttestationDataRequest) error 
 		return e
 	}
 	if c.inProgress[s] {
-		return errors.New("already in progress")
+		return ErrAlreadyInProgress
 	}
 	c.inProgress[s] = true
 	return nil

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -35,7 +35,10 @@ var (
 	})
 )
 
-const ErrAlreadyInProgress = errors.New("already in progress")
+// ErrAlreadyInProgress appears when attempting to mark a cache as in progress while it is
+// already in progress. The client should handle this error and wait for the in progress
+// data to resolve via Get.
+var ErrAlreadyInProgress = errors.New("already in progress")
 
 // AttestationCache is used to store the cached results of an AttestationData request.
 type AttestationCache struct {

--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "attester_server_test.go",
         "beacon_server_test.go",

--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 	"fmt"
 
+	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
-	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"

--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -5,14 +5,13 @@ import (
 	"errors"
 	"fmt"
 
-	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
-
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
+	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/p2p"

--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
@@ -77,6 +78,17 @@ func (as *AttesterServer) AttestationDataAtSlot(ctx context.Context, req *pb.Att
 	}
 
 	if err := as.cache.MarkInProgress(req); err != nil {
+		if err == cache.ErrAlreadyInProgress {
+			res, err := as.cache.Get(ctx, req)
+			if err != nil {
+				return nil, err
+			}
+
+			if res == nil {
+				return nil, errors.New("a request was in progress and resolved to nil")
+			}
+			return res, nil
+		}
 		return nil, err
 	}
 	defer func() {


### PR DESCRIPTION
I am seeing an occasional race condition where a request is marked in progress. 

This provides a retry for fetching the cached method. 