### PR TITLE
Remove logging from state transition functions

### DIFF
--- a/beacon-chain/blockchain/block_processing.go
+++ b/beacon-chain/blockchain/block_processing.go
@@ -217,7 +217,6 @@ func (c *ChainService) AdvanceState(
 		block,
 		&state.TransitionConfig{
 			VerifySignatures: false, // We disable signature verification for now.
-			Logging:          true,  // We enable logging in this state transition call.
 		},
 	)
 	if err != nil {

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
-	"github.com/sirupsen/logrus"
 )
 
 var eth1DataCache = cache.NewEth1DataVoteCache()
@@ -184,7 +183,6 @@ func ProcessRandao(
 	beaconState *pb.BeaconState,
 	body *pb.BeaconBlockBody,
 	verifySignatures bool,
-	enableLogging bool,
 ) (*pb.BeaconState, error) {
 	if verifySignatures {
 		proposerIdx, err := helpers.BeaconProposerIndex(beaconState)
@@ -192,7 +190,7 @@ func ProcessRandao(
 			return nil, fmt.Errorf("could not get beacon proposer index: %v", err)
 		}
 
-		if err := verifyBlockRandao(beaconState, body, proposerIdx, enableLogging); err != nil {
+		if err := verifyBlockRandao(beaconState, body, proposerIdx); err != nil {
 			return nil, fmt.Errorf("could not verify block randao: %v", err)
 		}
 	}
@@ -211,7 +209,7 @@ func ProcessRandao(
 
 // Verify that bls_verify(proposer.pubkey, hash_tree_root(get_current_epoch(state)),
 //   block.body.randao_reveal, domain=get_domain(state.fork, get_current_epoch(state), DOMAIN_RANDAO))
-func verifyBlockRandao(beaconState *pb.BeaconState, body *pb.BeaconBlockBody, proposerIdx uint64, enableLogging bool) error {
+func verifyBlockRandao(beaconState *pb.BeaconState, body *pb.BeaconBlockBody, proposerIdx uint64) error {
 	proposer := beaconState.Validators[proposerIdx]
 	pub, err := bls.PublicKeyFromBytes(proposer.Pubkey)
 	if err != nil {
@@ -225,12 +223,7 @@ func verifyBlockRandao(beaconState *pb.BeaconState, body *pb.BeaconBlockBody, pr
 	if err != nil {
 		return fmt.Errorf("could not deserialize block randao reveal: %v", err)
 	}
-	if enableLogging {
-		log.WithFields(logrus.Fields{
-			"epoch":         helpers.CurrentEpoch(beaconState),
-			"proposerIndex": proposerIdx,
-		}).Info("Verifying randao")
-	}
+
 	if !sig.Verify(buf, pub, domain) {
 		return fmt.Errorf("block randao reveal signature did not verify")
 	}

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -354,8 +354,7 @@ func TestProcessRandao_IncorrectProposerFailsVerification(t *testing.T) {
 	if _, err := blocks.ProcessRandao(
 		beaconState,
 		block.Body,
-		true,  /* verify signatures */
-		false, /* disable logging */
+		true, /* verify signatures */
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %v, received %v", want, err)
 	}
@@ -383,8 +382,7 @@ func TestProcessRandao_SignatureVerifiesAndUpdatesLatestStateMixes(t *testing.T)
 	newState, err := blocks.ProcessRandao(
 		beaconState,
 		block.Body,
-		true,  /* verify signatures */
-		false, /* disable logging */
+		true, /* verify signatures */
 	)
 	if err != nil {
 		t.Errorf("Unexpected error processing block randao: %v", err)

--- a/beacon-chain/core/blocks/validity_conditions.go
+++ b/beacon-chain/core/blocks/validity_conditions.go
@@ -10,10 +10,7 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"github.com/sirupsen/logrus"
 )
-
-var log = logrus.WithField("prefix", "core/blocks")
 
 // IsValidBlock ensures that the block is compliant with the block processing validity conditions.
 func IsValidBlock(
@@ -61,11 +58,6 @@ func IsSlotValid(slot uint64, genesisTime time.Time) bool {
 	validTimeThreshold := genesisTime.Add(secondsPerSlot)
 	now := clock.Now()
 	isValid := now.After(validTimeThreshold)
-	if !isValid {
-		log.WithFields(logrus.Fields{
-			"localTime":           now,
-			"genesisPlusSlotTime": validTimeThreshold,
-		}).Info("Waiting for slot to be valid")
-	}
+
 	return isValid
 }

--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -13,13 +13,11 @@ go_library(
         "//beacon-chain/core/epoch:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
-        "//shared/bytesutil:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/trieutil:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
     ],
 )

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -564,8 +564,6 @@ func TestProcessEpoch_NotPanicOnEmptyActiveValidatorIndices(t *testing.T) {
 		Slashings:        make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector),
 		RandaoMixes:      make([][]byte, params.BeaconConfig().SlotsPerEpoch),
 	}
-	config := state.DefaultConfig()
-	config.Logging = true
 
 	state.ProcessEpoch(context.Background(), newState)
 }
@@ -697,7 +695,6 @@ func BenchmarkProcessBlk_65536Validators_FullBlock(b *testing.B) {
 
 	c := &state.TransitionConfig{
 		VerifySignatures: true,
-		Logging:          false, // We enable logging in this state transition call.
 	}
 
 	// Set up proposer slashing object for block


### PR DESCRIPTION
This PR removes the general logging for core package. As discussed this morning, logging volume should be controlled by the logging framework, not conditionals in method arguments. The info logs should be pushed on to the service level