### PR TITLE
Change detection and updating in Slasher to per attestation

### DIFF
--- a/slasher/detection/BUILD.bazel
+++ b/slasher/detection/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//slasher:__subpackages__"],
     deps = [
         "//shared/event:go_default_library",
-        "//shared/hashutil:go_default_library",
         "//shared/sliceutil:go_default_library",
         "//slasher/beaconclient:go_default_library",
         "//slasher/db:go_default_library",

--- a/slasher/detection/attestations/BUILD.bazel
+++ b/slasher/detection/attestations/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/slasher/detection/attestations",
     visibility = ["//slasher:__subpackages__"],
     deps = [
+        "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//slasher/db:go_default_library",
         "//slasher/detection/attestations/iface:go_default_library",
@@ -23,7 +24,6 @@ go_test(
     srcs = ["spanner_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//shared/sliceutil:go_default_library",
         "//slasher/db/testing:go_default_library",
         "//slasher/detection/attestations/types:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/slasher/detection/attestations/iface/iface.go
+++ b/slasher/detection/attestations/iface/iface.go
@@ -10,11 +10,10 @@ import (
 // SpanDetector defines an interface for Spanners to follow to allow mocks.
 type SpanDetector interface {
 	// Read functions.
-	DetectSlashingForValidator(
+	DetectSlashingsForAttestation(
 		ctx context.Context,
-		validatorIdx uint64,
-		attData *ethpb.AttestationData,
-	) (*types.DetectionResult, error)
+		att *ethpb.IndexedAttestation,
+	) ([]*types.DetectionResult, error)
 
 	// Write functions.
 	UpdateSpans(ctx context.Context, att *ethpb.IndexedAttestation) error

--- a/slasher/detection/attestations/spanner.go
+++ b/slasher/detection/attestations/spanner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	db "github.com/prysmaticlabs/prysm/slasher/db"
 	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/iface"
@@ -35,18 +36,17 @@ func NewSpanDetector(db db.Database) *SpanDetector {
 	}
 }
 
-// DetectSlashingForValidator uses a validator index and its corresponding
+// DetectSlashingsForAttestation uses a validator index and its corresponding
 // min-max spans during an epoch to detect an epoch in which the validator
 // committed a slashable attestation.
-func (s *SpanDetector) DetectSlashingForValidator(
+func (s *SpanDetector) DetectSlashingsForAttestation(
 	ctx context.Context,
-	validatorIdx uint64,
-	attData *ethpb.AttestationData,
-) (*types.DetectionResult, error) {
-	ctx, traceSpan := trace.StartSpan(ctx, "spanner.DetectSlashingForValidator")
+	att *ethpb.IndexedAttestation,
+) ([]*types.DetectionResult, error) {
+	ctx, traceSpan := trace.StartSpan(ctx, "spanner.DetectSlashingsForAttestation")
 	defer traceSpan.End()
-	sourceEpoch := attData.Source.Epoch
-	targetEpoch := attData.Target.Epoch
+	sourceEpoch := att.Data.Source.Epoch
+	targetEpoch := att.Data.Target.Epoch
 	if (targetEpoch - sourceEpoch) > params.BeaconConfig().WeakSubjectivityPeriod {
 		return nil, fmt.Errorf(
 			"attestation span was greater than weak subjectivity period %d, received: %d",
@@ -54,139 +54,168 @@ func (s *SpanDetector) DetectSlashingForValidator(
 			targetEpoch-sourceEpoch,
 		)
 	}
+
+	spanMap, err := s.slasherDB.EpochSpansMap(ctx, sourceEpoch)
+	if err != nil {
+		return nil, err
+	}
+	targetSpanMap, err := s.slasherDB.EpochSpansMap(ctx, targetEpoch)
+	if err != nil {
+		return nil, err
+	}
+
+	var detections []*types.DetectionResult
 	distance := uint16(targetEpoch - sourceEpoch)
-	sp, err := s.slasherDB.EpochSpanByValidatorIndex(ctx, validatorIdx, sourceEpoch)
-	if err != nil {
-		return nil, err
-	}
-
-	minSpan := sp.MinSpan
-	if minSpan > 0 && minSpan < distance {
-		slashableEpoch := sourceEpoch + uint64(minSpan)
-		span, err := s.slasherDB.EpochSpanByValidatorIndex(ctx, validatorIdx, slashableEpoch)
-		if err != nil {
-			return nil, err
+	for _, idx := range att.AttestingIndices {
+		span := spanMap[idx]
+		minSpan := span.MinSpan
+		if minSpan > 0 && minSpan < distance {
+			slashableEpoch := sourceEpoch + uint64(minSpan)
+			targetSpan, err := s.slasherDB.EpochSpanByValidatorIndex(ctx, idx, slashableEpoch)
+			if err != nil {
+				return nil, err
+			}
+			detections = append(detections, &types.DetectionResult{
+				Kind:           types.SurroundVote,
+				SlashableEpoch: slashableEpoch,
+				SigBytes:       targetSpan.SigBytes,
+			})
+			continue
 		}
-		return &types.DetectionResult{
-			Kind:           types.SurroundVote,
-			SlashableEpoch: slashableEpoch,
-			SigBytes:       span.SigBytes,
-		}, nil
-	}
 
-	maxSpan := sp.MaxSpan
-	if maxSpan > distance {
-		slashableEpoch := sourceEpoch + uint64(maxSpan)
-		span, err := s.slasherDB.EpochSpanByValidatorIndex(ctx, validatorIdx, slashableEpoch)
-		if err != nil {
-			return nil, err
+		maxSpan := span.MaxSpan
+		if maxSpan > distance {
+			slashableEpoch := sourceEpoch + uint64(maxSpan)
+			targetSpan, err := s.slasherDB.EpochSpanByValidatorIndex(ctx, idx, slashableEpoch)
+			if err != nil {
+				return nil, err
+			}
+			detections = append(detections, &types.DetectionResult{
+				Kind:           types.SurroundVote,
+				SlashableEpoch: slashableEpoch,
+				SigBytes:       targetSpan.SigBytes,
+			})
+			continue
 		}
-		return &types.DetectionResult{
-			Kind:           types.SurroundVote,
-			SlashableEpoch: slashableEpoch,
-			SigBytes:       span.SigBytes,
-		}, nil
+
+		targetSpan := targetSpanMap[idx]
+		// Check if the validator has attested for this epoch or not.
+		if targetSpan.HasAttested {
+			detections = append(detections, &types.DetectionResult{
+				Kind:           types.DoubleVote,
+				SlashableEpoch: targetEpoch,
+				SigBytes:       targetSpan.SigBytes,
+			})
+			continue
+		}
 	}
 
-	sp, err = s.slasherDB.EpochSpanByValidatorIndex(ctx, validatorIdx, targetEpoch)
-	if err != nil {
-		return nil, err
+
+	// Clear out any duplicate results.
+	keys := make(map[[32]byte]bool)
+	var detectionList []*types.DetectionResult
+	for _, dd := range detections {
+		hash := hashutil.Hash(dd.Marshal())
+		if _, value := keys[hash]; !value {
+			keys[hash] = true
+			detectionList = append(detectionList, dd)
+		}
 	}
 
-	// Check if the validator has attested for this epoch or not.
-	if sp.HasAttested {
-		return &types.DetectionResult{
-			Kind:           types.DoubleVote,
-			SlashableEpoch: targetEpoch,
-			SigBytes:       sp.SigBytes,
-		}, nil
-	}
-
-	return nil, nil
+	return detectionList, nil
 }
 
 // UpdateSpans given an indexed attestation for all of its attesting indices.
 func (s *SpanDetector) UpdateSpans(ctx context.Context, att *ethpb.IndexedAttestation) error {
 	ctx, span := trace.StartSpan(ctx, "spanner.UpdateSpans")
 	defer span.End()
-	source := att.Data.Source.Epoch
-	target := att.Data.Target.Epoch
-	for i := 0; i < len(att.AttestingIndices); i++ {
-		valIdx := att.AttestingIndices[i]
-		// Save the signature for the received attestation so we can have more detail to find it in the DB.
-		err := s.saveSigBytes(ctx, att, valIdx)
-		if err != nil {
-			return err
-		}
-		// Update min and max spans.
-		err = s.updateMinSpan(ctx, source, target, valIdx)
-		if err != nil {
-			return err
-		}
-		err = s.updateMaxSpan(ctx, source, target, valIdx)
-		if err != nil {
-			return err
-		}
+	// Save the signature for the received attestation so we can have more detail to find it in the DB.
+	if err := s.saveSigBytes(ctx, att); err != nil {
+		return err
+	}
+	// Update min and max spans.
+	if err := s.updateMinSpan(ctx, att); err != nil {
+		return err
+	}
+	if err := s.updateMaxSpan(ctx, att); err != nil {
+		return err
 	}
 	return nil
 }
 
 // saveSigBytes saves the first 2 bytes of the signature for the att we're updating the spans to.
 // Later used to help us find the violating attestation in the DB.
-func (s *SpanDetector) saveSigBytes(ctx context.Context, att *ethpb.IndexedAttestation, valIdx uint64) error {
+func (s *SpanDetector) saveSigBytes(ctx context.Context, att *ethpb.IndexedAttestation) error {
 	ctx, traceSpan := trace.StartSpan(ctx, "spanner.saveSigBytes")
 	defer traceSpan.End()
 	target := att.Data.Target.Epoch
-	span, err := s.slasherDB.EpochSpanByValidatorIndex(ctx, valIdx, target)
+	spanMap, err := s.slasherDB.EpochSpansMap(ctx, target)
 	if err != nil {
 		return err
 	}
 
-	// If the validator has already attested for this target epoch,
-	// then we do not need to update the values of the span sig bytes.
-	if span.HasAttested {
-		return nil
-	}
+	// We loop through the indices, instead of constantly locking/unlocking the cache for equivalent accesses.
+	for _, idx := range att.AttestingIndices {
+		span := spanMap[idx]
+		// If the validator has already attested for this target epoch,
+		// then we do not need to update the values of the span sig bytes.
+		if span.HasAttested {
+			return nil
+		}
 
-	sigBytes := [2]byte{0, 0}
-	if len(att.Signature) > 1 {
-		sigBytes = [2]byte{att.Signature[0], att.Signature[1]}
+		sigBytes := [2]byte{0, 0}
+		if len(att.Signature) > 1 {
+			sigBytes = [2]byte{att.Signature[0], att.Signature[1]}
+		}
+		// Save the signature bytes into the span for this epoch.
+		span.HasAttested = true
+		span.SigBytes = sigBytes
+		spanMap[idx] = span
 	}
-	// Save the signature bytes into the span for this epoch.
-	span.HasAttested = true
-	span.SigBytes = sigBytes
-	return s.slasherDB.SaveValidatorEpochSpan(ctx, valIdx, target, span)
+	return s.slasherDB.SaveEpochSpansMap(ctx, target, spanMap)
 }
 
 // Updates a min span for a validator index given a source and target epoch
 // for an attestation produced by the validator. Used for catching surrounding votes.
-func (s *SpanDetector) updateMinSpan(ctx context.Context, source uint64, target uint64, valIdx uint64) error {
+func (s *SpanDetector) updateMinSpan(ctx context.Context, att *ethpb.IndexedAttestation) error {
 	ctx, traceSpan := trace.StartSpan(ctx, "spanner.updateMinSpan")
 	defer traceSpan.End()
+	source := att.Data.Source.Epoch
+	target := att.Data.Target.Epoch
 	if source < 1 {
 		return nil
 	}
+	valIndices := make([]uint64, len(att.AttestingIndices))
+	copy(valIndices, att.AttestingIndices)
 	lowestEpoch := source - epochLookback
 	if int(lowestEpoch) <= 0 {
 		lowestEpoch = 0
 	}
+
 	for epoch := source - 1; epoch >= lowestEpoch; epoch-- {
-		span, err := s.slasherDB.EpochSpanByValidatorIndex(ctx, valIdx, epoch)
+		spanMap, err := s.slasherDB.EpochSpansMap(ctx, epoch)
 		if err != nil {
 			return err
 		}
-		newMinSpan := uint16(target - epoch)
-		if span.MinSpan == 0 || span.MinSpan > newMinSpan {
-			span = types.Span{
-				MinSpan:     newMinSpan,
-				MaxSpan:     span.MaxSpan,
-				SigBytes:    span.SigBytes,
-				HasAttested: span.HasAttested,
+		indices := valIndices[:0]
+		for _, idx := range valIndices {
+			span := spanMap[idx]
+			newMinSpan := uint16(target - epoch)
+			if span.MinSpan == 0 || span.MinSpan > newMinSpan {
+				span = types.Span{
+					MinSpan:     newMinSpan,
+					MaxSpan:     span.MaxSpan,
+					SigBytes:    span.SigBytes,
+					HasAttested: span.HasAttested,
+				}
+				spanMap[idx] = span
+				indices = append(indices, idx)
 			}
-			if err := s.slasherDB.SaveValidatorEpochSpan(ctx, valIdx, epoch, span); err != nil {
-				return err
-			}
-		} else {
+		}
+		if err := s.slasherDB.SaveEpochSpansMap(ctx, epoch, spanMap); err != nil {
+			return err
+		}
+		if len(indices) == 0 {
 			break
 		}
 		if epoch == 0 {
@@ -198,26 +227,37 @@ func (s *SpanDetector) updateMinSpan(ctx context.Context, source uint64, target 
 
 // Updates a max span for a validator index given a source and target epoch
 // for an attestation produced by the validator. Used for catching surrounded votes.
-func (s *SpanDetector) updateMaxSpan(ctx context.Context, source uint64, target uint64, valIdx uint64) error {
+func (s *SpanDetector) updateMaxSpan(ctx context.Context, att *ethpb.IndexedAttestation) error {
 	ctx, traceSpan := trace.StartSpan(ctx, "spanner.updateMaxSpan")
 	defer traceSpan.End()
+	source := att.Data.Source.Epoch
+	target := att.Data.Target.Epoch
+	valIndices := make([]uint64, len(att.AttestingIndices))
+	copy(valIndices, att.AttestingIndices)
 	for epoch := source + 1; epoch < target; epoch++ {
-		span, err := s.slasherDB.EpochSpanByValidatorIndex(ctx, valIdx, epoch)
+		spanMap, err := s.slasherDB.EpochSpansMap(ctx, epoch)
 		if err != nil {
 			return err
 		}
-		newMaxSpan := uint16(target - epoch)
-		if newMaxSpan > span.MaxSpan {
-			span = types.Span{
-				MinSpan:     span.MinSpan,
-				MaxSpan:     newMaxSpan,
-				SigBytes:    span.SigBytes,
-				HasAttested: span.HasAttested,
+		indices := valIndices[:0]
+		for _, idx := range valIndices {
+			span := spanMap[idx]
+			newMaxSpan := uint16(target - epoch)
+			if newMaxSpan > span.MaxSpan {
+				span = types.Span{
+					MinSpan:     span.MinSpan,
+					MaxSpan:     newMaxSpan,
+					SigBytes:    span.SigBytes,
+					HasAttested: span.HasAttested,
+				}
+				spanMap[idx] = span
+				indices = append(indices, idx)
 			}
-			if err := s.slasherDB.SaveValidatorEpochSpan(ctx, valIdx, epoch, span); err != nil {
-				return err
-			}
-		} else {
+		}
+		if err := s.slasherDB.SaveEpochSpansMap(ctx, epoch, spanMap); err != nil {
+			return err
+		}
+		if len(indices) == 0 {
 			break
 		}
 	}

--- a/slasher/detection/attestations/spanner_test.go
+++ b/slasher/detection/attestations/spanner_test.go
@@ -2,7 +2,6 @@ package attestations
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 

--- a/slasher/detection/attestations/spanner_test.go
+++ b/slasher/detection/attestations/spanner_test.go
@@ -2,16 +2,16 @@ package attestations
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/shared/sliceutil"
 	testDB "github.com/prysmaticlabs/prysm/slasher/db/testing"
 	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/types"
 )
 
-func TestSpanDetector_DetectSlashingForValidator_Double(t *testing.T) {
+func TestSpanDetector_DetectSlashingsForAttestation_Double(t *testing.T) {
 	type testStruct struct {
 		name        string
 		att         *ethpb.IndexedAttestation
@@ -146,7 +146,7 @@ func TestSpanDetector_DetectSlashingForValidator_Double(t *testing.T) {
 					BeaconBlockRoot: []byte("bad block root"),
 				},
 			},
-			slashCount: 3,
+			slashCount: 1,
 		},
 		{
 			name: "att with different target, should not detect possible double",
@@ -212,7 +212,7 @@ func TestSpanDetector_DetectSlashingForValidator_Double(t *testing.T) {
 					BeaconBlockRoot: []byte("good block root"),
 				},
 			},
-			slashCount: 2,
+			slashCount: 1,
 		},
 	}
 	for _, tt := range tests {
@@ -229,33 +229,32 @@ func TestSpanDetector_DetectSlashingForValidator_Double(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			slashTotal := uint64(0)
-			for _, valIdx := range sliceutil.IntersectionUint64(tt.att.AttestingIndices, tt.incomingAtt.AttestingIndices) {
-				res, err := sd.DetectSlashingForValidator(ctx, valIdx, tt.incomingAtt.Data)
-				if err != nil {
-					t.Fatal(err)
-				}
-				var want *types.DetectionResult
-				if tt.slashCount > 0 {
-					slashTotal++
-					want = &types.DetectionResult{
+			res, err := sd.DetectSlashingsForAttestation(ctx, tt.incomingAtt)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var want []*types.DetectionResult
+			if tt.slashCount > 0 {
+				want = []*types.DetectionResult{
+					{
 						Kind:           types.DoubleVote,
 						SlashableEpoch: tt.incomingAtt.Data.Target.Epoch,
 						SigBytes:       [2]byte{1, 2},
-					}
-				}
-				if !reflect.DeepEqual(res, want) {
-					t.Errorf("Wanted: %v, received %v", want, res)
+					},
 				}
 			}
-			if slashTotal != tt.slashCount {
-				t.Fatalf("Unexpected amount of slashings found, received %db, expected %db", slashTotal, tt.slashCount)
+			if !reflect.DeepEqual(res, want) {
+				t.Errorf("Wanted: %v, received %v", want, res)
+			}
+			if uint64(len(res)) != tt.slashCount {
+				t.Fatalf("Unexpected amount of slashings found, received %db, expected %d", len(res), tt.slashCount)
 			}
 		})
 	}
 }
 
-func TestSpanDetector_DetectSlashingForValidator_Surround(t *testing.T) {
+func TestSpanDetector_DetectSlashingsForAttestation_Surround(t *testing.T) {
 	type testStruct struct {
 		name                     string
 		sourceEpoch              uint64
@@ -468,15 +467,18 @@ func TestSpanDetector_DetectSlashingForValidator_Surround(t *testing.T) {
 				}
 			}
 
-			attData := &ethpb.AttestationData{
-				Source: &ethpb.Checkpoint{
-					Epoch: tt.sourceEpoch,
+			att := &ethpb.IndexedAttestation{
+				Data: &ethpb.AttestationData{
+					Source: &ethpb.Checkpoint{
+						Epoch: tt.sourceEpoch,
+					},
+					Target: &ethpb.Checkpoint{
+						Epoch: tt.targetEpoch,
+					},
 				},
-				Target: &ethpb.Checkpoint{
-					Epoch: tt.targetEpoch,
-				},
+				AttestingIndices: []uint64{0},
 			}
-			res, err := sd.DetectSlashingForValidator(ctx, validatorIndex, attData)
+			res, err := sd.DetectSlashingsForAttestation(ctx, att)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -484,9 +486,11 @@ func TestSpanDetector_DetectSlashingForValidator_Surround(t *testing.T) {
 				t.Fatalf("Did not want validator to be slashed but found slashable offense: %v", res)
 			}
 			if tt.shouldSlash {
-				want := &types.DetectionResult{
-					Kind:           types.SurroundVote,
-					SlashableEpoch: tt.slashableEpoch,
+				want := []*types.DetectionResult{
+					{
+						Kind:           types.SurroundVote,
+						SlashableEpoch: tt.slashableEpoch,
+					},
 				}
 				if !reflect.DeepEqual(res, want) {
 					t.Errorf("Wanted: %v, received %v", want, res)
@@ -496,7 +500,7 @@ func TestSpanDetector_DetectSlashingForValidator_Surround(t *testing.T) {
 	}
 }
 
-func TestSpanDetector_DetectSlashingForValidator_MultipleValidators(t *testing.T) {
+func TestSpanDetector_DetectSlashingsForAttestation_MultipleValidators(t *testing.T) {
 	type testStruct struct {
 		name            string
 		sourceEpochs    []uint64
@@ -581,15 +585,18 @@ func TestSpanDetector_DetectSlashingForValidator_MultipleValidators(t *testing.T
 				}
 			}
 			for valIdx := uint64(0); valIdx < uint64(len(tt.shouldSlash)); valIdx++ {
-				attData := &ethpb.AttestationData{
-					Source: &ethpb.Checkpoint{
-						Epoch: tt.sourceEpochs[valIdx],
+				att := &ethpb.IndexedAttestation{
+					Data: &ethpb.AttestationData{
+						Source: &ethpb.Checkpoint{
+							Epoch: tt.sourceEpochs[valIdx],
+						},
+						Target: &ethpb.Checkpoint{
+							Epoch: tt.targetEpochs[valIdx],
+						},
 					},
-					Target: &ethpb.Checkpoint{
-						Epoch: tt.targetEpochs[valIdx],
-					},
+					AttestingIndices: []uint64{valIdx},
 				}
-				res, err := sd.DetectSlashingForValidator(ctx, valIdx, attData)
+				res, err := sd.DetectSlashingsForAttestation(ctx, att)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -597,9 +604,11 @@ func TestSpanDetector_DetectSlashingForValidator_MultipleValidators(t *testing.T
 					t.Fatalf("Did not want validator to be slashed but found slashable offense: %v", res)
 				}
 				if tt.shouldSlash[valIdx] {
-					want := &types.DetectionResult{
-						Kind:           types.SurroundVote,
-						SlashableEpoch: tt.slashableEpochs[valIdx],
+					want := []*types.DetectionResult{
+						{
+							Kind:           types.SurroundVote,
+							SlashableEpoch: tt.slashableEpochs[valIdx],
+						},
 					}
 					if !reflect.DeepEqual(res, want) {
 						t.Errorf("Wanted: %v, received %v", want, res)

--- a/slasher/detection/attestations/types/BUILD.bazel
+++ b/slasher/detection/attestations/types/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["types.go"],
     importpath = "github.com/prysmaticlabs/prysm/slasher/detection/attestations/types",
     visibility = ["//visibility:public"],
+    deps = ["//shared/bytesutil:go_default_library"],
 )

--- a/slasher/detection/attestations/types/types.go
+++ b/slasher/detection/attestations/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/prysmaticlabs/prysm/shared/bytesutil"
+
 // DetectionKind defines an enum type that
 // gives us information on the type of slashable offense
 // found when analyzing validator min-max spans.
@@ -25,6 +27,16 @@ type DetectionResult struct {
 	SlashableEpoch uint64
 	Kind           DetectionKind
 	SigBytes       [2]byte
+}
+
+// Marshal the result into bytes, used for removing duplicates.
+func (result *DetectionResult) Marshal() []byte {
+	numBytes := bytesutil.ToBytes(result.SlashableEpoch, 8)
+	var resultBytes []byte
+	resultBytes = append(resultBytes, uint8(result.Kind))
+	resultBytes = append(resultBytes, result.SigBytes[:]...)
+	resultBytes = append(resultBytes, numBytes...)
+	return resultBytes
 }
 
 // Span defines the structure used for detecting surround and double votes.

--- a/slasher/detection/listeners_test.go
+++ b/slasher/detection/listeners_test.go
@@ -65,8 +65,11 @@ func TestService_DetectIncomingAttestations(t *testing.T) {
 	att := &ethpb.IndexedAttestation{
 		Data: &ethpb.AttestationData{
 			Slot: 1,
-			Target: &ethpb.Checkpoint{
+			Source: &ethpb.Checkpoint{
 				Epoch: 0,
+			},
+			Target: &ethpb.Checkpoint{
+				Epoch: 1,
 			},
 		},
 	}


### PR DESCRIPTION
Part of #4836 

This PR modifies how updating and detection is performed on the slasher by changing it to perform the actions on a per attestation basis, rather than a per validating indice basis.

This gives us less overhead, less DB locks, and makes detection much simpler. 