### PR TITLE
Applies assertion funcs to cache tests

### DIFF
--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -150,3 +150,177 @@ func TestService_ReceiveBlock(t *testing.T) {
 		})
 	}
 }
+
+func TestService_ReceiveBlockInitialSync(t *testing.T) {
+	ctx := context.Background()
+
+	genesis, keys := testutil.DeterministicGenesisState(t, 64)
+	genFullBlock := func(t *testing.T, conf *testutil.BlockGenConfig, slot uint64) *ethpb.SignedBeaconBlock {
+		blk, err := testutil.GenerateFullBlock(genesis, keys, conf, slot)
+		if err != nil {
+			t.Error(err)
+		}
+		return blk
+	}
+
+	type args struct {
+		block *ethpb.SignedBeaconBlock
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		check   func(*testing.T, *Service)
+	}{
+		{
+			name: "applies block with state transition",
+			args: args{
+				block: genFullBlock(t, testutil.DefaultBlockGenConfig(), 2 /*slot*/),
+			},
+			check: func(t *testing.T, s *Service) {
+				assert.Equal(t, uint64(2), s.head.state.Slot(), "Incorrect head state slot")
+				assert.Equal(t, uint64(2), s.head.block.Block.Slot, "Incorrect head block slot")
+			},
+		},
+		{
+			name: "notifies block processed on state feed",
+			args: args{
+				block: genFullBlock(t, testutil.DefaultBlockGenConfig(), 1 /*slot*/),
+			},
+			check: func(t *testing.T, s *Service) {
+				if recvd := len(s.stateNotifier.(*blockchainTesting.MockStateNotifier).ReceivedEvents()); recvd < 1 {
+					t.Errorf("Received %d state notifications, expected at least 1", recvd)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, stateSummaryCache := testDB.SetupDB(t)
+			genesisBlockRoot := bytesutil.ToBytes32(nil)
+
+			cfg := &Config{
+				BeaconDB: db,
+				ForkChoiceStore: protoarray.New(
+					0, // justifiedEpoch
+					0, // finalizedEpoch
+					genesisBlockRoot,
+				),
+				StateNotifier: &blockchainTesting.MockStateNotifier{RecordEvents: true},
+				StateGen:      stategen.New(db, stateSummaryCache),
+			}
+			s, err := NewService(ctx, cfg)
+			require.NoError(t, err)
+			err = s.saveGenesisData(ctx, genesis)
+			require.NoError(t, err)
+			gBlk, err := s.beaconDB.GenesisBlock(ctx)
+			require.NoError(t, err)
+
+			gRoot, err := stateutil.BlockRoot(gBlk.Block)
+			s.finalizedCheckpt = &ethpb.Checkpoint{Root: gRoot[:]}
+			root, err := stateutil.BlockRoot(tt.args.block.Block)
+			require.NoError(t, err)
+
+			if err := s.ReceiveBlockInitialSync(ctx, tt.args.block, root); (err != nil) != tt.wantErr {
+				t.Errorf("ReceiveBlockInitialSync() error = %v, wantErr %v", err, tt.wantErr)
+			} else {
+				tt.check(t, s)
+			}
+		})
+	}
+}
+
+func TestService_ReceiveBlockBatch(t *testing.T) {
+	ctx := context.Background()
+
+	genesis, keys := testutil.DeterministicGenesisState(t, 64)
+	genFullBlock := func(t *testing.T, conf *testutil.BlockGenConfig, slot uint64) *ethpb.SignedBeaconBlock {
+		blk, err := testutil.GenerateFullBlock(genesis, keys, conf, slot)
+		if err != nil {
+			t.Error(err)
+		}
+		return blk
+	}
+
+	type args struct {
+		block *ethpb.SignedBeaconBlock
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		check   func(*testing.T, *Service)
+	}{
+		{
+			name: "applies block with state transition",
+			args: args{
+				block: genFullBlock(t, testutil.DefaultBlockGenConfig(), 2 /*slot*/),
+			},
+			check: func(t *testing.T, s *Service) {
+				assert.Equal(t, uint64(2), s.head.state.Slot(), "Incorrect head state slot")
+				assert.Equal(t, uint64(2), s.head.block.Block.Slot, "Incorrect head block slot")
+			},
+		},
+		{
+			name: "notifies block processed on state feed",
+			args: args{
+				block: genFullBlock(t, testutil.DefaultBlockGenConfig(), 1 /*slot*/),
+			},
+			check: func(t *testing.T, s *Service) {
+				if recvd := len(s.stateNotifier.(*blockchainTesting.MockStateNotifier).ReceivedEvents()); recvd < 1 {
+					t.Errorf("Received %d state notifications, expected at least 1", recvd)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, stateSummaryCache := testDB.SetupDB(t)
+			genesisBlockRoot := bytesutil.ToBytes32(nil)
+
+			cfg := &Config{
+				BeaconDB: db,
+				ForkChoiceStore: protoarray.New(
+					0, // justifiedEpoch
+					0, // finalizedEpoch
+					genesisBlockRoot,
+				),
+				StateNotifier: &blockchainTesting.MockStateNotifier{RecordEvents: true},
+				StateGen:      stategen.New(db, stateSummaryCache),
+			}
+			s, err := NewService(ctx, cfg)
+			require.NoError(t, err)
+			err = s.saveGenesisData(ctx, genesis)
+			require.NoError(t, err)
+			gBlk, err := s.beaconDB.GenesisBlock(ctx)
+			require.NoError(t, err)
+
+			gRoot, err := stateutil.BlockRoot(gBlk.Block)
+			s.finalizedCheckpt = &ethpb.Checkpoint{Root: gRoot[:]}
+			root, err := stateutil.BlockRoot(tt.args.block.Block)
+			require.NoError(t, err)
+			blks := []*ethpb.SignedBeaconBlock{tt.args.block}
+			roots := [][32]byte{root}
+			if err := s.ReceiveBlockBatch(ctx, blks, roots); (err != nil) != tt.wantErr {
+				t.Errorf("ReceiveBlockBatch() error = %v, wantErr %v", err, tt.wantErr)
+			} else {
+				tt.check(t, s)
+			}
+		})
+	}
+}
+
+func TestService_HasInitSyncBlock(t *testing.T) {
+	s, err := NewService(context.Background(), &Config{})
+	require.NoError(t, err)
+	r := [32]byte{'a'}
+	if s.HasInitSyncBlock(r) {
+		t.Error("Should not have block")
+	}
+	s.saveInitSyncBlock(r, testutil.NewBeaconBlock())
+	if !s.HasInitSyncBlock(r) {
+		t.Error("Should have block")
+	}
+}

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -58,6 +58,8 @@ go_test(
         "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/testutil/assert:go_default_library",
+        "//shared/testutil/require:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/beacon-chain/cache/attestation_data_test.go
+++ b/beacon-chain/cache/attestation_data_test.go
@@ -1,4 +1,4 @@
-package cache_test
+package cache
 
 import (
 	"context"
@@ -6,12 +6,12 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 )
 
 func TestAttestationCache_RoundTrip(t *testing.T) {
 	ctx := context.Background()
-	c := cache.NewAttestationCache()
+	c := NewAttestationCache()
 
 	req := &ethpb.AttestationDataRequest{
 		CommitteeIndex: 0,
@@ -19,34 +19,20 @@ func TestAttestationCache_RoundTrip(t *testing.T) {
 	}
 
 	response, err := c.Get(ctx, req)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, (*ethpb.AttestationData)(nil), response)
 
-	if response != nil {
-		t.Errorf("Empty cache returned an object: %v", response)
-	}
-
-	if err := c.MarkInProgress(req); err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, c.MarkInProgress(req))
 
 	res := &ethpb.AttestationData{
 		Target: &ethpb.Checkpoint{Epoch: 5},
 	}
 
-	if err = c.Put(ctx, req, res); err != nil {
-		t.Error(err)
-	}
-
-	if err := c.MarkNotInProgress(req); err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, c.Put(ctx, req, res))
+	assert.NoError(t, c.MarkNotInProgress(req))
 
 	response, err = c.Get(ctx, req)
-	if err != nil {
-		t.Error(err)
-	}
+	assert.NoError(t, err)
 
 	if !proto.Equal(response, res) {
 		t.Error("Expected equal protos to return from cache")

--- a/beacon-chain/cache/attestation_data_test.go
+++ b/beacon-chain/cache/attestation_data_test.go
@@ -1,4 +1,4 @@
-package cache
+package cache_test
 
 import (
 	"context"
@@ -6,12 +6,13 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 )
 
 func TestAttestationCache_RoundTrip(t *testing.T) {
 	ctx := context.Background()
-	c := NewAttestationCache()
+	c := cache.NewAttestationCache()
 
 	req := &ethpb.AttestationDataRequest{
 		CommitteeIndex: 0,

--- a/beacon-chain/cache/committee_test.go
+++ b/beacon-chain/cache/committee_test.go
@@ -45,7 +45,6 @@ func TestCommitteeCache_CommitteesByEpoch(t *testing.T) {
 	if indices != nil {
 		t.Error("Expected committee not to exist in empty cache")
 	}
-
 	require.NoError(t, cache.AddCommitteeShuffledList(item))
 
 	wantedIndex := uint64(0)
@@ -98,7 +97,6 @@ func TestCommitteeCache_AddProposerIndicesList(t *testing.T) {
 	if indices != nil {
 		t.Error("Expected committee count not to exist in empty cache")
 	}
-
 	require.NoError(t, cache.AddProposerIndicesList(seed, indices))
 
 	received, err := cache.ProposerIndices(seed)
@@ -113,7 +111,6 @@ func TestCommitteeCache_AddProposerIndicesList(t *testing.T) {
 	if indices != nil {
 		t.Error("Expected committee count not to exist in empty cache")
 	}
-
 	require.NoError(t, cache.AddProposerIndicesList(item.Seed, indices))
 
 	received, err = cache.ProposerIndices(item.Seed)

--- a/beacon-chain/cache/depositcache/BUILD.bazel
+++ b/beacon-chain/cache/depositcache/BUILD.bazel
@@ -35,6 +35,8 @@ go_test(
         "//proto/beacon/db:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/testutil/assert:go_default_library",
+        "//shared/testutil/require:go_default_library",
         "//shared/trieutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/beacon-chain/cache/depositcache/deposits_cache_test.go
+++ b/beacon-chain/cache/depositcache/deposits_cache_test.go
@@ -3,6 +3,7 @@ package depositcache
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -11,6 +12,8 @@ import (
 	dbpb "github.com/prysmaticlabs/prysm/proto/beacon/db"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 	"github.com/prysmaticlabs/prysm/shared/trieutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
@@ -25,12 +28,8 @@ func TestInsertDeposit_LogsOnNilDepositInsertion(t *testing.T) {
 
 	dc.InsertDeposit(context.Background(), nil, 1, 0, [32]byte{})
 
-	if len(dc.deposits) != 0 {
-		t.Fatal("Number of deposits changed")
-	}
-	if hook.LastEntry().Message != nilDepositErr {
-		t.Errorf("Did not log correct message, wanted \"Ignoring nil deposit insertion\", got \"%s\"", hook.LastEntry().Message)
-	}
+	require.Equal(t, 0, len(dc.deposits), "Number of deposits changed")
+	assert.Equal(t, nilDepositErr, hook.LastEntry().Message)
 }
 
 func TestInsertDeposit_MaintainsSortedOrderByIndex(t *testing.T) {
@@ -69,9 +68,8 @@ func TestInsertDeposit_MaintainsSortedOrderByIndex(t *testing.T) {
 
 	expectedIndices := []int64{0, 1, 3, 4}
 	for i, ei := range expectedIndices {
-		if dc.deposits[i].Index != ei {
-			t.Errorf("dc.deposits[%d].Index = %d, wanted %d", i, dc.deposits[i].Index, ei)
-		}
+		assert.Equal(t, ei, dc.deposits[i].Index,
+			fmt.Sprintf("dc.deposits[%d].Index = %d, wanted %d", i, dc.deposits[i].Index, ei))
 	}
 }
 
@@ -111,9 +109,8 @@ func TestAllDeposits_ReturnsAllDeposits(t *testing.T) {
 	dc.deposits = deposits
 
 	d := dc.AllDeposits(context.Background(), nil)
-	if len(d) != len(deposits) {
-		t.Errorf("Return the wrong number of deposits (%d) wanted %d", len(d), len(deposits))
-	}
+
+	assert.Equal(t, len(deposits), len(d))
 }
 
 func TestAllDeposits_FiltersDepositUpToAndIncludingBlockNumber(t *testing.T) {
@@ -152,10 +149,8 @@ func TestAllDeposits_FiltersDepositUpToAndIncludingBlockNumber(t *testing.T) {
 	dc.deposits = deposits
 
 	d := dc.AllDeposits(context.Background(), big.NewInt(11))
-	expected := 5
-	if len(d) != expected {
-		t.Errorf("Return the wrong number of deposits (%d) wanted %d", len(d), expected)
-	}
+
+	assert.Equal(t, 5, len(d))
 }
 
 func TestDepositsNumberAndRootAtHeight_ReturnsAppropriateCountAndRoot(t *testing.T) {
@@ -194,13 +189,9 @@ func TestDepositsNumberAndRootAtHeight_ReturnsAppropriateCountAndRoot(t *testing
 	}
 
 	n, root := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(11))
-	if int(n) != 5 {
-		t.Errorf("Returned unexpected deposits number %d wanted %d", n, 5)
-	}
 
-	if root != bytesutil.ToBytes32([]byte("root")) {
-		t.Errorf("Returned unexpected root: %v", root)
-	}
+	assert.Equal(t, 5, int(n))
+	assert.Equal(t, bytesutil.ToBytes32([]byte("root")), root)
 }
 
 func TestDepositsNumberAndRootAtHeight_ReturnsEmptyTrieIfBlockHeightLessThanOldestDeposit(t *testing.T) {
@@ -220,13 +211,9 @@ func TestDepositsNumberAndRootAtHeight_ReturnsEmptyTrieIfBlockHeightLessThanOlde
 	}
 
 	n, root := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(2))
-	if int(n) != 0 {
-		t.Errorf("Returned unexpected deposits number %d wanted %d", n, 0)
-	}
 
-	if root != [32]byte{} {
-		t.Errorf("Returned unexpected root: %v", root)
-	}
+	assert.Equal(t, 0, int(n))
+	assert.Equal(t, [32]byte{}, root)
 }
 
 func TestDepositByPubkey_ReturnsFirstMatchingDeposit(t *testing.T) {
@@ -272,9 +259,8 @@ func TestDepositByPubkey_ReturnsFirstMatchingDeposit(t *testing.T) {
 	if !bytes.Equal(dep.Data.PublicKey, []byte("pk1")) {
 		t.Error("Returned wrong deposit")
 	}
-	if blkNum.Cmp(big.NewInt(10)) != 0 {
-		t.Errorf("Returned wrong block number %v", blkNum)
-	}
+	assert.Equal(t, 0, blkNum.Cmp(big.NewInt(10)),
+		fmt.Sprintf("Returned wrong block number %v", blkNum))
 }
 
 func TestFinalizedDeposits_DepositsCachedCorrectly(t *testing.T) {
@@ -318,31 +304,18 @@ func TestFinalizedDeposits_DepositsCachedCorrectly(t *testing.T) {
 	dc.InsertFinalizedDeposits(context.Background(), 2)
 
 	cachedDeposits := dc.FinalizedDeposits(context.Background())
-	if cachedDeposits == nil {
-		t.Fatalf("Deposits not cached")
-	}
-	if cachedDeposits.MerkleTrieIndex != 2 {
-		t.Errorf("Incorrect index of last deposit (%d) vs expected 2", cachedDeposits.MerkleTrieIndex)
-	}
+	require.NotNil(t, cachedDeposits, "Deposits not cached")
+	assert.Equal(t, int64(2), cachedDeposits.MerkleTrieIndex)
 
 	var deps [][]byte
 	for _, d := range finalizedDeposits {
 		hash, err := ssz.HashTreeRoot(d.Deposit.Data)
-		if err != nil {
-			t.Fatalf("Could not hash deposit data")
-		}
+		require.NoError(t, err, "Could not hash deposit data")
 		deps = append(deps, hash[:])
 	}
 	trie, err := trieutil.GenerateTrieFromItems(deps, int(params.BeaconConfig().DepositContractTreeDepth))
-	if err != nil {
-		t.Fatalf("Could not generate deposit trie")
-	}
-
-	actualRoot := cachedDeposits.Deposits.HashTreeRoot()
-	expectedRoot := trie.HashTreeRoot()
-	if actualRoot != expectedRoot {
-		t.Errorf("Incorrect deposit trie root (%x) vs expected %x", actualRoot, expectedRoot)
-	}
+	require.NoError(t, err, "Could not generate deposit trie")
+	assert.Equal(t, trie.HashTreeRoot(), cachedDeposits.Deposits.HashTreeRoot())
 }
 
 func TestFinalizedDeposits_UtilizesPreviouslyCachedDeposits(t *testing.T) {
@@ -382,31 +355,18 @@ func TestFinalizedDeposits_UtilizesPreviouslyCachedDeposits(t *testing.T) {
 	dc.InsertFinalizedDeposits(context.Background(), 2)
 
 	cachedDeposits := dc.FinalizedDeposits(context.Background())
-	if cachedDeposits == nil {
-		t.Fatalf("Deposits not cached")
-	}
-	if cachedDeposits.MerkleTrieIndex != 2 {
-		t.Errorf("Incorrect index of last deposit (%d) vs expected 3", cachedDeposits.MerkleTrieIndex)
-	}
+	require.NotNil(t, cachedDeposits, "Deposits not cached")
+	assert.Equal(t, int64(2), cachedDeposits.MerkleTrieIndex)
 
 	var deps [][]byte
 	for _, d := range append(oldFinalizedDeposits, &newFinalizedDeposit) {
 		hash, err := ssz.HashTreeRoot(d.Deposit.Data)
-		if err != nil {
-			t.Fatalf("Could not hash deposit data")
-		}
+		require.NoError(t, err, "Could not hash deposit data")
 		deps = append(deps, hash[:])
 	}
 	trie, err := trieutil.GenerateTrieFromItems(deps, int(params.BeaconConfig().DepositContractTreeDepth))
-	if err != nil {
-		t.Fatalf("Could not generate deposit trie")
-	}
-
-	actualRoot := cachedDeposits.Deposits.HashTreeRoot()
-	expectedRoot := trie.HashTreeRoot()
-	if actualRoot != expectedRoot {
-		t.Errorf("Incorrect deposit trie root (%x) vs expected %x", actualRoot, expectedRoot)
-	}
+	require.NoError(t, err, "Could not generate deposit trie")
+	assert.Equal(t, trie.HashTreeRoot(), cachedDeposits.Deposits.HashTreeRoot())
 }
 
 func TestNonFinalizedDeposits_ReturnsAllNonFinalizedDeposits(t *testing.T) {
@@ -454,9 +414,7 @@ func TestNonFinalizedDeposits_ReturnsAllNonFinalizedDeposits(t *testing.T) {
 	dc.InsertFinalizedDeposits(context.Background(), 1)
 
 	deps := dc.NonFinalizedDeposits(context.Background(), nil)
-	if len(deps) != 2 {
-		t.Errorf("Incorrect number of non-finalized deposits (%d) vs expected 2", len(deps))
-	}
+	assert.Equal(t, 2, len(deps))
 }
 
 func TestNonFinalizedDeposits_ReturnsNonFinalizedDepositsUpToBlockNumber(t *testing.T) {
@@ -504,7 +462,5 @@ func TestNonFinalizedDeposits_ReturnsNonFinalizedDepositsUpToBlockNumber(t *test
 	dc.InsertFinalizedDeposits(context.Background(), 1)
 
 	deps := dc.NonFinalizedDeposits(context.Background(), big.NewInt(10))
-	if len(deps) != 1 {
-		t.Errorf("Incorrect number of non-finalized deposits (%d) vs expected 1", len(deps))
-	}
+	assert.Equal(t, 1, len(deps))
 }

--- a/beacon-chain/cache/depositcache/deposits_cache_test.go
+++ b/beacon-chain/cache/depositcache/deposits_cache_test.go
@@ -109,7 +109,6 @@ func TestAllDeposits_ReturnsAllDeposits(t *testing.T) {
 	dc.deposits = deposits
 
 	d := dc.AllDeposits(context.Background(), nil)
-
 	assert.Equal(t, len(deposits), len(d))
 }
 
@@ -149,7 +148,6 @@ func TestAllDeposits_FiltersDepositUpToAndIncludingBlockNumber(t *testing.T) {
 	dc.deposits = deposits
 
 	d := dc.AllDeposits(context.Background(), big.NewInt(11))
-
 	assert.Equal(t, 5, len(d))
 }
 
@@ -189,7 +187,6 @@ func TestDepositsNumberAndRootAtHeight_ReturnsAppropriateCountAndRoot(t *testing
 	}
 
 	n, root := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(11))
-
 	assert.Equal(t, 5, int(n))
 	assert.Equal(t, bytesutil.ToBytes32([]byte("root")), root)
 }
@@ -211,7 +208,6 @@ func TestDepositsNumberAndRootAtHeight_ReturnsEmptyTrieIfBlockHeightLessThanOlde
 	}
 
 	n, root := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(2))
-
 	assert.Equal(t, 0, int(n))
 	assert.Equal(t, [32]byte{}, root)
 }

--- a/beacon-chain/cache/depositcache/pending_deposits_test.go
+++ b/beacon-chain/cache/depositcache/pending_deposits_test.go
@@ -3,13 +3,13 @@ package depositcache
 import (
 	"context"
 	"math/big"
-	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	dbpb "github.com/prysmaticlabs/prysm/proto/beacon/db"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 )
 
 var _ = PendingDepositsFetcher(&DepositCache{})
@@ -18,18 +18,14 @@ func TestInsertPendingDeposit_OK(t *testing.T) {
 	dc := DepositCache{}
 	dc.InsertPendingDeposit(context.Background(), &ethpb.Deposit{}, 111, 100, [32]byte{})
 
-	if len(dc.pendingDeposits) != 1 {
-		t.Error("Deposit not inserted")
-	}
+	assert.Equal(t, 1, len(dc.pendingDeposits), "Deposit not inserted")
 }
 
 func TestInsertPendingDeposit_ignoresNilDeposit(t *testing.T) {
 	dc := DepositCache{}
 	dc.InsertPendingDeposit(context.Background(), nil /*deposit*/, 0 /*blockNum*/, 0, [32]byte{})
 
-	if len(dc.pendingDeposits) > 0 {
-		t.Error("Unexpected deposit insertion")
-	}
+	assert.Equal(t, 0, len(dc.pendingDeposits))
 }
 
 func TestRemovePendingDeposit_OK(t *testing.T) {
@@ -55,9 +51,7 @@ func TestRemovePendingDeposit_IgnoresNilDeposit(t *testing.T) {
 	dc := DepositCache{}
 	dc.pendingDeposits = []*dbpb.DepositContainer{{Deposit: &ethpb.Deposit{}}}
 	dc.RemovePendingDeposit(context.Background(), nil /*deposit*/)
-	if len(dc.pendingDeposits) != 1 {
-		t.Errorf("Deposit unexpectedly removed")
-	}
+	assert.Equal(t, 1, len(dc.pendingDeposits), "Deposit unexpectedly removed")
 }
 
 func TestPendingDeposit_RoundTrip(t *testing.T) {
@@ -67,9 +61,7 @@ func TestPendingDeposit_RoundTrip(t *testing.T) {
 	dep := &ethpb.Deposit{Proof: proof}
 	dc.InsertPendingDeposit(context.Background(), dep, 111, 100, [32]byte{})
 	dc.RemovePendingDeposit(context.Background(), dep)
-	if len(dc.pendingDeposits) != 0 {
-		t.Error("Failed to insert & delete a pending deposit")
-	}
+	assert.Equal(t, 0, len(dc.pendingDeposits), "Failed to insert & delete a pending deposit")
 }
 
 func TestPendingDeposits_OK(t *testing.T) {
@@ -86,15 +78,10 @@ func TestPendingDeposits_OK(t *testing.T) {
 		{Proof: [][]byte{[]byte("A")}},
 		{Proof: [][]byte{[]byte("B")}},
 	}
-
-	if !reflect.DeepEqual(deposits, expected) {
-		t.Errorf("Unexpected deposits. got=%+v want=%+v", deposits, expected)
-	}
+	assert.DeepEqual(t, expected, deposits)
 
 	all := dc.PendingDeposits(context.Background(), nil)
-	if len(all) != len(dc.pendingDeposits) {
-		t.Error("PendingDeposits(ctx, nil) did not return all deposits")
-	}
+	assert.Equal(t, len(dc.pendingDeposits), len(all), "PendingDeposits(ctx, nil) did not return all deposits")
 }
 
 func TestPrunePendingDeposits_ZeroMerkleIndex(t *testing.T) {
@@ -118,9 +105,8 @@ func TestPrunePendingDeposits_ZeroMerkleIndex(t *testing.T) {
 		{Eth1BlockHeight: 10, Index: 10},
 		{Eth1BlockHeight: 12, Index: 12},
 	}
-	if !reflect.DeepEqual(dc.pendingDeposits, expected) {
-		t.Errorf("Unexpected deposits. got=%+v want=%+v", dc.pendingDeposits, expected)
-	}
+
+	assert.DeepEqual(t, expected, dc.pendingDeposits)
 }
 
 func TestPrunePendingDeposits_OK(t *testing.T) {
@@ -143,9 +129,7 @@ func TestPrunePendingDeposits_OK(t *testing.T) {
 		{Eth1BlockHeight: 12, Index: 12},
 	}
 
-	if !reflect.DeepEqual(dc.pendingDeposits, expected) {
-		t.Errorf("Unexpected deposits. got=%+v want=%+v", dc.pendingDeposits, expected)
-	}
+	assert.DeepEqual(t, expected, dc.pendingDeposits)
 
 	dc.pendingDeposits = []*dbpb.DepositContainer{
 		{Eth1BlockHeight: 2, Index: 2},
@@ -162,8 +146,5 @@ func TestPrunePendingDeposits_OK(t *testing.T) {
 		{Eth1BlockHeight: 12, Index: 12},
 	}
 
-	if !reflect.DeepEqual(dc.pendingDeposits, expected) {
-		t.Errorf("Unexpected deposits. got=%+v want=%+v", dc.pendingDeposits, expected)
-	}
-
+	assert.DeepEqual(t, expected, dc.pendingDeposits)
 }

--- a/beacon-chain/cache/depositcache/pending_deposits_test.go
+++ b/beacon-chain/cache/depositcache/pending_deposits_test.go
@@ -105,7 +105,6 @@ func TestPrunePendingDeposits_ZeroMerkleIndex(t *testing.T) {
 		{Eth1BlockHeight: 10, Index: 10},
 		{Eth1BlockHeight: 12, Index: 12},
 	}
-
 	assert.DeepEqual(t, expected, dc.pendingDeposits)
 }
 

--- a/beacon-chain/cache/hot_state_cache_test.go
+++ b/beacon-chain/cache/hot_state_cache_test.go
@@ -1,8 +1,9 @@
-package cache
+package cache_test
 
 import (
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
@@ -10,7 +11,7 @@ import (
 )
 
 func TestHotStateCache_RoundTrip(t *testing.T) {
-	c := NewHotStateCache()
+	c := cache.NewHotStateCache()
 	root := [32]byte{'A'}
 	state := c.Get(root)
 	assert.Equal(t, (*stateTrie.BeaconState)(nil), state)

--- a/beacon-chain/cache/hot_state_cache_test.go
+++ b/beacon-chain/cache/hot_state_cache_test.go
@@ -1,46 +1,33 @@
-package cache_test
+package cache
 
 import (
-	"reflect"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
 func TestHotStateCache_RoundTrip(t *testing.T) {
-	c := cache.NewHotStateCache()
+	c := NewHotStateCache()
 	root := [32]byte{'A'}
 	state := c.Get(root)
-	if state != nil {
-		t.Errorf("Empty cache returned an object: %v", state)
-	}
-	if c.Has(root) {
-		t.Error("Empty cache has an object")
-	}
+	assert.Equal(t, (*stateTrie.BeaconState)(nil), state)
+	assert.Equal(t, false, c.Has(root), "Empty cache has an object")
 
 	state, err := stateTrie.InitializeFromProto(&pb.BeaconState{
 		Slot: 10,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	c.Put(root, state)
+	require.NoError(t, err)
 
-	if !c.Has(root) {
-		t.Error("Empty cache does not have an object")
-	}
+	c.Put(root, state)
+	assert.Equal(t, true, c.Has(root), "Empty cache does not have an object")
+
 	res := c.Get(root)
-	if state == nil {
-		t.Errorf("Empty cache returned an object: %v", state)
-	}
-	if !reflect.DeepEqual(state.CloneInnerState(), res.CloneInnerState()) {
-		t.Error("Expected equal protos to return from cache")
-	}
+	assert.NotNil(t, state)
+	assert.DeepEqual(t, res.CloneInnerState(), state.CloneInnerState(), "Expected equal protos to return from cache")
 
 	c.Delete(root)
-	if c.Has(root) {
-		t.Error("Cache not suppose to have the object")
-	}
+	assert.Equal(t, false, c.Has(root), "Cache not supposed to have the object")
 }

--- a/beacon-chain/cache/skip_slot_cache_test.go
+++ b/beacon-chain/cache/skip_slot_cache_test.go
@@ -1,9 +1,10 @@
-package cache
+package cache_test
 
 import (
 	"context"
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
@@ -12,7 +13,7 @@ import (
 
 func TestSkipSlotCache_RoundTrip(t *testing.T) {
 	ctx := context.Background()
-	c := NewSkipSlotCache()
+	c := cache.NewSkipSlotCache()
 
 	state, err := c.Get(ctx, 5)
 	require.NoError(t, err)

--- a/beacon-chain/cache/skip_slot_cache_test.go
+++ b/beacon-chain/cache/skip_slot_cache_test.go
@@ -1,53 +1,34 @@
-package cache_test
+package cache
 
 import (
 	"context"
-	"reflect"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
 func TestSkipSlotCache_RoundTrip(t *testing.T) {
 	ctx := context.Background()
-	c := cache.NewSkipSlotCache()
+	c := NewSkipSlotCache()
 
 	state, err := c.Get(ctx, 5)
-	if err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, (*stateTrie.BeaconState)(nil), state, "Empty cache returned an object")
 
-	if state != nil {
-		t.Errorf("Empty cache returned an object: %v", state)
-	}
-
-	if err := c.MarkInProgress(5); err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, c.MarkInProgress(5))
 
 	state, err = stateTrie.InitializeFromProto(&pb.BeaconState{
 		Slot: 10,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
-	if err = c.Put(ctx, 5, state); err != nil {
-		t.Error(err)
-	}
-
-	if err := c.MarkNotInProgress(5); err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, c.Put(ctx, 5, state))
+	require.NoError(t, c.MarkNotInProgress(5))
 
 	res, err := c.Get(ctx, 5)
-	if err != nil {
-		t.Error(err)
-	}
-
-	if !reflect.DeepEqual(state.CloneInnerState(), res.CloneInnerState()) {
-		t.Error("Expected equal protos to return from cache")
-	}
+	require.NoError(t, err)
+	assert.DeepEqual(t, res.CloneInnerState(), state.CloneInnerState(), "Expected equal protos to return from cache")
 }

--- a/beacon-chain/cache/subnet_ids_test.go
+++ b/beacon-chain/cache/subnet_ids_test.go
@@ -1,58 +1,44 @@
 package cache
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
 func TestSubnetIDsCache_RoundTrip(t *testing.T) {
 	c := newSubnetIDs()
 	slot := uint64(100)
 	committeeIDs := c.GetAggregatorSubnetIDs(slot)
-	if len(committeeIDs) != 0 {
-		t.Errorf("Empty cache returned an object: %v", committeeIDs)
-	}
+	assert.Equal(t, 0, len(committeeIDs), "Empty cache returned an object")
 
 	c.AddAggregatorSubnetID(slot, 1)
 	res := c.GetAggregatorSubnetIDs(slot)
-	if !reflect.DeepEqual(res, []uint64{1}) {
-		t.Error("Expected equal value to return from cache")
-	}
+	assert.DeepEqual(t, []uint64{1}, res)
 
 	c.AddAggregatorSubnetID(slot, 2)
 	res = c.GetAggregatorSubnetIDs(slot)
-	if !reflect.DeepEqual(res, []uint64{1, 2}) {
-		t.Error("Expected equal value to return from cache")
-	}
+	assert.DeepEqual(t, []uint64{1, 2}, res)
 
 	c.AddAggregatorSubnetID(slot, 3)
 	res = c.GetAggregatorSubnetIDs(slot)
-	if !reflect.DeepEqual(res, []uint64{1, 2, 3}) {
-		t.Error("Expected equal value to return from cache")
-	}
+	assert.DeepEqual(t, []uint64{1, 2, 3}, res)
 
 	committeeIDs = c.GetAttesterSubnetIDs(slot)
-	if len(committeeIDs) != 0 {
-		t.Errorf("Empty cache returned an object: %v", committeeIDs)
-	}
+	assert.Equal(t, 0, len(committeeIDs), "Empty cache returned an object")
 
 	c.AddAttesterSubnetID(slot, 11)
 	res = c.GetAttesterSubnetIDs(slot)
-	if !reflect.DeepEqual(res, []uint64{11}) {
-		t.Error("Expected equal value to return from cache")
-	}
+	assert.DeepEqual(t, []uint64{11}, res)
 
 	c.AddAttesterSubnetID(slot, 22)
 	res = c.GetAttesterSubnetIDs(slot)
-	if !reflect.DeepEqual(res, []uint64{11, 22}) {
-		t.Error("Expected equal value to return from cache")
-	}
+	assert.DeepEqual(t, []uint64{11, 22}, res)
 
 	c.AddAttesterSubnetID(slot, 33)
 	res = c.GetAttesterSubnetIDs(slot)
-	if !reflect.DeepEqual(res, []uint64{11, 22, 33}) {
-		t.Error("Expected equal value to return from cache")
-	}
+	assert.DeepEqual(t, []uint64{11, 22, 33}, res)
 }
 
 func TestSubnetIDsCache_PersistentCommitteeRoundtrip(t *testing.T) {
@@ -73,12 +59,8 @@ func TestSubnetIDsCache_PersistentCommitteeRoundtrip(t *testing.T) {
 			t.Errorf("Couldn't find entry in cache for pubkey %#x", pubkey)
 			continue
 		}
-		if idxs[0] != i {
-			t.Fatalf("Wanted index of %d but got %d", i, idxs[0])
-		}
+		require.Equal(t, i, idxs[0])
 	}
 	coms := c.GetAllSubnets()
-	if len(coms) != 20 {
-		t.Errorf("Number of committees is not %d but is %d", 20, len(coms))
-	}
+	assert.Equal(t, 20, len(coms))
 }


### PR DESCRIPTION
**What type of PR is this?**

Other/Tests Refactoring

**What does this PR do? Why is it needed?**

applies `testutil/assert` and `testutil/require` to cache tests

**Which issues(s) does this PR fix?**

Part of #6590

**Other notes for review**

I don't know how to assert that a slice variable is `nil`. Trying `assert.Equal(t, ([]unit64)(nil), x)` results in
```
panic: runtime error: comparing uncomparable type []uint64 [recovered]
        panic: runtime error: comparing uncomparable type []uint64
```