### PR TITLE
Allow a Larger Allowance for Peer Faults

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -59,7 +59,7 @@ const lookupLimit = 15
 const prysmProtocolPrefix = "/prysm/0.0.0"
 
 // maxBadResponses is the maximum number of bad responses from a peer before we stop talking to it.
-const maxBadResponses = 3
+const maxBadResponses = 6
 
 const (
 	pubsubFlood  = "flood"

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -59,7 +59,7 @@ const lookupLimit = 15
 const prysmProtocolPrefix = "/prysm/0.0.0"
 
 // maxBadResponses is the maximum number of bad responses from a peer before we stop talking to it.
-const maxBadResponses = 6
+const maxBadResponses = 5
 
 const (
 	pubsubFlood  = "flood"

--- a/beacon-chain/p2p/subnets_test.go
+++ b/beacon-chain/p2p/subnets_test.go
@@ -100,7 +100,7 @@ func TestStartDiscV5_DiscoverPeersWithSubnets(t *testing.T) {
 	}
 
 	// Wait for the nodes to have their local routing tables to be populated with the other nodes
-	time.Sleep(4 * discoveryWaitTime)
+	time.Sleep(6 * discoveryWaitTime)
 
 	// look up 3 different subnets
 	exists, err := s.FindPeersWithSubnet(1)

--- a/beacon-chain/sync/rpc_metadata.go
+++ b/beacon-chain/sync/rpc_metadata.go
@@ -55,7 +55,6 @@ func (r *Service) sendMetaDataRequest(ctx context.Context, id peer.ID) (*pb.Meta
 	}
 	msg := new(pb.MetaData)
 	if err := r.p2p.Encoding().DecodeWithLength(stream, msg); err != nil {
-		r.p2p.Peers().IncrementBadResponses(stream.Conn().RemotePeer())
 		return nil, err
 	}
 	return msg, nil

--- a/beacon-chain/sync/rpc_ping.go
+++ b/beacon-chain/sync/rpc_ping.go
@@ -70,7 +70,6 @@ func (r *Service) sendPingRequest(ctx context.Context, id peer.ID) error {
 	}
 	msg := new(uint64)
 	if err := r.p2p.Encoding().DecodeWithLength(stream, msg); err != nil {
-		r.p2p.Peers().IncrementBadResponses(stream.Conn().RemotePeer())
 		return err
 	}
 	valid, err := r.validateSequenceNum(*msg, stream.Conn().RemotePeer())

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -122,8 +122,9 @@ func (r *Service) reValidatePeer(ctx context.Context, id peer.ID) error {
 	if err := r.sendRPCStatusRequest(ctx, id); err != nil {
 		return err
 	}
+	// Do not return an error for ping requests.
 	if err := r.sendPingRequest(ctx, id); err != nil {
-		return err
+		log.WithError(err).Error("Could not ping peer")
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

Code Cleanup

**What does this PR do? Why is it needed?**

This PR increases the number of allowed faults from a peer to 5. Given that the network is much larger now, it would make sense to have a larger allowance for peer faults. Also removes us marking a peer as bad in some occasions. 


**Which issues(s) does this PR fix?**


**Other notes for review**
