### PR TITLE
Fix static peering

### DIFF
--- a/shared/p2p/monitoring.go
+++ b/shared/p2p/monitoring.go
@@ -22,7 +22,7 @@ var (
 )
 
 // starPeerWatcher updates the peer count metric and calls to reconnect any VIP
-// peers such as the bootnode peer or relay node peer.
+// peers such as the bootnode peer, the relay node peer or the static peers.
 func startPeerWatcher(ctx context.Context, h host.Host, reconnectPeers ...string) {
 
 	go (func() {
@@ -67,7 +67,7 @@ func ensurePeerConnections(ctx context.Context, h host.Host, peers ...string) {
 			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			defer cancel()
 			if err := h.Connect(ctx, *peer); err != nil {
-				log.Errorf("Failed to reconnect to peer %v", err)
+				log.WithField("peer", peer.ID).WithField("addrs", peer.Addrs).Errorf("Failed to reconnect to peer %v", err)
 				continue
 			}
 		}

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -227,7 +227,9 @@ func (s *Server) Start() {
 		}
 		peersToWatch = append(peersToWatch, s.staticPeers...)
 	}
-	startPeerWatcher(ctx, s.host, peersToWatch...)
+	if len(peersToWatch) > 0 {
+		startPeerWatcher(ctx, s.host, peersToWatch...)
+	}
 }
 
 // Stop the main p2p loop.

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/libp2p/go-libp2p-peerstore"
 	"io"
 	"net"
 	"reflect"
@@ -215,15 +216,14 @@ func (s *Server) Start() {
 		startPeerWatcher(ctx, s.host, s.bootstrapNode, s.relayNodeAddr)
 	}
 
-	maxTime := time.Duration(1 << 62)
-
-	for _, peer := range s.staticPeers {
-		peerInfo, err := peerInfoFromAddr(peer)
+	for _, staticPeer := range s.staticPeers {
+		peerInfo, err := peerInfoFromAddr(staticPeer)
 		if err != nil {
 			log.Errorf("Invalid peer address: %v", err)
 		} else {
-			s.host.Peerstore().AddAddrs(peerInfo.ID, peerInfo.Addrs, maxTime)
+			s.host.Peerstore().AddAddrs(peerInfo.ID, peerInfo.Addrs, peerstore.PermanentAddrTTL)
 		}
+		startPeerWatcher(ctx, s.host, s.staticPeers...)
 	}
 }
 

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -21,7 +21,6 @@ import (
 	dhtopts "github.com/libp2p/go-libp2p-kad-dht/opts"
 	libp2pnet "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
-	"github.com/libp2p/go-libp2p-peerstore"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	protocol "github.com/libp2p/go-libp2p-protocol"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"


### PR DESCRIPTION
I found static peers were not being dialed. They also were not tracked as peers with the prometheus gauge.
This PR fixes this behavior.
