### PR TITLE
Tweak validator logging

### DIFF
--- a/validator/client/validator_aggregate.go
+++ b/validator/client/validator_aggregate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -115,7 +116,7 @@ func (v *validator) signSlot(ctx context.Context, pubKey [48]byte, slot uint64) 
 
 	sig, err := v.keyManager.Sign(pubKey, slotRoot, domain.SignatureDomain)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to sign slot")
 	}
 
 	return sig.Marshal(), nil


### PR DESCRIPTION
A couple of changes to validator logging:

- log the deadline when the validator starts work for a given slot
- demote the "nothing to do" log entry to TRACE; in any slot 5/6 of validators would report this and it floods the logs with no useful information

And because it was in my queue, a more detailed error when the "sign slot" operation fails.