### PR TITLE
Fix resync

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -145,7 +145,7 @@ func (s *Service) Syncing() bool {
 func (s *Service) Resync() error {
 	// set it to false since we are syncing again
 	s.synced = false
-	defer func() { s.synced = true }()
+	defer func() { s.synced = true }() // Reset it at the end of the method.
 	headState, err := s.chain.HeadState(context.Background())
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve head state")

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -145,6 +145,7 @@ func (s *Service) Syncing() bool {
 func (s *Service) Resync() error {
 	// set it to false since we are syncing again
 	s.synced = false
+	defer func() { s.synced = true }()
 	headState, err := s.chain.HeadState(context.Background())
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve head state")
@@ -153,12 +154,10 @@ func (s *Service) Resync() error {
 
 	s.waitForMinimumPeers()
 	err = s.roundRobinSync(genesis)
-	if err == nil {
-		s.synced = true
-	} else {
+	if err != nil {
 		log = log.WithError(err)
 	}
-	log.WithField("synced", s.synced).WithField("slot", s.chain.HeadSlot()).Info("Resync attempt complete")
+	log.WithField("slot", s.chain.HeadSlot()).Info("Resync attempt complete")
 
 	return nil
 }


### PR DESCRIPTION
If round robin were to fail for any reason, we would be stuck in a state where the node reports that it is syncing but no active operation were happening. This may cause nodes to appear stalled.