### PR TITLE
RPC: Only advance slot when the request is for a future epoch

### DIFF
--- a/beacon-chain/rpc/validator/attester.go
+++ b/beacon-chain/rpc/validator/attester.go
@@ -69,9 +69,11 @@ func (vs *Server) GetAttestationData(ctx context.Context, req *ethpb.Attestation
 		return nil, status.Errorf(codes.Internal, "Could not hash head block: %v", err)
 	}
 
-	headState, err = state.ProcessSlots(ctx, headState, req.Slot)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not process slots up to %d: %v", req.Slot, err)
+	if helpers.CurrentEpoch(headState) < helpers.SlotToEpoch(req.Slot) {
+		headState, err = state.ProcessSlots(ctx, headState, req.Slot)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not process slots up to %d: %v", req.Slot, err)
+		}
 	}
 
 	targetEpoch := helpers.CurrentEpoch(headState)


### PR DESCRIPTION
Accessing the state is only used for the target root which is the root of the epoch start slot of the requested slot. Given this constraint, we only need to advance skip slots if the head state is not in the same epoch as the requested slot.