### PR TITLE
Process slots exit early if same slot

### DIFF
--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -256,11 +256,17 @@ func ProcessSlots(ctx context.Context, state *pb.BeaconState, slot uint64) (*pb.
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.ProcessSlots")
 	defer span.End()
 	span.AddAttributes(trace.Int64Attribute("slots", int64(slot)-int64(state.Slot)))
+
 	if state.Slot > slot {
 		err := fmt.Errorf("expected state.slot %d < slot %d", state.Slot, slot)
 		traceutil.AnnotateError(span, err)
 		return nil, err
 	}
+
+	if state.Slot == slot {
+		return state, nil
+	}
+
 	highestSlot := state.Slot
 	var root [32]byte
 	var writeToCache bool


### PR DESCRIPTION
With the recent addition of skip slot cache, we `HashTreeRoot` the `state` every time `ProcessSlots` is called. Even under the condition where input `slot` is equal to `state.slot` 
https://github.com/prysmaticlabs/prysm/blob/master/beacon-chain/core/state/transition.go#L277

It was an unnecessary operation and was discovered while running a 16384 validators node.  The proper fix here is to return the input `state` early if the `slot` is equal

With this, we see a 3x reduction when profiling RPC request attestations 

<img width="1616" alt="Screen Shot 2019-12-17 at 7 32 55 PM" src="https://user-images.githubusercontent.com/21316537/71054333-81d59500-2106-11ea-9997-d952a37fe3d6.png">

<img width="1608" alt="Screen Shot 2019-12-17 at 7 15 49 PM" src="https://user-images.githubusercontent.com/21316537/71054381-a6317180-2106-11ea-8275-91b768130b86.png">

