### PR TITLE
Fixes intersection functions (uint64, int64, []byte)

### DIFF
--- a/shared/sliceutil/slice.go
+++ b/shared/sliceutil/slice.go
@@ -155,19 +155,22 @@ func IntersectionInt64(s ...[]int64) []int64 {
 	if len(s) == 1 {
 		return s[0]
 	}
-	set := make([]int64, 0)
-	m := make(map[int64]bool)
-	for i := 1; i < len(s); i++ {
-		for j := 0; j < len(s[i-1]); j++ {
-			m[s[i-1][j]] = true
-		}
-		for j := 0; j < len(s[i]); j++ {
-			if _, found := m[s[i][j]]; found {
-				set = append(set, s[i][j])
+	intersect := make([]int64, 0)
+	m := make(map[int64]int)
+	for _, k := range s[0] {
+		m[k] = 1
+	}
+	for i, num := 1, len(s); i < num; i++ {
+		for _, k := range s[i] {
+			if count, found := m[k]; found && count < num {
+				m[k]++
+				if m[k] == num {
+					intersect = append(intersect, k)
+				}
 			}
 		}
 	}
-	return set
+	return intersect
 }
 
 // UnionInt64 of any number of int64 slices with time

--- a/shared/sliceutil/slice.go
+++ b/shared/sliceutil/slice.go
@@ -41,14 +41,17 @@ func IntersectionUint64(s ...[]uint64) []uint64 {
 		return s[0]
 	}
 	intersect := make([]uint64, 0)
-	for i := 1; i < len(s); i++ {
-		m := make(map[uint64]bool)
-		for j := 0; j < len(s[i-1]); j++ {
-			m[s[i-1][j]] = true
-		}
-		for j := 0; j < len(s[i]); j++ {
-			if _, found := m[s[i][j]]; found {
-				intersect = append(intersect, s[i][j])
+	m := make(map[uint64]int)
+	for _, k := range s[0] {
+		m[k] = 1
+	}
+	for i, num := 1, len(s); i < num; i++ {
+		for _, k := range s[i] {
+			if count, found := m[k]; found && count < num {
+				m[k]++
+				if m[k] == num {
+					intersect = append(intersect, k)
+				}
 			}
 		}
 	}

--- a/shared/sliceutil/slice.go
+++ b/shared/sliceutil/slice.go
@@ -47,7 +47,8 @@ func IntersectionUint64(s ...[]uint64) []uint64 {
 	}
 	for i, num := 1, len(s); i < num; i++ {
 		for _, k := range s[i] {
-			if count, found := m[k]; found && count < num {
+			// Increment and check only if item is present in both, and no increment has happened yet.
+			if _, found := m[k]; found && (i-m[k]) == 0 {
 				m[k]++
 				if m[k] == num {
 					intersect = append(intersect, k)
@@ -162,7 +163,7 @@ func IntersectionInt64(s ...[]int64) []int64 {
 	}
 	for i, num := 1, len(s); i < num; i++ {
 		for _, k := range s[i] {
-			if count, found := m[k]; found && count < num {
+			if _, found := m[k]; found && (i-m[k]) == 0 {
 				m[k]++
 				if m[k] == num {
 					intersect = append(intersect, k)
@@ -268,7 +269,7 @@ func IntersectionByteSlices(s ...[][]byte) [][]byte {
 	}
 	for i, num := 1, len(s); i < num; i++ {
 		for _, k := range s[i] {
-			if count, found := m[string(k)]; found && count < num {
+			if _, found := m[string(k)]; found && (i-m[string(k)]) == 0 {
 				m[string(k)]++
 				if m[string(k)] == num {
 					inter = append(inter, k)

--- a/shared/sliceutil/slice.go
+++ b/shared/sliceutil/slice.go
@@ -262,26 +262,19 @@ func IntersectionByteSlices(s ...[][]byte) [][]byte {
 		return s[0]
 	}
 	inter := make([][]byte, 0)
-	for i := 1; i < len(s); i++ {
-		hash := make(map[string]bool)
-		for _, e := range s[i-1] {
-			hash[string(e)] = true
-		}
-		for _, e := range s[i] {
-			if hash[string(e)] {
-				inter = append(inter, e)
+	m := make(map[string]int)
+	for _, k := range s[0] {
+		m[string(k)] = 1
+	}
+	for i, num := 1, len(s); i < num; i++ {
+		for _, k := range s[i] {
+			if count, found := m[string(k)]; found && count < num {
+				m[string(k)]++
+				if m[string(k)] == num {
+					inter = append(inter, k)
+				}
 			}
 		}
-		tmp := make([][]byte, 0)
-		// Remove duplicates from slice.
-		encountered := make(map[string]bool)
-		for _, element := range inter {
-			if !encountered[string(element)] {
-				tmp = append(tmp, element)
-				encountered[string(element)] = true
-			}
-		}
-		inter = tmp
 	}
 	return inter
 }

--- a/shared/sliceutil/slice_test.go
+++ b/shared/sliceutil/slice_test.go
@@ -2,6 +2,7 @@ package sliceutil_test
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
@@ -32,21 +33,42 @@ func TestIntersectionUint64(t *testing.T) {
 	testCases := []struct {
 		setA []uint64
 		setB []uint64
+		setC []uint64
 		out  []uint64
 	}{
-		{[]uint64{2, 3, 5}, []uint64{3}, []uint64{3}},
-		{[]uint64{2, 3, 5}, []uint64{3, 5}, []uint64{3, 5}},
-		{[]uint64{2, 3, 5}, []uint64{5, 3, 2}, []uint64{5, 3, 2}},
-		{[]uint64{2, 3, 5}, []uint64{2, 3, 5}, []uint64{2, 3, 5}},
-		{[]uint64{2, 3, 5}, []uint64{}, []uint64{}},
-		{[]uint64{}, []uint64{2, 3, 5}, []uint64{}},
-		{[]uint64{}, []uint64{}, []uint64{}},
-		{[]uint64{1}, []uint64{1}, []uint64{1}},
+		{[]uint64{2, 3, 5}, []uint64{3}, []uint64{3}, []uint64{3}},
+		{[]uint64{2, 3, 5}, []uint64{3, 5}, []uint64{5}, []uint64{5}},
+		{[]uint64{2, 3, 5}, []uint64{3, 5}, []uint64{3, 5}, []uint64{3, 5}},
+		{[]uint64{2, 3, 5}, []uint64{5, 3, 2}, []uint64{3, 2, 5}, []uint64{2, 3, 5}},
+		{[]uint64{3, 2, 5}, []uint64{5, 3, 2}, []uint64{3, 2, 5}, []uint64{2, 3, 5}},
+		{[]uint64{3, 3, 5}, []uint64{5, 3, 2}, []uint64{3, 2, 5}, []uint64{3, 5}},
+		{[]uint64{2, 3, 5}, []uint64{2, 3, 5}, []uint64{2, 3, 5}, []uint64{2, 3, 5}},
+		{[]uint64{2, 3, 5}, []uint64{}, []uint64{}, []uint64{}},
+		{[]uint64{2, 3, 5}, []uint64{2, 3, 5}, []uint64{}, []uint64{}},
+		{[]uint64{}, []uint64{2, 3, 5}, []uint64{}, []uint64{}},
+		{[]uint64{}, []uint64{}, []uint64{}, []uint64{}},
+		{[]uint64{1}, []uint64{1}, []uint64{}, []uint64{}},
+		{[]uint64{1, 1, 1}, []uint64{1, 1}, []uint64{1, 2, 3}, []uint64{1}},
 	}
 	for _, tt := range testCases {
-		result := sliceutil.IntersectionUint64(tt.setA, tt.setB)
+		setA := append([]uint64{}, tt.setA...)
+		setB := append([]uint64{}, tt.setB...)
+		setC := append([]uint64{}, tt.setC...)
+		result := sliceutil.IntersectionUint64(setA, setB, setC)
+		sort.Slice(result, func(i, j int) bool {
+			return result[i] < result[j]
+		})
 		if !reflect.DeepEqual(result, tt.out) {
 			t.Errorf("got %d, want %d", result, tt.out)
+		}
+		if !reflect.DeepEqual(setA, tt.setA) {
+			t.Errorf("slice modified, got %v, want %v", setA, tt.setA)
+		}
+		if !reflect.DeepEqual(setB, tt.setB) {
+			t.Errorf("slice modified, got %v, want %v", setB, tt.setB)
+		}
+		if !reflect.DeepEqual(setC, tt.setC) {
+			t.Errorf("slice modified, got %v, want %v", setC, tt.setC)
 		}
 	}
 }

--- a/shared/sliceutil/slice_test.go
+++ b/shared/sliceutil/slice_test.go
@@ -386,7 +386,7 @@ func TestIntersectionByteSlices(t *testing.T) {
 					{4, 5},
 				},
 			},
-			result: [][]byte{{4, 5}, {4, 5}},
+			result: [][]byte{{4, 5}},
 		},
 		// Ensure no intersection returns an empty set.
 		{

--- a/shared/sliceutil/slice_test.go
+++ b/shared/sliceutil/slice_test.go
@@ -442,9 +442,8 @@ func TestIntersectionByteSlices(t *testing.T) {
 			{},
 		}
 		result := sliceutil.IntersectionByteSlices(input...)
-		want := [][]byte{}
-		if !reflect.DeepEqual(result, want) {
-			t.Errorf("IntersectionByteSlices(%v)=%v, wanted: %v", input, result, want)
+		if !reflect.DeepEqual(result, [][]byte{}) {
+			t.Errorf("IntersectionByteSlices(%v)=%v, wanted: %v", input, result, [][]byte{})
 		}
 	})
 }

--- a/shared/sliceutil/slice_test.go
+++ b/shared/sliceutil/slice_test.go
@@ -45,6 +45,8 @@ func TestIntersectionUint64(t *testing.T) {
 		{[]uint64{2, 3, 5}, []uint64{2, 3, 5}, []uint64{2, 3, 5}, []uint64{2, 3, 5}},
 		{[]uint64{2, 3, 5}, []uint64{}, []uint64{}, []uint64{}},
 		{[]uint64{2, 3, 5}, []uint64{2, 3, 5}, []uint64{}, []uint64{}},
+		{[]uint64{2, 3}, []uint64{2, 3, 5}, []uint64{5}, []uint64{}},
+		{[]uint64{2, 2, 2}, []uint64{2, 2, 2}, []uint64{}, []uint64{}},
 		{[]uint64{}, []uint64{2, 3, 5}, []uint64{}, []uint64{}},
 		{[]uint64{}, []uint64{}, []uint64{}, []uint64{}},
 		{[]uint64{1}, []uint64{1}, []uint64{}, []uint64{}},
@@ -107,6 +109,8 @@ func TestIntersectionInt64(t *testing.T) {
 		{[]int64{2, 3, 5}, []int64{2, 3, 5}, []int64{2, 3, 5}, []int64{2, 3, 5}},
 		{[]int64{2, 3, 5}, []int64{}, []int64{}, []int64{}},
 		{[]int64{2, 3, 5}, []int64{2, 3, 5}, []int64{}, []int64{}},
+		{[]int64{2, 3}, []int64{2, 3, 5}, []int64{5}, []int64{}},
+		{[]int64{2, 2, 2}, []int64{2, 2, 2}, []int64{}, []int64{}},
 		{[]int64{}, []int64{2, 3, 5}, []int64{}, []int64{}},
 		{[]int64{}, []int64{}, []int64{}, []int64{}},
 		{[]int64{1}, []int64{1}, []int64{}, []int64{}},
@@ -351,10 +355,12 @@ func TestUnionByteSlices(t *testing.T) {
 
 func TestIntersectionByteSlices(t *testing.T) {
 	testCases := []struct {
+		name   string
 		input  [][][]byte
 		result [][]byte
 	}{
 		{
+			name: "intersect with empty set",
 			input: [][][]byte{
 				{
 					{1, 2, 3},
@@ -368,8 +374,8 @@ func TestIntersectionByteSlices(t *testing.T) {
 			},
 			result: [][]byte{},
 		},
-		// Ensure duplicate elements are removed in the resulting set.
 		{
+			name: "ensure duplicate elements are removed in the resulting set",
 			input: [][][]byte{
 				{
 					{1, 2, 3},
@@ -388,8 +394,8 @@ func TestIntersectionByteSlices(t *testing.T) {
 			},
 			result: [][]byte{{4, 5}},
 		},
-		// Ensure no intersection returns an empty set.
 		{
+			name: "ensure no intersection returns an empty set",
 			input: [][][]byte{
 				{
 					{1, 2, 3},
@@ -404,8 +410,8 @@ func TestIntersectionByteSlices(t *testing.T) {
 			},
 			result: [][]byte{},
 		},
-		//  Intersection between A and A should return A.
 		{
+			name: "intersection between A and A should return A",
 			input: [][][]byte{
 				{
 					{1, 2},
@@ -421,12 +427,26 @@ func TestIntersectionByteSlices(t *testing.T) {
 		},
 	}
 	for _, tt := range testCases {
-		result := sliceutil.IntersectionByteSlices(tt.input...)
-		if !reflect.DeepEqual(result, tt.result) {
-			t.Errorf("IntersectionByteSlices(%v)=%v, wanted: %v",
-				tt.input, result, tt.result)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			result := sliceutil.IntersectionByteSlices(tt.input...)
+			if !reflect.DeepEqual(result, tt.result) {
+				t.Errorf("IntersectionByteSlices(%v)=%v, wanted: %v",
+					tt.input, result, tt.result)
+			}
+		})
 	}
+	t.Run("properly handle duplicates", func(t *testing.T) {
+		input := [][][]byte{
+			{{1, 2}, {1, 2}},
+			{{1, 2}, {1, 2}},
+			{},
+		}
+		result := sliceutil.IntersectionByteSlices(input...)
+		want := [][]byte{}
+		if !reflect.DeepEqual(result, want) {
+			t.Errorf("IntersectionByteSlices(%v)=%v, wanted: %v", input, result, want)
+		}
+	})
 }
 
 func TestSplitCommaSeparated(t *testing.T) {

--- a/shared/sliceutil/slice_test.go
+++ b/shared/sliceutil/slice_test.go
@@ -95,21 +95,42 @@ func TestIntersectionInt64(t *testing.T) {
 	testCases := []struct {
 		setA []int64
 		setB []int64
+		setC []int64
 		out  []int64
 	}{
-		{[]int64{2, 3, 5}, []int64{3}, []int64{3}},
-		{[]int64{2, 3, 5}, []int64{3, 5}, []int64{3, 5}},
-		{[]int64{2, 3, 5}, []int64{5, 3, 2}, []int64{5, 3, 2}},
-		{[]int64{2, 3, 5}, []int64{2, 3, 5}, []int64{2, 3, 5}},
-		{[]int64{2, 3, 5}, []int64{}, []int64{}},
-		{[]int64{}, []int64{2, 3, 5}, []int64{}},
-		{[]int64{}, []int64{}, []int64{}},
-		{[]int64{1}, []int64{1}, []int64{1}},
+		{[]int64{2, 3, 5}, []int64{3}, []int64{3}, []int64{3}},
+		{[]int64{2, 3, 5}, []int64{3, 5}, []int64{5}, []int64{5}},
+		{[]int64{2, 3, 5}, []int64{3, 5}, []int64{3, 5}, []int64{3, 5}},
+		{[]int64{2, 3, 5}, []int64{5, 3, 2}, []int64{3, 2, 5}, []int64{2, 3, 5}},
+		{[]int64{3, 2, 5}, []int64{5, 3, 2}, []int64{3, 2, 5}, []int64{2, 3, 5}},
+		{[]int64{3, 3, 5}, []int64{5, 3, 2}, []int64{3, 2, 5}, []int64{3, 5}},
+		{[]int64{2, 3, 5}, []int64{2, 3, 5}, []int64{2, 3, 5}, []int64{2, 3, 5}},
+		{[]int64{2, 3, 5}, []int64{}, []int64{}, []int64{}},
+		{[]int64{2, 3, 5}, []int64{2, 3, 5}, []int64{}, []int64{}},
+		{[]int64{}, []int64{2, 3, 5}, []int64{}, []int64{}},
+		{[]int64{}, []int64{}, []int64{}, []int64{}},
+		{[]int64{1}, []int64{1}, []int64{}, []int64{}},
+		{[]int64{1, 1, 1}, []int64{1, 1}, []int64{1, 2, 3}, []int64{1}},
 	}
 	for _, tt := range testCases {
-		result := sliceutil.IntersectionInt64(tt.setA, tt.setB)
+		setA := append([]int64{}, tt.setA...)
+		setB := append([]int64{}, tt.setB...)
+		setC := append([]int64{}, tt.setC...)
+		result := sliceutil.IntersectionInt64(setA, setB, setC)
+		sort.Slice(result, func(i, j int) bool {
+			return result[i] < result[j]
+		})
 		if !reflect.DeepEqual(result, tt.out) {
 			t.Errorf("got %d, want %d", result, tt.out)
+		}
+		if !reflect.DeepEqual(setA, tt.setA) {
+			t.Errorf("slice modified, got %v, want %v", setA, tt.setA)
+		}
+		if !reflect.DeepEqual(setB, tt.setB) {
+			t.Errorf("slice modified, got %v, want %v", setB, tt.setB)
+		}
+		if !reflect.DeepEqual(setC, tt.setC) {
+			t.Errorf("slice modified, got %v, want %v", setC, tt.setC)
 		}
 	}
 }
@@ -343,8 +364,9 @@ func TestIntersectionByteSlices(t *testing.T) {
 					{1, 2},
 					{4, 5},
 				},
+				{},
 			},
-			result: [][]byte{{4, 5}},
+			result: [][]byte{},
 		},
 		// Ensure duplicate elements are removed in the resulting set.
 		{
@@ -359,8 +381,12 @@ func TestIntersectionByteSlices(t *testing.T) {
 					{4, 5},
 					{4, 5},
 				},
+				{
+					{4, 5},
+					{4, 5},
+				},
 			},
-			result: [][]byte{{4, 5}},
+			result: [][]byte{{4, 5}, {4, 5}},
 		},
 		// Ensure no intersection returns an empty set.
 		{
@@ -372,12 +398,18 @@ func TestIntersectionByteSlices(t *testing.T) {
 				{
 					{1, 2},
 				},
+				{
+					{1, 2},
+				},
 			},
 			result: [][]byte{},
 		},
 		//  Intersection between A and A should return A.
 		{
 			input: [][][]byte{
+				{
+					{1, 2},
+				},
 				{
 					{1, 2},
 				},


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- Fixes issue with intersection functions, when argument list has more than 2 slices (issue is reported by audit team)

**Which issues(s) does this PR fix?**

Fixes #6029

**Other notes for review**
- This is **an alternative** PR to the one that has been created by Terence: https://github.com/prysmaticlabs/prysm/pull/6050 
- Terence's PR was blocked by what seemed to be issues in `init-sync` fetcher tests. The issue proved to be not in tests, but in how intersection was implemented: it modified passed in argument (the first slice), which was unexpected. While debugging the issue, I came up with this alternative implementation.
- This PR uses different implementation (still the one based on map - so efficiency is the same), which doesn't require modification of function argument. Also, I believe that proposed implementation is easier to reason about and more generic (so, should we want to use reflection - the very same code can be used for `int64/uint64` and `[]byte` - in previous implementation `[]byte` has somewhat different code).
- More test cases has been checked
- **Proposed action:** either cherry-pick from this PR, or merge this one and close the original #6050.