### PR TITLE
Better caching of attestation pre state

### DIFF
--- a/beacon-chain/blockchain/forkchoice/process_attestation_test.go
+++ b/beacon-chain/blockchain/forkchoice/process_attestation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
@@ -40,7 +41,7 @@ func TestStore_OnAttestation(t *testing.T) {
 		t.Fatal(err)
 	}
 	BlkWithStateBadAttRoot, _ := ssz.HashTreeRoot(BlkWithStateBadAtt.Block)
-	if err := store.db.SaveState(ctx, &pb.BeaconState{}, BlkWithStateBadAttRoot); err != nil {
+	if err := store.db.SaveState(ctx, &pb.BeaconState{Slot: 100 * params.BeaconConfig().SlotsPerEpoch}, BlkWithStateBadAttRoot); err != nil {
 		t.Fatal(err)
 	}
 
@@ -150,7 +151,8 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 	}
 
 	cp1 := &ethpb.Checkpoint{Epoch: 1, Root: []byte{'A'}}
-	s1, err := store.saveCheckpointState(ctx, s, cp1)
+	store.db.SaveState(ctx, s, bytesutil.ToBytes32([]byte{'A'}))
+	s1, err := store.getAttPreState(ctx, cp1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +161,8 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 	}
 
 	cp2 := &ethpb.Checkpoint{Epoch: 2, Root: []byte{'B'}}
-	s2, err := store.saveCheckpointState(ctx, s, cp2)
+	store.db.SaveState(ctx, s, bytesutil.ToBytes32([]byte{'B'}))
+	s2, err := store.getAttPreState(ctx, cp2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +170,7 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 		t.Errorf("Wanted state slot: %d, got: %d", 2*params.BeaconConfig().SlotsPerEpoch, s2.Slot)
 	}
 
-	s1, err = store.saveCheckpointState(ctx, nil, cp1)
+	s1, err = store.getAttPreState(ctx, cp1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +199,8 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 		t.Fatal(err)
 	}
 	cp3 := &ethpb.Checkpoint{Epoch: 1, Root: []byte{'C'}}
