### PR TITLE
Use RunEvery in place of custom tickers

### DIFF
--- a/beacon-chain/p2p/connmgr/BUILD.bazel
+++ b/beacon-chain/p2p/connmgr/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/p2p/connmgr",
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
+        "//shared/runutil:go_default_library",
         "@com_github_ipfs_go_log//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//connmgr:go_default_library",
         "@com_github_libp2p_go_libp2p_core//network:go_default_library",

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -213,6 +213,7 @@ func (s *Service) Start() {
 
 // Stop the p2p service and terminate all peer connections.
 func (s *Service) Stop() error {
+	defer s.cancel()
 	s.started = false
 	if s.dv5Listener != nil {
 		s.dv5Listener.Close()

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/runutil"
 	"github.com/prysmaticlabs/prysm/shared/traceutil"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -21,17 +22,10 @@ var processPendingBlocksPeriod = time.Duration(params.BeaconConfig().SecondsPerS
 
 // processes pending blocks queue on every processPendingBlocksPeriod
 func (r *RegularSync) processPendingBlocksQueue() {
-	ticker := time.NewTicker(processPendingBlocksPeriod)
-	for {
-		ctx := context.TODO()
-		select {
-		case <-ticker.C:
-			r.processPendingBlocks(ctx)
-		case <-r.ctx.Done():
-			log.Debug("Context closed, exiting routine")
-			return
-		}
-	}
+	ctx := context.Background()
+	runutil.RunEvery(r.ctx, processPendingBlocksPeriod, func() {
+		r.processPendingBlocks(ctx)
+	})
 }
 
 // processes the block tree inside the queue

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -38,8 +38,10 @@ type blockchainService interface {
 
 // NewRegularSync service.
 func NewRegularSync(cfg *Config) *RegularSync {
+	ctx, cancel := context.WithCancel(context.Background())
 	r := &RegularSync{
-		ctx:                 context.Background(),
+		ctx:                 ctx,
+		cancel:              cancel,
 		db:                  cfg.DB,
 		p2p:                 cfg.P2P,
 		operations:          cfg.Operations,
@@ -60,6 +62,7 @@ func NewRegularSync(cfg *Config) *RegularSync {
 // main entry point for network messages.
 type RegularSync struct {
 	ctx                 context.Context
+	cancel              context.CancelFunc
 	p2p                 p2p.P2P
 	db                  db.Database
 	operations          *operations.Service
@@ -77,12 +80,13 @@ type RegularSync struct {
 func (r *RegularSync) Start() {
 	r.p2p.AddConnectionHandler(r.sendRPCStatusRequest)
 	r.p2p.AddDisconnectionHandler(r.removeDisconnectedPeerStatus)
-	go r.processPendingBlocksQueue()
-	go r.maintainPeerStatuses()
+	r.processPendingBlocksQueue()
+	r.maintainPeerStatuses()
 }
 
 // Stop the regular sync service.
 func (r *RegularSync) Stop() error {
+	defer r.cancel()
 	return nil
 }
 


### PR DESCRIPTION
This is a follow-on to #4285 that converts some more ticker code to use the `RunEvery` helper.

It also updates the `sync` and `p2p` services to cancel tickers when stopped.