### PR TITLE
Account for Skipped Slots When Requesting for Blocks

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -79,7 +79,7 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 
 			// Short circuit start far exceeding the highest finalized epoch in some infinite loop.
 			if start > helpers.StartSlot(highestFinalizedEpoch()+1) {
-				return nil, errors.New("attempted to ask for a start slot greater than the next highest epoch")
+				return nil, errors.Errorf("attempted to ask for a start slot of %d which is greater than the next highest epoch of %d", start, helpers.StartSlot(highestFinalizedEpoch()+1))
 			}
 
 			atomic.AddInt32(&p2pRequestCount, int32(len(peers)))
@@ -157,6 +157,12 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 					}
 				}
 			}
+		}
+		startBlock := s.chain.HeadSlot() + 1
+		skippedBlocks := blockBatchSize * uint64(lastEmptyRequests*len(peers))
+		if startBlock+skippedBlocks > helpers.StartSlot(finalizedEpoch+1) {
+			log.Debug("requested block range is greater than the finalized epoch")
+			break
 		}
 
 		blocks, err := request(

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -161,7 +161,7 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 		startBlock := s.chain.HeadSlot() + 1
 		skippedBlocks := blockBatchSize * uint64(lastEmptyRequests*len(peers))
 		if startBlock+skippedBlocks > helpers.StartSlot(finalizedEpoch+1) {
-			log.Debug("requested block range is greater than the finalized epoch")
+			log.WithField("finalizedEpoch", finalizedEpoch).Debug("Requested block range is greater than the finalized epoch")
 			break
 		}
 

--- a/tools/blocktree/main.go
+++ b/tools/blocktree/main.go
@@ -35,7 +35,7 @@ var (
 type node struct {
 	parentRoot [32]byte
 	dothNode   *dot.Node
-	score map[uint64]bool
+	score      map[uint64]bool
 }
 
 func main() {


### PR DESCRIPTION
Resolves #4041

Before sending out a new request, we check if the start slot of the request is higher than the finalized epoch. We also include potential skipped slots in our check.