### PR TITLE
Change database *Index() to use slice

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -332,7 +332,7 @@ func (s *Store) saveNewValidators(ctx context.Context, preStateValidatorCount in
 	if preStateValidatorCount != postStateValidatorCount {
 		for i := preStateValidatorCount; i < postStateValidatorCount; i++ {
 			pubKey := postState.Validators[i].PublicKey
-			if err := s.db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey), uint64(i)); err != nil {
+			if err := s.db.SaveValidatorIndex(ctx, pubKey, uint64(i)); err != nil {
 				return errors.Wrapf(err, "could not save activated validator: %d", i)
 			}
 			log.WithFields(logrus.Fields{

--- a/beacon-chain/blockchain/forkchoice/process_block_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_block_test.go
@@ -119,20 +119,22 @@ func TestStore_SaveNewValidators(t *testing.T) {
 	store := NewForkChoiceService(ctx, db)
 	preCount := 2 // validators 0 and validators 1
 	s := &pb.BeaconState{Validators: []*ethpb.Validator{
-		{PublicKey: []byte{0}}, {PublicKey: []byte{1}},
-		{PublicKey: []byte{2}}, {PublicKey: []byte{3}},
+		{PublicKey: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{PublicKey: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}},
+		{PublicKey: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}},
+		{PublicKey: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}},
 	}}
 	if err := store.saveNewValidators(ctx, preCount, s); err != nil {
 		t.Fatal(err)
 	}
 
-	if !db.HasValidatorIndex(ctx, bytesutil.ToBytes48([]byte{2})) {
+	if !db.HasValidatorIndex(ctx, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}) {
 		t.Error("Wanted validator saved in db")
 	}
-	if !db.HasValidatorIndex(ctx, bytesutil.ToBytes48([]byte{3})) {
+	if !db.HasValidatorIndex(ctx, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}) {
 		t.Error("Wanted validator saved in db")
 	}
-	if db.HasValidatorIndex(ctx, bytesutil.ToBytes48([]byte{1})) {
+	if db.HasValidatorIndex(ctx, []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}) {
 		t.Error("validator not suppose to be saved in db")
 	}
 }

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -293,7 +293,7 @@ func (s *Service) saveHeadNoDB(ctx context.Context, b *ethpb.SignedBeaconBlock, 
 // This gets called when beacon chain is first initialized to save validator indices and pubkeys in db
 func (s *Service) saveGenesisValidators(ctx context.Context, state *pb.BeaconState) error {
 	for i, v := range state.Validators {
-		if err := s.beaconDB.SaveValidatorIndex(ctx, bytesutil.ToBytes48(v.PublicKey), uint64(i)); err != nil {
+		if err := s.beaconDB.SaveValidatorIndex(ctx, v.PublicKey, uint64(i)); err != nil {
 			return errors.Wrapf(err, "could not save validator index: %d", i)
 		}
 	}

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -259,7 +259,7 @@ func TestChainService_InitializeBeaconChain(t *testing.T) {
 	}
 
 	for _, v := range s.Validators {
-		if !db.HasValidatorIndex(ctx, bytesutil.ToBytes48(v.PublicKey)) {
+		if !db.HasValidatorIndex(ctx, v.PublicKey) {
 			t.Errorf("Validator %s missing from db", hex.EncodeToString(v.PublicKey))
 		}
 	}

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -44,10 +44,10 @@ type Database interface {
 	SaveGenesisBlockRoot(ctx context.Context, blockRoot [32]byte) error
 	IsFinalizedBlock(ctx context.Context, blockRoot [32]byte) bool
 	// Validator related methods.
-	ValidatorIndex(ctx context.Context, publicKey [48]byte) (uint64, bool, error)
-	HasValidatorIndex(ctx context.Context, publicKey [48]byte) bool
-	DeleteValidatorIndex(ctx context.Context, publicKey [48]byte) error
-	SaveValidatorIndex(ctx context.Context, publicKey [48]byte, validatorIdx uint64) error
+	ValidatorIndex(ctx context.Context, publicKey []byte) (uint64, bool, error)
+	HasValidatorIndex(ctx context.Context, publicKey []byte) bool
+	DeleteValidatorIndex(ctx context.Context, publicKey []byte) error
+	SaveValidatorIndex(ctx context.Context, publicKey []byte, validatorIdx uint64) error
 	// State related methods.
 	State(ctx context.Context, blockRoot [32]byte) (*ethereum_beacon_p2p_v1.BeaconState, error)
 	HeadState(ctx context.Context) (*ethereum_beacon_p2p_v1.BeaconState, error)

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -87,17 +87,17 @@ func (e Exporter) DeleteBlocks(ctx context.Context, blockRoots [][32]byte) error
 }
 
 // ValidatorIndex -- passthrough.
-func (e Exporter) ValidatorIndex(ctx context.Context, publicKey [48]byte) (uint64, bool, error) {
+func (e Exporter) ValidatorIndex(ctx context.Context, publicKey []byte) (uint64, bool, error) {
 	return e.db.ValidatorIndex(ctx, publicKey)
 }
 
 // HasValidatorIndex -- passthrough.
-func (e Exporter) HasValidatorIndex(ctx context.Context, publicKey [48]byte) bool {
+func (e Exporter) HasValidatorIndex(ctx context.Context, publicKey []byte) bool {
 	return e.db.HasValidatorIndex(ctx, publicKey)
 }
 
 // DeleteValidatorIndex -- passthrough.
-func (e Exporter) DeleteValidatorIndex(ctx context.Context, publicKey [48]byte) error {
+func (e Exporter) DeleteValidatorIndex(ctx context.Context, publicKey []byte) error {
 	return e.db.DeleteValidatorIndex(ctx, publicKey)
 }
 
@@ -212,7 +212,7 @@ func (e Exporter) SaveGenesisBlockRoot(ctx context.Context, blockRoot [32]byte) 
 }
 
 // SaveValidatorIndex -- passthrough.
-func (e Exporter) SaveValidatorIndex(ctx context.Context, publicKey [48]byte, validatorIdx uint64) error {
+func (e Exporter) SaveValidatorIndex(ctx context.Context, publicKey []byte, validatorIdx uint64) error {
 	return e.db.SaveValidatorIndex(ctx, publicKey, validatorIdx)
 }
 

--- a/beacon-chain/db/kv/validators.go
+++ b/beacon-chain/db/kv/validators.go
@@ -5,20 +5,25 @@ import (
 	"encoding/binary"
 
 	"github.com/boltdb/bolt"
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"go.opencensus.io/trace"
 )
 
 // ValidatorIndex by public key.
-func (k *Store) ValidatorIndex(ctx context.Context, publicKey [48]byte) (uint64, bool, error) {
+func (k *Store) ValidatorIndex(ctx context.Context, publicKey []byte) (uint64, bool, error) {
+	if len(publicKey) != params.BeaconConfig().BLSPubkeyLength {
+		return 0, false, errors.New("incorrect key length")
+	}
 	// Return latest validatorIndex from cache if it exists.
-	if v, ok := k.validatorIndexCache.Get(string(publicKey[:])); v != nil && ok {
+	if v, ok := k.validatorIndexCache.Get(string(publicKey)); v != nil && ok {
 		return v.(uint64), true, nil
 	}
 	var validatorIdx uint64
 	var ok bool
 	err := k.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(validatorsBucket)
-		enc := bkt.Get(publicKey[:])
+		enc := bkt.Get(publicKey)
 		if enc == nil {
 			return nil
 		}
@@ -31,42 +36,45 @@ func (k *Store) ValidatorIndex(ctx context.Context, publicKey [48]byte) (uint64,
 }
 
 // HasValidatorIndex verifies if a validator's index by public key exists in the db.
-func (k *Store) HasValidatorIndex(ctx context.Context, publicKey [48]byte) bool {
+func (k *Store) HasValidatorIndex(ctx context.Context, publicKey []byte) bool {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasValidatorIndex")
 	defer span.End()
-	if v, ok := k.validatorIndexCache.Get(string(publicKey[:])); v != nil && ok {
+	if v, ok := k.validatorIndexCache.Get(string(publicKey)); v != nil && ok {
 		return true
 	}
 	exists := false
 	// #nosec G104. Always returns nil.
 	k.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(validatorsBucket)
-		exists = bkt.Get(publicKey[:]) != nil
+		exists = bkt.Get(publicKey) != nil
 		return nil
 	})
 	return exists
 }
 
 // DeleteValidatorIndex clears a validator index from the db by the validator's public key.
-func (k *Store) DeleteValidatorIndex(ctx context.Context, publicKey [48]byte) error {
+func (k *Store) DeleteValidatorIndex(ctx context.Context, publicKey []byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteValidatorIndex")
 	defer span.End()
 	return k.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(validatorsBucket)
-		k.validatorIndexCache.Del(string(publicKey[:]))
-		return bucket.Delete(publicKey[:])
+		k.validatorIndexCache.Del(string(publicKey))
+		return bucket.Delete(publicKey)
 	})
 }
 
 // SaveValidatorIndex by public key in the db.
-func (k *Store) SaveValidatorIndex(ctx context.Context, publicKey [48]byte, validatorIdx uint64) error {
+func (k *Store) SaveValidatorIndex(ctx context.Context, publicKey []byte, validatorIdx uint64) error {
+	if len(publicKey) != params.BeaconConfig().BLSPubkeyLength {
+		return errors.New("incorrect key length")
+	}
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveValidatorIndex")
 	defer span.End()
 	return k.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(validatorsBucket)
 		buf := uint64ToBytes(validatorIdx)
-		k.validatorIndexCache.Set(string(publicKey[:]), validatorIdx, int64(len(buf)))
-		return bucket.Put(publicKey[:], buf)
+		k.validatorIndexCache.Set(string(publicKey), validatorIdx, int64(len(buf)))
+		return bucket.Put(publicKey, buf)
 	})
 }
 

--- a/beacon-chain/db/kv/validators_test.go
+++ b/beacon-chain/db/kv/validators_test.go
@@ -9,7 +9,7 @@ func TestStore_ValidatorIndexCRUD(t *testing.T) {
 	db := setupDB(t)
 	defer teardownDB(t, db)
 	validatorIdx := uint64(100)
-	pubKey := [48]byte{1, 2, 3, 4}
+	pubKey := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4}
 	ctx := context.Background()
 	_, ok, err := db.ValidatorIndex(ctx, pubKey)
 	if err != nil {

--- a/beacon-chain/interop-cold-start/BUILD.bazel
+++ b/beacon-chain/interop-cold-start/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//beacon-chain/powchain:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared:go_default_library",
-        "//shared/bytesutil:go_default_library",
         "//shared/interop:go_default_library",
         "//shared/stateutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/beacon-chain/interop-cold-start/service.go
+++ b/beacon-chain/interop-cold-start/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/powchain"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/interop"
 	"github.com/prysmaticlabs/prysm/shared/stateutil"
 )
@@ -171,7 +170,7 @@ func (s *Service) saveGenesisState(ctx context.Context, genesisState *pb.BeaconS
 	}
 
 	for i, v := range genesisState.Validators {
-		if err := s.beaconDB.SaveValidatorIndex(ctx, bytesutil.ToBytes48(v.PublicKey), uint64(i)); err != nil {
+		if err := s.beaconDB.SaveValidatorIndex(ctx, v.PublicKey, uint64(i)); err != nil {
 			return errors.Wrapf(err, "could not save validator index: %d", i)
 		}
 		s.chainStartDeposits[i] = &ethpb.Deposit{

--- a/beacon-chain/rpc/aggregator/BUILD.bazel
+++ b/beacon-chain/rpc/aggregator/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//beacon-chain/p2p:go_default_library",
         "//beacon-chain/sync:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",
-        "//shared/bytesutil:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",

--- a/beacon-chain/rpc/aggregator/server.go
+++ b/beacon-chain/rpc/aggregator/server.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/beacon-chain/sync"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 	"google.golang.org/grpc/codes"
@@ -44,7 +43,7 @@ func (as *Server) SubmitAggregateAndProof(ctx context.Context, req *pb.Aggregati
 		return nil, status.Errorf(codes.Unavailable, "Syncing to latest head, not ready to respond")
 	}
 
-	validatorIndex, exists, err := as.BeaconDB.ValidatorIndex(ctx, bytesutil.ToBytes48(req.PublicKey))
+	validatorIndex, exists, err := as.BeaconDB.ValidatorIndex(ctx, req.PublicKey)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get validator index from DB: %v", err)
 	}

--- a/beacon-chain/rpc/aggregator/server_test.go
+++ b/beacon-chain/rpc/aggregator/server_test.go
@@ -28,8 +28,8 @@ func init() {
 	params.OverrideBeaconConfig(params.MinimalSpecConfig())
 }
 
-// _pubKey is a helper to generate a well-formed public key.
-func _pubKey(i uint64) []byte {
+// pubKey is a helper to generate a well-formed public key.
+func pubKey(i uint64) []byte {
 	pubKey := make([]byte, params.BeaconConfig().BLSPubkeyLength)
 	binary.LittleEndian.PutUint64(pubKey, uint64(i))
 	return pubKey
@@ -72,7 +72,7 @@ func TestSubmitAggregateAndProof_CantFindValidatorIndex(t *testing.T) {
 
 	priv := bls.RandKey()
 	sig := priv.Sign([]byte{'A'}, 0)
-	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: _pubKey(3)}
+	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: pubKey(3)}
 	wanted := "Could not locate validator index in DB"
 	if _, err := aggregatorServer.SubmitAggregateAndProof(ctx, req); !strings.Contains(err.Error(), wanted) {
 		t.Errorf("Did not receive wanted error: expected %v, received %v", wanted, err.Error())
@@ -97,7 +97,7 @@ func TestSubmitAggregateAndProof_IsAggregator(t *testing.T) {
 
 	priv := bls.RandKey()
 	sig := priv.Sign([]byte{'A'}, 0)
-	pubKey := _pubKey(1)
+	pubKey := pubKey(1)
 	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: pubKey}
 	if err := aggregatorServer.BeaconDB.SaveValidatorIndex(ctx, pubKey, 100); err != nil {
 		t.Fatal(err)
@@ -135,7 +135,7 @@ func TestSubmitAggregateAndProof_AggregateOk(t *testing.T) {
 
 	priv := bls.RandKey()
 	sig := priv.Sign([]byte{'B'}, 0)
-	pubKey := _pubKey(2)
+	pubKey := pubKey(2)
 	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: pubKey}
 	if err := aggregatorServer.BeaconDB.SaveValidatorIndex(ctx, pubKey, 100); err != nil {
 		t.Fatal(err)
@@ -188,7 +188,7 @@ func TestSubmitAggregateAndProof_AggregateNotOk(t *testing.T) {
 
 	priv := bls.RandKey()
 	sig := priv.Sign([]byte{'B'}, 0)
-	pubKey := _pubKey(2)
+	pubKey := pubKey(2)
 	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: pubKey}
 	if err := aggregatorServer.BeaconDB.SaveValidatorIndex(ctx, pubKey, 100); err != nil {
 		t.Fatal(err)

--- a/beacon-chain/rpc/aggregator/server_test.go
+++ b/beacon-chain/rpc/aggregator/server_test.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	"context"
+	"encoding/binary"
 	"reflect"
 	"strings"
 	"testing"
@@ -25,6 +26,13 @@ import (
 func init() {
 	// Use minimal config to reduce test setup time.
 	params.OverrideBeaconConfig(params.MinimalSpecConfig())
+}
+
+// _pubKey is a helper to generate a well-formed public key.
+func _pubKey(i uint64) []byte {
+	pubKey := make([]byte, params.BeaconConfig().BLSPubkeyLength)
+	binary.LittleEndian.PutUint64(pubKey, uint64(i))
+	return pubKey
 }
 
 func TestSubmitAggregateAndProof_Syncing(t *testing.T) {
@@ -64,10 +72,10 @@ func TestSubmitAggregateAndProof_CantFindValidatorIndex(t *testing.T) {
 
 	priv := bls.RandKey()
 	sig := priv.Sign([]byte{'A'}, 0)
-	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal()}
+	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: _pubKey(3)}
 	wanted := "Could not locate validator index in DB"
 	if _, err := aggregatorServer.SubmitAggregateAndProof(ctx, req); !strings.Contains(err.Error(), wanted) {
-		t.Error("Did not receive wanted error")
+		t.Errorf("Did not receive wanted error: expected %v, received %v", wanted, err.Error())
 	}
 }
 
@@ -89,8 +97,8 @@ func TestSubmitAggregateAndProof_IsAggregator(t *testing.T) {
 
 	priv := bls.RandKey()
 	sig := priv.Sign([]byte{'A'}, 0)
-	pubKey := [48]byte{'A'}
-	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: pubKey[:]}
+	pubKey := _pubKey(1)
+	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: pubKey}
 	if err := aggregatorServer.BeaconDB.SaveValidatorIndex(ctx, pubKey, 100); err != nil {
 		t.Fatal(err)
 	}
@@ -127,8 +135,8 @@ func TestSubmitAggregateAndProof_AggregateOk(t *testing.T) {
 
 	priv := bls.RandKey()
 	sig := priv.Sign([]byte{'B'}, 0)
-	pubKey := [48]byte{'B'}
-	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: pubKey[:]}
+	pubKey := _pubKey(2)
+	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: pubKey}
 	if err := aggregatorServer.BeaconDB.SaveValidatorIndex(ctx, pubKey, 100); err != nil {
 		t.Fatal(err)
 	}
@@ -180,8 +188,8 @@ func TestSubmitAggregateAndProof_AggregateNotOk(t *testing.T) {
 
 	priv := bls.RandKey()
 	sig := priv.Sign([]byte{'B'}, 0)
-	pubKey := [48]byte{'B'}
-	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: pubKey[:]}
+	pubKey := _pubKey(2)
+	req := &pb.AggregationRequest{CommitteeIndex: 1, SlotSignature: sig.Marshal(), PublicKey: pubKey}
 	if err := aggregatorServer.BeaconDB.SaveValidatorIndex(ctx, pubKey, 100); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/rpc/beacon/assignments.go
+++ b/beacon-chain/rpc/beacon/assignments.go
@@ -60,7 +60,7 @@ func (bs *Server) ListValidatorAssignments(
 
 	// Filter out assignments by public keys.
 	for _, pubKey := range req.PublicKeys {
-		index, ok, err := bs.BeaconDB.ValidatorIndex(ctx, bytesutil.ToBytes48(pubKey))
+		index, ok, err := bs.BeaconDB.ValidatorIndex(ctx, pubKey)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not retrieve validator index: %v", err)
 		}

--- a/beacon-chain/rpc/beacon/committees_test.go
+++ b/beacon-chain/rpc/beacon/committees_test.go
@@ -2,6 +2,7 @@ package beacon
 
 import (
 	"context"
+	"encoding/binary"
 	"reflect"
 	"testing"
 
@@ -187,12 +188,14 @@ func setupActiveValidators(t *testing.T, db db.Database, count int) *pbp2p.Beaco
 	balances := make([]uint64, count)
 	validators := make([]*ethpb.Validator, 0, count)
 	for i := 0; i < count; i++ {
-		if err := db.SaveValidatorIndex(ctx, [48]byte{byte(i)}, uint64(i)); err != nil {
+		pubKey := make([]byte, params.BeaconConfig().BLSPubkeyLength)
+		binary.LittleEndian.PutUint64(pubKey, uint64(i))
+		if err := db.SaveValidatorIndex(ctx, pubKey, uint64(i)); err != nil {
 			t.Fatal(err)
 		}
 		balances[i] = uint64(i)
 		validators = append(validators, &ethpb.Validator{
-			PublicKey:       []byte{byte(i)},
+			PublicKey:       pubKey,
 			ActivationEpoch: 0,
 			ExitEpoch:       params.BeaconConfig().FarFutureEpoch,
 		})

--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/pagination"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"google.golang.org/grpc/codes"
@@ -80,7 +79,7 @@ func (bs *Server) ListValidatorBalances(
 			continue
 		}
 
-		index, ok, err := bs.BeaconDB.ValidatorIndex(ctx, bytesutil.ToBytes48(pubKey))
+		index, ok, err := bs.BeaconDB.ValidatorIndex(ctx, pubKey)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not retrieve validator index: %v", err)
 		}
@@ -566,7 +565,7 @@ func (bs *Server) GetValidatorPerformance(
 	balances := make([]uint64, len(req.PublicKeys))
 	missingValidators := make([][]byte, 0)
 	for i, key := range req.PublicKeys {
-		index, ok, err := bs.BeaconDB.ValidatorIndex(ctx, bytesutil.ToBytes48(key))
+		index, ok, err := bs.BeaconDB.ValidatorIndex(ctx, key)
 		if err != nil || !ok {
 			missingValidators = append(missingValidators, key)
 			balances[i] = 0

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -225,7 +225,7 @@ func TestServer_ListValidatorBalances_ExceedsMaxPageSize(t *testing.T) {
 	}
 }
 
-func _pubKey(i uint64) []byte {
+func pubKey(i uint64) []byte {
 	pubKey := make([]byte, params.BeaconConfig().BLSPubkeyLength)
 	binary.LittleEndian.PutUint64(pubKey, i)
 	return pubKey
@@ -251,10 +251,10 @@ func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 		req *ethpb.ListValidatorBalancesRequest
 		res *ethpb.ValidatorBalances
 	}{
-		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{_pubKey(99)}},
+		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{pubKey(99)}},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{Index: 99, PublicKey: _pubKey(99), Balance: 99},
+					{Index: 99, PublicKey: pubKey(99), Balance: 99},
 				},
 				NextPageToken: "",
 				TotalSize:     1,
@@ -263,30 +263,30 @@ func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 		{req: &ethpb.ListValidatorBalancesRequest{Indices: []uint64{1, 2, 3}},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{Index: 1, PublicKey: _pubKey(1), Balance: 1},
-					{Index: 2, PublicKey: _pubKey(2), Balance: 2},
-					{Index: 3, PublicKey: _pubKey(3), Balance: 3},
+					{Index: 1, PublicKey: pubKey(1), Balance: 1},
+					{Index: 2, PublicKey: pubKey(2), Balance: 2},
+					{Index: 3, PublicKey: pubKey(3), Balance: 3},
 				},
 				NextPageToken: "",
 				TotalSize:     3,
 			},
 		},
-		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{_pubKey(10), _pubKey(11), _pubKey(12)}},
+		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{pubKey(10), pubKey(11), pubKey(12)}},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{Index: 10, PublicKey: _pubKey(10), Balance: 10},
-					{Index: 11, PublicKey: _pubKey(11), Balance: 11},
-					{Index: 12, PublicKey: _pubKey(12), Balance: 12},
+					{Index: 10, PublicKey: pubKey(10), Balance: 10},
+					{Index: 11, PublicKey: pubKey(11), Balance: 11},
+					{Index: 12, PublicKey: pubKey(12), Balance: 12},
 				},
 				NextPageToken: "",
 				TotalSize:     3,
 			}},
-		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{_pubKey(2), _pubKey(3)}, Indices: []uint64{3, 4}}, // Duplication
+		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{pubKey(2), pubKey(3)}, Indices: []uint64{3, 4}}, // Duplication
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{Index: 2, PublicKey: _pubKey(2), Balance: 2},
-					{Index: 3, PublicKey: _pubKey(3), Balance: 3},
-					{Index: 4, PublicKey: _pubKey(4), Balance: 4},
+					{Index: 2, PublicKey: pubKey(2), Balance: 2},
+					{Index: 3, PublicKey: pubKey(3), Balance: 3},
+					{Index: 4, PublicKey: pubKey(4), Balance: 4},
 				},
 				NextPageToken: "",
 				TotalSize:     3,
@@ -294,8 +294,8 @@ func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{{}}, Indices: []uint64{3, 4}}, // Public key has a blank value
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{Index: 3, PublicKey: _pubKey(3), Balance: 3},
-					{Index: 4, PublicKey: _pubKey(4), Balance: 4},
+					{Index: 3, PublicKey: pubKey(3), Balance: 3},
+					{Index: 4, PublicKey: pubKey(4), Balance: 4},
 				},
 				NextPageToken: "",
 				TotalSize:     2,
@@ -337,35 +337,35 @@ func TestServer_ListValidatorBalances_Pagination_CustomPageSizes(t *testing.T) {
 		{req: &ethpb.ListValidatorBalancesRequest{PageToken: strconv.Itoa(1), PageSize: 3},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{PublicKey: _pubKey(3), Index: 3, Balance: uint64(3)},
-					{PublicKey: _pubKey(4), Index: 4, Balance: uint64(4)},
-					{PublicKey: _pubKey(5), Index: 5, Balance: uint64(5)}},
+					{PublicKey: pubKey(3), Index: 3, Balance: uint64(3)},
+					{PublicKey: pubKey(4), Index: 4, Balance: uint64(4)},
+					{PublicKey: pubKey(5), Index: 5, Balance: uint64(5)}},
 				NextPageToken: strconv.Itoa(2),
 				TotalSize:     int32(count)}},
 		{req: &ethpb.ListValidatorBalancesRequest{PageToken: strconv.Itoa(10), PageSize: 5},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{PublicKey: _pubKey(50), Index: 50, Balance: uint64(50)},
-					{PublicKey: _pubKey(51), Index: 51, Balance: uint64(51)},
-					{PublicKey: _pubKey(52), Index: 52, Balance: uint64(52)},
-					{PublicKey: _pubKey(53), Index: 53, Balance: uint64(53)},
-					{PublicKey: _pubKey(54), Index: 54, Balance: uint64(54)}},
+					{PublicKey: pubKey(50), Index: 50, Balance: uint64(50)},
+					{PublicKey: pubKey(51), Index: 51, Balance: uint64(51)},
+					{PublicKey: pubKey(52), Index: 52, Balance: uint64(52)},
+					{PublicKey: pubKey(53), Index: 53, Balance: uint64(53)},
+					{PublicKey: pubKey(54), Index: 54, Balance: uint64(54)}},
 				NextPageToken: strconv.Itoa(11),
 				TotalSize:     int32(count)}},
 		{req: &ethpb.ListValidatorBalancesRequest{PageToken: strconv.Itoa(33), PageSize: 3},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{PublicKey: _pubKey(99), Index: 99, Balance: uint64(99)},
-					{PublicKey: _pubKey(100), Index: 100, Balance: uint64(100)},
-					{PublicKey: _pubKey(101), Index: 101, Balance: uint64(101)},
+					{PublicKey: pubKey(99), Index: 99, Balance: uint64(99)},
+					{PublicKey: pubKey(100), Index: 100, Balance: uint64(100)},
+					{PublicKey: pubKey(101), Index: 101, Balance: uint64(101)},
 				},
 				NextPageToken: "34",
 				TotalSize:     int32(count)}},
 		{req: &ethpb.ListValidatorBalancesRequest{PageSize: 2},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{PublicKey: _pubKey(0), Index: 0, Balance: uint64(0)},
-					{PublicKey: _pubKey(1), Index: 1, Balance: uint64(1)}},
+					{PublicKey: pubKey(0), Index: 0, Balance: uint64(0)},
+					{PublicKey: pubKey(1), Index: 1, Balance: uint64(1)}},
 				NextPageToken: strconv.Itoa(1),
 				TotalSize:     int32(count)}},
 	}
