### PR TITLE
Configurable min genesis delay

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -232,9 +232,9 @@ func (s *Service) createGenesisTime(timeStamp uint64) uint64 {
 	if !featureconfig.Get().GenesisDelay {
 		return uint64(time.Unix(int64(timeStamp), 0).Add(30 * time.Second).Unix())
 	}
-	timeStampRdDown := timeStamp - timeStamp%params.BeaconConfig().SecondsPerDay
+	timeStampRdDown := timeStamp - timeStamp%params.BeaconConfig().MinGenesisDelay
 	// genesisTime will be set to the first second of the day, two days after it was triggered.
-	return timeStampRdDown + 2*params.BeaconConfig().SecondsPerDay
+	return timeStampRdDown + 2*params.BeaconConfig().MinGenesisDelay
 }
 
 // processPastLogs processes all the past logs from the deposit contract and

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -229,9 +229,6 @@ func (s *Service) ProcessChainStart(genesisTime uint64, eth1BlockHash [32]byte, 
 }
 
 func (s *Service) createGenesisTime(timeStamp uint64) uint64 {
-	if !featureconfig.Get().GenesisDelay {
-		return uint64(time.Unix(int64(timeStamp), 0).Add(30 * time.Second).Unix())
-	}
 	timeStampRdDown := timeStamp - timeStamp%params.BeaconConfig().MinGenesisDelay
 	// genesisTime will be set to the first second of the day, two days after it was triggered.
 	return timeStampRdDown + 2*params.BeaconConfig().MinGenesisDelay

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -25,7 +25,6 @@ var log = logrus.WithField("prefix", "flags")
 
 // Flags is a struct to represent which features the client will perform on runtime.
 type Flags struct {
-	GenesisDelay              bool   // GenesisDelay when processing a chain start genesis event.
 	MinimalConfig             bool   // MinimalConfig as defined in the spec.
 	WriteSSZStateTransitions  bool   // WriteSSZStateTransitions to tmp directory.
 	InitSyncNoVerify          bool   // InitSyncNoVerify when initial syncing w/o verifying block's contents.
@@ -68,10 +67,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.GlobalBool(MinimalConfigFlag.Name) {
 		log.Warn("Using minimal config")
 		cfg.MinimalConfig = true
-	}
-	if ctx.GlobalBool(GenesisDelayFlag.Name) {
-		log.Warn("Using non standard genesis delay. This may cause problems in a multi-node environment.")
-		cfg.GenesisDelay = true
 	}
 	if ctx.GlobalBool(writeSSZStateTransitionsFlag.Name) {
 		log.Warn("Writing SSZ states and blocks after state transitions")

--- a/shared/featureconfig/config_test.go
+++ b/shared/featureconfig/config_test.go
@@ -10,21 +10,21 @@ import (
 
 func TestInitFeatureConfig(t *testing.T) {
 	cfg := &featureconfig.Flags{
-		GenesisDelay: true,
+		MinimalConfig: true,
 	}
 	featureconfig.Init(cfg)
-	if c := featureconfig.Get(); !c.GenesisDelay {
-		t.Errorf("GenesisDelay in FeatureFlags incorrect. Wanted true, got false")
+	if c := featureconfig.Get(); !c.MinimalConfig {
+		t.Errorf("MinimalConfig in FeatureFlags incorrect. Wanted true, got false")
 	}
 }
 
 func TestConfigureBeaconConfig(t *testing.T) {
 	app := cli.NewApp()
 	set := flag.NewFlagSet("test", 0)
-	set.Bool(featureconfig.GenesisDelayFlag.Name, true, "enable attestation verification")
+	set.Bool(featureconfig.MinimalConfigFlag.Name, true, "test")
 	context := cli.NewContext(app, set, nil)
 	featureconfig.ConfigureBeaconChain(context)
-	if c := featureconfig.Get(); !c.GenesisDelay {
-		t.Errorf("GenesisDelay in FeatureFlags incorrect. Wanted true, got false")
+	if c := featureconfig.Get(); !c.MinimalConfig {
+		t.Errorf("MinimalConfig in FeatureFlags incorrect. Wanted true, got false")
 	}
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -5,11 +5,6 @@ import (
 )
 
 var (
-	// GenesisDelayFlag disables the standard genesis delay.
-	GenesisDelayFlag = cli.BoolFlag{
-		Name:  "genesis-delay",
-		Usage: "Wait and process the genesis event at the midnight of the next day rather than 30s after the ETH1 block time of the chainstart triggering deposit",
-	}
 	// MinimalConfigFlag enables the minimal configuration.
 	MinimalConfigFlag = cli.BoolFlag{
 		Name:  "minimal-config",
@@ -144,6 +139,9 @@ var (
 		Usage: deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedGenesisDelayFlag = cli.BoolFlag{
+		Name: "genesis-delay",
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -160,6 +158,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedEnableCommitteeCacheFlag,
 	deprecatedEnableBLSPubkeyCacheFlag,
 	deprecatedFastCommitteeAssignmentsFlag,
+	deprecatedGenesisDelayFlag,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -169,7 +168,6 @@ var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 
 // BeaconChainFlags contains a list of all the feature flags that apply to the beacon-chain client.
 var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
-	GenesisDelayFlag,
 	MinimalConfigFlag,
 	writeSSZStateTransitionsFlag,
 	EnableAttestationCacheFlag,

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -141,6 +141,8 @@ var (
 	}
 	deprecatedGenesisDelayFlag = cli.BoolFlag{
 		Name: "genesis-delay",
+		Usage: deprecatedUsage,
+		Hidden: true,
 	}
 )
 

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -15,7 +15,7 @@ type BeaconChainConfig struct {
 	FarFutureEpoch           uint64 `yaml:"FAR_FUTURE_EPOCH"`            // FarFutureEpoch represents a epoch extremely far away in the future used as the default penalization slot for validators.
 	BaseRewardsPerEpoch      uint64 `yaml:"BASE_REWARDS_PER_EPOCH"`      // BaseRewardsPerEpoch is used to calculate the per epoch rewards.
 	DepositContractTreeDepth uint64 `yaml:"DEPOSIT_CONTRACT_TREE_DEPTH"` // Depth of the Merkle trie of deposits in the validator deposit contract on the PoW chain.
-	SecondsPerDay            uint64 `yaml:"SECONDS_PER_DAY"`             // SecondsPerDay number of seconds in day constant.
+	MinGenesisDelay          uint64 `yaml:"MIN_GENESIS_DELAY"`           // Minimum number of seconds to delay starting the ETH2 genesis.
 
 	// Misc constants.
 	TargetCommitteeSize            uint64 `yaml:"TARGET_COMMITTEE_SIZE"`        // TargetCommitteeSize is the number of validators in a committee when the chain is healthy.
@@ -115,7 +115,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	FarFutureEpoch:           1<<64 - 1,
 	BaseRewardsPerEpoch:      4,
 	DepositContractTreeDepth: 32,
-	SecondsPerDay:            86400,
+	MinGenesisDelay:          86400, // 1 day
 
 	// Misc constant.
 	TargetCommitteeSize:            128,
@@ -256,6 +256,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.ShuffleRoundCount = 10
 	minimalConfig.MinGenesisActiveValidatorCount = 64
 	minimalConfig.MinGenesisTime = 0
+	minimalConfig.MinGenesisDelay = 300 // 5 minutes
 	minimalConfig.TargetAggregatorsPerCommittee = 3
 
 	// Gwei values

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -15,7 +15,7 @@ type BeaconChainConfig struct {
 	FarFutureEpoch           uint64 `yaml:"FAR_FUTURE_EPOCH"`            // FarFutureEpoch represents a epoch extremely far away in the future used as the default penalization slot for validators.
 	BaseRewardsPerEpoch      uint64 `yaml:"BASE_REWARDS_PER_EPOCH"`      // BaseRewardsPerEpoch is used to calculate the per epoch rewards.
 	DepositContractTreeDepth uint64 `yaml:"DEPOSIT_CONTRACT_TREE_DEPTH"` // Depth of the Merkle trie of deposits in the validator deposit contract on the PoW chain.
-	MinGenesisDelay          uint64 `yaml:"MIN_GENESIS_DELAY"`           // Minimum number of seconds to delay starting the ETH2 genesis.
+	MinGenesisDelay          uint64 `yaml:"MIN_GENESIS_DELAY"`           // Minimum number of seconds to delay starting the ETH2 genesis. Must be at least 1 second.
 
 	// Misc constants.
 	TargetCommitteeSize            uint64 `yaml:"TARGET_COMMITTEE_SIZE"`        // TargetCommitteeSize is the number of validators in a committee when the chain is healthy.
@@ -25,7 +25,7 @@ type BeaconChainConfig struct {
 	ChurnLimitQuotient             uint64 `yaml:"CHURN_LIMIT_QUOTIENT"`               // ChurnLimitQuotient is used to determine the limit of how many validators can rotate per epoch.
 	ShuffleRoundCount              uint64 `yaml:"SHUFFLE_ROUND_COUNT"`                // ShuffleRoundCount is used for retrieving the permuted index.
 	MinGenesisActiveValidatorCount uint64 `yaml:"MIN_GENESIS_ACTIVE_VALIDATOR_COUNT"` // MinGenesisActiveValidatorCount defines how many validator deposits needed to kick off beacon chain.
-	MinGenesisTime                 uint64 `yaml:"MIN_GENESIS_TIME"`                   // MinGenesisTime is the time that needed to pass before kicking off beacon chain. Currently set to Jan/3/2020.
+	MinGenesisTime                 uint64 `yaml:"MIN_GENESIS_TIME"`                   // MinGenesisTime is the time that needed to pass before kicking off beacon chain.
 	TargetAggregatorsPerCommittee  uint64 // TargetAggregatorsPerCommittee defines the number of aggregators inside one committee.
 
 	// Gwei value constants.

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -237,6 +237,7 @@ func DemoBeaconConfig() *BeaconChainConfig {
 	demoConfig.EjectionBalance = 3 * 1e9
 	demoConfig.EffectiveBalanceIncrement = 0.1 * 1e9
 	demoConfig.Eth1FollowDistance = 16
+	demoConfig.MinGenesisDelay = 30 // 30 seconds
 
 	// Increment this number after a full testnet tear down.
 	demoConfig.GenesisForkVersion = []byte{0, 0, 0, 3}


### PR DESCRIPTION
Changes based on https://github.com/ethereum/eth2.0-specs/pull/1557

Additionally, we will remove the no-genesis-delay flag. If we want no delay, we'll configure this via config. 