### PR TITLE
Add hot state by slot retrival

### DIFF
--- a/beacon-chain/state/stategen/BUILD.bazel
+++ b/beacon-chain/state/stategen/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/cache:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/db/filters:go_default_library",

--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -13,6 +13,7 @@ import (
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"go.opencensus.io/trace"
 )
 
@@ -247,7 +248,8 @@ func (s *State) lastSavedBlock(ctx context.Context, slot uint64) ([32]byte, uint
 		return [32]byte{}, 0, err
 	}
 	if len(rs) == 0 {
-		return [32]byte{}, 0, errors.New("block root has 0 length")
+		// Return zero hash if there hasn't been any block in the DB yet.
+		return params.BeaconChainConfig{}.ZeroHash, 0, nil
 	}
 	lastRoot := rs[len(rs)-1]
 
@@ -286,7 +288,8 @@ func (s *State) lastSavedState(ctx context.Context, slot uint64) ([32]byte, erro
 		return [32]byte{}, err
 	}
 	if len(rs) == 0 {
-		return [32]byte{}, errors.New("block root has 0 length")
+		// Return zero hash if there hasn't been any block in the DB yet.
+		return params.BeaconChainConfig{}.ZeroHash, nil
 	}
 	for i := len(rs) - 1; i >= 0; i-- {
 		// Stop until a state is saved.

--- a/beacon-chain/state/stategen/replay_test.go
+++ b/beacon-chain/state/stategen/replay_test.go
@@ -415,7 +415,7 @@ func TestLastSavedBlock_CanGet(t *testing.T) {
 	}
 }
 
-func TestLastSavedBlock_OutOfRange(t *testing.T) {
+func TestLastSavedBlock_NoSavedBlock(t *testing.T) {
 	db := testDB.SetupDB(t)
 	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
@@ -429,9 +429,12 @@ func TestLastSavedBlock_OutOfRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err := s.lastSavedBlock(ctx, s.lastArchivedSlot+1)
-	if err.Error() != "block root has 0 length" {
-		t.Error("Did not get wanted error")
+	r, slot, err := s.lastSavedBlock(ctx, s.lastArchivedSlot+1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slot != 0 || r != params.BeaconConfig().ZeroHash {
+		t.Error("Did not get no saved block info")
 	}
 }
 
@@ -504,7 +507,7 @@ func TestLastSavedState_CanGet(t *testing.T) {
 	}
 }
 
-func TestLastSavedState_OutOfRange(t *testing.T) {
+func TestLastSavedState_NoSavedBlockState(t *testing.T) {
 	db := testDB.SetupDB(t)
 	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
@@ -518,9 +521,12 @@ func TestLastSavedState_OutOfRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := s.lastSavedState(ctx, s.lastArchivedSlot+1)
-	if err.Error() != "block root has 0 length" {
-		t.Error("Did not get wanted error")
+	r, err := s.lastSavedState(ctx, s.lastArchivedSlot+1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r != params.BeaconConfig().ZeroHash {
+		t.Error("Did not get no saved block info")
 	}
 }
 


### PR DESCRIPTION
As we previously added method to retrieve hot state by `root`, this PR adds in the method to retrieve hot state by `slot`.  This uses rarely than formal but proven to be useful at times. Also added tests to go with it