### PR TITLE
Fixed typo in stdout log

### DIFF
--- a/beacon-chain/sync/initial-sync-old/round_robin.go
+++ b/beacon-chain/sync/initial-sync-old/round_robin.go
@@ -199,7 +199,7 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 			0,                    // remainder
 		)
 		if err != nil {
-			log.WithError(err).Error("Round robing sync request failed")
+			log.WithError(err).Error("Round robin sync request failed")
 			continue
 		}
 


### PR DESCRIPTION
"Round robin**g** sync request failed"

changed to

"Round robin sync request failed"

TODO(you): choose "part of" or "resolves" and the associated github issue #.

[Part of|Resolves] #531 

---

# Description

**Write why you are making the changes in this pull request**

**Write a summary of the changes you are making**

**Link anything that would be helpful or relevant to the reviewers**
