### PR TITLE
Separate anti flakes to prevent E2E issues

### DIFF
--- a/endtoend/BUILD.bazel
+++ b/endtoend/BUILD.bazel
@@ -6,7 +6,8 @@ go_test(
     testonly = True,
     srcs = [
         "endtoend_test.go",
-        "minimal_antiflake_e2e_test.go",
+        "minimal_antiflake_e2e_1_test.go",
+        "minimal_antiflake_e2e_2_test.go",
         "minimal_e2e_test.go",
         "minimal_slashing_e2e_test.go",
     ],

--- a/endtoend/minimal_antiflake_e2e_1_test.go
+++ b/endtoend/minimal_antiflake_e2e_1_test.go
@@ -1,0 +1,33 @@
+package endtoend
+
+import (
+	"testing"
+
+	ev "github.com/prysmaticlabs/prysm/endtoend/evaluators"
+	e2eParams "github.com/prysmaticlabs/prysm/endtoend/params"
+	"github.com/prysmaticlabs/prysm/endtoend/types"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+)
+
+func TestEndToEnd_AntiFlake_MinimalConfig_1(t *testing.T) {
+	testutil.ResetCache()
+	params.UseMinimalConfig()
+
+	minimalConfig := &types.E2EConfig{
+		BeaconFlags:    []string{"--minimal-config", "--custom-genesis-delay=10"},
+		ValidatorFlags: []string{"--minimal-config"},
+		EpochsToRun:    3,
+		TestSync:       false,
+		TestSlasher:    false,
+		Evaluators: []types.Evaluator{
+			ev.PeersConnect,
+			ev.ValidatorsAreActive,
+		},
+	}
+	if err := e2eParams.Init(4); err != nil {
+		t.Fatal(err)
+	}
+
+	runEndToEndTest(t, minimalConfig)
+}

--- a/endtoend/minimal_antiflake_e2e_2_test.go
+++ b/endtoend/minimal_antiflake_e2e_2_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
-func TestEndToEnd_AntiFlake_MinimalConfig(t *testing.T) {
+func TestEndToEnd_AntiFlake_MinimalConfig_2(t *testing.T) {
 	testutil.ResetCache()
 	params.UseMinimalConfig()
 
@@ -29,7 +29,5 @@ func TestEndToEnd_AntiFlake_MinimalConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Running this test twice to test the quickest conditions (3 epochs) twice.
-	runEndToEndTest(t, minimalConfig)
 	runEndToEndTest(t, minimalConfig)
 }


### PR DESCRIPTION
This splits up the antiflake tests to prevent conflicts with the bazel containers.