### PR TITLE
Fixed inaccurate account balances in validator

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -28,7 +28,7 @@ type validator struct {
 	attesterClient       pb.AttesterServiceClient
 	keys                 map[string]*keystore.Key
 	pubkeys              [][]byte
-	prevBalance          uint64
+	prevBalances         []uint64
 	logValidatorBalances bool
 }
 

--- a/validator/client/validator_metrics.go
+++ b/validator/client/validator_metrics.go
@@ -24,13 +24,14 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 		return nil
 	}
 
-	epoch := slot / params.BeaconConfig().SlotsPerEpoch
-	if epoch == params.BeaconConfig().GenesisEpoch {
-		v.prevBalance = params.BeaconConfig().MaxDepositAmount
+	if (len(v.prevBalances) == 0) {
+		for i := 0; i < len(v.pubkeys); i++ {
+			v.prevBalances = append(v.prevBalances, params.BeaconConfig().MaxDepositAmount);
+		}
 	}
 	var totalPrevBalance uint64
 	reported := false
-	for _, pkey := range v.pubkeys {
+	for i, pkey := range v.pubkeys {
 		req := &pb.ValidatorPerformanceRequest{
 			Slot:      slot,
 			PublicKey: pkey,
@@ -61,8 +62,8 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 		}
 		newBalance := float64(resp.Balance) / float64(params.BeaconConfig().GweiPerEth)
 
-		if v.prevBalance > 0 {
-			prevBalance := float64(v.prevBalance) / float64(params.BeaconConfig().GweiPerEth)
+		if v.prevBalances[i] > 0 {
+			prevBalance := float64(v.prevBalances[i]) / float64(params.BeaconConfig().GweiPerEth)
 			percentNet := (newBalance - prevBalance) / prevBalance
 			log.WithFields(logrus.Fields{
 				"prevBalance":   prevBalance,
@@ -71,10 +72,14 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 				"percentChange": fmt.Sprintf("%.5f%%", percentNet*100),
 				"pubKey":        tpk,
 			}).Info("Net gains/losses in eth")
+			// Remove the line below this comment if you want the prevBalance to be the
+			// initial balance so that the log actually shows the NET gains/losses since
+			// the accounts started validating. Otherwise it will show the gains/losses
+			// since the previous block.
+			v.prevBalances[i] = resp.Balance
 		}
 		totalPrevBalance += resp.Balance
 	}
 
-	v.prevBalance = totalPrevBalance
 	return nil
 }


### PR DESCRIPTION
TODO(you): choose "part of" or "resolves" and the associated github issue #.

Resolves #2573

---

When staking with multiple keys, the validator thinks each account started with the sum of all account balances. This causes it to calculate losses incorrectly.

**Write why you are making the changes in this pull request**

**Write a summary of the changes you are making**

**Link anything that would be helpful or relevant to the reviewers**
