### PR TITLE
Fix validator creation path issue on windows

### DIFF
--- a/validator/accounts/account.go
+++ b/validator/accounts/account.go
@@ -215,6 +215,9 @@ func HandleEmptyKeystoreFlags(cliCtx *cli.Context, confirmPassword bool) (string
 		if text = strings.Replace(text, "\n", "", -1); text != "" {
 			path = text
 		}
+		if text = strings.Replace(text, "\r", "", -1); text != "" {
+			path = text
+		}
 	}
 
 	if passphrase == "" {

--- a/validator/main.go
+++ b/validator/main.go
@@ -125,6 +125,7 @@ contract in order to activate the validator client`,
 						keystorePath, passphrase, err := accounts.HandleEmptyKeystoreFlags(cliCtx, true /*confirmPassword*/)
 						if err != nil {
 							log.WithError(err).Error("Could not list keys")
+							return nil
 						}
 						if _, _, err := accounts.CreateValidatorAccount(keystorePath, passphrase); err != nil {
 							log.WithField("err", err.Error()).Fatalf("Could not create validator at path: %s", keystorePath)


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR fixes an issue on windows that when reading from the terminal, the command primpt would inject unsupported line endings, and mess up the path entered, preventing windows users from using the script and bat script properly.

**Which issues(s) does this PR fix?**

Fixes #5456

