### PR TITLE
Add attestation inclusion histogram

### DIFF
--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -94,6 +94,13 @@ var (
 			Buckets: []float64{1000, 2000, 3000, 4000, 5000, 6000},
 		},
 	)
+	attestationInclusionDelay = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name: "attestation_inclusion_delay_slots",
+			Help: "The number of slots between att.Slot and block.Slot",
+			Buckets: []float64{1, 2, 3, 4, 6, 32, 64},
+		},
+	)
 )
 
 // reportSlotMetrics reports slot related metrics.
@@ -205,4 +212,10 @@ func captureSentTimeMetric(genesisTime uint64, currentSlot uint64) error {
 	sentBlockPropagationHistogram.Observe(float64(diffMs))
 
 	return nil
+}
+
+func reportAttestationInclusion(blk *ethpb.BeaconBlock) {
+	for _, att := range blk.Body.Attestations {
+		attestationInclusionDelay.Observe(float64(blk.Slot-att.Data.Slot))
+	}
 }

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -182,6 +182,8 @@ func (s *Service) onBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock, 
 		s.slashingPool.MarkIncludedAttesterSlashing(b.Body.AttesterSlashings[i])
 	}
 
+	defer reportAttestationInclusion(b)
+
 	return postState, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR adds monitoring around attestation inclusion delay. Ideally, all attestations would be included in a block 1 slot after their creation. 

After a few minutes:
```
# HELP attestation_inclusion_delay_slots The number of slots between att.Slot and block.Slot
# TYPE attestation_inclusion_delay_slots histogram
attestation_inclusion_delay_slots_bucket{le="1"} 469
attestation_inclusion_delay_slots_bucket{le="2"} 599
attestation_inclusion_delay_slots_bucket{le="3"} 669
attestation_inclusion_delay_slots_bucket{le="4"} 702
attestation_inclusion_delay_slots_bucket{le="6"} 721
attestation_inclusion_delay_slots_bucket{le="32"} 1405
attestation_inclusion_delay_slots_bucket{le="64"} 1405
attestation_inclusion_delay_slots_bucket{le="+Inf"} 1405
attestation_inclusion_delay_slots_sum 16402
```

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
