### PR TITLE
Reduce amount of time for benchmark tests

### DIFF
--- a/beacon-chain/core/state/benchmarks/README.md
+++ b/beacon-chain/core/state/benchmarks/README.md
@@ -18,8 +18,8 @@ Bazel does not allow writing to the project directory, so running with `go run` 
 
 ## Current Results as of November 2019
 ```
-BenchmarkExecuteStateTransition-4   	         25	35901941409 ns/op	7465058127 B/op	111046635 allocs/op
-BenchmarkExecuteStateTransition_WithCache-4    25	24352836461 ns/op	716078697 B/op	22348530 allocs/op
-BenchmarkProcessEpoch_2FullEpochs-4   	       5	177559078808 ns/op	12754314974 B/op	176571470 allocs/op
-BenchmarkHashTreeRoot_FullState-4   	         50	1321382095 ns/op	253959577 B/op	 9645648 allocs/op
+BenchmarkExecuteStateTransition-4             	      20	33020593584 ns/op
+BenchmarkExecuteStateTransition_WithCache-4   	      20	21272276477 ns/op
+BenchmarkProcessEpoch_2FullEpochs-4           	       5	158161708836 ns/op
+BenchmarkHashTreeRoot_FullState-4   	              50	1509721280 ns/op
 ```

--- a/beacon-chain/core/state/benchmarks/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks/benchmarks_test.go
@@ -29,7 +29,7 @@ func TestBenchmarkExecuteStateTransition(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := state.ExecuteStateTransitionNoVerify(context.Background(), beaconState, block); err != nil {
+	if _, err := state.ExecuteStateTransition(context.Background(), beaconState, block); err != nil {
 		t.Fatalf("failed to process block, benchmarks will fail: %v", err)
 	}
 }

--- a/beacon-chain/core/state/benchmarks/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks/benchmarks_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
-var runAmount = 25
+var runAmount = 20
 
 func TestBenchmarkExecuteStateTransition(t *testing.T) {
 	SetConfig()
@@ -93,8 +93,18 @@ func BenchmarkExecuteStateTransition_WithCache(b *testing.B) {
 	if err := helpers.UpdateCommitteeCache(beaconState); err != nil {
 		b.Fatal(err)
 	}
-
+	if _, err := helpers.ActiveValidatorIndices(beaconState, 0); err != nil {
+		b.Fatal(err)
+	}
 	beaconState.Slot = currentSlot
+	if _, err := helpers.ActiveValidatorIndices(beaconState, 1); err != nil {
+		b.Fatal(err)
+	}
+	// Run the state transition once to populate the cache.
+	if _, err := state.ExecuteStateTransition(context.Background(), beaconState, block); err != nil {
+		b.Fatalf("failed to process block, benchmarks will fail: %v", err)
+	}
+
 	b.N = runAmount
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
This PR fixes the issue of the sanity tests for benchmarks taking too long, it removes the test for ProcessEpoch (Which takes way too long and isn't really needed for this).

It also caches BLS pubkeys for the block benchmark, to bring us an improved time of 21 seconds.