@@ -549,7 +549,7 @@ func TestServer_ListValidators_OnlyActiveValidators(t *testing.T) {
 	validators := make([]*ethpb.Validator, count)
 	activeValidators := make([]*ethpb.Validators_ValidatorContainer, 0)
 	for i := 0; i < count; i++ {
-		pubKey := _pubKey(uint64(i))
+		pubKey := pubKey(uint64(i))
 		if err := db.SaveValidatorIndex(ctx, pubKey, uint64(i)); err != nil {
 			t.Fatal(err)
 		}
@@ -665,19 +665,19 @@ func TestServer_ListValidators_Pagination(t *testing.T) {
 				ValidatorList: []*ethpb.Validators_ValidatorContainer{
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(3),
+							PublicKey: pubKey(3),
 						},
 						Index: 3,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(4),
+							PublicKey: pubKey(4),
 						},
 						Index: 4,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(5),
+							PublicKey: pubKey(5),
 						},
 						Index: 5,
 					},
@@ -689,31 +689,31 @@ func TestServer_ListValidators_Pagination(t *testing.T) {
 				ValidatorList: []*ethpb.Validators_ValidatorContainer{
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(50),
+							PublicKey: pubKey(50),
 						},
 						Index: 50,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(51),
+							PublicKey: pubKey(51),
 						},
 						Index: 51,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(52),
