### PR TITLE
Nil Check in Active Set Changes RPC

### DIFF
--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -232,6 +232,13 @@ func (bs *Server) GetValidatorActiveSetChanges(
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not fetch archived active validator changes: %v", err)
 		}
+		if archivedChanges == nil {
+			return nil, status.Errorf(
+				codes.NotFound,
+				"Could not retrieve data for epoch %d, perhaps --archive in the running beacon node is disabled",
+				requestedEpoch,
+			)
+		}
 		activatedIndices = archivedChanges.Activated
 		slashedIndices = archivedChanges.Slashed
 		exitedIndices = archivedChanges.Exited


### PR DESCRIPTION
No tracking issue.

---

# Description

**Write why you are making the changes in this pull request**

Thanks @tzapu for catching this error:

```
alex@playground:~$ curl -X GET "http://localhost:3001/eth/v1alpha1/validators/activesetchanges?epoch=85" -H  "accept: application/json"
{"error":"runtime error: invalid memory address or nil pointer dereference","code":2,"message":"runtime error: invalid memory address or nil pointer dereference"}alex@playground:~$ 
```
The problem is when we retrieve archival data from the DB in that RPC method, we don't do a nil check on the retrieved data.

**Write a summary of the changes you are making**

This PR adds a nil check to return a proper error instead of panicking.
