### PR TITLE
Replace all Breaks with Returns

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -259,7 +259,7 @@ func (s *Service) listenForNewNodes() {
 			s.connectWithAllPeers(multiAddresses)
 		case <-s.ctx.Done():
 			log.Debug("p2p context is closed, exiting routine")
-			break
+			return
 		}
 	}
 }


### PR DESCRIPTION
Adding on to #4040 , replaces all breaks with returns in cases of canceled context.