### PR TITLE
Revert "Fix Round Robin Test"

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -70,18 +70,9 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 				if ctx.Err() != nil {
 					return nil, ctx.Err()
 				}
-
-				originalStart := start
-				originalCount := count
 				start := start + uint64(i)*step
 				step := step * uint64(len(peers))
-				count := mathutil.Min(count, (helpers.StartSlot(finalizedEpoch+1)-originalStart)/step)
-				// If there is only 1 peer left, rather than further minimising the count in the situation
-				// of a large step value. we remove the variable entirely. This also handles the case if
-				// there is only 1 peer overall(step = 1).
-				if len(peers) == 1 {
-					count = mathutil.Min(originalCount, helpers.StartSlot(finalizedEpoch+1)-originalStart)
-				}
+				count := mathutil.Min(count, (helpers.StartSlot(finalizedEpoch+1)-start)/step)
 				// If the count was divided by an odd number of peers, there will be some blocks
 				// missing from the first requests so we accommodate that scenario.
 				if i < remainder {

--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -136,36 +136,37 @@ func TestRoundRobinSync(t *testing.T) {
 			},
 		},
 
-		{
-			name:               "Multiple peers with multiple failures",
-			currentSlot:        320, // 5 epochs
-			expectedBlockSlots: makeSequence(1, 320),
-			peers: []*peerData{
-				{
-					blocks:         makeSequence(1, 320),
-					finalizedEpoch: 4,
-					headSlot:       320,
-				},
-				{
-					blocks:         makeSequence(1, 320),
-					finalizedEpoch: 4,
-					headSlot:       320,
-					failureSlots:   makeSequence(1, 320),
-				},
-				{
-					blocks:         makeSequence(1, 320),
-					finalizedEpoch: 4,
-					headSlot:       320,
-					failureSlots:   makeSequence(1, 320),
-				},
-				{
-					blocks:         makeSequence(1, 320),
-					finalizedEpoch: 4,
-					headSlot:       320,
-					failureSlots:   makeSequence(1, 320),
-				},
-			},
-		},
+		// TODO(3147): Handle multiple failures.
+		//{
+		//	name:               "Multiple peers with multiple failures",
+		//	currentSlot:        320, // 5 epochs
+		//	expectedBlockSlots: makeSequence(1, 320),
+		//	peers: []*peerData{
+		//		{
+		//			blocks:         makeSequence(1, 320),
+		//			finalizedEpoch: 4,
+		//			headSlot:       320,
+		//		},
+		//		{
+		//			blocks:         makeSequence(1, 320),
+		//			finalizedEpoch: 4,
+		//			headSlot:       320,
+		//			failureSlots:   makeSequence(1, 320),
+		//		},
+		//		{
+		//			blocks:         makeSequence(1, 320),
+		//			finalizedEpoch: 4,
+		//			headSlot:       320,
+		//			failureSlots:   makeSequence(1, 320),
+		//		},
+		//		{
+		//			blocks:         makeSequence(1, 320),
+		//			finalizedEpoch: 4,
+		//			headSlot:       320,
+		//			failureSlots:   makeSequence(1, 320),
+		//		},
+		//	},
+		//},
 		{
 			name:               "Multiple peers with different finalized epoch",
 			currentSlot:        320, // 5 epochs


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#3775

This is often causing peers to get spammed with erroneous ranges in the hundreds of thousands or millions. This issue is worse than missing blocks in multiple failure conditions. 