### PR TITLE
Don't insert head to proto array DAG as index 0

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -163,9 +163,7 @@ func (s *Service) Start() {
 			s.finalizedCheckpt = proto.Clone(finalizedCheckpoint).(*ethpb.Checkpoint)
 			s.prevFinalizedCheckpt = proto.Clone(finalizedCheckpoint).(*ethpb.Checkpoint)
 
-			if err := s.resumeForkChoice(ctx, justifiedCheckpoint, finalizedCheckpoint); err != nil {
-				log.Fatalf("Could not resume fork choice: %v", err)
-			}
+			s.resumeForkChoice(justifiedCheckpoint, finalizedCheckpoint)
 		}
 
 		if finalizedCheckpoint.Epoch > 1 {
@@ -476,33 +474,7 @@ func (s *Service) pruneGarbageState(ctx context.Context, slot uint64) error {
 
 // This is called when a client starts from non-genesis slot. This passes last justified and finalized
 // information to fork choice service to initializes fork choice store.
-func (s *Service) resumeForkChoice(
-	ctx context.Context,
-	justifiedCheckpoint *ethpb.Checkpoint,
-	finalizedCheckpoint *ethpb.Checkpoint) error {
+func (s *Service) resumeForkChoice(justifiedCheckpoint *ethpb.Checkpoint, finalizedCheckpoint *ethpb.Checkpoint) {
 	store := protoarray.New(justifiedCheckpoint.Epoch, finalizedCheckpoint.Epoch, bytesutil.ToBytes32(finalizedCheckpoint.Root))
 	s.forkChoiceStore = store
-
-	headBlock, err := s.beaconDB.HeadBlock(ctx)
-	if err != nil {
-		return err
-	}
-	if headBlock == nil || headBlock.Block == nil {
-		return errors.New("head block is nil")
-	}
-	headBlockRoot, err := ssz.HashTreeRoot(headBlock.Block)
-	if err != nil {
-		return err
-	}
-	if err := s.forkChoiceStore.ProcessBlock(
-		ctx,
-		headBlock.Block.Slot,
-		headBlockRoot,
-		bytesutil.ToBytes32(headBlock.Block.ParentRoot),
-		finalizedCheckpoint.Epoch,
-		justifiedCheckpoint.Epoch); err != nil {
-		return err
-	}
-
-	return nil
 }


### PR DESCRIPTION
Looking at the Vizgraph, I was confused on why initial sync and regular sync don’t belong in the same branch. As we didn’t think it was that big of the deal, the following warning log was temporary as it eventually goes away:
`[2020-02-04 15:31:07]  WARN blockchain: Skip head update for slot 187055: head at slot 187008 with weight 4831 is not eligible, finalizedEpoch 5842 != 5843, justifiedEpoch 5843 != 5844`

After looking at this more, we realized to resume syncing, node gets the 1.) head block then start start sync from 2.) last finalized check point. So fork choice insert head block into the array as index 0. The issue is illustrated as the following:
```
Index 0, block_at_slot: 888 (head block)
Index 1, block_at_slot: 800 (last finalized block)
Index 2, block_at_slot: 801 (last finalized block)
Index 3, block_at_slot: 802 (last finalized block)
…
…
Index 889, block_at_slot: 889 (head_block_slot + 1)
```

What's wrong with above is the node at index 889 got built on top of index 0 instead of index 888 and became its separate branch. So everything from index 1 to index 888 basically didn’t count which is why it takes some time to get a new head when node first starts. Bottom branch is 1 to 888. And top is 889 built on top of index 0. The graph proved it:

![Screen Shot 2020-02-04 at 3 32 30 PM](https://user-images.githubusercontent.com/21316537/73802266-fd041080-4771-11ea-8add-ba873ef2c572.png)

To fix this, a node simply should not insert head to index 0, there's just no reason to do it. 