### PR TITLE
Regen historical using `ArchivedPointRoot` then `State`

### DIFF
--- a/beacon-chain/db/kv/regen_historical_states.go
+++ b/beacon-chain/db/kv/regen_historical_states.go
@@ -43,18 +43,11 @@ func (kv *Store) regenHistoricalStates(ctx context.Context) error {
 	}
 	if lastArchivedIndex > 0 {
 		archivedIndexStart := lastArchivedIndex - 1
-		wantedSlotBelow := archivedIndexStart*slotsPerArchivedPoint + 1
-		states, err := kv.HighestSlotStatesBelow(ctx, wantedSlotBelow)
+		archivedRoot := kv.ArchivedPointRoot(ctx, archivedIndexStart)
+		currentState, err := kv.State(ctx, archivedRoot)
 		if err != nil {
 			return err
 		}
-		if len(states) == 0 {
-			return errors.New("states can't be empty")
-		}
-		if states[0] == nil {
-			return errors.New("nil last state")
-		}
-		currentState = states[0]
 		startSlot = currentState.Slot()
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
Use proper getters to retrieve last archived state instead of `HighestSlotStatesBelow`

**Which issues(s) does this PR fix?**
Fixes #5843 

**Other notes for review**
Regen and save from genesis to latest head 🆗 
