### PR TITLE
cli: Added flag for GRPC max msg size

### DIFF
--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -55,6 +55,11 @@ var (
 		Name:  "graffiti",
 		Usage: "String to include in proposed blocks",
 	}
+	// GrpcMaxCallRecvMsgSizeFlag defines the max call message size for GRPC
+	GrpcMaxCallRecvMsgSizeFlag = cli.IntFlag{
+		Name:  "grpc-max-msg-size",
+		Usage: "Integer to define max recieve message call size (default: 52428800 (for 50Mb)).",
+	}
 )
 
 func homeDir() string {

--- a/validator/main.go
+++ b/validator/main.go
@@ -44,6 +44,7 @@ var appFlags = []cli.Flag{
 	flags.UnencryptedKeysFlag,
 	flags.InteropStartIndex,
 	flags.InteropNumValidators,
+	flags.GrpcMaxCallRecvMsgSizeFlag,
 	cmd.VerbosityFlag,
 	cmd.DataDirFlag,
 	cmd.ClearDB,

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -168,13 +168,15 @@ func (s *ValidatorClient) registerClientService(ctx *cli.Context, keyManager key
 	logValidatorBalances := !ctx.GlobalBool(flags.DisablePenaltyRewardLogFlag.Name)
 	cert := ctx.GlobalString(flags.CertFlag.Name)
 	graffiti := ctx.GlobalString(flags.GraffitiFlag.Name)
+	maxCallRecvMsgSize := ctx.GlobalInt(flags.GrpcMaxCallRecvMsgSizeFlag.Name)
 	v, err := client.NewValidatorService(context.Background(), &client.Config{
-		Endpoint:             endpoint,
-		DataDir:              dataDir,
-		KeyManager:           keyManager,
-		LogValidatorBalances: logValidatorBalances,
-		CertFlag:             cert,
-		GraffitiFlag:         graffiti,
+		Endpoint:                   endpoint,
+		DataDir:                    dataDir,
+		KeyManager:                 keyManager,
+		LogValidatorBalances:       logValidatorBalances,
+		CertFlag:                   cert,
+		GraffitiFlag:               graffiti,
+		GrpcMaxCallRecvMsgSizeFlag: maxCallRecvMsgSize,
 	})
 	if err != nil {
 		return errors.Wrap(err, "could not initialize client service")

--- a/validator/usage.go
+++ b/validator/usage.go
@@ -81,6 +81,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.DisablePenaltyRewardLogFlag,
 			flags.UnencryptedKeysFlag,
 			flags.GraffitiFlag,
+			flags.GrpcMaxCallRecvMsgSizeFlag,
 		},
 	},
 	{


### PR DESCRIPTION
I have added a flag `grpc-max-msg-size` for setting GRPC msg size through the command line.

[Resolves] #4444