### PR TITLE
Initialize chain service properly if head slot is 0

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -157,7 +157,8 @@ func (s *Service) Start() {
 	attestationProcessorSubscribed := make(chan struct{}, 1)
 
 	// If the chain has already been initialized, simply start the block processing routine.
-	if beaconState != nil {
+	// A node should still initialize rest of the chain service if the finalized state's slot is 0.
+	if beaconState != nil && beaconState.Slot() != 0 {
 		log.Info("Blockchain data already exists in DB, initializing...")
 		s.genesisTime = time.Unix(int64(beaconState.GenesisTime()), 0)
 		s.opsService.SetGenesisTime(beaconState.GenesisTime())


### PR DESCRIPTION
Caught this edge case in v0.11, with the latest features, if the head or finalized state is 0, a node should still properly initialize rest of the components in chain service