### PR TITLE
Update sync/initialSync service name

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -363,7 +363,7 @@ func (b *BeaconNode) registerSyncService(ctx *cli.Context) error {
 		return err
 	}
 
-	var initSync *initialsync.InitialSync
+	var initSync *initialsync.Service
 	if err := b.services.FetchService(&initSync); err != nil {
 		return err
 	}
@@ -414,7 +414,7 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 		return err
 	}
 
-	var syncService *initialsync.InitialSync
+	var syncService *initialsync.Service
 	if err := b.services.FetchService(&syncService); err != nil {
 		return err
 	}

--- a/beacon-chain/sync/error.go
+++ b/beacon-chain/sync/error.go
@@ -16,7 +16,7 @@ var responseCodeSuccess = byte(0x00)
 var responseCodeInvalidRequest = byte(0x01)
 var responseCodeServerError = byte(0x02)
 
-func (r *RegularSync) generateErrorResponse(code byte, reason string) ([]byte, error) {
+func (r *Service) generateErrorResponse(code byte, reason string) ([]byte, error) {
 	buf := bytes.NewBuffer([]byte{code})
 	if _, err := r.p2p.Encoding().EncodeWithLength(buf, []byte(reason)); err != nil {
 		return nil, err

--- a/beacon-chain/sync/error_test.go
+++ b/beacon-chain/sync/error_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestRegularSync_generateErrorResponse(t *testing.T) {
-	r := &RegularSync{
+	r := &Service{
 		p2p: p2ptest.NewTestP2P(t),
 	}
 	data, err := r.generateErrorResponse(responseCodeServerError, "something bad happened")

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -37,7 +37,7 @@ const refreshTime = 6 * time.Second
 // Using the finalized root as the head_block_root and the epoch start slot
 // after the finalized epoch, request blocks to head from some subset of peers
 // where step = 1.
-func (s *InitialSync) roundRobinSync(genesis time.Time) error {
+func (s *Service) roundRobinSync(genesis time.Time) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -266,7 +266,7 @@ func (s *InitialSync) roundRobinSync(genesis time.Time) error {
 }
 
 // requestBlocks by range to a specific peer.
-func (s *InitialSync) requestBlocks(ctx context.Context, req *p2ppb.BeaconBlocksByRangeRequest, pid peer.ID) ([]*eth.BeaconBlock, error) {
+func (s *Service) requestBlocks(ctx context.Context, req *p2ppb.BeaconBlocksByRangeRequest, pid peer.ID) ([]*eth.BeaconBlock, error) {
 	log.WithFields(logrus.Fields{
 		"peer":  pid,
 		"start": req.StartSlot,
@@ -297,7 +297,7 @@ func (s *InitialSync) requestBlocks(ctx context.Context, req *p2ppb.BeaconBlocks
 
 // highestFinalizedEpoch as reported by peers. This is the absolute highest finalized epoch as
 // reported by peers.
-func (s *InitialSync) highestFinalizedEpoch() uint64 {
+func (s *Service) highestFinalizedEpoch() uint64 {
 	_, epoch, _ := s.bestFinalized()
 	return epoch
 }
@@ -307,7 +307,7 @@ func (s *InitialSync) highestFinalizedEpoch() uint64 {
 // which most peers can serve blocks. Ideally, all peers would be reporting the same finalized
 // epoch.
 // Returns the best finalized root, epoch number, and peers that agree.
-func (s *InitialSync) bestFinalized() ([]byte, uint64, []peer.ID) {
+func (s *Service) bestFinalized() ([]byte, uint64, []peer.ID) {
 	finalized := make(map[[32]byte]uint64)
 	rootToEpoch := make(map[[32]byte]uint64)
 	for _, pid := range s.p2p.Peers().Connected() {
@@ -343,7 +343,7 @@ func (s *InitialSync) bestFinalized() ([]byte, uint64, []peer.ID) {
 }
 
 // bestPeer returns the peer ID of the peer reporting the highest head slot.
-func (s *InitialSync) bestPeer() peer.ID {
+func (s *Service) bestPeer() peer.ID {
 	var best peer.ID
 	var bestSlot uint64
 	for _, k := range s.p2p.Peers().Connected() {
@@ -357,7 +357,7 @@ func (s *InitialSync) bestPeer() peer.ID {
 }
 
 // logSyncStatus and increment block processing counter.
-func (s *InitialSync) logSyncStatus(genesis time.Time, blk *eth.BeaconBlock, syncingPeers []peer.ID, counter *ratecounter.RateCounter) {
+func (s *Service) logSyncStatus(genesis time.Time, blk *eth.BeaconBlock, syncingPeers []peer.ID, counter *ratecounter.RateCounter) {
 	counter.Incr(1)
 	rate := float64(counter.Rate()) / counterSeconds
 	if rate == 0 {

--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -255,7 +255,7 @@ func TestRoundRobinSync(t *testing.T) {
 				Root:  genesisRoot[:],
 				DB:    beaconDB,
 			} // no-op mock
-			s := &InitialSync{
+			s := &Service{
 				chain:        mc,
 				p2p:          p,
 				db:           beaconDB,
@@ -428,7 +428,7 @@ func TestMakeSequence(t *testing.T) {
 
 func TestBestFinalized_returnsMaxValue(t *testing.T) {
 	p := p2pt.NewTestP2P(t)
-	s := &InitialSync{
+	s := &Service{
 		p2p: p,
 	}
 

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -18,7 +18,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/roughtime"
 )
 
-var _ = shared.Service(&InitialSync{})
+var _ = shared.Service(&Service{})
 
 type blockchainService interface {
 	blockchain.BlockReceiver
@@ -37,8 +37,8 @@ type Config struct {
 	StateNotifier statefeed.Notifier
 }
 
-// InitialSync service.
-type InitialSync struct {
+// Service service.
+type Service struct {
 	ctx           context.Context
 	chain         blockchainService
 	p2p           p2p.P2P
@@ -50,8 +50,8 @@ type InitialSync struct {
 
 // NewInitialSync configures the initial sync service responsible for bringing the node up to the
 // latest head of the blockchain.
-func NewInitialSync(cfg *Config) *InitialSync {
-	return &InitialSync{
+func NewInitialSync(cfg *Config) *Service {
+	return &Service{
 		ctx:           context.Background(),
 		chain:         cfg.Chain,
 		p2p:           cfg.P2P,
@@ -61,7 +61,7 @@ func NewInitialSync(cfg *Config) *InitialSync {
 }
 
 // Start the initial sync service.
-func (s *InitialSync) Start() {
+func (s *Service) Start() {
 	var genesis time.Time
 
 	headState, err := s.chain.HeadState(s.ctx)
@@ -137,12 +137,12 @@ func (s *InitialSync) Start() {
 }
 
 // Stop initial sync.
-func (s *InitialSync) Stop() error {
+func (s *Service) Stop() error {
 	return nil
 }
 
 // Status of initial sync.
-func (s *InitialSync) Status() error {
+func (s *Service) Status() error {
 	if !s.synced && s.chainStarted {
 		return errors.New("syncing")
 	}
@@ -150,7 +150,7 @@ func (s *InitialSync) Status() error {
 }
 
 // Syncing returns true if initial sync is still running.
-func (s *InitialSync) Syncing() bool {
+func (s *Service) Syncing() bool {
 	return !s.synced
 }
 

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -20,7 +20,7 @@ import (
 var processPendingBlocksPeriod = time.Duration(params.BeaconConfig().SecondsPerSlot/3) * time.Second
 
 // processes pending blocks queue on every processPendingBlocksPeriod
-func (r *RegularSync) processPendingBlocksQueue() {
+func (r *Service) processPendingBlocksQueue() {
 	ticker := time.NewTicker(processPendingBlocksPeriod)
 	for {
 		ctx := context.TODO()
@@ -35,7 +35,7 @@ func (r *RegularSync) processPendingBlocksQueue() {
 }
 
 // processes the block tree inside the queue
-func (r *RegularSync) processPendingBlocks(ctx context.Context) error {
+func (r *Service) processPendingBlocks(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "processPendingBlocks")
 	defer span.End()
 
@@ -104,7 +104,7 @@ func (r *RegularSync) processPendingBlocks(ctx context.Context) error {
 	return nil
 }
 
-func (r *RegularSync) sortedPendingSlots() []int {
+func (r *Service) sortedPendingSlots() []int {
 	r.pendingQueueLock.RLock()
 	defer r.pendingQueueLock.RUnlock()
 
@@ -119,7 +119,7 @@ func (r *RegularSync) sortedPendingSlots() []int {
 // validatePendingSlots validates the pending blocks
 // by their slot. If they are before the current finalized
 // checkpoint, these blocks are removed from the queue.
-func (r *RegularSync) validatePendingSlots() error {
+func (r *Service) validatePendingSlots() error {
 	r.pendingQueueLock.RLock()
 	defer r.pendingQueueLock.RUnlock()
 	oldBlockRoots := make(map[[32]byte]bool)

--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -30,7 +30,7 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks1(t *testing.T) {
 	defer dbtest.TeardownDB(t, db)
 
 	p1 := p2ptest.NewTestP2P(t)
-	r := &RegularSync{
+	r := &Service{
 		p2p: p1,
 		db:  db,
 		chain: &mock.ChainService{
@@ -119,7 +119,7 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks2(t *testing.T) {
 		}
 	})
 
-	r := &RegularSync{
+	r := &Service{
 		p2p: p1,
 		db:  db,
 		chain: &mock.ChainService{
@@ -214,7 +214,7 @@ func TestRegularSyncBeaconBlockSubscriber_PruneOldPendingBlocks(t *testing.T) {
 		t.Error("Expected peers to be connected")
 	}
 
-	r := &RegularSync{
+	r := &Service{
 		p2p: p1,
 		db:  db,
 		chain: &mock.ChainService{

--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -29,7 +29,7 @@ const maxChunkSize = 1 << 20
 type rpcHandler func(context.Context, interface{}, libp2pcore.Stream) error
 
 // registerRPCHandlers for p2p RPC.
-func (r *RegularSync) registerRPCHandlers() {
+func (r *Service) registerRPCHandlers() {
 	r.registerRPC(
 		"/eth2/beacon_chain/req/status/1",
 		&pb.Status{},
@@ -53,7 +53,7 @@ func (r *RegularSync) registerRPCHandlers() {
 }
 
 // registerRPC for a given topic with an expected protobuf message type.
-func (r *RegularSync) registerRPC(topic string, base interface{}, handle rpcHandler) {
+func (r *Service) registerRPC(topic string, base interface{}, handle rpcHandler) {
 	topic += r.p2p.Encoding().ProtocolSuffix()
 	log := log.WithField("topic", topic)
 	r.p2p.SetStreamHandler(topic, func(stream network.Stream) {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -14,7 +14,7 @@ import (
 )
 
 // beaconBlocksByRangeRPCHandler looks up the request blocks from the database from a given start block.
-func (r *RegularSync) beaconBlocksByRangeRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
+func (r *Service) beaconBlocksByRangeRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
 	ctx, span := trace.StartSpan(ctx, "sync.BeaconBlocksByRangeHandler")
 	defer span.End()
 	defer stream.Close()

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
@@ -38,7 +38,7 @@ func TestBeaconBlocksRPCHandler_ReturnsBlocks(t *testing.T) {
 		}
 	}
 
-	r := &RegularSync{p2p: p1, db: d}
+	r := &Service{p2p: p1, db: d}
 	pcl := protocol.ID("/testing")
 
 	var wg sync.WaitGroup

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -13,7 +13,7 @@ import (
 
 // sendRecentBeaconBlocksRequest sends a recent beacon blocks request to a peer to get
 // those corresponding blocks from that peer.
-func (r *RegularSync) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots [][32]byte, id peer.ID) error {
+func (r *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots [][32]byte, id peer.ID) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -44,7 +44,7 @@ func (r *RegularSync) sendRecentBeaconBlocksRequest(ctx context.Context, blockRo
 }
 
 // beaconBlocksRootRPCHandler looks up the request blocks from the database from the given block roots.
-func (r *RegularSync) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
+func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
 	defer stream.Close()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -45,7 +45,7 @@ func TestRecentBeaconBlocksRPCHandler_ReturnsBlocks(t *testing.T) {
 		blkRoots = append(blkRoots, root)
 	}
 
-	r := &RegularSync{p2p: p1, db: d}
+	r := &Service{p2p: p1, db: d}
 	pcl := protocol.ID("/testing")
 
 	var wg sync.WaitGroup
@@ -108,7 +108,7 @@ func TestRecentBeaconBlocks_RPCRequestSent(t *testing.T) {
 
 	expectedRoots := [][32]byte{blockBRoot, blockARoot}
 
-	r := &RegularSync{
+	r := &Service{
 		p2p: p1,
 		chain: &mock.ChainService{
 			State:               genesisState,

--- a/beacon-chain/sync/rpc_chunked_response.go
+++ b/beacon-chain/sync/rpc_chunked_response.go
@@ -13,7 +13,7 @@ import (
 // chunkWriter writes the given message as a chunked response to the given network
 // stream.
 // response_chunk ::= | <result> | <encoding-dependent-header> | <encoded-payload>
-func (r *RegularSync) chunkWriter(stream libp2pcore.Stream, msg interface{}) error {
+func (r *Service) chunkWriter(stream libp2pcore.Stream, msg interface{}) error {
 	setStreamWriteDeadline(stream, defaultWriteDuration)
 	return WriteChunk(stream, r.p2p.Encoding(), msg)
 }

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -21,7 +21,7 @@ var goodByes = map[uint64]string{
 }
 
 // goodbyeRPCHandler reads the incoming goodbye rpc message from the peer.
-func (r *RegularSync) goodbyeRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
+func (r *Service) goodbyeRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
 	defer stream.Close()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()

--- a/beacon-chain/sync/rpc_goodbye_test.go
+++ b/beacon-chain/sync/rpc_goodbye_test.go
@@ -25,7 +25,7 @@ func TestGoodByeRPCHandler_Disconnects_With_Peer(t *testing.T) {
 	d := db.SetupDB(t)
 	defer db.TeardownDB(t, d)
 
-	r := &RegularSync{
+	r := &Service{
 		db:  d,
 		p2p: p1,
 	}

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -18,7 +18,7 @@ import (
 const statusInterval = 6 * time.Minute // 60 slots.
 
 // maintainPeerStatuses by infrequently polling peers for their latest status.
-func (r *RegularSync) maintainPeerStatuses() {
+func (r *Service) maintainPeerStatuses() {
 	ctx := context.Background()
 	runutil.RunEvery(r.ctx, statusInterval, func() {
 		for _, pid := range r.p2p.Peers().Connected() {
@@ -38,7 +38,7 @@ func (r *RegularSync) maintainPeerStatuses() {
 }
 
 // sendRPCStatusRequest for a given topic with an expected protobuf message type.
-func (r *RegularSync) sendRPCStatusRequest(ctx context.Context, id peer.ID) error {
+func (r *Service) sendRPCStatusRequest(ctx context.Context, id peer.ID) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
@@ -77,13 +77,13 @@ func (r *RegularSync) sendRPCStatusRequest(ctx context.Context, id peer.ID) erro
 	return err
 }
 
-func (r *RegularSync) removeDisconnectedPeerStatus(ctx context.Context, pid peer.ID) error {
+func (r *Service) removeDisconnectedPeerStatus(ctx context.Context, pid peer.ID) error {
 	return nil
 }
 
 // statusRPCHandler reads the incoming Status RPC from the peer and responds with our version of a status message.
 // This handler will disconnect any peer that does not match our fork version.
-func (r *RegularSync) statusRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
+func (r *Service) statusRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
 	defer stream.Close()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -130,7 +130,7 @@ func (r *RegularSync) statusRPCHandler(ctx context.Context, msg interface{}, str
 	return err
 }
 
-func (r *RegularSync) validateStatusMessage(msg *pb.Status, stream network.Stream) error {
+func (r *Service) validateStatusMessage(msg *pb.Status, stream network.Stream) error {
 	if !bytes.Equal(params.BeaconConfig().GenesisForkVersion, msg.HeadForkVersion) {
 		return errWrongForkVersion
 	}

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -35,7 +35,7 @@ func TestHelloRPCHandler_Disconnects_OnForkVersionMismatch(t *testing.T) {
 		t.Error("Expected peers to be connected")
 	}
 
-	r := &RegularSync{p2p: p1}
+	r := &Service{p2p: p1}
 	pcl := protocol.ID("/testing")
 
 	var wg sync.WaitGroup
@@ -102,7 +102,7 @@ func TestHelloRPCHandler_ReturnsHelloMessage(t *testing.T) {
 		Root:  finalizedRoot[:],
 	}
 
-	r := &RegularSync{
+	r := &Service{
 		p2p: p1,
 		chain: &mock.ChainService{
 			State:               genesisState,
@@ -158,7 +158,7 @@ func TestHandshakeHandlers_Roundtrip(t *testing.T) {
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p: p1,
 		chain: &mock.ChainService{
 			State:               &pb.BeaconState{Slot: 5},
@@ -262,7 +262,7 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 		Root:  finalizedRoot[:],
 	}
 
-	r := &RegularSync{
+	r := &Service{
 		p2p: p1,
 		chain: &mock.ChainService{
 			State:               genesisState,
@@ -334,7 +334,7 @@ func TestStatusRPCRequest_BadPeerHandshake(t *testing.T) {
 		Root:  finalizedRoot[:],
 	}
 
-	r := &RegularSync{
+	r := &Service{
 		p2p: p1,
 		chain: &mock.ChainService{
 			State:               genesisState,

--- a/beacon-chain/sync/rpc_test.go
+++ b/beacon-chain/sync/rpc_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // expectSuccess status code from a stream in regular sync.
-func expectSuccess(t *testing.T, r *RegularSync, stream network.Stream) {
+func expectSuccess(t *testing.T, r *Service, stream network.Stream) {
 	code, errMsg, err := ReadStatusCode(stream, &encoder.SszNetworkEncoder{})
 	if err != nil {
 		t.Fatal(err)
@@ -30,7 +30,7 @@ func expectSuccess(t *testing.T, r *RegularSync, stream network.Stream) {
 }
 
 // expectResetStream status code from a stream in regular sync.
-func expectResetStream(t *testing.T, r *RegularSync, stream network.Stream) {
+func expectResetStream(t *testing.T, r *Service, stream network.Stream) {
 	expectedErr := "stream reset"
 	_, _, err := ReadStatusCode(stream, &encoder.SszNetworkEncoder{})
 	if err.Error() != expectedErr {
@@ -40,7 +40,7 @@ func expectResetStream(t *testing.T, r *RegularSync, stream network.Stream) {
 
 func TestRegisterRPC_ReceivesValidMessage(t *testing.T) {
 	p2p := p2ptest.NewTestP2P(t)
-	r := &RegularSync{
+	r := &Service{
 		ctx: context.Background(),
 		p2p: p2p,
 	}

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared"
 )
 
-var _ = shared.Service(&RegularSync{})
+var _ = shared.Service(&Service{})
 
 // Config to set up the regular sync service.
 type Config struct {
@@ -37,8 +37,8 @@ type blockchainService interface {
 }
 
 // NewRegularSync service.
-func NewRegularSync(cfg *Config) *RegularSync {
-	r := &RegularSync{
+func NewRegularSync(cfg *Config) *Service {
+	r := &Service{
 		ctx:                 context.Background(),
 		db:                  cfg.DB,
 		p2p:                 cfg.P2P,
@@ -56,9 +56,9 @@ func NewRegularSync(cfg *Config) *RegularSync {
 	return r
 }
 
-// RegularSync service is responsible for handling all run time p2p related operations as the
+// Service is responsible for handling all run time p2p related operations as the
 // main entry point for network messages.
-type RegularSync struct {
+type Service struct {
 	ctx                 context.Context
 	p2p                 p2p.P2P
 	db                  db.Database
@@ -74,7 +74,7 @@ type RegularSync struct {
 }
 
 // Start the regular sync service.
-func (r *RegularSync) Start() {
+func (r *Service) Start() {
 	r.p2p.AddConnectionHandler(r.sendRPCStatusRequest)
 	r.p2p.AddDisconnectionHandler(r.removeDisconnectedPeerStatus)
 	go r.processPendingBlocksQueue()
@@ -82,12 +82,12 @@ func (r *RegularSync) Start() {
 }
 
 // Stop the regular sync service.
-func (r *RegularSync) Stop() error {
+func (r *Service) Stop() error {
 	return nil
 }
 
 // Status of the currently running regular sync service.
-func (r *RegularSync) Status() error {
+func (r *Service) Status() error {
 	if r.chainStarted && r.initialSync.Syncing() {
 		return errors.New("waiting for initial sync")
 	}

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -38,7 +38,7 @@ func noopValidator(_ context.Context, _ proto.Message, _ p2p.Broadcaster, _ bool
 }
 
 // Register PubSub subscribers
-func (r *RegularSync) registerSubscribers() {
+func (r *Service) registerSubscribers() {
 	go func() {
 		// Wait until chain start.
 		stateChannel := make(chan *feed.Event, 1)
@@ -94,7 +94,7 @@ func (r *RegularSync) registerSubscribers() {
 
 // subscribe to a given topic with a given validator and subscription handler.
 // The base protobuf message is used to initialize new messages for decoding.
-func (r *RegularSync) subscribe(topic string, validate validator, handle subHandler) {
+func (r *Service) subscribe(topic string, validate validator, handle subHandler) {
 	base := p2p.GossipTopicMappings[topic]
 	if base == nil {
 		panic(fmt.Sprintf("%s is not mapped to any message in GossipTopicMappings", topic))

--- a/beacon-chain/sync/subscriber_beacon_attestation.go
+++ b/beacon-chain/sync/subscriber_beacon_attestation.go
@@ -9,7 +9,7 @@ import (
 
 // beaconAttestationSubscriber forwards the incoming validated attestation to the blockchain
 // service for processing.
-func (r *RegularSync) beaconAttestationSubscriber(ctx context.Context, msg proto.Message) error {
+func (r *Service) beaconAttestationSubscriber(ctx context.Context, msg proto.Message) error {
 	if err := r.operations.HandleAttestation(ctx, msg.(*ethpb.Attestation)); err != nil {
 		return err
 	}

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 )
 
-func (r *RegularSync) beaconBlockSubscriber(ctx context.Context, msg proto.Message) error {
+func (r *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) error {
 	block := msg.(*ethpb.BeaconBlock)
 
 	headState, err := r.chain.HeadState(ctx)

--- a/beacon-chain/sync/subscriber_beacon_blocks_test.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks_test.go
@@ -31,7 +31,7 @@ func TestRegularSyncBeaconBlockSubscriber_FilterByFinalizedEpoch(t *testing.T) {
 		t.Fatal(err)
 	}
 	parentRoot, _ := ssz.SigningRoot(parent)
-	r := &RegularSync{
+	r := &Service{
 		db:    db,
 		chain: &mock.ChainService{State: s},
 	}

--- a/beacon-chain/sync/subscriber_handlers.go
+++ b/beacon-chain/sync/subscriber_handlers.go
@@ -6,16 +6,16 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func (r *RegularSync) voluntaryExitSubscriber(ctx context.Context, msg proto.Message) error {
+func (r *Service) voluntaryExitSubscriber(ctx context.Context, msg proto.Message) error {
 	return r.operations.HandleValidatorExits(ctx, msg)
 }
 
-func (r *RegularSync) attesterSlashingSubscriber(ctx context.Context, msg proto.Message) error {
+func (r *Service) attesterSlashingSubscriber(ctx context.Context, msg proto.Message) error {
 	// TODO(#3259): Requires handlers in operations service to be implemented.
 	return nil
 }
 
-func (r *RegularSync) proposerSlashingSubscriber(ctx context.Context, msg proto.Message) error {
+func (r *Service) proposerSlashingSubscriber(ctx context.Context, msg proto.Message) error {
 	// TODO(#3259): Requires handlers in operations service to be implemented.
 	return nil
 }

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestSubscribe_ReceivesValidMessage(t *testing.T) {
 	p2p := p2ptest.NewTestP2P(t)
-	r := RegularSync{
+	r := Service{
 		ctx: context.Background(),
 		p2p: p2p,
 	}
@@ -47,7 +47,7 @@ func TestSubscribe_ReceivesValidMessage(t *testing.T) {
 func TestSubscribe_WaitToSync(t *testing.T) {
 	p2p := p2ptest.NewTestP2P(t)
 	chainService := &mockChain.ChainService{}
-	r := RegularSync{
+	r := Service{
 		ctx:           context.Background(),
 		p2p:           p2p,
 		chain:         chainService,
@@ -87,7 +87,7 @@ func TestSubscribe_WaitToSync(t *testing.T) {
 
 func TestSubscribe_HandlesPanic(t *testing.T) {
 	p2p := p2ptest.NewTestP2P(t)
-	r := RegularSync{
+	r := Service{
 		ctx: context.Background(),
 		p2p: p2p,
 	}

--- a/beacon-chain/sync/validate_attester_slashing.go
+++ b/beacon-chain/sync/validate_attester_slashing.go
@@ -35,7 +35,7 @@ func attSlashingCacheKey(slashing *ethpb.AttesterSlashing) (string, error) {
 
 // Clients who receive an attester slashing on this topic MUST validate the conditions within VerifyAttesterSlashing before
 // forwarding it across the network.
-func (r *RegularSync) validateAttesterSlashing(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
+func (r *Service) validateAttesterSlashing(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
 	// The head state will be too far away to validate any slashing.
 	if r.initialSync.Syncing() {
 		return false, nil

--- a/beacon-chain/sync/validate_attester_slashing_test.go
+++ b/beacon-chain/sync/validate_attester_slashing_test.go
@@ -87,7 +87,7 @@ func TestValidateAttesterSlashing_ValidSlashing(t *testing.T) {
 
 	slashing, s := setupValidAttesterSlashing(t)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p:         p2p,
 		chain:       &mock.ChainService{State: s},
 		initialSync: &mockSync.Sync{IsSyncing: false},
@@ -126,7 +126,7 @@ func TestValidateAttesterSlashing_ValidSlashing_FromSelf(t *testing.T) {
 
 	slashing, s := setupValidAttesterSlashing(t)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p:         p2p,
 		chain:       &mock.ChainService{State: s},
 		initialSync: &mockSync.Sync{IsSyncing: false},
@@ -150,7 +150,7 @@ func TestValidateAttesterSlashing_ContextTimeout(t *testing.T) {
 
 	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p:         p2p,
 		chain:       &mock.ChainService{State: state},
 		initialSync: &mockSync.Sync{IsSyncing: false},
@@ -168,7 +168,7 @@ func TestValidateAttesterSlashing_Syncing(t *testing.T) {
 
 	slashing, s := setupValidAttesterSlashing(t)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p:         p2p,
 		chain:       &mock.ChainService{State: s},
 		initialSync: &mockSync.Sync{IsSyncing: true},

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -19,7 +19,7 @@ var errPointsToBlockNotInDatabase = errors.New("attestation points to a block wh
 
 // validateBeaconAttestation validates that the block being voted for passes validation before forwarding to the
 // network.
-func (r *RegularSync) validateBeaconAttestation(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
+func (r *Service) validateBeaconAttestation(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
 	// Attestation processing requires the target block to be present in the database, so we'll skip
 	// validating or processing attestations until fully synced.
 	if r.initialSync.Syncing() {

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -20,7 +20,7 @@ func TestValidateBeaconAttestation_ValidBlock(t *testing.T) {
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 
-	rs := &RegularSync{
+	rs := &Service{
 		db: db,
 		chain: &mockChain.ChainService{
 			FinalizedCheckPoint: &ethpb.Checkpoint{
@@ -84,7 +84,7 @@ func TestValidateBeaconAttestation_InvalidBlock(t *testing.T) {
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 
-	rs := &RegularSync{
+	rs := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
@@ -110,7 +110,7 @@ func TestValidateBeaconAttestation_ValidBlock_FromSelf(t *testing.T) {
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 
-	rs := &RegularSync{
+	rs := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 	}
@@ -149,7 +149,7 @@ func TestValidateBeaconAttestation_Syncing(t *testing.T) {
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 
-	rs := &RegularSync{
+	rs := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: true},
 	}
@@ -184,7 +184,7 @@ func TestValidateBeaconAttestation_OldAttestation(t *testing.T) {
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 
-	rs := &RegularSync{
+	rs := &Service{
 		db: db,
 		chain: &mockChain.ChainService{
 			FinalizedCheckPoint: &ethpb.Checkpoint{
@@ -261,7 +261,7 @@ func TestValidateBeaconAttestation_FirstEpoch(t *testing.T) {
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 
-	rs := &RegularSync{
+	rs := &Service{
 		db: db,
 		chain: &mockChain.ChainService{
 			FinalizedCheckPoint: &ethpb.Checkpoint{

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -26,7 +26,7 @@ var recentlySeenRoots, _ = ristretto.NewCache(&ristretto.Config{
 // validateBeaconBlockPubSub checks that the incoming block has a valid BLS signature.
 // Blocks that have already been seen are ignored. If the BLS signature is any valid signature,
 // this method rebroadcasts the message.
-func (r *RegularSync) validateBeaconBlockPubSub(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
+func (r *Service) validateBeaconBlockPubSub(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
 	ctx, span := trace.StartSpan(ctx, "sync.validateBeaconBlockPubSub")
 	defer span.End()
 

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -31,7 +31,7 @@ func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 
 	mockBroadcaster := &p2ptest.MockBroadcaster{}
 
-	r := &RegularSync{
+	r := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 		chain: &mock.ChainService{Genesis: time.Now(),
@@ -70,7 +70,7 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 	}
 
 	mockBroadcaster := &p2ptest.MockBroadcaster{}
-	r := &RegularSync{
+	r := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 		chain:       &mock.ChainService{Genesis: time.Now()},
@@ -107,7 +107,7 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInCache(t *testing.T) {
 
 	mockBroadcaster := &p2ptest.MockBroadcaster{}
 
-	r := &RegularSync{
+	r := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 		chain: &mock.ChainService{Genesis: time.Now(),
@@ -165,7 +165,7 @@ func TestValidateBeaconBlockPubSub_ValidSignature(t *testing.T) {
 
 	mockBroadcaster := &p2ptest.MockBroadcaster{}
 
-	r := &RegularSync{
+	r := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 		chain: &mock.ChainService{Genesis: time.Now(),
@@ -205,7 +205,7 @@ func TestValidateBeaconBlockPubSub_ValidSignature_FromSelf(t *testing.T) {
 
 	mockBroadcaster := &p2ptest.MockBroadcaster{}
 
-	r := &RegularSync{
+	r := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 		chain:       &mock.ChainService{Genesis: time.Now()},
@@ -241,7 +241,7 @@ func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
 
 	mockBroadcaster := &p2ptest.MockBroadcaster{}
 
-	r := &RegularSync{
+	r := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: true},
 		chain: &mock.ChainService{
@@ -282,7 +282,7 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 
 	mockBroadcaster := &p2ptest.MockBroadcaster{}
 
-	r := &RegularSync{
+	r := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 		chain:       &mock.ChainService{Genesis: time.Now()},
@@ -323,7 +323,7 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
 
 	mockBroadcaster := &p2ptest.MockBroadcaster{}
 	genesisTime := time.Now()
-	r := &RegularSync{
+	r := &Service{
 		db:          db,
 		initialSync: &mockSync.Sync{IsSyncing: false},
 		chain: &mock.ChainService{

--- a/beacon-chain/sync/validate_proposer_slashing.go
+++ b/beacon-chain/sync/validate_proposer_slashing.go
@@ -33,7 +33,7 @@ func propSlashingCacheKey(slashing *ethpb.ProposerSlashing) (string, error) {
 
 // Clients who receive a proposer slashing on this topic MUST validate the conditions within VerifyProposerSlashing before
 // forwarding it across the network.
-func (r *RegularSync) validateProposerSlashing(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
+func (r *Service) validateProposerSlashing(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
 	// The head state will be too far away to validate any slashing.
 	if r.initialSync.Syncing() {
 		return false, nil

--- a/beacon-chain/sync/validate_proposer_slashing_test.go
+++ b/beacon-chain/sync/validate_proposer_slashing_test.go
@@ -100,7 +100,7 @@ func TestValidateProposerSlashing_ValidSlashing(t *testing.T) {
 
 	slashing, s := setupValidProposerSlashing(t)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p:         p2p,
 		chain:       &mock.ChainService{State: s},
 		initialSync: &mockSync.Sync{IsSyncing: false},
@@ -138,7 +138,7 @@ func TestValidateProposerSlashing_ValidSlashing_FromSelf(t *testing.T) {
 
 	slashing, s := setupValidProposerSlashing(t)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p:         p2p,
 		chain:       &mock.ChainService{State: s},
 		initialSync: &mockSync.Sync{IsSyncing: false},
@@ -162,7 +162,7 @@ func TestValidateProposerSlashing_ContextTimeout(t *testing.T) {
 
 	ctx, _ := context.WithTimeout(context.Background(), 100*time.Millisecond)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p:         p2p,
 		chain:       &mock.ChainService{State: state},
 		initialSync: &mockSync.Sync{IsSyncing: false},
@@ -180,7 +180,7 @@ func TestValidateProposerSlashing_Syncing(t *testing.T) {
 
 	slashing, s := setupValidProposerSlashing(t)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p:         p2p,
 		chain:       &mock.ChainService{State: s},
 		initialSync: &mockSync.Sync{IsSyncing: true},

--- a/beacon-chain/sync/validate_voluntary_exit.go
+++ b/beacon-chain/sync/validate_voluntary_exit.go
@@ -30,7 +30,7 @@ func exitCacheKey(exit *ethpb.VoluntaryExit) string {
 
 // Clients who receive a voluntary exit on this topic MUST validate the conditions within process_voluntary_exit before
 // forwarding it across the network.
-func (r *RegularSync) validateVoluntaryExit(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
+func (r *Service) validateVoluntaryExit(ctx context.Context, msg proto.Message, p p2p.Broadcaster, fromSelf bool) (bool, error) {
 	// The head state will be too far away to validate any voluntary exit.
 	if r.initialSync.Syncing() {
 		return false, nil

--- a/beacon-chain/sync/validate_voluntary_exit_test.go
+++ b/beacon-chain/sync/validate_voluntary_exit_test.go
@@ -62,7 +62,7 @@ func TestValidateVoluntaryExit_ValidExit(t *testing.T) {
 
 	exit, s := setupValidExit(t)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p: p2p,
 		chain: &mock.ChainService{
 			State: s,
@@ -102,7 +102,7 @@ func TestValidateVoluntaryExit_ValidExit_FromSelf(t *testing.T) {
 
 	exit, s := setupValidExit(t)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p: p2p,
 		chain: &mock.ChainService{
 			State: s,
@@ -126,7 +126,7 @@ func TestValidateVoluntaryExit_ValidExit_Syncing(t *testing.T) {
 
 	exit, s := setupValidExit(t)
 
-	r := &RegularSync{
+	r := &Service{
 		p2p: p2p,
 		chain: &mock.ChainService{
 			State: s,


### PR DESCRIPTION
Cosmetic fixes. This PR updates packages `sync` and `initialsync` to use `Service` as name for service struct. Before It was `initialsync.InitialSync` and `sync.RegularSync`

Before:

[2019-12-15 11:04:13]  INFO registry: Starting 9 services: [*p2p.Service *powchain.Service *operations.Service *attestations.Service *blockchain.Service *initialsync.**InitialSync** *sync.**RegularSync** *rpc.Service *prometheus.Service]

Now:

[2019-12-15 11:04:13]  INFO registry: Starting 9 services: [*p2p.Service *powchain.Service *operations.Service *attestations.Service *blockchain.Service *initialsync.**Service** *sync.**Service** *rpc.Service *prometheus.Service]
