### PR TITLE
Fix RPC metadata

### DIFF
--- a/beacon-chain/p2p/sender.go
+++ b/beacon-chain/p2p/sender.go
@@ -30,21 +30,19 @@ func (s *Service) Send(ctx context.Context, message interface{}, baseTopic strin
 		traceutil.AnnotateError(span, err)
 		return nil, err
 	}
+	defer func() {
+		// Close stream for writing.
+		if err := stream.Close(); err != nil {
+			traceutil.AnnotateError(span, err)
+		}
+	}()
 	// do not encode anything if we are sending a metadata request
 	if baseTopic == RPCMetaDataTopic {
 		return stream, nil
 	}
-
 	if _, err := s.Encoding().EncodeWithMaxLength(stream, message); err != nil {
 		traceutil.AnnotateError(span, err)
 		return nil, err
 	}
-
-	// Close stream for writing.
-	if err := stream.Close(); err != nil {
-		traceutil.AnnotateError(span, err)
-		return nil, err
-	}
-
 	return stream, nil
 }

--- a/beacon-chain/sync/rpc_metadata.go
+++ b/beacon-chain/sync/rpc_metadata.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"time"
 
 	libp2pcore "github.com/libp2p/go-libp2p-core"
 	"github.com/libp2p/go-libp2p-core/helpers"
@@ -9,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/roughtime"
 )
 
 // metaDataHandler reads the incoming metadata rpc request from the peer.
@@ -43,11 +43,7 @@ func (s *Service) sendMetaDataRequest(ctx context.Context, id peer.ID) (*pb.Meta
 	if err != nil {
 		return nil, err
 	}
-	// Spec: The requesting side must close the stream for writes immediately after sending.
-	if err := stream.Close(); err != nil {
-		return nil, err
-	}
-	if err := stream.SetDeadline(roughtime.Now().Add(helpers.EOFTimeout)); err != nil {
+	if err := stream.SetDeadline(time.Now().Add(helpers.EOFTimeout)); err != nil {
 		return nil, err
 	}
 	code, errMsg, err := ReadStatusCode(stream, s.p2p.Encoding())

--- a/beacon-chain/sync/rpc_metadata.go
+++ b/beacon-chain/sync/rpc_metadata.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"context"
-	"time"
 
 	libp2pcore "github.com/libp2p/go-libp2p-core"
 	"github.com/libp2p/go-libp2p-core/helpers"
@@ -43,9 +42,7 @@ func (s *Service) sendMetaDataRequest(ctx context.Context, id peer.ID) (*pb.Meta
 	if err != nil {
 		return nil, err
 	}
-	if err := stream.SetDeadline(time.Now().Add(helpers.EOFTimeout)); err != nil {
-		return nil, err
-	}
+	SetStreamReadDeadline(stream, helpers.EOFTimeout)
 	code, errMsg, err := ReadStatusCode(stream, s.p2p.Encoding())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Two issues:
- Spec requires that the sender immediately close their stream for writes after sending the metadata.
- helpers.AwaitEOF would error and reset the stream if any response other than EOF was returned, so I removed that and set the deadline manually.

**Which issues(s) does this PR fix?**

Fixes #6837

**Other notes for review**

Tested briefly at runtime for medalla. I observed less debug level errors about i/o deadline reached for metadata RPC.
