### PR TITLE
Lower conn mgr grace period to 1s

### DIFF
--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -24,7 +24,7 @@ func buildOptions(cfg *Config, ip net.IP, priKey *ecdsa.PrivateKey) []libp2p.Opt
 		libp2p.EnableRelay(),
 		libp2p.ListenAddrs(listen),
 		whitelistSubnet(cfg.WhitelistCIDR),
-		libp2p.ConnectionManager(connmgr.NewConnManager(int(cfg.MaxPeers), int(cfg.MaxPeers), 1 * time.Minute)),
+		libp2p.ConnectionManager(connmgr.NewConnManager(int(cfg.MaxPeers), int(cfg.MaxPeers), 1 * time.Second)),
 	}
 	if cfg.EnableUPnP {
 		options = append(options, libp2p.NATPortMap()) //Allow to use UPnP


### PR DESCRIPTION
We are observing a high churn of peers, probably because they are allowed to be connected for 1 minute before being disconnected.