### PR TITLE
Use OR to track all of the bits we have seen so far

### DIFF
--- a/beacon-chain/operations/attestations/prepare_forkchoice_test.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice_test.go
@@ -275,7 +275,13 @@ func TestService_seen(t *testing.T) {
 			},
 			want: true, // We've full committee at this point.
 		},
-
+		{
+			att: &ethpb.Attestation{
+				AggregationBits: bitfield.Bitlist{0b11111},
+				Data:            &ethpb.AttestationData{Slot:2},
+			},
+			want: false, // Different root is different bitlist.
+		},
 		{
 			att: &ethpb.Attestation{
 				AggregationBits: bitfield.Bitlist{0b11111001},

--- a/beacon-chain/operations/attestations/prepare_forkchoice_test.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice_test.go
@@ -243,54 +243,53 @@ func TestSeenAttestations_PresentInCache(t *testing.T) {
 
 func TestService_seen(t *testing.T) {
 	// Attestation are checked in order of this list.
-	tests := []struct{
-		att *ethpb.Attestation
+	tests := []struct {
+		att  *ethpb.Attestation
 		want bool
 	}{
 		{
 			att: &ethpb.Attestation{
 				AggregationBits: bitfield.Bitlist{0b11011},
-				Data:            &ethpb.AttestationData{Slot:1},
+				Data:            &ethpb.AttestationData{Slot: 1},
 			},
 			want: false,
 		},
 		{
 			att: &ethpb.Attestation{
 				AggregationBits: bitfield.Bitlist{0b11011},
-				Data:            &ethpb.AttestationData{Slot:1},
+				Data:            &ethpb.AttestationData{Slot: 1},
 			},
 			want: true, // Exact same attestation should return true
 		},
 		{
 			att: &ethpb.Attestation{
 				AggregationBits: bitfield.Bitlist{0b10101},
-				Data:            &ethpb.AttestationData{Slot:1},
+				Data:            &ethpb.AttestationData{Slot: 1},
 			},
 			want: false, // Haven't seen the bit at index 2 yet.
 		},
 		{
 			att: &ethpb.Attestation{
 				AggregationBits: bitfield.Bitlist{0b11111},
-				Data:            &ethpb.AttestationData{Slot:1},
+				Data:            &ethpb.AttestationData{Slot: 1},
 			},
 			want: true, // We've full committee at this point.
 		},
 		{
 			att: &ethpb.Attestation{
 				AggregationBits: bitfield.Bitlist{0b11111},
-				Data:            &ethpb.AttestationData{Slot:2},
+				Data:            &ethpb.AttestationData{Slot: 2},
 			},
 			want: false, // Different root is different bitlist.
 		},
 		{
 			att: &ethpb.Attestation{
 				AggregationBits: bitfield.Bitlist{0b11111001},
-				Data:            &ethpb.AttestationData{Slot:1},
+				Data:            &ethpb.AttestationData{Slot: 1},
 			},
 			want: false, // Sanity test that an attestation of different lengths does not panic.
 		},
 	}
-
 
 	s, err := NewService(context.Background(), &Config{Pool: NewPool()})
 	if err != nil {

--- a/beacon-chain/operations/attestations/prepare_forkchoice_test.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice_test.go
@@ -240,3 +240,61 @@ func TestSeenAttestations_PresentInCache(t *testing.T) {
 		t.Error("Wanted true, got false")
 	}
 }
+
+func TestService_seen(t *testing.T) {
+	// Attestation are checked in order of this list.
+	tests := []struct{
+		att *ethpb.Attestation
+		want bool
+	}{
+		{
+			att: &ethpb.Attestation{
+				AggregationBits: bitfield.Bitlist{0b11011},
+				Data:            &ethpb.AttestationData{Slot:1},
+			},
+			want: false,
+		},
+		{
+			att: &ethpb.Attestation{
+				AggregationBits: bitfield.Bitlist{0b11011},
+				Data:            &ethpb.AttestationData{Slot:1},
+			},
+			want: true, // Exact same attestation should return true
+		},
+		{
+			att: &ethpb.Attestation{
+				AggregationBits: bitfield.Bitlist{0b10101},
+				Data:            &ethpb.AttestationData{Slot:1},
+			},
+			want: false, // Haven't seen the bit at index 2 yet.
+		},
+		{
+			att: &ethpb.Attestation{
+				AggregationBits: bitfield.Bitlist{0b11111},
+				Data:            &ethpb.AttestationData{Slot:1},
+			},
+			want: true, // We've full committee at this point.
+		},
+
+		{
+			att: &ethpb.Attestation{
+				AggregationBits: bitfield.Bitlist{0b11111001},
+				Data:            &ethpb.AttestationData{Slot:1},
+			},
+			want: false, // Sanity test that an attestation of different lengths does not panic.
+		},
+	}
+
+
+	s, err := NewService(context.Background(), &Config{Pool: NewPool()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i, tt := range tests {
+		if got, _ := s.seen(tt.att); got != tt.want {
+			t.Errorf("Test %d failed. Got=%v want=%v", i, got, tt.want)
+		}
+		time.Sleep(10) // Sleep briefly for cache to routine to buffer.
+	}
+}


### PR DESCRIPTION
As feedback from #4669.

The problem can be seen in the regression tests. 
The expected behavior is that we want to return true if all of the bits in the incoming bitlist have been seen.

