### PR TITLE
Add Back Displaying Deposit Data + Misc Bugs

### DIFF
--- a/validator/accounts/v2/accounts_list.go
+++ b/validator/accounts/v2/accounts_list.go
@@ -115,10 +115,6 @@ func listDerivedKeymanagerAccounts(
 	keymanager *derived.Keymanager,
 ) error {
 	au := aurora.NewAurora(true)
-	fmt.Println(
-		au.BrightRed("View the eth1 deposit transaction data for your accounts " +
-			"by running `validator accounts-v2 list --show-deposit-data"),
-	)
 	fmt.Printf("(keymanager kind) %s\n", au.BrightGreen("derived, (HD) hierarchical-deterministic").Bold())
 	fmt.Printf("(derivation format) %s\n", au.BrightGreen(keymanager.Config().DerivedPathStructure).Bold())
 	ctx := context.Background()
@@ -169,7 +165,7 @@ func listDerivedKeymanagerAccounts(
 			return errors.Wrapf(err, "could not deposit data for account: %s", accountNames[i])
 		}
 		fmt.Printf(`
-======================SSZ Deposit Data=====================
+======================Eth1 Deposit Transaction Data=====================
 
 %#x
 

--- a/validator/accounts/v2/prompt.go
+++ b/validator/accounts/v2/prompt.go
@@ -22,7 +22,7 @@ const (
 	importKeysDirPromptText      = "Enter the directory or filepath where your keystores to import are located"
 	exportDirPromptText          = "Enter a file location to write the exported account(s) to"
 	walletDirPromptText          = "Enter a wallet directory"
-	passwordsDirPromptText       = "Directory where passwords will be stored"
+	passwordsDirPromptText       = "Directory where your account passwords are"
 	newWalletPasswordPromptText  = "New wallet password"
 	confirmPasswordPromptText    = "Confirm password"
 	walletPasswordPromptText     = "Wallet password"

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -189,6 +189,13 @@ func OpenWallet(cliCtx *cli.Context) (*Wallet, error) {
 				validateExistingPass,
 			)
 		} else {
+			passwordsDir, err := inputDirectory(cliCtx, passwordsDirPromptText, flags.WalletPasswordsDirFlag)
+			if err != nil {
+				return nil, err
+			}
+			w.passwordsDir = passwordsDir
+			au := aurora.NewAurora(true)
+			log.Infof("%s %s", au.BrightMagenta("(account passwords path)"), w.passwordsDir)
 			fmt.Println("\nWe have revamped how imported accounts work, improving speed significantly for your " +
 				"validators as well as reducing memory and CPU requirements. This unifies all your existing accounts " +
 				"into a single format protected by a strong password. You'll need to set a new password for this " +
@@ -205,35 +212,6 @@ func OpenWallet(cliCtx *cli.Context) (*Wallet, error) {
 			return nil, err
 		}
 		w.walletPassword = walletPassword
-	}
-	if keymanagerKind == v2keymanager.Direct && !hasNewFormat {
-		keymanagerCfg, err := w.ReadKeymanagerConfigFromDisk(context.Background())
-		if err != nil {
-			return nil, err
-		}
-		directCfg, err := direct.UnmarshalConfigFile(keymanagerCfg)
-		if err != nil {
-			return nil, err
-		}
-		w.passwordsDir = directCfg.AccountPasswordsDirectory
-		// If the user provided a flag and for the password directory, and that value does not match
-		// the wallet's configuration then log a warning to the user.
-		// See https://github.com/prysmaticlabs/prysm/issues/6794.
-		if cliCtx.IsSet(flags.WalletPasswordsDirFlag.Name) &&
-			cliCtx.String(flags.WalletPasswordsDirFlag.Name) != w.passwordsDir {
-			log.Warnf("The provided value for --%s does not match the wallet configuration. "+
-				"Please edit your wallet password directory using wallet-v2 edit-config.",
-				flags.WalletPasswordsDirFlag.Name,
-			)
-			w.passwordsDir = cliCtx.String(flags.WalletPasswordsDirFlag.Name) // Override config value.
-		}
-		passwordsPath, err := expandPath(w.passwordsDir)
-		if err != nil {
-			return nil, err
-		}
-		w.passwordsDir = passwordsPath
-		au := aurora.NewAurora(true)
-		log.Infof("%s %s", au.BrightMagenta("(account passwords path)"), w.passwordsDir)
 	}
 	return w, nil
 }
@@ -671,10 +649,13 @@ func readKeymanagerKindFromWalletPath(walletPath string) (v2keymanager.Kind, err
 	if err != nil {
 		return 0, fmt.Errorf("could not read files in directory: %s", walletPath)
 	}
-	if len(list) != 1 {
-		return 0, fmt.Errorf("wanted 1 directory in wallet dir, received %d", len(list))
+	for _, n := range list {
+		keymanagerKind, err := v2keymanager.ParseKind(n)
+		if err == nil {
+			return keymanagerKind, nil
+		}
 	}
-	return v2keymanager.ParseKind(list[0])
+	return 0, errors.New("no keymanager folder, 'direct', 'remote', nor 'derived' found in wallet path")
 }
 
 func createOrOpenWallet(cliCtx *cli.Context, creationFunc func(cliCtx *cli.Context) (*Wallet, error)) (*Wallet, error) {
@@ -725,13 +706,17 @@ func hasDir(dirPath string) (bool, error) {
 // isEmptyWallet checks if a folder consists key directory such as `derived`, `remote` or `direct`.
 // Returns true if exists, false otherwise.
 func isEmptyWallet(name string) (bool, error) {
-	f, err := os.Open(name)
+	expanded, err := expandPath(name)
+	if err != nil {
+		return false, err
+	}
+	f, err := os.Open(expanded)
 	if err != nil {
 		return false, err
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
-			log.Debugf("Could not close directory: %s", name)
+			log.Debugf("Could not close directory: %s", expanded)
 		}
 	}()
 	names, err := f.Readdirnames(-1)

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -153,7 +153,26 @@ func OpenWallet(cliCtx *cli.Context) (*Wallet, error) {
 		return nil, errors.Wrap(err, "could not read wallet dir")
 	}
 	log.Infof("%s %s", au.BrightMagenta("(wallet directory)"), w.walletDir)
-	if keymanagerKind == v2keymanager.Derived || keymanagerKind == v2keymanager.Direct {
+	if keymanagerKind == v2keymanager.Derived {
+		validateExistingPass := func(input string) error {
+			if input == "" {
+				return errors.New("password input cannot be empty")
+			}
+			return nil
+		}
+		walletPassword, err := inputPassword(
+			cliCtx,
+			flags.WalletPasswordFileFlag,
+			walletPasswordPromptText,
+			noConfirmPass,
+			validateExistingPass,
+		)
+		if err != nil {
+			return nil, err
+		}
+		w.walletPassword = walletPassword
+	}
+	if keymanagerKind == v2keymanager.Direct {
 		var walletPassword string
 		if hasNewFormat {
 			validateExistingPass := func(input string) error {

--- a/validator/keymanager/v2/derived/BUILD.bazel
+++ b/validator/keymanager/v2/derived/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//validator/accounts/v2/iface:go_default_library",
         "@com_github_google_uuid//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
-        "@com_github_prysmaticlabs_go_ssz//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_tyler_smith_go_bip39//:go_default_library",
         "@com_github_wealdtech_go_eth2_util//:go_default_library",

--- a/validator/keymanager/v2/derived/derived.go
+++ b/validator/keymanager/v2/derived/derived.go
@@ -365,7 +365,7 @@ func (dr *Keymanager) FetchWithdrawalPublicKeys(ctx context.Context) ([][48]byte
 	return publicKeys, nil
 }
 
-// DepositDataForAccount with a given index returns and ssz-encoded deposit data object.
+// DepositDataForAccount with a given index returns the RLP encoded eth1 deposit transaction data.
 func (dr *Keymanager) DepositDataForAccount(accountIndex uint64) ([]byte, error) {
 	withdrawalKeyPath := fmt.Sprintf(WithdrawalKeyDerivationPathTemplate, accountIndex)
 	validatingKeyPath := fmt.Sprintf(ValidatingKeyDerivationPathTemplate, accountIndex)
@@ -388,11 +388,11 @@ func (dr *Keymanager) DepositDataForAccount(accountIndex uint64) ([]byte, error)
 	if err != nil {
 		return nil, err
 	}
-	_, depositData, err := depositutil.GenerateDepositTransaction(blsValidatingKey, blsWithdrawalKey)
+	tx, _, err := depositutil.GenerateDepositTransaction(blsValidatingKey, blsWithdrawalKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not generate deposit transaction data")
 	}
-	return ssz.Marshal(depositData)
+	return tx.Data(), nil
 }
 
 func (dr *Keymanager) initializeSecretKeysCache() error {

--- a/validator/keymanager/v2/derived/derived.go
+++ b/validator/keymanager/v2/derived/derived.go
@@ -11,11 +11,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/tyler-smith/go-bip39"
-	util "github.com/wealdtech/go-eth2-util"
-	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
-
 	validatorpb "github.com/prysmaticlabs/prysm/proto/validator/accounts/v2"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -23,6 +18,10 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/petnames"
 	"github.com/prysmaticlabs/prysm/shared/rand"
 	"github.com/prysmaticlabs/prysm/validator/accounts/v2/iface"
+	"github.com/sirupsen/logrus"
+	"github.com/tyler-smith/go-bip39"
+	util "github.com/wealdtech/go-eth2-util"
+	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
 )
 
 var log = logrus.WithField("prefix", "derived-keymanager-v2")

--- a/validator/keymanager/v2/direct/BUILD.bazel
+++ b/validator/keymanager/v2/direct/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//proto/validator/accounts/v2:go_default_library",
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
+        "//shared/depositutil:go_default_library",
         "//shared/petnames:go_default_library",
         "//shared/promptutil:go_default_library",
         "//validator/accounts/v2/iface:go_default_library",

--- a/validator/keymanager/v2/direct/direct.go
+++ b/validator/keymanager/v2/direct/direct.go
@@ -15,6 +15,7 @@ import (
 	validatorpb "github.com/prysmaticlabs/prysm/proto/validator/accounts/v2"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/depositutil"
 	"github.com/prysmaticlabs/prysm/shared/petnames"
 	"github.com/prysmaticlabs/prysm/shared/promptutil"
 	"github.com/prysmaticlabs/prysm/validator/accounts/v2/iface"
@@ -182,6 +183,20 @@ func (dr *Keymanager) CreateAccount(ctx context.Context) (string, error) {
 ===================================================================
 	`, withdrawalKey.Marshal())
 	fmt.Println(" ")
+
+	// Upon confirmation of the withdrawal key, proceed to display
+	// and write associated deposit data to disk.
+	tx, _, err := depositutil.GenerateDepositTransaction(validatingKey, withdrawalKey)
+	if err != nil {
+		return "", errors.Wrap(err, "could not generate deposit transaction data")
+	}
+
+	// Log the deposit transaction data to the user.
+	fmt.Printf(`
+======================Eth1 Deposit Transaction Data================
+%#x
+===================================================================`, tx.Data())
+	fmt.Println("")
 
 	// Write the encoded keystore to disk with the timestamp appended
 	encoded, err := json.MarshalIndent(newStore, "", "\t")


### PR DESCRIPTION
This PR adds back the displaying of deposit data to show the eth1 deposit tx data users can then easily copy into metamask
Also, gets rid of the following issues:
- Not able to open a wallet if other files exist in the directory
- Fix relative paths in various inputs
- Fix the experience of not asking users to migrate if they are already using an HD wallet