### PR TITLE
Handle Unsynced ETH1 Node

### DIFF
--- a/beacon-chain/powchain/block_reader.go
+++ b/beacon-chain/powchain/block_reader.go
@@ -23,7 +23,7 @@ func (s *Service) BlockExists(ctx context.Context, hash common.Hash) (bool, *big
 		return true, blkInfo.Number, nil
 	}
 	span.AddAttributes(trace.BoolAttribute("blockCacheHit", false))
-	block, err := s.blockFetcher.BlockByHash(ctx, hash)
+	block, err := s.eth1DataFetcher.BlockByHash(ctx, hash)
 	if err != nil {
 		return false, big.NewInt(0), errors.Wrap(err, "could not query block with given hash")
 	}
@@ -48,7 +48,7 @@ func (s *Service) BlockHashByHeight(ctx context.Context, height *big.Int) (commo
 		return blkInfo.Hash, nil
 	}
 	span.AddAttributes(trace.BoolAttribute("blockCacheHit", false))
-	block, err := s.blockFetcher.BlockByNumber(ctx, height)
+	block, err := s.eth1DataFetcher.BlockByNumber(ctx, height)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, fmt.Sprintf("could not query block with height %d", height.Uint64()))
 	}
@@ -62,7 +62,7 @@ func (s *Service) BlockHashByHeight(ctx context.Context, height *big.Int) (commo
 func (s *Service) BlockTimeByHeight(ctx context.Context, height *big.Int) (uint64, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.web3service.BlockTimeByHeight")
 	defer span.End()
-	block, err := s.blockFetcher.BlockByNumber(ctx, height)
+	block, err := s.eth1DataFetcher.BlockByNumber(ctx, height)
 	if err != nil {
 		return 0, errors.Wrap(err, fmt.Sprintf("could not query block with height %d", height.Uint64()))
 	}
@@ -77,7 +77,7 @@ func (s *Service) BlockNumberByTimestamp(ctx context.Context, time uint64) (*big
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.web3service.BlockByTimestamp")
 	defer span.End()
 
-	head, err := s.blockFetcher.BlockByNumber(ctx, nil)
+	head, err := s.eth1DataFetcher.BlockByNumber(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (s *Service) BlockNumberByTimestamp(ctx context.Context, time uint64) (*big
 		}
 
 		if !exists {
-			blk, err := s.blockFetcher.BlockByNumber(ctx, bn)
+			blk, err := s.eth1DataFetcher.BlockByNumber(ctx, bn)
 			if err != nil {
 				return nil, err
 			}

--- a/beacon-chain/powchain/block_reader_test.go
+++ b/beacon-chain/powchain/block_reader_test.go
@@ -19,7 +19,7 @@ import (
 var endpoint = "http://127.0.0.1"
 
 func setDefaultMocks(service *Service) *Service {
-	service.blockFetcher = &goodFetcher{}
+	service.eth1DataFetcher = &goodFetcher{}
 	service.httpLogger = &goodLogger{}
 	service.stateNotifier = &goodNotifier{}
 	return service
@@ -41,7 +41,7 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 	}
 	web3Service = setDefaultMocks(web3Service)
 	web3Service.rpcClient = &mockPOW.RPCClient{Backend: testAcc.Backend}
-	web3Service.blockFetcher = &goodFetcher{backend: testAcc.Backend}
+	web3Service.eth1DataFetcher = &goodFetcher{backend: testAcc.Backend}
 
 	web3Service.depositContractCaller, err = contracts.NewDepositContractCaller(testAcc.ContractAddr, testAcc.Backend)
 	if err != nil {
@@ -56,7 +56,7 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 		<-exitRoutine
 	}()
 
-	header, err := web3Service.blockFetcher.HeaderByNumber(web3Service.ctx, nil)
+	header, err := web3Service.eth1DataFetcher.HeaderByNumber(web3Service.ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,8 +203,8 @@ func TestBlockExists_UsesCachedBlockInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to setup web3 ETH1.0 chain service: %v", err)
 	}
-	// nil blockFetcher would panic if cached value not used
-	web3Service.blockFetcher = nil
+	// nil eth1DataFetcher would panic if cached value not used
+	web3Service.eth1DataFetcher = nil
 
 	block := gethTypes.NewBlock(
 		&gethTypes.Header{

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -488,7 +488,7 @@ func TestProcessETH2GenesisLog_CorrectNumOfDeposits(t *testing.T) {
 	}
 	web3Service.rpcClient = &mockPOW.RPCClient{Backend: testAcc.Backend}
 	web3Service.httpLogger = testAcc.Backend
-	web3Service.blockFetcher = &goodFetcher{backend: testAcc.Backend}
+	web3Service.eth1DataFetcher = &goodFetcher{backend: testAcc.Backend}
 	web3Service.latestEth1Data.LastRequestedBlock = 0
 	web3Service.latestEth1Data.BlockHeight = testAcc.Backend.Blockchain().CurrentBlock().NumberU64()
 	web3Service.latestEth1Data.BlockTime = testAcc.Backend.Blockchain().CurrentBlock().Time()
@@ -780,7 +780,7 @@ func newPowchainService(t *testing.T, eth1Backend *contracts.TestAccount, beacon
 	}
 
 	web3Service.rpcClient = &mockPOW.RPCClient{Backend: eth1Backend.Backend}
-	web3Service.blockFetcher = &goodFetcher{backend: eth1Backend.Backend}
+	web3Service.eth1DataFetcher = &goodFetcher{backend: eth1Backend.Backend}
 	web3Service.httpLogger = &goodLogger{backend: eth1Backend.Backend}
 	params.SetupTestConfigCleanup(t)
 	bConfig := params.MinimalSpecConfig()


### PR DESCRIPTION
**What type of PR is this?**

Feature Improvement

**What does this PR do? Why is it needed?**

We handle unsynced eth1 nodes, and do not ask data from them until they are fully synced. We also introduce backoffs before redialing an eth1 node so as to not overwhelm them.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
