### PR TITLE
Fix Panic in Wallet HasDir()

### DIFF
--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -700,6 +700,9 @@ func hasDir(dirPath string) (bool, error) {
 	if os.IsNotExist(err) {
 		return false, nil
 	}
+	if info == nil {
+		return false, nil
+	}
 	return info.IsDir(), err
 }
 


### PR DESCRIPTION
No tracking issue. The code above panics on the last line for certain users as `info` could be nil. It is unclear how this could happen, but we prevent it for now by adding a nil check and returning false

```go
// Checks if a directory indeed exists at the specified path.
func hasDir(dirPath string) (bool, error) {
	fullPath, err := expandPath(dirPath)
	if err != nil {
		return false, err
	}
	info, err := os.Stat(fullPath)
	if os.IsNotExist(err) {
		return false, nil
	}
	return info.IsDir(), err
}
```