### PR TITLE
`GetValidatorPerformance` return `Unavailable` when syncing

### DIFF
--- a/beacon-chain/rpc/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/beacon/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
         "//beacon-chain/state/stateutil:go_default_library",
+        "//beacon-chain/sync:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",
         "//shared/attestationutil:go_default_library",

--- a/beacon-chain/rpc/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/beacon/BUILD.bazel
@@ -98,6 +98,7 @@ go_test(
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
         "//beacon-chain/state/stateutil:go_default_library",
+        "//beacon-chain/sync/initial-sync/testing:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",
         "//shared/attestationutil:go_default_library",

--- a/beacon-chain/rpc/beacon/server.go
+++ b/beacon-chain/rpc/beacon/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/beacon-chain/powchain"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
+	"github.com/prysmaticlabs/prysm/beacon-chain/sync"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 
@@ -46,4 +47,5 @@ type Server struct {
 	ReceivedAttestationsBuffer  chan *ethpb.Attestation
 	CollectedAttestationsBuffer chan []*ethpb.Attestation
 	StateGen                    *stategen.State
+	SyncChecker                 sync.Checker
 }

--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -932,6 +932,10 @@ func (bs *Server) GetValidatorQueue(
 func (bs *Server) GetValidatorPerformance(
 	ctx context.Context, req *ethpb.ValidatorPerformanceRequest,
 ) (*ethpb.ValidatorPerformanceResponse, error) {
+	if bs.SyncChecker.Syncing() {
+		return nil, status.Errorf(codes.Unavailable, "Syncing to latest head, not ready to respond")
+	}
+
 	validatorSummary := state.ValidatorSummary
 
 	reqPubKeysCount := len(req.PublicKeys)

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -269,6 +269,7 @@ func (s *Service) Start() {
 		AttestationNotifier:         s.operationNotifier,
 		Broadcaster:                 s.p2p,
 		StateGen:                    s.stateGen,
+		SyncChecker:                 s.syncService,
 		ReceivedAttestationsBuffer:  make(chan *ethpb.Attestation, 100),
 		CollectedAttestationsBuffer: make(chan []*ethpb.Attestation, 100),
 	}


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
When a beacon node is syncing, `GetValidatorPerformance` should return Unavailable upon request. `GetValidatorPerformance` requires the beacon node to be on head since it computes validator performances at the most current time

**Which issues(s) does this PR fix?**

Part fix for #5746 

**Other notes for review**
Tested it with my local node and validators syncing with Topaz testnet
