### PR TITLE
Complete finalization metrics

### DIFF
--- a/beacon-chain/blockchain/forkchoice/metrics.go
+++ b/beacon-chain/blockchain/forkchoice/metrics.go
@@ -17,6 +17,14 @@ var (
 		Name: "beacon_finalized_root",
 		Help: "Last finalized root of the processed state",
 	})
+	cacheFinalizedEpoch = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_finalized_epoch",
+		Help: "Last cached finalized epoch",
+	})
+	cacheFinalizedRoot = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cache_finalized_root",
+		Help: "Last cached finalized root",
+	})
 	beaconCurrentJustifiedEpoch = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "beacon_current_justified_epoch",
 		Help: "Current justified epoch of the processed state",

--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -292,6 +292,8 @@ func (s *Store) updateCheckpoints(ctx context.Context, postState *pb.BeaconState
 
 		s.prevFinalizedCheckpt = s.finalizedCheckpt
 		s.finalizedCheckpt = postState.FinalizedCheckpoint
+		cacheFinalizedEpoch.Set(float64(s.finalizedCheckpt.Epoch))
+		cacheFinalizedRoot.Set(float64(bytesutil.ToLowInt64(s.finalizedCheckpt.Root)))
 	}
 	return nil
 }

--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -61,6 +61,8 @@ func (s *Service) reportSlotMetrics(currentSlot uint64) {
 	beaconSlot.Set(float64(currentSlot))
 	beaconHeadSlot.Set(float64(s.HeadSlot()))
 	beaconHeadRoot.Set(float64(bytesutil.ToLowInt64(s.HeadRoot())))
-	headFinalizedEpoch.Set(float64(s.headState.FinalizedCheckpoint.Epoch))
-	headFinalizedRoot.Set(float64(bytesutil.ToLowInt64(s.headState.FinalizedCheckpoint.Root)))
+	if s.headState != nil {
+		headFinalizedEpoch.Set(float64(s.headState.FinalizedCheckpoint.Epoch))
+		headFinalizedRoot.Set(float64(bytesutil.ToLowInt64(s.headState.FinalizedCheckpoint.Root)))
+	}
 }

--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -47,10 +47,20 @@ var (
 		Name: "processed_attestation_counter",
 		Help: "The # of processed attestation with pubsub and fork choice, this ususally means attestations from rpc",
 	})
+	headFinalizedEpoch = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "head_finalized_epoch",
+		Help: "Last finalized epoch of the head state",
+	})
+	headFinalizedRoot = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "head_finalized_root",
+		Help: "Last finalized root of the head state",
+	})
 )
 
 func (s *Service) reportSlotMetrics(currentSlot uint64) {
 	beaconSlot.Set(float64(currentSlot))
 	beaconHeadSlot.Set(float64(s.HeadSlot()))
 	beaconHeadRoot.Set(float64(bytesutil.ToLowInt64(s.HeadRoot())))
+	headFinalizedEpoch.Set(float64(s.headState.FinalizedCheckpoint.Epoch))
+	headFinalizedRoot.Set(float64(bytesutil.ToLowInt64(s.headState.FinalizedCheckpoint.Root)))
 }


### PR DESCRIPTION
The previous metrics to capture finalization stats was not enough. It only captures finalization from a processed state. This PR adds additional metrics for
-  head state
- cached check point