### PR TITLE
Update BLS with @protolambda's improvements

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -991,8 +991,10 @@ go_repository(
 
 go_repository(
     name = "com_github_phoreproject_bls",
-    commit = "b495094dc72c7043b549f511a798391201624b14",
+    commit = "c5146d944578a777ce791f889b36584d82413a10",
     importpath = "github.com/phoreproject/bls",
+    remote = "https://github.com/protolambda/bls",
+    vcs = "git",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -991,10 +991,8 @@ go_repository(
 
 go_repository(
     name = "com_github_phoreproject_bls",
-    commit = "c5146d944578a777ce791f889b36584d82413a10",
+    commit = "fb0e03c433000562a8f27e0e820667fd6c13d62b",
     importpath = "github.com/phoreproject/bls",
-    remote = "https://github.com/protolambda/bls",
-    vcs = "git",
 )
 
 go_repository(

--- a/shared/bls/spectest/g2_compressed_test.go
+++ b/shared/bls/spectest/g2_compressed_test.go
@@ -2,6 +2,7 @@ package spectest
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
@@ -25,10 +26,12 @@ func TestG2CompressedHash(t *testing.T) {
 
 	for i, tt := range test.TestCases {
 		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			b := make([]byte, 8)
+			binary.BigEndian.PutUint64(b, tt.Input.Domain)
 
 			projective := bls.HashG2WithDomain(
 				bytesutil.ToBytes32(tt.Input.Message),
-				tt.Input.Domain,
+				bytesutil.ToBytes8(b),
 			)
 			hash := bls.CompressG2(projective.ToAffine())
 

--- a/shared/bls/spectest/g2_uncompressed_test.go
+++ b/shared/bls/spectest/g2_uncompressed_test.go
@@ -2,6 +2,7 @@ package spectest
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"testing"
 
@@ -26,9 +27,12 @@ func TestG2UncompressedHash(t *testing.T) {
 
 	for i, tt := range test.TestCases {
 		t.Run(fmt.Sprintf("Test %d", i), func(t *testing.T) {
+			b := make([]byte, 8)
+			binary.BigEndian.PutUint64(b, tt.Input.Domain)
+
 			projective := bls.HashG2WithDomain(
 				bytesutil.ToBytes32(tt.Input.Message),
-				tt.Input.Domain,
+				bytesutil.ToBytes8(b),
 			)
 			hash := projective.ToAffine().SerializeBytes()
 

--- a/shared/bytesutil/bytes.go
+++ b/shared/bytesutil/bytes.go
@@ -86,6 +86,15 @@ func LowerThan(x []byte, y []byte) bool {
 	return true
 }
 
+// ToBytes8 is a convenience method for converting a byte slice to a fix
+// sized 8 byte array. This method will truncate the input if it is larger
+// than 8 bytes.
+func ToBytes8(x []byte) [8]byte {
+	var y [8]byte
+	copy(y[:], x)
+	return y
+}
+
 // ToBytes32 is a convenience method for converting a byte slice to a fix
 // sized 32 byte array. This method will truncate the input if it is larger
 // than 32 bytes.


### PR DESCRIPTION
WIP until https://github.com/phoreproject/bls/pull/11

There are some API changes that need to be improved as well. We're doing unnecessary domain conversions now that the underlying library expects `[8]byte` instead of `uint64`.

Tasks: 
- [x] Update WORKSPACE after https://github.com/phoreproject/bls/pull/11 is merged
- [ ] Update API to accept [8]byte
- [ ] Update domain constants to be [8]byte instead of []byte

Opening this early to test deployment performance and track in progress work. 