### PR TITLE
Use same permissions for all files in Prysm 

### DIFF
--- a/beacon-chain/db/kv/backup.go
+++ b/beacon-chain/db/kv/backup.go
@@ -30,7 +30,7 @@ func (kv *Store) Backup(ctx context.Context) error {
 		return errors.New("no head block")
 	}
 	// Ensure the backups directory exists.
-	if err := os.MkdirAll(backupsDir, os.ModePerm); err != nil {
+	if err := os.MkdirAll(backupsDir, params.BeaconIoConfig().ReadWritePermissions); err != nil {
 		return err
 	}
 	backupPath := path.Join(backupsDir, fmt.Sprintf("prysm_beacondb_at_slot_%07d.backup", head.Block.Slot))

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -49,7 +49,7 @@ type Store struct {
 // path specified, creates the kv-buckets based on the schema, and stores
 // an open connection db object as a property of the Store struct.
 func NewKVStore(dirPath string, stateSummaryCache *cache.StateSummaryCache) (*Store, error) {
-	if err := os.MkdirAll(dirPath, 0700); err != nil {
+	if err := os.MkdirAll(dirPath, params.BeaconIoConfig().ReadWritePermissions); err != nil {
 		return nil, err
 	}
 	datafile := path.Join(dirPath, databaseFileName)

--- a/shared/keystore/BUILD.bazel
+++ b/shared/keystore/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//shared/bls:go_default_library",
+        "//shared/params:go_default_library",
         "//shared/roughtime:go_default_library",
         "@com_github_minio_sha256_simd//:go_default_library",
         "@com_github_pborman_uuid//:go_default_library",

--- a/shared/keystore/key.go
+++ b/shared/keystore/key.go
@@ -25,6 +25,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/prysmaticlabs/prysm/shared/params"
+
 	"github.com/pborman/uuid"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 )
@@ -169,8 +171,7 @@ func storeNewRandomKey(ks keyStore, password string) error {
 func writeKeyFile(file string, content []byte) error {
 	// Create the keystore directory with appropriate permissions
 	// in case it is not present yet.
-	const dirPerm = 0700
-	if err := os.MkdirAll(filepath.Dir(file), dirPerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(file), params.BeaconIoConfig().ReadWritePermissions); err != nil {
 		return err
 	}
 	// Atomic write: create a temporary hidden file first

--- a/shared/keystore/key.go
+++ b/shared/keystore/key.go
@@ -25,10 +25,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/prysmaticlabs/prysm/shared/params"
-
 	"github.com/pborman/uuid"
 	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
 const (

--- a/slasher/db/kv/kv.go
+++ b/slasher/db/kv/kv.go
@@ -88,7 +88,7 @@ func createBuckets(tx *bolt.Tx, buckets ...[]byte) error {
 // path specified, creates the kv-buckets based on the schema, and stores
 // an open connection db object as a property of the Store struct.
 func NewKVStore(dirPath string, cfg *Config) (*Store, error) {
-	if err := os.MkdirAll(dirPath, 0700); err != nil {
+	if err := os.MkdirAll(dirPath, params.BeaconIoConfig().ReadWritePermissions); err != nil {
 		return nil, err
 	}
 	datafile := path.Join(dirPath, databaseFileName)

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/shared/params"
+
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
 )
@@ -60,11 +62,11 @@ func createBuckets(tx *bolt.Tx, buckets ...[]byte) error {
 // path specified, creates the kv-buckets based on the schema, and stores
 // an open connection db object as a property of the Store struct.
 func NewKVStore(dirPath string, pubKeys [][48]byte) (*Store, error) {
-	if err := os.MkdirAll(dirPath, 0700); err != nil {
+	if err := os.MkdirAll(dirPath, params.BeaconIoConfig().ReadWritePermissions); err != nil {
 		return nil, err
 	}
 	datafile := filepath.Join(dirPath, databaseFileName)
-	boltDB, err := bolt.Open(datafile, 0600, &bolt.Options{Timeout: 1 * time.Second})
+	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		if err == bolt.ErrTimeout {
 			return nil, errors.New("cannot obtain database lock, database may be in use by another process")
@@ -98,7 +100,7 @@ func GetKVStore(directory string) (*Store, error) {
 	if _, err := os.Stat(fileName); os.IsNotExist(err) {
 		return nil, nil
 	}
-	boltDb, err := bolt.Open(fileName, 0600, &bolt.Options{Timeout: 1 * time.Second})
+	boltDb, err := bolt.Open(fileName, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: 1 * time.Second})
 	if err != nil {
 		if err == bolt.ErrTimeout {
 			return nil, errors.New("cannot obtain database lock, database may be in use by another process")

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -6,9 +6,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/prysmaticlabs/prysm/shared/params"
-
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	bolt "go.etcd.io/bbolt"
 )
 


### PR DESCRIPTION
**What type of PR is this?**
Permissions cleanup
 
**What does this PR do? Why is it needed?**
This PR covers 57 and 58 of the audit best practices feedback by changing all files to the same perms, 0600 as used in the IO Config.