### PR TITLE
Send Slashing Objects to Beacon Node via RPC

### DIFF
--- a/slasher/beaconclient/BUILD.bazel
+++ b/slasher/beaconclient/BUILD.bazel
@@ -26,13 +26,18 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["receivers_test.go"],
+    srcs = [
+        "receivers_test.go",
+        "submit_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//shared/event:go_default_library",
         "//shared/mock:go_default_library",
+        "//shared/testutil:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
 )

--- a/slasher/beaconclient/submit_test.go
+++ b/slasher/beaconclient/submit_test.go
@@ -1,0 +1,90 @@
+package beaconclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/event"
+	"github.com/prysmaticlabs/prysm/shared/mock"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	logTest "github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestService_SubscribeDetectedProposerSlashings(t *testing.T) {
+	hook := logTest.NewGlobal()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock.NewMockBeaconChainClient(ctrl)
+
+	bs := Service{
+		client:                client,
+		proposerSlashingsFeed: new(event.Feed),
+	}
+
+	slashing := &ethpb.ProposerSlashing{
+		ProposerIndex: 5,
+		Header_1: &ethpb.SignedBeaconBlockHeader{
+			Header: &ethpb.BeaconBlockHeader{
+				Slot: 5,
+			},
+			Signature: make([]byte, 96),
+		},
+		Header_2: &ethpb.SignedBeaconBlockHeader{
+			Header: &ethpb.BeaconBlockHeader{
+				Slot: 5,
+			},
+			Signature: make([]byte, 96),
+		},
+	}
+
+	exitRoutine := make(chan bool)
+	slashingsChan := make(chan *ethpb.ProposerSlashing)
+	ctx, cancel := context.WithCancel(context.Background())
+	client.EXPECT().SubmitProposerSlashing(gomock.Any(), slashing)
+	go func(tt *testing.T) {
+		bs.subscribeDetectedProposerSlashings(ctx, slashingsChan)
+		<-exitRoutine
+	}(t)
+	slashingsChan <- slashing
+	cancel()
+	exitRoutine <- true
+	testutil.AssertLogsContain(t, hook, "Context canceled")
+}
+
+func TestService_SubscribeDetectedAttesterSlashings(t *testing.T) {
+	hook := logTest.NewGlobal()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock.NewMockBeaconChainClient(ctrl)
+
+	bs := Service{
+		client:                client,
+		attesterSlashingsFeed: new(event.Feed),
+	}
+
+	slashing := &ethpb.AttesterSlashing{
+		Attestation_1: &ethpb.IndexedAttestation{
+			AttestingIndices: []uint64{1, 2, 3},
+			Data:             nil,
+		},
+		Attestation_2: &ethpb.IndexedAttestation{
+			AttestingIndices: []uint64{3, 4, 5},
+			Data:             nil,
+		},
+	}
+
+	exitRoutine := make(chan bool)
+	slashingsChan := make(chan *ethpb.AttesterSlashing)
+	ctx, cancel := context.WithCancel(context.Background())
+	client.EXPECT().SubmitAttesterSlashing(gomock.Any(), slashing)
+	go func(tt *testing.T) {
+		bs.subscribeDetectedAttesterSlashings(ctx, slashingsChan)
+		<-exitRoutine
+	}(t)
+	slashingsChan <- slashing
+	cancel()
+	exitRoutine <- true
+	testutil.AssertLogsContain(t, hook, "Context canceled")
+}

--- a/slasher/node/BUILD.bazel
+++ b/slasher/node/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//shared:go_default_library",
         "//shared/cmd:go_default_library",
         "//shared/debug:go_default_library",
+        "//shared/event:go_default_library",
         "//shared/tracing:go_default_library",
         "//slasher/beaconclient:go_default_library",
         "//slasher/db:go_default_library",

--- a/slasher/node/node.go
+++ b/slasher/node/node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared"
 	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/debug"
+	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/tracing"
 	"github.com/prysmaticlabs/prysm/slasher/beaconclient"
 	"github.com/prysmaticlabs/prysm/slasher/db"
@@ -28,11 +29,13 @@ const slasherDBName = "slasherdata"
 // for eth2. It handles the lifecycle of the entire system and registers
 // services to a service registry.
 type SlasherNode struct {
-	ctx      *cli.Context
-	lock     sync.RWMutex
-	services *shared.ServiceRegistry
-	stop     chan struct{} // Channel to wait for termination notifications.
-	db       db.Database
+	ctx                   *cli.Context
+	lock                  sync.RWMutex
+	services              *shared.ServiceRegistry
+	proposerSlashingsFeed *event.Feed
+	attesterSlashingsFeed *event.Feed
+	stop                  chan struct{} // Channel to wait for termination notifications.
+	db                    db.Database
 }
 
 // NewSlasherNode creates a new node instance, sets up configuration options,
@@ -50,9 +53,11 @@ func NewSlasherNode(ctx *cli.Context) (*SlasherNode, error) {
 	registry := shared.NewServiceRegistry()
 
 	slasher := &SlasherNode{
-		ctx:      ctx,
-		services: registry,
-		stop:     make(chan struct{}),
+		ctx:                   ctx,
+		proposerSlashingsFeed: new(event.Feed),
+		attesterSlashingsFeed: new(event.Feed),
+		services:              registry,
+		stop:                  make(chan struct{}),
 	}
 
 	if err := slasher.startDB(ctx); err != nil {
@@ -149,8 +154,10 @@ func (s *SlasherNode) registerBeaconClientService(ctx *cli.Context) error {
 		beaconProvider = flags.BeaconRPCProviderFlag.Value
 	}
 	bs := beaconclient.NewBeaconClient(context.Background(), &beaconclient.Config{
-		BeaconCert:     beaconCert,
-		BeaconProvider: beaconProvider,
+		BeaconCert:            beaconCert,
+		BeaconProvider:        beaconProvider,
+		AttesterSlashingsFeed: s.attesterSlashingsFeed,
+		ProposerSlashingsFeed: s.proposerSlashingsFeed,
 	})
 	return s.services.RegisterService(bs)
 }


### PR DESCRIPTION
Part of #4836 

---

# Description

**Write a summary of the changes you are making**

This PR sets up the slasher to submit attester/proposer slashing objects via RPC to the connected beacon node as soon as they are seen. It subscribes to a global event feed in the slasher runtime to then submit the items.