### PR TITLE
Update CommitteeAssignment

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -235,7 +235,7 @@ func CommitteeAssignment(
 					proposerIndex, err := BeaconProposerIndex(state)
 					if err != nil {
 						return nil, 0, 0, false, fmt.Errorf(
-							"could not get check proposer index: %v", err)
+							"could not check proposer index: %v", err)
 					}
 					isProposer := proposerIndex == validatorIndex
 					return committee, shard, slot, isProposer, nil

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -277,8 +277,6 @@ func TestVerifyBitfield_OK(t *testing.T) {
 }
 
 func TestCommitteeAssignment_CanRetrieve(t *testing.T) {
-	t.Skip()
-
 	// Initialize test with 128 validators, each slot and each shard gets 2 validators.
 	validators := make([]*pb.Validator, 2*params.BeaconConfig().SlotsPerEpoch)
 	for i := 0; i < len(validators); i++ {
@@ -302,37 +300,36 @@ func TestCommitteeAssignment_CanRetrieve(t *testing.T) {
 	}{
 		{
 			index:      0,
-			slot:       151,
-			committee:  []uint64{28, 0},
-			shard:      88,
-			isProposer: true,
+			slot:       161,
+			committee:  []uint64{0, 107},
+			shard:      97,
+			isProposer: false,
 		},
 		{
 			index:      105,
-			slot:       157,
-			committee:  []uint64{105, 40},
-			shard:      94,
+			slot:       156,
+			committee:  []uint64{88, 105},
+			shard:      92,
 			isProposer: false,
 		},
 		{
 			index:      64,
-			slot:       163,
-			committee:  []uint64{64, 27},
-			shard:      100,
+			slot:       172,
+			committee:  []uint64{64, 31},
+			shard:      108,
 			isProposer: false,
 		},
 		{
 			index:      11,
-			slot:       160,
-			committee:  []uint64{11, 101},
-			shard:      97,
-			isProposer: true,
+			slot:       169,
+			committee:  []uint64{13, 11},
+			shard:      105,
+			isProposer: false,
 		},
 	}
 
 	for _, tt := range tests {
-		committee, shard, slot, isProposer, err := CommitteeAssignment(
-			state, tt.slot, tt.index, false)
+		committee, shard, slot, isProposer, err := CommitteeAssignment(state, tt.slot/params.BeaconConfig().SlotsPerEpoch, tt.index)
 		if err != nil {
 			t.Fatalf("failed to execute NextEpochCommitteeAssignment: %v", err)
 		}
@@ -362,7 +359,7 @@ func TestCommitteeAssignment_CantFindValidator(t *testing.T) {
 		LatestActiveIndexRoots: make([][]byte, params.BeaconConfig().LatestActiveIndexRootsLength),
 	}
 	index := uint64(10000)
-	_, _, _, _, err := CommitteeAssignment(state, state.Slot, index, false)
+	_, _, _, _, err := CommitteeAssignment(state, 1, index)
 	statusErr, ok := status.FromError(err)
 	if !ok {
 		t.Fatal(err)
@@ -479,7 +476,7 @@ func TestCommitteeAssignment_CommitteeCacheHit(t *testing.T) {
 	}
 
 	committee, shard, _, isProposer, err :=
-		CommitteeAssignment(beaconState, csInSlot.Slot, 105, false)
+		CommitteeAssignment(beaconState, csInSlot.Slot, 105)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -523,7 +520,7 @@ func TestCommitteeAssignment_CommitteeCacheMissSaved(t *testing.T) {
 	}
 
 	committee, shard, _, isProposer, err :=
-		CommitteeAssignment(state, slotOffset, 105, false)
+		CommitteeAssignment(state, slotOffset, 105)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -173,7 +173,7 @@ func (vs *ValidatorServer) assignment(
 	}
 
 	committee, shard, slot, isProposer, err :=
-		helpers.CommitteeAssignment(beaconState, epochStart, uint64(idx), false)
+		helpers.CommitteeAssignment(beaconState, epochStart, uint64(idx))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR updates committee_assignment helper function using the latest spec's implementation

- Updated [get_committee_assignment](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/validator/0_beacon-chain-validator.md#validator-assignments)
- Updated and enabled test for get_committee_assignment