### PR TITLE
Change to Random Vote

### DIFF
--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -4,7 +4,9 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"net"
+	"os"
 	"time"
 
 	middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -35,6 +37,7 @@ var log logrus.FieldLogger
 
 func init() {
 	log = logrus.WithField("prefix", "rpc")
+	rand.Seed(int64(os.Getpid()))
 }
 
 // Service defining an RPC server for a beacon node.

--- a/proto/eth/v1alpha1/slasher.pb.go
+++ b/proto/eth/v1alpha1/slasher.pb.go
@@ -6,11 +6,12 @@ package eth
 import (
 	context "context"
 	fmt "fmt"
+	io "io"
+	math "math"
+
 	proto "github.com/gogo/protobuf/proto"
 	types "github.com/gogo/protobuf/types"
 	grpc "google.golang.org/grpc"
-	io "io"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
We change to a random vote instead of a mocked vote due to the fact that if we do become disconnected with an eth1node. We do not want the mocked eth1Data to form the majority, so we instead utilize a random eth1data vote so that they can never form a majority and be included in the state as each node will have a different eth1data vote.