+							PublicKey: pubKey(52),
 						},
 						Index: 52,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(53),
+							PublicKey: pubKey(53),
 						},
 						Index: 53,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(54),
+							PublicKey: pubKey(54),
 						},
 						Index: 54,
 					},
@@ -725,7 +725,7 @@ func TestServer_ListValidators_Pagination(t *testing.T) {
 				ValidatorList: []*ethpb.Validators_ValidatorContainer{
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(99),
+							PublicKey: pubKey(99),
 						},
 						Index: 99,
 					},
@@ -737,13 +737,13 @@ func TestServer_ListValidators_Pagination(t *testing.T) {
 				ValidatorList: []*ethpb.Validators_ValidatorContainer{
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(0),
+							PublicKey: pubKey(0),
 						},
 						Index: 0,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: _pubKey(1),
+							PublicKey: pubKey(1),
 						},
 						Index: 1,
 					},
@@ -907,7 +907,7 @@ func TestServer_GetValidator(t *testing.T) {
 	for i := 0; i < count; i++ {
 		validators[i] = &ethpb.Validator{
 			ActivationEpoch: uint64(i),
-			PublicKey:       _pubKey(uint64(i)),
+			PublicKey:       pubKey(uint64(i)),
 		}
 	}
 
@@ -946,7 +946,7 @@ func TestServer_GetValidator(t *testing.T) {
 		{
 			req: &ethpb.GetValidatorRequest{
 				QueryFilter: &ethpb.GetValidatorRequest_PublicKey{
-					PublicKey: _pubKey(5),
+					PublicKey: pubKey(5),
 				},
 			},
 			res:     validators[5],
@@ -1499,7 +1499,7 @@ func setupValidators(t *testing.T, db db.Database, count int) ([]*ethpb.Validato
 	balances := make([]uint64, count)
 	validators := make([]*ethpb.Validator, 0, count)
 	for i := 0; i < count; i++ {
-		pubKey := _pubKey(uint64(i))
+		pubKey := pubKey(uint64(i))
 		if err := db.SaveValidatorIndex(ctx, pubKey, uint64(i)); err != nil {
 			t.Fatal(err)
 		}

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -2,6 +2,7 @@ package beacon
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -224,6 +225,12 @@ func TestServer_ListValidatorBalances_ExceedsMaxPageSize(t *testing.T) {
 	}
 }
 
+func _pubKey(i uint64) []byte {
+	pubKey := make([]byte, params.BeaconConfig().BLSPubkeyLength)
+	binary.LittleEndian.PutUint64(pubKey, i)
+	return pubKey
+}
+
 func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 	db := dbTest.SetupDB(t)
 	defer dbTest.TeardownDB(t, db)
@@ -244,10 +251,10 @@ func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 		req *ethpb.ListValidatorBalancesRequest
 		res *ethpb.ValidatorBalances
 	}{
-		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{{99}}},
+		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{_pubKey(99)}},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{Index: 99, PublicKey: []byte{99}, Balance: 99},
+					{Index: 99, PublicKey: _pubKey(99), Balance: 99},
 				},
 				NextPageToken: "",
 				TotalSize:     1,
@@ -256,30 +263,30 @@ func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 		{req: &ethpb.ListValidatorBalancesRequest{Indices: []uint64{1, 2, 3}},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{Index: 1, PublicKey: []byte{1}, Balance: 1},
-					{Index: 2, PublicKey: []byte{2}, Balance: 2},
-					{Index: 3, PublicKey: []byte{3}, Balance: 3},
+					{Index: 1, PublicKey: _pubKey(1), Balance: 1},
+					{Index: 2, PublicKey: _pubKey(2), Balance: 2},
+					{Index: 3, PublicKey: _pubKey(3), Balance: 3},
 				},
 				NextPageToken: "",
 				TotalSize:     3,
 			},
 		},
