### PR TITLE
Update to v0.11.2 badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build status](https://badge.buildkite.com/b555891daf3614bae4284dcf365b2340cefc0089839526f096.svg?branch=master)](https://buildkite.com/prysmatic-labs/prysm)
 [![fuzzit](https://app.fuzzit.dev/badge?org_id=prysmaticlabs-gh)](https://app.fuzzit.dev/orgs/prysmaticlabs-gh/dashboard)
-[![ETH2.0_Spec_Version 0.11.1](https://img.shields.io/badge/ETH2.0%20Spec%20Version-v0.11.1-blue.svg)](https://github.com/ethereum/eth2.0-specs/tree/v0.11.1)
+[![ETH2.0_Spec_Version 0.11.2](https://img.shields.io/badge/ETH2.0%20Spec%20Version-v0.11.2-blue.svg)](https://github.com/ethereum/eth2.0-specs/tree/v0.11.2)
 [![Discord](https://user-images.githubusercontent.com/7288322/34471967-1df7808a-efbb-11e7-9088-ed0b04151291.png)](https://discord.gg/KSA7rPr)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/prysmaticlabs/geth-sharding?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
Update to spec v0.11.2 badge with #5655 is likely done and in [alpha.6](https://github.com/prysmaticlabs/prysm/releases/tag/v1.0.0-alpha.6)