### PR TITLE
QSP 32: Add Appropriate Stream Deadlines for RPC Requests

### DIFF
--- a/beacon-chain/sync/error.go
+++ b/beacon-chain/sync/error.go
@@ -3,7 +3,6 @@ package sync
 import (
 	"bytes"
 	"errors"
-	"time"
 
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
@@ -39,9 +38,7 @@ func (s *Service) generateErrorResponse(code byte, reason string) ([]byte, error
 // ReadStatusCode response from a RPC stream.
 func ReadStatusCode(stream network.Stream, encoding encoder.NetworkEncoding) (uint8, string, error) {
 	// Set ttfb deadline.
-	if err := stream.SetReadDeadline(time.Now().Add(params.BeaconNetworkConfig().TtfbTimeout)); err != nil {
-		return 0, "", err
-	}
+	SetStreamReadDeadline(stream, params.BeaconNetworkConfig().TtfbTimeout)
 	b := make([]byte, 1)
 	_, err := stream.Read(b)
 	if err != nil {
@@ -50,16 +47,13 @@ func ReadStatusCode(stream network.Stream, encoding encoder.NetworkEncoding) (ui
 
 	if b[0] == responseCodeSuccess {
 		// Set response deadline on a successful response code.
-		if err := stream.SetReadDeadline(time.Now().Add(params.BeaconNetworkConfig().RespTimeout)); err != nil {
-			return 0, "", err
-		}
+		SetStreamReadDeadline(stream, params.BeaconNetworkConfig().RespTimeout)
+
 		return 0, "", nil
 	}
 
 	// Set response deadline, when reading error message.
-	if err := stream.SetReadDeadline(time.Now().Add(params.BeaconNetworkConfig().RespTimeout)); err != nil {
-		return 0, "", err
-	}
+	SetStreamReadDeadline(stream, params.BeaconNetworkConfig().RespTimeout)
 	msg := &pb.ErrorResponse{
 		Message: []byte{},
 	}

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -330,7 +330,8 @@ func (f *blocksFetcher) requestBlocks(
 
 	resp := make([]*eth.SignedBeaconBlock, 0, req.Count)
 	for i := uint64(0); ; i++ {
-		blk, err := prysmsync.ReadChunkedBlock(stream, f.p2p)
+		isFirstChunk := i == 0
+		blk, err := prysmsync.ReadChunkedBlock(stream, f.p2p, isFirstChunk)
 		if err == io.EOF {
 			break
 		}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -31,7 +31,8 @@ func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 		}
 	}()
 	for i := 0; i < len(blockRoots); i++ {
-		blk, err := ReadChunkedBlock(stream, s.p2p)
+		isFirstChunk := i == 0
+		blk, err := ReadChunkedBlock(stream, s.p2p, isFirstChunk)
 		// Return error until #6408 is resolved.
 		if err == io.EOF {
 			return err
@@ -79,7 +80,8 @@ func (s *Service) sendRecentBeaconBlocksRequestFallback(ctx context.Context, blo
 		}
 	}()
 	for i := 0; i < len(blockRoots); i++ {
-		blk, err := ReadChunkedBlock(stream, s.p2p)
+		isFirstChunk := i == 0
+		blk, err := ReadChunkedBlock(stream, s.p2p, isFirstChunk)
 		if err == io.EOF {
 			break
 		}

--- a/beacon-chain/sync/rpc_chunked_response.go
+++ b/beacon-chain/sync/rpc_chunked_response.go
@@ -29,7 +29,11 @@ func WriteChunk(stream libp2pcore.Stream, encoding encoder.NetworkEncoding, msg 
 
 // ReadChunkedBlock handles each response chunk that is sent by the
 // peer and converts it into a beacon block.
-func ReadChunkedBlock(stream libp2pcore.Stream, p2p p2p.P2P) (*eth.SignedBeaconBlock, error) {
+func ReadChunkedBlock(stream libp2pcore.Stream, p2p p2p.P2P, isFirstChunk bool) (*eth.SignedBeaconBlock, error) {
+	// Handle deadlines differently for first chunk
+	if isFirstChunk {
+		return readFirstChunkedBlock(stream, p2p)
+	}
 	blk := &eth.SignedBeaconBlock{}
 	if err := readResponseChunk(stream, p2p, blk); err != nil {
 		return nil, err
@@ -37,11 +41,26 @@ func ReadChunkedBlock(stream libp2pcore.Stream, p2p p2p.P2P) (*eth.SignedBeaconB
 	return blk, nil
 }
 
+// readFirstChunkedBlock reads the first chunked block and applies the appropriate deadlines to
+// it.
+func readFirstChunkedBlock(stream libp2pcore.Stream, p2p p2p.P2P) (*eth.SignedBeaconBlock, error) {
+	blk := &eth.SignedBeaconBlock{}
+	code, errMsg, err := ReadStatusCode(stream, p2p.Encoding())
+	if err != nil {
+		return nil, err
+	}
+	if code != 0 {
+		return nil, errors.New(errMsg)
+	}
+	err = p2p.Encoding().DecodeWithMaxLength(stream, blk)
+	return blk, err
+}
+
 // readResponseChunk reads the response from the stream and decodes it into the
 // provided message type.
 func readResponseChunk(stream libp2pcore.Stream, p2p p2p.P2P, to interface{}) error {
 	SetStreamReadDeadline(stream, respTimeout)
-	code, errMsg, err := ReadStatusCode(stream, p2p.Encoding())
+	code, errMsg, err := readStatusCodeNoDeadline(stream, p2p.Encoding())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**

Audit Feedback

**What does this PR do? Why is it needed?**

- [x] Shifts out setting rpc deadlines from `Send` to `ReadStatusCode` , so that we can apply the appropriate `ttfb` and `response` deadlines for the relevant requests.
- [x] Handle the first response chunk differently for the first block, in order to apply ttfb deadline before reading from the stream.

**Which issues(s) does this PR fix?**

Part of #6327 

**Other notes for review**
