### PR TITLE
Make Constants Explicit and Minor Cleanups

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -610,7 +610,7 @@ func ConvertToIndexed(state *pb.BeaconState, attestation *pb.Attestation) (*pb.I
 //    if len(custody_bit_1_indices) > 0:  # [TO BE REMOVED IN PHASE 1]
 //        return False
 //
-//    if not (1 <= len(custody_bit_0_indices) + len(custody_bit_1_indices) <= MAX_INDICES_PER_ATTESTATION):
+//    if not (1 <= len(custody_bit_0_indices) + len(custody_bit_1_indices) <= MAX_VALIDATORS_PER_COMMITTEE):
 //        return False
 //
 //    return bls_verify_multiple(
@@ -634,7 +634,7 @@ func VerifyIndexedAttestation(indexedAtt *pb.IndexedAttestation, verifySignature
 		return fmt.Errorf("expected no bit 1 indices, received %v", len(custodyBit1Indices))
 	}
 
-	maxIndices := params.BeaconConfig().MaxIndicesPerAttestation
+	maxIndices := params.BeaconConfig().MaxValidatorsPerCommittee
 	totalIndicesLength := uint64(len(custodyBit0Indices) + len(custodyBit1Indices))
 	if maxIndices < totalIndicesLength || totalIndicesLength < 1 {
 		return fmt.Errorf("over max number of allowed indices per attestation: %d", totalIndicesLength)

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -732,7 +732,7 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 						Shard: 4,
 					},
 				},
-				CustodyBit_0Indices: make([]uint64, params.BeaconConfig().MaxIndicesPerAttestation+1),
+				CustodyBit_0Indices: make([]uint64, params.BeaconConfig().MaxValidatorsPerCommittee+1),
 			},
 			Attestation_2: &pb.IndexedAttestation{
 				Data: &pb.AttestationData{
@@ -742,7 +742,7 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 						Shard: 4,
 					},
 				},
-				CustodyBit_0Indices: make([]uint64, params.BeaconConfig().MaxIndicesPerAttestation+1),
+				CustodyBit_0Indices: make([]uint64, params.BeaconConfig().MaxValidatorsPerCommittee+1),
 			},
 		},
 	}
