### PR TITLE
Ignore VI swapfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ bazel-*
 .DS_Store
 .swp
 
+# Ignore VI/Vim swapfiles
+.*.sw?
+
 # IntelliJ
 .idea
 .ijwb


### PR DESCRIPTION
A previous commit of mine included a vim swapfile by accident.  This patch adds swapfiles to the list of ignored files for git so it won't happen again.