### PR TITLE
p2p: Check if we are already synced to the current epoch before querying peerstore

### DIFF
--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -36,7 +36,10 @@ func (r *Service) maintainPeerStatuses() {
 				}
 			}
 		}
-		for !r.initialSync.Syncing() {
+		// If our head slot is not in the latest epoch, check peers to determine if we need to
+		// resync with the network.
+		currentSlot := uint64(roughtime.Now().Unix()-r.chain.GenesisTime().Unix()) / params.BeaconConfig().SecondsPerSlot
+		for !r.initialSync.Syncing() && helpers.SlotToEpoch(r.chain.HeadSlot()) < helpers.SlotToEpoch(currentSlot) {
 			_, highestEpoch, _ := r.p2p.Peers().BestFinalized(params.BeaconConfig().MaxPeersToSync, helpers.SlotToEpoch(r.chain.HeadSlot()))
 			if helpers.StartSlot(highestEpoch) > r.chain.HeadSlot() {
 				numberOfTimesResyncedCounter.Inc()


### PR DESCRIPTION
Iterating over all of the peer statuses is not useful when you are already synced to the current epoch. This change aims to save some CPU time when this method is run. 

cc: @mcdee 