### PR TITLE
Compare hex/hash bytes instead of strings

### DIFF
--- a/shared/p2p/BUILD.bazel
+++ b/shared/p2p/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//shared/event:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/iputils:go_default_library",
+        "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_gogo_protobuf//io:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",

--- a/shared/p2p/negotiation.go
+++ b/shared/p2p/negotiation.go
@@ -1,8 +1,10 @@
 package p2p
 
 import (
+	"bytes"
 	"context"
 
+	"github.com/ethereum/go-ethereum/common"
 	ggio "github.com/gogo/protobuf/io"
 	host "github.com/libp2p/go-libp2p-host"
 	inet "github.com/libp2p/go-libp2p-net"
@@ -76,7 +78,7 @@ func setupPeerNegotiation(h host.Host, contractAddress string, exclusions []peer
 
 				log.WithField("msg", resp).Debug("Handshake received")
 
-				if resp.DepositContractAddress != contractAddress {
+				if !bytes.Equal(common.HexToHash(resp.DepositContractAddress).Bytes(), common.HexToHash(contractAddress).Bytes()) {
 					log.WithFields(logrus.Fields{
 						"peerContract":     resp.DepositContractAddress,
 						"expectedContract": contractAddress,

--- a/shared/p2p/negotiation_test.go
+++ b/shared/p2p/negotiation_test.go
@@ -17,7 +17,7 @@ func TestNegotiation_AcceptsValidPeer(t *testing.T) {
 	hostA := bhost.NewBlankHost(swarmt.GenSwarm(t, ctx))
 	hostB := bhost.NewBlankHost(swarmt.GenSwarm(t, ctx))
 
-	address := "same"
+	address := "0x83250193c56fab7a25b40fe98c9b4f7fc238a568"
 	setHandshakeHandler(hostA, address)
 	setHandshakeHandler(hostB, address)
 
@@ -40,11 +40,11 @@ func TestNegotiation_DisconnectsDifferentDepositContract(t *testing.T) {
 	hostA := bhost.NewBlankHost(swarmt.GenSwarm(t, ctx))
 	hostB := bhost.NewBlankHost(swarmt.GenSwarm(t, ctx))
 
-	setHandshakeHandler(hostA, "hostA")
-	setHandshakeHandler(hostB, "hostB")
+	setHandshakeHandler(hostA, "0x83250193c56fab7a25b40fe98c9b4f7fc238a568")
+	setHandshakeHandler(hostB, "0x9d525e28fe5830ee92d7aa799c4d21590567b595")
 
-	setupPeerNegotiation(hostA, "hostA", []peer.ID{})
-	setupPeerNegotiation(hostB, "hostB", []peer.ID{})
+	setupPeerNegotiation(hostA, "0x83250193c56fab7a25b40fe98c9b4f7fc238a568", []peer.ID{})
+	setupPeerNegotiation(hostB, "0x9d525e28fe5830ee92d7aa799c4d21590567b595", []peer.ID{})
 
 	if err := hostA.Connect(ctx, pstore.PeerInfo{ID: hostB.ID(), Addrs: hostB.Addrs()}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Resolves #3071 where two similar contracts were failing negotiation 