### PR TITLE
Fix init sync race condition

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -304,9 +304,9 @@ func (s *Service) initializeChainInfo(ctx context.Context) error {
 
 	finalized, err := s.beaconDB.FinalizedCheckpoint(ctx)
 	if err != nil {
-		return errors.Wrap(err,"could not get finalized checkpoint from db")
+		return errors.Wrap(err, "could not get finalized checkpoint from db")
 	}
-	if finalized == nil{
+	if finalized == nil {
 		// This should never happen. At chain start, the finalized checkpoint
 		// would be the genesis state and block.
 		return errors.New("no finalized epoch in the database")

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -354,13 +354,13 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 
-	finalizedSlot := params.BeaconConfig().SlotsPerEpoch*2+1
+	finalizedSlot := params.BeaconConfig().SlotsPerEpoch*2 + 1
 	headBlock := &ethpb.BeaconBlock{Slot: finalizedSlot}
 	headState := &pb.BeaconState{Slot: finalizedSlot}
 	headRoot, _ := ssz.SigningRoot(headBlock)
 	if err := db.SaveFinalizedCheckpoint(ctx, &ethpb.Checkpoint{
-		Epoch:                helpers.SlotToEpoch(finalizedSlot),
-		Root:                 headRoot[:],
+		Epoch: helpers.SlotToEpoch(finalizedSlot),
+		Root:  headRoot[:],
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -57,11 +57,10 @@ func (s *InitialSync) Start() {
 	var genesis time.Time
 
 	// Wait for state to be initialized, if not already.
+	ch := make(chan time.Time)
+	sub := s.chain.StateInitializedFeed().Subscribe(ch)
+	defer sub.Unsubscribe()
 	if s.chain.HeadState() == nil {
-		ch := make(chan time.Time)
-		sub := s.chain.StateInitializedFeed().Subscribe(ch)
-		defer sub.Unsubscribe()
-
 		// Wait until chain start.
 		genesis = <-ch
 	} else {

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -85,7 +85,7 @@ func (r *RegularSync) Stop() error {
 
 // Status of the currently running regular sync service.
 func (r *RegularSync) Status() error {
-	if r.initialSync.Syncing(){
+	if r.initialSync.Syncing() {
 		return errors.New("waiting for initial sync")
 	}
 	return nil


### PR DESCRIPTION
There are some rare cases where initial sync is not starting. I suspect that the state was initialized before initial sync service subscribed to feed. 

This PR subscribes to the state feed then checks if the state was already initialized. Maybe another improvement is to panic when trying to subscribe to this feed when we know it would never fire again. 

Also ran gofmt.