### PR TITLE
Fix Copying of Fields

### DIFF
--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -1,6 +1,7 @@
 package blockchain
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -26,6 +27,14 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (*sta
 	}
 	if cachedState != nil {
 		return cachedState, nil
+	}
+
+	headRoot, err := s.HeadRoot(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get head root")
+	}
+	if bytes.Equal(headRoot, c.Root) {
+		return s.HeadState(ctx)
 	}
 
 	baseState, err := s.beaconDB.State(ctx, bytesutil.ToBytes32(c.Root))

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -73,7 +73,13 @@ func (s *Service) verifyBlkPreState(ctx context.Context, b *ethpb.BeaconBlock) (
 		}
 		return preState.Copy(), nil
 	}
-
+	headRoot, err := s.HeadRoot(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get head root")
+	}
+	if bytes.Equal(headRoot, b.ParentRoot) {
+		return s.HeadState(ctx)
+	}
 	preState, err := s.beaconDB.State(ctx, bytesutil.ToBytes32(b.ParentRoot))
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get pre state for slot %d", b.Slot)

--- a/beacon-chain/state/BUILD.bazel
+++ b/beacon-chain/state/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/hashutil:go_default_library",
+        "//shared/memorypool:go_default_library",
         "//shared/params:go_default_library",
         "//shared/stateutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -190,9 +190,7 @@ func (b *BeaconState) BlockRootAtIndex(idx uint64) ([]byte, error) {
 	if len(b.state.BlockRoots) <= int(idx) {
 		return nil, fmt.Errorf("index %d out of range", idx)
 	}
-	root := make([]byte, 32)
-	copy(root, b.state.BlockRoots[idx])
-	return root, nil
+	return bytesutil.Copy(b.state.BlockRoots[idx]), nil
 }
 
 // StateRoots kept track of in the beacon state.

--- a/beacon-chain/state/types.go
+++ b/beacon-chain/state/types.go
@@ -80,6 +80,9 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconState) (*BeaconState, error) {
 
 	// Initialize field shared mutexes
 	b.sharedFieldMutexes[randaoMixes] = new(sync.RWMutex)
+	b.sharedFieldMutexes[validators] = new(sync.RWMutex)
+	b.sharedFieldMutexes[previousEpochAttestations] = new(sync.RWMutex)
+	b.sharedFieldMutexes[currentEpochAttestations] = new(sync.RWMutex)
 
 	return b, nil
 }

--- a/beacon-chain/state/types.go
+++ b/beacon-chain/state/types.go
@@ -57,6 +57,7 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconState) (*BeaconState, error) {
 		state:                 st,
 		dirtyFields:           make(map[fieldIndex]interface{}, 20),
 		sharedFieldReferences: make(map[fieldIndex]*reference, 10),
+		sharedFieldMutexes:    make(map[fieldIndex]*sync.RWMutex),
 		valIdxMap:             coreutils.ValidatorIndexMap(st.Validators),
 	}
 
@@ -120,6 +121,7 @@ func (b *BeaconState) Copy() *BeaconState {
 		},
 		dirtyFields:           make(map[fieldIndex]interface{}, 20),
 		sharedFieldReferences: make(map[fieldIndex]*reference, 10),
+		sharedFieldMutexes:    make(map[fieldIndex]*sync.RWMutex),
 
 		// Copy on write validator index map.
 		valIdxMap: b.valIdxMap,

--- a/beacon-chain/state/types.go
+++ b/beacon-chain/state/types.go
@@ -78,8 +78,11 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconState) (*BeaconState, error) {
 	b.sharedFieldReferences[historicalRoots] = &reference{refs: 1}
 	b.sharedFieldReferences[validatorIdxMap] = &reference{refs: 1}
 
-	// Initialize field shared mutexes
+	// Initialize field shared mutexes, these are for fields
+	// in which we are not practicing copy on write.
 	b.sharedFieldMutexes[randaoMixes] = new(sync.RWMutex)
+	b.sharedFieldMutexes[blockRoots] = new(sync.RWMutex)
+	b.sharedFieldMutexes[stateRoots] = new(sync.RWMutex)
 	b.sharedFieldMutexes[validators] = new(sync.RWMutex)
 	b.sharedFieldMutexes[previousEpochAttestations] = new(sync.RWMutex)
 	b.sharedFieldMutexes[currentEpochAttestations] = new(sync.RWMutex)

--- a/beacon-chain/state/types.go
+++ b/beacon-chain/state/types.go
@@ -81,8 +81,6 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconState) (*BeaconState, error) {
 	// Initialize field shared mutexes, these are for fields
 	// in which we are not practicing copy on write.
 	b.sharedFieldMutexes[randaoMixes] = new(sync.RWMutex)
-	b.sharedFieldMutexes[blockRoots] = new(sync.RWMutex)
-	b.sharedFieldMutexes[stateRoots] = new(sync.RWMutex)
 	b.sharedFieldMutexes[validators] = new(sync.RWMutex)
 	b.sharedFieldMutexes[previousEpochAttestations] = new(sync.RWMutex)
 	b.sharedFieldMutexes[currentEpochAttestations] = new(sync.RWMutex)

--- a/beacon-chain/state/types.go
+++ b/beacon-chain/state/types.go
@@ -12,6 +12,7 @@ import (
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
+	"github.com/prysmaticlabs/prysm/shared/memorypool"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/stateutil"
 )
@@ -73,6 +74,7 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconState) (*BeaconState, error) {
 	b.sharedFieldReferences[validators] = &reference{refs: 1}
 	b.sharedFieldReferences[balances] = &reference{refs: 1}
 	b.sharedFieldReferences[historicalRoots] = &reference{refs: 1}
+	b.sharedFieldReferences[validatorIdxMap] = &reference{refs: 1}
 
 	return b, nil
 }
