### PR TITLE
Use cached state to validate `beacon_aggregate_and_proof`

### DIFF
--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -202,6 +202,11 @@ func (ms *ChainService) ReceiveAttestationNoPubsub(context.Context, *ethpb.Attes
 	return nil
 }
 
+// AttestationPreState mocks AttestationPreState method in chain service.
+func (ms *ChainService) AttestationPreState(ctx context.Context, att *ethpb.Attestation) (*stateTrie.BeaconState, error) {
+	return ms.State, nil
+}
+
 // HeadValidatorsIndices mocks the same method in the chain service.
 func (ms *ChainService) HeadValidatorsIndices(epoch uint64) ([]uint64, error) {
 	if ms.State == nil {

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -91,7 +91,7 @@ func (r *Service) validateAggregatedAtt(ctx context.Context, signed *ethpb.Signe
 		return false
 	}
 
-	s, err := r.chain.HeadState(ctx)
+	s, err := r.chain.AttestationPreState(ctx, signed.Message.Aggregate)
 	if err != nil {
 		traceutil.AnnotateError(span, err)
 		return false


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Feature

**What does this PR do? Why is it needed?**
This reduces beacon node's memory usage by a good 30%. Instead of using head state + copy to validate `beacon_aggregate_and_proof`, it uses cached check point state to validate.
Before:
<img width="1978" alt="Screen Shot 2020-05-04 at 8 39 14 AM" src="https://user-images.githubusercontent.com/21316537/81018033-84682b00-8e18-11ea-90c8-cabce8bcbb2c.png">

After:
<img width="2341" alt="Screen Shot 2020-05-04 at 11 15 20 AM" src="https://user-images.githubusercontent.com/21316537/81018051-8e8a2980-8e18-11ea-9e89-a876b8e039cd.png">

**Which issues(s) does this PR fix?**
Fixes #5736