### PR TITLE
Fix flaky E2E test sharding

### DIFF
--- a/endtoend/BUILD.bazel
+++ b/endtoend/BUILD.bazel
@@ -18,7 +18,7 @@ go_test(
         "//validator",
         "@com_github_ethereum_go_ethereum//cmd/geth",
     ],
-    shard_count = 3,
+    shard_count = 4,
     tags = [
         "block-network",
         "e2e",

--- a/endtoend/components/slasher.go
+++ b/endtoend/components/slasher.go
@@ -31,8 +31,9 @@ func StartSlashers(t *testing.T) []int {
 
 		args := []string{
 			fmt.Sprintf("--log-file=%s", stdOutFile.Name()),
+			fmt.Sprintf("--rpc-port=%d", e2e.TestParams.SlasherRPCPort+i),
 			fmt.Sprintf("--datadir=%s/slasher-data-%d/", e2e.TestParams.TestPath, i),
-			fmt.Sprintf("--monitoring-port=%d", 3535+i+e2e.TestParams.TestShardIndex*100),
+			fmt.Sprintf("--monitoring-port=%d", e2e.TestParams.SlasherMetricsPort+i),
 			fmt.Sprintf("--beacon-rpc-provider=localhost:%d", e2e.TestParams.BeaconNodeRPCPort+i),
 			"--force-clear-db",
 			"--span-map-cache",

--- a/endtoend/params/params.go
+++ b/endtoend/params/params.go
@@ -20,6 +20,8 @@ type Params struct {
 	BeaconNodeRPCPort     int
 	BeaconNodeMetricsPort int
 	ValidatorMetricsPort  int
+	SlasherRPCPort        int
+	SlasherMetricsPort    int
 }
 
 // TestParams is the globally accessible var for getting config elements.
@@ -59,6 +61,8 @@ func Init(beaconNodeCount int) error {
 		BeaconNodeRPCPort:     4000 + testIndex*100,
 		BeaconNodeMetricsPort: 5000 + testIndex*100,
 		ValidatorMetricsPort:  6000 + testIndex*100,
+		SlasherRPCPort:        7000 + testIndex*100,
+		SlasherMetricsPort:    8000 + testIndex*100,
 	}
 	return nil
 }

--- a/slasher/flags/flags.go
+++ b/slasher/flags/flags.go
@@ -13,7 +13,7 @@ var (
 	// RPCPort defines a slasher node RPC port to open.
 	RPCPort = &cli.IntFlag{
 		Name:  "rpc-port",
-		Usage: "RPC port exposed by a beacon node",
+		Usage: "RPC port exposed by the slasher",
 		Value: 5000,
 	}
 	// KeyFlag defines a flag for the node's TLS key.


### PR DESCRIPTION
This PR fixes some possible issues that could be caused by sharding the E2E tests which we do for every PR now. Should prevent more flakes from occurring.