-	s3, err := store.saveCheckpointState(ctx, s, cp3)
+	store.db.SaveState(ctx, s, bytesutil.ToBytes32([]byte{'C'}))
+	s3, err := store.getAttPreState(ctx, cp3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,11 +243,12 @@ func TestStore_UpdateCheckpointState(t *testing.T) {
 	baseState, _ := testutil.DeterministicGenesisState(t, 1)
 	baseState.Slot = epoch * params.BeaconConfig().SlotsPerEpoch
 	checkpoint := &ethpb.Checkpoint{Epoch: epoch}
-	returned, err := store.saveCheckpointState(ctx, baseState, checkpoint)
+	store.db.SaveState(ctx, baseState, bytesutil.ToBytes32(checkpoint.Root))
+	returned, err := store.getAttPreState(ctx, checkpoint)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(baseState, returned) {
+	if baseState.Slot != returned.Slot {
 		t.Error("Incorrectly returned base state")
 	}
 
@@ -251,13 +256,14 @@ func TestStore_UpdateCheckpointState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cached != nil {
-		t.Error("State shouldn't have been cached")
+	if cached == nil {
+		t.Error("State should have been cached")
 	}
 
 	epoch = uint64(2)
 	newCheckpoint := &ethpb.Checkpoint{Epoch: epoch}
-	returned, err = store.saveCheckpointState(ctx, baseState, newCheckpoint)
+	store.db.SaveState(ctx, baseState, bytesutil.ToBytes32(newCheckpoint.Root))
+	returned, err = store.getAttPreState(ctx, newCheckpoint)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +271,7 @@ func TestStore_UpdateCheckpointState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(baseState, returned) {
+	if baseState.Slot != returned.Slot {
 		t.Error("Incorrectly returned base state")
 	}
 

--- a/beacon-chain/blockchain/process_attestation.go
+++ b/beacon-chain/blockchain/process_attestation.go
@@ -83,7 +83,7 @@ func (s *Service) onAttestation(ctx context.Context, a *ethpb.Attestation) ([]ui
 	}
 
 	// Verify attestation target has had a valid pre state produced by the target block.
-	baseState, err := s.verifyAttPreState(ctx, tgt)
+	baseState, err := s.getAttPreState(ctx, tgt)
 	if err != nil {
 		return nil, err
 	}
@@ -101,12 +101,6 @@ func (s *Service) onAttestation(ctx context.Context, a *ethpb.Attestation) ([]ui
 	// Verify attestation beacon block is known and not from the future.
 	if err := s.verifyBeaconBlock(ctx, a.Data); err != nil {
 		return nil, errors.Wrap(err, "could not verify attestation beacon block")
-	}
-
-	// Service target checkpoint state if not yet seen.
-	baseState, err = s.saveCheckpointState(ctx, baseState, tgt)
-	if err != nil {
-		return nil, err
 	}
 
 	// Verify attestations can only affect the fork choice of subsequent slots.

--- a/beacon-chain/blockchain/process_attestation.go
+++ b/beacon-chain/blockchain/process_attestation.go
@@ -82,7 +82,8 @@ func (s *Service) onAttestation(ctx context.Context, a *ethpb.Attestation) ([]ui
 		return nil, ErrTargetRootNotInDB
 	}
 
-	// Verify attestation target has had a valid pre state produced by the target block.
+	// Retrieve attestation's data beacon block pre state. Advance pre state to latest epoch if necessary and
+	// save it to the cache.
 	baseState, err := s.getAttPreState(ctx, tgt)
 	if err != nil {
 		return nil, err

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -44,7 +44,6 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (*pb.
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not process slots up to %d", helpers.StartSlot(c.Epoch))
 		}
-
 	}
 
 	if err := s.checkpointState.AddCheckpointState(&cache.CheckpointState{

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -15,11 +15,20 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/attestationutil"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"go.opencensus.io/trace"
 )
 
-// verifyAttPreState validates input attested check point has a valid pre-state.
-func (s *Service) verifyAttPreState(ctx context.Context, c *ethpb.Checkpoint) (*pb.BeaconState, error) {
+// getAttPreState retrieves the att pre state by either from the cache or the DB.
+func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (*pb.BeaconState, error) {
+	s.checkpointStateLock.Lock()
+	defer s.checkpointStateLock.Unlock()
+	cachedState, err := s.checkpointState.StateByCheckpoint(c)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get cached checkpoint state")
+	}
+	if cachedState != nil {
+		return cachedState, nil
+	}
+
 	baseState, err := s.beaconDB.State(ctx, bytesutil.ToBytes32(c.Root))
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get pre state for slot %d", helpers.StartSlot(c.Epoch))
@@ -27,7 +36,25 @@ func (s *Service) verifyAttPreState(ctx context.Context, c *ethpb.Checkpoint) (*
 	if baseState == nil {
 		return nil, fmt.Errorf("pre state of target block %d does not exist", helpers.StartSlot(c.Epoch))
 	}
-	return baseState, nil
+
+	stateCopy := proto.Clone(baseState).(*pb.BeaconState)
+
+	if helpers.StartSlot(c.Epoch) > stateCopy.Slot {
+		stateCopy, err = state.ProcessSlots(ctx, stateCopy, helpers.StartSlot(c.Epoch))
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not process slots up to %d", helpers.StartSlot(c.Epoch))
+		}
+
+	}
+
+	if err := s.checkpointState.AddCheckpointState(&cache.CheckpointState{
+		Checkpoint: c,
+		State:      stateCopy,
+	}); err != nil {
+		return nil, errors.Wrap(err, "could not saved checkpoint state to cache")
+	}
+
+	return stateCopy, nil
 }
 
 // verifyAttTargetEpoch validates attestation is from the current or previous epoch.
@@ -58,42 +85,6 @@ func (s *Service) verifyBeaconBlock(ctx context.Context, data *ethpb.Attestation
 		return fmt.Errorf("could not process attestation for future block, %d > %d", b.Block.Slot, data.Slot)
 	}
 	return nil
-}
-
-// saveCheckpointState saves and returns the processed state with the associated check point.
-func (s *Service) saveCheckpointState(ctx context.Context, baseState *pb.BeaconState, c *ethpb.Checkpoint) (*pb.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "blockchain.saveCheckpointState")
-	defer span.End()
-
-	s.checkpointStateLock.Lock()
-	defer s.checkpointStateLock.Unlock()
-	cachedState, err := s.checkpointState.StateByCheckpoint(c)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get cached checkpoint state")
-	}
-	if cachedState != nil {
-		return cachedState, nil
-	}
-
-	// Advance slots only when it's higher than current state slot.
-	if helpers.StartSlot(c.Epoch) > baseState.Slot {
-		stateCopy := proto.Clone(baseState).(*pb.BeaconState)
-		stateCopy, err = state.ProcessSlots(ctx, stateCopy, helpers.StartSlot(c.Epoch))
-		if err != nil {
-			return nil, errors.Wrapf(err, "could not process slots up to %d", helpers.StartSlot(c.Epoch))
-		}
-
-		if err := s.checkpointState.AddCheckpointState(&cache.CheckpointState{
-			Checkpoint: c,
-			State:      stateCopy,
-		}); err != nil {
-			return nil, errors.Wrap(err, "could not saved checkpoint state to cache")
-		}
-
-		return stateCopy, nil
-	}
-
-	return baseState, nil
 }
 
 // verifyAttestation validates input attestation is valid.

--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -201,7 +201,7 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 	service.finalizedCheckpt = &ethpb.Checkpoint{Root: r[:]}
 	service.prevFinalizedCheckpt = &ethpb.Checkpoint{Root: r[:]}
 	cp3 := &ethpb.Checkpoint{Epoch: 1, Root: []byte{'C'}}
-
+	service.beaconDB.SaveState(ctx, s, bytesutil.ToBytes32([]byte{'C'}))
 	s3, err := service.getAttPreState(ctx, cp3)
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/cache/checkpoint_state.go
+++ b/beacon-chain/cache/checkpoint_state.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -92,7 +91,7 @@ func (c *CheckpointStateCache) StateByCheckpoint(cp *ethpb.Checkpoint) (*pb.Beac
 		return nil, ErrNotCheckpointState
 	}
 
-	return proto.Clone(info.State).(*pb.BeaconState), nil
+	return info.State, nil
 }
 
 // AddCheckpointState adds CheckpointState object to the cache. This method also trims the least

--- a/endtoend/helpers.go
+++ b/endtoend/helpers.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	maxPollingWaitTime = 36 * time.Second
+	maxPollingWaitTime  = 36 * time.Second
 	filePollingInterval = 1 * time.Second
 )
 
@@ -50,7 +50,7 @@ func waitForTextInFile(file *os.File, text string) error {
 			}
 			return fmt.Errorf("could not find requested text \"%s\" in logs:\n%s", text, string(contents))
 		case <-ticker.C:
-			_, err := file.Seek(0,io.SeekStart)
+			_, err := file.Seek(0, io.SeekStart)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR fixed up `OnAttestation` to better use the check point cache. As we previously implement from the spec, which required duplicated DB and cache read, it was bad as we saw it occupied most of the flames. The better algorithms are specified below:


**Before**
1. Always attestation pre state from DB and perform a few checks with it
2. Then check if the attestation pre state is in cache, if yes, clone the attestation and use it instead of the one in DB
3. Check if the attestation pre state is processed to latest epoch slot
4. if 2 or 3 are *no*, we use the state from step 1, and process state to the latest epoch slot
5. Save the processed state to cache

**After (optimized)**
1. Get the attestation pre state from cache
2. If it's not in cache, we get the attestation pre state from DB, clone the pre state
3. If attestation pre state is not processed to latest epoch slot, process the state to latest epoch slot
4. Save the processed state to cache
5. Perform rest of the checks

As you can see, the optimized version requires far lesser DB reads code and cloning. This has bene tested run time

**Before**
![Screen Shot 2020-01-29 at 9 41 56 AM](https://user-images.githubusercontent.com/21316537/73385146-79ce5080-4281-11ea-968a-1c9f79a1dcda.png)
**After (10x improvements)**
![Screen Shot 2020-01-29 at 9 08 53 AM](https://user-images.githubusercontent.com/21316537/73385145-79ce5080-4281-11ea-9599-dce749c5d1ff.png)