### PR TITLE
Deprecate the old, and add new DB setup util for tests

### DIFF
--- a/beacon-chain/attestation/service_test.go
+++ b/beacon-chain/attestation/service_test.go
@@ -26,8 +26,8 @@ func init() {
 var _ = TargetHandler(&Service{})
 
 func TestUpdateLatestAttestation_UpdatesLatest(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	var validators []*ethpb.Validator
@@ -98,8 +98,8 @@ func TestUpdateLatestAttestation_UpdatesLatest(t *testing.T) {
 }
 
 func TestAttestationPool_UpdatesAttestationPool(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	var validators []*ethpb.Validator
@@ -140,8 +140,8 @@ func TestAttestationPool_UpdatesAttestationPool(t *testing.T) {
 }
 
 func TestLatestAttestationTarget_CantGetAttestation(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	if err := beaconDB.SaveState(ctx, &pb.BeaconState{
@@ -163,8 +163,8 @@ func TestLatestAttestationTarget_CantGetAttestation(t *testing.T) {
 }
 
 func TestLatestAttestationTarget_ReturnsLatestAttestedBlock(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	pubKey := []byte{'A'}
@@ -215,9 +215,9 @@ func TestLatestAttestationTarget_ReturnsLatestAttestedBlock(t *testing.T) {
 }
 
 func TestUpdateLatestAttestation_InvalidIndex(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
+	beaconDB := internal.SetupDBDeprecated(t)
 	hook := logTest.NewGlobal()
-	defer internal.TeardownDB(t, beaconDB)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	var validators []*ethpb.Validator
@@ -266,8 +266,8 @@ func TestUpdateLatestAttestation_InvalidIndex(t *testing.T) {
 }
 
 func TestBatchUpdate_FromSync(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	var validators []*ethpb.Validator
@@ -321,8 +321,8 @@ func TestBatchUpdate_FromSync(t *testing.T) {
 }
 
 func TestUpdateLatestAttestation_BatchUpdate(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	var validators []*ethpb.Validator

--- a/beacon-chain/blockchain/block_processing_test.go
+++ b/beacon-chain/blockchain/block_processing_test.go
@@ -54,8 +54,8 @@ func initBlockStateRoot(t *testing.T, block *ethpb.BeaconBlock, chainService *Ch
 }
 
 func TestReceiveBlock_FaultyPOWChain(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	chainService := setupBeaconChain(t, db, nil)
 	unixTime := uint64(time.Now().Unix())
 	deposits, _ := testutil.SetupInitialDeposits(t, 100)
@@ -101,8 +101,8 @@ func TestReceiveBlock_FaultyPOWChain(t *testing.T) {
 
 func TestReceiveBlock_ProcessCorrectly(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	chainService := setupBeaconChain(t, db, nil)
@@ -194,8 +194,8 @@ func TestReceiveBlock_ProcessCorrectly(t *testing.T) {
 
 func TestReceiveBlock_UsesParentBlockState(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	chainService := setupBeaconChain(t, db, nil)
@@ -278,8 +278,8 @@ func TestReceiveBlock_UsesParentBlockState(t *testing.T) {
 }
 
 func TestReceiveBlock_DeletesBadBlock(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	attsService := attestation.NewAttestationService(
@@ -363,8 +363,8 @@ func TestReceiveBlock_DeletesBadBlock(t *testing.T) {
 
 func TestReceiveBlock_CheckBlockStateRoot_GoodState(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	attsService := attestation.NewAttestationService(
@@ -442,8 +442,8 @@ func TestReceiveBlock_CheckBlockStateRoot_GoodState(t *testing.T) {
 }
 
 func TestReceiveBlock_CheckBlockStateRoot_BadState(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 	chainService := setupBeaconChain(t, db, nil)
 	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
@@ -509,8 +509,8 @@ func TestReceiveBlock_CheckBlockStateRoot_BadState(t *testing.T) {
 
 func TestReceiveBlock_RemovesPendingDeposits(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	attsService := attestation.NewAttestationService(
@@ -705,8 +705,8 @@ func TestReceiveBlock_OnChainSplit(t *testing.T) {
 	// we process F, the G. The expected behavior is that we load the historical
 	// state from slot 3 where the common ancestor block C is present.
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	chainService := setupBeaconChain(t, db, nil)
@@ -915,8 +915,8 @@ func TestReceiveBlock_OnChainSplit(t *testing.T) {
 }
 
 func TestIsBlockReadyForProcessing_ValidBlock(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	chainService := setupBeaconChain(t, db, nil)
@@ -1005,8 +1005,8 @@ func TestIsBlockReadyForProcessing_ValidBlock(t *testing.T) {
 }
 
 func TestDeleteValidatorIdx_DeleteWorks(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	epoch := uint64(2)
 	v.InsertActivatedIndices(epoch+1, []uint64{0, 1, 2})
 	v.InsertExitedVal(epoch+1, []uint64{0, 2})
@@ -1048,8 +1048,8 @@ func TestDeleteValidatorIdx_DeleteWorks(t *testing.T) {
 }
 
 func TestSaveValidatorIdx_SaveRetrieveWorks(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	epoch := uint64(1)
 	v.InsertActivatedIndices(epoch+1, []uint64{0, 1, 2})
 	var validators []*ethpb.Validator
@@ -1084,8 +1084,8 @@ func TestSaveValidatorIdx_SaveRetrieveWorks(t *testing.T) {
 }
 
 func TestSaveValidatorIdx_IdxNotInState(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	epoch := uint64(100)
 
 	// Tried to insert 5 active indices to DB with only 3 validators in state

--- a/beacon-chain/blockchain/fork_choice_reorg_test.go
+++ b/beacon-chain/blockchain/fork_choice_reorg_test.go
@@ -31,8 +31,8 @@ func TestApplyForkChoice_ChainSplitReorg(t *testing.T) {
 	// TODO(#2307): Fix test once v0.6 is merged.
 	t.Skip()
 	hook := logTest.NewGlobal()
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 
 	ctx := context.Background()
 	deposits, _ := testutil.SetupInitialDeposits(t, 100)

--- a/beacon-chain/blockchain/fork_choice_test.go
+++ b/beacon-chain/blockchain/fork_choice_test.go
@@ -80,8 +80,8 @@ func TestApplyForkChoice_SetsCanonicalHead(t *testing.T) {
 	}
 	for _, tt := range tests {
 		hook := logTest.NewGlobal()
-		beaconDb := internal.SetupDB(t)
-		defer internal.TeardownDB(t, beaconDb)
+		beaconDb := internal.SetupDBDeprecated(t)
+		defer internal.TeardownDBDeprecated(t, beaconDb)
 		attsService := attestation.NewAttestationService(
 			context.Background(),
 			&attestation.Config{BeaconDB: beaconDb})
@@ -136,8 +136,8 @@ func TestApplyForkChoice_SetsCanonicalHead(t *testing.T) {
 func TestVoteCount_ParentDoesNotExistNoVoteCount(t *testing.T) {
 	// TODO(#2307): Fix test once v0.6 is merged.
 	t.Skip()
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	genesisBlock := b.NewGenesisBlock([]byte("stateroot"))
 	if err := beaconDB.SaveBlock(genesisBlock); err != nil {
 		t.Fatal(err)
@@ -169,8 +169,8 @@ func TestVoteCount_ParentDoesNotExistNoVoteCount(t *testing.T) {
 }
 
 func TestVoteCount_IncreaseCountCorrectly(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	genesisBlock := b.NewGenesisBlock([]byte("stateroot"))
 	genesisRoot, err := ssz.SigningRoot(genesisBlock)
 	if err != nil {
@@ -228,8 +228,8 @@ func TestVoteCount_IncreaseCountCorrectly(t *testing.T) {
 func TestAttestationTargets_RetrieveWorks(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	pubKey := []byte{'A'}
@@ -283,8 +283,8 @@ func TestAttestationTargets_RetrieveWorks(t *testing.T) {
 func TestBlockChildren_2InARow(t *testing.T) {
 	// TODO(#2307): Fix test once v0.6 is merged.
 	t.Skip()
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	chainService := setupBeaconChain(t, beaconDB, nil)
@@ -351,8 +351,8 @@ func TestBlockChildren_2InARow(t *testing.T) {
 func TestBlockChildren_ChainSplits(t *testing.T) {
 	// TODO(#2307): Fix test once v0.6 is merged.
 	t.Skip()
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	chainService := setupBeaconChain(t, beaconDB, nil)
@@ -428,8 +428,8 @@ func TestBlockChildren_ChainSplits(t *testing.T) {
 func TestBlockChildren_SkipSlots(t *testing.T) {
 	// TODO(#2307): Fix test once v0.6 is merged.
 	t.Skip()
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	chainService := setupBeaconChain(t, beaconDB, nil)
@@ -496,8 +496,8 @@ func TestBlockChildren_SkipSlots(t *testing.T) {
 func TestLMDGhost_TrivialHeadUpdate(t *testing.T) {
 	// TODO(#2307): Fix test once v0.6 is merged.
 	t.Skip()
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	beaconState := &pb.BeaconState{
@@ -561,8 +561,8 @@ func TestLMDGhost_TrivialHeadUpdate(t *testing.T) {
 func TestLMDGhost_3WayChainSplitsSameHeight(t *testing.T) {
 	// TODO(#2307): Fix test once v0.6 is merged.
 	t.Skip()
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	beaconState := &pb.BeaconState{
@@ -679,8 +679,8 @@ func TestLMDGhost_3WayChainSplitsSameHeight(t *testing.T) {
 func TestIsDescendant_Ok(t *testing.T) {
 	// TODO(#2307): Fix test once v0.6 is merged.
 	t.Skip()
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	chainService := setupBeaconChain(t, beaconDB, nil)
 
 	// Construct the following chain:
@@ -771,8 +771,8 @@ func TestIsDescendant_Ok(t *testing.T) {
 func TestLMDGhost_2WayChainSplitsDiffHeight(t *testing.T) {
 	// TODO(#2307): Fix test once v0.6 is merged.
 	t.Skip()
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	beaconState := &pb.BeaconState{
@@ -911,8 +911,8 @@ func TestLMDGhost_2WayChainSplitsDiffHeight(t *testing.T) {
 // Ex:
 // 	B0 - B1 - B2 - B3 - B4 - B5 - B6 - B7 (8 votes)
 func BenchmarkLMDGhost_8Slots_8Validators(b *testing.B) {
-	beaconDB := internal.SetupDB(b)
-	defer internal.TeardownDB(b, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(b)
+	defer internal.TeardownDBDeprecated(b, beaconDB)
 	ctx := context.Background()
 
 	validatorCount := 8
@@ -992,8 +992,8 @@ func BenchmarkLMDGhost_8Slots_8Validators(b *testing.B) {
 // Ex:
 // 	B0 - B1 - B2 - B3 - B4 - B5 - B6 - B7 (8 votes)
 func BenchmarkLMDGhost_32Slots_8Validators(b *testing.B) {
-	beaconDB := internal.SetupDB(b)
-	defer internal.TeardownDB(b, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(b)
+	defer internal.TeardownDBDeprecated(b, beaconDB)
 	ctx := context.Background()
 
 	validatorCount := 8
@@ -1071,8 +1071,8 @@ func BenchmarkLMDGhost_32Slots_8Validators(b *testing.B) {
 // Ex:
 // 	B0 - B1 - B2 - ... - B32 (64 votes)
 func BenchmarkLMDGhost_32Slots_64Validators(b *testing.B) {
-	beaconDB := internal.SetupDB(b)
-	defer internal.TeardownDB(b, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(b)
+	defer internal.TeardownDBDeprecated(b, beaconDB)
 	ctx := context.Background()
 
 	validatorCount := 64
@@ -1150,8 +1150,8 @@ func BenchmarkLMDGhost_32Slots_64Validators(b *testing.B) {
 // Ex:
 // 	B0 - B1 - B2 - ... - B64 (16384 votes)
 func BenchmarkLMDGhost_64Slots_16384Validators(b *testing.B) {
-	beaconDB := internal.SetupDB(b)
-	defer internal.TeardownDB(b, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(b)
+	defer internal.TeardownDBDeprecated(b, beaconDB)
 	ctx := context.Background()
 
 	validatorCount := 16384
@@ -1263,8 +1263,8 @@ func TestUpdateFFGCheckPts_NewJustifiedSlot(t *testing.T) {
 	helpers.ClearAllCaches()
 
 	genesisSlot := uint64(0)
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	chainSvc := setupBeaconChain(t, beaconDB, nil)
@@ -1340,8 +1340,8 @@ func TestUpdateFFGCheckPts_NewFinalizedSlot(t *testing.T) {
 	helpers.ClearAllCaches()
 
 	genesisSlot := uint64(0)
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	chainSvc := setupBeaconChain(t, beaconDB, nil)
 	ctx := context.Background()
 
@@ -1422,8 +1422,8 @@ func TestUpdateFFGCheckPts_NewJustifiedSkipSlot(t *testing.T) {
 	helpers.ClearAllCaches()
 
 	genesisSlot := uint64(0)
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	chainSvc := setupBeaconChain(t, beaconDB, nil)
@@ -1575,8 +1575,8 @@ func TestVoteCount_CacheEnabledAndMiss(t *testing.T) {
 		featureconfig.InitFeatureConfig(nil)
 	}()
 
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	genesisBlock := b.NewGenesisBlock([]byte("stateroot"))
 	genesisRoot, err := ssz.SigningRoot(genesisBlock)
 	if err != nil {
@@ -1642,8 +1642,8 @@ func TestVoteCount_CacheEnabledAndMiss(t *testing.T) {
 }
 
 func TestVoteCount_CacheEnabledAndHit(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	genesisBlock := b.NewGenesisBlock([]byte("stateroot"))
 	genesisRoot, err := ssz.SigningRoot(genesisBlock)
 	if err != nil {

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -205,8 +205,8 @@ func SetSlotInState(service *ChainService, slot uint64) error {
 
 func TestChainStartStop_Uninitialized(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	chainService := setupBeaconChain(t, db, nil)
 
 	// Test the start function.
@@ -244,8 +244,8 @@ func TestChainStartStop_Uninitialized(t *testing.T) {
 
 func TestChainStartStop_Initialized(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	chainService := setupBeaconChain(t, db, nil)
 

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -13,8 +13,8 @@ import (
 )
 
 func TestAttestationDataSlot_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	deposits, _ := testutil.SetupInitialDeposits(t, 100)
 	if err := db.InitializeState(context.Background(), uint64(0), deposits, &ethpb.Eth1Data{}); err != nil {
 		t.Fatalf("Could not initialize beacon state to disk: %v", err)
@@ -62,8 +62,8 @@ func TestAttestationDataSlot_ReturnsErrorWithNilData(t *testing.T) {
 }
 
 func TestAttestationDataSlot_ReturnsErrorWithErroneousTargetEpoch(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	deposits, _ := testutil.SetupInitialDeposits(t, 100)
 	if err := db.InitializeState(context.Background(), uint64(0), deposits, &ethpb.Eth1Data{}); err != nil {
 		t.Fatalf("Could not initialize beacon state to disk: %v", err)
@@ -82,8 +82,8 @@ func TestAttestationDataSlot_ReturnsErrorWithErroneousTargetEpoch(t *testing.T) 
 }
 
 func TestAttestationDataSlot_ReturnsErrorWhenTargetEpochLessThanCurrentEpoch(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	deposits, _ := testutil.SetupInitialDeposits(t, 100)
 	if err := db.InitializeState(context.Background(), uint64(0), deposits, &ethpb.Eth1Data{}); err != nil {
 		t.Fatalf("Could not initialize beacon state to disk: %v", err)

--- a/beacon-chain/deprecated-sync/initial-sync/service_test.go
+++ b/beacon-chain/deprecated-sync/initial-sync/service_test.go
@@ -114,8 +114,8 @@ func setUpGenesisStateAndBlock(beaconDB *db.BeaconDB, t *testing.T) {
 }
 
 func TestProcessingBatchedBlocks_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	setUpGenesisStateAndBlock(db, t)
 
 	cfg := &Config{
@@ -166,8 +166,8 @@ func TestProcessingBatchedBlocks_OK(t *testing.T) {
 }
 
 func TestProcessingBlocks_SkippedSlots(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	setUpGenesisStateAndBlock(db, t)
 	ctx := context.Background()
 

--- a/beacon-chain/deprecated-sync/querier_test.go
+++ b/beacon-chain/deprecated-sync/querier_test.go
@@ -60,8 +60,8 @@ func (mp *afterGenesisPowChain) AreAllDepositsProcessed() (bool, error) {
 
 func TestQuerier_StartStop(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	cfg := &QuerierConfig{
 		P2P:                &mockP2P{},
 		ResponseBufferSize: 100,
@@ -91,8 +91,8 @@ func TestQuerier_StartStop(t *testing.T) {
 }
 
 func TestListenForStateInitialization_ContextCancelled(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	cfg := &QuerierConfig{
 		P2P:                &mockP2P{},
 		ResponseBufferSize: 100,
@@ -120,8 +120,8 @@ func TestListenForStateInitialization_ContextCancelled(t *testing.T) {
 }
 
 func TestListenForStateInitialization(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	cfg := &QuerierConfig{
 		P2P:                &mockP2P{},
 		ResponseBufferSize: 100,
@@ -211,8 +211,8 @@ func TestQuerier_BestPeerAssignment(t *testing.T) {
 }
 
 func TestSyncedInGenesis(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	cfg := &QuerierConfig{
 		P2P:                &mockP2P{},
 		ResponseBufferSize: 100,
@@ -236,8 +236,8 @@ func TestSyncedInGenesis(t *testing.T) {
 }
 
 func TestSyncedInRestarts(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	cfg := &QuerierConfig{
 		P2P:                &mockP2P{},
 		ResponseBufferSize: 100,
@@ -289,8 +289,8 @@ func TestSyncedInRestarts(t *testing.T) {
 }
 
 func TestWaitForDepositsProcessed_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	powchain := &genesisPowChain{depositsProcessed: false}
 	cfg := &QuerierConfig{
 		P2P:                &mockP2P{},

--- a/beacon-chain/deprecated-sync/receive_block_test.go
+++ b/beacon-chain/deprecated-sync/receive_block_test.go
@@ -65,8 +65,8 @@ func setupBlocksMissingParent(parents []*ethpb.BeaconBlock, parentRoots [][32]by
 
 func TestReceiveBlockAnnounce_SkipsBlacklistedBlock(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	rsCfg := DefaultRegularSyncConfig()
 	rsCfg.ChainService = &mockChainService{
@@ -91,8 +91,8 @@ func TestReceiveBlockAnnounce_SkipsBlacklistedBlock(t *testing.T) {
 }
 
 func TestReceiveBlock_RecursivelyProcessesChildren(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	rsCfg := DefaultRegularSyncConfig()

--- a/beacon-chain/deprecated-sync/regular_sync_test.go
+++ b/beacon-chain/deprecated-sync/regular_sync_test.go
@@ -138,8 +138,8 @@ func setupService(db *db.BeaconDB) *RegularSync {
 func TestProcessBlockRoot_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	// set the channel's buffer to 0 to make channel interactions blocking
 	cfg := &RegularSyncConfig{
@@ -173,8 +173,8 @@ func TestProcessBlockRoot_OK(t *testing.T) {
 func TestProcessBlock_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	validators := make([]*ethpb.Validator, 10)
 	for i := 0; i < len(validators); i++ {
 		validators[i] = &ethpb.Validator{
@@ -250,8 +250,8 @@ func TestProcessBlock_OK(t *testing.T) {
 func TestProcessBlock_MultipleBlocksProcessedOK(t *testing.T) {
 	hook := logTest.NewGlobal()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	validators := make([]*ethpb.Validator, 10)
 	for i := 0; i < len(validators); i++ {
@@ -363,8 +363,8 @@ func TestReceiveAttestation_OK(t *testing.T) {
 	os := &mockOperationService{}
 	ctx := context.Background()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	beaconState := &pb.BeaconState{
 		Slot:                2,
 		FinalizedCheckpoint: &ethpb.Checkpoint{},
@@ -420,8 +420,8 @@ func TestReceiveAttestation_OlderThanPrevEpoch(t *testing.T) {
 	os := &mockOperationService{}
 	ctx := context.Background()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	state := &pb.BeaconState{
 		Slot:                2 * params.BeaconConfig().SlotsPerEpoch,
 		FinalizedCheckpoint: &ethpb.Checkpoint{Epoch: 1},
@@ -471,8 +471,8 @@ func TestReceiveAttestation_OlderThanPrevEpoch(t *testing.T) {
 func TestReceiveExitReq_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
 	os := &mockOperationService{}
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	cfg := &RegularSyncConfig{
 		OperationService: os,
@@ -500,8 +500,8 @@ func TestReceiveExitReq_OK(t *testing.T) {
 func TestHandleStateReq_NOState(t *testing.T) {
 	hook := logTest.NewGlobal()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	ss := setupService(db)
 
@@ -531,8 +531,8 @@ func TestHandleStateReq_NOState(t *testing.T) {
 
 func TestHandleStateReq_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 	helpers.ClearAllCaches()
 
@@ -579,8 +579,8 @@ func TestHandleStateReq_OK(t *testing.T) {
 }
 
 func TestCanonicalBlockList_CanRetrieveCanonical(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ss := setupService(db)
 
 	// Construct the following chain:
@@ -621,8 +621,8 @@ func TestCanonicalBlockList_CanRetrieveCanonical(t *testing.T) {
 }
 
 func TestCanonicalBlockList_SameFinalizedAndHead(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ss := setupService(db)
 
 	// Construct the following chain:
@@ -647,8 +647,8 @@ func TestCanonicalBlockList_SameFinalizedAndHead(t *testing.T) {
 }
 
 func TestCanonicalBlockList_NilBlock(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ss := setupService(db)
 
 	want := "nil block 0x42 from db"
@@ -658,8 +658,8 @@ func TestCanonicalBlockList_NilBlock(t *testing.T) {
 }
 
 func TestCanonicalBlockList_NilParentBlock(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ss := setupService(db)
 
 	block1 := &ethpb.BeaconBlock{Slot: 1, ParentRoot: []byte{'B'}}

--- a/beacon-chain/deprecated-sync/service_test.go
+++ b/beacon-chain/deprecated-sync/service_test.go
@@ -45,7 +45,7 @@ func initializeTestSyncService(ctx context.Context, cfg *Config, synced bool) *S
 }
 
 func setupTestSyncService(t *testing.T, synced bool) (*Service, *db.BeaconDB) {
-	db := internal.SetupDB(t)
+	db := internal.SetupDBDeprecated(t)
 
 	unixTime := uint64(time.Now().Unix())
 	deposits, _ := testutil.SetupInitialDeposits(t, 100)
@@ -68,7 +68,7 @@ func setupTestSyncService(t *testing.T, synced bool) (*Service, *db.BeaconDB) {
 
 func TestStatus_NotSynced(t *testing.T) {
 	serviceNotSynced, db := setupTestSyncService(t, false)
-	defer internal.TeardownDB(t, db)
+	defer internal.TeardownDBDeprecated(t, db)
 	synced := serviceNotSynced.InitialSync.NodeIsSynced()
 	if synced {
 		t.Error("Wanted false, but got true")

--- a/beacon-chain/internal/BUILD.bazel
+++ b/beacon-chain/internal/BUILD.bazel
@@ -7,12 +7,14 @@ go_library(
     srcs = [
         "beacon_service_mock.go",
         "db_test_util.go",
+        "db_test_util_deprecated.go",
         "validator_service_mock.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/internal",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/db:go_default_library",
+        "//beacon-chain/db/kv:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
         "//shared/testutil:go_default_library",

--- a/beacon-chain/internal/db_test_util.go
+++ b/beacon-chain/internal/db_test_util.go
@@ -8,12 +8,13 @@ import (
 	"path"
 	"testing"
 
-	db "github.com/prysmaticlabs/prysm/beacon-chain/db/kv"
+	"github.com/prysmaticlabs/prysm/beacon-chain/db"
+	kv "github.com/prysmaticlabs/prysm/beacon-chain/db/kv"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
 // SetupDB instantiates and returns a BeaconDB instance.
-func SetupDB(t testing.TB) *db.Store {
+func SetupDB(t testing.TB) db.Database {
 	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	if err != nil {
 		t.Fatalf("Could not generate random file path: %v", err)
@@ -22,7 +23,7 @@ func SetupDB(t testing.TB) *db.Store {
 	if err := os.RemoveAll(path); err != nil {
 		t.Fatalf("Failed to remove directory: %v", err)
 	}
-	db, err := db.NewKVStore(path)
+	db, err := kv.NewKVStore(path)
 	if err != nil {
 		t.Fatalf("Could not setup DB: %v", err)
 	}
@@ -30,7 +31,7 @@ func SetupDB(t testing.TB) *db.Store {
 }
 
 // TeardownDB cleans up a BeaconDB instance.
-func TeardownDB(t testing.TB, db *db.Store) {
+func TeardownDB(t testing.TB, db *kv.Store) {
 	if err := db.Close(); err != nil {
 		t.Fatalf("Failed to close database: %v", err)
 	}

--- a/beacon-chain/internal/db_test_util_deprecated.go
+++ b/beacon-chain/internal/db_test_util_deprecated.go
@@ -8,12 +8,13 @@ import (
 	"path"
 	"testing"
 
-	db "github.com/prysmaticlabs/prysm/beacon-chain/db/kv"
+	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
-// SetupDB instantiates and returns a BeaconDB instance.
-func SetupDB(t testing.TB) *db.Store {
+// SetupDBDeprecated instantiates and returns a BeaconDB instance.
+// This is deprecated and used to set up the pre refactored db for testing.
+func SetupDBDeprecated(t testing.TB) *db.BeaconDB {
 	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	if err != nil {
 		t.Fatalf("Could not generate random file path: %v", err)
@@ -22,15 +23,16 @@ func SetupDB(t testing.TB) *db.Store {
 	if err := os.RemoveAll(path); err != nil {
 		t.Fatalf("Failed to remove directory: %v", err)
 	}
-	db, err := db.NewKVStore(path)
+	db, err := db.NewDB(path)
 	if err != nil {
 		t.Fatalf("Could not setup DB: %v", err)
 	}
 	return db
 }
 
-// TeardownDB cleans up a BeaconDB instance.
-func TeardownDB(t testing.TB, db *db.Store) {
+// TeardownDBDeprecated cleans up a BeaconDB instance.
+// This is deprecated and used to tear up the pre refactored db for testing.
+func TeardownDBDeprecated(t testing.TB, db *db.BeaconDB) {
 	if err := db.Close(); err != nil {
 		t.Fatalf("Failed to close database: %v", err)
 	}

--- a/beacon-chain/operations/service_test.go
+++ b/beacon-chain/operations/service_test.go
@@ -70,8 +70,8 @@ func TestServiceStatus_Error(t *testing.T) {
 
 func TestIncomingExits_Ok(t *testing.T) {
 	hook := logTest.NewGlobal()
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	service := NewOpsPoolService(context.Background(), &Config{BeaconDB: beaconDB})
 
 	exit := &ethpb.VoluntaryExit{Epoch: 100}
@@ -84,8 +84,8 @@ func TestIncomingExits_Ok(t *testing.T) {
 }
 
 func TestHandleAttestation_Saves_NewAttestation(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	broadcaster := &mockBroadcaster{}
 	service := NewOpsPoolService(context.Background(), &Config{
 		BeaconDB: beaconDB,
@@ -164,8 +164,8 @@ func TestHandleAttestation_Saves_NewAttestation(t *testing.T) {
 }
 
 func TestHandleAttestation_Aggregates_SameAttestationData(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	broadcaster := &mockBroadcaster{}
 	service := NewOpsPoolService(context.Background(), &Config{
 		BeaconDB: beaconDB,
@@ -293,8 +293,8 @@ func TestHandleAttestation_Aggregates_SameAttestationData(t *testing.T) {
 }
 
 func TestHandleAttestation_Skips_PreviouslyAggregatedAttestations(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	helpers.ClearAllCaches()
 	broadcaster := &mockBroadcaster{}
 	service := NewOpsPoolService(context.Background(), &Config{
@@ -474,8 +474,8 @@ func TestHandleAttestation_Skips_PreviouslyAggregatedAttestations(t *testing.T) 
 func TestRetrieveAttestations_OK(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	service := NewOpsPoolService(context.Background(), &Config{BeaconDB: beaconDB})
 
 	// Save 140 attestations for test. During 1st retrieval we should get slot:1 - slot:61 attestations.
@@ -519,8 +519,8 @@ func TestRetrieveAttestations_OK(t *testing.T) {
 func TestRetrieveAttestations_PruneInvalidAtts(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	service := NewOpsPoolService(context.Background(), &Config{BeaconDB: beaconDB})
 
 	// Save 140 attestations for slots 0 to 139.
@@ -569,8 +569,8 @@ func TestRetrieveAttestations_PruneInvalidAtts(t *testing.T) {
 }
 
 func TestRemoveProcessedAttestations_Ok(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	s := NewOpsPoolService(context.Background(), &Config{BeaconDB: db})
 
 	attestations := make([]*ethpb.Attestation, 10)
@@ -615,8 +615,8 @@ func TestRemoveProcessedAttestations_Ok(t *testing.T) {
 }
 
 func TestReceiveBlkRemoveOps_Ok(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	s := NewOpsPoolService(context.Background(), &Config{BeaconDB: db})
 
 	attestations := make([]*ethpb.Attestation, 10)
@@ -669,8 +669,8 @@ func TestReceiveBlkRemoveOps_Ok(t *testing.T) {
 func TestIsCanonical_CanGetCanonical(t *testing.T) {
 	t.Skip()
 	// TODO(#2307): This will be irrelevant after the revamp of our DB package post v0.6.
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	s := NewOpsPoolService(context.Background(), &Config{BeaconDB: db})
 
 	cb1 := &ethpb.BeaconBlock{Slot: 999, ParentRoot: []byte{'A'}}
@@ -710,8 +710,8 @@ func TestIsCanonical_CanGetCanonical(t *testing.T) {
 }
 
 func TestIsCanonical_NilBlocks(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	s := NewOpsPoolService(context.Background(), &Config{BeaconDB: db})
 
 	canonical, err := s.IsAttCanonical(context.Background(), &ethpb.Attestation{Data: &ethpb.AttestationData{}})

--- a/beacon-chain/rpc/attester_server_test.go
+++ b/beacon-chain/rpc/attester_server_test.go
@@ -23,8 +23,8 @@ func (m *mockBroadcaster) Broadcast(ctx context.Context, msg proto.Message) {
 }
 
 func TestSubmitAttestation_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	mockOperationService := &mockOperationService{}
 	attesterServer := &AttesterServer{
 		operationService: mockOperationService,
@@ -80,8 +80,8 @@ func TestSubmitAttestation_OK(t *testing.T) {
 }
 
 func TestRequestAttestation_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	block := &ethpb.BeaconBlock{
@@ -193,8 +193,8 @@ func TestAttestationDataAtSlot_handlesFarAwayJustifiedEpoch(t *testing.T) {
 	// HistoricalRootsLimit = 8192
 	//
 	// More background: https://github.com/prysmaticlabs/prysm/issues/2153
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	// This test breaks if it doesnt use mainnet config
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())

--- a/beacon-chain/rpc/beacon_chain_server_test.go
+++ b/beacon-chain/rpc/beacon_chain_server_test.go
@@ -37,8 +37,8 @@ func (m *mockPool) AttestationPool(ctx context.Context, expectedSlot uint64) ([]
 }
 
 func TestBeaconChainServer_ListAttestationsNoPagination(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	count := uint64(10)
@@ -72,8 +72,8 @@ func TestBeaconChainServer_ListAttestationsNoPagination(t *testing.T) {
 }
 
 func TestBeaconChainServer_ListAttestationsPagination(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	count := uint64(100)
@@ -170,8 +170,8 @@ func TestBeaconChainServer_ListAttestationsPagination(t *testing.T) {
 }
 
 func TestBeaconChainServer_ListAttestationsPaginationOutOfRange(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	count := uint64(1)
@@ -214,8 +214,8 @@ func TestBeaconChainServer_ListAttestationsExceedsMaxPageSize(t *testing.T) {
 }
 
 func TestBeaconChainServer_ListAttestationsDefaultPageSize(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	count := uint64(params.BeaconConfig().DefaultPageSize)
@@ -253,8 +253,8 @@ func TestBeaconChainServer_ListAttestationsDefaultPageSize(t *testing.T) {
 
 func TestBeaconChainServer_AttestationPool(t *testing.T) {
 	ctx := context.Background()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	bs := &BeaconChainServer{
 		pool:     &mockPool{},
 		beaconDB: db,
@@ -276,8 +276,8 @@ func TestBeaconChainServer_AttestationPool(t *testing.T) {
 }
 
 func TestBeaconChainServer_ListValidatorBalances(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	count := 100
 	balances := make([]uint64, count)
@@ -345,8 +345,8 @@ func TestBeaconChainServer_ListValidatorBalances(t *testing.T) {
 }
 
 func TestBeaconChainServer_ListValidatorBalancesOutOfRange(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	count := 1
 	balances := make([]uint64, count)
@@ -377,8 +377,8 @@ func TestBeaconChainServer_ListValidatorBalancesOutOfRange(t *testing.T) {
 }
 
 func TestBeaconChainServer_GetValidatorsNoPagination(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	count := 100
 	validators := make([]*ethpb.Validator, 0, count)
@@ -410,8 +410,8 @@ func TestBeaconChainServer_GetValidatorsNoPagination(t *testing.T) {
 }
 
 func TestBeaconChainServer_GetValidatorsPagination(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	count := 100
 	balances := make([]uint64, count)
@@ -482,8 +482,8 @@ func TestBeaconChainServer_GetValidatorsPagination(t *testing.T) {
 }
 
 func TestBeaconChainServer_GetValidatorsPaginationOutOfRange(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	count := 1
 	validators := make([]*ethpb.Validator, 0, count)
@@ -523,8 +523,8 @@ func TestBeaconChainServer_GetValidatorsExceedsMaxPageSize(t *testing.T) {
 }
 
 func TestBeaconChainServer_GetValidatorsDefaultPageSize(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	count := 1000
 	validators := make([]*ethpb.Validator, 0, count)
@@ -559,8 +559,8 @@ func TestBeaconChainServer_GetValidatorsDefaultPageSize(t *testing.T) {
 }
 
 func TestBeaconChainServer_ListAssignmentsInputOutOfRange(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	count := 1
 	validators := make([]*ethpb.Validator, 0, count)
@@ -597,8 +597,8 @@ func TestBeaconChainServer_ListAssignmentsExceedsMaxPageSize(t *testing.T) {
 }
 
 func TestBeaconChainServer_ListAssignmentsDefaultPageSize(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	count := 1000
 	validators := make([]*ethpb.Validator, 0, count)
@@ -659,8 +659,8 @@ func TestBeaconChainServer_ListAssignmentsDefaultPageSize(t *testing.T) {
 
 func TestBeaconChainServer_ListAssignmentsFilterPubkeysIndicesNoPage(t *testing.T) {
 	helpers.ClearAllCaches()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	count := 100
 	validators := make([]*ethpb.Validator, 0, count)
@@ -717,8 +717,8 @@ func TestBeaconChainServer_ListAssignmentsFilterPubkeysIndicesNoPage(t *testing.
 
 func TestBeaconChainServer_ListAssignmentsCanFilterPubkeysIndicesWithPages(t *testing.T) {
 	helpers.ClearAllCaches()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	count := 100
 	validators := make([]*ethpb.Validator, 0, count)
@@ -814,8 +814,8 @@ func TestBeaconChainServer_ListAssignmentsCanFilterPubkeysIndicesWithPages(t *te
 func TestBeaconChainServer_GetValidatorsParticipation(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	epoch := uint64(1)
 	attestedBalance := uint64(1)
@@ -885,8 +885,8 @@ func TestBeaconChainServer_GetValidatorsParticipation(t *testing.T) {
 }
 
 func TestBeaconChainServer_ListBlocksPagination(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	count := uint64(100)
@@ -980,8 +980,8 @@ func TestBeaconChainServer_ListBlocksPagination(t *testing.T) {
 
 func TestBeaconChainServer_ListBlocksErrors(t *testing.T) {
 	ctx := context.Background()
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	bs := &BeaconChainServer{beaconDB: db}
 	exceedsMax := int32(params.BeaconConfig().MaxPageSize + 1)

--- a/beacon-chain/rpc/beacon_server_test.go
+++ b/beacon-chain/rpc/beacon_server_test.go
@@ -248,8 +248,8 @@ func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 }
 
 func TestBlockTree_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 	// We want to ensure that if our block tree looks as follows, the RPC response
 	// returns the correct information.
@@ -469,8 +469,8 @@ func TestBlockTree_OK(t *testing.T) {
 }
 
 func TestBlockTreeBySlots_ArgsValildation(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 	// We want to ensure that if our block tree looks as follows, the RPC response
 	// returns the correct information.
@@ -680,8 +680,8 @@ func TestBlockTreeBySlots_ArgsValildation(t *testing.T) {
 func TestBlockTreeBySlots_OK(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 	// We want to ensure that if our block tree looks as follows, the RPC response
 	// returns the correct information.

--- a/beacon-chain/rpc/node_server_test.go
+++ b/beacon-chain/rpc/node_server_test.go
@@ -48,8 +48,8 @@ func TestNodeServer_GetSyncStatus(t *testing.T) {
 }
 
 func TestNodeServer_GetGenesis(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 	addr := [20]byte{1, 2, 3, 4, 5, 6}
 	beaconDB.VerifyContractAddress(ctx, common.Address(addr))

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -30,8 +30,8 @@ func init() {
 }
 
 func TestProposeBlock_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	mockChain := &mockChainService{}
 	ctx := context.Background()
 
@@ -69,8 +69,8 @@ func TestProposeBlock_OK(t *testing.T) {
 }
 
 func TestComputeStateRoot_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 	helpers.ClearAllCaches()
 
@@ -146,8 +146,8 @@ func TestComputeStateRoot_OK(t *testing.T) {
 func TestPendingAttestations_FiltersWithinInclusionDelay(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	// This test breaks if it doesnt use mainnet config
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
@@ -261,8 +261,8 @@ func TestPendingAttestations_FiltersWithinInclusionDelay(t *testing.T) {
 }
 
 func TestPendingAttestations_FiltersExpiredAttestations(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	// This test breaks if it doesnt use mainnet config
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
@@ -470,7 +470,7 @@ func TestPendingDeposits_Eth1DataVoteOK(t *testing.T) {
 			int(newHeight.Int64()): []byte("0x1"),
 		},
 	}
-	d := internal.SetupDB(t)
+	d := internal.SetupDBDeprecated(t)
 
 	var votes []*ethpb.Eth1Data
 
@@ -558,7 +558,7 @@ func TestPendingDeposits_OutsideEth1FollowWindow(t *testing.T) {
 			int(height.Int64()): []byte("0x0"),
 		},
 	}
-	d := internal.SetupDB(t)
+	d := internal.SetupDBDeprecated(t)
 
 	beaconState := &pbp2p.BeaconState{
 		Eth1Data: &ethpb.Eth1Data{
@@ -681,7 +681,7 @@ func TestPendingDeposits_FollowsCorrectEth1Block(t *testing.T) {
 			int(newHeight.Int64()): []byte("0x1"),
 		},
 	}
-	d := internal.SetupDB(t)
+	d := internal.SetupDBDeprecated(t)
 
 	var votes []*ethpb.Eth1Data
 
@@ -815,7 +815,7 @@ func TestPendingDeposits_CantReturnBelowStateEth1DepositIndex(t *testing.T) {
 			int(height.Int64()): []byte("0x0"),
 		},
 	}
-	d := internal.SetupDB(t)
+	d := internal.SetupDBDeprecated(t)
 
 	beaconState := &pbp2p.BeaconState{
 		Eth1Data: &ethpb.Eth1Data{
@@ -917,7 +917,7 @@ func TestPendingDeposits_CantReturnMoreThanMax(t *testing.T) {
 			int(height.Int64()): []byte("0x0"),
 		},
 	}
-	d := internal.SetupDB(t)
+	d := internal.SetupDBDeprecated(t)
 
 	beaconState := &pbp2p.BeaconState{
 		Eth1Data: &ethpb.Eth1Data{
@@ -1016,7 +1016,7 @@ func TestPendingDeposits_CantReturnMoreDepositCount(t *testing.T) {
 			int(height.Int64()): []byte("0x0"),
 		},
 	}
-	d := internal.SetupDB(t)
+	d := internal.SetupDBDeprecated(t)
 
 	beaconState := &pbp2p.BeaconState{
 		Eth1Data: &ethpb.Eth1Data{
@@ -1106,8 +1106,8 @@ func TestPendingDeposits_CantReturnMoreDepositCount(t *testing.T) {
 }
 
 func TestEth1Data_EmptyVotesFetchBlockHashFailure(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	proposerServer := &ProposerServer{
@@ -1132,8 +1132,8 @@ func TestEth1Data_EmptyVotesFetchBlockHashFailure(t *testing.T) {
 }
 
 func TestDefaultEth1Data_NoBlockExists(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 	ctx := context.Background()
 
 	height := big.NewInt(int64(params.BeaconConfig().Eth1FollowDistance))
@@ -1199,8 +1199,8 @@ func TestDefaultEth1Data_NoBlockExists(t *testing.T) {
 
 // TODO(2312): Add more tests for edge cases and better coverage.
 func TestEth1Data(t *testing.T) {
-	beaconDB := internal.SetupDB(t)
-	defer internal.TeardownDB(t, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, beaconDB)
 
 	slot := uint64(10000)
 
@@ -1231,8 +1231,8 @@ func TestEth1Data(t *testing.T) {
 }
 
 func Benchmark_Eth1Data(b *testing.B) {
-	beaconDB := internal.SetupDB(b)
-	defer internal.TeardownDB(b, beaconDB)
+	beaconDB := internal.SetupDBDeprecated(b)
+	defer internal.TeardownDBDeprecated(b, beaconDB)
 	ctx := context.Background()
 
 	hashesByHeight := make(map[int][]byte)
@@ -1314,7 +1314,7 @@ func TestDeposits_ReturnsEmptyList_IfLatestEth1DataEqGenesisEth1Block(t *testing
 		},
 		genesisEth1Block: height,
 	}
-	d := internal.SetupDB(t)
+	d := internal.SetupDBDeprecated(t)
 
 	beaconState := &pbp2p.BeaconState{
 		Eth1Data: &ethpb.Eth1Data{

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -31,8 +31,8 @@ import (
 )
 
 func TestValidatorIndex_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	pubKey := []byte{'A'}
 	if err := db.SaveValidatorIndex(pubKey, 0); err != nil {
@@ -52,8 +52,8 @@ func TestValidatorIndex_OK(t *testing.T) {
 }
 
 func TestValidatorIndex_InStateNotInDB(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 
 	pubKey := []byte{'A'}
 
@@ -94,9 +94,9 @@ func TestValidatorIndex_InStateNotInDB(t *testing.T) {
 }
 
 func TestNextEpochCommitteeAssignment_WrongPubkeyLength(t *testing.T) {
-	db := internal.SetupDB(t)
+	db := internal.SetupDBDeprecated(t)
 	ctx := context.Background()
-	defer internal.TeardownDB(t, db)
+	defer internal.TeardownDBDeprecated(t, db)
 	helpers.ClearAllCaches()
 
 	deposits, _ := testutil.SetupInitialDeposits(t, 8)
@@ -128,8 +128,8 @@ func TestNextEpochCommitteeAssignment_WrongPubkeyLength(t *testing.T) {
 }
 
 func TestNextEpochCommitteeAssignment_CantFindValidatorIdx(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 	genesis := blk.NewGenesisBlock([]byte{})
 	if err := db.SaveBlock(genesis); err != nil {
@@ -159,8 +159,8 @@ func TestNextEpochCommitteeAssignment_CantFindValidatorIdx(t *testing.T) {
 func TestCommitteeAssignment_OK(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	genesis := blk.NewGenesisBlock([]byte{})
@@ -240,8 +240,8 @@ func TestCommitteeAssignment_OK(t *testing.T) {
 func TestCommitteeAssignment_CurrentEpoch_ShouldNotFail(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	genesis := blk.NewGenesisBlock([]byte{})
@@ -296,8 +296,8 @@ func TestCommitteeAssignment_CurrentEpoch_ShouldNotFail(t *testing.T) {
 }
 
 func TestCommitteeAssignment_multipleKeys_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	genesis := blk.NewGenesisBlock([]byte{})
@@ -354,8 +354,8 @@ func TestCommitteeAssignment_multipleKeys_OK(t *testing.T) {
 }
 
 func TestValidatorStatus_PendingActive(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	pubKey := []byte{'A'}
@@ -408,8 +408,8 @@ func TestValidatorStatus_PendingActive(t *testing.T) {
 }
 
 func TestValidatorStatus_Active(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	// This test breaks if it doesnt use mainnet config
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
@@ -476,8 +476,8 @@ func TestValidatorStatus_Active(t *testing.T) {
 }
 
 func TestValidatorStatus_InitiatedExit(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	pubKey := []byte{'A'}
@@ -536,8 +536,8 @@ func TestValidatorStatus_InitiatedExit(t *testing.T) {
 }
 
 func TestValidatorStatus_Withdrawable(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	pubKey := []byte{'A'}
@@ -593,8 +593,8 @@ func TestValidatorStatus_Withdrawable(t *testing.T) {
 }
 
 func TestValidatorStatus_ExitedSlashed(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	pubKey := []byte{'A'}
@@ -650,8 +650,8 @@ func TestValidatorStatus_ExitedSlashed(t *testing.T) {
 }
 
 func TestValidatorStatus_Exited(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	pubKey := []byte{'A'}
@@ -706,8 +706,8 @@ func TestValidatorStatus_Exited(t *testing.T) {
 }
 
 func TestValidatorStatus_UnknownStatus(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	pubKey := []byte{'A'}
@@ -760,8 +760,8 @@ func TestValidatorStatus_UnknownStatus(t *testing.T) {
 }
 
 func TestWaitForActivation_ContextClosed(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	beaconState := &pbp2p.BeaconState{
@@ -803,8 +803,8 @@ func TestWaitForActivation_ContextClosed(t *testing.T) {
 }
 
 func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	// This test breaks if it doesnt use mainnet config
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
@@ -912,8 +912,8 @@ func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 }
 
 func TestMultipleValidatorStatus_OK(t *testing.T) {
-	db := internal.SetupDB(t)
-	defer internal.TeardownDB(t, db)
+	db := internal.SetupDBDeprecated(t)
+	defer internal.TeardownDBDeprecated(t, db)
 	ctx := context.Background()
 
 	pubKeys := [][]byte{{'A'}, {'B'}, {'C'}}


### PR DESCRIPTION
This PR postfixed the old `SetupDB` and `TeardownDB` test util as deprecated. It also adds the new `SetupDB` and `TeardownDB ` that points to the new /db/kv store