### PR TITLE
Pass E2E Tests for v0.11 and Enable Attestation Subnets By Default

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -46,9 +46,8 @@ var _ = shared.Service(&Service{})
 // Check local table every 5 seconds for newly added peers.
 var pollingPeriod = 5 * time.Second
 
-// Refresh rate of ENR set at every quarter of an epoch.
-var refreshRate = time.Duration((params.BeaconConfig().SecondsPerSlot*
-	params.BeaconConfig().SlotsPerEpoch)/4) * time.Second
+// Refresh rate of ENR set at once per slot.
+var refreshRate = time.Duration(params.BeaconConfig().SecondsPerSlot/2) * time.Second
 
 // search limit for number of peers in discovery v5.
 const searchLimit = 100

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -136,6 +136,7 @@ go_test(
         "//shared/attestationutil:go_default_library",
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
+        "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
         "//shared/roughtime:go_default_library",
         "//shared/testutil:go_default_library",

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -288,14 +288,14 @@ func (r *Service) subscribeDynamic(topicFormat string, determineSubsLen func() i
 				wantedSubs := determineSubsLen()
 				// Resize as appropriate.
 				if len(subscriptions) > wantedSubs { // Reduce topics
-					//var cancelSubs []*pubsub.Subscription
-					//subscriptions, cancelSubs = subscriptions[:wantedSubs-1], subscriptions[wantedSubs:]
-					//for i, sub := range cancelSubs {
-					//	sub.Cancel()
-					//	if err := r.p2p.PubSub().UnregisterTopicValidator(fmt.Sprintf(topicFormat, i+wantedSubs)); err != nil {
-					//		log.WithError(err).Error("Failed to unregister topic validator")
-					//	}
-					//}
+					var cancelSubs []*pubsub.Subscription
+					subscriptions, cancelSubs = subscriptions[:wantedSubs-1], subscriptions[wantedSubs:]
+					for i, sub := range cancelSubs {
+						sub.Cancel()
+						if err := r.p2p.PubSub().UnregisterTopicValidator(fmt.Sprintf(topicFormat, i+wantedSubs)); err != nil {
+							log.WithError(err).Error("Failed to unregister topic validator")
+						}
+					}
 				} else if len(subscriptions) < wantedSubs { // Increase topics
 					for i := len(subscriptions); i < wantedSubs; i++ {
 						sub := r.subscribeWithBase(base, fmt.Sprintf(topicFormat, digest, i), validate, handle)

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -12,16 +12,16 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"go.opencensus.io/trace"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/messagehandler"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/roughtime"
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
 	"github.com/prysmaticlabs/prysm/shared/traceutil"
-	"go.opencensus.io/trace"
 )
 
 const pubsubMessageTimeout = 30 * time.Second
@@ -96,20 +96,20 @@ func (r *Service) registerSubscribers() {
 		r.validateAttesterSlashing,
 		r.attesterSlashingSubscriber,
 	)
-	if featureconfig.Get().EnableDynamicCommitteeSubnets {
-		r.subscribeDynamicWithSubnets(
-			"/eth2/%x/committee_index%d_beacon_attestation",
-			r.validateCommitteeIndexBeaconAttestation,   /* validator */
-			r.committeeIndexBeaconAttestationSubscriber, /* message handler */
-		)
-	} else {
-		r.subscribeDynamic(
-			"/eth2/%x/committee_index%d_beacon_attestation",
-			r.committeesCount,                           /* determineSubsLen */
-			r.validateCommitteeIndexBeaconAttestation,   /* validator */
-			r.committeeIndexBeaconAttestationSubscriber, /* message handler */
-		)
-	}
+	//if featureconfig.Get().EnableDynamicCommitteeSubnets {
+	r.subscribeDynamicWithSubnets(
+		"/eth2/%x/committee_index%d_beacon_attestation",
+		r.validateCommitteeIndexBeaconAttestation,   /* validator */
+		r.committeeIndexBeaconAttestationSubscriber, /* message handler */
+	)
+	//} else {
+	//	r.subscribeDynamic(
+	//		"/eth2/%x/committee_index%d_beacon_attestation",
+	//		r.committeesCount,                           /* determineSubsLen */
+	//		r.validateCommitteeIndexBeaconAttestation,   /* validator */
+	//		r.committeeIndexBeaconAttestationSubscriber, /* message handler */
+	//	)
+	//}
 }
 
 // subscribe to a given topic with a given validator and subscription handler.

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/messagehandler"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/roughtime"
@@ -96,20 +97,20 @@ func (r *Service) registerSubscribers() {
 		r.validateAttesterSlashing,
 		r.attesterSlashingSubscriber,
 	)
-	//if featureconfig.Get().EnableDynamicCommitteeSubnets {
-	r.subscribeDynamicWithSubnets(
-		"/eth2/%x/committee_index%d_beacon_attestation",
-		r.validateCommitteeIndexBeaconAttestation,   /* validator */
-		r.committeeIndexBeaconAttestationSubscriber, /* message handler */
-	)
-	//} else {
-	//	r.subscribeDynamic(
-	//		"/eth2/%x/committee_index%d_beacon_attestation",
-	//		r.committeesCount,                           /* determineSubsLen */
-	//		r.validateCommitteeIndexBeaconAttestation,   /* validator */
-	//		r.committeeIndexBeaconAttestationSubscriber, /* message handler */
-	//	)
-	//}
+	if featureconfig.Get().DisableDynamicCommitteeSubnets {
+		r.subscribeDynamic(
+			"/eth2/%x/committee_index%d_beacon_attestation",
+			r.committeesCount,                           /* determineSubsLen */
+			r.validateCommitteeIndexBeaconAttestation,   /* validator */
+			r.committeeIndexBeaconAttestationSubscriber, /* message handler */
+		)
+	} else {
+		r.subscribeDynamicWithSubnets(
+			"/eth2/%x/committee_index%d_beacon_attestation",
+			r.validateCommitteeIndexBeaconAttestation,   /* validator */
+			r.committeeIndexBeaconAttestationSubscriber, /* message handler */
+		)
+	}
 }
 
 // subscribe to a given topic with a given validator and subscription handler.

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -288,14 +288,14 @@ func (r *Service) subscribeDynamic(topicFormat string, determineSubsLen func() i
 				wantedSubs := determineSubsLen()
 				// Resize as appropriate.
 				if len(subscriptions) > wantedSubs { // Reduce topics
-					var cancelSubs []*pubsub.Subscription
-					subscriptions, cancelSubs = subscriptions[:wantedSubs-1], subscriptions[wantedSubs:]
-					for i, sub := range cancelSubs {
-						sub.Cancel()
-						if err := r.p2p.PubSub().UnregisterTopicValidator(fmt.Sprintf(topicFormat, i+wantedSubs)); err != nil {
-							log.WithError(err).Error("Failed to unregister topic validator")
-						}
-					}
+					//var cancelSubs []*pubsub.Subscription
+					//subscriptions, cancelSubs = subscriptions[:wantedSubs-1], subscriptions[wantedSubs:]
+					//for i, sub := range cancelSubs {
+					//	sub.Cancel()
+					//	if err := r.p2p.PubSub().UnregisterTopicValidator(fmt.Sprintf(topicFormat, i+wantedSubs)); err != nil {
+					//		log.WithError(err).Error("Failed to unregister topic validator")
+					//	}
+					//}
 				} else if len(subscriptions) < wantedSubs { // Increase topics
 					for i := len(subscriptions); i < wantedSubs; i++ {
 						sub := r.subscribeWithBase(base, fmt.Sprintf(topicFormat, digest, i), validate, handle)

--- a/beacon-chain/sync/subscriber_committee_index_beacon_attestation_test.go
+++ b/beacon-chain/sync/subscriber_committee_index_beacon_attestation_test.go
@@ -17,11 +17,15 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
 func TestService_committeeIndexBeaconAttestationSubscriber_ValidMessage(t *testing.T) {
 	p := p2ptest.NewTestP2P(t)
+	fc := featureconfig.Get()
+	fc.DisableDynamicCommitteeSubnets = true
+	featureconfig.Init(fc)
 
 	ctx := context.Background()
 	db := dbtest.SetupDB(t)

--- a/endtoend/components/beacon_node.go
+++ b/endtoend/components/beacon_node.go
@@ -54,6 +54,7 @@ func StartNewBeaconNode(t *testing.T, config *types.E2EConfig, index int, enr st
 		fmt.Sprintf("--rpc-max-page-size=%d", params.BeaconConfig().MinGenesisActiveValidatorCount),
 		"--force-clear-db",
 		fmt.Sprintf("--bootstrap-node=%s", enr),
+		"--verbosity debug",
 	}
 	args = append(args, featureconfig.E2EBeaconChainFlags...)
 	args = append(args, config.BeaconFlags...)

--- a/endtoend/components/beacon_node.go
+++ b/endtoend/components/beacon_node.go
@@ -54,7 +54,7 @@ func StartNewBeaconNode(t *testing.T, config *types.E2EConfig, index int, enr st
 		fmt.Sprintf("--rpc-max-page-size=%d", params.BeaconConfig().MinGenesisActiveValidatorCount),
 		"--force-clear-db",
 		fmt.Sprintf("--bootstrap-node=%s", enr),
-		"--verbosity debug",
+		"--verbosity=debug",
 	}
 	args = append(args, featureconfig.E2EBeaconChainFlags...)
 	args = append(args, config.BeaconFlags...)

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -31,7 +31,7 @@ type Flags struct {
 	MinimalConfig                              bool // MinimalConfig as defined in the spec.
 	WriteSSZStateTransitions                   bool // WriteSSZStateTransitions to tmp directory.
 	InitSyncNoVerify                           bool // InitSyncNoVerify when initial syncing w/o verifying block's contents.
-	EnableDynamicCommitteeSubnets              bool // Enables dynamic attestation committee subnets via p2p.
+	DisableDynamicCommitteeSubnets             bool // Disables dynamic attestation committee subnets via p2p.
 	SkipBLSVerify                              bool // Skips BLS verification across the runtime.
 	EnableBackupWebhook                        bool // EnableBackupWebhook to allow database backups to trigger from monitoring port /db/backup.
 	PruneEpochBoundaryStates                   bool // PruneEpochBoundaryStates prunes the epoch boundary state before last finalized check point.
@@ -104,9 +104,9 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("UNSAFE: Disabled fork choice for updating chain head")
 		cfg.DisableForkChoice = true
 	}
-	if ctx.Bool(enableDynamicCommitteeSubnets.Name) {
-		log.Warn("Enabled dynamic attestation committee subnets")
-		cfg.EnableDynamicCommitteeSubnets = true
+	if ctx.Bool(disableDynamicCommitteeSubnets.Name) {
+		log.Warn("Disabled dynamic attestation committee subnets")
+		cfg.DisableDynamicCommitteeSubnets = true
 	}
 	cfg.EnableSSZCache = true
 	if ctx.Bool(disableSSZCache.Name) {

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -17,9 +17,9 @@ var (
 		Name:  "interop-write-ssz-state-transitions",
 		Usage: "Write ssz states to disk after attempted state transition",
 	}
-	enableDynamicCommitteeSubnets = &cli.BoolFlag{
-		Name:  "enable-dynamic-committee-subnets",
-		Usage: "Enable dynamic committee attestation subnets.",
+	disableDynamicCommitteeSubnets = &cli.BoolFlag{
+		Name:  "disable-dynamic-committee-subnets",
+		Usage: "Disable dynamic committee attestation subnets.",
 	}
 	// disableForkChoiceUnsafeFlag disables using the LMD-GHOST fork choice to update
 	// the head of the chain based on attestations and instead accepts any valid received block
@@ -142,6 +142,11 @@ var (
 const deprecatedUsage = "DEPRECATED. DO NOT USE."
 
 var (
+	deprecatedEnableDynamicCommitteeSubnets = &cli.BoolFlag{
+		Name:   "enable-dynamic-committee-subnets",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 	deprecatedNoCustomConfigFlag = &cli.BoolFlag{
 		Name:   "no-custom-config",
 		Usage:  deprecatedUsage,
@@ -286,6 +291,7 @@ var (
 )
 
 var deprecatedFlags = []cli.Flag{
+	deprecatedEnableDynamicCommitteeSubnets,
 	deprecatedNoCustomConfigFlag,
 	deprecatedEnableInitSyncQueue,
 	deprecatedEnableFinalizedBlockRootIndexFlag,
@@ -335,7 +341,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	minimalConfigFlag,
 	writeSSZStateTransitionsFlag,
 	disableForkChoiceUnsafeFlag,
-	enableDynamicCommitteeSubnets,
+	disableDynamicCommitteeSubnets,
 	disableSSZCache,
 	enableEth1DataVoteCacheFlag,
 	initSyncVerifyEverythingFlag,
@@ -367,6 +373,4 @@ var E2EBeaconChainFlags = []string{
 	"--enable-state-gen-sig-verify",
 	"--check-head-state",
 	"--enable-state-field-trie",
-	// TODO(5123): This flag currently fails E2E. Commenting until it's resolved.
-	"--enable-dynamic-committee-subnets",
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -368,5 +368,5 @@ var E2EBeaconChainFlags = []string{
 	"--check-head-state",
 	"--enable-state-field-trie",
 	// TODO(5123): This flag currently fails E2E. Commenting until it's resolved.
-	//"--enable-dynamic-committee-subnets",
+	"--enable-dynamic-committee-subnets",
 }


### PR DESCRIPTION
No tracking issue.

---

# Description

**Write a summary of the changes you are making**

This PR fixes e2e tests for v0.11 and enables attestation committee subnets by default. It increases the refresh rate for node ENRs to twice per slot for a good tolerance necessary to pass tests.