### PR TITLE
Update SSZ Dependency With Tree Hash Cache Enabled

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -205,7 +205,7 @@ go_repository(
 
 go_repository(
     name = "com_github_prysmaticlabs_go_ssz",
-    commit = "a333bd6a39a6be22bfd11eccb21fdb90812c9e0d",
+    commit = "48789cbaf046ec783a407a76c50a9cdd7507875b",
     importpath = "github.com/prysmaticlabs/go-ssz",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -205,7 +205,7 @@ go_repository(
 
 go_repository(
     name = "com_github_prysmaticlabs_go_ssz",
-    commit = "16d4b0a834f2b17cdc19e3b63e967f15bf91fb1b",
+    commit = "a333bd6a39a6be22bfd11eccb21fdb90812c9e0d",
     importpath = "github.com/prysmaticlabs/go-ssz",
 )
 

--- a/beacon-chain/core/helpers/eth1data.go
+++ b/beacon-chain/core/helpers/eth1data.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prysmaticlabs/go-ssz"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
 
 // VoteHierarchyMap struct that holds all the relevant data in order to count and
@@ -35,10 +36,11 @@ func EmptyVoteHierarchyMap() *VoteHierarchyMap {
 // CountVote takes a votecount map and adds the given vote to it in the relevant
 // position while updating the best vote, most votes and best vote hash.
 func CountVote(voteMap *VoteHierarchyMap, vote *ethpb.Eth1Data, blockHeight *big.Int) (*VoteHierarchyMap, error) {
-	he, err := ssz.HashedEncoding(vote)
+	encoded, err := ssz.Marshal(vote)
 	if err != nil {
 		return &VoteHierarchyMap{}, fmt.Errorf("could not get encoded hash of eth1data object: %v", err)
 	}
+	he := hashutil.Hash(encoded)
 	v, ok := voteMap.voteCountMap[string(he[:])]
 
 	if !ok {


### PR DESCRIPTION
No tracking issue - this PR updates our SSZ to utilize latest changes included in https://github.com/prysmaticlabs/go-ssz/pull/58 to have the hash cache enabled for faster runtime/test time