### PR TITLE
Complain about improperly sized tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,3 @@
 # Print warnings for tests with inappropriate test size or timeout.
-build --test_verbose_timeout_warnings
+test --test_verbose_timeout_warnings
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+# Print warnings for tests with inappropriate test size or timeout.
+build --test_verbose_timeout_warnings
+

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -17,6 +17,9 @@ build:remote-cache --jobs=50
 build:remote-cache --host_platform_remote_properties_override='properties:{name:\"cache-silo-key\" value:\"prysm\"}' 
 build:remote-cache --remote_instance_name=projects/prysmaticlabs/instances/default_instance
 
+# Import workspace options.
+import %workspace%/.bazelrc
+
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
 build --experimental_multi_threaded_digest
@@ -28,6 +31,5 @@ build --curses=yes --color=yes
 build --keep_going
 build --test_output=errors
 build --flaky_test_attempts=5
-build --test_timeout=5,60,-1,-1
 # Disabled race detection due to unstable test results under constrained environment build kite
 # build --features=race

--- a/beacon-chain/attestation/BUILD.bazel
+++ b/beacon-chain/attestation/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["service_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -42,5 +43,4 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/attestation/BUILD.bazel
+++ b/beacon-chain/attestation/BUILD.bazel
@@ -42,4 +42,5 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -71,4 +71,5 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "block_processing_test.go",
         "fork_choice_reorg_test.go",
@@ -71,5 +72,4 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/blockchain/stategenerator/BUILD.bazel
+++ b/beacon-chain/blockchain/stategenerator/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["state_generator_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -28,5 +29,4 @@ go_test(
         "//shared/params:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/blockchain/stategenerator/BUILD.bazel
+++ b/beacon-chain/blockchain/stategenerator/BUILD.bazel
@@ -28,4 +28,5 @@ go_test(
         "//shared/params:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/chaintest/BUILD.bazel
+++ b/beacon-chain/chaintest/BUILD.bazel
@@ -22,6 +22,7 @@ go_binary(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["yaml_test.go"],
     data = glob(["tests/**"]),
     embed = [":go_default_library"],
@@ -29,5 +30,4 @@ go_test(
         "//beacon-chain/chaintest/backend:go_default_library",
         "//shared/featureconfig:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/chaintest/BUILD.bazel
+++ b/beacon-chain/chaintest/BUILD.bazel
@@ -29,4 +29,5 @@ go_test(
         "//beacon-chain/chaintest/backend:go_default_library",
         "//shared/featureconfig:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/chaintest/backend/BUILD.bazel
+++ b/beacon-chain/chaintest/backend/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["simulated_backend_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -39,5 +40,4 @@ go_test(
         "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/chaintest/backend/BUILD.bazel
+++ b/beacon-chain/chaintest/backend/BUILD.bazel
@@ -39,4 +39,5 @@ go_test(
         "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/core/balances/BUILD.bazel
+++ b/beacon-chain/core/balances/BUILD.bazel
@@ -23,4 +23,5 @@ go_test(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/params:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/core/balances/BUILD.bazel
+++ b/beacon-chain/core/balances/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["rewards_penalties_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -23,5 +24,4 @@ go_test(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/params:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -54,4 +54,5 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "block_operations_test.go",
         "block_test.go",
@@ -54,5 +55,4 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/core/epoch/BUILD.bazel
+++ b/beacon-chain/core/epoch/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "epoch_operations_test.go",
         "epoch_processing_test.go",
@@ -39,5 +40,4 @@ go_test(
         "//shared/params:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/core/epoch/BUILD.bazel
+++ b/beacon-chain/core/epoch/BUILD.bazel
@@ -39,4 +39,5 @@ go_test(
         "//shared/params:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -47,4 +47,5 @@ go_test(
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "committee_test.go",
         "deposits_test.go",
@@ -47,5 +48,4 @@ go_test(
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "state_test.go",
         "transition_test.go",
@@ -42,5 +43,4 @@ go_test(
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -42,4 +42,5 @@ go_test(
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/core/state/stateutils/BUILD.bazel
+++ b/beacon-chain/core/state/stateutils/BUILD.bazel
@@ -19,4 +19,5 @@ go_test(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/core/state/stateutils/BUILD.bazel
+++ b/beacon-chain/core/state/stateutils/BUILD.bazel
@@ -13,11 +13,11 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["validator_index_map_test.go"],
     embed = [":go_default_library"],
     deps = [
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/core/validators/BUILD.bazel
+++ b/beacon-chain/core/validators/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["validator_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -28,5 +29,4 @@ go_test(
         "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/core/validators/BUILD.bazel
+++ b/beacon-chain/core/validators/BUILD.bazel
@@ -28,4 +28,5 @@ go_test(
         "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/db/BUILD.bazel
+++ b/beacon-chain/db/BUILD.bazel
@@ -62,4 +62,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/db/BUILD.bazel
+++ b/beacon-chain/db/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "attestation_test.go",
         "block_operations_test.go",
@@ -62,5 +63,4 @@ go_test(
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -48,4 +48,5 @@ go_test(
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["node_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -48,5 +49,4 @@ go_test(
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "block_cache_test.go",
         "block_reader_test.go",
@@ -60,5 +61,4 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -60,4 +60,5 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "attester_server_test.go",
         "beacon_server_test.go",
@@ -75,5 +76,4 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -45,7 +45,6 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    size = "small",
     srcs = [
         "attester_server_test.go",
         "beacon_server_test.go",
@@ -76,4 +75,5 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["service_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -49,5 +50,4 @@ go_test(
         "@com_github_libp2p_go_libp2p_peer//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -49,4 +49,5 @@ go_test(
         "@com_github_libp2p_go_libp2p_peer//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+    size = "small",
 )

--- a/beacon-chain/utils/BUILD.bazel
+++ b/beacon-chain/utils/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "clock_test.go",
         "shuffle_test.go",
@@ -28,5 +29,4 @@ go_test(
         "//shared/params:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
     ],
-    size = "small",
 )

--- a/beacon-chain/utils/BUILD.bazel
+++ b/beacon-chain/utils/BUILD.bazel
@@ -28,4 +28,5 @@ go_test(
         "//shared/params:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
     ],
+    size = "small",
 )

--- a/contracts/deposit-contract/BUILD.bazel
+++ b/contracts/deposit-contract/BUILD.bazel
@@ -31,4 +31,5 @@ go_test(
         "@com_github_ethereum_go_ethereum//core:go_default_library",
         "@com_github_ethereum_go_ethereum//crypto:go_default_library",
     ],
+    size = "small",
 )

--- a/contracts/deposit-contract/BUILD.bazel
+++ b/contracts/deposit-contract/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["depositContract_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -31,5 +32,4 @@ go_test(
         "@com_github_ethereum_go_ethereum//core:go_default_library",
         "@com_github_ethereum_go_ethereum//crypto:go_default_library",
     ],
-    size = "small",
 )

--- a/shared/BUILD.bazel
+++ b/shared/BUILD.bazel
@@ -12,4 +12,5 @@ go_test(
     name = "go_default_test",
     srcs = ["service_registry_test.go"],
     embed = [":go_default_library"],
+    size = "small",
 )

--- a/shared/BUILD.bazel
+++ b/shared/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["service_registry_test.go"],
     embed = [":go_default_library"],
-    size = "small",
 )

--- a/shared/bitutil/BUILD.bazel
+++ b/shared/bitutil/BUILD.bazel
@@ -13,8 +13,8 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["bit_test.go"],
     embed = [":go_default_library"],
     deps = ["//shared/mathutil:go_default_library"],
-    size = "small",
 )

--- a/shared/bitutil/BUILD.bazel
+++ b/shared/bitutil/BUILD.bazel
@@ -16,4 +16,5 @@ go_test(
     srcs = ["bit_test.go"],
     embed = [":go_default_library"],
     deps = ["//shared/mathutil:go_default_library"],
+    size = "small",
 )

--- a/shared/bls/BUILD.bazel
+++ b/shared/bls/BUILD.bazel
@@ -13,8 +13,8 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["bls_test.go"],
     embed = [":go_default_library"],
     deps = ["//shared/bytesutil:go_default_library"],
-    size = "small",
 )

--- a/shared/bls/BUILD.bazel
+++ b/shared/bls/BUILD.bazel
@@ -16,4 +16,5 @@ go_test(
     srcs = ["bls_test.go"],
     embed = [":go_default_library"],
     deps = ["//shared/bytesutil:go_default_library"],
+    size = "small",
 )

--- a/shared/bls/spectest/BUILD.bazel
+++ b/shared/bls/spectest/BUILD.bazel
@@ -36,4 +36,5 @@ go_test(
         "@com_github_phoreproject_bls//:go_default_library",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
+    size = "small",
 )

--- a/shared/bls/spectest/BUILD.bazel
+++ b/shared/bls/spectest/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "aggregate_pubkeys_test.go",
         "aggregate_sigs_test.go",
@@ -36,5 +37,4 @@ go_test(
         "@com_github_phoreproject_bls//:go_default_library",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",
     ],
-    size = "small",
 )

--- a/shared/bytesutil/BUILD.bazel
+++ b/shared/bytesutil/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["bytes_test.go"],
     embed = [":go_default_library"],
-    size = "small",
 )

--- a/shared/bytesutil/BUILD.bazel
+++ b/shared/bytesutil/BUILD.bazel
@@ -11,4 +11,5 @@ go_test(
     name = "go_default_test",
     srcs = ["bytes_test.go"],
     embed = [":go_default_library"],
+    size = "small",
 )

--- a/shared/cmd/BUILD.bazel
+++ b/shared/cmd/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["customflags_test.go"],
     embed = [":go_default_library"],
-    size = "small",
 )

--- a/shared/cmd/BUILD.bazel
+++ b/shared/cmd/BUILD.bazel
@@ -16,4 +16,5 @@ go_test(
     name = "go_default_test",
     srcs = ["customflags_test.go"],
     embed = [":go_default_library"],
+    size = "small",
 )

--- a/shared/event/BUILD.bazel
+++ b/shared/event/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "example_feed_test.go",
         "example_scope_test.go",
@@ -21,5 +22,4 @@ go_test(
         "subscription_test.go",
     ],
     embed = [":go_default_library"],
-    size = "small",
 )

--- a/shared/event/BUILD.bazel
+++ b/shared/event/BUILD.bazel
@@ -21,4 +21,5 @@ go_test(
         "subscription_test.go",
     ],
     embed = [":go_default_library"],
+    size = "small",
 )

--- a/shared/featureconfig/BUILD.bazel
+++ b/shared/featureconfig/BUILD.bazel
@@ -19,4 +19,5 @@ go_test(
     srcs = ["config_test.go"],
     embed = [":go_default_library"],
     deps = ["@com_github_urfave_cli//:go_default_library"],
+    size = "small",
 )

--- a/shared/featureconfig/BUILD.bazel
+++ b/shared/featureconfig/BUILD.bazel
@@ -16,8 +16,8 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["config_test.go"],
     embed = [":go_default_library"],
     deps = ["@com_github_urfave_cli//:go_default_library"],
-    size = "small",
 )

--- a/shared/forkutil/BUILD.bazel
+++ b/shared/forkutil/BUILD.bazel
@@ -10,8 +10,8 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["signature_test.go"],
     embed = [":go_default_library"],
     deps = ["//proto/beacon/p2p/v1:go_default_library"],
-    size = "small",
 )

--- a/shared/forkutil/BUILD.bazel
+++ b/shared/forkutil/BUILD.bazel
@@ -13,4 +13,5 @@ go_test(
     srcs = ["signature_test.go"],
     embed = [":go_default_library"],
     deps = ["//proto/beacon/p2p/v1:go_default_library"],
+    size = "small",
 )

--- a/shared/hashutil/BUILD.bazel
+++ b/shared/hashutil/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "beacon_block_test.go",
         "hash_test.go",
@@ -31,5 +32,4 @@ go_test(
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
     ],
-    size = "small",
 )

--- a/shared/hashutil/BUILD.bazel
+++ b/shared/hashutil/BUILD.bazel
@@ -31,4 +31,5 @@ go_test(
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
     ],
+    size = "small",
 )

--- a/shared/iputils/BUILD.bazel
+++ b/shared/iputils/BUILD.bazel
@@ -9,8 +9,8 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["external_ip_test.go"],
     embed = [":go_default_library"],
     tags = ["requires-network"],
-    size = "small",
 )

--- a/shared/iputils/BUILD.bazel
+++ b/shared/iputils/BUILD.bazel
@@ -12,4 +12,5 @@ go_test(
     srcs = ["external_ip_test.go"],
     embed = [":go_default_library"],
     tags = ["requires-network"],
+    size = "small",
 )

--- a/shared/keystore/BUILD.bazel
+++ b/shared/keystore/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "deposit_input_test.go",
         "key_test.go",
@@ -42,5 +43,4 @@ go_test(
         "@com_github_pborman_uuid//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
     ],
-    size = "small",
 )

--- a/shared/keystore/BUILD.bazel
+++ b/shared/keystore/BUILD.bazel
@@ -42,4 +42,5 @@ go_test(
         "@com_github_pborman_uuid//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
     ],
+    size = "small",
 )

--- a/shared/mathutil/BUILD.bazel
+++ b/shared/mathutil/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["math_helper_test.go"],
     embed = [":go_default_library"],
-    size = "small",
 )

--- a/shared/mathutil/BUILD.bazel
+++ b/shared/mathutil/BUILD.bazel
@@ -11,4 +11,5 @@ go_test(
     name = "go_default_test",
     srcs = ["math_helper_test.go"],
     embed = [":go_default_library"],
+    size = "small",
 )

--- a/shared/messagehandler/BUILD.bazel
+++ b/shared/messagehandler/BUILD.bazel
@@ -22,4 +22,5 @@ go_test(
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+    size = "small",
 )

--- a/shared/messagehandler/BUILD.bazel
+++ b/shared/messagehandler/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["messagehandler_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -22,5 +23,4 @@ go_test(
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
-    size = "small",
 )

--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "addr_factory_test.go",
         "connection_manager_test.go",
@@ -97,7 +98,6 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
-    size = "small",
 )
 
 # by default gazelle tries to add all the test files to the  first
@@ -108,6 +108,7 @@ go_test(
 
 go_test(
     name = "go_norace_test",
+    size = "small",
     srcs = [
         "discovery_norace_test.go",
         "service_norace_test.go",
@@ -121,5 +122,4 @@ go_test(
         "@com_github_libp2p_go_libp2p_swarm//testing:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
-    size = "small",
 )

--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -97,6 +97,7 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+    size = "small",
 )
 
 # by default gazelle tries to add all the test files to the  first
@@ -120,4 +121,5 @@ go_test(
         "@com_github_libp2p_go_libp2p_swarm//testing:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+    size = "small",
 )

--- a/shared/p2p/adapter/metric/BUILD.bazel
+++ b/shared/p2p/adapter/metric/BUILD.bazel
@@ -22,4 +22,5 @@ go_test(
         "//shared/p2p:go_default_library",
         "//shared/prometheus:go_default_library",
     ],
+    size = "small",
 )

--- a/shared/p2p/adapter/metric/BUILD.bazel
+++ b/shared/p2p/adapter/metric/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["metric_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -22,5 +23,4 @@ go_test(
         "//shared/p2p:go_default_library",
         "//shared/prometheus:go_default_library",
     ],
-    size = "small",
 )

--- a/shared/params/BUILD.bazel
+++ b/shared/params/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["config_test.go"],
     embed = [":go_default_library"],
-    size = "small",
 )

--- a/shared/params/BUILD.bazel
+++ b/shared/params/BUILD.bazel
@@ -11,4 +11,5 @@ go_test(
     name = "go_default_test",
     srcs = ["config_test.go"],
     embed = [":go_default_library"],
+    size = "small",
 )

--- a/shared/prometheus/BUILD.bazel
+++ b/shared/prometheus/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "logrus_collector_test.go",
         "service_test.go",
@@ -31,5 +32,4 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
-    size = "small",
 )

