### PR TITLE
Updated README Deploying with Docker in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,32 @@ Prysm ships with two important components: a beacon node and a validator client.
 Another critical component of Ethereum 2.0 is the Validator Deposit Contract, which is a smart contract deployed on the Ethereum 1.0 chain which can be used for current holders of ETH to do a one-way transfer into Ethereum 2.0.
 
 ### Running an Ethereum 2.0 Beacon Node
-With docker:
+<b>With Docker</b>
 
+Docker on Linux/Mac: 
 ```
 docker run -v /tmp/prysm-data:/data -p 4000:4000 \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
   --datadir=/data
   --clear-db
 ```
+Docker on Windows:
+
+1) You will need to share the local drive you wish to mount to to container (e.g. C:)
+    1. Enter Docker settings (right click tray icon)
+    2. Click Shared Drives
+    3. Select Drive to share
+    4. Click Apply
+    
+2) You will next need to create a folder in the drive to use as your data directory (Docker will not create this if it does not exist). For the purposes of these instructions, C: is shared, and we created the /tmp/prysm-data/ directory within. This path must be used for the local data directory for chain data for the Beacon Node, and when creating an account and keystore for the validator, and when running the validator.
+
+3) Run the beacon node (Docker CLI in Windows seems to have trouble ingesting with escapes and new lines, so keep it on one line):
+```
+docker run -it -v c:/tmp/prysm-data:/data -p 4000:4000 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db
+```
+<b>With Bazel</b>
 
 To start your beacon node with bazel:
-
 ```
 bazel run //beacon-chain -- --clear-db --datadir=/tmp/prysm-data
 ```


### PR DESCRIPTION
Resolves #2597

---

# Description

**Write why you are making the changes in this pull request**
Updated instructions for running Beacon Node in Docker on Windows. The process requires a few additional steps to make a local volume available to mount the data dir. If this doesn't happen, the /tmp/prysm-data dir won't be created at run, and the chaindata will not be stored locally, nor will the account creation process store the key files appropriately for reference when running the validator.

**Write a summary of the changes you are making**
Added content related to docker on Windows specifically, including adding he -it switch to 'docker run', adding information regarding the need to share a local drive for mounting from the container, and an updated example of the local data directory path that must be manually created (i.e. c:/tmp/prysm-data) for docker in Windows.