### PR TITLE
Increase check point state cache size to 10

### DIFF
--- a/beacon-chain/cache/checkpoint_state.go
+++ b/beacon-chain/cache/checkpoint_state.go
@@ -19,7 +19,9 @@ var (
 	ErrNotCheckpointState = errors.New("object is not a state by check point struct")
 
 	// maxCheckpointStateSize defines the max number of entries check point to state cache can contain.
-	maxCheckpointStateSize = 4
+	// Choosing 10 to account for multiple forks, this allows 5 forks per epoch boundary with 2 epochs
+	// window to accept attestation based on latest spec.
+	maxCheckpointStateSize = 10
 
 	// Metrics.
 	checkpointStateMiss = promauto.NewCounter(prometheus.CounterOpts{


### PR DESCRIPTION
Previous size 4 was not enough given more forks than expected in current testnet. 
```
# HELP check_point_state_cache_hit The number of check point state requests that are present in the cache.
check_point_state_cache_hit 133643
# HELP check_point_statecache_miss The number of check point state requests that aren't present in the cache.
check_point_statecache_miss 2762
```

Increased the 10:
```
# HELP committee_cache_hit The number of committee requests that are present in the cache.
committee_cache_hit 135609
# HELP committee_cache_miss The number of committee requests that aren't present in the cache.
committee_cache_miss 12
```

Improved hit ratio from 97.9% to 99.9%, it may not seem like a lot but that's a saving of 2000 extra hash tree root and epoch transition of a mainnet state