### PR TITLE
Increase BLS pubkey cache to 100k from 10k

### DIFF
--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -24,7 +24,7 @@ func init() {
 	bls12.SetETHserialization(true)
 }
 
-var maxKeys = int64(10000)
+var maxKeys = int64(100000)
 var pubkeyCache, _ = ristretto.NewCache(&ristretto.Config{
 	NumCounters: maxKeys,
 	MaxCost:     1 << 19, // 500 kb is cache max size


### PR DESCRIPTION
Heap was showing about 15mb of usage after an hour or so at this size. This significantly reduced CPU usage in BLS. 