### PR TITLE
Fix up attestation pool

### DIFF
--- a/beacon-chain/operations/attestations/aggregate.go
+++ b/beacon-chain/operations/attestations/aggregate.go
@@ -60,15 +60,8 @@ func (s *Service) aggregateAttestations(ctx context.Context, attsToBeAggregated 
 			return err
 		}
 		for _, att := range aggregatedAtts {
-			// In case of aggregation bit overlaps or there's only one
-			// unaggregated att in pool. Not every attestations will
-			// be aggregated.
 			if helpers.IsAggregated(att) {
 				if err := s.pool.SaveAggregatedAttestation(att); err != nil {
-					return err
-				}
-			} else {
-				if err := s.pool.SaveUnaggregatedAttestation(att); err != nil {
 					return err
 				}
 			}

--- a/beacon-chain/operations/attestations/aggregate_test.go
+++ b/beacon-chain/operations/attestations/aggregate_test.go
@@ -33,8 +33,8 @@ func TestAggregateAttestations_SingleAttestation(t *testing.T) {
 		t.Error("Nothing should be aggregated")
 	}
 
-	if !reflect.DeepEqual(unaggregatedAtts, s.pool.UnaggregatedAttestations()) {
-		t.Error("Did not preserve unaggregated attestation")
+	if len(s.pool.UnaggregatedAttestations()) != 0 {
+		t.Error("Unaggregated pool should be empty")
 	}
 }
 
@@ -91,12 +91,8 @@ func TestAggregateAttestations_MultipleAttestationsDifferentRoots(t *testing.T) 
 		t.Fatal(err)
 	}
 
-	wanted, err := helpers.AggregateAttestations([]*ethpb.Attestation{atts[4]})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(wanted, s.pool.UnaggregatedAttestations()) {
-		t.Error("Did not preserve unaggregated attestation")
+	if len(s.pool.UnaggregatedAttestations()) != 0 {
+		t.Error("Unaggregated att pool did not clean up")
 	}
 
 	received := s.pool.AggregatedAttestations()
@@ -105,7 +101,7 @@ func TestAggregateAttestations_MultipleAttestationsDifferentRoots(t *testing.T) 
 	})
 	att1, _ := helpers.AggregateAttestations([]*ethpb.Attestation{atts[0], atts[1]})
 	att2, _ := helpers.AggregateAttestations([]*ethpb.Attestation{atts[2], atts[3]})
-	wanted = append(att1, att2...)
+	wanted := append(att1, att2...)
 	if !reflect.DeepEqual(wanted, s.pool.AggregatedAttestations()) {
 		t.Error("Did not aggregate attestations")
 	}

--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -18,9 +18,8 @@ func (p *AttCaches) SaveAggregatedAttestation(att *ethpb.Attestation) error {
 		return errors.Wrap(err, "could not tree hash attestation")
 	}
 
-	key := string(r[:])
 	var atts []*ethpb.Attestation
