### PR TITLE
QSP 50, QSP 51: Make Noise Default 

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -73,6 +73,7 @@ go_library(
         "@com_github_libp2p_go_libp2p_peerstore//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//pb:go_default_library",
+        "@com_github_libp2p_go_libp2p_secio//:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
         "@com_github_multiformats_go_multiaddr_net//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/libp2p/go-libp2p"
 	noise "github.com/libp2p/go-libp2p-noise"
+	secio "github.com/libp2p/go-libp2p-secio"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
@@ -37,8 +38,10 @@ func (s *Service) buildOptions(ip net.IP, priKey *ecdsa.PrivateKey) []libp2p.Opt
 		libp2p.ConnectionGater(s),
 	}
 	if featureconfig.Get().EnableNoise {
-		// Enable NOISE for the beacon node
-		options = append(options, libp2p.Security(noise.ID, noise.New))
+		// Enable NOISE for the beacon node with secio as a fallback.
+		options = append(options, libp2p.Security(noise.ID, noise.New), libp2p.Security(secio.ID, secio.New))
+	} else {
+		options = append(options, libp2p.Security(secio.ID, secio.New))
 	}
 	if cfg.EnableUPnP {
 		options = append(options, libp2p.NATPortMap()) //Allow to use UPnP

--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-peerstore v0.2.4
 	github.com/libp2p/go-libp2p-pubsub v0.3.1
+	github.com/libp2p/go-libp2p-secio v0.2.2
 	github.com/libp2p/go-libp2p-swarm v0.2.5
 	github.com/libp2p/go-libp2p-tls v0.1.4-0.20200421131144-8a8ad624a291 // indirect
 	github.com/libp2p/go-libp2p-yamux v0.2.8 // indirect

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -175,9 +175,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Enabling check head state for chainservice")
 		cfg.CheckHeadState = true
 	}
-	if ctx.Bool(enableNoiseHandshake.Name) {
-		log.Warn("Enabling noise handshake for peer")
-		cfg.EnableNoise = true
+	cfg.EnableNoise = true
+	if ctx.Bool(disableNoiseHandshake.Name) {
+		log.Warn("Disabling noise handshake for peer")
+		cfg.EnableNoise = false
 	}
 	if ctx.Bool(dontPruneStateStartUp.Name) {
 		log.Warn("Not enabling state pruning upon start up")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -98,9 +98,9 @@ var (
 		Name:  "check-head-state",
 		Usage: "Enables the checking of head state in chainservice first before retrieving the desired state from the db.",
 	}
-	enableNoiseHandshake = &cli.BoolFlag{
-		Name: "enable-noise",
-		Usage: "This enables the beacon node to use NOISE instead of SECIO for performing handshakes between peers and " +
+	disableNoiseHandshake = &cli.BoolFlag{
+		Name: "disable-noise",
+		Usage: "This disables the beacon node from using NOISE and instead uses SECIO instead for performing handshakes between peers and " +
 			"securing transports between peers",
 	}
 	dontPruneStateStartUp = &cli.BoolFlag{
@@ -435,6 +435,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableNoise = &cli.BoolFlag{
+		Name:   "enable-noise",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -492,6 +497,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedDisableStateRefCopy,
 	deprecatedDisableFieldTrie,
 	deprecateddisableInitSyncBatchSaveBlocks,
+	deprecatedEnableNoise,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -536,7 +542,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	disableUpdateHeadPerAttestation,
 	enableStateGenSigVerify,
 	checkHeadState,
-	enableNoiseHandshake,
+	disableNoiseHandshake,
 	dontPruneStateStartUp,
 	disableBroadcastSlashingFlag,
 	waitForSyncedFlag,


### PR DESCRIPTION
**What type of PR is this?**

Feature Addition

**What does this PR do? Why is it needed?**

We make NOISE as the default for our security handshake, so as to be able to interop with the other clients. This
adds SECIO as the fallback, so that onyx can work as normal.

**Which issues(s) does this PR fix?**

Part of #6327 and also addresses QSP 50 and QSP 51

**Other notes for review**
