### PR TITLE
Make No Genesis Delay the Default

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -212,7 +212,7 @@ func (s *Service) ProcessChainStart(genesisTime uint64, eth1BlockHash [32]byte, 
 }
 
 func (s *Service) setGenesisTime(timeStamp uint64) {
-	if featureconfig.Get().NoGenesisDelay {
+	if !featureconfig.Get().GenesisDelay {
 		s.eth2GenesisTime = uint64(time.Unix(int64(timeStamp), 0).Add(30 * time.Second).Unix())
 	} else {
 		timeStampRdDown := timeStamp - timeStamp%params.BeaconConfig().SecondsPerDay

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -25,7 +25,7 @@ var log = logrus.WithField("prefix", "flags")
 
 // Flag is a struct to represent what features the client will perform on runtime.
 type Flag struct {
-	NoGenesisDelay           bool // NoGenesisDelay when processing a chain start genesis event.
+	GenesisDelay             bool // GenesisDelay when processing a chain start genesis event.
 	MinimalConfig            bool // MinimalConfig as defined in the spec.
 	WriteSSZStateTransitions bool // WriteSSZStateTransitions to tmp directory.
 	InitSyncNoVerify         bool // InitSyncNoVerify when initial syncing w/o verifying block's contents.
@@ -64,9 +64,9 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Using minimal config")
 		cfg.MinimalConfig = true
 	}
-	if ctx.GlobalBool(NoGenesisDelayFlag.Name) {
+	if ctx.GlobalBool(GenesisDelayFlag.Name) {
 		log.Warn("Using non standard genesis delay. This may cause problems in a multi-node environment.")
-		cfg.NoGenesisDelay = true
+		cfg.GenesisDelay = true
 	}
 	if ctx.GlobalBool(writeSSZStateTransitionsFlag.Name) {
 		log.Warn("Writing SSZ states and blocks after state transitions")

--- a/shared/featureconfig/config_test.go
+++ b/shared/featureconfig/config_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestInitFeatureConfig(t *testing.T) {
 	cfg := &featureconfig.Flag{
-		NoGenesisDelay: true,
+		GenesisDelay: true,
 	}
 	featureconfig.Init(cfg)
-	if c := featureconfig.Get(); !c.NoGenesisDelay {
+	if c := featureconfig.Get(); !c.GenesisDelay {
 		t.Errorf("NoGenesisDelay in FeatureFlags incorrect. Wanted true, got false")
 	}
 }
@@ -21,10 +21,10 @@ func TestInitFeatureConfig(t *testing.T) {
 func TestConfigureBeaconConfig(t *testing.T) {
 	app := cli.NewApp()
 	set := flag.NewFlagSet("test", 0)
-	set.Bool(featureconfig.NoGenesisDelayFlag.Name, true, "enable attestation verification")
+	set.Bool(featureconfig.GenesisDelayFlag.Name, true, "enable attestation verification")
 	context := cli.NewContext(app, set, nil)
 	featureconfig.ConfigureBeaconChain(context)
-	if c := featureconfig.Get(); !c.NoGenesisDelay {
+	if c := featureconfig.Get(); !c.GenesisDelay {
 		t.Errorf("NoGenesisDelay in FeatureFlags incorrect. Wanted true, got false")
 	}
 }

--- a/shared/featureconfig/config_test.go
+++ b/shared/featureconfig/config_test.go
@@ -14,7 +14,7 @@ func TestInitFeatureConfig(t *testing.T) {
 	}
 	featureconfig.Init(cfg)
 	if c := featureconfig.Get(); !c.GenesisDelay {
-		t.Errorf("NoGenesisDelay in FeatureFlags incorrect. Wanted true, got false")
+		t.Errorf("GenesisDelay in FeatureFlags incorrect. Wanted true, got false")
 	}
 }
 

--- a/shared/featureconfig/config_test.go
+++ b/shared/featureconfig/config_test.go
@@ -25,6 +25,6 @@ func TestConfigureBeaconConfig(t *testing.T) {
 	context := cli.NewContext(app, set, nil)
 	featureconfig.ConfigureBeaconChain(context)
 	if c := featureconfig.Get(); !c.GenesisDelay {
-		t.Errorf("NoGenesisDelay in FeatureFlags incorrect. Wanted true, got false")
+		t.Errorf("GenesisDelay in FeatureFlags incorrect. Wanted true, got false")
 	}
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -5,10 +5,10 @@ import (
 )
 
 var (
-	// NoGenesisDelayFlag disables the standard genesis delay.
-	NoGenesisDelayFlag = cli.BoolFlag{
-		Name:  "no-genesis-delay",
-		Usage: "Process genesis event 30s after the ETH1 block time, rather than wait to midnight of the next day.",
+	// GenesisDelayFlag disables the standard genesis delay.
+	GenesisDelayFlag = cli.BoolFlag{
+		Name:  "genesis-delay",
+		Usage: "Wait and process the genesis event at the midnight of the next day rather than 30s after the ETH1 block time of the chainstart triggering deposit",
 	}
 	// MinimalConfigFlag enables the minimal configuration.
 	MinimalConfigFlag = cli.BoolFlag{
@@ -70,7 +70,7 @@ var ValidatorFlags = []cli.Flag{
 
 // BeaconChainFlags contains a list of all the feature flags that apply to the beacon-chain client.
 var BeaconChainFlags = []cli.Flag{
-	NoGenesisDelayFlag,
+	GenesisDelayFlag,
 	MinimalConfigFlag,
 	writeSSZStateTransitionsFlag,
 	EnableAttestationCacheFlag,


### PR DESCRIPTION
 - [x] This changes the flag from `no-genesis-delay` to `genesis-delay`
 - [x] Fixes all references in prysm