### PR TITLE
Adds type info into equality assertions

### DIFF
--- a/shared/testutil/assert/assertions_test.go
+++ b/shared/testutil/assert/assertions_test.go
@@ -104,7 +104,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 			},
-			expectedErr: "Values are not equal, got: {41}, want: {42}",
+			expectedErr: "Values are not equal, want: {42}, got: {41}",
 		},
 		{
 			name: "custom error message",
@@ -114,7 +114,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				actual:   struct{ i int }{41},
 				msgs:     []interface{}{"Custom values are not equal"},
 			},
-			expectedErr: "Custom values are not equal, got: {41}, want: {42}",
+			expectedErr: "Custom values are not equal, want: {42}, got: {41}",
 		},
 		{
 			name: "custom error message with params",
@@ -124,7 +124,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				actual:   struct{ i int }{41},
 				msgs:     []interface{}{"Custom values are not equal (for slot %d)", 12},
 			},
-			expectedErr: "Custom values are not equal (for slot 12), got: {41}, want: {42}",
+			expectedErr: "Custom values are not equal (for slot 12), want: {42}, got: {41}",
 		},
 	}
 	for _, tt := range tests {

--- a/shared/testutil/assert/assertions_test.go
+++ b/shared/testutil/assert/assertions_test.go
@@ -29,13 +29,22 @@ func TestAssert_Equal(t *testing.T) {
 			},
 		},
 		{
+			name: "equal values different types",
+			args: args{
+				tb:       &assertions.TBMock{},
+				expected: uint64(42),
+				actual:   42,
+			},
+			expectedErr: "Values are not equal, want: 42 (uint64), got: 42 (int)",
+		},
+		{
 			name: "non-equal values",
 			args: args{
 				tb:       &assertions.TBMock{},
 				expected: 42,
 				actual:   41,
 			},
-			expectedErr: "Values are not equal, got: 41, want: 42",
+			expectedErr: "Values are not equal, want: 42 (int), got: 41 (int)",
 		},
 		{
 			name: "custom error message",
@@ -45,7 +54,7 @@ func TestAssert_Equal(t *testing.T) {
 				actual:   41,
 				msgs:     []interface{}{"Custom values are not equal"},
 			},
-			expectedErr: "Custom values are not equal, got: 41, want: 42",
+			expectedErr: "Custom values are not equal, want: 42 (int), got: 41 (int)",
 		},
 		{
 			name: "custom error message with params",
@@ -55,7 +64,7 @@ func TestAssert_Equal(t *testing.T) {
 				actual:   41,
 				msgs:     []interface{}{"Custom values are not equal (for slot %d)", 12},
 			},
-			expectedErr: "Custom values are not equal (for slot 12), got: 41, want: 42",
+			expectedErr: "Custom values are not equal (for slot 12), want: 42 (int), got: 41 (int)",
 		},
 	}
 	for _, tt := range tests {

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -30,7 +30,7 @@ func DeepEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...
 	errMsg := parseMsg("Values are not equal", msg...)
 	if !reflect.DeepEqual(expected, actual) {
 		_, file, line, _ := runtime.Caller(2)
-		loggerFn("%s:%d %s, got: %v, want: %v", filepath.Base(file), line, errMsg, actual, expected)
+		loggerFn("%s:%d %s, want: %v, got: %v", filepath.Base(file), line, errMsg, expected, actual)
 	}
 }
 

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -21,7 +21,7 @@ func Equal(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...inte
 	errMsg := parseMsg("Values are not equal", msg...)
 	if expected != actual {
 		_, file, line, _ := runtime.Caller(2)
-		loggerFn("%s:%d %s, got: %v, want: %v", filepath.Base(file), line, errMsg, actual, expected)
+		loggerFn("%s:%d %s, got: %[4]v (%[4]T), want: %[5]v (%[5]T)", filepath.Base(file), line, errMsg, actual, expected)
 	}
 }
 
