### PR TITLE
Renames receiver in sync service

### DIFF
--- a/beacon-chain/sync/decode_pubsub.go
+++ b/beacon-chain/sync/decode_pubsub.go
@@ -10,26 +10,26 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 )
 
-func (xx *Service) decodePubsubMessage(msg *pubsub.Message) (proto.Message, error) {
+func (s *Service) decodePubsubMessage(msg *pubsub.Message) (proto.Message, error) {
 	if msg == nil || msg.TopicIDs == nil || len(msg.TopicIDs) == 0 {
 		return nil, errors.New("nil pubsub message")
 	}
 	topic := msg.TopicIDs[0]
-	topic = strings.TrimSuffix(topic, xx.p2p.Encoding().ProtocolSuffix())
-	topic = xx.replaceForkDigest(topic)
+	topic = strings.TrimSuffix(topic, s.p2p.Encoding().ProtocolSuffix())
+	topic = s.replaceForkDigest(topic)
 	base, ok := p2p.GossipTopicMappings[topic]
 	if !ok {
 		return nil, fmt.Errorf("no message mapped for topic %s", topic)
 	}
 	m := proto.Clone(base)
-	if err := xx.p2p.Encoding().DecodeGossip(msg.Data, m); err != nil {
+	if err := s.p2p.Encoding().DecodeGossip(msg.Data, m); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
 // Replaces our fork digest with the formatter.
-func (xx *Service) replaceForkDigest(topic string) string {
+func (s *Service) replaceForkDigest(topic string) string {
 	subStrings := strings.Split(topic, "/")
 	subStrings[2] = "%x"
 	return strings.Join(subStrings, "/")

--- a/beacon-chain/sync/decode_pubsub.go
+++ b/beacon-chain/sync/decode_pubsub.go
@@ -10,26 +10,26 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 )
 
-func (r *Service) decodePubsubMessage(msg *pubsub.Message) (proto.Message, error) {
+func (xx *Service) decodePubsubMessage(msg *pubsub.Message) (proto.Message, error) {
 	if msg == nil || msg.TopicIDs == nil || len(msg.TopicIDs) == 0 {
 		return nil, errors.New("nil pubsub message")
 	}
 	topic := msg.TopicIDs[0]
-	topic = strings.TrimSuffix(topic, r.p2p.Encoding().ProtocolSuffix())
-	topic = r.replaceForkDigest(topic)
+	topic = strings.TrimSuffix(topic, xx.p2p.Encoding().ProtocolSuffix())
+	topic = xx.replaceForkDigest(topic)
 	base, ok := p2p.GossipTopicMappings[topic]
 	if !ok {
 		return nil, fmt.Errorf("no message mapped for topic %s", topic)
 	}
 	m := proto.Clone(base)
-	if err := r.p2p.Encoding().DecodeGossip(msg.Data, m); err != nil {
+	if err := xx.p2p.Encoding().DecodeGossip(msg.Data, m); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
 // Replaces our fork digest with the formatter.
-func (r *Service) replaceForkDigest(topic string) string {
+func (xx *Service) replaceForkDigest(topic string) string {
 	subStrings := strings.Split(topic, "/")
 	subStrings[2] = "%x"
 	return strings.Join(subStrings, "/")

--- a/beacon-chain/sync/error.go
+++ b/beacon-chain/sync/error.go
@@ -22,12 +22,12 @@ var responseCodeSuccess = byte(0x00)
 var responseCodeInvalidRequest = byte(0x01)
 var responseCodeServerError = byte(0x02)
 
-func (xx *Service) generateErrorResponse(code byte, reason string) ([]byte, error) {
+func (s *Service) generateErrorResponse(code byte, reason string) ([]byte, error) {
 	buf := bytes.NewBuffer([]byte{code})
 	resp := &pb.ErrorResponse{
 		Message: []byte(reason),
 	}
-	if _, err := xx.p2p.Encoding().EncodeWithLength(buf, resp); err != nil {
+	if _, err := s.p2p.Encoding().EncodeWithLength(buf, resp); err != nil {
 		return nil, err
 	}
 

--- a/beacon-chain/sync/error.go
+++ b/beacon-chain/sync/error.go
@@ -22,12 +22,12 @@ var responseCodeSuccess = byte(0x00)
 var responseCodeInvalidRequest = byte(0x01)
 var responseCodeServerError = byte(0x02)
 
-func (r *Service) generateErrorResponse(code byte, reason string) ([]byte, error) {
+func (xx *Service) generateErrorResponse(code byte, reason string) ([]byte, error) {
 	buf := bytes.NewBuffer([]byte{code})
 	resp := &pb.ErrorResponse{
 		Message: []byte(reason),
 	}
-	if _, err := r.p2p.Encoding().EncodeWithLength(buf, resp); err != nil {
+	if _, err := xx.p2p.Encoding().EncodeWithLength(buf, resp); err != nil {
 		return nil, err
 	}
 

--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -78,23 +78,23 @@ var (
 	)
 )
 
-func (r *Service) updateMetrics() {
+func (xx *Service) updateMetrics() {
 	// do not update metrics if genesis time
 	// has not been initialized
-	if r.chain.GenesisTime().IsZero() {
+	if xx.chain.GenesisTime().IsZero() {
 		return
 	}
 	// We update the dynamic subnet topics.
-	digest, err := r.forkDigest()
+	digest, err := xx.forkDigest()
 	if err != nil {
 		log.WithError(err).Errorf("Could not compute fork digest")
 	}
-	indices := r.aggregatorSubnetIndices(r.chain.CurrentSlot())
+	indices := xx.aggregatorSubnetIndices(xx.chain.CurrentSlot())
 	attTopic := p2p.GossipTypeMapping[reflect.TypeOf(&pb.Attestation{})]
-	attTopic += r.p2p.Encoding().ProtocolSuffix()
+	attTopic += xx.p2p.Encoding().ProtocolSuffix()
 	for _, committeeIdx := range indices {
 		formattedTopic := fmt.Sprintf(attTopic, digest, committeeIdx)
-		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(r.p2p.PubSub().ListPeers(formattedTopic))))
+		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(xx.p2p.PubSub().ListPeers(formattedTopic))))
 	}
 	// We update all other gossip topics.
 	for topic := range p2p.GossipTopicMappings {
@@ -102,12 +102,12 @@ func (r *Service) updateMetrics() {
 		if strings.Contains(topic, "beacon_attestation") {
 			continue
 		}
-		topic += r.p2p.Encoding().ProtocolSuffix()
+		topic += xx.p2p.Encoding().ProtocolSuffix()
 		if !strings.Contains(topic, "%x") {
-			topicPeerCount.WithLabelValues(topic).Set(float64(len(r.p2p.PubSub().ListPeers(topic))))
+			topicPeerCount.WithLabelValues(topic).Set(float64(len(xx.p2p.PubSub().ListPeers(topic))))
 			continue
 		}
 		formattedTopic := fmt.Sprintf(topic, digest)
-		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(r.p2p.PubSub().ListPeers(formattedTopic))))
+		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(xx.p2p.PubSub().ListPeers(formattedTopic))))
 	}
 }

--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -78,23 +78,23 @@ var (
 	)
 )
 
-func (xx *Service) updateMetrics() {
+func (s *Service) updateMetrics() {
 	// do not update metrics if genesis time
 	// has not been initialized
-	if xx.chain.GenesisTime().IsZero() {
+	if s.chain.GenesisTime().IsZero() {
 		return
 	}
 	// We update the dynamic subnet topics.
-	digest, err := xx.forkDigest()
+	digest, err := s.forkDigest()
 	if err != nil {
 		log.WithError(err).Errorf("Could not compute fork digest")
 	}
-	indices := xx.aggregatorSubnetIndices(xx.chain.CurrentSlot())
+	indices := s.aggregatorSubnetIndices(s.chain.CurrentSlot())
 	attTopic := p2p.GossipTypeMapping[reflect.TypeOf(&pb.Attestation{})]
-	attTopic += xx.p2p.Encoding().ProtocolSuffix()
+	attTopic += s.p2p.Encoding().ProtocolSuffix()
 	for _, committeeIdx := range indices {
 		formattedTopic := fmt.Sprintf(attTopic, digest, committeeIdx)
-		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(xx.p2p.PubSub().ListPeers(formattedTopic))))
+		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.p2p.PubSub().ListPeers(formattedTopic))))
 	}
 	// We update all other gossip topics.
 	for topic := range p2p.GossipTopicMappings {
@@ -102,12 +102,12 @@ func (xx *Service) updateMetrics() {
 		if strings.Contains(topic, "beacon_attestation") {
 			continue
 		}
-		topic += xx.p2p.Encoding().ProtocolSuffix()
+		topic += s.p2p.Encoding().ProtocolSuffix()
 		if !strings.Contains(topic, "%x") {
-			topicPeerCount.WithLabelValues(topic).Set(float64(len(xx.p2p.PubSub().ListPeers(topic))))
+			topicPeerCount.WithLabelValues(topic).Set(float64(len(s.p2p.PubSub().ListPeers(topic))))
 			continue
 		}
 		formattedTopic := fmt.Sprintf(topic, digest)
-		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(xx.p2p.PubSub().ListPeers(formattedTopic))))
+		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.p2p.PubSub().ListPeers(formattedTopic))))
 	}
 }

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -25,12 +25,12 @@ import (
 var processPendingAttsPeriod = slotutil.DivideSlotBy(2 /* twice per slot */)
 
 // This processes pending attestation queues on every `processPendingAttsPeriod`.
-func (s *Service) processPendingAttsQueue() {
+func (xx *Service) processPendingAttsQueue() {
 	ctx := context.Background()
 	mutex := new(sync.Mutex)
-	runutil.RunEvery(s.ctx, processPendingAttsPeriod, func() {
+	runutil.RunEvery(xx.ctx, processPendingAttsPeriod, func() {
 		mutex.Lock()
-		if err := s.processPendingAtts(ctx); err != nil {
+		if err := xx.processPendingAtts(ctx); err != nil {
 			log.WithError(err).Errorf("Could not process pending attestation: %v", err)
 		}
 		mutex.Unlock()
@@ -41,31 +41,31 @@ func (s *Service) processPendingAttsQueue() {
 // 1. Clean up invalid pending attestations from the queue.
 // 2. Check if pending attestations can be processed when the block has arrived.
 // 3. Request block from a random peer if unable to proceed step 2.
-func (s *Service) processPendingAtts(ctx context.Context) error {
+func (xx *Service) processPendingAtts(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "processPendingAtts")
 	defer span.End()
 
-	pids := s.p2p.Peers().Connected()
+	pids := xx.p2p.Peers().Connected()
 
 	// Before a node processes pending attestations queue, it verifies
 	// the attestations in the queue are still valid. Attestations will
 	// be deleted from the queue if invalid (ie. getting staled from falling too many slots behind).
-	s.validatePendingAtts(ctx, s.chain.CurrentSlot())
+	xx.validatePendingAtts(ctx, xx.chain.CurrentSlot())
 
-	roots := make([][32]byte, 0, len(s.blkRootToPendingAtts))
-	s.pendingAttsLock.RLock()
-	for br := range s.blkRootToPendingAtts {
+	roots := make([][32]byte, 0, len(xx.blkRootToPendingAtts))
+	xx.pendingAttsLock.RLock()
+	for br := range xx.blkRootToPendingAtts {
 		roots = append(roots, br)
 	}
-	s.pendingAttsLock.RUnlock()
+	xx.pendingAttsLock.RUnlock()
 
 	for _, bRoot := range roots {
-		s.pendingAttsLock.RLock()
-		attestations := s.blkRootToPendingAtts[bRoot]
-		s.pendingAttsLock.RUnlock()
+		xx.pendingAttsLock.RLock()
+		attestations := xx.blkRootToPendingAtts[bRoot]
+		xx.pendingAttsLock.RUnlock()
 		// Has the pending attestation's missing block arrived and the node processed block yet?
-		hasStateSummary := featureconfig.Get().NewStateMgmt && s.db.HasStateSummary(ctx, bRoot) || s.stateSummaryCache.Has(bRoot)
-		if s.db.HasBlock(ctx, bRoot) && (s.db.HasState(ctx, bRoot) || hasStateSummary) {
+		hasStateSummary := featureconfig.Get().NewStateMgmt && xx.db.HasStateSummary(ctx, bRoot) || xx.stateSummaryCache.Has(bRoot)
+		if xx.db.HasBlock(ctx, bRoot) && (xx.db.HasState(ctx, bRoot) || hasStateSummary) {
 			numberOfBlocksRecoveredFromAtt.Inc()
 			for _, signedAtt := range attestations {
 				att := signedAtt.Message
@@ -74,15 +74,15 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 				if helpers.IsAggregated(att.Aggregate) {
 					// Save the pending aggregated attestation to the pool if it passes the aggregated
 					// validation steps.
-					aggValid := s.validateAggregatedAtt(ctx, signedAtt) == pubsub.ValidationAccept
-					if s.validateBlockInAttestation(ctx, signedAtt) && aggValid {
-						if err := s.attPool.SaveAggregatedAttestation(att.Aggregate); err != nil {
+					aggValid := xx.validateAggregatedAtt(ctx, signedAtt) == pubsub.ValidationAccept
+					if xx.validateBlockInAttestation(ctx, signedAtt) && aggValid {
+						if err := xx.attPool.SaveAggregatedAttestation(att.Aggregate); err != nil {
 							return err
 						}
 						numberOfAttsRecovered.Inc()
 
 						// Broadcasting the signed attestation again once a node is able to process it.
-						if err := s.p2p.Broadcast(ctx, signedAtt); err != nil {
+						if err := xx.p2p.Broadcast(ctx, signedAtt); err != nil {
 							log.WithError(err).Error("Failed to broadcast")
 						}
 					}
@@ -92,13 +92,13 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 					if _, err := bls.SignatureFromBytes(att.Aggregate.Signature); err != nil {
 						continue
 					}
-					if err := s.attPool.SaveUnaggregatedAttestation(att.Aggregate); err != nil {
+					if err := xx.attPool.SaveUnaggregatedAttestation(att.Aggregate); err != nil {
 						return err
 					}
 					numberOfAttsRecovered.Inc()
 
 					// Broadcasting the signed attestation again once a node is able to process it.
-					if err := s.p2p.Broadcast(ctx, signedAtt); err != nil {
+					if err := xx.p2p.Broadcast(ctx, signedAtt); err != nil {
 						log.WithError(err).Error("Failed to broadcast")
 					}
 				}
@@ -109,13 +109,13 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 			}).Info("Verified and saved pending attestations to pool")
 
 			// Delete the missing block root key from pending attestation queue so a node will not request for the block again.
-			s.pendingAttsLock.Lock()
-			delete(s.blkRootToPendingAtts, bRoot)
-			s.pendingAttsLock.Unlock()
+			xx.pendingAttsLock.Lock()
+			delete(xx.blkRootToPendingAtts, bRoot)
+			xx.pendingAttsLock.Unlock()
 		} else {
 			// Pending attestation's missing block has not arrived yet.
 			log.WithFields(logrus.Fields{
-				"currentSlot": s.chain.CurrentSlot(),
+				"currentSlot": xx.chain.CurrentSlot(),
 				"attSlot":     attestations[0].Message.Aggregate.Data.Slot,
 				"attCount":    len(attestations),
 				"blockRoot":   hex.EncodeToString(bytesutil.Trunc(bRoot[:])),
@@ -129,7 +129,7 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 			pid := pids[rand.Int()%len(pids)]
 			targetSlot := helpers.SlotToEpoch(attestations[0].Message.Aggregate.Data.Target.Epoch)
 			for _, p := range pids {
-				cs, err := s.p2p.Peers().ChainState(p)
+				cs, err := xx.p2p.Peers().ChainState(p)
 				if err != nil {
 					return errors.Wrap(err, "could not get chain state for peer")
 				}
@@ -140,7 +140,7 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 			}
 
 			req := [][]byte{bRoot[:]}
-			if err := s.sendRecentBeaconBlocksRequest(ctx, req, pid); err != nil {
+			if err := xx.sendRecentBeaconBlocksRequest(ctx, req, pid); err != nil {
 				traceutil.AnnotateError(span, err)
 				log.Errorf("Could not send recent block request: %v", err)
 			}
@@ -152,32 +152,32 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 // This defines how pending attestations is saved in the map. The key is the
 // root of the missing block. The value is the list of pending attestations
 // that voted for that block root.
-func (s *Service) savePendingAtt(att *ethpb.SignedAggregateAttestationAndProof) {
+func (xx *Service) savePendingAtt(att *ethpb.SignedAggregateAttestationAndProof) {
 	root := bytesutil.ToBytes32(att.Message.Aggregate.Data.BeaconBlockRoot)
 
-	s.pendingAttsLock.Lock()
-	defer s.pendingAttsLock.Unlock()
-	_, ok := s.blkRootToPendingAtts[root]
+	xx.pendingAttsLock.Lock()
+	defer xx.pendingAttsLock.Unlock()
+	_, ok := xx.blkRootToPendingAtts[root]
 	if !ok {
-		s.blkRootToPendingAtts[root] = []*ethpb.SignedAggregateAttestationAndProof{att}
+		xx.blkRootToPendingAtts[root] = []*ethpb.SignedAggregateAttestationAndProof{att}
 		return
 	}
 
-	s.blkRootToPendingAtts[root] = append(s.blkRootToPendingAtts[root], att)
+	xx.blkRootToPendingAtts[root] = append(xx.blkRootToPendingAtts[root], att)
 }
 
 // This validates the pending attestations in the queue are still valid.
 // If not valid, a node will remove it in the queue in place. The validity
 // check specifies the pending attestation could not fall one epoch behind
 // of the current slot.
-func (s *Service) validatePendingAtts(ctx context.Context, slot uint64) {
+func (xx *Service) validatePendingAtts(ctx context.Context, slot uint64) {
 	ctx, span := trace.StartSpan(ctx, "validatePendingAtts")
 	defer span.End()
 
-	s.pendingAttsLock.Lock()
-	defer s.pendingAttsLock.Unlock()
+	xx.pendingAttsLock.Lock()
+	defer xx.pendingAttsLock.Unlock()
 
-	for bRoot, atts := range s.blkRootToPendingAtts {
+	for bRoot, atts := range xx.blkRootToPendingAtts {
 		for i := len(atts) - 1; i >= 0; i-- {
 			if slot >= atts[i].Message.Aggregate.Data.Slot+params.BeaconConfig().SlotsPerEpoch {
 				// Remove the pending attestation from the list in place.
@@ -185,12 +185,12 @@ func (s *Service) validatePendingAtts(ctx context.Context, slot uint64) {
 				numberOfAttsNotRecovered.Inc()
 			}
 		}
-		s.blkRootToPendingAtts[bRoot] = atts
+		xx.blkRootToPendingAtts[bRoot] = atts
 
 		// If the pending attestations list of a given block root is empty,
 		// a node will remove the key from the map to avoid dangling keys.
-		if len(s.blkRootToPendingAtts[bRoot]) == 0 {
-			delete(s.blkRootToPendingAtts, bRoot)
+		if len(xx.blkRootToPendingAtts[bRoot]) == 0 {
+			delete(xx.blkRootToPendingAtts, bRoot)
 			numberOfBlocksNotRecoveredFromAtt.Inc()
 		}
 	}

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -22,12 +22,12 @@ import (
 var processPendingBlocksPeriod = slotutil.DivideSlotBy(3 /* times per slot */)
 
 // processes pending blocks queue on every processPendingBlocksPeriod
-func (r *Service) processPendingBlocksQueue() {
+func (xx *Service) processPendingBlocksQueue() {
 	ctx := context.Background()
 	locker := new(sync.Mutex)
-	runutil.RunEvery(r.ctx, processPendingBlocksPeriod, func() {
+	runutil.RunEvery(xx.ctx, processPendingBlocksPeriod, func() {
 		locker.Lock()
-		if err := r.processPendingBlocks(ctx); err != nil {
+		if err := xx.processPendingBlocks(ctx); err != nil {
 			log.WithError(err).Error("Failed to process pending blocks")
 		}
 		locker.Unlock()
@@ -35,37 +35,37 @@ func (r *Service) processPendingBlocksQueue() {
 }
 
 // processes the block tree inside the queue
-func (r *Service) processPendingBlocks(ctx context.Context) error {
+func (xx *Service) processPendingBlocks(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "processPendingBlocks")
 	defer span.End()
 
-	pids := r.p2p.Peers().Connected()
-	if err := r.validatePendingSlots(); err != nil {
+	pids := xx.p2p.Peers().Connected()
+	if err := xx.validatePendingSlots(); err != nil {
 		return errors.Wrap(err, "could not validate pending slots")
 	}
-	slots := r.sortedPendingSlots()
+	slots := xx.sortedPendingSlots()
 
 	span.AddAttributes(
 		trace.Int64Attribute("numSlots", int64(len(slots))),
 		trace.Int64Attribute("numPeers", int64(len(pids))),
 	)
 
-	for _, s := range slots {
+	for _, slot := range slots {
 		ctx, span := trace.StartSpan(ctx, "processPendingBlocks.InnerLoop")
-		span.AddAttributes(trace.Int64Attribute("slot", int64(s)))
+		span.AddAttributes(trace.Int64Attribute("slot", int64(slot)))
 
-		r.pendingQueueLock.RLock()
-		b := r.slotToPendingBlocks[s]
+		xx.pendingQueueLock.RLock()
+		b := xx.slotToPendingBlocks[slot]
 		// Skip if block does not exist.
 		if b == nil || b.Block == nil {
-			r.pendingQueueLock.RUnlock()
+			xx.pendingQueueLock.RUnlock()
 			span.End()
 			continue
 		}
-		r.pendingQueueLock.RUnlock()
-		inPendingQueue := r.seenPendingBlocks[bytesutil.ToBytes32(b.Block.ParentRoot)]
+		xx.pendingQueueLock.RUnlock()
+		inPendingQueue := xx.seenPendingBlocks[bytesutil.ToBytes32(b.Block.ParentRoot)]
 
-		inDB := r.db.HasBlock(ctx, bytesutil.ToBytes32(b.Block.ParentRoot))
+		inDB := xx.db.HasBlock(ctx, bytesutil.ToBytes32(b.Block.ParentRoot))
 		hasPeer := len(pids) != 0
 
 		// Only request for missing parent block if it's not in DB, not in pending cache
@@ -81,17 +81,17 @@ func (r *Service) processPendingBlocks(ctx context.Context) error {
 			// have a head slot newer than the block slot we are requesting.
 			pid := pids[rand.Int()%len(pids)]
 			for _, p := range pids {
-				cs, err := r.p2p.Peers().ChainState(p)
+				cs, err := xx.p2p.Peers().ChainState(p)
 				if err != nil {
 					return errors.Wrap(err, "failed to read chain state for peer")
 				}
-				if cs != nil && cs.HeadSlot >= s {
+				if cs != nil && cs.HeadSlot >= slot {
 					pid = p
 					break
 				}
 			}
 
-			if err := r.sendRecentBeaconBlocksRequest(ctx, req, pid); err != nil {
+			if err := xx.sendRecentBeaconBlocksRequest(ctx, req, pid); err != nil {
 				traceutil.AnnotateError(span, err)
 				log.Errorf("Could not send recent block request: %v", err)
 			}
@@ -111,23 +111,23 @@ func (r *Service) processPendingBlocks(ctx context.Context) error {
 			return err
 		}
 
-		if err := r.chain.ReceiveBlockNoPubsub(ctx, b, blkRoot); err != nil {
+		if err := xx.chain.ReceiveBlockNoPubsub(ctx, b, blkRoot); err != nil {
 			log.Errorf("Could not process block from slot %d: %v", b.Block.Slot, err)
 			traceutil.AnnotateError(span, err)
 		}
 
 		// Broadcasting the block again once a node is able to process it.
-		if err := r.p2p.Broadcast(ctx, b); err != nil {
+		if err := xx.p2p.Broadcast(ctx, b); err != nil {
 			log.WithError(err).Error("Failed to broadcast block")
 		}
 
-		r.pendingQueueLock.Lock()
-		delete(r.slotToPendingBlocks, s)
-		delete(r.seenPendingBlocks, blkRoot)
-		r.pendingQueueLock.Unlock()
+		xx.pendingQueueLock.Lock()
+		delete(xx.slotToPendingBlocks, slot)
+		delete(xx.seenPendingBlocks, blkRoot)
+		xx.pendingQueueLock.Unlock()
 
 		log.WithFields(logrus.Fields{
-			"slot":      s,
+			"slot":      slot,
 			"blockRoot": hex.EncodeToString(bytesutil.Trunc(blkRoot[:])),
 		}).Debug("Processed pending block and cleared it in cache")
 
@@ -137,13 +137,13 @@ func (r *Service) processPendingBlocks(ctx context.Context) error {
 	return nil
 }
 
-func (r *Service) sortedPendingSlots() []uint64 {
-	r.pendingQueueLock.RLock()
-	defer r.pendingQueueLock.RUnlock()
+func (xx *Service) sortedPendingSlots() []uint64 {
+	xx.pendingQueueLock.RLock()
+	defer xx.pendingQueueLock.RUnlock()
 
-	slots := make([]uint64, 0, len(r.slotToPendingBlocks))
-	for s := range r.slotToPendingBlocks {
-		slots = append(slots, s)
+	slots := make([]uint64, 0, len(xx.slotToPendingBlocks))
+	for slot := range xx.slotToPendingBlocks {
+		slots = append(slots, slot)
 	}
 	sort.Slice(slots, func(i, j int) bool {
 		return slots[i] < slots[j]
@@ -154,13 +154,13 @@ func (r *Service) sortedPendingSlots() []uint64 {
 // validatePendingSlots validates the pending blocks
 // by their slot. If they are before the current finalized
 // checkpoint, these blocks are removed from the queue.
-func (r *Service) validatePendingSlots() error {
-	r.pendingQueueLock.Lock()
-	defer r.pendingQueueLock.Unlock()
+func (xx *Service) validatePendingSlots() error {
+	xx.pendingQueueLock.Lock()
+	defer xx.pendingQueueLock.Unlock()
 	oldBlockRoots := make(map[[32]byte]bool)
 
-	finalizedEpoch := r.chain.FinalizedCheckpt().Epoch
-	for s, b := range r.slotToPendingBlocks {
+	finalizedEpoch := xx.chain.FinalizedCheckpt().Epoch
+	for s, b := range xx.slotToPendingBlocks {
 		epoch := helpers.SlotToEpoch(s)
 		// remove all descendant blocks of old blocks
 		if oldBlockRoots[bytesutil.ToBytes32(b.Block.ParentRoot)] {
@@ -169,8 +169,8 @@ func (r *Service) validatePendingSlots() error {
 				return err
 			}
 			oldBlockRoots[root] = true
-			delete(r.slotToPendingBlocks, s)
-			delete(r.seenPendingBlocks, root)
+			delete(xx.slotToPendingBlocks, s)
+			delete(xx.seenPendingBlocks, root)
 			continue
 		}
 		// don't process old blocks
@@ -180,16 +180,16 @@ func (r *Service) validatePendingSlots() error {
 				return err
 			}
 			oldBlockRoots[blkRoot] = true
-			delete(r.slotToPendingBlocks, s)
-			delete(r.seenPendingBlocks, blkRoot)
+			delete(xx.slotToPendingBlocks, s)
+			delete(xx.seenPendingBlocks, blkRoot)
 		}
 	}
 	return nil
 }
 
-func (r *Service) clearPendingSlots() {
-	r.pendingQueueLock.Lock()
-	defer r.pendingQueueLock.Unlock()
-	r.slotToPendingBlocks = make(map[uint64]*ethpb.SignedBeaconBlock)
-	r.seenPendingBlocks = make(map[[32]byte]bool)
+func (xx *Service) clearPendingSlots() {
+	xx.pendingQueueLock.Lock()
+	defer xx.pendingQueueLock.Unlock()
+	xx.slotToPendingBlocks = make(map[uint64]*ethpb.SignedBeaconBlock)
+	xx.seenPendingBlocks = make(map[[32]byte]bool)
 }

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -17,12 +17,12 @@ import (
 
 // sendRecentBeaconBlocksRequest sends a recent beacon blocks request to a peer to get
 // those corresponding blocks from that peer.
-func (r *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots [][]byte, id peer.ID) error {
+func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots [][]byte, id peer.ID) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	req := &pbp2p.BeaconBlocksByRootRequest{BlockRoots: blockRoots}
-	stream, err := r.p2p.Send(ctx, req, p2p.RPCBlocksByRootTopic, id)
+	stream, err := s.p2p.Send(ctx, req, p2p.RPCBlocksByRootTopic, id)
 	if err != nil {
 		return err
 	}
@@ -32,7 +32,7 @@ func (r *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 		}
 	}()
 	for i := 0; i < len(blockRoots); i++ {
-		blk, err := ReadChunkedBlock(stream, r.p2p)
+		blk, err := ReadChunkedBlock(stream, s.p2p)
 		if err == io.EOF {
 			break
 		}
@@ -49,17 +49,17 @@ func (r *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 		if err != nil {
 			return err
 		}
-		r.pendingQueueLock.Lock()
-		r.slotToPendingBlocks[blk.Block.Slot] = blk
-		r.seenPendingBlocks[blkRoot] = true
-		r.pendingQueueLock.Unlock()
+		s.pendingQueueLock.Lock()
+		s.slotToPendingBlocks[blk.Block.Slot] = blk
+		s.seenPendingBlocks[blkRoot] = true
+		s.pendingQueueLock.Unlock()
 
 	}
 	return nil
 }
 
 // beaconBlocksRootRPCHandler looks up the request blocks from the database from the given block roots.
-func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
+func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
 	defer func() {
 		if err := stream.Close(); err != nil {
 			log.WithError(err).Error("Failed to close stream")
@@ -75,7 +75,7 @@ func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		return errors.New("message is not type BeaconBlocksByRootRequest")
 	}
 	if len(req.BlockRoots) == 0 {
-		resp, err := r.generateErrorResponse(responseCodeInvalidRequest, "no block roots provided in request")
+		resp, err := s.generateErrorResponse(responseCodeInvalidRequest, "no block roots provided in request")
 		if err != nil {
 			log.WithError(err).Error("Failed to generate a response error")
 		} else {
@@ -86,17 +86,17 @@ func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		return errors.New("no block roots provided")
 	}
 
-	if int64(len(req.BlockRoots)) > r.blocksRateLimiter.Remaining(stream.Conn().RemotePeer().String()) {
-		r.p2p.Peers().IncrementBadResponses(stream.Conn().RemotePeer())
-		if r.p2p.Peers().IsBad(stream.Conn().RemotePeer()) {
+	if int64(len(req.BlockRoots)) > s.blocksRateLimiter.Remaining(stream.Conn().RemotePeer().String()) {
+		s.p2p.Peers().IncrementBadResponses(stream.Conn().RemotePeer())
+		if s.p2p.Peers().IsBad(stream.Conn().RemotePeer()) {
 			log.Debug("Disconnecting bad peer")
 			defer func() {
-				if err := r.p2p.Disconnect(stream.Conn().RemotePeer()); err != nil {
+				if err := s.p2p.Disconnect(stream.Conn().RemotePeer()); err != nil {
 					log.WithError(err).Error("Failed to disconnect peer")
 				}
 			}()
 		}
-		resp, err := r.generateErrorResponse(responseCodeInvalidRequest, rateLimitedError)
+		resp, err := s.generateErrorResponse(responseCodeInvalidRequest, rateLimitedError)
 		if err != nil {
 			log.WithError(err).Error("Failed to generate a response error")
 		} else {
@@ -108,7 +108,7 @@ func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 	}
 
 	if uint64(len(req.BlockRoots)) > params.BeaconNetworkConfig().MaxRequestBlocks {
-		resp, err := r.generateErrorResponse(responseCodeInvalidRequest, "requested more than the max block limit")
+		resp, err := s.generateErrorResponse(responseCodeInvalidRequest, "requested more than the max block limit")
 		if err != nil {
 			log.WithError(err).Error("Failed to generate a response error")
 		} else {
@@ -119,13 +119,13 @@ func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		return errors.New("requested more than the max block limit")
 	}
 
-	r.blocksRateLimiter.Add(stream.Conn().RemotePeer().String(), int64(len(req.BlockRoots)))
+	s.blocksRateLimiter.Add(stream.Conn().RemotePeer().String(), int64(len(req.BlockRoots)))
 
 	for _, root := range req.BlockRoots {
-		blk, err := r.db.Block(ctx, bytesutil.ToBytes32(root))
+		blk, err := s.db.Block(ctx, bytesutil.ToBytes32(root))
 		if err != nil {
 			log.WithError(err).Error("Failed to fetch block")
-			resp, err := r.generateErrorResponse(responseCodeServerError, genericError)
+			resp, err := s.generateErrorResponse(responseCodeServerError, genericError)
 			if err != nil {
 				log.WithError(err).Error("Failed to generate a response error")
 			} else {
@@ -138,7 +138,7 @@ func (r *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		if blk == nil {
 			continue
 		}
-		if err := r.chunkWriter(stream, blk); err != nil {
+		if err := s.chunkWriter(stream, blk); err != nil {
 			return err
 		}
 	}

--- a/beacon-chain/sync/rpc_chunked_response.go
+++ b/beacon-chain/sync/rpc_chunked_response.go
@@ -13,9 +13,9 @@ import (
 // chunkWriter writes the given message as a chunked response to the given network
 // stream.
 // response_chunk ::= | <result> | <encoding-dependent-header> | <encoded-payload>
-func (r *Service) chunkWriter(stream libp2pcore.Stream, msg interface{}) error {
+func (s *Service) chunkWriter(stream libp2pcore.Stream, msg interface{}) error {
 	setStreamWriteDeadline(stream, defaultWriteDuration)
-	return WriteChunk(stream, r.p2p.Encoding(), msg)
+	return WriteChunk(stream, s.p2p.Encoding(), msg)
 }
 
 // WriteChunk object to stream.

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -24,7 +24,7 @@ var goodByes = map[uint64]string{
 }
 
 // goodbyeRPCHandler reads the incoming goodbye rpc message from the peer.
-func (r *Service) goodbyeRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
+func (s *Service) goodbyeRPCHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
 	defer func() {
 		if err := stream.Close(); err != nil {
 			log.WithError(err).Error("Failed to close stream")
@@ -41,27 +41,27 @@ func (r *Service) goodbyeRPCHandler(ctx context.Context, msg interface{}, stream
 	log := log.WithField("Reason", goodbyeMessage(*m))
 	log.WithField("peer", stream.Conn().RemotePeer()).Debug("Peer has sent a goodbye message")
 	// closes all streams with the peer
-	return r.p2p.Disconnect(stream.Conn().RemotePeer())
+	return s.p2p.Disconnect(stream.Conn().RemotePeer())
 }
 
-func (r *Service) sendGoodByeAndDisconnect(ctx context.Context, code uint64, id peer.ID) error {
-	if err := r.sendGoodByeMessage(ctx, code, id); err != nil {
+func (s *Service) sendGoodByeAndDisconnect(ctx context.Context, code uint64, id peer.ID) error {
+	if err := s.sendGoodByeMessage(ctx, code, id); err != nil {
 		log.WithFields(logrus.Fields{
 			"error": err,
 			"peer":  id,
 		}).Debug("Could not send goodbye message to peer")
 	}
-	if err := r.p2p.Disconnect(id); err != nil {
+	if err := s.p2p.Disconnect(id); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (r *Service) sendGoodByeMessage(ctx context.Context, code uint64, id peer.ID) error {
+func (s *Service) sendGoodByeMessage(ctx context.Context, code uint64, id peer.ID) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	stream, err := r.p2p.Send(ctx, &code, p2p.RPCGoodByeTopic, id)
+	stream, err := s.p2p.Send(ctx, &code, p2p.RPCGoodByeTopic, id)
 	if err != nil {
 		return err
 	}
@@ -79,8 +79,8 @@ func (r *Service) sendGoodByeMessage(ctx context.Context, code uint64, id peer.I
 }
 
 // sends a goodbye message for a generic error
-func (r *Service) sendGenericGoodbyeMessage(ctx context.Context, id peer.ID) error {
-	return r.sendGoodByeMessage(ctx, codeGenericError, id)
+func (s *Service) sendGenericGoodbyeMessage(ctx context.Context, id peer.ID) error {
+	return s.sendGoodByeMessage(ctx, codeGenericError, id)
 }
 
 func goodbyeMessage(num uint64) string {

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -140,45 +140,45 @@ func NewRegularSync(cfg *Config) *Service {
 }
 
 // Start the regular sync service.
-func (r *Service) Start() {
-	if err := r.initCaches(); err != nil {
+func (s *Service) Start() {
+	if err := s.initCaches(); err != nil {
 		panic(err)
 	}
 
-	r.p2p.AddConnectionHandler(r.reValidatePeer, r.sendGenericGoodbyeMessage)
-	r.p2p.AddDisconnectionHandler(r.removeDisconnectedPeerStatus)
-	r.p2p.AddPingMethod(r.sendPingRequest)
-	r.processPendingBlocksQueue()
-	r.processPendingAttsQueue()
-	r.maintainPeerStatuses()
-	r.resyncIfBehind()
+	s.p2p.AddConnectionHandler(s.reValidatePeer, s.sendGenericGoodbyeMessage)
+	s.p2p.AddDisconnectionHandler(s.removeDisconnectedPeerStatus)
+	s.p2p.AddPingMethod(s.sendPingRequest)
+	s.processPendingBlocksQueue()
+	s.processPendingAttsQueue()
+	s.maintainPeerStatuses()
+	s.resyncIfBehind()
 
 	// Update sync metrics.
-	runutil.RunEvery(r.ctx, time.Second*10, r.updateMetrics)
+	runutil.RunEvery(s.ctx, time.Second*10, s.updateMetrics)
 }
 
 // Stop the regular sync service.
-func (r *Service) Stop() error {
+func (s *Service) Stop() error {
 	defer func() {
-		if r.blocksRateLimiter != nil {
-			r.blocksRateLimiter.Free()
-			r.blocksRateLimiter = nil
+		if s.blocksRateLimiter != nil {
+			s.blocksRateLimiter.Free()
+			s.blocksRateLimiter = nil
 		}
 	}()
-	defer r.cancel()
+	defer s.cancel()
 	return nil
 }
 
 // Status of the currently running regular sync service.
-func (r *Service) Status() error {
-	if r.chainStarted {
-		if r.initialSync.Syncing() {
+func (s *Service) Status() error {
+	if s.chainStarted {
+		if s.initialSync.Syncing() {
 			return errors.New("waiting for initial sync")
 		}
 		// If our head slot is on a previous epoch and our peers are reporting their head block are
 		// in the most recent epoch, then we might be out of sync.
-		if headEpoch := helpers.SlotToEpoch(r.chain.HeadSlot()); headEpoch+1 < helpers.SlotToEpoch(r.chain.CurrentSlot()) &&
-			headEpoch+1 < r.p2p.Peers().CurrentEpoch() {
+		if headEpoch := helpers.SlotToEpoch(s.chain.HeadSlot()); headEpoch+1 < helpers.SlotToEpoch(s.chain.CurrentSlot()) &&
+			headEpoch+1 < s.p2p.Peers().CurrentEpoch() {
 			return errors.New("out of sync")
 		}
 	}
@@ -187,7 +187,7 @@ func (r *Service) Status() error {
 
 // This initializes the caches to update seen beacon objects coming in from the wire
 // and prevent DoS.
-func (r *Service) initCaches() error {
+func (s *Service) initCaches() error {
 	blkCache, err := lru.New(seenBlockSize)
 	if err != nil {
 		return err
@@ -208,21 +208,21 @@ func (r *Service) initCaches() error {
 	if err != nil {
 		return err
 	}
-	r.seenBlockCache = blkCache
-	r.seenAttestationCache = attCache
-	r.seenExitCache = exitCache
-	r.seenAttesterSlashingCache = attesterSlashingCache
-	r.seenProposerSlashingCache = proposerSlashingCache
+	s.seenBlockCache = blkCache
+	s.seenAttestationCache = attCache
+	s.seenExitCache = exitCache
+	s.seenAttesterSlashingCache = attesterSlashingCache
+	s.seenProposerSlashingCache = proposerSlashingCache
 
 	return nil
 }
 
-func (r *Service) registerHandlers() {
+func (s *Service) registerHandlers() {
 	// Wait until chain start.
 	stateChannel := make(chan *feed.Event, 1)
-	stateSub := r.stateNotifier.StateFeed().Subscribe(stateChannel)
+	stateSub := s.stateNotifier.StateFeed().Subscribe(stateChannel)
 	defer stateSub.Unsubscribe()
-	for r.chainStarted == false {
+	for s.chainStarted == false {
 		select {
 		case event := <-stateChannel:
 			if event.Type == statefeed.Initialized {
@@ -234,16 +234,16 @@ func (r *Service) registerHandlers() {
 				log.WithField("starttime", data.StartTime).Debug("Received state initialized event")
 
 				// Register respective rpc and pubsub handlers at state initialized event.
-				r.registerRPCHandlers()
-				r.registerSubscribers()
+				s.registerRPCHandlers()
+				s.registerSubscribers()
 
 				if data.StartTime.After(roughtime.Now()) {
 					stateSub.Unsubscribe()
 					time.Sleep(roughtime.Until(data.StartTime))
 				}
-				r.chainStarted = true
+				s.chainStarted = true
 			}
-		case <-r.ctx.Done():
+		case <-s.ctx.Done():
 			log.Debug("Context closed, exiting goroutine")
 			return
 		case err := <-stateSub.Err():

--- a/beacon-chain/sync/subscriber_beacon_aggregate_proof.go
+++ b/beacon-chain/sync/subscriber_beacon_aggregate_proof.go
@@ -14,7 +14,7 @@ import (
 
 // beaconAggregateProofSubscriber forwards the incoming validated aggregated attestation and proof to the
 // attestation pool for processing.
-func (r *Service) beaconAggregateProofSubscriber(ctx context.Context, msg proto.Message) error {
+func (s *Service) beaconAggregateProofSubscriber(ctx context.Context, msg proto.Message) error {
 	a, ok := msg.(*ethpb.SignedAggregateAttestationAndProof)
 	if !ok {
 		return fmt.Errorf("message was not type *eth.SignedAggregateAttestationAndProof, type=%T", msg)
@@ -26,7 +26,7 @@ func (r *Service) beaconAggregateProofSubscriber(ctx context.Context, msg proto.
 
 	// Broadcast the aggregated attestation on a feed to notify other services in the beacon node
 	// of a received aggregated attestation.
-	r.attestationNotifier.OperationFeed().Send(&feed.Event{
+	s.attestationNotifier.OperationFeed().Send(&feed.Event{
 		Type: operation.AggregatedAttReceived,
 		Data: &operation.AggregatedAttReceivedData{
 			Attestation: a.Message,
@@ -35,8 +35,8 @@ func (r *Service) beaconAggregateProofSubscriber(ctx context.Context, msg proto.
 
 	// An unaggregated attestation can make it here. It’s valid, the aggregator it just itself, although it means poor performance for the subnet.
 	if !helpers.IsAggregated(a.Message.Aggregate) {
-		return r.attPool.SaveUnaggregatedAttestation(a.Message.Aggregate)
+		return s.attPool.SaveUnaggregatedAttestation(a.Message.Aggregate)
 	}
 
-	return r.attPool.SaveAggregatedAttestation(a.Message.Aggregate)
+	return s.attPool.SaveAggregatedAttestation(a.Message.Aggregate)
 }

--- a/beacon-chain/sync/subscriber_handlers.go
+++ b/beacon-chain/sync/subscriber_handlers.go
@@ -9,7 +9,7 @@ import (
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 )
 
-func (r *Service) voluntaryExitSubscriber(ctx context.Context, msg proto.Message) error {
+func (s *Service) voluntaryExitSubscriber(ctx context.Context, msg proto.Message) error {
 	ve, ok := msg.(*ethpb.SignedVoluntaryExit)
 	if !ok {
 		return fmt.Errorf("wrong type, expected: *ethpb.SignedVoluntaryExit got: %T", msg)
@@ -18,17 +18,17 @@ func (r *Service) voluntaryExitSubscriber(ctx context.Context, msg proto.Message
 	if ve.Exit == nil {
 		return errors.New("exit can't be nil")
 	}
-	r.setExitIndexSeen(ve.Exit.ValidatorIndex)
+	s.setExitIndexSeen(ve.Exit.ValidatorIndex)
 
-	s, err := r.chain.HeadState(ctx)
+	headState, err := s.chain.HeadState(ctx)
 	if err != nil {
 		return err
 	}
-	r.exitPool.InsertVoluntaryExit(ctx, s, ve)
+	s.exitPool.InsertVoluntaryExit(ctx, headState, ve)
 	return nil
 }
 
-func (r *Service) attesterSlashingSubscriber(ctx context.Context, msg proto.Message) error {
+func (s *Service) attesterSlashingSubscriber(ctx context.Context, msg proto.Message) error {
 	aSlashing, ok := msg.(*ethpb.AttesterSlashing)
 	if !ok {
 		return fmt.Errorf("wrong type, expected: *ethpb.AttesterSlashing got: %T", msg)
@@ -37,19 +37,19 @@ func (r *Service) attesterSlashingSubscriber(ctx context.Context, msg proto.Mess
 	aSlashing1IsNil := aSlashing == nil || aSlashing.Attestation_1 == nil || aSlashing.Attestation_1.AttestingIndices == nil
 	aSlashing2IsNil := aSlashing == nil || aSlashing.Attestation_2 == nil || aSlashing.Attestation_2.AttestingIndices == nil
 	if !aSlashing1IsNil && !aSlashing2IsNil {
-		headState, err := r.chain.HeadState(ctx)
+		headState, err := s.chain.HeadState(ctx)
 		if err != nil {
 			return err
 		}
-		if err := r.slashingPool.InsertAttesterSlashing(ctx, headState, aSlashing); err != nil {
+		if err := s.slashingPool.InsertAttesterSlashing(ctx, headState, aSlashing); err != nil {
 			return errors.Wrap(err, "could not insert attester slashing into pool")
 		}
-		r.setAttesterSlashingIndicesSeen(aSlashing.Attestation_1.AttestingIndices, aSlashing.Attestation_2.AttestingIndices)
+		s.setAttesterSlashingIndicesSeen(aSlashing.Attestation_1.AttestingIndices, aSlashing.Attestation_2.AttestingIndices)
 	}
 	return nil
 }
 
-func (r *Service) proposerSlashingSubscriber(ctx context.Context, msg proto.Message) error {
+func (s *Service) proposerSlashingSubscriber(ctx context.Context, msg proto.Message) error {
 	pSlashing, ok := msg.(*ethpb.ProposerSlashing)
 	if !ok {
 		return fmt.Errorf("wrong type, expected: *ethpb.ProposerSlashing got: %T", msg)
@@ -58,14 +58,14 @@ func (r *Service) proposerSlashingSubscriber(ctx context.Context, msg proto.Mess
 	header1IsNil := pSlashing == nil || pSlashing.Header_1 == nil || pSlashing.Header_1.Header == nil
 	header2IsNil := pSlashing == nil || pSlashing.Header_2 == nil || pSlashing.Header_2.Header == nil
 	if !header1IsNil && !header2IsNil {
-		headState, err := r.chain.HeadState(ctx)
+		headState, err := s.chain.HeadState(ctx)
 		if err != nil {
 			return err
 		}
-		if err := r.slashingPool.InsertProposerSlashing(ctx, headState, pSlashing); err != nil {
+		if err := s.slashingPool.InsertProposerSlashing(ctx, headState, pSlashing); err != nil {
 			return errors.Wrap(err, "could not insert proposer slashing into pool")
 		}
-		r.setProposerSlashingIndexSeen(pSlashing.Header_1.Header.ProposerIndex)
+		s.setProposerSlashingIndexSeen(pSlashing.Header_1.Header.ProposerIndex)
 	}
 	return nil
 }

--- a/beacon-chain/sync/utils.go
+++ b/beacon-chain/sync/utils.go
@@ -28,7 +28,7 @@ func (s sortedObj) Len() int {
 }
 
 // removes duplicates from provided blocks and roots.
-func (r *Service) dedupBlocksAndRoots(blks []*ethpb.SignedBeaconBlock, roots [][32]byte) ([]*ethpb.SignedBeaconBlock, [][32]byte) {
+func (s *Service) dedupBlocksAndRoots(blks []*ethpb.SignedBeaconBlock, roots [][32]byte) ([]*ethpb.SignedBeaconBlock, [][32]byte) {
 	// Remove duplicate blocks received
 	rootMap := make(map[[32]byte]bool)
 	newBlks := make([]*ethpb.SignedBeaconBlock, 0, len(blks))
@@ -46,7 +46,7 @@ func (r *Service) dedupBlocksAndRoots(blks []*ethpb.SignedBeaconBlock, roots [][
 
 // sort the provided blocks and roots in ascending order. This method assumes that the size of
 // block slice and root slice is equal.
-func (r *Service) sortBlocksAndRoots(blks []*ethpb.SignedBeaconBlock, roots [][32]byte) ([]*ethpb.SignedBeaconBlock, [][32]byte) {
+func (s *Service) sortBlocksAndRoots(blks []*ethpb.SignedBeaconBlock, roots [][32]byte) ([]*ethpb.SignedBeaconBlock, [][32]byte) {
 	obj := sortedObj{
 		blks:  blks,
 		roots: roots,

--- a/beacon-chain/sync/validate_attester_slashing.go
+++ b/beacon-chain/sync/validate_attester_slashing.go
@@ -18,22 +18,22 @@ import (
 
 // Clients who receive an attester slashing on this topic MUST validate the conditions within VerifyAttesterSlashing before
 // forwarding it across the network.
-func (r *Service) validateAttesterSlashing(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
+func (s *Service) validateAttesterSlashing(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
 	// Validation runs on publish (not just subscriptions), so we should approve any message from
 	// ourselves.
-	if pid == r.p2p.PeerID() {
+	if pid == s.p2p.PeerID() {
 		return pubsub.ValidationAccept
 	}
 
 	// The head state will be too far away to validate any slashing.
-	if r.initialSync.Syncing() {
+	if s.initialSync.Syncing() {
 		return pubsub.ValidationIgnore
 	}
 
 	ctx, span := trace.StartSpan(ctx, "sync.validateAttesterSlashing")
 	defer span.End()
 
-	m, err := r.decodePubsubMessage(msg)
+	m, err := s.decodePubsubMessage(msg)
 	if err != nil {
 		log.WithError(err).Error("Failed to decode message")
 		traceutil.AnnotateError(span, err)
@@ -47,29 +47,29 @@ func (r *Service) validateAttesterSlashing(ctx context.Context, pid peer.ID, msg
 	if slashing == nil || slashing.Attestation_1 == nil || slashing.Attestation_2 == nil {
 		return pubsub.ValidationReject
 	}
-	if r.hasSeenAttesterSlashingIndices(slashing.Attestation_1.AttestingIndices, slashing.Attestation_2.AttestingIndices) {
+	if s.hasSeenAttesterSlashingIndices(slashing.Attestation_1.AttestingIndices, slashing.Attestation_2.AttestingIndices) {
 		return pubsub.ValidationIgnore
 	}
 
 	// Retrieve head state, advance state to the epoch slot used specified in slashing message.
-	s, err := r.chain.HeadState(ctx)
+	headState, err := s.chain.HeadState(ctx)
 	if err != nil {
 		return pubsub.ValidationIgnore
 	}
 	slashSlot := slashing.Attestation_1.Data.Target.Epoch * params.BeaconConfig().SlotsPerEpoch
-	if s.Slot() < slashSlot {
+	if headState.Slot() < slashSlot {
 		if ctx.Err() != nil {
 			return pubsub.ValidationIgnore
 		}
 
 		var err error
-		s, err = state.ProcessSlots(ctx, s, slashSlot)
+		headState, err = state.ProcessSlots(ctx, headState, slashSlot)
 		if err != nil {
 			return pubsub.ValidationIgnore
 		}
 	}
 
-	if err := blocks.VerifyAttesterSlashing(ctx, s, slashing); err != nil {
+	if err := blocks.VerifyAttesterSlashing(ctx, headState, slashing); err != nil {
 		return pubsub.ValidationReject
 	}
 
@@ -78,9 +78,9 @@ func (r *Service) validateAttesterSlashing(ctx context.Context, pid peer.ID, msg
 }
 
 // Returns true if the node has already received a valid attester slashing with the attesting indices.
-func (r *Service) hasSeenAttesterSlashingIndices(indices1 []uint64, indices2 []uint64) bool {
-	r.seenAttesterSlashingLock.RLock()
-	defer r.seenAttesterSlashingLock.RUnlock()
+func (s *Service) hasSeenAttesterSlashingIndices(indices1 []uint64, indices2 []uint64) bool {
+	s.seenAttesterSlashingLock.RLock()
+	defer s.seenAttesterSlashingLock.RUnlock()
 
 	slashableIndices := sliceutil.IntersectionUint64(indices1, indices2)
 	sort.SliceStable(slashableIndices, func(i, j int) bool {
@@ -92,14 +92,14 @@ func (r *Service) hasSeenAttesterSlashingIndices(indices1 []uint64, indices2 []u
 	}
 	b := hashutil.FastSum256(IndicesInBytes)
 
-	_, seen := r.seenAttesterSlashingCache.Get(b)
+	_, seen := s.seenAttesterSlashingCache.Get(b)
 	return seen
 }
 
 // Set attester slashing indices in attester slashing cache.
-func (r *Service) setAttesterSlashingIndicesSeen(indices1 []uint64, indices2 []uint64) {
-	r.seenAttesterSlashingLock.Lock()
-	defer r.seenAttesterSlashingLock.Unlock()
+func (s *Service) setAttesterSlashingIndicesSeen(indices1 []uint64, indices2 []uint64) {
+	s.seenAttesterSlashingLock.Lock()
+	defer s.seenAttesterSlashingLock.Unlock()
 
 	slashableIndices := sliceutil.IntersectionUint64(indices1, indices2)
 	sort.SliceStable(slashableIndices, func(i, j int) bool {
@@ -111,5 +111,5 @@ func (r *Service) setAttesterSlashingIndicesSeen(indices1 []uint64, indices2 []u
 	}
 	b := hashutil.FastSum256(IndicesInBytes)
 
-	r.seenAttesterSlashingCache.Add(b, true)
+	s.seenAttesterSlashingCache.Add(b, true)
 }

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -24,30 +24,30 @@ import (
 // validateBeaconBlockPubSub checks that the incoming block has a valid BLS signature.
 // Blocks that have already been seen are ignored. If the BLS signature is any valid signature,
 // this method rebroadcasts the message.
-func (r *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
+func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
 	// Validation runs on publish (not just subscriptions), so we should approve any message from
 	// ourselves.
-	if pid == r.p2p.PeerID() {
+	if pid == s.p2p.PeerID() {
 		return pubsub.ValidationAccept
 	}
 
 	// We should not attempt to process blocks until fully synced, but propagation is OK.
-	if r.initialSync.Syncing() {
+	if s.initialSync.Syncing() {
 		return pubsub.ValidationIgnore
 	}
 
 	ctx, span := trace.StartSpan(ctx, "sync.validateBeaconBlockPubSub")
 	defer span.End()
 
-	m, err := r.decodePubsubMessage(msg)
+	m, err := s.decodePubsubMessage(msg)
 	if err != nil {
 		log.WithError(err).Error("Failed to decode message")
 		traceutil.AnnotateError(span, err)
 		return pubsub.ValidationReject
 	}
 
-	r.validateBlockLock.Lock()
-	defer r.validateBlockLock.Unlock()
+	s.validateBlockLock.Lock()
+	defer s.validateBlockLock.Unlock()
 
 	blk, ok := m.(*ethpb.SignedBeaconBlock)
 	if !ok {
@@ -60,7 +60,7 @@ func (r *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 
 	// Broadcast the block on a feed to notify other services in the beacon node
 	// of a received block (even if it does not process correctly through a state transition).
-	r.blockNotifier.BlockFeed().Send(&feed.Event{
+	s.blockNotifier.BlockFeed().Send(&feed.Event{
 		Type: blockfeed.ReceivedBlock,
 		Data: &blockfeed.ReceivedBlockData{
 			SignedBlock: blk,
@@ -68,7 +68,7 @@ func (r *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 	})
 
 	// Verify the block is the first block received for the proposer for the slot.
-	if r.hasSeenBlockIndexSlot(blk.Block.Slot, blk.Block.ProposerIndex) {
+	if s.hasSeenBlockIndexSlot(blk.Block.Slot, blk.Block.ProposerIndex) {
 		return pubsub.ValidationIgnore
 	}
 
@@ -76,49 +76,49 @@ func (r *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 	if err != nil {
 		return pubsub.ValidationIgnore
 	}
-	if r.db.HasBlock(ctx, blockRoot) {
+	if s.db.HasBlock(ctx, blockRoot) {
 		return pubsub.ValidationIgnore
 	}
 
-	r.pendingQueueLock.RLock()
-	if r.seenPendingBlocks[blockRoot] {
-		r.pendingQueueLock.RUnlock()
+	s.pendingQueueLock.RLock()
+	if s.seenPendingBlocks[blockRoot] {
+		s.pendingQueueLock.RUnlock()
 		return pubsub.ValidationIgnore
 	}
-	r.pendingQueueLock.RUnlock()
+	s.pendingQueueLock.RUnlock()
 
 	// Add metrics for block arrival time subtracts slot start time.
-	if captureArrivalTimeMetric(uint64(r.chain.GenesisTime().Unix()), blk.Block.Slot) != nil {
+	if captureArrivalTimeMetric(uint64(s.chain.GenesisTime().Unix()), blk.Block.Slot) != nil {
 		return pubsub.ValidationIgnore
 	}
 
-	if err := helpers.VerifySlotTime(uint64(r.chain.GenesisTime().Unix()), blk.Block.Slot, params.BeaconNetworkConfig().MaximumGossipClockDisparity); err != nil {
+	if err := helpers.VerifySlotTime(uint64(s.chain.GenesisTime().Unix()), blk.Block.Slot, params.BeaconNetworkConfig().MaximumGossipClockDisparity); err != nil {
 		log.WithError(err).WithField("blockSlot", blk.Block.Slot).Warn("Rejecting incoming block.")
 		return pubsub.ValidationIgnore
 	}
 
-	if helpers.StartSlot(r.chain.FinalizedCheckpt().Epoch) >= blk.Block.Slot {
+	if helpers.StartSlot(s.chain.FinalizedCheckpt().Epoch) >= blk.Block.Slot {
 		log.Debug("Block slot older/equal than last finalized epoch start slot, rejecting it")
 		return pubsub.ValidationIgnore
 	}
 
 	// Handle block when the parent is unknown.
-	if !r.db.HasBlock(ctx, bytesutil.ToBytes32(blk.Block.ParentRoot)) {
-		r.pendingQueueLock.Lock()
-		r.slotToPendingBlocks[blk.Block.Slot] = blk
-		r.seenPendingBlocks[blockRoot] = true
-		r.pendingQueueLock.Unlock()
+	if !s.db.HasBlock(ctx, bytesutil.ToBytes32(blk.Block.ParentRoot)) {
+		s.pendingQueueLock.Lock()
+		s.slotToPendingBlocks[blk.Block.Slot] = blk
+		s.seenPendingBlocks[blockRoot] = true
+		s.pendingQueueLock.Unlock()
 		return pubsub.ValidationIgnore
 	}
 
 	if featureconfig.Get().NewStateMgmt {
-		hasStateSummaryDB := r.db.HasStateSummary(ctx, bytesutil.ToBytes32(blk.Block.ParentRoot))
-		hasStateSummaryCache := r.stateSummaryCache.Has(bytesutil.ToBytes32(blk.Block.ParentRoot))
+		hasStateSummaryDB := s.db.HasStateSummary(ctx, bytesutil.ToBytes32(blk.Block.ParentRoot))
+		hasStateSummaryCache := s.stateSummaryCache.Has(bytesutil.ToBytes32(blk.Block.ParentRoot))
 		if !hasStateSummaryDB && !hasStateSummaryCache {
 			log.WithError(err).WithField("blockSlot", blk.Block.Slot).Warn("No access to parent state")
 			return pubsub.ValidationIgnore
 		}
-		parentState, err := r.stateGen.StateByRoot(ctx, bytesutil.ToBytes32(blk.Block.ParentRoot))
+		parentState, err := s.stateGen.StateByRoot(ctx, bytesutil.ToBytes32(blk.Block.ParentRoot))
 		if err != nil {
 			log.WithError(err).WithField("blockSlot", blk.Block.Slot).Warn("Could not get parent state")
 			return pubsub.ValidationIgnore
@@ -150,20 +150,20 @@ func (r *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 }
 
 // Returns true if the block is not the first block proposed for the proposer for the slot.
-func (r *Service) hasSeenBlockIndexSlot(slot uint64, proposerIdx uint64) bool {
-	r.seenBlockLock.RLock()
-	defer r.seenBlockLock.RUnlock()
+func (s *Service) hasSeenBlockIndexSlot(slot uint64, proposerIdx uint64) bool {
+	s.seenBlockLock.RLock()
+	defer s.seenBlockLock.RUnlock()
 	b := append(bytesutil.Bytes32(slot), bytesutil.Bytes32(proposerIdx)...)
-	_, seen := r.seenBlockCache.Get(string(b))
+	_, seen := s.seenBlockCache.Get(string(b))
 	return seen
 }
 
 // Set block proposer index and slot as seen for incoming blocks.
-func (r *Service) setSeenBlockIndexSlot(slot uint64, proposerIdx uint64) {
-	r.seenBlockLock.Lock()
-	defer r.seenBlockLock.Unlock()
+func (s *Service) setSeenBlockIndexSlot(slot uint64, proposerIdx uint64) {
+	s.seenBlockLock.Lock()
+	defer s.seenBlockLock.Unlock()
 	b := append(bytesutil.Bytes32(slot), bytesutil.Bytes32(proposerIdx)...)
-	r.seenBlockCache.Add(string(b), true)
+	s.seenBlockCache.Add(string(b), true)
 }
 
 // This captures metrics for block arrival time by subtracts slot start time.

--- a/beacon-chain/sync/validate_proposer_slashing.go
+++ b/beacon-chain/sync/validate_proposer_slashing.go
@@ -14,22 +14,22 @@ import (
 
 // Clients who receive a proposer slashing on this topic MUST validate the conditions within VerifyProposerSlashing before
 // forwarding it across the network.
-func (r *Service) validateProposerSlashing(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
+func (s *Service) validateProposerSlashing(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
 	// Validation runs on publish (not just subscriptions), so we should approve any message from
 	// ourselves.
-	if pid == r.p2p.PeerID() {
+	if pid == s.p2p.PeerID() {
 		return pubsub.ValidationAccept
 	}
 
 	// The head state will be too far away to validate any slashing.
-	if r.initialSync.Syncing() {
+	if s.initialSync.Syncing() {
 		return pubsub.ValidationIgnore
 	}
 
 	ctx, span := trace.StartSpan(ctx, "sync.validateProposerSlashing")
 	defer span.End()
 
-	m, err := r.decodePubsubMessage(msg)
+	m, err := s.decodePubsubMessage(msg)
 	if err != nil {
 		log.WithError(err).Error("Failed to decode message")
 		traceutil.AnnotateError(span, err)
@@ -44,28 +44,28 @@ func (r *Service) validateProposerSlashing(ctx context.Context, pid peer.ID, msg
 	if slashing.Header_1 == nil || slashing.Header_1.Header == nil {
 		return pubsub.ValidationReject
 	}
-	if r.hasSeenProposerSlashingIndex(slashing.Header_1.Header.ProposerIndex) {
+	if s.hasSeenProposerSlashingIndex(slashing.Header_1.Header.ProposerIndex) {
 		return pubsub.ValidationIgnore
 	}
 
 	// Retrieve head state, advance state to the epoch slot used specified in slashing message.
-	s, err := r.chain.HeadState(ctx)
+	headState, err := s.chain.HeadState(ctx)
 	if err != nil {
 		return pubsub.ValidationIgnore
 	}
 	slashSlot := slashing.Header_1.Header.Slot
-	if s.Slot() < slashSlot {
+	if headState.Slot() < slashSlot {
 		if ctx.Err() != nil {
 			return pubsub.ValidationIgnore
 		}
 		var err error
-		s, err = state.ProcessSlots(ctx, s, slashSlot)
+		headState, err = state.ProcessSlots(ctx, headState, slashSlot)
 		if err != nil {
 			return pubsub.ValidationIgnore
 		}
 	}
 
-	if err := blocks.VerifyProposerSlashing(s, slashing); err != nil {
+	if err := blocks.VerifyProposerSlashing(headState, slashing); err != nil {
 		return pubsub.ValidationReject
 	}
 
@@ -74,16 +74,16 @@ func (r *Service) validateProposerSlashing(ctx context.Context, pid peer.ID, msg
 }
 
 // Returns true if the node has already received a valid proposer slashing received for the proposer with index
-func (r *Service) hasSeenProposerSlashingIndex(i uint64) bool {
-	r.seenProposerSlashingLock.RLock()
-	defer r.seenProposerSlashingLock.RUnlock()
-	_, seen := r.seenProposerSlashingCache.Get(i)
+func (s *Service) hasSeenProposerSlashingIndex(i uint64) bool {
+	s.seenProposerSlashingLock.RLock()
+	defer s.seenProposerSlashingLock.RUnlock()
+	_, seen := s.seenProposerSlashingCache.Get(i)
 	return seen
 }
 
 // Set proposer slashing index in proposer slashing cache.
-func (r *Service) setProposerSlashingIndexSeen(i uint64) {
-	r.seenProposerSlashingLock.Lock()
-	defer r.seenProposerSlashingLock.Unlock()
-	r.seenProposerSlashingCache.Add(i, true)
+func (s *Service) setProposerSlashingIndexSeen(i uint64) {
+	s.seenProposerSlashingLock.Lock()
+	defer s.seenProposerSlashingLock.Unlock()
+	s.seenProposerSlashingCache.Add(i, true)
 }

--- a/beacon-chain/sync/validate_voluntary_exit.go
+++ b/beacon-chain/sync/validate_voluntary_exit.go
@@ -14,22 +14,22 @@ import (
 
 // Clients who receive a voluntary exit on this topic MUST validate the conditions within process_voluntary_exit before
 // forwarding it across the network.
-func (r *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
+func (s *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
 	// Validation runs on publish (not just subscriptions), so we should approve any message from
 	// ourselves.
-	if pid == r.p2p.PeerID() {
+	if pid == s.p2p.PeerID() {
 		return pubsub.ValidationAccept
 	}
 
 	// The head state will be too far away to validate any voluntary exit.
-	if r.initialSync.Syncing() {
+	if s.initialSync.Syncing() {
 		return pubsub.ValidationIgnore
 	}
 
 	ctx, span := trace.StartSpan(ctx, "sync.validateVoluntaryExit")
 	defer span.End()
 
-	m, err := r.decodePubsubMessage(msg)
+	m, err := s.decodePubsubMessage(msg)
 	if err != nil {
 		log.WithError(err).Error("Failed to decode message")
 		traceutil.AnnotateError(span, err)
@@ -44,24 +44,24 @@ func (r *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *p
 	if exit.Exit == nil {
 		return pubsub.ValidationReject
 	}
-	if r.hasSeenExitIndex(exit.Exit.ValidatorIndex) {
+	if s.hasSeenExitIndex(exit.Exit.ValidatorIndex) {
 		return pubsub.ValidationIgnore
 	}
 
-	s, err := r.chain.HeadState(ctx)
+	headState, err := s.chain.HeadState(ctx)
 	if err != nil {
 		return pubsub.ValidationIgnore
 	}
 
 	exitedEpochSlot := exit.Exit.Epoch * params.BeaconConfig().SlotsPerEpoch
-	if int(exit.Exit.ValidatorIndex) >= s.NumValidators() {
+	if int(exit.Exit.ValidatorIndex) >= headState.NumValidators() {
 		return pubsub.ValidationReject
 	}
-	val, err := s.ValidatorAtIndexReadOnly(exit.Exit.ValidatorIndex)
+	val, err := headState.ValidatorAtIndexReadOnly(exit.Exit.ValidatorIndex)
 	if err != nil {
 		return pubsub.ValidationIgnore
 	}
-	if err := blocks.VerifyExit(val, exitedEpochSlot, s.Fork(), exit, s.GenesisValidatorRoot()); err != nil {
+	if err := blocks.VerifyExit(val, exitedEpochSlot, headState.Fork(), exit, headState.GenesisValidatorRoot()); err != nil {
 		return pubsub.ValidationReject
 	}
 
@@ -71,16 +71,16 @@ func (r *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *p
 }
 
 // Returns true if the node has already received a valid exit request for the validator with index `i`.
-func (r *Service) hasSeenExitIndex(i uint64) bool {
-	r.seenExitLock.RLock()
-	defer r.seenExitLock.RUnlock()
-	_, seen := r.seenExitCache.Get(i)
+func (s *Service) hasSeenExitIndex(i uint64) bool {
+	s.seenExitLock.RLock()
+	defer s.seenExitLock.RUnlock()
+	_, seen := s.seenExitCache.Get(i)
 	return seen
 }
 
 // Set exit request index `i` in seen exit request cache.
-func (r *Service) setExitIndexSeen(i uint64) {
-	r.seenExitLock.Lock()
-	defer r.seenExitLock.Unlock()
-	r.seenExitCache.Add(i, true)
+func (s *Service) setExitIndexSeen(i uint64) {
+	s.seenExitLock.Lock()
+	defer s.seenExitLock.Unlock()
+	s.seenExitCache.Add(i, true)
 }


### PR DESCRIPTION
**What type of PR is this?**

Other/Refactoring

**What does this PR do? Why is it needed?**
- in some places it was `r` in others `s`
- this PR, uses `s` as receiver name everywhere (it's short, it is consistent with what `init-sync` uses)
- having receiver as `service` (as suggested) - seems too verbose

**Which issues(s) does this PR fix?**

73 and 74 in https://github.com/prysmaticlabs/prysm/issues/6337

**Other notes for review**
