### PR TITLE
Fix Panics in P2P Service

### DIFF
--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -226,8 +226,8 @@ func (p *Status) SubscribedToSubnet(index uint64) []peer.ID {
 	peers := make([]peer.ID, 0)
 	for pid, status := range p.status {
 		// look at active peers
-		if status.peerState == PeerConnecting || status.peerState == PeerConnected &&
-			status.metaData != nil {
+		connectedStatus := status.peerState == PeerConnecting || status.peerState == PeerConnected
+		if connectedStatus && status.metaData != nil && status.metaData.Attnets != nil {
 			indices := retrieveIndicesFromBitfield(status.metaData.Attnets)
 			for _, idx := range indices {
 				if idx == index {

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -391,6 +391,10 @@ func (s *Service) RefreshENR(epoch uint64) {
 // with those peers.
 func (s *Service) FindPeersWithSubnet(index uint64) (bool, error) {
 	nodes := make([]*enode.Node, searchLimit)
+	if s.dv5Listener == nil {
+		// return if discovery isn't set
+		return false, nil
+	}
 	num := s.dv5Listener.ReadRandomNodes(nodes)
 	exists := false
 	for _, node := range nodes[:num] {


### PR DESCRIPTION
- [x] Performs nil checks so that in the event discovery is unset, or we have a malformed metadata object the node will not crash