### PR TITLE
Filter attestation with ProcessAttestationNoSignatureVerify

### DIFF
--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -358,10 +358,10 @@ func (vs *Server) filterAttestationsForBlockInclusion(ctx context.Context, slot 
 			break
 		}
 
-		// TODO(4512): Until we align bls lib to latest IETF spec and has `FastAggregateVerify`,
+		// TODO(4512): Until we align bls lib to latest IETF spec with `FastAggregateVerify`,
 		// we assume complete honest model and skip attestation's signature verification before
 		// including in block. We do verify everything about the attestation and just not
-		// the signature.
+		// its signature.
 		if _, err := blocks.ProcessAttestationNoVerify(ctx, bState, att); err != nil {
 			inValidAtts = append(inValidAtts, att)
 			continue

--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -358,7 +358,11 @@ func (vs *Server) filterAttestationsForBlockInclusion(ctx context.Context, slot 
 			break
 		}
 
-		if _, err := blocks.ProcessAttestation(ctx, bState, att); err != nil {
+		// TODO(4512): Until we align bls lib to latest IETF spec and has `FastAggregateVerify`,
+		// we assume complete honest model and skip attestation's signature verification before
+		// including in block. We do verify everything about the attestation and just not
+		// the signature.
+		if _, err := blocks.ProcessAttestationNoVerify(ctx, bState, att); err != nil {
 			inValidAtts = append(inValidAtts, att)
 			continue
 

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -1050,7 +1050,7 @@ func TestFilterAttestation_OK(t *testing.T) {
 		aggBits.SetBitAt(0, true)
 		atts[i] = &ethpb.Attestation{Data: &ethpb.AttestationData{
 			CommitteeIndex: uint64(i),
-			Target:         &ethpb.Checkpoint{},
+			Target:         &ethpb.Checkpoint{Epoch: 1},
 			Source:         &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}},
 			AggregationBits: aggBits,
 		}
@@ -1075,7 +1075,7 @@ func TestFilterAttestation_OK(t *testing.T) {
 		}
 		atts[i].Signature = bls.AggregateSignatures(sigs).Marshal()[:]
 	}
-
+	atts[0].Data.Target.Epoch = 0
 	received, err = proposerServer.filterAttestationsForBlockInclusion(context.Background(), 1, atts)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This alleviates #4507

Uses `ProcessAttestationNoVerify` instead of `ProcessAttestation`, the only difference is missing signature verification.  And we will switch back to `ProcessAttestation` after #4512 is implemented.
`ProcessAttestationNoVerify` verifies everything except for attestation signature which is sufficient enough for current testnet