### PR TITLE
Better Password Input Experience

### DIFF
--- a/shared/promptutil/validate.go
+++ b/shared/promptutil/validate.go
@@ -11,9 +11,9 @@ import (
 const (
 	// Constants for passwords.
 	minPasswordLength = 8
-	// Min password score of 3 out of 5 based on the https://github.com/nbutton23/zxcvbn-go
+	// Min password score of 2 out of 5 based on the https://github.com/nbutton23/zxcvbn-go
 	// library for strong-entropy password computation.
-	minPasswordScore = 3
+	minPasswordScore = 2
 )
 
 // NotEmpty is a validation function to make sure the input given isn't empty and is valid unicode.

--- a/validator/keymanager/v2/direct/import.go
+++ b/validator/keymanager/v2/direct/import.go
@@ -45,8 +45,10 @@ func (dr *Keymanager) ImportKeystores(cliCtx *cli.Context, keystores []*v2keyman
 		}
 	}
 	fmt.Println("Importing accounts, this may take a while...")
+	var privKeyBytes []byte
+	var pubKeyBytes []byte
 	for i := 0; i < len(keystores); i++ {
-		privKeyBytes, pubKeyBytes, err := dr.attemptDecryptKeystore(decryptor, keystores[i], password)
+		privKeyBytes, pubKeyBytes, password, err = dr.attemptDecryptKeystore(decryptor, keystores[i], password)
 		if err != nil {
 			return err
 		}
@@ -79,7 +81,7 @@ func (dr *Keymanager) ImportKeystores(cliCtx *cli.Context, keystores []*v2keyman
 // it prompts the user for the correct password until it confirms.
 func (dr *Keymanager) attemptDecryptKeystore(
 	enc *keystorev4.Encryptor, keystore *v2keymanager.Keystore, password string,
-) ([]byte, []byte, error) {
+) ([]byte, []byte, string, error) {
 	// Attempt to decrypt the keystore with the specifies password.
 	var privKeyBytes []byte
 	var err error
@@ -87,18 +89,18 @@ func (dr *Keymanager) attemptDecryptKeystore(
 	if err != nil && strings.Contains(err.Error(), "invalid checksum") {
 		// If the password fails for an individual account, we ask the user to input
 		// that individual account's password until it succeeds.
-		privKeyBytes, err = dr.askUntilPasswordConfirms(enc, keystore)
+		privKeyBytes, password, err = dr.askUntilPasswordConfirms(enc, keystore)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "could not confirm password via prompt")
+			return nil, nil, "", errors.Wrap(err, "could not confirm password via prompt")
 		}
 	} else if err != nil {
-		return nil, nil, errors.Wrap(err, "could not decrypt keystore")
+		return nil, nil, "", errors.Wrap(err, "could not decrypt keystore")
 	}
 	pubKeyBytes, err := hex.DecodeString(keystore.Pubkey)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not decode pubkey from keystore")
+		return nil, nil, "", errors.Wrap(err, "could not decode pubkey from keystore")
 	}
-	return privKeyBytes, pubKeyBytes, nil
+	return privKeyBytes, pubKeyBytes, password, nil
 }
 
 func initializeProgressBar(numItems int, msg string) *progressbar.ProgressBar {


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Currently, during the account import process, if a single password fails to confirm, we prompt the user to input it once more. However, this makes us re-prompt for every single following password which makes for a choppy user experience. Additionally, the strong entropy password check is too strong, with many users complaining their typical 'strong passwords' are not making the cut.