### PR TITLE
Accounts V2: Fix Up Utilization Bugs

### DIFF
--- a/validator/accounts/v2/doc.go
+++ b/validator/accounts/v2/doc.go
@@ -1,4 +1,5 @@
 // Package v2 defines a new model for accounts management in Prysm, using best
 // practices for user security, UX, and extensibility via different wallet types
-// including derived, HD wallets and remote-signing capable configurations.
+// including HD wallets, non-HD wallets, and remote-signing capable configurations. This model
+// is compliant with the EIP-2333, EIP-2334, and EIP-2335 standards for key management in eth2.
 package v2

--- a/validator/accounts/v2/list.go
+++ b/validator/accounts/v2/list.go
@@ -152,6 +152,14 @@ func listDerivedKeymanagerAccounts(
 	if err != nil {
 		return err
 	}
+	if len(accountNames) == 1 {
+		fmt.Print("Showing 1 validator account\n")
+	} else if len(accountNames) == 0 {
+		fmt.Print("No accounts found\n")
+		return nil
+	} else {
+		fmt.Printf("Showing %d validator accounts\n", len(accountNames))
+	}
 	for i := uint64(0); i <= currentAccountNumber; i++ {
 		fmt.Println("")
 		validatingKeyPath := fmt.Sprintf(derived.ValidatingKeyDerivationPathTemplate, i)

--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -16,7 +16,11 @@ import (
 // wallet already exists in the path, it suggests the user alternatives
 // such as how to edit their existing wallet configuration.
 func CreateWallet(cliCtx *cli.Context) error {
-	w, err := NewWallet(cliCtx)
+	keymanagerKind, err := inputKeymanagerKind(cliCtx)
+	if err != nil {
+		return err
+	}
+	w, err := NewWallet(cliCtx, keymanagerKind)
 	if err != nil {
 		return errors.Wrap(err, "could not check if wallet directory exists")
 	}
@@ -64,11 +68,7 @@ func createDirectKeymanagerWallet(cliCtx *cli.Context, wallet *Wallet) error {
 func createDerivedKeymanagerWallet(cliCtx *cli.Context, wallet *Wallet) error {
 	skipMnemonicConfirm := cliCtx.Bool(flags.SkipMnemonicConfirmFlag.Name)
 	ctx := context.Background()
-	walletPassword, err := inputPassword(cliCtx, newWalletPasswordPromptText, confirmPass)
-	if err != nil {
-		return err
-	}
-	seedConfig, err := derived.InitializeWalletSeedFile(ctx, walletPassword, skipMnemonicConfirm)
+	seedConfig, err := derived.InitializeWalletSeedFile(ctx, wallet.walletPassword, skipMnemonicConfirm)
 	if err != nil {
 		return errors.Wrap(err, "could not initialize new wallet seed file")
 	}

--- a/validator/accounts/v2/wallet_recover.go
+++ b/validator/accounts/v2/wallet_recover.go
@@ -9,6 +9,7 @@ import (
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/validator/flags"
+	v2keymanager "github.com/prysmaticlabs/prysm/validator/keymanager/v2"
 	"github.com/prysmaticlabs/prysm/validator/keymanager/v2/derived"
 	"github.com/urfave/cli/v2"
 )
@@ -21,7 +22,7 @@ func RecoverWallet(cliCtx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "could not get mnemonic phrase")
 	}
-	wallet, err := NewWallet(cliCtx)
+	wallet, err := NewWallet(cliCtx, v2keymanager.Derived)
 	if err != nil {
 		return errors.Wrap(err, "could not create new wallet")
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

- Listing derived wallet with 0 accounts leads to a fatal (FIXED)
- Recover shouldnt ask for the type of wallet desired (FIXED)
- Recover didn’t ask me for the new password I want for my desired wallet (FIXED)
- Using wrong recovery function from bip39 (FIXED)
- Sanitize all user input, both from files and from stdin
- Issue import/export with password file not found
- Interrupts during user input can lead to a corrupted wallet

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
