### PR TITLE
Prevent Whistleblower Index Bug

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -397,7 +397,7 @@ func ProcessProposerSlashings(
 			return nil, errors.Wrapf(err, "could not verify proposer slashing %d", idx)
 		}
 		beaconState, err = v.SlashValidator(
-			beaconState, slashing.Header_1.Header.ProposerIndex, 0, /* proposer is whistleblower */
+			beaconState, slashing.Header_1.Header.ProposerIndex,
 		)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
@@ -487,7 +487,7 @@ func ProcessAttesterSlashings(
 				return nil, err
 			}
 			if helpers.IsSlashableValidator(val, currentEpoch) {
-				beaconState, err = v.SlashValidator(beaconState, validatorIndex, 0)
+				beaconState, err = v.SlashValidator(beaconState, validatorIndex)
 				if err != nil {
 					return nil, errors.Wrapf(err, "could not slash validator index %d",
 						validatorIndex)

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -115,7 +115,7 @@ func InitiateValidatorExit(state *stateTrie.BeaconState, idx uint64) (*stateTrie
 //    proposer_reward = Gwei(whistleblower_reward // PROPOSER_REWARD_QUOTIENT)
 //    increase_balance(state, proposer_index, proposer_reward)
 //    increase_balance(state, whistleblower_index, whistleblower_reward - proposer_reward)
-func SlashValidator(state *stateTrie.BeaconState, slashedIdx uint64, whistleBlowerIdx uint64) (*stateTrie.BeaconState, error) {
+func SlashValidator(state *stateTrie.BeaconState, slashedIdx uint64) (*stateTrie.BeaconState, error) {
 	state, err := InitiateValidatorExit(state, slashedIdx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
@@ -149,10 +149,8 @@ func SlashValidator(state *stateTrie.BeaconState, slashedIdx uint64, whistleBlow
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get proposer idx")
 	}
-
-	if whistleBlowerIdx == 0 {
-		whistleBlowerIdx = proposerIdx
-	}
+	// In phase 0, the proposer is the whistleblower.
+	whistleBlowerIdx := proposerIdx
 	whistleblowerReward := validator.EffectiveBalance / params.BeaconConfig().WhistleBlowerRewardQuotient
 	proposerReward := whistleblowerReward / params.BeaconConfig().ProposerRewardQuotient
 	err = helpers.IncreaseBalance(state, proposerIdx, proposerReward)

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -75,11 +75,17 @@ func (v *ReadOnlyValidator) WithdrawalCredentials() []byte {
 
 // Slashed returns the read only validator is slashed.
 func (v *ReadOnlyValidator) Slashed() bool {
+	if v == nil || v.validator == nil {
+		return false
+	}
 	return v.validator.Slashed
 }
 
 // CopyValidator returns the copy of the read only validator.
 func (v *ReadOnlyValidator) CopyValidator() *ethpb.Validator {
+	if v == nil || v.validator == nil {
+		return nil
+	}
 	return CopyValidator(v.validator)
 }
 

--- a/beacon-chain/state/getters_test.go
+++ b/beacon-chain/state/getters_test.go
@@ -75,3 +75,13 @@ func TestNilState_NoPanic(t *testing.T) {
 	_ = st.FinalizedCheckpoint()
 	_ = err
 }
+
+func TestReadOnlyValidator_NoPanic(t *testing.T) {
+	v := &ReadOnlyValidator{}
+	if v.Slashed() == true {
+		t.Error("Expected not slashed")
+	}
+	if v.CopyValidator() != nil {
+		t.Error("Expected nil result")
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Resolves a whistleblower index bug, which sets the whistleblower index to proposer index if the input argument is 0 (given 0 is the Go default value). The current behavior can lead to a consensus bug in phase 1, so it's best to get rid of potential for abuse by preventing that use of a default validator index altogether.

**Which issues(s) does this PR fix?**

Fixes #6106
