### PR TITLE
Skip accessing peer status if it does not exist

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -306,6 +306,9 @@ func bestFinalized() ([]byte, uint64, []peer.ID) {
 	rootToEpoch := make(map[[32]byte]uint64)
 	for _, k := range peerstatus.Keys() {
 		s := peerstatus.Get(k)
+		if s == nil {
+			continue
+		}
 		r := bytesutil.ToBytes32(s.FinalizedRoot)
 		finalized[r]++
 		rootToEpoch[r] = s.FinalizedEpoch


### PR DESCRIPTION
Resolves #4225 
Resolves #4221 

Somehow peerstatus.Get(k) can return nil, maybe a peer disconnected during the loop.