### PR TITLE
init-sync: refactor block fetching

### DIFF
--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
+        "//beacon-chain/db:go_default_library",
         "//beacon-chain/db/testing:go_default_library",
         "//beacon-chain/p2p/peers:go_default_library",
         "//beacon-chain/p2p/testing:go_default_library",

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -58,10 +58,13 @@ go_test(
         "//shared/params:go_default_library",
         "//shared/roughtime:go_default_library",
         "//shared/sliceutil:go_default_library",
+        "//shared/testutil:go_default_library",
         "@com_github_kevinms_leakybucket_go//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//network:go_default_library",
+        "@com_github_libp2p_go_libp2p_core//peer:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
 )

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "blocks_fetcher.go",
         "log.go",
         "round_robin.go",
         "service.go",
@@ -37,7 +38,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["round_robin_test.go"],
+    srcs = [
+        "blocks_fetcher_test.go",
+        "round_robin_test.go",
+    ],
     embed = [":go_default_library"],
     race = "on",
     tags = ["race_on"],

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -173,16 +173,13 @@ func (f *blocksFetcher) loop() {
 }
 
 // scheduleRequest adds request to incoming queue.
-// Should be non-blocking, as actual request processing is done asynchronously.
 func (f *blocksFetcher) scheduleRequest(req *fetchRequestParams) {
-	go func() { // non-blocking, we can re-throw requests within consuming method
-		select {
-		case <-f.quit:
-			return
-		case f.requests <- req:
-			return
-		}
-	}()
+	select {
+	case <-f.quit:
+		return
+	default:
+		f.requests <- req
+	}
 }
 
 // processFetchRequest orchestrates block fetching from the available peers.

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -56,6 +56,7 @@ type fetchRequestResponse struct {
 	params *fetchRequestParams
 	blocks []*eth.SignedBeaconBlock
 	err    error
+	peers  []peer.ID
 }
 
 // newBlocksFetcher creates ready to use fetcher
@@ -154,6 +155,7 @@ func (f *blocksFetcher) loop() {
 				f.receivedFetchResponses <- &fetchRequestResponse{
 					params: req,
 					blocks: resp,
+					peers:  peers,
 				}
 			}(root, finalizedEpoch, req.start, req.count, peers)
 		}

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -175,7 +175,7 @@ func (f *blocksFetcher) processFetchRequest(root []byte, finalizedEpoch, start, 
 		return nil, errors.WithStack(errors.New("no peers left to request blocks"))
 	}
 
-	// TODO account for skipped slots:
+	// TODO(4815): Account for skipped slots:
 	// Handle block large block ranges of skipped slots.
 	lastEmptyRequests := 0
 	start += count * uint64(lastEmptyRequests*len(peers))
