### PR TITLE
Fix inconsistent pubkey formatting in logs 

### DIFF
--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -186,7 +186,7 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 		}
 
 		fmtKey := fmt.Sprintf("%#x", pubKey)
-		truncatedKey := fmt.Sprintf("%#x", pubKey[:8])
+		truncatedKey := fmt.Sprintf("%#x", bytesutil.Trunc(pubKey))
 		if v.prevBalance[pubKeyBytes] > 0 {
 			newBalance := float64(resp.BalancesAfterEpochTransition[i]) / gweiPerEth
 			prevBalance := float64(resp.BalancesBeforeEpochTransition[i]) / gweiPerEth

--- a/validator/node/BUILD.bazel
+++ b/validator/node/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     visibility = ["//validator:__subpackages__"],
     deps = [
         "//shared:go_default_library",
+        "//shared/bytesutil:go_default_library",
         "//shared/cmd:go_default_library",
         "//shared/debug:go_default_library",
         "//shared/featureconfig:go_default_library",

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/debug"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
@@ -120,7 +121,7 @@ func NewValidatorClient(cliCtx *cli.Context) (*ValidatorClient, error) {
 	} else {
 		log.WithField("validators", len(pubKeys)).Debug("Found validator keys")
 		for _, key := range pubKeys {
-			log.WithField("pubKey", fmt.Sprintf("%#x", key)).Info("Validating for public key")
+			log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(key[:]))).Info("Validating for public key")
 		}
 	}
 


### PR DESCRIPTION
**What does this PR do? Why is it needed?**
Fix inconsistent pubkey formatting in logs. Use `bytesutil.Trunc` for the public keys. 

**Which issues(s) does this PR fix?**

Fixes #6595

