### PR TITLE
Don't blacklist on pubsub when disconnecting

### DIFF
--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -35,8 +35,6 @@ func (s *Service) AddConnectionHandler(reqFunc func(ctx context.Context, id peer
 				return
 			}
 			if s.peers.IsBad(conn.RemotePeer()) {
-				// Add peer to gossipsub blacklist.
-				s.pubsub.BlacklistPeer(conn.RemotePeer())
 				log.Trace("Disconnecting from bad peer")
 				if err := s.Disconnect(conn.RemotePeer()); err != nil {
 					log.WithError(err).Error("Unable to disconnect from peer")


### PR DESCRIPTION
This seems unnecessary and a permanent blacklist while disconnects are temporary with decay. 