### PR TITLE
Add varint prefixing to ssz network encoder

### DIFF
--- a/beacon-chain/p2p/encoder/BUILD.bazel
+++ b/beacon-chain/p2p/encoder/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "doc.go",
         "network_encoding.go",
         "ssz.go",
+        "varint.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder",
     visibility = ["//beacon-chain:__subpackages__"],
@@ -18,7 +19,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["ssz_test.go"],
+    srcs = [
+        "ssz_test.go",
+        "varint_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//proto/testing:go_default_library",

--- a/beacon-chain/p2p/encoder/network_encoding.go
+++ b/beacon-chain/p2p/encoder/network_encoding.go
@@ -1,11 +1,17 @@
 package encoder
 
-import "github.com/gogo/protobuf/proto"
+import (
+	"io"
+
+	"github.com/gogo/protobuf/proto"
+)
 
 // NetworkEncoding represents an encoder compatible with Ethereum 2.0 p2p.
 type NetworkEncoding interface {
-	// DecodeTo accepts a byte slice and decodes it to the provided message.
-	DecodeTo([]byte, proto.Message) error
-	// Encode an arbitrary message to bytes.
-	Encode(proto.Message) ([]byte, error)
+	// Decode reads bytes from the reader and decodes it to the provided message.
+	Decode(io.Reader, proto.Message) error
+	// Encode an arbitrary message to the provided writer.
+	Encode(io.Writer, proto.Message) (int, error)
+	// ProtocolSuffix returns the last part of the protocol ID to indicate the encoding scheme.
+	ProtocolSuffix() string
 }

--- a/beacon-chain/p2p/encoder/ssz.go
+++ b/beacon-chain/p2p/encoder/ssz.go
@@ -16,7 +16,7 @@ type SszNetworkEncoder struct {
 	UseSnappyCompression bool
 }
 
-// Encode the proto message to bytes. This encoding prefixes the byte slice with a protobuf varint
+// Encode the proto message to the io.Writer. This encoding prefixes the byte slice with a protobuf varint
 // to indicate the size of the message.
 func (e SszNetworkEncoder) Encode(w io.Writer, msg proto.Message) (int, error) {
 	if msg == nil {
@@ -34,7 +34,7 @@ func (e SszNetworkEncoder) Encode(w io.Writer, msg proto.Message) (int, error) {
 	return w.Write(b)
 }
 
-// DecodeTo decodes the bytes to the protobuf message provided.
+// Decode the bytes from io.Reader to the protobuf message provided.
 func (e SszNetworkEncoder) Decode(r io.Reader, to proto.Message) error {
 	msgLen, err := readVarint(r)
 	if err != nil {
@@ -56,6 +56,7 @@ func (e SszNetworkEncoder) Decode(r io.Reader, to proto.Message) error {
 	return ssz.Unmarshal(b, to)
 }
 
+// ProtocolSuffix returns the appropriate suffix for protocol IDs.
 func (e SszNetworkEncoder) ProtocolSuffix() string {
 	if e.UseSnappyCompression {
 		return "/ssz_snappy"

--- a/beacon-chain/p2p/encoder/ssz.go
+++ b/beacon-chain/p2p/encoder/ssz.go
@@ -1,6 +1,8 @@
 package encoder
 
 import (
+	"io"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
 	"github.com/prysmaticlabs/go-ssz"
@@ -14,24 +16,35 @@ type SszNetworkEncoder struct {
 	UseSnappyCompression bool
 }
 
-// Encode the proto message to bytes.
-func (e SszNetworkEncoder) Encode(msg proto.Message) ([]byte, error) {
+// Encode the proto message to bytes. This encoding prefixes the byte slice with a protobuf varint
+// to indicate the size of the message.
+func (e SszNetworkEncoder) Encode(w io.Writer, msg proto.Message) (int, error) {
 	if msg == nil {
-		return nil, nil
+		return 0, nil
 	}
 
 	b, err := ssz.Marshal(msg)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 	if e.UseSnappyCompression {
 		b = snappy.Encode(nil /*dst*/, b)
 	}
-	return b, nil
+	b = append(proto.EncodeVarint(uint64(len(b))), b...)
+	return w.Write(b)
 }
 
 // DecodeTo decodes the bytes to the protobuf message provided.
-func (e SszNetworkEncoder) DecodeTo(b []byte, to proto.Message) error {
+func (e SszNetworkEncoder) Decode(r io.Reader, to proto.Message) error {
+	msgLen, err := readVarint(r)
+	if err != nil {
+		return err
+	}
+	b := make([]byte, msgLen)
+	_, err = r.Read(b)
+	if err != nil {
+		return err
+	}
 	if e.UseSnappyCompression {
 		var err error
 		b, err = snappy.Decode(nil /*dst*/, b)
@@ -41,4 +54,11 @@ func (e SszNetworkEncoder) DecodeTo(b []byte, to proto.Message) error {
 	}
 
 	return ssz.Unmarshal(b, to)
+}
+
+func (e SszNetworkEncoder) ProtocolSuffix() string {
+	if e.UseSnappyCompression {
+		return "/ssz_snappy"
+	}
+	return "/ssz"
 }

--- a/beacon-chain/p2p/encoder/ssz_test.go
+++ b/beacon-chain/p2p/encoder/ssz_test.go
@@ -1,11 +1,13 @@
 package encoder_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
-	encoder "github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
 	testpb "github.com/prysmaticlabs/prysm/proto/testing"
+
+	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
 )
 
 func TestSszNetworkEncoder_RoundTrip(t *testing.T) {
@@ -19,16 +21,17 @@ func TestSszNetworkEncoder_RoundTrip_Snappy(t *testing.T) {
 }
 
 func testRoundTrip(t *testing.T, e *encoder.SszNetworkEncoder) {
+	buf := new(bytes.Buffer)
 	msg := &testpb.TestSimpleMessage{
 		Foo: []byte("fooooo"),
 		Bar: 9001,
 	}
-	encoded, err := e.Encode(msg)
+	_, err := e.Encode(buf, msg)
 	if err != nil {
 		t.Fatal(err)
 	}
 	decoded := &testpb.TestSimpleMessage{}
-	if err := e.DecodeTo(encoded, decoded); err != nil {
+	if err := e.Decode(buf, decoded); err != nil {
 		t.Fatal(err)
 	}
 	if !proto.Equal(decoded, msg) {

--- a/beacon-chain/p2p/encoder/ssz_test.go
+++ b/beacon-chain/p2p/encoder/ssz_test.go
@@ -5,9 +5,8 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
-	testpb "github.com/prysmaticlabs/prysm/proto/testing"
-
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
+	testpb "github.com/prysmaticlabs/prysm/proto/testing"
 )
 
 func TestSszNetworkEncoder_RoundTrip(t *testing.T) {

--- a/beacon-chain/p2p/encoder/varint.go
+++ b/beacon-chain/p2p/encoder/varint.go
@@ -24,7 +24,7 @@ func readVarint(r io.Reader) (uint64, error) {
 		}
 		b = append(b, b1[0])
 
-		// If most signficant bit is not set, we have reached the end of the Varint.
+		// If most significant bit is not set, we have reached the end of the Varint.
 		if b1[0]&0x80 == 0 {
 			break
 		}

--- a/beacon-chain/p2p/encoder/varint.go
+++ b/beacon-chain/p2p/encoder/varint.go
@@ -1,0 +1,36 @@
+package encoder
+
+import (
+	"errors"
+	"io"
+
+	"github.com/gogo/protobuf/proto"
+)
+
+const maxVarintLength = 10
+
+func readVarint(r io.Reader) (uint64, error) {
+	b := make([]byte, 0, maxVarintLength)
+	for i := 0; i < maxVarintLength; i++ {
+		b1 := make([]byte, 1)
+		n, err := r.Read(b1)
+		if err != nil {
+			return 0, err
+		}
+		if n != 1 {
+			return 0, errors.New("did not read a byte from stream")
+		}
+		b = append(b, b1[0])
+
+		// If most signficant bit is not set, we have reached the end of the Varint.
+		if b1[0]&0x80 == 0 {
+			break
+		}
+	}
+
+	vi, n := proto.DecodeVarint(b)
+	if n != len(b) {
+		return 0, errors.New("varint did not decode entire byte slice")
+	}
+	return vi, nil
+}

--- a/beacon-chain/p2p/encoder/varint.go
+++ b/beacon-chain/p2p/encoder/varint.go
@@ -9,6 +9,8 @@ import (
 
 const maxVarintLength = 10
 
+// readVarint at the beginning of a byte slice. This varint may be used to indicate
+// the length of the remaining bytes in the reader.
 func readVarint(r io.Reader) (uint64, error) {
 	b := make([]byte, 0, maxVarintLength)
 	for i := 0; i < maxVarintLength; i++ {

--- a/beacon-chain/p2p/encoder/varint_test.go
+++ b/beacon-chain/p2p/encoder/varint_test.go
@@ -1,0 +1,21 @@
+package encoder
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+)
+
+func TestReadVarint(t *testing.T) {
+	data := []byte("foobar data")
+	prefixedData := append(proto.EncodeVarint(uint64(len(data))), data...)
+
+	vi, err := readVarint(bytes.NewBuffer(prefixedData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if vi != uint64(len(data)) {
+		t.Errorf("Received wrong varint. Wanted %d, got %d", len(data), vi)
+	}
+}


### PR DESCRIPTION
Part of #3147 

P2P messages with SSZ must have the length of the data prefixed as a protobuf.Varint.

There's also some API changes with the network encoder to support `io.Reader` which plays much nicer with libp2p streams than `[]byte`. 