### PR TITLE
Tool to dump graphviz data for block tree

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1347,3 +1347,9 @@ go_repository(
     sum = "h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=",
     version = "v1.7.0",
 )
+
+go_repository(
+    name = "com_github_emicklei_dot",
+    commit = "f4a04130244d60cef56086d2f649b4b55e9624aa",
+    importpath = "github.com/emicklei/dot",
+)

--- a/tools/blocktree/BUILD.bazel
+++ b/tools/blocktree/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/prysmaticlabs/prysm/tools/blocktree",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//beacon-chain/db:go_default_library",
+        "//beacon-chain/db/filters:go_default_library",
+        "//shared/bytesutil:go_default_library",
+        "@com_github_emicklei_dot//:go_default_library",
+        "@com_github_prysmaticlabs_go_ssz//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "blocktree",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/blocktree/main.go
+++ b/tools/blocktree/main.go
@@ -1,0 +1,84 @@
+/**
+ * Block tree graph viz
+ *
+ * Given a DB, start slot and end slot. This tool computes the graphviz data
+ * needed to construct the block tree in graphviz data format. Then one can paste
+ * the data in a Graph rendering engine (ie. http://www.webgraphviz.com/) to see the visual format.
+
+ */
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"strconv"
+
+	"github.com/emicklei/dot"
+	"github.com/prysmaticlabs/go-ssz"
+	"github.com/prysmaticlabs/prysm/beacon-chain/db"
+	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+)
+
+var (
+	// Required fields
+	datadir   = flag.String("datadir", "", "Path to data directory.")
+	startSlot = flag.Uint("startSlot", 0, "Start slot of the block tree")
+	endSlot   = flag.Uint("endSlot", 0, "Start slot of the block tree")
+)
+
+// Used for tree, each node is a representation of a node in the graph
+type node struct {
+	parentRoot [32]byte
+	dothNode   *dot.Node
+}
+
+func main() {
+	flag.Parse()
+	db, err := db.NewDB(*datadir)
+	if err != nil {
+		panic(err)
+	}
+
+	graph := dot.NewGraph(dot.Directed)
+	graph.Attr("rankdir", "RL")
+	graph.Attr("labeljust", "l")
+
+	startSlot := uint64(*startSlot)
+	endSlot := uint64(*endSlot)
+	filter := filters.NewFilter().SetStartSlot(startSlot).SetEndSlot(endSlot)
+	blks, err := db.Blocks(context.Background(), filter)
+	if err != nil {
+		panic(err)
+	}
+
+	// Construct nodes
+	m := make(map[[32]byte]*node)
+	for i := 0; i < len(blks); i++ {
+		b := blks[i]
+		r, err := ssz.SigningRoot(b)
+		if err != nil {
+			panic(err)
+		}
+		// Construct label of each node.
+		rStr := hex.EncodeToString(r[:2])
+		label := "slot: " + strconv.Itoa(int(b.Slot)) + "\n root: " + rStr
+		dotN := graph.Node(rStr).Box().Attr("label", label)
+		n := &node{
+			parentRoot: bytesutil.ToBytes32(b.ParentRoot),
+			dothNode:   &dotN,
+		}
+		m[r] = n
+	}
+
+	// Construct an edge only if block's parent exist in the tree.
+	for _, n := range m {
+		if _, ok := m[n.parentRoot]; ok {
+			graph.Edge(*n.dothNode, *m[n.parentRoot].dothNode)
+		}
+	}
+
+	fmt.Println(graph.String())
+}


### PR DESCRIPTION
This tool helps to generate graphviz data by inputing a db, start slot and end slot. One can paste this graphviz data to a render site to get the full visualized form of the tree. 

example
```
➜  blocktree git:(block-tree-tool) go run main.go --datadir /Users/terencetsao/badfinality/beaconchaindata/ --startSlot 74101 --endSlot 74150
digraph  {
        labeljust="l";rankdir="RL";
        n10[label="slot: 74114\n root: 0165",shape="box"];
        n25[label="slot: 74132\n root: 04bb",shape="box"];
        n2[label="slot: 74104\n root: 0bbc",shape="box"];
        n33[label="slot: 74148\n root: 0d5e",shape="box"];
        n8[label="slot: 74111\n root: 1c5a",shape="box"];
        n24[label="slot: 74131\n root: 219a",shape="box"];
        n14[label="slot: 74118\n root: 2880",shape="box"];
        n6[label="slot: 74109\n root: 2c3f",shape="box"];
        n15[label="slot: 74121\n root: 503b",shape="box"];
        n21[label="slot: 74128\n root: 520f",shape="box"];
        n26[label="slot: 74133\n root: 5328",shape="box"];
        n11[label="slot: 74115\n root: 55e5",shape="box"];
        n29[label="slot: 74137\n root: 5892",shape="box"];
        n3[label="slot: 74105\n root: 5ae0",shape="box"];
        n12[label="slot: 74116\n root: 5d07",shape="box"];
        n28[label="slot: 74135\n root: 5eb7",shape="box"];
        n20[label="slot: 74127\n root: 6324",shape="box"];
        n22[label="slot: 74129\n root: 6e65",shape="box"];
        n5[label="slot: 74108\n root: 6ec8",shape="box"];
        n31[label="slot: 74145\n root: 6ffd",shape="box"];
        n13[label="slot: 74117\n root: 716f",shape="box"];
        n35[label="slot: 74150\n root: 7cc6",shape="box"];
        n9[label="slot: 74113\n root: 7f0e",shape="box"];
        n7[label="slot: 74110\n root: 81b8",shape="box"];
        n17[label="slot: 74123\n root: 8556",shape="box"];
        n32[label="slot: 74146\n root: 872c",shape="box"];
        n19[label="slot: 74126\n root: 8c29",shape="box"];
        n4[label="slot: 74107\n root: b117",shape="box"];
        n1[label="slot: 74101\n root: bf92",shape="box"];
        n16[label="slot: 74122\n root: c30c",shape="box"];
        n27[label="slot: 74134\n root: c85f",shape="box"];
        n18[label="slot: 74125\n root: dd1c",shape="box"];
        n34[label="slot: 74149\n root: e209",shape="box"];
        n23[label="slot: 74130\n root: e5de",shape="box"];
        n30[label="slot: 74144\n root: f9fd",shape="box"];
        n10->n9;
        n25->n24;
        n2->n1;
        n33->n32;
        n8->n7;
        n24->n22;
        n14->n13;
        n6->n5;
        n15->n14;
        n21->n20;
        n26->n25;
        n11->n10;
        n29->n25;
        n3->n1;
        n12->n11;
        n28->n27;
        n20->n19;
        n22->n21;
        n5->n4;
        n31->n30;
        n13->n12;
        n35->n34;
        n9->n8;
        n7->n6;
        n17->n16;
        n32->n31;
        n19->n18;
        n4->n3;
        n16->n15;
        n27->n26;
        n18->n17;
        n34->n33;
        n23->n18;
        n30->n23;
}
```

After rendering:
![Screen Shot 2019-11-25 at 2 25 56 PM](https://user-images.githubusercontent.com/21316537/69583336-838cbc80-0f8f-11ea-8744-033d9dc796da.png)
