### PR TITLE
Remove participation link when `list` accounts

### DIFF
--- a/validator/accounts/v2/list.go
+++ b/validator/accounts/v2/list.go
@@ -117,9 +117,6 @@ func listDirectKeymanagerAccounts(
 
 ===================================================================`, enc)
 		fmt.Println("")
-		fmt.Println(
-			au.BrightRed("Enter the above deposit data into step 3 on https://prylabs.net/participate").Bold(),
-		)
 	}
 	fmt.Println("")
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Feature

**What does this PR do? Why is it needed?**
Showing Prysmatic Lab's participation link means our validator accounts are tightly coupled with `https://prylabs.net/p...` as the "canonical" location for sending deposit. It may not be the case in the near future as there maybe better options and launchpad should the canonical one. This PR removes this.

Fixes #

**Other notes for review**
Before:
```
[public key] 0xa802d90ed457a2937ab96218c358f7819ec0239470bdb6088f1ee872f266c52392f377ec44e5320f66e8634138aaabf8
[created at] 2020-07-09 09:09:36 -0700 PDT
(deposit tx file) /Users/terence/Library/Eth2Validators/.prysm-wallet-v2/direct/wildly-well-walrus/deposit_transaction.rlp

======================Deposit Transaction Data=====================

0x22895118000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000001204b6773a6ff30b960652ab68742ee91adf800100f8fb2bd340ce3f36c09e26dcb0000000000000000000000000000000000000000000000000000000000000030a802d90ed457a2937ab96218c358f7819ec0239470bdb6088f1ee872f266c52392f377ec44e5320f66e8634138aaabf800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000e10273b00d4c9a9959723fe933166083a335e25f1896dfbc6c618b250fae0b0000000000000000000000000000000000000000000000000000000000000060842b5d0f65758aac716188b2fc39b3569d6f12060302b24d7dd8804555f96b1144b4ac741dbe8fe5ae22e0c55a80900e08ed61102683337c12bcaa03f7d028b77321997bb00eae9ecb974b22659fdb0f824a31ebd247ded016b5ed6a170be82f

===================================================================
Enter the above deposit data into step 3 on https://prylabs.net/participate
```

After:
```
[public key] 0xa802d90ed457a2937ab96218c358f7819ec0239470bdb6088f1ee872f266c52392f377ec44e5320f66e8634138aaabf8
[created at] 2020-07-09 09:09:36 -0700 PDT
(deposit tx file) /Users/terence/Library/Eth2Validators/.prysm-wallet-v2/direct/wildly-well-walrus/deposit_transaction.rlp

======================Deposit Transaction Data=====================

0x22895118000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000001204b6773a6ff30b960652ab68742ee91adf800100f8fb2bd340ce3f36c09e26dcb0000000000000000000000000000000000000000000000000000000000000030a802d90ed457a2937ab96218c358f7819ec0239470bdb6088f1ee872f266c52392f377ec44e5320f66e8634138aaabf800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000e10273b00d4c9a9959723fe933166083a335e25f1896dfbc6c618b250fae0b0000000000000000000000000000000000000000000000000000000000000060842b5d0f65758aac716188b2fc39b3569d6f12060302b24d7dd8804555f96b1144b4ac741dbe8fe5ae22e0c55a80900e08ed61102683337c12bcaa03f7d028b77321997bb00eae9ecb974b22659fdb0f824a31ebd247ded016b5ed6a170be82f
```
