### PR TITLE
Fix assignment to advance state up to requested slot

### DIFF
--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -140,8 +140,8 @@ func (vs *ValidatorServer) CommitteeAssignment(ctx context.Context, req *pb.Assi
 	}
 
 	// Advance state with empty transitions up to the requested slot.
-	wantedSlot := req.EpochStart * params.BeaconConfig().SlotsPerEpoch
-	s, err = state.ProcessSlots(ctx, s, wantedSlot)
+	slotsToAdvance := req.EpochStart * params.BeaconConfig().SlotsPerEpoch
+	s, err = state.ProcessSlots(ctx, s, slotsToAdvance)
 	if err != nil {
 		return nil, fmt.Errorf("could not process slots up to ")
 	}

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -185,6 +185,7 @@ func (vs *ValidatorServer) assignment(
 	beaconState *pbp2p.BeaconState,
 	epochStart uint64,
 ) (*pb.AssignmentResponse_ValidatorAssignment, error) {
+
 	if len(pubkey) != params.BeaconConfig().BLSPubkeyLength {
 		return nil, fmt.Errorf(
 			"expected public key to have length %d, received %d",
@@ -197,6 +198,7 @@ func (vs *ValidatorServer) assignment(
 	if err != nil {
 		return nil, fmt.Errorf("could not get active validator index: %v", err)
 	}
+
 	committee, shard, slot, isProposer, err :=
 		helpers.CommitteeAssignment(beaconState, epochStart, uint64(idx))
 	if err != nil {

--- a/beacon-chain/rpc/validator_server.go
+++ b/beacon-chain/rpc/validator_server.go
@@ -143,7 +143,7 @@ func (vs *ValidatorServer) CommitteeAssignment(ctx context.Context, req *pb.Assi
 	slotsToAdvance := req.EpochStart * params.BeaconConfig().SlotsPerEpoch
 	s, err = state.ProcessSlots(ctx, s, slotsToAdvance)
 	if err != nil {
-		return nil, fmt.Errorf("could not process slots up to ")
+		return nil, fmt.Errorf("could not process slots up to %d", slotsToAdvance)
 	}
 
 	validatorIndexMap := stateutils.ValidatorIndexMap(s)


### PR DESCRIPTION
As title suggested, this fixes validator server to advance the correct number of slots for assignment request.

Looking at previous implementation, `req.EpochStart` = `2`, `s.Slot` = `15`. We'll never be able to advance the slot to 16

```go
	if req.EpochStart > 1 && s.Slot < helpers.StartSlot(req.EpochStart-1) {
		slotsToAdvance := helpers.StartSlot(req.EpochStart - 1)
		s, err = state.ProcessSlots(ctx, s, slotsToAdvance)
		if err != nil {
			return nil, err
		}
```