### PR TITLE
Lookup Bootnode instead of Random Nodes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -194,7 +194,7 @@ protobuf_deps()
 
 go_repository(
     name = "com_github_ethereum_go_ethereum",
-    commit = "31f7cb1c214026485e7f04c7d0388410dc30c027",
+    commit = "e36fbe823b302313369711c4704b352710c3c510",
     importpath = "github.com/ethereum/go-ethereum",
     # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
     # a fork that has resolved these issues by disabling HID/USB support and

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -97,7 +97,7 @@ func convertToMultiAddr(nodes []*enode.Node) []ma.Multiaddr {
 func convertToSingleMultiAddr(node *enode.Node) (ma.Multiaddr, error) {
 	ip4 := node.IP().To4()
 	if ip4 == nil {
-		return nil, errors.New("node doesn't have an ip4 address")
+		return nil, errors.Errorf("node doesn't have an ip4 address, it's stated IP is %s", node.IP().String())
 	}
 	pubkey := node.Pubkey()
 	assertedKey := convertToInterfacePubkey(pubkey)

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -190,10 +190,14 @@ func (s *Service) Disconnect(pid peer.ID) error {
 // listen for new nodes watches for new nodes in the network and adds them to the peerstore.
 func (s *Service) listenForNewNodes() {
 	ticker := time.NewTicker(pollingPeriod)
+	bootNode, err := enode.Parse(enode.ValidSchemes, s.cfg.BootstrapNodeAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
 	for {
 		select {
 		case <-ticker.C:
-			nodes := s.dv5Listener.LookupRandom()
+			nodes := s.dv5Listener.Lookup(bootNode.ID())
 			multiAddresses := convertToMultiAddr(nodes)
 			s.connectWithAllPeers(multiAddresses)
 		case <-s.ctx.Done():


### PR DESCRIPTION
This should allow multiple peers to be able to be use discv5 properly