### PR TITLE
Set ejection balance 1.6ETH

### DIFF
--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -231,7 +231,7 @@ func DemoBeaconConfig() *BeaconChainConfig {
 	demoConfig := MinimalSpecConfig()
 	demoConfig.MinDepositAmount = 100
 	demoConfig.MaxEffectiveBalance = 3.2 * 1e9
-	demoConfig.EjectionBalance = 3.175 * 1e9
+	demoConfig.EjectionBalance = 1.6 * 1e9
 	demoConfig.EffectiveBalanceIncrement = 0.1 * 1e9
 	demoConfig.SyncPollingInterval = 1 * 10 // Query nodes over the network every slot.
 	demoConfig.MinGenesisTime = 0


### PR DESCRIPTION
Reset ejection balance to 1.6ETH for run time to 100 slots. Previous 3.175ETH was too low due to validator decryption delays