### PR TITLE
Reset Streams Properly

### DIFF
--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-	// The time to wait before disconnecting a peer.
-	flushDuration = 50 * time.Millisecond
 	// The time to wait for a status request.
 	timeForStatus = 10 * time.Second
 )
@@ -85,9 +83,6 @@ func (s *Service) AddConnectionHandler(reqFunc func(ctx context.Context, id peer
 					if err := goodbyeFunc(context.Background(), remotePeer); err != nil {
 						log.WithError(err).Trace("Unable to send goodbye message to peer")
 					}
-					// Add a short delay to allow the stream to flush before closing the connection.
-					// There is still a chance that the peer won't receive the message.
-					time.Sleep(flushDuration)
 					disconnectFromPeer()
 					return
 				}

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -459,7 +459,7 @@ func (f *blocksFetcher) requestBlocks(
 	}
 	defer func() {
 		if err := stream.Reset(); err != nil {
-			log.WithError(err).Error("Failed to close stream with protocol %s", stream.Protocol())
+			log.WithError(err).Errorf("Failed to close stream with protocol %s", stream.Protocol())
 		}
 	}()
 

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -458,8 +458,8 @@ func (f *blocksFetcher) requestBlocks(
 		return nil, err
 	}
 	defer func() {
-		if err := stream.Close(); err != nil {
-			log.WithError(err).Error("Failed to close stream")
+		if err := stream.Reset(); err != nil {
+			log.WithError(err).Error("Failed to close stream with protocol %s", stream.Protocol())
 		}
 	}()
 

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -22,6 +22,11 @@ func (r *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := stream.Reset(); err != nil {
+			log.WithError(err).Error("Failed to reset stream with protocol %s", stream.Protocol())
+		}
+	}()
 	for i := 0; i < len(blockRoots); i++ {
 		blk, err := ReadChunkedBlock(stream, r.p2p)
 		if err == io.EOF {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -24,7 +24,7 @@ func (r *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 	}
 	defer func() {
 		if err := stream.Reset(); err != nil {
-			log.WithError(err).Error("Failed to reset stream with protocol %s", stream.Protocol())
+			log.WithError(err).Errorf("Failed to reset stream with protocol %s", stream.Protocol())
 		}
 	}()
 	for i := 0; i < len(blockRoots); i++ {

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -51,9 +51,6 @@ func (r *Service) sendGoodByeAndDisconnect(ctx context.Context, code uint64, id 
 			"peer":  id,
 		}).Debug("Could not send goodbye message to peer")
 	}
-	// Add a short delay to allow the stream to flush before closing the connection.
-	// There is still a chance that the peer won't receive the message.
-	time.Sleep(50 * time.Millisecond)
 	if err := r.p2p.Disconnect(id); err != nil {
 		return err
 	}
@@ -68,8 +65,16 @@ func (r *Service) sendGoodByeMessage(ctx context.Context, code uint64, id peer.I
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := stream.Reset(); err != nil {
+			log.WithError(err).Error("Failed to reset stream with protocol %s", stream.Protocol())
+		}
+	}()
 	log := log.WithField("Reason", goodbyeMessage(code))
 	log.WithField("peer", stream.Conn().RemotePeer()).Debug("Sending Goodbye message to peer")
+	// Add a short delay to allow the stream to flush before resetting it.
+	// There is still a chance that the peer won't receive the message.
+	time.Sleep(50 * time.Millisecond)
 	return nil
 }
 

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -67,7 +67,7 @@ func (r *Service) sendGoodByeMessage(ctx context.Context, code uint64, id peer.I
 	}
 	defer func() {
 		if err := stream.Reset(); err != nil {
-			log.WithError(err).Error("Failed to reset stream with protocol %s", stream.Protocol())
+			log.WithError(err).Errorf("Failed to reset stream with protocol %s", stream.Protocol())
 		}
 	}()
 	log := log.WithField("Reason", goodbyeMessage(code))

--- a/beacon-chain/sync/rpc_metadata.go
+++ b/beacon-chain/sync/rpc_metadata.go
@@ -41,8 +41,8 @@ func (r *Service) sendMetaDataRequest(ctx context.Context, id peer.ID) (*pb.Meta
 	// metadata requests send no payload, so closing the
 	// stream early leads it to a reset.
 	defer func() {
-		if err := stream.Close(); err != nil {
-			log.WithError(err).Error("Failed to close stream")
+		if err := stream.Reset(); err != nil {
+			log.WithError(err).Errorf("Failed to reset stream for protocol %s", stream.Protocol())
 		}
 	}()
 	code, errMsg, err := ReadStatusCode(stream, r.p2p.Encoding())

--- a/beacon-chain/sync/rpc_ping.go
+++ b/beacon-chain/sync/rpc_ping.go
@@ -60,7 +60,7 @@ func (r *Service) sendPingRequest(ctx context.Context, id peer.ID) error {
 	}
 	defer func() {
 		if err := stream.Reset(); err != nil {
-			log.WithError(err).Error("Failed to reset stream with protocol %s", stream.Protocol())
+			log.WithError(err).Errorf("Failed to reset stream with protocol %s", stream.Protocol())
 		}
 	}()
 

--- a/beacon-chain/sync/rpc_ping.go
+++ b/beacon-chain/sync/rpc_ping.go
@@ -58,6 +58,11 @@ func (r *Service) sendPingRequest(ctx context.Context, id peer.ID) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := stream.Reset(); err != nil {
+			log.WithError(err).Error("Failed to reset stream with protocol %s", stream.Protocol())
+		}
+	}()
 
 	code, errMsg, err := ReadStatusCode(stream, r.p2p.Encoding())
 	if err != nil {

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -97,7 +97,7 @@ func (r *Service) sendRPCStatusRequest(ctx context.Context, id peer.ID) error {
 	}
 	defer func() {
 		if err := stream.Reset(); err != nil {
-			log.WithError(err).Error("Failed to reset stream with protocol %s", stream.Protocol())
+			log.WithError(err).Errorf("Failed to reset stream with protocol %s", stream.Protocol())
 		}
 	}()
 

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -95,6 +95,11 @@ func (r *Service) sendRPCStatusRequest(ctx context.Context, id peer.ID) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err := stream.Reset(); err != nil {
+			log.WithError(err).Error("Failed to reset stream with protocol %s", stream.Protocol())
+		}
+	}()
 
 	code, errMsg, err := ReadStatusCode(stream, r.p2p.Encoding())
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

On long running nodes, profile snapshots constantly showed a larger growing heap. Initially it was not obvious what was the root cause, but after a while it became clear that a large amount of streams were not cleaned up properly. While in most situations closing the stream is fine, as the other user will also close the stream on their end too.  This allows the yamux session to remove the dead stream and clean it up. However there are situations when the other peer does not reply back or no messages are received,etc. This leads to the stream being left open and not being cleaned up. While it was not an issue with 30 peers, it becomes much worse with a larger number of peers over a period of time.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

N.A