### PR TITLE
Continue if archival state is not in DB

### DIFF
--- a/beacon-chain/state/stategen/cold.go
+++ b/beacon-chain/state/stategen/cold.go
@@ -18,7 +18,7 @@ func (s *State) saveColdState(ctx context.Context, blockRoot [32]byte, state *st
 	defer span.End()
 
 	if state.Slot()%s.slotsPerArchivedPoint != 0 {
-		return errSlotNonArchivedPoint
+		return nil
 	}
 
 	if err := s.beaconDB.SaveState(ctx, state, blockRoot); err != nil {

--- a/beacon-chain/state/stategen/cold_test.go
+++ b/beacon-chain/state/stategen/cold_test.go
@@ -25,8 +25,8 @@ func TestSaveColdState_NonArchivedPoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := service.saveColdState(ctx, [32]byte{}, beaconState); err != errSlotNonArchivedPoint {
-		t.Error("Did not get wanted error")
+	if err := service.saveColdState(ctx, [32]byte{}, beaconState); err != nil {
+		t.Error(err)
 	}
 }
 

--- a/beacon-chain/state/stategen/migrate.go
+++ b/beacon-chain/state/stategen/migrate.go
@@ -56,17 +56,7 @@ func (s *State) MigrateToCold(ctx context.Context, finalizedSlot uint64, finaliz
 		// Only migrate if current slot is equal to or greater than next archived point slot.
 		if stateSummary.Slot >= nextArchivedPointSlot {
 			if !s.beaconDB.HasState(ctx, r) {
-				recoveredArchivedState, err := s.ComputeStateUpToSlot(ctx, stateSummary.Slot)
-				if err != nil {
-					// For whatever reason if node fails to generate archived state of a certain slot,
-					// a node should just skip that slot rather than fail to whole process block routine.
-					// Missing an archived point of a certain slot is less of a deal than failing process block.
-					log.Warnf("Unable to generate archived state: %v", err)
-					continue
-				}
-				if err := s.beaconDB.SaveState(ctx, recoveredArchivedState.Copy(), r); err != nil {
-					return err
-				}
+				continue
 			}
 			if err := s.beaconDB.SaveArchivedPointRoot(ctx, r, archivedPointIndex); err != nil {
 				return err


### PR DESCRIPTION
This fixes #5555 

When there's a finalized check point, a node enters in a migration phase to delete states that's not on the archival point.  In previous iteration, a node will regenerate the state if the state does not exist on the migration point but that quickly becomes too buggy as the underlying block may not exist as well.

This PR went with the simpler approach to only preserve the state that is on the archival point.