### PR TITLE
Don't Copy The Whole Validator Map each time

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -945,7 +945,6 @@ func ProcessDeposit(
 	pubKey := deposit.Data.PublicKey
 	amount := deposit.Data.Amount
 	index, ok := beaconState.ValidatorIndexByPubkey(bytesutil.ToBytes48(pubKey))
-	numVals := beaconState.NumValidators()
 	if !ok {
 		domain, err := helpers.ComputeDomain(params.BeaconConfig().DomainDeposit, nil, nil)
 		if err != nil {
@@ -976,8 +975,6 @@ func ProcessDeposit(
 		if err := beaconState.AppendBalance(amount); err != nil {
 			return nil, err
 		}
-		numVals++
-		beaconState.SetValidatorIndexByPubkey(bytesutil.ToBytes48(pubKey), uint64(numVals-1))
 	} else {
 		if err := helpers.IncreaseBalance(beaconState, uint64(index), amount); err != nil {
 			return nil, err

--- a/beacon-chain/state/setters.go
+++ b/beacon-chain/state/setters.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 	coreutils "github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/memorypool"
@@ -657,10 +656,8 @@ func (b *BeaconState) AppendValidator(val *ethpb.Validator) error {
 	}
 	b.lock.RLock()
 	vals := b.state.Validators
-	valMap := b.valIdxMap
 	if b.sharedFieldReferences[validators].refs > 1 {
 		vals = b.Validators()
-		valMap = coreutils.ValidatorIndexMap(vals)
 		b.sharedFieldReferences[validators].MinusRef()
 		b.sharedFieldReferences[validators] = &reference{refs: 1}
 	}
@@ -673,7 +670,7 @@ func (b *BeaconState) AppendValidator(val *ethpb.Validator) error {
 	// it to the validator map
 	b.state.Validators = append(vals, val)
 	valIdx := uint64(len(b.state.Validators) - 1)
-	valMap[bytesutil.ToBytes48(val.PublicKey)] = valIdx
+	valMap := coreutils.ValidatorIndexMap(b.state.Validators)
 
 	b.markFieldAsDirty(validators)
 	b.AddDirtyIndices(validators, []uint64{valIdx})


### PR DESCRIPTION
**What type of PR is this?**

Code Cleanup

**What does this PR do? Why is it needed?**

Refactor to only append validators and internally add pubkeys to our validator index map. ~This makes each map track the validator field as its 'reference'~. We only copy the whole map once per deposit, so as to reduce the time spent of map copies.

**Which issues(s) does this PR fix?**
Part of #5779

**Other notes for review**
