### PR TITLE
Reduce attester state copies

### DIFF
--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     deps = [
         "//beacon-chain/state:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
+        "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/sliceutil:go_default_library",

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -98,7 +98,6 @@ func (c *AttestationCache) Get(ctx context.Context, req *ethpb.AttestationDataRe
 
 	if exists && item != nil && item.(*attestationReqResWrapper).res != nil {
 		attestationCacheHit.Inc()
-		state.CopyAttestationData(item.(*attestationReqResWrapper).res)
 		return state.CopyAttestationData(item.(*attestationReqResWrapper).res), nil
 	}
 	attestationCacheMiss.Inc()

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -162,7 +162,7 @@ func wrapperToKey(i interface{}) (string, error) {
 }
 
 func reqToKey(req *ethpb.AttestationDataRequest) (string, error) {
-	return fmt.Sprintf("%d-%d", req.CommitteeIndex, req.Slot), nil
+	return fmt.Sprintf("%d", req.Slot), nil
 }
 
 type attestationReqResWrapper struct {

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -98,7 +99,10 @@ func (c *AttestationCache) Get(ctx context.Context, req *ethpb.AttestationDataRe
 
 	if exists && item != nil && item.(*attestationReqResWrapper).res != nil {
 		attestationCacheHit.Inc()
-		return state.CopyAttestationData(item.(*attestationReqResWrapper).res), nil
+		if featureconfig.Get().ReduceAttesterStateCopy {
+			return state.CopyAttestationData(item.(*attestationReqResWrapper).res), nil
+		}
+		return item.(*attestationReqResWrapper).res, nil
 	}
 	attestationCacheMiss.Inc()
 	return nil, nil
@@ -163,7 +167,10 @@ func wrapperToKey(i interface{}) (string, error) {
 }
 
 func reqToKey(req *ethpb.AttestationDataRequest) (string, error) {
-	return fmt.Sprintf("%d", req.Slot), nil
+	if featureconfig.Get().ReduceAttesterStateCopy {
+		return fmt.Sprintf("%d", req.Slot), nil
+	}
+	return fmt.Sprintf("%d-%d", req.CommitteeIndex, req.Slot), nil
 }
 
 type attestationReqResWrapper struct {

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -97,7 +98,8 @@ func (c *AttestationCache) Get(ctx context.Context, req *ethpb.AttestationDataRe
 
 	if exists && item != nil && item.(*attestationReqResWrapper).res != nil {
 		attestationCacheHit.Inc()
-		return item.(*attestationReqResWrapper).res, nil
+		state.CopyAttestationData(item.(*attestationReqResWrapper).res)
+		return state.CopyAttestationData(item.(*attestationReqResWrapper).res), nil
 	}
 	attestationCacheMiss.Inc()
 	return nil, nil

--- a/beacon-chain/rpc/validator/attester.go
+++ b/beacon-chain/rpc/validator/attester.go
@@ -47,6 +47,7 @@ func (vs *Server) GetAttestationData(ctx context.Context, req *ethpb.Attestation
 		return nil, status.Errorf(codes.Internal, "Could not retrieve data from attestation cache: %v", err)
 	}
 	if res != nil {
+		res.CommitteeIndex = req.CommitteeIndex
 		return res, nil
 	}
 
@@ -59,6 +60,7 @@ func (vs *Server) GetAttestationData(ctx context.Context, req *ethpb.Attestation
 			if res == nil {
 				return nil, status.Error(codes.DataLoss, "A request was in progress and resolved to nil")
 			}
+			res.CommitteeIndex = req.CommitteeIndex
 			return res, nil
 		}
 		return nil, status.Errorf(codes.Internal, "Could not mark attestation as in-progress: %v", err)

--- a/beacon-chain/rpc/validator/attester.go
+++ b/beacon-chain/rpc/validator/attester.go
@@ -47,7 +47,9 @@ func (vs *Server) GetAttestationData(ctx context.Context, req *ethpb.Attestation
 		return nil, status.Errorf(codes.Internal, "Could not retrieve data from attestation cache: %v", err)
 	}
 	if res != nil {
-		res.CommitteeIndex = req.CommitteeIndex
+		if featureconfig.Get().ReduceAttesterStateCopy {
+			res.CommitteeIndex = req.CommitteeIndex
+		}
 		return res, nil
 	}
 
@@ -60,7 +62,9 @@ func (vs *Server) GetAttestationData(ctx context.Context, req *ethpb.Attestation
 			if res == nil {
 				return nil, status.Error(codes.DataLoss, "A request was in progress and resolved to nil")
 			}
-			res.CommitteeIndex = req.CommitteeIndex
+			if featureconfig.Get().ReduceAttesterStateCopy {
+				res.CommitteeIndex = req.CommitteeIndex
+			}
 			return res, nil
 		}
 		return nil, status.Errorf(codes.Internal, "Could not mark attestation as in-progress: %v", err)

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -58,6 +58,7 @@ type Flags struct {
 	WaitForSynced                              bool // WaitForSynced uses WaitForSynced in validator startup to ensure it can communicate with the beacon node as soon as possible.
 	SkipRegenHistoricalStates                  bool // SkipRegenHistoricalState skips regenerating historical states from genesis to last finalized. This enables a quick switch over to using new-state-mgmt.
 	EnableInitSyncWeightedRoundRobin           bool // EnableInitSyncWeightedRoundRobin enables weighted round robin fetching optimization in initial syncing.
+	ReduceAttesterStateCopy                    bool // ReduceAttesterStateCopy reduces head state copies for attester rpc.
 
 	// DisableForkChoice disables using LMD-GHOST fork choice to update
 	// the head of the chain based on attestations and instead accepts any valid received block
@@ -213,6 +214,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.Bool(disableStateRefCopy.Name) {
 		log.Warn("Disabling state reference copy")
 		cfg.EnableStateRefCopy = false
+	}
+	if ctx.Bool(reduceAttesterStateCopy.Name) {
+		log.Warn("Enabling feature that reduces attester state copy")
+		cfg.ReduceAttesterStateCopy = true
 	}
 	Init(cfg)
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -156,6 +156,10 @@ var (
 		Name:  "enable-init-sync-wrr",
 		Usage: "Enables weighted round robin fetching optimization",
 	}
+	reduceAttesterStateCopy = &cli.BoolFlag{
+		Name:  "reduce-attester-state-copy",
+		Usage: "Reduces the amount of state copies for attester rpc",
+	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
@@ -163,6 +167,7 @@ var devModeFlags = []cli.Flag{
 	enableFieldTrie,
 	enableNewStateMgmt,
 	enableInitSyncWeightedRoundRobin,
+	reduceAttesterStateCopy,
 }
 
 // Deprecated flags list.
@@ -476,6 +481,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	skipRegenHistoricalStates,
 	enableInitSyncWeightedRoundRobin,
 	disableStateRefCopy,
+	reduceAttesterStateCopy,
 }...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.
@@ -486,4 +492,5 @@ var E2EBeaconChainFlags = []string{
 	"--enable-state-field-trie",
 	"--enable-new-state-mgmt",
 	"--enable-init-sync-wrr",
+	"--reduce-attester-state-copy",
 }


### PR DESCRIPTION
**What type of PR is this?**
> Feature

**What does this PR do? Why is it needed?**
This significantly reduces the amount of head state copy for RPC attester from `ASSIGNED_COMMITTED_COUNT` down to 1. With great saving when there's multiple keys, because chances are a validator client are assigned to more than 1 committee. In the current experiment, we see with 50 validators, the validator client are very often assigned to 8 committees per slot. That's 7 extra copies saved. This works because shard is not in play for phase 0, all committees are the same from beacon node's perspective.

Gated behind feature flag `--reduce-attester-state-copy`

**Which issues(s) does this PR fix?**

Fixes #5961 

**Other notes for review**
Tested it locally for 12 hours with 4k validators. This saves ~1GB run time memory. For 4k, less than 1.5GB memory used. The for attester's head state copy is gone
![Screen Shot 2020-05-28 at 6 54 17 AM](https://user-images.githubusercontent.com/21316537/83150494-2f82a200-a0b0-11ea-80f8-75488348e720.png)