### PR TITLE
Ping handler timeout

### DIFF
--- a/beacon-chain/sync/rpc_ping.go
+++ b/beacon-chain/sync/rpc_ping.go
@@ -13,41 +13,60 @@ import (
 
 // pingHandler reads the incoming ping rpc message from the peer.
 func (r *Service) pingHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
-	defer func() {
-		if err := stream.Close(); err != nil {
-			log.WithError(err).Error("Failed to close stream")
-		}
-	}()
 	setRPCStreamDeadlines(stream)
 
 	m, ok := msg.(*uint64)
 	if !ok {
+		if err := stream.Close(); err != nil {
+			log.WithError(err).Error("Failed to close stream")
+		}
 		return fmt.Errorf("wrong message type for ping, got %T, wanted *uint64", msg)
 	}
 	valid, err := r.validateSequenceNum(*m, stream.Conn().RemotePeer())
 	if err != nil {
+		if err := stream.Close(); err != nil {
+			log.WithError(err).Error("Failed to close stream")
+		}
 		return err
 	}
-	if !valid {
-		// send metadata request in a new routine and stream.
-		go func(peer peer.ID) {
+	if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
+		if err := stream.Close(); err != nil {
+			log.WithError(err).Error("Failed to close stream")
+		}
+		return err
+	}
+	if _, err := r.p2p.Encoding().EncodeWithLength(stream, r.p2p.MetadataSeq()); err != nil {
+		if err := stream.Close(); err != nil {
+			log.WithError(err).Error("Failed to close stream")
+		}
+	}
+
+	if valid {
+		// If the sequence number was valid we're done.
+		if err := stream.Close(); err != nil {
+			log.WithError(err).Error("Failed to close stream")
+		}
+	} else {
+		// send metadata request in a new routine.
+		go func() {
+			defer func() {
+				if err := stream.Close(); err != nil {
+					log.WithError(err).Error("Failed to close stream")
+				}
+			}()
 			// New context so the calling function doesn't cancel on us.
 			ctx, cancel := context.WithTimeout(context.Background(), ttfbTimeout)
 			defer cancel()
-			md, err := r.sendMetaDataRequest(ctx, peer)
+			md, err := r.sendMetaDataRequest(ctx, stream.Conn().RemotePeer())
 			if err != nil {
-				log.WithField("peer", peer).WithError(err).Debug("Failed to send metadata request")
+				log.WithField("peer", stream.Conn().RemotePeer()).WithError(err).Debug("Failed to send metadata request")
 				return
 			}
 			// update metadata if there is no error
-			r.p2p.Peers().SetMetadata(peer, md)
-		}(stream.Conn().RemotePeer())
+			r.p2p.Peers().SetMetadata(stream.Conn().RemotePeer(), md)
+		}()
 	}
-	if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
-		return err
-	}
-	_, err = r.p2p.Encoding().EncodeWithLength(stream, r.p2p.MetadataSeq())
-	return err
+	return nil
 }
 
 func (r *Service) sendPingRequest(ctx context.Context, id peer.ID) error {


### PR DESCRIPTION
When receiving a ping there is a goroutine that can be spawned, however as it stands that goroutine operates on a closed stream with a cancelled context.

This patch alters the ping handler in a few ways.

First, it doesn't `defer` closing the stream but instead explicitly closes it on return conditions.  This ensures that the stream is available to the goroutine.

Second, the goroutine uses a new context (with appropriate timeout) rather than the one passed in to the function (which is cancelled when the calling function returns).

Finally, it removes an unused context that was created.

