### PR TITLE
Recommend Users Blocked By Antivirus a Way to Curl Prysm.sh

### DIFF
--- a/prysm.bat
+++ b/prysm.bat
@@ -47,7 +47,7 @@ if %WinOS%==64BIT (
 mkdir %wrapper_dir%
 
 REM get_prysm_version - Find the latest Prysm version available for download.
-(for /f %%i in ('curl -f -s https://prysmaticlabs.com/releases/latest') do set prysm_version=%%i) || (echo [31mERROR: Starting prysm requires an internet connection. [0m && exit /b 1)
+(for /f %%i in ('curl -f -s https://prysmaticlabs.com/releases/latest') do set prysm_version=%%i) || (echo [31mERROR: Starting prysm requires an internet connection. If you are being blocked by your antivirus, you can re-run with --ssl-no-revoke [0m && exit /b 1)
 echo [37mLatest prysm release is %prysm_version%.[0m
 IF defined USE_PRYSM_VERSION (
     echo [33mdetected variable USE_PRYSM_VERSION=%USE_PRYSM_VERSION%[0m

--- a/prysm.sh
+++ b/prysm.sh
@@ -107,7 +107,7 @@ function get_prysm_version() {
     else
         # Find the latest Prysm version available for download.
         readonly reason="automatically selected latest available version"
-        prysm_version=$(curl -f -s https://prysmaticlabs.com/releases/latest) || (color "31" "Starting prysm requires an internet connection." && exit 1)
+        prysm_version=$(curl -f -s https://prysmaticlabs.com/releases/latest) || (color "31" "Starting prysm requires an internet connection. If you are being blocked by your antivirus, you can re-run with --ssl-no-revoke" && exit 1)
         readonly prysm_version
     fi
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What does this PR do? Why is it needed?**

Users can circumvent their antivirus blocking curl requests to prysm.sh by specifying --ssl-no-revoke. This PR recommends that option to users who may be blocked by their antivirus.

**Which issues(s) does this PR fix?**

Fixes #5986 
