### PR TITLE
Properly Use Demo Config

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -82,7 +82,7 @@ func NewBeaconNode(ctx *cli.Context) (*BeaconNode, error) {
 	// Use custom config values if the --no-custom-config flag is set.
 	if !ctx.GlobalBool(flags.NoCustomConfigFlag.Name) {
 		log.Info("Using custom parameter configuration")
-		if ctx.GlobalBool(featureconfig.DemoConfigFlag.Name) {
+		if featureconfig.FeatureConfig().DemoConfig {
 			log.Info("Using demo config")
 			params.UseDemoBeaconConfig()
 		} else {

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -82,9 +82,11 @@ func NewBeaconNode(ctx *cli.Context) (*BeaconNode, error) {
 	// Use custom config values if the --no-custom-config flag is set.
 	if !ctx.GlobalBool(flags.NoCustomConfigFlag.Name) {
 		log.Info("Using custom parameter configuration")
-		if featureconfig.FeatureConfig().DemoConfig {
+		if ctx.GlobalBool(featureconfig.DemoConfigFlag.Name) {
+			log.Info("Using demo config")
 			params.UseDemoBeaconConfig()
 		} else {
+			log.Info("Using minimal config")
 			params.UseMinimalConfig()
 		}
 	}

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -57,6 +57,10 @@ func InitFeatureConfig(c *FeatureFlagConfig) {
 // on what flags are enabled for the beacon-chain client.
 func ConfigureBeaconFeatures(ctx *cli.Context) {
 	cfg := &FeatureFlagConfig{}
+	if ctx.GlobalBool(DemoConfigFlag.Name) {
+		log.Warn("Using demo config")
+		cfg.DemoConfig = true
+	}
 	if ctx.GlobalBool(NoGenesisDelayFlag.Name) {
 		log.Warn("Using non standard genesis delay. This may cause problems in a multi-node environment.")
 		cfg.NoGenesisDelay = true


### PR DESCRIPTION
No tracking issue - we were not using the demo config flag when starting the beacon chain properly, preventing k8s cluster runs from succeeding