### PR TITLE
Refactor setupDB to return the state summary cache used by the database

### DIFF
--- a/beacon-chain/archiver/service_test.go
+++ b/beacon-chain/archiver/service_test.go
@@ -436,7 +436,7 @@ func setupState(validatorCount uint64) (*stateTrie.BeaconState, error) {
 }
 
 func setupService(t *testing.T) (*Service, db.Database) {
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	validatorCount := uint64(100)
 	totalBalance := validatorCount * params.BeaconConfig().MaxEffectiveBalance

--- a/beacon-chain/blockchain/chain_info_norace_test.go
+++ b/beacon-chain/blockchain/chain_info_norace_test.go
@@ -5,13 +5,12 @@ import (
 	"testing"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
 )
 
 func TestHeadSlot_DataRace(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	s := &Service{
 		beaconDB: db,
 	}
@@ -24,11 +23,11 @@ func TestHeadSlot_DataRace(t *testing.T) {
 }
 
 func TestHeadRoot_DataRace(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 	s := &Service{
 		beaconDB: db,
 		head:     &head{root: [32]byte{'A'}},
-		stateGen: stategen.New(db, cache.NewStateSummaryCache()),
+		stateGen: stategen.New(db, sc),
 	}
 	go func() {
 		if err := s.saveHead(context.Background(), [32]byte{}); err != nil {
@@ -41,11 +40,11 @@ func TestHeadRoot_DataRace(t *testing.T) {
 }
 
 func TestHeadBlock_DataRace(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 	s := &Service{
 		beaconDB: db,
 		head:     &head{block: &ethpb.SignedBeaconBlock{}},
-		stateGen: stategen.New(db, cache.NewStateSummaryCache()),
+		stateGen: stategen.New(db, sc),
 	}
 	go func() {
 		if err := s.saveHead(context.Background(), [32]byte{}); err != nil {
@@ -58,10 +57,10 @@ func TestHeadBlock_DataRace(t *testing.T) {
 }
 
 func TestHeadState_DataRace(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 	s := &Service{
 		beaconDB: db,
-		stateGen: stategen.New(db, cache.NewStateSummaryCache()),
+		stateGen: stategen.New(db, sc),
 	}
 	go func() {
 		if err := s.saveHead(context.Background(), [32]byte{}); err != nil {

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -21,16 +21,16 @@ var _ = TimeFetcher(&Service{})
 var _ = ForkFetcher(&Service{})
 
 func TestFinalizedCheckpt_Nil(t *testing.T) {
-	db := testDB.SetupDB(t)
-	c := setupBeaconChain(t, db)
+	db, sc := testDB.SetupDB(t)
+	c := setupBeaconChain(t, db, sc)
 	if !bytes.Equal(c.FinalizedCheckpt().Root, params.BeaconConfig().ZeroHash[:]) {
 		t.Error("Incorrect pre chain start value")
 	}
 }
 
 func TestHeadRoot_Nil(t *testing.T) {
-	db := testDB.SetupDB(t)
-	c := setupBeaconChain(t, db)
+	db, sc := testDB.SetupDB(t)
+	c := setupBeaconChain(t, db, sc)
 	headRoot, err := c.HeadRoot(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -41,10 +41,10 @@ func TestHeadRoot_Nil(t *testing.T) {
 }
 
 func TestFinalizedCheckpt_CanRetrieve(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 
 	cp := &ethpb.Checkpoint{Epoch: 5, Root: []byte("foo")}
-	c := setupBeaconChain(t, db)
+	c := setupBeaconChain(t, db, sc)
 	c.finalizedCheckpt = cp
 
 	if c.FinalizedCheckpt().Epoch != cp.Epoch {
@@ -53,11 +53,11 @@ func TestFinalizedCheckpt_CanRetrieve(t *testing.T) {
 }
 
 func TestFinalizedCheckpt_GenesisRootOk(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 
 	genesisRoot := [32]byte{'A'}
 	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}
-	c := setupBeaconChain(t, db)
+	c := setupBeaconChain(t, db, sc)
 	c.finalizedCheckpt = cp
 	c.genesisRoot = genesisRoot
 
@@ -67,10 +67,10 @@ func TestFinalizedCheckpt_GenesisRootOk(t *testing.T) {
 }
 
 func TestCurrentJustifiedCheckpt_CanRetrieve(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 
 	cp := &ethpb.Checkpoint{Epoch: 6, Root: []byte("foo")}
-	c := setupBeaconChain(t, db)
+	c := setupBeaconChain(t, db, sc)
 	c.justifiedCheckpt = cp
 
 	if c.CurrentJustifiedCheckpt().Epoch != cp.Epoch {
@@ -79,11 +79,11 @@ func TestCurrentJustifiedCheckpt_CanRetrieve(t *testing.T) {
 }
 
 func TestJustifiedCheckpt_GenesisRootOk(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 
 	genesisRoot := [32]byte{'B'}
 	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}
-	c := setupBeaconChain(t, db)
+	c := setupBeaconChain(t, db, sc)
 	c.justifiedCheckpt = cp
 	c.genesisRoot = genesisRoot
 
@@ -93,10 +93,10 @@ func TestJustifiedCheckpt_GenesisRootOk(t *testing.T) {
 }
 
 func TestPreviousJustifiedCheckpt_CanRetrieve(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 
 	cp := &ethpb.Checkpoint{Epoch: 7, Root: []byte("foo")}
-	c := setupBeaconChain(t, db)
+	c := setupBeaconChain(t, db, sc)
 	c.prevJustifiedCheckpt = cp
 
 	if c.PreviousJustifiedCheckpt().Epoch != cp.Epoch {
@@ -105,11 +105,11 @@ func TestPreviousJustifiedCheckpt_CanRetrieve(t *testing.T) {
 }
 
 func TestPrevJustifiedCheckpt_GenesisRootOk(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 
 	genesisRoot := [32]byte{'C'}
 	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}
-	c := setupBeaconChain(t, db)
+	c := setupBeaconChain(t, db, sc)
 	c.prevJustifiedCheckpt = cp
 	c.genesisRoot = genesisRoot
 
@@ -212,8 +212,8 @@ func TestGenesisValidatorRoot_CanRetrieve(t *testing.T) {
 }
 
 func TestHeadETH1Data_Nil(t *testing.T) {
-	db := testDB.SetupDB(t)
-	c := setupBeaconChain(t, db)
+	db, sc := testDB.SetupDB(t)
+	c := setupBeaconChain(t, db, sc)
 	if !reflect.DeepEqual(c.HeadETH1Data(), &ethpb.Eth1Data{}) {
 		t.Error("Incorrect pre chain start value")
 	}

--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestSaveHead_Same(t *testing.T) {
-	db := testDB.SetupDB(t)
-	service := setupBeaconChain(t, db)
+	db, sc := testDB.SetupDB(t)
+	service := setupBeaconChain(t, db, sc)
 
 	r := [32]byte{'A'}
 	service.head = &head{slot: 0, root: r}
@@ -35,8 +35,8 @@ func TestSaveHead_Same(t *testing.T) {
 }
 
 func TestSaveHead_Different(t *testing.T) {
-	db := testDB.SetupDB(t)
-	service := setupBeaconChain(t, db)
+	db, sc := testDB.SetupDB(t)
+	service := setupBeaconChain(t, db, sc)
 
 	oldRoot := [32]byte{'A'}
 	service.head = &head{slot: 0, root: oldRoot}
@@ -86,8 +86,8 @@ func TestSaveHead_Different(t *testing.T) {
 
 func TestSaveHead_Different_Reorg(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := testDB.SetupDB(t)
-	service := setupBeaconChain(t, db)
+	db, sc := testDB.SetupDB(t)
+	service := setupBeaconChain(t, db, sc)
 
 	oldRoot := [32]byte{'A'}
 	service.head = &head{slot: 0, root: oldRoot}
@@ -141,8 +141,8 @@ func TestSaveHead_Different_Reorg(t *testing.T) {
 }
 
 func TestUpdateRecentCanonicalBlocks_CanUpdateWithoutParent(t *testing.T) {
-	db := testDB.SetupDB(t)
-	service := setupBeaconChain(t, db)
+	db, sc := testDB.SetupDB(t)
+	service := setupBeaconChain(t, db, sc)
 
 	r := [32]byte{'a'}
 	if err := service.updateRecentCanonicalBlocks(context.Background(), r); err != nil {
@@ -158,8 +158,8 @@ func TestUpdateRecentCanonicalBlocks_CanUpdateWithoutParent(t *testing.T) {
 }
 
 func TestUpdateRecentCanonicalBlocks_CanUpdateWithParent(t *testing.T) {
-	db := testDB.SetupDB(t)
-	service := setupBeaconChain(t, db)
+	db, sc := testDB.SetupDB(t)
+	service := setupBeaconChain(t, db, sc)
 	oldHead := [32]byte{'a'}
 	if err := service.forkChoiceStore.ProcessBlock(context.Background(), 1, oldHead, [32]byte{'g'}, [32]byte{}, 0, 0); err != nil {
 		t.Fatal(err)
@@ -200,8 +200,8 @@ func TestUpdateRecentCanonicalBlocks_CanUpdateWithParent(t *testing.T) {
 }
 
 func TestCacheJustifiedStateBalances_CanCache(t *testing.T) {
-	db := testDB.SetupDB(t)
-	service := setupBeaconChain(t, db)
+	db, sc := testDB.SetupDB(t)
+	service := setupBeaconChain(t, db, sc)
 
 	state, _ := testutil.DeterministicGenesisState(t, 100)
 	r := [32]byte{'a'}

--- a/beacon-chain/blockchain/init_sync_process_block_test.go
+++ b/beacon-chain/blockchain/init_sync_process_block_test.go
@@ -6,7 +6,6 @@ import (
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
@@ -18,8 +17,8 @@ import (
 )
 
 func TestGenerateState_CorrectlyGenerated(t *testing.T) {
-	db := testDB.SetupDB(t)
-	cfg := &Config{BeaconDB: db, StateGen: stategen.New(db, cache.NewStateSummaryCache())}
+	db, sc := testDB.SetupDB(t)
+	cfg := &Config{BeaconDB: db, StateGen: stategen.New(db, sc)}
 	service, err := NewService(context.Background(), cfg)
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
@@ -23,12 +22,12 @@ import (
 
 func TestStore_OnAttestation(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 
 	cfg := &Config{
 		BeaconDB:        db,
 		ForkChoiceStore: protoarray.New(0, 0, [32]byte{}),
-		StateGen:        stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:        stategen.New(db, sc),
 	}
 	service, err := NewService(ctx, cfg)
 	if err != nil {
@@ -162,11 +161,11 @@ func TestStore_OnAttestation(t *testing.T) {
 
 func TestStore_SaveCheckpointState(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 
 	cfg := &Config{
 		BeaconDB: db,
-		StateGen: stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen: stategen.New(db, sc),
 	}
 	service, err := NewService(ctx, cfg)
 	if err != nil {
@@ -282,11 +281,11 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 
 func TestStore_UpdateCheckpointState(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 
 	cfg := &Config{
 		BeaconDB: db,
-		StateGen: stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen: stategen.New(db, sc),
 	}
 	service, err := NewService(ctx, cfg)
 	if err != nil {
@@ -346,7 +345,7 @@ func TestStore_UpdateCheckpointState(t *testing.T) {
 
 func TestAttEpoch_MatchPrevEpoch(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -365,7 +364,7 @@ func TestAttEpoch_MatchPrevEpoch(t *testing.T) {
 
 func TestAttEpoch_MatchCurrentEpoch(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -384,7 +383,7 @@ func TestAttEpoch_MatchCurrentEpoch(t *testing.T) {
 
 func TestAttEpoch_NotMatch(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -404,7 +403,7 @@ func TestAttEpoch_NotMatch(t *testing.T) {
 
 func TestVerifyBeaconBlock_NoBlock(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -420,7 +419,7 @@ func TestVerifyBeaconBlock_NoBlock(t *testing.T) {
 
 func TestVerifyBeaconBlock_futureBlock(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -446,7 +445,7 @@ func TestVerifyBeaconBlock_futureBlock(t *testing.T) {
 
 func TestVerifyBeaconBlock_OK(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -471,7 +470,7 @@ func TestVerifyBeaconBlock_OK(t *testing.T) {
 
 func TestVerifyLMDFFGConsistent_NotOK(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)
@@ -504,7 +503,7 @@ func TestVerifyLMDFFGConsistent_NotOK(t *testing.T) {
 
 func TestVerifyLMDFFGConsistent_OK(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	cfg := &Config{BeaconDB: db}
 	service, err := NewService(ctx, cfg)

--- a/beacon-chain/blockchain/receive_attestation_test.go
+++ b/beacon-chain/blockchain/receive_attestation_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestVerifyCheckpointEpoch_Ok(t *testing.T) {
 	helpers.ClearCache()
-	db := testDB.SetupDB(t)
+	db, sc := testDB.SetupDB(t)
 
-	chainService := setupBeaconChain(t, db)
+	chainService := setupBeaconChain(t, db, sc)
 	chainService.genesisTime = time.Now()
 
 	if !chainService.verifyCheckpointEpoch(&ethpb.Checkpoint{}) {

--- a/beacon-chain/blockchain/service_norace_test.go
+++ b/beacon-chain/blockchain/service_norace_test.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 func TestChainService_SaveHead_DataRace(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	s := &Service{
 		beaconDB: db,
 	}

--- a/beacon-chain/db/testing/setup_db.go
+++ b/beacon-chain/db/testing/setup_db.go
@@ -17,7 +17,7 @@ import (
 )
 
 // SetupDB instantiates and returns database backed by key value store.
-func SetupDB(t testing.TB) db.Database {
+func SetupDB(t testing.TB) (db.Database, *cache.StateSummaryCache) {
 	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	if err != nil {
 		t.Fatalf("could not generate random file path: %v", err)
@@ -26,7 +26,8 @@ func SetupDB(t testing.TB) db.Database {
 	if err := os.RemoveAll(p); err != nil {
 		t.Fatalf("failed to remove directory: %v", err)
 	}
-	s, err := kv.NewKVStore(p, cache.NewStateSummaryCache())
+	sc := cache.NewStateSummaryCache()
+	s, err := kv.NewKVStore(p, sc)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,5 +39,5 @@ func SetupDB(t testing.TB) db.Database {
 			t.Fatalf("could not remove tmp db dir: %v", err)
 		}
 	})
-	return s
+	return s, sc
 }

--- a/beacon-chain/powchain/block_reader_test.go
+++ b/beacon-chain/powchain/block_reader_test.go
@@ -30,7 +30,7 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -96,7 +96,7 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 }
 
 func TestBlockHashByHeight_ReturnsHash(t *testing.T) {
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -137,7 +137,7 @@ func TestBlockHashByHeight_ReturnsHash(t *testing.T) {
 }
 
 func TestBlockExists_ValidHash(t *testing.T) {
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -178,7 +178,7 @@ func TestBlockExists_ValidHash(t *testing.T) {
 }
 
 func TestBlockExists_InvalidHash(t *testing.T) {
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -195,7 +195,7 @@ func TestBlockExists_InvalidHash(t *testing.T) {
 }
 
 func TestBlockExists_UsesCachedBlockInfo(t *testing.T) {
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -233,7 +233,7 @@ func TestBlockExists_UsesCachedBlockInfo(t *testing.T) {
 }
 
 func TestBlockNumberByTimestamp(t *testing.T) {
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,

--- a/beacon-chain/powchain/deposit_test.go
+++ b/beacon-chain/powchain/deposit_test.go
@@ -19,7 +19,7 @@ import (
 const pubKeyErr = "could not convert bytes to public key"
 
 func TestProcessDeposit_OK(t *testing.T) {
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -53,7 +53,7 @@ func TestProcessDeposit_OK(t *testing.T) {
 }
 
 func TestProcessDeposit_InvalidMerkleBranch(t *testing.T) {
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -90,7 +90,7 @@ func TestProcessDeposit_InvalidMerkleBranch(t *testing.T) {
 
 func TestProcessDeposit_InvalidPublicKey(t *testing.T) {
 	hook := logTest.NewGlobal()
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -135,7 +135,7 @@ func TestProcessDeposit_InvalidPublicKey(t *testing.T) {
 
 func TestProcessDeposit_InvalidSignature(t *testing.T) {
 	hook := logTest.NewGlobal()
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -179,7 +179,7 @@ func TestProcessDeposit_InvalidSignature(t *testing.T) {
 
 func TestProcessDeposit_UnableToVerify(t *testing.T) {
 	hook := logTest.NewGlobal()
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -221,7 +221,7 @@ func TestProcessDeposit_UnableToVerify(t *testing.T) {
 }
 
 func TestProcessDeposit_IncompleteDeposit(t *testing.T) {
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,
@@ -300,7 +300,7 @@ func TestProcessDeposit_IncompleteDeposit(t *testing.T) {
 }
 
 func TestProcessDeposit_AllDepositedSuccessfully(t *testing.T) {
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -43,7 +43,7 @@ func TestProcessDepositLog_OK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -117,7 +117,7 @@ func TestProcessDepositLog_InsertsPendingDeposit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -190,7 +190,7 @@ func TestUnpackDepositLogData_OK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		BeaconDB:        beaconDB,
@@ -269,7 +269,7 @@ func TestProcessETH2GenesisLog_8DuplicatePubkeys(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -354,7 +354,7 @@ func TestProcessETH2GenesisLog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -471,7 +471,7 @@ func TestProcessETH2GenesisLog_CorrectNumOfDeposits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	kvStore := testDB.SetupDB(t)
+	kvStore, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -580,7 +580,7 @@ func TestWeb3ServiceProcessDepositLog_RequestMissedDeposits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -697,7 +697,7 @@ func TestConsistentGenesisState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := testDB.SetupDB(t)
+	beaconDB, _ := testDB.SetupDB(t)
 	web3Service := newPowchainService(t, testAcc, beaconDB)
 
 	testAcc.Backend.Commit()
@@ -746,7 +746,7 @@ func TestConsistentGenesisState(t *testing.T) {
 	}
 
 	// New db to prevent registration error.
-	newBeaconDB := testDB.SetupDB(t)
+	newBeaconDB, _ := testDB.SetupDB(t)
 
 	newWeb3Service := newPowchainService(t, testAcc, newBeaconDB)
 	go newWeb3Service.run(ctx.Done())

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -125,7 +125,7 @@ var depositsReqForChainStart = 64
 
 func TestStart_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	testAcc, err := contracts.Setup()
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
@@ -164,7 +164,7 @@ func TestStop_OK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -197,7 +197,7 @@ func TestService_Eth1Synced(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -228,7 +228,7 @@ func TestFollowBlock_OK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -289,7 +289,7 @@ func TestInitDataFromContract_OK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to set up simulated backend %v", err)
 	}
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint:    endpoint,
 		DepositContract: testAcc.ContractAddr,
@@ -342,7 +342,7 @@ func TestStatus(t *testing.T) {
 
 func TestHandlePanic_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
-	beaconDB := dbutil.SetupDB(t)
+	beaconDB, _ := dbutil.SetupDB(t)
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndPoint: endpoint,
 		BeaconDB:     beaconDB,

--- a/beacon-chain/rpc/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/beacon/BUILD.bazel
@@ -79,7 +79,6 @@ go_test(
     shard_count = 4,
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
-        "//beacon-chain/cache:go_default_library",
         "//beacon-chain/core/epoch/precompute:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/block:go_default_library",

--- a/beacon-chain/rpc/beacon/assignments_test.go
+++ b/beacon-chain/rpc/beacon/assignments_test.go
@@ -13,7 +13,6 @@ import (
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-ssz"
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	dbTest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
@@ -28,7 +27,7 @@ func TestServer_ListAssignments_CannotRequestFutureEpoch(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 	bs := &Server{
 		BeaconDB:           db,
@@ -52,7 +51,7 @@ func TestServer_ListAssignments_NoResults(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 	st := testutil.NewBeaconState()
 
@@ -74,7 +73,7 @@ func TestServer_ListAssignments_NoResults(t *testing.T) {
 	bs := &Server{
 		BeaconDB:           db,
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 	wanted := &ethpb.ValidatorAssignments{
 		Assignments:   make([]*ethpb.ValidatorAssignments_CommitteeAssignment, 0),
@@ -101,7 +100,7 @@ func TestServer_ListAssignments_Pagination_InputOutOfRange(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 	setupValidators(t, db, 1)
 	headState, err := db.HeadState(ctx)
@@ -127,7 +126,7 @@ func TestServer_ListAssignments_Pagination_InputOutOfRange(t *testing.T) {
 	bs := &Server{
 		BeaconDB:           db,
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 
 	wanted := fmt.Sprintf("page start %d >= list %d", 0, 0)
@@ -157,7 +156,7 @@ func TestServer_ListAssignments_Pagination_ExceedsMaxPageSize(t *testing.T) {
 
 func TestServer_ListAssignments_Pagination_DefaultPageSize_NoArchive(t *testing.T) {
 	helpers.ClearCache()
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 	count := 500
 	validators := make([]*ethpb.Validator, 0, count)
@@ -212,7 +211,7 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_NoArchive(t *testing.
 			},
 		},
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 
 	res, err := bs.ListValidatorAssignments(context.Background(), &ethpb.ListValidatorAssignmentsRequest{
@@ -254,7 +253,7 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_NoArchive(t *testing.
 
 func TestServer_ListAssignments_Pagination_DefaultPageSize_FromArchive(t *testing.T) {
 	helpers.ClearCache()
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -313,7 +312,7 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_FromArchive(t *testin
 			},
 		},
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 
 	// Construct the wanted assignments.
@@ -354,7 +353,7 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_FromArchive(t *testin
 
 func TestServer_ListAssignments_FilterPubkeysIndices_NoPagination(t *testing.T) {
 	helpers.ClearCache()
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -393,7 +392,7 @@ func TestServer_ListAssignments_FilterPubkeysIndices_NoPagination(t *testing.T) 
 			},
 		},
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 
 	pubKey1 := make([]byte, params.BeaconConfig().BLSPubkeyLength)
@@ -441,7 +440,7 @@ func TestServer_ListAssignments_CanFilterPubkeysIndices_WithPagination(t *testin
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 	count := 100
 	validators := make([]*ethpb.Validator, 0, count)
@@ -477,7 +476,7 @@ func TestServer_ListAssignments_CanFilterPubkeysIndices_WithPagination(t *testin
 			},
 		},
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 
 	req := &ethpb.ListValidatorAssignmentsRequest{Indices: []uint64{1, 2, 3, 4, 5, 6}, PageSize: 2, PageToken: "1"}

--- a/beacon-chain/rpc/beacon/attestations_test.go
+++ b/beacon-chain/rpc/beacon/attestations_test.go
@@ -16,7 +16,6 @@ import (
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-bitfield"
 	chainMock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed/operation"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
@@ -38,7 +37,7 @@ import (
 )
 
 func TestServer_ListAttestations_NoResults(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	st, err := stateTrie.InitializeFromProto(&pbp2p.BeaconState{
@@ -70,7 +69,7 @@ func TestServer_ListAttestations_NoResults(t *testing.T) {
 }
 
 func TestServer_ListAttestations_Genesis(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	st, err := stateTrie.InitializeFromProto(&pbp2p.BeaconState{
@@ -157,7 +156,7 @@ func TestServer_ListAttestations_Genesis(t *testing.T) {
 }
 
 func TestServer_ListAttestations_NoPagination(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	count := uint64(8)
@@ -207,7 +206,7 @@ func TestServer_ListAttestations_NoPagination(t *testing.T) {
 }
 
 func TestServer_ListAttestations_FiltersCorrectly(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	someRoot := [32]byte{1, 2, 3}
@@ -332,7 +331,7 @@ func TestServer_ListAttestations_FiltersCorrectly(t *testing.T) {
 }
 
 func TestServer_ListAttestations_Pagination_CustomPageParameters(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	count := params.BeaconConfig().SlotsPerEpoch * 4
@@ -450,7 +449,7 @@ func TestServer_ListAttestations_Pagination_CustomPageParameters(t *testing.T) {
 }
 
 func TestServer_ListAttestations_Pagination_OutOfRange(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 	testutil.NewBeaconBlock()
 	count := uint64(1)
@@ -512,7 +511,7 @@ func TestServer_ListAttestations_Pagination_ExceedsMaxPageSize(t *testing.T) {
 }
 
 func TestServer_ListAttestations_Pagination_DefaultPageSize(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	count := uint64(params.BeaconConfig().DefaultPageSize)
@@ -611,7 +610,7 @@ func TestServer_ListIndexedAttestations_NewStateManagnmentDisabled(t *testing.T)
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.MainnetConfig())
 
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 	numValidators := uint64(128)
 	state, _ := testutil.DeterministicGenesisState(t, numValidators)
@@ -619,7 +618,7 @@ func TestServer_ListIndexedAttestations_NewStateManagnmentDisabled(t *testing.T)
 	bs := &Server{
 		BeaconDB:           db,
 		GenesisTimeFetcher: &chainMock.ChainService{State: state},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 	_, err := bs.ListIndexedAttestations(ctx, &ethpb.ListIndexedAttestationsRequest{
 		QueryFilter: &ethpb.ListIndexedAttestationsRequest_GenesisEpoch{
@@ -643,7 +642,7 @@ func TestServer_ListIndexedAttestations_GenesisEpoch(t *testing.T) {
 	defer resetCfg()
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.MainnetConfig())
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	helpers.ClearCache()
 	ctx := context.Background()
 	targetRoot1 := bytesutil.ToBytes32([]byte("root"))
@@ -735,7 +734,7 @@ func TestServer_ListIndexedAttestations_GenesisEpoch(t *testing.T) {
 	bs := &Server{
 		BeaconDB:           db,
 		GenesisTimeFetcher: &chainMock.ChainService{State: state},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 	if err := db.SaveStateSummary(ctx, &pbp2p.StateSummary{
 		Root: targetRoot1[:],
@@ -784,7 +783,7 @@ func TestServer_ListIndexedAttestations_OldEpoch(t *testing.T) {
 	defer resetCfg()
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.MainnetConfig())
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	helpers.ClearCache()
 	ctx := context.Background()
 
@@ -856,7 +855,7 @@ func TestServer_ListIndexedAttestations_OldEpoch(t *testing.T) {
 		GenesisTimeFetcher: &chainMock.ChainService{
 			Genesis: time.Now(),
 		},
-		StateGen: stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen: stategen.New(db, sc),
 	}
 	if err := db.SaveStateSummary(ctx, &pbp2p.StateSummary{
 		Root: blockRoot[:],
@@ -1055,7 +1054,7 @@ func TestServer_StreamIndexedAttestations_ContextCanceled(t *testing.T) {
 func TestServer_StreamIndexedAttestations_OK(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.MainnetConfig())
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	exitRoutine := make(chan bool)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1156,7 +1155,7 @@ func TestServer_StreamIndexedAttestations_OK(t *testing.T) {
 		},
 		AttestationNotifier:         chainService.OperationNotifier(),
 		CollectedAttestationsBuffer: make(chan []*ethpb.Attestation, 1),
-		StateGen:                    stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:                    stategen.New(db, sc),
 	}
 
 	for dataRoot, sameDataAtts := range atts {

--- a/beacon-chain/rpc/beacon/blocks_test.go
+++ b/beacon-chain/rpc/beacon/blocks_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestServer_ListBlocks_NoResults(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	bs := &Server{
@@ -76,7 +76,7 @@ func TestServer_ListBlocks_NoResults(t *testing.T) {
 }
 
 func TestServer_ListBlocks_Genesis(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	bs := &Server{
@@ -130,7 +130,7 @@ func TestServer_ListBlocks_Genesis(t *testing.T) {
 }
 
 func TestServer_ListBlocks_Genesis_MultiBlocks(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	bs := &Server{
@@ -186,7 +186,7 @@ func TestServer_ListBlocks_Genesis_MultiBlocks(t *testing.T) {
 }
 
 func TestServer_ListBlocks_Pagination(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	count := uint64(100)
@@ -328,7 +328,7 @@ func TestServer_ListBlocks_Pagination(t *testing.T) {
 }
 
 func TestServer_ListBlocks_Errors(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	bs := &Server{BeaconDB: db}
@@ -399,7 +399,7 @@ func TestServer_ListBlocks_Errors(t *testing.T) {
 }
 
 func TestServer_GetChainHead_NoFinalizedBlock(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 
 	s, err := stateTrie.InitializeFromProto(&pbp2p.BeaconState{
 		Slot:                        1,
@@ -453,7 +453,7 @@ func TestServer_GetChainHead_NoHeadBlock(t *testing.T) {
 }
 
 func TestServer_GetChainHead(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 
 	genBlock := testutil.NewBeaconBlock()
 	genBlock.Block.ParentRoot = bytesutil.PadTo([]byte{'G'}, 32)
@@ -564,7 +564,7 @@ func TestServer_GetChainHead(t *testing.T) {
 }
 
 func TestServer_StreamChainHead_ContextCanceled(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -591,7 +591,7 @@ func TestServer_StreamChainHead_ContextCanceled(t *testing.T) {
 }
 
 func TestServer_StreamChainHead_OnHeadUpdated(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 
 	genBlock := testutil.NewBeaconBlock()
 	genBlock.Block.ParentRoot = bytesutil.PadTo([]byte{'G'}, 32)
@@ -708,7 +708,7 @@ func TestServer_StreamChainHead_OnHeadUpdated(t *testing.T) {
 }
 
 func TestServer_StreamBlocks_ContextCanceled(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	chainService := &chainMock.ChainService{}

--- a/beacon-chain/rpc/beacon/committees_test.go
+++ b/beacon-chain/rpc/beacon/committees_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	dbTest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
@@ -26,7 +25,7 @@ import (
 )
 
 func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	helpers.ClearCache()
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
@@ -41,7 +40,7 @@ func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
 	bs := &Server{
 		HeadFetcher:        m,
 		GenesisTimeFetcher: m,
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	if err := db.SaveBlock(ctx, b); err != nil {
@@ -91,7 +90,7 @@ func TestServer_ListBeaconCommittees_PreviousEpoch(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
 	defer resetCfg()
 
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	helpers.ClearCache()
 
 	numValidators := 128
@@ -163,7 +162,7 @@ func TestServer_ListBeaconCommittees_FromArchive(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
 	defer resetCfg()
 
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	helpers.ClearCache()
 	ctx := context.Background()
 
@@ -261,7 +260,7 @@ func TestRetrieveCommitteesForRoot(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	helpers.ClearCache()
 	ctx := context.Background()
 
@@ -274,7 +273,7 @@ func TestRetrieveCommitteesForRoot(t *testing.T) {
 	bs := &Server{
 		HeadFetcher:        m,
 		GenesisTimeFetcher: m,
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	if err := db.SaveBlock(ctx, b); err != nil {

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/go-ssz"
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/epoch/precompute"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
@@ -36,7 +35,7 @@ import (
 )
 
 func TestServer_GetValidatorActiveSetChanges_CannotRequestFutureEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 	st := testutil.NewBeaconState()
 	if err := st.SetSlot(0); err != nil {
@@ -64,7 +63,7 @@ func TestServer_GetValidatorActiveSetChanges_CannotRequestFutureEpoch(t *testing
 }
 
 func TestServer_ListValidatorBalances_CannotRequestFutureEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	st := testutil.NewBeaconState()
@@ -93,7 +92,7 @@ func TestServer_ListValidatorBalances_CannotRequestFutureEpoch(t *testing.T) {
 }
 
 func TestServer_ListValidatorBalances_NoResults(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -104,7 +103,7 @@ func TestServer_ListValidatorBalances_NoResults(t *testing.T) {
 	}
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 
 	headState := testutil.NewBeaconState()
@@ -145,7 +144,7 @@ func TestServer_ListValidatorBalances_NoResults(t *testing.T) {
 }
 
 func TestServer_ListValidatorBalances_DefaultResponse_NoArchive(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	numItems := 100
@@ -190,7 +189,7 @@ func TestServer_ListValidatorBalances_DefaultResponse_NoArchive(t *testing.T) {
 	}
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 		HeadFetcher: &mock.ChainService{
 			State: st,
 		},
@@ -210,7 +209,7 @@ func TestServer_ListValidatorBalances_DefaultResponse_NoArchive(t *testing.T) {
 }
 
 func TestServer_ListValidatorBalances_PaginationOutOfRange(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 	setupValidators(t, db, 3)
 	st := testutil.NewBeaconState()
@@ -231,7 +230,7 @@ func TestServer_ListValidatorBalances_PaginationOutOfRange(t *testing.T) {
 
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 		HeadFetcher: &mock.ChainService{
 			State: st,
 		},
@@ -266,7 +265,7 @@ func pubKey(i uint64) []byte {
 }
 
 func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	setupValidators(t, db, 100)
@@ -288,7 +287,7 @@ func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 		HeadFetcher: &mock.ChainService{
 			State: headState,
 		},
@@ -360,7 +359,7 @@ func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 }
 
 func TestServer_ListValidatorBalances_Pagination_CustomPageSizes(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	count := 1000
@@ -383,7 +382,7 @@ func TestServer_ListValidatorBalances_Pagination_CustomPageSizes(t *testing.T) {
 
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 		HeadFetcher: &mock.ChainService{
 			State: headState,
 		},
@@ -440,7 +439,7 @@ func TestServer_ListValidatorBalances_Pagination_CustomPageSizes(t *testing.T) {
 }
 
 func TestServer_ListValidatorBalances_OutOfRange(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 	ctx := context.Background()
@@ -464,7 +463,7 @@ func TestServer_ListValidatorBalances_OutOfRange(t *testing.T) {
 
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 		HeadFetcher: &mock.ChainService{
 			State: headState,
 		},
@@ -478,7 +477,7 @@ func TestServer_ListValidatorBalances_OutOfRange(t *testing.T) {
 }
 
 func TestServer_ListValidators_CannotRequestFutureEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	st := testutil.NewBeaconState()
@@ -510,7 +509,7 @@ func TestServer_ListValidators_CannotRequestFutureEpoch(t *testing.T) {
 }
 
 func TestServer_ListValidatorBalances_FromArchive(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
 	defer resetCfg()
@@ -567,7 +566,7 @@ func TestServer_ListValidatorBalances_FromArchive(t *testing.T) {
 }
 
 func TestServer_ListValidatorBalances_FromArchive_NewValidatorNotFound(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
@@ -608,7 +607,7 @@ func TestServer_ListValidatorBalances_FromArchive_NewValidatorNotFound(t *testin
 }
 
 func TestServer_ListValidators_NoResults(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
@@ -714,7 +713,7 @@ func TestServer_ListValidators_OnlyActiveValidators(t *testing.T) {
 }
 
 func TestServer_ListValidators_NoPagination(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 
 	validators, _ := setupValidators(t, db, 100)
 	want := make([]*ethpb.Validators_ValidatorContainer, len(validators))
@@ -755,7 +754,7 @@ func TestServer_ListValidators_NoPagination(t *testing.T) {
 }
 
 func TestServer_ListValidators_IndicesPubKeys(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 
 	validators, _ := setupValidators(t, db, 100)
 	indicesWanted := []uint64{2, 7, 11, 17}
@@ -811,7 +810,7 @@ func TestServer_ListValidators_IndicesPubKeys(t *testing.T) {
 }
 
 func TestServer_ListValidators_Pagination(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 
 	count := 100
 	setupValidators(t, db, count)
@@ -954,7 +953,7 @@ func TestServer_ListValidators_Pagination(t *testing.T) {
 }
 
 func TestServer_ListValidators_PaginationOutOfRange(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 
 	count := 1
 	validators, _ := setupValidators(t, db, count)
@@ -997,7 +996,7 @@ func TestServer_ListValidators_ExceedsMaxPageSize(t *testing.T) {
 }
 
 func TestServer_ListValidators_DefaultPageSize(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 
 	validators, _ := setupValidators(t, db, 1000)
 	want := make([]*ethpb.Validators_ValidatorContainer, len(validators))
@@ -1282,7 +1281,7 @@ func TestServer_GetValidator(t *testing.T) {
 }
 
 func TestServer_GetValidatorActiveSetChanges(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -1351,7 +1350,7 @@ func TestServer_GetValidatorActiveSetChanges(t *testing.T) {
 			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0},
 		},
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:           stategen.New(db, sc),
 	}
 	res, err := bs.GetValidatorActiveSetChanges(ctx, &ethpb.GetValidatorActiveSetChangesRequest{
 		QueryFilter: &ethpb.GetValidatorActiveSetChangesRequest_Genesis{Genesis: true},
@@ -1398,7 +1397,7 @@ func TestServer_GetValidatorActiveSetChanges_FromArchive(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
 	defer resetCfg()
 
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	validators := make([]*ethpb.Validator, 8)
@@ -1710,7 +1709,7 @@ func TestServer_GetValidatorQueue_PendingExit(t *testing.T) {
 }
 
 func TestServer_GetValidatorParticipation_CannotRequestCurrentEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	headState := testutil.NewBeaconState()
@@ -1738,7 +1737,7 @@ func TestServer_GetValidatorParticipation_CannotRequestCurrentEpoch(t *testing.T
 }
 
 func TestServer_GetValidatorParticipation_CannotRequestFutureEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
 	defer resetCfg()
@@ -1770,7 +1769,7 @@ func TestServer_GetValidatorParticipation_CannotRequestFutureEpoch(t *testing.T)
 }
 
 func TestServer_GetValidatorParticipation_FromArchive(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
@@ -1834,7 +1833,7 @@ func TestServer_GetValidatorParticipation_FromArchive(t *testing.T) {
 }
 
 func TestServer_GetValidatorParticipation_PrevEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
@@ -1884,7 +1883,7 @@ func TestServer_GetValidatorParticipation_PrevEpoch(t *testing.T) {
 		HeadFetcher:          m,
 		ParticipationFetcher: m,
 		GenesisTimeFetcher:   &mock.ChainService{},
-		StateGen:             stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:             stategen.New(db, sc),
 	}
 
 	res, err := bs.GetValidatorParticipation(ctx, &ethpb.GetValidatorParticipationRequest{QueryFilter: &ethpb.GetValidatorParticipationRequest_Epoch{Epoch: 0}})
@@ -1901,7 +1900,7 @@ func TestServer_GetValidatorParticipation_PrevEpoch(t *testing.T) {
 }
 
 func TestServer_GetValidatorParticipation_DoesntExist(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	headState := testutil.NewBeaconState()
@@ -1927,7 +1926,7 @@ func TestServer_GetValidatorParticipation_DoesntExist(t *testing.T) {
 		HeadFetcher:          m,
 		ParticipationFetcher: m,
 		GenesisTimeFetcher:   &mock.ChainService{},
-		StateGen:             stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:             stategen.New(db, sc),
 	}
 
 	wanted := "Participation information for epoch 0 is not yet available"
@@ -1937,7 +1936,7 @@ func TestServer_GetValidatorParticipation_DoesntExist(t *testing.T) {
 }
 
 func TestServer_GetValidatorParticipation_FromArchive_FinalizedEpoch(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: false})
@@ -2259,7 +2258,7 @@ func TestGetValidatorPerformance_IndicesPubkeys(t *testing.T) {
 
 func BenchmarkListValidatorBalances(b *testing.B) {
 	b.StopTimer()
-	db := dbTest.SetupDB(b)
+	db, _ := dbTest.SetupDB(b)
 	ctx := context.Background()
 
 	count := 1000
@@ -2287,7 +2286,7 @@ func BenchmarkListValidatorBalances(b *testing.B) {
 
 func BenchmarkListValidatorBalances_FromArchive(b *testing.B) {
 	b.StopTimer()
-	db := dbTest.SetupDB(b)
+	db, _ := dbTest.SetupDB(b)
 	ctx := context.Background()
 
 	currentNumValidators := 1000
@@ -2394,7 +2393,7 @@ func TestServer_GetIndividualVotes_ValidatorsDontExist(t *testing.T) {
 
 	params.UseMinimalConfig()
 	defer params.UseMainnetConfig()
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	validators := uint64(64)
@@ -2416,7 +2415,7 @@ func TestServer_GetIndividualVotes_ValidatorsDontExist(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gen := stategen.New(db, cache.NewStateSummaryCache())
+	gen := stategen.New(db, sc)
 	if err := gen.SaveState(ctx, gRoot, beaconState); err != nil {
 		t.Fatal(err)
 	}
@@ -2495,7 +2494,7 @@ func TestServer_GetIndividualVotes_Working(t *testing.T) {
 
 	params.UseMinimalConfig()
 	defer params.UseMainnetConfig()
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 
 	validators := uint64(64)
@@ -2544,7 +2543,7 @@ func TestServer_GetIndividualVotes_Working(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gen := stategen.New(db, cache.NewStateSummaryCache())
+	gen := stategen.New(db, sc)
 	if err := gen.SaveState(ctx, gRoot, beaconState); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/rpc/debug/BUILD.bazel
+++ b/beacon-chain/rpc/debug/BUILD.bazel
@@ -42,7 +42,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
-        "//beacon-chain/cache:go_default_library",
         "//beacon-chain/db/testing:go_default_library",
         "//beacon-chain/forkchoice/protoarray:go_default_library",
         "//beacon-chain/p2p/testing:go_default_library",

--- a/beacon-chain/rpc/debug/block_test.go
+++ b/beacon-chain/rpc/debug/block_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestServer_GetBlock(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	db, _ := dbTest.SetupDB(t)
 	ctx := context.Background()
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{
 		Slot: 100,

--- a/beacon-chain/rpc/debug/state_test.go
+++ b/beacon-chain/rpc/debug/state_test.go
@@ -8,7 +8,6 @@ import (
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	dbTest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
@@ -21,7 +20,7 @@ func TestServer_GetBeaconState(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
-	db := dbTest.SetupDB(t)
+	db, sc := dbTest.SetupDB(t)
 	ctx := context.Background()
 	st := testutil.NewBeaconState()
 	slot := uint64(100)
@@ -38,7 +37,7 @@ func TestServer_GetBeaconState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gen := stategen.New(db, cache.NewStateSummaryCache())
+	gen := stategen.New(db, sc)
 	if err := gen.SaveState(ctx, gRoot, st); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/rpc/node/server_test.go
+++ b/beacon-chain/rpc/node/server_test.go
@@ -46,7 +46,7 @@ func TestNodeServer_GetSyncStatus(t *testing.T) {
 }
 
 func TestNodeServer_GetGenesis(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 	addr := common.Address{1, 2, 3}
 	if err := db.SaveDepositContractAddress(ctx, addr); err != nil {

--- a/beacon-chain/rpc/validator/aggregator_test.go
+++ b/beacon-chain/rpc/validator/aggregator_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestSubmitAggregateAndProof_Syncing(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	s := &beaconstate.BeaconState{}
@@ -43,7 +43,7 @@ func TestSubmitAggregateAndProof_Syncing(t *testing.T) {
 }
 
 func TestSubmitAggregateAndProof_CantFindValidatorIndex(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	s, err := beaconstate.InitializeFromProto(&pbp2p.BeaconState{
@@ -69,7 +69,7 @@ func TestSubmitAggregateAndProof_CantFindValidatorIndex(t *testing.T) {
 }
 
 func TestSubmitAggregateAndProof_IsAggregatorAndNoAtts(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	s, err := beaconstate.InitializeFromProto(&pbp2p.BeaconState{
@@ -110,7 +110,7 @@ func TestSubmitAggregateAndProof_UnaggregateOk(t *testing.T) {
 	c.TargetAggregatorsPerCommittee = 16
 	params.OverrideBeaconConfig(c)
 
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 32)
@@ -154,7 +154,7 @@ func TestSubmitAggregateAndProof_AggregateOk(t *testing.T) {
 	c.TargetAggregatorsPerCommittee = 16
 	params.OverrideBeaconConfig(c)
 
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 32)
@@ -216,7 +216,7 @@ func TestSubmitAggregateAndProof_AggregateNotOk(t *testing.T) {
 	c.TargetAggregatorsPerCommittee = 16
 	params.OverrideBeaconConfig(c)
 
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)

--- a/beacon-chain/rpc/validator/assignments_test.go
+++ b/beacon-chain/rpc/validator/assignments_test.go
@@ -35,7 +35,7 @@ func pubKey(i uint64) []byte {
 	return pubKey
 }
 func TestGetDuties_NextEpoch_CantFindValidatorIdx(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 	beaconState, _ := testutil.DeterministicGenesisState(t, 10)
 
@@ -75,7 +75,7 @@ func TestGetDuties_NextEpoch_CantFindValidatorIdx(t *testing.T) {
 }
 
 func TestGetDuties_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
@@ -162,7 +162,7 @@ func TestGetDuties_OK(t *testing.T) {
 }
 
 func TestGetDuties_CurrentEpoch_ShouldNotFail(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
@@ -219,7 +219,7 @@ func TestGetDuties_CurrentEpoch_ShouldNotFail(t *testing.T) {
 }
 
 func TestGetDuties_MultipleKeys_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := uint64(64)
@@ -306,7 +306,7 @@ func TestStreamDuties_SyncNotReady(t *testing.T) {
 }
 
 func TestStreamDuties_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
@@ -377,7 +377,7 @@ func TestStreamDuties_OK(t *testing.T) {
 }
 
 func TestStreamDuties_OK_ChainReorg(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
@@ -484,7 +484,7 @@ func TestAssignValidatorToSubnet(t *testing.T) {
 }
 
 func BenchmarkCommitteeAssignment(b *testing.B) {
-	db := dbutil.SetupDB(b)
+	db, _ := dbutil.SetupDB(b)
 
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := uint64(8192 * 2)

--- a/beacon-chain/rpc/validator/attester_test.go
+++ b/beacon-chain/rpc/validator/attester_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestProposeAttestation_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	attesterServer := &Server{
@@ -92,7 +92,7 @@ func TestProposeAttestation_OK(t *testing.T) {
 }
 
 func TestProposeAttestation_IncorrectSignature(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	attesterServer := &Server{
 		HeadFetcher:       &mock.ChainService{},
@@ -117,7 +117,7 @@ func TestProposeAttestation_IncorrectSignature(t *testing.T) {
 
 func TestGetAttestationData_OK(t *testing.T) {
 	ctx := context.Background()
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	block := &ethpb.BeaconBlock{
 		Slot: 3*params.BeaconConfig().SlotsPerEpoch + 1,
@@ -234,7 +234,7 @@ func TestAttestationDataAtSlot_HandlesFarAwayJustifiedEpoch(t *testing.T) {
 	//
 	// More background: https://github.com/prysmaticlabs/prysm/issues/2153
 	// This test breaks if it doesnt use mainnet config
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 	// Ensure HistoricalRootsLimit matches scenario
 	params.SetupTestConfigCleanup(t)
@@ -419,7 +419,7 @@ func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testin
 	// attestation is referencing be less than or equal to the attestation data slot.
 	// See: https://github.com/prysmaticlabs/prysm/issues/5164
 	ctx := context.Background()
-	db := dbutil.SetupDB(t)
+	db, sc := dbutil.SetupDB(t)
 
 	slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
 	block := &ethpb.BeaconBlock{
@@ -500,7 +500,7 @@ func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testin
 		FinalizationFetcher: &mock.ChainService{CurrentJustifiedCheckPoint: beaconState.CurrentJustifiedCheckpoint()},
 		GenesisTimeFetcher:  &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*int64(slot*params.BeaconConfig().SecondsPerSlot)) * time.Second)},
 		StateNotifier:       chainService.StateNotifier(),
-		StateGen:            stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:            stategen.New(db, sc),
 	}
 	if err := db.SaveState(ctx, beaconState, blockRoot); err != nil {
 		t.Fatal(err)
@@ -541,7 +541,7 @@ func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testin
 
 func TestGetAttestationData_SucceedsInFirstEpoch(t *testing.T) {
 	ctx := context.Background()
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	slot := uint64(5)
 	block := &ethpb.BeaconBlock{
@@ -638,7 +638,7 @@ func TestGetAttestationData_SucceedsInFirstEpoch(t *testing.T) {
 }
 
 func TestServer_SubscribeCommitteeSubnets_NoSlots(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	attesterServer := &Server{
 		HeadFetcher:       &mock.ChainService{},
@@ -660,7 +660,7 @@ func TestServer_SubscribeCommitteeSubnets_NoSlots(t *testing.T) {
 }
 
 func TestServer_SubscribeCommitteeSubnets_DifferentLengthSlots(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	// fixed seed
 	s := rand.NewSource(10)
@@ -699,7 +699,7 @@ func TestServer_SubscribeCommitteeSubnets_DifferentLengthSlots(t *testing.T) {
 }
 
 func TestServer_SubscribeCommitteeSubnets_MultipleSlots(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	// fixed seed
 	s := rand.NewSource(10)
 	randGen := rand.New(s)

--- a/beacon-chain/rpc/validator/exit_test.go
+++ b/beacon-chain/rpc/validator/exit_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestSub(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 	testutil.ResetCache()
 	deposits, keys, err := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
@@ -111,7 +111,7 @@ func TestSub(t *testing.T) {
 }
 
 func TestProposeExit_NoPanic(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 	testutil.ResetCache()
 	deposits, keys, err := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/go-ssz"
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache/depositcache"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
@@ -39,7 +38,7 @@ import (
 )
 
 func TestGetBlock_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, sc := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	testutil.ResetCache()
@@ -80,7 +79,7 @@ func TestGetBlock_OK(t *testing.T) {
 		AttPool:           attestations.NewPool(),
 		SlashingsPool:     slashings.NewPool(),
 		ExitPool:          voluntaryexits.NewPool(),
-		StateGen:          stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:          stategen.New(db, sc),
 	}
 
 	randaoReveal, err := testutil.RandaoReveal(beaconState, 0, privKeys)
@@ -159,7 +158,7 @@ func TestGetBlock_OK(t *testing.T) {
 }
 
 func TestGetBlock_AddsUnaggregatedAtts(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, sc := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	params.SetupTestConfigCleanup(t)
@@ -199,7 +198,7 @@ func TestGetBlock_AddsUnaggregatedAtts(t *testing.T) {
 		SlashingsPool:     slashings.NewPool(),
 		AttPool:           attestations.NewPool(),
 		ExitPool:          voluntaryexits.NewPool(),
-		StateGen:          stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:          stategen.New(db, sc),
 	}
 
 	// Generate a bunch of random attestations at slot. These would be considered double votes, but
@@ -283,7 +282,7 @@ func TestGetBlock_AddsUnaggregatedAtts(t *testing.T) {
 }
 
 func TestProposeBlock_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.MainnetConfig())
@@ -326,7 +325,7 @@ func TestProposeBlock_OK(t *testing.T) {
 }
 
 func TestComputeStateRoot_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, sc := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	params.SetupTestConfigCleanup(t)
@@ -359,7 +358,7 @@ func TestComputeStateRoot_OK(t *testing.T) {
 		ChainStartFetcher: &mockPOW.POWChain{},
 		Eth1InfoFetcher:   &mockPOW.POWChain{},
 		Eth1BlockFetcher:  &mockPOW.POWChain{},
-		StateGen:          stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen:          stategen.New(db, sc),
 	}
 
 	req := &ethpb.SignedBeaconBlock{
@@ -1309,7 +1308,7 @@ func TestEth1Data_SmallerDepositCount(t *testing.T) {
 }
 
 func TestEth1Data_MockEnabled(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	// If a mock eth1 data votes is specified, we use the following for the
 	// eth1data we provide to every proposer based on https://github.com/ethereum/eth2.0-pm/issues/62:
 	//
@@ -1359,7 +1358,7 @@ func TestEth1Data_MockEnabled(t *testing.T) {
 }
 
 func TestFilterAttestation_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	params.SetupTestConfigCleanup(t)

--- a/beacon-chain/rpc/validator/server_test.go
+++ b/beacon-chain/rpc/validator/server_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestValidatorIndex_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 	st := testutil.NewBeaconState()
 	if err := db.SaveState(ctx, st.Copy(), [32]byte{}); err != nil {
@@ -59,7 +59,7 @@ func TestValidatorIndex_OK(t *testing.T) {
 }
 
 func TestWaitForActivation_ContextClosed(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	beaconState, err := stateTrie.InitializeFromProto(&pbp2p.BeaconState{
@@ -112,7 +112,7 @@ func TestWaitForActivation_ContextClosed(t *testing.T) {
 }
 
 func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	// This test breaks if it doesnt use mainnet config
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.MainnetConfig())
@@ -211,7 +211,7 @@ func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 }
 
 func TestWaitForActivation_MultipleStatuses(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	priv1 := bls.RandKey()
 	priv2 := bls.RandKey()
@@ -304,7 +304,7 @@ func TestWaitForActivation_MultipleStatuses(t *testing.T) {
 }
 
 func TestWaitForChainStart_ContextClosed(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -334,7 +334,7 @@ func TestWaitForChainStart_ContextClosed(t *testing.T) {
 }
 
 func TestWaitForChainStart_AlreadyStarted(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 	headBlockRoot := [32]byte{0x01, 0x02}
 	trie := testutil.NewBeaconState()
@@ -373,7 +373,7 @@ func TestWaitForChainStart_AlreadyStarted(t *testing.T) {
 }
 
 func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	hook := logTest.NewGlobal()
 	chainService := &mockChain.ChainService{}
@@ -418,7 +418,7 @@ func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 }
 
 func TestWaitForSynced_ContextClosed(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -448,7 +448,7 @@ func TestWaitForSynced_ContextClosed(t *testing.T) {
 }
 
 func TestWaitForSynced_AlreadySynced(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 	headBlockRoot := [32]byte{0x01, 0x02}
 	trie := testutil.NewBeaconState()
@@ -488,7 +488,7 @@ func TestWaitForSynced_AlreadySynced(t *testing.T) {
 }
 
 func TestWaitForSynced_NotStartedThenLogFired(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 
 	hook := logTest.NewGlobal()
 	chainService := &mockChain.ChainService{}

--- a/beacon-chain/rpc/validator/status_test.go
+++ b/beacon-chain/rpc/validator/status_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestValidatorStatus_DepositedEth1(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pubKey1 := pubKey(1)
@@ -74,7 +74,7 @@ func TestValidatorStatus_DepositedEth1(t *testing.T) {
 }
 
 func TestValidatorStatus_Deposited(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pubKey1 := pubKey(1)
@@ -131,7 +131,7 @@ func TestValidatorStatus_Deposited(t *testing.T) {
 }
 
 func TestValidatorStatus_Pending(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -208,7 +208,7 @@ func TestValidatorStatus_Pending(t *testing.T) {
 }
 
 func TestValidatorStatus_Active(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	// This test breaks if it doesnt use mainnet config
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.MainnetConfig())
@@ -290,7 +290,7 @@ func TestValidatorStatus_Active(t *testing.T) {
 }
 
 func TestValidatorStatus_Exiting(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -363,7 +363,7 @@ func TestValidatorStatus_Exiting(t *testing.T) {
 }
 
 func TestValidatorStatus_Slashing(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -433,7 +433,7 @@ func TestValidatorStatus_Slashing(t *testing.T) {
 }
 
 func TestValidatorStatus_Exited(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -511,7 +511,7 @@ func TestValidatorStatus_Exited(t *testing.T) {
 }
 
 func TestValidatorStatus_UnknownStatus(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	pubKey := pubKey(1)
 	depositCache := depositcache.NewDepositCache()
 	stateObj, err := stateTrie.InitializeFromProtoUnsafe(&pbp2p.BeaconState{
@@ -541,7 +541,7 @@ func TestValidatorStatus_UnknownStatus(t *testing.T) {
 }
 
 func TestActivationStatus_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pubKeys := [][]byte{pubKey(1), pubKey(2), pubKey(3), pubKey(4)}
@@ -650,7 +650,7 @@ func TestActivationStatus_OK(t *testing.T) {
 }
 
 func TestValidatorStatus_CorrectActivationQueue(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pbKey := pubKey(5)
@@ -766,7 +766,7 @@ func TestValidatorStatus_CorrectActivationQueue(t *testing.T) {
 }
 
 func TestDepositBlockSlotAfterGenesisTime(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -841,7 +841,7 @@ func TestDepositBlockSlotAfterGenesisTime(t *testing.T) {
 }
 
 func TestDepositBlockSlotBeforeGenesisTime(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pubKey := pubKey(1)
@@ -915,7 +915,7 @@ func TestDepositBlockSlotBeforeGenesisTime(t *testing.T) {
 }
 
 func TestMultipleValidatorStatus_Pubkeys(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	pubKeys := [][]byte{pubKey(1), pubKey(2), pubKey(3), pubKey(4)}
@@ -1028,7 +1028,7 @@ func TestMultipleValidatorStatus_Pubkeys(t *testing.T) {
 }
 
 func TestMultipleValidatorStatus_Indices(t *testing.T) {
-	db := dbutil.SetupDB(t)
+	db, _ := dbutil.SetupDB(t)
 	slot := uint64(10000)
 	epoch := helpers.SlotToEpoch(slot)
 	pubKeys := [][]byte{pubKey(1), pubKey(2), pubKey(3), pubKey(4)}

--- a/beacon-chain/state/stategen/cold_test.go
+++ b/beacon-chain/state/stategen/cold_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestSaveColdState_NonArchivedPoint(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 2
@@ -31,7 +31,7 @@ func TestSaveColdState_NonArchivedPoint(t *testing.T) {
 
 func TestSaveColdState_CanSave(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
@@ -56,7 +56,7 @@ func TestSaveColdState_CanSave(t *testing.T) {
 
 func TestLoadColdStateByRoot_NoStateSummary(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	if _, err := service.loadColdStateByRoot(ctx, [32]byte{'a'}); !strings.Contains(err.Error(), errUnknownStateSummary.Error()) {
@@ -66,7 +66,7 @@ func TestLoadColdStateByRoot_NoStateSummary(t *testing.T) {
 
 func TestLoadColdStateByRoot_CanGet(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
@@ -108,7 +108,7 @@ func TestLoadColdStateByRoot_CanGet(t *testing.T) {
 
 func TestLoadColdStateBySlot_CanGet(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestStateByRoot_ColdState(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 2
@@ -66,7 +66,7 @@ func TestStateByRoot_ColdState(t *testing.T) {
 
 func TestStateByRoot_HotStateDB(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -119,7 +119,7 @@ func TestStateByRoot_HotStateDB(t *testing.T) {
 
 func TestStateByRoot_HotStateCached(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -143,7 +143,7 @@ func TestStateByRoot_HotStateCached(t *testing.T) {
 
 func TestStateByRootInitialSync_UseDB(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -196,7 +196,7 @@ func TestStateByRootInitialSync_UseDB(t *testing.T) {
 
 func TestStateByRootInitialSync_UseCache(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -220,7 +220,7 @@ func TestStateByRootInitialSync_UseCache(t *testing.T) {
 
 func TestStateByRootInitialSync_CanProcessUpTo(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -263,7 +263,7 @@ func TestStateByRootInitialSync_CanProcessUpTo(t *testing.T) {
 
 func TestStateBySlot_ColdState(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = params.BeaconConfig().SlotsPerEpoch * 2
@@ -314,7 +314,7 @@ func TestStateBySlot_ColdState(t *testing.T) {
 
 func TestStateBySlot_HotStateDB(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -346,7 +346,7 @@ func TestStateBySlot_HotStateDB(t *testing.T) {
 
 func TestStateSummary_CanGetFromCacheOrDB(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 

--- a/beacon-chain/state/stategen/hot_test.go
+++ b/beacon-chain/state/stategen/hot_test.go
@@ -22,7 +22,7 @@ import (
 func TestSaveHotState_AlreadyHas(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -50,7 +50,7 @@ func TestSaveHotState_AlreadyHas(t *testing.T) {
 func TestSaveHotState_CanSaveOnEpochBoundary(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -76,7 +76,7 @@ func TestSaveHotState_CanSaveOnEpochBoundary(t *testing.T) {
 func TestSaveHotState_NoSaveNotEpochBoundary(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -112,7 +112,7 @@ func TestSaveHotState_NoSaveNotEpochBoundary(t *testing.T) {
 
 func TestLoadHoteStateByRoot_Cached(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -132,7 +132,7 @@ func TestLoadHoteStateByRoot_Cached(t *testing.T) {
 
 func TestLoadHoteStateByRoot_FromDBCanProcess(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -176,7 +176,7 @@ func TestLoadHoteStateByRoot_FromDBCanProcess(t *testing.T) {
 
 func TestLoadHoteStateByRoot_FromDBBoundaryCase(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -213,7 +213,7 @@ func TestLoadHoteStateByRoot_FromDBBoundaryCase(t *testing.T) {
 
 func TestLoadHoteStateBySlot_CanAdvanceSlotUsingDB(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -243,7 +243,7 @@ func TestLoadHoteStateBySlot_CanAdvanceSlotUsingDB(t *testing.T) {
 
 func TestLastAncestorState_CanGet(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	b0 := testutil.NewBeaconBlock()

--- a/beacon-chain/state/stategen/migrate_test.go
+++ b/beacon-chain/state/stategen/migrate_test.go
@@ -18,7 +18,7 @@ import (
 func TestMigrateToCold_NoBlock(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 1
@@ -32,7 +32,7 @@ func TestMigrateToCold_NoBlock(t *testing.T) {
 func TestMigrateToCold_HigherSplitSlot(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 2
@@ -46,7 +46,7 @@ func TestMigrateToCold_HigherSplitSlot(t *testing.T) {
 func TestMigrateToCold_MigrationCompletes(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 1
@@ -109,7 +109,7 @@ func TestMigrateToCold_MigrationCompletes(t *testing.T) {
 
 func TestMigrateToCold_CantDeleteCurrentArchivedIndex(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 1
@@ -176,7 +176,7 @@ func TestMigrateToCold_CantDeleteCurrentArchivedIndex(t *testing.T) {
 }
 
 func TestSkippedArchivedPoint_CanRecover(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 32

--- a/beacon-chain/state/stategen/replay_test.go
+++ b/beacon-chain/state/stategen/replay_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestComputeStateUpToSlot_GenesisState(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -53,7 +53,7 @@ func TestComputeStateUpToSlot_GenesisState(t *testing.T) {
 
 func TestComputeStateUpToSlot_CanProcessUpTo(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 
@@ -85,7 +85,7 @@ func TestComputeStateUpToSlot_CanProcessUpTo(t *testing.T) {
 }
 
 func TestReplayBlocks_AllSkipSlots(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	genesisBlock := blocks.NewGenesisBlock([]byte{})
@@ -129,7 +129,7 @@ func TestReplayBlocks_AllSkipSlots(t *testing.T) {
 }
 
 func TestReplayBlocks_SameSlot(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	genesisBlock := blocks.NewGenesisBlock([]byte{})
@@ -173,7 +173,7 @@ func TestReplayBlocks_SameSlot(t *testing.T) {
 }
 
 func TestLoadBlocks_FirstBranch(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -206,7 +206,7 @@ func TestLoadBlocks_FirstBranch(t *testing.T) {
 }
 
 func TestLoadBlocks_SecondBranch(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -237,7 +237,7 @@ func TestLoadBlocks_SecondBranch(t *testing.T) {
 }
 
 func TestLoadBlocks_ThirdBranch(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -270,7 +270,7 @@ func TestLoadBlocks_ThirdBranch(t *testing.T) {
 }
 
 func TestLoadBlocks_SameSlots(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -301,7 +301,7 @@ func TestLoadBlocks_SameSlots(t *testing.T) {
 }
 
 func TestLoadBlocks_SameEndSlots(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -331,7 +331,7 @@ func TestLoadBlocks_SameEndSlots(t *testing.T) {
 }
 
 func TestLoadBlocks_SameEndSlotsWith2blocks(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -360,7 +360,7 @@ func TestLoadBlocks_SameEndSlotsWith2blocks(t *testing.T) {
 }
 
 func TestLoadBlocks_BadStart(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB: db,
@@ -377,7 +377,7 @@ func TestLoadBlocks_BadStart(t *testing.T) {
 }
 
 func TestLastSavedBlock_Genesis(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -409,7 +409,7 @@ func TestLastSavedBlock_Genesis(t *testing.T) {
 }
 
 func TestLastSavedBlock_CanGet(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -446,7 +446,7 @@ func TestLastSavedBlock_CanGet(t *testing.T) {
 }
 
 func TestLastSavedBlock_NoSavedBlock(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -463,7 +463,7 @@ func TestLastSavedBlock_NoSavedBlock(t *testing.T) {
 }
 
 func TestLastSavedState_Genesis(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -492,7 +492,7 @@ func TestLastSavedState_Genesis(t *testing.T) {
 }
 
 func TestLastSavedState_CanGet(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -534,7 +534,7 @@ func TestLastSavedState_CanGet(t *testing.T) {
 }
 
 func TestLastSavedState_NoSavedBlockState(t *testing.T) {
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
 	s := &State{
 		beaconDB:  db,
@@ -554,7 +554,7 @@ func TestLastSavedState_NoSavedBlockState(t *testing.T) {
 
 func TestArchivedRoot_CanGetSpecificIndex(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	r := [32]byte{'a'}
@@ -572,7 +572,7 @@ func TestArchivedRoot_CanGetSpecificIndex(t *testing.T) {
 
 func TestArchivedRoot_CanGetOlderOlder(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	r := [32]byte{'a'}
@@ -594,7 +594,7 @@ func TestArchivedRoot_CanGetOlderOlder(t *testing.T) {
 
 func TestArchivedRoot_CanGetGenesisIndex(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	gBlock := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -619,7 +619,7 @@ func TestArchivedRoot_CanGetGenesisIndex(t *testing.T) {
 
 func TestArchivedState_CanGetSpecificIndex(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 
 	r := [32]byte{'a'}
@@ -648,7 +648,7 @@ func TestArchivedState_CanGetSpecificIndex(t *testing.T) {
 
 func TestProcessStateUpToSlot_CanExitEarly(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -667,7 +667,7 @@ func TestProcessStateUpToSlot_CanExitEarly(t *testing.T) {
 
 func TestProcessStateUpToSlot_CanProcess(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)

--- a/beacon-chain/state/stategen/service_test.go
+++ b/beacon-chain/state/stategen/service_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestResume(t *testing.T) {
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	root := [32]byte{'A'}

--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -15,7 +15,7 @@ import (
 func TestSaveState_ColdStateCanBeSaved(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
@@ -47,7 +47,7 @@ func TestSaveState_ColdStateCanBeSaved(t *testing.T) {
 func TestSaveState_HotStateCanBeSaved(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
@@ -75,7 +75,7 @@ func TestSaveState_HotStateCanBeSaved(t *testing.T) {
 func TestSaveState_HotStateCached(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
-	db := testDB.SetupDB(t)
+	db, _ := testDB.SetupDB(t)
 
 	service := New(db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -255,7 +255,7 @@ func TestBlocksFetcher_RoundRobin(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cache.initializeRootCache(tt.expectedBlockSlots, t)
 
-			beaconDB := dbtest.SetupDB(t)
+			beaconDB, _ := dbtest.SetupDB(t)
 
 			p := p2pt.NewTestP2P(t)
 			connectPeers(t, p, tt.peers, p.Peers())

--- a/beacon-chain/sync/initial-sync/initial_sync_test.go
+++ b/beacon-chain/sync/initial-sync/initial_sync_test.go
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 
 func initializeTestServices(t *testing.T, blocks []uint64, peers []*peerData) (*mock.ChainService, *p2pt.TestP2P, db.Database) {
 	cache.initializeRootCache(blocks, t)
-	beaconDB := dbtest.SetupDB(t)
+	beaconDB, _ := dbtest.SetupDB(t)
 
 	p := p2pt.NewTestP2P(t)
 	connectPeers(t, p, peers, p.Peers())

--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -231,7 +231,7 @@ func TestService_roundRobinSync(t *testing.T) {
 			cache.initializeRootCache(tt.expectedBlockSlots, t)
 
 			p := p2pt.NewTestP2P(t)
-			beaconDB := dbtest.SetupDB(t)
+			beaconDB, _ := dbtest.SetupDB(t)
 
 			connectPeers(t, p, tt.peers, p.Peers())
 			cache.RLock()
@@ -283,7 +283,7 @@ func TestService_roundRobinSync(t *testing.T) {
 }
 
 func TestService_processBlock(t *testing.T) {
-	beaconDB := dbtest.SetupDB(t)
+	beaconDB, _ := dbtest.SetupDB(t)
 	genesisBlk := &eth.BeaconBlock{
 		Slot: 0,
 	}

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)
 	p1.Connect(p2)
@@ -61,7 +61,7 @@ func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
 
 func TestProcessPendingAtts_HasBlockSaveUnAggregatedAtt(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p1 := p2ptest.NewTestP2P(t)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
@@ -115,7 +115,7 @@ func TestProcessPendingAtts_HasBlockSaveUnAggregatedAtt(t *testing.T) {
 
 func TestProcessPendingAtts_HasBlockSaveAggregatedAtt(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p1 := p2ptest.NewTestP2P(t)
 	validators := uint64(256)
 	testutil.ResetCache()

--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -25,7 +25,7 @@ import (
 //    \- b3
 // Test b1 was missing then received and we can process b0 -> b1 -> b2
 func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks1(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 
 	p1 := p2ptest.NewTestP2P(t)
 	r := &Service{
@@ -100,7 +100,7 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks1(t *testing.T) {
 //    \- b3 - b4
 // Test b2 and b3 were missed, after receiving them we can process 2 chains.
 func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks2(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)
 	p1.Connect(p2)
@@ -230,7 +230,7 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks2(t *testing.T) {
 }
 
 func TestRegularSyncBeaconBlockSubscriber_PruneOldPendingBlocks(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)
 	p1.Connect(p2)

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
@@ -27,7 +27,7 @@ func TestRPCBeaconBlocksByRange_RPCHandlerReturnsBlocks(t *testing.T) {
 	if len(p1.BHost.Network().Peers()) != 1 {
 		t.Error("Expected peers to be connected")
 	}
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 
 	req := &pb.BeaconBlocksByRangeRequest{
 		StartSlot: 100,
@@ -92,7 +92,7 @@ func TestRPCBeaconBlocksByRange_RPCHandlerReturnsSortedBlocks(t *testing.T) {
 	if len(p1.BHost.Network().Peers()) != 1 {
 		t.Error("Expected peers to be connected")
 	}
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 
 	req := &pb.BeaconBlocksByRangeRequest{
 		StartSlot: 200,
@@ -153,7 +153,7 @@ func TestRPCBeaconBlocksByRange_ReturnsGenesisBlock(t *testing.T) {
 	if len(p1.BHost.Network().Peers()) != 1 {
 		t.Error("Expected peers to be connected")
 	}
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 
 	req := &pb.BeaconBlocksByRangeRequest{
 		StartSlot: 0,
@@ -219,7 +219,7 @@ func TestRPCBeaconBlocksByRange_ReturnsGenesisBlock(t *testing.T) {
 }
 
 func TestRPCBeaconBlocksByRange_RPCHandlerRateLimitOverflow(t *testing.T) {
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 	hook := logTest.NewGlobal()
 	saveBlocks := func(req *pb.BeaconBlocksByRangeRequest) {
 		// Populate the database with blocks that would match the request.

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -29,7 +29,7 @@ func TestRecentBeaconBlocksRPCHandler_ReturnsBlocks(t *testing.T) {
 	if len(p1.BHost.Network().Peers()) != 1 {
 		t.Error("Expected peers to be connected")
 	}
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 
 	var blkRoots [][]byte
 	// Populate the database with blocks that would match the request.

--- a/beacon-chain/sync/rpc_goodbye_test.go
+++ b/beacon-chain/sync/rpc_goodbye_test.go
@@ -22,7 +22,7 @@ func TestGoodByeRPCHandler_Disconnects_With_Peer(t *testing.T) {
 	}
 
 	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 	r := &Service{
 		db:  d,
 		p2p: p1,
@@ -66,7 +66,7 @@ func TestSendGoodbye_SendsMessage(t *testing.T) {
 	}
 
 	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 	r := &Service{
 		db:  d,
 		p2p: p1,
@@ -113,7 +113,7 @@ func TestSendGoodbye_DisconnectWithPeer(t *testing.T) {
 	}
 
 	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 	r := &Service{
 		db:  d,
 		p2p: p1,

--- a/beacon-chain/sync/rpc_metadata_test.go
+++ b/beacon-chain/sync/rpc_metadata_test.go
@@ -30,7 +30,7 @@ func TestMetaDataRPCHandler_ReceivesMetadata(t *testing.T) {
 	}
 
 	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 	r := &Service{
 		db:  d,
 		p2p: p1,
@@ -85,7 +85,7 @@ func TestMetadataRPCHandler_SendsMetadata(t *testing.T) {
 	}
 
 	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 	r := &Service{
 		db:  d,
 		p2p: p1,

--- a/beacon-chain/sync/rpc_ping_test.go
+++ b/beacon-chain/sync/rpc_ping_test.go
@@ -33,7 +33,7 @@ func TestPingRPCHandler_ReceivesPing(t *testing.T) {
 	}
 
 	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 	r := &Service{
 		db:  d,
 		p2p: p1,
@@ -96,7 +96,7 @@ func TestPingRPCHandler_SendsPing(t *testing.T) {
 	}
 
 	// Set up a head state in the database with data we expect.
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 	r := &Service{
 		db:  d,
 		p2p: p1,

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -169,7 +169,7 @@ func TestStatusRPCHandler_ReturnsHelloMessage(t *testing.T) {
 	if len(p1.BHost.Network().Peers()) != 1 {
 		t.Error("Expected peers to be connected")
 	}
-	db := testingDB.SetupDB(t)
+	db, _ := testingDB.SetupDB(t)
 
 	// Set up a head state with data we expect.
 	headRoot, err := ssz.HashTreeRoot(&ethpb.BeaconBlock{Slot: 111})
@@ -270,7 +270,7 @@ func TestHandshakeHandlers_Roundtrip(t *testing.T) {
 	// p2 disconnects and p1 should forget the handshake status.
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)
-	db := testingDB.SetupDB(t)
+	db, _ := testingDB.SetupDB(t)
 
 	p1.LocalMetadata = &pb.MetaData{
 		SeqNumber: 2,
@@ -514,7 +514,7 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 func TestStatusRPCRequest_FinalizedBlockExists(t *testing.T) {
 	p1 := p2ptest.NewTestP2P(t)
 	p2 := p2ptest.NewTestP2P(t)
-	db := testingDB.SetupDB(t)
+	db, _ := testingDB.SetupDB(t)
 
 	// Set up a head state with data we expect.
 	headRoot, err := ssz.HashTreeRoot(&ethpb.BeaconBlock{Slot: 111})

--- a/beacon-chain/sync/subscriber_beacon_attestation_test.go
+++ b/beacon-chain/sync/subscriber_beacon_attestation_test.go
@@ -31,7 +31,7 @@ func TestService_committeeIndexBeaconAttestationSubscriber_ValidMessage(t *testi
 	defer resetCfg()
 
 	ctx := context.Background()
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	s, sKeys := testutil.DeterministicGenesisState(t, 64 /*validators*/)
 	if err := s.SetGenesisTime(uint64(time.Now().Unix())); err != nil {
 		t.Fatal(err)

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -67,7 +67,7 @@ func TestSubscribe_ReceivesValidMessage(t *testing.T) {
 func TestSubscribe_ReceivesAttesterSlashing(t *testing.T) {
 	p2p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 	chainService := &mockChain.ChainService{
 		Genesis:        time.Now(),
 		ValidatorsRoot: [32]byte{'A'},
@@ -134,7 +134,7 @@ func TestSubscribe_ReceivesProposerSlashing(t *testing.T) {
 		ValidatorsRoot: [32]byte{'A'},
 		Genesis:        time.Now(),
 	}
-	d := db.SetupDB(t)
+	d, _ := db.SetupDB(t)
 	c, err := lru.New(10)
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -148,7 +148,7 @@ func TestVerifySelection_CanVerify(t *testing.T) {
 }
 
 func TestValidateAggregateAndProof_NoBlock(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 
 	att := &ethpb.Attestation{
@@ -199,7 +199,7 @@ func TestValidateAggregateAndProof_NoBlock(t *testing.T) {
 }
 
 func TestValidateAggregateAndProof_NotWithinSlotRange(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 
 	validators := uint64(256)
@@ -293,7 +293,7 @@ func TestValidateAggregateAndProof_NotWithinSlotRange(t *testing.T) {
 }
 
 func TestValidateAggregateAndProof_ExistedInPool(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 
 	validators := uint64(256)
@@ -369,7 +369,7 @@ func TestValidateAggregateAndProofWithNewStateMgmt_CanValidate(t *testing.T) {
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{NewStateMgmt: true})
 	defer resetCfg()
 
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 
 	validators := uint64(256)
@@ -496,7 +496,7 @@ func TestValidateAggregateAndProofWithNewStateMgmt_CanValidate(t *testing.T) {
 }
 
 func TestVerifyIndexInCommittee_SeenAggregatorEpoch(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 
 	validators := uint64(256)

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -29,7 +29,7 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 
 	ctx := context.Background()
 	p := p2ptest.NewTestP2P(t)
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	chain := &mockChain.ChainService{
 		// 1 slot ago.
 		Genesis:          time.Now().Add(time.Duration(-1*int64(params.BeaconConfig().SecondsPerSlot)) * time.Second),

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 	ctx := context.Background()
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	msg := &ethpb.SignedBeaconBlock{
 		Block: &ethpb.BeaconBlock{
 			Slot:       1,
@@ -84,7 +84,7 @@ func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	ctx := context.Background()
 
 	p := p2ptest.NewTestP2P(t)
@@ -133,7 +133,7 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, stateSummaryCache := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 100)
@@ -186,7 +186,6 @@ func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stateSummaryCache := cache.NewStateSummaryCache()
 	stateGen := stategen.New(db, stateSummaryCache)
 	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
 		State: beaconState,
@@ -229,7 +228,7 @@ func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, stateSummaryCache := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 100)
@@ -285,7 +284,6 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stateSummaryCache := cache.NewStateSummaryCache()
 	stateGen := stategen.New(db, stateSummaryCache)
 	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(blkSlot*params.BeaconConfig().SecondsPerSlot), 0),
 		State: beaconState,
@@ -328,7 +326,7 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 	b := []byte("sk")
@@ -375,7 +373,7 @@ func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 	b := []byte("sk")
@@ -427,7 +425,7 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	b := []byte("sk")
 	b32 := bytesutil.ToBytes32(b)
 	p := p2ptest.NewTestP2P(t)
@@ -483,7 +481,7 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
 }
 
 func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 	ctx := context.Background()
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 100)
@@ -570,7 +568,7 @@ func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
 
 func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
 	hook := logTest.NewGlobal()
-	db := dbtest.SetupDB(t)
+	db, _ := dbtest.SetupDB(t)
 	p := p2ptest.NewTestP2P(t)
 
 	parent := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

As title describes, this refactors the testutil.SetupDB to return the state summary cache used by the database. To better test this cache, tests should use the same cache that the database uses.

**Which issues(s) does this PR fix?**

No known issues.

**Other notes for review**

This idea was inspired by @terencechain commit on PR #6298 https://github.com/prysmaticlabs/prysm/pull/6298/commits/63d33b07a512b90fa546d31917799624d48b3fb4.

No production code changes, only tests.
