### PR TITLE
Handle missing target 

### DIFF
--- a/beacon-chain/state/types.go
+++ b/beacon-chain/state/types.go
@@ -86,7 +86,7 @@ func (b *BeaconState) Copy() *BeaconState {
 		dirtyFields: make(map[fieldIndex]interface{}, 20),
 
 		// Copy on write validator index map.
-		valIdxMap:   b.valIdxMap,
+		valIdxMap: b.valIdxMap,
 	}
 
 	for i := range b.dirtyFields {

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -47,7 +47,8 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 		// Has the pending attestation's missing block arrived yet?
 		beaconRoot := bytesutil.ToBytes32(bRoot[:32])
 		targetRoot := bytesutil.ToBytes32(bRoot[32:])
-		if s.db.HasBlock(ctx, beaconRoot) && s.db.HasBlock(ctx, targetRoot) {
+		if s.db.HasBlock(ctx, beaconRoot) &&
+			(targetRoot != params.BeaconConfig().ZeroHash || s.db.HasBlock(ctx, targetRoot)) {
 			numberOfBlocksRecoveredFromAtt.Inc()
 			for _, att := range attestations {
 				// The pending attestations can arrive in both aggregated and unaggregated forms,

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -56,7 +56,7 @@ func NewRegularSync(cfg *Config) *Service {
 		initialSync:          cfg.InitialSync,
 		slotToPendingBlocks:  make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:    make(map[[32]byte]bool),
-		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.AggregateAttestationAndProof),
+		blkRootToPendingAtts: make(map[[64]byte][]*ethpb.AggregateAttestationAndProof),
 		stateNotifier:        cfg.StateNotifier,
 		blocksRateLimiter:    leakybucket.NewCollector(allowedBlocksPerSecond, allowedBlocksBurst, false /* deleteEmptyBuckets */),
 	}
@@ -79,7 +79,7 @@ type Service struct {
 	chain                blockchainService
 	slotToPendingBlocks  map[uint64]*ethpb.SignedBeaconBlock
 	seenPendingBlocks    map[[32]byte]bool
-	blkRootToPendingAtts map[[32]byte][]*ethpb.AggregateAttestationAndProof
+	blkRootToPendingAtts map[[64]byte][]*ethpb.AggregateAttestationAndProof
 	pendingAttsLock      sync.RWMutex
 	pendingQueueLock     sync.RWMutex
 	chainStarted         bool

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -81,11 +81,6 @@ func (r *Service) validateAggregatedAtt(ctx context.Context, a *ethpb.AggregateA
 		return false
 	}
 
-	if !r.db.HasBlock(ctx, bytesutil.ToBytes32(a.Aggregate.Data.Target.Root)) {
-		r.savePendingAtt(a)
-		return false
-	}
-
 	// Verify attestation slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots.
 	currentSlot := uint64(roughtime.Now().Unix()-r.chain.GenesisTime().Unix()) / params.BeaconConfig().SecondsPerSlot
 	if attSlot > currentSlot || currentSlot > attSlot+params.BeaconConfig().AttestationPropagationSlotRange {

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -81,6 +81,11 @@ func (r *Service) validateAggregatedAtt(ctx context.Context, a *ethpb.AggregateA
 		return false
 	}
 
+	if !r.db.HasBlock(ctx, bytesutil.ToBytes32(a.Aggregate.Data.Target.Root)) {
+		r.savePendingAtt(a)
+		return false
+	}
+
 	// Verify attestation slot is within the last ATTESTATION_PROPAGATION_SLOT_RANGE slots.
 	currentSlot := uint64(roughtime.Now().Unix()-r.chain.GenesisTime().Unix()) / params.BeaconConfig().SecondsPerSlot
 	if attSlot > currentSlot || currentSlot > attSlot+params.BeaconConfig().AttestationPropagationSlotRange {

--- a/shared/bytesutil/bytes.go
+++ b/shared/bytesutil/bytes.go
@@ -122,6 +122,15 @@ func ToBytes48(x []byte) [48]byte {
 	return y
 }
 
+// ToBytes64 is a convenience method for converting a byte slice to a fix
+// sized 64 byte array. This method will truncate the input if it is larger
+// than 64 bytes.
+func ToBytes64(x []byte) [64]byte {
+	var y [64]byte
+	copy(y[:], x)
+	return y
+}
+
 // FromBytes32 is a convenience method for converting a fixed-size byte array
 // to a byte slice.
 func FromBytes32(x [32]byte) []byte {


### PR DESCRIPTION
Change list
* Turn key from **32byte** block root to **64byte** block root and target root
* Require both to be in DB to save to validate and save to attestation pool
* Request either block root or target root from peer if not in DB