@@ -1254,11 +1254,11 @@ func TestConvertToIndexed_OK(t *testing.T) {
 
 func TestValidateIndexedAttestation_AboveMaxLength(t *testing.T) {
 	indexedAtt1 := &pb.IndexedAttestation{
-		CustodyBit_0Indices: make([]uint64, params.BeaconConfig().MaxIndicesPerAttestation+5),
+		CustodyBit_0Indices: make([]uint64, params.BeaconConfig().MaxValidatorsPerCommittee+5),
 		CustodyBit_1Indices: []uint64{},
 	}
 
-	for i := uint64(0); i < params.BeaconConfig().MaxIndicesPerAttestation+5; i++ {
+	for i := uint64(0); i < params.BeaconConfig().MaxValidatorsPerCommittee+5; i++ {
 		indexedAtt1.CustodyBit_0Indices[i] = i
 	}
 

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -1146,7 +1146,7 @@ func TestProcessRegistryUpdates_ActivationCompletes(t *testing.T) {
 func TestProcessRegistryUpdates_CanExits(t *testing.T) {
 	epoch := uint64(5)
 	exitEpoch := helpers.DelayedActivationExitEpoch(epoch)
-	minWithdrawalDelay := params.BeaconConfig().MinValidatorWithdrawalDelay
+	minWithdrawalDelay := params.BeaconConfig().MinValidatorWithdrawabilityDelay
 	state := &pb.BeaconState{
 		Slot: epoch * params.BeaconConfig().SlotsPerEpoch,
 		Validators: []*pb.Validator{

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -4,6 +4,7 @@ package helpers
 import (
 	"errors"
 	"fmt"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/utils"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"

--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/epoch:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
-        "//beacon-chain/core/validators:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/blockutil:go_default_library",
         "//shared/bytesutil:go_default_library",

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -141,10 +141,8 @@ func GenesisBeaconState(deposits []*pb.Deposit, genesisTime uint64, eth1Data *pb
 	for i := 0; i < len(state.Validators); i++ {
 		if state.Validators[i].EffectiveBalance >=
 			params.BeaconConfig().MaxEffectiveBalance {
-			state, err = v.ActivateValidator(state, uint64(i), true)
-			if err != nil {
-				return nil, fmt.Errorf("could not activate validator: %v", err)
-			}
+			state.Validators[i].ActivationEligibilityEpoch = 0
+			state.Validators[i].ActivationEpoch = 0
 		}
 	}
 	activeValidators, err := helpers.ActiveValidatorIndices(state, 0)

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -10,7 +10,6 @@ import (
 
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -121,7 +121,7 @@ func InitiateValidatorExit(state *pb.BeaconState, idx uint64) (*pb.BeaconState, 
 		exitQueueEpoch++
 	}
 	state.Validators[idx].ExitEpoch = exitQueueEpoch
-	state.Validators[idx].WithdrawableEpoch = exitQueueEpoch + params.BeaconConfig().MinValidatorWithdrawalDelay
+	state.Validators[idx].WithdrawableEpoch = exitQueueEpoch + params.BeaconConfig().MinValidatorWithdrawabilityDelay
 	return state, nil
 }
 
@@ -170,11 +170,11 @@ func ExitValidator(state *pb.BeaconState, idx uint64) *pb.BeaconState {
 //    proposer_index = get_beacon_proposer_index(state)
 //    if whistleblower_index is None:
 //      whistleblower_index = proposer_index
-//	  whistleblowing_reward = slashed_balance // WHISTLEBLOWING_REWARD_QUOTIENT
-//	  proposer_reward = whistleblowing_reward // PROPOSER_REWARD_QUOTIENT
+//	  whistleblower_reward = slashed_balance // WHISTLEBLOWER_REWARD_QUOTIENT
+//	  proposer_reward = whistleblower_reward // PROPOSER_REWARD_QUOTIENT
 //	  increase_balance(state, proposer_index, proposer_reward)
-//	  increase_balance(state, whistleblower_index, whistleblowing_reward - proposer_reward)
-//	  decrease_balance(state, slashed_index, whistleblowing_reward)
+//	  increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
+//	  decrease_balance(state, slashed_index, whistleblower_reward)
 func SlashValidator(state *pb.BeaconState, slashedIdx uint64, whistleBlowerIdx uint64) (*pb.BeaconState, error) {
 	state, err := InitiateValidatorExit(state, slashedIdx)
 	if err != nil {
@@ -194,7 +194,7 @@ func SlashValidator(state *pb.BeaconState, slashedIdx uint64, whistleBlowerIdx u
 	if whistleBlowerIdx == 0 {
 		whistleBlowerIdx = proposerIdx
 	}
-	whistleblowerReward := slashedBalance / params.BeaconConfig().WhistleBlowingRewardQuotient
+	whistleblowerReward := slashedBalance / params.BeaconConfig().WhistleblowerRewardQuotient
 	proposerReward := whistleblowerReward / params.BeaconConfig().ProposerRewardQuotient
 	state = helpers.IncreaseBalance(state, proposerIdx, proposerReward)
 	state = helpers.IncreaseBalance(state, whistleBlowerIdx, whistleblowerReward-proposerReward)

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -30,37 +30,6 @@ var VStore = validatorStore{
 	exitedValidators:    make(map[uint64][]uint64),
 }
 
-// ActivateValidator takes in validator index and updates
-// validator's activation slot.
-//
-// Spec pseudocode definition:
-//  def activate_validator(state: BeaconState, index: ValidatorIndex, is_genesis: bool) -> None:
-//    """
-//    Activate the validator of the given ``index``.
-//    Note that this function mutates ``state``.
-//    """
-//    validator = state.validator_registry[index]
-//
-//    validator.activation_epoch = GENESIS_EPOCH if is_genesis else get_entry_exit_effect_epoch(get_current_epoch(state))
-func ActivateValidator(state *pb.BeaconState, idx uint64, genesis bool) (*pb.BeaconState, error) {
-	validator := state.Validators[idx]
-	if genesis {
-		validator.ActivationEligibilityEpoch = 0
-		validator.ActivationEpoch = 0
-	} else {
-		validator.ActivationEpoch = helpers.DelayedActivationExitEpoch(helpers.CurrentEpoch(state))
-	}
-
-	state.Validators[idx] = validator
-
-	log.WithFields(logrus.Fields{
-		"index":           idx,
-		"activationEpoch": validator.ActivationEpoch,
-	}).Info("Validator activated")
-
-	return state, nil
-}
-
 // InitiateValidatorExit takes in validator index and updates
 // validator with correct voluntary exit parameters.
 //

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -228,7 +228,7 @@ func TestSlashValidator_OK(t *testing.T) {
 		t.Errorf("Could not get proposer %v", err)
 	}
 
-	whistleblowerReward := slashedBalance / params.BeaconConfig().WhistleBlowingRewardQuotient
+	whistleblowerReward := slashedBalance / params.BeaconConfig().WhistleblowerRewardQuotient
 	proposerReward := whistleblowerReward / params.BeaconConfig().ProposerRewardQuotient
 
 	if state.Balances[proposer] != params.BeaconConfig().MaxEffectiveBalance+proposerReward {

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -46,46 +46,6 @@ func TestHasVoted_OK(t *testing.T) {
 	}
 }
 
-func TestActivateValidatorGenesis_OK(t *testing.T) {
-	state := &pb.BeaconState{
-		Validators: []*pb.Validator{
-			{Pubkey: []byte{'A'}},
-		},
-	}
-	newState, err := ActivateValidator(state, 0, true)
-	if err != nil {
-		t.Fatalf("could not execute activateValidator:%v", err)
-	}
-	if newState.Validators[0].ActivationEpoch != 0 {
-		t.Errorf("Wanted activation epoch = genesis epoch, got %d",
-			newState.Validators[0].ActivationEpoch)
-	}
-	if newState.Validators[0].ActivationEligibilityEpoch != 0 {
-		t.Errorf("Wanted activation eligibility epoch = genesis epoch, got %d",
-			newState.Validators[0].ActivationEligibilityEpoch)
-	}
-}
-
-func TestActivateValidator_OK(t *testing.T) {
-	state := &pb.BeaconState{
-		Slot: 100, // epoch 2
-		Validators: []*pb.Validator{
-			{Pubkey: []byte{'A'}},
-		},
-	}
-	newState, err := ActivateValidator(state, 0, false)
-	if err != nil {
-		t.Fatalf("could not execute activateValidator:%v", err)
-	}
-	currentEpoch := helpers.CurrentEpoch(state)
-	wantedEpoch := helpers.DelayedActivationExitEpoch(currentEpoch)
-	if newState.Validators[0].ActivationEpoch != wantedEpoch {
-		t.Errorf("Wanted activation slot = %d, got %d",
-			wantedEpoch,
-			newState.Validators[0].ActivationEpoch)
-	}
-}
-
 func TestInitiateValidatorExit_AlreadyExited(t *testing.T) {
 	exitEpoch := uint64(199)
 	state := &pb.BeaconState{Validators: []*pb.Validator{{

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -424,7 +424,7 @@ func TestValidatorStatus_InitiatedExit(t *testing.T) {
 	slot := uint64(10000)
 	epoch := helpers.SlotToEpoch(slot)
 	exitEpoch := helpers.DelayedActivationExitEpoch(epoch)
-	withdrawableEpoch := exitEpoch + params.BeaconConfig().MinValidatorWithdrawalDelay
+	withdrawableEpoch := exitEpoch + params.BeaconConfig().MinValidatorWithdrawabilityDelay
 	if err := db.SaveState(ctx, &pbp2p.BeaconState{
 		Slot: slot,
 		Validators: []*pbp2p.Validator{{

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -9,21 +9,21 @@ import (
 
 // BeaconChainConfig contains constant configs for node to participate in beacon chain.
 type BeaconChainConfig struct {
+	// Constants (non-configurable)
+	FarFutureEpoch           uint64 `yaml:"FAR_FUTURE_EPOCH"`            // FarFutureEpoch represents a epoch extremely far away in the future used as the default penalization slot for validators.
+	BaseRewardsPerEpoch      uint64 `yaml:"BASE_REWARDS_PER_EPOCH"`      // BaseRewardsPerEpoch is used to calculate the per epoch rewards.
+	DepositContractTreeDepth uint64 `yaml:"DEPOSIT_CONTRACT_TREE_DEPTH"` // Depth of the Merkle trie of deposits in the validator deposit contract on the PoW chain.
+	JustificationBitsLength  uint64 `yaml:"JUSTIFICATION_BITS_LENGTH"`   // JustificationBitsLength defines the length in bytes of the justification bits.
+
 	// Misc constants.
 	ShardCount                     uint64 `yaml:"SHARD_COUNT"`                        // ShardCount is the number of shard chains in Ethereum 2.0.
 	TargetCommitteeSize            uint64 `yaml:"TARGET_COMMITTEE_SIZE"`              // TargetCommitteeSize is the number of validators in a committee when the chain is healthy.
-	MaxIndicesPerAttestation       uint64 `yaml:"MAX_INDICES_PER_ATTESTATION"`        // MaxIndicesPerAttestation is used to determine how many validators participate in an attestation.
+	MaxValidatorsPerCommittee      uint64 `yaml:"MAX_VALIDATORS_PER_COMMITTEE"`       // MaxValidatorsPerCommittee defines the upper bound of the size of a committee.
 	MinPerEpochChurnLimit          uint64 `yaml:"MIN_PER_EPOCH_CHURN_LIMIT"`          // MinPerEpochChurnLimit is the minimum amount of churn allotted for validator rotations.
 	ChurnLimitQuotient             uint64 `yaml:"CHURN_LIMIT_QUOTIENT"`               // ChurnLimitQuotient is used to determine the limit of how many validators can rotate per epoch.
-	BaseRewardsPerEpoch            uint64 `yaml:"BASE_REWARDS_PER_EPOCH"`             // BaseRewardsPerEpoch is used to calculate the per epoch rewards.
 	ShuffleRoundCount              uint64 `yaml:"SHUFFLE_ROUND_COUNT"`                // ShuffleRoundCount is used for retrieving the permuted index.
-	MaxValidatorsPerCommittee      uint64 `yaml:"MAX_VALIDATORS_PER_COMMITTEE"`       // MaxValidatorsPerCommittee defines the upper bound of the size of a committee.
 	MinGenesisActiveValidatorCount uint64 `yaml:"MIN_GENESIS_ACTIVE_VALIDATOR_COUNT"` // MinGenesisActiveValidatorCount defines how many validator deposits needed to kick off beacon chain.
 	MinGenesisTime                 uint64 `yaml:"MIN_GENESIS_TIME"`                   // MinGenesisTime is the time that needed to pass before kicking off beacon chain. Currently set to Jan/3/2020.
-	JustificationBitsLength        uint64 `yaml:"JUSTIFICATION_BITS_LENGTH"`          // JustificationBitsLength defines the length in bytes of the justification bits.
-
-	// Deposit contract constants.
-	DepositContractTreeDepth uint64 `yaml:"DEPOSIT_CONTRACT_TREE_DEPTH"` // Depth of the Merkle trie of deposits in the validator deposit contract on the PoW chain.
 
 	// Gwei value constants.
 	MinDepositAmount          uint64 `yaml:"MIN_DEPOSIT_AMOUNT"`          // MinDepositAmount is the maximal amount of Gwei a validator can send to the deposit contract at once.
@@ -32,23 +32,24 @@ type BeaconChainConfig struct {
 	EffectiveBalanceIncrement uint64 `yaml:"EFFECTIVE_BALANCE_INCREMENT"` // EffectiveBalanceIncrement is used for converting the high balance into the low balance for validators.
 
 	// Initial value constants.
-	FarFutureEpoch          uint64   `yaml:"FAR_FUTURE_EPOCH"`           // FarFutureEpoch represents a epoch extremely far away in the future used as the default penalization slot for validators.
+	GenesisSlot             byte     `yaml:"GENESIS_SLOT"`               // GenesisSlot is the initial slot that ETH2 will use starting from genesis.
+	GenesisEpoch            byte     `yaml:"GENESIS_EPOCH"`              // GenesisEpoch is the initial epoch that ETH2 will use starting from genesis.
 	BLSWithdrawalPrefixByte byte     `yaml:"BLS_WITHDRAWAL_PREFIX_BYTE"` // BLSWithdrawalPrefixByte is used for BLS withdrawal and it's the first byte.
 	ZeroHash                [32]byte // ZeroHash is used to represent a zeroed out 32 byte array.
 
 	// Time parameters constants.
-	SecondsPerSlot               uint64 `yaml:"SECONDS_PER_SLOT"`                    // SecondsPerSlot is how many seconds are in a single slot.
-	MinAttestationInclusionDelay uint64 `yaml:"MIN_ATTESTATION_INCLUSION_DELAY"`     // MinAttestationInclusionDelay defines how long validator has to wait to include attestation for beacon block.
-	SlotsPerEpoch                uint64 `yaml:"SLOTS_PER_EPOCH"`                     // SlotsPerEpoch is the number of slots in an epoch.
-	MinSeedLookahead             uint64 `yaml:"MIN_SEED_LOOKAHEAD"`                  // SeedLookahead is the duration of randao look ahead seed.
-	ActivationExitDelay          uint64 `yaml:"ACTIVATION_EXIT_DELAY"`               // ActivationExitDelay is the duration a validator has to wait for entry and exit in epoch.
-	SlotsPerEth1VotingPeriod     uint64 `yaml:"SLOTS_PER_ETH1_VOTING_PERIOD"`        // SlotsPerEth1VotingPeriod defines how often the merkle root of deposit receipts get updated in beacon node.
-	SlotsPerHistoricalRoot       uint64 `yaml:"SLOTS_PER_HISTORICAL_ROOT"`           // SlotsPerHistoricalRoot defines how often the historical root is saved.
-	MinValidatorWithdrawalDelay  uint64 `yaml:"MIN_VALIDATOR_WITHDRAWABILITY_DELAY"` // MinValidatorWithdrawalEpochs is the shortest amount of time a validator has to wait to withdraw.
-	PersistentCommitteePeriod    uint64 `yaml:"PERSISTENT_COMMITTEE_PERIOD"`         // PersistentCommitteePeriod is the minimum amount of epochs a validator must participate before exitting.
-	MaxEpochsPerCrosslink        uint64 `yaml:"MAX_EPOCHS_PER_CROSSLINK"`            // MaxEpochsPerCrosslink defines the max epoch from current a crosslink can be formed at.
-	MinEpochsToInactivityPenalty uint64 `yaml:"MIN_EPOCHS_TO_INACTIVITY_PENALTY"`    // MinEpochsToInactivityPenalty defines the minimum amount of epochs since finality to begin penalizing inactivity.
-	Eth1FollowDistance           uint64 // Eth1FollowDistance is the number of eth1.0 blocks to wait before considering a new deposit for voting. This only applies after the chain as been started.
+	MinAttestationInclusionDelay     uint64 `yaml:"MIN_ATTESTATION_INCLUSION_DELAY"`     // MinAttestationInclusionDelay defines how long validator has to wait to include attestation for beacon block.
+	SecondsPerSlot                   uint64 `yaml:"SECONDS_PER_SLOT"`                    // SecondsPerSlot is how many seconds are in a single slot.
+	SlotsPerEpoch                    uint64 `yaml:"SLOTS_PER_EPOCH"`                     // SlotsPerEpoch is the number of slots in an epoch.
+	MinSeedLookahead                 uint64 `yaml:"MIN_SEED_LOOKAHEAD"`                  // SeedLookahead is the duration of randao look ahead seed.
+	ActivationExitDelay              uint64 `yaml:"ACTIVATION_EXIT_DELAY"`               // ActivationExitDelay is the duration a validator has to wait for entry and exit in epoch.
+	SlotsPerEth1VotingPeriod         uint64 `yaml:"SLOTS_PER_ETH1_VOTING_PERIOD"`        // SlotsPerEth1VotingPeriod defines how often the merkle root of deposit receipts get updated in beacon node.
+	SlotsPerHistoricalRoot           uint64 `yaml:"SLOTS_PER_HISTORICAL_ROOT"`           // SlotsPerHistoricalRoot defines how often the historical root is saved.
+	MinValidatorWithdrawabilityDelay uint64 `yaml:"MIN_VALIDATOR_WITHDRAWABILITY_DELAY"` // MinValidatorWithdrawabilityDelay is the shortest amount of time a validator has to wait to withdraw.
+	PersistentCommitteePeriod        uint64 `yaml:"PERSISTENT_COMMITTEE_PERIOD"`         // PersistentCommitteePeriod is the minimum amount of epochs a validator must participate before exitting.
+	MaxEpochsPerCrosslink            uint64 `yaml:"MAX_EPOCHS_PER_CROSSLINK"`            // MaxEpochsPerCrosslink defines the max epoch from current a crosslink can be formed at.
+	MinEpochsToInactivityPenalty     uint64 `yaml:"MIN_EPOCHS_TO_INACTIVITY_PENALTY"`    // MinEpochsToInactivityPenalty defines the minimum amount of epochs since finality to begin penalizing inactivity.
+	Eth1FollowDistance               uint64 // Eth1FollowDistance is the number of eth1.0 blocks to wait before considering a new deposit for voting. This only applies after the chain as been started.
 
 	// State list lengths
 	EpochsPerHistoricalVector uint64 `yaml:"EPOCHS_PER_HISTORICAL_VECTOR"` // EpochsPerHistoricalVector defines max length in epoch to store old historical stats in beacon state.
@@ -57,11 +58,11 @@ type BeaconChainConfig struct {
 	ValidatorsLimit           uint64 `yaml:"VALIDATOR_REGISTRY_LIMIT"`     // ValidatorsLimit defines the upper bound of validators can participate in eth2.
 
 	// Reward and penalty quotients constants.
-	BaseRewardFactor             uint64 `yaml:"BASE_REWARD_FACTOR"`             // BaseRewardFactor is used to calculate validator per-slot interest rate.
-	WhistleBlowingRewardQuotient uint64 `yaml:"WHISTLEBLOWING_REWARD_QUOTIENT"` // WhistleBlowingRewardQuotient is used to calculate whistler blower reward.
-	ProposerRewardQuotient       uint64 `yaml:"PROPOSER_REWARD_QUOTIENT"`       // ProposerRewardQuotient is used to calculate the reward for proposers.
-	InactivityPenaltyQuotient    uint64 `yaml:"INACTIVITY_PENALTY_QUOTIENT"`    // InactivityPenaltyQuotient is used to calculate the penalty for a validator that is offline.
-	MinSlashingPenaltyQuotient   uint64 `yaml:"MIN_SLASHING_PENALTY_QUOTIENT"`  // MinSlashingPenaltyQuotient is used to calculate the minimum penalty to prevent DoS attacks.
+	BaseRewardFactor            uint64 `yaml:"BASE_REWARD_FACTOR"`            // BaseRewardFactor is used to calculate validator per-slot interest rate.
+	WhistleblowerRewardQuotient uint64 `yaml:"WHISTLEBLOWer_REWARD_QUOTIENT"` // WhistleBlowerRewardQuotient is used to calculate whistler blower reward.
+	ProposerRewardQuotient      uint64 `yaml:"PROPOSER_REWARD_QUOTIENT"`      // ProposerRewardQuotient is used to calculate the reward for proposers.
+	InactivityPenaltyQuotient   uint64 `yaml:"INACTIVITY_PENALTY_QUOTIENT"`   // InactivityPenaltyQuotient is used to calculate the penalty for a validator that is offline.
+	MinSlashingPenaltyQuotient  uint64 `yaml:"MIN_SLASHING_PENALTY_QUOTIENT"` // MinSlashingPenaltyQuotient is used to calculate the minimum penalty to prevent DoS attacks.
 
 	// Max operations per block constants.
 	MaxProposerSlashings uint64 `yaml:"MAX_PROPOSER_SLASHINGS"` // MaxProposerSlashings defines the maximum number of slashings of proposers possible in a block.
@@ -109,21 +110,21 @@ type ShardChainConfig struct {
 }
 
 var defaultBeaconConfig = &BeaconChainConfig{
+	// Constants (Non-configurable)
+	FarFutureEpoch:           1<<64 - 1,
+	BaseRewardsPerEpoch:      5,
+	DepositContractTreeDepth: 32,
+	JustificationBitsLength:  4,
+
 	// Misc constant.
 	ShardCount:                     1024,
 	TargetCommitteeSize:            128,
-	MaxIndicesPerAttestation:       4096,
+	MaxValidatorsPerCommittee:      4096,
 	MinPerEpochChurnLimit:          4,
 	ChurnLimitQuotient:             1 << 16,
-	BaseRewardsPerEpoch:            5,
 	ShuffleRoundCount:              90,
-	MaxValidatorsPerCommittee:      4096,
 	MinGenesisActiveValidatorCount: 65536,
 	MinGenesisTime:                 1578009600,
-	JustificationBitsLength:        4,
-
-	// Deposit contract constants.
-	DepositContractTreeDepth: 32,
 
 	// Gwei value constants.
 	MinDepositAmount:          1 * 1e9,
@@ -132,23 +133,24 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	EffectiveBalanceIncrement: 1 * 1e9,
 
 	// Initial value constants.
-	FarFutureEpoch:          1<<64 - 1,
-	ZeroHash:                [32]byte{},
+	GenesisSlot:             0,
+	GenesisEpoch:            0,
 	BLSWithdrawalPrefixByte: byte(0),
+	ZeroHash:                [32]byte{},
 
 	// Time parameter constants.
-	SecondsPerSlot:               6,
-	MinAttestationInclusionDelay: 1,
-	SlotsPerEpoch:                64,
-	MinSeedLookahead:             1,
-	ActivationExitDelay:          4,
-	SlotsPerEth1VotingPeriod:     1024,
-	SlotsPerHistoricalRoot:       8192,
-	MinValidatorWithdrawalDelay:  256,
-	PersistentCommitteePeriod:    2048,
-	MaxEpochsPerCrosslink:        64,
-	MinEpochsToInactivityPenalty: 4,
-	Eth1FollowDistance:           1024,
+	MinAttestationInclusionDelay:     1,
+	SecondsPerSlot:                   6,
+	SlotsPerEpoch:                    64,
+	MinSeedLookahead:                 1,
+	ActivationExitDelay:              4,
+	SlotsPerEth1VotingPeriod:         1024,
+	SlotsPerHistoricalRoot:           8192,
+	MinValidatorWithdrawabilityDelay: 256,
+	PersistentCommitteePeriod:        2048,
+	MaxEpochsPerCrosslink:            64,
+	MinEpochsToInactivityPenalty:     4,
+	Eth1FollowDistance:               1024,
 
 	// State list length constants.
 	EpochsPerHistoricalVector: 65536,
@@ -157,11 +159,11 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	ValidatorsLimit:           1099511627776,
 
 	// Reward and penalty quotients constants.
-	BaseRewardFactor:             64,
-	ProposerRewardQuotient:       8,
-	WhistleBlowingRewardQuotient: 512,
-	InactivityPenaltyQuotient:    1 << 25,
-	MinSlashingPenaltyQuotient:   32,
+	BaseRewardFactor:            64,
+	WhistleblowerRewardQuotient: 512,
+	ProposerRewardQuotient:      8,
+	InactivityPenaltyQuotient:   1 << 25,
+	MinSlashingPenaltyQuotient:  32,
 
 	// Max operations per block constants.
 	MaxProposerSlashings: 16,
@@ -250,7 +252,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig := *defaultBeaconConfig
 	minimalConfig.ShardCount = 8
 	minimalConfig.TargetCommitteeSize = 4
-	minimalConfig.MaxIndicesPerAttestation = 4096
+	minimalConfig.MaxValidatorsPerCommittee = 4096
 	minimalConfig.MinPerEpochChurnLimit = 4
 	minimalConfig.ChurnLimitQuotient = 65536
 	minimalConfig.BaseRewardsPerEpoch = 5
@@ -271,7 +273,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.SlotsPerEth1VotingPeriod = 16
 	minimalConfig.HistoricalRootsLimit = 64
 	minimalConfig.SlotsPerHistoricalRoot = 64
-	minimalConfig.MinValidatorWithdrawalDelay = 256
+	minimalConfig.MinValidatorWithdrawabilityDelay = 256
 	minimalConfig.PersistentCommitteePeriod = 2048
 	minimalConfig.MaxEpochsPerCrosslink = 4
 	minimalConfig.MinEpochsToInactivityPenalty = 4
@@ -280,7 +282,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.HistoricalRootsLimit = 16777216
 	minimalConfig.ValidatorsLimit = 1099511627776
 	minimalConfig.BaseRewardFactor = 64
-	minimalConfig.WhistleBlowingRewardQuotient = 512
+	minimalConfig.WhistleblowerRewardQuotient = 512
 	minimalConfig.ProposerRewardQuotient = 8
 	minimalConfig.InactivityPenaltyQuotient = 33554432
 	minimalConfig.MinSlashingPenaltyQuotient = 32

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -32,8 +32,6 @@ type BeaconChainConfig struct {
 	EffectiveBalanceIncrement uint64 `yaml:"EFFECTIVE_BALANCE_INCREMENT"` // EffectiveBalanceIncrement is used for converting the high balance into the low balance for validators.
 
 	// Initial value constants.
-	GenesisSlot             byte     `yaml:"GENESIS_SLOT"`               // GenesisSlot is the initial slot that ETH2 will use starting from genesis.
-	GenesisEpoch            byte     `yaml:"GENESIS_EPOCH"`              // GenesisEpoch is the initial epoch that ETH2 will use starting from genesis.
 	BLSWithdrawalPrefixByte byte     `yaml:"BLS_WITHDRAWAL_PREFIX_BYTE"` // BLSWithdrawalPrefixByte is used for BLS withdrawal and it's the first byte.
 	ZeroHash                [32]byte // ZeroHash is used to represent a zeroed out 32 byte array.
 
@@ -133,8 +131,6 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	EffectiveBalanceIncrement: 1 * 1e9,
 
 	// Initial value constants.
-	GenesisSlot:             0,
-	GenesisEpoch:            0,
 	BLSWithdrawalPrefixByte: byte(0),
 	ZeroHash:                [32]byte{},
 

--- a/shared/sliceutil/slice.go
+++ b/shared/sliceutil/slice.go
@@ -10,7 +10,7 @@ func SubsetUint64(a []uint64, b []uint64) bool {
 
 	set := make(map[uint64]uint64)
 	for _, v := range b {
-		set[v] ++
+		set[v]++
 	}
 
 	for _, v := range a {


### PR DESCRIPTION
Part of #2891, this PR updates the beacon chain config to explicitly mention which fields are constants and which are configurable.

Added `Constants (non-configurable)` section to beacon chain config. Did not include `SECONDS_PER_DAY` and `ENDIANNESS` with changes.

Removed `ActivateValidator` function, replaced with appropriate hard coding in `GenesisBeaconState`, it serves almost no purpose now and would just spam logs upon genesis. 

Removed `MAX_INDICES_PER_ATTESTATION` replaced with `MAX_VALIDATORS_PER_COMMITTEE`.

Renamed `MinValidatorWithdrawalDelay` to `MinValidatorWithdrawabilityDelay` to be aligned with spec.
Renamed `WhistleBlowingRewardQuotient` to `WhistleblowerRewardQuotient` to be aligned with spec.

