### PR TITLE
Accounts-V2: Change accounts-v2 import to use directory of keystores

### DIFF
--- a/validator/accounts/v2/BUILD.bazel
+++ b/validator/accounts/v2/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/petnames:go_default_library",
+        "//shared/roughtime:go_default_library",
         "//shared/testutil:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
@@ -71,7 +72,9 @@ go_test(
         "//validator/keymanager/v2/direct:go_default_library",
         "//validator/keymanager/v2/remote:go_default_library",
         "@com_github_dustin_go_humanize//:go_default_library",
+        "@com_github_google_uuid//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
+        "@com_github_wealdtech_go_eth2_wallet_encryptor_keystorev4//:go_default_library",
     ],
 )

--- a/validator/accounts/v2/accounts_export_test.go
+++ b/validator/accounts/v2/accounts_export_test.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/testutil"
@@ -17,6 +16,7 @@ import (
 )
 
 func TestZipAndUnzip(t *testing.T) {
+	t.Skip("skipping until exporting is implemented")
 	walletDir, passwordsDir, _ := setupWalletAndPasswordsDir(t)
 	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	require.NoError(t, err, "Could not generate random file path")
@@ -56,15 +56,6 @@ func TestZipAndUnzip(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(exportDir, archiveFilename)); os.IsNotExist(err) {
 		t.Fatal("Expected file to exist")
-	}
-
-	importedAccounts := []string{}
-
-	allAccountsStr := strings.Join(accounts, " ")
-	for _, importedAccount := range importedAccounts {
-		if !strings.Contains(allAccountsStr, importedAccount) {
-			t.Fatalf("Expected %s to be in %s", importedAccount, allAccountsStr)
-		}
 	}
 }
 

--- a/validator/accounts/v2/accounts_export_test.go
+++ b/validator/accounts/v2/accounts_export_test.go
@@ -58,8 +58,7 @@ func TestZipAndUnzip(t *testing.T) {
 		t.Fatal("Expected file to exist")
 	}
 
