### PR TITLE
Fixed Skipped Tests for RPC Server

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -101,7 +101,6 @@ func ComputeCommittee(
 	validatorCount := uint64(len(validatorIndices))
 	startOffset := utils.SplitOffset(validatorCount, totalCommittees, index)
 	endOffset := utils.SplitOffset(validatorCount, totalCommittees, index+1)
-
 	indices := make([]uint64, endOffset-startOffset)
 	for i := startOffset; i < endOffset; i++ {
 		permutedIndex, err := utils.PermutedIndex(i, validatorCount, seed)

--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/ssz:go_default_library",
         "//shared/testutil:go_default_library",
         "//shared/trieutil:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",

--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -39,17 +39,17 @@ func (as *AttesterServer) AttestHead(ctx context.Context, att *pbp2p.Attestation
 
 	// Update attestation target for RPC server to run necessary fork choice.
 	// We need to retrieve the head block to get its parent root.
-	head, err := as.beaconDB.Block(bytesutil.ToBytes32(att.Data.BeaconBlockRootHash32))
+	head, err := as.beaconDB.Block(bytesutil.ToBytes32(att.Data.BeaconBlockRoot))
 	if err != nil {
 		return nil, err
 	}
 	// If the head block is nil, we can't save the attestation target.
 	if head == nil {
-		return nil, fmt.Errorf("could not find head %#x in db", bytesutil.Trunc(att.Data.BeaconBlockRootHash32))
+		return nil, fmt.Errorf("could not find head %#x in db", bytesutil.Trunc(att.Data.BeaconBlockRoot))
 	}
 	attTarget := &pbp2p.AttestationTarget{
 		Slot:       att.Data.Slot,
-		BlockRoot:  att.Data.BeaconBlockRootHash32,
+		BlockRoot:  att.Data.BeaconBlockRoot,
 		ParentRoot: head.ParentBlockRoot,
 	}
 	if err := as.beaconDB.SaveAttestationTarget(ctx, attTarget); err != nil {

--- a/beacon-chain/rpc/attester_server_test.go
+++ b/beacon-chain/rpc/attester_server_test.go
@@ -20,7 +20,6 @@ func (m *mockBroadcaster) Broadcast(ctx context.Context, msg proto.Message) {
 }
 
 func TestAttestHead_OK(t *testing.T) {
-	t.Skip()
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
 	mockOperationService := &mockOperationService{}

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -100,7 +100,6 @@ func (ps *ProposerServer) PendingAttestations(ctx context.Context, req *pb.Pendi
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}
-
 			log.WithError(err).WithFields(logrus.Fields{
 				"slot":     att.Data.Slot,
 				"headRoot": fmt.Sprintf("%#x", bytesutil.Trunc(att.Data.BeaconBlockRootHash32))}).Info(

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -154,14 +154,14 @@ func TestPendingAttestations_FiltersWithinInclusionDelay(t *testing.T) {
 
 	stateSlot := params.BeaconConfig().MinAttestationInclusionDelay + 100
 	beaconState := &pbp2p.BeaconState{
-		Slot: stateSlot,
+		Slot:              stateSlot,
 		ValidatorRegistry: validators,
 		LatestCrosslinks: []*pbp2p.Crosslink{{
-			Epoch:                   1,
+			Epoch:    1,
 			DataRoot: params.BeaconConfig().ZeroHash[:],
 		}},
-		LatestRandaoMixes:         make([][]byte, params.BeaconConfig().LatestRandaoMixesLength),
-		LatestActiveIndexRoots:    make([][]byte, params.BeaconConfig().LatestActiveIndexRootsLength),
+		LatestRandaoMixes:      make([][]byte, params.BeaconConfig().LatestRandaoMixesLength),
+		LatestActiveIndexRoots: make([][]byte, params.BeaconConfig().LatestActiveIndexRootsLength),
 	}
 	beaconState.PreviousCrosslinks = []*pbp2p.Crosslink{
 		{
@@ -178,12 +178,12 @@ func TestPendingAttestations_FiltersWithinInclusionDelay(t *testing.T) {
 			pendingAttestations: []*pbp2p.Attestation{
 				{Data: &pbp2p.AttestationData{
 					Slot:              beaconState.Slot - params.BeaconConfig().MinAttestationInclusionDelay,
-					Shard: 1000,
+					Shard:             1000,
 					CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-					Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
+					Crosslink:         &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 				},
 					AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0},
-	},
+				},
 			},
 		},
 		chainService: &mockChainService{},
@@ -228,7 +228,7 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 	) - 1
 
 	expectedEpoch := uint64(100)
-	crosslink := &pbp2p.Crosslink{Epoch: 9, CrosslinkDataRootHash32:params.BeaconConfig().ZeroHash[:]}
+	crosslink := &pbp2p.Crosslink{Epoch: 9, CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:]}
 	encoded, err := ssz.TreeHash(crosslink)
 	if err != nil {
 		t.Fatal(err)
@@ -239,69 +239,69 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 			//Expired attestations
 			{Data: &pbp2p.AttestationData{
 				Slot:              0,
-				TargetEpoch: 10,
-				SourceEpoch:    expectedEpoch,
+				TargetEpoch:       10,
+				SourceEpoch:       expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
+				Crosslink:         &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
-				Slot:              currentSlot - 10000,
+				Slot:        currentSlot - 10000,
 				TargetEpoch: 10,
 
-				SourceEpoch:    expectedEpoch,
+				SourceEpoch:       expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
+				Crosslink:         &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 5000,
-				TargetEpoch: 10,
-				SourceEpoch:    expectedEpoch,
+				TargetEpoch:       10,
+				SourceEpoch:       expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
+				Crosslink:         &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 100,
-				TargetEpoch: 10,
-				SourceEpoch:    expectedEpoch,
+				TargetEpoch:       10,
+				SourceEpoch:       expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
+				Crosslink:         &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - params.BeaconConfig().SlotsPerEpoch,
-				TargetEpoch: 10,
-				SourceEpoch:    expectedEpoch,
+				TargetEpoch:       10,
+				SourceEpoch:       expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
+				Crosslink:         &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			// Non-expired attestation with incorrect justified epoch
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 5,
-				TargetEpoch: 10,
-				SourceEpoch:    expectedEpoch - 1,
+				TargetEpoch:       10,
+				SourceEpoch:       expectedEpoch - 1,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
+				Crosslink:         &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			// Non-expired attestations with correct justified epoch
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 5,
-				TargetEpoch: 10,
-				SourceEpoch:    expectedEpoch,
+				TargetEpoch:       10,
+				SourceEpoch:       expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-				Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+				Crosslink:         &pbp2p.Crosslink{Epoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 			}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 2,
-				TargetEpoch: 10,
-				SourceEpoch:    expectedEpoch,
+				TargetEpoch:       10,
+				SourceEpoch:       expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-				Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+				Crosslink:         &pbp2p.Crosslink{Epoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 			}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot,
-				TargetEpoch: 10,
-				SourceEpoch:    expectedEpoch,
+				TargetEpoch:       10,
+				SourceEpoch:       expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-				Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+				Crosslink:         &pbp2p.Crosslink{Epoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 			}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 		},
 	}
@@ -320,7 +320,7 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 	}
 
 	beaconState := &pbp2p.BeaconState{
-		ValidatorRegistry: validators,
+		ValidatorRegistry:      validators,
 		Slot:                   currentSlot + params.BeaconConfig().MinAttestationInclusionDelay,
 		CurrentJustifiedEpoch:  expectedEpoch,
 		PreviousJustifiedEpoch: expectedEpoch,
@@ -328,8 +328,8 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 			Epoch:                   9,
 			CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:],
 		}},
-		LatestRandaoMixes:         make([][]byte, params.BeaconConfig().LatestRandaoMixesLength),
-		LatestActiveIndexRoots:    make([][]byte, params.BeaconConfig().LatestActiveIndexRootsLength),
+		LatestRandaoMixes:      make([][]byte, params.BeaconConfig().LatestRandaoMixesLength),
+		LatestActiveIndexRoots: make([][]byte, params.BeaconConfig().LatestActiveIndexRootsLength),
 	}
 
 	if err := db.SaveState(ctx, beaconState); err != nil {
@@ -368,28 +368,27 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 	expectedAtts := []*pbp2p.Attestation{
 		{Data: &pbp2p.AttestationData{
 			Slot:              currentSlot - 5,
-			TargetEpoch: 10,
-			SourceEpoch:    expectedEpoch,
+			TargetEpoch:       10,
+			SourceEpoch:       expectedEpoch,
 			CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-			Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+			Crosslink:         &pbp2p.Crosslink{Epoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 		}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 		{Data: &pbp2p.AttestationData{
 			Slot:              currentSlot - 2,
-			TargetEpoch: 10,
-			SourceEpoch:    expectedEpoch,
+			TargetEpoch:       10,
+			SourceEpoch:       expectedEpoch,
 			CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-			Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+			Crosslink:         &pbp2p.Crosslink{Epoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 		}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 		{Data: &pbp2p.AttestationData{
 			Slot:              currentSlot,
-			TargetEpoch: 10,
-			SourceEpoch:    expectedEpoch,
+			TargetEpoch:       10,
+			SourceEpoch:       expectedEpoch,
 			CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-			Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+			Crosslink:         &pbp2p.Crosslink{Epoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 		}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 	}
 	if !reflect.DeepEqual(res.PendingAttestations, expectedAtts) {
 		t.Error("Did not receive expected attestations")
 	}
 }
-

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -15,6 +15,7 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/ssz"
 )
 
 func init() {
@@ -140,27 +141,49 @@ func TestComputeStateRoot_OK(t *testing.T) {
 }
 
 func TestPendingAttestations_FiltersWithinInclusionDelay(t *testing.T) {
-	t.Skip()
-	// TODO(#2307): Update this runtime functionality based on v0.6.
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
 	ctx := context.Background()
 
+	validators := make([]*pbp2p.Validator, params.BeaconConfig().DepositsForChainStart/8)
+	for i := 0; i < len(validators); i++ {
+		validators[i] = &pbp2p.Validator{
+			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+		}
+	}
+
 	stateSlot := params.BeaconConfig().MinAttestationInclusionDelay + 100
 	beaconState := &pbp2p.BeaconState{
 		Slot: stateSlot,
+		ValidatorRegistry: validators,
 		LatestCrosslinks: []*pbp2p.Crosslink{{
 			Epoch:                   1,
-			CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:],
+			DataRoot: params.BeaconConfig().ZeroHash[:],
 		}},
+		LatestRandaoMixes:         make([][]byte, params.BeaconConfig().LatestRandaoMixesLength),
+		LatestActiveIndexRoots:    make([][]byte, params.BeaconConfig().LatestActiveIndexRootsLength),
 	}
+	beaconState.PreviousCrosslinks = []*pbp2p.Crosslink{
+		{
+			Shard: 0,
+		},
+	}
+	encoded, err := ssz.TreeHash(beaconState.PreviousCrosslinks[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	proposerServer := &ProposerServer{
 		operationService: &mockOperationService{
 			pendingAttestations: []*pbp2p.Attestation{
 				{Data: &pbp2p.AttestationData{
 					Slot:              beaconState.Slot - params.BeaconConfig().MinAttestationInclusionDelay,
+					Shard: 1000,
 					CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-				}},
+					Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
+				},
+					AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0},
+	},
 			},
 		},
 		chainService: &mockChainService{},
@@ -194,8 +217,6 @@ func TestPendingAttestations_FiltersWithinInclusionDelay(t *testing.T) {
 }
 
 func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
-	t.Skip()
-	// TODO(#2307): Update this runtime functionality based on v0.6.
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
 	ctx := context.Background()
@@ -207,57 +228,81 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 	) - 1
 
 	expectedEpoch := uint64(100)
+	crosslink := &pbp2p.Crosslink{Epoch: 9, CrosslinkDataRootHash32:params.BeaconConfig().ZeroHash[:]}
+	encoded, err := ssz.TreeHash(crosslink)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	opService := &mockOperationService{
 		pendingAttestations: []*pbp2p.Attestation{
 			//Expired attestations
 			{Data: &pbp2p.AttestationData{
 				Slot:              0,
-				JustifiedEpoch:    expectedEpoch,
+				TargetEpoch: 10,
+				SourceEpoch:    expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
+				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 10000,
-				JustifiedEpoch:    expectedEpoch,
+				TargetEpoch: 10,
+
+				SourceEpoch:    expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
+				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 5000,
-				JustifiedEpoch:    expectedEpoch,
+				TargetEpoch: 10,
+				SourceEpoch:    expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
+				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 100,
-				JustifiedEpoch:    expectedEpoch,
+				TargetEpoch: 10,
+				SourceEpoch:    expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
+				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - params.BeaconConfig().SlotsPerEpoch,
-				JustifiedEpoch:    expectedEpoch,
+				TargetEpoch: 10,
+				SourceEpoch:    expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
+				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
 			}},
 			// Non-expired attestation with incorrect justified epoch
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 5,
-				JustifiedEpoch:    expectedEpoch - 1,
+				TargetEpoch: 10,
+				SourceEpoch:    expectedEpoch - 1,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
+				Crosslink: &pbp2p.Crosslink{DataRoot:params.BeaconConfig().ZeroHash[:]},
 			}},
 			// Non-expired attestations with correct justified epoch
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 5,
-				JustifiedEpoch:    expectedEpoch,
+				TargetEpoch: 10,
+				SourceEpoch:    expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-			}},
+				Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+			}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot - 2,
-				JustifiedEpoch:    expectedEpoch,
+				TargetEpoch: 10,
+				SourceEpoch:    expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-			}},
+				Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+			}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 			{Data: &pbp2p.AttestationData{
 				Slot:              currentSlot,
-				JustifiedEpoch:    expectedEpoch,
+				TargetEpoch: 10,
+				SourceEpoch:    expectedEpoch,
 				CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-			}},
+				Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+			}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 		},
 	}
 	expectedNumberOfAttestations := 3
