### PR TITLE
Skip E2E in v0.9.2

### DIFF
--- a/beacon-chain/rpc/testing/beacon_node_validator_service_mock.go
+++ b/beacon-chain/rpc/testing/beacon_node_validator_service_mock.go
@@ -6,10 +6,11 @@ package testing
 
 import (
 	context "context"
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	metadata "google.golang.org/grpc/metadata"
-	reflect "reflect"
 )
 
 // MockBeaconNodeValidator_WaitForActivationServer is a mock of BeaconNodeValidator_WaitForActivationServer interface

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/libp2p/go-libp2p-pubsub"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"

--- a/endtoend/demo_e2e_test.go
+++ b/endtoend/demo_e2e_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestEndToEnd_DemoConfig(t *testing.T) {
+	t.Skip("Skipping till #4224 is resolved")
 	testutil.ResetCache()
 	params.UseDemoBeaconConfig()
 

--- a/endtoend/minimal_e2e_test.go
+++ b/endtoend/minimal_e2e_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestEndToEnd_MinimalConfig(t *testing.T) {
+	t.Skip("Skipping till #4224 is resolved")
 	testutil.ResetCache()
 	params.UseMinimalConfig()
 

--- a/validator/internal/beacon_chain_service_mock.go
+++ b/validator/internal/beacon_chain_service_mock.go
@@ -6,11 +6,12 @@ package internal
 
 import (
 	context "context"
+	reflect "reflect"
+
 	empty "github.com/gogo/protobuf/types"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	grpc "google.golang.org/grpc"
-	reflect "reflect"
 )
 
 // MockBeaconChainClient is a mock of BeaconChainClient interface

--- a/validator/internal/beacon_node_validator_service_mock.go
+++ b/validator/internal/beacon_node_validator_service_mock.go
@@ -6,12 +6,13 @@ package internal
 
 import (
 	context "context"
+	reflect "reflect"
+
 	empty "github.com/gogo/protobuf/types"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	grpc "google.golang.org/grpc"
 	metadata "google.golang.org/grpc/metadata"
-	reflect "reflect"
 )
 
 // MockBeaconNodeValidator_WaitForActivationClient is a mock of BeaconNodeValidator_WaitForActivationClient interface


### PR DESCRIPTION
Skips all end to end tests for the timebeing.