### PR TITLE
State service clean up - better cold state getter

### DIFF
--- a/beacon-chain/state/stategen/cold.go
+++ b/beacon-chain/state/stategen/cold.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
-	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
@@ -37,9 +36,7 @@ func (s *State) saveColdState(ctx context.Context, blockRoot [32]byte, state *st
 	return nil
 }
 
-// This loads the cold state by block root, it decides whether to load from archived point (faster) or
-// somewhere between archived points (slower) because it requires replaying blocks.
-// This method is more efficient than load cold state by slot.
+// This loads the cold state by block root.
 func (s *State) loadColdStateByRoot(ctx context.Context, blockRoot [32]byte) (*state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "stateGen.loadColdStateByRoot")
 	defer span.End()
@@ -49,168 +46,13 @@ func (s *State) loadColdStateByRoot(ctx context.Context, blockRoot [32]byte) (*s
 		return nil, errors.Wrap(err, "could not get state summary")
 	}
 
-	// Use the archived point state if the summary slot lies on top of the archived point.
-	if summary.Slot%s.slotsPerArchivedPoint == 0 {
-		archivedPoint := summary.Slot / s.slotsPerArchivedPoint
-		s, err := s.loadColdStateByArchivedPoint(ctx, archivedPoint)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get cold state using archived index")
-		}
-		if s == nil {
-			return nil, errUnknownArchivedState
-		}
-		return s, nil
-	}
-
-	return s.loadColdIntermediateStateByRoot(ctx, summary.Slot, blockRoot)
+	return s.ComputeStateUpToSlot(ctx, summary.Slot)
 }
 
