### PR TITLE
Validator prometheus metrics

### DIFF
--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -41,6 +41,8 @@ go_library(
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
     ],
 )
 

--- a/validator/client/validator_aggregate.go
+++ b/validator/client/validator_aggregate.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,9 +25,7 @@ var (
 		},
 		[]string{
 			// validator pubkey
-			"pubKey",
-			// slot for this metric
-			"slot",
+			"pkey",
 		},
 	)
 	validatorAggFailVec = promauto.NewCounterVec(
@@ -38,9 +35,7 @@ var (
 		},
 		[]string{
 			// validator pubkey
-			"pubKey",
-			// slot for this metric
-			"slot",
+			"pkey",
 		},
 	)
 )
@@ -59,14 +54,14 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot uint64, pu
 	duty, err := v.duty(pubKey)
 	if err != nil {
 		log.Errorf("Could not fetch validator assignment: %v", err)
-		validatorAggFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
+		validatorAggFailVec.WithLabelValues(fmtKey).Inc()
 		return
 	}
 
 	slotSig, err := v.signSlot(ctx, pubKey, slot)
 	if err != nil {
 		log.Errorf("Could not sign slot: %v", err)
-		validatorAggFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
+		validatorAggFailVec.WithLabelValues(fmtKey).Inc()
 		return
 	}
 
@@ -83,16 +78,16 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot uint64, pu
 	})
 	if err != nil {
 		log.Errorf("Could not submit slot signature to beacon node: %v", err)
-		validatorAggFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
+		validatorAggFailVec.WithLabelValues().Inc()
 		return
 	}
 
 	if err := v.addIndicesToLog(duty); err != nil {
 		log.Errorf("Could not add aggregator indices to logs: %v", err)
-		validatorAggFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
+		validatorAggFailVec.WithLabelValues(fmtKey).Inc()
 		return
 	}
-	validatorAggSuccessVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
+	validatorAggSuccessVec.WithLabelValues(fmtKey).Inc()
 
 }
 

--- a/validator/client/validator_aggregate.go
+++ b/validator/client/validator_aggregate.go
@@ -22,7 +22,7 @@ var (
 	validatorAggSuccessVec = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "validator",
-			Name:      "successful_attestations",
+			Name:      "successful_aggregations",
 		},
 		[]string{
 			// validator pubkey
@@ -34,7 +34,7 @@ var (
 	validatorAggFailVec = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "validator",
-			Name:      "failed_attestations",
+			Name:      "failed_aggregations",
 		},
 		[]string{
 			// validator pubkey

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/go-ssz"
@@ -21,6 +24,33 @@ import (
 	"go.opencensus.io/trace"
 )
 
+var (
+	validatorAttestSuccessVec = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "validator",
+			Name:      "successful_attestations",
+		},
+		[]string{
+			// validator pubkey
+			"pubKey",
+			// slot for this metric
+			"slot",
+		},
+	)
+	validatorAttestFailVec = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "validator",
+			Name:      "failed_attestations",
+		},
+		[]string{
+			// validator pubkey
+			"pubKey",
+			// slot for this metric
+			"slot",
+		},
+	)
+)
+
 // SubmitAttestation completes the validator client's attester responsibility at a given slot.
 // It fetches the latest beacon block head along with the latest canonical beacon state
 // information in order to sign the block and include information about the validator's
@@ -30,10 +60,12 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 	defer span.End()
 	span.AddAttributes(trace.StringAttribute("validator", fmt.Sprintf("%#x", pubKey)))
 
+	fmtKey := fmt.Sprintf("%#x", pubKey[:8])
 	log := log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKey[:]))).WithField("slot", slot)
 	duty, err := v.duty(pubKey)
 	if err != nil {
 		log.WithError(err).Error("Could not fetch validator assignment")
+		validatorAttestFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 		return
 	}
 
@@ -49,6 +81,7 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 	data, err := v.validatorClient.GetAttestationData(ctx, req)
 	if err != nil {
 		log.WithError(err).Error("Could not request attestation to sign at slot")
+		validatorAttestFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 		return
 	}
 
@@ -56,6 +89,7 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		history, err := v.db.AttestationHistory(ctx, pubKey[:])
 		if err != nil {
 			log.Errorf("Could not get attestation history from DB: %v", err)
+			validatorAttestFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 			return
 		}
 		if isNewAttSlashable(history, data.Source.Epoch, data.Target.Epoch) {
@@ -63,6 +97,7 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 				"sourceEpoch": data.Source.Epoch,
 				"targetEpoch": data.Target.Epoch,
 			}).Error("Attempted to make a slashable attestation, rejected")
+			validatorAttestFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 			return
 		}
 	}
@@ -70,6 +105,7 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 	sig, err := v.signAtt(ctx, pubKey, data)
 	if err != nil {
 		log.WithError(err).Error("Could not sign attestation")
+		validatorAttestFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 		return
 	}
 
@@ -84,6 +120,7 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 	}
 	if !found {
 		log.Errorf("Validator ID %d not found in committee of %v", duty.ValidatorIndex, duty.Committee)
+		validatorAttestFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 		return
 	}
 
