### PR TITLE
Fix Querier to handle Deposit Logs Race

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -33,6 +33,8 @@ func (w *Web3Service) ETH2GenesisTime() uint64 {
 // ProcessLog is the main method which handles the processing of all
 // logs from the deposit contract on the ETH1.0 chain.
 func (w *Web3Service) ProcessLog(depositLog gethTypes.Log) {
+	w.processingLock.Lock()
+	defer w.processingLock.Unlock()
 	// Process logs according to their event signature.
 	if depositLog.Topics[0] == hashutil.HashKeccak256(depositEventSignature) {
 		w.ProcessDepositLog(depositLog)

--- a/beacon-chain/sync/querier.go
+++ b/beacon-chain/sync/querier.go
@@ -17,6 +17,7 @@ import (
 )
 
 var queryLog = logrus.WithField("prefix", "syncQuerier")
+var logQueryInterval = 1 * time.Second
 
 type powChainService interface {
 	HasChainStarted() bool
@@ -213,7 +214,7 @@ func (q *Querier) waitForAllDepositsToBeProcessed() {
 		if processed {
 			break
 		}
-		time.Sleep(1 * time.Second)
+		time.Sleep(logQueryInterval)
 	}
 }
 

--- a/beacon-chain/sync/querier_test.go
+++ b/beacon-chain/sync/querier_test.go
@@ -32,6 +32,10 @@ func (mp *genesisPowChain) ChainStartFeed() *event.Feed {
 	return mp.feed
 }
 
+func (mp *genesisPowChain) AreAllDepositsProcessed() (bool, error) {
+	return false, nil
+}
+
 type afterGenesisPowChain struct {
 	feed *event.Feed
 }
@@ -46,6 +50,10 @@ func (mp *afterGenesisPowChain) BlockExists(ctx context.Context, hash common.Has
 
 func (mp *afterGenesisPowChain) ChainStartFeed() *event.Feed {
 	return mp.feed
+}
+
+func (mp *afterGenesisPowChain) AreAllDepositsProcessed() (bool, error) {
+	return true, nil
 }
 
 func TestQuerier_StartStop(t *testing.T) {

--- a/beacon-chain/sync/querier_test.go
+++ b/beacon-chain/sync/querier_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 type genesisPowChain struct {
-	feed *event.Feed
+	feed              *event.Feed
+	depositsProcessed bool
 }
 
 func (mp *genesisPowChain) HasChainStarted() bool {
@@ -33,7 +34,7 @@ func (mp *genesisPowChain) ChainStartFeed() *event.Feed {
 }
 
 func (mp *genesisPowChain) AreAllDepositsProcessed() (bool, error) {
-	return false, nil
+	return mp.depositsProcessed, nil
 }
 
 type afterGenesisPowChain struct {
@@ -216,7 +217,7 @@ func TestSyncedInGenesis(t *testing.T) {
 		ResponseBufferSize: 100,
 		ChainService:       &mockChainService{},
 		BeaconDB:           db,
-		PowChain:           &genesisPowChain{},
+		PowChain:           &genesisPowChain{depositsProcessed: true},
 	}
 	sq := NewQuerierService(context.Background(), cfg)
 
@@ -284,4 +285,34 @@ func TestSyncedInRestarts(t *testing.T) {
 		t.Errorf("node is synced when it is not supposed to be in a restart")
 	}
 	sq.cancel()
+}
+
+func TestWaitForDepositsProcessed_OK(t *testing.T) {
+	db := internal.SetupDB(t)
+	defer internal.TeardownDB(t, db)
+	powchain := &genesisPowChain{depositsProcessed: false}
+	cfg := &QuerierConfig{
+		P2P:                &mockP2P{},
+		ResponseBufferSize: 100,
+		ChainService:       &mockChainService{},
+		BeaconDB:           db,
+		PowChain:           powchain,
+	}
+	sq := NewQuerierService(context.Background(), cfg)
+
+	sq.chainStartBuf <- time.Now()
+	exitRoutine := make(chan bool)
+	go func() {
+		sq.waitForAllDepositsToBeProcessed()
+		exitRoutine <- true
+	}()
+	if len(exitRoutine) == 1 {
+		t.Fatal("Deposits processed despite not being ready")
+	}
+
+	powchain.depositsProcessed = true
+	<-exitRoutine
+
+	sq.cancel()
+	close(exitRoutine)
 }


### PR DESCRIPTION
- [x] Waits for all the deposit logs to be processed before resuming querying
- [x] Add a mutex to lock the service when processing a log, to prevent a race