### PR TITLE
Add warning if shell expansion characters make it in to the path

### DIFF
--- a/validator/keymanager/direct_keystore.go
+++ b/validator/keymanager/direct_keystore.go
@@ -42,6 +42,10 @@ func NewKeystore(input string) (KeyManager, string, error) {
 		return nil, keystoreOptsHelp, err
 	}
 
+	if strings.Contains(opts.Path, "$") || strings.Contains(opts.Path, "~") || strings.Contains(opts.Path, "%") {
+		log.WithField("path", opts.Path).Warn("Keystore path contains unexpanded shell expansion characters")
+	}
+
 	if opts.Path == "" {
 		opts.Path = defaultValidatorDir()
 	}

--- a/validator/keymanager/direct_unencrypted.go
+++ b/validator/keymanager/direct_unencrypted.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -33,6 +34,10 @@ func NewUnencrypted(input string) (*Unencrypted, string, error) {
 	err := json.Unmarshal([]byte(input), opts)
 	if err != nil {
 		return nil, unencryptedOptsHelp, err
+	}
+
+	if strings.Contains(opts.Path, "$") || strings.Contains(opts.Path, "~") || strings.Contains(opts.Path, "%") {
+		log.WithField("path", opts.Path).Warn("Keystore path contains unexpanded shell expansion characters")
 	}
 
 	path, err := filepath.Abs(opts.Path)

--- a/validator/keymanager/wallet.go
+++ b/validator/keymanager/wallet.go
@@ -60,6 +60,9 @@ func NewWallet(input string) (KeyManager, string, error) {
 		accounts: make(map[[48]byte]e2wtypes.Account),
 	}
 
+	if strings.Contains(opts.Location, "$") || strings.Contains(opts.Location, "~") || strings.Contains(opts.Location, "%") {
+		log.WithField("path", opts.Location).Warn("Keystore path contains unexpanded shell expansion characters")
+	}
 	var store e2wtypes.Store
 	if opts.Location == "" {
 		store = filesystem.New()


### PR DESCRIPTION
User hit the situation where they wrapped a shell expansion character for the keymanager options in quotes, so the shell did not expand it.  Although we cannot prevent this, we can detect it and highlight it in the logs, as otherwise it is not an obvious mistake and can cause user confusion (especially in situations where we try to help by creating the path directory if it doesn't exist rather than erroring).

This prints a suitable warning in the log on detection of this condition.

Resolves #4998 (as much as we can).