### PR TITLE
Allow Peers to Also be Specified Using ENRs

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -198,7 +198,7 @@ func (s *Service) Start() {
 	s.started = true
 
 	if len(s.cfg.StaticPeers) > 0 {
-		addrs, err := manyMultiAddrsFromString(s.cfg.StaticPeers)
+		addrs, err := peersFromStringAddrs(s.cfg.StaticPeers)
 		if err != nil {
 			log.Errorf("Could not connect to static peer: %v", err)
 		}


### PR DESCRIPTION
Currently when providing a peer as an argument, we can only represent it as a multi-address. This PR allows peers to be represented as ENRs too 