-		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{{10}, {11}, {12}}},
+		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{_pubKey(10), _pubKey(11), _pubKey(12)}},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{Index: 10, PublicKey: []byte{10}, Balance: 10},
-					{Index: 11, PublicKey: []byte{11}, Balance: 11},
-					{Index: 12, PublicKey: []byte{12}, Balance: 12},
+					{Index: 10, PublicKey: _pubKey(10), Balance: 10},
+					{Index: 11, PublicKey: _pubKey(11), Balance: 11},
+					{Index: 12, PublicKey: _pubKey(12), Balance: 12},
 				},
 				NextPageToken: "",
 				TotalSize:     3,
 			}},
-		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{{2}, {3}}, Indices: []uint64{3, 4}}, // Duplication
+		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{_pubKey(2), _pubKey(3)}, Indices: []uint64{3, 4}}, // Duplication
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{Index: 2, PublicKey: []byte{2}, Balance: 2},
-					{Index: 3, PublicKey: []byte{3}, Balance: 3},
-					{Index: 4, PublicKey: []byte{4}, Balance: 4},
+					{Index: 2, PublicKey: _pubKey(2), Balance: 2},
+					{Index: 3, PublicKey: _pubKey(3), Balance: 3},
+					{Index: 4, PublicKey: _pubKey(4), Balance: 4},
 				},
 				NextPageToken: "",
 				TotalSize:     3,
