### PR TITLE
fixes data race in state.Slot

### DIFF
--- a/beacon-chain/state/BUILD.bazel
+++ b/beacon-chain/state/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "getters_test.go",
         "references_test.go",
         "types_test.go",
     ],

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -134,6 +134,9 @@ func (b *BeaconState) Slot() uint64 {
 	if !b.HasInnerState() {
 		return 0
 	}
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+
 	return b.state.Slot
 }
 

--- a/beacon-chain/state/getters_test.go
+++ b/beacon-chain/state/getters_test.go
@@ -1,0 +1,25 @@
+package state
+
+import (
+	"sync"
+	"testing"
+
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+)
+
+func TestBeaconState_SlotDataRace(t *testing.T) {
+	headState, _ := InitializeFromProto(&pb.BeaconState{Slot: 1})
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		headState.SetSlot(uint64(0))
+		wg.Done()
+	}()
+	go func() {
+		headState.Slot()
+		wg.Done()
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
When writing tests for initial sync, I've noticed that `BeaconState.Slot()/SetSlot()` has a data race condition (on getter we don't obtain mutex). This PR fixes that race.

I haven't enabled "race=on" in the `BUILD.bazel` because there are a lot of data races in other tests of the state package (and I can't jump to that rabbit hole just yet).