### PR TITLE
Fix incorrect proposer slashing domain calculation

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -450,7 +450,7 @@ func ProcessProposerSlashings(
 	return beaconState, nil
 }
 
-// VerifyProposerSlashing verifies that the data provided fro slashing is valid.
+// VerifyProposerSlashing verifies that the data provided from slashing is valid.
 func VerifyProposerSlashing(
 	beaconState *stateTrie.BeaconState,
 	slashing *ethpb.ProposerSlashing,
@@ -472,7 +472,7 @@ func VerifyProposerSlashing(
 		return fmt.Errorf("validator with key %#x is not slashable", proposer.PublicKey)
 	}
 	// Using headerEpoch1 here because both of the headers should have the same epoch.
-	domain, err := helpers.Domain(beaconState.Fork(), helpers.StartSlot(slashing.Header_1.Header.Slot), params.BeaconConfig().DomainBeaconProposer)
+	domain, err := helpers.Domain(beaconState.Fork(), helpers.SlotToEpoch(slashing.Header_1.Header.Slot), params.BeaconConfig().DomainBeaconProposer)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
To calculate domain for `ProposerSlashing`,  it's suppose to use `header.Slot` coverts to epoch, not the start slot of the `header.Slot` which turned out to be `header.Slot * 32`