### PR TITLE
Fixes receiver name in db/kv

### DIFF
--- a/beacon-chain/db/kv/archive.go
+++ b/beacon-chain/db/kv/archive.go
@@ -12,13 +12,13 @@ import (
 )
 
 // ArchivedActiveValidatorChanges retrieval by epoch.
-func (k *Store) ArchivedActiveValidatorChanges(ctx context.Context, epoch uint64) (*pb.ArchivedActiveSetChanges, error) {
+func (kv *Store) ArchivedActiveValidatorChanges(ctx context.Context, epoch uint64) (*pb.ArchivedActiveSetChanges, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.ArchivedActiveValidatorChanges")
 	defer span.End()
 
 	buf := bytesutil.Uint64ToBytes(epoch)
 	var target *pb.ArchivedActiveSetChanges
-	err := k.db.View(func(tx *bolt.Tx) error {
+	err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(archivedValidatorSetChangesBucket)
 		enc := bkt.Get(buf)
 		if enc == nil {
@@ -31,7 +31,7 @@ func (k *Store) ArchivedActiveValidatorChanges(ctx context.Context, epoch uint64
 }
 
 // SaveArchivedActiveValidatorChanges by epoch.
-func (k *Store) SaveArchivedActiveValidatorChanges(ctx context.Context, epoch uint64, changes *pb.ArchivedActiveSetChanges) error {
+func (kv *Store) SaveArchivedActiveValidatorChanges(ctx context.Context, epoch uint64, changes *pb.ArchivedActiveSetChanges) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveArchivedActiveValidatorChanges")
 	defer span.End()
 	buf := bytesutil.Uint64ToBytes(epoch)
@@ -39,20 +39,20 @@ func (k *Store) SaveArchivedActiveValidatorChanges(ctx context.Context, epoch ui
 	if err != nil {
 		return err
 	}
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(archivedValidatorSetChangesBucket)
 		return bucket.Put(buf, enc)
 	})
 }
 
 // ArchivedCommitteeInfo retrieval by epoch.
-func (k *Store) ArchivedCommitteeInfo(ctx context.Context, epoch uint64) (*pb.ArchivedCommitteeInfo, error) {
+func (kv *Store) ArchivedCommitteeInfo(ctx context.Context, epoch uint64) (*pb.ArchivedCommitteeInfo, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.ArchivedCommitteeInfo")
 	defer span.End()
 
 	buf := bytesutil.Uint64ToBytes(epoch)
 	var target *pb.ArchivedCommitteeInfo
-	err := k.db.View(func(tx *bolt.Tx) error {
+	err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(archivedCommitteeInfoBucket)
 		enc := bkt.Get(buf)
 		if enc == nil {
@@ -65,7 +65,7 @@ func (k *Store) ArchivedCommitteeInfo(ctx context.Context, epoch uint64) (*pb.Ar
 }
 
 // SaveArchivedCommitteeInfo by epoch.
-func (k *Store) SaveArchivedCommitteeInfo(ctx context.Context, epoch uint64, info *pb.ArchivedCommitteeInfo) error {
+func (kv *Store) SaveArchivedCommitteeInfo(ctx context.Context, epoch uint64, info *pb.ArchivedCommitteeInfo) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveArchivedCommitteeInfo")
 	defer span.End()
 	buf := bytesutil.Uint64ToBytes(epoch)
@@ -73,20 +73,20 @@ func (k *Store) SaveArchivedCommitteeInfo(ctx context.Context, epoch uint64, inf
 	if err != nil {
 		return err
 	}
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(archivedCommitteeInfoBucket)
 		return bucket.Put(buf, enc)
 	})
 }
 
 // ArchivedBalances retrieval by epoch.
-func (k *Store) ArchivedBalances(ctx context.Context, epoch uint64) ([]uint64, error) {
+func (kv *Store) ArchivedBalances(ctx context.Context, epoch uint64) ([]uint64, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.ArchivedBalances")
 	defer span.End()
 
 	buf := bytesutil.Uint64ToBytes(epoch)
 	var target []uint64
-	err := k.db.View(func(tx *bolt.Tx) error {
+	err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(archivedBalancesBucket)
 		enc := bkt.Get(buf)
 		if enc == nil {
@@ -99,25 +99,25 @@ func (k *Store) ArchivedBalances(ctx context.Context, epoch uint64) ([]uint64, e
 }
 
 // SaveArchivedBalances by epoch.
-func (k *Store) SaveArchivedBalances(ctx context.Context, epoch uint64, balances []uint64) error {
+func (kv *Store) SaveArchivedBalances(ctx context.Context, epoch uint64, balances []uint64) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveArchivedBalances")
 	defer span.End()
 	buf := bytesutil.Uint64ToBytes(epoch)
 	enc := marshalBalances(ctx, balances)
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(archivedBalancesBucket)
 		return bucket.Put(buf, enc)
 	})
 }
 
 // ArchivedValidatorParticipation retrieval by epoch.
-func (k *Store) ArchivedValidatorParticipation(ctx context.Context, epoch uint64) (*ethpb.ValidatorParticipation, error) {
+func (kv *Store) ArchivedValidatorParticipation(ctx context.Context, epoch uint64) (*ethpb.ValidatorParticipation, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.ArchivedValidatorParticipation")
 	defer span.End()
 
 	buf := bytesutil.Uint64ToBytes(epoch)
 	var target *ethpb.ValidatorParticipation
-	err := k.db.View(func(tx *bolt.Tx) error {
+	err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(archivedValidatorParticipationBucket)
 		enc := bkt.Get(buf)
 		if enc == nil {
@@ -130,7 +130,7 @@ func (k *Store) ArchivedValidatorParticipation(ctx context.Context, epoch uint64
 }
 
 // SaveArchivedValidatorParticipation by epoch.
-func (k *Store) SaveArchivedValidatorParticipation(ctx context.Context, epoch uint64, part *ethpb.ValidatorParticipation) error {
+func (kv *Store) SaveArchivedValidatorParticipation(ctx context.Context, epoch uint64, part *ethpb.ValidatorParticipation) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveArchivedValidatorParticipation")
 	defer span.End()
 	buf := bytesutil.Uint64ToBytes(epoch)
@@ -138,7 +138,7 @@ func (k *Store) SaveArchivedValidatorParticipation(ctx context.Context, epoch ui
 	if err != nil {
 		return err
 	}
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(archivedValidatorParticipationBucket)
 		return bucket.Put(buf, enc)
 	})

--- a/beacon-chain/db/kv/archived_point.go
+++ b/beacon-chain/db/kv/archived_point.go
@@ -10,32 +10,32 @@ import (
 )
 
 // SaveArchivedPointRoot saves an archived point root to the DB. This is used for cold state management.
-func (k *Store) SaveArchivedPointRoot(ctx context.Context, blockRoot [32]byte, index uint64) error {
+func (kv *Store) SaveArchivedPointRoot(ctx context.Context, blockRoot [32]byte, index uint64) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveArchivedPointRoot")
 	defer span.End()
 
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(archivedIndexRootBucket)
 		return bucket.Put(bytesutil.Uint64ToBytes(index), blockRoot[:])
 	})
 }
 
 // SaveLastArchivedIndex to the db.
-func (k *Store) SaveLastArchivedIndex(ctx context.Context, index uint64) error {
+func (kv *Store) SaveLastArchivedIndex(ctx context.Context, index uint64) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveLastArchivedIndex")
 	defer span.End()
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(archivedIndexRootBucket)
 		return bucket.Put(lastArchivedIndexKey, bytesutil.Uint64ToBytes(index))
 	})
 }
 
 // LastArchivedIndex from the db.
-func (k *Store) LastArchivedIndex(ctx context.Context) (uint64, error) {
+func (kv *Store) LastArchivedIndex(ctx context.Context) (uint64, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.LastArchivedIndex")
 	defer span.End()
 	var index uint64
-	err := k.db.Update(func(tx *bolt.Tx) error {
+	err := kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(archivedIndexRootBucket)
 		b := bucket.Get(lastArchivedIndexKey)
 		if b == nil {
@@ -49,12 +49,12 @@ func (k *Store) LastArchivedIndex(ctx context.Context) (uint64, error) {
 }
 
 // LastArchivedIndexRoot from the db.
-func (k *Store) LastArchivedIndexRoot(ctx context.Context) [32]byte {
+func (kv *Store) LastArchivedIndexRoot(ctx context.Context) [32]byte {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.LastArchivedIndexRoot")
 	defer span.End()
 
 	var blockRoot []byte
-	if err := k.db.View(func(tx *bolt.Tx) error {
+	if err := kv.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(archivedIndexRootBucket)
 		lastArchivedIndex := bucket.Get(lastArchivedIndexKey)
 		if lastArchivedIndex == nil {
@@ -71,12 +71,12 @@ func (k *Store) LastArchivedIndexRoot(ctx context.Context) [32]byte {
 
 // ArchivedPointRoot returns the block root of an archived point from the DB.
 // This is essential for cold state management and to restore a cold state.
-func (k *Store) ArchivedPointRoot(ctx context.Context, index uint64) [32]byte {
+func (kv *Store) ArchivedPointRoot(ctx context.Context, index uint64) [32]byte {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.ArchivedPointRoot")
 	defer span.End()
 
 	var blockRoot []byte
-	if err := k.db.View(func(tx *bolt.Tx) error {
+	if err := kv.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(archivedIndexRootBucket)
 		blockRoot = bucket.Get(bytesutil.Uint64ToBytes(index))
 		return nil
@@ -88,11 +88,11 @@ func (k *Store) ArchivedPointRoot(ctx context.Context, index uint64) [32]byte {
 }
 
 // HasArchivedPoint returns true if an archived point exists in DB.
-func (k *Store) HasArchivedPoint(ctx context.Context, index uint64) bool {
+func (kv *Store) HasArchivedPoint(ctx context.Context, index uint64) bool {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasArchivedPoint")
 	defer span.End()
 	var exists bool
-	if err := k.db.View(func(tx *bolt.Tx) error {
+	if err := kv.db.View(func(tx *bolt.Tx) error {
 		iBucket := tx.Bucket(archivedIndexRootBucket)
 		exists = iBucket.Get(bytesutil.Uint64ToBytes(index)) != nil
 		return nil

--- a/beacon-chain/db/kv/backup.go
+++ b/beacon-chain/db/kv/backup.go
@@ -16,12 +16,12 @@ const backupsDirectoryName = "backups"
 
 // Backup the database to the datadir backup directory.
 // Example for backup at slot 345: $DATADIR/backups/prysm_beacondb_at_slot_0000345.backup
-func (k *Store) Backup(ctx context.Context) error {
+func (kv *Store) Backup(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.Backup")
 	defer span.End()
 
-	backupsDir := path.Join(k.databasePath, backupsDirectoryName)
-	head, err := k.HeadBlock(ctx)
+	backupsDir := path.Join(kv.databasePath, backupsDirectoryName)
+	head, err := kv.HeadBlock(ctx)
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func (k *Store) Backup(ctx context.Context) error {
 		}
 	}()
 
-	return k.db.View(func(tx *bolt.Tx) error {
+	return kv.db.View(func(tx *bolt.Tx) error {
 		return tx.ForEach(func(name []byte, b *bolt.Bucket) error {
 			logrus.Debugf("Copying bucket %s\n", name)
 			return copyDB.Update(func(tx2 *bolt.Tx) error {

--- a/beacon-chain/db/kv/deposit_contract.go
+++ b/beacon-chain/db/kv/deposit_contract.go
@@ -11,11 +11,11 @@ import (
 
 // DepositContractAddress returns contract address is the address of
 // the deposit contract on the proof of work chain.
-func (k *Store) DepositContractAddress(ctx context.Context) ([]byte, error) {
+func (kv *Store) DepositContractAddress(ctx context.Context) ([]byte, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DepositContractAddress")
 	defer span.End()
 	var addr []byte
-	if err := k.db.View(func(tx *bolt.Tx) error {
+	if err := kv.db.View(func(tx *bolt.Tx) error {
 		chainInfo := tx.Bucket(chainMetadataBucket)
 		addr = chainInfo.Get(depositContractAddressKey)
 		return nil
@@ -26,11 +26,11 @@ func (k *Store) DepositContractAddress(ctx context.Context) ([]byte, error) {
 }
 
 // SaveDepositContractAddress to the db. It returns an error if an address has been previously saved.
-func (k *Store) SaveDepositContractAddress(ctx context.Context, addr common.Address) error {
+func (kv *Store) SaveDepositContractAddress(ctx context.Context, addr common.Address) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.VerifyContractAddress")
 	defer span.End()
 
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		chainInfo := tx.Bucket(chainMetadataBucket)
 		expectedAddress := chainInfo.Get(depositContractAddressKey)
 		if expectedAddress != nil {

--- a/beacon-chain/db/kv/finalized_block_roots.go
+++ b/beacon-chain/db/kv/finalized_block_roots.go
@@ -37,7 +37,7 @@ var containerFinalizedButNotCanonical = []byte("recent block needs reindexing to
 //
 // This method ensures that all blocks from the current finalized epoch are considered "final" while
 // maintaining only canonical and finalized blocks older than the current finalized epoch.
-func (k *Store) updateFinalizedBlockRoots(ctx context.Context, tx *bolt.Tx, checkpoint *ethpb.Checkpoint) error {
+func (kv *Store) updateFinalizedBlockRoots(ctx context.Context, tx *bolt.Tx, checkpoint *ethpb.Checkpoint) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.updateFinalizedBlockRoots")
 	defer span.End()
 
@@ -56,7 +56,7 @@ func (k *Store) updateFinalizedBlockRoots(ctx context.Context, tx *bolt.Tx, chec
 		}
 	}
 
-	blockRoots, err := k.BlockRoots(ctx, filters.NewFilter().
+	blockRoots, err := kv.BlockRoots(ctx, filters.NewFilter().
 		SetStartEpoch(previousFinalizedCheckpoint.Epoch).
 		SetEndEpoch(checkpoint.Epoch+1),
 	)
@@ -78,7 +78,7 @@ func (k *Store) updateFinalizedBlockRoots(ctx context.Context, tx *bolt.Tx, chec
 			break
 		}
 
-		signedBlock, err := k.Block(ctx, bytesutil.ToBytes32(root))
+		signedBlock, err := kv.Block(ctx, bytesutil.ToBytes32(root))
 		if err != nil {
 			traceutil.AnnotateError(span, err)
 			return err
@@ -129,7 +129,7 @@ func (k *Store) updateFinalizedBlockRoots(ctx context.Context, tx *bolt.Tx, chec
 	}
 
 	// Upsert blocks from the current finalized epoch.
-	roots, err := k.BlockRoots(ctx, filters.NewFilter().SetStartEpoch(checkpoint.Epoch).SetEndEpoch(checkpoint.Epoch+1))
+	roots, err := kv.BlockRoots(ctx, filters.NewFilter().SetStartEpoch(checkpoint.Epoch).SetEndEpoch(checkpoint.Epoch+1))
 	if err != nil {
 		traceutil.AnnotateError(span, err)
 		return err
@@ -159,12 +159,12 @@ func (k *Store) updateFinalizedBlockRoots(ctx context.Context, tx *bolt.Tx, chec
 // A beacon block root contained exists in this index if it is considered finalized and canonical.
 // Note: beacon blocks from the latest finalized epoch return true, whether or not they are
 // considered canonical in the "head view" of the beacon node.
-func (k *Store) IsFinalizedBlock(ctx context.Context, blockRoot [32]byte) bool {
+func (kv *Store) IsFinalizedBlock(ctx context.Context, blockRoot [32]byte) bool {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.IsFinalizedBlock")
 	defer span.End()
 
 	var exists bool
-	err := k.db.View(func(tx *bolt.Tx) error {
+	err := kv.db.View(func(tx *bolt.Tx) error {
 		exists = tx.Bucket(finalizedBlockRootsIndexBucket).Get(blockRoot[:]) != nil
 		// Check genesis block root.
 		if !exists {

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -127,26 +127,26 @@ func NewKVStore(dirPath string, stateSummaryCache *cache.StateSummaryCache) (*St
 }
 
 // ClearDB removes the previously stored database in the data directory.
-func (k *Store) ClearDB() error {
-	if _, err := os.Stat(k.databasePath); os.IsNotExist(err) {
+func (kv *Store) ClearDB() error {
+	if _, err := os.Stat(kv.databasePath); os.IsNotExist(err) {
 		return nil
 	}
-	prometheus.Unregister(createBoltCollector(k.db))
-	if err := os.Remove(path.Join(k.databasePath, databaseFileName)); err != nil {
+	prometheus.Unregister(createBoltCollector(kv.db))
+	if err := os.Remove(path.Join(kv.databasePath, databaseFileName)); err != nil {
 		return errors.Wrap(err, "could not remove database file")
 	}
 	return nil
 }
 
 // Close closes the underlying BoltDB database.
-func (k *Store) Close() error {
-	prometheus.Unregister(createBoltCollector(k.db))
-	return k.db.Close()
+func (kv *Store) Close() error {
+	prometheus.Unregister(createBoltCollector(kv.db))
+	return kv.db.Close()
 }
 
 // DatabasePath at which this database writes files.
-func (k *Store) DatabasePath() string {
-	return k.databasePath
+func (kv *Store) DatabasePath() string {
+	return kv.databasePath
 }
 
 func createBuckets(tx *bolt.Tx, buckets ...[]byte) error {

--- a/beacon-chain/db/kv/operations.go
+++ b/beacon-chain/db/kv/operations.go
@@ -10,11 +10,11 @@ import (
 )
 
 // VoluntaryExit retrieval by signing root.
-func (k *Store) VoluntaryExit(ctx context.Context, exitRoot [32]byte) (*ethpb.VoluntaryExit, error) {
+func (kv *Store) VoluntaryExit(ctx context.Context, exitRoot [32]byte) (*ethpb.VoluntaryExit, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.VoluntaryExit")
 	defer span.End()
 	var exit *ethpb.VoluntaryExit
-	err := k.db.View(func(tx *bolt.Tx) error {
+	err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(voluntaryExitsBucket)
 		enc := bkt.Get(exitRoot[:])
 		if enc == nil {
@@ -27,11 +27,11 @@ func (k *Store) VoluntaryExit(ctx context.Context, exitRoot [32]byte) (*ethpb.Vo
 }
 
 // HasVoluntaryExit verifies if a voluntary exit is stored in the db by its signing root.
-func (k *Store) HasVoluntaryExit(ctx context.Context, exitRoot [32]byte) bool {
+func (kv *Store) HasVoluntaryExit(ctx context.Context, exitRoot [32]byte) bool {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasVoluntaryExit")
 	defer span.End()
 	exists := false
-	if err := k.db.View(func(tx *bolt.Tx) error {
+	if err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(voluntaryExitsBucket)
 		exists = bkt.Get(exitRoot[:]) != nil
 		return nil
@@ -42,7 +42,7 @@ func (k *Store) HasVoluntaryExit(ctx context.Context, exitRoot [32]byte) bool {
 }
 
 // SaveVoluntaryExit to the db by its signing root.
-func (k *Store) SaveVoluntaryExit(ctx context.Context, exit *ethpb.VoluntaryExit) error {
+func (kv *Store) SaveVoluntaryExit(ctx context.Context, exit *ethpb.VoluntaryExit) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveVoluntaryExit")
 	defer span.End()
 	exitRoot, err := ssz.HashTreeRoot(exit)
@@ -53,17 +53,17 @@ func (k *Store) SaveVoluntaryExit(ctx context.Context, exit *ethpb.VoluntaryExit
 	if err != nil {
 		return err
 	}
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(voluntaryExitsBucket)
 		return bucket.Put(exitRoot[:], enc)
 	})
 }
 
 // DeleteVoluntaryExit clears a voluntary exit from the db by its signing root.
-func (k *Store) DeleteVoluntaryExit(ctx context.Context, exitRoot [32]byte) error {
+func (kv *Store) DeleteVoluntaryExit(ctx context.Context, exitRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteVoluntaryExit")
 	defer span.End()
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(voluntaryExitsBucket)
 		return bucket.Delete(exitRoot[:])
 	})

--- a/beacon-chain/db/kv/powchain.go
+++ b/beacon-chain/db/kv/powchain.go
@@ -10,11 +10,11 @@ import (
 )
 
 // SavePowchainData saves the pow chain data.
-func (k *Store) SavePowchainData(ctx context.Context, data *db.ETH1ChainData) error {
+func (kv *Store) SavePowchainData(ctx context.Context, data *db.ETH1ChainData) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SavePowchainData")
 	defer span.End()
 
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(powchainBucket)
 		enc, err := proto.Marshal(data)
 		if err != nil {
@@ -25,12 +25,12 @@ func (k *Store) SavePowchainData(ctx context.Context, data *db.ETH1ChainData) er
 }
 
 // PowchainData retrieves the powchain data.
-func (k *Store) PowchainData(ctx context.Context) (*db.ETH1ChainData, error) {
+func (kv *Store) PowchainData(ctx context.Context) (*db.ETH1ChainData, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.PowchainData")
 	defer span.End()
 
 	var data *db.ETH1ChainData
-	err := k.db.View(func(tx *bolt.Tx) error {
+	err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(powchainBucket)
 		enc := bkt.Get(powchainDataKey)
 		if len(enc) == 0 {

--- a/beacon-chain/db/kv/slashings.go
+++ b/beacon-chain/db/kv/slashings.go
@@ -10,11 +10,11 @@ import (
 )
 
 // ProposerSlashing retrieval by slashing root.
-func (k *Store) ProposerSlashing(ctx context.Context, slashingRoot [32]byte) (*ethpb.ProposerSlashing, error) {
+func (kv *Store) ProposerSlashing(ctx context.Context, slashingRoot [32]byte) (*ethpb.ProposerSlashing, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.ProposerSlashing")
 	defer span.End()
 	var slashing *ethpb.ProposerSlashing
-	err := k.db.View(func(tx *bolt.Tx) error {
+	err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(proposerSlashingsBucket)
 		enc := bkt.Get(slashingRoot[:])
 		if enc == nil {
@@ -27,11 +27,11 @@ func (k *Store) ProposerSlashing(ctx context.Context, slashingRoot [32]byte) (*e
 }
 
 // HasProposerSlashing verifies if a slashing is stored in the db.
-func (k *Store) HasProposerSlashing(ctx context.Context, slashingRoot [32]byte) bool {
+func (kv *Store) HasProposerSlashing(ctx context.Context, slashingRoot [32]byte) bool {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasProposerSlashing")
 	defer span.End()
 	exists := false
-	if err := k.db.View(func(tx *bolt.Tx) error {
+	if err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(proposerSlashingsBucket)
 		exists = bkt.Get(slashingRoot[:]) != nil
 		return nil
@@ -42,7 +42,7 @@ func (k *Store) HasProposerSlashing(ctx context.Context, slashingRoot [32]byte) 
 }
 
 // SaveProposerSlashing to the db by its hash tree root.
-func (k *Store) SaveProposerSlashing(ctx context.Context, slashing *ethpb.ProposerSlashing) error {
+func (kv *Store) SaveProposerSlashing(ctx context.Context, slashing *ethpb.ProposerSlashing) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveProposerSlashing")
 	defer span.End()
 	slashingRoot, err := ssz.HashTreeRoot(slashing)
@@ -53,28 +53,28 @@ func (k *Store) SaveProposerSlashing(ctx context.Context, slashing *ethpb.Propos
 	if err != nil {
 		return err
 	}
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(proposerSlashingsBucket)
 		return bucket.Put(slashingRoot[:], enc)
 	})
 }
 
 // DeleteProposerSlashing clears a proposer slashing from the db by its hash tree root.
-func (k *Store) DeleteProposerSlashing(ctx context.Context, slashingRoot [32]byte) error {
+func (kv *Store) DeleteProposerSlashing(ctx context.Context, slashingRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteProposerSlashing")
 	defer span.End()
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(proposerSlashingsBucket)
 		return bucket.Delete(slashingRoot[:])
 	})
 }
 
 // AttesterSlashing retrieval by hash tree root.
-func (k *Store) AttesterSlashing(ctx context.Context, slashingRoot [32]byte) (*ethpb.AttesterSlashing, error) {
+func (kv *Store) AttesterSlashing(ctx context.Context, slashingRoot [32]byte) (*ethpb.AttesterSlashing, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.AttesterSlashing")
 	defer span.End()
 	var slashing *ethpb.AttesterSlashing
-	err := k.db.View(func(tx *bolt.Tx) error {
+	err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(attesterSlashingsBucket)
 		enc := bkt.Get(slashingRoot[:])
 		if enc == nil {
@@ -87,11 +87,11 @@ func (k *Store) AttesterSlashing(ctx context.Context, slashingRoot [32]byte) (*e
 }
 
 // HasAttesterSlashing verifies if a slashing is stored in the db.
-func (k *Store) HasAttesterSlashing(ctx context.Context, slashingRoot [32]byte) bool {
+func (kv *Store) HasAttesterSlashing(ctx context.Context, slashingRoot [32]byte) bool {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasAttesterSlashing")
 	defer span.End()
 	exists := false
-	if err := k.db.View(func(tx *bolt.Tx) error {
+	if err := kv.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(attesterSlashingsBucket)
 		exists = bkt.Get(slashingRoot[:]) != nil
 		return nil
@@ -102,7 +102,7 @@ func (k *Store) HasAttesterSlashing(ctx context.Context, slashingRoot [32]byte) 
 }
 
 // SaveAttesterSlashing to the db by its hash tree root.
-func (k *Store) SaveAttesterSlashing(ctx context.Context, slashing *ethpb.AttesterSlashing) error {
+func (kv *Store) SaveAttesterSlashing(ctx context.Context, slashing *ethpb.AttesterSlashing) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveAttesterSlashing")
 	defer span.End()
 	slashingRoot, err := ssz.HashTreeRoot(slashing)
@@ -113,17 +113,17 @@ func (k *Store) SaveAttesterSlashing(ctx context.Context, slashing *ethpb.Attest
 	if err != nil {
 		return err
 	}
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(attesterSlashingsBucket)
 		return bucket.Put(slashingRoot[:], enc)
 	})
 }
 
 // DeleteAttesterSlashing clears an attester slashing from the db by its hash tree root.
-func (k *Store) DeleteAttesterSlashing(ctx context.Context, slashingRoot [32]byte) error {
+func (kv *Store) DeleteAttesterSlashing(ctx context.Context, slashingRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteAttesterSlashing")
 	defer span.End()
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(attesterSlashingsBucket)
 		return bucket.Delete(slashingRoot[:])
 	})

--- a/beacon-chain/db/kv/state_summary.go
+++ b/beacon-chain/db/kv/state_summary.go
@@ -9,7 +9,7 @@ import (
 )
 
 // SaveStateSummary saves a state summary object to the DB.
-func (k *Store) SaveStateSummary(ctx context.Context, summary *pb.StateSummary) error {
+func (kv *Store) SaveStateSummary(ctx context.Context, summary *pb.StateSummary) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveStateSummary")
 	defer span.End()
 
@@ -17,18 +17,18 @@ func (k *Store) SaveStateSummary(ctx context.Context, summary *pb.StateSummary) 
 	if err != nil {
 		return err
 	}
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(stateSummaryBucket)
 		return bucket.Put(summary.Root, enc)
 	})
 }
 
 // SaveStateSummaries saves state summary objects to the DB.
-func (k *Store) SaveStateSummaries(ctx context.Context, summaries []*pb.StateSummary) error {
+func (kv *Store) SaveStateSummaries(ctx context.Context, summaries []*pb.StateSummary) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveStateSummaries")
 	defer span.End()
 
-	return k.db.Update(func(tx *bolt.Tx) error {
+	return kv.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(stateSummaryBucket)
 		for _, summary := range summaries {
 			enc, err := encode(summary)
@@ -44,12 +44,12 @@ func (k *Store) SaveStateSummaries(ctx context.Context, summaries []*pb.StateSum
 }
 
 // StateSummary returns the state summary object from the db using input block root.
-func (k *Store) StateSummary(ctx context.Context, blockRoot [32]byte) (*pb.StateSummary, error) {
+func (kv *Store) StateSummary(ctx context.Context, blockRoot [32]byte) (*pb.StateSummary, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.StateSummary")
 	defer span.End()
 
 	var summary *pb.StateSummary
-	err := k.db.View(func(tx *bolt.Tx) error {
+	err := kv.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(stateSummaryBucket)
 		enc := bucket.Get(blockRoot[:])
 		if enc == nil {
@@ -63,11 +63,11 @@ func (k *Store) StateSummary(ctx context.Context, blockRoot [32]byte) (*pb.State
 }
 
 // HasStateSummary returns true if a state summary exists in DB.
-func (k *Store) HasStateSummary(ctx context.Context, blockRoot [32]byte) bool {
+func (kv *Store) HasStateSummary(ctx context.Context, blockRoot [32]byte) bool {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasStateSummary")
 	defer span.End()
 	var exists bool
-	if err := k.db.View(func(tx *bolt.Tx) error {
+	if err := kv.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(stateSummaryBucket)
 		exists = bucket.Get(blockRoot[:]) != nil
 		return nil


### PR DESCRIPTION


**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
- in `db/kv` in some places `k` was used as receiver, in others `kv`
- this PR makes `kv` the receiver, everywhere (it is short, but not too short, stands for key-value)


**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- item 60 in https://github.com/prysmaticlabs/prysm/issues/6337
