### PR TITLE
Fix Fork Copying

### DIFF
--- a/beacon-chain/state/BUILD.bazel
+++ b/beacon-chain/state/BUILD.bazel
@@ -46,5 +46,6 @@ go_test(
         "//shared/stateutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@com_github_prysmaticlabs_go_ssz//:go_default_library",
     ],
 )

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -135,8 +135,8 @@ func (b *BeaconState) Fork() *pbp2p.Fork {
 
 	prevVersion := make([]byte, len(b.state.Fork.PreviousVersion))
 	copy(prevVersion, b.state.Fork.PreviousVersion)
-	currVersion := make([]byte, len(b.state.Fork.PreviousVersion))
-	copy(currVersion, b.state.Fork.PreviousVersion)
+	currVersion := make([]byte, len(b.state.Fork.CurrentVersion))
+	copy(currVersion, b.state.Fork.CurrentVersion)
 	return &pbp2p.Fork{
 		PreviousVersion: prevVersion,
 		CurrentVersion:  currVersion,

--- a/beacon-chain/state/types_test.go
+++ b/beacon-chain/state/types_test.go
@@ -5,10 +5,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/prysmaticlabs/go-ssz"
-
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/go-ssz"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"


### PR DESCRIPTION
We were incorrectly copying the current fork version which lead to failures in the v0.10.1 spectests. This PR has the fix and regression test for it