### PR TITLE
Ensure Only Noise And Secio Are Security Transports

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -76,6 +76,7 @@ go_library(
         "@com_github_libp2p_go_libp2p_peerstore//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//pb:go_default_library",
+        "@com_github_libp2p_go_libp2p_secio//:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",

--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/libp2p/go-libp2p"
 	noise "github.com/libp2p/go-libp2p-noise"
+	secio "github.com/libp2p/go-libp2p-secio"
 	filter "github.com/multiformats/go-multiaddr"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
@@ -33,7 +34,9 @@ func buildOptions(cfg *Config, ip net.IP, priKey *ecdsa.PrivateKey) []libp2p.Opt
 	}
 	if featureconfig.Get().EnableNoise {
 		// Enable NOISE for the beacon node
-		options = append(options, libp2p.Security(noise.ID, noise.New))
+		options = append(options, libp2p.Security(noise.ID, noise.New), libp2p.Security(secio.ID, secio.New))
+	} else {
+		options = append(options, libp2p.Security(secio.ID, secio.New))
 	}
 	if cfg.EnableUPnP {
 		options = append(options, libp2p.NATPortMap()) //Allow to use UPnP


### PR DESCRIPTION
**What type of PR is this?**

Ensures that for v0.12 only Noise and Secio are used as security transports.

**What does this PR do? Why is it needed?**

Makes sure that we only use the correct security transports instead of something like 
`TLS` which is now the default option along with secio

**Which issues(s) does this PR fix?**

Fixes #6032 

**Other notes for review**
