### PR TITLE
QSP-41 Clarify Block Filters Passthrough In DB

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -600,6 +600,8 @@ func createBlockIndicesFromFilters(ctx context.Context, f *filters.QueryFilter) 
 				return nil, errors.New("parent root is not []byte")
 			}
 			indicesByBucket[string(blockParentRootIndicesBucket)] = parentRoot
+		// The following cases are passthroughs for blocks, as they are not used
+		// for filtering indices.
 		case filters.StartSlot:
 		case filters.EndSlot:
 		case filters.StartEpoch:


### PR DESCRIPTION
Part of #6327, this PR adds a clarifying comment as to why the block filters aren't required in beacon-chain/db/kv/blocks.go