### PR TITLE
Define -c opt for release builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,7 @@ run --define kafka_enabled=false
 # Release flags
 build:release --workspace_status_command=./scripts/workspace_status.sh
 build:release --stamp
+build:release --compilation_mode=opt
 
 # multi-arch cross-compiling toolchain configs:
 -----------------------------------------------


### PR DESCRIPTION
The default was fastbuild.

See https://docs.bazel.build/versions/master/user-manual.html#flag--compilation_mode

`fastbuild` means build as fast as possible: generate minimal debugging information (-gmlt -Wl,-S), and don't optimize. This is the default. Note: -DNDEBUG will not be set.

`opt` means build with optimization enabled and with assert() calls disabled (-O2 -DNDEBUG). Debugging information will not be generated in opt mode unless you also pass --copt -g.

Example improvement impact with -c opt
```
Before
BenchmarkProcessEpoch_2FullEpochs-8           25          45139085 ns/op        15178165 B/op     223523 allocs/op

After
BenchmarkProcessEpoch_2FullEpochs-8           32          38769789 ns/op        15178783 B/op     223539 allocs/op
```