### PR TITLE
p2p --next: only attempt discv5 listener when no-discovery flag is not present

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -68,7 +68,7 @@ func (s *Service) Start() {
 		return
 	}
 	s.host = h
-	if s.cfg.BootstrapNodeAddr != "" {
+	if s.cfg.BootstrapNodeAddr != "" && !s.cfg.NoDiscovery {
 		listener, err := startDiscoveryV5(ipAddr, privKey, s.cfg)
 		if err != nil {
 			log.WithError(err).Error("Failed to start discovery")


### PR DESCRIPTION
No tracking issue. As title describes. 