### PR TITLE
retrieve included attestation from block

### DIFF
--- a/beacon-chain/rpc/beacon/attestations_test.go
+++ b/beacon-chain/rpc/beacon/attestations_test.go
@@ -541,13 +541,15 @@ func TestServer_ListAttestations_Pagination_DefaultPageSize(t *testing.T) {
 	}
 }
 
-func TestServer_ListIndexedAttestations_GenesisEpoch(t *testing.T) {
+func TestServer_ListIndexedAttestations_FromBlockEpoch(t *testing.T) {
 	db := dbTest.SetupDB(t)
 	defer dbTest.TeardownDB(t, db)
 	helpers.ClearCache()
 	ctx := context.Background()
 
-	count := params.BeaconConfig().SlotsPerEpoch
+	count := params.BeaconConfig().SlotsPerEpoch * 10 //10 epochs
+	epoch := uint64(2)
+	startSlot := params.BeaconConfig().SlotsPerEpoch * epoch
 	atts := make([]*ethpb.Attestation, 0, count)
 	for i := uint64(0); i < count; i++ {
 		attExample := &ethpb.Attestation{
@@ -556,111 +558,25 @@ func TestServer_ListIndexedAttestations_GenesisEpoch(t *testing.T) {
 				Slot:            i,
 				CommitteeIndex:  0,
 				Target: &ethpb.Checkpoint{
-					Epoch: 0,
+					Epoch: i / params.BeaconConfig().SlotsPerEpoch,
 					Root:  make([]byte, 32),
 				},
 			},
 			AggregationBits: bitfield.Bitlist{0b11},
 		}
-		atts = append(atts, attExample)
-	}
-	if err := db.SaveAttestations(ctx, atts); err != nil {
-		t.Fatal(err)
-	}
-
-	// We setup 128 validators.
-	numValidators := 128
-	headState := setupActiveValidators(t, db, numValidators)
-
-	randaoMixes := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := 0; i < len(randaoMixes); i++ {
-		randaoMixes[i] = make([]byte, 32)
-	}
-	if err := headState.SetRandaoMixes(randaoMixes); err != nil {
-		t.Fatal(err)
-	}
-
-	activeIndices, err := helpers.ActiveValidatorIndices(headState, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	epoch := uint64(0)
-	attesterSeed, err := helpers.Seed(headState, epoch, params.BeaconConfig().DomainBeaconAttester)
-	if err != nil {
-		t.Fatal(err)
-	}
-	committees, err := computeCommittees(helpers.StartSlot(epoch), activeIndices, attesterSeed)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Next up we convert the test attestations to indexed form:
-	indexedAtts := make([]*ethpb.IndexedAttestation, len(atts), len(atts))
-	for i := 0; i < len(indexedAtts); i++ {
-		att := atts[i]
-		committee := committees[att.Data.Slot].Committees[att.Data.CommitteeIndex]
-		idxAtt, err := attestationutil.ConvertToIndexed(ctx, atts[i], committee.ValidatorIndices)
-		if err != nil {
-			t.Fatalf("Could not convert attestation to indexed: %v", err)
-		}
-		indexedAtts[i] = idxAtt
-	}
-
-	bs := &Server{
-		BeaconDB: db,
-		HeadFetcher: &mock.ChainService{
-			State: headState,
-		},
-		GenesisTimeFetcher: &mock.ChainService{
-			Genesis: time.Now(),
-		},
-	}
-
-	res, err := bs.ListIndexedAttestations(ctx, &ethpb.ListIndexedAttestationsRequest{
-		QueryFilter: &ethpb.ListIndexedAttestationsRequest_GenesisEpoch{
-			GenesisEpoch: true,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !reflect.DeepEqual(indexedAtts, res.IndexedAttestations) {
-		t.Fatalf(
-			"Incorrect list indexed attestations response: wanted %v, received %v",
-			indexedAtts,
-			res.IndexedAttestations,
-		)
-	}
-}
-
-func TestServer_ListIndexedAttestations_ArchivedEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-	helpers.ClearCache()
-	ctx := context.Background()
-
-	count := params.BeaconConfig().SlotsPerEpoch
-	atts := make([]*ethpb.Attestation, 0, count)
-	startSlot := helpers.StartSlot(50)
-	epoch := uint64(50)
-	for i := startSlot; i < count; i++ {
-		attExample := &ethpb.Attestation{
-			Data: &ethpb.AttestationData{
-				BeaconBlockRoot: []byte("root"),
-				Slot:            i,
-				CommitteeIndex:  0,
-				Target: &ethpb.Checkpoint{
-					Epoch: epoch,
-					Root:  make([]byte, 32),
-				},
+		blk := &ethpb.SignedBeaconBlock{
+			Block: &ethpb.BeaconBlock{
+				Slot: i,
+				Body: &ethpb.BeaconBlockBody{Attestations: []*ethpb.Attestation{attExample}},
 			},
-			AggregationBits: bitfield.Bitlist{0b11},
 		}
-		atts = append(atts, attExample)
-	}
-	if err := db.SaveAttestations(ctx, atts); err != nil {
-		t.Fatal(err)
+		if i/(params.BeaconConfig().SlotsPerEpoch) == epoch {
+			atts = append(atts, attExample)
+		}
+		if err := db.SaveBlock(ctx, blk); err != nil {
+			t.Fatal(err)
+		}
+
 	}
 
 	// We setup 128 validators.
@@ -686,7 +602,7 @@ func TestServer_ListIndexedAttestations_ArchivedEpoch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	committees, err := computeCommittees(epoch, activeIndices, attesterSeed)
+	committees, err := computeCommittees(startSlot, activeIndices, attesterSeed)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
[Resolves] #5030

---

list attestations that were included in blocks by epoch.
@rauljordan i think we need to:
- rename the endpoint
- remove genesis filter (we just extract included attestations from blocks
- change ListIndexedAttestationsRequest_TargetEpoch to  ListIndexedAttestationsRequest_IncludedInEpoch

