### PR TITLE
Update process_epoch benchmark

### DIFF
--- a/beacon-chain/core/state/benchmarks/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks/benchmarks_test.go
@@ -119,9 +119,9 @@ func BenchmarkProcessEpoch_2FullEpochs(b *testing.B) {
 	}
 	beaconState.Slot = currentSlot
 
-	b.N = 5
-	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		// ProcessEpochPrecompute is the optimized version of process epoch. It's enabled by default
+		// at run time.
 		if _, err := state.ProcessEpochPrecompute(context.Background(), cleanStates[i]); err != nil {
 			b.Fatal(err)
 		}

--- a/beacon-chain/core/state/benchmarks/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks/benchmarks_test.go
@@ -119,6 +119,8 @@ func BenchmarkProcessEpoch_2FullEpochs(b *testing.B) {
 	}
 	beaconState.Slot = currentSlot
 
+	b.N = 5
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// ProcessEpochPrecompute is the optimized version of process epoch. It's enabled by default
 		// at run time.

--- a/beacon-chain/core/state/benchmarks/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks/benchmarks_test.go
@@ -122,7 +122,7 @@ func BenchmarkProcessEpoch_2FullEpochs(b *testing.B) {
 	b.N = 5
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := state.ProcessEpoch(context.Background(), cleanStates[i]); err != nil {
+		if _, err := state.ProcessEpochPrecompute(context.Background(), cleanStates[i]); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Updating process epoch benchmark to use `ProcessEpochPrecompute` the optimized version `ProcessEpoch` the optimized version is deprecated 