### PR TITLE
Only write interop ssz states to disk with flag ON

### DIFF
--- a/beacon-chain/core/state/interop/BUILD.bazel
+++ b/beacon-chain/core/state/interop/BUILD.bazel
@@ -4,12 +4,14 @@ go_library(
     name = "go_default_library",
     srcs = [
         "log.go",
+        "write_block_to_disk.go",
         "write_state_to_disk.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/core/state/interop",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//proto/beacon/p2p/v1:go_default_library",
+        "//proto/eth/v1alpha1:go_default_library",
         "//shared/featureconfig:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/core/state/interop/BUILD.bazel
+++ b/beacon-chain/core/state/interop/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//proto/beacon/p2p/v1:go_default_library",
+        "//shared/featureconfig:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/beacon-chain/core/state/interop/write_block_to_disk.go
+++ b/beacon-chain/core/state/interop/write_block_to_disk.go
@@ -1,0 +1,30 @@
+package interop
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/prysmaticlabs/go-ssz"
+	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
+)
+
+// WriteBlockToDisk as a block ssz. Writes to temp directory. Debug!
+func WriteBlockToDisk(block *ethpb.BeaconBlock) {
+	if !featureconfig.FeatureConfig().WriteSSZStateTransitions {
+		return
+	}
+	
+	fp := path.Join(os.TempDir(), fmt.Sprintf("beacon_block_%d.ssz", block.Slot))
+	log.Warnf("Writing block to disk at %s", fp)
+	enc, err := ssz.Marshal(block)
+	if err != nil {
+		log.WithError(err).Error("Failed to ssz encode block")
+		return
+	}
+	if err := ioutil.WriteFile(fp, enc, 0664); err != nil {
+		log.WithError(err).Error("Failed to write to disk")
+	}
+}

--- a/beacon-chain/core/state/interop/write_state_to_disk.go
+++ b/beacon-chain/core/state/interop/write_state_to_disk.go
@@ -8,10 +8,14 @@ import (
 
 	"github.com/prysmaticlabs/go-ssz"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 )
 
 // WriteStateToDisk as a state ssz. Writes to temp directory. Debug!
 func WriteStateToDisk(state *pb.BeaconState) {
+	if !featureconfig.FeatureConfig().WriteSSZStates {
+		return
+	}
 	fp := path.Join(os.TempDir(), fmt.Sprintf("beacon_state_%d.ssz", state.Slot))
 	log.Warnf("Writing state to disk at %s", fp)
 	enc, err := ssz.Marshal(state)

--- a/beacon-chain/core/state/interop/write_state_to_disk.go
+++ b/beacon-chain/core/state/interop/write_state_to_disk.go
@@ -13,7 +13,7 @@ import (
 
 // WriteStateToDisk as a state ssz. Writes to temp directory. Debug!
 func WriteStateToDisk(state *pb.BeaconState) {
-	if !featureconfig.FeatureConfig().WriteSSZStates {
+	if !featureconfig.FeatureConfig().WriteSSZStateTransitions {
 		return
 	}
 	fp := path.Join(os.TempDir(), fmt.Sprintf("beacon_state_%d.ssz", state.Slot))

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -63,6 +63,7 @@ func ExecuteStateTransition(
 		}
 	}
 
+	interop.WriteBlockToDisk(block)
 	interop.WriteStateToDisk(state)
 
 	postStateRoot, err := ssz.HashTreeRoot(state)

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -27,7 +27,7 @@ var log = logrus.WithField("prefix", "flags")
 type FeatureFlagConfig struct {
 	NoGenesisDelay bool // NoGenesisDelay when processing a chain start genesis event.
 	DemoConfig     bool // DemoConfig with lower deposit thresholds.
-	WriteSSZStates bool // WriteSSZStates to tmp directory.
+	WriteSSZStateTransitions bool // WriteSSZStateTransitions to tmp directory.
 
 	// Cache toggles.
 	EnableActiveBalanceCache bool // EnableActiveBalanceCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
@@ -66,9 +66,9 @@ func ConfigureBeaconFeatures(ctx *cli.Context) {
 		log.Warn("Using non standard genesis delay. This may cause problems in a multi-node environment.")
 		cfg.NoGenesisDelay = true
 	}
-	if ctx.GlobalBool(writeSSZStatesFlag.Name) {
-		log.Warn("Writing SSZ states after state transitions")
-		cfg.WriteSSZStates = true
+	if ctx.GlobalBool(writeSSZStateTransitionsFlag.Name) {
+		log.Warn("Writing SSZ states and blocks after state transitions")
+		cfg.WriteSSZStateTransitions = true
 	}
 	if ctx.GlobalBool(EnableActiveBalanceCacheFlag.Name) {
 		log.Warn("Enabled unsafe active balance cache")

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -66,7 +66,7 @@ func ConfigureBeaconFeatures(ctx *cli.Context) {
 		log.Warn("Using non standard genesis delay. This may cause problems in a multi-node environment.")
 		cfg.NoGenesisDelay = true
 	}
-	if ctx.GlobalBool(WriteSSZStatesFlag.Name) {
+	if ctx.GlobalBool(writeSSZStatesFlag.Name) {
 		log.Warn("Writing SSZ states after state transitions")
 		cfg.WriteSSZStates = true
 	}

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -27,6 +27,7 @@ var log = logrus.WithField("prefix", "flags")
 type FeatureFlagConfig struct {
 	NoGenesisDelay bool // NoGenesisDelay when processing a chain start genesis event.
 	DemoConfig     bool // DemoConfig with lower deposit thresholds.
+	WriteSSZStates bool // WriteSSZStates to tmp directory.
 
 	// Cache toggles.
 	EnableActiveBalanceCache bool // EnableActiveBalanceCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
@@ -64,6 +65,10 @@ func ConfigureBeaconFeatures(ctx *cli.Context) {
 	if ctx.GlobalBool(NoGenesisDelayFlag.Name) {
 		log.Warn("Using non standard genesis delay. This may cause problems in a multi-node environment.")
 		cfg.NoGenesisDelay = true
+	}
+	if ctx.GlobalBool(WriteSSZStatesFlag.Name) {
+		log.Warn("Writing SSZ states after state transitions")
+		cfg.WriteSSZStates = true
 	}
 	if ctx.GlobalBool(EnableActiveBalanceCacheFlag.Name) {
 		log.Warn("Enabled unsafe active balance cache")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -15,6 +15,10 @@ var (
 		Name:  "demo-config",
 		Usage: "Use demo config with lower deposit thresholds.",
 	}
+	WriteSSZStatesFlag = cli.BoolFlag {
+		name: "interop-write-ssz-states",
+		Usage: "Write ssz states to disk after attempted state transition",
+	}
 	// EnableActiveBalanceCacheFlag see https://github.com/prysmaticlabs/prysm/issues/3106.
 	EnableActiveBalanceCacheFlag = cli.BoolFlag{
 		Name:  "enable-active-balance-cache",
@@ -61,6 +65,7 @@ var ValidatorFlags = []cli.Flag{
 var BeaconChainFlags = []cli.Flag{
 	NoGenesisDelayFlag,
 	DemoConfigFlag,
+	WriteSSZStatesFlag,
 	EnableActiveBalanceCacheFlag,
 	EnableAttestationCacheFlag,
 	EnableAncestorBlockCacheFlag,

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -15,8 +15,8 @@ var (
 		Name:  "demo-config",
 		Usage: "Use demo config with lower deposit thresholds.",
 	}
-	WriteSSZStatesFlag = cli.BoolFlag {
-		name: "interop-write-ssz-states",
+	writeSSZStatesFlag = cli.BoolFlag {
+		Name: "interop-write-ssz-states",
 		Usage: "Write ssz states to disk after attempted state transition",
 	}
 	// EnableActiveBalanceCacheFlag see https://github.com/prysmaticlabs/prysm/issues/3106.
@@ -65,7 +65,7 @@ var ValidatorFlags = []cli.Flag{
 var BeaconChainFlags = []cli.Flag{
 	NoGenesisDelayFlag,
 	DemoConfigFlag,
-	WriteSSZStatesFlag,
+	writeSSZStatesFlag,
 	EnableActiveBalanceCacheFlag,
 	EnableAttestationCacheFlag,
 	EnableAncestorBlockCacheFlag,

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -15,8 +15,8 @@ var (
 		Name:  "demo-config",
 		Usage: "Use demo config with lower deposit thresholds.",
 	}
-	writeSSZStatesFlag = cli.BoolFlag {
-		Name: "interop-write-ssz-states",
+	writeSSZStateTransitionsFlag = cli.BoolFlag {
+		Name: "interop-write-ssz-state-transitions",
 		Usage: "Write ssz states to disk after attempted state transition",
 	}
 	// EnableActiveBalanceCacheFlag see https://github.com/prysmaticlabs/prysm/issues/3106.
@@ -65,7 +65,7 @@ var ValidatorFlags = []cli.Flag{
 var BeaconChainFlags = []cli.Flag{
 	NoGenesisDelayFlag,
 	DemoConfigFlag,
-	writeSSZStatesFlag,
+	writeSSZStateTransitionsFlag,
 	EnableActiveBalanceCacheFlag,
 	EnableAttestationCacheFlag,
 	EnableAncestorBlockCacheFlag,


### PR DESCRIPTION
This should be opt-in rather than always on. 

Also writes blocks too. 

resolves #3492