### PR TITLE
shared/keystore: cleanup

### DIFF
--- a/shared/keystore/key.go
+++ b/shared/keystore/key.go
@@ -62,11 +62,11 @@ type Key struct {
 }
 
 type keyStore interface {
-	// Loads and decrypts the key from disk.
+	// GetKey loads and decrypts the key from disk.
 	GetKey(filename string, password string) (*Key, error)
-	// Writes and encrypts the key.
+	// StoreKey writes and encrypts the key.
 	StoreKey(filename string, k *Key, auth string) error
-	// Joins filename with the key directory unless it is already absolute.
+	// JoinPath joins filename with the key directory unless it is already absolute.
 	JoinPath(filename string) string
 }
 
@@ -95,7 +95,7 @@ type cipherparamsJSON struct {
 	IV string `json:"iv"`
 }
 
-// MarshalJSON marshalls a key struct into a JSON blob.
+// MarshalJSON marshals a key struct into a JSON blob.
 func (k *Key) MarshalJSON() (j []byte, err error) {
 	jStruct := plainKeyJSON{
 		hex.EncodeToString(k.PublicKey.Marshal()),

--- a/shared/keystore/key_test.go
+++ b/shared/keystore/key_test.go
@@ -3,7 +3,6 @@ package keystore
 import (
 	"bytes"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/pborman/uuid"
@@ -42,20 +41,16 @@ func TestMarshalAndUnmarshal(t *testing.T) {
 }
 
 func TestStoreRandomKey(t *testing.T) {
-	tmpdir := testutil.TempDir()
-	filedir := tmpdir + "/keystore"
+	tempDir := testutil.TempDir() + "/keystore"
+	defer teardownTempKeystore(t, tempDir)
 	ks := &Store{
-		keysDirPath: filedir,
+		keysDirPath: tempDir,
 		scryptN:     LightScryptN,
 		scryptP:     LightScryptP,
 	}
 
 	if err := storeNewRandomKey(ks, "password"); err != nil {
 		t.Fatalf("storage of random key unsuccessful %v", err)
-	}
-
-	if err := os.RemoveAll(filedir); err != nil {
-		t.Errorf("unable to remove temporary files %v", err)
 	}
 }
 
@@ -83,26 +78,22 @@ func TestNewKeyFromBLS(t *testing.T) {
 }
 
 func TestWriteFile(t *testing.T) {
-	tmpdir := testutil.TempDir()
-	filedir := tmpdir + "/keystore"
+	tempDir := testutil.TempDir() + "/keystore"
+	defer teardownTempKeystore(t, tempDir)
 
 	testKeystore := []byte{'t', 'e', 's', 't'}
 
-	err := writeKeyFile(filedir, testKeystore)
+	err := writeKeyFile(tempDir, testKeystore)
 	if err != nil {
 		t.Fatalf("unable to write file %v", err)
 	}
 
-	keystore, err := ioutil.ReadFile(filedir)
+	keystore, err := ioutil.ReadFile(tempDir)
 	if err != nil {
 		t.Fatalf("unable to retrieve file %v", err)
 	}
 
 	if !bytes.Equal(keystore, testKeystore) {
 		t.Fatalf("retrieved keystore is not the same %v", keystore)
-	}
-
-	if err := os.RemoveAll(filedir); err != nil {
-		t.Errorf("unable to remove temporary files %v", err)
 	}
 }

--- a/shared/keystore/key_test.go
+++ b/shared/keystore/key_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
 func TestMarshalAndUnmarshal(t *testing.T) {
@@ -41,8 +40,8 @@ func TestMarshalAndUnmarshal(t *testing.T) {
 }
 
 func TestStoreRandomKey(t *testing.T) {
-	tempDir := testutil.TempDir() + "/keystore"
-	defer teardownTempKeystore(t, tempDir)
+	tempDir, teardown := setupTempKeystoreDir(t)
+	defer teardown()
 	ks := &Store{
 		keysDirPath: tempDir,
 		scryptN:     LightScryptN,
@@ -78,8 +77,8 @@ func TestNewKeyFromBLS(t *testing.T) {
 }
 
 func TestWriteFile(t *testing.T) {
-	tempDir := testutil.TempDir() + "/keystore"
-	defer teardownTempKeystore(t, tempDir)
+	tempDir, teardown := setupTempKeystoreDir(t)
+	defer teardown()
 
 	testKeystore := []byte{'t', 'e', 's', 't'}
 

--- a/shared/keystore/keystore.go
+++ b/shared/keystore/keystore.go
@@ -98,14 +98,14 @@ func (ks Store) GetKeys(directory, filePrefix, password string, warnOnFail bool)
 		cp := strings.Contains(n, strings.TrimPrefix(filePrefix, "/"))
 		if f.Mode().IsRegular() && cp {
 			// #nosec G304
-			keyjson, err := ioutil.ReadFile(filePath)
+			keyJSON, err := ioutil.ReadFile(filePath)
 			if err != nil {
 				return nil, err
 			}
-			key, err := DecryptKey(keyjson, password)
+			key, err := DecryptKey(keyJSON, password)
 			if err != nil {
 				if warnOnFail {
-					log.WithError(err).WithField("keyfile", string(keyjson)).Warn("Failed to decrypt key")
+					log.WithError(err).WithField("keyfile", string(keyJSON)).Warn("Failed to decrypt key")
 				}
 				continue
 			}
@@ -132,7 +132,7 @@ func (ks Store) JoinPath(filename string) string {
 	return filepath.Join(ks.keysDirPath, filename)
 }
 
-// EncryptKey encrypts a key using the specified scrypt parameters into a json
+// EncryptKey encrypts a key using the specified scrypt parameters into a JSON
 // blob that can be decrypted later on.
 func EncryptKey(key *Key, password string, scryptN, scryptP int) ([]byte, error) {
 	authArray := []byte(password)
@@ -188,7 +188,7 @@ func EncryptKey(key *Key, password string, scryptN, scryptP int) ([]byte, error)
 	return json.Marshal(encryptedJSON)
 }
 
-// DecryptKey decrypts a key from a json blob, returning the private key itself.
+// DecryptKey decrypts a key from a JSON blob, returning the private key itself.
 func DecryptKey(keyJSON []byte, password string) (*Key, error) {
 	var keyBytes, keyID []byte
 	var err error

--- a/shared/keystore/keystore.go
+++ b/shared/keystore/keystore.go
@@ -76,16 +76,16 @@ func NewKeystore(directory string) Store {
 func (ks Store) GetKey(filename, password string) (*Key, error) {
 	// Load the key from the keystore and decrypt its contents
 	// #nosec G304
-	keyjson, err := ioutil.ReadFile(filename)
+	keyJSON, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
-	return DecryptKey(keyjson, password)
+	return DecryptKey(keyJSON, password)
 }
 
 // GetKeys from directory using the prefix to filter relevant files
 // and a decryption password.
-func (ks Store) GetKeys(directory, fileprefix, password string, warnOnFail bool) (map[string]*Key, error) {
+func (ks Store) GetKeys(directory, filePrefix, password string, warnOnFail bool) (map[string]*Key, error) {
 	// Load the key from the keystore and decrypt its contents
 	// #nosec G304
 	files, err := ioutil.ReadDir(directory)
@@ -106,7 +106,7 @@ func (ks Store) GetKeys(directory, fileprefix, password string, warnOnFail bool)
 				}
 			}
 		}
-		cp := strings.Contains(n, strings.TrimPrefix(fileprefix, "/"))
+		cp := strings.Contains(n, strings.TrimPrefix(filePrefix, "/"))
 		if f.Mode().IsRegular() && cp {
 			// #nosec G304
 			keyjson, err := ioutil.ReadFile(filePath)
@@ -128,11 +128,11 @@ func (ks Store) GetKeys(directory, fileprefix, password string, warnOnFail bool)
 
 // StoreKey in filepath and encrypt it with a password.
 func (ks Store) StoreKey(filename string, key *Key, auth string) error {
-	keyjson, err := EncryptKey(key, auth, ks.scryptN, ks.scryptP)
+	keyJSON, err := EncryptKey(key, auth, ks.scryptN, ks.scryptP)
 	if err != nil {
 		return err
 	}
-	return writeKeyFile(filename, keyjson)
+	return writeKeyFile(filename, keyJSON)
 }
 
 // JoinPath joins the filename with the keystore directory path.
@@ -206,12 +206,12 @@ func EncryptKey(key *Key, password string, scryptN, scryptP int) ([]byte, error)
 }
 
 // DecryptKey decrypts a key from a json blob, returning the private key itself.
-func DecryptKey(keyjson []byte, password string) (*Key, error) {
+func DecryptKey(keyJSON []byte, password string) (*Key, error) {
 	var keyBytes, keyID []byte
 	var err error
 
 	k := new(encryptedKeyJSON)
-	if err := json.Unmarshal(keyjson, k); err != nil {
+	if err := json.Unmarshal(keyJSON, k); err != nil {
 		return nil, err
 	}
 

--- a/shared/keystore/keystore.go
+++ b/shared/keystore/keystore.go
@@ -52,17 +52,6 @@ type Store struct {
 	scryptP     int
 }
 
-// RetrievePubKey retrieves the public key from the keystore.
-func RetrievePubKey(directory string, password string) (*bls.PublicKey, error) {
-	ks := Store{
-		keysDirPath: directory,
-		scryptN:     StandardScryptN,
-		scryptP:     StandardScryptP,
-	}
-	key, err := ks.GetKey(ks.keysDirPath, password)
-	return key.PublicKey, err
-}
-
 // NewKeystore from a directory.
 func NewKeystore(directory string) Store {
 	return Store{
@@ -141,12 +130,6 @@ func (ks Store) JoinPath(filename string) string {
 		return filename
 	}
 	return filepath.Join(ks.keysDirPath, filename)
-}
-
-// StoreRandomKey generates a key, encrypts with 'auth' and stores in the given directory
-func StoreRandomKey(dir, password string, scryptN, scryptP int) error {
-	err := storeNewRandomKey(Store{dir, scryptN, scryptP}, password)
-	return err
 }
 
 // EncryptKey encrypts a key using the specified scrypt parameters into a json

--- a/shared/keystore/keystore_test.go
+++ b/shared/keystore/keystore_test.go
@@ -29,13 +29,13 @@ func TestStoreAndGetKey(t *testing.T) {
 		t.Fatalf("unable to store key %v", err)
 	}
 
-	newkey, err := ks.GetKey(tempDir, "password")
+	decryptedKey, err := ks.GetKey(tempDir, "password")
 	if err != nil {
 		t.Fatalf("unable to get key %v", err)
 	}
 
-	if !bytes.Equal(newkey.SecretKey.Marshal(), key.SecretKey.Marshal()) {
-		t.Fatalf("retrieved secret keys are not equal %v , %v", newkey.SecretKey.Marshal(), key.SecretKey.Marshal())
+	if !bytes.Equal(decryptedKey.SecretKey.Marshal(), key.SecretKey.Marshal()) {
+		t.Fatalf("retrieved secret keys are not equal %v , %v", decryptedKey.SecretKey.Marshal(), key.SecretKey.Marshal())
 	}
 }
 
@@ -63,11 +63,11 @@ func TestStoreAndGetKeys(t *testing.T) {
 	if err := ks.StoreKey(tempDir+"/test-2", key2, "password"); err != nil {
 		t.Fatalf("unable to store key %v", err)
 	}
-	newkeys, err := ks.GetKeys(tempDir, "test", "password", false)
+	decryptedKeys, err := ks.GetKeys(tempDir, "test", "password", false)
 	if err != nil {
 		t.Fatalf("unable to get key %v", err)
 	}
-	for _, s := range newkeys {
+	for _, s := range decryptedKeys {
 		if !bytes.Equal(s.SecretKey.Marshal(), key.SecretKey.Marshal()) && !bytes.Equal(s.SecretKey.Marshal(), key2.SecretKey.Marshal()) {
 			t.Fatalf("retrieved secret keys are not equal %v ", s.SecretKey.Marshal())
 		}
@@ -91,23 +91,23 @@ func TestEncryptDecryptKey(t *testing.T) {
 		PublicKey: pk.PublicKey(),
 	}
 
-	keyjson, err := EncryptKey(key, password, LightScryptN, LightScryptP)
+	keyJSON, err := EncryptKey(key, password, LightScryptN, LightScryptP)
 	if err != nil {
 		t.Fatalf("unable to encrypt key %v", err)
 	}
 
-	newkey, err := DecryptKey(keyjson, password)
+	decryptedKey, err := DecryptKey(keyJSON, password)
 	if err != nil {
 		t.Fatalf("unable to decrypt keystore %v", err)
 	}
 
-	if !bytes.Equal(newkey.ID, newID) {
-		t.Fatalf("decrypted key's uuid doesn't match %v", newkey.ID)
+	if !bytes.Equal(decryptedKey.ID, newID) {
+		t.Fatalf("decrypted key's uuid doesn't match %v", decryptedKey.ID)
 	}
 
 	expected := pk.Marshal()
-	if !bytes.Equal(newkey.SecretKey.Marshal(), expected) {
-		t.Fatalf("decrypted key's value is not equal %v", newkey.SecretKey.Marshal())
+	if !bytes.Equal(decryptedKey.SecretKey.Marshal(), expected) {
+		t.Fatalf("decrypted key's value is not equal %v", decryptedKey.SecretKey.Marshal())
 	}
 }
 
@@ -132,14 +132,14 @@ func TestGetSymlinkedKeys(t *testing.T) {
 		t.Fatalf("unable to create symlink: %v", err)
 	}
 
-	newkeys, err := ks.GetKeys(tempDir, "test", "password", false)
+	decryptedKeys, err := ks.GetKeys(tempDir, "test", "password", false)
 	if err != nil {
 		t.Fatalf("unable to get key %v", err)
 	}
-	if len(newkeys) != 1 {
-		t.Errorf("unexpected number of keys returned, want: %d, got: %d", 1, len(newkeys))
+	if len(decryptedKeys) != 1 {
+		t.Errorf("unexpected number of keys returned, want: %d, got: %d", 1, len(decryptedKeys))
 	}
-	for _, s := range newkeys {
+	for _, s := range decryptedKeys {
 		if !bytes.Equal(s.SecretKey.Marshal(), key.SecretKey.Marshal()) {
 			t.Fatalf("retrieved secret keys are not equal %v ", s.SecretKey.Marshal())
 		}


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
- minor fixes of issues discovered when implementing #5679 

**Which issues(s) does this PR fix?**
N/A

**Other notes for review**
This PR:
- makes naming consistent
- removes unused code
- fixes incorrect temp data teardown in tests (temp files were removed at the end of the functions, and `t.Fatalf()` were used in code - so on error teardown never occured, thus making running tests non-idempotent operation)
- also temp directory used wasn't assuming tests can be run concurrently/sharded
