### PR TITLE
Fixed 2 cosmetic errors

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_attestation.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation.go
@@ -240,7 +240,7 @@ func (s *Store) verifyAttestation(ctx context.Context, baseState *pb.BeaconState
 		return nil, errors.Wrap(err, "could not convert attestation to indexed attestation")
 	}
 	if err := blocks.VerifyIndexedAttestation(baseState, indexedAtt); err != nil {
-		return nil, errors.New("could not verify indexed attestation")
+		return nil, errors.Wrap(err, "could not verify indexed attestation")
 	}
 	return indexedAtt, nil
 }

--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -32,7 +32,7 @@ type AttesterServer struct {
 // SubmitAttestation is a function called by an attester in a sharding validator to vote
 // on a block via an attestation object as defined in the Ethereum Serenity specification.
 func (as *AttesterServer) SubmitAttestation(ctx context.Context, att *ethpb.Attestation) (*pb.AttestResponse, error) {
-	root, err := ssz.SigningRoot(att)
+	root, err := ssz.SigningRoot(att.Data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to sign root attestation")
 	}

--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -34,7 +34,7 @@ type AttesterServer struct {
 func (as *AttesterServer) SubmitAttestation(ctx context.Context, att *ethpb.Attestation) (*pb.AttestResponse, error) {
 	root, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to sign root attestation")
+		return nil, errors.Wrap(err, "failed to hash tree root attestation")
 	}
 
 	go func() {

--- a/beacon-chain/rpc/attester_server.go
+++ b/beacon-chain/rpc/attester_server.go
@@ -32,7 +32,7 @@ type AttesterServer struct {
 // SubmitAttestation is a function called by an attester in a sharding validator to vote
 // on a block via an attestation object as defined in the Ethereum Serenity specification.
 func (as *AttesterServer) SubmitAttestation(ctx context.Context, att *ethpb.Attestation) (*pb.AttestResponse, error) {
-	root, err := ssz.SigningRoot(att.Data)
+	root, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to sign root attestation")
 	}


### PR DESCRIPTION
1. When logging broadcasted attestation root, use `TreeHashRoot(att.Data)`
2. Use `errors.Wrap` for `VerifyIndexedAttestation` in process attestation