### PR TITLE
Set a max limit for decoding ssz objects from p2p

### DIFF
--- a/beacon-chain/p2p/encoder/ssz_test.go
+++ b/beacon-chain/p2p/encoder/ssz_test.go
@@ -103,3 +103,12 @@ func TestSszNetworkEncoder_DecodeWithMaxLength(t *testing.T) {
 		t.Errorf("error did not contain wanted message. Wanted: %s but Got: %s", wanted, err.Error())
 	}
 }
+
+func TestSszNetworkEncoder_DecodeWithMaxLength_TooLarge(t *testing.T) {
+	e := &encoder.SszNetworkEncoder{UseSnappyCompression: false}
+	if err := e.DecodeWithMaxLength(nil, nil, encoder.MaxChunkSize+1); err == nil {
+		t.Fatal("Nil error")
+	} else if !strings.Contains(err.Error(), "exceeds max chunk size") {
+		t.Error("Expected error to contain 'exceeds max chunk size'")
+	}
+}


### PR DESCRIPTION
Spec defines a 1Mb chunk size limit that was not enforced in Prysm's network decoder.

 https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/p2p-interface.md#configuration

Discovered in fuzz testing when the test tried to send a 84 byte message with a length of over 9000 petabytes. 