### PR TITLE
Remove ChainStartFeed mocks

### DIFF
--- a/beacon-chain/interop-cold-start/BUILD.bazel
+++ b/beacon-chain/interop-cold-start/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared:go_default_library",
         "//shared/bytesutil:go_default_library",
-        "//shared/event:go_default_library",
         "//shared/interop:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/beacon-chain/interop-cold-start/service.go
+++ b/beacon-chain/interop-cold-start/service.go
@@ -15,7 +15,6 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/interop"
 )
 
@@ -121,11 +120,6 @@ func (s *Service) ChainStartDeposits() []*ethpb.Deposit {
 // ChainStartEth1Data mocks out the powchain functionality for interop.
 func (s *Service) ChainStartEth1Data() *ethpb.Eth1Data {
 	return &ethpb.Eth1Data{}
-}
-
-// ChainStartFeed mocks out the powchain functionality for interop.
-func (s *Service) ChainStartFeed() *event.Feed {
-	return new(event.Feed)
 }
 
 // DepositByPubkey mocks out the deposit cache functionality for interop.

--- a/beacon-chain/powchain/testing/faulty_mock.go
+++ b/beacon-chain/powchain/testing/faulty_mock.go
@@ -22,11 +22,6 @@ func (f *FaultyMockPOWChain) Eth2GenesisPowchainInfo() (uint64, *big.Int) {
 	return 0, big.NewInt(0)
 }
 
-// ChainStartFeed --
-func (f *FaultyMockPOWChain) ChainStartFeed() *event.Feed {
-	return f.ChainFeed
-}
-
 // LatestBlockHeight --
 func (f *FaultyMockPOWChain) LatestBlockHeight() *big.Int {
 	return big.NewInt(0)

--- a/beacon-chain/powchain/testing/mock.go
+++ b/beacon-chain/powchain/testing/mock.go
@@ -24,11 +24,6 @@ type POWChain struct {
 	GenesisEth1Block    *big.Int
 }
 
-// ChainStartFeed --
-func (m *POWChain) ChainStartFeed() *event.Feed {
-	return m.ChainFeed
-}
-
 // Eth2GenesisPowchainInfo --
 func (m *POWChain) Eth2GenesisPowchainInfo() (uint64, *big.Int) {
 	blk := m.GenesisEth1Block


### PR DESCRIPTION
ChainStartFeed was removed a while back when it was rolled in to state feed but this mock was missed in a few places.  Removing now