### PR TITLE
Fix State Root Verification in Sync

### DIFF
--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prysmaticlabs/go-ssz"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	e "github.com/prysmaticlabs/prysm/beacon-chain/core/epoch"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
@@ -44,7 +43,7 @@ func ExecuteStateTransition(
 		return nil, ctx.Err()
 	}
 	helpers.ClearStartShardCache()
-	blocks.ClearEth1DataVoteCache()
+	b.ClearEth1DataVoteCache()
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.ExecuteStateTransition")
 	defer span.End()
 	var err error
@@ -101,7 +100,7 @@ func ExecuteStateTransitionNoVerify(
 
 	stateCopy := proto.Clone(state).(*pb.BeaconState)
 	helpers.ClearStartShardCache()
-	blocks.ClearEth1DataVoteCache()
+	b.ClearEth1DataVoteCache()
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.ExecuteStateTransition")
 	defer span.End()
 	var err error

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prysmaticlabs/go-ssz"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	e "github.com/prysmaticlabs/prysm/beacon-chain/core/epoch"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
@@ -42,7 +43,8 @@ func ExecuteStateTransition(
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-
+	helpers.ClearStartShardCache()
+	blocks.ClearEth1DataVoteCache()
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.ExecuteStateTransition")
 	defer span.End()
 	var err error
@@ -98,7 +100,8 @@ func ExecuteStateTransitionNoVerify(
 	}
 
 	stateCopy := proto.Clone(state).(*pb.BeaconState)
-
+	helpers.ClearStartShardCache()
+	blocks.ClearEth1DataVoteCache()
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.ExecuteStateTransition")
 	defer span.End()
 	var err error


### PR DESCRIPTION
Resolves #3082, by clearing out caches at the start of each state transition.