### PR TITLE
Properly cache state for batch sync

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
+	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
 	"github.com/prysmaticlabs/prysm/shared/attestationutil"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -225,6 +226,13 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []*ethpb.SignedBeaconBl
 		set, preState, err = state.ExecuteStateTransitionNoVerifyAnySig(ctx, preState, b)
 		if err != nil {
 			return nil, nil, nil, err
+		}
+		r, err := stateutil.BlockRoot(b.Block)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if err := s.stateGen.SaveState(ctx, r, preState); err != nil {
+			return nil, nil, nil, errors.Wrap(err, "could not save state")
 		}
 		jCheckpoints[i] = preState.CurrentJustifiedCheckpoint()
 		fCheckpoints[i] = preState.FinalizedCheckpoint()

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -157,10 +157,6 @@ func (s *Service) ReceiveBlockBatch(ctx context.Context, blocks []*ethpb.SignedB
 	lastBlk := blocks[len(blocks)-1]
 	lastRoot := blkRoots[len(blkRoots)-1]
 
-	if err := s.stateGen.SaveState(ctx, lastRoot, postState); err != nil {
-		return errors.Wrap(err, "could not save state")
-	}
-
 	cachedHeadRoot, err := s.HeadRoot(ctx)
 	if err != nil {
 		return errors.Wrap(err, "could not get head root from cache")


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
For batch sync, we were only caching states at the end batch slot which was an intermittent interval (ex: 2343, 2390, 2441.. etc)
This scheme not work for initial syncing with the new state mgmt. As we previously design would always cache epoch boundary states for migration and even every slot because it's really cheap since `saveHotState` doesn't touch DB.
This PR fixed it by caching states as the same as previous interval. To reiterate, this only writes the state to memory so it's very cheap.

<img width="1614" alt="Screen Shot 2020-07-09 at 9 18 44 PM" src="https://user-images.githubusercontent.com/21316537/87116097-ce5efa00-c229-11ea-96df-627bf30b583b.png">

