### PR TITLE
Beaconblock over wire

### DIFF
--- a/beacon-chain/p2p/encoder/BUILD.bazel
+++ b/beacon-chain/p2p/encoder/BUILD.bazel
@@ -14,9 +14,11 @@ go_library(
         "//shared/deprecated-p2p:__pkg__",  # TODO(3147): Remove.
     ],
     deps = [
+        "//proto/eth/v1alpha1:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_golang_snappy//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 
@@ -28,7 +30,9 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//proto/eth/v1alpha1:go_default_library",
         "//proto/testing:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_prysmaticlabs_go_ssz//:go_default_library",
     ],
 )

--- a/beacon-chain/p2p/encoder/network_encoding.go
+++ b/beacon-chain/p2p/encoder/network_encoding.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/gogo/protobuf/proto"
+	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 )
 
 // Defines the different encoding formats
@@ -18,6 +19,8 @@ type NetworkEncoding interface {
 	Decode([]byte, proto.Message) error
 	// DecodeWithLength a bytes from a reader with a varint length prefix.
 	DecodeWithLength(io.Reader, proto.Message) error
+	// DecodeSliceWithLength a bytes from a reader with a varint length prefix.
+	DecodeSliceWithLength(io.Reader, *[]*ethpb.BeaconBlock) error
 	// Encode an arbitrary message to the provided writer.
 	Encode(io.Writer, proto.Message) (int, error)
 	// EncodeWithLength an arbitrary message to the provided writer with a varint length prefix.

--- a/beacon-chain/p2p/encoder/ssz_test.go
+++ b/beacon-chain/p2p/encoder/ssz_test.go
@@ -2,10 +2,13 @@ package encoder_test
 
 import (
 	"bytes"
+	"github.com/prysmaticlabs/go-ssz"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
+	//pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	testpb "github.com/prysmaticlabs/prysm/proto/testing"
 )
 
@@ -59,4 +62,13 @@ func testRoundTripWithLength(t *testing.T, e *encoder.SszNetworkEncoder) {
 		t.Logf("decoded=%+v\n", decoded)
 		t.Error("Decoded message is not the same as original")
 	}
+}
+
+func TestLighthouseBeaconBlockResponse(t *testing.T) {
+	buf := []byte{4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 28, 71, 156, 79, 199, 27, 222, 126, 43, 250, 217, 225, 182, 66, 10, 239, 42, 82, 185, 124, 196, 228, 234, 124, 248, 85, 153, 182, 92, 139, 53, 220, 172, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 224, 0, 0, 0, 224, 0, 0, 0, 224, 0, 0, 0, 224, 0, 0, 0, 224, 0, 0, 0, 224, 0, 0, 0}
+	decoded := &[]ethpb.BeaconBlock{}
+	if err := ssz.Unmarshal(buf, decoded); err != nil {
+		t.Fatal(err)
+	}
+
 }

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -104,7 +104,7 @@ func (s *InitialSync) Start() {
 	var last *eth.BeaconBlock
 	for headSlot := s.chain.HeadSlot(); headSlot < slotsSinceGenesis(genesis); {
 		req := &pb.BeaconBlocksRequest{
-			HeadSlot:      headSlot,
+			HeadSlot:      headSlot + 1,
 			HeadBlockRoot: s.chain.HeadRoot(),
 			Count:         64,
 			Step:          1,
@@ -127,14 +127,15 @@ func (s *InitialSync) Start() {
 			panic(errMsg.ErrorMessage)
 		}
 
-		resp := &pb.BeaconBlocksResponse{}
-		if err := s.p2p.Encoding().DecodeWithLength(strm, resp); err != nil {
-			panic(err)
+		resp := &[]*eth.BeaconBlock{}
+		if err := s.p2p.Encoding().DecodeSliceWithLength(strm, resp); err != nil {
+			log.Error(err)
+			continue
 		}
+		log.Infof("blocks received: %v", resp)
+		log.Infof("Received %d blocks", len(*resp))
 
-		log.Infof("Received %d blocks", len(resp.Blocks))
-
-		for _, blk := range resp.Blocks {
+		for _, blk := range *resp {
 			if blk.Slot <= headSlot {
 				continue
 			}

--- a/tools/genesis-state-gen/main.go
+++ b/tools/genesis-state-gen/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"io/ioutil"
@@ -10,6 +9,7 @@ import (
 	"math/big"
 
 	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
@@ -33,10 +33,14 @@ var (
 	sszOutputFile      = flag.String("output-ssz", "", "Output filename of the SSZ marshaling of the generated genesis state")
 	yamlOutputFile     = flag.String("output-yaml", "", "Output filename of the YAML marshaling of the generated genesis state")
 	jsonOutputFile     = flag.String("output-json", "", "Output filename of the JSON marshaling of the generated genesis state")
+	// This is the recommended mock eth1 block hash according to the Eth2 interop guidelines.
+	// https://github.com/ethereum/eth2.0-pm/blob/a085c9870f3956d6228ed2a40cd37f0c6580ecd7/interop/mocked_start/README.md
+	mockEth1BlockHash = []byte{66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66}
 )
 
 func main() {
 	flag.Parse()
+	// TODO(#3398): Cannot generate more than 190 keys due to BLS errors.
 	if *numValidators == 0 {
 		log.Fatal("Expected --num-validators to have been provided, received 0")
 	}
@@ -49,123 +53,140 @@ func main() {
 	if !*useMainnetConfig {
 		params.OverrideBeaconConfig(params.MinimalSpecConfig())
 	}
-	privKeys, pubKeys := deterministicallyGenerateKeys(*numValidators)
-	hashes := make([][]byte, len(privKeys))
-	dataList := make([]*ethpb.Deposit_Data, len(privKeys))
-	for i := 0; i < len(dataList); i++ {
-		data, err := createDepositData(privKeys[i], pubKeys[i])
-		if err != nil {
-			panic(err)
-		}
-		hash, err := ssz.HashTreeRoot(data)
-		if err != nil {
-			panic(err)
-		}
-		hashes[i] = hash[:]
-		dataList[i] = data
+	privKeys, pubKeys, err := deterministicallyGenerateKeys(*numValidators)
+	if err != nil {
+		log.Fatalf("Could not deterministically generate keys for %d validators: %v", *numValidators, err)
+	}
+	depositDataItems, depositDataRoots, err := depositDataFromKeys(privKeys, pubKeys)
+	if err != nil {
+		log.Fatalf("Could not generate deposit data from keys: %v", err)
 	}
 	trie, err := trieutil.GenerateTrieFromItems(
-		hashes,
+		depositDataRoots,
 		int(params.BeaconConfig().DepositContractTreeDepth),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Could not generate Merkle trie for deposit proofs: %v", err)
 	}
-	deposits := make([]*ethpb.Deposit, len(dataList))
-	for i, item := range dataList {
-		proof, err := trie.MerkleProof(i)
-		if err != nil {
-			panic(err)
-		}
-		deposits[i] = &ethpb.Deposit{
-			Proof: proof,
-			Data:  item,
-		}
+	deposits, err := generateDepositsFromData(depositDataItems, trie)
+	if err != nil {
+		log.Fatalf("Could not generate deposits from the deposit data provided: %v", err)
 	}
 	root := trie.Root()
-	// Mock eth1 data for the beacon state.
-	blockHash, err := hex.DecodeString("4242424242424242424242424242424242424242424242424242424242424242")
-	if err != nil {
-		panic(err)
-	}
 	genesisState, err := state.GenesisBeaconState(deposits, *genesisTime, &ethpb.Eth1Data{
 		DepositRoot:  root[:],
 		DepositCount: uint64(len(deposits)),
-		BlockHash:    blockHash,
+		BlockHash:    mockEth1BlockHash,
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("Could not generate genesis beacon state: %v", err)
 	}
 	if *sszOutputFile != "" {
 		encodedState, err := ssz.Marshal(genesisState)
 		if err != nil {
-			panic(err)
+			log.Fatalf("Could not ssz marshal the genesis beacon state: %v", err)
 		}
 		if err := ioutil.WriteFile(*sszOutputFile, encodedState, 0644); err != nil {
-			panic(err)
+			log.Fatalf("Could not write encoded genesis beacon state to file: %v", err)
 		}
 		log.Printf("Done writing to %s", *sszOutputFile)
 	}
 	if *yamlOutputFile != "" {
 		encodedState, err := yaml.Marshal(genesisState)
 		if err != nil {
-			panic(err)
+			log.Fatalf("Could not yaml marshal the genesis beacon state: %v", err)
 		}
 		if err := ioutil.WriteFile(*yamlOutputFile, encodedState, 0644); err != nil {
-			panic(err)
+			log.Fatalf("Could not write encoded genesis beacon state to file: %v", err)
 		}
 		log.Printf("Done writing to %s", *yamlOutputFile)
 	}
 	if *jsonOutputFile != "" {
 		encodedState, err := json.Marshal(genesisState)
 		if err != nil {
-			panic(err)
+			log.Fatalf("Could not json marshal the genesis beacon state: %v", err)
 		}
 		if err := ioutil.WriteFile(*jsonOutputFile, encodedState, 0644); err != nil {
-			panic(err)
+			log.Fatalf("Could not write encoded genesis beacon state to file: %v", err)
 		}
 		log.Printf("Done writing to %s", *jsonOutputFile)
 	}
 }
 
-func deterministicallyGenerateKeys(n int) ([]*bls.SecretKey, []*bls.PublicKey) {
+// Deterministically creates BLS private keys using a fixed curve order according to
+// the algorithm specified in the Eth2.0-Specs interop mock start section found here:
+// https://github.com/ethereum/eth2.0-pm/blob/a085c9870f3956d6228ed2a40cd37f0c6580ecd7/interop/mocked_start/README.md
+func deterministicallyGenerateKeys(n int) ([]*bls.SecretKey, []*bls.PublicKey, error) {
 	privKeys := make([]*bls.SecretKey, n)
 	pubKeys := make([]*bls.PublicKey, n)
 	for i := 0; i < n; i++ {
 		enc := make([]byte, 32)
 		binary.LittleEndian.PutUint32(enc, uint32(i))
 		hash := hashutil.Hash(enc)
-		b := hash[:]
 		// Reverse byte order to big endian for use with big ints.
-		for i := 0; i < len(b)/2; i++ {
-			b[i], b[len(b)-i-1] = b[len(b)-i-1], b[i]
-		}
+		b := reverseByteOrder(hash[:])
 		num := new(big.Int)
 		num = num.SetBytes(b)
 		order := new(big.Int)
 		var ok bool
 		order, ok = order.SetString(blsCurveOrder, 10)
 		if !ok {
-			panic("Not ok")
+			return nil, nil, errors.New("could not set bls curve order as big int")
 		}
 		num = num.Mod(num, order)
 		priv, err := bls.SecretKeyFromBytes(num.Bytes())
 		if err != nil {
-			panic(err)
+			return nil, nil, errors.Wrap(err, "could not create bls secret key from raw bytes")
 		}
 		privKeys[i] = priv
 		pubKeys[i] = priv.PublicKey()
 	}
-	return privKeys, pubKeys
+	return privKeys, pubKeys, nil
 }
 
+// Generates a list of deposit items by creating proofs for each of them from a sparse Merkle trie.
+func generateDepositsFromData(depositDataItems []*ethpb.Deposit_Data, trie *trieutil.MerkleTrie) ([]*ethpb.Deposit, error) {
+	deposits := make([]*ethpb.Deposit, len(depositDataItems))
+	for i, item := range depositDataItems {
+		proof, err := trie.MerkleProof(i)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not generate proof for deposit %d", i)
+		}
+		deposits[i] = &ethpb.Deposit{
+			Proof: proof,
+			Data:  item,
+		}
+	}
+	return deposits, nil
+}
+
+// Generates a list of deposit data items from a set of BLS validator keys.
+func depositDataFromKeys(privKeys []*bls.SecretKey, pubKeys []*bls.PublicKey) ([]*ethpb.Deposit_Data, [][]byte, error) {
+	dataRoots := make([][]byte, len(privKeys))
+	depositDataItems := make([]*ethpb.Deposit_Data, len(privKeys))
+	for i := 0; i < len(privKeys); i++ {
+		data, err := createDepositData(privKeys[i], pubKeys[i])
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "could not create deposit data for key: %#x", privKeys[i].Marshal())
+		}
+		hash, err := ssz.HashTreeRoot(data)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "could not hash tree root deposit data item")
+		}
+		dataRoots[i] = hash[:]
+		depositDataItems[i] = data
+	}
+	return depositDataItems, dataRoots, nil
+}
+
+// Generates a deposit data item from BLS keys and signs the hash tree root of the data.
 func createDepositData(privKey *bls.SecretKey, pubKey *bls.PublicKey) (*ethpb.Deposit_Data, error) {
 	di := &ethpb.Deposit_Data{
 		PublicKey:             pubKey.Marshal(),
 		WithdrawalCredentials: withdrawalCredentialsHash(pubKey.Marshal()),
 		Amount:                params.BeaconConfig().MaxEffectiveBalance,
 	}
-	sr, err := ssz.HashTreeRoot(di)
+	sr, err := ssz.SigningRoot(di)
 	if err != nil {
 		return nil, err
 	}
@@ -184,4 +205,13 @@ func createDepositData(privKey *bls.SecretKey, pubKey *bls.PublicKey) (*ethpb.De
 func withdrawalCredentialsHash(pubKey []byte) []byte {
 	h := hashutil.HashKeccak256(pubKey)
 	return append([]byte{blsWithdrawalPrefixByte}, h[0:]...)[:32]
+}
+
+// Switch the endianness of a byte slice by reversing its order.
+func reverseByteOrder(input []byte) []byte {
+	b := input
+	for i := 0; i < len(b)/2; i++ {
+		b[i], b[len(b)-i-1] = b[len(b)-i-1], b[i]
+	}
+	return b
 }

--- a/tools/genesis-state-gen/main.go
+++ b/tools/genesis-state-gen/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"io/ioutil"
@@ -9,7 +10,6 @@ import (
 	"math/big"
 
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
@@ -33,14 +33,10 @@ var (
 	sszOutputFile      = flag.String("output-ssz", "", "Output filename of the SSZ marshaling of the generated genesis state")
 	yamlOutputFile     = flag.String("output-yaml", "", "Output filename of the YAML marshaling of the generated genesis state")
 	jsonOutputFile     = flag.String("output-json", "", "Output filename of the JSON marshaling of the generated genesis state")
-	// This is the recommended mock eth1 block hash according to the Eth2 interop guidelines.
-	// https://github.com/ethereum/eth2.0-pm/blob/a085c9870f3956d6228ed2a40cd37f0c6580ecd7/interop/mocked_start/README.md
-	mockEth1BlockHash = []byte{66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66}
 )
 
 func main() {
 	flag.Parse()
-	// TODO(#3398): Cannot generate more than 190 keys due to BLS errors.
 	if *numValidators == 0 {
 		log.Fatal("Expected --num-validators to have been provided, received 0")
 	}
@@ -53,140 +49,123 @@ func main() {
 	if !*useMainnetConfig {
 		params.OverrideBeaconConfig(params.MinimalSpecConfig())
 	}
-	privKeys, pubKeys, err := deterministicallyGenerateKeys(*numValidators)
-	if err != nil {
-		log.Fatalf("Could not deterministically generate keys for %d validators: %v", *numValidators, err)
-	}
-	depositDataItems, depositDataRoots, err := depositDataFromKeys(privKeys, pubKeys)
-	if err != nil {
-		log.Fatalf("Could not generate deposit data from keys: %v", err)
+	privKeys, pubKeys := deterministicallyGenerateKeys(*numValidators)
+	hashes := make([][]byte, len(privKeys))
+	dataList := make([]*ethpb.Deposit_Data, len(privKeys))
+	for i := 0; i < len(dataList); i++ {
+		data, err := createDepositData(privKeys[i], pubKeys[i])
+		if err != nil {
+			panic(err)
+		}
+		hash, err := ssz.HashTreeRoot(data)
+		if err != nil {
+			panic(err)
+		}
+		hashes[i] = hash[:]
+		dataList[i] = data
 	}
 	trie, err := trieutil.GenerateTrieFromItems(
-		depositDataRoots,
+		hashes,
 		int(params.BeaconConfig().DepositContractTreeDepth),
 	)
 	if err != nil {
-		log.Fatalf("Could not generate Merkle trie for deposit proofs: %v", err)
+		panic(err)
 	}
-	deposits, err := generateDepositsFromData(depositDataItems, trie)
-	if err != nil {
-		log.Fatalf("Could not generate deposits from the deposit data provided: %v", err)
-	}
-	root := trie.Root()
-	genesisState, err := state.GenesisBeaconState(deposits, *genesisTime, &ethpb.Eth1Data{
-		DepositRoot:  root[:],
-		DepositCount: uint64(len(deposits)),
-		BlockHash:    mockEth1BlockHash,
-	})
-	if err != nil {
-		log.Fatalf("Could not generate genesis beacon state: %v", err)
-	}
-	if *sszOutputFile != "" {
-		encodedState, err := ssz.Marshal(genesisState)
-		if err != nil {
-			log.Fatalf("Could not ssz marshal the genesis beacon state: %v", err)
-		}
-		if err := ioutil.WriteFile(*sszOutputFile, encodedState, 0644); err != nil {
-			log.Fatalf("Could not write encoded genesis beacon state to file: %v", err)
-		}
-		log.Printf("Done writing to %s", *sszOutputFile)
-	}
-	if *yamlOutputFile != "" {
-		encodedState, err := yaml.Marshal(genesisState)
-		if err != nil {
-			log.Fatalf("Could not yaml marshal the genesis beacon state: %v", err)
-		}
-		if err := ioutil.WriteFile(*yamlOutputFile, encodedState, 0644); err != nil {
-			log.Fatalf("Could not write encoded genesis beacon state to file: %v", err)
-		}
-		log.Printf("Done writing to %s", *yamlOutputFile)
-	}
-	if *jsonOutputFile != "" {
-		encodedState, err := json.Marshal(genesisState)
-		if err != nil {
-			log.Fatalf("Could not json marshal the genesis beacon state: %v", err)
-		}
-		if err := ioutil.WriteFile(*jsonOutputFile, encodedState, 0644); err != nil {
-			log.Fatalf("Could not write encoded genesis beacon state to file: %v", err)
-		}
-		log.Printf("Done writing to %s", *jsonOutputFile)
-	}
-}
-
-// Deterministically creates BLS private keys using a fixed curve order according to
-// the algorithm specified in the Eth2.0-Specs interop mock start section found here:
-// https://github.com/ethereum/eth2.0-pm/blob/a085c9870f3956d6228ed2a40cd37f0c6580ecd7/interop/mocked_start/README.md
-func deterministicallyGenerateKeys(n int) ([]*bls.SecretKey, []*bls.PublicKey, error) {
-	privKeys := make([]*bls.SecretKey, n)
-	pubKeys := make([]*bls.PublicKey, n)
-	for i := 0; i < n; i++ {
-		enc := make([]byte, 32)
-		binary.LittleEndian.PutUint32(enc, uint32(i))
-		hash := hashutil.Hash(enc)
-		// Reverse byte order to big endian for use with big ints.
-		b := reverseByteOrder(hash[:])
-		num := new(big.Int)
-		num = num.SetBytes(b)
-		order := new(big.Int)
-		var ok bool
-		order, ok = order.SetString(blsCurveOrder, 10)
-		if !ok {
-			return nil, nil, errors.New("could not set bls curve order as big int")
-		}
-		num = num.Mod(num, order)
-		priv, err := bls.SecretKeyFromBytes(num.Bytes())
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "could not create bls secret key from raw bytes")
-		}
-		privKeys[i] = priv
-		pubKeys[i] = priv.PublicKey()
-	}
-	return privKeys, pubKeys, nil
-}
-
-// Generates a list of deposit items by creating proofs for each of them from a sparse Merkle trie.
-func generateDepositsFromData(depositDataItems []*ethpb.Deposit_Data, trie *trieutil.MerkleTrie) ([]*ethpb.Deposit, error) {
-	deposits := make([]*ethpb.Deposit, len(depositDataItems))
-	for i, item := range depositDataItems {
+	deposits := make([]*ethpb.Deposit, len(dataList))
+	for i, item := range dataList {
 		proof, err := trie.MerkleProof(i)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not generate proof for deposit %d", i)
+			panic(err)
 		}
 		deposits[i] = &ethpb.Deposit{
 			Proof: proof,
 			Data:  item,
 		}
 	}
-	return deposits, nil
-}
-
-// Generates a list of deposit data items from a set of BLS validator keys.
-func depositDataFromKeys(privKeys []*bls.SecretKey, pubKeys []*bls.PublicKey) ([]*ethpb.Deposit_Data, [][]byte, error) {
-	dataRoots := make([][]byte, len(privKeys))
-	depositDataItems := make([]*ethpb.Deposit_Data, len(privKeys))
-	for i := 0; i < len(privKeys); i++ {
-		data, err := createDepositData(privKeys[i], pubKeys[i])
-		if err != nil {
-			return nil, nil, errors.Wrapf(err, "could not create deposit data for key: %#x", privKeys[i].Marshal())
-		}
-		hash, err := ssz.HashTreeRoot(data)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "could not hash tree root deposit data item")
-		}
-		dataRoots[i] = hash[:]
-		depositDataItems[i] = data
+	root := trie.Root()
+	// Mock eth1 data for the beacon state.
+	blockHash, err := hex.DecodeString("4242424242424242424242424242424242424242424242424242424242424242")
+	if err != nil {
+		panic(err)
 	}
-	return depositDataItems, dataRoots, nil
+	genesisState, err := state.GenesisBeaconState(deposits, *genesisTime, &ethpb.Eth1Data{
+		DepositRoot:  root[:],
+		DepositCount: uint64(len(deposits)),
+		BlockHash:    blockHash,
+	})
+	if err != nil {
+		panic(err)
+	}
+	if *sszOutputFile != "" {
+		encodedState, err := ssz.Marshal(genesisState)
+		if err != nil {
+			panic(err)
+		}
+		if err := ioutil.WriteFile(*sszOutputFile, encodedState, 0644); err != nil {
+			panic(err)
+		}
+		log.Printf("Done writing to %s", *sszOutputFile)
+	}
+	if *yamlOutputFile != "" {
+		encodedState, err := yaml.Marshal(genesisState)
+		if err != nil {
+			panic(err)
+		}
+		if err := ioutil.WriteFile(*yamlOutputFile, encodedState, 0644); err != nil {
+			panic(err)
+		}
+		log.Printf("Done writing to %s", *yamlOutputFile)
+	}
+	if *jsonOutputFile != "" {
+		encodedState, err := json.Marshal(genesisState)
+		if err != nil {
+			panic(err)
+		}
+		if err := ioutil.WriteFile(*jsonOutputFile, encodedState, 0644); err != nil {
+			panic(err)
+		}
+		log.Printf("Done writing to %s", *jsonOutputFile)
+	}
 }
 
-// Generates a deposit data item from BLS keys and signs the hash tree root of the data.
+func deterministicallyGenerateKeys(n int) ([]*bls.SecretKey, []*bls.PublicKey) {
+	privKeys := make([]*bls.SecretKey, n)
+	pubKeys := make([]*bls.PublicKey, n)
+	for i := 0; i < n; i++ {
+		enc := make([]byte, 32)
+		binary.LittleEndian.PutUint32(enc, uint32(i))
+		hash := hashutil.Hash(enc)
+		b := hash[:]
+		// Reverse byte order to big endian for use with big ints.
+		for i := 0; i < len(b)/2; i++ {
+			b[i], b[len(b)-i-1] = b[len(b)-i-1], b[i]
+		}
+		num := new(big.Int)
+		num = num.SetBytes(b)
+		order := new(big.Int)
+		var ok bool
+		order, ok = order.SetString(blsCurveOrder, 10)
+		if !ok {
+			panic("Not ok")
+		}
+		num = num.Mod(num, order)
+		priv, err := bls.SecretKeyFromBytes(num.Bytes())
+		if err != nil {
+			panic(err)
+		}
+		privKeys[i] = priv
+		pubKeys[i] = priv.PublicKey()
+	}
+	return privKeys, pubKeys
+}
+
 func createDepositData(privKey *bls.SecretKey, pubKey *bls.PublicKey) (*ethpb.Deposit_Data, error) {
 	di := &ethpb.Deposit_Data{
 		PublicKey:             pubKey.Marshal(),
 		WithdrawalCredentials: withdrawalCredentialsHash(pubKey.Marshal()),
 		Amount:                params.BeaconConfig().MaxEffectiveBalance,
 	}
-	sr, err := ssz.SigningRoot(di)
+	sr, err := ssz.HashTreeRoot(di)
 	if err != nil {
 		return nil, err
 	}
@@ -205,13 +184,4 @@ func createDepositData(privKey *bls.SecretKey, pubKey *bls.PublicKey) (*ethpb.De
 func withdrawalCredentialsHash(pubKey []byte) []byte {
 	h := hashutil.HashKeccak256(pubKey)
 	return append([]byte{blsWithdrawalPrefixByte}, h[0:]...)[:32]
-}
-
-// Switch the endianness of a byte slice by reversing its order.
-func reverseByteOrder(input []byte) []byte {
-	b := input
-	for i := 0; i < len(b)/2; i++ {
-		b[i], b[len(b)-i-1] = b[len(b)-i-1], b[i]
-	}
-	return b
 }


### PR DESCRIPTION

[Part of] #3398

---

We have requested headslot as start slot in the beacon block request added +1 to request the block ahead 

We have previously sent and expected BeaconBlockRespone over the wire while it contained protobuf fields that other client don't send or expect to get. we have fixed the way we un marshal it from the wire 