### PR TITLE
Fix `pre state of target block does not exist` error

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -188,10 +188,10 @@ func (s *Service) onBlockInitialSyncStateTransition(ctx context.Context, signed 
 
 	if featureconfig.Get().InitSyncCacheState {
 		s.initSyncState[root] = postState
-	}
-
-	if err := s.beaconDB.SaveState(ctx, postState, root); err != nil {
-		return nil, errors.Wrap(err, "could not save state")
+	} else {
+		if err := s.beaconDB.SaveState(ctx, postState, root); err != nil {
+			return nil, errors.Wrap(err, "could not save state")
+		}
 	}
 
 	// Update justified check point.
@@ -240,6 +240,14 @@ func (s *Service) onBlockInitialSyncStateTransition(ctx context.Context, signed 
 		}
 		if err := helpers.UpdateProposerIndicesInCache(postState, helpers.CurrentEpoch(postState)); err != nil {
 			return nil, err
+		}
+
+		if featureconfig.Get().InitSyncCacheState {
+			if helpers.IsEpochStart(postState.Slot()) {
+				if err := s.beaconDB.SaveState(ctx, postState, root); err != nil {
+					return nil, errors.Wrap(err, "could not save state")
+				}
+			}
 		}
 	}
 

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -188,10 +188,10 @@ func (s *Service) onBlockInitialSyncStateTransition(ctx context.Context, signed 
 
 	if featureconfig.Get().InitSyncCacheState {
 		s.initSyncState[root] = postState
-	} else {
-		if err := s.beaconDB.SaveState(ctx, postState, root); err != nil {
-			return nil, errors.Wrap(err, "could not save state")
-		}
+	}
+
+	if err := s.beaconDB.SaveState(ctx, postState, root); err != nil {
+		return nil, errors.Wrap(err, "could not save state")
 	}
 
 	// Update justified check point.

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -112,10 +112,10 @@ func (s *Service) processAttestation() {
 
 				if err := s.ReceiveAttestationNoPubsub(ctx, a); err != nil {
 					log.WithFields(logrus.Fields{
-						"slot": a.Data.Slot,
-						"committeeIndex": a.Data.CommitteeIndex,
-						"beaconBlockRoot": fmt.Sprintf("%#x", bytesutil.Trunc(a.Data.BeaconBlockRoot)),
-						"targetRoot": fmt.Sprintf("%#x", bytesutil.Trunc(a.Data.Target.Root)),
+						"slot":             a.Data.Slot,
+						"committeeIndex":   a.Data.CommitteeIndex,
+						"beaconBlockRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(a.Data.BeaconBlockRoot)),
+						"targetRoot":       fmt.Sprintf("%#x", bytesutil.Trunc(a.Data.Target.Root)),
 						"aggregationCount": a.AggregationBits.Count(),
 					}).WithError(err).Error("Could not receive attestation in chain service")
 				}


### PR DESCRIPTION
We still need to save the state (not expensive) because we need to process attestations right after initial sync ends. We also does state pruning during initial sync so it's not a big deal.

This solves the following error:
![Screen Shot 2020-02-03 at 5 46 37 PM](https://user-images.githubusercontent.com/21316537/73720699-64b94d80-46d7-11ea-9669-98c005e30886.png)
