### PR TITLE
Only build with cgosymbolizer when explicitly requested

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -86,6 +86,7 @@ build:cgo_symbolizer --config=llvm
 build:cgo_symbolizer --copt=-g
 build:cgo_symbolizer --define=USE_CGO_SYMBOLIZER=true
 build:cgo_symbolizer -c dbg
+build:cgo_symbolizer --define=gotags=cgosymbolizer_enabled
 
 # multi-arch cross-compiling toolchain configs:
 -----------------------------------------------

--- a/shared/debug/cgo_symbolizer.go
+++ b/shared/debug/cgo_symbolizer.go
@@ -1,3 +1,5 @@
+// +build cgosymbolizer_enabled
+
 package debug
 
 import (


### PR DESCRIPTION
This fixes Mac OS X builds with "go build". 

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Error on Mac OS X:
```
go test -v ./validator/node/...
# github.com/ianlancetaylor/cgosymbolizer
Undefined symbols for architecture x86_64:
  "_backtrace_initialize", referenced from:
      _fileline_initialize in _x004.o
  "_cgoTraceback", referenced from:
      __cgohack_cgoTraceback in _cgo_main.o
     (maybe you meant: __cgohack_cgoTraceback)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
FAIL    github.com/prysmaticlabs/prysm/validator/node [build failed]
FAIL
```

