### PR TITLE
Add Unsafe Sync

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -80,6 +80,11 @@ var (
 		Usage: "The percentage of freshly allocated data to live data on which the gc will be run again.",
 		Value: 100,
 	}
+	// UnsafeSync starts the beacon node from the previously saved head state and syncs from there.
+	UnsafeSync = cli.BoolFlag{
+		Name:  "unsafe-sync",
+		Usage: "Starts the beacon node with the previously saved head state instead of finalized state.",
+	}
 	// SlasherCertFlag defines a flag for the slasher TLS certificate.
 	SlasherCertFlag = cli.StringFlag{
 		Name:  "slasher-tls-cert",

--- a/beacon-chain/flags/config.go
+++ b/beacon-chain/flags/config.go
@@ -16,6 +16,7 @@ type GlobalFlags struct {
 	MinimumSyncPeers                  int
 	MaxPageSize                       int
 	DeploymentBlock                   int
+	UnsafeSync                        bool
 }
 
 var globalConfig *GlobalFlags
@@ -48,6 +49,9 @@ func ConfigureGlobalFlags(ctx *cli.Context) {
 	}
 	if ctx.GlobalBool(ArchiveAttestationsFlag.Name) {
 		cfg.EnableArchivedAttestations = true
+	}
+	if ctx.GlobalBool(UnsafeSync.Name) {
+		cfg.UnsafeSync = true
 	}
 	cfg.MaxPageSize = ctx.GlobalInt(RPCMaxPageSize.Name)
 	cfg.DeploymentBlock = ctx.GlobalInt(ContractDeploymentBlock.Name)

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -37,6 +37,7 @@ var appFlags = []cli.Flag{
 	flags.RPCMaxPageSize,
 	flags.ContractDeploymentBlock,
 	flags.SetGCPercent,
+	flags.UnsafeSync,
 	flags.InteropMockEth1DataVotesFlag,
 	flags.InteropGenesisStateFlag,
 	flags.InteropNumValidatorsFlag,

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -26,6 +26,7 @@ type blockchainService interface {
 	blockchain.BlockReceiver
 	blockchain.HeadFetcher
 	ClearCachedStates()
+	blockchain.FinalizationFetcher
 }
 
 const (
@@ -178,7 +179,7 @@ func (s *Service) waitForMinimumPeers() {
 		required = flags.Get().MinimumSyncPeers
 	}
 	for {
-		_, _, peers := s.p2p.Peers().BestFinalized(params.BeaconConfig().MaxPeersToSync, helpers.SlotToEpoch(s.chain.HeadSlot()))
+		_, _, peers := s.p2p.Peers().BestFinalized(params.BeaconConfig().MaxPeersToSync, s.chain.FinalizedCheckpt().Epoch)
 		if len(peers) >= required {
 			break
 		}

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -90,6 +90,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.GRPCGatewayPort,
 			flags.HTTPWeb3ProviderFlag,
 			flags.SetGCPercent,
+			flags.UnsafeSync,
 		},
 	},
 	{


### PR DESCRIPTION
This leads to the node starting with the previously saved head state instead of finalized state with the flag utilized. 