### PR TITLE
Resolves issues from the best practices in sync package

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -333,12 +333,12 @@ func (f *blocksFetcher) fetchBlocksFromPeers(
 
 		// If the count was divided by an odd number of peers, there will be some blocks
 		// missing from the first requests so we accommodate that scenario.
-		count := perPeerCount
+		peerCount := perPeerCount
 		if i < remainder {
-			count++
+			peerCount++
 		}
 		// Asking for no blocks may cause the client to hang.
-		if count == 0 {
+		if peerCount == 0 {
 			p2pRequests.Done()
 			continue
 		}
@@ -346,7 +346,7 @@ func (f *blocksFetcher) fetchBlocksFromPeers(
 		go func(ctx context.Context, pid peer.ID) {
 			defer p2pRequests.Done()
 
-			blocks, err := f.requestBeaconBlocksByRange(ctx, pid, root, start, step, count)
+			blocks, err := f.requestBeaconBlocksByRange(ctx, pid, root, start, step, peerCount)
 			if err != nil {
 				select {
 				case <-ctx.Done():

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -283,7 +283,6 @@ func (q *blocksQueue) onReadyToSendEvent(ctx context.Context) eventHandlerFn {
 				switch fsm.state {
 				case stateNew, stateScheduled, stateDataParsed:
 					return m.state, nil
-				default:
 				}
 			}
 		}

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -3,7 +3,6 @@ package sync
 import (
 	"context"
 	"encoding/hex"
-	"sync"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/pkg/errors"
@@ -27,13 +26,10 @@ var processPendingAttsPeriod = slotutil.DivideSlotBy(2 /* twice per slot */)
 // This processes pending attestation queues on every `processPendingAttsPeriod`.
 func (s *Service) processPendingAttsQueue() {
 	ctx := context.Background()
-	mutex := new(sync.Mutex)
 	runutil.RunEvery(s.ctx, processPendingAttsPeriod, func() {
-		mutex.Lock()
 		if err := s.processPendingAtts(ctx); err != nil {
 			log.WithError(err).Errorf("Could not process pending attestation: %v", err)
 		}
-		mutex.Unlock()
 	})
 }
 

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"sort"
-	"sync"
 
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -24,13 +23,10 @@ var processPendingBlocksPeriod = slotutil.DivideSlotBy(3 /* times per slot */)
 // processes pending blocks queue on every processPendingBlocksPeriod
 func (s *Service) processPendingBlocksQueue() {
 	ctx := context.Background()
-	locker := new(sync.Mutex)
 	runutil.RunEvery(s.ctx, processPendingBlocksPeriod, func() {
-		locker.Lock()
 		if err := s.processPendingBlocks(ctx); err != nil {
 			log.WithError(err).Error("Failed to process pending blocks")
 		}
-		locker.Unlock()
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
Fixes:
- **Issue 37:** In beacon-chain/sync/initial-sync/block_fetcher.go#269, the name count is reused (previously used as a name of of the argument). We recommend using different names.
- **Issue 38** In beacon-chain/sync/initial-sync/blocks_queue.go#310, there is a switch statement with an empty default label. Some logging/comment would be handy.
- **Issue 75:** In beacon-chain/sync/pending_blocks_queue.go, lock/unlock in processPendingBlocksQueue() is not required, as the internal function execution never overlaps with itself.
- **Issue 76:** In beacon-chain/sync/pending_attestations_queue.go, lock/unlock in processPendingAttsQueue() is not required, as the internal function execution never overlaps with itself.

**Which issues(s) does this PR fix?**

Part of #6337 

**Other notes for review**

