### PR TITLE
Additional log information for invalid deposits

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -157,6 +157,8 @@ func (s *Service) ProcessDepositLog(ctx context.Context, depositLog gethTypes.Lo
 		validDepositsCount.Inc()
 	} else {
 		log.WithFields(logrus.Fields{
+			"block":           depositLog.BlockHash.Hex(),
+			"tx":              depositLog.TxHash.Hex(),
 			"merkleTreeIndex": index,
 		}).Info("Invalid deposit registered in deposit contract")
 	}

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -157,8 +157,8 @@ func (s *Service) ProcessDepositLog(ctx context.Context, depositLog gethTypes.Lo
 		validDepositsCount.Inc()
 	} else {
 		log.WithFields(logrus.Fields{
-			"block":           depositLog.BlockHash.Hex(),
-			"tx":              depositLog.TxHash.Hex(),
+			"eth1Block":       depositLog.BlockHash.Hex(),
+			"eth1Tx":          depositLog.TxHash.Hex(),
 			"merkleTreeIndex": index,
 		}).Info("Invalid deposit registered in deposit contract")
 	}


### PR DESCRIPTION
This adds the tx and block hashes to the error generated when an invalid deposit on the ETH1 chain is detected, to allow for easier tracing on that chain.