### PR TITLE
Fixes bug with excessive rate limiting

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -111,6 +111,7 @@ go_test(
         "subscriber_beacon_blocks_test.go",
         "subscriber_committee_index_beacon_attestation_test.go",
         "subscriber_test.go",
+        "sync_test.go",
         "validate_aggregate_proof_test.go",
         "validate_attester_slashing_test.go",
         "validate_beacon_blocks_test.go",

--- a/beacon-chain/sync/sync_test.go
+++ b/beacon-chain/sync/sync_test.go
@@ -1,0 +1,19 @@
+package sync
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestMain(m *testing.M) {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
+
+	allowedBlocksPerSecond = 64
+	allowedBlocksBurst = int64(10 * allowedBlocksPerSecond)
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- Fixes issue when rate limiting was too aggressive, depleting capacity excessively
- Improves speed of test (15s -> 5s), but setting up database for blocks used in tests only (not all blocks in range)

**Which issues(s) does this PR fix?**

Issue located when working on `init-sync` optimizations, and fix was found immediately - so no corresponding issue opened.

**Other notes for review**
We had several issues:
- Rate limiter's capacity was decreased even before any block streaming occurred - which is unfair, as before blocks are streamed, we can't count them. It is correct to check if limits are exceeded **before** sending anything, but updating capacity should occur after the streaming.
- **More importantly**, we've always decreased capacity by `allowedBlocksPerSecond`:
https://github.com/prysmaticlabs/prysm/blob/34c02ffd346462f387f3d99eab798cf81f845c8e/beacon-chain/sync/rpc_beacon_blocks_by_range.go#L78
This means, that with our current `init-sync` routine, where requests are interleaved, and it is common to request less than a dozen of blocks for each peer, every request (even for, say, 4 blocks) - will be considered a *served* request for 64 blocks. So, effectively, *sometimes* we mark as bad peers, peers which are not bad at all. That's our node sends 9 requests for 4 blocks (and it keeps track to make sure it doesn't get over the limit) in 1 sec - it gets banned (we do not allow x10 increase - x9 is enough to get banned). 

This issue shouldn't manifest itself with update (#5798) where I indeed force single peer to fetch close to allowed max blocks in each request. But with current routine - we are excessively banning peers.
