### PR TITLE
Runtime fix for p2p --next

### DIFF
--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -44,7 +44,7 @@ func (r *RegularSync) registerSubscribers() {
 	r.subscribe(
 		"/eth2/beacon_attestation",
 		r.validateBeaconAttestation,
-		r.beaconBlockSubscriber,
+		r.beaconAttestationSubscriber,
 	)
 	r.subscribe(
 		"/eth2/voluntary_exit",

--- a/beacon-chain/sync/subscriber_handlers.go
+++ b/beacon-chain/sync/subscriber_handlers.go
@@ -6,16 +6,16 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func (s *RegularSync) voluntaryExitSubscriber(ctx context.Context, msg proto.Message) error {
-	return s.operations.HandleValidatorExits(ctx, msg)
+func (r *RegularSync) voluntaryExitSubscriber(ctx context.Context, msg proto.Message) error {
+	return r.operations.HandleValidatorExits(ctx, msg)
 }
 
-func (s *RegularSync) attesterSlashingSubscriber(ctx context.Context, msg proto.Message) error {
+func (r *RegularSync) attesterSlashingSubscriber(ctx context.Context, msg proto.Message) error {
 	// TODO(#3259): Requires handlers in operations service to be implemented.
 	return nil
 }
 
-func (s *RegularSync) proposerSlashingSubscriber(ctx context.Context, msg proto.Message) error {
+func (r *RegularSync) proposerSlashingSubscriber(ctx context.Context, msg proto.Message) error {
 	// TODO(#3259): Requires handlers in operations service to be implemented.
 	return nil
 }


### PR DESCRIPTION
No tracking issue, this was causing a panic because it was wrongly registered.

Also renamed some receiver names to be consistent. 