### PR TITLE
E2E cleanup and fix ETH1 chain startup

### DIFF
--- a/endtoend/beacon_node.go
+++ b/endtoend/beacon_node.go
@@ -65,6 +65,10 @@ func startNewBeaconNode(t *testing.T, config *end2EndConfig, beaconNodes []*beac
 
 	args := []string{
 		"--no-discovery",
+		"--new-cache",
+		"--enable-shuffled-index-cache",
+		"--enable-skip-slots-cache",
+		"--enable-attestation-cache",
 		"--http-web3provider=http://127.0.0.1:8545",
 		"--web3provider=ws://127.0.0.1:8546",
 		fmt.Sprintf("--datadir=%s/eth2-beacon-node-%d", tmpPath, index),
@@ -100,7 +104,7 @@ func startNewBeaconNode(t *testing.T, config *end2EndConfig, beaconNodes []*beac
 
 	multiAddr, err := getMultiAddrFromLogFile(file.Name())
 	if err != nil {
-		t.Fatalf("could not get multiaddr fpr node %d: %v", index, err)
+		t.Fatalf("could not get multiaddr for node %d: %v", index, err)
 	}
 
 	return &beaconNodeInfo{
@@ -135,9 +139,9 @@ func getMultiAddrFromLogFile(name string) (string, error) {
 
 func waitForTextInFile(file *os.File, text string) error {
 	wait := 0
-	// Putting the wait cap at 24 seconds.
-	totalWait := 24
-	for wait < totalWait {
+	// Putting the wait cap at 36 seconds.
+	maxWait := 36
+	for wait < maxWait {
 		time.Sleep(2 * time.Second)
 		// Rewind the file pointer to the start of the file so we can read it again.
 		_, err := file.Seek(0, io.SeekStart)
@@ -160,5 +164,5 @@ func waitForTextInFile(file *os.File, text string) error {
 	if err != nil {
 		return err
 	}
-	return fmt.Errorf("could not find requested text %s in logs:\n%s", text, string(contents))
+	return fmt.Errorf("could not find requested text \"%s\" in logs:\n%s", text, string(contents))
 }

--- a/endtoend/validator.go
+++ b/endtoend/validator.go
@@ -2,6 +2,7 @@ package endtoend
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math/big"

--- a/endtoend/validator.go
+++ b/endtoend/validator.go
@@ -31,7 +31,6 @@ func initializeValidators(
 	t *testing.T,
 	config *end2EndConfig,
 	keystorePath string,
-	beaconNodes []*beaconNodeInfo,
 ) []*validatorClientInfo {
 	binaryPath, found := bazel.FindBinary("validator", "validator")
 	if !found {
@@ -88,6 +87,11 @@ func initializeValidators(
 	depositInGwei := big.NewInt(int64(params.BeaconConfig().MaxEffectiveBalance))
 	txOps.Value = depositInGwei.Mul(depositInGwei, big.NewInt(int64(params.BeaconConfig().GweiPerEth)))
 	txOps.GasLimit = 4000000
+	nonce, err := web3.PendingNonceAt(context.Background(), txOps.From)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txOps.Nonce = big.NewInt(int64(nonce))
 
 	contract, err := contracts.NewDepositContract(config.contractAddr, web3)
 	if err != nil {
@@ -102,16 +106,17 @@ func initializeValidators(
 	for index, dd := range deposits {
 		_, err = contract.Deposit(txOps, dd.Data.PublicKey, dd.Data.WithdrawalCredentials, dd.Data.Signature, roots[index])
 		if err != nil {
-			t.Error("unable to send transaction to contract")
+			t.Errorf("unable to send transaction to contract: %v", err)
 		}
+		txOps.Nonce = txOps.Nonce.Add(txOps.Nonce, big.NewInt(1))
 	}
 
 	keystore, err := keystore.DecryptKey(jsonBytes, "" /*password*/)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Picked 20 for this as a "safe" number of blocks to mine so the deposits
-	// are detected.
+
+	// "Safe" amount of blocks to mine to make sure the deposits are seen.
 	if err := mineBlocks(web3, keystore, 20); err != nil {
 		t.Fatalf("failed to mine blocks %v", err)
 	}


### PR DESCRIPTION
Resolves #4378

This increases the totalWait for reading the logs from 24 seconds to 36, to make sure the ETH1 chain has time to start.
Also adds several checks if `t.Failed()` to make sure the tests stop running after a failure.