### PR TITLE
Remove metrics with high cardinality

### DIFF
--- a/beacon-chain/attestation/service.go
+++ b/beacon-chain/attestation/service.go
@@ -280,13 +280,6 @@ func (a *Service) updateAttestation(beaconState *pb.BeaconState, attestation *et
 					"sourceEpoch":     attestation.Data.Source.Epoch,
 				},
 			).Debug("Attestation store updated")
-
-			blockRoot := bytesutil.ToBytes32(attestation.Data.BeaconBlockRoot)
-			votedBlock, err := a.beaconDB.Block(blockRoot)
-			if err != nil {
-				return err
-			}
-			reportVoteMetrics(committee[i], votedBlock)
 		}
 	}
 	return nil

--- a/beacon-chain/attestation/vote_metrics.go
+++ b/beacon-chain/attestation/vote_metrics.go
@@ -1,20 +1,11 @@
 package attestation
 
 import (
-	"strconv"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 )
 
 var (
-	validatorLastVoteGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "validators_last_vote",
-		Help: "Votes of validators, updated when there's a new attestation",
-	}, []string{
-		"validatorIndex",
-	})
 	totalAttestationSeen = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "total_seen_attestations",
 		Help: "Total number of attestations seen by the validators",
@@ -29,13 +20,3 @@ var (
 		Help: "The current size of the attestation pool",
 	})
 )
-
-func reportVoteMetrics(index uint64, block *ethpb.BeaconBlock) {
-	// Don't update vote metrics if the incoming block is nil.
-	if block == nil {
-		return
-	}
-
-	validatorLastVoteGauge.WithLabelValues(
-		"v" + strconv.Itoa(int(index))).Set(float64(block.Slot))
-}

--- a/beacon-chain/db/state_metrics.go
+++ b/beacon-chain/db/state_metrics.go
@@ -1,40 +1,14 @@
 package db
 
 import (
-	"encoding/hex"
-	"strconv"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
 var (
-	validatorBalancesGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "state_validator_balances",
-		Help: "Balances of validators, updated on epoch transition",
-	}, []string{
-		"validator",
-	})
-	validatorActivatedGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "state_validator_activated_epoch",
-		Help: "Activated epoch of validators, updated on epoch transition",
-	}, []string{
-		"validatorIndex",
-	})
-	validatorExitedGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "state_validator_exited_epoch",
-		Help: "Exited epoch of validators, updated on epoch transition",
-	}, []string{
-		"validatorIndex",
-	})
-	validatorSlashedGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "state_validator_slashed_epoch",
-		Help: "Slashed epoch of validators, updated on epoch transition",
-	}, []string{
-		"validatorIndex",
-	})
 	lastSlotGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "state_last_slot",
 		Help: "Last slot number of the processed state",
@@ -55,43 +29,42 @@ var (
 		Name: "state_active_validators",
 		Help: "Total number of active validators",
 	})
+	slashedValidatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "state_slashed_validators",
+		Help: "Total slashed validators",
+	})
+	withdrawnValidatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "state_withdrawn_validators",
+		Help: "Total withdrawn validators",
+	})
+	totalValidatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "state_total_validators",
+		Help: "All time total validators",
+	})
 )
 
 func reportStateMetrics(state *pb.BeaconState) {
 	currentEpoch := state.Slot / params.BeaconConfig().SlotsPerEpoch
-	// Validator balances
-	for i, bal := range state.Balances {
-		validatorBalancesGauge.WithLabelValues(
-			"0x" + hex.EncodeToString(state.Validators[i].PublicKey), // Validator
-		).Set(float64(bal))
-	}
 
+	// Validator counts
 	var active float64
-	for i, v := range state.Validators {
-		// Track individual Validator's activation epochs
-		validatorActivatedGauge.WithLabelValues(
-			strconv.Itoa(i), //Validator index
-		).Set(float64(v.ActivationEpoch))
-		// Track individual Validator's exited epochs
-		validatorExitedGauge.WithLabelValues(
-			strconv.Itoa(i), //Validator index
-		).Set(float64(v.ExitEpoch))
-		// Track individual Validator's slashed epochs
-		if v.Slashed {
-			validatorSlashedGauge.WithLabelValues(
-				strconv.Itoa(i), //Validator index
-			).Set(float64(v.WithdrawableEpoch - params.BeaconConfig().EpochsPerSlashingsVector))
-		} else {
-			validatorSlashedGauge.WithLabelValues(
-				strconv.Itoa(i), //Validator index
-			).Set(float64(params.BeaconConfig().FarFutureEpoch))
-		}
-		// Total number of active validators
+	var slashed float64
+	var withdrawn float64
+	for _, v := range state.Validators {
 		if v.ActivationEpoch <= currentEpoch && currentEpoch < v.ExitEpoch {
 			active++
 		}
+		if v.Slashed {
+			slashed++
+		}
+		if currentEpoch >= v.ExitEpoch {
+			withdrawn++
+		}
 	}
 	activeValidatorsGauge.Set(active)
+	slashedValidatorsGauge.Set(slashed)
+	withdrawnValidatorsGauge.Set(withdrawn)
+	totalValidatorsGauge.Set(float64(len(state.Validators)))
 
 	// Slot number
 	lastSlotGauge.Set(float64(state.Slot))

--- a/beacon-chain/db/state_metrics.go
+++ b/beacon-chain/db/state_metrics.go
@@ -4,7 +4,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 


### PR DESCRIPTION
We had a 5 metrics that scaled labels with the validator count. 
This causes a larger burden on the time series database as well as the reporting beacon node. 

I've also added metrics to show total slashed, withdrawn, active, and all time counts.