### PR TITLE
Remove verify unaggregated attestation when aggregating

### DIFF
--- a/beacon-chain/rpc/aggregator/BUILD.bazel
+++ b/beacon-chain/rpc/aggregator/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/blockchain:go_default_library",
-        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/operations/attestations:go_default_library",

--- a/beacon-chain/rpc/aggregator/server.go
+++ b/beacon-chain/rpc/aggregator/server.go
@@ -5,7 +5,6 @@ import (
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
@@ -79,24 +78,8 @@ func (as *Server) SubmitAggregateAndProof(ctx context.Context, req *pb.Aggregati
 	// Retrieve the unaggregated attestation from pool
 	atts := as.AttPool.UnaggregatedAttestationsBySlotIndex(req.Slot, req.CommitteeIndex)
 
-	headState, err := as.HeadFetcher.HeadState(ctx)
-	if err != nil {
-		return nil, err
-	}
-	// Verify attestations are valid before aggregating and broadcasting them out.
-	validAtts := make([]*ethpb.Attestation, 0, len(atts))
-	for _, att := range atts {
-		if err := blocks.VerifyAttestation(ctx, headState, att); err != nil {
-			if err := as.AttPool.DeleteUnaggregatedAttestation(att); err != nil {
-				return nil, status.Errorf(codes.Internal, "Could not delete invalid attestation: %v", err)
-			}
-			continue
-		}
-		validAtts = append(validAtts, att)
-	}
-
 	// Aggregate the attestations and broadcast them.
-	aggregatedAtts, err := helpers.AggregateAttestations(validAtts)
+	aggregatedAtts, err := helpers.AggregateAttestations(atts)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not aggregate attestations: %v", err)
 	}

--- a/beacon-chain/rpc/validator/BUILD.bazel
+++ b/beacon-chain/rpc/validator/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//beacon-chain/sync:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",
+        "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",


### PR DESCRIPTION
When running 16384 validators on a beacon node. One of the biggest bottleneck is attestation aggregation. With 16384 validators, there's going to be roughly 64 aggregators per slot (16 per committee, 4 committees). Per aggregator, it verifies all the unaggregated attestations, and doing it 64 times is intensive. Although it's unlikely one will run that amount of validators on a single beacon node in production

This PR removed unaggregated attestation verification as part of aggregating loop. To compensate this removal, we added signature verification when attester service receives unaggregated attestation so attestation with bad signature won't get accepted into the pool nor broadcasted 

Before and after:
![Screen Shot 2019-12-23 at 12 31 47 PM](https://user-images.githubusercontent.com/21316537/71380981-7959e000-2586-11ea-8939-627157ae5318.png)
![Screen Shot 2019-12-23 at 1 08 38 PM](https://user-images.githubusercontent.com/21316537/71380982-7959e000-2586-11ea-8953-3d1ef944847d.png)
