### PR TITLE
Increment Metric at the Start of Validation

### DIFF
--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -166,8 +166,6 @@ func (r *Service) subscribeWithBase(base proto.Message, topic string, validator 
 				continue
 			}
 
-			messageReceivedCounter.WithLabelValues(topic).Inc()
-
 			go pipeline(msg)
 		}
 	}
@@ -181,6 +179,7 @@ func (r *Service) subscribeWithBase(base proto.Message, topic string, validator 
 func wrapAndReportValidation(topic string, v pubsub.Validator) (string, pubsub.Validator) {
 	return topic, func(ctx context.Context, pid peer.ID, msg *pubsub.Message) bool {
 		defer messagehandler.HandlePanic(ctx, msg)
+		messageReceivedCounter.WithLabelValues(topic).Inc()
 		b := v(ctx, pid, msg)
 		if !b {
 			messageFailedValidationCounter.WithLabelValues(topic).Inc()


### PR DESCRIPTION
To ensure the message received metrics are accurate, we increment whenever we receive any message from gossipsub.