### PR TITLE
Save Blocks Before Migrating

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -201,6 +201,13 @@ func (s *Service) updateJustified(ctx context.Context, state *stateTrie.BeaconSt
 }
 
 func (s *Service) updateFinalized(ctx context.Context, cp *ethpb.Checkpoint) error {
+	// Blocks need to be saved so that we can retrieve finalized block from
+	// DB when migrating states.
+	if err := s.beaconDB.SaveBlocks(ctx, s.getInitSyncBlocks()); err != nil {
+		return err
+	}
+	s.clearInitSyncBlocks()
+
 	s.prevFinalizedCheckpt = s.finalizedCheckpt
 	s.finalizedCheckpt = cp
 


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Reverts change from #6562 , so as to save all blocks before we start migrating states upon a new finalized checkpoint.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
