### PR TITLE
Accounts V2: improve progressbar feedback

### DIFF
--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -505,6 +505,8 @@ func (w *Wallet) enterPasswordForAllAccounts(cliCtx *cli.Context, accountNames [
 				BarStart:      "[",
 				BarEnd:        "]",
 			}),
+			progressbar.OptionOnCompletion(func() {fmt.Println()}),
+			progressbar.OptionSetDescription("Importing accounts"),
 		)
 		ctx := context.Background()
 		for i := 0; i < len(accountNames); i++ {

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -505,7 +505,7 @@ func (w *Wallet) enterPasswordForAllAccounts(cliCtx *cli.Context, accountNames [
 				BarStart:      "[",
 				BarEnd:        "]",
 			}),
-			progressbar.OptionOnCompletion(func() {fmt.Println()}),
+			progressbar.OptionOnCompletion(func() { fmt.Println() }),
 			progressbar.OptionSetDescription("Importing accounts"),
 		)
 		ctx := context.Background()

--- a/validator/keymanager/v2/direct/direct.go
+++ b/validator/keymanager/v2/direct/direct.go
@@ -421,7 +421,7 @@ func initializeProgressBar(numItems int) *progressbar.ProgressBar {
 			BarStart:      "[",
 			BarEnd:        "]",
 		}),
-		progressbar.OptionOnCompletion(func() {fmt.Println()}),
+		progressbar.OptionOnCompletion(func() { fmt.Println() }),
 		progressbar.OptionSetDescription("Loading validator accounts"),
 	)
 }

--- a/validator/keymanager/v2/direct/direct.go
+++ b/validator/keymanager/v2/direct/direct.go
@@ -303,7 +303,6 @@ func (dr *Keymanager) initializeSecretKeysCache(ctx context.Context) error {
 	if len(accountNames) == 0 {
 		return nil
 	}
-	log.Info("Decrypting validator accounts...")
 	// We initialize a nice progress bar to offer the user feedback
 	// during this slow operation.
 	bar := initializeProgressBar(len(accountNames))
@@ -422,6 +421,8 @@ func initializeProgressBar(numItems int) *progressbar.ProgressBar {
 			BarStart:      "[",
 			BarEnd:        "]",
 		}),
+		progressbar.OptionOnCompletion(func() {fmt.Println()}),
+		progressbar.OptionSetDescription("Loading validator accounts"),
 	)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This is a minor improvement on the logging of progress bars.

Before this PR, there was no new line after the progress bar and the next log message appeared on the same line.

```
[2020-07-31 12:53:09]  INFO node: Starting validator node version=Prysm/{STABLE_GIT_TAG}/ca2c0f9844143d24b743f8bd2663125d176bda52. Built at: 2020-07-31T12:53:09-07:00
 100% [===============================================================]  [0s:0s][2020-07-31 12:53:09]  WARN validator: You are using an insecure gRPC connection. If you are running your beacon node and validator on the same machines, you can ignore this message. If you want to know how to enable secure connections, see: https://docs.prylabs.network/docs/prysm-usage/secure-grpc
[2020-07-31 12:53:09]  INFO validator: Waiting for beacon chain start log from the ETH 1.0 deposit contract
```

Now it looks more like this
```
[2020-07-31 13:02:52]  INFO accounts-v2: (wallet path) /home/preston/.eth2validators/prysm-wallet-v2
[2020-07-31 13:02:52]  INFO accounts-v2: (wallet directory) /home/preston/.eth2validators/prysm-wallet-v2
[2020-07-31 13:02:52]  INFO accounts-v2: (account passwords path) /home/preston/.eth2validators/prysm-wallet-v2-passwords
[2020-07-31 13:02:52]  INFO accounts-v2: Successfully opened wallet
[2020-07-31 13:02:53]  INFO node: Validating for public key pubKey=0x91322467339f
[2020-07-31 13:02:53]  INFO node: Checking DB databasePath=/home/preston/.eth2
Loading validator accounts 100% [=====================================]  [0s:0s]
[2020-07-31 13:02:53]  INFO node: Starting validator node version=Prysm/{STABLE_GIT_TAG}/ca2c0f9844143d24b743f8bd2663125d176bda52. Built at: 2020-07-31T13:02:52-07:00
[2020-07-31 13:02:53]  WARN validator: You are using an insecure gRPC connection. If you are running your beacon node and validator on the same machines, you can ignore this message. If you want to know how to enable secure connections, see: https://docs.prylabs.network/docs/prysm-usage/secure-grpc
[2020-07-31 13:02:53]  INFO validator: Waiting for beacon chain start log from the ETH 1.0 deposit contract
```

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
