### PR TITLE
Refactors init-sync: queue streams blocks in batches

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -49,8 +49,8 @@ type blocksQueue struct {
 	blocksFetcher       *blocksFetcher
 	headFetcher         blockchain.HeadFetcher
 	highestExpectedSlot uint64
-	fetchedBlocks       chan *eth.SignedBeaconBlock // output channel for ready blocks
-	quit                chan struct{}               // termination notifier
+	fetchedBlocks       chan []*eth.SignedBeaconBlock // output channel for ready blocks
+	quit                chan struct{}                 // termination notifier
 }
 
 // newBlocksQueue creates initialized priority queue.
@@ -75,7 +75,7 @@ func newBlocksQueue(ctx context.Context, cfg *blocksQueueConfig) *blocksQueue {
 		highestExpectedSlot: highestExpectedSlot,
 		blocksFetcher:       blocksFetcher,
 		headFetcher:         cfg.headFetcher,
-		fetchedBlocks:       make(chan *eth.SignedBeaconBlock, blocksFetcher.blocksPerSecond),
+		fetchedBlocks:       make(chan []*eth.SignedBeaconBlock, lookaheadSteps),
 		quit:                make(chan struct{}),
 	}
 
@@ -260,12 +260,10 @@ func (q *blocksQueue) onReadyToSendEvent(ctx context.Context) eventHandlerFn {
 		}
 
 		send := func() (stateID, error) {
-			for _, block := range m.blocks {
-				select {
-				case <-ctx.Done():
-					return m.state, ctx.Err()
-				case q.fetchedBlocks <- block:
-				}
+			select {
+			case <-ctx.Done():
+				return m.state, ctx.Err()
+			case q.fetchedBlocks <- m.blocks:
 			}
 			return stateSent, nil
 		}

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -287,11 +287,13 @@ func TestBlocksQueueLoop(t *testing.T) {
 			}
 
 			var blocks []*eth.SignedBeaconBlock
-			for block := range queue.fetchedBlocks {
-				if err := processBlock(block); err != nil {
-					continue
+			for fetchedBlocks := range queue.fetchedBlocks {
+				for _, block := range fetchedBlocks {
+					if err := processBlock(block); err != nil {
+						continue
+					}
+					blocks = append(blocks, block)
 				}
-				blocks = append(blocks, block)
 			}
 
 			if err := queue.stop(); err != nil {

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -58,10 +58,12 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 	blockReceiver := s.chain.ReceiveBlockInitialSync
 
 	// Step 1 - Sync to end of finalized epoch.
-	for blk := range queue.fetchedBlocks {
-		if err := s.processBlock(ctx, genesis, blk, blockReceiver); err != nil {
-			log.WithError(err).Info("Block is not processed")
-			continue
+	for fetchedBlocks := range queue.fetchedBlocks {
+		for _, blk := range fetchedBlocks {
+			if err := s.processBlock(ctx, genesis, blk, blockReceiver); err != nil {
+				log.WithError(err).Info("Block is not processed")
+				continue
+			}
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
- In https://github.com/prysmaticlabs/prysm/pull/6469 Nishant is woking on multi-block verification of blocks in init-sync, so needs to have a way to access incoming blocks in batches, hence this PR

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
