### PR TITLE
Log warning with error instead of returning an error in fork choice attestation votes updates

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -155,7 +155,7 @@ func (s *Store) updateBlockAttestationsVotes(ctx context.Context, atts []*ethpb.
 			continue
 		}
 		if err := s.updateBlockAttestationVote(ctx, att); err != nil {
-			return err
+			log.WithError(err).Warn("Attestation failed to update vote")
 		}
 		s.seenAtts[r] = true
 	}


### PR DESCRIPTION
As title describes, invalid attestations would break initial sync but should be ignored.