### PR TITLE
Add Flag for Additional Listening Addresses

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -50,6 +50,7 @@ var appFlags = []cli.Flag{
 	cmd.RelayNode,
 	cmd.P2PUDPPort,
 	cmd.P2PTCPPort,
+	cmd.P2PIP,
 	cmd.P2PHost,
 	cmd.P2PHostDNS,
 	cmd.P2PMaxPeers,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -271,6 +271,7 @@ func (b *BeaconNode) registerP2P(ctx *cli.Context) error {
 		BootstrapNodeAddr: bootnodeAddrs,
 		RelayNodeAddr:     ctx.GlobalString(cmd.RelayNode.Name),
 		DataDir:           ctx.GlobalString(cmd.DataDirFlag.Name),
+		LocalIP:           ctx.GlobalString(cmd.P2PIP.Name),
 		HostAddress:       ctx.GlobalString(cmd.P2PHost.Name),
 		HostDNS:           ctx.GlobalString(cmd.P2PHostDNS.Name),
 		PrivateKey:        ctx.GlobalString(cmd.P2PPrivKey.Name),

--- a/beacon-chain/p2p/config.go
+++ b/beacon-chain/p2p/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	KademliaBootStrapAddr []string
 	Discv5BootStrapAddr   []string
 	RelayNodeAddr         string
+	LocalIP               string
 	HostAddress           string
 	HostDNS               string
 	PrivateKey            string

--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -56,6 +56,17 @@ func buildOptions(cfg *Config, ip net.IP, priKey *ecdsa.PrivateKey) []libp2p.Opt
 			return addrs
 		}))
 	}
+	if cfg.LocalIP != "" {
+		if net.ParseIP(cfg.LocalIP) == nil {
+			log.Errorf("Invalid local ip provided: %s", cfg.LocalIP)
+			return options
+		}
+		listen, err = ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", cfg.LocalIP, cfg.TCPPort))
+		if err != nil {
+			log.Fatalf("Failed to p2p listen: %v", err)
+		}
+		options = append(options, libp2p.ListenAddrs(listen))
+	}
 	return options
 }
 

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -94,6 +94,7 @@ var appHelpFlagGroups = []flagGroup{
 	{
 		Name: "p2p",
 		Flags: []cli.Flag{
+			cmd.P2PIP,
 			cmd.P2PHost,
 			cmd.P2PHostDNS,
 			cmd.P2PMaxPeers,

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -88,6 +88,12 @@ var (
 		Usage: "The port used by libp2p.",
 		Value: 13000,
 	}
+	// P2PIP defines the local IP to be used by libp2p.
+	P2PIP = cli.StringFlag{
+		Name:  "p2p-local-ip",
+		Usage: "The local ip address to listen for incoming data.",
+		Value: "",
+	}
 	// P2PHost defines the host IP to be used by libp2p.
 	P2PHost = cli.StringFlag{
 		Name:  "p2p-host-ip",


### PR DESCRIPTION
Adds in a flag so that the beacon node can listen at another local ip address for incoming data. This requires that the beacon node be able to bind to the provided ip address.