### PR TITLE
Adds gofmt checker action to GitHub workflow

### DIFF
--- a/.github/actions/gofmt/Dockerfile
+++ b/.github/actions/gofmt/Dockerfile
@@ -1,0 +1,5 @@
+FROM cytopia/gofmt
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/gofmt/action.yml
+++ b/.github/actions/gofmt/action.yml
@@ -1,0 +1,12 @@
+name: 'Gofmt checker'
+description: 'Checks that all project files have been properly formatted.'
+inputs:
+  path:
+    description: 'Path to check'
+    required: true
+    default: './'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.path }}

--- a/.github/actions/gofmt/entrypoint.sh
+++ b/.github/actions/gofmt/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -l
+set -e
+
+cd $GITHUB_WORKSPACE
+
+# Check if any files are not formatted.
+nonformatted="$(gofmt -l $1 2>&1)"
+
+# Return if `go fmt` passes.
+[ -z "$nonformatted" ] && exit 0
+
+# Notify of issues with formatting.
+echo "Following files need to be properly formatted:"
+echo "$nonformatted"
+exit 1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,11 +8,23 @@ on:
 
 jobs:
 
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Gofmt checker
+        id: gofmt
+        uses: ./.github/actions/gofmt
+        with:
+          path: ./
+
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
**What type of PR is this?**

Other/CI Improvement

**What does this PR do? Why is it needed?**
- if your run `gofmt -l ./` on our master now, you will get:
![image](https://user-images.githubusercontent.com/188194/83778136-f9868480-a692-11ea-8e8b-90c94bb63e9f.png)
And we have number of PRs that simply run `gofmt` from time to time. To make sure that `go fmt` is checked before commit can be merged, custom GitHub action has been created.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- Once this PR is merged, the next PR will not be able to pass checks - unless that file above is formatted.
