### PR TITLE
Fork choice: only update head if the new block is a higher block slot

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -125,7 +125,7 @@ func (s *Service) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.SignedB
 
 	processedBlkNoPubsub.Inc()
 
-	if featureconfig.Get().DisableForkChoice {
+	if featureconfig.Get().DisableForkChoice && block.Block.Slot > s.headSlot {
 		if err := s.saveHead(ctx, blockCopy, root); err != nil {
 			return errors.Wrap(err, "could not save head")
 		}


### PR DESCRIPTION
When fork choice is disabled, use a naive "if this block has a higher slot than my previous head" method rather than "whatever comes in next is the new head".

This fix recovered the testnet issues today.