### PR TITLE
Epoch boundary cache

### DIFF
--- a/beacon-chain/state/stategen/BUILD.bazel
+++ b/beacon-chain/state/stategen/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "cold_test.go",
+        "epoch_boundary_state_cache_test.go",
         "getter_test.go",
         "hot_test.go",
         "migrate_test.go",

--- a/beacon-chain/state/stategen/BUILD.bazel
+++ b/beacon-chain/state/stategen/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cold.go",
+        "epoch_boundary_state_cache.go",
         "errors.go",
         "getter.go",
         "hot.go",
@@ -32,6 +33,7 @@ go_library(
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_client_go//tools/cache:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
     ],
 )

--- a/beacon-chain/state/stategen/epoch_boundary_state_cache.go
+++ b/beacon-chain/state/stategen/epoch_boundary_state_cache.go
@@ -1,0 +1,155 @@
+package stategen
+
+import (
+	"errors"
+	"strconv"
+	"sync"
+
+	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
+	"k8s.io/client-go/tools/cache"
+)
+
+var (
+	// maxCacheSize is 8. That means 8 epochs and roughly an hour
+	// of no finality can be endured.
+	maxCacheSize        = uint64(8)
+	errNotSlotRootInfo  = errors.New("not slot root info type")
+	errNotRootStateInfo = errors.New("not root state info type")
+)
+
+// rootStateInfo specifies the root state info in the epoch boundary state cache.
+type rootStateInfo struct {
+	root  [32]byte
+	state *stateTrie.BeaconState
+}
+
+// slotRootInfo specifies the slot root info in the epoch boundary state cache.
+type slotRootInfo struct {
+	root [32]byte
+	slot uint64
+}
+
+// rootKeyFn takes the string representation of the block root to be used as key
+// to retrieve epoch boundary state.
+func rootKeyFn(obj interface{}) (string, error) {
+	s, ok := obj.(*rootStateInfo)
+	if !ok {
+		return "", errNotRootStateInfo
+	}
+	return string(s.root[:]), nil
+}
+
+// slotKeyFn takes the string representation of the slot to be used as key
+// to retrieve root.
+func slotKeyFn(obj interface{}) (string, error) {
+	s, ok := obj.(*slotRootInfo)
+	if !ok {
+		return "", errNotSlotRootInfo
+	}
+	return slotToString(s.slot), nil
+}
+
+// epochBoundaryState struct with two queues by looking up by slot or root.
+type epochBoundaryState struct {
+	rootStateCache *cache.FIFO
+	slotRootCache  *cache.FIFO
+	lock           sync.RWMutex
+}
+
+// newBoundaryStateCache creates a new block epochBoundaryState for storing/accessing epoch boundary states from
+// memory.
+func newBoundaryStateCache() *epochBoundaryState {
+	return &epochBoundaryState{
+		rootStateCache: cache.NewFIFO(rootKeyFn),
+		slotRootCache:  cache.NewFIFO(slotKeyFn),
+	}
+}
+
+// get epoch boundary state by its block root. Returns copied state in state info object if exists. Otherwise returns nil.
+func (e *epochBoundaryState) getByRoot(r [32]byte) (*rootStateInfo, bool, error) {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+
+	obj, exists, err := e.rootStateCache.GetByKey(string(r[:]))
+	if err != nil {
+		return nil, false, err
+	}
+	if !exists {
+		return nil, false, nil
+	}
+	s, ok := obj.(*rootStateInfo)
+	if !ok {
+		return nil, false, errNotRootStateInfo
+	}
+
+	return &rootStateInfo{
+		root:  r,
+		state: s.state.Copy(),
+	}, true, nil
+}
+
+// get epoch boundary state by its slot. Returns copied state in state info object if exists. Otherwise returns nil.
+func (e *epochBoundaryState) getBySlot(s uint64) (*rootStateInfo, bool, error) {
+	e.lock.RLock()
+	defer e.lock.RUnlock()
+
+	obj, exists, err := e.slotRootCache.GetByKey(slotToString(s))
+	if err != nil {
+		return nil, false, err
+	}
+	if !exists {
+		return nil, false, nil
+	}
+	info, ok := obj.(*slotRootInfo)
+	if !ok {
+		return nil, false, errNotSlotRootInfo
+	}
+
+	return e.getByRoot(info.root)
+}
+
+// put adds a state to the epoch boundary state cache. This method also trims the
+// least recently added state info if the cache size has reached the max cache
+// size limit.
+func (e *epochBoundaryState) put(r [32]byte, s *stateTrie.BeaconState) error {
+	e.lock.Lock()
+
+	if err := e.rootStateCache.AddIfNotPresent(&rootStateInfo{
+		root:  r,
+		state: s.Copy(),
+	}); err != nil {
+		return err
+	}
+	if err := e.slotRootCache.AddIfNotPresent(&slotRootInfo{
+		root: r,
+		slot: s.Slot(),
+	}); err != nil {
+		return err
+	}
+
+	e.lock.Unlock()
+
+	trim(e.rootStateCache, maxCacheSize)
+	trim(e.slotRootCache, maxCacheSize)
+
+	return nil
+}
+
+// trim the FIFO queue to the maxSize.
+func trim(queue *cache.FIFO, maxSize uint64) {
+	for s := uint64(len(queue.ListKeys())); s > maxSize; s-- {
+		if _, err := queue.Pop(popProcessNoopFunc); err != nil { // This never returns an error, but we'll handle anyway for sanity.
+			panic(err)
+		}
+	}
+}
+
+// popProcessNoopFunc is a no-op function that never returns an error.
+func popProcessNoopFunc(obj interface{}) error {
+	return nil
+}
+
+// Converts input uint64 to string. To be used as key for slot to get root.
+func slotToString(s uint64) string {
+	return strconv.FormatUint(s, 10)
+}

