### PR TITLE
Do Not Ignore Max Gateway Size gRPC

### DIFF
--- a/beacon-chain/gateway/gateway.go
+++ b/beacon-chain/gateway/gateway.go
@@ -160,10 +160,9 @@ func (g *Gateway) dial(ctx context.Context, network, addr string) (*grpc.ClientC
 // dialTCP creates a client connection via TCP.
 // "addr" must be a valid TCP address with a port number.
 func (g *Gateway) dialTCP(ctx context.Context, addr string) (*grpc.ClientConn, error) {
-	opts := []grpc.DialOption{grpc.WithInsecure()}
-
-	if g.enableDebugRPCEndpoints {
-		opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(int(g.maxCallRecvMsgSize))))
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(int(g.maxCallRecvMsgSize))),
 	}
 
 	return grpc.DialContext(
@@ -179,5 +178,10 @@ func dialUnix(ctx context.Context, addr string) (*grpc.ClientConn, error) {
 	d := func(addr string, timeout time.Duration) (net.Conn, error) {
 		return net.DialTimeout("unix", addr, timeout)
 	}
-	return grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithDialer(d))
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithDialer(d),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(int(g.maxCallRecvMsgSize))),
+	}
+	return grpc.DialContext(ctx, addr, opts...)
 }

--- a/beacon-chain/gateway/gateway.go
+++ b/beacon-chain/gateway/gateway.go
@@ -151,7 +151,7 @@ func (g *Gateway) dial(ctx context.Context, network, addr string) (*grpc.ClientC
 	case "tcp":
 		return g.dialTCP(ctx, addr)
 	case "unix":
-		return dialUnix(ctx, addr)
+		return g.dialUnix(ctx, addr)
 	default:
 		return nil, fmt.Errorf("unsupported network type %q", network)
 	}
@@ -174,7 +174,7 @@ func (g *Gateway) dialTCP(ctx context.Context, addr string) (*grpc.ClientConn, e
 
 // dialUnix creates a client connection via a unix domain socket.
 // "addr" must be a valid path to the socket.
-func dialUnix(ctx context.Context, addr string) (*grpc.ClientConn, error) {
+func (g *Gateway) dialUnix(ctx context.Context, addr string) (*grpc.ClientConn, error) {
 	d := func(addr string, timeout time.Duration) (net.Conn, error) {
 		return net.DialTimeout("unix", addr, timeout)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

We were ignoring the max grpc message size in the grpc gateway unless the --enable-debug-rpc-endpoints flag was on, which doesn't make sense as they should not depend on each other.

**Which issues(s) does this PR fix?**

Fixes #6068

**Other notes for review**
