### PR TITLE
Add missing TLS-related flags to Beacon Chain and Slasher

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -39,6 +39,8 @@ var appFlags = []cli.Flag{
 	flags.ContractDeploymentBlock,
 	flags.SetGCPercent,
 	flags.UnsafeSync,
+	flags.SlasherCertFlag,
+	flags.SlasherProviderFlag,
 	flags.DisableDiscv5,
 	flags.BlockBatchLimit,
 	flags.BlockBatchLimitBurstFactor,

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -93,6 +93,8 @@ var appHelpFlagGroups = []flagGroup{
 			flags.HTTPWeb3ProviderFlag,
 			flags.SetGCPercent,
 			flags.UnsafeSync,
+			flags.SlasherCertFlag,
+			flags.SlasherProviderFlag,
 			flags.SlotsPerArchivedPoint,
 			flags.DisableDiscv5,
 			flags.BlockBatchLimit,

--- a/slasher/main.go
+++ b/slasher/main.go
@@ -60,6 +60,7 @@ var appFlags = []cli.Flag{
 	debug.TraceFlag,
 	flags.RPCPort,
 	flags.RPCHost,
+	flags.CertFlag,
 	flags.KeyFlag,
 	flags.RebuildSpanMapsFlag,
 	flags.BeaconCertFlag,

--- a/slasher/usage.go
+++ b/slasher/usage.go
@@ -73,6 +73,7 @@ var appHelpFlagGroups = []flagGroup{
 		Name: "slasher",
 		Flags: []cli.Flag{
 			flags.BeaconCertFlag,
+			flags.CertFlag,
 			flags.KeyFlag,
 			flags.RPCPort,
 			flags.RPCHost,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Some flags for configuring TLS certs are missing. This adds the missing flags to Beacon Chain and Slasher. The values are already used but aren't exposed as flags (don't show up under --help). Maybe they already work with the file-based approach and that's why it hasn't been noticed yet.

**Which issues(s) does this PR fix?**

Didn't create one as it's a small fix.

**Other notes for review**
