### PR TITLE
Cache epoch boundary state cache proof of concept

### DIFF
--- a/beacon-chain/blockchain/chain_info_norace_test.go
+++ b/beacon-chain/blockchain/chain_info_norace_test.go
@@ -27,7 +27,7 @@ func TestHeadRoot_DataRace(t *testing.T) {
 	s := &Service{
 		beaconDB: db,
 		head:     &head{root: [32]byte{'A'}},
-		stateGen: stategen.New(db, sc),
+		stateGen: stategen.New(ctx, db, sc),
 	}
 	go func() {
 		if err := s.saveHead(context.Background(), [32]byte{}); err != nil {
@@ -44,7 +44,7 @@ func TestHeadBlock_DataRace(t *testing.T) {
 	s := &Service{
 		beaconDB: db,
 		head:     &head{block: &ethpb.SignedBeaconBlock{}},
-		stateGen: stategen.New(db, sc),
+		stateGen: stategen.New(ctx, db, sc),
 	}
 	go func() {
 		if err := s.saveHead(context.Background(), [32]byte{}); err != nil {
@@ -60,7 +60,7 @@ func TestHeadState_DataRace(t *testing.T) {
 	db, sc := testDB.SetupDB(t)
 	s := &Service{
 		beaconDB: db,
-		stateGen: stategen.New(db, sc),
+		stateGen: stategen.New(ctx, db, sc),
 	}
 	go func() {
 		if err := s.saveHead(context.Background(), [32]byte{}); err != nil {

--- a/beacon-chain/blockchain/init_sync_process_block_test.go
+++ b/beacon-chain/blockchain/init_sync_process_block_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGenerateState_CorrectlyGenerated(t *testing.T) {
 	db, sc := testDB.SetupDB(t)
-	cfg := &Config{BeaconDB: db, StateGen: stategen.New(db, sc)}
+	cfg := &Config{BeaconDB: db, StateGen: stategen.New(ctx, db, sc)}
 	service, err := NewService(context.Background(), cfg)
 	if err != nil {
 		t.Fatal(err)

--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -27,7 +27,7 @@ func TestStore_OnAttestation(t *testing.T) {
 	cfg := &Config{
 		BeaconDB:        db,
 		ForkChoiceStore: protoarray.New(0, 0, [32]byte{}),
-		StateGen:        stategen.New(db, sc),
+		StateGen:        stategen.New(ctx, db, sc),
 	}
 	service, err := NewService(ctx, cfg)
 	if err != nil {
@@ -165,7 +165,7 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 
 	cfg := &Config{
 		BeaconDB: db,
-		StateGen: stategen.New(db, sc),
+		StateGen: stategen.New(ctx, db, sc),
 	}
 	service, err := NewService(ctx, cfg)
 	if err != nil {
@@ -285,7 +285,7 @@ func TestStore_UpdateCheckpointState(t *testing.T) {
 
 	cfg := &Config{
 		BeaconDB: db,
-		StateGen: stategen.New(db, sc),
+		StateGen: stategen.New(ctx, db, sc),
 	}
 	service, err := NewService(ctx, cfg)
 	if err != nil {

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -31,7 +31,7 @@ func TestStore_OnBlock(t *testing.T) {
 
 	cfg := &Config{
 		BeaconDB: db,
-		StateGen: stategen.New(db, sc),
+		StateGen: stategen.New(ctx, db, sc),
 	}
 	service, err := NewService(ctx, cfg)
 	if err != nil {
@@ -234,7 +234,7 @@ func TestCachedPreState_CanGetFromStateSummary(t *testing.T) {
 
 	cfg := &Config{
 		BeaconDB: db,
-		StateGen: stategen.New(db, sc),
+		StateGen: stategen.New(ctx, db, sc),
 	}
 	service, err := NewService(ctx, cfg)
 	if err != nil {
@@ -272,7 +272,7 @@ func TestCachedPreState_CanGetFromDB(t *testing.T) {
 
 	cfg := &Config{
 		BeaconDB: db,
-		StateGen: stategen.New(db, sc),
+		StateGen: stategen.New(ctx, db, sc),
 	}
 	service, err := NewService(ctx, cfg)
 	if err != nil {
@@ -678,7 +678,7 @@ func TestFinalizedImpliesNewJustified(t *testing.T) {
 		if err := beaconState.SetCurrentJustifiedCheckpoint(test.args.stateCheckPoint); err != nil {
 			t.Fatal(err)
 		}
-		service, err := NewService(ctx, &Config{BeaconDB: db, StateGen: stategen.New(db, sc)})
+		service, err := NewService(ctx, &Config{BeaconDB: db, StateGen: stategen.New(ctx, db, sc)})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -116,7 +116,7 @@ func setupBeaconChain(t *testing.T, beaconDB db.Database, sc *cache.StateSummary
 		P2p:               &mockBroadcaster{},
 		StateNotifier:     &mockBeaconNode{},
 		AttPool:           attestations.NewPool(),
-		StateGen:          stategen.New(beaconDB, sc),
+		StateGen:          stategen.New(ctx, beaconDB, sc),
 		ForkChoiceStore:   protoarray.New(0, 0, params.BeaconConfig().ZeroHash),
 		OpsService:        opsService,
 	}
@@ -329,7 +329,7 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	c := &Service{beaconDB: db, stateGen: stategen.New(db, sc)}
+	c := &Service{beaconDB: db, stateGen: stategen.New(ctx, db, sc)}
 	if err := c.initializeChainInfo(ctx); err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +367,7 @@ func TestChainService_SaveHeadNoDB(t *testing.T) {
 	ctx := context.Background()
 	s := &Service{
 		beaconDB: db,
-		stateGen: stategen.New(db, sc),
+		stateGen: stategen.New(ctx, db, sc),
 	}
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 1}}
 	r, err := ssz.HashTreeRoot(b)

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -146,7 +146,9 @@ func NewBeaconNode(cliCtx *cli.Context) (*BeaconNode, error) {
 		return nil, err
 	}
 
-	beacon.startStateGen()
+	if err := beacon.startStateGen(); err != nil {
+		return nil, err
+	}
 
 	if err := beacon.registerP2P(cliCtx); err != nil {
 		return nil, err
@@ -312,8 +314,13 @@ func (b *BeaconNode) startDB(cliCtx *cli.Context) error {
 	return nil
 }
 
-func (b *BeaconNode) startStateGen() {
-	b.stateGen = stategen.New(b.db, b.stateSummaryCache)
+func (b *BeaconNode) startStateGen() error {
+	var err error
+	b.stateGen, err = stategen.New(b.ctx, b.db, b.stateSummaryCache)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func readbootNodes(fileName string) ([]string, error) {

--- a/beacon-chain/rpc/beacon/assignments_test.go
+++ b/beacon-chain/rpc/beacon/assignments_test.go
@@ -73,7 +73,7 @@ func TestServer_ListAssignments_NoResults(t *testing.T) {
 	bs := &Server{
 		BeaconDB:           db,
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 	wanted := &ethpb.ValidatorAssignments{
 		Assignments:   make([]*ethpb.ValidatorAssignments_CommitteeAssignment, 0),
@@ -126,7 +126,7 @@ func TestServer_ListAssignments_Pagination_InputOutOfRange(t *testing.T) {
 	bs := &Server{
 		BeaconDB:           db,
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 
 	wanted := fmt.Sprintf("page start %d >= list %d", 0, 0)
@@ -211,7 +211,7 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_NoArchive(t *testing.
 			},
 		},
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 
 	res, err := bs.ListValidatorAssignments(context.Background(), &ethpb.ListValidatorAssignmentsRequest{
@@ -312,7 +312,7 @@ func TestServer_ListAssignments_Pagination_DefaultPageSize_FromArchive(t *testin
 			},
 		},
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 
 	// Construct the wanted assignments.
@@ -392,7 +392,7 @@ func TestServer_ListAssignments_FilterPubkeysIndices_NoPagination(t *testing.T) 
 			},
 		},
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 
 	pubKey1 := make([]byte, params.BeaconConfig().BLSPubkeyLength)
@@ -476,7 +476,7 @@ func TestServer_ListAssignments_CanFilterPubkeysIndices_WithPagination(t *testin
 			},
 		},
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 
 	req := &ethpb.ListValidatorAssignmentsRequest{Indices: []uint64{1, 2, 3, 4, 5, 6}, PageSize: 2, PageToken: "1"}

--- a/beacon-chain/rpc/beacon/attestations_test.go
+++ b/beacon-chain/rpc/beacon/attestations_test.go
@@ -618,7 +618,7 @@ func TestServer_ListIndexedAttestations_NewStateManagnmentDisabled(t *testing.T)
 	bs := &Server{
 		BeaconDB:           db,
 		GenesisTimeFetcher: &chainMock.ChainService{State: state},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 	_, err := bs.ListIndexedAttestations(ctx, &ethpb.ListIndexedAttestationsRequest{
 		QueryFilter: &ethpb.ListIndexedAttestationsRequest_GenesisEpoch{
@@ -734,7 +734,7 @@ func TestServer_ListIndexedAttestations_GenesisEpoch(t *testing.T) {
 	bs := &Server{
 		BeaconDB:           db,
 		GenesisTimeFetcher: &chainMock.ChainService{State: state},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 	if err := db.SaveStateSummary(ctx, &pbp2p.StateSummary{
 		Root: targetRoot1[:],
@@ -855,7 +855,7 @@ func TestServer_ListIndexedAttestations_OldEpoch(t *testing.T) {
 		GenesisTimeFetcher: &chainMock.ChainService{
 			Genesis: time.Now(),
 		},
-		StateGen: stategen.New(db, sc),
+		StateGen: stategen.New(ctx, db, sc),
 	}
 	if err := db.SaveStateSummary(ctx, &pbp2p.StateSummary{
 		Root: blockRoot[:],
@@ -1155,7 +1155,7 @@ func TestServer_StreamIndexedAttestations_OK(t *testing.T) {
 		},
 		AttestationNotifier:         chainService.OperationNotifier(),
 		CollectedAttestationsBuffer: make(chan []*ethpb.Attestation, 1),
-		StateGen:                    stategen.New(db, sc),
+		StateGen:                    stategen.New(ctx, db, sc),
 	}
 
 	for dataRoot, sameDataAtts := range atts {

--- a/beacon-chain/rpc/beacon/committees_test.go
+++ b/beacon-chain/rpc/beacon/committees_test.go
@@ -40,7 +40,7 @@ func TestServer_ListBeaconCommittees_CurrentEpoch(t *testing.T) {
 	bs := &Server{
 		HeadFetcher:        m,
 		GenesisTimeFetcher: m,
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	if err := db.SaveBlock(ctx, b); err != nil {
@@ -273,7 +273,7 @@ func TestRetrieveCommitteesForRoot(t *testing.T) {
 	bs := &Server{
 		HeadFetcher:        m,
 		GenesisTimeFetcher: m,
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	if err := db.SaveBlock(ctx, b); err != nil {

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -104,7 +104,7 @@ func TestServer_ListValidatorBalances_NoResults(t *testing.T) {
 	}
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 
 	headState := testutil.NewBeaconState()
@@ -190,7 +190,7 @@ func TestServer_ListValidatorBalances_DefaultResponse_NoArchive(t *testing.T) {
 	}
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 		HeadFetcher: &mock.ChainService{
 			State: st,
 		},
@@ -231,7 +231,7 @@ func TestServer_ListValidatorBalances_PaginationOutOfRange(t *testing.T) {
 
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 		HeadFetcher: &mock.ChainService{
 			State: st,
 		},
@@ -288,7 +288,7 @@ func TestServer_ListValidatorBalances_Pagination_Default(t *testing.T) {
 
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 		HeadFetcher: &mock.ChainService{
 			State: headState,
 		},
@@ -383,7 +383,7 @@ func TestServer_ListValidatorBalances_Pagination_CustomPageSizes(t *testing.T) {
 
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 		HeadFetcher: &mock.ChainService{
 			State: headState,
 		},
@@ -464,7 +464,7 @@ func TestServer_ListValidatorBalances_OutOfRange(t *testing.T) {
 
 	bs := &Server{
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 		HeadFetcher: &mock.ChainService{
 			State: headState,
 		},
@@ -634,7 +634,7 @@ func TestServer_ListValidators_NoResults(t *testing.T) {
 		HeadFetcher: &mock.ChainService{
 			State: st,
 		},
-		StateGen: stategen.New(db, cache.NewStateSummaryCache()),
+		StateGen: stategen.New(ctx, db, cache.NewStateSummaryCache()),
 	}
 	wanted := &ethpb.Validators{
 		ValidatorList: make([]*ethpb.Validators_ValidatorContainer, 0),
@@ -1358,7 +1358,7 @@ func TestServer_GetValidatorActiveSetChanges(t *testing.T) {
 			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0},
 		},
 		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, sc),
+		StateGen:           stategen.New(ctx, db, sc),
 	}
 	res, err := bs.GetValidatorActiveSetChanges(ctx, &ethpb.GetValidatorActiveSetChangesRequest{
 		QueryFilter: &ethpb.GetValidatorActiveSetChangesRequest_Genesis{Genesis: true},
@@ -1891,7 +1891,7 @@ func TestServer_GetValidatorParticipation_PrevEpoch(t *testing.T) {
 		HeadFetcher:          m,
 		ParticipationFetcher: m,
 		GenesisTimeFetcher:   &mock.ChainService{},
-		StateGen:             stategen.New(db, sc),
+		StateGen:             stategen.New(ctx, db, sc),
 	}
 
 	res, err := bs.GetValidatorParticipation(ctx, &ethpb.GetValidatorParticipationRequest{QueryFilter: &ethpb.GetValidatorParticipationRequest_Epoch{Epoch: 0}})
@@ -1934,7 +1934,7 @@ func TestServer_GetValidatorParticipation_DoesntExist(t *testing.T) {
 		HeadFetcher:          m,
 		ParticipationFetcher: m,
 		GenesisTimeFetcher:   &mock.ChainService{},
-		StateGen:             stategen.New(db, sc),
+		StateGen:             stategen.New(ctx, db, sc),
 	}
 
 	wanted := "Participation information for epoch 0 is not yet available"
@@ -2423,7 +2423,7 @@ func TestServer_GetIndividualVotes_ValidatorsDontExist(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gen := stategen.New(db, sc)
+	gen := stategen.New(ctx, db, sc)
 	if err := gen.SaveState(ctx, gRoot, beaconState); err != nil {
 		t.Fatal(err)
 	}
@@ -2551,7 +2551,7 @@ func TestServer_GetIndividualVotes_Working(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gen := stategen.New(db, sc)
+	gen := stategen.New(ctx, db, sc)
 	if err := gen.SaveState(ctx, gRoot, beaconState); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/rpc/debug/state_test.go
+++ b/beacon-chain/rpc/debug/state_test.go
@@ -37,7 +37,7 @@ func TestServer_GetBeaconState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	gen := stategen.New(db, sc)
+	gen := stategen.New(ctx, db, sc)
 	if err := gen.SaveState(ctx, gRoot, st); err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/rpc/validator/attester_test.go
+++ b/beacon-chain/rpc/validator/attester_test.go
@@ -500,7 +500,7 @@ func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testin
 		FinalizationFetcher: &mock.ChainService{CurrentJustifiedCheckPoint: beaconState.CurrentJustifiedCheckpoint()},
 		GenesisTimeFetcher:  &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*int64(slot*params.BeaconConfig().SecondsPerSlot)) * time.Second)},
 		StateNotifier:       chainService.StateNotifier(),
-		StateGen:            stategen.New(db, sc),
+		StateGen:            stategen.New(ctx, db, sc),
 	}
 	if err := db.SaveState(ctx, beaconState, blockRoot); err != nil {
 		t.Fatal(err)

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -79,7 +79,7 @@ func TestGetBlock_OK(t *testing.T) {
 		AttPool:           attestations.NewPool(),
 		SlashingsPool:     slashings.NewPool(),
 		ExitPool:          voluntaryexits.NewPool(),
-		StateGen:          stategen.New(db, sc),
+		StateGen:          stategen.New(ctx, db, sc),
 	}
 
 	randaoReveal, err := testutil.RandaoReveal(beaconState, 0, privKeys)
@@ -198,7 +198,7 @@ func TestGetBlock_AddsUnaggregatedAtts(t *testing.T) {
 		SlashingsPool:     slashings.NewPool(),
 		AttPool:           attestations.NewPool(),
 		ExitPool:          voluntaryexits.NewPool(),
-		StateGen:          stategen.New(db, sc),
+		StateGen:          stategen.New(ctx, db, sc),
 	}
 
 	// Generate a bunch of random attestations at slot. These would be considered double votes, but
@@ -358,7 +358,7 @@ func TestComputeStateRoot_OK(t *testing.T) {
 		ChainStartFetcher: &mockPOW.POWChain{},
 		Eth1InfoFetcher:   &mockPOW.POWChain{},
 		Eth1BlockFetcher:  &mockPOW.POWChain{},
-		StateGen:          stategen.New(db, sc),
+		StateGen:          stategen.New(ctx, db, sc),
 	}
 
 	req := &ethpb.SignedBeaconBlock{

--- a/beacon-chain/state/stategen/BUILD.bazel
+++ b/beacon-chain/state/stategen/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cold.go",
+        "epoch_state_cache.go",
         "errors.go",
         "getter.go",
         "hot.go",
@@ -28,7 +29,10 @@ go_library(
         "//shared/bytesutil:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
+        "@com_github_hashicorp_golang_lru//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/state/stategen/cold_test.go
+++ b/beacon-chain/state/stategen/cold_test.go
@@ -17,7 +17,7 @@ func TestSaveColdState_NonArchivedPoint(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 2
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	if err := beaconState.SetSlot(1); err != nil {
@@ -33,7 +33,7 @@ func TestSaveColdState_CanSave(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	if err := beaconState.SetSlot(1); err != nil {
@@ -58,7 +58,7 @@ func TestLoadColdStateByRoot_NoStateSummary(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	if _, err := service.loadColdStateByRoot(ctx, [32]byte{'a'}); !strings.Contains(err.Error(), errUnknownStateSummary.Error()) {
 		t.Fatal("Did not get correct error")
 	}
@@ -68,7 +68,7 @@ func TestLoadColdStateByRoot_CanGet(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
@@ -110,7 +110,7 @@ func TestLoadColdStateBySlot_CanGet(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	blk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}

--- a/beacon-chain/state/stategen/epoch_state_cache.go
+++ b/beacon-chain/state/stategen/epoch_state_cache.go
@@ -1,0 +1,95 @@
+package stategen
+
+import (
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
+)
+
+var (
+	// epochStateCacheSize defines the max number of epoch state this can cache.
+	// 8 means it can handle no finality for up to an hour before starting to replay
+	// from the last finalized check point.
+	epochStateCacheSize = 8
+	// Metrics
+	epochStateCacheHit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "epoch_state_cache_hit",
+		Help: "The total number of cache hits on the epoch state cache.",
+	})
+	epochStateCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "epoch_state_cache_miss",
+		Help: "The total number of cache misses on the epoch state cache.",
+	})
+)
+
+// epochStateCache is used to store the processed beacon state after finalized check point..
+type epochStateCache struct {
+	fRoot [32]byte
+	fState *stateTrie.BeaconState
+	cache *lru.Cache
+	lock  sync.RWMutex
+}
+
+// newEpochStateCache initializes the map and underlying cache.
+func newEpochStateCache(fRoot [32]byte, fState *stateTrie.BeaconState) *epochStateCache {
+	cache, err := lru.New(epochStateCacheSize)
+	if err != nil {
+		panic(err)
+	}
+	return &epochStateCache{
+		fRoot: fRoot,
+		fState: fState,
+		cache: cache,
+	}
+}
+
+// Get returns a cached finalized or epoch boundary state via input block root.
+// The response is copied by default.
+func (e *epochStateCache) Get(root [32]byte) *stateTrie.BeaconState {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+
+	// First checks if the root is a finalized state.
+	if root == e.fRoot {
+		epochStateCacheHit.Inc()
+		return e.fState.Copy()
+	}
+
+	item, exists := e.cache.Get(root)
+	if exists && item != nil {
+		epochStateCacheHit.Inc()
+		return item.(*stateTrie.BeaconState).Copy()
+	}
+
+	epochStateCacheMiss.Inc()
+	return nil
+}
+
+// PutEpochBoundaryState puts the epoch boundary state in the cache.
+func (e *epochStateCache) PutEpochBoundaryState(root [32]byte, state *stateTrie.BeaconState) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.cache.Add(root, state)
+}
+
+// PutFinalizedState puts the finalized state in the cache.
+func (e *epochStateCache) PutFinalizedState(root [32]byte, state *stateTrie.BeaconState) {
+	e.lock.Lock()
+	defer e.lock.Unlock()
+	e.fRoot = root
+	e.fState = state
+
+	// Remove finalized state from cache since it's saved outside of the cache.
+	e.cache.Remove(root)
+}
+
+// Has returns true if the key exists in the epoch boundary cache.
+func (e *epochStateCache) Has(root [32]byte) bool {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+
+	return root == e.fRoot  || e.cache.Contains(root)
+}

--- a/beacon-chain/state/stategen/epoch_state_cache.go
+++ b/beacon-chain/state/stategen/epoch_state_cache.go
@@ -25,7 +25,7 @@ var (
 	})
 )
 
-// epochStateCache is used to store the processed beacon state after finalized check point..
+// epochStateCache is used to store the processed epoch boundary state and finalized state post finalization.
 type epochStateCache struct {
 	fRoot [32]byte
 	fState *stateTrie.BeaconState

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -18,7 +18,7 @@ func TestStateByRoot_ColdState(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 2
 	service.slotsPerArchivedPoint = 1
 
@@ -68,7 +68,7 @@ func TestStateByRoot_HotStateDB(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	blk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -121,7 +121,7 @@ func TestStateByRoot_HotStateCached(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	r := [32]byte{'A'}
@@ -145,7 +145,7 @@ func TestStateByRootInitialSync_UseDB(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	blk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -198,7 +198,7 @@ func TestStateByRootInitialSync_UseCache(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	r := [32]byte{'A'}
@@ -221,7 +221,7 @@ func TestStateByRootInitialSync_UseCache(t *testing.T) {
 func TestStateByRootInitialSync_CanProcessUpTo(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	blk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -265,7 +265,7 @@ func TestStateBySlot_ColdState(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = params.BeaconConfig().SlotsPerEpoch * 2
 	service.splitInfo.slot = service.slotsPerArchivedPoint + 1
 
@@ -316,7 +316,7 @@ func TestStateBySlot_HotStateDB(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -348,7 +348,7 @@ func TestStateSummary_CanGetFromCacheOrDB(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	r := [32]byte{'a'}
 	summary := &pb.StateSummary{Slot: 100}

--- a/beacon-chain/state/stategen/hot_test.go
+++ b/beacon-chain/state/stategen/hot_test.go
@@ -23,7 +23,7 @@ func TestSaveHotState_AlreadyHas(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	if err := beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch); err != nil {
@@ -51,7 +51,7 @@ func TestSaveHotState_CanSaveOnEpochBoundary(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	if err := beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch); err != nil {
@@ -77,7 +77,7 @@ func TestSaveHotState_NoSaveNotEpochBoundary(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	if err := beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch - 1); err != nil {
@@ -113,7 +113,7 @@ func TestSaveHotState_NoSaveNotEpochBoundary(t *testing.T) {
 func TestLoadHoteStateByRoot_Cached(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	r := [32]byte{'A'}
@@ -133,7 +133,7 @@ func TestLoadHoteStateByRoot_Cached(t *testing.T) {
 func TestLoadHoteStateByRoot_FromDBCanProcess(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	blk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -177,7 +177,7 @@ func TestLoadHoteStateByRoot_FromDBCanProcess(t *testing.T) {
 func TestLoadHoteStateByRoot_FromDBBoundaryCase(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	blk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
@@ -214,7 +214,7 @@ func TestLoadHoteStateByRoot_FromDBBoundaryCase(t *testing.T) {
 func TestLoadHoteStateBySlot_CanAdvanceSlotUsingDB(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	if err := service.beaconDB.SaveBlock(ctx, b); err != nil {
@@ -244,7 +244,7 @@ func TestLoadHoteStateBySlot_CanAdvanceSlotUsingDB(t *testing.T) {
 func TestLastAncestorState_CanGet(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	b0 := testutil.NewBeaconBlock()
 	b0.Block.ParentRoot = bytesutil.PadTo([]byte{'a'}, 32)

--- a/beacon-chain/state/stategen/migrate_test.go
+++ b/beacon-chain/state/stategen/migrate_test.go
@@ -20,7 +20,7 @@ func TestMigrateToCold_NoBlock(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 1
 	if err := service.MigrateToCold(ctx, params.BeaconConfig().SlotsPerEpoch, [32]byte{}); err != nil {
 		t.Fatal(err)
@@ -34,7 +34,7 @@ func TestMigrateToCold_HigherSplitSlot(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 2
 	if err := service.MigrateToCold(ctx, 1, [32]byte{}); err != nil {
 		t.Fatal(err)
@@ -48,7 +48,7 @@ func TestMigrateToCold_MigrationCompletes(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 1
 	service.slotsPerArchivedPoint = 2
 
@@ -111,7 +111,7 @@ func TestMigrateToCold_CantDeleteCurrentArchivedIndex(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.splitInfo.slot = 1
 	service.slotsPerArchivedPoint = 2
 
@@ -178,7 +178,7 @@ func TestMigrateToCold_CantDeleteCurrentArchivedIndex(t *testing.T) {
 func TestSkippedArchivedPoint_CanRecover(t *testing.T) {
 	db, _ := testDB.SetupDB(t)
 	ctx := context.Background()
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 32
 
 	b := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: 31}}

--- a/beacon-chain/state/stategen/replay_test.go
+++ b/beacon-chain/state/stategen/replay_test.go
@@ -23,7 +23,7 @@ func TestComputeStateUpToSlot_GenesisState(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	gBlk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	gRoot, err := stateutil.BlockRoot(gBlk.Block)
@@ -55,7 +55,7 @@ func TestComputeStateUpToSlot_CanProcessUpTo(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	gBlk := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	gRoot, err := stateutil.BlockRoot(gBlk.Block)
@@ -116,7 +116,7 @@ func TestReplayBlocks_AllSkipSlots(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	targetSlot := params.BeaconConfig().SlotsPerEpoch - 1
 	newState, err := service.ReplayBlocks(context.Background(), beaconState, []*ethpb.SignedBeaconBlock{}, targetSlot)
 	if err != nil {
@@ -160,7 +160,7 @@ func TestReplayBlocks_SameSlot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	targetSlot := beaconState.Slot()
 	newState, err := service.ReplayBlocks(context.Background(), beaconState, []*ethpb.SignedBeaconBlock{}, targetSlot)
 	if err != nil {
@@ -555,7 +555,7 @@ func TestLastSavedState_NoSavedBlockState(t *testing.T) {
 func TestArchivedRoot_CanGetSpecificIndex(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	r := [32]byte{'a'}
 	if err := db.SaveArchivedPointRoot(ctx, r, 1); err != nil {
@@ -573,7 +573,7 @@ func TestArchivedRoot_CanGetSpecificIndex(t *testing.T) {
 func TestArchivedRoot_CanGetOlderOlder(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	r := [32]byte{'a'}
 	if err := db.SaveArchivedPointRoot(ctx, r, 10); err != nil {
@@ -595,7 +595,7 @@ func TestArchivedRoot_CanGetOlderOlder(t *testing.T) {
 func TestArchivedRoot_CanGetGenesisIndex(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	gBlock := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	gRoot, err := stateutil.BlockRoot(gBlock.Block)
@@ -620,7 +620,7 @@ func TestArchivedRoot_CanGetGenesisIndex(t *testing.T) {
 func TestArchivedState_CanGetSpecificIndex(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 
 	r := [32]byte{'a'}
 	if err := db.SaveArchivedPointRoot(ctx, r, 1); err != nil {
@@ -650,7 +650,7 @@ func TestProcessStateUpToSlot_CanExitEarly(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	if err := beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch + 1); err != nil {
 		t.Fatal(err)
@@ -669,7 +669,7 @@ func TestProcessStateUpToSlot_CanProcess(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 
 	s, err := service.processStateUpTo(ctx, beaconState, params.BeaconConfig().SlotsPerEpoch+1)

--- a/beacon-chain/state/stategen/service_test.go
+++ b/beacon-chain/state/stategen/service_test.go
@@ -15,7 +15,7 @@ func TestResume(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	root := [32]byte{'A'}
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	if err := beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch); err != nil {

--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -17,7 +17,7 @@ func TestSaveState_ColdStateCanBeSaved(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 
@@ -49,7 +49,7 @@ func TestSaveState_HotStateCanBeSaved(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	// This goes to hot section, verify it can save on epoch boundary.
@@ -77,7 +77,7 @@ func TestSaveState_HotStateCached(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDB.SetupDB(t)
 
-	service := New(db, cache.NewStateSummaryCache())
+	service := New(ctx, db, cache.NewStateSummaryCache())
 	service.slotsPerArchivedPoint = 1
 	beaconState, _ := testutil.DeterministicGenesisState(t, 32)
 	if err := beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch); err != nil {

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -186,7 +186,7 @@ func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stateGen := stategen.New(db, stateSummaryCache)
+	stateGen := stategen.New(ctx, db, stateSummaryCache)
 	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
 		State: beaconState,
 		FinalizedCheckPoint: &ethpb.Checkpoint{
@@ -284,7 +284,7 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	stateGen := stategen.New(db, stateSummaryCache)
+	stateGen := stategen.New(ctx, db, stateSummaryCache)
 	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(blkSlot*params.BeaconConfig().SecondsPerSlot), 0),
 		State: beaconState,
 		FinalizedCheckPoint: &ethpb.Checkpoint{


### PR DESCRIPTION
Opening this PR to get feedback from @prestonvanloon 

What's implemented:
- An epoch boundary state cache which handles finalized state outside of the cache
- Cache usages in hot getter and setter, this replaces db usages
- In hot -> cold migration. A new finalized state is stored in the cache