### PR TITLE
Update comments for `get_committee_count_per_slot`

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -27,11 +27,10 @@ var committeeCache = cache.NewCommitteesCache()
 //
 //
 // Spec pseudocode definition:
-//   def get_committee_count_at_slot(state: BeaconState, slot: Slot) -> uint64:
+//   def get_committee_count_per_slot(state: BeaconState, epoch: Epoch) -> uint64:
 //    """
-//    Return the number of committees at ``slot``.
+//    Return the number of committees in each slot for the given ``epoch``.
 //    """
-//    epoch = compute_epoch_at_slot(slot)
 //    return max(1, min(
 //        MAX_COMMITTEES_PER_SLOT,
 //        len(get_active_validator_indices(state, epoch)) // SLOTS_PER_EPOCH // TARGET_COMMITTEE_SIZE,


### PR DESCRIPTION
Part of #6716 

Addresses point `Avoid state in p2p validation, compute committee count per slot for epoch`

Our version of `get_committee_count_per_slot` was already optimized by passing in `active_validator_count` instead of `state` and `epoch`. I updated the pseudocode  comments. 

Reference: https://github.com/ethereum/eth2.0-specs/pull/1904

