### PR TITLE
Account for Bad Blocks in Gossip

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -40,6 +40,8 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks1(t *testing.T) {
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 	}
+	err := r.initCaches()
+	require.NoError(t, err)
 
 	b0 := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{}}
 	require.NoError(t, r.db.SaveBlock(context.Background(), b0))
@@ -109,6 +111,8 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks2(t *testing.T) {
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 	}
+	err := r.initCaches()
+	require.NoError(t, err)
 	p1.Peers().Add(new(enr.Record), p2.PeerID(), nil, network.DirOutbound)
 	p1.Peers().SetConnectionState(p2.PeerID(), peers.PeerConnected)
 	p1.Peers().SetChainState(p2.PeerID(), &pb.Status{})
@@ -181,6 +185,8 @@ func TestRegularSyncBeaconBlockSubscriber_PruneOldPendingBlocks(t *testing.T) {
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 	}
+	err := r.initCaches()
+	require.NoError(t, err)
 	p1.Peers().Add(new(enr.Record), p1.PeerID(), nil, network.DirOutbound)
 	p1.Peers().SetConnectionState(p1.PeerID(), peers.PeerConnected)
 	p1.Peers().SetChainState(p1.PeerID(), &pb.Status{})

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -39,6 +39,7 @@ const seenAttSize = 10000
 const seenExitSize = 100
 const seenAttesterSlashingSize = 100
 const seenProposerSlashingSize = 100
+const badBlockSize = 1000
 
 const syncMetricsInterval = 10 * time.Second
 
@@ -103,6 +104,8 @@ type Service struct {
 	seenProposerSlashingCache *lru.Cache
 	seenAttesterSlashingLock  sync.RWMutex
 	seenAttesterSlashingCache *lru.Cache
+	badBlockCache             *lru.Cache
+	badBlockLock              sync.RWMutex
 	stateSummaryCache         *cache.StateSummaryCache
 	stateGen                  *stategen.State
 }
@@ -209,11 +212,16 @@ func (s *Service) initCaches() error {
 	if err != nil {
 		return err
 	}
+	badBlockCache, err := lru.New(badBlockSize)
+	if err != nil {
+		return err
+	}
 	s.seenBlockCache = blkCache
 	s.seenAttestationCache = attCache
 	s.seenExitCache = exitCache
 	s.seenAttesterSlashingCache = attesterSlashingCache
 	s.seenProposerSlashingCache = proposerSlashingCache
+	s.badBlockCache = badBlockCache
 
 	return nil
 }

--- a/beacon-chain/sync/subscriber_beacon_attestation_test.go
+++ b/beacon-chain/sync/subscriber_beacon_attestation_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestService_committeeIndexBeaconAttestationSubscriber_ValidMessage(t *testing.T) {
-	t.Skip("Temporarily disabled, fixed in v0.12 branch.")
 
 	p := p2ptest.NewTestP2P(t)
 	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{DisableDynamicCommitteeSubnets: true})
@@ -64,6 +63,8 @@ func TestService_committeeIndexBeaconAttestationSubscriber_ValidMessage(t *testi
 		seenAttestationCache: c,
 		stateSummaryCache:    cache.NewStateSummaryCache(),
 	}
