### PR TITLE
Enable go-ethereum logs for bootnode

### DIFF
--- a/tools/bootnode/BUILD.bazel
+++ b/tools/bootnode/BUILD.bazel
@@ -36,6 +36,7 @@ go_image(
     deps = [
         "//shared/version:go_default_library",
         "@com_github_btcsuite_btcd//btcec:go_default_library",
+        "@com_github_ethereum_go_ethereum//log:go_default_library",
         "@com_github_ethereum_go_ethereum//p2p/discover:go_default_library",
         "@com_github_ethereum_go_ethereum//p2p/enode:go_default_library",
         "@com_github_ethereum_go_ethereum//p2p/enr:go_default_library",

--- a/tools/bootnode/BUILD.bazel
+++ b/tools/bootnode/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//shared/version:go_default_library",
         "@com_github_btcsuite_btcd//btcec:go_default_library",
+        "@com_github_ethereum_go_ethereum//log:go_default_library",
         "@com_github_ethereum_go_ethereum//p2p/discover:go_default_library",
         "@com_github_ethereum_go_ethereum//p2p/enode:go_default_library",
         "@com_github_ethereum_go_ethereum//p2p/enr:go_default_library",

--- a/tools/bootnode/bootnode.go
+++ b/tools/bootnode/bootnode.go
@@ -16,6 +16,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/ethereum/go-ethereum/p2p/discover"
@@ -25,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared/version"
 	"github.com/sirupsen/logrus"
+	gethlog "github.com/ethereum/go-ethereum/log"
 	_ "go.uber.org/automaxprocs"
 )
 
@@ -44,6 +46,13 @@ func main() {
 
 	if *debug {
 		logrus.SetLevel(logrus.DebugLevel)
+
+		// Geth specific logging.
+		glogger := gethlog.NewGlogHandler(gethlog.StreamHandler(os.Stderr, gethlog.TerminalFormat(false)))
+		glogger.Verbosity(gethlog.LvlTrace)
+		gethlog.Root().SetHandler(glogger)
+
+		log.Debug("Debug logging enabled.")
 	}
 	cfg := discover.Config{
 		PrivateKey: extractPrivateKey(),


### PR DESCRIPTION
This adds more logging with the `--debug` flag