### PR TITLE
Remove extra committee shuffling for initial syncing

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -298,13 +298,6 @@ func ShuffledIndices(state *stateTrie.BeaconState, epoch uint64) ([]uint64, erro
 // list with committee index and epoch number. It caches the shuffled indices for current epoch and next epoch.
 func UpdateCommitteeCache(state *stateTrie.BeaconState, epoch uint64) error {
 	for _, e := range []uint64{epoch, epoch + 1} {
-		shuffledIndices, err := ShuffledIndices(state, e)
-		if err != nil {
-			return err
-		}
-
-		count := SlotCommitteeCount(uint64(len(shuffledIndices)))
-
 		seed, err := Seed(state, e, params.BeaconConfig().DomainBeaconAttester)
 		if err != nil {
 			return err
@@ -312,6 +305,13 @@ func UpdateCommitteeCache(state *stateTrie.BeaconState, epoch uint64) error {
 		if _, exists, err := committeeCache.CommitteeCache.GetByKey(string(seed[:])); err == nil && exists {
 			return nil
 		}
+
+		shuffledIndices, err := ShuffledIndices(state, e)
+		if err != nil {
+			return err
+		}
+
+		count := SlotCommitteeCount(uint64(len(shuffledIndices)))
 
 		// Store the sorted indices as well as shuffled indices. In current spec,
 		// sorted indices is required to retrieve proposer index. This is also


### PR DESCRIPTION
**What type of PR is this?**
> Feature

**What does this PR do? Why is it needed?**
Committee cache checks if the key already exists in cache before updating the cache, but `ShuffledIndices` was placed before the check so it would just shuffle the indices regardless key exists. The extra shuffle was observed in flame during initial syncing. 
Before the fix (shuffle twice per 2 epochs):
<img width="1606" alt="Screen Shot 2020-05-13 at 10 44 32 AM" src="https://user-images.githubusercontent.com/21316537/81859817-af3e3780-951a-11ea-8d96-b3ac1ed2d018.png">

After the fix(shuffle once per 2 epochs) :
![Screen Shot 2020-05-13 at 12 32 34 PM](https://user-images.githubusercontent.com/21316537/81860101-1cea6380-951b-11ea-9215-6bd7bfc22d92.png)

It may not seem a lot (3% saving in profile) but it resulted in 15% faster initial syncing time!

**Which issues(s) does this PR fix?**

Fixes #5840 

**Other notes for review**
Tested syncing from genesis to head
