### PR TITLE
Adds BlockBatchLimitBurstFactor flag

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -124,6 +124,12 @@ var (
 		Usage: "The amount of blocks the local peer is bounded to request and respond to in a batch.",
 		Value: 64,
 	}
+	// BlockBatchLimitBurstFactor specifies the factor by which block batch size may increase.
+	BlockBatchLimitBurstFactor = &cli.IntFlag{
+		Name:  "block-batch-limit-burst-factor",
+		Usage: "The factor by which block batch limit may increase on burst.",
+		Value: 10,
+	}
 	// EnableDebugRPCEndpoints as /v1/beacon/state.
 	EnableDebugRPCEndpoints = &cli.BoolFlag{
 		Name:  "enable-debug-rpc-endpoints",

--- a/beacon-chain/flags/config.go
+++ b/beacon-chain/flags/config.go
@@ -19,6 +19,7 @@ type GlobalFlags struct {
 	MaxPageSize                       int
 	DeploymentBlock                   int
 	BlockBatchLimit                   int
+	BlockBatchLimitBurstFactor        int
 }
 
 var globalConfig *GlobalFlags
@@ -59,6 +60,7 @@ func ConfigureGlobalFlags(ctx *cli.Context) {
 		cfg.DisableDiscv5 = true
 	}
 	cfg.BlockBatchLimit = ctx.Int(BlockBatchLimit.Name)
+	cfg.BlockBatchLimitBurstFactor = ctx.Int(BlockBatchLimitBurstFactor.Name)
 	cfg.MaxPageSize = ctx.Int(RPCMaxPageSize.Name)
 	cfg.DeploymentBlock = ctx.Int(ContractDeploymentBlock.Name)
 	configureMinimumPeers(ctx, cfg)

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -41,6 +41,7 @@ var appFlags = []cli.Flag{
 	flags.UnsafeSync,
 	flags.DisableDiscv5,
 	flags.BlockBatchLimit,
+	flags.BlockBatchLimitBurstFactor,
 	flags.InteropMockEth1DataVotesFlag,
 	flags.InteropGenesisStateFlag,
 	flags.InteropNumValidatorsFlag,

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -110,7 +110,7 @@ type Service struct {
 func NewRegularSync(cfg *Config) *Service {
 	// Intialize block limits.
 	allowedBlocksPerSecond = float64(flags.Get().BlockBatchLimit)
-	allowedBlocksBurst = int64(10 * allowedBlocksPerSecond)
+	allowedBlocksBurst = int64(flags.Get().BlockBatchLimitBurstFactor * flags.Get().BlockBatchLimit)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	r := &Service{

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -96,6 +96,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.SlotsPerArchivedPoint,
 			flags.DisableDiscv5,
 			flags.BlockBatchLimit,
+			flags.BlockBatchLimitBurstFactor,
 			flags.EnableDebugRPCEndpoints,
 		},
 	},


### PR DESCRIPTION
I am working on optimizing init-sync, and want to use whole bandwidth available. So, need to know preferred block batch size and burst factor. In order not to use magic constant in second place (inside of `initialsync` package), new flag is introduced.