### PR TITLE
More explicit error message on wrong process when running prysm.sh

### DIFF
--- a/prysm.sh
+++ b/prysm.sh
@@ -225,6 +225,7 @@ slasher)
     color "31" "Usage: ./prysm.sh PROCESS FLAGS."
     color "31" "       ./prysm.sh PROCESS --download-only."
     color "31" "PROCESS can be beacon-chain, validator, or slasher."
+    exit 1
     ;;
 esac
 

--- a/prysm.sh
+++ b/prysm.sh
@@ -222,6 +222,7 @@ slasher)
     ;;
 
 *)
+    color "31" "Process '$1' not found!"
     color "31" "Usage: ./prysm.sh PROCESS FLAGS."
     color "31" "       ./prysm.sh PROCESS --download-only."
     color "31" "PROCESS can be beacon-chain, validator, or slasher."

--- a/prysm.sh
+++ b/prysm.sh
@@ -222,7 +222,7 @@ slasher)
     ;;
 
 *)
-    color "31" "Process '$1' not found!"
+    color "31" "Process '$1' is not found!"
     color "31" "Usage: ./prysm.sh PROCESS FLAGS."
     color "31" "       ./prysm.sh PROCESS --download-only."
     color "31" "PROCESS can be beacon-chain, validator, or slasher."


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
- Fixes a bug: when incorrect process name was used, process didn't exit properly
![image](https://user-images.githubusercontent.com/188194/81063841-3e2ace80-8ee1-11ea-924e-85e34bf82b0a.png)


- Adds more explicit error message, where it mentions what process has been called - helps us debugging as well:
![image](https://user-images.githubusercontent.com/188194/81063777-22bfc380-8ee1-11ea-8ff3-8dbf8bc713a9.png)

**Which issues(s) does this PR fix?**

Fixes #5735

**Other notes for review**
