### PR TITLE
Skip empty criteria for public key instead of fail

### DIFF
--- a/beacon-chain/rpc/beacon_chain_server.go
+++ b/beacon-chain/rpc/beacon_chain_server.go
@@ -229,6 +229,11 @@ func (bs *BeaconChainServer) ListValidatorBalances(
 	}
 
 	for _, pubKey := range req.PublicKeys {
+		// Skip empty public key
+		if len(pubKey) == 0 {
+			continue
+		}
+
 		index, err := bs.beaconDB.ValidatorIndex(pubKey)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "could not retrieve validator index: %v", err)

--- a/beacon-chain/rpc/beacon_chain_server_test.go
+++ b/beacon-chain/rpc/beacon_chain_server_test.go
@@ -326,6 +326,11 @@ func TestBeaconChainServer_ListValidatorBalances(t *testing.T) {
 				{Index: 3, PublicKey: []byte{3}, Balance: 3},
 				{Index: 4, PublicKey: []byte{4}, Balance: 4}},
 			}},
+		{req: &ethpb.GetValidatorBalancesRequest{PublicKeys: [][]byte{{}}, Indices: []uint64{3, 4}}, // Public key has a blank value
+			res: &ethpb.ValidatorBalances{Balances: []*ethpb.ValidatorBalances_Balance{
+				{Index: 3, PublicKey: []byte{3}, Balance: 3},
+				{Index: 4, PublicKey: []byte{4}, Balance: 4}},
+			}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This PR skips empty public key to query validator balances instead of fair on empty public key