### PR TITLE
Update higherThanFinalized in the loop

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -405,6 +405,7 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, blk *ethpb.
 		pendingNodes = append(pendingNodes, b.Block)
 		parentRoot = bytesutil.ToBytes32(b.Block.ParentRoot)
 		slot = b.Block.Slot
+		higherThanFinalized = slot > helpers.StartSlot(s.finalizedCheckpt.Epoch)
 	}
 
 	// Insert parent nodes to fork choice store in reverse order.

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -564,7 +564,8 @@ func TestFillForkChoiceMissingBlocks_CanSave(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(service.forkChoiceStore.Nodes()) != 6 {
+	// 5 nodes from the block tree 1. B0 - B3 - B4 - B6 - B8
+	if len(service.forkChoiceStore.Nodes()) != 5 {
 		t.Error("Miss match nodes")
 	}
 


### PR DESCRIPTION
We never updated boolean variable `higherThanFinalized` in the loop so the loop traversed all the way back to genesis slot 😸 

Added a regression test. Thanks @prestonvanloon for the catch