### PR TITLE
Default BeaconRPCProvider for Validator Should Match Beacon Node's Host

### DIFF
--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -18,7 +18,7 @@ var (
 	BeaconRPCProviderFlag = &cli.StringFlag{
 		Name:  "beacon-rpc-provider",
 		Usage: "Beacon node RPC provider endpoint",
-		Value: "localhost:4000",
+		Value: "127.0.0.1:4000",
 	}
 	// CertFlag defines a flag for the node's TLS certificate.
 	CertFlag = &cli.StringFlag{
@@ -29,7 +29,7 @@ var (
 	SlasherRPCProviderFlag = &cli.StringFlag{
 		Name:  "slasher-rpc-provider",
 		Usage: "Slasher node RPC provider endpoint",
-		Value: "localhost:4002",
+		Value: "127.0.0.1:4002",
 	}
 	// SlasherCertFlag defines a flag for the slasher node's TLS certificate.
 	SlasherCertFlag = &cli.StringFlag{


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Our beacon node binds its RPC host by default to `127.0.0.1` but our validator tries to connect to `localhost`, which causes some issues in containerized deployments. This PR ensures both match, making validators bind on `127.0.0.1` by default.

**Which issues(s) does this PR fix?**

Fixes #6238 
