### PR TITLE
Direct Keymanager: Implement FetchValidatingPublicKeys()

### DIFF
--- a/validator/accounts/v2/new.go
+++ b/validator/accounts/v2/new.go
@@ -102,7 +102,7 @@ func NewAccount(cliCtx *cli.Context) error {
 	}
 
 	// Create a new validator account using the specified keymanager.
-	if err := keymanager.CreateAccount(ctx, password); err != nil {
+	if _, err := keymanager.CreateAccount(ctx, password); err != nil {
 		log.Fatalf("Could not create account in wallet: %v", err)
 	}
 	return nil

--- a/validator/accounts/v2/testing/BUILD.bazel
+++ b/validator/accounts/v2/testing/BUILD.bazel
@@ -9,4 +9,5 @@ go_library(
         "//validator:__subpackages__",
     ],
     deps = ["@com_github_dustinkirkland_golang_petname//:go_default_library"],
+    testonly = 1,
 )

--- a/validator/accounts/v2/testing/BUILD.bazel
+++ b/validator/accounts/v2/testing/BUILD.bazel
@@ -2,6 +2,7 @@ load("@prysm//tools/go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
+    testonly = 1,
     srcs = ["mock.go"],
     importpath = "github.com/prysmaticlabs/prysm/validator/accounts/v2/testing",
     visibility = [
@@ -9,5 +10,4 @@ go_library(
         "//validator:__subpackages__",
     ],
     deps = ["@com_github_dustinkirkland_golang_petname//:go_default_library"],
-    testonly = 1,
 )

--- a/validator/accounts/v2/testing/BUILD.bazel
+++ b/validator/accounts/v2/testing/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mock.go"],
+    importpath = "github.com/prysmaticlabs/prysm/validator/accounts/v2/testing",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_dustinkirkland_golang_petname//:go_default_library"],
+)

--- a/validator/accounts/v2/testing/BUILD.bazel
+++ b/validator/accounts/v2/testing/BUILD.bazel
@@ -4,6 +4,9 @@ go_library(
     name = "go_default_library",
     srcs = ["mock.go"],
     importpath = "github.com/prysmaticlabs/prysm/validator/accounts/v2/testing",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//validator:__pkg__",
+        "//validator:__subpackages__",
+    ],
     deps = ["@com_github_dustinkirkland_golang_petname//:go_default_library"],
 )

--- a/validator/accounts/v2/testing/mock.go
+++ b/validator/accounts/v2/testing/mock.go
@@ -1,0 +1,66 @@
+package mock
+
+import (
+	"context"
+	"errors"
+
+	petname "github.com/dustinkirkland/golang-petname"
+)
+
+// MockWallet contains an in-memory, simulated wallet implementation.
+type MockWallet struct {
+	Files            map[string][]byte
+	AccountPasswords map[string]string
+}
+
+// AccountNames --
+func (m *MockWallet) AccountNames() ([]string, error) {
+	names := make([]string, 0)
+	for name := range m.AccountPasswords {
+		names = append(names, name)
+	}
+	return names, nil
+}
+
+// AccountsDir --
+func (m *MockWallet) AccountsDir() string {
+	return ""
+}
+
+// WriteAccountToDisk --
+func (m *MockWallet) WriteAccountToDisk(ctx context.Context, password string) (string, error) {
+	accountName := petname.Generate(3, "-")
+	m.AccountPasswords[accountName] = password
+	return accountName, nil
+}
+
+// WriteFileForAccount --
+func (m *MockWallet) WriteFileForAccount(
+	ctx context.Context,
+	accountName string,
+	fileName string,
+	data []byte,
+) error {
+	m.Files[fileName] = data
+	return nil
+}
+
+// ReadPasswordForAccount --
+func (m *MockWallet) ReadPasswordForAccount(accountName string) (string, error) {
+	for name, password := range m.AccountPasswords {
+		if name == accountName {
+			return password, nil
+		}
+	}
+	return "", errors.New("account not found")
+}
+
+// ReadFileForAccount --
+func (m *MockWallet) ReadFileForAccount(accountName string, fileName string) ([]byte, error) {
+	for f, v := range m.Files {
+		if f == fileName {
+			return v, nil
+		}
+	}
+	return nil, errors.New("file not found")
+}

