### PR TITLE
Fix eth1data on v0.11

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -144,7 +144,6 @@ func Eth1DataHasEnoughSupport(beaconState *stateTrie.BeaconState, data *ethpb.Et
 		if err != nil {
 			return false, errors.Wrap(err, "could not retrieve eth1 data vote cache")
 		}
-
 	}
 	if voteCount == 0 {
 		for _, vote := range beaconState.Eth1DataVotes() {

--- a/beacon-chain/core/blocks/eth1_data_test.go
+++ b/beacon-chain/core/blocks/eth1_data_test.go
@@ -11,6 +11,17 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
+func FakeDeposits(n int) []*ethpb.Eth1Data {
+	deposits := make([]*ethpb.Eth1Data, n)
+	for i := 0; i < n; i++ {
+		deposits[i] = &ethpb.Eth1Data{
+			DepositCount: 1,
+			DepositRoot:  []byte("root"),
+		}
+	}
+	return deposits
+}
+
 func TestEth1DataHasEnoughSupport(t *testing.T) {
 	tests := []struct {
 		stateVotes         []*ethpb.Eth1Data
@@ -19,43 +30,15 @@ func TestEth1DataHasEnoughSupport(t *testing.T) {
 		votingPeriodLength uint64
 	}{
 		{
-			stateVotes: []*ethpb.Eth1Data{
-				{
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				}, {
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				}, {
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				}, {
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				},
-			},
+			stateVotes: FakeDeposits(4 * int(params.BeaconConfig().SlotsPerEpoch)),
 			data: &ethpb.Eth1Data{
 				DepositCount: 1,
 				DepositRoot:  []byte("root"),
 			},
-			hasSupport:         false,
+			hasSupport:         true,
 			votingPeriodLength: 7,
 		}, {
-			stateVotes: []*ethpb.Eth1Data{
-				{
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				}, {
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				}, {
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				}, {
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				},
-			},
+			stateVotes: FakeDeposits(4 * int(params.BeaconConfig().SlotsPerEpoch)),
 			data: &ethpb.Eth1Data{
 				DepositCount: 1,
 				DepositRoot:  []byte("root"),
@@ -63,21 +46,7 @@ func TestEth1DataHasEnoughSupport(t *testing.T) {
 			hasSupport:         false,
 			votingPeriodLength: 8,
 		}, {
-			stateVotes: []*ethpb.Eth1Data{
-				{
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				}, {
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				}, {
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				}, {
-					DepositCount: 1,
-					DepositRoot:  []byte("root"),
-				},
-			},
+			stateVotes: FakeDeposits(4 * int(params.BeaconConfig().SlotsPerEpoch)),
 			data: &ethpb.Eth1Data{
 				DepositCount: 1,
 				DepositRoot:  []byte("root"),
@@ -103,8 +72,7 @@ func TestEth1DataHasEnoughSupport(t *testing.T) {
 
 			if result != tt.hasSupport {
 				t.Errorf(
-					"blocks.Eth1DataHasEnoughSupport(%+v, %+v) = %t, wanted %t",
-					s,
+					"blocks.Eth1DataHasEnoughSupport(%+v) = %t, wanted %t",
 					tt.data,
 					result,
 					tt.hasSupport,

--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -164,7 +164,7 @@ func (vs *Server) eth1Data(ctx context.Context, slot uint64) (*ethpb.Eth1Data, e
 	eth1DataNotification = false
 
 	eth1VotingPeriodStartTime, _ := vs.Eth1InfoFetcher.Eth2GenesisPowchainInfo()
-	eth1VotingPeriodStartTime += (slot - (slot % params.BeaconConfig().EpochsPerEth1VotingPeriod * params.BeaconConfig().SlotsPerEpoch)) * params.BeaconConfig().SecondsPerSlot
+	eth1VotingPeriodStartTime += (slot - (slot % (params.BeaconConfig().EpochsPerEth1VotingPeriod * params.BeaconConfig().SlotsPerEpoch))) * params.BeaconConfig().SecondsPerSlot
 
 	// Look up most recent block up to timestamp
 	blockNumber, err := vs.Eth1BlockFetcher.BlockNumberByTimestamp(ctx, eth1VotingPeriodStartTime)


### PR DESCRIPTION
This PR resolves a bug introduced in https://github.com/prysmaticlabs/prysm/commit/ec614578eeaa46e95d5bbe1dad9942cf422c7409 for `eth1data`, it would return the wrong starting time for the Eth1VotingPeriod resulting in no eth1 vote getting enough support and no deposits being processed.

Also cleans up the tests to make sure they're properly working.