@@ -30,7 +30,7 @@ func DeepEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...
 	errMsg := parseMsg("Values are not equal", msg...)
 	if !reflect.DeepEqual(expected, actual) {
 		_, file, line, _ := runtime.Caller(2)
-		loggerFn("%s:%d %s, got: %v, want: %v", filepath.Base(file), line, errMsg, actual, expected)
+		loggerFn("%s:%d %s, got: %[4]v (%[4]T), want: %[5]v (%[5]T)", filepath.Base(file), line, errMsg, actual, expected)
 	}
 }
 

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -21,7 +21,7 @@ func Equal(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...inte
 	errMsg := parseMsg("Values are not equal", msg...)
 	if expected != actual {
 		_, file, line, _ := runtime.Caller(2)
-		loggerFn("%s:%d %s, got: %[4]v (%[4]T), want: %[5]v (%[5]T)", filepath.Base(file), line, errMsg, actual, expected)
+		loggerFn("%s:%d %s, want: %[4]v (%[4]T), got: %[5]v (%[5]T)", filepath.Base(file), line, errMsg, expected, actual)
 	}
 }
 
@@ -30,7 +30,7 @@ func DeepEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...
 	errMsg := parseMsg("Values are not equal", msg...)
 	if !reflect.DeepEqual(expected, actual) {
 		_, file, line, _ := runtime.Caller(2)
-		loggerFn("%s:%d %s, got: %[4]v (%[4]T), want: %[5]v (%[5]T)", filepath.Base(file), line, errMsg, actual, expected)
+		loggerFn("%s:%d %s, got: %v, want: %v", filepath.Base(file), line, errMsg, actual, expected)
 	}
 }
 

--- a/shared/testutil/require/requires_test.go
+++ b/shared/testutil/require/requires_test.go
@@ -104,7 +104,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 			},
-			expectedErr: "Values are not equal, got: {41}, want: {42}",
+			expectedErr: "Values are not equal, want: {42}, got: {41}",
 		},
 		{
 			name: "custom error message",
@@ -114,7 +114,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				actual:   struct{ i int }{41},
 				msgs:     []interface{}{"Custom values are not equal"},
 			},
-			expectedErr: "Custom values are not equal, got: {41}, want: {42}",
+			expectedErr: "Custom values are not equal, want: {42}, got: {41}",
 		},
 		{
 			name: "custom error message with params",
@@ -124,7 +124,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				actual:   struct{ i int }{41},
 				msgs:     []interface{}{"Custom values are not equal (for slot %d)", 12},
 			},
-			expectedErr: "Custom values are not equal (for slot 12), got: {41}, want: {42}",
+			expectedErr: "Custom values are not equal (for slot 12), want: {42}, got: {41}",
 		},
 	}
 	for _, tt := range tests {

--- a/shared/testutil/require/requires_test.go
+++ b/shared/testutil/require/requires_test.go
@@ -29,13 +29,22 @@ func TestAssert_Equal(t *testing.T) {
 			},
 		},
 		{
+			name: "equal values different types",
+			args: args{
+				tb:       &assertions.TBMock{},
+				expected: uint64(42),
+				actual:   42,
+			},
+			expectedErr: "Values are not equal, want: 42 (uint64), got: 42 (int)",
+		},
+		{
 			name: "non-equal values",
 			args: args{
 				tb:       &assertions.TBMock{},
 				expected: 42,
 				actual:   41,
 			},
-			expectedErr: "Values are not equal, got: 41, want: 42",
+			expectedErr: "Values are not equal, want: 42 (int), got: 41 (int)",
 		},
 		{
 			name: "custom error message",
@@ -45,7 +54,7 @@ func TestAssert_Equal(t *testing.T) {
 				actual:   41,
 				msgs:     []interface{}{"Custom values are not equal"},
 			},
-			expectedErr: "Custom values are not equal, got: 41, want: 42",
+			expectedErr: "Custom values are not equal, want: 42 (int), got: 41 (int)",
 		},
 		{
 			name: "custom error message with params",
@@ -55,7 +64,7 @@ func TestAssert_Equal(t *testing.T) {
 				actual:   41,
 				msgs:     []interface{}{"Custom values are not equal (for slot %d)", 12},
 			},
-			expectedErr: "Custom values are not equal (for slot 12), got: 41, want: 42",
+			expectedErr: "Custom values are not equal (for slot 12), want: 42 (int), got: 41 (int)",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

Other/Test Usability

**What does this PR do? Why is it needed?**
- When comparing scalars having equal numeric values, assertions produce hard to understand messages, like:
> Values are not equal, want: 42, got: 42
- The reason those values are not equal is they have different type. This PR, updates error printing to include type info:
> Values are not equal, want: 42 (int), got: 42 (uint64)

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- When reporting failed equality test, order of got/want, has been changed to want/got (to mimic passed in params to `(assert|require).(Deep)Equal`)