### PR TITLE
p2p --next start error logging

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -57,6 +57,7 @@ func (s *Service) Start() {
 	privKey, err := privKey(s.cfg)
 	if err != nil {
 		s.startupErr = err
+		log.WithError(err).Error("Failed to generate p2p private key")
 		return
 	}
 
@@ -65,6 +66,7 @@ func (s *Service) Start() {
 	h, err := libp2p.New(s.ctx, opts...)
 	if err != nil {
 		s.startupErr = err
+		log.WithError(err).Error("Failed to create p2p host")
 		return
 	}
 	s.host = h


### PR DESCRIPTION
No tracking issue, just adding logs to avoid silent failures. 