### PR TITLE
Implement Accounts-v2 List: Direct Keymanager

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -368,3 +368,10 @@ go_repository(
     sum = "h1:futFTqrUAf1IanFLU+jK4D1NpgE/+gCbnCG7Fl0rHs0=",
     version = "v0.0.0-20180124190051-72af92c51f88",
 )
+
+go_repository(
+    name = "com_github_logrusorgru_aurora",
+    importpath = "github.com/logrusorgru/aurora",
+    sum = "h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=",
+    version = "v2.0.3+incompatible",
+)

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/libp2p/go-libp2p-tls v0.1.4-0.20200421131144-8a8ad624a291 // indirect
 	github.com/libp2p/go-libp2p-yamux v0.2.8 // indirect
 	github.com/libp2p/go-maddr-filter v0.1.0 // indirect
+	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/manifoldco/promptui v0.7.0
 	github.com/minio/highwayhash v1.0.0
 	github.com/minio/sha256-simd v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/libp2p/go-libp2p-tls v0.1.4-0.20200421131144-8a8ad624a291 // indirect
 	github.com/libp2p/go-libp2p-yamux v0.2.8 // indirect
 	github.com/libp2p/go-maddr-filter v0.1.0 // indirect
-	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
+	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/manifoldco/promptui v0.7.0
 	github.com/minio/highwayhash v1.0.0
 	github.com/minio/sha256-simd v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -688,6 +688,8 @@ github.com/libp2p/go-yamux v1.3.5/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZ
 github.com/libp2p/go-yamux v1.3.6/go.mod h1:FGTiPvoV/3DVdgWpX+tM0OW3tsM+W5bSE3gZwqQTcow=
 github.com/libp2p/go-yamux v1.3.7 h1:v40A1eSPJDIZwz2AvrV3cxpTZEGDP11QJbukmEhYyQI=
 github.com/libp2p/go-yamux v1.3.7/go.mod h1:fr7aVgmdNGJK+N1g+b6DW6VxzbRCjCOejR/hkmpooHE=
+github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
+github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lucas-clemente/quic-go v0.15.7 h1:Pu7To5/G9JoP1mwlrcIvfV8ByPBlCzif3MCl8+1W83I=
 github.com/lucas-clemente/quic-go v0.15.7/go.mod h1:Myi1OyS0FOjL3not4BxT7KN29bRkcMUV5JVVFLKtDp8=
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=

--- a/validator/accounts/v2/BUILD.bazel
+++ b/validator/accounts/v2/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "cmd.go",
         "doc.go",
+        "list.go",
         "new.go",
         "wallet.go",
     ],
@@ -15,11 +16,11 @@ go_library(
         "//validator:__subpackages__",
     ],
     deps = [
-        "//shared/featureconfig:go_default_library",
         "//validator/flags:go_default_library",
         "//validator/keymanager/v2:go_default_library",
         "//validator/keymanager/v2/direct:go_default_library",
         "@com_github_dustinkirkland_golang_petname//:go_default_library",
+        "@com_github_logrusorgru_aurora//:go_default_library",
         "@com_github_manifoldco_promptui//:go_default_library",
         "@com_github_nbutton23_zxcvbn_go//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/validator/accounts/v2/BUILD.bazel
+++ b/validator/accounts/v2/BUILD.bazel
@@ -32,14 +32,18 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "list_test.go",
         "new_test.go",
         "wallet_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//shared/bls:go_default_library",
+        "//shared/bytesutil:go_default_library",
         "//shared/testutil:go_default_library",
         "//validator/keymanager/v2:go_default_library",
         "//validator/keymanager/v2/direct:go_default_library",
+        "//validator/keymanager/v2/testing:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/validator/accounts/v2/cmd.go
+++ b/validator/accounts/v2/cmd.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/validator/flags"
 	"github.com/urfave/cli/v2"
 )