-	d, ok := p.aggregatedAtt.Get(key)
+	d, ok := p.aggregatedAtt.Get(string(r[:]))
 	if !ok {
 		atts = make([]*ethpb.Attestation, 0)
 	} else {
@@ -40,7 +39,7 @@ func (p *AttCaches) SaveAggregatedAttestation(att *ethpb.Attestation) error {
 
 	// DefaultExpiration is set to what was given to New(). In this case
 	// it's one epoch.
-	p.aggregatedAtt.Set(key, atts, cache.DefaultExpiration)
+	p.aggregatedAtt.Set(string(r[:]), atts, cache.DefaultExpiration)
 
 	return nil
 }
@@ -99,8 +98,7 @@ func (p *AttCaches) DeleteAggregatedAttestation(att *ethpb.Attestation) error {
 	if err != nil {
 		return errors.Wrap(err, "could not tree hash attestation data")
 	}
-	key := string(r[:])
-	a, ok := p.aggregatedAtt.Get(key)
+	a, ok := p.aggregatedAtt.Get(string(r[:]))
 	if !ok {
 		return nil
 	}
@@ -115,9 +113,9 @@ func (p *AttCaches) DeleteAggregatedAttestation(att *ethpb.Attestation) error {
 		}
 	}
 	if len(filtered) == 0 {
-		p.aggregatedAtt.Delete(key)
+		p.aggregatedAtt.Delete(string(r[:]))
 	} else {
-		p.aggregatedAtt.Set(key, filtered, cache.DefaultExpiration)
+		p.aggregatedAtt.Set(string(r[:]), filtered, cache.DefaultExpiration)
 	}
 
 	return nil

--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -38,8 +38,6 @@ func (p *AttCaches) SaveAggregatedAttestation(att *ethpb.Attestation) error {
 	}
 	atts = append(atts, att)
 
-	// TODO: ensure that the new attestation does not supersede existing attestations.
-
 	// DefaultExpiration is set to what was given to New(). In this case
 	// it's one epoch.
 	p.aggregatedAtt.Set(key, atts, cache.DefaultExpiration)

--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -47,7 +47,7 @@ func (p *AttCaches) SaveAggregatedAttestations(atts []*ethpb.Attestation) error 
 	return nil
 }
 
