### PR TITLE
Notify users' with warning about using default ETH 1.0 RPC

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -406,6 +406,10 @@ func (b *BeaconNode) registerPOWChainService() error {
 		log.Fatalf("Invalid deposit contract address given: %s", depAddress)
 	}
 
+	if !b.cliCtx.IsSet(flags.HTTPWeb3ProviderFlag.Name) {
+		log.Warn("Using default ETH1 connection provided by Prysmatic Labs. Please consider running your own ETH1 node for better uptime, security, and decentralization of ETH2. Visit https://docs.prylabs.net/setup-eth1 for more information.")
+	}
+
 	cfg := &powchain.Web3ServiceConfig{
 		HTTPEndPoint:    b.cliCtx.String(flags.HTTPWeb3ProviderFlag.Name),
 		DepositContract: common.HexToAddress(depAddress),

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -407,7 +407,7 @@ func (b *BeaconNode) registerPOWChainService() error {
 	}
 
 	if !b.cliCtx.IsSet(flags.HTTPWeb3ProviderFlag.Name) {
-		log.Warn("Using default ETH1 connection provided by Prysmatic Labs. Please consider running your own ETH1 node for better uptime, security, and decentralization of ETH2. Visit https://docs.prylabs.net/setup-eth1 for more information.")
+		log.Warn("Using default ETH1 connection provided by Prysmatic Labs. Please consider running your own ETH1 node for better uptime, security, and decentralization of ETH2. Visit https://docs.prylabs.network/docs/prysm-usage/setup-eth1 for more information.")
 	}
 
 	cfg := &powchain.Web3ServiceConfig{


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Warning of CLI flags

**What does this PR do? Why is it needed?**

Adds a log to warn users about the use of the default ETH 1.0 RPC at `https://goerli.prylabs.net`

**Which issues(s) does this PR fix?**

Fixes #6051 