@@ -266,15 +311,27 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 		chainService:     &mockChainService{},
 		beaconDB:         db,
 	}
+
+	validators := make([]*pbp2p.Validator, params.BeaconConfig().DepositsForChainStart/8)
+	for i := 0; i < len(validators); i++ {
+		validators[i] = &pbp2p.Validator{
+			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+		}
+	}
+
 	beaconState := &pbp2p.BeaconState{
+		ValidatorRegistry: validators,
 		Slot:                   currentSlot + params.BeaconConfig().MinAttestationInclusionDelay,
 		CurrentJustifiedEpoch:  expectedEpoch,
 		PreviousJustifiedEpoch: expectedEpoch,
-		LatestCrosslinks: []*pbp2p.Crosslink{{
+		CurrentCrosslinks: []*pbp2p.Crosslink{{
 			Epoch:                   9,
 			CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:],
 		}},
+		LatestRandaoMixes:         make([][]byte, params.BeaconConfig().LatestRandaoMixesLength),
+		LatestActiveIndexRoots:    make([][]byte, params.BeaconConfig().LatestActiveIndexRootsLength),
 	}
+
 	if err := db.SaveState(ctx, beaconState); err != nil {
 		t.Fatal(err)
 	}
@@ -311,66 +368,28 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 	expectedAtts := []*pbp2p.Attestation{
 		{Data: &pbp2p.AttestationData{
 			Slot:              currentSlot - 5,
-			JustifiedEpoch:    expectedEpoch,
+			TargetEpoch: 10,
+			SourceEpoch:    expectedEpoch,
 			CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-		}},
+			Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+		}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 		{Data: &pbp2p.AttestationData{
 			Slot:              currentSlot - 2,
-			JustifiedEpoch:    expectedEpoch,
+			TargetEpoch: 10,
+			SourceEpoch:    expectedEpoch,
 			CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-		}},
+			Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+		}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 		{Data: &pbp2p.AttestationData{
 			Slot:              currentSlot,
-			JustifiedEpoch:    expectedEpoch,
+			TargetEpoch: 10,
+			SourceEpoch:    expectedEpoch,
 			CrosslinkDataRoot: params.BeaconConfig().ZeroHash[:],
-		}},
+			Crosslink: &pbp2p.Crosslink{Epoch: 10, DataRoot:params.BeaconConfig().ZeroHash[:],ParentRoot: encoded[:]},
+		}, AggregationBitfield: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 	}
 	if !reflect.DeepEqual(res.PendingAttestations, expectedAtts) {
 		t.Error("Did not receive expected attestations")
 	}
 }
 
