### PR TITLE
Testnet restart: bump fork version

### DIFF
--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -233,7 +233,7 @@ func DemoBeaconConfig() *BeaconChainConfig {
 	demoConfig.Eth1FollowDistance = 16
 
 	// Increment this number after a full testnet tear down.
-	demoConfig.GenesisForkVersion = []byte{0, 0, 0, 2}
+	demoConfig.GenesisForkVersion = []byte{0, 0, 0, 3}
 
 	return demoConfig
 }


### PR DESCRIPTION
OK to merge now. Testnet is down pending restart. 