@@ -257,9 +257,11 @@ func (f *blocksFetcher) processFetchRequest(root []byte, finalizedEpoch, start, 
 			return nil, err
 		case resp, ok := <-blocksChan:
 			if ok {
-				//  if this synchronization becomes a bottleneck:
-				//    think about immediately allocating space for all peers in unionRespBlocks,
-				//    and write without synchronization
+				// if this synchronization becomes a bottleneck:
+				// think about immediately allocating space for all peers in unionRespBlocks,
+				// and write without synchronization
+				// alternatively: we can limit how many peers are processing each request range
+				// and find good blocks range/peers ratio. Requests to different peer sets can be run concurrently.
 				unionRespBlocks = append(unionRespBlocks, resp...)
 			} else {
 				return unionRespBlocks, nil

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -98,7 +98,7 @@ func (f *blocksFetcher) loop() {
 		select {
 		case <-f.ctx.Done():
 			// upstream context is done
-			f.stop()
+			return
 		case <-f.quit:
 			// terminating abort all operations
 			return

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -1,0 +1,318 @@
+package initialsync
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/kevinms/leakybucket-go"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/pkg/errors"
+	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
+	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
+	prysmsync "github.com/prysmaticlabs/prysm/beacon-chain/sync"
+	p2ppb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/mathutil"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/sirupsen/logrus"
+)
+
+// blocksFetcherConfig is a config to setup block fetcher
+type blocksFetcherConfig struct {
+	ctx         context.Context
+	chain       blockchainService
+	p2p         p2p.P2P
+	rateLimiter *leakybucket.Collector
+}
+
+// blocksFetcher is a service to fetch chain data from peers.
+// On an incoming requests, requested block range is evenly divided
+// among available peers (for fair network load distribution).
+type blocksFetcher struct {
+	ctx         context.Context
+	chain       blockchainService
+	p2p         p2p.P2P
+	rateLimiter *leakybucket.Collector
+
+	requests chan *fetchRequestParams // incoming fetch requests
+	out      chan *fetchRequestResult // outgoing responses
+	quit     chan struct{}            // termination notifier
+}
+
+// fetchRequestParams holds parameters necessary to schedule a fetch request
+type fetchRequestParams struct {
+	start uint64 // starting slot
+	count uint64 // how many slots to receive (fetcher may return fewer slots)
+}
+
+// fetchRequestResult is a combined type to hold results of both successful executions and errors.
+// Valid usage pattern will be to check whether result's `err` is nil, before using `blocks`.
+type fetchRequestResult struct {
+	params *fetchRequestParams
+	blocks []*eth.SignedBeaconBlock
+	err    error
+}
+
+// newBlocksFetcher creates ready to use fetcher
+func newBlocksFetcher(cfg *blocksFetcherConfig) *blocksFetcher {
+	return &blocksFetcher{
+		ctx:         cfg.ctx,
+		chain:       cfg.chain,
+		p2p:         cfg.p2p,
+		rateLimiter: cfg.rateLimiter,
+		requests:    make(chan *fetchRequestParams),
+		out:         make(chan *fetchRequestResult),
+		quit:        make(chan struct{}),
+	}
+}
+
+// start boots up the fetcher, which starts listening for incoming fetch requests.
+func (f *blocksFetcher) start() {
+	go f.loop()
+}
+
+// stop terminates all fetcher operations
+func (f *blocksFetcher) stop() {
+	close(f.quit)
+}
+
+// iter returns outgoing channel, on which consumers is expected to constantly iterate for results/errors
+func (f *blocksFetcher) iter() <-chan *fetchRequestResult {
+	return f.out
+}
+
+// loop is a main fetcher loop, listens for incoming requests/cancellations, forwards outgoing responses
+func (f *blocksFetcher) loop() {
+	defer close(f.out)
+
+	randGenerator := rand.New(rand.NewSource(time.Now().Unix()))
+	highestFinalizedSlot := helpers.StartSlot(f.highestFinalizedEpoch() + 1)
+
+	for {
+		select {
+		case <-f.ctx.Done():
+			// upstream context is done
+			f.stop()
+		case <-f.quit:
+			// terminating abort all operations
+			return
+		case req := <-f.requests:
+			root, finalizedEpoch, peers := f.p2p.Peers().BestFinalized(params.BeaconConfig().MaxPeersToSync, helpers.SlotToEpoch(f.chain.HeadSlot()))
+
+			if len(peers) == 0 {
+				log.Warn("No peers; waiting for reconnect")
+				time.Sleep(refreshTime)
+				continue
+			}
+
+			if len(peers) >= flags.Get().MinimumSyncPeers {
+				highestFinalizedSlot = helpers.StartSlot(finalizedEpoch + 1)
+			}
+
+			// Short circuit start far exceeding the highest finalized epoch in some infinite loop.
+			if req.start > highestFinalizedSlot {
+				err := errors.Errorf("requested a start slot of %d which is greater than the next highest slot of %d", req.start, highestFinalizedSlot)
+				log.WithError(err).Debug("Block fetch request failed")
+				f.out <- &fetchRequestResult{
+					params: req,
+					err:    err,
+				}
+				continue
+			}
+
+			// shuffle peers to prevent a bad peer from
+			// stalling sync with invalid blocks
+			randGenerator.Shuffle(len(peers), func(i, j int) {
+				peers[i], peers[j] = peers[j], peers[i]
+			})
+
+			resp, err := f.processFetchRequest(root, finalizedEpoch, req.start, req.count, peers)
+			if err != nil {
+				log.WithError(err).Debug("Block fetch request failed")
+				f.out <- &fetchRequestResult{
+					params: req,
+					err:    err,
+				}
+				continue
+			}
+
+			f.out <- &fetchRequestResult{
+				params: req,
+				blocks: resp,
+			}
+		}
+	}
+}
+
+// scheduleRequest adds request to incoming queue.
+// Should be non-blocking, actual requests processing is done asynchronously.
+func (f *blocksFetcher) scheduleRequest(req *fetchRequestParams) {
+	go func() { // non-blocking, we can re-throw requests within consuming method
+		select {
+		case <-f.quit:
+			return
+		case f.requests <- req:
+			return
+		}
+	}()
+}
+
+// processFetchRequest orchestrates block fetching from the available peers.
+// In each request a range of blocks is to be requested from multiple peers.
+// Example:
+//   - number of peers = 4
+//   - range of block slots is 64...128
+//   Four requests will be spread across the peers using step argument to distribute the load
+//   i.e. the first peer is asked for block 64, 68, 72... while the second peer is asked for
+//   65, 69, 73... and so on for other peers.
+func (f *blocksFetcher) processFetchRequest(root []byte, finalizedEpoch, start, count uint64, peers []peer.ID) ([]*eth.SignedBeaconBlock, error) {
+	if len(peers) == 0 {
+		return nil, errors.WithStack(errors.New("no peers left to request blocks"))
+	}
+
+	// TODO account for skipped slots:
+	// Handle block large block ranges of skipped slots.
+	lastEmptyRequests := 0
+	start += count * uint64(lastEmptyRequests*len(peers))
+
+	p2pRequests := new(sync.WaitGroup)
+	errChan := make(chan error)
+	blocksChan := make(chan []*eth.SignedBeaconBlock)
+
+	p2pRequests.Add(len(peers))
+	go func() {
+		p2pRequests.Wait()
+		close(blocksChan)
+	}()
+
+	// Short circuit start far exceeding the highest finalized epoch in some infinite loop.
+	highestFinalizedSlot := helpers.StartSlot(finalizedEpoch + 1)
+	if start > highestFinalizedSlot {
+		return nil, errors.Errorf("attempted to ask for a start slot of %d which is greater than the next highest slot of %d", start, highestFinalizedSlot)
+	}
+
+	avgCount := mathutil.Min(count, (helpers.StartSlot(finalizedEpoch+1)-start+1)/uint64(len(peers)))
+	remainder := int((helpers.StartSlot(finalizedEpoch+1) - start + 1) % uint64(len(peers)))
+	for i, pid := range peers {
+		if f.ctx.Err() != nil {
+			return nil, f.ctx.Err()
+		}
+		start := start + uint64(i)
+		// If the count was divided by an odd number of peers, there will be some blocks
+		// missing from the first requests so we accommodate that scenario.
+		count := avgCount
+		if i < remainder {
+			count++
+		}
+		// asking for no blocks may cause the client to hang. This should never happen and
+		// the peer may return an error anyway, but we'll ask for at least one block.
+		if count == 0 {
+			count = 1
+		}
+		req := &p2ppb.BeaconBlocksByRangeRequest{
+			HeadBlockRoot: root,
+			StartSlot:     start,
+			Count:         count,
+			Step:          uint64(len(peers)),
+		}
+
+		go func(i int, pid peer.ID) {
+			defer p2pRequests.Done()
+
+			resp, err := f.requestBlocks(f.ctx, req, pid)
+			if err != nil {
+				// fail over to other peers by splitting this requests evenly across them.
+				ps := append(peers[:i], peers[i+1:]...)
+				log.WithError(err).WithField(
+					"remaining peers",
+					len(ps),
+				).WithField(
+					"peer",
+					pid.Pretty(),
+				).Debug("Request failed, trying to round robin with other peers")
+				if len(ps) == 0 {
+					errChan <- errors.WithStack(errors.New("no peers left to request blocks"))
+					return
+				}
+				resp, err = f.processFetchRequest(root, finalizedEpoch, start, count/uint64(len(ps)), ps)
+				if err != nil {
+					errChan <- err
+					return
+				}
+			}
+			log.WithField("peer", pid).WithField("count", len(resp)).Debug("Received blocks")
+			blocksChan <- resp
+		}(i, pid)
+	}
+
+	var unionRespBlocks []*eth.SignedBeaconBlock
+	for {
+		select {
+		case err := <-errChan:
+			return nil, err
+		case resp, ok := <-blocksChan:
+			if ok {
+				//  if this synchronization becomes a bottleneck:
+				//    think about immediately allocating space for all peers in unionRespBlocks,
+				//    and write without synchronization
+				unionRespBlocks = append(unionRespBlocks, resp...)
+			} else {
+				return unionRespBlocks, nil
+			}
+		}
+	}
+}
+
+// requestBlocks is a wrapper for handling BeaconBlocksByRangeRequest requests/streams.
+func (f *blocksFetcher) requestBlocks(ctx context.Context, req *p2ppb.BeaconBlocksByRangeRequest, pid peer.ID) ([]*eth.SignedBeaconBlock, error) {
+	if f.rateLimiter.Remaining(pid.String()) < int64(req.Count) {
+		log.WithField("peer", pid).Debug("Slowing down for rate limit")
+		time.Sleep(f.rateLimiter.TillEmpty(pid.String()))
+	}
+	f.rateLimiter.Add(pid.String(), int64(req.Count))
+	log.WithFields(logrus.Fields{
+		"peer":  pid,
+		"start": req.StartSlot,
+		"count": req.Count,
+		"step":  req.Step,
+		"head":  fmt.Sprintf("%#x", req.HeadBlockRoot),
+	}).Debug("Requesting blocks")
+	stream, err := f.p2p.Send(ctx, req, pid)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to send request to peer")
+	}
+	defer stream.Close()
+
+	resp := make([]*eth.SignedBeaconBlock, 0, req.Count)
+	for {
+		blk, err := prysmsync.ReadChunkedBlock(stream, f.p2p)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read chunked block")
+		}
+		resp = append(resp, blk)
+	}
+
+	return resp, nil
+}
+
+// highestFinalizedEpoch returns the absolute highest finalized epoch of all connected peers.
+// Note this can be lower than our finalized epoch if we have no peers or peers that are all behind us.
+func (f *blocksFetcher) highestFinalizedEpoch() uint64 {
+	highest := uint64(0)
+	for _, pid := range f.p2p.Peers().Connected() {
+		peerChainState, err := f.p2p.Peers().ChainState(pid)
+		if err == nil && peerChainState != nil && peerChainState.FinalizedEpoch > highest {
+			highest = peerChainState.FinalizedEpoch
+		}
+	}
+
+	return highest
+}

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -99,8 +99,8 @@ func (f *blocksFetcher) stop() {
 	}
 }
 
