### PR TITLE
Delete States More Efficiently

### DIFF
--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -228,7 +228,7 @@ func (k *Store) DeleteStates(ctx context.Context, blockRoots [][32]byte) error {
 				if bytes.Equal(blockRoot[:], checkpoint.Root) || bytes.Equal(blockRoot[:], genesisBlockRoot) || bytes.Equal(blockRoot[:], headBlkRoot) {
 					return errors.New("could not delete genesis, finalized, or head state")
 				}
-				if err := bkt.Delete(blockRoot[:]); err != nil {
+				if err := c.Delete(); err != nil {
 					return err
 				}
 			}

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -197,6 +197,9 @@ func (k *Store) DeleteState(ctx context.Context, blockRoot [32]byte) error {
 func (k *Store) DeleteStates(ctx context.Context, blockRoots [][32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteStates")
 	defer span.End()
+	// only sync when all states are deleted
+	k.db.NoSync = true
+	defer func() { k.db.NoSync = false }()
 
 	return k.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(blocksBucket)


### PR DESCRIPTION
Instead of doing a binary search for already deleted keys we store the relevant keys in a map, and use the bolt cursor to efficiently traverse all the keys in the bucket. This results in much faster deletion of states