### PR TITLE
Verify historical slots per archived point

### DIFF
--- a/beacon-chain/db/kv/BUILD.bazel
+++ b/beacon-chain/db/kv/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "attestations_test.go",
         "backup_test.go",
         "blocks_test.go",
+        "check_historical_test_test.go",
         "checkpoint_test.go",
         "deposit_contract_test.go",
         "encoding_test.go",

--- a/beacon-chain/db/kv/check_historical_test_test.go
+++ b/beacon-chain/db/kv/check_historical_test_test.go
@@ -1,0 +1,33 @@
+package kv
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/params"
+)
+
+func TestVerifySlotsPerArchivePoint(t *testing.T) {
+	db := setupDB(t)
+
+	// This should set default to 2048.
+	if err := db.verifySlotsPerArchivePoint(); err != nil {
+		t.Fatal(err)
+	}
+
+	// This should not fail with default 2048.
+	if err := db.verifySlotsPerArchivePoint(); err != nil {
+		t.Fatal(err)
+	}
+
+	params.SetupTestConfigCleanup(t)
+	config := params.BeaconConfig()
+	config.SlotsPerArchivedPoint = 256
+	params.OverrideBeaconConfig(config)
+
+	// This should fail.
+	msg := "could not update --slots-per-archive-point after it has been set"
+	if err := db.verifySlotsPerArchivePoint(); err == nil || !strings.Contains(err.Error(), msg) {
+		t.Error("Did not get wanted error")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> Feature

**What does this PR do? Why is it needed?**
Lesson learned from #6156
A node should disallow operation to change `--slots-per-archive-point` when the node is already in operation. Meaning if a user has set slots-per-archive-point to 256 to start with. The node should disallow user changing it to 2048 or any value once the node has state in DB`
The consequence of changing --slots-per-archive-point in flight will create inconsistency of archived points mapping, which results in poor UX for the users.

**Which issues(s) does this PR fix?**
Fixes #6158

**Other notes for review**
Verified run time:
```
DEBUG: /private/var/tmp/_bazel_terence/ab2b20e4e89e932d12c8d013e1bb88e2/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:100:9: rbe_ubuntu_clang_gen not using checked in configs as user set attr to 'False'
DEBUG: /private/var/tmp/_bazel_terence/ab2b20e4e89e932d12c8d013e1bb88e2/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:100:9: rbe_ubuntu_gcc_gen not using checked in configs as user set attr to 'False'
DEBUG: /private/var/tmp/_bazel_terence/ab2b20e4e89e932d12c8d013e1bb88e2/external/bazel_toolchains/rules/rbe_repo/checked_in.bzl:125:9: rbe_ubuntu_clang not using checked in configs; Bazel version 3.0.0 was picked/selected but no checked in config was found in map {"2.1.1": ["clang", "gcc"]}
INFO: Analyzed target //beacon-chain:beacon-chain (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //beacon-chain:beacon-chain up-to-date:
  bazel-bin/beacon-chain/darwin_amd64_stripped/beacon-chain
INFO: Elapsed time: 0.182s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Running command line: bazel-bin/beacon-chain/darwin_amd64_stripped/beacon-chain '--datadir=/tmp/topaz2048-1' '--min-sync-peers=1' --grpc-gateway-port 6002 --enable-debug-rpc-endpoints '--web3provider=ws://127.0.0.1:8546/' '--http-web3provider=http://127.0.0.1:8545/' --dev '--monitoring-portINFO: Build completed successfully, 1 total action
2020/06/06 13:28:20 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
[2020-06-06 13:28:20] ERROR flags: web3provider is deprecated and has no effect. Do not use this flag, it will be deleted soon.
[2020-06-06 13:28:20]  WARN flags: Enabling development mode flags
[2020-06-06 13:28:20]  WARN flags: Enabling state management service
[2020-06-06 13:28:20]  WARN flags: Enabling weighted round robin in initial syncing
[2020-06-06 13:28:20]  WARN flags: Enabling feature that reduces attester state copy
[2020-06-06 13:28:20] ERROR main: could not update --slots-per-archive-point after it has been set. Please continue to use 2048, or resync from genesis using 256
```