### PR TITLE
Remove Deprecated Beacon Chain Configs

### DIFF
--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -1539,7 +1539,7 @@ func setupFFGTest(t *testing.T) ([32]byte, *pb.BeaconBlock, *pb.BeaconState, []*
 	}
 	gState := &pb.BeaconState{
 		Slot:                   genesisSlot,
-		LatestBlockRoots:       make([][]byte, params.BeaconConfig().LatestBlockRootsLength),
+		LatestBlockRoots:       make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot),
 		LatestRandaoMixes:      latestRandaoMixes,
 		LatestActiveIndexRoots: make([][]byte, params.BeaconConfig().LatestActiveIndexRootsLength),
 		LatestSlashedBalances:  make([]uint64, params.BeaconConfig().LatestSlashedExitLength),

--- a/beacon-chain/core/blocks/block.go
+++ b/beacon-chain/core/blocks/block.go
@@ -44,13 +44,13 @@ func NewGenesisBlock(stateRoot []byte) *pb.BeaconBlock {
 //		"""
 //		returns the block root at a recent ``slot``.
 //		"""
-//		assert state.slot <= slot + LATEST_BLOCK_ROOTS_LENGTH
+//		assert state.slot <= slot + SLOTS_PER_HISTORICAL_ROOT
 //		assert slot < state.slote
-//		return state.latest_block_roots[slot % LATEST_BLOCK_ROOTS_LENGTH]
+//		return state.latest_block_roots[slot % SLOTS_PER_HISTORICAL_ROOT]
 func BlockRoot(state *pb.BeaconState, slot uint64) ([]byte, error) {
 	earliestSlot := uint64(0)
-	if state.Slot > params.BeaconConfig().LatestBlockRootsLength {
-		earliestSlot = state.Slot - params.BeaconConfig().LatestBlockRootsLength
+	if state.Slot > params.BeaconConfig().SlotsPerHistoricalRoot {
+		earliestSlot = state.Slot - params.BeaconConfig().SlotsPerHistoricalRoot
 	}
 
 	if slot < earliestSlot || slot >= state.Slot {
@@ -61,16 +61,16 @@ func BlockRoot(state *pb.BeaconState, slot uint64) ([]byte, error) {
 		)
 	}
 
-	return state.LatestBlockRoots[slot%params.BeaconConfig().LatestBlockRootsLength], nil
+	return state.LatestBlockRoots[slot%params.BeaconConfig().SlotsPerHistoricalRoot], nil
 }
 
 // ProcessBlockRoots processes the previous block root into the state, by appending it
 // to the most recent block roots.
 // Spec:
 //  Let previous_block_root be the tree_hash_root of the previous beacon block processed in the chain.
-//	Set state.latest_block_roots[(state.slot - 1) % LATEST_BLOCK_ROOTS_LENGTH] = previous_block_root.
+//	Set state.latest_block_roots[(state.slot - 1) % SLOTS_PER_HISTORICAL_ROOT] = previous_block_root.
 func ProcessBlockRoots(state *pb.BeaconState, parentRoot [32]byte) *pb.BeaconState {
-	state.LatestBlockRoots[(state.Slot-1)%params.BeaconConfig().LatestBlockRootsLength] = parentRoot[:]
+	state.LatestBlockRoots[(state.Slot-1)%params.BeaconConfig().SlotsPerHistoricalRoot] = parentRoot[:]
 	return state
 }
 

--- a/beacon-chain/core/blocks/block_test.go
+++ b/beacon-chain/core/blocks/block_test.go
@@ -46,7 +46,7 @@ func TestBlockRootAtSlot_AccurateBlockRoot(t *testing.T) {
 	}
 	var blockRoots [][]byte
 
-	for i := uint64(0); i < params.BeaconConfig().LatestBlockRootsLength; i++ {
+	for i := uint64(0); i < params.BeaconConfig().SlotsPerHistoricalRoot; i++ {
 		blockRoots = append(blockRoots, []byte{byte(i)})
 	}
 	state := &pb.BeaconState{
@@ -106,7 +106,7 @@ func TestBlockRootAtSlot_OutOfBounds(t *testing.T) {
 
 	var blockRoots [][]byte
 
-	for i := uint64(0); i < params.BeaconConfig().LatestBlockRootsLength; i++ {
+	for i := uint64(0); i < params.BeaconConfig().SlotsPerHistoricalRoot; i++ {
 		blockRoots = append(blockRoots, []byte{byte(i)})
 	}
 	state := &pb.BeaconState{
@@ -144,8 +144,8 @@ func TestBlockRootAtSlot_OutOfBounds(t *testing.T) {
 func TestProcessBlockRoots_AccurateMerkleTree(t *testing.T) {
 	state := &pb.BeaconState{}
 
-	state.LatestBlockRoots = make([][]byte, params.BeaconConfig().LatestBlockRootsLength)
-	state.Slot = params.BeaconConfig().LatestBlockRootsLength + 1
+	state.LatestBlockRoots = make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
+	state.Slot = params.BeaconConfig().SlotsPerHistoricalRoot + 1
 
 	testRoot := [32]byte{'a'}
 

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -71,7 +71,7 @@ func GenesisBeaconState(
 		}
 	}
 
-	latestBlockRoots := make([][]byte, params.BeaconConfig().LatestBlockRootsLength)
+	latestBlockRoots := make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 	for i := 0; i < len(latestBlockRoots); i++ {
 		latestBlockRoots[i] = zeroHash
 	}

--- a/beacon-chain/core/state/state_test.go
+++ b/beacon-chain/core/state/state_test.go
@@ -47,8 +47,8 @@ func TestGenesisBeaconState_OK(t *testing.T) {
 	}
 	shardCount := int(params.BeaconConfig().ShardCount)
 
-	if params.BeaconConfig().LatestBlockRootsLength != 8192 {
-		t.Error("LatestBlockRootsLength should be 8192 for these tests to pass")
+	if params.BeaconConfig().SlotsPerHistoricalRoot != 8192 {
+		t.Error("SlotsPerHistoricalRoot should be 8192 for these tests to pass")
 	}
 
 	if params.BeaconConfig().DepositsForChainStart != 16384 {
@@ -194,7 +194,7 @@ func TestGenesisState_HashEquality(t *testing.T) {
 
 func TestGenesisState_InitializesLatestBlockHashes(t *testing.T) {
 	s, _ := state.GenesisBeaconState(nil, 0, nil)
-	want, got := len(s.LatestBlockRoots), int(params.BeaconConfig().LatestBlockRootsLength)
+	want, got := len(s.LatestBlockRoots), int(params.BeaconConfig().SlotsPerHistoricalRoot)
 	if want != got {
 		t.Errorf("Wrong number of recent block hashes. Got: %d Want: %d", got, want)
 	}

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -264,7 +264,7 @@ func TestProcessBlock_IncorrectProcessExits(t *testing.T) {
 		},
 	}
 	var blockRoots [][]byte
-	for i := uint64(0); i < params.BeaconConfig().LatestBlockRootsLength; i++ {
+	for i := uint64(0); i < params.BeaconConfig().SlotsPerHistoricalRoot; i++ {
 		blockRoots = append(blockRoots, []byte{byte(i)})
 	}
 	beaconState.LatestBlockRoots = blockRoots
@@ -380,7 +380,7 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 		},
 	}
 	var blockRoots [][]byte
-	for i := uint64(0); i < params.BeaconConfig().LatestBlockRootsLength; i++ {
+	for i := uint64(0); i < params.BeaconConfig().SlotsPerHistoricalRoot; i++ {
 		blockRoots = append(blockRoots, []byte{byte(i)})
 	}
 	beaconState.LatestBlockRoots = blockRoots

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -338,28 +338,3 @@ func DeleteExitedVal(epoch uint64) {
 	defer VStore.Unlock()
 	delete(VStore.exitedValidators, epoch)
 }
-
-// allValidatorsIndices returns all validator indices from 0 to
-// the last validator.
-func allValidatorsIndices(state *pb.BeaconState) []uint64 {
-	validatorIndices := make([]uint64, len(state.ValidatorRegistry))
-	for i := 0; i < len(validatorIndices); i++ {
-		validatorIndices[i] = uint64(i)
-	}
-	return validatorIndices
-}
-
-// maxBalanceChurn returns the maximum balance churn in Gwei,
-// this determines how many validators can be rotated
-// in and out of the validator pool.
-// Spec pseudocode definition:
-//     max_balance_churn = max(
-//        MAX_DEPOSIT_AMOUNT,
-//        total_balance // (2 * MAX_BALANCE_CHURN_QUOTIENT))
-func maxBalanceChurn(totalBalance uint64) uint64 {
-	maxBalanceChurn := totalBalance / (2 * params.BeaconConfig().MaxBalanceChurnQuotient)
-	if maxBalanceChurn > params.BeaconConfig().MaxDepositAmount {
-		return maxBalanceChurn
-	}
-	return params.BeaconConfig().MaxDepositAmount
-}

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -49,24 +49,6 @@ func TestHasVoted_OK(t *testing.T) {
 	}
 }
 
-func TestAllValidatorIndices_OK(t *testing.T) {
-	tests := []struct {
-		registries []*pb.Validator
-		indices    []uint64
-	}{
-		{registries: []*pb.Validator{}, indices: []uint64{}},
-		{registries: []*pb.Validator{{}}, indices: []uint64{0}},
-		{registries: []*pb.Validator{{}, {}, {}, {}}, indices: []uint64{0, 1, 2, 3}},
-	}
-	for _, tt := range tests {
-		state := &pb.BeaconState{ValidatorRegistry: tt.registries}
-		if !reflect.DeepEqual(allValidatorsIndices(state), tt.indices) {
-			t.Errorf("AllValidatorsIndices(%v) = %v, wanted:%v",
-				tt.registries, allValidatorsIndices(state), tt.indices)
-		}
-	}
-}
-
 func TestProcessDeposit_BadWithdrawalCredentials(t *testing.T) {
 	registry := []*pb.Validator{
 		{
@@ -463,27 +445,6 @@ func TestExitValidator_AlreadyExited(t *testing.T) {
 	state = ExitValidator(state, 0)
 	if state.ValidatorRegistry[0].ExitEpoch != params.BeaconConfig().ActivationExitDelay {
 		t.Error("Expected exited validator to stay exited")
-	}
-}
-
-func TestMaxBalanceChurn_OK(t *testing.T) {
-	maxDepositAmount := params.BeaconConfig().MaxDepositAmount
-	tests := []struct {
-		totalBalance    uint64
-		maxBalanceChurn uint64
-	}{
-		{totalBalance: 1e9, maxBalanceChurn: maxDepositAmount},
-		{totalBalance: maxDepositAmount, maxBalanceChurn: maxDepositAmount},
-		{totalBalance: maxDepositAmount * 10, maxBalanceChurn: maxDepositAmount},
-		{totalBalance: params.BeaconConfig().MaxDepositAmount * 1000, maxBalanceChurn: 5 * 1e11},
-	}
-
-	for _, tt := range tests {
-		churn := maxBalanceChurn(tt.totalBalance)
-		if tt.maxBalanceChurn != churn {
-			t.Errorf("MaxBalanceChurn was not an expected value. Wanted: %d, got: %d",
-				tt.maxBalanceChurn, churn)
-		}
 	}
 }
 

--- a/beacon-chain/rpc/attester_server_test.go
+++ b/beacon-chain/rpc/attester_server_test.go
@@ -105,7 +105,7 @@ func TestAttestationDataAtSlot_OK(t *testing.T) {
 	beaconState := &pbp2p.BeaconState{
 		Slot:                  3*params.BeaconConfig().SlotsPerEpoch + 1,
 		CurrentJustifiedEpoch: 2 + 0,
-		LatestBlockRoots:      make([][]byte, params.BeaconConfig().LatestBlockRootsLength),
+		LatestBlockRoots:      make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot),
 		CurrentCrosslinks: []*pbp2p.Crosslink{
 			{
 				DataRoot: []byte("A"),
@@ -166,16 +166,16 @@ func TestAttestationDataAtSlot_handlesFarAwayJustifiedEpoch(t *testing.T) {
 	//
 	// State slot = 10000
 	// Last justified slot = epoch start of 1500
-	// LatestBlockRootsLength = 8192
+	// SlotsPerHistoricalRoot = 8192
 	//
 	// More background: https://github.com/prysmaticlabs/prysm/issues/2153
 	db := internal.SetupDB(t)
 	defer internal.TeardownDB(t, db)
 	ctx := context.Background()
 
-	// Ensure LatestBlockRootsLength matches scenario
+	// Ensure SlotsPerHistoricalRoot matches scenario
 	cfg := params.BeaconConfig()
-	cfg.LatestBlockRootsLength = 8192
+	cfg.SlotsPerHistoricalRoot = 8192
 	params.OverrideBeaconConfig(cfg)
 
 	block := &pbp2p.BeaconBlock{
@@ -202,7 +202,7 @@ func TestAttestationDataAtSlot_handlesFarAwayJustifiedEpoch(t *testing.T) {
 	beaconState := &pbp2p.BeaconState{
 		Slot:                  10000,
 		CurrentJustifiedEpoch: helpers.SlotToEpoch(1500),
-		LatestBlockRoots:      make([][]byte, params.BeaconConfig().LatestBlockRootsLength),
+		LatestBlockRoots:      make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot),
 		CurrentCrosslinks: []*pbp2p.Crosslink{
 			{
 				DataRoot: []byte("A"),

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -464,7 +464,7 @@ func (vs *ValidatorServer) depositBlockSlot(ctx context.Context, currentSlot uin
 	followTime := time.Duration(params.BeaconConfig().Eth1FollowDistance*params.BeaconConfig().GoerliBlockTime) * time.Second
 	eth1UnixTime := time.Unix(int64(blockTimeStamp), 0).Add(followTime)
 
-	votingPeriodSlots := helpers.StartSlot(params.BeaconConfig().EpochsPerEth1VotingPeriod)
+	votingPeriodSlots := helpers.StartSlot(params.BeaconConfig().SlotsPerEth1VotingPeriod / params.BeaconConfig().SlotsPerEpoch)
 	votingPeriodSeconds := time.Duration(votingPeriodSlots*params.BeaconConfig().SecondsPerSlot) * time.Second
 	timeToInclusion := eth1UnixTime.Add(votingPeriodSeconds)
 

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -17,15 +17,6 @@ type BeaconChainConfig struct {
 	ChurnLimitQuotient       uint64 `yaml:"CHURN_LIMIT_QUOTIENT"`        // ChurnLimitQuotient is used to determine the limit of how many validators can rotate per epoch.
 	BaseRewardsPerEpoch      uint64 `yaml:"BASE_REWARDS_PER_EPOCH"`      // BaseRewardsPerEpoch is used to calculate the per epoch rewards.
 	ShuffleRoundCount        uint64 `yaml:"SHUFFLE_ROUND_COUNT"`         // ShuffleRoundCount is used for retrieving the permuted index.
-	// TODO(2307): Remove deprecated fields
-	// Deprecated: Do not use.
-	MaxBalanceChurnQuotient uint64 // MaxBalanceChurnQuotient is used to determine how many validators can rotate per epoch.
-	// Deprecated: Do not use.
-	BeaconChainShardNumber uint64 // BeaconChainShardNumber is the shard number of the beacon chain.
-	// Deprecated: Do not use.
-	MaxIndicesPerSlashableVote uint64 // MaxIndicesPerSlashableVote is used to determine how many validators can be slashed per vote.
-	// Deprecated: Do not use.
-	MaxExitDequeuesPerEpoch uint64 // MaxWithdrawalsPerEpoch is the max withdrawals can happen for a single epoch.
 
 	// Deposit contract constants.
 	DepositContractAddress   []byte `yaml:"DEPOSIT_CONTRACT_ADDRESS"`    // DepositContractAddress is the address of the deposit contract in PoW chain.
@@ -37,21 +28,11 @@ type BeaconChainConfig struct {
 	MaxEffectiveBalance       uint64 `yaml:"MAX_EFFECTIVE_BALANCE"`       // MaxEffectiveBalance is the maximal amount of Gwie that is effective for staking.
 	EjectionBalance           uint64 `yaml:"EJECTION_BALANCE"`            // EjectionBalance is the minimal GWei a validator needs to have before ejected.
 	EffectiveBalanceIncrement uint64 `yaml:"EFFECTIVE_BALANCE_INCREMENT"` // EffectiveBalanceIncrement is used for converting the high balance into the low balance for validators.
-	// TODO(2307): Remove deprecated fields
-	//Deprecated: Do not use.
-	ForkChoiceBalanceIncrement uint64 // ForkChoiceBalanceIncrement is used to track block score based on balances for fork choice.
 
 	// Initial value constants.
 	FarFutureEpoch          uint64   `yaml:"FAR_FUTURE_EPOCH"` // FarFutureEpoch represents a epoch extremely far away in the future used as the default penalization slot for validators.
 	ZeroHash                [32]byte // ZeroHash is used to represent a zeroed out 32 byte array.
 	BLSWithdrawalPrefixByte byte     `yaml:"BLS_WITHDRAWAL_PREFIX_BYTE"` // BLSWithdrawalPrefixByte is used for BLS withdrawal and it's the first byte.
-	// TODO(2307): Remove deprecated fields
-	// Deprecated: Do not use.
-	GenesisForkVersion []byte `yaml:"GENESIS_FORK_VERSION"` // GenesisForkVersion is used to track fork version between state transitions.
-	// Deprecated: Do not use.
-	GenesisStartShard uint64 // GenesisStartShard is the first shard to assign validators.
-	// Deprecated: Do not use.
-	EmptySignature [96]byte // EmptySignature is used to represent a zeroed out BLS Signature.
 
 	// Time parameters constants.
 	SecondsPerSlot               uint64 `yaml:"SECONDS_PER_SLOT"`                    // SecondsPerSlot is how many seconds are in a single slot.
@@ -66,17 +47,11 @@ type BeaconChainConfig struct {
 	MaxCrosslinkEpochs           uint64 `yaml:"MAX_EPOCHS_PER_CROSSLINK"`            // MaxCrosslinkEpochs defines the max epoch from current a crosslink can be formed at.
 	MinEpochsToInactivityPenalty uint64 `yaml:"MIN_EPOCHS_TO_INACTIVITY_PENALTY"`    // MinEpochsToInactivityPenalty defines the minimum amount of epochs since finality to begin penalizing inactivity.
 	Eth1FollowDistance           uint64 // Eth1FollowDistance is the number of eth1.0 blocks to wait before considering a new deposit for voting. This only applies after the chain as been started.
-	// TODO(2307): Remove deprecated fields
-	// Deprecated: Do not use.
-	EpochsPerEth1VotingPeriod uint64 // EpochsPerEth1VotingPeriod defines how often the merkle root of deposit receipts get updated in beacon node.
 
 	// State list lengths
 	LatestRandaoMixesLength      uint64 `yaml:"LATEST_RANDAO_MIXES_LENGTH"`       // LatestRandaoMixesLength is the number of randao mixes kept in the beacon state.
 	LatestActiveIndexRootsLength uint64 `yaml:"LATEST_ACTIVE_INDEX_ROOTS_LENGTH"` // LatestIndexRootsLength is the number of index roots kept in beacon state, used by light client.
 	LatestSlashedExitLength      uint64 `yaml:"LATEST_SLASHED_EXIT_LENGTH"`       // LatestSlashedExitLength is used to track penalized exit balances per time interval.
-	// TODO(2307): Remove deprecated fields
-	// Deprecated: Do not use.
-	LatestBlockRootsLength uint64 // LatestBlockRootsLength is the number of block roots kept in the beacon state.
 
 	// Reward and penalty quotients constants.
 	BaseRewardQuotient           uint64 `yaml:"BASE_REWARD_QUOTIENT"`           // BaseRewardQuotient is used to calculate validator per-slot interest rate.
@@ -84,9 +59,6 @@ type BeaconChainConfig struct {
 	ProposerRewardQuotient       uint64 `yaml:"PROPOSER_REWARD_QUOTIENT"`       // ProposerRewardQuotient is used to calculate the reward for proposers.
 	InactivityPenaltyQuotient    uint64 `yaml:"INACTIVITY_PENALTY_QUOTIENT"`    // InactivityPenaltyQuotient is used to calculate the penalty for a validator that is offline.
 	MinSlashingPenaltyQuotient   uint64 `yaml:"MIN_SLASHING_PENALTY_QUOTIENT"`  // MinSlashingPenaltyQuotient is used to calculate the minimum penalty to prevent DoS attacks.
-	// TODO(2307): Remove deprecated fields
-	// Deprecated: Do not use.
-	AttestationInclusionRewardQuotient uint64 // AttestationInclusionRewardQuotient defines the reward quotient of proposer for including attestations.
 
 	// Max operations per block constants.
 	MaxProposerSlashings uint64 `yaml:"MAX_PROPOSER_SLASHINGS"` // MaxProposerSlashings defines the maximum number of slashings of proposers possible in a block.
@@ -121,6 +93,8 @@ type BeaconChainConfig struct {
 	RPCSyncCheck              time.Duration // Number of seconds to query the sync service, to find out if the node is synced or not.
 	TestnetContractEndpoint   string        // TestnetContractEndpoint to fetch the contract address of the Prysmatic Labs testnet.
 	GoerliBlockTime           uint64        // GoerliBlockTime is the number of seconds on avg a Goerli block is created.
+	GenesisForkVersion []byte `yaml:"GENESIS_FORK_VERSION"` // GenesisForkVersion is used to track fork version between state transitions.
+	EmptySignature [96]byte // EmptySignature is used to represent a zeroed out BLS Signature.
 }
 
 // DepositContractConfig contains the deposits for
@@ -146,13 +120,6 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	BaseRewardsPerEpoch:      5,
 	ShuffleRoundCount:        90,
 
-	// TODO(2307): Remove deprecated fields
-	// Deprecated.
-	MaxBalanceChurnQuotient:    32,
-	BeaconChainShardNumber:     1<<64 - 1,
-	MaxIndicesPerSlashableVote: 4096,
-	MaxExitDequeuesPerEpoch:    4,
-
 	// Deposit contract constants.
 	DepositContractTreeDepth: 32,
 
@@ -162,18 +129,11 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	MaxEffectiveBalance:        32 * 1e9,
 	EjectionBalance:            16 * 1e9,
 	EffectiveBalanceIncrement:  1 * 1e9,
-	ForkChoiceBalanceIncrement: 1 * 1e9,
 
 	// Initial value constants.
 	FarFutureEpoch:          1<<64 - 1,
 	ZeroHash:                [32]byte{},
 	BLSWithdrawalPrefixByte: byte(0),
-
-	// TODO(2307): Remove deprecated fields
-	// Deprecated.
-	GenesisForkVersion: []byte{0, 0, 0, 0},
-	GenesisStartShard:  0,
-	EmptySignature:     [96]byte{},
 
 	// Time parameter constants.
 	SecondsPerSlot:               6,
@@ -194,16 +154,10 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	LatestActiveIndexRootsLength: 8192,
 	LatestSlashedExitLength:      8192,
 
-	// TODO(2307): Remove deprecated fields
-	// Deprecated.
-	EpochsPerEth1VotingPeriod: 16,
-	LatestBlockRootsLength:    8192,
-
 	// Reward and penalty quotients constants.
 	BaseRewardQuotient:                 32,
 	ProposerRewardQuotient:             8,
 	WhistleBlowingRewardQuotient:       512,
-	AttestationInclusionRewardQuotient: 8,
 	InactivityPenaltyQuotient:          1 << 25,
 	MinSlashingPenaltyQuotient:         32,
 
@@ -237,6 +191,8 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	ValidatorPrivkeyFileName:  "/validatorprivatekey",
 	RPCSyncCheck:              1,
 	GoerliBlockTime:           14, // 14 seconds on average for a goerli block to be created.
+	GenesisForkVersion: []byte{0, 0, 0, 0},
+	EmptySignature:     [96]byte{},
 
 	// Testnet misc values.
 	TestnetContractEndpoint: "https://beta.prylabs.net/contract", // defines an http endpoint to fetch the testnet contract addr.
@@ -275,11 +231,11 @@ func DemoBeaconConfig() *BeaconChainConfig {
 	demoConfig.EjectionBalance = 3.175 * 1e9
 	demoConfig.SyncPollingInterval = 1 * 10 // Query nodes over the network every slot.
 	demoConfig.Eth1FollowDistance = 5
-	demoConfig.EpochsPerEth1VotingPeriod = 1
+	demoConfig.SlotsPerEth1VotingPeriod = 1
 	demoConfig.LatestRandaoMixesLength = 5 * demoConfig.SlotsPerEpoch
 	demoConfig.LatestActiveIndexRootsLength = 5 * demoConfig.SlotsPerEpoch
 	demoConfig.LatestSlashedExitLength = 5 * demoConfig.SlotsPerEpoch
-	demoConfig.LatestBlockRootsLength = 5 * demoConfig.SlotsPerEpoch
+	demoConfig.SlotsPerHistoricalRoot = 5 * demoConfig.SlotsPerEpoch
 
 	return &demoConfig
 }


### PR DESCRIPTION
This PR cleaned up all the deprecated beacon chain configs from `config.go`

`LATEST_BLOCK_ROOTS_LENGTH` was renamed to `SLOTS_PER_HISTORICAL_ROOT` in the spec