### PR TITLE
Add a few logs at start of initial sync

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -61,8 +61,13 @@ func (s *InitialSync) Start() {
 	// Wait until chain start.
 	genesis := <-ch
 	if genesis.After(roughtime.Now()) {
+		log.WithField(
+			"genesis time",
+			genesis,
+		).Warn("Genesis time is in the future. Waiting to start sync.")
 		time.Sleep(roughtime.Until(genesis))
 	}
+	log.Info("Starting initial sync.")
 	s.chainStarted = true
 	currentSlot := slotsSinceGenesis(genesis)
 	if helpers.SlotToEpoch(currentSlot) == 0 {


### PR DESCRIPTION
Seeing some weird scenario in prod were initial sync never started. These logs might help troubleshoot the event when it happens again.