### PR TITLE
Filter block tree verifies block root has state

### DIFF
--- a/beacon-chain/blockchain/forkchoice/service.go
+++ b/beacon-chain/blockchain/forkchoice/service.go
@@ -366,6 +366,10 @@ func (s *Store) getFilterBlockTree(ctx context.Context) (map[[32]byte]*ethpb.Bea
 //    # Otherwise, branch not viable
 //    return False
 func (s *Store) filterBlockTree(ctx context.Context, blockRoot [32]byte, filteredBlocks map[[32]byte]*ethpb.BeaconBlock) (bool, error) {
+	if !s.db.HasState(ctx, blockRoot) {
+		return false, nil
+	}
+
 	ctx, span := trace.StartSpan(ctx, "forkchoice.filterBlockTree")
 	defer span.End()
 	signed, err := s.db.Block(ctx, blockRoot)
@@ -400,7 +404,6 @@ func (s *Store) filterBlockTree(ctx context.Context, blockRoot [32]byte, filtere
 		}
 		return false, nil
 	}
-
 
 	headState, err := s.db.State(ctx, blockRoot)
 	if err != nil {


### PR DESCRIPTION
Here's the edge case I caught at run time. In the case of `process_block` takes longer than `attestation delay` + `process_attestation`. The processed attestation will trigger fork choice but `process_block` is not done. Therefore it'll complain there's no state associated with latest block root. In such case we should return false as the block is ineligible to be accounted for fork choice

The error:
`[2020-01-10 22:44:26] ERROR blockchain: Could not receive attestation in chain service error=no state matching block root e49f52bddde16bb23aad425b47b5e16dea4e00b5007f360983a81ff91b428bb3
`
