### PR TITLE
Require state to exist when updating finalized checkpoint

### DIFF
--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -358,13 +358,13 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 	headBlock := &ethpb.BeaconBlock{Slot: finalizedSlot}
 	headState := &pb.BeaconState{Slot: finalizedSlot}
 	headRoot, _ := ssz.SigningRoot(headBlock)
+	if err := db.SaveState(ctx, headState, headRoot); err != nil {
+		t.Fatal(err)
+	}
 	if err := db.SaveFinalizedCheckpoint(ctx, &ethpb.Checkpoint{
 		Epoch: helpers.SlotToEpoch(finalizedSlot),
 		Root:  headRoot[:],
 	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := db.SaveState(ctx, headState, headRoot); err != nil {
 		t.Fatal(err)
 	}
 	if err := db.SaveBlock(ctx, headBlock); err != nil {

--- a/beacon-chain/db/kv/BUILD.bazel
+++ b/beacon-chain/db/kv/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//beacon-chain/db/filters:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
+        "//shared/bytesutil:go_default_library",
         "//shared/testutil:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",

--- a/beacon-chain/db/kv/checkpoint.go
+++ b/beacon-chain/db/kv/checkpoint.go
@@ -79,6 +79,9 @@ func (k *Store) SaveFinalizedCheckpoint(ctx context.Context, checkpoint *ethpb.C
 	}
 	return k.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(checkpointBucket)
+		// The corresponding state must exist or there is a risk that the beacondb enters a state
+		// where the finalized beaconState is missing. This would be a fatal condition requiring
+		// a new sync from genesis.
 		if tx.Bucket(stateBucket).Get(checkpoint.Root) == nil {
 			traceutil.AnnotateError(span, errMissingStateForFinalizedCheckpoint)
 			return errMissingStateForFinalizedCheckpoint

--- a/beacon-chain/db/kv/checkpoint_test.go
+++ b/beacon-chain/db/kv/checkpoint_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 )
 
 func TestStore_JustifiedCheckpoint_CanSaveRetrieve(t *testing.T) {
@@ -34,9 +36,15 @@ func TestStore_FinalizedCheckpoint_CanSaveRetrieve(t *testing.T) {
 	db := setupDB(t)
 	defer teardownDB(t, db)
 	ctx := context.Background()
+	root := bytesutil.ToBytes32([]byte{'B'})
 	cp := &ethpb.Checkpoint{
 		Epoch: 5,
-		Root:  []byte{'B'},
+		Root:  root[:],
+	}
+
+	// a state is required to save checkpoint
+	if err := db.SaveState(ctx, &pb.BeaconState{}, root); err != nil {
+		t.Fatal(err)
 	}
 
 	if err := db.SaveFinalizedCheckpoint(ctx, cp); err != nil {
@@ -89,5 +97,19 @@ func TestStore_FinalizedCheckpoint_DefaultCantBeNil(t *testing.T) {
 	}
 	if !proto.Equal(cp, retrieved) {
 		t.Errorf("Wanted %v, received %v", cp, retrieved)
+	}
+}
+
+func TestStore_FinalizedCheckpoint_StateMustExist(t *testing.T) {
+	db := setupDB(t)
+	defer teardownDB(t, db)
+	ctx := context.Background()
+	cp := &ethpb.Checkpoint{
+		Epoch: 5,
+		Root:  []byte{'B'},
+	}
+
+	if err := db.SaveFinalizedCheckpoint(ctx, cp);  err != errMissingStateForFinalizedCheckpoint {
+		t.Fatalf("wanted err %v, got %v", errMissingStateForFinalizedCheckpoint, err)
 	}
 }

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -188,12 +188,12 @@ func TestStore_DeleteFinalizedState(t *testing.T) {
 	ctx := context.Background()
 
 	finalizedBlockRoot := [32]byte{'A'}
-	finalizedCheckpoint := &ethpb.Checkpoint{Root: finalizedBlockRoot[:]}
-	if err := db.SaveFinalizedCheckpoint(ctx, finalizedCheckpoint); err != nil {
-		t.Fatal(err)
-	}
 	finalizedState := &pb.BeaconState{Slot: 100}
 	if err := db.SaveState(ctx, finalizedState, finalizedBlockRoot); err != nil {
+		t.Fatal(err)
+	}
+	finalizedCheckpoint := &ethpb.Checkpoint{Root: finalizedBlockRoot[:]}
+	if err := db.SaveFinalizedCheckpoint(ctx, finalizedCheckpoint); err != nil {
 		t.Fatal(err)
 	}
 	wantedErr := "could not delete genesis or finalized state"


### PR DESCRIPTION
Part of prevention for #3841.

The database must have the finalized state before updating the finalized checkpoint. 