### PR TITLE
Save cached blocks to db during phase 2 of initial sync

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -112,6 +112,13 @@ func (s *Service) onBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock) 
 
 	// Update finalized check point. Prune the block cache and helper caches on every new finalized epoch.
 	if postState.FinalizedCheckpointEpoch() > s.finalizedCheckpt.Epoch {
+		if !featureconfig.Get().NoInitSyncBatchSaveBlocks {
+			if err := s.beaconDB.SaveBlocks(ctx, s.getInitSyncBlocks()); err != nil {
+				return nil, err
+			}
+			s.clearInitSyncBlocks()
+		}
+
 		if err := s.beaconDB.SaveFinalizedCheckpoint(ctx, postState.FinalizedCheckpoint()); err != nil {
 			return nil, errors.Wrap(err, "could not save finalized checkpoint")
 		}

--- a/beacon-chain/operations/attestations/kv/unaggregated_test.go
+++ b/beacon-chain/operations/attestations/kv/unaggregated_test.go
@@ -40,6 +40,7 @@ func TestKV_Unaggregated_CanDelete(t *testing.T) {
 	if err := cache.DeleteUnaggregatedAttestation(att2); err != nil {
 		t.Fatal(err)
 	}
+
 	if err := cache.DeleteUnaggregatedAttestation(att3); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This ensures saving of initial sync cached blocks to DB during phase 2 of the syncing where `onBlock` os used.

I saw an edge case that syncing phase 2 kicked in but finalized block did not make it to the db:
```
[2020-04-04 14:15:06] ERROR sync: Could not process block from slot 618374: could not process block: could not save finalized checkpoint: missing block in database: block root=0x76213df966a6a9fb0f6eb53ea57d678ab6eaff2c2acd16a2f822f9ddce821279
```