### PR TITLE
Inclusion rewards are based off previous epoch

### DIFF
--- a/beacon-chain/core/epoch/precompute/attestation.go
+++ b/beacon-chain/core/epoch/precompute/attestation.go
@@ -139,19 +139,18 @@ func UpdateValidator(vp []*Validator, record *Validator, indices []uint64, a *pb
 		}
 		if record.IsPrevEpochAttester {
 			vp[i].IsPrevEpochAttester = true
+			// Update attestation inclusion info if inclusion slot is lower than before
+			if inclusionSlot < vp[i].InclusionSlot {
+				vp[i].InclusionSlot = aSlot + a.InclusionDelay
+				vp[i].InclusionDistance = a.InclusionDelay
+				vp[i].ProposerIndex = a.ProposerIndex
+			}
 		}
 		if record.IsPrevEpochTargetAttester {
 			vp[i].IsPrevEpochTargetAttester = true
 		}
 		if record.IsPrevEpochHeadAttester {
 			vp[i].IsPrevEpochHeadAttester = true
-		}
-
-		// Update attestation inclusion info if inclusion slot is lower than before
-		if inclusionSlot < vp[i].InclusionSlot {
-			vp[i].InclusionSlot = aSlot + a.InclusionDelay
-			vp[i].InclusionDistance = a.InclusionDelay
-			vp[i].ProposerIndex = a.ProposerIndex
 		}
 	}
 	return vp

--- a/beacon-chain/core/epoch/precompute/reward_penalty.go
+++ b/beacon-chain/core/epoch/precompute/reward_penalty.go
@@ -153,7 +153,7 @@ func crosslinkDeltaPreCompute(state *pb.BeaconState, bp *Balance, vp []*Validato
 		attestingBalance := helpers.TotalBalance(state, attestingIndices)
 
 		for _, index := range committee {
-			base := vp[i].CurrentEpochEffectiveBalance * params.BeaconConfig().BaseRewardFactor / mathutil.IntegerSquareRoot(bp.CurrentEpoch) / params.BeaconConfig().BaseRewardsPerEpoch
+			base := vp[index].CurrentEpochEffectiveBalance * params.BeaconConfig().BaseRewardFactor / mathutil.IntegerSquareRoot(bp.CurrentEpoch) / params.BeaconConfig().BaseRewardsPerEpoch
 			if _, ok := attested[index]; ok {
 				rewards[index] += base * attestingBalance / committeeBalance
 			} else {


### PR DESCRIPTION
This fixes a bug with process epoch using optimized mode. When we calculate attestation inclusion rewards, it's based off on previous epoch attestations. In the current implementations, we are based off on previous and current attestations