### PR TITLE
Add Chain Config File for Validator 

### DIFF
--- a/validator/main.go
+++ b/validator/main.go
@@ -71,6 +71,7 @@ var appFlags = []cli.Flag{
 	debug.TraceFlag,
 	cmd.LogFileName,
 	cmd.ConfigFileFlag,
+	cmd.ChainConfigFileFlag,
 }
 
 func init() {

--- a/validator/node/BUILD.bazel
+++ b/validator/node/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//shared/cmd:go_default_library",
         "//shared/debug:go_default_library",
         "//shared/featureconfig:go_default_library",
+        "//shared/params:go_default_library",
         "//shared/prometheus:go_default_library",
         "//shared/tracing:go_default_library",
         "//shared/version:go_default_library",

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/debug"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/prometheus"
 	"github.com/prysmaticlabs/prysm/shared/tracing"
 	"github.com/prysmaticlabs/prysm/shared/version"
@@ -65,6 +66,11 @@ func NewValidatorClient(ctx *cli.Context) (*ValidatorClient, error) {
 		ctx:      ctx,
 		services: registry,
 		stop:     make(chan struct{}),
+	}
+
+	if ctx.IsSet(cmd.ChainConfigFileFlag.Name) {
+		chainConfigFileName := ctx.String(cmd.ChainConfigFileFlag.Name)
+		params.LoadChainConfigFile(chainConfigFileName)
 	}
 
 	featureconfig.ConfigureValidator(ctx)

--- a/validator/usage.go
+++ b/validator/usage.go
@@ -56,6 +56,7 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.LogFormat,
 			cmd.LogFileName,
 			cmd.ConfigFileFlag,
+			cmd.ChainConfigFileFlag,
 		},
 	},
 	{


### PR DESCRIPTION
Follow-up to #5694, this adds the same functionality of loading a custom config from a file to the validator client