### PR TITLE
add --dev flag

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -28,7 +28,6 @@ var log = logrus.WithField("prefix", "flags")
 
 // Flags is a struct to represent which features the client will perform on runtime.
 type Flags struct {
-	DevMode                                    bool // DevMode enables all development mode features.
 	MinimalConfig                              bool // MinimalConfig as defined in the spec.
 	WriteSSZStateTransitions                   bool // WriteSSZStateTransitions to tmp directory.
 	InitSyncNoVerify                           bool // InitSyncNoVerify when initial syncing w/o verifying block's contents.

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -5,6 +5,10 @@ import (
 )
 
 var (
+	devModeFlag = &cli.BoolFlag{
+		Name:  "dev",
+		Usage: "Enable development mode features.",
+	}
 	broadcastSlashingFlag = &cli.BoolFlag{
 		Name:  "broadcast-slashing",
 		Usage: "Broadcast slashings from slashing pool.",
@@ -143,6 +147,13 @@ var (
 		Usage: "Enables the usage of a new copying method for our state fields.",
 	}
 )
+
+// devModeFlags holds list of flags that are set when development mode is on.
+var devModeFlags = []cli.Flag{
+	enableByteMempool,
+	enableStateRefCopy,
+	enableFieldTrie,
+}
 
 // Deprecated flags list.
 const deprecatedUsage = "DEPRECATED. DO NOT USE."
@@ -343,6 +354,7 @@ var E2EValidatorFlags = []string{
 
 // BeaconChainFlags contains a list of all the feature flags that apply to the beacon-chain client.
 var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
+	devModeFlag,
 	customGenesisDelayFlag,
 	minimalConfigFlag,
 	writeSSZStateTransitionsFlag,

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -7,7 +7,7 @@ import (
 var (
 	devModeFlag = &cli.BoolFlag{
 		Name:  "dev",
-		Usage: "Enable development mode features.",
+		Usage: "Enable experimental features still in development. These features may not be stable.",
 	}
 	broadcastSlashingFlag = &cli.BoolFlag{
 		Name:  "broadcast-slashing",


### PR DESCRIPTION

Resolves #5270

- Adds `--dev` flag to beacon node.
- Currently, it will enable: `--enable-state-ref-copy`, `--enable-state-field-trie`, `--enable-byte-mempool`