### PR TITLE
Add Ability to Restrict Outbound Dials

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -64,6 +64,7 @@ var appFlags = []cli.Flag{
 	cmd.P2PPrivKey,
 	cmd.P2PMetadata,
 	cmd.P2PWhitelist,
+	cmd.P2PBlacklist,
 	cmd.P2PEncoding,
 	cmd.P2PPubsub,
 	cmd.DataDirFlag,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -320,6 +320,7 @@ func (b *BeaconNode) registerP2P(cliCtx *cli.Context) error {
 		UDPPort:           cliCtx.Uint(cmd.P2PUDPPort.Name),
 		MaxPeers:          cliCtx.Uint(cmd.P2PMaxPeers.Name),
 		WhitelistCIDR:     cliCtx.String(cmd.P2PWhitelist.Name),
+		BlacklistCIDR:     sliceutil.SplitCommaSeparated(cliCtx.StringSlice(cmd.P2PBlacklist.Name)),
 		EnableUPnP:        cliCtx.Bool(cmd.EnableUPnPFlag.Name),
 		DisableDiscv5:     cliCtx.Bool(flags.DisableDiscv5.Name),
 		Encoding:          cliCtx.String(cmd.P2PEncoding.Name),

--- a/beacon-chain/p2p/config.go
+++ b/beacon-chain/p2p/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	UDPPort               uint
 	MaxPeers              uint
 	WhitelistCIDR         string
+	BlacklistCIDR         []string
 	Encoding              string
 	StateNotifier         statefeed.Notifier
 	PubSub                string

--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -2,13 +2,18 @@ package p2p
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
@@ -56,5 +61,56 @@ func TestPrivateKeyLoading(t *testing.T) {
 	}
 	if !bytes.Equal(newRaw, rawBytes) {
 		t.Errorf("Private keys do not match got %#x but wanted %#x", rawBytes, newRaw)
+	}
+}
+
+func TestPeerBlacklist(t *testing.T) {
+	// create host with blacklist
+	ipAddr, pkey := createAddrAndPrivKey(t)
+	ipAddr2, pkey2 := createAddrAndPrivKey(t)
+
+	mask := ipAddr2.DefaultMask()
+	ones, _ := mask.Size()
+	maskedIP := ipAddr2.Mask(mask)
+	cidr := maskedIP.String() + fmt.Sprintf("/%d", ones)
+
+	listen, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ipAddr, 2000))
+	if err != nil {
+		t.Fatalf("Failed to p2p listen: %v", err)
+	}
+	h1, err := libp2p.New(context.Background(), []libp2p.Option{privKeyOption(pkey), libp2p.ListenAddrs(listen), blacklistSubnets([]string{cidr})}...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := h1.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// create alternate host
+	listen, err = multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ipAddr2, 3000))
+	if err != nil {
+		t.Fatalf("Failed to p2p listen: %v", err)
+	}
+	h2, err := libp2p.New(context.Background(), []libp2p.Option{privKeyOption(pkey2), libp2p.ListenAddrs(listen)}...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err := h2.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	multiAddress, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d/p2p/%s", ipAddr2, 3000, h2.ID()))
+	addrInfo, err := peer.AddrInfoFromP2pAddr(multiAddress)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = h1.Connect(context.Background(), *addrInfo)
+	if err == nil {
+		t.Error("Wanted connection to fail with blacklist")
 	}
 }

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -109,6 +109,7 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.P2PPrivKey,
 			cmd.P2PMetadata,
 			cmd.P2PWhitelist,
+			cmd.P2PBlacklist,
 			cmd.StaticPeers,
 			cmd.EnableUPnPFlag,
 			cmd.P2PEncoding,

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -125,6 +125,13 @@ var (
 			"would whitelist connections to peers on your local network only. The default " +
 			"is to accept all connections.",
 	}
+	// P2PBlacklist defines a list of CIDR subnets to disallow connections from them.
+	P2PBlacklist = &cli.StringSliceFlag{
+		Name: "p2p-blacklist",
+		Usage: "The CIDR subnets for blacklisting peer connections. Example: 192.168.0.0/16 " +
+			"would blacklist connections from peers on your local network only. The default " +
+			"is to accept all connections.",
+	}
 	// P2PEncoding defines the encoding format for p2p messages.
 	P2PEncoding = &cli.StringFlag{
 		Name:  "p2p-encoding",


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix 

**What does this PR do? Why is it needed?**

This adds the ability for the beacon node to restrict outbound dials to undesirable ip ranges. Partially helps with #5663. This is a patch for users, so that they do not have to mess around and configure with `ufw` or `iptables` to prevent dials to internal ips.

**Which issues(s) does this PR fix?**

#5663

**Other notes for review**

N.A