### PR TITLE
Rate limiter for rpc beacon blocks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1473,3 +1473,10 @@ go_repository(
     commit = "d7df74196a9e781ede915320c11c378c1b2f3a1f",
     importpath = "github.com/cespare/xxhash",
 )
+
+go_repository(
+    name = "com_github_kevinms_leakybucket_go",
+    importpath = "github.com/kevinms/leakybucket-go",
+    sum = "h1:oq6BiN7v0MfWCRcJAxSV+hesVMAAV8COrQbTjYNnso4=",
+    version = "v0.0.0-20190611015032-8a3d0352aa79",
+)

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -116,6 +116,7 @@ go_test(
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_kevinms_leakybucket_go//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//network:go_default_library",
         "@com_github_libp2p_go_libp2p_core//protocol:go_default_library",

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -56,6 +56,7 @@ go_library(
         "//shared/slotutil:go_default_library",
         "//shared/traceutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_kevinms_leakybucket_go//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//network:go_default_library",
         "@com_github_libp2p_go_libp2p_core//peer:go_default_library",

--- a/beacon-chain/sync/error.go
+++ b/beacon-chain/sync/error.go
@@ -9,6 +9,7 @@ import (
 )
 
 const genericError = "internal service error"
+const rateLimitedError = "rate limited"
 
 var errWrongForkVersion = errors.New("wrong fork version")
 var errInvalidEpoch = errors.New("invalid epoch")

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -13,7 +13,6 @@ import (
 	"go.opencensus.io/trace"
 )
 
-
 // beaconBlocksByRangeRPCHandler looks up the request blocks from the database from a given start block.
 func (r *Service) beaconBlocksByRangeRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
 	ctx, span := trace.StartSpan(ctx, "sync.BeaconBlocksByRangeHandler")

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -42,7 +42,7 @@ func (r *Service) beaconBlocksByRangeRPCHandler(ctx context.Context, msg interfa
 		r.p2p.Peers().IncrementBadResponses(stream.Conn().RemotePeer())
 		if r.p2p.Peers().IsBad(stream.Conn().RemotePeer()) {
 			log.Debug("Disconnecting bad peer")
-			r.p2p.Disconnect(stream.Conn().RemotePeer())
+			defer r.p2p.Disconnect(stream.Conn().RemotePeer())
 		}
 		resp, err := r.generateErrorResponse(responseCodeInvalidRequest, rateLimitedError)
 		if err != nil {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -39,6 +39,11 @@ func (r *Service) beaconBlocksByRangeRPCHandler(ctx context.Context, msg interfa
 	)
 
 	if m.Count > uint64(remainingBucketCapacity) {
+		r.p2p.Peers().IncrementBadResponses(stream.Conn().RemotePeer())
+		if r.p2p.Peers().IsBad(stream.Conn().RemotePeer()) {
+			log.Debug("Disconnecting bad peer")
+			r.p2p.Disconnect(stream.Conn().RemotePeer())
+		}
 		return errors.New("rate limited")
 	}
 

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kevinms/leakybucket-go"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/protocol"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -38,7 +39,7 @@ func TestBeaconBlocksRPCHandler_ReturnsBlocks(t *testing.T) {
 		}
 	}
 
-	r := &Service{p2p: p1, db: d}
+	r := &Service{p2p: p1, db: d, blocksRateLimiter: leakybucket.NewCollector(10000, 10000, false)}
 	pcl := protocol.ID("/testing")
 
 	var wg sync.WaitGroup

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -68,7 +68,7 @@ func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		r.p2p.Peers().IncrementBadResponses(stream.Conn().RemotePeer())
 		if r.p2p.Peers().IsBad(stream.Conn().RemotePeer()) {
 			log.Debug("Disconnecting bad peer")
-			r.p2p.Disconnect(stream.Conn().RemotePeer())
+			defer r.p2p.Disconnect(stream.Conn().RemotePeer())
 		}
 		resp, err := r.generateErrorResponse(responseCodeInvalidRequest, rateLimitedError)
 		if err != nil {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -70,7 +70,15 @@ func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 			log.Debug("Disconnecting bad peer")
 			r.p2p.Disconnect(stream.Conn().RemotePeer())
 		}
-		return errors.New("rate limited")
+		resp, err := r.generateErrorResponse(responseCodeInvalidRequest, rateLimitedError)
+		if err != nil {
+			log.WithError(err).Error("Failed to generate a response error")
+		} else {
+			if _, err := stream.Write(resp); err != nil {
+				log.WithError(err).Errorf("Failed to write to stream")
+			}
+		}
+		return errors.New(rateLimitedError)
 	}
 
 	r.blocksRateLimiter.Add(stream.Conn().RemotePeer().String(), int64(len(blockRoots)))

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -65,6 +65,11 @@ func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 	}
 
 	if int64(len(blockRoots)) > r.blocksRateLimiter.Remaining(stream.Conn().RemotePeer().String()) {
+		r.p2p.Peers().IncrementBadResponses(stream.Conn().RemotePeer())
+		if r.p2p.Peers().IsBad(stream.Conn().RemotePeer()) {
+			log.Debug("Disconnecting bad peer")
+			r.p2p.Disconnect(stream.Conn().RemotePeer())
+		}
 		return errors.New("rate limited")
 	}
 

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -64,6 +64,12 @@ func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		return errors.New("no block roots provided")
 	}
 
