### PR TITLE
Do not overwrite keys in the unencrypted-keys-gen 

### DIFF
--- a/tools/unencrypted-keys-gen/README.md
+++ b/tools/unencrypted-keys-gen/README.md
@@ -7,7 +7,7 @@ client for fast development startup times instead of using the Prysm keystore.
 Usage:
 
 ```
-bazel run //tools/unencrypted-keys-gen -- --num-keys 64 --output-file /path/to/output.json
+bazel run //tools/unencrypted-keys-gen -- --num-keys 64 --output-json /path/to/output.json
 ```
 
 Which will create 64 BLS private keys each for validator signing and withdrawals. 

--- a/tools/unencrypted-keys-gen/main.go
+++ b/tools/unencrypted-keys-gen/main.go
@@ -15,6 +15,7 @@ import (
 var (
 	numKeys    = flag.Int("num-keys", 0, "Number of validator private/withdrawal keys to generate")
 	outputJSON = flag.String("output-json", "", "JSON file to write output to")
+	overwrite  = flag.Bool("overwrite", false, "If the key file exists, it will be overwritten")
 )
 
 type unencryptedKeysContainer struct {
@@ -33,6 +34,12 @@ func main() {
 	}
 	if *outputJSON == "" {
 		log.Fatal("Please specify an --output-json file to write the unencrypted keys to")
+	}
+
+	if !*overwrite {
+		if _, err := os.Stat(*outputJSON); err == nil {
+			log.Fatal("The file exists. Use a different file name or the --overwrite flag")
+		}
 	}
 
 	file, err := os.Create(*outputJSON)


### PR DESCRIPTION
Added to the unencrypted-keys-gen a check that the file does not exist yet. This should help prevent accidentally overwriting keys.