### PR TITLE
Temporarily ban peer if it fails to connect

### DIFF
--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"io"
 	"sync"
 
 	"github.com/libp2p/go-libp2p-core/network"
@@ -36,7 +37,7 @@ func (s *Service) AddConnectionHandler(reqFunc func(ctx context.Context, id peer
 				log.WithField("peer", conn.RemotePeer()).Debug(
 					"Performing handshake with peer",
 				)
-				if err := reqFunc(ctx, conn.RemotePeer()); err != nil {
+				if err := reqFunc(ctx, conn.RemotePeer()); err != nil && err != io.EOF {
 					log.WithError(err).Error("Could not send successful hello rpc request")
 					if err := s.Disconnect(conn.RemotePeer()); err != nil {
 						log.WithError(err).Errorf("Unable to close peer %s", conn.RemotePeer())

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -217,7 +217,8 @@ func (s *Service) connectWithAllPeers(multiAddrs []ma.Multiaddr) {
 			continue
 		}
 		if err := s.host.Connect(s.ctx, info); err != nil {
-			log.Errorf("Could not connect with peer: %v", err)
+			log.Errorf("Could not connect with peer %s: %v", info.String(), err)
+			s.exclusionList.Set(info.ID.String(), true, ttl)
 		}
 	}
 }


### PR DESCRIPTION
I think this was somehow reverted, but we shouldn't repeatedly try to dial a peer that is unreachable. 