### PR TITLE
Add --rpc-host option to beacon chain

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -27,6 +27,12 @@ var (
 		Name:  "deposit-contract",
 		Usage: "Deposit contract address. Beacon chain node will listen logs coming from the deposit contract to determine when validator is eligible to participate.",
 	}
+	// RPCHost defines the host on which the RPC server should listen.
+	RPCHost = cli.StringFlag{
+		Name:  "rpc-host",
+		Usage: "Host on which the RPC server should listen",
+		Value: "0.0.0.0",
+	}
 	// RPCPort defines a beacon node RPC port to open.
 	RPCPort = cli.IntFlag{
 		Name:  "rpc-port",

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -28,6 +28,7 @@ var appFlags = []cli.Flag{
 	flags.DepositContractFlag,
 	flags.Web3ProviderFlag,
 	flags.HTTPWeb3ProviderFlag,
+	flags.RPCHost,
 	flags.RPCPort,
 	flags.CertFlag,
 	flags.KeyFlag,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -446,6 +446,7 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 		chainStartFetcher = web3Service
 	}
 
+	host := ctx.GlobalString(flags.RPCHost.Name)
 	port := ctx.GlobalString(flags.RPCPort.Name)
 	cert := ctx.GlobalString(flags.CertFlag.Name)
 	key := ctx.GlobalString(flags.KeyFlag.Name)
@@ -454,6 +455,7 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 
 	mockEth1DataVotes := ctx.GlobalBool(flags.InteropMockEth1DataVotesFlag.Name)
 	rpcService := rpc.NewService(context.Background(), &rpc.Config{
+		Host:                  host,
 		Port:                  port,
 		CertFlag:              cert,
 		KeyFlag:               key,

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -65,6 +65,7 @@ type Service struct {
 	mockEth1Votes          bool
 	attestationsPool       attestations.Pool
 	syncService            sync.Checker
+	host                   string
 	port                   string
 	listener               net.Listener
 	withCert               string
@@ -88,6 +89,7 @@ type Service struct {
 
 // Config options for the beacon node RPC server.
 type Config struct {
+	Host                  string
 	Port                  string
 	CertFlag              string
 	KeyFlag               string
@@ -136,6 +138,7 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		mockEth1Votes:         cfg.MockEth1Votes,
 		attestationsPool:      cfg.AttestationsPool,
 		syncService:           cfg.SyncService,
+		host:                  cfg.Host,
 		port:                  cfg.Port,
 		withCert:              cfg.CertFlag,
 		withKey:               cfg.KeyFlag,
@@ -152,12 +155,13 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 
 // Start the gRPC server.
 func (s *Service) Start() {
-	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", s.port))
+	address := fmt.Sprintf("%s:%s", s.host, s.port)
+	lis, err := net.Listen("tcp", address)
 	if err != nil {
-		log.Errorf("Could not listen to port in Start() :%s: %v", s.port, err)
+		log.Errorf("Could not listen to port in Start() %s: %v", address, err)
 	}
 	s.listener = lis
-	log.WithField("port", fmt.Sprintf(":%s", s.port)).Info("RPC-API listening on port")
+	log.WithField("address", address).Info("RPC-API listening on port")
 
 	opts := []grpc.ServerOption{
 		grpc.StatsHandler(&ocgrpc.ServerHandler{}),

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -82,6 +82,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.DepositContractFlag,
 			flags.ContractDeploymentBlock,
 			flags.Web3ProviderFlag,
+			flags.RPCHost,
 			flags.RPCPort,
 			flags.CertFlag,
 			flags.KeyFlag,


### PR DESCRIPTION
The beacon chain currently binds its RPC server to all network interfaces.  This is undesirable in implementations where the RPC server should be protected (pretty much any production instance where other servers are on the same network).

This patch adds a `--rpc-host` option that can specify a particular host interface to which to bind.  It can be an IP address (_e.g._ `127.0.0.1`) or a resolvable name (_e.g._ `localhost`).  The default value is `0.0.0.0`, which mirrors the current functionality.