### PR TITLE
PR #4502 take two

### DIFF
--- a/beacon-chain/blockchain/forkchoice/lmd_ghost_yaml_test.go
+++ b/beacon-chain/blockchain/forkchoice/lmd_ghost_yaml_test.go
@@ -11,6 +11,7 @@ import (
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -30,6 +31,7 @@ type Config struct {
 }
 
 func TestGetHeadFromYaml(t *testing.T) {
+	helpers.ClearCache()
 	ctx := context.Background()
 	filename, _ := filepath.Abs("./lmd_ghost_test.yaml")
 	yamlFile, err := ioutil.ReadFile(filename)
@@ -104,7 +106,7 @@ func TestGetHeadFromYaml(t *testing.T) {
 			validators[i] = &ethpb.Validator{ExitEpoch: 2, EffectiveBalance: 1e9}
 		}
 
-		s := &pb.BeaconState{Validators: validators}
+		s := &pb.BeaconState{Validators: validators, RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)}
 
 		if err := store.db.SaveState(ctx, s, bytesutil.ToBytes32(blksRoot[0])); err != nil {
 			t.Fatal(err)

--- a/beacon-chain/blockchain/forkchoice/process_block.go
+++ b/beacon-chain/blockchain/forkchoice/process_block.go
@@ -135,10 +135,8 @@ func (s *Store) OnBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock) er
 		reportEpochMetrics(postState)
 
 		// Update committees cache at epoch boundary slot.
-		if featureconfig.Get().EnableNewCache {
-			if err := helpers.UpdateCommitteeCache(postState, helpers.CurrentEpoch(postState)); err != nil {
-				return err
-			}
+		if err := helpers.UpdateCommitteeCache(postState, helpers.CurrentEpoch(postState)); err != nil {
+			return err
 		}
 
 		s.nextEpochBoundarySlot = helpers.StartSlot(helpers.NextEpoch(postState))

--- a/beacon-chain/blockchain/forkchoice/service_test.go
+++ b/beacon-chain/blockchain/forkchoice/service_test.go
@@ -11,11 +11,13 @@ import (
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/stateutil"
 )
 
@@ -137,6 +139,7 @@ func TestStore_AncestorNotPartOfTheChain(t *testing.T) {
 }
 
 func TestStore_LatestAttestingBalance(t *testing.T) {
+	helpers.ClearCache()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
 	defer testDB.TeardownDB(t, db)
@@ -153,7 +156,7 @@ func TestStore_LatestAttestingBalance(t *testing.T) {
 		validators[i] = &ethpb.Validator{ExitEpoch: 2, EffectiveBalance: 1e9}
 	}
 
-	s := &pb.BeaconState{Validators: validators}
+	s := &pb.BeaconState{Validators: validators, RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)}
 	stateRoot, err := stateutil.HashTreeRootState(s)
 	if err != nil {
 		t.Fatal(err)
@@ -243,6 +246,7 @@ func TestStore_ChildrenBlocksFromParentRoot(t *testing.T) {
 }
 
 func TestStore_GetHead(t *testing.T) {
+	helpers.ClearCache()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
 	defer testDB.TeardownDB(t, db)
@@ -259,7 +263,7 @@ func TestStore_GetHead(t *testing.T) {
 		validators[i] = &ethpb.Validator{ExitEpoch: 2, EffectiveBalance: 1e9}
 	}
 
-	s := &pb.BeaconState{Validators: validators}
+	s := &pb.BeaconState{Validators: validators, RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)}
 	stateRoot, err := stateutil.HashTreeRootState(s)
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -210,10 +210,8 @@ func (s *Service) initializeBeaconChain(
 	log.Info("Initialized beacon chain genesis state")
 
 	// Update committee shuffled indices for genesis epoch.
-	if featureconfig.Get().EnableNewCache {
-		if err := helpers.UpdateCommitteeCache(genesisState, 0 /* genesis epoch */); err != nil {
-			return err
-		}
+	if err := helpers.UpdateCommitteeCache(genesisState, 0 /* genesis epoch */); err != nil {
+		return err
 	}
 
 	return nil

--- a/beacon-chain/cache/feature_flag_test.go
+++ b/beacon-chain/cache/feature_flag_test.go
@@ -4,8 +4,7 @@ import "github.com/prysmaticlabs/prysm/shared/featureconfig"
 
 func init() {
 	featureconfig.Init(&featureconfig.Flags{
-		EnableAttestationCache:   true,
-		EnableEth1DataVoteCache:  true,
-		EnableShuffledIndexCache: true,
+		EnableAttestationCache:  true,
+		EnableEth1DataVoteCache: true,
 	})
 }

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -1135,6 +1135,7 @@ func TestProcessAttestationsNoVerify_OK(t *testing.T) {
 }
 
 func TestConvertToIndexed_OK(t *testing.T) {
+	helpers.ClearCache()
 	validators := make([]*ethpb.Validator, 2*params.BeaconConfig().SlotsPerEpoch)
 	for i := 0; i < len(validators); i++ {
 		validators[i] = &ethpb.Validator{

--- a/beacon-chain/core/blocks/spectest/block_processing_test.go
+++ b/beacon-chain/core/blocks/spectest/block_processing_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params/spectest"
@@ -27,6 +28,7 @@ func runBlockProcessingTest(t *testing.T, config string) {
 	testFolders, testsFolderPath := testutil.TestFolders(t, config, "sanity/blocks/pyspec_tests")
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
+			helpers.ClearCache()
 			preBeaconStateFile, err := testutil.BazelFileBytes(testsFolderPath, folder.Name(), "pre.ssz")
 			if err != nil {
 				t.Fatal(err)

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -105,6 +105,7 @@ func TestUnslashedAttestingIndices_DuplicatedAttestations(t *testing.T) {
 }
 
 func TestAttestingBalance_CorrectBalance(t *testing.T) {
+	helpers.ClearCache()
 	// Generate 2 attestations.
 	atts := make([]*pb.PendingAttestation, 2)
 	for i := 0; i < len(atts); i++ {

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
-        "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/roughtime:go_default_library",

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -10,7 +10,6 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
 )
@@ -72,36 +71,32 @@ func BeaconCommitteeFromState(state *pb.BeaconState, slot uint64, committeeIndex
 		return nil, errors.Wrap(err, "could not get seed")
 	}
 
-	if featureconfig.Get().EnableNewCache {
-		indices, err := committeeCache.Committee(slot, seed, committeeIndex)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not interface with committee cache")
-		}
-		if indices != nil {
-			return indices, nil
-		}
+	indices, err := committeeCache.Committee(slot, seed, committeeIndex)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not interface with committee cache")
+	}
+	if indices != nil {
+		return indices, nil
 	}
 
-	indices, err := ActiveValidatorIndices(state, epoch)
+	activeIndices, err := ActiveValidatorIndices(state, epoch)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get active indices")
 	}
 
-	return BeaconCommittee(indices, seed, slot, committeeIndex)
+	return BeaconCommittee(activeIndices, seed, slot, committeeIndex)
 }
 
 // BeaconCommittee returns the crosslink committee of a given slot and committee index. The
 // validator indices and seed are provided as an argument rather than a direct implementation
 // from the spec definition. Having them as an argument allows for cheaper computation run time.
 func BeaconCommittee(validatorIndices []uint64, seed [32]byte, slot uint64, committeeIndex uint64) ([]uint64, error) {
-	if featureconfig.Get().EnableNewCache {
-		indices, err := committeeCache.Committee(slot, seed, committeeIndex)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not interface with committee cache")
-		}
-		if indices != nil {
-			return indices, nil
-		}
+	indices, err := committeeCache.Committee(slot, seed, committeeIndex)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not interface with committee cache")
+	}
+	if indices != nil {
+		return indices, nil
 	}
 
 	committeesPerSlot := SlotCommitteeCount(uint64(len(validatorIndices)))
@@ -438,4 +433,9 @@ func UpdateCommitteeCache(state *pb.BeaconState, epoch uint64) error {
 	}
 
 	return nil
+}
+
+// ClearCache clears the committee cache
+func ClearCache() {
+	committeeCache = cache.NewCommitteesCache()
 }

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -316,6 +316,7 @@ func TestCommitteeAssignment_CanRetrieve(t *testing.T) {
 }
 
 func TestCommitteeAssignment_CantFindValidator(t *testing.T) {
+	ClearCache()
 	validators := make([]*ethpb.Validator, 1)
 	for i := 0; i < len(validators); i++ {
 		validators[i] = &ethpb.Validator{
@@ -338,6 +339,7 @@ func TestCommitteeAssignment_CantFindValidator(t *testing.T) {
 // Test helpers.CommitteeAssignments against the results of helpers.CommitteeAssignment by validator
 // index. Warning: this test is a bit slow!
 func TestCommitteeAssignments_AgreesWithSpecDefinitionMethod(t *testing.T) {
+	ClearCache()
 	// Initialize test with 256 validators, each slot and each index gets 4 validators.
 	validators := make([]*ethpb.Validator, 4*params.BeaconConfig().SlotsPerEpoch)
 	for i := 0; i < len(validators); i++ {
@@ -439,6 +441,7 @@ func TestCommitteeAssignments_CanRetrieve(t *testing.T) {
 
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ClearCache()
 			validatorIndexToCommittee, proposerIndexToSlot, err := CommitteeAssignments(state, SlotToEpoch(tt.slot))
 			if err != nil {
 				t.Fatalf("failed to determine CommitteeAssignments: %v", err)
@@ -549,6 +552,7 @@ func TestVerifyAttestationBitfieldLengths_OK(t *testing.T) {
 	}
 
 	for i, tt := range tests {
+		ClearCache()
 		state.Slot = tt.stateSlot
 		err := VerifyAttestationBitfieldLengths(state, tt.attestation)
 		if tt.verificationFailure {
@@ -606,8 +610,8 @@ func TestShuffledIndices_ShuffleRightLength(t *testing.T) {
 }
 
 func TestUpdateCommitteeCache_CanUpdate(t *testing.T) {
+	ClearCache()
 	c := featureconfig.Get()
-	c.EnableNewCache = true
 	featureconfig.Init(c)
 	defer featureconfig.Init(nil)
 
@@ -835,7 +839,6 @@ func BenchmarkComputeCommittee4000000_WithOutCache(b *testing.B) {
 
 func TestBeaconCommitteeFromState_UpdateCacheForPreviousEpoch(t *testing.T) {
 	c := featureconfig.Get()
-	c.EnableNewCache = true
 	featureconfig.Init(c)
 	defer featureconfig.Init(nil)
 

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -6,7 +6,6 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
@@ -57,18 +56,16 @@ func IsSlashableValidator(validator *ethpb.Validator, epoch uint64) bool {
 //    """
 //    return [ValidatorIndex(i) for i, v in enumerate(state.validators) if is_active_validator(v, epoch)]
 func ActiveValidatorIndices(state *pb.BeaconState, epoch uint64) ([]uint64, error) {
-	if featureconfig.Get().EnableNewCache {
-		seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get seed")
-		}
-		activeIndices, err := committeeCache.ActiveIndices(seed)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not interface with committee cache")
-		}
-		if activeIndices != nil {
-			return activeIndices, nil
-		}
+	seed, err := Seed(state, epoch, params.BeaconConfig().DomainBeaconAttester)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get seed")
+	}
+	activeIndices, err := committeeCache.ActiveIndices(seed)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not interface with committee cache")
+	}
+	if activeIndices != nil {
+		return activeIndices, nil
 	}
 
 	var indices []uint64
@@ -78,10 +75,8 @@ func ActiveValidatorIndices(state *pb.BeaconState, epoch uint64) ([]uint64, erro
 		}
 	}
 
-	if featureconfig.Get().EnableNewCache {
-		if err := UpdateCommitteeCache(state, epoch); err != nil {
-			return nil, errors.Wrap(err, "could not update committee cache")
-		}
+	if err := UpdateCommitteeCache(state, epoch); err != nil {
+		return nil, errors.Wrap(err, "could not update committee cache")
 	}
 
 	return indices, nil

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -159,6 +159,7 @@ func TestBeaconProposerIndex_OK(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		ClearCache()
 		state.Slot = tt.slot
 		result, err := BeaconProposerIndex(state)
 		if err != nil {
@@ -266,6 +267,7 @@ func TestActiveValidatorIndices(t *testing.T) {
 			name: "all_active_epoch_10",
 			args: args{
 				state: &pb.BeaconState{
+					RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 					Validators: []*ethpb.Validator{
 						{
 							ActivationEpoch: 0,
@@ -289,6 +291,7 @@ func TestActiveValidatorIndices(t *testing.T) {
 			name: "some_active_epoch_10",
 			args: args{
 				state: &pb.BeaconState{
+					RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 					Validators: []*ethpb.Validator{
 						{
 							ActivationEpoch: 0,
@@ -312,6 +315,7 @@ func TestActiveValidatorIndices(t *testing.T) {
 			name: "some_active_with_recent_new_epoch_10",
 			args: args{
 				state: &pb.BeaconState{
+					RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 					Validators: []*ethpb.Validator{
 						{
 							ActivationEpoch: 0,
@@ -339,6 +343,7 @@ func TestActiveValidatorIndices(t *testing.T) {
 			name: "some_active_with_recent_new_epoch_10",
 			args: args{
 				state: &pb.BeaconState{
+					RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 					Validators: []*ethpb.Validator{
 						{
 							ActivationEpoch: 0,
@@ -366,6 +371,7 @@ func TestActiveValidatorIndices(t *testing.T) {
 			name: "some_active_with_recent_new_epoch_10",
 			args: args{
 				state: &pb.BeaconState{
+					RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 					Validators: []*ethpb.Validator{
 						{
 							ActivationEpoch: 0,
@@ -400,6 +406,7 @@ func TestActiveValidatorIndices(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ActiveValidatorIndices() got = %v, want %v", got, tt.want)
 			}
+			ClearCache()
 		})
 	}
 }

--- a/beacon-chain/core/state/benchmarks/BUILD.bazel
+++ b/beacon-chain/core/state/benchmarks/BUILD.bazel
@@ -9,7 +9,6 @@ go_test(
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
-        "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
         "//shared/stateutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",

--- a/beacon-chain/core/state/benchmarks/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks/benchmarks_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/stateutil"
 )
@@ -58,11 +57,6 @@ func BenchmarkExecuteStateTransition_FullBlock(b *testing.B) {
 }
 
 func BenchmarkExecuteStateTransition_WithCache(b *testing.B) {
-	config := &featureconfig.Flags{
-		EnableNewCache:           true,
-		EnableShuffledIndexCache: true,
-	}
-	featureconfig.Init(config)
 	SetConfig()
 
 	beaconState, err := beaconState1Epoch()
@@ -98,11 +92,6 @@ func BenchmarkExecuteStateTransition_WithCache(b *testing.B) {
 }
 
 func BenchmarkProcessEpoch_2FullEpochs(b *testing.B) {
-	config := &featureconfig.Flags{
-		EnableNewCache:           true,
-		EnableShuffledIndexCache: true,
-	}
-	featureconfig.Init(config)
 	SetConfig()
 	beaconState, err := beaconState2FullEpochs()
 	if err != nil {

--- a/beacon-chain/rpc/beacon/assignments_test.go
+++ b/beacon-chain/rpc/beacon/assignments_test.go
@@ -52,7 +52,7 @@ func TestServer_ListAssignments_NoResults(t *testing.T) {
 	bs := &Server{
 		BeaconDB: db,
 		HeadFetcher: &mock.ChainService{
-			State: &pbp2p.BeaconState{Slot: 0},
+			State: &pbp2p.BeaconState{Slot: 0, RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)},
 		},
 	}
 	wanted := &ethpb.ValidatorAssignments{
@@ -213,6 +213,7 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_NoArchive(t *testing.
 }
 
 func TestServer_ListAssignments_Pagination_DefaultPageSize_FromArchive(t *testing.T) {
+	helpers.ClearCache()
 	db := dbTest.SetupDB(t)
 	defer dbTest.TeardownDB(t, db)
 
@@ -330,6 +331,7 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_FromArchive(t *testin
 }
 
 func TestServer_ListAssignments_FilterPubkeysIndices_NoPagination(t *testing.T) {
+	helpers.ClearCache()
 	db := dbTest.SetupDB(t)
 	defer dbTest.TeardownDB(t, db)
 

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -1517,7 +1517,7 @@ func setupValidators(t *testing.T, db db.Database, count int) ([]*ethpb.Validato
 	}
 	if err := db.SaveState(
 		context.Background(),
-		&pbp2p.BeaconState{Validators: validators, Balances: balances},
+		&pbp2p.BeaconState{Validators: validators, Balances: balances, RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)},
 		blockRoot,
 	); err != nil {
 		t.Fatal(err)

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -38,12 +38,10 @@ type Flags struct {
 	EnableSavingOfDepositData bool   // EnableSavingOfDepositData allows the saving of eth1 related data such as deposits,chain data to be saved.
 
 	// Cache toggles.
-	EnableAttestationCache   bool // EnableAttestationCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
-	EnableEth1DataVoteCache  bool // EnableEth1DataVoteCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
-	EnableNewCache           bool // EnableNewCache enables the node to use the new caching scheme.
-	EnableShuffledIndexCache bool // EnableShuffledIndexCache to cache expensive shuffled index computation.
-	EnableSkipSlotsCache     bool // EnableSkipSlotsCache caches the state in skipped slots.
-	EnableSlasherConnection  bool // EnableSlasher enable retrieval of slashing events from a slasher instance.
+	EnableAttestationCache  bool // EnableAttestationCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
+	EnableEth1DataVoteCache bool // EnableEth1DataVoteCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
+	EnableSkipSlotsCache    bool // EnableSkipSlotsCache caches the state in skipped slots.
+	EnableSlasherConnection bool // EnableSlasher enable retrieval of slashing events from a slasher instance.
 }
 
 var featureConfig *Flags
@@ -92,10 +90,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	} else {
 		cfg.InitSyncNoVerify = true
 	}
-	if ctx.GlobalBool(NewCacheFlag.Name) {
-		log.Warn("Using new cache for committee shuffled indices")
-		cfg.EnableNewCache = true
-	}
 	if ctx.GlobalBool(SkipBLSVerifyFlag.Name) {
 		log.Warn("UNSAFE: Skipping BLS verification at runtime")
 		cfg.SkipBLSVerify = true
@@ -103,10 +97,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.GlobalBool(enableBackupWebhookFlag.Name) {
 		log.Warn("Allowing database backups to be triggered from HTTP webhook.")
 		cfg.EnableBackupWebhook = true
-	}
-	if ctx.GlobalBool(enableShuffledIndexCache.Name) {
-		log.Warn("Enabled shuffled index cache.")
-		cfg.EnableShuffledIndexCache = true
 	}
 	if ctx.GlobalBool(enableSkipSlotsCache.Name) {
 		log.Warn("Enabled skip slots cache.")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -24,15 +24,6 @@ var (
 		Name:  "enable-eth1-data-vote-cache",
 		Usage: "Enable unsafe cache mechanism. See https://github.com/prysmaticlabs/prysm/issues/3106",
 	}
-	enableShuffledIndexCache = cli.BoolFlag{
-		Name:  "enable-shuffled-index-cache",
-		Usage: "Enable unsafe cache mechanism. See https://github.com/prysmaticlabs/prysm/issues/3106",
-	}
-	// NewCacheFlag enables the node to use the new caching scheme.
-	NewCacheFlag = cli.BoolFlag{
-		Name:  "new-cache",
-		Usage: "Use the new shuffled indices cache for committee. Much improvement than previous caching implementations",
-	}
 	// SkipBLSVerifyFlag skips BLS signature verification across the runtime for development purposes.
 	SkipBLSVerifyFlag = cli.BoolFlag{
 		Name:  "skip-bls-verify",
@@ -150,6 +141,17 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedNewCacheFlag = cli.BoolFlag{
+		Name:   "new-cache",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
+	deprecatedEnableShuffledIndexCache = cli.BoolFlag{
+		Name:  "enable-shuffled-index-cache",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
+
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -166,6 +168,8 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedEnableBLSPubkeyCacheFlag,
 	deprecatedFastCommitteeAssignmentsFlag,
 	deprecatedGenesisDelayFlag,
+	deprecatedNewCacheFlag,
+	deprecatedEnableShuffledIndexCache,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -182,11 +186,9 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	EnableEth1DataVoteCacheFlag,
 	initSyncVerifyEverythingFlag,
 	initSyncCacheState,
-	NewCacheFlag,
 	SkipBLSVerifyFlag,
 	kafkaBootstrapServersFlag,
 	enableBackupWebhookFlag,
-	enableShuffledIndexCache,
 	enableSkipSlotsCache,
 	saveDepositData,
 	enableSlasherFlag,

--- a/shared/testutil/spectest.go
+++ b/shared/testutil/spectest.go
@@ -14,6 +14,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"gopkg.in/d4l3k/messagediff.v1"
 )
@@ -93,6 +94,7 @@ func RunBlockOperationTest(
 		t.Fatal(err)
 	}
 
+	helpers.ClearCache()
 	beaconState, err := operationFn(context.Background(), preState, body)
 	if postSSZExists {
 		if err != nil {


### PR DESCRIPTION
Redo for #4502.

This PR is the same changes from #4502 but also deprecates the shuffled index cache which is no longer used. 

#4502 was reverted quickly due to seemingly irrelevant changes. The --enable-shuffled-index-cache is safe to deprecate as well.