### PR TITLE
WIP: Fix Recursive Calls from Initial Sync

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -109,7 +109,7 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 							errChan <- errors.WithStack(errors.New("no peers left to request blocks"))
 							return
 						}
-						_, err = request(start, step, count/uint64(len(ps)) /*count*/, ps, int(count)%len(ps) /*remainder*/)
+						_, err = request(start, step/uint64(len(peers)), count/uint64(len(ps)) /*count*/, ps, int(count)%len(ps) /*remainder*/)
 						if err != nil {
 							errChan <- err
 							return


### PR DESCRIPTION
- [x] This divides the step by number of peers so as to prevent the step value from increasing when performing recursive calls
- [ ] Add regression test