### PR TITLE
Use Compute Domain Instead of Get Domain

### DIFF
--- a/beacon-chain/powchain/deposit.go
+++ b/beacon-chain/powchain/deposit.go
@@ -29,7 +29,7 @@ func (s *Service) processDeposit(
 		if err != nil {
 			return errors.Wrap(err, "could not deserialize validator public key")
 		}
-		domain := bls.Domain(params.BeaconConfig().DomainDeposit, params.BeaconConfig().GenesisForkVersion)
+		domain := bls.ComputeDomain(params.BeaconConfig().DomainDeposit)
 		sig, err := bls.SignatureFromBytes(deposit.Data.Signature)
 		if err != nil {
 			return errors.Wrap(err, "could not convert bytes to signature")

--- a/beacon-chain/powchain/deposit_test.go
+++ b/beacon-chain/powchain/deposit_test.go
@@ -202,7 +202,7 @@ func TestProcessDeposit_UnableToVerify(t *testing.T) {
 	testutil.ResetCache()
 
 	deposits, _, keys := testutil.SetupInitialDeposits(t, 1)
-	sig := keys[0].Sign([]byte{'F', 'A', 'K', 'E'}, bls.Domain(params.BeaconConfig().DomainDeposit, params.BeaconConfig().GenesisForkVersion))
+	sig := keys[0].Sign([]byte{'F', 'A', 'K', 'E'}, bls.ComputeDomain(params.BeaconConfig().DomainDeposit))
 	deposits[0].Data.Signature = sig.Marshal()[:]
 	eth1Data := testutil.GenerateEth1Data(t, deposits)
 
@@ -250,7 +250,7 @@ func TestProcessDeposit_IncompleteDeposit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sig := sk.Sign(signedRoot[:], bls.Domain(params.BeaconConfig().DomainDeposit, params.BeaconConfig().GenesisForkVersion))
+	sig := sk.Sign(signedRoot[:], bls.ComputeDomain(params.BeaconConfig().DomainDeposit))
 	deposit.Data.Signature = sig.Marshal()
 
 	_, root := testutil.GenerateDepositProof(t, []*ethpb.Deposit{deposit})

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -933,7 +933,7 @@ func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	domain := bls.Domain(params.BeaconConfig().DomainDeposit, params.BeaconConfig().GenesisForkVersion)
+	domain := bls.ComputeDomain(params.BeaconConfig().DomainDeposit)
 	depData.Signature = priv1.Sign(signingRoot[:], domain).Marshal()[:]
 
 	deposit := &ethpb.Deposit{

--- a/shared/bls/BUILD.bazel
+++ b/shared/bls/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//shared/bytesutil:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
+        "//shared/params:go_default_library",
         "@com_github_karlseguin_ccache//:go_default_library",
         "@com_github_kilic_bls12-381//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
+	"github.com/prysmaticlabs/prysm/shared/params"
 
 	bls12 "github.com/kilic/bls12-381"
 )
@@ -275,6 +276,19 @@ func Domain(domainType []byte, forkVersion []byte) uint64 {
 	b = append(b, domainType[:4]...)
 	b = append(b, forkVersion[:4]...)
 	return bytesutil.FromBytes8(b)
+}
+
+// ComputeDomain returns the domain version for BLS private key to sign and verify with a zeroed 4-byte
+// array as the fork version.
+//
+// def compute_domain(domain_type: DomainType, fork_version: Version=Version()) -> Domain:
+//    """
+//    Return the domain for the ``domain_type`` and ``fork_version``.
+//    """
+//    return Domain(domain_type + fork_version)
+func ComputeDomain(domainType []byte) uint64 {
+	// TODO(#3853): Hardcode the fork version to []byte{0,0,0,0}
+	return Domain(domainType, params.BeaconConfig().GenesisForkVersion)
 }
 
 // HashWithDomain hashes 32 byte message and uint64 domain parameters a Fp2 element

--- a/shared/bls/bls_test.go
+++ b/shared/bls/bls_test.go
@@ -82,3 +82,22 @@ func TestVerifyAggregate_ReturnsFalseOnEmptyPubKeyList(t *testing.T) {
 			"of public keys.")
 	}
 }
+
+func TestComputeDomain_OK(t *testing.T) {
+	tests := []struct {
+		epoch      uint64
+		domainType uint64
+		domain     uint64
+	}{
+		{epoch: 1, domainType: 4, domain: 4},
+		{epoch: 2, domainType: 4, domain: 4},
+		{epoch: 2, domainType: 5, domain: 5},
+		{epoch: 3, domainType: 4, domain: 4},
+		{epoch: 3, domainType: 5, domain: 5},
+	}
+	for _, tt := range tests {
+		if bls.ComputeDomain(bytesutil.Bytes4(tt.domainType)) != tt.domain {
+			t.Errorf("wanted domain version: %d, got: %d", tt.domain, bls.ComputeDomain(bytesutil.Bytes4(tt.domainType)))
+		}
+	}
+}

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -58,7 +58,7 @@ var (
 		Usage: "Process epoch with optimizations",
 	}
 	pruneFinalizedStatesFlag = cli.BoolFlag{
-		Name: "prune-finalized-states",
+		Name:  "prune-finalized-states",
 		Usage: "Delete old states from the database after reaching new finalized checkpoint",
 	}
 )

--- a/shared/interop/generate_genesis_state.go
+++ b/shared/interop/generate_genesis_state.go
@@ -102,7 +102,7 @@ func createDepositData(privKey *bls.SecretKey, pubKey *bls.PublicKey) (*ethpb.De
 	if err != nil {
 		return nil, err
 	}
-	domain := bls.Domain(params.BeaconConfig().DomainDeposit, params.BeaconConfig().GenesisForkVersion)
+	domain := bls.ComputeDomain(params.BeaconConfig().DomainDeposit)
 	di.Signature = privKey.Sign(sr[:], domain).Marshal()
 	return di, nil
 }

--- a/shared/keystore/deposit_input.go
+++ b/shared/keystore/deposit_input.go
@@ -34,7 +34,7 @@ func DepositInput(depositKey *Key, withdrawalKey *Key, amountInGwei uint64) (*et
 		return nil, err
 	}
 
-	domain := bls.Domain(params.BeaconConfig().DomainDeposit, params.BeaconConfig().GenesisForkVersion)
+	domain := bls.ComputeDomain(params.BeaconConfig().DomainDeposit)
 	di.Signature = depositKey.SecretKey.Sign(sr[:], domain).Marshal()
 
 	return di, nil

--- a/shared/testutil/helpers.go
+++ b/shared/testutil/helpers.go
@@ -67,7 +67,7 @@ func SetupInitialDeposits(t testing.TB, numDeposits uint64) ([]*ethpb.Deposit, [
 				WithdrawalCredentials: withdrawalCreds[:],
 			}
 
-			domain := bls.Domain(params.BeaconConfig().DomainDeposit, params.BeaconConfig().GenesisForkVersion)
+			domain := bls.ComputeDomain(params.BeaconConfig().DomainDeposit)
 			root, err := ssz.SigningRoot(depositData)
 			if err != nil {
 				t.Fatalf("could not get signing root of deposit data %v", err)


### PR DESCRIPTION
We were using `get_domain` instead of `compute_domain` to both sign and verify deposits. Thanks to @paulhauner for bringing this up. The spec requires the domain to use a zeroed fork version https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#compute_domain

- [x] Use Compute Domain and fix references to it across the repo, using it to retrieve the domain. 
- [x] Add Test For Compue Domain

However we cannot hardcode it yet to use a zeroed fork version until the next testnet restart. This is tracked here #3853