### PR TITLE
Log warn instead of return error 

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -210,7 +210,7 @@ func (s *Service) rmStatesOlderThanLastFinalized(ctx context.Context, startSlot 
 	}
 
 	if err := s.beaconDB.DeleteStates(ctx, roots); err != nil {
-		return err
+		log.Warnf("Could not delete states: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
This fixes #5395

Log warn instead of return err if state deletion fails
Noted this code path is only for `--diable-new-state-mgmt` so almost no risk for current master