### PR TITLE
fixes param concatenation

### DIFF
--- a/prysm.sh
+++ b/prysm.sh
@@ -148,5 +148,5 @@ case $1 in
     ;;
 esac
 
-color "36" "Starting Prysm $1 ${@:2}"
+color "36" "Starting Prysm $1 ${*:2}"
 exec -a "$0" "${process}" "${@:2}"


### PR DESCRIPTION
- When running `prysm.sh validator accounts create` I got strange sequence of chars:
![image](https://user-images.githubusercontent.com/188194/80113948-9aa9f780-858b-11ea-9add-c2e3b505c914.png)

- The problem is that we are concatenating array and string (see https://github.com/koalaman/shellcheck/wiki/SC2145 for more details), so this tiny PR fixes it:
![image](https://user-images.githubusercontent.com/188194/80114108-d349d100-858b-11ea-9674-419e8c0b6ad2.png)
