### PR TITLE
Verify historical states exist in node pkg

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -131,7 +131,6 @@ type Database interface {
 	// Backup and restore methods
 	Backup(ctx context.Context) error
 
-	// HistoricalStatesDeleted verifies historical states exist in DB and is compatible
-	// with user config flags.
+	// HistoricalStatesDeleted verifies historical states exist in DB.
 	HistoricalStatesDeleted(ctx context.Context) error
 }

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -130,4 +130,8 @@ type Database interface {
 
 	// Backup and restore methods
 	Backup(ctx context.Context) error
+
+	// HistoricalStatesDeleted verifies historical states exist in DB and is compatible
+	// with user config flags.
+	HistoricalStatesDeleted(ctx context.Context) error
 }

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -357,3 +357,8 @@ func (e Exporter) SaveLastArchivedIndex(ctx context.Context, index uint64) error
 func (e Exporter) LastArchivedIndex(ctx context.Context) (uint64, error) {
 	return e.db.LastArchivedIndex(ctx)
 }
+
+// HistoricalStatesDeleted -- passthrough
+func (e Exporter) HistoricalStatesDeleted(ctx context.Context) error {
+	return e.db.HistoricalStatesDeleted(ctx)
+}

--- a/beacon-chain/db/kv/check_historical_state.go
+++ b/beacon-chain/db/kv/check_historical_state.go
@@ -11,7 +11,7 @@ import (
 
 var historicalStateDeletedKey = []byte("historical-states-deleted")
 
-func (kv *Store) ensureNewStateServiceCompatible(ctx context.Context) error {
+func (kv *Store) HistoricalStatesDeleted(ctx context.Context) error {
 	if featureconfig.Get().DisableNewStateMgmt {
 		return kv.db.Update(func(tx *bolt.Tx) error {
 			bkt := tx.Bucket(newStateServiceCompatibleBucket)
@@ -32,9 +32,9 @@ func (kv *Store) ensureNewStateServiceCompatible(ctx context.Context) error {
 	regenHistoricalStatesConfirmed := false
 	var err error
 	if historicalStateDeleted {
-		actionText := "--disable-new-state-mgmt was used. To proceed without the flag, the db will need " +
-			"to generate and save historical states. This process may take a while, - do you want to proceed? (Y/N)"
-		deniedText := "Historical states will not be generated. Please continue use --disable-new-state-mgmt"
+		actionText := "--disable-new-state-mgmt was used and historical states were deleted, to proceed without the flag, the db will need " +
+			"to generate and re-save historical states. This process may take a while, - do you want to proceed? (Y/N)"
+		deniedText := "Historical states will not be generated. Please continue using --disable-new-state-mgmt"
 
 		regenHistoricalStatesConfirmed, err = cmd.ConfirmAction(actionText, deniedText)
 		if err != nil {

--- a/beacon-chain/db/kv/check_historical_state.go
+++ b/beacon-chain/db/kv/check_historical_state.go
@@ -11,6 +11,7 @@ import (
 
 var historicalStateDeletedKey = []byte("historical-states-deleted")
 
+// HistoricalStatesDeleted verifies historical states exist in DB.
 func (kv *Store) HistoricalStatesDeleted(ctx context.Context) error {
 	if featureconfig.Get().DisableNewStateMgmt {
 		return kv.db.Update(func(tx *bolt.Tx) error {

--- a/beacon-chain/db/kv/check_historical_state.go
+++ b/beacon-chain/db/kv/check_historical_state.go
@@ -33,7 +33,7 @@ func (kv *Store) HistoricalStatesDeleted(ctx context.Context) error {
 	regenHistoricalStatesConfirmed := false
 	var err error
 	if historicalStateDeleted {
-		actionText := "--disable-new-state-mgmt was used and historical states were deleted, to proceed without the flag, the db will need " +
+		actionText := "--disable-new-state-mgmt was previously used and historical states cannot be found. To proceed without using the flag, the db will need " +
 			"to generate and re-save historical states. This process may take a while, - do you want to proceed? (Y/N)"
 		deniedText := "Historical states will not be generated. Please continue using --disable-new-state-mgmt"
 

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -1,7 +1,6 @@
 package kv
 
 import (
-	"context"
 	"os"
 	"path"
 	"sync"
@@ -117,10 +116,6 @@ func NewKVStore(dirPath string, stateSummaryCache *cache.StateSummaryCache) (*St
 			newStateServiceCompatibleBucket,
 		)
 	}); err != nil {
-		return nil, err
-	}
-
-	if err := kv.ensureNewStateServiceCompatible(context.Background()); err != nil {
 		return nil, err
 	}
 

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -259,7 +259,12 @@ func (b *BeaconNode) startDB(ctx *cli.Context) error {
 		if err != nil {
 			return err
 		}
+	} else {
+		if err := d.HistoricalStatesDeleted(ctx); err != nil {
+			return err
+		}
 	}
+
 	log.WithField("database-path", dbPath).Info("Checking DB")
 	b.db = d
 	b.depositCache = depositcache.NewDepositCache()


### PR DESCRIPTION
With the testnet restart, there's a UX friction when `--clear-db` or `--force-clear-db` is defined on the existing DB used in previous testnet. This PR solves the UX friction by moving `HistoricalStatesDeleted` to `startDB`