### PR TITLE
Add block number to deposit log

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -182,6 +182,7 @@ func (s *Service) ProcessDepositLog(ctx context.Context, depositLog gethTypes.Lo
 	}
 	if validData {
 		log.WithFields(logrus.Fields{
+			"block":           depositLog.BlockNumber,
 			"publicKey":       fmt.Sprintf("%#x", depositData.PublicKey),
 			"merkleTreeIndex": index,
 		}).Debug("Deposit registered from deposit contract")


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Deposits are now processed after they have cleared `ETH1_FOLLOW_DISTANCE`, which makes tracking deposits from log entries significantly more difficult.  This adds a "block" field to the deposit log entry to make this easier.