### PR TITLE
Add probot no-response configuration

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 14
+# Label requiring a response
+responseRequiredLabel: more-information-needed
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. With only the
+  information that is currently in the issue, we don't have enough information
+  to take action. Please reach out if you have or find the answers we need so
+  that we can investigate further.

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -3,7 +3,7 @@
 # Number of days of inactivity before an Issue is closed for lack of response
 daysUntilClose: 14
 # Label requiring a response
-responseRequiredLabel: more-information-needed
+responseRequiredLabel: Need-Info
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable
 closeComment: >
   This issue has been automatically closed because there has been no response


### PR DESCRIPTION
This bot will automatically close issues where we don't have enough information to proceed and the author has not responded in 14 days.

Use the label `Need-Info` to activate this process.