### PR TITLE
Use Less Intensive Search

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/iputils:go_default_library",
+        "//shared/mathutil:go_default_library",
         "//shared/p2putils:go_default_library",
         "//shared/params:go_default_library",
         "//shared/roughtime:go_default_library",

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -31,6 +31,7 @@ type Listener interface {
 	Ping(*enode.Node) error
 	RequestENR(*enode.Node) (*enode.Node, error)
 	LocalNode() *enode.LocalNode
+	AllNodes() []*enode.Node
 }
 
 // RefreshENR uses an epoch to refresh the enr entry for our node
@@ -143,8 +144,10 @@ func (s *Service) createListener(
 		}
 	}
 	dv5Cfg := discover.Config{
-		PrivateKey: privKey,
+		PrivateKey:   privKey,
+		ValidSchemes: enode.ValidSchemes,
 	}
+
 	dv5Cfg.Bootnodes = []*enode.Node{}
 	for _, addr := range s.cfg.Discv5BootStrapAddr {
 		bootNode, err := enode.Parse(enode.ValidSchemes, addr)

--- a/beacon-chain/p2p/service_test.go
+++ b/beacon-chain/p2p/service_test.go
@@ -25,6 +25,10 @@ import (
 
 type mockListener struct{}
 
+func (mockListener) AllNodes() []*enode.Node {
+	panic("implement me")
+}
+
 func (mockListener) Self() *enode.Node {
 	panic("implement me")
 }

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -6,6 +6,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/prysmaticlabs/go-bitfield"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/mathutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
@@ -22,7 +23,12 @@ func (s *Service) FindPeersWithSubnet(index uint64) (bool, error) {
 		return false, nil
 	}
 	iterator := s.dv5Listener.RandomNodes()
-	nodes := enode.ReadNodes(iterator, lookupLimit)
+
+	// Select appropriate size for search.
+	maxSize := uint64(len(s.dv5Listener.AllNodes()))
+	min := int(mathutil.Min(maxSize, lookupLimit))
+
+	nodes := enode.ReadNodes(iterator, min)
 	exists := false
 	for _, node := range nodes {
 		if node.IP() == nil {


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

If a peer is connected to a very small number of nodes or zero, then this method will cause excessive CPU usage
and build up of memory.

To resolve this we look at the total size of the local table and then select a minimum between that and our lookup limit. So that 
we wont perform lookups for a very small number of peers.
 
**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
