### PR TITLE
Allow Nil Return from DB Methods

### DIFF
--- a/beacon-chain/db/kv/attestations.go
+++ b/beacon-chain/db/kv/attestations.go
@@ -15,13 +15,14 @@ import (
 
 // Attestation retrieval by attestation data root.
 func (k *Store) Attestation(ctx context.Context, attDataRoot [32]byte) (*ethpb.Attestation, error) {
-	att := &ethpb.Attestation{}
+	var att *ethpb.Attestation
 	err := k.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(attestationsBucket)
 		enc := bkt.Get(attDataRoot[:])
 		if enc == nil {
 			return nil
 		}
+		att = &ethpb.Attestation{}
 		return proto.Unmarshal(enc, att)
 	})
 	return att, err

--- a/beacon-chain/db/kv/attestations_test.go
+++ b/beacon-chain/db/kv/attestations_test.go
@@ -31,10 +31,17 @@ func TestStore_AttestationCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	retrievedAtt, err := db.Attestation(ctx, attDataRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retrievedAtt != nil {
+		t.Errorf("Expected nil attestation, received %v", retrievedAtt)
+	}
 	if !db.HasAttestation(ctx, attDataRoot) {
 		t.Error("Expected attestation to exist in the db")
 	}
-	retrievedAtt, err := db.Attestation(ctx, attDataRoot)
+	retrievedAtt, err = db.Attestation(ctx, attDataRoot)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/db/kv/attestations_test.go
+++ b/beacon-chain/db/kv/attestations_test.go
@@ -24,9 +24,6 @@ func TestStore_AttestationCRUD(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	if err := db.SaveAttestation(ctx, att); err != nil {
-		t.Fatal(err)
-	}
 	attDataRoot, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {
 		t.Fatal(err)
@@ -37,6 +34,9 @@ func TestStore_AttestationCRUD(t *testing.T) {
 	}
 	if retrievedAtt != nil {
 		t.Errorf("Expected nil attestation, received %v", retrievedAtt)
+	}
+	if err := db.SaveAttestation(ctx, att); err != nil {
+		t.Fatal(err)
 	}
 	if !db.HasAttestation(ctx, attDataRoot) {
 		t.Error("Expected attestation to exist in the db")

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -16,13 +16,14 @@ import (
 
 // Block retrieval by root.
 func (k *Store) Block(ctx context.Context, blockRoot [32]byte) (*ethpb.BeaconBlock, error) {
-	block := &ethpb.BeaconBlock{}
+	var block *ethpb.BeaconBlock
 	err := k.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(blocksBucket)
 		enc := bkt.Get(blockRoot[:])
 		if enc == nil {
 			return nil
 		}
+		block = &ethpb.BeaconBlock{}
 		return proto.Unmarshal(enc, block)
 	})
 	return block, err
@@ -30,7 +31,7 @@ func (k *Store) Block(ctx context.Context, blockRoot [32]byte) (*ethpb.BeaconBlo
 
 // HeadBlock returns the latest canonical block in eth2.
 func (k *Store) HeadBlock(ctx context.Context) (*ethpb.BeaconBlock, error) {
-	headBlock := &ethpb.BeaconBlock{}
+	var headBlock *ethpb.BeaconBlock
 	err := k.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(validatorsBucket)
 		headRoot := bkt.Get(headBlockRootKey)
@@ -41,6 +42,7 @@ func (k *Store) HeadBlock(ctx context.Context) (*ethpb.BeaconBlock, error) {
 		if enc == nil {
 			return nil
 		}
+		headBlock = &ethpb.BeaconBlock{}
 		return proto.Unmarshal(enc, headBlock)
 	})
 	return headBlock, err

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -13,22 +13,29 @@ import (
 func TestStore_BlocksCRUD(t *testing.T) {
 	db := setupDB(t)
 	defer teardownDB(t, db)
+	ctx := context.Background()
 	block := &ethpb.BeaconBlock{
 		Slot:       20,
 		ParentRoot: []byte{1, 2, 3},
-	}
-	ctx := context.Background()
-	if err := db.SaveBlock(ctx, block); err != nil {
-		t.Fatal(err)
 	}
 	blockRoot, err := ssz.SigningRoot(block)
 	if err != nil {
 		t.Fatal(err)
 	}
+	retrievedBlock, err := db.Block(ctx, blockRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retrievedBlock != nil {
+		t.Errorf("Expected nil block, received %v", retrievedBlock)
+	}
+	if err := db.SaveBlock(ctx, block); err != nil {
+		t.Fatal(err)
+	}
 	if !db.HasBlock(ctx, blockRoot) {
 		t.Error("Expected block to exist in the db")
 	}
-	retrievedBlock, err := db.Block(ctx, blockRoot)
+	retrievedBlock, err = db.Block(ctx, blockRoot)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -22,7 +22,6 @@ func (k *Store) State(ctx context.Context, blockRoot [32]byte) (*pb.BeaconState,
 
 		var err error
 		s, err = createState(enc)
-
 		return err
 	})
 	return s, err
@@ -45,7 +44,6 @@ func (k *Store) HeadState(ctx context.Context) (*pb.BeaconState, error) {
 
 		var err error
 		s, err = createState(enc)
-
 		return err
 	})
 	return s, err

--- a/beacon-chain/db/kv/validators.go
+++ b/beacon-chain/db/kv/validators.go
@@ -13,13 +13,14 @@ import (
 // ValidatorLatestVote retrieval by validator index.
 func (k *Store) ValidatorLatestVote(ctx context.Context, validatorIdx uint64) (*pb.ValidatorLatestVote, error) {
 	buf := uint64ToBytes(validatorIdx)
-	latestVote := &pb.ValidatorLatestVote{}
+	var latestVote *pb.ValidatorLatestVote
 	err := k.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(validatorsBucket)
 		enc := bkt.Get(buf)
 		if enc == nil {
 			return nil
 		}
+		latestVote = &pb.ValidatorLatestVote{}
 		return proto.Unmarshal(enc, latestVote)
 	})
 	return latestVote, err

--- a/beacon-chain/db/kv/validators_test.go
+++ b/beacon-chain/db/kv/validators_test.go
@@ -45,19 +45,26 @@ func TestStore_ValidatorIndexCRUD(t *testing.T) {
 func TestStore_ValidatorLatestVoteCRUD(t *testing.T) {
 	db := setupDB(t)
 	defer teardownDB(t, db)
+	ctx := context.Background()
 	validatorIdx := uint64(100)
 	latestVote := &pb.ValidatorLatestVote{
 		Epoch: 1,
 		Root:  []byte("root"),
 	}
-	ctx := context.Background()
+	retrievedVote, err := db.ValidatorLatestVote(ctx, validatorIdx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retrievedVote != nil {
+		t.Errorf("Expected nil validator latest vote, received %v", retrievedVote)
+	}
 	if err := db.SaveValidatorLatestVote(ctx, validatorIdx, latestVote); err != nil {
 		t.Fatal(err)
 	}
 	if !db.HasValidatorLatestVote(ctx, validatorIdx) {
 		t.Error("Expected validator latest vote to exist in the db")
 	}
-	retrievedVote, err := db.ValidatorLatestVote(ctx, validatorIdx)
+	retrievedVote, err = db.ValidatorLatestVote(ctx, validatorIdx)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
No tracking issue - the current DB refactor had a bug that would not return a nil element if none was found.
