### PR TITLE
Avoid crash due to invalid validator summary index

### DIFF
--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -606,6 +606,11 @@ func (bs *Server) GetValidatorPerformance(
 			missingValidators = append(missingValidators, key)
 			continue
 		}
+		if idx >= uint64(len(validatorSummary)) {
+			// Not listed in validator summary yet; treat it as missing.
+			missingValidators = append(missingValidators, key)
+			continue
+		}
 
 		effectiveBalances = append(effectiveBalances, validatorSummary[idx].CurrentEpochEffectiveBalance)
 		beforeTransitionBalances = append(beforeTransitionBalances, validatorSummary[idx].BeforeEpochTransitionBalance)


### PR DESCRIPTION
The validator performance RPC call fetches a validator index and assumes said index is present in the validator summary slice.  This could be a bad assumption for a new validator.

This patch ensures the validator is present in the validator summary slice before attempting to provide statistics; if not found it will make the validator as missing for completeness' sake.

Resolves #4986