### PR TITLE
Enhancing block tree viewer

### DIFF
--- a/beacon-chain/blockchain/info.go
+++ b/beacon-chain/blockchain/info.go
@@ -1,6 +1,7 @@
 package blockchain
 
 import (
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -53,9 +54,10 @@ func (s *Service) TreeHandler(w http.ResponseWriter, _ *http.Request) {
 		slot := strconv.Itoa(int(nodes[i].Slot))
 		weight := strconv.Itoa(int(nodes[i].Weight / 1e9)) // Convert unit Gwei to unit ETH.
 		votes := strconv.Itoa(int(nodes[i].Weight / 1e9 / avgBalance))
-		bestDescendent := strconv.Itoa(int(nodes[i].BestDescendent))
 		index := strconv.Itoa(int(i))
-		label := "slot: " + slot + "\n index: " + index + "\n bestDescendent: " + bestDescendent + "\n votes: " + votes + "\n weight: " + weight
+		g := nodes[i].Graffiti[:]
+		graffiti := hex.EncodeToString(g[:8])
+		label := "slot: " + slot + "\n votes: " + votes + "\n weight: " + weight + "\n graffiti: " + graffiti
 		var dotN dot.Node
 		if nodes[i].Parent != ^uint64(0) {
 			dotN = graph.Node(index).Box().Attr("label", label)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -356,7 +356,7 @@ func (s *Service) insertBlockToForkChoiceStore(ctx context.Context, blk *ethpb.B
 
 	// Feed in block to fork choice store.
 	if err := s.forkChoiceStore.ProcessBlock(ctx,
-		blk.Slot, root, bytesutil.ToBytes32(blk.ParentRoot),
+		blk.Slot, root, bytesutil.ToBytes32(blk.ParentRoot), bytesutil.ToBytes32(blk.Body.Graffiti),
 		state.CurrentJustifiedCheckpoint().Epoch,
 		state.FinalizedCheckpointEpoch()); err != nil {
 		return errors.Wrap(err, "could not process block for proto array fork choice")

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -486,7 +486,7 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, blk *ethpb.
 		}
 
 		if err := s.forkChoiceStore.ProcessBlock(ctx,
-			b.Slot, r, bytesutil.ToBytes32(b.ParentRoot),
+			b.Slot, r, bytesutil.ToBytes32(b.ParentRoot), bytesutil.ToBytes32(b.Body.Graffiti),
 			state.CurrentJustifiedCheckpoint().Epoch,
 			state.FinalizedCheckpointEpoch()); err != nil {
 			return errors.Wrap(err, "could not process block for proto array fork choice")

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -607,7 +607,7 @@ func TestFillForkChoiceMissingBlocks_CanSave(t *testing.T) {
 	}
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
-	block := &ethpb.BeaconBlock{Slot: 9, ParentRoot: roots[8]}
+	block := &ethpb.BeaconBlock{Slot: 9, ParentRoot: roots[8], Body: &ethpb.BeaconBlockBody{Graffiti: []byte{}}}
 	if err := service.fillInForkChoiceMissingBlocks(context.Background(), block, beaconState); err != nil {
 		t.Fatal(err)
 	}
@@ -657,7 +657,7 @@ func TestFillForkChoiceMissingBlocks_FilterFinalized(t *testing.T) {
 	}
 
 	// Define a tree branch, slot 63 <- 64 <- 65
-	b63 := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 63}}
+	b63 := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 63, Body: &ethpb.BeaconBlockBody{}}}
 	if err := service.beaconDB.SaveBlock(ctx, b63); err != nil {
 		t.Fatal(err)
 	}
@@ -665,7 +665,7 @@ func TestFillForkChoiceMissingBlocks_FilterFinalized(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b64 := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 64, ParentRoot: r63[:]}}
+	b64 := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 64, ParentRoot: r63[:], Body: &ethpb.BeaconBlockBody{}}}
 	if err := service.beaconDB.SaveBlock(ctx, b64); err != nil {
 		t.Fatal(err)
 	}
@@ -673,7 +673,7 @@ func TestFillForkChoiceMissingBlocks_FilterFinalized(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b65 := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 65, ParentRoot: r64[:]}}
+	b65 := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 65, ParentRoot: r64[:], Body: &ethpb.BeaconBlockBody{}}}
 	if err := service.beaconDB.SaveBlock(ctx, b65); err != nil {
 		t.Fatal(err)
 	}
