### PR TITLE
Reverts the Revert

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -172,15 +172,10 @@ http_archive(
 )
 
 http_archive(
-    name = "zzzcom_github_herumi_bls_eth_go_binary",
+    name = "com_github_herumi_bls_eth_go_binary",
     sha256 = "7e00d57869645a6e6ed90004bef0717627597ed8d93ab3e3426240c0122c4d54",
     strip_prefix = "bls-go-binary-ae02584f5db9279fb0b2d95214d2179c65c74544",
     url = "https://github.com/nisdas/bls-go-binary/archive/ae02584f5db9279fb0b2d95214d2179c65c74544.zip",
-)
-
-local_repository(
-    name = "com_github_herumi_bls_eth_go_binary",
-    path = "/home/nishant/Projects/GoProjects/src/github.com/nisdas/bls-go-binary",
 )
 
 load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -171,6 +171,13 @@ http_archive(
     url = "https://github.com/bazelbuild/buildtools/archive/bf564b4925ab5876a3f64d8b90fab7f769013d42.zip",
 )
 
+http_archive(
+    name = "com_github_herumi_bls_eth_go_binary",
+    sha256 = "7e00d57869645a6e6ed90004bef0717627597ed8d93ab3e3426240c0122c4d54",
+    strip_prefix = "bls-go-binary-ae02584f5db9279fb0b2d95214d2179c65c74544",
+    url = "https://github.com/nisdas/bls-go-binary/archive/ae02584f5db9279fb0b2d95214d2179c65c74544.zip",
+)
+
 load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")
 
 buildifier_dependencies()
@@ -1236,13 +1243,6 @@ go_repository(
     importpath = "github.com/mdlayher/prombolt",
     sum = "h1:N257g6TTx0LxYoskSDFxvkSJ3NOZpy9IF1xQ7Gu+K8I=",
     version = "v0.0.0-20161005185022-dfcf01d20ee9",
-)
-
-go_repository(
-    name = "com_github_kilic_bls12-381",
-    importpath = "github.com/kilic/bls12-381",
-    sum = "h1:hCD4IWWYsETkACK7U+isYppKfB/6d54sBkCDk3k+w2U=",
-    version = "v0.0.0-20191005202515-c798d6202457",
 )
 
 go_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -172,10 +172,15 @@ http_archive(
 )
 
 http_archive(
-    name = "com_github_herumi_bls_eth_go_binary",
+    name = "zzzcom_github_herumi_bls_eth_go_binary",
     sha256 = "7e00d57869645a6e6ed90004bef0717627597ed8d93ab3e3426240c0122c4d54",
     strip_prefix = "bls-go-binary-ae02584f5db9279fb0b2d95214d2179c65c74544",
     url = "https://github.com/nisdas/bls-go-binary/archive/ae02584f5db9279fb0b2d95214d2179c65c74544.zip",
+)
+
+local_repository(
+    name = "com_github_herumi_bls_eth_go_binary",
+    path = "/home/nishant/Projects/GoProjects/src/github.com/nisdas/bls-go-binary",
 )
 
 load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")

