### PR TITLE
Fix proposal bug

### DIFF
--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -195,7 +195,7 @@ func (vs *Server) randomETH1DataVote(ctx context.Context) (*ethpb.Eth1Data, erro
 // computeStateRoot computes the state root after a block has been processed through a state transition and
 // returns it to the validator client.
 func (vs *Server) computeStateRoot(ctx context.Context, block *ethpb.SignedBeaconBlock) ([]byte, error) {
-	beaconState, err := vs.BeaconDB.HeadState(ctx)
+	beaconState, err := vs.BeaconDB.State(ctx, bytesutil.ToBytes32(block.Block.ParentRoot))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not retrieve beacon state")
 	}

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -51,9 +51,6 @@ func TestProposeBlock_OK(t *testing.T) {
 	if err := db.SaveState(ctx, beaconState, genesisRoot); err != nil {
 		t.Fatalf("Could not save genesis state: %v", err)
 	}
-	if err := db.SaveHeadBlockRoot(ctx, genesisRoot); err != nil {
-		t.Fatalf("Could not save genesis state: %v", err)
-	}
 
 	proposerServer := &Server{
 		BeaconDB:          db,


### PR DESCRIPTION
When receiving a block proposal, the beacon node was assuming this was built off of the "head state" as indicated by the beacon DB. 

However, this may not always be the case and is not the correct way to compute the state root of a block in RPC.

Edit: the error was 
```
rpc error: code = Internal desc = Could not compute state root: could not calculate state root at slot 6656: could not process block: could not process block header: parent root 0x06afbf5025c87236b3773fd12621c6cda392081e226947e60826f00b09c7428a does not match the latest block header signing root in state 0xf8b1ccfec3a0d3098b5f35e303bfdc41575b3269a65c203c63b4198a1717d5b1
```