### PR TITLE
Avoid duplicated aggregation request

### DIFF
--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "@com_github_grpc_ecosystem_go_grpc_middleware//retry:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_middleware//tracing/opentracing:go_default_library",
         "@com_github_grpc_ecosystem_go_grpc_prometheus//:go_default_library",
+        "@com_github_hashicorp_golang_lru//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//validator/keymanager:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
+        "@com_github_hashicorp_golang_lru//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -9,12 +9,14 @@ import (
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/validator/db"
 	"github.com/prysmaticlabs/prysm/validator/keymanager"
 	"github.com/sirupsen/logrus"
@@ -164,18 +166,24 @@ func (v *ValidatorService) Start() {
 		panic(err)
 	}
 
+	aggregatedSlotCommitteeIDCache, err := lru.New(int(params.BeaconConfig().MaxCommitteesPerSlot))
+	if err != nil {
+		log.Errorf("Could not initialize cache: %v", err)
+		return
+	}
 	v.validator = &validator{
-		db:                   valDB,
-		validatorClient:      ethpb.NewBeaconNodeValidatorClient(v.conn),
-		beaconClient:         ethpb.NewBeaconChainClient(v.conn),
-		node:                 ethpb.NewNodeClient(v.conn),
-		keyManager:           v.keyManager,
-		graffiti:             v.graffiti,
-		logValidatorBalances: v.logValidatorBalances,
-		emitAccountMetrics:   v.emitAccountMetrics,
-		prevBalance:          make(map[[48]byte]uint64),
-		attLogs:              make(map[[32]byte]*attSubmitted),
-		domainDataCache:      cache,
+		db:                             valDB,
+		validatorClient:                ethpb.NewBeaconNodeValidatorClient(v.conn),
+		beaconClient:                   ethpb.NewBeaconChainClient(v.conn),
+		node:                           ethpb.NewNodeClient(v.conn),
+		keyManager:                     v.keyManager,
+		graffiti:                       v.graffiti,
+		logValidatorBalances:           v.logValidatorBalances,
+		emitAccountMetrics:             v.emitAccountMetrics,
+		prevBalance:                    make(map[[48]byte]uint64),
+		attLogs:                        make(map[[32]byte]*attSubmitted),
+		domainDataCache:                cache,
+		aggregatedSlotCommitteeIDCache: aggregatedSlotCommitteeIDCache,
 	}
 	go run(v.ctx, v.validator)
 }

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -42,23 +42,24 @@ const (
 )
 
 type validator struct {
-	genesisTime                    uint64
-	ticker                         *slotutil.SlotTicker
-	db                             *db.Store
-	duties                         *ethpb.DutiesResponse
-	validatorClient                ethpb.BeaconNodeValidatorClient
-	beaconClient                   ethpb.BeaconChainClient
-	graffiti                       []byte
-	node                           ethpb.NodeClient
-	keyManager                     keymanager.KeyManager
-	prevBalance                    map[[48]byte]uint64
-	logValidatorBalances           bool
-	emitAccountMetrics             bool
-	attLogs                        map[[32]byte]*attSubmitted
-	attLogsLock                    sync.Mutex
-	domainDataLock                 sync.Mutex
-	domainDataCache                *ristretto.Cache
-	aggregatedSlotCommitteeIDCache *lru.Cache
+	genesisTime                        uint64
+	ticker                             *slotutil.SlotTicker
+	db                                 *db.Store
+	duties                             *ethpb.DutiesResponse
+	validatorClient                    ethpb.BeaconNodeValidatorClient
+	beaconClient                       ethpb.BeaconChainClient
+	graffiti                           []byte
+	node                               ethpb.NodeClient
+	keyManager                         keymanager.KeyManager
+	prevBalance                        map[[48]byte]uint64
+	logValidatorBalances               bool
+	emitAccountMetrics                 bool
+	attLogs                            map[[32]byte]*attSubmitted
+	attLogsLock                        sync.Mutex
+	domainDataLock                     sync.Mutex
+	domainDataCache                    *ristretto.Cache
+	aggregatedSlotCommitteeIDCache     *lru.Cache
+	aggregatedSlotCommitteeIDCacheLock sync.Mutex
 }
 
 var validatorStatusesGaugeVec = promauto.NewGaugeVec(

--- a/validator/client/validator_aggregate.go
+++ b/validator/client/validator_aggregate.go
@@ -61,6 +61,8 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot uint64, pu
 
 	// Avoid sending beacon node duplicated aggregation requests.
 	k := validatorSubscribeKey(slot, duty.CommitteeIndex)
+	v.aggregatedSlotCommitteeIDCacheLock.Lock()
+	defer v.aggregatedSlotCommitteeIDCacheLock.Unlock()
 	if v.aggregatedSlotCommitteeIDCache.Contains(k) {
 		return
 	}

--- a/validator/client/validator_aggregate.go
+++ b/validator/client/validator_aggregate.go
@@ -59,6 +59,13 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot uint64, pu
 		return
 	}
 
+	// Avoid sending beacon node duplicated aggregation requests.
+	k := validatorSubscribeKey(slot, duty.CommitteeIndex)
+	if v.aggregatedSlotCommitteeIDCache.Contains(k) {
+		return
+	}
+	v.aggregatedSlotCommitteeIDCache.Add(k, true)
+
 	slotSig, err := v.signSlot(ctx, pubKey, slot)
 	if err != nil {
 		log.Errorf("Could not sign slot: %v", err)


### PR DESCRIPTION
Given our beacon node aggregate attestations on demand in v0.11, a single validator client (VC) could multiple keys that have duplicated assignment for aggregator for the same committee and the same slot. There's no reason for VC to produce duplicated `AggregateAndProof` request which would result in the same proof signature while there's no reward for aggregating. 
Also the gossip network would try to supress the duplicated `AggregateAndProof`. Confirmed with Adrian from Teku and Paul from Lighthouse that's their design as well. 


We are getting such a performance improvement from this radical change! 
Before bottlenecks:
<img width="2026" alt="Screen Shot 2020-04-07 at 6 32 46 PM" src="https://user-images.githubusercontent.com/21316537/78735238-202c7700-78ff-11ea-9bd8-d12a3568fe45.png">

After bottlenecks:
<img width="2015" alt="Screen Shot 2020-04-07 at 6 29 00 PM" src="https://user-images.githubusercontent.com/21316537/78735242-23276780-78ff-11ea-9789-ff63f522e451.png">
