### PR TITLE
Add BoltTimeout to IO config 

### DIFF
--- a/beacon-chain/db/kv/backup.go
+++ b/beacon-chain/db/kv/backup.go
@@ -36,7 +36,7 @@ func (kv *Store) Backup(ctx context.Context) error {
 	backupPath := path.Join(backupsDir, fmt.Sprintf("prysm_beacondb_at_slot_%07d.backup", head.Block.Slot))
 	logrus.WithField("prefix", "db").WithField("backup", backupPath).Info("Writing backup database.")
 
-	copyDB, err := bolt.Open(backupPath, params.BeaconIoConfig().ReadWritePermissions, nil)
+	copyDB, err := bolt.Open(backupPath, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: params.BeaconIoConfig().BoltTimeout})
 	if err != nil {
 		panic(err)
 	}

--- a/shared/params/io_config.go
+++ b/shared/params/io_config.go
@@ -1,16 +1,21 @@
 package params
 
-import "os"
+import (
+	"os"
+	"time"
+)
 
 // IoConfig defines the shared io parameters.
 type IoConfig struct {
 	ReadWritePermissions        os.FileMode
 	ReadWriteExecutePermissions os.FileMode
+	BoltTimeout                 time.Duration
 }
 
 var defaultIoConfig = &IoConfig{
-	ReadWritePermissions:        0600, //-rw------- Read and Write permissions for user
-	ReadWriteExecutePermissions: 0700, //-rwx------ Read Write and Execute (traverse) permissions for user
+	ReadWritePermissions:        0600,            //-rw------- Read and Write permissions for user
+	ReadWriteExecutePermissions: 0700,            //-rwx------ Read Write and Execute (traverse) permissions for user
+	BoltTimeout:                 1 * time.Second, // 1 second for the bolt DB to timeout.
 }
 
 // BeaconIoConfig returns the current io config for

--- a/slasher/db/kv/kv.go
+++ b/slasher/db/kv/kv.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"os"
 	"path"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -92,7 +91,7 @@ func NewKVStore(dirPath string, cfg *Config) (*Store, error) {
 		return nil, err
 	}
 	datafile := path.Join(dirPath, databaseFileName)
-	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: 1 * time.Second})
+	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: params.BeaconIoConfig().BoltTimeout})
 	if err != nil {
 		if err == bolt.ErrTimeout {
 			return nil, errors.New("cannot obtain database lock, database may be in use by another process")

--- a/tools/cluster-pk-manager/server/db.go
+++ b/tools/cluster-pk-manager/server/db.go
@@ -53,7 +53,7 @@ type db struct {
 
 func newDB(dbPath string) *db {
 	datafile := path.Join(dbPath, dbFileName)
-	boltdb, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: 1 * time.Second})
+	boltdb, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: params.BeaconIoConfig().BoltTimeout})
 	if err != nil {
 		panic(err)
 	}

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -4,7 +4,6 @@ package kv
 import (
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -65,7 +64,7 @@ func NewKVStore(dirPath string, pubKeys [][48]byte) (*Store, error) {
 		return nil, err
 	}
 	datafile := filepath.Join(dirPath, databaseFileName)
-	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: 1 * time.Second})
+	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: params.BeaconIoConfig().BoltTimeout})
 	if err != nil {
 		if err == bolt.ErrTimeout {
 			return nil, errors.New("cannot obtain database lock, database may be in use by another process")
@@ -99,7 +98,7 @@ func GetKVStore(directory string) (*Store, error) {
 	if _, err := os.Stat(fileName); os.IsNotExist(err) {
 		return nil, nil
 	}
-	boltDb, err := bolt.Open(fileName, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: 1 * time.Second})
+	boltDb, err := bolt.Open(fileName, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: params.BeaconIoConfig().BoltTimeout})
 	if err != nil {
 		if err == bolt.ErrTimeout {
 			return nil, errors.New("cannot obtain database lock, database may be in use by another process")


### PR DESCRIPTION
**What type of PR is this?**
Best practices 

**What does this PR do? Why is it needed?**
This is part of #6337 , changes bolt timeout to a global config and sets it to backup.go