### PR TITLE
Include Beacon Client Package in Slasher

### DIFF
--- a/slasher/beaconclient/BUILD.bazel
+++ b/slasher/beaconclient/BUILD.bazel
@@ -7,7 +7,7 @@ go_library(
         "service.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/slasher/beaconclient",
-    visibility = ["//visibility:public"],
+    visibility = ["//slasher:__subpackages__"],
     deps = [
         "//shared/event:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",

--- a/slasher/beaconclient/BUILD.bazel
+++ b/slasher/beaconclient/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -20,5 +20,18 @@ go_library(
         "@io_opencensus_go//trace:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["receivers_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//shared/event:go_default_library",
+        "//shared/mock:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_golang_mock//gomock:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
     ],
 )

--- a/slasher/beaconclient/BUILD.bazel
+++ b/slasher/beaconclient/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["service.go"],
+    importpath = "github.com/prysmaticlabs/prysm/slasher/beaconclient",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_grpc_ecosystem_go_grpc_middleware//tracing/opentracing:go_default_library",
+        "@com_github_grpc_ecosystem_go_grpc_prometheus//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_opencensus_go//plugin/ocgrpc:go_default_library",
+        "@org_golang_google_grpc//:go_default_library",
+    ],
+)

--- a/slasher/beaconclient/BUILD.bazel
+++ b/slasher/beaconclient/BUILD.bazel
@@ -2,14 +2,23 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["service.go"],
+    srcs = [
+        "receivers.go",
+        "service.go",
+    ],
     importpath = "github.com/prysmaticlabs/prysm/slasher/beaconclient",
     visibility = ["//visibility:public"],
     deps = [
+        "//shared/event:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
+        "@com_github_grpc_ecosystem_go_grpc_middleware//:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_middleware//tracing/opentracing:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//plugin/ocgrpc:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
     ],
 )

--- a/slasher/beaconclient/receivers.go
+++ b/slasher/beaconclient/receivers.go
@@ -1,0 +1,63 @@
+package beaconclient
+
+import (
+	"context"
+	"io"
+
+	ptypes "github.com/gogo/protobuf/types"
+	"go.opencensus.io/trace"
+)
+
+func (bs *Service) receiveBlocks(ctx context.Context) {
+	ctx, span := trace.StartSpan(ctx, "beaconclient.receiveBlocks")
+	defer span.End()
+	stream, err := bs.client.StreamBlocks(ctx, &ptypes.Empty{})
+	if err != nil {
+		log.WithError(err).Error("Failed to retrieve blocks stream")
+		return
+	}
+	for {
+		res, err := stream.Recv()
+		// If the stream is closed, we stop the loop.
+		if err == io.EOF {
+			break
+		}
+		// If context is canceled we stop the loop.
+		if ctx.Err() == context.Canceled {
+			log.WithError(ctx.Err()).Error("Context canceled - shutting down blocks receiver")
+			return
+		}
+		if err != nil {
+			log.WithError(err).Error("Could not receive block from beacon node")
+		}
+		// We send the received block over the block feed.
+		bs.blockFeed.Send(res)
+	}
+}
+
+func (bs *Service) receiveAttestations(ctx context.Context) {
+	ctx, span := trace.StartSpan(ctx, "beaconclient.receiveAttestations")
+	defer span.End()
+	stream, err := bs.client.StreamAttestations(ctx, &ptypes.Empty{})
+	if err != nil {
+		log.WithError(err).Error("Failed to retrieve attestations stream")
+		return
+	}
+	for {
+		res, err := stream.Recv()
+		// If the stream is closed, we stop the loop.
+		if err == io.EOF {
+			break
+		}
+		// If context is canceled we stop the loop.
+		if ctx.Err() == context.Canceled {
+			log.WithError(ctx.Err()).Error("Context canceled - shutting down attestations receiver")
+			return
+		}
+		if err != nil {
+			log.WithError(err).Error("Could not receive attestations from beacon node")
+		}
+		// We send the received attestation over the attestation feed.
+		bs.attestationFeed.Send(res)
+	}
+}

