### PR TITLE
Fix cloning target state for check point state cache

### DIFF
--- a/beacon-chain/blockchain/forkchoice/BUILD.bazel
+++ b/beacon-chain/blockchain/forkchoice/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
+        "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/db/filters:go_default_library",
         "//beacon-chain/db/testing:go_default_library",

--- a/beacon-chain/blockchain/forkchoice/process_attestation_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation_test.go
@@ -14,6 +14,7 @@ import (
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
 func TestStore_OnAttestation(t *testing.T) {
@@ -221,7 +222,8 @@ func TestStore_UpdateCheckpointState(t *testing.T) {
 	store := NewForkChoiceService(ctx, db)
 
 	epoch := uint64(1)
-	baseState := &pb.BeaconState{Slot: epoch * params.BeaconConfig().SlotsPerEpoch}
+	baseState, _ := testutil.DeterministicGenesisState(t, 1)
+	baseState.Slot = epoch * params.BeaconConfig().SlotsPerEpoch
 	checkpoint := &ethpb.Checkpoint{Epoch: epoch}
 	returned, err := store.saveCheckpointState(ctx, baseState, checkpoint)
 	if err != nil {
@@ -253,12 +255,11 @@ func TestStore_UpdateCheckpointState(t *testing.T) {
 		t.Error("Incorrectly returned base state")
 	}
 
-	cached, err = store.checkpointState.StateByCheckpoint(checkpoint)
+	cached, err = store.checkpointState.StateByCheckpoint(newCheckpoint)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(baseState, cached) {
+	if !reflect.DeepEqual(returned, cached) {
 		t.Error("Incorrectly cached base state")
 	}
-
 }

--- a/beacon-chain/operations/attestations/kv/unaggregated_test.go
+++ b/beacon-chain/operations/attestations/kv/unaggregated_test.go
@@ -32,8 +32,8 @@ func TestKV_Unaggregated_CanSaveRetrieve(t *testing.T) {
 
 	data := &ethpb.AttestationData{Slot: 100, CommitteeIndex: 99}
 	att1 := &ethpb.Attestation{Data: &ethpb.AttestationData{}, AggregationBits: bitfield.Bitlist{0b101}}
-	att2 := &ethpb.Attestation{Data: data, Signature: []byte{0,0}, AggregationBits: bitfield.Bitlist{0b110}}
-	att3 := &ethpb.Attestation{Data: data, Signature: []byte{0,1}, AggregationBits: bitfield.Bitlist{0b110}}
+	att2 := &ethpb.Attestation{Data: data, Signature: []byte{0, 0}, AggregationBits: bitfield.Bitlist{0b110}}
+	att3 := &ethpb.Attestation{Data: data, Signature: []byte{0, 1}, AggregationBits: bitfield.Bitlist{0b110}}
 	atts := []*ethpb.Attestation{att1, att2, att3}
 
 	for _, att := range atts {


### PR DESCRIPTION
As part of `process_attestation`, we retrieve `target_state` (ie. state by `target_root`), if such state is behind `target_epoch`, we advance the the state up to `target_epoch` via `process_slots`. To avoid running this this for every attestation, a `check_point` to state cache was advocated in the spec. To avoid mutation of the base target state, state gets cloned before the `process_slot`. This caught my eye because clone it took a big chunk of flame graph:

<img width="1336" alt="Screen Shot 2019-12-13 at 5 20 41 PM" src="https://user-images.githubusercontent.com/21316537/70853984-79612e00-1e6a-11ea-9ffd-f711b01134c3.png">

Upon further investigation, I found a bug where the return of `process_slots` is assigned back to the `baseState`:

`baseState, err = state.ProcessSlots(ctx, stateCopy, helpers.StartSlot(c.Epoch))`
Should be:
`stateCopy, err = state.ProcessSlots(ctx, stateCopy, helpers.StartSlot(c.Epoch))`

Fixed the issue and verified the flame graph again, clone is much smaller and barely noticible:

<img width="1352" alt="Screen Shot 2019-12-13 at 5 31 08 PM" src="https://user-images.githubusercontent.com/21316537/70854034-1754f880-1e6b-11ea-9f6a-7b90a42b5653.png">

Edit: 
After chatting with @prestonvanloon the above description is missing a few more info. To clarify reassigning `baseState` is not any impact performance change. However only saving the checkpoint sometimes is a performance diff. It could be incorrectly updating the cache  