### PR TITLE
Log Ethereum 1 deposits before chainstart

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -184,6 +184,13 @@ func (s *Service) ProcessDepositLog(ctx context.Context, depositLog gethTypes.Lo
 			"merkleTreeIndex": index,
 		}).Debug("Deposit registered from deposit contract")
 		validDepositsCount.Inc()
+		// Notify users what is going on, from time to time.
+		if !s.chainStartData.Chainstarted {
+			deposits := len(s.chainStartData.ChainstartDeposits)
+			if deposits%512 == 0 {
+				log.WithField("deposits", deposits).Info("Processing deposits from Ethereum 1 chain")
+			}
+		}
 	} else {
 		log.WithFields(logrus.Fields{
 			"eth1Block":       depositLog.BlockHash.Hex(),


### PR DESCRIPTION
Provide occasional (every 512 deposits) log entries at info level to keep users informed that prysm is still alive and working when users start it up for the first time.

Fixes #4492 and #4498 