### PR TITLE
Lock around validateBeaconBlockPubSub

### DIFF
--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -66,6 +66,7 @@ type RegularSync struct {
 	pendingQueueLock    sync.RWMutex
 	chainStarted        bool
 	initialSync         Checker
+	validateBlockLock    sync.RWMutex
 }
 
 // Start the regular sync service.

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -19,6 +19,8 @@ var recentlySeenRoots = ccache.New(ccache.Configure().MaxSize(100000))
 // Blocks that have already been seen are ignored. If the BLS signature is any valid signature,
 // this method rebroadcasts the message.
 func (r *RegularSync) validateBeaconBlockPubSub(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) bool {
+	r.validateBlockLock.Lock()
+	defer r.validateBlockLock.Unlock()
 	m := msg.(*ethpb.BeaconBlock)
 
 	blockRoot, err := ssz.SigningRoot(m)


### PR DESCRIPTION
We saw multiple processing of beacon block during regular sync:
```
[2019-09-23 16:11:03]  INFO forkchoice: Executing state transition on block slot=531
[2019-09-23 16:11:03]  INFO forkchoice: Executing state transition on block slot=531
[2019-09-23 16:11:03]  INFO forkchoice: Executing state transition on block slot=531
```
This happens because we receive blocks from 3 people at the same time, which is why we are adding a lock around `validateBeaconBlockPubSub`