### PR TITLE
Rlock around len(map)

### DIFF
--- a/beacon-chain/sync/peerstatus/peer_statuses.go
+++ b/beacon-chain/sync/peerstatus/peer_statuses.go
@@ -35,6 +35,8 @@ func Delete(pid peer.ID) {
 
 // Count of peer statuses in cache. Threadsafe.
 func Count() int {
+	lock.RLock()
+	defer lock.RUnlock()
 	return len(peerStatuses)
 }
 


### PR DESCRIPTION
Is `len(map)` threadsafe? I'm not so sure about it. It is technically an integer read on a map and all map operations are not threadsafe.

Adding RLock to be safe. 