### PR TITLE
Fix Invalid SSZ in Block Roots RPC Request

### DIFF
--- a/beacon-chain/p2p/encoder/ssz.go
+++ b/beacon-chain/p2p/encoder/ssz.go
@@ -117,7 +117,6 @@ func (e SszNetworkEncoder) doDecode(b []byte, to interface{}) error {
 		// unmarshalling again. This is temporary to
 		// avoid too much disruption to live nodes.
 		if _, ok := to.([][32]byte); ok {
-			fmt.Sprintf("\n lopping off 4 bytes with length %d", len(b))
 			return ssz.Unmarshal(b[4:], to)
 		}
 		return err

--- a/beacon-chain/p2p/encoder/ssz.go
+++ b/beacon-chain/p2p/encoder/ssz.go
@@ -110,7 +110,19 @@ func (e SszNetworkEncoder) doDecode(b []byte, to interface{}) error {
 	if v, ok := to.(fastssz.Unmarshaler); ok {
 		return v.UnmarshalSSZ(b)
 	}
-	return ssz.Unmarshal(b, to)
+	err := ssz.Unmarshal(b, to)
+	if err != nil {
+		// Check if we are unmarshalling block roots
+		// and then lop off the 4 byte offset and try
+		// unmarshalling again. This is temporary to
+		// avoid too much disruption to live nodes.
+		if _, ok := to.([][32]byte); ok {
+			fmt.Sprintf("\n lopping off 4 bytes with length %d", len(b))
+			return ssz.Unmarshal(b[4:], to)
+		}
+		return err
+	}
+	return nil
 }
 
 // Decode the bytes to the protobuf message provided.

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -159,6 +159,8 @@ go_test(
         "@com_github_libp2p_go_libp2p_core//protocol:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//pb:go_default_library",
+        "@com_github_protolambda_zssz//:go_default_library",
+        "@com_github_protolambda_zssz//types:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -143,10 +143,12 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 				}
 			}
 
-			req := [][]byte{bRoot[:]}
+			req := [][32]byte{bRoot}
 			if err := s.sendRecentBeaconBlocksRequest(ctx, req, pid); err != nil {
-				traceutil.AnnotateError(span, err)
-				log.Errorf("Could not send recent block request: %v", err)
+				if err = s.sendRecentBeaconBlocksRequestFallback(ctx, req, pid); err != nil {
+					traceutil.AnnotateError(span, err)
+					log.Errorf("Could not send recent block request: %v", err)
+				}
 			}
 		}
 	}

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -76,7 +76,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 				"currentSlot": b.Block.Slot,
 				"parentRoot":  hex.EncodeToString(bytesutil.Trunc(b.Block.ParentRoot)),
 			}).Info("Requesting parent block")
-			req := [][]byte{b.Block.ParentRoot}
+			req := [][32]byte{bytesutil.ToBytes32(b.Block.ParentRoot)}
 
 			// Start with a random peer to query, but choose the first peer in our unsorted list that claims to
 			// have a head slot newer than the block slot we are requesting.
@@ -93,8 +93,10 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 			}
 
 			if err := s.sendRecentBeaconBlocksRequest(ctx, req, pid); err != nil {
-				traceutil.AnnotateError(span, err)
-				log.Errorf("Could not send recent block request: %v", err)
+				if err = s.sendRecentBeaconBlocksRequestFallback(ctx, req, pid); err != nil {
+					traceutil.AnnotateError(span, err)
+					log.Errorf("Could not send recent block request: %v", err)
+				}
 			}
 			span.End()
 			continue

