### PR TITLE
Attestation cache: check bitlist length before checking contains

### DIFF
--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -188,7 +188,7 @@ func (p *AttCaches) HasAggregatedAttestation(att *ethpb.Attestation) (bool, erro
 	defer p.aggregatedAttLock.RUnlock()
 	if atts, ok := p.aggregatedAtt[r]; ok {
 		for _, a := range atts {
-			if a.AggregationBits.Contains(att.AggregationBits) {
+			if a.AggregationBits.Len() == att.AggregationBits.Len() && a.AggregationBits.Contains(att.AggregationBits) {
 				return true, nil
 			}
 		}
@@ -198,7 +198,7 @@ func (p *AttCaches) HasAggregatedAttestation(att *ethpb.Attestation) (bool, erro
 	defer p.blockAttLock.RUnlock()
 	if atts, ok := p.blockAtt[r]; ok {
 		for _, a := range atts {
-			if a.AggregationBits.Contains(att.AggregationBits) {
+			if a.AggregationBits.Len() == att.AggregationBits.Len() && a.AggregationBits.Contains(att.AggregationBits) {
 				return true, nil
 			}
 		}

--- a/beacon-chain/operations/attestations/kv/aggregated_test.go
+++ b/beacon-chain/operations/attestations/kv/aggregated_test.go
@@ -382,6 +382,24 @@ func TestKV_Aggregated_HasAggregatedAttestation(t *testing.T) {
 				AggregationBits: bitfield.Bitlist{0b1111111}},
 			want: false,
 		},
+		{
+			name: "attestations with different bitlist lengths",
+			existing: []*ethpb.Attestation{
+				{
+					Data: &ethpb.AttestationData{
+						Slot: 2,
+					},
+					AggregationBits: bitfield.Bitlist{0b1111000},
+				},
+			},
+			input: &ethpb.Attestation{
+				Data: &ethpb.AttestationData{
+					Slot: 2,
+				},
+				AggregationBits: bitfield.Bitlist{0b1111},
+			},
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Fixes an error like
```
prefix=message-handler r="bitlists are different lengths" time="2020-07-10 19:13:42" level=error msg="Received nil message on pubsub" prefix=sync
```

**Which issues(s) does this PR fix?**

Part of https://github.com/prysmaticlabs/prysm/issues/6548#issuecomment-656847650

**Other notes for review**
