### PR TITLE
Add the ability for graffiti to be read from a file

### DIFF
--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -254,27 +254,25 @@ func ConstructDialOptions(
 	return dialOpts
 }
 
-// fetch Graffiti from a file or path.
+// fetch Graffiti from a file or flag.
 func fetchGraffiti(flag string) [][]byte {
-	var graffitiData [][]byte
 	if flag == "" {
 		// No graffiti.
-		return graffitiData
+		return make([][]byte, 1)
 	}
 
 	data, err := ioutil.ReadFile(flag)
 	if err != nil {
-		// Use graffiti as a static value.
-		graffitiData = append(graffitiData, []byte(flag))
-	} else {
-		// Use graffiti from the file.
-		graffitiData = bytes.Split(bytes.Replace(data, []byte("\r\n"), []byte("\n"), -1), []byte("\n"))
-		// Shuffle the entries.
-		for i := range graffitiData {
-			j := rand.Intn(i + 1)
-			graffitiData[i], graffitiData[j] = graffitiData[j], graffitiData[i]
-		}
+		// Single graffiti.
+		return [][]byte{[]byte(flag)}
 	}
 
+	// Multiple graffiti.
+	graffitiData := bytes.Split(bytes.Replace(data, []byte("\r\n"), []byte("\n"), -1), []byte("\n"))
+	// Shuffle the entries.
+	for i := range graffitiData {
+		j := rand.Intn(i + 1)
+		graffitiData[i], graffitiData[j] = graffitiData[j], graffitiData[i]
+	}
 	return graffitiData
 }

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -74,14 +74,13 @@ type Config struct {
 // registry.
 func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	graffitiData := fetchGraffiti(cfg.GraffitiFlag)
 	return &ValidatorService{
 		ctx:                  ctx,
 		cancel:               cancel,
 		endpoint:             cfg.Endpoint,
 		withCert:             cfg.CertFlag,
 		dataDir:              cfg.DataDir,
-		graffiti:             graffitiData,
+		graffiti:             fetchGraffiti(cfg.GraffitiFlag),
 		keyManager:           cfg.KeyManager,
 		logValidatorBalances: cfg.LogValidatorBalances,
 		emitAccountMetrics:   cfg.EmitAccountMetrics,

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -50,7 +50,8 @@ type validator struct {
 	duties                             *ethpb.DutiesResponse
 	validatorClient                    ethpb.BeaconNodeValidatorClient
 	beaconClient                       ethpb.BeaconChainClient
-	graffiti                           []byte
+	graffiti                           [][]byte
+	graffitiOffset                     int
 	node                               ethpb.NodeClient
 	keyManager                         keymanager.KeyManager
 	prevBalance                        map[[48]byte]uint64

--- a/validator/client/validator_propose.go
+++ b/validator/client/validator_propose.go
@@ -83,15 +83,11 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 		return
 	}
 
-	var graffiti []byte
-	if len(v.graffiti) > 0 {
-		graffiti = []byte(v.graffiti[v.graffitiOffset])
-	}
 	// Request block from beacon node
 	b, err := v.validatorClient.GetBlock(ctx, &ethpb.BlockRequest{
 		Slot:         slot,
 		RandaoReveal: randaoReveal,
-		Graffiti:     graffiti,
+		Graffiti:     v.graffiti[v.graffitiOffset],
 	})
 	if err != nil {
 		log.WithField("blockSlot", slot).WithError(err).Error("Failed to request block from beacon node")

--- a/validator/client/validator_propose_test.go
+++ b/validator/client/validator_propose_test.go
@@ -44,7 +44,7 @@ func setup(t *testing.T) (*validator, *mocks, func()) {
 		db:                             valDB,
 		validatorClient:                m.validatorClient,
 		keyManager:                     testKeyManager,
-		graffiti:                       []byte{},
+		graffiti:                       [][]byte{},
 		attLogs:                        make(map[[32]byte]*attSubmitted),
 		aggregatedSlotCommitteeIDCache: aggregatedSlotCommitteeIDCache,
 		attesterHistoryByPubKey:        attHistoryByPubKey,
@@ -309,7 +309,7 @@ func TestProposeBlock_BroadcastsBlock_WithGraffiti(t *testing.T) {
 	validator, m, finish := setup(t)
 	defer finish()
 
-	validator.graffiti = []byte("12345678901234567890123456789012")
+	validator.graffiti = [][]byte{[]byte("12345678901234567890123456789012")}
 
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx
@@ -319,7 +319,7 @@ func TestProposeBlock_BroadcastsBlock_WithGraffiti(t *testing.T) {
 	m.validatorClient.EXPECT().GetBlock(
 		gomock.Any(), // ctx
 		gomock.Any(),
-	).Return(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{Graffiti: validator.graffiti}}, nil /*err*/)
+	).Return(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{Graffiti: validator.graffiti[0]}}, nil /*err*/)
 
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx
@@ -338,7 +338,7 @@ func TestProposeBlock_BroadcastsBlock_WithGraffiti(t *testing.T) {
 
 	validator.ProposeBlock(context.Background(), 1, validatorPubKey)
 
-	if string(sentBlock.Block.Body.Graffiti) != string(validator.graffiti) {
-		t.Errorf("Block was broadcast with the wrong graffiti field, wanted \"%v\", got \"%v\"", string(validator.graffiti), string(sentBlock.Block.Body.Graffiti))
+	if string(sentBlock.Block.Body.Graffiti) != string(validator.graffiti[0]) {
+		t.Errorf("Block was broadcast with the wrong graffiti field, wanted \"%v\", got \"%v\"", string(validator.graffiti[0]), string(sentBlock.Block.Body.Graffiti))
 	}
 }

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -44,7 +44,7 @@ var (
 	// GraffitiFlag defines the graffiti value included in proposed blocks
 	GraffitiFlag = &cli.StringFlag{
 		Name:  "graffiti",
-		Usage: "String to include in proposed blocks",
+		Usage: "String to include in proposed blocks, or path to a file containing one or more strings to be included",
 	}
 	// GrpcRetriesFlag defines the number of times to retry a failed gRPC request.
 	GrpcRetriesFlag = &cli.UintFlag{


### PR DESCRIPTION
As requested by @0xKiwi 

This patch allows multiple graffiti entries to be read from a file, shuffling them and sending them in sequentially with proposed blocks.  This is achieved by supplying `--graffiti` with the path to a file containing one or more lines of text _e.g._ `--graffiti=/home/me/graffiti.txt`

Existing functionality of the `graffiti` flag is unchanged.

Note that this creates a function in the validator called `fetchGraffiti`; there should be tests added for this function (looking at you, @0xKiwi , as you asked for this :smile:).  There may also be some e2e changes required.