### PR TITLE
Fix duplicated selectV1Keymanager

### DIFF
--- a/validator/main.go
+++ b/validator/main.go
@@ -178,6 +178,7 @@ contract in order to activate the validator client`,
 						if cliCtx.String(flags.KeyManager.Name) != "" {
 							pubKeysBytes48, success := node.ExtractPublicKeysFromKeymanager(
 								cliCtx,
+								nil, /* nil v1 keymanager */
 								nil, /* nil v2 keymanager */
 							)
 							pubKeys, err = bytesutil.FromBytes48Array(pubKeysBytes48), success

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -112,7 +112,7 @@ func NewValidatorClient(cliCtx *cli.Context) (*ValidatorClient, error) {
 		}
 	}
 
-	pubKeys, err := ExtractPublicKeysFromKeymanager(cliCtx, keyManagerV2)
+	pubKeys, err := ExtractPublicKeysFromKeymanager(cliCtx, keyManagerV1, keyManagerV2)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func clearDB(dataDir string, pubkeys [][48]byte, force bool) error {
 }
 
 // ExtractPublicKeysFromKeymanager extracts only the public keys from the specified key manager.
-func ExtractPublicKeysFromKeymanager(cliCtx *cli.Context, keyManagerV2 v2.IKeymanager) ([][48]byte, error) {
+func ExtractPublicKeysFromKeymanager(cliCtx *cli.Context, keyManagerV1 v1.KeyManager, keyManagerV2 v2.IKeymanager) ([][48]byte, error) {
 	var pubKeys [][48]byte
 	var err error
 	if featureconfig.Get().EnableAccountsV2 {
@@ -383,9 +383,5 @@ func ExtractPublicKeysFromKeymanager(cliCtx *cli.Context, keyManagerV2 v2.IKeyma
 		}
 		return pubKeys, nil
 	}
-	km, err := selectV1Keymanager(cliCtx)
-	if err != nil {
-		return nil, err
-	}
-	return km.FetchValidatingKeys()
+	return keyManagerV1.FetchValidatingKeys()
 }


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix (cosmetic)


**What does this PR do? Why is it needed?**
This fixes a cosmetic bug introduced in #6489. `selectV1Keymanager` was getting called twice. This removes the extra instance inside `ExtractPublicKeysFromKeymanager` 

**Which issues(s) does this PR fix?**

Fixes #6601 

**Other notes for review**
