### PR TITLE
Minor fixes for runtime

### DIFF
--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/prysmaticlabs/go-ssz"
@@ -181,14 +180,13 @@ func GenesisBeaconState(deposits []*pb.Deposit, genesisTime uint64, eth1Data *pb
 
 	depositRoot := trie.Root()
 	for i, deposit := range deposits {
-		eth1DataExists := eth1Data != nil && !bytes.Equal(eth1Data.DepositRoot, []byte{})
 		state.Eth1Data.DepositRoot = depositRoot[:]
 		state, err = b.ProcessDeposit(
 			state,
 			deposit,
 			validatorMap,
-			true,
-			eth1DataExists,
+			true, // Verify signatures
+			true, // Verify deposit tree
 		)
 		if err != nil {
 			return nil, fmt.Errorf("could not process validator deposit %d: %v", i, err)

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/prysmaticlabs/go-ssz"
@@ -180,13 +181,14 @@ func GenesisBeaconState(deposits []*pb.Deposit, genesisTime uint64, eth1Data *pb
 
 	depositRoot := trie.Root()
 	for i, deposit := range deposits {
+		eth1DataExists := eth1Data != nil && !bytes.Equal(eth1Data.DepositRoot, []byte{})
 		state.Eth1Data.DepositRoot = depositRoot[:]
 		state, err = b.ProcessDeposit(
 			state,
 			deposit,
 			validatorMap,
-			true, // Verify signatures
-			true, // Verify deposit tree
+			false,
+			eth1DataExists,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("could not process validator deposit %d: %v", i, err)

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -187,7 +187,7 @@ func GenesisBeaconState(deposits []*pb.Deposit, genesisTime uint64, eth1Data *pb
 			state,
 			deposit,
 			validatorMap,
-			false,
+			true,
 			eth1DataExists,
 		)
 		if err != nil {

--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/trieutil:go_default_library",

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -3,6 +3,7 @@ package powchain
 import (
 	"encoding/binary"
 	"fmt"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"math/big"
 	"time"
 
@@ -185,9 +186,13 @@ func (w *Web3Service) ProcessChainStart(genesisTime uint64) {
 }
 
 func (w *Web3Service) setGenesisTime(timeStamp uint64) {
-	timeStampRdDown := timeStamp - timeStamp%params.BeaconConfig().SecondsPerDay
-	// genesisTime will be set to the first second of the day, two days after it was triggered.
-	w.eth2GenesisTime = timeStampRdDown + 2*params.BeaconConfig().SecondsPerDay
+	if featureconfig.FeatureConfig().NoGenesisDelay {
+		w.eth2GenesisTime = uint64(time.Unix(int64(timeStamp), 0).Add(30 * time.Second).Unix())
+	} else {
+		timeStampRdDown := timeStamp - timeStamp%params.BeaconConfig().SecondsPerDay
+		// genesisTime will be set to the first second of the day, two days after it was triggered.
+		w.eth2GenesisTime = timeStampRdDown + 2*params.BeaconConfig().SecondsPerDay
+	}
 }
 
 // processPastLogs processes all the past logs from the deposit contract and

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -3,7 +3,6 @@ package powchain
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"math/big"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	contracts "github.com/prysmaticlabs/prysm/contracts/deposit-contract"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -34,6 +34,7 @@ type FeatureFlagConfig struct {
 	EnableCommitteesCache         bool // EnableCommitteesCache for state transition.
 	CacheTreeHash                 bool // CacheTreeHash determent whether tree hashes will be cached.
 	EnableExcessDeposits          bool // EnableExcessDeposits in validator balances.
+	NoGenesisDelay                bool // NoGenesisDelay when processing a chain start genesis event.
 }
 
 var featureConfig *FeatureFlagConfig
@@ -82,6 +83,10 @@ func ConfigureBeaconFeatures(ctx *cli.Context) {
 	if ctx.GlobalBool(DisableGossipSubFlag.Name) {
 		log.Info("Disabled gossipsub, using floodsub")
 		cfg.DisableGossipSub = true
+	}
+	if ctx.GlobalBool(NoGenesisDelayFlag.Name) {
+		log.Warn("Using non standard genesis delay. This may cause problems in a multi-node environment.")
+		cfg.NoGenesisDelay = true
 	}
 	InitFeatureConfig(cfg)
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -56,6 +56,11 @@ var (
 		Name:  "enables-excess-deposit",
 		Usage: "Enables balances more than max deposit amount for a validator",
 	}
+	// NoGenesisDelay
+	NoGenesisDelayFlag = cli.BoolFlag{
+		Name:  "no-genesis-delay",
+		Usage: "Process genesis event 30s after the ETH1 block time, rather than wait to midnight of the next day.",
+	}
 )
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -73,4 +78,5 @@ var BeaconChainFlags = []cli.Flag{
 	DisableGossipSubFlag,
 	CacheTreeHashFlag,
 	EnableExcessDepositsFlag,
+	NoGenesisDelayFlag,
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -56,7 +56,7 @@ var (
 		Name:  "enables-excess-deposit",
 		Usage: "Enables balances more than max deposit amount for a validator",
 	}
-	// NoGenesisDelay
+	// NoGenesisDelayFlag disables the standard genesis delay.
 	NoGenesisDelayFlag = cli.BoolFlag{
 		Name:  "no-genesis-delay",
 		Usage: "Process genesis event 30s after the ETH1 block time, rather than wait to midnight of the next day.",

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -95,7 +95,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, pk strin
 		// Default is false until phase 1 where proof of custody gets implemented.
 		CustodyBit: false,
 	}
-	root, err := ssz.SigningRoot(attDataAndCustodyBit)
+	root, err := ssz.HashTreeRoot(attDataAndCustodyBit)
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
 			"validator": truncatedPk,

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -157,7 +157,7 @@ func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
 		Data:       expectedAttestation.Data,
 		CustodyBit: false,
 	}
-	root, err := ssz.SigningRoot(attDataAndCustodyBit)
+	root, err := ssz.HashTreeRoot(attDataAndCustodyBit)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Changes:
- ~Verify signature and deposit tree of deposits~ will follow up in a different PR, this breaks a lot of test setup. 
- Add a feature flag to disable standard genesis delay for testing
- Fix validator signing by using tree hash root instead of signing root