### PR TITLE
Disable kafka build by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,3 +24,8 @@ build --define ssz=mainnet
 build --incompatible_strict_action_env
 test --incompatible_strict_action_env
 run --incompatible_strict_action_env
+
+# Disable kafka by default, it takes a long time to build...
+build --define kafka_enabled=false
+test --define kafka_enabled=false
+run --define kafka_enabled=false

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -45,3 +45,8 @@ build --stamp
 test --local_test_jobs=2
 # Disabled race detection due to unstable test results under constrained environment build kite
 # build --features=race
+
+# Enable kafka for CI and docker images
+build --define kafka_enabled=true
+test --define kafka_enabled=true
+run --define kafka_enabled=true


### PR DESCRIPTION
Building libkafka from source takes a really long time and even fails on some operating systems.

As suggested by @nisdas a few weeks ago, let's make it the default to not build kafka locally, but enable it by default in the CI. 