### PR TITLE
Fix Validator Accounts-V2 Runtime

### DIFF
--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -79,11 +79,8 @@ func NewValidatorClient(cliCtx *cli.Context) (*ValidatorClient, error) {
 
 	cmd.ConfigureValidator(cliCtx)
 	featureconfig.ConfigureValidator(cliCtx)
-	keyManagerV1, err := selectV1Keymanager(cliCtx)
-	if err != nil {
-		return nil, err
-	}
 
+	var keyManagerV1 v1.KeyManager
 	var keyManagerV2 v2.IKeymanager
 	if featureconfig.Get().EnableAccountsV2 {
 		walletDir := cliCtx.String(flags.WalletDirFlag.Name)
@@ -104,6 +101,11 @@ func NewValidatorClient(cliCtx *cli.Context) (*ValidatorClient, error) {
 		)
 		if err != nil {
 			log.Fatalf("Could not read existing keymanager for wallet: %v", err)
+		}
+	} else {
+		keyManagerV1, err = selectV1Keymanager(cliCtx)
+		if err != nil {
+			return nil, err
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Accounts V2 was not working properly at runtime as we would still select the v1 keymanager version despite the --enable-accounts-v2 flag being enabled. This PR fixes it.
