### PR TITLE
Add epoch filter for fork choice attestation

### DIFF
--- a/beacon-chain/blockchain/forkchoice/service.go
+++ b/beacon-chain/blockchain/forkchoice/service.go
@@ -401,7 +401,6 @@ func (s *Store) filterBlockTree(ctx context.Context, blockRoot [32]byte, filtere
 		return false, nil
 	}
 
-
 	headState, err := s.db.State(ctx, blockRoot)
 	if err != nil {
 		return false, err

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -100,6 +100,8 @@ func (s *Service) processAttestation() {
 	}
 }
 
+// This verifies the epoch of input checkpoint is within current epoch and previous epoch
+// with respect to current time. Returns true if it's within, false if it's not.
 func (s *Service) verifyCheckpointEpoch(c *ethpb.Checkpoint) bool {
 	now := uint64(time.Now().Unix())
 	genesisTime := uint64(s.genesisTime.Unix())

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
@@ -84,6 +86,10 @@ func (s *Service) processAttestation() {
 					log.WithError(err).Error("Could not delete fork choice attestation in pool")
 				}
 
+				if !s.verifyCheckpointEpoch(a.Data.Target) {
+					continue
+				}
+
 				if err := s.ReceiveAttestationNoPubsub(ctx, a); err != nil {
 					log.WithFields(logrus.Fields{
 						"targetRoot": fmt.Sprintf("%#x", a.Data.Target.Root),
@@ -92,4 +98,22 @@ func (s *Service) processAttestation() {
 			}
 		}
 	}
+}
+
+func (s *Service) verifyCheckpointEpoch(c *ethpb.Checkpoint) bool {
+	now := uint64(time.Now().Unix())
+	genesisTime := uint64(s.genesisTime.Unix())
+	currentSlot := (now - genesisTime) / params.BeaconConfig().SecondsPerSlot
+	currentEpoch := helpers.SlotToEpoch(currentSlot)
+
+	var prevEpoch uint64
+	if currentEpoch > 1 {
+		prevEpoch = currentEpoch - 1
+	}
+
+	if c.Epoch != prevEpoch && c.Epoch != currentEpoch {
+		return false
+	}
+
+	return true
 }

--- a/beacon-chain/blockchain/receive_attestation_test.go
+++ b/beacon-chain/blockchain/receive_attestation_test.go
@@ -2,6 +2,7 @@ package blockchain
 
 import (
 	"testing"
+	"time"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
@@ -43,4 +44,20 @@ func TestReceiveAttestationNoPubsub_ProcessCorrectly(t *testing.T) {
 
 	testutil.AssertLogsContain(t, hook, "Saved new head info")
 	testutil.AssertLogsDoNotContain(t, hook, "Broadcasting attestation")
+}
+
+func TestVerifyCheckpointEpoch_Ok(t *testing.T) {
+	db := testDB.SetupDB(t)
+	defer testDB.TeardownDB(t, db)
+
+	chainService := setupBeaconChain(t, db)
+	chainService.genesisTime = time.Now()
+
+	if !chainService.verifyCheckpointEpoch(&ethpb.Checkpoint{}) {
+		t.Error("Wanted true, got false")
+	}
+
+	if chainService.verifyCheckpointEpoch(&ethpb.Checkpoint{Epoch: 1}) {
+		t.Error("Wanted false, got true")
+	}
 }


### PR DESCRIPTION
This fixes #4484 

Although patrikman's go-cache prunes itself every epoch, it's not guaranteed the cache gets pruned at the start the epoch. Because of that, we see a few target epoch missmatch error. This PR added a filter to ensure target epoch is within range before passing it to vote counter