### PR TITLE
Save head block root for new DB refactor

### DIFF
--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -35,11 +35,11 @@ type Database interface {
 	DeleteBlock(ctx context.Context, blockRoot [32]byte) error
 	SaveBlock(ctx context.Context, block *ethpb.BeaconBlock) error
 	SaveBlocks(ctx context.Context, blocks []*ethpb.BeaconBlock) error
+	SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error
 	ValidatorLatestVote(ctx context.Context, validatorIdx uint64) (*pb.ValidatorLatestVote, error)
 	HasValidatorLatestVote(ctx context.Context, validatorIdx uint64) bool
 	SaveValidatorLatestVote(ctx context.Context, validatorIdx uint64, vote *pb.ValidatorLatestVote) error
 	State(ctx context.Context, f *filters.QueryFilter) (*pb.BeaconState, error)
-	HeadState(ctx context.Context) (*pb.BeaconState, error)
 	SaveState(ctx context.Context, state *pb.BeaconState, blockRoot [32]byte) error
 	ValidatorIndex(ctx context.Context, publicKey [48]byte) (uint64, error)
 	HasValidatorIndex(ctx context.Context, publicKey [48]byte) bool

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -29,6 +29,7 @@ type Database interface {
 	SaveAttestation(ctx context.Context, att *ethpb.Attestation) error
 	SaveAttestations(ctx context.Context, atts []*ethpb.Attestation) error
 	Block(ctx context.Context, blockRoot [32]byte) (*ethpb.BeaconBlock, error)
+	HeadBlock(ctx context.Context) (*ethpb.BeaconBlock, error)
 	Blocks(ctx context.Context, f *filters.QueryFilter) ([]*ethpb.BeaconBlock, error)
 	BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][]byte, error)
 	HasBlock(ctx context.Context, blockRoot [32]byte) bool
@@ -40,6 +41,7 @@ type Database interface {
 	HasValidatorLatestVote(ctx context.Context, validatorIdx uint64) bool
 	SaveValidatorLatestVote(ctx context.Context, validatorIdx uint64, vote *pb.ValidatorLatestVote) error
 	State(ctx context.Context, f *filters.QueryFilter) (*pb.BeaconState, error)
+	HeadState(ctx context.Context) (*pb.BeaconState, error)
 	SaveState(ctx context.Context, state *pb.BeaconState, blockRoot [32]byte) error
 	ValidatorIndex(ctx context.Context, publicKey [48]byte) (uint64, error)
 	HasValidatorIndex(ctx context.Context, publicKey [48]byte) bool

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -13,6 +13,12 @@ func (k *Store) Block(ctx context.Context, blockRoot [32]byte) (*ethpb.BeaconBlo
 	return nil, nil
 }
 
+// HeadBlock returns the latest canonical block in eth2.
+// TODO(#3164): Implement.
+func (k *Store) HeadBlock(ctx context.Context) (*ethpb.BeaconBlock, error) {
+	return nil, nil
+}
+
 // Blocks retrieves a list of beacon blocks by filter criteria.
 // TODO(#3164): Implement.
 func (k *Store) Blocks(ctx context.Context, f *filters.QueryFilter) ([]*ethpb.BeaconBlock, error) {

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -48,3 +48,9 @@ func (k *Store) SaveBlock(ctx context.Context, block *ethpb.BeaconBlock) error {
 func (k *Store) SaveBlocks(ctx context.Context, blocks []*ethpb.BeaconBlock) error {
 	return nil
 }
+
+// SaveHeadBlockRoot to the db.
+// TODO(#3164): Implement.
+func (k *Store) SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error {
+	return nil
+}

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -13,6 +13,12 @@ func (k *Store) State(ctx context.Context, f *filters.QueryFilter) (*pb.BeaconSt
 	return nil, nil
 }
 
+// HeadState returns the latest canonical state in eth2.
+// TODO(#3164): Implement.
+func (k *Store) HeadState(ctx context.Context) (*pb.BeaconState, error) {
+	return nil, nil
+}
+
 // SaveState stores a state to the db by the block root which triggered it.
 // TODO(#3164): Implement.
 func (k *Store) SaveState(ctx context.Context, state *pb.BeaconState, blockRoot [32]byte) error {

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -13,12 +13,6 @@ func (k *Store) State(ctx context.Context, f *filters.QueryFilter) (*pb.BeaconSt
 	return nil, nil
 }
 
-// HeadState returns the latest canonical state in eth2.
-// TODO(#3164): Implement.
-func (k *Store) HeadState(ctx context.Context) (*pb.BeaconState, error) {
-	return nil, nil
-}
-
 // SaveState stores a state to the db by the block root which triggered it.
 // TODO(#3164): Implement.
 func (k *Store) SaveState(ctx context.Context, state *pb.BeaconState, blockRoot [32]byte) error {


### PR DESCRIPTION
It was discussed offline we do want to save latest head root in DB. Any node could go offline for a few sec and it would be valuable to have such head information in the DB.

Added `SaveHeadBlockRoot` API for DB, keep in mind we don't need to `SaveHeadBlock` and `SaveHeadState`. Just saving the head root is sufficient enough for the future retrievals. 