### PR TITLE
Add Host Flags for All Servers running in Prysm

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -38,12 +38,6 @@ var (
 		Usage: "Max number of items returned per page in RPC responses for paginated endpoints.",
 		Value: 500,
 	}
-	// MonitoringHostFlag defines the host used to serve prometheus metrics.
-	MonitoringHostFlag = &cli.StringFlag{
-		Name:  "monitoring-host",
-		Usage: "Host used for listening and responding metrics for prometheus.",
-		Value: "127.0.0.1",
-	}
 	// MonitoringPortFlag defines the http port used to serve prometheus metrics.
 	MonitoringPortFlag = &cli.Int64Flag{
 		Name:  "monitoring-port",

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -76,7 +76,7 @@ var appFlags = []cli.Flag{
 	cmd.TracingProcessNameFlag,
 	cmd.TracingEndpointFlag,
 	cmd.TraceSampleFractionFlag,
-	flags.MonitoringHostFlag,
+	cmd.MonitoringHostFlag,
 	flags.MonitoringPortFlag,
 	cmd.DisableMonitoringFlag,
 	cmd.ClearDB,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -584,7 +584,7 @@ func (b *BeaconNode) registerPrometheusService() error {
 	additionalHandlers = append(additionalHandlers, prometheus.Handler{Path: "/tree", Handler: c.TreeHandler})
 
 	service := prometheus.NewPrometheusService(
-		fmt.Sprintf("%s:%d", b.cliCtx.String(flags.MonitoringHostFlag.Name), b.cliCtx.Int64(flags.MonitoringPortFlag.Name)),
+		fmt.Sprintf("%s:%d", b.cliCtx.String(cmd.MonitoringHostFlag.Name), b.cliCtx.Int64(flags.MonitoringPortFlag.Name)),
 		b.services,
 		additionalHandlers...,
 	)

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -55,7 +55,7 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.TracingProcessNameFlag,
 			cmd.TracingEndpointFlag,
 			cmd.TraceSampleFractionFlag,
-			flags.MonitoringHostFlag,
+			cmd.MonitoringHostFlag,
 			flags.MonitoringPortFlag,
 			cmd.DisableMonitoringFlag,
 			cmd.MaxGoroutines,

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -41,6 +41,12 @@ var (
 		Usage: "Indicate what fraction of p2p messages are sampled for tracing.",
 		Value: 0.20,
 	}
+	// MonitoringHostFlag defines the host used to serve prometheus metrics.
+	MonitoringHostFlag = &cli.StringFlag{
+		Name:  "monitoring-host",
+		Usage: "Host used for listening and responding metrics for prometheus.",
+		Value: "127.0.0.1",
+	}
 	// DisableMonitoringFlag defines a flag to disable the metrics collection.
 	DisableMonitoringFlag = &cli.BoolFlag{
 		Name:  "disable-monitoring",

--- a/slasher/flags/flags.go
+++ b/slasher/flags/flags.go
@@ -28,12 +28,6 @@ var (
 		Name:  "tls-key",
 		Usage: "Key for secure gRPC. Pass this and the tls-cert flag in order to use gRPC securely.",
 	}
-	// MonitoringHostFlag defines the host used to serve prometheus metrics.
-	MonitoringHostFlag = &cli.StringFlag{
-		Name:  "monitoring-host",
-		Usage: "Host used for listening and responding metrics for prometheus.",
-		Value: "127.0.0.1",
-	}
 	// MonitoringPortFlag defines the http port used to serve prometheus metrics.
 	MonitoringPortFlag = &cli.Int64Flag{
 		Name:  "monitoring-port",

--- a/slasher/main.go
+++ b/slasher/main.go
@@ -46,7 +46,7 @@ var appFlags = []cli.Flag{
 	cmd.TracingProcessNameFlag,
 	cmd.TracingEndpointFlag,
 	cmd.TraceSampleFractionFlag,
-	flags.MonitoringHostFlag,
+	cmd.MonitoringHostFlag,
 	flags.MonitoringPortFlag,
 	cmd.LogFileName,
 	cmd.LogFormat,

--- a/slasher/node/node.go
+++ b/slasher/node/node.go
@@ -147,7 +147,7 @@ func (s *SlasherNode) Close() {
 
 func (s *SlasherNode) registerPrometheusService() error {
 	service := prometheus.NewPrometheusService(
-		fmt.Sprintf("%s:%d", s.cliCtx.String(flags.MonitoringHostFlag.Name), s.cliCtx.Int64(flags.MonitoringPortFlag.Name)),
+		fmt.Sprintf("%s:%d", s.cliCtx.String(cmd.MonitoringHostFlag.Name), s.cliCtx.Int64(flags.MonitoringPortFlag.Name)),
 		s.services,
 	)
 	logrus.AddHook(prometheus.NewLogrusCollector())

--- a/slasher/usage.go
+++ b/slasher/usage.go
@@ -50,7 +50,7 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.TracingProcessNameFlag,
 			cmd.TracingEndpointFlag,
 			cmd.TraceSampleFractionFlag,
-			flags.MonitoringHostFlag,
+			cmd.MonitoringHostFlag,
 			flags.MonitoringPortFlag,
 			cmd.LogFormat,
 			cmd.LogFileName,

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -75,12 +75,6 @@ var (
 		Name:  "keystore-path",
 		Usage: "Path to the desired keystore directory",
 	}
-	// MonitoringHostFlag defines the host used to serve prometheus metrics.
-	MonitoringHostFlag = &cli.StringFlag{
-		Name:  "monitoring-host",
-		Usage: "Host used for listening and responding metrics for prometheus.",
-		Value: "127.0.0.1",
-	}
 	// MonitoringPortFlag defines the http port used to serve prometheus metrics.
 	MonitoringPortFlag = &cli.Int64Flag{
 		Name:  "monitoring-port",

--- a/validator/main.go
+++ b/validator/main.go
@@ -62,7 +62,7 @@ var appFlags = []cli.Flag{
 	flags.KeyManager,
 	flags.KeyManagerOpts,
 	flags.DisableAccountMetricsFlag,
-	flags.MonitoringHostFlag,
+	cmd.MonitoringHostFlag,
 	flags.MonitoringPortFlag,
 	flags.SlasherRPCProviderFlag,
 	flags.SlasherCertFlag,

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -174,7 +174,7 @@ func (s *ValidatorClient) Close() {
 
 func (s *ValidatorClient) registerPrometheusService() error {
 	service := prometheus.NewPrometheusService(
-		fmt.Sprintf("%s:%d", s.cliCtx.String(flags.MonitoringHostFlag.Name), s.cliCtx.Int64(flags.MonitoringPortFlag.Name)),
+		fmt.Sprintf("%s:%d", s.cliCtx.String(cmd.MonitoringHostFlag.Name), s.cliCtx.Int64(flags.MonitoringPortFlag.Name)),
 		s.services,
 	)
 	logrus.AddHook(prometheus.NewLogrusCollector())

--- a/validator/usage.go
+++ b/validator/usage.go
@@ -52,7 +52,7 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.TracingProcessNameFlag,
 			cmd.TracingEndpointFlag,
 			cmd.TraceSampleFractionFlag,
-			flags.MonitoringHostFlag,
+			cmd.MonitoringHostFlag,
 			flags.MonitoringPortFlag,
 			cmd.LogFormat,
 			cmd.LogFileName,


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix and Feature Improvement

**What does this PR do? Why is it needed?**

- [x] Adds gateway host flag
- [x] Adds monitoring host flag for prometheus for 
all binaries
- [x] Adds another gateway host flag for our grpc gateway binary.
- [x] Fixes prometheus server to run on configurable host.

**Which issues(s) does this PR fix?**

Fixes #6196 and supersedes #6197 

**Other notes for review**
