### PR TITLE
Lower jaegar BufferMaxCount

### DIFF
--- a/shared/tracing/tracer.go
+++ b/shared/tracing/tracer.go
@@ -37,7 +37,7 @@ func Setup(serviceName, processName, endpoint string, sampleFraction float64, en
 				jaeger.StringTag("version", version.GetVersion()),
 			},
 		},
-		BufferMaxCount: 256 * 1e6, // 256Mb
+		BufferMaxCount: 10000,
 		OnError: func(err error) {
 			log.WithError(err).Error("Failed to process span")
 		},

--- a/tools/cluster-pk-manager/client/main.go
+++ b/tools/cluster-pk-manager/client/main.go
@@ -47,8 +47,7 @@ func main() {
 	for i, privateKey := range resp.PrivateKeys.PrivateKeys {
 		pk, err := bls.SecretKeyFromBytes(privateKey)
 		if err != nil {
-			fmt.Printf("Received invalid secret key, ignoreing. %v\n", err)
-			continue
+			panic(err)
 		}
 
 		k := &keystore.Key{

--- a/tools/cluster-pk-manager/client/main.go
+++ b/tools/cluster-pk-manager/client/main.go
@@ -47,7 +47,8 @@ func main() {
 	for i, privateKey := range resp.PrivateKeys.PrivateKeys {
 		pk, err := bls.SecretKeyFromBytes(privateKey)
 		if err != nil {
-			panic(err)
+			fmt.Printf("Received invalid secret key, ignoreing. %v\n", err)
+			continue
 		}
 
 		k := &keystore.Key{


### PR DESCRIPTION
This value is copied from Google's error reporting library.

https://github.com/googleapis/google-cloud-go/blob/b8d0ccd262efda18e5b6684077d076e50541dfff/errorreporting/errors.go#L130

Potentially addresses memory leak: https://github.com/census-ecosystem/opencensus-go-exporter-jaeger/issues/12