### PR TITLE
Propagate blocks again after we process it in pending blocks queue

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -100,6 +100,11 @@ func (r *Service) processPendingBlocks(ctx context.Context) error {
 			traceutil.AnnotateError(span, err)
 		}
 
+		// Broadcasting the block again once a node is able to process it.
+		if err := r.p2p.Broadcast(ctx, b); err != nil {
+			log.WithError(err).Error("Failed to broadcast block")
+		}
+
 		blkRoot, err := ssz.HashTreeRoot(b.Block)
 		if err != nil {
 			traceutil.AnnotateError(span, err)


### PR DESCRIPTION
Since we didn't propagate a block that failed to process when we were missing the parent block, broadcast each block after it has been processed to ensure it reaches the full network.