### PR TITLE
Warn rather than fail on incorrect keystore password

### DIFF
--- a/shared/keystore/BUILD.bazel
+++ b/shared/keystore/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@com_github_pborman_uuid//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_x_crypto//pbkdf2:go_default_library",
         "@org_golang_x_crypto//scrypt:go_default_library",
         "@org_golang_x_crypto//sha3:go_default_library",

--- a/shared/keystore/keystore_test.go
+++ b/shared/keystore/keystore_test.go
@@ -67,7 +67,7 @@ func TestStoreAndGetKeys(t *testing.T) {
 	if err := ks.StoreKey(tmpdir+filePrefix+"/test-2", key2, "password"); err != nil {
 		t.Fatalf("unable to store key %v", err)
 	}
-	newkeys, err := ks.GetKeys(tmpdir+filePrefix, "test", "password")
+	newkeys, err := ks.GetKeys(tmpdir+filePrefix, "test", "password", false)
 	if err != nil {
 		t.Fatalf("unable to get key %v", err)
 	}

--- a/tools/sendDepositTx/sendDeposits.go
+++ b/tools/sendDepositTx/sendDeposits.go
@@ -176,7 +176,7 @@ func main() {
 			store := prysmKeyStore.NewKeystore(prysmKeystorePath)
 			rawPassword := loadTextFromFile(passwordFile)
 			prefix := params.BeaconConfig().ValidatorPrivkeyFileName
-			validatorKeys, err = store.GetKeys(prysmKeystorePath, prefix, rawPassword)
+			validatorKeys, err = store.GetKeys(prysmKeystorePath, prefix, rawPassword, false /* warnOnFail */)
 			if err != nil {
 				log.WithField("path", prysmKeystorePath).WithField("password", rawPassword).Errorf("Could not get keys: %v", err)
 			}

--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -23,7 +23,7 @@ var log = logrus.WithField("prefix", "accounts")
 func DecryptKeysFromKeystore(directory string, password string) (map[string]*keystore.Key, error) {
 	validatorPrefix := params.BeaconConfig().ValidatorPrivkeyFileName
 	ks := keystore.NewKeystore(directory)
-	validatorKeys, err := ks.GetKeys(directory, validatorPrefix, password)
+	validatorKeys, err := ks.GetKeys(directory, validatorPrefix, password, true /* warnOnFail */)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get private key")
 	}
@@ -41,10 +41,10 @@ func VerifyAccountNotExists(directory string, password string) error {
 	// First, if the keystore already exists, throws an error as there can only be
 	// one keystore per validator client.
 	ks := keystore.NewKeystore(directory)
-	if _, err := ks.GetKeys(directory, shardWithdrawalKeyFile, password); err == nil {
+	if _, err := ks.GetKeys(directory, shardWithdrawalKeyFile, password, false /* warnOnFail */); err == nil {
 		return fmt.Errorf("keystore at path already exists: %s", shardWithdrawalKeyFile)
 	}
-	if _, err := ks.GetKeys(directory, validatorKeyFile, password); err == nil {
+	if _, err := ks.GetKeys(directory, validatorKeyFile, password, false /* warnOnFail */); err == nil {
 		return fmt.Errorf("keystore at path already exists: %s", validatorKeyFile)
 	}
 	return nil


### PR DESCRIPTION
This fixes an issue on validator startup where any failure to decrypt a keystore would cause the validator to exit.  It now provides a warning about the failure, and continues.

Resolves #4955 