### PR TITLE
Skip proposer duty calculation for slot 0

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -201,6 +201,10 @@ func CommitteeAssignments(
 	startSlot := StartSlot(epoch)
 	proposerIndexToSlots := make(map[uint64][]uint64)
 	for slot := startSlot; slot < startSlot+params.BeaconConfig().SlotsPerEpoch; slot++ {
+		// Skip proposer assignment for genesis slot.
+		if slot == 0 {
+			continue
+		}
 		if err := state.SetSlot(slot); err != nil {
 			return nil, nil, err
 		}

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -212,6 +212,39 @@ func TestCommitteeAssignments_CannotRetrieveFutureEpoch(t *testing.T) {
 	}
 }
 
+func TestCommitteeAssignments_NoProposerForSlot0(t *testing.T) {
+	validators := make([]*ethpb.Validator, 4*params.BeaconConfig().SlotsPerEpoch)
+	for i := 0; i < len(validators); i++ {
+		var activationEpoch uint64
+		if i >= len(validators)/2 {
+			activationEpoch = 3
+		}
+		validators[i] = &ethpb.Validator{
+			ActivationEpoch: activationEpoch,
+			ExitEpoch:       params.BeaconConfig().FarFutureEpoch,
+		}
+	}
+	state, err := beaconstate.InitializeFromProto(&pb.BeaconState{
+		Validators:  validators,
+		Slot:        2 * params.BeaconConfig().SlotsPerEpoch, // epoch 2
+		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, proposerIndexToSlots, err := CommitteeAssignments(state, 0)
+	if err != nil {
+		t.Fatalf("failed to determine CommitteeAssignments: %v", err)
+	}
+	for _, slots := range proposerIndexToSlots {
+		for _, s := range slots {
+			if s == 0 {
+				t.Error("No proposer should be assigned to slot 0")
+			}
+		}
+	}
+}
+
 func TestCommitteeAssignments_CanRetrieve(t *testing.T) {
 	// Initialize test with 256 validators, each slot and each index gets 4 validators.
 	validators := make([]*ethpb.Validator, 4*params.BeaconConfig().SlotsPerEpoch)

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -232,6 +232,7 @@ func TestCommitteeAssignments_NoProposerForSlot0(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ClearCache()
 	_, proposerIndexToSlots, err := CommitteeAssignments(state, 0)
 	if err != nil {
 		t.Fatalf("failed to determine CommitteeAssignments: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
Proposer should not have duty for slot 0. `CommitteeAssignments` will skip 0 for caching proposer index to slot duty.

**Which issues(s) does this PR fix?**

Fixes #6227 

**Other notes for review**
Tested run time
Before
```go
[2020-06-12 07:57:55]  INFO validator: Beacon chain started genesisTime=2020-06-13 22:17:24 -0700 PDT
[2020-06-12 07:57:55]  INFO validator: Validator activated index=539 publicKey=0x81a455477ae5
[2020-06-12 07:57:55]  INFO validator: Proposal schedule pubKey=0x81a455477ae5 slot=0
[2020-06-12 07:57:55]  INFO validator: Attestation schedule attesters=1 pubKeys=[0x81a455477ae5] slot=13
```
After
```go
[2020-06-12 07:57:38]  INFO validator: Beacon chain started genesisTime=2020-06-13 22:17:24 -0700 PDT
[2020-06-12 07:57:38]  INFO validator: Validator activated index=539 publicKey=0x81a455477ae5
[2020-06-12 07:57:38]  INFO validator: Attestation schedule attesters=1 pubKeys=[0x81a455477ae5] slot=13
```
