### PR TITLE
Batch Save Genesis Validators

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -293,12 +293,13 @@ func (s *Service) saveHeadNoDB(ctx context.Context, b *ethpb.SignedBeaconBlock, 
 
 // This gets called when beacon chain is first initialized to save validator indices and pubkeys in db
 func (s *Service) saveGenesisValidators(ctx context.Context, state *pb.BeaconState) error {
+	pubkeys := make([][]byte, len(state.Validators))
+	indices := make([]uint64, len(state.Validators))
 	for i, v := range state.Validators {
-		if err := s.beaconDB.SaveValidatorIndex(ctx, v.PublicKey, uint64(i)); err != nil {
-			return errors.Wrapf(err, "could not save validator index: %d", i)
-		}
+		pubkeys[i] = v.PublicKey
+		indices[i] = uint64(i)
 	}
-	return nil
+	return s.beaconDB.SaveValidatorIndices(ctx, pubkeys, indices)
 }
 
 // This gets called when beacon chain is first initialized to save genesis data (state, block, and more) in db


### PR DESCRIPTION
Instead of writing to the db for each index, we save all the indexes in a single transaction.