### PR TITLE
Terminate bootnode after E2E test completion

### DIFF
--- a/endtoend/endtoend_test.go
+++ b/endtoend/endtoend_test.go
@@ -30,11 +30,11 @@ func runEndToEndTest(t *testing.T, config *types.E2EConfig) {
 	t.Logf("Log Path: %s\n\n", e2e.TestParams.LogPath)
 
 	keystorePath, eth1PID := components.StartEth1Node(t)
-	bootnodeENR, _ := components.StartBootnode(t)
+	bootnodeENR, bootnodePID := components.StartBootnode(t)
 	bProcessIDs := components.StartBeaconNodes(t, config, bootnodeENR)
 	valProcessIDs := components.StartValidatorClients(t, config, keystorePath)
 	processIDs := append(valProcessIDs, bProcessIDs...)
-	processIDs = append(processIDs, eth1PID)
+	processIDs = append(processIDs, []int{eth1PID, bootnodePID}...)
 	defer helpers.LogOutput(t, config)
 	defer helpers.KillProcesses(t, processIDs)
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
This PR solves an issue for the long running E2E where the bootnode process would not be terminated and conflict with any other tests on that shard. This changes E2E to terminate it with everything else.
