### PR TITLE
Create Empty BlockBody in stateutil.BlockBodyRoot if nil #6094

### DIFF
--- a/beacon-chain/state/stateutil/blocks.go
+++ b/beacon-chain/state/stateutil/blocks.go
@@ -67,7 +67,22 @@ func BlockBodyRoot(body *ethpb.BeaconBlockBody) ([32]byte, error) {
 	if body == nil {
 		// Treat nil body to be the same as empty. This is mostly for test setup purposes and would
 		// be very unlikely to happen in production workflow.
-		return [32]byte{117, 149, 118, 243, 29, 85, 147, 152, 201, 11, 234, 19, 146, 229, 35, 209, 93, 246, 109, 242, 141, 181, 176, 126, 79, 196, 1, 189, 124, 203, 199, 62}, nil
+		emptyRoot := make([]byte, 32)
+		emptyRandao := make([]byte, 96)
+		body = &ethpb.BeaconBlockBody{
+			RandaoReveal: emptyRandao,
+			Eth1Data: &ethpb.Eth1Data{
+				DepositRoot:  emptyRoot,
+				DepositCount: 0,
+				BlockHash:    emptyRoot,
+			},
+			Graffiti:          emptyRoot,
+			ProposerSlashings: make([]*ethpb.ProposerSlashing, 0),
+			AttesterSlashings: make([]*ethpb.AttesterSlashing, 0),
+			Attestations:      make([]*ethpb.Attestation, 0),
+			Deposits:          make([]*ethpb.Deposit, 0),
+			VoluntaryExits:    make([]*ethpb.SignedVoluntaryExit, 0),
+		}
 	}
 	hasher := hashutil.CustomSHA256Hasher()
 	fieldRoots := make([][32]byte, 8)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Discovered a hard-coded block body root if an input is nil in stateutil.BlockBodyRoot. This PR changes that to instead be an empty beacon block body input.