### PR TITLE
Require a state to exist to save justified checkpoint

### DIFF
--- a/beacon-chain/db/kv/checkpoint_test.go
+++ b/beacon-chain/db/kv/checkpoint_test.go
@@ -15,9 +15,14 @@ func TestStore_JustifiedCheckpoint_CanSaveRetrieve(t *testing.T) {
 	db := setupDB(t)
 	defer teardownDB(t, db)
 	ctx := context.Background()
+	root := bytesutil.ToBytes32([]byte{'A'})
 	cp := &ethpb.Checkpoint{
 		Epoch: 10,
-		Root:  []byte{'A'},
+		Root:  root[:],
+	}
+
+	if err := db.SaveState(ctx, &pb.BeaconState{Slot:1}, root); err != nil {
+		t.Fatal(err)
 	}
 
 	if err := db.SaveJustifiedCheckpoint(ctx, cp); err != nil {
@@ -130,7 +135,7 @@ func TestStore_FinalizedCheckpoint_StateMustExist(t *testing.T) {
 		Root:  []byte{'B'},
 	}
 
-	if err := db.SaveFinalizedCheckpoint(ctx, cp); err != errMissingStateForFinalizedCheckpoint {
-		t.Fatalf("wanted err %v, got %v", errMissingStateForFinalizedCheckpoint, err)
+	if err := db.SaveFinalizedCheckpoint(ctx, cp); err != errMissingStateForCheckpoint {
+		t.Fatalf("wanted err %v, got %v", errMissingStateForCheckpoint, err)
 	}
 }

--- a/beacon-chain/db/kv/checkpoint_test.go
+++ b/beacon-chain/db/kv/checkpoint_test.go
@@ -21,7 +21,7 @@ func TestStore_JustifiedCheckpoint_CanSaveRetrieve(t *testing.T) {
 		Root:  root[:],
 	}
 
-	if err := db.SaveState(ctx, &pb.BeaconState{Slot:1}, root); err != nil {
+	if err := db.SaveState(ctx, &pb.BeaconState{Slot: 1}, root); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
To prevent a scenario where we are missing the justified state in the database. 