### PR TITLE
Use helper to aggregate attestations in pool

### DIFF
--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -29,13 +29,10 @@ func (p *AttCaches) SaveAggregatedAttestation(att *ethpb.Attestation) error {
 		}
 	}
 
-	// Ensure that this attestation is not already fully contained in an existing attestation.
-	for _, a := range atts {
-		if a.AggregationBits.Contains(att.AggregationBits) {
-			return nil
-		}
+	atts, err = helpers.AggregateAttestations(append(atts, att))
+	if err != nil {
+		return err
 	}
-	atts = append(atts, att)
 
 	// DefaultExpiration is set to what was given to New(). In this case
 	// it's one epoch.


### PR DESCRIPTION
Example block: https://beaconcha.in/block/208922#pills-attestations

In existing implementation: 
When att0 arrived in pubsub we insert into pool.
When att1 arrived in pubsub, we see it has bits that don't exist in the pool, we append it. Now there are two attestations in the pool which would be included in a block.

With this fix, att0 and att1 would be reduced to just att1