### PR TITLE
Use time.Now() for roughtime delta computation instead of t0

### DIFF
--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -42,13 +42,12 @@ func init() {
 }
 
 func recalibrateRoughtime() {
-	t0 := time.Now()
 	results := rt.Do(rt.Ecosystem, rt.DefaultQueryAttempts, rt.DefaultQueryTimeout, nil)
 	// Compute the average difference between the system's time and the
 	// Roughtime responses from the servers, rejecting responses whose radii
 	// are larger than 2 seconds.
 	var err error
-	offset, err = rt.AvgDeltaWithRadiusThresh(results, t0, 2*time.Second)
+	offset, err = rt.AvgDeltaWithRadiusThresh(results, time.Now(), 2*time.Second)
 	if err != nil {
 		log.WithError(err).Error("Failed to calculate roughtime offset")
 	}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

A quick follow up to #6546. I think rt.Do might have a non-trivial delay which would make t0 inaccurate as a "now" value.

**Which issues(s) does this PR fix?**

Part of investigation for #6544.

**Other notes for review**
