### PR TITLE
Change GetValidatorParticipation to compute participation from previous epoch 

### DIFF
--- a/beacon-chain/archiver/service.go
+++ b/beacon-chain/archiver/service.go
@@ -113,13 +113,13 @@ func (s *Service) archiveActiveSetChanges(ctx context.Context, headState *pb.Bea
 }
 
 // We compute participation metrics by first retrieving the head state and
-// matching validator attestations curing the epoch.
+// matching validator attestations during the epoch.
 func (s *Service) archiveParticipation(ctx context.Context, headState *pb.BeaconState) error {
-	participation, err := epoch.ComputeValidatorParticipation(headState, helpers.CurrentEpoch(headState))
+	participation, err := epoch.ComputeValidatorParticipation(headState, helpers.SlotToEpoch(headState.Slot))
 	if err != nil {
 		return errors.Wrap(err, "could not compute participation")
 	}
-	return s.beaconDB.SaveArchivedValidatorParticipation(ctx, helpers.CurrentEpoch(headState), participation)
+	return s.beaconDB.SaveArchivedValidatorParticipation(ctx, helpers.SlotToEpoch(headState.Slot), participation)
 }
 
 // We archive validator balances and active indices.

--- a/beacon-chain/archiver/service.go
+++ b/beacon-chain/archiver/service.go
@@ -115,11 +115,11 @@ func (s *Service) archiveActiveSetChanges(ctx context.Context, headState *pb.Bea
 // We compute participation metrics by first retrieving the head state and
 // matching validator attestations from the previous epoch.
 func (s *Service) archiveParticipation(ctx context.Context, headState *pb.BeaconState) error {
-	participation, err := epoch.ComputeValidatorParticipation(headState, helpers.PrevEpoch(headState))
+	participation, err := epoch.ComputeValidatorParticipation(headState, helpers.CurrentEpoch(headState))
 	if err != nil {
 		return errors.Wrap(err, "could not compute participation")
 	}
-	return s.beaconDB.SaveArchivedValidatorParticipation(ctx, helpers.PrevEpoch(headState), participation)
+	return s.beaconDB.SaveArchivedValidatorParticipation(ctx, helpers.CurrentEpoch(headState), participation)
 }
 
 // We archive validator balances and active indices.

--- a/beacon-chain/archiver/service.go
+++ b/beacon-chain/archiver/service.go
@@ -113,13 +113,13 @@ func (s *Service) archiveActiveSetChanges(ctx context.Context, headState *pb.Bea
 }
 
 // We compute participation metrics by first retrieving the head state and
-// matching validator attestations during the epoch.
+// matching validator attestations from the previous epoch.
 func (s *Service) archiveParticipation(ctx context.Context, headState *pb.BeaconState) error {
-	participation, err := epoch.ComputeValidatorParticipation(headState)
+	participation, err := epoch.ComputeValidatorParticipation(headState, helpers.PrevEpoch(headState))
 	if err != nil {
 		return errors.Wrap(err, "could not compute participation")
 	}
-	return s.beaconDB.SaveArchivedValidatorParticipation(ctx, helpers.SlotToEpoch(headState.Slot), participation)
+	return s.beaconDB.SaveArchivedValidatorParticipation(ctx, helpers.PrevEpoch(headState), participation)
 }
 
 // We archive validator balances and active indices.

--- a/beacon-chain/archiver/service.go
+++ b/beacon-chain/archiver/service.go
@@ -113,7 +113,7 @@ func (s *Service) archiveActiveSetChanges(ctx context.Context, headState *pb.Bea
 }
 
 // We compute participation metrics by first retrieving the head state and
-// matching validator attestations from the previous epoch.
+// matching validator attestations curing the epoch.
 func (s *Service) archiveParticipation(ctx context.Context, headState *pb.BeaconState) error {
 	participation, err := epoch.ComputeValidatorParticipation(headState, helpers.CurrentEpoch(headState))
 	if err != nil {

--- a/beacon-chain/archiver/service_test.go
+++ b/beacon-chain/archiver/service_test.go
@@ -72,20 +72,20 @@ func TestArchiverService_ComputesAndSavesParticipation(t *testing.T) {
 	triggerNewHeadEvent(t, svc, [32]byte{})
 
 	attestedBalance := uint64(1)
-	currentEpoch := helpers.CurrentEpoch(headState)
+	previousEpoch := helpers.PrevEpoch(headState)
 	wanted := &ethpb.ValidatorParticipation{
 		VotedEther:              attestedBalance,
 		EligibleEther:           validatorCount * params.BeaconConfig().MaxEffectiveBalance,
 		GlobalParticipationRate: float32(attestedBalance) / float32(validatorCount*params.BeaconConfig().MaxEffectiveBalance),
 	}
 
-	retrieved, err := svc.beaconDB.ArchivedValidatorParticipation(svc.ctx, currentEpoch)
+	retrieved, err := svc.beaconDB.ArchivedValidatorParticipation(svc.ctx, previousEpoch)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if !proto.Equal(wanted, retrieved) {
-		t.Errorf("Wanted participation for epoch %d %v, retrieved %v", currentEpoch, wanted, retrieved)
+		t.Errorf("Wanted participation for epoch %d %v, retrieved %v", previousEpoch, wanted, retrieved)
 	}
 	testutil.AssertLogsContain(t, hook, "Successfully archived")
 }

--- a/beacon-chain/archiver/service_test.go
+++ b/beacon-chain/archiver/service_test.go
@@ -72,20 +72,20 @@ func TestArchiverService_ComputesAndSavesParticipation(t *testing.T) {
 	triggerNewHeadEvent(t, svc, [32]byte{})
 
 	attestedBalance := uint64(1)
-	previousEpoch := helpers.PrevEpoch(headState)
+	currentEpoch := helpers.CurrentEpoch(headState)
 	wanted := &ethpb.ValidatorParticipation{
 		VotedEther:              attestedBalance,
 		EligibleEther:           validatorCount * params.BeaconConfig().MaxEffectiveBalance,
 		GlobalParticipationRate: float32(attestedBalance) / float32(validatorCount*params.BeaconConfig().MaxEffectiveBalance),
 	}
 
-	retrieved, err := svc.beaconDB.ArchivedValidatorParticipation(svc.ctx, previousEpoch)
+	retrieved, err := svc.beaconDB.ArchivedValidatorParticipation(svc.ctx, currentEpoch)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if !proto.Equal(wanted, retrieved) {
-		t.Errorf("Wanted participation for epoch %d %v, retrieved %v", previousEpoch, wanted, retrieved)
+		t.Errorf("Wanted participation for epoch %d %v, retrieved %v", currentEpoch, wanted, retrieved)
 	}
 	testutil.AssertLogsContain(t, hook, "Successfully archived")
 }

--- a/beacon-chain/core/epoch/BUILD.bazel
+++ b/beacon-chain/core/epoch/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "//beacon-chain/core/helpers:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
+        "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",

--- a/beacon-chain/core/epoch/participation_test.go
+++ b/beacon-chain/core/epoch/participation_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/epoch"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
-func TestComputeValidatorParticipation(t *testing.T) {
+func TestComputeValidatorParticipation_PreviousEpoch(t *testing.T) {
 	params.OverrideBeaconConfig(params.MinimalSpecConfig())
 	e := uint64(1)
-	attestedBalance := uint64(1)
+	attestedBalance := uint64(20) * params.BeaconConfig().MaxEffectiveBalance
 	validatorCount := uint64(100)
 
 	validators := make([]*ethpb.Validator, validatorCount)
@@ -27,22 +28,128 @@ func TestComputeValidatorParticipation(t *testing.T) {
 		balances[i] = params.BeaconConfig().MaxEffectiveBalance
 	}
 
-	atts := []*pb.PendingAttestation{{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{}}}}
+	blockRoots := make([][]byte, 256)
+	for i := 0; i < len(blockRoots); i++ {
+		slot := bytesutil.Bytes32(uint64(i))
+		blockRoots[i] = slot
+	}
+	target := &ethpb.Checkpoint{
+		Epoch: e,
+		Root:  blockRoots[0],
+	}
+
+	atts := []*pb.PendingAttestation{
+		{
+			Data:            &ethpb.AttestationData{Target: target, Slot: 0},
+			AggregationBits: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			Data:            &ethpb.AttestationData{Target: target, Slot: 1},
+			AggregationBits: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			Data:            &ethpb.AttestationData{Target: target, Slot: 2},
+			AggregationBits: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			Data:            &ethpb.AttestationData{Target: target, Slot: 3},
+			AggregationBits: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			Data:            &ethpb.AttestationData{Target: target, Slot: 4},
+			AggregationBits: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+	}
 
 	s := &pb.BeaconState{
-		Slot:                       e*params.BeaconConfig().SlotsPerEpoch + 1,
+		Slot:                        e*params.BeaconConfig().SlotsPerEpoch + 1,
+		Validators:                  validators,
+		Balances:                    balances,
+		BlockRoots:                  blockRoots,
+		Slashings:                   []uint64{0, 1e9, 1e9},
+		RandaoMixes:                 make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
+		PreviousEpochAttestations:   atts,
+		FinalizedCheckpoint:         &ethpb.Checkpoint{},
+		JustificationBits:           bitfield.Bitvector4{0x00},
+		PreviousJustifiedCheckpoint: target,
+	}
+
+	res, err := epoch.ComputeValidatorParticipation(s, e-1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wanted := &ethpb.ValidatorParticipation{
+		VotedEther:              attestedBalance,
+		EligibleEther:           validatorCount * params.BeaconConfig().MaxEffectiveBalance,
+		GlobalParticipationRate: float32(attestedBalance) / float32(validatorCount*params.BeaconConfig().MaxEffectiveBalance),
+	}
+
+	if !reflect.DeepEqual(res, wanted) {
+		t.Errorf("Incorrect validator participation, wanted %v received %v", wanted, res)
+	}
+}
+
+func TestComputeValidatorParticipation_CurrentEpoch(t *testing.T) {
+	params.OverrideBeaconConfig(params.MinimalSpecConfig())
+	e := uint64(1)
+	attestedBalance := uint64(16) * params.BeaconConfig().MaxEffectiveBalance
+	validatorCount := uint64(100)
+
+	validators := make([]*ethpb.Validator, validatorCount)
+	balances := make([]uint64, validatorCount)
+	for i := 0; i < len(validators); i++ {
+		validators[i] = &ethpb.Validator{
+			ExitEpoch:        params.BeaconConfig().FarFutureEpoch,
+			EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance,
+		}
+		balances[i] = params.BeaconConfig().MaxEffectiveBalance
+	}
+
+	slot := e*params.BeaconConfig().SlotsPerEpoch + 4
+	blockRoots := make([][]byte, 256)
+	for i := 0; i < len(blockRoots); i++ {
+		slot := bytesutil.Bytes32(uint64(i))
+		blockRoots[i] = slot
+	}
+	target := &ethpb.Checkpoint{
+		Epoch: e,
+		Root:  blockRoots[params.BeaconConfig().SlotsPerEpoch],
+	}
+
+	atts := []*pb.PendingAttestation{
+		{
+			Data:            &ethpb.AttestationData{Target: target, Slot: slot - 4},
+			AggregationBits: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			Data:            &ethpb.AttestationData{Target: target, Slot: slot - 3},
+			AggregationBits: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			Data:            &ethpb.AttestationData{Target: target, Slot: slot - 2},
+			AggregationBits: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			Data:            &ethpb.AttestationData{Target: target, Slot: slot - 1},
+			AggregationBits: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+	}
+
+	s := &pb.BeaconState{
+		Slot:                       slot,
 		Validators:                 validators,
 		Balances:                   balances,
-		BlockRoots:                 make([][]byte, 128),
+		BlockRoots:                 blockRoots,
 		Slashings:                  []uint64{0, 1e9, 1e9},
 		RandaoMixes:                make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 		CurrentEpochAttestations:   atts,
 		FinalizedCheckpoint:        &ethpb.Checkpoint{},
 		JustificationBits:          bitfield.Bitvector4{0x00},
-		CurrentJustifiedCheckpoint: &ethpb.Checkpoint{},
+		CurrentJustifiedCheckpoint: target,
 	}
 
-	res, err := epoch.ComputeValidatorParticipation(s)
+	res, err := epoch.ComputeValidatorParticipation(s, e)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -811,7 +811,7 @@ func TestServer_GetValidatorsParticipation_FromArchive(t *testing.T) {
 		VotedEther:              20,
 		EligibleEther:           20,
 	}
-	if err := db.SaveArchivedValidatorParticipation(ctx, epoch, part); err != nil {
+	if err := db.SaveArchivedValidatorParticipation(ctx, epoch-2, part); err != nil {
 		t.Fatal(err)
 	}
 
@@ -843,13 +843,13 @@ func TestServer_GetValidatorsParticipation_FromArchive(t *testing.T) {
 	}
 
 	want := &ethpb.ValidatorParticipationResponse{
-		Epoch:         epoch,
+		Epoch:         epoch - 2,
 		Finalized:     true,
 		Participation: part,
 	}
 	res, err := bs.GetValidatorParticipation(ctx, &ethpb.GetValidatorParticipationRequest{
 		QueryFilter: &ethpb.GetValidatorParticipationRequest_Epoch{
-			Epoch: epoch,
+			Epoch: epoch - 2,
 		},
 	})
 	if err != nil {
@@ -900,7 +900,11 @@ func TestServer_GetValidatorsParticipation_CurrentEpoch(t *testing.T) {
 		HeadFetcher: &mock.ChainService{State: s},
 	}
 
-	res, err := bs.GetValidatorParticipation(ctx, &ethpb.GetValidatorParticipationRequest{})
+	res, err := bs.GetValidatorParticipation(ctx, &ethpb.GetValidatorParticipationRequest{
+		QueryFilter: &ethpb.GetValidatorParticipationRequest_Epoch{
+			Epoch: epoch,
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools/forkchecker/forkchecker.go
+++ b/tools/forkchecker/forkchecker.go
@@ -110,7 +110,9 @@ func compareHeads(clients map[string]pb.BeaconChainClient) {
 
 			if (head1.BlockSlot+1)%params.BeaconConfig().SlotsPerEpoch == 0 {
 				p, err := clients[endpt2].GetValidatorParticipation(context.Background(), &pb.GetValidatorParticipationRequest{
-
+					QueryFilter: &pb.GetValidatorParticipationRequest_Epoch{
+						Epoch: head2.BlockSlot / params.BeaconConfig().SlotsPerEpoch,
+					},
 				})
 				if err != nil {
 					log.Fatal(err)

--- a/tools/forkchecker/forkchecker.go
+++ b/tools/forkchecker/forkchecker.go
@@ -109,7 +109,9 @@ func compareHeads(clients map[string]pb.BeaconChainClient) {
 			logHead(endpt2, head2)
 
 			if (head1.BlockSlot+1)%params.BeaconConfig().SlotsPerEpoch == 0 {
-				p, err := clients[endpt2].GetValidatorParticipation(context.Background(), &pb.GetValidatorParticipationRequest{})
+				p, err := clients[endpt2].GetValidatorParticipation(context.Background(), &pb.GetValidatorParticipationRequest{
+
+				})
 				if err != nil {
 					log.Fatal(err)
 				}


### PR DESCRIPTION
Resolves #3971 

Currently, `GetValidatorParticipation` in the API only gets the participation for the current head, which changes every slot, and is not accurate at all for participation unless called on the last slot, which is not user friendly.

This PR changes `ComputeValidatorParticipation` to allow computing validator participation for the current and previous epoch. It also changes `GetValidatorParticipation` to return the previous epoch participation by default, calculated from the state, and the current head participation can be specifically requested (as I did for fork choice) as needed.