### PR TITLE
Benchmark active indices

### DIFF
--- a/beacon-chain/cache/benchmarks_test.go
+++ b/beacon-chain/cache/benchmarks_test.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"testing"
+)
+
+var aInfo300K, _ = createIndices(300000)
+var aInfo1M, _ = createIndices(1000000)
+var epoch = uint64(1)
+var _, treeIndices300K = createIndices(300000)
+
+func createIndices(count int) (*ActiveIndicesByEpoch, []uint64) {
+	indices := make([]uint64, 0, count)
+	for i := 0; i < count; i++ {
+		indices = append(indices, uint64(i))
+	}
+	return &ActiveIndicesByEpoch{
+		Epoch:         epoch,
+		ActiveIndices: indices,
+	}, indices
+}
+
+func BenchmarkCachingAddRetrieve(b *testing.B) {
+
+	c := NewActiveIndicesCache()
+
+	b.Run("ADD300K", func(b *testing.B) {
+		b.N = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := c.AddActiveIndicesList(aInfo300K); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("RETR300K", func(b *testing.B) {
+		b.N = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := c.ActiveIndicesInEpoch(epoch); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+}
+
+func BenchmarkTreeAddRetrieve(b *testing.B) {
+	t := NewActiveIndicesTree()
+
+	b.Run("TREEADD300K", func(b *testing.B) {
+		b.N = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			t.InsertReplaceActiveIndicesTree(treeIndices300K)
+		}
+	})
+
+	b.Run("RETRTREE300K", func(b *testing.B) {
+		b.N = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := t.RetrieveActiveIndicesTree(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("TREEADDNOREPL300K", func(b *testing.B) {
+		b.N = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			t.InsertNoReplaceActiveIndicesTree(treeIndices300K)
+		}
+	})
+
+	b.Run("RETRTREE300K", func(b *testing.B) {
+		b.N = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if _, err := t.RetrieveActiveIndicesTree(); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/beacon-chain/cache/benchmarks_test.go
+++ b/beacon-chain/cache/benchmarks_test.go
@@ -88,7 +88,6 @@ func BenchmarkTreeAddRetrieve(b *testing.B) {
 	})
 }
 
-
 func BenchmarkBloomFilter(b *testing.B) {
 	bf := NewBloomFilter()
 
@@ -112,7 +111,32 @@ func BenchmarkBloomFilter(b *testing.B) {
 		}
 		bf.ClearBloomFilter()
 	})
-
-
-
 }
+
+// think about delete func (cf *CFilter) Delete(item []byte) bool {
+func BenchmarkCFilter(b *testing.B) {
+	cf := NewCFilter()
+
+
+	b.Run("CFILTERADD300K", func(b *testing.B) {
+		b.N = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			cf.InsertActiveIndicesCFilter(byteIndices300k)
+		}
+	})
+
+
+	b.Run("CFILTERLOOKUP300K", func(b *testing.B) {
+		b.N = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if !cf.LookupActiveIndicesCFilter(byteIndices300k) {
+				break;
+			}
+		}
+		// think about delete func (cf *CFilter) Delete(item []byte) bool {
+	})
+}
+
+

--- a/beacon-chain/cache/benchmarks_test.go
+++ b/beacon-chain/cache/benchmarks_test.go
@@ -113,7 +113,6 @@ func BenchmarkBloomFilter(b *testing.B) {
 	})
 }
 
-// think about delete func (cf *CFilter) Delete(item []byte) bool {
 func BenchmarkCFilter(b *testing.B) {
 	cf := NewCFilter()
 
@@ -135,7 +134,6 @@ func BenchmarkCFilter(b *testing.B) {
 				break;
 			}
 		}
-		// think about delete func (cf *CFilter) Delete(item []byte) bool {
 	})
 }
 

--- a/beacon-chain/cache/benchmarks_test.go
+++ b/beacon-chain/cache/benchmarks_test.go
@@ -4,12 +4,10 @@ import (
 	"testing"
 )
 
