### PR TITLE
Remove deprecated fields from attestation data

### DIFF
--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -284,7 +284,7 @@ func (a *Service) updateAttestation(beaconState *pb.BeaconState, attestation *pb
 			log.WithFields(
 				logrus.Fields{
 					"attestationSlot": slot,
-					"sourceEpoch":     attestation.Data.SourceEpoch,
+					"sourceEpoch":     attestation.Data.Source.Epoch,
 				},
 			).Debug("Attestation store updated")
 

--- a/beacon-chain/attestation/service_test.go
+++ b/beacon-chain/attestation/service_test.go
@@ -60,6 +60,8 @@ func TestUpdateLatestAttestation_UpdatesLatest(t *testing.T) {
 			Crosslink: &pb.Crosslink{
 				Shard: 1,
 			},
+			Target: &pb.Checkpoint{},
+			Source: &pb.Checkpoint{},
 		},
 	}
 
@@ -248,6 +250,8 @@ func TestUpdateLatestAttestation_InvalidIndex(t *testing.T) {
 			Crosslink: &pb.Crosslink{
 				Shard: 1,
 			},
+			Target: &pb.Checkpoint{},
+			Source: &pb.Checkpoint{},
 		},
 	}
 
@@ -299,7 +303,8 @@ func TestBatchUpdate_FromSync(t *testing.T) {
 		attestation := &pb.Attestation{
 			AggregationBits: []byte{0x80},
 			Data: &pb.AttestationData{
-				TargetEpoch: 2,
+				Target: &pb.Checkpoint{Epoch: 2},
+				Source: &pb.Checkpoint{},
 				Crosslink: &pb.Crosslink{
 					Shard: 1,
 				},
@@ -352,6 +357,8 @@ func TestUpdateLatestAttestation_BatchUpdate(t *testing.T) {
 				Crosslink: &pb.Crosslink{
 					Shard: 1,
 				},
+				Target: &pb.Checkpoint{},
+				Source: &pb.Checkpoint{},
 			},
 		})
 	}

--- a/beacon-chain/blockchain/block_processing_test.go
+++ b/beacon-chain/blockchain/block_processing_test.go
@@ -295,7 +295,7 @@ func TestReceiveBlock_DeletesBadBlock(t *testing.T) {
 			RandaoReveal: []byte{},
 			Attestations: []*pb.Attestation{{
 				Data: &pb.AttestationData{
-					TargetEpoch: 5,
+					Target: &pb.Checkpoint{Epoch: 5},
 				},
 			}},
 		},
