### PR TITLE
Re-enables multi-failure test case in round robin

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -141,7 +141,7 @@ func (q *blocksQueue) loop() {
 				q.highestExpectedSlot = q.blocksFetcher.bestFinalizedSlot()
 				continue
 			}
-			log.Debug("Highest expected slot reached")
+			log.WithField("slot", q.highestExpectedSlot).Debug("Highest expected slot reached")
 			q.cancel()
 		}
 

--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -117,38 +117,36 @@ func TestRoundRobinSync(t *testing.T) {
 				},
 			},
 		},
-
-		// TODO(3147): Handle multiple failures.
-		//{
-		//	name:               "Multiple peers with multiple failures",
-		//	currentSlot:        320, // 10 epochs
-		//	expectedBlockSlots: makeSequence(1, 320),
-		//	peers: []*peerData{
-		//		{
-		//			blocks:         makeSequence(1, 320),
-		//			finalizedEpoch: 4,
-		//			headSlot:       320,
-		//		},
-		//		{
-		//			blocks:         makeSequence(1, 320),
-		//			finalizedEpoch: 4,
-		//			headSlot:       320,
-		//			failureSlots:   makeSequence(1, 320),
-		//		},
-		//		{
-		//			blocks:         makeSequence(1, 320),
-		//			finalizedEpoch: 4,
-		//			headSlot:       320,
-		//			failureSlots:   makeSequence(1, 320),
-		//		},
-		//		{
-		//			blocks:         makeSequence(1, 320),
-		//			finalizedEpoch: 4,
-		//			headSlot:       320,
-		//			failureSlots:   makeSequence(1, 320),
-		//		},
-		//	},
-		//},
+		{
+			name:               "Multiple peers with multiple failures",
+			currentSlot:        320, // 10 epochs
+			expectedBlockSlots: makeSequence(1, 320),
+			peers: []*peerData{
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 9,
+					headSlot:       320,
+				},
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 9,
+					headSlot:       320,
+					failureSlots:   makeSequence(1, 320),
+				},
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 9,
+					headSlot:       320,
+					failureSlots:   makeSequence(1, 320),
+				},
+				{
+					blocks:         makeSequence(1, 320),
+					finalizedEpoch: 9,
+					headSlot:       320,
+					failureSlots:   makeSequence(1, 320),
+				},
+			},
+		},
 		{
 			name:               "Multiple peers with different finalized epoch",
 			currentSlot:        320, // 10 epochs


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
- There is a commented out test case in init-sync's round robin test file. I suppose there were some issues with multi-failure test case (it was commented out on previous implementation of syncing) - thus it was commented out.
- Our current implementation is capable of processing such multiple bad peers w/o any issues, so the case is re-enabled.

**Which issues(s) does this PR fix?**
N/A

**Other notes for review**
