### PR TITLE
Add new log formats and set fluentd as default for cluster

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1084,3 +1084,9 @@ go_repository(
     commit = "5249ec107e4544863dd8c61a6417b640d03a62a2",
     importpath = "github.com/libp2p/go-libp2p-connmgr",
 )
+
+go_repository(
+    name = "com_github_joonix_log",
+    commit = "e0e770ceed363301a4f50bbc9599c6925c77b2d8",
+    importpath = "github.com/joonix/log",
+)

--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//shared/debug:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/version:go_default_library",
+        "@com_github_joonix_log//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
         "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",

--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -44,6 +44,7 @@ go_image(
         "//shared/debug:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/version:go_default_library",
+        "@com_github_joonix_log//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
         "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",

--- a/k8s/beacon-chain/beacon-chain.deploy.yaml
+++ b/k8s/beacon-chain/beacon-chain.deploy.yaml
@@ -63,6 +63,7 @@ spec:
             # Disabling gossip sub until a larger beacon chain deployment.
             - --disable-gossip-sub
             - --p2p-max-peers=50
+            - --log-format=fluentd
           resources:
             requests:
               memory: "100Mi"

--- a/k8s/beacon-chain/validator.deploy.yaml
+++ b/k8s/beacon-chain/validator.deploy.yaml
@@ -32,6 +32,7 @@ spec:
         - --tracing-process-name=$(POD_NAME)
         - --tracing-endpoint=http://jaeger-collector.istio-system.svc.cluster.local:14268
         - --trace-sample-fraction=1.0
+        - --log-format=fluentd
         volumeMounts:
         - name: localdata
           mountPath: /data

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -99,4 +99,10 @@ var (
 		Name:  "clear-db",
 		Usage: "Clears any previously stored data at the data directory",
 	}
+	// LogFormat specifies the log output format.
+	LogFormat = cli.StringFlag{
+		Name:  "log-format",
+		Usage: "Specify log formatting. Supports: text, json, fluentd.",
+		Value: "text",
+	}
 )

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//validator/accounts:go_default_library",
         "//validator/node:go_default_library",
         "//validator/types:go_default_library",
+        "@com_github_joonix_log//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
         "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -48,6 +48,7 @@ go_image(
         "//validator/accounts:go_default_library",
         "//validator/node:go_default_library",
         "//validator/types:go_default_library",
+        "@com_github_joonix_log//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
         "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",

--- a/validator/main.go
+++ b/validator/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	joonix "github.com/joonix/log"
 	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/debug"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
@@ -98,10 +99,6 @@ func createValidatorAccount(ctx *cli.Context) (string, string, error) {
 }
 
 func main() {
-	customFormatter := new(prefixed.TextFormatter)
-	customFormatter.TimestampFormat = "2006-01-02 15:04:05"
-	customFormatter.FullTimestamp = true
-	logrus.SetFormatter(customFormatter)
 	log := logrus.WithField("prefix", "main")
 	app := cli.NewApp()
 	app.Name = "validator"
@@ -147,6 +144,7 @@ contract in order to activate the validator client`,
 		cmd.TraceSampleFractionFlag,
 		cmd.BootstrapNode,
 		cmd.MonitoringPortFlag,
+		cmd.LogFormat,
 		debug.PProfFlag,
 		debug.PProfAddrFlag,
 		debug.PProfPortFlag,
@@ -158,6 +156,24 @@ contract in order to activate the validator client`,
 	app.Flags = append(app.Flags, featureconfig.ValidatorFlags...)
 
 	app.Before = func(ctx *cli.Context) error {
+		format := ctx.GlobalString(cmd.LogFormat.Name)
+		switch format {
+		case "text":
+			formatter := new(prefixed.TextFormatter)
+			formatter.TimestampFormat = "2006-01-02 15:04:05"
+			formatter.FullTimestamp = true
+			logrus.SetFormatter(formatter)
+			break
+		case "fluentd":
+			logrus.SetFormatter(&joonix.FluentdFormatter{})
+			break
+		case "json":
+			logrus.SetFormatter(&logrus.JSONFormatter{})
+			break
+		default:
+			return fmt.Errorf("unknown log format %s", format)
+		}
+
 		runtime.GOMAXPROCS(runtime.NumCPU())
 		return debug.Setup(ctx)
 	}


### PR DESCRIPTION
As title describes.

Try new flag `--log-format=json` default is text and fluentd is the format supported by GKE and other log aggregation systems. 