### PR TITLE
Add Anti-Flake test for E2E

### DIFF
--- a/endtoend/BUILD.bazel
+++ b/endtoend/BUILD.bazel
@@ -6,6 +6,7 @@ go_test(
     srcs = [
         "demo_e2e_test.go",
         "endtoend_test.go",
+        "minimal_antiflake_e2e_test.go",
         "minimal_e2e_test.go",
         "minimal_slashing_e2e_test.go",
     ],
@@ -17,7 +18,7 @@ go_test(
         "@com_github_ethereum_go_ethereum//cmd/geth",
     ],
     embed = [":go_default_library"],
-    shard_count = 2,
+    shard_count = 3,
     tags = [
         "block-network",
         "e2e",

--- a/endtoend/README.md
+++ b/endtoend/README.md
@@ -17,8 +17,11 @@ Evaluators have 3 parts, the name for it's test name, a `policy` which declares 
 ## Instructions
 If you wish to run all the E2E tests, you can run them through bazel with:
 
-```bazel test //endtoend:go_default_test --test_output=streamed```
+```
+bazel test //endtoend:go_default_test --test_output=streamed --test_arg=-test.v --nocache_test_results
+```
 
-To test only for a specific config, run:
-
-```bazel test //endtoend:go_default_test --test_output=streamed --test_filter=TestEndToEnd_DemoConfig```
+To run the anti-flake E2E tests, run:
+```
+bazel test //endtoend:go_default_test --test_output=streamed --test_filter=TestEndToEnd_AntiFlake_MinimalConfig --test_arg=-test.v --nocache_test_results
+```

--- a/endtoend/beacon_node.go
+++ b/endtoend/beacon_node.go
@@ -21,6 +21,7 @@ type end2EndConfig struct {
 	numValidators  uint64
 	numBeaconNodes uint64
 	testSync       bool
+	testSlasher    bool
 	contractAddr   common.Address
 	evaluators     []ev.Evaluator
 }
@@ -31,7 +32,7 @@ var beaconNodeLogFileName = "beacon-%d.log"
 func startBeaconNodes(t *testing.T, config *end2EndConfig) []*ev.BeaconNodeInfo {
 	numNodes := config.numBeaconNodes
 
-	nodeInfo := []*ev.BeaconNodeInfo{}
+	var nodeInfo []*ev.BeaconNodeInfo
 	for i := uint64(0); i < numNodes; i++ {
 		newNode := startNewBeaconNode(t, config, nodeInfo)
 		nodeInfo = append(nodeInfo, newNode)

--- a/endtoend/evaluators/validator.go
+++ b/endtoend/evaluators/validator.go
@@ -13,7 +13,7 @@ import (
 // ValidatorsAreActive ensures the expected amount of validators are active.
 var ValidatorsAreActive = Evaluator{
 	Name:       "validators_active_epoch_%d",
-	Policy:     allEpochs(),
+	Policy:     allEpochs,
 	Evaluation: validatorsAreActive,
 }
 
@@ -46,10 +46,8 @@ func afterNthEpoch(afterEpoch uint64) func(uint64) bool {
 }
 
 // All epochs.
-func allEpochs() func(uint64) bool {
-	return func(currentEpoch uint64) bool {
-		return true
-	}
+func allEpochs(currentEpoch uint64) bool {
+	return true
 }
 
 func validatorsAreActive(conns ...*grpc.ClientConn) error {

--- a/endtoend/evaluators/validator.go
+++ b/endtoend/evaluators/validator.go
@@ -13,7 +13,7 @@ import (
 // ValidatorsAreActive ensures the expected amount of validators are active.
 var ValidatorsAreActive = Evaluator{
 	Name:       "validators_active_epoch_%d",
-	Policy:     afterNthEpoch(1),
+	Policy:     allEpochs(),
 	Evaluation: validatorsAreActive,
 }
 
@@ -42,6 +42,13 @@ var SlashedValidatorsLoseBalance = Evaluator{
 func afterNthEpoch(afterEpoch uint64) func(uint64) bool {
 	return func(currentEpoch uint64) bool {
 		return currentEpoch > afterEpoch
+	}
+}
+
+// All epochs.
+func allEpochs() func(uint64) bool {
+	return func(currentEpoch uint64) bool {
+		return true
 	}
 }
 

--- a/endtoend/helpers.go
+++ b/endtoend/helpers.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	maxPollingWaitTime  = 60 * time.Second
-	filePollingInterval = 1 * time.Second
+	filePollingInterval = 500 * time.Millisecond
 )
 
 func killProcesses(t *testing.T, pIDs []int) {
@@ -82,26 +82,28 @@ func waitForTextInFile(file *os.File, text string) error {
 	}
 }
 
-func logOutput(t *testing.T, tmpPath string, config *end2EndConfig) {
+func logOutput(t *testing.T, config *end2EndConfig) {
 	// Log out errors from beacon chain nodes.
 	for i := uint64(0); i < config.numBeaconNodes; i++ {
-		beaconLogFile, err := os.Open(path.Join(tmpPath, fmt.Sprintf(beaconNodeLogFileName, i)))
+		beaconLogFile, err := os.Open(path.Join(config.tmpPath, fmt.Sprintf(beaconNodeLogFileName, i)))
 		if err != nil {
 			t.Fatal(err)
 		}
 		logErrorOutput(t, beaconLogFile, "beacon chain node", i)
 
-		validatorLogFile, err := os.Open(path.Join(tmpPath, fmt.Sprintf(validatorLogFileName, i)))
+		validatorLogFile, err := os.Open(path.Join(config.tmpPath, fmt.Sprintf(validatorLogFileName, i)))
 		if err != nil {
 			t.Fatal(err)
 		}
 		logErrorOutput(t, validatorLogFile, "validator client", i)
 
-		slasherLogFile, err := os.Open(path.Join(tmpPath, fmt.Sprintf(slasherLogFileName, i)))
-		if err != nil {
-			t.Fatal(err)
+		if config.testSlasher {
+			slasherLogFile, err := os.Open(path.Join(config.tmpPath, fmt.Sprintf(slasherLogFileName, i)))
+			if err != nil {
+				t.Fatal(err)
+			}
+			logErrorOutput(t, slasherLogFile, "slasher client", i)
 		}
-		logErrorOutput(t, slasherLogFile, "slasher client", i)
 	}
 	t.Logf("Ending time: %s\n", time.Now().String())
 }

--- a/endtoend/minimal_antiflake_e2e_test.go
+++ b/endtoend/minimal_antiflake_e2e_test.go
@@ -26,6 +26,7 @@ func TestEndToEnd_AntiFlake_MinimalConfig(t *testing.T) {
 			ev.ValidatorsAreActive,
 		},
 	}
+	// Running this test twice to test the quickest conditions (3 epochs) twice.
 	runEndToEndTest(t, minimalConfig)
 	runEndToEndTest(t, minimalConfig)
 }

--- a/endtoend/minimal_antiflake_e2e_test.go
+++ b/endtoend/minimal_antiflake_e2e_test.go
@@ -9,24 +9,23 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
-func TestEndToEnd_MinimalConfig(t *testing.T) {
+func TestEndToEnd_AntiFlake_MinimalConfig(t *testing.T) {
 	testutil.ResetCache()
 	params.UseMinimalConfig()
 
 	minimalConfig := &end2EndConfig{
-		beaconFlags:    append(featureconfig.E2EBeaconChainFlags, "--minimal-config", "--custom-genesis-delay=15"),
+		beaconFlags:    append(featureconfig.E2EBeaconChainFlags, "--minimal-config", "--custom-genesis-delay=10"),
 		validatorFlags: append(featureconfig.E2EValidatorFlags, "--minimal-config"),
-		epochsToRun:    6,
+		epochsToRun:    2,
 		numBeaconNodes: 4,
 		numValidators:  params.BeaconConfig().MinGenesisActiveValidatorCount,
-		testSync:       true,
-		testSlasher:    true,
+		testSync:       false,
+		testSlasher:    false,
 		evaluators: []ev.Evaluator{
 			ev.PeersConnect,
 			ev.ValidatorsAreActive,
-			ev.ValidatorsParticipating,
-			ev.FinalizationOccurs,
 		},
 	}
+	runEndToEndTest(t, minimalConfig)
 	runEndToEndTest(t, minimalConfig)
 }

--- a/endtoend/minimal_slashing_e2e_test.go
+++ b/endtoend/minimal_slashing_e2e_test.go
@@ -20,6 +20,7 @@ func TestEndToEnd_Slashing_MinimalConfig(t *testing.T) {
 		numBeaconNodes: 2,
 		numValidators:  params.BeaconConfig().MinGenesisActiveValidatorCount,
 		testSync:       false,
+		testSlasher:    true,
 		evaluators: []ev.Evaluator{
 			ev.PeersConnect,
 			ev.ValidatorsSlashed,

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -330,5 +330,4 @@ var E2EBeaconChainFlags = []string{
 	"--enable-state-gen-sig-verify",
 	"--check-head-state",
 	"--enable-initial-sync-queue",
-	"--enable-dynamic-committee-subnets",
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -330,4 +330,6 @@ var E2EBeaconChainFlags = []string{
 	"--enable-state-gen-sig-verify",
 	"--check-head-state",
 	"--enable-initial-sync-queue",
+	// TODO(nishant): This flag currently fails E2E. Commenting until it's resolved.
+	//"--enable-dynamic-committee-subnets",
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -330,6 +330,6 @@ var E2EBeaconChainFlags = []string{
 	"--enable-state-gen-sig-verify",
 	"--check-head-state",
 	"--enable-initial-sync-queue",
-	// TODO(nishant): This flag currently fails E2E. Commenting until it's resolved.
+	// TODO(5123): This flag currently fails E2E. Commenting until it's resolved.
 	//"--enable-dynamic-committee-subnets",
 }


### PR DESCRIPTION
This PR adds 2 extremely simple tests to make sure flakes do not pass the E2E. Also comments out the flag for #5123 as it causes flakes.

This extends the E2E test by 5 minutes. 