### PR TITLE
Set WriteToCache Bool Correctly

### DIFF
--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -259,14 +259,16 @@ func ProcessSlots(ctx context.Context, state *pb.BeaconState, slot uint64) (*pb.
 		cached, ok := skipSlotCache.Get(root)
 		// if cache key does not exist, we write it to the cache.
 		writeToCache = !ok
-		if ok && cached.(*pb.BeaconState).Slot <= slot {
+		if ok {
 			// do not write to cache if state with higher slot exists.
-			writeToCache = writeToCache || cached.(*pb.BeaconState).Slot <= slot
-			state = proto.Clone(cached.(*pb.BeaconState)).(*pb.BeaconState)
-			highestSlot = state.Slot
-			skipSlotCacheHit.Inc()
-		} else {
-			skipSlotCacheMiss.Inc()
+			writeToCache = cached.(*pb.BeaconState).Slot <= slot
+			if cached.(*pb.BeaconState).Slot <= slot {
+				state = proto.Clone(cached.(*pb.BeaconState)).(*pb.BeaconState)
+				highestSlot = state.Slot
+				skipSlotCacheHit.Inc()
+			} else {
+				skipSlotCacheMiss.Inc()
+			}
 		}
 	}
 

--- a/shared/version/version.go
+++ b/shared/version/version.go
@@ -3,8 +3,8 @@ package version
 import (
 	"fmt"
 	"log"
-	"strings"
 	"os/exec"
+	"strings"
 	"time"
 )
 


### PR DESCRIPTION
Following on #3879, this resolves a small bug which was introduced where state entries would be written to the cache regardless if the retrieved state from the cache had a higher or lower slot. This fixes it by only writing to the cache in the case that the cached entry has a lower slot then the needed slot. 