### PR TITLE
Use correct context for chainHeadRetrieval

### DIFF
--- a/beacon-chain/rpc/beacon/blocks.go
+++ b/beacon-chain/rpc/beacon/blocks.go
@@ -226,7 +226,7 @@ func (bs *Server) StreamChainHead(_ *ptypes.Empty, stream ethpb.BeaconChain_Stre
 		select {
 		case event := <-stateChannel:
 			if event.Type == statefeed.BlockProcessed {
-				res, err := bs.chainHeadRetrieval(bs.Ctx)
+				res, err := bs.chainHeadRetrieval(stream.Context())
 				if err != nil {
 					return status.Errorf(codes.Internal, "Could not retrieve chain head: %v", err)
 				}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The improper context was being used. Any context deadline or timeout would not be respected otherwise. Additionally, this improves jaeger span collection (the call hierarchy would be preserved in the span).

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
