### PR TITLE
Fix E2E eth1 flaking 

### DIFF
--- a/endtoend/endtoend_test.go
+++ b/endtoend/endtoend_test.go
@@ -27,7 +27,7 @@ func runEndToEndTest(t *testing.T, config *types.E2EConfig) {
 	keystorePath, eth1PID := components.StartEth1Node(t)
 	multiAddrs, bProcessIDs := components.StartBeaconNodes(t, config)
 	valProcessIDs := components.StartValidators(t, config, keystorePath)
-	processIDs := append(bProcessIDs, valProcessIDs...)
+	processIDs := append(valProcessIDs, bProcessIDs...)
 	processIDs = append(processIDs, eth1PID)
 	defer helpers.LogOutput(t, config)
 	defer helpers.KillProcesses(t, processIDs)
@@ -95,7 +95,7 @@ func runEndToEndTest(t *testing.T, config *types.E2EConfig) {
 		return
 	}
 
-	multiAddr, pID := components.StartNewBeaconNode(t, config, multiAddrs)
+	multiAddr, processID := components.StartNewBeaconNode(t, config, multiAddrs)
 	multiAddrs = append(multiAddrs, multiAddr)
 	index := e2e.TestParams.BeaconNodeCount
 	syncConn, err := grpc.Dial(fmt.Sprintf("127.0.0.1:%d", e2e.TestParams.BeaconNodeRPCPort+index), grpc.WithInsecure())
@@ -115,7 +115,7 @@ func runEndToEndTest(t *testing.T, config *types.E2EConfig) {
 		t.Fatal(err)
 	}
 	defer helpers.LogErrorOutput(t, syncLogFile, "beacon chain node", index)
-	defer helpers.KillProcesses(t, []int{pID})
+	defer helpers.KillProcesses(t, []int{processID})
 	if err := helpers.WaitForTextInFile(syncLogFile, "Synced up to"); err != nil {
 		t.Fatalf("Failed to sync: %v", err)
 	}

--- a/endtoend/minimal_antiflake_e2e_1_test.go
+++ b/endtoend/minimal_antiflake_e2e_1_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestEndToEnd_AntiFlake_MinimalConfig_1(t *testing.T) {
-	t.Skip("skipping to prevent E2E flakes")
 	testutil.ResetCache()
 	params.UseMinimalConfig()
 

--- a/endtoend/minimal_antiflake_e2e_2_test.go
+++ b/endtoend/minimal_antiflake_e2e_2_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestEndToEnd_AntiFlake_MinimalConfig_2(t *testing.T) {
-	t.Skip("skipping to prevent E2E flakes")
 	testutil.ResetCache()
 	params.UseMinimalConfig()
 

--- a/endtoend/params/params.go
+++ b/endtoend/params/params.go
@@ -45,6 +45,7 @@ func Init(beaconNodeCount int) error {
 	}
 	testIndexStr, ok := os.LookupEnv("TEST_SHARD_INDEX")
 	if !ok {
+		// Picking a index that won't normally be used.
 		testIndexStr = "8"
 	}
 	testIndex, err := strconv.Atoi(testIndexStr)
@@ -57,12 +58,12 @@ func Init(beaconNodeCount int) error {
 		LogPath:               logPath,
 		TestShardIndex:        testIndex,
 		BeaconNodeCount:       beaconNodeCount,
-		Eth1RPCPort:           3000 + testIndex*100, // Multiplying 100 here so the test index doesn't conflict with the other node ports.
-		BeaconNodeRPCPort:     4000 + testIndex*100,
-		BeaconNodeMetricsPort: 5000 + testIndex*100,
-		ValidatorMetricsPort:  6000 + testIndex*100,
-		SlasherRPCPort:        7000 + testIndex*100,
-		SlasherMetricsPort:    8000 + testIndex*100,
+		Eth1RPCPort:           3100 + testIndex*100, // Multiplying 100 here so the test index doesn't conflict with the other node ports.
+		BeaconNodeRPCPort:     4100 + testIndex*100,
+		BeaconNodeMetricsPort: 5100 + testIndex*100,
+		ValidatorMetricsPort:  6100 + testIndex*100,
+		SlasherRPCPort:        7100 + testIndex*100,
+		SlasherMetricsPort:    8100 + testIndex*100,
 	}
 	return nil
 }


### PR DESCRIPTION
This PR solves the flaky E2E issue of eth1 port not being ready by offsetting the ports by 100, in order to prevent being on a commonly used port like 3000.  