### PR TITLE
Minor v0.7 updates to config names and function parameters

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -579,7 +579,7 @@ func ProcessAttestation(beaconState *pb.BeaconState, att *pb.Attestation, verify
 	if data.TargetEpoch != ffgTargetEpoch {
 		return nil, fmt.Errorf("expected target epoch %d, received %d", ffgTargetEpoch, data.TargetEpoch)
 	}
-	endEpoch := parentCrosslink.EndEpoch + params.BeaconConfig().MaxCrosslinkEpochs
+	endEpoch := parentCrosslink.EndEpoch + params.BeaconConfig().MaxEpochsPerCrosslink
 	if data.TargetEpoch < endEpoch {
 		endEpoch = data.TargetEpoch
 	}

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -410,10 +410,9 @@ func ProcessRegistryUpdates(state *pb.BeaconState) (*pb.BeaconState, error) {
 //
 //  def process_slashings(state: BeaconState) -> None:
 //    current_epoch = get_current_epoch(state)
-//    active_validator_indices = get_active_validator_indices(state, current_epoch)
-//    total_balance = get_total_balance(state, active_validator_indices)
+//    total_balance = get_total_active_balance(state)
 //
-//    # Compute `total_penalties`
+//    # Compute slashed balances in the current epoch
 //    total_at_start = state.latest_slashed_balances[(current_epoch + 1) % LATEST_SLASHED_EXIT_LENGTH]
 //    total_at_end = state.latest_slashed_balances[current_epoch % LATEST_SLASHED_EXIT_LENGTH]
 //    total_penalties = total_at_end - total_at_start
@@ -432,7 +431,7 @@ func ProcessSlashings(state *pb.BeaconState) (*pb.BeaconState, error) {
 		return nil, fmt.Errorf("could not get total active balance: %v", err)
 	}
 
-	// Compute the total penalties.
+	// Compute slashed balances in the current epoch
 	exitLength := params.BeaconConfig().LatestSlashedExitLength
 	totalAtStart := state.LatestSlashedBalances[(currentEpoch+1)%exitLength]
 	totalAtEnd := state.LatestSlashedBalances[currentEpoch%exitLength]
@@ -754,7 +753,7 @@ func attestationDelta(state *pb.BeaconState) ([]uint64, []uint64, error) {
 		return nil, nil, fmt.Errorf("could not get total active balance: %v", err)
 	}
 	adjustedQuotient := mathutil.IntegerSquareRoot(totalBalance /
-		params.BeaconConfig().BaseRewardQuotient)
+		params.BeaconConfig().BaseRewardFactor)
 	rewards := make([]uint64, len(state.ValidatorRegistry))
 	penalties := make([]uint64, len(state.ValidatorRegistry))
 
@@ -902,7 +901,7 @@ func crosslinkDelta(state *pb.BeaconState) ([]uint64, []uint64, error) {
 		return nil, nil, fmt.Errorf("could not get total active balance: %v", err)
 	}
 	adjustedQuotient := mathutil.IntegerSquareRoot(totalBalance /
-		params.BeaconConfig().BaseRewardQuotient)
+		params.BeaconConfig().BaseRewardFactor)
 
 	rewards := make([]uint64, len(state.ValidatorRegistry))
 	penalties := make([]uint64, len(state.ValidatorRegistry))

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -618,7 +618,7 @@ func TestBaseReward_AccurateRewards(t *testing.T) {
 			Balances: []uint64{tt.a},
 		}
 		totalBalance, _ := helpers.TotalActiveBalance(state)
