### PR TITLE
Restores att-aggregation benchmarks

### DIFF
--- a/shared/aggregation/aggregation.go
+++ b/shared/aggregation/aggregation.go
@@ -3,6 +3,7 @@ package aggregation
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/sirupsen/logrus"
@@ -27,4 +28,9 @@ type Aggregation struct {
 	Coverage bitfield.Bitlist
 	// Keys is a list of candidate keys in the best available solution.
 	Keys []int
+}
+
+// String provides string representation of a solution.
+func (ag *Aggregation) String() string {
+	return fmt.Sprintf("{coverage: %#b, keys: %v}", ag.Coverage, ag.Keys)
 }

--- a/shared/aggregation/attestations/attestations_bench_test.go
+++ b/shared/aggregation/attestations/attestations_bench_test.go
@@ -1,0 +1,104 @@
+package attestations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/go-bitfield"
+	aggtesting "github.com/prysmaticlabs/prysm/shared/aggregation/testing"
+	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/bls/iface"
+	"github.com/prysmaticlabs/prysm/shared/params"
+)
+
+func BenchmarkAggregateAttestations_Aggregate(b *testing.B) {
+	// Override expensive BLS aggregation method with cheap no-op such that this benchmark profiles
+	// the logic of aggregation selection rather than BLS logic.
+	aggregateSignatures = func(sigs []iface.Signature) iface.Signature {
+		return sigs[0]
+	}
+	signatureFromBytes = func(sig []byte) (iface.Signature, error) {
+		return bls.NewAggregateSignature(), nil
+	}
+	defer func() {
+		aggregateSignatures = bls.AggregateSignatures
+		signatureFromBytes = bls.SignatureFromBytes
+	}()
+
+	bitlistLen := params.BeaconConfig().MaxValidatorsPerCommittee
+
+	tests := []struct {
+		name   string
+		inputs []bitfield.Bitlist
+		want   []bitfield.Bitlist
+	}{
+		{
+			name:   "64 attestations with single bit set",
+			inputs: aggtesting.BitlistsWithSingleBitSet(b, 64, bitlistLen),
+			want: []bitfield.Bitlist{
+				aggtesting.BitlistWithAllBitsSet(b, 64),
+			},
+		},
+		{
+			name:   "64 attestations with 8 random bits set",
+			inputs: aggtesting.BitlistsWithMultipleBitSet(b, 64, bitlistLen, 8),
+			want: []bitfield.Bitlist{
+				aggtesting.BitlistWithAllBitsSet(b, 64),
+			},
+		},
+		{
+			name:   "64 attestations with 16 random bits set",
+			inputs: aggtesting.BitlistsWithMultipleBitSet(b, 64, bitlistLen, 16),
+			want: []bitfield.Bitlist{
+				aggtesting.BitlistWithAllBitsSet(b, 64),
+			},
+		},
+		{
+			name:   "64 attestations with 32 random bits set",
+			inputs: aggtesting.BitlistsWithMultipleBitSet(b, 64, bitlistLen, 32),
+			want: []bitfield.Bitlist{
+				aggtesting.BitlistWithAllBitsSet(b, 64),
+			},
+		},
+		{
+			name:   "128 attestations with single bit set",
+			inputs: aggtesting.BitlistsWithSingleBitSet(b, 128, bitlistLen),
+			want: []bitfield.Bitlist{
+				aggtesting.BitlistWithAllBitsSet(b, 128),
+			},
+		},
+		{
+			name:   "256 attestations with single bit set",
+			inputs: aggtesting.BitlistsWithSingleBitSet(b, 256, bitlistLen),
+			want: []bitfield.Bitlist{
+				aggtesting.BitlistWithAllBitsSet(b, 256),
+			},
+		},
+		{
+			name:   "512 attestations with single bit set",
+			inputs: aggtesting.BitlistsWithSingleBitSet(b, 512, bitlistLen),
+			want: []bitfield.Bitlist{
+				aggtesting.BitlistWithAllBitsSet(b, 512),
+			},
+		},
+		{
+			name:   "1024 attestations with single bit set",
+			inputs: aggtesting.BitlistsWithSingleBitSet(b, 1024, bitlistLen),
+			want: []bitfield.Bitlist{
+				aggtesting.BitlistWithAllBitsSet(b, 1024),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			atts := aggtesting.MakeAttestationsFromBitlists(b, tt.inputs)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := Aggregate(atts)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/shared/aggregation/maxcover.go
+++ b/shared/aggregation/maxcover.go
@@ -1,6 +1,7 @@
 package aggregation
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -194,4 +195,9 @@ func (cl *MaxCoverCandidates) validate() error {
 		}
 	}
 	return nil
+}
+
+// String provides string representation of a candidate.
+func (c *MaxCoverCandidate) String() string {
+	return fmt.Sprintf("{%v, %#b, s%d, %t}", c.key, c.bits, c.score, c.processed)
 }


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
- During #6234 benchmark hasn't been moved into the new `shared/aggregation/attestations` package, this PR restores that benchmark file

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
