### PR TITLE
Use size `SlotsPerHistoricalRoot` for block and state roots

### DIFF
--- a/beacon-chain/blockchain/fork_choice_reorg_test.go
+++ b/beacon-chain/blockchain/fork_choice_reorg_test.go
@@ -40,7 +40,7 @@ func TestApplyForkChoice_ChainSplitReorg(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Can't generate genesis state: %v", err)
 	}
-	justifiedState.StateRoots = make([][]byte, params.BeaconConfig().HistoricalRootsLimit)
+	justifiedState.StateRoots = make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
 	justifiedState.LatestBlockHeader = &ethpb.BeaconBlockHeader{
 		StateRoot: []byte{},
 	}

--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -1546,7 +1546,7 @@ func setupFFGTest(t *testing.T) ([32]byte, *ethpb.BeaconBlock, *pb.BeaconState, 
 	}
 	gState := &pb.BeaconState{
 		Slot:              genesisSlot,
-		BlockRoots:        make([][]byte, params.BeaconConfig().HistoricalRootsLimit),
+		BlockRoots:        make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot),
 		RandaoMixes:       latestRandaoMixes,
 		ActiveIndexRoots:  make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 		Slashings:         make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector),

--- a/beacon-chain/core/helpers/block_test.go
+++ b/beacon-chain/core/helpers/block_test.go
@@ -12,7 +12,7 @@ import (
 func TestBlockRootAtSlot_CorrectBlockRoot(t *testing.T) {
 	var blockRoots [][]byte
 
-	for i := uint64(0); i < params.BeaconConfig().HistoricalRootsLimit; i++ {
+	for i := uint64(0); i < params.BeaconConfig().SlotsPerHistoricalRoot; i++ {
 		blockRoots = append(blockRoots, []byte{byte(i)})
 	}
 	s := &pb.BeaconState{
@@ -76,7 +76,7 @@ func TestBlockRootAtSlot_CorrectBlockRoot(t *testing.T) {
 func TestBlockRootAtSlot_OutOfBounds(t *testing.T) {
 	var blockRoots [][]byte
 
-	for i := uint64(0); i < params.BeaconConfig().HistoricalRootsLimit; i++ {
+	for i := uint64(0); i < params.BeaconConfig().SlotsPerHistoricalRoot; i++ {
 		blockRoots = append(blockRoots, []byte{byte(i)})
 	}
 	state := &pb.BeaconState{
@@ -102,7 +102,7 @@ func TestBlockRootAtSlot_OutOfBounds(t *testing.T) {
 			// Edge case where stateSlot is over slots per historical root and
 			// slot is not within (stateSlot - HistoricalRootsLimit, statSlot]
 			slot:        1,
-			stateSlot:   params.BeaconConfig().HistoricalRootsLimit + 2,
+			stateSlot:   params.BeaconConfig().SlotsPerHistoricalRoot + 2,
 			expectedErr: "slot out of bounds",
 		},
 	}

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -360,7 +360,7 @@ func TestProcessBlock_IncorrectProcessExits(t *testing.T) {
 		},
 	}
 	var blockRoots [][]byte
-	for i := uint64(0); i < params.BeaconConfig().HistoricalRootsLimit; i++ {
+	for i := uint64(0); i < params.BeaconConfig().SlotsPerHistoricalRoot; i++ {
 		blockRoots = append(blockRoots, []byte{byte(i)})
 	}
 	beaconState.BlockRoots = blockRoots
@@ -549,7 +549,7 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 	}
 
 	var blockRoots [][]byte
-	for i := uint64(0); i < params.BeaconConfig().HistoricalRootsLimit; i++ {
+	for i := uint64(0); i < params.BeaconConfig().SlotsPerHistoricalRoot; i++ {
 		blockRoots = append(blockRoots, []byte{byte(i)})
 	}
 	beaconState.BlockRoots = blockRoots

--- a/beacon-chain/rpc/attester_server_test.go
+++ b/beacon-chain/rpc/attester_server_test.go
@@ -108,7 +108,7 @@ func TestRequestAttestation_OK(t *testing.T) {
 
 	beaconState := &pbp2p.BeaconState{
 		Slot:       3*params.BeaconConfig().SlotsPerEpoch + 1,
-		BlockRoots: make([][]byte, params.BeaconConfig().HistoricalRootsLimit),
+		BlockRoots: make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot),
 		CurrentCrosslinks: []*ethpb.Crosslink{
 			{
 				DataRoot: []byte("A"),
@@ -228,7 +228,7 @@ func TestAttestationDataAtSlot_handlesFarAwayJustifiedEpoch(t *testing.T) {
 	}
 	beaconState := &pbp2p.BeaconState{
 		Slot:       10000,
-		BlockRoots: make([][]byte, params.BeaconConfig().HistoricalRootsLimit),
+		BlockRoots: make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot),
 		PreviousCrosslinks: []*ethpb.Crosslink{
 			{
 				DataRoot: []byte("A"),

--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -63,7 +63,7 @@ func NewValidatorAccount(directory string, password string) error {
 	}
 	validatorKeyFile = validatorKeyFile + hex.EncodeToString(validatorKey.PublicKey.Marshal())[:12]
 	if err := ks.StoreKey(validatorKeyFile, validatorKey, password); err != nil {
-		return errors.Wrap(err,"unable to store key %v")
+		return errors.Wrap(err, "unable to store key %v")
 	}
 	log.WithField(
 		"path",


### PR DESCRIPTION
To build off #3158 

Here we replaced block and state roots construction to default size `SlotsPerHistoricalRoot` in all tests