### PR TITLE
Temporarily remove new state mgmt from e2e

### DIFF
--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -319,7 +319,7 @@ var (
 		Hidden: true,
 	}
 	deprecatedEnableCustomBlockHTR = &cli.BoolFlag{
-		Name:  "enable-custom-block-htr",
+		Name:   "enable-custom-block-htr",
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
@@ -429,5 +429,4 @@ var E2EBeaconChainFlags = []string{
 	"--check-head-state",
 	"--enable-state-field-trie",
 	"--enable-state-ref-copy",
-	"--enable-new-state-mgmt",
 }


### PR DESCRIPTION
Over the last few days, e2e test has grown more flakey with `--enable-new-state-mgmt` flag. I need time to investigate why. In this mean time, disabling it to unblock regular flow