### PR TITLE
Fix Round Robin Test

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -75,8 +75,11 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 				start := start + uint64(i)*step
 				step := step * uint64(len(peers))
 				count := mathutil.Min(count, (helpers.StartSlot(finalizedEpoch+1)-originalStart)/step)
+				// If there is only 1 peer left, rather than further minimising the count in the situation
+				// of a large step value. we remove the variable entirely. This also handles the case if
+				// there is only 1 peer overall(step = 1).
 				if len(peers) == 1 {
-					count = originalCount
+					count = mathutil.Min(originalCount, helpers.StartSlot(finalizedEpoch+1)-originalStart)
 				}
 				// If the count was divided by an odd number of peers, there will be some blocks
 				// missing from the first requests so we accommodate that scenario.

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -69,9 +69,15 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 				if ctx.Err() != nil {
 					return nil, ctx.Err()
 				}
+
+				originalStart := start
+				originalCount := count
 				start := start + uint64(i)*step
 				step := step * uint64(len(peers))
-				count := mathutil.Min(count, (helpers.StartSlot(finalizedEpoch+1)-start)/step)
+				count := mathutil.Min(count, (helpers.StartSlot(finalizedEpoch+1)-originalStart)/step)
+				if len(peers) == 1 {
+					count = originalCount
+				}
 				// If the count was divided by an odd number of peers, there will be some blocks
 				// missing from the first requests so we accommodate that scenario.
 				if i < remainder {

--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -128,37 +128,36 @@ func TestRoundRobinSync(t *testing.T) {
 			},
 		},
 
-		// TODO(3147): Handle multiple failures.
-		//{
-		//	name:               "Multiple peers with multiple failures",
-		//	currentSlot:        320, // 5 epochs
-		//	expectedBlockSlots: makeSequence(1, 320),
-		//	peers: []*peerData{
-		//		{
-		//			blocks:         makeSequence(1, 320),
-		//			finalizedEpoch: 4,
-		//			headSlot:       320,
-		//		},
-		//		{
-		//			blocks:         makeSequence(1, 320),
-		//			finalizedEpoch: 4,
-		//			headSlot:       320,
-		//			failureSlots:   makeSequence(1, 320),
-		//		},
-		//		{
-		//			blocks:         makeSequence(1, 320),
-		//			finalizedEpoch: 4,
-		//			headSlot:       320,
-		//			failureSlots:   makeSequence(1, 320),
-		//		},
-		//		{
-		//			blocks:         makeSequence(1, 320),
-		//			finalizedEpoch: 4,
-		//			headSlot:       320,
-		//			failureSlots:   makeSequence(1, 320),
-		//		},
-		//	},
-		//},
+		{
+			name:               "Multiple peers with multiple failures",
+			currentSlot:        320, // 5 epochs
+			expectedBlockSlots: makeSequence(1, 320),
+			peers: []*peerData{
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 4,
+					headSlot:       320,
+				},
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 4,
+					headSlot:       320,
+					failureSlots:   makeSequence(1, 320),
+				},
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 4,
+					headSlot:       320,
+					failureSlots:   makeSequence(1, 320),
+				},
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 4,
+					headSlot:       320,
+					failureSlots:   makeSequence(1, 320),
+				},
+			},
+		},
 		{
 			name:               "Multiple peers with different finalized epoch",
 			currentSlot:        320, // 5 epochs


### PR DESCRIPTION
This fixes our test by fixing some bugs in our initial sync algorithm. 
- [x] When choosing the count, we only need to take into account the original start value
- [x] If there is only 1 peer left, we should not continue dividing by the step value. As in situation with
multiple failures, the step value grows large