### PR TITLE
Check new state mgmt service is compatible with DB

### DIFF
--- a/beacon-chain/db/kv/BUILD.bazel
+++ b/beacon-chain/db/kv/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "attestations.go",
         "backup.go",
         "blocks.go",
+        "check_state.go",
         "checkpoint.go",
         "deposit_contract.go",
         "encoding.go",

--- a/beacon-chain/db/kv/check_state.go
+++ b/beacon-chain/db/kv/check_state.go
@@ -1,0 +1,33 @@
+package kv
+
+import (
+	"errors"
+
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
+	bolt "go.etcd.io/bbolt"
+)
+
+var historicalStateDeletedKey = []byte("historical-states-deleted")
+
+func (kv *Store) ensureNewStateServiceCompatible() error {
+	if !featureconfig.Get().NewStateMgmt {
+		return kv.db.Update(func(tx *bolt.Tx) error {
+			bkt := tx.Bucket(newStateCompatible)
+			return bkt.Put(historicalStateDeletedKey, []byte{0x01})
+		})
+	}
+
+	var historicalStateDeleted bool
+	kv.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(newStateCompatible)
+		v := bkt.Get(historicalStateDeletedKey)
+		historicalStateDeleted = len(v) == 1 && v[0] == 0x01
+		return nil
+	})
+
+	if historicalStateDeleted {
+		return errors.New("historical states were pruned in db, do not run with flag --new-state-mgmt")
+	}
+
+	return nil
+}

--- a/beacon-chain/db/kv/check_state.go
+++ b/beacon-chain/db/kv/check_state.go
@@ -12,14 +12,14 @@ var historicalStateDeletedKey = []byte("historical-states-deleted")
 func (kv *Store) ensureNewStateServiceCompatible() error {
 	if !featureconfig.Get().NewStateMgmt {
 		return kv.db.Update(func(tx *bolt.Tx) error {
-			bkt := tx.Bucket(newStateCompatible)
+			bkt := tx.Bucket(newStateServiceCompatibleBucket)
 			return bkt.Put(historicalStateDeletedKey, []byte{0x01})
 		})
 	}
 
 	var historicalStateDeleted bool
 	kv.db.View(func(tx *bolt.Tx) error {
-		bkt := tx.Bucket(newStateCompatible)
+		bkt := tx.Bucket(newStateServiceCompatibleBucket)
 		v := bkt.Get(historicalStateDeletedKey)
 		historicalStateDeleted = len(v) == 1 && v[0] == 0x01
 		return nil

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -110,8 +110,8 @@ func NewKVStore(dirPath string) (*Store, error) {
 			blockSlotIndicesBucket,
 			blockParentRootIndicesBucket,
 			finalizedBlockRootsIndexBucket,
-			// State scheme bucket.
-			newStateCompatible,
+			// New State Management service bucket.
+			newStateServiceCompatibleBucket,
 		)
 	}); err != nil {
 		return nil, err

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -110,10 +110,14 @@ func NewKVStore(dirPath string) (*Store, error) {
 			blockSlotIndicesBucket,
 			blockParentRootIndicesBucket,
 			finalizedBlockRootsIndexBucket,
-			// Migration bucket.
-			migrationBucket,
+			// State scheme bucket.
+			newStateCompatible,
 		)
 	}); err != nil {
+		return nil, err
+	}
+
+	if err := kv.ensureNewStateServiceCompatible(); err != nil {
 		return nil, err
 	}
 

--- a/beacon-chain/db/kv/schema.go
+++ b/beacon-chain/db/kv/schema.go
@@ -46,6 +46,6 @@ var (
 	savedBlockSlotsKey        = []byte("saved-block-slots")
 	savedStateSlotsKey        = []byte("saved-state-slots")
 
-	// Migration bucket.
-	migrationBucket = []byte("migrations")
+	// New state compatible bucket.
+	newStateCompatible = []byte("new-state-compatible")
 )

--- a/beacon-chain/db/kv/schema.go
+++ b/beacon-chain/db/kv/schema.go
@@ -46,6 +46,6 @@ var (
 	savedBlockSlotsKey        = []byte("saved-block-slots")
 	savedStateSlotsKey        = []byte("saved-state-slots")
 
-	// New state compatible bucket.
-	newStateCompatible = []byte("new-state-compatible")
+	// New state management service compatibility bucket.
+	newStateServiceCompatibleBucket = []byte("new-state-compatible")
 )


### PR DESCRIPTION
This PR adds a check to ensure new state management service is compatible with beacon node DB. It implements the following conditions:
`old-state-mgmt-service -> new-state-mgmt-service`  is not ok and errors out
`new-state-mgmt-service -> old-state-mgmt-service` is ok