### PR TITLE
Reduce genesis validator ocunt

### DIFF
--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -120,7 +120,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	MinPerEpochChurnLimit:          4,
 	ChurnLimitQuotient:             1 << 16,
 	ShuffleRoundCount:              90,
-	MinGenesisActiveValidatorCount: 65536,
+	MinGenesisActiveValidatorCount: 16384,
 	MinGenesisTime:                 1578009600,
 	TargetAggregatorsPerCommittee:  16,
 


### PR DESCRIPTION
Part of #4098 

Reduced genesis validator count from 65536 to 16384

See rationale: https://github.com/ethereum/eth2.0-specs/pull/1467