@@ -287,8 +294,8 @@ func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 		{req: &ethpb.ListValidatorBalancesRequest{PublicKeys: [][]byte{{}}, Indices: []uint64{3, 4}}, // Public key has a blank value
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{Index: 3, PublicKey: []byte{3}, Balance: 3},
-					{Index: 4, PublicKey: []byte{4}, Balance: 4},
+					{Index: 3, PublicKey: _pubKey(3), Balance: 3},
+					{Index: 4, PublicKey: _pubKey(4), Balance: 4},
 				},
 				NextPageToken: "",
 				TotalSize:     2,
@@ -330,35 +337,35 @@ func TestServer_ListValidatorBalances_Pagination_CustomPageSizes(t *testing.T) {
 		{req: &ethpb.ListValidatorBalancesRequest{PageToken: strconv.Itoa(1), PageSize: 3},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{PublicKey: []byte{3}, Index: 3, Balance: uint64(3)},
-					{PublicKey: []byte{4}, Index: 4, Balance: uint64(4)},
-					{PublicKey: []byte{5}, Index: 5, Balance: uint64(5)}},
+					{PublicKey: _pubKey(3), Index: 3, Balance: uint64(3)},
+					{PublicKey: _pubKey(4), Index: 4, Balance: uint64(4)},
+					{PublicKey: _pubKey(5), Index: 5, Balance: uint64(5)}},
 				NextPageToken: strconv.Itoa(2),
 				TotalSize:     int32(count)}},
 		{req: &ethpb.ListValidatorBalancesRequest{PageToken: strconv.Itoa(10), PageSize: 5},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{PublicKey: []byte{50}, Index: 50, Balance: uint64(50)},
-					{PublicKey: []byte{51}, Index: 51, Balance: uint64(51)},
-					{PublicKey: []byte{52}, Index: 52, Balance: uint64(52)},
-					{PublicKey: []byte{53}, Index: 53, Balance: uint64(53)},
-					{PublicKey: []byte{54}, Index: 54, Balance: uint64(54)}},
+					{PublicKey: _pubKey(50), Index: 50, Balance: uint64(50)},
+					{PublicKey: _pubKey(51), Index: 51, Balance: uint64(51)},
+					{PublicKey: _pubKey(52), Index: 52, Balance: uint64(52)},
+					{PublicKey: _pubKey(53), Index: 53, Balance: uint64(53)},
+					{PublicKey: _pubKey(54), Index: 54, Balance: uint64(54)}},
 				NextPageToken: strconv.Itoa(11),
 				TotalSize:     int32(count)}},
 		{req: &ethpb.ListValidatorBalancesRequest{PageToken: strconv.Itoa(33), PageSize: 3},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{PublicKey: []byte{99}, Index: 99, Balance: uint64(99)},
-					{PublicKey: []byte{100}, Index: 100, Balance: uint64(100)},
-					{PublicKey: []byte{101}, Index: 101, Balance: uint64(101)},
+					{PublicKey: _pubKey(99), Index: 99, Balance: uint64(99)},
+					{PublicKey: _pubKey(100), Index: 100, Balance: uint64(100)},
+					{PublicKey: _pubKey(101), Index: 101, Balance: uint64(101)},
 				},
 				NextPageToken: "34",
 				TotalSize:     int32(count)}},
 		{req: &ethpb.ListValidatorBalancesRequest{PageSize: 2},
 			res: &ethpb.ValidatorBalances{
 				Balances: []*ethpb.ValidatorBalances_Balance{
-					{PublicKey: []byte{0}, Index: 0, Balance: uint64(0)},
-					{PublicKey: []byte{1}, Index: 1, Balance: uint64(1)}},
+					{PublicKey: _pubKey(0), Index: 0, Balance: uint64(0)},
+					{PublicKey: _pubKey(1), Index: 1, Balance: uint64(1)}},
 				NextPageToken: strconv.Itoa(1),
 				TotalSize:     int32(count)}},
 	}
