### PR TITLE
Added the 'enable-upnp' flag to the list of command line args

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -57,6 +57,7 @@ var appFlags = []cli.Flag{
 	debug.CPUProfileFlag,
 	debug.TraceFlag,
 	cmd.LogFileName,
+    cmd.EnableUPnPFlag,
 }
 
 func init() {

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -57,7 +57,7 @@ var appFlags = []cli.Flag{
 	debug.CPUProfileFlag,
 	debug.TraceFlag,
 	cmd.LogFileName,
-    cmd.EnableUPnPFlag,
+	cmd.EnableUPnPFlag,
 }
 
 func init() {

--- a/beacon-chain/node/p2p_config.go
+++ b/beacon-chain/node/p2p_config.go
@@ -55,6 +55,7 @@ func configureP2P(ctx *cli.Context) (*p2p.Server, error) {
 		PrvKey:                 ctx.GlobalString(cmd.P2PPrivKey.Name),
 		DepositContractAddress: contractAddress,
 		WhitelistCIDR:          ctx.GlobalString(cmd.P2PWhitelist.Name),
+        EnableUPnP:				ctx.GlobalBool(cmd.EnableUPnPFlag.Name),
 	})
 	if err != nil {
 		return nil, err

--- a/beacon-chain/node/p2p_config.go
+++ b/beacon-chain/node/p2p_config.go
@@ -55,7 +55,7 @@ func configureP2P(ctx *cli.Context) (*p2p.Server, error) {
 		PrvKey:                 ctx.GlobalString(cmd.P2PPrivKey.Name),
 		DepositContractAddress: contractAddress,
 		WhitelistCIDR:          ctx.GlobalString(cmd.P2PWhitelist.Name),
-        EnableUPnP:				ctx.GlobalBool(cmd.EnableUPnPFlag.Name),
+		EnableUPnP:             ctx.GlobalBool(cmd.EnableUPnPFlag.Name),
 	})
 	if err != nil {
 		return nil, err

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -93,6 +93,7 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.P2PPrivKey,
 			cmd.P2PWhitelist,
 			cmd.StaticPeers,
+			cmd.EnableUPnPFlag,
 		},
 	},
 	{

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -132,6 +132,6 @@ var (
 	// EnableUPnPFlag specifies if UPnP should be enabled or not. The default value is false.
 	EnableUPnPFlag = cli.BoolFlag{
 		Name:  "enable-upnp",
-		Usage: "Enable UPnP",
+		Usage: "Enable the service (Beacon chain or Validator) to use UPnP when possibe.",
 	}
 )

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -129,4 +129,9 @@ var (
 		Name:  "log-file",
 		Usage: "Specify log file name, relative or absolute",
 	}
+	// EnableUPnPFlag specifies if UPnP should be enabled or not. The default value is false.
+	EnableUPnPFlag = cli.BoolFlag{
+		Name:  "enable-upnp",
+		Usage: "Enable UPnP",
+	}
 )

--- a/shared/p2p/options.go
+++ b/shared/p2p/options.go
@@ -28,13 +28,19 @@ func buildOptions(cfg *ServerConfig) []libp2p.Option {
 		log.Errorf("Failed to p2p listen: %v", err)
 	}
 
-	return []libp2p.Option{
+	options := []libp2p.Option{
 		libp2p.ListenAddrs(listen),
 		libp2p.EnableRelay(), // Allows dialing to peers via relay.
 		optionConnectionManager(cfg.MaxPeers),
 		whitelistSubnet(cfg.WhitelistCIDR),
 		privKey(cfg.PrvKey),
 	}
+
+	if cfg.EnableUPnP {
+		options = append(options, libp2p.NATPortMap()) //Allow to use UPnP
+	}
+
+	return options
 }
 
 // whitelistSubnet adds a whitelist multiaddress filter for a given CIDR subnet.

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -75,6 +75,7 @@ type ServerConfig struct {
 	MaxPeers               int
 	DepositContractAddress string
 	WhitelistCIDR          string
+	EnableUPnP             bool
 }
 
 // NewServer creates a new p2p server instance.
@@ -216,6 +217,8 @@ func (s *Server) Start() {
 		}
 
 		peersToWatch = append(peersToWatch, s.bootstrapNode, s.relayNodeAddr)
+
+		log.Info("Listening on ", s.host.Addrs())
 	}
 
 	for _, staticPeer := range s.staticPeers {

--- a/shared/p2p/service.go
+++ b/shared/p2p/service.go
@@ -218,7 +218,7 @@ func (s *Server) Start() {
 
 		peersToWatch = append(peersToWatch, s.bootstrapNode, s.relayNodeAddr)
 
-		log.Info("Listening on ", s.host.Addrs())
+		log.Infof("Listening on %s", s.host.Addrs())
 	}
 
 	for _, staticPeer := range s.staticPeers {

--- a/validator/main.go
+++ b/validator/main.go
@@ -154,6 +154,7 @@ contract in order to activate the validator client`,
 		debug.CPUProfileFlag,
 		debug.TraceFlag,
 		cmd.LogFileName,
+		cmd.EnableUPnPFlag,
 	}
 
 	app.Flags = append(app.Flags, featureconfig.ValidatorFlags...)


### PR DESCRIPTION
If the user specifies this feature flag (adds --enable-upnp as an argument) - the Beacon-chain and Validator services, when started, will initialize libp2p with the UPNP options.


This pull request will resolve issue #2757 

**summary of the changes**
I added a new command line argument : 'enable-upnp'. 
If the user specifies this feature flag (adds --enable-upnp as an argument) - the Beacon-chain and Validator services, when started, will initialize libp2p with the UPNP option. 