@@ -141,8 +143,11 @@ func (b *BeaconState) Copy() *BeaconState {
 
 	// Finalizer runs when dst is being destroyed in garbage collection.
 	runtime.SetFinalizer(dst, func(b *BeaconState) {
-		for _, v := range b.sharedFieldReferences {
+		for i, v := range b.sharedFieldReferences {
 			v.refs--
+			if i == randaoMixes && v.refs == 0 {
+				memorypool.PutDoubleByteSlice(b.state.RandaoMixes)
+			}
 		}
 	})
 
@@ -166,6 +171,12 @@ func (b *BeaconState) HashTreeRoot() ([32]byte, error) {
 	}
 
 	for field := range b.dirtyFields {
+		// do not compute root for field
+		// thats not part of the state.
+		if field == validatorIdxMap {
+			delete(b.dirtyFields, field)
+			continue
+		}
 		root, err := b.rootSelector(field)
 		if err != nil {
 			return [32]byte{}, err

--- a/shared/bytesutil/bytes.go
+++ b/shared/bytesutil/bytes.go
@@ -5,6 +5,14 @@ import (
 	"encoding/binary"
 )
 
+// Copy copies a byte slice into a newly
+// allocated slice.
+func Copy(x []byte) []byte {
+	newSlice := make([]byte, len(x))
+	copy(newSlice, x)
+	return newSlice
+}
+
 // ToBytes returns integer x to bytes in little-endian format at the specified length.
 // Spec pseudocode definition:
 //   def int_to_bytes(integer: int, length: int) -> bytes:

--- a/shared/memorypool/BUILD.bazel
+++ b/shared/memorypool/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["memorypool.go"],
+    importpath = "github.com/prysmaticlabs/prysm/shared/memorypool",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["memorypool_test.go"],
+    embed = [":go_default_library"],
+)

--- a/shared/memorypool/memorypool.go
+++ b/shared/memorypool/memorypool.go
@@ -1,0 +1,27 @@
+package memorypool
+
+import "sync"
+
+// DoubleByteSlicePool represents the memory pool
+// for 2d byte slices
+var DoubleByteSlicePool = new(sync.Pool)
+
+// GetDoubleByteSlice retrieves the 2d byte slice of
+// the desired size from the memory pool.
+func GetDoubleByteSlice(size int) [][]byte {
+	rawObj := DoubleByteSlicePool.Get()
+	if rawObj == nil {
+		return make([][]byte, size)
+	}
+	byteSlice := rawObj.([][]byte)
+	if len(byteSlice) >= size {
+		return byteSlice[:size]
+	}
+	return append(byteSlice, make([][]byte, size-len(byteSlice))...)
+}
+
+// PutDoubleByteSlice places the provided 2d byte slice
+// in the memory pool
+func PutDoubleByteSlice(data [][]byte) {
+	DoubleByteSlicePool.Put(data)
+}

--- a/shared/memorypool/memorypool_test.go
+++ b/shared/memorypool/memorypool_test.go
@@ -1,0 +1,16 @@
+package memorypool
+
+import (
+	"testing"
+)
+
+func TestRoundTripMemoryRetrieval(t *testing.T) {
+	byteSlice := make([][]byte, 1000)
+	PutDoubleByteSlice(byteSlice)
+	newSlice := GetDoubleByteSlice(1000)
+
+	if len(newSlice) != 1000 {
+		t.Errorf("Wanted same slice object, but got different object. "+
+			"Wanted  slice with length %d but got length %d", 1000, len(newSlice))
+	}
+}


### PR DESCRIPTION
Incorporates #4811

The original PR was reverted due to it leading to a few bugs. This was due to how we accessed certain fields. We now use a shared mutex between fields which share references. This will prevent multiple routines from writing to the same reference at once.