### PR TITLE
Disable Kademlia Discovery By Default

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/shared/featureconfig"
+
 	"github.com/dgraph-io/ristretto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
@@ -137,7 +139,7 @@ func NewService(cfg *Config) (*Service, error) {
 		return nil, err
 	}
 
-	if len(cfg.KademliaBootStrapAddr) != 0 && !cfg.NoDiscovery {
+	if len(cfg.KademliaBootStrapAddr) != 0 && !cfg.NoDiscovery && featureconfig.Get().EnableKadDHT {
 		dopts := []dhtopts.Option{
 			dhtopts.Datastore(dsync.MutexWrap(ds.NewMapDatastore())),
 			dhtopts.Protocols(
@@ -236,7 +238,7 @@ func (s *Service) Start() {
 		go s.listenForNewNodes()
 	}
 
-	if len(s.cfg.KademliaBootStrapAddr) != 0 && !s.cfg.NoDiscovery {
+	if len(s.cfg.KademliaBootStrapAddr) != 0 && !s.cfg.NoDiscovery && featureconfig.Get().EnableKadDHT {
 		for _, addr := range s.cfg.KademliaBootStrapAddr {
 			peersToWatch = append(peersToWatch, addr)
 			err := startDHTDiscovery(s.host, addr)

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
-
 	"github.com/dgraph-io/ristretto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -30,9 +30,9 @@ var log = logrus.WithField("prefix", "flags")
 // Flags is a struct to represent which features the client will perform on runtime.
 type Flags struct {
 	// Configuration related flags.
-	MinimalConfig bool // MinimalConfig as defined in the spec.
-	SchlesiTestnet                             bool // SchlesiTestnet preconfigured spec.
-	E2EConfig     bool //E2EConfig made specifically for testing, do not use except in E2E.
+	MinimalConfig  bool // MinimalConfig as defined in the spec.
+	SchlesiTestnet bool // SchlesiTestnet preconfigured spec.
+	E2EConfig      bool //E2EConfig made specifically for testing, do not use except in E2E.
 
 	// Feature related flags.
 	WriteSSZStateTransitions                   bool // WriteSSZStateTransitions to tmp directory.
@@ -60,7 +60,7 @@ type Flags struct {
 	SkipRegenHistoricalStates                  bool // SkipRegenHistoricalState skips regenerating historical states from genesis to last finalized. This enables a quick switch over to using new-state-mgmt.
 	EnableInitSyncWeightedRoundRobin           bool // EnableInitSyncWeightedRoundRobin enables weighted round robin fetching optimization in initial syncing.
 	ReduceAttesterStateCopy                    bool // ReduceAttesterStateCopy reduces head state copies for attester rpc.
-
+	EnableKadDHT                               bool // EnableKadDHT stops libp2p's kademlia based discovery from running.
 	// DisableForkChoice disables using LMD-GHOST fork choice to update
 	// the head of the chain based on attestations and instead accepts any valid received block
 	// as the chain head. UNSAFE, use with caution.
@@ -257,6 +257,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.Bool(reduceAttesterStateCopy.Name) {
 		log.Warn("Enabling feature that reduces attester state copy")
 		cfg.ReduceAttesterStateCopy = true
+	}
+	if ctx.Bool(enableKadDht.Name) {
+		log.Warn("Enabling libp2p's kademlia discovery")
+		cfg.EnableKadDHT = true
 	}
 	Init(cfg)
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -18,9 +18,9 @@ var (
 		Usage: "Use minimal config with parameters as defined in the spec.",
 	}
 	schlesiTestnetFlag = &cli.BoolFlag{
-Name:  "schlesi-testnet",
-Usage: "Use the preconfigured Schlesi multi-client testnet spec.",
-}
+		Name:  "schlesi-testnet",
+		Usage: "Use the preconfigured Schlesi multi-client testnet spec.",
+	}
 	e2eConfigFlag = &cli.BoolFlag{
 		Name:  "e2e-config",
 		Usage: "Use the E2E testing config, only for use within end-to-end testing.",
@@ -164,6 +164,10 @@ Usage: "Use the preconfigured Schlesi multi-client testnet spec.",
 	reduceAttesterStateCopy = &cli.BoolFlag{
 		Name:  "reduce-attester-state-copy",
 		Usage: "Reduces the amount of state copies for attester rpc",
+	}
+	enableKadDht = &cli.BoolFlag{
+		Name:  "enable-kad-dht",
+		Usage: "Enables libp2p's kademlia based discovery to start running",
 	}
 )
 
@@ -499,6 +503,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	disableFieldTrie,
 	disableStateRefCopy,
 	reduceAttesterStateCopy,
+	enableKadDht,
 }...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
**What type of PR is this?**

Disables libp2p's Kademlia based discovery instead making only discoveryV5 the default. 

**What does this PR do? Why is it needed?**

This adds a flag to enable kad-dht in `v0.12`, meaning that it will be disabled by default.
 
**Which issues(s) does this PR fix?**

Part of #6076 

**Other notes for review**
