### PR TITLE
Delete block attestations from the pool

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -148,6 +148,11 @@ func (s *Service) onBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock) 
 		s.nextEpochBoundarySlot = helpers.StartSlot(helpers.NextEpoch(postState))
 	}
 
+	// Delete the processed block attestations from attestation pool.
+	if err := s.deletePoolAtts(b.Body.Attestations); err != nil {
+		return nil, err
+	}
+
 	return postState, nil
 }
 

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -432,3 +432,20 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, blk *ethpb.
 
 	return nil
 }
+
+// The deletes input from the attestation pool, so proposers don't include them in a block for the future.
+func (s *Service) deletePoolAtts(atts []*ethpb.Attestation) error {
+	for _, att := range atts {
+		if helpers.IsAggregated(att) {
+			if err := s.attPool.DeleteAggregatedAttestation(att); err != nil {
+				return err
+			}
+		} else {
+			if err := s.attPool.DeleteUnaggregatedAttestation(att); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -433,7 +433,7 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, blk *ethpb.
 	return nil
 }
 
-// The deletes input from the attestation pool, so proposers don't include them in a block for the future.
+// The deletes input attestations from the attestation pool, so proposers don't include them in a block for the future.
 func (s *Service) deletePoolAtts(atts []*ethpb.Attestation) error {
 	for _, att := range atts {
 		if helpers.IsAggregated(att) {

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -95,7 +95,7 @@ var (
 		Usage: "Preprocess attestations by aggregation before running fork choice.",
 	}
 	disableStrictAttestationPubsubVerificationFlag = cli.BoolFlag{
-		Name: "disable-strict-attestation-pubsub-verification",
+		Name:  "disable-strict-attestation-pubsub-verification",
 		Usage: "Disable strict signature verification of attestations in pubsub. See PR 4782 for details.",
 	}
 )


### PR DESCRIPTION
Delete block attestations from the pool instead holding them to delete at expiration time