### PR TITLE
Update justified point for batch sync

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -98,6 +98,7 @@ go_test(
         "//shared/event:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
+        "//shared/testutil/assert:go_default_library",
         "@com_github_ethereum_go_ethereum//:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -166,6 +166,12 @@ func (s *Service) onBlockInitialSyncStateTransition(ctx context.Context, signed 
 		s.clearInitSyncBlocks()
 	}
 
+	if postState.CurrentJustifiedCheckpoint().Epoch > s.justifiedCheckpt.Epoch {
+		if err := s.updateJustifiedInitSync(ctx, postState.CurrentJustifiedCheckpoint()); err != nil {
+			return err
+		}
+	}
+
 	// Update finalized check point. Prune the block cache and helper caches on every new finalized epoch.
 	if postState.FinalizedCheckpointEpoch() > s.finalizedCheckpt.Epoch {
 		if err := s.updateFinalized(ctx, postState.FinalizedCheckpoint()); err != nil {

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -258,6 +258,12 @@ func (s *Service) handleBlockAfterBatchVerify(ctx context.Context, signed *ethpb
 		s.clearInitSyncBlocks()
 	}
 
+	if jCheckpoint.Epoch > s.justifiedCheckpt.Epoch {
+		if err := s.updateJustifiedInitSync(ctx, jCheckpoint); err != nil {
+			return err
+		}
+	}
+
 	// Update finalized check point. Prune the block cache and helper caches on every new finalized epoch.
 	if fCheckpoint.Epoch > s.finalizedCheckpt.Epoch {
 		if err := s.beaconDB.SaveBlocks(ctx, s.getInitSyncBlocks()); err != nil {

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -202,6 +202,9 @@ func (s *Service) updateJustified(ctx context.Context, state *stateTrie.BeaconSt
 	return s.beaconDB.SaveJustifiedCheckpoint(ctx, cpt)
 }
 
+// This caches input checkpoint as justified for the service struct. It rotates current justified to previous justified,
+// caches justified checkpoint balances for fork choice and save justified checkpoint in DB.
+// This method does not have defense against fork choice bouncing attack, which is why it's only recommend to be used during initial syncing.
 func (s *Service) updateJustifiedInitSync(ctx context.Context, cp *ethpb.Checkpoint) error {
 	s.prevJustifiedCheckpt = s.justifiedCheckpt
 	s.justifiedCheckpt = cp


### PR DESCRIPTION
This PR ensures cached justified check point in service struct is properly updated during initial sync.
An intermittent issue was caught during initial batch sync where justified check point didn't get cache and a node has to check ancestor block all the way back from genesis 