### PR TITLE
Fixes issue with concurrent map writes in gossipsub

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -98,6 +98,7 @@ go_test(
         "gossip_topic_mappings_test.go",
         "options_test.go",
         "parameter_test.go",
+        "pubsub_test.go",
         "rpc_topic_mappings_test.go",
         "sender_test.go",
         "service_test.go",

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -11,6 +11,9 @@ import (
 
 // JoinTopic will join PubSub topic, if not already joined.
 func (s *Service) JoinTopic(topic string, opts ...pubsub.TopicOpt) (*pubsub.Topic, error) {
+	s.joinedTopicsLock.Lock()
+	defer s.joinedTopicsLock.Unlock()
+
 	if _, ok := s.joinedTopics[topic]; !ok {
 		topicHandle, err := s.pubsub.Join(topic, opts...)
 		if err != nil {
@@ -25,6 +28,9 @@ func (s *Service) JoinTopic(topic string, opts ...pubsub.TopicOpt) (*pubsub.Topi
 // LeaveTopic closes topic and removes corresponding handler from list of joined topics.
 // This method will return error if there are outstanding event handlers or subscriptions.
 func (s *Service) LeaveTopic(topic string) error {
+	s.joinedTopicsLock.Lock()
+	defer s.joinedTopicsLock.Unlock()
+
 	if t, ok := s.joinedTopics[topic]; ok {
 		if err := t.Close(); err != nil {
 			return err

--- a/beacon-chain/p2p/pubsub_test.go
+++ b/beacon-chain/p2p/pubsub_test.go
@@ -1,0 +1,28 @@
+package p2p
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestService_PublishToTopicConcurrentMapWrite(t *testing.T) {
+	s, err := NewService(&Config{})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wg := sync.WaitGroup{}
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go func(i int) {
+			assert.NoError(t, s.PublishToTopic(ctx, fmt.Sprintf("foo%v", i), []byte{}))
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+}

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -6,6 +6,7 @@ package p2p
 import (
 	"context"
 	"crypto/ecdsa"
+	"sync"
 	"time"
 
 	"github.com/dgraph-io/ristretto"
@@ -69,6 +70,7 @@ type Service struct {
 	metaData              *pb.MetaData
 	pubsub                *pubsub.PubSub
 	joinedTopics          map[string]*pubsub.Topic
+	joinedTopicsLock      sync.Mutex
 	dv5Listener           Listener
 	startupErr            error
 	stateNotifier         statefeed.Notifier


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- In `p2p/pubsub` access to the list of handlers for joined topics is not protected by mutex, while concurrent access is allowed. This results in the following failure:
![image](https://user-images.githubusercontent.com/188194/88492583-5710c080-cfb4-11ea-979b-30f02947e0bd.png)
- This PR puts the map behind the mutex.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
