### PR TITLE
Skip spec tests until v0.12 changes are complete 

### DIFF
--- a/beacon-chain/core/blocks/spectest/attestation_test.go
+++ b/beacon-chain/core/blocks/spectest/attestation_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func runAttestationTest(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/blocks/spectest/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/spectest/attester_slashing_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func runAttesterSlashingTest(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/blocks/spectest/block_header_test.go
+++ b/beacon-chain/core/blocks/spectest/block_header_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func runBlockHeaderTest(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/blocks/spectest/block_processing_test.go
+++ b/beacon-chain/core/blocks/spectest/block_processing_test.go
@@ -28,6 +28,7 @@ func init() {
 }
 
 func runBlockProcessingTest(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/blocks/spectest/deposit_test.go
+++ b/beacon-chain/core/blocks/spectest/deposit_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func runDepositTest(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/blocks/spectest/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/spectest/proposer_slashing_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func runProposerSlashingTest(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/blocks/spectest/voluntary_exit_test.go
+++ b/beacon-chain/core/blocks/spectest/voluntary_exit_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func runVoluntaryExitTest(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/epoch/spectest/final_updates_test.go
+++ b/beacon-chain/core/epoch/spectest/final_updates_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func runFinalUpdatesTests(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/epoch/spectest/justification_and_finalization_test.go
+++ b/beacon-chain/core/epoch/spectest/justification_and_finalization_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func runJustificationAndFinalizationTests(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/epoch/spectest/registry_test.go
+++ b/beacon-chain/core/epoch/spectest/registry_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func runRegistryUpdatesTests(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/epoch/spectest/rewards_and_penalties_test.go
+++ b/beacon-chain/core/epoch/spectest/rewards_and_penalties_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func runRewardsAndPenaltiesTests(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/epoch/spectest/slashings_test.go
+++ b/beacon-chain/core/epoch/spectest/slashings_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func runSlashingsTests(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/helpers/spectest/shuffle_yaml_test.go
+++ b/beacon-chain/core/helpers/spectest/shuffle_yaml_test.go
@@ -25,6 +25,7 @@ func TestShufflingMainnet(t *testing.T) {
 }
 
 func runShuffleTests(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/state/spectest/slot_processing_test.go
+++ b/beacon-chain/core/state/spectest/slot_processing_test.go
@@ -20,6 +20,7 @@ func init() {
 }
 
 func runSlotProcessingTests(t *testing.T, config string) {
+	t.Skip("Skipping until #5935 is complete")
 	if err := spectest.SetConfig(t, config); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
Test skipping

**What does this PR do? Why is it needed?**
This PR skips all of the spec tests in beacon-chain/core/ to not pollute buildkite with test failures while we work on the branch. Once #5935 is complete, this will be reverted.

This PR does not add skips to `shared/bls/spectest` and `shared/params/spectest`, please let me know if either of those are needed. 