### PR TITLE
Clear initial sync state caches after round robin sync

### DIFF
--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -232,4 +232,5 @@ func (ms *ChainService) IsValidAttestation(ctx context.Context, att *ethpb.Attes
 	return ms.ValidAttestation
 }
 
+// ClearCachedStates does nothing.
 func (ms *ChainService) ClearCachedStates() {}

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -231,3 +231,5 @@ func (ms *ChainService) Participation(epoch uint64) *precompute.Balance {
 func (ms *ChainService) IsValidAttestation(ctx context.Context, att *ethpb.Attestation) bool {
 	return ms.ValidAttestation
 }
+
+func (ms *ChainService) ClearCachedStates() {}

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -43,6 +43,7 @@ const refreshTime = 6 * time.Second
 func (s *Service) roundRobinSync(genesis time.Time) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	defer s.chain.ClearCachedStates()
 
 	if cfg := featureconfig.Get(); cfg.EnableSkipSlotsCache {
 		cfg.EnableSkipSlotsCache = false

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -25,6 +25,7 @@ var _ = shared.Service(&Service{})
 type blockchainService interface {
 	blockchain.BlockReceiver
 	blockchain.HeadFetcher
+	ClearCachedStates()
 }
 
 const (


### PR DESCRIPTION
States were using 600mb in memory after sync.