### PR TITLE
Fixes issue with vals order in assert.Equal

### DIFF
--- a/shared/testutil/assert/assertions.go
+++ b/shared/testutil/assert/assertions.go
@@ -5,13 +5,13 @@ import (
 )
 
 // Equal compares values using comparison operator.
-func Equal(tb assertions.AssertionTestingTB, expected, actual interface{}, msg ...string) {
-	assertions.Equal(tb.Errorf, expected, actual, msg...)
+func Equal(tb assertions.AssertionTestingTB, x, y interface{}, msg ...string) {
+	assertions.Equal(tb.Errorf, x, y, msg...)
 }
 
 // DeepEqual compares values using DeepEqual.
-func DeepEqual(tb assertions.AssertionTestingTB, expected, actual interface{}, msg ...string) {
-	assertions.DeepEqual(tb.Errorf, expected, actual, msg...)
+func DeepEqual(tb assertions.AssertionTestingTB, x, y interface{}, msg ...string) {
+	assertions.DeepEqual(tb.Errorf, x, y, msg...)
 }
 
 // NoError asserts that error is nil.

--- a/shared/testutil/assert/assertions_test.go
+++ b/shared/testutil/assert/assertions_test.go
@@ -35,7 +35,7 @@ func TestAssert_Equal(t *testing.T) {
 				expected: 42,
 				actual:   41,
 			},
-			expectedErr: "Values are not equal, got: 41, want: 42",
+			expectedErr: "Values are not equal, x: 41, y: 42",
 		},
 		{
 			name: "custom error message",
@@ -45,7 +45,7 @@ func TestAssert_Equal(t *testing.T) {
 				actual:   41,
 				msg:      []string{"Custom values are not equal"},
 			},
-			expectedErr: "Custom values are not equal, got: 41, want: 42",
+			expectedErr: "Custom values are not equal, x: 41, y: 42",
 		},
 	}
 	for _, tt := range tests {
@@ -85,7 +85,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 			},
-			expectedErr: "Values are not equal, got: {41}, want: {42}",
+			expectedErr: "Values are not equal, x: {41}, y: {42}",
 		},
 		{
 			name: "custom error message",
@@ -95,7 +95,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				actual:   struct{ i int }{41},
 				msg:      []string{"Custom values are not equal"},
 			},
-			expectedErr: "Custom values are not equal, got: {41}, want: {42}",
+			expectedErr: "Custom values are not equal, x: {41}, y: {42}",
 		},
 	}
 	for _, tt := range tests {

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -21,7 +21,7 @@ func Equal(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...stri
 	errMsg := parseMsg("Values are not equal", msg...)
 	if expected != actual {
 		_, file, line, _ := runtime.Caller(2)
-		loggerFn("%s:%d %s, got: %v, want: %v", filepath.Base(file), line, errMsg, actual, expected)
+		loggerFn("%s:%d %s, x: %v, y: %v", filepath.Base(file), line, errMsg, actual, expected)
 	}
 }
 
@@ -30,7 +30,7 @@ func DeepEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...
 	errMsg := parseMsg("Values are not equal", msg...)
 	if !reflect.DeepEqual(expected, actual) {
 		_, file, line, _ := runtime.Caller(2)
-		loggerFn("%s:%d %s, got: %v, want: %v", filepath.Base(file), line, errMsg, actual, expected)
+		loggerFn("%s:%d %s, x: %v, y: %v", filepath.Base(file), line, errMsg, actual, expected)
 	}
 }
 

--- a/shared/testutil/require/requires.go
+++ b/shared/testutil/require/requires.go
@@ -5,13 +5,13 @@ import (
 )
 
 // Equal compares values using comparison operator.
-func Equal(tb assertions.AssertionTestingTB, expected, actual interface{}, msg ...string) {
-	assertions.Equal(tb.Fatalf, expected, actual, msg...)
+func Equal(tb assertions.AssertionTestingTB, x, y interface{}, msg ...string) {
+	assertions.Equal(tb.Fatalf, x, y, msg...)
 }
 
 // DeepEqual compares values using DeepEqual.
-func DeepEqual(tb assertions.AssertionTestingTB, expected, actual interface{}, msg ...string) {
-	assertions.DeepEqual(tb.Fatalf, expected, actual, msg...)
+func DeepEqual(tb assertions.AssertionTestingTB, x, y interface{}, msg ...string) {
+	assertions.DeepEqual(tb.Fatalf, x, y, msg...)
 }
 
 // NoError asserts that error is nil.

--- a/shared/testutil/require/requires_test.go
+++ b/shared/testutil/require/requires_test.go
@@ -35,7 +35,7 @@ func TestAssert_Equal(t *testing.T) {
 				expected: 42,
 				actual:   41,
 			},
-			expectedErr: "Values are not equal, got: 41, want: 42",
+			expectedErr: "Values are not equal, x: 41, y: 42",
 		},
 		{
 			name: "custom error message",
@@ -45,7 +45,7 @@ func TestAssert_Equal(t *testing.T) {
 				actual:   41,
 				msg:      []string{"Custom values are not equal"},
 			},
-			expectedErr: "Custom values are not equal, got: 41, want: 42",
+			expectedErr: "Custom values are not equal, x: 41, y: 42",
 		},
 	}
 	for _, tt := range tests {
@@ -85,7 +85,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 			},
-			expectedErr: "Values are not equal, got: {41}, want: {42}",
+			expectedErr: "Values are not equal, x: {41}, y: {42}",
 		},
 		{
 			name: "custom error message",
@@ -95,7 +95,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				actual:   struct{ i int }{41},
 				msg:      []string{"Custom values are not equal"},
 			},
-			expectedErr: "Custom values are not equal, got: {41}, want: {42}",
+			expectedErr: "Custom values are not equal, x: {41}, y: {42}",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

Other/Usability

**What does this PR do? Why is it needed?**
- Order of arguments in `assert.Equal()` and `require.Equal`, was `expected value, wanted value`. This seems to be confusing (the reason this particular order was chosen was because it seems more extensive libs, like testify, are using it).
- This PR makes sure that there's no assumption on what is expected and what is wanted -- just two values (`x` and `y` like in `go-cmp`), and if they are not equal, they are reported:
![image](https://user-images.githubusercontent.com/188194/87850074-06cf9980-c8f6-11ea-92f0-268add980a9e.png)


**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
