### PR TITLE
on evict test fix

### DIFF
--- a/slasher/cache/span_cache.go
+++ b/slasher/cache/span_cache.go
@@ -27,7 +27,10 @@ type EpochSpansCache struct {
 }
 
 // NewEpochSpansCache initializes the map and underlying cache.
-func NewEpochSpansCache(onEvicted func(key interface{}, value interface {})) (*EpochSpansCache, error) {
+func NewEpochSpansCache(size int, onEvicted func(key interface{}, value interface{})) (*EpochSpansCache, error) {
+	if size != 0 {
+		epochSpansCacheSize = size
+	}
 	cache, err := lru.NewWithEvict(epochSpansCacheSize, onEvicted)
 	if err != nil {
 		return nil, err

--- a/slasher/db/kv/kv.go
+++ b/slasher/db/kv/kv.go
@@ -25,6 +25,7 @@ type Store struct {
 type Config struct {
 	// SpanCacheEnabled uses span cache to detect surround slashing.
 	SpanCacheEnabled bool
+	SpanCacheSize    int
 }
 
 // Close closes the underlying boltdb database.
@@ -85,7 +86,7 @@ func NewKVStore(dirPath string, cfg *Config) (*Store, error) {
 		return nil, err
 	}
 	kv := &Store{db: boltDB, databasePath: datafile, spanCacheEnabled: cfg.SpanCacheEnabled}
-	spanCache, err := cache.NewEpochSpansCache(persistSpanMapsOnEviction(kv))
+	spanCache, err := cache.NewEpochSpansCache(cfg.SpanCacheSize, persistSpanMapsOnEviction(kv))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create new cache")
 	}

--- a/slasher/db/kv/kv_test.go
+++ b/slasher/db/kv/kv_test.go
@@ -31,7 +31,7 @@ func setupDB(t testing.TB, ctx *cli.Context) *Store {
 	return db
 }
 
-func setupDBDiffCacheSize(t testing.TB, cacheItems int64, maxCacheSize int64) *Store {
+func setupDBDiffCacheSize(t testing.TB, cacheSize int) *Store {
 	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	if err != nil {
 		t.Fatalf("Could not generate random file path: %v", err)
@@ -40,7 +40,7 @@ func setupDBDiffCacheSize(t testing.TB, cacheItems int64, maxCacheSize int64) *S
 	if err := os.RemoveAll(p); err != nil {
 		t.Fatalf("Failed to remove directory: %v", err)
 	}
-	cfg := &Config{SpanCacheEnabled: true}
+	cfg := &Config{SpanCacheEnabled: true, SpanCacheSize: cacheSize}
 	newDB, err := NewKVStore(p, cfg)
 	if err != nil {
 		t.Fatalf("Failed to instantiate DB: %v", err)

--- a/slasher/db/kv/spanner_test.go
+++ b/slasher/db/kv/spanner_test.go
@@ -207,7 +207,7 @@ func TestValidatorSpanMap_DeletesOnCacheSavesToDB(t *testing.T) {
 }
 
 func TestValidatorSpanMap_SaveOnEvict(t *testing.T) {
-	db := setupDBDiffCacheSize(t, 5, 5)
+	db := setupDBDiffCacheSize(t, 5)
 	defer teardownDB(t, db)
 	ctx := context.Background()
 

--- a/slasher/node/node.go
+++ b/slasher/node/node.go
@@ -9,11 +9,11 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/prysmaticlabs/prysm/shared/prometheus"
 	"github.com/prysmaticlabs/prysm/shared"
 	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/debug"
 	"github.com/prysmaticlabs/prysm/shared/event"
+	"github.com/prysmaticlabs/prysm/shared/prometheus"
 	"github.com/prysmaticlabs/prysm/shared/tracing"
 	"github.com/prysmaticlabs/prysm/slasher/beaconclient"
 	"github.com/prysmaticlabs/prysm/slasher/db"


### PR DESCRIPTION
Part of #4836 

This PR fixes LRU cache to take cache size as parameter and fix `TestValidatorSpanMap_SaveOnEvict`.
