### PR TITLE
Refactor verifyBlkDescendant to be public in chainservice API

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -57,6 +57,7 @@ type ForkFetcher interface {
 // CanonicalFetcher retrieves the current chain's canonical information.
 type CanonicalFetcher interface {
 	IsCanonical(ctx context.Context, blockRoot [32]byte) (bool, error)
+	VerifyBlkDescendant(ctx context.Context, blockRoot [32]byte) error
 }
 
 // FinalizationFetcher defines a common interface for methods in blockchain service which

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -54,7 +54,7 @@ func (s *Service) getBlockPreState(ctx context.Context, b *ethpb.BeaconBlock) (*
 	}
 
 	// Verify block is a descendent of a finalized block.
-	if err := s.verifyBlkDescendant(ctx, bytesutil.ToBytes32(b.ParentRoot), b.Slot); err != nil {
+	if err := s.VerifyBlkDescendant(ctx, bytesutil.ToBytes32(b.ParentRoot)); err != nil {
 		return nil, err
 	}
 
@@ -87,10 +87,10 @@ func (s *Service) verifyBlkPreState(ctx context.Context, b *ethpb.BeaconBlock) e
 	return nil
 }
 
-// verifyBlkDescendant validates input block root is a descendant of the
+// VerifyBlkDescendant validates input block root is a descendant of the
 // current finalized block root.
-func (s *Service) verifyBlkDescendant(ctx context.Context, root [32]byte, slot uint64) error {
-	ctx, span := trace.StartSpan(ctx, "forkChoice.verifyBlkDescendant")
+func (s *Service) VerifyBlkDescendant(ctx context.Context, root [32]byte) error {
+	ctx, span := trace.StartSpan(ctx, "forkChoice.VerifyBlkDescendant")
 	defer span.End()
 
 	finalizedBlkSigned, err := s.beaconDB.Block(ctx, bytesutil.ToBytes32(s.finalizedCheckpt.Root))
@@ -104,12 +104,13 @@ func (s *Service) verifyBlkDescendant(ctx context.Context, root [32]byte, slot u
 		return errors.Wrap(err, "could not get finalized block root")
 	}
 	if bFinalizedRoot == nil {
-		return fmt.Errorf("no finalized block known for block from slot %d", slot)
+		return fmt.Errorf("no finalized block known for block %#x", bytesutil.Trunc(root[:]))
 	}
 
 	if !bytes.Equal(bFinalizedRoot, s.finalizedCheckpt.Root) {
-		err := fmt.Errorf("block from slot %d is not a descendent of the current finalized block slot %d, %#x != %#x",
-			slot, finalizedBlk.Slot, bytesutil.Trunc(bFinalizedRoot), bytesutil.Trunc(s.finalizedCheckpt.Root))
+		err := fmt.Errorf("block %#x is not a descendent of the current finalized block slot %d, %#x != %#x",
+			bytesutil.Trunc(root[:]), finalizedBlk.Slot, bytesutil.Trunc(bFinalizedRoot),
+			bytesutil.Trunc(s.finalizedCheckpt.Root))
 		traceutil.AnnotateError(span, err)
 		return err
 	}

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -100,7 +100,7 @@ func TestStore_OnBlock(t *testing.T) {
 			name:          "could not get finalized block",
 			blk:           &ethpb.BeaconBlock{ParentRoot: randomParentRoot[:]},
 			s:             st.Copy(),
-			wantErrString: "block from slot 0 is not a descendent of the current finalized block",
+			wantErrString: "is not a descendent of the current finalized block",
 		},
 		{
 			name:          "same slot as finalized block",

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -347,6 +347,7 @@ func (ms *ChainService) HasInitSyncBlock(root [32]byte) bool {
 func (ms *ChainService) HeadGenesisValidatorRoot() [32]byte {
 	return [32]byte{}
 }
+
 // VerifyBlkDescendant mocks VerifyBlkDescendant and always returns nil.
 func (ms *ChainService) VerifyBlkDescendant(ctx context.Context, root [32]byte) error {
 	return nil

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -347,3 +347,7 @@ func (ms *ChainService) HasInitSyncBlock(root [32]byte) bool {
 func (ms *ChainService) HeadGenesisValidatorRoot() [32]byte {
 	return [32]byte{}
 }
+// VerifyBlkDescendant mocks VerifyBlkDescendant and always returns nil.
+func (ms *ChainService) VerifyBlkDescendant(ctx context.Context, root [32]byte) error {
+	return nil
+}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Verifying a block root is a descendant of the finalized chain is important for stopping propagation of bad blocks.
See: #6548.

**Which issues(s) does this PR fix?**

Part of #6548.
Requirement for #6549.

**Other notes for review**

Opening this small PR to reduce review scope / size of #6549.
