### PR TITLE
Fix validator still performing after slashed bug

### DIFF
--- a/beacon-chain/rpc/validator/assignments.go
+++ b/beacon-chain/rpc/validator/assignments.go
@@ -56,8 +56,9 @@ func (vs *Server) GetDuties(ctx context.Context, req *ethpb.DutiesRequest) (*eth
 		if ok {
 			ca, ok := committeeAssignments[idx]
 			if ok {
+				vStatus := vs.assignmentStatus(idx, s)
 				assignment.Committee = ca.Committee
-				assignment.Status = ethpb.ValidatorStatus_ACTIVE
+				assignment.Status = vStatus
 				assignment.ValidatorIndex = idx
 				assignment.PublicKey = pubKey
 				assignment.AttesterSlot = ca.AttesterSlot

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -291,7 +291,7 @@ func (v *validator) RolesAt(ctx context.Context, slot uint64) (map[[48]byte][]pb
 	for _, duty := range v.duties.Duties {
 		var roles []pb.ValidatorRole
 
-		if duty == nil {
+		if duty == nil || duty.Status != ethpb.ValidatorStatus_ACTIVE {
 			continue
 		}
 		if duty.ProposerSlot > 0 && duty.ProposerSlot == slot {


### PR DESCRIPTION
This PR fixes a bug where a validator still performs it's responsibilities even after if it has been slashed.