### PR TITLE
Add a 2 second timeout to fetching eth1data

### DIFF
--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"time"
 
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"

--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -174,12 +174,12 @@ func (vs *Server) eth1Data(ctx context.Context, slot uint64) (*ethpb.Eth1Data, e
 	blockNumber, err := vs.Eth1BlockFetcher.BlockNumberByTimestamp(ctx, eth1VotingPeriodStartTime)
 	if err != nil {
 		log.WithError(err).Error("Failed to get block number from timestamp")
-		return vs.randomETH1DataVote(ctx, slot)
+		return vs.randomETH1DataVote(ctx)
 	}
 	eth1Data, err := vs.defaultEth1DataResponse(ctx, blockNumber)
 	if err != nil {
 		log.WithError(err).Error("Failed to get eth1 data from block number")
-		return vs.randomETH1DataVote(ctx, slot)
+		return vs.randomETH1DataVote(ctx)
 	}
 
 	return eth1Data, nil

--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -31,6 +31,8 @@ import (
 // eth1DataNotification is a latch to stop flooding logs with the same warning.
 var eth1DataNotification bool
 
+const eth1dataTimeout = 2 * time.Second
+
 // GetBlock is called by a proposer during its assigned slot to request a block to sign
 // by passing in the slot and the signed randao reveal of the slot.
 func (vs *Server) GetBlock(ctx context.Context, req *ethpb.BlockRequest) (*ethpb.BeaconBlock, error) {
@@ -155,7 +157,7 @@ func (vs *Server) ProposeBlock(ctx context.Context, blk *ethpb.SignedBeaconBlock
 //  - Subtract that eth1block.number by ETH1_FOLLOW_DISTANCE.
 //  - This is the eth1block to use for the block proposal.
 func (vs *Server) eth1Data(ctx context.Context, slot uint64) (*ethpb.Eth1Data, error) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, eth1dataTimeout)
 	defer cancel()
 
 	if vs.MockEth1Votes {

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"math/big"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -1130,9 +1129,8 @@ func TestEth1Data_EmptyVotesFetchBlockHashFailure(t *testing.T) {
 		BlockReceiver:     &mock.ChainService{State: beaconState},
 		HeadFetcher:       &mock.ChainService{State: beaconState},
 	}
-	want := "could not fetch ETH1_FOLLOW_DISTANCE ancestor"
-	if _, err := proposerServer.eth1Data(context.Background(), beaconState.Slot()+1); err == nil || !strings.Contains(err.Error(), want) {
-		t.Errorf("Expected error %v, received %v", want, err)
+	if _, err := proposerServer.eth1Data(context.Background(), beaconState.Slot()+1); err != nil {
+		t.Errorf("A failed request should not have returned an error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
This PR returns a random eth1data vote if the node has an issue retrieving data from eth1 in a timely manner.

Resolves #5521