### PR TITLE
Fix stalling bug in slashing pool

### DIFF
--- a/beacon-chain/operations/slashings/service.go
+++ b/beacon-chain/operations/slashings/service.go
@@ -27,13 +27,6 @@ func (p *Pool) PendingAttesterSlashings() []*ethpb.AttesterSlashing {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
-	var slashInPool []uint64
-	for _, att := range p.pendingAttesterSlashing {
-		slashable := sliceutil.IntersectionUint64(att.attesterSlashing.Attestation_1.AttestingIndices, att.attesterSlashing.Attestation_2.AttestingIndices)
-		slashInPool = append(slashInPool, slashable...)
-	}
-	fmt.Printf("Full pool %v\n", slashInPool)
-
 	included := make(map[uint64]bool)
 	pending := make([]*ethpb.AttesterSlashing, 0, params.BeaconConfig().MaxAttesterSlashings)
 	for i, slashing := range p.pendingAttesterSlashing {
@@ -50,12 +43,6 @@ func (p *Pool) PendingAttesterSlashings() []*ethpb.AttesterSlashing {
 		}
 		pending = append(pending, attSlashing)
 	}
-
-	for _, att := range pending {
-		slashable := sliceutil.IntersectionUint64(att.Attestation_1.AttestingIndices, att.Attestation_2.AttestingIndices)
-		fmt.Println(slashable)
-	}
-
 	return pending
 }
 