@@ -542,7 +549,8 @@ func TestServer_ListValidators_OnlyActiveValidators(t *testing.T) {
 	validators := make([]*ethpb.Validator, count)
 	activeValidators := make([]*ethpb.Validators_ValidatorContainer, 0)
 	for i := 0; i < count; i++ {
-		if err := db.SaveValidatorIndex(ctx, [48]byte{byte(i)}, uint64(i)); err != nil {
+		pubKey := _pubKey(uint64(i))
+		if err := db.SaveValidatorIndex(ctx, pubKey, uint64(i)); err != nil {
 			t.Fatal(err)
 		}
 		balances[i] = params.BeaconConfig().MaxEffectiveBalance
@@ -550,7 +558,7 @@ func TestServer_ListValidators_OnlyActiveValidators(t *testing.T) {
 		// We mark even validators as active, and odd validators as inactive.
 		if i%2 == 0 {
 			val := &ethpb.Validator{
-				PublicKey:       []byte{byte(i)},
+				PublicKey:       pubKey,
 				ActivationEpoch: 0,
 				ExitEpoch:       params.BeaconConfig().FarFutureEpoch,
 			}
@@ -561,7 +569,7 @@ func TestServer_ListValidators_OnlyActiveValidators(t *testing.T) {
 			})
 		} else {
 			validators[i] = &ethpb.Validator{
-				PublicKey:       []byte{byte(i)},
+				PublicKey:       pubKey,
 				ActivationEpoch: 0,
 				ExitEpoch:       0,
 			}
@@ -657,19 +665,19 @@ func TestServer_ListValidators_Pagination(t *testing.T) {
 				ValidatorList: []*ethpb.Validators_ValidatorContainer{
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{3},
+							PublicKey: _pubKey(3),
 						},
 						Index: 3,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{4},
+							PublicKey: _pubKey(4),
 						},
 						Index: 4,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{5},
+							PublicKey: _pubKey(5),
 						},
 						Index: 5,
 					},
@@ -681,31 +689,31 @@ func TestServer_ListValidators_Pagination(t *testing.T) {
 				ValidatorList: []*ethpb.Validators_ValidatorContainer{
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{50},
+							PublicKey: _pubKey(50),
 						},
 						Index: 50,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{51},
+							PublicKey: _pubKey(51),
 						},
 						Index: 51,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{52},
+							PublicKey: _pubKey(52),
 						},
 						Index: 52,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{53},
+							PublicKey: _pubKey(53),
 						},
 						Index: 53,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{54},
+							PublicKey: _pubKey(54),
 						},
 						Index: 54,
 					},
@@ -717,7 +725,7 @@ func TestServer_ListValidators_Pagination(t *testing.T) {
 				ValidatorList: []*ethpb.Validators_ValidatorContainer{
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{99},
+							PublicKey: _pubKey(99),
 						},
 						Index: 99,
 					},
@@ -729,13 +737,13 @@ func TestServer_ListValidators_Pagination(t *testing.T) {
 				ValidatorList: []*ethpb.Validators_ValidatorContainer{
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{0},
+							PublicKey: _pubKey(0),
 						},
 						Index: 0,
 					},
 					{
 						Validator: &ethpb.Validator{
-							PublicKey: []byte{1},
+							PublicKey: _pubKey(1),
 						},
 						Index: 1,
 					},
