### PR TITLE
Refactor ReceiveBlock to receive the block root.

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -54,7 +54,7 @@ var initialSyncBlockCacheSize = 2 * params.BeaconConfig().SlotsPerEpoch
 //    # Update finalized checkpoint
 //    if state.finalized_checkpoint.epoch > store.finalized_checkpoint.epoch:
 //        store.finalized_checkpoint = state.finalized_checkpoint
-func (s *Service) onBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock) (*stateTrie.BeaconState, error) {
+func (s *Service) onBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock, blockRoot [32]byte) (*stateTrie.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "blockchain.onBlock")
 	defer span.End()
 

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -119,7 +119,11 @@ func TestStore_OnBlock(t *testing.T) {
 			service.prevFinalizedCheckpt = &ethpb.Checkpoint{Root: validGenesisRoot[:]}
 			service.finalizedCheckpt.Root = roots[0]
 
-			_, err := service.onBlock(ctx, &ethpb.SignedBeaconBlock{Block: tt.blk})
+			root, err := stateutil.BlockRoot(tt.blk)
+			if err != nil {
+				t.Error(err)
+			}
+			_, err = service.onBlock(ctx, &ethpb.SignedBeaconBlock{Block: tt.blk}, root)
 			if err == nil || !strings.Contains(err.Error(), tt.wantErrString) {
 				t.Errorf("Store.OnBlock() error = %v, wantErr = %v", err, tt.wantErrString)
 			}

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -122,7 +122,7 @@ func (ms *ChainService) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.S
 }
 
 // ReceiveBlockNoPubsubForkchoice mocks ReceiveBlockNoPubsubForkchoice method in chain service.
