### PR TITLE
QSP-42 Remove Double Unsubscribe in Initial Sync

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -80,7 +80,6 @@ func (s *Service) Start() {
 		// Wait for state to be initialized.
 		stateChannel := make(chan *feed.Event, 1)
 		stateSub := s.stateNotifier.StateFeed().Subscribe(stateChannel)
-		defer stateSub.Unsubscribe()
 		genesisSet := false
 		for !genesisSet {
 			select {
@@ -97,10 +96,10 @@ func (s *Service) Start() {
 				}
 			case <-s.ctx.Done():
 				log.Debug("Context closed, exiting goroutine")
-				return
+				break
 			case err := <-stateSub.Err():
 				log.WithError(err).Error("Subscription to state notifier failed")
-				return
+				break
 			}
 		}
 		stateSub.Unsubscribe()

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -80,8 +80,7 @@ func (s *Service) Start() {
 		// Wait for state to be initialized.
 		stateChannel := make(chan *feed.Event, 1)
 		stateSub := s.stateNotifier.StateFeed().Subscribe(stateChannel)
-		genesisSet := false
-		for !genesisSet {
+		for genesisSet := false; !genesisSet; {
 			select {
 			case event := <-stateChannel:
 				if event.Type == statefeed.Initialized {


### PR DESCRIPTION
Part of #6327, removes a call to double unsubscribe from a feed in initial-sync/service.go