### PR TITLE
Add tag for benchmark test

### DIFF
--- a/beacon-chain/core/state/benchmarks/BUILD.bazel
+++ b/beacon-chain/core/state/benchmarks/BUILD.bazel
@@ -5,6 +5,7 @@ go_test(
     srcs = ["benchmarks_test.go"],
     data = ["//beacon-chain/core/state/benchmarks/benchmark_files:benchmark_data"],
     embed = [":go_default_library"],
+    tags = ["benchmark"],
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",


### PR DESCRIPTION
It was reported by multiple users that `TestBenchmarkExecuteStateTransition` was taking more than 300s with constant time out. Since it uses mainnet config with most extreme scenarios. 

This PR adds a benchmark tag for the bazel build file

Credit @mcdee for the suggestion