### PR TITLE
Operations service: exit go routine on error

### DIFF
--- a/beacon-chain/operations/service.go
+++ b/beacon-chain/operations/service.go
@@ -240,8 +240,10 @@ func (s *Service) removeOperations() {
 		select {
 		case <-incomingBlockSub.Err():
 			log.Debug("Subscriber closed, exiting goroutine")
+			return
 		case <-s.ctx.Done():
 			log.Debug("operations service context closed, exiting remove goroutine")
+			return
 		// Listen for processed block from the block chain service.
 		case block := <-s.incomingProcessedBlock:
 			handler.SafelyHandleMessage(ctx, s.handleProcessedBlock, block)


### PR DESCRIPTION
This was causing a wall of logs on shutdown at debug level