### PR TITLE
Resolves possible import cycle in testutils assertions

### DIFF
--- a/shared/testutil/BUILD.bazel
+++ b/shared/testutil/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     name = "go_default_library",
     testonly = True,
     srcs = [
-        "assertions.go",
         "block.go",
         "deposits.go",
         "helpers.go",

--- a/shared/testutil/assert/BUILD.bazel
+++ b/shared/testutil/assert/BUILD.bazel
@@ -7,12 +7,12 @@ go_library(
     srcs = ["assertions.go"],
     importpath = "github.com/prysmaticlabs/prysm/shared/testutil/assert",
     visibility = ["//visibility:public"],
-    deps = ["//shared/testutil:go_default_library"],
+    deps = ["//shared/testutil/assertions:go_default_library"],
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["assertions_test.go"],
     embed = [":go_default_library"],
-    deps = ["//shared/testutil:go_default_library"],
+    deps = ["//shared/testutil/assertions:go_default_library"],
 )

--- a/shared/testutil/assert/assertions.go
+++ b/shared/testutil/assert/assertions.go
@@ -1,30 +1,30 @@
 package assert
 
 import (
-	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assertions"
 )
 
 // Equal compares values using comparison operator.
-func Equal(tb testutil.AssertionTestingTB, expected, actual interface{}, msg ...string) {
-	testutil.Equal(tb.Errorf, expected, actual, msg...)
+func Equal(tb assertions.AssertionTestingTB, expected, actual interface{}, msg ...string) {
+	assertions.Equal(tb.Errorf, expected, actual, msg...)
 }
 
 // DeepEqual compares values using DeepEqual.
-func DeepEqual(tb testutil.AssertionTestingTB, expected, actual interface{}, msg ...string) {
-	testutil.DeepEqual(tb.Errorf, expected, actual, msg...)
+func DeepEqual(tb assertions.AssertionTestingTB, expected, actual interface{}, msg ...string) {
+	assertions.DeepEqual(tb.Errorf, expected, actual, msg...)
 }
 
 // NoError asserts that error is nil.
-func NoError(tb testutil.AssertionTestingTB, err error, msg ...string) {
-	testutil.NoError(tb.Errorf, err, msg...)
+func NoError(tb assertions.AssertionTestingTB, err error, msg ...string) {
+	assertions.NoError(tb.Errorf, err, msg...)
 }
 
 // ErrorContains asserts that actual error contains wanted message.
-func ErrorContains(tb testutil.AssertionTestingTB, want string, err error, msg ...string) {
-	testutil.ErrorContains(tb.Errorf, want, err, msg...)
+func ErrorContains(tb assertions.AssertionTestingTB, want string, err error, msg ...string) {
+	assertions.ErrorContains(tb.Errorf, want, err, msg...)
 }
 
 // NotNil asserts that passed value is not nil.
-func NotNil(tb testutil.AssertionTestingTB, obj interface{}, msg ...string) {
-	testutil.NotNil(tb.Errorf, obj, msg...)
+func NotNil(tb assertions.AssertionTestingTB, obj interface{}, msg ...string) {
+	assertions.NotNil(tb.Errorf, obj, msg...)
 }

--- a/shared/testutil/assert/assertions_test.go
+++ b/shared/testutil/assert/assertions_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAssert_Equal(t *testing.T) {
 	type args struct {
-		tb       *assertions.AssertionsTBMock
+		tb       *assertions.TBMock
 		expected interface{}
 		actual   interface{}
 		msg      []string
@@ -23,7 +23,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "equal values",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: 42,
 				actual:   42,
 			},
@@ -31,7 +31,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "non-equal values",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: 42,
 				actual:   41,
 			},
@@ -40,7 +40,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "custom error message",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: 42,
 				actual:   41,
 				msg:      []string{"Custom values are not equal"},
@@ -60,7 +60,7 @@ func TestAssert_Equal(t *testing.T) {
 
 func TestAssert_DeepEqual(t *testing.T) {
 	type args struct {
-		tb       *assertions.AssertionsTBMock
+		tb       *assertions.TBMock
 		expected interface{}
 		actual   interface{}
 		msg      []string
@@ -73,7 +73,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "equal values",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{42},
 			},
@@ -81,7 +81,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "non-equal values",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 			},
@@ -90,7 +90,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "custom error message",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 				msg:      []string{"Custom values are not equal"},
@@ -110,7 +110,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 
 func TestAssert_NoError(t *testing.T) {
 	type args struct {
-		tb  *assertions.AssertionsTBMock
+		tb  *assertions.TBMock
 		err error
 		msg []string
 	}
@@ -122,13 +122,13 @@ func TestAssert_NoError(t *testing.T) {
 		{
 			name: "nil error",
 			args: args{
-				tb: &assertions.AssertionsTBMock{},
+				tb: &assertions.TBMock{},
 			},
 		},
 		{
 			name: "non-nil error",
 			args: args{
-				tb:  &assertions.AssertionsTBMock{},
+				tb:  &assertions.TBMock{},
 				err: errors.New("failed"),
 			},
 			expectedErr: "Unexpected error: failed",
@@ -136,7 +136,7 @@ func TestAssert_NoError(t *testing.T) {
 		{
 			name: "non-nil error",
 			args: args{
-				tb:  &assertions.AssertionsTBMock{},
+				tb:  &assertions.TBMock{},
 				err: errors.New("failed"),
 				msg: []string{"Custom error message"},
 			},
@@ -155,7 +155,7 @@ func TestAssert_NoError(t *testing.T) {
 
 func TestAssert_ErrorContains(t *testing.T) {
 	type args struct {
-		tb   *assertions.AssertionsTBMock
+		tb   *assertions.TBMock
 		want string
 		err  error
 		msg  []string
@@ -168,7 +168,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "nil error",
 			args: args{
-				tb:   &assertions.AssertionsTBMock{},
+				tb:   &assertions.TBMock{},
 				want: "some error",
 			},
 			expectedErr: "Expected error not returned, got: <nil>, want: some error",
@@ -176,7 +176,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "unexpected error",
 			args: args{
-				tb:   &assertions.AssertionsTBMock{},
+				tb:   &assertions.TBMock{},
 				want: "another error",
 				err:  errors.New("failed"),
 			},
@@ -185,7 +185,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "expected error",
 			args: args{
-				tb:   &assertions.AssertionsTBMock{},
+				tb:   &assertions.TBMock{},
 				want: "failed",
 				err:  errors.New("failed"),
 			},
@@ -194,7 +194,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "custom unexpected error",
 			args: args{
-				tb:   &assertions.AssertionsTBMock{},
+				tb:   &assertions.TBMock{},
 				want: "another error",
 				err:  errors.New("failed"),
 				msg:  []string{"Something wrong"},
@@ -204,7 +204,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "expected error",
 			args: args{
-				tb:   &assertions.AssertionsTBMock{},
+				tb:   &assertions.TBMock{},
 				want: "failed",
 				err:  errors.New("failed"),
 				msg:  []string{"Something wrong"},
@@ -224,7 +224,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 
 func TestAssert_NotNil(t *testing.T) {
 	type args struct {
-		tb  *assertions.AssertionsTBMock
+		tb  *assertions.TBMock
 		obj interface{}
 		msg []string
 	}
@@ -236,14 +236,14 @@ func TestAssert_NotNil(t *testing.T) {
 		{
 			name: "nil",
 			args: args{
-				tb: &assertions.AssertionsTBMock{},
+				tb: &assertions.TBMock{},
 			},
 			expectedErr: "Unexpected nil value",
 		},
 		{
 			name: "nil custom message",
 			args: args{
-				tb:  &assertions.AssertionsTBMock{},
+				tb:  &assertions.TBMock{},
 				msg: []string{"This should not be nil"},
 			},
 			expectedErr: "This should not be nil",
@@ -251,7 +251,7 @@ func TestAssert_NotNil(t *testing.T) {
 		{
 			name: "not nil",
 			args: args{
-				tb:  &assertions.AssertionsTBMock{},
+				tb:  &assertions.TBMock{},
 				obj: "some value",
 			},
 			expectedErr: "",

--- a/shared/testutil/assert/assertions_test.go
+++ b/shared/testutil/assert/assertions_test.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assertions"
 )
 
 func TestAssert_Equal(t *testing.T) {
 	type args struct {
-		tb       *testutil.AssertionsTBMock
+		tb       *assertions.AssertionsTBMock
 		expected interface{}
 		actual   interface{}
 		msg      []string
@@ -23,7 +23,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "equal values",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: 42,
 				actual:   42,
 			},
@@ -31,7 +31,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "non-equal values",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: 42,
 				actual:   41,
 			},
@@ -40,7 +40,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "custom error message",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: 42,
 				actual:   41,
 				msg:      []string{"Custom values are not equal"},
@@ -60,7 +60,7 @@ func TestAssert_Equal(t *testing.T) {
 
 func TestAssert_DeepEqual(t *testing.T) {
 	type args struct {
-		tb       *testutil.AssertionsTBMock
+		tb       *assertions.AssertionsTBMock
 		expected interface{}
 		actual   interface{}
 		msg      []string
@@ -73,7 +73,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "equal values",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{42},
 			},
@@ -81,7 +81,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "non-equal values",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 			},
@@ -90,7 +90,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "custom error message",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 				msg:      []string{"Custom values are not equal"},
@@ -110,7 +110,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 
 func TestAssert_NoError(t *testing.T) {
 	type args struct {
-		tb  *testutil.AssertionsTBMock
+		tb  *assertions.AssertionsTBMock
 		err error
 		msg []string
 	}
@@ -122,13 +122,13 @@ func TestAssert_NoError(t *testing.T) {
 		{
 			name: "nil error",
 			args: args{
-				tb: &testutil.AssertionsTBMock{},
+				tb: &assertions.AssertionsTBMock{},
 			},
 		},
 		{
 			name: "non-nil error",
 			args: args{
-				tb:  &testutil.AssertionsTBMock{},
+				tb:  &assertions.AssertionsTBMock{},
 				err: errors.New("failed"),
 			},
 			expectedErr: "Unexpected error: failed",
@@ -136,7 +136,7 @@ func TestAssert_NoError(t *testing.T) {
 		{
 			name: "non-nil error",
 			args: args{
-				tb:  &testutil.AssertionsTBMock{},
+				tb:  &assertions.AssertionsTBMock{},
 				err: errors.New("failed"),
 				msg: []string{"Custom error message"},
 			},
@@ -155,7 +155,7 @@ func TestAssert_NoError(t *testing.T) {
 
 func TestAssert_ErrorContains(t *testing.T) {
 	type args struct {
-		tb   *testutil.AssertionsTBMock
+		tb   *assertions.AssertionsTBMock
 		want string
 		err  error
 		msg  []string
@@ -168,7 +168,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "nil error",
 			args: args{
-				tb:   &testutil.AssertionsTBMock{},
+				tb:   &assertions.AssertionsTBMock{},
 				want: "some error",
 			},
 			expectedErr: "Expected error not returned, got: <nil>, want: some error",
@@ -176,7 +176,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "unexpected error",
 			args: args{
-				tb:   &testutil.AssertionsTBMock{},
+				tb:   &assertions.AssertionsTBMock{},
 				want: "another error",
 				err:  errors.New("failed"),
 			},
@@ -185,7 +185,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "expected error",
 			args: args{
-				tb:   &testutil.AssertionsTBMock{},
+				tb:   &assertions.AssertionsTBMock{},
 				want: "failed",
 				err:  errors.New("failed"),
 			},
@@ -194,7 +194,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "custom unexpected error",
 			args: args{
-				tb:   &testutil.AssertionsTBMock{},
+				tb:   &assertions.AssertionsTBMock{},
 				want: "another error",
 				err:  errors.New("failed"),
 				msg:  []string{"Something wrong"},
@@ -204,7 +204,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "expected error",
 			args: args{
-				tb:   &testutil.AssertionsTBMock{},
+				tb:   &assertions.AssertionsTBMock{},
 				want: "failed",
 				err:  errors.New("failed"),
 				msg:  []string{"Something wrong"},
@@ -224,7 +224,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 
 func TestAssert_NotNil(t *testing.T) {
 	type args struct {
-		tb  *testutil.AssertionsTBMock
+		tb  *assertions.AssertionsTBMock
 		obj interface{}
 		msg []string
 	}
@@ -236,14 +236,14 @@ func TestAssert_NotNil(t *testing.T) {
 		{
 			name: "nil",
 			args: args{
-				tb: &testutil.AssertionsTBMock{},
+				tb: &assertions.AssertionsTBMock{},
 			},
 			expectedErr: "Unexpected nil value",
 		},
 		{
 			name: "nil custom message",
 			args: args{
-				tb:  &testutil.AssertionsTBMock{},
+				tb:  &assertions.AssertionsTBMock{},
 				msg: []string{"This should not be nil"},
 			},
 			expectedErr: "This should not be nil",
@@ -251,7 +251,7 @@ func TestAssert_NotNil(t *testing.T) {
 		{
 			name: "not nil",
 			args: args{
-				tb:  &testutil.AssertionsTBMock{},
+				tb:  &assertions.AssertionsTBMock{},
 				obj: "some value",
 			},
 			expectedErr: "",

--- a/shared/testutil/assertions/BUILD.bazel
+++ b/shared/testutil/assertions/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["assertions.go"],
+    importpath = "github.com/prysmaticlabs/prysm/shared/testutil/assertions",
+    visibility = ["//visibility:public"],
+)

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -69,7 +69,7 @@ func parseMsg(defaultMsg string, msg ...string) string {
 	return msgString
 }
 
-// AssertionsTBMock exposes enough testing.TB methods for assertions.
+// TBMock exposes enough testing.TB methods for assertions.
 type TBMock struct {
 	ErrorfMsg string
 	FatalfMsg string

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -1,4 +1,4 @@
-package testutil
+package assertions
 
 import (
 	"fmt"

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -70,17 +70,17 @@ func parseMsg(defaultMsg string, msg ...string) string {
 }
 
 // AssertionsTBMock exposes enough testing.TB methods for assertions.
-type AssertionsTBMock struct {
+type TBMock struct {
 	ErrorfMsg string
 	FatalfMsg string
 }
 
 // Errorf writes testing logs to ErrorfMsg.
-func (tb *AssertionsTBMock) Errorf(format string, args ...interface{}) {
+func (tb *TBMock) Errorf(format string, args ...interface{}) {
 	tb.ErrorfMsg = fmt.Sprintf(format, args...)
 }
 
 // Fatalf writes testing logs to FatalfMsg.
-func (tb *AssertionsTBMock) Fatalf(format string, args ...interface{}) {
+func (tb *TBMock) Fatalf(format string, args ...interface{}) {
 	tb.FatalfMsg = fmt.Sprintf(format, args...)
 }

--- a/shared/testutil/require/BUILD.bazel
+++ b/shared/testutil/require/BUILD.bazel
@@ -7,12 +7,12 @@ go_library(
     srcs = ["requires.go"],
     importpath = "github.com/prysmaticlabs/prysm/shared/testutil/require",
     visibility = ["//visibility:public"],
-    deps = ["//shared/testutil:go_default_library"],
+    deps = ["//shared/testutil/assertions:go_default_library"],
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["requires_test.go"],
     embed = [":go_default_library"],
-    deps = ["//shared/testutil:go_default_library"],
+    deps = ["//shared/testutil/assertions:go_default_library"],
 )

--- a/shared/testutil/require/requires.go
+++ b/shared/testutil/require/requires.go
@@ -1,30 +1,30 @@
 package require
 
 import (
-	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assertions"
 )
 
 // Equal compares values using comparison operator.
-func Equal(tb testutil.AssertionTestingTB, expected, actual interface{}, msg ...string) {
-	testutil.Equal(tb.Fatalf, expected, actual, msg...)
+func Equal(tb assertions.AssertionTestingTB, expected, actual interface{}, msg ...string) {
+	assertions.Equal(tb.Fatalf, expected, actual, msg...)
 }
 
 // DeepEqual compares values using DeepEqual.
-func DeepEqual(tb testutil.AssertionTestingTB, expected, actual interface{}, msg ...string) {
-	testutil.DeepEqual(tb.Fatalf, expected, actual, msg...)
+func DeepEqual(tb assertions.AssertionTestingTB, expected, actual interface{}, msg ...string) {
+	assertions.DeepEqual(tb.Fatalf, expected, actual, msg...)
 }
 
 // NoError asserts that error is nil.
-func NoError(tb testutil.AssertionTestingTB, err error, msg ...string) {
-	testutil.NoError(tb.Fatalf, err, msg...)
+func NoError(tb assertions.AssertionTestingTB, err error, msg ...string) {
+	assertions.NoError(tb.Fatalf, err, msg...)
 }
 
 // ErrorContains asserts that actual error contains wanted message.
-func ErrorContains(tb testutil.AssertionTestingTB, want string, err error, msg ...string) {
-	testutil.ErrorContains(tb.Fatalf, want, err, msg...)
+func ErrorContains(tb assertions.AssertionTestingTB, want string, err error, msg ...string) {
+	assertions.ErrorContains(tb.Fatalf, want, err, msg...)
 }
 
 // NotNil asserts that passed value is not nil.
-func NotNil(tb testutil.AssertionTestingTB, obj interface{}, msg ...string) {
-	testutil.NotNil(tb.Fatalf, obj, msg...)
+func NotNil(tb assertions.AssertionTestingTB, obj interface{}, msg ...string) {
+	assertions.NotNil(tb.Fatalf, obj, msg...)
 }

--- a/shared/testutil/require/requires_test.go
+++ b/shared/testutil/require/requires_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAssert_Equal(t *testing.T) {
 	type args struct {
-		tb       *assertions.AssertionsTBMock
+		tb       *assertions.TBMock
 		expected interface{}
 		actual   interface{}
 		msg      []string
@@ -23,7 +23,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "equal values",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: 42,
 				actual:   42,
 			},
@@ -31,7 +31,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "non-equal values",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: 42,
 				actual:   41,
 			},
@@ -40,7 +40,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "custom error message",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: 42,
 				actual:   41,
 				msg:      []string{"Custom values are not equal"},
@@ -60,7 +60,7 @@ func TestAssert_Equal(t *testing.T) {
 
 func TestAssert_DeepEqual(t *testing.T) {
 	type args struct {
-		tb       *assertions.AssertionsTBMock
+		tb       *assertions.TBMock
 		expected interface{}
 		actual   interface{}
 		msg      []string
@@ -73,7 +73,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "equal values",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{42},
 			},
@@ -81,7 +81,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "non-equal values",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 			},
@@ -90,7 +90,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "custom error message",
 			args: args{
-				tb:       &assertions.AssertionsTBMock{},
+				tb:       &assertions.TBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 				msg:      []string{"Custom values are not equal"},
@@ -110,7 +110,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 
 func TestAssert_NoError(t *testing.T) {
 	type args struct {
-		tb  *assertions.AssertionsTBMock
+		tb  *assertions.TBMock
 		err error
 		msg []string
 	}
@@ -122,13 +122,13 @@ func TestAssert_NoError(t *testing.T) {
 		{
 			name: "nil error",
 			args: args{
-				tb: &assertions.AssertionsTBMock{},
+				tb: &assertions.TBMock{},
 			},
 		},
 		{
 			name: "non-nil error",
 			args: args{
-				tb:  &assertions.AssertionsTBMock{},
+				tb:  &assertions.TBMock{},
 				err: errors.New("failed"),
 			},
 			expectedErr: "Unexpected error: failed",
@@ -136,7 +136,7 @@ func TestAssert_NoError(t *testing.T) {
 		{
 			name: "non-nil error",
 			args: args{
-				tb:  &assertions.AssertionsTBMock{},
+				tb:  &assertions.TBMock{},
 				err: errors.New("failed"),
 				msg: []string{"Custom error message"},
 			},
@@ -155,7 +155,7 @@ func TestAssert_NoError(t *testing.T) {
 
 func TestAssert_ErrorContains(t *testing.T) {
 	type args struct {
-		tb   *assertions.AssertionsTBMock
+		tb   *assertions.TBMock
 		want string
 		err  error
 		msg  []string
@@ -168,7 +168,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "nil error",
 			args: args{
-				tb:   &assertions.AssertionsTBMock{},
+				tb:   &assertions.TBMock{},
 				want: "some error",
 			},
 			expectedErr: "Expected error not returned, got: <nil>, want: some error",
@@ -176,7 +176,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "unexpected error",
 			args: args{
-				tb:   &assertions.AssertionsTBMock{},
+				tb:   &assertions.TBMock{},
 				want: "another error",
 				err:  errors.New("failed"),
 			},
@@ -185,7 +185,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "expected error",
 			args: args{
-				tb:   &assertions.AssertionsTBMock{},
+				tb:   &assertions.TBMock{},
 				want: "failed",
 				err:  errors.New("failed"),
 			},
@@ -194,7 +194,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "custom unexpected error",
 			args: args{
-				tb:   &assertions.AssertionsTBMock{},
+				tb:   &assertions.TBMock{},
 				want: "another error",
 				err:  errors.New("failed"),
 				msg:  []string{"Something wrong"},
@@ -204,7 +204,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "expected error",
 			args: args{
-				tb:   &assertions.AssertionsTBMock{},
+				tb:   &assertions.TBMock{},
 				want: "failed",
 				err:  errors.New("failed"),
 				msg:  []string{"Something wrong"},
@@ -224,7 +224,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 
 func TestAssert_NotNil(t *testing.T) {
 	type args struct {
-		tb  *assertions.AssertionsTBMock
+		tb  *assertions.TBMock
 		obj interface{}
 		msg []string
 	}
@@ -236,14 +236,14 @@ func TestAssert_NotNil(t *testing.T) {
 		{
 			name: "nil",
 			args: args{
-				tb: &assertions.AssertionsTBMock{},
+				tb: &assertions.TBMock{},
 			},
 			expectedErr: "Unexpected nil value",
 		},
 		{
 			name: "nil custom message",
 			args: args{
-				tb:  &assertions.AssertionsTBMock{},
+				tb:  &assertions.TBMock{},
 				msg: []string{"This should not be nil"},
 			},
 			expectedErr: "This should not be nil",
@@ -251,7 +251,7 @@ func TestAssert_NotNil(t *testing.T) {
 		{
 			name: "not nil",
 			args: args{
-				tb:  &assertions.AssertionsTBMock{},
+				tb:  &assertions.TBMock{},
 				obj: "some value",
 			},
 			expectedErr: "",

--- a/shared/testutil/require/requires_test.go
+++ b/shared/testutil/require/requires_test.go
@@ -5,12 +5,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assertions"
 )
 
 func TestAssert_Equal(t *testing.T) {
 	type args struct {
-		tb       *testutil.AssertionsTBMock
+		tb       *assertions.AssertionsTBMock
 		expected interface{}
 		actual   interface{}
 		msg      []string
@@ -23,7 +23,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "equal values",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: 42,
 				actual:   42,
 			},
@@ -31,7 +31,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "non-equal values",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: 42,
 				actual:   41,
 			},
@@ -40,7 +40,7 @@ func TestAssert_Equal(t *testing.T) {
 		{
 			name: "custom error message",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: 42,
 				actual:   41,
 				msg:      []string{"Custom values are not equal"},
@@ -60,7 +60,7 @@ func TestAssert_Equal(t *testing.T) {
 
 func TestAssert_DeepEqual(t *testing.T) {
 	type args struct {
-		tb       *testutil.AssertionsTBMock
+		tb       *assertions.AssertionsTBMock
 		expected interface{}
 		actual   interface{}
 		msg      []string
@@ -73,7 +73,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "equal values",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{42},
 			},
@@ -81,7 +81,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "non-equal values",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 			},
@@ -90,7 +90,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 		{
 			name: "custom error message",
 			args: args{
-				tb:       &testutil.AssertionsTBMock{},
+				tb:       &assertions.AssertionsTBMock{},
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 				msg:      []string{"Custom values are not equal"},
@@ -110,7 +110,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 
 func TestAssert_NoError(t *testing.T) {
 	type args struct {
-		tb  *testutil.AssertionsTBMock
+		tb  *assertions.AssertionsTBMock
 		err error
 		msg []string
 	}
@@ -122,13 +122,13 @@ func TestAssert_NoError(t *testing.T) {
 		{
 			name: "nil error",
 			args: args{
-				tb: &testutil.AssertionsTBMock{},
+				tb: &assertions.AssertionsTBMock{},
 			},
 		},
 		{
 			name: "non-nil error",
 			args: args{
-				tb:  &testutil.AssertionsTBMock{},
+				tb:  &assertions.AssertionsTBMock{},
 				err: errors.New("failed"),
 			},
 			expectedErr: "Unexpected error: failed",
@@ -136,7 +136,7 @@ func TestAssert_NoError(t *testing.T) {
 		{
 			name: "non-nil error",
 			args: args{
-				tb:  &testutil.AssertionsTBMock{},
+				tb:  &assertions.AssertionsTBMock{},
 				err: errors.New("failed"),
 				msg: []string{"Custom error message"},
 			},
@@ -155,7 +155,7 @@ func TestAssert_NoError(t *testing.T) {
 
 func TestAssert_ErrorContains(t *testing.T) {
 	type args struct {
-		tb   *testutil.AssertionsTBMock
+		tb   *assertions.AssertionsTBMock
 		want string
 		err  error
 		msg  []string
@@ -168,7 +168,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "nil error",
 			args: args{
-				tb:   &testutil.AssertionsTBMock{},
+				tb:   &assertions.AssertionsTBMock{},
 				want: "some error",
 			},
 			expectedErr: "Expected error not returned, got: <nil>, want: some error",
@@ -176,7 +176,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "unexpected error",
 			args: args{
-				tb:   &testutil.AssertionsTBMock{},
+				tb:   &assertions.AssertionsTBMock{},
 				want: "another error",
 				err:  errors.New("failed"),
 			},
@@ -185,7 +185,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "expected error",
 			args: args{
-				tb:   &testutil.AssertionsTBMock{},
+				tb:   &assertions.AssertionsTBMock{},
 				want: "failed",
 				err:  errors.New("failed"),
 			},
@@ -194,7 +194,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "custom unexpected error",
 			args: args{
-				tb:   &testutil.AssertionsTBMock{},
+				tb:   &assertions.AssertionsTBMock{},
 				want: "another error",
 				err:  errors.New("failed"),
 				msg:  []string{"Something wrong"},
@@ -204,7 +204,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 		{
 			name: "expected error",
 			args: args{
-				tb:   &testutil.AssertionsTBMock{},
+				tb:   &assertions.AssertionsTBMock{},
 				want: "failed",
 				err:  errors.New("failed"),
 				msg:  []string{"Something wrong"},
@@ -224,7 +224,7 @@ func TestAssert_ErrorContains(t *testing.T) {
 
 func TestAssert_NotNil(t *testing.T) {
 	type args struct {
-		tb  *testutil.AssertionsTBMock
+		tb  *assertions.AssertionsTBMock
 		obj interface{}
 		msg []string
 	}
@@ -236,14 +236,14 @@ func TestAssert_NotNil(t *testing.T) {
 		{
 			name: "nil",
 			args: args{
-				tb: &testutil.AssertionsTBMock{},
+				tb: &assertions.AssertionsTBMock{},
 			},
 			expectedErr: "Unexpected nil value",
 		},
 		{
 			name: "nil custom message",
 			args: args{
-				tb:  &testutil.AssertionsTBMock{},
+				tb:  &assertions.AssertionsTBMock{},
 				msg: []string{"This should not be nil"},
 			},
 			expectedErr: "This should not be nil",
@@ -251,7 +251,7 @@ func TestAssert_NotNil(t *testing.T) {
 		{
 			name: "not nil",
 			args: args{
-				tb:  &testutil.AssertionsTBMock{},
+				tb:  &assertions.AssertionsTBMock{},
 				obj: "some value",
 			},
 			expectedErr: "",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- Assertions shouldn't depend on any of our other packages, otherwise there's a possibility for import cycle (assertions are imported into test that imports such a dependency, which in turn may import sth from the package being tested). This PR fixes this by decoupling assertions base file.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
