### PR TITLE
Accounts V2: Fix issues reported by rkapka

### DIFF
--- a/validator/accounts/v2/accounts_import.go
+++ b/validator/accounts/v2/accounts_import.go
@@ -24,6 +24,23 @@ func ImportAccount(cliCtx *cli.Context) error {
 	if err != nil && !errors.Is(err, ErrNoWalletFound) {
 		return errors.Wrap(err, "could not parse wallet directory")
 	}
+	// Check if the user has a wallet at the specified path. If so, only let them continue if it is a non-HD wallet.
+	walletExists, err := hasDir(walletDir)
+	if err != nil {
+		return errors.Wrap(err, "could not check if wallet exists")
+	}
+	if walletExists {
+		keymanagerKind, err := readKeymanagerKindFromWalletPath(walletDir)
+		if err != nil {
+			return errors.Wrap(err, "could not read keymanager kind for existing wallet")
+		}
+		if keymanagerKind != v2keymanager.Direct {
+			return fmt.Errorf(
+				"importing non-HD accounts into a non-direct wallet is not allowed, given wallet path contains a %s wallet",
+				keymanagerKind.String(),
+			)
+		}
+	}
 	passwordsDir, err := inputDirectory(cliCtx, passwordsDirPromptText, flags.WalletPasswordsDirFlag)
 	if err != nil {
 		return err

--- a/validator/accounts/v2/accounts_list.go
+++ b/validator/accounts/v2/accounts_list.go
@@ -93,8 +93,6 @@ func listDirectKeymanagerAccounts(
 	}
 	for i := 0; i < len(accountNames); i++ {
 		fmt.Println("")
-		fmt.Printf("%s\n", au.BrightGreen(accountNames[i]).Bold())
-		fmt.Printf("%s %#x\n", au.BrightMagenta("[public key]").Bold(), pubKeys[i])
 
 		// Retrieve the account creation timestamp.
 		createdAtBytes, err := wallet.ReadFileAtPath(ctx, accountNames[i], direct.TimestampFileName)
@@ -106,7 +104,9 @@ func listDirectKeymanagerAccounts(
 			return errors.Wrapf(err, "could not parse account created at timestamp: %s", createdAtBytes)
 		}
 		unixTimestamp := time.Unix(unixTimestampStr, 0)
-		fmt.Printf("%s %s\n", au.BrightCyan("[created at]").Bold(), humanize.Time(unixTimestamp))
+
+		fmt.Printf("%s | %s\n", au.BrightGreen(accountNames[i]).Bold(), humanize.Time(unixTimestamp))
+		fmt.Printf("%s %#x\n", au.BrightMagenta("[validating public key]").Bold(), pubKeys[i])
 		if !showDepositData {
 			continue
 		}

--- a/validator/accounts/v2/cmd_accounts.go
+++ b/validator/accounts/v2/cmd_accounts.go
@@ -22,7 +22,6 @@ this command outputs a deposit data string which is required to become a validat
 				flags.WalletDirFlag,
 				flags.WalletPasswordsDirFlag,
 				flags.PasswordFileFlag,
-				flags.SkipMnemonicConfirmFlag,
 				featureconfig.AltonaTestnet,
 				featureconfig.MedallaTestnet,
 			},

--- a/validator/accounts/v2/cmd_accounts.go
+++ b/validator/accounts/v2/cmd_accounts.go
@@ -15,7 +15,7 @@ var AccountCommands = &cli.Command{
 		// AccountCommands for accounts-v2 for Prysm validators.
 		{
 			Name: "create",
-			Description: `creates a new validator account for eth2. If no account exists at the wallet path, creates a new wallet for a user based on
+			Description: `creates a new validator account for eth2. If no wallet exists at the given wallet path, creates a new wallet for a user based on
 specified input, capable of creating a direct, derived, or remote wallet.
 this command outputs a deposit data string which is required to become a validator in eth2.`,
 			Flags: []cli.Flag{

--- a/validator/accounts/v2/prompt.go
+++ b/validator/accounts/v2/prompt.go
@@ -110,11 +110,11 @@ func inputPassword(cliCtx *cli.Context, promptText string, confirmPassword passw
 		if err != nil {
 			return "", err
 		}
-		enteredPassword := string(data)
+		enteredPassword := strings.TrimRight(string(data), "\r\n")
 		if err := validatePasswordInput(enteredPassword); err != nil {
 			return "", errors.Wrap(err, "password did not pass validation")
 		}
-		return strings.TrimRight(enteredPassword, "\r\n"), nil
+		return enteredPassword, nil
 	}
 
 	var hasValidPassword bool

--- a/validator/accounts/v2/testing/mock.go
+++ b/validator/accounts/v2/testing/mock.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"strings"
 	"sync"
 )
 
@@ -77,7 +78,7 @@ func (m *Wallet) ReadFileAtPath(ctx context.Context, pathName string, fileName s
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 	for f, v := range m.Files[pathName] {
-		if f == fileName {
+		if strings.Contains(fileName, f) {
 			return v, nil
 		}
 	}

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -80,8 +80,7 @@ func NewWallet(
 	}
 	if walletExists {
 		return nil, errors.New(
-			"you already have a wallet at the specified path. You can " +
-				"edit your wallet configuration by running ./prysm.sh validator wallet-v2 edit",
+			,
 		)
 	}
 	accountsPath := filepath.Join(walletDir, keymanagerKind.String())

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -46,6 +46,13 @@ const (
 	DirectoryPermissions = os.ModePerm
 )
 
+var (
+	// Wallet error vars.
+	ErrWalletExists = errors.New("you already have a wallet at the specified path. You can " +
+		"edit your wallet configuration by running ./prysm.sh validator wallet-v2 edit-config",
+	)
+)
+
 // Wallet is a primitive in Prysm's v2 account management which
 // has the capability of creating new accounts, reading existing accounts,
 // and providing secure access to eth2 secrets depending on an
@@ -79,10 +86,7 @@ func NewWallet(
 		return nil, errors.Wrap(err, "could not check if wallet exists")
 	}
 	if walletExists {
-		return nil, errors.New(
-			"you already have a wallet at the specified path. You can " +
-				"edit your wallet configuration by running ./prysm.sh validator wallet-v2 edit-config",
-		)
+		return nil, ErrWalletExists
 	}
 	accountsPath := filepath.Join(walletDir, keymanagerKind.String())
 	w := &Wallet{

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -48,6 +48,7 @@ const (
 
 var (
 	// Wallet error vars.
+	// ErrWalletExists is an error returned when a wallet already exists in the path provided.
 	ErrWalletExists = errors.New("you already have a wallet at the specified path. You can " +
 		"edit your wallet configuration by running ./prysm.sh validator wallet-v2 edit-config",
 	)

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -80,7 +80,8 @@ func NewWallet(
 	}
 	if walletExists {
 		return nil, errors.New(
-			,
+			"you already have a wallet at the specified path. You can " +
+				"edit your wallet configuration by running ./prysm.sh validator wallet-v2 edit-config",
 		)
 	}
 	accountsPath := filepath.Join(walletDir, keymanagerKind.String())

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -47,7 +47,6 @@ const (
 )
 
 var (
-	// Wallet error vars.
 	// ErrWalletExists is an error returned when a wallet already exists in the path provided.
 	ErrWalletExists = errors.New("you already have a wallet at the specified path. You can " +
 		"edit your wallet configuration by running ./prysm.sh validator wallet-v2 edit-config",

--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -29,7 +29,7 @@ func CreateWallet(cliCtx *cli.Context) error {
 		if err = createDirectKeymanagerWallet(cliCtx, w); err != nil {
 			return errors.Wrap(err, "could not initialize wallet with direct keymanager")
 		}
-		log.WithField("wallet-path", w.accountsPath).Infof(
+		log.WithField("wallet-dir", w.accountsPath).Infof(
 			"Successfully created wallet with on-disk keymanager configuration. " +
 				"Make a new validator account with ./prysm.sh validator accounts-v2 create",
 		)
@@ -37,7 +37,7 @@ func CreateWallet(cliCtx *cli.Context) error {
 		if err = createDerivedKeymanagerWallet(cliCtx, w); err != nil {
 			return errors.Wrap(err, "could not initialize wallet with derived keymanager")
 		}
-		log.WithField("wallet-path", w.accountsPath).Infof(
+		log.WithField("wallet-dir", w.accountsPath).Infof(
 			"Successfully created HD wallet and saved configuration to disk. " +
 				"Make a new validator account with ./prysm.sh validator accounts-2 create",
 		)

--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -21,8 +21,11 @@ func CreateWallet(cliCtx *cli.Context) error {
 		return err
 	}
 	w, err := NewWallet(cliCtx, keymanagerKind)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrWalletExists) {
 		return errors.Wrap(err, "could not check if wallet directory exists")
+	}
+	if errors.Is(err, ErrWalletExists) {
+		return ErrWalletExists
 	}
 	switch w.KeymanagerKind() {
 	case v2keymanager.Direct:

--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -32,7 +32,7 @@ func CreateWallet(cliCtx *cli.Context) error {
 		if err = createDirectKeymanagerWallet(cliCtx, w); err != nil {
 			return errors.Wrap(err, "could not initialize wallet with direct keymanager")
 		}
-		log.WithField("wallet-dir", w.accountsPath).Infof(
+		log.WithField("wallet-path", w.accountsPath).Infof(
 			"Successfully created wallet with on-disk keymanager configuration. " +
 				"Make a new validator account with ./prysm.sh validator accounts-v2 create",
 		)
@@ -40,7 +40,7 @@ func CreateWallet(cliCtx *cli.Context) error {
 		if err = createDerivedKeymanagerWallet(cliCtx, w); err != nil {
 			return errors.Wrap(err, "could not initialize wallet with derived keymanager")
 		}
-		log.WithField("wallet-dir", w.accountsPath).Infof(
+		log.WithField("wallet-path", w.accountsPath).Infof(
 			"Successfully created HD wallet and saved configuration to disk. " +
 				"Make a new validator account with ./prysm.sh validator accounts-2 create",
 		)

--- a/validator/accounts/v2/wallet_recover.go
+++ b/validator/accounts/v2/wallet_recover.go
@@ -69,7 +69,7 @@ func inputMnemonic(cliCtx *cli.Context) (string, error) {
 		return enteredMnemonic, nil
 	}
 	prompt := promptui.Prompt{
-		Label:    "Enter the wallet recovery seed phrase you would like to recover",
+		Label:    "Enter the seed phrase for the wallet you would like to recover",
 		Validate: validateMnemonic,
 	}
 	menmonicPhrase, err := prompt.Run()

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -136,7 +136,7 @@ var (
 	// PasswordFileFlag is used to enter a file to get a password for new account creation, non-interactively.
 	PasswordFileFlag = &cli.StringFlag{
 		Name:  "password-file",
-		Usage: "Path to a file containing a password in text to interact with wallets/accounts in a non-interactive way",
+		Usage: "Path to a plaintext password.txt file",
 	}
 	// MnemonicFileFlag is used to enter a file to mnemonic phrase for new wallet creation, non-interactively.
 	MnemonicFileFlag = &cli.StringFlag{

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -136,7 +136,7 @@ var (
 	// PasswordFileFlag is used to enter a file to get a password for new account creation, non-interactively.
 	PasswordFileFlag = &cli.StringFlag{
 		Name:  "password-file",
-		Usage: "Path to a file containing a password to interact with wallets/accounts in a non-interactive way",
+		Usage: "Path to a file containing a password in text to interact with wallets/accounts in a non-interactive way",
 	}
 	// MnemonicFileFlag is used to enter a file to mnemonic phrase for new wallet creation, non-interactively.
 	MnemonicFileFlag = &cli.StringFlag{

--- a/validator/keymanager/v2/derived/derived.go
+++ b/validator/keymanager/v2/derived/derived.go
@@ -211,9 +211,10 @@ func SeedFileFromMnemonic(ctx context.Context, mnemonic string, password string)
 	walletSeed, err := bip39.EntropyFromMnemonic(mnemonic)
 	if err != nil && strings.Contains(err.Error(), "not found in reverse map") {
 		return nil, errors.New("could not convert mnemonic to wallet seed: invalid seed word entered")
-	}
-	if errors.Is(err, bip39.ErrInvalidMnemonic) {
+	} else if errors.Is(err, bip39.ErrInvalidMnemonic) {
 		return nil, errors.Wrap(bip39.ErrInvalidMnemonic, "could not convert mnemonic to wallet seed")
+	} else if err != nil {
+		return nil, errors.Wrap(err, "could not convert mnemonic to wallet seed")
 	}
 	encryptor := keystorev4.New()
 	cryptoFields, err := encryptor.Encrypt(walletSeed, []byte(password))

--- a/validator/keymanager/v2/derived/derived.go
+++ b/validator/keymanager/v2/derived/derived.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -208,8 +209,11 @@ func InitializeWalletSeedFile(ctx context.Context, password string, skipMnemonic
 // appropriate seed file for recovering a derived wallets.
 func SeedFileFromMnemonic(ctx context.Context, mnemonic string, password string) (*SeedConfig, error) {
 	walletSeed, err := bip39.EntropyFromMnemonic(mnemonic)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not convert mnemonic to wallet seed")
+	if err != nil && strings.Contains(err.Error(), "not found in reverse map") {
+		return nil, errors.New("could not convert mnemonic to wallet seed: invalid seed word entered")
+	}
+	if errors.Is(err, bip39.ErrInvalidMnemonic) {
+		return nil, errors.Wrap(bip39.ErrInvalidMnemonic, "could not convert mnemonic to wallet seed")
 	}
 	encryptor := keystorev4.New()
 	cryptoFields, err := encryptor.Encrypt(walletSeed, []byte(password))

--- a/validator/keymanager/v2/derived/mnemonic.go
+++ b/validator/keymanager/v2/derived/mnemonic.go
@@ -2,6 +2,7 @@ package derived
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/manifoldco/promptui"
 	"github.com/tyler-smith/go-bip39"
@@ -55,7 +56,7 @@ func (m *EnglishMnemonicGenerator) ConfirmAcknowledgement(phrase string) error {
 	expected := "y"
 	var result string
 	var err error
-	for result != expected {
+	for strings.ToLower(result) != expected {
 		result, err = prompt.Run()
 		if err != nil {
 			log.Errorf("Could not confirm acknowledgement of prompt, please enter y")

--- a/validator/main.go
+++ b/validator/main.go
@@ -72,6 +72,7 @@ var appFlags = []cli.Flag{
 	flags.SlasherRPCProviderFlag,
 	flags.SlasherCertFlag,
 	flags.WalletPasswordsDirFlag,
+	flags.PasswordFileFlag,
 	flags.WalletDirFlag,
 	cmd.MinimalConfigFlag,
 	cmd.E2EConfigFlag,

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
-	"path"
 	"strings"
 	"sync"
 	"syscall"
@@ -83,14 +82,6 @@ func NewValidatorClient(cliCtx *cli.Context) (*ValidatorClient, error) {
 	var keyManagerV1 v1.KeyManager
 	var keyManagerV2 v2.IKeymanager
 	if featureconfig.Get().EnableAccountsV2 {
-		walletDir := cliCtx.String(flags.WalletDirFlag.Name)
-		if walletDir == flags.DefaultValidatorDir() {
-			walletDir = path.Join(walletDir, accountsv2.WalletDefaultDirName)
-		}
-		passwordsDir := cliCtx.String(flags.WalletPasswordsDirFlag.Name)
-		if passwordsDir == flags.DefaultValidatorDir() {
-			passwordsDir = path.Join(passwordsDir, accountsv2.PasswordsDefaultDirName)
-		}
 		// Read the wallet from the specified path.
 		wallet, err := accountsv2.OpenWallet(cliCtx)
 		if err != nil {

--- a/validator/usage.go
+++ b/validator/usage.go
@@ -83,6 +83,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.KeyManagerOpts,
 			flags.KeystorePathFlag,
 			flags.PasswordFlag,
+			flags.PasswordFileFlag,
 			flags.DisablePenaltyRewardLogFlag,
 			flags.UnencryptedKeysFlag,
 			flags.GraffitiFlag,


### PR DESCRIPTION
**What type of PR is this?**
Bug fix and cleanup

**What does this PR do? Why is it needed?**
Part of #6723, this solves some of the issues reported by rkapka. Issues includes:
--skip-mnemonic-confirm being on `accounts-v2 create help`
--password-file flag not being allowed in runtime
Allowing "y" or "Y" for prompt confirmation entry.
Cleaning up errors for invalid words entered for mnemonics, or just entirely invalid mnemonics
Fixing formatting of accounts list from derived vs. non-hd
Solves some formatting and test issues for logs 
Adds an error if you try to import non-HD accounts into a HD wallet 

Also fixes a bug with password file entry