@@ -899,7 +907,7 @@ func TestServer_GetValidator(t *testing.T) {
 	for i := 0; i < count; i++ {
 		validators[i] = &ethpb.Validator{
 			ActivationEpoch: uint64(i),
-			PublicKey:       []byte(strconv.Itoa(i)),
+			PublicKey:       _pubKey(uint64(i)),
 		}
 	}
 
@@ -938,7 +946,7 @@ func TestServer_GetValidator(t *testing.T) {
 		{
 			req: &ethpb.GetValidatorRequest{
 				QueryFilter: &ethpb.GetValidatorRequest_PublicKey{
-					PublicKey: []byte(strconv.Itoa(5)),
+					PublicKey: _pubKey(5),
 				},
 			},
 			res:     validators[5],
@@ -947,7 +955,7 @@ func TestServer_GetValidator(t *testing.T) {
 		{
 			req: &ethpb.GetValidatorRequest{
 				QueryFilter: &ethpb.GetValidatorRequest_PublicKey{
-					PublicKey: []byte("bad-key"),
+					PublicKey: []byte("bad-keyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
 				},
 			},
 			res:     nil,
@@ -1491,12 +1499,13 @@ func setupValidators(t *testing.T, db db.Database, count int) ([]*ethpb.Validato
 	balances := make([]uint64, count)
 	validators := make([]*ethpb.Validator, 0, count)
 	for i := 0; i < count; i++ {
-		if err := db.SaveValidatorIndex(ctx, [48]byte{byte(i)}, uint64(i)); err != nil {
+		pubKey := _pubKey(uint64(i))
+		if err := db.SaveValidatorIndex(ctx, pubKey, uint64(i)); err != nil {
 			t.Fatal(err)
 		}
 		balances[i] = uint64(i)
 		validators = append(validators, &ethpb.Validator{
-			PublicKey: []byte{byte(i)},
+			PublicKey: pubKey,
 		})
 	}
 	blk := &ethpb.BeaconBlock{

--- a/beacon-chain/rpc/validator/BUILD.bazel
+++ b/beacon-chain/rpc/validator/BUILD.bazel
@@ -80,7 +80,6 @@ go_test(
         "//proto/beacon/db:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bls:go_default_library",
-        "//shared/bytesutil:go_default_library",
         "//shared/event:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",

--- a/beacon-chain/rpc/validator/assignments.go
+++ b/beacon-chain/rpc/validator/assignments.go
@@ -6,7 +6,6 @@ import (
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -50,7 +49,7 @@ func (vs *Server) GetDuties(ctx context.Context, req *ethpb.DutiesRequest) (*eth
 			PublicKey: pubKey,
 		}
 
-		idx, ok, err := vs.BeaconDB.ValidatorIndex(ctx, bytesutil.ToBytes48(pubKey))
+		idx, ok, err := vs.BeaconDB.ValidatorIndex(ctx, pubKey)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not fetch validator idx for public key %#x: %v", pubKey, err)
 		}

--- a/beacon-chain/rpc/validator/assignments_test.go
+++ b/beacon-chain/rpc/validator/assignments_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
-// _pubKey is a helper to generate a well-formed public key.
-func _pubKey(i uint64) []byte {
+// pubKey is a helper to generate a well-formed public key.
+func pubKey(i uint64) []byte {
 	pubKey := make([]byte, params.BeaconConfig().BLSPubkeyLength)
 	binary.LittleEndian.PutUint64(pubKey, uint64(i))
 	return pubKey
@@ -73,7 +73,7 @@ func TestGetDuties_NextEpoch_CantFindValidatorIdx(t *testing.T) {
 		SyncChecker: &mockSync.Sync{IsSyncing: false},
 	}
 
-	pubKey := _pubKey(99999)
+	pubKey := pubKey(99999)
 	req := &ethpb.DutiesRequest{
 		PublicKeys: [][]byte{pubKey},
 		Epoch:      0,

--- a/beacon-chain/rpc/validator/assignments_test.go
+++ b/beacon-chain/rpc/validator/assignments_test.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"strings"
 	"sync"
@@ -14,10 +15,16 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	dbutil "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
+
+// _pubKey is a helper to generate a well-formed public key.
+func _pubKey(i uint64) []byte {
+	pubKey := make([]byte, params.BeaconConfig().BLSPubkeyLength)
+	binary.LittleEndian.PutUint64(pubKey, uint64(i))
+	return pubKey
+}
 
 func TestGetDuties_NextEpoch_WrongPubkeyLength(t *testing.T) {
 	db := dbutil.SetupDB(t)
@@ -43,9 +50,8 @@ func TestGetDuties_NextEpoch_WrongPubkeyLength(t *testing.T) {
 		PublicKeys: [][]byte{{1}},
 		Epoch:      0,
 	}
-	want := fmt.Sprintf("expected public key to have length %d", params.BeaconConfig().BLSPubkeyLength)
-	if _, err := Server.GetDuties(context.Background(), req); err != nil && !strings.Contains(err.Error(), want) {
-		t.Errorf("Expected %v, received %v", want, err)
+	if _, err := Server.GetDuties(context.Background(), req); err != nil && !strings.Contains(err.Error(), "incorrect key length") {
+		t.Errorf("Expected \"incorrect key length\", received %v", err)
 	}
 }
 
@@ -67,7 +73,7 @@ func TestGetDuties_NextEpoch_CantFindValidatorIdx(t *testing.T) {
 		SyncChecker: &mockSync.Sync{IsSyncing: false},
 	}
 
-	pubKey := make([]byte, 96)
+	pubKey := _pubKey(99999)
 	req := &ethpb.DutiesRequest{
 		PublicKeys: [][]byte{pubKey},
 		Epoch:      0,
@@ -105,7 +111,7 @@ func TestGetDuties_OK(t *testing.T) {
 	for i := 0; i < len(deposits); i++ {
 		wg.Add(1)
 		go func(index int) {
-			errs <- db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(deposits[index].Data.PublicKey), uint64(index))
+			errs <- db.SaveValidatorIndex(ctx, deposits[index].Data.PublicKey, uint64(index))
 			wg.Done()
 		}(i)
 	}
@@ -182,7 +188,7 @@ func TestGetDuties_CurrentEpoch_ShouldNotFail(t *testing.T) {
 	for i := 0; i < len(deposits); i++ {
 		wg.Add(1)
 		go func(index int) {
-			errs <- db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(deposits[index].Data.PublicKey), uint64(index))
+			errs <- db.SaveValidatorIndex(ctx, deposits[index].Data.PublicKey, uint64(index))
 			wg.Done()
 		}(i)
 	}
@@ -241,7 +247,7 @@ func TestGetDuties_MultipleKeys_OK(t *testing.T) {
 	for i := 0; i < numOfValidators; i++ {
 		wg.Add(1)
 		go func(index int) {
-			errs <- db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(deposits[index].Data.PublicKey), uint64(index))
+			errs <- db.SaveValidatorIndex(ctx, deposits[index].Data.PublicKey, uint64(index))
 			wg.Done()
 		}(i)
 	}
@@ -320,7 +326,7 @@ func BenchmarkCommitteeAssignment(b *testing.B) {
 	for i := 0; i < numOfValidators; i++ {
 		wg.Add(1)
 		go func(index int) {
-			errs <- db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(deposits[index].Data.PublicKey), uint64(index))
+			errs <- db.SaveValidatorIndex(ctx, deposits[index].Data.PublicKey, uint64(index))
 			wg.Done()
 		}(i)
 	}

--- a/beacon-chain/rpc/validator/server.go
+++ b/beacon-chain/rpc/validator/server.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/sync"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -103,7 +102,7 @@ func (vs *Server) WaitForActivation(req *ethpb.ValidatorActivationRequest, strea
 
 // ValidatorIndex is called by a validator to get its index location in the beacon state.
 func (vs *Server) ValidatorIndex(ctx context.Context, req *ethpb.ValidatorIndexRequest) (*ethpb.ValidatorIndexResponse, error) {
-	index, ok, err := vs.BeaconDB.ValidatorIndex(ctx, bytesutil.ToBytes48(req.PublicKey))
+	index, ok, err := vs.BeaconDB.ValidatorIndex(ctx, req.PublicKey)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not fetch validator index: %v", err)
 	}

--- a/beacon-chain/rpc/validator/server_test.go
+++ b/beacon-chain/rpc/validator/server_test.go
@@ -22,7 +22,6 @@ import (
 	mockRPC "github.com/prysmaticlabs/prysm/beacon-chain/rpc/testing"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bls"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
@@ -43,8 +42,8 @@ func TestValidatorIndex_OK(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pubKey := []byte{'A'}
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey), 0); err != nil {
+	pubKey := _pubKey(1)
+	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
 
@@ -90,7 +89,7 @@ func TestWaitForActivation_ContextClosed(t *testing.T) {
 		HeadFetcher:        &mockChain.ChainService{State: beaconState, Root: genesisRoot[:]},
 	}
 	req := &ethpb.ValidatorActivationRequest{
-		PublicKeys: [][]byte{[]byte("A")},
+		PublicKeys: [][]byte{_pubKey(1)},
 	}
 
 	ctrl := gomock.NewController(t)
@@ -125,10 +124,10 @@ func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 	pubKey1 := priv1.PublicKey().Marshal()[:]
 	pubKey2 := priv2.PublicKey().Marshal()[:]
 
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey1), 0); err != nil {
+	if err := db.SaveValidatorIndex(ctx, pubKey1, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey2), 0); err != nil {
+	if err := db.SaveValidatorIndex(ctx, pubKey2, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
 
@@ -167,10 +166,10 @@ func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 	}
 	depositCache := depositcache.NewDepositCache()
 	depositCache.InsertDeposit(ctx, deposit, 10 /*blockNum*/, 0, depositTrie.Root())
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey1), 0); err != nil {
+	if err := db.SaveValidatorIndex(ctx, pubKey1, 0); err != nil {
 		t.Fatalf("could not save validator index: %v", err)
 	}
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey2), 1); err != nil {
+	if err := db.SaveValidatorIndex(ctx, pubKey2, 1); err != nil {
 		t.Fatalf("could not save validator index: %v", err)
 	}
 	vs := &Server{

--- a/beacon-chain/rpc/validator/server_test.go
+++ b/beacon-chain/rpc/validator/server_test.go
@@ -42,7 +42,7 @@ func TestValidatorIndex_OK(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pubKey := _pubKey(1)
+	pubKey := pubKey(1)
 	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestWaitForActivation_ContextClosed(t *testing.T) {
 		HeadFetcher:        &mockChain.ChainService{State: beaconState, Root: genesisRoot[:]},
 	}
 	req := &ethpb.ValidatorActivationRequest{
-		PublicKeys: [][]byte{_pubKey(1)},
+		PublicKeys: [][]byte{pubKey(1)},
 	}
 
 	ctrl := gomock.NewController(t)

--- a/beacon-chain/rpc/validator/status.go
+++ b/beacon-chain/rpc/validator/status.go
@@ -9,7 +9,6 @@ import (
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/traceutil"
 	"go.opencensus.io/trace"
@@ -141,7 +140,7 @@ func (vs *Server) retrieveStatusFromState(
 	if headState == nil {
 		return ethpb.ValidatorStatus(0), 0, errors.New("head state does not exist")
 	}
-	idx, ok, err := vs.BeaconDB.ValidatorIndex(ctx, bytesutil.ToBytes48(pubKey))
+	idx, ok, err := vs.BeaconDB.ValidatorIndex(ctx, pubKey)
 	if err != nil {
 		return ethpb.ValidatorStatus(0), 0, err
 	}

--- a/beacon-chain/rpc/validator/status_test.go
+++ b/beacon-chain/rpc/validator/status_test.go
@@ -25,7 +25,7 @@ func TestValidatorStatus_DepositReceived(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := _pubKey(1)
+	pubKey := pubKey(1)
 	depData := &ethpb.Deposit_Data{
 		PublicKey:             pubKey,
 		Signature:             []byte("hi"),
@@ -72,7 +72,7 @@ func TestValidatorStatus_PendingActive(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := _pubKey(1)
+	pubKey := pubKey(1)
 	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
@@ -151,7 +151,7 @@ func TestValidatorStatus_Active(t *testing.T) {
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
 	ctx := context.Background()
 
-	pubKey := _pubKey(1)
+	pubKey := pubKey(1)
 	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
@@ -230,7 +230,7 @@ func TestValidatorStatus_InitiatedExit(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := _pubKey(1)
+	pubKey := pubKey(1)
 	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestValidatorStatus_Withdrawable(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := _pubKey(1)
+	pubKey := pubKey(1)
 	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
@@ -374,7 +374,7 @@ func TestValidatorStatus_ExitedSlashed(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := _pubKey(1)
+	pubKey := pubKey(1)
 	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
@@ -444,7 +444,7 @@ func TestValidatorStatus_Exited(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := _pubKey(1)
+	pubKey := pubKey(1)
 	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
@@ -519,7 +519,7 @@ func TestValidatorStatus_Exited(t *testing.T) {
 func TestValidatorStatus_UnknownStatus(t *testing.T) {
 	db := dbutil.SetupDB(t)
 	defer dbutil.TeardownDB(t, db)
-	pubKey := _pubKey(1)
+	pubKey := pubKey(1)
 	depositCache := depositcache.NewDepositCache()
 	vs := &Server{
 		DepositFetcher:  depositCache,
@@ -548,7 +548,7 @@ func TestMultipleValidatorStatus_OK(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKeys := [][]byte{_pubKey(1), _pubKey(2), _pubKey(3)}
+	pubKeys := [][]byte{pubKey(1), pubKey(2), pubKey(3)}
 	beaconState := &pbp2p.BeaconState{
 		Slot: 4000,
 		Validators: []*ethpb.Validator{
@@ -570,7 +570,7 @@ func TestMultipleValidatorStatus_OK(t *testing.T) {
 		t.Fatalf("Could not get signing root %v", err)
 	}
 	depData := &ethpb.Deposit_Data{
-		PublicKey:             _pubKey(1),
+		PublicKey:             pubKey(1),
 		Signature:             []byte("hi"),
 		WithdrawalCredentials: []byte("hey"),
 		Amount:                10,
@@ -586,7 +586,7 @@ func TestMultipleValidatorStatus_OK(t *testing.T) {
 	depositCache := depositcache.NewDepositCache()
 	depositCache.InsertDeposit(ctx, dep, 10 /*blockNum*/, 0, depositTrie.Root())
 	depData = &ethpb.Deposit_Data{
-		PublicKey:             _pubKey(3),
+		PublicKey:             pubKey(3),
 		Signature:             []byte("hi"),
 		WithdrawalCredentials: []byte("hey"),
 		Amount:                10,

--- a/beacon-chain/rpc/validator/status_test.go
+++ b/beacon-chain/rpc/validator/status_test.go
@@ -15,7 +15,6 @@ import (
 	dbutil "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	mockPOW "github.com/prysmaticlabs/prysm/beacon-chain/powchain/testing"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
@@ -26,7 +25,7 @@ func TestValidatorStatus_DepositReceived(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := []byte{'A'}
+	pubKey := _pubKey(1)
 	depData := &ethpb.Deposit_Data{
 		PublicKey:             pubKey,
 		Signature:             []byte("hi"),
@@ -73,8 +72,8 @@ func TestValidatorStatus_PendingActive(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := []byte{'A'}
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey), 0); err != nil {
+	pubKey := _pubKey(1)
+	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
 	block := blk.NewGenesisBlock([]byte{})
@@ -152,8 +151,8 @@ func TestValidatorStatus_Active(t *testing.T) {
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
 	ctx := context.Background()
 
-	pubKey := []byte{'A'}
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey), 0); err != nil {
+	pubKey := _pubKey(1)
+	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
 
@@ -231,8 +230,8 @@ func TestValidatorStatus_InitiatedExit(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := []byte{'A'}
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey), 0); err != nil {
+	pubKey := _pubKey(1)
+	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
 
@@ -305,8 +304,8 @@ func TestValidatorStatus_Withdrawable(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := []byte{'A'}
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey), 0); err != nil {
+	pubKey := _pubKey(1)
+	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
 
@@ -375,8 +374,8 @@ func TestValidatorStatus_ExitedSlashed(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := []byte{'A'}
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey), 0); err != nil {
+	pubKey := _pubKey(1)
+	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
 
@@ -445,8 +444,8 @@ func TestValidatorStatus_Exited(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKey := []byte{'A'}
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKey), 0); err != nil {
+	pubKey := _pubKey(1)
+	if err := db.SaveValidatorIndex(ctx, pubKey, 0); err != nil {
 		t.Fatalf("Could not save validator index: %v", err)
 	}
 
@@ -520,7 +519,7 @@ func TestValidatorStatus_Exited(t *testing.T) {
 func TestValidatorStatus_UnknownStatus(t *testing.T) {
 	db := dbutil.SetupDB(t)
 	defer dbutil.TeardownDB(t, db)
-	pubKey := []byte{'A'}
+	pubKey := _pubKey(1)
 	depositCache := depositcache.NewDepositCache()
 	vs := &Server{
 		DepositFetcher:  depositCache,
@@ -549,7 +548,7 @@ func TestMultipleValidatorStatus_OK(t *testing.T) {
 	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
-	pubKeys := [][]byte{{'A'}, {'B'}, {'C'}}
+	pubKeys := [][]byte{_pubKey(1), _pubKey(2), _pubKey(3)}
 	beaconState := &pbp2p.BeaconState{
 		Slot: 4000,
 		Validators: []*ethpb.Validator{
@@ -571,7 +570,7 @@ func TestMultipleValidatorStatus_OK(t *testing.T) {
 		t.Fatalf("Could not get signing root %v", err)
 	}
 	depData := &ethpb.Deposit_Data{
-		PublicKey:             []byte{'A'},
+		PublicKey:             _pubKey(1),
 		Signature:             []byte("hi"),
 		WithdrawalCredentials: []byte("hey"),
 		Amount:                10,
@@ -587,7 +586,7 @@ func TestMultipleValidatorStatus_OK(t *testing.T) {
 	depositCache := depositcache.NewDepositCache()
 	depositCache.InsertDeposit(ctx, dep, 10 /*blockNum*/, 0, depositTrie.Root())
 	depData = &ethpb.Deposit_Data{
-		PublicKey:             []byte{'C'},
+		PublicKey:             _pubKey(3),
 		Signature:             []byte("hi"),
 		WithdrawalCredentials: []byte("hey"),
 		Amount:                10,
@@ -599,10 +598,10 @@ func TestMultipleValidatorStatus_OK(t *testing.T) {
 	depositTrie.Insert(dep.Data.Signature, 15)
 	depositCache.InsertDeposit(context.Background(), dep, 0, 0, depositTrie.Root())
 
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKeys[0]), 0); err != nil {
+	if err := db.SaveValidatorIndex(ctx, pubKeys[0], 0); err != nil {
 		t.Fatalf("could not save validator index: %v", err)
 	}
-	if err := db.SaveValidatorIndex(ctx, bytesutil.ToBytes48(pubKeys[1]), 1); err != nil {
+	if err := db.SaveValidatorIndex(ctx, pubKeys[1], 1); err != nil {
 		t.Fatalf("could not save validator index: %v", err)
 	}
 	vs := &Server{


### PR DESCRIPTION
This patch change the signature of the validator-related methods in `beacon-chain/db/iface/interface.go` from taking arrays to taking slices as their argument for the public key.

There are a few reasons for doing this.  First, every instance of the code that called these functions outside of tests held slices, so wrapped all of the keys in `bytesutil.ToBytes48()` to pass the argument which were then all accessed with `[:]` as the downstream functions also use slices.  So this change reduces unnecessary allocations.

Second, wrapping the keys hid potential issues with keys of incorrect lengths, as `ToBytes48()` will always provide a 48-byte array regardless of the length of the slice.  Storing and retrieving keys will now error if they are of an incorrect size.

Third, arrays are hard-coded to 48 bytes when we store this value in our configuration parameters and would prefer to use that.  The code now checks length against `params.BeaconConfig().BLSPubkeyLength`

The patch also fixes up a number of tests where invalid public keys (e.g. `[]byte{'A'}`) were used.