@@ -17,12 +16,20 @@ var Commands = &cli.Command{
 			Description: `creates a new validator account for eth2. If no account exists at the wallet path, creates a new wallet for a user based on
 specified input, capable of creating a direct, derived, or remote wallet.
 this command outputs a deposit data string which is required to become a validator in eth2.`,
-			Flags: append(featureconfig.ActiveFlags(featureconfig.ValidatorFlags),
-				[]cli.Flag{
-					flags.WalletDirFlag,
-					flags.WalletPasswordsDirFlag,
-				}...),
+			Flags: []cli.Flag{
+				flags.WalletDirFlag,
+				flags.WalletPasswordsDirFlag,
+			},
 			Action: NewAccount,
+		},
+		{
+			Name:        "list",
+			Description: "Lists all validator accounts in a user's wallet directory",
+			Flags: []cli.Flag{
+				flags.WalletDirFlag,
+				flags.WalletPasswordsDirFlag,
+			},
+			Action: ListAccounts,
 		},
 	},
 }

--- a/validator/accounts/v2/cmd.go
+++ b/validator/accounts/v2/cmd.go
@@ -28,6 +28,7 @@ this command outputs a deposit data string which is required to become a validat
 			Flags: []cli.Flag{
 				flags.WalletDirFlag,
 				flags.WalletPasswordsDirFlag,
+				flags.ShowDepositDataFlag,
 			},
 			Action: ListAccounts,
 		},