@@ -887,7 +887,7 @@ func TestIsBlockReadyForProcessing_ValidBlock(t *testing.T) {
 				AggregationBits: []byte{128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 					0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 				Data: &pb.AttestationData{
-					SourceRoot: parentRoot[:],
+					Source: &pb.Checkpoint{Root: parentRoot[:]},
 					Crosslink: &pb.Crosslink{
 						Shard: 960,
 					},

--- a/beacon-chain/cache/attestation_data_test.go
+++ b/beacon-chain/cache/attestation_data_test.go
@@ -33,7 +33,7 @@ func TestAttestationCache_RoundTrip(t *testing.T) {
 	}
 
 	res := &pbp2p.AttestationData{
-		TargetEpoch: 5,
+		Target: &pbp2p.Checkpoint{Epoch: 5},
 	}
 
 	if err = c.Put(ctx, req, res); err != nil {

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -639,19 +639,19 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 }
 func TestSlashableAttestationData_CanSlash(t *testing.T) {
 	att1 := &pb.AttestationData{
-		TargetEpoch: 1,
-		SourceRoot:  []byte{'A'},
+		Target: &pb.Checkpoint{Epoch: 1},
+		Source: &pb.Checkpoint{Root: []byte{'A'}},
 	}
 	att2 := &pb.AttestationData{
-		TargetEpoch: 1,
-		SourceRoot:  []byte{'B'},
+		Target: &pb.Checkpoint{Epoch: 1},
+		Source: &pb.Checkpoint{Root: []byte{'B'}},
 	}
 	if !blocks.IsSlashableAttestationData(att1, att2) {
 		t.Error("atts should have been slashable")
 	}
-	att1.TargetEpoch = 4
-	att1.SourceEpoch = 2
-	att2.SourceEpoch = 3
+	att1.Target.Epoch = 4
+	att1.Source.Epoch = 2
+	att2.Source.Epoch = 3
 	if !blocks.IsSlashableAttestationData(att1, att2) {
 		t.Error("atts should have been slashable")
 	}
@@ -691,8 +691,8 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 		{
 			Attestation_1: &pb.IndexedAttestation{
 				Data: &pb.AttestationData{
-					SourceEpoch: 0,
-					TargetEpoch: 0,
+					Source: &pb.Checkpoint{Epoch: 0},
+					Target: &pb.Checkpoint{Epoch: 0},
 					Crosslink: &pb.Crosslink{
 						Shard: 4,
 					},
@@ -700,8 +700,8 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 			},
 			Attestation_2: &pb.IndexedAttestation{
 				Data: &pb.AttestationData{
-					SourceEpoch: 1,
-					TargetEpoch: 1,
+					Source: &pb.Checkpoint{Epoch: 1},
+					Target: &pb.Checkpoint{Epoch: 1},
 					Crosslink: &pb.Crosslink{
 						Shard: 3,
 					},
@@ -737,8 +737,8 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 		{
 			Attestation_1: &pb.IndexedAttestation{
 				Data: &pb.AttestationData{
-					SourceEpoch: 1,
-					TargetEpoch: 0,
+					Source: &pb.Checkpoint{Epoch: 1},
+					Target: &pb.Checkpoint{Epoch: 0},
 					Crosslink: &pb.Crosslink{
 						Shard: 4,
 					},
@@ -748,8 +748,8 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 			},
 			Attestation_2: &pb.IndexedAttestation{
 				Data: &pb.AttestationData{
-					SourceEpoch: 0,
-					TargetEpoch: 0,
+					Source: &pb.Checkpoint{Epoch: 0},
+					Target: &pb.Checkpoint{Epoch: 0},
 					Crosslink: &pb.Crosslink{
 						Shard: 4,
 					},
@@ -785,8 +785,8 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 		{
 			Attestation_1: &pb.IndexedAttestation{
 				Data: &pb.AttestationData{
-					SourceEpoch: 1,
-					TargetEpoch: 0,
+					Source: &pb.Checkpoint{Epoch: 1},
+					Target: &pb.Checkpoint{Epoch: 0},
 					Crosslink: &pb.Crosslink{
 						Shard: 4,
 					},
@@ -795,8 +795,8 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 			},
 			Attestation_2: &pb.IndexedAttestation{
 				Data: &pb.AttestationData{
-					SourceEpoch: 0,
-					TargetEpoch: 0,
+					Source: &pb.Checkpoint{Epoch: 0},
+					Target: &pb.Checkpoint{Epoch: 0},
 					Crosslink: &pb.Crosslink{
 						Shard: 4,
 					},
@@ -839,8 +839,8 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 		{
 			Attestation_1: &pb.IndexedAttestation{
 				Data: &pb.AttestationData{
-					SourceEpoch: 1,
-					TargetEpoch: 0,
+					Source: &pb.Checkpoint{Epoch: 1},
+					Target: &pb.Checkpoint{Epoch: 0},
 					Crosslink: &pb.Crosslink{
 						Shard: 4,
 					},
@@ -849,8 +849,8 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 			},
 			Attestation_2: &pb.IndexedAttestation{
 				Data: &pb.AttestationData{
-					SourceEpoch: 0,
-					TargetEpoch: 0,
+					Source: &pb.Checkpoint{Epoch: 0},
+					Target: &pb.Checkpoint{Epoch: 0},
 					Crosslink: &pb.Crosslink{
 						Shard: 4,
 					},
@@ -905,7 +905,7 @@ func TestProcessBlockAttestations_ThresholdReached(t *testing.T) {
 			Attestations: attestations,
 		},
 	}
-	state := &pb.BeaconState{}
+	s := &pb.BeaconState{}
 
 	want := fmt.Sprintf(
 		"number of attestations in block (%d) exceeds allowed threshold of %d",
@@ -914,7 +914,7 @@ func TestProcessBlockAttestations_ThresholdReached(t *testing.T) {
 	)
 
 	if _, err := blocks.ProcessBlockAttestations(
-		state,
+		s,
 		block,
 		false,
 	); !strings.Contains(err.Error(), want) {
@@ -926,7 +926,7 @@ func TestProcessBlockAttestations_InclusionDelayFailure(t *testing.T) {
 	attestations := []*pb.Attestation{
 		{
 			Data: &pb.AttestationData{
-				TargetEpoch: 0,
+				Target: &pb.Checkpoint{Epoch: 0},
 				Crosslink: &pb.Crosslink{
 					Shard: 0,
 				},
@@ -972,7 +972,7 @@ func TestProcessBlockAttestations_NeitherCurrentNorPrevEpoch(t *testing.T) {
 	attestations := []*pb.Attestation{
 		{
 			Data: &pb.AttestationData{
-				TargetEpoch: 0,
+				Target: &pb.Checkpoint{Epoch: 0},
 				Crosslink: &pb.Crosslink{
 					Shard: 0,
 				},
@@ -993,7 +993,7 @@ func TestProcessBlockAttestations_NeitherCurrentNorPrevEpoch(t *testing.T) {
 
 	want := fmt.Sprintf(
 		"expected target epoch %d == %d or %d",
-		attestations[0].Data.TargetEpoch,
+		attestations[0].Data.Target.Epoch,
 		helpers.PrevEpoch(beaconState),
 		helpers.CurrentEpoch(beaconState),
 	)
@@ -1012,8 +1012,8 @@ func TestProcessBlockAttestations_CurrentEpochFFGDataMismatches(t *testing.T) {
 	attestations := []*pb.Attestation{
 		{
 			Data: &pb.AttestationData{
-				TargetEpoch: 0,
-				SourceEpoch: 1,
+				Target: &pb.Checkpoint{Epoch: 0},
+				Source: &pb.Checkpoint{Epoch: 1},
 				Crosslink: &pb.Crosslink{
 					Shard: 0,
 				},
@@ -1042,7 +1042,7 @@ func TestProcessBlockAttestations_CurrentEpochFFGDataMismatches(t *testing.T) {
 	want := fmt.Sprintf(
 		"expected source epoch %d, received %d",
 		helpers.CurrentEpoch(beaconState),
-		attestations[0].Data.SourceEpoch,
+		attestations[0].Data.Source.Epoch,
 	)
 	if _, err := blocks.ProcessBlockAttestations(
 		beaconState,
@@ -1052,13 +1052,13 @@ func TestProcessBlockAttestations_CurrentEpochFFGDataMismatches(t *testing.T) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 
-	block.Body.Attestations[0].Data.SourceEpoch = helpers.CurrentEpoch(beaconState)
-	block.Body.Attestations[0].Data.SourceRoot = []byte{}
+	block.Body.Attestations[0].Data.Source.Epoch = helpers.CurrentEpoch(beaconState)
+	block.Body.Attestations[0].Data.Source.Root = []byte{}
 
 	want = fmt.Sprintf(
 		"expected source root %#x, received %#x",
 		beaconState.CurrentJustifiedCheckpoint.Root,
-		attestations[0].Data.SourceRoot,
+		attestations[0].Data.Source.Root,
 	)
 	if _, err := blocks.ProcessBlockAttestations(
 		beaconState,
@@ -1075,8 +1075,8 @@ func TestProcessBlockAttestations_PrevEpochFFGDataMismatches(t *testing.T) {
 	attestations := []*pb.Attestation{
 		{
 			Data: &pb.AttestationData{
-				TargetEpoch: 0,
-				SourceEpoch: 1,
+				Target: &pb.Checkpoint{Epoch: 0},
+				Source: &pb.Checkpoint{Epoch: 1},
 				Crosslink: &pb.Crosslink{
 					Shard: 0,
 				},
@@ -1105,7 +1105,7 @@ func TestProcessBlockAttestations_PrevEpochFFGDataMismatches(t *testing.T) {
 	want := fmt.Sprintf(
 		"expected source epoch %d, received %d",
 		helpers.PrevEpoch(beaconState),
-		attestations[0].Data.SourceEpoch,
+		attestations[0].Data.Source.Epoch,
 	)
 	if _, err := blocks.ProcessBlockAttestations(
 		beaconState,
@@ -1115,13 +1115,13 @@ func TestProcessBlockAttestations_PrevEpochFFGDataMismatches(t *testing.T) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 
-	block.Body.Attestations[0].Data.SourceEpoch = helpers.PrevEpoch(beaconState)
-	block.Body.Attestations[0].Data.SourceRoot = []byte{}
+	block.Body.Attestations[0].Data.Source.Epoch = helpers.PrevEpoch(beaconState)
+	block.Body.Attestations[0].Data.Source.Root = []byte{}
 
 	want = fmt.Sprintf(
 		"expected source root %#x, received %#x",
 		beaconState.PreviousJustifiedCheckpoint.Root,
-		attestations[0].Data.SourceRoot,
+		attestations[0].Data.Source.Root,
 	)
 	if _, err := blocks.ProcessBlockAttestations(
 		beaconState,
@@ -1138,9 +1138,11 @@ func TestProcessBlockAttestations_CrosslinkMismatches(t *testing.T) {
 	attestations := []*pb.Attestation{
 		{
 			Data: &pb.AttestationData{
-				TargetEpoch: 0,
-				SourceEpoch: 0,
-				SourceRoot:  []byte("hello-world"),
+				Target: &pb.Checkpoint{Epoch: 0},
+				Source: &pb.Checkpoint{
+					Epoch: 0,
+					Root:  []byte("hello-world"),
+				},
 				Crosslink: &pb.Crosslink{
 					Shard: 0,
 				},
@@ -1207,9 +1209,8 @@ func TestProcessBlockAttestations_OK(t *testing.T) {
 	attestations := []*pb.Attestation{
 		{
 			Data: &pb.AttestationData{
-				TargetEpoch: 0,
-				SourceEpoch: 0,
-				SourceRoot:  []byte("hello-world"),
+				Target: &pb.Checkpoint{Epoch: 0},
+				Source: &pb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
 				Crosslink: &pb.Crosslink{
 					Shard:      0,
 					StartEpoch: 0,
@@ -1307,8 +1308,8 @@ func TestConvertToIndexed_OK(t *testing.T) {
 	attestation := &pb.Attestation{
 		Signature: []byte("signed"),
 		Data: &pb.AttestationData{
-			SourceEpoch: 0,
-			TargetEpoch: 0,
+			Source: &pb.Checkpoint{Epoch: 0},
+			Target: &pb.Checkpoint{Epoch: 0},
 			Crosslink: &pb.Crosslink{
 				Shard: 3,
 			},

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -84,7 +84,7 @@ func MatchAttestations(state *pb.BeaconState, epoch uint64) (*MatchedAttestation
 	for _, srcAtt := range srcAtts {
 		// If the target root matches attestation's target root,
 		// then we know this attestation has correctly voted for target.
-		if bytes.Equal(srcAtt.Data.TargetRoot, targetRoot) {
+		if bytes.Equal(srcAtt.Data.Target.Root, targetRoot) {
 			tgtAtts = append(tgtAtts, srcAtt)
 		}
 

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -66,8 +66,8 @@ func TestUnslashedAttestingIndices_CanSortAndFilter(t *testing.T) {
 	atts := make([]*pb.PendingAttestation, 2)
 	for i := 0; i < len(atts); i++ {
 		atts[i] = &pb.PendingAttestation{
-			Data: &pb.AttestationData{
-				TargetEpoch: 0,
+			Data: &pb.AttestationData{Source: &pb.Checkpoint{},
+				Target: &pb.Checkpoint{Epoch: 0},
 				Crosslink: &pb.Crosslink{
 					Shard: uint64(i),
 				},
@@ -118,8 +118,8 @@ func TestUnslashedAttestingIndices_CantGetIndicesBitfieldError(t *testing.T) {
 	atts := make([]*pb.PendingAttestation, 2)
 	for i := 0; i < len(atts); i++ {
 		atts[i] = &pb.PendingAttestation{
-			Data: &pb.AttestationData{
-				TargetEpoch: 0,
+			Data: &pb.AttestationData{Source: &pb.Checkpoint{},
+				Target: &pb.Checkpoint{Epoch: 0},
 				Crosslink: &pb.Crosslink{
 					Shard: uint64(i),
 				},
@@ -150,6 +150,8 @@ func TestAttestingBalance_CorrectBalance(t *testing.T) {
 				Crosslink: &pb.Crosslink{
 					Shard: uint64(i),
 				},
+				Target: &pb.Checkpoint{},
+				Source: &pb.Checkpoint{},
 			},
 			AggregationBits: []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
 				0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
@@ -191,7 +193,8 @@ func TestAttestingBalance_CantGetIndicesBitfieldError(t *testing.T) {
 	for i := 0; i < len(atts); i++ {
 		atts[i] = &pb.PendingAttestation{
 			Data: &pb.AttestationData{
-				TargetEpoch: 0,
+				Source: &pb.Checkpoint{},
+				Target: &pb.Checkpoint{Epoch: 0},
 				Crosslink: &pb.Crosslink{
 					Shard: uint64(i),
 				},
@@ -220,20 +223,20 @@ func TestMatchAttestations_PrevEpoch(t *testing.T) {
 	// The correct vote for target is '1'
 	// The correct vote for head is '2'
 	prevAtts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}}},                                                     // source
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, TargetRoot: []byte{1}}},                              // source, target
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, TargetRoot: []byte{3}}},                              // source
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, TargetRoot: []byte{1}}},                              // source, target
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}}},                        // source, head
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{4}}},                         // source
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{1}}}, // source, target, head
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{5}, TargetRoot: []byte{1}}},  // source, target
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{6}}}, // source, head
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{}}},                                             // source
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{Root: []byte{1}}}},                              // source, target
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{Root: []byte{3}}}},                              // source
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{Root: []byte{1}}}},                              // source, target
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{}}},                // source, head
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{4}, Target: &pb.Checkpoint{}}},                 // source
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{1}}}}, // source, target, head
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{5}, Target: &pb.Checkpoint{Root: []byte{1}}}},  // source, target
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{6}}}}, // source, head
 	}
 
 	currentAtts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + e + 1}}},                                                    // none
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + e + 1}, BeaconBlockRoot: []byte{2}, TargetRoot: []byte{1}}}, // none
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + e + 1}, Target: &pb.Checkpoint{}}},                                            // none
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + e + 1}, BeaconBlockRoot: []byte{2}, Target: &pb.Checkpoint{Root: []byte{1}}}}, // none
 	}
 
 	blockRoots := make([][]byte, 128)
@@ -255,34 +258,34 @@ func TestMatchAttestations_PrevEpoch(t *testing.T) {
 	}
 
 	wantedSrcAtts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, TargetRoot: []byte{1}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, TargetRoot: []byte{3}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, TargetRoot: []byte{1}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{4}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{1}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{5}, TargetRoot: []byte{1}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{6}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{Root: []byte{1}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{Root: []byte{3}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{Root: []byte{1}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{4}, Target: &pb.Checkpoint{}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{1}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{5}, Target: &pb.Checkpoint{Root: []byte{1}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{6}}}},
 	}
 	if !reflect.DeepEqual(mAtts.source, wantedSrcAtts) {
 		t.Error("source attestations don't match")
 	}
 
 	wantedTgtAtts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, TargetRoot: []byte{1}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, TargetRoot: []byte{1}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{1}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{5}, TargetRoot: []byte{1}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{Root: []byte{1}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{Root: []byte{1}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{1}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{5}, Target: &pb.Checkpoint{Root: []byte{1}}}},
 	}
 	if !reflect.DeepEqual(mAtts.Target, wantedTgtAtts) {
 		t.Error("target attestations don't match")
 	}
 
 	wantedHeadAtts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{1}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{6}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{1}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{6}}}},
 	}
 	if !reflect.DeepEqual(mAtts.head, wantedHeadAtts) {
 		t.Error("head attestations don't match")
@@ -298,17 +301,17 @@ func TestMatchAttestations_CurrentEpoch(t *testing.T) {
 	// The correct vote for target is '65'
 	// The correct vote for head is '66'
 	prevAtts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}}},                                                    // none
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{2}, TargetRoot: []byte{1}}}, // none
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{5}, TargetRoot: []byte{1}}}, // none
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{2}, TargetRoot: []byte{6}}}, // none
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{}}},                                            // none
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{2}, Target: &pb.Checkpoint{Root: []byte{1}}}}, // none
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{5}, Target: &pb.Checkpoint{Root: []byte{1}}}}, // none
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{2}, Target: &pb.Checkpoint{Root: []byte{6}}}}, // none
 	}
 
 	currentAtts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}}},                                                      // source
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{65}}}, // source, target, head
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{69}, TargetRoot: []byte{65}}}, // source, target
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{68}}}, // source, head
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{}}},                                              // source
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{65}}}}, // source, target, head
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{69}, Target: &pb.Checkpoint{Root: []byte{65}}}}, // source, target
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{68}}}}, // source, head
 	}
 
 	blockRoots := make([][]byte, 128)
