### PR TITLE
Bootstrap from finalized checkpoint rather than head slot

### DIFF
--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -27,6 +27,7 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/event"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/sirupsen/logrus"
 	logTest "github.com/sirupsen/logrus/hooks/test"
@@ -353,16 +354,20 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 
-	headBlock := &ethpb.BeaconBlock{Slot: 1}
-	headState := &pb.BeaconState{Slot: 1}
+	finalizedSlot := params.BeaconConfig().SlotsPerEpoch*2+1
+	headBlock := &ethpb.BeaconBlock{Slot: finalizedSlot}
+	headState := &pb.BeaconState{Slot: finalizedSlot}
 	headRoot, _ := ssz.SigningRoot(headBlock)
+	if err := db.SaveFinalizedCheckpoint(ctx, &ethpb.Checkpoint{
+		Epoch:                helpers.SlotToEpoch(finalizedSlot),
+		Root:                 headRoot[:],
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if err := db.SaveState(ctx, headState, headRoot); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.SaveBlock(ctx, headBlock); err != nil {
-		t.Fatal(err)
-	}
-	if err := db.SaveHeadBlockRoot(ctx, headRoot); err != nil {
 		t.Fatal(err)
 	}
 	c := &Service{beaconDB: db, canonicalRoots: make(map[uint64][]byte)}


### PR DESCRIPTION
Specifically when starting initial sync from an existing database, there is a chance that the node's existing data is on a fork of the finalized chain. Rolling back their view of "head" to the last finalized epoch gives certainty that the beacon chain node will correctly sync the finalized chain.