-	importedAccounts, err := unzipArchiveToTarget(exportDir, importDir)
-	require.NoError(t, err)
+	importedAccounts := []string{}
 
 	allAccountsStr := strings.Join(accounts, " ")
 	for _, importedAccount := range importedAccounts {

--- a/validator/accounts/v2/accounts_import.go
+++ b/validator/accounts/v2/accounts_import.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
 	"github.com/logrusorgru/aurora"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared/petnames"

--- a/validator/accounts/v2/accounts_import.go
+++ b/validator/accounts/v2/accounts_import.go
@@ -29,7 +29,7 @@ func ImportAccount(cliCtx *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	keysDir, err := inputDirectory(cliCtx, keysDirPromptText, flags.KeysDirFlag)
+	keysDir, err := inputDirectory(cliCtx, importKeysDirPromptText, flags.KeysDirFlag)
 	if err != nil {
 		return errors.Wrap(err, "could not parse keys directory")
 	}

--- a/validator/accounts/v2/accounts_import.go
+++ b/validator/accounts/v2/accounts_import.go
@@ -31,7 +31,7 @@ func ImportAccount(cliCtx *cli.Context) error {
 	}
 	keysDir, err := inputDirectory(cliCtx, keysDirPromptText, flags.KeysDirFlag)
 	if err != nil {
-		return errors.Wrap(err, "could not parse output directory")
+		return errors.Wrap(err, "could not parse keys directory")
 	}
 
 	accountsPath := filepath.Join(walletDir, v2keymanager.Direct.String())

--- a/validator/accounts/v2/accounts_import.go
+++ b/validator/accounts/v2/accounts_import.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -107,7 +108,11 @@ func (w *Wallet) importKeystore(ctx context.Context, keystoreFilePath string) (s
 	if err := json.Unmarshal(keystoreBytes, keystoreFile); err != nil {
 		return "", errors.Wrap(err, "could not decode keystore json")
 	}
-	accountName := petnames.DeterministicName([]byte(keystoreFile.Pubkey), "-")
+	pubKeyBytes, err := hex.DecodeString(keystoreFile.Pubkey)
+	if err != nil {
+		return "", errors.Wrap(err, "could not decode public key string in keystore")
+	}
+	accountName := petnames.DeterministicName(pubKeyBytes, "-")
 	keystoreFileName := filepath.Base(keystoreFilePath)
 	if err := w.WriteFileAtPath(ctx, accountName, keystoreFileName, keystoreBytes); err != nil {
 		return "", errors.Wrap(err, "could not write keystore to account dir")

--- a/validator/accounts/v2/accounts_import_test.go
+++ b/validator/accounts/v2/accounts_import_test.go
@@ -3,40 +3,40 @@ package v2
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/roughtime"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 	v2keymanager "github.com/prysmaticlabs/prysm/validator/keymanager/v2"
 	"github.com/prysmaticlabs/prysm/validator/keymanager/v2/direct"
+	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
 )
 
 func TestImport_Noninteractive(t *testing.T) {
-	walletDir, passwordsDir, _ := setupWalletAndPasswordsDir(t)
+	walletDir, passwordsDir, passwordFilePath := setupWalletAndPasswordsDir(t)
 	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
 	require.NoError(t, err, "Could not generate random file path")
-	exportDir := filepath.Join(testutil.TempDir(), fmt.Sprintf("/%d", randPath), "export")
-	importDir := filepath.Join(testutil.TempDir(), fmt.Sprintf("/%d", randPath), "import")
-	importPasswordDir := filepath.Join(testutil.TempDir(), fmt.Sprintf("/%d", randPath), "importpassword")
+	keysDir := filepath.Join(testutil.TempDir(), fmt.Sprintf("/%d", randPath), "keysDir")
+	require.NoError(t, os.MkdirAll(keysDir, os.ModePerm))
 	t.Cleanup(func() {
-		require.NoError(t, os.RemoveAll(exportDir), "Failed to remove directory")
-		require.NoError(t, os.RemoveAll(importDir), "Failed to remove directory")
-		require.NoError(t, os.RemoveAll(importPasswordDir), "Failed to remove directory")
+		require.NoError(t, os.RemoveAll(keysDir), "Failed to remove directory")
 	})
-	require.NoError(t, os.MkdirAll(importPasswordDir, os.ModePerm))
-	passwordFilePath := filepath.Join(importPasswordDir, passwordFileName)
-	require.NoError(t, ioutil.WriteFile(passwordFilePath, []byte(password), os.ModePerm))
 
 	cliCtx := setupWalletCtx(t, &testWalletConfig{
 		walletDir:      walletDir,
 		passwordsDir:   passwordsDir,
-		exportDir:      exportDir,
+		keysDir:        keysDir,
 		keymanagerKind: v2keymanager.Direct,
 		passwordFile:   passwordFilePath,
 	})
@@ -54,19 +54,17 @@ func TestImport_Noninteractive(t *testing.T) {
 		keymanagerCfg,
 	)
 	require.NoError(t, err)
-	_, err = keymanager.CreateAccount(ctx, password)
-	require.NoError(t, err)
 
+	// Make sure there are no accounts at the start.
 	accounts, err := keymanager.ValidatingAccountNames()
 	require.NoError(t, err)
-	assert.Equal(t, len(accounts), 1)
+	assert.Equal(t, len(accounts), 0)
 
-	require.NoError(t, wallet.zipAccounts(accounts, exportDir))
-	if _, err := os.Stat(filepath.Join(exportDir, archiveFilename)); os.IsNotExist(err) {
-		t.Fatal("Expected file to exist")
-	}
+	// Create 2 keys.
+	createKeystore(t, keysDir)
+	time.Sleep(time.Second)
+	createKeystore(t, keysDir)
 
-	require.NoError(t, os.RemoveAll(walletDir), "Failed to remove directory")
 	require.NoError(t, ImportAccount(cliCtx))
 
 	wallet, err = OpenWallet(cliCtx)
@@ -76,5 +74,27 @@ func TestImport_Noninteractive(t *testing.T) {
 	keys, err := km.FetchValidatingPublicKeys(ctx)
 	require.NoError(t, err)
 
-	assert.Equal(t, len(keys), 1)
+	assert.Equal(t, 2, len(keys))
+}
+
+func createKeystore(t *testing.T, path string) {
+	validatingKey := bls.RandKey()
+	encryptor := keystorev4.New()
+	cryptoFields, err := encryptor.Encrypt(validatingKey.Marshal(), []byte(password))
+	require.NoError(t, err)
+	id, err := uuid.NewRandom()
+	require.NoError(t, err)
+	keystoreFile := &v2keymanager.Keystore{
+		Crypto:  cryptoFields,
+		ID:      id.String(),
+		Pubkey:  fmt.Sprintf("%x", validatingKey.PublicKey().Marshal()),
+		Version: encryptor.Version(),
+		Name:    encryptor.Name(),
+	}
+	encoded, err := json.MarshalIndent(keystoreFile, "", "\t")
+	require.NoError(t, err)
+	// Write the encoded keystore to disk with the timestamp appended
+	createdAt := roughtime.Now().Unix()
+	fullPath := filepath.Join(path, fmt.Sprintf(direct.KeystoreFileNameFormat, createdAt))
+	require.NoError(t, ioutil.WriteFile(fullPath, encoded, os.ModePerm))
 }

--- a/validator/accounts/v2/cmd_accounts.go
+++ b/validator/accounts/v2/cmd_accounts.go
@@ -76,7 +76,7 @@ this command outputs a deposit data string which is required to become a validat
 			Flags: []cli.Flag{
 				flags.WalletDirFlag,
 				flags.WalletPasswordsDirFlag,
-				flags.BackupDirFlag,
+				flags.KeysDirFlag,
 				flags.PasswordFileFlag,
 				featureconfig.AltonaTestnet,
 				featureconfig.MedallaTestnet,

--- a/validator/accounts/v2/prompt.go
+++ b/validator/accounts/v2/prompt.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	importDirPromptText          = "Enter the file location of the exported wallet zip to import"
-	keysDirPromptText            = "Enter the directory where your saved "
+	importKeysDirPromptText      = "Enter the directory where your keystores to import are located"
 	exportDirPromptText          = "Enter a file location to write the exported wallet to"
 	walletDirPromptText          = "Enter a wallet directory"
 	passwordsDirPromptText       = "Directory where passwords will be stored"

--- a/validator/accounts/v2/prompt.go
+++ b/validator/accounts/v2/prompt.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	importDirPromptText          = "Enter the file location of the exported wallet zip to import"
+	keysDirPromptText            = "Enter the directory where your saved "
 	exportDirPromptText          = "Enter a file location to write the exported wallet to"
 	walletDirPromptText          = "Enter a wallet directory"
 	passwordsDirPromptText       = "Directory where passwords will be stored"

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -399,7 +399,7 @@ func (w *Wallet) enterPasswordForAccount(cliCtx *cli.Context, accountName string
 		// Loop asking for the password until the user enters it correctly.
 		for attemptingPassword {
 			// Ask the user for the password to their account.
-			password, err = inputPassword(cliCtx, fmt.Sprintf(passwordForAccountPromptText, accountName), noConfirmPass)
+			password, err = inputWeakPassword(cliCtx, fmt.Sprintf(passwordForAccountPromptText, accountName))
 			if err != nil {
 				return errors.Wrap(err, "could not input password")
 			}

--- a/validator/accounts/v2/wallet_test.go
+++ b/validator/accounts/v2/wallet_test.go
@@ -31,6 +31,7 @@ type testWalletConfig struct {
 	walletDir        string
 	passwordsDir     string
 	exportDir        string
+	keysDir          string
 	accountsToExport string
 	passwordFile     string
 	numAccounts      int64
@@ -45,6 +46,7 @@ func setupWalletCtx(
 	set := flag.NewFlagSet("test", 0)
 	set.String(flags.WalletDirFlag.Name, cfg.walletDir, "")
 	set.String(flags.WalletPasswordsDirFlag.Name, cfg.passwordsDir, "")
+	set.String(flags.KeysDirFlag.Name, cfg.keysDir, "")
 	set.String(flags.KeymanagerKindFlag.Name, cfg.keymanagerKind.String(), "")
 	set.String(flags.BackupDirFlag.Name, cfg.exportDir, "")
 	set.String(flags.AccountsFlag.Name, cfg.accountsToExport, "")
@@ -53,6 +55,7 @@ func setupWalletCtx(
 	set.Int64(flags.NumAccountsFlag.Name, cfg.numAccounts, "")
 	assert.NoError(tb, set.Set(flags.WalletDirFlag.Name, cfg.walletDir))
 	assert.NoError(tb, set.Set(flags.WalletPasswordsDirFlag.Name, cfg.passwordsDir))
+	assert.NoError(tb, set.Set(flags.KeysDirFlag.Name, cfg.keysDir))
 	assert.NoError(tb, set.Set(flags.KeymanagerKindFlag.Name, cfg.keymanagerKind.String()))
 	assert.NoError(tb, set.Set(flags.BackupDirFlag.Name, cfg.exportDir))
 	assert.NoError(tb, set.Set(flags.AccountsFlag.Name, cfg.accountsToExport))

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -175,7 +175,6 @@ var (
 	KeysDirFlag = &cli.StringFlag{
 		Name:  "keys-dir",
 		Usage: "Path to a directory where keystores to be imported are stored",
-		Value: DefaultValidatorDir(),
 	}
 	// GrpcRemoteAddressFlag defines the host:port address for a remote keymanager to connect to.
 	GrpcRemoteAddressFlag = &cli.StringFlag{

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -171,6 +171,12 @@ var (
 		Usage: "Path to a directory where accounts will be exported into a zip file",
 		Value: DefaultValidatorDir(),
 	}
+	// KeysDirFlag defines the path for a directory where keystores to be imported at stored.
+	KeysDirFlag = &cli.StringFlag{
+		Name:  "keys-dir",
+		Usage: "Path to a directory where keystores to be imported are stored",
+		Value: DefaultValidatorDir(),
+	}
 	// GrpcRemoteAddressFlag defines the host:port address for a remote keymanager to connect to.
 	GrpcRemoteAddressFlag = &cli.StringFlag{
 		Name:  "grpc-remote-address",


### PR DESCRIPTION
**What type of PR is this?**
Accounts V2 Feature 

**What does this PR do? Why is it needed?**
This PR changes `accounts-v2 import` to take in a `--keys-dir`, which is a folder containing keystore files. 