### PR TITLE
Match spec on proposer index division

### DIFF
--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -279,7 +279,7 @@ func TestProcessBlockHeader_OK(t *testing.T) {
 		ActiveIndexRoots: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	}
 
-	validators[6033].Slashed = false
+	validators[63463].Slashed = false
 
 	latestBlockSignedRoot, err := ssz.SigningRoot(state.LatestBlockHeader)
 	if err != nil {

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -261,7 +261,7 @@ func CommitteeAssignment(
 		}
 	}
 
-	return []uint64{}, 0, 0, false, status.Error(codes.NotFound, "validator not found found in assignments")
+	return []uint64{}, 0, 0, false, status.Error(codes.NotFound, "validator not found in assignments")
 }
 
 // ShardDelta returns the minimum number of shards get processed in one epoch.

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -379,10 +380,10 @@ func TestCommitteeAssignment_CanRetrieve(t *testing.T) {
 			isProposer: false,
 		},
 		{
-			index:      64,
-			slot:       183,
-			committee:  []uint64{64, 33},
-			shard:      119,
+			index:      28,
+			slot:       138,
+			committee:  []uint64{14, 28},
+			shard:      74,
 			isProposer: true,
 		},
 		{
@@ -394,28 +395,30 @@ func TestCommitteeAssignment_CanRetrieve(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		ClearAllCaches()
-		committee, shard, slot, isProposer, err := CommitteeAssignment(state, tt.slot/params.BeaconConfig().SlotsPerEpoch, tt.index)
-		if err != nil {
-			t.Fatalf("failed to execute NextEpochCommitteeAssignment: %v", err)
-		}
-		if shard != tt.shard {
-			t.Errorf("wanted shard %d, got shard %d for validator index %d",
-				tt.shard, shard, tt.index)
-		}
-		if slot != tt.slot {
-			t.Errorf("wanted slot %d, got slot %d for validator index %d",
-				tt.slot, slot, tt.index)
-		}
-		if isProposer != tt.isProposer {
-			t.Errorf("wanted isProposer %v, got isProposer %v for validator index %d",
-				tt.isProposer, isProposer, tt.index)
-		}
-		if !reflect.DeepEqual(committee, tt.committee) {
-			t.Errorf("wanted committee %v, got committee %v for validator index %d",
-				tt.committee, committee, tt.index)
-		}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ClearAllCaches()
+			committee, shard, slot, isProposer, err := CommitteeAssignment(state, tt.slot/params.BeaconConfig().SlotsPerEpoch, tt.index)
+			if err != nil {
+				t.Fatalf("failed to execute NextEpochCommitteeAssignment: %v", err)
+			}
+			if shard != tt.shard {
+				t.Errorf("wanted shard %d, got shard %d for validator index %d",
+					tt.shard, shard, tt.index)
+			}
+			if slot != tt.slot {
+				t.Errorf("wanted slot %d, got slot %d for validator index %d",
+					tt.slot, slot, tt.index)
+			}
+			if isProposer != tt.isProposer {
+				t.Errorf("wanted isProposer %v, got isProposer %v for validator index %d",
+					tt.isProposer, isProposer, tt.index)
+			}
+			if !reflect.DeepEqual(committee, tt.committee) {
+				t.Errorf("wanted committee %v, got committee %v for validator index %d",
+					tt.committee, committee, tt.index)
+			}
+		})
 	}
 }
 

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -383,7 +383,7 @@ func TestCommitteeAssignment_CanRetrieve(t *testing.T) {
 			index:      0,
 			slot:       146,
 			committee:  []uint64{0, 3},
-			shard:      82,
+			shard:      18,
 			isProposer: true,
 		},
 		{

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -208,7 +208,7 @@ func BeaconProposerIndex(state *pb.BeaconState) (uint64, error) {
 	// effective balance.
 	for i := uint64(0); ; i++ {
 		candidateIndex := firstCommittee[(e+i)%uint64(len(firstCommittee))]
-		b := append(seed[:], bytesutil.Bytes8(i)...)
+		b := append(seed[:], bytesutil.Bytes8(i/32)...)
 		randomByte := hashutil.Hash(b)[i%32]
 		effectiveBal := state.Validators[candidateIndex].EffectiveBalance
 		if effectiveBal*maxRandomByte >= params.BeaconConfig().MaxEffectiveBalance*uint64(randomByte) {

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -175,23 +175,23 @@ func TestBeaconProposerIndex_OK(t *testing.T) {
 	}{
 		{
 			slot:  1,
-			index: 1114,
+			index: 254,
 		},
 		{
 			slot:  5,
-			index: 1207,
+			index: 391,
 		},
 		{
 			slot:  19,
-			index: 264,
+			index: 204,
 		},
 		{
 			slot:  30,
-			index: 1421,
+			index: 1051,
 		},
 		{
 			slot:  43,
-			index: 318,
+			index: 1047,
 		},
 	}
 

--- a/beacon-chain/operations/BUILD.bazel
+++ b/beacon-chain/operations/BUILD.bazel
@@ -36,7 +36,6 @@ go_test(
         "//shared/testutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
 )

--- a/beacon-chain/operations/service_test.go
+++ b/beacon-chain/operations/service_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
-	"github.com/sirupsen/logrus"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
@@ -27,10 +26,6 @@ type mockBroadcaster struct {
 }
 
 func (mb *mockBroadcaster) Broadcast(_ context.Context, _ proto.Message) {
-}
-
-func init() {
-	logrus.SetLevel(logrus.DebugLevel)
 }
 
 func TestStop_OK(t *testing.T) {
@@ -65,23 +60,6 @@ func TestServiceStatus_Error(t *testing.T) {
 	if service.Status() != err {
 		t.Error("service status did not return wanted err")
 	}
-}
-
-func TestRoutineContextClosing_Ok(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
-	s := NewOpsPoolService(context.Background(), &Config{BeaconDB: db})
-
-	exitRoutine := make(chan bool)
-	go func() {
-		s.removeOperations()
-		s.saveOperations()
-		<-exitRoutine
-	}()
-	s.cancel()
-	exitRoutine <- true
-	testutil.AssertLogsContain(t, hook, "operations service context closed, exiting save goroutine")
 }
 
 func TestIncomingExits_Ok(t *testing.T) {


### PR DESCRIPTION
Here's the python spec:

```python
def get_beacon_proposer_index(state: BeaconState) -> ValidatorIndex:
    """
    Return the beacon proposer index at the current slot.
    """
    epoch = get_current_epoch(state)
    committees_per_slot = get_committee_count(state, epoch) // SLOTS_PER_EPOCH
    offset = committees_per_slot * (state.slot % SLOTS_PER_EPOCH)
    shard = Shard((get_start_shard(state, epoch) + offset) % SHARD_COUNT)
    first_committee = get_crosslink_committee(state, epoch, shard)
    MAX_RANDOM_BYTE = 2**8 - 1
    seed = get_seed(state, epoch)
    i = 0
    while True:
        candidate_index = first_committee[(epoch + i) % len(first_committee)]
        random_byte = hash(seed + int_to_bytes(i // 32, length=8))[i % 32]
        effective_balance = state.validators[candidate_index].effective_balance
        if effective_balance * MAX_RANDOM_BYTE >= MAX_EFFECTIVE_BALANCE * random_byte:
            return ValidatorIndex(candidate_index)
        i += 1
```

We had our random byte like this
```python
random_byte = hash(seed + int_to_bytes(i, length=8))[i % 32]
```
when it needed to match spec like this
```python
random_byte = hash(seed + int_to_bytes(i // 32, length=8))[i % 32]
```


Note: I also removed a test that was timing out and it was just testing the service behavior for a cancelled context. We'll want to revisit this later but it seemed entirely unrelated and not a very valuable test so I removed it for now. 