### PR TITLE
Verify proposer signature in sync

### DIFF
--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -25,25 +25,9 @@ func (r *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 
 	block := signed.Block
 
-	headState, err := r.chain.HeadState(ctx)
-	if err != nil {
-		log.Errorf("Head state is not available: %v", err)
-		return nil
-	}
-	// Ignore block older than last finalized checkpoint.
-	if block.Slot < helpers.StartSlot(headState.FinalizedCheckpointEpoch()) {
-		log.Debugf("Received a block older than finalized checkpoint, %d < %d",
-			block.Slot, helpers.StartSlot(headState.FinalizedCheckpointEpoch()))
-		return nil
-	}
-
 	blockRoot, err := ssz.HashTreeRoot(block)
 	if err != nil {
 		log.Errorf("Could not sign root block: %v", err)
-		return nil
-	}
-
-	if r.db.HasBlock(ctx, blockRoot) {
 		return nil
 	}
 

--- a/beacon-chain/sync/subscriber_beacon_blocks_test.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks_test.go
@@ -1,70 +1,17 @@
 package sync
 
 import (
-	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
-	lru "github.com/hashicorp/golang-lru"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-bitfield"
-	"github.com/prysmaticlabs/go-ssz"
-	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
-	dbtest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
-	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
-	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/params"
-	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/sirupsen/logrus"
-	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func init() {
 	logrus.SetLevel(logrus.DebugLevel)
-}
-
-func TestRegularSyncBeaconBlockSubscriber_FilterByFinalizedEpoch(t *testing.T) {
-	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
-
-	s, err := stateTrie.InitializeFromProto(&pb.BeaconState{
-		FinalizedCheckpoint: &ethpb.Checkpoint{Epoch: 1},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	parent := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
-	if err := db.SaveBlock(context.Background(), parent); err != nil {
-		t.Fatal(err)
-	}
-	parentRoot, _ := ssz.HashTreeRoot(parent.Block)
-	chain := &mock.ChainService{State: s}
-	c, _ := lru.New(10)
-	r := &Service{
-		db:             db,
-		chain:          chain,
-		blockNotifier:  chain.BlockNotifier(),
-		attPool:        attestations.NewPool(),
-		seenBlockCache: c,
-	}
-
-	b := &ethpb.SignedBeaconBlock{
-		Block: &ethpb.BeaconBlock{Slot: 1, ParentRoot: parentRoot[:], Body: &ethpb.BeaconBlockBody{}},
-	}
-	if err := r.beaconBlockSubscriber(context.Background(), b); err != nil {
-		t.Fatal(err)
-	}
-	testutil.AssertLogsContain(t, hook, fmt.Sprintf("Received a block older than finalized checkpoint, 1 < %d", params.BeaconConfig().SlotsPerEpoch))
-
-	hook.Reset()
-	b.Block.Slot = params.BeaconConfig().SlotsPerEpoch
-	if err := r.beaconBlockSubscriber(context.Background(), b); err != nil {
-		t.Fatal(err)
-	}
-	testutil.AssertLogsDoNotContain(t, hook, "Received a block older than finalized checkpoint")
 }
 
 func TestDeleteAttsInPool(t *testing.T) {


### PR DESCRIPTION
This PR updates beacon block's validation pipeline from verifying "a valid BLS signature" to verifying a "valid proposer signature"