### PR TITLE
Ensure initial sync is initialised

### DIFF
--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -49,7 +49,7 @@ func (r *Service) resyncIfBehind() {
 	runutil.RunEvery(r.ctx, interval, func() {
 		currentEpoch := uint64(roughtime.Now().Unix()-r.chain.GenesisTime().Unix()) / (params.BeaconConfig().SecondsPerSlot * params.BeaconConfig().SlotsPerEpoch)
 		syncedEpoch := helpers.SlotToEpoch(r.chain.HeadSlot())
-		if !r.initialSync.Syncing() && syncedEpoch < currentEpoch-1 {
+		if r.initialSync != nil && !r.initialSync.Syncing() && syncedEpoch < currentEpoch-1 {
 			_, highestEpoch, _ := r.p2p.Peers().BestFinalized(params.BeaconConfig().MaxPeersToSync, syncedEpoch)
 			if helpers.StartSlot(highestEpoch) > r.chain.HeadSlot() {
 				log.WithFields(logrus.Fields{


### PR DESCRIPTION
The periodic checker for resync doesn't confirm that the initial sync service is running before checking a value in it.  This patch fixes this.

(Seen a couple of test failures because of this; tests now run okay).