### PR TITLE
Fix Flakey Slot Ticker Test

### DIFF
--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/slotutil:go_default_library",
         "//shared/traceutil:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_middleware//:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_middleware//recovery:go_default_library",

--- a/beacon-chain/rpc/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/beacon/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
         "//beacon-chain/rpc/testing:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/slotutil/testing:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",

--- a/beacon-chain/rpc/beacon/attestations.go
+++ b/beacon-chain/rpc/beacon/attestations.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
 	"github.com/prysmaticlabs/prysm/shared/pagination"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"github.com/prysmaticlabs/prysm/shared/slotutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -120,11 +119,9 @@ func (bs *Server) ListAttestations(
 func (bs *Server) StreamAttestations(
 	_ *ptypes.Empty, stream ethpb.BeaconChain_StreamAttestationsServer,
 ) error {
-	genesisTime := bs.GenesisTimeFetcher.GenesisTime()
-	st := slotutil.GetSlotTicker(genesisTime, params.BeaconConfig().SecondsPerSlot)
 	for {
 		select {
-		case <-st.C():
+		case <-bs.SlotTicker.C():
 			atts := bs.Pool.AggregatedAttestations()
 			for i := 0; i < len(atts); i++ {
 				if err := stream.Send(atts[i]); err != nil {

--- a/beacon-chain/rpc/beacon/server.go
+++ b/beacon-chain/rpc/beacon/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	"github.com/prysmaticlabs/prysm/beacon-chain/powchain"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/slotutil"
 )
 
 // Server defines a server implementation of the gRPC Beacon Chain service,
@@ -27,5 +28,5 @@ type Server struct {
 	IncomingAttestation chan *ethpb.Attestation
 	CanonicalStateChan  chan *pbp2p.BeaconState
 	ChainStartChan      chan time.Time
-	GenesisTimeFetcher  blockchain.GenesisTimeFetcher
+	SlotTicker          slotutil.Ticker
 }

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"testing"
+	"time"
 
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	mockPOW "github.com/prysmaticlabs/prysm/beacon-chain/powchain/testing"
@@ -22,7 +23,9 @@ func init() {
 
 func TestLifecycle_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
-	chainService := &mock.ChainService{}
+	chainService := &mock.ChainService{
+		Genesis: time.Now(),
+	}
 	rpcService := NewService(context.Background(), &Config{
 		Port:                "7348",
 		CertFlag:            "alice.crt",
@@ -31,6 +34,7 @@ func TestLifecycle_OK(t *testing.T) {
 		BlockReceiver:       chainService,
 		AttestationReceiver: chainService,
 		HeadFetcher:         chainService,
+		GenesisTimeFetcher:  chainService,
 		POWChainService:     &mockPOW.POWChain{},
 		StateNotifier:       chainService.StateNotifier(),
 	})

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -58,11 +58,12 @@ func TestStatus_CredentialError(t *testing.T) {
 
 func TestRPC_InsecureEndpoint(t *testing.T) {
 	hook := logTest.NewGlobal()
-	chainService := &mock.ChainService{}
+	chainService := &mock.ChainService{Genesis: time.Now()}
 	rpcService := NewService(context.Background(), &Config{
 		Port:                "7777",
 		SyncService:         &mockSync.Sync{IsSyncing: false},
 		BlockReceiver:       chainService,
+		GenesisTimeFetcher:  chainService,
 		AttestationReceiver: chainService,
 		HeadFetcher:         chainService,
 		POWChainService:     &mockPOW.POWChain{},

--- a/beacon-chain/rpc/validator/assignments.go
+++ b/beacon-chain/rpc/validator/assignments.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// CommitteeAssignment returns the committee assignment response from a given validator public key.
+// GetDuties returns the committee assignment response from a given validator public key.
 // The committee assignment response contains the following fields for the current and previous epoch:
 //	1.) The list of validators in the committee.
 //	2.) The shard to which the committee is assigned.

--- a/beacon-chain/rpc/validator/exit.go
+++ b/beacon-chain/rpc/validator/exit.go
@@ -20,7 +20,7 @@ func (vs *Server) ProposeExit(ctx context.Context, req *ethpb.SignedVoluntaryExi
 	}
 
 	// Confirm the validator is eligible to exit with the parameters provided
-	err = exit.ValidateVoluntaryExit(s, vs.GenesisTimeFetcher.GenesisTime(), req)
+	err = exit.ValidateVoluntaryExit(s, vs.GenesisTime, req)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/beacon-chain/rpc/validator/exit_test.go
+++ b/beacon-chain/rpc/validator/exit_test.go
@@ -41,12 +41,12 @@ func TestSub(t *testing.T) {
 	genesisTime := time.Now().Add(time.Duration(-100*int64(params.BeaconConfig().SecondsPerSlot*params.BeaconConfig().SlotsPerEpoch)) * time.Second)
 	mockChainService := &mockChain.ChainService{State: beaconState, Root: genesisRoot[:], Genesis: genesisTime}
 	server := &Server{
-		BeaconDB:           db,
-		HeadFetcher:        mockChainService,
-		SyncChecker:        &mockSync.Sync{IsSyncing: false},
-		GenesisTimeFetcher: mockChainService,
-		StateNotifier:      mockChainService.StateNotifier(),
-		OperationNotifier:  mockChainService.OperationNotifier(),
+		BeaconDB:          db,
+		HeadFetcher:       mockChainService,
+		SyncChecker:       &mockSync.Sync{IsSyncing: false},
+		GenesisTime:       genesisTime,
+		StateNotifier:     mockChainService.StateNotifier(),
+		OperationNotifier: mockChainService.OperationNotifier(),
 	}
 
 	// Subscribe to operation notifications

--- a/beacon-chain/rpc/validator/server.go
+++ b/beacon-chain/rpc/validator/server.go
@@ -56,7 +56,7 @@ type Server struct {
 	Eth1BlockFetcher       powchain.POWBlockFetcher
 	PendingDepositsFetcher depositcache.PendingDepositsFetcher
 	OperationNotifier      opfeed.Notifier
-	GenesisTimeFetcher     blockchain.GenesisTimeFetcher
+	GenesisTime            time.Time
 }
 
 // WaitForActivation checks if a validator public key exists in the active validator registry of the current

--- a/shared/slotutil/slotticker.go
+++ b/shared/slotutil/slotticker.go
@@ -6,6 +6,13 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/roughtime"
 )
 
+// The Ticker interface defines a type which can expose a
+// receive-only channel firing slot events.
+type Ticker interface {
+	C() <-chan uint64
+	Done()
+}
+
 // SlotTicker is a special ticker for the beacon chain block.
 // The channel emits over the slot interval, and ensures that
 // the ticks are in line with the genesis time. This means that

--- a/shared/slotutil/slotticker_test.go
+++ b/shared/slotutil/slotticker_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+var _ = Ticker(&SlotTicker{})
+
 func TestSlotTicker(t *testing.T) {
 	ticker := &SlotTicker{
 		c:    make(chan uint64),

--- a/shared/slotutil/testing/BUILD.bazel
+++ b/shared/slotutil/testing/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mock.go"],
+    importpath = "github.com/prysmaticlabs/prysm/shared/slotutil/testing",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["mock_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//shared/slotutil:go_default_library"],
+)

--- a/shared/slotutil/testing/mock.go
+++ b/shared/slotutil/testing/mock.go
@@ -1,0 +1,17 @@
+package testing
+
+// MockTicker defines a useful struct for mocking the Ticker interface
+// from the slotutil package.
+type MockTicker struct {
+	Channel chan uint64
+}
+
+// C --
+func (m *MockTicker) C() <-chan uint64 {
+	return m.Channel
+}
+
+// Done --
+func (m *MockTicker) Done() {
+	return
+}

--- a/shared/slotutil/testing/mock_test.go
+++ b/shared/slotutil/testing/mock_test.go
@@ -1,0 +1,5 @@
+package testing
+
+import "github.com/prysmaticlabs/prysm/shared/slotutil"
+
+var _ = slotutil.Ticker(&MockTicker{})


### PR DESCRIPTION
No tracking issue

---

# Description

**Write why you are making the changes in this pull request**

An RPC test that uses time and our slot ticker from `shared/slotutil` was flakey due to poor abstraction. Instead, we create a `Ticker` interface that defines a method `C() <-chan uint64` and are able to use a mock when testing behavior to remove flakeyness.
