### PR TITLE
Invert reduce attester state copies

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -217,10 +217,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Disabling state reference copy")
 		cfg.EnableStateRefCopy = false
 	}
-	if ctx.Bool(reduceAttesterStateCopy.Name) {
-		log.Warn("Enabling feature that reduces attester state copy")
-		cfg.ReduceAttesterStateCopy = true
-	}
 	if ctx.IsSet(deprecatedP2PWhitelist.Name) {
 		log.Warnf("--%s is deprecated, please use --%s", deprecatedP2PWhitelist.Name, cmd.P2PAllowList.Name)
 		if err := ctx.Set(cmd.P2PAllowList.Name, ctx.String(deprecatedP2PWhitelist.Name)); err != nil {
@@ -233,7 +229,11 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 			log.WithError(err).Error("Failed to update P2PDenyList flag")
 		}
 	}
-
+	cfg.ReduceAttesterStateCopy = true
+	if ctx.Bool(disableReduceAttesterStateCopy.Name) {
+		log.Warn("Disabling reducing attester state copy")
+		cfg.ReduceAttesterStateCopy = false
+	}
 	Init(cfg)
 }
 

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -157,9 +157,9 @@ var (
 		Name:  "enable-init-sync-wrr",
 		Usage: "Enables weighted round robin fetching optimization",
 	}
-	reduceAttesterStateCopy = &cli.BoolFlag{
-		Name:  "reduce-attester-state-copy",
-		Usage: "Reduces the amount of state copies for attester rpc",
+	disableReduceAttesterStateCopy = &cli.BoolFlag{
+		Name:  "disable-reduce-attester-state-copy",
+		Usage: "Disables the feature to reduce the amount of state copies for attester rpc",
 	}
 )
 
@@ -400,6 +400,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecateReduceAttesterStateCopies = &cli.BoolFlag{
+		Name:   "reduce-attester-state-copy",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -448,6 +453,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecateEnableFieldTrie,
 	deprecatedP2PWhitelist,
 	deprecatedP2PBlacklist,
+	deprecateReduceAttesterStateCopies
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -505,7 +511,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	enableInitSyncWeightedRoundRobin,
 	disableFieldTrie,
 	disableStateRefCopy,
-	reduceAttesterStateCopy,
+	disableReduceAttesterStateCopy,
 }...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.
@@ -515,5 +521,4 @@ var E2EBeaconChainFlags = []string{
 	"--check-head-state",
 	"--enable-new-state-mgmt",
 	"--enable-init-sync-wrr",
-	"--reduce-attester-state-copy",
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -167,7 +167,6 @@ var (
 var devModeFlags = []cli.Flag{
 	enableNewStateMgmt,
 	enableInitSyncWeightedRoundRobin,
-	reduceAttesterStateCopy,
 }
 
 // Deprecated flags list.
@@ -453,7 +452,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecateEnableFieldTrie,
 	deprecatedP2PWhitelist,
 	deprecatedP2PBlacklist,
-	deprecateReduceAttesterStateCopies
+	deprecateReduceAttesterStateCopies,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.


### PR DESCRIPTION
This PR inverts `ReduceAttesterStateCopy` feature flag. This flag has been running great in exp pods for the last 10 days. Exp pods's memories are 500MB less than prod pods