### PR TITLE
DB: finalized and justified checkpoints can't return nil

### DIFF
--- a/beacon-chain/db/kv/checkpoint.go
+++ b/beacon-chain/db/kv/checkpoint.go
@@ -20,7 +20,7 @@ func (k *Store) JustifiedCheckpoint(ctx context.Context) (*ethpb.Checkpoint, err
 		if enc == nil {
 			blockBucket := tx.Bucket(blocksBucket)
 			genesisRoot := blockBucket.Get(genesisBlockRootKey)
-			checkpoint = &ethpb.Checkpoint{Root:genesisRoot}
+			checkpoint = &ethpb.Checkpoint{Root: genesisRoot}
 			return nil
 		}
 		checkpoint = &ethpb.Checkpoint{}
@@ -40,7 +40,7 @@ func (k *Store) FinalizedCheckpoint(ctx context.Context) (*ethpb.Checkpoint, err
 		if enc == nil {
 			blockBucket := tx.Bucket(blocksBucket)
 			genesisRoot := blockBucket.Get(genesisBlockRootKey)
-			checkpoint = &ethpb.Checkpoint{Root:genesisRoot}
+			checkpoint = &ethpb.Checkpoint{Root: genesisRoot}
 			return nil
 		}
 		checkpoint = &ethpb.Checkpoint{}

--- a/beacon-chain/db/kv/checkpoint.go
+++ b/beacon-chain/db/kv/checkpoint.go
@@ -18,6 +18,9 @@ func (k *Store) JustifiedCheckpoint(ctx context.Context) (*ethpb.Checkpoint, err
 		bkt := tx.Bucket(checkpointBucket)
 		enc := bkt.Get(justifiedCheckpointKey)
 		if enc == nil {
+			blockBucket := tx.Bucket(blocksBucket)
+			genesisRoot := blockBucket.Get(genesisBlockRootKey)
+			checkpoint = &ethpb.Checkpoint{Root:genesisRoot}
 			return nil
 		}
 		checkpoint = &ethpb.Checkpoint{}
@@ -35,6 +38,9 @@ func (k *Store) FinalizedCheckpoint(ctx context.Context) (*ethpb.Checkpoint, err
 		bkt := tx.Bucket(checkpointBucket)
 		enc := bkt.Get(finalizedCheckpointKey)
 		if enc == nil {
+			blockBucket := tx.Bucket(blocksBucket)
+			genesisRoot := blockBucket.Get(genesisBlockRootKey)
+			checkpoint = &ethpb.Checkpoint{Root:genesisRoot}
 			return nil
 		}
 		checkpoint = &ethpb.Checkpoint{}

--- a/beacon-chain/db/kv/checkpoint_test.go
+++ b/beacon-chain/db/kv/checkpoint_test.go
@@ -65,3 +65,43 @@ func TestStore_FinalizedCheckpoint_CanSaveRetrieve(t *testing.T) {
 		t.Errorf("Wanted %v, received %v", cp, retrieved)
 	}
 }
+
+func TestStore_JustifiedCheckpoint_CantBeNil(t *testing.T) {
+	db := setupDB(t)
+	defer teardownDB(t, db)
+	ctx := context.Background()
+
+	genesisRoot := [32]byte{'A'}
+	if err := db.SaveGenesisBlockRoot(ctx, genesisRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}
+	retrieved, err := db.JustifiedCheckpoint(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !proto.Equal(cp, retrieved) {
+		t.Errorf("Wanted %v, received %v", cp, retrieved)
+	}
+}
+
+func TestStore_FinalizedCheckpoint_CantBeNil(t *testing.T) {
+	db := setupDB(t)
+	defer teardownDB(t, db)
+	ctx := context.Background()
+
+	genesisRoot := [32]byte{'B'}
+	if err := db.SaveGenesisBlockRoot(ctx, genesisRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}
+	retrieved, err := db.FinalizedCheckpoint(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !proto.Equal(cp, retrieved) {
+		t.Errorf("Wanted %v, received %v", cp, retrieved)
+	}
+}

--- a/beacon-chain/db/kv/checkpoint_test.go
+++ b/beacon-chain/db/kv/checkpoint_test.go
@@ -17,18 +17,11 @@ func TestStore_JustifiedCheckpoint_CanSaveRetrieve(t *testing.T) {
 		Root:  []byte{'A'},
 	}
 
-	retrieved, err := db.JustifiedCheckpoint(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if retrieved != nil {
-		t.Errorf("Expected nil check point, received %v", retrieved)
-	}
 	if err := db.SaveJustifiedCheckpoint(ctx, cp); err != nil {
 		t.Fatal(err)
 	}
 
-	retrieved, err = db.JustifiedCheckpoint(ctx)
+	retrieved, err := db.JustifiedCheckpoint(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,18 +39,11 @@ func TestStore_FinalizedCheckpoint_CanSaveRetrieve(t *testing.T) {
 		Root:  []byte{'B'},
 	}
 
-	retrieved, err := db.FinalizedCheckpoint(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if retrieved != nil {
-		t.Errorf("Expected nil check point, received %v", retrieved)
-	}
 	if err := db.SaveFinalizedCheckpoint(ctx, cp); err != nil {
 		t.Fatal(err)
 	}
 
-	retrieved, err = db.FinalizedCheckpoint(ctx)
+	retrieved, err := db.FinalizedCheckpoint(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +52,7 @@ func TestStore_FinalizedCheckpoint_CanSaveRetrieve(t *testing.T) {
 	}
 }
 
-func TestStore_JustifiedCheckpoint_CantBeNil(t *testing.T) {
+func TestStore_JustifiedCheckpoint_DefaultCantBeNil(t *testing.T) {
 	db := setupDB(t)
 	defer teardownDB(t, db)
 	ctx := context.Background()
@@ -86,7 +72,7 @@ func TestStore_JustifiedCheckpoint_CantBeNil(t *testing.T) {
 	}
 }
 
-func TestStore_FinalizedCheckpoint_CantBeNil(t *testing.T) {
+func TestStore_FinalizedCheckpoint_DefaultCantBeNil(t *testing.T) {
 	db := setupDB(t)
 	defer teardownDB(t, db)
 	ctx := context.Background()


### PR DESCRIPTION
Before the first justified or finalized epoch, `db.JustifiedCheckpoint` and `db. FinalizedCheckpoint` will return nil. This fixed them to return the expected checkpoint: `Checkpoint{Root:genesisRoot}`
