### PR TITLE
infostream: unlock mutex on return

### DIFF
--- a/beacon-chain/rpc/beacon/validators_stream.go
+++ b/beacon-chain/rpc/beacon/validators_stream.go
@@ -334,6 +334,7 @@ func (is *infostream) generatePendingValidatorInfo(info *ethpb.ValidatorInfo) (*
 		var ok bool
 		deposit, ok = fetchedDeposit.(*eth1Deposit)
 		if !ok {
+			is.eth1DepositsMutex.Unlock()
 			return nil, errors.New("cached eth1 deposit is not type *eth1Deposit")
 		}
 	} else {
@@ -501,6 +502,7 @@ func (is *infostream) depositQueueTimestamp(eth1BlockNumber *big.Int) (uint64, e
 		var ok bool
 		blockTimestamp, ok = cachedTimestamp.(uint64)
 		if !ok {
+			is.eth1BlocktimesMutex.Unlock()
 			return 0, errors.New("cached timestamp is not type uint64")
 		}
 	} else {


### PR DESCRIPTION
This patch adds a couple of `Unlock()`s for a mutex.  The situations in which these have been added are "should never happen" cast failures, but as the path exists in the code the mutex should be unlocked before returning.