### PR TITLE
remove the fork version changes from 3216

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -76,21 +76,6 @@ func NewBeaconNode(ctx *cli.Context) (*BeaconNode, error) {
 	if !ctx.GlobalBool(flags.NoCustomConfigFlag.Name) {
 		log.Info("Using custom parameter configuration")
 		params.UseDemoBeaconConfig()
-
-		// For demo purposes, set the genesis fork version to the first 4 bytes of the deposit
-		// contract address.
-		depAddress := ctx.GlobalString(flags.DepositContractFlag.Name)
-		if depAddress == "" {
-			var err error
-			depAddress, err = fetchDepositContract()
-			if err != nil {
-				log.WithError(err).Fatal("Cannot fetch deposit contract")
-			}
-		}
-		cfg := params.BeaconConfig()
-		a := common.HexToAddress(depAddress)
-		cfg.GenesisForkVersion = a[0:4]
-		params.OverrideBeaconConfig(cfg)
 	}
 
 	featureconfig.ConfigureBeaconFeatures(ctx)


### PR DESCRIPTION
Resolves #3223.

The fork version changes would need to be added everywhere deposits are calculated. 
Instead of using these changes for genesis fork version, we'll add a parameter in p2p that advertises a fork version for handshakes specifically for prysm testnets. 

Reverts part of #3216 