-// iter returns an outgoing channel, on which consumers are expected to constantly iterate for results/errors.
-func (f *blocksFetcher) iter() <-chan *fetchRequestResponse {
+// requestResponses exposes a channel into which fetcher pushes generated request responses.
+func (f *blocksFetcher) requestResponses() <-chan *fetchRequestResponse {
 	return f.receivedFetchResponses
 }
 

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -150,7 +150,7 @@ func TestBlocksFetcher(t *testing.T) {
 
 				for {
 					select {
-					case <-time.After(5 * time.Second): // TODO: temporary safeguard, remove
+					case <-time.After(5 * time.Second): // TODO(4815): Temporary safeguard, remove
 						t.Fatal("timeout")
 					case resp, ok := <-fetcher.iter():
 						if !ok { // channel closed, aggregate

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -129,40 +129,9 @@ func TestBlocksFetcher(t *testing.T) {
 			},
 		},
 		{
-			name:               "Multiple peers with all blocks (count boundaries)",
-			expectedBlockSlots: append(makeSequence(1, 32), makeSequence(92, 105)...),
-			peers: []*peerData{
-				{
-					blocks:         append(makeSequence(1, 64), makeSequence(92, 200)...),
-					finalizedEpoch: 6,
-					headSlot:       200,
-				},
-				{
-					blocks:         append(makeSequence(1, 64), makeSequence(92, 200)...),
-					finalizedEpoch: 6,
-					headSlot:       200,
-				},
-				{
-					blocks:         append(makeSequence(1, 64), makeSequence(92, 200)...),
-					finalizedEpoch: 6,
-					headSlot:       200,
-				},
-			},
-			requests: []*fetchRequestParams{
-				{
-					start: 1,
-					count: blockBatchSize / 2,
-				},
-				{
-					start: 90,
-					count: 15, // [90, 105), since data available from 92, expected output: 92, 93, ..., 105
-				},
-			},
-		},
-		{
 			name: "Multiple peers with skipped slots",
 			// finalizedEpoch(18).slot = 608
-			expectedBlockSlots: append(makeSequence(1, 64), makeSequence(500, 608)...), // up to 18th epoch
+			expectedBlockSlots: append(makeSequence(1, 64), makeSequence(500, 640)...), // up to 18th epoch
 			peers: []*peerData{
 				{
 					blocks:         append(makeSequence(1, 64), makeSequence(500, 640)...),
@@ -195,10 +164,10 @@ func TestBlocksFetcher(t *testing.T) {
 				},
 				{
 					start: 400,
-					count: 150, // [400, 550), with blocks availability starting at 500. So, 500, 501, ..., 550
+					count: 150,
 				},
 				{
-					start: 551,
+					start: 553,
 					count: 200,
 				},
 			},

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -1,0 +1,197 @@
+package initialsync
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/kevinms/leakybucket-go"
+	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
+	dbtest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
+	p2pt "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
+	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
+	p2ppb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/sirupsen/logrus"
+)
+
+func TestBlocksFetcher(t *testing.T) {
+	tests := []struct {
+		name               string
+		currentSlot        uint64
+		expectedBlockSlots []uint64
+		peers              []*peerData
+		requestParams      []*fetchRequestParams
+	}{
+		//{
+		//	name:               "Single peer with all blocks",
+		//	currentSlot:        131,
+		//	expectedBlockSlots: makeSequence(1, 131),
+		//	peers: []*peerData{
+		//		{
+		//			blocks:         makeSequence(1, 131),
+		//			finalizedEpoch: 1,
+		//			headSlot:       131,
+		//		},
+		//	},
+		//},
+		{
+			name:               "Multiple peers with all blocks",
+			currentSlot:        131,
+			expectedBlockSlots: makeSequence(1, 131),
+			peers: []*peerData{
+				{
+					blocks:         makeSequence(1, 131),
+					finalizedEpoch: 2,
+					headSlot:       131,
+				},
+				{
+					blocks:         makeSequence(1, 131),
+					finalizedEpoch: 2,
+					headSlot:       131,
+				},
+				{
+					blocks:         makeSequence(1, 131),
+					finalizedEpoch: 1,
+					headSlot:       131,
+				},
+				{
+					blocks:         makeSequence(1, 131),
+					finalizedEpoch: 1,
+					headSlot:       131,
+				},
+			},
+			requestParams: []*fetchRequestParams{
+				{
+					start: 1,
+					count: blockBatchSize,
+				},
+				{
+					start: blockBatchSize + 1,
+					count: blockBatchSize,
+				},
+			},
+		},
+		//{
+		//	name:               "Multiple peers with many skipped slots",
+		//	currentSlot:        640, // 10 epochs
+		//	expectedBlockSlots: append(makeSequence(1, 64), makeSequence(500, 640)...),
+		//	peers: []*peerData{
+		//		{
+		//			blocks:         append(makeSequence(1, 64), makeSequence(500, 640)...),
+		//			finalizedEpoch: 18,
+		//			headSlot:       640,
+		//		},
+		//		{
+		//			blocks:         append(makeSequence(1, 64), makeSequence(500, 640)...),
+		//			finalizedEpoch: 18,
+		//			headSlot:       640,
+		//		},
+		//		{
+		//			blocks:         append(makeSequence(1, 64), makeSequence(500, 640)...),
+		//			finalizedEpoch: 18,
+		//			headSlot:       640,
+		//		},
+		//	},
+		//},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initializeRootCache(tt.expectedBlockSlots, t)
+
+			beaconDB := dbtest.SetupDB(t)
+
+			p := p2pt.NewTestP2P(t)
+			connectPeers(t, p, tt.peers, p.Peers())
+			genesisRoot := rootCache[0]
+
+			err := beaconDB.SaveBlock(context.Background(), &eth.SignedBeaconBlock{
+				Block: &eth.BeaconBlock{
+					Slot: 0,
+				}})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			st, err := stateTrie.InitializeFromProto(&p2ppb.BeaconState{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			mc := &mock.ChainService{
+				State: st,
+				Root:  genesisRoot[:],
+				DB:    beaconDB,
+			} // no-op mock
+
+			ctx, cancel := context.WithCancel(context.Background())
+			fetcher := newBlocksFetcher(&blocksFetcherConfig{
+				ctx:         ctx,
+				chain:       mc,
+				p2p:         p,
+				rateLimiter: leakybucket.NewCollector(allowedBlocksPerSecond, allowedBlocksPerSecond, false /* deleteEmptyBuckets */),
+			})
+
+			fetcher.start()
+
+			var wg sync.WaitGroup
+			wg.Add(len(tt.requestParams)) // how many block requests we are going to make
+			go func() {
+				wg.Wait()
+				log.Debug("Stopping fetcher")
+				fetcher.stop()
+			}()
+
+			processFetchedBlocks := func() ([]*eth.SignedBeaconBlock, error) {
+				defer cancel()
+				var unionRespBlocks []*eth.SignedBeaconBlock
+
+				for {
+					select {
+					case <-time.After(5 * time.Second): // TODO: temporary safeguard, remove
+						t.Fatal("timeout")
+					case resp, ok := <-fetcher.iter():
+						if !ok { // channel closed, aggregate
+							return unionRespBlocks, nil
+						}
+
+						if resp.err != nil {
+							log.WithError(resp.err).Debug("Block fetcher returned error")
+						} else {
+							unionRespBlocks = append(unionRespBlocks, resp.blocks...)
+						}
+
+						wg.Done()
+					}
+				}
+			}
+
+			for _, requestParams := range tt.requestParams {
+				fetcher.scheduleRequest(requestParams)
+			}
+
+			blocks, err := processFetchedBlocks()
+			if err != nil {
+				t.Error(err)
+			}
+
+			sort.Slice(blocks, func(i, j int) bool {
+				return blocks[i].Block.Slot < blocks[j].Block.Slot
+			})
+
+			slots := make([]uint64, len(blocks))
+			for i, block := range blocks {
+				slots[i] = block.Block.Slot
+			}
+
+			log.WithFields(logrus.Fields{
+				"blocksLen": len(blocks),
+				"slots":     slots,
+			}).Debug("Finished block fetching")
+
+			dbtest.TeardownDB(t, beaconDB)
+		})
+	}
+}

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -273,7 +273,7 @@ func TestBlocksFetcher(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			fetcher := newBlocksFetcher(&blocksFetcherConfig{
 				ctx:         ctx,
-				chain:       mc,
+				headFetcher: mc,
 				p2p:         p,
 				rateLimiter: leakybucket.NewCollector(allowedBlocksPerSecond, allowedBlocksPerSecond, false /* deleteEmptyBuckets */),
 			})

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -203,6 +203,43 @@ func TestBlocksFetcher(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:               "Multiple peers with failures",
+			expectedBlockSlots: makeSequence(1, 2*blockBatchSize),
+			peers: []*peerData{
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 8,
+					headSlot:       320,
+				},
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 8,
+					headSlot:       320,
+					failureSlots:   makeSequence(1, 32), // first epoch
+				},
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 8,
+					headSlot:       320,
+				},
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 8,
+					headSlot:       320,
+				},
+			},
+			requests: []*fetchRequestParams{
+				{
+					start: 1,
+					count: blockBatchSize,
+				},
+				{
+					start: blockBatchSize + 1,
+					count: blockBatchSize,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -268,7 +268,7 @@ func TestBlocksFetcher(t *testing.T) {
 				State: st,
 				Root:  genesisRoot[:],
 				DB:    beaconDB,
-			} // no-op mock
+			}
 
 			ctx, cancel := context.WithCancel(context.Background())
 			fetcher := newBlocksFetcher(&blocksFetcherConfig{

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -267,7 +267,7 @@ func TestBlocksFetcherRoundRobin(t *testing.T) {
 
 				for {
 					select {
-					case resp, ok := <-fetcher.iter():
+					case resp, ok := <-fetcher.requestResponses():
 						if !ok { // channel closed, aggregate
 							return unionRespBlocks, nil
 						}
@@ -370,7 +370,7 @@ func TestHandleRequest(t *testing.T) {
 	select {
 	case <-ctx.Done():
 		t.Error(ctx.Err())
-	case resp := <-fetcher.iter():
+	case resp := <-fetcher.requestResponses():
 		if resp.err != nil {
 			t.Error(resp.err)
 		} else {

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -158,7 +158,7 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 		}
 	}
 
-	fetcher.stop() // manners
+	fetcher.stop()
 
 	log.Debug("Synced to finalized epoch - now syncing blocks up to current head")
 

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -61,7 +61,7 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 
 	fetcher := newBlocksFetcher(&blocksFetcherConfig{
 		ctx:         ctx,
-		chain:       s.chain,
+		headFetcher: s.chain,
 		p2p:         s.p2p,
 		rateLimiter: s.blocksRateLimiter,
 	})

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -76,7 +76,7 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case resp, ok := <-fetcher.iter(): // fetcher will stop when upstream ctx is closed
+			case resp, ok := <-fetcher.requestResponses():
 				if !ok {
 					return nil, errors.New("block fetcher is not running")
 				}

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -111,7 +111,7 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 			}
 		}
 
-		fetcher.scheduleRequest(&fetchRequestParams{
+		go fetcher.scheduleRequest(&fetchRequestParams{
 			start: startBlock,
 			count: blockBatchSize,
 		})

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"sort"
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -100,13 +99,6 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 			time.After(refreshTime)
 			continue
 		}
-
-		// Since the block responses were appended to the list, we must sort them in order to
-		// process sequentially. This method doesn't make much wall time compared to block
-		// processing.
-		sort.Slice(blocks, func(i, j int) bool {
-			return blocks[i].Block.Slot < blocks[j].Block.Slot
-		})
 
 		numProcessedBlocks := 0
 		for _, blk := range blocks {

--- a/endtoend/beacon_node.go
+++ b/endtoend/beacon_node.go
@@ -55,6 +55,7 @@ func startNewBeaconNode(t *testing.T, config *end2EndConfig, beaconNodes []*ev.B
 
 	args := []string{
 		"--force-clear-db",
+		"--verbosity=debug",
 		"--no-discovery",
 		"--http-web3provider=http://127.0.0.1:8745",
 		"--web3provider=ws://127.0.0.1:8746",


### PR DESCRIPTION
Part of #4815

---

# Description

Reference implementation of non-blocking initial synchronization, where producer-consumer queue is used to separate block fetching from processing (and allow them to run concurrently).  More details are outlined in the [design document](https://docs.google.com/document/d/1mm__vLgJfkq25iryIAqWNSgFNfaXqU2tM7P31e8jyf8/edit?usp=sharing).

This PR, handles only fetching part of the requirements:
- round robin initial sync **has been patched** to use new fetcher
- while new fetcher can be run in a non-blocking mode, since we've decided to move in incremental steps, almost one-to-one functionality port was made. So, ideally, everything should be run as before, but the code underneath is decoupled.