### PR TITLE
Fix activationEpoch=FarFutureEpoch in validator client logging

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -259,7 +259,7 @@ func (v *validator) checkAndLogValidatorStatus(validatorStatuses []*ethpb.Valida
 			} else {
 				log.WithFields(logrus.Fields{
 					"activationEpoch": status.Status.ActivationEpoch,
-				}).Info("Waiting to be activated")
+				}).Info("Waiting for activation")
 			}
 		case ethpb.ValidatorStatus_ACTIVE:
 			activatedKeys = append(activatedKeys, status.PublicKey)

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -255,7 +255,7 @@ func (v *validator) checkAndLogValidatorStatus(validatorStatuses []*ethpb.Valida
 			if status.Status.ActivationEpoch == params.BeaconConfig().FarFutureEpoch {
 				log.WithFields(logrus.Fields{
 					"positionInActivationQueue": status.Status.PositionInActivationQueue,
-				}).Info("Waiting to assigned activation epoch")
+				}).Info("Waiting to be assigned activation epoch")
 			} else {
 				log.WithFields(logrus.Fields{
 					"activationEpoch": status.Status.ActivationEpoch,

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -252,10 +252,15 @@ func (v *validator) checkAndLogValidatorStatus(validatorStatuses []*ethpb.Valida
 				).Info("Deposit processed, entering activation queue after finalization")
 			}
 		case ethpb.ValidatorStatus_PENDING:
-			log.WithFields(logrus.Fields{
-				"positionInActivationQueue": status.Status.PositionInActivationQueue,
-				"activationEpoch":           status.Status.ActivationEpoch,
-			}).Info("Waiting to be activated")
+			if status.Status.ActivationEpoch == params.BeaconConfig().FarFutureEpoch {
+				log.WithFields(logrus.Fields{
+					"positionInActivationQueue": status.Status.PositionInActivationQueue,
+				}).Info("Waiting to assigned activation epoch")
+			} else {
+				log.WithFields(logrus.Fields{
+					"activationEpoch": status.Status.ActivationEpoch,
+				}).Info("Waiting to be activated")
+			}
 		case ethpb.ValidatorStatus_ACTIVE:
 			activatedKeys = append(activatedKeys, status.PublicKey)
 		case ethpb.ValidatorStatus_EXITED:

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -865,11 +865,23 @@ func TestCheckAndLogValidatorStatus_OK(t *testing.T) {
 				PublicKey: pubKeys[0],
 				Status: &ethpb.ValidatorStatusResponse{
 					Status:                    ethpb.ValidatorStatus_PENDING,
+					ActivationEpoch:           params.BeaconConfig().FarFutureEpoch,
+					PositionInActivationQueue: 6,
+				},
+			},
+			log: "Waiting to be assigned activation epoch\" positionInActivationQueue=6",
+		},
+		{
+			name: "PENDING",
+			status: &ethpb.ValidatorActivationResponse_Status{
+				PublicKey: pubKeys[0],
+				Status: &ethpb.ValidatorStatusResponse{
+					Status:                    ethpb.ValidatorStatus_PENDING,
 					ActivationEpoch:           60,
 					PositionInActivationQueue: 5,
 				},
 			},
-			log: "Waiting to be activated\" activationEpoch=60 positionInActivationQueue=5",
+			log: "Waiting to be activated\" activationEpoch=60",
 		},
 		{
 			name: "EXITED",

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -881,7 +881,7 @@ func TestCheckAndLogValidatorStatus_OK(t *testing.T) {
 					PositionInActivationQueue: 5,
 				},
 			},
-			log: "Waiting to be activated\" activationEpoch=60",
+			log: "Waiting for activation\" activationEpoch=60",
 		},
 		{
 			name: "EXITED",


### PR DESCRIPTION
This PR gets rid of a case where a validator is in the state, past the DEPOSITED state, but still not assigned a ActivationEpoch. I misunderstood how the activation process works.