### PR TITLE
Follow Up to #6225 

### DIFF
--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prysmaticlabs/prysm/shared/roughtime"
-
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/kevinms/leakybucket-go"
 	"github.com/pkg/errors"
@@ -30,6 +28,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
 	"github.com/prysmaticlabs/prysm/shared"
+	"github.com/prysmaticlabs/prysm/shared/roughtime"
 	"github.com/prysmaticlabs/prysm/shared/runutil"
 )
 

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -28,7 +28,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
 	"github.com/prysmaticlabs/prysm/shared"
-	"github.com/prysmaticlabs/prysm/shared/roughtime"
 	"github.com/prysmaticlabs/prysm/shared/runutil"
 )
 
@@ -226,10 +225,7 @@ func (r *Service) registerHandlers() {
 					return
 				}
 				log.WithField("starttime", data.StartTime).Debug("Received state initialized event")
-				if data.StartTime.After(roughtime.Now()) {
-					stateSub.Unsubscribe()
-					time.Sleep(roughtime.Until(data.StartTime))
-				}
+				stateSub.Unsubscribe()
 				r.chainStarted = true
 			}
 		case <-r.ctx.Done():


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix to Bug Fix

**What does this PR do? Why is it needed?**

Follows on from #6225, seeing as we prematurely set the `chainstarted` var throught those changes we revert it and instead just register the handlers when state is initialized.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
