### PR TITLE
Delete DB states older than finalized checkpoint

### DIFF
--- a/beacon-chain/blockchain/forkchoice/service.go
+++ b/beacon-chain/blockchain/forkchoice/service.go
@@ -222,22 +222,22 @@ func (s *Store) Head(ctx context.Context) ([]byte, error) {
 
 		// if a block has one child, then we don't have to lookup anything to
 		// know that this child will be the best child.
-		head = children[0]
+		head = children[0][:]
 		if len(children) > 1 {
 			highest, err := s.latestAttestingBalance(ctx, head)
 			if err != nil {
 				return nil, errors.Wrap(err, "could not get latest balance")
 			}
 			for _, child := range children[1:] {
-				balance, err := s.latestAttestingBalance(ctx, child)
+				balance, err := s.latestAttestingBalance(ctx, child[:])
 				if err != nil {
 					return nil, errors.Wrap(err, "could not get latest balance")
 				}
 				// When there's a tie, it's broken lexicographically to favor the higher one.
 				if balance > highest ||
-					balance == highest && bytes.Compare(child, head) > 0 {
+					balance == highest && bytes.Compare(child[:], head) > 0 {
 					highest = balance
-					head = child
+					head = child[:]
 				}
 			}
 		}

--- a/beacon-chain/db/db.go
+++ b/beacon-chain/db/db.go
@@ -31,7 +31,7 @@ type Database interface {
 	Block(ctx context.Context, blockRoot [32]byte) (*ethpb.BeaconBlock, error)
 	HeadBlock(ctx context.Context) (*ethpb.BeaconBlock, error)
 	Blocks(ctx context.Context, f *filters.QueryFilter) ([]*ethpb.BeaconBlock, error)
-	BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][]byte, error)
+	BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][32]byte, error)
 	HasBlock(ctx context.Context, blockRoot [32]byte) bool
 	DeleteBlock(ctx context.Context, blockRoot [32]byte) error
 	DeleteBlocks(ctx context.Context, blockRoots [][32]byte) error

--- a/beacon-chain/db/kv/BUILD.bazel
+++ b/beacon-chain/db/kv/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//proto/beacon/db:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
+        "//shared/bytesutil:go_default_library",
         "//shared/sliceutil:go_default_library",
         "//shared/traceutil:go_default_library",
         "@com_github_boltdb_bolt//:go_default_library",

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
 	"go.opencensus.io/trace"
 )
@@ -123,10 +124,10 @@ func (k *Store) Blocks(ctx context.Context, f *filters.QueryFilter) ([]*ethpb.Be
 }
 
 // BlockRoots retrieves a list of beacon block roots by filter criteria.
-func (k *Store) BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][]byte, error) {
+func (k *Store) BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][32]byte, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.BlockRoots")
 	defer span.End()
-	blockRoots := make([][]byte, 0)
+	blockRoots := make([][32]byte, 0)
 	err := k.db.View(func(tx *bolt.Tx) error {
 		// If no filter criteria are specified, return an error.
 		if f == nil {
@@ -168,7 +169,7 @@ func (k *Store) BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][]byt
 			}
 		}
 		for i := 0; i < len(keys); i++ {
-			blockRoots = append(blockRoots, keys[i])
+			blockRoots = append(blockRoots, bytesutil.ToBytes32(keys[i]))
 		}
 		return nil
 	})

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -133,7 +133,7 @@ func TestStore_StatesBatchDelete(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := db.SaveState(context.Background(), &pb.BeaconState{Slot:uint64(i)}, r); err != nil {
+		if err := db.SaveState(context.Background(), &pb.BeaconState{Slot: uint64(i)}, r); err != nil {
 			t.Fatal(err)
 		}
 		blockRoots = append(blockRoots, r)

--- a/beacon-chain/gateway/gateway.go
+++ b/beacon-chain/gateway/gateway.go
@@ -8,10 +8,10 @@ import (
 	"time"
 
 	gwruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1_gateway"
 	"github.com/prysmaticlabs/prysm/shared"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
-	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1_gateway"
 )
 
 var _ = shared.Service(&Gateway{})


### PR DESCRIPTION
This PR implements the deletion of beacon states in DB that's older than finalized check point. The deletion happens when a new finalized check point occurs