-var aInfo300K, _ = createIndices(300000)
-var aInfo1M, _ = createIndices(1000000)
+var indices300k, _ = createIndices(300000)
 var epoch = uint64(1)
 var _, treeIndices300K = createIndices(300000)
-var byteIndices300k = convertUint64ToByteSlice(treeIndices300K);
-
+var byteIndices300k = convertUint64ToByteSlice(treeIndices300K)
 
 func createIndices(count int) (*ActiveIndicesByEpoch, []uint64) {
 	indices := make([]uint64, 0, count)
@@ -30,7 +28,7 @@ func BenchmarkCachingAddRetrieve(b *testing.B) {
 		b.N = 10
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			if err := c.AddActiveIndicesList(aInfo300K); err != nil {
+			if err := c.AddActiveIndicesList(indices300k); err != nil {
 				b.Fatal(err)
 			}
 		}
@@ -91,7 +89,6 @@ func BenchmarkTreeAddRetrieve(b *testing.B) {
 func BenchmarkBloomFilter(b *testing.B) {
 	bf := NewBloomFilter()
 
-
 	b.Run("BLOOMADD300K", func(b *testing.B) {
 		b.N = 10
 		b.ResetTimer()
@@ -100,13 +97,12 @@ func BenchmarkBloomFilter(b *testing.B) {
 		}
 	})
 
-
 	b.Run("BLOOMTEST300K", func(b *testing.B) {
 		b.N = 10
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			if !bf.TestActiveIndicesBloomFilter(byteIndices300k) {
-				break;
+				break
 			}
 		}
 		bf.ClearBloomFilter()
@@ -116,7 +112,6 @@ func BenchmarkBloomFilter(b *testing.B) {
 func BenchmarkCFilter(b *testing.B) {
 	cf := NewCFilter()
 
-
 	b.Run("CFILTERADD300K", func(b *testing.B) {
 		b.N = 10
 		b.ResetTimer()
@@ -125,16 +120,13 @@ func BenchmarkCFilter(b *testing.B) {
 		}
 	})
 
-
 	b.Run("CFILTERLOOKUP300K", func(b *testing.B) {
 		b.N = 10
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			if !cf.LookupActiveIndicesCFilter(byteIndices300k) {
-				break;
+				break
 			}
 		}
 	})
 }
-
-

--- a/beacon-chain/cache/benchmarks_test.go
+++ b/beacon-chain/cache/benchmarks_test.go
@@ -8,6 +8,8 @@ var aInfo300K, _ = createIndices(300000)
 var aInfo1M, _ = createIndices(1000000)
 var epoch = uint64(1)
 var _, treeIndices300K = createIndices(300000)
+var byteIndices300k = convertUint64ToByteSlice(treeIndices300K);
+
 
 func createIndices(count int) (*ActiveIndicesByEpoch, []uint64) {
 	indices := make([]uint64, 0, count)
@@ -84,4 +86,33 @@ func BenchmarkTreeAddRetrieve(b *testing.B) {
 			}
 		}
 	})
+}
+
+
+func BenchmarkBloomFilter(b *testing.B) {
+	bf := NewBloomFilter()
+
+
+	b.Run("BLOOMADD300K", func(b *testing.B) {
+		b.N = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			bf.AddActiveIndicesBloomFilter(byteIndices300k)
+		}
+	})
+
+
+	b.Run("BLOOMTEST300K", func(b *testing.B) {
+		b.N = 10
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if !bf.TestActiveIndicesBloomFilter(byteIndices300k) {
+				break;
+			}
+		}
+		bf.ClearBloomFilter()
+	})
+
+
+
 }

--- a/beacon-chain/cache/bloom_filter.go
+++ b/beacon-chain/cache/bloom_filter.go
@@ -1,18 +1,18 @@
 package cache
 
 import (
-	"sync"
 	"encoding/binary"
-	
+	"sync"
+
 	"github.com/willf/bloom"
 )
 
 // ActiveIndicesBloomFilter defines BloomFilter for storing and twsting of active indices
