### PR TITLE
Fix SaveCheckpointState slot advancement

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_attestation_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation_test.go
@@ -198,4 +198,17 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 	if s2.Slot != 2*params.BeaconConfig().SlotsPerEpoch {
 		t.Errorf("Wanted state slot: %d, got: %d", 2*params.BeaconConfig().SlotsPerEpoch, s2.Slot)
 	}
+
+	s.Slot = params.BeaconConfig().SlotsPerEpoch + 1
+	if err := store.GenesisStore(ctx, s); err != nil {
+		t.Fatal(err)
+	}
+	cp3 := &ethpb.Checkpoint{Epoch: 1, Root: []byte{'C'}}
+	s3, err := store.saveCheckpointState(ctx, s, cp3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s3.Slot != s.Slot {
+		t.Errorf("Wanted state slot: %d, got: %d", s.Slot, s3.Slot)
+	}
 }


### PR DESCRIPTION
This fixes #3348 

We added a check to ensure `checkpoint's epoch slot` is greater than `current slot` before advancing the current state to `checkpoint's epoch slot`