### PR TITLE
Rename mock POWChain field name

### DIFF
--- a/beacon-chain/powchain/testing/mock.go
+++ b/beacon-chain/powchain/testing/mock.go
@@ -22,13 +22,13 @@ import (
 
 // POWChain defines a properly functioning mock for the powchain service.
 type POWChain struct {
-	ChainFeed           *event.Feed
-	LatestBlockNumber   *big.Int
-	HashesByHeight      map[int][]byte
-	TimesByHeight       map[int]uint64
-	BlockNumberByHeight map[uint64]*big.Int
-	Eth1Data            *ethpb.Eth1Data
-	GenesisEth1Block    *big.Int
+	ChainFeed         *event.Feed
+	LatestBlockNumber *big.Int
+	HashesByHeight    map[int][]byte
+	TimesByHeight     map[int]uint64
+	BlockNumberByTime map[uint64]*big.Int
+	Eth1Data          *ethpb.Eth1Data
+	GenesisEth1Block  *big.Int
 }
 
 // Eth2GenesisPowchainInfo --
@@ -78,7 +78,7 @@ func (m *POWChain) BlockTimeByHeight(_ context.Context, height *big.Int) (uint64
 
 // BlockNumberByTimestamp --
 func (m *POWChain) BlockNumberByTimestamp(_ context.Context, time uint64) (*big.Int, error) {
-	return m.BlockNumberByHeight[time], nil
+	return m.BlockNumberByTime[time], nil
 }
 
 // DepositRoot --

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -1333,7 +1333,7 @@ func TestEth1Data(t *testing.T) {
 	slot := uint64(20000)
 
 	p := &mockPOW.POWChain{
-		BlockNumberByHeight: map[uint64]*big.Int{
+		BlockNumberByTime: map[uint64]*big.Int{
 			slot * params.BeaconConfig().SecondsPerSlot: big.NewInt(8196),
 		},
 		HashesByHeight: map[int][]byte{
@@ -1401,7 +1401,7 @@ func TestEth1Data_SmallerDepositCount(t *testing.T) {
 	}
 
 	p := &mockPOW.POWChain{
-		BlockNumberByHeight: map[uint64]*big.Int{
+		BlockNumberByTime: map[uint64]*big.Int{
 			slot * params.BeaconConfig().SecondsPerSlot: big.NewInt(4096),
 		},
 		HashesByHeight: map[int][]byte{


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR renames `POWChain.BlockNumberByHeight` to `POWChain.BlockNumberByTime` to align the field name with its usage.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
