### PR TITLE
Don't serialize bls signature just to deserialize it again

### DIFF
--- a/beacon-chain/core/helpers/attestation.go
+++ b/beacon-chain/core/helpers/attestation.go
@@ -128,7 +128,7 @@ func SlotSignature(state *pb.BeaconState, slot uint64, privKey *bls.SecretKey) (
 //    committee = get_beacon_committee(state, slot, index)
 //    modulo = max(1, len(committee) // TARGET_AGGREGATORS_PER_COMMITTEE)
 //    return bytes_to_int(hash(slot_signature)[0:8]) % modulo == 0
-func IsAggregator(state *pb.BeaconState, slot uint64, index uint64, slotSig *bls.Signature) (bool, error) {
+func IsAggregator(state *pb.BeaconState, slot uint64, index uint64, slotSig []byte) (bool, error) {
 	committee, err := BeaconCommittee(state, slot, index)
 	if err != nil {
 		return false, err
@@ -138,7 +138,7 @@ func IsAggregator(state *pb.BeaconState, slot uint64, index uint64, slotSig *bls
 		modulo = uint64(len(committee)) / params.BeaconConfig().TargetAggregatorsPerCommittee
 	}
 
-	b := hashutil.Hash(slotSig.Marshal())
+	b := hashutil.Hash(slotSig)
 	return binary.LittleEndian.Uint64(b[:8])%modulo == 0, nil
 }
 

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -229,7 +229,7 @@ func TestSlotSignature_Verify(t *testing.T) {
 func TestIsAggregator_True(t *testing.T) {
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 100)
 	sig := privKeys[0].Sign([]byte{}, 0)
-	agg, err := helpers.IsAggregator(beaconState, 0, 0, sig)
+	agg, err := helpers.IsAggregator(beaconState, 0, 0, sig.Marshal())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +244,7 @@ func TestIsAggregator_False(t *testing.T) {
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 2048)
 
 	sig := privKeys[0].Sign([]byte{}, 0)
-	agg, err := helpers.IsAggregator(beaconState, 0, 0, sig)
+	agg, err := helpers.IsAggregator(beaconState, 0, 0, sig.Marshal())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/rpc/aggregator/BUILD.bazel
+++ b/beacon-chain/rpc/aggregator/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/sync:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",
-        "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",

--- a/beacon-chain/rpc/aggregator/server.go
+++ b/beacon-chain/rpc/aggregator/server.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/sync"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
-	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -59,11 +58,7 @@ func (as *Server) SubmitAggregateAndProof(ctx context.Context, req *pb.Aggregati
 	}
 
 	// Check if the validator is an aggregator
-	sig, err := bls.SignatureFromBytes(req.SlotSignature)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not convert signature to byte: %v", err)
-	}
-	isAggregator, err := helpers.IsAggregator(headState, req.Slot, req.CommitteeIndex, sig)
+	isAggregator, err := helpers.IsAggregator(headState, req.Slot, req.CommitteeIndex, req.SlotSignature)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get aggregator status: %v", err)
 	}


### PR DESCRIPTION
I noticed this from the `SubmitAggregatorSignature` RPC method, the code would hydrate a BLS signature object then marshal it back to the original bytes to determine if the signature is an aggregator. 