### PR TITLE
Wait Till Genesis Time Before Listening for Attestations

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -7,14 +7,14 @@ import (
 
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
-	"github.com/sirupsen/logrus"
-	"go.opencensus.io/trace"
 )
 
 // AttestationReceiver interface defines the methods of chain service receive and processing new attestations.
@@ -58,12 +58,6 @@ func (s *Service) IsValidAttestation(ctx context.Context, att *ethpb.Attestation
 
 // This processes attestations from the attestation pool to account for validator votes and fork choice.
 func (s *Service) processAttestation() {
-	// Wait for state to be initialized.
-	stateChannel := make(chan *feed.Event, 1)
-	stateSub := s.stateNotifier.StateFeed().Subscribe(stateChannel)
-	<-stateChannel
-	stateSub.Unsubscribe()
-
 	st := slotutil.GetSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)
 	for {
 		select {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -168,6 +168,8 @@ func (s *Service) Start() {
 				StartTime: s.genesisTime,
 			},
 		})
+
+		go s.processAttestation()
 	} else {
 		log.Info("Waiting to reach the validator deposit threshold to start the beacon chain...")
 		if s.chainStartFetcher == nil {
@@ -185,6 +187,7 @@ func (s *Service) Start() {
 						data := event.Data.(*statefeed.ChainStartedData)
 						log.WithField("starttime", data.StartTime).Debug("Received chain start event")
 						s.processChainStartTime(ctx, data.StartTime)
+						go s.processAttestation()
 						return
 					}
 				case <-s.ctx.Done():
@@ -197,8 +200,6 @@ func (s *Service) Start() {
 			}
 		}()
 	}
-
-	go s.processAttestation()
 }
 
 // processChainStartTime initializes a series of deposits from the ChainStart deposits in the eth1


### PR DESCRIPTION
No tracking issue.

---

# Description

**Write why you are making the changes in this pull request**

Found an interesting bug when doing local chain runs where slotutil.GetSlotTicker would tick thousands of times per second. Turns out, we were initializing it with a genesis time before we received the genesis state initialization, causing the ticker to go crazy. This issue is reproducible locally around 50% of the time, likely depending on how fast a machine can initialize a genesis state.