### PR TITLE
Reduce noise in validator logs

### DIFF
--- a/shared/prometheus/BUILD.bazel
+++ b/shared/prometheus/BUILD.bazel
@@ -28,8 +28,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//shared:go_default_library",
-        "//shared/testutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
 )

--- a/shared/service_registry.go
+++ b/shared/service_registry.go
@@ -38,7 +38,7 @@ func NewServiceRegistry() *ServiceRegistry {
 
 // StartAll initialized each service in order of registration.
 func (s *ServiceRegistry) StartAll() {
-	log.Infof("Starting %d services: %v", len(s.serviceTypes), s.serviceTypes)
+	log.Debugf("Starting %d services: %v", len(s.serviceTypes), s.serviceTypes)
 	for _, kind := range s.serviceTypes {
 		log.Debugf("Starting service type %v", kind)
 		go s.services[kind].Start()

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -101,12 +101,14 @@ func (v *ValidatorService) Start() {
 
 	md := make(metadata.MD)
 	for _, hdr := range v.grpcHeaders {
-		ss := strings.Split(hdr, "=")
-		if len(ss) != 2 {
-			log.Warnf("Incorrect gRPC header flag format. Skipping %v", hdr)
-			continue
+		if hdr != "" {
+			ss := strings.Split(hdr, "=")
+			if len(ss) != 2 {
+				log.Warnf("Incorrect gRPC header flag format. Skipping %v", hdr)
+				continue
+			}
+			md.Set(ss[0], ss[1])
 		}
-		md.Set(ss[0], ss[1])
 	}
 
 	opts := []grpc.DialOption{
@@ -134,7 +136,7 @@ func (v *ValidatorService) Start() {
 		log.Errorf("Could not dial endpoint: %s, %v", v.endpoint, err)
 		return
 	}
-	log.Info("Successfully started gRPC connection")
+	log.Debug("Successfully started gRPC connection")
 
 	pubkeys, err := v.keyManager.FetchValidatingKeys()
 	if err != nil {

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -80,7 +80,7 @@ func NewValidatorClient(ctx *cli.Context) (*ValidatorClient, error) {
 		if len(pubKeys) == 0 {
 			log.Warn("No keys found; nothing to validate")
 		} else {
-			log.WithField("validators", len(pubKeys)).Info("Found validator keys")
+			log.WithField("validators", len(pubKeys)).Debug("Found validator keys")
 			for _, key := range pubKeys {
 				log.WithField("pubKey", fmt.Sprintf("%#x", key)).Info("Validating for public key")
 			}


### PR DESCRIPTION
The validator log is a little chatty, especially at startup.  This results in potentially important messages being missed by users.

This patch reduces the severity of some log messages that aren't relevant to end users, and cuts down on the number of messages that are emitted by prometheus when the monitoring port is already in use.

Sample startup before this patch:

```
[2020-04-04 16:56:22]  INFO flags: Using custom chain parameters config=demo
[2020-04-04 16:56:23]  INFO node: Found validator keys validators=1
[2020-04-04 16:56:23]  INFO node: Validating for public key pubKey=0xa551e2558c839162b5df961ceb27cd10e9cf711ac15ff7866143cbf6df5fe523e5c3c91fdfa95f47e20b9499ee5766fc
[2020-04-04 16:56:23]  INFO node: Starting validator node version=Prysm/Git commit: 9aac572c21b06c45fc792ce6db3b0a820745a974. Built at: 2020-04-04T16:56:22+01:00
[2020-04-04 16:56:23]  INFO registry: Starting 2 services: [*prometheus.Service *client.ValidatorService]
[2020-04-04 16:56:23]  WARN validator: You are using an insecure gRPC connection! Please provide a certificate and key to use a secure connection.
[2020-04-04 16:56:23]  INFO prometheus: Collecting metrics at endpoint endpoint=:8080
[2020-04-04 16:56:23]  WARN validator: Incorrect gRPC header flag format. Skipping 
[2020-04-04 16:56:23]  INFO validator: Successfully started gRPC connection
[2020-04-04 16:56:23] ERROR prometheus: Could not listen to host:port ::8080: listen tcp :8080: bind: address already in use
[2020-04-04 16:56:23]  INFO validator: Waiting for beacon chain start log from the ETH 1.0 deposit contract
[2020-04-04 16:56:23]  INFO validator: Beacon chain started genesisTime=2020-01-10 00:00:00 +0000 GMT
```

Sample startup with this patch:

```
[2020-04-04 16:53:44]  INFO flags: Using custom chain parameters config=demo
[2020-04-04 16:53:45]  INFO node: Validating for public key pubKey=0xa551e2558c839162b5df961ceb27cd10e9cf711ac15ff7866143cbf6df5fe523e5c3c91fdfa95f47e20b9499ee5766fc
[2020-04-04 16:53:45]  INFO node: Starting validator node version=Prysm/Git commit: 28bdbb1f44fc150b5ebd6cb643c183ef8e48de55. Built at: 2020-04-04T16:53:44+01:00
[2020-04-04 16:53:45]  WARN prometheus: Port already in use; cannot start prometheus service address=:8080
[2020-04-04 16:53:45]  WARN validator: You are using an insecure gRPC connection! Please provide a certificate and key to use a secure connection.
[2020-04-04 16:53:45]  INFO validator: Waiting for beacon chain start log from the ETH 1.0 deposit contract
[2020-04-04 16:53:45]  INFO validator: Beacon chain started genesisTime=2020-01-10 00:00:00 +0000 GMT
```

It also tidies up the prometheus lifecycle test by testing the service rather than just watching for a log entry.