### PR TITLE
Add database API for creating backups

### DIFF
--- a/beacon-chain/db/BUILD.bazel
+++ b/beacon-chain/db/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["db.go"],
+    srcs = [
+        "db.go",
+        "http_backup_handler.go",
+    ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/db",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
@@ -11,6 +14,7 @@ go_library(
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -17,6 +17,8 @@ type Database interface {
 	io.Closer
 	DatabasePath() string
 	ClearDB() error
+	// Backup and restore methods
+	Backup(ctx context.Context) error
 	// Attestation related methods.
 	Attestation(ctx context.Context, attDataRoot [32]byte) (*ethpb.Attestation, error)
 	Attestations(ctx context.Context, f *filters.QueryFilter) ([]*ethpb.Attestation, error)

--- a/beacon-chain/db/http_backup_handler.go
+++ b/beacon-chain/db/http_backup_handler.go
@@ -22,6 +22,8 @@ func BackupHandler(db Database) func(http.ResponseWriter, *http.Request) {
 		}
 		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprint(w, "OK")
-		log.WithError(err).Error("Failed to write OK")
+		if err != nil {
+			log.WithError(err).Error("Failed to write OK")
+		}
 	}
 }

--- a/beacon-chain/db/http_backup_handler.go
+++ b/beacon-chain/db/http_backup_handler.go
@@ -1,0 +1,27 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+)
+
+// BackupHandler for accepting requests to initiate a new database backup.
+func BackupHandler(db Database) func(http.ResponseWriter, *http.Request) {
+	log := logrus.WithField("prefix", "db")
+
+	return func(w http.ResponseWriter, _ *http.Request) {
+		log.Debug("Creating database backup from HTTP webhook.")
+
+		if err := db.Backup(context.Background()); err != nil {
+			log.WithError(err).Error("Failed to create backup")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(w, "OK")
+		log.WithError(err).Error("Failed to write OK")
+	}
+}

--- a/beacon-chain/db/kv/BUILD.bazel
+++ b/beacon-chain/db/kv/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "archive.go",
         "attestations.go",
+        "backup.go",
         "blocks.go",
         "checkpoint.go",
         "deposit_contract.go",
@@ -40,6 +41,7 @@ go_test(
     srcs = [
         "archive_test.go",
         "attestations_test.go",
+        "backup_test.go",
         "blocks_test.go",
         "checkpoint_test.go",
         "deposit_contract_test.go",

--- a/beacon-chain/db/kv/BUILD.bazel
+++ b/beacon-chain/db/kv/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
     ],
 )

--- a/beacon-chain/db/kv/backup.go
+++ b/beacon-chain/db/kv/backup.go
@@ -15,7 +15,7 @@ import (
 const backupsDirectoryName = "backups"
 
 // Backup the database to the datadir backup directory.
-// Example for backup at slot 345: $DATADIR/backups/slot_0000345.backup
+// Example for backup at slot 345: $DATADIR/backups/prysm_beacondb_at_slot_0000345.backup
 func (k *Store) Backup(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.Backup")
 	defer span.End()
@@ -32,7 +32,7 @@ func (k *Store) Backup(ctx context.Context) error {
 	if err := os.MkdirAll(backupsDir, os.ModePerm); err != nil {
 		return err
 	}
-	backupPath := path.Join(backupsDir, fmt.Sprintf("slot_%07d.backup", head.Slot))
+	backupPath := path.Join(backupsDir, fmt.Sprintf("prysm_beacondb_at_slot_%07d.backup", head.Slot))
 	logrus.WithField("prefix", "db").WithField("backup", backupPath).Info("Writing backup database.")
 	return k.db.View(func(tx *bolt.Tx) error {
 		return tx.CopyFile(backupPath, 0666)

--- a/beacon-chain/db/kv/backup.go
+++ b/beacon-chain/db/kv/backup.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/boltdb/bolt"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
 
@@ -32,6 +33,7 @@ func (k *Store) Backup(ctx context.Context) error {
 		return err
 	}
 	backupPath := path.Join(backupsDir, fmt.Sprintf("slot_%07d.backup", head.Slot))
+	logrus.WithField("prefix", "db").WithField("backup", backupPath).Info("Writing backup database.")
 	return k.db.View(func(tx *bolt.Tx) error {
 		return tx.CopyFile(backupPath, 0666)
 	})

--- a/beacon-chain/db/kv/backup.go
+++ b/beacon-chain/db/kv/backup.go
@@ -1,0 +1,29 @@
+package kv
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/boltdb/bolt"
+	"go.opencensus.io/trace"
+)
+
+const backupsDirectoryName = "backups"
+
+// Backup the database to the datadir backup directory.
+// Example for backup at slot 345: $DATADIR/backups/slot_0000345.backup
+func (k *Store) Backup(ctx context.Context) error {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.Backup")
+	defer span.End()
+
+	backupsDir := path.Join(k.databasePath, backupsDirectoryName)
+	head, err := k.HeadBlock(ctx)
+	if err != nil {
+		return err
+	}
+	backupPath := path.Join(backupsDir, fmt.Sprintf("slot_%7d.backup", head.Slot))
+	return k.db.View(func(tx *bolt.Tx) error {
+		return tx.CopyFile(backupPath, 0666)
+	})
+}

--- a/beacon-chain/db/kv/backup_test.go
+++ b/beacon-chain/db/kv/backup_test.go
@@ -1,0 +1,43 @@
+package kv
+
+import (
+	"context"
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/prysmaticlabs/go-ssz"
+	eth "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+)
+
+func TestStore_Backup(t *testing.T) {
+	db := setupDB(t)
+	defer teardownDB(t, db)
+	ctx := context.Background()
+
+	head := &eth.BeaconBlock{}
+	head.Slot = 5000
+
+	if err := db.SaveBlock(ctx, head); err != nil {
+		t.Fatal(err)
+	}
+	root, err := ssz.HashTreeRoot(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveHeadBlockRoot(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Backup(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := ioutil.ReadDir(path.Join(db.databasePath+backupsDirectoryName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("No backups created.")
+	}
+}

--- a/beacon-chain/db/kv/backup_test.go
+++ b/beacon-chain/db/kv/backup_test.go
@@ -21,7 +21,7 @@ func TestStore_Backup(t *testing.T) {
 	if err := db.SaveBlock(ctx, head); err != nil {
 		t.Fatal(err)
 	}
-	root, err := ssz.HashTreeRoot(head)
+	root, err := ssz.SigningRoot(head)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestStore_Backup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	files, err := ioutil.ReadDir(path.Join(db.databasePath+backupsDirectoryName))
+	files, err := ioutil.ReadDir(path.Join(db.databasePath, backupsDirectoryName))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -21,6 +21,8 @@ const VotesCacheSize = 1000000
 // ValidatorIndexCacheSize of 1M * 8 bytes, ~8 Mb
 const ValidatorIndexCacheSize = 1000000
 
+const databaseFileName = "beaconchain.db"
+
 // Store defines an implementation of the Prysm Database interface
 // using BoltDB as the underlying persistent kv-store for eth2.
 type Store struct {
@@ -38,7 +40,7 @@ func NewKVStore(dirPath string) (*Store, error) {
 	if err := os.MkdirAll(dirPath, 0700); err != nil {
 		return nil, err
 	}
-	datafile := path.Join(dirPath, "beaconchain.db")
+	datafile := path.Join(dirPath, databaseFileName)
 	boltDB, err := bolt.Open(datafile, 0600, &bolt.Options{Timeout: 1 * time.Second, InitialMmapSize: 10e6})
 	if err != nil {
 		if err == bolt.ErrTimeout {
@@ -88,13 +90,13 @@ func NewKVStore(dirPath string) (*Store, error) {
 	return kv, err
 }
 
-// ClearDB removes the previously stored directory at the data directory.
+// ClearDB removes the previously stored database in the data directory.
 func (k *Store) ClearDB() error {
 	if _, err := os.Stat(k.databasePath); os.IsNotExist(err) {
 		return nil
 	}
 	prometheus.Unregister(createBoltCollector(k.db))
-	return os.RemoveAll(k.databasePath)
+	return os.Remove(path.Join(k.databasePath, databaseFileName))
 }
 
 // Close closes the underlying BoltDB database.

--- a/beacon-chain/node/clear_db.go
+++ b/beacon-chain/node/clear_db.go
@@ -14,8 +14,8 @@ func confirmDelete(d db.Database, path string) (db.Database, error) {
 	var err error
 	reader := bufio.NewReader(os.Stdin)
 
-	log.Warn("This will delete all the chain data stored in your data directory - " +
-		"do you want to proceed? (Y/N)")
+	log.Warn("This will delete your beacon chain data base stored in your data directory. " +
+		"Your database backups will not be removed - do you want to proceed? (Y/N)")
 
 	for {
 		fmt.Print(">> ")
@@ -31,11 +31,11 @@ func confirmDelete(d db.Database, path string) (db.Database, error) {
 			continue
 		}
 		if lineInput == "Y" {
-			log.Warn("Deleting all chain data from data directory")
+			log.Warn("Deleting beaconchain.db from data directory")
 			clearDB = true
 			break
 		}
-		log.Info("Not deleting chain data, the db will be initialized" +
+		log.Info("Not deleting chain database, the db will be initialized" +
 			" with the current data directory.")
 		break
 	}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -478,6 +478,10 @@ func (b *BeaconNode) registerPrometheusService(ctx *cli.Context) error {
 	}
 	additionalHandlers = append(additionalHandlers, prometheus.Handler{Path: "/heads", Handler: c.HeadsHandler})
 
+	if featureconfig.FeatureConfig().EnableBackupWebhook {
+		additionalHandlers = append(additionalHandlers, prometheus.Handler{Path: "/db/backup", Handler: db.BackupHandler(b.db)})
+	}
+
 	service := prometheus.NewPrometheusService(
 		fmt.Sprintf(":%d", ctx.GlobalInt64(cmd.MonitoringPortFlag.Name)),
 		b.services,

--- a/beacon-chain/p2p/sender.go
+++ b/beacon-chain/p2p/sender.go
@@ -21,7 +21,7 @@ func (s *Service) Send(ctx context.Context, message interface{}, pid peer.ID) (n
 	span.AddAttributes(trace.StringAttribute("topic", topic))
 
 	// TTFB_TIME (5s) + RESP_TIMEOUT (10s).
-	const deadline = 15*time.Second
+	const deadline = 15 * time.Second
 	ctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
 

--- a/beacon-chain/p2p/sender.go
+++ b/beacon-chain/p2p/sender.go
@@ -8,28 +8,44 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
+	"github.com/prysmaticlabs/prysm/shared/traceutil"
+	"go.opencensus.io/trace"
 )
 
 // Send a message to a specific peer. The returned stream may be used for reading, but has been
 // closed for writing.
 func (s *Service) Send(ctx context.Context, message interface{}, pid peer.ID) (network.Stream, error) {
+	ctx, span := trace.StartSpan(ctx, "p2p.Send")
+	defer span.End()
 	topic := RPCTypeMapping[reflect.TypeOf(message)] + s.Encoding().ProtocolSuffix()
+	span.AddAttributes(trace.StringAttribute("topic", topic))
 
 	// TTFB_TIME (5s) + RESP_TIMEOUT (10s).
-	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	const deadline = 15*time.Second
+	ctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
 
 	stream, err := s.host.NewStream(ctx, pid, protocol.ID(topic))
 	if err != nil {
+		traceutil.AnnotateError(span, err)
 		return nil, err
 	}
-
+	if err := stream.SetReadDeadline(time.Now().Add(deadline)); err != nil {
+		traceutil.AnnotateError(span, err)
+		return nil, err
+	}
+	if err := stream.SetWriteDeadline(time.Now().Add(deadline)); err != nil {
+		traceutil.AnnotateError(span, err)
+		return nil, err
+	}
 	if _, err := s.Encoding().EncodeWithLength(stream, message); err != nil {
+		traceutil.AnnotateError(span, err)
 		return nil, err
 	}
 
 	// Close stream for writing.
 	if err := stream.Close(); err != nil {
+		traceutil.AnnotateError(span, err)
 		return nil, err
 	}
 

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -30,6 +30,7 @@ type FeatureFlagConfig struct {
 	WriteSSZStateTransitions bool // WriteSSZStateTransitions to tmp directory.
 	InitSyncNoVerify         bool // InitSyncNoVerify when initial syncing w/o verifying block's contents.
 	SkipBLSVerify            bool // Skips BLS verification across the runtime.
+	EnableBackupWebhook      bool // EnableBackupWebhook to allow database backups to trigger from monitoring port /db/backup
 
 	// Cache toggles.
 	EnableAttestationCache  bool // EnableAttestationCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
@@ -87,6 +88,10 @@ func ConfigureBeaconFeatures(ctx *cli.Context) {
 	if ctx.GlobalBool(SkipBLSVerifyFlag.Name) {
 		log.Warn("UNSAFE: Skipping BLS verification at runtime")
 		cfg.SkipBLSVerify = true
+	}
+	if ctx.GlobalBool(enableBackupWebhookFlag.Name) {
+		log.Warn("Allowing database backups to be triggered from HTTP webhook.")
+		cfg.EnableBackupWebhook = true
 	}
 	InitFeatureConfig(cfg)
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -44,6 +44,10 @@ var (
 		Name:  "skip-bls-verify",
 		Usage: "Whether or not to skip BLS verification of signature at runtime, this is unsafe and should only be used for development",
 	}
+	enableBackupWebhookFlag = cli.BoolFlag{
+		Name: "enable-db-backup-webhook",
+		Usage: "Serve HTTP handler to initiate database backups. The handler is served on the monitoring port at path /db/backup.",
+	}
 )
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -61,4 +65,5 @@ var BeaconChainFlags = []cli.Flag{
 	InitSyncNoVerifyFlag,
 	NewCacheFlag,
 	SkipBLSVerifyFlag,
+	enableBackupWebhookFlag,
 }


### PR DESCRIPTION
Also adds the ability to initiate the database backup via web hook. 

With the flag `--enable-db-backup-webhook`, you can http call `GET http://localhost:8080/db/backup` and the backup will be written to disk.