-// This loads the cold state for the input archived point.
-func (s *State) loadColdStateByArchivedPoint(ctx context.Context, archivedPoint uint64) (*state.BeaconState, error) {
-	states, err := s.beaconDB.HighestSlotStatesBelow(ctx, archivedPoint*s.slotsPerArchivedPoint+1)
-	if err != nil {
-		return nil, err
-	}
-	return states[0], nil
-}
-
-// This loads a cold state by slot and block root combinations.
-// This is a faster implementation than by slot given the input block root is provided.
-func (s *State) loadColdIntermediateStateByRoot(ctx context.Context, slot uint64, blockRoot [32]byte) (*state.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "stateGen.loadColdIntermediateStateByRoot")
+// This loads a cold state by slot.
+func (s *State) loadColdStateBySlot(ctx context.Context, slot uint64) (*state.BeaconState, error) {
+	ctx, span := trace.StartSpan(ctx, "stateGen.loadColdStateBySlot")
 	defer span.End()
 
-	// Load the archive point for lower side of the intermediate state.
-	lowArchivedPointIdx := slot / s.slotsPerArchivedPoint
-	lowArchivedPointState, err := s.archivedPointByIndex(ctx, lowArchivedPointIdx)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get lower archived state using index")
-	}
-	if lowArchivedPointState == nil {
-		return nil, errUnknownArchivedState
-	}
-
-	replayBlks, err := s.LoadBlocks(ctx, lowArchivedPointState.Slot()+1, slot, blockRoot)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get load blocks for cold state using slot")
-	}
-
-	return s.ReplayBlocks(ctx, lowArchivedPointState, replayBlks, slot)
-}
-
-// This loads a cold state by slot where the slot lies between the archived point.
-// This is a slower implementation given there's no root and slot is the only argument. It requires fetching
-// all the blocks between the archival points.
-func (s *State) loadColdIntermediateStateBySlot(ctx context.Context, slot uint64) (*state.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "stateGen.loadColdIntermediateStateBySlot")
-	defer span.End()
-
-	// Load the archive point for lower and high side of the intermediate state.
-	lowArchivedPointIdx := slot / s.slotsPerArchivedPoint
-	highArchivedPointIdx := lowArchivedPointIdx + 1
-
-	lowArchivedPointState, err := s.archivedPointByIndex(ctx, lowArchivedPointIdx)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get lower bound archived state using index")
-	}
-	if lowArchivedPointState == nil {
-		return nil, errUnknownArchivedState
-	}
-
-	// If the slot of the high archived point lies outside of the split slot, use the split slot and root
-	// for the upper archived point.
-	var highArchivedPointRoot [32]byte
-	highArchivedPointSlot := highArchivedPointIdx * s.slotsPerArchivedPoint
-	if highArchivedPointSlot >= s.splitInfo.slot {
-		highArchivedPointRoot = s.splitInfo.root
-		highArchivedPointSlot = s.splitInfo.slot
-	} else {
-		if _, err := s.archivedPointByIndex(ctx, highArchivedPointIdx); err != nil {
-			return nil, errors.Wrap(err, "could not get upper bound archived state using index")
-		}
-		highArchivedPointRoot = s.beaconDB.ArchivedPointRoot(ctx, highArchivedPointIdx)
-		slot, err := s.blockRootSlot(ctx, highArchivedPointRoot)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get high archived point slot")
-		}
-		highArchivedPointSlot = slot
-	}
-
-	replayBlks, err := s.LoadBlocks(ctx, lowArchivedPointState.Slot()+1, highArchivedPointSlot, highArchivedPointRoot)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not load block for cold state using slot")
-	}
-
-	return s.ReplayBlocks(ctx, lowArchivedPointState, replayBlks, slot)
-}
-
-// Given the archive index, this returns the archived cold state in the DB.
-// If the archived state does not exist in the state, it'll compute it and save it.
-func (s *State) archivedPointByIndex(ctx context.Context, archiveIndex uint64) (*state.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "stateGen.loadArchivedPointByIndex")
-	defer span.End()
-	if s.beaconDB.HasArchivedPoint(ctx, archiveIndex) {
-		return s.loadColdStateByArchivedPoint(ctx, archiveIndex)
-	}
-
-	// If for certain reasons, archived point does not exist in DB,
-	// a node should regenerate it and save it.
-	return s.recoverArchivedPointByIndex(ctx, archiveIndex)
-}
-
-// This recovers an archived point by index. For certain reasons (ex. user toggles feature flag),
-// an archived point may not be present in the DB. This regenerates the archived point state via
-// playback and saves the archived root/state to the DB.
-func (s *State) recoverArchivedPointByIndex(ctx context.Context, archiveIndex uint64) (*state.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "stateGen.recoverArchivedPointByIndex")
-	defer span.End()
-
-	archivedSlot := archiveIndex * s.slotsPerArchivedPoint
-	archivedState, err := s.ComputeStateUpToSlot(ctx, archivedSlot)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not compute state up to archived index slot")
-	}
-	if archivedState == nil {
-		return nil, errUnknownArchivedState
-	}
-	lastRoot, _, err := s.lastSavedBlock(ctx, archivedSlot)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get last valid block up to archived index slot")
-	}
-
-	if err := s.beaconDB.SaveArchivedPointRoot(ctx, lastRoot, archiveIndex); err != nil {
-		return nil, err
-	}
-
-	return archivedState, nil
-}
-
-// Given a block root, this returns the slot of the block root using state summary look up in DB.
-// If state summary does not exist in DB, it will recover the state summary and save it to the DB.
-// This is used to cover corner cases where users toggle new state service's feature flag.
-func (s *State) blockRootSlot(ctx context.Context, blockRoot [32]byte) (uint64, error) {
-	ctx, span := trace.StartSpan(ctx, "stateGen.blockRootSlot")
-	defer span.End()
-
-	if s.StateSummaryExists(ctx, blockRoot) {
-		summary, err := s.stateSummary(ctx, blockRoot)
-		if err != nil {
-			return 0, err
-		}
-		return summary.Slot, nil
-	}
-
-	// Couldn't find state summary in DB. Retry with block bucket to get block slot.
-	b, err := s.beaconDB.Block(ctx, blockRoot)
-	if err != nil {
-		return 0, err
-	}
-	if b == nil || b.Block == nil {
-		return 0, errUnknownBlock
-	}
-	if err := s.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{Root: blockRoot[:], Slot: b.Block.Slot}); err != nil {
-		return 0, errors.Wrap(err, "could not save state summary")
-	}
-
-	return b.Block.Slot, nil
+	return s.ComputeStateUpToSlot(ctx, slot)
 }

--- a/beacon-chain/state/stategen/cold_test.go
+++ b/beacon-chain/state/stategen/cold_test.go
@@ -5,13 +5,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
@@ -65,7 +63,7 @@ func TestLoadColdStateByRoot_NoStateSummary(t *testing.T) {
 	}
 }
 
