### PR TITLE
Verify many block attestations at once

### DIFF
--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -831,22 +831,20 @@ func VerifyAttestations(ctx context.Context, beaconState *stateTrie.BeaconState,
 		}
 		ia := attestationutil.ConvertToIndexed(ctx, a, c)
 		indices := ia.AttestingIndices
-		if len(indices) > 0 {
-			var pk *bls.PublicKey
-			for i := 0; i < len(indices); i++ {
-				pubkeyAtIdx := beaconState.PubkeyAtIndex(indices[i])
-				p, err := bls.PublicKeyFromBytes(pubkeyAtIdx[:])
-				if err != nil {
-					return errors.Wrap(err, "could not deserialize validator public key")
-				}
-				if pk == nil {
-					pk = p
-				} else {
-					pk.Aggregate(p)
-				}
+		var pk *bls.PublicKey
+		for i := 0; i < len(indices); i++ {
+			pubkeyAtIdx := beaconState.PubkeyAtIndex(indices[i])
+			p, err := bls.PublicKeyFromBytes(pubkeyAtIdx[:])
+			if err != nil {
+				return errors.Wrap(err, "could not deserialize validator public key")
 			}
-			pks[i] = pk
+			if pk == nil {
+				pk = p
+			} else {
+				pk.Aggregate(p)
+			}
 		}
+		pks[i] = pk
 
 		root, err := helpers.ComputeSigningRoot(ia.Data, domain)
 		if err != nil {

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -802,7 +802,7 @@ func VerifyAttestation(ctx context.Context, beaconState *stateTrie.BeaconState, 
 
 // VerifyAttestations will verify the signatures of the provided attestations.
 func VerifyAttestations(ctx context.Context, beaconState *stateTrie.BeaconState, atts []*ethpb.Attestation) error {
-	ctx, span := trace.StartSpan(ctx, "VerifyAttestations")
+	ctx, span := trace.StartSpan(ctx, "core.VerifyAttestations")
 	defer span.End()
 	span.AddAttributes(trace.Int64Attribute("attestations", int64(len(atts))))
 

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -800,7 +800,11 @@ func VerifyAttestation(ctx context.Context, beaconState *stateTrie.BeaconState, 
 	return VerifyIndexedAttestation(ctx, beaconState, indexedAtt)
 }
 
-// VerifyAttestations will verify the signatures of the provided attestations.
+// VerifyAttestations will verify the signatures of the provided attestations. This method performs
+// a single BLS verification call to verify the signatures of all of the provided attestations. All
+// of the provided attestations must have valid signatures or this method will return an error.
+// This method does not determine which attestation signature is invalid, only that one or more
+// attestation signatures were not valid.
 func VerifyAttestations(ctx context.Context, beaconState *stateTrie.BeaconState, atts []*ethpb.Attestation) error {
 	ctx, span := trace.StartSpan(ctx, "core.VerifyAttestations")
 	defer span.End()
@@ -810,10 +814,50 @@ func VerifyAttestations(ctx context.Context, beaconState *stateTrie.BeaconState,
 		return nil
 	}
 
-	// TODO(6277): Domain selection will not work for all attestations provided when there is a planned fork.
-	domain, err := helpers.Domain(beaconState.Fork(), helpers.SlotToEpoch(beaconState.Slot()), params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorRoot())
+	fork := beaconState.Fork()
+	gvr := beaconState.GenesisValidatorRoot()
+	dt := params.BeaconConfig().DomainBeaconAttester
+
+	// Split attestations by fork. Note: the domain will differ based on the fork.
+	var preForkAtts []*ethpb.Attestation
+	var postForkAtts []*ethpb.Attestation
+	for _, a := range atts {
+		if helpers.SlotToEpoch(a.Data.Slot) < fork.Epoch {
+			preForkAtts = append(preForkAtts, a)
+		} else {
+			postForkAtts = append(postForkAtts, a)
+		}
+	}
+
+	// Check attestations from before the fork.
+	if fork.Epoch > 0 { // Check to prevent underflow.
+		prevDomain, err := helpers.Domain(fork, fork.Epoch-1, dt, gvr)
+		if err != nil {
+			return err
+		}
+		if err := verifyAttestationsWithDomain(ctx, beaconState, preForkAtts, prevDomain); err != nil {
+			return err
+		}
+	} else if len(preForkAtts) > 0 {
+		// This is a sanity check that preForkAtts were not ignored when fork.Epoch == 0. This
+		// condition is not possible, but it doesn't hurt to check anyway.
+		return errors.New("some attestations were not verified from previous fork before genesis")
+	}
+
+	// Then check attestations from after the fork.
+	currDomain, err := helpers.Domain(fork, fork.Epoch, dt, gvr)
 	if err != nil {
 		return err
+	}
+
+	return verifyAttestationsWithDomain(ctx, beaconState, postForkAtts, currDomain)
+}
+
+// Inner method to verify attestations. This abstraction allows for the domain to be provided as an
+// argument.
+func verifyAttestationsWithDomain(ctx context.Context, beaconState *stateTrie.BeaconState, atts []*ethpb.Attestation, domain []byte) error {
+	if len(atts) == 0 {
+		return nil
 	}
 
 	sigs := make([]*bls.Signature, len(atts))

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -818,7 +818,7 @@ func VerifyAttestations(ctx context.Context, beaconState *stateTrie.BeaconState,
 	gvr := beaconState.GenesisValidatorRoot()
 	dt := params.BeaconConfig().DomainBeaconAttester
 
-	// Split attestations by fork. Note: the domain will differ based on the fork.
+	// Split attestations by fork. Note: the signature domain will differ based on the fork.
 	var preForkAtts []*ethpb.Attestation
 	var postForkAtts []*ethpb.Attestation
 	for _, a := range atts {

--- a/beacon-chain/core/blocks/block_operations.go
+++ b/beacon-chain/core/blocks/block_operations.go
@@ -800,6 +800,7 @@ func VerifyAttestation(ctx context.Context, beaconState *stateTrie.BeaconState, 
 	return VerifyIndexedAttestation(ctx, beaconState, indexedAtt)
 }
 
+// VerifyAttestations will verify the signatures of the provided attestations.
 func VerifyAttestations(ctx context.Context, beaconState *stateTrie.BeaconState, atts []*ethpb.Attestation) error {
 	ctx, span := trace.StartSpan(ctx, "VerifyAttestations")
 	defer span.End()
@@ -809,6 +810,7 @@ func VerifyAttestations(ctx context.Context, beaconState *stateTrie.BeaconState,
 		return nil
 	}
 
+	// TODO(6277): Domain selection will not work for all attestations provided when there is a planned fork.
 	domain, err := helpers.Domain(beaconState.Fork(), helpers.SlotToEpoch(beaconState.Slot()), params.BeaconConfig().DomainBeaconAttester, beaconState.GenesisValidatorRoot())
 	if err != nil {
 		return err

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -2058,3 +2058,13 @@ func TestProcessVoluntaryExits_AppliesCorrectStatus(t *testing.T) {
 			helpers.ActivationExitEpoch(state.Slot()/params.BeaconConfig().SlotsPerEpoch), newRegistry[0].ExitEpoch)
 	}
 }
+
+func TestVerifyAttestations_VerifiesMultipleAttestations(t *testing.T) {
+	// TODO
+	t.Fail()
+}
+
+func TestVerifyAttestations_HandlesPlannedFork(t *testing.T) {
+	// TODO
+	t.Fail()
+}

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -2060,11 +2060,165 @@ func TestProcessVoluntaryExits_AppliesCorrectStatus(t *testing.T) {
 }
 
 func TestVerifyAttestations_VerifiesMultipleAttestations(t *testing.T) {
-	// TODO
-	t.Fail()
+	ctx := context.Background()
+	numOfValidators := 4 * params.BeaconConfig().SlotsPerEpoch
+	validators := make([]*ethpb.Validator, numOfValidators)
+	_, keys, err := testutil.DeterministicDepositsAndKeys(numOfValidators)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < len(validators); i++ {
+		validators[i] = &ethpb.Validator{
+			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+			PublicKey: keys[i].PublicKey().Marshal(),
+		}
+	}
+
+	st, err := stateTrie.InitializeFromProto(&pb.BeaconState{
+		Slot:       5,
+		Validators: validators,
+		Fork: &pb.Fork{
+			Epoch:           0,
+			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+		},
+		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
+	})
+
+	comm1, err := helpers.BeaconCommitteeFromState(st, 1 /*slot*/, 0 /*committeeIndex*/)
+	if err != nil {
+		t.Fatal(err)
+	}
+	att1 := &ethpb.Attestation{
+		AggregationBits: bitfield.NewBitlist(uint64(len(comm1))),
+		Data:            &ethpb.AttestationData{
+			Slot:            1,
+			CommitteeIndex:  0,
+		},
+		Signature:       nil,
+	}
+	domain, err := helpers.Domain(st.Fork(), st.Fork().Epoch, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorRoot())
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := helpers.ComputeSigningRoot(att1.Data, domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sigs []*bls.Signature
+	for i, u := range comm1 {
+		att1.AggregationBits.SetBitAt(uint64(i), true)
+		sigs = append(sigs, keys[u].Sign(root[:]))
+	}
+	att1.Signature = bls.AggregateSignatures(sigs).Marshal()
+
+	comm2, err := helpers.BeaconCommitteeFromState(st, 1 /*slot*/, 1 /*committeeIndex*/)
+	if err != nil {
+		t.Fatal(err)
+	}
+	att2 := &ethpb.Attestation{
+		AggregationBits: bitfield.NewBitlist(uint64(len(comm2))),
+		Data:            &ethpb.AttestationData{
+			Slot:            1,
+			CommitteeIndex:  1,
+		},
+		Signature:       nil,
+	}
+	root, err = helpers.ComputeSigningRoot(att2.Data, domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sigs = nil
+	for i, u := range comm2 {
+		att2.AggregationBits.SetBitAt(uint64(i), true)
+		sigs = append(sigs, keys[u].Sign(root[:]))
+	}
+	att2.Signature = bls.AggregateSignatures(sigs).Marshal()
+
+	if err := blocks.VerifyAttestations(ctx, st, []*ethpb.Attestation{att1, att2}); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestVerifyAttestations_HandlesPlannedFork(t *testing.T) {
-	// TODO
-	t.Fail()
+	// In this test, att1 is from the prior fork and att2 is from the new fork.
+	ctx := context.Background()
+	numOfValidators := 4 * params.BeaconConfig().SlotsPerEpoch
+	validators := make([]*ethpb.Validator, numOfValidators)
+	_, keys, err := testutil.DeterministicDepositsAndKeys(numOfValidators)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < len(validators); i++ {
+		validators[i] = &ethpb.Validator{
+			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+			PublicKey: keys[i].PublicKey().Marshal(),
+		}
+	}
+
+	st, err := stateTrie.InitializeFromProto(&pb.BeaconState{
+		Slot:       35,
+		Validators: validators,
+		Fork: &pb.Fork{
+			Epoch:           1,
+			CurrentVersion:  []byte{0, 1, 2, 3},
+			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+		},
+		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
+	})
+
+	comm1, err := helpers.BeaconCommitteeFromState(st, 1 /*slot*/, 0 /*committeeIndex*/)
+	if err != nil {
+		t.Fatal(err)
+	}
+	att1 := &ethpb.Attestation{
+		AggregationBits: bitfield.NewBitlist(uint64(len(comm1))),
+		Data:            &ethpb.AttestationData{
+			Slot:            1,
+			CommitteeIndex:  0,
+		},
+		Signature:       nil,
+	}
+	prevDomain, err := helpers.Domain(st.Fork(), st.Fork().Epoch-1, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorRoot())
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, err := helpers.ComputeSigningRoot(att1.Data, prevDomain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sigs []*bls.Signature
+	for i, u := range comm1 {
+		att1.AggregationBits.SetBitAt(uint64(i), true)
+		sigs = append(sigs, keys[u].Sign(root[:]))
+	}
+	att1.Signature = bls.AggregateSignatures(sigs).Marshal()
+
+	comm2, err := helpers.BeaconCommitteeFromState(st, 1*params.BeaconConfig().SlotsPerEpoch+1 /*slot*/, 1 /*committeeIndex*/)
+	if err != nil {
+		t.Fatal(err)
+	}
+	att2 := &ethpb.Attestation{
+		AggregationBits: bitfield.NewBitlist(uint64(len(comm2))),
+		Data:            &ethpb.AttestationData{
+			Slot:            1*params.BeaconConfig().SlotsPerEpoch+1,
+			CommitteeIndex:  1,
+		},
+		Signature:       nil,
+	}
+	currDomain, err := helpers.Domain(st.Fork(), st.Fork().Epoch, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorRoot())
+	root, err = helpers.ComputeSigningRoot(att2.Data, currDomain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sigs = nil
+	for i, u := range comm2 {
+		att2.AggregationBits.SetBitAt(uint64(i), true)
+		sigs = append(sigs, keys[u].Sign(root[:]))
+	}
+	att2.Signature = bls.AggregateSignatures(sigs).Marshal()
+
+	if err := blocks.VerifyAttestations(ctx, st, []*ethpb.Attestation{att1, att2}); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/beacon-chain/core/blocks/block_operations_test.go
+++ b/beacon-chain/core/blocks/block_operations_test.go
@@ -2091,11 +2091,11 @@ func TestVerifyAttestations_VerifiesMultipleAttestations(t *testing.T) {
 	}
 	att1 := &ethpb.Attestation{
 		AggregationBits: bitfield.NewBitlist(uint64(len(comm1))),
-		Data:            &ethpb.AttestationData{
-			Slot:            1,
-			CommitteeIndex:  0,
+		Data: &ethpb.AttestationData{
+			Slot:           1,
+			CommitteeIndex: 0,
 		},
-		Signature:       nil,
+		Signature: nil,
 	}
 	domain, err := helpers.Domain(st.Fork(), st.Fork().Epoch, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorRoot())
 	if err != nil {
@@ -2118,11 +2118,11 @@ func TestVerifyAttestations_VerifiesMultipleAttestations(t *testing.T) {
 	}
 	att2 := &ethpb.Attestation{
 		AggregationBits: bitfield.NewBitlist(uint64(len(comm2))),
-		Data:            &ethpb.AttestationData{
-			Slot:            1,
-			CommitteeIndex:  1,
+		Data: &ethpb.AttestationData{
+			Slot:           1,
+			CommitteeIndex: 1,
 		},
-		Signature:       nil,
+		Signature: nil,
 	}
 	root, err = helpers.ComputeSigningRoot(att2.Data, domain)
 	if err != nil {
@@ -2173,11 +2173,11 @@ func TestVerifyAttestations_HandlesPlannedFork(t *testing.T) {
 	}
 	att1 := &ethpb.Attestation{
 		AggregationBits: bitfield.NewBitlist(uint64(len(comm1))),
-		Data:            &ethpb.AttestationData{
-			Slot:            1,
-			CommitteeIndex:  0,
+		Data: &ethpb.AttestationData{
+			Slot:           1,
+			CommitteeIndex: 0,
 		},
-		Signature:       nil,
+		Signature: nil,
 	}
 	prevDomain, err := helpers.Domain(st.Fork(), st.Fork().Epoch-1, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorRoot())
 	if err != nil {
@@ -2200,11 +2200,11 @@ func TestVerifyAttestations_HandlesPlannedFork(t *testing.T) {
 	}
 	att2 := &ethpb.Attestation{
 		AggregationBits: bitfield.NewBitlist(uint64(len(comm2))),
-		Data:            &ethpb.AttestationData{
-			Slot:            1*params.BeaconConfig().SlotsPerEpoch+1,
-			CommitteeIndex:  1,
+		Data: &ethpb.AttestationData{
+			Slot:           1*params.BeaconConfig().SlotsPerEpoch + 1,
+			CommitteeIndex: 1,
 		},
-		Signature:       nil,
+		Signature: nil,
 	}
 	currDomain, err := helpers.Domain(st.Fork(), st.Fork().Epoch, params.BeaconConfig().DomainBeaconAttester, st.GenesisValidatorRoot())
 	root, err = helpers.ComputeSigningRoot(att2.Data, currDomain)

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -464,9 +464,12 @@ func ProcessOperations(
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block attester slashings")
 	}
-	state, err = b.ProcessAttestations(ctx, state, body)
+	state, err = b.ProcessAttestationsNoVerify(ctx, state, body)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block attestations")
+	}
+	if err := b.VerifyAttestations(ctx, state, body.Attestations); err != nil {
+		return nil, errors.Wrap(err, "could not verify attestations")
 	}
 	state, err = b.ProcessDeposits(ctx, state, body)
 	if err != nil {

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -267,6 +267,8 @@ func AggregateSignatures(sigs []*Signature) *Signature {
 //
 // In ETH2.0 specification:
 // def Aggregate(signatures: Sequence[BLSSignature]) -> BLSSignature
+//
+// Deprecated: Use AggregateSignatures.
 func Aggregate(sigs []*Signature) *Signature {
 	return AggregateSignatures(sigs)
 }

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -28,7 +28,7 @@ const DomainByteLength = 4
 var maxKeys = int64(100000)
 var pubkeyCache, _ = ristretto.NewCache(&ristretto.Config{
 	NumCounters: maxKeys,
-	MaxCost:     1 << 19, // 500 kb is cache max size
+	MaxCost:     1 << 22, // ~4mb is cache max size
 	BufferItems: 64,
 })
 

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -208,7 +208,8 @@ func (s *Signature) AggregateVerify(pubKeys []*PublicKey, msgs [][32]byte) bool 
 		msgSlices = append(msgSlices, msgs[i][:]...)
 		rawKeys = append(rawKeys, *pubKeys[i].p)
 	}
-	return s.s.AggregateVerify(rawKeys, msgSlices)
+	// Use "NoCheck" because we do not care if the messages are unique or not.
+	return s.s.AggregateVerifyNoCheck(rawKeys, msgSlices)
 }
 
 // FastAggregateVerify verifies all the provided public keys with their aggregated signature.


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Validating all attestations in a block is rather slow, especially when done individually.
This PR verifies all of the attestation signatures of a block in a single cgo call rather than `n` cgo calls to BLS.

**Which issues(s) does this PR fix?**

Requirement for #5176 

**Other notes for review**

With `--initial-sync-verify-all-signatures`, I was seeing an improvement from around 7bps to around 20bps. 

Also increases the public key cache to 4 megabytes. This greatly reduces the amount of cache misses and public key deserialization required for sync.