### PR TITLE
Invert enable-state-field-trie flag

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -188,9 +188,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Enabling state management service")
 		cfg.NewStateMgmt = true
 	}
-	if ctx.Bool(enableFieldTrie.Name) {
-		log.Warn("Enabling state field trie")
-		cfg.EnableFieldTrie = true
+	cfg.EnableFieldTrie = true
+	if ctx.Bool(disableFieldTrie.Name) {
+		log.Warn("Disabling state field trie")
+		cfg.EnableFieldTrie = false
 	}
 	if ctx.Bool(disableInitSyncBatchSaveBlocks.Name) {
 		log.Warn("Disabling init sync batch save blocks mode")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -124,10 +124,11 @@ var (
 		Name:  "enable-new-state-mgmt",
 		Usage: "This enable the usage of state mgmt service across Prysm",
 	}
-	enableFieldTrie = &cli.BoolFlag{
-		Name:  "enable-state-field-trie",
-		Usage: "Enables the usage of state field tries to compute the state root",
+	disableFieldTrie = &cli.BoolFlag{
+		Name:  "disable-state-field-trie",
+		Usage: "Disables the usage of state field tries to compute the state root",
 	}
+
 	disableInitSyncBatchSaveBlocks = &cli.BoolFlag{
 		Name:  "disable-init-sync-batch-save-blocks",
 		Usage: "Instead of saving batch blocks to the DB during initial syncing, this disables batch saving of blocks",
@@ -156,7 +157,6 @@ var (
 
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
-	enableFieldTrie,
 	enableNewStateMgmt,
 	enableInitSyncWeightedRoundRobin,
 }
@@ -371,6 +371,10 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecateEnableFieldTrie = &cli.BoolFlag{
+		Name:   "enable-state-field-trie",
+		Usage:  deprecatedUsage,
+		Hidden: true}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -415,6 +419,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedBroadcastSlashingFlag,
 	deprecatedDisableHistoricalDetectionFlag,
 	deprecateEnableStateRefCopy,
+	deprecateEnableFieldTrie,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -466,11 +471,11 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	dontPruneStateStartUp,
 	disableBroadcastSlashingFlag,
 	enableNewStateMgmt,
-	enableFieldTrie,
 	disableInitSyncBatchSaveBlocks,
 	waitForSyncedFlag,
 	skipRegenHistoricalStates,
 	enableInitSyncWeightedRoundRobin,
+	disableFieldTrie,
 }...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.
@@ -478,7 +483,6 @@ var E2EBeaconChainFlags = []string{
 	"--cache-filtered-block-tree",
 	"--enable-state-gen-sig-verify",
 	"--check-head-state",
-	"--enable-state-field-trie",
 	"--enable-new-state-mgmt",
 	"--enable-init-sync-wrr",
 }


### PR DESCRIPTION
Review and merge #6012 first

As part of alpha9 todo, this PR inverts enable-state-field-trie flag. This flag has been running in exp pods and on external validators many weeks without any issue