### PR TITLE
Runtime Optimizations

### DIFF
--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -163,7 +163,7 @@ func ProcessSlashings(state *stateTrie.BeaconState) (*stateTrie.BeaconState, err
 
 	// a callback is used here to apply the following actions  to all validators
 	// below equally.
-	validatorFunc := func(idx int, val *ethpb.Validator) error {
+	err = state.ApplyToEveryValidator(func(idx int, val *ethpb.Validator) error {
 		correctEpoch := (currentEpoch + exitLength/2) == val.WithdrawableEpoch
 		if val.Slashed && correctEpoch {
 			minSlashing := mathutil.Min(totalSlashing*3, totalBalance)
@@ -175,8 +175,7 @@ func ProcessSlashings(state *stateTrie.BeaconState) (*stateTrie.BeaconState, err
 			}
 		}
 		return nil
-	}
-	err = state.ApplyToEveryValidator(validatorFunc)
+	})
 	return state, err
 }
 

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -161,6 +161,8 @@ func ProcessSlashings(state *stateTrie.BeaconState) (*stateTrie.BeaconState, err
 		totalSlashing += slashing
 	}
 
+	// a callback is used here to apply the following actions  to all validators
+	// below equally.
 	validatorFunc := func(idx int, val *ethpb.Validator) error {
 		correctEpoch := (currentEpoch + exitLength/2) == val.WithdrawableEpoch
 		if val.Slashed && correctEpoch {

--- a/beacon-chain/core/epoch/precompute/new.go
+++ b/beacon-chain/core/epoch/precompute/new.go
@@ -22,7 +22,7 @@ func New(ctx context.Context, state *stateTrie.BeaconState) ([]*Validator, *Bala
 	currentEpoch := helpers.CurrentEpoch(state)
 	prevEpoch := helpers.PrevEpoch(state)
 
-	state.ReadFromEveryValidator(func(idx int, val *stateTrie.Validator) error {
+	state.ReadFromEveryValidator(func(idx int, val *stateTrie.ReadOnlyValidator) error {
 		// Was validator withdrawable or slashed
 		withdrawable := currentEpoch >= val.WithdrawableEpoch()
 		p := &Validator{

--- a/beacon-chain/core/epoch/precompute/slashing.go
+++ b/beacon-chain/core/epoch/precompute/slashing.go
@@ -1,6 +1,7 @@
 package precompute
 
 import (
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/shared/mathutil"
@@ -20,19 +21,19 @@ func ProcessSlashingsPrecompute(state *stateTrie.BeaconState, p *Balance) error 
 		totalSlashing += slashing
 	}
 
-	vals := state.Validators()
-	// Compute slashing for each validator.
-	for index, validator := range vals {
-		correctEpoch := (currentEpoch + exitLength/2) == validator.WithdrawableEpoch
-		if validator.Slashed && correctEpoch {
+	validatorFunc := func(idx int, val *ethpb.Validator) error {
+		correctEpoch := (currentEpoch + exitLength/2) == val.WithdrawableEpoch
+		if val.Slashed && correctEpoch {
 			minSlashing := mathutil.Min(totalSlashing*3, p.CurrentEpoch)
 			increment := params.BeaconConfig().EffectiveBalanceIncrement
-			penaltyNumerator := validator.EffectiveBalance / increment * minSlashing
+			penaltyNumerator := val.EffectiveBalance / increment * minSlashing
 			penalty := penaltyNumerator / p.CurrentEpoch * increment
-			if err := helpers.DecreaseBalance(state, uint64(index), penalty); err != nil {
+			if err := helpers.DecreaseBalance(state, uint64(idx), penalty); err != nil {
 				return err
 			}
 		}
+		return nil
 	}
-	return nil
+
+	return state.ApplyToEveryValidator(validatorFunc)
 }

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//shared/bytesutil:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
+        "//shared/mputil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/roughtime:go_default_library",
         "//shared/sliceutil:go_default_library",
@@ -37,6 +38,7 @@ go_library(
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//shared/bytesutil:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
-        "//shared/mputil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/roughtime:go_default_library",
         "//shared/sliceutil:go_default_library",

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -375,8 +375,7 @@ func ShuffledIndices(state *stateTrie.BeaconState, epoch uint64) ([]uint64, erro
 	}
 
 	indices := make([]uint64, 0, state.NumofValidators())
-	// ignore error as no error is returned in above callback.
-	state.ReadFromEveryValidator(func(idx int, val *stateTrie.Validator) error {
+	state.ReadFromEveryValidator(func(idx int, val *stateTrie.ReadOnlyValidator) error {
 		if IsActiveValidatorUsingTrie(val, epoch) {
 			indices = append(indices, uint64(idx))
 		}

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -6,8 +6,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/prysmaticlabs/prysm/shared/mputil"
-
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-bitfield"
@@ -16,6 +14,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
+	"github.com/prysmaticlabs/prysm/shared/mputil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
 )

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -375,14 +375,13 @@ func ShuffledIndices(state *stateTrie.BeaconState, epoch uint64) ([]uint64, erro
 	}
 
 	indices := make([]uint64, 0, state.NumofValidators())
-	validatorFunc := func(idx int, val *ethpb.Validator) error {
-		if IsActiveValidator(val, epoch) {
+	// ignore error as no error is returned in above callback.
+	state.ReadFromEveryValidator(func(idx int, val *stateTrie.Validator) error {
+		if IsActiveValidatorUsingTrie(val, epoch) {
 			indices = append(indices, uint64(idx))
 		}
 		return nil
-	}
-	// ignore error as no error is returned in above callback.
-	state.ReadFromEveryValidator(validatorFunc)
+	})
 
 	return UnshuffleList(indices, seed)
 }

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/prysmaticlabs/prysm/shared/mputil"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-bitfield"
@@ -401,15 +399,13 @@ func ShuffledIndices(state *stateTrie.BeaconState, epoch uint64) ([]uint64, erro
 	validatorCount := uint64(len(indices))
 	shuffledIndices := make([]uint64, validatorCount)
 
-	mputil.Scatter(int(validatorCount), func(offset int, entries int, _ *sync.RWMutex) (interface{}, error) {
+	_, err = mputil.Scatter(int(validatorCount), func(offset int, entries int, _ *sync.RWMutex) (interface{}, error) {
 		err := shuffleMultipleIndices(uint64(offset), uint64(entries), validatorCount, seed, indices, shuffledIndices)
-		if err != nil {
-			return nil, err
-		}
-		return []uint64{}, err
+		return nil, err
 	})
-
-	logrus.Errorf("Done with shuffled indices ")
+	if err != nil {
+		return []uint64{}, err
+	}
 
 	return shuffledIndices, nil
 }

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -185,7 +185,7 @@ func ComputeCommittee(
 //    return set(index for i, index in enumerate(committee) if bits[i])
 func AttestingIndices(bf bitfield.Bitfield, committee []uint64) ([]uint64, error) {
 	indices := make([]uint64, 0, len(committee))
-	indicesSet := make(map[uint64]bool)
+	indicesSet := make(map[uint64]bool, len(committee))
 	for i, idx := range committee {
 		if !indicesSet[idx] {
 			if bf.BitAt(uint64(i)) {

--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -17,7 +17,7 @@ func TotalBalance(state *stateTrie.BeaconState, indices []uint64) uint64 {
 	total := uint64(0)
 
 	for _, idx := range indices {
-		val, err := state.ValidatorAtIndexNoClone(idx)
+		val, err := state.ValidatorAtIndexReadOnly(idx)
 		if err != nil {
 			continue
 		}
@@ -43,7 +43,7 @@ func TotalBalance(state *stateTrie.BeaconState, indices []uint64) uint64 {
 //    return get_total_balance(state, set(get_active_validator_indices(state, get_current_epoch(state))))
 func TotalActiveBalance(state *stateTrie.BeaconState) (uint64, error) {
 	total := uint64(0)
-	state.ReadFromEveryValidator(func(idx int, val *stateTrie.Validator) error {
+	state.ReadFromEveryValidator(func(idx int, val *stateTrie.ReadOnlyValidator) error {
 		if IsActiveValidatorUsingTrie(val, SlotToEpoch(state.Slot())) {
 			total += val.EffectiveBalance()
 		}

--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -1,7 +1,6 @@
 package helpers
 
 import (
-	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 )
 
@@ -16,12 +15,14 @@ import (
 //    return Gwei(max(1, sum([state.validators[index].effective_balance for index in indices])))
 func TotalBalance(state *stateTrie.BeaconState, indices []uint64) uint64 {
 	total := uint64(0)
-	validatorFunc := func(idx int, val *ethpb.Validator) error {
-		total += val.EffectiveBalance
-		return nil
+
+	for _, idx := range indices {
+		val, err := state.ValidatorAtIndexNoClone(idx)
+		if err != nil {
+			continue
+		}
+		total += val.EffectiveBalance()
 	}
-	// no error is returned from callback func
-	state.ReadFromEveryValidator(validatorFunc)
 
 	// Return 1 Gwei minimum to avoid divisions by zero
 	if total == 0 {
@@ -42,14 +43,13 @@ func TotalBalance(state *stateTrie.BeaconState, indices []uint64) uint64 {
 //    return get_total_balance(state, set(get_active_validator_indices(state, get_current_epoch(state))))
 func TotalActiveBalance(state *stateTrie.BeaconState) (uint64, error) {
 	total := uint64(0)
-	validatorFunc := func(idx int, val *ethpb.Validator) error {
-		if IsActiveValidator(val, SlotToEpoch(state.Slot())) {
-			total += val.EffectiveBalance
+	state.ReadFromEveryValidator(func(idx int, val *stateTrie.Validator) error {
+		if IsActiveValidatorUsingTrie(val, SlotToEpoch(state.Slot())) {
+			total += val.EffectiveBalance()
 		}
 		return nil
-	}
-	err := state.ReadFromEveryValidator(validatorFunc)
-	return total, err
+	})
+	return total, nil
 }
 
 // IncreaseBalance increases validator with the given 'index' balance by 'delta' in Gwei.

--- a/beacon-chain/core/helpers/shuffle.go
+++ b/beacon-chain/core/helpers/shuffle.go
@@ -163,6 +163,7 @@ func innerShuffleList(input []uint64, seed [32]byte, shuffle bool) ([]uint64, er
 			len(input))
 	}
 	rounds := uint8(params.BeaconConfig().ShuffleRoundCount)
+	hashfunc := hashutil.CustomSHA256Hasher()
 	if rounds == 0 {
 		return input, nil
 	}
@@ -175,23 +176,23 @@ func innerShuffleList(input []uint64, seed [32]byte, shuffle bool) ([]uint64, er
 	copy(buf[:seedSize], seed[:])
 	for {
 		buf[seedSize] = r
-		ph := hashutil.Hash(buf[:pivotViewSize])
+		ph := hashfunc(buf[:pivotViewSize])
 		pivot := bytesutil.FromBytes8(ph[:8]) % listSize
 		mirror := (pivot + 1) >> 1
 		binary.LittleEndian.PutUint32(buf[pivotViewSize:], uint32(pivot>>8))
-		source := hashutil.Hash(buf)
+		source := hashfunc(buf)
 		byteV := source[(pivot&0xff)>>3]
 		for i, j := uint64(0), pivot; i < mirror; i, j = i+1, j-1 {
-			byteV, source = swapOrNot(buf, byteV, i, input, j, source)
+			byteV, source = swapOrNot(buf, byteV, i, input, j, source, hashfunc)
 		}
 		// Now repeat, but for the part after the pivot.
 		mirror = (pivot + listSize + 1) >> 1
 		end := listSize - 1
 		binary.LittleEndian.PutUint32(buf[pivotViewSize:], uint32(end>>8))
-		source = hashutil.Hash(buf)
+		source = hashfunc(buf)
 		byteV = source[(end&0xff)>>3]
 		for i, j := pivot+1, end; i < mirror; i, j = i+1, j-1 {
-			byteV, source = swapOrNot(buf, byteV, i, input, j, source)
+			byteV, source = swapOrNot(buf, byteV, i, input, j, source, hashfunc)
 		}
 		if shuffle {
 			r++
@@ -210,11 +211,12 @@ func innerShuffleList(input []uint64, seed [32]byte, shuffle bool) ([]uint64, er
 
 // swapOrNot describes the main algorithm behind the shuffle where we swap bytes in the inputted value
 // depending on if the conditions are met.
-func swapOrNot(buf []byte, byteV byte, i uint64, input []uint64, j uint64, source [32]byte) (byte, [32]byte) {
+func swapOrNot(buf []byte, byteV byte, i uint64, input []uint64,
+	j uint64, source [32]byte, hashFunc func([]byte) [32]byte) (byte, [32]byte) {
 	if j&0xff == 0xff {
 		// just overwrite the last part of the buffer, reuse the start (seed, round)
 		binary.LittleEndian.PutUint32(buf[pivotViewSize:], uint32(j>>8))
-		source = hashutil.Hash(buf)
+		source = hashFunc(buf)
 	}
 	if j&0x7 == 0x7 {
 		byteV = source[(j&0xff)>>3]

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -25,6 +25,7 @@ func IsActiveValidator(validator *ethpb.Validator, epoch uint64) bool {
 	return checkValidatorActiveStatus(validator.ActivationEpoch, validator.ExitEpoch, epoch)
 }
 
+// IsActiveValidatorUsingTrie checks if a read only validator is active.
 func IsActiveValidatorUsingTrie(validator *stateTrie.ReadOnlyValidator, epoch uint64) bool {
 	return checkValidatorActiveStatus(validator.ActivationEpoch(), validator.ExitEpoch(), epoch)
 }

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -25,7 +25,7 @@ func IsActiveValidator(validator *ethpb.Validator, epoch uint64) bool {
 	return checkValidatorActiveStatus(validator.ActivationEpoch, validator.ExitEpoch, epoch)
 }
 
-func IsActiveValidatorUsingTrie(validator *stateTrie.Validator, epoch uint64) bool {
+func IsActiveValidatorUsingTrie(validator *stateTrie.ReadOnlyValidator, epoch uint64) bool {
 	return checkValidatorActiveStatus(validator.ActivationEpoch(), validator.ExitEpoch(), epoch)
 }
 
@@ -77,8 +77,7 @@ func ActiveValidatorIndices(state *stateTrie.BeaconState, epoch uint64) ([]uint6
 		return activeIndices, nil
 	}
 	var indices []uint64
-	// ignoring error as none is returned in the above callback
-	state.ReadFromEveryValidator(func(idx int, val *stateTrie.Validator) error {
+	state.ReadFromEveryValidator(func(idx int, val *stateTrie.ReadOnlyValidator) error {
 		if IsActiveValidatorUsingTrie(val, epoch) {
 			indices = append(indices, uint64(idx))
 		}
@@ -96,7 +95,7 @@ func ActiveValidatorIndices(state *stateTrie.BeaconState, epoch uint64) ([]uint6
 // at the given epoch.
 func ActiveValidatorCount(state *stateTrie.BeaconState, epoch uint64) (uint64, error) {
 	count := uint64(0)
-	state.ReadFromEveryValidator(func(idx int, val *stateTrie.Validator) error {
+	state.ReadFromEveryValidator(func(idx int, val *stateTrie.ReadOnlyValidator) error {
 		if IsActiveValidatorUsingTrie(val, epoch) {
 			count++
 		}

--- a/beacon-chain/rpc/validator/exit.go
+++ b/beacon-chain/rpc/validator/exit.go
@@ -24,10 +24,11 @@ func (vs *Server) ProposeExit(ctx context.Context, req *ethpb.SignedVoluntaryExi
 	}
 
 	// Confirm the validator is eligible to exit with the parameters provided.
-	if int(req.Exit.ValidatorIndex) >= len(s.Validators) {
+	val, err := s.ValidatorAtIndex(req.Exit.ValidatorIndex)
+	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, "validator index exceeds validator set length")
 	}
-	if err := blocks.VerifyExit(s.Validators[req.Exit.ValidatorIndex], helpers.StartSlot(req.Exit.Epoch), s.Fork, req); err != nil {
+	if err := blocks.VerifyExit(val, helpers.StartSlot(req.Exit.Epoch), s.Fork(), req); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
@@ -39,7 +40,7 @@ func (vs *Server) ProposeExit(ctx context.Context, req *ethpb.SignedVoluntaryExi
 		},
 	})
 
-	vs.ExitPool.InsertVoluntaryExit(ctx, s.Validators, req)
+	vs.ExitPool.InsertVoluntaryExit(ctx, s.Validators(), req)
 
 	return nil, vs.P2P.Broadcast(ctx, req)
 }

--- a/beacon-chain/state/BUILD.bazel
+++ b/beacon-chain/state/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "types.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/state",
-    visibility = ["//visibility:public"],
+    visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/core/state/stateutils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -11,39 +11,39 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 )
 
-func (v *Validator) EffectiveBalance() uint64 {
+func (v *ReadOnlyValidator) EffectiveBalance() uint64 {
 	return v.validator.EffectiveBalance
 }
 
-func (v *Validator) ActivationEligibilityEpoch() uint64 {
+func (v *ReadOnlyValidator) ActivationEligibilityEpoch() uint64 {
 	return v.validator.ActivationEligibilityEpoch
 }
 
-func (v *Validator) ActivationEpoch() uint64 {
+func (v *ReadOnlyValidator) ActivationEpoch() uint64 {
 	return v.validator.ActivationEpoch
 }
 
-func (v *Validator) WithdrawableEpoch() uint64 {
+func (v *ReadOnlyValidator) WithdrawableEpoch() uint64 {
 	return v.validator.WithdrawableEpoch
 }
 
-func (v *Validator) ExitEpoch() uint64 {
+func (v *ReadOnlyValidator) ExitEpoch() uint64 {
 	return v.validator.ExitEpoch
 }
 
-func (v *Validator) PublicKey() [48]byte {
+func (v *ReadOnlyValidator) PublicKey() [48]byte {
 	var pubkey [48]byte
 	copy(pubkey[:], v.validator.PublicKey)
 	return pubkey
 }
 
-func (v *Validator) WithdrawalCredentials() []byte {
+func (v *ReadOnlyValidator) WithdrawalCredentials() []byte {
 	creds := make([]byte, len(v.validator.WithdrawalCredentials))
 	copy(creds[:], v.validator.WithdrawalCredentials)
 	return creds
 }
 
-func (v *Validator) Slashed() bool {
+func (v *ReadOnlyValidator) Slashed() bool {
 	return v.validator.Slashed
 }
 
@@ -260,16 +260,16 @@ func (b *BeaconState) Validators() []*ethpb.Validator {
 	return res
 }
 
-// ValidatorsNoClone returns validators participating in consensus on the beacon chain. This
-// method doesn't clone the respective validators.
-func (b *BeaconState) ValidatorsNoClone() []*Validator {
+// ValidatorsReadOnly returns validators participating in consensus on the beacon chain. This
+// method doesn't clone the respective validators and returns read only references to the validators.
+func (b *BeaconState) ValidatorsReadOnly() []*ReadOnlyValidator {
 	if b.state.Validators == nil {
 		return nil
 	}
-	res := make([]*Validator, len(b.state.Validators))
+	res := make([]*ReadOnlyValidator, len(b.state.Validators))
 	for i := 0; i < len(res); i++ {
 		val := b.state.Validators[i]
-		res[i] = &Validator{validator: val}
+		res[i] = &ReadOnlyValidator{validator: val}
 	}
 	return res
 }
@@ -299,16 +299,16 @@ func (b *BeaconState) ValidatorAtIndex(idx uint64) (*ethpb.Validator, error) {
 	}, nil
 }
 
-// ValidatorAtIndexNoClone is the validator at the provided index.This method
+// ValidatorAtIndexReadOnly is the validator at the provided index.This method
 // doesn't clone the validator.
-func (b *BeaconState) ValidatorAtIndexNoClone(idx uint64) (*Validator, error) {
+func (b *BeaconState) ValidatorAtIndexReadOnly(idx uint64) (*ReadOnlyValidator, error) {
 	if b.state.Validators == nil {
-		return &Validator{}, nil
+		return &ReadOnlyValidator{}, nil
 	}
 	if len(b.state.Validators) <= int(idx) {
 		return nil, fmt.Errorf("index %d out of range", idx)
 	}
-	return &Validator{b.state.Validators[idx]}, nil
+	return &ReadOnlyValidator{b.state.Validators[idx]}, nil
 }
 
 // ValidatorIndexByPubkey returns a given validator by its 48-byte public key.
@@ -332,9 +332,9 @@ func (b *BeaconState) NumofValidators() int {
 
 // ReadFromEveryValidator reads values from every validator and applies it to the provided function.
 // Warning: This method is potentially unsafe, as it exposes the actual validator registry.
-func (b *BeaconState) ReadFromEveryValidator(f func(idx int, val *Validator) error) error {
+func (b *BeaconState) ReadFromEveryValidator(f func(idx int, val *ReadOnlyValidator) error) error {
 	for i, v := range b.state.Validators {
-		err := f(i, &Validator{validator: v})
+		err := f(i, &ReadOnlyValidator{validator: v})
 		if err != nil {
 			return err
 		}

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -11,38 +11,53 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 )
 
+// EffectiveBalance returns the effective balance of the
+// read only validator.
 func (v *ReadOnlyValidator) EffectiveBalance() uint64 {
 	return v.validator.EffectiveBalance
 }
 
+// ActivationEligibilityEpoch returns the activation eligibility epoch of the
+// read only validator.
 func (v *ReadOnlyValidator) ActivationEligibilityEpoch() uint64 {
 	return v.validator.ActivationEligibilityEpoch
 }
 
+// ActivationEpoch returns the activation epoch of the
+// read only validator.
 func (v *ReadOnlyValidator) ActivationEpoch() uint64 {
 	return v.validator.ActivationEpoch
 }
 
+// WithdrawableEpoch returns the withdrawable epoch of the
+// read only validator.
 func (v *ReadOnlyValidator) WithdrawableEpoch() uint64 {
 	return v.validator.WithdrawableEpoch
 }
 
+// ExitEpoch returns the exit epoch of the
+// read only validator.
 func (v *ReadOnlyValidator) ExitEpoch() uint64 {
 	return v.validator.ExitEpoch
 }
 
+// PublicKey returns the public key of the
+// read only validator.
 func (v *ReadOnlyValidator) PublicKey() [48]byte {
 	var pubkey [48]byte
 	copy(pubkey[:], v.validator.PublicKey)
 	return pubkey
 }
 
+// WithdrawalCredentials returns the withdrawal credentials of the
+// read only validator.
 func (v *ReadOnlyValidator) WithdrawalCredentials() []byte {
 	creds := make([]byte, len(v.validator.WithdrawalCredentials))
 	copy(creds[:], v.validator.WithdrawalCredentials)
 	return creds
 }
 
+// Slashed returns the read only validator is slashed.
 func (v *ReadOnlyValidator) Slashed() bool {
 	return v.validator.Slashed
 }

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -268,6 +268,18 @@ func (b *BeaconState) NumofValidators() int {
 	return len(b.state.Validators)
 }
 
+// ReadFromEveryValidator reads values from every validator and applies it to the provided function.
+// Warning: This method is potentially unsafe, as it exposes the actual validator registry.
+func (b *BeaconState) ReadFromEveryValidator(f func(idx int, val *ethpb.Validator) error) error {
+	for i, v := range b.state.Validators {
+		err := f(i, v)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Balances of validators participating in consensus on the beacon chain.
 func (b *BeaconState) Balances() []uint64 {
 	if b.state.Balances == nil {

--- a/beacon-chain/state/setters.go
+++ b/beacon-chain/state/setters.go
@@ -180,6 +180,8 @@ func (b *BeaconState) SetValidators(val []*ethpb.Validator) error {
 	return nil
 }
 
+// ApplyToEveryValidator applies the provided callback function to each validator in the
+// validator registry.
 func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val *ethpb.Validator) error) error {
 	for i, val := range b.state.Validators {
 		err := f(i, val)

--- a/beacon-chain/state/setters.go
+++ b/beacon-chain/state/setters.go
@@ -208,7 +208,7 @@ func (b *BeaconState) UpdateValidatorAtIndex(idx uint64, val *ethpb.Validator) e
 	return nil
 }
 
-// SetValidatorAtIndexByPubkey updates the validator index mapping maintained internally to
+// SetValidatorIndexByPubkey updates the validator index mapping maintained internally to
 // a given input 48-byte, public key.
 func (b *BeaconState) SetValidatorIndexByPubkey(pubKey [48]byte, validatorIdx uint64) {
 	b.lock.Lock()

--- a/beacon-chain/state/setters.go
+++ b/beacon-chain/state/setters.go
@@ -180,6 +180,19 @@ func (b *BeaconState) SetValidators(val []*ethpb.Validator) error {
 	return nil
 }
 
+func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val *ethpb.Validator) error) error {
+	for i, val := range b.state.Validators {
+		err := f(i, val)
+		if err != nil {
+			return err
+		}
+	}
+	b.lock.Lock()
+	b.markFieldAsDirty(validators)
+	b.lock.Unlock()
+	return nil
+}
+
 // UpdateValidatorAtIndex for the beacon state. This PR updates the randao mixes
 // at a specific index to a new value.
 func (b *BeaconState) UpdateValidatorAtIndex(idx uint64, val *ethpb.Validator) error {

--- a/beacon-chain/state/types.go
+++ b/beacon-chain/state/types.go
@@ -3,10 +3,10 @@ package state
 import (
 	"sync"
 
-	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/protolambda/zssz/merkle"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	coreutils "github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"

--- a/beacon-chain/state/types.go
+++ b/beacon-chain/state/types.go
@@ -26,7 +26,9 @@ type BeaconState struct {
 	merkleLayers [][][]byte
 }
 
-type Validator struct {
+// ReadOnlyValidator returns a wrapper that only allows fields from a validator
+// to be read, and prevents any modification of internal validator fields.
+type ReadOnlyValidator struct {
 	validator *ethpb.Validator
 }
 

--- a/beacon-chain/state/types.go
+++ b/beacon-chain/state/types.go
@@ -3,6 +3,8 @@ package state
 import (
 	"sync"
 
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/protolambda/zssz/merkle"
@@ -22,6 +24,10 @@ type BeaconState struct {
 	dirtyFields  map[fieldIndex]interface{}
 	valIdxMap    map[[48]byte]uint64
 	merkleLayers [][][]byte
+}
+
+type Validator struct {
+	validator *ethpb.Validator
 }
 
 // InitializeFromProto the beacon state from a protobuf representation.

--- a/beacon-chain/state/types_test.go
+++ b/beacon-chain/state/types_test.go
@@ -1,4 +1,4 @@
-package state
+package state_test
 
 import (
 	"strconv"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/interop"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -15,7 +16,7 @@ import (
 func TestBeaconState_ProtoBeaconStateCompatibility(t *testing.T) {
 	params.UseMinimalConfig()
 	genesis := setupGenesisState(t, 64)
-	customState, err := InitializeFromProto(genesis)
+	customState, err := stateTrie.InitializeFromProto(genesis)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +143,7 @@ func BenchmarkStateClone_Manual(b *testing.B) {
 	b.StopTimer()
 	params.UseMinimalConfig()
 	genesis := setupGenesisState(b, 64)
-	st, err := InitializeFromProto(genesis)
+	st, err := stateTrie.InitializeFromProto(genesis)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/beacon-chain/sync/subscriber_handlers.go
+++ b/beacon-chain/sync/subscriber_handlers.go
@@ -12,7 +12,7 @@ func (r *Service) voluntaryExitSubscriber(ctx context.Context, msg proto.Message
 	if err != nil {
 		return err
 	}
-	r.exitPool.InsertVoluntaryExit(ctx, s.Validators, msg.(*ethpb.SignedVoluntaryExit))
+	r.exitPool.InsertVoluntaryExit(ctx, s.Validators(), msg.(*ethpb.SignedVoluntaryExit))
 	return nil
 }
 

--- a/shared/hashutil/hash.go
+++ b/shared/hashutil/hash.go
@@ -37,9 +37,9 @@ func Hash(data []byte) [32]byte {
 // use as the same hasher is being called throughout.
 func CustomSHA256Hasher() func([]byte) [32]byte {
 	hasher := sha256.New()
-	return func(data []byte) [32]byte {
-		var hash [32]byte
+	var hash [32]byte
 
+	return func(data []byte) [32]byte {
 		// The hash interface never returns an error, for that reason
 		// we are not handling the error below. For reference, it is
 		// stated here https://golang.org/pkg/hash/#Hash

--- a/shared/stateutil/arrays.go
+++ b/shared/stateutil/arrays.go
@@ -1,19 +1,17 @@
 package stateutil
 
 import (
-	"bytes"
 	"errors"
 	"sync"
 
 	"github.com/protolambda/zssz/merkle"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
 
 var (
-	leavesCache = make(map[string][][]byte)
-	layersCache = make(map[string][][][]byte)
+	leavesCache = make(map[string][][32]byte)
+	layersCache = make(map[string][][][32]byte)
 	lock        sync.RWMutex
 )
 
@@ -31,12 +29,14 @@ func (h *stateRootHasher) arraysRoot(input [][]byte, length uint64, fieldName st
 	lock.Lock()
 	if _, ok := layersCache[fieldName]; !ok && h.rootsCache != nil {
 		depth := merkle.GetDepth(length)
-		layersCache[fieldName] = make([][][]byte, depth+1)
+		layersCache[fieldName] = make([][][32]byte, depth+1)
 	}
 	lock.Unlock()
 
-	leaves := make([][]byte, length)
-	copy(leaves, input)
+	leaves := make([][32]byte, length)
+	for i, chunk := range input {
+		copy(leaves[i][:], chunk)
+	}
 	bytesProcessed := 0
 	changedIndices := make([]int, 0)
 	lock.RLock()
@@ -47,10 +47,8 @@ func (h *stateRootHasher) arraysRoot(input [][]byte, length uint64, fieldName st
 	}
 
 	for i := 0; i < len(leaves); i++ {
-		padded := bytesutil.ToBytes32(leaves[i])
-		leaves[i] = padded[:]
 		// We check if any items changed since the roots were last recomputed.
-		notEqual := !bytes.Equal(leaves[i], prevLeaves[i])
+		notEqual := leaves[i] != prevLeaves[i]
 		if ok && h.rootsCache != nil && notEqual {
 			changedIndices = append(changedIndices, i)
 		}
@@ -92,17 +90,17 @@ func (h *stateRootHasher) arraysRoot(input [][]byte, length uint64, fieldName st
 	return res, nil
 }
 
-func (h *stateRootHasher) merkleizeWithCache(leaves [][]byte, length uint64,
+func (h *stateRootHasher) merkleizeWithCache(leaves [][32]byte, length uint64,
 	fieldName string, hasher func([]byte) [32]byte) [32]byte {
 	lock.Lock()
 	defer lock.Unlock()
 	if len(leaves) == 1 {
 		var root [32]byte
-		copy(root[:], leaves[0])
+		root = leaves[0]
 		return root
 	}
 	hashLayer := leaves
-	layers := make([][][]byte, merkle.GetDepth(length)+1)
+	layers := make([][][32]byte, merkle.GetDepth(length)+1)
 	if items, ok := layersCache[fieldName]; ok && h.rootsCache != nil {
 		if len(items[0]) == len(leaves) {
 			layers = items
@@ -117,24 +115,24 @@ func (h *stateRootHasher) merkleizeWithCache(leaves [][]byte, length uint64,
 	// [A]  [B]  [C]  [D] -> The bottom layer has length 4 (needs to be a power of two).
 	i := 1
 	for len(hashLayer) > 1 && i < len(layers) {
-		layer := make([][]byte, 0)
+		layer := make([][32]byte, 0)
 		for i := 0; i < len(hashLayer); i += 2 {
-			hashedChunk := hasher(append(hashLayer[i], hashLayer[i+1]...))
-			layer = append(layer, hashedChunk[:])
+			hashedChunk := hasher(append(hashLayer[i][:], hashLayer[i+1][:]...))
+			layer = append(layer, hashedChunk)
 		}
 		hashLayer = layer
 		layers[i] = hashLayer
 		i++
 	}
 	var root [32]byte
-	copy(root[:], hashLayer[0])
+	root = hashLayer[0]
 	if h.rootsCache != nil {
 		layersCache[fieldName] = layers
 	}
 	return root
 }
 
-func recomputeRoot(idx int, chunks [][]byte, length uint64,
+func recomputeRoot(idx int, chunks [][32]byte, length uint64,
 	fieldName string, hasher func([]byte) [32]byte) ([32]byte, error) {
 	lock.Lock()
 	defer lock.Unlock()
@@ -157,16 +155,16 @@ func recomputeRoot(idx int, chunks [][]byte, length uint64,
 		isLeft := currentIndex%2 == 0
 		neighborIdx := currentIndex ^ 1
 
-		neighbor := make([]byte, 32)
+		neighbor := [32]byte{}
 		if layers[i] != nil && len(layers[i]) != 0 && neighborIdx < len(layers[i]) {
 			neighbor = layers[i][neighborIdx]
 		}
 		if isLeft {
-			parentHash := hasher(append(root, neighbor...))
-			root = parentHash[:]
+			parentHash := hasher(append(root[:], neighbor[:]...))
+			root = parentHash
 		} else {
-			parentHash := hasher(append(neighbor, root...))
-			root = parentHash[:]
+			parentHash := hasher(append(neighbor[:], root[:]...))
+			root = parentHash
 		}
 		parentIdx := currentIndex / 2
 		// Update the cached layers at the parent index.
@@ -180,7 +178,7 @@ func recomputeRoot(idx int, chunks [][]byte, length uint64,
 	layersCache[fieldName] = layers
 	// If there is only a single leaf, we return it (the identity element).
 	if len(layers[0]) == 1 {
-		return bytesutil.ToBytes32(layers[0][0]), nil
+		return layers[0][0], nil
 	}
-	return bytesutil.ToBytes32(root), nil
+	return root, nil
 }

--- a/shared/stateutil/helpers.go
+++ b/shared/stateutil/helpers.go
@@ -54,6 +54,18 @@ func bitwiseMerkleize(chunks [][]byte, count uint64, limit uint64) ([32]byte, er
 	return merkle.Merkleize(hasher, count, limit, leafIndexer), nil
 }
 
+// bitwiseMerkleizeArrays is used when a set of 32-byte root chunks are provided.
+func bitwiseMerkleizeArrays(chunks [][32]byte, count uint64, limit uint64) ([32]byte, error) {
+	if count > limit {
+		return [32]byte{}, errors.New("merkleizing list that is too large, over limit")
+	}
+	hasher := htr.HashFn(hashutil.CustomSHA256Hasher())
+	leafIndexer := func(i uint64) []byte {
+		return chunks[i][:]
+	}
+	return merkle.Merkleize(hasher, count, limit, leafIndexer), nil
+}
+
 func pack(serializedItems [][]byte) ([][]byte, error) {
 	areAllEmpty := true
 	for _, item := range serializedItems {

--- a/shared/stateutil/validators.go
+++ b/shared/stateutil/validators.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -61,7 +60,7 @@ func ValidatorBalancesRoot(balances []uint64) ([32]byte, error) {
 
 func (h *stateRootHasher) validatorRegistryRoot(validators []*ethpb.Validator) ([32]byte, error) {
 	hashKeyElements := make([]byte, len(validators)*32)
-	roots := make([][]byte, len(validators))
+	roots := make([][32]byte, len(validators))
 	emptyKey := hashutil.FastSum256(hashKeyElements)
 	bytesProcessed := 0
 	for i := 0; i < len(validators); i++ {
@@ -70,7 +69,7 @@ func (h *stateRootHasher) validatorRegistryRoot(validators []*ethpb.Validator) (
 			return [32]byte{}, errors.Wrap(err, "could not compute validators merkleization")
 		}
 		copy(hashKeyElements[bytesProcessed:bytesProcessed+32], val[:])
-		roots[i] = val[:]
+		roots[i] = val
 		bytesProcessed += 32
 	}
 
@@ -81,7 +80,7 @@ func (h *stateRootHasher) validatorRegistryRoot(validators []*ethpb.Validator) (
 		}
 	}
 
-	validatorsRootsRoot, err := bitwiseMerkleize(roots, uint64(len(roots)), params.BeaconConfig().ValidatorRegistryLimit)
+	validatorsRootsRoot, err := bitwiseMerkleizeArrays(roots, uint64(len(roots)), params.BeaconConfig().ValidatorRegistryLimit)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute validator registry merkleization")
 	}
@@ -90,9 +89,9 @@ func (h *stateRootHasher) validatorRegistryRoot(validators []*ethpb.Validator) (
 		return [32]byte{}, errors.Wrap(err, "could not marshal validator registry length")
 	}
 	// We need to mix in the length of the slice.
-	validatorsRootsBufRoot := make([]byte, 32)
-	copy(validatorsRootsBufRoot, validatorsRootsBuf.Bytes())
-	res := mixInLength(validatorsRootsRoot, validatorsRootsBufRoot)
+	var validatorsRootsBufRoot [32]byte
+	copy(validatorsRootsBufRoot[:], validatorsRootsBuf.Bytes())
+	res := mixInLength(validatorsRootsRoot, validatorsRootsBufRoot[:])
 	if hashKey != emptyKey && h.rootsCache != nil {
 		h.rootsCache.Set(string(hashKey[:]), res, 32)
 	}
@@ -102,34 +101,34 @@ func (h *stateRootHasher) validatorRegistryRoot(validators []*ethpb.Validator) (
 func (h *stateRootHasher) validatorRoot(validator *ethpb.Validator) ([32]byte, error) {
 	// Validator marshaling for caching.
 	enc := make([]byte, 122)
-	fieldRoots := make([][]byte, 8)
+	fieldRoots := make([][32]byte, 2, 8)
 
 	if validator != nil {
 		copy(enc[0:48], validator.PublicKey)
 		copy(enc[48:80], validator.WithdrawalCredentials)
-		effectiveBalanceBuf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(effectiveBalanceBuf, validator.EffectiveBalance)
-		copy(enc[80:88], effectiveBalanceBuf)
+		effectiveBalanceBuf := [32]byte{}
+		binary.LittleEndian.PutUint64(effectiveBalanceBuf[:8], validator.EffectiveBalance)
+		copy(enc[80:88], effectiveBalanceBuf[:8])
 		if validator.Slashed {
 			enc[88] = uint8(1)
 		} else {
 			enc[88] = uint8(0)
 		}
-		activationEligibilityBuf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(activationEligibilityBuf, validator.ActivationEligibilityEpoch)
-		copy(enc[89:97], activationEligibilityBuf)
+		activationEligibilityBuf := [32]byte{}
+		binary.LittleEndian.PutUint64(activationEligibilityBuf[:8], validator.ActivationEligibilityEpoch)
+		copy(enc[89:97], activationEligibilityBuf[:8])
 
-		activationBuf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(activationBuf, validator.ActivationEpoch)
-		copy(enc[97:105], activationBuf)
+		activationBuf := [32]byte{}
+		binary.LittleEndian.PutUint64(activationBuf[:8], validator.ActivationEpoch)
+		copy(enc[97:105], activationBuf[:8])
 
-		exitBuf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(exitBuf, validator.ExitEpoch)
-		copy(enc[105:113], exitBuf)
+		exitBuf := [32]byte{}
+		binary.LittleEndian.PutUint64(exitBuf[:8], validator.ExitEpoch)
+		copy(enc[105:113], exitBuf[:8])
 
-		withdrawalBuf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(withdrawalBuf, validator.WithdrawableEpoch)
-		copy(enc[113:121], exitBuf)
+		withdrawalBuf := [32]byte{}
+		binary.LittleEndian.PutUint64(withdrawalBuf[:8], validator.WithdrawableEpoch)
+		copy(enc[113:121], withdrawalBuf[:8])
 
 		// Check if it exists in cache:
 		if h.rootsCache != nil {
@@ -147,43 +146,37 @@ func (h *stateRootHasher) validatorRoot(validator *ethpb.Validator) ([32]byte, e
 		if err != nil {
 			return [32]byte{}, err
 		}
-		fieldRoots[0] = pubKeyRoot[:]
+		fieldRoots[0] = pubKeyRoot
 
 		// Withdrawal credentials.
-		fieldRoots[1] = validator.WithdrawalCredentials
+		copy(fieldRoots[1][:], validator.WithdrawalCredentials)
 
 		// Effective balance.
-		effBalRoot := bytesutil.ToBytes32(effectiveBalanceBuf)
-		fieldRoots[2] = effBalRoot[:]
+		fieldRoots = append(fieldRoots, effectiveBalanceBuf)
 
 		// Slashed.
-		slashBuf := make([]byte, 1)
+		slashBuf := [32]byte{}
 		if validator.Slashed {
 			slashBuf[0] = uint8(1)
 		} else {
 			slashBuf[0] = uint8(0)
 		}
-		slashBufRoot := bytesutil.ToBytes32(slashBuf)
-		fieldRoots[3] = slashBufRoot[:]
+		fieldRoots = append(fieldRoots, slashBuf)
 
 		// Activation eligibility epoch.
-		activationEligibilityRoot := bytesutil.ToBytes32(activationEligibilityBuf)
-		fieldRoots[4] = activationEligibilityRoot[:]
+		fieldRoots = append(fieldRoots, activationEligibilityBuf)
 
 		// Activation epoch.
-		activationRoot := bytesutil.ToBytes32(activationBuf)
-		fieldRoots[5] = activationRoot[:]
+		fieldRoots = append(fieldRoots, activationBuf)
 
 		// Exit epoch.
-		exitBufRoot := bytesutil.ToBytes32(exitBuf)
-		fieldRoots[6] = exitBufRoot[:]
+		fieldRoots = append(fieldRoots, exitBuf)
 
 		// Withdrawable epoch.
-		withdrawalBufRoot := bytesutil.ToBytes32(withdrawalBuf)
-		fieldRoots[7] = withdrawalBufRoot[:]
+		fieldRoots = append(fieldRoots, withdrawalBuf)
 	}
 
-	valRoot, err := bitwiseMerkleize(fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
+	valRoot, err := bitwiseMerkleizeArrays(fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
 	if err != nil {
 		return [32]byte{}, err
 	}


### PR DESCRIPTION
- [x] We parallelize shuffling, by splitting the indices into chunks and then letting those chunks be shuffled by separate goroutines using `Scatter`.
- [x] Add validator callback methods to allow reading from and writing to each validator in the scope
of the provided callback.
- [x] Use callbacks to minimize registry clones, and instead directly access validators.
- [x] Use 32 byte arrays instead of slices in HTR, so as to allow for easier load on the GC when cleaning the object up. 
- [x] Reduce copying, instead re-using allocated memory when appropriate.
- [x] Fix a cache bug with our exit epoch root in our validator object in HTR.