### PR TITLE
feature default validator keystore path

### DIFF
--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -132,28 +135,62 @@ func Exists(keystorePath string) (bool, error) {
 // CreateValidatorAccount creates a validator account from the given cli context.
 func CreateValidatorAccount(path string, passphrase string) (string, string, error) {
 	if passphrase == "" {
-		reader := bufio.NewReader(os.Stdin)
 		log.Info("Create a new validator account for eth2")
 		log.Info("Enter a password:")
 		bytePassword, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 		if err != nil {
 			log.Fatalf("Could not read account password: %v", err)
+			return path, passphrase, err
 		}
 		text := string(bytePassword)
 		passphrase = strings.Replace(text, "\n", "", -1)
-		log.Infof("Keystore path to save your private keys (leave blank for default %s):", path)
-		text, err = reader.ReadString('\n')
-		if err != nil {
-			log.Fatal(err)
-		}
-		text = strings.Replace(text, "\n", "", -1)
-		if text != "" {
-			path = text
-		}
+
+	}
+
+	if path == "" {
+		path = DefaultValidatorDir()
+	}
+	log.Infof("Keystore path to save your private keys (default: %q):", path)
+	reader := bufio.NewReader(os.Stdin)
+	text, err := reader.ReadString('\n')
+	if err != nil {
+		log.Fatal(err)
+		return path, passphrase, err
+	}
+	if text = strings.Replace(text, "\n", "", -1); text != "" {
+		path = text
 	}
 
 	if err := NewValidatorAccount(path, passphrase); err != nil {
 		return "", "", errors.Wrapf(err, "could not initialize validator account")
 	}
 	return path, passphrase, nil
+}
+
+// DefaultValidatorDir returns OS-specific default keystore directory.
+func DefaultValidatorDir() string {
+	// Try to place the data folder in the user's home dir
+	home := homeDir()
+	if home != "" {
+		if runtime.GOOS == "darwin" {
+			return filepath.Join(home, "Library", "Eth2Validators")
+		} else if runtime.GOOS == "windows" {
+			return filepath.Join(home, "AppData", "Roaming", "Eth2Validators")
+		} else {
+			return filepath.Join(home, ".eth2validators")
+		}
+	}
+	// As we cannot guess a stable location, return empty and handle later
+	return ""
+}
+
+// homeDir returns home directory path.
+func homeDir() string {
+	if home := os.Getenv("HOME"); home != "" {
+		return home
+	}
+	if usr, err := user.Current(); err == nil {
+		return usr.HomeDir
+	}
+	return ""
 }

--- a/validator/keymanager/direct_keystore.go
+++ b/validator/keymanager/direct_keystore.go
@@ -3,9 +3,6 @@ package keymanager
 import (
 	"encoding/json"
 	"os"
-	"os/user"
-	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/prysmaticlabs/prysm/shared/bls"
@@ -46,7 +43,7 @@ func NewKeystore(input string) (KeyManager, string, error) {
 	}
 
 	if opts.Path == "" {
-		opts.Path = defaultValidatorDir()
+		opts.Path = accounts.DefaultValidatorDir()
 	}
 
 	exists, err := accounts.Exists(opts.Path)
@@ -92,30 +89,4 @@ func NewKeystore(input string) (KeyManager, string, error) {
 		km.secretKeys[pubKey] = key.SecretKey
 	}
 	return km, "", nil
-}
-
-func homeDir() string {
-	if home := os.Getenv("HOME"); home != "" {
-		return home
-	}
-	if usr, err := user.Current(); err == nil {
-		return usr.HomeDir
-	}
-	return ""
-}
-
-func defaultValidatorDir() string {
-	// Try to place the data folder in the user's home dir
-	home := homeDir()
-	if home != "" {
-		if runtime.GOOS == "darwin" {
-			return filepath.Join(home, "Library", "Eth2Validators")
-		} else if runtime.GOOS == "windows" {
-			return filepath.Join(home, "AppData", "Roaming", "Eth2Validators")
-		} else {
-			return filepath.Join(home, ".eth2validators")
-		}
-	}
-	// As we cannot guess a stable location, return empty and handle later
-	return ""
 }


### PR DESCRIPTION
Resolves #5438 

- decouples password and keystore path processing logic (previously we had a bug where on empty `--password` flag, keystore path input was expected from user too - even when `--keystore-path` is provided)
- moves `DefaultValidatorDir()` to accounts processing, and allows keystore manager to access it to. Effectively, now it is not required to provide path at all - as it will default to OS-specific one and will be used in both account creation and validator node running
- once this PR is merged, it is advised to cut a new release (so that `prysm.sh` works) and merge (and publish) https://github.com/prysmaticlabs/prysm-testnet-site/pull/117

With this PR, when new validator account creation is requested, it features default path:
![image](https://user-images.githubusercontent.com/188194/80112773-26bb1f80-858a-11ea-83bc-75c7c3e645d0.png)
