### PR TITLE
Clean up feature flag namings

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -125,7 +125,7 @@ func (s *Store) OnBlock(ctx context.Context, b *ethpb.BeaconBlock) error {
 		reportEpochMetrics(postState)
 
 		// Update committee shuffled indices at the end of every epoch
-		if featureconfig.FeatureConfig().EnableNewCache {
+		if featureconfig.Get().EnableNewCache {
 			if err := helpers.UpdateCommitteeCache(postState); err != nil {
 				return err
 			}

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -174,7 +174,7 @@ func (s *Service) initializeBeaconChain(
 	}
 
 	// Update committee shuffled indices for genesis epoch.
-	if featureconfig.FeatureConfig().EnableNewCache {
+	if featureconfig.Get().EnableNewCache {
 		if err := helpers.UpdateCommitteeCache(genesisState); err != nil {
 			return err
 		}

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -60,7 +60,7 @@ func NewAttestationCache() *AttestationCache {
 // Get waits for any in progress calculation to complete before returning a
 // cached response, if any.
 func (c *AttestationCache) Get(ctx context.Context, req *pb.AttestationRequest) (*ethpb.AttestationData, error) {
-	if !featureconfig.FeatureConfig().EnableAttestationCache {
+	if !featureconfig.Get().EnableAttestationCache {
 		// Return a miss result if cache is not enabled.
 		attestationCacheMiss.Inc()
 		return nil, nil
@@ -114,7 +114,7 @@ func (c *AttestationCache) Get(ctx context.Context, req *pb.AttestationRequest) 
 // MarkInProgress a request so that any other similar requests will block on
 // Get until MarkNotInProgress is called.
 func (c *AttestationCache) MarkInProgress(req *pb.AttestationRequest) error {
-	if !featureconfig.FeatureConfig().EnableAttestationCache {
+	if !featureconfig.Get().EnableAttestationCache {
 		return nil
 	}
 
@@ -127,7 +127,7 @@ func (c *AttestationCache) MarkInProgress(req *pb.AttestationRequest) error {
 	if c.inProgress[s] {
 		return ErrAlreadyInProgress
 	}
-	if featureconfig.FeatureConfig().EnableAttestationCache {
+	if featureconfig.Get().EnableAttestationCache {
 		c.inProgress[s] = true
 	}
 	return nil
@@ -136,7 +136,7 @@ func (c *AttestationCache) MarkInProgress(req *pb.AttestationRequest) error {
 // MarkNotInProgress will release the lock on a given request. This should be
 // called after put.
 func (c *AttestationCache) MarkNotInProgress(req *pb.AttestationRequest) error {
-	if !featureconfig.FeatureConfig().EnableAttestationCache {
+	if !featureconfig.Get().EnableAttestationCache {
 		return nil
 	}
 
@@ -152,7 +152,7 @@ func (c *AttestationCache) MarkNotInProgress(req *pb.AttestationRequest) error {
 
 // Put the response in the cache.
 func (c *AttestationCache) Put(ctx context.Context, req *pb.AttestationRequest, res *ethpb.AttestationData) error {
-	if !featureconfig.FeatureConfig().EnableAttestationCache {
+	if !featureconfig.Get().EnableAttestationCache {
 		return nil
 	}
 

--- a/beacon-chain/cache/eth1_data.go
+++ b/beacon-chain/cache/eth1_data.go
@@ -61,7 +61,7 @@ func NewEth1DataVoteCache() *Eth1DataVoteCache {
 // Eth1DataVote fetches eth1 data vote count by the eth1data hash. Returns vote count,
 // if exists. Otherwise returns false, nil.
 func (c *Eth1DataVoteCache) Eth1DataVote(eth1DataHash [32]byte) (uint64, error) {
-	if !featureconfig.FeatureConfig().EnableEth1DataVoteCache {
+	if !featureconfig.Get().EnableEth1DataVoteCache {
 		// Return a miss result if cache is not enabled.
 		eth1DataVoteCacheMiss.Inc()
 		return 0, nil
@@ -92,7 +92,7 @@ func (c *Eth1DataVoteCache) Eth1DataVote(eth1DataHash [32]byte) (uint64, error) 
 // AddEth1DataVote adds eth1 data vote object to the cache. This method also trims the least
 // recently added Eth1DataVoteByEpoch object if the cache size has ready the max cache size limit.
 func (c *Eth1DataVoteCache) AddEth1DataVote(eth1DataVote *Eth1DataVote) error {
-	if !featureconfig.FeatureConfig().EnableEth1DataVoteCache {
+	if !featureconfig.Get().EnableEth1DataVoteCache {
 		return nil
 	}
 
@@ -109,7 +109,7 @@ func (c *Eth1DataVoteCache) AddEth1DataVote(eth1DataVote *Eth1DataVote) error {
 // IncrementEth1DataVote increments the existing eth1 data object's vote count by 1,
 // and returns the vote count.
 func (c *Eth1DataVoteCache) IncrementEth1DataVote(eth1DataHash [32]byte) (uint64, error) {
-	if !featureconfig.FeatureConfig().EnableEth1DataVoteCache {
+	if !featureconfig.Get().EnableEth1DataVoteCache {
 		return 0, nil
 	}
 

--- a/beacon-chain/cache/feature_flag_test.go
+++ b/beacon-chain/cache/feature_flag_test.go
@@ -3,7 +3,7 @@ package cache
 import "github.com/prysmaticlabs/prysm/shared/featureconfig"
 
 func init() {
-	featureconfig.InitFeatureConfig(&featureconfig.FeatureFlagConfig{
+	featureconfig.Init(&featureconfig.Flag{
 		EnableAttestationCache:  true,
 		EnableEth1DataVoteCache: true,
 	})

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -96,7 +96,7 @@ func Eth1DataHasEnoughSupport(beaconState *pb.BeaconState, data *ethpb.Eth1Data)
 	voteCount := uint64(0)
 	var eth1DataHash [32]byte
 	var err error
-	if featureconfig.FeatureConfig().EnableEth1DataVoteCache {
+	if featureconfig.Get().EnableEth1DataVoteCache {
 		eth1DataHash, err = hashutil.HashProto(data)
 		if err != nil {
 			return false, errors.Wrap(err, "could not hash eth1data")
@@ -117,7 +117,7 @@ func Eth1DataHasEnoughSupport(beaconState *pb.BeaconState, data *ethpb.Eth1Data)
 		voteCount++
 	}
 
-	if featureconfig.FeatureConfig().EnableEth1DataVoteCache {
+	if featureconfig.Get().EnableEth1DataVoteCache {
 		if err := eth1DataCache.AddEth1DataVote(&cache.Eth1DataVote{
 			Eth1DataHash: eth1DataHash,
 			VoteCount:    voteCount,

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -33,7 +33,7 @@ var committeeCache = cache.NewCommitteeCache()
 //    ))
 //    return committees_per_slot * SLOTS_PER_EPOCH
 func CommitteeCount(state *pb.BeaconState, epoch uint64) (uint64, error) {
-	if featureconfig.FeatureConfig().EnableNewCache {
+	if featureconfig.Get().EnableNewCache {
 		count, exists, err := committeeCache.CommitteeCount(epoch)
 		if err != nil {
 			return 0, errors.Wrap(err, "could not interface with committee cache")
@@ -80,7 +80,7 @@ func CommitteeCount(state *pb.BeaconState, epoch uint64) (uint64, error) {
 //        count=get_committee_count(state, epoch),
 //    )
 func CrosslinkCommittee(state *pb.BeaconState, epoch uint64, shard uint64) ([]uint64, error) {
-	if featureconfig.FeatureConfig().EnableNewCache {
+	if featureconfig.Get().EnableNewCache {
 		indices, err := committeeCache.ShuffledIndices(epoch, shard)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not interface with committee cache")
@@ -338,7 +338,7 @@ func shardDeltaFromCommitteeCount(committeeCount uint64) uint64 {
 //        shard = Shard((shard + SHARD_COUNT - get_shard_delta(state, check_epoch)) % SHARD_COUNT)
 //    return shard
 func StartShard(state *pb.BeaconState, epoch uint64) (uint64, error) {
-	if featureconfig.FeatureConfig().EnableNewCache {
+	if featureconfig.Get().EnableNewCache {
 		startShard, exists, err := committeeCache.StartShard(epoch)
 		if err != nil {
 			return 0, errors.Wrap(err, "could not interface with committee cache")

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -63,7 +63,7 @@ func IsSlashableValidator(validator *ethpb.Validator, epoch uint64) bool {
 //    """
 //    return [ValidatorIndex(i) for i, v in enumerate(state.validators) if is_active_validator(v, epoch)]
 func ActiveValidatorIndices(state *pb.BeaconState, epoch uint64) ([]uint64, error) {
-	if featureconfig.FeatureConfig().EnableNewCache {
+	if featureconfig.Get().EnableNewCache {
 		activeIndices, err := committeeCache.ActiveIndices(epoch)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not interface with committee cache")

--- a/beacon-chain/core/state/interop/write_block_to_disk.go
+++ b/beacon-chain/core/state/interop/write_block_to_disk.go
@@ -13,7 +13,7 @@ import (
 
 // WriteBlockToDisk as a block ssz. Writes to temp directory. Debug!
 func WriteBlockToDisk(block *ethpb.BeaconBlock, failed bool) {
-	if !featureconfig.FeatureConfig().WriteSSZStateTransitions {
+	if !featureconfig.Get().WriteSSZStateTransitions {
 		return
 	}
 

--- a/beacon-chain/core/state/interop/write_state_to_disk.go
+++ b/beacon-chain/core/state/interop/write_state_to_disk.go
@@ -13,7 +13,7 @@ import (
 
 // WriteStateToDisk as a state ssz. Writes to temp directory. Debug!
 func WriteStateToDisk(state *pb.BeaconState) {
-	if !featureconfig.FeatureConfig().WriteSSZStateTransitions {
+	if !featureconfig.Get().WriteSSZStateTransitions {
 		return
 	}
 	fp := path.Join(os.TempDir(), fmt.Sprintf("beacon_state_%d.ssz", state.Slot))

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -73,7 +73,7 @@ func NewBeaconNode(ctx *cli.Context) (*BeaconNode, error) {
 	); err != nil {
 		return nil, err
 	}
-	featureconfig.ConfigureBeaconFeatures(ctx)
+	featureconfig.ConfigureBeaconChain(ctx)
 	registry := shared.NewServiceRegistry()
 
 	beacon := &BeaconNode{
@@ -84,7 +84,7 @@ func NewBeaconNode(ctx *cli.Context) (*BeaconNode, error) {
 
 	// Use custom config values if the --no-custom-config flag is set.
 	if !ctx.GlobalBool(flags.NoCustomConfigFlag.Name) {
-		if featureconfig.FeatureConfig().MinimalConfig {
+		if featureconfig.Get().MinimalConfig {
 			log.WithField(
 				"config", "minimal-spec",
 			).Info("Using custom chain parameters")
@@ -478,7 +478,7 @@ func (b *BeaconNode) registerPrometheusService(ctx *cli.Context) error {
 	}
 	additionalHandlers = append(additionalHandlers, prometheus.Handler{Path: "/heads", Handler: c.HeadsHandler})
 
-	if featureconfig.FeatureConfig().EnableBackupWebhook {
+	if featureconfig.Get().EnableBackupWebhook {
 		additionalHandlers = append(additionalHandlers, prometheus.Handler{Path: "/db/backup", Handler: db.BackupHandler(b.db)})
 	}
 

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -210,7 +210,7 @@ func (s *Service) ProcessChainStart(genesisTime uint64, eth1BlockHash [32]byte, 
 }
 
 func (s *Service) setGenesisTime(timeStamp uint64) {
-	if featureconfig.FeatureConfig().NoGenesisDelay {
+	if featureconfig.Get().NoGenesisDelay {
 		s.eth2GenesisTime = uint64(time.Unix(int64(timeStamp), 0).Add(30 * time.Second).Unix())
 	} else {
 		timeStampRdDown := timeStamp - timeStamp%params.BeaconConfig().SecondsPerDay

--- a/beacon-chain/rpc/attester_server_test.go
+++ b/beacon-chain/rpc/attester_server_test.go
@@ -272,11 +272,11 @@ func TestAttestationDataAtSlot_handlesFarAwayJustifiedEpoch(t *testing.T) {
 
 func TestAttestationDataAtSlot_handlesInProgressRequest(t *testing.T) {
 	// Cache toggled by feature flag for now. See https://github.com/prysmaticlabs/prysm/issues/3106.
-	featureconfig.InitFeatureConfig(&featureconfig.FeatureFlagConfig{
+	featureconfig.Init(&featureconfig.Flag{
 		EnableAttestationCache: true,
 	})
 	defer func() {
-		featureconfig.InitFeatureConfig(nil)
+		featureconfig.Init(nil)
 	}()
 
 	ctx := context.Background()

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -155,7 +155,7 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 
 		for _, blk := range blocks {
 			logSyncStatus(genesis, blk, peers, counter)
-			if featureconfig.FeatureConfig().InitSyncNoVerify {
+			if featureconfig.Get().InitSyncNoVerify {
 				if err := s.chain.ReceiveBlockNoVerify(ctx, blk); err != nil {
 					return err
 				}

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -62,11 +62,11 @@ func SecretKeyFromBytes(priv []byte) (*SecretKey, error) {
 
 // PublicKeyFromBytes creates a BLS public key from a  LittleEndian byte slice.
 func PublicKeyFromBytes(pub []byte) (*PublicKey, error) {
-	if featureconfig.FeatureConfig().SkipBLSVerify {
+	if featureconfig.Get().SkipBLSVerify {
 		return &PublicKey{}, nil
 	}
 	cv := pubkeyCache.Get(string(pub))
-	if cv != nil && cv.Value() != nil && featureconfig.FeatureConfig().EnableBLSPubkeyCache {
+	if cv != nil && cv.Value() != nil && featureconfig.Get().EnableBLSPubkeyCache {
 		return cv.Value().(*PublicKey).Copy(), nil
 	}
 	b := bytesutil.ToBytes48(pub)
@@ -82,7 +82,7 @@ func PublicKeyFromBytes(pub []byte) (*PublicKey, error) {
 
 // SignatureFromBytes creates a BLS signature from a LittleEndian byte slice.
 func SignatureFromBytes(sig []byte) (*Signature, error) {
-	if featureconfig.FeatureConfig().SkipBLSVerify {
+	if featureconfig.Get().SkipBLSVerify {
 		return &Signature{}, nil
 	}
 	s, err := bls12.NewG2(nil).FromCompressed(sig)
@@ -101,7 +101,7 @@ func (s *SecretKey) PublicKey() *PublicKey {
 
 // Sign a message using a secret key - in a beacon/validator client.
 func (s *SecretKey) Sign(msg []byte, domain uint64) *Signature {
-	if featureconfig.FeatureConfig().SkipBLSVerify {
+	if featureconfig.Get().SkipBLSVerify {
 		return &Signature{}
 	}
 	g2 := bls12.NewG2(nil)
@@ -134,7 +134,7 @@ func (p *PublicKey) Copy() *PublicKey {
 
 // Aggregate two public keys.
 func (p *PublicKey) Aggregate(p2 *PublicKey) *PublicKey {
-	if featureconfig.FeatureConfig().SkipBLSVerify {
+	if featureconfig.Get().SkipBLSVerify {
 		return p
 	}
 	bls12.NewG1(nil).Add(p.p, p.p, p2.p)
@@ -143,7 +143,7 @@ func (p *PublicKey) Aggregate(p2 *PublicKey) *PublicKey {
 
 // Verify a bls signature given a public key, a message, and a domain.
 func (s *Signature) Verify(msg []byte, pub *PublicKey, domain uint64) bool {
-	if featureconfig.FeatureConfig().SkipBLSVerify {
+	if featureconfig.Get().SkipBLSVerify {
 		return true
 	}
 	b := [8]byte{}
@@ -167,7 +167,7 @@ func (s *Signature) Verify(msg []byte, pub *PublicKey, domain uint64) bool {
 // This is vulnerable to rogue public-key attack. Each user must
 // provide a proof-of-knowledge of the public key.
 func (s *Signature) VerifyAggregate(pubKeys []*PublicKey, msg [][32]byte, domain uint64) bool {
-	if featureconfig.FeatureConfig().SkipBLSVerify {
+	if featureconfig.Get().SkipBLSVerify {
 		return true
 	}
 	size := len(pubKeys)
@@ -197,7 +197,7 @@ func (s *Signature) VerifyAggregate(pubKeys []*PublicKey, msg [][32]byte, domain
 // This is vulnerable to rogue public-key attack. Each user must
 // provide a proof-of-knowledge of the public key.
 func (s *Signature) VerifyAggregateCommon(pubKeys []*PublicKey, msg []byte, domain uint64) bool {
-	if featureconfig.FeatureConfig().SkipBLSVerify {
+	if featureconfig.Get().SkipBLSVerify {
 		return true
 	}
 	if len(pubKeys) == 0 {
@@ -237,7 +237,7 @@ func NewAggregatePubkey() *PublicKey {
 
 // AggregateSignatures converts a list of signatures into a single, aggregated sig.
 func AggregateSignatures(sigs []*Signature) *Signature {
-	if featureconfig.FeatureConfig().SkipBLSVerify {
+	if featureconfig.Get().SkipBLSVerify {
 		return sigs[0]
 	}
 	aggregated := NewAggregateSignature()
@@ -254,7 +254,7 @@ func AggregateSignatures(sigs []*Signature) *Signature {
 
 // Marshal a signature into a LittleEndian byte slice.
 func (s *Signature) Marshal() []byte {
-	if featureconfig.FeatureConfig().SkipBLSVerify {
+	if featureconfig.Get().SkipBLSVerify {
 		return make([]byte, 96)
 	}
 	return bls12.NewG2(nil).ToCompressed(s.s)

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -9,10 +9,10 @@ The process for implementing new features using this package is as follows:
 	4. Place any "previous" behavior in the `else` statement.
 	5. Ensure any tests using the new feature fail if the flag isn't enabled.
 	5a. Use the following to enable your flag for tests:
-	cfg := &featureconfig.FeatureFlagConfig{
+	cfg := &featureconfig.Flag{
 		VerifyAttestationSigs: true,
 	}
-	featureconfig.InitFeatureConfig(cfg)
+	featureconfig.Init(cfg)
 */
 package featureconfig
 
@@ -23,8 +23,8 @@ import (
 
 var log = logrus.WithField("prefix", "flags")
 
-// FeatureFlagConfig is a struct to represent what features the client will perform on runtime.
-type FeatureFlagConfig struct {
+// Flag is a struct to represent what features the client will perform on runtime.
+type Flag struct {
 	NoGenesisDelay           bool // NoGenesisDelay when processing a chain start genesis event.
 	MinimalConfig            bool // MinimalConfig as defined in the spec.
 	WriteSSZStateTransitions bool // WriteSSZStateTransitions to tmp directory.
@@ -39,25 +39,25 @@ type FeatureFlagConfig struct {
 	EnableBLSPubkeyCache    bool // EnableBLSPubkeyCache to improve wall time of PubkeyFromBytes.
 }
 
-var featureConfig *FeatureFlagConfig
+var featureConfig *Flag
 
-// FeatureConfig retrieves feature config.
-func FeatureConfig() *FeatureFlagConfig {
+// Get retrieves feature config.
+func Get() *Flag {
 	if featureConfig == nil {
-		return &FeatureFlagConfig{}
+		return &Flag{}
 	}
 	return featureConfig
 }
 
-// InitFeatureConfig sets the global config equal to the config that is passed in.
-func InitFeatureConfig(c *FeatureFlagConfig) {
+// Init sets the global config equal to the config that is passed in.
+func Init(c *Flag) {
 	featureConfig = c
 }
 
-// ConfigureBeaconFeatures sets the global config based
+// ConfigureBeaconChain sets the global config based
 // on what flags are enabled for the beacon-chain client.
-func ConfigureBeaconFeatures(ctx *cli.Context) {
-	cfg := &FeatureFlagConfig{}
+func ConfigureBeaconChain(ctx *cli.Context) {
+	cfg := &Flag{}
 	if ctx.GlobalBool(MinimalConfigFlag.Name) {
 		log.Warn("Using minimal config")
 		cfg.MinimalConfig = true
@@ -98,16 +98,16 @@ func ConfigureBeaconFeatures(ctx *cli.Context) {
 		log.Warn("Enabled BLS pubkey cache.")
 		cfg.EnableBLSPubkeyCache = true
 	}
-	InitFeatureConfig(cfg)
+	Init(cfg)
 }
 
-// ConfigureValidatorFeatures sets the global config based
+// ConfigureValidator sets the global config based
 // on what flags are enabled for the validator client.
-func ConfigureValidatorFeatures(ctx *cli.Context) {
-	cfg := &FeatureFlagConfig{}
+func ConfigureValidator(ctx *cli.Context) {
+	cfg := &Flag{}
 	if ctx.GlobalBool(MinimalConfigFlag.Name) {
 		log.Warn("Using minimal config")
 		cfg.MinimalConfig = true
 	}
-	InitFeatureConfig(cfg)
+	Init(cfg)
 }

--- a/shared/featureconfig/config_test.go
+++ b/shared/featureconfig/config_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestInitFeatureConfig(t *testing.T) {
-	cfg := &featureconfig.FeatureFlagConfig{
+	cfg := &featureconfig.Flag{
 		NoGenesisDelay: true,
 	}
-	featureconfig.InitFeatureConfig(cfg)
-	if c := featureconfig.FeatureConfig(); !c.NoGenesisDelay {
+	featureconfig.Init(cfg)
+	if c := featureconfig.Get(); !c.NoGenesisDelay {
 		t.Errorf("NoGenesisDelay in FeatureFlags incorrect. Wanted true, got false")
 	}
 }
@@ -23,8 +23,8 @@ func TestConfigureBeaconConfig(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool(featureconfig.NoGenesisDelayFlag.Name, true, "enable attestation verification")
 	context := cli.NewContext(app, set, nil)
-	featureconfig.ConfigureBeaconFeatures(context)
-	if c := featureconfig.FeatureConfig(); !c.NoGenesisDelay {
+	featureconfig.ConfigureBeaconChain(context)
+	if c := featureconfig.Get(); !c.NoGenesisDelay {
 		t.Errorf("NoGenesisDelay in FeatureFlags incorrect. Wanted true, got false")
 	}
 }

--- a/validator/main.go
+++ b/validator/main.go
@@ -87,11 +87,11 @@ contract in order to activate the validator client`,
 						flags.PasswordFlag,
 					},
 					Action: func(ctx *cli.Context) {
-						featureconfig.ConfigureValidatorFeatures(ctx)
+						featureconfig.ConfigureValidator(ctx)
 						// Use custom config values if the --no-custom-config flag is set.
 						if !ctx.GlobalBool(flags.NoCustomConfigFlag.Name) {
 							log.Info("Using custom parameter configuration")
-							if featureconfig.FeatureConfig().MinimalConfig {
+							if featureconfig.Get().MinimalConfig {
 								log.Warn("Using Minimal Config")
 								params.UseMinimalConfig()
 							} else {

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -64,11 +64,11 @@ func NewValidatorClient(ctx *cli.Context) (*ValidatorClient, error) {
 		stop:     make(chan struct{}),
 	}
 
-	featureconfig.ConfigureValidatorFeatures(ctx)
+	featureconfig.ConfigureValidator(ctx)
 	// Use custom config values if the --no-custom-config flag is set.
 	if !ctx.GlobalBool(flags.NoCustomConfigFlag.Name) {
 		log.Info("Using custom parameter configuration")
-		if featureconfig.FeatureConfig().MinimalConfig {
+		if featureconfig.Get().MinimalConfig {
 			log.Warn("Using Minimal Config")
 			params.UseMinimalConfig()
 		} else {


### PR DESCRIPTION
This PR cleans up feature config naming to avoid duplication with package names:

`featureconfig.FeatureConfig` -> `featureconfig.Get`
`featureconfig.InitFeatureConfig` -> `featureconfig.Init`
`featureconfig.ConfigureBeaconFeatures` -> `featureconfig.ConfigureBeaconChain`
`featureconfig.ConfigureValidatorFeatures` -> `featureconfig.ConfigureValidator`