### PR TITLE
Remove Balance Updates With Excessive Locking

### DIFF
--- a/beacon-chain/core/epoch/precompute/reward_penalty.go
+++ b/beacon-chain/core/epoch/precompute/reward_penalty.go
@@ -44,7 +44,6 @@ func ProcessRewardsAndPenaltiesPrecompute(
 		validatorBals[i] = helpers.DecreaseBalanceWithVal(validatorBals[i], attsPenalties[i])
 
 		vp[i].AfterEpochTransitionBalance = validatorBals[i]
-
 	}
 
 	if err := state.SetBalances(validatorBals); err != nil {

--- a/beacon-chain/core/epoch/precompute/reward_penalty_test.go
+++ b/beacon-chain/core/epoch/precompute/reward_penalty_test.go
@@ -390,7 +390,15 @@ func TestFinalityDelay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	d := finalityDelay(state)
+	prevEpoch := uint64(0)
+	finalizedEpoch := uint64(0)
+	// Set values for each test case
+	setVal := func() {
+		prevEpoch = helpers.PrevEpoch(state)
+		finalizedEpoch = state.FinalizedCheckpointEpoch()
+	}
+	setVal()
+	d := finalityDelay(prevEpoch, finalizedEpoch)
 	w := helpers.PrevEpoch(state) - state.FinalizedCheckpointEpoch()
 	if d != w {
 		t.Error("Did not get wanted finality delay")
@@ -399,7 +407,8 @@ func TestFinalityDelay(t *testing.T) {
 	if err := state.SetFinalizedCheckpoint(&ethpb.Checkpoint{Epoch: 4}); err != nil {
 		t.Fatal(err)
 	}
-	d = finalityDelay(state)
+	setVal()
+	d = finalityDelay(prevEpoch, finalizedEpoch)
 	w = helpers.PrevEpoch(state) - state.FinalizedCheckpointEpoch()
 	if d != w {
 		t.Error("Did not get wanted finality delay")
@@ -408,7 +417,8 @@ func TestFinalityDelay(t *testing.T) {
 	if err := state.SetFinalizedCheckpoint(&ethpb.Checkpoint{Epoch: 5}); err != nil {
 		t.Fatal(err)
 	}
-	d = finalityDelay(state)
+	setVal()
+	d = finalityDelay(prevEpoch, finalizedEpoch)
 	w = helpers.PrevEpoch(state) - state.FinalizedCheckpointEpoch()
 	if d != w {
 		t.Error("Did not get wanted finality delay")
@@ -422,21 +432,31 @@ func TestIsInInactivityLeak(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !isInInactivityLeak(state) {
+	prevEpoch := uint64(0)
+	finalizedEpoch := uint64(0)
+	// Set values for each test case
+	setVal := func() {
+		prevEpoch = helpers.PrevEpoch(state)
+		finalizedEpoch = state.FinalizedCheckpointEpoch()
+	}
+	setVal()
+	if !isInInactivityLeak(prevEpoch, finalizedEpoch) {
 		t.Error("Wanted inactivity leak true")
 	}
 
 	if err := state.SetFinalizedCheckpoint(&ethpb.Checkpoint{Epoch: 4}); err != nil {
 		t.Fatal(err)
 	}
-	if !isInInactivityLeak(state) {
+	setVal()
+	if !isInInactivityLeak(prevEpoch, finalizedEpoch) {
 		t.Error("Wanted inactivity leak true")
 	}
 
 	if err := state.SetFinalizedCheckpoint(&ethpb.Checkpoint{Epoch: 5}); err != nil {
 		t.Fatal(err)
 	}
-	if isInInactivityLeak(state) {
+	setVal()
+	if isInInactivityLeak(prevEpoch, finalizedEpoch) {
 		t.Error("Wanted inactivity leak false")
 	}
 }

--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -69,7 +69,21 @@ func IncreaseBalance(state *stateTrie.BeaconState, idx uint64, delta uint64) err
 	if err != nil {
 		return err
 	}
-	return state.UpdateBalancesAtIndex(idx, balAtIdx+delta)
+	return state.UpdateBalancesAtIndex(idx, IncreaseBalanceWithVal(balAtIdx, delta))
+}
+
+// IncreaseBalanceWithVal increases validator with the given 'index' balance by 'delta' in Gwei.
+// This method is flattened version of the spec method, taking in the raw balance and returning
+// the post balance.
+//
+// Spec pseudocode definition:
+//  def increase_balance(state: BeaconState, index: ValidatorIndex, delta: Gwei) -> None:
+//    """
+//    Increase the validator balance at index ``index`` by ``delta``.
+//    """
+//    state.balances[index] += delta
+func IncreaseBalanceWithVal(currBalance uint64, delta uint64) uint64 {
+	return currBalance + delta
 }
 
 // DecreaseBalance decreases validator with the given 'index' balance by 'delta' in Gwei.
@@ -85,8 +99,22 @@ func DecreaseBalance(state *stateTrie.BeaconState, idx uint64, delta uint64) err
 	if err != nil {
 		return err
 	}
-	if delta > balAtIdx {
-		return state.UpdateBalancesAtIndex(idx, 0)
+	return state.UpdateBalancesAtIndex(idx, DecreaseBalanceWithVal(balAtIdx, delta))
+}
+
+// DecreaseBalanceWithVal decreases validator with the given 'index' balance by 'delta' in Gwei.
+// This method is flattened version of the spec method, taking in the raw balance and returning
+// the post balance.
+//
+// Spec pseudocode definition:
+//  def decrease_balance(state: BeaconState, index: ValidatorIndex, delta: Gwei) -> None:
+//    """
+//    Decrease the validator balance at index ``index`` by ``delta``, with underflow protection.
+//    """
+//    state.balances[index] = 0 if delta > state.balances[index] else state.balances[index] - delta
+func DecreaseBalanceWithVal(currBalance uint64, delta uint64) uint64 {
+	if delta > currBalance {
+		return 0
 	}
-	return state.UpdateBalancesAtIndex(idx, balAtIdx-delta)
+	return currBalance - delta
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature improvement

**What does this PR do? Why is it needed?**

This removes excessive locking when updating validator balances. Instead of acquiring the lock for
each validator we only acquire it once. This makes balance updates in epoch transitions much more efficient.
 
**Which issues(s) does this PR fix?**

Fixes #6111

**Other notes for review**

N.A