### PR TITLE
SubscribeCommitteeSubnets fields length check

### DIFF
--- a/beacon-chain/rpc/validator/attester.go
+++ b/beacon-chain/rpc/validator/attester.go
@@ -194,7 +194,7 @@ func (vs *Server) SubscribeCommitteeSubnets(ctx context.Context, req *ethpb.Comm
 	ctx, span := trace.StartSpan(ctx, "AttesterServer.SubscribeCommitteeSubnets")
 	defer span.End()
 
-	if len(req.Slots) != len(req.CommitteeIds) && len(req.CommitteeIds) != len(req.IsAggregator) {
+	if len(req.Slots) != len(req.CommitteeIds) || len(req.CommitteeIds) != len(req.IsAggregator) {
 		return nil, status.Error(codes.InvalidArgument, "request fields are not the same length")
 	}
 	if len(req.Slots) == 0 {


### PR DESCRIPTION
A case where `len(req.Slots) != len(req.CommitteeIds)` but `len(req.CommitteeIds) == len(req.IsAggregator)`
should also throw an error. Without this fix only 2 length inequalities will throw the error.

Greetings from PwC Switzerland

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

Unexpected runtime error can be thrown

**Which issues(s) does this PR fix?**

Fixes #

A case where `len(req.Slots) != len(req.CommitteeIds)` but `len(req.CommitteeIds) == len(req.IsAggregator)`
should also throw an error. Without this fix only 2 length inequalities will throw the error.

**Other notes for review**

A test case should be added to cover the cse where 
`len(req.Slots) != len(req.CommitteeIds)` but `len(req.CommitteeIds) == len(req.IsAggregator)`