### PR TITLE
Sync forwards attestation to operation services

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -35,7 +36,14 @@ func (c *ChainService) ReceiveAttestation(ctx context.Context, att *ethpb.Attest
 	if err := c.p2p.Broadcast(ctx, att); err != nil {
 		return errors.Wrap(err, "could not broadcast attestation")
 	}
+
+	attRoot, err := ssz.HashTreeRoot(att)
+	if err != nil {
+		log.WithError(err).Error("Failed to hash attestation")
+	}
+
 	log.WithFields(logrus.Fields{
+		"attRoot": hex.EncodeToString(attRoot[:]),
 		"attDataRoot": hex.EncodeToString(att.Data.BeaconBlockRoot),
 	}).Debug("Broadcasting attestation")
 

--- a/beacon-chain/rpc/proposer_server.go
+++ b/beacon-chain/rpc/proposer_server.go
@@ -116,6 +116,9 @@ func (ps *ProposerServer) RequestBlock(ctx context.Context, req *pb.BlockRequest
 // ProposeBlock is called by a proposer during its assigned slot to create a block in an attempt
 // to get it processed by the beacon node as the canonical head.
 func (ps *ProposerServer) ProposeBlock(ctx context.Context, blk *ethpb.BeaconBlock) (*pb.ProposeResponse, error) {
+	// TODO(#78): To protect against blk not filling, this will be handled within the SSZ code codebase.
+	// https://github.com/prysmaticlabs/go-ssz/issues/78
+	blk.Body.Graffiti = make([]byte, 32)
 	root, err := ssz.SigningRoot(blk)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not tree hash block")

--- a/beacon-chain/sync/subscriber_beacon_attestation.go
+++ b/beacon-chain/sync/subscriber_beacon_attestation.go
@@ -10,5 +10,9 @@ import (
 // beaconAttestationSubscriber forwards the incoming validated attestation to the blockchain
 // service for processing.
 func (r *RegularSync) beaconAttestationSubscriber(ctx context.Context, msg proto.Message) error {
+	if err := r.operations.HandleAttestation(ctx, msg.(*ethpb.Attestation)); err != nil {
+		return err
+	}
+
 	return r.chain.ReceiveAttestationNoPubsub(ctx, msg.(*ethpb.Attestation))
 }


### PR DESCRIPTION
This PR adds the functionlity of sync to forward incoming attestation to operation service. It also initializes block's graffiti field with a `TODO` (currently getting worked on in go-ssz)