### PR TITLE
Properly Archive Active Set Changes

### DIFF
--- a/beacon-chain/archiver/service.go
+++ b/beacon-chain/archiver/service.go
@@ -88,11 +88,15 @@ func (s *Service) archiveCommitteeInfo(ctx context.Context, headState *pb.Beacon
 	return nil
 }
 
-// We archive active validator set changes that happened during the epoch.
+// We archive active validator set changes that happened during the previous epoch.
 func (s *Service) archiveActiveSetChanges(ctx context.Context, headState *pb.BeaconState) error {
-	activations := validators.ActivatedValidatorIndices(headState)
-	slashings := validators.SlashedValidatorIndices(headState)
-	exited, err := validators.ExitedValidatorIndices(headState)
+	activations := validators.ActivatedValidatorIndices(helpers.PrevEpoch(headState), headState.Validators)
+	slashings := validators.SlashedValidatorIndices(helpers.PrevEpoch(headState), headState.Validators)
+	activeValidatorCount, err := helpers.ActiveValidatorCount(headState, helpers.PrevEpoch(headState))
+	if err != nil {
+		return errors.Wrap(err, "could not get active validator count")
+	}
+	exited, err := validators.ExitedValidatorIndices(headState.Validators, activeValidatorCount)
 	if err != nil {
 		return errors.Wrap(err, "could not determine exited validator indices")
 	}
@@ -101,7 +105,7 @@ func (s *Service) archiveActiveSetChanges(ctx context.Context, headState *pb.Bea
 		Exited:    exited,
 		Slashed:   slashings,
 	}
-	if err := s.beaconDB.SaveArchivedActiveValidatorChanges(ctx, helpers.CurrentEpoch(headState), activeSetChanges); err != nil {
+	if err := s.beaconDB.SaveArchivedActiveValidatorChanges(ctx, helpers.PrevEpoch(headState), activeSetChanges); err != nil {
 		return errors.Wrap(err, "could not archive active validator set changes")
 	}
 	return nil

--- a/beacon-chain/archiver/service_test.go
+++ b/beacon-chain/archiver/service_test.go
@@ -165,13 +165,13 @@ func TestArchiverService_SavesActivatedValidatorChanges(t *testing.T) {
 	svc.headFetcher = &mock.ChainService{
 		State: headState,
 	}
-	currentEpoch := helpers.CurrentEpoch(headState)
-	delayedActEpoch := helpers.DelayedActivationExitEpoch(currentEpoch)
+	prevEpoch := helpers.PrevEpoch(headState)
+	delayedActEpoch := helpers.DelayedActivationExitEpoch(prevEpoch)
 	headState.Validators[4].ActivationEpoch = delayedActEpoch
 	headState.Validators[5].ActivationEpoch = delayedActEpoch
 	triggerNewHeadEvent(t, svc, [32]byte{})
 
-	retrieved, err := beaconDB.ArchivedActiveValidatorChanges(svc.ctx, currentEpoch)
+	retrieved, err := beaconDB.ArchivedActiveValidatorChanges(svc.ctx, prevEpoch)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -190,12 +190,12 @@ func TestArchiverService_SavesSlashedValidatorChanges(t *testing.T) {
 	svc.headFetcher = &mock.ChainService{
 		State: headState,
 	}
-	currentEpoch := helpers.CurrentEpoch(headState)
+	prevEpoch := helpers.PrevEpoch(headState)
 	headState.Validators[95].Slashed = true
 	headState.Validators[96].Slashed = true
 	triggerNewHeadEvent(t, svc, [32]byte{})
 
-	retrieved, err := beaconDB.ArchivedActiveValidatorChanges(svc.ctx, currentEpoch)
+	retrieved, err := beaconDB.ArchivedActiveValidatorChanges(svc.ctx, prevEpoch)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,12 +214,12 @@ func TestArchiverService_SavesExitedValidatorChanges(t *testing.T) {
 	svc.headFetcher = &mock.ChainService{
 		State: headState,
 	}
-	currentEpoch := helpers.CurrentEpoch(headState)
-	headState.Validators[95].ExitEpoch = currentEpoch + 1
-	headState.Validators[95].WithdrawableEpoch = currentEpoch + 1 + params.BeaconConfig().MinValidatorWithdrawabilityDelay
+	prevEpoch := helpers.PrevEpoch(headState)
+	headState.Validators[95].ExitEpoch = prevEpoch + 1
+	headState.Validators[95].WithdrawableEpoch = prevEpoch + 1 + params.BeaconConfig().MinValidatorWithdrawabilityDelay
 	triggerNewHeadEvent(t, svc, [32]byte{})
 
-	retrieved, err := beaconDB.ArchivedActiveValidatorChanges(svc.ctx, currentEpoch)
+	retrieved, err := beaconDB.ArchivedActiveValidatorChanges(svc.ctx, prevEpoch)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -314,7 +314,12 @@ func ProcessRegistryUpdates(state *pb.BeaconState) (*pb.BeaconState, error) {
 
 	// Only activate just enough validators according to the activation churn limit.
 	limit := len(activationQ)
-	churnLimit, err := helpers.ValidatorChurnLimit(state)
+	activeValidatorCount, err := helpers.ActiveValidatorCount(state, currentEpoch)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get active validator count")
+	}
+
+	churnLimit, err := helpers.ValidatorChurnLimit(activeValidatorCount)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get churn limit")
 	}

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -920,7 +920,7 @@ func TestProcessRegistryUpdates_EligibleToActivate(t *testing.T) {
 		Slot:                5 * params.BeaconConfig().SlotsPerEpoch,
 		FinalizedCheckpoint: &ethpb.Checkpoint{},
 	}
-	limit, err := helpers.ValidatorChurnLimit(state)
+	limit, err := helpers.ValidatorChurnLimit(0)
 	if err != nil {
 		t.Error(err)
 	}

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -146,12 +146,8 @@ func DelayedActivationExitEpoch(epoch uint64) uint64 {
 //    """
 //    active_validator_indices = get_active_validator_indices(state, get_current_epoch(state))
 //    return max(MIN_PER_EPOCH_CHURN_LIMIT, len(active_validator_indices) // CHURN_LIMIT_QUOTIENT)
-func ValidatorChurnLimit(state *pb.BeaconState) (uint64, error) {
-	validatorCount, err := ActiveValidatorCount(state, CurrentEpoch(state))
-	if err != nil {
-		return 0, errors.Wrap(err, "could not get validator count")
-	}
-	churnLimit := validatorCount / params.BeaconConfig().ChurnLimitQuotient
+func ValidatorChurnLimit(activeValidatorCount uint64) (uint64, error) {
+	churnLimit := activeValidatorCount / params.BeaconConfig().ChurnLimitQuotient
 	if churnLimit < params.BeaconConfig().MinPerEpochChurnLimit {
 		churnLimit = params.BeaconConfig().MinPerEpochChurnLimit
 	}

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -208,7 +208,11 @@ func TestChurnLimit_OK(t *testing.T) {
 			Validators:  validators,
 			RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 		}
-		resultChurn, err := ValidatorChurnLimit(beaconState)
+		validatorCount, err := ActiveValidatorCount(beaconState, CurrentEpoch(beaconState))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resultChurn, err := ValidatorChurnLimit(validatorCount)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/beacon-chain/core/validators/BUILD.bazel
+++ b/beacon-chain/core/validators/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
+        "//proto/eth/v1alpha1:go_default_library",
         "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -328,7 +328,11 @@ func TestExitedValidatorIndices(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		exitedIndices, err := ExitedValidatorIndices(tt.state)
+		activeCount, err := helpers.ActiveValidatorCount(tt.state, helpers.CurrentEpoch(tt.state))
+		if err != nil {
+			t.Fatal(err)
+		}
+		exitedIndices, err := ExitedValidatorIndices(tt.state.Validators, activeCount)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -213,7 +213,7 @@ func TestActivatedValidatorIndices(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		activatedIndices := ActivatedValidatorIndices(tt.state)
+		activatedIndices := ActivatedValidatorIndices(helpers.CurrentEpoch(tt.state), tt.state.Validators)
 		if !reflect.DeepEqual(tt.wanted, activatedIndices) {
 			t.Errorf("Wanted %v, received %v", tt.wanted, activatedIndices)
 		}
@@ -270,7 +270,7 @@ func TestSlashedValidatorIndices(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		slashedIndices := SlashedValidatorIndices(tt.state)
+		slashedIndices := SlashedValidatorIndices(helpers.CurrentEpoch(tt.state), tt.state.Validators)
 		if !reflect.DeepEqual(tt.wanted, slashedIndices) {
 			t.Errorf("Wanted %v, received %v", tt.wanted, slashedIndices)
 		}

--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -225,8 +225,6 @@ func (bs *Server) GetValidatorActiveSetChanges(
 	slashedIndices := make([]uint64, 0)
 	exitedIndices := make([]uint64, 0)
 	finalizedEpoch := bs.FinalizationFetcher.FinalizedCheckpt().Epoch
-	var err error
-
 	if requestedEpoch < finalizedEpoch {
 		archivedChanges, err := bs.BeaconDB.ArchivedActiveValidatorChanges(ctx, requestedEpoch)
 		if err != nil {
@@ -235,7 +233,7 @@ func (bs *Server) GetValidatorActiveSetChanges(
 		if archivedChanges == nil {
 			return nil, status.Errorf(
 				codes.NotFound,
-				"Could not retrieve data for epoch %d, perhaps --archive in the running beacon node is disabled",
+				"Did not find any data for epoch %d - perhaps no active set changed occurred during the epoch",
 				requestedEpoch,
 			)
 		}
@@ -243,9 +241,13 @@ func (bs *Server) GetValidatorActiveSetChanges(
 		slashedIndices = archivedChanges.Slashed
 		exitedIndices = archivedChanges.Exited
 	} else {
-		activatedIndices = validators.ActivatedValidatorIndices(headState)
-		slashedIndices = validators.SlashedValidatorIndices(headState)
-		exitedIndices, err = validators.ExitedValidatorIndices(headState)
+		activeValidatorCount, err := helpers.ActiveValidatorCount(headState, helpers.CurrentEpoch(headState))
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not get active validator count: %v", err)
+		}
+		activatedIndices = validators.ActivatedValidatorIndices(helpers.CurrentEpoch(headState), headState.Validators)
+		slashedIndices = validators.SlashedValidatorIndices(helpers.PrevEpoch(headState), headState.Validators)
+		exitedIndices, err = validators.ExitedValidatorIndices(headState.Validators, activeValidatorCount)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not determine exited validator indices: %v", err)
 		}
@@ -382,7 +384,11 @@ func (bs *Server) GetValidatorQueue(
 
 	// Only activate just enough validators according to the activation churn limit.
 	activationQueueChurn := len(activationQ)
-	churnLimit, err := helpers.ValidatorChurnLimit(headState)
+	activeValidatorCount, err := helpers.ActiveValidatorCount(headState, helpers.CurrentEpoch(headState))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not get active validator count: %v", err)
+	}
+	churnLimit, err := helpers.ValidatorChurnLimit(activeValidatorCount)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not compute churn limit: %v", err)
 	}

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -736,7 +736,11 @@ func TestServer_GetValidatorQueue_PendingActivation(t *testing.T) {
 		[]byte("2"),
 		[]byte("3"),
 	}
-	wantChurn, err := helpers.ValidatorChurnLimit(headState)
+	activeValidatorCount, err := helpers.ActiveValidatorCount(headState, helpers.CurrentEpoch(headState))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantChurn, err := helpers.ValidatorChurnLimit(activeValidatorCount)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -789,7 +793,11 @@ func TestServer_GetValidatorQueue_PendingExit(t *testing.T) {
 		[]byte("2"),
 		[]byte("3"),
 	}
-	wantChurn, err := helpers.ValidatorChurnLimit(headState)
+	activeValidatorCount, err := helpers.ActiveValidatorCount(headState, helpers.CurrentEpoch(headState))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantChurn, err := helpers.ValidatorChurnLimit(activeValidatorCount)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR is a follow-up to #4005 

---

# Description

**Write why you are making the changes in this pull request**

Active set changes were not being properly archived and saved to the DB due to an off by one. In particular, we were trying to store the active set changes for the current epoch, but that is not possible, as those will only exist for a previous epoch given how the helper functions work.

**Write a summary of the changes you are making**

This PR also refactors some helper functions for reusability to take in specific input arguments instead of `state *pb.BeaconState`