### PR TITLE
Change slashing pool to use spec code 

### DIFF
--- a/beacon-chain/operations/slashings/service_attester_test.go
+++ b/beacon-chain/operations/slashings/service_attester_test.go
@@ -105,33 +105,31 @@ func TestPool_InsertAttesterSlashing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	exitedVal.ExitEpoch = 0
 	exitedVal.WithdrawableEpoch = 0
-	futureExitedVal, err := beaconState.ValidatorAtIndex(uint64(4))
+	if err := beaconState.UpdateValidatorAtIndex(uint64(2), exitedVal); err != nil {
+		t.Fatal(err)
+	}
+	futureWithdrawVal, err := beaconState.ValidatorAtIndex(uint64(4))
 	if err != nil {
 		t.Fatal(err)
 	}
-	futureExitedVal.ExitEpoch = 17
-	futureExitedVal.WithdrawableEpoch = 17
+	futureWithdrawVal.WithdrawableEpoch = 17
+	if err := beaconState.UpdateValidatorAtIndex(uint64(4), futureWithdrawVal); err != nil {
+		t.Fatal(err)
+	}
 	slashedVal, err := beaconState.ValidatorAtIndex(uint64(5))
 	if err != nil {
 		t.Fatal(err)
 	}
 	slashedVal.Slashed = true
+	if err := beaconState.UpdateValidatorAtIndex(uint64(5), slashedVal); err != nil {
+		t.Fatal(err)
+	}
 	slashedVal2, err := beaconState.ValidatorAtIndex(uint64(21))
 	if err != nil {
 		t.Fatal(err)
 	}
 	slashedVal2.Slashed = true
-	if err := beaconState.UpdateValidatorAtIndex(uint64(2), exitedVal); err != nil {
-		t.Fatal(err)
-	}
-	if err := beaconState.UpdateValidatorAtIndex(uint64(4), futureExitedVal); err != nil {
-		t.Fatal(err)
-	}
-	if err := beaconState.UpdateValidatorAtIndex(uint64(5), slashedVal); err != nil {
-		t.Fatal(err)
-	}
 	if err := beaconState.UpdateValidatorAtIndex(uint64(21), slashedVal2); err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +190,7 @@ func TestPool_InsertAttesterSlashing(t *testing.T) {
 			want: pendingSlashings[1:2],
 		},
 		{
-			name: "Slashing for already slashed validator",
+			name: "Slashing for already exit validator",
 			fields: fields{
 				pending:  []*PendingAttesterSlashing{},
 				included: make(map[uint64]bool),
@@ -204,7 +202,7 @@ func TestPool_InsertAttesterSlashing(t *testing.T) {
 			want: []*PendingAttesterSlashing{},
 		},
 		{
-			name: "Slashing for exited validator",
+			name: "Slashing for withdrawable validator",
 			fields: fields{
 				pending:  []*PendingAttesterSlashing{},
 				included: make(map[uint64]bool),
@@ -216,7 +214,7 @@ func TestPool_InsertAttesterSlashing(t *testing.T) {
 			want: []*PendingAttesterSlashing{},
 		},
 		{
-			name: "Slashing for futuristic exited validator",
+			name: "Slashing for slashed validator",
 			fields: fields{
 				pending:  []*PendingAttesterSlashing{},
 				included: make(map[uint64]bool),

--- a/beacon-chain/operations/slashings/service_attester_test.go
+++ b/beacon-chain/operations/slashings/service_attester_test.go
@@ -106,11 +106,13 @@ func TestPool_InsertAttesterSlashing(t *testing.T) {
 		t.Fatal(err)
 	}
 	exitedVal.ExitEpoch = 0
+	exitedVal.WithdrawableEpoch = 0
 	futureExitedVal, err := beaconState.ValidatorAtIndex(uint64(4))
 	if err != nil {
 		t.Fatal(err)
 	}
 	futureExitedVal.ExitEpoch = 17
+	futureExitedVal.WithdrawableEpoch = 17
 	slashedVal, err := beaconState.ValidatorAtIndex(uint64(5))
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/operations/slashings/service_proposer_test.go
+++ b/beacon-chain/operations/slashings/service_proposer_test.go
@@ -55,13 +55,11 @@ func TestPool_InsertProposerSlashing(t *testing.T) {
 		t.Fatal(err)
 	}
 	exitedVal.WithdrawableEpoch = 0
-	exitedVal.ExitEpoch = 0
 	futureExitedVal, err := beaconState.ValidatorAtIndex(uint64(4))
 	if err != nil {
 		t.Fatal(err)
 	}
 	futureExitedVal.WithdrawableEpoch = 17
-	futureExitedVal.ExitEpoch = 17
 	slashedVal, err := beaconState.ValidatorAtIndex(uint64(5))
 	if err != nil {
 		t.Fatal(err)
@@ -121,7 +119,7 @@ func TestPool_InsertProposerSlashing(t *testing.T) {
 			want: []*ethpb.ProposerSlashing{},
 		},
 		{
-			name: "Slashing for future exited validator",
+			name: "Slashing for exiting validator",
 			fields: fields{
 				pending:  []*ethpb.ProposerSlashing{},
 				included: make(map[uint64]bool),

--- a/beacon-chain/operations/slashings/service_proposer_test.go
+++ b/beacon-chain/operations/slashings/service_proposer_test.go
@@ -54,11 +54,13 @@ func TestPool_InsertProposerSlashing(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	exitedVal.WithdrawableEpoch = 0
 	exitedVal.ExitEpoch = 0
 	futureExitedVal, err := beaconState.ValidatorAtIndex(uint64(4))
 	if err != nil {
 		t.Fatal(err)
 	}
+	futureExitedVal.WithdrawableEpoch = 17
 	futureExitedVal.ExitEpoch = 17
 	slashedVal, err := beaconState.ValidatorAtIndex(uint64(5))
 	if err != nil {
@@ -111,7 +113,7 @@ func TestPool_InsertProposerSlashing(t *testing.T) {
 				pending:  []*ethpb.ProposerSlashing{},
 				included: make(map[uint64]bool),
 				wantErr:  true,
-				err:      "cannot be slashed",
+				err:      "is not slashable",
 			},
 			args: args{
 				slashings: slashings[2:3],


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR modifies the slashing pool to use more spec code, to prevent duplicated code that needs to be maintained. This fixes an improper calculation for slashing validation, allowing a possibly invalid slashing to be put into the pool.