### PR TITLE
Aggregate unaggregated with prev aggregated attestations

### DIFF
--- a/beacon-chain/operations/attestations/aggregate.go
+++ b/beacon-chain/operations/attestations/aggregate.go
@@ -24,8 +24,8 @@ func (s *Service) aggregateRoutine() {
 		case <-s.ctx.Done():
 			return
 		case <-ticker.C:
-			unaggregatedAtts := s.pool.UnaggregatedAttestations()
-			if err := s.aggregateAttestations(ctx, unaggregatedAtts); err != nil {
+			attsToBeAggregated := append(s.pool.UnaggregatedAttestations(), s.pool.AggregatedAttestations()...)
+			if err := s.aggregateAttestations(ctx, attsToBeAggregated); err != nil {
 				log.WithError(err).Error("Could not aggregate attestation")
 			}
 		}
@@ -34,25 +34,27 @@ func (s *Service) aggregateRoutine() {
 
 // This aggregates the input attestations via AggregateAttestations helper
 // function.
-func (s *Service) aggregateAttestations(ctx context.Context, unaggregatedAtts []*ethpb.Attestation) error {
+func (s *Service) aggregateAttestations(ctx context.Context, attsToBeAggregated []*ethpb.Attestation) error {
 	ctx, span := trace.StartSpan(ctx, "Operations.attestations.aggregateAttestations")
 	defer span.End()
 
-	unaggregatedAttsByRoot := make(map[[32]byte][]*ethpb.Attestation)
+	attsByRoot := make(map[[32]byte][]*ethpb.Attestation)
 
-	for _, att := range unaggregatedAtts {
+	for _, att := range attsToBeAggregated {
 		attDataRoot, err := ssz.HashTreeRoot(att.Data)
 		if err != nil {
 			return err
 		}
-		unaggregatedAttsByRoot[attDataRoot] = append(unaggregatedAttsByRoot[attDataRoot], att)
+		attsByRoot[attDataRoot] = append(attsByRoot[attDataRoot], att)
 
-		if err := s.pool.DeleteUnaggregatedAttestation(att); err != nil {
-			return err
+		if !helpers.IsAggregated(att) {
+			if err := s.pool.DeleteUnaggregatedAttestation(att); err != nil {
+				return err
+			}
 		}
 	}
 
-	for _, atts := range unaggregatedAttsByRoot {
+	for _, atts := range attsByRoot {
 		aggregatedAtts, err := helpers.AggregateAttestations(atts)
 		if err != nil {
 			return err

--- a/beacon-chain/operations/attestations/aggregate_test.go
+++ b/beacon-chain/operations/attestations/aggregate_test.go
@@ -47,13 +47,13 @@ func TestAggregateAttestations_MultipleAttestationsSameRoot(t *testing.T) {
 	sk := bls.RandKey()
 	sig := sk.Sign([]byte("dummy_test_data"), 0 /*domain*/)
 
-	unaggregatedAtts := []*ethpb.Attestation{
-		{Data: &ethpb.AttestationData{}, AggregationBits: bitfield.Bitlist{0b100001}, Signature: sig.Marshal()},
+	attsToBeAggregated := []*ethpb.Attestation{
+		{Data: &ethpb.AttestationData{}, AggregationBits: bitfield.Bitlist{0b110001}, Signature: sig.Marshal()},
 		{Data: &ethpb.AttestationData{}, AggregationBits: bitfield.Bitlist{0b100010}, Signature: sig.Marshal()},
-		{Data: &ethpb.AttestationData{}, AggregationBits: bitfield.Bitlist{0b100100}, Signature: sig.Marshal()},
+		{Data: &ethpb.AttestationData{}, AggregationBits: bitfield.Bitlist{0b101100}, Signature: sig.Marshal()},
 	}
 
-	if err := s.aggregateAttestations(context.Background(), unaggregatedAtts); err != nil {
+	if err := s.aggregateAttestations(context.Background(), attsToBeAggregated); err != nil {
 		t.Fatal(err)
 	}
 
@@ -61,7 +61,7 @@ func TestAggregateAttestations_MultipleAttestationsSameRoot(t *testing.T) {
 		t.Error("Nothing should be unaggregated")
 	}
 
-	wanted, err := helpers.AggregateAttestations(unaggregatedAtts)
+	wanted, err := helpers.AggregateAttestations(attsToBeAggregated)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,7 +83,7 @@ func TestAggregateAttestations_MultipleAttestationsDifferentRoots(t *testing.T) 
 		{Data: &ethpb.AttestationData{}, AggregationBits: bitfield.Bitlist{0b100001}, Signature: sig.Marshal()},
 		{Data: &ethpb.AttestationData{}, AggregationBits: bitfield.Bitlist{0b100010}, Signature: sig.Marshal()},
 		{Data: &ethpb.AttestationData{Slot: 1}, AggregationBits: bitfield.Bitlist{0b100001}, Signature: sig.Marshal()},
-		{Data: &ethpb.AttestationData{Slot: 1}, AggregationBits: bitfield.Bitlist{0b100100}, Signature: sig.Marshal()},
+		{Data: &ethpb.AttestationData{Slot: 1}, AggregationBits: bitfield.Bitlist{0b100110}, Signature: sig.Marshal()},
 		{Data: &ethpb.AttestationData{Slot: 2}, AggregationBits: bitfield.Bitlist{0b100100}, Signature: sig.Marshal()},
 	}
 


### PR DESCRIPTION
We saw quite a few overlapping attestations in the block (example below). The is due to a node does not reuse the already aggregated attestations to aggregate unaggregated attestation. Therefore overlapping attestations could exist in the aggregated pool. To fix this, at the aggregation interval, we aggregate the unaggregated attestations with the aggregated ones in pool

```
Slot / CommitteeIndex/ Aggregation Bitfield
1527 1 [11111111 01110101 11111111 00101011 11111011 11111111 11111111 01111101 11101001 10011111 11111111 11101111 11111101 11111011 11011111 01111110 00000010]
1527 1 [11111111 01110101 11111111 00101011 11111011 11111111 11111111 01111101 11111001 10111111 11111111 11101111 11111101 11111011 11111111 01111110 00000010]

1550 1 [11000011 00000010 01101000 00000011 01101001 00010011 00000000 11101001 00101000 11100001 00101000 11000100 10000010 01010001 10010000 11010100 00000011]
1550 1 [11000111 11100010 01111000 10110011 01101111 00111011 10000011 11101101 11101110 11101111 11101011 11100110 11011111 01110011 11110000 11111111 00000011]
```

This is also why there's so many attestations in a block:
````
[2020-01-10 06:20:41]  INFO blockchain: Finished applying state transition attestations=62 deposits=0 slot=4303
[2020-01-10 06:20:53]  INFO blockchain: Finished applying state transition attestations=128 deposits=0 slot=4304
[2020-01-10 06:21:22]  INFO blockchain: Finished applying state transition attestations=120 deposits=0 slot=4306
```