### PR TITLE
Partially revert #4477

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -115,10 +115,11 @@ func (s *Service) Start() {
 		return
 	}
 	s.waitForMinimumPeers()
-	if err := s.roundRobinSync(genesis); err == nil {
-		log.Infof("Synced up to slot %d", s.chain.HeadSlot())
-		s.synced = true
+	if err := s.roundRobinSync(genesis); err != nil {
+		panic(err)
 	}
+	log.Infof("Synced up to slot %d", s.chain.HeadSlot())
+	s.synced = true
 }
 
 // Stop initial sync.


### PR DESCRIPTION
Panicking may not the best response to an error, but we were silently throwing the error away and doing nothing about it.

Until we have a better approach, let's partially revert #4477 and panic if sync fails.