### PR TITLE
Remove pruned states check

### DIFF
--- a/beacon-chain/db/kv/prune_states.go
+++ b/beacon-chain/db/kv/prune_states.go
@@ -7,6 +7,7 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/sirupsen/logrus"
 )
 
@@ -14,6 +15,13 @@ var pruneStatesKey = []byte("prune-states")
 
 func (kv *Store) pruneStates(ctx context.Context) error {
 	var pruned bool
+
+	if !featureconfig.Get().PruneEpochBoundaryStates {
+		return kv.db.Update(func(tx *bolt.Tx) error {
+			bkt := tx.Bucket(migrationBucket)
+			return bkt.Put(pruneStatesKey, []byte{0x00})
+		})
+	}
 
 	kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(migrationBucket)

--- a/beacon-chain/db/kv/prune_states.go
+++ b/beacon-chain/db/kv/prune_states.go
@@ -3,12 +3,10 @@ package kv
 import (
 	"bytes"
 	"context"
-	"errors"
 
 	"github.com/boltdb/bolt"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,13 +21,6 @@ func (kv *Store) pruneStates(ctx context.Context) error {
 		pruned = len(v) == 1 && v[0] == 0x01
 		return nil
 	})
-
-	if !featureconfig.Get().PruneEpochBoundaryStates {
-		if pruned {
-			return errors.New("beaconDB has been pruned for states before last finalized checkpoint, run with flag --prune-states")
-		}
-		return nil
-	}
 
 	if pruned {
 		return nil


### PR DESCRIPTION
Removing already pruned states check.  It shouldn't be a problem to go back saving boundary states once it's already pruned 
Flipped `pruneStatesKey` to `0x00` when going back to saving boundary states