### PR TITLE
Migrate periodic function to use RunEvery

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -205,9 +205,13 @@ func (s *Service) Start() {
 		s.connectWithAllPeers(addrs)
 	}
 
-	startPeerWatcher(s.ctx, s.host, peersToWatch...)
+	// Periodic functions.
+	runutil.RunEvery(s.ctx, 5*time.Second, func() {
+		ensurePeerConnections(s.ctx, s.host, peersToWatch...)
+	})
 	runutil.RunEvery(s.ctx, time.Hour, s.Peers().Decay)
 	runutil.RunEvery(s.ctx, 10*time.Second, s.updateMetrics)
+
 	multiAddrs := s.host.Network().ListenAddresses()
 	logIP4Addr(s.host.ID(), multiAddrs...)
 }

--- a/beacon-chain/p2p/watch_peers.go
+++ b/beacon-chain/p2p/watch_peers.go
@@ -7,24 +7,6 @@ import (
 	host "github.com/libp2p/go-libp2p-host"
 )
 
-// starPeerWatcher  calls to reconnect any VIP peers such as the bootnode peer, the relay node peer
-// or the static peers.
-func startPeerWatcher(ctx context.Context, h host.Host, reconnectPeers ...string) {
-	go (func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				ensurePeerConnections(ctx, h, reconnectPeers...)
-
-				// Wait 5 second to update again
-				time.Sleep(5 * time.Second)
-			}
-		}
-	})()
-}
-
 // ensurePeerConnections will attempt to reestablish connection to the peers
 // if there are currently no connections to that peer.
 func ensurePeerConnections(ctx context.Context, h host.Host, peers ...string) {


### PR DESCRIPTION
Another function that loops moved to `RunEvery`; missed this one in the last pass as it used sleep rather than a ticker.