### PR TITLE
Allow to start slasher RPC server with TLS

### DIFF
--- a/slasher/rpc/service.go
+++ b/slasher/rpc/service.go
@@ -65,6 +65,8 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		port:         cfg.Port,
 		detector:     cfg.Detector,
 		slasherDB:    cfg.SlasherDB,
+		withCert:     cfg.CertFlag,
+		withKey:      cfg.KeyFlag,
 		beaconclient: cfg.BeaconClient,
 	}
 }

--- a/slasher/rpc/service.go
+++ b/slasher/rpc/service.go
@@ -106,6 +106,10 @@ func (s *Service) Start() {
 			s.credentialError = err
 		}
 		opts = append(opts, grpc.Creds(creds))
+	} else {
+		log.Warn("You are using an insecure gRPC server. If you are running your slasher and " +
+			"validator on the same machines, you can ignore this message. If you want to know " +
+			"how to enable secure connections, see: https://docs.prylabs.network/docs/prysm-usage/secure-grpc")
 	}
 	s.grpcServer = grpc.NewServer(opts...)
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`--tls-key` and `--tls-cert` flags on the slasher rpc server are ignored leading to spinning up a non-tls server.

**Which issues(s) does this PR fix?**

None created

**Other notes for review**

This was only visible in the validator failing the call to external slashing protection with a hint about tls. The warning code for non-tls enabled connections that are present in beacon chain etc. was missing. I also added that so it's easier to see when the slasher doesn't run with tls.