### PR TITLE
Committee cache fuzz tests

### DIFF
--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     srcs = [
         "attestation_data_test.go",
         "checkpoint_state_test.go",
+        "committee_fuzz_test.go",
         "committee_test.go",
         "eth1_data_test.go",
         "feature_flag_test.go",
@@ -44,6 +45,7 @@ go_test(
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_google_gofuzz//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
     ],
 )

--- a/beacon-chain/cache/committee_fuzz_test.go
+++ b/beacon-chain/cache/committee_fuzz_test.go
@@ -1,0 +1,21 @@
+package cache
+
+import (
+	"testing"
+
+	fuzz "github.com/google/gofuzz"
+)
+
+func TestCommitteeKeyFuzz_OK(t *testing.T) {
+	fuzzer := fuzz.NewWithSeed(0)
+	c := &Committees{}
+	fuzzer.Funcs(c)
+
+	k, err := committeeKeyFn(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if k != key(c.Seed) {
+		t.Errorf("Incorrect hash k: %s, expected %s", k, key(c.Seed))
+	}
+}

--- a/beacon-chain/cache/committee_fuzz_test.go
+++ b/beacon-chain/cache/committee_fuzz_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"reflect"
 	"testing"
 
 	fuzz "github.com/google/gofuzz"
@@ -9,13 +10,59 @@ import (
 func TestCommitteeKeyFuzz_OK(t *testing.T) {
 	fuzzer := fuzz.NewWithSeed(0)
 	c := &Committees{}
-	fuzzer.Funcs(c)
 
-	k, err := committeeKeyFn(c)
-	if err != nil {
-		t.Fatal(err)
+	for i := 0; i < 100000; i++ {
+		fuzzer.Fuzz(c)
+		k, err := committeeKeyFn(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if k != key(c.Seed) {
+			t.Errorf("Incorrect hash k: %s, expected %s", k, key(c.Seed))
+		}
 	}
-	if k != key(c.Seed) {
-		t.Errorf("Incorrect hash k: %s, expected %s", k, key(c.Seed))
+}
+
+func TestCommitteeCache_FuzzCommitteesByEpoch(t *testing.T) {
+	cache := NewCommitteesCache()
+	fuzzer := fuzz.NewWithSeed(0)
+	c := &Committees{}
+
+	for i := 0; i < 100000; i++ {
+		fuzzer.Fuzz(c)
+		if err := cache.AddCommitteeShuffledList(c); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := cache.Committee(0, c.Seed, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if len(cache.CommitteeCache.ListKeys()) != maxCommitteesCacheSize {
+		t.Error("Incorrect key size")
+	}
+}
+
+func TestCommitteeCache_FuzzActiveIndices(t *testing.T) {
+	cache := NewCommitteesCache()
+	fuzzer := fuzz.NewWithSeed(0)
+	c := &Committees{}
+
+	for i := 0; i < 100000; i++ {
+		fuzzer.Fuzz(c)
+		if err := cache.AddCommitteeShuffledList(c); err != nil {
+			t.Fatal(err)
+		}
+		indices, err := cache.ActiveIndices(c.Seed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(indices, c.SortedIndices) {
+			t.Error("Saved indices not the same")
+		}
+	}
+
+	if len(cache.CommitteeCache.ListKeys()) != maxCommitteesCacheSize {
+		t.Error("Incorrect key size")
 	}
 }

--- a/beacon-chain/rpc/validator/status.go
+++ b/beacon-chain/rpc/validator/status.go
@@ -176,7 +176,7 @@ func (vs *Server) assignmentStatus(validatorIdx uint64, beaconState *pbp2p.Beaco
 	return status
 }
 
-func (vs *Server) depositBlockSlot(ctx context.Context, eth1BlockNumBigInt *big.Int, beaconState *pbp2p.BeaconState, ) (uint64, error) {
+func (vs *Server) depositBlockSlot(ctx context.Context, eth1BlockNumBigInt *big.Int, beaconState *pbp2p.BeaconState) (uint64, error) {
 	blockTimeStamp, err := vs.BlockFetcher.BlockTimeByHeight(ctx, eth1BlockNumBigInt)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Added fuzz tests for committee cache. The test contains fuzz tests for converting cache key, saving/retrieving committees and active indices