### PR TITLE
Remove lightouse compatibility test

### DIFF
--- a/beacon-chain/p2p/encoder/BUILD.bazel
+++ b/beacon-chain/p2p/encoder/BUILD.bazel
@@ -27,7 +27,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//proto/eth/v1alpha1:go_default_library",
         "//proto/testing:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
     ],

--- a/beacon-chain/p2p/encoder/ssz_test.go
+++ b/beacon-chain/p2p/encoder/ssz_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
-	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	testpb "github.com/prysmaticlabs/prysm/proto/testing"
 )
 
@@ -61,16 +60,6 @@ func testRoundTripWithLength(t *testing.T, e *encoder.SszNetworkEncoder) {
 	if !proto.Equal(decoded, msg) {
 		t.Logf("decoded=%+v\n", decoded)
 		t.Error("Decoded message is not the same as original")
-	}
-}
-
-// Regression test to see that a block array response received from Sigma Prime's lighthouse would decode.
-func TestLighthouseBeaconBlockResponse(t *testing.T) {
-	b := []byte{4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 28, 71, 156, 79, 199, 27, 222, 126, 43, 250, 217, 225, 182, 66, 10, 239, 42, 82, 185, 124, 196, 228, 234, 124, 248, 85, 153, 182, 92, 139, 53, 220, 172, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 224, 0, 0, 0, 224, 0, 0, 0, 224, 0, 0, 0, 224, 0, 0, 0, 224, 0, 0, 0, 224, 0, 0, 0}
-	decoded := make([]ethpb.BeaconBlock, 0)
-	e := &encoder.SszNetworkEncoder{UseSnappyCompression: false}
-	if err := e.Decode(b, &decoded); err != nil {
-		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
`TestLighthouseBeaconBlockResponse` no longer works with latest SSZ commit and v0.9. The test solely depends on raw bytes data which makes it really hard to maintain.
We'll have more lighthouse compatibility tests and fixes as they join our testnet soon 