### PR TITLE
Refactor db teardown to testing.TB.Cleanup

### DIFF
--- a/beacon-chain/archiver/service_test.go
+++ b/beacon-chain/archiver/service_test.go
@@ -31,8 +31,7 @@ func init() {
 
 func TestArchiverService_ReceivesBlockProcessedEvent(t *testing.T) {
 	hook := logTest.NewGlobal()
-	svc, beaconDB := setupService(t)
-	defer dbutil.TeardownDB(t, beaconDB)
+	svc, _ := setupService(t)
 	st := testutil.NewBeaconState()
 	if err := st.SetSlot(1); err != nil {
 		t.Fatal(err)
@@ -55,8 +54,7 @@ func TestArchiverService_ReceivesBlockProcessedEvent(t *testing.T) {
 
 func TestArchiverService_OnlyArchiveAtEpochEnd(t *testing.T) {
 	hook := logTest.NewGlobal()
-	svc, beaconDB := setupService(t)
-	defer dbutil.TeardownDB(t, beaconDB)
+	svc, _ := setupService(t)
 	// The head state is NOT an epoch end.
 	st := testutil.NewBeaconState()
 	if err := st.SetSlot(params.BeaconConfig().SlotsPerEpoch - 2); err != nil {
@@ -86,13 +84,12 @@ func TestArchiverService_OnlyArchiveAtEpochEnd(t *testing.T) {
 
 func TestArchiverService_ArchivesEvenThroughSkipSlot(t *testing.T) {
 	hook := logTest.NewGlobal()
-	svc, beaconDB := setupService(t)
+	svc, _ := setupService(t)
 	validatorCount := uint64(100)
 	headState, err := setupState(validatorCount)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer dbutil.TeardownDB(t, beaconDB)
 	event := &feed.Event{
 		Type: statefeed.BlockProcessed,
 		Data: &statefeed.BlockProcessedData{
@@ -146,8 +143,7 @@ func TestArchiverService_ComputesAndSavesParticipation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	svc, beaconDB := setupService(t)
-	defer dbutil.TeardownDB(t, beaconDB)
+	svc, _ := setupService(t)
 	svc.headFetcher = &mock.ChainService{
 		State: headState,
 	}
@@ -187,8 +183,7 @@ func TestArchiverService_SavesIndicesAndBalances(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	svc, beaconDB := setupService(t)
-	defer dbutil.TeardownDB(t, beaconDB)
+	svc, _ := setupService(t)
 	svc.headFetcher = &mock.ChainService{
 		State: headState,
 	}
@@ -223,8 +218,7 @@ func TestArchiverService_SavesCommitteeInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	svc, beaconDB := setupService(t)
-	defer dbutil.TeardownDB(t, beaconDB)
+	svc, _ := setupService(t)
 	svc.headFetcher = &mock.ChainService{
 		State: headState,
 	}
@@ -274,7 +268,6 @@ func TestArchiverService_SavesActivatedValidatorChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 	svc, beaconDB := setupService(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	svc.headFetcher = &mock.ChainService{
 		State: headState,
 	}
@@ -326,7 +319,6 @@ func TestArchiverService_SavesSlashedValidatorChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 	svc, beaconDB := setupService(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	svc.headFetcher = &mock.ChainService{
 		State: headState,
 	}
@@ -377,7 +369,6 @@ func TestArchiverService_SavesExitedValidatorChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 	svc, beaconDB := setupService(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	svc.headFetcher = &mock.ChainService{
 		State: headState,
 	}

--- a/beacon-chain/blockchain/chain_info_norace_test.go
+++ b/beacon-chain/blockchain/chain_info_norace_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestHeadSlot_DataRace(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	s := &Service{
 		beaconDB: db,
 	}
@@ -26,7 +25,6 @@ func TestHeadSlot_DataRace(t *testing.T) {
 
 func TestHeadRoot_DataRace(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	s := &Service{
 		beaconDB: db,
 		head:     &head{root: [32]byte{'A'}},
@@ -44,7 +42,6 @@ func TestHeadRoot_DataRace(t *testing.T) {
 
 func TestHeadBlock_DataRace(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	s := &Service{
 		beaconDB: db,
 		head:     &head{block: &ethpb.SignedBeaconBlock{}},
@@ -62,7 +59,6 @@ func TestHeadBlock_DataRace(t *testing.T) {
 
 func TestHeadState_DataRace(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	s := &Service{
 		beaconDB: db,
 		stateGen: stategen.New(db, cache.NewStateSummaryCache()),

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -22,7 +22,6 @@ var _ = ForkFetcher(&Service{})
 
 func TestFinalizedCheckpt_Nil(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	c := setupBeaconChain(t, db)
 	if !bytes.Equal(c.FinalizedCheckpt().Root, params.BeaconConfig().ZeroHash[:]) {
 		t.Error("Incorrect pre chain start value")
@@ -31,7 +30,6 @@ func TestFinalizedCheckpt_Nil(t *testing.T) {
 
 func TestHeadRoot_Nil(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	c := setupBeaconChain(t, db)
 	headRoot, err := c.HeadRoot(context.Background())
 	if err != nil {
@@ -44,7 +42,6 @@ func TestHeadRoot_Nil(t *testing.T) {
 
 func TestFinalizedCheckpt_CanRetrieve(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cp := &ethpb.Checkpoint{Epoch: 5, Root: []byte("foo")}
 	c := setupBeaconChain(t, db)
@@ -57,7 +54,6 @@ func TestFinalizedCheckpt_CanRetrieve(t *testing.T) {
 
 func TestFinalizedCheckpt_GenesisRootOk(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	genesisRoot := [32]byte{'A'}
 	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}
@@ -72,7 +68,6 @@ func TestFinalizedCheckpt_GenesisRootOk(t *testing.T) {
 
 func TestCurrentJustifiedCheckpt_CanRetrieve(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cp := &ethpb.Checkpoint{Epoch: 6, Root: []byte("foo")}
 	c := setupBeaconChain(t, db)
@@ -85,7 +80,6 @@ func TestCurrentJustifiedCheckpt_CanRetrieve(t *testing.T) {
 
 func TestJustifiedCheckpt_GenesisRootOk(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	genesisRoot := [32]byte{'B'}
 	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}
@@ -100,7 +94,6 @@ func TestJustifiedCheckpt_GenesisRootOk(t *testing.T) {
 
 func TestPreviousJustifiedCheckpt_CanRetrieve(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cp := &ethpb.Checkpoint{Epoch: 7, Root: []byte("foo")}
 	c := setupBeaconChain(t, db)
@@ -113,7 +106,6 @@ func TestPreviousJustifiedCheckpt_CanRetrieve(t *testing.T) {
 
 func TestPrevJustifiedCheckpt_GenesisRootOk(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	genesisRoot := [32]byte{'C'}
 	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}

--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestSaveHead_Same(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	service := setupBeaconChain(t, db)
 
 	r := [32]byte{'A'}
@@ -36,7 +35,6 @@ func TestSaveHead_Same(t *testing.T) {
 
 func TestSaveHead_Different(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	service := setupBeaconChain(t, db)
 
 	oldRoot := [32]byte{'A'}

--- a/beacon-chain/blockchain/init_sync_process_block_test.go
+++ b/beacon-chain/blockchain/init_sync_process_block_test.go
@@ -23,7 +23,6 @@ import (
 func TestFilterBoundaryCandidates_FilterCorrect(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -87,7 +86,6 @@ func TestFilterBoundaryCandidates_FilterCorrect(t *testing.T) {
 func TestFilterBoundaryCandidates_HandleSkippedSlots(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -161,7 +159,6 @@ func TestFilterBoundaryCandidates_HandleSkippedSlots(t *testing.T) {
 func TestPruneOldStates_AlreadyFinalized(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -200,7 +197,6 @@ func TestPruneOldStates_AlreadyFinalized(t *testing.T) {
 func TestPruneNonBoundary_CanPrune(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -238,7 +234,6 @@ func TestPruneNonBoundary_CanPrune(t *testing.T) {
 
 func TestGenerateState_CorrectlyGenerated(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	cfg := &Config{BeaconDB: db, StateGen: stategen.New(db, cache.NewStateSummaryCache())}
 	service, err := NewService(context.Background(), cfg)
 	if err != nil {

--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -24,7 +24,6 @@ import (
 func TestStore_OnAttestation(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{
 		BeaconDB:        db,
@@ -164,7 +163,6 @@ func TestStore_OnAttestation(t *testing.T) {
 func TestStore_SaveCheckpointState(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{
 		BeaconDB: db,
@@ -285,7 +283,6 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 func TestStore_UpdateCheckpointState(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{
 		BeaconDB: db,
@@ -350,7 +347,6 @@ func TestStore_UpdateCheckpointState(t *testing.T) {
 func TestAttEpoch_MatchPrevEpoch(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -370,7 +366,6 @@ func TestAttEpoch_MatchPrevEpoch(t *testing.T) {
 func TestAttEpoch_MatchCurrentEpoch(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -390,7 +385,6 @@ func TestAttEpoch_MatchCurrentEpoch(t *testing.T) {
 func TestAttEpoch_NotMatch(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -411,7 +405,6 @@ func TestAttEpoch_NotMatch(t *testing.T) {
 func TestVerifyBeaconBlock_NoBlock(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -428,7 +421,6 @@ func TestVerifyBeaconBlock_NoBlock(t *testing.T) {
 func TestVerifyBeaconBlock_futureBlock(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -455,7 +447,6 @@ func TestVerifyBeaconBlock_futureBlock(t *testing.T) {
 func TestVerifyBeaconBlock_OK(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -28,7 +28,6 @@ import (
 func TestStore_OnBlock(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{
 		BeaconDB: db,
@@ -130,7 +129,6 @@ func TestStore_OnBlock(t *testing.T) {
 func TestRemoveStateSinceLastFinalized(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	params.UseMinimalConfig()
 	defer params.UseMainnetConfig()
 
@@ -210,7 +208,6 @@ func TestRemoveStateSinceLastFinalized(t *testing.T) {
 func TestRemoveStateSinceLastFinalized_EmptyStartSlot(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	params.UseMinimalConfig()
 	defer params.UseMainnetConfig()
 
@@ -261,7 +258,6 @@ func TestRemoveStateSinceLastFinalized_EmptyStartSlot(t *testing.T) {
 func TestShouldUpdateJustified_ReturnFalse(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	params.UseMinimalConfig()
 	defer params.UseMainnetConfig()
 
@@ -306,7 +302,6 @@ func TestCachedPreState_CanGetFromStateSummary(t *testing.T) {
 
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{
 		BeaconDB: db,
@@ -342,7 +337,6 @@ func TestCachedPreState_CanGetFromStateSummary(t *testing.T) {
 func TestCachedPreState_CanGetFromDB(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -388,7 +382,6 @@ func TestCachedPreState_CanGetFromDB(t *testing.T) {
 func TestSaveInitState_CanSaveDelete(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -436,7 +429,6 @@ func TestSaveInitState_CanSaveDelete(t *testing.T) {
 func TestUpdateJustified_CouldUpdateBest(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -487,7 +479,6 @@ func TestUpdateJustified_CouldUpdateBest(t *testing.T) {
 func TestFilterBlockRoots_CanFilter(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -541,7 +532,6 @@ func TestFilterBlockRoots_CanFilter(t *testing.T) {
 func TestPersistCache_CanSave(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -583,7 +573,6 @@ func TestPersistCache_CanSave(t *testing.T) {
 func TestFillForkChoiceMissingBlocks_CanSave(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -637,7 +626,6 @@ func TestFillForkChoiceMissingBlocks_CanSave(t *testing.T) {
 func TestFillForkChoiceMissingBlocks_FilterFinalized(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)

--- a/beacon-chain/blockchain/receive_attestation_test.go
+++ b/beacon-chain/blockchain/receive_attestation_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestVerifyCheckpointEpoch_Ok(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	chainService := setupBeaconChain(t, db)
 	chainService.genesisTime = time.Now()

--- a/beacon-chain/blockchain/service_norace_test.go
+++ b/beacon-chain/blockchain/service_norace_test.go
@@ -16,7 +16,6 @@ func init() {
 
 func TestChainService_SaveHead_DataRace(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	s := &Service{
 		beaconDB: db,
 	}

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -163,7 +163,6 @@ func setupBeaconChain(t *testing.T, beaconDB db.Database) *Service {
 func TestChainStartStop_Uninitialized(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	chainService := setupBeaconChain(t, db)
 
 	// Listen for state events.
@@ -219,7 +218,6 @@ func TestChainStartStop_Initialized(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	chainService := setupBeaconChain(t, db)
 
@@ -264,7 +262,6 @@ func TestChainStartStop_Initialized(t *testing.T) {
 
 func TestChainService_InitializeBeaconChain(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 
 	bc := setupBeaconChain(t, db)
@@ -319,7 +316,6 @@ func TestChainService_InitializeBeaconChain(t *testing.T) {
 
 func TestChainService_InitializeChainInfo(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 
 	genesis := b.NewGenesisBlock([]byte{})
@@ -400,7 +396,6 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 
 func TestChainService_SaveHeadNoDB(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &Service{
 		beaconDB: db,
@@ -431,7 +426,6 @@ func TestChainService_SaveHeadNoDB(t *testing.T) {
 
 func TestChainService_PruneOldStates(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &Service{
 		beaconDB: db,
@@ -480,7 +474,6 @@ func TestChainService_PruneOldStates(t *testing.T) {
 func TestHasBlock_ForkChoiceAndDB(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	s := &Service{
 		forkChoiceStore:  protoarray.New(0, 0, [32]byte{}),
 		finalizedCheckpt: &ethpb.Checkpoint{},
@@ -511,7 +504,6 @@ func TestHasBlock_ForkChoiceAndDB(t *testing.T) {
 
 func BenchmarkHasBlockDB(b *testing.B) {
 	db := testDB.SetupDB(b)
-	defer testDB.TeardownDB(b, db)
 	ctx := context.Background()
 	s := &Service{
 		beaconDB: db,
@@ -536,7 +528,6 @@ func BenchmarkHasBlockDB(b *testing.B) {
 func BenchmarkHasBlockForkChoiceStore(b *testing.B) {
 	ctx := context.Background()
 	db := testDB.SetupDB(b)
-	defer testDB.TeardownDB(b, db)
 	s := &Service{
 		forkChoiceStore:  protoarray.New(0, 0, [32]byte{}),
 		finalizedCheckpt: &ethpb.Checkpoint{},

--- a/beacon-chain/db/kv/archive_test.go
+++ b/beacon-chain/db/kv/archive_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestStore_ArchivedActiveValidatorChanges(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	activated := []uint64{3, 4, 5}
 	exited := []uint64{6, 7, 8}
@@ -106,7 +105,6 @@ func TestStore_ArchivedActiveValidatorChanges(t *testing.T) {
 
 func TestStore_ArchivedCommitteeInfo(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	someSeed := [32]byte{1, 2, 3}
 	info := &pbp2p.ArchivedCommitteeInfo{
@@ -128,7 +126,6 @@ func TestStore_ArchivedCommitteeInfo(t *testing.T) {
 
 func TestStore_ArchivedBalances(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	balances := []uint64{2, 3, 4, 5, 6, 7}
 	epoch := uint64(10)
@@ -146,7 +143,6 @@ func TestStore_ArchivedBalances(t *testing.T) {
 
 func TestStore_ArchivedValidatorParticipation(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	epoch := uint64(10)
 	part := &ethpb.ValidatorParticipation{

--- a/beacon-chain/db/kv/archived_point_test.go
+++ b/beacon-chain/db/kv/archived_point_test.go
@@ -7,7 +7,6 @@ import (
 
 func TestArchivedPointIndexRoot_CanSaveRetrieve(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	i1 := uint64(100)
 	r1 := [32]byte{'A'}
@@ -28,7 +27,6 @@ func TestArchivedPointIndexRoot_CanSaveRetrieve(t *testing.T) {
 
 func TestLastArchivedPoint_CanRetrieve(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	i, err := db.LastArchivedIndex(ctx)
 	if err != nil {

--- a/beacon-chain/db/kv/attestations_test.go
+++ b/beacon-chain/db/kv/attestations_test.go
@@ -17,7 +17,6 @@ import (
 
 func TestStore_AttestationCRUD(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	att := &ethpb.Attestation{
 		Data:            &ethpb.AttestationData{Slot: 10},
 		AggregationBits: bitfield.Bitlist{0b00000001, 0b1},
@@ -57,7 +56,6 @@ func TestStore_AttestationCRUD(t *testing.T) {
 
 func TestStore_AttestationsBatchDelete(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	numAtts := 10
 	totalAtts := make([]*ethpb.Attestation, numAtts)
@@ -111,7 +109,6 @@ func TestStore_AttestationsBatchDelete(t *testing.T) {
 
 func TestStore_BoltDontPanic(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	var wg sync.WaitGroup
 
 	for i := 0; i <= 100; i++ {
@@ -167,7 +164,6 @@ func TestStore_BoltDontPanic(t *testing.T) {
 
 func TestStore_Attestations_FiltersCorrectly(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	someRoot := [32]byte{1, 2, 3}
 	otherRoot := [32]byte{4, 5, 6}
 	atts := []*ethpb.Attestation{
@@ -269,7 +265,6 @@ func TestStore_Attestations_FiltersCorrectly(t *testing.T) {
 
 func TestStore_DuplicatedAttestations_FiltersCorrectly(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	someRoot := [32]byte{1, 2, 3}
 	att := &ethpb.Attestation{
 		Data: &ethpb.AttestationData{
@@ -416,7 +411,6 @@ func TestStore_Attestations_BitfieldLogic(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := setupDB(t)
-			defer teardownDB(t, db)
 			ctx := context.Background()
 			if err := db.SaveAttestations(ctx, tt.input); err != nil {
 				t.Fatal(err)

--- a/beacon-chain/db/kv/backup_test.go
+++ b/beacon-chain/db/kv/backup_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestStore_Backup(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	head := &eth.SignedBeaconBlock{Block: &eth.BeaconBlock{Slot: 5000}}

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -16,7 +16,6 @@ import (
 func TestStore_SaveBlock_NoDuplicates(t *testing.T) {
 	BlockCacheSize = 1
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	slot := uint64(20)
 	ctx := context.Background()
 	// First we save a previous block to ensure the cache max size is reached.
@@ -56,7 +55,6 @@ func TestStore_SaveBlock_NoDuplicates(t *testing.T) {
 
 func TestStore_BlocksCRUD(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	block := &ethpb.SignedBeaconBlock{
 		Block: &ethpb.BeaconBlock{
@@ -98,7 +96,6 @@ func TestStore_BlocksCRUD(t *testing.T) {
 
 func TestStore_BlocksBatchDelete(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	numBlocks := 1000
 	totalBlocks := make([]*ethpb.SignedBeaconBlock, numBlocks)
@@ -151,7 +148,6 @@ func TestStore_BlocksBatchDelete(t *testing.T) {
 
 func TestStore_GenesisBlock(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	genesisBlock := &ethpb.SignedBeaconBlock{
 		Block: &ethpb.BeaconBlock{
@@ -180,7 +176,6 @@ func TestStore_GenesisBlock(t *testing.T) {
 
 func TestStore_BlocksCRUD_NoCache(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	block := &ethpb.SignedBeaconBlock{
 		Block: &ethpb.BeaconBlock{
@@ -223,7 +218,6 @@ func TestStore_BlocksCRUD_NoCache(t *testing.T) {
 
 func TestStore_Blocks_FiltersCorrectly(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	blocks := []*ethpb.SignedBeaconBlock{
 		{
 			Block: &ethpb.BeaconBlock{
@@ -329,7 +323,6 @@ func TestStore_Blocks_FiltersCorrectly(t *testing.T) {
 
 func TestStore_Blocks_Retrieve_SlotRange(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	b := make([]*ethpb.SignedBeaconBlock, 500)
 	for i := 0; i < 500; i++ {
 		b[i] = &ethpb.SignedBeaconBlock{
@@ -355,7 +348,6 @@ func TestStore_Blocks_Retrieve_SlotRange(t *testing.T) {
 
 func TestStore_Blocks_Retrieve_Epoch(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	slots := params.BeaconConfig().SlotsPerEpoch * 7
 	b := make([]*ethpb.SignedBeaconBlock, slots)
 	for i := uint64(0); i < slots; i++ {
@@ -390,7 +382,6 @@ func TestStore_Blocks_Retrieve_Epoch(t *testing.T) {
 
 func TestStore_Blocks_Retrieve_SlotRangeWithStep(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	b := make([]*ethpb.SignedBeaconBlock, 500)
 	for i := 0; i < 500; i++ {
 		b[i] = &ethpb.SignedBeaconBlock{
@@ -422,7 +413,6 @@ func TestStore_Blocks_Retrieve_SlotRangeWithStep(t *testing.T) {
 
 func TestStore_SaveBlock_CanGetHighest(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	block := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 1}}
@@ -464,7 +454,6 @@ func TestStore_SaveBlock_CanGetHighest(t *testing.T) {
 
 func TestStore_SaveBlock_CanGetHighestAt(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	block1 := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 1}}
@@ -521,7 +510,6 @@ func TestStore_SaveBlock_CanGetHighestAt(t *testing.T) {
 
 func TestStore_GenesisBlock_CanGetHighestAt(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	genesisBlock := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -565,7 +553,6 @@ func TestStore_GenesisBlock_CanGetHighestAt(t *testing.T) {
 
 func TestStore_SaveBlocks_CanGetHighest(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	b := make([]*ethpb.SignedBeaconBlock, 500)
@@ -592,7 +579,6 @@ func TestStore_SaveBlocks_CanGetHighest(t *testing.T) {
 
 func TestStore_SaveBlocks_HasCachedBlocks(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	b := make([]*ethpb.SignedBeaconBlock, 500)
@@ -625,7 +611,6 @@ func TestStore_SaveBlocks_HasCachedBlocks(t *testing.T) {
 
 func TestStore_DeleteBlock_CanGetHighest(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	b50 := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 50}}
@@ -671,7 +656,6 @@ func TestStore_DeleteBlock_CanGetHighest(t *testing.T) {
 
 func TestStore_DeleteBlocks_CanGetHighest(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	var err error

--- a/beacon-chain/db/kv/checkpoint_test.go
+++ b/beacon-chain/db/kv/checkpoint_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestStore_JustifiedCheckpoint_CanSaveRetrieve(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	root := bytesutil.ToBytes32([]byte{'A'})
 	cp := &ethpb.Checkpoint{
@@ -45,7 +44,6 @@ func TestStore_JustifiedCheckpoint_CanSaveRetrieve(t *testing.T) {
 
 func TestStore_FinalizedCheckpoint_CanSaveRetrieve(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	genesis := bytesutil.ToBytes32([]byte{'G', 'E', 'N', 'E', 'S', 'I', 'S'})
@@ -98,7 +96,6 @@ func TestStore_FinalizedCheckpoint_CanSaveRetrieve(t *testing.T) {
 
 func TestStore_JustifiedCheckpoint_DefaultCantBeNil(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	genesisRoot := [32]byte{'A'}
@@ -118,7 +115,6 @@ func TestStore_JustifiedCheckpoint_DefaultCantBeNil(t *testing.T) {
 
 func TestStore_FinalizedCheckpoint_DefaultCantBeNil(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	genesisRoot := [32]byte{'B'}
@@ -138,7 +134,6 @@ func TestStore_FinalizedCheckpoint_DefaultCantBeNil(t *testing.T) {
 
 func TestStore_FinalizedCheckpoint_StateMustExist(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	cp := &ethpb.Checkpoint{
 		Epoch: 5,

--- a/beacon-chain/db/kv/deposit_contract_test.go
+++ b/beacon-chain/db/kv/deposit_contract_test.go
@@ -9,7 +9,6 @@ import (
 
 func TestStore_DepositContract(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	contractAddress := common.Address{1, 2, 3}
 	retrieved, err := db.DepositContractAddress(ctx)

--- a/beacon-chain/db/kv/finalized_block_roots_test.go
+++ b/beacon-chain/db/kv/finalized_block_roots_test.go
@@ -16,7 +16,6 @@ var genesisBlockRoot = bytesutil.ToBytes32([]byte{'G', 'E', 'N', 'E', 'S', 'I', 
 func TestStore_IsFinalizedBlock(t *testing.T) {
 	slotsPerEpoch := int(params.BeaconConfig().SlotsPerEpoch)
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	if err := db.SaveGenesisBlockRoot(ctx, genesisBlockRoot); err != nil {
@@ -89,7 +88,6 @@ func TestStore_IsFinalized_ForkEdgeCase(t *testing.T) {
 	blocks2 := makeBlocks(t, slotsPerEpoch*2, slotsPerEpoch, bytesutil.ToBytes32(sszRootOrDie(t, blocks1[len(blocks1)-1])))
 
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	if err := db.SaveGenesisBlockRoot(ctx, genesisBlockRoot); err != nil {

--- a/beacon-chain/db/kv/kv_test.go
+++ b/beacon-chain/db/kv/kv_test.go
@@ -18,23 +18,21 @@ func setupDB(t testing.TB) *Store {
 	if err != nil {
 		t.Fatalf("Could not generate random file path: %v", err)
 	}
-	path := path.Join(testutil.TempDir(), fmt.Sprintf("/%d", randPath))
-	if err := os.RemoveAll(path); err != nil {
+	p := path.Join(testutil.TempDir(), fmt.Sprintf("/%d", randPath))
+	if err := os.RemoveAll(p); err != nil {
 		t.Fatalf("Failed to remove directory: %v", err)
 	}
-	db, err := NewKVStore(path, cache.NewStateSummaryCache())
+	db, err := NewKVStore(p, cache.NewStateSummaryCache())
 	if err != nil {
 		t.Fatalf("Failed to instantiate DB: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Failed to close database: %v", err)
+		}
+		if err := os.RemoveAll(db.DatabasePath()); err != nil {
+			t.Fatalf("Failed to remove directory: %v", err)
+		}
+	})
 	return db
-}
-
-// teardownDB cleans up a test Store instance.
-func teardownDB(t testing.TB, db *Store) {
-	if err := db.Close(); err != nil {
-		t.Fatalf("Failed to close database: %v", err)
-	}
-	if err := os.RemoveAll(db.DatabasePath()); err != nil {
-		t.Fatalf("Failed to remove directory: %v", err)
-	}
 }

--- a/beacon-chain/db/kv/operations_test.go
+++ b/beacon-chain/db/kv/operations_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestStore_VoluntaryExits_CRUD(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	exit := &ethpb.VoluntaryExit{
 		Epoch: 5,

--- a/beacon-chain/db/kv/slashings_test.go
+++ b/beacon-chain/db/kv/slashings_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestStore_ProposerSlashing_CRUD(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	prop := &ethpb.ProposerSlashing{
 		Header_1: &ethpb.SignedBeaconBlockHeader{
@@ -67,7 +66,6 @@ func TestStore_ProposerSlashing_CRUD(t *testing.T) {
 
 func TestStore_AttesterSlashing_CRUD(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	att := &ethpb.AttesterSlashing{
 		Attestation_1: &ethpb.IndexedAttestation{

--- a/beacon-chain/db/kv/state_summary_test.go
+++ b/beacon-chain/db/kv/state_summary_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestStateSummary_CanSaveRretrieve(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	r1 := bytesutil.ToBytes32([]byte{'A'})
 	r2 := bytesutil.ToBytes32([]byte{'B'})

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestState_CanSaveRetrieve(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 
 	r := [32]byte{'A'}
 
@@ -58,7 +57,6 @@ func TestState_CanSaveRetrieve(t *testing.T) {
 
 func TestHeadState_CanSaveRetrieve(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 
 	headRoot := [32]byte{'A'}
 
@@ -87,7 +85,6 @@ func TestHeadState_CanSaveRetrieve(t *testing.T) {
 
 func TestGenesisState_CanSaveRetrieve(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 
 	headRoot := [32]byte{'B'}
 
@@ -129,7 +126,6 @@ func TestGenesisState_CanSaveRetrieve(t *testing.T) {
 
 func TestStore_StatesBatchDelete(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	numBlocks := 100
 	totalBlocks := make([]*ethpb.SignedBeaconBlock, numBlocks)
@@ -182,7 +178,6 @@ func TestStore_StatesBatchDelete(t *testing.T) {
 
 func TestStore_DeleteGenesisState(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	genesisBlockRoot := [32]byte{'A'}
@@ -204,7 +199,6 @@ func TestStore_DeleteGenesisState(t *testing.T) {
 
 func TestStore_DeleteFinalizedState(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	genesis := bytesutil.ToBytes32([]byte{'G', 'E', 'N', 'E', 'S', 'I', 'S'})
@@ -247,7 +241,6 @@ func TestStore_DeleteFinalizedState(t *testing.T) {
 
 func TestStore_DeleteHeadState(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	genesis := bytesutil.ToBytes32([]byte{'G', 'E', 'N', 'E', 'S', 'I', 'S'})
@@ -287,7 +280,6 @@ func TestStore_DeleteHeadState(t *testing.T) {
 
 func TestStore_SaveDeleteState_CanGetHighest(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 1}}
 	r, err := ssz.HashTreeRoot(b.Block)
@@ -385,7 +377,6 @@ func TestStore_SaveDeleteState_CanGetHighest(t *testing.T) {
 
 func TestStore_SaveDeleteState_CanGetHighestBelow(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 1}}
 	r, err := ssz.HashTreeRoot(b.Block)
@@ -474,7 +465,6 @@ func TestStore_SaveDeleteState_CanGetHighestBelow(t *testing.T) {
 
 func TestStore_GenesisState_CanGetHighestBelow(t *testing.T) {
 	db := setupDB(t)
-	defer teardownDB(t, db)
 
 	genesisState := testutil.NewBeaconState()
 	genesisRoot := [32]byte{'a'}

--- a/beacon-chain/db/testing/setup_db.go
+++ b/beacon-chain/db/testing/setup_db.go
@@ -30,15 +30,13 @@ func SetupDB(t testing.TB) db.Database {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		if err := s.Close(); err != nil {
+			t.Fatalf("failed to close database: %v", err)
+		}
+		if err := os.RemoveAll(s.DatabasePath()); err != nil {
+			t.Fatalf("could not remove tmp db dir: %v", err)
+		}
+	})
 	return s
-}
-
-// TeardownDB closes a database and destroys the files at the database path.
-func TeardownDB(t testing.TB, db db.Database) {
-	if err := db.Close(); err != nil {
-		t.Fatalf("failed to close database: %v", err)
-	}
-	if err := os.RemoveAll(db.DatabasePath()); err != nil {
-		t.Fatalf("could not remove tmp db dir: %v", err)
-	}
 }

--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -110,7 +110,6 @@ go_test(
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
-        "//beacon-chain/db/testing:go_default_library",
         "//beacon-chain/p2p/testing:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/testing:go_default_library",

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -17,7 +17,6 @@ import (
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
-	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/shared/iputils"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"
@@ -167,8 +166,6 @@ func TestMultiAddrConversion_OK(t *testing.T) {
 }
 
 func TestStaticPeering_PeersAreAdded(t *testing.T) {
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	cfg := &Config{
 		Encoding: "ssz", MaxPeers: 30,
 	}

--- a/beacon-chain/p2p/fork_test.go
+++ b/beacon-chain/p2p/fork_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/p2putils"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -24,8 +23,6 @@ import (
 )
 
 func TestStartDiscv5_DifferentForkDigests(t *testing.T) {
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	port := 2000
 	ipAddr, pkey := createAddrAndPrivKey(t)
 	genesisTime := time.Now()
@@ -107,8 +104,6 @@ func TestStartDiscv5_DifferentForkDigests(t *testing.T) {
 }
 
 func TestStartDiscv5_SameForkDigests_DifferentNextForkData(t *testing.T) {
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	hook := logTest.NewGlobal()
 	logrus.SetLevel(logrus.DebugLevel)
 	port := 2000

--- a/beacon-chain/p2p/service_test.go
+++ b/beacon-chain/p2p/service_test.go
@@ -17,7 +17,6 @@ import (
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
-	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
@@ -101,8 +100,6 @@ func TestService_Stop_DontPanicIfDv5ListenerIsNotInited(t *testing.T) {
 }
 
 func TestService_Start_OnlyStartsOnce(t *testing.T) {
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	hook := logTest.NewGlobal()
 
 	cfg := &Config{
@@ -153,8 +150,6 @@ func TestService_Status_NotRunning(t *testing.T) {
 
 func TestListenForNewNodes(t *testing.T) {
 	// Setup bootnode.
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	cfg := &Config{}
 	port := 2000
 	cfg.UDPPort = uint(port)

--- a/beacon-chain/p2p/subnets_test.go
+++ b/beacon-chain/p2p/subnets_test.go
@@ -11,13 +11,10 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
-	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 
 func TestStartDiscV5_DiscoverPeersWithSubnets(t *testing.T) {
-	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	port := 2000
 	ipAddr, pkey := createAddrAndPrivKey(t)
 	genesisTime := time.Now()

--- a/beacon-chain/powchain/block_reader_test.go
+++ b/beacon-chain/powchain/block_reader_test.go
@@ -33,7 +33,6 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -97,7 +96,6 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 
 func TestBlockHashByHeight_ReturnsHash(t *testing.T) {
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -139,7 +137,6 @@ func TestBlockHashByHeight_ReturnsHash(t *testing.T) {
 
 func TestBlockExists_ValidHash(t *testing.T) {
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -181,7 +178,6 @@ func TestBlockExists_ValidHash(t *testing.T) {
 
 func TestBlockExists_InvalidHash(t *testing.T) {
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -199,7 +195,6 @@ func TestBlockExists_InvalidHash(t *testing.T) {
 
 func TestBlockExists_UsesCachedBlockInfo(t *testing.T) {
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -238,7 +233,6 @@ func TestBlockExists_UsesCachedBlockInfo(t *testing.T) {
 
 func TestBlockNumberByTimestamp(t *testing.T) {
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,

--- a/beacon-chain/powchain/deposit_test.go
+++ b/beacon-chain/powchain/deposit_test.go
@@ -20,7 +20,6 @@ const pubKeyErr = "could not convert bytes to public key"
 
 func TestProcessDeposit_OK(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -55,7 +54,6 @@ func TestProcessDeposit_OK(t *testing.T) {
 
 func TestProcessDeposit_InvalidMerkleBranch(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -93,7 +91,6 @@ func TestProcessDeposit_InvalidMerkleBranch(t *testing.T) {
 func TestProcessDeposit_InvalidPublicKey(t *testing.T) {
 	hook := logTest.NewGlobal()
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -139,7 +136,6 @@ func TestProcessDeposit_InvalidPublicKey(t *testing.T) {
 func TestProcessDeposit_InvalidSignature(t *testing.T) {
 	hook := logTest.NewGlobal()
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -184,7 +180,6 @@ func TestProcessDeposit_InvalidSignature(t *testing.T) {
 func TestProcessDeposit_UnableToVerify(t *testing.T) {
 	hook := logTest.NewGlobal()
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -227,7 +222,6 @@ func TestProcessDeposit_UnableToVerify(t *testing.T) {
 
 func TestProcessDeposit_IncompleteDeposit(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -307,7 +301,6 @@ func TestProcessDeposit_IncompleteDeposit(t *testing.T) {
 
 func TestProcessDeposit_AllDepositedSuccessfully(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -44,7 +44,6 @@ func TestProcessDepositLog_OK(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -119,7 +118,6 @@ func TestProcessDepositLog_InsertsPendingDeposit(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -193,7 +191,6 @@ func TestUnpackDepositLogData_OK(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		BeaconDB:        beaconDB,
@@ -273,7 +270,6 @@ func TestProcessETH2GenesisLog_8DuplicatePubkeys(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -358,7 +354,6 @@ func TestProcessETH2GenesisLog(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -475,7 +470,6 @@ func TestProcessETH2GenesisLog_CorrectNumOfDeposits(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	kvStore := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, kvStore)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -579,7 +573,6 @@ func TestWeb3ServiceProcessDepositLog_RequestMissedDeposits(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -696,7 +689,6 @@ func TestConsistentGenesisState(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, beaconDB)
 	web3Service := newPowchainService(t, testAcc, beaconDB)
 
 	testAcc.Backend.Commit()
@@ -744,11 +736,8 @@ func TestConsistentGenesisState(t *testing.T) {
 		testAcc.Backend.Commit()
 	}
 
-	// Tearing down to prevent registration error.
-	testDB.TeardownDB(t, beaconDB)
-
+	// New db to prevent registration error.
 	newBeaconDB := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, newBeaconDB)
 
 	newWeb3Service := newPowchainService(t, testAcc, newBeaconDB)
 	go newWeb3Service.run(ctx.Done())

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -157,7 +157,6 @@ func TestNewWeb3Service_OK(t *testing.T) {
 	ctx := context.Background()
 	var err error
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	if _, err = NewService(ctx, &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: common.Address{},
@@ -194,7 +193,6 @@ func TestNewWeb3Service_OK(t *testing.T) {
 func TestStart_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	testAcc, err := contracts.Setup()
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
@@ -234,7 +232,6 @@ func TestStop_OK(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -268,7 +265,6 @@ func TestInitDataFromContract_OK(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -297,7 +293,6 @@ func TestWeb3Service_BadReader(t *testing.T) {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -357,7 +352,6 @@ func TestStatus(t *testing.T) {
 func TestHandlePanic_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
 	beaconDB := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, beaconDB)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		ETH1Endpoint: endpoint,
 		BeaconDB:     beaconDB,

--- a/beacon-chain/rpc/beacon/assignments_test.go
+++ b/beacon-chain/rpc/beacon/assignments_test.go
@@ -28,8 +28,6 @@ func TestServer_ListAssignments_CannotRequestFutureEpoch(t *testing.T) {
 	defer resetCfg()
 
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
 	bs := &Server{
 		BeaconDB:           db,
@@ -54,8 +52,6 @@ func TestServer_ListAssignments_NoResults(t *testing.T) {
 	defer resetCfg()
 
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
 	st := testutil.NewBeaconState()
 
@@ -105,8 +101,6 @@ func TestServer_ListAssignments_Pagination_InputOutOfRange(t *testing.T) {
 	defer resetCfg()
 
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
 	setupValidators(t, db, 1)
 	headState, err := db.HeadState(ctx)
@@ -163,8 +157,6 @@ func TestServer_ListAssignments_Pagination_ExceedsMaxPageSize(t *testing.T) {
 func TestServer_ListAssignments_Pagination_DefaultPageSize_NoArchive(t *testing.T) {
 	helpers.ClearCache()
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
 	count := 500
 	validators := make([]*ethpb.Validator, 0, count)
@@ -262,7 +254,6 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_NoArchive(t *testing.
 func TestServer_ListAssignments_Pagination_DefaultPageSize_FromArchive(t *testing.T) {
 	helpers.ClearCache()
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -363,7 +354,6 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_FromArchive(t *testin
 func TestServer_ListAssignments_FilterPubkeysIndices_NoPagination(t *testing.T) {
 	helpers.ClearCache()
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -451,8 +441,6 @@ func TestServer_ListAssignments_CanFilterPubkeysIndices_WithPagination(t *testin
 	defer resetCfg()
 
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
 	count := 100
 	validators := make([]*ethpb.Validator, 0, count)

--- a/beacon-chain/rpc/beacon/attestations_test.go
+++ b/beacon-chain/rpc/beacon/attestations_test.go
@@ -38,9 +38,8 @@ import (
 
 func TestServer_ListAttestations_NoResults(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
+
 	st, err := stateTrie.InitializeFromProto(&pbp2p.BeaconState{
 		Slot: 0,
 	})
@@ -71,9 +70,8 @@ func TestServer_ListAttestations_NoResults(t *testing.T) {
 
 func TestServer_ListAttestations_Genesis(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
+
 	st, err := stateTrie.InitializeFromProto(&pbp2p.BeaconState{
 		Slot: 0,
 	})
@@ -150,7 +148,6 @@ func TestServer_ListAttestations_Genesis(t *testing.T) {
 
 func TestServer_ListAttestations_NoPagination(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	count := uint64(8)
@@ -198,7 +195,6 @@ func TestServer_ListAttestations_NoPagination(t *testing.T) {
 
 func TestServer_ListAttestations_FiltersCorrectly(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	someRoot := []byte{1, 2, 3}
@@ -312,7 +308,6 @@ func TestServer_ListAttestations_FiltersCorrectly(t *testing.T) {
 
 func TestServer_ListAttestations_Pagination_CustomPageParameters(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	count := params.BeaconConfig().SlotsPerEpoch * 4
@@ -427,7 +422,6 @@ func TestServer_ListAttestations_Pagination_CustomPageParameters(t *testing.T) {
 
 func TestServer_ListAttestations_Pagination_OutOfRange(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	count := uint64(1)
@@ -485,7 +479,6 @@ func TestServer_ListAttestations_Pagination_ExceedsMaxPageSize(t *testing.T) {
 
 func TestServer_ListAttestations_Pagination_DefaultPageSize(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	count := uint64(params.BeaconConfig().DefaultPageSize)
@@ -578,7 +571,6 @@ func TestServer_ListIndexedAttestations_NewStateManagnmentDisabled(t *testing.T)
 	defer resetCfg()
 
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
 	ctx := context.Background()
@@ -613,7 +605,6 @@ func TestServer_ListIndexedAttestations_GenesisEpoch(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt:true})
 	defer resetCfg()
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	helpers.ClearCache()
 	ctx := context.Background()
 	targetRoot1 := bytesutil.ToBytes32([]byte("root"))
@@ -750,7 +741,6 @@ func TestServer_ListIndexedAttestations_OldEpoch(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt:true})
 	defer resetCfg()
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	helpers.ClearCache()
 	ctx := context.Background()
 
@@ -989,8 +979,6 @@ func TestServer_AttestationPool_Pagination_CustomPageSize(t *testing.T) {
 }
 
 func TestServer_StreamIndexedAttestations_ContextCanceled(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	chainService := &mock.ChainService{}
@@ -1021,7 +1009,6 @@ func TestServer_StreamIndexedAttestations_OK(t *testing.T) {
 	resetCfg := params.OverrideBeaconConfigWithReset(params.MainnetConfig())
 	defer resetCfg()
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	exitRoutine := make(chan bool)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1159,8 +1146,6 @@ func TestServer_StreamIndexedAttestations_OK(t *testing.T) {
 }
 
 func TestServer_StreamAttestations_ContextCanceled(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -1189,8 +1174,6 @@ func TestServer_StreamAttestations_ContextCanceled(t *testing.T) {
 }
 
 func TestServer_StreamAttestations_OnSlotTick(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	exitRoutine := make(chan bool)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/beacon-chain/rpc/beacon/blocks_test.go
+++ b/beacon-chain/rpc/beacon/blocks_test.go
@@ -28,9 +28,8 @@ import (
 
 func TestServer_ListBlocks_NoResults(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
+
 	bs := &Server{
 		BeaconDB: db,
 	}
@@ -76,9 +75,8 @@ func TestServer_ListBlocks_NoResults(t *testing.T) {
 
 func TestServer_ListBlocks_Genesis(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
+
 	bs := &Server{
 		BeaconDB: db,
 	}
@@ -135,9 +133,8 @@ func TestServer_ListBlocks_Genesis(t *testing.T) {
 
 func TestServer_ListBlocks_Genesis_MultiBlocks(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
+
 	bs := &Server{
 		BeaconDB: db,
 	}
@@ -192,7 +189,6 @@ func TestServer_ListBlocks_Genesis_MultiBlocks(t *testing.T) {
 
 func TestServer_ListBlocks_Pagination(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	count := uint64(100)
@@ -296,7 +292,6 @@ func TestServer_ListBlocks_Pagination(t *testing.T) {
 
 func TestServer_ListBlocks_Errors(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	bs := &Server{BeaconDB: db}
@@ -368,7 +363,6 @@ func TestServer_ListBlocks_Errors(t *testing.T) {
 
 func TestServer_GetChainHead_NoFinalizedBlock(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 
 	s, err := stateTrie.InitializeFromProto(&pbp2p.BeaconState{
 		Slot:                        1,
@@ -410,7 +404,6 @@ func TestServer_GetChainHead_NoHeadBlock(t *testing.T) {
 
 func TestServer_GetChainHead(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 
 	finalizedBlock := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 1, ParentRoot: []byte{'A'}}}
 	if err := db.SaveBlock(context.Background(), finalizedBlock); err != nil {
@@ -501,7 +494,6 @@ func TestServer_GetChainHead(t *testing.T) {
 
 func TestServer_StreamChainHead_ContextCanceled(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -529,7 +521,6 @@ func TestServer_StreamChainHead_ContextCanceled(t *testing.T) {
 
 func TestServer_StreamChainHead_OnHeadUpdated(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 
 	finalizedBlock := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 1, ParentRoot: []byte{'A'}}}
 	if err := db.SaveBlock(context.Background(), finalizedBlock); err != nil {
@@ -626,7 +617,6 @@ func TestServer_StreamChainHead_OnHeadUpdated(t *testing.T) {
 
 func TestServer_StreamBlocks_ContextCanceled(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	chainService := &mock.ChainService{}
@@ -653,9 +643,6 @@ func TestServer_StreamBlocks_ContextCanceled(t *testing.T) {
 }
 
 func TestServer_StreamBlocks_OnHeadUpdated(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	b := &ethpb.SignedBeaconBlock{
 		Block: &ethpb.BeaconBlock{
 			Slot: 1,

--- a/beacon-chain/rpc/beacon/committees_test.go
+++ b/beacon-chain/rpc/beacon/committees_test.go
@@ -27,7 +27,6 @@ import (
 
 func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	helpers.ClearCache()
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt:true})
 	defer resetCfg()
@@ -93,7 +92,6 @@ func TestServer_ListBeaconCommittees_PreviousEpoch(t *testing.T) {
 	defer resetCfg()
 
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	helpers.ClearCache()
 
 	numValidators := 128
@@ -166,7 +164,6 @@ func TestServer_ListBeaconCommittees_FromArchive(t *testing.T) {
 	defer resetCfg()
 
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	helpers.ClearCache()
 	ctx := context.Background()
 

--- a/beacon-chain/rpc/beacon/config_test.go
+++ b/beacon-chain/rpc/beacon/config_test.go
@@ -7,14 +7,10 @@ import (
 	"testing"
 
 	ptypes "github.com/gogo/protobuf/types"
-	dbTest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
 func TestServer_GetBeaconConfig(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
 	bs := &Server{}
 	res, err := bs.GetBeaconConfig(ctx, &ptypes.Empty{})

--- a/beacon-chain/rpc/beacon/state_test.go
+++ b/beacon-chain/rpc/beacon/state_test.go
@@ -20,8 +20,6 @@ func TestServer_GetBeaconState(t *testing.T) {
 	defer resetCfg()
 
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
 	st := testutil.NewBeaconState()
 	slot := uint64(100)

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -33,7 +33,6 @@ import (
 
 func TestServer_GetValidatorActiveSetChanges_CannotRequestFutureEpoch(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 	st := testutil.NewBeaconState()
 	if err := st.SetSlot(0); err != nil {
@@ -62,9 +61,8 @@ func TestServer_GetValidatorActiveSetChanges_CannotRequestFutureEpoch(t *testing
 
 func TestServer_ListValidatorBalances_CannotRequestFutureEpoch(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
+
 	st := testutil.NewBeaconState()
 	if err := st.SetSlot(0); err != nil {
 		t.Fatal(err)
@@ -92,7 +90,6 @@ func TestServer_ListValidatorBalances_CannotRequestFutureEpoch(t *testing.T) {
 
 func TestServer_ListValidatorBalances_NoResults(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -145,9 +142,8 @@ func TestServer_ListValidatorBalances_NoResults(t *testing.T) {
 
 func TestServer_ListValidatorBalances_DefaultResponse_NoArchive(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
+
 	numItems := 100
 	validators := make([]*ethpb.Validator, numItems)
 	balances := make([]uint64, numItems)
@@ -211,7 +207,6 @@ func TestServer_ListValidatorBalances_DefaultResponse_NoArchive(t *testing.T) {
 
 func TestServer_ListValidatorBalances_PaginationOutOfRange(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 	setupValidators(t, db, 3)
 	st := testutil.NewBeaconState()
@@ -268,7 +263,6 @@ func pubKey(i uint64) []byte {
 
 func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	setupValidators(t, db, 100)
@@ -363,8 +357,8 @@ func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 
 func TestServer_ListValidatorBalances_Pagination_CustomPageSizes(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
+
 	count := 1000
 	setupValidators(t, db, count)
 	headState, err := db.HeadState(context.Background())
@@ -443,7 +437,6 @@ func TestServer_ListValidatorBalances_Pagination_CustomPageSizes(t *testing.T) {
 
 func TestServer_ListValidatorBalances_OutOfRange(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 	ctx := context.Background()
@@ -482,9 +475,8 @@ func TestServer_ListValidatorBalances_OutOfRange(t *testing.T) {
 
 func TestServer_ListValidators_CannotRequestFutureEpoch(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
+
 	st := testutil.NewBeaconState()
 	if err := st.SetSlot(0); err != nil {
 		t.Fatal(err)
@@ -511,7 +503,6 @@ func TestServer_ListValidators_CannotRequestFutureEpoch(t *testing.T) {
 
 func TestServer_ListValidatorBalances_FromArchive(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
 	defer resetCfg()
@@ -569,7 +560,6 @@ func TestServer_ListValidatorBalances_FromArchive(t *testing.T) {
 
 func TestServer_ListValidatorBalances_FromArchive_NewValidatorNotFound(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
@@ -611,7 +601,6 @@ func TestServer_ListValidatorBalances_FromArchive_NewValidatorNotFound(t *testin
 
 func TestServer_ListValidators_NoResults(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
@@ -650,10 +639,8 @@ func TestServer_ListValidators_NoResults(t *testing.T) {
 }
 
 func TestServer_ListValidators_OnlyActiveValidators(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
+
 	count := 100
 	balances := make([]uint64, count)
 	validators := make([]*ethpb.Validator, count)
@@ -712,7 +699,6 @@ func TestServer_ListValidators_OnlyActiveValidators(t *testing.T) {
 
 func TestServer_ListValidators_NoPagination(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 
 	validators, _ := setupValidators(t, db, 100)
 	want := make([]*ethpb.Validators_ValidatorContainer, len(validators))
@@ -750,7 +736,6 @@ func TestServer_ListValidators_NoPagination(t *testing.T) {
 
 func TestServer_ListValidators_IndicesPubKeys(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 
 	validators, _ := setupValidators(t, db, 100)
 	indicesWanted := []uint64{2, 7, 11, 17}
@@ -803,7 +788,6 @@ func TestServer_ListValidators_IndicesPubKeys(t *testing.T) {
 
 func TestServer_ListValidators_Pagination(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 
 	count := 100
 	setupValidators(t, db, count)
@@ -943,7 +927,6 @@ func TestServer_ListValidators_Pagination(t *testing.T) {
 
 func TestServer_ListValidators_PaginationOutOfRange(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 
 	count := 1
 	validators, _ := setupValidators(t, db, count)
@@ -983,7 +966,6 @@ func TestServer_ListValidators_ExceedsMaxPageSize(t *testing.T) {
 
 func TestServer_ListValidators_DefaultPageSize(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 
 	validators, _ := setupValidators(t, db, 1000)
 	want := make([]*ethpb.Validators_ValidatorContainer, len(validators))
@@ -1023,9 +1005,6 @@ func TestServer_ListValidators_DefaultPageSize(t *testing.T) {
 }
 
 func TestServer_ListValidators_FromOldEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	numEpochs := 30
 	validators := make([]*ethpb.Validator, numEpochs)
 	for i := 0; i < numEpochs; i++ {
@@ -1084,9 +1063,6 @@ func TestServer_ListValidators_FromOldEpoch(t *testing.T) {
 }
 
 func TestServer_GetValidator(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	count := 30
 	validators := make([]*ethpb.Validator, count)
 	for i := 0; i < count; i++ {
@@ -1180,7 +1156,6 @@ func TestServer_GetValidator(t *testing.T) {
 
 func TestServer_GetValidatorActiveSetChanges(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -1297,8 +1272,8 @@ func TestServer_GetValidatorActiveSetChanges_FromArchive(t *testing.T) {
 	defer resetCfg()
 
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
+
 	validators := make([]*ethpb.Validator, 8)
 	headState := testutil.NewBeaconState()
 	if err := headState.SetSlot(helpers.StartSlot(100)); err != nil {
@@ -1609,9 +1584,8 @@ func TestServer_GetValidatorQueue_PendingExit(t *testing.T) {
 
 func TestServer_GetValidatorParticipation_CannotRequestCurrentEpoch(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
-
 	ctx := context.Background()
+
 	headState := testutil.NewBeaconState()
 	if err := headState.SetSlot(helpers.StartSlot(2)); err != nil {
 		t.Fatal(err)
@@ -1638,7 +1612,6 @@ func TestServer_GetValidatorParticipation_CannotRequestCurrentEpoch(t *testing.T
 
 func TestServer_GetValidatorParticipation_CannotRequestFutureEpoch(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
 	defer resetCfg()
@@ -1671,7 +1644,6 @@ func TestServer_GetValidatorParticipation_CannotRequestFutureEpoch(t *testing.T)
 
 func TestServer_GetValidatorParticipation_FromArchive(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
@@ -1736,7 +1708,6 @@ func TestServer_GetValidatorParticipation_FromArchive(t *testing.T) {
 
 func TestServer_GetValidatorParticipation_PrevEpoch(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -1802,7 +1773,6 @@ func TestServer_GetValidatorParticipation_PrevEpoch(t *testing.T) {
 
 func TestServer_GetValidatorParticipation_DoesntExist(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	headState := testutil.NewBeaconState()
@@ -1843,7 +1813,6 @@ func TestServer_GetValidatorParticipation_DoesntExist(t *testing.T) {
 
 func TestServer_GetValidatorParticipation_FromArchive_FinalizedEpoch(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	defer dbTest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
@@ -1989,9 +1958,8 @@ func TestGetValidatorPerformance_OK(t *testing.T) {
 func BenchmarkListValidatorBalances(b *testing.B) {
 	b.StopTimer()
 	db := dbTest.SetupDB(b)
-	defer dbTest.TeardownDB(b, db)
-
 	ctx := context.Background()
+
 	count := 1000
 	setupValidators(b, db, count)
 
@@ -2018,9 +1986,8 @@ func BenchmarkListValidatorBalances(b *testing.B) {
 func BenchmarkListValidatorBalances_FromArchive(b *testing.B) {
 	b.StopTimer()
 	db := dbTest.SetupDB(b)
-	defer dbTest.TeardownDB(b, db)
-
 	ctx := context.Background()
+
 	currentNumValidators := 1000
 	numOldBalances := 50
 	validators := make([]*ethpb.Validator, currentNumValidators)

--- a/beacon-chain/rpc/node/server_test.go
+++ b/beacon-chain/rpc/node/server_test.go
@@ -44,7 +44,6 @@ func TestNodeServer_GetSyncStatus(t *testing.T) {
 
 func TestNodeServer_GetGenesis(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 	addr := common.Address{1, 2, 3}
 	if err := db.SaveDepositContractAddress(ctx, addr); err != nil {

--- a/beacon-chain/rpc/validator/aggregator_test.go
+++ b/beacon-chain/rpc/validator/aggregator_test.go
@@ -29,7 +29,6 @@ func init() {
 
 func TestSubmitAggregateAndProof_Syncing(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	s := &beaconstate.BeaconState{}
@@ -49,7 +48,6 @@ func TestSubmitAggregateAndProof_Syncing(t *testing.T) {
 
 func TestSubmitAggregateAndProof_CantFindValidatorIndex(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	s, err := beaconstate.InitializeFromProto(&pbp2p.BeaconState{
@@ -76,7 +74,6 @@ func TestSubmitAggregateAndProof_CantFindValidatorIndex(t *testing.T) {
 
 func TestSubmitAggregateAndProof_IsAggregatorAndNoAtts(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	s, err := beaconstate.InitializeFromProto(&pbp2p.BeaconState{
@@ -119,7 +116,6 @@ func TestSubmitAggregateAndProof_AggregateOk(t *testing.T) {
 	defer params.UseMinimalConfig()
 
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 32)
@@ -183,7 +179,6 @@ func TestSubmitAggregateAndProof_AggregateNotOk(t *testing.T) {
 	defer params.UseMinimalConfig()
 
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)

--- a/beacon-chain/rpc/validator/assignments_test.go
+++ b/beacon-chain/rpc/validator/assignments_test.go
@@ -30,7 +30,6 @@ func pubKey(i uint64) []byte {
 }
 func TestGetDuties_NextEpoch_CantFindValidatorIdx(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 	beaconState, _ := testutil.DeterministicGenesisState(t, 10)
 
@@ -68,7 +67,6 @@ func TestGetDuties_NextEpoch_CantFindValidatorIdx(t *testing.T) {
 
 func TestGetDuties_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 
 	genesis := blk.NewGenesisBlock([]byte{})
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
@@ -154,7 +152,6 @@ func TestGetDuties_OK(t *testing.T) {
 
 func TestGetDuties_CurrentEpoch_ShouldNotFail(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 
 	genesis := blk.NewGenesisBlock([]byte{})
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
@@ -209,7 +206,6 @@ func TestGetDuties_CurrentEpoch_ShouldNotFail(t *testing.T) {
 
 func TestGetDuties_MultipleKeys_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 
 	genesis := blk.NewGenesisBlock([]byte{})
 	depChainStart := uint64(64)
@@ -280,7 +276,6 @@ func TestGetDuties_SyncNotReady(t *testing.T) {
 
 func BenchmarkCommitteeAssignment(b *testing.B) {
 	db := dbutil.SetupDB(b)
-	defer dbutil.TeardownDB(b, db)
 
 	genesis := blk.NewGenesisBlock([]byte{})
 	depChainStart := uint64(8192 * 2)

--- a/beacon-chain/rpc/validator/attester_test.go
+++ b/beacon-chain/rpc/validator/attester_test.go
@@ -34,7 +34,6 @@ func init() {
 
 func TestProposeAttestation_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	attesterServer := &Server{
@@ -99,7 +98,6 @@ func TestProposeAttestation_OK(t *testing.T) {
 
 func TestProposeAttestation_IncorrectSignature(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 
 	attesterServer := &Server{
 		HeadFetcher:       &mock.ChainService{},
@@ -125,7 +123,6 @@ func TestProposeAttestation_IncorrectSignature(t *testing.T) {
 func TestGetAttestationData_OK(t *testing.T) {
 	ctx := context.Background()
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 
 	block := &ethpb.BeaconBlock{
 		Slot: 3*params.BeaconConfig().SlotsPerEpoch + 1,
@@ -243,7 +240,6 @@ func TestAttestationDataAtSlot_HandlesFarAwayJustifiedEpoch(t *testing.T) {
 	// More background: https://github.com/prysmaticlabs/prysm/issues/2153
 	// This test breaks if it doesnt use mainnet config
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
@@ -431,7 +427,6 @@ func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testin
 	// See: https://github.com/prysmaticlabs/prysm/issues/5164
 	ctx := context.Background()
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 
 	slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
 	block := &ethpb.BeaconBlock{
@@ -554,7 +549,6 @@ func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testin
 func TestGetAttestationData_SucceedsInFirstEpoch(t *testing.T) {
 	ctx := context.Background()
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 
 	slot := uint64(5)
 	block := &ethpb.BeaconBlock{

--- a/beacon-chain/rpc/validator/exit_test.go
+++ b/beacon-chain/rpc/validator/exit_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
 	mockChain "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
@@ -18,13 +17,13 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/voluntaryexits"
 	mockp2p "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
 func TestSub(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 	testutil.ResetCache()
 	deposits, keys, err := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
@@ -114,7 +113,6 @@ func TestSub(t *testing.T) {
 
 func TestProposeExit_NoPanic(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 	testutil.ResetCache()
 	deposits, keys, err := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -42,7 +42,6 @@ func init() {
 
 func TestGetBlock_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	testutil.ResetCache()
@@ -151,7 +150,6 @@ func TestGetBlock_OK(t *testing.T) {
 
 func TestGetBlock_AddsUnaggregatedAtts(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	params.OverrideBeaconConfig(params.MainnetConfig())
@@ -276,7 +274,6 @@ func TestGetBlock_AddsUnaggregatedAtts(t *testing.T) {
 
 func TestProposeBlock_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
@@ -324,7 +321,6 @@ func TestProposeBlock_OK(t *testing.T) {
 
 func TestComputeStateRoot_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	params.OverrideBeaconConfig(params.MainnetConfig())
@@ -1237,7 +1233,6 @@ func TestEth1Data(t *testing.T) {
 
 func TestEth1Data_MockEnabled(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	// If a mock eth1 data votes is specified, we use the following for the
 	// eth1data we provide to every proposer based on https://github.com/ethereum/eth2.0-pm/issues/62:
 	//
@@ -1290,7 +1285,6 @@ func TestEth1Data_MockEnabled(t *testing.T) {
 
 func TestFilterAttestation_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	params.OverrideBeaconConfig(params.MainnetConfig())

--- a/beacon-chain/rpc/validator/server_test.go
+++ b/beacon-chain/rpc/validator/server_test.go
@@ -39,7 +39,6 @@ func init() {
 
 func TestValidatorIndex_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 	st := testutil.NewBeaconState()
 	if err := db.SaveState(ctx, st.Copy(), [32]byte{}); err != nil {
@@ -68,7 +67,6 @@ func TestValidatorIndex_OK(t *testing.T) {
 
 func TestWaitForActivation_ContextClosed(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	beaconState, err := stateTrie.InitializeFromProto(&pbp2p.BeaconState{
@@ -122,7 +120,6 @@ func TestWaitForActivation_ContextClosed(t *testing.T) {
 
 func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	// This test breaks if it doesnt use mainnet config
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
@@ -218,7 +215,6 @@ func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 
 func TestWaitForActivation_MultipleStatuses(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 
 	priv1 := bls.RandKey()
 	priv2 := bls.RandKey()
@@ -309,7 +305,6 @@ func TestWaitForActivation_MultipleStatuses(t *testing.T) {
 
 func TestWaitForChainStart_ContextClosed(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -340,7 +335,6 @@ func TestWaitForChainStart_ContextClosed(t *testing.T) {
 
 func TestWaitForChainStart_AlreadyStarted(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 	headBlockRoot := [32]byte{0x01, 0x02}
 	trie := testutil.NewBeaconState()
@@ -380,7 +374,6 @@ func TestWaitForChainStart_AlreadyStarted(t *testing.T) {
 
 func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 
 	hook := logTest.NewGlobal()
 	chainService := &mockChain.ChainService{}
@@ -426,7 +419,6 @@ func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 
 func TestWaitForSynced_ContextClosed(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -457,7 +449,6 @@ func TestWaitForSynced_ContextClosed(t *testing.T) {
 
 func TestWaitForSynced_AlreadySynced(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 	headBlockRoot := [32]byte{0x01, 0x02}
 	trie := testutil.NewBeaconState()
@@ -498,7 +489,6 @@ func TestWaitForSynced_AlreadySynced(t *testing.T) {
 
 func TestWaitForSynced_NotStartedThenLogFired(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 
 	hook := logTest.NewGlobal()
 	chainService := &mockChain.ChainService{}

--- a/beacon-chain/rpc/validator/status_test.go
+++ b/beacon-chain/rpc/validator/status_test.go
@@ -24,7 +24,6 @@ import (
 
 func TestValidatorStatus_DepositedEth1(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	pubKey1 := pubKey(1)
@@ -75,7 +74,6 @@ func TestValidatorStatus_DepositedEth1(t *testing.T) {
 
 func TestValidatorStatus_Deposited(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	pubKey1 := pubKey(1)
@@ -133,7 +131,6 @@ func TestValidatorStatus_Deposited(t *testing.T) {
 
 func TestValidatorStatus_Pending(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -211,7 +208,6 @@ func TestValidatorStatus_Pending(t *testing.T) {
 
 func TestValidatorStatus_Active(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	// This test breaks if it doesnt use mainnet config
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	defer params.OverrideBeaconConfig(params.MinimalSpecConfig())
@@ -294,7 +290,6 @@ func TestValidatorStatus_Active(t *testing.T) {
 
 func TestValidatorStatus_Exiting(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -368,7 +363,6 @@ func TestValidatorStatus_Exiting(t *testing.T) {
 
 func TestValidatorStatus_Slashing(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -439,7 +433,6 @@ func TestValidatorStatus_Slashing(t *testing.T) {
 
 func TestValidatorStatus_Exited(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -518,7 +511,6 @@ func TestValidatorStatus_Exited(t *testing.T) {
 
 func TestValidatorStatus_UnknownStatus(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	pubKey := pubKey(1)
 	depositCache := depositcache.NewDepositCache()
 	stateObj, err := stateTrie.InitializeFromProtoUnsafe(&pbp2p.BeaconState{
@@ -549,7 +541,6 @@ func TestValidatorStatus_UnknownStatus(t *testing.T) {
 
 func TestMultipleValidatorStatus_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	pubKeys := [][]byte{pubKey(1), pubKey(2), pubKey(3), pubKey(4)}
@@ -647,7 +638,6 @@ func TestMultipleValidatorStatus_OK(t *testing.T) {
 
 func TestValidatorStatus_CorrectActivationQueue(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	pbKey := pubKey(5)
@@ -764,7 +754,6 @@ func TestValidatorStatus_CorrectActivationQueue(t *testing.T) {
 
 func TestDepositBlockSlotAfterGenesisTime(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -840,7 +829,6 @@ func TestDepositBlockSlotAfterGenesisTime(t *testing.T) {
 
 func TestDepositBlockSlotBeforeGenesisTime(t *testing.T) {
 	db := dbutil.SetupDB(t)
-	defer dbutil.TeardownDB(t, db)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)

--- a/beacon-chain/state/stategen/cold_test.go
+++ b/beacon-chain/state/stategen/cold_test.go
@@ -16,7 +16,6 @@ import (
 func TestSaveColdState_NonArchivedPoint(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 2
@@ -33,7 +32,6 @@ func TestSaveColdState_NonArchivedPoint(t *testing.T) {
 func TestSaveColdState_CanSave(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
@@ -59,7 +57,6 @@ func TestSaveColdState_CanSave(t *testing.T) {
 func TestLoadColdStateByRoot_NoStateSummary(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	if _, err := service.loadColdStateByRoot(ctx, [32]byte{'a'}); !strings.Contains(err.Error(), errUnknownStateSummary.Error()) {
@@ -70,7 +67,6 @@ func TestLoadColdStateByRoot_NoStateSummary(t *testing.T) {
 func TestLoadColdStateByRoot_CanGet(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
@@ -107,7 +103,6 @@ func TestLoadColdStateByRoot_CanGet(t *testing.T) {
 func TestLoadColdStateBySlot_CanGet(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -17,7 +17,6 @@ import (
 func TestStateByRoot_ColdState(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 2
@@ -59,7 +58,6 @@ func TestStateByRoot_ColdState(t *testing.T) {
 func TestStateByRoot_HotStateDB(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -113,7 +111,6 @@ func TestStateByRoot_HotStateDB(t *testing.T) {
 func TestStateByRoot_HotStateCached(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -138,7 +135,6 @@ func TestStateByRoot_HotStateCached(t *testing.T) {
 func TestStateBySlot_ColdState(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = params.BeaconConfig().SlotsPerEpoch * 2
@@ -190,7 +186,6 @@ func TestStateBySlot_ColdState(t *testing.T) {
 func TestStateBySlot_HotStateDB(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -223,7 +218,6 @@ func TestStateBySlot_HotStateDB(t *testing.T) {
 func TestStateSummary_CanGetFromCacheOrDB(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 

--- a/beacon-chain/state/stategen/hot_test.go
+++ b/beacon-chain/state/stategen/hot_test.go
@@ -21,7 +21,6 @@ func TestSaveHotState_AlreadyHas(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -50,7 +49,6 @@ func TestSaveHotState_CanSaveOnEpochBoundary(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -77,7 +75,6 @@ func TestSaveHotState_NoSaveNotEpochBoundary(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -114,7 +111,6 @@ func TestSaveHotState_NoSaveNotEpochBoundary(t *testing.T) {
 func TestLoadHoteStateByRoot_Cached(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -135,7 +131,6 @@ func TestLoadHoteStateByRoot_Cached(t *testing.T) {
 func TestLoadHoteStateByRoot_FromDBCanProcess(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -180,7 +175,6 @@ func TestLoadHoteStateByRoot_FromDBCanProcess(t *testing.T) {
 func TestLoadHoteStateByRoot_FromDBBoundaryCase(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -218,7 +212,6 @@ func TestLoadHoteStateByRoot_FromDBBoundaryCase(t *testing.T) {
 func TestLoadHoteStateBySlot_CanAdvanceSlotUsingDB(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	service := New(db, cache.NewStateSummaryCache())
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -249,7 +242,6 @@ func TestLoadHoteStateBySlot_CanAdvanceSlotUsingDB(t *testing.T) {
 func TestLastAncestorState_CanGet(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	service := New(db, cache.NewStateSummaryCache())
 
 	b0 := &ethpb.BeaconBlock{Slot: 0, ParentRoot: []byte{'a'}}

--- a/beacon-chain/state/stategen/migrate_test.go
+++ b/beacon-chain/state/stategen/migrate_test.go
@@ -18,7 +18,6 @@ func TestMigrateToCold_NoBlock(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -33,7 +32,6 @@ func TestMigrateToCold_HigherSplitSlot(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 2
@@ -48,7 +46,6 @@ func TestMigrateToCold_MigrationCompletes(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 2

--- a/beacon-chain/state/stategen/replay_test.go
+++ b/beacon-chain/state/stategen/replay_test.go
@@ -21,7 +21,6 @@ import (
 func TestComputeStateUpToSlot_GenesisState(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -54,7 +53,6 @@ func TestComputeStateUpToSlot_GenesisState(t *testing.T) {
 func TestComputeStateUpToSlot_CanProcessUpTo(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -87,7 +85,6 @@ func TestComputeStateUpToSlot_CanProcessUpTo(t *testing.T) {
 
 func TestReplayBlocks_AllSkipSlots(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	genesisBlock := blocks.NewGenesisBlock([]byte{})
@@ -132,7 +129,6 @@ func TestReplayBlocks_AllSkipSlots(t *testing.T) {
 
 func TestReplayBlocks_SameSlot(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	genesisBlock := blocks.NewGenesisBlock([]byte{})
@@ -177,7 +173,6 @@ func TestReplayBlocks_SameSlot(t *testing.T) {
 
 func TestLoadBlocks_FirstBranch(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -208,7 +203,6 @@ func TestLoadBlocks_FirstBranch(t *testing.T) {
 
 func TestLoadBlocks_SecondBranch(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -237,7 +231,6 @@ func TestLoadBlocks_SecondBranch(t *testing.T) {
 
 func TestLoadBlocks_ThirdBranch(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -268,7 +261,6 @@ func TestLoadBlocks_ThirdBranch(t *testing.T) {
 
 func TestLoadBlocks_SameSlots(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -297,7 +289,6 @@ func TestLoadBlocks_SameSlots(t *testing.T) {
 
 func TestLoadBlocks_SameEndSlots(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -325,7 +316,6 @@ func TestLoadBlocks_SameEndSlots(t *testing.T) {
 
 func TestLoadBlocks_SameEndSlotsWith2blocks(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -352,7 +342,6 @@ func TestLoadBlocks_SameEndSlotsWith2blocks(t *testing.T) {
 
 func TestLoadBlocks_BadStart(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -370,7 +359,6 @@ func TestLoadBlocks_BadStart(t *testing.T) {
 
 func TestLastSavedBlock_Genesis(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -403,7 +391,6 @@ func TestLastSavedBlock_Genesis(t *testing.T) {
 
 func TestLastSavedBlock_CanGet(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -441,7 +428,6 @@ func TestLastSavedBlock_CanGet(t *testing.T) {
 
 func TestLastSavedBlock_NoSavedBlock(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -459,7 +445,6 @@ func TestLastSavedBlock_NoSavedBlock(t *testing.T) {
 
 func TestLastSavedState_Genesis(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -489,7 +474,6 @@ func TestLastSavedState_Genesis(t *testing.T) {
 
 func TestLastSavedState_CanGet(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -532,7 +516,6 @@ func TestLastSavedState_CanGet(t *testing.T) {
 
 func TestLastSavedState_NoSavedBlockState(t *testing.T) {
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,

--- a/beacon-chain/state/stategen/service_test.go
+++ b/beacon-chain/state/stategen/service_test.go
@@ -14,7 +14,6 @@ import (
 func TestResume(t *testing.T) {
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	root := [32]byte{'A'}

--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -16,7 +16,6 @@ func TestSaveState_ColdStateCanBeSaved(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
@@ -49,7 +48,6 @@ func TestSaveState_HotStateCanBeSaved(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
@@ -78,7 +76,6 @@ func TestSaveState_HotStateCached(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db := testDB.SetupDB(t)
-	defer testDB.TeardownDB(t, db)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1

--- a/beacon-chain/sync/initial-sync-old/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync-old/round_robin_test.go
@@ -271,7 +271,6 @@ func TestRoundRobinSync(t *testing.T) {
 			if missing := sliceutil.NotUint64(sliceutil.IntersectionUint64(tt.expectedBlockSlots, receivedBlockSlots), tt.expectedBlockSlots); len(missing) > 0 {
 				t.Errorf("Missing blocks at slots %v", missing)
 			}
-			dbtest.TeardownDB(t, beaconDB)
 		})
 	}
 }

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestBlocksFetcherInitStartStop(t *testing.T) {
-	mc, p2p, beaconDB := initializeTestServices(t, []uint64{}, []*peerData{})
+	mc, p2p, _ := initializeTestServices(t, []uint64{}, []*peerData{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -84,8 +84,6 @@ func TestBlocksFetcherInitStartStop(t *testing.T) {
 		cancel()
 		fetcher.stop()
 	})
-
-	dbtest.TeardownDB(t, beaconDB)
 }
 
 func TestBlocksFetcherRoundRobin(t *testing.T) {
@@ -411,8 +409,6 @@ func TestBlocksFetcherRoundRobin(t *testing.T) {
 			if missing := sliceutil.NotUint64(sliceutil.IntersectionUint64(tt.expectedBlockSlots, receivedBlockSlots), tt.expectedBlockSlots); len(missing) > 0 {
 				t.Errorf("Missing blocks at slots %v", missing)
 			}
-
-			dbtest.TeardownDB(t, beaconDB)
 		})
 	}
 }
@@ -451,8 +447,7 @@ func TestBlocksFetcherHandleRequest(t *testing.T) {
 		},
 	}
 
-	mc, p2p, beaconDB := initializeTestServices(t, chainConfig.expectedBlockSlots, chainConfig.peers)
-	defer dbtest.TeardownDB(t, beaconDB)
+	mc, p2p, _ := initializeTestServices(t, chainConfig.expectedBlockSlots, chainConfig.peers)
 
 	t.Run("context cancellation", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -531,7 +526,7 @@ func TestBlocksFetcherRequestBeaconBlocksByRangeRequest(t *testing.T) {
 	}
 
 	hook := logTest.NewGlobal()
-	mc, p2p, beaconDB := initializeTestServices(t, chainConfig.expectedBlockSlots, chainConfig.peers)
+	mc, p2p, _ := initializeTestServices(t, chainConfig.expectedBlockSlots, chainConfig.peers)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -578,8 +573,6 @@ func TestBlocksFetcherRequestBeaconBlocksByRangeRequest(t *testing.T) {
 	if err == nil || err.Error() != "context canceled" {
 		t.Errorf("expected context closed error, got: %v", err)
 	}
-
-	dbtest.TeardownDB(t, beaconDB)
 }
 
 func TestBlocksFetcherSelectFailOverPeer(t *testing.T) {
@@ -681,8 +674,7 @@ func TestBlocksFetcherNonSkippedSlotAfter(t *testing.T) {
 		},
 	}
 
-	mc, p2p, beaconDB := initializeTestServices(t, chainConfig.expectedBlockSlots, chainConfig.peers)
-	defer dbtest.TeardownDB(t, beaconDB)
+	mc, p2p, _ := initializeTestServices(t, chainConfig.expectedBlockSlots, chainConfig.peers)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -6,15 +6,13 @@ import (
 	"testing"
 
 	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	dbtest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
 )
 
 func TestBlocksQueueInitStartStop(t *testing.T) {
-	mc, p2p, beaconDB := initializeTestServices(t, []uint64{}, []*peerData{})
-	defer dbtest.TeardownDB(t, beaconDB)
+	mc, p2p, _ := initializeTestServices(t, []uint64{}, []*peerData{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -255,7 +253,6 @@ func TestBlocksQueueLoop(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mc, p2p, beaconDB := initializeTestServices(t, tt.expectedBlockSlots, tt.peers)
-			defer dbtest.TeardownDB(t, beaconDB)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -314,7 +314,6 @@ func TestRoundRobinSync(t *testing.T) {
 			if missing := sliceutil.NotUint64(sliceutil.IntersectionUint64(tt.expectedBlockSlots, receivedBlockSlots), tt.expectedBlockSlots); len(missing) > 0 {
 				t.Errorf("Missing blocks at slots %v", missing)
 			}
-			dbtest.TeardownDB(t, beaconDB)
 		})
 	}
 }

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -32,7 +32,6 @@ import (
 func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)
 	p1.Connect(p2)
@@ -63,7 +62,6 @@ func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
 func TestProcessPendingAtts_HasBlockSaveUnAggregatedAtt(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p1 := p2ptest.NewTestP2P(t)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
@@ -118,7 +116,6 @@ func TestProcessPendingAtts_HasBlockSaveUnAggregatedAtt(t *testing.T) {
 func TestProcessPendingAtts_HasBlockSaveAggregatedAtt(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p1 := p2ptest.NewTestP2P(t)
 	validators := uint64(256)
 	testutil.ResetCache()
@@ -241,9 +238,6 @@ func TestProcessPendingAtts_HasBlockSaveAggregatedAtt(t *testing.T) {
 }
 
 func TestValidatePendingAtts_CanPruneOldAtts(t *testing.T) {
-	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
-
 	s := &Service{
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
 	}

--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -28,7 +28,6 @@ func init() {
 // Test b1 was missing then received and we can process b0 -> b1 -> b2
 func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks1(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 
 	p1 := p2ptest.NewTestP2P(t)
 	r := &Service{
@@ -104,7 +103,6 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks1(t *testing.T) {
 // Test b2 and b3 were missed, after receiving them we can process 2 chains.
 func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks2(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)
 	p1.Connect(p2)
@@ -234,7 +232,6 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks2(t *testing.T) {
 
 func TestRegularSyncBeaconBlockSubscriber_PruneOldPendingBlocks(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)
 	p1.Connect(p2)

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
@@ -24,7 +24,6 @@ func TestBeaconBlocksRPCHandler_ReturnsBlocks(t *testing.T) {
 		t.Error("Expected peers to be connected")
 	}
 	d := db.SetupDB(t)
-	defer db.TeardownDB(t, d)
 
 	req := &pb.BeaconBlocksByRangeRequest{
 		StartSlot: 100,

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -28,7 +28,6 @@ func TestRecentBeaconBlocksRPCHandler_ReturnsBlocks(t *testing.T) {
 		t.Error("Expected peers to be connected")
 	}
 	d := db.SetupDB(t)
-	defer db.TeardownDB(t, d)
 
 	var blkRoots [][32]byte
 	// Populate the database with blocks that would match the request.

--- a/beacon-chain/sync/rpc_goodbye_test.go
+++ b/beacon-chain/sync/rpc_goodbye_test.go
@@ -23,8 +23,6 @@ func TestGoodByeRPCHandler_Disconnects_With_Peer(t *testing.T) {
 
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
-	defer db.TeardownDB(t, d)
-
 	r := &Service{
 		db:  d,
 		p2p: p1,
@@ -69,8 +67,6 @@ func TestSendGoodbye_SendsMessage(t *testing.T) {
 
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
-	defer db.TeardownDB(t, d)
-
 	r := &Service{
 		db:  d,
 		p2p: p1,

--- a/beacon-chain/sync/rpc_metadata_test.go
+++ b/beacon-chain/sync/rpc_metadata_test.go
@@ -31,8 +31,6 @@ func TestMetaDataRPCHandler_ReceivesMetadata(t *testing.T) {
 
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
-	defer db.TeardownDB(t, d)
-
 	r := &Service{
 		db:  d,
 		p2p: p1,
@@ -88,8 +86,6 @@ func TestMetadataRPCHandler_SendsMetadata(t *testing.T) {
 
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
-	defer db.TeardownDB(t, d)
-
 	r := &Service{
 		db:  d,
 		p2p: p1,

--- a/beacon-chain/sync/rpc_ping_test.go
+++ b/beacon-chain/sync/rpc_ping_test.go
@@ -34,8 +34,6 @@ func TestPingRPCHandler_ReceivesPing(t *testing.T) {
 
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
-	defer db.TeardownDB(t, d)
-
 	r := &Service{
 		db:  d,
 		p2p: p1,
@@ -99,8 +97,6 @@ func TestPingRPCHandler_SendsPing(t *testing.T) {
 
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
-	defer db.TeardownDB(t, d)
-
 	r := &Service{
 		db:  d,
 		p2p: p1,

--- a/beacon-chain/sync/subscriber_committee_index_beacon_attestation_test.go
+++ b/beacon-chain/sync/subscriber_committee_index_beacon_attestation_test.go
@@ -28,7 +28,6 @@ func TestService_committeeIndexBeaconAttestationSubscriber_ValidMessage(t *testi
 
 	ctx := context.Background()
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	s, sKeys := testutil.DeterministicGenesisState(t, 64 /*validators*/)
 	if err := s.SetGenesisTime(uint64(time.Now().Unix())); err != nil {
 		t.Fatal(err)

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -72,7 +72,6 @@ func TestSubscribe_ReceivesAttesterSlashing(t *testing.T) {
 	p2p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 	d := db.SetupDB(t)
-	defer db.TeardownDB(t, d)
 	chainService := &mockChain.ChainService{
 		Genesis:        time.Now(),
 		ValidatorsRoot: [32]byte{'A'},
@@ -139,7 +138,6 @@ func TestSubscribe_ReceivesProposerSlashing(t *testing.T) {
 		Genesis:        time.Now(),
 	}
 	d := db.SetupDB(t)
-	defer db.TeardownDB(t, d)
 	c, err := lru.New(10)
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -118,7 +118,6 @@ func TestVerifySelection_CanVerify(t *testing.T) {
 
 func TestValidateAggregateAndProof_NoBlock(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p := p2ptest.NewTestP2P(t)
 
 	att := &ethpb.Attestation{
@@ -170,7 +169,6 @@ func TestValidateAggregateAndProof_NoBlock(t *testing.T) {
 
 func TestValidateAggregateAndProof_NotWithinSlotRange(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p := p2ptest.NewTestP2P(t)
 
 	validators := uint64(256)
@@ -265,7 +263,6 @@ func TestValidateAggregateAndProof_NotWithinSlotRange(t *testing.T) {
 
 func TestValidateAggregateAndProof_ExistedInPool(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p := p2ptest.NewTestP2P(t)
 
 	validators := uint64(256)
@@ -342,7 +339,6 @@ func TestValidateAggregateAndProofWithNewStateMgmt_CanValidate(t *testing.T) {
 	defer resetCfg()
 
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p := p2ptest.NewTestP2P(t)
 
 	validators := uint64(256)
@@ -470,7 +466,6 @@ func TestValidateAggregateAndProofWithNewStateMgmt_CanValidate(t *testing.T) {
 
 func TestVerifyIndexInCommittee_SeenAggregatorEpoch(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p := p2ptest.NewTestP2P(t)
 
 	validators := uint64(256)

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -36,7 +36,6 @@ import (
 func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 	ctx := context.Background()
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	msg := &ethpb.SignedBeaconBlock{
 		Block: &ethpb.BeaconBlock{
 			Slot:       1,
@@ -83,7 +82,6 @@ func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 
 func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	ctx := context.Background()
 
 	p := p2ptest.NewTestP2P(t)
@@ -131,7 +129,6 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 
 func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 100)
@@ -226,7 +223,6 @@ func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
 
 func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 	b := []byte("sk")
@@ -273,7 +269,6 @@ func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 	b := []byte("sk")
@@ -324,7 +319,6 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	b := []byte("sk")
 	b32 := bytesutil.ToBytes32(b)
 	p := p2ptest.NewTestP2P(t)
@@ -379,7 +373,6 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
 
 func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 100)
@@ -465,7 +458,6 @@ func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
 func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	p := p2ptest.NewTestP2P(t)
 
 	parent := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}

--- a/beacon-chain/sync/validate_committee_index_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_committee_index_beacon_attestation_test.go
@@ -27,7 +27,6 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 	ctx := context.Background()
 	p := p2ptest.NewTestP2P(t)
 	db := dbtest.SetupDB(t)
-	defer dbtest.TeardownDB(t, db)
 	chain := &mockChain.ChainService{
 		Genesis:          time.Now().Add(time.Duration(-64*int64(params.BeaconConfig().SecondsPerSlot)) * time.Second), // 64 slots ago
 		ValidatorsRoot:   [32]byte{'A'},

--- a/slasher/beaconclient/historical_data_retrieval_test.go
+++ b/slasher/beaconclient/historical_data_retrieval_test.go
@@ -20,7 +20,6 @@ func TestService_RequestHistoricalAttestations(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	db := testDB.SetupSlasherDB(t, false)
-	defer testDB.TeardownSlasherDB(t, db)
 	client := mock.NewMockBeaconChainClient(ctrl)
 
 	bs := Service{

--- a/slasher/db/kv/BUILD.bazel
+++ b/slasher/db/kv/BUILD.bazel
@@ -52,7 +52,6 @@ go_test(
         "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
-        "//slasher/db/iface:go_default_library",
         "//slasher/db/types:go_default_library",
         "//slasher/detection/attestations/types:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",

--- a/slasher/db/kv/attester_slashings_test.go
+++ b/slasher/db/kv/attester_slashings_test.go
@@ -17,7 +17,6 @@ func TestStore_AttesterSlashingNilBucket(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	as := &ethpb.AttesterSlashing{Attestation_1: &ethpb.IndexedAttestation{Signature: bytesutil.PadTo([]byte("hello"), 96)}}
@@ -42,7 +41,6 @@ func TestStore_SaveAttesterSlashing(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	data := &ethpb.AttestationData{
@@ -90,7 +88,6 @@ func TestStore_SaveAttesterSlashings(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	ckpt := &ethpb.Checkpoint{}
@@ -121,7 +118,6 @@ func TestStore_UpdateAttesterSlashingStatus(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -179,7 +175,6 @@ func TestStore_LatestEpochDetected(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	e, err := db.GetLatestEpochDetected(ctx)

--- a/slasher/db/kv/block_header_test.go
+++ b/slasher/db/kv/block_header_test.go
@@ -16,7 +16,6 @@ func TestNilDBHistoryBlkHdr(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	slot := uint64(1)
@@ -81,7 +80,6 @@ func TestDeleteHistoryBlkHdr(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -135,7 +133,6 @@ func TestHasHistoryBlkHdr(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -183,7 +180,6 @@ func TestPruneHistoryBlkHdr(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	tests := []struct {

--- a/slasher/db/kv/indexed_attestations_test.go
+++ b/slasher/db/kv/indexed_attestations_test.go
@@ -65,7 +65,6 @@ func TestHasIndexedAttestation_NilDB(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	hasIdxAtt, err := db.HasIndexedAttestation(ctx, tests[0].idxAtt)
@@ -81,7 +80,6 @@ func TestSaveIndexedAttestation(t *testing.T) {
 	app := &cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	for _, tt := range tests {
@@ -327,7 +325,6 @@ func TestIndexedAttestationsWithPrefix(t *testing.T) {
 			app := cli.App{}
 			set := flag.NewFlagSet("test", 0)
 			db := setupDB(t, cli.NewContext(&app, set, nil))
-			defer teardownDB(t, db)
 			ctx := context.Background()
 
 			if err := db.SaveIndexedAttestations(ctx, tt.attsInDB); err != nil {
@@ -497,7 +494,6 @@ func TestIndexedAttestationsForTarget(t *testing.T) {
 			app := cli.App{}
 			set := flag.NewFlagSet("test", 0)
 			db := setupDB(t, cli.NewContext(&app, set, nil))
-			defer teardownDB(t, db)
 			ctx := context.Background()
 
 			if err := db.SaveIndexedAttestations(ctx, tt.attsInDB); err != nil {
@@ -691,7 +687,6 @@ func TestDeleteIndexedAttestation(t *testing.T) {
 			app := &cli.App{}
 			set := flag.NewFlagSet("test", 0)
 			db := setupDB(t, cli.NewContext(app, set, nil))
-			defer teardownDB(t, db)
 			ctx := context.Background()
 
 			if err := db.SaveIndexedAttestations(ctx, tt.attsInDB); err != nil {
@@ -731,7 +726,6 @@ func TestHasIndexedAttestation(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	for _, tt := range tests {
@@ -763,7 +757,6 @@ func TestPruneHistoryIndexedAttestation(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	for _, tt := range tests {

--- a/slasher/db/kv/kv_test.go
+++ b/slasher/db/kv/kv_test.go
@@ -27,6 +27,9 @@ func setupDB(t testing.TB, ctx *cli.Context) *Store {
 	if err != nil {
 		t.Fatalf("Failed to instantiate DB: %v", err)
 	}
+	t.Cleanup(func() {
+		teardownDB(t, db)
+	})
 	return db
 }
 
@@ -44,6 +47,9 @@ func setupDBDiffCacheSize(t testing.TB, cacheSize int) *Store {
 	if err != nil {
 		t.Fatalf("Failed to instantiate DB: %v", err)
 	}
+	t.Cleanup(func() {
+		teardownDB(t, newDB)
+	})
 	return newDB
 }
 

--- a/slasher/db/kv/proposer_slashings_test.go
+++ b/slasher/db/kv/proposer_slashings_test.go
@@ -17,7 +17,6 @@ func TestStore_ProposerSlashingNilBucket(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	ps := &ethpb.ProposerSlashing{Header_1: &ethpb.SignedBeaconBlockHeader{Header: &ethpb.BeaconBlockHeader{ProposerIndex: 1}}}
@@ -42,7 +41,6 @@ func TestStore_SaveProposerSlashing(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -96,7 +94,6 @@ func TestStore_UpdateProposerSlashingStatus(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	tests := []struct {
@@ -156,7 +153,6 @@ func TestStore_SaveProposerSlashings(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	ps := []*ethpb.ProposerSlashing{

--- a/slasher/db/kv/spanner_test.go
+++ b/slasher/db/kv/spanner_test.go
@@ -51,7 +51,6 @@ func TestValidatorSpanMap_NilDB(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	validatorIdx := uint64(1)
@@ -68,7 +67,6 @@ func TestStore_SaveSpans(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	for _, tt := range spanTests {
@@ -98,7 +96,6 @@ func TestStore_SaveCachedSpans(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	for _, tt := range spanTests {
@@ -130,7 +127,6 @@ func TestStore_DeleteEpochSpans(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	db.spanCacheEnabled = false
 	for _, tt := range spanTests {
@@ -166,7 +162,6 @@ func TestValidatorSpanMap_DeletesOnCacheSavesToDB(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	for _, tt := range spanTests {
@@ -205,7 +200,6 @@ func TestValidatorSpanMap_DeletesOnCacheSavesToDB(t *testing.T) {
 
 func TestValidatorSpanMap_SaveOnEvict(t *testing.T) {
 	db := setupDBDiffCacheSize(t, 5)
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	tsm := &spanMapTestStruct{
@@ -240,7 +234,6 @@ func TestValidatorSpanMap_SaveCachedSpansMaps(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	for _, tt := range spanTests {
@@ -270,7 +263,6 @@ func TestStore_ReadWriteEpochsSpanByValidatorsIndices(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 	db.spanCacheEnabled = false
 
@@ -309,5 +301,4 @@ func TestStore_ReadWriteEpochsSpanByValidatorsIndices(t *testing.T) {
 			t.Errorf("Wanted span map to be equal to: %v , received span map: %v ", spanTests[0].spanMap, res[1])
 		}
 	}
-
 }

--- a/slasher/db/kv/spanner_test.go
+++ b/slasher/db/kv/spanner_test.go
@@ -284,12 +284,11 @@ func TestStore_ReadWriteEpochsSpanByValidatorsIndices(t *testing.T) {
 			t.Errorf("Wanted span map to be equal to: %v , received span map: %v ", spanTests[0].spanMap, res[1])
 		}
 	}
-	teardownDB(t, db)
-	db = setupDB(t, cli.NewContext(&app, set, nil))
-	if err := db.SaveEpochsSpanByValidatorsIndices(ctx, res); err != nil {
+	db1 := setupDB(t, cli.NewContext(&app, set, nil))
+	if err := db1.SaveEpochsSpanByValidatorsIndices(ctx, res); err != nil {
 		t.Fatal(err)
 	}
-	res, err = db.EpochsSpanByValidatorsIndices(ctx, []uint64{1, 2, 3}, 3)
+	res, err = db1.EpochsSpanByValidatorsIndices(ctx, []uint64{1, 2, 3}, 3)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/slasher/db/kv/validator_id_pubkey_test.go
+++ b/slasher/db/kv/validator_id_pubkey_test.go
@@ -37,7 +37,6 @@ func TestNilDBValidatorPublicKey(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	validatorID := uint64(1)
@@ -56,7 +55,6 @@ func TestSavePubKey(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	for _, tt := range pkTests {
@@ -81,7 +79,6 @@ func TestDeletePublicKey(t *testing.T) {
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
 	db := setupDB(t, cli.NewContext(&app, set, nil))
-	defer teardownDB(t, db)
 	ctx := context.Background()
 
 	for _, tt := range pkTests {

--- a/slasher/db/testing/BUILD.bazel
+++ b/slasher/db/testing/BUILD.bazel
@@ -17,4 +17,9 @@ go_test(
     name = "go_default_test",
     srcs = ["setup_db_test.go"],
     embed = [":go_default_library"],
+    deps = [
+        "//shared/testutil:go_default_library",
+        "//slasher/db:go_default_library",
+        "//slasher/db/kv:go_default_library",
+    ],
 )

--- a/slasher/db/testing/setup_db.go
+++ b/slasher/db/testing/setup_db.go
@@ -31,33 +31,13 @@ func SetupSlasherDB(t testing.TB, spanCacheEnabled bool) *kv.Store {
 	if err != nil {
 		t.Fatalf("Failed to instantiate DB: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Failed to close database: %v", err)
+		}
+		if err := os.RemoveAll(db.DatabasePath()); err != nil {
+			t.Fatalf("Failed to remove directory: %v", err)
+		}
+	})
 	return db
-}
-
-// SetupSlasherDBDiffCacheSize instantiates and returns a SlasherDB instance with non default cache size.
-func SetupSlasherDBDiffCacheSize(t testing.TB, cacheItems int64, maxCacheSize int64) *kv.Store {
-	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
-	if err != nil {
-		t.Fatalf("Could not generate random file path: %v", err)
-	}
-	p := path.Join(testutil.TempDir(), fmt.Sprintf("/%d", randPath))
-	if err := os.RemoveAll(p); err != nil {
-		t.Fatalf("Failed to remove directory: %v", err)
-	}
-	cfg := &kv.Config{}
-	newDB, err := slasherDB.NewDB(p, cfg)
-	if err != nil {
-		t.Fatalf("Failed to instantiate DB: %v", err)
-	}
-	return newDB
-}
-
-// TeardownSlasherDB cleans up a test SlasherDB instance.
-func TeardownSlasherDB(t testing.TB, db *kv.Store) {
-	if err := db.Close(); err != nil {
-		t.Fatalf("Failed to close database: %v", err)
-	}
-	if err := os.RemoveAll(db.DatabasePath()); err != nil {
-		t.Fatalf("Failed to remove directory: %v", err)
-	}
 }

--- a/slasher/db/testing/setup_db_test.go
+++ b/slasher/db/testing/setup_db_test.go
@@ -1,17 +1,38 @@
 package testing
 
 import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
 	"os"
+	"path"
 	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	slasherDB "github.com/prysmaticlabs/prysm/slasher/db"
+	"github.com/prysmaticlabs/prysm/slasher/db/kv"
 )
 
 func TestClearDB(t *testing.T) {
-	slasherDB := SetupSlasherDB(t, false)
-	if err := slasherDB.ClearDB(); err != nil {
+	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	if err != nil {
+		t.Fatalf("Could not generate random file path: %v", err)
+	}
+	p := path.Join(testutil.TempDir(), fmt.Sprintf("/%d", randPath))
+	if err := os.RemoveAll(p); err != nil {
+		t.Fatalf("Failed to remove directory: %v", err)
+	}
+	cfg := &kv.Config{}
+	db, err := slasherDB.NewDB(p, cfg)
+	db.EnableSpanCache(false)
+	if err != nil {
+		t.Fatalf("Failed to instantiate DB: %v", err)
+	}
+	if err := db.ClearDB(); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := os.Stat(slasherDB.DatabasePath()); !os.IsNotExist(err) {
+	if _, err := os.Stat(db.DatabasePath()); !os.IsNotExist(err) {
 		t.Fatalf("db wasnt cleared %v", err)
 	}
 }

--- a/slasher/db/testing/setup_db_test.go
+++ b/slasher/db/testing/setup_db_test.go
@@ -7,7 +7,6 @@ import (
 
 func TestClearDB(t *testing.T) {
 	slasherDB := SetupSlasherDB(t, false)
-	defer TeardownSlasherDB(t, slasherDB)
 	if err := slasherDB.ClearDB(); err != nil {
 		t.Fatal(err)
 	}

--- a/slasher/db/testing/setup_db_test.go
+++ b/slasher/db/testing/setup_db_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestClearDB(t *testing.T) {
+	// Setting up manually is required, since SetupDB() will also register a teardown procedure.
 	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	if err != nil {
 		t.Fatalf("Could not generate random file path: %v", err)

--- a/slasher/detection/attestations/spanner_test.go
+++ b/slasher/detection/attestations/spanner_test.go
@@ -235,7 +235,6 @@ func TestSpanDetector_DetectSlashingsForAttestation_Double(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := testDB.SetupSlasherDB(t, false)
-			defer testDB.TeardownSlasherDB(t, db)
 			ctx := context.Background()
 
 			sd := &SpanDetector{
@@ -466,7 +465,6 @@ func TestSpanDetector_DetectSlashingsForAttestation_Surround(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			db := testDB.SetupSlasherDB(t, false)
 			ctx := context.Background()
-			defer testDB.TeardownSlasherDB(t, db)
 
 			sd := &SpanDetector{
 				slasherDB: db,

--- a/slasher/detection/detect_test.go
+++ b/slasher/detection/detect_test.go
@@ -147,7 +147,6 @@ func TestDetect_detectAttesterSlashings_Surround(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := testDB.SetupSlasherDB(t, false)
-			defer testDB.TeardownSlasherDB(t, db)
 			ctx := context.Background()
 			ds := Service{
 				ctx:                ctx,
@@ -301,7 +300,6 @@ func TestDetect_detectAttesterSlashings_Double(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := testDB.SetupSlasherDB(t, false)
-			defer testDB.TeardownSlasherDB(t, db)
 			ctx := context.Background()
 			ds := Service{
 				ctx:                ctx,
@@ -387,7 +385,6 @@ func TestDetect_detectProposerSlashing(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := testDB.SetupSlasherDB(t, false)
-			defer testDB.TeardownSlasherDB(t, db)
 			ctx := context.Background()
 			ds := Service{
 				ctx:               ctx,

--- a/slasher/detection/listeners_test.go
+++ b/slasher/detection/listeners_test.go
@@ -37,7 +37,6 @@ func (m *mockNotifier) ClientReadyFeed() *event.Feed {
 func TestService_DetectIncomingBlocks(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := testDB.SetupSlasherDB(t, false)
-	defer testDB.TeardownSlasherDB(t, db)
 	ds := Service{
 		notifier:          &mockNotifier{},
 		proposalsDetector: proposals.NewProposeDetector(db),

--- a/slasher/detection/proposals/detector_test.go
+++ b/slasher/detection/proposals/detector_test.go
@@ -66,7 +66,6 @@ func TestProposalsDetector_DetectSlashingsForBlockHeaders(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := testDB.SetupSlasherDB(t, false)
-			defer testDB.TeardownSlasherDB(t, db)
 			ctx := context.Background()
 
 			sd := &ProposeDetector{

--- a/slasher/rpc/server_test.go
+++ b/slasher/rpc/server_test.go
@@ -12,7 +12,6 @@ import (
 
 func Test_DetectionFlow(t *testing.T) {
 	db := testDB.SetupSlasherDB(t, false)
-	defer testDB.TeardownSlasherDB(t, db)
 
 	savedAttestation := &ethpb.IndexedAttestation{
 		AttestingIndices: []uint64{3},

--- a/validator/client/validator_propose_test.go
+++ b/validator/client/validator_propose_test.go
@@ -124,7 +124,6 @@ func TestProposeBlock_BlocksDoubleProposal(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validator, m, finish := setup(t)
 	defer finish()
-	defer db.TeardownDB(t, validator.db)
 
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx
@@ -162,7 +161,6 @@ func TestProposeBlock_BlocksDoubleProposal_After54KEpochs(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validator, m, finish := setup(t)
 	defer finish()
-	defer db.TeardownDB(t, validator.db)
 
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx
@@ -201,7 +199,6 @@ func TestProposeBlock_AllowsPastProposals(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validator, m, finish := setup(t)
 	defer finish()
-	defer db.TeardownDB(t, validator.db)
 
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx
@@ -241,7 +238,6 @@ func TestProposeBlock_AllowsSameEpoch(t *testing.T) {
 	hook := logTest.NewGlobal()
 	validator, m, finish := setup(t)
 	defer finish()
-	defer db.TeardownDB(t, validator.db)
 
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx

--- a/validator/db/attestation_history_test.go
+++ b/validator/db/attestation_history_test.go
@@ -12,7 +12,6 @@ import (
 func TestAttestationHistory_EmptyVal(t *testing.T) {
 	pubkeys := [][48]byte{{30}, {25}, {20}}
 	db := SetupDB(t, pubkeys)
-	defer TeardownDB(t, db)
 
 	for _, pub := range pubkeys {
 		attestationHistory, err := db.AttestationHistory(context.Background(), pub[:])
@@ -33,7 +32,6 @@ func TestAttestationHistory_EmptyVal(t *testing.T) {
 
 func TestSaveAttestationHistory_OK(t *testing.T) {
 	db := SetupDB(t, [][48]byte{})
-	defer TeardownDB(t, db)
 
 	pubkey := []byte{3}
 	epoch := uint64(2)
@@ -72,7 +70,6 @@ func TestSaveAttestationHistory_OK(t *testing.T) {
 
 func TestSaveAttestationHistory_Overwrites(t *testing.T) {
 	db := SetupDB(t, [][48]byte{})
-	defer TeardownDB(t, db)
 	farFuture := params.BeaconConfig().FarFutureEpoch
 	newMap1 := make(map[uint64]uint64)
 	newMap1[0] = farFuture
@@ -140,7 +137,6 @@ func TestSaveAttestationHistory_Overwrites(t *testing.T) {
 
 func TestDeleteAttestationHistory_OK(t *testing.T) {
 	db := SetupDB(t, [][48]byte{})
-	defer TeardownDB(t, db)
 
 	pubkey := []byte{2}
 	newMap := make(map[uint64]uint64)

--- a/validator/db/proposal_history_test.go
+++ b/validator/db/proposal_history_test.go
@@ -15,7 +15,6 @@ import (
 func TestProposalHistoryForEpoch_InitializesNewPubKeys(t *testing.T) {
 	pubkeys := [][48]byte{{30}, {25}, {20}}
 	db := SetupDB(t, pubkeys)
-	defer TeardownDB(t, db)
 
 	for _, pub := range pubkeys {
 		slotBits, err := db.ProposalHistoryForEpoch(context.Background(), pub[:], 0)
@@ -33,7 +32,6 @@ func TestProposalHistoryForEpoch_InitializesNewPubKeys(t *testing.T) {
 func TestProposalHistoryForEpoch_NilDB(t *testing.T) {
 	valPubkey := [48]byte{1, 2, 3}
 	db := SetupDB(t, [][48]byte{})
-	defer TeardownDB(t, db)
 
 	_, err := db.ProposalHistoryForEpoch(context.Background(), valPubkey[:], 0)
 	if err == nil {
@@ -48,7 +46,6 @@ func TestProposalHistoryForEpoch_NilDB(t *testing.T) {
 func TestSaveProposalHistoryForEpoch_OK(t *testing.T) {
 	pubkey := [48]byte{3}
 	db := SetupDB(t, [][48]byte{pubkey})
-	defer TeardownDB(t, db)
 
 	epoch := uint64(2)
 	slot := uint64(2)
@@ -98,7 +95,6 @@ func TestSaveProposalHistoryForEpoch_Overwrites(t *testing.T) {
 
 	for _, tt := range tests {
 		db := SetupDB(t, [][48]byte{pubkey})
-		defer TeardownDB(t, db)
 		if err := db.SaveProposalHistoryForEpoch(context.Background(), pubkey[:], 0, tt.slotBits); err != nil {
 			t.Fatalf("Saving proposal history failed: %v", err)
 		}
@@ -157,7 +153,6 @@ func TestProposalHistoryForEpoch_MultipleEpochs(t *testing.T) {
 
 	for _, tt := range tests {
 		db := SetupDB(t, [][48]byte{pubKey})
-		defer TeardownDB(t, db)
 		for _, slot := range tt.slots {
 			slotBits, err := db.ProposalHistoryForEpoch(context.Background(), pubKey[:], helpers.SlotToEpoch(slot))
 			if err != nil {
@@ -211,7 +206,6 @@ func TestPruneProposalHistory_OK(t *testing.T) {
 
 	for _, tt := range tests {
 		db := SetupDB(t, [][48]byte{pubKey})
-		defer TeardownDB(t, db)
 		for _, slot := range tt.slots {
 			slotBits, err := db.ProposalHistoryForEpoch(context.Background(), pubKey[:], helpers.SlotToEpoch(slot))
 			if err != nil {
@@ -247,7 +241,6 @@ func TestPruneProposalHistory_OK(t *testing.T) {
 func TestDeleteProposalHistory_OK(t *testing.T) {
 	pubkey := [48]byte{2}
 	db := SetupDB(t, [][48]byte{pubkey})
-	defer TeardownDB(t, db)
 
 	slotBits := bitfield.Bitlist{0x01, 0x00, 0x00, 0x00, 0x02}
 

--- a/validator/db/setup_db.go
+++ b/validator/db/setup_db.go
@@ -23,6 +23,14 @@ func SetupDB(t testing.TB, pubkeys [][48]byte) *Store {
 	if err != nil {
 		t.Fatalf("Failed to instantiate DB: %v", err)
 	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Failed to close database: %v", err)
+		}
+		if err := db.ClearDB(); err != nil {
+			t.Fatalf("Failed to clear database: %v", err)
+		}
+	})
 	return db
 }
 
@@ -35,14 +43,4 @@ func TempDir() string {
 		return os.TempDir()
 	}
 	return d
-}
-
-// TeardownDB cleans up a test DB instance.
-func TeardownDB(t testing.TB, db *Store) {
-	if err := db.Close(); err != nil {
-		t.Fatalf("Failed to close database: %v", err)
-	}
-	if err := db.ClearDB(); err != nil {
-		t.Fatalf("Failed to clear database: %v", err)
-	}
 }

--- a/validator/db/setup_db_test.go
+++ b/validator/db/setup_db_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestClearDB(t *testing.T) {
-	// Setting up manually, as SetupDB() will also register a teardown procedure.
+	// Setting up manually is required, since SetupDB() will also register a teardown procedure.
 	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	if err != nil {
 		t.Fatalf("Could not generate random file path: %v", err)

--- a/validator/db/setup_db_test.go
+++ b/validator/db/setup_db_test.go
@@ -1,13 +1,28 @@
 package db
 
 import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestClearDB(t *testing.T) {
-	db := SetupDB(t, [][48]byte{})
+	// Setting up manually, as SetupDB() will also register a teardown procedure.
+	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	if err != nil {
+		t.Fatalf("Could not generate random file path: %v", err)
+	}
+	p := filepath.Join(TempDir(), fmt.Sprintf("/%d", randPath))
+	if err := os.RemoveAll(p); err != nil {
+		t.Fatalf("Failed to remove directory: %v", err)
+	}
+	db, err := NewKVStore(p, [][48]byte{})
+	if err != nil {
+		t.Fatalf("Failed to instantiate DB: %v", err)
+	}
 	if err := db.ClearDB(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
- Currently we are using manual `setupDB()/teardownDB()` pairs, but as of Go 1.14 [testing.TB.Cleanup](https://tip.golang.org/pkg/testing/#T.Cleanup) allows more robust and elegant method of cleanup.
- This PR, removes all unnecessary teardown code - teardown procedure is  setup when someone calls `setupDB()`
- In short: no more `defer teardownDB(t, db)` calls

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
Using `testing.TB.Cleanup()` is preferred because:
- less code, you don't need to worry about tearing down
- if database variable is not used, code will not compile (there are several cases where db var was used in teardown function call *only* - and while db was inited and not used compiler didn't report it)

NB: it seems more convenience methods arriving in testing package (in Go 1.15 we will have auto cleaning `TempDir()` method)
