### PR TITLE
Fix deposits at genesis eth1data

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -88,6 +88,7 @@ type Web3Service struct {
 	depositTrie             *trieutil.MerkleTrie
 	chainStartDeposits      []*ethpb.Deposit
 	chainStarted            bool
+	chainStartBlockNumber   *big.Int
 	beaconDB                *db.BeaconDB
 	lastReceivedMerkleIndex int64 // Keeps track of the last received index to prevent log spam.
 	isRunning               bool

--- a/beacon-chain/rpc/beacon_server.go
+++ b/beacon-chain/rpc/beacon_server.go
@@ -40,7 +40,7 @@ func (bs *BeaconServer) WaitForChainStart(req *ptypes.Empty, stream pb.BeaconSer
 	ok := bs.powChainService.HasChainStarted()
 
 	if ok {
-		genesisTime := bs.powChainService.ETH2GenesisTime()
+		genesisTime, _ := bs.powChainService.ETH2GenesisTime()
 
 		res := &pb.ChainStartResponse{
 			Started:     true,

--- a/beacon-chain/rpc/beacon_server_test.go
+++ b/beacon-chain/rpc/beacon_server_test.go
@@ -39,8 +39,8 @@ type faultyPOWChainService struct {
 func (f *faultyPOWChainService) HasChainStarted() bool {
 	return false
 }
-func (f *faultyPOWChainService) ETH2GenesisTime() uint64 {
-	return 0
+func (f *faultyPOWChainService) ETH2GenesisTime() (uint64, *big.Int) {
+	return 0, big.NewInt(0)
 }
 
 func (f *faultyPOWChainService) ChainStartFeed() *event.Feed {
@@ -103,8 +103,8 @@ func (m *mockPOWChainService) HasChainStarted() bool {
 	return true
 }
 
-func (m *mockPOWChainService) ETH2GenesisTime() uint64 {
-	return uint64(time.Unix(0, 0).Unix())
+func (m *mockPOWChainService) ETH2GenesisTime() (uint64, *big.Int) {
+	return uint64(time.Unix(0, 0).Unix()), big.NewInt(0)
 }
 func (m *mockPOWChainService) ChainStartFeed() *event.Feed {
 	return m.chainStartFeed

--- a/beacon-chain/rpc/beacon_server_test.go
+++ b/beacon-chain/rpc/beacon_server_test.go
@@ -97,6 +97,7 @@ type mockPOWChainService struct {
 	blockTimeByHeight   map[int]uint64
 	blockNumberByHeight map[uint64]*big.Int
 	eth1Data            *ethpb.Eth1Data
+	genesisEth1Block    *big.Int
 }
 
 func (m *mockPOWChainService) HasChainStarted() bool {
@@ -104,7 +105,11 @@ func (m *mockPOWChainService) HasChainStarted() bool {
 }
 
 func (m *mockPOWChainService) ETH2GenesisTime() (uint64, *big.Int) {
-	return uint64(time.Unix(0, 0).Unix()), big.NewInt(0)
+	blk := m.genesisEth1Block
+	if blk == nil {
+		blk = big.NewInt(0)
+	}
+	return uint64(time.Unix(0, 0).Unix()), blk
 }
 func (m *mockPOWChainService) ChainStartFeed() *event.Feed {
 	return m.chainStartFeed

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -209,7 +209,7 @@ func (ps *ProposerServer) attestations(ctx context.Context, expectedSlot uint64)
 //  - Subtract that eth1block.number by ETH1_FOLLOW_DISTANCE.
 //  - This is the eth1block to use for the block proposal.
 func (ps *ProposerServer) eth1Data(ctx context.Context, slot uint64) (*ethpb.Eth1Data, error) {
-	eth1VotingPeriodStartTime := ps.powChainService.ETH2GenesisTime()
+	eth1VotingPeriodStartTime, _ := ps.powChainService.ETH2GenesisTime()
 	eth1VotingPeriodStartTime += (slot - (slot % params.BeaconConfig().SlotsPerEth1VotingPeriod)) * params.BeaconConfig().SecondsPerSlot
 
 	// Look up most recent block up to timestamp
@@ -251,17 +251,6 @@ func (ps *ProposerServer) computeStateRoot(ctx context.Context, block *ethpb.Bea
 // enough support, then use that vote for basis of determining deposits, otherwise use current state
 // eth1data.
 func (ps *ProposerServer) deposits(ctx context.Context, currentVote *ethpb.Eth1Data) ([]*ethpb.Deposit, error) {
-	bNum := ps.powChainService.LatestBlockHeight()
-	if bNum == nil {
-		return nil, errors.New("latest PoW block number is unknown")
-	}
-	// Only request deposits that have passed the ETH1 follow distance window.
-	subbedBnum := big.NewInt(0).Sub(bNum, big.NewInt(int64(params.BeaconConfig().Eth1FollowDistance)))
-	allDeps := ps.beaconDB.AllDeposits(ctx, subbedBnum)
-	if len(allDeps) == 0 {
-		return nil, nil
-	}
-
 	// Need to fetch if the deposits up to the state's latest eth 1 data matches
 	// the number of all deposits in this RPC call. If not, then we return nil.
 	beaconState, err := ps.beaconDB.HeadState(ctx)
@@ -272,13 +261,13 @@ func (ps *ProposerServer) deposits(ctx context.Context, currentVote *ethpb.Eth1D
 	if err != nil {
 		return nil, err
 	}
-	// If the state's latest eth1 data's block hash has a height of 100, we fetch all the deposits up to height 100.
-	// If this is more than the total number of deposits stored in our deposit cache, we return an error
-	upToEth1DataDeposits := ps.beaconDB.AllDeposits(ctx, latestEth1DataHeight)
-	if len(upToEth1DataDeposits) > len(allDeps) {
-		return nil, errors.Wrapf(err, "number of deposits referred to by the eth1data is more than the current "+
-			"number of deposits in the deposit cache. %d is more than %d", len(upToEth1DataDeposits), len(allDeps))
+
+	_, genesisEth1Block := ps.powChainService.ETH2GenesisTime()
+	if genesisEth1Block.Cmp(latestEth1DataHeight) == 0 {
+		return []*ethpb.Deposit{}, nil
 	}
+
+	upToEth1DataDeposits := ps.beaconDB.AllDeposits(ctx, latestEth1DataHeight)
 	depositData := [][]byte{}
 	for _, dep := range upToEth1DataDeposits {
 		depHash, err := ssz.HashTreeRoot(dep.Data)

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -458,18 +458,6 @@ func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
 	}
 }
 
-func TestPendingDeposits_UnknownBlockNum(t *testing.T) {
-	p := &mockPOWChainService{
-		latestBlockNumber: nil,
-	}
-	ps := ProposerServer{powChainService: p}
-
-	_, err := ps.deposits(context.Background(), &ethpb.Eth1Data{})
-	if err.Error() != "latest PoW block number is unknown" {
-		t.Errorf("Received unexpected error: %v", err)
-	}
-}
-
 func TestPendingDeposits_Eth1DataVoteOK(t *testing.T) {
 	ctx := context.Background()
 

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -1201,3 +1201,101 @@ func Benchmark_Eth1Data(b *testing.B) {
 		}
 	}
 }
+
+func TestDeposits_ReturnsEmptyList_IfLatestEth1DataEqGenesisEth1Block(t *testing.T) {
+	ctx := context.Background()
+
+	height := big.NewInt(int64(params.BeaconConfig().Eth1FollowDistance))
+	p := &mockPOWChainService{
+		latestBlockNumber: height,
+		hashesByHeight: map[int][]byte{
+			int(height.Int64()): []byte("0x0"),
+		},
+		genesisEth1Block: height,
+	}
+	d := internal.SetupDB(t)
+
+	beaconState := &pbp2p.BeaconState{
+		Eth1Data: &ethpb.Eth1Data{
+			BlockHash: []byte("0x0"),
+		},
+		Eth1DepositIndex: 2,
+	}
+	if err := d.SaveState(ctx, beaconState); err != nil {
+		t.Fatal(err)
+	}
+	var mockSig [96]byte
+	var mockCreds [32]byte
+
+	readyDeposits := []*db.DepositContainer{
+		{
+			Index: 0,
+			Deposit: &ethpb.Deposit{
+				Data: &ethpb.Deposit_Data{
+					PublicKey:             []byte("a"),
+					Signature:             mockSig[:],
+					WithdrawalCredentials: mockCreds[:],
+				}},
+		},
+		{
+			Index: 1,
+			Deposit: &ethpb.Deposit{
+				Data: &ethpb.Deposit_Data{
+					PublicKey:             []byte("b"),
+					Signature:             mockSig[:],
+					WithdrawalCredentials: mockCreds[:],
+				}},
+		},
+	}
+
+	var recentDeposits []*db.DepositContainer
+	for i := 2; i < 22; i++ {
+		recentDeposits = append(recentDeposits, &db.DepositContainer{
+			Index: i,
+			Deposit: &ethpb.Deposit{
+				Data: &ethpb.Deposit_Data{
+					PublicKey:             []byte{byte(i)},
+					Signature:             mockSig[:],
+					WithdrawalCredentials: mockCreds[:],
+				}},
+		})
+	}
+	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
+	if err != nil {
+		t.Fatalf("could not setup deposit trie: %v", err)
+	}
+	for _, dp := range append(readyDeposits, recentDeposits...) {
+		depositHash, err := ssz.HashTreeRoot(dp.Deposit.Data)
+		if err != nil {
+			t.Fatalf("Unable to determine hashed value of deposit %v", err)
+		}
+
+		if err := depositTrie.InsertIntoTrie(depositHash[:], int(dp.Index)); err != nil {
+			t.Fatalf("Unable to insert deposit into trie %v", err)
+		}
+
+		d.InsertDeposit(ctx, dp.Deposit, big.NewInt(int64(dp.Index)), dp.Index, depositTrie.Root())
+	}
+	for _, dp := range recentDeposits {
+		d.InsertPendingDeposit(ctx, dp.Deposit, big.NewInt(int64(dp.Index)), dp.Index, depositTrie.Root())
+	}
+
+	bs := &ProposerServer{
+		beaconDB:        d,
+		powChainService: p,
+		chainService:    newMockChainService(),
+	}
+
+	// It should also return the recent deposits after their follow window.
+	p.latestBlockNumber = big.NewInt(0).Add(p.latestBlockNumber, big.NewInt(10000))
+	deposits, err := bs.deposits(ctx, &ethpb.Eth1Data{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deposits) != 0 {
+		t.Errorf(
+			"Received unexpected number of pending deposits: %d, wanted: 0",
+			len(deposits),
+		)
+	}
+}

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -54,7 +54,7 @@ type operationService interface {
 
 type powChainService interface {
 	HasChainStarted() bool
-	ETH2GenesisTime() uint64
+	ETH2GenesisTime() (uint64, *big.Int)
 	ChainStartFeed() *event.Feed
 	LatestBlockHeight() *big.Int
 	BlockExists(ctx context.Context, hash common.Hash) (bool, *big.Int, error)


### PR DESCRIPTION
Problem scenario: if the genesis event happens in a block that has remaining deposits then these deposits are incorrectly being selected for inclusion in a block.

Solution: if the eth1data points to the genesis eth1 event block, do not include new deposits. 

This only effects early epochs around chain start. 