### PR TITLE
Cluster: Save keys unencrypted for validators

### DIFF
--- a/tools/cluster-pk-manager/client/BUILD.bazel
+++ b/tools/cluster-pk-manager/client/BUILD.bazel
@@ -10,9 +10,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//proto/cluster:go_default_library",
-        "//shared/bls:go_default_library",
-        "//shared/keystore:go_default_library",
-        "//shared/params:go_default_library",
+        "@com_github_bazelbuild_buildtools//file:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_uber_go_automaxprocs//:go_default_library",
     ],
@@ -40,6 +38,7 @@ go_image(
         "//shared/bls:go_default_library",
         "//shared/keystore:go_default_library",
         "//shared/params:go_default_library",
+        "@com_github_bazelbuild_buildtools//file:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_uber_go_automaxprocs//:go_default_library",
     ],


### PR DESCRIPTION
This saves a lot of time on start up for testnet validators.