### PR TITLE
Add Genesis State Diffing Tool

### DIFF
--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -52,6 +52,7 @@ func NewKVStore(dirPath string) (*Store, error) {
 		}
 		return nil, err
 	}
+	boltDB.AllocSize = 8 * 1024 * 1024
 	blockCache, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1000,           // number of keys to track frequency of (1000).
 		MaxCost:     BlockCacheSize, // maximum cost of cache (1000 Blocks).

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -115,7 +115,7 @@ func NewKVStore(dirPath string) (*Store, error) {
 		return nil, err
 	}
 
-	err = prometheus.Register(createBoltCollector(kv.db))
+	//err = prometheus.Register(createBoltCollector(kv.db))
 
 	return kv, err
 }

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -52,7 +52,6 @@ func NewKVStore(dirPath string) (*Store, error) {
 		}
 		return nil, err
 	}
-	boltDB.AllocSize = 8 * 1024 * 1024
 	blockCache, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1000,           // number of keys to track frequency of (1000).
 		MaxCost:     BlockCacheSize, // maximum cost of cache (1000 Blocks).

--- a/tools/state-diff/BUILD.bazel
+++ b/tools/state-diff/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/prysmaticlabs/prysm/tools/state-diff",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//beacon-chain/db:go_default_library",
+        "//shared/params:go_default_library",
+        "//shared/stateutil:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@in_gopkg_d4l3k_messagediff_v1//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "state-diff",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/state-diff/main.go
+++ b/tools/state-diff/main.go
@@ -1,0 +1,83 @@
+/**
+ * Genesis state differ between two beacon nodes
+ *
+ * Given two beacon nodes' DB's, this tool looks at the differences between their
+ * genesis states, genesis blocks, and genesis state roots for debugging.
+ */
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/prysmaticlabs/prysm/beacon-chain/db"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/stateutil"
+	"gopkg.in/d4l3k/messagediff.v1"
+)
+
+var (
+	datadir1 = flag.String("a", "", "Path to node A's datadir")
+	datadir2 = flag.String("b", "", "Path to node B's datadir")
+)
+
+func main() {
+	params.UseDemoBeaconConfig()
+
+	flag.Parse()
+	db1, err := db.NewDB(*datadir1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	db2, err := db.NewDB(*datadir2)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	s1, err := db1.GenesisState(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	stateRoot1, err := stateutil.HashTreeRootState(s1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	s2, err := db2.GenesisState(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	stateRoot2, err := stateutil.HashTreeRootState(s2)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	gs1, err := db1.GenesisBlock(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	gs2, err := db2.GenesisBlock(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if !proto.Equal(s1, s2) {
+		log.Println(messagediff.PrettyDiff(s1, s2))
+	} else {
+		log.Println("States match")
+	}
+
+	if stateRoot1 != stateRoot2 {
+		log.Printf("State roots mismatch, want %#x got %#x", stateRoot1, stateRoot2)
+	} else {
+		log.Printf("Genesis state roots match, %#x == %#x", stateRoot1, stateRoot2)
+	}
+
+	if !proto.Equal(gs1, gs2) {
+		log.Printf("Genesis block state root mismatch, %v", messagediff.PrettyDiff(gs1, gs2))
+	} else {
+		log.Println("Genesis blocks match")
+	}
+}


### PR DESCRIPTION
Part of #4476 

---

# Description

**Write why you are making the changes in this pull request**

We have no easy way to inspect the difference between two genesis beacon DB's

**Write a summary of the changes you are making**

This PR adds a simple tool to diff two genesis DB's from 2 beacon nodes. Run as follows:

```
bazel run //tools/state-diff -- --a /path/to/datadir1 --b /path/to/datadir2
```
