### PR TITLE
Revert "Change public key map identifier to byte array"

### DIFF
--- a/validator/client/fake_validator_test.go
+++ b/validator/client/fake_validator_test.go
@@ -71,20 +71,20 @@ func (fv *fakeValidator) LogValidatorGainsAndLosses(_ context.Context, slot uint
 	return nil
 }
 
-func (fv *fakeValidator) RolesAt(slot uint64) map[[48]byte]pb.ValidatorRole {
+func (fv *fakeValidator) RolesAt(slot uint64) map[string]pb.ValidatorRole {
 	fv.RoleAtCalled = true
 	fv.RoleAtArg1 = slot
-	vr := make(map[[48]byte]pb.ValidatorRole)
-	vr[[48]byte{1}] = fv.RoleAtRet
+	vr := make(map[string]pb.ValidatorRole)
+	vr["a"] = fv.RoleAtRet
 	return vr
 }
 
-func (fv *fakeValidator) AttestToBlockHead(_ context.Context, slot uint64, pubKey [48]byte) {
+func (fv *fakeValidator) AttestToBlockHead(_ context.Context, slot uint64, idx string) {
 	fv.AttestToBlockHeadCalled = true
 	fv.AttestToBlockHeadArg1 = slot
 }
 
-func (fv *fakeValidator) ProposeBlock(_ context.Context, slot uint64, pubKey [48]byte) {
+func (fv *fakeValidator) ProposeBlock(_ context.Context, slot uint64, idx string) {
 	fv.ProposeBlockCalled = true
 	fv.ProposeBlockArg1 = slot
 }

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -27,7 +27,7 @@ type ValidatorService struct {
 	conn                 *grpc.ClientConn
 	endpoint             string
 	withCert             string
-	keys                 map[[48]byte]*keystore.Key
+	keys                 map[string]*keystore.Key
 	logValidatorBalances bool
 }
 
@@ -43,18 +43,12 @@ type Config struct {
 // registry.
 func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	pubKeys := make(map[[48]byte]*keystore.Key)
-	for _, v := range cfg.Keys {
-		var pubKey [48]byte
-		copy(pubKey[:], v.PublicKey.Marshal())
-		pubKeys[pubKey] = v
-	}
 	return &ValidatorService{
 		ctx:                  ctx,
 		cancel:               cancel,
 		endpoint:             cfg.Endpoint,
 		withCert:             cfg.CertFlag,
-		keys:                 pubKeys,
+		keys:                 cfg.Keys,
 		logValidatorBalances: cfg.LogValidatorBalances,
 	}, nil
 }
@@ -62,10 +56,11 @@ func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, e
 // Start the validator service. Launches the main go routine for the validator
 // client.
 func (v *ValidatorService) Start() {
-	pubKeys := make([][]byte, 0)
-	for pubKey := range v.keys {
-		log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKey[:]))).Info("New validator service")
-		pubKeys = append(pubKeys, pubKey[:])
+	pubkeys := make([][]byte, 0)
+	for i := range v.keys {
+		pubkey := v.keys[i].PublicKey.Marshal()
+		log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubkey))).Info("New validator service")
+		pubkeys = append(pubkeys, pubkey)
 	}
 
 	var dialOpt grpc.DialOption
@@ -102,7 +97,7 @@ func (v *ValidatorService) Start() {
 		attesterClient:       pb.NewAttesterServiceClient(v.conn),
 		proposerClient:       pb.NewProposerServiceClient(v.conn),
 		keys:                 v.keys,
-		pubkeys:              pubKeys,
+		pubkeys:              pubkeys,
 		logValidatorBalances: v.logValidatorBalances,
 		prevBalance:          make(map[[48]byte]uint64),
 	}

--- a/validator/client/service_test.go
+++ b/validator/client/service_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"crypto/rand"
+	"encoding/hex"
 	"os"
 	"strings"
 	"testing"
