### PR TITLE
Don't save nil head state

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -155,7 +155,12 @@ func (s *Service) HeadState(ctx context.Context) (*state.BeaconState, error) {
 	defer s.headLock.RUnlock()
 
 	if s.headState == nil {
-		return s.beaconDB.HeadState(ctx)
+		headState, err := s.beaconDB.HeadState(ctx)
+		if err != nil {
+			return nil, err
+		}
+		s.headState = headState
+		return headState, nil
 	}
 
 	return s.headState.Copy(), nil

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -64,6 +64,9 @@ func (s *Service) saveHead(ctx context.Context, headRoot [32]byte) error {
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve head state in DB")
 	}
+	if headState == nil {
+		return errors.New("cannot save nil head state")
+	}
 
 	s.headLock.Lock()
 	defer s.headLock.Unlock()


### PR DESCRIPTION
if head state is nil, return error. Similar to what we did with block
Also update cached had state on retrieval 