### PR TITLE
Add the latest git tag as part of the version string

### DIFF
--- a/scripts/workspace_status.sh
+++ b/scripts/workspace_status.sh
@@ -3,3 +3,4 @@
 echo STABLE_GIT_COMMIT $(git rev-parse HEAD)
 echo DATE $(date --rfc-3339=seconds --utc)
 echo DOCKER_TAG $(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short=6 HEAD)
+echo LATEST_GIT_TAG $(git describe --tags $(git rev-list --tags --max-count=1))

--- a/shared/version/BUILD.bazel
+++ b/shared/version/BUILD.bazel
@@ -8,5 +8,6 @@ go_library(
     x_defs = {
         "gitCommit": "{STABLE_GIT_COMMIT}",
         "buildDate": "{DATE}",
+        "gitTag": "{LATEST_GIT_TAG}",
     },
 )

--- a/shared/version/version.go
+++ b/shared/version/version.go
@@ -13,6 +13,7 @@ import (
 // The value of these vars are set through linker options.
 var gitCommit = "Local build"
 var buildDate = "Moments ago"
+var gitTag = "Unknown"
 
 // GetVersion returns the version string of this build.
 func GetVersion() string {
@@ -29,5 +30,5 @@ func GetVersion() string {
 		now := time.Now().Format(time.RFC3339)
 		buildDate = now
 	}
-	return fmt.Sprintf("Prysm/Git commit: %s. Built at: %s", gitCommit, buildDate)
+	return fmt.Sprintf("Prysm/%s/%s. Built at: %s", gitTag, gitCommit, buildDate)
 }


### PR DESCRIPTION
Example:

version=Prysm/v1.0.0-alpha.10/28e61fa40c7d16774b3b1c18d8382c64537bfa84. Built at: 2020-06-11 04:29:18+00:00

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This is helpful for understand what the latest git version tag the Prysm client is running.

**Which issues(s) does this PR fix?**

**Other notes for review**
