### PR TITLE
Fix chain info's pre chain start return values

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//proto/eth/v1alpha1:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/params:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
 // ChainInfoRetriever defines a common interface for methods in blockchain service which
@@ -40,7 +41,12 @@ type FinalizationRetriever interface {
 
 // FinalizedCheckpt returns the latest finalized checkpoint tracked in fork choice service.
 func (c *ChainService) FinalizedCheckpt() *ethpb.Checkpoint {
-	return c.forkChoiceStore.FinalizedCheckpt()
+	cp := c.forkChoiceStore.FinalizedCheckpt()
+	if cp != nil {
+		return cp
+	}
+
+	return &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
 }
 
 // HeadSlot returns the slot of the head of the chain.
@@ -53,7 +59,12 @@ func (c *ChainService) HeadRoot() []byte {
 	c.canonicalRootsLock.RLock()
 	defer c.canonicalRootsLock.RUnlock()
 
-	return c.canonicalRoots[c.headSlot]
+	root := c.canonicalRoots[c.headSlot]
+	if len(root) != 0 {
+		return root
+	}
+
+	return params.BeaconConfig().ZeroHash[:]
 }
 
 // HeadBlock returns the head block of the chain.

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -10,10 +10,25 @@ import (
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
 // Ensure ChainService implements chain info interface.
 var _ = ChainInfoRetriever(&ChainService{})
+
+func TestFinalizedCheckpt_Nil(t *testing.T) {
+	c := setupBeaconChain(t, nil)
+	if !bytes.Equal(c.FinalizedCheckpt().Root, params.BeaconConfig().ZeroHash[:]) {
+		t.Error("Incorrect pre chain start value")
+	}
+}
+
+func TestHeadRoot_Nil(t *testing.T) {
+	c := setupBeaconChain(t, nil)
+	if !bytes.Equal(c.HeadRoot(), params.BeaconConfig().ZeroHash[:]) {
+		t.Error("Incorrect pre chain start value")
+	}
+}
 
 func TestFinalizedCheckpt_CanRetrieve(t *testing.T) {
 	db := testDB.SetupDB(t)

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -143,6 +143,8 @@ func (c *ChainService) initializeBeaconChain(
 	if err != nil {
 		return errors.Wrap(err, "could not initialize genesis state")
 	}
+	c.headState = genesisState
+
 	stateRoot, err := ssz.HashTreeRoot(genesisState)
 	if err != nil {
 		return errors.Wrap(err, "could not tree hash genesis state")

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -143,7 +143,6 @@ func (c *ChainService) initializeBeaconChain(
 	if err != nil {
 		return errors.Wrap(err, "could not initialize genesis state")
 	}
-	c.headState = genesisState
 
 	stateRoot, err := ssz.HashTreeRoot(genesisState)
 	if err != nil {


### PR DESCRIPTION
Chain info from blockchain service should never return nil. This PR ensures before chain start we return zero hashes for FinalizedCheckpoint and HeadRoot 