--- a/validator/accounts/v2/list.go
+++ b/validator/accounts/v2/list.go
@@ -17,14 +17,11 @@ import (
 
 // ListAccounts displays all available validator accounts in a Prysm wallet.
 func ListAccounts(cliCtx *cli.Context) error {
-	walletDir := cliCtx.String(flags.WalletDirFlag.Name)
-	if walletDir == flags.DefaultValidatorDir() {
-		walletDir = path.Join(walletDir, WalletDefaultDirName)
+	walletDir, err := inputWalletDir(cliCtx)
+	if err != nil {
+		log.Fatal(err)
 	}
-	passwordsDir := cliCtx.String(flags.WalletPasswordsDirFlag.Name)
-	if passwordsDir == flags.DefaultValidatorDir() {
-		passwordsDir = path.Join(passwordsDir, PasswordsDefaultDirName)
-	}
+	passwordsDir := inputPasswordsDirectory(cliCtx)
 	// Read the wallet from the specified path.
 	ctx := context.Background()
 	wallet, err := OpenWallet(ctx, &WalletConfig{

--- a/validator/accounts/v2/list.go
+++ b/validator/accounts/v2/list.go
@@ -1,10 +1,67 @@
 package v2
 
 import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/logrusorgru/aurora"
 	"github.com/urfave/cli/v2"
+
+	"github.com/prysmaticlabs/prysm/validator/flags"
 )
 
 // ListAccounts --
 func ListAccounts(cliCtx *cli.Context) error {
+	walletDir := cliCtx.String(flags.WalletDirFlag.Name)
+	if walletDir == flags.DefaultValidatorDir() {
+		walletDir = path.Join(walletDir, WalletDefaultDirName)
+	}
+	passwordsDir := cliCtx.String(flags.WalletPasswordsDirFlag.Name)
+	if passwordsDir == flags.DefaultValidatorDir() {
+		passwordsDir = path.Join(passwordsDir, PasswordsDefaultDirName)
+	}
+	// Read the wallet from the specified path.
+	ctx := context.Background()
+	wallet, err := OpenWallet(ctx, &WalletConfig{
+		PasswordsDir: passwordsDir,
+		WalletDir:    walletDir,
+	})
+	if err == ErrNoWalletFound {
+		log.Fatal("No wallet found")
+	} else if err != nil {
+		log.Fatalf("Could not read wallet at specified path %s: %v", walletDir, err)
+	}
+	// We initialize the wallet's keymanager.
+	accountNames, err := wallet.AccountNames()
+	if err != nil {
+		log.Fatal(err)
+	}
+	keymanager, err := wallet.ExistingKeyManager(ctx)
+	if err != nil {
+		log.Fatalf("Could not initialize keymanager: %v", err)
+	}
+	pubKeys, err := keymanager.FetchValidatingPublicKeys(ctx)
+	if err != nil {
+		log.Fatal(err)
+	}
+	au := aurora.NewAurora(true)
+	numAccounts := au.BrightYellow(len(accountNames))
+	fmt.Println("")
+	if len(accountNames) == 1 {
+		fmt.Printf("Found %d validator account\n", numAccounts)
+	} else {
+		fmt.Printf("Found %d validator accounts\n", numAccounts)
+	}
+	fmt.Printf("%s %s\n", dirPath, wallet.AccountsDir())
+	dirPath := au.BrightMagenta("(directory path)")
+	fmt.Printf("%s %s\n", dirPath, wallet.AccountsDir())
+	passwordsPath := au.BrightCyan("(passwords path)")
+	fmt.Printf("%s %s\n", passwordsPath, wallet.passwordsDir)
+	for i := 0; i < len(accountNames); i++ {
+		fmt.Println("")
+		fmt.Println(au.BrightGreen(accountNames[i]).Bold())
+		fmt.Printf("%#x\n", pubKeys[i])
+	}
 	return nil
 }

--- a/validator/accounts/v2/list.go
+++ b/validator/accounts/v2/list.go
@@ -49,19 +49,45 @@ func ListAccounts(cliCtx *cli.Context) error {
 	numAccounts := au.BrightYellow(len(accountNames))
 	fmt.Println("")
 	if len(accountNames) == 1 {
-		fmt.Printf("Found %d validator account\n", numAccounts)
+		fmt.Printf("Showing %d validator account\n", numAccounts)
 	} else {
-		fmt.Printf("Found %d validator accounts\n", numAccounts)
+		fmt.Printf("Showing %d validator accounts\n", numAccounts)
 	}
+	fmt.Println(
+		au.BrightRed("View the eth1 deposit transaction data for your accounts " +
+			"by running `validator accounts-v2 list --deposit-data"),
+	)
+	dirPath := au.BrightCyan("(wallet dir)")
 	fmt.Printf("%s %s\n", dirPath, wallet.AccountsDir())
-	dirPath := au.BrightMagenta("(directory path)")
-	fmt.Printf("%s %s\n", dirPath, wallet.AccountsDir())
-	passwordsPath := au.BrightCyan("(passwords path)")
-	fmt.Printf("%s %s\n", passwordsPath, wallet.passwordsDir)
+	dirPath = au.BrightCyan("(passwords dir)")
+	fmt.Printf("%s %s\n", dirPath, wallet.passwordsDir)
+	fmt.Printf("Keymanager kind: %s\n", au.BrightGreen(wallet.KeymanagerKind().String()).Bold())
+
+	showDepositData := cliCtx.Bool(flags.ShowDepositDataFlag.Name)
 	for i := 0; i < len(accountNames); i++ {
 		fmt.Println("")
-		fmt.Println(au.BrightGreen(accountNames[i]).Bold())
-		fmt.Printf("%#x\n", pubKeys[i])
+		fmt.Printf("%s\n", au.BrightGreen(accountNames[i]).Bold())
+		fmt.Printf("%s %#x\n", au.BrightMagenta("[public key]").Bold(), pubKeys[i])
+		fmt.Printf("%s %s\n", au.BrightCyan("[created at]").Bold(), "July 07, 2020 2:32 PM")
+		fmt.Printf("%s %s\n", "(eth1 tx data file)", "deposit_transaction.rlp")
+		if !showDepositData {
+			continue
+		}
+		enc, err := wallet.ReadFileForAccount(accountNames[i], "deposit_transaction.rlp")
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf(`
+======================Deposit Transaction Data=====================
+
+%#x
+
+===================================================================`, enc)
+		fmt.Println("")
+		fmt.Println(
+			au.BrightRed("Enter the above deposit data into step 3 on https://prylabs.net/participate").Bold(),
+		)
 	}
+	fmt.Println("")
 	return nil
 }

--- a/validator/accounts/v2/list.go
+++ b/validator/accounts/v2/list.go
@@ -1,0 +1,10 @@
+package v2
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+// ListAccounts --
+func ListAccounts(cliCtx *cli.Context) error {
+	return nil
+}

--- a/validator/accounts/v2/list_test.go
+++ b/validator/accounts/v2/list_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -56,6 +57,11 @@ func TestListAccounts_DirectKeymanager(t *testing.T) {
 		depositData := []byte(strconv.Itoa(i))
 		depositDataForAccounts[i] = depositData
 		if err := wallet.WriteFileForAccount(ctx, name, direct.DepositTransactionFileName, depositData); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write the creation timestamp for the account with unix timestamp 0.
+		if err := wallet.WriteFileForAccount(ctx, name, direct.TimestampFileName, []byte("0")); err != nil {
 			t.Fatal(err)
 		}
 
@@ -116,6 +122,11 @@ func TestListAccounts_DirectKeymanager(t *testing.T) {
 		// Assert the deposit data for the account is printed to stdout.
 		if !strings.Contains(stringOutput, fmt.Sprintf("%#x", depositData)) {
 			t.Errorf("Did not find deposit data %#x in output", depositData)
+		}
+
+		// Assert the account creation time is displayed
+		if !strings.Contains(stringOutput, fmt.Sprintf("%v", time.Unix(0, 0).String())) {
+			t.Error("Did not display account creation timestamp")
 		}
 	}
 }

--- a/validator/accounts/v2/list_test.go
+++ b/validator/accounts/v2/list_test.go
@@ -70,7 +70,10 @@ func TestListAccounts_DirectKeymanager(t *testing.T) {
 		pubKeys[i] = bytesutil.ToBytes48(key.PublicKey().Marshal())
 	}
 	rescueStdout := os.Stdout
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
 	os.Stdout = w
 
 	keymanager := &mock.MockKeymanager{
@@ -88,7 +91,10 @@ func TestListAccounts_DirectKeymanager(t *testing.T) {
 	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
-	out, _ := ioutil.ReadAll(r)
+	out, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
 	os.Stdout = rescueStdout
 
 	// Assert the keymanager kind is printed to stdout.

--- a/validator/accounts/v2/list_test.go
+++ b/validator/accounts/v2/list_test.go
@@ -1,0 +1,121 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	v2keymanager "github.com/prysmaticlabs/prysm/validator/keymanager/v2"
+	"github.com/prysmaticlabs/prysm/validator/keymanager/v2/direct"
+	mock "github.com/prysmaticlabs/prysm/validator/keymanager/v2/testing"
+)
+
+func TestListAccounts_DirectKeymanager(t *testing.T) {
+	walletDir, passwordsDir := setupWalletDir(t)
+	keymanagerKind := v2keymanager.Direct
+	ctx := context.Background()
+	wallet, err := CreateWallet(ctx, &WalletConfig{
+		PasswordsDir:   passwordsDir,
+		WalletDir:      walletDir,
+		KeymanagerKind: keymanagerKind,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	numAccounts := 5
+	accountNames := make([]string, numAccounts)
+	pubKeys := make([][48]byte, numAccounts)
+	password := "passw0rd2020%%"
+	depositDataForAccounts := make([][]byte, numAccounts)
+	for i := 0; i < numAccounts; i++ {
+		// Generate a new account name and write the account
+		// to disk using the wallet.
+		name, err := wallet.generateAccountName()
+		if err != nil {
+			t.Fatal(err)
+		}
+		accountNames[i] = name
+		// Generate a directory for the account name and
+		// write its associated password to disk.
+		accountPath := path.Join(wallet.accountsPath, name)
+		if err := os.MkdirAll(accountPath, directoryPermissions); err != nil {
+			t.Fatal(err)
+		}
+		if err := wallet.writePasswordToFile(name, password); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write the deposit data for each account.
+		depositData := []byte(strconv.Itoa(i))
+		depositDataForAccounts[i] = depositData
+		if err := wallet.WriteFileForAccount(ctx, name, direct.DepositTransactionFileName, depositData); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create public keys for the accounts.
+		key := bls.RandKey()
+		pubKeys[i] = bytesutil.ToBytes48(key.PublicKey().Marshal())
+	}
+	rescueStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	keymanager := &mock.MockKeymanager{
+		PublicKeys: pubKeys,
+	}
+	// We call the list direct keymanager accounts function.
+	if err := listDirectKeymanagerAccounts(
+		true, /* show deposit data */
+		wallet,
+		keymanager,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, _ := ioutil.ReadAll(r)
+	os.Stdout = rescueStdout
+
+	// Assert the keymanager kind is printed to stdout.
+	stringOutput := string(out)
+	if !strings.Contains(stringOutput, wallet.KeymanagerKind().String()) {
+		t.Error("Did not find Keymanager kind in output")
+	}
+
+	// Assert the wallet and passwords paths are in stdout.
+	if !strings.Contains(stringOutput, wallet.accountsPath) {
+		t.Errorf("Did not find accounts path %s in output", wallet.accountsPath)
+	}
+	if !strings.Contains(stringOutput, wallet.passwordsDir) {
+		t.Errorf("Did not find passwords path %s in output", wallet.passwordsDir)
+	}
+
+	for i := 0; i < numAccounts; i++ {
+		accountName := accountNames[i]
+		// Assert the account name is printed to stdout.
+		if !strings.Contains(stringOutput, accountName) {
+			t.Errorf("Did not find account %s in output", accountName)
+		}
+		key := pubKeys[i]
+		depositData := depositDataForAccounts[i]
+
+		// Assert every public key is printed to stdout.
+		if !strings.Contains(stringOutput, fmt.Sprintf("%#x", key)) {
+			t.Errorf("Did not find pubkey %#x in output", key)
+		}
+
+		// Assert the deposit data for the account is printed to stdout.
+		if !strings.Contains(stringOutput, fmt.Sprintf("%#x", depositData)) {
+			t.Errorf("Did not find deposit data %#x in output", depositData)
+		}
+	}
+}

--- a/validator/accounts/v2/wallet_test.go
+++ b/validator/accounts/v2/wallet_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	v2keymanager "github.com/prysmaticlabs/prysm/validator/keymanager/v2"
 	"github.com/prysmaticlabs/prysm/validator/keymanager/v2/direct"
-
+	mock "github.com/prysmaticlabs/prysm/validator/keymanager/v2/testing"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,18 +23,6 @@ func init() {
 }
 
 var _ = direct.Wallet(&Wallet{})
-
-type mockKeymanager struct {
-	configFileContents []byte
-}
-
-func (m *mockKeymanager) CreateAccount(ctx context.Context, password string) error {
-	return nil
-}
-
-func (m *mockKeymanager) MarshalConfigFile(ctx context.Context) ([]byte, error) {
-	return m.configFileContents, nil
-}
 
 func setupWalletDir(t testing.TB) (string, string) {
 	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
@@ -79,8 +67,8 @@ func TestCreateAndReadWallet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	keymanager := &mockKeymanager{
-		configFileContents: []byte("hello-world"),
+	keymanager := &mock.MockKeymanager{
+		ConfigFileContents: []byte("hello-world"),
 	}
 	keymanagerConfig, err := keymanager.MarshalConfigFile(ctx)
 	if err != nil {

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -126,6 +126,12 @@ var (
 		Usage: "Path to a directory on-disk where wallet passwords are stored",
 		Value: DefaultValidatorDir(),
 	}
+	// ShowDepositDataFlag for accounts-v2.
+	ShowDepositDataFlag = &cli.BoolFlag{
+		Name:  "show-deposit-data",
+		Usage: "Display raw eth1 tx deposit data for validator accounts-v2",
+		Value: false,
+	}
 )
 
 // DefaultValidatorDir returns OS-specific default validator directory.

--- a/validator/keymanager/v2/direct/BUILD.bazel
+++ b/validator/keymanager/v2/direct/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//shared/bytesutil:go_default_library",
         "//shared/depositutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/roughtime:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
         "@com_github_manifoldco_promptui//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/validator/keymanager/v2/direct/direct.go
+++ b/validator/keymanager/v2/direct/direct.go
@@ -25,9 +25,11 @@ import (
 var log = logrus.WithField("prefix", "keymanager-v2")
 
 const (
+	// DepositTransactionFileName for the encoded, eth1 raw deposit tx data
+	// for a validator account.
+	DepositTransactionFileName = "deposit_transaction.rlp"
 	keystoreFileName           = "keystore.json"
 	depositDataFileName        = "deposit_data.ssz"
-	depositTransactionFileName = "deposit_transaction.rlp"
 	eipVersion                 = "EIP-2335"
 )
 
@@ -140,8 +142,8 @@ func (dr *Keymanager) CreateAccount(ctx context.Context, password string) (strin
 	logDepositTransaction(tx)
 
 	// We write the raw deposit transaction as an .rlp encoded file.
-	if err := dr.wallet.WriteFileForAccount(ctx, accountName, depositTransactionFileName, tx.Data()); err != nil {
-		return "", errors.Wrapf(err, "could not write for account %s: %s", accountName, depositTransactionFileName)
+	if err := dr.wallet.WriteFileForAccount(ctx, accountName, DepositTransactionFileName, tx.Data()); err != nil {
+		return "", errors.Wrapf(err, "could not write for account %s: %s", accountName, DepositTransactionFileName)
 	}
 
 	// We write the ssz-encoded deposit data to disk as a .ssz file.

--- a/validator/keymanager/v2/testing/BUILD.bazel
+++ b/validator/keymanager/v2/testing/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["mock.go"],
+    importpath = "github.com/prysmaticlabs/prysm/validator/keymanager/v2/testing",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//proto/validator/accounts/v2:go_default_library",
+        "//shared/bls:go_default_library",
+        "//shared/bytesutil:go_default_library",
+    ],
+)

--- a/validator/keymanager/v2/testing/BUILD.bazel
+++ b/validator/keymanager/v2/testing/BUILD.bazel
@@ -2,9 +2,13 @@ load("@prysm//tools/go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
+    testonly = 1,
     srcs = ["mock.go"],
     importpath = "github.com/prysmaticlabs/prysm/validator/keymanager/v2/testing",
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//validator:__pkg__",
+        "//validator:__subpackages__",
+    ],
     deps = [
         "//proto/validator/accounts/v2:go_default_library",
         "//shared/bls:go_default_library",

--- a/validator/keymanager/v2/testing/mock.go
+++ b/validator/keymanager/v2/testing/mock.go
@@ -26,7 +26,7 @@ func (m *MockKeymanager) MarshalConfigFile(ctx context.Context) ([]byte, error) 
 	return m.ConfigFileContents, nil
 }
 
-// FetchValidatingKeys --
+// FetchValidatingPublicKeys --
 func (m *MockKeymanager) FetchValidatingPublicKeys(ctx context.Context) ([][48]byte, error) {
 	return m.PublicKeys, nil
 }

--- a/validator/keymanager/v2/testing/mock.go
+++ b/validator/keymanager/v2/testing/mock.go
@@ -1,0 +1,42 @@
+package testing
+
+import (
+	"context"
+	"errors"
+
+	validatorpb "github.com/prysmaticlabs/prysm/proto/validator/accounts/v2"
+	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+)
+
+// MockKeymanager --
+type MockKeymanager struct {
+	ConfigFileContents  []byte
+	PublicKeys          [][48]byte
+	PubkeystoSecretKeys map[[48]byte]bls.SecretKey
+}
+
+// CreateAccount --
+func (m *MockKeymanager) CreateAccount(ctx context.Context, password string) (string, error) {
+	return "", nil
+}
+
+// MarshalConfigFile --
+func (m *MockKeymanager) MarshalConfigFile(ctx context.Context) ([]byte, error) {
+	return m.ConfigFileContents, nil
+}
+
+// FetchValidatingKeys --
+func (m *MockKeymanager) FetchValidatingPublicKeys(ctx context.Context) ([][48]byte, error) {
+	return m.PublicKeys, nil
+}
+
+// Sign --
+func (m *MockKeymanager) Sign(ctx context.Context, req *validatorpb.SignRequest) (bls.Signature, error) {
+	pubKey := bytesutil.ToBytes48(req.PublicKey)
+	secretKey, ok := m.PubkeystoSecretKeys[pubKey]
+	if !ok {
+		return nil, errors.New("no secret key found")
+	}
+	return secretKey.Sign(req.Data), nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR implements `validator accounts-v2 list` with the option of displaying deposit data for all validator accounts using the `--show-deposit-data` flag. It additionally adds created_at and updated_at metadata files containing a raw unix timestamp to each direct keymanager account.

<img width="1166" alt="Screen Shot 2020-07-07 at 4 13 01 PM" src="https://user-images.githubusercontent.com/5572669/86843837-c443cc80-c06c-11ea-9ce6-0b47f141584a.png">

**Which issues(s) does this PR fix?**

Part of #6220 and depends on #6489 
