### PR TITLE
Pubsub: Only advance state for validating attestation and proof if different epoch

### DIFF
--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -79,7 +79,8 @@ func (r *Service) validateAggregateAndProof(ctx context.Context, pid peer.ID, ms
 		return false
 	}
 
-	if attSlot > s.Slot {
+	// Only advance state if different epoch as the committee can only change on an epoch transition.
+	if helpers.SlotToEpoch(attSlot) > helpers.SlotToEpoch(s.Slot) {
 		s, err = state.ProcessSlots(ctx, s, attSlot)
 		if err != nil {
 			traceutil.AnnotateError(span, err)


### PR DESCRIPTION
As title describes, only advance the state when there would be an epoch transition. This is because the committee can only change if there is an epoch transition so there is no need to advance empty slots in the same epoch.