### PR TITLE
Tidy up "Requesting blocks" log in initial sync

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/mathutil"
+	"github.com/sirupsen/logrus"
 )
 
 const blockBatchSize = 64
@@ -266,7 +267,13 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 
 // requestBlocks by range to a specific peer.
 func (s *InitialSync) requestBlocks(ctx context.Context, req *p2ppb.BeaconBlocksByRangeRequest, pid peer.ID) ([]*eth.BeaconBlock, error) {
-	log.WithField("peer", pid.Pretty()).WithField("req", req).Debug("Requesting blocks...")
+	log.WithFields(logrus.Fields{
+		"peer":  pid,
+		"start": req.StartSlot,
+		"count": req.Count,
+		"step":  req.Step,
+		"head":  fmt.Sprintf("%#x", req.HeadBlockRoot),
+	}).Debug("Requesting blocks")
 	stream, err := s.p2p.Send(ctx, req, pid)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to send request to peer")


### PR DESCRIPTION
The "Requesting blocks" log currently dumps the raw request object, which results in the head root being not very useful:

```
time="2019-12-11 12:08:38" level=debug msg="Requesting blocks..." peer=16Uiu2HAkzsDxvZHjNnF2cmAon4gggjU1YLanSNSFP8gWfchzN2e7 prefix=initial-sync req=head_block_root:"\321\211Q\206\r\335\324\252F\317z\261\314\266\276\002\210V~<\371\366j\225\330\031\210'\372\344\270\017" start_slot:214682 count:23 step:1 
```

This patch dumps each element in the request, giving a cleaner head root:
```
time="2019-12-11 12:08:38" level=debug msg="Requesting blocks" count=23 head=0xd18951860dddd4aa46cf7ab1ccb6be0288567e3cf9f66a95d8198827fae4b80f peer=16Uiu2HAkzsDxvZHjNnF2cmAon4gggjU1YLanSNSFP8gWfchzN2e7 prefix=initial-sync start=214682 step=1
```