### PR TITLE
Query a roughtime server to mitigate NTP attacks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1265,7 +1265,6 @@ go_repository(
     name = "com_github_cloudflare_roughtime",
     commit = "6b7e31ac9cb2d6048096585d2e8563ee60b28f84",
     importpath = "github.com/cloudflare/roughtime",
-    vcs = "git",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1261,12 +1261,10 @@ go_repository(
     importpath = "github.com/prysmaticlabs/ethereumapis",
 )
 
-# TODO: Update this dependency after https://github.com/cloudflare/roughtime/pull/13 is merged.
 go_repository(
     name = "com_github_cloudflare_roughtime",
     commit = "6b7e31ac9cb2d6048096585d2e8563ee60b28f84",
     importpath = "github.com/cloudflare/roughtime",
-    remote = "https://github.com/kivutar/roughtime",
     vcs = "git",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1260,3 +1260,19 @@ go_repository(
     commit = "11bc5ee7ad5de4bf1380f3103eebdd40db99a666",
     importpath = "github.com/prysmaticlabs/ethereumapis",
 )
+
+# TODO: Update this dependency after https://github.com/cloudflare/roughtime/pull/13 is merged.
+go_repository(
+    name = "com_github_cloudflare_roughtime",
+    commit = "6b7e31ac9cb2d6048096585d2e8563ee60b28f84",
+    importpath = "github.com/cloudflare/roughtime",
+    remote = "https://github.com/kivutar/roughtime",
+    vcs = "git",
+)
+
+go_repository(
+    name = "com_googlesource_roughtime_roughtime_git",
+    build_file_generation = "on",
+    commit = "51f6971f5f06ec101e5fbcabe5a49477708540f3",
+    importpath = "roughtime.googlesource.com/roughtime.git",
+)

--- a/shared/roughtime/BUILD.bazel
+++ b/shared/roughtime/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["roughtime.go"],
+    importpath = "github.com/prysmaticlabs/prysm/shared/roughtime",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_cloudflare_roughtime//:go_default_library",
+        "@com_googlesource_roughtime_roughtime_git//go/config:go_default_library",
+    ],
+)

--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -1,0 +1,69 @@
+// Copyright 2016 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+// Package roughtime is a wrapper for a roughtime clock source
+package roughtime
+
+import (
+	"fmt"
+	"time"
+	"encoding/base64"
+
+	"github.com/cloudflare/roughtime"
+	"roughtime.googlesource.com/roughtime.git/go/config"
+)
+
+// offset is the difference between the system time and the time returned by
+// the roughtime server
+var offset time.Duration
+
+func init() {
+	pk, err := base64.StdEncoding.DecodeString("gD63hSj3ScS+wuOeGrubXlq35N1c5Lby/S+T7MNTjxo=")
+	if err != nil {
+		panic(err)
+	}
+
+	server := &config.Server{
+		Name:          "",
+		PublicKeyType: "ed25519",
+		PublicKey:     pk,
+		Addresses: []config.ServerAddress{
+			config.ServerAddress{
+				Protocol: "udp",
+				Address:  "roughtime.cloudflare.com:2002",
+			},
+		},
+	}
+
+	rt, err := roughtime.Get(server, roughtime.DefaultQueryAttempts, roughtime.DefaultQueryTimeout, nil)
+	if err != nil {
+		panic(err)
+	}
+	rtTime, _ := rt.Now()
+	offset = rtTime.Sub(time.Now())
+	fmt.Println("init:", time.Now(), rtTime, offset)
+}
+
+// Since returns the duration since t, based on the roughtime response
+func Since(t time.Time) time.Duration {
+	fmt.Println("since:", time.Now(), time.Now().Add(offset), time.Now().Add(offset).Sub(t))
+	return time.Now().Add(offset).Sub(t)
+}
+
+// Until returns the duration until t, based on the roughtime response
+func Until(t time.Time) time.Duration {
+	return t.Sub(time.Now().Add(offset))
+}

