### PR TITLE
Update initial sync save justification to align with v0.9.3

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -195,10 +195,9 @@ func (s *Store) OnBlockInitialSyncStateTransition(ctx context.Context, signed *e
 	}
 
 	// Update justified check point.
-	if postState.CurrentJustifiedCheckpoint.Epoch > s.JustifiedCheckpt().Epoch {
-		s.justifiedCheckpt = postState.CurrentJustifiedCheckpoint
-		if err := s.db.SaveJustifiedCheckpoint(ctx, postState.CurrentJustifiedCheckpoint); err != nil {
-			return errors.Wrap(err, "could not save justified checkpoint")
+	if postState.CurrentJustifiedCheckpoint.Epoch > s.justifiedCheckpt.Epoch {
+		if err := s.updateJustified(ctx, postState); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
At v0.9.3, bunch of fixes for fork choice went in to treat justification updates. In block processing, there's 2 code paths for processing block. One for normal and one for initial sync case. The normal code path has the v0.9.3 fork choice justification fixes. See:
https://github.com/prysmaticlabs/prysm/blob/v0.9.2/beacon-chain/blockchain/forkchoice/process_block.go#L98

But the initial sync does not have it, and it still updates justified check point using the old method. This PR fixes initial sync update justification to align with normal block processing code