### PR TITLE
Decoy flip flop check

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_attestation.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation.go
@@ -72,6 +72,11 @@ func (s *Store) OnAttestation(ctx context.Context, a *ethpb.Attestation) (uint64
 		return 0, err
 	}
 
+	// Verify attestation is from current epoch or previous epoch.
+	if err := s.verifyAttTargetEpoch(ctx, baseState.GenesisTime, uint64(time.Now().Unix()), tgt); err != nil {
+		return 0, err
+	}
+
 	// Verify Attestations cannot be from future epochs.
 	if err := helpers.VerifySlotTime(baseState.GenesisTime, tgtSlot); err != nil {
 		return 0, errors.Wrap(err, "could not verify attestation target slot")
@@ -145,6 +150,21 @@ func (s *Store) verifyAttPreState(ctx context.Context, c *ethpb.Checkpoint) (*pb
 		return nil, fmt.Errorf("pre state of target block %d does not exist", helpers.StartSlot(c.Epoch))
 	}
 	return baseState, nil
+}
+
+// verifyAttTargetEpoch validates attestation is from the current or previous epoch.
+func (s *Store) verifyAttTargetEpoch(ctx context.Context, genesisTime uint64, nowTime uint64, c *ethpb.Checkpoint) error {
+	currentSlot := (nowTime - genesisTime) / params.BeaconConfig().SecondsPerSlot
+	currentEpoch := helpers.SlotToEpoch(currentSlot)
+	var prevEpoch uint64
+	// Prevents previous epoch under flow
+	if currentEpoch > 1 {
+		prevEpoch = currentEpoch - 1
+	}
+	if c.Epoch != prevEpoch && c.Epoch != currentEpoch {
+		return fmt.Errorf("target epoch %d does not match current epoch %d or prev epoch %d", c.Epoch, currentEpoch, prevEpoch)
+	}
+	return nil
 }
 
 // saveCheckpointState saves and returns the processed state with the associated check point.

--- a/beacon-chain/blockchain/forkchoice/process_attestation_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation_test.go
@@ -82,12 +82,12 @@ func TestStore_OnAttestation(t *testing.T) {
 			wantErrString: "pre state of target block 0 does not exist",
 		},
 		{
-			name: "process attestation from future epoch",
+			name: "process attestation doesn't match current epoch",
 			a: &ethpb.Attestation{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{Epoch: params.BeaconConfig().FarFutureEpoch,
 				Root: BlkWithStateBadAttRoot[:]}}},
 			s:             &pb.BeaconState{},
 			wantErr:       true,
-			wantErrString: "could not process slot from the future",
+			wantErrString: "does not match current epoch",
 		},
 	}
 
@@ -299,7 +299,7 @@ func TestAttEpoch_NotMatch(t *testing.T) {
 		ctx,
 		0,
 		2*params.BeaconConfig().SlotsPerEpoch*params.BeaconConfig().SecondsPerSlot,
-		&ethpb.Checkpoint{}); strings.Contains(err.Error(), "target epoch 0 does not match current epoch 2 or prev epoch 1") {
+		&ethpb.Checkpoint{}); !strings.Contains(err.Error(), "target epoch 0 does not match current epoch 2 or prev epoch 1") {
 		t.Error("Did not receive wanted error")
 	}
 }

--- a/beacon-chain/blockchain/forkchoice/process_attestation_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation_test.go
@@ -299,7 +299,8 @@ func TestAttEpoch_NotMatch(t *testing.T) {
 		ctx,
 		0,
 		2*params.BeaconConfig().SlotsPerEpoch*params.BeaconConfig().SecondsPerSlot,
-		&ethpb.Checkpoint{}); !strings.Contains(err.Error(), "target epoch 0 does not match current epoch 2 or prev epoch 1") {
+		&ethpb.Checkpoint{}); !strings.Contains(err.Error(),
+			"target epoch 0 does not match current epoch 2 or prev epoch 1") {
 		t.Error("Did not receive wanted error")
 	}
 }


### PR DESCRIPTION
Part of #3960 

Given current time now. This PR added validation step to verify attestation's target epoch is the same as current epoch or previous epoch