### PR TITLE
Fixed a bug in ActivatedValidatorIndices

### DIFF
--- a/beacon-chain/archiver/service_test.go
+++ b/beacon-chain/archiver/service_test.go
@@ -317,8 +317,8 @@ func TestArchiverService_SavesActivatedValidatorChanges(t *testing.T) {
 	if retrieved == nil {
 		t.Fatal("Retrieved indices are nil")
 	}
-	if !reflect.DeepEqual(retrieved.Activated, []uint64{4, 5}) {
-		t.Errorf("Wanted indices 4 5 activated, received %v", retrieved.Activated)
+	if len(retrieved.Activated) != 98 {
+		t.Error("Did not get wanted active length")
 	}
 	testutil.AssertLogsContain(t, hook, "Successfully archived")
 }

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -169,10 +169,9 @@ func SlashValidator(state *stateTrie.BeaconState, slashedIdx uint64, whistleBlow
 // ActivatedValidatorIndices determines the indices activated during the given epoch.
 func ActivatedValidatorIndices(epoch uint64, validators []*ethpb.Validator) []uint64 {
 	activations := make([]uint64, 0)
-	delayedActivationEpoch := helpers.ActivationExitEpoch(epoch)
 	for i := 0; i < len(validators); i++ {
 		val := validators[i]
-		if val.ActivationEpoch == delayedActivationEpoch {
+		if val.ActivationEpoch <= epoch && epoch < val.ExitEpoch {
 			activations = append(activations, uint64(i))
 		}
 	}

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -223,16 +223,19 @@ func TestActivatedValidatorIndices(t *testing.T) {
 				Slot: 0,
 				Validators: []*ethpb.Validator{
 					{
-						ActivationEpoch: helpers.ActivationExitEpoch(0),
+						ActivationEpoch: 0,
+						ExitEpoch:       1,
 					},
 					{
-						ActivationEpoch: helpers.ActivationExitEpoch(0),
+						ActivationEpoch: 0,
+						ExitEpoch:       1,
 					},
 					{
-						ActivationEpoch: helpers.ActivationExitEpoch(5),
+						ActivationEpoch: 5,
 					},
 					{
-						ActivationEpoch: helpers.ActivationExitEpoch(0),
+						ActivationEpoch: 0,
+						ExitEpoch:       1,
 					},
 				},
 			},
@@ -254,7 +257,8 @@ func TestActivatedValidatorIndices(t *testing.T) {
 				Slot: 0,
 				Validators: []*ethpb.Validator{
 					{
-						ActivationEpoch: helpers.ActivationExitEpoch(0),
+						ActivationEpoch: 0,
+						ExitEpoch:       1,
 					},
 				},
 			},

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -1173,7 +1173,7 @@ func TestServer_GetValidatorActiveSetChanges(t *testing.T) {
 		balance := params.BeaconConfig().MaxEffectiveBalance
 		// Mark indices divisible by two as activated.
 		if i%2 == 0 {
-			activationEpoch = helpers.ActivationExitEpoch(0)
+			activationEpoch = 0
 		} else if i%3 == 0 {
 			// Mark indices divisible by 3 as slashed.
 			withdrawableEpoch = params.BeaconConfig().EpochsPerSlashingsVector


### PR DESCRIPTION
`ActivatedValidatorIndices` was incorrectly implemented, it should be the following and not use `delayedActivationEpoch`  I think this came from the old spec
```python
validator.activation_epoch <= epoch < validator.exit_epoch
```
