### PR TITLE
RPC checks sync status

### DIFF
--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -176,6 +176,7 @@ func (s *Service) Start() {
 		canonicalStateChan:     s.canonicalStateChan,
 		depositFetcher:         s.depositFetcher,
 		pendingDepositsFetcher: s.pendingDepositFetcher,
+		syncChecker:            s.syncService,
 	}
 	attesterServer := &AttesterServer{
 		p2p:               s.p2p,
@@ -184,6 +185,7 @@ func (s *Service) Start() {
 		attReceiver:       s.attestationReceiver,
 		headFetcher:       s.headFetcher,
 		attestationCache:  cache.NewAttestationCache(),
+		syncChecker:       s.syncService,
 	}
 	validatorServer := &ValidatorServer{
 		ctx:                s.ctx,
@@ -195,6 +197,7 @@ func (s *Service) Start() {
 		chainStartFetcher:  s.chainStartFetcher,
 		eth1InfoFetcher:    s.powChainService,
 		depositFetcher:     s.depositFetcher,
+		syncChecker:        s.syncService,
 		stateFeedListener:  s.stateFeedListener,
 		chainStartChan:     make(chan time.Time),
 	}

--- a/beacon-chain/rpc/validator_server_test.go
+++ b/beacon-chain/rpc/validator_server_test.go
@@ -84,6 +84,7 @@ func TestNextEpochCommitteeAssignment_WrongPubkeyLength(t *testing.T) {
 	validatorServer := &ValidatorServer{
 		beaconDB:    db,
 		headFetcher: &mockChain.ChainService{State: beaconState, Root: genesisRoot[:]},
+		syncChecker: &mockSyncChecker{false},
 	}
 	req := &pb.AssignmentRequest{
 		PublicKeys: [][]byte{{1}},
@@ -113,6 +114,7 @@ func TestNextEpochCommitteeAssignment_CantFindValidatorIdx(t *testing.T) {
 	vs := &ValidatorServer{
 		beaconDB:    db,
 		headFetcher: &mockChain.ChainService{State: beaconState, Root: genesisRoot[:]},
+		syncChecker: &mockSyncChecker{false},
 	}
 
 	pubKey := make([]byte, 96)
@@ -166,6 +168,7 @@ func TestCommitteeAssignment_OK(t *testing.T) {
 	vs := &ValidatorServer{
 		beaconDB:    db,
 		headFetcher: &mockChain.ChainService{State: state, Root: genesisRoot[:]},
+		syncChecker: &mockSyncChecker{false},
 	}
 
 	// Test the first validator in registry.
@@ -248,6 +251,7 @@ func TestCommitteeAssignment_CurrentEpoch_ShouldNotFail(t *testing.T) {
 	vs := &ValidatorServer{
 		beaconDB:    db,
 		headFetcher: &mockChain.ChainService{State: state, Root: genesisRoot[:]},
+		syncChecker: &mockSyncChecker{false},
 	}
 
 	// Test the first validator in registry.
@@ -302,6 +306,7 @@ func TestCommitteeAssignment_MultipleKeys_OK(t *testing.T) {
 	vs := &ValidatorServer{
 		beaconDB:    db,
 		headFetcher: &mockChain.ChainService{State: state, Root: genesisRoot[:]},
+		syncChecker: &mockSyncChecker{false},
 	}
 
 	pubkey0 := deposits[0].Data.PublicKey
@@ -319,6 +324,16 @@ func TestCommitteeAssignment_MultipleKeys_OK(t *testing.T) {
 
 	if len(res.ValidatorAssignment) != 2 {
 		t.Fatalf("expected 2 assignments but got %d", len(res.ValidatorAssignment))
+	}
+}
+
+func TestCommitteeAssignment_SyncNotReady(t *testing.T) {
+	vs := &ValidatorServer{
+		syncChecker: &mockSyncChecker{syncing: true},
+	}
+	_, err := vs.CommitteeAssignment(context.Background(), &pb.AssignmentRequest{})
+	if strings.Contains(err.Error(), "syncing to latest head") {
+		t.Error("Did not get wanted error")
 	}
 }
 


### PR DESCRIPTION
These RPC methods will require beacon node to be sync'ed to latest head. Added a check and if it's not sync'ed, returns error 