### PR TITLE
Check DB for Justified State

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -267,6 +267,9 @@ func (s *Service) updateJustified(ctx context.Context, state *stateTrie.BeaconSt
 		// If justified state is nil, resume back to normal syncing process and save
 		// justified check point.
 		if justifiedState == nil {
+			if s.beaconDB.HasState(ctx, justifiedRoot) {
+				return s.beaconDB.SaveJustifiedCheckpoint(ctx, cpt)
+			}
 			justifiedState, err = s.generateState(ctx, bytesutil.ToBytes32(s.finalizedCheckpt.Root), justifiedRoot)
 			if err != nil {
 				log.Error(err)


### PR DESCRIPTION
If we use the initial sync flag, we will generate a justified state each time we want to save a justified checkpoint. This PR checks if a state exists first.