### PR TITLE
Remove redundant check in attestation_utils.go

### DIFF
--- a/shared/attestationutil/BUILD.bazel
+++ b/shared/attestationutil/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
         "//shared/bls:go_default_library",
-        "//shared/params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",

--- a/shared/attestationutil/attestation_utils.go
+++ b/shared/attestationutil/attestation_utils.go
@@ -5,7 +5,6 @@ package attestationutil
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"reflect"
 	"sort"
 

--- a/shared/attestationutil/attestation_utils.go
+++ b/shared/attestationutil/attestation_utils.go
@@ -151,9 +151,6 @@ func IsValidAttestationIndices(ctx context.Context, indexedAttestation *ethpb.In
 	if len(indices) == 0 {
 		return errors.New("expected non-empty attesting indices")
 	}
-	if uint64(len(indices)) > params.BeaconConfig().MaxValidatorsPerCommittee {
-		return fmt.Errorf("validator indices count exceeds MAX_VALIDATORS_PER_COMMITTEE, %d > %d", len(indices), params.BeaconConfig().MaxValidatorsPerCommittee)
-	}
 	set := make(map[uint64]bool, len(indices))
 	setIndices := make([]uint64, 0, len(indices))
 	for _, i := range indices {

--- a/shared/attestationutil/attestation_utils.go
+++ b/shared/attestationutil/attestation_utils.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/bls"
-	"github.com/prysmaticlabs/prysm/shared/params"
 	"go.opencensus.io/trace"
 )
 


### PR DESCRIPTION
The number of indices, by construction, will be no more than `MAX_VALIDATORS_PER_COMMITTEE` because the SSZ type of `indexedAttestation.AttestingIndices` is a list with max size `MAX_VALIDATORS_PER_COMMITTEE`. This is a minor cleanup similar to #6559.