### PR TITLE
Check HeadState First

### DIFF
--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -1,6 +1,7 @@
 package blockchain
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -27,6 +28,23 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (*sta
 	}
 	if cachedState != nil {
 		return cachedState, nil
+	}
+	headRoot, err := s.HeadRoot(ctx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not get head root")
+	}
+	if bytes.Equal(headRoot, c.Root) {
+		st, err := s.HeadState(ctx)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not get head state")
+		}
+		if err := s.checkpointState.AddCheckpointState(&cache.CheckpointState{
+			Checkpoint: c,
+			State:      st.Copy(),
+		}); err != nil {
+			return nil, errors.Wrap(err, "could not saved checkpoint state to cache")
+		}
+		return st, nil
 	}
 
 	baseState, err := s.beaconDB.State(ctx, bytesutil.ToBytes32(c.Root))


### PR DESCRIPTION
When processing an attestation or block, we retrieve the pre-state from the db. This PR makes sure that we check the head state first before retrieving from the db.