### PR TITLE
Initialize chain info w/o clear db

### DIFF
--- a/beacon-chain/blockchain/forkchoice/service.go
+++ b/beacon-chain/blockchain/forkchoice/service.go
@@ -35,7 +35,7 @@ type Store struct {
 	justifiedCheckpt *ethpb.Checkpoint
 	finalizedCheckpt *ethpb.Checkpoint
 	checkpointState  *cache.CheckpointStateCache
-	lock         sync.RWMutex
+	lock             sync.RWMutex
 }
 
 // NewForkChoiceService instantiates a new service instance that will


### PR DESCRIPTION
This PR initializes chain info when chain services first starts. This is when `--clear-db` is not used and there's head stored in DB