### PR TITLE
Retrieve last ancestor state from DB. (Radical improvement from 5466)

### DIFF
--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -114,7 +114,7 @@ func TestStore_OnAttestation(t *testing.T) {
 			a:             &ethpb.Attestation{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{Root: BlkWithOutStateRoot[:]}}},
 			s:             &pb.BeaconState{},
 			wantErr:       true,
-			wantErrString: "could not get pre state for slot 0: could not get state summary",
+			wantErrString: "could not get pre state for slot 0: could not get ancestor state",
 		},
 		{
 			name: "process attestation doesn't match current epoch",

--- a/beacon-chain/state/stategen/hot.go
+++ b/beacon-chain/state/stategen/hot.go
@@ -149,6 +149,9 @@ func (s *State) lastAncestorState(ctx context.Context, root [32]byte) (*state.Be
 	}
 
 	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		parentRoot := bytesutil.ToBytes32(b.Block.ParentRoot)
 		if s.beaconDB.HasState(ctx, parentRoot) {
 			return s.beaconDB.State(ctx, parentRoot)

--- a/beacon-chain/state/stategen/hot_test.go
+++ b/beacon-chain/state/stategen/hot_test.go
@@ -245,3 +245,60 @@ func TestLoadHoteStateBySlot_CanAdvanceSlotUsingDB(t *testing.T) {
 		t.Error("Did not correctly load state")
 	}
 }
+
+func TestLastAncestorState_CanGet(t *testing.T) {
+	ctx := context.Background()
+	db := testDB.SetupDB(t)
+	defer testDB.TeardownDB(t, db)
+	service := New(db, cache.NewStateSummaryCache())
+
+	b0 := &ethpb.BeaconBlock{Slot: 0, ParentRoot: []byte{'a'}}
+	r0, err := ssz.HashTreeRoot(b0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b1 := &ethpb.BeaconBlock{Slot: 1, ParentRoot: r0[:]}
+	r1, err := ssz.HashTreeRoot(b1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b2 := &ethpb.BeaconBlock{Slot: 2, ParentRoot: r1[:]}
+	r2, err := ssz.HashTreeRoot(b2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b3 := &ethpb.BeaconBlock{Slot: 3, ParentRoot: r2[:]}
+	r3, err := ssz.HashTreeRoot(b3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b1State := testutil.NewBeaconState()
+	if err := b1State.SetSlot(1); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := service.beaconDB.SaveBlock(ctx, &ethpb.SignedBeaconBlock{Block: b0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.beaconDB.SaveBlock(ctx, &ethpb.SignedBeaconBlock{Block: b1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.beaconDB.SaveBlock(ctx, &ethpb.SignedBeaconBlock{Block: b2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.beaconDB.SaveBlock(ctx, &ethpb.SignedBeaconBlock{Block: b3}); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.beaconDB.SaveState(ctx, b1State, r1); err != nil {
+		t.Fatal(err)
+	}
+
+	lastState, err := service.lastAncestorState(ctx, r3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lastState.Slot() != b1State.Slot() {
+		t.Error("Did not get wanted state")
+	}
+}


### PR DESCRIPTION
Radical improvement from #5466. Refactored the recursive lookup of parent state into its own method `lastAncestorState` instead of recursively calling `loadHotStateByRoot`

Tested with the bad DB to verify it works and tested with unit test.

Note: We don't have to merge this before Topez genesis, but we should be merging it soon after genesis. Perhaps 20 finalized epochs