### PR TITLE
Revert "Disable libp2p TLS security protocols for now"

### DIFF
--- a/shared/p2p/options.go
+++ b/shared/p2p/options.go
@@ -9,12 +9,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/iputils"
 )
 
-// Using package global for test. Swarm testing does not allow testing with
-// NoSecurity option enabled. If this is resolved upstream, we can set up swarm
-// with security disabled in the pubsub tests and remove this package global.
-// https://github.com/libp2p/go-libp2p-swarm/issues/124
-var disableSecurity = true
-
 // buildOptions for the libp2p host.
 // TODO(287): Expand on these options and provide the option configuration via flags.
 // Currently, this is a random port and a (seemingly) consistent private key
@@ -30,15 +24,9 @@ func buildOptions(port, maxPeers int) []libp2p.Option {
 		log.Errorf("Failed to p2p listen: %v", err)
 	}
 
-	opts := []libp2p.Option{
+	return []libp2p.Option{
 		libp2p.ListenAddrs(listen),
 		libp2p.EnableRelay(), // Allows dialing to peers via relay.
 		optionConnectionManager(maxPeers),
 	}
-
-	if disableSecurity {
-		opts = append(opts, libp2p.NoSecurity)
-	}
-
-	return opts
 }

--- a/shared/p2p/service_test.go
+++ b/shared/p2p/service_test.go
@@ -37,10 +37,6 @@ const testTopic = "test_topic"
 
 func init() {
 	logrus.SetLevel(logrus.DebugLevel)
-
-	// Security required for swarm testing.
-	// https://github.com/libp2p/go-libp2p-swarm/issues/124
-	disableSecurity = false
 }
 
 func TestNewServer_InvalidMultiaddress(t *testing.T) {


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#2622

This is not behaving properly with the bootnode and relay.