### PR TITLE
Change attester protection to return default if DB is empty

### DIFF
--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -83,8 +83,9 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		return
 	}
 
+	var history *slashpb.AttestationHistory
 	if featureconfig.Get().ProtectAttester {
-		history, err := v.db.AttestationHistory(ctx, pubKey[:])
+		history, err = v.db.AttestationHistory(ctx, pubKey[:])
 		if err != nil {
 			log.Errorf("Could not get attestation history from DB: %v", err)
 			if v.emitAccountMetrics {
@@ -148,14 +149,6 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 	}
 
 	if featureconfig.Get().ProtectAttester {
-		history, err := v.db.AttestationHistory(ctx, pubKey[:])
-		if err != nil {
-			log.Errorf("Could not get attestation history from DB: %v", err)
-			if v.emitAccountMetrics {
-				validatorAttestFailVec.WithLabelValues(fmtKey).Inc()
-			}
-			return
-		}
 		history = markAttestationForTargetEpoch(history, data.Source.Epoch, data.Target.Epoch)
 		if err := v.db.SaveAttestationHistory(ctx, pubKey[:], history); err != nil {
 			log.Errorf("Could not save attestation history to DB: %v", err)

--- a/validator/db/attestation_history.go
+++ b/validator/db/attestation_history.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
 	slashpb "github.com/prysmaticlabs/prysm/proto/slashing"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	bolt "go.etcd.io/bbolt"
 	"go.opencensus.io/trace"
 )
@@ -31,6 +32,11 @@ func (db *Store) AttestationHistory(ctx context.Context, publicKey []byte) (*sla
 		bucket := tx.Bucket(historicAttestationsBucket)
 		enc := bucket.Get(publicKey)
 		if enc == nil {
+			newMap := make(map[uint64]uint64)
+			newMap[0] = params.BeaconConfig().FarFutureEpoch
+			attestationHistory = &slashpb.AttestationHistory{
+				TargetToSource: newMap,
+			}
 			return nil
 		}
 		attestationHistory, err = unmarshalAttestationHistory(enc)

--- a/validator/db/attestation_history_test.go
+++ b/validator/db/attestation_history_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
-func TestAttestationHistory_InitializesNewPubKeys(t *testing.T) {
+func TestAttestationHistory_EmptyVal(t *testing.T) {
 	pubkeys := [][48]byte{{30}, {25}, {20}}
 	db := SetupDB(t, pubkeys)
 	defer TeardownDB(t, db)
@@ -28,22 +28,6 @@ func TestAttestationHistory_InitializesNewPubKeys(t *testing.T) {
 		if !reflect.DeepEqual(attestationHistory, clean) {
 			t.Fatalf("Expected attestation history epoch bits to be empty, received %v", attestationHistory)
 		}
-	}
-}
-
-func TestAttestationHistory_NilDB(t *testing.T) {
-	db := SetupDB(t, [][48]byte{})
-	defer TeardownDB(t, db)
-
-	valPubkey := []byte{1, 2, 3}
-
-	attestationHistory, err := db.AttestationHistory(context.Background(), valPubkey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if attestationHistory != nil {
-		t.Fatalf("Expected attestation history to be nil, received: %v", attestationHistory)
 	}
 }
 
@@ -187,7 +171,12 @@ func TestDeleteAttestationHistory_OK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to get attestation history: %v", err)
 	}
-	if savedHistory != nil {
-		t.Fatalf("Expected attestation history to be nil, received %v", savedHistory)
+	cleanMap := make(map[uint64]uint64)
+	cleanMap[0] = params.BeaconConfig().FarFutureEpoch
+	clean := &slashpb.AttestationHistory{
+		TargetToSource: newMap,
+	}
+	if !reflect.DeepEqual(savedHistory, clean) {
+		t.Fatalf("Expected attestation history to be clean, received %v", savedHistory)
 	}
 }

--- a/validator/db/attestation_history_test.go
+++ b/validator/db/attestation_history_test.go
@@ -174,9 +174,9 @@ func TestDeleteAttestationHistory_OK(t *testing.T) {
 	cleanMap := make(map[uint64]uint64)
 	cleanMap[0] = params.BeaconConfig().FarFutureEpoch
 	clean := &slashpb.AttestationHistory{
-		TargetToSource: newMap,
+		TargetToSource: cleanMap,
 	}
 	if !reflect.DeepEqual(savedHistory, clean) {
-		t.Fatalf("Expected attestation history to be clean, received %v", savedHistory)
+		t.Fatalf("Expected attestation history to be %v, received %v", clean, savedHistory)
 	}
 }

--- a/validator/db/db.go
+++ b/validator/db/db.go
@@ -1,14 +1,11 @@
 package db
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
-	slashpb "github.com/prysmaticlabs/prysm/proto/slashing"
-	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/validator/db/iface"
 	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"

--- a/validator/db/db.go
+++ b/validator/db/db.go
@@ -92,26 +92,9 @@ func NewKVStore(dirPath string, pubKeys [][48]byte) (*Store, error) {
 		return nil, err
 	}
 
-	// Initialize the required pubKeys into the DB to ensure they're not empty.
+	// Initialize the required public keys into the DB to ensure they're not empty.
 	if err := kv.initializeSubBuckets(pubKeys); err != nil {
 		return nil, err
-	}
-	for _, pubkey := range pubKeys {
-		attHistory, err := kv.AttestationHistory(context.Background(), pubkey[:])
-		if err != nil {
-			return nil, err
-		}
-		if attHistory == nil {
-			newMap := make(map[uint64]uint64)
-			newMap[0] = params.BeaconConfig().FarFutureEpoch
-			cleanHistory := &slashpb.AttestationHistory{
-				TargetToSource: newMap,
-			}
-			if err := kv.SaveAttestationHistory(context.Background(), pubkey[:], cleanHistory); err != nil {
-				return nil, err
-			}
-		}
-
 	}
 
 	return kv, err

--- a/validator/db/proposal_history.go
+++ b/validator/db/proposal_history.go
@@ -97,7 +97,7 @@ func (db *Store) initializeSubBuckets(pubKeys [][48]byte) error {
 		bucket := tx.Bucket(historicProposalsBucket)
 		for _, pubKey := range pubKeys {
 			if _, err := bucket.CreateBucketIfNotExists(pubKey[:]); err != nil {
-				return errors.Wrap(err, "failed to delete the proposal history")
+				return errors.Wrap(err, "failed to create proposal history bucket")
 			}
 		}
 		return nil


### PR DESCRIPTION
This change removes a bottleneck for starting a validator client by no longer creating N validator DB transactions upon launch. Instead of preloading default values into the DB, it will return default values if the DB is empty.  

Also removes a wasteful db call for both attesting and proposing