### PR TITLE
Make `SlotsPerArchivedPoint` configurable

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -111,7 +111,7 @@ var (
 	SlotsPerArchivedPoint = &cli.IntFlag{
 		Name:  "slots-per-archive-point",
 		Usage: "The slot durations of when an archived state gets saved in the DB.",
-		Value: 128,
+		Value: 2048,
 	}
 	// DisableDiscv5 disables running discv5.
 	DisableDiscv5 = &cli.BoolFlag{

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -97,6 +97,12 @@ func NewBeaconNode(cliCtx *cli.Context) (*BeaconNode, error) {
 		params.LoadChainConfigFile(chainConfigFileName)
 	}
 
+	if cliCtx.IsSet(flags.SlotsPerArchivedPoint.Name) {
+		c := params.MainnetConfig()
+		c.SlotsPerArchivedPoint = uint64(cliCtx.Int(flags.SlotsPerArchivedPoint.Name))
+		params.OverrideBeaconConfig(c)
+	}
+
 	featureconfig.ConfigureBeaconChain(cliCtx)
 	flags.ConfigureGlobalFlags(cliCtx)
 	registry := shared.NewServiceRegistry()

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -98,7 +98,7 @@ func NewBeaconNode(cliCtx *cli.Context) (*BeaconNode, error) {
 	}
 
 	if cliCtx.IsSet(flags.SlotsPerArchivedPoint.Name) {
-		c := params.MainnetConfig()
+		c := params.BeaconConfig()
 		c.SlotsPerArchivedPoint = uint64(cliCtx.Int(flags.SlotsPerArchivedPoint.Name))
 		params.OverrideBeaconConfig(c)
 	}

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -98,6 +98,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.BlockBatchLimit,
 			flags.BlockBatchLimitBurstFactor,
 			flags.EnableDebugRPCEndpoints,
+			flags.SlotsPerArchivedPoint,
 		},
 	},
 	{

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -203,7 +203,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	EmptySignature:            [96]byte{},
 	DefaultPageSize:           250,
 	MaxPeersToSync:            15,
-	SlotsPerArchivedPoint:     256,
+	SlotsPerArchivedPoint:     2048,
 
 	// Slasher related values.
 	WeakSubjectivityPeriod:    54000,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Feature

**What does this PR do? Why is it needed?**
Change list:
 * Set default `SlotsPerArchivedPoint` to 2048 to align with LH
 * Make `SlotsPerArchivedPoint` configurable via flag `--slots-per-archive-point`