### PR TITLE
Only one handshake at a time with active peers

### DIFF
--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -22,8 +22,8 @@ func (s *Service) AddConnectionHandler(reqFunc func(ctx context.Context, id peer
 
 			// Handle the various pre-existing conditions that will result in us not handshaking.
 			peerConnectionState, err := s.peers.ConnectionState(conn.RemotePeer())
-			if err == nil && peerConnectionState == peers.PeerConnected {
-				log.Debug("Peer already connected; not handshaking again")
+			if err == nil && (peerConnectionState == peers.PeerConnected || peerConnectionState == peers.PeerConnecting) {
+				log.WithField("currentState", peerConnectionState).Debug("Peer already active; not handshaking again")
 				return
 			}
 			s.peers.Add(conn.RemotePeer(), conn.RemoteMultiaddr(), conn.Stat().Direction)


### PR DESCRIPTION
Handshaking has protection against attempts from already-connected peers that attempt to handshake again.  This extends the protection to peers that attempt to connect again whilst going through the connection process (_i.e_. a second attempt to connect before the first attempt has completed).