### PR TITLE
Add State Batch Delete for DB

### DIFF
--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -54,6 +54,8 @@ type Database interface {
 	HeadState(ctx context.Context) (*pb.BeaconState, error)
 	GenesisState(ctx context.Context) (*pb.BeaconState, error)
 	SaveState(ctx context.Context, state *pb.BeaconState, blockRoot [32]byte) error
+	DeleteState(ctx context.Context, blockRoot [32]byte) error
+	DeleteStates(ctx context.Context, blockRoots [][32]byte)
 	// Slashing operations.
 	ProposerSlashing(ctx context.Context, slashingRoot [32]byte) (*ethpb.ProposerSlashing, error)
 	AttesterSlashing(ctx context.Context, slashingRoot [32]byte) (*ethpb.AttesterSlashing, error)

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -55,7 +55,7 @@ type Database interface {
 	GenesisState(ctx context.Context) (*pb.BeaconState, error)
 	SaveState(ctx context.Context, state *pb.BeaconState, blockRoot [32]byte) error
 	DeleteState(ctx context.Context, blockRoot [32]byte) error
-	DeleteStates(ctx context.Context, blockRoots [][32]byte)
+	DeleteStates(ctx context.Context, blockRoots [][32]byte) error
 	// Slashing operations.
 	ProposerSlashing(ctx context.Context, slashingRoot [32]byte) (*ethpb.ProposerSlashing, error)
 	AttesterSlashing(ctx context.Context, slashingRoot [32]byte) (*ethpb.AttesterSlashing, error)

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -110,7 +110,7 @@ func (k *Store) DeleteState(ctx context.Context, blockRoot [32]byte) error {
 	})
 }
 
-// DeleteStatesby block roots.
+// DeleteStates by block roots.
 func (k *Store) DeleteStates(ctx context.Context, blockRoots [][32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteStates")
 	defer span.End()

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -5,7 +5,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/prysmaticlabs/go-ssz"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 )
 
 func TestState_CanSaveRetrieve(t *testing.T) {
@@ -111,5 +113,52 @@ func TestGenesisState_CanSaveRetrieve(t *testing.T) {
 
 	if savedGenesisS != nil {
 		t.Error("unsaved genesis state should've been nil")
+	}
+}
+
+func TestStore_StatesBatchDelete(t *testing.T) {
+	db := setupDB(t)
+	defer teardownDB(t, db)
+	ctx := context.Background()
+	numBlocks := 100
+	totalBlocks := make([]*ethpb.BeaconBlock, numBlocks)
+	blockRoots := make([][32]byte, 0)
+	evenBlockRoots := make([][32]byte, 0)
+	for i := 0; i < len(totalBlocks); i++ {
+		totalBlocks[i] = &ethpb.BeaconBlock{
+			Slot:       uint64(i),
+			ParentRoot: []byte("parent"),
+		}
+		r, err := ssz.SigningRoot(totalBlocks[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := db.SaveState(context.Background(), &pb.BeaconState{Slot:uint64(i)}, r); err != nil {
+			t.Fatal(err)
+		}
+		blockRoots = append(blockRoots, r)
+		if i%2 == 0 {
+			evenBlockRoots = append(evenBlockRoots, r)
+		}
+	}
+	if err := db.SaveBlocks(ctx, totalBlocks); err != nil {
+		t.Fatal(err)
+	}
+	// We delete all even indexed states.
+	if err := db.DeleteStates(ctx, evenBlockRoots); err != nil {
+		t.Fatal(err)
+	}
+	// When we retrieve the data, only the odd indexed state should remain.
+	for _, r := range blockRoots {
+		s, err := db.State(context.Background(), r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if s == nil {
+			continue
+		}
+		if s.Slot%2 == 0 {
+			t.Errorf("State with slot %d should have been deleted", s.Slot)
+		}
 	}
 }


### PR DESCRIPTION
This PR adds functions to batch delete in DB. This will be used for pruning beacon state stored in DB prior to finalized check point