### PR TITLE
`saveHeadNoDB ` does not invalidate hot state cache

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -131,7 +131,7 @@ func (s *Service) saveHead(ctx context.Context, headRoot [32]byte) error {
 // This gets called to update canonical root mapping. It does not save head block
 // root in DB. With the inception of initial-sync-cache-state flag, it uses finalized
 // check point as anchors to resume sync therefore head is no longer needed to be saved on per slot basis.
-func (s *Service) saveHeadNoDB(ctx context.Context, b *ethpb.SignedBeaconBlock, r [32]byte) error {
+func (s *Service) saveHeadNoDB(ctx context.Context, b *ethpb.SignedBeaconBlock, r [32]byte, hs *state.BeaconState) error {
 	cachedHeadRoot, err := s.HeadRoot(ctx)
 	if err != nil {
 		return errors.Wrap(err, "could not get head root from cache")
@@ -144,16 +144,7 @@ func (s *Service) saveHeadNoDB(ctx context.Context, b *ethpb.SignedBeaconBlock, 
 		return errors.New("cannot save nil head block")
 	}
 
-	headState, err := s.stateGen.StateByRootInitialSync(ctx, r)
-	if err != nil {
-		return errors.Wrap(err, "could not retrieve head state in DB")
-	}
-	if headState == nil {
-		return errors.New("nil head state")
-	}
-
-	s.setHeadInitialSync(r, stateTrie.CopySignedBeaconBlock(b), headState)
-
+	s.setHeadInitialSync(r, stateTrie.CopySignedBeaconBlock(b), hs)
 	return nil
 }
 

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -84,13 +84,6 @@ func (s *Service) ReceiveBlockInitialSync(ctx context.Context, block *ethpb.Sign
 		return err
 	}
 
-	// Save the latest block as head in cache.
-	if err := s.saveHeadNoDB(ctx, blockCopy, blockRoot); err != nil {
-		err := errors.Wrap(err, "could not save head")
-		traceutil.AnnotateError(span, err)
-		return err
-	}
-
 	// Send notification of the processed block to the state feed.
 	s.stateNotifier.StateFeed().Send(&feed.Event{
 		Type: statefeed.BlockProcessed,
@@ -147,14 +140,6 @@ func (s *Service) ReceiveBlockBatch(ctx context.Context, blocks []*ethpb.SignedB
 
 		// Reports on blockCopy and fork choice metrics.
 		reportSlotMetrics(blockCopy.Block.Slot, s.headSlot(), s.CurrentSlot(), s.finalizedCheckpt)
-	}
-
-	lastBlk := blocks[len(blocks)-1]
-	lastRoot := blkRoots[len(blkRoots)-1]
-	if err := s.saveHeadNoDB(ctx, lastBlk, lastRoot); err != nil {
-		err := errors.Wrap(err, "could not save head")
-		traceutil.AnnotateError(span, err)
-		return err
 	}
 
 	return nil

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -300,7 +300,7 @@ func TestChainService_SaveHeadNoDB(t *testing.T) {
 	require.NoError(t, err)
 	newState := testutil.NewBeaconState()
 	require.NoError(t, s.stateGen.SaveState(ctx, r, newState))
-	require.NoError(t, s.saveHeadNoDB(ctx, b, r))
+	require.NoError(t, s.saveHeadNoDB(ctx, b, r, newState))
 
 	newB, err := s.beaconDB.HeadBlock(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
As stated in #6728, the pre-state retrieval is broken due to `saveHeadNoDB` invalidates the saved state.

1.) Process block 100
2.) Save state 100
3.) Request stategen for state 100 to cache head info, this invalidates caching of state 100 (PROBLEM)
4.) Receive block 101
5.) Request state 100 for pre state to process block 101, caching of state 100 no longer available. Replay blocks for state 100 

This PR changes to:
1.) Process block 100
2.) Save state 100
3.) Cache head info using **passed** state 100 instead of requesting from stategen
4.) Receive block 101
5.) Request state 100 for pre state to process block 101, caching of state 100 is not invalidated. Yay!

**Which issues(s) does this PR fix?**

Fixes #6728 

**Other notes for review**

Tested run time

![Screen Shot 2020-07-26 at 12 39 59 PM](https://user-images.githubusercontent.com/21316537/88490359-fbace700-cf4f-11ea-9346-83f6f3c725fb.png)
![Screen Shot 2020-07-26 at 12 40 08 PM](https://user-images.githubusercontent.com/21316537/88490360-fd76aa80-cf4f-11ea-9627-883d9042b7a7.png)

