### PR TITLE
Release --enable-bls-pubkey-cache

### DIFF
--- a/beacon-chain/core/state/benchmarks/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks/benchmarks_test.go
@@ -60,7 +60,6 @@ func BenchmarkExecuteStateTransition_WithCache(b *testing.B) {
 	config := &featureconfig.Flags{
 		EnableNewCache:           true,
 		EnableShuffledIndexCache: true,
-		EnableBLSPubkeyCache:     true,
 	}
 	featureconfig.Init(config)
 	SetConfig()
@@ -101,7 +100,6 @@ func BenchmarkProcessEpoch_2FullEpochs(b *testing.B) {
 	config := &featureconfig.Flags{
 		EnableNewCache:           true,
 		EnableShuffledIndexCache: true,
-		EnableBLSPubkeyCache:     true,
 	}
 	featureconfig.Init(config)
 	SetConfig()

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -86,7 +86,7 @@ func PublicKeyFromBytes(pub []byte) (*PublicKey, error) {
 		return nil, fmt.Errorf("public key must be %d bytes", params.BeaconConfig().BLSPubkeyLength)
 	}
 	cv, ok := pubkeyCache.Get(string(pub))
-	if ok && featureconfig.Get().EnableBLSPubkeyCache {
+	if ok {
 		return cv.(*PublicKey).Copy()
 	}
 	pubKey := &bls12.PublicKey{}
@@ -99,9 +99,7 @@ func PublicKeyFromBytes(pub []byte) (*PublicKey, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not copy pubkey")
 	}
-	if featureconfig.Get().EnableBLSPubkeyCache {
-		pubkeyCache.Set(string(pub), copiedKey, 48)
-	}
+	pubkeyCache.Set(string(pub), copiedKey, 48)
 	return pubkeyObj, nil
 }
 

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -42,7 +42,6 @@ type Flags struct {
 	EnableAttestationCache   bool // EnableAttestationCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
 	EnableEth1DataVoteCache  bool // EnableEth1DataVoteCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
 	EnableNewCache           bool // EnableNewCache enables the node to use the new caching scheme.
-	EnableBLSPubkeyCache     bool // EnableBLSPubkeyCache to improve wall time of PubkeyFromBytes.
 	EnableShuffledIndexCache bool // EnableShuffledIndexCache to cache expensive shuffled index computation.
 	EnableSkipSlotsCache     bool // EnableSkipSlotsCache caches the state in skipped slots.
 }
@@ -108,10 +107,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.GlobalBool(enableBackupWebhookFlag.Name) {
 		log.Warn("Allowing database backups to be triggered from HTTP webhook.")
 		cfg.EnableBackupWebhook = true
-	}
-	if ctx.GlobalBool(enableBLSPubkeyCacheFlag.Name) {
-		log.Warn("Enabled BLS pubkey cache.")
-		cfg.EnableBLSPubkeyCache = true
 	}
 	if ctx.GlobalBool(enableShuffledIndexCache.Name) {
 		log.Warn("Enabled shuffled index cache.")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -52,10 +52,6 @@ var (
 		Name:  "enable-db-backup-webhook",
 		Usage: "Serve HTTP handler to initiate database backups. The handler is served on the monitoring port at path /db/backup.",
 	}
-	enableBLSPubkeyCacheFlag = cli.BoolFlag{
-		Name:  "enable-bls-pubkey-cache",
-		Usage: "Enable BLS pubkey cache to improve wall time of PubkeyFromBytes",
-	}
 	// enableSkipSlotsCache enables the skips slots lru cache to be used in runtime.
 	enableSkipSlotsCache = cli.BoolFlag{
 		Name:  "enable-skip-slots-cache",
@@ -140,6 +136,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableBLSPubkeyCacheFlag = cli.BoolFlag{
+		Name:   "enable-bls-pubkey-cache",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -152,6 +153,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedEnableActiveIndicesCacheFlag,
 	deprecatedEnableActiveCountCacheFlag,
 	deprecatedEnableCommitteeCacheFlag,
+	deprecatedEnableBLSPubkeyCacheFlag,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -173,7 +175,6 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	SkipBLSVerifyFlag,
 	kafkaBootstrapServersFlag,
 	enableBackupWebhookFlag,
-	enableBLSPubkeyCacheFlag,
 	enableShuffledIndexCache,
 	enableSkipSlotsCache,
 	enableSnappyDBCompressionFlag,


### PR DESCRIPTION
This feature has been running in prod since the beginning of the current testnet. 
It saves significant time on deserializing BLS pubkeys from bytes. 
Since the set of pubkeys rarely changes (except on new deposits / activations), this cache has a very high hit ratio.