### PR TITLE
Cleanup Subnets Feature

### DIFF
--- a/beacon-chain/cache/committee_ids.go
+++ b/beacon-chain/cache/committee_ids.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
 )
 
-type committeeIDs struct {
+type subnetIDs struct {
 	attester          *lru.Cache
 	attesterLock      sync.RWMutex
 	aggregator        *lru.Cache
@@ -19,10 +19,10 @@ type committeeIDs struct {
 	subnetsLock       sync.RWMutex
 }
 
-// CommitteeIDs for attester and aggregator.
-var CommitteeIDs = newCommitteeIDs()
+// SubnetIDs for attester and aggregator.
+var SubnetIDs = newSubnetIDs()
 
-func newCommitteeIDs() *committeeIDs {
+func newSubnetIDs() *subnetIDs {
 	// Given a node can calculate committee assignments of current epoch and next epoch.
 	// Max size is set to 2 epoch length.
 	cacheSize := int(params.BeaconConfig().MaxCommitteesPerSlot * params.BeaconConfig().SlotsPerEpoch * 2)
@@ -37,11 +37,11 @@ func newCommitteeIDs() *committeeIDs {
 	epochDuration := time.Duration(params.BeaconConfig().SlotsPerEpoch * params.BeaconConfig().SecondsPerSlot)
 	subLength := epochDuration * time.Duration(params.BeaconNetworkConfig().EpochsPerRandomSubnetSubscription)
 	persistentCache := cache.New(subLength*time.Second, epochDuration*time.Second)
-	return &committeeIDs{attester: attesterCache, aggregator: aggregatorCache, persistentSubnets: persistentCache}
+	return &subnetIDs{attester: attesterCache, aggregator: aggregatorCache, persistentSubnets: persistentCache}
 }
 
 // AddAttesterSubnetID adds the subnet index for subscribing subnet for the attester of a given slot.
-func (c *committeeIDs) AddAttesterSubnetID(slot uint64, subnetID uint64) {
+func (c *subnetIDs) AddAttesterSubnetID(slot uint64, subnetID uint64) {
 	c.attesterLock.Lock()
 	defer c.attesterLock.Unlock()
 
@@ -54,7 +54,7 @@ func (c *committeeIDs) AddAttesterSubnetID(slot uint64, subnetID uint64) {
 }
 
 // GetAttesterSubnetIDs gets the subnet IDs for subscribed subnets for attesters of the slot.
-func (c *committeeIDs) GetAttesterSubnetIDs(slot uint64) []uint64 {
+func (c *subnetIDs) GetAttesterSubnetIDs(slot uint64) []uint64 {
 	c.attesterLock.RLock()
 	defer c.attesterLock.RUnlock()
 
@@ -69,7 +69,7 @@ func (c *committeeIDs) GetAttesterSubnetIDs(slot uint64) []uint64 {
 }
 
 // AddAggregatorSubnetID adds the subnet ID for subscribing subnet for the aggregator of a given slot.
-func (c *committeeIDs) AddAggregatorSubnetID(slot uint64, subnetID uint64) {
+func (c *subnetIDs) AddAggregatorSubnetID(slot uint64, subnetID uint64) {
 	c.aggregatorLock.Lock()
 	defer c.aggregatorLock.Unlock()
 
@@ -82,7 +82,7 @@ func (c *committeeIDs) AddAggregatorSubnetID(slot uint64, subnetID uint64) {
 }
 
 // GetAggregatorSubnetIDs gets the subnet IDs for subscribing subnet for aggregator of the slot.
-func (c *committeeIDs) GetAggregatorSubnetIDs(slot uint64) []uint64 {
+func (c *subnetIDs) GetAggregatorSubnetIDs(slot uint64) []uint64 {
 	c.aggregatorLock.RLock()
 	defer c.aggregatorLock.RUnlock()
 
@@ -93,9 +93,9 @@ func (c *committeeIDs) GetAggregatorSubnetIDs(slot uint64) []uint64 {
 	return val.([]uint64)
 }
 
-// GetPersistentCommittees retrieves the persistent committee and expiration time of that validator's
+// GetPersistentSubnets retrieves the persistent subnet and expiration time of that validator's
 // subscription.
-func (c *committeeIDs) GetPersistentCommittees(pubkey []byte) ([]uint64, bool, time.Time) {
+func (c *subnetIDs) GetPersistentSubnets(pubkey []byte) ([]uint64, bool, time.Time) {
 	c.subnetsLock.RLock()
 	defer c.subnetsLock.RUnlock()
 
@@ -106,9 +106,9 @@ func (c *committeeIDs) GetPersistentCommittees(pubkey []byte) ([]uint64, bool, t
 	return id.([]uint64), ok, duration
 }
 
-// GetAllCommittees retrieves all the non-expired subscribed committees of all the validators
+// GetAllSubnets retrieves all the non-expired subscribed subnets of all the validators
 // in the cache.
-func (c *committeeIDs) GetAllCommittees() []uint64 {
+func (c *subnetIDs) GetAllSubnets() []uint64 {
 	c.subnetsLock.RLock()
 	defer c.subnetsLock.RUnlock()
 
@@ -126,7 +126,7 @@ func (c *committeeIDs) GetAllCommittees() []uint64 {
 
 // AddPersistentCommittee adds the relevant committee for that particular validator along with its
 // expiration period.
-func (c *committeeIDs) AddPersistentCommittee(pubkey []byte, comIndex []uint64, duration time.Duration) {
+func (c *subnetIDs) AddPersistentCommittee(pubkey []byte, comIndex []uint64, duration time.Duration) {
 	c.subnetsLock.Lock()
 	defer c.subnetsLock.Unlock()
 

--- a/beacon-chain/cache/committee_ids_test.go
+++ b/beacon-chain/cache/committee_ids_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCommitteeIDCache_RoundTrip(t *testing.T) {
-	c := newCommitteeIDs()
+	c := newSubnetIDs()
 	slot := uint64(100)
 	committeeIDs := c.GetAggregatorSubnetIDs(slot)
 	if len(committeeIDs) != 0 {
@@ -57,7 +57,7 @@ func TestCommitteeIDCache_RoundTrip(t *testing.T) {
 
 func TestCommitteeIDs_PersistentCommitteeRoundtrip(t *testing.T) {
 	pubkeySet := [][48]byte{}
-	c := newCommitteeIDs()
+	c := newSubnetIDs()
 
 	for i := 0; i < 20; i++ {
 		pubkey := [48]byte{byte(i)}
@@ -68,7 +68,7 @@ func TestCommitteeIDs_PersistentCommitteeRoundtrip(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		pubkey := [48]byte{byte(i)}
 
-		idxs, ok, _ := c.GetPersistentCommittees(pubkey[:])
+		idxs, ok, _ := c.GetPersistentSubnets(pubkey[:])
 		if !ok {
 			t.Errorf("Couldn't find entry in cache for pubkey %#x", pubkey)
 			continue
@@ -77,7 +77,7 @@ func TestCommitteeIDs_PersistentCommitteeRoundtrip(t *testing.T) {
 			t.Fatalf("Wanted index of %d but got %d", i, idxs[0])
 		}
 	}
-	coms := c.GetAllCommittees()
+	coms := c.GetAllSubnets()
 	if len(coms) != 20 {
 		t.Errorf("Number of committees is not %d but is %d", 20, len(coms))
 	}

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -390,7 +390,7 @@ func (s *Service) RefreshENR() {
 		return
 	}
 	bitV := bitfield.NewBitvector64()
-	committees := cache.CommitteeIDs.GetAllCommittees()
+	committees := cache.SubnetIDs.GetAllSubnets()
 	for _, idx := range committees {
 		bitV.SetBitAt(idx, true)
 	}

--- a/beacon-chain/p2p/subnets_test.go
+++ b/beacon-chain/p2p/subnets_test.go
@@ -124,7 +124,7 @@ func TestStartDiscV5_DiscoverPeersWithSubnets(t *testing.T) {
 		dv5Listener: listeners[0],
 		metaData:    &pb.MetaData{},
 	}
-	cache.CommitteeIDs.AddAttesterSubnetID(0, 10)
+	cache.SubnetIDs.AddAttesterSubnetID(0, 10)
 	testService.RefreshENR()
 	time.Sleep(2 * time.Second)
 

--- a/beacon-chain/rpc/validator/assignments.go
+++ b/beacon-chain/rpc/validator/assignments.go
@@ -194,7 +194,7 @@ func assignValidatorToSubnet(pubkey []byte, status ethpb.ValidatorStatus) {
 		return
 	}
 
-	_, ok, expTime := cache.CommitteeIDs.GetPersistentCommittees(pubkey)
+	_, ok, expTime := cache.SubnetIDs.GetPersistentSubnets(pubkey)
 	if ok && expTime.After(roughtime.Now()) {
 		return
 	}
@@ -208,5 +208,5 @@ func assignValidatorToSubnet(pubkey []byte, status ethpb.ValidatorStatus) {
 	assignedDuration += int(params.BeaconNetworkConfig().EpochsPerRandomSubnetSubscription)
 
 	totalDuration := epochDuration * time.Duration(assignedDuration)
-	cache.CommitteeIDs.AddPersistentCommittee(pubkey, assignedIdxs, totalDuration*time.Second)
+	cache.SubnetIDs.AddPersistentCommittee(pubkey, assignedIdxs, totalDuration*time.Second)
 }

--- a/beacon-chain/rpc/validator/assignments_test.go
+++ b/beacon-chain/rpc/validator/assignments_test.go
@@ -469,7 +469,7 @@ func TestAssignValidatorToSubnet(t *testing.T) {
 	k := pubKey(3)
 
 	assignValidatorToSubnet(k, ethpb.ValidatorStatus_ACTIVE)
-	coms, ok, exp := cache.CommitteeIDs.GetPersistentCommittees(k)
+	coms, ok, exp := cache.SubnetIDs.GetPersistentSubnets(k)
 	if !ok {
 		t.Fatal("No cache entry found for validator")
 	}

--- a/beacon-chain/rpc/validator/attester.go
+++ b/beacon-chain/rpc/validator/attester.go
@@ -219,11 +219,12 @@ func (vs *Server) SubscribeCommitteeSubnets(ctx context.Context, req *ethpb.Comm
 			if err != nil {
 				return nil, err
 			}
+			currEpoch = helpers.SlotToEpoch(req.Slots[i])
 		}
 		subnet := helpers.ComputeSubnetFromCommitteeAndSlot(currValsLen, req.CommitteeIds[i], req.Slots[i])
-		cache.CommitteeIDs.AddAttesterSubnetID(req.Slots[i], subnet)
+		cache.SubnetIDs.AddAttesterSubnetID(req.Slots[i], subnet)
 		if req.IsAggregator[i] {
-			cache.CommitteeIDs.AddAggregatorSubnetID(req.Slots[i], subnet)
+			cache.SubnetIDs.AddAggregatorSubnetID(req.Slots[i], subnet)
 		}
 	}
 

--- a/beacon-chain/sync/subscriber_beacon_attestation.go
+++ b/beacon-chain/sync/subscriber_beacon_attestation.go
@@ -51,7 +51,7 @@ func (r *Service) subnetCount() int {
 }
 
 func (r *Service) persistentSubnetIndices() []uint64 {
-	return cache.CommitteeIDs.GetAllCommittees()
+	return cache.SubnetIDs.GetAllSubnets()
 }
 
 func (r *Service) aggregatorSubnetIndices(currentSlot uint64) []uint64 {
@@ -59,7 +59,7 @@ func (r *Service) aggregatorSubnetIndices(currentSlot uint64) []uint64 {
 	endSlot := endEpoch * params.BeaconConfig().SlotsPerEpoch
 	commIds := []uint64{}
 	for i := currentSlot; i <= endSlot; i++ {
-		commIds = append(commIds, cache.CommitteeIDs.GetAggregatorSubnetIDs(i)...)
+		commIds = append(commIds, cache.SubnetIDs.GetAggregatorSubnetIDs(i)...)
 	}
 	return sliceutil.SetUint64(commIds)
 }
@@ -69,7 +69,7 @@ func (r *Service) attesterSubnetIndices(currentSlot uint64) []uint64 {
 	endSlot := endEpoch * params.BeaconConfig().SlotsPerEpoch
 	commIds := []uint64{}
 	for i := currentSlot; i <= endSlot; i++ {
-		commIds = append(commIds, cache.CommitteeIDs.GetAttesterSubnetIDs(i)...)
+		commIds = append(commIds, cache.SubnetIDs.GetAttesterSubnetIDs(i)...)
 	}
 	return sliceutil.SetUint64(commIds)
 }


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

- [x] Cleans up References to Committee Indexes.
- [x] Fix bug with referencing of epochs for validator indices
- [x] Add tests for `SubscribeCommitteeSubnets`

**Which issues(s) does this PR fix?**
Part of #5935 

**Other notes for review**
