### PR TITLE
Update API to return empty next page token on last page response

### DIFF
--- a/shared/pagination/pagination.go
+++ b/shared/pagination/pagination.go
@@ -23,7 +23,7 @@ func StartAndEndPage(pageToken string, pageSize int, totalSize int) (int, int, s
 		return 0, 0, "", errors.Wrap(err, "could not convert page token")
 	}
 
-	// Start page can not be greater than validator size.
+	// Start page can not be greater than set size.
 	start := token * pageSize
 	if start >= totalSize {
 		return 0, 0, "", fmt.Errorf("page start %d >= list %d", start, totalSize)
@@ -31,10 +31,12 @@ func StartAndEndPage(pageToken string, pageSize int, totalSize int) (int, int, s
 
 	// End page can not go out of bound.
 	end := start + pageSize
+	nextPageToken := strconv.Itoa(token + 1)
+
 	if end > totalSize {
 		end = totalSize
+		nextPageToken = ""
 	}
 
-	nextPageToken := strconv.Itoa(token + 1)
 	return start, end, nextPageToken, nil
 }

--- a/shared/pagination/pagination.go
+++ b/shared/pagination/pagination.go
@@ -35,7 +35,7 @@ func StartAndEndPage(pageToken string, pageSize int, totalSize int) (int, int, s
 
 	if end > totalSize {
 		end = totalSize
-		nextPageToken = ""
+		nextPageToken = "" // Return an empty next page token for the last page of a set
 	}
 
 	return start, end, nextPageToken, nil

--- a/shared/pagination/pagination_test.go
+++ b/shared/pagination/pagination_test.go
@@ -44,7 +44,7 @@ func TestStartAndEndPage(t *testing.T) {
 			token:     "3",
 			pageSize:  33,
 			totalSize: 100,
-			nextToken: "4",
+			nextToken: "",
 			start:     99,
 			end:       100,
 		},


### PR DESCRIPTION
Part of #4174 

---

# Description

**Write why you are making the changes in this pull request**
Currently page api calls always return a next page token, even if there is no next page available in the requested set. This makes reading paged data from the api difficult as it also errors when passing a page token for a non-existing page.

**Write a summary of the changes you are making**
This change modifies the `StartAndEndPage` helper function to return an empty page token on the last page of a set.

