### PR TITLE
Return err instead of 0 for unavailable participation

### DIFF
--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -813,7 +813,7 @@ func (bs *Server) getValidatorParticipationUsingOldArchival(
 
 	pBal := bs.ParticipationFetcher.Participation(requestedEpoch)
 	if pBal == nil {
-		pBal = &precompute.Balance{}
+		return nil, status.Errorf(codes.Unavailable, "Participation information for epoch %d is not yet available", requestedEpoch)
 	}
 	participation := &ethpb.ValidatorParticipation{
 		EligibleEther: pBal.ActivePrevEpoch,

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -1803,13 +1803,9 @@ func TestServer_GetValidatorParticipation_DoesntExist(t *testing.T) {
 		StateGen:             stategen.New(db, cache.NewStateSummaryCache()),
 	}
 
-	res, err := bs.GetValidatorParticipation(ctx, &ethpb.GetValidatorParticipationRequest{QueryFilter: &ethpb.GetValidatorParticipationRequest_Epoch{Epoch: 0}})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if res.Participation.VotedEther != 0 || res.Participation.EligibleEther != 0 {
-		t.Error("Incorrect validator participation response")
+	wanted := "Participation information for epoch 0 is not yet available"
+	if _, err := bs.GetValidatorParticipation(ctx, &ethpb.GetValidatorParticipationRequest{QueryFilter: &ethpb.GetValidatorParticipationRequest_Epoch{Epoch: 0}}); err != nil && !strings.Contains(err.Error(), wanted) {
+		t.Errorf("Expected error %v, received %v", wanted, err)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
If the participation info of an epoch is not yet available (ie due to skip blocks, node processes epoch based on new block, not based on time), the node should return an `unavailable` error, instead of return new struct with all fields initialized to 0s. This has been confusing to many users, they often asked, why my node reported 0 stake was participated.