### PR TITLE
Clear Run Error in Powchain Service Upon Reconnect

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -584,6 +584,7 @@ func (s *Service) run(done <-chan struct{}) {
 			log.WithError(s.runError).Error("Subscription to new head notifier failed")
 			s.connectedETH1 = false
 			s.waitForConnection()
+			s.runError = nil
 			headSub, err = s.reader.SubscribeNewHead(s.ctx, s.headerChan)
 			if err != nil {
 				log.WithError(err).Error("Unable to re-subscribe to incoming ETH1.0 chain headers")

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -584,13 +584,13 @@ func (s *Service) run(done <-chan struct{}) {
 			log.WithError(s.runError).Error("Subscription to new head notifier failed")
 			s.connectedETH1 = false
 			s.waitForConnection()
-			s.runError = nil
 			headSub, err = s.reader.SubscribeNewHead(s.ctx, s.headerChan)
 			if err != nil {
 				log.WithError(err).Error("Unable to re-subscribe to incoming ETH1.0 chain headers")
 				s.runError = err
 				return
 			}
+			s.runError = nil
 		case header, ok := <-s.headerChan:
 			if ok {
 				s.processSubscribedHeaders(header)


### PR DESCRIPTION
Resolves #4055

---

# Description

**Write why you are making the changes in this pull request**

We have a `Status()` function that is used in liveness probes in our beacon node for every service. The powchain service upon losing a websocket connection to eth1 returns an error perpetually in this `Status()` function even after it reconnects.

**Write a summary of the changes you are making**

This PR clears the `service.runErr` value back to `nil` after a successful powchain reconnect.
