### PR TITLE
Add @prysmaticlabs/core-team as codeowner for deps.bzl

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Automatically require code review from core-team.
 * @prysmaticlabs/core-team
 
-# Anyone on prylabs team can approve dependency updates.
-deps.bzl @prysmaticlabs/core-team
-
 # Starlark code owners
 *.bzl @prestonvanloon
+
+# Anyone on prylabs team can approve dependency updates.
+deps.bzl @prysmaticlabs/core-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
 # Automatically require code review from core-team.
 * @prysmaticlabs/core-team
 
+# Anyone on prylabs team can approve dependency updates.
+deps.bzl @prysmaticlabs/core-team
+
 # Starlark code owners
 *.bzl @prestonvanloon


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This allows any team member to approve deps.bzl changes.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

CODEOWNERS order of precedence is "latest definition wins" so this change must come after the global starlark owners.
