### PR TITLE
Fix initial sync cache state

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_block_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_block_test.go
@@ -429,7 +429,7 @@ func TestCachedPreState_CanGetFromCache(t *testing.T) {
 	store.initSyncState[r] = s
 
 	wanted := "pre state of slot 1 does not exist"
-	if _, err := store.cachedPreState(ctx, b); !strings.Contains(err.Error(), wanted) {
+	if _, err := store.verifyBlkPreState(ctx, b); !strings.Contains(err.Error(), wanted) {
 		t.Fatal("Not expected error")
 	}
 }
@@ -449,7 +449,7 @@ func TestCachedPreState_CanGetFromCacheWithFeature(t *testing.T) {
 	b := &ethpb.BeaconBlock{Slot: 1, ParentRoot: r[:]}
 	store.initSyncState[r] = s
 
-	received, err := store.cachedPreState(ctx, b)
+	received, err := store.verifyBlkPreState(ctx, b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -467,7 +467,7 @@ func TestCachedPreState_CanGetFromDB(t *testing.T) {
 	r := [32]byte{'A'}
 	b := &ethpb.BeaconBlock{Slot: 1, ParentRoot: r[:]}
 
-	_, err := store.cachedPreState(ctx, b)
+	_, err := store.verifyBlkPreState(ctx, b)
 	wanted := "pre state of slot 1 does not exist"
 	if err.Error() != wanted {
 		t.Error("Did not get wanted error")
@@ -476,7 +476,7 @@ func TestCachedPreState_CanGetFromDB(t *testing.T) {
 	s := &pb.BeaconState{Slot: 1}
 	store.db.SaveState(ctx, s, r)
 
-	received, err := store.cachedPreState(ctx, b)
+	received, err := store.verifyBlkPreState(ctx, b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -152,7 +152,7 @@ func (s *Service) onBlockInitialSyncStateTransition(ctx context.Context, signed 
 	defer s.initSyncStateLock.Unlock()
 
 	// Retrieve incoming block's pre state.
-	preState, err := s.cachedPreState(ctx, b)
+	preState, err := s.verifyBlkPreState(ctx, b)
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -321,7 +321,7 @@ func TestCachedPreState_CanGetFromCache(t *testing.T) {
 	service.initSyncState[r] = s
 
 	wanted := "pre state of slot 1 does not exist"
-	if _, err := service.cachedPreState(ctx, b); !strings.Contains(err.Error(), wanted) {
+	if _, err := service.verifyBlkPreState(ctx, b); !strings.Contains(err.Error(), wanted) {
 		t.Fatal("Not expected error")
 	}
 }
@@ -346,7 +346,7 @@ func TestCachedPreState_CanGetFromCacheWithFeature(t *testing.T) {
 	b := &ethpb.BeaconBlock{Slot: 1, ParentRoot: r[:]}
 	service.initSyncState[r] = s
 
-	received, err := service.cachedPreState(ctx, b)
+	received, err := service.verifyBlkPreState(ctx, b)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -369,7 +369,7 @@ func TestCachedPreState_CanGetFromDB(t *testing.T) {
 	r := [32]byte{'A'}
 	b := &ethpb.BeaconBlock{Slot: 1, ParentRoot: r[:]}
 
-	_, err = service.cachedPreState(ctx, b)
+	_, err = service.verifyBlkPreState(ctx, b)
 	wanted := "pre state of slot 1 does not exist"
 	if err.Error() != wanted {
 		t.Error("Did not get wanted error")
@@ -378,7 +378,7 @@ func TestCachedPreState_CanGetFromDB(t *testing.T) {
 	s := &pb.BeaconState{Slot: 1}
 	service.beaconDB.SaveState(ctx, s, r)
 
-	received, err := service.cachedPreState(ctx, b)
+	received, err := service.verifyBlkPreState(ctx, b)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -313,6 +313,10 @@ func (s *Service) saveHeadNoDB(ctx context.Context, b *ethpb.SignedBeaconBlock, 
 	s.headLock.Lock()
 	defer s.headLock.Unlock()
 
+	if b == nil || b.Block == nil {
+		return errors.New("cannot save nil head block")
+	}
+
 	s.headSlot = b.Block.Slot
 
 	s.canonicalRoots[b.Block.Slot] = r[:]

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -590,6 +590,7 @@ func (s *Service) run(done <-chan struct{}) {
 				s.runError = err
 				return
 			}
+			s.runError = nil
 		case header, ok := <-s.headerChan:
 			if ok {
 				s.processSubscribedHeaders(header)

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -240,6 +240,7 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 		best = s.bestPeer()
 		root, _, _ = s.p2p.Peers().BestFinalized(params.BeaconConfig().MaxPeersToSync, helpers.SlotToEpoch(s.chain.HeadSlot()))
 	}
+
 	for head := helpers.SlotsSince(genesis); s.chain.HeadSlot() < head; {
 		req := &p2ppb.BeaconBlocksByRangeRequest{
 			HeadBlockRoot: root,

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -247,5 +247,5 @@ var E2EBeaconChainFlags = []string{
 	"--cache-filtered-block-tree",
 	"--enable-skip-slots-cache",
 	"--enable-eth1-data-vote-cache",
-	"--proto-array-forkchoice",
+	"--initial-sync-cache-state",
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -248,4 +248,5 @@ var E2EBeaconChainFlags = []string{
 	"--enable-skip-slots-cache",
 	"--enable-eth1-data-vote-cache",
 	"--initial-sync-cache-state",
+	"--proto-array-forkchoice",
 }


### PR DESCRIPTION
Resolves #4583 

Previous when we switch from initial sync step 1 to step 2, step 2 would fail because there's no real state in DB. (ie the state was still cached). This fixes it by checking both the 1.) cached state and the 2.) DB state for step 1 -> step 2 transition