### PR TITLE
Use db head info for request attestation

### DIFF
--- a/beacon-chain/rpc/validator/attester.go
+++ b/beacon-chain/rpc/validator/attester.go
@@ -56,11 +56,18 @@ func (vs *Server) GetAttestationData(ctx context.Context, req *ethpb.Attestation
 		}
 	}()
 
-	headState, err := vs.HeadFetcher.HeadState(ctx)
+	headState, err := vs.BeaconDB.HeadState(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not retrieve head state: %v", err)
 	}
-	headRoot := vs.HeadFetcher.HeadRoot()
+	headBlock, err := vs.BeaconDB.HeadBlock(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not retrieve head block: %v", err)
+	}
+	headRoot, err := ssz.HashTreeRoot(headBlock.Block)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not hash head block: %v", err)
+	}
 
 	headState, err = state.ProcessSlots(ctx, headState, req.Slot)
 	if err != nil {

--- a/beacon-chain/rpc/validator/attester_test.go
+++ b/beacon-chain/rpc/validator/attester_test.go
@@ -114,6 +114,10 @@ func TestProposeAttestation_IncorrectSignature(t *testing.T) {
 }
 
 func TestGetAttestationData_OK(t *testing.T) {
+	ctx := context.Background()
+	db := dbutil.SetupDB(t)
+	defer dbutil.TeardownDB(t, db)
+
 	block := &ethpb.BeaconBlock{
 		Slot: 3*params.BeaconConfig().SlotsPerEpoch + 1,
 	}
@@ -148,10 +152,20 @@ func TestGetAttestationData_OK(t *testing.T) {
 	beaconState.BlockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
 	beaconState.BlockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
 	attesterServer := &Server{
+		BeaconDB:         db,
 		P2P:              &mockp2p.MockBroadcaster{},
 		SyncChecker:      &mockSync.Sync{IsSyncing: false},
 		AttestationCache: cache.NewAttestationCache(),
 		HeadFetcher:      &mock.ChainService{State: beaconState, Root: blockRoot[:]},
+	}
+	if err := attesterServer.BeaconDB.SaveState(ctx, beaconState, blockRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := attesterServer.BeaconDB.SaveBlock(ctx, &ethpb.SignedBeaconBlock{Block: block}); err != nil {
+		t.Fatal(err)
+	}
+	if err := attesterServer.BeaconDB.SaveHeadBlockRoot(ctx, blockRoot); err != nil {
+		t.Fatal(err)
 	}
 
 	req := &ethpb.AttestationDataRequest{
@@ -199,6 +213,9 @@ func TestAttestationDataAtSlot_handlesFarAwayJustifiedEpoch(t *testing.T) {
 	//
 	// More background: https://github.com/prysmaticlabs/prysm/issues/2153
 	// This test breaks if it doesnt use mainnet config
+	db := dbutil.SetupDB(t)
+	defer dbutil.TeardownDB(t, db)
+	ctx := context.Background()
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
 
@@ -240,10 +257,20 @@ func TestAttestationDataAtSlot_handlesFarAwayJustifiedEpoch(t *testing.T) {
 	beaconState.BlockRoots[1*params.BeaconConfig().SlotsPerEpoch] = epochBoundaryRoot[:]
 	beaconState.BlockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedBlockRoot[:]
 	attesterServer := &Server{
+		BeaconDB:         db,
 		P2P:              &mockp2p.MockBroadcaster{},
 		AttestationCache: cache.NewAttestationCache(),
 		HeadFetcher:      &mock.ChainService{State: beaconState, Root: blockRoot[:]},
 		SyncChecker:      &mockSync.Sync{IsSyncing: false},
+	}
+	if err := attesterServer.BeaconDB.SaveState(ctx, beaconState, blockRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := attesterServer.BeaconDB.SaveBlock(ctx, &ethpb.SignedBeaconBlock{Block: block}); err != nil {
+		t.Fatal(err)
+	}
+	if err := attesterServer.BeaconDB.SaveHeadBlockRoot(ctx, blockRoot); err != nil {
+		t.Fatal(err)
 	}
 
 	req := &ethpb.AttestationDataRequest{


### PR DESCRIPTION
To ensure the correct head info is getting passed to construct attestation