### PR TITLE
Implement `AggregatedAttestation` helper

### DIFF
--- a/beacon-chain/blockchain/forkchoice/BUILD.bazel
+++ b/beacon-chain/blockchain/forkchoice/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//beacon-chain/db/filters:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
-        "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",

--- a/beacon-chain/blockchain/forkchoice/process_attestation.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -203,23 +202,12 @@ func (s *Store) aggregateAttestation(ctx context.Context, att *ethpb.Attestation
 		return err
 	}
 
-	incomingAttBits := att.AggregationBits
 	if a, ok := s.attsQueue[root]; ok {
-		if !a.AggregationBits.Contains(incomingAttBits) {
-			newBits := a.AggregationBits.Or(incomingAttBits)
-			incomingSig, err := bls.SignatureFromBytes(att.Signature)
-			if err != nil {
-				return err
-			}
-			currentSig, err := bls.SignatureFromBytes(a.Signature)
-			if err != nil {
-				return err
-			}
-			aggregatedSig := bls.AggregateSignatures([]*bls.Signature{currentSig, incomingSig})
-			a.Signature = aggregatedSig.Marshal()
-			a.AggregationBits = newBits
-			s.attsQueue[root] = a
+		a, err := helpers.AggregateAttestation(a, att)
+		if err != nil {
+			return nil
 		}
+		s.attsQueue[root] = a
 		return nil
 	}
 

--- a/beacon-chain/blockchain/forkchoice/service.go
+++ b/beacon-chain/blockchain/forkchoice/service.go
@@ -252,5 +252,3 @@ func (s *Store) JustifiedCheckpt() *ethpb.Checkpoint {
 func (s *Store) FinalizedCheckpt() *ethpb.Checkpoint {
 	return proto.Clone(s.finalizedCheckpt).(*ethpb.Checkpoint)
 }
-
-

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -41,7 +41,7 @@ func (s *Service) ReceiveBlock(ctx context.Context, block *ethpb.BeaconBlock) er
 	}
 	log.WithFields(logrus.Fields{
 		"blockRoot": hex.EncodeToString(root[:]),
-	}).Info("Broadcasting block")
+	}).Debug("Broadcasting block")
 
 	if err := s.ReceiveBlockNoPubsub(ctx, block); err != nil {
 		return err

--- a/beacon-chain/operations/BUILD.bazel
+++ b/beacon-chain/operations/BUILD.bazel
@@ -7,10 +7,10 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/core/blocks:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
-        "//shared/bls:go_default_library",
         "//shared/event:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/messagehandler:go_default_library",

--- a/beacon-chain/operations/service.go
+++ b/beacon-chain/operations/service.go
@@ -13,10 +13,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	handler "github.com/prysmaticlabs/prysm/shared/messagehandler"
@@ -214,31 +214,17 @@ func (s *Service) HandleAttestation(ctx context.Context, message proto.Message) 
 		}
 	}
 
-	incomingAttBits := attestation.AggregationBits
 	if s.beaconDB.HasAttestation(ctx, root) {
 		dbAtt, err := s.beaconDB.Attestation(ctx, root)
 		if err != nil {
 			return err
 		}
-
-		if !dbAtt.AggregationBits.Contains(incomingAttBits) {
-			newAggregationBits := dbAtt.AggregationBits.Or(incomingAttBits)
-			incomingAttSig, err := bls.SignatureFromBytes(attestation.Signature)
-			if err != nil {
-				return err
-			}
-			dbSig, err := bls.SignatureFromBytes(dbAtt.Signature)
-			if err != nil {
-				return err
-			}
-			aggregatedSig := bls.AggregateSignatures([]*bls.Signature{dbSig, incomingAttSig})
-			dbAtt.Signature = aggregatedSig.Marshal()
-			dbAtt.AggregationBits = newAggregationBits
-			if err := s.beaconDB.SaveAttestation(ctx, dbAtt); err != nil {
-				return err
-			}
-		} else {
-			return nil
+		attestation, err = helpers.AggregateAttestation(dbAtt, attestation)
+		if err != nil {
+			return err
+		}
+		if err := s.beaconDB.SaveAttestation(ctx, attestation); err != nil {
+			return err
 		}
 	} else {
 		if err := s.beaconDB.SaveAttestation(ctx, attestation); err != nil {

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -37,12 +37,12 @@ type blockchainService interface {
 // NewRegularSync service.
 func NewRegularSync(cfg *Config) *RegularSync {
 	r := &RegularSync{
-		ctx:         context.Background(),
-		db:          cfg.DB,
-		p2p:         cfg.P2P,
-		operations:  cfg.Operations,
-		chain:       cfg.Chain,
-		initialSync: cfg.InitialSync,
+		ctx:                 context.Background(),
+		db:                  cfg.DB,
+		p2p:                 cfg.P2P,
+		operations:          cfg.Operations,
+		chain:               cfg.Chain,
+		initialSync:         cfg.InitialSync,
 		slotToPendingBlocks: make(map[uint64]*ethpb.BeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 	}
@@ -65,7 +65,7 @@ type RegularSync struct {
 	seenPendingBlocks   map[[32]byte]bool
 	pendingQueueLock    sync.RWMutex
 	chainStarted        bool
-	initialSync Checker
+	initialSync         Checker
 }
 
 // Start the regular sync service.


### PR DESCRIPTION
Part of the effort to separate out attestation pool from persistent storage. 
This PR implements `AggregatedAttestation` helper. This is to reduce disparity, there's more than one code block that aggregates attestation.
Tested run time and confirmed it works