### PR TITLE
Add CORS preflight support

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -61,7 +61,7 @@ var (
 	GPRCGatewayCorsDomain = &cli.StringFlag{
 		Name: "grpc-gateway-corsdomain",
 		Usage: "Comma separated list of domains from which to accept cross origin requests " +
-			"(browser enforced). This flag must be used with --grpc-gateway-port.",
+			"(browser enforced). This flag has no effect if not used with --grpc-gateway-port.",
 	}
 	// MinSyncPeers specifies the required number of successful peer handshakes in order
 	// to start syncing with external peers.

--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -57,9 +57,11 @@ var (
 		Name:  "grpc-gateway-port",
 		Usage: "Enable gRPC gateway for JSON requests",
 	}
+	// GPRCGatewayCorsDomain serves preflight requests when serving gRPC JSON gateway.
 	GPRCGatewayCorsDomain = &cli.StringFlag{
 		Name: "grpc-gateway-corsdomain",
-		Usage: "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
+		Usage: "Comma separated list of domains from which to accept cross origin requests " +
+			"(browser enforced). This flag must be used with --grpc-gateway-port.",
 	}
 	// MinSyncPeers specifies the required number of successful peer handshakes in order
 	// to start syncing with external peers.

--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -57,6 +57,10 @@ var (
 		Name:  "grpc-gateway-port",
 		Usage: "Enable gRPC gateway for JSON requests",
 	}
+	GPRCGatewayCorsDomain = &cli.StringFlag{
+		Name: "grpc-gateway-corsdomain",
+		Usage: "Comma separated list of domains from which to accept cross origin requests (browser enforced)",
+	}
 	// MinSyncPeers specifies the required number of successful peer handshakes in order
 	// to start syncing with external peers.
 	MinSyncPeers = &cli.IntFlag{

--- a/beacon-chain/gateway/BUILD.bazel
+++ b/beacon-chain/gateway/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "cors.go",
         "gateway.go",
         "handlers.go",
         "log.go",
@@ -16,6 +17,7 @@ go_library(
     deps = [
         "//shared:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_grpc_gateway_library",
+        "@com_github_rs_cors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@grpc_ecosystem_grpc_gateway//runtime:go_default_library",
         "@org_golang_google_grpc//:go_default_library",

--- a/beacon-chain/gateway/cors.go
+++ b/beacon-chain/gateway/cors.go
@@ -1,0 +1,20 @@
+package gateway
+
+import (
+	"net/http"
+
+	"github.com/rs/cors"
+)
+
+func newCorsHandler(srv http.Handler, allowedOrigins []string) http.Handler {
+	if len(allowedOrigins) == 0 {
+		return srv
+	}
+	c := cors.New(cors.Options{
+		AllowedOrigins: allowedOrigins,
+		AllowedMethods: []string{http.MethodPost, http.MethodGet},
+		MaxAge:         600,
+		AllowedHeaders: []string{"*"},
+	})
+	return c.Handler(srv)
+}

--- a/beacon-chain/gateway/server/main.go
+++ b/beacon-chain/gateway/server/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"strings"
 
 	joonix "github.com/joonix/log"
 	"github.com/prysmaticlabs/prysm/beacon-chain/gateway"
@@ -13,9 +14,10 @@ import (
 )
 
 var (
-	beaconRPC = flag.String("beacon-rpc", "localhost:4000", "Beacon chain gRPC endpoint")
-	port      = flag.Int("port", 8000, "Port to serve on")
-	debug     = flag.Bool("debug", false, "Enable debug logging")
+	beaconRPC      = flag.String("beacon-rpc", "localhost:4000", "Beacon chain gRPC endpoint")
+	port           = flag.Int("port", 8000, "Port to serve on")
+	debug          = flag.Bool("debug", false, "Enable debug logging")
+	allowedOrigins = flag.String("corsdomain", "", "A comma separated list of CORS domains to allow.")
 )
 
 func init() {
@@ -31,7 +33,7 @@ func main() {
 	}
 
 	mux := http.NewServeMux()
-	gw := gateway.New(context.Background(), *beaconRPC, fmt.Sprintf("0.0.0.0:%d", *port), mux)
+	gw := gateway.New(context.Background(), *beaconRPC, fmt.Sprintf("0.0.0.0:%d", *port), mux, strings.Split(*allowedOrigins, ","))
 	mux.HandleFunc("/swagger/", gateway.SwaggerServer())
 	mux.HandleFunc("/healthz", healthzServer(gw))
 	gw.Start()

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -588,7 +588,8 @@ func (b *BeaconNode) registerGRPCGateway(ctx *cli.Context) error {
 	if gatewayPort > 0 {
 		selfAddress := fmt.Sprintf("127.0.0.1:%d", ctx.Int(flags.RPCPort.Name))
 		gatewayAddress := fmt.Sprintf("0.0.0.0:%d", gatewayPort)
-		return b.services.RegisterService(gateway.New(context.Background(), selfAddress, gatewayAddress, nil /*optional mux*/))
+		allowedOrigins := strings.Split(ctx.String(flags.GPRCGatewayCorsDomain.Name), ",")
+		return b.services.RegisterService(gateway.New(context.Background(), selfAddress, gatewayAddress, nil /*optional mux*/, allowedOrigins))
 	}
 	return nil
 }


### PR DESCRIPTION
Resolves #5175

This PR adds a flag to use with gRPC gateway to serve CORS pre-flight requests. 

Example: `--grpc-gateway-corsdomain=domain.com,domain2.com,domain3.com`