--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -28,7 +28,7 @@ func init() {
 	// A list of reliable roughtime servers with their public keys.
 	// From https://github.com/cloudflare/roughtime/blob/master/ecosystem.json
 	servers := []config.Server{
-		config.Server{
+		{
 			Name:          "Caesium",
 			PublicKeyType: "ed25519",
 			PublicKey:     mustDecodeString("iBVjxg/1j7y1+kQUTBYdTabxCppesU/07D4PMDJk2WA="),
@@ -39,7 +39,7 @@ func init() {
 				},
 			},
 		},
-		config.Server{
+		{
 			Name:          "Chainpoint-Roughtime",
 			PublicKeyType: "ed25519",
 			PublicKey:     mustDecodeString("bbT+RPS7zKX6w71ssPibzmwWqU9ffRV5oj2OresSmhE="),
@@ -50,7 +50,7 @@ func init() {
 				},
 			},
 		},
-		config.Server{
+		{
 			Name:          "Cloudflare-Roughtime",
 			PublicKeyType: "ed25519",
 			PublicKey:     mustDecodeString("gD63hSj3ScS+wuOeGrubXlq35N1c5Lby/S+T7MNTjxo="),

--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -18,7 +18,6 @@
 package roughtime
 
 import (
-	"fmt"
 	"time"
 	"encoding/base64"
 
@@ -54,12 +53,10 @@ func init() {
 	}
 	rtTime, _ := rt.Now()
 	offset = rtTime.Sub(time.Now())
-	fmt.Println("init:", time.Now(), rtTime, offset)
 }
 
 // Since returns the duration since t, based on the roughtime response
 func Since(t time.Time) time.Duration {
-	fmt.Println("since:", time.Now(), time.Now().Add(offset), time.Now().Add(offset).Sub(t))
 	return time.Now().Add(offset).Sub(t)
 }
 

--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -1,25 +1,9 @@
-// Copyright 2016 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
-
 // Package roughtime is a wrapper for a roughtime clock source
 package roughtime
 
 import (
-	"time"
 	"encoding/base64"
+	"time"
 
 	"github.com/cloudflare/roughtime"
 	"roughtime.googlesource.com/roughtime.git/go/config"

--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -14,6 +14,8 @@ import (
 var offset time.Duration
 
 func init() {
+	// This is the public key used to check roughtime.cloudflare.com:2002 responses
+	// See https://github.com/cloudflare/roughtime/blob/master/README.md
 	pk, err := base64.StdEncoding.DecodeString("gD63hSj3ScS+wuOeGrubXlq35N1c5Lby/S+T7MNTjxo=")
 	if err != nil {
 		panic(err)

--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -24,7 +24,7 @@ func init() {
 		PublicKeyType: "ed25519",
 		PublicKey:     pk,
 		Addresses: []config.ServerAddress{
-			config.ServerAddress{
+			{
 				Protocol: "udp",
 				Address:  "roughtime.cloudflare.com:2002",
 			},

--- a/shared/slotutil/BUILD.bazel
+++ b/shared/slotutil/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["slotticker.go"],
     importpath = "github.com/prysmaticlabs/prysm/shared/slotutil",
     visibility = ["//visibility:public"],
+    deps = ["//shared/roughtime:go_default_library"],
 )
 
 go_test(

--- a/shared/slotutil/slotticker.go
+++ b/shared/slotutil/slotticker.go
@@ -2,6 +2,8 @@ package slotutil
 
 import (
 	"time"
+
+	"github.com/prysmaticlabs/prysm/shared/roughtime"
 )
 
 // SlotTicker is a special ticker for the beacon chain block.
@@ -34,7 +36,7 @@ func GetSlotTicker(genesisTime time.Time, secondsPerSlot uint64) *SlotTicker {
 		c:    make(chan uint64),
 		done: make(chan struct{}),
 	}
-	ticker.start(genesisTime, secondsPerSlot, time.Since, time.Until, time.After)
+	ticker.start(genesisTime, secondsPerSlot, roughtime.Since, roughtime.Until, time.After)
 	return ticker
 }
 


### PR DESCRIPTION
Part of #2834

---

# Description

NTP (network time protocol) responses are insecure and may be subject to MITM attacks.

This PR introduces roughtime which provide secure time synchronisation. We query the time server only once during the package init and panic if the query failed. Roughtime is now used in the validator, but could be used in more contexts.

See https://www.cloudflare.com/time/
