### PR TITLE
Update Genesis Delay to v0.12.1

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -245,12 +245,9 @@ func (s *Service) ProcessChainStart(genesisTime uint64, eth1BlockHash [32]byte, 
 }
 
 func (s *Service) createGenesisTime(timeStamp uint64) uint64 {
-	if featureconfig.Get().CustomGenesisDelay == 0 {
-		return timeStamp
-	}
-	timeStampRdDown := timeStamp - timeStamp%featureconfig.Get().CustomGenesisDelay
-	// genesisTime will be set to the first second of the day, two days after it was triggered.
-	return timeStampRdDown + 2*featureconfig.Get().CustomGenesisDelay
+	// adds in the genesis delay to the eth1 block time
+	// on which it was triggered.
+	return timeStamp + featureconfig.Get().CustomGenesisDelay
 }
 
 // processPastLogs processes all the past logs from the deposit contract and

--- a/endtoend/endtoend_test.go
+++ b/endtoend/endtoend_test.go
@@ -45,7 +45,7 @@ func runEndToEndTest(t *testing.T, config *types.E2EConfig) {
 	defer helpers.KillProcesses(t, processIDs)
 
 	// Sleep depending on the count of validators, as generating the genesis state could take some time.
-	time.Sleep(time.Duration(params.BeaconConfig().MinGenesisDelay) * time.Second)
+	time.Sleep(time.Duration(params.BeaconConfig().GenesisDelay) * time.Second)
 	beaconLogFile, err := os.Open(path.Join(e2e.TestParams.LogPath, fmt.Sprintf(e2e.BeaconNodeLogFileName, 0)))
 	if err != nil {
 		t.Fatal(err)

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -151,7 +151,7 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.Bool(devModeFlag.Name) {
 		enableDevModeFlags(ctx)
 	}
-	delay := params.BeaconConfig().MinGenesisDelay
+	delay := params.BeaconConfig().GenesisDelay
 	if ctx.IsSet(customGenesisDelayFlag.Name) {
 		delay = ctx.Uint64(customGenesisDelayFlag.Name)
 		log.Warnf("Starting ETH2 with genesis delay of %d seconds", delay)

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -44,7 +44,7 @@ type BeaconChainConfig struct {
 	ZeroHash                [32]byte // ZeroHash is used to represent a zeroed out 32 byte array.
 
 	// Time parameters constants.
-	MinGenesisDelay                  uint64 `yaml:"MIN_GENESIS_DELAY"`                   // Minimum number of seconds to delay starting the ETH2 genesis. Must be at least 1 second.
+	GenesisDelay                     uint64 `yaml:"GENESIS_DELAY"`                       // Minimum number of seconds to delay starting the ETH2 genesis. Must be at least 1 second.
 	MinAttestationInclusionDelay     uint64 `yaml:"MIN_ATTESTATION_INCLUSION_DELAY"`     // MinAttestationInclusionDelay defines how many slots validator has to wait to include attestation for beacon block.
 	SecondsPerSlot                   uint64 `yaml:"SECONDS_PER_SLOT"`                    // SecondsPerSlot is how many seconds are in a single slot.
 	SlotsPerEpoch                    uint64 `yaml:"SLOTS_PER_EPOCH"`                     // SlotsPerEpoch is the number of slots in an epoch.
@@ -117,7 +117,7 @@ var defaultBeaconConfig = &BeaconChainConfig{
 	FarFutureEpoch:           1<<64 - 1,
 	BaseRewardsPerEpoch:      4,
 	DepositContractTreeDepth: 32,
-	MinGenesisDelay:          86400, // 1 day
+	GenesisDelay:             172800, // 1 day
 
 	// Misc constant.
 	TargetCommitteeSize:            128,
@@ -234,7 +234,7 @@ func SchlesiTestnetConfig() *BeaconChainConfig {
 
 	schlesiTestnet.MinGenesisActiveValidatorCount = 4
 	schlesiTestnet.MinGenesisTime = 1587755000
-	schlesiTestnet.MinGenesisDelay = 3600
+	schlesiTestnet.GenesisDelay = 3600
 
 	return &schlesiTestnet
 }
@@ -251,7 +251,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.ShuffleRoundCount = 10
 	minimalConfig.MinGenesisActiveValidatorCount = 64
 	minimalConfig.MinGenesisTime = 0
-	minimalConfig.MinGenesisDelay = 300 // 5 minutes
+	minimalConfig.GenesisDelay = 300 // 5 minutes
 	minimalConfig.TargetAggregatorsPerCommittee = 3
 
 	// Gwei values
@@ -318,7 +318,7 @@ func E2ETestConfig() *BeaconChainConfig {
 
 	// Misc.
 	e2eConfig.MinGenesisActiveValidatorCount = 256
-	e2eConfig.MinGenesisDelay = 30 // 30 seconds so E2E has enough time to process deposits and get started.
+	e2eConfig.GenesisDelay = 30 // 30 seconds so E2E has enough time to process deposits and get started.
 
 	// Time parameters.
 	e2eConfig.SecondsPerSlot = 8


### PR DESCRIPTION
**What type of PR is this?**

Update to v0.12.1 version of the spec

**What does this PR do? Why is it needed?**

This PR updates our genesis delay values to those of the spec and brings the naming in line of what is expected.

**Which issues(s) does this PR fix?**

Builds on https://github.com/ethereum/eth2.0-specs/pull/1866 

And is part of #6076 

**Other notes for review**
