### PR TITLE
Add a Log for Newly Connected gRPC Clients in the Beacon Node

### DIFF
--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "@io_opencensus_go//plugin/ocgrpc:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
+        "@org_golang_google_grpc//peer:go_default_library",
         "@org_golang_google_grpc//reflection:go_default_library",
     ],
 )

--- a/go.sum
+++ b/go.sum
@@ -1491,6 +1491,7 @@ gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
+grpc.go4.org v0.0.0-20170609214715-11d0a25b4919 h1:tmXTu+dfa+d9Evp8NpJdgOy6+rt8/x4yG7qPBrtNfLY=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -66,6 +66,9 @@ type Flags struct {
 	// as the chain head. UNSAFE, use with caution.
 	DisableForkChoice bool
 
+	// Logging related toggles.
+	DisableGRPCConnectionLogs bool // Disables logging when a new grpc client has connected.
+
 	// Slasher toggles.
 	DisableBroadcastSlashings bool // DisableBroadcastSlashings disables p2p broadcasting of proposer and attester slashings.
 	EnableHistoricalDetection bool // EnableHistoricalDetection disables historical attestation detection and performs detection on the chain head immediately.
@@ -239,6 +242,9 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.Bool(disableReduceAttesterStateCopy.Name) {
 		log.Warn("Disabling reducing attester state copy")
 		cfg.ReduceAttesterStateCopy = false
+	}
+	if ctx.IsSet(disableGRPCConnectionLogging.Name) {
+		cfg.DisableGRPCConnectionLogs = true
 	}
 	Init(cfg)
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -165,6 +165,10 @@ var (
 		Name:  "disable-init-sync-wrr",
 		Usage: "Disables weighted round robin fetching optimization",
 	}
+	disableGRPCConnectionLogging = &cli.BoolFlag{
+		Name:  "disable-grpc-connection-logging",
+		Usage: "Disables displaying logs for newly connected grpc clients",
+	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
@@ -531,6 +535,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	disableNewStateMgmt,
 	enableKadDht,
 	disableReduceAttesterStateCopy,
+	disableGRPCConnectionLogging,
 }...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR adds the ability to log new grpc client connections to beacon nodes:

```
[2020-06-12 15:04:18]  INFO rpc: New gRPC client connected to beacon node addr=127.0.0.1:59704
```

Helping give feedback to users that their validator client is properly connected. This feature can be disabled with `--disable-grpc-connection-logs`

**Which issues(s) does this PR fix?**

Fixes #5647, which brought up that we log p2p peer connections and disconnections but do not do the same for gRPC client connections (i.e. validator clients).
