### PR TITLE
Pruning old states: Use a warning level log instead of fatal

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -170,7 +170,7 @@ func (s *Service) Start() {
 
 		if finalizedCheckpoint.Epoch > 1 {
 			if err := s.pruneGarbageState(ctx, helpers.StartSlot(finalizedCheckpoint.Epoch)-params.BeaconConfig().SlotsPerEpoch); err != nil {
-				log.Fatalf("Could not prune garbaged state: %v", err)
+				log.WithError(err).Warn("Could not prune old states")
 			}
 		}
 


### PR DESCRIPTION
Resolves #4706. 

This isn't a full fix because DeleteStates transaction is rolled back when the transaction fails, but it resolves #4706 which was blocking users starting.