@@ -328,26 +331,26 @@ func TestMatchAttestations_CurrentEpoch(t *testing.T) {
 	}
 
 	wantedSrcAtts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{65}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{69}, TargetRoot: []byte{65}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{68}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, Target: &pb.Checkpoint{}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{65}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{69}, Target: &pb.Checkpoint{Root: []byte{65}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{68}}}},
 	}
 	if !reflect.DeepEqual(mAtts.source, wantedSrcAtts) {
 		t.Error("source attestations don't match")
 	}
 
 	wantedTgtAtts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{65}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{69}, TargetRoot: []byte{65}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{65}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{69}, Target: &pb.Checkpoint{Root: []byte{65}}}},
 	}
 	if !reflect.DeepEqual(mAtts.Target, wantedTgtAtts) {
 		t.Error("target attestations don't match")
 	}
 
 	wantedHeadAtts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{65}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, TargetRoot: []byte{68}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{65}}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{Shard: s + 1}, BeaconBlockRoot: []byte{66}, Target: &pb.Checkpoint{Root: []byte{68}}}},
 	}
 	if !reflect.DeepEqual(mAtts.head, wantedHeadAtts) {
 		t.Error("head attestations don't match")
@@ -366,14 +369,14 @@ func TestAttsForCrosslink_CanGetAttestations(t *testing.T) {
 		DataRoot: []byte{'B'},
 	}
 	atts := []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{DataRoot: []byte{'A'}}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{DataRoot: []byte{'B'}}}}, // Selected
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{DataRoot: []byte{'C'}}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{DataRoot: []byte{'B'}}}}} // Selected
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{DataRoot: []byte{'A'}}, Target: &pb.Checkpoint{}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{DataRoot: []byte{'B'}}, Target: &pb.Checkpoint{}}}, // Selected
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{DataRoot: []byte{'C'}}, Target: &pb.Checkpoint{}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{DataRoot: []byte{'B'}}, Target: &pb.Checkpoint{}}}} // Selected
 
 	if !reflect.DeepEqual(attsForCrosslink(c, atts), []*pb.PendingAttestation{
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{DataRoot: []byte{'B'}}}},
-		{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{DataRoot: []byte{'B'}}}}}) {
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{DataRoot: []byte{'B'}}, Target: &pb.Checkpoint{}}},
+		{Data: &pb.AttestationData{Source: &pb.Checkpoint{}, Crosslink: &pb.Crosslink{DataRoot: []byte{'B'}}, Target: &pb.Checkpoint{}}}}) {
 		t.Error("Incorrect attestations for crosslink")
 	}
 }
@@ -430,6 +433,8 @@ func TestWinningCrosslink_CanGetWinningRoot(t *testing.T) {
 					Shard:    1,
 					DataRoot: []byte{'A'},
 				},
+				Target: &pb.Checkpoint{},
+				Source: &pb.Checkpoint{},
 			},
 		},
 		{
@@ -438,6 +443,8 @@ func TestWinningCrosslink_CanGetWinningRoot(t *testing.T) {
 					Shard:    1,
 					DataRoot: []byte{'B'}, // Winner
 				},
+				Target: &pb.Checkpoint{},
+				Source: &pb.Checkpoint{},
 			},
 		},
 		{
@@ -446,6 +453,8 @@ func TestWinningCrosslink_CanGetWinningRoot(t *testing.T) {
 					Shard:    1,
 					DataRoot: []byte{'C'},
 				},
+				Target: &pb.Checkpoint{},
+				Source: &pb.Checkpoint{},
 			},
 		},
 	}
@@ -564,12 +573,12 @@ func TestProcessCrosslinks_SuccessfulUpdate(t *testing.T) {
 	startShard := uint64(960)
 	for s := uint64(0); s < params.BeaconConfig().SlotsPerEpoch; s++ {
 		atts = append(atts, &pb.PendingAttestation{
-			Data: &pb.AttestationData{
+			Data: &pb.AttestationData{Source: &pb.Checkpoint{},
 				Crosslink: &pb.Crosslink{
 					Shard:    startShard + s,
 					DataRoot: []byte{'B'},
 				},
-				TargetEpoch: 0,
+				Target: &pb.Checkpoint{Epoch: 0},
 			},
 			AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0},
 		})
@@ -940,6 +949,8 @@ func TestCrosslinkDelta_SomeAttested(t *testing.T) {
 					Shard:    startShard + uint64(i),
 					DataRoot: []byte{'A'},
 				},
+				Target: &pb.Checkpoint{},
+				Source: &pb.Checkpoint{},
 			},
 			InclusionDelay:  uint64(i + 100),
 			AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0},
@@ -1017,6 +1028,8 @@ func TestAttestationDelta_CantGetAttestationIndices(t *testing.T) {
 				Crosslink: &pb.Crosslink{
 					Shard: uint64(i),
 				},
+				Target: &pb.Checkpoint{},
+				Source: &pb.Checkpoint{},
 			},
 			InclusionDelay:  uint64(i + 100),
 			AggregationBits: []byte{0xff},
@@ -1044,6 +1057,8 @@ func TestAttestationDelta_NoOneAttested(t *testing.T) {
 					Shard:    uint64(i),
 					DataRoot: []byte{'A'},
 				},
+				Target: &pb.Checkpoint{},
+				Source: &pb.Checkpoint{},
 			},
 			InclusionDelay:  uint64(i + 100),
 			AggregationBits: []byte{0xC0},
@@ -1084,6 +1099,8 @@ func TestAttestationDelta_SomeAttested(t *testing.T) {
 					Shard:    startShard + uint64(i),
 					DataRoot: []byte{'A'},
 				},
+				Target: &pb.Checkpoint{},
+				Source: &pb.Checkpoint{},
 			},
 			AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0},
 			InclusionDelay:  1,
@@ -1242,6 +1259,8 @@ func TestProcessRewardsAndPenalties_SomeAttested(t *testing.T) {
 					Shard:    startShard + uint64(i),
 					DataRoot: []byte{'A'},
 				},
+				Target: &pb.Checkpoint{},
+				Source: &pb.Checkpoint{},
 			},
 			AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0},
 			InclusionDelay:  1,

