### PR TITLE
Remove Warning on Using Default Mainnet Config

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -280,8 +280,6 @@ func configureConfig(ctx *cli.Context, cfg *Flags) *Flags {
 		log.Warn("Using minimal config")
 		cfg.MinimalConfig = true
 		params.UseMinimalConfig()
-	} else {
-		log.Warn("Using default mainnet config")
 	}
 	return cfg
 }


### PR DESCRIPTION
No tracking issue. This PR removes the log `WARN: using default mainnet config` from beacon nodes, as we should only be warning a user if they are using minimal