### PR TITLE
End to end deposit testing

### DIFF
--- a/contracts/deposit-contract/sendDepositTx/BUILD.bazel
+++ b/contracts/deposit-contract/sendDepositTx/BUILD.bazel
@@ -34,12 +34,11 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//contracts/deposit-contract:go_default_library",
-        "//proto/eth/v1alpha1:go_default_library",
         "//shared/keystore:go_default_library",
         "//shared/testutil:go_default_library",
         "@com_github_ethereum_go_ethereum//:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
+        "@com_github_prysmaticlabs_prysm//bazel-prysm/beacon-chain/powchain:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
 )

--- a/contracts/deposit-contract/sendDepositTx/BUILD.bazel
+++ b/contracts/deposit-contract/sendDepositTx/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -26,4 +26,20 @@ go_binary(
     name = "sendDepositTx",
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["sendDeposits_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//contracts/deposit-contract:go_default_library",
+        "//proto/eth/v1alpha1:go_default_library",
+        "//shared/keystore:go_default_library",
+        "//shared/testutil:go_default_library",
+        "@com_github_ethereum_go_ethereum//:go_default_library",
+        "@com_github_ethereum_go_ethereum//common:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
+    ],
 )

--- a/contracts/deposit-contract/sendDepositTx/sendDeposits_test.go
+++ b/contracts/deposit-contract/sendDepositTx/sendDeposits_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	contracts "github.com/prysmaticlabs/prysm/contracts/deposit-contract"
+)
+
+
+
+/*
+Plan
+1)create a simulated backend
+2)deploy a contract  /deployContract.go
+3)send deposits
+4)validate that deposit log has been emitted with correct data
+5)deposit log should be valid
+*/
+
+func TestEndtoEndDeposits((t *testing.T)  {
+	testAcc, err := contracts.Setup()
+	if err != nil {
+		t.Fatalf("Unable to set up simulated backend %v", err)
+	}
+	/* type TestAccount struct {
+		Addr         common.Address
+		Contract     *DepositContract
+		ContractAddr common.Address
+		Backend      *backends.SimulatedBackend
+		TxOpts       *bind.TransactOpts
+	}  */
+
+   
+
+}
+

--- a/contracts/deposit-contract/sendDepositTx/sendDeposits_test.go
+++ b/contracts/deposit-contract/sendDepositTx/sendDeposits_test.go
@@ -1,34 +1,128 @@
 package main
 
 import (
+	"crypto/rand"
+	"io/ioutil"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
 	contracts "github.com/prysmaticlabs/prysm/contracts/deposit-contract"
+	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	prysmKeyStore "github.com/prysmaticlabs/prysm/shared/keystore"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/sirupsen/logrus"
+	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
+func generateValidators(count int64) map[string]*prysmKeyStore.Key {
+	validatorKeys := make(map[string]*prysmKeyStore.Key)
+	for i := int64(0); i < count; i++ {
+		validatorKey, err := prysmKeyStore.NewKey(rand.Reader)
+		if err != nil {
+			log.Errorf("Could not generate random key: %v", err)
+		}
+		validatorKeys[hex.EncodeToString(validatorKey.PublicKey.Marshal())] = validatorKey
+	}
+}
 
+//should I explicitly return err here?
+func sendDeposits(testAcc *contracts.TestAccount, validatorKeys map[string]*prysmKeyStore.Key,
+	numberOfDeposits int64, log *Entry) {
+	depositAmountInGwei := contracts.Amount32Eth.Uint64()
 
-/*
-Plan
-1)create a simulated backend
-2)deploy a contract  /deployContract.go
-3)send deposits
-4)validate that deposit log has been emitted with correct data
-5)deposit log should be valid
-*/
+	depositDelay := int64(1)
+	depositContractAddrStr := testAcc.ContractAddr.GetHex()
 
-func TestEndtoEndDeposits((t *testing.T)  {
+	for _, validatorKey := range validatorKeys {
+		data, err := prysmKeyStore.DepositInput(validatorKey, validatorKey, depositAmountInGwei)
+		if err != nil {
+			log.Errorf("Could not generate deposit input data: %v", err)
+			continue
+		}
+
+		for i := int64(0); i < numberOfDeposits; i++ {
+			tx, err := testAcc.Contract.Deposit(testAcc.TxOpts, data.PublicKey, data.WithdrawalCredentials, data.Signature)
+			if err != nil {
+				log.Error("unable to send transaction to contract")
+			}
+
+			testAcc.Backend.Commit()
+
+			log.WithFields(logrus.Fields{
+				"Transaction Hash": fmt.Sprintf("%#x", tx.Hash()),
+			}).Infof("Deposit %d sent to contract address %v for validator with a public key %#x", i, depositContractAddrStr, validatorKey.PublicKey.Marshal())
+
+			time.Sleep(time.Duration(depositDelay) * time.Second)
+		}
+	}
+}
+
+func init() {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
+}
+
+func TestEndtoEndDeposits(t *testing.T) {
+	log = logrus.WithField("prefix", "main")
+	testutil.ResetCache()
 	testAcc, err := contracts.Setup()
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	/* type TestAccount struct {
-		Addr         common.Address
-		Contract     *DepositContract
-		ContractAddr common.Address
-		Backend      *backends.SimulatedBackend
-		TxOpts       *bind.TransactOpts
-	}  */
 
-   
+	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
+		Endpoint:        endpoint,
+		DepositContract: testAcc.ContractAddr,
+		Reader:          &goodReader{},
+		Logger:          &goodLogger{},
+		HTTPLogger:      &goodLogger{},
+		ContractBackend: testAcc.Backend,
+		BeaconDB:        &kv.Store{},
+		DepositCache:    depositcache.NewDepositCache(),
+	})
+	if err != nil {
+		t.Fatalf("unable to setup web3 ETH1.0 chain service: %v", err)
+	}
 
+	testAcc.Backend.Commit()
+
+	validatorsWanted := int64(16)
+	validatorKeys := generateValidators(validatorsWanted)
+
+	numberOfDeposits := int64(16)
+
+	testAcc.TxOpts.Value = contracts.Amount32Eth()
+	testAcc.TxOpts.GasLimit = 1000000
+
+	sendDeposits(testAcc, validatorKeys, numberOfDeposits, log)
+
+	query := ethereum.FilterQuery{
+		Addresses: []common.Address{
+			web3Service.depositContractAddress,
+		},
+	}
+
+	logs, err := testAcc.Backend.FilterLogs(web3Service.ctx, query)
+	if err != nil {
+		t.Fatalf("Unable to retrieve logs %v", err)
+	}
+	if len(logs) == 0 {
+		t.Fatal("no logs")
+	}
+
+	web3Service.chainStarted = true
+
+	for _, log := range logs {
+		if err := web3Service.ProcessDepositLog(context.Background(), log); err != nil {
+			t.Fatal("Unable to process deposit log %v", err)
+		}
+	}
+	totalNumberOfDeposits := validatorsWanted * numberOfDeposits
+	pendingDeposits := web3Service.depositCache.PendingDeposits(context.Background(), nil /*blockNum*/)
+	if len(pendingDeposits) != int(totalNumberOfDeposits) {
+		t.Errorf("Unexpected number of deposits. Wanted %v deposits, got %+v", int(totalNumberOfDeposits), pendingDeposits)
+	}
 }
-


### PR DESCRIPTION
This is a draft PR towards end to end deposit testing 

[Resolves] #2955

In [powchain](https://github.com/prysmaticlabs/prysm/blob/master/beacon-chain/powchain/log_processing_test.go) there is good testing for deposit processing logs.

1.TestEndToEndDeposits right now is a copy of [TestProcessDepositLog_InsertsPendingDeposit](https://github.com/prysmaticlabs/prysm/blob/master/beacon-chain/powchain/log_processing_test.go#L92). I tried to test it locally , it has output multiple [errors](https://play.golang.org/p/TNlVcEKU6kf) from bls package. How can I fix them?

@nisdas has pointed out , i have to test [sendDeposits.go](https://github.com/prysmaticlabs/prysm/blob/master/contracts/deposit-contract/sendDepositTx/sendDeposits.go). I guess i have to follow these steps:

1. Create [client app](https://github.com/prysmaticlabs/prysm/blob/master/contracts/deposit-contract/sendDepositTx/sendDeposits.go#L117) and  get a [client](https://github.com/prysmaticlabs/prysm/blob/master/contracts/deposit-contract/sendDepositTx/sendDeposits.go#L133). 

2. deploy the deposit [contract](https://github.com/prysmaticlabs/prysm/blob/master/contracts/deposit-contract/sendDepositTx/sendDeposits.go#L165)

3. get [deposit data](https://github.com/prysmaticlabs/prysm/blob/master/contracts/deposit-contract/sendDepositTx/sendDeposits.go#L189)

4. call [deposit](https://github.com/prysmaticlabs/prysm/blob/master/contracts/deposit-contract/sendDepositTx/sendDeposits.go#L197) to the contract 

5. the final step would be run [ProcessLog](https://github.com/prysmaticlabs/prysm/blob/master/beacon-chain/powchain/log_processing.go#L38) to validate deposit logs.

Do these steps sound good? or I missed something?

Questions:
1.In a step 1 should I use `testAcc, err := contracts.Setup()` instead?


