### PR TITLE
Remove next slot requirement for processing attestations

### DIFF
--- a/beacon-chain/blockchain/process_attestation.go
+++ b/beacon-chain/blockchain/process_attestation.go
@@ -108,7 +108,7 @@ func (s *Service) onAttestation(ctx context.Context, a *ethpb.Attestation) ([]ui
 	}
 
 	// Verify attestations can only affect the fork choice of subsequent slots.
-	if err := helpers.VerifySlotTime(genesisTime, a.Data.Slot+1); err != nil {
+	if err := helpers.VerifySlotTime(genesisTime, a.Data.Slot); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Resolves #5359.

There is no need to reject attestations for fork choice if they arrive before their next slot. 
