### PR TITLE
Pre-allocate slices when reporting validator performance

### DIFF
--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -584,15 +584,16 @@ func (bs *Server) GetValidatorPerformance(
 ) (*ethpb.ValidatorPerformanceResponse, error) {
 	validatorSummary := state.ValidatorSummary
 
-	beforeTransitionBalances := make([]uint64, 0)
-	afterTransitionBalances := make([]uint64, 0)
-	effectiveBalances := make([]uint64, 0)
-	inclusionSlots := make([]uint64, 0)
-	inclusionDistances := make([]uint64, 0)
-	correctlyVotedSource := make([]bool, 0)
-	correctlyVotedTarget := make([]bool, 0)
-	correctlyVotedHead := make([]bool, 0)
-	missingValidators := make([][]byte, 0)
+	reqPubKeysCount := len(req.PublicKeys)
+	beforeTransitionBalances := make([]uint64, 0, reqPubKeysCount)
+	afterTransitionBalances := make([]uint64, 0, reqPubKeysCount)
+	effectiveBalances := make([]uint64, 0, reqPubKeysCount)
+	inclusionSlots := make([]uint64, 0, reqPubKeysCount)
+	inclusionDistances := make([]uint64, 0, reqPubKeysCount)
+	correctlyVotedSource := make([]bool, 0, reqPubKeysCount)
+	correctlyVotedTarget := make([]bool, 0, reqPubKeysCount)
+	correctlyVotedHead := make([]bool, 0, reqPubKeysCount)
+	missingValidators := make([][]byte, 0, reqPubKeysCount)
 
 	// Convert the list of validator public keys to list of validator indices.
 	// Also track missing validators using public keys.


### PR DESCRIPTION
This allocates slices with a suitable initial capacity so that re-allocations do not occur when responding to the validator performance request.