### PR TITLE
/healthz endpoint accepts JSON now

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1686,3 +1686,9 @@ go_repository(
     sum = "h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=",
     version = "v0.2.0",
 )
+
+go_repository(
+    name = "com_github_golang_gddo",
+    commit = "3c2cc9a6329d9842b3bbdaf307a8110d740cf94c",
+    importpath = "github.com/golang/gddo",
+)

--- a/shared/prometheus/BUILD.bazel
+++ b/shared/prometheus/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "content_negotiation.go",
         "logrus_collector.go",
         "service.go",
         "simple_server.go",
@@ -11,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//shared:go_default_library",
+        "@com_github_golang_gddo//httputil:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",

--- a/shared/prometheus/content_negotiation.go
+++ b/shared/prometheus/content_negotiation.go
@@ -1,0 +1,59 @@
+package prometheus
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/golang/gddo/httputil"
+)
+
+const (
+	contentTypePlainText = "text/plain"
+	contentTypeJSON      = "application/json"
+)
+
+// generatedResponse is a container for response output.
+type generatedResponse struct {
+	// Err is protocol error, if any.
+	Err string `json:"error"`
+
+	// Data is response output, if any.
+	Data interface{} `json:"data"`
+}
+
+// negotiateContentType parses "Accept:" header and returns preferred content type string.
+func negotiateContentType(r *http.Request) string {
+	contentTypes := []string{
+		contentTypePlainText,
+		contentTypeJSON,
+	}
+	return httputil.NegotiateContentType(r, contentTypes, contentTypePlainText)
+}
+
+// writeResponse is content-type aware response writer.
+func writeResponse(w http.ResponseWriter, r *http.Request, response generatedResponse) error {
+	if response.Err != "" {
+		w.WriteHeader(http.StatusInternalServerError)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	switch negotiateContentType(r) {
+	case contentTypePlainText:
+		buf, ok := response.Data.(bytes.Buffer)
+		if !ok {
+			return fmt.Errorf("unexpected data: %v", response.Data)
+		}
+		if _, err := w.Write(buf.Bytes()); err != nil {
+			return fmt.Errorf("could not write response body: %v", err)
+		}
+	case contentTypeJSON:
+		w.Header().Set("Content-Type", contentTypeJSON)
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/shared/prometheus/service.go
+++ b/shared/prometheus/service.go
@@ -52,39 +52,49 @@ func NewPrometheusService(addr string, svcRegistry *shared.ServiceRegistry, addi
 	return s
 }
 
-func (s *Service) healthzHandler(w http.ResponseWriter, _ *http.Request) {
-	// Call all services in the registry.
-	// if any are not OK, write 500
-	// print the statuses of all services.
+func (s *Service) healthzHandler(w http.ResponseWriter, r *http.Request) {
+	response := generatedResponse{}
 
-	statuses := s.svcRegistry.Statuses()
-	hasError := false
-	var buf bytes.Buffer
-	for k, v := range statuses {
-		var status string
-		if v == nil {
-			status = "OK"
-		} else {
-			hasError = true
-			status = "ERROR " + v.Error()
+	type serviceStatus struct {
+		Name   string `json:"service"`
+		Status bool   `json:"status"`
+		Err    string `json:"error"`
+	}
+	var statuses []serviceStatus
+	for k, v := range s.svcRegistry.Statuses() {
+		s := serviceStatus{
+			Name:   fmt.Sprintf("%s", k),
+			Status: true,
 		}
+		if v != nil {
+			s.Status = false
+			s.Err = v.Error()
+		}
+		statuses = append(statuses, s)
+	}
+	response.Data = statuses
 
-		if _, err := buf.WriteString(fmt.Sprintf("%s: %s\n", k, status)); err != nil {
-			hasError = true
+	// Handle plain text content.
+	if contentType := negotiateContentType(r); contentType == contentTypePlainText {
+		var buf bytes.Buffer
+		for _, s := range statuses {
+			var status string
+			if s.Status {
+				status = "OK"
+			} else {
+				status = "ERROR " + s.Err
+			}
+
+			if _, err := buf.WriteString(fmt.Sprintf("%s: %s\n", s.Name, status)); err != nil {
+				response.Err = err.Error()
+				break
+			}
 		}
+		response.Data = buf
 	}
 
-	// Write status header
-	if hasError {
-		w.WriteHeader(http.StatusInternalServerError)
-		log.WithField("statuses", buf.String()).Warn("Node is unhealthy!")
-	} else {
-		w.WriteHeader(http.StatusOK)
-	}
-
-	// Write http body
-	if _, err := w.Write(buf.Bytes()); err != nil {
-		log.Errorf("Could not write healthz body %v", err)
+	if err := writeResponse(w, r, response); err != nil {
+		log.Errorf("Error writing response: %v", err)
 	}
 }
 


### PR DESCRIPTION
Resolves #5546 

- Extends `/healthz` to accept JSON as preferred output.
- By default `text/plain` context type is used, however, when JSON is accepted as response (that's when `Accept: application/json, */*;q=0.5` header is sent), output is JSON:
```json
{
    "data": [
        {
            "error": "",
            "service": "*attestations.Service",
            "status": true
        },
        {
            "error": "",
            "service": "*powchain.Service",
            "status": true
        }
    ],
    "error": ""
}
```
- Fixes the response code as well. [Previously](https://github.com/prysmaticlabs/prysm/blob/19b879ec17b0f73cc8f9ec5d836d1b061db638d1/shared/prometheus/service.go#L79) whenever some service was down HTTP 500 error was returned, this is **incorrect** use of the code (that code is suitable for situations when server cannot complete request due to some problem, in our case server is capable of performing request, and as such `200 OK` is valid code). Each individual service has status field (both in plain and JSON output), as well as error message, so individual services can be checked.
- To keep PR focused, only `/healthz` endpoint is extended (while code was written in a way that it shouldn't be to hard to extend `/metrics` and `/goroutinez` endpoints as well)

