### PR TITLE
Do Not Reject Attestations in Genesis Epoch

### DIFF
--- a/beacon-chain/db/kv/finalized_block_roots_test.go
+++ b/beacon-chain/db/kv/finalized_block_roots_test.go
@@ -57,7 +57,7 @@ func TestStore_IsFinalizedBlock(t *testing.T) {
 			t.Errorf("Block at index %d was not considered finalized in the index", i)
 		}
 	}
-	for i := slotsPerEpoch*3; i < len(blks); i++ {
+	for i := slotsPerEpoch * 3; i < len(blks); i++ {
 		root, err := ssz.SigningRoot(blks[i])
 		if err != nil {
 			t.Fatal(err)
@@ -83,10 +83,9 @@ func TestStore_IsFinalized_ForkEdgeCase(t *testing.T) {
 	blocks0 := makeBlocks(t, slotsPerEpoch*0, slotsPerEpoch, genesisBlockRoot)
 	blocks1 := append(
 		makeBlocks(t, slotsPerEpoch*1, 1, bytesutil.ToBytes32(sszRootOrDie(t, blocks0[len(blocks0)-1]))), // No block builds off of the first block in epoch.
-		makeBlocks(t, slotsPerEpoch*1+1, slotsPerEpoch-1, bytesutil.ToBytes32(sszRootOrDie(t, blocks0[len(blocks0)-1])))...
+		makeBlocks(t, slotsPerEpoch*1+1, slotsPerEpoch-1, bytesutil.ToBytes32(sszRootOrDie(t, blocks0[len(blocks0)-1])))...,
 	)
 	blocks2 := makeBlocks(t, slotsPerEpoch*2, slotsPerEpoch, bytesutil.ToBytes32(sszRootOrDie(t, blocks1[len(blocks1)-1])))
-
 
 	db := setupDB(t)
 	defer teardownDB(t, db)

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -66,7 +66,8 @@ func (r *RegularSync) validateBeaconAttestation(ctx context.Context, msg proto.M
 	}
 
 	finalizedEpoch := r.chain.FinalizedCheckpt().Epoch
-	if finalizedEpoch >= att.Data.Source.Epoch || finalizedEpoch >= att.Data.Target.Epoch {
+	attestationDataEpochOld := finalizedEpoch >= att.Data.Source.Epoch || finalizedEpoch >= att.Data.Target.Epoch
+	if finalizedEpoch != 0 && attestationDataEpochOld {
 		log.WithFields(logrus.Fields{
 			"AttestationRoot": fmt.Sprintf("%#x", attRoot),
 			"TargetEpoch":     att.Data.Target.Epoch,

--- a/proto/eth/v1alpha1/slasher.pb.go
+++ b/proto/eth/v1alpha1/slasher.pb.go
@@ -6,11 +6,12 @@ package eth
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+
 	proto "github.com/gogo/protobuf/proto"
 	types "github.com/gogo/protobuf/types"
 	grpc "google.golang.org/grpc"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/slasher/db/min_max-span_test.go
+++ b/slasher/db/min_max-span_test.go
@@ -1,8 +1,9 @@
 package db
 
 import (
-	"github.com/gogo/protobuf/proto"
 	"testing"
+
+	"github.com/gogo/protobuf/proto"
 
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 )

--- a/validator/internal/attester_service_mock.go
+++ b/validator/internal/attester_service_mock.go
@@ -6,11 +6,12 @@ package internal
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	v1alpha1 "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	grpc "google.golang.org/grpc"
-	reflect "reflect"
 )
 
 // MockAttesterServiceClient is a mock of AttesterServiceClient interface

--- a/validator/internal/node_mock.go
+++ b/validator/internal/node_mock.go
@@ -6,11 +6,12 @@ package internal
 
 import (
 	context "context"
+	reflect "reflect"
+
 	types "github.com/gogo/protobuf/types"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	grpc "google.golang.org/grpc"
-	reflect "reflect"
 )
 
 // MockNodeClient is a mock of NodeClient interface

--- a/validator/internal/proposer_service_mock.go
+++ b/validator/internal/proposer_service_mock.go
@@ -6,11 +6,12 @@ package internal
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	v1alpha1 "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	grpc "google.golang.org/grpc"
-	reflect "reflect"
 )
 
 // MockProposerServiceClient is a mock of ProposerServiceClient interface

--- a/validator/internal/validator_service_mock.go
+++ b/validator/internal/validator_service_mock.go
@@ -6,13 +6,14 @@ package internal
 
 import (
 	context "context"
+	reflect "reflect"
+
 	types "github.com/gogo/protobuf/types"
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	v1alpha1 "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	grpc "google.golang.org/grpc"
 	metadata "google.golang.org/grpc/metadata"
-	reflect "reflect"
 )
 
 // MockValidatorServiceClient is a mock of ValidatorServiceClient interface


### PR DESCRIPTION
Currently as part of our attestation validation, we reject attestations which have the less than or equal to source/target epoch as our finalized checkpoint. However this also ends up rejecting attestations in our genesis epoch.

- [x] Add special case to handle attestations in genesis epoch
- [x] Add regression test