### PR TITLE
Minor runtime fixes 

### DIFF
--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -146,9 +146,12 @@ func ProcessSlot(ctx context.Context, state *pb.BeaconState) (*pb.BeaconState, e
 //    ]
 func ProcessSlots(ctx context.Context, state *pb.BeaconState, slot uint64) (*pb.BeaconState, error) {
 	if state.Slot > slot {
-		return nil, fmt.Errorf("expected state.slot %d < block.slot %d", state.Slot, slot)
+		return nil, fmt.Errorf("expected state.slot %d < slot %d", state.Slot, slot)
 	}
 	for state.Slot < slot {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		state, err := ProcessSlot(ctx, state)
 		if err != nil {
 			return nil, fmt.Errorf("could not process slot: %v", err)

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"math/big"
 	"time"
 
@@ -137,6 +138,16 @@ func (vs *ValidatorServer) CommitteeAssignment(ctx context.Context, req *pb.Assi
 		return nil, fmt.Errorf("could not fetch beacon state: %v", err)
 	}
 
+	// Advance state with empty transitions if the head state slot is farther
+	// than 1 epoch away from the request.
+	if helpers.SlotToEpoch(s.Slot) < req.EpochStart-1 {
+		slotsToAdvance := helpers.StartSlot(req.EpochStart-1) - s.Slot
+		s, err = state.ProcessSlots(ctx, s, slotsToAdvance)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	validatorIndexMap := stateutils.ValidatorIndexMap(s)
 	var assignments []*pb.AssignmentResponse_ValidatorAssignment
 
@@ -191,7 +202,7 @@ func (vs *ValidatorServer) assignment(
 	}
 
 	committee, shard, slot, isProposer, err :=
-		helpers.CommitteeAssignment(beaconState, epochStart, uint64(idx))
+		helpers.CommitteeAssignment(beaconState, helpers.SlotToEpoch(epochStart), uint64(idx))
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"math/big"
 	"time"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -140,7 +140,7 @@ func (vs *ValidatorServer) CommitteeAssignment(ctx context.Context, req *pb.Assi
 
 	// Advance state with empty transitions if the head state slot is farther
 	// than 1 epoch away from the request.
-	if helpers.SlotToEpoch(s.Slot) < req.EpochStart-1 {
+	if req.EpochStart > 1 && helpers.SlotToEpoch(s.Slot) < req.EpochStart-1 {
 		slotsToAdvance := helpers.StartSlot(req.EpochStart-1) - s.Slot
 		s, err = state.ProcessSlots(ctx, s, slotsToAdvance)
 		if err != nil {

--- a/contracts/deposit-contract/drainContracts/drainContracts.go
+++ b/contracts/deposit-contract/drainContracts/drainContracts.go
@@ -174,8 +174,15 @@ func allDepositContractAddresses(client *ethclient.Client) ([]common.Address, er
 	log.Print("Looking up contracts")
 	addresses := make(map[common.Address]bool)
 
-	depositEventSignature := []byte("Deposit(bytes32,bytes,bytes,bytes32[32])")
-	depositTopicHash := crypto.Keccak256Hash(depositEventSignature)
+	// Hash of deposit log signature
+	// DepositEvent: event({
+	//    pubkey: bytes[48],
+	//    withdrawal_credentials: bytes[32],
+	//    amount: bytes[8],
+	//    signature: bytes[96],
+	//    index: bytes[8],
+	// })
+	depositTopicHash := common.HexToHash("0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5")
 	fmt.Println(depositTopicHash.Hex())
 
 	query := ethereum.FilterQuery{
@@ -183,7 +190,7 @@ func allDepositContractAddresses(client *ethclient.Client) ([]common.Address, er
 		Topics: [][]common.Hash{
 			{depositTopicHash},
 		},
-		FromBlock: big.NewInt(400000), // Contracts before this may not have drain().
+		FromBlock: big.NewInt(800000), // Contracts before this may not have drain().
 	}
 
 	logs, err := client.FilterLogs(context.Background(), query)

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -183,7 +183,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	// Prysm constants.
 	GweiPerEth:                1000000000,
 	LogBlockDelay:             2,
-	BLSPubkeyLength:           96,
+	BLSPubkeyLength:           48,
 	DefaultBufferSize:         10000,
 	WithdrawalPrivkeyFileName: "/shardwithdrawalkey",
 	ValidatorPrivkeyFileName:  "/validatorprivatekey",
@@ -223,26 +223,20 @@ func MainnetConfig() *BeaconChainConfig {
 }
 
 // DemoBeaconConfig retrieves the demo beacon chain config.
+// Notable changes from minimal config:
+//   - Max effective balance is 3.2 ETH
+//   - Ejection threshold is 3.175 ETH
+//   - Genesis threshold is disabled (minimum date to start the chain)
 func DemoBeaconConfig() *BeaconChainConfig {
-	demoConfig := *defaultBeaconConfig
-	demoConfig.ShardCount = 8
-	demoConfig.MinAttestationInclusionDelay = 1
-	demoConfig.TargetCommitteeSize = 1
-	demoConfig.MinGenesisActiveValidatorCount = 8
-	demoConfig.SlotsPerEpoch = 8
+	demoConfig := MinimalSpecConfig()
 	demoConfig.MinDepositAmount = 100
 	demoConfig.MaxEffectiveBalance = 3.2 * 1e9
+	demoConfig.EffectiveBalanceIncrement = 0.1 * 1e9
 	demoConfig.EjectionBalance = 3.175 * 1e9
 	demoConfig.SyncPollingInterval = 1 * 10 // Query nodes over the network every slot.
-	demoConfig.Eth1FollowDistance = 5
-	demoConfig.SlotsPerEth1VotingPeriod = 1
-	demoConfig.EpochsPerHistoricalVector = 5 * demoConfig.SlotsPerEpoch
-	demoConfig.EpochsPerSlashingsVector = 5 * demoConfig.SlotsPerEpoch
-	demoConfig.HistoricalRootsLimit = 5 * demoConfig.SlotsPerEpoch
-	demoConfig.SlotsPerHistoricalRoot = 5 * demoConfig.SlotsPerEpoch
 	demoConfig.MinGenesisTime = 0
 
-	return &demoConfig
+	return demoConfig
 }
 
 // MinimalSpecConfig retrieves the minimal config used in spec tests.


### PR DESCRIPTION
Changes:
- ProcessSlots handles context deadlines in case of long requests
- CommitteeAssignment advances empty state transitions if the requested epoch is farther away than the head state can determine w/o advancements
- Update drain contract to use the new topic hash
- Change demo config to be an extension of the minimal config, with very minor changes
- BLSPubkeyLength updated to 48