### PR TITLE
pubsub: Only advance to the correct epoch

### DIFF
--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -81,7 +81,7 @@ func (r *Service) validateAggregateAndProof(ctx context.Context, pid peer.ID, ms
 
 	// Only advance state if different epoch as the committee can only change on an epoch transition.
 	if helpers.SlotToEpoch(attSlot) > helpers.SlotToEpoch(s.Slot) {
-		s, err = state.ProcessSlots(ctx, s, attSlot)
+		s, err = state.ProcessSlots(ctx, s, helpers.StartSlot(helpers.SlotToEpoch(attSlot)))
 		if err != nil {
 			traceutil.AnnotateError(span, err)
 			return false


### PR DESCRIPTION
The state must be on the same epoch as the attestation, but does not have to advance all the way to the same slot. If we are behind by less than one epoch then this could be a non-trivial improvement. 