-func (ms *ChainService) ReceiveBlockNoPubsubForkchoice(ctx context.Context, block *ethpb.SignedBeaconBlock) error {
+func (ms *ChainService) ReceiveBlockNoPubsubForkchoice(ctx context.Context, block *ethpb.SignedBeaconBlock, blockRoot [32]byte) error {
 	if ms.State == nil {
 		ms.State = &stateTrie.BeaconState{}
 	}

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -117,7 +117,7 @@ func (ms *ChainService) ReceiveBlockNoVerify(ctx context.Context, block *ethpb.S
 }
 
 // ReceiveBlockNoPubsub mocks ReceiveBlockNoPubsub method in chain service.
-func (ms *ChainService) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.SignedBeaconBlock) error {
+func (ms *ChainService) ReceiveBlockNoPubsub(ctx context.Context, block *ethpb.SignedBeaconBlock, blockRoot [32]byte) error {
 	return nil
 }
 

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -112,7 +112,7 @@ func (ms *ChainService) ReceiveBlock(ctx context.Context, block *ethpb.SignedBea
 }
 
 // ReceiveBlockNoVerify mocks ReceiveBlockNoVerify method in chain service.
-func (ms *ChainService) ReceiveBlockNoVerify(ctx context.Context, block *ethpb.SignedBeaconBlock) error {
+func (ms *ChainService) ReceiveBlockNoVerify(ctx context.Context, block *ethpb.SignedBeaconBlock, blockRoot [32]byte) error {
 	return nil
 }
 

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -107,7 +107,7 @@ func (mon *MockOperationNotifier) OperationFeed() *event.Feed {
 }
 
 // ReceiveBlock mocks ReceiveBlock method in chain service.
-func (ms *ChainService) ReceiveBlock(ctx context.Context, block *ethpb.SignedBeaconBlock) error {
+func (ms *ChainService) ReceiveBlock(ctx context.Context, block *ethpb.SignedBeaconBlock, blockRoot [32]byte) error {
 	return nil
 }
 

--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -133,7 +133,7 @@ func (vs *Server) ProposeBlock(ctx context.Context, blk *ethpb.SignedBeaconBlock
 		})
 	}()
 
-	if err := vs.BlockReceiver.ReceiveBlock(ctx, blk); err != nil {
+	if err := vs.BlockReceiver.ReceiveBlock(ctx, blk, root); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not process beacon block: %v", err)
 	}
 

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -275,7 +275,7 @@ func TestBlocksQueueLoop(t *testing.T) {
 					return fmt.Errorf("beacon node doesn't have a block in db with root %#x", block.Block.ParentRoot)
 				}
 				if featureconfig.Get().InitSyncNoVerify {
-					if err := mc.ReceiveBlockNoVerify(ctx, block); err != nil {
+					if err := mc.ReceiveBlockNoVerify(ctx, block, root); err != nil {
 						return err
 					}
 				} else {

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -275,6 +275,10 @@ func TestBlocksQueueLoop(t *testing.T) {
 					return fmt.Errorf("beacon node doesn't have a block in db with root %#x", block.Block.ParentRoot)
 				}
 				if featureconfig.Get().InitSyncNoVerify {
+					root, err := stateutil.BlockRoot(block.Block)
+					if err != nil {
+						return err
+					}
 					if err := mc.ReceiveBlockNoVerify(ctx, block, root); err != nil {
 						return err
 					}

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -3,6 +3,7 @@ package initialsync
 import (
 	"context"
 	"fmt"
+	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
 	"testing"
 
 	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -278,7 +279,11 @@ func TestBlocksQueueLoop(t *testing.T) {
 						return err
 					}
 				} else {
-					if err := mc.ReceiveBlockNoPubsubForkchoice(ctx, block); err != nil {
+					root, err := stateutil.BlockRoot(block.Block)
+					if err != nil {
+						return err
+					}
+					if err := mc.ReceiveBlockNoPubsubForkchoice(ctx, block, root); err != nil {
 						return err
 					}
 				}

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -105,7 +105,11 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 
 		for _, blk := range resp {
 			s.logSyncStatus(genesis, blk.Block, counter)
-			if err := s.chain.ReceiveBlockNoPubsubForkchoice(ctx, blk); err != nil {
+			root, err := stateutil.BlockRoot(blk.Block)
+			if err != nil {
+				return err
+			}
+			if err := s.chain.ReceiveBlockNoPubsubForkchoice(ctx, blk, root); err != nil {
 				log.WithError(err).Error("Failed to process block, exiting init sync")
 				return nil
 			}
@@ -174,7 +178,11 @@ func (s *Service) processBlock(ctx context.Context, blk *eth.SignedBeaconBlock) 
 			return err
 		}
 	} else {
-		if err := s.chain.ReceiveBlockNoPubsubForkchoice(ctx, blk); err != nil {
+		root, err := stateutil.BlockRoot(blk.Block)
+		if err != nil {
+			return err
+		}
+		if err := s.chain.ReceiveBlockNoPubsubForkchoice(ctx, blk, root); err != nil {
 			return err
 		}
 	}

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -58,7 +58,12 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 	// Step 1 - Sync to end of finalized epoch.
 	for blk := range queue.fetchedBlocks {
 		s.logSyncStatus(genesis, blk.Block, counter)
-		if err := s.processBlock(ctx, blk); err != nil {
+		root, err := stateutil.BlockRoot(blk.Block)
+		if err != nil {
+			log.WithError(err).Info("Cannot determine root of block")
+			continue
+		}
+		if err := s.processBlock(ctx, blk, root); err != nil {
 			log.WithError(err).Info("Block is invalid")
 			continue
 		}
@@ -164,7 +169,7 @@ func (s *Service) logSyncStatus(genesis time.Time, blk *eth.BeaconBlock, counter
 	)
 }
 
-func (s *Service) processBlock(ctx context.Context, blk *eth.SignedBeaconBlock) error {
+func (s *Service) processBlock(ctx context.Context, blk *eth.SignedBeaconBlock, blockRoot [32]byte) error {
 	parentRoot := bytesutil.ToBytes32(blk.Block.ParentRoot)
 	if !s.db.HasBlock(ctx, parentRoot) && !s.chain.HasInitSyncBlock(parentRoot) {
 		return fmt.Errorf("beacon node doesn't have a block in db with root %#x", blk.Block.ParentRoot)
@@ -174,15 +179,11 @@ func (s *Service) processBlock(ctx context.Context, blk *eth.SignedBeaconBlock) 
 		Data: &blockfeed.ReceivedBlockData{SignedBlock: blk},
 	})
 	if featureconfig.Get().InitSyncNoVerify {
-		if err := s.chain.ReceiveBlockNoVerify(ctx, blk); err != nil {
+		if err := s.chain.ReceiveBlockNoVerify(ctx, blk, blockRoot); err != nil {
 			return err
 		}
 	} else {
-		root, err := stateutil.BlockRoot(blk.Block)
-		if err != nil {
-			return err
-		}
-		if err := s.chain.ReceiveBlockNoPubsubForkchoice(ctx, blk, root); err != nil {
+		if err := s.chain.ReceiveBlockNoPubsubForkchoice(ctx, blk, blockRoot); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The critical path for ProposeBlock required calling HashTreeRoot ~three~ four times for a beacon block.
Additionally, receiving a block from pubsub would call HashTreeRoot twice, at least. 

**Which issues(s) does this PR fix?**

N/A - super small

**Other notes for review**
