### PR TITLE
Set ssz cache enabled by default

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -109,9 +109,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Enabled dynamic attestation committee subnets")
 		cfg.EnableDynamicCommitteeSubnets = true
 	}
-	if ctx.Bool(enableSSZCache.Name) {
-		log.Warn("Enabled unsafe ssz cache")
-		cfg.EnableSSZCache = true
+	cfg.EnableSSZCache = true
+	if ctx.Bool(disableSSZCache.Name) {
+		log.Warn("Disabled ssz cache")
+		cfg.EnableSSZCache = false
 	}
 	if ctx.Bool(enableEth1DataVoteCacheFlag.Name) {
 		log.Warn("Enabled unsafe eth1 data vote cache")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -273,8 +273,8 @@ var (
 		Hidden: true,
 	}
 	deprecatedEnableSSZCache = &cli.BoolFlag{
-		Name:  "enable-ssz-cache",
-		Usage: deprecatedUsage,
+		Name:   "enable-ssz-cache",
+		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
 )

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -32,11 +32,10 @@ var (
 		Name:  "disable-fork-choice-unsafe",
 		Usage: "UNSAFE: disable fork choice for determining head of the beacon chain.",
 	}
-	// enableAttestationCacheFlag see https://github.com/prysmaticlabs/prysm/issues/3106.
-	// enableSSZCache see https://github.com/prysmaticlabs/prysm/pull/4558.
-	enableSSZCache = &cli.BoolFlag{
-		Name:  "enable-ssz-cache",
-		Usage: "Enable ssz state root cache mechanism.",
+	// disableSSZCache see https://github.com/prysmaticlabs/prysm/pull/4558.
+	disableSSZCache = &cli.BoolFlag{
+		Name:  "disable-ssz-cache",
+		Usage: "Disable ssz state root cache mechanism.",
 	}
 	// enableEth1DataVoteCacheFlag see https://github.com/prysmaticlabs/prysm/issues/3106.
 	enableEth1DataVoteCacheFlag = &cli.BoolFlag{
@@ -273,6 +272,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableSSZCache = &cli.BoolFlag{
+		Name:  "enable-ssz-cache",
+		Usage: deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -301,6 +305,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedInitSyncCacheStateFlag,
 	deprecatedProtectAttesterFlag,
 	deprecatedProtectProposerFlag,
+	deprecatedEnableSSZCache,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -324,7 +329,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	writeSSZStateTransitionsFlag,
 	disableForkChoiceUnsafeFlag,
 	enableDynamicCommitteeSubnets,
-	enableSSZCache,
+	disableSSZCache,
 	enableEth1DataVoteCacheFlag,
 	initSyncVerifyEverythingFlag,
 	skipBLSVerifyFlag,
@@ -349,7 +354,6 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.
 var E2EBeaconChainFlags = []string{
-	"--enable-ssz-cache",
 	"--cache-filtered-block-tree",
 	"--enable-eth1-data-vote-cache",
 	"--enable-byte-mempool",


### PR DESCRIPTION
This is now running in prod after fixing race conditions in #5364 and the flag is now considered safe to use. :tada: 

This flag gives a very noticeable improvement in getBlock latency stability with 99 percentile under 2.5s. 

![Screenshot from 2020-04-12 14-13-06](https://user-images.githubusercontent.com/7246818/79080457-dc07f080-7cc9-11ea-90fa-2007d8083051.png)

(Red line indicates when the flag was flipped)