--- a/validator/accounts/v2/testing/mock.go
+++ b/validator/accounts/v2/testing/mock.go
@@ -9,7 +9,7 @@ import (
 
 // MockWallet contains an in-memory, simulated wallet implementation.
 type MockWallet struct {
-	Files            map[string][]byte
+	Files            map[string]map[string][]byte
 	AccountPasswords map[string]string
 }
 
@@ -41,7 +41,10 @@ func (m *MockWallet) WriteFileForAccount(
 	fileName string,
 	data []byte,
 ) error {
-	m.Files[fileName] = data
+	if m.Files[accountName] == nil {
+		m.Files[accountName] = make(map[string][]byte)
+	}
+	m.Files[accountName][fileName] = data
 	return nil
 }
 
@@ -57,7 +60,7 @@ func (m *MockWallet) ReadPasswordForAccount(accountName string) (string, error) 
 
 // ReadFileForAccount --
 func (m *MockWallet) ReadFileForAccount(accountName string, fileName string) ([]byte, error) {
-	for f, v := range m.Files {
+	for f, v := range m.Files[accountName] {
 		if f == fileName {
 			return v, nil
 		}

--- a/validator/accounts/v2/testing/mock.go
+++ b/validator/accounts/v2/testing/mock.go
@@ -7,14 +7,14 @@ import (
 	petname "github.com/dustinkirkland/golang-petname"
 )
 
-// MockWallet contains an in-memory, simulated wallet implementation.
-type MockWallet struct {
+// Wallet contains an in-memory, simulated wallet implementation.
+type Wallet struct {
 	Files            map[string]map[string][]byte
 	AccountPasswords map[string]string
 }
 
 // AccountNames --
-func (m *MockWallet) AccountNames() ([]string, error) {
+func (m *Wallet) AccountNames() ([]string, error) {
 	names := make([]string, 0)
 	for name := range m.AccountPasswords {
 		names = append(names, name)
@@ -23,19 +23,19 @@ func (m *MockWallet) AccountNames() ([]string, error) {
 }
 
 // AccountsDir --
-func (m *MockWallet) AccountsDir() string {
+func (m *Wallet) AccountsDir() string {
 	return ""
 }
 
 // WriteAccountToDisk --
-func (m *MockWallet) WriteAccountToDisk(ctx context.Context, password string) (string, error) {
+func (m *Wallet) WriteAccountToDisk(ctx context.Context, password string) (string, error) {
 	accountName := petname.Generate(3, "-")
 	m.AccountPasswords[accountName] = password
 	return accountName, nil
 }
 
 // WriteFileForAccount --
-func (m *MockWallet) WriteFileForAccount(
+func (m *Wallet) WriteFileForAccount(
 	ctx context.Context,
 	accountName string,
 	fileName string,
@@ -49,7 +49,7 @@ func (m *MockWallet) WriteFileForAccount(
 }
 
 // ReadPasswordForAccount --
-func (m *MockWallet) ReadPasswordForAccount(accountName string) (string, error) {
+func (m *Wallet) ReadPasswordForAccount(accountName string) (string, error) {
 	for name, password := range m.AccountPasswords {
 		if name == accountName {
 			return password, nil
@@ -59,7 +59,7 @@ func (m *MockWallet) ReadPasswordForAccount(accountName string) (string, error) 
 }
 
 // ReadFileForAccount --
-func (m *MockWallet) ReadFileForAccount(accountName string, fileName string) ([]byte, error) {
+func (m *Wallet) ReadFileForAccount(accountName string, fileName string) ([]byte, error) {
 	for f, v := range m.Files[accountName] {
 		if f == fileName {
 			return v, nil

--- a/validator/keymanager/v2/direct/BUILD.bazel
+++ b/validator/keymanager/v2/direct/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//contracts/deposit-contract:go_default_library",
         "//shared/bls:go_default_library",
+        "//shared/bytesutil:go_default_library",
         "//shared/depositutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
@@ -39,6 +40,7 @@ go_test(
         "//shared/bls:go_default_library",
         "//shared/depositutil:go_default_library",
         "//shared/testutil:go_default_library",
+        "//validator/accounts/v2/testing:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",

--- a/validator/keymanager/v2/direct/BUILD.bazel
+++ b/validator/keymanager/v2/direct/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//shared/bls:go_default_library",
+        "//shared/bytesutil:go_default_library",
         "//shared/depositutil:go_default_library",
         "//shared/testutil:go_default_library",
         "//validator/accounts/v2/testing:go_default_library",

--- a/validator/keymanager/v2/direct/direct.go
+++ b/validator/keymanager/v2/direct/direct.go
@@ -170,7 +170,6 @@ func (dr *Keymanager) FetchValidatingPublicKeys() ([][48]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	decryptor := keystorev4.New()
 	publicKeys := make([][48]byte, len(accountNames))
 	for i, name := range accountNames {
 		password, err := dr.wallet.ReadPasswordForAccount(name)
@@ -188,6 +187,7 @@ func (dr *Keymanager) FetchValidatingPublicKeys() ([][48]byte, error) {
 		// We extract the validator signing private key from the keystore
 		// by utilizing the password and initialize a new BLS secret key from
 		// its raw bytes.
+		decryptor := keystorev4.New()
 		rawSigningKey, err := decryptor.Decrypt(keystoreJSON, []byte(password))
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not decrypt validator signing key for account: %s", name)
@@ -198,7 +198,7 @@ func (dr *Keymanager) FetchValidatingPublicKeys() ([][48]byte, error) {
 		}
 		publicKeys[i] = bytesutil.ToBytes48(validatorSigningKey.PublicKey().Marshal())
 	}
-	return publicKeys, errors.New("unimplemented")
+	return publicKeys, nil
 }
 
 // Sign signs a message using a validator key.

--- a/validator/keymanager/v2/direct/direct.go
+++ b/validator/keymanager/v2/direct/direct.go
@@ -33,6 +33,8 @@ const (
 // Useful for keymanager to have persistent capabilities for accounts on-disk.
 type Wallet interface {
 	AccountsDir() string
+	AccountNames() ([]string, error)
+	ReadPasswordForAccount(accountName string) (string, error)
 	WriteAccountToDisk(ctx context.Context, password string) (string, error)
 	WriteFileForAccount(ctx context.Context, accountName string, fileName string, data []byte) error
 }
@@ -162,6 +164,11 @@ func (dr *Keymanager) MarshalConfigFile(ctx context.Context) ([]byte, error) {
 
 // FetchValidatingPublicKeys fetches the list of public keys from the direct account keystores.
 func (dr *Keymanager) FetchValidatingPublicKeys() ([][48]byte, error) {
+	accountNames, err := dr.wallet.AccountNames()
+	if err != nil {
+		return nil, err
+	}
+
 	return nil, errors.New("unimplemented")
 }
 

--- a/validator/keymanager/v2/direct/direct_test.go
+++ b/validator/keymanager/v2/direct/direct_test.go
@@ -11,32 +11,12 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/depositutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
+	mock "github.com/prysmaticlabs/prysm/validator/accounts/v2/testing"
+
 	logTest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/tyler-smith/go-bip39"
 	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
 )
-
-type mockWallet struct {
-	files map[string][]byte
-}
-
-func (m *mockWallet) AccountsDir() string {
-	return ""
-}
-
-func (m *mockWallet) WriteAccountToDisk(ctx context.Context, password string) (string, error) {
-	return "mockaccount", nil
-}
-
-func (m *mockWallet) WriteFileForAccount(
-	ctx context.Context,
-	accountName string,
-	fileName string,
-	data []byte,
-) error {
-	m.files[fileName] = data
-	return nil
-}
 
 type mockMnemonicGenerator struct {
 	generatedMnemonics []string
@@ -57,7 +37,10 @@ func (m *mockMnemonicGenerator) ConfirmAcknowledgement(phrase string) error {
 
 func TestKeymanager_CreateAccount(t *testing.T) {
 	hook := logTest.NewGlobal()
-	wallet := &mockWallet{files: make(map[string][]byte)}
+	wallet := &mock.MockWallet{
+		Files:            make(map[string][]byte),
+		AccountPasswords: make(map[string]string),
+	}
 	mnemonicGenerator := &mockMnemonicGenerator{
 		generatedMnemonics: make([]string, 0),
 	}
@@ -73,7 +56,7 @@ func TestKeymanager_CreateAccount(t *testing.T) {
 
 	// Ensure the keystore file was written to the wallet
 	// and ensure we can decrypt it using the EIP-2335 standard.
-	encodedKeystore, ok := wallet.files[keystoreFileName]
+	encodedKeystore, ok := wallet.Files[keystoreFileName]
 	if !ok {
 		t.Fatalf("Expected to have stored %s in wallet", keystoreFileName)
 	}
@@ -98,7 +81,7 @@ func TestKeymanager_CreateAccount(t *testing.T) {
 	// Decode the deposit_data.ssz file and confirm
 	// the public key matches the public key from the
 	// account's decrypted keystore.
-	encodedDepositData, ok := wallet.files[depositDataFileName]
+	encodedDepositData, ok := wallet.Files[depositDataFileName]
 	if !ok {
 		t.Fatalf("Expected to have stored %s in wallet", depositDataFileName)
 	}
@@ -142,4 +125,8 @@ func TestKeymanager_CreateAccount(t *testing.T) {
 		)
 	}
 	testutil.AssertLogsContain(t, hook, "Successfully created new validator account")
+}
+
+func TestKeymanager_FetchValidatingPublicKeys(t *testing.T) {
+
 }

--- a/validator/keymanager/v2/direct/direct_test.go
+++ b/validator/keymanager/v2/direct/direct_test.go
@@ -38,7 +38,7 @@ func (m *mockMnemonicGenerator) ConfirmAcknowledgement(phrase string) error {
 
 func TestKeymanager_CreateAccount(t *testing.T) {
 	hook := logTest.NewGlobal()
-	wallet := &mock.MockWallet{
+	wallet := &mock.Wallet{
 		Files:            make(map[string]map[string][]byte),
 		AccountPasswords: make(map[string]string),
 	}
@@ -130,7 +130,7 @@ func TestKeymanager_CreateAccount(t *testing.T) {
 }
 
 func TestKeymanager_FetchValidatingPublicKeys(t *testing.T) {
-	wallet := &mock.MockWallet{
+	wallet := &mock.Wallet{
 		Files:            make(map[string]map[string][]byte),
 		AccountPasswords: make(map[string]string),
 	}
@@ -159,7 +159,7 @@ func TestKeymanager_FetchValidatingPublicKeys(t *testing.T) {
 
 func BenchmarkKeymanager_FetchValidatingPublicKeys(b *testing.B) {
 	b.StopTimer()
-	wallet := &mock.MockWallet{
+	wallet := &mock.Wallet{
 		Files:            make(map[string]map[string][]byte),
 		AccountPasswords: make(map[string]string),
 	}

--- a/validator/keymanager/v2/types.go
+++ b/validator/keymanager/v2/types.go
@@ -9,7 +9,7 @@ import (
 
 // IKeymanager defines a general keymanager-v2 interface for Prysm wallets.
 type IKeymanager interface {
-	// CreateAccount based on the keymanager's logic.
+	// CreateAccount based on the keymanager's logic. Returns the account name.
 	CreateAccount(ctx context.Context, password string) (string, error)
 	// MarshalConfigFile for the keymanager's options.
 	MarshalConfigFile(ctx context.Context) ([]byte, error)

--- a/validator/keymanager/v2/types.go
+++ b/validator/keymanager/v2/types.go
@@ -10,7 +10,7 @@ import (
 // IKeymanager defines a general keymanager-v2 interface for Prysm wallets.
 type IKeymanager interface {
 	// CreateAccount based on the keymanager's logic.
-	CreateAccount(ctx context.Context, password string) error
+	CreateAccount(ctx context.Context, password string) (string, error)
 	// MarshalConfigFile for the keymanager's options.
 	MarshalConfigFile(ctx context.Context) ([]byte, error)
 	// FetchValidatingKeys fetches the list of public keys that should be used to validate with.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR implements the `FetchValidatingPublicKeys()` function for a direct keymanager, retrieving account names from disk and unlocking them from their associated passwords using the EIP-2335 keystore reference.

**Which issues(s) does this PR fix?**

Part of #6220
