### PR TITLE
Resume new state mgmt

### DIFF
--- a/beacon-chain/state/stategen/service_test.go
+++ b/beacon-chain/state/stategen/service_test.go
@@ -1,12 +1,44 @@
 package stategen
 
 import (
+	"context"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
+	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
-func Test_verifySlotsPerArchivePoint(t *testing.T) {
+func TestResume(t *testing.T) {
+	ctx := context.Background()
+	db := testDB.SetupDB(t)
+	defer testDB.TeardownDB(t, db)
+
+	service := New(db)
+	root := [32]byte{'A'}
+	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
+	beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch - 2)
+
+	service.beaconDB.SaveState(ctx, beaconState, root)
+
+	resumeState, err := service.Resume(ctx, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !proto.Equal(beaconState.InnerStateUnsafe(), resumeState.InnerStateUnsafe()) {
+		t.Error("Diff saved state")
+	}
+	if !service.beaconDB.HasStateSummary(ctx, root) {
+		t.Error("Did not save state summary")
+	}
+	if cachedRoot, _ := service.epochBoundaryRoot(params.BeaconConfig().SlotsPerEpoch); cachedRoot != root {
+		t.Error("Did not save boundary root")
+	}
+}
+
+func TestVerifySlotsPerArchivePoint(t *testing.T) {
 	type tc struct {
 		input  uint64
 		result bool

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -74,7 +74,7 @@ func newBlocksFetcher(ctx context.Context, cfg *blocksFetcherConfig) *blocksFetc
 	rateLimiter := leakybucket.NewCollector(
 		allowedBlocksPerSecond, /* rate */
 		allowedBlocksPerSecond, /* capacity */
-		false                   /* deleteEmptyBuckets */)
+		false /* deleteEmptyBuckets */)
 
 	return &blocksFetcher{
 		ctx:            ctx,


### PR DESCRIPTION
This PR added a new method `Resume` which resumes the usage of new state management. This gets called whenever node restarts with an existing db. Also added a test to go with this