### PR TITLE
Improve block descendant error log

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -100,6 +100,10 @@ func (s *Service) verifyBlkDescendant(ctx context.Context, root [32]byte, slot u
 	if err != nil {
 		return errors.Wrap(err, "could not get finalized block root")
 	}
+	if bFinalizedRoot == nil {
+		return fmt.Errorf("no finalized block known for block from slot %d", slot)
+	}
+
 	if !bytes.Equal(bFinalizedRoot, s.finalizedCheckpt.Root) {
 		err := fmt.Errorf("block from slot %d is not a descendent of the current finalized block slot %d, %#x != %#x",
 			slot, finalizedBlk.Slot, bytesutil.Trunc(bFinalizedRoot), bytesutil.Trunc(s.finalizedCheckpt.Root))


### PR DESCRIPTION
If the incoming block's finalized block is not known to us (ie `nil`), it's better to log the following:
```
no finalized block known for block from slot 258817
```

Than
```
block from slot 258817 is not a descendent of the current finalized block slot 258752,  != 0x86724b59c12c
```