### PR TITLE
validator/accounts: don't ask for keystore path if specified

### DIFF
--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -159,9 +159,9 @@ func CreateValidatorAccount(path string, passphrase string) (string, string, err
 		if text = strings.Replace(text, "\n", "", -1); text != "" {
 			path = text
 		}
-		if err := NewValidatorAccount(path, passphrase); err != nil {
-			return "", "", errors.Wrapf(err, "could not initialize validator account")
-		}
+	}
+	if err := NewValidatorAccount(path, passphrase); err != nil {
+		return "", "", errors.Wrapf(err, "could not initialize validator account")
 	}
 	return path, passphrase, nil
 }

--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -149,20 +149,19 @@ func CreateValidatorAccount(path string, passphrase string) (string, string, err
 
 	if path == "" {
 		path = DefaultValidatorDir()
-	}
-	log.Infof("Keystore path to save your private keys (default: %q):", path)
-	reader := bufio.NewReader(os.Stdin)
-	text, err := reader.ReadString('\n')
-	if err != nil {
-		log.Fatal(err)
-		return path, passphrase, err
-	}
-	if text = strings.Replace(text, "\n", "", -1); text != "" {
-		path = text
-	}
-
-	if err := NewValidatorAccount(path, passphrase); err != nil {
-		return "", "", errors.Wrapf(err, "could not initialize validator account")
+		log.Infof("Please specify a keystore path to save your private keys (default: %q):", path)
+		reader := bufio.NewReader(os.Stdin)
+		text, err := reader.ReadString('\n')
+		if err != nil {
+			log.Fatal(err)
+			return path, passphrase, err
+		}
+		if text = strings.Replace(text, "\n", "", -1); text != "" {
+			path = text
+		}
+		if err := NewValidatorAccount(path, passphrase); err != nil {
+			return "", "", errors.Wrapf(err, "could not initialize validator account")
+		}
 	}
 	return path, passphrase, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

Usability

**What does this PR do? Why is it needed?**

If you run a validator with `--keystore-path` it still asks you for a keystore path. 

This PR improves usability in two ways:
1. It does not ask you to confirm the path if you already specified one.
2. It clarifies the wording that user interaction is necessary (_"Please specify ..."_).

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

As discussed on Discord with  @nisdas 