### PR TITLE
Expose Nodes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -194,7 +194,7 @@ protobuf_deps()
 
 go_repository(
     name = "com_github_ethereum_go_ethereum",
-    commit = "e36fbe823b302313369711c4704b352710c3c510",
+    commit = "1c80f374f8d07774091c0574154bbef5b261d09d",
     importpath = "github.com/ethereum/go-ethereum",
     # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
     # a fork that has resolved these issues by disabling HID/USB support and

--- a/tools/bootnode/bootnode.go
+++ b/tools/bootnode/bootnode.go
@@ -32,12 +32,11 @@ import (
 )
 
 var (
-	debug        = flag.Bool("debug", false, "Enable debug logging")
-	privateKey   = flag.String("private", "", "Private key to use for peer ID")
-	port         = flag.Int("port", 4000, "Port to listen for connections")
-	metricsPort  = flag.Int("metrics-port", 5000, "Port to listen for connections")
-	externalIP   = flag.String("external-ip", "127.0.0.1", "External IP for the bootnode")
-	externalPeer = flag.String("external-peer", "", "")
+	debug       = flag.Bool("debug", false, "Enable debug logging")
+	privateKey  = flag.String("private", "", "Private key to use for peer ID")
+	port        = flag.Int("port", 4000, "Port to listen for connections")
+	metricsPort = flag.Int("metrics-port", 5000, "Port to listen for connections")
+	externalIP  = flag.String("external-ip", "127.0.0.1", "External IP for the bootnode")
 
 	log = logrus.WithField("prefix", "bootnode")
 )
@@ -63,13 +62,6 @@ func main() {
 	}
 	cfg := discover.Config{
 		PrivateKey: extractPrivateKey(),
-	}
-	if *externalPeer != "" {
-		extPeer, err := enode.Parse(enode.ValidSchemes, *externalPeer)
-		if err != nil {
-			log.Fatal(err)
-		}
-		cfg.Bootnodes = []*enode.Node{extPeer}
 	}
 	listener := createListener(*externalIP, *port, cfg)
 

--- a/tools/bootnode/bootnode.go
+++ b/tools/bootnode/bootnode.go
@@ -16,6 +16,7 @@ import (
 	"flag"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 
 	"github.com/btcsuite/btcd/btcec"
@@ -31,13 +32,19 @@ import (
 )
 
 var (
-	debug      = flag.Bool("debug", false, "Enable debug logging")
-	privateKey = flag.String("private", "", "Private key to use for peer ID")
-	port       = flag.Int("port", 4000, "Port to listen for connections")
-	externalIP = flag.String("external-ip", "127.0.0.1", "External IP for the bootnode")
+	debug        = flag.Bool("debug", false, "Enable debug logging")
+	privateKey   = flag.String("private", "", "Private key to use for peer ID")
+	port         = flag.Int("port", 4000, "Port to listen for connections")
+	metricsPort  = flag.Int("metrics-port", 5000, "Port to listen for connections")
+	externalIP   = flag.String("external-ip", "127.0.0.1", "External IP for the bootnode")
+	externalPeer = flag.String("external-peer", "", "")
 
 	log = logrus.WithField("prefix", "bootnode")
 )
+
+type handler struct {
+	listener *discover.UDPv5
+}
 
 func main() {
 	flag.Parse()
@@ -57,10 +64,27 @@ func main() {
 	cfg := discover.Config{
 		PrivateKey: extractPrivateKey(),
 	}
+	if *externalPeer != "" {
+		extPeer, err := enode.Parse(enode.ValidSchemes, *externalPeer)
+		if err != nil {
+			log.Fatal(err)
+		}
+		cfg.Bootnodes = []*enode.Node{extPeer}
+	}
 	listener := createListener(*externalIP, *port, cfg)
 
 	node := listener.Self()
 	log.Infof("Running bootnode: %s", node.String())
+
+	handler := &handler{
+		listener: listener,
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/p2p", handler.httpHandler)
+
+	if err := http.ListenAndServe(fmt.Sprintf(":%d", *metricsPort), mux); err != nil {
+		log.Fatalf("Failed to start server %v", err)
+	}
 
 	select {}
 }
@@ -88,6 +112,21 @@ func createListener(ipAddr string, port int, cfg discover.Config) *discover.UDPv
 		log.Fatal(err)
 	}
 	return network
+}
+
+func (h *handler) httpHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	allNodes := h.listener.AllNodes()
+	w.Write([]byte("Nodes stored in the table:\n"))
+	for i, n := range allNodes {
+		w.Write([]byte(fmt.Sprintf("Node %d\n", i)))
+		w.Write([]byte(n.String() + "\n"))
+		w.Write([]byte("Node ID: " + n.ID().String() + "\n"))
+		w.Write([]byte("IP: " + n.IP().String() + "\n"))
+		w.Write([]byte(fmt.Sprintf("UDP Port: %d", n.UDP()) + "\n"))
+		w.Write([]byte(fmt.Sprintf("TCP Port: %d", n.UDP()) + "\n\n"))
+	}
+
 }
 
 func createLocalNode(privKey *ecdsa.PrivateKey, ipAddr net.IP, port int) (*enode.LocalNode, error) {


### PR DESCRIPTION
This exposes all the bootnode's stored nodes to a page, from which we can inspect them.

`localhost:5000/p2p` would be served with information on all the nodes