@@ -743,6 +743,7 @@ func blockTree1(db db.Database, genesisRoot []byte) ([][]byte, error) {
 	st := testutil.NewBeaconState()
 
 	for _, b := range []*ethpb.BeaconBlock{b0, b1, b3, b4, b5, b6, b7, b8} {
+		b.Body = &ethpb.BeaconBlockBody{}
 		if err := db.SaveBlock(context.Background(), &ethpb.SignedBeaconBlock{Block: b}); err != nil {
 			return nil, err
 		}

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -362,6 +362,7 @@ func (s *Service) saveGenesisData(ctx context.Context, genesisState *stateTrie.B
 		genesisBlk.Block.Slot,
 		genesisBlkRoot,
 		params.BeaconConfig().ZeroHash,
+		[32]byte{},
 		genesisCheckpoint.Epoch,
 		genesisCheckpoint.Epoch); err != nil {
 		log.Fatalf("Could not process genesis block for fork choice: %v", err)

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -22,7 +22,7 @@ type HeadRetriever interface {
 
 // BlockProcessor processes the block that's used for accounting fork choice.
 type BlockProcessor interface {
-	ProcessBlock(context.Context, uint64, [32]byte, [32]byte, uint64, uint64) error
+	ProcessBlock(context.Context, uint64, [32]byte, [32]byte, [32]byte, uint64, uint64) error
 }
 
 // AttestationProcessor processes the attestation that's used for accounting fork choice.

--- a/beacon-chain/forkchoice/protoarray/ffg_update_test.go
+++ b/beacon-chain/forkchoice/protoarray/ffg_update_test.go
@@ -28,13 +28,13 @@ func TestFFGUpdates_OneBranch(t *testing.T) {
 	//            2 <- justified: 1, finalized: 0
 	//            |
 	//            3 <- justified: 2, finalized: 1
-	if err := f.ProcessBlock(context.Background(), 1, indexToHash(1), params.BeaconConfig().ZeroHash, 0, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 1, indexToHash(1), params.BeaconConfig().ZeroHash, [32]byte{}, 0, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 2, indexToHash(2), indexToHash(1), 1, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 2, indexToHash(2), indexToHash(1), [32]byte{}, 1, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 3, indexToHash(3), indexToHash(2), 2, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 3, indexToHash(3), indexToHash(2), [32]byte{}, 2, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -112,35 +112,35 @@ func TestFFGUpdates_TwoBranches(t *testing.T) {
 	//                              |   |
 	//  justified: 2, finalized: 0 -> 9  10 <- justified: 2, finalized: 0
 	// Left branch.
-	if err := f.ProcessBlock(context.Background(), 1, indexToHash(1), params.BeaconConfig().ZeroHash, 0, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 1, indexToHash(1), params.BeaconConfig().ZeroHash, [32]byte{}, 0, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 2, indexToHash(3), indexToHash(1), 1, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 2, indexToHash(3), indexToHash(1), [32]byte{}, 1, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 3, indexToHash(5), indexToHash(3), 1, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 3, indexToHash(5), indexToHash(3), [32]byte{}, 1, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 4, indexToHash(7), indexToHash(5), 1, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 4, indexToHash(7), indexToHash(5), [32]byte{}, 1, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 4, indexToHash(9), indexToHash(7), 2, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 4, indexToHash(9), indexToHash(7), [32]byte{}, 2, 0); err != nil {
 		t.Fatal(err)
 	}
 	// Right branch.
-	if err := f.ProcessBlock(context.Background(), 1, indexToHash(2), params.BeaconConfig().ZeroHash, 0, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 1, indexToHash(2), params.BeaconConfig().ZeroHash, [32]byte{}, 0, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 2, indexToHash(4), indexToHash(2), 0, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 2, indexToHash(4), indexToHash(2), [32]byte{}, 0, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 3, indexToHash(6), indexToHash(4), 0, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 3, indexToHash(6), indexToHash(4), [32]byte{}, 0, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 4, indexToHash(8), indexToHash(6), 1, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 4, indexToHash(8), indexToHash(6), [32]byte{}, 1, 0); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 4, indexToHash(10), indexToHash(8), 2, 0); err != nil {
+	if err := f.ProcessBlock(context.Background(), 4, indexToHash(10), indexToHash(8), [32]byte{}, 2, 0); err != nil {
 		t.Fatal(err)
 	}
 

--- a/beacon-chain/forkchoice/protoarray/no_vote_test.go
+++ b/beacon-chain/forkchoice/protoarray/no_vote_test.go
@@ -25,7 +25,7 @@ func TestNoVote_CanFindHead(t *testing.T) {
 	//         0
 	//        /
 	//       2 <- head
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(2), params.BeaconConfig().ZeroHash, 1, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(2), params.BeaconConfig().ZeroHash, [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -40,7 +40,7 @@ func TestNoVote_CanFindHead(t *testing.T) {
 	//            0
 	//           / \
 	//  head -> 2  1
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(1), params.BeaconConfig().ZeroHash, 1, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(1), params.BeaconConfig().ZeroHash, [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -57,7 +57,7 @@ func TestNoVote_CanFindHead(t *testing.T) {
 	//  head -> 2  1
 	//             |
 	//             3
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(3), indexToHash(1), 1, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(3), indexToHash(1), [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -74,7 +74,7 @@ func TestNoVote_CanFindHead(t *testing.T) {
 	//          2  1
 	//          |  |
 	//  head -> 4  3
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(4), indexToHash(2), 1, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(4), indexToHash(2), [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -93,7 +93,7 @@ func TestNoVote_CanFindHead(t *testing.T) {
 	//  head -> 4  3
 	//          |
 	//          5 <- justified epoch = 2
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(5), indexToHash(4), 2, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(5), indexToHash(4), [32]byte{}, 2, 1); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -144,7 +144,7 @@ func TestNoVote_CanFindHead(t *testing.T) {
 	//          5
 	//          |
 	//          6 <- head
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(6), indexToHash(5), 2, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(6), indexToHash(5), [32]byte{}, 2, 1); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 2, indexToHash(5), balances, 1)

--- a/beacon-chain/forkchoice/protoarray/nodes.go
+++ b/beacon-chain/forkchoice/protoarray/nodes.go
@@ -60,6 +60,7 @@ func (s *Store) insert(ctx context.Context,
 	slot uint64,
 	root [32]byte,
 	parent [32]byte,
+	graffiti [32]byte,
 	justifiedEpoch uint64, finalizedEpoch uint64) error {
 	ctx, span := trace.StartSpan(ctx, "protoArrayForkChoice.insert")
 	defer span.End()
@@ -82,6 +83,7 @@ func (s *Store) insert(ctx context.Context,
 	n := &Node{
 		Slot:           slot,
 		root:           root,
+		Graffiti:       graffiti,
 		Parent:         parentIndex,
 		justifiedEpoch: justifiedEpoch,
 		finalizedEpoch: finalizedEpoch,

--- a/beacon-chain/forkchoice/protoarray/nodes_test.go
+++ b/beacon-chain/forkchoice/protoarray/nodes_test.go
@@ -64,7 +64,7 @@ func TestStore_Head_BestDescendant(t *testing.T) {
 func TestStore_Insert_UnknownParent(t *testing.T) {
 	// The new node does not have a parent.
 	s := &Store{nodeIndices: make(map[[32]byte]uint64)}
-	if err := s.insert(context.Background(), 100, [32]byte{'A'}, [32]byte{'B'}, 1, 1); err != nil {
+	if err := s.insert(context.Background(), 100, [32]byte{'A'}, [32]byte{'B'}, [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -95,7 +95,7 @@ func TestStore_Insert_KnownParent(t *testing.T) {
 	s.nodes = []*Node{{}}
 	p := [32]byte{'B'}
 	s.nodeIndices[p] = 0
-	if err := s.insert(context.Background(), 100, [32]byte{'A'}, p, 1, 1); err != nil {
+	if err := s.insert(context.Background(), 100, [32]byte{'A'}, p, [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 

--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -86,11 +86,11 @@ func (f *ForkChoice) ProcessAttestation(ctx context.Context, validatorIndices []
 }
 
 // ProcessBlock processes a new block by inserting it to the fork choice store.
-func (f *ForkChoice) ProcessBlock(ctx context.Context, slot uint64, blockRoot [32]byte, parentRoot [32]byte, justifiedEpoch uint64, finalizedEpoch uint64) error {
+func (f *ForkChoice) ProcessBlock(ctx context.Context, slot uint64, blockRoot [32]byte, parentRoot [32]byte, graffiti [32]byte, justifiedEpoch uint64, finalizedEpoch uint64) error {
 	ctx, span := trace.StartSpan(ctx, "protoArrayForkChoice.ProcessBlock")
 	defer span.End()
 
-	return f.store.insert(ctx, slot, blockRoot, parentRoot, justifiedEpoch, finalizedEpoch)
+	return f.store.insert(ctx, slot, blockRoot, parentRoot, graffiti, justifiedEpoch, finalizedEpoch)
 }
 
 // Prune prunes the fork choice store with the new finalized root. The store is only pruned if the input

--- a/beacon-chain/forkchoice/protoarray/types.go
+++ b/beacon-chain/forkchoice/protoarray/types.go
@@ -31,6 +31,7 @@ type Node struct {
 	Weight         uint64   // weight of this node.
 	bestChild      uint64   // best child index of this node.
 	BestDescendent uint64   // head index of this node.
+	Graffiti       [32]byte // graffati of the block node.
 }
 
 // Vote defines an individual validator's vote.

--- a/beacon-chain/forkchoice/protoarray/vote_test.go
+++ b/beacon-chain/forkchoice/protoarray/vote_test.go
@@ -24,7 +24,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//         0
 	//        /
 	//       2 <- head
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(2), params.BeaconConfig().ZeroHash, 1, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(2), params.BeaconConfig().ZeroHash, [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -39,7 +39,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//            0
 	//           / \
 	//  head -> 2  1
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(1), params.BeaconConfig().ZeroHash, 1, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(1), params.BeaconConfig().ZeroHash, [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -82,7 +82,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//  head -> 2  1
 	//             |
 	//             3
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(3), indexToHash(1), 1, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(3), indexToHash(1), [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -131,7 +131,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//             3
 	//             |
 	//             4 <- head
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(4), indexToHash(3), 1, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(4), indexToHash(3), [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -152,7 +152,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//             4 <- head
 	//            /
 	//           5 <- justified epoch = 2
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(5), indexToHash(4), 2, 2); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(5), indexToHash(4), [32]byte{}, 2, 2); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -173,7 +173,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//             4 <- head
 	//            / \
 	//           5  6 <- justified epoch = 0
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(6), indexToHash(4), 1, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(6), indexToHash(4), [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -187,7 +187,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//             4
 	//            / \
 	// 2 votes-> 5  6
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(6), indexToHash(4), 1, 1); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(6), indexToHash(4), [32]byte{}, 1, 1); err != nil {
 		t.Fatal(err)
 	}
 	f.ProcessAttestation(context.Background(), []uint64{0, 1}, indexToHash(5), 4)
@@ -209,13 +209,13 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//           8
 	//           |
 	//           9
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(7), indexToHash(5), 2, 2); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(7), indexToHash(5), [32]byte{}, 2, 2); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(8), indexToHash(7), 2, 2); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(8), indexToHash(7), [32]byte{}, 2, 2); err != nil {
 		t.Fatal(err)
 	}
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(9), indexToHash(8), 2, 2); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(9), indexToHash(8), [32]byte{}, 2, 2); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 1, params.BeaconConfig().ZeroHash, balances, 1)
@@ -269,7 +269,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//           / \
 	// 2 votes->9  10
 	f.ProcessAttestation(context.Background(), []uint64{0, 1}, indexToHash(9), 5)
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(10), indexToHash(8), 2, 2); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(10), indexToHash(8), [32]byte{}, 2, 2); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 2, indexToHash(5), balances, 2)
@@ -383,7 +383,7 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//        9  10
 	//        |
 	// head-> 11
-	if err := f.ProcessBlock(context.Background(), 0, indexToHash(11), indexToHash(9), 2, 2); err != nil {
+	if err := f.ProcessBlock(context.Background(), 0, indexToHash(11), indexToHash(9), [32]byte{}, 2, 2); err != nil {
 		t.Fatal(err)
 	}
 	r, err = f.Head(context.Background(), 2, indexToHash(5), balances, 2)


### PR DESCRIPTION
Made the following enhancements to block tree viewer (http://localhost:8080/tree)

Change list:
- Removed index field. Proposers don't care which index the block is in the proto array. This info was too low level
- Removed best descendent field. Proposers don't care the index of the best descendent and the best descendent can be seen as green
- Added graffiti field. It makes it easier to debug whose proposers submitted the forked blocks. Super useful to debug multi client testnet. If we agree this is too verbose, we also can remove it before mainnet.
