### PR TITLE
beacon/log: augment logs with block roots

### DIFF
--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -1,6 +1,7 @@
 package blockchain
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -21,7 +22,17 @@ func logStateTransitionData(b *ethpb.BeaconBlock) {
 		"attesterSlashings": len(b.Body.AttesterSlashings),
 		"proposerSlashings": len(b.Body.ProposerSlashings),
 		"voluntaryExits":    len(b.Body.VoluntaryExits),
-	}).Info("Finished applying state transition")
+	}).Debug("Finished applying state transition")
+}
+
+func logSyncStatus(block *ethpb.BeaconBlock, blockRoot [32]byte, finalized *ethpb.Checkpoint) {
+	log.WithFields(logrus.Fields{
+		"slot":           block.Slot,
+		"block":          fmt.Sprintf("0x%s...", hex.EncodeToString(blockRoot[:])[:8]),
+		"epoch":          helpers.SlotToEpoch(block.Slot),
+		"finalizedEpoch": finalized.Epoch,
+		"finalizedRoot":  fmt.Sprintf("0x%s...", hex.EncodeToString(finalized.Root[:])[:8]),
+	}).Info("Synced")
 }
 
 func logEpochData(beaconState *stateTrie.BeaconState) {

--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -16,7 +16,6 @@ var log = logrus.WithField("prefix", "blockchain")
 // logs state transition related data every slot.
 func logStateTransitionData(b *ethpb.BeaconBlock) {
 	log.WithFields(logrus.Fields{
-		"slot":              b.Slot,
 		"attestations":      len(b.Body.Attestations),
 		"deposits":          len(b.Body.Deposits),
 		"attesterSlashings": len(b.Body.AttesterSlashings),
@@ -25,14 +24,14 @@ func logStateTransitionData(b *ethpb.BeaconBlock) {
 	}).Info("Finished applying state transition")
 }
 
-func logSyncStatus(block *ethpb.BeaconBlock, blockRoot [32]byte, finalized *ethpb.Checkpoint) {
+func logBlockSyncStatus(block *ethpb.BeaconBlock, blockRoot [32]byte, finalized *ethpb.Checkpoint) {
 	log.WithFields(logrus.Fields{
 		"slot":           block.Slot,
 		"block":          fmt.Sprintf("0x%s...", hex.EncodeToString(blockRoot[:])[:8]),
 		"epoch":          helpers.SlotToEpoch(block.Slot),
 		"finalizedEpoch": finalized.Epoch,
 		"finalizedRoot":  fmt.Sprintf("0x%s...", hex.EncodeToString(finalized.Root[:])[:8]),
-	}).Info("Synced")
+	}).Info("Synced new block")
 }
 
 func logEpochData(beaconState *stateTrie.BeaconState) {

--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -22,7 +22,7 @@ func logStateTransitionData(b *ethpb.BeaconBlock) {
 		"attesterSlashings": len(b.Body.AttesterSlashings),
 		"proposerSlashings": len(b.Body.ProposerSlashings),
 		"voluntaryExits":    len(b.Body.VoluntaryExits),
-	}).Debug("Finished applying state transition")
+	}).Info("Finished applying state transition")
 }
 
 func logSyncStatus(block *ethpb.BeaconBlock, blockRoot [32]byte, finalized *ethpb.Checkpoint) {

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -77,7 +77,7 @@ func (s *Service) onBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock) 
 	log.WithFields(logrus.Fields{
 		"slot": b.Slot,
 		"root": fmt.Sprintf("0x%s...", hex.EncodeToString(root[:])[:8]),
-	}).Info("Executing state transition on block")
+	}).Debug("Executing state transition on block")
 
 	postState, err := state.ExecuteStateTransition(ctx, preState, signed)
 	if err != nil {

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -118,11 +118,11 @@ func (s *Service) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.SignedB
 	// Reports on block and fork choice metrics.
 	reportSlotMetrics(blockCopy.Block.Slot, s.headSlot(), s.CurrentSlot(), s.finalizedCheckpt)
 
+	// Log block sync status.
+	logBlockSyncStatus(blockCopy.Block, root, s.finalizedCheckpt)
+
 	// Log state transition data.
 	logStateTransitionData(blockCopy.Block)
-
-	// Log sync status.
-	logSyncStatus(blockCopy.Block, root, s.finalizedCheckpt)
 
 	return nil
 }
@@ -171,11 +171,11 @@ func (s *Service) ReceiveBlockNoPubsubForkchoice(ctx context.Context, block *eth
 	// Reports on block and fork choice metrics.
 	reportSlotMetrics(blockCopy.Block.Slot, s.headSlot(), s.CurrentSlot(), s.finalizedCheckpt)
 
+	// Log block sync status.
+	logBlockSyncStatus(blockCopy.Block, root, s.finalizedCheckpt)
+
 	// Log state transition data.
 	logStateTransitionData(blockCopy.Block)
-
-	// Log sync status.
-	logSyncStatus(blockCopy.Block, root, s.finalizedCheckpt)
 
 	s.epochParticipationLock.Lock()
 	defer s.epochParticipationLock.Unlock()

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -121,6 +121,9 @@ func (s *Service) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.SignedB
 	// Log state transition data.
 	logStateTransitionData(blockCopy.Block)
 
+	// Log sync status.
+	logSyncStatus(blockCopy.Block, root, s.finalizedCheckpt)
+
 	return nil
 }
 
@@ -170,6 +173,9 @@ func (s *Service) ReceiveBlockNoPubsubForkchoice(ctx context.Context, block *eth
 
 	// Log state transition data.
 	logStateTransitionData(blockCopy.Block)
+
+	// Log sync status.
+	logSyncStatus(blockCopy.Block, root, s.finalizedCheckpt)
 
 	s.epochParticipationLock.Lock()
 	defer s.epochParticipationLock.Unlock()

--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/flags:go_default_library",
         "//beacon-chain/p2p:go_default_library",
+        "//beacon-chain/state/stateutil:go_default_library",
         "//beacon-chain/sync:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared:go_default_library",

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -130,7 +130,7 @@ func (r *Service) processPendingBlocks(ctx context.Context) error {
 		log.WithFields(logrus.Fields{
 			"slot":      s,
 			"blockRoot": hex.EncodeToString(bytesutil.Trunc(blkRoot[:])),
-		}).Info("Processed pending block and cleared it in cache")
+		}).Debug("Processed pending block and cleared it in cache")
 
 		span.End()
 	}


### PR DESCRIPTION

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR augments sync logs with some additional information that helps identifying the best block and epoch without increasing verbosity but also by avoiding too much log spam.

This PR is the sister of https://github.com/sigp/lighthouse/pull/1084

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

Initial Sync:
![Screenshot at 2020-04-29 16-13-38](https://user-images.githubusercontent.com/58883403/80606885-1648f000-8a35-11ea-8d94-187c638ceb61.png)

New Blocks Received: 
![Screenshot at 2020-04-29 16-24-04](https://user-images.githubusercontent.com/58883403/80607542-ed752a80-8a35-11ea-9893-cdc48979e3cf.png)
