### PR TITLE
Assert gfind is available on OSX, for protobufs updates

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -24,7 +24,7 @@ findutil="find"
 # On OSX `find` is not GNU find compatible, so require "findutils" package.
 if [ "$system" == "darwin" ]; then
     if [[ ! -x "/usr/local/bin/gfind" ]]; then
-        color 31 "Make sure that GNU 'findutils' are installed: brew install findutils"
+        color 31 "Make sure that GNU 'findutils' package is installed: brew install findutils"
         exit 1
     else
         findutil="gfind"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function color() {
+    # Usage: color "31;5" "string"
+    # Some valid values for color:
+    # - 5 blink, 1 strong, 4 underlined
+    # - fg: 31 red,  32 green, 33 yellow, 34 blue, 35 purple, 36 cyan, 37 white
+    # - bg: 40 black, 41 red, 44 blue, 45 purple
+    printf '\033[%sm%s\033[0m\n' "$@"
+}
+
+system=""
+case "$OSTYPE" in
+darwin*) system="darwin" ;;
+linux*) system="linux" ;;
+msys*) system="windows" ;;
+cygwin*) system="windows" ;;
+*) exit 1 ;;
+esac
+readonly system
+
+# Get locations of pb.go and pb.gw.go files.
+findutil="find"
+# On OSX `find` is not GNU find compatible, so require "findutils" package.
+if [ "$system" == "darwin" ]; then
+    if [[ ! -x "/usr/local/bin/gfind" ]]; then
+        color 31 "Make sure that GNU 'findutils' are installed: brew install findutils"
+        exit 1
+    else
+        findutil="gfind"
+    fi
+fi

--- a/scripts/update-go-pbs.sh
+++ b/scripts/update-go-pbs.sh
@@ -1,30 +1,28 @@
 #!/bin/bash
+. $(dirname "$0")/common.sh
 
 # Script to copy pb.go files from bazel build folder to appropriate location.
 # Bazel builds to bazel-bin/... folder, script copies them back to original folder where .proto is.
 
 bazel build //proto/...
 
-# Get locations of pb.go and pb.gw.go files.
-
 file_list=()
-while IFS= read -d $'\0' -r file ; do
+while IFS= read -d $'\0' -r file; do
     file_list=("${file_list[@]}" "$file")
-done < <(find -L $(bazel info bazel-bin)/proto -type f -regextype sed -regex ".*pb\.\(gw\.\)\?go$" -print0)
- 
+done < <($findutil -L $(bazel info bazel-bin)/proto -type f -regextype sed -regex ".*pb\.\(gw\.\)\?go$" -print0)
+
 arraylength=${#file_list[@]}
 searchstring="prysmaticlabs/prysm/"
 
 # Copy pb.go files from bazel-bin to original folder where .proto is.
-
-for (( i=0; i<${arraylength}; i++ ));
-do
-  destination=${file_list[i]#*$searchstring}
-  chmod 755 "$destination"
-  cp -R -L "${file_list[i]}" "$destination"
+for ((i = 0; i < ${arraylength}; i++)); do
+    color "34" $destination
+    destination=${file_list[i]#*$searchstring}
+    chmod 755 "$destination"
+    cp -R -L "${file_list[i]}" "$destination"
 done
 
-# Run goimports on newly generated protos until gogo protobuf's proto-gen-go 
+# Run goimports on newly generated protos until gogo protobuf's proto-gen-go
 # formats imports properly.
 # https://github.com/gogo/protobuf/issues/554
 goimports -w proto/**/*.pb.go

--- a/scripts/update-go-ssz.sh
+++ b/scripts/update-go-ssz.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+. $(dirname "$0")/common.sh
 
 # Script to copy ssz.go files from bazel build folder to appropriate location.
 # Bazel builds to bazel-bin/... folder, script copies them back to original folder where target is.
@@ -6,21 +7,18 @@
 bazel query 'kind(ssz_gen_marshal, //proto/...) union kind(ssz_gen_marshal, //fuzz/...)' | xargs bazel build
 
 # Get locations of proto ssz.go files.
-
 file_list=()
-while IFS= read -d $'\0' -r file ; do
+while IFS= read -d $'\0' -r file; do
     file_list=("${file_list[@]}" "$file")
-done < <(find -L $(bazel info bazel-bin)/ -type f -regextype sed -regex ".*ssz\.go$" -print0)
+done < <($findutil -L $(bazel info bazel-bin)/ -type f -regextype sed -regex ".*ssz\.go$" -print0)
 
 arraylength=${#file_list[@]}
 searchstring="/bin/"
 
 # Copy ssz.go files from bazel-bin to original folder where the target is located.
-
-for (( i=0; i<${arraylength}; i++ ));
-do
-  destination=${file_list[i]#*$searchstring}
-  chmod 755 "$destination"
-  cp -R -L "${file_list[i]}" "$destination"
+for ((i = 0; i < ${arraylength}; i++)); do
+    destination=${file_list[i]#*$searchstring}
+    color "34" $destination
+    chmod 755 "$destination"
+    cp -R -L "${file_list[i]}" "$destination"
 done
-


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
- allows running `./scripts/update-go-ssz.sh` an `./scripts/update-go-pbs.sh` on OSX (where find is not GNU compatible)

**Other notes for review**
- OSX's version of `find` doesn't have `-regexptype` flag, so those scripts weren't working
- OSX has GNU compatible version, installable via `brew install findutils`
- So, if we are on OS, script checks whether `gfind` is available (GNU compatible find):
![image](https://user-images.githubusercontent.com/188194/83687379-567f2d80-a5f4-11ea-860a-6c9a742da9bf.png)
- If `gfind` is avaialble, it is used:
![image](https://user-images.githubusercontent.com/188194/83687435-6dbe1b00-a5f4-11ea-94ea-3cdbdcf4dfbd.png)

