### PR TITLE
Add separate permission for directories.

### DIFF
--- a/beacon-chain/db/kv/backup.go
+++ b/beacon-chain/db/kv/backup.go
@@ -30,7 +30,7 @@ func (kv *Store) Backup(ctx context.Context) error {
 		return errors.New("no head block")
 	}
 	// Ensure the backups directory exists.
-	if err := os.MkdirAll(backupsDir, params.BeaconIoConfig().ReadWritePermissions); err != nil {
+	if err := os.MkdirAll(backupsDir, params.BeaconIoConfig().ReadWriteExecutePermissions); err != nil {
 		return err
 	}
 	backupPath := path.Join(backupsDir, fmt.Sprintf("prysm_beacondb_at_slot_%07d.backup", head.Block.Slot))

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -49,7 +49,7 @@ type Store struct {
 // path specified, creates the kv-buckets based on the schema, and stores
 // an open connection db object as a property of the Store struct.
 func NewKVStore(dirPath string, stateSummaryCache *cache.StateSummaryCache) (*Store, error) {
-	if err := os.MkdirAll(dirPath, params.BeaconIoConfig().ReadWritePermissions); err != nil {
+	if err := os.MkdirAll(dirPath, params.BeaconIoConfig().ReadWriteExecutePermissions); err != nil {
 		return nil, err
 	}
 	datafile := path.Join(dirPath, databaseFileName)

--- a/shared/keystore/key.go
+++ b/shared/keystore/key.go
@@ -170,7 +170,7 @@ func storeNewRandomKey(ks keyStore, password string) error {
 func writeKeyFile(file string, content []byte) error {
 	// Create the keystore directory with appropriate permissions
 	// in case it is not present yet.
-	if err := os.MkdirAll(filepath.Dir(file), params.BeaconIoConfig().ReadWritePermissions); err != nil {
+	if err := os.MkdirAll(filepath.Dir(file), params.BeaconIoConfig().ReadWriteExecutePermissions); err != nil {
 		return err
 	}
 	// Atomic write: create a temporary hidden file first

--- a/shared/params/io_config.go
+++ b/shared/params/io_config.go
@@ -4,11 +4,13 @@ import "os"
 
 // IoConfig defines the shared io parameters.
 type IoConfig struct {
-	ReadWritePermissions os.FileMode
+	ReadWritePermissions        os.FileMode
+	ReadWriteExecutePermissions os.FileMode
 }
 
 var defaultIoConfig = &IoConfig{
-	ReadWritePermissions: 0600, //-rw------- Read and Write permissions for user
+	ReadWritePermissions:        0600, //-rw------- Read and Write permissions for user
+	ReadWriteExecutePermissions: 0700, //-rwx------ Read Write and Execute (traverse) permissions for user
 }
 
 // BeaconIoConfig returns the current io config for

--- a/slasher/db/kv/kv.go
+++ b/slasher/db/kv/kv.go
@@ -88,7 +88,7 @@ func createBuckets(tx *bolt.Tx, buckets ...[]byte) error {
 // path specified, creates the kv-buckets based on the schema, and stores
 // an open connection db object as a property of the Store struct.
 func NewKVStore(dirPath string, cfg *Config) (*Store, error) {
-	if err := os.MkdirAll(dirPath, params.BeaconIoConfig().ReadWritePermissions); err != nil {
+	if err := os.MkdirAll(dirPath, params.BeaconIoConfig().ReadWriteExecutePermissions); err != nil {
 		return nil, err
 	}
 	datafile := path.Join(dirPath, databaseFileName)

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -61,7 +61,7 @@ func createBuckets(tx *bolt.Tx, buckets ...[]byte) error {
 // path specified, creates the kv-buckets based on the schema, and stores
 // an open connection db object as a property of the Store struct.
 func NewKVStore(dirPath string, pubKeys [][48]byte) (*Store, error) {
-	if err := os.MkdirAll(dirPath, params.BeaconIoConfig().ReadWritePermissions); err != nil {
+	if err := os.MkdirAll(dirPath, params.BeaconIoConfig().ReadWriteExecutePermissions); err != nil {
 		return nil, err
 	}
 	datafile := filepath.Join(dirPath, databaseFileName)


### PR DESCRIPTION
#6522 uses the same permissions for files and directories, which results in prysm being unable to traverse directories due to the lack of the executable bit.

This patch adds a second permission suitable for directories, and uses it where appropriate.