### PR TITLE
Make a simple json-rpc call to ensure we are connected to a real ETH1 node

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -338,6 +338,12 @@ func (s *Service) dialETH1Nodes() (*ethclient.Client, *gethRPC.Client, error) {
 		return nil, nil, err
 	}
 	httpClient := ethclient.NewClient(httpRPCClient)
+
+	// Make a simple call to ensure we are actually connected to a working node.
+	if _, err := httpClient.ChainID(s.ctx); err != nil {
+		return nil, nil, err
+	}
+
 	return httpClient, httpRPCClient, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

If a user specifies an address like "localhost:8545" and nothing is running at that address, they will not receive a "dial" error and may be spammed with error logs. This PR resolves that issue by making a simple check that they are connected to a real node.

**Which issues(s) does this PR fix?**

Outlined above.

**Other notes for review**

Required for v0.12 launch.