### PR TITLE
Allow overwriting of default bootstrap node

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"path"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -215,7 +216,7 @@ func (b *BeaconNode) startDB(ctx *cli.Context) error {
 
 func (b *BeaconNode) registerP2P(ctx *cli.Context) error {
 	// Bootnode ENR may be a filepath to an ENR file.
-	bootnodeAddrs := sliceutil.SplitCommaSeparated(ctx.GlobalStringSlice(cmd.BootstrapNode.Name))
+	bootnodeAddrs := strings.Split(ctx.GlobalString(cmd.BootstrapNode.Name), ",")
 	for i, addr := range bootnodeAddrs {
 		if filepath.Ext(addr) == ".enr" {
 			b, err := ioutil.ReadFile(addr)

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -99,18 +99,22 @@ func startDHTDiscovery(host core.Host, bootstrapAddr string) error {
 }
 
 func parseBootStrapAddrs(addrs []string) (discv5Nodes []string, kadDHTNodes []string) {
-	for _, addr := range addrs {
-		_, err := enode.Parse(enode.ValidSchemes, addr)
-		if err == nil {
-			discv5Nodes = append(discv5Nodes, addr)
-			continue
+	if len(addrs) == 1 && addrs[0] == "" {
+		log.Warn("No bootstrap addresses supplied")
+	} else {
+		for _, addr := range addrs {
+			_, err := enode.Parse(enode.ValidSchemes, addr)
+			if err == nil {
+				discv5Nodes = append(discv5Nodes, addr)
+				continue
+			}
+			_, err = multiAddrFromString(addr)
+			if err == nil {
+				kadDHTNodes = append(kadDHTNodes, addr)
+				continue
+			}
+			log.Errorf("Invalid bootstrap address of %s provided", addr)
 		}
-		_, err = multiAddrFromString(addr)
-		if err == nil {
-			kadDHTNodes = append(kadDHTNodes, addr)
-			continue
-		}
-		log.Errorf("Invalid bootstrap address of %s provided", addr)
 	}
 	return discv5Nodes, kadDHTNodes
 }

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -99,22 +99,25 @@ func startDHTDiscovery(host core.Host, bootstrapAddr string) error {
 }
 
 func parseBootStrapAddrs(addrs []string) (discv5Nodes []string, kadDHTNodes []string) {
-	if len(addrs) == 1 && addrs[0] == "" {
-		log.Warn("No bootstrap addresses supplied")
-	} else {
-		for _, addr := range addrs {
-			_, err := enode.Parse(enode.ValidSchemes, addr)
-			if err == nil {
-				discv5Nodes = append(discv5Nodes, addr)
-				continue
-			}
-			_, err = multiAddrFromString(addr)
-			if err == nil {
-				kadDHTNodes = append(kadDHTNodes, addr)
-				continue
-			}
-			log.Errorf("Invalid bootstrap address of %s provided", addr)
+	for _, addr := range addrs {
+		if addr == "" {
+			// Ignore empty entries
+			continue
 		}
+		_, err := enode.Parse(enode.ValidSchemes, addr)
+		if err == nil {
+			discv5Nodes = append(discv5Nodes, addr)
+			continue
+		}
+		_, err = multiAddrFromString(addr)
+		if err == nil {
+			kadDHTNodes = append(kadDHTNodes, addr)
+			continue
+		}
+		log.Errorf("Invalid bootstrap address of %s provided", addr)
+	}
+	if len(discv5Nodes) == 0 && len(kadDHTNodes) == 0 {
+		log.Warn("No bootstrap addresses supplied")
 	}
 	return discv5Nodes, kadDHTNodes
 }

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -64,10 +64,10 @@ var (
 		Usage: "Connect with this peer. This flag may be used multiple times.",
 	}
 	// BootstrapNode tells the beacon node which bootstrap node to connect to
-	BootstrapNode = cli.StringSliceFlag{
+	BootstrapNode = cli.StringFlag{
 		Name:  "bootstrap-node",
-		Usage: "The address of bootstrap node. Beacon node will connect for peer discovery via DHT",
-		Value: &cli.StringSlice{"/dns4/prylabs.net/tcp/30001/p2p/16Uiu2HAm7Qwe19vz9WzD2Mxn7fXd1vgHHp4iccuyq7TxwRXoAGfc"},
+		Usage: "The address of bootstrap node. Beacon node will connect for peer discovery via DHT.  Multiple nodes can be separated with comma",
+		Value: "/dns4/prylabs.net/tcp/30001/p2p/16Uiu2HAm7Qwe19vz9WzD2Mxn7fXd1vgHHp4iccuyq7TxwRXoAGfc",
 	}
 	// RelayNode tells the beacon node which relay node to connect to.
 	RelayNode = cli.StringFlag{

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -66,7 +66,7 @@ var (
 	// BootstrapNode tells the beacon node which bootstrap node to connect to
 	BootstrapNode = cli.StringFlag{
 		Name:  "bootstrap-node",
-		Usage: "The address of bootstrap node. Beacon node will connect for peer discovery via DHT.  Multiple nodes can be separated with comma",
+		Usage: "The address of bootstrap node. Beacon node will connect for peer discovery via DHT.  Multiple nodes can be separated with a comma",
 		Value: "/dns4/prylabs.net/tcp/30001/p2p/16Uiu2HAm7Qwe19vz9WzD2Mxn7fXd1vgHHp4iccuyq7TxwRXoAGfc",
 	}
 	// RelayNode tells the beacon node which relay node to connect to.


### PR DESCRIPTION
At current the `--bootstrap-node` appends to the default list of bootstrap nodes rather than overwriting it.

This patch provides the desired functionality, retaining the ability to supply multiple comma-separate nodes if required.