### PR TITLE
Update committee cache prev epoch

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -138,7 +138,7 @@ func (s *Store) OnBlock(ctx context.Context, b *ethpb.BeaconBlock) error {
 
 		// Update committees cache at epoch boundary slot.
 		if featureconfig.Get().EnableNewCache {
-			if err := helpers.UpdateCommitteeCache(postState, postState.Slot); err != nil {
+			if err := helpers.UpdateCommitteeCache(postState, helpers.CurrentEpoch(postState)); err != nil {
 				return err
 			}
 		}

--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -138,7 +138,7 @@ func (s *Store) OnBlock(ctx context.Context, b *ethpb.BeaconBlock) error {
 
 		// Update committees cache at epoch boundary slot.
 		if featureconfig.Get().EnableNewCache {
-			if err := helpers.UpdateCommitteeCache(postState); err != nil {
+			if err := helpers.UpdateCommitteeCache(postState, postState.Slot); err != nil {
 				return err
 			}
 		}

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -205,7 +205,7 @@ func (s *Service) initializeBeaconChain(
 
 	// Update committee shuffled indices for genesis epoch.
 	if featureconfig.Get().EnableNewCache {
-		if err := helpers.UpdateCommitteeCache(genesisState); err != nil {
+		if err := helpers.UpdateCommitteeCache(genesisState, 0 /* genesis epoch */); err != nil {
 			return err
 		}
 	}

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -407,9 +407,8 @@ func ShuffledIndices(state *pb.BeaconState, epoch uint64) ([]uint64, error) {
 
 // UpdateCommitteeCache gets called at the beginning of every epoch to cache the committee shuffled indices
 // list with committee index and epoch number. It caches the shuffled indices for current epoch and next epoch.
-func UpdateCommitteeCache(state *pb.BeaconState) error {
-	currentEpoch := CurrentEpoch(state)
-	for _, epoch := range []uint64{currentEpoch, currentEpoch + 1} {
+func UpdateCommitteeCache(state *pb.BeaconState, epoch uint64) error {
+	for _, epoch := range []uint64{epoch, epoch + 1} {
 		shuffledIndices, err := ShuffledIndices(state, epoch)
 		if err != nil {
 			return err

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -639,7 +639,7 @@ func TestUpdateCommitteeCache_CanUpdate(t *testing.T) {
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	}
 
-	if err := UpdateCommitteeCache(state, state.Slot); err != nil {
+	if err := UpdateCommitteeCache(state, CurrentEpoch(state)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -79,7 +79,7 @@ func ActiveValidatorIndices(state *pb.BeaconState, epoch uint64) ([]uint64, erro
 	}
 
 	if featureconfig.Get().EnableNewCache {
-		if err := UpdateCommitteeCache(state); err != nil {
+		if err := UpdateCommitteeCache(state, epoch); err != nil {
 			return nil, errors.Wrap(err, "could not update committee cache")
 		}
 	}

--- a/beacon-chain/core/state/benchmarks/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks/benchmarks_test.go
@@ -79,7 +79,7 @@ func BenchmarkExecuteStateTransition_WithCache(b *testing.B) {
 	// some attestations in block are from previous epoch
 	currentSlot := beaconState.Slot
 	beaconState.Slot -= params.BeaconConfig().SlotsPerEpoch
-	if err := helpers.UpdateCommitteeCache(beaconState); err != nil {
+	if err := helpers.UpdateCommitteeCache(beaconState, beaconState.Slot); err != nil {
 		b.Fatal(err)
 	}
 	beaconState.Slot = currentSlot
@@ -115,7 +115,7 @@ func BenchmarkProcessEpoch_2FullEpochs(b *testing.B) {
 	// some attestations in block are from previous epoch
 	currentSlot := beaconState.Slot
 	beaconState.Slot -= params.BeaconConfig().SlotsPerEpoch
-	if err := helpers.UpdateCommitteeCache(beaconState); err != nil {
+	if err := helpers.UpdateCommitteeCache(beaconState, beaconState.Slot); err != nil {
 		b.Fatal(err)
 	}
 	beaconState.Slot = currentSlot

--- a/beacon-chain/core/state/benchmarks/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks/benchmarks_test.go
@@ -79,7 +79,7 @@ func BenchmarkExecuteStateTransition_WithCache(b *testing.B) {
 	// some attestations in block are from previous epoch
 	currentSlot := beaconState.Slot
 	beaconState.Slot -= params.BeaconConfig().SlotsPerEpoch
-	if err := helpers.UpdateCommitteeCache(beaconState, beaconState.Slot); err != nil {
+	if err := helpers.UpdateCommitteeCache(beaconState, helpers.CurrentEpoch(beaconState)); err != nil {
 		b.Fatal(err)
 	}
 	beaconState.Slot = currentSlot
@@ -115,7 +115,7 @@ func BenchmarkProcessEpoch_2FullEpochs(b *testing.B) {
 	// some attestations in block are from previous epoch
 	currentSlot := beaconState.Slot
 	beaconState.Slot -= params.BeaconConfig().SlotsPerEpoch
-	if err := helpers.UpdateCommitteeCache(beaconState, beaconState.Slot); err != nil {
+	if err := helpers.UpdateCommitteeCache(beaconState, helpers.CurrentEpoch(beaconState)); err != nil {
 		b.Fatal(err)
 	}
 	beaconState.Slot = currentSlot

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -360,7 +360,7 @@ func TestWaitActivation_NotAllValidatorsActivatedOK(t *testing.T) {
 		keys:            keyMapThreeValidators,
 		validatorClient: client,
 		pubkeys:         publicKeys(keyMapThreeValidators),
-		genesisTime: 1,
+		genesisTime:     1,
 	}
 	resp := generateMockStatusResponse(v.pubkeys)
 	resp.Statuses[0].Status.Status = pb.ValidatorStatus_ACTIVE


### PR DESCRIPTION
This covers an edge case when process attestations during epoch transition, the attestations can come from previous epoch. But committee cache update uses current epoch in state and + 1. Such behavior will always trigger a cache miss and excessive cache update when process previous epoch attestations. Hence the following flame

![image](https://user-images.githubusercontent.com/21316537/71754098-b0a77700-2e39-11ea-897d-63b2d3621efd.png)
