### PR TITLE
Add individual p2p host counts

### DIFF
--- a/beacon-chain/p2p/monitoring.go
+++ b/beacon-chain/p2p/monitoring.go
@@ -1,46 +1,30 @@
 package p2p
 
 import (
-	"time"
-
-	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prysmaticlabs/prysm/shared/runutil"
 )
 
 var (
 	p2pTopicPeerCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "p2p_topic_peer_count",
-		Help: "The number of peers subscribed to a topic",
+		Help: "The number of peers subscribed to a given topic.",
 	},
 		[]string{"topic"})
+	p2pPeerCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "p2p_peer_count",
+		Help: "The number of peers in a given state.",
+	},
+		[]string{"state"})
 )
 
-func registerMetrics(s *Service) {
-
-	// Metrics with a single value can use GaugeFunc, CounterFunc, etc.
-	if err := prometheus.DefaultRegisterer.Register(prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "p2p_peer_count",
-		Help: "The number of currently connected peers",
-	}, func() float64 {
-		return float64(peerCount(s.host))
-	})); err != nil {
-		// This should only happen in tests.
-		log.WithError(err).Error("Failed to register metric")
-	}
-
-	// Metrics with labels, polled every 10s.
-	runutil.RunEvery(s.ctx, time.Duration(10*time.Second), s.updateP2PTopicPeerCount)
-}
-
-func peerCount(h host.Host) int {
-	return len(h.Network().Peers())
-}
-
-func (s *Service) updateP2PTopicPeerCount() {
+func (s *Service) updateMetrics() {
 	for topic := range GossipTopicMappings {
 		topic += s.Encoding().ProtocolSuffix()
 		p2pTopicPeerCount.WithLabelValues(topic).Set(float64(len(s.pubsub.ListPeers(topic))))
 	}
+	p2pPeerCount.WithLabelValues("Connected").Set(float64(len(s.peers.Connected())))
+	p2pPeerCount.WithLabelValues("Disconnected").Set(float64(len(s.peers.Disconnected())))
+	p2pPeerCount.WithLabelValues("Connecting").Set(float64(len(s.peers.Connecting())))
+	p2pPeerCount.WithLabelValues("Disconnecting").Set(float64(len(s.peers.Disconnecting())))
 }

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -207,7 +207,7 @@ func (s *Service) Start() {
 
 	startPeerWatcher(s.ctx, s.host, peersToWatch...)
 	runutil.RunEvery(s.ctx, time.Hour, s.Peers().Decay)
-	registerMetrics(s)
+	runutil.RunEvery(s.ctx, 10*time.Second, s.updateMetrics)
 	multiAddrs := s.host.Network().ListenAddresses()
 	logIP4Addr(s.host.ID(), multiAddrs...)
 }


### PR DESCRIPTION
The prometheus metric `p2p_peer_count` was returning the count of all nodes known to libp2p, which isn't very useful.

This patch provides the a count broken down by status as provided by `peers`, e.g.

```
p2p_peer_count{state="Connected"} 22
p2p_peer_count{state="Connecting"} 1
p2p_peer_count{state="Disconnected"} 18
p2p_peer_count{state="Disconnecting"} 0
```

It also takes the opportunity to call the periodic update function directly rather than jump through a single-line function.