### PR TITLE
Downgrade "Validator indices saved in DB" log entry

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -136,7 +136,7 @@ func (s *Service) saveNewValidators(ctx context.Context, preStateValidatorCount 
 		log.WithFields(logrus.Fields{
 			"indices":             indices,
 			"totalValidatorCount": postStateValidatorCount - preStateValidatorCount,
-		}).Info("Validator indices saved in DB")
+		}).Trace("Validator indices saved in DB")
 	}
 	return nil
 }


### PR DESCRIPTION
On a new sync at info level logging I see a *lot* of these:

```
{"indices":[27148,27149,27150,27151,27152,27153,27154,27155,27156,27157,27158,27159,27160,27161,27162,27163],"level":"info","msg":"Validator indices saved in DB","prefix":"blockchain","time":"2020-02-08T09:34:14Z","totalValidatorCount":16}
{"indices":[27164,27165,27166,27167,27168,27169,27170,27171,27172,27173,27174,27175,27176,27177,27178,27179],"level":"info","msg":"Validator indices saved in DB","prefix":"blockchain","time":"2020-02-08T09:34:15Z","totalValidatorCount":16}
{"indices":[27180,27181,27182,27183,27184,27185,27186,27187,27188,27189,27190,27191,27192,27193,27194,27195],"level":"info","msg":"Validator indices saved in DB","prefix":"blockchain","time":"2020-02-08T09:34:15Z","totalValidatorCount":16}
{"indices":[27196,27197,27198,27199,27200,27201,27202,27203,27204,27205,27206,27207,27208,27209,27210,27211],"level":"info","msg":"Validator indices saved in DB","prefix":"blockchain","time":"2020-02-08T09:34:15Z","totalValidatorCount":16}
```

given their nature it seems that this should be way down in the weeds, so I've pushed this down to a trace.