### PR TITLE
Remove suprious error messages in wallet keymanager

### DIFF
--- a/validator/keymanager/BUILD.bazel
+++ b/validator/keymanager/BUILD.bazel
@@ -34,10 +34,14 @@ go_test(
         "direct_interop_test.go",
         "direct_test.go",
         "opts_test.go",
+        "wallet_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
+        "@com_github_wealdtech_go_eth2_wallet_encryptor_keystorev4//:go_default_library",
+        "@com_github_wealdtech_go_eth2_wallet_nd//:go_default_library",
+        "@com_github_wealdtech_go_eth2_wallet_store_filesystem//:go_default_library",
     ],
 )

--- a/validator/keymanager/wallet.go
+++ b/validator/keymanager/wallet.go
@@ -84,14 +84,21 @@ func NewWallet(input string) (KeyManager, string, error) {
 		}
 		re := regexp.MustCompile(accountSpecifier)
 		for account := range wallet.Accounts() {
+			log := log.WithField("account", fmt.Sprintf("%s/%s", wallet.Name(), account.Name()))
 			if re.Match([]byte(account.Name())) {
 				pubKey := bytesutil.ToBytes48(account.PublicKey().Marshal())
+				unlocked := false
 				for _, passphrase := range opts.Passphrases {
 					if err := account.Unlock([]byte(passphrase)); err != nil {
-						log.WithError(err).WithField("pubKey", fmt.Sprintf("%#x", pubKey)).Warn("Failed to unlock account with supplied passphrases; cannot validate")
+						log.WithError(err).Trace("Failed to unlock account with one of the supplied passphrases")
 					} else {
 						km.accounts[pubKey] = account
+						unlocked = true
+						break
 					}
+				}
+				if !unlocked {
+					log.Warn("Failed to unlock account with any supplied passphrase; cannot validate with this key")
 				}
 			}
 		}

--- a/validator/keymanager/wallet_test.go
+++ b/validator/keymanager/wallet_test.go
@@ -1,0 +1,93 @@
+package keymanager_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/validator/keymanager"
+	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
+	nd "github.com/wealdtech/go-eth2-wallet-nd"
+	filesystem "github.com/wealdtech/go-eth2-wallet-store-filesystem"
+)
+
+func SetupWallet(t *testing.T) string {
+	path, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := filesystem.New(filesystem.WithLocation(path))
+	encryptor := keystorev4.New()
+
+	// Create wallets with keys.
+	w1, err := nd.CreateWallet("Wallet 1", store, encryptor)
+	if err != nil {
+		t.Fatalf("Failed to create wallet: %v", err)
+	}
+	err = w1.Unlock(nil)
+	if err != nil {
+		t.Fatalf("Failed to unlock wallet: %v", err)
+	}
+	_, err = w1.CreateAccount("Account 1", []byte("foo"))
+	if err != nil {
+		t.Fatalf("Failed to create account 1: %v", err)
+	}
+	_, err = w1.CreateAccount("Account 2", []byte("bar"))
+	if err != nil {
+		t.Fatalf("Failed to create account 2: %v", err)
+	}
+
+	return path
+}
+
+func wallet(t *testing.T, opts string) keymanager.KeyManager {
+	km, _, err := keymanager.NewWallet(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return km
+}
+
+func TestMultiplePassphrases(t *testing.T) {
+	path := SetupWallet(t)
+	defer os.RemoveAll(path)
+	tests := []struct {
+		name     string
+		wallet   keymanager.KeyManager
+		accounts int
+	}{
+		{
+			name:     "Neither",
+			wallet:   wallet(t, fmt.Sprintf(`{"location":%q,"accounts":["Wallet 1"],"passphrases":["neither"]}`, path)),
+			accounts: 0,
+		},
+		{
+			name:     "Foo",
+			wallet:   wallet(t, fmt.Sprintf(`{"location":%q,"accounts":["Wallet 1"],"passphrases":["foo"]}`, path)),
+			accounts: 1,
+		},
+		{
+			name:     "Bar",
+			wallet:   wallet(t, fmt.Sprintf(`{"location":%q,"accounts":["Wallet 1"],"passphrases":["bar"]}`, path)),
+			accounts: 1,
+		},
+		{
+			name:     "Both",
+			wallet:   wallet(t, fmt.Sprintf(`{"location":%q,"accounts":["Wallet 1"],"passphrases":["foo","bar"]}`, path)),
+			accounts: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			keys, err := test.wallet.FetchValidatingKeys()
+			if err != nil {
+				t.Error(err)
+			}
+			if len(keys) != test.accounts {
+				t.Errorf("Found %d keys; expected %d", len(keys), test.accounts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If the wallet keymanager were given multiple passphrases it would try each for each account, resulting in spurious error messages in the log.

This patch alters the process so that an error message is only written if none of the supplied passphrases can unlock an account.