### PR TITLE
Revert "Send blocks that fails validation to slasher"

### DIFF
--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state/interop"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 )
 
 func (r *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) error {
@@ -32,16 +31,15 @@ func (r *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 	if err != nil {
 		return err
 	}
-	if !featureconfig.Get().SlasherP2P {
-		// Broadcast the block on a feed to notify other services in the beacon node
-		// of a received block (even if it does not process correctly through a state transition).
-		r.blockNotifier.BlockFeed().Send(&feed.Event{
-			Type: blockfeed.ReceivedBlock,
-			Data: &blockfeed.ReceivedBlockData{
-				SignedBlock: signed,
-			},
-		})
-	}
+
+	// Broadcast the block on a feed to notify other services in the beacon node
+	// of a received block (even if it does not process correctly through a state transition).
+	r.blockNotifier.BlockFeed().Send(&feed.Event{
+		Type: blockfeed.ReceivedBlock,
+		Data: &blockfeed.ReceivedBlockData{
+			SignedBlock: signed,
+		},
+	})
 
 	if err := r.chain.ReceiveBlockNoPubsub(ctx, signed, root); err != nil {
 		interop.WriteBlockToDisk(signed, true /*failed*/)

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -8,8 +8,6 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
-	blockfeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/block"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -56,13 +54,10 @@ func (r *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 	if blk.Block == nil {
 		return pubsub.ValidationReject
 	}
-	hasSeen := false
+
 	// Verify the block is the first block received for the proposer for the slot.
 	if r.hasSeenBlockIndexSlot(blk.Block.Slot, blk.Block.ProposerIndex) {
-		if !featureconfig.Get().SlasherP2P {
-			return pubsub.ValidationIgnore
-		}
-		hasSeen = true
+		return pubsub.ValidationIgnore
 	}
 
 	blockRoot, err := stateutil.BlockRoot(blk.Block)
@@ -79,27 +74,6 @@ func (r *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 		return pubsub.ValidationIgnore
 	}
 	r.pendingQueueLock.RUnlock()
-
-	// Send block to block stream for slasher detection after minimal validation.
-	if featureconfig.Get().SlasherP2P {
-		state, err := r.chain.HeadState(ctx)
-		if err != nil {
-			return pubsub.ValidationIgnore
-		}
-		if err := blocks.VerifyBlockSignature(state, blk); err != nil {
-			log.WithError(err).WithField("blockSlot", blk.Block.Slot).Warn("Could not verify block signature")
-			return pubsub.ValidationReject
-		}
-		r.blockNotifier.BlockFeed().Send(&feed.Event{
-			Type: blockfeed.ReceivedBlock,
-			Data: &blockfeed.ReceivedBlockData{
-				SignedBlock: blk,
-			},
-		})
-	}
-	if hasSeen {
-		return pubsub.ValidationReject
-	}
 
 	// Add metrics for block arrival time subtracts slot start time.
 	if captureArrivalTimeMetric(uint64(r.chain.GenesisTime().Unix()), blk.Block.Slot) != nil {

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -45,7 +45,6 @@ type Flags struct {
 	ProtectProposer                            bool // ProtectProposer prevents the validator client from signing any proposals that would be considered a slashable offense.
 	ProtectAttester                            bool // ProtectAttester prevents the validator client from signing any attestations that would be considered a slashable offense.
 	SlasherProtection                          bool // SlasherProtection protects validator fron sending over a slashable offense over the network using external slasher.
-	SlasherP2P                                 bool // SlasherP2P use less restrictive p2p validation for beacon nodes that have a connected slasher.
 	DisableStrictAttestationPubsubVerification bool // DisableStrictAttestationPubsubVerification will disabling strict signature verification in pubsub.
 	DisableUpdateHeadPerAttestation            bool // DisableUpdateHeadPerAttestation will disabling update head on per attestation basis.
 	EnableDomainDataCache                      bool // EnableDomainDataCache caches validator calls to DomainData per epoch.
@@ -223,11 +222,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.Bool(enableKadDht.Name) {
 		log.Warn("Enabling libp2p's kademlia discovery")
 		cfg.EnableKadDHT = true
-	}
-	if ctx.Bool(slasherP2P.Name) {
-		log.Warn("Enabled slasher-friendly P2P validation. Please do not use this flag if you are not running a slasher " +
-			"that connects to this beacon node!")
-		cfg.SlasherP2P = true
 	}
 	if ctx.IsSet(deprecatedP2PWhitelist.Name) {
 		log.Warnf("--%s is deprecated, please use --%s", deprecatedP2PWhitelist.Name, cmd.P2PAllowList.Name)

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -165,12 +165,6 @@ var (
 		Name:  "disable-init-sync-wrr",
 		Usage: "Disables weighted round robin fetching optimization",
 	}
-	// SlasherRPCProviderFlag defines a slasher node RPC endpoint.
-	slasherP2P = &cli.BoolFlag{
-		Name: "slasher-p2p",
-		Usage: "Use this flag to reduce block p2p validation in order for the slasher to receive any blocks" +
-			"the beacon node receives. Please only use if there is a slasher connected to this beacon node",
-	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
@@ -537,7 +531,6 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	disableNewStateMgmt,
 	enableKadDht,
 	disableReduceAttesterStateCopy,
-	slasherP2P,
 }...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.
@@ -545,5 +538,4 @@ var E2EBeaconChainFlags = []string{
 	"--cache-filtered-block-tree",
 	"--enable-state-gen-sig-verify",
 	"--check-head-state",
-	"--slasher-p2p",
 }


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#6164

I have a few concerns with 6164
 * This loosens the security of beacon node because it has to serve slasher; it is not a good compromise. This deviates regular beacon node from the spec implementation and there's no issue to follow up with this. There's also no warning message around it. A user could be using this flag without knowing their beacon node could get spammed 

* The correct implementation should be feed: any incoming block to the slasher RPC server before the `hasSeenBlockIndexSlot` check 

We should either implement proper warning message or fix it by using proper event feed instead of feature flag as a work around