### PR TITLE
Handing pending atts if they dont have the state

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -60,8 +60,8 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 		s.pendingAttsLock.RLock()
 		attestations := s.blkRootToPendingAtts[bRoot]
 		s.pendingAttsLock.RUnlock()
-		// Has the pending attestation's missing block arrived yet?
-		if s.db.HasBlock(ctx, bRoot) {
+		// Has the pending attestation's missing block arrived and the node processed block yet?
+		if s.db.HasBlock(ctx, bRoot) && s.db.HasState(ctx, bRoot) {
 			numberOfBlocksRecoveredFromAtt.Inc()
 			for _, att := range attestations {
 				// The pending attestations can arrive in both aggregated and unaggregated forms,

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/peers"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
+	beaconstate "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/attestationutil"
 	"github.com/prysmaticlabs/prysm/shared/bls"
@@ -77,7 +78,9 @@ func TestProcessPendingAtts_HasBlockSaveUnAggregatedAtt(t *testing.T) {
 
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	r32, _ := ssz.HashTreeRoot(b.Block)
+	s, _ := beaconstate.InitializeFromProto(&pb.BeaconState{})
 	r.db.SaveBlock(context.Background(), b)
+	r.db.SaveState(context.Background(), s, r32)
 
 	r.blkRootToPendingAtts[r32] = []*ethpb.AggregateAttestationAndProof{a}
 	if err := r.processPendingAtts(context.Background()); err != nil {
@@ -172,6 +175,8 @@ func TestProcessPendingAtts_HasBlockSaveAggregatedAtt(t *testing.T) {
 	sb = &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	r32, _ := ssz.HashTreeRoot(sb.Block)
 	r.db.SaveBlock(context.Background(), sb)
+	s, _ := beaconstate.InitializeFromProto(&pb.BeaconState{})
+	r.db.SaveState(context.Background(), s, r32)
 
 	r.blkRootToPendingAtts[r32] = []*ethpb.AggregateAttestationAndProof{aggregateAndProof}
 	if err := r.processPendingAtts(context.Background()); err != nil {

--- a/beacon-chain/sync/subscriber_committee_index_beacon_attestation_test.go
+++ b/beacon-chain/sync/subscriber_committee_index_beacon_attestation_test.go
@@ -14,7 +14,9 @@ import (
 	dbtest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
+	beaconstate "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
@@ -39,6 +41,9 @@ func TestService_committeeIndexBeaconAttestationSubscriber_ValidMessage(t *testi
 	if err := db.SaveBlock(ctx, blk); err != nil {
 		t.Fatal(err)
 	}
+	savedState, _ := beaconstate.InitializeFromProto(&pb.BeaconState{})
+	db.SaveState(context.Background(), savedState, root)
+
 	r := &Service{
 		attPool: attestations.NewPool(),
 		chain: &mock.ChainService{

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -127,8 +127,10 @@ func (r *Service) validateAggregatedAtt(ctx context.Context, a *ethpb.AggregateA
 }
 
 func (r *Service) validateBlockInAttestation(ctx context.Context, a *ethpb.AggregateAttestationAndProof) bool {
-	// Verify the block being voted is in DB. The block should have passed validation if it's in the DB.
-	if !r.db.HasBlock(ctx, bytesutil.ToBytes32(a.Aggregate.Data.BeaconBlockRoot)) {
+	// Verify the block being voted and the processed state is in DB. The block should have passed validation if it's in the DB.
+	hasState := r.db.HasState(ctx, bytesutil.ToBytes32(a.Aggregate.Data.BeaconBlockRoot))
+	hasBlock := r.db.HasBlock(ctx, bytesutil.ToBytes32(a.Aggregate.Data.BeaconBlockRoot))
+	if !(hasState && hasBlock) {
 		// A node doesn't have the block, it'll request from peer while saving the pending attestation to a queue.
 		r.savePendingAtt(a)
 		return false

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
+	beaconstate "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/attestationutil"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -165,6 +167,8 @@ func TestValidateAggregateAndProof_NotWithinSlotRange(t *testing.T) {
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	db.SaveBlock(context.Background(), b)
 	root, _ := ssz.HashTreeRoot(b.Block)
+	s, _ := beaconstate.InitializeFromProto(&pb.BeaconState{})
+	db.SaveState(context.Background(), s, root)
 
 	aggBits := bitfield.NewBitlist(3)
 	aggBits.SetBitAt(0, true)
@@ -305,6 +309,8 @@ func TestValidateAggregateAndProof_CanValidate(t *testing.T) {
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	db.SaveBlock(context.Background(), b)
 	root, _ := ssz.HashTreeRoot(b.Block)
+	s, _ := beaconstate.InitializeFromProto(&pb.BeaconState{})
+	db.SaveState(context.Background(), s, root)
 
 	aggBits := bitfield.NewBitlist(3)
 	aggBits.SetBitAt(0, true)

--- a/beacon-chain/sync/validate_committee_index_beacon_attestation.go
+++ b/beacon-chain/sync/validate_committee_index_beacon_attestation.go
@@ -73,8 +73,10 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		return false
 	}
 
-	// Verify the block being voted is in DB. The block should have passed validation if it's in the DB.
-	if !s.db.HasBlock(ctx, bytesutil.ToBytes32(att.Data.BeaconBlockRoot)) {
+	// Verify the block being voted and the processed state is in DB and. The block should have passed validation if it's in the DB.
+	hasState := s.db.HasState(ctx, bytesutil.ToBytes32(att.Data.BeaconBlockRoot))
+	hasBlock := s.db.HasBlock(ctx, bytesutil.ToBytes32(att.Data.BeaconBlockRoot))
+	if !(hasState && hasBlock) {
 		// A node doesn't have the block, it'll request from peer while saving the pending attestation to a queue.
 		s.savePendingAtt(&eth.AggregateAttestationAndProof{Aggregate: att})
 		return false

--- a/beacon-chain/sync/validate_committee_index_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_committee_index_beacon_attestation_test.go
@@ -14,7 +14,9 @@ import (
 	mockChain "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	dbtest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
+	beaconstate "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
@@ -48,6 +50,9 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	savedState, _ := beaconstate.InitializeFromProto(&pb.BeaconState{})
+	db.SaveState(context.Background(), savedState, validBlockRoot)
 
 	tests := []struct {
 		name                      string


### PR DESCRIPTION
Here's the problem, when a node receives an attestation and it doesn't have the block. It requests the block. It will then go ahead to validate the signature in sync without waiting for state to be processed. Breaking this down into time line:

1.)
```
[2020-02-18 09:23:15]  INFO blockchain: Executing state transition on block root=0x6b34ab0d... slot=286016
```

2.)
```
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
[2020-02-18 09:23:16] ERROR blockchain: Failed to validate attestation error=pre state of target block 286016 does not exist
```

3.)
```
[2020-02-18 09:23:16]  INFO blockchain: Starting next epoch epoch=8938 finalizedEpoch=8934 justifiedEpoch=8936 previousJustifiedEpoch=8936
[2020-02-18 09:23:16]  INFO blockchain: Validator registry information activeValidators=41660 averageBalance=3.17437 ETH totalValidators=41667
[2020-02-18 09:23:16]  INFO blockchain: Finished applying state transition attestations=1 deposits=0 slot=286016
```

3 needs to happen before 2.  This PR adds the `HasState` check around pending attestation queue to ensure the signature validation has the state in the DB