### PR TITLE
Generate keys in test

### DIFF
--- a/tools/unencrypted-keys-gen/main_test.go
+++ b/tools/unencrypted-keys-gen/main_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestSavesUnencryptedKeys(t *testing.T) {
+	keys := 2
+	numKeys = &keys
 	ctnr := generateUnencryptedKeys(0 /* start index */)
 	buf := new(bytes.Buffer)
 	if err := SaveUnencryptedKeysToFile(buf, ctnr); err != nil {


### PR DESCRIPTION
The test for the generate-unencrypted-keys tool doesn't generate any keys in its test.  This adds keys to the test to make it more realistic.

This also pre-emptively stops the test failing when it passed 0 to `interop.DeterministicallyGenerateKeys()`, which is required for a future PR.