### PR TITLE
Remove Canonical Attestation Filter

### DIFF
--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -171,18 +171,6 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 			}
 			continue
 		}
-		canonical, err := ps.operationService.IsAttCanonical(ctx, att)
-		if err != nil {
-			// Delete attestation that failed to verify as canonical.
-			if err := ps.beaconDB.DeleteAttestation(att); err != nil {
-				return nil, fmt.Errorf("could not delete failed attestation: %v", err)
-			}
-			return nil, fmt.Errorf("could not verify canonical attestation: %v", err)
-		}
-		// Skip the attestation if it's not canonical.
-		if !canonical {
-			continue
-		}
 
 		validAtts = append(validAtts, att)
 	}


### PR DESCRIPTION
After chatting with Danny and Vitalik, we have agreed that canonical filtering is not necessary and it's not a rational validator's behavior. This PR removes canonical attestation filtering 