### PR TITLE
Update BLS and use constant for SetETHmode

### DIFF
--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -19,7 +19,7 @@ func init() {
 	if err := bls12.Init(bls12.BLS12_381); err != nil {
 		panic(err)
 	}
-	if err := bls12.SetETHmode(1); err != nil {
+	if err := bls12.SetETHmode(bls12.EthModeDraft05); err != nil {
 		panic(err)
 	}
 }

--- a/third_party/herumi/herumi.bzl
+++ b/third_party/herumi/herumi.bzl
@@ -11,31 +11,31 @@ def bls_dependencies():
     _maybe(
         http_archive,
         name = "herumi_bls_eth_go_binary",
-        strip_prefix = "bls-eth-go-binary-f58f8b8bd66f1d286d650e9b39b9629411067f82",
+        strip_prefix = "bls-eth-go-binary-524312f42ec6769c557990175baede559f4c43b9",
         urls = [
-            "https://github.com/herumi/bls-eth-go-binary/archive/f58f8b8bd66f1d286d650e9b39b9629411067f82.tar.gz",
+            "https://github.com/herumi/bls-eth-go-binary/archive/524312f42ec6769c557990175baede559f4c43b9.tar.gz",
         ],
-        sha256 = "1a61363fdc33018d4334481410082c804f5aa083c4454b7eef3b2395a0df98f1",
+        sha256 = "c5d7e014059a8d95a8eb76817a53ef6e67b95b4cf6e8ad763fedf96bd2405add",
         build_file = "@prysm//third_party/herumi:bls_eth_go_binary.BUILD",
     )
     _maybe(
         http_archive,
         name = "herumi_mcl",
-        strip_prefix = "mcl-1b043ade54bf7e30b8edc29eb01410746ba92d3d",
+        strip_prefix = "mcl-95e80e3c7b3d3ba0e56ae4d8fdc75f80318fab6a",
         urls = [
-            "https://github.com/herumi/mcl/archive/1b043ade54bf7e30b8edc29eb01410746ba92d3d.tar.gz",
+            "https://github.com/herumi/mcl/archive/95e80e3c7b3d3ba0e56ae4d8fdc75f80318fab6a.tar.gz",
         ],
-        sha256 = "306bf22b747db174390bbe43de503131b0b5b75bbe586d44f3465c16bda8d28a",
+        sha256 = "4679383dd32a1a2c35680e4364250309c302c5473ce156991ce496bfcf1affaa",
         build_file = "@prysm//third_party/herumi:mcl.BUILD",
     )
     _maybe(
         http_archive,
         name = "herumi_bls",
-        strip_prefix = "bls-989e28ede489e5f0e50cfc87e3fd8a8767155b9f",
+        strip_prefix = "bls-f9af288f71b74e0eb9df366d5510210d70eb92e9",
         urls = [
-            "https://github.com/herumi/bls/archive/989e28ede489e5f0e50cfc87e3fd8a8767155b9f.tar.gz",
+            "https://github.com/herumi/bls/archive/f9af288f71b74e0eb9df366d5510210d70eb92e9.tar.gz",
         ],
-        sha256 = "14b441cc66ca7e6c4e0542dcfc6d9f83f4472f0e7a43efaa1d3ea93e2e2b7491",
+        sha256 = "97f8cdb9f1610753acac8e81ec7308245b9eb02a4bfac03a88aa298325520f30",
         build_file = "@prysm//third_party/herumi:bls.BUILD",
     )
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

SetETHmode(1) was not clear enough for us to understand what draft of BLS we were targeting in Prysm.

**Which issues(s) does this PR fix?**

N/A - Minor fix, no tracking issue.

**Other notes for review**

https://github.com/herumi/bls-eth-go-binary/pull/15 is out for review as well. We can update BLS again once that merges. 