### PR TITLE
Do not panic if initial sync fails

### DIFF
--- a/beacon-chain/p2p/peers/BUILD.bazel
+++ b/beacon-chain/p2p/peers/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "@com_github_libp2p_go_libp2p_core//network:go_default_library",
         "@com_github_libp2p_go_libp2p_core//peer:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/beacon-chain/p2p/peers/BUILD.bazel
+++ b/beacon-chain/p2p/peers/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "@com_github_libp2p_go_libp2p_core//network:go_default_library",
         "@com_github_libp2p_go_libp2p_core//peer:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -327,10 +327,12 @@ func (p *Status) BestFinalized(maxPeers int) ([]byte, uint64, []peer.ID) {
 	rootToEpoch := make(map[[32]byte]uint64)
 	for _, pid := range p.Connected() {
 		peerChainState, err := p.ChainState(pid)
-		if err == nil && peerChainState != nil {
-			r := bytesutil.ToBytes32(peerChainState.FinalizedRoot)
-			finalized[r]++
-			rootToEpoch[r] = peerChainState.FinalizedEpoch
+		if peerChainState.FinalizedEpoch > 0 {
+			if err == nil && peerChainState != nil {
+				r := bytesutil.ToBytes32(peerChainState.FinalizedRoot)
+				finalized[r]++
+				rootToEpoch[r] = peerChainState.FinalizedEpoch
+			}
 		}
 	}
 

--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -317,22 +317,19 @@ func (p *Status) Decay() {
 	}
 }
 
-// BestFinalized returns the highest finalized epoch that is agreed upon by the majority of
-// peers. This method may not return the absolute highest finalized, but the finalized epoch in
-// which most peers can serve blocks. Ideally, all peers would be reporting the same finalized
-// epoch.
-// Returns the best finalized root, epoch number, and peers that agree.
-func (p *Status) BestFinalized(maxPeers int) ([]byte, uint64, []peer.ID) {
+// BestFinalized returns the highest finalized epoch equal to or higher than ours that is agreed upon by the majority of peers.
+// This method may not return the absolute highest finalized, but the finalized epoch in which most peers can serve blocks.
+// Ideally, all peers would be reporting the same finalized epoch.
+// Returns the best finalized root, epoch number, and list of peers that agree.
+func (p *Status) BestFinalized(maxPeers int, ourFinalizedEpoch uint64) ([]byte, uint64, []peer.ID) {
 	finalized := make(map[[32]byte]uint64)
 	rootToEpoch := make(map[[32]byte]uint64)
 	for _, pid := range p.Connected() {
 		peerChainState, err := p.ChainState(pid)
-		if peerChainState.FinalizedEpoch > 0 {
-			if err == nil && peerChainState != nil {
-				r := bytesutil.ToBytes32(peerChainState.FinalizedRoot)
-				finalized[r]++
-				rootToEpoch[r] = peerChainState.FinalizedEpoch
-			}
+		if err == nil && peerChainState != nil && peerChainState.FinalizedEpoch >= ourFinalizedEpoch {
+			r := bytesutil.ToBytes32(peerChainState.FinalizedRoot)
+			finalized[r]++
+			rootToEpoch[r] = peerChainState.FinalizedEpoch
 		}
 	}
 

--- a/beacon-chain/p2p/peers/status_test.go
+++ b/beacon-chain/p2p/peers/status_test.go
@@ -378,7 +378,7 @@ func TestBestPeer(t *testing.T) {
 		FinalizedEpoch: 3,
 		FinalizedRoot:  junkRoot[:],
 	})
-	retRoot, retEpoch, _ := p.BestFinalized(15)
+	retRoot, retEpoch, _ := p.BestFinalized(15, 0)
 	if !bytes.Equal(retRoot, expectedRoot[:]) {
 		t.Errorf("Incorrect Finalized Root retrieved; wanted %v but got %v", expectedRoot, retRoot)
 	}
@@ -400,7 +400,7 @@ func TestBestFinalized_returnsMaxValue(t *testing.T) {
 		})
 	}
 
-	_, _, pids := p.BestFinalized(maxPeers)
+	_, _, pids := p.BestFinalized(maxPeers, 0)
 	if len(pids) != maxPeers {
 		t.Fatalf("returned wrong number of peers, wanted %d, got %d", maxPeers, len(pids))
 	}

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -36,14 +36,13 @@ func (r *Service) maintainPeerStatuses() {
 				}
 			}
 		}
-		if !r.initialSync.Syncing() {
-			_, highestEpoch, _ := r.p2p.Peers().BestFinalized(params.BeaconConfig().MaxPeersToSync)
+		for !r.initialSync.Syncing() {
+			_, highestEpoch, _ := r.p2p.Peers().BestFinalized(params.BeaconConfig().MaxPeersToSync, r.chain.HeadSlot()/params.BeaconConfig().SlotsPerEpoch)
 			if helpers.StartSlot(highestEpoch) > r.chain.HeadSlot() {
 				numberOfTimesResyncedCounter.Inc()
 				r.clearPendingSlots()
-				// block until we can resync the node
 				if err := r.initialSync.Resync(); err != nil {
-					log.Errorf("Could not Resync Chain: %v", err)
+					log.Errorf("Could not resync chain: %v", err)
 				}
 			}
 		}


### PR DESCRIPTION
This (hasty) patch stops a panic if a node is interrupted during initial sync and as such doesn't complete sync.  Sync will end without being marked as complete and will continue next run.