### PR TITLE
Fix Validator Account Creation

### DIFF
--- a/contracts/deposit-contract/testutils.go
+++ b/contracts/deposit-contract/testutils.go
@@ -54,7 +54,6 @@ func Setup() (*TestAccount, error) {
 		return nil, err
 	}
 	backend.Commit()
-	txOpts.GasLimit = 1000000
 
 	return &TestAccount{addr, contract, contractAddr, backend, txOpts}, nil
 }

--- a/contracts/deposit-contract/testutils.go
+++ b/contracts/deposit-contract/testutils.go
@@ -54,6 +54,7 @@ func Setup() (*TestAccount, error) {
 		return nil, err
 	}
 	backend.Commit()
+	txOpts.GasLimit = 1000000
 
 	return &TestAccount{addr, contract, contractAddr, backend, txOpts}, nil
 }

--- a/validator/accounts/BUILD.bazel
+++ b/validator/accounts/BUILD.bazel
@@ -6,10 +6,10 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/validator/accounts",
     visibility = ["//validator:__subpackages__"],
     deps = [
+        "//contracts/deposit-contract:go_default_library",
         "//shared/keystore:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
-        "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -90,6 +90,8 @@ func NewValidatorAccount(directory string, password string) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to create simulated backend")
 	}
+	testAcc.TxOpts.GasLimit = 1000000
+
 	tx, err := testAcc.Contract.Deposit(testAcc.TxOpts, data.PublicKey, data.WithdrawalCredentials, data.Signature)
 	if err != nil {
 		return errors.Wrap(err, "unable to create deposit transaction")

--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/go-ssz"
+	contract "github.com/prysmaticlabs/prysm/contracts/deposit-contract"
 	"github.com/prysmaticlabs/prysm/shared/keystore"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
@@ -86,18 +86,22 @@ func NewValidatorAccount(directory string, password string) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to generate deposit data")
 	}
-	serializedData, err := ssz.Marshal(data)
+	testAcc, err := contract.Setup()
 	if err != nil {
-		return errors.Wrap(err, "could not serialize deposit data")
+		return errors.Wrap(err, "unable to create simulated backend")
 	}
-	log.Info(`Account creation complete! Copy and paste the deposit data shown below when issuing a transaction into the ETH1.0 deposit contract to activate your validator client`)
+	tx, err := testAcc.Contract.Deposit(testAcc.TxOpts, data.PublicKey, data.WithdrawalCredentials, data.Signature)
+	if err != nil {
+		return errors.Wrap(err, "unable to create deposit transaction")
+	}
+	log.Info(`Account creation complete! Copy and paste the raw transaction data shown below when issuing a transaction into the ETH1.0 deposit contract to activate your validator client`)
 	fmt.Printf(`
-========================Deposit Data=======================
+========================Raw Transaction Data=======================
 
 %#x
 
 ===========================================================
-`, serializedData)
+`, tx.Data())
 	return nil
 }
 


### PR DESCRIPTION
Resolves #3576 
This prints the raw transaction data into the console, so that users can simply copy and paste it when submitting the transaction to the eth1 chain.