### PR TITLE
Add flag to enable BLS pubkey cache

### DIFF
--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -66,7 +66,7 @@ func PublicKeyFromBytes(pub []byte) (*PublicKey, error) {
 		return &PublicKey{}, nil
 	}
 	cv := pubkeyCache.Get(string(pub))
-	if cv != nil && cv.Value() != nil {
+	if cv != nil && cv.Value() != nil && featureconfig.FeatureConfig().EnableBLSPubkeyCache {
 		return cv.Value().(*PublicKey).Copy(), nil
 	}
 	b := bytesutil.ToBytes48(pub)

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -36,6 +36,7 @@ type FeatureFlagConfig struct {
 	EnableAttestationCache  bool // EnableAttestationCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
 	EnableEth1DataVoteCache bool // EnableEth1DataVoteCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
 	EnableNewCache          bool // EnableNewCache enables the node to use the new caching scheme.
+	EnableBLSPubkeyCache    bool // EnableBLSPubkeyCache to improve wall time of PubkeyFromBytes.
 }
 
 var featureConfig *FeatureFlagConfig
@@ -92,6 +93,10 @@ func ConfigureBeaconFeatures(ctx *cli.Context) {
 	if ctx.GlobalBool(enableBackupWebhookFlag.Name) {
 		log.Warn("Allowing database backups to be triggered from HTTP webhook.")
 		cfg.EnableBackupWebhook = true
+	}
+	if ctx.GlobalBool(enableBLSPubkeyCacheFlag.Name) {
+		log.Warn("Enabled BLS pubkey cache.")
+		cfg.EnableBLSPubkeyCache = true
 	}
 	InitFeatureConfig(cfg)
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -48,6 +48,10 @@ var (
 		Name: "enable-db-backup-webhook",
 		Usage: "Serve HTTP handler to initiate database backups. The handler is served on the monitoring port at path /db/backup.",
 	}
+	enableBLSPubkeyCacheFlag = cli.BoolFlag{
+		Name: "enable-bls-pubkey-cache",
+		Usage: "Enable BLS pubkey cache to improve wall time of PubkeyFromBytes",
+	}
 )
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -66,4 +70,5 @@ var BeaconChainFlags = []cli.Flag{
 	NewCacheFlag,
 	SkipBLSVerifyFlag,
 	enableBackupWebhookFlag,
+	enableBLSPubkeyCacheFlag,
 }


### PR DESCRIPTION
Right now, the BLS pubkey.Copy method does not do a clean copy. It is reusing pointers which could lead to a poisoned cache.

Adding a flag to selectively enable the cache while we resolve that issue. 