### PR TITLE
log buf.String() instead of map[reflect.Type]error

### DIFF
--- a/shared/prometheus/service.go
+++ b/shared/prometheus/service.go
@@ -75,7 +75,7 @@ func (s *Service) healthzHandler(w http.ResponseWriter, _ *http.Request) {
 	// Write status header
 	if hasError {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.WithField("statuses", statuses).Warn("Node is unhealthy!")
+		log.WithField("statuses", buf.String()).Warn("Node is unhealthy!")
 	} else {
 		w.WriteHeader(http.StatusOK)
 	}


### PR DESCRIPTION
Using fluentd logger we saw a lot of errors like 
```
Failed to obtain reader, failed to marshal fields to JSON, json: unsupported type: map[reflect.Type]error
```
