### PR TITLE
More efficient aggregation on demand

### DIFF
--- a/beacon-chain/operations/attestations/kv/BUILD.bazel
+++ b/beacon-chain/operations/attestations/kv/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//shared/hashutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@com_github_prysmaticlabs_go_ssz//:go_default_library",
     ],
 )
 

--- a/beacon-chain/operations/attestations/kv/BUILD.bazel
+++ b/beacon-chain/operations/attestations/kv/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//shared/bls:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
     ],

--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -3,9 +3,68 @@ package kv
 import (
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
+
+// AggregateUnaggregatedAttestations aggregates the unaggregated attestations and save the
+// newly aggregated attestations in the pool.
+// It tracks the unaggregated attestations that weren't able to aggregate to prevent
+// the deletion of unaggregated attestations in the pool.
+func (p *AttCaches) AggregateUnaggregatedAttestations() error {
+	attsByDataRoot := make(map[[32]byte][]*ethpb.Attestation)
+	unaggregatedAtts := p.UnaggregatedAttestations()
+	for _, att := range unaggregatedAtts {
+		attDataRoot, err := ssz.HashTreeRoot(att.Data)
+		if err != nil {
+			return err
+		}
+		attsByDataRoot[attDataRoot] = append(attsByDataRoot[attDataRoot], att)
+	}
+
+	// Aggregate unaggregated attestations from the pool and save them in the pool.
+	// Track the unaggregated attestations that aren't able to aggregate.
+	leftOverUnaggregatedAtt := make(map[[32]byte]bool)
+	for _, atts := range attsByDataRoot {
+		aggregatedAtts := make([]*ethpb.Attestation, 0, len(atts))
+		processedAtts, err := helpers.AggregateAttestations(atts)
+		if err != nil {
+			return err
+		}
+		for _, att := range processedAtts {
+			if helpers.IsAggregated(att) {
+				aggregatedAtts = append(aggregatedAtts, att)
+			} else {
+				h, err := hashutil.HashProto(att)
+				if err != nil {
+					return err
+				}
+				leftOverUnaggregatedAtt[h] = true
+			}
+		}
+		if err := p.SaveAggregatedAttestations(aggregatedAtts); err != nil {
+			return err
+		}
+	}
+
+	// Remove the unaggregated attestations from the pool that were successfully aggregated.
+	for _, att := range unaggregatedAtts {
+		h, err := hashutil.HashProto(att)
+		if err != nil {
+			return err
+		}
+		if leftOverUnaggregatedAtt[h] {
+			continue
+		}
+		if err := p.DeleteUnaggregatedAttestation(att); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 // SaveAggregatedAttestation saves an aggregated attestation in cache.
 func (p *AttCaches) SaveAggregatedAttestation(att *ethpb.Attestation) error {

--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -6,7 +6,6 @@ import (
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
-	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
 
 // AggregateUnaggregatedAttestations aggregates the unaggregated attestations and save the
@@ -37,7 +36,7 @@ func (p *AttCaches) AggregateUnaggregatedAttestations() error {
 			if helpers.IsAggregated(att) {
 				aggregatedAtts = append(aggregatedAtts, att)
 			} else {
-				h, err := hashutil.HashProto(att)
+				h, err := ssz.HashTreeRoot(att)
 				if err != nil {
 					return err
 				}
@@ -51,7 +50,7 @@ func (p *AttCaches) AggregateUnaggregatedAttestations() error {
 
 	// Remove the unaggregated attestations from the pool that were successfully aggregated.
 	for _, att := range unaggregatedAtts {
-		h, err := hashutil.HashProto(att)
+		h, err := ssz.HashTreeRoot(att)
 		if err != nil {
 			return err
 		}

--- a/beacon-chain/operations/attestations/kv/aggregated_test.go
+++ b/beacon-chain/operations/attestations/kv/aggregated_test.go
@@ -3,21 +3,45 @@ package kv
 import (
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/prysmaticlabs/prysm/shared/bls"
 )
 
-func TestKV_Aggregated_NotAggregated(t *testing.T) {
+func TestKV_AggregateUnaggregatedAttestations(t *testing.T) {
 	cache := NewAttCaches()
+	priv := bls.RandKey()
+	sig1 := priv.Sign([]byte{'a'})
+	sig2 := priv.Sign([]byte{'b'})
+	att1 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 1}, AggregationBits: bitfield.Bitlist{0b1001}, Signature: sig1.Marshal()}
+	att2 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 1}, AggregationBits: bitfield.Bitlist{0b1010}, Signature: sig1.Marshal()}
+	att3 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 1}, AggregationBits: bitfield.Bitlist{0b1100}, Signature: sig1.Marshal()}
+	att4 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 1}, AggregationBits: bitfield.Bitlist{0b1001}, Signature: sig2.Marshal()}
+	att5 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 2}, AggregationBits: bitfield.Bitlist{0b1001}, Signature: sig1.Marshal()}
+	att6 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 2}, AggregationBits: bitfield.Bitlist{0b1010}, Signature: sig1.Marshal()}
+	att7 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 2}, AggregationBits: bitfield.Bitlist{0b1100}, Signature: sig1.Marshal()}
+	att8 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 2}, AggregationBits: bitfield.Bitlist{0b1001}, Signature: sig2.Marshal()}
+	atts := []*ethpb.Attestation{att1, att2, att3, att4, att5, att6, att7, att8}
+	if err := cache.SaveUnaggregatedAttestations(atts); err != nil {
+		t.Fatal(err)
+	}
+	if err := cache.AggregateUnaggregatedAttestations(); err != nil {
+		t.Fatal(err)
+	}
 
