### PR TITLE
Validate attestation: fix error log

### DIFF
--- a/beacon-chain/core/helpers/attestation.go
+++ b/beacon-chain/core/helpers/attestation.go
@@ -150,7 +150,7 @@ func ValidateAttestationTime(attSlot uint64, genesisTime time.Time) error {
 		return fmt.Errorf(
 			"attestation slot %d not within attestation propagation range of %d to %d (current slot)",
 			attSlot,
-			currentSlot-params.BeaconNetworkConfig().AttestationPropagationSlotRange,
+			lowerBoundsSlot,
 			currentSlot,
 		)
 	}


### PR DESCRIPTION
Fixed an error log to avoid displaying underflow.

As seen in #6855
```
[2020-08-03 18:28:35] ERROR validator: Could not request attestation to sign at slot error=rpc error: code = InvalidArgument desc = invalid request: attestation slot 21233 not within attestation propagation range of 18446744073709551589 to 5 (current slot) pubKey=0x903e2989e744 slot=21233
```