### PR TITLE
Check attestations bitfield overlaps

### DIFF
--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -1331,20 +1331,7 @@ func TestProcessAggregatedAttestation_OverlappingBits(t *testing.T) {
 	}
 	att2.Signature = bls.AggregateSignatures(sigs).Marshal()[:]
 
-	aggregatedAtt, err := helpers.AggregateAttestation(att1, att2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	block := &ethpb.BeaconBlock{
-		Body: &ethpb.BeaconBlockBody{
-			Attestations: []*ethpb.Attestation{aggregatedAtt},
-		},
-	}
-
-	beaconState.Slot += params.BeaconConfig().MinAttestationInclusionDelay
-
-	wanted := "attestation aggregation signature did not verify"
-	if _, err := blocks.ProcessAttestations(context.Background(), beaconState, block.Body); !strings.Contains(err.Error(), wanted) {
+	if _, err = helpers.AggregateAttestation(att1, att2); err != helpers.ErrAttestationAggregationBitsOverlap {
 		t.Error("Did not receive wanted error")
 	}
 }

--- a/beacon-chain/core/helpers/attestation.go
+++ b/beacon-chain/core/helpers/attestation.go
@@ -17,6 +17,9 @@ var (
 	// ErrAttestationDataSlotNilData is returned when a nil attestation data
 	// argument is provided to AttestationDataSlot.
 	ErrAttestationDataSlotNilData = errors.New("nil data provided for AttestationDataSlot")
+	// ErrAttestationAggregationBitsOverlap is returned when two attestations aggregation
+	// bits overlap with each other.
+	ErrAttestationAggregationBitsOverlap = errors.New("overlapping aggregation bits")
 )
 
 // AttestationDataSlot returns current slot of AttestationData for given state
@@ -108,6 +111,10 @@ var signatureFromBytes = bls.SignatureFromBytes
 
 // AggregateAttestation aggregates attestations a1 and a2 together.
 func AggregateAttestation(a1 *ethpb.Attestation, a2 *ethpb.Attestation) (*ethpb.Attestation, error) {
+	if a1.AggregationBits.Overlaps(a2.AggregationBits) {
+		return nil, ErrAttestationAggregationBitsOverlap
+	}
+
 	baseAtt := proto.Clone(a1).(*ethpb.Attestation)
 	newAtt := proto.Clone(a2).(*ethpb.Attestation)
 	if newAtt.AggregationBits.Count() > baseAtt.AggregationBits.Count() {

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -118,6 +118,24 @@ func TestAggregateAttestation(t *testing.T) {
 	}
 }
 
+func TestAggregateAttestation_OverlapFails(t *testing.T) {
+	tests := []struct {
+		a1 *ethpb.Attestation
+		a2 *ethpb.Attestation
+	}{
+		{a1: &ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x1F}},
+			a2: &ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x11}}},
+		{a1: &ethpb.Attestation{AggregationBits: bitfield.Bitlist{0xFF, 0x85}},
+			a2: &ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x13, 0x8F}}},
+	}
+	for _, tt := range tests {
+		_, err := helpers.AggregateAttestation(tt.a1, tt.a2)
+		if err != helpers.ErrAttestationAggregationBitsOverlap {
+			t.Error("Did not receive wanted error")
+		}
+	}
+}
+
 func bitlistWithAllBitsSet(length uint64) bitfield.Bitlist {
 	b := bitfield.NewBitlist(length)
 	for i := uint64(0); i < length; i++ {


### PR DESCRIPTION
Returns error `ErrAttestationAggregationBitsOverlap` if two attestations bitfields overlap each other