### PR TITLE
Apply fixes to block slots methods in DB

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -303,9 +303,9 @@ func (k *Store) SaveGenesisBlockRoot(ctx context.Context, blockRoot [32]byte) er
 	})
 }
 
-// HighestSlotBlock returns the blocks with the highest slot from the db.
+// HighestSlotBlocks returns the blocks with the highest slot from the db.
 func (k *Store) HighestSlotBlocks(ctx context.Context) ([]*ethpb.SignedBeaconBlock, error) {
-	ctx, span := trace.StartSpan(ctx, "BeaconDB.HighestSlotBlock")
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.HighestSlotBlocks")
 	defer span.End()
 
 	blocks := make([]*ethpb.SignedBeaconBlock, 0)

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -429,11 +429,11 @@ func TestStore_SaveBlock_CanGetHighest(t *testing.T) {
 	if err := db.SaveBlock(ctx, block); err != nil {
 		t.Fatal(err)
 	}
-	highestSavedBlock, err := db.HighestSlotBlock(ctx)
+	highestSavedBlock, err := db.HighestSlotBlocks(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !proto.Equal(block, highestSavedBlock) {
+	if !proto.Equal(block, highestSavedBlock[0]) {
 		t.Errorf("Wanted %v, received %v", block, highestSavedBlock)
 	}
 
@@ -441,11 +441,11 @@ func TestStore_SaveBlock_CanGetHighest(t *testing.T) {
 	if err := db.SaveBlock(ctx, block); err != nil {
 		t.Fatal(err)
 	}
-	highestSavedBlock, err = db.HighestSlotBlock(ctx)
+	highestSavedBlock, err = db.HighestSlotBlocks(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !proto.Equal(block, highestSavedBlock) {
+	if !proto.Equal(block, highestSavedBlock[0]) {
 		t.Errorf("Wanted %v, received %v", block, highestSavedBlock)
 	}
 
@@ -453,11 +453,11 @@ func TestStore_SaveBlock_CanGetHighest(t *testing.T) {
 	if err := db.SaveBlock(ctx, block); err != nil {
 		t.Fatal(err)
 	}
-	highestSavedBlock, err = db.HighestSlotBlock(ctx)
+	highestSavedBlock, err = db.HighestSlotBlocks(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !proto.Equal(block, highestSavedBlock) {
+	if !proto.Equal(block, highestSavedBlock[0]) {
 		t.Errorf("Wanted %v, received %v", block, highestSavedBlock)
 	}
 }
@@ -480,11 +480,11 @@ func TestStore_SaveBlocks_CanGetHighest(t *testing.T) {
 	if err := db.SaveBlocks(ctx, b); err != nil {
 		t.Fatal(err)
 	}
-	highestSavedBlock, err := db.HighestSlotBlock(ctx)
+	highestSavedBlock, err := db.HighestSlotBlocks(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !proto.Equal(b[len(b)-1], highestSavedBlock) {
+	if !proto.Equal(b[len(b)-1], highestSavedBlock[0]) {
 		t.Errorf("Wanted %v, received %v", b[len(b)-1], highestSavedBlock)
 	}
 }
@@ -498,11 +498,11 @@ func TestStore_DeleteBlock_CanGetHighest(t *testing.T) {
 	if err := db.SaveBlock(ctx, b50); err != nil {
 		t.Fatal(err)
 	}
-	highestSavedBlock, err := db.HighestSlotBlock(ctx)
+	highestSavedBlock, err := db.HighestSlotBlocks(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !proto.Equal(b50, highestSavedBlock) {
+	if !proto.Equal(b50, highestSavedBlock[0]) {
 		t.Errorf("Wanted %v, received %v", b50, highestSavedBlock)
 	}
 
@@ -512,22 +512,22 @@ func TestStore_DeleteBlock_CanGetHighest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	highestSavedBlock, err = db.HighestSlotBlock(ctx)
+	highestSavedBlock, err = db.HighestSlotBlocks(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !proto.Equal(b51, highestSavedBlock) {
+	if !proto.Equal(b51, highestSavedBlock[0]) {
 		t.Errorf("Wanted %v, received %v", b51, highestSavedBlock)
 	}
 
 	if err := db.DeleteBlock(ctx, r51); err != nil {
 		t.Fatal(err)
 	}
-	highestSavedBlock, err = db.HighestSlotBlock(ctx)
+	highestSavedBlock, err = db.HighestSlotBlocks(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !proto.Equal(b50, highestSavedBlock) {
+	if !proto.Equal(b50, highestSavedBlock[0]) {
 		t.Errorf("Wanted %v, received %v", b50, highestSavedBlock)
 	}
 }
@@ -555,11 +555,11 @@ func TestStore_DeleteBlocks_CanGetHighest(t *testing.T) {
 	if err := db.DeleteBlocks(ctx, [][32]byte{r[99], r[98], r[97]}); err != nil {
 		t.Fatal(err)
 	}
-	highestSavedBlock, err := db.HighestSlotBlock(ctx)
+	highestSavedBlock, err := db.HighestSlotBlocks(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !proto.Equal(b[96], highestSavedBlock) {
+	if !proto.Equal(b[96], highestSavedBlock[0]) {
 		t.Errorf("Wanted %v, received %v", b[len(b)-1], highestSavedBlock)
 	}
 }

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prysmaticlabs/prombbolt"
+	prombolt "github.com/prysmaticlabs/prombbolt"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/iface"
 	bolt "go.etcd.io/bbolt"
 )
@@ -37,6 +37,7 @@ type Store struct {
 	blockCache          *ristretto.Cache
 	validatorIndexCache *ristretto.Cache
 	stateSlotBitLock    sync.Mutex
+	blockSlotBitLock    sync.Mutex
 }
 
 // NewKVStore initializes a new boltDB key-value store at the directory


### PR DESCRIPTION
Apply lesson learned from #5192 state slots to block slots 

Change list:
- Add locking to set bit and clear bit for block slots
- Update API to return multiple blocks 
- Address a underflow condition
- Comments on why copy is used