### PR TITLE
Accounts-V2: Fix “wallet can only have 1 directory” error

### DIFF
--- a/validator/accounts/v2/accounts_import.go
+++ b/validator/accounts/v2/accounts_import.go
@@ -31,7 +31,7 @@ func ImportAccount(cliCtx *cli.Context) error {
 			return nil, errors.Wrap(err, "could not create new wallet")
 		}
 		if err = createDirectKeymanagerWallet(cliCtx, w); err != nil {
-			return nil, errors.Wrap(err, "could not initialize wallet")
+			return nil, errors.Wrap(err, "could not create direct keyamanger wallet")
 		}
 		log.WithField("wallet-path", w.walletDir).Info(
 			"Successfully created new wallet",


### PR DESCRIPTION
**What type of PR is this?**
Accounts-V2 bug fix

**What does this PR do? Why is it needed?**
This PR fixes the error preventing users from creating wallets in non-empty directories.

