### PR TITLE
WIP: Update validators db during epoch boundary

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-ssz"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/sirupsen/logrus"
@@ -95,6 +98,13 @@ func (c *ChainService) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.Be
 		return errors.Wrap(err, "could not clean up block deposits, attestations, and other operations")
 	}
 
+	// Save newly active and deleted validator indices in DB.
+	if helpers.IsEpochStart(block.Slot) {
+		if err := c.updateValidatorsDB(ctx, root); err != nil {
+			return errors.Wrap(err, "could not update validators db")
+		}
+	}
+
 	processedBlkNoPubsub.Inc()
 	return nil
 }
@@ -127,6 +137,13 @@ func (c *ChainService) ReceiveBlockNoPubsubForkchoice(ctx context.Context, block
 		return errors.Wrap(err, "could not clean up block deposits, attestations, and other operations")
 	}
 
+	// Save newly active and deleted validator indices in DB.
+	if helpers.IsEpochStart(block.Slot) {
+		if err := c.updateValidatorsDB(ctx, root); err != nil {
+			return errors.Wrap(err, "could not update validators db")
+		}
+	}
+
 	processedBlkNoPubsubForkchoice.Inc()
 	return nil
 }
@@ -145,5 +162,62 @@ func (c *ChainService) CleanupBlockOperations(ctx context.Context, block *ethpb.
 	for _, dep := range block.Body.Deposits {
 		c.depositCache.RemovePendingDeposit(ctx, dep)
 	}
+	return nil
+}
+
+// this updates validator's pubkey to indices mapping stored in DB, due to validator activation
+// and exit, we should check on every epoch.
+func (c *ChainService) updateValidatorsDB(ctx context.Context, r [32]byte) error {
+	s, err := c.beaconDB.State(ctx, r)
+	if err != nil {
+		return errors.Wrap(err, "could not retrieve latest processed state in DB")
+	}
+	if err := c.saveGenesisValidators(ctx, s); err != nil {
+		return errors.Wrap(err, "could not save validator index")
+	}
+	if err := c.deleteValidatorIdx(ctx, s); err != nil {
+		return errors.Wrap(err, "could not delete validator index")
+	}
+	return nil
+}
+
+// saveValidatorIdx saves the validators public key to index mapping in DB, these
+// validators were activated from current epoch. After it saves, current epoch key
+// is deleted from ActivatedValidators mapping.
+func (c *ChainService) saveValidatorIdx(ctx context.Context, state *pb.BeaconState) error {
+	nextEpoch := helpers.CurrentEpoch(state) + 1
+	activatedValidators := validators.ActivatedValFromEpoch(nextEpoch)
+	var idxNotInState []uint64
+	for _, idx := range activatedValidators {
+		// If for some reason the activated validator indices is not in state,
+		// we skip them and save them to process for next epoch.
+		if int(idx) >= len(state.Validators) {
+			idxNotInState = append(idxNotInState, idx)
+			continue
+		}
+		pubKey := state.Validators[idx].PublicKey
+		if err := c.beaconDB.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey), idx); err != nil {
+			return errors.Wrap(err, "could not save validator index")
+		}
+	}
+	// Since we are processing next epoch, save the can't processed validator indices
+	// to the epoch after that.
+	validators.InsertActivatedIndices(nextEpoch+1, idxNotInState)
+	validators.DeleteActivatedVal(helpers.CurrentEpoch(state))
+	return nil
+}
+
+// deleteValidatorIdx deletes the validators public key to index mapping in DB, the
+// validators were exited from current epoch. After it deletes, current epoch key
+// is deleted from ExitedValidators mapping.
+func (c *ChainService) deleteValidatorIdx(ctx context.Context, state *pb.BeaconState) error {
+	exitedValidators := validators.ExitedValFromEpoch(helpers.CurrentEpoch(state) + 1)
+	for _, idx := range exitedValidators {
+		pubKey := state.Validators[idx].PublicKey
+		if err := c.beaconDB.DeleteValidatorIndex(ctx, bytesutil.ToBytes48(pubKey)); err != nil {
+			return errors.Wrap(err, "could not delete validator index")
+		}
+	}
+	validators.DeleteExitedVal(helpers.CurrentEpoch(state))
 	return nil
 }

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -17,9 +17,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain/forkchoice"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache/depositcache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
@@ -189,47 +187,6 @@ func (c *ChainService) Status() error {
 // when the beacon state is first initialized.
 func (c *ChainService) StateInitializedFeed() *event.Feed {
 	return c.stateInitializedFeed
-}
-
-// saveValidatorIdx saves the validators public key to index mapping in DB, these
-// validators were activated from current epoch. After it saves, current epoch key
-// is deleted from ActivatedValidators mapping.
-func (c *ChainService) saveValidatorIdx(ctx context.Context, state *pb.BeaconState) error {
-	nextEpoch := helpers.CurrentEpoch(state) + 1
-	activatedValidators := validators.ActivatedValFromEpoch(nextEpoch)
-	var idxNotInState []uint64
-	for _, idx := range activatedValidators {
-		// If for some reason the activated validator indices is not in state,
-		// we skip them and save them to process for next epoch.
-		if int(idx) >= len(state.Validators) {
-			idxNotInState = append(idxNotInState, idx)
-			continue
-		}
-		pubKey := state.Validators[idx].PublicKey
-		if err := c.beaconDB.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey), idx); err != nil {
-			return errors.Wrap(err, "could not save validator index")
-		}
-	}
-	// Since we are processing next epoch, save the can't processed validator indices
-	// to the epoch after that.
-	validators.InsertActivatedIndices(nextEpoch+1, idxNotInState)
-	validators.DeleteActivatedVal(helpers.CurrentEpoch(state))
-	return nil
-}
-
-// deleteValidatorIdx deletes the validators public key to index mapping in DB, the
-// validators were exited from current epoch. After it deletes, current epoch key
-// is deleted from ExitedValidators mapping.
-func (c *ChainService) deleteValidatorIdx(ctx context.Context, state *pb.BeaconState) error {
-	exitedValidators := validators.ExitedValFromEpoch(helpers.CurrentEpoch(state) + 1)
-	for _, idx := range exitedValidators {
-		pubKey := state.Validators[idx].PublicKey
-		if err := c.beaconDB.DeleteValidatorIndex(ctx, bytesutil.ToBytes48(pubKey)); err != nil {
-			return errors.Wrap(err, "could not delete validator index")
-		}
-	}
-	validators.DeleteExitedVal(helpers.CurrentEpoch(state))
-	return nil
 }
 
 // This gets called to update canonical root mapping.

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -64,7 +64,7 @@ func TestStartDiscV5_DiscoverAllPeers(t *testing.T) {
 
 	cfg := &Config{
 		BootstrapNodeAddr: bootNode.String(),
-		Encoding: "ssz",
+		Encoding:          "ssz",
 	}
 
 	var listeners []*discv5.Network

--- a/beacon-chain/p2p/monitoring.go
+++ b/beacon-chain/p2p/monitoring.go
@@ -13,7 +13,7 @@ var (
 		Name: "p2p_topic_peer_count",
 		Help: "The number of peers subscribed to a topic",
 	},
-	[]string{"topic"})
+		[]string{"topic"})
 )
 
 func registerMetrics(s *Service) {
@@ -28,7 +28,6 @@ func registerMetrics(s *Service) {
 		// This should only happen in tests.
 		log.WithError(err).Error("Failed to register metric")
 	}
-
 
 	// Metrics with labels, polled every 10s.
 	go func() {

--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -30,7 +30,7 @@ func TestPrivateKeyLoading(t *testing.T) {
 	log.WithField("file", file.Name()).WithField("key", keyStr).Info("Wrote key to file")
 	cfg := &Config{
 		PrivateKey: file.Name(),
-		Encoding: "ssz",
+		Encoding:   "ssz",
 	}
 	pKey, err := privKey(cfg)
 	if err != nil {

--- a/beacon-chain/p2p/service_test.go
+++ b/beacon-chain/p2p/service_test.go
@@ -91,8 +91,8 @@ func TestService_Start_OnlyStartsOnce(t *testing.T) {
 	hook := logTest.NewGlobal()
 
 	cfg := &Config{
-		Port:    2000,
-		UDPPort: 2000,
+		Port:     2000,
+		UDPPort:  2000,
 		Encoding: "ssz",
 	}
 	s, _ := NewService(cfg)
@@ -126,7 +126,7 @@ func TestListenForNewNodes(t *testing.T) {
 
 	cfg := &Config{
 		BootstrapNodeAddr: bootNode.String(),
-		Encoding: "ssz",
+		Encoding:          "ssz",
 	}
 	var listeners []*discv5.Network
 	var hosts []host.Host


### PR DESCRIPTION
This PR ensures we update validators DB during epoch boundary. So newly activated and exited validators get reflected via `pub key -> index`