### PR TITLE
Add GetGenesisValidatorsRoot method

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1305,7 +1305,7 @@ go_repository(
 
 go_repository(
     name = "com_github_prysmaticlabs_ethereumapis",
-    commit = "4685995df20b6d7a926fb98778c940e380db33ee",
+    commit = "867e307fa50f7fc069c19a12073a2f0944a13a30",
     importpath = "github.com/prysmaticlabs/ethereumapis",
 )
 

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -546,6 +546,7 @@ func (b *BeaconNode) registerRPCService(ctx *cli.Context) error {
 		ParticipationFetcher:  chainService,
 		BlockReceiver:         chainService,
 		AttestationReceiver:   chainService,
+		GenesisFetcher:        chainService,
 		GenesisTimeFetcher:    chainService,
 		AttestationsPool:      b.attestationPool,
 		ExitPool:              b.exitPool,

--- a/beacon-chain/rpc/beacon/config.go
+++ b/beacon-chain/rpc/beacon/config.go
@@ -23,3 +23,11 @@ func (bs *Server) GetBeaconConfig(ctx context.Context, _ *ptypes.Empty) (*ethpb.
 		Config: res,
 	}, nil
 }
+
+// GetGenesisValidatorsRoot fetches the genesis validators root, useful for signing
+func (bs *Server) GetGenesisValidatorsRoot(ctx context.Context, _ *ptypes.Empty) (*ethpb.GenesisValidatorsRoot, error) {
+	root := bs.GenesisFetcher.GenesisValidatorRoot()
+	return &ethpb.GenesisValidatorsRoot{
+		Root: root[:],
+	}, nil
+}

--- a/beacon-chain/rpc/beacon/config_test.go
+++ b/beacon-chain/rpc/beacon/config_test.go
@@ -1,12 +1,14 @@
 package beacon
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"reflect"
 	"testing"
 
 	ptypes "github.com/gogo/protobuf/types"
+	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	dbTest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
@@ -33,5 +35,33 @@ func TestServer_GetBeaconConfig(t *testing.T) {
 	// Check that an element is properly populated from the config.
 	if res.Config["Eth1FollowDistance"] != want {
 		t.Errorf("Wanted %s for eth1 follow distance, received %s", want, res.Config["Eth1FollowDistance"])
+	}
+}
+
+func TestServer_GetGenesisValidatorsRoot(t *testing.T) {
+	db := dbTest.SetupDB(t)
+	defer dbTest.TeardownDB(t, db)
+
+	mockedGenesisRoot := [32]byte{
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+		0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+	}
+
+	ctx := context.Background()
+	bs := &Server{
+		GenesisFetcher: &mock.ChainService{
+			ValidatorsRoot: mockedGenesisRoot,
+		},
+	}
+
+	res, err := bs.GetGenesisValidatorsRoot(ctx, &ptypes.Empty{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(mockedGenesisRoot[:], res.Root) {
+		t.Errorf("Incorrect genesis validators root: expected %#v, received %#v", mockedGenesisRoot, res.Root)
 	}
 }

--- a/beacon-chain/rpc/beacon/server.go
+++ b/beacon-chain/rpc/beacon/server.go
@@ -31,6 +31,7 @@ type Server struct {
 	ParticipationFetcher        blockchain.ParticipationFetcher
 	DepositFetcher              depositcache.DepositFetcher
 	BlockFetcher                powchain.POWBlockFetcher
+	GenesisFetcher              blockchain.GenesisFetcher
 	GenesisTimeFetcher          blockchain.TimeFetcher
 	StateNotifier               statefeed.Notifier
 	BlockNotifier               blockfeed.Notifier

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -58,6 +58,7 @@ type Service struct {
 	forkFetcher            blockchain.ForkFetcher
 	finalizationFetcher    blockchain.FinalizationFetcher
 	participationFetcher   blockchain.ParticipationFetcher
+	genesisFetcher         blockchain.GenesisFetcher
 	genesisTimeFetcher     blockchain.TimeFetcher
 	attestationReceiver    blockchain.AttestationReceiver
 	blockReceiver          blockchain.BlockReceiver
@@ -107,6 +108,7 @@ type Config struct {
 	BlockReceiver         blockchain.BlockReceiver
 	POWChainService       powchain.Chain
 	ChainStartFetcher     powchain.ChainStartFetcher
+	GenesisFetcher        blockchain.GenesisFetcher
 	GenesisTimeFetcher    blockchain.TimeFetcher
 	MockEth1Votes         bool
 	AttestationsPool      attestations.Pool
@@ -137,6 +139,7 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		forkFetcher:           cfg.ForkFetcher,
 		finalizationFetcher:   cfg.FinalizationFetcher,
 		participationFetcher:  cfg.ParticipationFetcher,
+		genesisFetcher:        cfg.GenesisFetcher,
 		genesisTimeFetcher:    cfg.GenesisTimeFetcher,
 		attestationReceiver:   cfg.AttestationReceiver,
 		blockReceiver:         cfg.BlockReceiver,
@@ -254,6 +257,7 @@ func (s *Service) Start() {
 		DepositFetcher:              s.depositFetcher,
 		BlockFetcher:                s.powChainService,
 		CanonicalStateChan:          s.canonicalStateChan,
+		GenesisFetcher:              s.genesisFetcher,
 		GenesisTimeFetcher:          s.genesisTimeFetcher,
 		StateNotifier:               s.stateNotifier,
 		BlockNotifier:               s.blockNotifier,

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -34,6 +34,7 @@ func TestLifecycle_OK(t *testing.T) {
 		BlockReceiver:       chainService,
 		AttestationReceiver: chainService,
 		HeadFetcher:         chainService,
+		GenesisFetcher:      chainService,
 		GenesisTimeFetcher:  chainService,
 		POWChainService:     &mockPOW.POWChain{},
 		StateNotifier:       chainService.StateNotifier(),

--- a/shared/mock/beacon_chain_service_mock.go
+++ b/shared/mock/beacon_chain_service_mock.go
@@ -78,6 +78,26 @@ func (mr *MockBeaconChainClientMockRecorder) GetBeaconConfig(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBeaconConfig", reflect.TypeOf((*MockBeaconChainClient)(nil).GetBeaconConfig), varargs...)
 }
 
+// GetGenesisValidatorsRoot mocks base method
+func (m *MockBeaconChainClient) GetGenesisValidatorsRoot(arg0 context.Context, arg1 *empty.Empty, arg2 ...grpc.CallOption) (*v1alpha1.GenesisValidatorsRoot, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetGenesisValidatorsRoot", varargs...)
+	ret0, _ := ret[0].(*v1alpha1.GenesisValidatorsRoot)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGenesisValidatorsRoot indicates an expected call of GetGenesisValidatorsRoot
+func (mr *MockBeaconChainClientMockRecorder) GetGenesisValidatorsRoot(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenesisValidatorsRoot", reflect.TypeOf((*MockBeaconChainClient)(nil).GetGenesisValidatorsRoot), varargs...)
+}
+
 // GetChainHead mocks base method
 func (m *MockBeaconChainClient) GetChainHead(arg0 context.Context, arg1 *empty.Empty, arg2 ...grpc.CallOption) (*v1alpha1.ChainHead, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR adds an implementation of the `GetGenesisValidatorsRoot`that landed in the ethereumapis repository recently.

The purpose of this method is to supply external programs with the genesis validators root.  This value is required for signing or checking signatures of various operations (slashings, voluntary exits _etc._)

This uses the pre-existing `GenesisFetcher` interface to fetch the information from the blockchain service.