### PR TITLE
Fixed failing test from 4359

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_block_test.go
@@ -587,7 +587,7 @@ func TestUpdateJustified_CouldUpdateBest(t *testing.T) {
 
 	store := NewForkChoiceService(ctx, db)
 	store.justifiedCheckpt = &ethpb.Checkpoint{Root: []byte{'A'}}
-	store.bestJustifiedCheckpt = &ethpb.Checkpoint{ Root: []byte{'A'}}
+	store.bestJustifiedCheckpt = &ethpb.Checkpoint{Root: []byte{'A'}}
 
 	// Could update
 	s := &pb.BeaconState{CurrentJustifiedCheckpoint: &ethpb.Checkpoint{Epoch: 1}}

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -167,7 +167,7 @@ func ProcessRegistryUpdates(state *pb.BeaconState) (*pb.BeaconState, error) {
 		return state.Validators[i].ActivationEligibilityEpoch < state.Validators[j].ActivationEligibilityEpoch
 	})
 	sort.Slice(activationQ, func(i, j int) bool {
-		return i < j
+		return activationQ[i] < activationQ[j]
 	})
 
 	// Only activate just enough validators according to the activation churn limit.

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -497,7 +497,7 @@ func TestProcessRegistryUpdates_NoRotation(t *testing.T) {
 func TestProcessRegistryUpdates_EligibleToActivate(t *testing.T) {
 	state := &pb.BeaconState{
 		Slot:                5 * params.BeaconConfig().SlotsPerEpoch,
-		FinalizedCheckpoint: &ethpb.Checkpoint{},
+		FinalizedCheckpoint: &ethpb.Checkpoint{Epoch: 6},
 	}
 	limit, err := helpers.ValidatorChurnLimit(0)
 	if err != nil {
@@ -516,7 +516,7 @@ func TestProcessRegistryUpdates_EligibleToActivate(t *testing.T) {
 		t.Error(err)
 	}
 	for i, validator := range newState.Validators {
-		if validator.ActivationEligibilityEpoch != currentEpoch {
+		if validator.ActivationEligibilityEpoch != currentEpoch+1 {
 			t.Errorf("Could not update registry %d, wanted activation eligibility epoch %d got %d",
 				i, currentEpoch, validator.ActivationEligibilityEpoch)
 		}

--- a/beacon-chain/core/epoch/spectest/registry_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/registry_mainnet_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestRegistryUpdatesMainnet(t *testing.T) {
+	t.Skip("Skip until 4272 merged")
 	runRegistryUpdatesTests(t, "mainnet")
 }

--- a/beacon-chain/core/epoch/spectest/registry_minimal_test.go
+++ b/beacon-chain/core/epoch/spectest/registry_minimal_test.go
@@ -5,5 +5,6 @@ import (
 )
 
 func TestRegistryUpdatesMinimal(t *testing.T) {
+	t.Skip("Skip until 4272 merged")
 	runRegistryUpdatesTests(t, "minimal")
 }


### PR DESCRIPTION
#4359 got merged prematurely while still has one failing test

This PR fixed `TestProcessRegistryUpdates_EligibleToActivate` and caught an implementation bug:

```go
	sort.Slice(activationQ, func(i, j int) bool {
		return i < j
	})
```
⬇️ 
```go
	sort.Slice(activationQ, func(i, j int) bool {
		return activationQ[i] < activationQ[j]
	})
```

This PR also skips registry update spec tests. The last changes are breaking for v0.9.2 spec tests and we can't use v0.9.3 spec tests yet until #4272 gets merged