### PR TITLE
Enforce --p2p-max-peers

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "@com_github_libp2p_go_libp2p//:go_default_library",
         "@com_github_libp2p_go_libp2p//config:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/host/routed:go_default_library",
+        "@com_github_libp2p_go_libp2p_connmgr//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//crypto:go_default_library",
         "@com_github_libp2p_go_libp2p_core//host:go_default_library",

--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -24,7 +24,7 @@ func buildOptions(cfg *Config, ip net.IP, priKey *ecdsa.PrivateKey) []libp2p.Opt
 		libp2p.EnableRelay(),
 		libp2p.ListenAddrs(listen),
 		whitelistSubnet(cfg.WhitelistCIDR),
-		libp2p.ConnectionManager(connmgr.NewConnManager(5, int(cfg.MaxPeers), 1 * time.Minute)),
+		libp2p.ConnectionManager(connmgr.NewConnManager(int(cfg.MaxPeers), int(cfg.MaxPeers), 1 * time.Minute)),
 	}
 	if cfg.EnableUPnP {
 		options = append(options, libp2p.NATPortMap()) //Allow to use UPnP

--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -4,8 +4,10 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-connmgr"
 	filter "github.com/libp2p/go-maddr-filter"
 	"github.com/multiformats/go-multiaddr"
 	ma "github.com/multiformats/go-multiaddr"
@@ -22,6 +24,7 @@ func buildOptions(cfg *Config, ip net.IP, priKey *ecdsa.PrivateKey) []libp2p.Opt
 		libp2p.EnableRelay(),
 		libp2p.ListenAddrs(listen),
 		whitelistSubnet(cfg.WhitelistCIDR),
+		libp2p.ConnectionManager(connmgr.NewConnManager(5, int(cfg.MaxPeers), 1 * time.Minute)),
 	}
 	if cfg.EnableUPnP {
 		options = append(options, libp2p.NATPortMap()) //Allow to use UPnP


### PR DESCRIPTION
This flag has been broken since the refactoring of p2p library.

I've tested locally that peer count is reduced to the threshold as expected.