### PR TITLE
Update BLS

### DIFF
--- a/third_party/herumi/herumi.bzl
+++ b/third_party/herumi/herumi.bzl
@@ -11,11 +11,11 @@ def bls_dependencies():
     _maybe(
         http_archive,
         name = "herumi_bls_eth_go_binary",
-        strip_prefix = "bls-eth-go-binary-01d282b5380b0b0a59a880a2a645143807595ff3",
+        strip_prefix = "bls-eth-go-binary-4d3c66ab099d05706ccefcc3c1d1e0f70ff5b2bf",
         urls = [
-            "https://github.com/herumi/bls-eth-go-binary/archive/01d282b5380b0b0a59a880a2a645143807595ff3.tar.gz",
+            "https://github.com/herumi/bls-eth-go-binary/archive/4d3c66ab099d05706ccefcc3c1d1e0f70ff5b2bf.tar.gz",
         ],
-	sha256 = "ec1a474732bd3abdaee86094b9a46362f70667c45a0c88535ac12e5f66221647",
+	sha256 = "584a95d4965aaa95445d8f4816a00be88d3ec2c30052dad331d9f5d4fcad9ffc",
         build_file = "@prysm//third_party/herumi:bls_eth_go_binary.BUILD",
     )
     _maybe(


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Updates our BLS dependency to handle a potentially bad edge case in random key generation.

There have been a few cases in our testnet of users complaining of having pubkeys of 
```
0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```

Looking at how our keys are created, they use this method in herumi's go BLS wrapper.
https://github.com/herumi/bls-eth-go-binary/blob/4d3c66ab099d05706ccefcc3c1d1e0f70ff5b2bf/bls/bls.go#L281

The method in which random keys are generated in mcl is https://github.com/herumi/mcl/blob/master/include/cybozu/random_generator.hpp#L90
which uses `dev/urandom` as its source of randomness. Whereas for windows this would use the 
`CryptGenRandom` API. Both of these should be fine as sources of randomness, however it seems like a couple of user's are running into certain edge cases where they instead get zero-value keys when using the random number generator. These 2 different users generated bad keys.  

Ex: https://www.beaconcha.in/validator/20390#overview , and sent deposits for the bad pubkeys. If you notice both deposits are identical, where both the validating key and withdrawal key are zero. This would indicate that the random number generator isn't working as expected and giving us junk keys.  

We still do not know the root cause of why we are getting zero keys, but the go BLS-wrapper now panics in the event it is invalid, which should prevent new users from creating bad keys for the timebeing. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
