### PR TITLE
Fix deposit input data

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -887,22 +887,6 @@ func ProcessDeposit(
 			if err != nil {
 				return nil, fmt.Errorf("could not determine signing root for deposit data: %v", err)
 			}
-
-			fmt.Printf(
-				`domain=%d
-root=%#x
-deposit.Data.Signature=%#x
-deposit.Data.Pubkey=%#x
-deposit.Data.WithdrawalCredentials=%#x
-deposit.Data.Amount=%d
-`,
-				domain,
-				root,
-				deposit.Data.Signature,
-				deposit.Data.Pubkey,
-				deposit.Data.WithdrawalCredentials,
-				deposit.Data.Amount)
-
 			if !sig.Verify(root[:], pub, domain) {
 				return nil, fmt.Errorf("deposit signature did not verify")
 			}

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -885,8 +885,24 @@ func ProcessDeposit(
 			}
 			root, err := ssz.SigningRoot(deposit.Data)
 			if err != nil {
-				return nil, fmt.Errorf("could not sign root for deposit data: %v", err)
+				return nil, fmt.Errorf("could not determine signing root for deposit data: %v", err)
 			}
+
+			fmt.Printf(
+				`domain=%d
+root=%#x
+deposit.Data.Signature=%#x
+deposit.Data.Pubkey=%#x
+deposit.Data.WithdrawalCredentials=%#x
+deposit.Data.Amount=%d
+`,
+				domain,
+				root,
+				deposit.Data.Signature,
+				deposit.Data.Pubkey,
+				deposit.Data.WithdrawalCredentials,
+				deposit.Data.Amount)
+
 			if !sig.Verify(root[:], pub, domain) {
 				return nil, fmt.Errorf("deposit signature did not verify")
 			}

--- a/contracts/deposit-contract/sendDepositTx/sendDeposits.go
+++ b/contracts/deposit-contract/sendDepositTx/sendDeposits.go
@@ -147,6 +147,7 @@ func main() {
 		}
 
 		client := ethclient.NewClient(rpcClient)
+		depositAmountInGwei := uint64(depositAmount)
 		depositAmount = depositAmount * 1e9
 
 		// User inputs private key, sign tx with private key
@@ -203,7 +204,7 @@ func main() {
 		}
 
 		for _, validatorKey := range validatorKeys {
-			data, err := prysmKeyStore.DepositInput(validatorKey, validatorKey)
+			data, err := prysmKeyStore.DepositInput(validatorKey, validatorKey, depositAmountInGwei)
 			if err != nil {
 				log.Errorf("Could not generate deposit input data: %v", err)
 				continue

--- a/shared/keystore/BUILD.bazel
+++ b/shared/keystore/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bls:go_default_library",
-        "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_pborman_uuid//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
@@ -34,13 +33,10 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
-        "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
-        "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_pborman_uuid//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
     ],

--- a/shared/keystore/deposit_input.go
+++ b/shared/keystore/deposit_input.go
@@ -3,7 +3,7 @@ package keystore
 import (
 	"github.com/prysmaticlabs/go-ssz"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
@@ -14,26 +14,27 @@ import (
 // Spec details about general deposit workflow:
 //   To submit a deposit:
 //
-//   - Pack the validator's initialization parameters into deposit_input, a DepositInput SSZ object.
-//   - Set deposit_input.proof_of_possession = EMPTY_SIGNATURE.
-//   - Let proof_of_possession be the result of bls_sign of the hash_tree_root(deposit_input) with domain=DOMAIN_DEPOSIT.
-//   - Set deposit_input.proof_of_possession = proof_of_possession.
-//   - Let amount be the amount in Gwei to be deposited by the validator where MIN_DEPOSIT_AMOUNT <= amount <= MAX_DEPOSIT_AMOUNT.
-//   - Send a transaction on the Ethereum 1.0 chain to DEPOSIT_CONTRACT_ADDRESS executing deposit along with serialize(deposit_input) as the singular bytes input along with a deposit amount in Gwei.
+//   - Pack the validator's initialization parameters into deposit_data, a DepositData SSZ object.
+//   - Let amount be the amount in Gwei to be deposited by the validator where MIN_DEPOSIT_AMOUNT <= amount <= MAX_EFFECTIVE_BALANCE.
+//   - Set deposit_data.amount = amount.
+//   - Let signature be the result of bls_sign of the signing_root(deposit_data) with domain=compute_domain(DOMAIN_DEPOSIT). (Deposits are valid regardless of fork version, compute_domain will default to zeroes there).
+//   - Send a transaction on the Ethereum 1.0 chain to DEPOSIT_CONTRACT_ADDRESS executing def deposit(pubkey: bytes[48], withdrawal_credentials: bytes[32], signature: bytes[96]) along with a deposit of amount Gwei.
 //
-// See: https://github.com/ethereum/eth2.0-specs/blob/dev/specs/validator/0_beacon-chain-validator.md#submit-deposit
-func DepositInput(depositKey *Key, withdrawalKey *Key) (*pb.DepositData, error) {
+// See: https://github.com/ethereum/eth2.0-specs/blob/master/specs/validator/0_beacon-chain-validator.md#submit-deposit
+func DepositInput(depositKey *Key, withdrawalKey *Key, amountInGwei uint64) (*pb.DepositData, error) {
 	di := &pb.DepositData{
 		Pubkey:                depositKey.PublicKey.Marshal(),
 		WithdrawalCredentials: withdrawalCredentialsHash(withdrawalKey),
+		Amount:                amountInGwei,
 	}
 
-	buf, err := ssz.Marshal(di)
+	sr, err := ssz.SigningRoot(di)
 	if err != nil {
 		return nil, err
 	}
-	domain := bytesutil.FromBytes4(params.BeaconConfig().DomainDeposit)
-	di.Signature = depositKey.SecretKey.Sign(buf, domain).Marshal()
+
+	domain := bls.Domain(params.BeaconConfig().DomainDeposit, params.BeaconConfig().GenesisForkVersion)
+	di.Signature = depositKey.SecretKey.Sign(sr[:], domain).Marshal()
 
 	return di, nil
 }

--- a/tools/cluster-pk-manager/server/server.go
+++ b/tools/cluster-pk-manager/server/server.go
@@ -141,7 +141,7 @@ func (s *server) allocateNewKeys(ctx context.Context, podName string, numKeys in
 
 		// Make the validator deposit
 		// NOTE: This uses the validator key as the withdrawal key
-		di, err := keystore.DepositInput(key /*depositKey*/, key /*withdrawalKey*/)
+		di, err := keystore.DepositInput(key /*depositKey*/, key /*withdrawalKey*/, new(big.Int).Div(s.depositAmount, big.NewInt(1e9)).Uint64())
 		if err != nil {
 			return nil, err
 		}

--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -70,7 +70,7 @@ func NewValidatorAccount(directory string, password string) error {
 		validatorKeyFile,
 	).Info("Keystore generated for validator signatures at path")
 
-	data, err := keystore.DepositInput(validatorKey, shardWithdrawalKey)
+	data, err := keystore.DepositInput(validatorKey, shardWithdrawalKey, params.BeaconConfig().MaxEffectiveBalance)
 	if err != nil {
 		return fmt.Errorf("unable to generate deposit data: %v", err)
 	}


### PR DESCRIPTION
Deposits inputs were not aligned with beacon chain logic. All deposits failed to verify. 

This issue shines light on a larger testing gap in Prysm. Tracked by https://github.com/prysmaticlabs/prysm/issues/2955