### PR TITLE
--initial-sync-cache-state don't need to save head root

### DIFF
--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -325,3 +325,26 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 		t.Error("head slot incorrect")
 	}
 }
+
+func TestChainService_SaveHeadNoDB(t *testing.T) {
+	db := testDB.SetupDB(t)
+	defer testDB.TeardownDB(t, db)
+	ctx := context.Background()
+	s := &Service{
+		beaconDB:       db,
+		canonicalRoots: make(map[uint64][]byte),
+	}
+	b := &ethpb.BeaconBlock{Slot: 1}
+	r, _ := ssz.SigningRoot(b)
+	if err := s.saveHeadNoDB(ctx, b, r); err != nil {
+		t.Fatal(err)
+	}
+
+	newB, err := s.beaconDB.HeadBlock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(newB, b) {
+		t.Error("head block should not be equal")
+	}
+}

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -26,7 +26,7 @@ type blockchainService interface {
 }
 
 const (
-	minStatusCount           = 1               // TODO(3147): Set this to more than 3, maybe configure from flag?
+	minStatusCount           = 3               // TODO(3147): Set this to more than 3, maybe configure from flag?
 	handshakePollingInterval = 5 * time.Second // Polling interval for checking the number of received handshakes.
 )
 

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -26,7 +26,7 @@ type blockchainService interface {
 }
 
 const (
-	minStatusCount           = 3               // TODO(3147): Set this to more than 3, maybe configure from flag?
+	minStatusCount           = 1               // TODO(3147): Set this to more than 3, maybe configure from flag?
 	handshakePollingInterval = 5 * time.Second // Polling interval for checking the number of received handshakes.
 )
 


### PR DESCRIPTION
The next bottle neck after 100blks/s is `SavedHeadBlockRoot`:
![Screen Shot 2019-12-07 at 10 14 24 AM](https://user-images.githubusercontent.com/21316537/70379783-f548fc80-18e5-11ea-8db9-f640af66d78e.png)

As turns out, when we use `--initial-sync-cache-state`, we already use finalized check point as start point to resume sync. Saving head block root on per slot basis during the first phase of initial sync is no longer needed. 

Change list:
* First part of initial sync calls `ReceiveBlockNoVerify` which calls `OnBlockInitialSyncStateTransition`. With `--initial-sync-cache-state`, we skip saving head block root every slot
* This doesn't change second part of initial sync. Second part of the initial sync doesn't not use `ReceiveBlockNoVerify`

After:
<img width="1327" alt="Screen Shot 2019-12-07 at 11 24 37 AM" src="https://user-images.githubusercontent.com/21316537/70379806-815b2400-18e6-11ea-9edd-a8537b785857.png">