--- a/beacon-chain/core/helpers/attestation.go
+++ b/beacon-chain/core/helpers/attestation.go
@@ -31,17 +31,17 @@ func AttestationDataSlot(state *pb.BeaconState, data *pb.AttestationData) (uint6
 	if data == nil {
 		return 0, ErrAttestationDataSlotNilData
 	}
-	committeeCount, err := EpochCommitteeCount(state, data.TargetEpoch)
+	committeeCount, err := EpochCommitteeCount(state, data.Target.Epoch)
 	if err != nil {
 		return 0, err
 	}
 
-	epochStartShardNumber, err := EpochStartShard(state, data.TargetEpoch)
+	epochStartShardNumber, err := EpochStartShard(state, data.Target.Epoch)
 	if err != nil { // This should never happen if EpochCommitteeCount was successful
 		return 0, fmt.Errorf("could not determine epoch start shard: %v", err)
 	}
 	offset := (data.Crosslink.Shard + params.BeaconConfig().ShardCount -
 		epochStartShardNumber) % params.BeaconConfig().ShardCount
 
-	return StartSlot(data.TargetEpoch) + offset/(committeeCount/params.BeaconConfig().SlotsPerEpoch), nil
+	return StartSlot(data.Target.Epoch) + offset/(committeeCount/params.BeaconConfig().SlotsPerEpoch), nil
 }

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -26,7 +26,7 @@ func TestAttestationDataSlot_OK(t *testing.T) {
 	committeeCount, _ := helpers.EpochCommitteeCount(beaconState, 0)
 	expect := offset / (committeeCount / params.BeaconConfig().SlotsPerEpoch)
 	attSlot, err := helpers.AttestationDataSlot(beaconState, &pb.AttestationData{
-		TargetEpoch: 0,
+		Target: &pb.Checkpoint{Epoch: 0},
 		Crosslink: &pb.Crosslink{
 			Shard: 0,
 		},
@@ -41,7 +41,7 @@ func TestAttestationDataSlot_OK(t *testing.T) {
 
 func TestAttestationDataSlot_ReturnsErrorWithNilState(t *testing.T) {
 	s, err := helpers.AttestationDataSlot(nil /*state*/, &pb.AttestationData{
-		TargetEpoch: 0,
+		Target: &pb.Checkpoint{Epoch: 0},
 		Crosslink: &pb.Crosslink{
 			Shard: 0,
 		},
@@ -72,7 +72,7 @@ func TestAttestationDataSlot_ReturnsErrorWithErroneousTargetEpoch(t *testing.T) 
 		t.Fatal(err)
 	}
 	s, err := helpers.AttestationDataSlot(beaconState, &pb.AttestationData{
-		TargetEpoch: 1<<63 - 1, // Far future epoch
+		Target: &pb.Checkpoint{Epoch: 1<<63 - 1 /* Far future epoch */},
 	})
 	if err == nil {
 		t.Error("Expected an error, but received nil")
@@ -92,7 +92,7 @@ func TestAttestationDataSlot_ReturnsErrorWhenTargetEpochLessThanCurrentEpoch(t *
 		t.Fatal(err)
 	}
 	s, err := helpers.AttestationDataSlot(beaconState, &pb.AttestationData{
-		TargetEpoch: 2,
+		Target: &pb.Checkpoint{Epoch: 2},
 	})
 	if err == nil {
 		t.Error("Expected an error, but received nil")

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -154,7 +154,7 @@ func ComputeCommittee(
 //    assert verify_bitfield(bitfield, len(committee))
 //    return sorted([index for i, index in enumerate(committee) if get_bitfield_bit(bitfield, i) == 0b1])
 func AttestingIndices(state *pb.BeaconState, data *pb.AttestationData, bitfield []byte) ([]uint64, error) {
-	committee, err := CrosslinkCommitteeAtEpoch(state, data.TargetEpoch, data.Crosslink.Shard)
+	committee, err := CrosslinkCommitteeAtEpoch(state, data.Target.Epoch, data.Crosslink.Shard)
 	if err != nil {
 		return nil, fmt.Errorf("could not get committee: %v", err)
 	}
@@ -378,7 +378,7 @@ func EpochStartShard(state *pb.BeaconState, epoch uint64) (uint64, error) {
 // VerifyAttestationBitfield verifies that an attestations bitfield is valid in respect
 // to the committees at that slot.
 func VerifyAttestationBitfield(bState *pb.BeaconState, att *pb.Attestation) (bool, error) {
-	committee, err := CrosslinkCommitteeAtEpoch(bState, att.Data.TargetEpoch, att.Data.Crosslink.Shard)
+	committee, err := CrosslinkCommitteeAtEpoch(bState, att.Data.Target.Epoch, att.Data.Crosslink.Shard)
 	if err != nil {
 		return false, fmt.Errorf("could not retrieve crosslink committees at slot: %v", err)
 	}

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -268,7 +268,7 @@ func TestAttestationParticipants_NoCommitteeCache(t *testing.T) {
 		attestationData.Crosslink = &pb.Crosslink{
 			Shard: tt.attestationSlot,
 		}
-		attestationData.TargetEpoch = 0
+		attestationData.Target = &pb.Checkpoint{Epoch: 0}
 
 		result, err := AttestingIndices(state, attestationData, tt.bitfield)
 		if err != nil {
@@ -302,7 +302,7 @@ func TestAttestationParticipants_IncorrectBitfield(t *testing.T) {
 		RandaoMixes:      make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 		ActiveIndexRoots: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	}
-	attestationData := &pb.AttestationData{Crosslink: &pb.Crosslink{}}
+	attestationData := &pb.AttestationData{Crosslink: &pb.Crosslink{}, Target: &pb.Checkpoint{}}
 
 	if _, err := AttestingIndices(state, attestationData, []byte{}); err == nil {
 		t.Error("attestation participants should have failed with incorrect bitfield")
@@ -327,7 +327,7 @@ func TestAttestationParticipants_EmptyBitfield(t *testing.T) {
 		RandaoMixes:      make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 		ActiveIndexRoots: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	}
-	attestationData := &pb.AttestationData{Crosslink: &pb.Crosslink{}}
+	attestationData := &pb.AttestationData{Crosslink: &pb.Crosslink{}, Target: &pb.Checkpoint{}}
 
 	var zeroByte [16]byte
 
@@ -635,6 +635,7 @@ func TestVerifyAttestationBitfield_OK(t *testing.T) {
 					Crosslink: &pb.Crosslink{
 						Shard: 5,
 					},
+					Target: &pb.Checkpoint{},
 				},
 			},
 			stateSlot: 5,
@@ -647,6 +648,7 @@ func TestVerifyAttestationBitfield_OK(t *testing.T) {
 					Crosslink: &pb.Crosslink{
 						Shard: 10,
 					},
+					Target: &pb.Checkpoint{},
 				},
 			},
 			stateSlot: 10,
@@ -658,6 +660,7 @@ func TestVerifyAttestationBitfield_OK(t *testing.T) {
 					Crosslink: &pb.Crosslink{
 						Shard: 20,
 					},
+					Target: &pb.Checkpoint{},
 				},
 			},
 			stateSlot: 20,
@@ -669,6 +672,7 @@ func TestVerifyAttestationBitfield_OK(t *testing.T) {
 					Crosslink: &pb.Crosslink{
 						Shard: 5,
 					},
+					Target: &pb.Checkpoint{},
 				},
 			},
 			stateSlot:   5,
@@ -681,6 +685,7 @@ func TestVerifyAttestationBitfield_OK(t *testing.T) {
 					Crosslink: &pb.Crosslink{
 						Shard: 20,
 					},
+					Target: &pb.Checkpoint{},
 				},
 			},
 			stateSlot:           20,

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -92,69 +92,6 @@ func TestProcessBlock_IncorrectProposerSlashing(t *testing.T) {
 	}
 }
 
-func TestProcessBlock_IncorrectAttesterSlashing(t *testing.T) {
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100, true)
-	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	slashings := []*pb.ProposerSlashing{
-		{
-			ProposerIndex: 1,
-			Header_1: &pb.BeaconBlockHeader{
-				Slot:      1,
-				Signature: []byte("A"),
-			},
-			Header_2: &pb.BeaconBlockHeader{
-				Slot:      1,
-				Signature: []byte("B"),
-			},
-		},
-	}
-	attesterSlashings := &pb.AttesterSlashing{
-		Attestation_1: &pb.IndexedAttestation{Data: &pb.AttestationData{}},
-		Attestation_2: &pb.IndexedAttestation{Data: &pb.AttestationData{}},
-	}
-	epoch := helpers.CurrentEpoch(beaconState)
-	randaoReveal, err := helpers.CreateRandaoReveal(beaconState, epoch, privKeys)
-	if err != nil {
-		t.Fatal(err)
-	}
-	genesisBlock := blocks.NewGenesisBlock([]byte{})
-	bodyRoot, err := ssz.HashTreeRoot(genesisBlock)
-	if err != nil {
-		t.Fatal(err)
-	}
-	beaconState.LatestBlockHeader = &pb.BeaconBlockHeader{
-		Slot:       genesisBlock.Slot,
-		ParentRoot: genesisBlock.ParentRoot,
-		BodyRoot:   bodyRoot[:],
-	}
-	parentRoot, err := ssz.SigningRoot(beaconState.LatestBlockHeader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	block := &pb.BeaconBlock{
-		ParentRoot: parentRoot[:],
-		Slot:       0,
-		Body: &pb.BeaconBlockBody{
-			RandaoReveal:      randaoReveal,
-			ProposerSlashings: slashings,
-			AttesterSlashings: []*pb.AttesterSlashing{attesterSlashings},
-			Eth1Data: &pb.Eth1Data{
-				DepositRoot: []byte{2},
-				BlockHash:   []byte{3},
-			},
-			Deposits: make([]*pb.Deposit, 16),
-		},
-	}
-	want := "could not process block attester slashing"
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, state.DefaultConfig()); !strings.Contains(err.Error(), want) {
-		t.Errorf("Expected %s, received %v", want, err)
-	}
-}
-
 func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 	deposits, privKeys := testutil.SetupInitialDeposits(t, 100, true)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), nil)
@@ -401,7 +338,7 @@ func TestProcessEpoch_CantGetAttsBalancePrevEpoch(t *testing.T) {
 
 	epoch := uint64(1)
 
-	atts := []*pb.PendingAttestation{{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: 961}}, AggregationBits: []byte{1}}}
+	atts := []*pb.PendingAttestation{{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: 961}, Target: &pb.Checkpoint{}}, AggregationBits: []byte{1}}}
 	_, err := state.ProcessEpoch(context.Background(), &pb.BeaconState{
 		Slot:                      epoch*params.BeaconConfig().SlotsPerEpoch + 1,
 		BlockRoots:                make([][]byte, 128),
@@ -416,7 +353,7 @@ func TestProcessEpoch_CantGetAttsBalancePrevEpoch(t *testing.T) {
 func TestProcessEpoch_CantGetAttsBalanceCurrentEpoch(t *testing.T) {
 	epoch := uint64(1)
 
-	atts := []*pb.PendingAttestation{{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: 961}}, AggregationBits: []byte{1}}}
+	atts := []*pb.PendingAttestation{{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: 961}, Target: &pb.Checkpoint{}}, AggregationBits: []byte{1}}}
 	_, err := state.ProcessEpoch(context.Background(), &pb.BeaconState{
 		Slot:                     epoch*params.BeaconConfig().SlotsPerEpoch + 1,
 		BlockRoots:               make([][]byte, 128),
@@ -431,7 +368,7 @@ func TestProcessEpoch_CantGetAttsBalanceCurrentEpoch(t *testing.T) {
 func TestProcessEpoch_CanProcess(t *testing.T) {
 	epoch := uint64(1)
 
-	atts := []*pb.PendingAttestation{{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: 961}}}}
+	atts := []*pb.PendingAttestation{{Data: &pb.AttestationData{Crosslink: &pb.Crosslink{Shard: 961}, Target: &pb.Checkpoint{}}}}
 	var crosslinks []*pb.Crosslink
 	for i := uint64(0); i < params.BeaconConfig().ShardCount; i++ {
 		crosslinks = append(crosslinks, &pb.Crosslink{

--- a/beacon-chain/operations/service_test.go
+++ b/beacon-chain/operations/service_test.go
@@ -135,6 +135,8 @@ func TestRetrieveAttestations_OK(t *testing.T) {
 				Crosslink: &pb.Crosslink{
 					Shard: uint64(i),
 				},
+				Source: &pb.Checkpoint{},
+				Target: &pb.Checkpoint{},
 			},
 		}
 		if err := service.beaconDB.SaveAttestation(context.Background(), origAttestations[i]); err != nil {
@@ -178,6 +180,8 @@ func TestRetrieveAttestations_PruneInvalidAtts(t *testing.T) {
 				Crosslink: &pb.Crosslink{
 					Shard: uint64(i) - shardDiff,
 				},
+				Source: &pb.Checkpoint{},
+				Target: &pb.Checkpoint{},
 			},
 		}
 		if err := service.beaconDB.SaveAttestation(context.Background(), origAttestations[i]); err != nil {
@@ -224,6 +228,8 @@ func TestRemoveProcessedAttestations_Ok(t *testing.T) {
 				Crosslink: &pb.Crosslink{
 					Shard: uint64(i),
 				},
+				Source: &pb.Checkpoint{},
+				Target: &pb.Checkpoint{},
 			},
 		}
 		if err := s.beaconDB.SaveAttestation(context.Background(), attestations[i]); err != nil {
@@ -268,6 +274,8 @@ func TestReceiveBlkRemoveOps_Ok(t *testing.T) {
 				Crosslink: &pb.Crosslink{
 					Shard: uint64(i),
 				},
+				Source: &pb.Checkpoint{},
+				Target: &pb.Checkpoint{},
 			},
 		}
 		if err := s.beaconDB.SaveAttestation(context.Background(), attestations[i]); err != nil {

--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -153,10 +153,11 @@ func (as *AttesterServer) RequestAttestation(ctx context.Context, req *pb.Attest
 	}
 	res = &pbp2p.AttestationData{
 		BeaconBlockRoot: headRoot[:],
-		SourceEpoch:     headState.CurrentJustifiedCheckpoint.Epoch,
-		SourceRoot:      headState.CurrentJustifiedCheckpoint.Root,
-		TargetEpoch:     targetEpoch,
-		TargetRoot:      targetRoot,
+		Source:          headState.CurrentJustifiedCheckpoint,
+		Target: &pbp2p.Checkpoint{
+			Epoch: targetEpoch,
+			Root:  targetRoot,
+		},
 		Crosslink: &pbp2p.Crosslink{
 			Shard:      req.Shard,
 			StartEpoch: startEpoch,

--- a/beacon-chain/rpc/attester_server_test.go
+++ b/beacon-chain/rpc/attester_server_test.go
@@ -69,6 +69,8 @@ func TestSubmitAttestation_OK(t *testing.T) {
 				Shard:    935,
 				DataRoot: []byte{'a'},
 			},
+			Source: &pbp2p.Checkpoint{},
+			Target: &pbp2p.Checkpoint{},
 		},
 	}
 	if _, err := attesterServer.SubmitAttestation(context.Background(), req); err != nil {
@@ -162,9 +164,13 @@ func TestRequestAttestation_OK(t *testing.T) {
 
 	expectedInfo := &pbp2p.AttestationData{
 		BeaconBlockRoot: blockRoot[:],
-		SourceEpoch:     2 + 0,
-		SourceRoot:      justifiedRoot[:],
-		TargetEpoch:     3,
+		Source: &pbp2p.Checkpoint{
+			Epoch: 2,
+			Root:  justifiedRoot[:],
+		},
+		Target: &pbp2p.Checkpoint{
+			Epoch: 3,
+		},
 		Crosslink: &pbp2p.Crosslink{
 			EndEpoch:   3,
 			ParentRoot: crosslinkRoot[:],
@@ -274,9 +280,13 @@ func TestAttestationDataAtSlot_handlesFarAwayJustifiedEpoch(t *testing.T) {
 
 	expectedInfo := &pbp2p.AttestationData{
 		BeaconBlockRoot: blockRoot[:],
-		SourceEpoch:     helpers.SlotToEpoch(1500),
-		SourceRoot:      justifiedBlockRoot[:],
-		TargetEpoch:     156,
+		Source: &pbp2p.Checkpoint{
+			Epoch: helpers.SlotToEpoch(1500),
+			Root:  justifiedBlockRoot[:],
+		},
+		Target: &pbp2p.Checkpoint{
+			Epoch: 156,
+		},
 		Crosslink: &pbp2p.Crosslink{
 			ParentRoot: crosslinkRoot[:],
 			EndEpoch:   params.BeaconConfig().SlotsPerEpoch,
@@ -301,7 +311,7 @@ func TestAttestationDataAtSlot_handlesInProgressRequest(t *testing.T) {
 	}
 
 	res := &pbp2p.AttestationData{
-		TargetEpoch: 55,
+		Target: &pbp2p.Checkpoint{Epoch: 55},
 	}
 
 	if err := server.cache.MarkInProgress(req); err != nil {

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -161,6 +161,8 @@ func TestPendingAttestations_FiltersWithinInclusionDelay(t *testing.T) {
 						Shard:      beaconState.Slot - params.BeaconConfig().MinAttestationInclusionDelay,
 						DataRoot:   params.BeaconConfig().ZeroHash[:],
 						ParentRoot: encoded[:]},
+					Source: &pbp2p.Checkpoint{},
+					Target: &pbp2p.Checkpoint{},
 				},
 					AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0},
 				},
@@ -216,51 +218,52 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 		pendingAttestations: []*pbp2p.Attestation{
 			//Expired attestations
 			{Data: &pbp2p.AttestationData{
-				TargetEpoch: 10,
-				SourceEpoch: expectedEpoch,
-				Crosslink:   &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
+				Target: &pbp2p.Checkpoint{Epoch: 10},
+				Source: &pbp2p.Checkpoint{Epoch: expectedEpoch},
+
+				Crosslink: &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
-				TargetEpoch: 10,
-				SourceEpoch: expectedEpoch,
-				Crosslink:   &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
+				Target:    &pbp2p.Checkpoint{Epoch: 10},
+				Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch},
+				Crosslink: &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
-				TargetEpoch: 10,
-				SourceEpoch: expectedEpoch,
-				Crosslink:   &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
+				Target:    &pbp2p.Checkpoint{Epoch: 10},
+				Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch},
+				Crosslink: &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
-				TargetEpoch: 10,
-				SourceEpoch: expectedEpoch,
-				Crosslink:   &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
+				Target:    &pbp2p.Checkpoint{Epoch: 10},
+				Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch},
+				Crosslink: &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			{Data: &pbp2p.AttestationData{
-				TargetEpoch: 10,
-				SourceEpoch: expectedEpoch,
-				Crosslink:   &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
+				Target:    &pbp2p.Checkpoint{Epoch: 10},
+				Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch},
+				Crosslink: &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			// Non-expired attestation with incorrect justified epoch
 			{Data: &pbp2p.AttestationData{
-				TargetEpoch: 10,
-				SourceEpoch: expectedEpoch - 1,
-				Crosslink:   &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
+				Target:    &pbp2p.Checkpoint{Epoch: 10},
+				Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch - 1},
+				Crosslink: &pbp2p.Crosslink{DataRoot: params.BeaconConfig().ZeroHash[:]},
 			}},
 			// Non-expired attestations with correct justified epoch
 			{Data: &pbp2p.AttestationData{
-				TargetEpoch: 10,
-				SourceEpoch: expectedEpoch,
-				Crosslink:   &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
+				Target:    &pbp2p.Checkpoint{Epoch: 10},
+				Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch},
+				Crosslink: &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 			}, AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 			{Data: &pbp2p.AttestationData{
-				TargetEpoch: 10,
-				SourceEpoch: expectedEpoch,
-				Crosslink:   &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
+				Target:    &pbp2p.Checkpoint{Epoch: 10},
+				Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch},
+				Crosslink: &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 			}, AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 			{Data: &pbp2p.AttestationData{
-				TargetEpoch: 10,
-				SourceEpoch: expectedEpoch,
-				Crosslink:   &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
+				Target:    &pbp2p.Checkpoint{Epoch: 10},
+				Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch},
+				Crosslink: &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 			}, AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 		},
 	}
@@ -325,19 +328,19 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 
 	expectedAtts := []*pbp2p.Attestation{
 		{Data: &pbp2p.AttestationData{
-			TargetEpoch: 10,
-			SourceEpoch: expectedEpoch,
-			Crosslink:   &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
+			Target:    &pbp2p.Checkpoint{Epoch: 10},
+			Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch},
+			Crosslink: &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 		}, AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 		{Data: &pbp2p.AttestationData{
-			TargetEpoch: 10,
-			SourceEpoch: expectedEpoch,
-			Crosslink:   &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
+			Target:    &pbp2p.Checkpoint{Epoch: 10},
+			Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch},
+			Crosslink: &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 		}, AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 		{Data: &pbp2p.AttestationData{
-			TargetEpoch: 10,
-			SourceEpoch: expectedEpoch,
-			Crosslink:   &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
+			Target:    &pbp2p.Checkpoint{Epoch: 10},
+			Source:    &pbp2p.Checkpoint{Epoch: expectedEpoch},
+			Crosslink: &pbp2p.Crosslink{EndEpoch: 10, DataRoot: params.BeaconConfig().ZeroHash[:], ParentRoot: encoded[:]},
 		}, AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0}},
 	}
 	if !reflect.DeepEqual(atts, expectedAtts) {

--- a/beacon-chain/sync/regular_sync.go
+++ b/beacon-chain/sync/regular_sync.go
@@ -400,7 +400,7 @@ func (rs *RegularSync) receiveAttestation(msg p2p.Message) error {
 	}
 	log.WithFields(logrus.Fields{
 		"headRoot":       fmt.Sprintf("%#x", bytesutil.Trunc(attestation.Data.BeaconBlockRoot)),
-		"justifiedEpoch": attestation.Data.SourceEpoch,
+		"justifiedEpoch": attestation.Data.Source.Epoch,
 	}).Debug("Received an attestation")
 
 	// Skip if attestation has been seen before.

--- a/beacon-chain/sync/regular_sync_test.go
+++ b/beacon-chain/sync/regular_sync_test.go
@@ -397,7 +397,10 @@ func TestReceiveAttestation_OK(t *testing.T) {
 			Data: &pb.AttestationData{
 				Crosslink: &pb.Crosslink{
 					Shard: 1,
-				}},
+				},
+				Source: &pb.Checkpoint{},
+				Target: &pb.Checkpoint{},
+			},
 		},
 	}
 
@@ -448,7 +451,10 @@ func TestReceiveAttestation_OlderThanPrevEpoch(t *testing.T) {
 			Data: &pb.AttestationData{
 				Crosslink: &pb.Crosslink{
 					Shard: 900,
-				}},
+				},
+				Source: &pb.Checkpoint{},
+				Target: &pb.Checkpoint{},
+			},
 		},
 	}
 

--- a/proto/beacon/p2p/v1/types.proto
+++ b/proto/beacon/p2p/v1/types.proto
@@ -67,9 +67,9 @@ message Attestation {
   // Bitfield representation of validator indices that have voted exactly
   // the same vote and have been aggregated into this attestation.
   // Spec type: Bitlist[4096]
-  bytes aggregation_bits = 2; // [(gogoproto.moretags) = "ssz:\"size=4096\""];
+  bytes aggregation_bits = 2;
   // Challengeable bit (SSZ-bool, 1 byte) for the custody of crosslink data. Not used in phase 0.
-  bytes custody_bits = 3; // [(gogoproto.moretags) = "ssz:\"size=4096\""];
+  bytes custody_bits = 3;
   // 96 byte BLS aggregate signature.
   bytes signature = 4 [(gogoproto.moretags) = "ssz:\"size=96\""];
 }

--- a/proto/beacon/p2p/v1/types.proto
+++ b/proto/beacon/p2p/v1/types.proto
@@ -66,9 +66,10 @@ message Attestation {
   AttestationData data = 1;
   // Bitfield representation of validator indices that have voted exactly
   // the same vote and have been aggregated into this attestation.
-  bytes aggregation_bits = 2;
+  // Spec type: Bitlist[4096]
+  bytes aggregation_bits = 2; // [(gogoproto.moretags) = "ssz:\"size=4096\""];
   // Challengeable bit (SSZ-bool, 1 byte) for the custody of crosslink data. Not used in phase 0.
-  bytes custody_bits = 3;
+  bytes custody_bits = 3; // [(gogoproto.moretags) = "ssz:\"size=4096\""];
   // 96 byte BLS aggregate signature.
   bytes signature = 4 [(gogoproto.moretags) = "ssz:\"size=96\""];
 }
@@ -91,12 +92,6 @@ message AttestationData {
 
   // Crosslink voted by this attestation.
   Crosslink crosslink = 4;
-
-  // Deprecated
-  uint64 source_epoch = 1001;
-  bytes source_root = 1002;
-  uint64 target_epoch = 1003;
-  bytes target_root = 1004;
 }
 
 message AttestationTarget {

--- a/proto/testing/ssz_minimal.yaml.go
+++ b/proto/testing/ssz_minimal.yaml.go
@@ -14,14 +14,18 @@ type SszMinimalTest struct {
 	TestCases     []struct {
 		Attestation struct {
 			Value struct {
-				AggregationBits []byte `json:"aggregation_bitfield"`
+				AggregationBits []byte `json:"aggregation_bits"`
 				Data            struct {
 					BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-					SourceEpoch     uint64 `json:"source_epoch"`
-					SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-					TargetEpoch     uint64 `json:"target_epoch"`
-					TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-					Crosslink       struct {
+					Source          struct {
+						Epoch uint64 `json:"epoch"`
+						Root  []byte `json:"root" ssz:"size=32"`
+					} `json:"source"`
+					Target struct {
+						Epoch uint64 `json:"epoch"`
+						Root  []byte `json:"root" ssz:"size=32"`
+					} `json:"target"`
+					Crosslink struct {
 						Shard      uint64 `json:"shard"`
 						StartEpoch uint64 `json:"start_epoch"`
 						EndEpoch   uint64 `json:"end_epoch"`
@@ -29,7 +33,7 @@ type SszMinimalTest struct {
 						DataRoot   []byte `json:"data_root" ssz:"size=32"`
 					} `json:"crosslink"`
 				} `json:"data"`
-				CustodyBits []byte `json:"custody_bitfield"`
+				CustodyBits []byte `json:"custody_bits"`
 				Signature   []byte `json:"signature" ssz:"size=96"`
 			} `json:"value"`
 			Serialized  []byte `json:"serialized"`
@@ -39,11 +43,15 @@ type SszMinimalTest struct {
 		AttestationData struct {
 			Value struct {
 				BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-				SourceEpoch     uint64 `json:"source_epoch"`
-				SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-				TargetEpoch     uint64 `json:"target_epoch"`
-				TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-				Crosslink       struct {
+				Source          struct {
+					Epoch uint64 `json:"epoch"`
+					Root  []byte `json:"root" ssz:"size=32"`
+				} `json:"source"`
+				Target struct {
+					Epoch uint64 `json:"epoch"`
+					Root  []byte `json:"root" ssz:"size=32"`
+				} `json:"target"`
+				Crosslink struct {
 					Shard      uint64 `json:"shard"`
 					StartEpoch uint64 `json:"start_epoch"`
 					EndEpoch   uint64 `json:"end_epoch"`
@@ -58,11 +66,15 @@ type SszMinimalTest struct {
 			Value struct {
 				Data struct {
 					BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-					SourceEpoch     uint64 `json:"source_epoch"`
-					SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-					TargetEpoch     uint64 `json:"target_epoch"`
-					TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-					Crosslink       struct {
+					Source          struct {
+						Epoch uint64 `json:"epoch"`
+						Root  []byte `json:"root" ssz:"size=32"`
+					} `json:"source"`
+					Target struct {
+						Epoch uint64 `json:"epoch"`
+						Root  []byte `json:"root" ssz:"size=32"`
+					} `json:"target"`
+					Crosslink struct {
 						Shard      uint64 `json:"shard"`
 						StartEpoch uint64 `json:"start_epoch"`
 						EndEpoch   uint64 `json:"end_epoch"`
@@ -82,11 +94,15 @@ type SszMinimalTest struct {
 					CustodyBit1Indices []uint64 `json:"custody_bit_1_indices"`
 					Data               struct {
 						BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-						SourceEpoch     uint64 `json:"source_epoch"`
-						SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-						TargetEpoch     uint64 `json:"target_epoch"`
-						TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-						Crosslink       struct {
+						Source          struct {
+							Epoch uint64 `json:"epoch"`
+							Root  []byte `json:"root" ssz:"size=32"`
+						} `json:"source"`
+						Target struct {
+							Epoch uint64 `json:"epoch"`
+							Root  []byte `json:"root" ssz:"size=32"`
+						} `json:"target"`
+						Crosslink struct {
 							Shard      uint64 `json:"shard"`
 							StartEpoch uint64 `json:"start_epoch"`
 							EndEpoch   uint64 `json:"end_epoch"`
@@ -101,11 +117,15 @@ type SszMinimalTest struct {
 					CustodyBit1Indices []uint64 `json:"custody_bit_1_indices"`
 					Data               struct {
 						BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-						SourceEpoch     uint64 `json:"source_epoch"`
-						SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-						TargetEpoch     uint64 `json:"target_epoch"`
-						TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-						Crosslink       struct {
+						Source          struct {
+							Epoch uint64 `json:"epoch"`
+							Root  []byte `json:"root" ssz:"size=32"`
+						} `json:"source"`
+						Target struct {
+							Epoch uint64 `json:"epoch"`
+							Root  []byte `json:"root" ssz:"size=32"`
+						} `json:"target"`
+						Crosslink struct {
 							Shard      uint64 `json:"shard"`
 							StartEpoch uint64 `json:"start_epoch"`
 							EndEpoch   uint64 `json:"end_epoch"`
@@ -155,11 +175,15 @@ type SszMinimalTest struct {
 							CustodyBit1Indices []uint64 `json:"custody_bit_1_indices"`
 							Data               struct {
 								BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-								SourceEpoch     uint64 `json:"source_epoch"`
-								SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-								TargetEpoch     uint64 `json:"target_epoch"`
-								TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-								Crosslink       struct {
+								Source          struct {
+									Epoch uint64 `json:"epoch"`
+									Root  []byte `json:"root" ssz:"size=32"`
+								} `json:"source"`
+								Target struct {
+									Epoch uint64 `json:"epoch"`
+									Root  []byte `json:"root" ssz:"size=32"`
+								} `json:"target"`
+								Crosslink struct {
 									Shard      uint64 `json:"shard"`
 									StartEpoch uint64 `json:"start_epoch"`
 									EndEpoch   uint64 `json:"end_epoch"`
@@ -174,11 +198,15 @@ type SszMinimalTest struct {
 							CustodyBit1Indices []uint64 `json:"custody_bit_1_indices"`
 							Data               struct {
 								BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-								SourceEpoch     uint64 `json:"source_epoch"`
-								SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-								TargetEpoch     uint64 `json:"target_epoch"`
-								TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-								Crosslink       struct {
+								Source          struct {
+									Epoch uint64 `json:"epoch"`
+									Root  []byte `json:"root" ssz:"size=32"`
+								} `json:"source"`
+								Target struct {
+									Epoch uint64 `json:"epoch"`
+									Root  []byte `json:"root" ssz:"size=32"`
+								} `json:"target"`
+								Crosslink struct {
 									Shard      uint64 `json:"shard"`
 									StartEpoch uint64 `json:"start_epoch"`
 									EndEpoch   uint64 `json:"end_epoch"`
@@ -190,14 +218,18 @@ type SszMinimalTest struct {
 						} `json:"attestation_2"`
 					} `json:"attester_slashings"`
 					Attestations []struct {
-						AggregationBits []byte `json:"aggregation_bitfield"`
+						AggregationBits []byte `json:"aggregation_bits"`
 						Data            struct {
 							BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-							SourceEpoch     uint64 `json:"source_epoch"`
-							SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-							TargetEpoch     uint64 `json:"target_epoch"`
-							TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-							Crosslink       struct {
+							Source          struct {
+								Epoch uint64 `json:"epoch"`
+								Root  []byte `json:"root" ssz:"size=32"`
+							} `json:"source"`
+							Target struct {
+								Epoch uint64 `json:"epoch"`
+								Root  []byte `json:"root" ssz:"size=32"`
+							} `json:"target"`
+							Crosslink struct {
 								Shard      uint64 `json:"shard"`
 								StartEpoch uint64 `json:"start_epoch"`
 								EndEpoch   uint64 `json:"end_epoch"`
@@ -205,7 +237,7 @@ type SszMinimalTest struct {
 								DataRoot   []byte `json:"data_root" ssz:"size=32"`
 							} `json:"crosslink"`
 						} `json:"data"`
-						CustodyBits []byte `json:"custody_bitfield"`
+						CustodyBits []byte `json:"custody_bits"`
 						Signature   []byte `json:"signature" ssz:"size=96"`
 					} `json:"attestations"`
 					Deposits []struct {
@@ -270,11 +302,15 @@ type SszMinimalTest struct {
 						CustodyBit1Indices []uint64 `json:"custody_bit_1_indices"`
 						Data               struct {
 							BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-							SourceEpoch     uint64 `json:"source_epoch"`
-							SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-							TargetEpoch     uint64 `json:"target_epoch"`
-							TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-							Crosslink       struct {
+							Source          struct {
+								Epoch uint64 `json:"epoch"`
+								Root  []byte `json:"root" ssz:"size=32"`
+							} `json:"source"`
+							Target struct {
+								Epoch uint64 `json:"epoch"`
+								Root  []byte `json:"root" ssz:"size=32"`
+							} `json:"target"`
+							Crosslink struct {
 								Shard      uint64 `json:"shard"`
 								StartEpoch uint64 `json:"start_epoch"`
 								EndEpoch   uint64 `json:"end_epoch"`
@@ -289,11 +325,15 @@ type SszMinimalTest struct {
 						CustodyBit1Indices []uint64 `json:"custody_bit_1_indices"`
 						Data               struct {
 							BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-							SourceEpoch     uint64 `json:"source_epoch"`
-							SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-							TargetEpoch     uint64 `json:"target_epoch"`
-							TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-							Crosslink       struct {
+							Source          struct {
+								Epoch uint64 `json:"epoch"`
+								Root  []byte `json:"root" ssz:"size=32"`
+							} `json:"source"`
+							Target struct {
+								Epoch uint64 `json:"epoch"`
+								Root  []byte `json:"root" ssz:"size=32"`
+							} `json:"target"`
+							Crosslink struct {
 								Shard      uint64 `json:"shard"`
 								StartEpoch uint64 `json:"start_epoch"`
 								EndEpoch   uint64 `json:"end_epoch"`
@@ -305,14 +345,18 @@ type SszMinimalTest struct {
 					} `json:"attestation_2"`
 				} `json:"attester_slashings"`
 				Attestations []struct {
-					AggregationBits []byte `json:"aggregation_bitfield"`
+					AggregationBits []byte `json:"aggregation_bits"`
 					Data            struct {
 						BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-						SourceEpoch     uint64 `json:"source_epoch"`
-						SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-						TargetEpoch     uint64 `json:"target_epoch"`
-						TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-						Crosslink       struct {
+						Source          struct {
+							Epoch uint64 `json:"epoch"`
+							Root  []byte `json:"root" ssz:"size=32"`
+						} `json:"source"`
+						Target struct {
+							Epoch uint64 `json:"epoch"`
+							Root  []byte `json:"root" ssz:"size=32"`
+						} `json:"target"`
+						Crosslink struct {
 							Shard      uint64 `json:"shard"`
 							StartEpoch uint64 `json:"start_epoch"`
 							EndEpoch   uint64 `json:"end_epoch"`
@@ -320,7 +364,7 @@ type SszMinimalTest struct {
 							DataRoot   []byte `json:"data_root" ssz:"size=32"`
 						} `json:"crosslink"`
 					} `json:"data"`
-					CustodyBits []byte `json:"custody_bitfield"`
+					CustodyBits []byte `json:"custody_bits"`
 					Signature   []byte `json:"signature" ssz:"size=96"`
 				} `json:"attestations"`
 				Deposits []struct {
@@ -385,14 +429,18 @@ type SszMinimalTest struct {
 				RandaoMixes               [][]byte `json:"latest_randao_mixes" ssz:"size=64,32"`
 				StartShard                uint64   `json:"latest_start_shard"`
 				PreviousEpochAttestations []struct {
-					AggregationBits []byte `json:"aggregation_bitfield"`
+					AggregationBits []byte `json:"aggregation_bits"`
 					Data            struct {
 						BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-						SourceEpoch     uint64 `json:"source_epoch"`
-						SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-						TargetEpoch     uint64 `json:"target_epoch"`
-						TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-						Crosslink       struct {
+						Source          struct {
+							Epoch uint64 `json:"epoch"`
+							Root  []byte `json:"root" ssz:"size=32"`
+						} `json:"source"`
+						Target struct {
+							Epoch uint64 `json:"epoch"`
+							Root  []byte `json:"root" ssz:"size=32"`
+						} `json:"target"`
+						Crosslink struct {
 							Shard      uint64 `json:"shard"`
 							StartEpoch uint64 `json:"start_epoch"`
 							EndEpoch   uint64 `json:"end_epoch"`
@@ -404,14 +452,18 @@ type SszMinimalTest struct {
 					ProposerIndex  uint64 `json:"proposer_index"`
 				} `json:"previous_epoch_attestations"`
 				CurrentEpochAttestations []struct {
-					AggregationBits []byte `json:"aggregation_bitfield"`
+					AggregationBits []byte `json:"aggregation_bits"`
 					Data            struct {
 						BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-						SourceEpoch     uint64 `json:"source_epoch"`
-						SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-						TargetEpoch     uint64 `json:"target_epoch"`
-						TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-						Crosslink       struct {
+						Source          struct {
+							Epoch uint64 `json:"epoch"`
+							Root  []byte `json:"root" ssz:"size=32"`
+						} `json:"source"`
+						Target struct {
+							Epoch uint64 `json:"epoch"`
+							Root  []byte `json:"root" ssz:"size=32"`
+						} `json:"target"`
+						Crosslink struct {
 							Shard      uint64 `json:"shard"`
 							StartEpoch uint64 `json:"start_epoch"`
 							EndEpoch   uint64 `json:"end_epoch"`
@@ -426,7 +478,7 @@ type SszMinimalTest struct {
 				CurrentJustifiedEpoch  uint64 `json:"current_justified_epoch"`
 				PreviousJustifiedRoot  []byte `json:"previous_justified_root" ssz:"size=32"`
 				CurrentJustifiedRoot   []byte `json:"current_justified_root" ssz:"size=32"`
-				JustificationBits      uint64 `json:"justification_bitfield"`
+				JustificationBits      []byte `json:"justification_bits"`
 				FinalizedEpoch         uint64 `json:"finalized_epoch"`
 				FinalizedRoot          []byte `json:"finalized_root" ssz:"size=32"`
 				CurrentCrosslinks      []struct {
@@ -537,11 +589,15 @@ type SszMinimalTest struct {
 				CustodyBit1Indices []uint64 `json:"custody_bit_1_indices"`
 				Data               struct {
 					BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-					SourceEpoch     uint64 `json:"source_epoch"`
-					SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-					TargetEpoch     uint64 `json:"target_epoch"`
-					TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-					Crosslink       struct {
+					Source          struct {
+						Epoch uint64 `json:"epoch"`
+						Root  []byte `json:"root" ssz:"size=32"`
+					} `json:"source"`
+					Target struct {
+						Epoch uint64 `json:"epoch"`
+						Root  []byte `json:"root" ssz:"size=32"`
+					} `json:"target"`
+					Crosslink struct {
 						Shard      uint64 `json:"shard"`
 						StartEpoch uint64 `json:"start_epoch"`
 						EndEpoch   uint64 `json:"end_epoch"`
@@ -557,14 +613,18 @@ type SszMinimalTest struct {
 		} `json:"IndexedAttestation,omitempty"`
 		PendingAttestation struct {
 			Value struct {
-				AggregationBits []byte `json:"aggregation_bitfield"`
+				AggregationBits []byte `json:"aggregation_bits"`
 				Data            struct {
 					BeaconBlockRoot []byte `json:"beacon_block_root" ssz:"size=32"`
-					SourceEpoch     uint64 `json:"source_epoch"`
-					SourceRoot      []byte `json:"source_root" ssz:"size=32"`
-					TargetEpoch     uint64 `json:"target_epoch"`
-					TargetRoot      []byte `json:"target_root" ssz:"size=32"`
-					Crosslink       struct {
+					Source          struct {
+						Epoch uint64 `json:"epoch"`
+						Root  []byte `json:"root" ssz:"size=32"`
+					} `json:"source"`
+					Target struct {
+						Epoch uint64 `json:"epoch"`
+						Root  []byte `json:"root" ssz:"size=32"`
+					} `json:"target"`
+					Crosslink struct {
 						Shard      uint64 `json:"shard"`
 						StartEpoch uint64 `json:"start_epoch"`
 						EndEpoch   uint64 `json:"end_epoch"`

--- a/proto/testing/tags_test.go
+++ b/proto/testing/tags_test.go
@@ -31,7 +31,7 @@ func TestSSZTagSize(t *testing.T) {
 		t.Errorf("wanted signature size: %d, got: %d", sigSize, sizes[0])
 	}
 
-	sizes, err = sszTagSizes(pb.BeaconState{}, "FinalizedCheckpoint.Root")
+	sizes, err = sszTagSizes(pb.Checkpoint{}, "Root")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -110,8 +110,8 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, pk strin
 	log.WithFields(logrus.Fields{
 		"headRoot":    fmt.Sprintf("%#x", bytesutil.Trunc(data.BeaconBlockRoot)),
 		"shard":       data.Crosslink.Shard,
-		"sourceEpoch": data.SourceEpoch,
-		"targetEpoch": data.TargetEpoch,
+		"sourceEpoch": data.Source.Epoch,
+		"targetEpoch": data.Target.Epoch,
 		"validator":   truncatedPk,
 	}).Info("Attested latest head")
 
@@ -120,8 +120,8 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, pk strin
 		trace.StringAttribute("attestationHash", fmt.Sprintf("%#x", attResp.Root)),
 		trace.Int64Attribute("shard", int64(data.Crosslink.Shard)),
 		trace.StringAttribute("blockRoot", fmt.Sprintf("%#x", data.BeaconBlockRoot)),
-		trace.Int64Attribute("justifiedEpoch", int64(data.SourceEpoch)),
-		trace.Int64Attribute("targetEpoch", int64(data.TargetEpoch)),
+		trace.Int64Attribute("justifiedEpoch", int64(data.Source.Epoch)),
+		trace.Int64Attribute("targetEpoch", int64(data.Target.Epoch)),
 		trace.StringAttribute("bitfield", fmt.Sprintf("%#x", aggregationBitfield)),
 	)
 }

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -77,8 +77,8 @@ func TestAttestToBlockHead_SubmitAttestationRequestFailure(t *testing.T) {
 		gomock.AssignableToTypeOf(&pb.AttestationRequest{}),
 	).Return(&pbp2p.AttestationData{
 		BeaconBlockRoot: []byte{},
-		TargetRoot:      []byte{},
-		SourceRoot:      []byte{},
+		Target:          &pbp2p.Checkpoint{},
+		Source:          &pbp2p.Checkpoint{},
 		Crosslink:       &pbp2p.Crosslink{},
 	}, nil)
 	m.attesterClient.EXPECT().SubmitAttestation(
@@ -114,10 +114,9 @@ func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
 		gomock.AssignableToTypeOf(&pb.AttestationRequest{}),
 	).Return(&pbp2p.AttestationData{
 		BeaconBlockRoot: []byte("A"),
-		TargetRoot:      []byte("B"),
-		SourceRoot:      []byte("C"),
+		Target:          &pbp2p.Checkpoint{Root: []byte("B")},
+		Source:          &pbp2p.Checkpoint{Root: []byte("C"), Epoch: 3},
 		Crosslink:       &pbp2p.Crosslink{Shard: 5, DataRoot: []byte{'D'}},
-		SourceEpoch:     3,
 	}, nil)
 
 	var generatedAttestation *pbp2p.Attestation
@@ -134,10 +133,9 @@ func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
 	expectedAttestation := &pbp2p.Attestation{
 		Data: &pbp2p.AttestationData{
 			BeaconBlockRoot: []byte("A"),
-			TargetRoot:      []byte("B"),
-			SourceRoot:      []byte("C"),
+			Target:          &pbp2p.Checkpoint{Root: []byte("B")},
+			Source:          &pbp2p.Checkpoint{Root: []byte("C"), Epoch: 3},
 			Crosslink:       &pbp2p.Crosslink{Shard: 5, DataRoot: []byte{'D'}},
-			SourceEpoch:     3,
 		},
 		CustodyBits: make([]byte, (len(committee)+7)/8),
 		Signature:   []byte("signed"),
@@ -208,10 +206,9 @@ func TestAttestToBlockHead_DoesAttestAfterDelay(t *testing.T) {
 		gomock.AssignableToTypeOf(&pb.AttestationRequest{}),
 	).Return(&pbp2p.AttestationData{
 		BeaconBlockRoot: []byte("A"),
-		TargetRoot:      []byte("B"),
-		SourceRoot:      []byte("C"),
+		Target:          &pbp2p.Checkpoint{Root: []byte("B")},
+		Source:          &pbp2p.Checkpoint{Root: []byte("C"), Epoch: 3},
 		Crosslink:       &pbp2p.Crosslink{DataRoot: []byte{'D'}},
-		SourceEpoch:     3,
 	}, nil).Do(func(arg0, arg1 interface{}) {
 		wg.Done()
 	})
@@ -255,11 +252,9 @@ func TestAttestToBlockHead_CorrectBitfieldLength(t *testing.T) {
 		gomock.Any(), // ctx
 		gomock.AssignableToTypeOf(&pb.AttestationRequest{}),
 	).Return(&pbp2p.AttestationData{
-		BeaconBlockRoot: []byte("A"),
-		TargetRoot:      []byte("B"),
-		SourceRoot:      []byte("C"),
-		Crosslink:       &pbp2p.Crosslink{DataRoot: []byte{'D'}},
-		SourceEpoch:     3,
+		Target:    &pbp2p.Checkpoint{Root: []byte("B")},
+		Source:    &pbp2p.Checkpoint{Root: []byte("C"), Epoch: 3},
+		Crosslink: &pbp2p.Crosslink{DataRoot: []byte{'D'}},
 	}, nil)
 
 	var generatedAttestation *pbp2p.Attestation


### PR DESCRIPTION
This is mostly checkpoint changes. 

Also restores some (but not all) validation that was removed in #2867