### PR TITLE
Update abigen command

### DIFF
--- a/contracts/deposit-contract/README.md
+++ b/contracts/deposit-contract/README.md
@@ -47,7 +47,7 @@ and save the bytecode in `bytecode.bin` in the folder. Now with both the abi and
 we can generate the go bindings. 
 
 ```
-abigen -bin ./bytecode.bin -abi ./abi.json -out ./depositContract.go --pkg depositContract
+abigen -bin ./bytecode.bin -abi ./abi.json -out ./depositContract.go --pkg depositcontract --type DepositContract
 
 ```
 


### PR DESCRIPTION
The `abigen` command specified in the validator contract's README has the incorrect arguments to create the desired result.  This patch provides the correct arguments (specifically the package and contract function names).