-		adjustedQuotient := mathutil.IntegerSquareRoot(totalBalance / params.BeaconConfig().BaseRewardQuotient)
+		adjustedQuotient := mathutil.IntegerSquareRoot(totalBalance / params.BeaconConfig().BaseRewardFactor)
 		c, err := baseReward(state, 0, adjustedQuotient)
 		if err != nil {
 			t.Fatal(err)
@@ -869,7 +869,7 @@ func TestCrosslinkDelta_NoOneAttested(t *testing.T) {
 		t.Fatal(err)
 	}
 	totalBalance, _ := helpers.TotalActiveBalance(state)
-	adjustedQuotient := mathutil.IntegerSquareRoot(totalBalance / params.BeaconConfig().BaseRewardQuotient)
+	adjustedQuotient := mathutil.IntegerSquareRoot(totalBalance / params.BeaconConfig().BaseRewardFactor)
 	for i := uint64(0); i < validatorCount; i++ {
 		// Since no one attested, all the validators should gain 0 reward
 		if rewards[i] != 0 {
@@ -1040,7 +1040,7 @@ func TestAttestationDelta_NoOneAttested(t *testing.T) {
 		t.Fatal(err)
 	}
 	totalBalance, _ := helpers.TotalActiveBalance(state)
-	adjustedQuotient := mathutil.IntegerSquareRoot(totalBalance / params.BeaconConfig().BaseRewardQuotient)
+	adjustedQuotient := mathutil.IntegerSquareRoot(totalBalance / params.BeaconConfig().BaseRewardFactor)
 	for i := uint64(0); i < validatorCount; i++ {
 		// Since no one attested, all the validators should gain 0 reward
 		if rewards[i] != 0 {
@@ -1096,7 +1096,7 @@ func TestAttestationDelta_SomeAttested(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	adjustedQuotient := mathutil.IntegerSquareRoot(totalBalance / params.BeaconConfig().BaseRewardQuotient)
+	adjustedQuotient := mathutil.IntegerSquareRoot(totalBalance / params.BeaconConfig().BaseRewardFactor)
 	for _, i := range attestedIndices {
 		base, _ := baseReward(state, i, adjustedQuotient)
 		// Base rewards for getting source right

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -19,7 +19,7 @@ import (
 // full deposits were made to the deposit contract and the ChainStart log gets emitted.
 //
 // Spec pseudocode definition:
-//  def get_genesis_beacon_state(genesis_validator_deposits: List[Deposit],
+//  def get_genesis_beacon_state(deposits: List[Deposit],
 //                             genesis_time: int,
 //                             genesis_eth1_data: Eth1Data) -> BeaconState:
 //    """
@@ -42,25 +42,15 @@ import (
 //        state.latest_active_index_roots[index] = genesis_active_index_root
 //
 //    return state
-func GenesisBeaconState(
-	genesisValidatorDeposits []*pb.Deposit,
-	genesisTime uint64,
-	eth1Data *pb.Eth1Data,
-) (*pb.BeaconState, error) {
-	latestRandaoMixes := make(
-		[][]byte,
-		params.BeaconConfig().LatestRandaoMixesLength,
-	)
+func GenesisBeaconState(deposits []*pb.Deposit, genesisTime uint64, eth1Data *pb.Eth1Data) (*pb.BeaconState, error) {
+	latestRandaoMixes := make([][]byte, params.BeaconConfig().LatestRandaoMixesLength)
 	for i := 0; i < len(latestRandaoMixes); i++ {
 		latestRandaoMixes[i] = make([]byte, 32)
 	}
 
 	zeroHash := params.BeaconConfig().ZeroHash[:]
 
-	latestActiveIndexRoots := make(
-		[][]byte,
-		params.BeaconConfig().LatestActiveIndexRootsLength,
-	)
+	latestActiveIndexRoots := make([][]byte, params.BeaconConfig().LatestActiveIndexRootsLength)
 	for i := 0; i < len(latestActiveIndexRoots); i++ {
 		latestActiveIndexRoots[i] = zeroHash
 	}
@@ -77,9 +67,8 @@ func GenesisBeaconState(
 		latestBlockRoots[i] = zeroHash
 	}
 
-	validatorRegistry := make([]*pb.Validator, len(genesisValidatorDeposits))
-	for i, d := range genesisValidatorDeposits {
-
+	validatorRegistry := make([]*pb.Validator, len(deposits))
+	for i, d := range deposits {
 		validator := &pb.Validator{
 			Pubkey:                d.Data.Pubkey,
 			WithdrawalCredentials: d.Data.WithdrawalCredentials,
@@ -92,7 +81,7 @@ func GenesisBeaconState(
 		validatorRegistry[i] = validator
 	}
 
-	latestBalances := make([]uint64, len(genesisValidatorDeposits))
+	latestBalances := make([]uint64, len(deposits))
 	latestSlashedExitBalances := make([]uint64, params.BeaconConfig().LatestSlashedExitLength)
 
 	state := &pb.BeaconState{
@@ -140,7 +129,7 @@ func GenesisBeaconState(
 	// Process initial deposits.
 	var err error
 	validatorMap := stateutils.ValidatorIndexMap(state)
-	for _, deposit := range genesisValidatorDeposits {
+	for _, deposit := range deposits {
 		state, err = v.ProcessDeposit(
 			state,
 			validatorMap,

--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -141,7 +141,7 @@ func (as *AttesterServer) RequestAttestation(ctx context.Context, req *pb.Attest
 	}
 
 	startEpoch := headState.PreviousCrosslinks[req.Shard].EndEpoch
-	endEpoch := startEpoch + params.BeaconConfig().MaxCrosslinkEpochs
+	endEpoch := startEpoch + params.BeaconConfig().MaxEpochsPerCrosslink
 	if endEpoch > targetEpoch {
 		endEpoch = targetEpoch
 	}

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -44,7 +44,7 @@ type BeaconChainConfig struct {
 	SlotsPerHistoricalRoot       uint64 `yaml:"SLOTS_PER_HISTORICAL_ROOT"`           // SlotsPerHistoricalRoot defines how often the historical root is saved.
 	MinValidatorWithdrawalDelay  uint64 `yaml:"MIN_VALIDATOR_WITHDRAWABILITY_DELAY"` // MinValidatorWithdrawalEpochs is the shortest amount of time a validator has to wait to withdraw.
 	PersistentCommitteePeriod    uint64 `yaml:"PERSISTENT_COMMITTEE_PERIOD"`         // PersistentCommitteePeriod is the minimum amount of epochs a validator must participate before exitting.
-	MaxCrosslinkEpochs           uint64 `yaml:"MAX_EPOCHS_PER_CROSSLINK"`            // MaxCrosslinkEpochs defines the max epoch from current a crosslink can be formed at.
+	MaxEpochsPerCrosslink        uint64 `yaml:"MAX_EPOCHS_PER_CROSSLINK"`            // MaxEpochsPerCrosslink defines the max epoch from current a crosslink can be formed at.
 	MinEpochsToInactivityPenalty uint64 `yaml:"MIN_EPOCHS_TO_INACTIVITY_PENALTY"`    // MinEpochsToInactivityPenalty defines the minimum amount of epochs since finality to begin penalizing inactivity.
 	Eth1FollowDistance           uint64 // Eth1FollowDistance is the number of eth1.0 blocks to wait before considering a new deposit for voting. This only applies after the chain as been started.
 
@@ -54,7 +54,7 @@ type BeaconChainConfig struct {
 	LatestSlashedExitLength      uint64 `yaml:"LATEST_SLASHED_EXIT_LENGTH"`       // LatestSlashedExitLength is used to track penalized exit balances per time interval.
 
 	// Reward and penalty quotients constants.
-	BaseRewardQuotient           uint64 `yaml:"BASE_REWARD_QUOTIENT"`           // BaseRewardQuotient is used to calculate validator per-slot interest rate.
+	BaseRewardFactor             uint64 `yaml:"BASE_REWARD_FACTOR"`             // BaseRewardFactor is used to calculate validator per-slot interest rate.
 	WhistleBlowingRewardQuotient uint64 `yaml:"WHISTLEBLOWING_REWARD_QUOTIENT"` // WhistleBlowingRewardQuotient is used to calculate whistler blower reward.
 	ProposerRewardQuotient       uint64 `yaml:"PROPOSER_REWARD_QUOTIENT"`       // ProposerRewardQuotient is used to calculate the reward for proposers.
 	InactivityPenaltyQuotient    uint64 `yaml:"INACTIVITY_PENALTY_QUOTIENT"`    // InactivityPenaltyQuotient is used to calculate the penalty for a validator that is offline.
@@ -145,7 +145,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	SlotsPerHistoricalRoot:       8192,
 	MinValidatorWithdrawalDelay:  256,
 	PersistentCommitteePeriod:    2048,
-	MaxCrosslinkEpochs:           64,
+	MaxEpochsPerCrosslink:        64,
 	MinEpochsToInactivityPenalty: 4,
 	Eth1FollowDistance:           1024,
 
@@ -155,7 +155,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	LatestSlashedExitLength:      8192,
 
 	// Reward and penalty quotients constants.
-	BaseRewardQuotient:           32,
+	BaseRewardFactor:             32,
 	ProposerRewardQuotient:       8,
 	WhistleBlowingRewardQuotient: 512,
 	InactivityPenaltyQuotient:    1 << 25,


### PR DESCRIPTION
Part of #2790 

Rename: 
`MaxCrosslinkEpochs` to `MaxEpochsPerCrosslink` in Beacon Chain config 
`BaseRewardQuotient` to [`BaseRewardFactor`](https://github.com/ethereum/eth2.0-specs/pull/1123/files#diff-51a43328a58414e132a744f3771f018cR227) 
parameters in [`get_genesis_beacon_state`](https://github.com/ethereum/eth2.0-specs/pull/1049/files#diff-51a43328a58414e132a744f3771f018cR1195)

Also documentation updates in `process_slashings`