### PR TITLE
Update pubkey logging of validators

### DIFF
--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -3,6 +3,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -29,9 +30,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, pk strin
 	span.AddAttributes(
 		trace.StringAttribute("validator", fmt.Sprintf("%#x", v.keys[pk].PublicKey.Marshal())),
 	)
-	truncatedPk := bytesutil.Trunc([]byte(pk))
 
-	log.WithField("validator", truncatedPk).Info("Attesting to a beacon block")
 	v.waitToSlotMidpoint(ctx, slot)
 
 	// We fetch the validator index as it is necessary to generate the aggregation
@@ -95,20 +94,17 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, pk strin
 		// Default is false until phase 1 where proof of custody gets implemented.
 		CustodyBit: false,
 	}
+
+	tpk := hex.EncodeToString([]byte(pk))[:12]
+
 	root, err := ssz.HashTreeRoot(attDataAndCustodyBit)
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
-			"validator": truncatedPk,
+			"pubKey": tpk,
 		}).Error("Failed to sign attestation data and custody bit")
 		return
 	}
 	sig := v.keys[pk].SecretKey.Sign(root[:], domain.SignatureDomain).Marshal()
-
-	log.WithFields(logrus.Fields{
-		"shard":     data.Crosslink.Shard,
-		"slot":      slot,
-		"validator": truncatedPk,
-	}).Info("Attesting to beacon chain head")
 
 	attestation := &pbp2p.Attestation{
 		Data:            data,
@@ -128,7 +124,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, pk strin
 		"shard":       data.Crosslink.Shard,
 		"sourceEpoch": data.Source.Epoch,
 		"targetEpoch": data.Target.Epoch,
-		"validator":   truncatedPk,
+		"pubKey":   tpk,
 	}).Info("Attested latest head")
 
 	span.AddAttributes(

--- a/validator/client/validator_propose.go
+++ b/validator/client/validator_propose.go
@@ -4,11 +4,11 @@ package client
 import (
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/prysmaticlabs/go-ssz"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -47,9 +47,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pk string) {
 		return
 	}
 	span.AddAttributes(trace.StringAttribute("validator", fmt.Sprintf("%#x", v.keys[pk].PublicKey.Marshal())))
-	truncatedPk := bytesutil.Trunc([]byte(pk))
-
-	log.WithFields(logrus.Fields{"validator": truncatedPk}).Info("Performing a beacon block proposal...")
+	tpk := hex.EncodeToString([]byte(pk))[:12]
 
 	domain, err = v.validatorClient.DomainData(ctx, &pb.DomainRequest{Epoch: epoch, Domain: params.BeaconConfig().DomainBeaconProposer})
 	if err != nil {
@@ -59,7 +57,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pk string) {
 	root, err := ssz.SigningRoot(b)
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
-			"validator": truncatedPk,
+			"pubKey": tpk,
 		}).Error("Failed to sign block")
 		return
 	}
@@ -70,7 +68,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pk string) {
 	blkResp, err := v.proposerClient.ProposeBlock(ctx, b)
 	if err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
-			"validator": truncatedPk,
+			"pubKey": tpk,
 		}).Error("Failed to propose block")
 		return
 	}
@@ -82,7 +80,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pk string) {
 	)
 
 	log.WithFields(logrus.Fields{
-		"validator":       truncatedPk,
+		"pubKey":       tpk,
 		"slot":            b.Slot,
 		"blockRoot":       fmt.Sprintf("%#x", blkResp.BlockRoot),
 		"numAttestations": len(b.Body.Attestations),


### PR DESCRIPTION
This PR fixes validator logging of public keys

**Before:**
`Attested latest head headRoot=0x415341308ef1ce2bdeed479a shard=2 sourceEpoch=0 targetEpoch=3 validator=[56 55 52 102 51 49 49 101 99 56 52 50]`
**Now:**
`Attested latest head headRoot=0x415341308ef1ce2bdeed479a shard=2 sourceEpoch=0 targetEpoch=3 pubKey=a6b7aec63d91`

There was a few redundant logging like: 1.) waiting to attest, 2.) attesting, 3.) attested. I removed the first two in favor of just attested. Gives us the same amount of information without spamming the logs