### PR TITLE
Ignore in progress attestation cache while disabled

### DIFF
--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -123,7 +123,9 @@ func (c *AttestationCache) MarkInProgress(req *pb.AttestationRequest) error {
 	if c.inProgress[s] {
 		return ErrAlreadyInProgress
 	}
-	c.inProgress[s] = true
+	if featureconfig.FeatureConfig().EnableAttestationCache {
+		c.inProgress[s] = true
+	}
 	return nil
 }
 


### PR DESCRIPTION
Followup to #3107. 

This was causing attestation issues where an in progress cache fetch would resolve to nil. 

```
[2019-07-30 00:54:48] ERROR validator: Could not request attestation to sign at slot 18: rpc error: code = Unknown desc = a request was in progress and resolved to nil
```