### PR TITLE
Update TargetAggregatorsPerCommittee  from 2 to 3

### DIFF
--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -250,7 +250,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.ShuffleRoundCount = 10
 	minimalConfig.MinGenesisActiveValidatorCount = 64
 	minimalConfig.MinGenesisTime = 0
-	minimalConfig.TargetAggregatorsPerCommittee = 2
+	minimalConfig.TargetAggregatorsPerCommittee = 3
 
 	// Gwei values
 	minimalConfig.MinDepositAmount = 1e9


### PR DESCRIPTION
After further investigating on missing participation of certain epoch, It turns out `TargetAggregatorsPerCommittee` set as 2 was not safe enough for 4 validators committee. There's 6% chance of missing an aggregator per committee. This PR updates `TargetAggregatorsPerCommittee` from 2 to 3 to cut down the chance of missing aggregator to 0.3%

| TargetAggregatorsPerCommittee|  len(committee) | Chance one validator gets selected   | Change of no aggregator  |
|---|---|---|---|
|  2 | 4  | 0.5 | 0.062   |
|  3 | 4  |  0.76 | 0.0033  |