### PR TITLE
Fix attester server test data race

### DIFF
--- a/beacon-chain/rpc/attester_server_test.go
+++ b/beacon-chain/rpc/attester_server_test.go
@@ -258,8 +258,8 @@ func TestAttestationDataAtSlot_handlesInProgressRequest(t *testing.T) {
 
 	var wg sync.WaitGroup
 
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 		response, err := server.AttestationDataAtSlot(ctx, req)
 		if err != nil {
@@ -270,8 +270,8 @@ func TestAttestationDataAtSlot_handlesInProgressRequest(t *testing.T) {
 		}
 	}()
 
+	wg.Add(1)
 	go func() {
-		wg.Add(1)
 		defer wg.Done()
 
 		if err := server.cache.Put(ctx, req, res); err != nil {


### PR DESCRIPTION
**Write why you are making the changes in this pull request**
I saw the following error message when I ran unit test with `-race` flag enabled.

```
==================
WARNING: DATA RACE
Write at 0x00c0000be134 by goroutine 79:
  sync.(*WaitGroup).Wait()
      /usr/local/Cellar/go/1.12.5/libexec/src/internal/race/race.go:41 +0xef
  github.com/prysmaticlabs/prysm/beacon-chain/rpc.TestAttestationDataAtSlot_handlesInProgressRequest()
      /Users/htkao/go/src/github.com/prysmaticlabs/prysm/beacon-chain/rpc/attester_server_test.go:285 +0x5a0
  testing.tRunner()
      /usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:865 +0x163

Previous read at 0x00c0000be134 by goroutine 80:
  sync.(*WaitGroup).Add()
      /usr/local/Cellar/go/1.12.5/libexec/src/internal/race/race.go:37 +0x169
  github.com/prysmaticlabs/prysm/beacon-chain/rpc.TestAttestationDataAtSlot_handlesInProgressRequest.func1()
      /Users/htkao/go/src/github.com/prysmaticlabs/prysm/beacon-chain/rpc/attester_server_test.go:262 +0x45

Goroutine 79 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:1072 +0x2eb
  main.main()
      _testmain.go:132 +0x222

Goroutine 80 (running) created at:
  github.com/prysmaticlabs/prysm/beacon-chain/rpc.TestAttestationDataAtSlot_handlesInProgressRequest()
      /Users/htkao/go/src/github.com/prysmaticlabs/prysm/beacon-chain/rpc/attester_server_test.go:261 +0x526
  testing.tRunner()
      /usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:865 +0x163
==================
--- FAIL: TestAttestationDataAtSlot_handlesInProgressRequest (0.00s)
    testing.go:809: race detected during execution of test
```

**Write a summary of the changes you are making**
Move WaitGroup.Add(1) out of goroutine.
