### PR TITLE
Return Nil Error if Pre-Genesis in P2P Service Healthz Check

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -61,7 +61,7 @@ const maxBadResponses = 3
 // Service for managing peer to peer (p2p) networking.
 type Service struct {
 	started               bool
-	isPreGenesis          bool // Variable determining if the chain is pre-genesis.
+	isPreGenesis          bool
 	pingMethod            func(ctx context.Context, id peer.ID) error
 	cancel                context.CancelFunc
 	cfg                   *Config

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -304,6 +304,9 @@ func (s *Service) Status() error {
 	if !s.started {
 		return errors.New("not running")
 	}
+	if s.startupErr != nil {
+		return s.startupErr
+	}
 	return nil
 }
 

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -67,6 +67,7 @@ type Service struct {
 	cfg                   *Config
 	startupErr            error
 	dv5Listener           Listener
+	isPreGenesis          bool // Variable determining if the chain is pre-genesis.
 	host                  host.Host
 	pubsub                *pubsub.PubSub
 	exclusionList         *ristretto.Cache
@@ -78,7 +79,6 @@ type Service struct {
 	metaData              *pb.MetaData
 	stateNotifier         statefeed.Notifier
 	pingMethod            func(ctx context.Context, id peer.ID) error
-	isPreGenesis          bool // Variable determining if the chain is pre-genesis.
 }
 
 // NewService initializes a new p2p service compatible with shared.Service interface. No

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -183,11 +183,10 @@ func (s *Service) Start() {
 	if genesisState != nil {
 		s.genesisTime = time.Unix(int64(genesisState.GenesisTime()), 0)
 		s.genesisValidatorsRoot = genesisState.GenesisValidatorRoot()
-		s.isPreGenesis = false
 	} else {
 		s.awaitStateInitialized()
-		s.isPreGenesis = false
 	}
+	s.isPreGenesis = false
 
 	var peersToWatch []string
 	if s.cfg.RelayNodeAddr != "" {

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -60,25 +60,25 @@ const maxBadResponses = 3
 
 // Service for managing peer to peer (p2p) networking.
 type Service struct {
-	beaconDB              db.Database
-	ctx                   context.Context
-	cancel                context.CancelFunc
 	started               bool
-	cfg                   *Config
-	startupErr            error
-	dv5Listener           Listener
 	isPreGenesis          bool // Variable determining if the chain is pre-genesis.
-	host                  host.Host
-	pubsub                *pubsub.PubSub
-	exclusionList         *ristretto.Cache
-	privKey               *ecdsa.PrivateKey
-	dht                   *kaddht.IpfsDHT
+	pingMethod            func(ctx context.Context, id peer.ID) error
+	cancel                context.CancelFunc
+	cfg                   *Config
 	peers                 *peers.Status
+	dht                   *kaddht.IpfsDHT
+	privKey               *ecdsa.PrivateKey
+	exclusionList         *ristretto.Cache
+	metaData              *pb.MetaData
+	pubsub                *pubsub.PubSub
+	beaconDB              db.Database
+	dv5Listener           Listener
+	startupErr            error
+	stateNotifier         statefeed.Notifier
+	ctx                   context.Context
+	host                  host.Host
 	genesisTime           time.Time
 	genesisValidatorsRoot []byte
-	metaData              *pb.MetaData
-	stateNotifier         statefeed.Notifier
-	pingMethod            func(ctx context.Context, id peer.ID) error
 }
 
 // NewService initializes a new p2p service compatible with shared.Service interface. No


### PR DESCRIPTION
No tracking issue. Given the nodes cannot peer until there is a genesis time, we return a healthy status if the chain is pre-genesis in the p2p service Status() function for healthz checks.