### PR TITLE
Reclaims leakybucket resources in sync service

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -132,8 +132,8 @@ func (f *blocksFetcher) start() error {
 
 // stop terminates all fetcher operations.
 func (f *blocksFetcher) stop() {
+	defer f.rateLimiter.Free()
 	f.cancel()
-	f.rateLimiter.Free()
 	<-f.quit // make sure that loop() is done
 }
 

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -133,6 +133,7 @@ func (f *blocksFetcher) start() error {
 // stop terminates all fetcher operations.
 func (f *blocksFetcher) stop() {
 	f.cancel()
+	f.rateLimiter.Free()
 	<-f.quit // make sure that loop() is done
 }
 

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -132,7 +132,12 @@ func (f *blocksFetcher) start() error {
 
 // stop terminates all fetcher operations.
 func (f *blocksFetcher) stop() {
-	defer f.rateLimiter.Free()
+	defer func() {
+		if f.rateLimiter != nil {
+			f.rateLimiter.Free()
+			f.rateLimiter = nil
+		}
+	}()
 	f.cancel()
 	<-f.quit // make sure that loop() is done
 }

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -160,6 +160,7 @@ func (r *Service) Start() {
 // Stop the regular sync service.
 func (r *Service) Stop() error {
 	defer r.cancel()
+	r.blocksRateLimiter.Free()
 	return nil
 }
 

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -159,8 +159,8 @@ func (r *Service) Start() {
 
 // Stop the regular sync service.
 func (r *Service) Stop() error {
+	defer r.blocksRateLimiter.Free()
 	defer r.cancel()
-	r.blocksRateLimiter.Free()
 	return nil
 }
 

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -159,7 +159,12 @@ func (r *Service) Start() {
 
 // Stop the regular sync service.
 func (r *Service) Stop() error {
-	defer r.blocksRateLimiter.Free()
+	defer func() {
+		if r.blocksRateLimiter != nil {
+			r.blocksRateLimiter.Free()
+			r.blocksRateLimiter = nil
+		}
+	}()
 	defer r.cancel()
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- We are using leakybucket in a way that empty buckets are not automatically deleted (this is intended, as resources are using multiple times - no need to reclaim memory too early).
- However, when service stops, we need to call `Free()` method to reclaim the resources.

**Which issues(s) does this PR fix?**

Part ot #6327

**Other notes for review**
