### PR TITLE
Fix blocking routine in cluster pk manager

### DIFF
--- a/tools/cluster-pk-manager/server/allocations.go
+++ b/tools/cluster-pk-manager/server/allocations.go
@@ -32,6 +32,8 @@ func (s *server) serveAllocationsHTTPPage() {
 	})
 
 	srv := &http.Server{Addr: ":8080", Handler: mux}
-	go log.Fatal(srv.ListenAndServe())
+	go func() {
+		log.Fatal(srv.ListenAndServe())
+	}()
 	log.Info("Serving allocations page at :8080/allocations")
 }


### PR DESCRIPTION
This was blocking the gRPC server from starting.