### PR TITLE
remove source epoch from indexed attestation indices

### DIFF
--- a/slasher/db/indexed_attestations.go
+++ b/slasher/db/indexed_attestations.go
@@ -35,9 +35,9 @@ func createValidatorIDsToIndexedAttestationList(enc []byte) (*ethpb.ValidatorIDT
 // IndexedAttestation accepts a epoch and validator index and returns a list of
 // indexed attestations.
 // Returns nil if the indexed attestation does not exist.
-func (db *Store) IndexedAttestation(sourceEpoch uint64, targetEpoch uint64, validatorID uint64) ([]*ethpb.IndexedAttestation, error) {
+func (db *Store) IndexedAttestation(targetEpoch uint64, validatorID uint64) ([]*ethpb.IndexedAttestation, error) {
 	var iAtt []*ethpb.IndexedAttestation
-	key := append(bytesutil.Bytes8(sourceEpoch), bytesutil.Bytes8(targetEpoch)...)
+	key := bytesutil.Bytes8(targetEpoch)
 	err := db.view(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(indexedAttestationsIndicesBucket)
 		enc := bucket.Get(key)
@@ -49,7 +49,7 @@ func (db *Store) IndexedAttestation(sourceEpoch uint64, targetEpoch uint64, vali
 			i := sort.Search(len(a.Indices), func(i int) bool { return a.Indices[i] >= validatorID })
 			if i < len(a.Indices) && a.Indices[i] == validatorID {
 				iaBucket := tx.Bucket(historicIndexedAttestationsBucket)
-				key := encodeEpochSig(sourceEpoch, targetEpoch, a.Signature)
+				key := encodeEpochSig(targetEpoch, a.Signature)
 				enc = iaBucket.Get(key)
 				if len(enc) == 0 {
 					continue
@@ -68,8 +68,8 @@ func (db *Store) IndexedAttestation(sourceEpoch uint64, targetEpoch uint64, vali
 }
 
 // HasIndexedAttestation accepts an epoch and validator id and returns true if the indexed attestation exists.
-func (db *Store) HasIndexedAttestation(sourceEpoch uint64, targetEpoch uint64, validatorID uint64) bool {
-	key := append(bytesutil.Bytes8(sourceEpoch), bytesutil.Bytes8(targetEpoch)...)
+func (db *Store) HasIndexedAttestation(targetEpoch uint64, validatorID uint64) bool {
+	key := bytesutil.Bytes8(targetEpoch)
 	var hasAttestation bool
 	// #nosec G104
 	_ = db.view(func(tx *bolt.Tx) error {
@@ -95,7 +95,7 @@ func (db *Store) HasIndexedAttestation(sourceEpoch uint64, targetEpoch uint64, v
 
 // SaveIndexedAttestation accepts epoch and indexed attestation and writes it to disk.
 func (db *Store) SaveIndexedAttestation(idxAttestation *ethpb.IndexedAttestation) error {
-	key := encodeEpochSig(idxAttestation.Data.Source.Epoch, idxAttestation.Data.Target.Epoch, idxAttestation.Signature)
+	key := encodeEpochSig(idxAttestation.Data.Target.Epoch, idxAttestation.Signature)
 	enc, err := proto.Marshal(idxAttestation)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal")
@@ -136,7 +136,7 @@ func createIndexedAttestationIndicesFromData(idxAttestation *ethpb.IndexedAttest
 		Indices:   indices,
 		DataRoot:  dataRoot[:],
 	}
-	key := append(bytesutil.Bytes8(idxAttestation.Data.Source.Epoch), bytesutil.Bytes8(idxAttestation.Data.Target.Epoch)...)
+	key := bytesutil.Bytes8(idxAttestation.Data.Target.Epoch)
 
 	bucket := tx.Bucket(indexedAttestationsIndicesBucket)
 	enc := bucket.Get(key)
@@ -157,7 +157,7 @@ func createIndexedAttestationIndicesFromData(idxAttestation *ethpb.IndexedAttest
 
 // DeleteIndexedAttestation deletes a indexed attestation using the slot and its root as keys in their respective buckets.
 func (db *Store) DeleteIndexedAttestation(idxAttestation *ethpb.IndexedAttestation) error {
-	key := encodeEpochSig(idxAttestation.Data.Source.Epoch, idxAttestation.Data.Target.Epoch, idxAttestation.Signature)
+	key := encodeEpochSig(idxAttestation.Data.Target.Epoch, idxAttestation.Signature)
 	return db.update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(historicIndexedAttestationsBucket)
 		enc := bucket.Get(key)
@@ -181,7 +181,7 @@ func removeIndexedAttestationIndicesFromData(idxAttestation *ethpb.IndexedAttest
 		Indices:   indices,
 		DataRoot:  dataRoot[:],
 	}
-	key := append(bytesutil.Bytes8(idxAttestation.Data.Source.Epoch), bytesutil.Bytes8(idxAttestation.Data.Target.Epoch)...)
+	key := bytesutil.Bytes8(idxAttestation.Data.Target.Epoch)
 	bucket := tx.Bucket(indexedAttestationsIndicesBucket)
 	enc := bucket.Get(key)
 	vIdxList, err := createValidatorIDsToIndexedAttestationList(enc)

--- a/slasher/db/indexed_attestations_test.go
+++ b/slasher/db/indexed_attestations_test.go
@@ -43,12 +43,12 @@ func TestNilDBHistoryIdxAtt(t *testing.T) {
 	epoch := uint64(1)
 	validatorID := uint64(1)
 
-	hasIdxAtt := db.HasIndexedAttestation(epoch, epoch, validatorID)
+	hasIdxAtt := db.HasIndexedAttestation(epoch, validatorID)
 	if hasIdxAtt {
 		t.Fatal("HasIndexedAttestation should return false")
 	}
 
-	idxAtt, err := db.IndexedAttestation(epoch, epoch, validatorID)
+	idxAtt, err := db.IndexedAttestation(epoch, validatorID)
 	if err != nil {
 		t.Fatalf("failed to get indexed attestation: %v", err)
 	}
@@ -67,7 +67,7 @@ func TestSaveIdxAtt(t *testing.T) {
 			t.Fatalf("save indexed attestation failed: %v", err)
 		}
 
-		iAarray, err := db.IndexedAttestation(tt.iA.Data.Source.Epoch, tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
+		iAarray, err := db.IndexedAttestation(tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
 		if err != nil {
 			t.Fatalf("failed to get indexed attestation: %v", err)
 		}
@@ -92,7 +92,7 @@ func TestDeleteHistoryIdxAtt(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		iAarray, err := db.IndexedAttestation(tt.iA.Data.Source.Epoch, tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
+		iAarray, err := db.IndexedAttestation(tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
 		if err != nil {
 			t.Fatalf("failed to get index attestation: %v", err)
 		}
@@ -104,8 +104,8 @@ func TestDeleteHistoryIdxAtt(t *testing.T) {
 		if err != nil {
 			t.Fatalf("delete index attestation failed: %v", err)
 		}
-		iAarray, err = db.IndexedAttestation(tt.iA.Data.Source.Epoch, tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
-		hasA := db.HasIndexedAttestation(tt.iA.Data.Source.Epoch, tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
+		iAarray, err = db.IndexedAttestation(tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
+		hasA := db.HasIndexedAttestation(tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -126,7 +126,7 @@ func TestHasIdxAtt(t *testing.T) {
 
 	for _, tt := range tests {
 
-		found := db.HasIndexedAttestation(tt.iA.Data.Source.Epoch, tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
+		found := db.HasIndexedAttestation(tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
 		if found {
 			t.Fatal("has indexed attestation should return false for indexed attestations that are not in db")
 		}
@@ -137,7 +137,7 @@ func TestHasIdxAtt(t *testing.T) {
 	}
 	for _, tt := range tests {
 
-		found := db.HasIndexedAttestation(tt.iA.Data.Source.Epoch, tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
+		found := db.HasIndexedAttestation(tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
 
 		if !found {
 			t.Fatal("has indexed attestation should return true")
@@ -155,7 +155,7 @@ func TestPruneHistoryIdxAtt(t *testing.T) {
 			t.Fatalf("save indexed attestation failed: %v", err)
 		}
 
-		iAarray, err := db.IndexedAttestation(tt.iA.Data.Source.Epoch, tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
+		iAarray, err := db.IndexedAttestation(tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
 		if err != nil {
 			t.Fatalf("failed to get indexed attestation: %v", err)
 		}
@@ -165,18 +165,18 @@ func TestPruneHistoryIdxAtt(t *testing.T) {
 		}
 	}
 	currentEpoch := uint64(3)
-	historyToKeep := uint64(2)
+	historyToKeep := uint64(1)
 	err := db.pruneAttHistory(currentEpoch, historyToKeep)
 	if err != nil {
 		t.Fatalf("failed to prune: %v", err)
 	}
 
 	for _, tt := range tests {
-		iAarray, err := db.IndexedAttestation(tt.iA.Data.Source.Epoch, tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
+		iAarray, err := db.IndexedAttestation(tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
 		if err != nil {
 			t.Fatalf("failed to get indexed attestation: %v", err)
 		}
-		hasIa := db.HasIndexedAttestation(tt.iA.Data.Source.Epoch, tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
+		hasIa := db.HasIndexedAttestation(tt.iA.Data.Target.Epoch, tt.iA.CustodyBit_0Indices[0])
 
 		if tt.iA.Data.Source.Epoch > currentEpoch-historyToKeep {
 			if iAarray == nil || !reflect.DeepEqual(iAarray[0], tt.iA) {

--- a/slasher/db/schema.go
+++ b/slasher/db/schema.go
@@ -24,7 +24,6 @@ func encodeEpochValidatorIDSig(epoch uint64, validatorID uint64, sig []byte) []b
 	return append(append(bytesutil.Bytes8(epoch), bytesutil.Bytes8(validatorID)...), sig...)
 }
 
-func encodeEpochSig(sourceEpoch uint64, targetEpoch uint64, sig []byte) []byte {
-	st := append(bytesutil.Bytes8(sourceEpoch), bytesutil.Bytes8(targetEpoch)...)
-	return append(st, sig...)
+func encodeEpochSig(targetEpoch uint64, sig []byte) []byte {
+	return append(bytesutil.Bytes8(targetEpoch), sig...)
 }


### PR DESCRIPTION
[Part of] #3133

---

# Description

remove source epoch from indexed attestation store as it is not needed for indexing and for double vote detection.