### PR TITLE
Remove old cross compile starlark rules

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -46,3 +46,6 @@ build --flaky_test_attempts=5
 
 # Enable kafka for CI tests only.
 test --define kafka_enabled=true
+
+build --bes_backend=grpcs://builds.prylabs.net:1985
+build --bes_results_url=https://builds.prylabs.net/invocation/

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,7 +4,6 @@ load("@com_github_atlassian_bazel_tools//goimports:def.bzl", "goimports")
 load("@io_kubernetes_build//defs:run_in_workspace.bzl", "workspace_binary")
 load("@io_bazel_rules_go//go:def.bzl", "nogo")
 load("@graknlabs_bazel_distribution//common:rules.bzl", "assemble_targz", "assemble_versioned")
-load("//tools:binary_targets.bzl", "binary_targets", "determine_targets")
 
 prefix = "github.com/prysmaticlabs/prysm"
 
@@ -108,36 +107,10 @@ nogo(
     ],
 )
 
-assemble_versioned(
-    name = "assemble-versioned-all",
-    tags = ["manual"],
-    targets = [
-        ":assemble-{}-{}-targz".format(
-            pair[0],
-            pair[1],
-        )
-        for pair in binary_targets
-    ],
-    version_file = "//:VERSION",
-)
-
 common_files = {
     "//:LICENSE.md": "LICENSE.md",
     "//:README.md": "README.md",
 }
-
-[assemble_targz(
-    name = "assemble-{}-{}-targz".format(
-        pair[0],
-        pair[1],
-    ),
-    additional_files = determine_targets(pair, common_files),
-    output_filename = "prysm-{}-{}".format(
-        pair[0],
-        pair[1],
-    ),
-    tags = ["manual"],
-) for pair in binary_targets]
 
 toolchain(
     name = "built_cmake_toolchain",

--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
-load("//tools:binary_targets.bzl", "binary_targets", "go_image_alpine", "go_image_debug")
+load("//tools:go_image.bzl", "go_image_alpine", "go_image_debug")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 go_library(
@@ -144,15 +144,3 @@ go_test(
         "@in_gopkg_urfave_cli_v2//:go_default_library",
     ],
 )
-
-[go_binary(
-    name = "beacon-chain-{}-{}".format(
-        pair[0],
-        pair[1],
-    ),
-    embed = [":go_default_library"],
-    goarch = pair[1],
-    goos = pair[0],
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-) for pair in binary_targets]

--- a/tools/go_image.bzl
+++ b/tools/go_image.bzl
@@ -1,31 +1,5 @@
 load("@io_bazel_rules_docker//container:providers.bzl", "ImageInfo")
 
-# Supported pairs of system and architecture. (GOOS, GOARCH).
-binary_targets = [
-    ("linux", "amd64"),
-    ("linux", "arm64"),
-    # TODO(2849): Enable after cross OS compilation is supported.
-    # https://github.com/prysmaticlabs/prysm/issues/2849
-    #    ("darwin", "amd64"),
-    #    ("windows", "amd64"),
-]
-
-# Determine binary targets from a supported pair. These targets are part of the
-# distributable bundle.
-def determine_targets(pair, common_files):
-    targets = {
-        "//beacon-chain:beacon-chain-{}-{}".format(
-            pair[0],
-            pair[1],
-        ): "beacon-chain",
-        "//validator:validator-{}-{}".format(
-            pair[0],
-            pair[1],
-        ): "validator",
-    }
-    targets.update(common_files)
-    return targets
-
 # Defines the debug transition implementation to enforce dbg mode.
 def _debug_transition_impl(settings, attr):
     return {

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
-load("//tools:binary_targets.bzl", "binary_targets", "go_image_alpine", "go_image_debug")
+load("//tools:go_image.bzl", "go_image_alpine", "go_image_debug")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 go_library(
@@ -134,18 +134,6 @@ go_binary(
         "//validator:__subpackages__",
     ],
 )
-
-[go_binary(
-    name = "validator-{}-{}".format(
-        pair[0],
-        pair[1],
-    ),
-    embed = [":go_default_library"],
-    goarch = pair[1],
-    goos = pair[0],
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-) for pair in binary_targets]
 
 go_test(
     name = "go_default_test",


### PR DESCRIPTION
These binary targets are no longer supported since adding cross compile toolchains.