### PR TITLE
Inverts enable-init-sync-wrr flag

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -208,9 +208,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Enabling skipping of historical states regen")
 		cfg.SkipRegenHistoricalStates = true
 	}
-	if ctx.Bool(enableInitSyncWeightedRoundRobin.Name) {
-		log.Warn("Enabling weighted round robin in initial syncing")
-		cfg.EnableInitSyncWeightedRoundRobin = true
+	cfg.EnableInitSyncWeightedRoundRobin = true
+	if ctx.Bool(disableInitSyncWeightedRoundRobin.Name) {
+		log.Warn("Disabling weighted round robin in initial syncing")
+		cfg.EnableInitSyncWeightedRoundRobin = false
 	}
 	cfg.EnableStateRefCopy = true
 	if ctx.Bool(disableStateRefCopy.Name) {

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -153,20 +153,19 @@ var (
 		Name:  "skip-regen-historical-states",
 		Usage: "Skips regeneration and saving of historical states from genesis to last finalized. This enables a quick switch-over to using `--enable-new-state-mgmt`",
 	}
-	enableInitSyncWeightedRoundRobin = &cli.BoolFlag{
-		Name:  "enable-init-sync-wrr",
-		Usage: "Enables weighted round robin fetching optimization",
-	}
 	disableReduceAttesterStateCopy = &cli.BoolFlag{
 		Name:  "disable-reduce-attester-state-copy",
 		Usage: "Disables the feature to reduce the amount of state copies for attester rpc",
+	}
+	disableInitSyncWeightedRoundRobin = &cli.BoolFlag{
+		Name:  "disable-init-sync-wrr",
+		Usage: "Disables weighted round robin fetching optimization",
 	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
 	enableNewStateMgmt,
-	enableInitSyncWeightedRoundRobin,
 }
 
 // Deprecated flags list.
@@ -404,6 +403,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableInitSyncWeightedRoundRobin = &cli.BoolFlag{
+		Name:   "enable-init-sync-wrr",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -453,6 +457,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedP2PWhitelist,
 	deprecatedP2PBlacklist,
 	deprecateReduceAttesterStateCopies,
+	deprecatedEnableInitSyncWeightedRoundRobin,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -507,7 +512,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	disableInitSyncBatchSaveBlocks,
 	waitForSyncedFlag,
 	skipRegenHistoricalStates,
-	enableInitSyncWeightedRoundRobin,
+	disableInitSyncWeightedRoundRobin,
 	disableFieldTrie,
 	disableStateRefCopy,
 	disableReduceAttesterStateCopy,
@@ -519,5 +524,4 @@ var E2EBeaconChainFlags = []string{
 	"--enable-state-gen-sig-verify",
 	"--check-head-state",
 	"--enable-new-state-mgmt",
-	"--enable-init-sync-wrr",
 }


### PR DESCRIPTION
**What type of PR is this?**

Other/Flag Inversion

**What does this PR do? Why is it needed?**
- Enables weighted round robin fetching (when data batch is fetched from a single peer - with fetching priority determined by weighted round robin)
- `enable-init-sync-wrr` -> `disable-init-sync-wrr`

**Which issues(s) does this PR fix?**

Part of #6024

**Other notes for review**
- The `enable-init-sync-wrr` was part of `--dev`, so whenever we used `--dev` the flag was enabled.
