### PR TITLE
Remove duplicated randao mix copy

### DIFF
--- a/beacon-chain/core/helpers/randao.go
+++ b/beacon-chain/core/helpers/randao.go
@@ -45,12 +45,5 @@ func Seed(state *stateTrie.BeaconState, epoch uint64, domain [bls.DomainByteLeng
 //    """
 //    return state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
 func RandaoMix(state *stateTrie.BeaconState, epoch uint64) ([]byte, error) {
-	currMix, err := state.RandaoMixAtIndex(epoch % params.BeaconConfig().EpochsPerHistoricalVector)
-	if err != nil {
-		return nil, err
-	}
-	newMixLength := len(currMix)
-	newMix := make([]byte, newMixLength)
-	copy(newMix, currMix)
-	return newMix, nil
+	return state.RandaoMixAtIndex(epoch % params.BeaconConfig().EpochsPerHistoricalVector)
 }


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

state.RandaoMixAtIndex already makes a copy of the 32 byte randao mix, there is no need to make another copy of it.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
