### PR TITLE
Add fetching validators by indices and public keys

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1296,7 +1296,7 @@ go_repository(
 
 go_repository(
     name = "com_github_prysmaticlabs_ethereumapis",
-    commit = "fca4d6f69bedb8615c2fc916d1a68f2692285caa",
+    commit = "25f267e475788bf8e5e01cb9d73cfd0c87020822",
     importpath = "github.com/prysmaticlabs/ethereumapis",
     patch_args = ["-p1"],
     patches = [

--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -200,13 +200,13 @@ func (bs *Server) ListValidators(
 
 	validatorList := make([]*ethpb.Validators_ValidatorContainer, 0)
 
-	for _, indice := range req.Indices {
-		val, err := headState.ValidatorAtIndex(indice)
+	for _, index := range req.Indices {
+		val, err := headState.ValidatorAtIndex(index)
 		if err != nil {
 			return nil, status.Error(codes.Internal, "Could not get validator")
 		}
 		validatorList = append(validatorList, &ethpb.Validators_ValidatorContainer{
-			Index:     indice,
+			Index:     index,
 			Validator: val,
 		})
 	}

--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -121,6 +121,7 @@ func (bs *Server) ListValidatorBalances(
 		}
 		balancesCount = len(res)
 	}
+	// Depending on the indices and public keys given, results might not be sorted.
 	sort.Slice(res, func(i, j int) bool {
 		return res[i].Index < res[j].Index
 	})
@@ -230,6 +231,7 @@ func (bs *Server) ListValidators(
 			Validator: val,
 		})
 	}
+	// Depending on the indices and public keys given, results might not be sorted.
 	sort.Slice(validatorList, func(i, j int) bool {
 		return validatorList[i].Index < validatorList[j].Index
 	})

--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -121,6 +121,9 @@ func (bs *Server) ListValidatorBalances(
 		}
 		balancesCount = len(res)
 	}
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].Index < res[j].Index
+	})
 
 	// If there are no balances, we simply return a response specifying this.
 	// Otherwise, attempting to paginate 0 balances below would result in an error.

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -99,7 +99,7 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 		req := &p2ppb.BeaconBlocksByRangeRequest{
 			HeadBlockRoot: root,
 			StartSlot:     s.chain.HeadSlot() + 1,
-			Count:         mathutil.Min(helpers.SlotsSince(genesis)-s.chain.HeadSlot()+1, 256),
+			Count:         mathutil.Min(helpers.SlotsSince(genesis)-s.chain.HeadSlot()+1, blockBatchSize),
 			Step:          1,
 		}
 

--- a/third_party/com_github_prysmaticlabs_ethereumapis-tags.patch
+++ b/third_party/com_github_prysmaticlabs_ethereumapis-tags.patch
@@ -262,7 +262,7 @@ index 2ce5c34..4cbb276 100644
 +    bytes signature = 3 [(gogoproto.moretags) = "ssz-size:\"96\""];
  }
 diff --git a/eth/v1alpha1/beacon_chain.proto b/eth/v1alpha1/beacon_chain.proto
-index 0099328..8b8c6eb 100644
+index 32d0b16..1679371 100644
 --- a/eth/v1alpha1/beacon_chain.proto
 +++ b/eth/v1alpha1/beacon_chain.proto
 @@ -15,6 +15,7 @@ syntax = "proto3";
@@ -327,7 +327,7 @@ index 0099328..8b8c6eb 100644
  
          // Validator's index in the validator set.
          uint64 index = 2;
-@@ -552,7 +553,7 @@ message GetValidatorRequest {
+@@ -560,7 +561,7 @@ message GetValidatorRequest {
          uint64 index = 1;
  
          // 48 byte validator public key.
@@ -336,7 +336,7 @@ index 0099328..8b8c6eb 100644
      }
  }
  
-@@ -594,26 +595,25 @@ message ActiveSetChanges {
+@@ -602,26 +603,25 @@ message ActiveSetChanges {
      uint64 epoch = 1;
  
      // 48 byte validator public keys that have been activated in the given epoch.
@@ -369,7 +369,7 @@ index 0099328..8b8c6eb 100644
  
      // Indices of validators ejected in the given epoch.
      repeated uint64 ejected_indices = 9;
-@@ -663,11 +663,11 @@ message ValidatorQueue {
+@@ -671,11 +671,11 @@ message ValidatorQueue {
  
      // Ordered list of 48 byte public keys awaiting activation. 0th index is the
      // next key to be processed.
@@ -383,7 +383,7 @@ index 0099328..8b8c6eb 100644
  }
  
  message ListValidatorAssignmentsRequest {
-@@ -679,7 +679,7 @@ message ListValidatorAssignmentsRequest {
+@@ -687,7 +687,7 @@ message ListValidatorAssignmentsRequest {
          bool genesis = 2;
      }
      // 48 byte validator public keys to filter assignments for the given epoch.
@@ -392,7 +392,7 @@ index 0099328..8b8c6eb 100644
          
      // Validator indicies to filter assignments for the given epoch.
      repeated uint64 indices = 4;
-@@ -714,7 +714,7 @@ message ValidatorAssignments {
+@@ -722,7 +722,7 @@ message ValidatorAssignments {
          uint64 proposer_slot = 4;
  
          // 48 byte BLS public key.


### PR DESCRIPTION
This PR adds the support for the `ListValidators` endpoint to retrieve validators by indice and public key.