### PR TITLE
Add dockerhub image endpoints

### DIFF
--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -74,6 +74,8 @@ container_bundle(
     images = {
         "gcr.io/prysmaticlabs/prysm/beacon-chain:latest": ":image",
         "gcr.io/prysmaticlabs/prysm/beacon-chain:{DOCKER_TAG}": ":image",
+        "index.docker.io/prysmaticlabs/prysm-beacon-chain:latest": ":image",
+        "index.docker.io/prysmaticlabs/prysm-beacon-chain:{DOCKER_TAG}": ":image",
     },
     tags = ["manual"],
 )
@@ -89,6 +91,8 @@ container_bundle(
     images = {
         "gcr.io/prysmaticlabs/prysm/beacon-chain:latest-debug": ":image_debug",
         "gcr.io/prysmaticlabs/prysm/beacon-chain:{DOCKER_TAG}-debug": ":image_debug",
+        "index.docker.io/prysmaticlabs/prysm-beacon-chain:latest-debug": ":image_debug",
+        "index.docker.io/prysmaticlabs/prysm-beacon-chain:{DOCKER_TAG}-debug": ":image_debug",
     },
     tags = ["manual"],
 )
@@ -104,6 +108,8 @@ container_bundle(
     images = {
         "gcr.io/prysmaticlabs/prysm/beacon-chain:latest-alpine": ":image_alpine",
         "gcr.io/prysmaticlabs/prysm/beacon-chain:{DOCKER_TAG}-alpine": ":image_alpine",
+        "index.docker.io/prysmaticlabs/prysm-beacon-chain:latest-alpine": ":image_alpine",
+        "index.docker.io/prysmaticlabs/prysm-beacon-chain:{DOCKER_TAG}-alpine": ":image_alpine",
     },
     tags = ["manual"],
 )

--- a/slasher/BUILD.bazel
+++ b/slasher/BUILD.bazel
@@ -74,6 +74,8 @@ container_bundle(
     images = {
         "gcr.io/prysmaticlabs/prysm/slasher:latest": ":image",
         "gcr.io/prysmaticlabs/prysm/slasher:{DOCKER_TAG}": ":image",
+        "index.docker.io/prysmaticlabs/prysm-slasher:latest": ":image",
+        "index.docker.io/prysmaticlabs/prysm-slasher:{DOCKER_TAG}": ":image",
     },
     tags = ["manual"],
 )

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -82,6 +82,8 @@ container_bundle(
     images = {
         "gcr.io/prysmaticlabs/prysm/validator:latest": ":image",
         "gcr.io/prysmaticlabs/prysm/validator:{DOCKER_TAG}": ":image",
+        "index.docker.io/prysmaticlabs/prysm-validator:latest": ":image",
+        "index.docker.io/prysmaticlabs/prysm-validator:{DOCKER_TAG}": ":image",
     },
     tags = ["manual"],
 )
@@ -97,6 +99,8 @@ container_bundle(
     images = {
         "gcr.io/prysmaticlabs/prysm/validator:latest-debug": ":image_debug",
         "gcr.io/prysmaticlabs/prysm/validator:{DOCKER_TAG}-debug": ":image_debug",
+        "index.docker.io/prysmaticlabs/prysm-validator:latest-debug": ":image_debug",
+        "index.docker.io/prysmaticlabs/prysm-validator:{DOCKER_TAG}-debug": ":image_debug",
     },
     tags = ["manual"],
 )
@@ -112,6 +116,8 @@ container_bundle(
     images = {
         "gcr.io/prysmaticlabs/prysm/validator:latest-alpine": ":image_alpine",
         "gcr.io/prysmaticlabs/prysm/validator:{DOCKER_TAG}-alpine": ":image_alpine",
+        "index.docker.io/prysmaticlabs/prysm-validator:latest-alpine": ":image_alpine",
+        "index.docker.io/prysmaticlabs/prysm-validator:{DOCKER_TAG}-alpine": ":image_alpine",
     },
     tags = ["manual"],
 )


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR adds support for pushing images directly to dockerhub.

Initially, we will support the following docker repositories:

- prysmaticlabs/prysm-beacon-chain
- prysmaticlabs/prysm-validator
- prysmaticlabs/prysm-slasher

**Which issues(s) does this PR fix?**

Fixes #3166

**Other notes for review**

CI might not have the credentials to push these images.
I'll work on that after this merges.
