### PR TITLE
Use BeaconBlockHeader in place of BeaconBlock for protecting keymanager

### DIFF
--- a/validator/keymanager/keymanager.go
+++ b/validator/keymanager/keymanager.go
@@ -27,7 +27,7 @@ type KeyManager interface {
 // ProtectingKeyManager provides access to a keymanager that protects its clients from slashing events.
 type ProtectingKeyManager interface {
 	// SignProposal signs a block proposal for the validator to broadcast.
-	SignProposal(pubKey [48]byte, domain uint64, data *ethpb.BeaconBlock) (*bls.Signature, error)
+	SignProposal(pubKey [48]byte, domain uint64, data *ethpb.BeaconBlockHeader) (*bls.Signature, error)
 
 	// SignAttestation signs an attestation for the validator to broadcast.
 	SignAttestation(pubKey [48]byte, domain uint64, data *ethpb.AttestationData) (*bls.Signature, error)


### PR DESCRIPTION
The protecting keymanager currently sends the entire block as part of its signing call.  This is unnecessary, as only the relevant roots are required.

This changes the relevant call from using `BeaconBlock` to `BeaconBlockHeader`, reducing the data passed around (especially important if the signer is remote).