--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -40,7 +40,7 @@ go_image(
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain",
     race = "off",
-    static = "off",  # Static enabled binary seems to cause issues with DNS lookup with cgo.
+    static = "on",  # Static enabled binary seems to cause issues with DNS lookup with cgo.
     tags = ["manual"],
     visibility = ["//visibility:private"],
     deps = [

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -3,7 +3,6 @@ package blocks_test
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
@@ -101,10 +100,7 @@ func TestProcessBlockHeader_DifferentSlots(t *testing.T) {
 	}
 	currentEpoch := helpers.CurrentEpoch(state)
 	dt := helpers.Domain(state.Fork, currentEpoch, params.BeaconConfig().DomainBeaconProposer)
-	priv, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Errorf("failed to generate private key got: %v", err)
-	}
+	priv := bls.RandKey()
 	blockSig := priv.Sign([]byte("hello"), dt)
 	validators[5896].PublicKey = priv.PublicKey().Marshal()
 	block := &ethpb.BeaconBlock{
@@ -145,10 +141,7 @@ func TestProcessBlockHeader_PreviousBlockRootNotSignedRoot(t *testing.T) {
 
 	currentEpoch := helpers.CurrentEpoch(state)
 	dt := helpers.Domain(state.Fork, currentEpoch, params.BeaconConfig().DomainBeaconProposer)
-	priv, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Errorf("failed to generate private key got: %v", err)
-	}
+	priv := bls.RandKey()
 	blockSig := priv.Sign([]byte("hello"), dt)
 	validators[5896].PublicKey = priv.PublicKey().Marshal()
 	block := &ethpb.BeaconBlock{
@@ -160,7 +153,7 @@ func TestProcessBlockHeader_PreviousBlockRootNotSignedRoot(t *testing.T) {
 		Signature:  blockSig.Marshal(),
 	}
 
-	_, err = blocks.ProcessBlockHeader(state, block)
+	_, err := blocks.ProcessBlockHeader(state, block)
 	want := "does not match"
 	if !strings.Contains(err.Error(), want) {
 		t.Errorf("Expected %v, received %v", want, err)
@@ -193,10 +186,7 @@ func TestProcessBlockHeader_SlashedProposer(t *testing.T) {
 	}
 	currentEpoch := helpers.CurrentEpoch(state)
 	dt := helpers.Domain(state.Fork, currentEpoch, params.BeaconConfig().DomainBeaconProposer)
-	priv, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Errorf("failed to generate private key got: %v", err)
-	}
+	priv := bls.RandKey()
 	blockSig := priv.Sign([]byte("hello"), dt)
 	validators[12683].PublicKey = priv.PublicKey().Marshal()
 	block := &ethpb.BeaconBlock{
@@ -243,10 +233,7 @@ func TestProcessBlockHeader_OK(t *testing.T) {
 	}
 	currentEpoch := helpers.CurrentEpoch(state)
 	dt := helpers.Domain(state.Fork, currentEpoch, params.BeaconConfig().DomainBeaconProposer)
-	priv, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Fatalf("Failed to generate private key got: %v", err)
-	}
+	priv := bls.RandKey()
 	block := &ethpb.BeaconBlock{
 		Slot: 0,
 		Body: &ethpb.BeaconBlockBody{
@@ -536,10 +523,7 @@ func TestProcessProposerSlashings_AppliesCorrectStatus(t *testing.T) {
 		helpers.CurrentEpoch(beaconState),
 		params.BeaconConfig().DomainBeaconProposer,
 	)
-	privKey, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Errorf("Could not generate random private key: %v", err)
-	}
+	privKey := bls.RandKey()
 
 	header1 := &ethpb.BeaconBlockHeader{
 		Slot:      0,
@@ -1525,10 +1509,7 @@ func TestProcessDeposits_AddsNewValidatorDeposit(t *testing.T) {
 }
 
 func TestProcessDeposits_RepeatedDeposit_IncreasesValidatorBalance(t *testing.T) {
-	sk, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sk := bls.RandKey()
 	deposit := &ethpb.Deposit{
 		Data: &ethpb.Deposit_Data{
 			PublicKey: sk.PublicKey().Marshal(),
@@ -1840,10 +1821,7 @@ func TestProcessVoluntaryExits_AppliesCorrectStatus(t *testing.T) {
 	}
 	state.Slot = state.Slot + (params.BeaconConfig().PersistentCommitteePeriod * params.BeaconConfig().SlotsPerEpoch)
 
-	priv, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Error(err)
-	}
+	priv := bls.RandKey()
 	state.Validators[0].PublicKey = priv.PublicKey().Marshal()[:]
 	signingRoot, err := ssz.SigningRoot(exits[0])
 	if err != nil {

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -2,7 +2,6 @@ package helpers_test
 
 import (
 	"bytes"
-	"crypto/rand"
 	"sort"
 	"testing"
 
@@ -168,10 +167,7 @@ func TestAggregateAttestations(t *testing.T) {
 	var makeAttestationsFromBitlists = func(bl []bitfield.Bitlist) []*ethpb.Attestation {
 		atts := make([]*ethpb.Attestation, len(bl))
 		for i, b := range bl {
-			sk, err := bls.RandKey(rand.Reader)
-			if err != nil {
-				panic(err)
-			}
+			sk := bls.RandKey()
 			sig := sk.Sign([]byte("dummy_test_data"), 0 /*domain*/)
 			atts[i] = &ethpb.Attestation{
 				AggregationBits: b,

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -3,7 +3,6 @@ package state_test
 import (
 	"bytes"
 	"context"
-	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"strings"
@@ -507,7 +506,7 @@ func TestProcessBlock_PassesProcessingConditions(t *testing.T) {
 	beaconState.BlockRoots = blockRoots
 
 	aggBits := bitfield.NewBitlist(1)
-	aggBits.SetBitAt(1, true)
+	aggBits.SetBitAt(0, true)
 	custodyBits := bitfield.NewBitlist(1)
 	blockAtt := &ethpb.Attestation{
 		Data: &ethpb.AttestationData{
@@ -836,10 +835,7 @@ func BenchmarkProcessBlk_65536Validators_FullBlock(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	priv, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		b.Fatal(err)
-	}
+	priv := bls.RandKey()
 	s.Validators[proposerIdx].PublicKey = priv.PublicKey().Marshal()
 	buf := make([]byte, 32)
 	binary.LittleEndian.PutUint64(buf, 0)

--- a/beacon-chain/gateway/server/BUILD.bazel
+++ b/beacon-chain/gateway/server/BUILD.bazel
@@ -30,7 +30,9 @@ go_image(
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/gateway/server",
+    pure = "off",
     race = "off",
+    static = "on",
     tags = ["manual"],
     visibility = ["//visibility:private"],
     deps = [

--- a/beacon-chain/operations/attestation_test.go
+++ b/beacon-chain/operations/attestation_test.go
@@ -41,7 +41,7 @@ func TestHandleAttestation_Saves_NewAttestation(t *testing.T) {
 			Source:          &ethpb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
 			Target:          &ethpb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
 		},
-		AggregationBits: bitfield.Bitlist{0xC0, 0xC0, 0xC0, 0xC0, 0x01},
+		AggregationBits: bitfield.Bitlist{0xCF, 0xC0, 0xC0, 0xC0, 0x01},
 		CustodyBits:     bitfield.Bitlist{0x00, 0x00, 0x00, 0x00, 0x01},
 	}
 
@@ -360,7 +360,7 @@ func TestRetrieveAttestations_OK(t *testing.T) {
 	}
 
 	aggBits := bitfield.NewBitlist(1)
-	aggBits.SetBitAt(1, true)
+	aggBits.SetBitAt(0, true)
 	custodyBits := bitfield.NewBitlist(1)
 	att := &ethpb.Attestation{
 		Data: &ethpb.AttestationData{
@@ -379,10 +379,12 @@ func TestRetrieveAttestations_OK(t *testing.T) {
 		CustodyBit: false,
 	}
 	domain := helpers.Domain(beaconState.Fork, 0, params.BeaconConfig().DomainBeaconAttester)
+
 	sigs := make([]*bls.Signature, len(attestingIndices))
 
 	zeroSig := [96]byte{}
 	att.Signature = zeroSig[:]
+
 	for i, indice := range attestingIndices {
 		hashTreeRoot, err := ssz.HashTreeRoot(dataAndCustodyBit)
 		if err != nil {
@@ -393,9 +395,7 @@ func TestRetrieveAttestations_OK(t *testing.T) {
 	}
 
 	beaconState.Slot += params.BeaconConfig().MinAttestationInclusionDelay
-
 	att.Signature = bls.AggregateSignatures(sigs).Marshal()[:]
-
 	beaconState.CurrentEpochAttestations = []*pb.PendingAttestation{}
 
 	r, _ := ssz.HashTreeRoot(att.Data)

--- a/beacon-chain/powchain/deposit_test.go
+++ b/beacon-chain/powchain/deposit_test.go
@@ -2,7 +2,6 @@ package powchain
 
 import (
 	"context"
-	"crypto/rand"
 	"strings"
 	"testing"
 
@@ -221,11 +220,7 @@ func TestProcessDeposit_IncompleteDeposit(t *testing.T) {
 		},
 	}
 
-	sk, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	sk := bls.RandKey()
 	deposit.Data.PublicKey = sk.PublicKey().Marshal()
 	signedRoot, err := ssz.SigningRoot(deposit.Data)
 	if err != nil {

--- a/beacon-chain/rpc/validator/server_test.go
+++ b/beacon-chain/rpc/validator/server_test.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -123,14 +122,9 @@ func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
 	ctx := context.Background()
 
-	priv1, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Error(err)
-	}
-	priv2, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Error(err)
-	}
+	priv1 := bls.RandKey()
+	priv2 := bls.RandKey()
+
 	pubKey1 := priv1.PublicKey().Marshal()[:]
 	pubKey2 := priv2.PublicKey().Marshal()[:]
 

--- a/beacon-chain/sync/validate_proposer_slashing_test.go
+++ b/beacon-chain/sync/validate_proposer_slashing_test.go
@@ -56,10 +56,7 @@ func setupValidProposerSlashing(t *testing.T) (*ethpb.ProposerSlashing, *pb.Beac
 		helpers.CurrentEpoch(state),
 		params.BeaconConfig().DomainBeaconProposer,
 	)
-	privKey, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Errorf("Could not generate random private key: %v", err)
-	}
+	privKey := bls.RandKey()
 
 	header1 := &ethpb.BeaconBlockHeader{
 		Slot:      0,

--- a/beacon-chain/sync/validate_voluntary_exit_test.go
+++ b/beacon-chain/sync/validate_voluntary_exit_test.go
@@ -41,10 +41,8 @@ func setupValidExit(t *testing.T) (*ethpb.VoluntaryExit, *pb.BeaconState) {
 		t.Error(err)
 	}
 	domain := helpers.Domain(state.Fork, helpers.CurrentEpoch(state), params.BeaconConfig().DomainVoluntaryExit)
-	priv, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Error(err)
-	}
+	priv := bls.RandKey()
+
 	sig := priv.Sign(signingRoot[:], domain)
 	exit.Signature = sig.Marshal()
 	state.Validators[0].PublicKey = priv.PublicKey().Marshal()[:]

--- a/shared/bls/BUILD.bazel
+++ b/shared/bls/BUILD.bazel
@@ -9,8 +9,8 @@ go_library(
         "//shared/bytesutil:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
+        "@com_github_herumi_bls_eth_go_binary//bls:go_default_library",
         "@com_github_karlseguin_ccache//:go_default_library",
-        "@com_github_kilic_bls12-381//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
     ],
 )
@@ -41,5 +41,7 @@ go_test(
     ],
     deps = [
         "//shared/bls:go_default_library",
+        "//shared/hashutil:go_default_library",
+        "@com_github_herumi_bls_eth_go_binary//bls:go_default_library",
     ],
 )

--- a/shared/bls/bls_benchmark_test.go
+++ b/shared/bls/bls_benchmark_test.go
@@ -1,17 +1,40 @@
 package bls_test
 
 import (
-	"crypto/rand"
 	"testing"
 
+	bls2 "github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
 
-func BenchmarkSignature_Verify(b *testing.B) {
-	sk, err := bls.RandKey(rand.Reader)
+func BenchmarkPairing(b *testing.B) {
+	bls2.Init(bls2.BLS12_381)
+	newGt := &bls2.GT{}
+	newG1 := &bls2.G1{}
+	newG2 := &bls2.G2{}
+
+	newGt.SetInt64(10)
+	hash := hashutil.Hash([]byte{})
+	err := newG1.HashAndMapTo(hash[:])
 	if err != nil {
 		b.Fatal(err)
 	}
+	err = newG2.HashAndMapTo(hash[:])
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		bls2.Pairing(newGt, newG1, newG2)
+	}
+
+}
+func BenchmarkSignature_Verify(b *testing.B) {
+	sk := bls.RandKey()
+
 	msg := []byte("Some msg")
 	domain := uint64(42)
 	sig := sk.Sign(msg, domain)
@@ -26,18 +49,19 @@ func BenchmarkSignature_Verify(b *testing.B) {
 
 func BenchmarkSignature_VerifyAggregate(b *testing.B) {
 	sigN := 128 // MAX_ATTESTATIONS per block.
-	msg := []byte("signed message")
+	msg := [32]byte{'s', 'i', 'g', 'n', 'e', 'd'}
 	domain := uint64(0)
 
 	var aggregated *bls.Signature
 	var pks []*bls.PublicKey
 	for i := 0; i < sigN; i++ {
-		sk, err := bls.RandKey(rand.Reader)
-		if err != nil {
-			b.Fatal(err)
+		sk := bls.RandKey()
+		sig := sk.Sign(msg[:], domain)
+		if aggregated == nil {
+			aggregated = bls.AggregateSignatures([]*bls.Signature{sig})
+		} else {
+			aggregated = bls.AggregateSignatures([]*bls.Signature{aggregated, sig})
 		}
-		sig := sk.Sign(msg, domain)
-		aggregated = bls.AggregateSignatures([]*bls.Signature{aggregated, sig})
 		pks = append(pks, sk.PublicKey())
 	}
 

--- a/shared/bls/bls_test.go
+++ b/shared/bls/bls_test.go
@@ -2,7 +2,6 @@ package bls_test
 
 import (
 	"bytes"
-	"crypto/rand"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/bls"
@@ -10,7 +9,7 @@ import (
 )
 
 func TestMarshalUnmarshal(t *testing.T) {
-	b := []byte("hi")
+	b := bls.RandKey().Marshal()
 	b32 := bytesutil.ToBytes32(b)
 	pk, err := bls.SecretKeyFromBytes(b32[:])
 	if err != nil {
@@ -26,7 +25,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 }
 
 func TestSignVerify(t *testing.T) {
-	priv, _ := bls.RandKey(rand.Reader)
+	priv := bls.RandKey()
 	pub := priv.PublicKey()
 	msg := []byte("hello")
 	sig := priv.Sign(msg, 0)
@@ -41,7 +40,7 @@ func TestVerifyAggregate(t *testing.T) {
 	var msgs [][32]byte
 	for i := 0; i < 100; i++ {
 		msg := [32]byte{'h', 'e', 'l', 'l', 'o', byte(i)}
-		priv, _ := bls.RandKey(rand.Reader)
+		priv := bls.RandKey()
 		pub := priv.PublicKey()
 		sig := priv.Sign(msg[:], 0)
 		pubkeys = append(pubkeys, pub)
@@ -57,11 +56,11 @@ func TestVerifyAggregate(t *testing.T) {
 func TestVerifyAggregateCommon(t *testing.T) {
 	pubkeys := make([]*bls.PublicKey, 0, 100)
 	sigs := make([]*bls.Signature, 0, 100)
-	msg := []byte("hello")
+	msg := [32]byte{'h', 'e', 'l', 'l', 'o'}
 	for i := 0; i < 100; i++ {
-		priv, _ := bls.RandKey(rand.Reader)
+		priv := bls.RandKey()
 		pub := priv.PublicKey()
-		sig := priv.Sign(msg, 0)
+		sig := priv.Sign(msg[:], 0)
 		pubkeys = append(pubkeys, pub)
 		sigs = append(sigs, sig)
 	}
@@ -74,7 +73,7 @@ func TestVerifyAggregateCommon(t *testing.T) {
 func TestVerifyAggregate_ReturnsFalseOnEmptyPubKeyList(t *testing.T) {
 	var pubkeys []*bls.PublicKey
 	sigs := make([]*bls.Signature, 0, 100)
-	msg := []byte("hello")
+	msg := [32]byte{'h', 'e', 'l', 'l', 'o'}
 
 	aggSig := bls.AggregateSignatures(sigs)
 	if aggSig.VerifyAggregateCommon(pubkeys, msg, 0 /*domain*/) != false {

--- a/shared/bls/spectest/BUILD.bazel
+++ b/shared/bls/spectest/BUILD.bazel
@@ -36,6 +36,6 @@ go_test(
         "//shared/bytesutil:go_default_library",
         "//shared/testutil:go_default_library",
         "@com_github_ghodss_yaml//:go_default_library",
-        "@com_github_kilic_bls12-381//:go_default_library",
+        "@com_github_herumi_bls_eth_go_binary//bls:go_default_library",
     ],
 )

--- a/shared/bls/spectest/aggregate_pubkeys_test.go
+++ b/shared/bls/spectest/aggregate_pubkeys_test.go
@@ -46,7 +46,7 @@ func TestAggregatePubkeysYaml(t *testing.T) {
 		t.Fatalf("Cannot decode string to bytes: %v", err)
 	}
 	if !bytes.Equal(outputBytes, pk.Marshal()) {
-		t.Fatal("Output does not equal marshaled aggregated public " +
-			"key bytes")
+		t.Fatalf("Output does not equal marshaled aggregated public "+
+			"key bytes. wanted %#x but got %#x", outputBytes, pk.Marshal())
 	}
 }

--- a/shared/bls/spectest/msg_hash_compressed_test.go
+++ b/shared/bls/spectest/msg_hash_compressed_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
-	bls12 "github.com/kilic/bls12-381"
+	bls2 "github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
@@ -37,13 +37,21 @@ func TestMsgHashCompressed(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Cannot decode string to bytes: %v", err)
 			}
-			g2 := bls12.NewG2(nil)
 			hash := bls.HashWithDomain(
 				bytesutil.ToBytes32(msgBytes),
 				bytesutil.ToBytes8(domain),
 			)
-			g2Point := g2.MapToPoint(hash)
-			compressedHash := g2.ToCompressed(g2Point)
+			g2Point := &bls2.G2{}
+			fp2Point := &bls2.Fp2{}
+			err = fp2Point.Deserialize(hash)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = bls2.MapToG2(g2Point, fp2Point)
+			if err != nil {
+				t.Fatal(err)
+			}
+			compressedHash := g2Point.Serialize()
 
 			var buf []byte
 			for _, innerString := range test.Output {

--- a/shared/bls/spectest/msg_hash_uncompressed_test.go
+++ b/shared/bls/spectest/msg_hash_uncompressed_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
-	bls12 "github.com/kilic/bls12-381"
+	bls2 "github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
@@ -42,8 +42,8 @@ func TestMsgHashUncompressed(t *testing.T) {
 				bytesutil.ToBytes32(msgBytes),
 				bytesutil.ToBytes8(domain),
 			)
-			g2Point := bls12.NewG2(nil).MapToPoint(hash)
-			uncompressed := bls12.NewG2(nil).ToUncompressed(g2Point)
+			sig := bls2.HashAndMapToSignature(hash)
+			uncompressed := sig.Serialize()
 
 			var buf []byte
 			for _, outputStrings := range test.Output {

--- a/shared/bls/spectest/priv_to_pub_test.go
+++ b/shared/bls/spectest/priv_to_pub_test.go
@@ -39,7 +39,7 @@ func TestPrivToPubYaml(t *testing.T) {
 				t.Fatalf("Cannot decode string to bytes: %v", err)
 			}
 			if !bytes.Equal(outputBytes, sk.PublicKey().Marshal()) {
-				t.Fatal("Output does not marshaled public key bytes")
+				t.Fatalf("Output does not marshaled public key bytes wanted %#x but got %#x", outputBytes, sk.PublicKey().Marshal())
 			}
 		})
 	}

--- a/shared/keystore/BUILD.bazel
+++ b/shared/keystore/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//shared/params:go_default_library",
         "@com_github_minio_sha256_simd//:go_default_library",
         "@com_github_pborman_uuid//:go_default_library",
-        "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@org_golang_x_crypto//pbkdf2:go_default_library",
         "@org_golang_x_crypto//scrypt:go_default_library",

--- a/shared/keystore/key.go
+++ b/shared/keystore/key.go
@@ -27,7 +27,6 @@ import (
 	"path/filepath"
 
 	"github.com/pborman/uuid"
-	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 )
 
@@ -153,10 +152,7 @@ func NewKeyFromBLS(blsKey *bls.SecretKey) (*Key, error) {
 
 // NewKey generates a new random key.
 func NewKey(rand io.Reader) (*Key, error) {
-	secretKey, err := bls.RandKey(rand)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not generate random key")
-	}
+	secretKey := bls.RandKey()
 	return NewKeyFromBLS(secretKey)
 }
 

--- a/shared/keystore/key_test.go
+++ b/shared/keystore/key_test.go
@@ -15,10 +15,8 @@ import (
 
 func TestMarshalAndUnmarshal(t *testing.T) {
 	testID := uuid.NewRandom()
-	blsKey, err := bls.RandKey(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
+	blsKey := bls.RandKey()
+
 	key := &Key{
 		ID:        testID,
 		SecretKey: blsKey,

--- a/shared/mathutil/math_helper_test.go
+++ b/shared/mathutil/math_helper_test.go
@@ -57,15 +57,15 @@ func TestIntegerSquareRoot(t *testing.T) {
 		},
 		{
 			number: 1024,
-			root: 32,
+			root:   32,
 		},
 		{
 			number: 4,
-			root: 2,
+			root:   2,
 		},
 		{
 			number: 16,
-			root: 4,
+			root:   4,
 		},
 	}
 

--- a/tools/cluster-pk-manager/client/BUILD.bazel
+++ b/tools/cluster-pk-manager/client/BUILD.bazel
@@ -30,7 +30,7 @@ go_image(
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/tools/cluster-pk-manager/client",
-    pure = "on",
+    pure = "off",
     race = "off",
     tags = ["manual"],
     visibility = ["//visibility:private"],

--- a/tools/cluster-pk-manager/client/BUILD.bazel
+++ b/tools/cluster-pk-manager/client/BUILD.bazel
@@ -30,9 +30,8 @@ go_image(
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/tools/cluster-pk-manager/client",
-    pure = "off",
+    pure = "on",
     race = "off",
-    static = "on",
     tags = ["manual"],
     visibility = ["//visibility:private"],
     deps = [

--- a/tools/cluster-pk-manager/client/BUILD.bazel
+++ b/tools/cluster-pk-manager/client/BUILD.bazel
@@ -30,7 +30,7 @@ go_image(
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/tools/cluster-pk-manager/client",
-    pure = "off",
+    ,off",
     race = "off",
     tags = ["manual"],
     visibility = ["//visibility:private"],

--- a/tools/cluster-pk-manager/client/BUILD.bazel
+++ b/tools/cluster-pk-manager/client/BUILD.bazel
@@ -30,8 +30,9 @@ go_image(
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/tools/cluster-pk-manager/client",
-    ,off",
+    pure = "off",
     race = "off",
+    static = "on",
     tags = ["manual"],
     visibility = ["//visibility:private"],
     deps = [

--- a/tools/cluster-pk-manager/client/BUILD.bazel
+++ b/tools/cluster-pk-manager/client/BUILD.bazel
@@ -30,8 +30,9 @@ go_image(
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/tools/cluster-pk-manager/client",
-    pure = "on",
+    pure = "off",
     race = "off",
+    static = "on",
     tags = ["manual"],
     visibility = ["//visibility:private"],
     deps = [

--- a/tools/cluster-pk-manager/server/BUILD.bazel
+++ b/tools/cluster-pk-manager/server/BUILD.bazel
@@ -78,7 +78,7 @@ go_image(
     importpath = "github.com/prysmaticlabs/prysm/tools/cluster-pk-manager/server",
     pure = "off",  # depends on cgo for go-ethereum crypto
     race = "off",
-    static = "off",
+    static = "on",
     tags = ["manual"],
     visibility = ["//visibility:private"],
     deps = [

--- a/tools/faucet/BUILD.bazel
+++ b/tools/faucet/BUILD.bazel
@@ -49,7 +49,7 @@ go_image(
     importpath = IMPORT_PATH,
     pure = "off",  # depends on cgo for go-ethereum crypto
     race = "off",
-    static = "off",  # go-ethereum is bad about static
+    static = "on",  # go-ethereum is bad about static
     tags = ["manual"],
     deps = DEPS,
 )

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -38,7 +38,7 @@ go_image(
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/validator",
-    pure = "on",
+    pure = "off",
     race = "off",
     tags = ["manual"],
     visibility = ["//visibility:private"],
@@ -77,7 +77,7 @@ docker_push(
 go_binary(
     name = "validator",
     embed = [":go_default_library"],
-    pure = "on",  # Enabled unless there is a valid reason to include cgo dep.
+    pure = "off",  # Enabled unless there is a valid reason to include cgo dep.
     visibility = ["//validator:__subpackages__"],
 )
 

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -40,6 +40,7 @@ go_image(
     importpath = "github.com/prysmaticlabs/prysm/validator",
     pure = "off",
     race = "off",
+    static = "on",
     tags = ["manual"],
     visibility = ["//visibility:private"],
     deps = [


### PR DESCRIPTION
Reverts #4006 which reverted #3752 . 

- [x] Make binaries with cgo deps static by using the `static` attribute in the build file.

This fixes our docker builds which doesn't ask for `libstdc++` when running a binary.