### PR TITLE
Continue Writing to The Stream Despite Failures

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -66,7 +66,7 @@ func (r *RegularSync) beaconBlocksRootRPCHandler(ctx context.Context, msg interf
 
 	for _, root := range blockRoots {
 		blk, err := r.db.Block(ctx, root)
-		if err != nil || blk == nil {
+		if err != nil {
 			if err != nil {
 				log.WithError(err).Error("Failed to fetch block")
 			}
@@ -79,6 +79,9 @@ func (r *RegularSync) beaconBlocksRootRPCHandler(ctx context.Context, msg interf
 				}
 			}
 			return err
+		}
+		if blk == nil {
+			continue
 		}
 		if err := r.chunkWriter(stream, blk); err != nil {
 			return err

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -67,9 +67,7 @@ func (r *RegularSync) beaconBlocksRootRPCHandler(ctx context.Context, msg interf
 	for _, root := range blockRoots {
 		blk, err := r.db.Block(ctx, root)
 		if err != nil {
-			if err != nil {
-				log.WithError(err).Error("Failed to fetch block")
-			}
+			log.WithError(err).Error("Failed to fetch block")
 			resp, err := r.generateErrorResponse(responseCodeServerError, genericError)
 			if err != nil {
 				log.WithError(err).Error("Failed to generate a response error")


### PR DESCRIPTION
We return a generic error, if the block does not exist in our db. However due to us no longer requiring a 1-1 mapping of requests and responses, we can ignore the request for that block root, and continue on towards the next block root requested to respond to.