### PR TITLE
Give peers a chance

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "log.go",
         "monitoring.go",
         "options.go",
+        "peer_decay.go",
         "rpc_topic_mappings.go",
         "sender.go",
         "service.go",

--- a/beacon-chain/p2p/peer_decay.go
+++ b/beacon-chain/p2p/peer_decay.go
@@ -1,0 +1,25 @@
+package p2p
+
+import (
+	"context"
+	"time"
+
+	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/peers"
+)
+
+// starPeerDecay starts a loop that periodically decays the bad response count of peers, giving reformed peers a chance to rejoin
+// the network.
+// This runs every hour.
+func startPeerDecay(ctx context.Context, peers *peers.Status) {
+	go (func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				peers.Decay()
+				time.Sleep(1 * time.Hour)
+			}
+		}
+	})()
+}

--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -303,6 +303,19 @@ func (p *Status) All() []peer.ID {
 	return pids
 }
 
+// Decay reduces the bad responses of all peers, giving reformed peers a chance to join the network.
+// This can be run periodically, although note that each time it runs it does give all bad peers another chance as well to clog up
+// the network with bad responses, so should not be run too frequently; once an hour would be reasonable.
+func (p *Status) Decay() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	for _, status := range p.status {
+		if status.badResponses > 0 {
+			status.badResponses--
+		}
+	}
+}
+
 // fetch is a helper function that fetches a peer status, possibly creating it.
 func (p *Status) fetch(pid peer.ID) *peerStatus {
 	if _, ok := p.status[pid]; !ok {

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -204,6 +204,7 @@ func (s *Service) Start() {
 	}
 
 	startPeerWatcher(s.ctx, s.host, peersToWatch...)
+	startPeerDecay(s.ctx, s.peers)
 	registerMetrics(s)
 	multiAddrs := s.host.Network().ListenAddresses()
 	logIP4Addr(s.host.ID(), multiAddrs...)


### PR DESCRIPTION
At current once a peer hits `maxBadResponses` in peer status it is ignored forever.  For very long-lived nodes this could result in legitimate peers being ignored because of a few transient network issues, or for upgraded peers to continue to be ignored due to past indiscretions.

This adds a decay feature to peer status: every hour the `badResponses` for all peers is reduced by 1.  If the peer is still bad it will quickly be re-marked as bad, but if it is reformed it will be able to rejoin the network and eventually its `badResponses`will decay to 0.