### PR TITLE
fix data race in roundRobinSync

### DIFF
--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -35,6 +35,8 @@ go_test(
     name = "go_default_test",
     srcs = ["round_robin_test.go"],
     embed = [":go_default_library"],
+    race = "on",
+    tags = ["race_on"],
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/p2p/testing:go_default_library",


### PR DESCRIPTION
Fixed the data racing and slightly changed the initial synchronization logic

Related to #3665 (might fix it)
Precisely makes initial synchronization more reliable

Major changes:
  * removed multithreaded call of `respBlocks = append (respBlocks, resp ...)`
  * variables is localized to avoid overlapping