### PR TITLE
Revert "Add Functions for Compressed and Uncompressed HashG2 With Domain"

### DIFF
--- a/shared/bls/BUILD.bazel
+++ b/shared/bls/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//shared/bytesutil:go_default_library",
-        "@com_github_phoreproject_bls//:go_default_library",
         "@com_github_phoreproject_bls//g1pubs:go_default_library",
     ],
 )
@@ -16,8 +15,5 @@ go_test(
     name = "go_default_test",
     srcs = ["bls_test.go"],
     embed = [":go_default_library"],
-    deps = [
-        "//shared/bytesutil:go_default_library",
-        "@com_github_phoreproject_bls//:go_default_library",
-    ],
+    deps = ["//shared/bytesutil:go_default_library"],
 )

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/phoreproject/bls"
 	g1 "github.com/phoreproject/bls/g1pubs"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 )
@@ -124,18 +123,6 @@ func AggregateSignatures(sigs []*Signature) *Signature {
 		ss = append(ss, v.val)
 	}
 	return &Signature{val: g1.AggregateSignatures(ss)}
-}
-
-// HashG2WithDomainCompressed returns the compressed hash.
-func HashG2WithDomainCompressed(msg [32]byte, domain uint64) [96]byte {
-	projective := bls.HashG2WithDomain(msg, domain)
-	return bls.CompressG2(projective.ToAffine())
-}
-
-// HashG2WithDomainUncompressed returns the uncompressed hash.
-func HashG2WithDomainUncompressed(msg [32]byte, domain uint64) [192]byte {
-	projective := bls.HashG2WithDomain(msg, domain)
-	return projective.ToAffine().SerializeBytes()
 }
 
 // Domain returns the bls domain given by the domain type and the operation 4 byte fork version.

--- a/shared/bls/bls_test.go
+++ b/shared/bls/bls_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"testing"
 
-	bls2 "github.com/phoreproject/bls"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 )
@@ -50,22 +49,5 @@ func TestVerifyAggregate(t *testing.T) {
 	aggSig := bls.AggregateSignatures(sigs)
 	if !aggSig.VerifyAggregate(pubkeys, msg, 0) {
 		t.Error("Signature did not verify")
-	}
-}
-
-func TestHashG2WithDomain(t *testing.T) {
-	var msg [32]byte
-	copy(msg[:], []byte{'H', 'E', 'L', 'L', 'O'})
-	domain := uint64(10)
-	compHash := bls.HashG2WithDomainCompressed(msg, domain)
-	unCompHash := bls.HashG2WithDomainUncompressed(msg, domain)
-	g2Affine, err := bls2.DecompressG2(compHash)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if unCompHash != g2Affine.SerializeBytes() {
-		t.Errorf("Uncompressed and Compressed Hash do not point to the same affine point. Expected %#x but got %#x",
-			unCompHash, g2Affine.SerializeBytes())
 	}
 }


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#2833

We don't need this functionality in our BLS API for spec tests alone. We can test the underlying library to ensure hash g2 messages work properly