### PR TITLE
Increase regen historical state cache size

### DIFF
--- a/beacon-chain/db/kv/regen_historical_states.go
+++ b/beacon-chain/db/kv/regen_historical_states.go
@@ -19,6 +19,11 @@ import (
 	"go.opencensus.io/trace"
 )
 
+// Using max possible size to avoid using DB to save and retrieve pre state (slow)
+// The size is 80 because block at slot 43772 built on top of block at slot 43693.
+// That is the worst case.
+const historicalStatesSize = 80
+
 func (kv *Store) regenHistoricalStates(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "db.regenHistoricalStates")
 	defer span.End()
@@ -57,10 +62,8 @@ func (kv *Store) regenHistoricalStates(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// Using max possible size to avoid using DB to save and retrieve pre state (slow)
-	// The size is 80 because block at slot 43772 built on top of block at slot 43693.
-	// That is the worst case.
-	cacheState, err := lru.New(80)
+
+	cacheState, err := lru.New(historicalStatesSize)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR fixes #5611.  It has no impact to beacon node run time, it only impacts the duration when beacon node is generating and saving historical states. It's 8 mins given current chain length

Change list:
 * Increased cache size from 64 to 80 with rationale
 * Garbage collect at the end of `regenHistoricalStates`