### PR TITLE
Improve Deposit Data Account Creation Prompt

### DIFF
--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -105,17 +105,17 @@ func NewValidatorAccount(directory string, password string) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to create deposit transaction")
 	}
-	log.Info(`Account creation complete! Copy and paste the raw transaction data shown below when issuing a transaction into the ETH1.0 deposit contract to activate your validator client`)
+	log.Info(`Account creation complete! Copy and paste the raw deposit data shown below when issuing a transaction into the ETH1.0 deposit contract to activate your validator client`)
 	fmt.Printf(`
-========================Raw Transaction Data=======================
+========================Deposit Data=======================
 
 %#x
 
 ===================================================================
 `, tx.Data())
-	fmt.Println("***Enter the above Raw Transaction Data into step 3 on https://prylabs.net/participate***")
+	fmt.Println("***Enter the above deposit data into step 3 on https://prylabs.net/participate***")
 	publicKey := validatorKey.PublicKey.Marshal()[:]
-	log.Infof("Deposit data displayed for public key: %#x", publicKey)
+	log.Infof("Public key: %#x", publicKey)
 	return nil
 }
 

--- a/validator/accounts/account_test.go
+++ b/validator/accounts/account_test.go
@@ -15,11 +15,10 @@ import (
 
 	"github.com/prysmaticlabs/go-bitfield"
 	slashpb "github.com/prysmaticlabs/prysm/proto/slashing"
-	"github.com/prysmaticlabs/prysm/validator/db"
-
 	"github.com/prysmaticlabs/prysm/shared/keystore"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/validator/db"
 	"github.com/prysmaticlabs/prysm/validator/flags"
 	"gopkg.in/urfave/cli.v2"
 )


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

A user reported the account creation deposit data is not quite clear, so they ended up pasting their public key into the prylabs.net/participate portal instead. This is because, intuitively, the user ignored the `======RAW TRANSACTION DATA======` text blob in the terminal. Instead, we should rename that to `DEPOSIT DATA` and mention clearly to paste in the deposit data shown above into the prylabs.net/participate page.
