### PR TITLE
Fix Goodbye RPC handler

### DIFF
--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -27,11 +27,11 @@ func (r *Service) goodbyeRPCHandler(ctx context.Context, msg interface{}, stream
 	defer cancel()
 	setRPCStreamDeadlines(stream)
 
-	m, ok := msg.(uint64)
+	m, ok := msg.(*uint64)
 	if !ok {
-		return fmt.Errorf("wrong message type for goodbye, got %T, wanted uint64", msg)
+		return fmt.Errorf("wrong message type for goodbye, got %T, wanted *uint64", msg)
 	}
-	log := log.WithField("Reason", goodbyeMessage(m))
+	log := log.WithField("Reason", goodbyeMessage(*m))
 	log.WithField("peer", stream.Conn().RemotePeer()).Info("Peer has sent a goodbye message")
 	// closes all streams with the peer
 	return r.p2p.Disconnect(stream.Conn().RemotePeer())

--- a/beacon-chain/sync/rpc_goodbye_test.go
+++ b/beacon-chain/sync/rpc_goodbye_test.go
@@ -42,8 +42,9 @@ func TestGoodByeRPCHandler_Disconnects_With_Peer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	clientCode := codeClientShutdown
 
-	err = r.goodbyeRPCHandler(context.Background(), codeClientShutdown, stream1)
+	err = r.goodbyeRPCHandler(context.Background(), &clientCode, stream1)
 	if err != nil {
 		t.Errorf("Unxpected error: %v", err)
 	}

--- a/beacon-chain/sync/rpc_goodbye_test.go
+++ b/beacon-chain/sync/rpc_goodbye_test.go
@@ -42,9 +42,9 @@ func TestGoodByeRPCHandler_Disconnects_With_Peer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	clientCode := codeClientShutdown
+	failureCode := codeClientShutdown
 
-	err = r.goodbyeRPCHandler(context.Background(), &clientCode, stream1)
+	err = r.goodbyeRPCHandler(context.Background(), &failureCode, stream1)
 	if err != nil {
 		t.Errorf("Unxpected error: %v", err)
 	}


### PR DESCRIPTION
- [x] Fixes our goodbye rpc handler to expect `*uint64` instead of `uint64`