### PR TITLE
Add Ethereum 1 block->timestamp cache for infostream

### DIFF
--- a/beacon-chain/rpc/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/beacon/BUILD.bazel
@@ -44,6 +44,8 @@ go_library(
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_patrickmn_go_cache//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",


### PR DESCRIPTION
For infostream to calculate the activation time for pending validators it requires the timestamp of the block in which the deposit was made.  This was being fetched each time the value was calculated, resulting in a lot of extraneous calls to `BlockTimeByHeight()`, which in turn talks to the Ethereum 1 node.

This patch adds a cache mapping block number to block time.  It also adds in prometheus metrics for the two infostream caches.  Finally, it handles blocks inline rather than spinning out a separate goroutine, as the gRPC server already puts the infostream call in a separate goroutine and this ensures the code isn't run for multiple epochs in parallel.