### PR TITLE
Empty Committee Check in Submit Attestation

### DIFF
--- a/validator/client/validator_attest.go
+++ b/validator/client/validator_attest.go
@@ -67,6 +67,10 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		}
 		return
 	}
+	if len(duty.Committee) == 0 {
+		log.Debug("Empty committee for validator duty, not attesting")
+		return
+	}
 
 	v.waitToSlotOneThird(ctx, slot)
 

--- a/validator/client/validator_attest_test.go
+++ b/validator/client/validator_attest_test.go
@@ -31,7 +31,23 @@ func TestRequestAttestation_ValidatorDutiesRequestFailure(t *testing.T) {
 	testutil.AssertLogsContain(t, hook, "Could not fetch validator assignment")
 }
 
-func TestAttestToBlockHead_SubmitAttestationRequestFailure(t *testing.T) {
+func TestAttestToBlockHead_SubmitAttestation_EmptyCommittee(t *testing.T) {
+	hook := logTest.NewGlobal()
+
+	validator, _, finish := setup(t)
+	defer finish()
+	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
+		{
+			PublicKey:      validatorKey.PublicKey.Marshal(),
+			CommitteeIndex: 0,
+			Committee:      make([]uint64, 0),
+			ValidatorIndex: 0,
+		}}}
+	validator.SubmitAttestation(context.Background(), 0, validatorPubKey)
+	testutil.AssertLogsContain(t, hook, "Empty committee")
+}
+
+func TestAttestToBlockHead_SubmitAttestation_RequestFailure(t *testing.T) {
 	hook := logTest.NewGlobal()
 
 	validator, m, finish := setup(t)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Sometimes due to a node disconnection or other timing-related issue, we get an empty duty with an empty committee when a validator attempts to attest. Instead of logging a scary error of `[2020-04-17 20:00:05] ERROR validator: Validator ID 0 not found in committee of [] pubKey=0xb4cffec577dd slot=0`, we emit a debug-level log that a received committee was empty in the duty value and exit the function early.

**Which issues(s) does this PR fix?**

Fixes #5481 

