### PR TITLE
Remove key duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ docker rm beacon-node
 and re-create it again and even reset the chain database adding the parameter `--clear-db` as specified here:
 
 ```
-docker run -v $HOME/prysm-data:/data -p 4000:4000 \
+docker run -it -v $HOME/prysm-data:/data -p 4000:4000 \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
   --name beacon-node \
   --datadir=/data \

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -62,13 +62,7 @@ func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, e
 // Start the validator service. Launches the main go routine for the validator
 // client.
 func (v *ValidatorService) Start() {
-	pubKeys := make([][]byte, 0)
-	for pubKey := range v.keys {
-		var pubKeyCopy [48]byte
-		copy(pubKeyCopy[:], pubKey[:])
-		pubKeys = append(pubKeys, pubKeyCopy[:])
-		log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKeyCopy[:]))).Info("New validator service")
-	}
+	pubKeys := pubKeysFromMap(v.keys)
 
 	var dialOpt grpc.DialOption
 	if v.withCert != "" {
@@ -129,4 +123,16 @@ func (v *ValidatorService) Status() error {
 		return errors.New("no connection to beacon RPC")
 	}
 	return nil
+}
+
+// pubKeysFromMap is a helper that creates an array of public keys given a map of keystores
+func pubKeysFromMap(keys map[[48]byte]*keystore.Key) [][]byte {
+	pubKeys := make([][]byte, 0)
+	for pubKey := range keys {
+		var pubKeyCopy [48]byte
+		copy(pubKeyCopy[:], pubKey[:])
+		pubKeys = append(pubKeys, pubKeyCopy[:])
+		log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKeyCopy[:]))).Info("New validator service")
+	}
+	return pubKeys
 }

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -64,8 +64,10 @@ func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, e
 func (v *ValidatorService) Start() {
 	pubKeys := make([][]byte, 0)
 	for pubKey := range v.keys {
-		log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKey[:]))).Info("New validator service")
-		pubKeys = append(pubKeys, pubKey[:])
+		var pubKeyCopy [48]byte
+		copy(pubKeyCopy[:], pubKey[:])
+		pubKeys = append(pubKeys, pubKeyCopy[:])
+		log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKeyCopy[:]))).Info("New validator service")
 	}
 
 	var dialOpt grpc.DialOption

--- a/validator/client/service_test.go
+++ b/validator/client/service_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"os"
@@ -105,5 +106,27 @@ func TestStatus_NoConnectionError(t *testing.T) {
 	validatorService := &ValidatorService{}
 	if err := validatorService.Status(); !strings.Contains(err.Error(), "no connection") {
 		t.Errorf("Expected status check to fail if no connection is found, received: %v", err)
+	}
+}
+
+func TestPubKeysFromMap(t *testing.T) {
+	pubKeys := pubKeysFromMap(keyMapThreeValidators)
+	if len(pubKeys) != len(keyMapThreeValidators) {
+		t.Fatalf("Incorrect number of public keys: expected %d, obtained %d", len(keyMapThreeValidators), len(pubKeys))
+	}
+
+	for i := range pubKeys {
+		// Ensure each public key exists in the map
+		var pubKey [48]byte
+		copy(pubKey[:], pubKeys[i])
+		if _, exists := keyMapThreeValidators[pubKey]; !exists {
+			t.Fatalf("Public key %#x does not exist in original map", pubKeys[i])
+		}
+		// Ensure each public key is different from the others
+		for j := range pubKeys {
+			if i != j && bytes.Compare(pubKeys[i], pubKeys[j]) == 0 {
+				t.Fatalf("Non-unique public keys at indices %d and %d", i, j)
+			}
+		}
 	}
 }


### PR DESCRIPTION
An earlier commit resulted in copying of the same validator key to all key entries; this fixes that issue.

Note I attempted to add a test to catch this but can't find a way of starting the validator service as it seems to want a valid GRPC endpoint.  Is there a mock endpoint that can be used to allow the test to proceed?

```
func TestSetup_UniqueKeys(t *testing.T) {
    ctx, cancel := context.WithCancel(context.Background())
    validatorService := &ValidatorService{
        ctx:      ctx,
        cancel:   cancel,
        endpoint: "???",
        keys:     keyMapThreeValidators,
    }
    validatorService.Start()

    if bytes.Compare(validatorService.validator.(*validator).pubkeys[0], validatorService.validator.(*validator).pubkeys[1]) == 0 {
        t.Fatalf("Multiple validator keys with same value")
    }

    cancel()
        if err := validatorService.Stop(); err != nil {
            t.Fatalf("Could not stop service: %v", err)
        }
}
```