### PR TITLE
Forkchoice get head tiebreaker

### DIFF
--- a/beacon-chain/blockchain/forkchoice/lmd_ghost_test.yaml
+++ b/beacon-chain/blockchain/forkchoice/lmd_ghost_test.yaml
@@ -30,7 +30,7 @@ test_cases:
       b2: 4
       b3: 3
     head: 'b1'
-  # Equal weights children, GHOST chooses b2 because it is lower lexicographically than b3
+  # Equal weights children, GHOST chooses b2 because it is higher lexicographically than b3
   - blocks:
       - id: 'b0'
         parent: 'b0'
@@ -45,7 +45,7 @@ test_cases:
       b2: 6
       b3: 6
     head: 'b2'
-  # Equal weights children, GHOST chooses b1 because it is lower lexicographically than b2
+  # Equal weights children, GHOST chooses b2 because it is higher lexicographically than b1
   - blocks:
       - id: 'b0'
         parent: 'b0'
@@ -56,4 +56,4 @@ test_cases:
     weights:
       b1: 0
       b2: 0
-    head: 'b1'
+    head: 'b2'

--- a/beacon-chain/blockchain/forkchoice/service.go
+++ b/beacon-chain/blockchain/forkchoice/service.go
@@ -225,7 +225,7 @@ func (s *Store) Head(ctx context.Context) ([]byte, error) {
 				}
 				// When there's a tie, it's broken lexicographically to favor the higher one.
 				if balance > highest ||
-					balance == highest && bytes.Compare(child, head)> 0{
+					balance == highest && bytes.Compare(child, head) > 0 {
 					highest = balance
 					head = child
 				}

--- a/beacon-chain/blockchain/forkchoice/service.go
+++ b/beacon-chain/blockchain/forkchoice/service.go
@@ -223,8 +223,9 @@ func (s *Store) Head(ctx context.Context) ([]byte, error) {
 				if err != nil {
 					return nil, errors.Wrap(err, "could not get latest balance")
 				}
-
-				if balance > highest {
+				// When there's a tie, it's broken lexicographically to favor the higher one.
+				if balance > highest ||
+					balance == highest && bytes.Compare(child, head)> 0{
 					highest = balance
 					head = child
 				}


### PR DESCRIPTION
This PR implements tie breaker for for getting head, and fixes existing test for such tie breaker. The tie breaker favors the one that's higher lexicographically