### PR TITLE
Release Skip Slot Cache to All

### DIFF
--- a/beacon-chain/cache/skip_slot_cache.go
+++ b/beacon-chain/cache/skip_slot_cache.go
@@ -9,9 +9,8 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.opencensus.io/trace"
-
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
+	"go.opencensus.io/trace"
 )
 
 var (

--- a/beacon-chain/cache/skip_slot_cache_test.go
+++ b/beacon-chain/cache/skip_slot_cache_test.go
@@ -8,15 +8,11 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 )
 
 func TestSkipSlotCache_RoundTrip(t *testing.T) {
 	ctx := context.Background()
 	c := cache.NewSkipSlotCache()
-	fc := featureconfig.Get()
-	fc.EnableSkipSlotsCache = true
-	featureconfig.Init(fc)
 
 	state, err := c.Get(ctx, 5)
 	if err != nil {

--- a/beacon-chain/core/state/BUILD.bazel
+++ b/beacon-chain/core/state/BUILD.bazel
@@ -59,7 +59,6 @@ go_test(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/attestationutil:go_default_library",
         "//shared/bls:go_default_library",
-        "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",

--- a/beacon-chain/core/state/skip_slot_cache.go
+++ b/beacon-chain/core/state/skip_slot_cache.go
@@ -4,8 +4,8 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 )
 
-// skipSlotCache exists for the unlikely scenario that is a large gap between the head state and
+// SkipSlotCache exists for the unlikely scenario that is a large gap between the head state and
 // the current slot. If the beacon chain were ever to be stalled for several epochs, it may be
 // difficult or impossible to compute the appropriate beacon state for assignments within a
 // reasonable amount of time.
-var skipSlotCache = cache.NewSkipSlotCache()
+var SkipSlotCache = cache.NewSkipSlotCache()

--- a/beacon-chain/core/state/skip_slot_cache_test.go
+++ b/beacon-chain/core/state/skip_slot_cache_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	beaconstate "github.com/prysmaticlabs/prysm/beacon-chain/state"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
@@ -18,14 +17,6 @@ func TestSkipSlotCache_OK(t *testing.T) {
 
 	blkCfg := testutil.DefaultBlockGenConfig()
 	blkCfg.NumAttestations = 1
-
-	cfg := featureconfig.Get()
-	cfg.EnableSkipSlotsCache = true
-	featureconfig.Init(cfg)
-	defer func() {
-		cfg.EnableSkipSlotsCache = false
-		featureconfig.Init(cfg)
-	}()
 
 	// First transition will be with an empty cache, so the cache becomes populated
 	// with the state

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -274,7 +274,7 @@ func ProcessSlots(ctx context.Context, state *stateTrie.BeaconState, slot uint64
 	key := state.Slot()
 
 	// Restart from cached value, if one exists.
-	cachedState, err := skipSlotCache.Get(ctx, key)
+	cachedState, err := SkipSlotCache.Get(ctx, key)
 	if err != nil {
 		return nil, err
 	}
@@ -283,8 +283,8 @@ func ProcessSlots(ctx context.Context, state *stateTrie.BeaconState, slot uint64
 		highestSlot = cachedState.Slot()
 		state = cachedState
 	}
-	if err := skipSlotCache.MarkInProgress(key); err == cache.ErrAlreadyInProgress {
-		cachedState, err = skipSlotCache.Get(ctx, key)
+	if err := SkipSlotCache.MarkInProgress(key); err == cache.ErrAlreadyInProgress {
+		cachedState, err = SkipSlotCache.Get(ctx, key)
 		if err != nil {
 			return nil, err
 		}
@@ -295,14 +295,14 @@ func ProcessSlots(ctx context.Context, state *stateTrie.BeaconState, slot uint64
 	} else if err != nil {
 		return nil, err
 	}
-	defer skipSlotCache.MarkNotInProgress(key)
+	defer SkipSlotCache.MarkNotInProgress(key)
 
 	for state.Slot() < slot {
 		if ctx.Err() != nil {
 			traceutil.AnnotateError(span, ctx.Err())
 			// Cache last best value.
 			if highestSlot < state.Slot() {
-				skipSlotCache.Put(ctx, key, state)
+				SkipSlotCache.Put(ctx, key, state)
 			}
 			return nil, ctx.Err()
 		}
@@ -322,7 +322,7 @@ func ProcessSlots(ctx context.Context, state *stateTrie.BeaconState, slot uint64
 	}
 
 	if highestSlot < state.Slot() {
-		skipSlotCache.Put(ctx, key, state)
+		SkipSlotCache.Put(ctx, key, state)
 	}
 
 	return state, nil

--- a/beacon-chain/sync/initial-sync-old/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync-old/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//beacon-chain/core/feed/block:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
+        "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/flags:go_default_library",
         "//beacon-chain/p2p:go_default_library",

--- a/beacon-chain/sync/initial-sync-old/round_robin.go
+++ b/beacon-chain/sync/initial-sync-old/round_robin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	blockfeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/block"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
 	prysmsync "github.com/prysmaticlabs/prysm/beacon-chain/sync"
 	p2ppb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -44,16 +45,8 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	defer s.chain.ClearCachedStates()
-
-	if cfg := featureconfig.Get(); cfg.EnableSkipSlotsCache {
-		cfg.EnableSkipSlotsCache = false
-		featureconfig.Init(cfg)
-		defer func() {
-			cfg := featureconfig.Get()
-			cfg.EnableSkipSlotsCache = true
-			featureconfig.Init(cfg)
-		}()
-	}
+	state.SkipSlotCache.Disable()
+	defer state.SkipSlotCache.Enable()
 
 	counter := ratecounter.NewRateCounter(counterSeconds * time.Second)
 	randGenerator := rand.New(rand.NewSource(time.Now().Unix()))

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//beacon-chain/core/feed/block:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
+        "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/flags:go_default_library",
         "//beacon-chain/p2p:go_default_library",

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -65,7 +65,6 @@ type Flags struct {
 	// Cache toggles.
 	EnableSSZCache          bool // EnableSSZCache see https://github.com/prysmaticlabs/prysm/pull/4558.
 	EnableEth1DataVoteCache bool // EnableEth1DataVoteCache; see https://github.com/prysmaticlabs/prysm/issues/3106.
-	EnableSkipSlotsCache    bool // EnableSkipSlotsCache caches the state in skipped slots.
 	EnableSlasherConnection bool // EnableSlasher enable retrieval of slashing events from a slasher instance.
 	EnableBlockTreeCache    bool // EnableBlockTreeCache enable fork choice service to maintain latest filtered block tree.
 }
@@ -130,10 +129,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.Bool(enableBackupWebhookFlag.Name) {
 		log.Warn("Allowing database backups to be triggered from HTTP webhook.")
 		cfg.EnableBackupWebhook = true
-	}
-	if ctx.Bool(enableSkipSlotsCacheFlag.Name) {
-		log.Warn("Enabled skip slots cache.")
-		cfg.EnableSkipSlotsCache = true
 	}
 	if ctx.String(kafkaBootstrapServersFlag.Name) != "" {
 		log.Warn("Enabling experimental kafka streaming.")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -51,10 +51,6 @@ var (
 		Name:  "enable-db-backup-webhook",
 		Usage: "Serve HTTP handler to initiate database backups. The handler is served on the monitoring port at path /db/backup.",
 	}
-	enableSkipSlotsCacheFlag = &cli.BoolFlag{
-		Name:  "enable-skip-slots-cache",
-		Usage: "Enables the skip slot cache to be used in the event of skipped slots.",
-	}
 	kafkaBootstrapServersFlag = &cli.StringFlag{
 		Name:  "kafka-url",
 		Usage: "Stream attestations and blocks to specified kafka servers. This field is used for bootstrap.servers kafka config field.",
@@ -313,7 +309,6 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	skipBLSVerifyFlag,
 	kafkaBootstrapServersFlag,
 	enableBackupWebhookFlag,
-	enableSkipSlotsCacheFlag,
 	enableSlasherFlag,
 	cacheFilteredBlockTreeFlag,
 	disableStrictAttestationPubsubVerificationFlag,
@@ -335,7 +330,6 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 var E2EBeaconChainFlags = []string{
 	"--enable-ssz-cache",
 	"--cache-filtered-block-tree",
-	"--enable-skip-slots-cache",
 	"--enable-eth1-data-vote-cache",
 	"--enable-byte-mempool",
 	"--enable-state-gen-sig-verify",

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -173,6 +173,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableSkipSlotsCacheFlag = &cli.BoolFlag{
+		Name:   "enable-skip-slots-cache",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 	deprecatedEnablePruneBoundaryStateFlag = &cli.BoolFlag{
 		Name:   "prune-states",
 		Usage:  deprecatedUsage,
@@ -262,6 +267,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedPruneFinalizedStatesFlag,
 	deprecatedOptimizeProcessEpochFlag,
 	deprecatedEnableSnappyDBCompressionFlag,
+	deprecatedEnableSkipSlotsCacheFlag,
 	deprecatedEnablePruneBoundaryStateFlag,
 	deprecatedEnableActiveIndicesCacheFlag,
 	deprecatedEnableActiveCountCacheFlag,


### PR DESCRIPTION
Resolves #5211 

---

# Description

**Write why you are making the changes in this pull request**

Our skip slot cache has been running for a while in prod and is good to make the default for the testnet restart. We allow for programmatic toggling of the cache useful for disabling it during initial sync.
