### PR TITLE
Make IP Static for Public IPs

### DIFF
--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -64,6 +64,7 @@ func (s *Service) createListener(
 			log.Errorf("Invalid host address given: %s", hostIP.String())
 		} else {
 			localNode.SetFallbackIP(hostIP)
+			localNode.SetStaticIP(hostIP)
 		}
 	}
 	dv5Cfg := discover.Config{


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Currently if we have a public ip specified, we will still use the endpoint predictor
to update our IP address. In the event we are peered with more local nodes vs 
external nodes, we might end up reverting back to our internal ip address. This 
instead makes our IPs static
 
**Which issues(s) does this PR fix?**

N.A

Fixes #

N.A

**Other notes for review**

cc @jrhea