### PR TITLE
p2p: Don't mark peer as bad in connection handler

### DIFF
--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -64,11 +64,6 @@ func (s *Service) AddConnectionHandler(reqFunc func(ctx context.Context, id peer
 						s.peers.SetConnectionState(conn.RemotePeer(), peers.PeerDisconnected)
 						return
 					}
-					s.peers.IncrementBadResponses(conn.RemotePeer())
-					badResponses, err := s.peers.BadResponses(conn.RemotePeer())
-					if err == nil && badResponses == s.peers.MaxBadResponses() {
-						log.Debug("Peer has given too many bad responses; will ignore in future")
-					}
 					s.peers.SetConnectionState(conn.RemotePeer(), peers.PeerDisconnecting)
 					if err := s.Disconnect(conn.RemotePeer()); err != nil {
 						log.WithError(err).Error("Unable to disconnect from peer")


### PR DESCRIPTION
It's already handled here:

https://github.com/prysmaticlabs/prysm/blob/d744aaa2cd56519016e6a6058859887b359e20b5/beacon-chain/sync/rpc_status.go#L108

The current implementation might cause the peer to be marked as bad twice and banned quickly.