### PR TITLE
Add location option for wallet keymanager

### DIFF
--- a/validator/keymanager/BUILD.bazel
+++ b/validator/keymanager/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//validator/accounts:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_wealdtech_go_eth2_wallet//:go_default_library",
+        "@com_github_wealdtech_go_eth2_wallet_store_filesystem//:go_default_library",
         "@com_github_wealdtech_go_eth2_wallet_types//:go_default_library",
         "@org_golang_x_crypto//ssh/terminal:go_default_library",
     ],


### PR DESCRIPTION
This exposes a wallet location option in the relevant `keymanageropts` to allow explicit definition of where the wallets can be found.

This is required when the validator is run in a docker container (and can be used when run standalone if the user wishes).