### PR TITLE
Stategen: always invalidate hot cache state in StateByRootInitialSync

### DIFF
--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -51,6 +51,9 @@ func (s *State) StateByRootInitialSync(ctx context.Context, blockRoot [32]byte) 
 		return s.beaconDB.State(ctx, blockRoot)
 	}
 
+	// To invalidate cache for parent root because pre state will get mutated.
+	defer s.hotStateCache.Delete(blockRoot)
+
 	if s.hotStateCache.Has(blockRoot) {
 		return s.hotStateCache.GetWithoutCopy(blockRoot), nil
 	}
@@ -86,9 +89,6 @@ func (s *State) StateByRootInitialSync(ctx context.Context, blockRoot [32]byte) 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not replay blocks for hot state using root")
 	}
-
-	// To invalidate cache for parent root because pre state will get mutated.
-	s.hotStateCache.Delete(blockRoot)
 
 	return startState, nil
 }

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -139,10 +139,13 @@ func TestStateByRootInitialSync_UseCache(t *testing.T) {
 	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{Root: r[:]}))
 	service.hotStateCache.Put(r, beaconState)
 
-	loadedState, err := service.StateByRoot(ctx, r)
+	loadedState, err := service.StateByRootInitialSync(ctx, r)
 	require.NoError(t, err)
 	if !proto.Equal(loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe()) {
 		t.Error("Did not correctly cache state")
+	}
+	if service.hotStateCache.Has(r) {
+		t.Error("Hot state cache was not invalidated")
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This method claims to invalidate the cache, but there were some code paths where it didn't invalidate the cache. 

Using defer will ensure that all code paths will invalidate the cached value.

**Which issues(s) does this PR fix?**

None reported.

**Other notes for review**

Part of an investigation for corrupted hot state caches.