--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -49,7 +49,7 @@ func (s *Service) registerRPCHandlers() {
 	)
 	s.registerRPC(
 		p2p.RPCBlocksByRootTopic,
-		&pb.BeaconBlocksByRootRequest{},
+		[][32]byte{},
 		s.beaconBlocksRootRPCHandler,
 	)
 	s.registerRPC(

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -5,23 +5,68 @@ import (
 	"io"
 	"time"
 
+	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+
 	libp2pcore "github.com/libp2p/go-libp2p-core"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
-	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
 // sendRecentBeaconBlocksRequest sends a recent beacon blocks request to a peer to get
 // those corresponding blocks from that peer.
-func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots [][]byte, id peer.ID) error {
+func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots [][32]byte, id peer.ID) error {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	req := &pbp2p.BeaconBlocksByRootRequest{BlockRoots: blockRoots}
+	stream, err := s.p2p.Send(ctx, blockRoots, p2p.RPCBlocksByRootTopic, id)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := stream.Reset(); err != nil {
+			log.WithError(err).Errorf("Failed to reset stream with protocol %s", stream.Protocol())
+		}
+	}()
+	for i := 0; i < len(blockRoots); i++ {
+		blk, err := ReadChunkedBlock(stream, s.p2p)
+		if err == io.EOF {
+			break
+		}
+		// Exit if peer sends more than max request blocks.
+		if uint64(i) >= params.BeaconNetworkConfig().MaxRequestBlocks {
+			break
+		}
+		if err != nil {
+			log.WithError(err).Error("Unable to retrieve block from stream")
+			return err
+		}
+
+		blkRoot, err := stateutil.BlockRoot(blk.Block)
+		if err != nil {
+			return err
+		}
+		s.pendingQueueLock.Lock()
+		s.slotToPendingBlocks[blk.Block.Slot] = blk
+		s.seenPendingBlocks[blkRoot] = true
+		s.pendingQueueLock.Unlock()
+
+	}
+	return nil
+}
+
+// Deprecated: sendRecentBeaconBlocksRequestFallback sends a recent beacon blocks request to a peer to get
+// those corresponding blocks from that peer. This is a method implemented so that we are eventually
+// backward compatible with old Onyx nodes.
+func (s *Service) sendRecentBeaconBlocksRequestFallback(ctx context.Context, blockRoots [][32]byte, id peer.ID) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	req := &pbp2p.BeaconBlocksByRootRequest{}
+	for _, root := range blockRoots {
+		req.BlockRoots = append(req.BlockRoots, root[:])
+	}
 	stream, err := s.p2p.Send(ctx, req, p2p.RPCBlocksByRootTopic, id)
 	if err != nil {
 		return err
@@ -70,11 +115,11 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 	setRPCStreamDeadlines(stream)
 	log := log.WithField("handler", "beacon_blocks_by_root")
 
-	req, ok := msg.(*pbp2p.BeaconBlocksByRootRequest)
+	blockRoots, ok := msg.([][32]byte)
 	if !ok {
 		return errors.New("message is not type BeaconBlocksByRootRequest")
 	}
-	if len(req.BlockRoots) == 0 {
+	if len(blockRoots) == 0 {
 		resp, err := s.generateErrorResponse(responseCodeInvalidRequest, "no block roots provided in request")
 		if err != nil {
 			log.WithError(err).Error("Failed to generate a response error")
@@ -86,7 +131,7 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		return errors.New("no block roots provided")
 	}
 
-	if int64(len(req.BlockRoots)) > s.blocksRateLimiter.Remaining(stream.Conn().RemotePeer().String()) {
+	if int64(len(blockRoots)) > s.blocksRateLimiter.Remaining(stream.Conn().RemotePeer().String()) {
 		s.p2p.Peers().IncrementBadResponses(stream.Conn().RemotePeer())
 		if s.p2p.Peers().IsBad(stream.Conn().RemotePeer()) {
 			log.Debug("Disconnecting bad peer")
@@ -107,7 +152,7 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		return errors.New(rateLimitedError)
 	}
 
-	if uint64(len(req.BlockRoots)) > params.BeaconNetworkConfig().MaxRequestBlocks {
+	if uint64(len(blockRoots)) > params.BeaconNetworkConfig().MaxRequestBlocks {
 		resp, err := s.generateErrorResponse(responseCodeInvalidRequest, "requested more than the max block limit")
 		if err != nil {
 			log.WithError(err).Error("Failed to generate a response error")
@@ -119,10 +164,10 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		return errors.New("requested more than the max block limit")
 	}
 
-	s.blocksRateLimiter.Add(stream.Conn().RemotePeer().String(), int64(len(req.BlockRoots)))
+	s.blocksRateLimiter.Add(stream.Conn().RemotePeer().String(), int64(len(blockRoots)))
 
-	for _, root := range req.BlockRoots {
-		blk, err := s.db.Block(ctx, bytesutil.ToBytes32(root))
+	for _, root := range blockRoots {
+		blk, err := s.db.Block(ctx, root)
 		if err != nil {
 			log.WithError(err).Error("Failed to fetch block")
 			resp, err := s.generateErrorResponse(responseCodeServerError, genericError)

--- a/deps.bzl
+++ b/deps.bzl
@@ -2594,8 +2594,8 @@ def prysm_deps():
     go_repository(
         name = "com_github_protolambda_zssz",
         importpath = "github.com/protolambda/zssz",
-        sum = "h1:4jkt8sqwhOVR8B1JebREU/gVX0Ply4GypsV8+RWrDuw=",
-        version = "v0.1.4",
+        sum = "h1:7fjJjissZIIaa2QcvmhS/pZISMX21zVITt49sW1ouek=",
+        version = "v0.1.5",
     )
     go_repository(
         name = "com_github_prysmaticlabs_ethereumapis",

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/prestonvanloon/go-recaptcha v0.0.0-20190217191114-0834cef6e8bd
 	github.com/prometheus/client_golang v1.6.0
 	github.com/prometheus/tsdb v0.10.0 // indirect
-	github.com/protolambda/zssz v0.1.4
+	github.com/protolambda/zssz v0.1.5
 	github.com/prysmaticlabs/ethereumapis v0.0.0-20200617012222-f52a0eff2886
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20200618145306-2ae0807bef65
 	github.com/prysmaticlabs/go-ssz v0.0.0-20200605034351-b6a925e519d0

--- a/go.sum
+++ b/go.sum
@@ -890,6 +890,8 @@ github.com/prometheus/tsdb v0.10.0/go.mod h1:oi49uRhEe9dPUTlS3JRZOwJuVi6tmh10QSg
 github.com/protolambda/zssz v0.1.3/go.mod h1:a4iwOX5FE7/JkKA+J/PH0Mjo9oXftN6P8NZyL28gpag=
 github.com/protolambda/zssz v0.1.4 h1:4jkt8sqwhOVR8B1JebREU/gVX0Ply4GypsV8+RWrDuw=
 github.com/protolambda/zssz v0.1.4/go.mod h1:a4iwOX5FE7/JkKA+J/PH0Mjo9oXftN6P8NZyL28gpag=
+github.com/protolambda/zssz v0.1.5 h1:7fjJjissZIIaa2QcvmhS/pZISMX21zVITt49sW1ouek=
+github.com/protolambda/zssz v0.1.5/go.mod h1:a4iwOX5FE7/JkKA+J/PH0Mjo9oXftN6P8NZyL28gpag=
 github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20200622172343-b50bad5c6f58 h1:6TlvcghiASejE0zd3ZEhd2ZQ+e+S2EALSgixivLzi8Q=
 github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20200622172343-b50bad5c6f58/go.mod h1:oP8FC5+TbICUyftkTWs+8JryntjIJLJvWvApK3z2AYw=
 github.com/prysmaticlabs/ethereumapis v0.0.0-20200617012222-f52a0eff2886 h1:0zB+DtS1NdwgYtto4JcvV3OX3m1wmM7ocjLvveNaMgA=

--- a/proto/beacon/p2p/v1/messages.proto
+++ b/proto/beacon/p2p/v1/messages.proto
@@ -17,7 +17,7 @@ message BeaconBlocksByRangeRequest {
   uint64 count = 2;
   uint64 step = 3;
 }
-
+// Deprecated: Will eventually be removed is only kept around for backward compatibility.
 message BeaconBlocksByRootRequest {
   repeated bytes block_roots = 1 [(gogoproto.moretags) = "ssz-size:\"?,32\" ssz-max:\"1024\""];
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] We change it to a list of roots, rather than a container containing roots, so as to be compatible with the spec.
- [x] In order to be backward compatible with old onyx nodes, we also handle requests of the old type and the new type
both for encoding and decoding.
- [x] Add compatibility test with zssz. 
**Which issues(s) does this PR fix?**

**Other notes for review**
