### PR TITLE
Ensure We Use Request.Epoch in the Validator Duties Server Implementation

### DIFF
--- a/beacon-chain/rpc/validator/assignments_test.go
+++ b/beacon-chain/rpc/validator/assignments_test.go
@@ -356,7 +356,7 @@ func TestStreamDuties_OK(t *testing.T) {
 	req := &ethpb.DutiesRequest{
 		PublicKeys: [][]byte{deposits[0].Data.PublicKey},
 	}
-	wantedRes, err := vs.duties(ctx, req, 0 /* epoch */)
+	wantedRes, err := vs.duties(ctx, req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,7 +427,7 @@ func TestStreamDuties_OK_ChainReorg(t *testing.T) {
 	req := &ethpb.DutiesRequest{
 		PublicKeys: [][]byte{deposits[0].Data.PublicKey},
 	}
-	wantedRes, err := vs.duties(ctx, req, 0 /* epoch */)
+	wantedRes, err := vs.duties(ctx, req)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

As a follow-up to #5849, we are seeing significant problems in the Topaz testnet due to a discrepancy in how duties are computed and sent to the validator client. The server implementation was doing:
```go
func (vs *Server) GetDuties(ctx context.Context, req *ethpb.DutiesRequest) (*ethpb.DutiesResponse, error) {
	if vs.SyncChecker.Syncing() {
		return nil, status.Error(codes.Unavailable, "Syncing to latest head, not ready to respond")
	}
	// If we are post-genesis time, then set the current epoch to
	// the number epochs since the genesis time, otherwise 0 by default.
	genesisTime := vs.GenesisTimeFetcher.GenesisTime()
	var currentEpoch uint64
	if roughtime.Now().After(genesisTime) {
		currentEpoch = slotutil.EpochsSinceGenesis(vs.GenesisTimeFetcher.GenesisTime())
	}
	return vs.duties(ctx, req, currentEpoch)
}
```
Instead of using req.Epoch passed in by the client, we are computing the duties based on the beacon node's idea of `roughtime.Now()`. We are suspecting there is a small discrepancy between a validator and a beacon node's idea of roughtime, leading to wrong duties being computed and catastrophic consequences in the chain. This PR reverts the change to use `req.Epoch` for computation instead, maintaining the same behavior prior to #5849.
