### PR TITLE
Add interface for spanner and MockSpanner

### DIFF
--- a/slasher/detection/attestations/BUILD.bazel
+++ b/slasher/detection/attestations/BUILD.bazel
@@ -11,6 +11,8 @@ go_library(
     deps = [
         "//proto/slashing:go_default_library",
         "//shared/params:go_default_library",
+        "//slasher/detection/attestations/iface:go_default_library",
+        "//slasher/detection/attestations/types:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
@@ -22,6 +24,7 @@ go_test(
     srcs = [
         "attestations_bench_test.go",
         "attestations_test.go",
+        "mock_spanner_test.go",
         "spanner_test.go",
     ],
     embed = [":go_default_library"],
@@ -29,6 +32,8 @@ go_test(
         "//proto/slashing:go_default_library",
         "//shared/params:go_default_library",
         "//slasher/db/testing:go_default_library",
+        "//slasher/detection/attestations/iface:go_default_library",
+        "//slasher/detection/attestations/types:go_default_library",
         "//slasher/flags:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/slasher/detection/attestations/iface/BUILD.bazel
+++ b/slasher/detection/attestations/iface/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["iface.go"],
+    importpath = "github.com/prysmaticlabs/prysm/slasher/detection/attestations/iface",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//slasher/detection/attestations/types:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+    ],
+)

--- a/slasher/detection/attestations/iface/iface.go
+++ b/slasher/detection/attestations/iface/iface.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/types"
 )
 
+// SpanDetector defines an interface for Spanners to follow to allow mocks.
 type SpanDetector interface {
 	// Read functions.
 	DetectSlashingForValidator(

--- a/slasher/detection/attestations/iface/iface.go
+++ b/slasher/detection/attestations/iface/iface.go
@@ -1,0 +1,23 @@
+package iface
+
+import (
+	"context"
+
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/types"
+)
+
+type SpanDetector interface {
+	// Read functions.
+	DetectSlashingForValidator(
+		ctx context.Context,
+		validatorIdx uint64,
+		attData *ethpb.AttestationData,
+	) (*types.DetectionResult, error)
+	SpanForEpochByValidator(ctx context.Context, valIdx uint64, epoch uint64) ([2]uint16, error)
+	ValidatorSpansByEpoch(ctx context.Context, epoch uint64) map[uint64][2]uint16
+
+	// Write functions.
+	UpdateSpans(ctx context.Context, att *ethpb.IndexedAttestation) error
+	DeleteValidatorSpansByEpoch(ctx context.Context, validatorIdx uint64, epoch uint64) error
+}

--- a/slasher/detection/attestations/mock_spanner_test.go
+++ b/slasher/detection/attestations/mock_spanner_test.go
@@ -1,0 +1,65 @@
+package attestations
+
+import (
+	"context"
+	"sync"
+
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/iface"
+	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/types"
+)
+
+var _ = iface.SpanDetector(&MockSpanDetector{})
+
+// MockSpanDetector defines a struct which can detect slashable
+// attestation offenses by tracking validator min-max
+// spans from validators.
+type MockSpanDetector struct {
+	// Slice of epochs for valindex => min-max span.
+	spans []map[uint64][2]uint16
+	lock  sync.RWMutex
+}
+
+// DetectSlashingForValidator uses a validator index and its corresponding
+// min-max spans during an epoch to detect an epoch in which the validator
+// committed a slashable attestation.
+func (s *MockSpanDetector) DetectSlashingForValidator(
+	ctx context.Context,
+	validatorIdx uint64,
+	attData *ethpb.AttestationData,
+) (*types.DetectionResult, error) {
+	if attData.Target.Epoch == 0 {
+		return nil, nil
+	} else if attData.Target.Epoch > 5 {
+		return &types.DetectionResult{
+			Kind:           types.SurroundVote,
+			SlashableEpoch: attData.Target.Epoch,
+		}, nil
+	} else {
+		return &types.DetectionResult{
+			Kind:           types.DoubleVote,
+			SlashableEpoch: attData.Target.Epoch,
+		}, nil
+	}
+}
+
+// SpanForEpochByValidator returns the specific min-max span for a
+// validator index in a given epoch.
+func (s *MockSpanDetector) SpanForEpochByValidator(ctx context.Context, valIdx uint64, epoch uint64) ([2]uint16, error) {
+	return [2]uint16{0, 0}, nil
+}
+
+// ValidatorSpansByEpoch returns a list of all validator spans in a given epoch.
+func (s *MockSpanDetector) ValidatorSpansByEpoch(ctx context.Context, epoch uint64) map[uint64][2]uint16 {
+	return make(map[uint64][2]uint16, 0)
+}
+
+// DeleteValidatorSpansByEpoch mocks the delete spans by epoch function.
+func (s *MockSpanDetector) DeleteValidatorSpansByEpoch(ctx context.Context, validatorIdx uint64, epoch uint64) error {
+	return nil
+}
+
+// UpdateSpans is a mock for updating the spans for a given attestation..
+func (s *MockSpanDetector) UpdateSpans(ctx context.Context, att *ethpb.IndexedAttestation) error {
+	return nil
+}

--- a/slasher/detection/attestations/spanner.go
+++ b/slasher/detection/attestations/spanner.go
@@ -7,32 +7,12 @@ import (
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/iface"
+	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/types"
 	"go.opencensus.io/trace"
 )
 
-// DetectionKind defines an enum type that
-// gives us information on the type of slashable offense
-// found when analyzing validator min-max spans.
-type DetectionKind int
-
-const (
-	// DoubleVote denotes a slashable offense in which
-	// a validator cast two conflicting attestations within
-	// the same target epoch.
-	DoubleVote DetectionKind = iota
-	// SurroundVote denotes a slashable offense in which
-	// a validator surrounded or was surrounded by a previous
-	// attestation created by the same validator.
-	SurroundVote
-)
-
-// DetectionResult tells us the kind of slashable
-// offense found from detecting on min-max spans +
-// the slashable epoch for the offense.
-type DetectionResult struct {
-	Kind           DetectionKind
-	SlashableEpoch uint64
-}
+var _ = iface.SpanDetector(&SpanDetector{})
 
 // SpanDetector defines a struct which can detect slashable
 // attestation offenses by tracking validator min-max
@@ -59,7 +39,7 @@ func (s *SpanDetector) DetectSlashingForValidator(
 	ctx context.Context,
 	validatorIdx uint64,
 	attData *ethpb.AttestationData,
-) (*DetectionResult, error) {
+) (*types.DetectionResult, error) {
 	ctx, span := trace.StartSpan(ctx, "detection.DetectSlashingForValidator")
 	defer span.End()
 	sourceEpoch := attData.Source.Epoch
@@ -78,16 +58,16 @@ func (s *SpanDetector) DetectSlashingForValidator(
 	if sp := s.spans[sourceEpoch%numSpans]; sp != nil {
 		minSpan := sp[validatorIdx][0]
 		if minSpan > 0 && minSpan < distance {
-			return &DetectionResult{
-				Kind:           SurroundVote,
+			return &types.DetectionResult{
+				Kind:           types.SurroundVote,
 				SlashableEpoch: sourceEpoch + uint64(minSpan),
 			}, nil
 		}
 
 		maxSpan := sp[validatorIdx][1]
 		if maxSpan > distance {
-			return &DetectionResult{
-				Kind:           SurroundVote,
+			return &types.DetectionResult{
+				Kind:           types.SurroundVote,
 				SlashableEpoch: sourceEpoch + uint64(maxSpan),
 			}, nil
 		}

--- a/slasher/detection/attestations/spanner_test.go
+++ b/slasher/detection/attestations/spanner_test.go
@@ -7,11 +7,8 @@ import (
 	"testing"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/iface"
 	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/types"
 )
-
-var _ = iface.SpanDetector{&SpanDetector{})
 
 func TestSpanDetector_DetectSlashingForValidator(t *testing.T) {
 	type testStruct struct {

--- a/slasher/detection/attestations/spanner_test.go
+++ b/slasher/detection/attestations/spanner_test.go
@@ -7,7 +7,11 @@ import (
 	"testing"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/iface"
+	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/types"
 )
+
+var _ = iface.SpanDetector{&SpanDetector{})
 
 func TestSpanDetector_DetectSlashingForValidator(t *testing.T) {
 	type testStruct struct {
@@ -229,8 +233,8 @@ func TestSpanDetector_DetectSlashingForValidator(t *testing.T) {
 				t.Fatalf("Did not want validator to be slashed but found slashable offense: %v", res)
 			}
 			if tt.shouldSlash {
-				want := &DetectionResult{
-					Kind:           SurroundVote,
+				want := &types.DetectionResult{
+					Kind:           types.SurroundVote,
 					SlashableEpoch: tt.slashableEpoch,
 				}
 				if !reflect.DeepEqual(res, want) {
@@ -335,8 +339,8 @@ func TestSpanDetector_DetectSlashingForValidator_MultipleValidators(t *testing.T
 					t.Fatalf("Did not want validator to be slashed but found slashable offense: %v", res)
 				}
 				if tt.shouldSlash[valIdx] {
-					want := &DetectionResult{
-						Kind:           SurroundVote,
+					want := &types.DetectionResult{
+						Kind:           types.SurroundVote,
 						SlashableEpoch: tt.slashableEpochs[valIdx],
 					}
 					if !reflect.DeepEqual(res, want) {

--- a/slasher/detection/attestations/types/BUILD.bazel
+++ b/slasher/detection/attestations/types/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["types.go"],
+    importpath = "github.com/prysmaticlabs/prysm/slasher/detection/attestations/types",
+    visibility = ["//visibility:public"],
+)

--- a/slasher/detection/attestations/types/types.go
+++ b/slasher/detection/attestations/types/types.go
@@ -1,0 +1,25 @@
+package types
+
+// DetectionKind defines an enum type that
+// gives us information on the type of slashable offense
+// found when analyzing validator min-max spans.
+type DetectionKind int
+
+const (
+	// DoubleVote denotes a slashable offense in which
+	// a validator cast two conflicting attestations within
+	// the same target epoch.
+	DoubleVote DetectionKind = iota
+	// SurroundVote denotes a slashable offense in which
+	// a validator surrounded or was surrounded by a previous
+	// attestation created by the same validator.
+	SurroundVote
+)
+
+// DetectionResult tells us the kind of slashable
+// offense found from detecting on min-max spans +
+// the slashable epoch for the offense.
+type DetectionResult struct {
+	Kind           DetectionKind
+	SlashableEpoch uint64
+}


### PR DESCRIPTION
Part of #4836 

This PR adds a `SpanDetector` interface and a mock `MockSpanner` to be used for future testing.