### PR TITLE
Update "Testing Prysm" readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ bazel run //validator
 bazel test //...
 ```
 
-**To run our linter**, make sure you have [golangci-lint](https://https://github.com/golangci/golangci-lint) installed and then issue the command:
+**To run our linter**, make sure you have [golangci-lint](https://github.com/golangci/golangci-lint) installed and then issue the command:
 ```
 golangci-lint run
 ```


### PR DESCRIPTION
Part of #2963 

---

# Description

While addressing the improve indices check for #2963, it was discovered that the README's https://github.com/prysmaticlabs/prysm#testing-prysm section links to an invalid URL.

This pull request updates the link to the correct URL: https://github.com/golangci/golangci-lint
