### PR TITLE
Asynchronous Dials To Peers 

### DIFF
--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -161,6 +161,7 @@ func TestStaticPeering_PeersAreAdded(t *testing.T) {
 	s.Start()
 	s.dv5Listener = &mockListener{}
 	defer s.Stop()
+	time.Sleep(100 * time.Millisecond)
 
 	peers := s.host.Network().Peers()
 	if len(peers) != 5 {

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -311,19 +311,19 @@ func (s *Service) connectWithAllPeers(multiAddrs []ma.Multiaddr) {
 		return
 	}
 	for _, info := range addrInfos {
-		if info.ID == s.host.ID() {
-			continue
-		}
-		if _, ok := s.exclusionList.Get(info.ID.String()); ok {
-			continue
-		}
-		if s.Peers().IsBad(info.ID) {
-			continue
-		}
-		if err := s.host.Connect(s.ctx, info); err != nil {
-			log.Errorf("Could not connect with peer %s: %v", info.String(), err)
-			s.exclusionList.Set(info.ID.String(), true, 1)
-		}
+		// make each dial non-blocking
+		go func(info peer.AddrInfo) {
+			if info.ID == s.host.ID() {
+				return
+			}
+			if s.Peers().IsBad(info.ID) {
+				return
+			}
+			if err := s.host.Connect(s.ctx, info); err != nil {
+				log.Errorf("Could not connect with peer %s: %v", info.String(), err)
+				s.Peers().IncrementBadResponses(info.ID)
+			}
+		}(info)
 	}
 }
 


### PR DESCRIPTION
This PR changes how we connect to peers, spinning each dial into a separate go-routine to make them non blocking. Also removes the exclusion list we were using an instead uses our peer handler, to handle bad peers.