### PR TITLE
QSP-62 Corrupted Clock In Stream Deadlines

### DIFF
--- a/beacon-chain/sync/deadlines.go
+++ b/beacon-chain/sync/deadlines.go
@@ -11,18 +11,19 @@ import (
 var defaultReadDuration = ttfbTimeout
 var defaultWriteDuration = params.BeaconNetworkConfig().RespTimeout // RESP_TIMEOUT
 
+// SetRPCStreamDeadlines sets read and write deadlines for libp2p-based connection streams.
 func SetRPCStreamDeadlines(stream network.Stream) {
 	SetStreamReadDeadline(stream, defaultReadDuration)
 	SetStreamWriteDeadline(stream, defaultWriteDuration)
 }
 
-// SetStreamReadDeadline for libp2p connection streams, deciding when to close
+// SetStreamReadDeadline for reading from libp2p connection streams, deciding when to close
 // a connection based on a particular duration.
 //
 // NOTE: libp2p uses the system clock time for determining the deadline so we use
 // time.Now() instead of the synchronized roughtime.Now(). If the system
 // time is corrupted (i.e. time does not advance), the node will experience
-// significant
+// significant.
 func SetStreamReadDeadline(stream network.Stream, duration time.Duration) {
 	if err := stream.SetReadDeadline(time.Now().Add(duration)); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
@@ -33,9 +34,14 @@ func SetStreamReadDeadline(stream network.Stream, duration time.Duration) {
 	}
 }
 
+// SetStreamWriteDeadline for writing to libp2p connection streams, deciding when to close
+// a connection based on a particular duration.
+//
+// NOTE: libp2p uses the system clock time for determining the deadline so we use
+// time.Now() instead of the synchronized roughtime.Now(). If the system
+// time is corrupted (i.e. time does not advance), the node will experience
+// significant.
 func SetStreamWriteDeadline(stream network.Stream, duration time.Duration) {
-	// libp2p uses the system clock time for determining the deadline so we use
-	// time.Now() instead of the synchronized roughtime.Now().
 	if err := stream.SetWriteDeadline(time.Now().Add(duration)); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
 			"peer":      stream.Conn().RemotePeer(),

--- a/beacon-chain/sync/deadlines.go
+++ b/beacon-chain/sync/deadlines.go
@@ -23,7 +23,8 @@ func SetRPCStreamDeadlines(stream network.Stream) {
 // NOTE: libp2p uses the system clock time for determining the deadline so we use
 // time.Now() instead of the synchronized roughtime.Now(). If the system
 // time is corrupted (i.e. time does not advance), the node will experience
-// significant.
+// issues being able to properly close streams, leading to unexpected failures and possible
+// memory leaks.
 func SetStreamReadDeadline(stream network.Stream, duration time.Duration) {
 	if err := stream.SetReadDeadline(time.Now().Add(duration)); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
@@ -40,7 +41,8 @@ func SetStreamReadDeadline(stream network.Stream, duration time.Duration) {
 // NOTE: libp2p uses the system clock time for determining the deadline so we use
 // time.Now() instead of the synchronized roughtime.Now(). If the system
 // time is corrupted (i.e. time does not advance), the node will experience
-// significant.
+// issues being able to properly close streams, leading to unexpected failures and possible
+// memory leaks.
 func SetStreamWriteDeadline(stream network.Stream, duration time.Duration) {
 	if err := stream.SetWriteDeadline(time.Now().Add(duration)); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{

--- a/beacon-chain/sync/deadlines.go
+++ b/beacon-chain/sync/deadlines.go
@@ -11,14 +11,19 @@ import (
 var defaultReadDuration = ttfbTimeout
 var defaultWriteDuration = params.BeaconNetworkConfig().RespTimeout // RESP_TIMEOUT
 
-func setRPCStreamDeadlines(stream network.Stream) {
-	setStreamReadDeadline(stream, defaultReadDuration)
-	setStreamWriteDeadline(stream, defaultWriteDuration)
+func SetRPCStreamDeadlines(stream network.Stream) {
+	SetStreamReadDeadline(stream, defaultReadDuration)
+	SetStreamWriteDeadline(stream, defaultWriteDuration)
 }
 
-func setStreamReadDeadline(stream network.Stream, duration time.Duration) {
-	// libp2p uses the system clock time for determining the deadline so we use
-	// time.Now() instead of the synchronized roughtime.Now().
+// SetStreamReadDeadline for libp2p connection streams, deciding when to close
+// a connection based on a particular duration.
+//
+// NOTE: libp2p uses the system clock time for determining the deadline so we use
+// time.Now() instead of the synchronized roughtime.Now(). If the system
+// time is corrupted (i.e. time does not advance), the node will experience
+// significant
+func SetStreamReadDeadline(stream network.Stream, duration time.Duration) {
 	if err := stream.SetReadDeadline(time.Now().Add(duration)); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
 			"peer":      stream.Conn().RemotePeer(),
@@ -28,7 +33,7 @@ func setStreamReadDeadline(stream network.Stream, duration time.Duration) {
 	}
 }
 
-func setStreamWriteDeadline(stream network.Stream, duration time.Duration) {
+func SetStreamWriteDeadline(stream network.Stream, duration time.Duration) {
 	// libp2p uses the system clock time for determining the deadline so we use
 	// time.Now() instead of the synchronized roughtime.Now().
 	if err := stream.SetWriteDeadline(time.Now().Add(duration)); err != nil {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -27,7 +27,7 @@ func (s *Service) beaconBlocksByRangeRPCHandler(ctx context.Context, msg interfa
 	}()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	setRPCStreamDeadlines(stream)
+	SetRPCStreamDeadlines(stream)
 	log := log.WithField("handler", "beacon_blocks_by_range")
 
 	// Ticker to stagger out large requests.

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -67,7 +67,7 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 	}()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	setRPCStreamDeadlines(stream)
+	SetRPCStreamDeadlines(stream)
 	log := log.WithField("handler", "beacon_blocks_by_root")
 
 	req, ok := msg.(*pbp2p.BeaconBlocksByRootRequest)

--- a/beacon-chain/sync/rpc_chunked_response.go
+++ b/beacon-chain/sync/rpc_chunked_response.go
@@ -14,7 +14,7 @@ import (
 // stream.
 // response_chunk ::= | <result> | <encoding-dependent-header> | <encoded-payload>
 func (s *Service) chunkWriter(stream libp2pcore.Stream, msg interface{}) error {
-	setStreamWriteDeadline(stream, defaultWriteDuration)
+	SetStreamWriteDeadline(stream, defaultWriteDuration)
 	return WriteChunk(stream, s.p2p.Encoding(), msg)
 }
 
@@ -41,7 +41,7 @@ func ReadChunkedBlock(stream libp2pcore.Stream, p2p p2p.P2P) (*eth.SignedBeaconB
 // readResponseChunk reads the response from the stream and decodes it into the
 // provided message type.
 func readResponseChunk(stream libp2pcore.Stream, p2p p2p.P2P, to interface{}) error {
-	setStreamReadDeadline(stream, 10*time.Second)
+	SetStreamReadDeadline(stream, 10*time.Second)
 	code, errMsg, err := ReadStatusCode(stream, p2p.Encoding())
 	if err != nil {
 		return err

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -32,7 +32,7 @@ func (s *Service) goodbyeRPCHandler(ctx context.Context, msg interface{}, stream
 	}()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	setRPCStreamDeadlines(stream)
+	SetRPCStreamDeadlines(stream)
 
 	m, ok := msg.(*uint64)
 	if !ok {

--- a/beacon-chain/sync/rpc_metadata.go
+++ b/beacon-chain/sync/rpc_metadata.go
@@ -20,7 +20,7 @@ func (s *Service) metaDataHandler(ctx context.Context, msg interface{}, stream l
 	}()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	setRPCStreamDeadlines(stream)
+	SetRPCStreamDeadlines(stream)
 
 	if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
 		return err

--- a/beacon-chain/sync/rpc_ping.go
+++ b/beacon-chain/sync/rpc_ping.go
@@ -13,7 +13,7 @@ import (
 
 // pingHandler reads the incoming ping rpc message from the peer.
 func (s *Service) pingHandler(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
-	setRPCStreamDeadlines(stream)
+	SetRPCStreamDeadlines(stream)
 
 	m, ok := msg.(*uint64)
 	if !ok {

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -168,7 +168,7 @@ func (s *Service) statusRPCHandler(ctx context.Context, msg interface{}, stream 
 	}()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	setRPCStreamDeadlines(stream)
+	SetRPCStreamDeadlines(stream)
 	log := log.WithField("handler", "status")
 	m, ok := msg.(*pb.Status)
 	if !ok {


### PR DESCRIPTION
Part of #6327. Libp2p stream read/write deadlines use the system time instead of roughtime. This PR adds clear information about why that is the case and what would happen if the system time becomes corrupted.