### PR TITLE
Add Benchmarks for Custom SSZ Hash Tree Root

### DIFF
--- a/shared/stateutil/BUILD.bazel
+++ b/shared/stateutil/BUILD.bazel
@@ -38,7 +38,9 @@ go_test(
     deps = [
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/interop:go_default_library",
+        "//shared/params:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
     ],
 )

--- a/shared/stateutil/state_root_test.go
+++ b/shared/stateutil/state_root_test.go
@@ -2,12 +2,15 @@ package stateutil_test
 
 import (
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/interop"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/stateutil"
 )
 
@@ -41,9 +44,31 @@ func TestHashTreeRootEquality(t *testing.T) {
 	}
 }
 
-func BenchmarkHashTreeRootState_Custom(b *testing.B) {
+func BenchmarkHashTreeRootState_Custom_512(b *testing.B) {
 	b.StopTimer()
 	genesisState := setupGenesisState(b, 512)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := stateutil.HashTreeRootState(genesisState); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkHashTreeRootState_Custom_16384(b *testing.B) {
+	b.StopTimer()
+	genesisState := setupGenesisState(b, 16384)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := stateutil.HashTreeRootState(genesisState); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkHashTreeRootState_Custom_300000(b *testing.B) {
+	b.StopTimer()
+	genesisState := setupGenesisState(b, 300000)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		if _, err := stateutil.HashTreeRootState(genesisState); err != nil {
@@ -64,9 +89,26 @@ func BenchmarkHashTreeRootState_Generic(b *testing.B) {
 }
 
 func setupGenesisState(tb testing.TB, count uint64) *pb.BeaconState {
-	genesisState, _, err := interop.GenerateGenesisState(0, count)
+	genesisState, _, err := interop.GenerateGenesisState(0, 1)
 	if err != nil {
 		tb.Fatalf("Could not generate genesis beacon state: %v", err)
+	}
+	for i := uint64(1); i < count; i++ {
+		someRoot := [32]byte{}
+		someKey := [48]byte{}
+		copy(someRoot[:], strconv.Itoa(int(i)))
+		copy(someKey[:], strconv.Itoa(int(i)))
+		genesisState.Validators = append(genesisState.Validators, &ethpb.Validator{
+			PublicKey:                  someKey[:],
+			WithdrawalCredentials:      someRoot[:],
+			EffectiveBalance:           params.BeaconConfig().MaxEffectiveBalance,
+			Slashed:                    false,
+			ActivationEligibilityEpoch: 1,
+			ActivationEpoch:            1,
+			ExitEpoch:                  1,
+			WithdrawableEpoch:          1,
+		})
+		genesisState.Balances = append(genesisState.Balances, params.BeaconConfig().MaxEffectiveBalance)
 	}
 	return genesisState
 }

--- a/shared/stateutil/state_root_test.go
+++ b/shared/stateutil/state_root_test.go
@@ -77,9 +77,31 @@ func BenchmarkHashTreeRootState_Custom_300000(b *testing.B) {
 	}
 }
 
-func BenchmarkHashTreeRootState_Generic(b *testing.B) {
+func BenchmarkHashTreeRootState_Generic_512(b *testing.B) {
 	b.StopTimer()
 	genesisState := setupGenesisState(b, 512)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ssz.HashTreeRoot(genesisState); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkHashTreeRootState_Generic_16384(b *testing.B) {
+	b.StopTimer()
+	genesisState := setupGenesisState(b, 16384)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ssz.HashTreeRoot(genesisState); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkHashTreeRootState_Generic_300000(b *testing.B) {
+	b.StopTimer()
+	genesisState := setupGenesisState(b, 300000)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		if _, err := ssz.HashTreeRoot(genesisState); err != nil {


### PR DESCRIPTION
No tracking issue

---

# Description

**Write why you are making the changes in this pull request**

This PR adds some useful benchmarks for custom SSZ Hash Tree Root in Prysm, giving us an idea about how fast these take for common validator counts such as 512, 16384, and 300000.

```
BenchmarkHashTreeRootState_Custom_512-4               57          21409712 ns/op
BenchmarkHashTreeRootState_Custom_16384-4             30          35877490 ns/op
BenchmarkHashTreeRootState_Custom_300000-4             1        4419664089 ns/op
```