### PR TITLE
Clean up MinMaxSpan implementation

### DIFF
--- a/slasher/detection/attestations/BUILD.bazel
+++ b/slasher/detection/attestations/BUILD.bazel
@@ -17,8 +17,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
-        "attestation_test.go",
         "attestations_bench_test.go",
+        "attestations_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/slasher/detection/attestations/attestations_bench_test.go
+++ b/slasher/detection/attestations/attestations_bench_test.go
@@ -27,7 +27,7 @@ func BenchmarkMinSpan(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				_, _, err = detectAndUpdateMinEpochSpan(ctx, i, i+diff, spanMap)
+				_, _, err = detectAndUpdateMinEpochSpan(ctx, spanMap, i, i+diff)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -52,7 +52,7 @@ func BenchmarkMaxSpan(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				_, _, err = detectAndUpdateMaxEpochSpan(ctx, diff, diff+i, spanMap)
+				_, _, err = detectAndUpdateMaxEpochSpan(ctx, spanMap, diff, diff+i)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -77,7 +77,7 @@ func BenchmarkDetectSpan(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				_, _, _, err = detectSlashingByEpochSpan(ctx, i, i+diff, spanMap, detectMax)
+				_, _, _, err = detectSlashingByEpochSpan(ctx, spanMap, i, i+diff, detectMax)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -91,7 +91,7 @@ func BenchmarkDetectSpan(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				_, _, _, err = detectSlashingByEpochSpan(ctx, i, i+diff, spanMap, detectMin)
+				_, _, _, err = detectSlashingByEpochSpan(ctx, spanMap, i, i+diff, detectMin)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/slasher/detection/attestations/attestations_test.go
+++ b/slasher/detection/attestations/attestations_test.go
@@ -206,7 +206,7 @@ func TestServer_UpdateMaxEpochSpan(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		st, spanMap, err := detectAndUpdateMaxEpochSpan(ctx, tt.sourceEpoch, tt.targetEpoch, spanMap)
+		spanMap, st, err := detectAndUpdateMaxEpochSpan(ctx, spanMap, tt.sourceEpoch, tt.targetEpoch)
 		if err != nil {
 			t.Fatalf("Failed to update span: %v", err)
 		}
@@ -239,7 +239,7 @@ func TestServer_UpdateMinEpochSpan(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		st, spanMap, err := detectAndUpdateMinEpochSpan(ctx, tt.sourceEpoch, tt.targetEpoch, spanMap)
+		spanMap, st, err := detectAndUpdateMinEpochSpan(ctx, spanMap, tt.sourceEpoch, tt.targetEpoch)
 		if err != nil {
 			t.Fatalf("Failed to update span: %v", err)
 		}
@@ -282,10 +282,10 @@ func TestServer_FailToUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := detectAndUpdateMinEpochSpan(ctx, spanTestsFail.sourceEpoch, spanTestsFail.targetEpoch, spanMap); err == nil {
+	if _, _, err := detectAndUpdateMinEpochSpan(ctx, spanMap, spanTestsFail.sourceEpoch, spanTestsFail.targetEpoch); err == nil {
 		t.Fatalf("Update should not support diff greater then weak subjectivity period: %v ", params.BeaconConfig().WeakSubjectivityPeriod)
 	}
-	if _, _, err := detectAndUpdateMaxEpochSpan(ctx, spanTestsFail.sourceEpoch, spanTestsFail.targetEpoch, spanMap); err == nil {
+	if _, _, err := detectAndUpdateMaxEpochSpan(ctx, spanMap, spanTestsFail.sourceEpoch, spanTestsFail.targetEpoch); err == nil {
 		t.Fatalf("Update should not support diff greater then weak subjectivity period: %v ", params.BeaconConfig().WeakSubjectivityPeriod)
 	}
 


### PR DESCRIPTION
This PR goes through the MinMaxSpan detection implementation and does things like organize parameters, reduce redundancy, and clean up logs.