### PR TITLE
Fix historical detection for the slasher

### DIFF
--- a/beacon-chain/rpc/beacon/attestations.go
+++ b/beacon-chain/rpc/beacon/attestations.go
@@ -159,7 +159,7 @@ func (bs *Server) ListIndexedAttestations(
 		if err != nil {
 			return nil, status.Errorf(
 				codes.Internal,
-				"Could not retrieve state for attestation data block root %v: %v",
+				"Could not retrieve state for attestation data block root %#x: %v",
 				targetRoot,
 				err,
 			)

--- a/slasher/beaconclient/receivers.go
+++ b/slasher/beaconclient/receivers.go
@@ -108,7 +108,7 @@ func (bs *Service) receiveAttestations(ctx context.Context) {
 				}
 			} else {
 				log.WithError(err).Error("Could not receive attestations from beacon node")
-				break
+				return
 			}
 		}
 		if res == nil {

--- a/slasher/beaconclient/receivers.go
+++ b/slasher/beaconclient/receivers.go
@@ -104,9 +104,11 @@ func (bs *Service) receiveAttestations(ctx context.Context) {
 					break
 				default:
 					log.WithError(err).Errorf("Could not receive attestations from beacon node. rpc status: %v", e.Code())
+					continue
 				}
 			} else {
 				log.WithError(err).Error("Could not receive attestations from beacon node")
+				continue
 			}
 		}
 		if res == nil {

--- a/slasher/beaconclient/receivers.go
+++ b/slasher/beaconclient/receivers.go
@@ -104,11 +104,9 @@ func (bs *Service) receiveAttestations(ctx context.Context) {
 					break
 				default:
 					log.WithError(err).Errorf("Could not receive attestations from beacon node. rpc status: %v", e.Code())
-					return
 				}
 			} else {
 				log.WithError(err).Error("Could not receive attestations from beacon node")
-				return
 			}
 		}
 		if res == nil {

--- a/slasher/beaconclient/receivers.go
+++ b/slasher/beaconclient/receivers.go
@@ -104,11 +104,11 @@ func (bs *Service) receiveAttestations(ctx context.Context) {
 					break
 				default:
 					log.WithError(err).Errorf("Could not receive attestations from beacon node. rpc status: %v", e.Code())
-					continue
+					break
 				}
 			} else {
 				log.WithError(err).Error("Could not receive attestations from beacon node")
-				continue
+				break
 			}
 		}
 		if res == nil {

--- a/slasher/detection/service.go
+++ b/slasher/detection/service.go
@@ -132,6 +132,9 @@ func (ds *Service) detectHistoricalChainData(ctx context.Context) {
 		)
 
 		for _, att := range indexedAtts {
+			if ctx.Err() == context.Canceled {
+				log.WithError(ctx.Err()).Error("context has been canceled, ending detection")
+			}
 			slashings, err := ds.DetectAttesterSlashings(ctx, att)
 			if err != nil {
 				log.WithError(err).Error("Could not detect attester slashings")

--- a/slasher/detection/service.go
+++ b/slasher/detection/service.go
@@ -89,7 +89,7 @@ func (ds *Service) Start() {
 	if !featureconfig.Get().DisableHistoricalDetection {
 		// The detection service runs detection on all historical
 		// chain data since genesis.
-		ds.detectHistoricalChainData(ds.ctx)
+		go ds.detectHistoricalChainData(ds.ctx)
 	}
 
 	// We subscribe to incoming blocks from the beacon node via

--- a/slasher/detection/service.go
+++ b/slasher/detection/service.go
@@ -89,7 +89,7 @@ func (ds *Service) Start() {
 	if !featureconfig.Get().DisableHistoricalDetection {
 		// The detection service runs detection on all historical
 		// chain data since genesis.
-		go ds.detectHistoricalChainData(ds.ctx)
+		ds.detectHistoricalChainData(ds.ctx)
 	}
 
 	// We subscribe to incoming blocks from the beacon node via

--- a/slasher/detection/service.go
+++ b/slasher/detection/service.go
@@ -134,6 +134,7 @@ func (ds *Service) detectHistoricalChainData(ctx context.Context) {
 		for _, att := range indexedAtts {
 			if ctx.Err() == context.Canceled {
 				log.WithError(ctx.Err()).Error("context has been canceled, ending detection")
+				return
 			}
 			slashings, err := ds.DetectAttesterSlashings(ctx, att)
 			if err != nil {

--- a/slasher/detection/service.go
+++ b/slasher/detection/service.go
@@ -137,6 +137,11 @@ func (ds *Service) detectHistoricalChainData(ctx context.Context) {
 				log.WithError(err).Error("Could not detect attester slashings")
 				continue
 			}
+			if len(slashings) < 1 {
+				if err := ds.minMaxSpanDetector.UpdateSpans(ctx, att); err != nil {
+					log.WithError(err).Error("Could not update spans")
+				}
+			}
 			ds.submitAttesterSlashings(ctx, slashings)
 		}
 		latestStoredHead = &ethpb.ChainHead{HeadEpoch: epoch}


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR is a few fixes made after my observations on my running slasher. The main fixes made are:
* Unretrievable committees no longer break detection
* Historical detection did not update the spans whatsoever, now they are updated and detection is reliable.