### PR TITLE
Only add chain start deposits up to min genesis active validator count

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -148,7 +148,7 @@ func (s *Service) ProcessDepositLog(ctx context.Context, depositLog gethTypes.Lo
 	// We always store all historical deposits in the DB.
 	s.depositCache.InsertDeposit(ctx, deposit, big.NewInt(int64(depositLog.BlockNumber)), int(index), s.depositTrie.Root())
 	validData := true
-	if !s.chainStarted {
+	if !s.chainStarted && uint64(len(s.chainStartDeposits)) < params.BeaconConfig().MinGenesisActiveValidatorCount {
 		s.chainStartDeposits = append(s.chainStartDeposits, deposit)
 		root := s.depositTrie.Root()
 		eth1Data := &ethpb.Eth1Data{

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -452,6 +452,7 @@ func TestProcessETH2GenesisLog_CorrectNumOfDeposits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	depositOffset := 5
 
 	// 64 Validators are used as size required for beacon-chain to start. This number
@@ -482,13 +483,17 @@ func TestProcessETH2GenesisLog_CorrectNumOfDeposits(t *testing.T) {
 	}
 
 	cachedDeposits := web3Service.ChainStartDeposits()
-	requiredDepsForChainstart := depositsReqForChainStart + depositOffset
-	if len(cachedDeposits) != requiredDepsForChainstart {
-		t.Fatalf(
+	if len(cachedDeposits) != depositsReqForChainStart {
+		t.Errorf(
 			"Did not cache the chain start deposits correctly, received %d, wanted %d",
 			len(cachedDeposits),
-			requiredDepsForChainstart,
+			depositsReqForChainStart,
 		)
+	}
+
+	pendingDeposits := web3Service.depositCache.PendingDeposits(context.Background(), testAcc.Backend.Blockchain().CurrentBlock().Number())
+	if len(pendingDeposits) != totalNumOfDeposits-depositsReqForChainStart-1 {
+		t.Errorf("Did not receive correct number of cached deposits. Got %d, wanted %d", len(pendingDeposits), totalNumOfDeposits-depositsReqForChainStart)
 	}
 
 	// Receive the chain started event.

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -182,7 +182,7 @@ func NewService(ctx context.Context, config *Web3ServiceConfig) (*Service, error
 		depositContractAddress:  config.DepositContract,
 		stateNotifier:           config.StateNotifier,
 		depositTrie:             depositTrie,
-		chainStartDeposits:      make([]*ethpb.Deposit, 0),
+		chainStartDeposits:      make([]*ethpb.Deposit, 0, params.BeaconConfig().MinGenesisActiveValidatorCount),
 		beaconDB:                config.BeaconDB,
 		depositCache:            config.DepositCache,
 		lastReceivedMerkleIndex: -1,


### PR DESCRIPTION
Resolves #4370.

This was a bug where the chain had not started, but the min genesis deposit threshold had been met while new deposit were sent to the contract. 