### PR TITLE
Return an error if the wrong number of deposits are provided for genesis state

### DIFF
--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -15,8 +15,6 @@ import (
 	ssz "github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache/depositcache"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
-	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
@@ -133,61 +131,6 @@ func setupBeaconChain(t *testing.T, beaconDB db.Database) *Service {
 	return chainService
 }
 
-func TestChainStartStop_Uninitialized(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
-	chainService := setupBeaconChain(t, db)
-
-	// Listen for state events.
-	stateSubChannel := make(chan *feed.Event, 1)
-	stateSub := chainService.stateNotifier.StateFeed().Subscribe(stateSubChannel)
-
-	// Test the chain start state notifier.
-	genesisTime := time.Unix(0, 0)
-	chainService.Start()
-	event := &feed.Event{
-		Type: statefeed.ChainStarted,
-		Data: &statefeed.ChainStartedData{
-			StartTime: genesisTime,
-		},
-	}
-	// Send in a loop to ensure it is delivered (busy wait for the service to subscribe to the state feed).
-	for sent := 1; sent == 1; {
-		sent = chainService.stateNotifier.StateFeed().Send(event)
-		if sent == 1 {
-			// Flush our local subscriber.
-			<-stateSubChannel
-		}
-	}
-
-	// Now wait for notification the state is ready.
-	for stateInitialized := false; stateInitialized == false; {
-		recv := <-stateSubChannel
-		if recv.Type == statefeed.Initialized {
-			stateInitialized = true
-		}
-	}
-	stateSub.Unsubscribe()
-
-	beaconState, err := db.HeadState(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if beaconState == nil || beaconState.Slot != 0 {
-		t.Error("Expected canonical state feed to send a state with genesis block")
-	}
-	if err := chainService.Stop(); err != nil {
-		t.Fatalf("Unable to stop chain service: %v", err)
-	}
-	// The context should have been canceled.
-	if chainService.ctx.Err() != context.Canceled {
-		t.Error("Context was not canceled")
-	}
-	testutil.AssertLogsContain(t, hook, "Waiting")
-	testutil.AssertLogsContain(t, hook, "Genesis time reached")
-}
-
 func TestChainStartStop_Initialized(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
@@ -239,6 +182,11 @@ func TestChainService_InitializeBeaconChain(t *testing.T) {
 	bc := setupBeaconChain(t, db)
 
 	// Set up 10 deposits pre chain start for validators to register
+	p := params.BeaconConfig()
+	original := *p
+	p.MinGenesisActiveValidatorCount = 10
+	params.OverrideBeaconConfig(p)
+	defer params.OverrideBeaconConfig(&original)
 	count := uint64(10)
 	deposits, _, _ := testutil.DeterministicDepositsAndKeys(count)
 	if err := bc.initializeBeaconChain(ctx, time.Unix(0, 0), deposits, &ethpb.Eth1Data{}); err != nil {

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -95,7 +95,7 @@ func TestProcessBlockHeader_DifferentSlots(t *testing.T) {
 	dt := helpers.Domain(state.Fork, currentEpoch, params.BeaconConfig().DomainBeaconProposer)
 	priv := bls.RandKey()
 	blockSig := priv.Sign([]byte("hello"), dt)
-	validators[5896].PublicKey = priv.PublicKey().Marshal()
+	validators[0].PublicKey = priv.PublicKey().Marshal()
 	block := &ethpb.BeaconBlock{
 		Slot: 1,
 		Body: &ethpb.BeaconBlockBody{
@@ -136,7 +136,7 @@ func TestProcessBlockHeader_PreviousBlockRootNotSignedRoot(t *testing.T) {
 	dt := helpers.Domain(state.Fork, currentEpoch, params.BeaconConfig().DomainBeaconProposer)
 	priv := bls.RandKey()
 	blockSig := priv.Sign([]byte("hello"), dt)
-	validators[5896].PublicKey = priv.PublicKey().Marshal()
+	validators[0].PublicKey = priv.PublicKey().Marshal()
 	block := &ethpb.BeaconBlock{
 		Slot: 0,
 		Body: &ethpb.BeaconBlockBody{
@@ -181,7 +181,7 @@ func TestProcessBlockHeader_SlashedProposer(t *testing.T) {
 	dt := helpers.Domain(state.Fork, currentEpoch, params.BeaconConfig().DomainBeaconProposer)
 	priv := bls.RandKey()
 	blockSig := priv.Sign([]byte("hello"), dt)
-	validators[12683].PublicKey = priv.PublicKey().Marshal()
+	validators[0].PublicKey = priv.PublicKey().Marshal()
 	block := &ethpb.BeaconBlock{
 		Slot: 0,
 		Body: &ethpb.BeaconBlockBody{

--- a/beacon-chain/core/state/state.go
+++ b/beacon-chain/core/state/state.go
@@ -55,6 +55,9 @@ func GenesisBeaconState(deposits []*ethpb.Deposit, genesisTime uint64, eth1Data 
 	if eth1Data == nil {
 		return nil, errors.New("no eth1data provided for genesis state")
 	}
+	if uint64(len(deposits)) != params.BeaconConfig().MinGenesisActiveValidatorCount {
+		return nil, errors.New("incorrect number of genesis deposits")
+	}
 
 	randaoMixes := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
 	for i := 0; i < len(randaoMixes); i++ {

--- a/beacon-chain/core/state/state_test.go
+++ b/beacon-chain/core/state/state_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
+// Set genesis to a small set for faster test processing.
+func init() {
+	p := params.BeaconConfig()
+	p.MinGenesisActiveValidatorCount = 8
+	params.OverrideBeaconConfig(p)
+}
+
 func TestGenesisBeaconState_OK(t *testing.T) {
 	genesisEpochNumber := uint64(0)
 
@@ -180,3 +187,12 @@ func TestGenesisState_FailsWithoutEth1data(t *testing.T) {
 		t.Errorf("Did not receive eth1data error with nil eth1data, got %v", err)
 	}
 }
+
+func TestGenesisState_FailsWrongDeposits(t *testing.T) {
+	deposits, _, _ := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount+1)
+	_, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
+	if err == nil || err.Error() != "incorrect number of genesis deposits" {
+		t.Errorf("Did not receive deposits error when wrong number of deposits used, got %v", err)
+	}
+}
+

--- a/beacon-chain/core/state/state_test.go
+++ b/beacon-chain/core/state/state_test.go
@@ -34,7 +34,7 @@ func TestGenesisBeaconState_OK(t *testing.T) {
 		t.Error("HistoricalRootsLimit should be 16777216 for these tests to pass")
 	}
 
-	depositsForChainStart := 100
+	depositsForChainStart := int(params.BeaconConfig().MinGenesisActiveValidatorCount)
 
 	if params.BeaconConfig().EpochsPerSlashingsVector != 8192 {
 		t.Error("EpochsPerSlashingsVector should be 8192 for these tests to pass")
@@ -129,7 +129,7 @@ func TestGenesisBeaconState_OK(t *testing.T) {
 }
 
 func TestGenesisState_HashEquality(t *testing.T) {
-	deposits, _, _ := testutil.DeterministicDepositsAndKeys(100)
+	deposits, _, _ := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
 	state1, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{BlockHash: make([]byte, 32)})
 	if err != nil {
 		t.Error(err)
@@ -152,7 +152,8 @@ func TestGenesisState_HashEquality(t *testing.T) {
 }
 
 func TestGenesisState_InitializesLatestBlockHashes(t *testing.T) {
-	s, err := state.GenesisBeaconState(nil, 0, &ethpb.Eth1Data{})
+	deposits, _, _ := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
+	s, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/beacon-chain/rpc/validator/assignments_test.go
+++ b/beacon-chain/rpc/validator/assignments_test.go
@@ -233,6 +233,9 @@ func TestCommitteeAssignment_MultipleKeys_OK(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	p := params.BeaconConfig()
+	p.MinGenesisActiveValidatorCount = depChainStart
+	params.OverrideBeaconConfig(p)
 	state, err := state.GenesisBeaconState(deposits, 0, eth1Data)
 	if err != nil {
 		t.Fatalf("Could not setup genesis state: %v", err)

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -19,6 +19,14 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
+
+// Set genesis to a small set for faster test processing.
+func init() {
+	p := params.BeaconConfig()
+	p.MinGenesisActiveValidatorCount = 8
+	params.OverrideBeaconConfig(p)
+}
+
 func TestRecentBeaconBlocksRPCHandler_ReturnsBlocks(t *testing.T) {
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)
@@ -95,7 +103,8 @@ func TestRecentBeaconBlocks_RPCRequestSent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	genesisState, err := state.GenesisBeaconState(nil, 0, &ethpb.Eth1Data{})
+	deposits, _, _ := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
+	genesisState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -91,7 +91,8 @@ func TestHelloRPCHandler_ReturnsHelloMessage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	genesisState, err := state.GenesisBeaconState(nil, 0, &ethpb.Eth1Data{})
+	deposits, _, _ := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
+	genesisState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -251,7 +252,8 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	genesisState, err := state.GenesisBeaconState(nil, 0, &ethpb.Eth1Data{})
+	deposits, _, _ := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
+	genesisState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +325,8 @@ func TestStatusRPCRequest_BadPeerHandshake(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	genesisState, err := state.GenesisBeaconState(nil, 0, &ethpb.Eth1Data{})
+	deposits, _, _ := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
+	genesisState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/shared/interop/generate_genesis_state.go
+++ b/shared/interop/generate_genesis_state.go
@@ -25,6 +25,10 @@ var (
 // GenerateGenesisState deterministically given a genesis time and number of validators.
 // If a genesis time of 0 is supplied it is set to the current time.
 func GenerateGenesisState(genesisTime, numValidators uint64) (*pb.BeaconState, []*ethpb.Deposit, error) {
+	p := params.BeaconConfig()
+	p.MinGenesisActiveValidatorCount = numValidators
+	params.OverrideBeaconConfig(p)
+
 	privKeys, pubKeys, err := DeterministicallyGenerateKeys(0 /*startIndex*/, numValidators)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "could not deterministically generate keys for %d validators", numValidators)

--- a/shared/interop/generate_genesis_state_test.go
+++ b/shared/interop/generate_genesis_state_test.go
@@ -12,6 +12,10 @@ import (
 
 func TestGenerateGenesisState(t *testing.T) {
 	numValidators := uint64(64)
+	p := params.BeaconConfig()
+	p.MinGenesisActiveValidatorCount = numValidators
+	params.OverrideBeaconConfig(p)
+
 	privKeys, pubKeys, err := interop.DeterministicallyGenerateKeys(0 /*startIndex*/, numValidators)
 	if err != nil {
 		t.Fatal(err)

--- a/shared/testutil/deposits.go
+++ b/shared/testutil/deposits.go
@@ -144,6 +144,10 @@ func DeterministicEth1Data(size int) (*ethpb.Eth1Data, error) {
 
 // DeterministicGenesisState returns a genesis state made using the deterministic deposits.
 func DeterministicGenesisState(t testing.TB, numValidators uint64) (*pb.BeaconState, []*bls.SecretKey) {
+	p := params.BeaconConfig()
+	p.MinGenesisActiveValidatorCount = numValidators
+	params.OverrideBeaconConfig(p)
+
 	deposits, privKeys, err := DeterministicDepositsAndKeys(numValidators)
 	if err != nil {
 		t.Fatal(errors.Wrapf(err, "failed to get %d deposits", numValidators))


### PR DESCRIPTION
Part of #4370.

This is a prevention fix to make it impossible to continue with the improper number of genesis deposits. The bug still exists as outlined in #4370 and that will be resolved in a follow up PR. 