### PR TITLE
Regen historical state: don't skip saving historical state

### DIFF
--- a/beacon-chain/db/kv/regen_historical_states.go
+++ b/beacon-chain/db/kv/regen_historical_states.go
@@ -122,7 +122,7 @@ func (kv *Store) regenHistoricalStates(ctx context.Context) error {
 
 		if len(blocks) > 0 {
 			// Save the historical root, state and highest index to the DB.
-			if helpers.IsEpochStart(currentState.Slot()) && currentState.Slot()%slotsPerArchivedPoint == 0 && blocks[len(blocks)-1].Block.Slot&slotsPerArchivedPoint == 0 {
+			if helpers.IsEpochStart(currentState.Slot()) && currentState.Slot()%slotsPerArchivedPoint == 0 {
 				if err := kv.saveArchivedInfo(ctx, currentState.Copy(), blocks, i); err != nil {
 					return err
 				}


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**

To regenerate and save historical state, the current behavior is it won't save the historical state on the archived slot if that archived slot is a skip slot. This behavior is obviously not ideal. See: 
<img width="612" alt="Screen Shot 2020-05-01 at 4 54 59 PM" src="https://user-images.githubusercontent.com/21316537/80849578-948bca80-8bcc-11ea-9b41-e60eb0700fe5.png">
(slot 256, 768.. and more are skipped)

After the fix:
<img width="609" alt="Screen Shot 2020-05-01 at 4 57 31 PM" src="https://user-images.githubusercontent.com/21316537/80849637-dd438380-8bcc-11ea-9bdb-68909dddeba7.png">


**Which issues(s) does this PR fix?**

Fixes #5711

**Other notes for review**
Tested run time 👌 