-// AggregatedAttestations returns the aggregated attestations in cache.
+// AggregatedAttestations returns all the aggregated attestations in cache.
 func (p *AttCaches) AggregatedAttestations() []*ethpb.Attestation {
 	var atts []*ethpb.Attestation
 	for s, i := range p.aggregatedAtt.Items() {
@@ -62,7 +62,7 @@ func (p *AttCaches) AggregatedAttestations() []*ethpb.Attestation {
 	return atts
 }
 
-// AggregatedAttestationsBySlotIndex returns the aggregated attestations in cache,
+// AggregatedAttestationsBySlotIndex returns the all aggregated attestations in cache,
 // filtered by committee index and slot.
 func (p *AttCaches) AggregatedAttestationsBySlotIndex(slot uint64, committeeIndex uint64) []*ethpb.Attestation {
 	var aggregatedAttsBySlotIndex []*ethpb.Attestation
@@ -83,7 +83,7 @@ func (p *AttCaches) AggregatedAttestationsBySlotIndex(slot uint64, committeeInde
 	return aggregatedAttsBySlotIndex
 }
 
-// HasAggregatedAttestation checks if the input attestations has already existed in cache.
+// HasAggregatedAttestation checks if the input attestation has already existed in cache.
 func (p *AttCaches) HasAggregatedAttestation(att *ethpb.Attestation) (bool, error) {
 	r, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {

--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -5,10 +5,14 @@ import (
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 )
 
 // SaveAggregatedAttestation saves an aggregated attestation in cache.
 func (p *AttCaches) SaveAggregatedAttestation(att *ethpb.Attestation) error {
+	if !helpers.IsAggregated(att) {
+		return errors.New("attestation is not aggregated")
+	}
 	r, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {
 		return errors.Wrap(err, "could not tree hash attestation")
@@ -90,6 +94,9 @@ func (p *AttCaches) AggregatedAttestationsBySlotIndex(slot uint64, committeeInde
 
 // DeleteAggregatedAttestation deletes the aggregated attestations in cache.
 func (p *AttCaches) DeleteAggregatedAttestation(att *ethpb.Attestation) error {
+	if !helpers.IsAggregated(att) {
+		return errors.New("attestation is not aggregated")
+	}
 	r, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {
 		return errors.Wrap(err, "could not tree hash attestation data")

--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -5,30 +5,36 @@ import (
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 )
 
 // SaveAggregatedAttestation saves an aggregated attestation in cache.
 func (p *AttCaches) SaveAggregatedAttestation(att *ethpb.Attestation) error {
-	if !helpers.IsAggregated(att) {
-		return errors.New("attestation is not aggregated")
-	}
-
 	r, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {
 		return errors.Wrap(err, "could not tree hash attestation")
 	}
-	key := string(r[:])
 
+	key := string(r[:])
 	var atts []*ethpb.Attestation
-	obj, ok := p.aggregatedAtt.Get(key)
-	if ok {
-		atts, ok = obj.([]*ethpb.Attestation)
+	d, ok := p.aggregatedAtt.Get(key)
+	if !ok {
+		atts = make([]*ethpb.Attestation, 0)
+	} else {
+		atts, ok = d.([]*ethpb.Attestation)
 		if !ok {
-			p.aggregatedAtt.Delete(key)
+			return errors.New("cached value is not of type []*ethpb.Attestation")
+		}
+	}
+
+	// Ensure that this attestation is not already fully contained in an existing attestation.
+	for _, a := range atts {
+		if a.AggregationBits.Contains(att.AggregationBits) {
+			return nil
 		}
 	}
 	atts = append(atts, att)
+
+	// TODO: ensure that the new attestation does not supersede existing attestations.
 
 	// DefaultExpiration is set to what was given to New(). In this case
 	// it's one epoch.
@@ -47,63 +53,94 @@ func (p *AttCaches) SaveAggregatedAttestations(atts []*ethpb.Attestation) error 
 	return nil
 }
 
-// AggregatedAttestations returns all the aggregated attestations in cache.
+// AggregatedAttestations returns the aggregated attestations in cache.
 func (p *AttCaches) AggregatedAttestations() []*ethpb.Attestation {
-	var atts []*ethpb.Attestation
+	atts := make([]*ethpb.Attestation, 0, p.aggregatedAtt.ItemCount())
 	for s, i := range p.aggregatedAtt.Items() {
 		// Type assertion for the worst case. This shouldn't happen.
-		att, ok := i.Object.([]*ethpb.Attestation)
+		a, ok := i.Object.([]*ethpb.Attestation)
 		if !ok {
 			p.aggregatedAtt.Delete(s)
 		}
-		atts = append(atts, att...)
+		atts = append(atts, a...)
 	}
 
 	return atts
 }
 
-// AggregatedAttestationsBySlotIndex returns the all aggregated attestations in cache,
+// AggregatedAttestationsBySlotIndex returns the aggregated attestations in cache,
 // filtered by committee index and slot.
 func (p *AttCaches) AggregatedAttestationsBySlotIndex(slot uint64, committeeIndex uint64) []*ethpb.Attestation {
-	var aggregatedAttsBySlotIndex []*ethpb.Attestation
+	atts := make([]*ethpb.Attestation, 0, p.aggregatedAtt.ItemCount())
 	for s, i := range p.aggregatedAtt.Items() {
 
 		// Type assertion for the worst case. This shouldn't happen.
-		atts, ok := i.Object.([]*ethpb.Attestation)
+		a, ok := i.Object.([]*ethpb.Attestation)
 		if !ok {
 			p.aggregatedAtt.Delete(s)
 		}
-		for _, att := range atts {
-			if slot == att.Data.Slot && committeeIndex == att.Data.CommitteeIndex {
-				aggregatedAttsBySlotIndex = append(aggregatedAttsBySlotIndex, att)
-			}
+
+		if slot == a[0].Data.Slot && committeeIndex == a[0].Data.CommitteeIndex {
+			atts = append(atts, a...)
 		}
 	}
 
-	return aggregatedAttsBySlotIndex
+	return atts
 }
 
-// HasAggregatedAttestation checks if the input attestation has already existed in cache.
+// DeleteAggregatedAttestation deletes the aggregated attestations in cache.
+func (p *AttCaches) DeleteAggregatedAttestation(att *ethpb.Attestation) error {
+	r, err := ssz.HashTreeRoot(att.Data)
+	if err != nil {
+		return errors.Wrap(err, "could not tree hash attestation data")
+	}
+	key := string(r[:])
+	a, ok := p.aggregatedAtt.Get(key)
+	if !ok {
+		return nil
+	}
+	atts, ok := a.([]*ethpb.Attestation)
+	if !ok {
+		return errors.New("cached value is not of type []*ethpb.Attestation")
+	}
+	filtered := make([]*ethpb.Attestation, 0)
+	for _, a := range atts {
+		if !att.AggregationBits.Contains(a.AggregationBits) {
+			filtered = append(filtered, a)
+		}
+	}
+	if len(filtered) == 0 {
+		p.aggregatedAtt.Delete(key)
+	} else {
+		p.aggregatedAtt.Set(key, filtered, cache.DefaultExpiration)
+	}
+
+	return nil
+}
+
+// HasAggregatedAttestation checks if the input attestations has already existed in cache.
 func (p *AttCaches) HasAggregatedAttestation(att *ethpb.Attestation) (bool, error) {
 	r, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {
 		return false, errors.Wrap(err, "could not tree hash attestation")
 	}
-	key := string(r[:])
 
-	obj, ok := p.aggregatedAtt.Get(key)
-	// Verify if we seen this attestation data at all.
-	if !ok {
-		return false, nil
-	} else {
-		atts, ok := obj.([]*ethpb.Attestation)
-		if !ok {
-			p.aggregatedAtt.Delete(key)
+	for k, atts := range p.aggregatedAtt.Items() {
+		if k == string(r[:]) {
+			for _, a := range atts.Object.([]*ethpb.Attestation) {
+				if a.AggregationBits.Contains(att.AggregationBits) {
+					return true, nil
+				}
+			}
 		}
-		// Verify the bit field of the input attestation is fully contained by the pool attestations.
-		for _, a := range atts {
-			if a.AggregationBits.Contains(att.AggregationBits) {
-				return true, nil
+	}
+
+	for k, atts := range p.blockAtt.Items() {
+		if k == string(r[:]) {
+			for _, a := range atts.Object.([]*ethpb.Attestation) {
+				if a.AggregationBits.Contains(att.AggregationBits) {
+					return true, nil
+				}
 			}
 		}
 	}

--- a/beacon-chain/operations/attestations/kv/aggregated_test.go
+++ b/beacon-chain/operations/attestations/kv/aggregated_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,11 +20,9 @@ func TestKV_Aggregated_NotAggregated(t *testing.T) {
 
 	att := &ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b11}}
 
-	if err := cache.SaveAggregatedAttestation(att); err != nil {
-		t.Error(err)
-	}
-	if ok, _ := cache.HasAggregatedAttestation(att); !ok {
-		t.Error("Expected cache to have attestation")
+	wanted := "attestation is not aggregated"
+	if err := cache.SaveAggregatedAttestation(att); !strings.Contains(err.Error(), wanted) {
+		t.Error("Did not received wanted error")
 	}
 }
 

--- a/beacon-chain/operations/attestations/kv/block.go
+++ b/beacon-chain/operations/attestations/kv/block.go
@@ -9,14 +9,34 @@ import (
 
 // SaveBlockAttestation saves an block attestation in cache.
 func (p *AttCaches) SaveBlockAttestation(att *ethpb.Attestation) error {
-	r, err := ssz.HashTreeRoot(att)
+	r, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {
 		return errors.Wrap(err, "could not tree hash attestation")
 	}
 
+	key := string(r[:])
+	var atts []*ethpb.Attestation
+	d, ok := p.blockAtt.Get(key)
+	if !ok {
+		atts = make([]*ethpb.Attestation, 0)
+	} else {
+		atts, ok = d.([]*ethpb.Attestation)
+		if !ok {
+			return errors.New("cached value is not of type []*ethpb.Attestation")
+		}
+	}
+
+	// Ensure that this attestation is not already fully contained in an existing attestation.
+	for _, a := range atts {
+		if a.AggregationBits.Contains(att.AggregationBits) {
+			return nil
+		}
+	}
+	atts = append(atts, att)
+
 	// DefaultExpiration is set to what was given to New(). In this case
 	// it's one epoch.
-	p.blockAtt.Set(string(r[:]), att, cache.DefaultExpiration)
+	p.blockAtt.Set(string(r[:]), atts, cache.DefaultExpiration)
 
 	return nil
 }
@@ -37,11 +57,11 @@ func (p *AttCaches) BlockAttestations() []*ethpb.Attestation {
 	atts := make([]*ethpb.Attestation, 0, p.blockAtt.ItemCount())
 	for s, i := range p.blockAtt.Items() {
 		// Type assertion for the worst case. This shouldn't happen.
-		att, ok := i.Object.(*ethpb.Attestation)
+		att, ok := i.Object.([]*ethpb.Attestation)
 		if !ok {
 			p.blockAtt.Delete(s)
 		}
-		atts = append(atts, att)
+		atts = append(atts, att...)
 	}
 
 	return atts
@@ -49,7 +69,7 @@ func (p *AttCaches) BlockAttestations() []*ethpb.Attestation {
 
 // DeleteBlockAttestation deletes a block attestation in cache.
 func (p *AttCaches) DeleteBlockAttestation(att *ethpb.Attestation) error {
-	r, err := ssz.HashTreeRoot(att)
+	r, err := ssz.HashTreeRoot(att.Data)
 	if err != nil {
 		return errors.Wrap(err, "could not tree hash attestation")
 	}

--- a/beacon-chain/operations/attestations/kv/block.go
+++ b/beacon-chain/operations/attestations/kv/block.go
@@ -14,9 +14,8 @@ func (p *AttCaches) SaveBlockAttestation(att *ethpb.Attestation) error {
 		return errors.Wrap(err, "could not tree hash attestation")
 	}
 
-	key := string(r[:])
 	var atts []*ethpb.Attestation
-	d, ok := p.blockAtt.Get(key)
+	d, ok := p.blockAtt.Get(string(r[:]))
 	if !ok {
 		atts = make([]*ethpb.Attestation, 0)
 	} else {

--- a/beacon-chain/operations/attestations/kv/block_test.go
+++ b/beacon-chain/operations/attestations/kv/block_test.go
@@ -72,7 +72,7 @@ func TestKV_BlockAttestation_CheckExpTime(t *testing.T) {
 	cache := NewAttCaches()
 
 	att := &ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b111}}
-	r, _ := ssz.HashTreeRoot(att)
+	r, _ := ssz.HashTreeRoot(att.Data)
 
 	if err := cache.SaveBlockAttestation(att); err != nil {
 		t.Fatal(err)
@@ -83,7 +83,7 @@ func TestKV_BlockAttestation_CheckExpTime(t *testing.T) {
 		t.Error("Saved att does not exist")
 	}
 
-	receivedAtt := item.(*ethpb.Attestation)
+	receivedAtt := item.([]*ethpb.Attestation)[0]
 	if !proto.Equal(att, receivedAtt) {
 		t.Error("Did not receive correct aggregated att")
 	}

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -1277,8 +1277,8 @@ func TestDeleteAttsInPool_Aggregated(t *testing.T) {
 		AttPool: attestations.NewPool(),
 	}
 
-	aggregatedAtts := []*ethpb.Attestation{{AggregationBits: bitfield.Bitlist{0b01101}}, {AggregationBits: bitfield.Bitlist{0b0111}}}
-	unaggregatedAtts := []*ethpb.Attestation{{AggregationBits: bitfield.Bitlist{0b001}}, {AggregationBits: bitfield.Bitlist{0b0001}}}
+	aggregatedAtts := []*ethpb.Attestation{{AggregationBits: bitfield.Bitlist{0b10101}}, {AggregationBits: bitfield.Bitlist{0b11010}}}
+	unaggregatedAtts := []*ethpb.Attestation{{AggregationBits: bitfield.Bitlist{0b1001}}, {AggregationBits: bitfield.Bitlist{0b0001}}}
 
 	if err := s.AttPool.SaveAggregatedAttestations(aggregatedAtts); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The current attestation pool needs structure changes to better support:
1.) filter out seen attestations from the wire 
2.) attestations to block inclusions 


Change list:
- Updated aggregated attestation pool to `map[HTR(att.Data)]*[]ethpb.Attestation` from `map[HTR(att)]*ethpb.Attestation`
- Updated `HasAggregatedAttestation` to consider bitfield containment 
- Better tests