### PR TITLE
QSP-61 Clarify Why Process Pending Attestations May Exit Early

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -124,7 +124,10 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 
 			// Start with a random peer to query, but choose the first peer in our unsorted list that claims to
 			// have a head slot newer or equal to the pending attestation's target boundary slot.
+			// If there are no peer id's available, then we should exit from this function. The function will
+			// be run again periodically, and there may be peers available in future runs.
 			if len(pids) == 0 {
+				log.Debug("No peer IDs available to request missing block from for pending attestation")
 				return nil
 			}
 			pid := pids[rand.Int()%len(pids)]


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Documentation

**What does this PR do? Why is it needed?**

Currently, we have a function processPendingAttestations() in sync which runs periodically and requests missing blocks from peers from pending attestations we have observed. If there are no peers to request from, the function exits early, however, there is no comment signifying why this is safe.

**Which issues(s) does this PR fix?**

Part of #6327 
