### PR TITLE
Fix most of skipped tests

### DIFF
--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -191,7 +191,6 @@ func (a *Service) UpdateLatestAttestation(ctx context.Context, attestation *pb.A
 // BatchUpdateLatestAttestation updates multiple attestations and adds them into the attestation store
 // if they are valid.
 func (a *Service) BatchUpdateLatestAttestation(ctx context.Context, attestations []*pb.Attestation) error {
-
 	if attestations == nil {
 		return nil
 	}

--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -191,6 +191,7 @@ func (a *Service) UpdateLatestAttestation(ctx context.Context, attestation *pb.A
 // BatchUpdateLatestAttestation updates multiple attestations and adds them into the attestation store
 // if they are valid.
 func (a *Service) BatchUpdateLatestAttestation(ctx context.Context, attestations []*pb.Attestation) error {
+
 	if attestations == nil {
 		return nil
 	}

--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -1614,10 +1614,14 @@ func TestVoteCount_CacheEnabledAndMiss(t *testing.T) {
 }
 
 func TestVoteCount_CacheEnabledAndHit(t *testing.T) {
-	t.Skip()
+	beaconDB := internal.SetupDB(t)
+	defer internal.TeardownDB(t, beaconDB)
 	genesisBlock := b.NewGenesisBlock([]byte("stateroot"))
 	genesisRoot, err := hashutil.HashBeaconBlock(genesisBlock)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := beaconDB.SaveBlock(genesisBlock); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1632,7 +1636,21 @@ func TestVoteCount_CacheEnabledAndHit(t *testing.T) {
 	}
 	pHeadHash2, _ := hashutil.HashBeaconBlock(potentialHead2)
 
-	beaconState := &pb.BeaconState{Balances: []uint64{1e9, 1e9}}
+	// We store these potential heads in the DB.
+	if err := beaconDB.SaveBlock(potentialHead); err != nil {
+		t.Fatal(err)
+	}
+	if err := beaconDB.SaveBlock(potentialHead2); err != nil {
+		t.Fatal(err)
+	}
+
+	beaconState := &pb.BeaconState{
+		Balances: []uint64{1e9, 1e9},
+		ValidatorRegistry: []*pb.Validator{
+			{EffectiveBalance: 1e9},
+			{EffectiveBalance: 1e9},
+		},
+	}
 	voteTargets := make(map[uint64]*pb.AttestationTarget)
 	voteTargets[0] = &pb.AttestationTarget{
 		Slot:       potentialHead.Slot,
@@ -1661,7 +1679,7 @@ func TestVoteCount_CacheEnabledAndHit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	count, err := VoteCount(genesisBlock, beaconState, voteTargets, nil)
+	count, err := VoteCount(genesisBlock, beaconState, voteTargets, beaconDB)
 	if err != nil {
 		t.Fatalf("Could not fetch vote balances: %v", err)
 	}

--- a/beacon-chain/blockchain/stategenerator/state_generator_test.go
+++ b/beacon-chain/blockchain/stategenerator/state_generator_test.go
@@ -17,7 +17,6 @@ func init() {
 	})
 }
 func TestGenerateState_OK(t *testing.T) {
-	t.Skip()
 	b, err := backend.NewSimulatedBackend()
 	if err != nil {
 		t.Fatalf("Could not create a new simulated backend %v", err)
@@ -82,75 +81,5 @@ func TestGenerateState_OK(t *testing.T) {
 
 	if !proto.Equal(newState, b.State()) {
 		t.Error("Generated and saved states are unequal")
-	}
-}
-
-func TestGenerateState_WithNilBlocksOK(t *testing.T) {
-	t.Skip()
-	b, err := backend.NewSimulatedBackend()
-	if err != nil {
-		t.Fatalf("Could not create a new simulated backend %v", err)
-	}
-	privKeys, err := b.SetupBackend(100)
-	if err != nil {
-		t.Fatalf("Could not set up backend %v", err)
-	}
-	beaconDb := b.DB()
-	defer b.Shutdown()
-	defer db.TeardownDB(beaconDb)
-	ctx := context.Background()
-
-	slotLimit := uint64(30)
-
-	// Run the simulated chain for 30 slots, to get a state that we can save as finalized.
-	for i := uint64(0); i < slotLimit; i++ {
-		if err := b.GenerateBlockAndAdvanceChain(&backend.SimulatedObjects{}, privKeys); err != nil {
-			t.Fatalf("Could not generate block and transition state successfully %v for slot %d", err, b.State().Slot+1)
-		}
-		inMemBlocks := b.InMemoryBlocks()
-		if err := beaconDb.SaveBlock(inMemBlocks[len(inMemBlocks)-1]); err != nil {
-			t.Fatalf("Unable to save block %v", err)
-		}
-		if err := beaconDb.UpdateChainHead(ctx, inMemBlocks[len(inMemBlocks)-1], b.State()); err != nil {
-			t.Fatalf("Unable to save block %v", err)
-		}
-		if err := beaconDb.SaveFinalizedBlock(inMemBlocks[len(inMemBlocks)-1]); err != nil {
-			t.Fatalf("Unable to save finalized state: %v", err)
-		}
-	}
-
-	if err := beaconDb.SaveFinalizedState(b.State()); err != nil {
-		t.Fatalf("Unable to save finalized state")
-	}
-
-	slotsWithNil := uint64(10)
-
-	for i := uint64(0); i < slotLimit-slotsWithNil; i++ {
-		if err := b.GenerateBlockAndAdvanceChain(&backend.SimulatedObjects{}, privKeys); err != nil {
-			t.Fatalf("Could not generate block and transition state successfully %v for slot %d", err, b.State().Slot+1)
-		}
-		inMemBlocks := b.InMemoryBlocks()
-		if err := beaconDb.SaveBlock(inMemBlocks[len(inMemBlocks)-1]); err != nil {
-			t.Fatalf("Unable to save block %v", err)
-		}
-		if err := beaconDb.UpdateChainHead(ctx, inMemBlocks[len(inMemBlocks)-1], b.State()); err != nil {
-			t.Fatalf("Unable to save block %v", err)
-		}
-	}
-
-	// Ran 30 slots to save finalized slot then ran another 10 slots w/o blocks and 20 slots w/ blocks.
-	slotToGenerateTill := slotLimit * 2
-	newState, err := stategenerator.GenerateStateFromBlock(context.Background(), beaconDb, slotToGenerateTill)
-	if err != nil {
-		t.Fatalf("Unable to generate new state from previous finalized state %v", err)
-	}
-
-	if newState.Slot != b.State().Slot {
-		t.Fatalf("The generated state and the current state do not have the same slot, expected: %d but got %d",
-			b.State().Slot, newState.Slot)
-	}
-
-	if !proto.Equal(newState, b.State()) {
-		t.Error("generated and saved states are unequal")
 	}
 }

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -381,8 +381,6 @@ func TestWaitActivation_NotAllValidatorsActivatedOK(t *testing.T) {
 }
 
 func TestUpdateAssignments_DoesNothingWhenNotEpochStartAndAlreadyExistingAssignments(t *testing.T) {
-	// TODO(2167): Unskip this test.
-	t.Skip()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := internal.NewMockValidatorServiceClient(ctrl)


### PR DESCRIPTION
Resolves #2696 

This removes `t.skip()` from the tests that were skipped when branch spec-v0.6 was broken. 

The following tests were fixed:
`TestReceiveBlock_DeletesBadBlock`
`TestVoteCount_CacheEnabledAndHit`
`TestGenerateState_OK`
`TestUpdateAssignments_DoesNothingWhenNotEpochStartAndAlreadyExistingAssignments`

The test `TestGenerateState_WithNilBlocksOK` was removed due to the function it was testing for being removed in [this commit](https://github.com/prysmaticlabs/prysm/commit/c0c2671c5f18eda7fbc1022f3027983a5557e080#diff-6ee4abce3ee9e6bd081889b033b07a3e).

The skipped tests I didn't fix are related to Eth1Data which is what #2733 is for and for proposer signatures which are not fully implemented yet. 