### PR TITLE
Unskipping E2E Tests

### DIFF
--- a/endtoend/long_minimal_e2e_test.go
+++ b/endtoend/long_minimal_e2e_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestEndToEnd_Long_MinimalConfig(t *testing.T) {
-	t.Skip("Skipping until eth1 changes in v0.12 can work with e2e")
 	testutil.ResetCache()
 	params.UseE2EConfig()
 

--- a/endtoend/minimal_e2e_test.go
+++ b/endtoend/minimal_e2e_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestEndToEnd_MinimalConfig(t *testing.T) {
-	t.Skip("Skipping until eth1 changes in v0.12 can work with e2e")
 	testutil.ResetCache()
 	params.UseE2EConfig()
 

--- a/endtoend/minimal_slashing_e2e_test.go
+++ b/endtoend/minimal_slashing_e2e_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestEndToEnd_Slashing_MinimalConfig(t *testing.T) {
-	t.Skip("Skipping until eth1 changes in v0.12 can work with e2e")
 	testutil.ResetCache()
 	params.UseE2EConfig()
 


### PR DESCRIPTION
This PR unskips e2e tests as the root cause of their previous failures have been resolved.