### PR TITLE
Revert "ReceiveBlock: Only retrieve head block from DB if necessary"

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -85,19 +85,16 @@ func (s *Service) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.SignedB
 	if err != nil {
 		return errors.Wrap(err, "could not get head from fork choice service")
 	}
+	signedHeadBlock, err := s.beaconDB.Block(ctx, bytesutil.ToBytes32(headRoot))
+	if err != nil {
+		return errors.Wrap(err, "could not compute state from block head")
+	}
+	if signedHeadBlock == nil || signedHeadBlock.Block == nil {
+		return errors.New("nil head block")
+	}
 
 	// Only save head if it's different than the current head.
 	if !bytes.Equal(headRoot, s.HeadRoot()) {
-		signedHeadBlock, err := s.beaconDB.Block(ctx, bytesutil.ToBytes32(headRoot))
-		if err != nil {
-			return errors.Wrap(err, "could not compute state from block head")
-		}
-		if signedHeadBlock == nil || signedHeadBlock.Block == nil {
-			return errors.New("nil head block")
-		}
-
-		logCompetingBlock(root[:], blockCopy.Block.Slot, headRoot, signedHeadBlock.Block.Slot)
-
 		if err := s.saveHead(ctx, signedHeadBlock, bytesutil.ToBytes32(headRoot)); err != nil {
 			return errors.Wrap(err, "could not save head")
 		}
@@ -120,6 +117,9 @@ func (s *Service) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.SignedB
 
 	// Reports on block and fork choice metrics.
 	s.reportSlotMetrics(blockCopy.Block.Slot)
+
+	// Log if block is a competing block.
+	isCompetingBlock(root[:], blockCopy.Block.Slot, headRoot, signedHeadBlock.Block.Slot)
 
 	// Log state transition data.
 	logStateTransitionData(blockCopy.Block)
@@ -244,12 +244,14 @@ func (s *Service) ReceiveBlockNoVerify(ctx context.Context, block *ethpb.SignedB
 }
 
 // This checks if the block is from a competing chain, emits warning and updates metrics.
-func logCompetingBlock(root []byte, slot uint64, headRoot []byte, headSlot uint64) {
-	log.WithFields(logrus.Fields{
-		"blkSlot":  slot,
-		"blkRoot":  hex.EncodeToString(root[:]),
-		"headSlot": headSlot,
-		"headRoot": hex.EncodeToString(headRoot),
-	}).Warn("Calculated head diffs from new block")
-	competingBlks.Inc()
+func isCompetingBlock(root []byte, slot uint64, headRoot []byte, headSlot uint64) {
+	if !bytes.Equal(root[:], headRoot) {
+		log.WithFields(logrus.Fields{
+			"blkSlot":  slot,
+			"blkRoot":  hex.EncodeToString(root[:]),
+			"headSlot": headSlot,
+			"headRoot": hex.EncodeToString(headRoot),
+		}).Warn("Calculated head diffs from new block")
+		competingBlks.Inc()
+	}
 }


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#4506

The fix didn't seem to consider all scenarios. We see `Calculated head diffs from new block` gets logged every slot. Can we revert this for now and come up with a better solution? See screen shot

![Screen Shot 2020-01-12 at 1 55 03 PM](https://user-images.githubusercontent.com/21316537/72226208-4bdbd300-3543-11ea-90e6-6ecb29c1bfea.png)
