### PR TITLE
Use `CopyValidator` for `ValidatorAtIndex`

### DIFF
--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -439,20 +439,7 @@ func (b *BeaconState) ValidatorAtIndex(idx uint64) (*ethpb.Validator, error) {
 		return nil, fmt.Errorf("index %d out of range", idx)
 	}
 	val := b.state.Validators[idx]
-	pubKey := make([]byte, len(val.PublicKey))
-	copy(pubKey, val.PublicKey)
-	withdrawalCreds := make([]byte, len(val.WithdrawalCredentials))
-	copy(withdrawalCreds, val.WithdrawalCredentials)
-	return &ethpb.Validator{
-		PublicKey:                  pubKey,
-		WithdrawalCredentials:      withdrawalCreds,
-		EffectiveBalance:           val.EffectiveBalance,
-		Slashed:                    val.Slashed,
-		ActivationEligibilityEpoch: val.ActivationEligibilityEpoch,
-		ActivationEpoch:            val.ActivationEpoch,
-		ExitEpoch:                  val.ExitEpoch,
-		WithdrawableEpoch:          val.WithdrawableEpoch,
-	}, nil
+	return CopyValidator(val), nil
 }
 
 // ValidatorAtIndexReadOnly is the validator at the provided index. This method


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Code health improvement

**What does this PR do? Why is it needed?**
`ValidatorAtIndex()` could reuse `CopyValidator()` to copy validator
