### PR TITLE
Guard against deleting genesis and finalized state in DB

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -384,7 +384,7 @@ func (s *Store) rmStatesBySlots(ctx context.Context, startSlot uint64, endSlot u
 
 	// Do not remove genesis state and epoch boundary state.
 	if startSlot%params.BeaconConfig().SlotsPerEpoch == 0 {
-		startSlot += 1
+		startSlot++
 	}
 
 	filter := filters.NewFilter().SetStartSlot(startSlot).SetEndSlot(endSlot)

--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -382,6 +382,11 @@ func (s *Store) rmStatesBySlots(ctx context.Context, startSlot uint64, endSlot u
 	ctx, span := trace.StartSpan(ctx, "forkchoice.rmStatesBySlots")
 	defer span.End()
 
+	// Do not remove genesis state and epoch boundary state.
+	if startSlot%params.BeaconConfig().SlotsPerEpoch == 0 {
+		startSlot++
+	}
+
 	filter := filters.NewFilter().SetStartSlot(startSlot).SetEndSlot(endSlot)
 	roots, err := s.db.BlockRoots(ctx, filter)
 	if err != nil {

--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -107,7 +107,7 @@ func (s *Store) OnBlock(ctx context.Context, b *ethpb.BeaconBlock) error {
 
 		startSlot := helpers.StartSlot(s.finalizedCheckpt.Epoch + 1)
 		endSlot := helpers.StartSlot(postState.FinalizedCheckpoint.Epoch+1) - 1 // Inclusive
-		if err := s.rmStatesBySlots(ctx, startSlot, endSlot); err != nil {
+		if err := s.rmStatesSinceLastFinalized(ctx, startSlot, endSlot); err != nil {
 			return errors.Wrapf(err, "could not delete states prior to finalized check point, range: %d, %d",
 				startSlot, endSlot+params.BeaconConfig().SlotsPerEpoch)
 		}
@@ -187,7 +187,7 @@ func (s *Store) OnBlockNoVerifyStateTransition(ctx context.Context, b *ethpb.Bea
 		helpers.ClearAllCaches()
 		startSlot := helpers.StartSlot(s.finalizedCheckpt.Epoch + 1)
 		endSlot := helpers.StartSlot(postState.FinalizedCheckpoint.Epoch+1) - 1 // Inclusive
-		if err := s.rmStatesBySlots(ctx, startSlot, endSlot); err != nil {
+		if err := s.rmStatesSinceLastFinalized(ctx, startSlot, endSlot); err != nil {
 			return errors.Wrapf(err, "could not delete states prior to finalized check point, range: %d, %d",
 				startSlot, endSlot+params.BeaconConfig().SlotsPerEpoch)
 		}
@@ -377,12 +377,12 @@ func (s *Store) clearSeenAtts() {
 	s.seenAtts = make(map[[32]byte]bool)
 }
 
-// rmStatesBySlots deletes the states in db in between the range of slots.
-func (s *Store) rmStatesBySlots(ctx context.Context, startSlot uint64, endSlot uint64) error {
+// rmStatesSinceLastFinalized deletes the states in db since last finalized check point.
+func (s *Store) rmStatesSinceLastFinalized(ctx context.Context, startSlot uint64, endSlot uint64) error {
 	ctx, span := trace.StartSpan(ctx, "forkchoice.rmStatesBySlots")
 	defer span.End()
 
-	// Do not remove genesis state and epoch boundary state.
+	// Do not remove genesis state or finalized state at epoch boundary.
 	if startSlot%params.BeaconConfig().SlotsPerEpoch == 0 {
 		startSlot++
 	}

--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -107,7 +107,7 @@ func (s *Store) OnBlock(ctx context.Context, b *ethpb.BeaconBlock) error {
 
 		startSlot := helpers.StartSlot(s.finalizedCheckpt.Epoch + 1)
 		endSlot := helpers.StartSlot(postState.FinalizedCheckpoint.Epoch+1) - 1 // Inclusive
-		if err := s.rmStatesSinceLastFinalized(ctx, startSlot, endSlot); err != nil {
+		if err := s.rmStatesOlderThanLastFinalized(ctx, startSlot, endSlot); err != nil {
 			return errors.Wrapf(err, "could not delete states prior to finalized check point, range: %d, %d",
 				startSlot, endSlot+params.BeaconConfig().SlotsPerEpoch)
 		}
@@ -187,7 +187,7 @@ func (s *Store) OnBlockNoVerifyStateTransition(ctx context.Context, b *ethpb.Bea
 		helpers.ClearAllCaches()
 		startSlot := helpers.StartSlot(s.finalizedCheckpt.Epoch + 1)
 		endSlot := helpers.StartSlot(postState.FinalizedCheckpoint.Epoch+1) - 1 // Inclusive
-		if err := s.rmStatesSinceLastFinalized(ctx, startSlot, endSlot); err != nil {
+		if err := s.rmStatesOlderThanLastFinalized(ctx, startSlot, endSlot); err != nil {
 			return errors.Wrapf(err, "could not delete states prior to finalized check point, range: %d, %d",
 				startSlot, endSlot+params.BeaconConfig().SlotsPerEpoch)
 		}
@@ -377,8 +377,8 @@ func (s *Store) clearSeenAtts() {
 	s.seenAtts = make(map[[32]byte]bool)
 }
 
-// rmStatesSinceLastFinalized deletes the states in db since last finalized check point.
-func (s *Store) rmStatesSinceLastFinalized(ctx context.Context, startSlot uint64, endSlot uint64) error {
+// rmStatesOlderThanLastFinalized deletes the states in db since last finalized check point.
+func (s *Store) rmStatesOlderThanLastFinalized(ctx context.Context, startSlot uint64, endSlot uint64) error {
 	ctx, span := trace.StartSpan(ctx, "forkchoice.rmStatesBySlots")
 	defer span.End()
 

--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -382,11 +382,6 @@ func (s *Store) rmStatesBySlots(ctx context.Context, startSlot uint64, endSlot u
 	ctx, span := trace.StartSpan(ctx, "forkchoice.rmStatesBySlots")
 	defer span.End()
 
-	// Do not remove genesis state and epoch boundary state.
-	if startSlot%params.BeaconConfig().SlotsPerEpoch == 0 {
-		startSlot++
-	}
-
 	filter := filters.NewFilter().SetStartSlot(startSlot).SetEndSlot(endSlot)
 	roots, err := s.db.BlockRoots(ctx, filter)
 	if err != nil {

--- a/beacon-chain/blockchain/forkchoice/process_block_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_block_test.go
@@ -334,9 +334,12 @@ func TestRemoveStateBySlots(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Also verifies genesis state didnt get deleted
-		if s != nil && s.Slot != 0 && s.Slot < endSlot {
-			t.Errorf("State with slot %d should not be in DB", s.Slot)
+		// Also verifies boundary state didnt get deleted
+		if s != nil {
+			isBoundary := s.Slot%params.BeaconConfig().SlotsPerEpoch == 0
+			if !isBoundary && s.Slot < endSlot {
+				t.Errorf("State with slot %d should not be in DB", s.Slot)
+			}
 		}
 	}
 }

--- a/beacon-chain/blockchain/forkchoice/process_block_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_block_test.go
@@ -276,7 +276,7 @@ func TestStore_SavesNewBlockAttestations(t *testing.T) {
 	}
 }
 
-func TestRemoveStateBySlots(t *testing.T) {
+func TestRemoveStateSinceLastFinalized(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
 	defer testDB.TeardownDB(t, db)
@@ -309,7 +309,7 @@ func TestRemoveStateBySlots(t *testing.T) {
 	// New finalized epoch: 1
 	finalizedEpoch := uint64(1)
 	endSlot := helpers.StartSlot(finalizedEpoch+1) - 1 // Inclusive
-	if err := store.rmStatesBySlots(ctx, 0, endSlot); err != nil {
+	if err := store.rmStatesSinceLastFinalized(ctx, 0, endSlot); err != nil {
 		t.Fatal(err)
 	}
 	for _, r := range blockRoots {
@@ -326,7 +326,7 @@ func TestRemoveStateBySlots(t *testing.T) {
 	// New finalized epoch: 5
 	newFinalizedEpoch := uint64(5)
 	endSlot = helpers.StartSlot(newFinalizedEpoch+1) - 1 // Inclusive
-	if err := store.rmStatesBySlots(ctx, helpers.StartSlot(finalizedEpoch+1), endSlot); err != nil {
+	if err := store.rmStatesSinceLastFinalized(ctx, helpers.StartSlot(finalizedEpoch+1), endSlot); err != nil {
 		t.Fatal(err)
 	}
 	for _, r := range blockRoots {

--- a/beacon-chain/blockchain/forkchoice/process_block_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_block_test.go
@@ -309,7 +309,7 @@ func TestRemoveStateSinceLastFinalized(t *testing.T) {
 	// New finalized epoch: 1
 	finalizedEpoch := uint64(1)
 	endSlot := helpers.StartSlot(finalizedEpoch+1) - 1 // Inclusive
-	if err := store.rmStatesSinceLastFinalized(ctx, 0, endSlot); err != nil {
+	if err := store.rmStatesOlderThanLastFinalized(ctx, 0, endSlot); err != nil {
 		t.Fatal(err)
 	}
 	for _, r := range blockRoots {
@@ -326,7 +326,7 @@ func TestRemoveStateSinceLastFinalized(t *testing.T) {
 	// New finalized epoch: 5
 	newFinalizedEpoch := uint64(5)
 	endSlot = helpers.StartSlot(newFinalizedEpoch+1) - 1 // Inclusive
-	if err := store.rmStatesSinceLastFinalized(ctx, helpers.StartSlot(finalizedEpoch+1), endSlot); err != nil {
+	if err := store.rmStatesOlderThanLastFinalized(ctx, helpers.StartSlot(finalizedEpoch+1), endSlot); err != nil {
 		t.Fatal(err)
 	}
 	for _, r := range blockRoots {

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -116,7 +116,7 @@ func (k *Store) DeleteState(ctx context.Context, blockRoot [32]byte) error {
 		genesisBlockRoot := bkt.Get(genesisBlockRootKey)
 		// Safe guard against deleting genesis or finalized state.
 		if bytes.Equal(blockRoot[:], finalizedCheckpt.Root) || bytes.Equal(blockRoot[:], genesisBlockRoot) {
-			return nil
+			return errors.New("could not delete genesis or finalized state")
 		}
 
 		bkt = tx.Bucket(stateBucket)

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -106,12 +106,12 @@ func (k *Store) DeleteState(ctx context.Context, blockRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteState")
 	defer span.End()
 
-	finalizedCheckpt, err := k.FinalizedCheckpoint(ctx)
-	if err != nil {
-		return err
-	}
-
 	return k.db.Batch(func(tx *bolt.Tx) error {
+		finalizedCheckpt, err := k.FinalizedCheckpoint(ctx)
+		if err != nil {
+			return err
+		}
+
 		bkt := tx.Bucket(blocksBucket)
 		genesisBlockRoot := bkt.Get(genesisBlockRootKey)
 		// Safe guard against deleting genesis or finalized state.

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -176,15 +176,9 @@ func TestStore_DeleteGenesisState(t *testing.T) {
 	if err := db.SaveState(ctx, genesisState, genesisBlockRoot); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.DeleteState(ctx, genesisBlockRoot); err != nil {
-		t.Fatal(err)
-	}
-	s, err := db.State(ctx, genesisBlockRoot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(s, genesisState) {
-		t.Error("Did not receive wanted genesis state")
+	wantedErr := "could not delete genesis or finalized state"
+	if err := db.DeleteState(ctx, genesisBlockRoot); err.Error() != wantedErr {
+		t.Error("Did not receive wanted error")
 	}
 }
 
@@ -202,14 +196,8 @@ func TestStore_DeleteFinalizedState(t *testing.T) {
 	if err := db.SaveState(ctx, finalizedState, finalizedBlockRoot); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.DeleteState(ctx, finalizedBlockRoot); err != nil {
-		t.Fatal(err)
-	}
-	s, err := db.State(ctx, finalizedBlockRoot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(s, finalizedState) {
-		t.Error("Did not receive wanted finalized state")
+	wantedErr := "could not delete genesis or finalized state"
+	if err := db.DeleteState(ctx, finalizedBlockRoot); err.Error() != wantedErr {
+		t.Error("Did not receive wanted error")
 	}
 }

--- a/tools/interop/export-genesis/main.go
+++ b/tools/interop/export-genesis/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 )
 
-
 // A basic tool to extract genesis.ssz from existing beaconchain.db.
 // ex:
 //   bazel run //tools/interop/export-genesis:export-genesis -- /tmp/data/beaconchaindata /tmp/genesis.ssz


### PR DESCRIPTION
Change list:
- Revert the order on `SaveFinalizedCheckpoint` and `rmStatesBySlots`
- Guard `DeleteState` against deleting genesis and finalized states


Resolves #3841