### PR TITLE
Remove invalid init-sync-no-verify option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ To start your beacon node, issue the following command:
 docker run -it -v $HOME/prysm:/data -p 4000:4000 --name beacon-node \
   gcr.io/prysmaticlabs/prysm/beacon-chain:latest \
   --datadir=/data \
-  --init-sync-no-verify
 ```
 
 The beacon node can be halted by either using `Ctrl+c` or with the command:
@@ -149,7 +148,7 @@ docker run -it -v $HOME/prysm:/data -p 4000:4000 --name beacon-node \
 3. To run the beacon node, issue the following command:
 
 ```text
-docker run -it -v c:/prysm/:/data -p 4000:4000 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --init-sync-no-verify --clear-db
+docker run -it -v c:/prysm/:/data -p 4000:4000 gcr.io/prysmaticlabs/prysm/beacon-chain:latest --datadir=/data --clear-db
 ```
 
 ### Running via Bazel


### PR DESCRIPTION
`init-sync-no-verify` was removed from `beacon-chain` in 32245a906246b8f152368120d932de032e98ac05

[Resolves] #4561