### PR TITLE
Revert "Check Whether Block Is Already Processed"

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -22,8 +22,6 @@ import (
 // This defines size of the upper bound for initial sync block cache.
 var initialSyncBlockCacheSize = 2 * params.BeaconConfig().SlotsPerEpoch
 
-var errAlreadyProcessed = errors.New("block already processed")
-
 // onBlock is called when a gossip block is received. It runs regular state transition on the block.
 // The block's signing root should be computed before calling this method to avoid redundant
 // computation in this method and methods it calls into.
@@ -203,11 +201,6 @@ func (s *Service) onBlockInitialSyncStateTransition(ctx context.Context, signed 
 	}
 
 	b := signed.Block
-
-	// Exit early if we have already processed this block.
-	if s.hasInitSyncBlock(blockRoot) || s.beaconDB.HasBlock(ctx, blockRoot) {
-		return errAlreadyProcessed
-	}
 
 	// Retrieve incoming block's pre state.
 	preState, err := s.verifyBlkPreState(ctx, b)

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/roughtime"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
-	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func TestStore_OnBlock(t *testing.T) {
@@ -88,7 +87,7 @@ func TestStore_OnBlock(t *testing.T) {
 	}{
 		{
 			name:          "parent block root does not have a state",
-			blk:           &ethpb.BeaconBlock{ParentRoot: []byte{'A'}},
+			blk:           &ethpb.BeaconBlock{},
 			s:             st.Copy(),
 			wantErrString: "provided block root does not have block saved in the db",
 		},
@@ -130,62 +129,6 @@ func TestStore_OnBlock(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestReceiveBlockNoVerify_DuplicateBlocks(t *testing.T) {
-	hook := logTest.NewGlobal()
-	ctx := context.Background()
-	db := testDB.SetupDB(t)
-
-	cfg := &Config{
-		BeaconDB: db,
-		StateGen: stategen.New(db, cache.NewStateSummaryCache()),
-	}
-	service, err := NewService(ctx, cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	genesisStateRoot := [32]byte{}
-	genesis := blocks.NewGenesisBlock(genesisStateRoot[:])
-	if err := db.SaveBlock(ctx, genesis); err != nil {
-		t.Error(err)
-	}
-	validGenesisRoot, err := stateutil.BlockRoot(genesis.Block)
-	if err != nil {
-		t.Error(err)
-	}
-	st := testutil.NewBeaconState()
-	if err := service.beaconDB.SaveState(ctx, st.Copy(), validGenesisRoot); err != nil {
-		t.Fatal(err)
-	}
-	roots, err := blockTree1(db, validGenesisRoot[:])
-	if err != nil {
-		t.Fatal(err)
-	}
-	random := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 1, ParentRoot: roots[0]}}
-	root, err := stateutil.BlockRoot(random.Block)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// sending a first duplicate block
-	if err := service.ReceiveBlockNoVerify(ctx, random, root); err != nil {
-		t.Fatal(err)
-	}
-	testutil.AssertLogsContain(t, hook, errAlreadyProcessed.Error())
-	hook.Reset()
-
-	random = &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 3, ParentRoot: roots[0]}}
-	root, err = stateutil.BlockRoot(random.Block)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// sending a second duplicate block
-	if err := service.ReceiveBlockNoVerify(ctx, random, root); err != nil {
-		t.Fatal(err)
-	}
-	testutil.AssertLogsContain(t, hook, errAlreadyProcessed.Error())
 }
 
 func TestRemoveStateSinceLastFinalized(t *testing.T) {

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"fmt"
 
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -184,12 +183,6 @@ func (s *Service) ReceiveBlockNoVerify(ctx context.Context, block *ethpb.SignedB
 
 	// Apply state transition on the incoming newly received blockCopy without verifying its BLS contents.
 	if err := s.onBlockInitialSyncStateTransition(ctx, blockCopy, blockRoot); err != nil {
-		if err == errAlreadyProcessed {
-			log.WithFields(logrus.Fields{
-				"root": fmt.Sprintf("%#x", blockRoot),
-			}).Debugf("Skipped processing block: %s", errAlreadyProcessed)
-			return nil
-		}
 		err := errors.Wrap(err, "could not process block")
 		traceutil.AnnotateError(span, err)
 		return err


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#5850

Per discussion with @nisdas and @farazdagi , we have concluded that it would be more complicated to satisfy this for `new-state-mgmt`, and it would make more sense to check this in initial sync and remove duplicated blocks from the syncing queue