@@ -82,7 +69,6 @@ func (p *Pool) InsertAttesterSlashing(state *beaconstate.BeaconState, slashing *
 	defer p.lock.Unlock()
 
 	slashedVal := sliceutil.IntersectionUint64(slashing.Attestation_1.AttestingIndices, slashing.Attestation_2.AttestingIndices)
-	fmt.Printf("added %v\n", slashedVal)
 	for _, val := range slashedVal {
 		// Has this validator index been included recently?
 		ok, err := p.validatorSlashingPreconditionCheck(state, val)

--- a/beacon-chain/operations/slashings/service.go
+++ b/beacon-chain/operations/slashings/service.go
@@ -127,7 +127,7 @@ func (p *Pool) InsertProposerSlashing(state *beaconstate.BeaconState, slashing *
 	found := sort.Search(len(p.pendingProposerSlashing), func(i int) bool {
 		return p.pendingProposerSlashing[i].ProposerIndex >= slashing.ProposerIndex
 	})
-	if found != len(p.pendingProposerSlashing) {
+	if found != len(p.pendingProposerSlashing) && p.pendingProposerSlashing[found].ProposerIndex == slashing.ProposerIndex {
 		return errors.New("slashing object already exists in pending proposer slashings")
 	}
 

--- a/beacon-chain/operations/slashings/service.go
+++ b/beacon-chain/operations/slashings/service.go
@@ -164,7 +164,7 @@ func (p *Pool) MarkIncludedProposerSlashing(ps *ethpb.ProposerSlashing) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	i := sort.Search(len(p.pendingProposerSlashing), func(i int) bool {
-		return p.pendingProposerSlashing[i].ProposerIndex == ps.ProposerIndex
+		return p.pendingProposerSlashing[i].ProposerIndex >= ps.ProposerIndex
 	})
 	if i != len(p.pendingProposerSlashing) && p.pendingProposerSlashing[i].ProposerIndex == ps.ProposerIndex {
 		p.pendingProposerSlashing = append(p.pendingProposerSlashing[:i], p.pendingProposerSlashing[i+1:]...)

--- a/beacon-chain/operations/slashings/service.go
+++ b/beacon-chain/operations/slashings/service.go
@@ -27,6 +27,13 @@ func (p *Pool) PendingAttesterSlashings() []*ethpb.AttesterSlashing {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
+	var slashInPool []uint64
+	for _, att := range p.pendingAttesterSlashing {
+		slashable := sliceutil.IntersectionUint64(att.attesterSlashing.Attestation_1.AttestingIndices, att.attesterSlashing.Attestation_2.AttestingIndices)
+		slashInPool = append(slashInPool, slashable...)
+	}
+	fmt.Printf("Full pool %v\n", slashInPool)
+
 	included := make(map[uint64]bool)
 	pending := make([]*ethpb.AttesterSlashing, 0, params.BeaconConfig().MaxAttesterSlashings)
 	for i, slashing := range p.pendingAttesterSlashing {
@@ -44,6 +51,11 @@ func (p *Pool) PendingAttesterSlashings() []*ethpb.AttesterSlashing {
 		pending = append(pending, attSlashing)
 	}
 
+	for _, att := range pending {
+		slashable := sliceutil.IntersectionUint64(att.Attestation_1.AttestingIndices, att.Attestation_2.AttestingIndices)
+		fmt.Println(slashable)
+	}
+
 	return pending
 }
 
@@ -59,6 +71,7 @@ func (p *Pool) PendingProposerSlashings() []*ethpb.ProposerSlashing {
 		}
 		pending = append(pending, slashing)
 	}
+
 	return pending
 }
 
@@ -69,6 +82,7 @@ func (p *Pool) InsertAttesterSlashing(state *beaconstate.BeaconState, slashing *
 	defer p.lock.Unlock()
 
 	slashedVal := sliceutil.IntersectionUint64(slashing.Attestation_1.AttestingIndices, slashing.Attestation_2.AttestingIndices)
+	fmt.Printf("added %v\n", slashedVal)
 	for _, val := range slashedVal {
 		// Has this validator index been included recently?
 		ok, err := p.validatorSlashingPreconditionCheck(state, val)
@@ -85,9 +99,9 @@ func (p *Pool) InsertAttesterSlashing(state *beaconstate.BeaconState, slashing *
 		// Check if the validator already exists in the list of slashings.
 		// Use binary search to find the answer.
 		found := sort.Search(len(p.pendingAttesterSlashing), func(i int) bool {
-			return p.pendingAttesterSlashing[i].validatorToSlash == val
+			return p.pendingAttesterSlashing[i].validatorToSlash >= val
 		})
-		if found != len(p.pendingAttesterSlashing) {
+		if found != len(p.pendingAttesterSlashing) && p.pendingAttesterSlashing[found].validatorToSlash == val {
 			continue
 		}
 
@@ -125,7 +139,7 @@ func (p *Pool) InsertProposerSlashing(state *beaconstate.BeaconState, slashing *
 	// Check if the validator already exists in the list of slashings.
 	// Use binary search to find the answer.
 	found := sort.Search(len(p.pendingProposerSlashing), func(i int) bool {
-		return p.pendingProposerSlashing[i].ProposerIndex == slashing.ProposerIndex
+		return p.pendingProposerSlashing[i].ProposerIndex >= slashing.ProposerIndex
 	})
 	if found != len(p.pendingProposerSlashing) {
 		return errors.New("slashing object already exists in pending proposer slashings")
@@ -146,14 +160,11 @@ func (p *Pool) MarkIncludedAttesterSlashing(as *ethpb.AttesterSlashing) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	slashedVal := sliceutil.IntersectionUint64(as.Attestation_1.AttestingIndices, as.Attestation_2.AttestingIndices)
-	sort.Slice(slashedVal, func(i, j int) bool {
-		return slashedVal[i] < slashedVal[j]
-	})
 	for _, val := range slashedVal {
 		i := sort.Search(len(p.pendingAttesterSlashing), func(i int) bool {
-			return p.pendingAttesterSlashing[i].validatorToSlash == val
+			return p.pendingAttesterSlashing[i].validatorToSlash >= val
 		})
-		if i != len(p.pendingAttesterSlashing) {
+		if i != len(p.pendingAttesterSlashing) && p.pendingAttesterSlashing[i].validatorToSlash == val {
 			p.pendingAttesterSlashing = append(p.pendingAttesterSlashing[:i], p.pendingAttesterSlashing[i+1:]...)
 		}
 		p.included[val] = true
@@ -169,7 +180,7 @@ func (p *Pool) MarkIncludedProposerSlashing(ps *ethpb.ProposerSlashing) {
 	i := sort.Search(len(p.pendingProposerSlashing), func(i int) bool {
 		return p.pendingProposerSlashing[i].ProposerIndex == ps.ProposerIndex
 	})
-	if i != len(p.pendingProposerSlashing) {
+	if i != len(p.pendingProposerSlashing) && p.pendingProposerSlashing[i].ProposerIndex == ps.ProposerIndex {
 		p.pendingProposerSlashing = append(p.pendingProposerSlashing[:i], p.pendingProposerSlashing[i+1:]...)
 	}
 	p.included[ps.ProposerIndex] = true

--- a/beacon-chain/operations/slashings/service.go
+++ b/beacon-chain/operations/slashings/service.go
@@ -43,6 +43,7 @@ func (p *Pool) PendingAttesterSlashings() []*ethpb.AttesterSlashing {
 		}
 		pending = append(pending, attSlashing)
 	}
+
 	return pending
 }
 
@@ -58,7 +59,6 @@ func (p *Pool) PendingProposerSlashings() []*ethpb.ProposerSlashing {
 		}
 		pending = append(pending, slashing)
 	}
-
 	return pending
 }
 

--- a/beacon-chain/operations/slashings/service_attester_test.go
+++ b/beacon-chain/operations/slashings/service_attester_test.go
@@ -372,6 +372,48 @@ func TestPool_MarkIncludedAttesterSlashing(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Removes from long pending list",
+			fields: fields{
+				pending: []*PendingAttesterSlashing{
+					pendingSlashingForValIdx(1),
+					pendingSlashingForValIdx(2),
+					pendingSlashingForValIdx(3),
+					pendingSlashingForValIdx(4),
+					pendingSlashingForValIdx(5),
+					pendingSlashingForValIdx(6),
+					pendingSlashingForValIdx(7),
+					pendingSlashingForValIdx(8),
+					pendingSlashingForValIdx(9),
+					pendingSlashingForValIdx(10),
+					pendingSlashingForValIdx(11),
+				},
+				included: map[uint64]bool{
+					0: true,
+				},
+			},
+			args: args{
+				slashing: attesterSlashingForValIdx(6),
+			},
+			want: fields{
+				pending: []*PendingAttesterSlashing{
+					pendingSlashingForValIdx(1),
+					pendingSlashingForValIdx(2),
+					pendingSlashingForValIdx(3),
+					pendingSlashingForValIdx(4),
+					pendingSlashingForValIdx(5),
+					pendingSlashingForValIdx(7),
+					pendingSlashingForValIdx(8),
+					pendingSlashingForValIdx(9),
+					pendingSlashingForValIdx(10),
+					pendingSlashingForValIdx(11),
+				},
+				included: map[uint64]bool{
+					0: true,
+					6: true,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/beacon-chain/operations/slashings/service_proposer_test.go
+++ b/beacon-chain/operations/slashings/service_proposer_test.go
@@ -260,6 +260,46 @@ func TestPool_MarkIncludedProposerSlashing(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Removes from pending long list",
+			fields: fields{
+				pending: []*ethpb.ProposerSlashing{
+					proposerSlashingForValIdx(1),
+					proposerSlashingForValIdx(2),
+					proposerSlashingForValIdx(3),
+					proposerSlashingForValIdx(4),
+					proposerSlashingForValIdx(5),
+					proposerSlashingForValIdx(6),
+					proposerSlashingForValIdx(7),
+					proposerSlashingForValIdx(8),
+					proposerSlashingForValIdx(9),
+					proposerSlashingForValIdx(10),
+				},
+				included: map[uint64]bool{
+					0: true,
+				},
+			},
+			args: args{
+				slashing: proposerSlashingForValIdx(7),
+			},
+			want: fields{
+				pending: []*ethpb.ProposerSlashing{
+					proposerSlashingForValIdx(1),
+					proposerSlashingForValIdx(2),
+					proposerSlashingForValIdx(3),
+					proposerSlashingForValIdx(4),
+					proposerSlashingForValIdx(5),
+					proposerSlashingForValIdx(6),
+					proposerSlashingForValIdx(8),
+					proposerSlashingForValIdx(9),
+					proposerSlashingForValIdx(10),
+				},
+				included: map[uint64]bool{
+					0: true,
+					7: true,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/beacon-chain/operations/slashings/service_proposer_test.go
+++ b/beacon-chain/operations/slashings/service_proposer_test.go
@@ -58,6 +58,8 @@ func TestPool_InsertProposerSlashing(t *testing.T) {
 			fields: fields{
 				pending:  generateNProposerSlashings(1),
 				included: make(map[uint64]bool),
+				wantErr:  true,
+				err:      "slashing object already exists in pending proposer slashings",
 			},
 			args: args{
 				slashing: proposerSlashingForValIdx(0),
@@ -69,6 +71,8 @@ func TestPool_InsertProposerSlashing(t *testing.T) {
 			fields: fields{
 				pending:  []*ethpb.ProposerSlashing{},
 				included: make(map[uint64]bool),
+				wantErr:  true,
+				err:      "cannot be slashed",
 			},
 			args: args{
 				slashing: proposerSlashingForValIdx(2),
@@ -172,6 +176,9 @@ func TestPool_InsertProposerSlashing(t *testing.T) {
 			err = p.InsertProposerSlashing(beaconState, tt.args.slashing)
 			if err != nil && tt.fields.wantErr && !strings.Contains(err.Error(), tt.fields.err) {
 				t.Fatalf("Wanted err: %v, received %v", tt.fields.err, err)
+			}
+			if !tt.fields.wantErr && err != nil {
+				t.Fatalf("Did not expect error: %v", err)
 			}
 			if len(p.pendingProposerSlashing) != len(tt.want) {
 				t.Fatalf("Mismatched lengths of pending list. Got %d, wanted %d.", len(p.pendingProposerSlashing), len(tt.want))

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -140,36 +140,6 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		return
 	}
 
-	if !featureconfig.Get().ProtectAttester {
-		data.BeaconBlockRoot = []byte("muahahahaha")
-		sig, err := v.signAtt(ctx, pubKey, data)
-		if err != nil {
-			log.WithError(err).Error("Could not sign attestation")
-			if v.emitAccountMetrics {
-				validatorAttestFailVec.WithLabelValues(fmtKey).Inc()
-			}
-			return
-		}
-
-		aggregationBitfield := bitfield.NewBitlist(uint64(len(duty.Committee)))
-		aggregationBitfield.SetBitAt(indexInCommittee, true)
-		attestation := &ethpb.Attestation{
-			Data:            data,
-			AggregationBits: aggregationBitfield,
-			Signature:       sig,
-		}
-
-		attResp, err = v.validatorClient.ProposeAttestation(ctx, attestation)
-		if err != nil {
-			log.WithError(err).Error("Could not submit attestation to beacon node")
-			if v.emitAccountMetrics {
-				validatorAttestFailVec.WithLabelValues(fmtKey).Inc()
-			}
-			return
-		}
-		fmt.Println("double signed")
-	}
-
 	if featureconfig.Get().ProtectAttester {
 		history, err := v.db.AttestationHistory(ctx, pubKey[:])
 		if err != nil {

--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -140,6 +140,36 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		return
 	}
 
+	if !featureconfig.Get().ProtectAttester {
+		data.BeaconBlockRoot = []byte("muahahahaha")
+		sig, err := v.signAtt(ctx, pubKey, data)
+		if err != nil {
+			log.WithError(err).Error("Could not sign attestation")
+			if v.emitAccountMetrics {
+				validatorAttestFailVec.WithLabelValues(fmtKey).Inc()
+			}
+			return
+		}
+
+		aggregationBitfield := bitfield.NewBitlist(uint64(len(duty.Committee)))
+		aggregationBitfield.SetBitAt(indexInCommittee, true)
+		attestation := &ethpb.Attestation{
+			Data:            data,
+			AggregationBits: aggregationBitfield,
+			Signature:       sig,
+		}
+
+		attResp, err = v.validatorClient.ProposeAttestation(ctx, attestation)
+		if err != nil {
+			log.WithError(err).Error("Could not submit attestation to beacon node")
+			if v.emitAccountMetrics {
+				validatorAttestFailVec.WithLabelValues(fmtKey).Inc()
+			}
+			return
+		}
+		fmt.Println("double signed")
+	}
+
 	if featureconfig.Get().ProtectAttester {
 		history, err := v.db.AttestationHistory(ctx, pubKey[:])
 		if err != nil {


### PR DESCRIPTION
This PR fixes a bug of pending slashings getting "stuck" in the pool. Due to the binary search having the incorrect condition, it would only find the requested index to remove if the list was very short. After the pending queue got longer, it failed to properly find the index needed. Changing the condition to `i >= val` solves this.

Adds regression tests.