### PR TITLE
Fix GetHeadFromYaml is flakey

### DIFF
--- a/beacon-chain/blockchain/forkchoice/lmd_ghost_yaml_test.go
+++ b/beacon-chain/blockchain/forkchoice/lmd_ghost_yaml_test.go
@@ -129,8 +129,8 @@ func TestGetHeadFromYaml(t *testing.T) {
 
 		if !bytes.Equal(head, wantedHead) {
 			t.Errorf("wanted root %#x, got root %#x", wantedHead, head)
-		}
-	}
 
-	helpers.ClearAllCaches()
+		}
+		helpers.ClearAllCaches()
+	}
 }

--- a/beacon-chain/blockchain/forkchoice/lmd_ghost_yaml_test.go
+++ b/beacon-chain/blockchain/forkchoice/lmd_ghost_yaml_test.go
@@ -129,8 +129,8 @@ func TestGetHeadFromYaml(t *testing.T) {
 
 		if !bytes.Equal(head, wantedHead) {
 			t.Errorf("wanted root %#x, got root %#x", wantedHead, head)
-
 		}
+
 		helpers.ClearAllCaches()
 	}
 }


### PR DESCRIPTION
The test `GetHeadFromYaml` fails 13 out of 100 times. The clear cache was outside of the test case loop so it only got cleared after all test cases ran