### PR TITLE
Improve validator logs

### DIFF
--- a/validator/client/validator_log.go
+++ b/validator/client/validator_log.go
@@ -29,7 +29,7 @@ func (v *validator) LogAttestationsSubmitted() {
 			"TargetRoot":        fmt.Sprintf("%#x", bytesutil.Trunc(attLog.data.Target.Root)),
 			"AttesterIndices":   attLog.attesterIndices,
 			"AggregatorIndices": attLog.aggregatorIndices,
-		}).Info("Submitted new attestation")
+		}).Info("Submitted new attestations")
 	}
 
 	v.attLogs = make(map[[32]byte]*attSubmitted)

--- a/validator/client/validator_log.go
+++ b/validator/client/validator_log.go
@@ -29,7 +29,7 @@ func (v *validator) LogAttestationsSubmitted() {
 			"TargetRoot":        fmt.Sprintf("%#x", bytesutil.Trunc(attLog.data.Target.Root)),
 			"AttesterIndices":   attLog.attesterIndices,
 			"AggregatorIndices": attLog.aggregatorIndices,
-		}).Info("Submitted new attestations")
+		}).Info("Submitted new attestation")
 	}
 
 	v.attLogs = make(map[[32]byte]*attSubmitted)


### PR DESCRIPTION
This PR makes very minor changes to the validator logs to improve UX.

Changes:
Removed `Waiting for validator to be activated in the beacon chain` log, spammed and provided nothing
Changed waiting deposit log to `Waiting for deposit to be seen` instead of `Waiting to be activated`.
Log out existing assignments for epoch on startup, instead of having the user waiting till next epoch to know if they have any assignments.