### PR TITLE
Add /p2p page

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -509,9 +509,15 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 }
 
 func (b *BeaconNode) registerPrometheusService(ctx *cli.Context) error {
+	var p *p2p.Service
+	if err := b.services.FetchService(&p); err != nil {
+		panic(err)
+	}
+
 	service := prometheus.NewPrometheusService(
 		fmt.Sprintf(":%d", ctx.GlobalInt64(cmd.MonitoringPortFlag.Name)),
 		b.services,
+		prometheus.Handler{Path: "/p2p", Handler: p.InfoHandler},
 	)
 	hook := prometheus.NewLogrusCollector()
 	logrus.AddHook(hook)

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -509,15 +509,20 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 }
 
 func (b *BeaconNode) registerPrometheusService(ctx *cli.Context) error {
-	var p *p2p.Service
-	if err := b.services.FetchService(&p); err != nil {
-		panic(err)
+	var additionalHandlers []prometheus.Handler
+	if featureconfig.FeatureConfig().UseNewP2P {
+		var p *p2p.Service
+		if err := b.services.FetchService(&p); err != nil {
+			panic(err)
+		}
+
+		additionalHandlers = append(additionalHandlers, prometheus.Handler{Path: "/p2p", Handler: p.InfoHandler})
 	}
 
 	service := prometheus.NewPrometheusService(
 		fmt.Sprintf(":%d", ctx.GlobalInt64(cmd.MonitoringPortFlag.Name)),
 		b.services,
-		prometheus.Handler{Path: "/p2p", Handler: p.InfoHandler},
+		additionalHandlers...,
 	)
 	hook := prometheus.NewLogrusCollector()
 	logrus.AddHook(hook)

--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "doc.go",
         "gossip_topic_mappings.go",
         "handshake.go",
+        "info.go",
         "interfaces.go",
         "log.go",
         "monitoring.go",

--- a/beacon-chain/p2p/info.go
+++ b/beacon-chain/p2p/info.go
@@ -1,0 +1,65 @@
+package p2p
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/sirupsen/logrus"
+)
+
+// InfoHandler is a handler to serve /p2p page in metrics.
+func (s *Service) InfoHandler(w http.ResponseWriter, _ *http.Request) {
+	buf := new(bytes.Buffer)
+	if _, err := fmt.Fprintf(buf, `bootnode=%s
+self=%s
+
+%d peers
+%v
+`,
+		s.cfg.BootstrapNodeAddr,
+		selfAddresses(s.host),
+		len(s.host.Network().Peers()),
+		formatPeers(s.host), // Must be last. Writes one entry per row.
+	); err != nil {
+		logrus.WithError(err).Error("Failed to render p2p info page")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		log.WithError(err).Error("Failed to render p2p info page")
+	}
+}
+
+// selfAddresses formats the host data into dialable strings, comma separated.
+func selfAddresses(h host.Host) string {
+	var addresses []string
+	for _, ma := range h.Addrs() {
+		addresses = append(addresses, ma.String()+"/p2p/"+h.ID().Pretty())
+	}
+	return strings.Join(addresses, ",")
+}
+
+// Format peer list to dialable addresses, separated by new line.
+func formatPeers(h host.Host) string {
+	var addresses []string
+
+	for _, pid := range h.Network().Peers() {
+		addresses = append(addresses, formatPeer(pid, h.Peerstore().PeerInfo(pid).Addrs))
+	}
+	return strings.Join(addresses, "\n")
+}
+
+// Format single peer info to dialable addresses, comma separated.
+func formatPeer(pid peer.ID, ma []ma.Multiaddr) string {
+	var addresses []string
+	for _, a := range ma {
+		addresses = append(addresses, a.String()+"/p2p/"+pid.Pretty())
+	}
+	return strings.Join(addresses, ",")
+}

--- a/shared/prometheus/service.go
+++ b/shared/prometheus/service.go
@@ -24,15 +24,26 @@ type Service struct {
 	failStatus  error
 }
 
+// Handler represents a path and handler func to serve on the same port as /metrics, /healthz, /goroutinez, etc.
+type Handler struct {
+	Path string
+	Handler func(http.ResponseWriter, *http.Request)
+}
+
 // NewPrometheusService sets up a new instance for a given address host:port.
 // An empty host will match with any IP so an address like ":2121" is perfectly acceptable.
-func NewPrometheusService(addr string, svcRegistry *shared.ServiceRegistry) *Service {
+func NewPrometheusService(addr string, svcRegistry *shared.ServiceRegistry, additionalHandlers ...Handler) *Service {
 	s := &Service{svcRegistry: svcRegistry}
 
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/healthz", s.healthzHandler)
 	mux.HandleFunc("/goroutinez", s.goroutinezHandler)
+
+	// Register additional handlers.
+	for _, h := range additionalHandlers {
+		mux.HandleFunc(h.Path, h.Handler)
+	}
 
 	s.server = &http.Server{Addr: addr, Handler: mux}
 


### PR DESCRIPTION
Adds new `/p2p` page served on the monitoring port. Try accessing `http://localhost:8080/p2p`. 


Example:
```
bootnode=enode://e410306cb51fecbb94cbfd7d95111e446c5f1f5fc9c9ddcdd587a1fbf3e5f1f2f636137b830bab2555ad0a66c0235cc9fed0bfb9f71cf9c6c9dd0e9dd2e0bec9@127.0.0.1:5544
self=/ip4/192.168.1.8/tcp/32302/p2p/16Uiu2HAkuvwPDqG7R9PmLm5L6cus2hRMiAC2dekGVqgfRv8mXaEA

1 peers
/ip4/192.168.1.8/tcp/12000/p2p/16Uiu2HAm3V9NRkErwwMkwPgS8oQrc9TFzmFooJRYctnZs8CxkkmL
```