### PR TITLE
Remove Deprecated SSZ Decode Edge Case for BeaconBlocksByRoots

### DIFF
--- a/beacon-chain/p2p/encoder/ssz.go
+++ b/beacon-chain/p2p/encoder/ssz.go
@@ -82,19 +82,7 @@ func (e SszNetworkEncoder) doDecode(b []byte, to interface{}) error {
 	if v, ok := to.(fastssz.Unmarshaler); ok {
 		return v.UnmarshalSSZ(b)
 	}
-	err := ssz.Unmarshal(b, to)
-	if err != nil {
-		// Check if we are unmarshalling block roots
-		// and then lop off the 4 byte offset and try
-		// unmarshalling again. This is temporary to
-		// avoid too much disruption to onyx nodes.
-		// TODO(#6408)
-		if _, ok := to.(*[][32]byte); ok {
-			return ssz.Unmarshal(b[4:], to)
-		}
-		return err
-	}
-	return nil
+	return ssz.Unmarshal(b, to)
 }
 
 // DecodeGossip decodes the bytes to the protobuf gossip message provided.

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -147,10 +147,8 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 
 			req := [][32]byte{bRoot}
 			if err := s.sendRecentBeaconBlocksRequest(ctx, req, pid); err != nil && err == io.EOF {
-				if err = s.sendRecentBeaconBlocksRequestFallback(ctx, req, pid); err != nil {
-					traceutil.AnnotateError(span, err)
-					log.Errorf("Could not send recent block request: %v", err)
-				}
+				traceutil.AnnotateError(span, err)
+				log.Errorf("Could not send recent block request: %v", err)
 			}
 		}
 	}

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -117,10 +117,8 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 			}
 
 			if err := s.sendRecentBeaconBlocksRequest(ctx, req, pid); err != nil {
-				if err = s.sendRecentBeaconBlocksRequestFallback(ctx, req, pid); err != nil {
-					traceutil.AnnotateError(span, err)
-					log.Errorf("Could not send recent block request: %v", err)
-				}
+				traceutil.AnnotateError(span, err)
+				log.Errorf("Could not send recent block request: %v", err)
 			}
 			span.End()
 			continue

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -6,12 +6,10 @@ import (
 
 	libp2pcore "github.com/libp2p/go-libp2p-core"
 	"github.com/libp2p/go-libp2p-core/helpers"
-	"github.com/libp2p/go-libp2p-core/mux"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
-	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
@@ -36,54 +34,6 @@ func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 		// Return error until #6408 is resolved.
 		if err == io.EOF {
 			return err
-		}
-		// Exit if peer sends more than max request blocks.
-		if uint64(i) >= params.BeaconNetworkConfig().MaxRequestBlocks {
-			break
-		}
-		if err != nil {
-			log.WithError(err).Error("Unable to retrieve block from stream")
-			return err
-		}
-
-		blkRoot, err := stateutil.BlockRoot(blk.Block)
-		if err != nil {
-			return err
-		}
-		s.pendingQueueLock.Lock()
-		s.slotToPendingBlocks[blk.Block.Slot] = blk
-		s.seenPendingBlocks[blkRoot] = true
-		s.pendingQueueLock.Unlock()
-
-	}
-	return nil
-}
-
-// Deprecated: sendRecentBeaconBlocksRequestFallback sends a recent beacon blocks request to a peer to get
-// those corresponding blocks from that peer. This is a method implemented so that we are eventually
-// backward compatible with old Onyx nodes.
-// TODO(#6408)
-func (s *Service) sendRecentBeaconBlocksRequestFallback(ctx context.Context, blockRoots [][32]byte, id peer.ID) error {
-	ctx, cancel := context.WithTimeout(ctx, respTimeout)
-	defer cancel()
-	req := &pbp2p.BeaconBlocksByRootRequest{}
-	for _, root := range blockRoots {
-		req.BlockRoots = append(req.BlockRoots, root[:])
-	}
-	stream, err := s.p2p.Send(ctx, req, p2p.RPCBlocksByRootTopic, id)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := helpers.FullClose(stream); err != nil && err.Error() != mux.ErrReset.Error() {
-			log.WithError(err).Debugf("Failed to reset stream with protocol %s", stream.Protocol())
-		}
-	}()
-	for i := 0; i < len(blockRoots); i++ {
-		isFirstChunk := i == 0
-		blk, err := ReadChunkedBlock(stream, s.p2p, isFirstChunk)
-		if err == io.EOF {
-			break
 		}
 		// Exit if peer sends more than max request blocks.
 		if uint64(i) >= params.BeaconNetworkConfig().MaxRequestBlocks {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -31,9 +31,8 @@ func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 	for i := 0; i < len(blockRoots); i++ {
 		isFirstChunk := i == 0
 		blk, err := ReadChunkedBlock(stream, s.p2p, isFirstChunk)
-		// Return error until #6408 is resolved.
 		if err == io.EOF {
-			return err
+			break
 		}
 		// Exit if peer sends more than max request blocks.
 		if uint64(i) >= params.BeaconNetworkConfig().MaxRequestBlocks {


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

This PR removes the deprecated fallback which existed in our codebase for compatibility with Onyx and Altona testnets:

```
// Check if we are unmarshalling block roots
// and then lop off the 4 byte offset and try
// unmarshalling again. This is temporary to
// avoid too much disruption to onyx nodes.
// TODO(#6408)
if _, ok := to.(*[][32]byte); ok {
       return ssz.Unmarshal(b[4:], to)
}
```
As this was not properly checking if the input had a length of at least 4 before decoding. This piece of code is no longer needed.
