### PR TITLE
Fix Discovery Panic

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -52,6 +52,7 @@ def prysm_deps():
         name = "com_github_prysmaticlabs_bazel_go_ethereum",
         build_file_generation = "off",
         importpath = "github.com/prysmaticlabs/bazel-go-ethereum",
+        replace = "github.com/ethereum/go-ethereum",
         sum = "h1:BgFL+G37WhgPOvkQveBXevApdusxtkrRoTzN9O3jnDM=",
         version = "v0.0.0-20200615030327-5f59060ced70",
     )

--- a/deps.bzl
+++ b/deps.bzl
@@ -52,16 +52,15 @@ def prysm_deps():
         name = "com_github_prysmaticlabs_bazel_go_ethereum",
         build_file_generation = "off",
         importpath = "github.com/prysmaticlabs/bazel-go-ethereum",
-        replace = "github.com/ethereum/go-ethereum",
-        sum = "h1:X44ghT3epjsrDWm1PRZ/aaQQcrl4y6/jtuge1sD32HY=",
-        version = "v0.0.0-20200421124922-0beb54b2147b",
+        sum = "h1:BgFL+G37WhgPOvkQveBXevApdusxtkrRoTzN9O3jnDM=",
+        version = "v0.0.0-20200615030327-5f59060ced70",
     )
 
     # Note: It is required to define com_github_ethereum_go_ethereum like this for some reason...
     # Note: The keep directives help gazelle leave this alone.
     go_repository(
         name = "com_github_ethereum_go_ethereum",
-        commit = "df74fa9e96217d0fffbe4f25788dd270b25243ed",  # keep
+        commit = "5f59060ced70d1107fd3df26bf248c95af388738",  # keep
         importpath = "github.com/ethereum/go-ethereum",  # keep
         # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
         # a fork that has resolved these issues by disabling HID/USB support and

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,6 @@ require (
 	github.com/libp2p/go-libp2p v0.9.2
 	github.com/libp2p/go-libp2p-blankhost v0.1.6
 	github.com/libp2p/go-libp2p-circuit v0.2.3
-	github.com/libp2p/go-libp2p-connmgr v0.2.3
 	github.com/libp2p/go-libp2p-core v0.5.6
 	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-host v0.1.0
@@ -72,6 +71,7 @@ require (
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/multiformats/go-multiaddr v0.2.2
+	github.com/multiformats/go-multiaddr-net v0.1.5
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/paulbellamy/ratecounter v0.2.0
@@ -118,6 +118,6 @@ require (
 	k8s.io/utils v0.0.0-20200520001619-278ece378a50 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20200530091827-df74fa9e9621
+replace github.com/ethereum/go-ethereum => github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20200615030327-5f59060ced70
 
 replace github.com/json-iterator/go => github.com/prestonvanloon/go v1.1.7-0.20190722034630-4f2e55fcf87b


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Updates our go-ethereum fork to handle the discoveryV5 panic.

**Which issues(s) does this PR fix?**

Fixes #6255 

**Other notes for review**
