### PR TITLE
Use sync.pool for keccak256 and sha256

### DIFF
--- a/shared/hashutil/hash.go
+++ b/shared/hashutil/hash.go
@@ -45,7 +45,7 @@ func Hash(data []byte) [32]byte {
 // an enclosed hasher. This is not safe for concurrent
 // use as the same hasher is being called throughout.
 func CustomSHA256Hasher() func([]byte) [32]byte {
-	hasher := sha256.New()
+	hasher := sha256Pool.Get().(hash.Hash)
 	var hash [32]byte
 
 	return func(data []byte) [32]byte {

--- a/shared/hashutil/hash.go
+++ b/shared/hashutil/hash.go
@@ -44,6 +44,9 @@ func Hash(data []byte) [32]byte {
 // CustomSHA256Hasher returns a hash function that uses
 // an enclosed hasher. This is not safe for concurrent
 // use as the same hasher is being called throughout.
+//
+// Note: that this method is only more performant over
+// hashutil.Hash if the callback is used more than 5 times.
 func CustomSHA256Hasher() func([]byte) [32]byte {
 	hasher := sha256Pool.Get().(hash.Hash)
 	hasher.Reset()

--- a/shared/hashutil/hash.go
+++ b/shared/hashutil/hash.go
@@ -36,7 +36,7 @@ func Hash(data []byte) [32]byte {
 
 	// #nosec G104
 	h.Write(data)
-	h.Sum(b[:])
+	h.Sum(b[:0])
 
 	return b
 }

--- a/shared/hashutil/hash.go
+++ b/shared/hashutil/hash.go
@@ -36,7 +36,7 @@ func Hash(data []byte) [32]byte {
 
 	// #nosec G104
 	h.Write(data)
-	h.Sum(b[:0])
+	h.Sum(b[:])
 
 	return b
 }
@@ -46,6 +46,7 @@ func Hash(data []byte) [32]byte {
 // use as the same hasher is being called throughout.
 func CustomSHA256Hasher() func([]byte) [32]byte {
 	hasher := sha256Pool.Get().(hash.Hash)
+	hasher.Reset()
 	var hash [32]byte
 
 	return func(data []byte) [32]byte {

--- a/shared/hashutil/hash_test.go
+++ b/shared/hashutil/hash_test.go
@@ -56,6 +56,12 @@ func TestHashKeccak256(t *testing.T) {
 	}
 }
 
+func BenchmarkHashKeccak256(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		hashutil.HashKeccak256([]byte("abc"))
+	}
+}
+
 func TestHashProto(t *testing.T) {
 	msg1 := &pb.Puzzle{
 		Challenge: "hello",

--- a/shared/hashutil/hash_test.go
+++ b/shared/hashutil/hash_test.go
@@ -28,6 +28,12 @@ func TestHash(t *testing.T) {
 	}
 }
 
+func BenchmarkHash(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		hashutil.Hash([]byte("abc"))
+	}
+}
+
 func TestHashKeccak256(t *testing.T) {
 	hashOf0 := [32]byte{188, 54, 120, 158, 122, 30, 40, 20, 54, 70, 66, 41, 130, 143, 129, 125, 102, 18, 247, 180, 119, 214, 101, 145, 255, 150, 169, 224, 100, 188, 201, 138}
 	hash := hashutil.HashKeccak256([]byte{0})


### PR DESCRIPTION
Before
```

BenchmarkHash-8                  1246952              1097 ns/op             179 B/op          4 allocs/op
BenchmarkHashKeccak256-8          344100              3352 ns/op             515 B/op          4 allocs/op

```

After
```
BenchmarkHash-8                  1967601               513 ns/op              35 B/op          2 allocs/op
BenchmarkHashKeccak256-8          807060              2536 ns/op             515 B/op          4 allocs/op
```


Non-trivial improvement, yay!