### PR TITLE
Return err for verifyAttestation

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_attestation.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation.go
@@ -89,7 +89,7 @@ func (s *Store) OnAttestation(ctx context.Context, a *ethpb.Attestation) error {
 	// Use the target state to to validate attestation and calculate the committees.
 	indexedAtt, err := s.verifyAttestation(ctx, baseState, a)
 	if err != nil {
-		log.WithError(err).Warn("Removing attestation from queue.")
+		return err
 	}
 
 	// Update every validator's latest vote.


### PR DESCRIPTION
This fixes #4035

When an attestation (bad) fails to verify, we should immediately return error rather than proceed to update its votes