### PR TITLE
Optimize ListBeaconCommittees to use committees cache

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -195,7 +195,6 @@ func (s *Service) initializeBeaconChain(
 	eth1data *ethpb.Eth1Data) error {
 	_, span := trace.StartSpan(context.Background(), "beacon-chain.Service.initializeBeaconChain")
 	defer span.End()
-	log.Info("Initializing beacon chain genesis state")
 	s.genesisTime = genesisTime
 	unixTime := uint64(genesisTime.Unix())
 
@@ -207,6 +206,8 @@ func (s *Service) initializeBeaconChain(
 	if err := s.saveGenesisData(ctx, genesisState); err != nil {
 		return errors.Wrap(err, "could not save genesis data")
 	}
+
+	log.Info("Initialized beacon chain genesis state")
 
 	// Update committee shuffled indices for genesis epoch.
 	if featureconfig.Get().EnableNewCache {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -195,7 +195,7 @@ func (s *Service) initializeBeaconChain(
 	eth1data *ethpb.Eth1Data) error {
 	_, span := trace.StartSpan(context.Background(), "beacon-chain.Service.initializeBeaconChain")
 	defer span.End()
-	log.Info("Genesis time reached, starting the beacon chain")
+	log.Info("Initializing beacon chain genesis state")
 	s.genesisTime = genesisTime
 	unixTime := uint64(genesisTime.Unix())
 

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -176,7 +176,7 @@ func TestChainStartStop_Uninitialized(t *testing.T) {
 		t.Error("Context was not canceled")
 	}
 	testutil.AssertLogsContain(t, hook, "Waiting")
-	testutil.AssertLogsContain(t, hook, "Genesis time reached")
+	testutil.AssertLogsContain(t, hook, "Initialized beacon chain genesis state")
 }
 
 func TestChainStartStop_Initialized(t *testing.T) {

--- a/beacon-chain/rpc/beacon/committees.go
+++ b/beacon-chain/rpc/beacon/committees.go
@@ -105,10 +105,8 @@ func (bs *Server) ListBeaconCommittees(
 			countAtSlot = 1
 		}
 		committeeItems := make([]*ethpb.BeaconCommittees_CommitteeItem, countAtSlot)
-		for i := uint64(0); i < countAtSlot; i++ {
-			epochOffset := i + (slot%params.BeaconConfig().SlotsPerEpoch)*countAtSlot
-			totalCount := countAtSlot * params.BeaconConfig().SlotsPerEpoch
-			committee, err := helpers.ComputeCommittee(activeIndices, attesterSeed, epochOffset, totalCount)
+		for committeeIndex := uint64(0); committeeIndex < countAtSlot; committeeIndex++ {
+			committee, err := helpers.BeaconCommittee(activeIndices, attesterSeed, slot, committeeIndex)
 			if err != nil {
 				return nil, status.Errorf(
 					codes.Internal,
@@ -117,7 +115,7 @@ func (bs *Server) ListBeaconCommittees(
 					err,
 				)
 			}
-			committeeItems[i] = &ethpb.BeaconCommittees_CommitteeItem{
+			committeeItems[committeeIndex] = &ethpb.BeaconCommittees_CommitteeItem{
 				ValidatorIndices: committee,
 			}
 		}


### PR DESCRIPTION
`ListBeaconCommittees` uses method `ComputeCommittee` which bypasses the committee cache. Instead it should use method `BeaconCommittee` (where the cache is) and `BeaconCommittee` calls `ComputeCommittee` underneath.

It also cleans up code path where we don't need to recalculate `epochOffset` and `totalCount`, it's already taken care of by `BeaconCommittee` 