### PR TITLE
Register RPC And Pubsub Handlers After Genesis is Determined

### DIFF
--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -15,6 +15,7 @@ import (
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	blockfeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/block"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed/operation"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
@@ -27,6 +28,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
 	"github.com/prysmaticlabs/prysm/shared"
+	"github.com/prysmaticlabs/prysm/shared/roughtime"
 	"github.com/prysmaticlabs/prysm/shared/runutil"
 )
 
@@ -131,8 +133,7 @@ func NewRegularSync(cfg *Config) *Service {
 		blocksRateLimiter:    leakybucket.NewCollector(allowedBlocksPerSecond, allowedBlocksBurst, false /* deleteEmptyBuckets */),
 	}
 
-	r.registerRPCHandlers()
-	go r.registerSubscribers()
+	go r.registerHandlers()
 
 	return r
 }
@@ -207,6 +208,40 @@ func (r *Service) initCaches() error {
 	r.seenProposerSlashingCache = proposerSlashingCache
 
 	return nil
+}
+
+func (r *Service) registerHandlers() {
+	// Wait until chain start.
+	stateChannel := make(chan *feed.Event, 1)
+	stateSub := r.stateNotifier.StateFeed().Subscribe(stateChannel)
+	defer stateSub.Unsubscribe()
+	for r.chainStarted == false {
+		select {
+		case event := <-stateChannel:
+			if event.Type == statefeed.Initialized {
+				data, ok := event.Data.(*statefeed.InitializedData)
+				if !ok {
+					log.Error("Event feed data is not type *statefeed.InitializedData")
+					return
+				}
+				log.WithField("starttime", data.StartTime).Debug("Received state initialized event")
+				if data.StartTime.After(roughtime.Now()) {
+					stateSub.Unsubscribe()
+					time.Sleep(roughtime.Until(data.StartTime))
+				}
+				r.chainStarted = true
+			}
+		case <-r.ctx.Done():
+			log.Debug("Context closed, exiting goroutine")
+			return
+		case err := <-stateSub.Err():
+			log.WithError(err).Error("Subscription to state notifier failed")
+			return
+		}
+	}
+	// Register respective rpc and pubsub handlers.
+	r.registerRPCHandlers()
+	r.registerSubscribers()
 }
 
 // Checker defines a struct which can verify whether a node is currently

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -1,14 +1,21 @@
 package sync
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	mockChain "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
+	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
 func TestService_StatusZeroEpoch(t *testing.T) {
@@ -30,4 +37,52 @@ func TestService_StatusZeroEpoch(t *testing.T) {
 	if err != nil {
 		t.Errorf("Wanted non failing status but got: %v", err)
 	}
+}
+
+func TestSyncHandlers_WaitToSync(t *testing.T) {
+	p2p := p2ptest.NewTestP2P(t)
+	chainService := &mockChain.ChainService{
+		Genesis:        time.Now(),
+		ValidatorsRoot: [32]byte{'A'},
+	}
+	r := Service{
+		ctx:           context.Background(),
+		p2p:           p2p,
+		chain:         chainService,
+		stateNotifier: chainService.StateNotifier(),
+		initialSync:   &mockSync.Sync{IsSyncing: false},
+	}
+
+	topic := "/eth2/%x/beacon_block"
+	go r.registerHandlers()
+	time.Sleep(100 * time.Millisecond)
+	i := r.stateNotifier.StateFeed().Send(&feed.Event{
+		Type: statefeed.Initialized,
+		Data: &statefeed.InitializedData{
+			StartTime: time.Now(),
+		},
+	})
+	if i == 0 {
+		t.Fatal("didn't send genesis time to subscribers")
+	}
+	b := []byte("sk")
+	b32 := bytesutil.ToBytes32(b)
+	sk, err := bls.SecretKeyFromBytes(b32[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := &ethpb.SignedBeaconBlock{
+		Block: &ethpb.BeaconBlock{
+			ParentRoot: testutil.Random32Bytes(t),
+		},
+		Signature: sk.Sign([]byte("data")).Marshal(),
+	}
+	p2p.ReceivePubSub(topic, msg)
+	// wait for chainstart to be sent
+	time.Sleep(400 * time.Millisecond)
+	if !r.chainStarted {
+		t.Fatal("Did not receive chain start event.")
+	}
+
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

It registers our handlers only after we receive the state initialized event.

**Which issues(s) does this PR fix?**

Resolves #5990 

**Other notes for review**
