### PR TITLE
Use STABLE_ prefix for git tag to force a relink of version

### DIFF
--- a/scripts/workspace_status.sh
+++ b/scripts/workspace_status.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Note: The STABLE_ prefix will force a relink when the value changes when using rules_go x_defs.
+
 echo STABLE_GIT_COMMIT $(git rev-parse HEAD)
 echo DATE $(date --rfc-3339=seconds --utc)
 echo DOCKER_TAG $(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short=6 HEAD)

--- a/scripts/workspace_status.sh
+++ b/scripts/workspace_status.sh
@@ -3,4 +3,4 @@
 echo STABLE_GIT_COMMIT $(git rev-parse HEAD)
 echo DATE $(date --rfc-3339=seconds --utc)
 echo DOCKER_TAG $(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short=6 HEAD)
-echo LATEST_GIT_TAG $(git describe --tags $(git rev-list --tags --max-count=1))
+echo STABLE_GIT_TAG $(git describe --tags $(git rev-list --tags --max-count=1))

--- a/shared/version/BUILD.bazel
+++ b/shared/version/BUILD.bazel
@@ -8,6 +8,6 @@ go_library(
     x_defs = {
         "gitCommit": "{STABLE_GIT_COMMIT}",
         "buildDate": "{DATE}",
-        "gitTag": "{LATEST_GIT_TAG}",
+        "gitTag": "{STABLE_GIT_TAG}",
     },
 )


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR uses the correct prefix for git tag such that a change in git tag will force a relink of //shared/version:go_default_library.

**Which issues(s) does this PR fix?**

May be related to #6300

**Other notes for review**
