### PR TITLE
Fix Weird Pre-Genesis Timestamp

### DIFF
--- a/beacon-chain/rpc/node/server.go
+++ b/beacon-chain/rpc/node/server.go
@@ -53,14 +53,11 @@ func (ns *Server) GetGenesis(ctx context.Context, _ *ptypes.Empty) (*ethpb.Genes
 	var gt *ptypes.Timestamp
 	if genesisTime == defaultGenesisTime {
 		gt, err = ptypes.TimestampProto(time.Unix(0, 0))
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not convert genesis time to proto: %v", err)
-		}
 	} else {
 		gt, err = ptypes.TimestampProto(genesisTime)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not convert genesis time to proto: %v", err)
-		}
+	}
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not convert genesis time to proto: %v", err)
 	}
 
 	genValRoot := ns.GenesisFetcher.GenesisValidatorRoot()

--- a/beacon-chain/rpc/node/server.go
+++ b/beacon-chain/rpc/node/server.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	ptypes "github.com/gogo/protobuf/types"
 	"github.com/libp2p/go-libp2p-core/network"
@@ -40,17 +41,28 @@ func (ns *Server) GetSyncStatus(ctx context.Context, _ *ptypes.Empty) (*ethpb.Sy
 	}, nil
 }
 
-// GetGenesis fetches genesis chain information of Ethereum 2.0.
+// GetGenesis fetches genesis chain information of Ethereum 2.0. Returns the unit timestamp 0
+// if there a genesis time has yet to be determined.
 func (ns *Server) GetGenesis(ctx context.Context, _ *ptypes.Empty) (*ethpb.Genesis, error) {
 	contractAddr, err := ns.BeaconDB.DepositContractAddress(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not retrieve contract address from db: %v", err)
 	}
 	genesisTime := ns.GenesisTimeFetcher.GenesisTime()
-	gt, err := ptypes.TimestampProto(genesisTime)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not convert genesis time to proto: %v", err)
+	var defaultGenesisTime time.Time
+	var gt *ptypes.Timestamp
+	if genesisTime == defaultGenesisTime {
+		gt, err = ptypes.TimestampProto(time.Unix(0, 0))
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not convert genesis time to proto: %v", err)
+		}
+	} else {
+		gt, err = ptypes.TimestampProto(genesisTime)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not convert genesis time to proto: %v", err)
+		}
 	}
+
 	genValRoot := ns.GenesisFetcher.GenesisValidatorRoot()
 	return &ethpb.Genesis{
 		GenesisTime:            gt,

--- a/beacon-chain/rpc/node/server_test.go
+++ b/beacon-chain/rpc/node/server_test.go
@@ -53,7 +53,7 @@ func TestNodeServer_GetGenesis(t *testing.T) {
 	genValRoot := bytesutil.ToBytes32([]byte("I am root"))
 	ns := &Server{
 		BeaconDB:           db,
-		GenesisTimeFetcher: &mock.ChainService{Genesis: time.Unix(0, 0)},
+		GenesisTimeFetcher: &mock.ChainService{},
 		GenesisFetcher: &mock.ChainService{
 			State:          st,
 			ValidatorsRoot: genValRoot,
@@ -75,6 +75,19 @@ func TestNodeServer_GetGenesis(t *testing.T) {
 	}
 	if !bytes.Equal(genValRoot[:], res.GenesisValidatorsRoot) {
 		t.Errorf("Wanted GenesisValidatorsRoot = %v, received %v", genValRoot, res.GenesisValidatorsRoot)
+	}
+
+	ns.GenesisTimeFetcher = &mock.ChainService{Genesis: time.Unix(10, 0)}
+	res, err = ns.GetGenesis(context.Background(), &ptypes.Empty{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pUnix, err = ptypes.TimestampProto(time.Unix(10, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.GenesisTime.Equal(pUnix) {
+		t.Errorf("Wanted GenesisTime() = %v, received %v", pUnix, res.GenesisTime)
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

If the beacon node is pre-genesis (as in, a genesis time has yet to be determined), the result of 

```
curl -X GET "http://localhost:4001/eth/v1alpha1/node/genesis" -H  "accept: application/json"
```
will be 0001-01-01T00:00:00Z, which is not a realistic value and returns -672637623 when attempting to convert into a unix timestamp. Instead, we should do a sensible default of unix timestamp 0.

Confirmed the result works:

```
{"genesisTime":"1970-01-01T00:00:00Z","depositContractAddress":"vhKJVwd36/uywA1nK2aeiStTAP4=","genesisValidatorsRoot":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}
```

**Which issues(s) does this PR fix?**

Fixes #5548 
