### PR TITLE
Wait for 3 peers to start sync

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -25,7 +25,7 @@ type blockchainService interface {
 }
 
 const (
-	minStatusCount           = 1               // TODO(3147): Set this to more than 1, maybe configure from flag?
+	minStatusCount           = 3               // TODO(3147): Set this to more than 3, maybe configure from flag?
 	handshakePollingInterval = 5 * time.Second // Polling interval for checking the number of received handshakes.
 )
 


### PR DESCRIPTION
Sometimes you start syncing with a bad peer and end up exiting sync early. Waiting for a few more peers may help alleviate this problem.