### PR TITLE
asserts non-nil state

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -126,9 +126,6 @@ func (s *Service) saveHeadNoDB(ctx context.Context, b *ethpb.SignedBeaconBlock, 
 		if err != nil {
 			return errors.Wrap(err, "could not retrieve head state in DB")
 		}
-		if headState == nil {
-			return errors.New("nil head state")
-		}
 	} else {
 		headState, err = s.beaconDB.State(ctx, r)
 		if err != nil {
@@ -142,6 +139,9 @@ func (s *Service) saveHeadNoDB(ctx context.Context, b *ethpb.SignedBeaconBlock, 
 			}
 			s.initSyncStateLock.RUnlock()
 		}
+	}
+	if headState == nil {
+		return errors.New("nil head state")
 	}
 
 	s.setHead(r, stateTrie.CopySignedBeaconBlock(b), headState)


### PR DESCRIPTION
When testing initial sync I got segmentation fault:

```
WARN blockchain: Generating missing state of slot 484934 and root 0x64c8990f9bfe5c884f985bbb6d77f074483c6defa338e0441758a0606c2cdc79
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x46a5f36]

goroutine 268 [running]:
github.com/prysmaticlabs/prysm/beacon-chain/state.(*BeaconState).HasInnerState(...)
beacon-chain/state/getters.go:121
github.com/prysmaticlabs/prysm/beacon-chain/state.(*BeaconState).Copy(0x0, 0x0)
beacon-chain/state/types.go:87 +0x56
github.com/prysmaticlabs/prysm/beacon-chain/blockchain.(*Service).setHead(0xc0001b0a80, 0x91e299afbecc6486, 0x87ae3d06cc6e14be, 0xe115cbeb3e4196b9, 0xb3992e5de0ce2335, 0xc01d20c480, 0x0)
beacon-chain/blockchain/head.go:162 +0x8e
github.com/prysmaticlabs/prysm/beacon-chain/blockchain.(*Service).saveHeadNoDB(0xc0001b0a80, 0x5664340, 0xc0106966f0, 0xc0165d2d40, 0x91e299afbecc6486, 0x87ae3d06cc6e14be, 0xe115cbeb3e4196b9, 0xb3992e5de0ce2335, 0xc0106966f0, 0xc015081c00)
beacon-chain/blockchain/head.go:147 +0x122
github.com/prysmaticlabs/prysm/beacon-chain/blockchain.(*Service).ReceiveBlockNoVerify(0xc0001b0a80, 0x5664340, 0xc0106966f0, 0xc01ab080c0, 0x0, 0x0)
beacon-chain/blockchain/receive_block.go:205 +0x6f4
github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync.(*Service).processBlock(0xc013777f10, 0x5664280, 0xc002673c40, 0xc01ab080c0, 0xc01b558780, 0xc002673c80)
beacon-chain/sync/initial-sync/round_robin.go:211 +0x1fa
github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync.(*Service).roundRobinSync(0xc013777f10, 0x0, 0xed5a9b580, 0x628e800, 0x0, 0x0)
beacon-chain/sync/initial-sync/round_robin.go:67 +0x3dd
github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync.(*Service).Start(0xc013777f10)
beacon-chain/sync/initial-sync/service.go:129 +0xa63
created by github.com/prysmaticlabs/prysm/shared.(*ServiceRegistry).StartAll
shared/service_registry.go:44 +0x23e
```

It seems there's a regression introduced as a part of https://github.com/prysmaticlabs/prysm/pull/5108/files#diff-0acd0390b320b02dc23ae65e02852f8d

Previous code enforced non-nil head state, the new one does so only in one execution branch. 

Then, since non-nil head is not properly enforced, on calling the following func
```go
func (b *BeaconState) HasInnerState() bool {
	return b.state != nil
}
```
we die with segmentation since `b` itself is nil.