### PR TITLE
Add Error to Message validation

### DIFF
--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -26,7 +26,7 @@ type subHandler func(context.Context, proto.Message) error
 // as expected, and return true or false to continue the message processing
 // pipeline. FromSelf indicates whether or not this is a message received from our
 // node in pubsub.
-type validator func(ctx context.Context, msg proto.Message, broadcaster p2p.Broadcaster, fromSelf bool) bool
+type validator func(ctx context.Context, msg proto.Message, broadcaster p2p.Broadcaster, fromSelf bool) (bool, error)
 
 // noopValidator is a no-op that always returns true and does not propagate any
 // message.
@@ -124,11 +124,15 @@ func (r *RegularSync) subscribe(topic string, validate validator, handle subHand
 			return
 		}
 
-		if !validate(ctx, msg, r.p2p, fromSelf) {
+		valid, err := validate(ctx, msg, r.p2p, fromSelf)
+		if err != nil {
 			if !fromSelf {
 				log.WithError(err).Debug("Message failed to verify")
 				messageFailedValidationCounter.WithLabelValues(topic).Inc()
 			}
+			return
+		}
+		if !valid {
 			return
 		}
 

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -30,8 +30,8 @@ type validator func(ctx context.Context, msg proto.Message, broadcaster p2p.Broa
 
 // noopValidator is a no-op that always returns true and does not propagate any
 // message.
-func noopValidator(_ context.Context, _ proto.Message, _ p2p.Broadcaster, _ bool) bool {
-	return true
+func noopValidator(_ context.Context, _ proto.Message, _ p2p.Broadcaster, _ bool) (bool, error) {
+	return true, nil
 }
 
 // Register PubSub subscribers

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -127,7 +127,7 @@ func (r *RegularSync) subscribe(topic string, validate validator, handle subHand
 		valid, err := validate(ctx, msg, r.p2p, fromSelf)
 		if err != nil {
 			if !fromSelf {
-				log.WithError(err).Debug("Message failed to verify")
+				log.WithError(err).Error("Message failed to verify")
 				messageFailedValidationCounter.WithLabelValues(topic).Inc()
 			}
 			return

--- a/beacon-chain/sync/validate_attester_slashing_test.go
+++ b/beacon-chain/sync/validate_attester_slashing_test.go
@@ -140,7 +140,7 @@ func TestValidateAttesterSlashing_ValidSlashing_FromSelf(t *testing.T) {
 	}
 
 	valid, _ := r.validateAttesterSlashing(ctx, slashing, p2p, true /*fromSelf*/)
-	if !valid {
+	if valid {
 		t.Error("Passed validation")
 	}
 
@@ -164,7 +164,7 @@ func TestValidateAttesterSlashing_ContextTimeout(t *testing.T) {
 	}
 
 	valid, _ := r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/)
-	if !valid {
+	if valid {
 		t.Error("slashing from the far distant future should have timed out and returned false")
 	}
 }
@@ -182,7 +182,7 @@ func TestValidateAttesterSlashing_Syncing(t *testing.T) {
 	}
 
 	valid, _ := r.validateAttesterSlashing(ctx, slashing, p2p, false /*fromSelf*/)
-	if !valid {
+	if valid {
 		t.Error("Passed validation")
 	}
 

--- a/beacon-chain/sync/validate_attester_slashing_test.go
+++ b/beacon-chain/sync/validate_attester_slashing_test.go
@@ -101,8 +101,12 @@ func TestValidateAttesterSlashing_ValidSlashing(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
 
-	if !r.validateAttesterSlashing(ctx, slashing, p2p, false /*fromSelf*/) {
-		t.Error("Failed validation")
+	valid, err := r.validateAttesterSlashing(ctx, slashing, p2p, false /*fromSelf*/)
+	if err != nil {
+		t.Errorf("Failed validation: %v", err)
+	}
+	if !valid {
+		t.Error("Failed Validation")
 	}
 
 	if !p2p.BroadcastCalled {
@@ -112,7 +116,9 @@ func TestValidateAttesterSlashing_ValidSlashing(t *testing.T) {
 	// A second message with the same information should not be valid for processing or
 	// propagation.
 	p2p.BroadcastCalled = false
-	if r.validateAttesterSlashing(ctx, slashing, p2p, false /*fromSelf*/) {
+	valid, _ = r.validateAttesterSlashing(ctx, slashing, p2p, false /*fromSelf*/)
+
+	if valid {
 		t.Error("Passed validation when should have failed")
 	}
 
@@ -133,7 +139,8 @@ func TestValidateAttesterSlashing_ValidSlashing_FromSelf(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
 
-	if r.validateAttesterSlashing(ctx, slashing, p2p, true /*fromSelf*/) {
+	valid, _ := r.validateAttesterSlashing(ctx, slashing, p2p, true /*fromSelf*/)
+	if !valid {
 		t.Error("Passed validation")
 	}
 
@@ -156,7 +163,8 @@ func TestValidateAttesterSlashing_ContextTimeout(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
 
-	if r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/) {
+	valid, _ := r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/)
+	if !valid {
 		t.Error("slashing from the far distant future should have timed out and returned false")
 	}
 }
@@ -173,7 +181,8 @@ func TestValidateAttesterSlashing_Syncing(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: true},
 	}
 
-	if r.validateAttesterSlashing(ctx, slashing, p2p, false /*fromSelf*/) {
+	valid, _ := r.validateAttesterSlashing(ctx, slashing, p2p, false /*fromSelf*/)
+	if !valid {
 		t.Error("Passed validation")
 	}
 

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
@@ -13,12 +14,12 @@ import (
 
 // validateBeaconAttestation validates that the block being voted for passes validation before forwarding to the
 // network.
-func (r *RegularSync) validateBeaconAttestation(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) bool {
+func (r *RegularSync) validateBeaconAttestation(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
 	// Attestation processing requires the target block to be present in the database, so we'll skip
 	// validating or processing attestations until fully synced.
 	if r.initialSync.Syncing() {
 		log.Debug("Not propagating or processing attestation during syncing")
-		return false
+		return false, nil
 	}
 
 	// TODO(1332): Add blocks.VerifyAttestation before processing further.
@@ -28,27 +29,27 @@ func (r *RegularSync) validateBeaconAttestation(ctx context.Context, msg proto.M
 
 	attRoot, err := ssz.HashTreeRoot(att)
 	if err != nil {
-		log.WithError(err).Error("Failed to hash attestation")
+		return false, errors.Wrap(err, "could not hash attestation")
 	}
 
 	// Only valid blocks are saved in the database.
 	if !r.db.HasBlock(ctx, bytesutil.ToBytes32(att.Data.BeaconBlockRoot)) {
 		log.Warn("Ignored incoming attestation that points to a block that isn't in the database.")
-		return false
+		return false, nil
 	}
 
 	if recentlySeenRoots.Get(string(attRoot[:])) != nil {
-		return false
+		return false, nil
 	}
 
 	recentlySeenRoots.Set(string(attRoot[:]), true /*value*/, 365*24*time.Hour /*TTL*/)
 
 	if fromSelf {
-		return false
+		return false, nil
 	}
 
 	if err := p.Broadcast(ctx, msg); err != nil {
 		log.WithError(err).Error("Failed to broadcast message")
 	}
-	return true
+	return true, nil
 }

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -41,7 +41,11 @@ func TestValidateBeaconAttestation_ValidBlock(t *testing.T) {
 		},
 	}
 
-	if !rs.validateBeaconAttestation(ctx, msg, p, false /*fromSelf*/) {
+	valid, err := rs.validateBeaconAttestation(ctx, msg, p, false /*fromSelf*/)
+	if err != nil {
+		t.Errorf("Beacon attestation failed validation: %v", err)
+	}
+	if !valid {
 		t.Error("Beacon attestation failed validation")
 	}
 
@@ -51,7 +55,8 @@ func TestValidateBeaconAttestation_ValidBlock(t *testing.T) {
 
 	// It should ignore duplicate identical attestations.
 	p.BroadcastCalled = false
-	if rs.validateBeaconAttestation(ctx, msg, p, false /*fromSelf*/) {
+	valid, _ = rs.validateBeaconAttestation(ctx, msg, p, false /*fromSelf*/)
+	if valid {
 		t.Error("Second identical beacon attestation passed validation when it should not have")
 	}
 	if p.BroadcastCalled {
@@ -76,7 +81,8 @@ func TestValidateBeaconAttestation_InvalidBlock(t *testing.T) {
 		},
 	}
 
-	if rs.validateBeaconAttestation(ctx, msg, p, false /*fromSelf*/) {
+	valid, _ := rs.validateBeaconAttestation(ctx, msg, p, false /*fromSelf*/)
+	if !valid {
 		t.Error("Invalid beacon attestation passed validation when it should not have")
 	}
 	if p.BroadcastCalled {
@@ -113,7 +119,8 @@ func TestValidateBeaconAttestation_ValidBlock_FromSelf(t *testing.T) {
 		},
 	}
 
-	if rs.validateBeaconAttestation(ctx, msg, p, true /*fromSelf*/) {
+	valid, _ := rs.validateBeaconAttestation(ctx, msg, p, true /*fromSelf*/)
+	if valid {
 		t.Error("Beacon attestation passed validation")
 	}
 
@@ -151,7 +158,8 @@ func TestValidateBeaconAttestation_Syncing(t *testing.T) {
 		},
 	}
 
-	if rs.validateBeaconAttestation(ctx, msg, p, false /*fromSelf*/) {
+	valid, err := rs.validateBeaconAttestation(ctx, msg, p, false /*fromSelf*/)
+	if valid {
 		t.Error("Beacon attestation passed validation")
 	}
 }

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -82,7 +82,7 @@ func TestValidateBeaconAttestation_InvalidBlock(t *testing.T) {
 	}
 
 	valid, _ := rs.validateBeaconAttestation(ctx, msg, p, false /*fromSelf*/)
-	if !valid {
+	if valid {
 		t.Error("Invalid beacon attestation passed validation when it should not have")
 	}
 	if p.BroadcastCalled {

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/karlseguin/ccache"
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
@@ -18,31 +19,30 @@ var recentlySeenRoots = ccache.New(ccache.Configure().MaxSize(100000))
 // validateBeaconBlockPubSub checks that the incoming block has a valid BLS signature.
 // Blocks that have already been seen are ignored. If the BLS signature is any valid signature,
 // this method rebroadcasts the message.
-func (r *RegularSync) validateBeaconBlockPubSub(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) bool {
+func (r *RegularSync) validateBeaconBlockPubSub(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
 	r.validateBlockLock.Lock()
 	defer r.validateBlockLock.Unlock()
 	m := msg.(*ethpb.BeaconBlock)
 
 	blockRoot, err := ssz.SigningRoot(m)
 	if err != nil {
-		log.WithField("validate", "beacon block").WithError(err).Error("Failed to get signing root of block")
-		return false
+		return false, errors.Wrap(err, "could not get signing root of beacon block")
 	}
 
 	r.pendingQueueLock.RLock()
 	if r.seenPendingBlocks[blockRoot] {
 		r.pendingQueueLock.RUnlock()
-		return false
+		return false, nil
 	}
 	r.pendingQueueLock.RUnlock()
 
 	if recentlySeenRoots.Get(string(blockRoot[:])) != nil || r.db.HasBlock(ctx, blockRoot) {
-		return false
+		return false, nil
 	}
 	recentlySeenRoots.Set(string(blockRoot[:]), true /*value*/, 365*24*time.Hour /*TTL*/)
 
 	if fromSelf {
-		return false
+		return false, nil
 	}
 
 	_, err = bls.SignatureFromBytes(m.Signature)
@@ -52,8 +52,8 @@ func (r *RegularSync) validateBeaconBlockPubSub(ctx context.Context, msg proto.M
 
 	// We should not attempt to process blocks until fully synced, but propagation is OK.
 	if r.initialSync.Syncing() {
-		return false
+		return false, nil
 	}
 
-	return err == nil
+	return err == nil, err
 }

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -31,7 +31,7 @@ func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
-	result := r.validateBeaconBlockPubSub(
+	result, _ := r.validateBeaconBlockPubSub(
 		context.Background(),
 		msg,
 		mock,
@@ -63,7 +63,7 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
 
-	result := r.validateBeaconBlockPubSub(
+	result, _ := r.validateBeaconBlockPubSub(
 		context.Background(),
 		msg,
 		mock,
@@ -98,12 +98,16 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInCache(t *testing.T) {
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
-	result := r.validateBeaconBlockPubSub(
+	result, _ := r.validateBeaconBlockPubSub(
 		context.Background(),
 		msg,
 		mock,
 		false, // fromSelf
 	)
+
+	if err != nil {
+		t.Errorf("Expected true result, got false: %v", err)
+	}
 
 	if !result {
 		t.Error("Expected true result, got false")
@@ -114,7 +118,7 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInCache(t *testing.T) {
 
 	// The value should be cached now so the second request will fail.
 	mock.BroadcastCalled = false
-	result = r.validateBeaconBlockPubSub(
+	result, _ = r.validateBeaconBlockPubSub(
 		context.Background(),
 		msg,
 		mock,
@@ -148,7 +152,7 @@ func TestValidateBeaconBlockPubSub_ValidSignature(t *testing.T) {
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
-	result := r.validateBeaconBlockPubSub(
+	result, _ := r.validateBeaconBlockPubSub(
 		context.Background(),
 		msg,
 		mock,
@@ -183,7 +187,7 @@ func TestValidateBeaconBlockPubSub_ValidSignature_FromSelf(t *testing.T) {
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
-	result := r.validateBeaconBlockPubSub(
+	result, _ := r.validateBeaconBlockPubSub(
 		context.Background(),
 		msg,
 		mock,
@@ -218,7 +222,7 @@ func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: true},
 	}
-	result := r.validateBeaconBlockPubSub(
+	result, _ := r.validateBeaconBlockPubSub(
 		context.Background(),
 		msg,
 		mock,

--- a/beacon-chain/sync/validate_proposer_slashing.go
+++ b/beacon-chain/sync/validate_proposer_slashing.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/karlseguin/ccache"
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
@@ -25,28 +26,27 @@ func propSlashingCacheKey(slashing *ethpb.ProposerSlashing) (string, error) {
 
 // Clients who receive a proposer slashing on this topic MUST validate the conditions within VerifyProposerSlashing before
 // forwarding it across the network.
-func (r *RegularSync) validateProposerSlashing(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) bool {
+func (r *RegularSync) validateProposerSlashing(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
 	// The head state will be too far away to validate any slashing.
 	if r.initialSync.Syncing() {
-		return false
+		return false, nil
 	}
 
 	slashing, ok := msg.(*ethpb.ProposerSlashing)
 	if !ok {
-		return false
+		return false, nil
 	}
 	cacheKey, err := propSlashingCacheKey(slashing)
 	if err != nil {
-		log.WithError(err).Warn("could not hash proposer slashing")
-		return false
+		return false, errors.Wrapf(err, "could not hash proposer slashing")
 	}
 
 	invalidKey := invalid + cacheKey
 	if seenProposerSlashings.Get(invalidKey) != nil {
-		return false
+		return false, errors.New("previously seen invalid proposer slashing received")
 	}
 	if seenProposerSlashings.Get(cacheKey) != nil {
-		return false
+		return false, nil
 	}
 
 	// Retrieve head state, advance state to the epoch slot used specified in slashing message.
@@ -54,30 +54,28 @@ func (r *RegularSync) validateProposerSlashing(ctx context.Context, msg proto.Me
 	slashSlot := slashing.Header_1.Slot
 	if s.Slot < slashSlot {
 		if ctx.Err() != nil {
-			log.WithError(ctx.Err()).Errorf("Failed to advance state to slot %d to process proposer slashing", slashSlot)
-			return false
+			return false, errors.Wrapf(ctx.Err(),
+				"Failed to advance state to slot %d to process proposer slashing", slashSlot)
 		}
 		var err error
 		s, err = state.ProcessSlots(ctx, s, slashSlot)
 		if err != nil {
-			log.WithError(err).Errorf("Failed to advance state to slot %d", slashSlot)
-			return false
+			return false, errors.Wrapf(err, "Failed to advance state to slot %d", slashSlot)
 		}
 	}
 
 	if err := blocks.VerifyProposerSlashing(s, slashing); err != nil {
-		log.WithError(err).Warn("Received invalid proposer slashing")
 		seenProposerSlashings.Set(invalidKey, true /*value*/, oneYear /*TTL*/)
-		return false
+		return false, errors.Wrap(err, "Received invalid proposer slashing")
 	}
 	seenProposerSlashings.Set(cacheKey, true /*value*/, oneYear /*TTL*/)
 
 	if fromSelf {
-		return false
+		return false, nil
 	}
 
 	if err := p.Broadcast(ctx, slashing); err != nil {
 		log.WithError(err).Error("Failed to propagate proposer slashing")
 	}
-	return true
+	return true, nil
 }

--- a/beacon-chain/sync/validate_proposer_slashing_test.go
+++ b/beacon-chain/sync/validate_proposer_slashing_test.go
@@ -109,7 +109,11 @@ func TestValidateProposerSlashing_ValidSlashing(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
 
-	if !r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/) {
+	valid, err := r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/)
+	if err != nil {
+		t.Error("Failed validation: %v", err)
+	}
+	if !valid {
 		t.Error("Failed validation")
 	}
 
@@ -120,7 +124,8 @@ func TestValidateProposerSlashing_ValidSlashing(t *testing.T) {
 	// A second message with the same information should not be valid for processing or
 	// propagation.
 	p2p.BroadcastCalled = false
-	if r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/) {
+	valid, _ = r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/)
+	if valid {
 		t.Error("Passed validation when should have failed")
 	}
 

--- a/beacon-chain/sync/validate_proposer_slashing_test.go
+++ b/beacon-chain/sync/validate_proposer_slashing_test.go
@@ -146,7 +146,8 @@ func TestValidateProposerSlashing_ValidSlashing_FromSelf(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
 
-	if r.validateProposerSlashing(ctx, slashing, p2p, true /*fromSelf*/) {
+	valid, _ := r.validateProposerSlashing(ctx, slashing, p2p, true /*fromSelf*/)
+	if valid {
 		t.Error("Did not fail validation")
 	}
 
@@ -169,7 +170,8 @@ func TestValidateProposerSlashing_ContextTimeout(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
 
-	if r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/) {
+	valid, _ := r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/)
+	if valid {
 		t.Error("slashing from the far distant future should have timed out and returned false")
 	}
 }
@@ -186,7 +188,8 @@ func TestValidateProposerSlashing_Syncing(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: true},
 	}
 
-	if r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/) {
+	valid, _ := r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/)
+	if valid {
 		t.Error("Did not fail validation")
 	}
 

--- a/beacon-chain/sync/validate_proposer_slashing_test.go
+++ b/beacon-chain/sync/validate_proposer_slashing_test.go
@@ -111,7 +111,7 @@ func TestValidateProposerSlashing_ValidSlashing(t *testing.T) {
 
 	valid, err := r.validateProposerSlashing(ctx, slashing, p2p, false /*fromSelf*/)
 	if err != nil {
-		t.Error("Failed validation: %v", err)
+		t.Errorf("Failed validation: %v", err)
 	}
 	if !valid {
 		t.Error("Failed validation")

--- a/beacon-chain/sync/validate_voluntary_exit_test.go
+++ b/beacon-chain/sync/validate_voluntary_exit_test.go
@@ -71,7 +71,11 @@ func TestValidateVoluntaryExit_ValidExit(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
 
-	if !r.validateVoluntaryExit(ctx, exit, p2p, false /*fromSelf*/) {
+	valid, err := r.validateVoluntaryExit(ctx, exit, p2p, false /*fromSelf*/)
+	if err != nil {
+		t.Errorf("Failed validation: %v", err)
+	}
+	if !valid {
 		t.Error("Failed validation")
 	}
 
@@ -82,7 +86,8 @@ func TestValidateVoluntaryExit_ValidExit(t *testing.T) {
 	// A second message with the same information should not be valid for processing or
 	// propagation.
 	p2p.BroadcastCalled = false
-	if r.validateVoluntaryExit(ctx, exit, p2p, false /*fromSelf*/) {
+	valid, _ = r.validateVoluntaryExit(ctx, exit, p2p, false /*fromSelf*/)
+	if valid {
 		t.Error("Passed validation when should have failed")
 	}
 
@@ -105,7 +110,8 @@ func TestValidateVoluntaryExit_ValidExit_FromSelf(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
 
-	if r.validateVoluntaryExit(ctx, exit, p2p, true /*fromSelf*/) {
+	valid, _ := r.validateVoluntaryExit(ctx, exit, p2p, true /*fromSelf*/)
+	if valid {
 		t.Error("Validation should have failed")
 	}
 
@@ -128,7 +134,8 @@ func TestValidateVoluntaryExit_ValidExit_Syncing(t *testing.T) {
 		initialSync: &mockSync.Sync{IsSyncing: true},
 	}
 
-	if r.validateVoluntaryExit(ctx, exit, p2p, false /*fromSelf*/) {
+	valid, _ := r.validateVoluntaryExit(ctx, exit, p2p, false /*fromSelf*/)
+	if valid {
 		t.Error("Validation should have failed")
 	}
 


### PR DESCRIPTION
This adds an error to message validation, so that we only log an error if an actual error exists. Otherwise we ignore it and do not log it.

- [x] Change subscriber methods
- [x] Fix references and tests