### PR TITLE
remove fully async from bes upload

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -14,8 +14,7 @@ build:remote-cache --strategy=Genrule=standalone
 build:remote-cache --bes_results_url="https://source.cloud.google.com/results/invocations/"
 build:remote-cache --bes_backend=buildeventservice.googleapis.com               
 build:remote-cache --bes_timeout=60s                                            
-build:remote-cache --project_id=prysmaticlabs  
-build:remote-cache --bes_upload_mode=fully_async
+build:remote-cache --project_id=prysmaticlabs
 
 # Prysm specific remote-cache properties.
 build:remote-cache --disk_cache=


### PR DESCRIPTION
I think builds are failing after upgrading bazel to v1.1.0 in build runners, it might be due to fully_async mode for build event service uploads to google cloud.