### PR TITLE
Fixes problem in YAML front-matter of the new flag tracking issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_flag.md
+++ b/.github/ISSUE_TEMPLATE/feature_flag.md
@@ -1,9 +1,7 @@
 ---
 name: "\U0001F984Feature Flag Tracking"
-about: Track a new feature, in development, in Prysm. This issue template should only be used by 
-developers or contributors!
+about: Track a new feature, in development, in Prysm. This issue template should only be used by developers or contributors!
 labels: Tracking
-
 ---
 <!--💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎💎
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- Fixes template's front-matter, allowing us to use that template

**Other notes for review**
- Wanted to use the template to track recently introduced flag, but template wasn't available on issue selection. Turns out there's a bug in YAML's front-matter.