+	if int64(len(blockRoots)) > r.blocksRateLimiter.Remaining(stream.Conn().RemotePeer().String()) {
+		return errors.New("rate limited")
+	}
+
+	r.blocksRateLimiter.Add(stream.Conn().RemotePeer().String(), int64(len(blockRoots)))
+
 	for _, root := range blockRoots {
 		blk, err := r.db.Block(ctx, root)
 		if err != nil {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kevinms/leakybucket-go"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/protocol"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -45,7 +46,7 @@ func TestRecentBeaconBlocksRPCHandler_ReturnsBlocks(t *testing.T) {
 		blkRoots = append(blkRoots, root)
 	}
 
-	r := &Service{p2p: p1, db: d}
+	r := &Service{p2p: p1, db: d, blocksRateLimiter: leakybucket.NewCollector(10000, 10000, false)}
 	pcl := protocol.ID("/testing")
 
 	var wg sync.WaitGroup
@@ -118,6 +119,7 @@ func TestRecentBeaconBlocks_RPCRequestSent(t *testing.T) {
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 		ctx:                 context.Background(),
+		blocksRateLimiter:   leakybucket.NewCollector(10000, 10000, false),
 	}
 
 	// Setup streams

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -18,7 +18,7 @@ import (
 var _ = shared.Service(&Service{})
 
 const allowedBlocksPerSecond = 32.0
-const allowedBlocksBurst = 5 * allowedBlocksPerSecond
+const allowedBlocksBurst = 10 * allowedBlocksPerSecond
 
 // Config to set up the regular sync service.
 type Config struct {

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -54,7 +54,7 @@ func NewRegularSync(cfg *Config) *Service {
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 		stateNotifier:       cfg.StateNotifier,
-		blocksRateLimiter:   leakybucket.NewCollector(allowedBlocksPerSecond, allowedBlocksBurst, true /* deleteEmptyBuckets */),
+		blocksRateLimiter:   leakybucket.NewCollector(allowedBlocksPerSecond, allowedBlocksBurst, false /* deleteEmptyBuckets */),
 	}
 
 	r.registerRPCHandlers()

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/kevinms/leakybucket-go"
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain"
@@ -12,13 +13,12 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/shared"
-	"github.com/kevinms/leakybucket-go"
 )
 
 var _ = shared.Service(&Service{})
 
 const allowedBlocksPerSecond = 32.0
-const allowedBlocksBurst = 5*allowedBlocksPerSecond
+const allowedBlocksBurst = 5 * allowedBlocksPerSecond
 
 // Config to set up the regular sync service.
 type Config struct {
@@ -54,7 +54,7 @@ func NewRegularSync(cfg *Config) *Service {
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 		stateNotifier:       cfg.StateNotifier,
-		blocksRateLimiter: leakybucket.NewCollector(allowedBlocksPerSecond, allowedBlocksBurst, true /* deleteEmptyBuckets */),
+		blocksRateLimiter:   leakybucket.NewCollector(allowedBlocksPerSecond, allowedBlocksBurst, true /* deleteEmptyBuckets */),
 	}
 
 	r.registerRPCHandlers()
@@ -79,7 +79,7 @@ type Service struct {
 	initialSync         Checker
 	validateBlockLock   sync.RWMutex
 	stateNotifier       statefeed.Notifier
-	blocksRateLimiter  *leakybucket.Collector
+	blocksRateLimiter   *leakybucket.Collector
 }
 
 // Start the regular sync service.


### PR DESCRIPTION
Key changes:
- Add a leaky bucket type rate limiter of 32 blocks per second with a burst of 160
- Respond to peer with rate limit error
- If peer continues to exceed rate limit, we eventually disconnect them