### PR TITLE
Do not use mutliple read locks

### DIFF
--- a/beacon-chain/sync/peerstatus/peer_statuses.go
+++ b/beacon-chain/sync/peerstatus/peer_statuses.go
@@ -49,7 +49,7 @@ func Count() int {
 func Keys() []peer.ID {
 	lock.RLock()
 	defer lock.RUnlock()
-	keys := make([]peer.ID, 0, Count())
+	keys := make([]peer.ID, 0, len(peerStatuses))
 	for k := range peerStatuses {
 		keys = append(keys, k)
 	}


### PR DESCRIPTION
`Count()` tries to secure another RLock when we already had one, to read the length of the map.

This might be causing goroutine issues and/or deadlocking 