### PR TITLE
Handle roughtime response error

### DIFF
--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -54,7 +54,7 @@ func recalibrateRoughtime() {
 	for _, res := range results {
 		if res.Error() != nil {
 			log.Errorf("Could not get rough time result: %v", res.Error())
-			break
+			continue
 		}
 		log.WithFields(logrus.Fields{
 			"Server Name": res.Server.Name,

--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -54,7 +54,7 @@ func recalibrateRoughtime() {
 	for _, res := range results {
 		if res.Error() != nil {
 			log.Errorf("Could not get rough time result: %v", res.Error())
-			continue
+			break
 		}
 		log.WithFields(logrus.Fields{
 			"Server Name": res.Server.Name,

--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -52,12 +52,15 @@ func recalibrateRoughtime() {
 
 	// Log Debug Results.
 	for _, res := range results {
+		if res.Error() != nil {
+			log.Errorf("Could not get rough time result: %v", res.Error())
+			continue
+		}
 		log.WithFields(logrus.Fields{
-			"Server Name":   res.Server.Name,
-			"Midpoint":      res.Midpoint,
-			"Delay":         res.Delay,
-			"Radius":        res.Roughtime.Radius,
-			"Request Error": res.Error(),
+			"Server Name": res.Server.Name,
+			"Midpoint":    res.Midpoint,
+			"Delay":       res.Delay,
+			"Radius":      res.Roughtime.Radius,
 		}).Debug("Response received from roughtime server")
 	}
 	// Compute the average difference between the system's time and the


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
The log addition in #6575 will cause a panic if `res.Error() != nil`. This PR properly handles such scenario

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x48c89c5]

goroutine 1 [running]:
github.com/prysmaticlabs/prysm/shared/roughtime.recalibrateRoughtime()
        shared/roughtime/roughtime.go:57 +0x225
github.com/prysmaticlabs/prysm/shared/roughtime.init.0()
        shared/roughtime/roughtime.go:45 +0x22
```
