### PR TITLE
Merkle tree math helpers

### DIFF
--- a/shared/trieutil/BUILD.bazel
+++ b/shared/trieutil/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "merkle_trie.go",
         "sparse_merkle.go",
         "zerohashes.go",
     ],
@@ -17,7 +18,10 @@ go_library(
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["sparse_merkle_test.go"],
+    srcs = [
+        "merkle_trie_test.go",
+        "sparse_merkle_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//contracts/deposit-contract:go_default_library",

--- a/shared/trieutil/merkle_trie.go
+++ b/shared/trieutil/merkle_trie.go
@@ -1,0 +1,37 @@
+package trieutil
+
+// NextPowerOf2 returns the next power of 2 >= the input
+//
+// Spec pseudocode definition:
+//   def get_next_power_of_two(x: int) -> int:
+//    """
+//    Get next power of 2 >= the input.
+//    """
+//    if x <= 2:
+//        return x
+//    else:
+//        return 2 * get_next_power_of_two((x + 1) // 2)
+func NextPowerOf2(n int) int {
+	if n <= 2 {
+		return n
+	}
+	return 2 * NextPowerOf2((n+1)/2)
+}
+
+// PrevPowerOf2 returns the previous power of 2 >= the input
+//
+// Spec pseudocode definition:
+//   def get_previous_power_of_two(x: int) -> int:
+//    """
+//    Get the previous power of 2 >= the input.
+//    """
+//    if x <= 2:
+//        return x
+//    else:
+//        return 2 * get_previous_power_of_two(x // 2)
+func PrevPowerOf2(n int) int {
+	if n <= 2 {
+		return n
+	}
+	return 2 * PrevPowerOf2(n/2)
+}

--- a/shared/trieutil/merkle_trie_test.go
+++ b/shared/trieutil/merkle_trie_test.go
@@ -1,0 +1,45 @@
+package trieutil
+
+import (
+"testing"
+)
+
+func TestNextPowerOf2(t *testing.T) {
+	tests := []struct {
+		input int
+		want int
+	}{
+		{input:0, want:0},
+		{input:1, want:1},
+		{input:2, want:2},
+		{input:3, want:4},
+		{input:5, want:8},
+		{input:9, want:16},
+		{input:20, want:32},
+	}
+	for _, tt := range tests {
+		if got := NextPowerOf2(tt.input); got != tt.want {
+			t.Errorf("NextPowerOf2() = %v, want %v", got, tt.want)
+		}
+	}
+}
+
+func TestPrevPowerOf2(t *testing.T) {
+	tests := []struct {
+		input int
+		want int
+	}{
+		{input:0, want:0},
+		{input:1, want:1},
+		{input:2, want:2},
+		{input:3, want:2},
+		{input:5, want:4},
+		{input:9, want:8},
+		{input:20, want:16},
+	}
+	for _, tt := range tests {
+		if got := PrevPowerOf2(tt.input); got != tt.want {
+			t.Errorf("PrevPowerOf2() = %v, want %v", got, tt.want)
+		}
+	}
+}

--- a/shared/trieutil/merkle_trie_test.go
+++ b/shared/trieutil/merkle_trie_test.go
@@ -1,21 +1,21 @@
 package trieutil
 
 import (
-"testing"
+	"testing"
 )
 
 func TestNextPowerOf2(t *testing.T) {
 	tests := []struct {
 		input int
-		want int
+		want  int
 	}{
-		{input:0, want:0},
-		{input:1, want:1},
-		{input:2, want:2},
-		{input:3, want:4},
-		{input:5, want:8},
-		{input:9, want:16},
-		{input:20, want:32},
+		{input: 0, want: 0},
+		{input: 1, want: 1},
+		{input: 2, want: 2},
+		{input: 3, want: 4},
+		{input: 5, want: 8},
+		{input: 9, want: 16},
+		{input: 20, want: 32},
 	}
 	for _, tt := range tests {
 		if got := NextPowerOf2(tt.input); got != tt.want {
@@ -27,15 +27,15 @@ func TestNextPowerOf2(t *testing.T) {
 func TestPrevPowerOf2(t *testing.T) {
 	tests := []struct {
 		input int
-		want int
+		want  int
 	}{
-		{input:0, want:0},
-		{input:1, want:1},
-		{input:2, want:2},
-		{input:3, want:2},
-		{input:5, want:4},
-		{input:9, want:8},
-		{input:20, want:16},
+		{input: 0, want: 0},
+		{input: 1, want: 1},
+		{input: 2, want: 2},
+		{input: 3, want: 2},
+		{input: 5, want: 4},
+		{input: 9, want: 8},
+		{input: 20, want: 16},
 	}
 	for _, tt := range tests {
 		if got := PrevPowerOf2(tt.input); got != tt.want {


### PR DESCRIPTION
Getting us ahead of the curve, this PR starts implementing merkle trie related helpers for testing generalized index and merkle multi proofs. This is a very important component for phase 1 and light client protocol.

References: https://github.com/ethereum/eth2.0-specs/blob/50209ea806820f83ceff3f21e1578191db0a71e5/specs/light_client/merkle_proofs.md#helper-functions