### PR TITLE
Log warn and cont if validator pub key not exist in DB

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -261,7 +261,8 @@ func (v *validator) UpdateAssignments(ctx context.Context, slot uint64) error {
 				// TODO(4379): Make validator index part of the assignment respond.
 				res, err := v.validatorClient.ValidatorIndex(ctx, &pb.ValidatorIndexRequest{PublicKey: assignment.PublicKey})
 				if err != nil {
-					return err
+					log.Warn("Validator pub key %#x does not exist in beacon node", bytesutil.Trunc(duty.PublicKey))
+					continue
 				}
 				v.pubKeyToID[bytesutil.ToBytes48(assignment.PublicKey)] = res.Index
 			}

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -261,7 +261,7 @@ func (v *validator) UpdateAssignments(ctx context.Context, slot uint64) error {
 				// TODO(4379): Make validator index part of the assignment respond.
 				res, err := v.validatorClient.ValidatorIndex(ctx, &pb.ValidatorIndexRequest{PublicKey: assignment.PublicKey})
 				if err != nil {
-					log.Warn("Validator pub key %#x does not exist in beacon node", bytesutil.Trunc(duty.PublicKey))
+					log.Warn("Validator pub key %#x does not exist in beacon node", bytesutil.Trunc(assignment.PublicKey))
 					continue
 				}
 				v.pubKeyToID[bytesutil.ToBytes48(assignment.PublicKey)] = res.Index

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -261,7 +261,7 @@ func (v *validator) UpdateAssignments(ctx context.Context, slot uint64) error {
 				// TODO(4379): Make validator index part of the assignment respond.
 				res, err := v.validatorClient.ValidatorIndex(ctx, &pb.ValidatorIndexRequest{PublicKey: assignment.PublicKey})
 				if err != nil {
-					log.Warn("Validator pub key %#x does not exist in beacon node", bytesutil.Trunc(assignment.PublicKey))
+					log.Warnf("Validator pub key %#x does not exist in beacon node", bytesutil.Trunc(assignment.PublicKey))
 					continue
 				}
 				v.pubKeyToID[bytesutil.ToBytes48(assignment.PublicKey)] = res.Index


### PR DESCRIPTION
Instead of failing the assignment for every validators in the same request, this changes the behavior to log warn and continue if a single validator's public key not in beacon node's db