### PR TITLE
Duplicate init sync test target for better coverage reporting

### DIFF
--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -43,7 +43,7 @@ go_library(
 )
 
 go_test(
-    name = "go_default_test",
+    name = "go_raceon_test",
     srcs = [
         "blocks_fetcher_test.go",
         "blocks_queue_test.go",
@@ -54,6 +54,44 @@ go_test(
     embed = [":go_default_library"],
     race = "on",
     tags = ["race_on"],
+    deps = [
+        "//beacon-chain/blockchain/testing:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
+        "//beacon-chain/db:go_default_library",
+        "//beacon-chain/db/testing:go_default_library",
+        "//beacon-chain/p2p/peers:go_default_library",
+        "//beacon-chain/p2p/testing:go_default_library",
+        "//beacon-chain/state:go_default_library",
+        "//beacon-chain/state/stateutil:go_default_library",
+        "//beacon-chain/sync:go_default_library",
+        "//proto/beacon/p2p/v1:go_default_library",
+        "//shared/bytesutil:go_default_library",
+        "//shared/featureconfig:go_default_library",
+        "//shared/hashutil:go_default_library",
+        "//shared/params:go_default_library",
+        "//shared/roughtime:go_default_library",
+        "//shared/sliceutil:go_default_library",
+        "//shared/testutil:go_default_library",
+        "@com_github_ethereum_go_ethereum//p2p/enr:go_default_library",
+        "@com_github_kevinms_leakybucket_go//:go_default_library",
+        "@com_github_libp2p_go_libp2p_core//network:go_default_library",
+        "@com_github_libp2p_go_libp2p_core//peer:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "blocks_fetcher_test.go",
+        "blocks_queue_test.go",
+        "fsm_test.go",
+        "initial_sync_test.go",
+        "round_robin_test.go",
+    ],
+    embed = [":go_default_library"],
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Adds second target for codecov to analyze code coverage. This is necessary since the coverage collector 

**Which issues(s) does this PR fix?**


**Other notes for review**

We are excluding race enabled tests from coverage since it causes issues. We don't have a great way to disable it, see https://github.com/bazelbuild/rules_go/issues/1875