### PR TITLE
Fix bad log messages for duplicate deposits

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -156,13 +156,12 @@ func (s *Service) ProcessDepositLog(ctx context.Context, depositLog gethTypes.Lo
 
 	// Make sure duplicates are rejected pre-chainstart.
 	if !s.chainStartData.Chainstarted {
-		var pubkey = fmt.Sprintf("#%x", depositData.PublicKey)
+		var pubkey = fmt.Sprintf("%#x", depositData.PublicKey)
 		if s.depositCache.PubkeyInChainstart(ctx, pubkey) {
-			log.Warnf("Pubkey %#x has already been submitted for chainstart", pubkey)
+			log.WithField("publicKey", pubkey).Warn("Pubkey has already been submitted for chainstart")
 		} else {
 			s.depositCache.MarkPubkeyForChainstart(ctx, pubkey)
 		}
-
 	}
 
 	// We always store all historical deposits in the DB.


### PR DESCRIPTION
If the beacon chain detects a duplicate deposit prior to chainstart it warns of this fact, but the log message as-is prints out the hex value of a text string.

This patch changes the log messages so it prints out the full validator key as a log field, congruent with the message format used for deposits that are included.