### PR TITLE
Cleanup featureconfig, make naming consistent

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -1,6 +1,6 @@
 /*
 Package featureconfig defines which features are enabled for runtime
-in order to selctively enable certain features to maintain a stable runtime.
+in order to selectively enable certain features to maintain a stable runtime.
 
 The process for implementing new features using this package is as follows:
 	1. Add a new CMD flag in flags.go, and place it in the proper list(s) var for its client.
@@ -70,7 +70,7 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Starting ETH2 with no genesis delay")
 		cfg.NoGenesisDelay = true
 	}
-	if ctx.GlobalBool(MinimalConfigFlag.Name) {
+	if ctx.GlobalBool(minimalConfigFlag.Name) {
 		log.Warn("Using minimal config")
 		cfg.MinimalConfig = true
 	}
@@ -78,11 +78,11 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Writing SSZ states and blocks after state transitions")
 		cfg.WriteSSZStateTransitions = true
 	}
-	if ctx.GlobalBool(EnableAttestationCacheFlag.Name) {
+	if ctx.GlobalBool(enableAttestationCacheFlag.Name) {
 		log.Warn("Enabled unsafe attestation cache")
 		cfg.EnableAttestationCache = true
 	}
-	if ctx.GlobalBool(EnableEth1DataVoteCacheFlag.Name) {
+	if ctx.GlobalBool(enableEth1DataVoteCacheFlag.Name) {
 		log.Warn("Enabled unsafe eth1 data vote cache")
 		cfg.EnableEth1DataVoteCache = true
 	}
@@ -92,7 +92,7 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	} else {
 		cfg.InitSyncNoVerify = true
 	}
-	if ctx.GlobalBool(SkipBLSVerifyFlag.Name) {
+	if ctx.GlobalBool(skipBLSVerifyFlag.Name) {
 		log.Warn("UNSAFE: Skipping BLS verification at runtime")
 		cfg.SkipBLSVerify = true
 	}
@@ -136,7 +136,7 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 func ConfigureValidator(ctx *cli.Context) {
 	complainOnDeprecatedFlags(ctx)
 	cfg := &Flags{}
-	if ctx.GlobalBool(MinimalConfigFlag.Name) {
+	if ctx.GlobalBool(minimalConfigFlag.Name) {
 		log.Warn("Using minimal config")
 		cfg.MinimalConfig = true
 	}

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -100,7 +100,7 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Allowing database backups to be triggered from HTTP webhook.")
 		cfg.EnableBackupWebhook = true
 	}
-	if ctx.GlobalBool(enableSkipSlotsCache.Name) {
+	if ctx.GlobalBool(enableSkipSlotsCacheFlag.Name) {
 		log.Warn("Enabled skip slots cache.")
 		cfg.EnableSkipSlotsCache = true
 	}
@@ -108,11 +108,11 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Enabling experimental kafka streaming.")
 		cfg.KafkaBootstrapServers = ctx.GlobalString(kafkaBootstrapServersFlag.Name)
 	}
-	if ctx.GlobalBool(initSyncCacheState.Name) {
+	if ctx.GlobalBool(initSyncCacheStateFlag.Name) {
 		log.Warn("Enabled initial sync cache state mode.")
 		cfg.InitSyncCacheState = true
 	}
-	if ctx.GlobalBool(saveDepositData.Name) {
+	if ctx.GlobalBool(saveDepositDataFlag.Name) {
 		log.Warn("Enabled saving of eth1 related chain/deposit data.")
 		cfg.EnableSavingOfDepositData = true
 	}
@@ -120,11 +120,11 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Enable slasher connection.")
 		cfg.EnableSlasherConnection = true
 	}
-	if ctx.GlobalBool(cacheFilteredBlockTree.Name) {
+	if ctx.GlobalBool(cacheFilteredBlockTreeFlag.Name) {
 		log.Warn("Enabled filtered block tree cache for fork choice.")
 		cfg.EnableBlockTreeCache = true
 	}
-	if ctx.GlobalBool(cacheProposerIndices.Name) {
+	if ctx.GlobalBool(cacheProposerIndicesFlag.Name) {
 		log.Warn("Enabled proposer index caching.")
 		cfg.EnableProposerIndexCache = true
 	}

--- a/shared/featureconfig/config_test.go
+++ b/shared/featureconfig/config_test.go
@@ -1,19 +1,18 @@
-package featureconfig_test
+package featureconfig
 
 import (
 	"flag"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/urfave/cli"
 )
 
 func TestInitFeatureConfig(t *testing.T) {
-	cfg := &featureconfig.Flags{
+	cfg := &Flags{
 		MinimalConfig: true,
 	}
-	featureconfig.Init(cfg)
-	if c := featureconfig.Get(); !c.MinimalConfig {
+	Init(cfg)
+	if c := Get(); !c.MinimalConfig {
 		t.Errorf("MinimalConfig in FeatureFlags incorrect. Wanted true, got false")
 	}
 }
@@ -21,10 +20,10 @@ func TestInitFeatureConfig(t *testing.T) {
 func TestConfigureBeaconConfig(t *testing.T) {
 	app := cli.NewApp()
 	set := flag.NewFlagSet("test", 0)
-	set.Bool(featureconfig.minimalConfigFlag.Name, true, "test")
+	set.Bool(minimalConfigFlag.Name, true, "test")
 	context := cli.NewContext(app, set, nil)
-	featureconfig.ConfigureBeaconChain(context)
-	if c := featureconfig.Get(); !c.MinimalConfig {
+	ConfigureBeaconChain(context)
+	if c := Get(); !c.MinimalConfig {
 		t.Errorf("MinimalConfig in FeatureFlags incorrect. Wanted true, got false")
 	}
 }

--- a/shared/featureconfig/config_test.go
+++ b/shared/featureconfig/config_test.go
@@ -21,7 +21,7 @@ func TestInitFeatureConfig(t *testing.T) {
 func TestConfigureBeaconConfig(t *testing.T) {
 	app := cli.NewApp()
 	set := flag.NewFlagSet("test", 0)
-	set.Bool(featureconfig.MinimalConfigFlag.Name, true, "test")
+	set.Bool(featureconfig.minimalConfigFlag.Name, true, "test")
 	context := cli.NewContext(app, set, nil)
 	featureconfig.ConfigureBeaconChain(context)
 	if c := featureconfig.Get(); !c.MinimalConfig {

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -5,8 +5,7 @@ import (
 )
 
 var (
-	// MinimalConfigFlag enables the minimal configuration.
-	MinimalConfigFlag = cli.BoolFlag{
+	minimalConfigFlag = cli.BoolFlag{
 		Name:  "minimal-config",
 		Usage: "Use minimal config with parameters as defined in the spec.",
 	}
@@ -14,18 +13,17 @@ var (
 		Name:  "interop-write-ssz-state-transitions",
 		Usage: "Write ssz states to disk after attempted state transition",
 	}
-	// EnableAttestationCacheFlag see https://github.com/prysmaticlabs/prysm/issues/3106.
-	EnableAttestationCacheFlag = cli.BoolFlag{
+	// enableAttestationCacheFlag see https://github.com/prysmaticlabs/prysm/issues/3106.
+	enableAttestationCacheFlag = cli.BoolFlag{
 		Name:  "enable-attestation-cache",
 		Usage: "Enable unsafe cache mechanism. See https://github.com/prysmaticlabs/prysm/issues/3106",
 	}
-	// EnableEth1DataVoteCacheFlag see https://github.com/prysmaticlabs/prysm/issues/3106.
-	EnableEth1DataVoteCacheFlag = cli.BoolFlag{
+	// enableEth1DataVoteCacheFlag see https://github.com/prysmaticlabs/prysm/issues/3106.
+	enableEth1DataVoteCacheFlag = cli.BoolFlag{
 		Name:  "enable-eth1-data-vote-cache",
 		Usage: "Enable unsafe cache mechanism. See https://github.com/prysmaticlabs/prysm/issues/3106",
 	}
-	// SkipBLSVerifyFlag skips BLS signature verification across the runtime for development purposes.
-	SkipBLSVerifyFlag = cli.BoolFlag{
+	skipBLSVerifyFlag = cli.BoolFlag{
 		Name:  "skip-bls-verify",
 		Usage: "Whether or not to skip BLS verification of signature at runtime, this is unsafe and should only be used for development",
 	}
@@ -33,8 +31,7 @@ var (
 		Name:  "enable-db-backup-webhook",
 		Usage: "Serve HTTP handler to initiate database backups. The handler is served on the monitoring port at path /db/backup.",
 	}
-	// enableSkipSlotsCache enables the skips slots lru cache to be used in runtime.
-	enableSkipSlotsCache = cli.BoolFlag{
+	enableSkipSlotsCacheFlag = cli.BoolFlag{
 		Name:  "enable-skip-slots-cache",
 		Usage: "Enables the skip slot cache to be used in the event of skipped slots.",
 	}
@@ -48,7 +45,7 @@ var (
 			"and attestation's aggregated signatures. Without this flag, only the proposer " +
 			"signature is verified until the node reaches the end of the finalized chain.",
 	}
-	initSyncCacheState = cli.BoolFlag{
+	initSyncCacheStateFlag = cli.BoolFlag{
 		Name: "initial-sync-cache-state",
 		Usage: "Save state in cache during initial sync. We currently save state in the DB during " +
 			"initial sync and disk-IO is one of the biggest bottleneck. This still saves finalized state in DB " +
@@ -56,10 +53,10 @@ var (
 	}
 	enableSlasherFlag = cli.BoolFlag{
 		Name: "enable-slasher",
-		Usage: "Connect to slasher in order to retrieve slashable events. Slasher is connected to beacon node using grpc" +
-			"User should be running slasher on current machine or include slasher-provider flag.",
+		Usage: "Enables connection to a slasher service in order to retrieve slashable events. Slasher is connected to the beacon node using gRPC and " +
+			"the slasher-provider flag can be used to pass its address.",
 	}
-	saveDepositData = cli.BoolFlag{
+	saveDepositDataFlag = cli.BoolFlag{
 		Name:  "save-deposit-data",
 		Usage: "Enable of the saving of deposit related data",
 	}
@@ -69,12 +66,12 @@ var (
 			"triggered the genesis as the genesis time. This flag should be used for local " +
 			"development and testing only.",
 	}
-	cacheFilteredBlockTree = cli.BoolFlag{
+	cacheFilteredBlockTreeFlag = cli.BoolFlag{
 		Name: "cache-filtered-block-tree",
 		Usage: "Cache filtered block tree by maintaining it rather than continually recalculating on the fly, " +
 			"this is used for fork choice.",
 	}
-	cacheProposerIndices = cli.BoolFlag{
+	cacheProposerIndicesFlag = cli.BoolFlag{
 		Name:  "cache-proposer-indices",
 		Usage: "Cache proposer indices on per epoch basis.",
 	}
@@ -89,7 +86,7 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
-	deprecatedOptimizeProcessEpoch = cli.BoolFlag{
+	deprecatedOptimizeProcessEpochFlag = cli.BoolFlag{
 		Name:   "optimize-process-epoch",
 		Usage:  deprecatedUsage,
 		Hidden: true,
@@ -125,7 +122,7 @@ var (
 		Hidden: true,
 	}
 
-	deprecatedEnableCustomStateSSZ = cli.BoolFlag{
+	deprecatedEnableCustomStateSSZFlag = cli.BoolFlag{
 		Name:   "enable-custom-state-ssz",
 		Usage:  deprecatedUsage,
 		Hidden: true,
@@ -155,7 +152,7 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
-	deprecatedEnableShuffledIndexCache = cli.BoolFlag{
+	deprecatedEnableShuffledIndexCacheFlag = cli.BoolFlag{
 		Name:   "enable-shuffled-index-cache",
 		Usage:  deprecatedUsage,
 		Hidden: true,
@@ -166,40 +163,40 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedEnableFinalizedBlockRootIndexFlag,
 	deprecatedScatterFlag,
 	deprecatedPruneFinalizedStatesFlag,
-	deprecatedOptimizeProcessEpoch,
+	deprecatedOptimizeProcessEpochFlag,
 	deprecatedEnableSnappyDBCompressionFlag,
 	deprecatedEnablePruneBoundaryStateFlag,
 	deprecatedEnableActiveIndicesCacheFlag,
 	deprecatedEnableActiveCountCacheFlag,
-	deprecatedEnableCustomStateSSZ,
+	deprecatedEnableCustomStateSSZFlag,
 	deprecatedEnableCommitteeCacheFlag,
 	deprecatedEnableBLSPubkeyCacheFlag,
 	deprecatedFastCommitteeAssignmentsFlag,
 	deprecatedGenesisDelayFlag,
 	deprecatedNewCacheFlag,
-	deprecatedEnableShuffledIndexCache,
+	deprecatedEnableShuffledIndexCacheFlag,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
 var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
-	MinimalConfigFlag,
+	minimalConfigFlag,
 }...)
 
 // BeaconChainFlags contains a list of all the feature flags that apply to the beacon-chain client.
 var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	noGenesisDelayFlag,
-	MinimalConfigFlag,
+	minimalConfigFlag,
 	writeSSZStateTransitionsFlag,
-	EnableAttestationCacheFlag,
-	EnableEth1DataVoteCacheFlag,
+	enableAttestationCacheFlag,
+	enableEth1DataVoteCacheFlag,
 	initSyncVerifyEverythingFlag,
-	initSyncCacheState,
-	SkipBLSVerifyFlag,
+	initSyncCacheStateFlag,
+	skipBLSVerifyFlag,
 	kafkaBootstrapServersFlag,
 	enableBackupWebhookFlag,
-	enableSkipSlotsCache,
-	saveDepositData,
+	enableSkipSlotsCacheFlag,
+	saveDepositDataFlag,
 	enableSlasherFlag,
-	cacheFilteredBlockTree,
-	cacheProposerIndices,
+	cacheFilteredBlockTreeFlag,
+	cacheProposerIndicesFlag,
 }...)


### PR DESCRIPTION
This PR makes the naming of flags more consistent, and unexports all the flag objects since it's not needed at all. 👍  