### PR TITLE
Enable validator account metrics by default

### DIFF
--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -341,6 +341,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedAccountMetricsFlag = &cli.BoolFlag{
+		Name: "enable-account-metrics",
+		Usage: deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -379,6 +384,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedDisableInitSyncQueueFlag,
 	deprecatedEnableCustomBlockHTR,
 	deprecatedEnableEth1DataVoteCacheFlag,
+	deprecatedAccountMetricsFlag,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -7,10 +7,12 @@ import (
 )
 
 var (
-	// AccountMetricsFlag defines the graffiti value included in proposed blocks, default false.
-	AccountMetricsFlag = &cli.BoolFlag{
-		Name:  "enable-account-metrics",
-		Usage: "Enable prometheus metrics for validator accounts",
+	// DisableAccountMetricsFlag defines the graffiti value included in proposed blocks, default false.
+	DisableAccountMetricsFlag = &cli.BoolFlag{
+		Name:  "disable-account-metrics",
+		Usage: "Disable prometheus metrics for validator accounts. Operators with high volumes " +
+			"of validating keys may wish to disable granular prometheus metrics as it increases " +
+			"the data cardinality.",
 	}
 	// BeaconRPCProviderFlag defines a beacon node RPC endpoint.
 	BeaconRPCProviderFlag = &cli.StringFlag{

--- a/validator/main.go
+++ b/validator/main.go
@@ -58,7 +58,7 @@ var appFlags = []cli.Flag{
 	flags.GrpcHeadersFlag,
 	flags.KeyManager,
 	flags.KeyManagerOpts,
-	flags.AccountMetricsFlag,
+	flags.DisableAccountMetricsFlag,
 	cmd.VerbosityFlag,
 	cmd.DataDirFlag,
 	cmd.ClearDB,

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -180,7 +180,7 @@ func (s *ValidatorClient) registerClientService(keyManager keymanager.KeyManager
 	endpoint := s.cliCtx.String(flags.BeaconRPCProviderFlag.Name)
 	dataDir := s.cliCtx.String(cmd.DataDirFlag.Name)
 	logValidatorBalances := !s.cliCtx.Bool(flags.DisablePenaltyRewardLogFlag.Name)
-	emitAccountMetrics := s.cliCtx.Bool(flags.AccountMetricsFlag.Name)
+	emitAccountMetrics := !s.cliCtx.Bool(flags.DisableAccountMetricsFlag.Name)
 	cert := s.cliCtx.String(flags.CertFlag.Name)
 	graffiti := s.cliCtx.String(flags.GraffitiFlag.Name)
 	maxCallRecvMsgSize := s.cliCtx.Int(cmd.GrpcMaxCallRecvMsgSizeFlag.Name)

--- a/validator/usage.go
+++ b/validator/usage.go
@@ -85,7 +85,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.GraffitiFlag,
 			flags.GrpcRetriesFlag,
 			flags.GrpcHeadersFlag,
-			flags.AccountMetricsFlag,
+			flags.DisableAccountMetricsFlag,
 		},
 	},
 	{


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Users have experienced issues where they expected account level metrics to be present in the Prometheus scraped data, but realized this data was only available with --enable-account-metrics. This PR inverts that flag, making the account metrics enabled by default. 

**Which issues(s) does this PR fix?**

Fixes #5883

**Other notes for review**
