### PR TITLE
Add Lock to Processing Pending Attestations

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -45,8 +45,8 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 	// be deleted from the queue if invalid (ie. getting staled from falling too many slots behind).
 	s.validatePendingAtts(ctx, s.chain.CurrentSlot())
 
-	s.pendingAttsLock.Lock()
-	defer s.pendingAttsLock.Lock()
+	s.pendingAttsLock.RLock()
+	defer s.pendingAttsLock.RUnlock()
 	for bRoot, attestations := range s.blkRootToPendingAtts {
 		// Has the pending attestation's missing block arrived yet?
 		if s.db.HasBlock(ctx, bRoot) {

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -25,7 +25,7 @@ func (s *Service) processPendingAttsQueue() {
 	ctx := context.Background()
 	runutil.RunEvery(s.ctx, processPendingAttsPeriod, func() {
 		if err := s.processPendingAtts(ctx); err != nil {
-			log.WithError(err).Errorf("Could not process pending attestation: %v")
+			log.WithError(err).Errorf("Could not process pending attestation: %v", err)
 		}
 	})
 }

--- a/beacon-chain/sync/validate_committee_index_beacon_attestation.go
+++ b/beacon-chain/sync/validate_committee_index_beacon_attestation.go
@@ -76,7 +76,9 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 	// Verify the block being voted is in DB. The block should have passed validation if it's in the DB.
 	if !s.db.HasBlock(ctx, bytesutil.ToBytes32(att.Data.BeaconBlockRoot)) {
 		// A node doesn't have the block, it'll request from peer while saving the pending attestation to a queue.
+		s.pendingAttsLock.Lock()
 		s.savePendingAtt(&eth.AggregateAttestationAndProof{Aggregate: att})
+		s.pendingAttsLock.Unlock()
 		return false
 	}
 


### PR DESCRIPTION
Resolves #4829 

---

# Description

**Write why you are making the changes in this pull request**

We had a function that would do concurrent map iterations in `beacon-chain/sync/pending_attestations_queue.go` called `processPendingAtt`. Thanks to @shayzluf for pointing this out.

**Write a summary of the changes you are making**

This func adds a lock to the function and properly handles its errors when it is called.
