### PR TITLE
Accounts V2: Allow user to override password-dir set in the wallet config

### DIFF
--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -179,7 +179,7 @@ func OpenWallet(cliCtx *cli.Context) (*Wallet, error) {
 		// the wallet's configuration then log a warning to the user.
 		// See https://github.com/prysmaticlabs/prysm/issues/6794.
 		if cliCtx.IsSet(flags.WalletPasswordsDirFlag.Name) && cliCtx.String(flags.WalletPasswordsDirFlag.Name) != w.passwordsDir {
-			log.Warnf("The provided value for --%s does not match the wallet configuration. " +
+			log.Warnf("The provided value for --%s does not match the wallet configuration. "+
 				"Please edit your wallet password directory using wallet-v2 edit-config.",
 				flags.WalletPasswordsDirFlag.Name,
 			)

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -177,6 +177,16 @@ func OpenWallet(cliCtx *cli.Context) (*Wallet, error) {
 		w.passwordsDir = directCfg.AccountPasswordsDirectory
 		au := aurora.NewAurora(true)
 		log.Infof("%s %s", au.BrightMagenta("(account passwords path)"), w.passwordsDir)
+
+		// If the user provided a flag and for the password directory, and that value does not match
+		// the wallet's configuration then log a warning to the user.
+		// See https://github.com/prysmaticlabs/prysm/issues/6794.
+		if cliCtx.IsSet(flags.WalletPasswordsDirFlag.Name) && cliCtx.String(flags.WalletPasswordsDirFlag.Name) != w.passwordsDir {
+			log.Warnf("The provided value for --%s does not match the wallet configuration. " +
+				"Please edit your wallet password directory using wallet-v2 edit-config!",
+				flags.WalletPasswordsDirFlag.Name,
+			)
+		}
 	}
 	log.Info("Successfully opened wallet")
 	return w, nil

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -175,18 +175,18 @@ func OpenWallet(cliCtx *cli.Context) (*Wallet, error) {
 			return nil, err
 		}
 		w.passwordsDir = directCfg.AccountPasswordsDirectory
-		au := aurora.NewAurora(true)
-		log.Infof("%s %s", au.BrightMagenta("(account passwords path)"), w.passwordsDir)
-
 		// If the user provided a flag and for the password directory, and that value does not match
 		// the wallet's configuration then log a warning to the user.
 		// See https://github.com/prysmaticlabs/prysm/issues/6794.
 		if cliCtx.IsSet(flags.WalletPasswordsDirFlag.Name) && cliCtx.String(flags.WalletPasswordsDirFlag.Name) != w.passwordsDir {
 			log.Warnf("The provided value for --%s does not match the wallet configuration. " +
-				"Please edit your wallet password directory using wallet-v2 edit-config!",
+				"Please edit your wallet password directory using wallet-v2 edit-config.",
 				flags.WalletPasswordsDirFlag.Name,
 			)
+			w.passwordsDir = cliCtx.String(flags.WalletPasswordsDirFlag.Name) // Override config value.
 		}
+		au := aurora.NewAurora(true)
+		log.Infof("%s %s", au.BrightMagenta("(account passwords path)"), w.passwordsDir)
 	}
 	log.Info("Successfully opened wallet")
 	return w, nil


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

As title describes. This feature will log a warning to the user suggesting that they edit the config and will override the config value at runtime as the user desires.

**Which issues(s) does this PR fix?**

Fixes #6794

**Other notes for review**
