### PR TITLE
Revert "Filter attestation with ProcessAttestationNoSignatureVerify"

### DIFF
--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -350,11 +350,7 @@ func (vs *Server) filterAttestationsForBlockInclusion(ctx context.Context, slot 
 			break
 		}
 
-		// TODO(4512): Until we align bls lib to latest IETF spec with `FastAggregateVerify`,
-		// we assume complete honest model and skip attestation's signature verification before
-		// including in block. We do verify everything about the attestation and just not
-		// its signature.
-		if _, err := blocks.ProcessAttestationNoVerify(ctx, bState, att); err != nil {
+		if _, err := blocks.ProcessAttestation(ctx, bState, att); err != nil {
 			inValidAtts = append(inValidAtts, att)
 			continue
 

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -1051,7 +1051,7 @@ func TestFilterAttestation_OK(t *testing.T) {
 		aggBits.SetBitAt(0, true)
 		atts[i] = &ethpb.Attestation{Data: &ethpb.AttestationData{
 			CommitteeIndex: uint64(i),
-			Target:         &ethpb.Checkpoint{Epoch: 1},
+			Target:         &ethpb.Checkpoint{},
 			Source:         &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}},
 			AggregationBits: aggBits,
 		}
@@ -1076,7 +1076,7 @@ func TestFilterAttestation_OK(t *testing.T) {
 		}
 		atts[i].Signature = bls.AggregateSignatures(sigs).Marshal()[:]
 	}
-	atts[0].Data.Target.Epoch = 0
+
 	received, err = proposerServer.filterAttestationsForBlockInclusion(context.Background(), 1, atts)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#4513

Discussed offline that this could generate blocks that immediately fail. Given that we only mark attestations as "deleted" from the pool on a successful block inclusion, we could end up with a stalled chain until that attestation is no longer valid. We're also not observing much improvement in GetBlock latency times with this change and we believe the bottleneck is in redundant computation of ProposerIndex. 