### PR TITLE
Add epoch boundary root map

### DIFF
--- a/beacon-chain/state/stategen/BUILD.bazel
+++ b/beacon-chain/state/stategen/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "epoch_boundary_root.go",
         "replay.go",
         "service.go",
     ],
@@ -23,7 +24,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["replay_test.go"],
+    srcs = [
+        "epoch_boundary_root_test.go",
+        "replay_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/core/blocks:go_default_library",

--- a/beacon-chain/state/stategen/epoch_boundary_root.go
+++ b/beacon-chain/state/stategen/epoch_boundary_root.go
@@ -22,4 +22,3 @@ func (s *State) deleteEpochBoundaryRoot(slot uint64) {
 	defer s.epochBoundaryLock.Unlock()
 	delete(s.epochBoundarySlotToRoot, slot)
 }
-

--- a/beacon-chain/state/stategen/epoch_boundary_root.go
+++ b/beacon-chain/state/stategen/epoch_boundary_root.go
@@ -1,0 +1,25 @@
+package stategen
+
+// This sets an epoch boundary slot to root mapping.
+// The slot is the key and the root is the value.
+func (s *State) setEpochBoundaryRoot(slot uint64, root [32]byte) {
+	s.epochBoundaryLock.Lock()
+	defer s.epochBoundaryLock.Unlock()
+	s.epochBoundarySlotToRoot[slot] = root
+}
+
+// This reads epoch boundary slot to root mapping.
+func (s *State) epochBoundaryRoot(slot uint64) ([32]byte, bool) {
+	s.epochBoundaryLock.RLock()
+	defer s.epochBoundaryLock.RUnlock()
+	r, ok := s.epochBoundarySlotToRoot[slot]
+	return r, ok
+}
+
+// This deletes an entry of epoch boundary slot to root mapping.
+func (s *State) deleteEpochBoundaryRoot(slot uint64) {
+	s.epochBoundaryLock.Lock()
+	defer s.epochBoundaryLock.Unlock()
+	delete(s.epochBoundarySlotToRoot, slot)
+}
+

--- a/beacon-chain/state/stategen/epoch_boundary_root_test.go
+++ b/beacon-chain/state/stategen/epoch_boundary_root_test.go
@@ -1,0 +1,32 @@
+package stategen
+
+import "testing"
+
+func TestEpochBoundaryRoot_CanSetGetDelete(t *testing.T) {
+	s := &State{
+		epochBoundarySlotToRoot: make(map[uint64][32]byte),
+	}
+	slot := uint64(100)
+	r := [32]byte{'A'}
+
+	_, exists := s.epochBoundaryRoot(slot)
+	if exists {
+		t.Fatal("should not be cached")
+	}
+
+	s.setEpochBoundaryRoot(slot, r)
+
+	rReceived, exists := s.epochBoundaryRoot(slot)
+	if !exists {
+		t.Fatal("should be cached")
+	}
+	if rReceived != r {
+		t.Error("did not cache right value")
+	}
+
+	s.deleteEpochBoundaryRoot(100)
+	_, exists = s.epochBoundaryRoot(slot)
+	if exists {
+		t.Fatal("should not be cached")
+	}
+}

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -9,7 +9,7 @@ import (
 // State represents a management object that handles the internal
 // logic of maintaining both hot and cold states in DB.
 type State struct {
-	beaconDB db.NoHeadAccessDatabase
+	beaconDB                db.NoHeadAccessDatabase
 	epochBoundarySlotToRoot map[uint64][32]byte
 	epochBoundaryLock       sync.RWMutex
 }
@@ -17,6 +17,7 @@ type State struct {
 // New returns a new state management object.
 func New(db db.NoHeadAccessDatabase) *State {
 	return &State{
-		beaconDB: db,
+		beaconDB:                db,
+		epochBoundarySlotToRoot: make(map[uint64][32]byte),
 	}
 }

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -1,6 +1,8 @@
 package stategen
 
 import (
+	"sync"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 )
 
@@ -8,6 +10,8 @@ import (
 // logic of maintaining both hot and cold states in DB.
 type State struct {
 	beaconDB db.NoHeadAccessDatabase
+	epochBoundarySlotToRoot map[uint64][32]byte
+	epochBoundaryLock       sync.RWMutex
 }
 
 // New returns a new state management object.


### PR DESCRIPTION
This is part of state gen service. To construct or reconstruct the state summary, a node will fill up or use the correct epoch boundary root of any given slot. This allows easy playback for state. This PR simply adds a cache of `slot -> boundary root`

Detail usages: #4834 