### PR TITLE
Prevent Requesting Current Epoch for Validator Participation

### DIFF
--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -374,6 +374,14 @@ func (bs *Server) GetValidatorParticipation(
 			Finalized:     requestedEpoch <= headState.FinalizedCheckpoint.Epoch,
 			Participation: participation,
 		}, nil
+	} else if requestedEpoch == currentEpoch {
+		// We cannot retrieve participation for an epoch currently in progress.
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"Cannot retrieve information about an epoch currently in progress, current epoch %d, requesting %d",
+			currentEpoch,
+			requestedEpoch,
+		)
 	} else if requestedEpoch > currentEpoch {
 		// We are requesting data from the future and we return an error.
 		return nil, status.Errorf(

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -1092,6 +1092,31 @@ func TestServer_GetValidatorQueue_PendingExit(t *testing.T) {
 	}
 }
 
+func TestServer_GetValidatorParticipation_CannotRequestCurrentEpoch(t *testing.T) {
+	db := dbTest.SetupDB(t)
+	defer dbTest.TeardownDB(t, db)
+
+	ctx := context.Background()
+	bs := &Server{
+		BeaconDB: db,
+		HeadFetcher: &mock.ChainService{
+			State: &pbp2p.BeaconState{Slot: helpers.StartSlot(2)},
+		},
+	}
+
+	wanted := "Cannot retrieve information about an epoch currently in progress"
+	if _, err := bs.GetValidatorParticipation(
+		ctx,
+		&ethpb.GetValidatorParticipationRequest{
+			QueryFilter: &ethpb.GetValidatorParticipationRequest_Epoch{
+				Epoch: 2,
+			},
+		},
+	); err != nil && !strings.Contains(err.Error(), wanted) {
+		t.Errorf("Expected error %v, received %v", wanted, err)
+	}
+}
+
 func TestServer_GetValidatorParticipation_CannotRequestFutureEpoch(t *testing.T) {
 	db := dbTest.SetupDB(t)
 	defer dbTest.TeardownDB(t, db)

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -1248,7 +1248,7 @@ func TestServer_GetValidatorParticipation_FromArchive_FinalizedEpoch(t *testing.
 	}
 }
 
-func TestServer_GetValidatorParticipation_CurrentEpoch(t *testing.T) {
+func TestServer_GetValidatorParticipation_PrevEpoch(t *testing.T) {
 	helpers.ClearAllCaches()
 	db := dbTest.SetupDB(t)
 	defer dbTest.TeardownDB(t, db)
@@ -1288,11 +1288,7 @@ func TestServer_GetValidatorParticipation_CurrentEpoch(t *testing.T) {
 		HeadFetcher: &mock.ChainService{State: s},
 	}
 
-	res, err := bs.GetValidatorParticipation(ctx, &ethpb.GetValidatorParticipationRequest{
-		QueryFilter: &ethpb.GetValidatorParticipationRequest_Epoch{
-			Epoch: epoch,
-		},
-	})
+	res, err := bs.GetValidatorParticipation(ctx, &ethpb.GetValidatorParticipationRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Resolves #4076

---

# Description

**Write why you are making the changes in this pull request**

We should not allow users to retrieve validator participation for the current epoch, as it is error-prone and almost entirely inaccurate. As seen in #4076, it can lead to big errors regarding out of bounds in certain arrays.

**Write a summary of the changes you are making**

This PR throws an error if attempting to retrieve current epoch participation specifically