### PR TITLE
`Load` config after `Configure` config

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -91,11 +91,6 @@ func NewBeaconNode(cliCtx *cli.Context) (*BeaconNode, error) {
 		return nil, err
 	}
 
-	if cliCtx.IsSet(cmd.ChainConfigFileFlag.Name) {
-		chainConfigFileName := cliCtx.String(cmd.ChainConfigFileFlag.Name)
-		params.LoadChainConfigFile(chainConfigFileName)
-	}
-
 	if cliCtx.IsSet(flags.HistoricalSlasherNode.Name) {
 		c := params.BeaconConfig()
 		c.SlotsPerArchivedPoint = params.BeaconConfig().SlotsPerEpoch
@@ -114,6 +109,11 @@ func NewBeaconNode(cliCtx *cli.Context) (*BeaconNode, error) {
 	featureconfig.ConfigureBeaconChain(cliCtx)
 	cmd.ConfigureBeaconChain(cliCtx)
 	flags.ConfigureGlobalFlags(cliCtx)
+
+	if cliCtx.IsSet(cmd.ChainConfigFileFlag.Name) {
+		chainConfigFileName := cliCtx.String(cmd.ChainConfigFileFlag.Name)
+		params.LoadChainConfigFile(chainConfigFileName)
+	}
 
 	// Setting chain network specific flags.
 	if cliCtx.IsSet(flags.DepositContractFlag.Name) {

--- a/validator/main.go
+++ b/validator/main.go
@@ -128,11 +128,12 @@ contract in order to activate the validator client`,
 							cmd.ChainConfigFileFlag,
 						}...),
 					Action: func(cliCtx *cli.Context) error {
+						featureconfig.ConfigureValidator(cliCtx)
+
 						if cliCtx.IsSet(cmd.ChainConfigFileFlag.Name) {
 							chainConfigFileName := cliCtx.String(cmd.ChainConfigFileFlag.Name)
 							params.LoadChainConfigFile(chainConfigFileName)
 						}
-						featureconfig.ConfigureValidator(cliCtx)
 
 						keystorePath, passphrase, err := v1.HandleEmptyKeystoreFlags(cliCtx, true /*confirmPassword*/)
 						if err != nil {

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -71,13 +71,13 @@ func NewValidatorClient(cliCtx *cli.Context) (*ValidatorClient, error) {
 		stop:     make(chan struct{}),
 	}
 
+	featureconfig.ConfigureValidator(cliCtx)
+	cmd.ConfigureValidator(cliCtx)
+
 	if cliCtx.IsSet(cmd.ChainConfigFileFlag.Name) {
 		chainConfigFileName := cliCtx.String(cmd.ChainConfigFileFlag.Name)
 		params.LoadChainConfigFile(chainConfigFileName)
 	}
-
-	featureconfig.ConfigureValidator(cliCtx)
-	cmd.ConfigureValidator(cliCtx)
 
 	var keyManagerV1 v1.KeyManager
 	var keyManagerV2 v2.IKeymanager


### PR DESCRIPTION
Fixes #6820

This ensures that loaded config does not get over written by moving `LoadChainConfigFile` after `ConfigureBeaconChain` 