### PR TITLE
Enable domain data cache by default

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -252,9 +252,10 @@ func ConfigureValidator(ctx *cli.Context) {
 		log.Warn("Enabled validator attestation and block slashing protection using an external slasher.")
 		cfg.SlasherProtection = true
 	}
-	if ctx.Bool(enableDomainDataCacheFlag.Name) {
-		log.Warn("Enabled domain data cache.")
-		cfg.EnableDomainDataCache = true
+	cfg.EnableDomainDataCache = true
+	if ctx.Bool(disableDomainDataCacheFlag.Name) {
+		log.Warn("Disabled domain data cache.")
+		cfg.EnableDomainDataCache = false
 	}
 	Init(cfg)
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -97,9 +97,9 @@ var (
 		Name:  "enable-byte-mempool",
 		Usage: "Enable use of sync.Pool for certain byte arrays in the beacon state",
 	}
-	enableDomainDataCacheFlag = &cli.BoolFlag{
-		Name: "enable-domain-data-cache",
-		Usage: "Enable caching of domain data requests per epoch. This feature reduces the total " +
+	disableDomainDataCacheFlag = &cli.BoolFlag{
+		Name: "disable-domain-data-cache",
+		Usage: "Disable caching of domain data requests per epoch. This feature reduces the total " +
 			"calls to the beacon node for each assignment.",
 	}
 	enableStateGenSigVerify = &cli.BoolFlag{
@@ -351,6 +351,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableDomainDataCacheFlag = &cli.BoolFlag{
+		Name: "enable-domain-data-cache",
+		Usage: deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -390,6 +395,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedEnableCustomBlockHTR,
 	deprecatedEnableEth1DataVoteCacheFlag,
 	deprecatedAccountMetricsFlag,
+	deprecatedEnableDomainDataCacheFlag,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -398,7 +404,7 @@ var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	enableProtectAttesterFlag,
 	enableProtectProposerFlag,
 	enableExternalSlasherProtectionFlag,
-	enableDomainDataCacheFlag,
+	disableDomainDataCacheFlag,
 	waitForSyncedFlag,
 }...)
 
@@ -410,7 +416,6 @@ var SlasherFlags = append(deprecatedFlags, []cli.Flag{
 
 // E2EValidatorFlags contains a list of the validator feature flags to be tested in E2E.
 var E2EValidatorFlags = []string{
-	"--enable-domain-data-cache",
 	"--wait-for-synced",
 	"--enable-protect-attester",
 	"--enable-protect-proposer",


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This reduces the number of calls between the beacon node and validator.

**Which issues(s) does this PR fix?**

Fixes #5680

**Other notes for review**
