### PR TITLE
Feature flag to disable head update on attestation basis

### DIFF
--- a/beacon-chain/blockchain/process_attestation.go
+++ b/beacon-chain/blockchain/process_attestation.go
@@ -128,10 +128,5 @@ func (s *Service) onAttestation(ctx context.Context, a *ethpb.Attestation) ([]ui
 	// Update forkchoice store with the new attestation for updating weight.
 	s.forkChoiceStore.ProcessAttestation(ctx, indexedAtt.AttestingIndices, bytesutil.ToBytes32(a.Data.BeaconBlockRoot), a.Data.Target.Epoch)
 
-	// Update fork choice head after updating weight.
-	if err := s.updateHead(ctx, baseState.Balances()); err != nil {
-		return nil, err
-	}
-
 	return indexedAtt.AttestingIndices, nil
 }

--- a/beacon-chain/blockchain/process_attestation.go
+++ b/beacon-chain/blockchain/process_attestation.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"go.opencensus.io/trace"
 )
 
@@ -127,6 +128,13 @@ func (s *Service) onAttestation(ctx context.Context, a *ethpb.Attestation) ([]ui
 
 	// Update forkchoice store with the new attestation for updating weight.
 	s.forkChoiceStore.ProcessAttestation(ctx, indexedAtt.AttestingIndices, bytesutil.ToBytes32(a.Data.BeaconBlockRoot), a.Data.Target.Epoch)
+
+	if !featureconfig.Get().DisableUpdateHeadPerAttestation {
+		// Update fork choice head after updating weight.
+		if err := s.updateHead(ctx, baseState.Balances()); err != nil {
+			return nil, err
+		}
+	}
 
 	return indexedAtt.AttestingIndices, nil
 }

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -27,7 +27,7 @@ func (r *Service) goodbyeRPCHandler(ctx context.Context, msg interface{}, stream
 	defer cancel()
 	setRPCStreamDeadlines(stream)
 
-	m, ok:= msg.(uint64)
+	m, ok := msg.(uint64)
 	if !ok {
 		return fmt.Errorf("wrong message type for goodbye, got %T, wanted uint64", msg)
 	}

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -42,6 +42,7 @@ type Flags struct {
 	ProtectAttester                            bool   // ProtectAttester prevents the validator client from signing any attestations that would be considered a slashable offense.
 	ForkchoiceAggregateAttestations            bool   // ForkchoiceAggregateAttestations attempts to aggregate attestations before processing in fork choice.
 	DisableStrictAttestationPubsubVerification bool   // DisableStrictAttestationPubsubVerification will disabling strict signature verification in pubsub.
+	DisableUpdateHeadPerAttestation            bool   // DisableUpdateHeadPerAttestation will disabling update head on per attestation basis.
 
 	// DisableForkChoice disables using LMD-GHOST fork choice to update
 	// the head of the chain based on attestations and instead accepts any valid received block
@@ -147,6 +148,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.GlobalBool(disableStrictAttestationPubsubVerificationFlag.Name) {
 		log.Warn("Disabled strict attestation signature verification in pubsub")
 		cfg.DisableStrictAttestationPubsubVerification = true
+	}
+	if ctx.GlobalBool(disableUpdateHeadPerAttestation.Name) {
+		log.Warn("Disabled update head on per attestation basis")
+		cfg.DisableUpdateHeadPerAttestation = true
 	}
 
 	Init(cfg)

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -98,6 +98,10 @@ var (
 		Name:  "disable-strict-attestation-pubsub-verification",
 		Usage: "Disable strict signature verification of attestations in pubsub. See PR 4782 for details.",
 	}
+	disableUpdateHeadPerAttestation = cli.BoolFlag{
+		Name:  "disable-update-head-attestation",
+		Usage: "Disable update fork choice head on per attestation. See PR 4802 for details.",
+	}
 )
 
 // Deprecated flags list.
@@ -249,6 +253,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	cacheFilteredBlockTreeFlag,
 	forkchoiceAggregateAttestations,
 	disableStrictAttestationPubsubVerificationFlag,
+	disableUpdateHeadPerAttestation,
 }...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
Computing head for every new attestation is a nice to have but may be too excessive, we can change the strategy to updating head every second. Opening this as an option to not compute  head on every attestation.   
Another option is to remove the tracing for the following methods. They seem to be the main bottlenecks. 


<img width="1629" alt="Screen Shot 2020-02-08 at 11 10 54 PM" src="https://user-images.githubusercontent.com/21316537/74098061-8136fa80-4ac8-11ea-85a2-78dfc7c17110.png">
