### PR TITLE
Update go-ssz lib dep and usage according to the changes in interface.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1100,6 +1100,6 @@ go_repository(
 
 go_repository(
     name = "com_github_prysmaticlabs_go_ssz",
-    commit = "766487b700edeebc75cac5d8297163f19c65bf5d",
+    commit = "035448cee754a2d959cea5a0ea6503324e5c731e",
     importpath = "github.com/prysmaticlabs/go-ssz",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -154,17 +154,6 @@ load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_depen
 
 buildifier_dependencies()
 
-# http_archive(
-#     name = "com_github_prysmaticlabs_go_ssz",
-#     sha256 = "f6fd5d623a988337810b956ddaf612dce771d9d0f9256934c8f4b1379f1cb2f6",
-#     strip_prefix = "go-ssz-2e84733edbac32aca6d47feafc4441e43b10047f",
-#     url = "https://github.com/prysmaticlabs/go-ssz/archive/2e84733edbac32aca6d47feafc4441e43b10047f.tar.gz",
-# )
-
-# load("@com_github_prysmaticlabs_go_ssz//:deps.bzl", "go_ssz_dependencies")
-
-# go_ssz_dependencies()
-
 go_repository(
     name = "com_github_golang_mock",
     commit = "51421b967af1f557f93a59e0057aaf15ca02e29c",  # v1.2.0
@@ -1103,3 +1092,4 @@ go_repository(
     commit = "035448cee754a2d959cea5a0ea6503324e5c731e",
     importpath = "github.com/prysmaticlabs/go-ssz",
 )
+go_ssz_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1092,4 +1092,5 @@ go_repository(
     commit = "035448cee754a2d959cea5a0ea6503324e5c731e",
     importpath = "github.com/prysmaticlabs/go-ssz",
 )
+load("@com_github_prysmaticlabs_go_ssz//:deps.bzl", "go_ssz_dependencies")
 go_ssz_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -154,16 +154,16 @@ load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_depen
 
 buildifier_dependencies()
 
-http_archive(
-    name = "com_github_prysmaticlabs_go_ssz",
-    sha256 = "f6fd5d623a988337810b956ddaf612dce771d9d0f9256934c8f4b1379f1cb2f6",
-    strip_prefix = "go-ssz-2e84733edbac32aca6d47feafc4441e43b10047f",
-    url = "https://github.com/prysmaticlabs/go-ssz/archive/2e84733edbac32aca6d47feafc4441e43b10047f.tar.gz",
-)
+# http_archive(
+#     name = "com_github_prysmaticlabs_go_ssz",
+#     sha256 = "f6fd5d623a988337810b956ddaf612dce771d9d0f9256934c8f4b1379f1cb2f6",
+#     strip_prefix = "go-ssz-2e84733edbac32aca6d47feafc4441e43b10047f",
+#     url = "https://github.com/prysmaticlabs/go-ssz/archive/2e84733edbac32aca6d47feafc4441e43b10047f.tar.gz",
+# )
 
-load("@com_github_prysmaticlabs_go_ssz//:deps.bzl", "go_ssz_dependencies")
+# load("@com_github_prysmaticlabs_go_ssz//:deps.bzl", "go_ssz_dependencies")
 
-go_ssz_dependencies()
+# go_ssz_dependencies()
 
 go_repository(
     name = "com_github_golang_mock",
@@ -1096,4 +1096,10 @@ go_repository(
     name = "com_github_koron_go_ssdp",
     commit = "4a0ed625a78b6858dc8d3a55fb7728968b712122",
     importpath = "github.com/koron/go-ssdp",
+)
+
+go_repository(
+    name = "com_github_prysmaticlabs_go_ssz",
+    commit = "766487b700edeebc75cac5d8297163f19c65bf5d",
+    importpath = "github.com/prysmaticlabs/go-ssz",
 )

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prysmaticlabs/go-ssz"
+	ssz "github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
@@ -820,7 +820,7 @@ func TestProcessBlockAttestations_PreviousJustifiedEpochVerificationFailure(t *t
 		},
 	}
 	state := &pb.BeaconState{
-		Slot:                   params.BeaconConfig().GenesisSlot + 2*params.BeaconConfig().SlotsPerEpoch,
+		Slot: params.BeaconConfig().GenesisSlot + 2*params.BeaconConfig().SlotsPerEpoch,
 		PreviousJustifiedEpoch: params.BeaconConfig().GenesisEpoch + 2,
 	}
 
@@ -854,7 +854,7 @@ func TestProcessBlockAttestations_CrosslinkRootFailure(t *testing.T) {
 		},
 	}
 	state := &pb.BeaconState{
-		Slot:                   params.BeaconConfig().GenesisSlot + 70,
+		Slot: params.BeaconConfig().GenesisSlot + 70,
 		PreviousJustifiedEpoch: params.BeaconConfig().GenesisEpoch,
 		LatestBlockRootHash32S: blockRoots,
 		PreviousJustifiedRoot:  blockRoots[0],
@@ -863,8 +863,8 @@ func TestProcessBlockAttestations_CrosslinkRootFailure(t *testing.T) {
 	attestations := []*pb.Attestation{
 		{
 			Data: &pb.AttestationData{
-				Shard:                    0,
-				Slot:                     params.BeaconConfig().GenesisSlot + 20,
+				Shard: 0,
+				Slot:  params.BeaconConfig().GenesisSlot + 20,
 				JustifiedBlockRootHash32: blockRoots[0],
 				LatestCrosslink:          &pb.Crosslink{CrosslinkDataRootHash32: []byte{2}},
 				CrosslinkDataRootHash32:  params.BeaconConfig().ZeroHash[:],
@@ -902,7 +902,7 @@ func TestProcessBlockAttestations_ShardBlockRootEqualZeroHashFailure(t *testing.
 		},
 	}
 	state := &pb.BeaconState{
-		Slot:                   params.BeaconConfig().GenesisSlot + 70,
+		Slot: params.BeaconConfig().GenesisSlot + 70,
 		PreviousJustifiedEpoch: params.BeaconConfig().GenesisEpoch,
 		LatestBlockRootHash32S: blockRoots,
 		LatestCrosslinks:       stateLatestCrosslinks,
@@ -911,8 +911,8 @@ func TestProcessBlockAttestations_ShardBlockRootEqualZeroHashFailure(t *testing.
 	attestations := []*pb.Attestation{
 		{
 			Data: &pb.AttestationData{
-				Shard:                    0,
-				Slot:                     params.BeaconConfig().GenesisSlot + 20,
+				Shard: 0,
+				Slot:  params.BeaconConfig().GenesisSlot + 20,
 				JustifiedBlockRootHash32: blockRoots[0],
 				LatestCrosslink:          &pb.Crosslink{CrosslinkDataRootHash32: []byte{1}},
 				CrosslinkDataRootHash32:  []byte{1},
@@ -951,7 +951,7 @@ func TestProcessBlockAttestations_CreatePendingAttestations(t *testing.T) {
 		},
 	}
 	state := &pb.BeaconState{
-		Slot:                   params.BeaconConfig().GenesisSlot + 70,
+		Slot: params.BeaconConfig().GenesisSlot + 70,
 		PreviousJustifiedEpoch: params.BeaconConfig().GenesisEpoch,
 		LatestBlockRootHash32S: blockRoots,
 		LatestCrosslinks:       stateLatestCrosslinks,
@@ -959,8 +959,8 @@ func TestProcessBlockAttestations_CreatePendingAttestations(t *testing.T) {
 	}
 	att1 := &pb.Attestation{
 		Data: &pb.AttestationData{
-			Shard:                    0,
-			Slot:                     params.BeaconConfig().GenesisSlot + 20,
+			Shard: 0,
+			Slot:  params.BeaconConfig().GenesisSlot + 20,
 			JustifiedBlockRootHash32: blockRoots[0],
 			LatestCrosslink:          &pb.Crosslink{CrosslinkDataRootHash32: []byte{1}},
 			CrosslinkDataRootHash32:  params.BeaconConfig().ZeroHash[:],
@@ -1064,7 +1064,7 @@ func TestProcessValidatorDeposits_MerkleBranchFailsVerification(t *testing.T) {
 	depositInput := &pb.DepositInput{
 		Pubkey: []byte{1, 2, 3},
 	}
-	encodedInput , err := ssz.Marshal(depositInput)
+	encodedInput, err := ssz.Marshal(depositInput)
 	if err != nil {
 		t.Fatalf("failed to encode deposit input: %v", err)
 	}
@@ -1117,11 +1117,11 @@ func TestProcessValidatorDeposits_ProcessDepositHelperFuncFails(t *testing.T) {
 	// validator helper function to fail with error when the public key
 	// currently exists in the validator registry.
 	depositInput := &pb.DepositInput{
-		Pubkey:                      []byte{1},
+		Pubkey: []byte{1},
 		WithdrawalCredentialsHash32: []byte{1, 2, 3},
 		ProofOfPossession:           []byte{},
 	}
-	encodedInput , err := ssz.Marshal(depositInput)
+	encodedInput, err := ssz.Marshal(depositInput)
 	if err != nil {
 		t.Fatalf("failed to encode deposit input: %v", err)
 	}
@@ -1172,7 +1172,7 @@ func TestProcessValidatorDeposits_ProcessDepositHelperFuncFails(t *testing.T) {
 	// the one specified in the deposit input, causing a failure.
 	registry := []*pb.Validator{
 		{
-			Pubkey:                      []byte{1},
+			Pubkey: []byte{1},
 			WithdrawalCredentialsHash32: []byte{4, 5, 6},
 		},
 	}
@@ -1199,11 +1199,11 @@ func TestProcessValidatorDeposits_ProcessDepositHelperFuncFails(t *testing.T) {
 
 func TestProcessValidatorDeposits_IncorrectMerkleIndex(t *testing.T) {
 	depositInput := &pb.DepositInput{
-		Pubkey:                      []byte{1},
+		Pubkey: []byte{1},
 		WithdrawalCredentialsHash32: []byte{1, 2, 3},
 		ProofOfPossession:           []byte{},
 	}
-	encodedInput , err := ssz.Marshal(depositInput)
+	encodedInput, err := ssz.Marshal(depositInput)
 	if err != nil {
 		t.Fatalf("failed to encode deposit input: %v", err)
 	}
@@ -1244,7 +1244,7 @@ func TestProcessValidatorDeposits_IncorrectMerkleIndex(t *testing.T) {
 	}
 	registry := []*pb.Validator{
 		{
-			Pubkey:                      []byte{1},
+			Pubkey: []byte{1},
 			WithdrawalCredentialsHash32: []byte{1, 2, 3},
 		},
 	}
@@ -1267,11 +1267,11 @@ func TestProcessValidatorDeposits_IncorrectMerkleIndex(t *testing.T) {
 
 func TestProcessValidatorDeposits_ProcessCorrectly(t *testing.T) {
 	depositInput := &pb.DepositInput{
-		Pubkey:                      []byte{1},
+		Pubkey: []byte{1},
 		WithdrawalCredentialsHash32: []byte{1, 2, 3},
 		ProofOfPossession:           []byte{},
 	}
-	encodedInput , err := ssz.Marshal(depositInput)
+	encodedInput, err := ssz.Marshal(depositInput)
 	if err != nil {
 		t.Fatalf("failed to encode deposit input: %v", err)
 	}
@@ -1322,7 +1322,7 @@ func TestProcessValidatorDeposits_ProcessCorrectly(t *testing.T) {
 	}
 	registry := []*pb.Validator{
 		{
-			Pubkey:                      []byte{1},
+			Pubkey: []byte{1},
 			WithdrawalCredentialsHash32: []byte{1, 2, 3},
 		},
 	}
@@ -1394,7 +1394,7 @@ func TestProcessValidatorDeposits_InvalidSSZ_DepositIndexIncremented(t *testing.
 	}
 	registry := []*pb.Validator{
 		{
-			Pubkey:                      []byte{1},
+			Pubkey: []byte{1},
 			WithdrawalCredentialsHash32: []byte{1, 2, 3},
 		},
 	}
@@ -1427,11 +1427,11 @@ func TestProcessValidatorDeposits_InvalidSSZ_DepositIndexIncremented(t *testing.
 func TestProcessValidatorDeposits_InvalidWithdrawalCreds_DepositIndexIncremented(t *testing.T) {
 	hook := logTest.NewGlobal()
 	depositInput := &pb.DepositInput{
-		Pubkey:                      []byte{1},
+		Pubkey: []byte{1},
 		WithdrawalCredentialsHash32: []byte{3, 2, 1},
 		ProofOfPossession:           []byte{},
 	}
-	encodedInput , err := ssz.Marshal(depositInput)
+	encodedInput, err := ssz.Marshal(depositInput)
 	if err != nil {
 		t.Fatalf("failed to encode deposit input: %v", err)
 	}
@@ -1482,7 +1482,7 @@ func TestProcessValidatorDeposits_InvalidWithdrawalCreds_DepositIndexIncremented
 	}
 	registry := []*pb.Validator{
 		{
-			Pubkey:                      []byte{1},
+			Pubkey: []byte{1},
 			WithdrawalCredentialsHash32: []byte{1, 2, 3},
 		},
 	}

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -1064,11 +1064,10 @@ func TestProcessValidatorDeposits_MerkleBranchFailsVerification(t *testing.T) {
 	depositInput := &pb.DepositInput{
 		Pubkey: []byte{1, 2, 3},
 	}
-	wBuf := new(bytes.Buffer)
-	if err := ssz.Encode(wBuf, depositInput); err != nil {
+	encodedInput , err := ssz.Marshal(depositInput)
+	if err != nil {
 		t.Fatalf("failed to encode deposit input: %v", err)
 	}
-	encodedInput := wBuf.Bytes()
 	data := []byte{}
 	value := make([]byte, 8)
 	timestamp := make([]byte, 8)
@@ -1122,11 +1121,10 @@ func TestProcessValidatorDeposits_ProcessDepositHelperFuncFails(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte{1, 2, 3},
 		ProofOfPossession:           []byte{},
 	}
-	wBuf := new(bytes.Buffer)
-	if err := ssz.Encode(wBuf, depositInput); err != nil {
+	encodedInput , err := ssz.Marshal(depositInput)
+	if err != nil {
 		t.Fatalf("failed to encode deposit input: %v", err)
 	}
-	encodedInput := wBuf.Bytes()
 	data := []byte{}
 
 	// We set a deposit value of 1000.
@@ -1205,11 +1203,10 @@ func TestProcessValidatorDeposits_IncorrectMerkleIndex(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte{1, 2, 3},
 		ProofOfPossession:           []byte{},
 	}
-	wBuf := new(bytes.Buffer)
-	if err := ssz.Encode(wBuf, depositInput); err != nil {
+	encodedInput , err := ssz.Marshal(depositInput)
+	if err != nil {
 		t.Fatalf("failed to encode deposit input: %v", err)
 	}
-	encodedInput := wBuf.Bytes()
 	data := []byte{}
 
 	// We set a deposit value of 1000.
@@ -1274,11 +1271,10 @@ func TestProcessValidatorDeposits_ProcessCorrectly(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte{1, 2, 3},
 		ProofOfPossession:           []byte{},
 	}
-	wBuf := new(bytes.Buffer)
-	if err := ssz.Encode(wBuf, depositInput); err != nil {
+	encodedInput , err := ssz.Marshal(depositInput)
+	if err != nil {
 		t.Fatalf("failed to encode deposit input: %v", err)
 	}
-	encodedInput := wBuf.Bytes()
 	data := []byte{}
 
 	// We set a deposit value of 1000.
@@ -1435,11 +1431,10 @@ func TestProcessValidatorDeposits_InvalidWithdrawalCreds_DepositIndexIncremented
 		WithdrawalCredentialsHash32: []byte{3, 2, 1},
 		ProofOfPossession:           []byte{},
 	}
-	wBuf := new(bytes.Buffer)
-	if err := ssz.Encode(wBuf, depositInput); err != nil {
+	encodedInput , err := ssz.Marshal(depositInput)
+	if err != nil {
 		t.Fatalf("failed to encode deposit input: %v", err)
 	}
-	encodedInput := wBuf.Bytes()
 	data := []byte{}
 
 	// We set a deposit value of 1000.

--- a/beacon-chain/core/helpers/deposits_test.go
+++ b/beacon-chain/core/helpers/deposits_test.go
@@ -8,7 +8,7 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"github.com/prysmaticlabs/go-ssz"
+	//"github.com/prysmaticlabs/go-ssz"
 )
 
 func init() {
@@ -123,16 +123,16 @@ func TestDecodeDepositAmountAndTimeStamp(t *testing.T) {
 	}
 }
 
-func TestSSZUnmarshalDepositInput(t *testing.T) {
+// func TestSSZUnmarshalDepositInput(t *testing.T) {
 
-	depositData :=[219]byte{0, 32, 188, 190, 0, 0, 0, 0, 124, 26, 9 ,93, 0, 0, 0, 0, 188, 0, 0, 0, 48, 0, 0, 0, 135, 33, 178, 215, 169, 185, 93, 20, 57, 117, 186, 21, 8, 219, 127, 49, 0, 150, 117, 121, 17, 213, 17, 63, 184, 76, 250, 231, 158, 185, 82, 221, 122, 169, 68, 116, 252, 48, 117, 244, 167, 243, 39, 135, 210, 213, 144, 252, 96, 0, 0, 0, 137, 33, 84, 14, 215, 15, 192, 157, 117, 121, 27, 154, 231, 61, 232, 61, 102, 153, 164, 125, 217, 131, 85, 182, 235, 80, 235, 159, 168, 178, 11, 196, 84, 3, 216, 235, 109, 122, 175, 63, 134, 114, 88, 146, 46 ,232, 144, 196, 10, 64, 148, 198, 57, 154, 225, 81, 222, 190, 54, 56, 87, 29, 206, 232, 112, 38, 32, 119, 75, 254, 153, 142, 168, 70, 152, 218, 2, 240, 93, 228, 221, 133, 1, 200, 204, 96, 246, 0 ,33, 160, 43 ,207, 45, 15, 35, 168, 32, 0, 0, 0, 0, 57, 187, 69, 48, 82, 158, 110, 143, 8, 66, 63, 143, 244, 215, 104, 9, 225, 31, 187, 40, 251, 230, 38, 236, 52, 117, 230, 50, 204, 41, 187}
-	depositInput := new(pb.DepositInput)
+// 	depositData :=[219]byte{0, 32, 188, 190, 0, 0, 0, 0, 124, 26, 9 ,93, 0, 0, 0, 0, 188, 0, 0, 0, 48, 0, 0, 0, 135, 33, 178, 215, 169, 185, 93, 20, 57, 117, 186, 21, 8, 219, 127, 49, 0, 150, 117, 121, 17, 213, 17, 63, 184, 76, 250, 231, 158, 185, 82, 221, 122, 169, 68, 116, 252, 48, 117, 244, 167, 243, 39, 135, 210, 213, 144, 252, 96, 0, 0, 0, 137, 33, 84, 14, 215, 15, 192, 157, 117, 121, 27, 154, 231, 61, 232, 61, 102, 153, 164, 125, 217, 131, 85, 182, 235, 80, 235, 159, 168, 178, 11, 196, 84, 3, 216, 235, 109, 122, 175, 63, 134, 114, 88, 146, 46 ,232, 144, 196, 10, 64, 148, 198, 57, 154, 225, 81, 222, 190, 54, 56, 87, 29, 206, 232, 112, 38, 32, 119, 75, 254, 153, 142, 168, 70, 152, 218, 2, 240, 93, 228, 221, 133, 1, 200, 204, 96, 246, 0 ,33, 160, 43 ,207, 45, 15, 35, 168, 32, 0, 0, 0, 0, 57, 187, 69, 48, 82, 158, 110, 143, 8, 66, 63, 143, 244, 215, 104, 9, 225, 31, 187, 40, 251, 230, 38, 236, 52, 117, 230, 50, 204, 41, 187}
+// 	depositInput := new(pb.DepositInput)
 	
-	// Since the value deposited and the timestamp are both 8 bytes each,
-	// the deposit data is the chunk after the first 16 bytes.
-	depositInputBytes := depositData[16:]
-	err := ssz.Unmarshal(depositInputBytes, &depositInput)
-	if err != nil {
-		t.Fatalf("TestSSZUnmarshal failed : %v", err)
-	}
-}
+// 	// Since the value deposited and the timestamp are both 8 bytes each,
+// 	// the deposit data is the chunk after the first 16 bytes.
+// 	depositInputBytes := depositData[16:]
+// 	err := ssz.Unmarshal(depositInputBytes, &depositInput)
+// 	if err != nil {
+// 		t.Fatalf("TestSSZUnmarshal failed : %v", err)
+// 	}
+// }

--- a/beacon-chain/core/helpers/deposits_test.go
+++ b/beacon-chain/core/helpers/deposits_test.go
@@ -8,6 +8,7 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/go-ssz"
 )
 
 func init() {
@@ -119,5 +120,19 @@ func TestDecodeDepositAmountAndTimeStamp(t *testing.T) {
 		if tt.timestamp != decTimestamp {
 			t.Errorf("decoded timestamp not equal to given timestamp, %d : %d", decTimestamp, tt.timestamp)
 		}
+	}
+}
+
+func TestSSZUnmarshalDepositInput(t *testing.T) {
+
+	depositData :=[219]byte{0, 32, 188, 190, 0, 0, 0, 0, 124, 26, 9 ,93, 0, 0, 0, 0, 188, 0, 0, 0, 48, 0, 0, 0, 135, 33, 178, 215, 169, 185, 93, 20, 57, 117, 186, 21, 8, 219, 127, 49, 0, 150, 117, 121, 17, 213, 17, 63, 184, 76, 250, 231, 158, 185, 82, 221, 122, 169, 68, 116, 252, 48, 117, 244, 167, 243, 39, 135, 210, 213, 144, 252, 96, 0, 0, 0, 137, 33, 84, 14, 215, 15, 192, 157, 117, 121, 27, 154, 231, 61, 232, 61, 102, 153, 164, 125, 217, 131, 85, 182, 235, 80, 235, 159, 168, 178, 11, 196, 84, 3, 216, 235, 109, 122, 175, 63, 134, 114, 88, 146, 46 ,232, 144, 196, 10, 64, 148, 198, 57, 154, 225, 81, 222, 190, 54, 56, 87, 29, 206, 232, 112, 38, 32, 119, 75, 254, 153, 142, 168, 70, 152, 218, 2, 240, 93, 228, 221, 133, 1, 200, 204, 96, 246, 0 ,33, 160, 43 ,207, 45, 15, 35, 168, 32, 0, 0, 0, 0, 57, 187, 69, 48, 82, 158, 110, 143, 8, 66, 63, 143, 244, 215, 104, 9, 225, 31, 187, 40, 251, 230, 38, 236, 52, 117, 230, 50, 204, 41, 187}
+	depositInput := new(pb.DepositInput)
+	
+	// Since the value deposited and the timestamp are both 8 bytes each,
+	// the deposit data is the chunk after the first 16 bytes.
+	depositInputBytes := depositData[16:]
+	err := ssz.Unmarshal(depositInputBytes, &depositInput)
+	if err != nil {
+		t.Fatalf("TestSSZUnmarshal failed : %v", err)
 	}
 }

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
+	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gogo/protobuf/proto"
-	"github.com/prysmaticlabs/go-ssz"
+	ssz "github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	contracts "github.com/prysmaticlabs/prysm/contracts/deposit-contract"
@@ -58,7 +58,7 @@ func TestProcessDepositLog_OK(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData, err := ssz.Marshal(data) 
+	serializedData, err := ssz.Marshal(data)
 	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
@@ -121,7 +121,7 @@ func TestProcessDepositLog_InsertsPendingDeposit(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData, err := ssz.Marshal(data) 
+	serializedData, err := ssz.Marshal(data)
 	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
@@ -195,7 +195,7 @@ func TestUnpackDepositLogData_OK(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData, err := ssz.Marshal(data) 
+	serializedData, err := ssz.Marshal(data)
 	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
@@ -276,7 +276,7 @@ func TestProcessChainStartLog_8DuplicatePubkeys(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData, err := ssz.Marshal(data) 
+	serializedData, err := ssz.Marshal(data)
 	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
@@ -365,7 +365,7 @@ func TestProcessChainStartLog_8UniquePubkeys(t *testing.T) {
 			WithdrawalCredentialsHash32: []byte("withdraw"),
 		}
 
-		serializedData, err := ssz.Marshal(data) 
+		serializedData, err := ssz.Marshal(data)
 		if err != nil {
 			t.Fatalf("Could not serialize data %v", err)
 		}
@@ -445,7 +445,7 @@ func TestUnpackChainStartLogData_OK(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData, err := ssz.Marshal(data) 
+	serializedData, err := ssz.Marshal(data)
 	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
@@ -513,7 +513,7 @@ func TestHasChainStartLogOccurred_OK(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData, err := ssz.Marshal(data) 
+	serializedData, err := ssz.Marshal(data)
 	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
@@ -574,7 +574,7 @@ func TestETH1DataGenesis_OK(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData, err := ssz.Marshal(data) 
+	serializedData, err := ssz.Marshal(data)
 	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -58,13 +58,13 @@ func TestProcessDepositLog_OK(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData := new(bytes.Buffer)
-	if err := ssz.Encode(serializedData, data); err != nil {
+	serializedData, err := ssz.Marshal(data) 
+	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
 
 	testAcc.txOpts.Value = amount32Eth
-	if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData.Bytes()); err != nil {
+	if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData); err != nil {
 		t.Fatalf("Could not deposit to deposit contract %v", err)
 	}
 
@@ -121,14 +121,14 @@ func TestProcessDepositLog_InsertsPendingDeposit(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData := new(bytes.Buffer)
-	if err := ssz.Encode(serializedData, data); err != nil {
+	serializedData, err := ssz.Marshal(data) 
+	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
 
 	testAcc.txOpts.Value = amount32Eth
 	badData := []byte("bad data")
-	if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData.Bytes()); err != nil {
+	if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData); err != nil {
 		t.Fatalf("Could not deposit to deposit contract %v", err)
 	}
 
@@ -195,13 +195,13 @@ func TestUnpackDepositLogData_OK(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData := new(bytes.Buffer)
-	if err := ssz.Encode(serializedData, data); err != nil {
+	serializedData, err := ssz.Marshal(data) 
+	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
 
 	testAcc.txOpts.Value = amount32Eth
-	if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData.Bytes()); err != nil {
+	if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData); err != nil {
 		t.Fatalf("Could not deposit to deposit contract %v", err)
 	}
 	testAcc.backend.Commit()
@@ -276,8 +276,8 @@ func TestProcessChainStartLog_8DuplicatePubkeys(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData := new(bytes.Buffer)
-	if err := ssz.Encode(serializedData, data); err != nil {
+	serializedData, err := ssz.Marshal(data) 
+	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
 
@@ -286,7 +286,7 @@ func TestProcessChainStartLog_8DuplicatePubkeys(t *testing.T) {
 	// is 2**14
 	for i := 0; i < depositsReqForChainStart; i++ {
 		testAcc.txOpts.Value = amount32Eth
-		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData.Bytes()); err != nil {
+		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData); err != nil {
 			t.Fatalf("Could not deposit to deposit contract %v", err)
 		}
 
@@ -365,13 +365,13 @@ func TestProcessChainStartLog_8UniquePubkeys(t *testing.T) {
 			WithdrawalCredentialsHash32: []byte("withdraw"),
 		}
 
-		serializedData := new(bytes.Buffer)
-		if err := ssz.Encode(serializedData, data); err != nil {
+		serializedData, err := ssz.Marshal(data) 
+		if err != nil {
 			t.Fatalf("Could not serialize data %v", err)
 		}
 
 		testAcc.txOpts.Value = amount32Eth
-		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData.Bytes()); err != nil {
+		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData); err != nil {
 			t.Fatalf("Could not deposit to deposit contract %v", err)
 		}
 
@@ -445,8 +445,8 @@ func TestUnpackChainStartLogData_OK(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData := new(bytes.Buffer)
-	if err := ssz.Encode(serializedData, data); err != nil {
+	serializedData, err := ssz.Marshal(data) 
+	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
 
@@ -454,7 +454,7 @@ func TestUnpackChainStartLogData_OK(t *testing.T) {
 	// is defined in the deposit contract as the number required for the testnet.
 	for i := 0; i < depositsReqForChainStart; i++ {
 		testAcc.txOpts.Value = amount32Eth
-		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData.Bytes()); err != nil {
+		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData); err != nil {
 			t.Fatalf("Could not deposit to deposit contract %v", err)
 		}
 
@@ -513,8 +513,8 @@ func TestHasChainStartLogOccurred_OK(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData := new(bytes.Buffer)
-	if err := ssz.Encode(serializedData, data); err != nil {
+	serializedData, err := ssz.Marshal(data) 
+	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
 	ok, _, err := web3Service.HasChainStartLogOccurred()
@@ -529,7 +529,7 @@ func TestHasChainStartLogOccurred_OK(t *testing.T) {
 	// is defined in the deposit contract as the number required for the testnet.
 	for i := 0; i < depositsReqForChainStart; i++ {
 		testAcc.txOpts.Value = amount32Eth
-		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData.Bytes()); err != nil {
+		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData); err != nil {
 			t.Fatalf("Could not deposit to deposit contract %v", err)
 		}
 		testAcc.backend.Commit()
@@ -574,8 +574,8 @@ func TestETH1DataGenesis_OK(t *testing.T) {
 		WithdrawalCredentialsHash32: []byte("withdraw"),
 	}
 
-	serializedData := new(bytes.Buffer)
-	if err := ssz.Encode(serializedData, data); err != nil {
+	serializedData, err := ssz.Marshal(data) 
+	if err != nil {
 		t.Fatalf("Could not serialize data %v", err)
 	}
 	ok, _, err := web3Service.HasChainStartLogOccurred()
@@ -590,7 +590,7 @@ func TestETH1DataGenesis_OK(t *testing.T) {
 	// is defined in the deposit contract as the number required for the testnet.
 	for i := 0; i < depositsReqForChainStart; i++ {
 		testAcc.txOpts.Value = amount32Eth
-		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData.Bytes()); err != nil {
+		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData); err != nil {
 			t.Fatalf("Could not deposit to deposit contract %v", err)
 		}
 		testAcc.backend.Commit()
@@ -620,7 +620,7 @@ func TestETH1DataGenesis_OK(t *testing.T) {
 	// We add in another 8 deposits after chainstart.
 	for i := 0; i < depositsReqForChainStart; i++ {
 		testAcc.txOpts.Value = amount32Eth
-		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData.Bytes()); err != nil {
+		if _, err := testAcc.contract.Deposit(testAcc.txOpts, serializedData); err != nil {
 			t.Fatalf("Could not deposit to deposit contract %v", err)
 		}
 		testAcc.backend.Commit()

--- a/contracts/deposit-contract/sendDepositTx/sendDeposits.go
+++ b/contracts/deposit-contract/sendDepositTx/sendDeposits.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -211,13 +210,12 @@ func main() {
 				continue
 			}
 
-			serializedData := new(bytes.Buffer)
-			if err := ssz.Encode(serializedData, data); err != nil {
+			serializedData, err := ssz.Marshal(data) 
+			if err != nil {
 				log.Errorf("could not serialize deposit data: %v", err)
 			}
-
 			for i := int64(0); i < numberOfDeposits; i++ {
-				tx, err := depositContract.Deposit(txOps, serializedData.Bytes())
+				tx, err := depositContract.Deposit(txOps, serializedData)
 				if err != nil {
 					log.Error("unable to send transaction to contract")
 				}

--- a/shared/bls/spectest/aggregate_pubkeys_test.go
+++ b/shared/bls/spectest/aggregate_pubkeys_test.go
@@ -35,7 +35,7 @@ func TestAggregatePubkeysYaml(t *testing.T) {
 			}
 
 			if !bytes.Equal(tt.Output, pk.Marshal()) {
-				t.Fatal("Output does not equal marshalled aggregated public " +
+				t.Fatal("Output does not equal marshaled aggregated public " +
 					"key bytes")
 			}
 		})

--- a/shared/bls/spectest/aggregate_sigs_test.go
+++ b/shared/bls/spectest/aggregate_sigs_test.go
@@ -33,7 +33,7 @@ func TestAggregateSignaturesYaml(t *testing.T) {
 			}
 			sig := bls.AggregateSignatures(sigs)
 			if !bytes.Equal(tt.Output, sig.Marshal()) {
-				t.Fatal("Output does not equal marshalled aggregated sig bytes")
+				t.Fatal("Output does not equal marshaled aggregated sig bytes")
 			}
 		})
 	}

--- a/shared/keystore/deposit_input.go
+++ b/shared/keystore/deposit_input.go
@@ -1,8 +1,6 @@
 package keystore
 
 import (
-	"bytes"
-
 	"github.com/prysmaticlabs/go-ssz"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -29,11 +27,11 @@ func DepositInput(depositKey *Key, withdrawalKey *Key) (*pb.DepositInput, error)
 		WithdrawalCredentialsHash32: withdrawalCredentialsHash(withdrawalKey),
 	}
 
-	buf := new(bytes.Buffer)
-	if err := ssz.Encode(buf, di); err != nil {
+	buf, err := ssz.Marshal(di)
+	if err != nil {
 		return nil, err
 	}
-	di.ProofOfPossession = depositKey.SecretKey.Sign(buf.Bytes(), params.BeaconConfig().DomainDeposit).Marshal()
+	di.ProofOfPossession = depositKey.SecretKey.Sign(buf, params.BeaconConfig().DomainDeposit).Marshal()
 
 	return di, nil
 }

--- a/shared/keystore/deposit_input_test.go
+++ b/shared/keystore/deposit_input_test.go
@@ -46,12 +46,13 @@ func TestDepositInput_GeneratesPb(t *testing.T) {
 	// Verify that the proof of possession is a signed copy of the input data.
 	proofOfPossessionInputPb := proto.Clone(result).(*pb.DepositInput)
 	proofOfPossessionInputPb.ProofOfPossession = nil
-	buf := new(bytes.Buffer)
-	if err := ssz.Encode(buf, proofOfPossessionInputPb); err != nil {
-		t.Fatal(err)
+	
+	buf, err := ssz.Marshal(proofOfPossessionInputPb) 
+	if err != nil {
+		t.Fatalf("Could not serialize data %v", err)
 	}
 
-	if !sig.Verify(buf.Bytes(), k1.PublicKey, params.BeaconConfig().DomainDeposit) {
+	if !sig.Verify(buf, k1.PublicKey, params.BeaconConfig().DomainDeposit) {
 		t.Error("Invalid proof of proofOfPossession signature")
 	}
 }

--- a/shared/sliceutil/slice_generic_test.go
+++ b/shared/sliceutil/slice_generic_test.go
@@ -1,7 +1,6 @@
 package sliceutil
 
 import (
-	"bytes"
 	"reflect"
 	"testing"
 
@@ -58,14 +57,11 @@ func TestGenericIntersectionWithSSZ(t *testing.T) {
 		{[]uint64{1}, []uint64{1}, []uint64{1}},
 	}
 	for _, tt := range testCases {
-		b1 := new(bytes.Buffer)
-		err := ssz.Encode(b1, tt.setA)
-
-		b2 := new(bytes.Buffer)
-		err1 := ssz.Encode(b2, tt.setA)
+		b1, err := ssz.Marshal(tt.setA)
+		b2, err1 := ssz.Marshal(tt.setA)
 		if err1 == nil && err == nil {
 
-			result, err := GenericIntersection(b1.Bytes(), b2.Bytes())
+			result, err := GenericIntersection(b1, b2)
 			if err != nil {
 				if !reflect.DeepEqual(result, tt.out) {
 					t.Errorf("got %v, want %d", result, tt.out)
@@ -534,14 +530,11 @@ func BenchmarkGenericIntersectionWithSSZ(b *testing.B) {
 			{[]uint64{1}, []uint64{1}, []uint64{1}},
 		}
 		for _, tt := range testCases {
-			b1 := new(bytes.Buffer)
-			err := ssz.Encode(b1, tt.setA)
-
-			b2 := new(bytes.Buffer)
-			err1 := ssz.Encode(b2, tt.setA)
+			b1, err := ssz.Marshal(tt.setA)
+			b2, err1 := ssz.Marshal(tt.setA)
 			if err1 == nil && err == nil {
 
-				res, err := GenericIntersection(b1.Bytes(), b2.Bytes())
+				res, err := GenericIntersection(b1, b2)
 				if err != nil {
 					b.Errorf("Benchmark error for %v", res)
 				}
@@ -568,14 +561,11 @@ func BenchmarkIntersectionWithSSZ(b *testing.B) {
 			{[]uint64{1}, []uint64{1}, []uint64{1}},
 		}
 		for _, tt := range testCases {
-			b1 := new(bytes.Buffer)
-			err := ssz.Encode(b1, tt.setA)
-
-			b2 := new(bytes.Buffer)
-			err1 := ssz.Encode(b2, tt.setA)
+			b1, err := ssz.Marshal(tt.setA)
+			b2, err1 := ssz.Marshal(tt.setA)
 			if err1 == nil && err == nil {
 
-				ByteIntersection(b1.Bytes(), b2.Bytes())
+				ByteIntersection(b1, b2)
 
 			}
 
@@ -600,14 +590,11 @@ func BenchmarkGenericUnionWithSSZ(b *testing.B) {
 			{[]uint64{1}, []uint64{1}, []uint64{1}},
 		}
 		for _, tt := range testCases {
-			b1 := new(bytes.Buffer)
-			err := ssz.Encode(b1, tt.setA)
-
-			b2 := new(bytes.Buffer)
-			err1 := ssz.Encode(b2, tt.setA)
+			b1, err := ssz.Marshal(tt.setA)
+			b2, err1 := ssz.Marshal(tt.setA)
 			if err1 == nil && err == nil {
 
-				res, err := GenericUnion(b1.Bytes(), b2.Bytes())
+				res, err := GenericUnion(b1, b2)
 				if err != nil {
 					b.Errorf("Benchmark error for %v", res)
 				}
@@ -634,14 +621,11 @@ func BenchmarkUnionWithSSZ(b *testing.B) {
 			{[]uint64{1}, []uint64{1}, []uint64{1}},
 		}
 		for _, tt := range testCases {
-			b1 := new(bytes.Buffer)
-			err := ssz.Encode(b1, tt.setA)
-
-			b2 := new(bytes.Buffer)
-			err1 := ssz.Encode(b2, tt.setA)
+			b1, err := ssz.Marshal(tt.setA)
+			b2, err1 := ssz.Marshal(tt.setA)
 			if err1 == nil && err == nil {
 
-				ByteUnion(b1.Bytes(), b2.Bytes())
+				ByteUnion(b1, b2)
 
 			}
 
@@ -666,14 +650,11 @@ func BenchmarkGenericNotWithSSZ(b *testing.B) {
 			{[]uint64{1}, []uint64{1}, []uint64{1}},
 		}
 		for _, tt := range testCases {
-			b1 := new(bytes.Buffer)
-			err := ssz.Encode(b1, tt.setA)
-
-			b2 := new(bytes.Buffer)
-			err1 := ssz.Encode(b2, tt.setA)
+			b1, err := ssz.Marshal(tt.setA)
+			b2, err1 := ssz.Marshal(tt.setA)
 			if err1 == nil && err == nil {
 
-				res, err := GenericNot(b1.Bytes(), b2.Bytes())
+				res, err := GenericNot(b1, b2)
 				if err != nil {
 					b.Errorf("Benchmark error for %v", res)
 				}
@@ -700,13 +681,10 @@ func BenchmarkNotWithSSZ(b *testing.B) {
 			{[]uint64{1}, []uint64{1}, []uint64{1}},
 		}
 		for _, tt := range testCases {
-			b1 := new(bytes.Buffer)
-			err := ssz.Encode(b1, tt.setA)
-
-			b2 := new(bytes.Buffer)
-			err1 := ssz.Encode(b2, tt.setA)
+			b1, err := ssz.Marshal(tt.setA)
+			b2, err1 := ssz.Marshal(tt.setA)
 			if err1 == nil && err == nil {
-				ByteNot(b1.Bytes(), b2.Bytes())
+				ByteNot(b1, b2)
 
 			}
 

--- a/tools/cluster-pk-manager/server/server.go
+++ b/tools/cluster-pk-manager/server/server.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/rand"
@@ -147,13 +146,14 @@ func (s *server) allocateNewKeys(ctx context.Context, podName string, numKeys in
 		if err != nil {
 			return nil, err
 		}
-		serializedData := new(bytes.Buffer)
-		if err := ssz.Encode(serializedData, di); err != nil {
+		
+		serializedData, err := ssz.Marshal(di) 
+		if err != nil {
 			return nil, fmt.Errorf("could not serialize deposit data: %v", err)
 		}
 
 		// Do the actual deposit
-		if err := s.makeDeposit(serializedData.Bytes()); err != nil {
+		if err := s.makeDeposit(serializedData); err != nil {
 			return nil, err
 		}
 		// Store in database

--- a/tools/ssz-server/main.go
+++ b/tools/ssz-server/main.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"bytes"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -74,7 +73,7 @@ func decodeDepositData(w http.ResponseWriter, r *http.Request) {
 
 	di := &pb.DepositInput{}
 
-	if err := ssz.Decode(bytes.NewReader(encodedData), di); err != nil {
+	if err := ssz.Unmarshal(encodedData, &di); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, err := fmt.Fprintf(w, "Failed to decode SSZ data: %v", err)
 		if err != nil {

--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -1,7 +1,6 @@
 package accounts
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
@@ -75,8 +74,9 @@ func NewValidatorAccount(directory string, password string) error {
 	if err != nil {
 		return fmt.Errorf("unable to generate deposit data: %v", err)
 	}
-	serializedData := new(bytes.Buffer)
-	if err := ssz.Encode(serializedData, data); err != nil {
+	
+	serializedData, err := ssz.Marshal(data)
+	if err != nil {
 		return fmt.Errorf("could not serialize deposit data: %v", err)
 	}
 	log.Info(`Account creation complete! Copy and paste the deposit data shown below when issuing a transaction into the ETH1.0 deposit contract to activate your validator client`)


### PR DESCRIPTION
Resolves #531 

# Description
Update go-ssz lib dep and usage according to the changes in interface.

**Write why you are making the changes in this pull request**
Code updated to use the Marshal/Unmarshal function of the go-ssz lib instead of 'Encode' and 'Decode'.

**Write a summary of the changes you are making**
1. Updated the ssz dependency to the latest go-ssz commit hash (as of now).
2. Changed the calls to ssz lib : ssz.Encode -> ssz.Marshal , ssz.Decode -> ssz.Unmarshal

**Link anything that would be helpful or relevant to the reviewers**
Currently the call to Unmashal results in panic. I need someone to help figure out if this is a go-ssz lib bug or something is wrong in my code.