+	err = r.initCaches()
+	require.NoError(t, err)
 	p.Digest, err = r.forkDigest()
 	require.NoError(t, err)
 	r.registerSubscribers()

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -32,6 +32,7 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 
 	if err := s.chain.ReceiveBlock(ctx, signed, root); err != nil {
 		interop.WriteBlockToDisk(signed, true /*failed*/)
+		s.setBadBlock(root)
 		return err
 	}
 

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -54,6 +54,10 @@ func (s *Service) validateAggregateAndProof(ctx context.Context, pid peer.ID, ms
 	if s.hasSeenAggregatorIndexEpoch(m.Message.Aggregate.Data.Target.Epoch, m.Message.AggregatorIndex) {
 		return pubsub.ValidationIgnore
 	}
+	// Check that the block being voted on isn't invalid.
+	if s.hasBadBlock(bytesutil.ToBytes32(m.Message.Aggregate.Data.BeaconBlockRoot)) {
+		return pubsub.ValidationReject
+	}
 
 	// Verify aggregate attestation has not already been seen via aggregate gossip, within a block, or through the creation locally.
 	seen, err := s.attPool.HasAggregatedAttestation(m.Message.Aggregate)

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -55,7 +55,8 @@ func (s *Service) validateAggregateAndProof(ctx context.Context, pid peer.ID, ms
 		return pubsub.ValidationIgnore
 	}
 	// Check that the block being voted on isn't invalid.
-	if s.hasBadBlock(bytesutil.ToBytes32(m.Message.Aggregate.Data.BeaconBlockRoot)) {
+	if s.hasBadBlock(bytesutil.ToBytes32(m.Message.Aggregate.Data.BeaconBlockRoot)) ||
+		s.hasBadBlock(bytesutil.ToBytes32(m.Message.Aggregate.Data.Target.Root)) {
 		return pubsub.ValidationReject
 	}
 

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -56,7 +56,8 @@ func (s *Service) validateAggregateAndProof(ctx context.Context, pid peer.ID, ms
 	}
 	// Check that the block being voted on isn't invalid.
 	if s.hasBadBlock(bytesutil.ToBytes32(m.Message.Aggregate.Data.BeaconBlockRoot)) ||
-		s.hasBadBlock(bytesutil.ToBytes32(m.Message.Aggregate.Data.Target.Root)) {
+		s.hasBadBlock(bytesutil.ToBytes32(m.Message.Aggregate.Data.Target.Root)) ||
+		s.hasBadBlock(bytesutil.ToBytes32(m.Message.Aggregate.Data.Source.Root)) {
 		return pubsub.ValidationReject
 	}
 

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -68,7 +68,9 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		return pubsub.ValidationIgnore
 	}
 	// Reject an attestation if it references an invalid block.
-	if s.hasBadBlock(bytesutil.ToBytes32(att.Data.BeaconBlockRoot)) || s.hasBadBlock(bytesutil.ToBytes32(att.Data.Target.Root)) {
+	if s.hasBadBlock(bytesutil.ToBytes32(att.Data.BeaconBlockRoot)) ||
+		s.hasBadBlock(bytesutil.ToBytes32(att.Data.Target.Root)) ||
+		s.hasBadBlock(bytesutil.ToBytes32(att.Data.Source.Root)) {
 		return pubsub.ValidationReject
 	}
 

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -67,6 +67,10 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 	if s.hasSeenCommitteeIndicesSlot(att.Data.Slot, att.Data.CommitteeIndex, att.AggregationBits) {
 		return pubsub.ValidationIgnore
 	}
+	// Reject an attestation if it references an invalid block.
+	if s.hasBadBlock(bytesutil.ToBytes32(att.Data.BeaconBlockRoot)) {
+		return pubsub.ValidationReject
+	}
 
 	// Verify the block being voted and the processed state is in DB and. The block should have passed validation if it's in the DB.
 	blockRoot := bytesutil.ToBytes32(att.Data.BeaconBlockRoot)

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -68,7 +68,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		return pubsub.ValidationIgnore
 	}
 	// Reject an attestation if it references an invalid block.
-	if s.hasBadBlock(bytesutil.ToBytes32(att.Data.BeaconBlockRoot)) {
+	if s.hasBadBlock(bytesutil.ToBytes32(att.Data.BeaconBlockRoot)) || s.hasBadBlock(bytesutil.ToBytes32(att.Data.Target.Root)) {
 		return pubsub.ValidationReject
 	}
 

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -52,6 +52,8 @@ func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 
 	c, err := lru.New(10)
 	require.NoError(t, err)
+	c2, err := lru.New(10)
+	require.NoError(t, err)
 	chainService := &mock.ChainService{Genesis: time.Now(),
 		FinalizedCheckPoint: &ethpb.Checkpoint{
 			Epoch: 0,
@@ -62,6 +64,7 @@ func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 		initialSync:    &mockSync.Sync{IsSyncing: false},
 		chain:          chainService,
 		seenBlockCache: c,
+		badBlockCache:  c2,
 		blockNotifier:  chainService.BlockNotifier(),
 	}
 
@@ -95,6 +98,8 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 
 	c, err := lru.New(10)
 	require.NoError(t, err)
+	c2, err := lru.New(10)
+	require.NoError(t, err)
 	chainService := &mock.ChainService{Genesis: time.Now()}
 	r := &Service{
 		db:                db,
@@ -102,6 +107,7 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 		initialSync:       &mockSync.Sync{IsSyncing: false},
 		chain:             chainService,
 		seenBlockCache:    c,
+		badBlockCache:     c2,
 		stateSummaryCache: cache.NewStateSummaryCache(),
 		blockNotifier:     chainService.BlockNotifier(),
 	}
@@ -159,6 +165,8 @@ func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
 
 	c, err := lru.New(10)
 	require.NoError(t, err)
+	c2, err := lru.New(10)
+	require.NoError(t, err)
 	stateGen := stategen.New(db, stateSummaryCache)
 	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
 		State: beaconState,
@@ -172,6 +180,7 @@ func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
 		chain:               chainService,
 		blockNotifier:       chainService.BlockNotifier(),
 		seenBlockCache:      c,
+		badBlockCache:       c2,
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 		stateSummaryCache:   stateSummaryCache,
@@ -233,6 +242,8 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 
 	c, err := lru.New(10)
 	require.NoError(t, err)
+	c2, err := lru.New(10)
+	require.NoError(t, err)
 	stateGen := stategen.New(db, stateSummaryCache)
 	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(blkSlot*params.BeaconConfig().SecondsPerSlot), 0),
 		State: beaconState,
@@ -246,6 +257,7 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 		chain:               chainService,
 		blockNotifier:       chainService.BlockNotifier(),
 		seenBlockCache:      c,
+		badBlockCache:       c2,
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 		stateSummaryCache:   stateSummaryCache,
@@ -327,6 +339,8 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 
 	c, err := lru.New(10)
 	require.NoError(t, err)
+	c2, err := lru.New(10)
+	require.NoError(t, err)
 	chainService := &mock.ChainService{Genesis: time.Now()}
 	r := &Service{
 		p2p:                 p,
@@ -335,6 +349,7 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 		chain:               chainService,
 		blockNotifier:       chainService.BlockNotifier(),
 		seenBlockCache:      c,
+		badBlockCache:       c2,
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 	}
@@ -373,6 +388,8 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
 	genesisTime := time.Now()
 	c, err := lru.New(10)
 	require.NoError(t, err)
+	c2, err := lru.New(10)
+	require.NoError(t, err)
 	chainService := &mock.ChainService{
 		Genesis: time.Unix(genesisTime.Unix()-1000, 0),
 		FinalizedCheckPoint: &ethpb.Checkpoint{
@@ -385,6 +402,7 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
 		chain:          chainService,
 		blockNotifier:  chainService.BlockNotifier(),
 		seenBlockCache: c,
+		badBlockCache:  c2,
 	}
 
 	buf := new(bytes.Buffer)
@@ -437,6 +455,8 @@ func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
 
 	c, err := lru.New(10)
 	require.NoError(t, err)
+	c2, err := lru.New(10)
+	require.NoError(t, err)
 	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
 		State: beaconState,
 		FinalizedCheckPoint: &ethpb.Checkpoint{
@@ -449,6 +469,7 @@ func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
 		chain:               chainService,
 		blockNotifier:       chainService.BlockNotifier(),
 		seenBlockCache:      c,
+		badBlockCache:       c2,
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 		stateSummaryCache:   cache.NewStateSummaryCache(),
@@ -486,6 +507,8 @@ func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
 		}}
 	c, err := lru.New(10)
 	require.NoError(t, err)
+	c2, err := lru.New(10)
+	require.NoError(t, err)
 	r := &Service{
 		db:             db,
 		p2p:            p,
@@ -493,6 +516,7 @@ func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
 		blockNotifier:  chain.BlockNotifier(),
 		attPool:        attestations.NewPool(),
 		seenBlockCache: c,
+		badBlockCache:  c2,
 		initialSync:    &mockSync.Sync{IsSyncing: false},
 	}
 
@@ -570,6 +594,8 @@ func TestValidateBeaconBlockPubSub_ParentNotFinalizedDescendant(t *testing.T) {
 
 	c, err := lru.New(10)
 	require.NoError(t, err)
+	c2, err := lru.New(10)
+	require.NoError(t, err)
 	stateGen := stategen.New(db, stateSummaryCache)
 	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
 		State: beaconState,
@@ -585,6 +611,7 @@ func TestValidateBeaconBlockPubSub_ParentNotFinalizedDescendant(t *testing.T) {
 		chain:               chainService,
 		blockNotifier:       chainService.BlockNotifier(),
 		seenBlockCache:      c,
+		badBlockCache:       c2,
 		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
 		seenPendingBlocks:   make(map[[32]byte]bool),
 		stateSummaryCache:   stateSummaryCache,
@@ -603,4 +630,110 @@ func TestValidateBeaconBlockPubSub_ParentNotFinalizedDescendant(t *testing.T) {
 	}
 	assert.Equal(t, pubsub.ValidationReject, r.validateBeaconBlockPubSub(ctx, "", m), "Wrong validation result returned")
 	testutil.AssertLogsContain(t, hook, "not part of finalized chain")
+}
+
+func TestValidateBeaconBlockPubSub_InvalidParentBlock(t *testing.T) {
+	db, stateSummaryCache := dbtest.SetupDB(t)
+	p := p2ptest.NewTestP2P(t)
+	ctx := context.Background()
+	beaconState, privKeys := testutil.DeterministicGenesisState(t, 100)
+	parentBlock := &ethpb.SignedBeaconBlock{
+		Block: &ethpb.BeaconBlock{
+			ProposerIndex: 0,
+			Slot:          0,
+		},
+	}
+	require.NoError(t, db.SaveBlock(ctx, parentBlock))
+	bRoot, err := stateutil.BlockRoot(parentBlock.Block)
+	require.NoError(t, err)
+	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))
+	require.NoError(t, db.SaveStateSummary(ctx, &pb.StateSummary{Root: bRoot[:]}))
+	copied := beaconState.Copy()
+	require.NoError(t, copied.SetSlot(1))
+	proposerIdx, err := helpers.BeaconProposerIndex(copied)
+	require.NoError(t, err)
+	msg := &ethpb.SignedBeaconBlock{
+		Block: &ethpb.BeaconBlock{
+			ProposerIndex: proposerIdx,
+			Slot:          1,
+			ParentRoot:    bRoot[:],
+		},
+	}
+
+	domain, err := helpers.Domain(beaconState.Fork(), 0, params.BeaconConfig().DomainBeaconProposer, beaconState.GenesisValidatorRoot())
+	require.NoError(t, err)
+	signingRoot, err := helpers.ComputeSigningRoot(msg.Block, domain)
+	require.NoError(t, err)
+	blockSig := privKeys[proposerIdx].Sign(signingRoot[:]).Marshal()
+	// Mutate Signature
+	copy(blockSig[:4], []byte{1, 2, 3, 4})
+	msg.Signature = blockSig
+
+	currBlockRoot, err := stateutil.BlockRoot(msg.Block)
+	require.NoError(t, err)
+
+	c, err := lru.New(10)
+	require.NoError(t, err)
+	c2, err := lru.New(10)
+	require.NoError(t, err)
+	stateGen := stategen.New(db, stateSummaryCache)
+	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),
+		State: beaconState,
+		FinalizedCheckPoint: &ethpb.Checkpoint{
+			Epoch: 0,
+		}}
+	r := &Service{
+		db:                  db,
+		p2p:                 p,
+		initialSync:         &mockSync.Sync{IsSyncing: false},
+		chain:               chainService,
+		blockNotifier:       chainService.BlockNotifier(),
+		seenBlockCache:      c,
+		badBlockCache:       c2,
+		slotToPendingBlocks: make(map[uint64]*ethpb.SignedBeaconBlock),
+		seenPendingBlocks:   make(map[[32]byte]bool),
+		stateSummaryCache:   stateSummaryCache,
+		stateGen:            stateGen,
+	}
+	buf := new(bytes.Buffer)
+	_, err = p.Encoding().EncodeGossip(buf, msg)
+	require.NoError(t, err)
+	m := &pubsub.Message{
+		Message: &pubsubpb.Message{
+			Data: buf.Bytes(),
+			TopicIDs: []string{
+				p2p.GossipTypeMapping[reflect.TypeOf(msg)],
+			},
+		},
+	}
+	result := r.validateBeaconBlockPubSub(ctx, "", m) == pubsub.ValidationAccept
+	assert.Equal(t, false, result)
+
+	require.NoError(t, copied.SetSlot(2))
+	proposerIdx, err = helpers.BeaconProposerIndex(copied)
+	require.NoError(t, err)
+
+	msg = &ethpb.SignedBeaconBlock{
+		Block: &ethpb.BeaconBlock{
+			ProposerIndex: proposerIdx,
+			Slot:          2,
+			ParentRoot:    currBlockRoot[:],
+		},
+	}
+
+	buf = new(bytes.Buffer)
+	_, err = p.Encoding().EncodeGossip(buf, msg)
+	require.NoError(t, err)
+	m = &pubsub.Message{
+		Message: &pubsubpb.Message{
+			Data: buf.Bytes(),
+			TopicIDs: []string{
+				p2p.GossipTypeMapping[reflect.TypeOf(msg)],
+			},
+		},
+	}
+
+	// Expect block with bad parent to fail too
+	result = r.validateBeaconBlockPubSub(ctx, "", m) == pubsub.ValidationAccept
+	assert.Equal(t, false, result)
 }


### PR DESCRIPTION
**What type of PR is this?**

Spec Update

**What does this PR do? Why is it needed?**

- [x] Add a bad block cache, to keep a record of all blocks which had invalid state transitions/signatures/etc. 
- [x] Reject blocks whose parent blocks are invalid.
- [x] Reject attestations whose voted block is invalid.
- [x] Reject Aggregate and Proof whose pointed block is invalid.
- [x] Add tests for all bad block checks.

**Which issues(s) does this PR fix?**

Part of #6716 and corresponding PR in the specs repo is
https://github.com/ethereum/eth2.0-specs/pull/1956

**Other notes for review**
