### PR TITLE
Fixes span naming in rpc/validator

### DIFF
--- a/beacon-chain/rpc/validator/proposer.go
+++ b/beacon-chain/rpc/validator/proposer.go
@@ -38,7 +38,7 @@ const eth1dataTimeout = 2 * time.Second
 // GetBlock is called by a proposer during its assigned slot to request a block to sign
 // by passing in the slot and the signed randao reveal of the slot.
 func (vs *Server) GetBlock(ctx context.Context, req *ethpb.BlockRequest) (*ethpb.BeaconBlock, error) {
-	ctx, span := trace.StartSpan(ctx, "ProposerServer.RequestBlock")
+	ctx, span := trace.StartSpan(ctx, "ProposerServer.GetBlock")
 	defer span.End()
 	span.AddAttributes(trace.Int64Attribute("slot", int64(req.Slot)))
 
@@ -454,7 +454,7 @@ func constructMerkleProof(trie *trieutil.SparseMerkleTrie, index int, deposit *e
 }
 
 func (vs *Server) packAttestations(ctx context.Context, slot uint64) ([]*ethpb.Attestation, error) {
-	ctx, span := trace.StartSpan(ctx, "validatorServer.packAttestations")
+	ctx, span := trace.StartSpan(ctx, "ProposerServer.packAttestations")
 	defer span.End()
 	st, err := vs.HeadFetcher.HeadState(ctx)
 	if err != nil {

--- a/beacon-chain/rpc/validator/status.go
+++ b/beacon-chain/rpc/validator/status.go
@@ -128,7 +128,7 @@ func (vs *Server) validatorStatus(
 	headState *stateTrie.BeaconState,
 	pubKey []byte,
 ) (*ethpb.ValidatorStatusResponse, uint64) {
-	ctx, span := trace.StartSpan(ctx, "validatorServer.validatorStatus")
+	ctx, span := trace.StartSpan(ctx, "ValidatorServer.validatorStatus")
 	defer span.End()
 
 	// Using ^0 as the default value for index, in case the validators index cannot be determined.


### PR DESCRIPTION
**What type of PR is this?**

Other/Minor Fix

**What does this PR do? Why is it needed?**
- Makes span naming consistent

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- When working on optimizations for `GetBlock` I've noticed that in jaeger it is referred as `RequestBlock`, which is inconsistent with how we are naming the rest of spans.
