### PR TITLE
Accounts V2: Create Wallet Non-Interactively + Add Test Coverage

### DIFF
--- a/validator/accounts/v2/BUILD.bazel
+++ b/validator/accounts/v2/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     srcs = [
         "list_test.go",
         "new_test.go",
+        "wallet_create_test.go",
         "wallet_edit_test.go",
         "wallet_test.go",
     ],

--- a/validator/accounts/v2/BUILD.bazel
+++ b/validator/accounts/v2/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//shared/bytesutil:go_default_library",
         "//shared/testutil:go_default_library",
         "//shared/testutil/assert:go_default_library",
+        "//shared/testutil/require:go_default_library",
         "//validator/flags:go_default_library",
         "//validator/keymanager/v2:go_default_library",
         "//validator/keymanager/v2/direct:go_default_library",

--- a/validator/accounts/v2/cmd_wallet.go
+++ b/validator/accounts/v2/cmd_wallet.go
@@ -15,6 +15,15 @@ var WalletCommands = &cli.Command{
 			Name: "create",
 			Usage: "creates a new wallet with a desired type of keymanager: " +
 				"either on-disk (direct), derived, or using remote credentials",
+			Flags: []cli.Flag{
+				flags.WalletDirFlag,
+				flags.WalletPasswordsDirFlag,
+				flags.KeymanagerKindFlag,
+				flags.GrpcRemoteAddressFlag,
+				flags.RemoteSignerCertPathFlag,
+				flags.RemoteSignerKeyPathFlag,
+				flags.RemoteSignerCACertPathFlag,
+			},
 			Action: CreateWallet,
 		},
 		{

--- a/validator/accounts/v2/new.go
+++ b/validator/accounts/v2/new.go
@@ -111,7 +111,10 @@ func inputWalletDir(cliCtx *cli.Context) (string, error) {
 	return walletPath, nil
 }
 
-func inputKeymanagerKind(_ *cli.Context) (v2keymanager.Kind, error) {
+func inputKeymanagerKind(cliCtx *cli.Context) (v2keymanager.Kind, error) {
+	if cliCtx.IsSet(flags.KeymanagerKindFlag.Name) {
+		return v2keymanager.ParseKind(cliCtx.String(flags.KeymanagerKindFlag.Name))
+	}
 	promptSelect := promptui.Select{
 		Label: "Select a type of wallet",
 		Items: []string{

--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -20,8 +20,8 @@ import (
 func CreateWallet(cliCtx *cli.Context) error {
 	// Read a wallet's directory from user input.
 	walletDir, err := inputWalletDir(cliCtx)
-	if !errors.Is(err, ErrNoWalletFound) {
-		return errors.Wrap(err, "could not parse wallet directory")
+	if err != nil && !errors.Is(err, ErrNoWalletFound) {
+		log.Fatalf("Could not parse wallet directory: %v", err)
 	}
 	// Check if the user has a wallet at the specified path.
 	// If a user does not have a wallet, we instantiate one
@@ -46,7 +46,7 @@ func CreateWallet(cliCtx *cli.Context) error {
 		if err = initializeDirectWallet(cliCtx, walletDir); err != nil {
 			log.Fatalf("Could not initialize wallet with direct keymanager: %v", err)
 		}
-		log.Infof(
+		log.WithField("wallet-path", walletDir).Infof(
 			"Successfully created wallet with on-disk keymanager configuration. " +
 				"Make a new validator account with ./prysm.sh validator accounts-2 new",
 		)
@@ -56,7 +56,7 @@ func CreateWallet(cliCtx *cli.Context) error {
 		if err = initializeRemoteSignerWallet(cliCtx, walletDir); err != nil {
 			log.Fatalf("Could not initialize wallet with remote keymanager: %v", err)
 		}
-		log.Infof(
+		log.WithField("wallet-path", walletDir).Infof(
 			"Successfully created wallet with remote keymanager configuration",
 		)
 	default:

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 	"github.com/prysmaticlabs/prysm/validator/flags"
 	v2keymanager "github.com/prysmaticlabs/prysm/validator/keymanager/v2"
 	"github.com/prysmaticlabs/prysm/validator/keymanager/v2/direct"
@@ -35,9 +36,7 @@ func TestCreateWallet_Direct(t *testing.T) {
 	cliCtx := cli.NewContext(&app, set, nil)
 
 	// We attempt to create the wallet.
-	if err := CreateWallet(cliCtx); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, CreateWallet(cliCtx))
 
 	// We attempt to open the newly created wallet.
 	ctx := context.Background()
@@ -89,9 +88,7 @@ func TestCreateWallet_Remote(t *testing.T) {
 	cliCtx := cli.NewContext(&app, set, nil)
 
 	// We attempt to create the wallet.
-	if err := CreateWallet(cliCtx); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, CreateWallet(cliCtx))
 
 	// We attempt to open the newly created wallet.
 	ctx := context.Background()

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -1,0 +1,113 @@
+package v2
+
+import (
+	"context"
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/validator/flags"
+	v2keymanager "github.com/prysmaticlabs/prysm/validator/keymanager/v2"
+	"github.com/prysmaticlabs/prysm/validator/keymanager/v2/direct"
+	"github.com/prysmaticlabs/prysm/validator/keymanager/v2/remote"
+	"github.com/urfave/cli/v2"
+)
+
+func TestCreateWallet_Direct(t *testing.T) {
+	walletDir := testutil.TempDir() + "/wallet"
+	passwordsDir := testutil.TempDir() + "/walletpasswords"
+	defer func() {
+		assert.NoError(t, os.RemoveAll(walletDir))
+		assert.NoError(t, os.RemoveAll(passwordsDir))
+	}()
+	wantCfg := direct.DefaultConfig()
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	keymanagerKind := "direct"
+	set.String(flags.WalletDirFlag.Name, walletDir, "")
+	set.String(flags.KeymanagerKindFlag.Name, keymanagerKind, "")
+	set.String(flags.WalletPasswordsDirFlag.Name, keymanagerKind, "")
+	assert.NoError(t, set.Set(flags.WalletDirFlag.Name, walletDir))
+	assert.NoError(t, set.Set(flags.WalletPasswordsDirFlag.Name, passwordsDir))
+	assert.NoError(t, set.Set(flags.KeymanagerKindFlag.Name, keymanagerKind))
+	cliCtx := cli.NewContext(&app, set, nil)
+
+	// We attempt to create the wallet.
+	if err := CreateWallet(cliCtx); err != nil {
+		t.Fatal(err)
+	}
+
+	// We attempt to open the newly created wallet.
+	ctx := context.Background()
+	wallet, err := OpenWallet(ctx, &WalletConfig{
+		WalletDir:         walletDir,
+		KeymanagerKind:    v2keymanager.Direct,
+		CanUnlockAccounts: false,
+	})
+	assert.NoError(t, err)
+
+	// We read the keymanager config for the newly created wallet.
+	encoded, err := wallet.ReadKeymanagerConfigFromDisk(ctx)
+	assert.NoError(t, err)
+	cfg, err := direct.UnmarshalConfigFile(encoded)
+	assert.NoError(t, err)
+
+	// We assert the created configuration was as desired.
+	assert.DeepEqual(t, wantCfg, cfg)
+}
+
+func TestCreateWallet_Remote(t *testing.T) {
+	walletDir := testutil.TempDir() + "/wallet"
+	defer func() {
+		assert.NoError(t, os.RemoveAll(walletDir))
+	}()
+	wantCfg := &remote.Config{
+		RemoteCertificate: &remote.CertificateConfig{
+			ClientCertPath: "/tmp/client.crt",
+			ClientKeyPath:  "/tmp/client.key",
+			CACertPath:     "/tmp/ca.crt",
+		},
+		RemoteAddr: "host.example.com:4000",
+	}
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	keymanagerKind := "remote"
+	set.String(flags.WalletDirFlag.Name, walletDir, "")
+	set.String(flags.KeymanagerKindFlag.Name, keymanagerKind, "")
+	set.String(flags.GrpcRemoteAddressFlag.Name, wantCfg.RemoteAddr, "")
+	set.String(flags.RemoteSignerCertPathFlag.Name, wantCfg.RemoteCertificate.ClientCertPath, "")
+	set.String(flags.RemoteSignerKeyPathFlag.Name, wantCfg.RemoteCertificate.ClientKeyPath, "")
+	set.String(flags.RemoteSignerCACertPathFlag.Name, wantCfg.RemoteCertificate.CACertPath, "")
+	assert.NoError(t, set.Set(flags.WalletDirFlag.Name, walletDir))
+	assert.NoError(t, set.Set(flags.KeymanagerKindFlag.Name, keymanagerKind))
+	assert.NoError(t, set.Set(flags.GrpcRemoteAddressFlag.Name, wantCfg.RemoteAddr))
+	assert.NoError(t, set.Set(flags.RemoteSignerCertPathFlag.Name, wantCfg.RemoteCertificate.ClientCertPath))
+	assert.NoError(t, set.Set(flags.RemoteSignerKeyPathFlag.Name, wantCfg.RemoteCertificate.ClientKeyPath))
+	assert.NoError(t, set.Set(flags.RemoteSignerCACertPathFlag.Name, wantCfg.RemoteCertificate.CACertPath))
+	cliCtx := cli.NewContext(&app, set, nil)
+
+	// We attempt to create the wallet.
+	if err := CreateWallet(cliCtx); err != nil {
+		t.Fatal(err)
+	}
+
+	// We attempt to open the newly created wallet.
+	ctx := context.Background()
+	wallet, err := OpenWallet(ctx, &WalletConfig{
+		WalletDir:         walletDir,
+		KeymanagerKind:    v2keymanager.Remote,
+		CanUnlockAccounts: false,
+	})
+	assert.NoError(t, err)
+
+	// We read the keymanager config for the newly created wallet.
+	encoded, err := wallet.ReadKeymanagerConfigFromDisk(ctx)
+	assert.NoError(t, err)
+	cfg, err := remote.UnmarshalConfigFile(encoded)
+	assert.NoError(t, err)
+
+	// We assert the created configuration was as desired.
+	assert.DeepEqual(t, wantCfg, cfg)
+}

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -180,6 +180,12 @@ var (
 		Usage: "/path/to/ca.crt for establishing a secure, TLS gRPC connection to a remote signer server",
 		Value: "",
 	}
+	// KeymanagerKindFlag defines the kind of keymanager desired by a user during wallet creation.
+	KeymanagerKindFlag = &cli.StringFlag{
+		Name:  "keymanager-kind",
+		Usage: "Kind of keymanager, either direct, derived, or remote, specified during wallet creation",
+		Value: "",
+	}
 )
 
 // DefaultValidatorDir returns OS-specific default validator directory.


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR allows us to run `prysm validator wallet-v2 create` non-interactively with a pure, flag-based setup.

**Remote Keymanager Wallet Creation**

```
bazel run //validator -- wallet-v2 create \
  --wallet-dir=/tmp/wallet \
  --passwords-dir=/tmp/walletpasswords \
  --keymanager-kind=remote \
  --grpc-remote-address=host.example.com:4000 \
  --remote-signer-crt-path=/tmp/client.crt \
   --remote-signer-key-path=/tmp/client.key \
   --remote-signer-ca-crt-path=/tmp/ca.crt
```

**Direct Keymanager Wallet Creation**

```
bazel run //validator -- wallet-v2 create \
  --wallet-dir=/tmp/wallet \
  --passwords-dir=/tmp/walletpasswords \
  --keymanager-kind=direct
```

**Which issues(s) does this PR fix?**

Part of #6220  