### PR TITLE
Accounts V2: Allow for user to specify single file rather than directory for keystore import

### DIFF
--- a/validator/accounts/v2/accounts_import_test.go
+++ b/validator/accounts/v2/accounts_import_test.go
@@ -79,7 +79,59 @@ func TestImport_Noninteractive(t *testing.T) {
 	assert.Equal(t, 2, len(keys))
 }
 
-func createKeystore(t *testing.T, path string) {
+func TestImport_Noninteractive_Filepath(t *testing.T) {
+	walletDir, passwordsDir, passwordFilePath := setupWalletAndPasswordsDir(t)
+	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	require.NoError(t, err, "Could not generate random file path")
+	keysDir := filepath.Join(testutil.TempDir(), fmt.Sprintf("/%d", randPath), "keysDir")
+	require.NoError(t, os.MkdirAll(keysDir, os.ModePerm))
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(keysDir), "Failed to remove directory")
+	})
+
+	cliCtx := setupWalletCtx(t, &testWalletConfig{
+		walletDir:           walletDir,
+		passwordsDir:        passwordsDir,
+		keysDir:             createKeystore(t, keysDir), // Using direct filepath to the new keystore.
+		keymanagerKind:      v2keymanager.Direct,
+		walletPasswordFile:  passwordFilePath,
+		accountPasswordFile: passwordFilePath,
+	})
+	wallet, err := NewWallet(cliCtx, v2keymanager.Direct)
+	require.NoError(t, err)
+	require.NoError(t, wallet.SaveWallet())
+	ctx := context.Background()
+	keymanagerCfg := direct.DefaultConfig()
+	keymanagerCfg.AccountPasswordsDirectory = passwordsDir
+	encodedCfg, err := direct.MarshalConfigFile(ctx, keymanagerCfg)
+	require.NoError(t, err)
+	require.NoError(t, wallet.WriteKeymanagerConfigToDisk(ctx, encodedCfg))
+	keymanager, err := direct.NewKeymanager(
+		ctx,
+		wallet,
+		keymanagerCfg,
+	)
+	require.NoError(t, err)
+
+	// Make sure there are no accounts at the start.
+	accounts, err := keymanager.ValidatingAccountNames()
+	require.NoError(t, err)
+	assert.Equal(t, len(accounts), 0)
+
+	require.NoError(t, ImportAccount(cliCtx))
+
+	wallet, err = OpenWallet(cliCtx)
+	require.NoError(t, err)
+	km, err := wallet.InitializeKeymanager(ctx, true)
+	require.NoError(t, err)
+	keys, err := km.FetchValidatingPublicKeys(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(keys))
+}
+
+// Returns the fullPath to the newly created keystore file.
+func createKeystore(t *testing.T, path string) string {
 	validatingKey := bls.RandKey()
 	encryptor := keystorev4.New()
 	cryptoFields, err := encryptor.Encrypt(validatingKey.Marshal(), password)
@@ -99,4 +151,5 @@ func createKeystore(t *testing.T, path string) {
 	createdAt := roughtime.Now().Unix()
 	fullPath := filepath.Join(path, fmt.Sprintf(direct.KeystoreFileNameFormat, createdAt))
 	require.NoError(t, ioutil.WriteFile(fullPath, encoded, os.ModePerm))
+	return fullPath
 }

--- a/validator/accounts/v2/prompt.go
+++ b/validator/accounts/v2/prompt.go
@@ -27,7 +27,7 @@ const (
 	confirmPasswordPromptText    = "Confirm password"
 	walletPasswordPromptText     = "Wallet password"
 	newAccountPasswordPromptText = "New account password"
-	passwordForAccountPromptText = "Enter password for account with public key %s"
+	passwordForAccountPromptText = "Enter password for account with public key %#x"
 )
 
 type passwordConfirm int

--- a/validator/accounts/v2/prompt.go
+++ b/validator/accounts/v2/prompt.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	importKeysDirPromptText      = "Enter the directory where your keystores to import are located"
+	importKeysDirPromptText      = "Enter the directory or filepath where your keystores to import are located"
 	exportDirPromptText          = "Enter a file location to write the exported account(s) to"
 	walletDirPromptText          = "Enter a wallet directory"
 	passwordsDirPromptText       = "Directory where passwords will be stored"


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

As title describes, I tried to put the full path to the keystore I wanted to enter, but the CLI requires a directory. So I have adapted the code to allow for either a directory or a single file for importing.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

Tested once at runtime.
