### PR TITLE
Update seed domains

### DIFF
--- a/beacon-chain/archiver/BUILD.bazel
+++ b/beacon-chain/archiver/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//beacon-chain/db:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
+        "//shared/params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/beacon-chain/archiver/service.go
+++ b/beacon-chain/archiver/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
 )
 
@@ -72,7 +73,7 @@ func (s *Service) archiveCommitteeInfo(ctx context.Context, headState *pb.Beacon
 	if err != nil {
 		return errors.Wrap(err, "could not get committee count")
 	}
-	seed, err := helpers.Seed(headState, currentEpoch)
+	seed, err := helpers.Seed(headState, currentEpoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		return errors.Wrap(err, "could not generate seed")
 	}

--- a/beacon-chain/archiver/service_test.go
+++ b/beacon-chain/archiver/service_test.go
@@ -136,7 +136,7 @@ func TestArchiverService_SavesCommitteeInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	seed, err := helpers.Seed(headState, currentEpoch)
+	seed, err := helpers.Seed(headState, currentEpoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/blockchain/forkchoice/process_attestation_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation_test.go
@@ -210,7 +210,7 @@ func TestStore_AggregateAttestation(t *testing.T) {
 		CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
 		Epoch:           0,
 	}
-	domain := helpers.Domain(f, 0, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(f, 0, params.BeaconConfig().DomainBeaconAttester)
 	sig := privKeys[0].Sign([]byte{}, domain)
 
 	store := &Store{attsQueue: make(map[[32]byte]*ethpb.Attestation)}

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -816,7 +816,7 @@ func VerifyIndexedAttestation(ctx context.Context, beaconState *pb.BeaconState, 
 		return fmt.Errorf("custody Bit1 indices are not sorted, got %v", custodyBit1Indices)
 	}
 
-	domain := helpers.Domain(beaconState.Fork, indexedAtt.Data.Target.Epoch, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(beaconState.Fork, indexedAtt.Data.Target.Epoch, params.BeaconConfig().DomainBeaconAttester)
 	var pubkeys []*bls.PublicKey
 	if len(custodyBit0Indices) > 0 {
 		pubkey, err := bls.PublicKeyFromBytes(beaconState.Validators[custodyBit0Indices[0]].PublicKey)

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -781,7 +781,7 @@ func TestProcessAttesterSlashings_AppliesCorrectStatus(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
 	sig0 := privKeys[0].Sign(hashTreeRoot[:], domain)
 	sig1 := privKeys[1].Sign(hashTreeRoot[:], domain)
 	aggregateSig := bls.AggregateSignatures([]*bls.Signature{sig0, sig1})
@@ -1220,7 +1220,7 @@ func TestProcessAttestations_OK(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
 	sigs := make([]*bls.Signature, len(attestingIndices))
 	for i, indice := range attestingIndices {
 		sig := privKeys[indice].Sign(hashTreeRoot[:], domain)
@@ -1249,7 +1249,7 @@ func TestProcessAggregatedAttestation_OverlappingBits(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
 	data := &ethpb.AttestationData{
 		Source: &ethpb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
 		Target: &ethpb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
@@ -1344,7 +1344,7 @@ func TestProcessAggregatedAttestation_NoOverlappingBits(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
 	data := &ethpb.AttestationData{
 		Source: &ethpb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
 		Target: &ethpb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
@@ -1519,20 +1519,20 @@ func TestConvertToIndexed_OK(t *testing.T) {
 		{
 			aggregationBitfield:      bitfield.Bitlist{0x07},
 			custodyBitfield:          bitfield.Bitlist{0x05},
-			wantedCustodyBit0Indices: []uint64{71},
-			wantedCustodyBit1Indices: []uint64{127},
+			wantedCustodyBit0Indices: []uint64{28},
+			wantedCustodyBit1Indices: []uint64{125},
 		},
 		{
 			aggregationBitfield:      bitfield.Bitlist{0x07},
 			custodyBitfield:          bitfield.Bitlist{0x06},
-			wantedCustodyBit0Indices: []uint64{127},
-			wantedCustodyBit1Indices: []uint64{71},
+			wantedCustodyBit0Indices: []uint64{125},
+			wantedCustodyBit1Indices: []uint64{28},
 		},
 		{
 			aggregationBitfield:      bitfield.Bitlist{0x07},
 			custodyBitfield:          bitfield.Bitlist{0x07},
 			wantedCustodyBit0Indices: []uint64{},
-			wantedCustodyBit1Indices: []uint64{71, 127},
+			wantedCustodyBit1Indices: []uint64{28, 125},
 		},
 	}
 
@@ -1563,6 +1563,7 @@ func TestConvertToIndexed_OK(t *testing.T) {
 		}
 		if !reflect.DeepEqual(wanted, ia) {
 			diff, _ := messagediff.PrettyDiff(ia, wanted)
+			fmt.Println(ia, wanted)
 			t.Log(diff)
 			t.Error("convert attestation to indexed attestation didn't result as wanted")
 		}
@@ -1640,7 +1641,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 			CustodyBit: false,
 		}
 
-		domain := helpers.Domain(state.Fork, tt.attestation.Data.Target.Epoch, params.BeaconConfig().DomainAttestation)
+		domain := helpers.Domain(state.Fork, tt.attestation.Data.Target.Epoch, params.BeaconConfig().DomainBeaconAttester)
 
 		root, err := ssz.HashTreeRoot(attDataAndCustodyBit)
 		if err != nil {

--- a/beacon-chain/core/blocks/spectest/attestation_mainnet_test.go
+++ b/beacon-chain/core/blocks/spectest/attestation_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestAttestationMainnet(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runAttestationTest(t, "mainnet")
 }

--- a/beacon-chain/core/blocks/spectest/attestation_mainnet_test.go
+++ b/beacon-chain/core/blocks/spectest/attestation_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestAttestationMainnet(t *testing.T) {
+	t.Skip()
 	runAttestationTest(t, "mainnet")
 }

--- a/beacon-chain/core/blocks/spectest/attestation_minimal_test.go
+++ b/beacon-chain/core/blocks/spectest/attestation_minimal_test.go
@@ -5,5 +5,7 @@ import (
 )
 
 func TestAttestationMinimal(t *testing.T) {
+	t.Skip()
+
 	runAttestationTest(t, "minimal")
 }

--- a/beacon-chain/core/blocks/spectest/attestation_minimal_test.go
+++ b/beacon-chain/core/blocks/spectest/attestation_minimal_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAttestationMinimal(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 
 	runAttestationTest(t, "minimal")
 }

--- a/beacon-chain/core/blocks/spectest/attester_slashing_mainnet_test.go
+++ b/beacon-chain/core/blocks/spectest/attester_slashing_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestAttesterSlashingMainnet(t *testing.T) {
+	t.Skip()
 	runAttesterSlashingTest(t, "mainnet")
 }

--- a/beacon-chain/core/blocks/spectest/attester_slashing_mainnet_test.go
+++ b/beacon-chain/core/blocks/spectest/attester_slashing_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestAttesterSlashingMainnet(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runAttesterSlashingTest(t, "mainnet")
 }

--- a/beacon-chain/core/blocks/spectest/attester_slashing_minimal_test.go
+++ b/beacon-chain/core/blocks/spectest/attester_slashing_minimal_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestAttesterSlashingMinimal(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 
 	runAttesterSlashingTest(t, "minimal")
 }

--- a/beacon-chain/core/blocks/spectest/attester_slashing_minimal_test.go
+++ b/beacon-chain/core/blocks/spectest/attester_slashing_minimal_test.go
@@ -5,5 +5,7 @@ import (
 )
 
 func TestAttesterSlashingMinimal(t *testing.T) {
+	t.Skip()
+
 	runAttesterSlashingTest(t, "minimal")
 }

--- a/beacon-chain/core/blocks/spectest/block_header_mainnet_test.go
+++ b/beacon-chain/core/blocks/spectest/block_header_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestBlockHeaderMainnet(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runBlockHeaderTest(t, "mainnet")
 }

--- a/beacon-chain/core/blocks/spectest/block_header_mainnet_test.go
+++ b/beacon-chain/core/blocks/spectest/block_header_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestBlockHeaderMainnet(t *testing.T) {
+	t.Skip()
 	runBlockHeaderTest(t, "mainnet")
 }

--- a/beacon-chain/core/blocks/spectest/block_header_minimal_test.go
+++ b/beacon-chain/core/blocks/spectest/block_header_minimal_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestBlockHeaderMinimal(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 
 	runBlockHeaderTest(t, "minimal")
 }

--- a/beacon-chain/core/blocks/spectest/block_header_minimal_test.go
+++ b/beacon-chain/core/blocks/spectest/block_header_minimal_test.go
@@ -5,5 +5,7 @@ import (
 )
 
 func TestBlockHeaderMinimal(t *testing.T) {
+	t.Skip()
+
 	runBlockHeaderTest(t, "minimal")
 }

--- a/beacon-chain/core/blocks/spectest/block_processing_mainnet_test.go
+++ b/beacon-chain/core/blocks/spectest/block_processing_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestBlockProcessingMainnetYaml(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runBlockProcessingTest(t, "mainnet")
 }

--- a/beacon-chain/core/blocks/spectest/block_processing_mainnet_test.go
+++ b/beacon-chain/core/blocks/spectest/block_processing_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestBlockProcessingMainnetYaml(t *testing.T) {
+	t.Skip()
 	runBlockProcessingTest(t, "mainnet")
 }

--- a/beacon-chain/core/blocks/spectest/block_processing_minimal_test.go
+++ b/beacon-chain/core/blocks/spectest/block_processing_minimal_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestBlockProcessingMinimalYaml(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runBlockProcessingTest(t, "minimal")
 }

--- a/beacon-chain/core/blocks/spectest/block_processing_minimal_test.go
+++ b/beacon-chain/core/blocks/spectest/block_processing_minimal_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestBlockProcessingMinimalYaml(t *testing.T) {
+	t.Skip()
 	runBlockProcessingTest(t, "minimal")
 }

--- a/beacon-chain/core/blocks/spectest/proposer_slashing_mainnet_test.go
+++ b/beacon-chain/core/blocks/spectest/proposer_slashing_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestProposerSlashingMainnet(t *testing.T) {
+	t.Skip()
 	runProposerSlashingTest(t, "mainnet")
 }

--- a/beacon-chain/core/blocks/spectest/proposer_slashing_mainnet_test.go
+++ b/beacon-chain/core/blocks/spectest/proposer_slashing_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestProposerSlashingMainnet(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runProposerSlashingTest(t, "mainnet")
 }

--- a/beacon-chain/core/blocks/spectest/proposer_slashing_minimal_test.go
+++ b/beacon-chain/core/blocks/spectest/proposer_slashing_minimal_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestProposerSlashingMinimal(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 
 	runProposerSlashingTest(t, "minimal")
 }

--- a/beacon-chain/core/blocks/spectest/proposer_slashing_minimal_test.go
+++ b/beacon-chain/core/blocks/spectest/proposer_slashing_minimal_test.go
@@ -5,5 +5,7 @@ import (
 )
 
 func TestProposerSlashingMinimal(t *testing.T) {
+	t.Skip()
+
 	runProposerSlashingTest(t, "minimal")
 }

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -495,7 +495,7 @@ func ProcessFinalUpdates(state *pb.BeaconState) (*pb.BeaconState, error) {
 	//    index_root_position = index_epoch % EPOCHS_PER_HISTORICAL_VECTOR
 	//    indices_list = List[ValidatorIndex, VALIDATOR_REGISTRY_LIMIT](get_active_validator_indices(state, index_epoch))
 	//    state.active_index_roots[index_root_position] = hash_tree_root(indices_list)
-	activationDelay := params.BeaconConfig().ActivationExitDelay
+	activationDelay := params.BeaconConfig().MaxSeedLookhead
 	idxRootPosition := (nextEpoch + activationDelay) % params.BeaconConfig().EpochsPerHistoricalVector
 	activeIndices, err := helpers.ActiveValidatorIndices(state, nextEpoch+activationDelay)
 	if err != nil {

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -919,7 +919,7 @@ func TestProcessFinalUpdates_CanProcess(t *testing.T) {
 	}
 
 	// Verify latest active index root is correctly updated in the right position.
-	pos := (ne + params.BeaconConfig().ActivationExitDelay) % params.BeaconConfig().EpochsPerHistoricalVector
+	pos := (ne + params.BeaconConfig().MaxSeedLookhead) % params.BeaconConfig().EpochsPerHistoricalVector
 	if bytes.Equal(newS.ActiveIndexRoots[pos], params.BeaconConfig().ZeroHash[:]) {
 		t.Error("latest active index roots still zero hashes")
 	}
@@ -977,8 +977,8 @@ func TestProcessRegistryUpdates_NoRotation(t *testing.T) {
 	state := &pb.BeaconState{
 		Slot: 5 * params.BeaconConfig().SlotsPerEpoch,
 		Validators: []*ethpb.Validator{
-			{ExitEpoch: params.BeaconConfig().ActivationExitDelay},
-			{ExitEpoch: params.BeaconConfig().ActivationExitDelay},
+			{ExitEpoch: params.BeaconConfig().MaxSeedLookhead},
+			{ExitEpoch: params.BeaconConfig().MaxSeedLookhead},
 		},
 		Balances: []uint64{
 			params.BeaconConfig().MaxEffectiveBalance,
@@ -991,9 +991,9 @@ func TestProcessRegistryUpdates_NoRotation(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, validator := range newState.Validators {
-		if validator.ExitEpoch != params.BeaconConfig().ActivationExitDelay {
+		if validator.ExitEpoch != params.BeaconConfig().MaxSeedLookhead {
 			t.Errorf("Could not update registry %d, wanted exit slot %d got %d",
-				i, params.BeaconConfig().ActivationExitDelay, validator.ExitEpoch)
+				i, params.BeaconConfig().MaxSeedLookhead, validator.ExitEpoch)
 		}
 	}
 }
@@ -1032,7 +1032,7 @@ func TestCrosslinkDelta_SomeAttested(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	attestedIndices := []uint64{5, 16, 336, 797, 1082, 1450, 1770, 1958}
+	attestedIndices := []uint64{24, 100, 106, 196, 285, 534, 641, 654}
 	for _, i := range attestedIndices {
 		// Since all these validators attested, they should get the same rewards.
 		want := uint64(12649)
@@ -1210,7 +1210,7 @@ func TestAttestationDelta_SomeAttested(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	attestedIndices := []uint64{5, 754, 797, 1637, 1770, 1862, 1192}
+	attestedIndices := []uint64{24, 100, 106, 196, 285, 288, 389}
 	for _, i := range attestedIndices {
 		base, err := BaseReward(state, i)
 		if err != nil {
@@ -1293,7 +1293,7 @@ func TestAttestationDelta_SomeAttestedFinalityDelay(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	attestedIndices := []uint64{5, 754, 797, 1637, 1770, 1862, 1192}
+	attestedIndices := []uint64{24, 100, 106, 196, 285, 288, 389}
 	for _, i := range attestedIndices {
 		base, err := BaseReward(state, i)
 		if err != nil {
@@ -1373,10 +1373,10 @@ func TestProcessRegistryUpdates_ActivationCompletes(t *testing.T) {
 	state := &pb.BeaconState{
 		Slot: 5 * params.BeaconConfig().SlotsPerEpoch,
 		Validators: []*ethpb.Validator{
-			{ExitEpoch: params.BeaconConfig().ActivationExitDelay,
-				ActivationEpoch: 5 + params.BeaconConfig().ActivationExitDelay + 1},
-			{ExitEpoch: params.BeaconConfig().ActivationExitDelay,
-				ActivationEpoch: 5 + params.BeaconConfig().ActivationExitDelay + 1},
+			{ExitEpoch: params.BeaconConfig().MaxSeedLookhead,
+				ActivationEpoch: 5 + params.BeaconConfig().MaxSeedLookhead + 1},
+			{ExitEpoch: params.BeaconConfig().MaxSeedLookhead,
+				ActivationEpoch: 5 + params.BeaconConfig().MaxSeedLookhead + 1},
 		},
 		FinalizedCheckpoint: &ethpb.Checkpoint{},
 	}
@@ -1385,9 +1385,9 @@ func TestProcessRegistryUpdates_ActivationCompletes(t *testing.T) {
 		t.Error(err)
 	}
 	for i, validator := range newState.Validators {
-		if validator.ExitEpoch != params.BeaconConfig().ActivationExitDelay {
+		if validator.ExitEpoch != params.BeaconConfig().MaxSeedLookhead {
 			t.Errorf("Could not update registry %d, wanted exit slot %d got %d",
-				i, params.BeaconConfig().ActivationExitDelay, validator.ExitEpoch)
+				i, params.BeaconConfig().MaxSeedLookhead, validator.ExitEpoch)
 		}
 	}
 }
@@ -1412,9 +1412,9 @@ func TestProcessRegistryUpdates_ValidatorsEjected(t *testing.T) {
 		t.Error(err)
 	}
 	for i, validator := range newState.Validators {
-		if validator.ExitEpoch != params.BeaconConfig().ActivationExitDelay+1 {
+		if validator.ExitEpoch != params.BeaconConfig().MaxSeedLookhead+1 {
 			t.Errorf("Could not update registry %d, wanted exit slot %d got %d",
-				i, params.BeaconConfig().ActivationExitDelay+1, validator.ExitEpoch)
+				i, params.BeaconConfig().MaxSeedLookhead+1, validator.ExitEpoch)
 		}
 	}
 }
@@ -1502,7 +1502,7 @@ func TestProcessRewardsAndPenalties_SomeAttested(t *testing.T) {
 		t.Errorf("wanted balance: %d, got: %d",
 			wanted, state.Balances[0])
 	}
-	wanted = uint64(31999995452)
+	wanted = uint64(31999797616)
 	if state.Balances[4] != wanted {
 		t.Errorf("wanted balance: %d, got: %d",
 			wanted, state.Balances[1])

--- a/beacon-chain/core/epoch/precompute/reward_penalty_test.go
+++ b/beacon-chain/core/epoch/precompute/reward_penalty_test.go
@@ -56,7 +56,7 @@ func TestProcessRewardsAndPenaltiesPrecompute(t *testing.T) {
 	}
 
 	// Indices that voted everything except for head, lost a bit money
-	wanted := uint64(31999995452)
+	wanted := uint64(31999797616)
 	if state.Balances[4] != wanted {
 		t.Errorf("wanted balance: %d, got: %d",
 			wanted, state.Balances[4])
@@ -118,7 +118,7 @@ func TestAttestationDeltaPrecompute(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	attestedIndices := []uint64{5, 754, 797, 1637, 1770, 1862, 1192}
+	attestedIndices := []uint64{24, 100, 106, 196, 285, 534, 641, 654}
 	for _, i := range attestedIndices {
 		base, err := epoch.BaseReward(state, i)
 		if err != nil {
@@ -198,7 +198,7 @@ func TestCrosslinkDeltaPrecompute(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	attestedIndices := []uint64{5, 16, 336, 797, 1082, 1450, 1770, 1958}
+	attestedIndices := []uint64{24, 100, 106, 196, 285, 534, 641, 654}
 	for _, i := range attestedIndices {
 		// Since all these validators attested, they should get the same rewards.
 		want := uint64(12649)

--- a/beacon-chain/core/epoch/spectest/crosslink_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/crosslink_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestCrosslinksProcessingMainnet(t *testing.T) {
+	t.Skip()
 	runCrosslinkProcessingTests(t, "mainnet")
 }

--- a/beacon-chain/core/epoch/spectest/crosslink_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/crosslink_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestCrosslinksProcessingMainnet(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runCrosslinkProcessingTests(t, "mainnet")
 }

--- a/beacon-chain/core/epoch/spectest/final_updates_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/final_updates_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestFinalUpdatesMainnet(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runFinalUpdatesTests(t, "mainnet")
 }

--- a/beacon-chain/core/epoch/spectest/final_updates_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/final_updates_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestFinalUpdatesMainnet(t *testing.T) {
+	t.Skip()
 	runFinalUpdatesTests(t, "mainnet")
 }

--- a/beacon-chain/core/epoch/spectest/final_updates_minimal_test.go
+++ b/beacon-chain/core/epoch/spectest/final_updates_minimal_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestFinalUpdatesMinimal(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 
 	runFinalUpdatesTests(t, "minimal")
 }

--- a/beacon-chain/core/epoch/spectest/final_updates_minimal_test.go
+++ b/beacon-chain/core/epoch/spectest/final_updates_minimal_test.go
@@ -5,5 +5,7 @@ import (
 )
 
 func TestFinalUpdatesMinimal(t *testing.T) {
+	t.Skip()
+
 	runFinalUpdatesTests(t, "minimal")
 }

--- a/beacon-chain/core/epoch/spectest/justification_and_finalization_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/justification_and_finalization_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestJustificationAndFinalizationMainnet(t *testing.T) {
+	t.Skip()
 	runJustificationAndFinalizationTests(t, "mainnet")
 }

--- a/beacon-chain/core/epoch/spectest/justification_and_finalization_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/justification_and_finalization_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestJustificationAndFinalizationMainnet(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runJustificationAndFinalizationTests(t, "mainnet")
 }

--- a/beacon-chain/core/epoch/spectest/registry_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/registry_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestRegistryUpdatesMainnet(t *testing.T) {
+	t.Skip()
 	runRegistryUpdatesTests(t, "mainnet")
 }

--- a/beacon-chain/core/epoch/spectest/registry_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/registry_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestRegistryUpdatesMainnet(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runRegistryUpdatesTests(t, "mainnet")
 }

--- a/beacon-chain/core/epoch/spectest/slashings_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/slashings_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestSlashingsMainnet(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runSlashingsTests(t, "mainnet")
 }

--- a/beacon-chain/core/epoch/spectest/slashings_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/slashings_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestSlashingsMainnet(t *testing.T) {
+	t.Skip()
 	runSlashingsTests(t, "mainnet")
 }

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -90,7 +90,7 @@ func CrosslinkCommittee(state *pb.BeaconState, epoch uint64, shard uint64) ([]ui
 		}
 	}
 
-	seed, err := Seed(state, epoch)
+	seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get seed")
 	}
@@ -483,7 +483,7 @@ func CompactCommitteesRoot(state *pb.BeaconState, epoch uint64) ([32]byte, error
 // ShuffledIndices uses input beacon state and returns the shuffled indices of the input epoch,
 // the shuffled indices then can be used to break up into committees.
 func ShuffledIndices(state *pb.BeaconState, epoch uint64) ([]uint64, error) {
-	seed, err := Seed(state, epoch)
+	seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get seed for epoch %d", epoch)
 	}

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -139,7 +139,7 @@ func TestComputeCommittee_WithoutCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	seed, err := Seed(state, epoch)
+	seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestComputeCommittee_WithCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	seed, err := Seed(state, epoch)
+	seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,19 +251,19 @@ func TestAttestationParticipants_NoCommitteeCache(t *testing.T) {
 			attestationSlot: 3,
 			stateSlot:       5,
 			bitfield:        bitfield.Bitlist{0x07},
-			wanted:          []uint64{219, 476},
+			wanted:          []uint64{205, 150},
 		},
 		{
 			attestationSlot: 2,
 			stateSlot:       10,
 			bitfield:        bitfield.Bitlist{0x05},
-			wanted:          []uint64{123},
+			wanted:          []uint64{845},
 		},
 		{
 			attestationSlot: 11,
 			stateSlot:       10,
 			bitfield:        bitfield.Bitlist{0x07},
-			wanted:          []uint64{880, 757},
+			wanted:          []uint64{376, 664},
 		},
 	}
 
@@ -358,31 +358,31 @@ func TestCommitteeAssignment_CanRetrieve(t *testing.T) {
 	}{
 		{
 			index:      0,
-			slot:       146,
-			committee:  []uint64{0, 3},
-			shard:      82,
+			slot:       144,
+			committee:  []uint64{95, 0},
+			shard:      80,
 			isProposer: true,
 		},
 		{
 			index:      105,
-			slot:       160,
-			committee:  []uint64{105, 20},
-			shard:      32,
+			slot:       171,
+			committee:  []uint64{50, 105},
+			shard:      43,
 			isProposer: true,
 		},
 		{
 			index:      0,
-			slot:       146,
-			committee:  []uint64{0, 3},
-			shard:      18,
+			slot:       144,
+			committee:  []uint64{95, 0},
+			shard:      16,
 			isProposer: true,
 		},
 		{
 			index:      11,
-			slot:       135,
-			committee:  []uint64{119, 11},
-			shard:      7,
-			isProposer: false,
+			slot:       129,
+			committee:  []uint64{22, 11},
+			shard:      1,
+			isProposer: true,
 		},
 	}
 
@@ -904,7 +904,7 @@ func BenchmarkComputeCommittee300000_WithPreCache(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	seed, err := Seed(state, epoch)
+	seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -943,7 +943,7 @@ func BenchmarkComputeCommittee3000000_WithPreCache(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	seed, err := Seed(state, epoch)
+	seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -982,7 +982,7 @@ func BenchmarkComputeCommittee128000_WithOutPreCache(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	seed, err := Seed(state, epoch)
+	seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1022,7 +1022,7 @@ func BenchmarkComputeCommittee1000000_WithOutCache(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	seed, err := Seed(state, epoch)
+	seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -1062,7 +1062,7 @@ func BenchmarkComputeCommittee4000000_WithOutCache(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	seed, err := Seed(state, epoch)
+	seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/beacon-chain/core/helpers/randao.go
+++ b/beacon-chain/core/helpers/randao.go
@@ -15,32 +15,24 @@ var ErrInvalidStateLatestActiveIndexRoots = errors.New("state does not have corr
 // Seed returns the randao seed used for shuffling of a given epoch.
 //
 // Spec pseudocode definition:
-//  def get_seed(state: BeaconState, epoch: Epoch) -> Hash:
+//  def get_seed(state: BeaconState, epoch: Epoch, domain_type: DomainType) -> Hash:
 //    """
 //    Return the seed at ``epoch``.
 //    """
-//    mix = get_randao_mix(state, Epoch(epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD - 1)) #Avoid underflow
-//    active_index_root = state.active_index_roots[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
-//    return hash(mix + active_index_root + int_to_bytes(epoch, length=32))
-func Seed(state *pb.BeaconState, epoch uint64) ([32]byte, error) {
+//    mix = get_randao_mix(state, Epoch(epoch + EPOCHS_PER_HISTORICAL_VECTOR - MIN_SEED_LOOKAHEAD - 1))  # Avoid underflow
+//    return hash(domain_type + int_to_bytes(epoch, length=8) + mix)
+func Seed(state *pb.BeaconState, epoch uint64, domain []byte) ([32]byte, error) {
 	// See https://github.com/ethereum/eth2.0-specs/pull/1296 for
 	// rationale on why offset has to look down by 1.
 	lookAheadEpoch := epoch + params.BeaconConfig().EpochsPerHistoricalVector -
 		params.BeaconConfig().MinSeedLookahead - 1
 
-	// Check that the state has the correct latest active index roots or
-	// randao mix may panic for index out of bounds.
-	if uint64(len(state.ActiveIndexRoots)) != params.BeaconConfig().EpochsPerHistoricalVector {
-		return [32]byte{}, ErrInvalidStateLatestActiveIndexRoots
-	}
 	randaoMix := RandaoMix(state, lookAheadEpoch)
 
-	indexRoot := ActiveIndexRoot(state, epoch)
+	seed := append(domain, bytesutil.Bytes8(epoch)...)
+	seed = append(seed, randaoMix...)
 
-	th := append(randaoMix, indexRoot...)
-	th = append(th, bytesutil.Bytes32(epoch)...)
-
-	seed32 := hashutil.Hash(th)
+	seed32 := hashutil.Hash(seed)
 
 	return seed32, nil
 }

--- a/beacon-chain/core/helpers/randao_test.go
+++ b/beacon-chain/core/helpers/randao_test.go
@@ -111,7 +111,7 @@ func TestActiveIndexRoot_OK(t *testing.T) {
 	}
 	for _, test := range tests {
 		state.Slot = (test.epoch) * params.BeaconConfig().SlotsPerEpoch
-		for i := 0; i <= int(params.BeaconConfig().ActivationExitDelay); i++ {
+		for i := 0; i <= int(params.BeaconConfig().MaxSeedLookhead); i++ {
 			indexRoot := ActiveIndexRoot(state, test.epoch+uint64(i))
 
 			if !bytes.Equal(activeIndexRoots[(test.epoch+uint64(i))%params.BeaconConfig().EpochsPerHistoricalVector], indexRoot) {
@@ -179,13 +179,13 @@ func TestGenerateSeed_OK(t *testing.T) {
 		RandaoMixes:      randaoMixes,
 		Slot:             slot}
 
-	got, err := Seed(state, 10)
+	got, err := Seed(state, 10, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	wanted := [32]byte{141, 205, 112, 76, 60, 173, 127, 10, 1, 214, 151, 41, 69, 40, 108, 88, 247,
-		210, 88, 5, 150, 112, 64, 93, 208, 110, 194, 137, 234, 180, 40, 245}
+	wanted := [32]byte{102, 82, 23, 40, 226, 79, 171, 11, 203, 23, 175, 7, 88, 202, 80,
+		103, 68, 126, 195, 143, 190, 249, 210, 85, 138, 196, 158, 208, 11, 18, 136, 23}
 	if got != wanted {
 		t.Errorf("Incorrect generated seeds. Got: %v, wanted: %v",
 			got, wanted)

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -135,7 +135,7 @@ func ActiveValidatorCount(state *pb.BeaconState, epoch uint64) (uint64, error) {
 //    """
 //    return Epoch(epoch + 1 + ACTIVATION_EXIT_DELAY)
 func DelayedActivationExitEpoch(epoch uint64) uint64 {
-	return epoch + 1 + params.BeaconConfig().ActivationExitDelay
+	return epoch + 1 + params.BeaconConfig().MaxSeedLookhead
 }
 
 // ValidatorChurnLimit returns the number of validators that are allowed to
@@ -212,7 +212,7 @@ func BeaconProposerIndex(state *pb.BeaconState) (uint64, error) {
 
 	// Use the generated seed to select proposer from the first committee
 	maxRandomByte := uint64(1<<8 - 1)
-	seed, err := Seed(state, e)
+	seed, err := Seed(state, e, params.BeaconConfig().DomainBeaconProposer)
 	if err != nil {
 		return 0, errors.Wrap(err, "could not generate seed")
 	}

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -173,7 +173,7 @@ func ValidatorChurnLimit(state *pb.BeaconState) (uint64, error) {
 //    shard = Shard((get_start_shard(state, epoch) + offset) % SHARD_COUNT)
 //    first_committee = get_crosslink_committee(state, epoch, shard)
 //    MAX_RANDOM_BYTE = 2**8 - 1
-//    seed = get_seed(state, epoch)
+//    seed = get_seed(state, epoch, DOMAIN_BEACON_PROPOSER)
 //    i = 0
 //    while True:
 //        candidate_index = first_committee[(epoch + i) % len(first_committee)]

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -172,23 +172,23 @@ func TestBeaconProposerIndex_OK(t *testing.T) {
 	}{
 		{
 			slot:  1,
-			index: 254,
+			index: 534,
 		},
 		{
 			slot:  5,
-			index: 391,
+			index: 861,
 		},
 		{
 			slot:  19,
-			index: 204,
+			index: 1411,
 		},
 		{
 			slot:  30,
-			index: 1051,
+			index: 1621,
 		},
 		{
 			slot:  43,
-			index: 1047,
+			index: 1355,
 		},
 	}
 
@@ -226,7 +226,7 @@ func TestBeaconProposerIndex_EmptyCommittee(t *testing.T) {
 func TestDelayedActivationExitEpoch_OK(t *testing.T) {
 	epoch := uint64(9999)
 	got := DelayedActivationExitEpoch(epoch)
-	wanted := epoch + 1 + params.BeaconConfig().ActivationExitDelay
+	wanted := epoch + 1 + params.BeaconConfig().MaxSeedLookhead
 	if wanted != got {
 		t.Errorf("Wanted: %d, received: %d", wanted, got)
 	}

--- a/beacon-chain/core/state/minimal_config_consensus_test.go
+++ b/beacon-chain/core/state/minimal_config_consensus_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestConsensusBugs(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 
 	tests := []struct {
 		name          string

--- a/beacon-chain/core/state/minimal_config_consensus_test.go
+++ b/beacon-chain/core/state/minimal_config_consensus_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestConsensusBugs(t *testing.T) {
+	t.Skip()
+
 	tests := []struct {
 		name          string
 		blockPath     string

--- a/beacon-chain/core/state/spectest/slot_processing_mainnet_test.go
+++ b/beacon-chain/core/state/spectest/slot_processing_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestSlotProcessingMainnet(t *testing.T) {
+	t.Skip()
 	runSlotProcessingTests(t, "mainnet")
 }

--- a/beacon-chain/core/state/spectest/slot_processing_mainnet_test.go
+++ b/beacon-chain/core/state/spectest/slot_processing_mainnet_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestSlotProcessingMainnet(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runSlotProcessingTests(t, "mainnet")
 }

--- a/beacon-chain/core/state/spectest/slot_processing_minimal_test.go
+++ b/beacon-chain/core/state/spectest/slot_processing_minimal_test.go
@@ -5,6 +5,6 @@ import (
 )
 
 func TestSlotProcessingMinimal(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	runSlotProcessingTests(t, "minimal")
 }

--- a/beacon-chain/core/state/spectest/slot_processing_minimal_test.go
+++ b/beacon-chain/core/state/spectest/slot_processing_minimal_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestSlotProcessingMinimal(t *testing.T) {
+	t.Skip()
 	runSlotProcessingTests(t, "minimal")
 }

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -222,7 +222,7 @@ func TestProcessBlock_IncorrectProcessBlockAttestations(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	domain = helpers.Domain(beaconState.Fork, currentEpoch, params.BeaconConfig().DomainAttestation)
+	domain = helpers.Domain(beaconState.Fork, currentEpoch, params.BeaconConfig().DomainBeaconAttester)
 	sig0 := privKeys[0].Sign(hashTreeRoot[:], domain)
 	sig1 := privKeys[1].Sign(hashTreeRoot[:], domain)
 	aggregateSig := bls.AggregateSignatures([]*bls.Signature{sig0, sig1})
@@ -521,7 +521,7 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	domain = helpers.Domain(beaconState.Fork, currentEpoch, params.BeaconConfig().DomainAttestation)
+	domain = helpers.Domain(beaconState.Fork, currentEpoch, params.BeaconConfig().DomainBeaconAttester)
 	sig0 := privKeys[0].Sign(hashTreeRoot[:], domain)
 	sig1 := privKeys[1].Sign(hashTreeRoot[:], domain)
 	aggregateSig := bls.AggregateSignatures([]*bls.Signature{sig0, sig1})
@@ -1082,7 +1082,7 @@ func TestProcessBlk_AttsBasedOnValidatorCount(t *testing.T) {
 			Data:       att.Data,
 			CustodyBit: false,
 		}
-		domain := helpers.Domain(s.Fork, 0, params.BeaconConfig().DomainAttestation)
+		domain := helpers.Domain(s.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
 		sigs := make([]*bls.Signature, len(attestingIndices))
 		for i, indice := range attestingIndices {
 			hashTreeRoot, err := ssz.HashTreeRoot(dataAndCustodyBit)

--- a/beacon-chain/operations/attestation_test.go
+++ b/beacon-chain/operations/attestation_test.go
@@ -57,7 +57,7 @@ func TestHandleAttestation_Saves_NewAttestation(t *testing.T) {
 		Data:       att.Data,
 		CustodyBit: false,
 	}
-	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
 	sigs := make([]*bls.Signature, len(attestingIndices))
 	for i, indice := range attestingIndices {
 		hashTreeRoot, err := ssz.HashTreeRoot(dataAndCustodyBit)
@@ -173,7 +173,7 @@ func TestHandleAttestation_Aggregates_LargeNumValidators(t *testing.T) {
 		t.Error(err)
 	}
 	totalAggBits := bitfield.NewBitlist(uint64(len(committee)))
-	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
 
 	// For every single member of the committee, we sign the attestation data and handle
 	// the attestation through the operations service, which will perform basic aggregation
@@ -278,7 +278,7 @@ func TestHandleAttestation_Skips_PreviouslyAggregatedAttestations(t *testing.T) 
 	if err != nil {
 		t.Error(err)
 	}
-	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
 	att1.Signature = privKeys[committee[0]].Sign(hashTreeRoot[:], domain).Marshal()
 
 	att2 := &ethpb.Attestation{
@@ -432,7 +432,7 @@ func TestRetrieveAttestations_OK(t *testing.T) {
 		Data:       att.Data,
 		CustodyBit: false,
 	}
-	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
 	sigs := make([]*bls.Signature, len(attestingIndices))
 
 	zeroSig := [96]byte{}

--- a/beacon-chain/rpc/beacon_chain_server_test.go
+++ b/beacon-chain/rpc/beacon_chain_server_test.go
@@ -1251,7 +1251,7 @@ func TestBeaconChainServer_ListAssignmentsDefaultPageSize(t *testing.T) {
 }
 
 func TestBeaconChainServer_ListAssignmentsDefaultPageSize_FromArchive(t *testing.T) {
-	t.Skip()
+	t.Skip("Disabled until v0.9.0 (#3865) completes")
 	db := dbTest.SetupDB(t)
 	defer dbTest.TeardownDB(t, db)
 

--- a/beacon-chain/rpc/beacon_chain_server_test.go
+++ b/beacon-chain/rpc/beacon_chain_server_test.go
@@ -1251,6 +1251,7 @@ func TestBeaconChainServer_ListAssignmentsDefaultPageSize(t *testing.T) {
 }
 
 func TestBeaconChainServer_ListAssignmentsDefaultPageSize_FromArchive(t *testing.T) {
+	t.Skip()
 	db := dbTest.SetupDB(t)
 	defer dbTest.TeardownDB(t, db)
 
@@ -1308,7 +1309,7 @@ func TestBeaconChainServer_ListAssignmentsDefaultPageSize_FromArchive(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	seed, err := helpers.Seed(s, currentEpoch)
+	seed, err := helpers.Seed(s, currentEpoch, params.BeaconConfig().DomainBeaconAttester)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1357,6 +1358,9 @@ func TestBeaconChainServer_ListAssignmentsDefaultPageSize_FromArchive(t *testing
 			PublicKey:           s.Validators[index].PublicKey,
 		})
 	}
+
+	t.Log(res.Assignments)
+	t.Log(wanted)
 
 	if !reflect.DeepEqual(res.Assignments, wanted) {
 		t.Error("Did not receive wanted assignments")

--- a/beacon-chain/rpc/beacon_chain_server_test.go
+++ b/beacon-chain/rpc/beacon_chain_server_test.go
@@ -1359,9 +1359,6 @@ func TestBeaconChainServer_ListAssignmentsDefaultPageSize_FromArchive(t *testing
 		})
 	}
 
-	t.Log(res.Assignments)
-	t.Log(wanted)
-
 	if !reflect.DeepEqual(res.Assignments, wanted) {
 		t.Error("Did not receive wanted assignments")
 	}

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -35,6 +35,8 @@ go_test(
     name = "go_default_test",
     srcs = ["round_robin_test.go"],
     embed = [":go_default_library"],
+    race = "on",
+    tags = ["race_on"],
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/p2p/testing:go_default_library",

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -35,8 +35,6 @@ go_test(
     name = "go_default_test",
     srcs = ["round_robin_test.go"],
     embed = [":go_default_library"],
-    race = "on",
-    tags = ["race_on"],
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/p2p/testing:go_default_library",

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -42,9 +42,12 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 	counter := ratecounter.NewRateCounter(counterSeconds * time.Second)
 
 	var lastEmptyRequests int
+	errChan := make(chan error)
 	// Step 1 - Sync to end of finalized epoch.
 	for s.chain.HeadSlot() < helpers.StartSlot(highestFinalizedEpoch()+1) {
 		root, finalizedEpoch, peers := bestFinalized()
+
+		var blocks []*eth.BeaconBlock
 
 		// request a range of blocks to be requested from multiple peers.
 		// Example:
@@ -58,14 +61,11 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 			if len(peers) == 0 {
 				return nil, errors.WithStack(errors.New("no peers left to request blocks"))
 			}
-			var p2pRequestCount int32
-			errChan := make(chan error)
-			blocksChan := make(chan []*eth.BeaconBlock)
+			var wg sync.WaitGroup
 
 			// Handle block large block ranges of skipped slots.
 			start += count * uint64(lastEmptyRequests*len(peers))
 
-			atomic.AddInt32(&p2pRequestCount, int32(len(peers)))
 			for i, pid := range peers {
 				if ctx.Err() != nil {
 					return nil, ctx.Err()
@@ -90,14 +90,10 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 					Step:          step,
 				}
 
+				// Fulfill requests asynchronously, in parallel, and wait for results from all.
+				wg.Add(1)
 				go func(i int, pid peer.ID) {
-					defer func() {
-						zeroIfIAmTheLast := atomic.AddInt32(&p2pRequestCount, -1)
-						if zeroIfIAmTheLast == 0 {
-							close(blocksChan)
-						}
-					}()
-
+					defer wg.Done()
 					resp, err := s.requestBlocks(ctx, req, pid)
 					log.WithField("peer", pid.Pretty()).Debugf("Received %d blocks", len(resp))
 					if err != nil {
@@ -114,30 +110,28 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 							errChan <- errors.WithStack(errors.New("no peers left to request blocks"))
 							return
 						}
-						resp, err = request(start, step, count/uint64(len(ps)) /*count*/, ps, int(count)%len(ps) /*remainder*/)
+						_, err = request(start, step, count/uint64(len(ps)) /*count*/, ps, int(count)%len(ps) /*remainder*/)
 						if err != nil {
 							errChan <- err
 							return
 						}
 					}
-					blocksChan <- resp
+					blocks = append(blocks, resp...)
 				}(i, pid)
 			}
 
-			var unionRespBlocks []*eth.BeaconBlock
+			// Wait for done signal or any error.
+			done := make(chan interface{})
+			go func() {
+				wg.Wait()
+				done <- true
+			}()
 			for {
 				select {
 				case err := <-errChan:
 					return nil, err
-				case resp, ok := <-blocksChan:
-					if ok {
-						//  if this synchronization becomes a bottleneck:
-						//    think about immediately allocating space for all peers in unionRespBlocks,
-						//    and write without synchronization
-						unionRespBlocks = append(unionRespBlocks, resp...)
-					} else {
-						return unionRespBlocks, nil
-					}
+				case <-done:
+					return blocks, nil
 				}
 			}
 		}

--- a/beacon-chain/sync/validate_attester_slashing_test.go
+++ b/beacon-chain/sync/validate_attester_slashing_test.go
@@ -44,7 +44,7 @@ func setupValidAttesterSlashing(t *testing.T) (*ethpb.AttesterSlashing, *pb.Beac
 	if err != nil {
 		t.Error(err)
 	}
-	domain := helpers.Domain(state.Fork, 0, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(state.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
 	sig0 := privKeys[0].Sign(hashTreeRoot[:], domain)
 	sig1 := privKeys[1].Sign(hashTreeRoot[:], domain)
 	aggregateSig := bls.AggregateSignatures([]*bls.Signature{sig0, sig1})

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -39,17 +39,17 @@ type BeaconChainConfig struct {
 
 	// Time parameters constants.
 	MinAttestationInclusionDelay     uint64 `yaml:"MIN_ATTESTATION_INCLUSION_DELAY"`     // MinAttestationInclusionDelay defines how many slots validator has to wait to include attestation for beacon block.
-	SecondsPerSlot                   uint64 `yaml:"SECONDS_PER_SLOT"`                    // SecondsPerSlot is how many seconds are in a single slot.
-	SlotsPerEpoch                    uint64 `yaml:"SLOTS_PER_EPOCH"`                     // SlotsPerEpoch is the number of slots in an epoch.
-	MinSeedLookahead                 uint64 `yaml:"MIN_SEED_LOOKAHEAD"`                  // SeedLookahead is the duration of randao look ahead seed.
-	ActivationExitDelay              uint64 `yaml:"ACTIVATION_EXIT_DELAY"`               // ActivationExitDelay is the duration a validator has to wait for entry and exit in epoch.
-	SlotsPerEth1VotingPeriod         uint64 `yaml:"SLOTS_PER_ETH1_VOTING_PERIOD"`        // SlotsPerEth1VotingPeriod defines how often the merkle root of deposit receipts get updated in beacon node.
-	SlotsPerHistoricalRoot           uint64 `yaml:"SLOTS_PER_HISTORICAL_ROOT"`           // SlotsPerHistoricalRoot defines how often the historical root is saved.
+	SecondsPerSlot           uint64 `yaml:"SECONDS_PER_SLOT"`                            // SecondsPerSlot is how many seconds are in a single slot.
+	SlotsPerEpoch            uint64 `yaml:"SLOTS_PER_EPOCH"`                             // SlotsPerEpoch is the number of slots in an epoch.
+	MinSeedLookahead         uint64 `yaml:"MIN_SEED_LOOKAHEAD"`                          // SeedLookahead is the duration of randao look ahead seed.
+	MaxSeedLookhead          uint64 `yaml:"ACTIVATION_EXIT_DELAY"`                       // MaxSeedLookhead is the duration a validator has to wait for entry and exit in epoch.
+	SlotsPerEth1VotingPeriod uint64 `yaml:"SLOTS_PER_ETH1_VOTING_PERIOD"`                // SlotsPerEth1VotingPeriod defines how often the merkle root of deposit receipts get updated in beacon node.
+	SlotsPerHistoricalRoot   uint64 `yaml:"SLOTS_PER_HISTORICAL_ROOT"`                   // SlotsPerHistoricalRoot defines how often the historical root is saved.
 	MinValidatorWithdrawabilityDelay uint64 `yaml:"MIN_VALIDATOR_WITHDRAWABILITY_DELAY"` // MinValidatorWithdrawabilityDelay is the shortest amount of time a validator has to wait to withdraw.
 	PersistentCommitteePeriod        uint64 `yaml:"PERSISTENT_COMMITTEE_PERIOD"`         // PersistentCommitteePeriod is the minimum amount of epochs a validator must participate before exitting.
 	MaxEpochsPerCrosslink            uint64 `yaml:"MAX_EPOCHS_PER_CROSSLINK"`            // MaxEpochsPerCrosslink defines the max epoch from current a crosslink can be formed at.
 	MinEpochsToInactivityPenalty     uint64 `yaml:"MIN_EPOCHS_TO_INACTIVITY_PENALTY"`    // MinEpochsToInactivityPenalty defines the minimum amount of epochs since finality to begin penalizing inactivity.
-	Eth1FollowDistance               uint64 // Eth1FollowDistance is the number of eth1.0 blocks to wait before considering a new deposit for voting. This only applies after the chain as been started.
+	Eth1FollowDistance               uint64                                              // Eth1FollowDistance is the number of eth1.0 blocks to wait before considering a new deposit for voting. This only applies after the chain as been started.
 
 	// State list lengths
 	EpochsPerHistoricalVector uint64 `yaml:"EPOCHS_PER_HISTORICAL_VECTOR"` // EpochsPerHistoricalVector defines max length in epoch to store old historical stats in beacon state.
@@ -75,7 +75,7 @@ type BeaconChainConfig struct {
 	// BLS domain values.
 	DomainBeaconProposer []byte `yaml:"DOMAIN_BEACON_PROPOSER"` // DomainBeaconProposer defines the BLS signature domain for beacon proposal verification.
 	DomainRandao         []byte `yaml:"DOMAIN_RANDAO"`          // DomainRandao defines the BLS signature domain for randao verification.
-	DomainAttestation    []byte `yaml:"DOMAIN_ATTESTATION"`     // DomainAttestation defines the BLS signature domain for attestation verification.
+	DomainBeaconAttester []byte `yaml:"DOMAIN_ATTESTATION"`     // DomainBeaconAttester defines the BLS signature domain for attestation verification.
 	DomainDeposit        []byte `yaml:"DOMAIN_DEPOSIT"`         // DomainDeposit defines the BLS signature domain for deposit verification.
 	DomainVoluntaryExit  []byte `yaml:"DOMAIN_VOLUNTARY_EXIT"`  // DomainVoluntaryExit defines the BLS signature domain for exit verification.
 	DomainTransfer       []byte `yaml:"DOMAIN_TRANSFER"`        // DomainTransfer defines the BLS signature domain for transfer verification.
@@ -139,7 +139,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	SecondsPerSlot:                   6,
 	SlotsPerEpoch:                    64,
 	MinSeedLookahead:                 1,
-	ActivationExitDelay:              4,
+	MaxSeedLookhead:                  4,
 	SlotsPerEth1VotingPeriod:         1024,
 	SlotsPerHistoricalRoot:           8192,
 	MinValidatorWithdrawabilityDelay: 256,
@@ -171,8 +171,8 @@ var defaultBeaconConfig = &BeaconChainConfig{
 
 	// BLS domain values.
 	DomainBeaconProposer: bytesutil.Bytes4(0),
-	DomainRandao:         bytesutil.Bytes4(1),
-	DomainAttestation:    bytesutil.Bytes4(2),
+	DomainBeaconAttester: bytesutil.Bytes4(1),
+	DomainRandao:         bytesutil.Bytes4(2),
 	DomainDeposit:        bytesutil.Bytes4(3),
 	DomainVoluntaryExit:  bytesutil.Bytes4(4),
 	DomainTransfer:       bytesutil.Bytes4(5),
@@ -265,7 +265,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.MinAttestationInclusionDelay = 1
 	minimalConfig.SlotsPerEpoch = 8
 	minimalConfig.MinSeedLookahead = 1
-	minimalConfig.ActivationExitDelay = 4
+	minimalConfig.MaxSeedLookhead = 4
 	minimalConfig.SlotsPerEth1VotingPeriod = 16
 	minimalConfig.SlotsPerHistoricalRoot = 64
 	minimalConfig.MinValidatorWithdrawabilityDelay = 256
@@ -298,7 +298,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	// Signature domains
 	minimalConfig.DomainBeaconProposer = bytesutil.Bytes4(0)
 	minimalConfig.DomainRandao = bytesutil.Bytes4(1)
-	minimalConfig.DomainAttestation = bytesutil.Bytes4(2)
+	minimalConfig.DomainBeaconAttester = bytesutil.Bytes4(2)
 	minimalConfig.DomainDeposit = bytesutil.Bytes4(3)
 	minimalConfig.DomainVoluntaryExit = bytesutil.Bytes4(4)
 	minimalConfig.DomainTransfer = bytesutil.Bytes4(5)

--- a/shared/testutil/block.go
+++ b/shared/testutil/block.go
@@ -215,7 +215,7 @@ func generateAttesterSlashings(
 		if err != nil {
 			t.Fatal(err)
 		}
-		domain := helpers.Domain(bState.Fork, i, params.BeaconConfig().DomainAttestation)
+		domain := helpers.Domain(bState.Fork, i, params.BeaconConfig().DomainBeaconAttester)
 		sig := privs[committee[i]].Sign(dataRoot[:], domain)
 		att1.Signature = bls.AggregateSignatures([]*bls.Signature{sig}).Marshal()
 
@@ -367,7 +367,7 @@ func generateAttestations(
 	}
 
 	bitsPerAtt := committeeSize / maxAttestations
-	domain := helpers.Domain(bState.Fork, parentCrosslink.EndEpoch+1, params.BeaconConfig().DomainAttestation)
+	domain := helpers.Domain(bState.Fork, parentCrosslink.EndEpoch+1, params.BeaconConfig().DomainBeaconAttester)
 	for i := uint64(0); i < committeeSize; i += bitsPerAtt {
 		aggregationBits := bitfield.NewBitlist(committeeSize)
 		sigs := []*bls.Signature{}

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -79,7 +79,7 @@ func (v *validator) AttestToBlockHead(ctx context.Context, slot uint64, pubKey [
 	aggregationBitfield := bitfield.NewBitlist(uint64(len(assignment.Committee)))
 	aggregationBitfield.SetBitAt(indexInCommittee, true)
 
-	domain, err := v.validatorClient.DomainData(ctx, &pb.DomainRequest{Epoch: data.Target.Epoch, Domain: params.BeaconConfig().DomainAttestation})
+	domain, err := v.validatorClient.DomainData(ctx, &pb.DomainRequest{Epoch: data.Target.Epoch, Domain: params.BeaconConfig().DomainBeaconAttester})
 	if err != nil {
 		log.WithError(err).Error("Failed to get domain data from beacon node")
 		return


### PR DESCRIPTION
Part of #3865 

This PR updates domain seed function, it corresponds to: https://github.com/ethereum/eth2.0-specs/pull/1415

Change list:
- Update `Seed` function
- Rename config variable `ACTIVATION_EXIT_DELAY` to `MAX_SEED_LOOKAHEAD`
- Rename config domain value for `ATTESTATION` to `BEACON_ATTESTER
- Update config domain value for `RANDAO` and `BEACON_ATTESTER`
- Fixed existing tests and skipped spec tests due to shuffling changes from before