### PR TITLE
Fix empty wallet check

### DIFF
--- a/validator/accounts/v2/BUILD.bazel
+++ b/validator/accounts/v2/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "//proto/validator/accounts/v2:go_default_library",
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
+        "//shared/params:go_default_library",
         "//shared/petnames:go_default_library",
         "//shared/roughtime:go_default_library",
         "//shared/testutil:go_default_library",

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -82,7 +82,7 @@ func NewWallet(
 		return nil, errors.Wrap(err, "could not check if wallet exists")
 	}
 	if walletExists {
-		isEmptyWallet, err := isEmptyDir(walletDir)
+		isEmptyWallet, err := isEmptyWallet(walletDir)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not check if wallet has files")
 		}
@@ -132,7 +132,7 @@ func OpenWallet(cliCtx *cli.Context) (*Wallet, error) {
 		return nil, errors.Wrap(err, "could not parse wallet directory")
 	}
 	if ok {
-		isEmptyWallet, err := isEmptyDir(walletDir)
+		isEmptyWallet, err := isEmptyWallet(walletDir)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not check if wallet has files")
 		}
@@ -621,7 +621,7 @@ func createOrOpenWallet(cliCtx *cli.Context, creationFunc func(cliCtx *cli.Conte
 		return nil, errors.Wrapf(err, "could not check if wallet dir %s exists", directory)
 	}
 	if ok {
-		isEmptyWallet, err := isEmptyDir(directory)
+		isEmptyWallet, err := isEmptyWallet(directory)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not check if wallet has files")
 		}
@@ -659,7 +659,9 @@ func hasDir(dirPath string) (bool, error) {
 	return info.IsDir(), err
 }
 
-func isEmptyDir(name string) (bool, error) {
+// isEmptyWallet checks if a folder consists key directory such as `derived`, `remote` or `direct`.
+// Returns true if exists, false otherwise.
+func isEmptyWallet(name string) (bool, error) {
 	f, err := os.Open(name)
 	if err != nil {
 		return false, err
@@ -669,9 +671,18 @@ func isEmptyDir(name string) (bool, error) {
 			log.Debugf("Could not close directory: %s", name)
 		}
 	}()
-	_, err = f.Readdirnames(1)
+	names, err := f.Readdirnames(-1)
 	if err == io.EOF {
 		return true, nil
 	}
-	return false, err // Either not empty or error, suits both cases
+
+	for _, n := range names {
+		// Nil error means input name is `derived`, `remote` or `direct`, the wallet is not empty.
+		_, err := v2keymanager.ParseKind(n)
+		if err == nil {
+			return false, nil
+		}
+	}
+
+	return true, err
 }

--- a/validator/accounts/v2/wallet_test.go
+++ b/validator/accounts/v2/wallet_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -138,4 +139,20 @@ func TestAccountTimestamp(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_IsEmptyWallet_RandomFiles(t *testing.T) {
+	path := testutil.TempDir()
+	walletDir := filepath.Join(path, "test")
+	require.NoError(t, os.MkdirAll(walletDir, params.BeaconIoConfig().ReadWriteExecutePermissions), "Failed to remove directory")
+	got, err := isEmptyWallet(path)
+	require.NoError(t, err)
+	assert.Equal(t, true, got)
+
+	walletDir = filepath.Join(path, "direct")
+	require.NoError(t, os.MkdirAll(walletDir, params.BeaconIoConfig().ReadWriteExecutePermissions), "Failed to remove directory")
+	got, err = isEmptyWallet(path)
+	require.NoError(t, err)
+	assert.Equal(t, false, got)
+	require.NoError(t, os.RemoveAll(walletDir), "Failed to remove directory")
 }


### PR DESCRIPTION
Fixes #6800

This considers where an empty wallet (folder) could be one with random files in it.

/wallet/hello_word.  <- wallet is empty

/wallet/derived. <- wallet is not empty