### PR TITLE
Remove formatting from error

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_attestation.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation.go
@@ -19,6 +19,11 @@ import (
 	"go.opencensus.io/trace"
 )
 
+
+// ErrTargetRootNotInDB returns when the target block root of an attestation cannot be found in the
+// beacon database.
+var ErrTargetRootNotInDB = errors.New("target root does not exist in db")
+
 // OnAttestation is called whenever an attestation is received, it updates validators latest vote,
 // as well as the fork choice store struct.
 //
@@ -61,7 +66,7 @@ func (s *Store) OnAttestation(ctx context.Context, a *ethpb.Attestation) error {
 
 	// Verify beacon node has seen the target block before.
 	if !s.db.HasBlock(ctx, bytesutil.ToBytes32(tgt.Root)) {
-		return fmt.Errorf("target root %#x does not exist in db", bytesutil.Trunc(tgt.Root))
+		return ErrTargetRootNotInDB
 	}
 
 	// Verify attestation target has had a valid pre state produced by the target block.

--- a/beacon-chain/blockchain/forkchoice/process_attestation_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation_test.go
@@ -69,7 +69,7 @@ func TestStore_OnAttestation(t *testing.T) {
 			a:             &ethpb.Attestation{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{Root: []byte{'A'}}}},
 			s:             &pb.BeaconState{},
 			wantErr:       true,
-			wantErrString: "target root 0x41 does not exist in db",
+			wantErrString: "target root does not exist in db",
 		},
 		{
 			name:          "no pre state for attestations's target block",

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -3,12 +3,14 @@ package blockchain
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
 
@@ -66,7 +68,9 @@ func (s *Service) processAttestation() {
 
 			for _, a := range atts {
 				if err := s.ReceiveAttestationNoPubsub(ctx, a); err != nil {
-					log.WithError(err).Error("Could not receive attestation in chain service")
+					log.WithFields(logrus.Fields{
+						"targetRoot": fmt.Sprintf("%#x", a.Data.Target.Root),
+					}).WithError(err).Error("Could not receive attestation in chain service")
 				}
 			}
 		case <-s.ctx.Done():


### PR DESCRIPTION
This error happens somewhat often. Removing the formatting makes the log easier to aggregate and monitor. 