### PR TITLE
Implement wait till two thirds

### DIFF
--- a/validator/client/validator_aggregate_test.go
+++ b/validator/client/validator_aggregate_test.go
@@ -3,9 +3,11 @@ package client
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
@@ -43,4 +45,20 @@ func TestSubmitAggregateAndProof_Ok(t *testing.T) {
 
 	validator.SubmitAggregateAndProof(context.Background(), 0, validatorPubKey)
 	testutil.AssertLogsContain(t, hook, "Assigned and submitted aggregation and proof request")
+}
+
+func TestWaitForSlotTwoThird_WaitCorrectly(t *testing.T) {
+	validator, _, finish := setup(t)
+	defer finish()
+	currentTime := uint64(time.Now().Unix())
+	numOfSlots := uint64(4)
+	validator.genesisTime = currentTime - (numOfSlots * params.BeaconConfig().SecondsPerSlot)
+	timeToSleep := params.BeaconConfig().SecondsPerSlot * 2 / 3
+	twoThirdTime := currentTime + timeToSleep
+	validator.waitToSlotTwoThirds(context.Background(), numOfSlots)
+
+	currentTime = uint64(time.Now().Unix())
+	if currentTime != twoThirdTime {
+		t.Errorf("Wanted %d time for slot two third but got %d", twoThirdTime, currentTime)
+	}
 }


### PR DESCRIPTION
For aggregator, one should wait until two thirds of the way through the slot to broad cast the best aggregate. This PR implements `waitToSlotTwoThirds` and test 