### PR TITLE
Fix pruning finalized state

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_block_test.go
@@ -315,8 +315,9 @@ func TestRemoveStateSinceLastFinalized(t *testing.T) {
 
 	// New finalized epoch: 1
 	finalizedEpoch := uint64(1)
+	finalizedSlot := finalizedEpoch * params.BeaconConfig().SlotsPerEpoch
 	endSlot := helpers.StartSlot(finalizedEpoch+1) - 1 // Inclusive
-	if err := store.rmStatesOlderThanLastFinalized(ctx, 0, endSlot); err != nil {
+	if err := store.rmStatesOlderThanLastFinalized(ctx, 0, finalizedSlot, endSlot); err != nil {
 		t.Fatal(err)
 	}
 	for _, r := range blockRoots {
@@ -325,15 +326,16 @@ func TestRemoveStateSinceLastFinalized(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Also verifies genesis state didnt get deleted
-		if s != nil && s.Slot != 0 && s.Slot < endSlot {
+		if s != nil && s.Slot != finalizedSlot && s.Slot != 0 && s.Slot < endSlot {
 			t.Errorf("State with slot %d should not be in DB", s.Slot)
 		}
 	}
 
 	// New finalized epoch: 5
 	newFinalizedEpoch := uint64(5)
+	newFinalizedSlot := newFinalizedEpoch * params.BeaconConfig().SlotsPerEpoch
 	endSlot = helpers.StartSlot(newFinalizedEpoch+1) - 1 // Inclusive
-	if err := store.rmStatesOlderThanLastFinalized(ctx, helpers.StartSlot(finalizedEpoch+1), endSlot); err != nil {
+	if err := store.rmStatesOlderThanLastFinalized(ctx, helpers.StartSlot(finalizedEpoch+1), newFinalizedSlot, endSlot); err != nil {
 		t.Fatal(err)
 	}
 	for _, r := range blockRoots {
@@ -341,12 +343,18 @@ func TestRemoveStateSinceLastFinalized(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Also verifies boundary state didnt get deleted
-		if s != nil {
-			isBoundary := s.Slot%params.BeaconConfig().SlotsPerEpoch == 0
-			if !isBoundary && s.Slot < endSlot {
-				t.Errorf("State with slot %d should not be in DB", s.Slot)
-			}
+		// Also verifies genesis state didnt get deleted
+		if s != nil && s.Slot != newFinalizedSlot && s.Slot != finalizedSlot && s.Slot != 0 && s.Slot < endSlot {
+			t.Errorf("State with slot %d should not be in DB", s.Slot)
 		}
+	}
+
+	// Verify finalized state did not get deleted
+	s, err := store.db.State(ctx, blockRoots[newFinalizedSlot])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s == nil {
+		t.Error("Finalized state got deleted")
 	}
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -58,7 +58,7 @@ var (
 		Usage: "Process epoch with optimizations",
 	}
 	pruneFinalizedStatesFlag = cli.BoolFlag{
-		Name: "prune-finalized-states",
+		Name:  "prune-finalized-states",
 		Usage: "Delete old states from the database after reaching new finalized checkpoint",
 	}
 )


### PR DESCRIPTION
We saw the following error: 
```
could not process block from fork choice service: could not save finalized checkpoint: no state exists with checkpoint root
```

This was due to incorrect pruning. We did not consider the edge case where `StartSlot` is not the same as `FinalizedSlot`. Example:
```
FinalizedEpoch:1, StartSlot: 8, EndSlot: 15 (Works!)
NewFinalizedEpoch:5, StartSlot: 16, EndSlot: 47 (Doesn't work! 40 gets deleted)

Instead we should delete them in pair:
NewFinalizedEpoch:5, (StartSlot: 16, EndSlot: 39), (StartSlot: 41 EndSlot: 47) 
```