### PR TITLE
Fix ancestor to return most recent root in the case of skip slot

### DIFF
--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -45,7 +45,6 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (*sta
 		}
 
 		if helpers.StartSlot(c.Epoch) > baseState.Slot() {
-			baseState = baseState.Copy()
 			baseState, err = state.ProcessSlots(ctx, baseState, helpers.StartSlot(c.Epoch))
 			if err != nil {
 				return nil, errors.Wrapf(err, "could not process slots up to %d", helpers.StartSlot(c.Epoch))
@@ -91,23 +90,22 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (*sta
 	}
 
 	if helpers.StartSlot(c.Epoch) > baseState.Slot() {
-		savedState := baseState.Copy()
-		savedState, err = state.ProcessSlots(ctx, savedState, helpers.StartSlot(c.Epoch))
+		baseState, err = state.ProcessSlots(ctx, baseState, helpers.StartSlot(c.Epoch))
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not process slots up to %d", helpers.StartSlot(c.Epoch))
 		}
 		if err := s.checkpointState.AddCheckpointState(&cache.CheckpointState{
 			Checkpoint: c,
-			State:      savedState.Copy(),
+			State:      baseState,
 		}); err != nil {
 			return nil, errors.Wrap(err, "could not saved checkpoint state to cache")
 		}
-		return savedState, nil
+		return baseState, nil
 	}
 
 	if err := s.checkpointState.AddCheckpointState(&cache.CheckpointState{
 		Checkpoint: c,
-		State:      baseState.Copy(),
+		State:      baseState,
 	}); err != nil {
 		return nil, errors.Wrap(err, "could not saved checkpoint state to cache")
 	}

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -380,15 +380,15 @@ func (s *Service) filterBlockRoots(ctx context.Context, roots [][32]byte) ([][32
 // ancestor returns the block root of an ancestry block from the input block root.
 //
 // Spec pseudocode definition:
-//   def get_ancestor(store: Store, root: Hash, slot: Slot) -> Hash:
+//   def get_ancestor(store: Store, root: Root, slot: Slot) -> Root:
 //    block = store.blocks[root]
 //    if block.slot > slot:
-//      return get_ancestor(store, block.parent_root, slot)
+//        return get_ancestor(store, block.parent_root, slot)
 //    elif block.slot == slot:
-//      return root
+//        return root
 //    else:
-//      # root is older than queried slot, thus a skip slot. Return most recent root prior to slot.
-//      return root
+//        # root is older than queried slot, thus a skip slot. Return most recent root prior to slot
+//        return root
 func (s *Service) ancestor(ctx context.Context, root []byte, slot uint64) ([]byte, error) {
 	ctx, span := trace.StartSpan(ctx, "forkchoice.ancestor")
 	defer span.End()
@@ -412,13 +412,7 @@ func (s *Service) ancestor(ctx context.Context, root []byte, slot uint64) ([]byt
 	}
 	b := signed.Block
 
-	// If we dont have the ancestor in the DB, simply return nil so rest of fork choice
-	// operation can proceed. This is not an error condition.
-	if b == nil || b.Slot < slot {
-		return nil, nil
-	}
-
-	if b.Slot == slot {
+	if b.Slot == slot || b.Slot < slot {
 		return root, nil
 	}
 

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -779,3 +779,57 @@ func TestCurrentSlot_HandlesOverflow(t *testing.T) {
 		t.Fatalf("Expected slot to be 0, got %d", slot)
 	}
 }
+
+func TestAncestor_HandleSkipSlot(t *testing.T) {
+	ctx := context.Background()
+	db := testDB.SetupDB(t)
+
+	cfg := &Config{BeaconDB: db}
+	service, err := NewService(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b1 := &ethpb.BeaconBlock{Slot: 1, ParentRoot: []byte{'a'}}
+	r1, err := ssz.HashTreeRoot(b1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b100 := &ethpb.BeaconBlock{Slot: 100, ParentRoot: r1[:]}
+	r100, err := ssz.HashTreeRoot(b100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b200 := &ethpb.BeaconBlock{Slot: 200, ParentRoot: r100[:]}
+	r200, err := ssz.HashTreeRoot(b200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, b := range []*ethpb.BeaconBlock{b1, b100, b200} {
+		beaconBlock := testutil.NewBeaconBlock()
+		beaconBlock.Block.Slot = b.Slot
+		beaconBlock.Block.ParentRoot = bytesutil.PadTo(b.ParentRoot, 32)
+		beaconBlock.Block.Body = &ethpb.BeaconBlockBody{}
+		if err := db.SaveBlock(context.Background(), beaconBlock); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Slots 100 to 200 are skip slots. Requesting root at 150 will yield root at 100. The last physical block.
+	r, err := service.ancestor(context.Background(), r200[:], 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytesutil.ToBytes32(r) != r100 {
+		t.Error("Did not get correct root")
+	}
+
+	// Slots 1 to 100 are skip slots. Requesting root at 50 will yield root at 1. The last physical block.
+	r, err = service.ancestor(context.Background(), r200[:], 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytesutil.ToBytes32(r) != r1 {
+		t.Error("Did not get correct root")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
The `ancestor` function  is old and hasn't been updated in a while. In the event of a skip slot, the `ancestor` function should return most recent root prior to slot. Instead, it was returning nil.

**Other notes for review**
Tested run time to and verified it fixed `FFG and LMD votes are not consistent` issue