### PR TITLE
Renovate Major Update

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,9 +5,9 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 http_archive(
     name = "bazel_skylib",
-    sha256 = "2ea8a5ed2b448baf4a6855d3ce049c4c452a6470b1efd1504fdb7c1c134d220a",
-    strip_prefix = "bazel-skylib-0.8.0",
-    url = "https://github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz",
+    sha256 = "e5d90f0ec952883d56747b7604e2a15ee36e288bb556c3d0ed33e818a4d971f2",
+    strip_prefix = "bazel-skylib-1.0.2",
+    url = "https://github.com/bazelbuild/bazel-skylib/archive/1.0.2.tar.gz",
 )
 
 http_archive(
@@ -44,8 +44,8 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "0942d188f4d0de6ddb743b9f6642a26ce1ad89f09c0035a9a5ca5ba9615c96aa",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.38.1/rules_nodejs-0.38.1.tar.gz"],
+    sha256 = "b6670f9f43faa66e3009488bbd909bc7bc46a5a9661a33f6bc578068d1837f37",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/1.3.0/rules_nodejs-1.3.0.tar.gz"],
 )
 
 git_repository(
@@ -204,7 +204,7 @@ buildifier_dependencies()
 
 go_repository(
     name = "com_github_golang_mock",
-    commit = "d74b93584564161b2de771089ee697f07d8bd5b5",  # v1.3.1
+    commit = "3dcdcb6994c4de42a73bd2e4790178be3ed4554b",  # v1.4.0
     importpath = "github.com/golang/mock",
 )
 
@@ -264,13 +264,13 @@ go_repository(
 
 go_repository(
     name = "com_github_urfave_cli",
-    commit = "e6cf83ec39f6e1158ced1927d4ed14578fda8edb",  # v1.21.0
+    commit = "aa1b27192cfe441ec1468207f66b6e121dbd81c2",  # v2.1.1
     importpath = "github.com/urfave/cli",
 )
 
 go_repository(
     name = "com_github_go_yaml_yaml",
-    commit = "f221b8435cfb71e54062f6c6e99e9ade30b124d5",  # v2.2.4
+    commit = "53403b58ad1b561927d19068c655246f2db79d48",  # v2.2.8
     importpath = "github.com/go-yaml/yaml",
 )
 
@@ -319,7 +319,7 @@ go_repository(
 
 go_repository(
     name = "com_github_ipfs_go_log",
-    commit = "91b837264c0f35dd4e2be341d711316b91d3573d",  # v0.0.1
+    commit = "03771230abae228f5c9a049173de35d673608842",  # v2.0.2
     importpath = "github.com/ipfs/go-log",
 )
 
@@ -421,7 +421,7 @@ go_repository(
 
 go_repository(
     name = "com_github_mr_tron_base58",
-    commit = "d504ab2e22d97cb9f10b1d146a1e6a063f4a5f43",  # v1.1.2
+    commit = "b1dd383fd2c02d7933db93f157e339f1899b5163",  # v1.1.3
     importpath = "github.com/mr-tron/base58",
 )
 
@@ -602,7 +602,7 @@ go_repository(
 
 go_repository(
     name = "com_github_jackpal_go_nat_pmp",
-    commit = "d89d09f6f3329bc3c2479aa3cafd76a5aa93a35c",
+    commit = "059203efa1edd7130293a583541b8308e7c640c4",  # v1.0.2
     importpath = "github.com/jackpal/go-nat-pmp",
 )
 
@@ -689,7 +689,7 @@ go_repository(
 
 go_repository(
     name = "com_github_prometheus_client_golang",
-    commit = "4ab88e80c249ed361d3299e2930427d9ac43ef8d",  # v1.0.0
+    commit = "913f67ef0627596efc752f02d4014308e7345dbf",  # v1.4.1
     importpath = "github.com/prometheus/client_golang",
 )
 
@@ -908,7 +908,7 @@ go_repository(
 
 go_repository(
     name = "in_gopkg_yaml_v2",
-    commit = "f221b8435cfb71e54062f6c6e99e9ade30b124d5",  # v2.2.4
+    commit = "53403b58ad1b561927d19068c655246f2db79d48",  # v2.2.8
     importpath = "gopkg.in/yaml.v2",
 )
 
@@ -1036,7 +1036,7 @@ go_repository(
 
 go_repository(
     name = "com_github_grpc_ecosystem_go_grpc_middleware",
-    commit = "dd15ed025b6054e5253963e355991f3070d4e593",  # v1.1.0
+    commit = "3c51f7f332123e8be5a157c0802a228ac85bf9db",  # v1.2.0
     importpath = "github.com/grpc-ecosystem/go-grpc-middleware",
 )
 
@@ -1066,7 +1066,7 @@ go_repository(
 
 go_repository(
     name = "grpc_ecosystem_grpc_gateway",
-    commit = "da7a886035e25b2f274f89b6f3c64bf70a9f6780",
+    commit = "e16fcd495a18ea01dbc6f5b6ac2956a94e1981a2",  # v1.12.2
     importpath = "github.com/grpc-ecosystem/grpc-gateway",
 )
 
@@ -1078,7 +1078,7 @@ go_repository(
 
 go_repository(
     name = "org_uber_go_automaxprocs",
-    commit = "946a8391268aea0a60a86403988ff3ab4b604a83",  # v1.2.0
+    commit = "e393bb0ea0644204c502247d647e428742196ebe",  # v1.3.0
     importpath = "go.uber.org/automaxprocs",
 )
 
@@ -1127,7 +1127,7 @@ go_repository(
 
 go_repository(
     name = "com_github_libp2p_go_yamux",
-    commit = "663972181d409e7263040f0b668462f87c85e1bd",  # v1.2.3
+    commit = "367fc7d3a370c44c62bc3278753532f5f4281229",  # v1.2.4
     importpath = "github.com/libp2p/go-yamux",
 )
 
@@ -1168,7 +1168,7 @@ go_ssz_dependencies()
 go_repository(
     name = "org_golang_google_grpc",
     build_file_proto_mode = "disable",
-    commit = "1d89a3c832915b2314551c1d2a506874d62e53f7",  # v1.22.0
+    commit = "f495f5b15ae7ccda3b38c53a1bfcde4c1a58a2bc",  # v1.27.1
     importpath = "google.golang.org/grpc",
 )
 
@@ -1222,7 +1222,7 @@ go_repository(
 
 go_repository(
     name = "io_k8s_sigs_yaml",
-    commit = "fd68e9863619f6ec2fdd8625fe1f02e7c877e480",  # v1.1.0
+    commit = "9fc95527decd95bb9d28cc2eab08179b2d0f6971",  # v1.2.0
     importpath = "sigs.k8s.io/yaml",
 )
 
@@ -1240,7 +1240,7 @@ go_repository(
 
 go_repository(
     name = "com_github_json_iterator_go",
-    commit = "4f2e55fcf87ba29ab80379002316db67620ff622",
+    commit = "0ff49de124c6f76f8494e194af75bde0f1a49a29",  # v1.1.6
     importpath = "github.com/json-iterator/go",
     remote = "https://github.com/prestonvanloon/go",
     vcs = "git",
@@ -1266,7 +1266,7 @@ go_repository(
 
 go_repository(
     name = "com_github_patrickmn_go_cache",
-    commit = "46f407853014144407b6c2ec7ccc76bf67958d93",
+    commit = "a3647f8e31d79543b2d0f0ae2fe5c379d72cedc0",  # v2.1.0
     importpath = "github.com/patrickmn/go-cache",
 )
 
@@ -1468,7 +1468,7 @@ go_repository(
 
 go_repository(
     name = "com_github_cespare_xxhash",
-    commit = "d7df74196a9e781ede915320c11c378c1b2f3a1f",
+    commit = "d7df74196a9e781ede915320c11c378c1b2f3a1f",  # v2.1.1
     importpath = "github.com/cespare/xxhash",
 )
 
@@ -1500,73 +1500,73 @@ go_repository(
 
 go_repository(
     name = "com_github_wealdtech_go_eth2_wallet",
-    commit = "6970d62e60d86fdae3c3e510e800e8a60d755a7d",
+    commit = "e93786451d9a0ee9404e7c50a413cd93bb39b48d",  # v1.9.1
     importpath = "github.com/wealdtech/go-eth2-wallet",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_eth2_wallet_hd",
-    commit = "ce0a252a01c621687e9786a64899cfbfe802ba73",
+    commit = "c9fef16fd435b632c971b787dbdd48847cd3f537",  # v1.10.0
     importpath = "github.com/wealdtech/go-eth2-wallet-hd",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_eth2_wallet_nd",
-    commit = "12c8c41cdbd16797ff292e27f58e126bb89e9706",
+    commit = "67358e23b8c2c2f858e6b9849139e1d9d1d391fc",  # v1.8.0
     importpath = "github.com/wealdtech/go-eth2-wallet-nd",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_eth2_wallet_store_filesystem",
-    commit = "1eea6a48d75380047d2ebe7c8c4bd8985bcfdeca",
+    commit = "2138fef339a0a0a3eb9e8d13324abab76b5d1cd6",  # v1.7.0
     importpath = "github.com/wealdtech/go-eth2-wallet-store-filesystem",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_eth2_wallet_store_s3",
-    commit = "1c821b5161f7bb0b3efa2030eff687eea5e70e53",
+    commit = "ad67d9addfd706229161aec764cb1a04dd628e7a",  # v1.6.0
     importpath = "github.com/wealdtech/go-eth2-wallet-store-s3",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_eth2_wallet_encryptor_keystorev4",
-    commit = "0c11c07b9544eb662210fadded94f40f309d8c8f",
+    commit = "e80bb6de751a1afe353aee9c0aadd61d001d0bd5",  # v1.0.0
     importpath = "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_eth2_wallet_types",
-    commit = "af67d8101be61e7c4dd8126d2b3eba20cff5dab2",
+    commit = "93c6a38134cd7a2fc7a483986b3bd2b784f5606f",  # v1.10.0
     importpath = "github.com/wealdtech/go-eth2-wallet-types",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_eth2_types",
-    commit = "f9c31ddf180537dd5712d5998a3d56c45864d71f",
+    commit = "f9c31ddf180537dd5712d5998a3d56c45864d71f",  # v1.0.0
     importpath = "github.com/wealdtech/go-eth2-types",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_eth2_util",
-    commit = "326ebb1755651131bb8f4506ea9a23be6d9ad1dd",
+    commit = "132c6320adebe41990171adf07ebbb9822797598",  # v1.1.0
     importpath = "github.com/wealdtech/go-eth2-util",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_ecodec",
-    commit = "7473d835445a3490e61a5fcf48fe4e9755a37957",
+    commit = "7473d835445a3490e61a5fcf48fe4e9755a37957",  # v1.1.0
     importpath = "github.com/wealdtech/go-ecodec",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_bytesutil",
-    commit = "e564d0ade555b9f97494f0f669196ddcc6bc531d",
+    commit = "e564d0ade555b9f97494f0f669196ddcc6bc531d",  # v1.1.0
     importpath = "github.com/wealdtech/go-bytesutil",
 )
 
 go_repository(
     name = "com_github_wealdtech_go_indexer",
-    commit = "334862c32b1e3a5c6738a2618f5c0a8ebeb8cd51",
+    commit = "a387900232398ee3feb4504491d67c3fb1f9bde5",  # v1.0.0
     importpath = "github.com/wealdtech/go-indexer",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -264,7 +264,7 @@ go_repository(
 
 go_repository(
     name = "com_github_urfave_cli",
-    commit = "aa1b27192cfe441ec1468207f66b6e121dbd81c2",  # v2.1.1
+    commit = "e6cf83ec39f6e1158ced1927d4ed14578fda8edb",  # v1.21.0
     importpath = "github.com/urfave/cli",
 )
 
@@ -319,7 +319,7 @@ go_repository(
 
 go_repository(
     name = "com_github_ipfs_go_log",
-    commit = "03771230abae228f5c9a049173de35d673608842",  # v2.0.2
+    commit = "91b837264c0f35dd4e2be341d711316b91d3573d",  # v0.0.1
     importpath = "github.com/ipfs/go-log",
 )
 
@@ -689,7 +689,7 @@ go_repository(
 
 go_repository(
     name = "com_github_prometheus_client_golang",
-    commit = "913f67ef0627596efc752f02d4014308e7345dbf",  # v1.4.1
+    commit = "4ab88e80c249ed361d3299e2930427d9ac43ef8d",  # v1.0.0
     importpath = "github.com/prometheus/client_golang",
 )
 


### PR DESCRIPTION
This PR is favored over #4810 

We include all renovate major updates except to urfave_cli, prometheus_client, and go_libp2p_go_log as those broke the build