### PR TITLE
Use Target Epoch to Determine Indexed Attestations for Slasher

### DIFF
--- a/beacon-chain/rpc/beacon/attestations.go
+++ b/beacon-chain/rpc/beacon/attestations.go
@@ -280,6 +280,10 @@ func (bs *Server) StreamIndexedAttestations(
 			if len(aggAtts) == 0 {
 				continue
 			}
+			// All attestations we receive have the same target epoch given they
+			// have the same data root, so we just use the target epoch from
+			// the first one to determine committees for converting into indexed
+			// form.
 			epoch := aggAtts[0].Data.Target.Epoch
 			committeesBySlot, _, err := bs.retrieveCommitteesForEpoch(stream.Context(), epoch)
 			if err != nil {

--- a/beacon-chain/rpc/beacon/attestations.go
+++ b/beacon-chain/rpc/beacon/attestations.go
@@ -277,7 +277,10 @@ func (bs *Server) StreamIndexedAttestations(
 					err,
 				)
 			}
-			epoch := helpers.SlotToEpoch(bs.HeadFetcher.HeadSlot())
+			if len(aggAtts) == 0 {
+				continue
+			}
+			epoch := aggAtts[0].Data.Target.Epoch
 			committeesBySlot, _, err := bs.retrieveCommitteesForEpoch(stream.Context(), epoch)
 			if err != nil {
 				return status.Errorf(

--- a/beacon-chain/rpc/beacon/attestations_test.go
+++ b/beacon-chain/rpc/beacon/attestations_test.go
@@ -999,6 +999,9 @@ func TestServer_StreamIndexedAttestations_OK(t *testing.T) {
 	server := &Server{
 		BeaconDB: db,
 		Ctx:      context.Background(),
+		HeadFetcher: &mock.ChainService{
+			State: headState,
+		},
 		GenesisTimeFetcher: &mock.ChainService{
 			Genesis: time.Now(),
 		},

--- a/beacon-chain/rpc/beacon/attestations_test.go
+++ b/beacon-chain/rpc/beacon/attestations_test.go
@@ -999,9 +999,6 @@ func TestServer_StreamIndexedAttestations_OK(t *testing.T) {
 	server := &Server{
 		BeaconDB: db,
 		Ctx:      context.Background(),
-		HeadFetcher: &mock.ChainService{
-			State: headState,
-		},
 		GenesisTimeFetcher: &mock.ChainService{
 			Genesis: time.Now(),
 		},


### PR DESCRIPTION
Part of #4836 

---

# Description

**Write why you are making the changes in this pull request**

Currently, our beacon node RPC endpoint `StreamIndexedAttestations` uses the current blockchain service HeadSlot to determine committees for converting attestations into indexed form. This is really bad and leads to signature did not verify failures. Instead, we should be using the target epoch of the attestations to convert them into indexed form based on the proper committees.

**Write a summary of the changes you are making**

This PR removes usage of HeadSlot in `StreamIndexedAttestations`.
