### PR TITLE
Update attester to wait till one-third

### DIFF
--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -44,7 +44,7 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 
 	// As specified in the spec, an attester should wait until one-third of the way through the slot,
 	// then create and broadcast the attestation.
-	// https://github.com/ethereum/eth2.0-specs/blob/dev/specs/validator/0_beacon-chain-validator.md#attesting
+	// https://github.com/ethereum/eth2.0-specs/blob/v0.9.0/specs/validator/0_beacon-chain-validator.md#attesting
 	v.waitToOneThird(ctx, slot)
 
 	req := &pb.AttestationRequest{

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -42,7 +42,10 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		return
 	}
 
-	v.waitToSlotMidpoint(ctx, slot)
+	// As specified in the spec, an attester should wait until one-third of the way through the slot,
+	// then create and broadcast the attestation.
+	// https://github.com/ethereum/eth2.0-specs/blob/dev/specs/validator/0_beacon-chain-validator.md#attesting
+	v.waitToOneThird(ctx, slot)
 
 	req := &pb.AttestationRequest{
 		Slot:           slot,
@@ -92,16 +95,16 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 	)
 }
 
-// waitToSlotMidpoint waits until halfway through the current slot period
+// waitToOneThird waits until one-third of the way through the slot
 // such that any blocks from this slot have time to reach the beacon node
 // before creating the attestation.
-func (v *validator) waitToSlotMidpoint(ctx context.Context, slot uint64) {
-	_, span := trace.StartSpan(ctx, "validator.waitToSlotMidpoint")
+func (v *validator) waitToOneThird(ctx context.Context, slot uint64) {
+	_, span := trace.StartSpan(ctx, "validator.waitToOneThird")
 	defer span.End()
 
-	half := params.BeaconConfig().SecondsPerSlot / 2
-	delay := time.Duration(half) * time.Second
-	if half == 0 {
+	oneThird := params.BeaconConfig().SecondsPerSlot / 3
+	delay := time.Duration(oneThird) * time.Second
+	if oneThird == 0 {
 		delay = 500 * time.Millisecond
 	}
 	startTime := slotutil.SlotStartTime(v.genesisTime, slot)

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -294,7 +294,7 @@ func TestWaitForSlotOneThird_WaitCorrectly(t *testing.T) {
 	currentTime := uint64(time.Now().Unix())
 	numOfSlots := uint64(4)
 	validator.genesisTime = currentTime - (numOfSlots * params.BeaconConfig().SecondsPerSlot)
-	timeToSleep := params.BeaconConfig().SecondsPerSlot / 2
+	timeToSleep := params.BeaconConfig().SecondsPerSlot / 3
 	oneThird := currentTime + timeToSleep
 	validator.waitToOneThird(context.Background(), numOfSlots)
 

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -296,7 +296,7 @@ func TestWaitForSlotMidPoint_WaitCorrectly(t *testing.T) {
 	validator.genesisTime = currentTime - (numOfSlots * params.BeaconConfig().SecondsPerSlot)
 	timeToSleep := params.BeaconConfig().SecondsPerSlot / 2
 	midpointTime := currentTime + timeToSleep
-	validator.waitToSlotMidpoint(context.Background(), numOfSlots)
+	validator.waitToOneThird(context.Background(), numOfSlots)
 
 	currentTime = uint64(time.Now().Unix())
 	if currentTime != midpointTime {

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -288,18 +288,18 @@ func TestAttestToBlockHead_CorrectBitfieldLength(t *testing.T) {
 	}
 }
 
-func TestWaitForSlotMidPoint_WaitCorrectly(t *testing.T) {
+func TestWaitForSlotOneThird_WaitCorrectly(t *testing.T) {
 	validator, _, finish := setup(t)
 	defer finish()
 	currentTime := uint64(time.Now().Unix())
 	numOfSlots := uint64(4)
 	validator.genesisTime = currentTime - (numOfSlots * params.BeaconConfig().SecondsPerSlot)
 	timeToSleep := params.BeaconConfig().SecondsPerSlot / 2
-	midpointTime := currentTime + timeToSleep
+	oneThird := currentTime + timeToSleep
 	validator.waitToOneThird(context.Background(), numOfSlots)
 
 	currentTime = uint64(time.Now().Unix())
-	if currentTime != midpointTime {
-		t.Errorf("Wanted %d time for slot midpoint but got %d", midpointTime, currentTime)
+	if currentTime != oneThird {
+		t.Errorf("Wanted %d time for slot one-third but got %d", oneThird, currentTime)
 	}
 }


### PR DESCRIPTION
Update the attester to wait till one-third from half of the slot to align with the spec:
https://github.com/ethereum/eth2.0-specs/blob/v0.9.0/specs/validator/0_beacon-chain-validator.md#attesting