@@ -17,23 +18,19 @@ import (
 
 var _ = shared.Service(&ValidatorService{})
 var validatorKey *keystore.Key
-var validatorPubKey [48]byte
-var keyMap map[[48]byte]*keystore.Key
-var keyMapThreeValidators map[[48]byte]*keystore.Key
+var keyMap map[string]*keystore.Key
+var keyMapThreeValidators map[string]*keystore.Key
 
 func keySetup() {
-	keyMap = make(map[[48]byte]*keystore.Key)
-	keyMapThreeValidators = make(map[[48]byte]*keystore.Key)
+	keyMap = make(map[string]*keystore.Key)
+	keyMapThreeValidators = make(map[string]*keystore.Key)
 
 	validatorKey, _ = keystore.NewKey(rand.Reader)
-	copy(validatorPubKey[:], validatorKey.PublicKey.Marshal())
-	keyMap[validatorPubKey] = validatorKey
+	keyMap[hex.EncodeToString(validatorKey.PublicKey.Marshal())] = validatorKey
 
 	for i := 0; i < 3; i++ {
 		vKey, _ := keystore.NewKey(rand.Reader)
-		var pubKey [48]byte
-		copy(pubKey[:], vKey.PublicKey.Marshal())
-		keyMapThreeValidators[pubKey] = vKey
+		keyMapThreeValidators[hex.EncodeToString(vKey.PublicKey.Marshal())] = vKey
 	}
 }
 

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -3,6 +3,7 @@ package client
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"time"
@@ -24,7 +25,7 @@ type validator struct {
 	proposerClient       pb.ProposerServiceClient
 	validatorClient      pb.ValidatorServiceClient
 	attesterClient       pb.AttesterServiceClient
-	keys                 map[[48]byte]*keystore.Key
+	keys                 map[string]*keystore.Key
 	pubkeys              [][]byte
 	prevBalance          map[[48]byte]uint64
 	logValidatorBalances bool
@@ -236,8 +237,8 @@ func (v *validator) UpdateAssignments(ctx context.Context, slot uint64) error {
 // RolesAt slot returns the validator roles at the given slot. Returns nil if the
 // validator is known to not have a roles at the at slot. Returns UNKNOWN if the
 // validator assignments are unknown. Otherwise returns a valid ValidatorRole map.
-func (v *validator) RolesAt(slot uint64) map[[48]byte]pb.ValidatorRole {
-	rolesAt := make(map[[48]byte]pb.ValidatorRole)
+func (v *validator) RolesAt(slot uint64) map[string]pb.ValidatorRole {
+	rolesAt := make(map[string]pb.ValidatorRole)
 	for _, assignment := range v.assignments.ValidatorAssignment {
 		var role pb.ValidatorRole
 		if assignment == nil {
@@ -253,9 +254,7 @@ func (v *validator) RolesAt(slot uint64) map[[48]byte]pb.ValidatorRole {
 		} else {
 			role = pb.ValidatorRole_UNKNOWN
 		}
-		var pubKey [48]byte
-		copy(pubKey[:], assignment.PublicKey)
-		rolesAt[pubKey] = role
+		rolesAt[hex.EncodeToString(assignment.PublicKey)] = role
 	}
 	return rolesAt
 }

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -21,28 +21,30 @@ import (
 // It fetches the latest beacon block head along with the latest canonical beacon state
 // information in order to sign the block and include information about the validator's
 // participation in voting on the block.
-func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, pubKey [48]byte) {
+func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, pk string) {
 	ctx, span := trace.StartSpan(ctx, "validator.AttestToBlockHead")
 	defer span.End()
 
-	span.AddAttributes(trace.StringAttribute("validator", fmt.Sprintf("%#x", pubKey)))
-	log := log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKey[:])))
+	tpk := v.keys[pk].PublicKey.Marshal()
+	span.AddAttributes(trace.StringAttribute("validator", fmt.Sprintf("%#x", tpk)))
+	log := log.WithField("pubKey", fmt.Sprintf("%#x", tpk[:8]))
 
 	// We fetch the validator index as it is necessary to generate the aggregation
 	// bitfield of the attestation itself.
+	pubKey := v.keys[pk].PublicKey.Marshal()
 	var assignment *pb.AssignmentResponse_ValidatorAssignment
 	if v.assignments == nil {
 		log.Errorf("No assignments for validators")
 		return
 	}
 	for _, assign := range v.assignments.ValidatorAssignment {
-		if bytes.Equal(pubKey[:], assign.PublicKey) {
+		if bytes.Equal(pubKey, assign.PublicKey) {
 			assignment = assign
 			break
 		}
 	}
 	idxReq := &pb.ValidatorIndexRequest{
-		PublicKey: pubKey[:],
+		PublicKey: pubKey,
 	}
 	validatorIndexRes, err := v.validatorClient.ValidatorIndex(ctx, idxReq)
 	if err != nil {
@@ -94,7 +96,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, pubKey [
 		log.WithError(err).Error("Failed to sign attestation data and custody bit")
 		return
 	}
-	sig := v.keys[pubKey].SecretKey.Sign(root[:], domain.SignatureDomain).Marshal()
+	sig := v.keys[pk].SecretKey.Sign(root[:], domain.SignatureDomain).Marshal()
 
 	attestation := &ethpb.Attestation{
 		Data:            data,

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"sync"
 	"testing"
@@ -29,7 +30,7 @@ func TestRequestAttestation_ValidatorIndexRequestFailure(t *testing.T) {
 		gomock.AssignableToTypeOf(&pb.ValidatorIndexRequest{}),
 	).Return(nil /* Validator Index Response*/, errors.New("something bad happened"))
 
-	validator.AttestToBlockHead(context.Background(), 30, validatorPubKey)
+	validator.AttestToBlockHead(context.Background(), 30, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 	testutil.AssertLogsContain(t, hook, "Could not fetch validator index")
 }
 
@@ -53,7 +54,7 @@ func TestAttestToBlockHead_RequestAttestationFailure(t *testing.T) {
 		gomock.AssignableToTypeOf(&pb.AttestationRequest{}),
 	).Return(nil, errors.New("something went wrong"))
 
-	validator.AttestToBlockHead(context.Background(), 30, validatorPubKey)
+	validator.AttestToBlockHead(context.Background(), 30, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 	testutil.AssertLogsContain(t, hook, "Could not request attestation to sign at slot")
 }
 
@@ -92,7 +93,7 @@ func TestAttestToBlockHead_SubmitAttestationRequestFailure(t *testing.T) {
 		gomock.AssignableToTypeOf(&ethpb.Attestation{}),
 	).Return(nil, errors.New("something went wrong"))
 
-	validator.AttestToBlockHead(context.Background(), 30, validatorPubKey)
+	validator.AttestToBlockHead(context.Background(), 30, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 	testutil.AssertLogsContain(t, hook, "Could not submit attestation to beacon node")
 }
 
@@ -138,7 +139,7 @@ func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
 		generatedAttestation = att
 	}).Return(&pb.AttestResponse{}, nil /* error */)
 
-	validator.AttestToBlockHead(context.Background(), 30, validatorPubKey)
+	validator.AttestToBlockHead(context.Background(), 30, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 
 	aggregationBitfield := bitfield.NewBitlist(uint64(len(committee)))
 	aggregationBitfield.SetBitAt(4, true)
@@ -163,7 +164,8 @@ func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sig := validator.keys[validatorPubKey].SecretKey.Sign(root[:], 0).Marshal()
+	k := hex.EncodeToString(validatorKey.PublicKey.Marshal())
+	sig := validator.keys[k].SecretKey.Sign(root[:], 0).Marshal()
 	expectedAttestation.Signature = sig
 
 	if !proto.Equal(generatedAttestation, expectedAttestation) {
@@ -199,7 +201,7 @@ func TestAttestToBlockHead_DoesNotAttestBeforeDelay(t *testing.T) {
 	).Return(&pb.AttestResponse{}, nil /* error */).Times(0)
 
 	timer := time.NewTimer(time.Duration(1 * time.Second))
-	go validator.AttestToBlockHead(context.Background(), 0, validatorPubKey)
+	go validator.AttestToBlockHead(context.Background(), 0, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 	<-timer.C
 }
 
@@ -252,7 +254,7 @@ func TestAttestToBlockHead_DoesAttestAfterDelay(t *testing.T) {
 		gomock.Any(),
 	).Return(&pb.AttestResponse{}, nil).Times(1)
 
-	validator.AttestToBlockHead(context.Background(), 0, validatorPubKey)
+	validator.AttestToBlockHead(context.Background(), 0, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 }
 
 func TestAttestToBlockHead_CorrectBitfieldLength(t *testing.T) {
@@ -294,7 +296,7 @@ func TestAttestToBlockHead_CorrectBitfieldLength(t *testing.T) {
 		generatedAttestation = att
 	}).Return(&pb.AttestResponse{}, nil /* error */)
 
-	validator.AttestToBlockHead(context.Background(), 30, validatorPubKey)
+	validator.AttestToBlockHead(context.Background(), 30, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 
 	if len(generatedAttestation.AggregationBits) != 2 {
 		t.Errorf("Wanted length %d, received %d", 2, len(generatedAttestation.AggregationBits))

--- a/validator/client/validator_propose.go
+++ b/validator/client/validator_propose.go
@@ -19,7 +19,7 @@ import (
 // chain node to construct the new block. The new block is then processed with
 // the state root computation, and finally signed by the validator before being
 // sent back to the beacon node for broadcasting.
-func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]byte) {
+func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pk string) {
 	if slot == 0 {
 		log.Info("Assigned to genesis slot, skipping proposal")
 		return
@@ -27,8 +27,9 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 	ctx, span := trace.StartSpan(ctx, "validator.ProposeBlock")
 	defer span.End()
 
-	span.AddAttributes(trace.StringAttribute("validator", fmt.Sprintf("%#x", pubKey)))
-	log := log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKey[:])))
+	tpk := v.keys[pk].PublicKey.Marshal()
+	span.AddAttributes(trace.StringAttribute("validator", fmt.Sprintf("%#x", tpk)))
+	log := log.WithField("pubKey", fmt.Sprintf("%#x", tpk[:8]))
 
 	epoch := slot / params.BeaconConfig().SlotsPerEpoch
 	domain, err := v.validatorClient.DomainData(ctx, &pb.DomainRequest{Epoch: epoch, Domain: params.BeaconConfig().DomainRandao})
@@ -38,7 +39,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 	}
 	buf := make([]byte, 32)
 	binary.LittleEndian.PutUint64(buf, epoch)
-	randaoReveal := v.keys[pubKey].SecretKey.Sign(buf, domain.SignatureDomain)
+	randaoReveal := v.keys[pk].SecretKey.Sign(buf, domain.SignatureDomain)
 
 	b, err := v.proposerClient.RequestBlock(ctx, &pb.BlockRequest{
 		Slot:         slot,
@@ -59,7 +60,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 		log.WithError(err).Error("Failed to sign block")
 		return
 	}
-	signature := v.keys[pubKey].SecretKey.Sign(root[:], domain.SignatureDomain)
+	signature := v.keys[pk].SecretKey.Sign(root[:], domain.SignatureDomain)
 	b.Signature = signature.Marshal()
 
 	// Broadcast network the signed block via beacon chain node.

--- a/validator/client/validator_propose_test.go
+++ b/validator/client/validator_propose_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"testing"
 
@@ -40,7 +41,7 @@ func TestProposeBlock_DoesNotProposeGenesisBlock(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validator, _, finish := setup(t)
 	defer finish()
-	validator.ProposeBlock(context.Background(), 0, validatorPubKey)
+	validator.ProposeBlock(context.Background(), 0, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 
 	testutil.AssertLogsContain(t, hook, "Assigned to genesis slot, skipping proposal")
 }
@@ -55,7 +56,7 @@ func TestProposeBlock_DomainDataFailed(t *testing.T) {
 		gomock.Any(), // epoch
 	).Return(nil /*response*/, errors.New("uh oh"))
 
-	validator.ProposeBlock(context.Background(), 1, validatorPubKey)
+	validator.ProposeBlock(context.Background(), 1, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 	testutil.AssertLogsContain(t, hook, "Failed to get domain data from beacon node")
 }
 
@@ -74,7 +75,7 @@ func TestProposeBlock_RequestBlockFailed(t *testing.T) {
 		gomock.Any(), // block request
 	).Return(nil /*response*/, errors.New("uh oh"))
 
-	validator.ProposeBlock(context.Background(), 1, validatorPubKey)
+	validator.ProposeBlock(context.Background(), 1, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 	testutil.AssertLogsContain(t, hook, "Failed to request block from beacon node")
 }
 
@@ -103,7 +104,7 @@ func TestProposeBlock_ProposeBlockFailed(t *testing.T) {
 		gomock.AssignableToTypeOf(&ethpb.BeaconBlock{}),
 	).Return(nil /*response*/, errors.New("uh oh"))
 
-	validator.ProposeBlock(context.Background(), 1, validatorPubKey)
+	validator.ProposeBlock(context.Background(), 1, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 	testutil.AssertLogsContain(t, hook, "Failed to propose block")
 }
 
@@ -131,5 +132,5 @@ func TestProposeBlock_BroadcastsBlock(t *testing.T) {
 		gomock.AssignableToTypeOf(&ethpb.BeaconBlock{}),
 	).Return(&pb.ProposeResponse{}, nil /*error*/)
 
-	validator.ProposeBlock(context.Background(), 1, validatorPubKey)
+	validator.ProposeBlock(context.Background(), 1, hex.EncodeToString(validatorKey.PublicKey.Marshal()))
 }

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"io/ioutil"
 	"strings"
@@ -29,10 +30,10 @@ var _ = Validator(&validator{})
 
 const cancelledCtx = "context has been canceled"
 
-func publicKeys(keys map[[48]byte]*keystore.Key) [][]byte {
+func publicKeys(keys map[string]*keystore.Key) [][]byte {
 	pks := make([][]byte, 0, len(keys))
-	for key := range keys {
-		pks = append(pks, key[:])
+	for _, value := range keys {
+		pks = append(pks, value.PublicKey.Marshal())
 	}
 	return pks
 }
@@ -490,29 +491,29 @@ func TestRolesAt_OK(t *testing.T) {
 					Shard:      1,
 					Slot:       1,
 					IsProposer: true,
-					PublicKey:  []byte{0x01},
+					PublicKey:  []byte("pk1"),
 				},
 				{
 					Shard:     2,
 					Slot:      1,
-					PublicKey: []byte{0x02},
+					PublicKey: []byte("pk2"),
 				},
 				{
 					Shard:     1,
 					Slot:      2,
-					PublicKey: []byte{0x03},
+					PublicKey: []byte("pk3"),
 				},
 			},
 		},
 	}
 	roleMap := v.RolesAt(1)
-	if roleMap[[48]byte{0x01}] != pb.ValidatorRole_PROPOSER {
+	if roleMap[hex.EncodeToString([]byte("pk1"))] != pb.ValidatorRole_PROPOSER {
 		t.Errorf("Unexpected validator role. want: ValidatorRole_PROPOSER")
 	}
-	if roleMap[[48]byte{0x02}] != pb.ValidatorRole_ATTESTER {
+	if roleMap[hex.EncodeToString([]byte("pk2"))] != pb.ValidatorRole_ATTESTER {
 		t.Errorf("Unexpected validator role. want: ValidatorRole_ATTESTER")
 	}
-	if roleMap[[48]byte{0x03}] != pb.ValidatorRole_UNKNOWN {
+	if roleMap[hex.EncodeToString([]byte("pk3"))] != pb.ValidatorRole_UNKNOWN {
 		t.Errorf("Unexpected validator role. want: UNKNOWN")
 	}
 


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#3716

This broke validator client run time. Validators assignments are messed up. With this, all validators instances in the client all share one public key and one assignment. Looks like:
```
[2019-10-14 11:06:48]  INFO validator: New assignment attesterSlot=97 epoch=12 proposerSlot=N/A pubKey=0x80c04686c2b39760
[2019-10-14 11:06:48]  INFO validator: New assignment attesterSlot=97 epoch=12 proposerSlot=N/A pubKey=0x80c04686c2b39760
[2019-10-14 11:06:48]  INFO validator: New assignment attesterSlot=97 epoch=12 proposerSlot=N/A pubKey=0x80c04686c2b39760
[2019-10-14 11:06:48]  INFO validator: New assignment attesterSlot=97 epoch=12 proposerSlot=N/A pubKey=0x80c04686c2b39760
[2019-10-14 11:06:48]  INFO validator: New assignment attesterSlot=97 epoch=12 proposerSlot=N/A pubKey=0x80c04686c2b39760
[2019-10-14 11:06:48]  INFO validator: New assignment attesterSlot=97 epoch=12 proposerSlot=N/A pubKey=0x80c04686c2b39760
[2019-10-14 11:06:48]  INFO validator: New assignment attesterSlot=97 epoch=12 proposerSlot=N/A pubKey=0x80c04686c2b39760
[2019-10-14 11:06:48]  INFO validator: New assignment attesterSlot=97 epoch=12 proposerSlot=N/A pubKey=0x80c04686c2b39760
[2019-10-14 11:06:48]  INFO validator: New assignment attesterSlot=97 epoch=12 proposerSlot=N/A pubKey=0x80c04686c2b39760
[2019-10-14 11:06:48]  INFO validator: New assignment attesterSlot=97 epoch=12 proposerSlot=N/A pubKey=0x80c04686c2b39760
[2019-10-14 11:06:54]  INFO validator: Submitted new attestation headRoot=0x45f0c8c8efd6 pubKey=0x80c04686c2b3
```