### PR TITLE
Use debug for `Skipping deposit...` log

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -987,7 +987,7 @@ func ProcessDeposit(
 		depositSig := deposit.Data.Signature
 		if err := verifyDepositDataSigningRoot(deposit.Data, pubKey, depositSig, domain); err != nil {
 			// Ignore this error as in the spec pseudo code.
-			log.Errorf("Skipping deposit: could not verify deposit data signature: %v", err)
+			log.Debugf("Skipping deposit: could not verify deposit data signature: %v", err)
 			return beaconState, nil
 		}
 


### PR DESCRIPTION
It's ok to drop this to debug since there's no error in the codebase or impact on the node/chain operaiton