### PR TITLE
VerifyIndexedAttestation to verify unique

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"reflect"
 	"sort"
 
 	"github.com/gogo/protobuf/proto"
@@ -702,11 +703,11 @@ func VerifyIndexedAttestation(ctx context.Context, beaconState *pb.BeaconState, 
 		setIndices = append(setIndices, i)
 		set[i] = true
 	}
-	sorted := sort.SliceIsSorted(setIndices, func(i, j int) bool {
+	sort.SliceStable(setIndices, func(i, j int) bool {
 		return setIndices[i] < setIndices[j]
 	})
-	if !sorted {
-		return fmt.Errorf("attesting indices are not sorted, got %v", sorted)
+	if !reflect.DeepEqual(setIndices, indices) {
+		return errors.New("attesting indices is not uniquely sorted")
 	}
 
 	domain := helpers.Domain(beaconState.Fork, indexedAtt.Data.Target.Epoch, params.BeaconConfig().DomainBeaconAttester)

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -1210,7 +1210,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 					Epoch: 1,
 				},
 			},
-			AttestingIndices: []uint64{47, 99, 99},
+			AttestingIndices: []uint64{47, 99, 101},
 		}},
 		{attestation: &ethpb.IndexedAttestation{
 			Data: &ethpb.AttestationData{
@@ -1218,7 +1218,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 					Epoch: 4,
 				},
 			},
-			AttestingIndices: []uint64{21, 72, 21},
+			AttestingIndices: []uint64{21, 72},
 		}},
 		{attestation: &ethpb.IndexedAttestation{
 			Data: &ethpb.AttestationData{
@@ -1226,7 +1226,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 					Epoch: 7,
 				},
 			},
-			AttestingIndices: []uint64{100, 121, 100, 121},
+			AttestingIndices: []uint64{100, 121, 122},
 		}},
 	}
 


### PR DESCRIPTION
[is_valid_indexed_attestation](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#is_valid_indexed_attestation) should verify if a list of attesting indices are unique and sorted. We only verify that it's sorted. This PR added in the verification of unique 