-	att := &ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b11}, Data: &ethpb.AttestationData{}}
-
-	wanted := "attestation is not aggregated"
-	if err := cache.SaveAggregatedAttestation(att); !strings.Contains(err.Error(), wanted) {
-		t.Error("Did not received wanted error")
+	if len(cache.AggregatedAttestationsBySlotIndex(1, 0)) != 1 {
+		t.Fatal("Did not aggregate correctly")
+	}
+	if len(cache.AggregatedAttestationsBySlotIndex(2, 0)) != 1 {
+		t.Fatal("Did not aggregate correctly")
+	}
+	if len(cache.UnAggregatedAttestationsBySlotIndex(1, 0)) != 0 {
+		t.Fatal("Did not clear unaggregated correctly")
+	}
+	if len(cache.UnAggregatedAttestationsBySlotIndex(2, 0)) != 0 {
+		t.Fatal("Did not clear unaggregated correctly")
 	}
 }
 

--- a/beacon-chain/operations/attestations/pool.go
+++ b/beacon-chain/operations/attestations/pool.go
@@ -11,6 +11,7 @@ import (
 // for aggregator actor.
 type Pool interface {
 	// For Aggregated attestations
+	AggregateUnaggregatedAttestations() error
 	SaveAggregatedAttestation(att *ethpb.Attestation) error
 	SaveAggregatedAttestations(atts []*ethpb.Attestation) error
 	AggregatedAttestations() []*ethpb.Attestation

--- a/beacon-chain/operations/attestations/prepare_forkchoice.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -68,10 +67,6 @@ func (s *Service) batchForkChoiceAtts(ctx context.Context) error {
 			return err
 		}
 		attsByDataRoot[attDataRoot] = append(attsByDataRoot[attDataRoot], att)
-	}
-
-	for _, attestations := range attsByDataRoot {
-		fmt.Println(attestations[0].Data.Slot, attestations[0].Data.CommitteeIndex, len(attestations), attestations[0].AggregationBits.Count())
 	}
 
 	for _, atts := range attsByDataRoot {

--- a/beacon-chain/operations/attestations/prepare_forkchoice.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -67,10 +68,18 @@ func (s *Service) batchForkChoiceAtts(ctx context.Context) error {
 		attsByDataRoot[attDataRoot] = append(attsByDataRoot[attDataRoot], att)
 	}
 
+	for _, attestations := range attsByDataRoot {
+		fmt.Println(attestations[0].Data.Slot, attestations[0].Data.CommitteeIndex, len(attestations))
+	}
+
 	for _, atts := range attsByDataRoot {
 		if err := s.aggregateAndSaveForkChoiceAtts(atts); err != nil {
 			return err
 		}
+	}
+
+	if err := s.pool.DeleteUnaggregatedAttestations(s.pool.UnaggregatedAttestations()); err != nil {
+		return err
 	}
 
 	for _, a := range s.pool.BlockAttestations() {

--- a/beacon-chain/operations/attestations/prepare_forkchoice_test.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice_test.go
@@ -98,21 +98,24 @@ func TestBatchAttestations_Multiple(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	wanted, err := helpers.AggregateAttestations([]*ethpb.Attestation{unaggregatedAtts[0], aggregatedAtts[0], blockAtts[0]})
+	wanted, err := helpers.AggregateAttestations([]*ethpb.Attestation{aggregatedAtts[0], blockAtts[0]})
 	if err != nil {
 		t.Fatal(err)
 	}
-	aggregated, err := helpers.AggregateAttestations([]*ethpb.Attestation{unaggregatedAtts[1], aggregatedAtts[1], blockAtts[1]})
+	aggregated, err := helpers.AggregateAttestations([]*ethpb.Attestation{aggregatedAtts[1], blockAtts[1]})
 	if err != nil {
 		t.Fatal(err)
 	}
 	wanted = append(wanted, aggregated...)
-	aggregated, err = helpers.AggregateAttestations([]*ethpb.Attestation{unaggregatedAtts[2], aggregatedAtts[2], blockAtts[2]})
+	aggregated, err = helpers.AggregateAttestations([]*ethpb.Attestation{aggregatedAtts[2], blockAtts[2]})
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	wanted = append(wanted, aggregated...)
+	if err := s.pool.AggregateUnaggregatedAttestations(); err != nil {
+		return
+	}
 	received := s.pool.ForkchoiceAttestations()
 
 	sort.Slice(received, func(i, j int) bool {

--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -59,7 +59,6 @@ func (vs *Server) GetBlock(ctx context.Context, req *ethpb.BlockRequest) (*ethpb
 
 	// Pack aggregated attestations which have not been included in the beacon chain.
 	atts := vs.AttPool.AggregatedAttestations()
-	fmt.Println("atts length  ", len(atts))
 	atts, err = vs.filterAttestationsForBlockInclusion(ctx, req.Slot, atts)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not filter attestations: %v", err)

--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -59,6 +59,7 @@ func (vs *Server) GetBlock(ctx context.Context, req *ethpb.BlockRequest) (*ethpb
 
 	// Pack aggregated attestations which have not been included in the beacon chain.
 	atts := vs.AttPool.AggregatedAttestations()
+	fmt.Println("atts length  ", len(atts))
 	atts, err = vs.filterAttestationsForBlockInclusion(ctx, req.Slot, atts)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not filter attestations: %v", err)


### PR DESCRIPTION
With the newly introduced aggregation on demand feature in v0.11, one of the major wasted compute is duplicated aggregating of unaggregated attestations.  In Prysm beacon node, aggregation of unaggregated attestations happens twice per slot. Once during fork choice and once during aggregator request via RPC. 

Before:
<img width="592" alt="Screen Shot 2020-04-08 at 11 01 53 AM" src="https://user-images.githubusercontent.com/21316537/78817690-611c9e00-7988-11ea-9684-aa60c9655ce6.png">

There's no reason to aggregate twice. This PR efficiently eliminates the second duplication of aggregation

After:
<img width="579" alt="Screen Shot 2020-04-08 at 10 58 35 AM" src="https://user-images.githubusercontent.com/21316537/78817388-ece1fa80-7987-11ea-952c-aa09919a6eba.png">
