### PR TITLE
Require Signature Verification in Randao, Attestations and AttesterSlashings

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -415,7 +415,6 @@ func slashableAttesterIndices(slashing *ethpb.AttesterSlashing) []uint64 {
 func ProcessAttestations(
 	beaconState *pb.BeaconState,
 	body *ethpb.BeaconBlockBody,
-	verifySignatures bool,
 ) (*pb.BeaconState, error) {
 	var err error
 	for idx, attestation := range body.Attestations {

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -345,7 +345,6 @@ func TestProcessRandao_IncorrectProposerFailsVerification(t *testing.T) {
 	if _, err := blocks.ProcessRandao(
 		beaconState,
 		block.Body,
-		true, /* verify signatures */
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %v, received %v", want, err)
 	}
@@ -373,7 +372,6 @@ func TestProcessRandao_SignatureVerifiesAndUpdatesLatestStateMixes(t *testing.T)
 	newState, err := blocks.ProcessRandao(
 		beaconState,
 		block.Body,
-		true, /* verify signatures */
 	)
 	if err != nil {
 		t.Errorf("Unexpected error processing block randao: %v", err)

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -897,7 +897,6 @@ func TestProcessAttestations_InclusionDelayFailure(t *testing.T) {
 	if _, err := blocks.ProcessAttestations(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -941,7 +940,6 @@ func TestProcessAttestations_NeitherCurrentNorPrevEpoch(t *testing.T) {
 	if _, err := blocks.ProcessAttestations(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -988,7 +986,6 @@ func TestProcessAttestations_CurrentEpochFFGDataMismatches(t *testing.T) {
 	if _, err := blocks.ProcessAttestations(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1004,7 +1001,6 @@ func TestProcessAttestations_CurrentEpochFFGDataMismatches(t *testing.T) {
 	if _, err := blocks.ProcessAttestations(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1052,7 +1048,6 @@ func TestProcessAttestations_PrevEpochFFGDataMismatches(t *testing.T) {
 	if _, err := blocks.ProcessAttestations(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1068,7 +1063,6 @@ func TestProcessAttestations_PrevEpochFFGDataMismatches(t *testing.T) {
 	if _, err := blocks.ProcessAttestations(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1112,7 +1106,6 @@ func TestProcessAttestations_CrosslinkMismatches(t *testing.T) {
 	if _, err := blocks.ProcessAttestations(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1121,7 +1114,6 @@ func TestProcessAttestations_CrosslinkMismatches(t *testing.T) {
 	if _, err := blocks.ProcessAttestations(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1136,7 +1128,6 @@ func TestProcessAttestations_CrosslinkMismatches(t *testing.T) {
 	if _, err := blocks.ProcessAttestations(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1209,7 +1200,6 @@ func TestProcessAttestations_OK(t *testing.T) {
 	if _, err := blocks.ProcessAttestations(
 		beaconState,
 		block.Body,
-		false,
 	); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -683,7 +683,6 @@ func TestProcessAttesterSlashings_DataNotSlashable(t *testing.T) {
 	if _, err := blocks.ProcessAttesterSlashings(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -733,7 +732,6 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 	if _, err := blocks.ProcessAttesterSlashings(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -769,73 +767,81 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 	if _, err := blocks.ProcessAttesterSlashings(
 		beaconState,
 		block.Body,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
 
 func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
-	// We test the case when data is correct and verify the validator
-	// registry has been updated.
-	validators := make([]*ethpb.Validator, params.BeaconConfig().MinGenesisActiveValidatorCount)
-	for i := 0; i < len(validators); i++ {
-		validators[i] = &ethpb.Validator{
-			ActivationEpoch:   0,
-			ExitEpoch:         params.BeaconConfig().FarFutureEpoch,
-			Slashed:           false,
-			WithdrawableEpoch: 1 * params.BeaconConfig().SlotsPerEpoch,
-		}
+	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
+	for _, vv := range beaconState.Validators {
+		vv.WithdrawableEpoch = 1 * params.BeaconConfig().SlotsPerEpoch
 	}
-	validatorBalances := make([]uint64, len(validators))
-	for i := 0; i < len(validatorBalances); i++ {
-		validatorBalances[i] = params.BeaconConfig().MaxEffectiveBalance
+
+	att1 := &ethpb.IndexedAttestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 1},
+			Target: &ethpb.Checkpoint{Epoch: 0},
+			Crosslink: &ethpb.Crosslink{
+				Shard: 4,
+			},
+		},
+		CustodyBit_0Indices: []uint64{0, 1},
 	}
+	dataAndCustodyBit := &pb.AttestationDataAndCustodyBit{
+		Data:       att1.Data,
+		CustodyBit: false,
+	}
+	hashTreeRoot, err := ssz.HashTreeRoot(dataAndCustodyBit)
+	if err != nil {
+		t.Error(err)
+	}
+	domain := helpers.Domain(beaconState, 0, params.BeaconConfig().DomainAttestation)
+	sig0 := privKeys[0].Sign(hashTreeRoot[:], domain)
+	sig1 := privKeys[1].Sign(hashTreeRoot[:], domain)
+	aggregateSig := bls.AggregateSignatures([]*bls.Signature{sig0, sig1})
+	att1.Signature = aggregateSig.Marshal()[:]
+
+	att2 := &ethpb.IndexedAttestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 0},
+			Target: &ethpb.Checkpoint{Epoch: 0},
+			Crosslink: &ethpb.Crosslink{
+				Shard: 4,
+			},
+		},
+		CustodyBit_0Indices: []uint64{0, 1},
+	}
+	dataAndCustodyBit = &pb.AttestationDataAndCustodyBit{
+		Data:       att2.Data,
+		CustodyBit: false,
+	}
+	hashTreeRoot, err = ssz.HashTreeRoot(dataAndCustodyBit)
+	if err != nil {
+		t.Error(err)
+	}
+	sig0 = privKeys[0].Sign(hashTreeRoot[:], domain)
+	sig1 = privKeys[1].Sign(hashTreeRoot[:], domain)
+	aggregateSig = bls.AggregateSignatures([]*bls.Signature{sig0, sig1})
+	att2.Signature = aggregateSig.Marshal()[:]
 
 	slashings := []*ethpb.AttesterSlashing{
 		{
-			Attestation_1: &ethpb.IndexedAttestation{
-				Data: &ethpb.AttestationData{
-					Source: &ethpb.Checkpoint{Epoch: 1},
-					Target: &ethpb.Checkpoint{Epoch: 0},
-					Crosslink: &ethpb.Crosslink{
-						Shard: 4,
-					},
-				},
-				CustodyBit_0Indices: []uint64{0, 1},
-			},
-			Attestation_2: &ethpb.IndexedAttestation{
-				Data: &ethpb.AttestationData{
-					Source: &ethpb.Checkpoint{Epoch: 0},
-					Target: &ethpb.Checkpoint{Epoch: 0},
-					Crosslink: &ethpb.Crosslink{
-						Shard: 4,
-					},
-				},
-				CustodyBit_0Indices: []uint64{0, 1},
-			},
+			Attestation_1: att1,
+			Attestation_2: att2,
 		},
 	}
 
 	currentSlot := 2 * params.BeaconConfig().SlotsPerEpoch
-	beaconState := &pb.BeaconState{
-		Validators:       validators,
-		Slot:             currentSlot,
-		Balances:         validatorBalances,
-		RandaoMixes:      make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
-		Slashings:        make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector),
-		ActiveIndexRoots: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
-	}
+	beaconState.Slot = currentSlot
+
 	block := &ethpb.BeaconBlock{
 		Body: &ethpb.BeaconBlockBody{
 			AttesterSlashings: slashings,
 		},
 	}
-	newState, err := blocks.ProcessAttesterSlashings(
-		beaconState,
-		block.Body,
-		false,
-	)
+	newState, err := blocks.ProcessAttesterSlashings(beaconState, block.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -843,13 +849,13 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 
 	// Given the intersection of slashable indices is [1], only validator
 	// at index 1 should be slashed and exited. We confirm this below.
-	if newRegistry[1].ExitEpoch != validators[1].ExitEpoch {
+	if newRegistry[1].ExitEpoch != beaconState.Validators[1].ExitEpoch {
 		t.Errorf(
 			`
 			Expected validator at index 1's exit epoch to match
 			%d, received %d instead
 			`,
-			validators[1].ExitEpoch,
+			beaconState.Validators[1].ExitEpoch,
 			newRegistry[1].ExitEpoch,
 		)
 	}
@@ -1138,31 +1144,51 @@ func TestProcessAttestations_CrosslinkMismatches(t *testing.T) {
 
 func TestProcessAttestations_OK(t *testing.T) {
 	helpers.ClearAllCaches()
-
-	attestations := []*ethpb.Attestation{
-		{
-			Data: &ethpb.AttestationData{
-				Source: &ethpb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
-				Target: &ethpb.Checkpoint{Epoch: 0},
-				Crosslink: &ethpb.Crosslink{
-					Shard:      0,
-					StartEpoch: 0,
-				},
-			},
-			AggregationBits: bitfield.Bitlist{0xC0, 0xC0, 0xC0, 0xC0, 0x01},
-			CustodyBits:     bitfield.Bitlist{0x00, 0x00, 0x00, 0x00, 0x01},
-		},
-	}
-	block := &ethpb.BeaconBlock{
-		Body: &ethpb.BeaconBlockBody{
-			Attestations: attestations,
-		},
-	}
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	att := &ethpb.Attestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
+			Target: &ethpb.Checkpoint{Epoch: 0},
+			Crosslink: &ethpb.Crosslink{
+				Shard:      0,
+				StartEpoch: 0,
+			},
+		},
+		AggregationBits: bitfield.Bitlist{0xC0, 0xC0, 0xC0, 0xC0, 0x01},
+		CustodyBits:     bitfield.Bitlist{0x00, 0x00, 0x00, 0x00, 0x01},
+	}
+
+	attestingIndices, err := helpers.AttestingIndices(beaconState, att.Data, att.AggregationBits)
+	if err != nil {
+		t.Error(err)
+	}
+	domain := helpers.Domain(beaconState, 0, params.BeaconConfig().DomainAttestation)
+	sigs := make([]*bls.Signature, len(attestingIndices))
+	for i, indice := range attestingIndices {
+		dataAndCustodyBit := &pb.AttestationDataAndCustodyBit{
+			Data:       att.Data,
+			CustodyBit: false,
+		}
+		hashTreeRoot, err := ssz.HashTreeRoot(dataAndCustodyBit)
+		if err != nil {
+			t.Error(err)
+		}
+		sig := privKeys[indice].Sign(hashTreeRoot[:], domain)
+		sigs[i] = sig
+	}
+	att.Signature = bls.AggregateSignatures(sigs).Marshal()[:]
+
+	block := &ethpb.BeaconBlock{
+		Body: &ethpb.BeaconBlockBody{
+			Attestations: []*ethpb.Attestation{att},
+		},
+	}
+
 	beaconState.Slot += params.BeaconConfig().MinAttestationInclusionDelay
 	beaconState.CurrentCrosslinks = []*ethpb.Crosslink{
 		{
@@ -1285,7 +1311,6 @@ func TestValidateIndexedAttestation_AboveMaxLength(t *testing.T) {
 	if err := blocks.VerifyIndexedAttestation(
 		&pb.BeaconState{},
 		indexedAtt1,
-		false,
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected verification to fail return false, received: %v", err)
 	}

--- a/beacon-chain/core/blocks/spectest/attestation_test.go
+++ b/beacon-chain/core/blocks/spectest/attestation_test.go
@@ -47,7 +47,7 @@ func runAttestationTest(t *testing.T, filename string) {
 				},
 			}
 
-			post, err := blocks.ProcessAttestations(tt.Pre, body, true /*verify sig*/)
+			post, err := blocks.ProcessAttestations(tt.Pre, body)
 			if !reflect.ValueOf(tt.Post).IsValid() {
 				// Note: This doesn't test anything worthwhile. It essentially tests
 				// that *any* error has occurred, not any specific error.

--- a/beacon-chain/core/blocks/spectest/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/spectest/attester_slashing_test.go
@@ -40,7 +40,7 @@ func runAttesterSlashingTest(t *testing.T, filename string) {
 
 			body := &ethpb.BeaconBlockBody{AttesterSlashings: []*ethpb.AttesterSlashing{tt.AttesterSlashing}}
 
-			postState, err := blocks.ProcessAttesterSlashings(tt.Pre, body, true)
+			postState, err := blocks.ProcessAttesterSlashings(tt.Pre, body)
 			// Note: This doesn't test anything worthwhile. It essentially tests
 			// that *any* error has occurred, not any specific error.
 			if tt.Post == nil {

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -69,7 +69,7 @@ func ExecuteStateTransition(
 
 	// Execute per block transition.
 	if block != nil {
-		state, err = ProcessBlock(ctx, state, block, config)
+		state, err = ProcessBlock(ctx, state, block)
 		if err != nil {
 			return nil, fmt.Errorf("could not process block: %v", err)
 		}
@@ -178,7 +178,6 @@ func ProcessBlock(
 	ctx context.Context,
 	state *pb.BeaconState,
 	block *ethpb.BeaconBlock,
-	config *TransitionConfig,
 ) (*pb.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock")
 	defer span.End()
@@ -198,7 +197,7 @@ func ProcessBlock(
 		return nil, fmt.Errorf("could not process eth1 data: %v", err)
 	}
 
-	state, err = ProcessOperations(ctx, state, block.Body, config)
+	state, err = ProcessOperations(ctx, state, block.Body)
 	if err != nil {
 		return nil, fmt.Errorf("could not process block operation: %v", err)
 	}
@@ -232,7 +231,7 @@ func ProcessOperations(
 	ctx context.Context,
 	state *pb.BeaconState,
 	body *ethpb.BeaconBlockBody,
-	config *TransitionConfig) (*pb.BeaconState, error) {
+) (*pb.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessOperations")
 	defer span.End()
 
@@ -261,7 +260,7 @@ func ProcessOperations(
 	if err != nil {
 		return nil, fmt.Errorf("could not process block attester slashings: %v", err)
 	}
-	state, err = b.ProcessAttestations(state, body, config.VerifySignatures)
+	state, err = b.ProcessAttestations(state, body)
 	if err != nil {
 		return nil, fmt.Errorf("could not process block attestations: %v", err)
 	}

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -257,7 +257,7 @@ func ProcessOperations(
 	if err != nil {
 		return nil, fmt.Errorf("could not process block proposer slashings: %v", err)
 	}
-	state, err = b.ProcessAttesterSlashings(state, body, config.VerifySignatures)
+	state, err = b.ProcessAttesterSlashings(state, body)
 	if err != nil {
 		return nil, fmt.Errorf("could not process block attester slashings: %v", err)
 	}

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -188,7 +188,7 @@ func ProcessBlock(
 		return nil, fmt.Errorf("could not process block header: %v", err)
 	}
 
-	state, err = b.ProcessRandao(state, block.Body, config.VerifySignatures)
+	state, err = b.ProcessRandao(state, block.Body)
 	if err != nil {
 		return nil, fmt.Errorf("could not verify and process randao: %v", err)
 	}

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -60,11 +60,18 @@ func TestExecuteStateTransition_FullProcess(t *testing.T) {
 		t.Error(err)
 	}
 
+	beaconState.Slot++
+	epoch := helpers.CurrentEpoch(beaconState)
+	randaoReveal, err := testutil.CreateRandaoReveal(beaconState, epoch, privKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	beaconState.Slot--
 	block := &ethpb.BeaconBlock{
 		Slot:       beaconState.Slot + 1,
 		ParentRoot: parentRoot[:],
 		Body: &ethpb.BeaconBlockBody{
-			RandaoReveal: []byte{'A', 'B', 'C'},
+			RandaoReveal: randaoReveal,
 			Eth1Data:     eth1Data,
 		},
 	}
@@ -529,11 +536,16 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	epoch := helpers.CurrentEpoch(beaconState)
+	randaoReveal, err := testutil.CreateRandaoReveal(beaconState, epoch, privKeys)
+	if err != nil {
+		t.Fatal(err)
+	}
 	block := &ethpb.BeaconBlock{
 		ParentRoot: parentRoot[:],
 		Slot:       beaconState.Slot,
 		Body: &ethpb.BeaconBlockBody{
-			RandaoReveal:      []byte{},
+			RandaoReveal:      randaoReveal,
 			ProposerSlashings: proposerSlashings,
 			AttesterSlashings: attesterSlashings,
 			Attestations:      []*ethpb.Attestation{blockAtt},

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -164,11 +164,8 @@ func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 
 	proposerSlashIdx := uint64(3)
 
-	domain := helpers.Domain(
-		beaconState,
-		helpers.CurrentEpoch(beaconState),
-		params.BeaconConfig().DomainBeaconProposer,
-	)
+	currentEpoch := helpers.CurrentEpoch(beaconState)
+	domain := helpers.Domain(beaconState, currentEpoch, params.BeaconConfig().DomainBeaconProposer)
 
 	header1 := &ethpb.BeaconBlockHeader{
 		Slot:      1,
@@ -199,32 +196,61 @@ func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 	}
 	beaconState.Validators[proposerSlashIdx].PublicKey = privKeys[proposerSlashIdx].PublicKey().Marshal()[:]
 
-	attesterSlashings := []*ethpb.AttesterSlashing{
+	att1 := &ethpb.IndexedAttestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 0},
+			Target: &ethpb.Checkpoint{Epoch: 0},
+			Crosslink: &ethpb.Crosslink{
+				Shard: 4,
+			},
+		},
+		CustodyBit_0Indices: []uint64{0, 1},
+	}
+	dataAndCustodyBit := &pb.AttestationDataAndCustodyBit{
+		Data:       att1.Data,
+		CustodyBit: false,
+	}
+	hashTreeRoot, err := ssz.HashTreeRoot(dataAndCustodyBit)
+	if err != nil {
+		t.Error(err)
+	}
+	domain = helpers.Domain(beaconState, currentEpoch, params.BeaconConfig().DomainAttestation)
+	sig0 := privKeys[0].Sign(hashTreeRoot[:], domain)
+	sig1 := privKeys[1].Sign(hashTreeRoot[:], domain)
+	aggregateSig := bls.AggregateSignatures([]*bls.Signature{sig0, sig1})
+	att1.Signature = aggregateSig.Marshal()[:]
+
+	att2 := &ethpb.IndexedAttestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 1},
+			Target: &ethpb.Checkpoint{Epoch: 0},
+			Crosslink: &ethpb.Crosslink{
+				Shard: 4,
+			},
+		},
+		CustodyBit_0Indices: []uint64{0, 1},
+	}
+	dataAndCustodyBit = &pb.AttestationDataAndCustodyBit{
+		Data:       att2.Data,
+		CustodyBit: false,
+	}
+	hashTreeRoot, err = ssz.HashTreeRoot(dataAndCustodyBit)
+	if err != nil {
+		t.Error(err)
+	}
+	sig0 = privKeys[0].Sign(hashTreeRoot[:], domain)
+	sig1 = privKeys[1].Sign(hashTreeRoot[:], domain)
+	aggregateSig = bls.AggregateSignatures([]*bls.Signature{sig0, sig1})
+	att2.Signature = aggregateSig.Marshal()[:]
+
+	slashings := []*ethpb.AttesterSlashing{
 		{
-			Attestation_1: &ethpb.IndexedAttestation{
-				Data: &ethpb.AttestationData{
-					Source: &ethpb.Checkpoint{Epoch: 0},
-					Target: &ethpb.Checkpoint{Epoch: 0},
-					Crosslink: &ethpb.Crosslink{
-						Shard: 4,
-					},
-				},
-				CustodyBit_0Indices: []uint64{0, 1},
-			},
-			Attestation_2: &ethpb.IndexedAttestation{
-				Data: &ethpb.AttestationData{
-					Source: &ethpb.Checkpoint{Epoch: 1},
-					Target: &ethpb.Checkpoint{Epoch: 0},
-					Crosslink: &ethpb.Crosslink{
-						Shard: 4,
-					},
-				},
-				CustodyBit_0Indices: []uint64{0, 1},
-			},
+			Attestation_1: att1,
+			Attestation_2: att2,
 		},
 	}
 
-	attestation := &ethpb.Attestation{
+	att := &ethpb.Attestation{
 		Data: &ethpb.AttestationData{
 			Target:    &ethpb.Checkpoint{Epoch: 0},
 			Crosslink: &ethpb.Crosslink{},
@@ -232,6 +258,7 @@ func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 		AggregationBits: bitfield.NewBitlist(0),
 		CustodyBits:     bitfield.NewBitlist(0),
 	}
+
 	epoch := helpers.CurrentEpoch(beaconState)
 	randaoReveal, err := testutil.CreateRandaoReveal(beaconState, epoch, privKeys)
 	if err != nil {
@@ -257,8 +284,8 @@ func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 		Body: &ethpb.BeaconBlockBody{
 			RandaoReveal:      randaoReveal,
 			ProposerSlashings: proposerSlashings,
-			AttesterSlashings: attesterSlashings,
-			Attestations:      []*ethpb.Attestation{attestation},
+			AttesterSlashings: slashings,
+			Attestations:      []*ethpb.Attestation{att},
 			Eth1Data: &ethpb.Eth1Data{
 				DepositRoot: []byte{2},
 				BlockHash:   []byte{3},
@@ -270,7 +297,7 @@ func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	want := "could not process block attestations"
+	want := "could not verify attestation at index 0"
 	if _, err := state.ProcessBlock(context.Background(), beaconState, block, state.DefaultConfig()); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -416,10 +443,13 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 	beaconState.Slashings = make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
 
 	proposerSlashIdx := uint64(3)
+	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
+	beaconState.Slot = (params.BeaconConfig().PersistentCommitteePeriod * slotsPerEpoch) + params.BeaconConfig().MinAttestationInclusionDelay
 
+	currentEpoch := helpers.CurrentEpoch(beaconState)
 	domain := helpers.Domain(
 		beaconState,
-		helpers.CurrentEpoch(beaconState),
+		currentEpoch,
 		params.BeaconConfig().DomainBeaconProposer,
 	)
 
@@ -452,30 +482,60 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 	}
 	beaconState.Validators[proposerSlashIdx].PublicKey = privKeys[proposerSlashIdx].PublicKey().Marshal()[:]
 
-	attesterSlashings := []*ethpb.AttesterSlashing{
-		{
-			Attestation_1: &ethpb.IndexedAttestation{
-				Data: &ethpb.AttestationData{
-					Source: &ethpb.Checkpoint{Epoch: 0, Root: []byte{'A'}},
-					Target: &ethpb.Checkpoint{Epoch: 0},
-					Crosslink: &ethpb.Crosslink{
-						Shard: 4,
-					},
-				},
-				CustodyBit_0Indices: []uint64{0, 1},
-			},
-			Attestation_2: &ethpb.IndexedAttestation{
-				Data: &ethpb.AttestationData{
-					Source: &ethpb.Checkpoint{Epoch: 0, Root: []byte{'B'}},
-					Target: &ethpb.Checkpoint{Epoch: 0},
-					Crosslink: &ethpb.Crosslink{
-						Shard: 4,
-					},
-				},
-				CustodyBit_0Indices: []uint64{0, 1},
+	att1 := &ethpb.IndexedAttestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 0, Root: []byte{'A'}},
+			Target: &ethpb.Checkpoint{Epoch: 0},
+			Crosslink: &ethpb.Crosslink{
+				Shard: 4,
 			},
 		},
+		CustodyBit_0Indices: []uint64{0, 1},
 	}
+	dataAndCustodyBit := &pb.AttestationDataAndCustodyBit{
+		Data:       att1.Data,
+		CustodyBit: false,
+	}
+	hashTreeRoot, err := ssz.HashTreeRoot(dataAndCustodyBit)
+	if err != nil {
+		t.Error(err)
+	}
+	domain = helpers.Domain(beaconState, currentEpoch, params.BeaconConfig().DomainAttestation)
+	sig0 := privKeys[0].Sign(hashTreeRoot[:], domain)
+	sig1 := privKeys[1].Sign(hashTreeRoot[:], domain)
+	aggregateSig := bls.AggregateSignatures([]*bls.Signature{sig0, sig1})
+	att1.Signature = aggregateSig.Marshal()[:]
+
+	att2 := &ethpb.IndexedAttestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 0, Root: []byte{'B'}},
+			Target: &ethpb.Checkpoint{Epoch: 0},
+			Crosslink: &ethpb.Crosslink{
+				Shard: 4,
+			},
+		},
+		CustodyBit_0Indices: []uint64{0, 1},
+	}
+	dataAndCustodyBit = &pb.AttestationDataAndCustodyBit{
+		Data:       att2.Data,
+		CustodyBit: false,
+	}
+	hashTreeRoot, err = ssz.HashTreeRoot(dataAndCustodyBit)
+	if err != nil {
+		t.Error(err)
+	}
+	sig0 = privKeys[0].Sign(hashTreeRoot[:], domain)
+	sig1 = privKeys[1].Sign(hashTreeRoot[:], domain)
+	aggregateSig = bls.AggregateSignatures([]*bls.Signature{sig0, sig1})
+	att2.Signature = aggregateSig.Marshal()[:]
+
+	attesterSlashings := []*ethpb.AttesterSlashing{
+		{
+			Attestation_1: att1,
+			Attestation_2: att2,
+		},
+	}
+
 	var blockRoots [][]byte
 	for i := uint64(0); i < params.BeaconConfig().HistoricalRootsLimit; i++ {
 		blockRoots = append(blockRoots, []byte{byte(i)})
@@ -486,8 +546,6 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 			DataRoot: []byte{1},
 		},
 	}
-	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
-	beaconState.Slot = (params.BeaconConfig().PersistentCommitteePeriod * slotsPerEpoch) + params.BeaconConfig().MinAttestationInclusionDelay
 	blockAtt := &ethpb.Attestation{
 		Data: &ethpb.AttestationData{
 			Target: &ethpb.Checkpoint{Epoch: helpers.SlotToEpoch(beaconState.Slot)},
@@ -503,6 +561,24 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 		AggregationBits: bitfield.Bitlist{0xC0, 0xC0, 0xC0, 0xC0, 0x01},
 		CustodyBits:     bitfield.Bitlist{0x00, 0x00, 0x00, 0x00, 0x01},
 	}
+	attestingIndices, err := helpers.AttestingIndices(beaconState, blockAtt.Data, blockAtt.AggregationBits)
+	if err != nil {
+		t.Error(err)
+	}
+	sigs := make([]*bls.Signature, len(attestingIndices))
+	for i, indice := range attestingIndices {
+		dataAndCustodyBit := &pb.AttestationDataAndCustodyBit{
+			Data:       blockAtt.Data,
+			CustodyBit: false,
+		}
+		hashTreeRoot, err := ssz.HashTreeRoot(dataAndCustodyBit)
+		if err != nil {
+			t.Error(err)
+		}
+		sig := privKeys[indice].Sign(hashTreeRoot[:], domain)
+		sigs[i] = sig
+	}
+	blockAtt.Signature = bls.AggregateSignatures(sigs).Marshal()[:]
 
 	exit := &ethpb.VoluntaryExit{
 		ValidatorIndex: 10,
@@ -512,11 +588,7 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not get signing root of beacon block header: %v", err)
 	}
-	domain = helpers.Domain(
-		beaconState,
-		helpers.CurrentEpoch(beaconState),
-		params.BeaconConfig().DomainVoluntaryExit,
-	)
+	domain = helpers.Domain(beaconState, currentEpoch, params.BeaconConfig().DomainVoluntaryExit)
 	exit.Signature = privKeys[exit.ValidatorIndex].Sign(signingRoot[:], domain).Marshal()[:]
 
 	parentRoot, err := ssz.SigningRoot(beaconState.LatestBlockHeader)
@@ -536,8 +608,7 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	epoch := helpers.CurrentEpoch(beaconState)
-	randaoReveal, err := testutil.CreateRandaoReveal(beaconState, epoch, privKeys)
+	randaoReveal, err := testutil.CreateRandaoReveal(beaconState, currentEpoch, privKeys)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -149,7 +149,7 @@ func TestProcessBlock_IncorrectProposerSlashing(t *testing.T) {
 	}
 
 	want := "could not process block proposer slashing"
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, state.DefaultConfig()); !strings.Contains(err.Error(), want) {
+	if _, err := state.ProcessBlock(context.Background(), beaconState, block); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
@@ -298,7 +298,7 @@ func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 		t.Error(err)
 	}
 	want := "could not verify attestation at index 0"
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, state.DefaultConfig()); !strings.Contains(err.Error(), want) {
+	if _, err := state.ProcessBlock(context.Background(), beaconState, block); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
 }
@@ -419,7 +419,7 @@ func TestProcessBlock_IncorrectProcessExits(t *testing.T) {
 	}
 	block.Body.Attestations[0].Data.Crosslink.ParentRoot = encoded[:]
 	block.Body.Attestations[0].Data.Crosslink.DataRoot = params.BeaconConfig().ZeroHash[:]
-	if _, err := state.ProcessBlock(context.Background(), beaconState, block, state.DefaultConfig()); err == nil {
+	if _, err := state.ProcessBlock(context.Background(), beaconState, block); err == nil {
 		t.Error("Expected err, received nil")
 	}
 }
@@ -634,7 +634,7 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 		t.Error(err)
 	}
 
-	beaconState, err = state.ProcessBlock(context.Background(), beaconState, block, state.DefaultConfig())
+	beaconState, err = state.ProcessBlock(context.Background(), beaconState, block)
 	if err != nil {
 		t.Errorf("Expected block to pass processing conditions: %v", err)
 	}
@@ -847,10 +847,6 @@ func BenchmarkProcessBlk_65536Validators_FullBlock(b *testing.B) {
 		CurrentCrosslinks: crosslinks,
 	}
 
-	c := &state.TransitionConfig{
-		VerifySignatures: true,
-	}
-
 	// Set up proposer slashing object for block
 	proposerSlashings := []*ethpb.ProposerSlashing{
 		{
@@ -989,7 +985,7 @@ func BenchmarkProcessBlk_65536Validators_FullBlock(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, err := state.ProcessBlock(context.Background(), s, blk, c)
+		_, err := state.ProcessBlock(context.Background(), s, blk)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -1055,7 +1051,6 @@ func TestProcessOperations_OverMaxProposerSlashings(t *testing.T) {
 		context.Background(),
 		&pb.BeaconState{},
 		block.Body,
-		state.DefaultConfig(),
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1075,7 +1070,6 @@ func TestProcessOperations_OverMaxAttesterSlashings(t *testing.T) {
 		context.Background(),
 		&pb.BeaconState{},
 		block.Body,
-		state.DefaultConfig(),
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1094,7 +1088,6 @@ func TestProcessOperations_OverMaxAttestations(t *testing.T) {
 		context.Background(),
 		&pb.BeaconState{},
 		block.Body,
-		state.DefaultConfig(),
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1113,7 +1106,6 @@ func TestProcessOperations_OverMaxTransfers(t *testing.T) {
 		context.Background(),
 		&pb.BeaconState{},
 		block.Body,
-		state.DefaultConfig(),
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1133,7 +1125,6 @@ func TestProcessOperation_OverMaxVoluntaryExits(t *testing.T) {
 		context.Background(),
 		&pb.BeaconState{},
 		block.Body,
-		state.DefaultConfig(),
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1156,7 +1147,6 @@ func TestProcessOperations_IncorrectDeposits(t *testing.T) {
 		context.Background(),
 		s,
 		block.Body,
-		state.DefaultConfig(),
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}
@@ -1191,7 +1181,6 @@ func TestProcessOperation_DuplicateTransfer(t *testing.T) {
 		context.Background(),
 		s,
 		block.Body,
-		state.DefaultConfig(),
 	); !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %s, received %v", want, err)
 	}

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -169,7 +169,7 @@ func (ps *ProposerServer) attestations(ctx context.Context, expectedSlot uint64)
 			return nil, fmt.Errorf("could not get attestation slot: %v", err)
 		}
 
-		if _, err := blocks.ProcessAttestation(beaconState, att, false); err != nil {
+		if _, err := blocks.ProcessAttestation(beaconState, att); err != nil {
 			if ctx.Err() != nil {
 				return nil, ctx.Err()
 			}

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -3,11 +3,12 @@ package rpc
 import (
 	"context"
 	"crypto/rand"
-	"github.com/prysmaticlabs/prysm/shared/bls"
 	"math/big"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/bls"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prysmaticlabs/go-bitfield"

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/shared/bls"
-
 	"github.com/gogo/protobuf/proto"
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/go-ssz"
@@ -20,6 +18,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/internal"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"


### PR DESCRIPTION
This PR is part of #2951 

This PR removes the verifySignature flag from the processes for RandaoReveal, Attestations, and AttesterSlashings. Since this means all of the operations now require BLS verification, the config parameter has been removed from ProcessOperations 😄  