### PR TITLE
ProcessAttestations: Add requirement that inclusion distance is not zero

### DIFF
--- a/beacon-chain/core/epoch/precompute/BUILD.bazel
+++ b/beacon-chain/core/epoch/precompute/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
+        "//shared/testutil/require:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",

--- a/beacon-chain/core/epoch/precompute/attestation.go
+++ b/beacon-chain/core/epoch/precompute/attestation.go
@@ -33,6 +33,9 @@ func ProcessAttestations(
 	var err error
 
 	for _, a := range append(state.PreviousEpochAttestations(), state.CurrentEpochAttestations()...) {
+		if a.InclusionDelay == 0 {
+			return nil, nil, errors.New("attestation with inclusion delay of 0")
+		}
 		v.IsCurrentEpochAttester, v.IsCurrentEpochTargetAttester, err = AttestedCurrentEpoch(state, a)
 		if err != nil {
 			traceutil.AnnotateError(span, err)

--- a/beacon-chain/core/epoch/precompute/attestation_test.go
+++ b/beacon-chain/core/epoch/precompute/attestation_test.go
@@ -224,11 +224,11 @@ func TestProcessAttestations(t *testing.T) {
 	}
 	att2.Data.Target.Root = newRt[:]
 	att2.Data.BeaconBlockRoot = newRt[:]
-	err := beaconState.SetPreviousEpochAttestations([]*pb.PendingAttestation{{Data: att1.Data, AggregationBits: bf}})
+	err := beaconState.SetPreviousEpochAttestations([]*pb.PendingAttestation{{Data: att1.Data, AggregationBits: bf, InclusionDelay: 1}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = beaconState.SetCurrentEpochAttestations([]*pb.PendingAttestation{{Data: att2.Data, AggregationBits: bf}})
+	err = beaconState.SetCurrentEpochAttestations([]*pb.PendingAttestation{{Data: att2.Data, AggregationBits: bf, InclusionDelay: 1}})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -731,7 +731,7 @@ func TestProcessBlockNoVerify_PassesProcessingConditions(t *testing.T) {
 func TestProcessEpochPrecompute_CanProcess(t *testing.T) {
 	epoch := uint64(1)
 
-	atts := []*pb.PendingAttestation{{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{}}}}
+	atts := []*pb.PendingAttestation{{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{}}, InclusionDelay: 1}}
 	slashing := make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector)
 	base := &pb.BeaconState{
 		Slot:                       epoch*params.BeaconConfig().SlotsPerEpoch + 1,

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -1619,7 +1619,7 @@ func TestServer_GetValidatorParticipation_PrevEpoch(t *testing.T) {
 		balances[i] = params.BeaconConfig().MaxEffectiveBalance
 	}
 
-	atts := []*pbp2p.PendingAttestation{{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{}}}}
+	atts := []*pbp2p.PendingAttestation{{Data: &ethpb.AttestationData{Target: &ethpb.Checkpoint{}}, InclusionDelay: 1}}
 	headState := testutil.NewBeaconState()
 	if err := headState.SetSlot(params.BeaconConfig().SlotsPerEpoch); err != nil {
 		t.Fatal(err)
@@ -2194,11 +2194,11 @@ func TestServer_GetIndividualVotes_Working(t *testing.T) {
 	}
 	att2.Data.Target.Root = rt[:]
 	att2.Data.BeaconBlockRoot = newRt[:]
-	err := beaconState.SetPreviousEpochAttestations([]*pb.PendingAttestation{{Data: att1.Data, AggregationBits: bf}})
+	err := beaconState.SetPreviousEpochAttestations([]*pb.PendingAttestation{{Data: att1.Data, AggregationBits: bf, InclusionDelay: 1}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = beaconState.SetCurrentEpochAttestations([]*pb.PendingAttestation{{Data: att2.Data, AggregationBits: bf}})
+	err = beaconState.SetCurrentEpochAttestations([]*pb.PendingAttestation{{Data: att2.Data, AggregationBits: bf, InclusionDelay: 1}})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Found by fuzz testing. 

```

panic: runtime error: integer divide by zero
--
  |  
  | goroutine 17 [running, locked to thread]:
  | github.com/prysmaticlabs/prysm/beacon-chain/core/epoch/precompute.attestationDelta(0x10c001334000, 0x10c001334340, 0x1, 0x0, 0x0, 0x0)
  | beacon-chain/core/epoch/precompute/reward_penalty.go:88 +0x805
  | github.com/prysmaticlabs/prysm/beacon-chain/core/epoch/precompute.AttestationsDelta(0x10c000150000, 0x10c001334000, 0x10c000c2f800, 0x100, 0x100, 0x20, 0x20, 0x20, 0x1, 0x1, ...)
  | beacon-chain/core/epoch/precompute/reward_penalty.go:66 +0x14b
  | github.com/prysmaticlabs/prysm/beacon-chain/core/epoch/precompute.ProcessRewardsAndPenaltiesPrecompute(0x10c000150000, 0x10c001334000, 0x10c000c2f800, 0x100, 0x100, 0x100, 0x10c001334000, 0x10c000c2f800)
  | beacon-chain/core/epoch/precompute/reward_penalty.go:29 +0x1fc
  | github.com/prysmaticlabs/prysm/beacon-chain/core/state.ProcessEpochPrecompute(0x13cc520, 0x10c0004c5950, 0x10c000150000, 0x0, 0x0, 0x0)
  | beacon-chain/core/state/transition.go:743 +0x30d
  | github.com/prysmaticlabs/prysm/beacon-chain/core/state.ProcessSlots(0x13cc520, 0x10c0004c4bd0, 0x10c000150000, 0x60, 0x0, 0x0, 0x0)
  | beacon-chain/core/state/transition.go:363 +0x65a
  | github.com/prysmaticlabs/prysm/fuzz.BeaconStateFuzz(0x10c000680000, 0x2995d1, 0x2995d1)
  | fuzz/state_fuzz.go:34 +0x184
  | main.LLVMFuzzerTestOneInput(...)
  | state_fuzz_test_libfuzz_main_main.fuzz.go:15
  | main._cgoexpwrap_5d6faa3079a2_LLVMFuzzerTestOneInput(0x7f2d8682c800, 0x2995d1, 0x7f2d86ac8800)
  | _cgo_gotypes.go:65 +0xc2
  | AddressSanitizer:DEADLYSIGNAL

```

**Which issues(s) does this PR fix?**

Fuzzing test case [5657818854064128](https://prysmaticlabs.appspot.com/testcase-detail/5657818854064128).

**Other notes for review**

This is not a possible scenario with a "valid" state, but it doesn't hurt to test this scenario since there is a possible divide by zero issue.
