### PR TITLE
[v0.12] Add Schlesi Testnet Preset

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -29,6 +29,7 @@ var log = logrus.WithField("prefix", "flags")
 // Flags is a struct to represent which features the client will perform on runtime.
 type Flags struct {
 	MinimalConfig                              bool // MinimalConfig as defined in the spec.
+	SchlesiTestnet                             bool // SchlesiTestnet preconfigured spec.
 	WriteSSZStateTransitions                   bool // WriteSSZStateTransitions to tmp directory.
 	InitSyncNoVerify                           bool // InitSyncNoVerify when initial syncing w/o verifying block's contents.
 	DisableDynamicCommitteeSubnets             bool // Disables dynamic attestation committee subnets via p2p.
@@ -90,6 +91,7 @@ func Init(c *Flags) {
 func (c *Flags) Copy() *Flags {
 	return &Flags{
 		MinimalConfig:                              c.MinimalConfig,
+		SchlesiTestnet:                             c.SchlesiTestnet,
 		WriteSSZStateTransitions:                   c.WriteSSZStateTransitions,
 		InitSyncNoVerify:                           c.InitSyncNoVerify,
 		DisableDynamicCommitteeSubnets:             c.DisableDynamicCommitteeSubnets,
@@ -300,6 +302,10 @@ func configureConfig(ctx *cli.Context, cfg *Flags) *Flags {
 		log.Warn("Using minimal config")
 		cfg.MinimalConfig = true
 		params.UseMinimalConfig()
+	} else if ctx.Bool(schlesiTestnetFlag.Name) {
+		log.Warn("Using schlesi testnet config")
+		cfg.SchlesiTestnet = true
+		params.UseSchlesiTestnet()
 	} else {
 		log.Warn("Using default mainnet config")
 	}

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -17,6 +17,10 @@ var (
 		Name:  "minimal-config",
 		Usage: "Use minimal config with parameters as defined in the spec.",
 	}
+	schlesiTestnetFlag = &cli.BoolFlag{
+		Name:  "schlesi-config",
+		Usage: "Use the preconfigured Schlesi multi-client testnet spec.",
+	}
 	writeSSZStateTransitionsFlag = &cli.BoolFlag{
 		Name:  "interop-write-ssz-state-transitions",
 		Usage: "Write ssz states to disk after attempted state transition",
@@ -352,6 +356,7 @@ var deprecatedFlags = []cli.Flag{
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
 var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	minimalConfigFlag,
+	schlesiTestnetFlag,
 	disableProtectAttesterFlag,
 	disableProtectProposerFlag,
 	enableDomainDataCacheFlag,
@@ -372,6 +377,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	devModeFlag,
 	customGenesisDelayFlag,
 	minimalConfigFlag,
+	schlesiTestnetFlag,
 	writeSSZStateTransitionsFlag,
 	disableForkChoiceUnsafeFlag,
 	disableDynamicCommitteeSubnets,

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -18,7 +18,7 @@ var (
 		Usage: "Use minimal config with parameters as defined in the spec.",
 	}
 	schlesiTestnetFlag = &cli.BoolFlag{
-		Name:  "schlesi-config",
+		Name:  "schlesi-testnet",
 		Usage: "Use the preconfigured Schlesi multi-client testnet spec.",
 	}
 	writeSSZStateTransitionsFlag = &cli.BoolFlag{

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -227,6 +227,18 @@ func MainnetConfig() *BeaconChainConfig {
 	return defaultBeaconConfig
 }
 
+// SchlesiTestnetConfig returns the mainnet config
+// adapted with Schlesi Testnet specific parameters.
+func SchlesiTestnetConfig() *BeaconChainConfig {
+	schlesiTestnet := *defaultBeaconConfig
+
+	schlesiTestnet.MinGenesisActiveValidatorCount = 4
+	schlesiTestnet.MinGenesisTime = 1587755000
+	schlesiTestnet.MinGenesisDelay = 3600
+
+	return &schlesiTestnet
+}
+
 // MinimalSpecConfig retrieves the minimal config used in spec tests.
 func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig := *defaultBeaconConfig
@@ -302,6 +314,11 @@ func MinimalSpecConfig() *BeaconChainConfig {
 // UseMinimalConfig for beacon chain services.
 func UseMinimalConfig() {
 	beaconConfig = MinimalSpecConfig()
+}
+
+// UseSchlesiTestnet for beacon chain services.
+func UseSchlesiTestnet() {
+	beaconConfig = SchlesiTestnetConfig()
 }
 
 // UseMainnetConfig for beacon chain services.

--- a/validator/main.go
+++ b/validator/main.go
@@ -101,6 +101,9 @@ contract in order to activate the validator client`,
 						if featureconfig.Get().MinimalConfig {
 							log.Warn("Using Minimal Config")
 							params.UseMinimalConfig()
+						} else if featureconfig.Get().SchlesiTestnet {
+							log.Warn("Using Schlesi Testnet")
+							params.UseSchlesiTestnet()
 						}
 
 						if keystoreDir, _, err := accounts.CreateValidatorAccount(ctx.String(flags.KeystorePathFlag.Name), ctx.String(flags.PasswordFlag.Name)); err != nil {


### PR DESCRIPTION

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This provides a config that modifies a mainnet spec according to the Schlesi testnet variables.

This allows users to run a Prysm node on Schlesi without patching the client by just providing `--schlesi-testnet` instead.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

I will personally commit to keep this updated.

Schlesi does not work on master, so I'll submit this PR to v0.12.

As a follow-up to this, in future, it would be nice to have some kind of abstraction for chain specifications that also would allow for more flexibility also regarding other options such as bootnodes or deposit contract etc.