### PR TITLE
Removed `verifyAttSlotTime` check for updating fork choice votes

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -169,12 +169,6 @@ func (s *Store) updateBlockAttestationVote(ctx context.Context, att *ethpb.Attes
 	if err != nil {
 		return errors.Wrap(err, "could not get state for attestation tgt root")
 	}
-	if err := s.waitForAttInclDelay(ctx, att, baseState); err != nil {
-		return errors.Wrap(err, "could not wait for attestation inclusion delay")
-	}
-	if err := s.verifyAttSlotTime(ctx, baseState, att.Data); err != nil {
-		return errors.Wrap(err, "could not verify attestation slot time")
-	}
 	indexedAtt, err := blocks.ConvertToIndexed(baseState, att)
 	if err != nil {
 		return errors.Wrap(err, "could not convert attestation to indexed attestation")


### PR DESCRIPTION
#3542 broke initial sync and regular sync by adding `waitForAttInclDelay` and `verifyAttSlotTime` checks for updating block's attestation votes. These checks were redundant as we already check them as part of processing block and processing attestations in block beforehand