### PR TITLE
Add alpine based docker images for validator and beacon chain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,6 +117,19 @@ load(
 
 container_repositories()
 
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+)
+
+container_pull(
+    name = "alpine_linux_amd64",
+    digest = "sha256:954b378c375d852eb3c63ab88978f640b4348b01c1b3456a024a81536dafbbf4",
+    registry = "index.docker.io",
+    repository = "library/alpine",
+    tag = "3.8",
+)
+
 load("@prysm//third_party/herumi:herumi.bzl", "bls_dependencies")
 
 bls_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -123,11 +123,10 @@ load(
 )
 
 container_pull(
-    name = "alpine_linux_amd64",
-    digest = "sha256:954b378c375d852eb3c63ab88978f640b4348b01c1b3456a024a81536dafbbf4",
+    name = "alpine_cc_linux_amd64",
+    digest = "sha256:d5cee45549351be7a03a96c7b319b9c1808979b10888b79acca4435cc068005e",
     registry = "index.docker.io",
-    repository = "library/alpine",
-    tag = "3.8",
+    repository = "frolvlad/alpine-glibc",
 )
 
 load("@prysm//third_party/herumi:herumi.bzl", "bls_dependencies")

--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
-load("//tools:binary_targets.bzl", "binary_targets", "go_image_debug")
+load("//tools:binary_targets.bzl", "binary_targets", "go_image_alpine", "go_image_debug")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 go_library(
@@ -37,7 +37,11 @@ go_image(
         "main.go",
         "usage.go",
     ],
-    base = "//tools:cc_image",
+    base = select({
+        "//tools:base_image_alpine": "//tools:alpine_image",
+        "//tools:base_image_cc": "//tools:cc_image",
+        "//conditions:default": "//tools:cc_image",
+    }),
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain",
@@ -87,6 +91,20 @@ container_bundle(
     tags = ["manual"],
 )
 
+go_image_alpine(
+    name = "image_alpine",
+    image = ":image",
+)
+
+container_bundle(
+    name = "image_bundle_alpine",
+    images = {
+        "gcr.io/prysmaticlabs/prysm/beacon-chain:latest-alpine": ":image_alpine",
+        "gcr.io/prysmaticlabs/prysm/beacon-chain:{DOCKER_TAG}-alpine": ":image_alpine",
+    },
+    tags = ["manual"],
+)
+
 docker_push(
     name = "push_images",
     bundle = ":image_bundle",
@@ -96,6 +114,12 @@ docker_push(
 docker_push(
     name = "push_images_debug",
     bundle = ":image_bundle_debug",
+    tags = ["manual"],
+)
+
+docker_push(
+    name = "push_images_alpine",
+    bundle = ":image_bundle_alpine",
     tags = ["manual"],
 )
 

--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -38,7 +38,7 @@ go_image(
         "usage.go",
     ],
     base = select({
-        "//tools:base_image_alpine": "//tools:alpine_image",
+        "//tools:base_image_alpine": "//tools:alpine_cc_image",
         "//tools:base_image_cc": "//tools:cc_image",
         "//conditions:default": "//tools:cc_image",
     }),

--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -80,6 +80,7 @@ container_bundle(
 go_image_debug(
     name = "image_debug",
     image = ":image",
+    tags = ["manual"],
 )
 
 container_bundle(
@@ -94,6 +95,7 @@ container_bundle(
 go_image_alpine(
     name = "image_alpine",
     image = ":image",
+    tags = ["manual"],
 )
 
 container_bundle(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -79,8 +79,8 @@ config_setting(
 )
 
 container_image(
-    name = "alpine_image",
-    base = "@alpine_linux_amd64//image",
+    name = "alpine_cc_image",
+    base = "@alpine_cc_linux_amd64//image",
     tars = [":passwd_tar"],
     user = "root",
     visibility = ["//visibility:public"],

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file"
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
 load("@io_bazel_rules_docker//cc:image.bzl", CC_DEFAULT_BASE = "DEFAULT_BASE")
 load("@io_bazel_rules_docker//go:image.bzl", GO_DEFAULT_BASE = "DEFAULT_BASE")
+load("//tools:build_settings.bzl", "base_image")
 
 alias(
     name = "kubesec",
@@ -57,6 +58,29 @@ container_image(
 container_image(
     name = "go_image",
     base = GO_DEFAULT_BASE,
+    tars = [":passwd_tar"],
+    user = "root",
+    visibility = ["//visibility:public"],
+)
+
+base_image(
+    name = "base_image",
+    build_setting_default = "cc_image",
+)
+
+config_setting(
+    name = "base_image_alpine",
+    flag_values = {"//tools:base_image": "alpine"},
+)
+
+config_setting(
+    name = "base_image_cc",
+    flag_values = {"//tools:base_image": "cc_image"},
+)
+
+container_image(
+    name = "alpine_image",
+    base = "@alpine_linux_amd64//image",
     tars = [":passwd_tar"],
     user = "root",
     visibility = ["//visibility:public"],

--- a/tools/binary_targets.bzl
+++ b/tools/binary_targets.bzl
@@ -39,6 +39,17 @@ build_in_debug_mode = transition(
     outputs = ["//command_line_option:compilation_mode"],
 )
 
+def _alpine_transition_impl(settings, attr):
+    return {
+        "//tools:base_image": "alpine",
+    }
+
+use_alpine = transition(
+    implementation = _alpine_transition_impl,
+    inputs = [],
+    outputs = ["//tools:base_image"],
+)
+
 # Defines a rule implementation that essentially returns all of the providers from the image attr.
 def _go_image_debug_impl(ctx):
     img = ctx.attr.image[0]
@@ -55,6 +66,17 @@ go_image_debug = rule(
     attrs = {
         "image": attr.label(
             cfg = build_in_debug_mode,
+            executable = True,
+        ),
+        # Whitelist is required or bazel complains.
+        "_whitelist_function_transition": attr.label(default = "@bazel_tools//tools/whitelists/function_transition_whitelist"),
+    },
+)
+go_image_alpine = rule(
+    _go_image_debug_impl,
+    attrs = {
+        "image": attr.label(
+            cfg = use_alpine,
             executable = True,
         ),
         # Whitelist is required or bazel complains.

--- a/tools/build_settings.bzl
+++ b/tools/build_settings.bzl
@@ -1,0 +1,9 @@
+BaseImageProvider = provider(fields = ["type"])
+
+def _impl(ctx):
+    return BaseImageProvider(type = ctx.build_setting_value)
+
+base_image = rule(
+    implementation = _impl,
+    build_setting = config.string(flag = True),
+)

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -38,7 +38,7 @@ go_image(
         "usage.go",
     ],
     base = select({
-        "//tools:base_image_alpine": "//tools:alpine_image",
+        "//tools:base_image_alpine": "//tools:alpine_cc_image",
         "//tools:base_image_cc": "//tools:cc_image",
         "//conditions:default": "//tools:cc_image",
     }),

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -80,6 +80,7 @@ container_bundle(
 go_image_debug(
     name = "image_debug",
     image = ":image",
+    tags = ["manual"],
 )
 
 container_bundle(
@@ -94,6 +95,7 @@ container_bundle(
 go_image_alpine(
     name = "image_alpine",
     image = ":image",
+    tags = ["manual"],
 )
 
 container_bundle(

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
-load("//tools:binary_targets.bzl", "binary_targets", "go_image_debug")
+load("//tools:binary_targets.bzl", "binary_targets", "go_image_alpine", "go_image_debug")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 go_library(
@@ -37,7 +37,11 @@ go_image(
         "main.go",
         "usage.go",
     ],
-    base = "//tools:cc_image",
+    base = select({
+        "//tools:base_image_alpine": "//tools:alpine_image",
+        "//tools:base_image_cc": "//tools:cc_image",
+        "//conditions:default": "//tools:cc_image",
+    }),
     goarch = "amd64",
     goos = "linux",
     importpath = "github.com/prysmaticlabs/prysm/validator",
@@ -87,6 +91,20 @@ container_bundle(
     tags = ["manual"],
 )
 
+go_image_alpine(
+    name = "image_alpine",
+    image = ":image",
+)
+
+container_bundle(
+    name = "image_bundle_alpine",
+    images = {
+        "gcr.io/prysmaticlabs/prysm/validator:latest-alpine": ":image_alpine",
+        "gcr.io/prysmaticlabs/prysm/validator:{DOCKER_TAG}-alpine": ":image_alpine",
+    },
+    tags = ["manual"],
+)
+
 docker_push(
     name = "push_images",
     bundle = ":image_bundle",
@@ -96,6 +114,12 @@ docker_push(
 docker_push(
     name = "push_images_debug",
     bundle = ":image_bundle_debug",
+    tags = ["manual"],
+)
+
+docker_push(
+    name = "push_images_alpine",
+    bundle = ":image_bundle_alpine",
     tags = ["manual"],
 )
 


### PR DESCRIPTION
This adds `-alpine` suffix tags for using alpine as the base image for the validator client and beacon-chain client.

Using alpine means you have a package manager and other helpful tooling that maybe useful in some deployments. The docker image size is only slightly larger, a few megabytes.

Uses an alpine image with glibc: https://hub.docker.com/r/frolvlad/alpine-glibc

Resolves #5212 