### PR TITLE
Allows empty string as validator password

### DIFF
--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -212,7 +212,7 @@ func HandleEmptyKeystoreFlags(cliCtx *cli.Context, confirmPassword bool) (string
 		}
 	}
 
-	if passphrase == "" {
+	if passphrase == "" && !cliCtx.IsSet(flags.PasswordFlag.Name) {
 		log.Info("Please enter the password for your private keys")
 		enteredPassphrase, err := cmd.EnterPassword(confirmPassword, cmd.StdInPasswordReader{})
 		if err != nil {

--- a/validator/accounts/account_test.go
+++ b/validator/accounts/account_test.go
@@ -62,26 +62,47 @@ func TestNewValidatorAccount_AccountExists(t *testing.T) {
 }
 
 func TestNewValidatorAccount_CreateValidatorAccount(t *testing.T) {
-	directory := testutil.TempDir() + "/testkeystore"
-	defer func() {
-		if err := os.RemoveAll(directory); err != nil {
-			t.Logf("Could not remove directory: %v", err)
+	t.Run("custom non-existent path", func(t *testing.T) {
+		_, _, err := CreateValidatorAccount("foobar", "foobar")
+		wantErrString := fmt.Sprintf("path %q does not exist", "foobar")
+		if err == nil || err.Error() != wantErrString {
+			t.Errorf("expected error not thrown, want: %v, got: %v", wantErrString, err)
 		}
-	}()
-	_, _, err := CreateValidatorAccount("foobar", "foobar")
-	wantErrString := fmt.Sprintf("path %q does not exist", "foobar")
-	if err == nil || err.Error() != wantErrString {
-		t.Errorf("expected error not thrown, want: %v, got: %v", wantErrString, err)
-	}
+	})
 
-	// Make sure that empty existing directory doesn't trigger any errors.
-	if err := os.Mkdir(directory, 0777); err != nil {
-		t.Fatal(err)
-	}
-	_, _, err = CreateValidatorAccount(directory, "foobar")
-	if err != nil {
-		t.Error(err)
-	}
+	t.Run("empty existing dir", func(t *testing.T) {
+		directory := testutil.TempDir() + "/testkeystore"
+		defer func() {
+			if err := os.RemoveAll(directory); err != nil {
+				t.Logf("Could not remove directory: %v", err)
+			}
+		}()
+
+		// Make sure that empty existing directory doesn't trigger any errors.
+		if err := os.Mkdir(directory, 0777); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := CreateValidatorAccount(directory, "foobar")
+		if err != nil {
+			t.Error(err)
+		}
+	})
+
+	t.Run("empty string as password", func(t *testing.T) {
+		directory := testutil.TempDir() + "/testkeystore"
+		defer func() {
+			if err := os.RemoveAll(directory); err != nil {
+				t.Logf("Could not remove directory: %v", err)
+			}
+		}()
+		if err := os.Mkdir(directory, 0777); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := CreateValidatorAccount(directory, "")
+		if err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestHandleEmptyFlags_FlagsSet(t *testing.T) {

--- a/validator/keymanager/direct_keystore.go
+++ b/validator/keymanager/direct_keystore.go
@@ -20,8 +20,8 @@ type Keystore struct {
 }
 
 type keystoreOpts struct {
-	Path       string `json:"path"`
-	Passphrase string `json:"passphrase"`
+	Path       string  `json:"path"`
+	Passphrase *string `json:"passphrase"`
 }
 
 var keystoreOptsHelp = `The keystore key manager generates keys and stores them in a local encrypted store.  The options are:
@@ -55,24 +55,25 @@ func NewKeystore(input string) (KeyManager, string, error) {
 		return nil, keystoreOptsHelp, err
 	}
 	if exists {
-		if opts.Passphrase == "" {
+		if opts.Passphrase == nil {
 			log.Info("Enter your validator account password:")
 			bytePassword, err := terminal.ReadPassword(int(os.Stdin.Fd()))
 			if err != nil {
 				return nil, keystoreOptsHelp, err
 			}
 			text := string(bytePassword)
-			opts.Passphrase = strings.Replace(text, "\n", "", -1)
+			*opts.Passphrase = strings.Replace(text, "\n", "", -1)
 		}
 
-		if err := accounts.VerifyAccountNotExists(opts.Path, opts.Passphrase); err == nil {
+		if err := accounts.VerifyAccountNotExists(opts.Path, *opts.Passphrase); err == nil {
 			log.Info("No account found, creating new validator account...")
 		}
 	} else {
 		return nil, "", errors.New("no validator keys found, please use validator accounts create")
 	}
 
-	keyMap, err := accounts.DecryptKeysFromKeystore(opts.Path, params.BeaconConfig().ValidatorPrivkeyFileName, opts.Passphrase)
+	keyMap, err := accounts.DecryptKeysFromKeystore(
+		opts.Path, params.BeaconConfig().ValidatorPrivkeyFileName, *opts.Passphrase)
 	if err != nil {
 		return nil, keystoreOptsHelp, err
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- Allows to have empty string as password
- Works for both for creating/running validators using `--password ''` option and `--keymanager=keystore --keymanageropts='{"path":"/foo/bar","passphrase":""}'`

**Which issues(s) does this PR fix?**

Fixes #6195

**Other notes for review**
N/A
