### PR TITLE
Handles case when no peers with finalized blocks are found

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -45,6 +45,28 @@ func TestService_roundRobinSync(t *testing.T) {
 			},
 		},
 		{
+			name:               "Multiple peers with no finalized blocks",
+			currentSlot:        2,
+			expectedBlockSlots: makeSequence(1, 2),
+			peers: []*peerData{
+				{
+					blocks:         makeSequence(1, 2),
+					finalizedEpoch: 0,
+					headSlot:       2,
+				},
+				{
+					blocks:         makeSequence(1, 2),
+					finalizedEpoch: 0,
+					headSlot:       2,
+				},
+				{
+					blocks:         makeSequence(1, 2),
+					finalizedEpoch: 0,
+					headSlot:       2,
+				},
+			},
+		},
+		{
 			name:               "Single peer with all blocks",
 			currentSlot:        131,
 			expectedBlockSlots: makeSequence(1, 131),

--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -33,6 +33,18 @@ func TestService_roundRobinSync(t *testing.T) {
 		peers              []*peerData
 	}{
 		{
+			name:               "Single peer with no finalized blocks",
+			currentSlot:        2,
+			expectedBlockSlots: makeSequence(1, 2),
+			peers: []*peerData{
+				{
+					blocks:         makeSequence(1, 2),
+					finalizedEpoch: 0,
+					headSlot:       2,
+				},
+			},
+		},
+		{
 			name:               "Single peer with all blocks",
 			currentSlot:        131,
 			expectedBlockSlots: makeSequence(1, 131),


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- When no peers with finalized blocks are found, queue will spin forever. This PR will periodically (when all FSMs are marked as skipped, and before resetting them) check if best finalized slot from peers is ahead of current head. If it is behind (or equal), queue cancels -- allowing normal sync to take control. If node falls behind, normal sync will re-trigger init-sync.

**Which issues(s) does this PR fix?**

Fixes #6655

**Other notes for review**
