### PR TITLE
Eliminate All Batch Calls to Deleting States

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -61,13 +61,10 @@ type NoHeadAccessDatabase interface {
 	ReadOnlyDatabase
 
 	// Attestation related methods.
-	DeleteAttestation(ctx context.Context, attDataRoot [32]byte) error
 	DeleteAttestations(ctx context.Context, attDataRoots [][32]byte) error
 	SaveAttestation(ctx context.Context, att *eth.Attestation) error
 	SaveAttestations(ctx context.Context, atts []*eth.Attestation) error
 	// Block related methods.
-	DeleteBlock(ctx context.Context, blockRoot [32]byte) error
-	DeleteBlocks(ctx context.Context, blockRoots [][32]byte) error
 	SaveBlock(ctx context.Context, block *eth.SignedBeaconBlock) error
 	SaveBlocks(ctx context.Context, blocks []*eth.SignedBeaconBlock) error
 	SaveGenesisBlockRoot(ctx context.Context, blockRoot [32]byte) error
@@ -77,7 +74,6 @@ type NoHeadAccessDatabase interface {
 	SaveValidatorIndices(ctx context.Context, publicKeys [][48]byte, validatorIndices []uint64) error
 	// State related methods.
 	SaveState(ctx context.Context, state *state.BeaconState, blockRoot [32]byte) error
-	DeleteState(ctx context.Context, blockRoot [32]byte) error
 	DeleteStates(ctx context.Context, blockRoots [][32]byte) error
 	// Slashing operations.
 	SaveProposerSlashing(ctx context.Context, slashing *eth.ProposerSlashing) error

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -42,11 +42,6 @@ func (e Exporter) HasAttestation(ctx context.Context, attDataRoot [32]byte) bool
 	return e.db.HasAttestation(ctx, attDataRoot)
 }
 
-// DeleteAttestation -- passthrough.
-func (e Exporter) DeleteAttestation(ctx context.Context, attDataRoot [32]byte) error {
-	return e.db.DeleteAttestation(ctx, attDataRoot)
-}
-
 // DeleteAttestations -- passthrough.
 func (e Exporter) DeleteAttestations(ctx context.Context, attDataRoots [][32]byte) error {
 	return e.db.DeleteAttestations(ctx, attDataRoots)
@@ -75,16 +70,6 @@ func (e Exporter) BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][32
 // HasBlock -- passthrough.
 func (e Exporter) HasBlock(ctx context.Context, blockRoot [32]byte) bool {
 	return e.db.HasBlock(ctx, blockRoot)
-}
-
-// DeleteBlock -- passthrough.
-func (e Exporter) DeleteBlock(ctx context.Context, blockRoot [32]byte) error {
-	return e.db.DeleteBlock(ctx, blockRoot)
-}
-
-// DeleteBlocks -- passthrough.
-func (e Exporter) DeleteBlocks(ctx context.Context, blockRoots [][32]byte) error {
-	return e.db.DeleteBlocks(ctx, blockRoots)
 }
 
 // ValidatorIndex -- passthrough.
@@ -275,11 +260,6 @@ func (e Exporter) SaveArchivedValidatorParticipation(ctx context.Context, epoch 
 // SaveDepositContractAddress -- passthrough.
 func (e Exporter) SaveDepositContractAddress(ctx context.Context, addr common.Address) error {
 	return e.db.SaveDepositContractAddress(ctx, addr)
-}
-
-// DeleteState -- passthrough.
-func (e Exporter) DeleteState(ctx context.Context, blockRoot [32]byte) error {
-	return e.db.DeleteState(ctx, blockRoot)
 }
 
 // DeleteStates -- passthrough.

--- a/beacon-chain/db/kv/attestations.go
+++ b/beacon-chain/db/kv/attestations.go
@@ -91,28 +91,6 @@ func (k *Store) HasAttestation(ctx context.Context, attDataRoot [32]byte) bool {
 	return exists
 }
 
-// DeleteAttestation by attestation data root.
-func (k *Store) DeleteAttestation(ctx context.Context, attDataRoot [32]byte) error {
-	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteAttestation")
-	defer span.End()
-	return k.db.Batch(func(tx *bolt.Tx) error {
-		bkt := tx.Bucket(attestationsBucket)
-		enc := bkt.Get(attDataRoot[:])
-		if enc == nil {
-			return nil
-		}
-		ac := &dbpb.AttestationContainer{}
-		if err := decode(enc, ac); err != nil {
-			return err
-		}
-		indicesByBucket := createAttestationIndicesFromData(ac.Data)
-		if err := deleteValueForIndices(indicesByBucket, attDataRoot[:], tx); err != nil {
-			return errors.Wrap(err, "could not delete root for DB indices")
-		}
-		return bkt.Delete(attDataRoot[:])
-	})
-}
-
 // DeleteAttestations by attestation data roots.
 func (k *Store) DeleteAttestations(ctx context.Context, attDataRoots [][32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteAttestations")

--- a/beacon-chain/db/kv/attestations_test.go
+++ b/beacon-chain/db/kv/attestations_test.go
@@ -47,7 +47,7 @@ func TestStore_AttestationCRUD(t *testing.T) {
 	if !proto.Equal(att, retrievedAtts[0]) {
 		t.Errorf("Wanted %v, received %v", att, retrievedAtts[0])
 	}
-	if err := db.DeleteAttestation(ctx, attDataRoot); err != nil {
+	if err := db.DeleteAttestations(ctx, [][32]byte{attDataRoot}); err != nil {
 		t.Fatal(err)
 	}
 	if db.HasAttestation(ctx, attDataRoot) {
@@ -153,7 +153,7 @@ func TestStore_BoltDontPanic(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := db.DeleteAttestation(ctx, attDataRoot); err != nil {
+			if err := db.DeleteAttestations(ctx, [][32]byte{attDataRoot}); err != nil {
 				t.Fatal(err)
 			}
 			if db.HasAttestation(ctx, attDataRoot) {

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -2,8 +2,6 @@ package kv
 
 import (
 	"context"
-	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -88,65 +86,6 @@ func TestStore_BlocksCRUD(t *testing.T) {
 	if !proto.Equal(block, retrievedBlock) {
 		t.Errorf("Wanted %v, received %v", block, retrievedBlock)
 	}
-	if err := db.DeleteBlock(ctx, blockRoot); err != nil {
-		t.Fatal(err)
-	}
-	if db.HasBlock(ctx, blockRoot) {
-		t.Error("Expected block to have been deleted from the db")
-	}
-}
-
-func TestStore_BlocksBatchDelete(t *testing.T) {
-	db := setupDB(t)
-	defer teardownDB(t, db)
-	ctx := context.Background()
-	numBlocks := 1000
-	totalBlocks := make([]*ethpb.SignedBeaconBlock, numBlocks)
-	blockRoots := make([][32]byte, 0)
-	oddBlocks := make([]*ethpb.SignedBeaconBlock, 0)
-	for i := 0; i < len(totalBlocks); i++ {
-		totalBlocks[i] = &ethpb.SignedBeaconBlock{
-			Block: &ethpb.BeaconBlock{
-				Slot:       uint64(i),
-				ParentRoot: []byte("parent"),
-			},
-		}
-
-		if i%2 == 0 {
-			r, err := ssz.HashTreeRoot(totalBlocks[i].Block)
-			if err != nil {
-				t.Fatal(err)
-			}
-			blockRoots = append(blockRoots, r)
-		} else {
-			oddBlocks = append(oddBlocks, totalBlocks[i])
-		}
-	}
-	if err := db.SaveBlocks(ctx, totalBlocks); err != nil {
-		t.Fatal(err)
-	}
-	retrieved, err := db.Blocks(ctx, filters.NewFilter().SetParentRoot([]byte("parent")))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(retrieved) != numBlocks {
-		t.Errorf("Received %d blocks, wanted 1000", len(retrieved))
-	}
-	// We delete all even indexed blocks.
-	if err := db.DeleteBlocks(ctx, blockRoots); err != nil {
-		t.Fatal(err)
-	}
-	// When we retrieve the data, only the odd indexed blocks should remain.
-	retrieved, err = db.Blocks(ctx, filters.NewFilter().SetParentRoot([]byte("parent")))
-	if err != nil {
-		t.Fatal(err)
-	}
-	sort.Slice(retrieved, func(i, j int) bool {
-		return retrieved[i].Block.Slot < retrieved[j].Block.Slot
-	})
-	if !reflect.DeepEqual(retrieved, oddBlocks) {
-		t.Errorf("Wanted %v, received %v", oddBlocks, retrieved)
-	}
 }
 
 func TestStore_GenesisBlock(t *testing.T) {
@@ -212,12 +151,6 @@ func TestStore_BlocksCRUD_NoCache(t *testing.T) {
 	}
 	if !proto.Equal(block, retrievedBlock) {
 		t.Errorf("Wanted %v, received %v", block, retrievedBlock)
-	}
-	if err := db.DeleteBlock(ctx, blockRoot); err != nil {
-		t.Fatal(err)
-	}
-	if db.HasBlock(ctx, blockRoot) {
-		t.Error("Expected block to have been deleted from the db")
 	}
 }
 

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -199,7 +199,7 @@ func TestStore_DeleteGenesisState(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantedErr := "cannot delete genesis, finalized, or head state"
-	if err := db.DeleteState(ctx, genesisBlockRoot); err.Error() != wantedErr {
+	if err := db.DeleteStates(ctx, [][32]byte{genesisBlockRoot}); err.Error() != wantedErr {
 		t.Error("Did not receive wanted error")
 	}
 }
@@ -241,7 +241,7 @@ func TestStore_DeleteFinalizedState(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantedErr := "cannot delete genesis, finalized, or head state"
-	if err := db.DeleteState(ctx, finalizedBlockRoot); err.Error() != wantedErr {
+	if err := db.DeleteStates(ctx, [][32]byte{finalizedBlockRoot}); err.Error() != wantedErr {
 		t.Error("Did not receive wanted error")
 	}
 }
@@ -282,7 +282,7 @@ func TestStore_DeleteHeadState(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantedErr := "cannot delete genesis, finalized, or head state"
-	if err := db.DeleteState(ctx, headBlockRoot); err.Error() != wantedErr {
+	if err := db.DeleteStates(ctx, [][32]byte{headBlockRoot}); err.Error() != wantedErr {
 		t.Error("Did not receive wanted error")
 	}
 }


### PR DESCRIPTION
This resolves #4619 

---

# Description

**Write why you are making the changes in this pull request**

Even though we had a lot of memory improvements in the beacon node, certain users were still reporting massive mem consumption, which was proven by a mem flame graph extracted by one our community members on discord: 

![heap](https://user-images.githubusercontent.com/5572669/73865075-4f900c00-4808-11ea-82b7-977773547540.png)

Most of the time was being spent calling bolt.Batch which only a few functions used, namely `DeleteStates`, which would likely cause a huge amount of resource consumption.

**Write a summary of the changes you are making**

This PR changes the bolt batch call to delete states to a db.Update instead to do in a single transaction. This PR also eliminates various other unused DB functions that we do not see using for the foreseeable future (_You ain't gonna need it_).