@@ -98,6 +135,7 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 	attResp, err := v.validatorClient.ProposeAttestation(ctx, attestation)
 	if err != nil {
 		log.WithError(err).Error("Could not submit attestation to beacon node")
+		validatorAttestFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 		return
 	}
 
@@ -105,19 +143,24 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		history, err := v.db.AttestationHistory(ctx, pubKey[:])
 		if err != nil {
 			log.Errorf("Could not get attestation history from DB: %v", err)
+			validatorAttestFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 			return
 		}
 		history = markAttestationForTargetEpoch(history, data.Source.Epoch, data.Target.Epoch)
 		if err := v.db.SaveAttestationHistory(ctx, pubKey[:], history); err != nil {
 			log.Errorf("Could not save attestation history to DB: %v", err)
+			validatorAttestFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 			return
 		}
 	}
 
 	if err := v.saveAttesterIndexToData(data, duty.ValidatorIndex); err != nil {
 		log.WithError(err).Error("Could not save validator index for logging")
+		validatorAttestFailVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 		return
 	}
+
+	validatorAttestSuccessVec.WithLabelValues(fmtKey, strconv.FormatUint(slot, 10)).Inc()
 
 	span.AddAttributes(
 		trace.Int64Attribute("slot", int64(slot)),

--- a/validator/client/validator_metrics.go
+++ b/validator/client/validator_metrics.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -21,9 +20,7 @@ var validatorBalancesGaugeVec = promauto.NewGaugeVec(
 	},
 	[]string{
 		// validator pubkey
-		"pubKey",
-		// slot for this metric
-		"slot",
+		"pkey",
 	},
 )
 
@@ -65,7 +62,7 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 		log := log.WithField("pubKey", pubKey)
 		if missingValidators[bytesutil.ToBytes48(pkey)] {
 			log.Info("Validator not in beacon chain")
-			validatorBalancesGaugeVec.WithLabelValues(pubKey, strconv.FormatUint(slot, 10)).Set(0)
+			validatorBalancesGaugeVec.WithLabelValues(pubKey).Set(0)
 			continue
 		}
 		if slot < params.BeaconConfig().SlotsPerEpoch {
@@ -82,7 +79,7 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 				"newBalance":    newBalance,
 				"percentChange": fmt.Sprintf("%.5f%%", percentNet*100),
 			}).Info("New Balance")
-			validatorBalancesGaugeVec.WithLabelValues(pubKey, strconv.FormatUint(slot, 10)).Set(newBalance)
+			validatorBalancesGaugeVec.WithLabelValues(pubKey).Set(newBalance)
 
 		}
 		v.prevBalance[bytesutil.ToBytes48(pkey)] = resp.Balances[i]

--- a/validator/client/validator_metrics.go
+++ b/validator/client/validator_metrics.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -20,7 +21,7 @@ var validatorBalancesGaugeVec = promauto.NewGaugeVec(
 	},
 	[]string{
 		// validator pubkey
-		"pkey",
+		"pubKey",
 		// slot for this metric
 		"slot",
 	},
@@ -64,7 +65,7 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 		log := log.WithField("pubKey", pubKey)
 		if missingValidators[bytesutil.ToBytes48(pkey)] {
 			log.Info("Validator not in beacon chain")
-			validatorBalancesGaugeVec.WithLabelValues(pubKey, slot).Set(0)
+			validatorBalancesGaugeVec.WithLabelValues(pubKey, strconv.FormatUint(slot, 10)).Set(0)
 			continue
 		}
 		if slot < params.BeaconConfig().SlotsPerEpoch {
@@ -81,7 +82,7 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 				"newBalance":    newBalance,
 				"percentChange": fmt.Sprintf("%.5f%%", percentNet*100),
 			}).Info("New Balance")
-			validatorBalancesGaugeVec.WithLabelValues(pubKey, slot).Set(newBalance)
+			validatorBalancesGaugeVec.WithLabelValues(pubKey, strconv.FormatUint(slot, 10)).Set(newBalance)
 
 		}
 		v.prevBalance[bytesutil.ToBytes48(pkey)] = resp.Balances[i]

--- a/validator/client/validator_propose.go
+++ b/validator/client/validator_propose.go
@@ -24,7 +24,7 @@ var (
 	validatorProposeSuccessVec = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "validator",
-			Name:      "successful_attestations",
+			Name:      "successful_proposals",
 		},
 		[]string{
 			// validator pubkey
@@ -36,7 +36,7 @@ var (
 	validatorProposeFailVec = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "validator",
-			Name:      "failed_attestations",
+			Name:      "failed_proposals",
 		},
 		[]string{
 			// validator pubkey


### PR DESCRIPTION
# Description

This PR adds validator prometheus metrics for balances, attestations, aggs and proposals.  The metrics are in support of dashboarding and alerting via prometheus/grafana:  https://gist.github.com/garyschulte/fda2a1878460f77b98f3af7b17748072

The namespace for these metrics is `validator`, and added metrics include
validator_balance {pkey=<public_key>}
validator_successful_attestations {pkey=<public_key>}
validator_failed_attestations {pkey=<public_key>}
validator_successful_aggregations {pkey=<public_key>}
validator_failed_aggregations {pkey=<public_key>}
validator_successful_proposals {pkey=<public_key>}
validator_failed_proposals {pkey=<public_key>}