### PR TITLE
Batch save attestations in state transition

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_attestation.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation.go
@@ -98,6 +98,7 @@ func (s *Store) OnAttestation(ctx context.Context, a *ethpb.Attestation) (uint64
 
 	s.attsQueueLock.Lock()
 	defer s.attsQueueLock.Unlock()
+	atts := make([]*ethpb.Attestation, 0, len(s.attsQueue))
 	for root, a := range s.attsQueue {
 		log.WithFields(logrus.Fields{
 			"AggregatedBitfield": fmt.Sprintf("%08b", a.AggregationBits),
@@ -120,9 +121,15 @@ func (s *Store) OnAttestation(ctx context.Context, a *ethpb.Attestation) (uint64
 			return 0, err
 		}
 		delete(s.attsQueue, root)
-		if err := s.saveNewAttestation(ctx, a); err != nil {
+		att, err := s.aggregatedAttestation(ctx, a)
+		if err != nil {
 			return 0, err
 		}
+		atts = append(atts, att)
+	}
+
+	if err := s.db.SaveAttestations(ctx, atts); err != nil {
+		return 0, err
 	}
 
 	return tgtSlot, nil
@@ -282,31 +289,25 @@ func (s *Store) setSeenAtt(a *ethpb.Attestation) error {
 	return nil
 }
 
-// savesNewAttestation saves the new attestations to DB.
-func (s *Store) saveNewAttestation(ctx context.Context, att *ethpb.Attestation) error {
+// aggregatedAttestation returns the aggregated attestation after checking saved one in db.
+func (s *Store) aggregatedAttestation(ctx context.Context, att *ethpb.Attestation) (*ethpb.Attestation, error) {
 	r, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	saved, err := s.db.Attestation(ctx, r)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if saved == nil {
-		if err := s.db.SaveAttestation(ctx, att); err != nil {
-			return err
-		}
-		return nil
+		return att, nil
 	}
 
 	aggregated, err := helpers.AggregateAttestation(saved, att)
 	if err != nil {
-		return err
-	}
-	if err := s.db.SaveAttestation(ctx, aggregated); err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return aggregated, nil
 }

--- a/beacon-chain/blockchain/forkchoice/process_attestation_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation_test.go
@@ -235,34 +235,24 @@ func TestStore_AggregateAttestation(t *testing.T) {
 	}
 }
 
-func TestStore_SaveNewAttestation(t *testing.T) {
+func TestStore_ReturnAggregatedAttestation(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
 	defer testDB.TeardownDB(t, db)
 
 	store := NewForkChoiceService(ctx, db)
 	a1 := &ethpb.Attestation{Data: &ethpb.AttestationData{}, AggregationBits: bitfield.Bitlist{0x02}}
-	r1, _ := ssz.HashTreeRoot(a1.Data)
-
-	if err := store.saveNewAttestation(ctx, a1); err != nil {
-		t.Fatal(err)
-	}
-	saved, err := store.db.Attestation(ctx, r1)
+	err := store.db.SaveAttestation(ctx, a1)
 	if err != nil {
 		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(a1, saved) {
-		t.Error("did not retrieve saved attestation")
 	}
 
 	a2 := &ethpb.Attestation{Data: &ethpb.AttestationData{}, AggregationBits: bitfield.Bitlist{0x03}}
-	if err := store.saveNewAttestation(ctx, a2); err != nil {
-		t.Fatal(err)
-	}
-	saved, err = store.db.Attestation(ctx, r1)
+	saved, err := store.aggregatedAttestation(ctx, a2)
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if !reflect.DeepEqual(a2, saved) {
 		t.Error("did not retrieve saved attestation")
 	}

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -245,7 +245,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.MinPerEpochChurnLimit = 4
 	minimalConfig.ChurnLimitQuotient = 65536
 	minimalConfig.ShuffleRoundCount = 10
-	minimalConfig.MinGenesisActiveValidatorCount = 512
+	minimalConfig.MinGenesisActiveValidatorCount = 64
 	minimalConfig.MinGenesisTime = 0
 
 	// Gwei values

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -245,7 +245,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.MinPerEpochChurnLimit = 4
 	minimalConfig.ChurnLimitQuotient = 65536
 	minimalConfig.ShuffleRoundCount = 10
-	minimalConfig.MinGenesisActiveValidatorCount = 64
+	minimalConfig.MinGenesisActiveValidatorCount = 512
 	minimalConfig.MinGenesisTime = 0
 
 	// Gwei values


### PR DESCRIPTION
Whether it was attestations in block or individual attestation over the wire, we were saving them one by one. This PR updated to batch save these attestations. This is a better practice because a block can contain up to 128 attestations