### PR TITLE
best peer assignment fix

### DIFF
--- a/beacon-chain/sync/querier.go
+++ b/beacon-chain/sync/querier.go
@@ -194,6 +194,7 @@ func (q *Querier) run() {
 				q.chainHeadResponses[msg.Peer] = response
 			}
 			if response.CanonicalSlot > q.currentHeadSlot {
+				q.bestPeer = msg.Peer
 				q.currentHeadSlot = response.CanonicalSlot
 				q.currentStateRoot = response.CanonicalStateRootHash32
 				q.currentFinalizedStateRoot = bytesutil.ToBytes32(response.FinalizedStateRootHash32S)


### PR DESCRIPTION
Now, in the log, the output: “INFO syncQuerier: Peer with highest canonical head peerID=” without specifying peerID.
After correction, the log is displayed correctly.