### PR TITLE
Add --initial-sync-verify-all-signatures as a dev flag

### DIFF
--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -172,7 +172,9 @@ var (
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
-var devModeFlags = []cli.Flag{}
+var devModeFlags = []cli.Flag{
+	initSyncVerifyEverythingFlag,
+}
 
 // Deprecated flags list.
 const deprecatedUsage = "DEPRECATED. DO NOT USE."
@@ -543,4 +545,5 @@ var E2EBeaconChainFlags = []string{
 	"--cache-filtered-block-tree",
 	"--enable-state-gen-sig-verify",
 	"--check-head-state",
+	"--dev",
 }


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

We want to release `--initial-sync-verify-all-signatures` flag soon so I am adding it to the `--dev` flag group for testing. 

**Which issues(s) does this PR fix?**

Part of #5176

**Other notes for review**

Also adds `--dev` to e2e