### PR TITLE
Update head slot metric after compute head

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -112,12 +112,6 @@ func (s *Service) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.SignedB
 		s.exitPool.MarkIncluded(exit)
 	}
 
-	// Reports on block and fork choice metrics.
-	metrics.ReportSlotMetrics(blockCopy.Block.Slot, s.headSlot, s.headState)
-
-	// Log state transition data.
-	logStateTransitionData(blockCopy.Block)
-
 	s.epochParticipationLock.Lock()
 	defer s.epochParticipationLock.Unlock()
 	s.epochParticipation[helpers.SlotToEpoch(blockCopy.Block.Slot)] = precompute.Balances
@@ -172,6 +166,12 @@ func (s *Service) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.SignedB
 			isCompetingBlock(root[:], blockCopy.Block.Slot, headRoot, signedHeadBlock.Block.Slot)
 		}
 	}
+
+	// Reports on block and fork choice metrics.
+	metrics.ReportSlotMetrics(blockCopy.Block.Slot, s.headSlot, s.headState)
+
+	// Log state transition data.
+	logStateTransitionData(blockCopy.Block)
 
 	return nil
 }


### PR DESCRIPTION
I found it weird the reporting of `head_slot` is always one slot behind versus proto array's service reporting. It turns out we update `head_slot` metric before computing for head slot. We should update `head_slot` metric after computing and this PR fixed that.