### PR TITLE
Update Helper Function's Pseudocode Definitions

### DIFF
--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -225,7 +225,7 @@ func (a *Service) InsertAttestationIntoStore(pubkey [48]byte, att *pb.Attestatio
 func (a *Service) updateAttestation(beaconState *pb.BeaconState, attestation *pb.Attestation) error {
 	totalAttestationSeen.Inc()
 
-	committee, err := helpers.CrosslinkCommitteeAtEpoch(beaconState, helpers.CurrentEpoch(beaconState), attestation.Data.Crosslink.Shard)
+	committee, err := helpers.CrosslinkCommittee(beaconState, helpers.CurrentEpoch(beaconState), attestation.Data.Crosslink.Shard)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -360,16 +360,17 @@ func verifyAttesterSlashing(slashing *pb.AttesterSlashing, verifySignatures bool
 // IsSlashableAttestationData verifies a slashing against the Casper Proof of Stake FFG rules.
 //
 // Spec pseudocode definition:
-//   return (
-//   # Double vote
-//   (data_1 != data_2 and data_1.target_epoch == data_2.target_epoch) or
-//   # Surround vote
-//   (data_1.source_epoch < data_2.source_epoch and data_2.target_epoch < data_1.target_epoch)
-//   )
+//   def is_slashable_attestation_data(data_1: AttestationData, data_2: AttestationData) -> bool:
+//    """
+//    Check if ``data_1`` and ``data_2`` are slashable according to Casper FFG rules.
+//    """
+//    return (
+//        # Double vote
+//        (data_1 != data_2 and data_1.target.epoch == data_2.target.epoch) or
+//        # Surround vote
+//        (data_1.source.epoch < data_2.source.epoch and data_2.target.epoch < data_1.target.epoch)
+//    )
 func IsSlashableAttestationData(data1 *pb.AttestationData, data2 *pb.AttestationData) bool {
-	// Inner attestation data structures for the votes should not be equal,
-	// as that would mean both votes are the same and therefore no slashing
-	// should occur.
 	isDoubleVote := !proto.Equal(data1, data2) && data1.TargetEpoch == data2.TargetEpoch
 	isSurroundVote := data1.SourceEpoch < data2.SourceEpoch && data2.TargetEpoch < data1.TargetEpoch
 	return isDoubleVote || isSurroundVote
@@ -597,34 +598,40 @@ func ConvertToIndexed(state *pb.BeaconState, attestation *pb.Attestation) (*pb.I
 // WIP - signing is not implemented until BLS is integrated into Prysm.
 //
 // Spec pseudocode definition:
-//  def verify_indexed_attestation(state: BeaconState, indexed_attestation: IndexedAttestation) -> bool:
+//  def is_valid_indexed_attestation(state: BeaconState, indexed_attestation: IndexedAttestation) -> bool:
 //    """
-//    Verify validity of ``indexed_attestation`` fields.
+//    Verify validity of ``indexed_attestation``.
 //    """
-//    custody_bit_0_indices = indexed_attestation.custody_bit_0_indices
-//    custody_bit_1_indices = indexed_attestation.custody_bit_1_indices
+//    bit_0_indices = indexed_attestation.custody_bit_0_indices
+//    bit_1_indices = indexed_attestation.custody_bit_1_indices
 //
-//    # Ensure no duplicate indices across custody bits
-//    assert len(set(custody_bit_0_indices).intersection(set(custody_bit_1_indices))) == 0
-//
-//    if len(custody_bit_1_indices) > 0:  # [TO BE REMOVED IN PHASE 1]
+//    # Verify no index has custody bit equal to 1 [to be removed in phase 1]
+//    if not len(bit_1_indices) == 0:
 //        return False
-//
-//    if not (1 <= len(custody_bit_0_indices) + len(custody_bit_1_indices) <= MAX_INDICES_PER_ATTESTATION):
+//    # Verify max number of indices
+//    if not len(bit_0_indices) + len(bit_1_indices) <= MAX_VALIDATORS_PER_COMMITTEE:
 //        return False
-//
-//    return bls_verify_multiple(
+//    # Verify index sets are disjoint
+//    if not len(set(bit_0_indices).intersection(bit_1_indices)) == 0:
+//        return False
+//    # Verify indices are sorted
+//    if not (bit_0_indices == sorted(bit_0_indices) and bit_1_indices == sorted(bit_1_indices)):
+//        return False
+//    # Verify aggregate signature
+//    if not bls_verify_multiple(
 //        pubkeys=[
-//            bls_aggregate_pubkeys([state.validator_registry[i].pubkey for i in custody_bit_0_indices]),
-//            bls_aggregate_pubkeys([state.validator_registry[i].pubkey for i in custody_bit_1_indices]),
+//            bls_aggregate_pubkeys([state.validators[i].pubkey for i in bit_0_indices]),
+//            bls_aggregate_pubkeys([state.validators[i].pubkey for i in bit_1_indices]),
 //        ],
 //        message_hashes=[
 //            hash_tree_root(AttestationDataAndCustodyBit(data=indexed_attestation.data, custody_bit=0b0)),
 //            hash_tree_root(AttestationDataAndCustodyBit(data=indexed_attestation.data, custody_bit=0b1)),
 //        ],
 //        signature=indexed_attestation.signature,
-//        domain=get_domain(state, DOMAIN_ATTESTATION, slot_to_epoch(indexed_attestation.data.slot)),
-//    )
+//        domain=get_domain(state, DOMAIN_ATTESTATION, indexed_attestation.data.target.epoch),
+//    ):
+//        return False
+//    return True
 func VerifyIndexedAttestation(indexedAtt *pb.IndexedAttestation, verifySignatures bool) error {
 	custodyBit0Indices := indexedAtt.CustodyBit_0Indices
 	custodyBit1Indices := indexedAtt.CustodyBit_1Indices
@@ -870,10 +877,13 @@ func verifyExit(beaconState *pb.BeaconState, exit *pb.VoluntaryExit, verifySigna
 //    assert state.balances[transfer.sender] >= max(transfer.amount, transfer.fee)
 //    # A transfer is valid in only one slot
 //    assert state.slot == transfer.slot
-//    # Sender must be not yet eligible for activation, withdrawn, or transfer balance over MAX_EFFECTIVE_BALANCE
+//    # Sender must satisfy at least one of the following conditions in the parenthesis:
 //    assert (
+//		  # * Has not been activated
 //        state.validator_registry[transfer.sender].activation_eligibility_epoch == FAR_FUTURE_EPOCH or
+//        # * Is withdrawable
 //        get_current_epoch(state) >= state.validator_registry[transfer.sender].withdrawable_epoch or
+//        # * Balance after transfer is more than the effective balance threshold
 //        transfer.amount + transfer.fee + MAX_EFFECTIVE_BALANCE <= state.balances[transfer.sender]
 //    )
 //    # Verify that the pubkey is valid

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -255,17 +255,17 @@ func ProcessCrosslinks(state *pb.BeaconState) (*pb.BeaconState, error) {
 	copy(state.PreviousCrosslinks, state.CurrentCrosslinks)
 	epochs := []uint64{helpers.PrevEpoch(state), helpers.CurrentEpoch(state)}
 	for _, e := range epochs {
-		count, err := helpers.EpochCommitteeCount(state, e)
+		count, err := helpers.CommitteeCount(state, e)
 		if err != nil {
 			return nil, fmt.Errorf("could not get epoch committee count: %v", err)
 		}
-		startShard, err := helpers.EpochStartShard(state, e)
+		startShard, err := helpers.StartShard(state, e)
 		if err != nil {
 			return nil, fmt.Errorf("could not get epoch start shards: %v", err)
 		}
 		for offset := uint64(0); offset < count; offset++ {
 			shard := (startShard + offset) % params.BeaconConfig().ShardCount
-			committee, err := helpers.CrosslinkCommitteeAtEpoch(state, e, shard)
+			committee, err := helpers.CrosslinkCommittee(state, e, shard)
 			if err != nil {
 				return nil, fmt.Errorf("could not get crosslink committee: %v", err)
 			}
@@ -382,7 +382,7 @@ func ProcessRegistryUpdates(state *pb.BeaconState) (*pb.BeaconState, error) {
 
 	// Only activate just enough validators according to the activation churn limit.
 	limit := len(activationQ)
-	churnLimit, err := helpers.ChurnLimit(state)
+	churnLimit, err := helpers.ValidatorChurnLimit(state)
 	if err != nil {
 		return nil, fmt.Errorf("could not get churn limit: %v", err)
 	}
@@ -902,17 +902,17 @@ func crosslinkDelta(state *pb.BeaconState) ([]uint64, []uint64, error) {
 	rewards := make([]uint64, len(state.Validators))
 	penalties := make([]uint64, len(state.Validators))
 	epoch := helpers.PrevEpoch(state)
-	count, err := helpers.EpochCommitteeCount(state, epoch)
+	count, err := helpers.CommitteeCount(state, epoch)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get epoch committee count: %v", err)
 	}
-	startShard, err := helpers.EpochStartShard(state, epoch)
+	startShard, err := helpers.StartShard(state, epoch)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not get epoch start shard: %v", err)
 	}
 	for i := uint64(0); i < count; i++ {
 		shard := (startShard + i) % params.BeaconConfig().ShardCount
-		committee, err := helpers.CrosslinkCommitteeAtEpoch(state, epoch, shard)
+		committee, err := helpers.CrosslinkCommittee(state, epoch, shard)
 		if err != nil {
 			return nil, nil, fmt.Errorf("could not get crosslink's committee: %v", err)
 		}

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -1093,7 +1093,7 @@ func TestProcessRegistryUpdates_EligibleToActivate(t *testing.T) {
 		Slot:                5 * params.BeaconConfig().SlotsPerEpoch,
 		FinalizedCheckpoint: &pb.Checkpoint{},
 	}
-	limit, _ := helpers.ChurnLimit(state)
+	limit, _ := helpers.ValidatorChurnLimit(state)
 	for i := 0; i < int(limit)+10; i++ {
 		state.Validators = append(state.Validators, &pb.Validator{
 			ActivationEligibilityEpoch: params.BeaconConfig().FarFutureEpoch,

--- a/beacon-chain/core/helpers/attestation.go
+++ b/beacon-chain/core/helpers/attestation.go
@@ -21,9 +21,12 @@ var (
 //
 // Spec pseudocode definition:
 //   def get_attestation_data_slot(state: BeaconState, data: AttestationData) -> Slot:
-//     committee_count = get_epoch_committee_count(state, data.target_epoch)
-//     offset = (data.crosslink.shard + SHARD_COUNT - get_epoch_start_shard(state, data.target_epoch)) % SHARD_COUNT
-//     return get_epoch_start_slot(data.target_epoch) + offset // (committee_count // SLOTS_PER_EPOCH)
+//    """
+//    Return the slot corresponding to the attestation ``data``.
+//    """
+//    committee_count = get_committee_count(state, data.target.epoch)
+//    offset = (data.crosslink.shard + SHARD_COUNT - get_start_shard(state, data.target.epoch)) % SHARD_COUNT
+//    return Slot(compute_start_slot_of_epoch(data.target.epoch) + offset // (committee_count // SLOTS_PER_EPOCH))
 func AttestationDataSlot(state *pb.BeaconState, data *pb.AttestationData) (uint64, error) {
 	if state == nil {
 		return 0, ErrAttestationDataSlotNilState
@@ -31,13 +34,13 @@ func AttestationDataSlot(state *pb.BeaconState, data *pb.AttestationData) (uint6
 	if data == nil {
 		return 0, ErrAttestationDataSlotNilData
 	}
-	committeeCount, err := EpochCommitteeCount(state, data.TargetEpoch)
+	committeeCount, err := CommitteeCount(state, data.TargetEpoch)
 	if err != nil {
 		return 0, err
 	}
 
-	epochStartShardNumber, err := EpochStartShard(state, data.TargetEpoch)
-	if err != nil { // This should never happen if EpochCommitteeCount was successful
+	epochStartShardNumber, err := StartShard(state, data.TargetEpoch)
+	if err != nil { // This should never happen if CommitteeCount was successful
 		return 0, fmt.Errorf("could not determine epoch start shard: %v", err)
 	}
 	offset := (data.Crosslink.Shard + params.BeaconConfig().ShardCount -

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -23,7 +23,7 @@ func TestAttestationDataSlot_OK(t *testing.T) {
 		t.Fatal(err)
 	}
 	offset := uint64(0)
-	committeeCount, _ := helpers.EpochCommitteeCount(beaconState, 0)
+	committeeCount, _ := helpers.CommitteeCount(beaconState, 0)
 	expect := offset / (committeeCount / params.BeaconConfig().SlotsPerEpoch)
 	attSlot, err := helpers.AttestationDataSlot(beaconState, &pb.AttestationData{
 		TargetEpoch: 0,

--- a/beacon-chain/core/helpers/block.go
+++ b/beacon-chain/core/helpers/block.go
@@ -11,13 +11,12 @@ import (
 // It returns an error if the requested block root is not within the slot range.
 //
 // Spec pseudocode definition:
-//  def get_block_root_at_slot(state: BeaconState,
-//                           slot: Slot) -> Bytes32:
+//  def get_block_root_at_slot(state: BeaconState, slot: Slot) -> Hash:
 //    """
 //    Return the block root at a recent ``slot``.
 //    """
 //    assert slot < state.slot <= slot + SLOTS_PER_HISTORICAL_ROOT
-//    return state.latest_block_roots[slot % SLOTS_PER_HISTORICAL_ROOT]
+//    return state.block_roots[slot % SLOTS_PER_HISTORICAL_ROOT]
 func BlockRootAtSlot(state *pb.BeaconState, slot uint64) ([]byte, error) {
 	earliestSlot := uint64(0)
 	if state.Slot > params.BeaconConfig().HistoricalRootsLimit {
@@ -39,12 +38,11 @@ func BlockRootAtSlot(state *pb.BeaconState, slot uint64) ([]byte, error) {
 // BlockRoot returns the block root stored in the BeaconState for epoch start slot.
 //
 // Spec pseudocode definition:
-//  def get_block_root(state: BeaconState,
-//                   epoch: Epoch) -> Bytes32:
+//  def get_block_root(state: BeaconState, epoch: Epoch) -> Hash:
 //    """
-//    Return the block root at a recent ``epoch``.
+//    Return the block root at the start of a recent ``epoch``.
 //    """
-//    return get_block_root_at_slot(state, get_epoch_start_slot(epoch))
+//    return get_block_root_at_slot(state, compute_start_slot_of_epoch(epoch))
 func BlockRoot(state *pb.BeaconState, epoch uint64) ([]byte, error) {
 	return BlockRootAtSlot(state, StartSlot(epoch))
 }

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -37,7 +37,7 @@ func TestEpochCommitteeCount_OK(t *testing.T) {
 		s := &pb.BeaconState{
 			Validators: vals,
 		}
-		count, err := EpochCommitteeCount(s, 1)
+		count, err := CommitteeCount(s, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -66,7 +66,7 @@ func TestEpochCommitteeCount_LessShardsThanEpoch(t *testing.T) {
 	s := &pb.BeaconState{
 		Validators: vals,
 	}
-	count, err := EpochCommitteeCount(s, 1)
+	count, err := CommitteeCount(s, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestComputeCommittee_WithoutCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	seed, err := GenerateSeed(state, epoch)
+	seed, err := Seed(state, epoch)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +194,7 @@ func TestComputeCommittee_WithCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	seed, err := GenerateSeed(state, epoch)
+	seed, err := Seed(state, epoch)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -507,7 +507,7 @@ func TestShardDelta_OK(t *testing.T) {
 }
 
 func TestEpochStartShard_EpochOutOfBound(t *testing.T) {
-	_, err := EpochStartShard(&pb.BeaconState{}, 2)
+	_, err := StartShard(&pb.BeaconState{}, 2)
 	want := "epoch 2 can't be greater than 1"
 	if err.Error() != want {
 		t.Fatalf("Did not generate correct error. Want: %s, got: %s",
@@ -537,7 +537,7 @@ func TestEpochStartShard_AccurateShard(t *testing.T) {
 			}
 		}
 		state := &pb.BeaconState{Validators: validators, StartShard: 100, Slot: 500}
-		startShard, err := EpochStartShard(state, 0)
+		startShard, err := StartShard(state, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -591,7 +591,7 @@ func TestEpochStartShard_MixedActivationValidatorRegistry(t *testing.T) {
 			Validators: vs,
 			Slot:       params.BeaconConfig().SlotsPerEpoch * 3,
 		}
-		startShard, err := EpochStartShard(s, 2 /*epoch*/)
+		startShard, err := StartShard(s, 2 /*epoch*/)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -733,7 +733,7 @@ func BenchmarkComputeCommittee300000_WithPreCache(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	seed, err := GenerateSeed(state, epoch)
+	seed, err := Seed(state, epoch)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -772,7 +772,7 @@ func BenchmarkComputeCommittee3000000_WithPreCache(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	seed, err := GenerateSeed(state, epoch)
+	seed, err := Seed(state, epoch)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -811,7 +811,7 @@ func BenchmarkComputeCommittee128000_WithOutPreCache(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	seed, err := GenerateSeed(state, epoch)
+	seed, err := Seed(state, epoch)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -851,7 +851,7 @@ func BenchmarkComputeCommittee1000000_WithOutCache(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	seed, err := GenerateSeed(state, epoch)
+	seed, err := Seed(state, epoch)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -891,7 +891,7 @@ func BenchmarkComputeCommittee4000000_WithOutCache(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	seed, err := GenerateSeed(state, epoch)
+	seed, err := Seed(state, epoch)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/beacon-chain/core/helpers/randao.go
+++ b/beacon-chain/core/helpers/randao.go
@@ -14,20 +14,17 @@ import (
 
 var currentEpochSeed = cache.NewSeedCache()
 
-// GenerateSeed generates the randao seed of a given epoch.
+// Seed returns the randao seed used for shuffling of a given epoch.
 //
 // Spec pseudocode definition:
-//  def generate_seed(state: BeaconState,
-//     epoch: Epoch) -> Bytes32:
-//     """
-//     Generate a seed for the given ``epoch``.
-//     """
-//     return hash(
-//     get_randao_mix(state, epoch + LATEST_RANDAO_MIXES_LENGTH - MIN_SEED_LOOKAHEAD) +
-//     get_active_index_root(state, epoch) +
-//     int_to_bytes32(epoch)
-// )
-func GenerateSeed(state *pb.BeaconState, epoch uint64) ([32]byte, error) {
+//  def get_seed(state: BeaconState, epoch: Epoch) -> Hash:
+//    """
+//    Return the seed at ``epoch``.
+//    """
+//    mix = get_randao_mix(state, Epoch(epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD))  # Avoid underflow
+//    active_index_root = state.active_index_roots[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
+//    return hash(mix + active_index_root + int_to_bytes(epoch, length=32))
+func Seed(state *pb.BeaconState, epoch uint64) ([32]byte, error) {
 	seed, err := currentEpochSeed.SeedInEpoch(epoch)
 	if err != nil {
 		return [32]byte{}, fmt.Errorf("could not retrieve total balance from cache: %v", err)
@@ -80,13 +77,11 @@ func ActiveIndexRoot(state *pb.BeaconState, epoch uint64) []byte {
 // of a given slot. It is used to shuffle validators.
 //
 // Spec pseudocode definition:
-//   def get_randao_mix(state: BeaconState,
-//                   epoch: Epoch) -> Bytes32:
+//   def get_randao_mix(state: BeaconState, epoch: Epoch) -> Hash:
 //    """
 //    Return the randao mix at a recent ``epoch``.
-//    ``epoch`` expected to be between (current_epoch - LATEST_RANDAO_MIXES_LENGTH, current_epoch].
 //    """
-//    return state.latest_randao_mixes[epoch % LATEST_RANDAO_MIXES_LENGTH]
+//    return state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
 func RandaoMix(state *pb.BeaconState, epoch uint64) []byte {
 	newMixLength := len(state.RandaoMixes[epoch%params.BeaconConfig().EpochsPerHistoricalVector])
 	newMix := make([]byte, newMixLength)

--- a/beacon-chain/core/helpers/randao_test.go
+++ b/beacon-chain/core/helpers/randao_test.go
@@ -190,7 +190,7 @@ func TestGenerateSeed_OK(t *testing.T) {
 		RandaoMixes:      randaoMixes,
 		Slot:             slot}
 
-	got, err := GenerateSeed(state, 10)
+	got, err := Seed(state, 10)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/helpers/slot_epoch.go
+++ b/beacon-chain/core/helpers/slot_epoch.go
@@ -8,11 +8,11 @@ import (
 // SlotToEpoch returns the epoch number of the input slot.
 //
 // Spec pseudocode definition:
-//  def slot_to_epoch(slot: Slot) -> Epoch:
-//   """
-//   Return the epoch number of the given ``slot``.
-//   """
-//   return slot // SLOTS_PER_EPOCH
+//  def compute_epoch_of_slot(slot: Slot) -> Epoch:
+//    """
+//    Return the epoch number of ``slot``.
+//    """
+//    return Epoch(slot // SLOTS_PER_EPOCH)
 func SlotToEpoch(slot uint64) uint64 {
 	return slot / params.BeaconConfig().SlotsPerEpoch
 }
@@ -23,9 +23,9 @@ func SlotToEpoch(slot uint64) uint64 {
 // Spec pseudocode definition:
 //  def get_current_epoch(state: BeaconState) -> Epoch:
 //    """
-//    Return the current epoch of the given ``state``.
+//    Return the current epoch.
 //    """
-//    return slot_to_epoch(state.slot)
+//    return compute_epoch_of_slot(state.slot)
 func CurrentEpoch(state *pb.BeaconState) uint64 {
 	return SlotToEpoch(state.Slot)
 }
@@ -37,11 +37,10 @@ func CurrentEpoch(state *pb.BeaconState) uint64 {
 // Spec pseudocode definition:
 //  def get_previous_epoch(state: BeaconState) -> Epoch:
 //    """`
-//    Return the previous epoch of the given ``state``.
-//    Return the current epoch if it's genesis epoch.
+//    Return the previous epoch (unless the current epoch is ``GENESIS_EPOCH``).
 //    """
 //    current_epoch = get_current_epoch(state)
-//    return GENESIS_EPOCH if current_epoch == GENESIS_EPOCH else current_epoch - 1
+//    return GENESIS_EPOCH if current_epoch == GENESIS_EPOCH else Epoch(current_epoch - 1)
 func PrevEpoch(state *pb.BeaconState) uint64 {
 	currentEpoch := CurrentEpoch(state)
 	if currentEpoch == 0 {
@@ -60,11 +59,11 @@ func NextEpoch(state *pb.BeaconState) uint64 {
 // current epoch.
 //
 // Spec pseudocode definition:
-//  def get_epoch_start_slot(epoch: Epoch) -> Slot:
+//  def compute_start_slot_of_epoch(epoch: Epoch) -> Slot:
 //    """
-//    Return the starting slot of the given ``epoch``.
+//    Return the start slot of ``epoch``.
 //    """
-//    return epoch * SLOTS_PER_EPOCH
+//    return Slot(epoch * SLOTS_PER_EPOCH
 func StartSlot(epoch uint64) uint64 {
 	return epoch * params.BeaconConfig().SlotsPerEpoch
 }

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -54,11 +54,11 @@ func IsSlashableValidator(validator *pb.Validator, epoch uint64) bool {
 // need the active validator indices for some specific reason.
 //
 // Spec pseudocode definition:
-//  def get_active_validator_indices(state: BeaconState, epoch: Epoch) -> List[ValidatorIndex]:
+//  def get_active_validator_indices(state: BeaconState, epoch: Epoch) -> Sequence[ValidatorIndex]:
 //    """
-//    Get active validator indices at ``epoch``.
+//    Return the sequence of active validator indices at ``epoch``.
 //    """
-//    return [i for i, v in enumerate(state.validator_registry) if is_active_validator(v, epoch)]
+//    return [ValidatorIndex(i) for i, v in enumerate(state.validators) if is_active_validator(v, epoch)]
 func ActiveValidatorIndices(state *pb.BeaconState, epoch uint64) ([]uint64, error) {
 	indices, err := activeIndicesCache.ActiveIndicesInEpoch(epoch)
 	if err != nil {
@@ -116,25 +116,26 @@ func ActiveValidatorCount(state *pb.BeaconState, epoch uint64) (uint64, error) {
 // the validator is eligible for activation and exit.
 //
 // Spec pseudocode definition:
-//  def get_delayed_activation_exit_epoch(epoch: Epoch) -> Epoch:
+//  def compute_activation_exit_epoch(epoch: Epoch) -> Epoch:
 //    """
-//    Return the epoch at which an activation or exit triggered in ``epoch`` takes effect.
+//    Return the epoch during which validator activations and exits initiated in ``epoch`` take effect.
 //    """
-//    return epoch + 1 + ACTIVATION_EXIT_DELAY
+//    return Epoch(epoch + 1 + ACTIVATION_EXIT_DELAY)
 func DelayedActivationExitEpoch(epoch uint64) uint64 {
 	return epoch + 1 + params.BeaconConfig().ActivationExitDelay
 }
 
-// ChurnLimit returns the number of validators that are allowed to
+// ValidatorChurnLimit returns the number of validators that are allowed to
 // enter and exit validator pool for an epoch.
 //
 // Spec pseudocode definition:
-//   def get_churn_limit(state: BeaconState) -> int:
-//    return max(
-//        MIN_PER_EPOCH_CHURN_LIMIT,
-//        len(get_active_validator_indices(state, get_current_epoch(state))) // CHURN_LIMIT_QUOTIENT
-//    )
-func ChurnLimit(state *pb.BeaconState) (uint64, error) {
+//   def get_validator_churn_limit(state: BeaconState) -> uint64:
+//    """
+//    Return the validator churn limit for the current epoch.
+//    """
+//    active_validator_indices = get_active_validator_indices(state, get_current_epoch(state))
+//    return max(MIN_PER_EPOCH_CHURN_LIMIT, len(active_validator_indices) // CHURN_LIMIT_QUOTIENT)
+func ValidatorChurnLimit(state *pb.BeaconState) (uint64, error) {
 	validatorCount, err := ActiveValidatorCount(state, CurrentEpoch(state))
 	if err != nil {
 		return 0, fmt.Errorf("could not get validator count: %v", err)
@@ -151,27 +152,27 @@ func ChurnLimit(state *pb.BeaconState) (uint64, error) {
 // Spec pseudocode definition:
 //  def get_beacon_proposer_index(state: BeaconState) -> ValidatorIndex:
 //    """
-//    Return the current beacon proposer index.
+//    Return the beacon proposer index at the current slot.
 //    """
 //    epoch = get_current_epoch(state)
-//    committees_per_slot = get_epoch_committee_count(state, epoch) // SLOTS_PER_EPOCH
+//    committees_per_slot = get_committee_count(state, epoch) // SLOTS_PER_EPOCH
 //    offset = committees_per_slot * (state.slot % SLOTS_PER_EPOCH)
-//    shard = (get_epoch_start_shard(state, epoch) + offset) % SHARD_COUNT
+//    shard = Shard((get_start_shard(state, epoch) + offset) % SHARD_COUNT)
 //    first_committee = get_crosslink_committee(state, epoch, shard)
 //    MAX_RANDOM_BYTE = 2**8 - 1
-//    seed = generate_seed(state, epoch)
+//    seed = get_seed(state, epoch)
 //    i = 0
 //    while True:
 //        candidate_index = first_committee[(epoch + i) % len(first_committee)]
 //        random_byte = hash(seed + int_to_bytes(i // 32, length=8))[i % 32]
-//        effective_balance = state.validator_registry[candidate_index].effective_balance
+//        effective_balance = state.validators[candidate_index].effective_balance
 //        if effective_balance * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE * random_byte:
-//            return candidate_index
+//            return ValidatorIndex(candidate_index)
 //        i += 1
 func BeaconProposerIndex(state *pb.BeaconState) (uint64, error) {
 	// Calculate the offset for slot and shard
 	e := CurrentEpoch(state)
-	committeeCount, err := EpochCommitteeCount(state, e)
+	committeeCount, err := CommitteeCount(state, e)
 	if err != nil {
 		return 0, err
 	}
@@ -180,7 +181,7 @@ func BeaconProposerIndex(state *pb.BeaconState) (uint64, error) {
 
 	// Calculate which shards get assigned given the epoch start shard
 	// and the offset
-	startShard, err := EpochStartShard(state, e)
+	startShard, err := StartShard(state, e)
 	if err != nil {
 		return 0, fmt.Errorf("could not get start shard: %v", err)
 	}
@@ -188,7 +189,7 @@ func BeaconProposerIndex(state *pb.BeaconState) (uint64, error) {
 
 	// Use the first committee of the given slot and shard
 	// to select proposer
-	firstCommittee, err := CrosslinkCommitteeAtEpoch(state, e, shard)
+	firstCommittee, err := CrosslinkCommittee(state, e, shard)
 	if err != nil {
 		return 0, fmt.Errorf("could not get first committee: %v", err)
 	}
@@ -198,7 +199,7 @@ func BeaconProposerIndex(state *pb.BeaconState) (uint64, error) {
 
 	// Use the generated seed to select proposer from the first committee
 	maxRandomByte := uint64(1<<8 - 1)
-	seed, err := GenerateSeed(state, e)
+	seed, err := Seed(state, e)
 	if err != nil {
 		return 0, fmt.Errorf("could not generate seed: %v", err)
 	}

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -140,12 +140,12 @@ func TestChurnLimit_OK(t *testing.T) {
 			RandaoMixes:      make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 			ActiveIndexRoots: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 		}
-		resultChurn, err := ChurnLimit(beaconState)
+		resultChurn, err := ValidatorChurnLimit(beaconState)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if resultChurn != test.wantedChurn {
-			t.Errorf("ChurnLimit(%d) = %d, want = %d",
+			t.Errorf("ValidatorChurnLimit(%d) = %d, want = %d",
 				test.validatorCount, resultChurn, test.wantedChurn)
 		}
 	}

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -652,7 +652,7 @@ func BenchmarkProcessEpoch65536Validators(b *testing.B) {
 
 	// Precache the shuffled indices
 	for i := uint64(0); i < shardCount; i++ {
-		if _, err := helpers.CrosslinkCommitteeAtEpoch(s, 0, i); err != nil {
+		if _, err := helpers.CrosslinkCommittee(s, 0, i); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -855,7 +855,7 @@ func BenchmarkProcessBlk_65536Validators_FullBlock(b *testing.B) {
 
 	// Precache the shuffled indices
 	for i := uint64(0); i < shardCount; i++ {
-		if _, err := helpers.CrosslinkCommitteeAtEpoch(s, 0, i); err != nil {
+		if _, err := helpers.CrosslinkCommittee(s, 0, i); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -66,24 +66,24 @@ func ActivateValidator(state *pb.BeaconState, idx uint64, genesis bool) (*pb.Bea
 //
 // Spec pseudocode definition:
 //  def initiate_validator_exit(state: BeaconState, index: ValidatorIndex) -> None:
-//   """
-//   Initiate the exit of the validator of the given ``index``.
-//   """
-//   # Return if validator already initiated exit
-//   validator = state.validator_registry[index]
-//   if validator.exit_epoch != FAR_FUTURE_EPOCH:
-//     return
+//    """
+//    Initiate the exit of the validator with index ``index``.
+//    """
+//    # Return if validator already initiated exit
+//    validator = state.validators[index]
+//    if validator.exit_epoch != FAR_FUTURE_EPOCH:
+//        return
 //
-//   # Compute exit queue epoch
-//   exit_epochs = [v.exit_epoch for v in state.validator_registry if v.exit_epoch != FAR_FUTURE_EPOCH]
-//   exit_queue_epoch = max(exit_epochs + [get_delayed_activation_exit_epoch(get_current_epoch(state))])
-//   exit_queue_churn = len([v for v in state.validator_registry if v.exit_epoch == exit_queue_epoch])
-//   if exit_queue_churn >= get_churn_limit(state):
-//     exit_queue_epoch += 1
+//    # Compute exit queue epoch
+//    exit_epochs = [v.exit_epoch for v in state.validators if v.exit_epoch != FAR_FUTURE_EPOCH]
+//    exit_queue_epoch = max(exit_epochs + [compute_activation_exit_epoch(get_current_epoch(state))])
+//    exit_queue_churn = len([v for v in state.validators if v.exit_epoch == exit_queue_epoch])
+//    if exit_queue_churn >= get_validator_churn_limit(state):
+//        exit_queue_epoch += Epoch(1)
 //
-//   # Set validator exit epoch and withdrawable epoch
-//   validator.exit_epoch = exit_queue_epoch
-//   validator.withdrawable_epoch = validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY
+//    # Set validator exit epoch and withdrawable epoch
+//    validator.exit_epoch = exit_queue_epoch
+//    validator.withdrawable_epoch = Epoch(validator.exit_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
 func InitiateValidatorExit(state *pb.BeaconState, idx uint64) (*pb.BeaconState, error) {
 	validator := state.Validators[idx]
 	if validator.ExitEpoch != params.BeaconConfig().FarFutureEpoch {
@@ -112,7 +112,7 @@ func InitiateValidatorExit(state *pb.BeaconState, idx uint64) (*pb.BeaconState, 
 			exitQueueChurn++
 		}
 	}
-	churn, err := helpers.ChurnLimit(state)
+	churn, err := helpers.ValidatorChurnLimit(state)
 	if err != nil {
 		return nil, fmt.Errorf("could not get churn limit: %v", err)
 	}
@@ -155,26 +155,28 @@ func ExitValidator(state *pb.BeaconState, idx uint64) *pb.BeaconState {
 // the whistleblower's balance.
 //
 // Spec pseudocode definition:
-//  def slash_validator(state: BeaconState, index: ValidatorIndex) -> None:
+//  def slash_validator(state: BeaconState,
+//                    slashed_index: ValidatorIndex,
+//                    whistleblower_index: ValidatorIndex=None) -> None:
 //    """
-//    Slash the validator of the given ``index``.
-//    Note that this function mutates ``state``.
+//    Slash the validator with index ``slashed_index``.
 //    """
-//    current_epoch = get_current_epoch(state)
+//    epoch = get_current_epoch(state)
 //    initiate_validator_exit(state, slashed_index)
-//    state.validator_registry[slashed_index].slashed = True
-//    state.validator_registry[slashed_index].withdrawable_epoch = current_epoch + LATEST_SLASHED_EXIT_LENGTH
-//    slashed_balance = state.validator_registry[slashed_index].effective_balance
-//    state.latest_slashed_balances[current_epoch % LATEST_SLASHED_EXIT_LENGTH] += slashed_balance
+//    validator = state.validators[slashed_index]
+//    validator.slashed = True
+//    validator.withdrawable_epoch = max(validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR))
+//    state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
+//    decrease_balance(state, slashed_index, validator.effective_balance // MIN_SLASHING_PENALTY_QUOTIENT)
 //
+//    # Apply proposer and whistleblower rewards
 //    proposer_index = get_beacon_proposer_index(state)
 //    if whistleblower_index is None:
-//      whistleblower_index = proposer_index
-//	  whistleblowing_reward = slashed_balance // WHISTLEBLOWING_REWARD_QUOTIENT
-//	  proposer_reward = whistleblowing_reward // PROPOSER_REWARD_QUOTIENT
-//	  increase_balance(state, proposer_index, proposer_reward)
-//	  increase_balance(state, whistleblower_index, whistleblowing_reward - proposer_reward)
-//	  decrease_balance(state, slashed_index, whistleblowing_reward)
+//        whistleblower_index = proposer_index
+//    whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
+//    proposer_reward = Gwei(whistleblower_reward // PROPOSER_REWARD_QUOTIENT)
+//    increase_balance(state, proposer_index, proposer_reward)
+//    increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
 func SlashValidator(state *pb.BeaconState, slashedIdx uint64, whistleBlowerIdx uint64) (*pb.BeaconState, error) {
 	state, err := InitiateValidatorExit(state, slashedIdx)
 	if err != nil {

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -985,7 +985,7 @@ func BenchmarkAssignment(b *testing.B) {
 
 	// Precache the shuffled indices
 	for i := uint64(0); i < validatorCount/params.BeaconConfig().TargetCommitteeSize; i++ {
-		if _, err := helpers.CrosslinkCommitteeAtEpoch(state, 0, i); err != nil {
+		if _, err := helpers.CrosslinkCommittee(state, 0, i); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/beacon-chain/utils/shuffle.go
+++ b/beacon-chain/utils/shuffle.go
@@ -45,23 +45,24 @@ func UnShuffledIndex(index uint64, indexCount uint64, seed [32]byte) (uint64, er
 }
 
 // Spec pseudocode definition:
-//   def get_shuffled_index(index: ValidatorIndex, index_count: int, seed: Bytes32) -> ValidatorIndex:
-//     """
-//     Return the shuffled validator index corresponding to ``seed`` (and ``index_count``).
-//     """
-//     assert index < index_count
-//     assert index_count <= 2**40
-//     # Swap or not (https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf)
-//     # See the 'generalized domain' algorithm on page 3
-//     for round in range(SHUFFLE_ROUND_COUNT):
-//         pivot = bytes_to_int(hash(seed + int_to_bytes(round, length=1))[0:8]) % index_count
-//         flip = (pivot + index_count - index) % index_count
-//         position = max(index, flip)
-//         source = hash(seed + int_to_bytes(round, length=1) + int_to_bytes(position // 256, length=4))
-//         byte = source[(position % 256) // 8]
-//         bit = (byte >> (position % 8)) % 2
-//         index = flip if bit else index
-//     return index
+//   def compute_shuffled_index(index: ValidatorIndex, index_count: uint64, seed: Hash) -> ValidatorIndex:
+//    """
+//    Return the shuffled validator index corresponding to ``seed`` (and ``index_count``).
+//    """
+//    assert index < index_count
+//
+//    # Swap or not (https://link.springer.com/content/pdf/10.1007%2F978-3-642-32009-5_1.pdf)
+//    # See the 'generalized domain' algorithm on page 3
+//    for current_round in range(SHUFFLE_ROUND_COUNT):
+//        pivot = bytes_to_int(hash(seed + int_to_bytes(current_round, length=1))[0:8]) % index_count
+//        flip = ValidatorIndex((pivot + index_count - index) % index_count)
+//        position = max(index, flip)
+//        source = hash(seed + int_to_bytes(current_round, length=1) + int_to_bytes(position // 256, length=4))
+//        byte = source[(position % 256) // 8]
+//        bit = (byte >> (position % 8)) % 2
+//        index = flip if bit else index
+//
+//    return ValidatorIndex(index)
 func innerShuffledIndex(index uint64, indexCount uint64, seed [32]byte, shuffle bool) (uint64, error) {
 	if params.BeaconConfig().ShuffleRoundCount == 0 {
 		return index, nil

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -128,11 +128,13 @@ func AggregateSignatures(sigs []*Signature) *Signature {
 // Domain returns the bls domain given by the domain type and the operation 4 byte fork version.
 //
 // Spec pseudocode definition:
-//  def bls_domain(domain_type: int, fork_version: bytes=b'\x00\x00\x00\x00') -> int:
+//  def get_domain(state: BeaconState, domain_type: DomainType, message_epoch: Epoch=None) -> Domain:
 //    """
-//    Return the bls domain given by the ``domain_type`` and optional 4 byte ``fork_version`` (defaults to zero).
+//    Return the signature domain (fork version concatenated with domain type) of a message.
 //    """
-//    return bytes_to_int(int_to_bytes(domain_type, length=4) + fork_version)
+//    epoch = get_current_epoch(state) if message_epoch is None else message_epoch
+//    fork_version = state.fork.previous_version if epoch < state.fork.epoch else state.fork.current_version
+//    return compute_domain(domain_type, fork_version)
 func Domain(domainType uint64, forkVersion []byte) uint64 {
 	b := []byte{}
 	b = append(b, bytesutil.Bytes4(domainType)...)


### PR DESCRIPTION
This PR is part of:
* cleanup helpers grouping, consistency in naming, comments, etc (https://github.com/ethereum/eth2.0-specs/pull/1237, https://github.com/ethereum/eth2.0-specs/pull/1241)

Change list:
- Updated pseudocode definition for the helper methods
- `CrosslinkCommitteeAtEpoch` -> `CrosslinkCommittee`
- `EpochCommitteeCount` -> `CommitteeCount`
- `EpochStartShard` -> `StartShard`