### PR TITLE
Default genesisTime to now when generating a genesis state.

### DIFF
--- a/INTEROP.md
+++ b/INTEROP.md
@@ -25,7 +25,7 @@ You can use `bazel run //tools/genesis-state-gen` to create a deterministic gene
 
 ### Usage
 
-- **--genesis-time** uint: Unix timestamp used as the genesis time in the generated genesis state
+- **--genesis-time** uint: Unix timestamp used as the genesis time in the generated genesis state (defaults to now)
 - **--mainnet-config** bool: Select whether genesis state should be generated with mainnet or minimal (default) params
 - **--num-validators** int: Number of validators to deterministically include in the generated genesis state
 - **--output-ssz** string: Output filename of the SSZ marshaling of the generated genesis state
@@ -50,7 +50,6 @@ bazel run //beacon-chain -- \
 --deposit-contract 0xD775140349E6A5D12524C6ccc3d6A1d4519D4029 \
 --clear-db \
 --interop-num-validators 64 \
---interop-genesis-time=$(date +%s) \
 --interop-eth1data-votes
 ```
 

--- a/beacon-chain/interop-cold-start/service.go
+++ b/beacon-chain/interop-cold-start/service.go
@@ -83,6 +83,10 @@ func NewColdStartService(ctx context.Context, cfg *Config) *Service {
 	if err != nil {
 		log.Fatalf("Could not generate interop genesis state: %v", err)
 	}
+	if s.genesisTime == 0 {
+		// Generated genesis time; fetch it
+		s.genesisTime = genesisState.GenesisTime
+	}
 	if err := s.saveGenesisState(ctx, genesisState); err != nil {
 		log.Fatalf("Could not save interop genesis state %v", err)
 	}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -414,12 +414,11 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 		return err
 	}
 
-	genesisTime := ctx.GlobalUint64(flags.InteropGenesisTimeFlag.Name)
 	genesisValidators := ctx.GlobalUint64(flags.InteropNumValidatorsFlag.Name)
 	genesisStatePath := ctx.GlobalString(flags.InteropGenesisStateFlag.Name)
 	var depositFetcher depositcache.DepositFetcher
 	var chainStartFetcher powchain.ChainStartFetcher
-	if genesisTime > 0 && genesisValidators > 0 || genesisStatePath != "" {
+	if genesisValidators > 0 || genesisStatePath != "" {
 		var interopService *interopcoldstart.Service
 		if err := b.services.FetchService(&interopService); err != nil {
 			return err
@@ -499,7 +498,7 @@ func (b *BeaconNode) registerInteropServices(ctx *cli.Context) error {
 	genesisValidators := ctx.GlobalUint64(flags.InteropNumValidatorsFlag.Name)
 	genesisStatePath := ctx.GlobalString(flags.InteropGenesisStateFlag.Name)
 
-	if genesisTime > 0 && genesisValidators > 0 || genesisStatePath != "" {
+	if genesisValidators > 0 || genesisStatePath != "" {
 		svc := interopcoldstart.NewColdStartService(context.Background(), &interopcoldstart.Config{
 			GenesisTime:   genesisTime,
 			NumValidators: genesisValidators,
@@ -509,8 +508,6 @@ func (b *BeaconNode) registerInteropServices(ctx *cli.Context) error {
 		})
 
 		return b.services.RegisterService(svc)
-	} else if genesisTime+genesisValidators > 0 {
-		log.Errorf("%s and %s must be used together", flags.InteropNumValidatorsFlag.Name, flags.InteropGenesisTimeFlag.Name)
 	}
 	return nil
 }

--- a/shared/interop/BUILD.bazel
+++ b/shared/interop/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//shared/bls:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/roughtime:go_default_library",
         "//shared/trieutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",

--- a/shared/interop/generate_genesis_state.go
+++ b/shared/interop/generate_genesis_state.go
@@ -1,6 +1,8 @@
 package interop
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
@@ -22,6 +24,7 @@ var (
 )
 
 // GenerateGenesisState deterministically given a genesis time and number of validators.
+// If a genesis time of 0 is supplied it is set to the current time.
 func GenerateGenesisState(genesisTime, numValidators uint64) (*pb.BeaconState, []*ethpb.Deposit, error) {
 	privKeys, pubKeys, err := DeterministicallyGenerateKeys(0 /*startIndex*/, numValidators)
 	if err != nil {
@@ -43,6 +46,9 @@ func GenerateGenesisState(genesisTime, numValidators uint64) (*pb.BeaconState, [
 		return nil, nil, errors.Wrap(err, "could not generate deposits from the deposit data provided")
 	}
 	root := trie.Root()
+	if genesisTime == 0 {
+		genesisTime = uint64(time.Now().Unix())
+	}
 	beaconState, err := state.GenesisBeaconState(deposits, genesisTime, &ethpb.Eth1Data{
 		DepositRoot:  root[:],
 		DepositCount: uint64(len(deposits)),

--- a/shared/interop/generate_genesis_state.go
+++ b/shared/interop/generate_genesis_state.go
@@ -1,8 +1,6 @@
 package interop
 
 import (
-	"time"
-
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
@@ -11,6 +9,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/roughtime"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
 )
 
@@ -47,7 +46,7 @@ func GenerateGenesisState(genesisTime, numValidators uint64) (*pb.BeaconState, [
 	}
 	root := trie.Root()
 	if genesisTime == 0 {
-		genesisTime = uint64(time.Now().Unix())
+		genesisTime = uint64(roughtime.Now().Unix())
 	}
 	beaconState, err := state.GenesisBeaconState(deposits, genesisTime, &ethpb.Eth1Data{
 		DepositRoot:  root[:],

--- a/tools/genesis-state-gen/main.go
+++ b/tools/genesis-state-gen/main.go
@@ -19,7 +19,7 @@ const (
 var (
 	numValidators    = flag.Int("num-validators", 0, "Number of validators to deterministically include in the generated genesis state")
 	useMainnetConfig = flag.Bool("mainnet-config", false, "Select whether genesis state should be generated with mainnet or minimal (default) params")
-	genesisTime      = flag.Uint64("genesis-time", 0, "Unix timestamp used as the genesis time in the generated genesis state")
+	genesisTime      = flag.Uint64("genesis-time", 0, "Unix timestamp used as the genesis time in the generated genesis state (defaults to now)")
 	sszOutputFile    = flag.String("output-ssz", "", "Output filename of the SSZ marshaling of the generated genesis state")
 	yamlOutputFile   = flag.String("output-yaml", "", "Output filename of the YAML marshaling of the generated genesis state")
 	jsonOutputFile   = flag.String("output-json", "", "Output filename of the JSON marshaling of the generated genesis state")
@@ -31,7 +31,7 @@ func main() {
 		log.Fatal("Expected --num-validators to have been provided, received 0")
 	}
 	if *genesisTime == 0 {
-		log.Print("No --genesis-time specified, defaulting to 0 as the unix timestamp")
+		log.Print("No --genesis-time specified, defaulting to now")
 	}
 	if *sszOutputFile == "" && *yamlOutputFile == "" && *jsonOutputFile == "" {
 		log.Fatal("Expected --output-ssz, --output-yaml, or --output-json to have been provided, received nil")


### PR DESCRIPTION
An attempt to generate a genesis with a large number of validators results in the beacon chain not able to start within the first epoch. As a result, the chain never runs.

This patch defaults the `genesisTime` parameter in `genesis-state-gen` to the current time *after all validator-related work has been completed*. This ensures the beacon chain can start in good time regardless of the number of validators.

Also updated interop doc, dropping genesis-time parameter where it is not required.