### PR TITLE
Add back archival endpoint `ListBeaconCommittees` with fallback

### DIFF
--- a/beacon-chain/rpc/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/beacon/BUILD.bazel
@@ -103,7 +103,6 @@ go_test(
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
-        "@in_gopkg_d4l3k_messagediff_v1//:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/beacon/BUILD.bazel
@@ -103,6 +103,7 @@ go_test(
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
+        "@in_gopkg_d4l3k_messagediff_v1//:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/beacon/attestations_test.go
+++ b/beacon-chain/rpc/beacon/attestations_test.go
@@ -1010,6 +1010,7 @@ func TestServer_StreamIndexedAttestations_ContextCanceled(t *testing.T) {
 }
 
 func TestServer_StreamIndexedAttestations_OK(t *testing.T) {
+	params.UseMainnetConfig()
 	db := dbTest.SetupDB(t)
 	defer dbTest.TeardownDB(t, db)
 	exitRoutine := make(chan bool)
@@ -1019,11 +1020,18 @@ func TestServer_StreamIndexedAttestations_OK(t *testing.T) {
 
 	numValidators := 64
 	headState, privKeys := testutil.DeterministicGenesisState(t, uint64(numValidators))
-	randaoMixes := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := 0; i < len(randaoMixes); i++ {
-		randaoMixes[i] = make([]byte, 32)
+	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
+	if err := db.SaveBlock(ctx, b); err != nil {
+		t.Fatal(err)
 	}
-	if err := headState.SetRandaoMixes(randaoMixes); err != nil {
+	gRoot, err := ssz.HashTreeRoot(b.Block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveGenesisBlockRoot(ctx, gRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveState(ctx, headState, gRoot); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1116,6 +1124,7 @@ func TestServer_StreamIndexedAttestations_OK(t *testing.T) {
 		},
 		AttestationNotifier:         chainService.OperationNotifier(),
 		CollectedAttestationsBuffer: make(chan []*ethpb.Attestation, 1),
+		StateGen:                    stategen.New(db, cache.NewStateSummaryCache()),
 	}
 
 	mockStream := mockRPC.NewMockBeaconChain_StreamIndexedAttestationsServer(ctrl)

--- a/beacon-chain/rpc/beacon/committees_test.go
+++ b/beacon-chain/rpc/beacon/committees_test.go
@@ -3,22 +3,22 @@ package beacon
 import (
 	"context"
 	"encoding/binary"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/go-ssz"
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
+	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	dbTest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
-	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/roughtime"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
-	"gopkg.in/d4l3k/messagediff.v1"
 )
 
 func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
@@ -27,23 +27,30 @@ func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
 	helpers.ClearCache()
 
 	numValidators := 128
+	ctx := context.Background()
 	headState := setupActiveValidators(t, db, numValidators)
 
-	randaoMixes := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := 0; i < len(randaoMixes); i++ {
-		randaoMixes[i] = make([]byte, 32)
-	}
-	if err := headState.SetRandaoMixes(randaoMixes); err != nil {
-		t.Fatal(err)
-	}
-
 	m := &mock.ChainService{
-		State:   headState,
 		Genesis: roughtime.Now().Add(time.Duration(-1*int64((headState.Slot()*params.BeaconConfig().SecondsPerSlot))) * time.Second),
 	}
 	bs := &Server{
 		HeadFetcher:        m,
 		GenesisTimeFetcher: m,
+		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+	}
+	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
+	if err := db.SaveBlock(ctx, b); err != nil {
+		t.Fatal(err)
+	}
+	gRoot, err := ssz.HashTreeRoot(b.Block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveGenesisBlockRoot(ctx, gRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveState(ctx, headState, gRoot); err != nil {
+		t.Fatal(err)
 	}
 
 	activeIndices, err := helpers.ActiveValidatorIndices(headState, 0)
@@ -72,172 +79,6 @@ func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
 	}
 	if !proto.Equal(res, wanted) {
 		t.Errorf("Expected %v, received %v", wanted, res)
-	}
-}
-
-func TestServer_ListBeaconCommittees_PreviousEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-	helpers.ClearCache()
-
-	numValidators := 128
-	headState := setupActiveValidators(t, db, numValidators)
-
-	mixes := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := 0; i < len(mixes); i++ {
-		mixes[i] = make([]byte, 32)
-	}
-	if err := headState.SetRandaoMixes(mixes); err != nil {
-		t.Fatal(err)
-	}
-	if err := headState.SetSlot(params.BeaconConfig().SlotsPerEpoch * 2); err != nil {
-		t.Fatal(err)
-	}
-
-	m := &mock.ChainService{
-		State:   headState,
-		Genesis: roughtime.Now().Add(time.Duration(-1*int64((headState.Slot()*params.BeaconConfig().SecondsPerSlot))) * time.Second),
-	}
-	bs := &Server{
-		HeadFetcher:        m,
-		GenesisTimeFetcher: m,
-	}
-
-	activeIndices, err := helpers.ActiveValidatorIndices(headState, 1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	attesterSeed, err := helpers.Seed(headState, 1, params.BeaconConfig().DomainBeaconAttester)
-	if err != nil {
-		t.Fatal(err)
-	}
-	startSlot := helpers.StartSlot(1)
-	wanted, err := computeCommittees(startSlot, activeIndices, attesterSeed)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tests := []struct {
-		req *ethpb.ListCommitteesRequest
-		res *ethpb.BeaconCommittees
-	}{
-		{
-			req: &ethpb.ListCommitteesRequest{
-				QueryFilter: &ethpb.ListCommitteesRequest_Epoch{Epoch: 1},
-			},
-			res: &ethpb.BeaconCommittees{
-				Epoch:                1,
-				Committees:           wanted,
-				ActiveValidatorCount: uint64(numValidators),
-			},
-		},
-	}
-	helpers.ClearCache()
-	for i, test := range tests {
-		res, err := bs.ListBeaconCommittees(context.Background(), test.req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !proto.Equal(res, test.res) {
-			diff, _ := messagediff.PrettyDiff(res, test.res)
-			t.Errorf("%d/ Diff between responses %s", i, diff)
-		}
-	}
-}
-
-func TestServer_ListBeaconCommittees_FromArchive(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-	helpers.ClearCache()
-	ctx := context.Background()
-
-	numValidators := 128
-	balances := make([]uint64, numValidators)
-	validators := make([]*ethpb.Validator, 0, numValidators)
-	for i := 0; i < numValidators; i++ {
-		pubKey := make([]byte, params.BeaconConfig().BLSPubkeyLength)
-		binary.LittleEndian.PutUint64(pubKey, uint64(i))
-		balances[i] = uint64(i)
-		validators = append(validators, &ethpb.Validator{
-			PublicKey:             pubKey,
-			ActivationEpoch:       0,
-			ExitEpoch:             params.BeaconConfig().FarFutureEpoch,
-			WithdrawalCredentials: make([]byte, 32),
-		})
-	}
-	headState, err := stateTrie.InitializeFromProto(&pbp2p.BeaconState{Validators: validators, Balances: balances})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	randaoMixes := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
-	for i := 0; i < len(randaoMixes); i++ {
-		randaoMixes[i] = make([]byte, 32)
-	}
-	if err := headState.SetRandaoMixes(randaoMixes); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := headState.SetSlot(params.BeaconConfig().SlotsPerEpoch * 10); err != nil {
-		t.Fatal(err)
-	}
-
-	// Store the genesis seed.
-	seed, err := helpers.Seed(headState, 0, params.BeaconConfig().DomainBeaconAttester)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := db.SaveArchivedCommitteeInfo(ctx, 0, &pbp2p.ArchivedCommitteeInfo{
-		AttesterSeed: seed[:],
-	}); err != nil {
-		t.Fatal(err)
-	}
-
-	m := &mock.ChainService{
-		State: headState,
-	}
-	bs := &Server{
-		BeaconDB:           db,
-		HeadFetcher:        m,
-		GenesisTimeFetcher: m,
-	}
-
-	activeIndices, err := helpers.ActiveValidatorIndices(headState, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wanted, err := computeCommittees(0, activeIndices, seed)
-	if err != nil {
-		t.Fatal(err)
-	}
-	res1, err := bs.ListBeaconCommittees(context.Background(), &ethpb.ListCommitteesRequest{
-		QueryFilter: &ethpb.ListCommitteesRequest_Genesis{
-			Genesis: true,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	res2, err := bs.ListBeaconCommittees(context.Background(), &ethpb.ListCommitteesRequest{
-		QueryFilter: &ethpb.ListCommitteesRequest_Epoch{
-			Epoch: 0,
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(res1, res2) {
-		t.Fatal(err)
-	}
-	wantedRes := &ethpb.BeaconCommittees{
-		Epoch:                0,
-		Committees:           wanted,
-		ActiveValidatorCount: uint64(numValidators),
-	}
-	if !reflect.DeepEqual(wantedRes, res1) {
-		t.Errorf("Wanted %v", wantedRes)
-		t.Errorf("Received %v", res1)
 	}
 }
 

--- a/beacon-chain/rpc/beacon/committees_test.go
+++ b/beacon-chain/rpc/beacon/committees_test.go
@@ -3,6 +3,7 @@ package beacon
 import (
 	"context"
 	"encoding/binary"
+	"reflect"
 	"testing"
 	"time"
 
@@ -16,9 +17,12 @@ import (
 	dbTest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
+	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/roughtime"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"gopkg.in/d4l3k/messagediff.v1"
 )
 
 func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
@@ -79,6 +83,180 @@ func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
 	}
 	if !proto.Equal(res, wanted) {
 		t.Errorf("Expected %v, received %v", wanted, res)
+	}
+}
+
+func TestServer_ListBeaconCommittees_PreviousEpoch(t *testing.T) {
+	fc := featureconfig.Get()
+	fc.DisableNewStateMgmt = true
+	featureconfig.Init(fc)
+
+	db := dbTest.SetupDB(t)
+	defer dbTest.TeardownDB(t, db)
+	helpers.ClearCache()
+
+	numValidators := 128
+	headState := setupActiveValidators(t, db, numValidators)
+
+	mixes := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
+	for i := 0; i < len(mixes); i++ {
+		mixes[i] = make([]byte, 32)
+	}
+	if err := headState.SetRandaoMixes(mixes); err != nil {
+		t.Fatal(err)
+	}
+	if err := headState.SetSlot(params.BeaconConfig().SlotsPerEpoch * 2); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &mock.ChainService{
+		State:   headState,
+		Genesis: roughtime.Now().Add(time.Duration(-1*int64((headState.Slot()*params.BeaconConfig().SecondsPerSlot))) * time.Second),
+	}
+	bs := &Server{
+		HeadFetcher:        m,
+		GenesisTimeFetcher: m,
+	}
+
+	activeIndices, err := helpers.ActiveValidatorIndices(headState, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attesterSeed, err := helpers.Seed(headState, 1, params.BeaconConfig().DomainBeaconAttester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	startSlot := helpers.StartSlot(1)
+	wanted, err := computeCommittees(startSlot, activeIndices, attesterSeed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		req *ethpb.ListCommitteesRequest
+		res *ethpb.BeaconCommittees
+	}{
+		{
+			req: &ethpb.ListCommitteesRequest{
+				QueryFilter: &ethpb.ListCommitteesRequest_Epoch{Epoch: 1},
+			},
+			res: &ethpb.BeaconCommittees{
+				Epoch:                1,
+				Committees:           wanted,
+				ActiveValidatorCount: uint64(numValidators),
+			},
+		},
+	}
+	helpers.ClearCache()
+	for i, test := range tests {
+		res, err := bs.ListBeaconCommittees(context.Background(), test.req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !proto.Equal(res, test.res) {
+			diff, _ := messagediff.PrettyDiff(res, test.res)
+			t.Errorf("%d/ Diff between responses %s", i, diff)
+		}
+	}
+}
+
+func TestServer_ListBeaconCommittees_FromArchive(t *testing.T) {
+	fc := featureconfig.Get()
+	fc.DisableNewStateMgmt = true
+	featureconfig.Init(fc)
+
+	db := dbTest.SetupDB(t)
+	defer dbTest.TeardownDB(t, db)
+	helpers.ClearCache()
+	ctx := context.Background()
+
+	numValidators := 128
+	balances := make([]uint64, numValidators)
+	validators := make([]*ethpb.Validator, 0, numValidators)
+	for i := 0; i < numValidators; i++ {
+		pubKey := make([]byte, params.BeaconConfig().BLSPubkeyLength)
+		binary.LittleEndian.PutUint64(pubKey, uint64(i))
+		balances[i] = uint64(i)
+		validators = append(validators, &ethpb.Validator{
+			PublicKey:             pubKey,
+			ActivationEpoch:       0,
+			ExitEpoch:             params.BeaconConfig().FarFutureEpoch,
+			WithdrawalCredentials: make([]byte, 32),
+		})
+	}
+	headState, err := stateTrie.InitializeFromProto(&pbp2p.BeaconState{Validators: validators, Balances: balances})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	randaoMixes := make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector)
+	for i := 0; i < len(randaoMixes); i++ {
+		randaoMixes[i] = make([]byte, 32)
+	}
+	if err := headState.SetRandaoMixes(randaoMixes); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := headState.SetSlot(params.BeaconConfig().SlotsPerEpoch * 10); err != nil {
+		t.Fatal(err)
+	}
+
+	// Store the genesis seed.
+	seed, err := helpers.Seed(headState, 0, params.BeaconConfig().DomainBeaconAttester)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.SaveArchivedCommitteeInfo(ctx, 0, &pbp2p.ArchivedCommitteeInfo{
+		AttesterSeed: seed[:],
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &mock.ChainService{
+		State: headState,
+	}
+	bs := &Server{
+		BeaconDB:           db,
+		HeadFetcher:        m,
+		GenesisTimeFetcher: m,
+	}
+
+	activeIndices, err := helpers.ActiveValidatorIndices(headState, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wanted, err := computeCommittees(0, activeIndices, seed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res1, err := bs.ListBeaconCommittees(context.Background(), &ethpb.ListCommitteesRequest{
+		QueryFilter: &ethpb.ListCommitteesRequest_Genesis{
+			Genesis: true,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res2, err := bs.ListBeaconCommittees(context.Background(), &ethpb.ListCommitteesRequest{
+		QueryFilter: &ethpb.ListCommitteesRequest_Epoch{
+			Epoch: 0,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(res1, res2) {
+		t.Fatal(err)
+	}
+	wantedRes := &ethpb.BeaconCommittees{
+		Epoch:                0,
+		Committees:           wanted,
+		ActiveValidatorCount: uint64(numValidators),
+	}
+	if !reflect.DeepEqual(wantedRes, res1) {
+		t.Errorf("Wanted %v", wantedRes)
+		t.Errorf("Received %v", res1)
 	}
 }
 


### PR DESCRIPTION
This PR added back archival end point `ListBeaconCommittees` with a proper fallback when `--disable-new-state-mgmt` is applied
The PR cherry picked #5411 was already approved and the fallback logic was already used in the wild. There's no new logic and nothing substantive here.

Tested first 100 epochs:
<img width="510" alt="Screen Shot 2020-04-19 at 1 15 10 PM" src="https://user-images.githubusercontent.com/21316537/79698881-cd2cbb00-8240-11ea-8017-1aa8c2462a11.png">
