### PR TITLE
Add Getter for Genesis Block

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	ethereum_beacon_p2p_v1 "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 
@@ -38,6 +39,7 @@ type Database interface {
 	SaveBlock(ctx context.Context, block *eth.BeaconBlock) error
 	SaveBlocks(ctx context.Context, blocks []*eth.BeaconBlock) error
 	SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error
+	GenesisBlock(ctx context.Context) (*ethpb.BeaconBlock, error)
 	SaveGenesisBlockRoot(ctx context.Context, blockRoot [32]byte) error
 	IsFinalizedBlock(ctx context.Context, blockRoot [32]byte) bool
 	// Validator related methods.

--- a/beacon-chain/db/kafka/BUILD.bazel
+++ b/beacon-chain/db/kafka/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
-        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1_gateway:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@in_gopkg_confluentinc_confluent_kafka_go_v1//kafka:go_default_library",

--- a/beacon-chain/db/kafka/BUILD.bazel
+++ b/beacon-chain/db/kafka/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1_gateway:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@in_gopkg_confluentinc_confluent_kafka_go_v1//kafka:go_default_library",

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1_gateway"
 	ethereum_beacon_p2p_v1 "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 
@@ -197,6 +198,11 @@ func (e Exporter) DepositContractAddress(ctx context.Context) ([]byte, error) {
 // SaveHeadBlockRoot -- passthrough.
 func (e Exporter) SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error {
 	return e.db.SaveHeadBlockRoot(ctx, blockRoot)
+}
+
+// GenesisBlock -- passthrough.
+func (e Exporter) GenesisBlock(ctx context.Context) (*ethpb.BeaconBlock, error) {
+	return e.db.GenesisBlock(ctx)
 }
 
 // SaveGenesisBlockRoot -- passthrough.

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
-	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1_gateway"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	ethereum_beacon_p2p_v1 "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -318,6 +318,24 @@ func (k *Store) SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error
 	})
 }
 
+// GenesisBlock retrieves the genesis block of the beacon chain.
+func (k *Store) GenesisBlock(ctx context.Context) (*ethpb.BeaconBlock, error) {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.GenesisBlock")
+	defer span.End()
+	var block *ethpb.BeaconBlock
+	err := k.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(blocksBucket)
+		root := bkt.Get(genesisBlockRootKey)
+		enc := bkt.Get(root)
+		if enc == nil {
+			return nil
+		}
+		block = &ethpb.BeaconBlock{}
+		return decode(enc, block)
+	})
+	return block, err
+}
+
 // SaveGenesisBlockRoot to the db.
 func (k *Store) SaveGenesisBlockRoot(ctx context.Context, blockRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveGenesisBlockRoot")

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -139,6 +139,33 @@ func TestStore_BlocksBatchDelete(t *testing.T) {
 	}
 }
 
+func TestStore_GenesisBlock(t *testing.T) {
+	db := setupDB(t)
+	defer teardownDB(t, db)
+	ctx := context.Background()
+	genesisBlock := &ethpb.BeaconBlock{
+		Slot:       0,
+		ParentRoot: []byte{1, 2, 3},
+	}
+	blockRoot, err := ssz.SigningRoot(genesisBlock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveGenesisBlockRoot(ctx, blockRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveBlock(ctx, genesisBlock); err != nil {
+		t.Fatal(err)
+	}
+	retrievedBlock, err := db.GenesisBlock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !proto.Equal(genesisBlock, retrievedBlock) {
+		t.Errorf("Wanted %v, received %v", genesisBlock, retrievedBlock)
+	}
+}
+
 func TestStore_BlocksCRUD_NoCache(t *testing.T) {
 	db := setupDB(t)
 	defer teardownDB(t, db)


### PR DESCRIPTION
Resolves #4257 

---

# Description

**Write why you are making the changes in this pull request**

Currently, our RPC API returns an error if there is more than 1 genesis block saved in the DB when attempting to retrieve blocks with slot == 0. It turns out the filter for genesis does not work, as we retrieve every possible block from the DB instead of returning 1.

**Write a summary of the changes you are making**

Adds a new DB getter that gets around the complexity of fetching genesis using the db.Blocks functions we would otherwise need