### PR TITLE
Fix save blocks return nil

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -238,7 +238,7 @@ func (k *Store) SaveBlocks(ctx context.Context, blocks []*ethpb.SignedBeaconBloc
 			}
 			bkt := tx.Bucket(blocksBucket)
 			if existingBlock := bkt.Get(blockRoot[:]); existingBlock != nil {
-				return nil
+				continue
 			}
 			enc, err := encode(block)
 			if err != nil {


### PR DESCRIPTION
Say to save blocks `[b0,b1,b2,b3,b4,b5,b6]`, if one of the block exists in the cache, the function will just `return nil` instead of `continue` which doesn't complete saving all the blocks 