### PR TITLE
Add quick bls benchmark

### DIFF
--- a/shared/bls/BUILD.bazel
+++ b/shared/bls/BUILD.bazel
@@ -19,3 +19,24 @@ go_test(
     embed = [":go_default_library"],
     deps = ["//shared/bytesutil:go_default_library"],
 )
+
+# gazelle:exclude bls_benchmark_test.go
+go_test(
+    name = "go_benchmark_test",
+    size = "small",
+    srcs = ["bls_benchmark_test.go"],
+    args = [
+        "-test.bench=.",
+        "-test.benchmem",
+        "-test.v",
+    ],
+    local = True,
+    tags = [
+        "benchmark",
+        "manual",
+        "no-cache",
+    ],
+    deps = [
+        "//shared/bls:go_default_library",
+    ],
+)

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -124,6 +124,9 @@ func (s *Signature) Marshal() []byte {
 func AggregateSignatures(sigs []*Signature) *Signature {
 	var ss []*g1.Signature
 	for _, v := range sigs {
+		if v == nil {
+			continue
+		}
 		ss = append(ss, v.val)
 	}
 	return &Signature{val: g1.AggregateSignatures(ss)}

--- a/shared/bls/bls_benchmark_test.go
+++ b/shared/bls/bls_benchmark_test.go
@@ -12,8 +12,8 @@ func BenchmarkSignature_Verify(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	msg := []byte("benchmark")
-	domain := uint64(100)
+	msg := []byte("Some msg")
+	domain := uint64(42)
 	sig := sk.Sign(msg, domain)
 
 	b.ResetTimer()
@@ -26,8 +26,8 @@ func BenchmarkSignature_Verify(b *testing.B) {
 
 func BenchmarkSignature_VerifyAggregate(b *testing.B) {
 	sigN := 128 // MAX_ATTESTATIONS per block.
-	msg := []byte("benchmark")
-	domain := uint64(100)
+	msg := []byte("signed message")
+	domain := uint64(0)
 
 	var aggregated *bls.Signature
 	var pks []*bls.PublicKey

--- a/shared/bls/bls_benchmark_test.go
+++ b/shared/bls/bls_benchmark_test.go
@@ -42,7 +42,6 @@ func BenchmarkSignature_VerifyAggregate(b *testing.B) {
 	}
 
 	b.ResetTimer()
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if !aggregated.VerifyAggregate(pks, msg, domain) {
 			b.Fatal("could not verify aggregate sig")

--- a/shared/bls/bls_benchmark_test.go
+++ b/shared/bls/bls_benchmark_test.go
@@ -1,0 +1,51 @@
+package bls_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/bls"
+)
+
+func BenchmarkSignature_Verify(b *testing.B) {
+	sk, err := bls.RandKey(rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+	msg := []byte("benchmark")
+	domain := uint64(100)
+	sig := sk.Sign(msg, domain)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !sig.Verify(msg, sk.PublicKey(), domain) {
+			b.Fatal("could not verify sig")
+		}
+	}
+}
+
+func BenchmarkSignature_VerifyAggregate(b *testing.B) {
+	sigN := 128 // MAX_ATTESTATIONS per block.
+	msg := []byte("benchmark")
+	domain := uint64(100)
+
+	var aggregated *bls.Signature
+	var pks []*bls.PublicKey
+	for i := 0; i < sigN; i++ {
+		sk, err := bls.RandKey(rand.Reader)
+		if err != nil {
+			b.Fatal(err)
+		}
+		sig := sk.Sign(msg, domain)
+		aggregated = bls.AggregateSignatures([]*bls.Signature{aggregated, sig})
+		pks = append(pks, sk.PublicKey())
+	}
+
+	b.ResetTimer()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !aggregated.VerifyAggregate(pks, msg, domain) {
+			b.Fatal("could not verify aggregate sig")
+		}
+	}
+}


### PR DESCRIPTION
`bazel test //shared/bls:go_benchmark_test --test_output=streamed`
```
goos: linux
goarch: amd64
BenchmarkSignature_Verify-4                  100          18446299 ns/op          776041 B/op       2482 allocs/op
BenchmarkSignature_VerifyAggregate-4           2         854807342 ns/op        32744296 B/op      86694 allocs/op
PASS
```
18ms to verify single signature, 850ms to verify aggregate signature of 128 keys (yikes!) 

For reference, [Sigma Prime's library](https://github.com/sigp/milagro_bls) benchmarks these at ~7.3ms and ~7.5ms respectively. 