### PR TITLE
Resubscribe Headers from ETH 1 Chain

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -401,7 +401,7 @@ func (s *Service) run(done <-chan struct{}) {
 			log.WithError(s.runError).Error("Subscription to new head notifier failed")
 			headSub, err = s.reader.SubscribeNewHead(s.ctx, s.headerChan)
 			if err != nil {
-				log.Errorf("Unable to re-subscribe to incoming ETH1.0 chain headers: %v", err)
+				log.WithError(err).Error("Unable to re-subscribe to incoming ETH1.0 chain headers")
 				s.runError = err
 				return
 			}

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -398,8 +398,13 @@ func (s *Service) run(done <-chan struct{}) {
 			log.Debug("Context closed, exiting goroutine")
 			return
 		case s.runError = <-headSub.Err():
-			log.WithError(err).Error("Subscription to new head notifier failed")
-			return
+			log.WithError(s.runError).Error("Subscription to new head notifier failed")
+			headSub, err = s.reader.SubscribeNewHead(s.ctx, s.headerChan)
+			if err != nil {
+				log.Errorf("Unable to re-subscribe to incoming ETH1.0 chain headers: %v", err)
+				s.runError = err
+				return
+			}
 		case header, ok := <-s.headerChan:
 			if ok {
 				s.processSubscribedHeaders(header)

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -45,11 +45,11 @@ var (
 		Usage: "Whether or not to skip BLS verification of signature at runtime, this is unsafe and should only be used for development",
 	}
 	enableBackupWebhookFlag = cli.BoolFlag{
-		Name: "enable-db-backup-webhook",
+		Name:  "enable-db-backup-webhook",
 		Usage: "Serve HTTP handler to initiate database backups. The handler is served on the monitoring port at path /db/backup.",
 	}
 	enableBLSPubkeyCacheFlag = cli.BoolFlag{
-		Name: "enable-bls-pubkey-cache",
+		Name:  "enable-bls-pubkey-cache",
 		Usage: "Enable BLS pubkey cache to improve wall time of PubkeyFromBytes",
 	}
 )


### PR DESCRIPTION
In the case of any failure from our current subscription, we will try to re-subscribe to the current headers from the eth1 chain.