### PR TITLE
Handle large ranges of skipped slots

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -105,6 +105,29 @@ func TestRoundRobinSync(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:               "Multiple peers with many skipped slots",
+			currentSlot:        640, // 10 epochs
+			expectedBlockSlots: append(makeSequence(1, 64), makeSequence(500, 640)...),
+			peers: []*peerData{
+				{
+					blocks:         append(makeSequence(1, 64), makeSequence(500, 640)...),
+					finalizedEpoch: 9,
+					headSlot:       640,
+				},
+				{
+					blocks:         append(makeSequence(1, 64), makeSequence(500, 640)...),
+					finalizedEpoch: 9,
+					headSlot:       640,
+				},
+				{
+					blocks:         append(makeSequence(1, 64), makeSequence(500, 640)...),
+					finalizedEpoch: 9,
+					headSlot:       640,
+				},
+			},
+		},
+
 		// TODO(3147): Handle multiple failures.
 		//{
 		//	name:               "Multiple peers with multiple failures",
@@ -236,16 +259,6 @@ func connectPeers(t *testing.T, host *p2pt.TestP2P, data []*peerData) {
 
 			// Determine the correct subset of blocks to return as dictated by the test scenario.
 			blocks := sliceutil.IntersectionUint64(datum.blocks, requestedBlocks)
-
-			if len(blocks) == 0 {
-				if _, err := stream.Write([]byte{0x01}); err != nil {
-					t.Error(err)
-				}
-				if _, err := peer.Encoding().EncodeWithLength(stream, "i don't have those blocks"); err != nil {
-					t.Error(err)
-				}
-				return
-			}
 
 			ret := make([]*eth.BeaconBlock, 0)
 			for _, slot := range blocks {


### PR DESCRIPTION
In the scenario where there are many skip slots, the round robin sync would stall if the given range was empty. This PR resolves that unlikely scenario.