### PR TITLE
Fix GetChainHead for RPC

### DIFF
--- a/beacon-chain/rpc/beacon_chain_server_test.go
+++ b/beacon-chain/rpc/beacon_chain_server_test.go
@@ -807,20 +807,7 @@ func TestBeaconChainServer_GetValidatorsParticipation(t *testing.T) {
 
 	bs := &BeaconChainServer{
 		beaconDB: db,
-	}
-
-	block := &ethpb.BeaconBlock{
-		Slot: 1,
-	}
-	blockRoot, err := ssz.SigningRoot(block)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := bs.beaconDB.SaveHeadBlockRoot(ctx, blockRoot); err != nil {
-		t.Fatal(err)
-	}
-	if err := bs.beaconDB.SaveState(ctx, s, blockRoot); err != nil {
-		t.Fatal(err)
+		head:     &mock.ChainService{State: s},
 	}
 
 	res, err := bs.GetValidatorParticipation(ctx, &ethpb.GetValidatorParticipationRequest{Epoch: epoch})

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -193,6 +193,7 @@ func (s *Service) Start() {
 	beaconChainServer := &BeaconChainServer{
 		beaconDB: s.beaconDB,
 		pool:     s.operationService,
+		head:     s.chainService,
 	}
 	pb.RegisterBeaconServiceServer(s.grpcServer, beaconServer)
 	pb.RegisterProposerServiceServer(s.grpcServer, proposerServer)

--- a/tools/forkchecker/forkchecker.go
+++ b/tools/forkchecker/forkchecker.go
@@ -89,10 +89,9 @@ func compareHeads(clients map[string]pb.BeaconChainClient) {
 		log.Fatal(err)
 	}
 
-	log.Infof("Compare all heads for head slot :%d", head1.BlockSlot)
-	if head1.BlockSlot%params.BeaconConfig().SlotsPerEpoch == 0 {
-		p, err := clients[endpt1].GetValidatorParticipation(context.Background(), &pb.GetValidatorParticipationRequest{
-			Epoch: (head1.BlockSlot / params.BeaconConfig().SlotsPerEpoch) - 1})
+	log.Infof("Comparing all heads for head slot :%d", head1.BlockSlot)
+	if (head1.BlockSlot+1)%params.BeaconConfig().SlotsPerEpoch == 0 {
+		p, err := clients[endpt1].GetValidatorParticipation(context.Background(), &pb.GetValidatorParticipationRequest{})
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -105,13 +104,12 @@ func compareHeads(clients map[string]pb.BeaconChainClient) {
 			log.Fatal(err)
 		}
 		if !reflect.DeepEqual(head1, head2) {
-			log.Error("Uh oh! Head miss-matched!")
+			log.Error("Uh oh! Heads missmatched!")
 			logHead(endpt1, head1)
 			logHead(endpt2, head2)
 
-			if head1.BlockSlot%params.BeaconConfig().SlotsPerEpoch == 0 {
-				p, err := clients[endpt2].GetValidatorParticipation(context.Background(), &pb.GetValidatorParticipationRequest{
-					Epoch: (head1.BlockSlot / params.BeaconConfig().SlotsPerEpoch) - 1})
+			if (head1.BlockSlot+1)%params.BeaconConfig().SlotsPerEpoch == 0 {
+				p, err := clients[endpt2].GetValidatorParticipation(context.Background(), &pb.GetValidatorParticipationRequest{})
 				if err != nil {
 					log.Fatal(err)
 				}
@@ -124,12 +122,12 @@ func compareHeads(clients map[string]pb.BeaconChainClient) {
 func logHead(endpt string, head *pb.ChainHead) {
 	log.WithFields(
 		logrus.Fields{
-			"HeadSlot":      head.BlockSlot,
-			"HeadRoot":      hex.EncodeToString(head.BlockRoot),
-			"JustifiedSlot": head.JustifiedSlot,
-			"JustifiedRoot": hex.EncodeToString(head.JustifiedBlockRoot),
-			"FinalizedSlot": head.FinalizedSlot,
-			"Finalizedroot": hex.EncodeToString(head.FinalizedBlockRoot),
+			"HeadSlot":       head.BlockSlot,
+			"HeadRoot":       hex.EncodeToString(head.BlockRoot),
+			"JustifiedEpoch": head.JustifiedSlot / params.BeaconConfig().SlotsPerEpoch,
+			"JustifiedRoot":  hex.EncodeToString(head.JustifiedBlockRoot),
+			"FinalizedEpoch": head.FinalizedSlot / params.BeaconConfig().SlotsPerEpoch,
+			"FinalizedRoot":  hex.EncodeToString(head.FinalizedBlockRoot),
 		}).Info("Head from beacon node ", endpt)
 }
 


### PR DESCRIPTION
Change list:
- Fixed `GetChainHead ` rpc call by actually passing down block chain service
- Updated `ForkChecker` tool and tested it works
```
INFO[0030] Comparing all heads for head slot :429        prefix=forkchoice_checker
INFO[0036] Comparing all heads for head slot :430        prefix=forkchoice_checker
INFO[0042] Comparing all heads for head slot :431        prefix=forkchoice_checker
INFO[0042] Participation rate from beacon node 127.0.0.1:4000  Epoch=53 Finalized=false ParticipationRate=0.875 TotalEther=204800000000 VotedEther=179200000000 prefix=forkchoice_checker
```