### PR TITLE
Move Block Operation Length Checks to ProcessOperations

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -243,11 +243,9 @@ func ProcessProposerSlashings(
 	body *pb.BeaconBlockBody,
 	verifySignatures bool,
 ) (*pb.BeaconState, error) {
-	registry := beaconState.Validators
-
 	var err error
 	for idx, slashing := range body.ProposerSlashings {
-		proposer := registry[slashing.ProposerIndex]
+		proposer := beaconState.Validators[slashing.ProposerIndex]
 		if err = verifyProposerSlashing(beaconState, proposer, slashing, verifySignatures); err != nil {
 			return nil, fmt.Errorf("could not verify proposer slashing %d: %v", idx, err)
 		}
@@ -314,7 +312,6 @@ func ProcessAttesterSlashings(
 	body *pb.BeaconBlockBody,
 	verifySignatures bool,
 ) (*pb.BeaconState, error) {
-
 	for idx, slashing := range body.AttesterSlashings {
 		if err := verifyAttesterSlashing(slashing, verifySignatures); err != nil {
 			return nil, fmt.Errorf("could not verify attester slashing #%d: %v", idx, err)
@@ -391,10 +388,8 @@ func ProcessAttestations(
 	body *pb.BeaconBlockBody,
 	verifySignatures bool,
 ) (*pb.BeaconState, error) {
-	atts := body.Attestations
-
 	var err error
-	for idx, attestation := range atts {
+	for idx, attestation := range body.Attestations {
 		beaconState, err = ProcessAttestation(beaconState, attestation, verifySignatures)
 		if err != nil {
 			return nil, fmt.Errorf("could not verify attestation at index %d in block: %v", idx, err)

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -273,28 +273,15 @@ func ProcessOperations(
 
 	if uint64(len(body.Attestations)) > params.BeaconConfig().MaxAttestations {
 		return nil, fmt.Errorf(
-			"number of attester slashings (%d) in block body exceeds allowed threshold of %d",
+			"number of attestations (%d) in block body exceeds allowed threshold of %d",
 			len(body.Attestations),
 			params.BeaconConfig().MaxAttestations,
 		)
 	}
 
-	maxDeposits := params.BeaconConfig().MaxDeposits
-	if state.Eth1Data.DepositCount-state.Eth1DepositIndex < maxDeposits {
-		maxDeposits = state.Eth1Data.DepositCount - state.Eth1DepositIndex
-	}
-	// Verify outstanding deposits are processed up to max number of deposits
-	if len(body.Deposits) != int(maxDeposits) {
-		return nil, fmt.Errorf(
-			"number of deposits (%d) in block body exceeds allowed threshold of %d",
-			len(body.Deposits),
-			maxDeposits,
-		)
-	}
-
 	if uint64(len(body.VoluntaryExits)) > params.BeaconConfig().MaxVoluntaryExits {
 		return nil, fmt.Errorf(
-			"number of exits (%d) in block body exceeds allowed threshold of %d",
+			"number of voluntary exits (%d) in block body exceeds allowed threshold of %d",
 			len(body.VoluntaryExits),
 			params.BeaconConfig().MaxVoluntaryExits,
 		)
@@ -306,6 +293,16 @@ func ProcessOperations(
 			len(body.Transfers),
 			params.BeaconConfig().MaxTransfers,
 		)
+	}
+
+	maxDeposits := params.BeaconConfig().MaxDeposits
+	if state.Eth1Data.DepositCount-state.Eth1DepositIndex < maxDeposits {
+		maxDeposits = state.Eth1Data.DepositCount - state.Eth1DepositIndex
+	}
+	// Verify outstanding deposits are processed up to max number of deposits
+	if len(body.Deposits) != int(maxDeposits) {
+		return nil, fmt.Errorf("incorrect outstanding deposits in block body, wanted: %d, got: %d",
+			maxDeposits, len(body.Deposits))
 	}
 
 	// Verify that there are no duplicate transfers

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -86,7 +86,7 @@ func TestProcessBlock_IncorrectProposerSlashing(t *testing.T) {
 			Deposits: blkDeposits,
 		},
 	}
-	want := "could not verify block proposer slashing"
+	want := "could not process block proposer slashing"
 	if _, err := state.ProcessBlock(context.Background(), beaconState, block, state.DefaultConfig()); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -149,7 +149,7 @@ func TestProcessBlock_IncorrectAttesterSlashing(t *testing.T) {
 			Deposits: make([]*pb.Deposit, 16),
 		},
 	}
-	want := "could not verify block attester slashing"
+	want := "could not process block attester slashing"
 	if _, err := state.ProcessBlock(context.Background(), beaconState, block, state.DefaultConfig()); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -578,13 +578,14 @@ func BenchmarkProcessBlk_65536Validators_FullBlock(b *testing.B) {
 	}
 
 	s := &pb.BeaconState{
-		Slot:             20,
-		BlockRoots:       make([][]byte, 254),
-		RandaoMixes:      randaoMixes,
-		Validators:       validators,
-		Balances:         validatorBalances,
-		Slashings:        make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector),
-		ActiveIndexRoots: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
+		Slot:              20,
+		LatestBlockHeader: &pb.BeaconBlockHeader{},
+		BlockRoots:        make([][]byte, 254),
+		RandaoMixes:       randaoMixes,
+		Validators:        validators,
+		Balances:          validatorBalances,
+		Slashings:         make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector),
+		ActiveIndexRoots:  make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 		CurrentJustifiedCheckpoint: &pb.Checkpoint{
 			Root: []byte("hello-world"),
 		},
@@ -715,7 +716,7 @@ func BenchmarkProcessBlk_65536Validators_FullBlock(b *testing.B) {
 	}
 
 	blk := &pb.BeaconBlock{
-		Slot: s.Slot + 1,
+		Slot: s.Slot,
 		Body: &pb.BeaconBlockBody{
 			Eth1Data: &pb.Eth1Data{
 				DepositRoot: root[:],

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -246,131 +246,6 @@ func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 	}
 }
 
-func TestProcessBlock_IncorrectProcessExits(t *testing.T) {
-	helpers.ClearAllCaches()
-
-	deposits, _ := testutil.SetupInitialDeposits(t, params.BeaconConfig().DepositsForChainStart/8, false)
-	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	beaconState.Slashings = make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
-	proposerSlashings := []*pb.ProposerSlashing{
-		{
-			ProposerIndex: 3,
-			Header_1: &pb.BeaconBlockHeader{
-				Slot:      1,
-				Signature: []byte("A"),
-			},
-			Header_2: &pb.BeaconBlockHeader{
-				Slot:      1,
-				Signature: []byte("B"),
-			},
-		},
-	}
-	attesterSlashings := []*pb.AttesterSlashing{
-		{
-			Attestation_1: &pb.IndexedAttestation{
-				Data: &pb.AttestationData{
-					SourceEpoch: 0,
-					TargetEpoch: 0,
-					Crosslink: &pb.Crosslink{
-						Shard: 4,
-					}},
-				CustodyBit_0Indices: []uint64{0, 1},
-			},
-			Attestation_2: &pb.IndexedAttestation{
-				Data: &pb.AttestationData{
-					SourceEpoch: 1,
-					TargetEpoch: 0,
-					Crosslink: &pb.Crosslink{
-						Shard: 4,
-					}},
-				CustodyBit_0Indices: []uint64{0, 1},
-			},
-		},
-	}
-	var blockRoots [][]byte
-	for i := uint64(0); i < params.BeaconConfig().HistoricalRootsLimit; i++ {
-		blockRoots = append(blockRoots, []byte{byte(i)})
-	}
-	beaconState.BlockRoots = blockRoots
-	beaconState.CurrentCrosslinks = []*pb.Crosslink{
-		{
-			DataRoot: []byte{1},
-		},
-	}
-	blockAtt := &pb.Attestation{
-		Data: &pb.AttestationData{
-			TargetEpoch: 0,
-			SourceEpoch: 0,
-			SourceRoot:  []byte("hello-world"),
-			Crosslink: &pb.Crosslink{
-				Shard:      0,
-				StartEpoch: 0,
-			},
-		},
-		AggregationBits: []byte{0xC0, 0xC0, 0xC0, 0xC0},
-		CustodyBits:     []byte{},
-	}
-	attestations := []*pb.Attestation{blockAtt}
-	var exits []*pb.VoluntaryExit
-	for i := uint64(0); i < params.BeaconConfig().MaxVoluntaryExits+1; i++ {
-		exits = append(exits, &pb.VoluntaryExit{})
-	}
-	genesisBlock := blocks.NewGenesisBlock([]byte{})
-	bodyRoot, err := ssz.HashTreeRoot(genesisBlock)
-	if err != nil {
-		t.Fatal(err)
-	}
-	beaconState.LatestBlockHeader = &pb.BeaconBlockHeader{
-		Slot:       genesisBlock.Slot,
-		ParentRoot: genesisBlock.ParentRoot,
-		BodyRoot:   bodyRoot[:],
-	}
-	beaconState.Eth1DepositIndex = 0
-
-	parentRoot, err := ssz.SigningRoot(beaconState.LatestBlockHeader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	block := &pb.BeaconBlock{
-		ParentRoot: parentRoot[:],
-		Slot:       1,
-		Body: &pb.BeaconBlockBody{
-			RandaoReveal:      []byte{},
-			ProposerSlashings: proposerSlashings,
-			AttesterSlashings: attesterSlashings,
-			Attestations:      attestations,
-			VoluntaryExits:    exits,
-			Eth1Data: &pb.Eth1Data{
-				DepositRoot: []byte{2},
-				BlockHash:   []byte{3},
-			},
-		},
-	}
-	beaconState.Slot += params.BeaconConfig().MinAttestationInclusionDelay
-	beaconState.CurrentCrosslinks = []*pb.Crosslink{
-		{
-			Shard:      0,
-			StartEpoch: 0,
-		},
-	}
-	beaconState.CurrentJustifiedCheckpoint.Root = []byte("hello-world")
-	beaconState.CurrentEpochAttestations = []*pb.PendingAttestation{}
-
-	encoded, err := ssz.HashTreeRoot(beaconState.CurrentCrosslinks[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	block.Body.Attestations[0].Data.Crosslink.ParentRoot = encoded[:]
-	block.Body.Attestations[0].Data.Crosslink.DataRoot = params.BeaconConfig().ZeroHash[:]
-	want := "could not process validator exits"
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, state.DefaultConfig()); !strings.Contains(err.Error(), want) {
-		t.Errorf("Expected %s, received %v", want, err)
-	}
-}
-
 func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 	deposits, _ := testutil.SetupInitialDeposits(t, params.BeaconConfig().DepositsForChainStart/8, false)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), nil)
@@ -642,6 +517,7 @@ func BenchmarkProcessEpoch65536Validators(b *testing.B) {
 		Validators:                validators,
 		Balances:                  balances,
 		StartShard:                512,
+		FinalizedCheckpoint:       &pb.Checkpoint{},
 		BlockRoots:                make([][]byte, 254),
 		Slashings:                 []uint64{0, 1e9, 0},
 		RandaoMixes:               make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),


### PR DESCRIPTION
Brought up in #2892, this moves all length checks to a `verifyOperationLengths` function to prevent extra unneeded computing if an invalid block is submitted.