-func TestLoadColdStateByRoot_ByArchivedPoint(t *testing.T) {
+func TestLoadColdStateByRoot_CanGet(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
 	defer testDB.TeardownDB(t, db)
@@ -83,7 +81,7 @@ func TestLoadColdStateByRoot_ByArchivedPoint(t *testing.T) {
 
 	if err := service.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{
 		Root: blkRoot[:],
-		Slot: 1,
+		Slot: 100,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -92,18 +90,17 @@ func TestLoadColdStateByRoot_ByArchivedPoint(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !proto.Equal(loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe()) {
+	if loadedState.Slot() != 100 {
 		t.Error("Did not correctly save state")
 	}
 }
 
-func TestLoadColdStateByRoot_IntermediatePlayback(t *testing.T) {
+func TestLoadColdStateBySlot_CanGet(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
 	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
-	service.slotsPerArchivedPoint = 2
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	blk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -113,255 +110,11 @@ func TestLoadColdStateByRoot_IntermediatePlayback(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := service.beaconDB.SaveArchivedPointRoot(ctx, [32]byte{}, 1); err != nil {
-		t.Fatal(err)
-	}
-	r := [32]byte{'a'}
-	slot := uint64(3)
-	if err := service.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{
-		Root: r[:],
-		Slot: slot,
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	loadedState, err := service.loadColdStateByRoot(ctx, r)
+	loadedState, err := service.loadColdStateBySlot(ctx, 200)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if loadedState.Slot() != slot {
+	if loadedState.Slot() != 200 {
 		t.Error("Did not correctly save state")
-	}
-}
-
-func TestLoadColdStateBySlotIntermediatePlayback_BeforeCutoff(t *testing.T) {
-	ctx := context.Background()
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
-
-	service := New(db, cache.NewStateSummaryCache())
-	service.slotsPerArchivedPoint = params.BeaconConfig().SlotsPerEpoch * 2
-
-	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
-	blk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
-	blkRoot, _ := ssz.HashTreeRoot(blk.Block)
-	service.beaconDB.SaveGenesisBlockRoot(ctx, blkRoot)
-	if err := service.beaconDB.SaveState(ctx, beaconState, blkRoot); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := service.beaconDB.SaveArchivedPointRoot(ctx, [32]byte{}, 0); err != nil {
-		t.Fatal(err)
-	}
-
-	futureBeaconState, _ := testutil.DeterministicGenesisState(t, 32)
-	futureBeaconState.SetSlot(service.slotsPerArchivedPoint)
-	if err := service.beaconDB.SaveState(ctx, futureBeaconState, [32]byte{'A'}); err != nil {
-		t.Fatal(err)
-	}
-	if err := service.beaconDB.SaveArchivedPointRoot(ctx, [32]byte{'A'}, 1); err != nil {
-		t.Fatal(err)
-	}
-
-	slot := uint64(20)
-	loadedState, err := service.loadColdIntermediateStateBySlot(ctx, slot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if loadedState.Slot() != slot {
-		t.Error("Did not correctly save state")
-	}
-}
-
-func TestLoadColdStateBySlotIntermediatePlayback_AfterCutoff(t *testing.T) {
-	ctx := context.Background()
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
-
-	service := New(db, cache.NewStateSummaryCache())
-	service.slotsPerArchivedPoint = params.BeaconConfig().SlotsPerEpoch
-
-	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
-	blk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
-	blkRoot, _ := ssz.HashTreeRoot(blk.Block)
-	service.beaconDB.SaveGenesisBlockRoot(ctx, blkRoot)
-	if err := service.beaconDB.SaveState(ctx, beaconState, blkRoot); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := service.beaconDB.SaveArchivedPointRoot(ctx, blkRoot, 0); err != nil {
-		t.Fatal(err)
-	}
-
-	slot := uint64(10)
-	loadedState, err := service.loadColdIntermediateStateBySlot(ctx, slot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if loadedState.Slot() != slot {
-		t.Error("Did not correctly save state")
-	}
-}
-
-func TestLoadColdStateByRoot_UnknownArchivedState(t *testing.T) {
-	ctx := context.Background()
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
-
-	service := New(db, cache.NewStateSummaryCache())
-	service.slotsPerArchivedPoint = 1
-	if _, err := service.loadColdIntermediateStateBySlot(ctx, 0); !strings.Contains(err.Error(), errUnknownArchivedState.Error()) {
-		t.Log(err)
-		t.Error("Did not get wanted error")
-	}
-}
-
-func TestArchivedPointByIndex_HasPoint(t *testing.T) {
-	ctx := context.Background()
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
-
-	service := New(db, cache.NewStateSummaryCache())
-	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
-	beaconState.SetSlot(1)
-	index := uint64(999)
-	blk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 1}}
-	blkRoot, _ := ssz.HashTreeRoot(blk.Block)
-	if err := service.beaconDB.SaveArchivedPointRoot(ctx, blkRoot, index); err != nil {
-		t.Fatal(err)
-	}
-	if err := service.beaconDB.SaveState(ctx, beaconState, blkRoot); err != nil {
-		t.Fatal(err)
-	}
-	if err := service.beaconDB.SaveBlock(ctx, blk); err != nil {
-		t.Fatal(err)
-	}
-
-	savedArchivedState, err := service.archivedPointByIndex(ctx, index)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !proto.Equal(beaconState.InnerStateUnsafe(), savedArchivedState.InnerStateUnsafe()) {
-		t.Error("Diff saved state")
-	}
-}
-
-func TestArchivedPointByIndex_DoesntHavePoint(t *testing.T) {
-	ctx := context.Background()
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
-
-	service := New(db, cache.NewStateSummaryCache())
-
-	gBlk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
-	gRoot, err := ssz.HashTreeRoot(gBlk.Block)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := service.beaconDB.SaveBlock(ctx, gBlk); err != nil {
-		t.Fatal(err)
-	}
-	if err := service.beaconDB.SaveGenesisBlockRoot(ctx, gRoot); err != nil {
-		t.Fatal(err)
-	}
-	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
-	if err := service.beaconDB.SaveState(ctx, beaconState, gRoot); err != nil {
-		t.Fatal(err)
-	}
-
-	service.slotsPerArchivedPoint = 32
-	recoveredState, err := service.archivedPointByIndex(ctx, 2)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if recoveredState.Slot() != service.slotsPerArchivedPoint*2 {
-		t.Error("Diff state slot")
-	}
-}
-
-func TestRecoverArchivedPointByIndex_CanRecover(t *testing.T) {
-	ctx := context.Background()
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
-
-	service := New(db, cache.NewStateSummaryCache())
-
-	gBlk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
-	gRoot, err := ssz.HashTreeRoot(gBlk.Block)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := service.beaconDB.SaveBlock(ctx, gBlk); err != nil {
-		t.Fatal(err)
-	}
-	if err := service.beaconDB.SaveGenesisBlockRoot(ctx, gRoot); err != nil {
-		t.Fatal(err)
-	}
-	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
-	if err := service.beaconDB.SaveState(ctx, beaconState, gRoot); err != nil {
-		t.Fatal(err)
-	}
-
-	service.slotsPerArchivedPoint = 32
-	recoveredState, err := service.recoverArchivedPointByIndex(ctx, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if recoveredState.Slot() != service.slotsPerArchivedPoint {
-		t.Error("Diff state slot")
-	}
-}
-
-func TestBlockRootSlot_Exists(t *testing.T) {
-	ctx := context.Background()
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
-
-	service := New(db, cache.NewStateSummaryCache())
-	bRoot := [32]byte{'A'}
-	bSlot := uint64(100)
-	if err := service.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{
-		Slot: bSlot,
-		Root: bRoot[:],
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	slot, err := service.blockRootSlot(ctx, bRoot)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if slot != bSlot {
-		t.Error("Did not get correct block root slot")
-	}
-}
-
-func TestBlockRootSlot_CanRecoverAndSave(t *testing.T) {
-	ctx := context.Background()
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
-
-	service := New(db, cache.NewStateSummaryCache())
-	bSlot := uint64(100)
-	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: bSlot}}
-	bRoot, _ := ssz.HashTreeRoot(b.Block)
-	if err := service.beaconDB.SaveBlock(ctx, b); err != nil {
-		t.Fatal(err)
-	}
-
-	slot, err := service.blockRootSlot(ctx, bRoot)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if slot != bSlot {
-		t.Error("Did not get correct block root slot")
-	}
-
-	// Verify state summary is saved.
-	if !service.beaconDB.HasStateSummary(ctx, bRoot) {
-		t.Error("State summary not saved")
 	}
 }

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -22,12 +22,12 @@ func (s *State) StateByRoot(ctx context.Context, blockRoot [32]byte) (*state.Bea
 		return s.beaconDB.State(ctx, blockRoot)
 	}
 
-	slot, err := s.blockRootSlot(ctx, blockRoot)
+	summary, err := s.stateSummary(ctx, blockRoot)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get state summary")
 	}
 
-	if slot < s.splitInfo.slot {
+	if summary.Slot < s.splitInfo.slot {
 		return s.loadColdStateByRoot(ctx, blockRoot)
 	}
 
@@ -44,7 +44,7 @@ func (s *State) StateBySlot(ctx context.Context, slot uint64) (*state.BeaconStat
 	defer span.End()
 
 	if slot < s.splitInfo.slot {
-		return s.loadColdIntermediateStateBySlot(ctx, slot)
+		return s.loadColdStateBySlot(ctx, slot)
 	}
 
 	return s.loadHotStateBySlot(ctx, slot)
@@ -70,7 +70,23 @@ func (s *State) stateSummary(ctx context.Context, blockRoot [32]byte) (*pb.State
 		}
 	}
 	if summary == nil {
-		return nil, errUnknownStateSummary
+		return s.recoverStateSummary(ctx, blockRoot)
 	}
 	return summary, nil
+}
+
+// This recovers state summary object of a given block root by using the saved block in DB.
+func (s *State) recoverStateSummary(ctx context.Context, blockRoot [32]byte) (*pb.StateSummary, error) {
+	if s.beaconDB.HasBlock(ctx, blockRoot) {
+		b, err := s.beaconDB.Block(ctx, blockRoot)
+		if err != nil {
+			return nil, err
+		}
+		summary := &pb.StateSummary{Slot: b.Block.Slot, Root: blockRoot[:]}
+		if err := s.beaconDB.SaveStateSummary(ctx, summary); err != nil {
+			return nil, err
+		}
+		return summary, nil
+	}
+	return nil, errUnknownStateSummary
 }

--- a/beacon-chain/state/stategen/hot.go
+++ b/beacon-chain/state/stategen/hot.go
@@ -108,6 +108,11 @@ func (s *State) loadHotStateBySlot(ctx context.Context, slot uint64) (*state.Bea
 	ctx, span := trace.StartSpan(ctx, "stateGen.loadHotStateBySlot")
 	defer span.End()
 
+	// Return genesis state if slot is 0.
+	if slot == 0 {
+		return s.beaconDB.GenesisState(ctx)
+	}
+
 	// Gather last saved state, that is where node starts to replay the blocks.
 	startState, err := s.lastSavedState(ctx, slot)
 

--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -41,6 +41,10 @@ func (s *State) ComputeStateUpToSlot(ctx context.Context, targetSlot uint64) (*s
 	if lastState == nil {
 		return nil, errUnknownState
 	}
+	// Short circuit if no block was saved, replay using slots only.
+	if lastBlockSlot == 0 {
+		return s.ReplayBlocks(ctx, lastState, []*ethpb.SignedBeaconBlock{}, targetSlot)
+	}
 
 	// Return if the last valid state's slot is higher than the target slot.
 	if lastState.Slot() >= targetSlot {
@@ -246,7 +250,7 @@ func (s *State) lastSavedBlock(ctx context.Context, slot uint64) ([32]byte, uint
 
 	lastSaved, err := s.beaconDB.HighestSlotBlocksBelow(ctx, slot+1)
 	if err != nil {
-		return [32]byte{}, 0, errUnknownBlock
+		return [32]byte{}, 0, err
 	}
 
 	// Given this is used to query canonical block. There should only be one saved canonical block of a given slot.
@@ -254,7 +258,7 @@ func (s *State) lastSavedBlock(ctx context.Context, slot uint64) ([32]byte, uint
 		return [32]byte{}, 0, fmt.Errorf("highest saved block does not equal to 1, it equals to %d", len(lastSaved))
 	}
 	if lastSaved[0] == nil || lastSaved[0].Block == nil {
-		return [32]byte{}, 0, errUnknownBlock
+		return [32]byte{}, 0, nil
 	}
 	r, err := ssz.HashTreeRoot(lastSaved[0].Block)
 	if err != nil {

--- a/beacon-chain/state/stategen/replay_test.go
+++ b/beacon-chain/state/stategen/replay_test.go
@@ -428,8 +428,12 @@ func TestLastSavedBlock_NoSavedBlock(t *testing.T) {
 		splitInfo: &splitSlotAndRoot{slot: 128},
 	}
 
-	if _, _, err := s.lastSavedBlock(ctx, s.splitInfo.slot+1); err != errUnknownBlock {
-		t.Error("Did not get wanted error")
+	root, slot, err := s.lastSavedBlock(ctx, s.splitInfo.slot+1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slot != 0 && root != [32]byte{} {
+		t.Error("Did not get wanted block")
 	}
 }
 


### PR DESCRIPTION
This PR revamps cold state getters for new state service. 

Change list:
- Modified cold state getters to use `ComputeStateUpToSlot` instead of archived points
- Added a nice helper `recoverStateSummary`
- Added a few short circuits for slot 0 conditions for efficiency 
- Updated tests