### PR TITLE
Do not panic if  DiscoveryV5 is not initialized

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/p2p/discv5"
 	"github.com/gogo/protobuf/proto"
-	"github.com/libp2p/go-libp2p"
+	libp2p "github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/host"
 	network "github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -116,7 +116,9 @@ func (s *Service) Start() {
 // Stop the p2p service and terminate all peer connections.
 func (s *Service) Stop() error {
 	s.started = false
-	s.dv5Listener.Close()
+	if s.dv5Listener != nil {
+		s.dv5Listener.Close()
+	}
 	return nil
 }
 

--- a/beacon-chain/p2p/service_test.go
+++ b/beacon-chain/p2p/service_test.go
@@ -9,10 +9,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/discv5"
-	"github.com/libp2p/go-libp2p"
+	libp2p "github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/multiformats/go-multiaddr"
+	multiaddr "github.com/multiformats/go-multiaddr"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
@@ -85,6 +85,11 @@ func TestService_Stop_SetsStartedToFalse(t *testing.T) {
 	if s.started != false {
 		t.Error("Expected Service.started to be false, got true")
 	}
+}
+
+func TestService_Stop_DontPanicIfDv5ListenerIsNotInited(t *testing.T) {
+	s, _ := NewService(nil)
+	_ = s.Stop()
 }
 
 func TestService_Start_OnlyStartsOnce(t *testing.T) {


### PR DESCRIPTION
Now, if  the beacon-node starts without DiscoveryV5 (no-discovery flag or empty / incorrect bootstrap-node flag) then panic occurs at the stop of the node 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1087ffe]

goroutine 196 [running]:
github.com/prysmaticlabs/prysm/beacon-chain/p2p.(*Service).Stop(0xc0000cf3e0, 0xc0001b2c30, 0xc0004bcf28)
	beacon-chain/p2p/service.go:119 +0x2e
github.com/prysmaticlabs/prysm/shared.(*ServiceRegistry).StopAll(0xc0000be860)
	shared/service_registry.go:54 +0xc9
github.com/prysmaticlabs/prysm/beacon-chain/node.(*BeaconNode).Close(0xc0000d6cd0)
	beacon-chain/node/node.go:174 +0xcb
created by github.com/prysmaticlabs/prysm/beacon-chain/node.(*BeaconNode).Start.func1
	beacon-chain/node/node.go:154 +0x17c
```
This PR fixed this panic.