-func TestPendingAttestations_OK(t *testing.T) {
-	t.Skip()
-	// TODO(#2307): Update this runtime functionality based on v0.6.
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
-	ctx := context.Background()
-
-	proposerServer := &ProposerServer{
-		operationService: &mockOperationService{},
-		chainService:     &mockChainService{},
-		beaconDB:         db,
-	}
-	beaconState := &pbp2p.BeaconState{
-		Slot: params.BeaconConfig().SlotsPerEpoch +
-			params.BeaconConfig().MinAttestationInclusionDelay,
-		LatestCrosslinks: []*pbp2p.Crosslink{{Epoch: 1,
-			CrosslinkDataRootHash32: params.BeaconConfig().ZeroHash[:]}},
-	}
-	if err := db.SaveState(ctx, beaconState); err != nil {
-		t.Fatal(err)
-	}
-
-	blk := &pbp2p.BeaconBlock{
-		Slot: beaconState.Slot,
-	}
-
-	if err := db.SaveBlock(blk); err != nil {
-		t.Fatalf("failed to save block %v", err)
-	}
-
-	if err := db.UpdateChainHead(ctx, blk, beaconState); err != nil {
-		t.Fatalf("couldnt update chainhead: %v", err)
-	}
-
-	res, err := proposerServer.PendingAttestations(context.Background(), &pb.PendingAttestationsRequest{
-		ProposalBlockSlot: blk.Slot + 1,
-	})
-	if err != nil {
-		t.Fatalf("Unexpected error fetching pending attestations: %v", err)
-	}
-	if len(res.PendingAttestations) == 0 {
-		t.Error("Expected pending attestations list to be non-empty")
-	}
-}

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -295,7 +295,7 @@ func TestCommitteeAssignment_multipleKeys_OK(t *testing.T) {
 	copy(pubKeyBuf0[:], []byte(strconv.Itoa(0)))
 	pubKeyBuf1 := make([]byte, params.BeaconConfig().BLSPubkeyLength)
 	copy(pubKeyBuf1[:], []byte(strconv.Itoa(1)))
-	
+
 	// Test the first validator in registry.
 	req := &pb.CommitteeAssignmentsRequest{
 		PublicKeys: [][]byte{pubKeyBuf0, pubKeyBuf1},

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -169,8 +169,6 @@ func TestNextEpochCommitteeAssignment_CantFindValidatorIdx(t *testing.T) {
 }
 
 func TestCommitteeAssignment_OK(t *testing.T) {
-	t.Skip()
-
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
 	ctx := context.Background()
@@ -212,6 +210,7 @@ func TestCommitteeAssignment_OK(t *testing.T) {
 
 	pubKeyBuf := make([]byte, params.BeaconConfig().BLSPubkeyLength)
 	copy(pubKeyBuf[:], []byte(strconv.FormatUint(0, 10)))
+
 	// Test the first validator in registry.
 	req := &pb.CommitteeAssignmentsRequest{
 		PublicKeys: [][]byte{pubKeyBuf},
@@ -253,8 +252,6 @@ func TestCommitteeAssignment_OK(t *testing.T) {
 }
 
 func TestCommitteeAssignment_multipleKeys_OK(t *testing.T) {
-	t.Skip()
-
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
 	ctx := context.Background()
@@ -298,6 +295,7 @@ func TestCommitteeAssignment_multipleKeys_OK(t *testing.T) {
 	copy(pubKeyBuf0[:], []byte(strconv.Itoa(0)))
 	pubKeyBuf1 := make([]byte, params.BeaconConfig().BLSPubkeyLength)
 	copy(pubKeyBuf1[:], []byte(strconv.Itoa(1)))
+	
 	// Test the first validator in registry.
 	req := &pb.CommitteeAssignmentsRequest{
 		PublicKeys: [][]byte{pubKeyBuf0, pubKeyBuf1},


### PR DESCRIPTION
This PR fixed most of the skipped tests for RPC server. The only ones left are beacon server because it needs a new implementation of ETH1Data end point.

`TestPendingAttestations_OK` was removed because it was a pointless test, not only it wasn't testing much, the main functionality was already covered in `TestPendingAttestations_FiltersExpiredAttestations`