### PR TITLE
Fix chain start assignment panic

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -196,9 +196,6 @@ func (v *validator) UpdateAssignments(ctx context.Context, slot uint64) error {
 	}
 	ctx, span := trace.StartSpan(ctx, "validator.UpdateAssignments")
 	defer span.End()
-	if slot == 0 {
-		return nil
-	}
 
 	req := &pb.AssignmentRequest{
 		EpochStart: slot / params.BeaconConfig().SlotsPerEpoch,


### PR DESCRIPTION
This fixes #3115 

I'm not sure why we are returning nil if `slot==0` there, it doesn't make sense and causes a panic because validator can't determine assignment until the first epoch start slot (slot8 or slot64) meaning `v.assignments` is `nil` before the first epoch