### PR TITLE
Increase hot state cache size to 32

### DIFF
--- a/beacon-chain/cache/hot_state_cache.go
+++ b/beacon-chain/cache/hot_state_cache.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	// hotStateCacheSize defines the max number of hot state this can cache.
-	hotStateCacheSize = 16
+	hotStateCacheSize = 32
 	// Metrics
 	hotStateCacheHit = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "hot_state_cache_hit",


### PR DESCRIPTION
**What type of PR is this?**
> Feature

**What does this PR do? Why is it needed?**
Increase hot state cache size from 16 to 32. This improves hot state miss rate from ~4% to 2% and brings in more memory saving to the `new-state-mgmt` feature. This was discussed with @nisdas and both of us tested this increase and mutually agreed this is a superior approach