### PR TITLE
Utilise a Flag to Toggle With the GC

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -74,6 +74,12 @@ var (
 		Usage: "The eth1 block in which the deposit contract was deployed.",
 		Value: 1960177,
 	}
+	// SetGCPercent is the percentage of current live allocations at which the garbage collector is to run.
+	SetGCPercent = cli.IntFlag{
+		Name:  "gc-percent",
+		Usage: "The percentage of freshly allocated data to live data on which the gc will be run again.",
+		Value: 100,
+	}
 	// SlasherCertFlag defines a flag for the slasher TLS certificate.
 	SlasherCertFlag = cli.StringFlag{
 		Name:  "slasher-tls-cert",

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -36,6 +36,7 @@ var appFlags = []cli.Flag{
 	flags.MinSyncPeers,
 	flags.RPCMaxPageSize,
 	flags.ContractDeploymentBlock,
+	flags.SetGCPercent,
 	flags.InteropMockEth1DataVotesFlag,
 	flags.InteropGenesisStateFlag,
 	flags.InteropNumValidatorsFlag,
@@ -126,6 +127,7 @@ func main() {
 			}
 		}
 
+		runtimeDebug.SetGCPercent(ctx.GlobalInt(flags.SetGCPercent.Name))
 		runtime.GOMAXPROCS(runtime.NumCPU())
 		return debug.Setup(ctx)
 	}

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -89,6 +89,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.KeyFlag,
 			flags.GRPCGatewayPort,
 			flags.HTTPWeb3ProviderFlag,
+			flags.SetGCPercent,
 		},
 	},
 	{


### PR DESCRIPTION
Originally a part of #4844 

This allows nodes to toggle with the percentage of newly allocated data to live data that the GC is triggered to run again.
