### PR TITLE
QSP-55 Remove Support for Other Pubsub Protocols

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -72,7 +72,6 @@ var appFlags = []cli.Flag{
 	cmd.P2PAllowList,
 	cmd.P2PDenyList,
 	cmd.P2PEncoding,
-	cmd.P2PPubsub,
 	cmd.DataDirFlag,
 	cmd.VerbosityFlag,
 	cmd.EnableTracingFlag,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -376,7 +376,6 @@ func (b *BeaconNode) registerP2P(cliCtx *cli.Context) error {
 		DisableDiscv5:     cliCtx.Bool(flags.DisableDiscv5.Name),
 		Encoding:          cliCtx.String(cmd.P2PEncoding.Name),
 		StateNotifier:     b,
-		PubSub:            cliCtx.String(cmd.P2PPubsub.Name),
 	})
 	if err != nil {
 		return err

--- a/beacon-chain/p2p/config.go
+++ b/beacon-chain/p2p/config.go
@@ -27,5 +27,4 @@ type Config struct {
 	DenyListCIDR        []string
 	Encoding            string
 	StateNotifier       statefeed.Notifier
-	PubSub              string
 }

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +25,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-bitfield"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
@@ -48,22 +48,11 @@ var pollingPeriod = 6 * time.Second
 // Refresh rate of ENR set at twice per slot.
 var refreshRate = slotutil.DivideSlotBy(2)
 
-// search limit for number of peers in discovery v5.
-const searchLimit = 100
-
 // lookup limit whenever looking up for random nodes.
 const lookupLimit = 15
 
-const prysmProtocolPrefix = "/prysm/0.0.0"
-
 // maxBadResponses is the maximum number of bad responses from a peer before we stop talking to it.
 const maxBadResponses = 5
-
-const (
-	pubsubFlood  = "flood"
-	pubsubGossip = "gossip"
-	pubsubRandom = "random"
-)
 
 // Service for managing peer to peer (p2p) networking.
 type Service struct {
@@ -150,19 +139,7 @@ func NewService(cfg *Config) (*Service, error) {
 		pubsub.WithMessageIdFn(msgIDFunction),
 	}
 
-	var gs *pubsub.PubSub
-	if cfg.PubSub == "" {
-		cfg.PubSub = pubsubGossip
-	}
-	if cfg.PubSub == pubsubFlood {
-		gs, err = pubsub.NewFloodSub(s.ctx, s.host, psOpts...)
-	} else if cfg.PubSub == pubsubGossip {
-		gs, err = pubsub.NewGossipSub(s.ctx, s.host, psOpts...)
-	} else if cfg.PubSub == pubsubRandom {
-		gs, err = pubsub.NewRandomSub(s.ctx, s.host, int(cfg.MaxPeers), psOpts...)
-	} else {
-		return nil, fmt.Errorf("unknown pubsub type %s", cfg.PubSub)
-	}
+	gs, err := pubsub.NewGossipSub(s.ctx, s.host, psOpts...)
 	if err != nil {
 		log.WithError(err).Error("Failed to start pubsub")
 		return nil, err

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -122,7 +122,6 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.StaticPeers,
 			cmd.EnableUPnPFlag,
 			cmd.P2PEncoding,
-			cmd.P2PPubsub,
 			flags.MinSyncPeers,
 		},
 	},

--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -160,12 +160,6 @@ var (
 		Usage: "The encoding format of messages sent over the wire. The default is 0, which represents ssz",
 		Value: "ssz-snappy",
 	}
-	// P2PPubsub defines the pubsub router to use for p2p messages.
-	P2PPubsub = &cli.StringFlag{
-		Name:  "p2p-pubsub",
-		Usage: "The name of the pubsub router to use. Supported values are: gossip, flood, random",
-		Value: "gossip",
-	}
 	// ForceClearDB removes any previously stored data at the data directory.
 	ForceClearDB = &cli.BoolFlag{
 		Name:  "force-clear-db",

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -164,6 +164,11 @@ var devModeFlags = []cli.Flag{
 const deprecatedUsage = "DEPRECATED. DO NOT USE."
 
 var (
+	deprecatedP2PPubsub = &cli.StringFlag{
+		Name:   "p2p-pubsub",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 	deprecatedEnableKadDht = &cli.BoolFlag{
 		Name:   "enable-kad-dht",
 		Usage:  deprecatedUsage,
@@ -433,6 +438,7 @@ var (
 )
 
 var deprecatedFlags = []cli.Flag{
+	deprecatedP2PPubsub,
 	deprecatedEnableKadDht,
 	deprecatedWeb3ProviderFlag,
 	deprecatedEnableDynamicCommitteeSubnets,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

This PR is part of #6327, it removes extra pubsub protocol support such as flood and random from Prysm, only allowing for gossip sub
