### PR TITLE
Shard //beacon-chain/core/state:go_default_test

### DIFF
--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     ],
     data = ["//shared/benchutil/benchmark_files:benchmark_data"],
     embed = [":go_default_library"],
+    shard_count = 3,
     deps = [
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",


### PR DESCRIPTION
Some of the fuzz tests in this package run 1000 times, sharding these test will allow these to run in parallel and less likely to timeout.