### PR TITLE
Change Validator Status for visible deposit back to DEPOSITED

### DIFF
--- a/beacon-chain/rpc/validator/status.go
+++ b/beacon-chain/rpc/validator/status.go
@@ -102,11 +102,13 @@ func (vs *Server) validatorStatus(ctx context.Context, pubKey []byte, headState 
 			log.Warn("Not connected to ETH1. Cannot determine validator ETH1 deposit block number")
 			return resp
 		}
-
 		_, eth1BlockNumBigInt := vs.DepositFetcher.DepositByPubkey(ctx, pubKey)
 		if eth1BlockNumBigInt == nil { // No deposit found in ETH1.
 			return resp
 		}
+
+		// Mark a validator as DEPOSITED if their deposit is visible.
+		resp.Status = ethpb.ValidatorStatus_DEPOSITED
 
 		resp.Eth1DepositBlockNumber = eth1BlockNumBigInt.Uint64()
 

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -239,13 +239,13 @@ func (v *validator) checkAndLogValidatorStatus(validatorStatuses []*ethpb.Valida
 		}
 		switch status.Status.Status {
 		case ethpb.ValidatorStatus_UNKNOWN_STATUS:
-			log.Info("Waiting for a deposit to be visble by the beacon chain")
+			log.Info("Waiting for deposit to be seen")
 		case ethpb.ValidatorStatus_DEPOSITED:
 			if status.Status.DepositInclusionSlot != 0 {
 				log.WithFields(logrus.Fields{
 					"expectedInclusionSlot":  status.Status.DepositInclusionSlot,
 					"eth1DepositBlockNumber": status.Status.Eth1DepositBlockNumber,
-				}).Info("Waiting for deposit to be processed by the beacon chain")
+				}).Info("Deposit for validator received but not processed into state")
 			} else {
 				log.WithField(
 					"positionInActivationQueue", status.Status.PositionInActivationQueue,

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -239,18 +239,18 @@ func (v *validator) checkAndLogValidatorStatus(validatorStatuses []*ethpb.Valida
 		}
 		switch status.Status.Status {
 		case ethpb.ValidatorStatus_UNKNOWN_STATUS:
+			log.Info("Waiting for a deposit to be visble by the beacon chain")
+		case ethpb.ValidatorStatus_DEPOSITED:
 			if status.Status.DepositInclusionSlot != 0 {
 				log.WithFields(logrus.Fields{
 					"expectedInclusionSlot":  status.Status.DepositInclusionSlot,
 					"eth1DepositBlockNumber": status.Status.Eth1DepositBlockNumber,
 				}).Info("Waiting for deposit to be processed by the beacon chain")
 			} else {
-				log.Info("Waiting for a deposit to be put into an eth1 block")
+				log.WithField(
+					"positionInActivationQueue", status.Status.PositionInActivationQueue,
+				).Info("Deposit processed, entering activation queue after finalization")
 			}
-		case ethpb.ValidatorStatus_DEPOSITED:
-			log.WithField(
-				"positionInActivationQueue", status.Status.PositionInActivationQueue,
-			).Info("Deposit processed, entering activation queue after finalization")
 		case ethpb.ValidatorStatus_PENDING:
 			log.WithFields(logrus.Fields{
 				"positionInActivationQueue": status.Status.PositionInActivationQueue,


### PR DESCRIPTION
This PR undoes a change in #5396 where we changed how a validator was considered DEPOSITED. Understandably it caused some confusion so that change is being reverted so the validator can be shown as DEPOSITED when their eth1 deposit is found.