### PR TITLE
Use the raw bytes, not the libp2p protobuf container for sepc256k1 private keys

### DIFF
--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/hex"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -21,17 +22,17 @@ func TestPrivateKeyLoading(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not generate key: %v", err)
 	}
-	marshalledKey, err := crypto.MarshalPrivateKey(key)
+	raw, err := key.Raw()
 	if err != nil {
-		t.Fatalf("Could not marshal key %v", err)
+		panic(err)
 	}
-	encodedKey := crypto.ConfigEncodeKey(marshalledKey)
+	out := hex.EncodeToString(raw)
 
-	err = ioutil.WriteFile(file.Name(), []byte(encodedKey), 0600)
+	err = ioutil.WriteFile(file.Name(), []byte(out), 0600)
 	if err != nil {
 		t.Fatalf("Could not write key to file: %v", err)
 	}
-	log.WithField("file", file.Name()).WithField("key", encodedKey).Info("Wrote key to file")
+	log.WithField("file", file.Name()).WithField("key", out).Info("Wrote key to file")
 	cfg := &Config{
 		PrivateKey: file.Name(),
 		Encoding:   "ssz",

--- a/tools/bootnode/bootnode.go
+++ b/tools/bootnode/bootnode.go
@@ -12,6 +12,7 @@ package main
 import (
 	"crypto/ecdsa"
 	"crypto/rand"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"net"
@@ -98,11 +99,11 @@ func createLocalNode(privKey *ecdsa.PrivateKey, ipAddr net.IP, port int) (*enode
 func extractPrivateKey() *ecdsa.PrivateKey {
 	var privKey *ecdsa.PrivateKey
 	if *privateKey != "" {
-		b, err := crypto.ConfigDecodeKey(*privateKey)
+		dst, err := hex.DecodeString(*privateKey)
 		if err != nil {
 			panic(err)
 		}
-		unmarshalledKey, err := crypto.UnmarshalPrivateKey(b)
+		unmarshalledKey, err := crypto.UnmarshalSecp256k1PrivateKey(dst)
 		if err != nil {
 			panic(err)
 		}
@@ -115,12 +116,11 @@ func extractPrivateKey() *ecdsa.PrivateKey {
 		}
 		privKey = (*ecdsa.PrivateKey)((*btcec.PrivateKey)(privInterfaceKey.(*crypto.Secp256k1PrivateKey)))
 		log.Warning("No private key was provided. Using default/random private key")
-
-		b, err := privInterfaceKey.Bytes()
+		b, err := privInterfaceKey.Raw()
 		if err != nil {
 			panic(err)
 		}
-		log.Debugf("Private key %s", crypto.ConfigEncodeKey(b))
+		log.Debugf("Private key %x", b)
 	}
 
 	return privKey

--- a/tools/bootnode/bootnode_test.go
+++ b/tools/bootnode/bootnode_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/ecdsa"
 	"crypto/rand"
+	"fmt"
 	"testing"
 	"time"
 
@@ -64,12 +65,12 @@ func TestPrivateKey_ParsesCorrectly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	marshalledKey, err := crypto.MarshalPrivateKey(privKey)
+
+	pk, err := privKey.Raw()
 	if err != nil {
 		t.Fatal(err)
 	}
-	encodedKey := crypto.ConfigEncodeKey(marshalledKey)
-	*privateKey = encodedKey
+	*privateKey = fmt.Sprintf("%x", pk)
 
 	extractedKey := extractPrivateKey()
 


### PR DESCRIPTION
The base64 encoded data was some protobuf container as the private key. 

That format breaks interop deploy. Let's use hex for compatibility  