### PR TITLE
fixes issue with ipc path checking

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -163,7 +163,7 @@ type Web3ServiceConfig struct {
 // NewService sets up a new instance with an ethclient when
 // given a web3 endpoint as a string in the config.
 func NewService(ctx context.Context, config *Web3ServiceConfig) (*Service, error) {
-	if !strings.HasPrefix(config.ETH1Endpoint, "ws") && !strings.HasPrefix(config.ETH1Endpoint, "ipc") {
+	if !strings.HasPrefix(config.ETH1Endpoint, "ws") && !strings.HasSuffix(config.ETH1Endpoint, "ipc") {
 		return nil, fmt.Errorf(
 			"powchain service requires either an IPC or WebSocket endpoint, provided %s",
 			config.ETH1Endpoint,


### PR DESCRIPTION
Resolves #5433 

- IPC path normally has `.ipc` extension, so suffix should be checked, but we check prefix (which is ok when it comes to web-sockets, which *start* with `ws://`)