### PR TITLE
Bootnode: Print private key at debug

### DIFF
--- a/tools/bootnode/BUILD.bazel
+++ b/tools/bootnode/BUILD.bazel
@@ -33,8 +33,8 @@ go_image(
         "//shared/version:go_default_library",
         "@com_github_btcsuite_btcd//btcec:go_default_library",
         "@com_github_ethereum_go_ethereum//p2p/discv5:go_default_library",
-        "@com_github_ipfs_go_log//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//crypto:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@org_uber_go_automaxprocs//:go_default_library",
     ],
 )

--- a/tools/bootnode/BUILD.bazel
+++ b/tools/bootnode/BUILD.bazel
@@ -12,8 +12,8 @@ go_library(
         "//shared/version:go_default_library",
         "@com_github_btcsuite_btcd//btcec:go_default_library",
         "@com_github_ethereum_go_ethereum//p2p/discv5:go_default_library",
-        "@com_github_ipfs_go_log//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//crypto:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@org_uber_go_automaxprocs//:go_default_library",
     ],
 )


### PR DESCRIPTION
When a random key is generated, print the private key at debug level so it may be reused if desired.

```
bazel run //tools/bootnode -- --debug
```