### PR TITLE
Validator caches index

### DIFF
--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -101,6 +101,7 @@ func (v *ValidatorService) Start() {
 		logValidatorBalances: v.logValidatorBalances,
 		prevBalance:          make(map[[48]byte]uint64),
 		attLogs:              make(map[[32]byte]*attSubmitted),
+		pubKeyToID:           make(map[[48]byte]uint64),
 	}
 	go run(v.ctx, v.validator)
 }

--- a/validator/client/validator_aggregate.go
+++ b/validator/client/validator_aggregate.go
@@ -97,12 +97,14 @@ func (v *validator) waitToSlotTwoThirds(ctx context.Context, slot uint64) {
 func (v *validator) addIndicesToLog(ctx context.Context, committeeIndex uint64, pubKey [48]byte) error {
 	v.attLogsLock.Lock()
 	defer v.attLogsLock.Unlock()
-	v.pubKeyToIDLock.Lock()
-	defer v.pubKeyToIDLock.Unlock()
+	v.pubKeyToIDLock.RLock()
+	defer v.pubKeyToIDLock.RUnlock()
 
 	for _, log := range v.attLogs {
 		if committeeIndex == log.data.CommitteeIndex {
-			log.aggregatorIndices = append(log.aggregatorIndices, v.pubKeyToID[pubKey])
+			if _, ok := v.pubKeyToID[pubKey]; ok {
+				log.aggregatorIndices = append(log.aggregatorIndices, v.pubKeyToID[pubKey])
+			}
 		}
 	}
 

--- a/validator/client/validator_aggregate.go
+++ b/validator/client/validator_aggregate.go
@@ -52,7 +52,7 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot uint64, pu
 		return
 	}
 
-	if err := v.addIndicesToLog(ctx, assignment.CommitteeIndex, pubKey[:]); err != nil {
+	if err := v.addIndicesToLog(ctx, assignment.CommitteeIndex, pubKey); err != nil {
 		log.Errorf("Could not add aggregator indices to logs: %v", err)
 		return
 	}
@@ -94,17 +94,15 @@ func (v *validator) waitToSlotTwoThirds(ctx context.Context, slot uint64) {
 	time.Sleep(roughtime.Until(finalTime))
 }
 
-func (v *validator) addIndicesToLog(ctx context.Context, committeeIndex uint64, pubKey []byte) error {
+func (v *validator) addIndicesToLog(ctx context.Context, committeeIndex uint64, pubKey [48]byte) error {
 	v.attLogsLock.Lock()
 	defer v.attLogsLock.Unlock()
-	res, err := v.validatorClient.ValidatorIndex(ctx, &pb.ValidatorIndexRequest{PublicKey: pubKey})
-	if err != nil {
-		return err
-	}
+	v.pubKeyToIDLock.Lock()
+	defer v.pubKeyToIDLock.Unlock()
 
 	for _, log := range v.attLogs {
 		if committeeIndex == log.data.CommitteeIndex {
-			log.aggregatorIndices = append(log.aggregatorIndices, res.Index)
+			log.aggregatorIndices = append(log.aggregatorIndices, v.pubKeyToID[pubKey])
 		}
 	}
 

--- a/validator/client/validator_aggregate_test.go
+++ b/validator/client/validator_aggregate_test.go
@@ -42,13 +42,6 @@ func TestSubmitAggregateAndProof_Ok(t *testing.T) {
 		gomock.AssignableToTypeOf(&pb.AggregationRequest{}),
 	).Return(&pb.AggregationResponse{}, nil)
 
-	m.validatorClient.EXPECT().ValidatorIndex(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&pb.ValidatorIndexRequest{}),
-	).Return(&pb.ValidatorIndexResponse{
-		Index: 0,
-	}, nil)
-
 	validator.SubmitAggregateAndProof(context.Background(), 0, validatorPubKey)
 }
 

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -130,8 +130,8 @@ func (v *validator) assignment(pubKey [48]byte) (*pb.AssignmentResponse_Validato
 // This returns the index of validator's position in a committee. It's used to construct aggregation and
 // custody bit fields.
 func (v *validator) indexInCommittee(pubKey [48]byte, assignment *pb.AssignmentResponse_ValidatorAssignment) (uint64, uint64, error) {
-	v.pubKeyToIDLock.Lock()
-	defer v.pubKeyToIDLock.Unlock()
+	v.pubKeyToIDLock.RLock()
+	defer v.pubKeyToIDLock.RUnlock()
 
 	index := v.pubKeyToID[pubKey]
 	for i, validatorIndex := range assignment.Committee {

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -36,7 +36,7 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		return
 	}
 
-	indexInCommittee, validatorIndex, err := v.indexInCommittee(ctx, pubKey, assignment)
+	indexInCommittee, validatorIndex, err := v.indexInCommittee(pubKey, assignment)
 	if err != nil {
 		log.Errorf("Could not get validator index in assignment: %v", err)
 		return
@@ -129,22 +129,18 @@ func (v *validator) assignment(pubKey [48]byte) (*pb.AssignmentResponse_Validato
 
 // This returns the index of validator's position in a committee. It's used to construct aggregation and
 // custody bit fields.
-func (v *validator) indexInCommittee(
-	ctx context.Context,
-	pubKey [48]byte,
-	assignment *pb.AssignmentResponse_ValidatorAssignment) (uint64, uint64, error) {
-	res, err := v.validatorClient.ValidatorIndex(ctx, &pb.ValidatorIndexRequest{PublicKey: pubKey[:]})
-	if err != nil {
-		return 0, 0, err
-	}
+func (v *validator) indexInCommittee(pubKey [48]byte, assignment *pb.AssignmentResponse_ValidatorAssignment) (uint64, uint64, error) {
+	v.pubKeyToIDLock.Lock()
+	defer v.pubKeyToIDLock.Unlock()
 
+	index := v.pubKeyToID[pubKey]
 	for i, validatorIndex := range assignment.Committee {
-		if validatorIndex == res.Index {
-			return uint64(i), res.Index, nil
+		if validatorIndex == index {
+			return uint64(i), index, nil
 		}
 	}
 
-	return 0, 0, fmt.Errorf("index %d not in committee", res.Index)
+	return 0, 0, fmt.Errorf("index %d not in committee", index)
 }
 
 // Given validator's public key, this returns the signature of an attestation data.

--- a/validator/client/validator_propose.go
+++ b/validator/client/validator_propose.go
@@ -72,12 +72,8 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 		trace.Int64Attribute("numAttestations", int64(len(b.Body.Attestations))),
 	)
 
-	res, err := v.validatorClient.ValidatorIndex(ctx, &pb.ValidatorIndexRequest{PublicKey: pubKey[:]})
-	if err != nil {
-		log.WithError(err).Error("Failed to get validator index")
-		return
-	}
-
+	v.pubKeyToIDLock.Lock()
+	defer v.pubKeyToIDLock.Unlock()
 	log.WithField("signature", fmt.Sprintf("%#x", b.Signature)).Debug("block signature")
 	blkRoot := fmt.Sprintf("%#x", bytesutil.Trunc(blkResp.BlockRoot))
 	log.WithFields(logrus.Fields{
@@ -85,7 +81,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 		"blockRoot":       blkRoot,
 		"numAttestations": len(b.Body.Attestations),
 		"numDeposits":     len(b.Body.Deposits),
-		"proposerIndex":   res.Index,
+		"proposerIndex":   v.pubKeyToID[pubKey],
 	}).Info("Submitted new block")
 }
 

--- a/validator/client/validator_propose.go
+++ b/validator/client/validator_propose.go
@@ -72,8 +72,8 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 		trace.Int64Attribute("numAttestations", int64(len(b.Body.Attestations))),
 	)
 
-	v.pubKeyToIDLock.Lock()
-	defer v.pubKeyToIDLock.Unlock()
+	v.pubKeyToIDLock.RLock()
+	defer v.pubKeyToIDLock.RUnlock()
 	log.WithField("signature", fmt.Sprintf("%#x", b.Signature)).Debug("block signature")
 	blkRoot := fmt.Sprintf("%#x", bytesutil.Trunc(blkResp.BlockRoot))
 	log.WithFields(logrus.Fields{

--- a/validator/client/validator_propose_test.go
+++ b/validator/client/validator_propose_test.go
@@ -136,11 +136,6 @@ func TestProposeBlock_BroadcastsBlock(t *testing.T) {
 		gomock.AssignableToTypeOf(&ethpb.BeaconBlock{}),
 	).Return(&pb.ProposeResponse{}, nil /*error*/)
 
-	m.validatorClient.EXPECT().ValidatorIndex(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&pb.ValidatorIndexRequest{}),
-	).Return(&pb.ValidatorIndexResponse{}, nil)
-
 	validator.ProposeBlock(context.Background(), 1, validatorPubKey)
 }
 
@@ -174,11 +169,6 @@ func TestProposeBlock_BroadcastsBlock_WithGraffiti(t *testing.T) {
 		sentBlock = block
 		return &pb.ProposeResponse{}, nil
 	})
-
-	m.validatorClient.EXPECT().ValidatorIndex(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&pb.ValidatorIndexRequest{}),
-	).Return(&pb.ValidatorIndexResponse{}, nil)
 
 	validator.ProposeBlock(context.Background(), 1, validatorPubKey)
 

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -525,13 +525,14 @@ func TestUpdateAssignments_OK(t *testing.T) {
 	v := validator{
 		keyManager:      testKeyManager,
 		validatorClient: client,
+		pubKeyToID:      make(map[[48]byte]uint64),
 	}
 	client.EXPECT().CommitteeAssignment(
 		gomock.Any(),
 		gomock.Any(),
 	).Return(resp, nil)
 
-	indexResp := &pb.ValidatorIndexResponse{}
+	indexResp := &pb.ValidatorIndexResponse{Index: 100}
 	client.EXPECT().ValidatorIndex(
 		gomock.Any(),
 		gomock.Any(),


### PR DESCRIPTION
In worst case, a validator requests its index 4 times on per slot basis. From getting assignment to proposing block, to submit unaggregation attestation and finally submit aggregation request.

This PR improves upon that by saving validator index and conveniently updates them during `UpdateAssignments`. This cuts the worst case to 1 time.

Tested run time 👍 