### PR TITLE
Remove unused parameters and unused code

### DIFF
--- a/beacon-chain/archiver/service_test.go
+++ b/beacon-chain/archiver/service_test.go
@@ -81,7 +81,7 @@ func TestArchiverService_ArchivesEvenThroughSkipSlot(t *testing.T) {
 	hook := logTest.NewGlobal()
 	svc, beaconDB := setupService(t)
 	validatorCount := uint64(100)
-	headState := setupState(t, validatorCount)
+	headState := setupState(validatorCount)
 	defer dbutil.TeardownDB(t, beaconDB)
 	event := &feed.Event{
 		Type: statefeed.BlockProcessed,
@@ -130,7 +130,7 @@ func TestArchiverService_ArchivesEvenThroughSkipSlot(t *testing.T) {
 func TestArchiverService_ComputesAndSavesParticipation(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validatorCount := uint64(100)
-	headState := setupState(t, validatorCount)
+	headState := setupState(validatorCount)
 	svc, beaconDB := setupService(t)
 	defer dbutil.TeardownDB(t, beaconDB)
 	svc.headFetcher = &mock.ChainService{
@@ -168,7 +168,7 @@ func TestArchiverService_ComputesAndSavesParticipation(t *testing.T) {
 func TestArchiverService_SavesIndicesAndBalances(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validatorCount := uint64(100)
-	headState := setupState(t, validatorCount)
+	headState := setupState(validatorCount)
 	svc, beaconDB := setupService(t)
 	defer dbutil.TeardownDB(t, beaconDB)
 	svc.headFetcher = &mock.ChainService{
@@ -201,7 +201,7 @@ func TestArchiverService_SavesIndicesAndBalances(t *testing.T) {
 func TestArchiverService_SavesCommitteeInfo(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validatorCount := uint64(100)
-	headState := setupState(t, validatorCount)
+	headState := setupState(validatorCount)
 	svc, beaconDB := setupService(t)
 	defer dbutil.TeardownDB(t, beaconDB)
 	svc.headFetcher = &mock.ChainService{
@@ -248,7 +248,7 @@ func TestArchiverService_SavesCommitteeInfo(t *testing.T) {
 func TestArchiverService_SavesActivatedValidatorChanges(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validatorCount := uint64(100)
-	headState := setupState(t, validatorCount)
+	headState := setupState(validatorCount)
 	svc, beaconDB := setupService(t)
 	defer dbutil.TeardownDB(t, beaconDB)
 	svc.headFetcher = &mock.ChainService{
@@ -283,7 +283,7 @@ func TestArchiverService_SavesActivatedValidatorChanges(t *testing.T) {
 func TestArchiverService_SavesSlashedValidatorChanges(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validatorCount := uint64(100)
-	headState := setupState(t, validatorCount)
+	headState := setupState(validatorCount)
 	svc, beaconDB := setupService(t)
 	defer dbutil.TeardownDB(t, beaconDB)
 	svc.headFetcher = &mock.ChainService{
@@ -317,7 +317,7 @@ func TestArchiverService_SavesSlashedValidatorChanges(t *testing.T) {
 func TestArchiverService_SavesExitedValidatorChanges(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validatorCount := uint64(100)
-	headState := setupState(t, validatorCount)
+	headState := setupState(validatorCount)
 	svc, beaconDB := setupService(t)
 	defer dbutil.TeardownDB(t, beaconDB)
 	svc.headFetcher = &mock.ChainService{
@@ -347,7 +347,7 @@ func TestArchiverService_SavesExitedValidatorChanges(t *testing.T) {
 	}
 }
 
-func setupState(t *testing.T, validatorCount uint64) *pb.BeaconState {
+func setupState(validatorCount uint64) *pb.BeaconState {
 	validators := make([]*ethpb.Validator, validatorCount)
 	balances := make([]uint64, validatorCount)
 	for i := 0; i < len(validators); i++ {

--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -8,7 +8,7 @@ import (
 var log = logrus.WithField("prefix", "blockchain")
 
 // logs state transition related data every slot.
-func logStateTransitionData(b *ethpb.BeaconBlock, r []byte) {
+func logStateTransitionData(b *ethpb.BeaconBlock) {
 	log.WithFields(logrus.Fields{
 		"slot":         b.Slot,
 		"attestations": len(b.Body.Attestations),

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -122,7 +122,7 @@ func (s *Service) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.SignedB
 	isCompetingBlock(root[:], blockCopy.Block.Slot, headRoot, signedHeadBlock.Block.Slot)
 
 	// Log state transition data.
-	logStateTransitionData(blockCopy.Block, root[:])
+	logStateTransitionData(blockCopy.Block)
 
 	s.epochParticipationLock.Lock()
 	defer s.epochParticipationLock.Unlock()
@@ -172,7 +172,7 @@ func (s *Service) ReceiveBlockNoPubsubForkchoice(ctx context.Context, block *eth
 	s.reportSlotMetrics(blockCopy.Block.Slot)
 
 	// Log state transition data.
-	logStateTransitionData(blockCopy.Block, root[:])
+	logStateTransitionData(blockCopy.Block)
 
 	s.epochParticipationLock.Lock()
 	defer s.epochParticipationLock.Unlock()

--- a/beacon-chain/db/kv/attestations.go
+++ b/beacon-chain/db/kv/attestations.go
@@ -105,7 +105,7 @@ func (k *Store) DeleteAttestation(ctx context.Context, attDataRoot [32]byte) err
 		if err := decode(enc, ac); err != nil {
 			return err
 		}
-		indicesByBucket := createAttestationIndicesFromData(ac.Data, tx)
+		indicesByBucket := createAttestationIndicesFromData(ac.Data)
 		if err := deleteValueForIndices(indicesByBucket, attDataRoot[:], tx); err != nil {
 			return errors.Wrap(err, "could not delete root for DB indices")
 		}
@@ -126,7 +126,7 @@ func (k *Store) DeleteAttestations(ctx context.Context, attDataRoots [][32]byte)
 			if err := decode(enc, ac); err != nil {
 				return err
 			}
-			indicesByBucket := createAttestationIndicesFromData(ac.Data, tx)
+			indicesByBucket := createAttestationIndicesFromData(ac.Data)
 			if err := deleteValueForIndices(indicesByBucket, attDataRoot[:], tx); err != nil {
 				return errors.Wrap(err, "could not delete root for DB indices")
 			}
@@ -175,7 +175,7 @@ func (k *Store) SaveAttestation(ctx context.Context, att *ethpb.Attestation) err
 			return err
 		}
 
-		indicesByBucket := createAttestationIndicesFromData(att.Data, tx)
+		indicesByBucket := createAttestationIndicesFromData(att.Data)
 		if err := updateValueForIndices(indicesByBucket, attDataRoot[:], tx); err != nil {
 			return errors.Wrap(err, "could not update DB indices")
 		}
@@ -217,7 +217,7 @@ func (k *Store) SaveAttestations(ctx context.Context, atts []*ethpb.Attestation)
 				return err
 			}
 
-			indicesByBucket := createAttestationIndicesFromData(att.Data, tx)
+			indicesByBucket := createAttestationIndicesFromData(att.Data)
 			if err := updateValueForIndices(indicesByBucket, attDataRoot[:], tx); err != nil {
 				return errors.Wrap(err, "could not update DB indices")
 			}
@@ -238,7 +238,7 @@ func (k *Store) SaveAttestations(ctx context.Context, atts []*ethpb.Attestation)
 // createAttestationIndicesFromData takes in attestation data and returns
 // a map of bolt DB index buckets corresponding to each particular key for indices for
 // data, such as (shard indices bucket -> shard 5).
-func createAttestationIndicesFromData(attData *ethpb.AttestationData, tx *bolt.Tx) map[string][]byte {
+func createAttestationIndicesFromData(attData *ethpb.AttestationData) map[string][]byte {
 	indicesByBucket := make(map[string][]byte)
 	buckets := make([][]byte, 0)
 	indices := make([][]byte, 0)

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -2,9 +2,6 @@ package validator
 
 import (
 	"context"
-	dbpb "github.com/prysmaticlabs/prysm/proto/beacon/db"
-	"github.com/prysmaticlabs/prysm/shared/stateutil"
-
 	"math/big"
 	"strings"
 	"testing"
@@ -20,10 +17,12 @@ import (
 	dbutil "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	mockPOW "github.com/prysmaticlabs/prysm/beacon-chain/powchain/testing"
+	dbpb "github.com/prysmaticlabs/prysm/proto/beacon/db"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/stateutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
 )

--- a/beacon-chain/rpc/validator/status.go
+++ b/beacon-chain/rpc/validator/status.go
@@ -105,7 +105,7 @@ func (vs *Server) validatorStatus(ctx context.Context, pubKey []byte, headState 
 
 	resp.Eth1DepositBlockNumber = eth1BlockNumBigInt.Uint64()
 
-	depositBlockSlot, err := vs.depositBlockSlot(ctx, headState.Slot, eth1BlockNumBigInt, headState)
+	depositBlockSlot, err := vs.depositBlockSlot(ctx, eth1BlockNumBigInt, headState)
 	if err != nil {
 		return resp
 	}
@@ -176,12 +176,7 @@ func (vs *Server) assignmentStatus(validatorIdx uint64, beaconState *pbp2p.Beaco
 	return status
 }
 
-func (vs *Server) depositBlockSlot(
-	ctx context.Context,
-	currentSlot uint64,
-	eth1BlockNumBigInt *big.Int,
-	beaconState *pbp2p.BeaconState,
-) (uint64, error) {
+func (vs *Server) depositBlockSlot(ctx context.Context, eth1BlockNumBigInt *big.Int, beaconState *pbp2p.BeaconState, ) (uint64, error) {
 	blockTimeStamp, err := vs.BlockFetcher.BlockTimeByHeight(ctx, eth1BlockNumBigInt)
 	if err != nil {
 		return 0, err

--- a/shared/keystore/deposit_input_test.go
+++ b/shared/keystore/deposit_input_test.go
@@ -2,7 +2,6 @@ package keystore_test
 
 import (
 	"bytes"
-	"crypto/rand"
 	"testing"
 
 	"github.com/prysmaticlabs/go-ssz"
@@ -13,11 +12,11 @@ import (
 )
 
 func TestDepositInput_GeneratesPb(t *testing.T) {
-	k1, err := keystore.NewKey(rand.Reader)
+	k1, err := keystore.NewKey()
 	if err != nil {
 		t.Fatal(err)
 	}
-	k2, err := keystore.NewKey(rand.Reader)
+	k2, err := keystore.NewKey()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/shared/keystore/key.go
+++ b/shared/keystore/key.go
@@ -21,7 +21,6 @@ package keystore
 import (
 	"encoding/hex"
 	"encoding/json"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -151,13 +150,13 @@ func NewKeyFromBLS(blsKey *bls.SecretKey) (*Key, error) {
 }
 
 // NewKey generates a new random key.
-func NewKey(rand io.Reader) (*Key, error) {
+func NewKey() (*Key, error) {
 	secretKey := bls.RandKey()
 	return NewKeyFromBLS(secretKey)
 }
 
-func storeNewRandomKey(ks keyStore, rand io.Reader, password string) error {
-	key, err := NewKey(rand)
+func storeNewRandomKey(ks keyStore, password string) error {
+	key, err := NewKey()
 	if err != nil {
 		return err
 	}

--- a/shared/keystore/key_test.go
+++ b/shared/keystore/key_test.go
@@ -2,7 +2,6 @@ package keystore
 
 import (
 	"bytes"
-	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -51,9 +50,7 @@ func TestStoreRandomKey(t *testing.T) {
 		scryptP:     LightScryptP,
 	}
 
-	reader := rand.Reader
-
-	if err := storeNewRandomKey(ks, reader, "password"); err != nil {
+	if err := storeNewRandomKey(ks, "password"); err != nil {
 		t.Fatalf("storage of random key unsuccessful %v", err)
 	}
 
@@ -79,9 +76,7 @@ func TestNewKeyFromBLS(t *testing.T) {
 		t.Fatalf("secret key is not of the expected value %d", key.SecretKey.Marshal())
 	}
 
-	reader := rand.Reader
-
-	_, err = NewKey(reader)
+	_, err = NewKey()
 	if err != nil {
 		t.Fatalf("random key unable to be generated: %v", err)
 	}

--- a/shared/keystore/keystore.go
+++ b/shared/keystore/keystore.go
@@ -131,7 +131,7 @@ func (ks Store) JoinPath(filename string) string {
 
 // StoreRandomKey generates a key, encrypts with 'auth' and stores in the given directory
 func StoreRandomKey(dir, password string, scryptN, scryptP int) error {
-	err := storeNewRandomKey(Store{dir, scryptN, scryptP}, rand.Reader, password)
+	err := storeNewRandomKey(Store{dir, scryptN, scryptP}, password)
 	return err
 }
 

--- a/shared/keystore/keystore_test.go
+++ b/shared/keystore/keystore_test.go
@@ -2,7 +2,6 @@ package keystore
 
 import (
 	"bytes"
-	"crypto/rand"
 	"os"
 	"testing"
 
@@ -21,7 +20,7 @@ func TestStoreAndGetKey(t *testing.T) {
 		scryptP:     LightScryptP,
 	}
 
-	key, err := NewKey(rand.Reader)
+	key, err := NewKey()
 	if err != nil {
 		t.Fatalf("key generation failed %v", err)
 	}
@@ -53,7 +52,7 @@ func TestStoreAndGetKeys(t *testing.T) {
 		scryptP:     LightScryptP,
 	}
 
-	key, err := NewKey(rand.Reader)
+	key, err := NewKey()
 	if err != nil {
 		t.Fatalf("key generation failed %v", err)
 	}
@@ -61,7 +60,7 @@ func TestStoreAndGetKeys(t *testing.T) {
 	if err := ks.StoreKey(tmpdir+filePrefix+"/test-1", key, "password"); err != nil {
 		t.Fatalf("unable to store key %v", err)
 	}
-	key2, err := NewKey(rand.Reader)
+	key2, err := NewKey()
 	if err != nil {
 		t.Fatalf("key generation failed %v", err)
 	}

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -3,7 +3,6 @@
 package params
 
 import (
-	"math/big"
 	"time"
 
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -103,13 +102,6 @@ type BeaconChainConfig struct {
 	PruneSlasherStoragePeriod uint64 // PruneSlasherStoragePeriod defines the time period expressed in number of epochs were proof of stake network should prune attestation and block header store.
 }
 
-// DepositContractConfig contains the deposits for
-type DepositContractConfig struct {
-	MinGenesisActiveValidatorCount *big.Int // MinGenesisActiveValidatorCount defines how many validator deposits needed to kick off beacon chain.
-	MinDepositAmount               *big.Int // MinDepositAmount defines the minimum deposit amount in gwei that is required in the deposit contract.
-	MaxEffectiveBalance            *big.Int // MaxEffectiveBalance defines the maximum deposit amount in gwei that is required in the deposit contract.
-}
-
 var defaultBeaconConfig = &BeaconChainConfig{
 	// Constants (Non-configurable)
 	FarFutureEpoch:           1<<64 - 1,
@@ -205,14 +197,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	TestnetContractEndpoint: "https://prylabs.net/contract", // defines an http endpoint to fetch the testnet contract addr.
 }
 
-var defaultDepositContractConfig = &DepositContractConfig{
-	MinGenesisActiveValidatorCount: big.NewInt(16384),
-	MinDepositAmount:               big.NewInt(1e9),
-	MaxEffectiveBalance:            big.NewInt(32e9),
-}
-
 var beaconConfig = defaultBeaconConfig
-var contractConfig = defaultDepositContractConfig
 
 // BeaconConfig retrieves beacon chain config.
 func BeaconConfig() *BeaconChainConfig {
@@ -310,11 +295,6 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.DepositContractTreeDepth = 32
 	minimalConfig.FarFutureEpoch = 1<<64 - 1
 	return &minimalConfig
-}
-
-// ContractConfig retrieves the deposit contract config
-func ContractConfig() *DepositContractConfig {
-	return contractConfig
 }
 
 // UseDemoBeaconConfig for beacon chain services.

--- a/tools/cluster-pk-manager/server/server.go
+++ b/tools/cluster-pk-manager/server/server.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/rand"
 	"math/big"
 	"sync"
 	"time"
@@ -139,7 +138,7 @@ func (s *server) allocateNewKeys(ctx context.Context, podName string, numKeys in
 	txMap := make(map[*keystore.Key]*types.Transaction)
 
 	for i := 0; i < numKeys; i++ {
-		key, err := keystore.NewKey(rand.Reader)
+		key, err := keystore.NewKey()
 		if err != nil {
 			return nil, err
 		}

--- a/tools/deployContract/deployContract.go
+++ b/tools/deployContract/deployContract.go
@@ -171,7 +171,7 @@ func main() {
 		}).Info("New contract deployed")
 
 		if k8sConfigMapName != "" {
-			if err := updateKubernetesConfigMap(k8sConfigMapName, addr.Hex()); err != nil {
+			if err := updateKubernetesConfigMap(addr.Hex()); err != nil {
 				log.Fatalf("Failed to update kubernetes config map: %v", err)
 			} else {
 				log.Printf("Updated config map %s", k8sConfigMapName)
@@ -187,7 +187,7 @@ func main() {
 
 // updateKubernetesConfigMap in the beacon-chain namespace. This specifically
 // updates the data value for DEPOSIT_CONTRACT_ADDRESS.
-func updateKubernetesConfigMap(configMapName string, contractAddr string) error {
+func updateKubernetesConfigMap(contractAddr string) error {
 	config, err := rest.InClusterConfig()
 	if err != nil {
 		return err

--- a/tools/sendDepositTx/sendDeposits.go
+++ b/tools/sendDepositTx/sendDeposits.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -167,7 +166,7 @@ func main() {
 
 		validatorKeys := make(map[string]*prysmKeyStore.Key)
 		if randomKey {
-			validatorKey, err := prysmKeyStore.NewKey(rand.Reader)
+			validatorKey, err := prysmKeyStore.NewKey()
 			validatorKeys[hex.EncodeToString(validatorKey.PublicKey.Marshal())] = validatorKey
 			if err != nil {
 				log.Errorf("Could not generate random key: %v", err)

--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -2,7 +2,6 @@ package accounts
 
 import (
 	"bufio"
-	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -61,7 +60,7 @@ func NewValidatorAccount(directory string, password string) error {
 	validatorKeyFile := directory + params.BeaconConfig().ValidatorPrivkeyFileName
 	ks := keystore.NewKeystore(directory)
 	// If the keystore does not exists at the path, we create a new one for the validator.
-	shardWithdrawalKey, err := keystore.NewKey(rand.Reader)
+	shardWithdrawalKey, err := keystore.NewKey()
 	if err != nil {
 		return err
 	}
@@ -73,7 +72,7 @@ func NewValidatorAccount(directory string, password string) error {
 		"path",
 		shardWithdrawalKeyFile,
 	).Info("Keystore generated for shard withdrawals at path")
-	validatorKey, err := keystore.NewKey(rand.Reader)
+	validatorKey, err := keystore.NewKey()
 	if err != nil {
 		return err
 	}

--- a/validator/accounts/account_test.go
+++ b/validator/accounts/account_test.go
@@ -1,7 +1,6 @@
 package accounts
 
 import (
-	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -14,7 +13,7 @@ import (
 func TestNewValidatorAccount_AccountExists(t *testing.T) {
 	directory := testutil.TempDir() + "/testkeystore"
 	defer os.RemoveAll(directory)
-	validatorKey, err := keystore.NewKey(rand.Reader)
+	validatorKey, err := keystore.NewKey()
 	if err != nil {
 		t.Fatalf("Cannot create new key: %v", err)
 	}

--- a/validator/client/service_test.go
+++ b/validator/client/service_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"crypto/rand"
 	"os"
 	"strings"
 	"testing"
@@ -29,7 +28,7 @@ func keySetup() {
 	keyMap = make(map[[48]byte]*keystore.Key)
 	keyMapThreeValidators = make(map[[48]byte]*keystore.Key)
 
-	validatorKey, _ = keystore.NewKey(rand.Reader)
+	validatorKey, _ = keystore.NewKey()
 	copy(validatorPubKey[:], validatorKey.PublicKey.Marshal())
 	keyMap[validatorPubKey] = validatorKey
 
@@ -39,7 +38,7 @@ func keySetup() {
 
 	sks = make([]*bls.SecretKey, 3)
 	for i := 0; i < 3; i++ {
-		vKey, _ := keystore.NewKey(rand.Reader)
+		vKey, _ := keystore.NewKey()
 		var pubKey [48]byte
 		copy(pubKey[:], vKey.PublicKey.Marshal())
 		keyMapThreeValidators[pubKey] = vKey


### PR DESCRIPTION
This PR removes unused parameters from a few functions like `keystore.NewKey` and entirely removes `DepositContractConfig` since it is no longer used.