-// Bloom Filter is a space-efficient probabilistic data structure 
+// Bloom Filter is a space-efficient probabilistic data structure
 // that is used to test whether an element is a member of a set
 type ActiveIndicesBloomFilter struct {
 	filter *bloom.BloomFilter
-	lock sync.RWMutex
+	lock   sync.RWMutex
 }
 
 // A Bloom filter has two parameters: m - maximum size, k -the number of hashing functions on elements of the set
@@ -23,11 +23,11 @@ const (
 
 // NewBloomFiltercreates a new Bloom Filter for storing and testing active indices
 func NewBloomFilter() *ActiveIndicesBloomFilter {
-	return &ActiveIndicesBloomFilter{filter : bloom.New(m, k)}
+	return &ActiveIndicesBloomFilter{filter: bloom.New(m, k)}
 }
 
 // AddActiveIndicesBloomFilter adds a byte representation of active indices to a bloom filter
-func (bf *ActiveIndicesBloomFilter) AddActiveIndicesBloomFilter(byteIndices [][]byte)  {
+func (bf *ActiveIndicesBloomFilter) AddActiveIndicesBloomFilter(byteIndices [][]byte) {
 	bf.lock.Lock()
 	defer bf.lock.Unlock()
 	for _, i := range byteIndices {
@@ -48,7 +48,7 @@ func (bf *ActiveIndicesBloomFilter) TestActiveIndicesBloomFilter(byteIndices [][
 }
 
 // ClearBloomFilter clears keys of bloom filter
-func (bf *ActiveIndicesBloomFilter) ClearBloomFilter()  {
+func (bf *ActiveIndicesBloomFilter) ClearBloomFilter() {
 	bf.filter = bf.filter.ClearAll()
 }
 
@@ -56,27 +56,9 @@ func (bf *ActiveIndicesBloomFilter) ClearBloomFilter()  {
 func convertUint64ToByteSlice(activeIndices []uint64) [][]byte {
 	byteIndices := make([][]byte, 0, len(activeIndices))
 	for _, i := range activeIndices {
-		n1 := make([]byte,8)
-		binary.BigEndian.PutUint64(n1,i)
+		n1 := make([]byte, 8)
+		binary.BigEndian.PutUint64(n1, i)
 		byteIndices = append(byteIndices, n1)
 	}
 	return byteIndices
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/beacon-chain/cache/bloom_filter.go
+++ b/beacon-chain/cache/bloom_filter.go
@@ -1,0 +1,77 @@
+package cache
+
+import (
+	"sync"
+	"encoding/binary"
+	
+	"github.com/willf/bloom"
+)
+
+
+type ActiveIndicesBloomFilter struct {
+	filter *bloom.BloomFilter
+	lock sync.RWMutex
+}
+
+const (
+	m = 300000
+	k = 5
+)
+
+
+func NewBloomFilter() *ActiveIndicesBloomFilter {
+	return &ActiveIndicesBloomFilter{filter : bloom.New(m, k)}
+}
+
+
+func (bf *ActiveIndicesBloomFilter) AddActiveIndicesBloomFilter(byteIndices [][]byte)  {
+	bf.lock.Lock()
+	defer bf.lock.Unlock()
+	for _, i := range byteIndices {
+		bf.filter.Add(i)
+	}
+}
+
+
+func (bf *ActiveIndicesBloomFilter) TestActiveIndicesBloomFilter(byteIndices [][]byte) bool {
+	bf.lock.Lock()
+	defer bf.lock.Unlock()
+	for _, i := range byteIndices {
+		if !bf.filter.Test(i) {
+			return false
+		}
+	}
+	return true
+}
+
+func (bf *ActiveIndicesBloomFilter) ClearBloomFilter()  {
+	bf.filter = bf.filter.ClearAll()
+}
+
+func convertUint64ToByteSlice(activeIndices []uint64) [][]byte {
+	byteIndices := make([][]byte, 0, len(activeIndices))
+	for _, i := range activeIndices {
+		n1 := make([]byte,8)
+		binary.BigEndian.PutUint64(n1,i)
+		byteIndices = append(byteIndices, n1)
+	}
+	return byteIndices
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/beacon-chain/cache/bloom_filter.go
+++ b/beacon-chain/cache/bloom_filter.go
@@ -7,23 +7,26 @@ import (
 	"github.com/willf/bloom"
 )
 
-
+// ActiveIndicesBloomFilter defines BloomFilter for storing and twsting of active indices
+// Bloom Filter is a space-efficient probabilistic data structure 
+// that is used to test whether an element is a member of a set
 type ActiveIndicesBloomFilter struct {
 	filter *bloom.BloomFilter
 	lock sync.RWMutex
 }
 
+// A Bloom filter has two parameters: m - maximum size, k -the number of hashing functions on elements of the set
 const (
 	m = 300000
 	k = 5
 )
 
-
+// NewBloomFiltercreates a new Bloom Filter for storing and testing active indices
 func NewBloomFilter() *ActiveIndicesBloomFilter {
 	return &ActiveIndicesBloomFilter{filter : bloom.New(m, k)}
 }
 
-
+// AddActiveIndicesBloomFilter adds a byte representation of active indices to a bloom filter
 func (bf *ActiveIndicesBloomFilter) AddActiveIndicesBloomFilter(byteIndices [][]byte)  {
 	bf.lock.Lock()
 	defer bf.lock.Unlock()
@@ -32,7 +35,7 @@ func (bf *ActiveIndicesBloomFilter) AddActiveIndicesBloomFilter(byteIndices [][]
 	}
 }
 
-
+// TestActiveIndicesBloomFilter tests makes a membership check if active indices are in bloom filter
 func (bf *ActiveIndicesBloomFilter) TestActiveIndicesBloomFilter(byteIndices [][]byte) bool {
 	bf.lock.Lock()
 	defer bf.lock.Unlock()
@@ -44,10 +47,12 @@ func (bf *ActiveIndicesBloomFilter) TestActiveIndicesBloomFilter(byteIndices [][
 	return true
 }
 
+// ClearBloomFilter clears keys of bloom filter
 func (bf *ActiveIndicesBloomFilter) ClearBloomFilter()  {
 	bf.filter = bf.filter.ClearAll()
 }
 
+// convertUint64ToByteSlice converts active indices to a byte representation
 func convertUint64ToByteSlice(activeIndices []uint64) [][]byte {
 	byteIndices := make([][]byte, 0, len(activeIndices))
 	for _, i := range activeIndices {

--- a/beacon-chain/cache/cfilter.go
+++ b/beacon-chain/cache/cfilter.go
@@ -2,7 +2,7 @@ package cache
 
 import (
 	"sync"
-	
+
 	"github.com/irfansharif/cfilter"
 )
 
@@ -10,16 +10,16 @@ import (
 // Cuckoo filter is a Bloom filter replacement for approximated set-membership queries. Cuckoo filters support adding and removing items dynamically while achieving even higher performance than Bloom filters
 type ActiveIndicesCFilter struct {
 	filter *cfilter.CFilter
-	lock sync.RWMutex
+	lock   sync.RWMutex
 }
 
 // NewCFilter a new cuckoo filter for storing and lookup active indices
 func NewCFilter() *ActiveIndicesCFilter {
-	return &ActiveIndicesCFilter{filter : cfilter.New()}
+	return &ActiveIndicesCFilter{filter: cfilter.New()}
 }
 
 // InsertActiveIndicesCFilter adds a byte representation of active indices to a cuckoo filter
-func (cf *ActiveIndicesCFilter) InsertActiveIndicesCFilter(byteIndices [][]byte)  {
+func (cf *ActiveIndicesCFilter) InsertActiveIndicesCFilter(byteIndices [][]byte) {
 	cf.lock.Lock()
 	defer cf.lock.Unlock()
 	for _, i := range byteIndices {
@@ -38,7 +38,3 @@ func (cf *ActiveIndicesCFilter) LookupActiveIndicesCFilter(byteIndices [][]byte)
 	}
 	return true
 }
-
-
-
-

--- a/beacon-chain/cache/cfilter.go
+++ b/beacon-chain/cache/cfilter.go
@@ -6,20 +6,19 @@ import (
 	"github.com/irfansharif/cfilter"
 )
 
-
+// ActiveIndicesCFilter defines cuckoo Filter for storing and lookup of active indices
+// Cuckoo filter is a Bloom filter replacement for approximated set-membership queries. Cuckoo filters support adding and removing items dynamically while achieving even higher performance than Bloom filters
 type ActiveIndicesCFilter struct {
 	filter *cfilter.CFilter
 	lock sync.RWMutex
 }
 
-
-
-
+// NewCFilter a new cuckoo filter for storing and lookup active indices
 func NewCFilter() *ActiveIndicesCFilter {
 	return &ActiveIndicesCFilter{filter : cfilter.New()}
 }
 
-
+// InsertActiveIndicesCFilter adds a byte representation of active indices to a cuckoo filter
 func (cf *ActiveIndicesCFilter) InsertActiveIndicesCFilter(byteIndices [][]byte)  {
 	cf.lock.Lock()
 	defer cf.lock.Unlock()
@@ -28,7 +27,7 @@ func (cf *ActiveIndicesCFilter) InsertActiveIndicesCFilter(byteIndices [][]byte)
 	}
 }
 
-// think about delete func (cf *CFilter) Delete(item []byte) bool { insteaf of lookup
+// LookupActiveIndicesCFilter makes a membership check if active indices are in cuckoo filter
 func (cf *ActiveIndicesCFilter) LookupActiveIndicesCFilter(byteIndices [][]byte) bool {
 	cf.lock.Lock()
 	defer cf.lock.Unlock()

--- a/beacon-chain/cache/cfilter.go
+++ b/beacon-chain/cache/cfilter.go
@@ -1,0 +1,45 @@
+package cache
+
+import (
+	"sync"
+	
+	"github.com/irfansharif/cfilter"
+)
+
+
+type ActiveIndicesCFilter struct {
+	filter *cfilter.CFilter
+	lock sync.RWMutex
+}
+
+
+
+
+func NewCFilter() *ActiveIndicesCFilter {
+	return &ActiveIndicesCFilter{filter : cfilter.New()}
+}
+
+
+func (cf *ActiveIndicesCFilter) InsertActiveIndicesCFilter(byteIndices [][]byte)  {
+	cf.lock.Lock()
+	defer cf.lock.Unlock()
+	for _, i := range byteIndices {
+		cf.filter.Insert(i)
+	}
+}
+
+// think about delete func (cf *CFilter) Delete(item []byte) bool { insteaf of lookup
+func (cf *ActiveIndicesCFilter) LookupActiveIndicesCFilter(byteIndices [][]byte) bool {
+	cf.lock.Lock()
+	defer cf.lock.Unlock()
+	for _, i := range byteIndices {
+		if !cf.filter.Lookup(i) {
+			return false
+		}
+	}
+	return true
+}
+
+
+
+

--- a/beacon-chain/cache/tree.go
+++ b/beacon-chain/cache/tree.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/petar/GoLLRB/llrb"
 )
+
 // ActiveIndicesTree defines active validator indices in LLRB tree
 type ActiveIndicesTree struct {
 	tree *llrb.LLRB

--- a/beacon-chain/cache/tree.go
+++ b/beacon-chain/cache/tree.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/petar/GoLLRB/llrb"
 )
-
+// ActiveIndicesTree defines active validator indices in LLRB tree
 type ActiveIndicesTree struct {
 	tree *llrb.LLRB
 	lock sync.RWMutex

--- a/beacon-chain/cache/tree.go
+++ b/beacon-chain/cache/tree.go
@@ -1,0 +1,61 @@
+package cache
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/petar/GoLLRB/llrb"
+)
+
+type ActiveIndicesTree struct {
+	tree *llrb.LLRB
+	lock sync.RWMutex
+}
+
+func NewActiveIndicesTree() *ActiveIndicesTree {
+	return &ActiveIndicesTree{tree: llrb.New()}
+}
+
+type index uint64
+
+func (i index) Less(than llrb.Item) bool {
+	return i < than.(index)
+}
+
+//InsertNoReplaceActiveIndicesTree inserts items in Left-Leaning Red-Black (LLRB) tree
+//  If an element has the same order, both elements remain in the tree.
+func (t *ActiveIndicesTree) InsertNoReplaceActiveIndicesTree(activeIndices []uint64) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	for _, i := range activeIndices {
+		t.tree.InsertNoReplace(index(i))
+	}
+}
+
+// InsertReplaceActiveIndicesTree inserts items into Left-Leaning Red-Black (LLRB) tree. If an
+// element has the same order, it is removed from the tree.
+func (t *ActiveIndicesTree) InsertReplaceActiveIndicesTree(activeIndices []uint64) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+	for _, i := range activeIndices {
+		t.tree.ReplaceOrInsert(index(i))
+	}
+}
+
+//RetrieveActiveIndicesTree retrieves all items from a Left-Leaning Red-Black (LLRB) tree and returns them
+func (t *ActiveIndicesTree) RetrieveActiveIndicesTree() ([]uint64, error) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	retrievedIndices := make([]uint64, 0, t.tree.Len())
+	t.tree.AscendGreaterOrEqual(index(0), func(i llrb.Item) bool {
+		item := i.(index)
+		retrievedIndices = append(retrievedIndices, uint64(item))
+		return true
+	})
+	if len(retrievedIndices) == 0 {
+		return nil, errors.New("retrievedIndices are empty")
+	}
+	return retrievedIndices, nil
+
+}

--- a/beacon-chain/cache/tree_test.go
+++ b/beacon-chain/cache/tree_test.go
@@ -1,0 +1,99 @@
+package cache
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/petar/GoLLRB/llrb"
+)
+
+func TestInsertNoReplaceActiveIndicesTree(t *testing.T) {
+	activeIndicesTree := NewActiveIndicesTree()
+	activeIndices := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+
+	activeIndicesTree.InsertNoReplaceActiveIndicesTree(activeIndices)
+
+	i := 1
+	activeIndicesTree.tree.AscendGreaterOrEqual(index(1),
+		func(item llrb.Item) bool {
+			if item.(index) != index(i) {
+				t.Errorf("bad order: got %d, expect %d", item.(index), index(i))
+			}
+			i++
+			return true
+		})
+
+	if activeIndicesTree.tree.Len() != 10 {
+		t.Errorf("Wanted: %v, got: %v", 10, activeIndicesTree.tree.Len())
+	}
+
+	activeIndicesTree.InsertNoReplaceActiveIndicesTree(activeIndices)
+
+	if activeIndicesTree.tree.Len() != 20 {
+		t.Errorf("Wanted: %v, got: %v", 20, activeIndicesTree.tree.Len())
+	}
+
+}
+
+func TestInsertReplaceActiveIndicesTree(t *testing.T) {
+	activeIndicesTree := NewActiveIndicesTree()
+	activeIndices := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+
+	activeIndicesTree.InsertReplaceActiveIndicesTree(activeIndices)
+
+	if activeIndicesTree.tree.Len() != 10 {
+		t.Errorf("Wanted: %v, got: %v", 10, activeIndicesTree.tree.Len())
+	}
+
+	activeIndicesTree.InsertReplaceActiveIndicesTree(activeIndices)
+
+	if activeIndicesTree.tree.Len() != 10 {
+		t.Errorf("Wanted: %v, got: %v", 10, activeIndicesTree.tree.Len())
+	}
+
+	i := 1
+	activeIndicesTree.tree.AscendGreaterOrEqual(index(1),
+		func(item llrb.Item) bool {
+			if item.(index) != index(i) {
+				t.Errorf("bad order: got %d, expect %d", item.(index), index(i))
+			}
+			i++
+			return true
+		})
+
+}
+
+func TestRetrieveActiveIndicesTree(t *testing.T) {
+
+	var ErrRetrievedIndicesEmpty = errors.New("retrievedIndices are empty")
+	activeIndicesTree := NewActiveIndicesTree()
+	activeIndices := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+
+	activeIndicesTree.InsertReplaceActiveIndicesTree(activeIndices)
+
+	retrievedIndices, err := activeIndicesTree.RetrieveActiveIndicesTree()
+	if err != nil {
+		t.Errorf("No error expected")
+	}
+	if !reflect.DeepEqual(activeIndices, retrievedIndices) {
+		t.Errorf("Wrong retrieved indices received")
+	}
+
+	for i := uint64(1); i < 11; i++ {
+		activeIndicesTree.tree.Delete(index(i))
+	}
+
+	if activeIndicesTree.tree.Len() != 0 {
+		t.Errorf("Wanted: %v, got: %v", 0, activeIndicesTree.tree.Len())
+	}
+
+	retrievedIndices, err = activeIndicesTree.RetrieveActiveIndicesTree()
+	if retrievedIndices != nil {
+		t.Errorf("retrievedIndices expected to be nil")
+	}
+	if !reflect.DeepEqual(err, ErrRetrievedIndicesEmpty) {
+		t.Errorf("Wanted: %v, got: %v", ErrRetrievedIndicesEmpty, err)
+	}
+
+}


### PR DESCRIPTION
|Resolves] #2740
[Part of] #3055

This PR adds 5 files:

1. beacon-chain/cache/tree.go that contains methods to insert and retrieve items from Left-Leaning Red-Black (LLRB) tree 

2. beacon-chain/cache/tree_test.go has methods for testing LLRB tree 

3.beacon-chain/cache/bloom_filter.go  has methods to add and make membership checks for active indices in a bloom filter. Bloom Filter is a space-efficient probabilistic data structure
that is used to test whether an element is a member of a set. 

4. beacon-chain/cache/cfilter.go has for storing and lookup of active indices for cuckoo filter.
Cuckoo filter is a Bloom filter replacement for approximated set-membership queries. Cuckoo filters support adding and removing items dynamically while achieving even higher performance than Bloom filters.

5.beacon-chain/cache/benchmarks_test.go has benchmarks for current, LLRB implementation, bloom and cuckoo filters.

**Benchmark results:**

- Current implementation:

BenchmarkCachingAddRetrieve/ADD300K-3 10 504 ns/op 16 B/op 1 allocs/op
BenchmarkCachingAddRetrieve/RETR300K-3 10 224 ns/op 0 B/op 0 allocs/op

- LLRB tree

BenchmarkTreeAddRetrieve/TREEADD300K-3 10 347157294 ns/op 3839993 B/op 329999 allocs/op
BenchmarkTreeAddRetrieve/RETRTREE300K-3 10 14174378 ns/op 2400256 B/op 1 allocs/op
BenchmarkTreeAddRetrieve/TREEADDNOREPL300K-3 10 593535169 ns/op 31199995 B/op 899999 allocs/op
BenchmarkTreeAddRetrieve/RETRTREE300K#01-3 10 201188730 ns/op 50405376 B/op 1 allocs/op

- Bloom filter 

BenchmarkBloomFilter/BLOOMADD300K-3         	      10	 108189202 ns/op	29100064 B/op	  600000 allocs/op
BenchmarkBloomFilter/BLOOMTEST300K-3        	      10	       440 ns/op	      11 B/op	       0 allocs/op

- Cuckoo filter

BenchmarkCFilter/CFILTERADD300K-3         	      10	11617697675 ns/op	 4800000 B/op	  600000 allocs/op
BenchmarkCFilter/CFILTERLOOKUP300K-3      	      10	      2255 ns/op	     152 B/op	      19 allocs/op

Conclusion : current implementation is the most efficient.
