### PR TITLE
Disallow allow duplicated indices for indexed attestation

### DIFF
--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -1195,7 +1195,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 					Epoch: 1,
 				},
 			},
-			AttestingIndices: []uint64{47, 99},
+			AttestingIndices: []uint64{47, 99, 99},
 		}},
 		{attestation: &ethpb.IndexedAttestation{
 			Data: &ethpb.AttestationData{
@@ -1203,7 +1203,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 					Epoch: 4,
 				},
 			},
-			AttestingIndices: []uint64{21, 72},
+			AttestingIndices: []uint64{21, 72, 21},
 		}},
 		{attestation: &ethpb.IndexedAttestation{
 			Data: &ethpb.AttestationData{
@@ -1211,7 +1211,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 					Epoch: 7,
 				},
 			},
-			AttestingIndices: []uint64{100, 121},
+			AttestingIndices: []uint64{100, 121, 100, 121},
 		}},
 	}
 


### PR DESCRIPTION
Part of #4272 

Added a check to disallow duplicated indices for indexed attestation since there's no bitfield. Updated test for further verification. 

See rationale for removing: https://github.com/ethereum/eth2.0-specs/issues/1486#issuecomment-564786571