### PR TITLE
Release DiscoveryV5 for Testnet Restart

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -105,9 +105,9 @@ var (
 		Usage: "The slot durations of when an archived state gets saved in the DB.",
 		Value: 128,
 	}
-	// EnableDiscv5 enables running discv5.
-	EnableDiscv5 = &cli.BoolFlag{
-		Name:  "enable-discv5",
-		Usage: "Starts dv5 dht.",
+	// DisableDiscv5 disables running discv5.
+	DisableDiscv5 = &cli.BoolFlag{
+		Name:  "disable-discv5",
+		Usage: "Does not run the discoveryV5 dht.",
 	}
 )

--- a/beacon-chain/flags/config.go
+++ b/beacon-chain/flags/config.go
@@ -14,7 +14,7 @@ type GlobalFlags struct {
 	EnableArchivedBlocks              bool
 	EnableArchivedAttestations        bool
 	UnsafeSync                        bool
-	EnableDiscv5                      bool
+	DisableDiscv5                     bool
 	MinimumSyncPeers                  int
 	MaxPageSize                       int
 	DeploymentBlock                   int
@@ -54,8 +54,8 @@ func ConfigureGlobalFlags(ctx *cli.Context) {
 	if ctx.Bool(UnsafeSync.Name) {
 		cfg.UnsafeSync = true
 	}
-	if ctx.Bool(EnableDiscv5.Name) {
-		cfg.EnableDiscv5 = true
+	if ctx.Bool(DisableDiscv5.Name) {
+		cfg.DisableDiscv5 = true
 	}
 	cfg.MaxPageSize = ctx.Int(RPCMaxPageSize.Name)
 	cfg.DeploymentBlock = ctx.Int(ContractDeploymentBlock.Name)

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -38,7 +38,7 @@ var appFlags = []cli.Flag{
 	flags.ContractDeploymentBlock,
 	flags.SetGCPercent,
 	flags.UnsafeSync,
-	flags.EnableDiscv5,
+	flags.DisableDiscv5,
 	flags.InteropMockEth1DataVotesFlag,
 	flags.InteropGenesisStateFlag,
 	flags.InteropNumValidatorsFlag,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -305,7 +305,7 @@ func (b *BeaconNode) registerP2P(ctx *cli.Context) error {
 		MaxPeers:          ctx.Uint(cmd.P2PMaxPeers.Name),
 		WhitelistCIDR:     ctx.String(cmd.P2PWhitelist.Name),
 		EnableUPnP:        ctx.Bool(cmd.EnableUPnPFlag.Name),
-		EnableDiscv5:      ctx.Bool(flags.EnableDiscv5.Name),
+		DisableDiscv5:     ctx.Bool(flags.DisableDiscv5.Name),
 		Encoding:          ctx.String(cmd.P2PEncoding.Name),
 		StateNotifier:     b,
 	})

--- a/beacon-chain/p2p/config.go
+++ b/beacon-chain/p2p/config.go
@@ -11,7 +11,7 @@ type Config struct {
 	BeaconDB              db.Database
 	NoDiscovery           bool
 	EnableUPnP            bool
-	EnableDiscv5          bool
+	DisableDiscv5         bool
 	StaticPeers           []string
 	BootstrapNodeAddr     []string
 	KademliaBootStrapAddr []string

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -201,7 +201,7 @@ func (s *Service) Start() {
 		s.host.ConnManager().Protect(peer.ID, "relay")
 	}
 
-	if (len(s.cfg.Discv5BootStrapAddr) != 0 && !s.cfg.NoDiscovery) || s.cfg.EnableDiscv5 {
+	if !s.cfg.NoDiscovery && !s.cfg.DisableDiscv5 {
 		ipAddr := ipAddr()
 		listener, err := s.startDiscoveryV5(
 			ipAddr,

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -92,7 +92,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.SetGCPercent,
 			flags.UnsafeSync,
 			flags.SlotsPerArchivedPoint,
-			flags.EnableDiscv5,
+			flags.DisableDiscv5,
 		},
 	},
 	{

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -272,6 +272,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedDiscv5Flag = &cli.BoolFlag{
+		Name:   "enable-discv5",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -301,6 +306,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedInitSyncCacheStateFlag,
 	deprecatedProtectAttesterFlag,
 	deprecatedProtectProposerFlag,
+	deprecatedDiscv5Flag,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.


### PR DESCRIPTION
This makes discoveryV5 the default method of discovery in Prysm, and adds in a flag to disable it