### PR TITLE
Fix some service context usage, add tracing to p2p handlers

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -91,7 +91,8 @@ func NewChainService(ctx context.Context, cfg *Config) (*ChainService, error) {
 
 // Start a blockchain service's main event loop.
 func (c *ChainService) Start() {
-	beaconState, err := c.beaconDB.HeadState(c.ctx)
+	ctx := context.TODO()
+	beaconState, err := c.beaconDB.HeadState(ctx)
 	if err != nil {
 		log.Fatalf("Could not fetch beacon state: %v", err)
 	}
@@ -99,18 +100,18 @@ func (c *ChainService) Start() {
 	if beaconState != nil {
 		log.Info("Beacon chain data already exists, starting service")
 		c.genesisTime = time.Unix(int64(beaconState.GenesisTime), 0)
-		if err := c.initializeChainInfo(c.ctx); err != nil {
+		if err := c.initializeChainInfo(ctx); err != nil {
 			log.Fatalf("Could not set up chain info: %v", err)
 		}
-		justifiedCheckpoint, err := c.beaconDB.JustifiedCheckpoint(c.ctx)
+		justifiedCheckpoint, err := c.beaconDB.JustifiedCheckpoint(ctx)
 		if err != nil {
 			log.Fatalf("Could not get justified checkpoint: %v", err)
 		}
-		finalizedCheckpoint, err := c.beaconDB.FinalizedCheckpoint(c.ctx)
+		finalizedCheckpoint, err := c.beaconDB.FinalizedCheckpoint(ctx)
 		if err != nil {
 			log.Fatalf("Could not get finalized checkpoint: %v", err)
 		}
-		if err := c.forkChoiceStore.GenesisStore(c.ctx, justifiedCheckpoint, finalizedCheckpoint); err != nil {
+		if err := c.forkChoiceStore.GenesisStore(ctx, justifiedCheckpoint, finalizedCheckpoint); err != nil {
 			log.Fatalf("Could not start fork choice service: %v", err)
 		}
 		c.stateInitializedFeed.Send(c.genesisTime)
@@ -123,7 +124,7 @@ func (c *ChainService) Start() {
 		subChainStart := c.web3Service.ChainStartFeed().Subscribe(c.chainStartChan)
 		go func() {
 			genesisTime := <-c.chainStartChan
-			c.processChainStartTime(c.ctx, genesisTime, subChainStart)
+			c.processChainStartTime(ctx, genesisTime, subChainStart)
 			return
 		}()
 	}

--- a/beacon-chain/operations/service.go
+++ b/beacon-chain/operations/service.go
@@ -189,6 +189,7 @@ func (s *Service) saveOperations() {
 	defer incomingAttSub.Unsubscribe()
 
 	for {
+		ctx := context.TODO()
 		select {
 		case <-incomingSub.Err():
 			log.Debug("Subscriber closed, exiting goroutine")
@@ -198,9 +199,9 @@ func (s *Service) saveOperations() {
 			return
 		// Listen for a newly received incoming exit from the sync service.
 		case exit := <-s.incomingValidatorExits:
-			handler.SafelyHandleMessage(s.ctx, s.HandleValidatorExits, exit)
+			handler.SafelyHandleMessage(ctx, s.HandleValidatorExits, exit)
 		case attestation := <-s.incomingAtt:
-			handler.SafelyHandleMessage(s.ctx, s.HandleAttestation, attestation)
+			handler.SafelyHandleMessage(ctx, s.HandleAttestation, attestation)
 		}
 	}
 }
@@ -301,6 +302,7 @@ func (s *Service) removeOperations() {
 	defer incomingBlockSub.Unsubscribe()
 
 	for {
+		ctx := context.TODO()
 		select {
 		case <-incomingBlockSub.Err():
 			log.Debug("Subscriber closed, exiting goroutine")
@@ -308,7 +310,7 @@ func (s *Service) removeOperations() {
 			log.Debug("operations service context closed, exiting remove goroutine")
 		// Listen for processed block from the block chain service.
 		case block := <-s.incomingProcessedBlock:
-			handler.SafelyHandleMessage(s.ctx, s.handleProcessedBlock, block)
+			handler.SafelyHandleMessage(ctx, s.handleProcessedBlock, block)
 		}
 	}
 }
@@ -320,7 +322,7 @@ func (s *Service) handleProcessedBlock(ctx context.Context, message proto.Messag
 	if err := s.removeAttestationsFromPool(ctx, block.Body.Attestations); err != nil {
 		return errors.Wrap(err, "could not remove processed attestations from DB")
 	}
-	state, err := s.beaconDB.HeadState(s.ctx)
+	state, err := s.beaconDB.HeadState(ctx)
 	if err != nil {
 		return errors.New("could not retrieve attestations from DB")
 	}

--- a/beacon-chain/powchain/block_reader.go
+++ b/beacon-chain/powchain/block_reader.go
@@ -47,7 +47,7 @@ func (w *Web3Service) BlockHashByHeight(ctx context.Context, height *big.Int) (c
 		return blkInfo.Hash, nil
 	}
 	span.AddAttributes(trace.BoolAttribute("blockCacheHit", false))
-	block, err := w.blockFetcher.BlockByNumber(w.ctx, height)
+	block, err := w.blockFetcher.BlockByNumber(ctx, height)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not query block with given height")
 	}
@@ -61,7 +61,7 @@ func (w *Web3Service) BlockHashByHeight(ctx context.Context, height *big.Int) (c
 func (w *Web3Service) BlockTimeByHeight(ctx context.Context, height *big.Int) (uint64, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.web3service.BlockTimeByHeight")
 	defer span.End()
-	block, err := w.blockFetcher.BlockByNumber(w.ctx, height)
+	block, err := w.blockFetcher.BlockByNumber(ctx, height)
 	if err != nil {
 		return 0, errors.Wrap(err, "could not query block with given height")
 	}

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -74,7 +74,7 @@ func TestProcessDepositLog_OK(t *testing.T) {
 		t.Fatal("no logs")
 	}
 
-	web3Service.ProcessLog(logs[0])
+	web3Service.ProcessLog(context.Background(), logs[0])
 
 	testutil.AssertLogsDoNotContain(t, hook, "Could not unpack log")
 	testutil.AssertLogsDoNotContain(t, hook, "Could not save in trie")
@@ -150,8 +150,8 @@ func TestProcessDepositLog_InsertsPendingDeposit(t *testing.T) {
 
 	web3Service.chainStarted = true
 
-	web3Service.ProcessDepositLog(logs[0])
-	web3Service.ProcessDepositLog(logs[1])
+	web3Service.ProcessDepositLog(context.Background(), logs[0])
+	web3Service.ProcessDepositLog(context.Background(), logs[1])
 	pendingDeposits := web3Service.depositCache.PendingDeposits(context.Background(), nil /*blockNum*/)
 	if len(pendingDeposits) != 2 {
 		t.Errorf("Unexpected number of deposits. Wanted 2 deposit, got %+v", pendingDeposits)
@@ -294,7 +294,7 @@ func TestProcessETH2GenesisLog_8DuplicatePubkeys(t *testing.T) {
 	}
 
 	for _, log := range logs {
-		web3Service.ProcessLog(log)
+		web3Service.ProcessLog(context.Background(), log)
 	}
 
 	if web3Service.chainStarted {
@@ -364,7 +364,7 @@ func TestProcessETH2GenesisLog(t *testing.T) {
 	defer sub.Unsubscribe()
 
 	for _, log := range logs {
-		web3Service.ProcessLog(log)
+		web3Service.ProcessLog(context.Background(), log)
 	}
 
 	cachedDeposits := web3Service.ChainStartDeposits()
@@ -439,7 +439,7 @@ func TestWeb3ServiceProcessDepositLog_RequestMissedDeposits(t *testing.T) {
 	logsToBeProcessed := append(logs[:depositsWanted-3], logs[depositsWanted-2:]...)
 	// we purposely miss processing the middle two logs so that the service, re-requests them
 	for _, log := range logsToBeProcessed {
-		if err := web3Service.ProcessLog(log); err != nil {
+		if err := web3Service.ProcessLog(context.Background(), log); err != nil {
 			t.Fatal(err)
 		}
 		web3Service.lastRequestedBlock.Set(big.NewInt(int64(log.BlockNumber)))

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -270,7 +270,7 @@ func (w *Web3Service) AreAllDepositsProcessed() (bool, error) {
 		return false, errors.Wrap(err, "could not get deposit count")
 	}
 	count := bytesutil.FromBytes8(countByte)
-	deposits := w.depositCache.AllDeposits(w.ctx, nil)
+	deposits := w.depositCache.AllDeposits(context.TODO(), nil)
 	if count != uint64(len(deposits)) {
 		return false, nil
 	}
@@ -327,7 +327,7 @@ func (w *Web3Service) handleDelayTicker() {
 	if w.lastRequestedBlock.Cmp(w.blockHeight) == 0 {
 		return
 	}
-	if err := w.requestBatchedLogs(); err != nil {
+	if err := w.requestBatchedLogs(context.Background()); err != nil {
 		w.runError = err
 		log.Error(err)
 	}
@@ -349,7 +349,7 @@ func (w *Web3Service) run(done <-chan struct{}) {
 		return
 	}
 
-	header, err := w.blockFetcher.HeaderByNumber(w.ctx, nil)
+	header, err := w.blockFetcher.HeaderByNumber(context.Background(), nil)
 	if err != nil {
 		log.Errorf("Unable to retrieve latest ETH1.0 chain header: %v", err)
 		w.runError = err
@@ -359,7 +359,7 @@ func (w *Web3Service) run(done <-chan struct{}) {
 	w.blockHeight = header.Number
 	w.blockHash = header.Hash()
 
-	if err := w.processPastLogs(); err != nil {
+	if err := w.processPastLogs(context.Background()); err != nil {
 		log.Errorf("Unable to process past logs %v", err)
 		w.runError = err
 		return

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/beacon-chain/sync/rpc_hello.go
+++ b/beacon-chain/sync/rpc_hello.go
@@ -18,7 +18,7 @@ import (
 func (r *RegularSync) sendRPCHelloRequest(ctx context.Context, id peer.ID) error {
 	log := log.WithField("rpc", "hello")
 
-	ctx, cancel := context.WithTimeout(r.ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	// return if hello already exists


### PR DESCRIPTION
We should not be using the parent context for most method calls. Avoid it whenever possible. There were even a few cases where we had a context passed by argument, but used the parent context for some reason. 