### PR TITLE
Add configurations for BLS builds

### DIFF
--- a/third_party/herumi/bls_eth_go_binary.BUILD
+++ b/third_party/herumi/bls_eth_go_binary.BUILD
@@ -1,8 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+config_setting(
+    name = "use_gmp",
+    values = {"define": "BLS_USE_GMP=true"},
+)
+
+config_setting(
+    name = "use_openssl",
+    values = {"define": "BLS_USE_OPENSSL=true"},
+)
+
 OPTS = [
-    "-DMCL_USE_VINT",
-    "-DMCL_DONT_USE_OPENSSL",
     "-DMCL_LLVM_BMI2=0",
     "-DMCL_USE_LLVM=1",
     "-DMCL_VINT_FIXED_BUFFER",
@@ -12,7 +20,19 @@ OPTS = [
     "-DCYBOZU_DONT_USE_STRING",
     "-DBLS_SWAP_G",
     "-DBLS_ETH",
-]
+] + select({
+    ":use_gmp": [],
+    "//conditions:default": [
+        "-DMCL_USE_VINT",
+    ],
+}) + select({
+    ":use_openssl": [],
+    "//conditions:default": [
+      "-DMCL_DONT_USE_OPENSSL",
+    ],
+})
+
+
 
 genrule(
     name = "base64_ll",
@@ -55,6 +75,16 @@ cc_library(
     copts = OPTS + [
         "-std=c++03",
     ],
+    linkopts = select({
+        ":use_gmp": ["-lgmp"],
+        "//conditions:default": [],
+    }) + select({
+        ":use_openssl": [
+            "-lssl",
+            "-lcrypto"
+        ],
+        "//conditions:default": [],
+    })
 )
 
 cc_library(

--- a/third_party/herumi/mcl.BUILD
+++ b/third_party/herumi/mcl.BUILD
@@ -1,18 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-MCL_OPTS = [
-    "-DMCL_USE_VINT",
-    "-DMCL_DONT_USE_OPENSSL",
-    "-DMCL_LLVM_BMI2=0",
-    "-DMCL_USE_LLVM=1",
-    "-DMCL_VINT_FIXED_BUFFER",
-    "-DMCL_SIZEOF_UNIT=8",
-    "-DMCL_MAX_BIT_SIZE=384",
-    "-DCYBOZU_DONT_USE_EXCEPTION",
-    "-DCYBOZU_DONT_USE_STRING",
-    "-std=c++03 ",
-]
-
 cc_library(
     name = "fp",
     srcs = [
@@ -40,7 +27,6 @@ cc_library(
         "src/proto.hpp",
         "src/low_func_llvm.hpp",
     ],
-    copts = MCL_OPTS,
 )
 
 cc_library(
@@ -63,7 +49,6 @@ cc_library(
         "include/mcl/operator.hpp",
     ],
     includes = ["include"],
-    copts = MCL_OPTS,
 )
 
 # src_gen is a tool to generate some llvm assembly language file.


### PR DESCRIPTION
These changes allow for flag based configuration of BLS build configuration. 

I was not able to find a noticeable improvement with gmp or ssl over the default configuration. 