### PR TITLE
Return 503 on healthz with error

### DIFF
--- a/shared/prometheus/service_test.go
+++ b/shared/prometheus/service_test.go
@@ -94,7 +94,7 @@ func TestHealthz(t *testing.T) {
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	if status := rr.Code; status != http.StatusOK {
+	if status := rr.Code; status != http.StatusServiceUnavailable {
 		t.Errorf("expected OK status but got %v", rr.Code)
 	}
 

--- a/shared/prometheus/service_test.go
+++ b/shared/prometheus/service_test.go
@@ -185,5 +185,8 @@ func TestContentNegotiation(t *testing.T) {
 		if !strings.Contains(body, expectedJSON) {
 			t.Errorf("Unexpected data, want: %q got %q", expectedJSON, body)
 		}
+		if rr.Code < 500 {
+			t.Errorf("Expected a server error response code, but got %d", rr.Code)
+		}
 	})
 }

--- a/shared/prometheus/service_test.go
+++ b/shared/prometheus/service_test.go
@@ -95,7 +95,7 @@ func TestHealthz(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 
 	if status := rr.Code; status != http.StatusServiceUnavailable {
-		t.Errorf("expected OK status but got %v", rr.Code)
+		t.Errorf("expected StatusServiceUnavailable status but got %v", rr.Code)
 	}
 
 	body = rr.Body.String()


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The healthz must return an error HTTP status code.

**Which issues(s) does this PR fix?**

Fixes a regression from #5558

**Other notes for review**

For this, I have chosen 503 since that indicates that the server is not ready to serve requests. 