### PR TITLE
Add more detail to README and add benchmark for HashTreeRootState

### DIFF
--- a/beacon-chain/core/state/benchmarks/BUILD.bazel
+++ b/beacon-chain/core/state/benchmarks/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/stateutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",

--- a/beacon-chain/core/state/benchmarks/README.md
+++ b/beacon-chain/core/state/benchmarks/README.md
@@ -16,6 +16,31 @@ go run beacon-chain/core/state/benchmarks/benchmark_files/generate_bench_files.g
 
 Bazel does not allow writing to the project directory, so running with `go run` is needed.
 
+## Running the benchmarks
+To run the ExecuteStateTransition benchmark:
+
+```bazel test //beacon-chain/core/state/benchmarks:go_default_test --test_filter=BenchmarkExecuteStateTransition_FullBlock --test_arg=-test.bench=BenchmarkExecuteStateTransition_FullBlock```
+
+To run the ExecuteStateTransition (with cache) benchmark:
+
+```bazel test //beacon-chain/core/state/benchmarks:go_default_test --test_filter=BenchmarkExecuteStateTransition_WithCache --test_arg=-test.bench=BenchmarkExecuteStateTransition_WithCache```
+
+To run the ProcessEpoch benchmark:
+
+```bazel test //beacon-chain/core/state/benchmarks:go_default_test --test_filter=BenchmarkProcessEpoch_2FullEpochs --test_arg=-test.bench=BenchmarkProcessEpoch_2FullEpochs```
+
+To run the HashTreeRoot benchmark:
+
+```bazel test //beacon-chain/core/state/benchmarks:go_default_test --test_filter=BenchmarkHashTreeRoot_FullState --test_arg=-test.bench=BenchmarkHashTreeRoot_FullState```
+
+To run the HashTreeRootState benchmark:
+
+```bazel test //beacon-chain/core/state/benchmarks:go_default_test --test_filter=BenchmarkHashTreeRootState_FullState --test_arg=-test.bench=BenchmarkHashTreeRootState_FullState```
+
+Extra flags needed to benchmark properly:
+
+```--nocache_test_results --test_arg=-test.v --test_timeout=2000 --test_arg=-test.cpuprofile=/tmp/cpu.profile --test_arg=-test.memprofile=/tmp/mem.profile --test_output=streamed```
+
 ## Current Results as of November 2019
 ```
 BenchmarkExecuteStateTransition-4             	      20	33020593584 ns/op

--- a/beacon-chain/core/state/benchmarks/README.md
+++ b/beacon-chain/core/state/benchmarks/README.md
@@ -43,8 +43,9 @@ Extra flags needed to benchmark properly:
 
 ## Current Results as of November 2019
 ```
-BenchmarkExecuteStateTransition-4             	      20	33020593584 ns/op
-BenchmarkExecuteStateTransition_WithCache-4   	      20	21272276477 ns/op
+BenchmarkExecuteStateTransition-4             	      20	 33020593584 ns/op
+BenchmarkExecuteStateTransition_WithCache-4   	      20	 21272276477 ns/op
 BenchmarkProcessEpoch_2FullEpochs-4           	       5	158161708836 ns/op
-BenchmarkHashTreeRoot_FullState-4   	              50	1509721280 ns/op
+BenchmarkHashTreeRoot_FullState-4   	              50	  1509721280 ns/op
+BenchmarkHashTreeRootState_FullState-4                50        67622586 ns/op
 ```

--- a/beacon-chain/core/state/benchmarks/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks/benchmarks_test.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/stateutil"
 )
 
 var runAmount = 25
@@ -34,7 +35,7 @@ func TestBenchmarkExecuteStateTransition(t *testing.T) {
 	}
 }
 
-func BenchmarkExecuteStateTransition(b *testing.B) {
+func BenchmarkExecuteStateTransition_FullBlock(b *testing.B) {
 	SetConfig()
 	beaconState, err := beaconState1Epoch()
 	if err != nil {
@@ -138,6 +139,26 @@ func BenchmarkHashTreeRoot_FullState(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if _, err := ssz.HashTreeRoot(beaconState); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkHashTreeRootState_FullState(b *testing.B) {
+	beaconState, err := beaconState2FullEpochs()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Hydrate the HashTreeRootState cache.
+	if _, err := stateutil.HashTreeRootState(beaconState); err != nil {
+		b.Fatal(err)
+	}
+
+	b.N = 50
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := stateutil.HashTreeRootState(beaconState); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
This adds the commands to run the benchmarks to the README for benchmarks. It also adds a benchmark for HashTreeRootState, so extra work isn't needed to benchmark it.