### PR TITLE
Increase slots per archived point to 2048

### DIFF
--- a/beacon-chain/state/stategen/migrate.go
+++ b/beacon-chain/state/stategen/migrate.go
@@ -20,7 +20,7 @@ func (s *State) MigrateToCold(ctx context.Context, finalizedSlot uint64, finaliz
 	// Verify migration is sensible. The new finalized point must increase the current split slot, and
 	// on an epoch boundary for hot state summary scheme to work.
 	currentSplitSlot := s.splitInfo.slot
-	if currentSplitSlot == 0 || currentSplitSlot > finalizedSlot {
+	if currentSplitSlot > finalizedSlot {
 		return nil
 	}
 

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -203,7 +203,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	EmptySignature:            [96]byte{},
 	DefaultPageSize:           250,
 	MaxPeersToSync:            15,
-	SlotsPerArchivedPoint:     256,
+	SlotsPerArchivedPoint:     2048,
 
 	// Slasher related values.
 	WeakSubjectivityPeriod:    54000,


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**
Change list: 
 * Set slots per archived point to 2048 to align with lighthouse and eth2 spec as specified in state sync. https://lighthouse-book.sigmaprime.io/advanced_database.html
 * Remove outdated `currentSplitSlot == 0` check

**Other notes for review**
Tested with 3 Topaz nodes locally. One synced from genesis to head. The rest synced to head with and without validators
