### PR TITLE
Change Batch Call to Update in Deleting States

### DIFF
--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -139,7 +139,7 @@ func (k *Store) DeleteState(ctx context.Context, blockRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteState")
 	defer span.End()
 
-	return k.db.Batch(func(tx *bolt.Tx) error {
+	return k.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(blocksBucket)
 		genesisBlockRoot := bkt.Get(genesisBlockRootKey)
 
@@ -170,7 +170,7 @@ func (k *Store) DeleteStates(ctx context.Context, blockRoots [][32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteStates")
 	defer span.End()
 
-	return k.db.Batch(func(tx *bolt.Tx) error {
+	return k.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(blocksBucket)
 		genesisBlockRoot := bkt.Get(genesisBlockRootKey)
 


### PR DESCRIPTION
This resolves #4619 

---

# Description

**Write why you are making the changes in this pull request**

Even though we had a lot of memory improvements in the beacon node, certain users were still reporting massive mem consumption, which was proven by a mem flame graph extracted by one our community members on discord: 

![heap](https://user-images.githubusercontent.com/5572669/73865075-4f900c00-4808-11ea-82b7-977773547540.png)

Most of the time was being spent calling bolt.Batch which only a few functions used, namely `DeleteStates`, which would likely cause a huge amount of resource consumption.

**Write a summary of the changes you are making**

This PR changes the bolt batch call to delete states to a db.Update instead to do in a single transaction.
