### PR TITLE
Add & use FinalizedCheckpointEpoch() to state

### DIFF
--- a/beacon-chain/blockchain/forkchoice/log.go
+++ b/beacon-chain/blockchain/forkchoice/log.go
@@ -13,13 +13,9 @@ var log = logrus.WithField("prefix", "forkchoice")
 
 // logs epoch related data during epoch boundary.
 func logEpochData(beaconState *stateTrie.BeaconState) {
-	var finalizedEpoch uint64
 	var prevJustifiedEpoch uint64
 	var currJustifiedEpoch uint64
-	finalizedCpt := beaconState.FinalizedCheckpoint()
-	if finalizedCpt != nil {
-		finalizedEpoch = finalizedCpt.Epoch
-	}
+	finalizedEpoch := beaconState.FinalizedCheckpointEpoch()
 	prevJustifiedCpt := beaconState.PreviousJustifiedCheckpoint()
 	if prevJustifiedCpt != nil {
 		prevJustifiedEpoch = prevJustifiedCpt.Epoch

--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -24,7 +24,7 @@ func logStateTransitionData(b *ethpb.BeaconBlock) {
 func logEpochData(beaconState *stateTrie.BeaconState) {
 	log.WithFields(logrus.Fields{
 		"epoch":                  helpers.CurrentEpoch(beaconState),
-		"finalizedEpoch":         beaconState.FinalizedCheckpoint().Epoch,
+		"finalizedEpoch":         beaconState.FinalizedCheckpointEpoch(),
 		"justifiedEpoch":         beaconState.CurrentJustifiedCheckpoint().Epoch,
 		"previousJustifiedEpoch": beaconState.PreviousJustifiedCheckpoint().Epoch,
 	}).Info("Starting next epoch")

--- a/beacon-chain/blockchain/metrics/metrics.go
+++ b/beacon-chain/blockchain/metrics/metrics.go
@@ -171,7 +171,7 @@ func ReportEpochMetrics(state *stateTrie.BeaconState) {
 	beaconPrevJustifiedRoot.Set(float64(bytesutil.ToLowInt64(state.PreviousJustifiedCheckpoint().Root)))
 
 	// Last finalized slot
-	beaconFinalizedEpoch.Set(float64(state.FinalizedCheckpoint().Epoch))
+	beaconFinalizedEpoch.Set(float64(state.FinalizedCheckpointEpoch()))
 	beaconFinalizedRoot.Set(float64(bytesutil.ToLowInt64(state.FinalizedCheckpoint().Root)))
 
 	currentEth1DataDepositCount.Set(float64(state.Eth1Data().DepositCount))

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -101,7 +101,7 @@ func (s *Service) onBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock) 
 	}
 
 	// Update finalized check point. Prune the block cache and helper caches on every new finalized epoch.
-	if postState.FinalizedCheckpoint().Epoch > s.finalizedCheckpt.Epoch {
+	if postState.FinalizedCheckpointEpoch() > s.finalizedCheckpt.Epoch {
 		if err := s.beaconDB.SaveFinalizedCheckpoint(ctx, postState.FinalizedCheckpoint()); err != nil {
 			return nil, errors.Wrap(err, "could not save finalized checkpoint")
 		}
@@ -207,7 +207,7 @@ func (s *Service) onBlockInitialSyncStateTransition(ctx context.Context, signed 
 	}
 
 	// Update finalized check point. Prune the block cache and helper caches on every new finalized epoch.
-	if postState.FinalizedCheckpoint().Epoch > s.finalizedCheckpt.Epoch {
+	if postState.FinalizedCheckpointEpoch() > s.finalizedCheckpt.Epoch {
 		startSlot := helpers.StartSlot(s.prevFinalizedCheckpt.Epoch)
 		endSlot := helpers.StartSlot(s.finalizedCheckpt.Epoch)
 		if endSlot > startSlot {
@@ -278,7 +278,7 @@ func (s *Service) insertBlockToForkChoiceStore(ctx context.Context, blk *ethpb.B
 	if err := s.forkChoiceStore.ProcessBlock(ctx,
 		blk.Slot, root, bytesutil.ToBytes32(blk.ParentRoot),
 		state.CurrentJustifiedCheckpoint().Epoch,
-		state.FinalizedCheckpoint().Epoch); err != nil {
+		state.FinalizedCheckpointEpoch()); err != nil {
 		return errors.Wrap(err, "could not process block for proto array fork choice")
 	}
 

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -420,7 +420,7 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, blk *ethpb.
 		if err := s.forkChoiceStore.ProcessBlock(ctx,
 			b.Slot, r, bytesutil.ToBytes32(b.ParentRoot),
 			state.CurrentJustifiedCheckpoint().Epoch,
-			state.FinalizedCheckpoint().Epoch); err != nil {
+			state.FinalizedCheckpointEpoch()); err != nil {
 			return errors.Wrap(err, "could not process block for proto array fork choice")
 		}
 	}

--- a/beacon-chain/core/epoch/precompute/justification_finalization_test.go
+++ b/beacon-chain/core/epoch/precompute/justification_finalization_test.go
@@ -62,8 +62,8 @@ func TestProcessJustificationAndFinalizationPreCompute_ConsecutiveEpochs(t *test
 		t.Errorf("Wanted current finalized root: %v, got: %v",
 			params.BeaconConfig().ZeroHash, newState.FinalizedCheckpoint().Root)
 	}
-	if newState.FinalizedCheckpoint().Epoch != 0 {
-		t.Errorf("Wanted finalized epoch: 0, got: %d", newState.FinalizedCheckpoint().Epoch)
+	if newState.FinalizedCheckpointEpoch() != 0 {
+		t.Errorf("Wanted finalized epoch: 0, got: %d", newState.FinalizedCheckpointEpoch())
 	}
 }
 
@@ -117,8 +117,8 @@ func TestProcessJustificationAndFinalizationPreCompute_JustifyCurrentEpoch(t *te
 		t.Errorf("Wanted current finalized root: %v, got: %v",
 			params.BeaconConfig().ZeroHash, newState.FinalizedCheckpoint().Root)
 	}
-	if newState.FinalizedCheckpoint().Epoch != 0 {
-		t.Errorf("Wanted finalized epoch: 0, got: %d", newState.FinalizedCheckpoint().Epoch)
+	if newState.FinalizedCheckpointEpoch() != 0 {
+		t.Errorf("Wanted finalized epoch: 0, got: %d", newState.FinalizedCheckpointEpoch())
 	}
 }
 
@@ -171,7 +171,7 @@ func TestProcessJustificationAndFinalizationPreCompute_JustifyPrevEpoch(t *testi
 		t.Errorf("Wanted current finalized root: %v, got: %v",
 			params.BeaconConfig().ZeroHash, newState.FinalizedCheckpoint().Root)
 	}
-	if newState.FinalizedCheckpoint().Epoch != 0 {
-		t.Errorf("Wanted finalized epoch: 0, got: %d", newState.FinalizedCheckpoint().Epoch)
+	if newState.FinalizedCheckpointEpoch() != 0 {
+		t.Errorf("Wanted finalized epoch: 0, got: %d", newState.FinalizedCheckpointEpoch())
 	}
 }

--- a/beacon-chain/core/epoch/precompute/reward_penalty.go
+++ b/beacon-chain/core/epoch/precompute/reward_penalty.go
@@ -96,10 +96,7 @@ func attestationDelta(state *stateTrie.BeaconState, bp *Balance, v *Validator) (
 	}
 
 	// Process finality delay penalty
-	var finalizedEpoch uint64
-	if state.FinalizedCheckpoint() != nil {
-		finalizedEpoch = state.FinalizedCheckpoint().Epoch
-	}
+	finalizedEpoch := state.FinalizedCheckpointEpoch()
 	finalityDelay := e - finalizedEpoch
 	if finalityDelay > params.BeaconConfig().MinEpochsToInactivityPenalty {
 		p += params.BeaconConfig().BaseRewardsPerEpoch * br

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -284,10 +284,7 @@ func IsEligibleForActivationQueue(validator *ethpb.Validator) bool {
 //        and validator.activation_epoch == FAR_FUTURE_EPOCH
 //    )
 func IsEligibleForActivation(state *stateTrie.BeaconState, validator *ethpb.Validator) bool {
-	cpt := state.FinalizedCheckpoint()
-	if cpt == nil {
-		return false
-	}
-	return validator.ActivationEligibilityEpoch <= cpt.Epoch &&
+	finalizedEpoch := state.FinalizedCheckpointEpoch()
+	return validator.ActivationEligibilityEpoch <= finalizedEpoch &&
 		validator.ActivationEpoch == params.BeaconConfig().FarFutureEpoch
 }

--- a/beacon-chain/core/state/benchmarks_test.go
+++ b/beacon-chain/core/state/benchmarks_test.go
@@ -100,7 +100,6 @@ func BenchmarkProcessEpoch_2FullEpochs(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	cleanStates := clonedStates(beaconState)
 
 	// We have to reset slot back to last epoch to hydrate cache. Since
 	// some attestations in block are from previous epoch
@@ -111,13 +110,11 @@ func BenchmarkProcessEpoch_2FullEpochs(b *testing.B) {
 	}
 	beaconState.SetSlot(currentSlot)
 
-	b.N = 5
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		// ProcessEpochPrecompute is the optimized version of process epoch. It's enabled by default
 		// at run time.
-		b.Log(i)
-		if _, err := ProcessEpochPrecompute(context.Background(), cleanStates[i]); err != nil {
+		if _, err := ProcessEpochPrecompute(context.Background(), beaconState.Copy()); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -161,11 +158,7 @@ func BenchmarkHashTreeRootState_FullState(b *testing.B) {
 func clonedStates(beaconState *beaconstate.BeaconState) []*beaconstate.BeaconState {
 	clonedStates := make([]*beaconstate.BeaconState, runAmount)
 	for i := 0; i < runAmount; i++ {
-		c, err := beaconstate.InitializeFromProto(beaconState.CloneInnerState())
-		if err != nil {
-			panic(err)
-		}
-		clonedStates[i] = c
+		clonedStates[i] = beaconState.Copy()
 	}
 	return clonedStates
 }

--- a/beacon-chain/core/state/state_test.go
+++ b/beacon-chain/core/state/state_test.go
@@ -93,7 +93,7 @@ func TestGenesisBeaconState_OK(t *testing.T) {
 	if newState.CurrentJustifiedCheckpoint().Epoch != genesisEpochNumber {
 		t.Error("JustifiedEpoch was not correctly initialized")
 	}
-	if newState.FinalizedCheckpoint().Epoch != genesisEpochNumber {
+	if newState.FinalizedCheckpointEpoch() != genesisEpochNumber {
 		t.Error("FinalizedSlot was not correctly initialized")
 	}
 	if newState.JustificationBits()[0] != 0x00 {

--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -441,7 +441,7 @@ func (bs *Server) GetValidatorParticipation(
 		}
 		return &ethpb.ValidatorParticipationResponse{
 			Epoch:         requestedEpoch,
-			Finalized:     requestedEpoch <= headState.FinalizedCheckpoint().Epoch,
+			Finalized:     requestedEpoch <= headState.FinalizedCheckpointEpoch(),
 			Participation: participation,
 		}, nil
 	} else if requestedEpoch == currentEpoch {
@@ -478,7 +478,7 @@ func (bs *Server) GetValidatorParticipation(
 
 	return &ethpb.ValidatorParticipationResponse{
 		Epoch:         requestedEpoch,
-		Finalized:     requestedEpoch <= headState.FinalizedCheckpoint().Epoch,
+		Finalized:     requestedEpoch <= headState.FinalizedCheckpointEpoch(),
 		Participation: participation,
 	}, nil
 }
@@ -499,7 +499,7 @@ func (bs *Server) GetValidatorQueue(
 	vals := headState.Validators()
 	for idx, validator := range vals {
 		eligibleActivated := validator.ActivationEligibilityEpoch != params.BeaconConfig().FarFutureEpoch
-		canBeActive := validator.ActivationEpoch >= helpers.DelayedActivationExitEpoch(headState.FinalizedCheckpoint().Epoch)
+		canBeActive := validator.ActivationEpoch >= helpers.DelayedActivationExitEpoch(headState.FinalizedCheckpointEpoch())
 		if eligibleActivated && canBeActive {
 			activationQ = append(activationQ, uint64(idx))
 		}

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -563,6 +563,16 @@ func (b *BeaconState) FinalizedCheckpoint() *ethpb.Checkpoint {
 	return CopyCheckpoint(b.state.FinalizedCheckpoint)
 }
 
+func (b *BeaconState) FinalizedCheckpointEpoch() uint64 {
+	if b.state.FinalizedCheckpoint == nil {
+		return 0
+	}
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
+	return b.state.FinalizedCheckpoint.Epoch
+}
+
 // CopyETH1Data copies the provided eth1data object.
 func CopyETH1Data(data *ethpb.Eth1Data) *ethpb.Eth1Data {
 	if data == nil {

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -563,6 +563,7 @@ func (b *BeaconState) FinalizedCheckpoint() *ethpb.Checkpoint {
 	return CopyCheckpoint(b.state.FinalizedCheckpoint)
 }
 
+// FinalizedCheckpointEpoch returns the epoch value of the finalized checkpoint.
 func (b *BeaconState) FinalizedCheckpointEpoch() uint64 {
 	if b.state.FinalizedCheckpoint == nil {
 		return 0

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -27,9 +27,9 @@ func (r *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 		return nil
 	}
 	// Ignore block older than last finalized checkpoint.
-	if cpt := headState.FinalizedCheckpoint(); block.Slot < helpers.StartSlot(cpt.Epoch) {
+	if block.Slot < helpers.StartSlot(headState.FinalizedCheckpointEpoch()) {
 		log.Debugf("Received a block older than finalized checkpoint, %d < %d",
-			block.Slot, helpers.StartSlot(cpt.Epoch))
+			block.Slot, helpers.StartSlot(headState.FinalizedCheckpointEpoch()))
 		return nil
 	}
 

--- a/shared/testutil/block_test.go
+++ b/shared/testutil/block_test.go
@@ -70,7 +70,7 @@ func TestGenerateFullBlock_Passes4Epochs(t *testing.T) {
 	if beaconState.CurrentJustifiedCheckpoint().Epoch != 3 {
 		t.Fatalf("expected justified epoch to change to 3, received %d", beaconState.CurrentJustifiedCheckpoint().Epoch)
 	}
-	if beaconState.FinalizedCheckpoint().Epoch != 2 {
+	if beaconState.FinalizedCheckpointEpoch() != 2 {
 		t.Fatalf("expected finalized epoch to change to 2, received %d", beaconState.CurrentJustifiedCheckpoint().Epoch)
 	}
 }


### PR DESCRIPTION
There were many instances where we were doing `state.FInalizedCheckpoint().Epoch` which makes a full copy of the checkpoint unnecessarily. Looking at this benchmark, it seems to improve epoch processing by about 30%. 


Before
```
BenchmarkProcessEpoch_2FullEpochs-8           39          34897535 ns/op        23557595 B/op     389336 allocs/op
```

After
```
BenchmarkProcessEpoch_2FullEpochs-8           54          25043262 ns/op        18837890 B/op     291021 allocs/op
```