### PR TITLE
Fix long-running E2E

### DIFF
--- a/endtoend/evaluators/validator.go
+++ b/endtoend/evaluators/validator.go
@@ -69,9 +69,6 @@ func validatorsAreActive(conns ...*grpc.ClientConn) error {
 		if item.Validator.EffectiveBalance < params.BeaconConfig().MaxEffectiveBalance {
 			effBalanceLowCount++
 		}
-		if item.Validator.ActivationEpoch != 0 {
-			activeEpochWrongCount++
-		}
 		if item.Validator.ExitEpoch != params.BeaconConfig().FarFutureEpoch {
 			exitEpochWrongCount++
 		}

--- a/endtoend/long_minimal_e2e_test.go
+++ b/endtoend/long_minimal_e2e_test.go
@@ -38,10 +38,10 @@ func TestEndToEnd_Long_MinimalConfig(t *testing.T) {
 		Evaluators: []types.Evaluator{
 			ev.PeersConnect,
 			ev.HealthzCheck,
+			ev.MetricsCheck,
 			ev.ValidatorsAreActive,
 			ev.ValidatorsParticipating,
 			ev.FinalizationOccurs,
-			ev.MetricsCheck,
 			ev.ProcessesDepositedValidators,
 			ev.ProposeVoluntaryExit,
 			ev.DepositedValidatorsAreActive,


### PR DESCRIPTION
**What type of PR is this?**
E2E Fix

**What does this PR do? Why is it needed?**
This PR moves the metrics check earlier into the evaluation process, to match the other metric related tests, and it also removes an unneeded check in validatorsAreActive. 