### PR TITLE
Enable slashing protection in validator by default

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -204,13 +204,15 @@ func ConfigureValidator(ctx *cli.Context) {
 	complainOnDeprecatedFlags(ctx)
 	cfg := &Flags{}
 	cfg = configureConfig(ctx, cfg)
-	if ctx.Bool(protectProposerFlag.Name) {
-		log.Warn("Enabled validator proposal slashing protection.")
-		cfg.ProtectProposer = true
+	cfg.ProtectProposer = true
+	if ctx.Bool(disableProtectProposerFlag.Name) {
+		log.Warn("Disabled validator proposal slashing protection.")
+		cfg.ProtectProposer = false
 	}
-	if ctx.Bool(protectAttesterFlag.Name) {
-		log.Warn("Enabled validator attestation slashing protection.")
-		cfg.ProtectAttester = true
+	cfg.ProtectAttester = true
+	if ctx.Bool(disableProtectAttesterFlag.Name) {
+		log.Warn("Disabled validator attestation slashing protection.")
+		cfg.ProtectAttester = false
 	}
 	if ctx.Bool(enableDomainDataCacheFlag.Name) {
 		log.Warn("Enabled domain data cache.")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -80,15 +80,15 @@ var (
 		Usage: "Cache filtered block tree by maintaining it rather than continually recalculating on the fly, " +
 			"this is used for fork choice.",
 	}
-	protectProposerFlag = &cli.BoolFlag{
-		Name: "protect-proposer",
-		Usage: "Prevent the validator client from signing and broadcasting 2 different block " +
-			"proposals in the same epoch. Protects from slashing.",
+	disableProtectProposerFlag = &cli.BoolFlag{
+		Name: "disable-protect-proposer",
+		Usage: "Disables functionality to prevent the validator client from signing and " +
+			"broadcasting 2 different block proposals in the same epoch. Protects from slashing.",
 	}
-	protectAttesterFlag = &cli.BoolFlag{
-		Name: "protect-attester",
-		Usage: "Prevent the validator client from signing and broadcasting 2 any slashable attestations. " +
-			"Protects from slashing.",
+	disableProtectAttesterFlag = &cli.BoolFlag{
+		Name: "disable-protect-attester",
+		Usage: "Disables functionality to prevent the validator client from signing and " +
+			"broadcasting 2 any slashable attestations.",
 	}
 	disableStrictAttestationPubsubVerificationFlag = &cli.BoolFlag{
 		Name:  "disable-strict-attestation-pubsub-verification",
@@ -258,6 +258,16 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedProtectProposerFlag = &cli.BoolFlag{
+		Name:   "protect-proposer",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
+	deprecatedProtectAttesterFlag = &cli.BoolFlag{
+		Name:   "protect-attester",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -282,13 +292,15 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedForkchoiceAggregateAttestations,
 	deprecatedEnableAttestationCacheFlag,
 	deprecatedInitSyncCacheStateFlag,
+	deprecatedProtectAttesterFlag,
+	deprecatedProtectProposerFlag,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
 var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	minimalConfigFlag,
-	protectAttesterFlag,
-	protectProposerFlag,
+	disableProtectAttesterFlag,
+	disableProtectProposerFlag,
 	enableDomainDataCacheFlag,
 }...)
 

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -306,8 +306,6 @@ var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 
 // E2EValidatorFlags contains a list of the validator feature flags to be tested in E2E.
 var E2EValidatorFlags = []string{
-	"--protect-attester",
-	"--protect-proposer",
 	"--enable-domain-data-cache",
 }
 

--- a/validator/client/validator_propose.go
+++ b/validator/client/validator_propose.go
@@ -97,7 +97,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 		}
 
 		if HasProposedForEpoch(history, epoch) {
-			log.WithField("epoch", epoch).Warn("Tried to sign a double proposal, rejected")
+			log.WithField("epoch", epoch).Error("Tried to sign a double proposal, rejected")
 			if v.emitAccountMetrics {
 				validatorProposeFailVec.WithLabelValues(fmtKey).Inc()
 			}


### PR DESCRIPTION
Resolves #5267

Also upgrades the warning message to error level.