### PR TITLE
SetupInitialDeposits() now returns deposit data roots

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_block_test.go
@@ -124,7 +124,7 @@ func TestStore_UpdateBlockAttestationVote(t *testing.T) {
 	defer testDB.TeardownDB(t, db)
 	params.UseMinimalConfig()
 
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -178,7 +178,7 @@ func TestStore_UpdateBlockAttestationsVote(t *testing.T) {
 	defer testDB.TeardownDB(t, db)
 	params.UseMinimalConfig()
 
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -23,7 +23,7 @@ func TestReceiveBlock_ProcessCorrectly(t *testing.T) {
 	ctx := context.Background()
 
 	chainService := setupBeaconChain(t, db)
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -187,7 +187,7 @@ func TestReceiveBlockNoPubsubForkchoice_ProcessCorrectly(t *testing.T) {
 	ctx := context.Background()
 
 	chainService := setupBeaconChain(t, db)
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -322,7 +322,7 @@ func TestChainService_InitializeBeaconChain(t *testing.T) {
 
 	// Set up 10 deposits pre chain start for validators to register
 	count := uint64(10)
-	deposits, _ := testutil.SetupInitialDeposits(t, count)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, count)
 	if err := bc.initializeBeaconChain(ctx, time.Unix(0, 0), deposits, &ethpb.Eth1Data{}); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -39,7 +39,7 @@ func TestProcessBlockHeader_WrongProposerSig(t *testing.T) {
 		t.Errorf("SlotsPerEpoch should be 64 for these tests to pass")
 	}
 
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Error(err)
@@ -318,7 +318,7 @@ func TestProcessBlockHeader_OK(t *testing.T) {
 func TestProcessRandao_IncorrectProposerFailsVerification(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -351,7 +351,7 @@ func TestProcessRandao_IncorrectProposerFailsVerification(t *testing.T) {
 }
 
 func TestProcessRandao_SignatureVerifiesAndUpdatesLatestStateMixes(t *testing.T) {
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -774,7 +774,7 @@ func TestProcessAttesterSlashings_IndexedAttestationFailedToVerify(t *testing.T)
 }
 
 func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	for _, vv := range beaconState.Validators {
 		vv.WithdrawableEpoch = 1 * params.BeaconConfig().SlotsPerEpoch
@@ -879,7 +879,7 @@ func TestProcessAttestations_InclusionDelayFailure(t *testing.T) {
 			Attestations: attestations,
 		},
 	}
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -921,7 +921,7 @@ func TestProcessAttestations_NeitherCurrentNorPrevEpoch(t *testing.T) {
 			Attestations: []*ethpb.Attestation{att},
 		},
 	}
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -971,7 +971,7 @@ func TestProcessAttestations_CurrentEpochFFGDataMismatches(t *testing.T) {
 			Attestations: attestations,
 		},
 	}
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -1010,7 +1010,7 @@ func TestProcessAttestations_CurrentEpochFFGDataMismatches(t *testing.T) {
 func TestProcessAttestations_PrevEpochFFGDataMismatches(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -1096,7 +1096,7 @@ func TestProcessAttestations_CrosslinkMismatches(t *testing.T) {
 			Attestations: attestations,
 		},
 	}
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -1135,7 +1135,7 @@ func TestProcessAttestations_CrosslinkMismatches(t *testing.T) {
 
 func TestProcessAttestations_InvalidAggregationBitsLength(t *testing.T) {
 	helpers.ClearAllCaches()
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -1188,7 +1188,7 @@ func TestProcessAttestations_InvalidAggregationBitsLength(t *testing.T) {
 
 func TestProcessAttestations_OK(t *testing.T) {
 	helpers.ClearAllCaches()
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -1261,7 +1261,7 @@ func TestProcessAttestations_OK(t *testing.T) {
 func TestProcessAttestationsNoVerify_OK(t *testing.T) {
 	// Attestation with an empty signature
 	helpers.ClearAllCaches()
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -1393,7 +1393,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 	}
 	numOfValidators := 2 * params.BeaconConfig().SlotsPerEpoch
 	validators := make([]*ethpb.Validator, numOfValidators)
-	_, keys := testutil.SetupInitialDeposits(t, numOfValidators)
+	_, _, keys := testutil.SetupInitialDeposits(t, numOfValidators)
 	for i := 0; i < len(validators); i++ {
 		validators[i] = &ethpb.Validator{
 			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
@@ -1538,7 +1538,7 @@ func TestProcessDeposits_MerkleBranchFailsVerification(t *testing.T) {
 }
 
 func TestProcessDeposits_AddsNewValidatorDeposit(t *testing.T) {
-	dep, _ := testutil.SetupInitialDeposits(t, 1)
+	dep, _, _ := testutil.SetupInitialDeposits(t, 1)
 	eth1Data := testutil.GenerateEth1Data(t, dep)
 
 	block := &ethpb.BeaconBlock{
@@ -1646,7 +1646,7 @@ func TestProcessDeposits_RepeatedDeposit_IncreasesValidatorBalance(t *testing.T)
 
 func TestProcessDeposit_AddsNewValidatorDeposit(t *testing.T) {
 	//Similar to TestProcessDeposits_AddsNewValidatorDeposit except that this test directly calls ProcessDeposit
-	dep, _ := testutil.SetupInitialDeposits(t, 1)
+	dep, _, _ := testutil.SetupInitialDeposits(t, 1)
 	eth1Data := testutil.GenerateEth1Data(t, dep)
 
 	registry := []*ethpb.Validator{
@@ -1690,7 +1690,7 @@ func TestProcessDeposit_AddsNewValidatorDeposit(t *testing.T) {
 
 func TestProcessDeposit_SkipsInvalidDeposit(t *testing.T) {
 	// Same test settings as in TestProcessDeposit_AddsNewValidatorDeposit, except that we use an invalid signature
-	dep, _ := testutil.SetupInitialDeposits(t, 1)
+	dep, _, _ := testutil.SetupInitialDeposits(t, 1)
 	dep[0].Data.Signature = make([]byte, 96)
 	eth1Data := testutil.GenerateEth1Data(t, dep)
 	testutil.ResetCache() // Can't have an invalid signature in the cache.
@@ -1739,7 +1739,7 @@ func TestProcessDeposit_SkipsInvalidDeposit(t *testing.T) {
 
 func TestProcessDeposit_SkipsDepositWithUncompressedSignature(t *testing.T) {
 	// Same test settings as in TestProcessDeposit_AddsNewValidatorDeposit, except that we use an uncompressed signature
-	dep, _ := testutil.SetupInitialDeposits(t, 1)
+	dep, _, _ := testutil.SetupInitialDeposits(t, 1)
 	a, _ := blsintern.DecompressG2(bytesutil.ToBytes96(dep[0].Data.Signature))
 	uncompressedSignature := a.SerializeBytes()
 	dep[0].Data.Signature = uncompressedSignature[:]

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAttestationDataSlot_OK(t *testing.T) {
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -58,7 +58,7 @@ func TestAttestationDataSlot_ReturnsErrorWithNilData(t *testing.T) {
 }
 
 func TestAttestationDataSlot_ReturnsErrorWithErroneousTargetEpoch(t *testing.T) {
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -73,7 +73,7 @@ func TestAttestationDataSlot_ReturnsErrorWithErroneousTargetEpoch(t *testing.T) 
 }
 
 func TestAttestationDataSlot_ReturnsErrorWhenTargetEpochLessThanCurrentEpoch(t *testing.T) {
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/core/state/state_test.go
+++ b/beacon-chain/core/state/state_test.go
@@ -52,7 +52,7 @@ func TestGenesisBeaconState_OK(t *testing.T) {
 	}
 
 	genesisTime := uint64(99999)
-	deposits, _ := testutil.SetupInitialDeposits(t, uint64(depositsForChainStart))
+	deposits, _, _ := testutil.SetupInitialDeposits(t, uint64(depositsForChainStart))
 	eth1Data := testutil.GenerateEth1Data(t, deposits)
 	newState, err := state.GenesisBeaconState(
 		deposits,
@@ -169,7 +169,7 @@ func TestGenesisBeaconState_OK(t *testing.T) {
 
 func TestGenesisState_HashEquality(t *testing.T) {
 	helpers.ClearAllCaches()
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	state1, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Error(err)

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -39,7 +39,7 @@ func TestExecuteStateTransition_IncorrectSlot(t *testing.T) {
 
 func TestExecuteStateTransition_FullProcess(t *testing.T) {
 	helpers.ClearAllCaches()
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -108,7 +108,7 @@ func TestExecuteStateTransition_FullProcess(t *testing.T) {
 
 func TestProcessBlock_IncorrectProposerSlashing(t *testing.T) {
 	helpers.ClearAllCaches()
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -163,7 +163,7 @@ func TestProcessBlock_IncorrectProposerSlashing(t *testing.T) {
 }
 
 func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -314,7 +314,7 @@ func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 func TestProcessBlock_IncorrectProcessExits(t *testing.T) {
 	helpers.ClearAllCaches()
 
-	deposits, _ := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -433,7 +433,7 @@ func TestProcessBlock_IncorrectProcessExits(t *testing.T) {
 }
 
 func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -1011,7 +1011,7 @@ func TestProcessBlk_AttsBasedOnValidatorCount(t *testing.T) {
 
 	// Default at 256 validators, can raise this number with faster BLS.
 	validatorCount := uint64(256)
-	deposits, privKeys := testutil.SetupInitialDeposits(t, validatorCount)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, validatorCount)
 	s, _ := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	s.Slot = params.BeaconConfig().SlotsPerEpoch
 

--- a/beacon-chain/operations/service_test.go
+++ b/beacon-chain/operations/service_test.go
@@ -83,7 +83,7 @@ func TestHandleAttestation_Saves_NewAttestation(t *testing.T) {
 		BeaconDB: beaconDB,
 	})
 
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -193,7 +193,7 @@ func TestHandleAttestation_Aggregates_LargeNumValidators(t *testing.T) {
 	}
 
 	// We setup the genesis state with 256 validators.
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 256)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 256)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -282,7 +282,7 @@ func TestHandleAttestation_Skips_PreviouslyAggregatedAttestations(t *testing.T) 
 	})
 	service.attestationPool = make(map[[32]byte]*ethpb.Attestation)
 
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 200)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 200)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -457,7 +457,7 @@ func TestRetrieveAttestations_OK(t *testing.T) {
 	service := NewService(context.Background(), &Config{BeaconDB: beaconDB})
 	service.attestationPool = make(map[[32]byte]*ethpb.Attestation)
 
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, uint64(0), &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/powchain/deposit_test.go
+++ b/beacon-chain/powchain/deposit_test.go
@@ -32,14 +32,9 @@ func TestProcessDeposit_OK(t *testing.T) {
 		t.Fatalf("Unable to setup web3 ETH1.0 chain service: %v", err)
 	}
 
-	deposits, _ := testutil.SetupInitialDeposits(t, 1)
+	deposits, depositDataRoots, _ := testutil.SetupInitialDeposits(t, 1)
 
-	leaf, err := ssz.HashTreeRoot(deposits[0].Data)
-	if err != nil {
-		t.Fatalf("Could not hash deposit %v", err)
-	}
-
-	trie, err := trieutil.GenerateTrieFromItems([][]byte{leaf[:]}, int(params.BeaconConfig().DepositContractTreeDepth))
+	trie, err := trieutil.GenerateTrieFromItems([][]byte{depositDataRoots[0][:]}, int(params.BeaconConfig().DepositContractTreeDepth))
 	if err != nil {
 		log.Error(err)
 	}
@@ -73,14 +68,9 @@ func TestProcessDeposit_InvalidMerkleBranch(t *testing.T) {
 		t.Fatalf("Unable to setup web3 ETH1.0 chain service: %v", err)
 	}
 
-	deposits, _ := testutil.SetupInitialDeposits(t, 1)
+	deposits, depositDataRoots, _ := testutil.SetupInitialDeposits(t, 1)
 
-	leaf, err := ssz.HashTreeRoot(deposits[0].Data)
-	if err != nil {
-		t.Fatalf("Could not hash deposit %v", err)
-	}
-
-	trie, err := trieutil.GenerateTrieFromItems([][]byte{leaf[:]}, int(params.BeaconConfig().DepositContractTreeDepth))
+	trie, err := trieutil.GenerateTrieFromItems([][]byte{depositDataRoots[0][:]}, int(params.BeaconConfig().DepositContractTreeDepth))
 	if err != nil {
 		log.Error(err)
 	}
@@ -120,14 +110,13 @@ func TestProcessDeposit_InvalidPublicKey(t *testing.T) {
 		t.Fatalf("Unable to setup web3 ETH1.0 chain service: %v", err)
 	}
 
-	deposits, _ := testutil.SetupInitialDeposits(t, 1)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 1)
 	deposits[0].Data.PublicKey = []byte("junk")
 
 	leaf, err := ssz.HashTreeRoot(deposits[0].Data)
 	if err != nil {
 		t.Fatalf("Could not hash deposit %v", err)
 	}
-
 	trie, err := trieutil.GenerateTrieFromItems([][]byte{leaf[:]}, int(params.BeaconConfig().DepositContractTreeDepth))
 	if err != nil {
 		log.Error(err)
@@ -164,7 +153,7 @@ func TestProcessDeposit_InvalidSignature(t *testing.T) {
 		t.Fatalf("Unable to setup web3 ETH1.0 chain service: %v", err)
 	}
 
-	deposits, _ := testutil.SetupInitialDeposits(t, 1)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 1)
 	var fakeSig [96]byte
 	copy(fakeSig[:], []byte{'F', 'A', 'K', 'E'})
 	deposits[0].Data.Signature = fakeSig[:]
@@ -212,7 +201,7 @@ func TestProcessDeposit_UnableToVerify(t *testing.T) {
 	}
 	testutil.ResetCache()
 
-	deposits, keys := testutil.SetupInitialDeposits(t, 1)
+	deposits, _, keys := testutil.SetupInitialDeposits(t, 1)
 	sig := keys[0].Sign([]byte{'F', 'A', 'K', 'E'}, bls.Domain(params.BeaconConfig().DomainDeposit, params.BeaconConfig().GenesisForkVersion))
 	deposits[0].Data.Signature = sig.Marshal()[:]
 	eth1Data := testutil.GenerateEth1Data(t, deposits)
@@ -298,7 +287,7 @@ func TestProcessDeposit_AllDepositedSuccessfully(t *testing.T) {
 	}
 	testutil.ResetCache()
 
-	deposits, keys := testutil.SetupInitialDeposits(t, 10)
+	deposits, _, keys := testutil.SetupInitialDeposits(t, 10)
 	deposits, root := testutil.GenerateDepositProof(t, deposits)
 
 	eth1Data := &ethpb.Eth1Data{

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -49,7 +49,7 @@ func TestProcessDepositLog_OK(t *testing.T) {
 	}
 
 	testAcc.Backend.Commit()
-	deposits, _ := testutil.SetupInitialDeposits(t, 1)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 1)
 	data := deposits[0].Data
 
 	testAcc.TxOpts.Value = contracts.Amount32Eth()
@@ -264,7 +264,7 @@ func TestProcessETH2GenesisLog_8DuplicatePubkeys(t *testing.T) {
 	testAcc.Backend.Commit()
 	testAcc.Backend.AdjustTime(time.Duration(int64(time.Now().Nanosecond())))
 
-	deposits, _ := testutil.SetupInitialDeposits(t, 1)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 1)
 	data := deposits[0].Data
 
 	testAcc.TxOpts.Value = contracts.Amount32Eth()
@@ -332,7 +332,7 @@ func TestProcessETH2GenesisLog(t *testing.T) {
 	testAcc.Backend.Commit()
 	testAcc.Backend.AdjustTime(time.Duration(int64(time.Now().Nanosecond())))
 
-	deposits, _ := testutil.SetupInitialDeposits(t, uint64(depositsReqForChainStart))
+	deposits, _, _ := testutil.SetupInitialDeposits(t, uint64(depositsReqForChainStart))
 
 	// 64 Validators are used as size required for beacon-chain to start. This number
 	// is defined in the deposit contract as the number required for the testnet. The actual number
@@ -412,7 +412,7 @@ func TestWeb3ServiceProcessDepositLog_RequestMissedDeposits(t *testing.T) {
 	testAcc.Backend.Commit()
 	testAcc.Backend.AdjustTime(time.Duration(int64(time.Now().Nanosecond())))
 	depositsWanted := 10
-	deposits, _ := testutil.SetupInitialDeposits(t, uint64(depositsWanted))
+	deposits, _, _ := testutil.SetupInitialDeposits(t, uint64(depositsWanted))
 
 	for i := 0; i < depositsWanted; i++ {
 		data := deposits[i].Data

--- a/beacon-chain/rpc/proposer_server_test.go
+++ b/beacon-chain/rpc/proposer_server_test.go
@@ -40,7 +40,7 @@ func TestProposeBlock_OK(t *testing.T) {
 	}
 
 	numDeposits := params.BeaconConfig().MinGenesisActiveValidatorCount
-	deposits, _ := testutil.SetupInitialDeposits(t, numDeposits)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, numDeposits)
 	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatalf("Could not instantiate genesis state: %v", err)
@@ -84,7 +84,7 @@ func TestComputeStateRoot_OK(t *testing.T) {
 	ctx := context.Background()
 	helpers.ClearAllCaches()
 
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 100)
 	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatalf("Could not instantiate genesis state: %v", err)

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -67,7 +67,7 @@ func TestNextEpochCommitteeAssignment_WrongPubkeyLength(t *testing.T) {
 	ctx := context.Background()
 	helpers.ClearAllCaches()
 
-	deposits, _ := testutil.SetupInitialDeposits(t, 8)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, 8)
 	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
@@ -99,7 +99,7 @@ func TestNextEpochCommitteeAssignment_CantFindValidatorIdx(t *testing.T) {
 	db := dbutil.SetupDB(t)
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
-	deposits, _ := testutil.SetupInitialDeposits(t, params.BeaconConfig().MinGenesisActiveValidatorCount)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, params.BeaconConfig().MinGenesisActiveValidatorCount)
 	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatalf("Could not setup genesis state: %v", err)
@@ -135,7 +135,7 @@ func TestCommitteeAssignment_OK(t *testing.T) {
 	genesis := blk.NewGenesisBlock([]byte{})
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount / 16
 
-	deposits, _ := testutil.SetupInitialDeposits(t, depChainStart)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, depChainStart)
 	state, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatalf("Could not setup genesis state: %v", err)
@@ -215,7 +215,7 @@ func TestCommitteeAssignment_CurrentEpoch_ShouldNotFail(t *testing.T) {
 	genesis := blk.NewGenesisBlock([]byte{})
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount / 16
 
-	deposits, _ := testutil.SetupInitialDeposits(t, depChainStart)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, depChainStart)
 	state, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatalf("Could not setup genesis state: %v", err)
@@ -271,7 +271,7 @@ func TestCommitteeAssignment_MultipleKeys_OK(t *testing.T) {
 
 	genesis := blk.NewGenesisBlock([]byte{})
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount / 16
-	deposits, _ := testutil.SetupInitialDeposits(t, depChainStart)
+	deposits, _, _ := testutil.SetupInitialDeposits(t, depChainStart)
 	state, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatalf("Could not setup genesis state: %v", err)

--- a/beacon-chain/sync/validate_attester_slashing_test.go
+++ b/beacon-chain/sync/validate_attester_slashing_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func setupValidAttesterSlashing(t *testing.T) (*ethpb.AttesterSlashing, *pb.BeaconState) {
-	deposits, privKeys := testutil.SetupInitialDeposits(t, 5)
+	deposits, _, privKeys := testutil.SetupInitialDeposits(t, 5)
 	state, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	for _, vv := range state.Validators {
 		vv.WithdrawableEpoch = 1 * params.BeaconConfig().SlotsPerEpoch

--- a/shared/testutil/helpers.go
+++ b/shared/testutil/helpers.go
@@ -31,7 +31,7 @@ var trie *trieutil.MerkleTrie
 // account is key n and the withdrawal account is key n+1.  As such,
 // if all secret keys for n validators are required then numDeposits
 // should be n+1
-func SetupInitialDeposits(t testing.TB, numDeposits uint64) ([]*ethpb.Deposit, []*bls.SecretKey) {
+func SetupInitialDeposits(t testing.TB, numDeposits uint64) ([]*ethpb.Deposit, [][32]byte, []*bls.SecretKey) {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -89,7 +89,7 @@ func SetupInitialDeposits(t testing.TB, numDeposits uint64) ([]*ethpb.Deposit, [
 	}
 
 	d, _ := GenerateDepositProof(t, deposits[0:numDeposits])
-	return d, privKeys[0:numDeposits]
+	return d, depositDataRoots[0:numDeposits], privKeys[0:numDeposits]
 }
 
 // GenerateDepositProof takes an array of deposits and generates the deposit trie for them and proofs.

--- a/shared/testutil/helpers_test.go
+++ b/shared/testutil/helpers_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSetupInitialDeposits(t *testing.T) {
 	entries := 1
-	deposits, privKeys := SetupInitialDeposits(t, uint64(entries))
+	deposits, depositDataRoots, privKeys := SetupInitialDeposits(t, uint64(entries))
 	if len(deposits) != entries {
 		t.Fatalf("incorrect number of deposits returned, wanted %d but received %d", entries, len(deposits))
 	}
@@ -29,13 +29,17 @@ func TestSetupInitialDeposits(t *testing.T) {
 	if !bytes.Equal(deposits[0].Data.WithdrawalCredentials, expectedWithdrawalCredentialsAt0) {
 		t.Fatalf("incorrect withdrawal credentials, wanted %x but received %x", expectedWithdrawalCredentialsAt0, deposits[0].Data.WithdrawalCredentials)
 	}
+	expectedDepositDataRootAt0 := []byte{0xc2, 0x58, 0x8b, 0xb0, 0x44, 0xf5, 0xe8, 0xaf, 0xb9, 0xb1, 0xcc, 0xb7, 0xe0, 0x83, 0x30, 0x35, 0x83, 0x18, 0xf2, 0x56, 0x27, 0x96, 0xfa, 0xad, 0xce, 0x92, 0x03, 0x50, 0x64, 0xaa, 0xf1, 0x3d}
+	if !bytes.Equal(depositDataRoots[0][:], expectedDepositDataRootAt0) {
+		t.Fatalf("incorrect deposit data root, wanted %x but received %x", expectedDepositDataRootAt0, depositDataRoots[0])
+	}
 	expectedSignatureAt0 := []byte{0xb3, 0xb9, 0x6e, 0xba, 0x50, 0xfa, 0x47, 0x49, 0x26, 0xfa, 0x46, 0xbb, 0xea, 0x3c, 0x8c, 0x73, 0x4c, 0x85, 0xc9, 0x70, 0x4e, 0x54, 0xb7, 0x19, 0xe5, 0x4e, 0x1b, 0xc5, 0x83, 0x77, 0xdd, 0x00, 0x30, 0x0b, 0x9e, 0xe4, 0xb0, 0x5b, 0xb2, 0x7b, 0x81, 0x8b, 0x38, 0xeb, 0xa2, 0x89, 0xcb, 0xe0, 0x06, 0x7a, 0x34, 0x56, 0xbc, 0xb8, 0xad, 0x59, 0xd0, 0x17, 0xfc, 0xf0, 0x04, 0xe5, 0xf1, 0xc5, 0xff, 0x1b, 0xf2, 0xe4, 0x89, 0x6b, 0x53, 0x2f, 0x4a, 0xea, 0x4b, 0x4c, 0x47, 0x06, 0x9a, 0x26, 0xe3, 0x85, 0x98, 0xf3, 0xd3, 0x37, 0x04, 0x7b, 0x8d, 0x0b, 0xd5, 0x25, 0xe4, 0x9f, 0xfc, 0xd2}
 	if !bytes.Equal(deposits[0].Data.Signature, expectedSignatureAt0) {
 		t.Fatalf("incorrect signature, wanted %x but received %x", expectedSignatureAt0, deposits[0].Data.Signature)
 	}
 
 	entries = 1024
-	deposits, privKeys = SetupInitialDeposits(t, uint64(entries))
+	deposits, depositDataRoots, privKeys = SetupInitialDeposits(t, uint64(entries))
 	if len(deposits) != entries {
 		t.Fatalf("incorrect number of deposits returned, wanted %d but received %d", entries, len(deposits))
 	}
@@ -49,6 +53,9 @@ func TestSetupInitialDeposits(t *testing.T) {
 	if !bytes.Equal(deposits[0].Data.WithdrawalCredentials, expectedWithdrawalCredentialsAt0) {
 		t.Fatalf("incorrect withdrawal credentials, wanted %x but received %x", expectedWithdrawalCredentialsAt0, deposits[0].Data.WithdrawalCredentials)
 	}
+	if !bytes.Equal(depositDataRoots[0][:], expectedDepositDataRootAt0) {
+		t.Fatalf("incorrect deposit data root, wanted %x but received %x", expectedDepositDataRootAt0, depositDataRoots[0])
+	}
 	if !bytes.Equal(deposits[0].Data.Signature, expectedSignatureAt0) {
 		t.Fatalf("incorrect signature, wanted %x but received %x", expectedSignatureAt0, deposits[0].Data.Signature)
 	}
@@ -60,6 +67,10 @@ func TestSetupInitialDeposits(t *testing.T) {
 	if !bytes.Equal(deposits[1023].Data.WithdrawalCredentials, expectedWithdrawalCredentialsAt1023) {
 		t.Fatalf("incorrect withdrawal credentials, wanted %x but received %x", expectedWithdrawalCredentialsAt1023, deposits[1023].Data.WithdrawalCredentials)
 	}
+	expectedDepositDataRootAt1023 := []byte{0x54, 0x45, 0x80, 0xf3, 0xc3, 0x87, 0xdd, 0xfb, 0x1f, 0xf7, 0x03, 0xab, 0x15, 0xc9, 0x5b, 0x56, 0x2c, 0x29, 0x04, 0x7b, 0x17, 0xb4, 0xa0, 0x19, 0x69, 0xd6, 0x45, 0x7d, 0xec, 0x4e, 0x87, 0xfc}
+	if !bytes.Equal(depositDataRoots[1023][:], expectedDepositDataRootAt1023) {
+		t.Fatalf("incorrect deposit data root, wanted %x but received %x", expectedDepositDataRootAt1023, depositDataRoots[1023])
+	}
 	expectedSignatureAt1023 := []byte{0xa2, 0xad, 0x23, 0x3b, 0x6d, 0xa0, 0xd9, 0xf8, 0xb4, 0xac, 0xe0, 0xc9, 0xae, 0x25, 0x81, 0xfb, 0xca, 0x2d, 0x0a, 0xed, 0x6a, 0xdc, 0xd6, 0xda, 0x49, 0x0a, 0x75, 0xab, 0x3a, 0x3c, 0xc6, 0x37, 0xec, 0x65, 0xe3, 0x3d, 0xbc, 0x00, 0xad, 0xd8, 0x5f, 0x1e, 0x7b, 0x93, 0xcd, 0x63, 0x74, 0x8e, 0x0c, 0x28, 0x60, 0x4f, 0x99, 0x33, 0x6a, 0x29, 0x21, 0x57, 0xb6, 0xe0, 0x45, 0x9f, 0xaa, 0x10, 0xe9, 0x78, 0x02, 0x01, 0x68, 0x65, 0xcf, 0x6a, 0x4c, 0x2a, 0xd5, 0x5f, 0x37, 0xa1, 0x66, 0x05, 0x2b, 0x55, 0x86, 0xe7, 0x68, 0xb7, 0xfd, 0x76, 0xd5, 0x91, 0x3e, 0xeb, 0x6e, 0x46, 0x3f, 0x6d}
 	if !bytes.Equal(deposits[1023].Data.Signature, expectedSignatureAt1023) {
 		t.Fatalf("incorrect signature, wanted %x but received %x", expectedSignatureAt1023, deposits[1023].Data.Signature)
@@ -67,7 +78,7 @@ func TestSetupInitialDeposits(t *testing.T) {
 }
 
 func TestSignBlock(t *testing.T) {
-	deposits, privKeys := SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := SetupInitialDeposits(t, 100)
 	validators := make([]*ethpb.Validator, len(deposits))
 	for i := 0; i < len(validators); i++ {
 		validators[i] = &ethpb.Validator{
@@ -114,7 +125,7 @@ func TestSignBlock(t *testing.T) {
 }
 
 func TestCreateRandaoReveal(t *testing.T) {
-	deposits, privKeys := SetupInitialDeposits(t, 100)
+	deposits, _, privKeys := SetupInitialDeposits(t, 100)
 	validators := make([]*ethpb.Validator, len(deposits))
 	for i := 0; i < len(validators); i++ {
 		validators[i] = &ethpb.Validator{


### PR DESCRIPTION
Second part of the updates to allow smoother transition to a validating deposit contract (first part was #3639)

---

# Description

This PR updates the signature of `testutils.SetupInitialDeposits()` to return the hash tree roots of the deposit data for each deposit.  This means that in future as/when the updated deposit contract requires this information it will be available within tests without additional work and reduce the size of that patchset.

At current this additional data is used in only one test, but there are other tests in the codebase that use junk data for the deposits.  Subsequent patches will fix up these tests to use real data from `SetupInitialDeposits()` to allow these structures to pass verification, provide well-defined results against which tests can be made, and to be passed to external entities such as the deposit contract without erroring.