### PR TITLE
Replace no-genesis-delay with custom-genesis-delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Open up two terminal windows. In the first, issue the command:
 
 ```text
 bazel run //beacon-chain -- \
---no-genesis-delay \
+--custom-genesis-delay=0 \
 --bootstrap-node= \
 --deposit-contract $(curl https://prylabs.net/contract) \
 --clear-db \

--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
         "//shared/trieutil:go_default_library",

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -240,12 +240,9 @@ func (s *Service) ProcessChainStart(genesisTime uint64, eth1BlockHash [32]byte, 
 }
 
 func (s *Service) createGenesisTime(timeStamp uint64) uint64 {
-	if featureconfig.Get().NoGenesisDelay {
-		return timeStamp
-	}
-	timeStampRdDown := timeStamp - timeStamp%params.BeaconConfig().MinGenesisDelay
+	timeStampRdDown := timeStamp - timeStamp%featureconfig.Get().CustomGenesisDelay
 	// genesisTime will be set to the first second of the day, two days after it was triggered.
-	return timeStampRdDown + 2*params.BeaconConfig().MinGenesisDelay
+	return timeStampRdDown + 2*featureconfig.Get().CustomGenesisDelay
 }
 
 // processPastLogs processes all the past logs from the deposit contract and

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -240,6 +240,9 @@ func (s *Service) ProcessChainStart(genesisTime uint64, eth1BlockHash [32]byte, 
 }
 
 func (s *Service) createGenesisTime(timeStamp uint64) uint64 {
+	if featureconfig.Get().CustomGenesisDelay == 0 {
+		return timeStamp
+	}
 	timeStampRdDown := timeStamp - timeStamp%featureconfig.Get().CustomGenesisDelay
 	// genesisTime will be set to the first second of the day, two days after it was triggered.
 	return timeStampRdDown + 2*featureconfig.Get().CustomGenesisDelay

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
 	mockPOW "github.com/prysmaticlabs/prysm/beacon-chain/powchain/testing"
 	contracts "github.com/prysmaticlabs/prysm/contracts/deposit-contract"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
@@ -322,6 +323,10 @@ func TestProcessETH2GenesisLog_8DuplicatePubkeys(t *testing.T) {
 }
 
 func TestProcessETH2GenesisLog(t *testing.T) {
+	config := &featureconfig.Flags{
+		CustomGenesisDelay: 0,
+	}
+	featureconfig.Init(config)
 	hook := logTest.NewGlobal()
 	testAcc, err := contracts.Setup()
 	if err != nil {

--- a/endtoend/beacon_node.go
+++ b/endtoend/beacon_node.go
@@ -69,7 +69,6 @@ func startNewBeaconNode(t *testing.T, config *end2EndConfig, beaconNodes []*beac
 	}
 
 	args := []string{
-		"--no-genesis-delay",
 		"--force-clear-db",
 		"--no-discovery",
 		"--http-web3provider=http://127.0.0.1:8745",

--- a/endtoend/demo_e2e_test.go
+++ b/endtoend/demo_e2e_test.go
@@ -15,7 +15,7 @@ func TestEndToEnd_DemoConfig(t *testing.T) {
 	params.UseDemoBeaconConfig()
 
 	demoConfig := &end2EndConfig{
-		beaconFlags:    featureconfig.E2EBeaconChainFlags,
+		beaconFlags:    append(featureconfig.E2EBeaconChainFlags, "--custom-genesis-delay=60"),
 		validatorFlags: featureconfig.E2EValidatorFlags,
 		epochsToRun:    5,
 		numBeaconNodes: 2,

--- a/endtoend/evaluators/BUILD.bazel
+++ b/endtoend/evaluators/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     testonly = True,
     srcs = [
+        "blocks.go",
         "finality.go",
         "validator.go",
     ],

--- a/endtoend/evaluators/BUILD.bazel
+++ b/endtoend/evaluators/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "go_default_library",
     testonly = True,
     srcs = [
-        "blocks.go",
         "finality.go",
         "node.go",
         "types.go",

--- a/endtoend/minimal_e2e_test.go
+++ b/endtoend/minimal_e2e_test.go
@@ -14,7 +14,7 @@ func TestEndToEnd_MinimalConfig(t *testing.T) {
 	params.UseMinimalConfig()
 
 	minimalConfig := &end2EndConfig{
-		beaconFlags:    append(featureconfig.E2EBeaconChainFlags, "--minimal-config"),
+		beaconFlags:    append(featureconfig.E2EBeaconChainFlags, "--minimal-config", "--custom-genesis-delay=15"),
 		validatorFlags: append(featureconfig.E2EValidatorFlags, "--minimal-config"),
 		epochsToRun:    5,
 		numBeaconNodes: 4,

--- a/shared/featureconfig/BUILD.bazel
+++ b/shared/featureconfig/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/shared/featureconfig",
     visibility = ["//visibility:public"],
     deps = [
+        "//shared/params:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli//:go_default_library",
     ],

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -19,6 +19,7 @@ The process for implementing new features using this package is as follows:
 package featureconfig
 
 import (
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )
@@ -27,7 +28,7 @@ var log = logrus.WithField("prefix", "flags")
 
 // Flags is a struct to represent which features the client will perform on runtime.
 type Flags struct {
-	NoGenesisDelay            bool   // NoGenesisDelay signals to start the chain as quickly as possible.
+	CustomGenesisDelay        uint64 // CustomGenesisDelay signals how long of a delay to set to start the chain.
 	MinimalConfig             bool   // MinimalConfig as defined in the spec.
 	WriteSSZStateTransitions  bool   // WriteSSZStateTransitions to tmp directory.
 	InitSyncNoVerify          bool   // InitSyncNoVerify when initial syncing w/o verifying block's contents.
@@ -76,9 +77,10 @@ func Init(c *Flags) {
 func ConfigureBeaconChain(ctx *cli.Context) {
 	complainOnDeprecatedFlags(ctx)
 	cfg := &Flags{}
-	if ctx.GlobalBool(noGenesisDelayFlag.Name) {
-		log.Warn("Starting ETH2 with no genesis delay")
-		cfg.NoGenesisDelay = true
+	if ctx.GlobalUint64(customGenesisDelayFlag.Name) != params.BeaconConfig().MinGenesisDelay {
+		delay := ctx.GlobalUint64(customGenesisDelayFlag.Name)
+		log.Warnf("Starting ETH2 with genesis delay of %d seconds", delay)
+		cfg.CustomGenesisDelay = delay
 	}
 	if ctx.GlobalBool(minimalConfigFlag.Name) {
 		log.Warn("Using minimal config")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -1,6 +1,7 @@
 package featureconfig
 
 import (
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/urfave/cli"
 )
 
@@ -68,11 +69,11 @@ var (
 		Usage: "Enables connection to a slasher service in order to retrieve slashable events. Slasher is connected to the beacon node using gRPC and " +
 			"the slasher-provider flag can be used to pass its address.",
 	}
-	noGenesisDelayFlag = cli.BoolFlag{
-		Name: "no-genesis-delay",
-		Usage: "Start the genesis event right away using the eth1 block timestamp which " +
-			"triggered the genesis as the genesis time. This flag should be used for local " +
-			"development and testing only.",
+	customGenesisDelayFlag = cli.Uint64Flag{
+		Name: "custom-genesis-delay",
+		Usage: "Start the genesis event with the configured genesis delay in seconds. " +
+			"This flag should be used for local development and testing only.",
+		Value: params.BeaconConfig().MinGenesisDelay,
 	}
 	cacheFilteredBlockTreeFlag = cli.BoolFlag{
 		Name: "cache-filtered-block-tree",
@@ -220,7 +221,7 @@ var E2EValidatorFlags = []string{
 
 // BeaconChainFlags contains a list of all the feature flags that apply to the beacon-chain client.
 var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
-	noGenesisDelayFlag,
+	customGenesisDelayFlag,
 	minimalConfigFlag,
 	writeSSZStateTransitionsFlag,
 	disableForkChoiceUnsafeFlag,

--- a/validator/db/attestation_history_test.go
+++ b/validator/db/attestation_history_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAttestationHistory_InitializesNewPubKeys(t *testing.T) {
-	pubkeys := [][48]byte{[48]byte{30}, [48]byte{25}, [48]byte{20}}
+	pubkeys := [][48]byte{{30}, {25}, {20}}
 	db := SetupDB(t, pubkeys)
 	defer TeardownDB(t, db)
 

--- a/validator/db/proposal_history_test.go
+++ b/validator/db/proposal_history_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestProposalHistory_InitializesNewPubKeys(t *testing.T) {
-	pubkeys := [][48]byte{[48]byte{30}, [48]byte{25}, [48]byte{20}}
+	pubkeys := [][48]byte{{30}, {25}, {20}}
 	db := SetupDB(t, pubkeys)
 	defer TeardownDB(t, db)
 


### PR DESCRIPTION
This PR changes `--no-genesis-delay` to `--custom-genesis-delay` in order to allow a 0 genesis delay but also allow configuring it for E2E and other instances where it might be needed.