--- a/slasher/beaconclient/receivers.go
+++ b/slasher/beaconclient/receivers.go
@@ -8,6 +8,9 @@ import (
 	"go.opencensus.io/trace"
 )
 
+// receiveBlocks starts a gRPC client stream listener to obtain
+// blocks from the beacon node. Upon receiving a block, the service
+// broadcasts it to a feed for other services in slasher to subscribe to.
 func (bs *Service) receiveBlocks(ctx context.Context) {
 	ctx, span := trace.StartSpan(ctx, "beaconclient.receiveBlocks")
 	defer span.End()
@@ -35,6 +38,9 @@ func (bs *Service) receiveBlocks(ctx context.Context) {
 	}
 }
 
+// receiveAttestations starts a gRPC client stream listener to obtain
+// attestations from the beacon node. Upon receiving an attestation, the service
+// broadcasts it to a feed for other services in slasher to subscribe to.
 func (bs *Service) receiveAttestations(ctx context.Context) {
 	ctx, span := trace.StartSpan(ctx, "beaconclient.receiveAttestations")
 	defer span.End()

--- a/slasher/beaconclient/receivers_test.go
+++ b/slasher/beaconclient/receivers_test.go
@@ -1,0 +1,41 @@
+package beaconclient
+
+import (
+	"testing"
+
+	ptypes "github.com/gogo/protobuf/types"
+	"github.com/golang/mock/gomock"
+
+	"github.com/prysmaticlabs/prysm/shared/mock"
+)
+
+func TestService_ReceiveBlocks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock.NewMockBeaconChainClient(ctrl)
+
+	bs := Service{
+		client: client,
+	}
+	stream := mock.NewMockBeaconChain_StreamBlocksClient(ctrl)
+	client.EXPECT().StreamBlocks(
+		gomock.Any(),
+		&ptypes.Empty{},
+	).Return(stream, nil)
+	stream.EXPECT().Recv().Return(
+		&ethpb.ChainStartResponse{
+			Started:     true,
+			GenesisTime: genesis,
+		},
+		nil,
+	)
+	if err := v.WaitForChainStart(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if v.genesisTime != genesis {
+		t.Errorf("Expected chain start time to equal %d, received %d", genesis, v.genesisTime)
+	}
+	if v.ticker == nil {
+		t.Error("Expected ticker to be set, received nil")
+	}
+}

--- a/slasher/beaconclient/service.go
+++ b/slasher/beaconclient/service.go
@@ -1,4 +1,4 @@
-/**
+/*
 Package beaconclient defines a service that interacts with a beacon
 node via a gRPC client to listen for streamed blocks, attestations, and to
 submit proposer/attester slashings to the node in case they are detected.

--- a/slasher/beaconclient/service.go
+++ b/slasher/beaconclient/service.go
@@ -1,3 +1,8 @@
+/**
+Package beaconclient defines a service that interacts with a beacon
+node via a gRPC client to listen for streamed blocks, attestations, and to
+submit proposer/attester slashings to the node in case they are detected.
+*/
 package beaconclient
 
 import (
@@ -17,7 +22,7 @@ import (
 
 var log = logrus.WithField("prefix", "beaconclient")
 
-// Service --
+// Service struct for the beaconclient service of the slasher.
 type Service struct {
 	context         context.Context
 	cancel          context.CancelFunc
@@ -29,17 +34,19 @@ type Service struct {
 	attestationFeed *event.Feed
 }
 
-// BlockFeed --
+// BlockFeed returns a feed other services in slasher can subscribe to
+// blocks received via the beacon node through gRPC.
 func (bs *Service) BlockFeed() *event.Feed {
 	return bs.blockFeed
 }
 
-// AttestationFeed --
+// AttestationFeed returns a feed other services in slasher can subscribe to
+// attestations received via the beacon node through gRPC.
 func (bs *Service) AttestationFeed() *event.Feed {
 	return bs.attestationFeed
 }
 
-// Stop the beacon client service.
+// Stop the beacon client service by closing the gRPC connection.
 func (bs *Service) Stop() error {
 	bs.cancel()
 	log.Info("Stopping service")
@@ -49,7 +56,8 @@ func (bs *Service) Stop() error {
 	return nil
 }
 
-// Status --
+// Status returns an error if there exists a gRPC connection error
+// in the service.
 func (bs *Service) Status() error {
 	if bs.conn == nil {
 		return errors.New("no connection to beacon RPC")
@@ -57,6 +65,10 @@ func (bs *Service) Status() error {
 	return nil
 }
 
+// Start the main runtime of the beaconclient service, initializing
+// a gRPC client connection with a beacon node, listening for
+// streamed blocks/attestations, and submitting slashing operations
+// after they are detected by other services in the slasher.
 func (bs *Service) Start() {
 	var dialOpt grpc.DialOption
 	if bs.cert != "" {

--- a/slasher/beaconclient/service.go
+++ b/slasher/beaconclient/service.go
@@ -1,0 +1,76 @@
+package beaconclient
+
+import (
+	"context"
+	"errors"
+
+	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/sirupsen/logrus"
+	"go.opencensus.io/plugin/ocgrpc"
+	"google.golang.org/grpc"
+)
+
+var log = logrus.WithField("prefix", "beaconclient")
+
+// Service --
+type Service struct {
+	context  context.Context
+	cancel   context.CancelFunc
+	cert     string
+	conn     *grpc.ClientConn
+	provider string
+	client   eth.BeaconChainClient
+}
+
+// Stop the beacon client service.
+func (bs *Service) Stop() error {
+	bs.cancel()
+	log.Info("Stopping service")
+	if bs.conn != nil {
+		return bs.conn.Close()
+	}
+	return nil
+}
+
+// Status --
+func (bs *Service) Status() error {
+	if bs.conn == nil {
+		return errors.New("no connection to beacon RPC")
+	}
+	return nil
+}
+
+func (bs *Service) Start() {
+	var dialOpt grpc.DialOption
+
+	if bs.cert != "" {
+		creds, err := credentials.NewClientTLSFromFile(bs.cert, "")
+		if err != nil {
+			log.Errorf("Could not get valid credentials: %v", err)
+		}
+		dialOpt = grpc.WithTransportCredentials(creds)
+	} else {
+		dialOpt = grpc.WithInsecure()
+		log.Warn("You are using an insecure gRPC connection to beacon chain! Please provide a certificate and key to use a secure connection.")
+	}
+	beaconOpts := []grpc.DialOption{
+		dialOpt,
+		grpc.WithStatsHandler(&ocgrpc.ClientHandler{}),
+		grpc.WithStreamInterceptor(middleware.ChainStreamClient(
+			grpc_opentracing.StreamClientInterceptor(),
+			grpc_prometheus.StreamClientInterceptor,
+		)),
+		grpc.WithUnaryInterceptor(middleware.ChainUnaryClient(
+			grpc_opentracing.UnaryClientInterceptor(),
+			grpc_prometheus.UnaryClientInterceptor,
+		)),
+	}
+	conn, err := grpc.DialContext(s.context, bs.provider, beaconOpts...)
+	if err != nil {
+		return fmt.Errorf("could not dial endpoint: %s, %v", bs.provider, err)
+	}
+	log.Info("Successfully started gRPC connection")
+	s.beaconConn = conn
+	s.beaconClient = eth.NewBeaconChainClient(bs.conn)
+}


### PR DESCRIPTION
Part of #4836

---

# Description

**Write why you are making the changes in this pull request**

Currently, slasher does a lot of things in single files, instead of having proper separation of concerns between services.

**Write a summary of the changes you are making**

This PR creates a `beaconclient` package in `slasher` that initializes a gRPC connection to a beacon node for listening to streamed blocks and attestations. The service then relays received data via a `BlockFeed *event.Feed` and `AttestationFeed *event.Feed` other services in the slasher runtime can subscribe to.

**Link anything that would be helpful or relevant to the reviewers**

This PR does **not** hook-up this service to a main slasher runtime. This will be done in a separate PR once all the difference pieces are built.
