### PR TITLE
Remove unused p2p encoding method

### DIFF
--- a/beacon-chain/p2p/encoder/network_encoding.go
+++ b/beacon-chain/p2p/encoder/network_encoding.go
@@ -12,8 +12,6 @@ const (
 
 // NetworkEncoding represents an encoder compatible with Ethereum 2.0 p2p.
 type NetworkEncoding interface {
-	// Decode to the provided message. The interface must be a pointer to the decoding destination.
-	Decode([]byte, interface{}) error
 	// DecodeGossip to the provided gossip message. The interface must be a pointer to the decoding destination.
 	DecodeGossip([]byte, interface{}) error
 	// DecodeWithLength a bytes from a reader with a varint length prefix. The interface must be a pointer to the

--- a/beacon-chain/p2p/encoder/ssz.go
+++ b/beacon-chain/p2p/encoder/ssz.go
@@ -1,7 +1,6 @@
 package encoder
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"sync"
@@ -111,23 +110,6 @@ func (e SszNetworkEncoder) doDecode(b []byte, to interface{}) error {
 		return v.UnmarshalSSZ(b)
 	}
 	return ssz.Unmarshal(b, to)
-}
-
-// Decode the bytes to the protobuf message provided.
-func (e SszNetworkEncoder) Decode(b []byte, to interface{}) error {
-	if e.UseSnappyCompression {
-		newBuffer := bytes.NewBuffer(b)
-		r := newBufferedReader(newBuffer)
-		defer bufReaderPool.Put(r)
-
-		newObj := make([]byte, len(b))
-		numOfBytes, err := r.Read(newObj)
-		if err != nil {
-			return err
-		}
-		return e.doDecode(newObj[:numOfBytes], to)
-	}
-	return e.doDecode(b, to)
 }
 
 // DecodeGossip decodes the bytes to the protobuf gossip message provided.


### PR DESCRIPTION
**What type of PR is this?**

 Other -- Code cleanup

**What does this PR do? Why is it needed?**

This method was not used (or tested) by any code within Prysm.

**Which issues(s) does this PR fix?**

No known production issues.

**Other notes for review**

I am not sure if this was going to be used at some point, but we can always add it back (with tests!) in the future if the spec requires this type of encoding.
