### PR TITLE
Fix Accounts List Show Deposit Data When Coming From Eth2.0 Deposit CLI

### DIFF
--- a/validator/accounts/v2/accounts_list.go
+++ b/validator/accounts/v2/accounts_list.go
@@ -110,7 +110,12 @@ func listDirectKeymanagerAccounts(
 		}
 		enc, err := wallet.ReadFileAtPath(ctx, accountNames[i], direct.DepositDataFileName)
 		if err != nil {
-			return errors.Wrapf(err, "could not read file for account: %s", direct.DepositDataFileName)
+			fmt.Printf(
+				"%s\n",
+				au.BrightRed("If you imported your account coming from the eth2 launchpad, you will find your "+
+					"deposit_data.json in the eth2.0-deposit-cli's validator_keys folder"),
+			)
+			continue
 		}
 		fmt.Printf(
 			"%s %s\n",


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**


> Bug fix

**What does this PR do? Why is it needed?**

When users import their accounts from the eth2.0 deposit cli, Prysm does not have access to their deposit data, so we should display a nice message if the user runs accounts-v2 list --show-deposit-data.

```
Account 7 | ghastly-top-narwhal | Created 16 minutes ago
[validating public key] 0xa77747e96475d26a750218c...
If you imported your account from the eth2 launchpad, you will find your deposit_data.json in the eth2.0-deposit-cli's validator_keys folder
```

**Which issues(s) does this PR fix?**

Fixes #6806