--- a/shared/prometheus/BUILD.bazel
+++ b/shared/prometheus/BUILD.bazel
@@ -31,4 +31,5 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
+    size = "small",
 )

--- a/shared/sliceutil/BUILD.bazel
+++ b/shared/sliceutil/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = [
         "slice_generic_test.go",
         "slice_test.go",
@@ -22,5 +23,4 @@ go_test(
         "//shared/featureconfig:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
     ],
-    size = "small",
 )

--- a/shared/sliceutil/BUILD.bazel
+++ b/shared/sliceutil/BUILD.bazel
@@ -22,4 +22,5 @@ go_test(
         "//shared/featureconfig:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
     ],
+    size = "small",
 )

--- a/shared/slotutil/BUILD.bazel
+++ b/shared/slotutil/BUILD.bazel
@@ -10,8 +10,8 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["slotticker_test.go"],
     embed = [":go_default_library"],
     deps = ["//shared/params:go_default_library"],
-    size = "small",
 )

--- a/shared/slotutil/BUILD.bazel
+++ b/shared/slotutil/BUILD.bazel
@@ -13,4 +13,5 @@ go_test(
     srcs = ["slotticker_test.go"],
     embed = [":go_default_library"],
     deps = ["//shared/params:go_default_library"],
+    size = "small",
 )