--- a/beacon-chain/state/stategen/epoch_boundary_state_cache_test.go
+++ b/beacon-chain/state/stategen/epoch_boundary_state_cache_test.go
@@ -7,6 +7,18 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 )
 
+func TestEpochBoundaryStateCache_BadSlotKey(t *testing.T) {
+	if _, err := slotKeyFn("sushi"); err == nil || err.Error() != errNotSlotRootInfo.Error() {
+		t.Error("Did not get wanted error")
+	}
+}
+
+func TestEpochBoundaryStateCache_BadRootKey(t *testing.T) {
+	if _, err := rootKeyFn("noodle"); err == nil || err.Error() != errNotRootStateInfo.Error() {
+		t.Error("Did not get wanted error")
+	}
+}
+
 func TestEpochBoundaryStateCache_CanSave(t *testing.T) {
 	e := newBoundaryStateCache()
 	s := testutil.NewBeaconState()
@@ -78,6 +90,9 @@ func TestEpochBoundaryStateCache_CanTrim(t *testing.T) {
 	}
 
 	if len(e.rootStateCache.ListKeys()) != int(maxCacheSize) {
+		t.Error("Did not trim to the correct amount")
+	}
+	if len(e.slotRootCache.ListKeys()) != int(maxCacheSize) {
 		t.Error("Did not trim to the correct amount")
 	}
 	for _, l := range e.rootStateCache.List() {

--- a/beacon-chain/state/stategen/epoch_boundary_state_cache_test.go
+++ b/beacon-chain/state/stategen/epoch_boundary_state_cache_test.go
@@ -1,0 +1,92 @@
+package stategen
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+)
+
+func TestEpochBoundaryStateCache_CanSave(t *testing.T) {
+	e := newBoundaryStateCache()
+	s := testutil.NewBeaconState()
+	if err := s.SetSlot(1); err != nil {
+		t.Fatal(err)
+	}
+	r := [32]byte{'a'}
+	if err := e.put(r, s); err != nil {
+		t.Fatal(err)
+	}
+
+	got, exists, err := e.getByRoot([32]byte{'b'})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("Should not exist")
+	}
+	if got != nil {
+		t.Error("Should not exist")
+	}
+
+	got, exists, err = e.getByRoot([32]byte{'a'})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("Should exist")
+	}
+	if !reflect.DeepEqual(got.state.InnerStateUnsafe(), s.InnerStateUnsafe()) {
+		t.Error("Should have the same state")
+	}
+
+	got, exists, err = e.getBySlot(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("Should not exist")
+	}
+	if got != nil {
+		t.Error("Should not exist")
+	}
+
+	got, exists, err = e.getBySlot(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("Should exist")
+	}
+	if !reflect.DeepEqual(got.state.InnerStateUnsafe(), s.InnerStateUnsafe()) {
+		t.Error("Should have the same state")
+	}
+}
+
+func TestEpochBoundaryStateCache_CanTrim(t *testing.T) {
+	e := newBoundaryStateCache()
+	offSet := uint64(10)
+	for i := uint64(0); i < maxCacheSize+offSet; i++ {
+		s := testutil.NewBeaconState()
+		if err := s.SetSlot(i); err != nil {
+			t.Fatal(err)
+		}
+		r := [32]byte{byte(i)}
+		if err := e.put(r, s); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if len(e.rootStateCache.ListKeys()) != int(maxCacheSize) {
+		t.Error("Did not trim to the correct amount")
+	}
+	for _, l := range e.rootStateCache.List() {
+		i, ok := l.(*rootStateInfo)
+		if !ok {
+			t.Fatal("Bad type assertion")
+		}
+		if i.state.Slot() < offSet {
+			t.Error("Did not trim the correct state")
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
Features


**What does this PR do? Why is it needed?**
Implemented a cache to store epoch boundary states. Features:
- Cache size is 8. (e.g. one hour of epoch boundary states given current configs)
- Two fifos involved. `slot -> root` and `root -> state`
- Epoch boundary states can be retrieved by root or by slot

**Other notes for review**
Tested run time
