### PR TITLE
Fix missing parameters in docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ docker rm beacon-node
 and re-create it again and even reset the chain database adding the parameter `--clear-db` as specified here:
 
 ```
-docker run -v $HOME/prysm-data:/data -p 4000:4000 \
+docker run -it -v $HOME/prysm-data:/data -p 4000:4000 \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
   --name beacon-node \
   --datadir=/data \


### PR DESCRIPTION
3 characters PR because ``--clear-db` require interactivity and terminal emulation to work and have a nice CLI