### PR TITLE
Fix DiscoveryV5

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -194,7 +194,7 @@ protobuf_deps()
 
 go_repository(
     name = "com_github_ethereum_go_ethereum",
-    commit = "31f7cb1c214026485e7f04c7d0388410dc30c027",
+    commit = "e36fbe823b302313369711c4704b352710c3c510",
     importpath = "github.com/ethereum/go-ethereum",
     # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
     # a fork that has resolved these issues by disabling HID/USB support and


### PR DESCRIPTION
Prevents bootnode restarts from disrupting the network, by making bootnode's permanent in the local table