### PR TITLE
Remove process block attestations as separate routine

### DIFF
--- a/beacon-chain/blockchain/forkchoice/BUILD.bazel
+++ b/beacon-chain/blockchain/forkchoice/BUILD.bazel
@@ -60,7 +60,6 @@ go_test(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/featureconfig:go_default_library",
-        "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/beacon-chain/blockchain/forkchoice/BUILD.bazel
+++ b/beacon-chain/blockchain/forkchoice/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/featureconfig:go_default_library",
-        "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/traceutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",

--- a/beacon-chain/blockchain/forkchoice/process_attestation.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation.go
@@ -2,6 +2,7 @@ package forkchoice
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -300,6 +301,7 @@ func (s *Store) setSeenAtt(a *ethpb.Attestation) error {
 	if err != nil {
 		return err
 	}
+	log.Info("Setting seen att ", hex.EncodeToString(r[:5]), a.Data.Slot, a.Data.CommitteeIndex)
 	s.seenAtts[r] = true
 
 	return nil

--- a/beacon-chain/blockchain/forkchoice/process_attestation.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation.go
@@ -2,7 +2,6 @@ package forkchoice
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -131,11 +129,6 @@ func (s *Store) OnAttestation(ctx context.Context, a *ethpb.Attestation) error {
 
 	// Update every validator's latest vote.
 	if err := s.updateAttVotes(ctx, indexedAtt, tgt.Root, tgt.Epoch); err != nil {
-		return err
-	}
-
-	// Mark attestation as seen we don't update votes when it appears in block.
-	if err := s.setSeenAtt(a); err != nil {
 		return err
 	}
 
@@ -289,21 +282,6 @@ func (s *Store) updateAttVotes(
 			}
 		}
 	}
-	return nil
-}
-
-// setSeenAtt sets the attestation hash in seen attestation map to true.
-func (s *Store) setSeenAtt(a *ethpb.Attestation) error {
-	s.seenAttsLock.Lock()
-	defer s.seenAttsLock.Unlock()
-
-	r, err := hashutil.HashProto(a)
-	if err != nil {
-		return err
-	}
-	log.Info("Setting seen att ", hex.EncodeToString(r[:5]), a.Data.Slot, a.Data.CommitteeIndex)
-	s.seenAtts[r] = true
-
 	return nil
 }
 

--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -103,7 +103,6 @@ func (s *Store) OnBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock) er
 	// Update finalized check point.
 	// Prune the block cache and helper caches on every new finalized epoch.
 	if postState.FinalizedCheckpoint.Epoch > s.finalizedCheckpt.Epoch {
-		s.clearSeenAtts()
 		if err := s.db.SaveFinalizedCheckpoint(ctx, postState.FinalizedCheckpoint); err != nil {
 			return errors.Wrap(err, "could not save finalized checkpoint")
 		}
@@ -206,8 +205,6 @@ func (s *Store) OnBlockInitialSyncStateTransition(ctx context.Context, signed *e
 	// Update finalized check point.
 	// Prune the block cache and helper caches on every new finalized epoch.
 	if postState.FinalizedCheckpoint.Epoch > s.finalizedCheckpt.Epoch {
-		s.clearSeenAtts()
-
 		startSlot := helpers.StartSlot(s.prevFinalizedCheckpt.Epoch)
 		endSlot := helpers.StartSlot(s.finalizedCheckpt.Epoch)
 		if endSlot > startSlot {
@@ -363,13 +360,6 @@ func (s *Store) saveNewBlockAttestations(ctx context.Context, atts []*ethpb.Atte
 		return err
 	}
 	return nil
-}
-
-// clearSeenAtts clears seen attestations map, it gets called upon new finalization.
-func (s *Store) clearSeenAtts() {
-	s.seenAttsLock.Lock()
-	s.seenAttsLock.Unlock()
-	s.seenAtts = make(map[[32]byte]bool)
 }
 
 // rmStatesOlderThanLastFinalized deletes the states in db since last finalized check point.

--- a/beacon-chain/blockchain/forkchoice/service.go
+++ b/beacon-chain/blockchain/forkchoice/service.go
@@ -44,8 +44,6 @@ type Store struct {
 	prevFinalizedCheckpt  *ethpb.Checkpoint
 	checkpointState       *cache.CheckpointStateCache
 	checkpointStateLock   sync.Mutex
-	seenAtts              map[[32]byte]bool
-	seenAttsLock          sync.Mutex
 	genesisTime           uint64
 	bestJustifiedCheckpt  *ethpb.Checkpoint
 	latestVoteMap         map[uint64]*pb.ValidatorLatestVote
@@ -65,7 +63,6 @@ func NewForkChoiceService(ctx context.Context, db db.Database) *Store {
 		db:              db,
 		checkpointState: cache.NewCheckpointStateCache(),
 		latestVoteMap:   make(map[uint64]*pb.ValidatorLatestVote),
-		seenAtts:        make(map[[32]byte]bool),
 		initSyncState:   make(map[[32]byte]*pb.BeaconState),
 	}
 }

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -278,9 +278,9 @@ func TestCanonicalHeadSlot_FailedRPC(t *testing.T) {
 	defer ctrl.Finish()
 	client := internal.NewMockBeaconChainClient(ctrl)
 	v := validator{
-		keyManager:      testKeyManager,
+		keyManager:   testKeyManager,
 		beaconClient: client,
-		genesisTime:     1,
+		genesisTime:  1,
 	}
 	client.EXPECT().GetChainHead(
 		gomock.Any(),
@@ -296,7 +296,7 @@ func TestCanonicalHeadSlot_OK(t *testing.T) {
 	defer ctrl.Finish()
 	client := internal.NewMockBeaconChainClient(ctrl)
 	v := validator{
-		keyManager:      testKeyManager,
+		keyManager:   testKeyManager,
 		beaconClient: client,
 	}
 	client.EXPECT().GetChainHead(


### PR DESCRIPTION
With the new attestation pool in v0.9.2. Processing block attestations for fork choice in no lounger needed as a separate routine during process block. This routine was taken care of by the attestation pool to aggregate all the similar data attestations together for fork choice in subsequent slot. See new: https://github.com/prysmaticlabs/prysm/blob/e43fa0168db4b9e6891b933c499967a45aa87e76/beacon-chain/blockchain/receive_block.go#L110

This PR removes the old design to process block attestations as a separate routine, we were double processing block attestations for fork choice in v0.9.2 this whole time! 