### PR TITLE
pre-allocate memory for AggregateVerify

### DIFF
--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -202,8 +202,8 @@ func (s *Signature) AggregateVerify(pubKeys []*PublicKey, msgs [][32]byte) bool 
 	if size != len(msgs) {
 		return false
 	}
-	msgSlices := []byte{}
-	var rawKeys []bls12.PublicKey
+	msgSlices := make([]byte, 0, 32*len(msgs))
+	rawKeys := make([]bls12.PublicKey, 0, len(pubKeys))
 	for i := 0; i < size; i++ {
 		msgSlices = append(msgSlices, msgs[i][:]...)
 		rawKeys = append(rawKeys, *pubKeys[i].p)


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR allocates the correct amount of memory so that the slices created in AggregateVerify have the correct capacity.

**Which issues(s) does this PR fix?**

Helps for #5176

**Other notes for review**

Tested at runtime with negligible improvements to init sync.
