### PR TITLE
Add `HasBlock` to verify parent check

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -71,7 +71,7 @@ func (s *Service) verifyBlkPreState(ctx context.Context, b *ethpb.BeaconBlock) (
 		// during initial syncing. There's no risk given a state summary object is just a
 		// a subset of the block object.
 		if !s.stateGen.StateSummaryExists(ctx, parentRoot) && !s.beaconDB.HasBlock(ctx, parentRoot) {
-			return nil, errors.New("provided block root does not have block saved in the db")
+			return nil, errors.New("could not reconstruct parent state")
 		}
 		preState, err := s.stateGen.StateByRoot(ctx, parentRoot)
 		if err != nil {

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -67,7 +67,10 @@ func (s *Service) verifyBlkPreState(ctx context.Context, b *ethpb.BeaconBlock) (
 
 	if !featureconfig.Get().DisableNewStateMgmt {
 		parentRoot := bytesutil.ToBytes32(b.ParentRoot)
-		if !s.stateGen.StateSummaryExists(ctx, parentRoot) {
+		// Loosen the check to HasBlock because state summary gets saved in batches
+		// during initial syncing. There's no risk given a state summary object is just a
+		// a subset of the block object.
+		if !s.stateGen.StateSummaryExists(ctx, parentRoot) && !s.beaconDB.HasBlock(ctx, parentRoot) {
 			return nil, errors.New("provided block root does not have block saved in the db")
 		}
 		preState, err := s.stateGen.StateByRoot(ctx, parentRoot)

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -88,7 +88,7 @@ func TestStore_OnBlock(t *testing.T) {
 			name:          "parent block root does not have a state",
 			blk:           &ethpb.BeaconBlock{},
 			s:             st.Copy(),
-			wantErrString: "provided block root does not have block saved in the db",
+			wantErrString: "could not reconstruct parent state",
 		},
 		{
 			name:          "block is from the feature",
@@ -354,7 +354,7 @@ func TestCachedPreState_CanGetFromDB(t *testing.T) {
 
 	service.finalizedCheckpt = &ethpb.Checkpoint{Root: r[:]}
 	_, err = service.verifyBlkPreState(ctx, b)
-	wanted := "provided block root does not have block saved in the db"
+	wanted := "could not reconstruct parent state"
 	if err.Error() != wanted {
 		t.Error("Did not get wanted error")
 	}


### PR DESCRIPTION
This fixes #5477 

Added `beaconDB.HasBlock` to `verifyBlkPreState` check. This fixed an edge case that request parent blocks syncing at time epoch 0 encountered

The alternative work around is to always `--force-clear-db` when syncing and the chain is before epoch 1