### PR TITLE
Tiny optimization in state refs lock/unlock

### DIFF
--- a/beacon-chain/state/BUILD.bazel
+++ b/beacon-chain/state/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
     ],
 )
 
+# gazelle:exclude types_bench_test.go
 go_test(
     name = "go_default_test",
     srcs = [

--- a/beacon-chain/state/types.go
+++ b/beacon-chain/state/types.go
@@ -115,11 +115,10 @@ func (r *reference) AddRef() {
 
 func (r *reference) MinusRef() {
 	r.lock.Lock()
-	defer r.lock.Unlock()
 	// Do not reduce further if object
 	// already has 0 reference to prevent underflow.
-	if r.refs == 0 {
-		return
+	if r.refs > 0 {
+		r.refs--
 	}
-	r.refs--
+	r.lock.Unlock()
 }

--- a/beacon-chain/state/types_bench_test.go
+++ b/beacon-chain/state/types_bench_test.go
@@ -1,0 +1,15 @@
+package state
+
+import (
+	"math"
+	"testing"
+)
+
+func BenchmarkReference_MinusRef(b *testing.B) {
+	ref := &reference{
+		refs: math.MaxUint64,
+	}
+	for i := 0; i < b.N; i++ {
+		ref.MinusRef()
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Other/Minor Optimization

**What does this PR do? Why is it needed?**
- The `defer` after release of Go1.4 is almost as good as inlined function call, yet it still has a bit of an overhead.
- I've noticed that `AddRef()` avoids calling `defer`, this PR makes sure that `MinusRef()` also calls unlocking inline.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- To help gauging utility of the PR, here is the output of `benchstats` (~0.5% improvement on speed -- really tiny optimization):
```
± benchstat bench.old bench.new
name                  old time/op    new time/op    delta
Reference_MinusRef-8    30.4ns ± 0%    28.8ns ± 0%   ~     (p=1.000 n=1+1)
```
