### PR TITLE
do not die if user does not have git installed

### DIFF
--- a/shared/version/version.go
+++ b/shared/version/version.go
@@ -18,9 +18,10 @@ func GetVersion() string {
 	if gitCommit == "{STABLE_GIT_COMMIT}" {
 		commit, err := exec.Command("git", "rev-parse", "HEAD").Output()
 		if err != nil {
-			log.Fatal(err)
+			log.Println(err)
+		} else {
+			gitCommit = strings.TrimRight(string(commit), "\r\n")
 		}
-		gitCommit = strings.TrimRight(string(commit), "\r\n")
 	}
 	if buildDate == "{DATE}" {
 		now := time.Now().Format(time.RFC3339)


### PR DESCRIPTION
Resolves #3943 

---

# Description

**Did not take into account that `git` would not be installed. This is the main case when run from a stripped down docker image.
