### PR TITLE
Update buildkite badge to show build for master only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Prysmatic Labs Ethereum Serenity Implementation
 
-[![Build status](https://badge.buildkite.com/b555891daf3614bae4284dcf365b2340cefc0089839526f096.svg)](https://buildkite.com/prysmatic-labs/prysm)
+[![Build status](https://badge.buildkite.com/b555891daf3614bae4284dcf365b2340cefc0089839526f096.svg?branch=master)](https://buildkite.com/prysmatic-labs/prysm)
 
 This is the main repository for the Go implementation of the Ethereum 2.0 Serenity [Prysmatic Labs](https://prysmaticlabs.com).
 


### PR DESCRIPTION
It was displaying the latest build status, so it was often failing if PRs were being worked on.