### PR TITLE
Removes excessive concurrency from init-sync queue

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -75,7 +75,7 @@ func newBlocksQueue(ctx context.Context, cfg *blocksQueueConfig) *blocksQueue {
 		highestExpectedSlot: highestExpectedSlot,
 		blocksFetcher:       blocksFetcher,
 		headFetcher:         cfg.headFetcher,
-		fetchedBlocks:       make(chan []*eth.SignedBeaconBlock),
+		fetchedBlocks:       make(chan []*eth.SignedBeaconBlock, 1),
 		quit:                make(chan struct{}),
 	}
 

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -75,7 +75,7 @@ func newBlocksQueue(ctx context.Context, cfg *blocksQueueConfig) *blocksQueue {
 		highestExpectedSlot: highestExpectedSlot,
 		blocksFetcher:       blocksFetcher,
 		headFetcher:         cfg.headFetcher,
-		fetchedBlocks:       make(chan []*eth.SignedBeaconBlock, lookaheadSteps),
+		fetchedBlocks:       make(chan []*eth.SignedBeaconBlock),
 		quit:                make(chan struct{}),
 	}
 


### PR DESCRIPTION

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- Follow up to #6470 
- There's no need for all FSMs pushing block batches concurrently - since up until a previous batch is processed (or thrown away) we cannot determine whether any given FSM's range of slots can be processed or needs to be refetched.
- Previously, channel was buffered with batch limit size - allowing blocks from a single FSM to be streamed w/o blocking. Now, no need to have buffer of size equal to number of FSMs (which I did in #6470), single buffer space is enough: round robin reads constantly, so processing one batch at a time, with first FSM non-blocking, and pre-fetching for all the FSMs is more than enough concurrency.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
