### PR TITLE
Release state-ref-copy flag

### DIFF
--- a/beacon-chain/state/references_test.go
+++ b/beacon-chain/state/references_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 	p2ppb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 )
 
 func TestStateReferenceSharing_Finalizer(t *testing.T) {
@@ -50,9 +49,6 @@ func TestStateReferenceSharing_Finalizer(t *testing.T) {
 }
 
 func TestStateReferenceCopy_NoUnexpectedRootsMutation(t *testing.T) {
-	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableStateRefCopy: true})
-	defer resetCfg()
-
 	root1, root2 := bytesutil.ToBytes32([]byte("foo")), bytesutil.ToBytes32([]byte("bar"))
 	a, err := InitializeFromProtoUnsafe(&p2ppb.BeaconState{
 		BlockRoots: [][]byte{
@@ -141,9 +137,6 @@ func TestStateReferenceCopy_NoUnexpectedRootsMutation(t *testing.T) {
 }
 
 func TestStateReferenceCopy_NoUnexpectedRandaoMutation(t *testing.T) {
-	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableStateRefCopy: true})
-	defer resetCfg()
-
 	val1, val2 := []byte("foo"), []byte("bar")
 	a, err := InitializeFromProtoUnsafe(&p2ppb.BeaconState{
 		RandaoMixes: [][]byte{
@@ -201,9 +194,6 @@ func TestStateReferenceCopy_NoUnexpectedRandaoMutation(t *testing.T) {
 }
 
 func TestStateReferenceCopy_NoUnexpectedAttestationsMutation(t *testing.T) {
-	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableStateRefCopy: true})
-	defer resetCfg()
-
 	assertAttFound := func(vals []*p2ppb.PendingAttestation, val uint64) {
 		for i := range vals {
 			if reflect.DeepEqual(vals[i].AggregationBits, bitfield.NewBitlist(val)) {

--- a/beacon-chain/state/setters.go
+++ b/beacon-chain/state/setters.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 	coreutils "github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
 
@@ -107,12 +106,8 @@ func (b *BeaconState) UpdateBlockRootAtIndex(idx uint64, blockRoot [32]byte) err
 	r := b.state.BlockRoots
 	if ref := b.sharedFieldReferences[blockRoots]; ref.refs > 1 {
 		// Copy on write since this is a shared array.
-		if featureconfig.Get().EnableStateRefCopy {
-			r = make([][]byte, len(b.state.BlockRoots))
-			copy(r, b.state.BlockRoots)
-		} else {
-			r = b.BlockRoots()
-		}
+		r = make([][]byte, len(b.state.BlockRoots))
+		copy(r, b.state.BlockRoots)
 
 		ref.MinusRef()
 		b.sharedFieldReferences[blockRoots] = &reference{refs: 1}
@@ -164,12 +159,8 @@ func (b *BeaconState) UpdateStateRootAtIndex(idx uint64, stateRoot [32]byte) err
 	r := b.state.StateRoots
 	if ref := b.sharedFieldReferences[stateRoots]; ref.refs > 1 {
 		// Perform a copy since this is a shared reference and we don't want to mutate others.
-		if featureconfig.Get().EnableStateRefCopy {
-			r = make([][]byte, len(b.state.StateRoots))
-			copy(r, b.state.StateRoots)
-		} else {
-			r = b.StateRoots()
-		}
+		r = make([][]byte, len(b.state.StateRoots))
+		copy(r, b.state.StateRoots)
 
 		ref.MinusRef()
 		b.sharedFieldReferences[stateRoots] = &reference{refs: 1}
@@ -245,12 +236,9 @@ func (b *BeaconState) AppendEth1DataVotes(val *ethpb.Eth1Data) error {
 	b.lock.RLock()
 	votes := b.state.Eth1DataVotes
 	if b.sharedFieldReferences[eth1DataVotes].refs > 1 {
-		if featureconfig.Get().EnableStateRefCopy {
-			votes = make([]*ethpb.Eth1Data, len(b.state.Eth1DataVotes))
-			copy(votes, b.state.Eth1DataVotes)
-		} else {
-			votes = b.Eth1DataVotes()
-		}
+		votes = make([]*ethpb.Eth1Data, len(b.state.Eth1DataVotes))
+		copy(votes, b.state.Eth1DataVotes)
+
 		b.sharedFieldReferences[eth1DataVotes].MinusRef()
 		b.sharedFieldReferences[eth1DataVotes] = &reference{refs: 1}
 	}
@@ -454,12 +442,9 @@ func (b *BeaconState) UpdateRandaoMixesAtIndex(idx uint64, val []byte) error {
 	b.lock.RLock()
 	mixes := b.state.RandaoMixes
 	if refs := b.sharedFieldReferences[randaoMixes].refs; refs > 1 {
-		if featureconfig.Get().EnableStateRefCopy {
-			mixes = make([][]byte, len(b.state.RandaoMixes))
-			copy(mixes, b.state.RandaoMixes)
-		} else {
-			mixes = b.RandaoMixes()
-		}
+		mixes = make([][]byte, len(b.state.RandaoMixes))
+		copy(mixes, b.state.RandaoMixes)
+
 		b.sharedFieldReferences[randaoMixes].MinusRef()
 		b.sharedFieldReferences[randaoMixes] = &reference{refs: 1}
 	}
@@ -568,12 +553,9 @@ func (b *BeaconState) AppendHistoricalRoots(root [32]byte) error {
 	b.lock.RLock()
 	roots := b.state.HistoricalRoots
 	if b.sharedFieldReferences[historicalRoots].refs > 1 {
-		if featureconfig.Get().EnableStateRefCopy {
-			roots = make([][]byte, len(b.state.HistoricalRoots))
-			copy(roots, b.state.HistoricalRoots)
-		} else {
-			roots = b.HistoricalRoots()
-		}
+		roots = make([][]byte, len(b.state.HistoricalRoots))
+		copy(roots, b.state.HistoricalRoots)
+
 		b.sharedFieldReferences[historicalRoots].MinusRef()
 		b.sharedFieldReferences[historicalRoots] = &reference{refs: 1}
 	}
@@ -597,12 +579,9 @@ func (b *BeaconState) AppendCurrentEpochAttestations(val *pbp2p.PendingAttestati
 
 	atts := b.state.CurrentEpochAttestations
 	if b.sharedFieldReferences[currentEpochAttestations].refs > 1 {
-		if featureconfig.Get().EnableStateRefCopy {
-			atts = make([]*pbp2p.PendingAttestation, len(b.state.CurrentEpochAttestations))
-			copy(atts, b.state.CurrentEpochAttestations)
-		} else {
-			atts = b.CurrentEpochAttestations()
-		}
+		atts = make([]*pbp2p.PendingAttestation, len(b.state.CurrentEpochAttestations))
+		copy(atts, b.state.CurrentEpochAttestations)
+
 		b.sharedFieldReferences[currentEpochAttestations].MinusRef()
 		b.sharedFieldReferences[currentEpochAttestations] = &reference{refs: 1}
 	}
@@ -626,12 +605,9 @@ func (b *BeaconState) AppendPreviousEpochAttestations(val *pbp2p.PendingAttestat
 	b.lock.RLock()
 	atts := b.state.PreviousEpochAttestations
 	if b.sharedFieldReferences[previousEpochAttestations].refs > 1 {
-		if featureconfig.Get().EnableStateRefCopy {
-			atts = make([]*pbp2p.PendingAttestation, len(b.state.PreviousEpochAttestations))
-			copy(atts, b.state.PreviousEpochAttestations)
-		} else {
-			atts = b.PreviousEpochAttestations()
-		}
+		atts = make([]*pbp2p.PendingAttestation, len(b.state.PreviousEpochAttestations))
+		copy(atts, b.state.PreviousEpochAttestations)
+
 		b.sharedFieldReferences[previousEpochAttestations].MinusRef()
 		b.sharedFieldReferences[previousEpochAttestations] = &reference{refs: 1}
 	}

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -54,7 +54,6 @@ type Flags struct {
 	NewStateMgmt                               bool // NewStateMgmt enables the new state mgmt service.
 	EnableFieldTrie                            bool // EnableFieldTrie enables the state from using field specific tries when computing the root.
 	NoInitSyncBatchSaveBlocks                  bool // NoInitSyncBatchSaveBlocks disables batch save blocks mode during initial syncing.
-	EnableStateRefCopy                         bool // EnableStateRefCopy copies the references to objects instead of the objects themselves when copying state fields.
 	WaitForSynced                              bool // WaitForSynced uses WaitForSynced in validator startup to ensure it can communicate with the beacon node as soon as possible.
 	SkipRegenHistoricalStates                  bool // SkipRegenHistoricalState skips regenerating historical states from genesis to last finalized. This enables a quick switch over to using new-state-mgmt.
 	EnableInitSyncWeightedRoundRobin           bool // EnableInitSyncWeightedRoundRobin enables weighted round robin fetching optimization in initial syncing.
@@ -196,10 +195,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.Bool(disableInitSyncBatchSaveBlocks.Name) {
 		log.Warn("Disabling init sync batch save blocks mode")
 		cfg.NoInitSyncBatchSaveBlocks = true
-	}
-	if ctx.Bool(enableStateRefCopy.Name) {
-		log.Warn("Enabling state reference copy")
-		cfg.EnableStateRefCopy = true
 	}
 	if ctx.Bool(disableBroadcastSlashingFlag.Name) {
 		log.Warn("Disabling slashing broadcasting to p2p network")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -132,10 +132,6 @@ var (
 		Name:  "disable-init-sync-batch-save-blocks",
 		Usage: "Instead of saving batch blocks to the DB during initial syncing, this disables batch saving of blocks",
 	}
-	enableStateRefCopy = &cli.BoolFlag{
-		Name:  "enable-state-ref-copy",
-		Usage: "Enables the usage of a new copying method for our state fields.",
-	}
 	waitForSyncedFlag = &cli.BoolFlag{
 		Name:  "wait-for-synced",
 		Usage: "Uses WaitForSynced for validator startup, to ensure a validator is able to communicate with the beacon node as quick as possible",
@@ -160,7 +156,6 @@ var (
 
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
-	enableStateRefCopy,
 	enableFieldTrie,
 	enableNewStateMgmt,
 	enableInitSyncWeightedRoundRobin,
@@ -371,6 +366,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecateEnableStateRefCopy = &cli.BoolFlag{
+		Name:   "enable-state-ref-copy",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -414,6 +414,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedEnableByteMempool,
 	deprecatedBroadcastSlashingFlag,
 	deprecatedDisableHistoricalDetectionFlag,
+	deprecateEnableStateRefCopy,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -467,7 +468,6 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	enableNewStateMgmt,
 	enableFieldTrie,
 	disableInitSyncBatchSaveBlocks,
-	enableStateRefCopy,
 	waitForSyncedFlag,
 	skipRegenHistoricalStates,
 	enableInitSyncWeightedRoundRobin,
@@ -479,7 +479,6 @@ var E2EBeaconChainFlags = []string{
 	"--enable-state-gen-sig-verify",
 	"--check-head-state",
 	"--enable-state-field-trie",
-	"--enable-state-ref-copy",
 	"--enable-new-state-mgmt",
 	"--enable-init-sync-wrr",
 }


### PR DESCRIPTION
As part of alpha9 todo, this PR releases`enable-state-ref-copy` flag. This flag has been running in exp pods and on external validators many weeks without any issue