### PR TITLE
Fix Committee Assignment

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -240,7 +240,7 @@ func CommitteeAssignment(
 				return nil, 0, 0, false, 0, fmt.Errorf(
 					"could not get crosslink committee: %v", err)
 			}
-			for i, v := range committee {
+			for _, v := range committee {
 				if validatorIndex == v {
 					proposerSlot, isProposer := proposerIndexToSlot[v]
 					return committee, uint64(i), slot, isProposer, proposerSlot, nil

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -243,7 +243,7 @@ func TestCommitteeAssignment_CanRetrieve(t *testing.T) {
 			index:          0,
 			slot:           92,
 			committee:      []uint64{46, 0},
-			committeeIndex: 1,
+			committeeIndex: 0,
 			isProposer:     false,
 		},
 		{
@@ -258,7 +258,7 @@ func TestCommitteeAssignment_CanRetrieve(t *testing.T) {
 			index:          11,
 			slot:           64,
 			committee:      []uint64{30, 11},
-			committeeIndex: 1,
+			committeeIndex: 0,
 			isProposer:     false,
 		},
 	}


### PR DESCRIPTION
Quick fix on committee assignment, we were suppose to use the index of the committee in respective to slot, not the index of the validator in respective to committee