### PR TITLE
Buildkite changes

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -26,10 +26,10 @@ build:remote-cache --remote_download_minimal
 import %workspace%/.bazelrc
 
 startup --host_jvm_args=-Xmx1000m --host_jvm_args=-Xms1000m
+common --repository_cache=/tmp/repositorycache
+common --experimental_repository_cache_hardlinks
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
-build --repository_cache=/tmp/repositorycache
-build --experimental_repository_cache_hardlinks
 build --experimental_multi_threaded_digest
 build --sandbox_tmpfs_path=/tmp
 build --verbose_failures

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -29,6 +29,7 @@ startup --host_jvm_args=-Xmx1000m --host_jvm_args=-Xms1000m
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
 build --repository_cache=/tmp/repositorycache
+build --experimental_repository_cache_hardlinks
 build --experimental_multi_threaded_digest
 build --sandbox_tmpfs_path=/tmp
 build --verbose_failures

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -26,8 +26,10 @@ build:remote-cache --remote_download_minimal
 import %workspace%/.bazelrc
 
 startup --host_jvm_args=-Xmx1000m --host_jvm_args=-Xms1000m
-common --repository_cache=/tmp/repositorycache
-common --experimental_repository_cache_hardlinks
+query --repository_cache=/tmp/repositorycache
+query --experimental_repository_cache_hardlinks
+build --repository_cache=/tmp/repositorycache
+build --experimental_repository_cache_hardlinks
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
 build --experimental_multi_threaded_digest

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -28,6 +28,7 @@ import %workspace%/.bazelrc
 startup --host_jvm_args=-Xmx1000m --host_jvm_args=-Xms1000m
 build --experimental_strict_action_env
 build --disk_cache=/tmp/bazelbuilds
+build --repository_cache=/tmp/repositorycache
 build --experimental_multi_threaded_digest
 build --sandbox_tmpfs_path=/tmp
 build --verbose_failures

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -20,10 +20,7 @@ build:remote-cache --strategy=Genrule=standalone
 build:remote-cache --disk_cache=
 build:remote-cache --host_platform_remote_properties_override='properties:{name:\"cache-silo-key\" value:\"prysm\"}' 
 build:remote-cache --remote_instance_name=projects/prysmaticlabs/instances/default_instance
-
-build:remote-cache --experimental_remote_download_outputs=minimal
-build:remote-cache --experimental_inmemory_jdeps_files
-build:remote-cache --experimental_inmemory_dotd_files
+build:remote-cache --remote_download_minimal
 
 # Import workspace options.
 import %workspace%/.bazelrc

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -36,13 +36,10 @@ build --sandbox_tmpfs_path=/tmp
 build --verbose_failures
 build --announce_rc
 build --show_progress_rate_limit=5
-build --curses=yes --color=yes
+build --curses=yes --color=no
 build --keep_going
 build --test_output=errors
 build --flaky_test_attempts=5
-build --jobs=50
-build --stamp
-test --local_test_jobs=2
 # Disabled race detection due to unstable test results under constrained environment build kite
 # build --features=race
 


### PR DESCRIPTION
Seeing some build issues that might be due to over-stressed builders.

Removing some job count overrides, bazel defaults jobs to HOST_CPU. 
50 is way too many for non-RBE builds. 

Colors were polluting the downloaded logs, it's not as pretty but makes better log files :smile: 

Also added repository caching to reduce fetching