### PR TITLE
Add committee ID check to process attestation

### DIFF
--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
+        "//shared/testutil/require:go_default_library",
         "//shared/trieutil:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",

--- a/beacon-chain/core/blocks/attestation.go
+++ b/beacon-chain/core/blocks/attestation.go
@@ -38,10 +38,10 @@ func ProcessAttestations(
 // Spec pseudocode definition:
 //  def process_attestation(state: BeaconState, attestation: Attestation) -> None:
 //    data = attestation.data
-//    assert data.index < get_committee_count_at_slot(state, data.slot)
 //    assert data.target.epoch in (get_previous_epoch(state), get_current_epoch(state))
 //    assert data.target.epoch == compute_epoch_at_slot(data.slot)
 //    assert data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot <= data.slot + SLOTS_PER_EPOCH
+//    assert data.index < get_committee_count_per_slot(state, data.target.epoch)
 //
 //    committee = get_beacon_committee(state, data.slot, data.index)
 //    assert len(attestation.aggregation_bits) == len(committee)
@@ -143,6 +143,14 @@ func ProcessAttestationNoVerify(
 			s,
 			params.BeaconConfig().SlotsPerEpoch,
 		)
+	}
+	activeValidatorCount, err := helpers.ActiveValidatorCount(beaconState, att.Data.Target.Epoch)
+	if err != nil {
+		return nil, err
+	}
+	c := helpers.SlotCommitteeCount(activeValidatorCount)
+	if att.Data.CommitteeIndex > c {
+		return nil, fmt.Errorf("data index %d >= committee count %d", att.Data.CommitteeIndex, c)
 	}
 
 	if err := helpers.VerifyAttestationBitfieldLengths(beaconState, att); err != nil {

--- a/beacon-chain/core/blocks/attestation.go
+++ b/beacon-chain/core/blocks/attestation.go
@@ -150,7 +150,7 @@ func ProcessAttestationNoVerify(
 	}
 	c := helpers.SlotCommitteeCount(activeValidatorCount)
 	if att.Data.CommitteeIndex > c {
-		return nil, fmt.Errorf("data index %d >= committee count %d", att.Data.CommitteeIndex, c)
+		return nil, fmt.Errorf("committee index %d >= committee count %d", att.Data.CommitteeIndex, c)
 	}
 
 	if err := helpers.VerifyAttestationBitfieldLengths(beaconState, att); err != nil {

--- a/beacon-chain/core/blocks/attestation_test.go
+++ b/beacon-chain/core/blocks/attestation_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
 func TestProcessAttestations_InclusionDelayFailure(t *testing.T) {
@@ -528,6 +529,31 @@ func TestProcessAttestationsNoVerify_OK(t *testing.T) {
 	if _, err := blocks.ProcessAttestationNoVerify(context.TODO(), beaconState, att); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
+}
+
+func TestProcessAttestationsNoVerify_BadAttIdx(t *testing.T) {
+	beaconState, _ := testutil.DeterministicGenesisState(t, 100)
+	aggBits := bitfield.NewBitlist(3)
+	aggBits.SetBitAt(1, true)
+	var mockRoot [32]byte
+	copy(mockRoot[:], "hello-world")
+	att := &ethpb.Attestation{
+		Data: &ethpb.AttestationData{
+			CommitteeIndex: 100,
+			Source:         &ethpb.Checkpoint{Epoch: 0, Root: mockRoot[:]},
+			Target:         &ethpb.Checkpoint{Epoch: 0},
+		},
+		AggregationBits: aggBits,
+	}
+	zeroSig := [96]byte{}
+	att.Signature = zeroSig[:]
+	require.NoError(t, beaconState.SetSlot(beaconState.Slot()+params.BeaconConfig().MinAttestationInclusionDelay))
+	ckp := beaconState.CurrentJustifiedCheckpoint()
+	copy(ckp.Root, "hello-world")
+	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(ckp))
+	require.NoError(t, beaconState.SetCurrentEpochAttestations([]*pb.PendingAttestation{}))
+	_, err := blocks.ProcessAttestationNoVerify(context.TODO(), beaconState, att)
+	require.ErrorContains(t, "data index 100 >= committee count 1", err)
 }
 
 func TestConvertToIndexed_OK(t *testing.T) {

--- a/beacon-chain/core/blocks/attestation_test.go
+++ b/beacon-chain/core/blocks/attestation_test.go
@@ -553,7 +553,7 @@ func TestProcessAttestationsNoVerify_BadAttIdx(t *testing.T) {
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(ckp))
 	require.NoError(t, beaconState.SetCurrentEpochAttestations([]*pb.PendingAttestation{}))
 	_, err := blocks.ProcessAttestationNoVerify(context.TODO(), beaconState, att)
-	require.ErrorContains(t, "data index 100 >= committee count 1", err)
+	require.ErrorContains(t, "committee index 100 >= committee count 1", err)
 }
 
 func TestConvertToIndexed_OK(t *testing.T) {


### PR DESCRIPTION
Part of #6716 

Addresses point `Reorder conditions to validator target_epoch before its use`

Wow! We were missing the committee ID check this whole time. This PR adds the committee ID check and a regression test

Reference: https://github.com/ethereum/eth2.0-specs/pull/1996

