### PR TITLE
Add Fast Copy of Trie

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -229,7 +229,7 @@ func (s *Service) onBlockInitialSyncStateTransition(ctx context.Context, signed 
 	} else {
 		s.initSyncStateLock.Lock()
 		defer s.initSyncStateLock.Unlock()
-		s.initSyncState[root] = postState.Copy()
+		s.initSyncState[root] = postState.FastCopy()
 		s.filterBoundaryCandidates(ctx, root, postState)
 	}
 

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -99,7 +99,7 @@ func (s *Service) verifyBlkPreState(ctx context.Context, b *ethpb.BeaconBlock) (
 		}
 		return preState, nil // No copy needed from newly hydrated DB object.
 	}
-	return preState.Copy(), nil
+	return preState.FastCopy(), nil
 }
 
 // verifyBlkDescendant validates input block root is a descendant of the


### PR DESCRIPTION
To reduce memory usage from the copying of the field trie, we utilize a new method called `FastCopy` which removes all references to the trie in the source state. This is used when the state we are copying from is going to be garbage collected and eventually destroyed. 

- [x] Also re-order check in `saveHeadNoDB` to check our state map first.