### PR TITLE
Don't regen parent state for genesis state

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -454,8 +454,10 @@ func (s *Service) initializeChainInfo(ctx context.Context) error {
 		return errors.Wrap(err, "could not get finalized block from db")
 	}
 
-	if featureconfig.Get().NewStateMgmt && featureconfig.Get().SkipRegenHistoricalStates {
-		// To skip the regeneration of historical state, the node has to generate the parent of the last finalized state.
+	// To skip the regeneration of historical state, the node has to generate the parent of the last finalized state.
+	// We don't need to do this for genesis.
+	atGenesis := s.CurrentSlot() == 0
+	if featureconfig.Get().NewStateMgmt && featureconfig.Get().SkipRegenHistoricalStates && !atGenesis {
 		parentRoot := bytesutil.ToBytes32(finalizedBlock.Block.ParentRoot)
 		parentState, err := s.generateState(ctx, finalizedRoot, parentRoot)
 		if err != nil {


### PR DESCRIPTION
**What does this PR do? Why is it needed?**
If the genesis state is the finalized state or head state. We don't need to regen genesis's parent state. This PR skips regeneration of genesis's parent state.

**Which issues(s) does this PR fix?**

Fixes #6235 

**Other notes for review**
Tested it run time.
```go
➜  prysm git:(dont-regen-genesis-parent-state) bazel run //beacon-chain -- --datadir=/tmp/onyx2048-1 --min-sync-peers=1  --http-web3provider=http://127.0.0.1:8545/ --monitoring-port=8085  -p2p-udp-port 14622 --p2p-tcp-port 14632 --skip-regen-historical-states
2020/06/13 08:54:37 maxprocs: Leaving GOMAXPROCS=12: CPU quota undefined
[2020-06-13 08:54:37]  WARN flags: Enabling skipping of historical states regen
[2020-06-13 08:54:37]  INFO node: Checking DB database-path=/tmp/onyx2048-1/beaconchaindata
[2020-06-13 08:54:38]  INFO node: Starting beacon node version=Prysm/{LATEST_GIT_TAG}/c67ce69ee1920ef09827b90e7b8d1ba84827586d. Built at: 2020-06-13T08:54:37-07:00
[2020-06-13 08:54:38]  INFO gateway: Starting JSON-HTTP API address=127.0.0.1:3500
[2020-06-13 08:54:38] ERROR rpc: Could not listen to port in Start() 127.0.0.1:4000: listen tcp 127.0.0.1:4000: bind: address already in use
[2020-06-13 08:54:38]  INFO rpc: RPC-API listening on port address=127.0.0.1:4000
[2020-06-13 08:54:38]  WARN rpc: You are using an insecure gRPC connection! Provide a certificate and key to connect securely
[2020-06-13 08:54:38]  INFO powchain: Connected to eth1 proof-of-work chain endpoint=http://127.0.0.1:8545/
[2020-06-13 08:54:38]  INFO initial-sync: Chain started within the last epoch - not syncing genesisTime=2020-06-13 22:17:24 -0700 PDT
[2020-06-13 08:54:38]  INFO blockchain: Blockchain data already exists in DB, initializing...
[2020-06-13 08:54:38]  INFO p2p: Started discovery v5 ENR=enr:-LK4QNd-aR4lAiWJvXojK-WcLgPU3AY2Sp1pYMKNibFVc77Ce9jPMoE1z3QcPXvJONQTnJTmJT4huJg411kK3tUXd5IBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCmW0iXAAAAAP__________gmlkgnY0gmlwhMCoAQuJc2VjcDI1NmsxoQIUcj1W65sAPg5SC8rv5t4-dktblgCZMEwooPgPEkHnhIN0Y3CCOSiDdWRwgjke
MsuYsUT3oB8TusUmJ peer=16Uiu2HAkwwVfNBdYZpkYhfUVZijXmgVY9qqMsuYsUT3oB8TusUmJ
[2020-06-13 08:54:40]  INFO p2p: Peer Connected activePeers=6 direction=Outbound multiAddr=/ip4/178.48.161.120/tcp/13000/p2p/16Uiu2HAmQ9ivMakucwWRkpxhHdTdgsnAFyk5CvLqSkVN6cTkMyzA peer=16Uiu2HAmQ9ivMakucwWRkpxhHdTdgsnAFyk5CvLqSkVN6cTkMyzA
```
