### PR TITLE
Allow spaces in keystore account passwords

### DIFF
--- a/shared/promptutil/validate.go
+++ b/shared/promptutil/validate.go
@@ -51,7 +51,8 @@ func IsValidUnicode(input string) bool {
 		if !(unicode.IsLetter(char) ||
 			unicode.IsNumber(char) ||
 			unicode.IsPunct(char) ||
-			unicode.IsSymbol(char)) {
+			unicode.IsSymbol(char) ||
+			unicode.IsSpace(char)) {
 			return false
 		}
 	}
@@ -73,7 +74,11 @@ func ValidatePasswordInput(input string) error {
 	}
 	for _, char := range input {
 		switch {
-		case !(unicode.IsLetter(char) || unicode.IsNumber(char) || unicode.IsPunct(char) || unicode.IsSymbol(char)):
+		case !(unicode.IsSpace(char) ||
+			unicode.IsLetter(char) ||
+			unicode.IsNumber(char) ||
+			unicode.IsPunct(char) ||
+			unicode.IsSymbol(char)):
 			return errors.New("password must only contain alphanumeric characters, punctuation, or symbols")
 		case unicode.IsLetter(char):
 			hasLetter = true

--- a/shared/promptutil/validate_test.go
+++ b/shared/promptutil/validate_test.go
@@ -34,9 +34,9 @@ func TestValidatePasswordInput(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "Unicode strings separated by a space character",
+			name:    "allow spaces",
 			input:   "x*329293@aAJSD i22903saj",
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -62,7 +62,7 @@ func TestIsValidUnicode(t *testing.T) {
 		{
 			name:  "Unicode strings separated by a space character",
 			input: "x*329293@aAJSD i22903saj",
-			want:  false,
+			want:  true,
 		},
 		{
 			name:  "Japanese",


### PR DESCRIPTION
Currently, accounts-v2 does not allow passwords with spaces, but the eth2.0-deposit-cli does. This fixes the discrepancy for users by allowing spaces in our passwords.