--- a/shared/trieutil/BUILD.bazel
+++ b/shared/trieutil/BUILD.bazel
@@ -13,8 +13,8 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["sparse_merkle_test.go"],
     embed = [":go_default_library"],
     deps = ["//shared/hashutil:go_default_library"],
-    size = "small",
 )

--- a/shared/trieutil/BUILD.bazel
+++ b/shared/trieutil/BUILD.bazel
@@ -16,4 +16,5 @@ go_test(
     srcs = ["sparse_merkle_test.go"],
     embed = [":go_default_library"],
     deps = ["//shared/hashutil:go_default_library"],
+    size = "small",
 )

--- a/tools/cluster-pk-manager/server/BUILD.bazel
+++ b/tools/cluster-pk-manager/server/BUILD.bazel
@@ -52,10 +52,10 @@ go_binary(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["server_test.go"],
     embed = [":go_default_library"],
     deps = ["//proto/cluster:go_default_library"],
-    size = "small",
 )
 
 go_image(

--- a/tools/cluster-pk-manager/server/BUILD.bazel
+++ b/tools/cluster-pk-manager/server/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     srcs = ["server_test.go"],
     embed = [":go_default_library"],
     deps = ["//proto/cluster:go_default_library"],
+    size = "small",
 )
 
 go_image(

--- a/validator/accounts/BUILD.bazel
+++ b/validator/accounts/BUILD.bazel
@@ -23,4 +23,5 @@ go_test(
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
     ],
+    size = "small",
 )

--- a/validator/accounts/BUILD.bazel
+++ b/validator/accounts/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["account_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -23,5 +24,4 @@ go_test(
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
     ],
-    size = "small",
 )

--- a/validator/node/BUILD.bazel
+++ b/validator/node/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//validator/accounts:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],
+    size = "small",
 )
 
 go_library(

--- a/validator/node/BUILD.bazel
+++ b/validator/node/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["node_test.go"],
     embed = [":go_default_library"],
     deps = [
@@ -10,7 +11,6 @@ go_test(
         "//validator/accounts:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],
-    size = "small",
 )
 
 go_library(


### PR DESCRIPTION
Also remove test timeout overrides. 

See: https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests

If a test size is improperly specified, a non-breaking WARNING will appear in the bazel output. This WARNING should be addressed by the author to set their test to the appropriate time. 

An example is that if someone set their test to "large" and it only took 5 seconds, this is an inappropriate selection. We may handle larger test sizes differently in the test runner in the future so it is important that these tests are properly sized. 

