### PR TITLE
Networking Fixes

### DIFF
--- a/beacon-chain/p2p/interfaces.go
+++ b/beacon-chain/p2p/interfaces.go
@@ -58,6 +58,7 @@ type PeerManager interface {
 	PeerID() peer.ID
 	RefreshENR(epoch uint64)
 	FindPeersWithSubnet(index uint64) (bool, error)
+	AddPingMethod(reqFunc func(ctx context.Context, id peer.ID) error)
 }
 
 // Sender abstracts the sending functionality from libp2p.

--- a/beacon-chain/p2p/testing/p2p.go
+++ b/beacon-chain/p2p/testing/p2p.go
@@ -264,7 +264,7 @@ func (p *TestP2P) MetadataSeq() uint64 {
 	return p.LocalMetadata.SeqNumber
 }
 
-// // AddPingMethod mocks the p2p func.
+// AddPingMethod mocks the p2p func.
 func (p *TestP2P) AddPingMethod(reqFunc func(ctx context.Context, id peer.ID) error) {
 	// no-op
 }

--- a/beacon-chain/p2p/testing/p2p.go
+++ b/beacon-chain/p2p/testing/p2p.go
@@ -263,3 +263,8 @@ func (p *TestP2P) Metadata() *pb.MetaData {
 func (p *TestP2P) MetadataSeq() uint64 {
 	return p.LocalMetadata.SeqNumber
 }
+
+// // AddPingMethod mocks the p2p func.
+func (p *TestP2P) AddPingMethod(reqFunc func(ctx context.Context, id peer.ID) error) {
+	// no-op
+}

--- a/beacon-chain/sync/rpc_metadata.go
+++ b/beacon-chain/sync/rpc_metadata.go
@@ -33,6 +33,10 @@ func (r *Service) sendMetaDataRequest(ctx context.Context, id peer.ID) (*pb.Meta
 	if err != nil {
 		return nil, err
 	}
+	// we close the stream outside of `send` because
+	// metadata requests send no payload, so closing the
+	// stream early leads it to a reset.
+	defer stream.Close()
 	code, errMsg, err := ReadStatusCode(stream, r.p2p.Encoding())
 	if err != nil {
 		return nil, err

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -136,6 +136,7 @@ func (r *Service) Start() {
 
 	r.p2p.AddConnectionHandler(r.reValidatePeer)
 	r.p2p.AddDisconnectionHandler(r.removeDisconnectedPeerStatus)
+	r.p2p.AddPingMethod(r.sendPingRequest)
 	r.processPendingBlocksQueue()
 	r.processPendingAttsQueue()
 	r.maintainPeerStatuses()

--- a/beacon-chain/sync/subscriber_committee_index_beacon_attestation.go
+++ b/beacon-chain/sync/subscriber_committee_index_beacon_attestation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed/operation"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/sliceutil"
 )
 
 func (r *Service) committeeIndexBeaconAttestationSubscriber(ctx context.Context, msg proto.Message) error {
@@ -56,7 +57,7 @@ func (r *Service) aggregatorCommitteeIndices(currentSlot uint64) []uint64 {
 	for i := currentSlot; i <= endSlot; i++ {
 		commIds = append(commIds, cache.CommitteeIDs.GetAggregatorCommitteeIDs(i)...)
 	}
-	return commIds
+	return sliceutil.SetUint64(commIds)
 }
 
 func (r *Service) attesterCommitteeIndices(currentSlot uint64) []uint64 {
@@ -66,5 +67,5 @@ func (r *Service) attesterCommitteeIndices(currentSlot uint64) []uint64 {
 	for i := currentSlot; i <= endSlot; i++ {
 		commIds = append(commIds, cache.CommitteeIDs.GetAttesterCommitteeIDs(i)...)
 	}
-	return commIds
+	return sliceutil.SetUint64(commIds)
 }


### PR DESCRIPTION
- [x] Use Ping RPC method whenever our local ENR is updated. 
- [x] Remove duplicate indices from committees when looking for subnets. 
- [x] Defer closing of streams for metadata rpc requests.