### PR TITLE
Fix Prysm Deposit Formatting

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -986,6 +986,12 @@ func verifyDeposit(beaconState *pb.BeaconState, deposit *ethpb.Deposit) error {
 	if err != nil {
 		return errors.Wrap(err, "could not tree hash deposit data")
 	}
+	fmt.Printf("Root %#x\n", receiptRoot)
+	fmt.Printf("Dep index %d\n", beaconState.Eth1DepositIndex)
+	fmt.Println("--Proof")
+	for _, item := range deposit.Proof {
+		fmt.Printf("%#x\n", item)
+	}
 	if ok := trieutil.VerifyMerkleProof(
 		receiptRoot,
 		leaf[:],

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -987,6 +987,8 @@ func verifyDeposit(beaconState *pb.BeaconState, deposit *ethpb.Deposit) error {
 		return errors.Wrap(err, "could not tree hash deposit data")
 	}
 	fmt.Printf("Root %#x\n", receiptRoot)
+	fmt.Printf("Leaf %#x\n", leaf)
+	fmt.Printf("Hash(Leaf+Proof[0]) = %#x\n", hashutil.Hash(append(leaf[:], deposit.Proof[0]...)))
 	fmt.Printf("Dep index %d\n", beaconState.Eth1DepositIndex)
 	fmt.Println("--Proof")
 	for _, item := range deposit.Proof {

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -986,14 +986,6 @@ func verifyDeposit(beaconState *pb.BeaconState, deposit *ethpb.Deposit) error {
 	if err != nil {
 		return errors.Wrap(err, "could not tree hash deposit data")
 	}
-	fmt.Printf("Root %#x\n", receiptRoot)
-	fmt.Printf("Leaf %#x\n", leaf)
-	fmt.Printf("Hash(Leaf+Proof[0]) = %#x\n", hashutil.Hash(append(leaf[:], deposit.Proof[0]...)))
-	fmt.Printf("Dep index %d\n", beaconState.Eth1DepositIndex)
-	fmt.Println("--Proof")
-	for _, item := range deposit.Proof {
-		fmt.Printf("%#x\n", item)
-	}
 	if ok := trieutil.VerifyMerkleProof(
 		receiptRoot,
 		leaf[:],

--- a/shared/trieutil/sparse_merkle.go
+++ b/shared/trieutil/sparse_merkle.go
@@ -103,18 +103,14 @@ func (m *MerkleTrie) HashTreeRoot() [32]byte {
 // VerifyMerkleProof verifies a Merkle branch against a root of a trie.
 func VerifyMerkleProof(root []byte, item []byte, merkleIndex int, proof [][]byte) bool {
 	node := bytesutil.ToBytes32(item)
-	branchIndices := branchIndices(merkleIndex, len(proof))
-	fmt.Println(branchIndices)
-	fmt.Println("--Verifying")
-	for i := 0; i < len(proof)-1; i++ {
-		if branchIndices[i]%2 == 0 {
-			parentHash := hashutil.Hash(append(node[:], proof[i]...))
-			node = parentHash
-			fmt.Printf("%#x\n", node)
-		} else {
+	for i := 0; i < len(proof); i++ {
+		isLeft := merkleIndex / (1 << uint64(i))
+		if isLeft%2 != 0 {
 			parentHash := hashutil.Hash(append(proof[i], node[:]...))
 			node = parentHash
-			fmt.Printf("%#x\n", node)
+		} else {
+			parentHash := hashutil.Hash(append(node[:], proof[i]...))
+			node = parentHash
 		}
 	}
 	return bytes.Equal(root, node[:])
@@ -140,17 +136,6 @@ func calcTreeFromLeaves(leaves [][]byte, depth int) [][][]byte {
 		layers[i+1] = updatedValues
 	}
 	return layers
-}
-
-func branchIndices(merkleIndex int, depth int) []int {
-	indices := make([]int, depth)
-	idx := merkleIndex
-	indices[0] = idx
-	for i := 1; i < depth; i++ {
-		idx /= 2
-		indices[i] = idx
-	}
-	return indices
 }
 
 func (m *MerkleTrie) updateTrie() error {

--- a/shared/trieutil/sparse_merkle.go
+++ b/shared/trieutil/sparse_merkle.go
@@ -104,11 +104,7 @@ func (m *MerkleTrie) HashTreeRoot() [32]byte {
 func VerifyMerkleProof(root []byte, item []byte, merkleIndex int, proof [][]byte) bool {
 	node := bytesutil.ToBytes32(item)
 	branchIndices := branchIndices(merkleIndex, len(proof))
-	fmt.Printf("Node %s, Proof item %s\n", node, proof[0])
-	for i := 0; i < len(proof); i++ {
-		if i > 0 {
-			fmt.Printf("Node %#x, Proof item %#x\n", node, proof[i])
-		}
+	for i := 0; i < len(proof)-1; i++ {
 		if branchIndices[i]%2 == 0 {
 			parentHash := hashutil.Hash(append(node[:], proof[i]...))
 			node = parentHash

--- a/shared/trieutil/sparse_merkle.go
+++ b/shared/trieutil/sparse_merkle.go
@@ -104,13 +104,17 @@ func (m *MerkleTrie) HashTreeRoot() [32]byte {
 func VerifyMerkleProof(root []byte, item []byte, merkleIndex int, proof [][]byte) bool {
 	node := bytesutil.ToBytes32(item)
 	branchIndices := branchIndices(merkleIndex, len(proof))
+	fmt.Println(branchIndices)
+	fmt.Println("--Verifying")
 	for i := 0; i < len(proof)-1; i++ {
 		if branchIndices[i]%2 == 0 {
 			parentHash := hashutil.Hash(append(node[:], proof[i]...))
 			node = parentHash
+			fmt.Printf("%#x\n", node)
 		} else {
 			parentHash := hashutil.Hash(append(proof[i], node[:]...))
 			node = parentHash
+			fmt.Printf("%#x\n", node)
 		}
 	}
 	return bytes.Equal(root, node[:])

--- a/shared/trieutil/sparse_merkle.go
+++ b/shared/trieutil/sparse_merkle.go
@@ -70,7 +70,7 @@ func (m *MerkleTrie) MerkleProof(index int) ([][]byte, error) {
 	if index >= len(leaves) {
 		return nil, fmt.Errorf("merkle index out of range in trie, max range: %d, received: %d", len(leaves), index)
 	}
-	proof := make([][]byte, m.depth)
+	proof := make([][]byte, m.depth+1)
 	for i := uint(0); i < m.depth; i++ {
 		subIndex := (merkleIndex / (1 << i)) ^ 1
 		if subIndex < uint(len(m.branches[i])) {
@@ -79,6 +79,8 @@ func (m *MerkleTrie) MerkleProof(index int) ([][]byte, error) {
 			proof[i] = zeroHashes[i]
 		}
 	}
+	root := m.Root()
+	proof[len(proof)-1] = root[:]
 	return proof, nil
 }
 
@@ -101,7 +103,7 @@ func (m *MerkleTrie) HashTreeRoot() [32]byte {
 func VerifyMerkleProof(root []byte, item []byte, merkleIndex int, proof [][]byte) bool {
 	node := item
 	branchIndices := branchIndices(merkleIndex, len(proof))
-	for i := 0; i < len(proof); i++ {
+	for i := 0; i < len(proof)-1; i++ {
 		if branchIndices[i]%2 == 0 {
 			parentHash := hashutil.Hash(append(node[:], proof[i]...))
 			node = parentHash[:]

--- a/shared/trieutil/sparse_merkle.go
+++ b/shared/trieutil/sparse_merkle.go
@@ -2,6 +2,7 @@ package trieutil
 
 import (
 	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
 
@@ -60,7 +61,9 @@ func (m *MerkleTrie) Items() [][]byte {
 
 // Root returns the top-most, Merkle root of the trie.
 func (m *MerkleTrie) Root() [32]byte {
-	return bytesutil.ToBytes32(m.branches[len(m.branches)-1][0])
+	enc := [32]byte{}
+	binary.LittleEndian.PutUint64(enc[:], uint64(len(m.originalItems)))
+	return hashutil.Hash(append(m.branches[len(m.branches)-1][0], enc[:]...))
 }
 
 // MerkleProof computes a proof from a trie's branches using a Merkle index.
@@ -80,8 +83,9 @@ func (m *MerkleTrie) MerkleProof(index int) ([][]byte, error) {
 			proof[i] = zeroHashes[i]
 		}
 	}
-	root := m.Root()
-	proof[len(proof)-1] = root[:]
+	enc := [32]byte{}
+	binary.LittleEndian.PutUint64(enc[:], uint64(len(m.originalItems)))
+	proof[len(proof)-1] = enc[:]
 	return proof, nil
 }
 

--- a/shared/trieutil/sparse_merkle_test.go
+++ b/shared/trieutil/sparse_merkle_test.go
@@ -1,8 +1,8 @@
 package trieutil
 
 import (
-	"fmt"
 	"math/big"
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -55,18 +55,9 @@ func TestMarshalDepositWithProof(t *testing.T) {
 	if err := ssz.Unmarshal(enc, &dec); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println("--Unmarshaled")
-	for _, item := range dec.Proof {
-		fmt.Printf("%#x\n", item)
+	if !reflect.DeepEqual(dec, dep) {
+		t.Errorf("Wanted %v, received %v", dep, dec)
 	}
-	fmt.Println(" ")
-	fmt.Println("--Original")
-	for _, item := range dep.Proof {
-		fmt.Printf("%#x\n", item)
-	}
-	//if !reflect.DeepEqual(dec, dep) {
-	//	t.Errorf("Wanted %v, received %v", dep, dec)
-	//}
 }
 
 func TestMerkleTrie_BranchIndices(t *testing.T) {
@@ -128,38 +119,39 @@ func TestGenerateTrieFromItems_NoItemsProvided(t *testing.T) {
 func TestMerkleTrie_VerifyMerkleProof(t *testing.T) {
 	items := [][]byte{
 		[]byte("A"),
-		[]byte("BB"),
-		[]byte("CCC"),
-		[]byte("DDDD"),
-		[]byte("EEEEE"),
-		[]byte("FFFFFF"),
-		[]byte("GGGGGGG"),
+		[]byte("B"),
+		[]byte("C"),
+		[]byte("D"),
+		[]byte("E"),
+		[]byte("F"),
+		[]byte("G"),
+		[]byte("H"),
 	}
-	m, err := GenerateTrieFromItems(items, 32)
+	m, err := GenerateTrieFromItems(items, 3)
 	if err != nil {
 		t.Fatalf("Could not generate Merkle trie from items: %v", err)
 	}
-	proof, err := m.MerkleProof(2)
+	proof, err := m.MerkleProof(0)
 	if err != nil {
 		t.Fatalf("Could not generate Merkle proof: %v", err)
 	}
-	if len(proof) != 33 {
+	if len(proof) != 4 {
 		t.Errorf("Received len %d, wanted 33", len(proof))
 	}
 	root := m.Root()
-	if ok := VerifyMerkleProof(root[:], items[2], 2, proof); !ok {
-		t.Error("Merkle proof did not verify")
+	if ok := VerifyMerkleProof(root[:], items[0], 0, proof); !ok {
+		t.Error("First Merkle proof did not verify")
 	}
-	proof, err = m.MerkleProof(3)
-	if err != nil {
-		t.Fatalf("Could not generate Merkle proof: %v", err)
-	}
-	if ok := VerifyMerkleProof(root[:], items[3], 3, proof); !ok {
-		t.Error("Merkle proof did not verify")
-	}
-	if ok := VerifyMerkleProof(root[:], []byte("buzz"), 3, proof); ok {
-		t.Error("Item not in tree should fail to verify")
-	}
+	//proof, err = m.MerkleProof(3)
+	//if err != nil {
+	//	t.Fatalf("Could not generate Merkle proof: %v", err)
+	//}
+	//if ok := VerifyMerkleProof(root[:], items[3], 3, proof); !ok {
+	//	t.Error("Second Merkle proof did not verify")
+	//}
+	//if ok := VerifyMerkleProof(root[:], []byte("buzz"), 3, proof); ok {
+	//	t.Error("Item not in tree should fail to verify")
+	//}
 }
 
 func BenchmarkGenerateTrieFromItems(b *testing.B) {

--- a/shared/trieutil/sparse_merkle_test.go
+++ b/shared/trieutil/sparse_merkle_test.go
@@ -109,13 +109,13 @@ func TestGenerateTrieFromItems_NoItemsProvided(t *testing.T) {
 func TestMerkleTrie_VerifyMerkleProof(t *testing.T) {
 	items := [][]byte{
 		[]byte("A"),
-		[]byte("B"),
-		[]byte("C"),
-		[]byte("D"),
-		[]byte("E"),
-		[]byte("F"),
-		[]byte("G"),
-		[]byte("H"),
+		//[]byte("B"),
+		//[]byte("C"),
+		//[]byte("D"),
+		//[]byte("E"),
+		//[]byte("F"),
+		//[]byte("G"),
+		//[]byte("H"),
 	}
 	m, err := GenerateTrieFromItems(items, 32)
 	if err != nil {
@@ -132,16 +132,16 @@ func TestMerkleTrie_VerifyMerkleProof(t *testing.T) {
 	if ok := VerifyMerkleProof(root[:], items[0], 0, proof); !ok {
 		t.Error("First Merkle proof did not verify")
 	}
-	proof, err = m.MerkleProof(3)
-	if err != nil {
-		t.Fatalf("Could not generate Merkle proof: %v", err)
-	}
-	if ok := VerifyMerkleProof(root[:], items[3], 3, proof); !ok {
-		t.Error("Second Merkle proof did not verify")
-	}
-	if ok := VerifyMerkleProof(root[:], []byte("buzz"), 3, proof); ok {
-		t.Error("Item not in tree should fail to verify")
-	}
+	//proof, err = m.MerkleProof(3)
+	//if err != nil {
+	//	t.Fatalf("Could not generate Merkle proof: %v", err)
+	//}
+	//if ok := VerifyMerkleProof(root[:], items[3], 3, proof); !ok {
+	//	t.Error("Second Merkle proof did not verify")
+	//}
+	//if ok := VerifyMerkleProof(root[:], []byte("buzz"), 3, proof); ok {
+	//	t.Error("Item not in tree should fail to verify")
+	//}
 }
 
 func BenchmarkGenerateTrieFromItems(b *testing.B) {

--- a/shared/trieutil/sparse_merkle_test.go
+++ b/shared/trieutil/sparse_merkle_test.go
@@ -109,13 +109,13 @@ func TestGenerateTrieFromItems_NoItemsProvided(t *testing.T) {
 func TestMerkleTrie_VerifyMerkleProof(t *testing.T) {
 	items := [][]byte{
 		[]byte("A"),
-		//[]byte("B"),
-		//[]byte("C"),
-		//[]byte("D"),
-		//[]byte("E"),
-		//[]byte("F"),
-		//[]byte("G"),
-		//[]byte("H"),
+		[]byte("B"),
+		[]byte("C"),
+		[]byte("D"),
+		[]byte("E"),
+		[]byte("F"),
+		[]byte("G"),
+		[]byte("H"),
 	}
 	m, err := GenerateTrieFromItems(items, 32)
 	if err != nil {
@@ -132,16 +132,16 @@ func TestMerkleTrie_VerifyMerkleProof(t *testing.T) {
 	if ok := VerifyMerkleProof(root[:], items[0], 0, proof); !ok {
 		t.Error("First Merkle proof did not verify")
 	}
-	//proof, err = m.MerkleProof(3)
-	//if err != nil {
-	//	t.Fatalf("Could not generate Merkle proof: %v", err)
-	//}
-	//if ok := VerifyMerkleProof(root[:], items[3], 3, proof); !ok {
-	//	t.Error("Second Merkle proof did not verify")
-	//}
-	//if ok := VerifyMerkleProof(root[:], []byte("buzz"), 3, proof); ok {
-	//	t.Error("Item not in tree should fail to verify")
-	//}
+	proof, err = m.MerkleProof(3)
+	if err != nil {
+		t.Fatalf("Could not generate Merkle proof: %v", err)
+	}
+	if ok := VerifyMerkleProof(root[:], items[3], 3, proof); !ok {
+		t.Error("Second Merkle proof did not verify")
+	}
+	if ok := VerifyMerkleProof(root[:], []byte("buzz"), 3, proof); ok {
+		t.Error("Item not in tree should fail to verify")
+	}
 }
 
 func BenchmarkGenerateTrieFromItems(b *testing.B) {

--- a/shared/trieutil/sparse_merkle_test.go
+++ b/shared/trieutil/sparse_merkle_test.go
@@ -60,16 +60,6 @@ func TestMarshalDepositWithProof(t *testing.T) {
 	}
 }
 
-func TestMerkleTrie_BranchIndices(t *testing.T) {
-	indices := branchIndices(1024, 3 /* depth */)
-	expected := []int{1024, 512, 256}
-	for i := 0; i < len(indices); i++ {
-		if expected[i] != indices[i] {
-			t.Errorf("Expected %d, received %d", expected[i], indices[i])
-		}
-	}
-}
-
 func TestMerkleTrie_MerkleProofOutOfRange(t *testing.T) {
 	h := hashutil.Hash([]byte("hi"))
 	m := &MerkleTrie{

--- a/shared/trieutil/sparse_merkle_test.go
+++ b/shared/trieutil/sparse_merkle_test.go
@@ -127,7 +127,7 @@ func TestMerkleTrie_VerifyMerkleProof(t *testing.T) {
 		[]byte("G"),
 		[]byte("H"),
 	}
-	m, err := GenerateTrieFromItems(items, 3)
+	m, err := GenerateTrieFromItems(items, 32)
 	if err != nil {
 		t.Fatalf("Could not generate Merkle trie from items: %v", err)
 	}
@@ -135,23 +135,23 @@ func TestMerkleTrie_VerifyMerkleProof(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not generate Merkle proof: %v", err)
 	}
-	if len(proof) != 4 {
+	if len(proof) != 33 {
 		t.Errorf("Received len %d, wanted 33", len(proof))
 	}
 	root := m.Root()
 	if ok := VerifyMerkleProof(root[:], items[0], 0, proof); !ok {
 		t.Error("First Merkle proof did not verify")
 	}
-	//proof, err = m.MerkleProof(3)
-	//if err != nil {
-	//	t.Fatalf("Could not generate Merkle proof: %v", err)
-	//}
-	//if ok := VerifyMerkleProof(root[:], items[3], 3, proof); !ok {
-	//	t.Error("Second Merkle proof did not verify")
-	//}
-	//if ok := VerifyMerkleProof(root[:], []byte("buzz"), 3, proof); ok {
-	//	t.Error("Item not in tree should fail to verify")
-	//}
+	proof, err = m.MerkleProof(3)
+	if err != nil {
+		t.Fatalf("Could not generate Merkle proof: %v", err)
+	}
+	if ok := VerifyMerkleProof(root[:], items[3], 3, proof); !ok {
+		t.Error("Second Merkle proof did not verify")
+	}
+	if ok := VerifyMerkleProof(root[:], []byte("buzz"), 3, proof); ok {
+		t.Error("Item not in tree should fail to verify")
+	}
 }
 
 func BenchmarkGenerateTrieFromItems(b *testing.B) {


### PR DESCRIPTION
Resolves #3393 

---

# Description

**Write why you are making the changes in this pull request**

Currently, our deposit proofs have size `[32][32]byte` when they should instead be `[33][32]byte` for SSZ.

**Write a summary of the changes you are making**

This PR fixes such formatting at the trieutil level. It adds a regression test for SSZ round trip marshal/unmarshal for a deposit containing a Merkle proof, which was the panic we saw at runtime.