### PR TITLE
Return an error when wallet is nil rather than panic

### DIFF
--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -58,6 +58,9 @@ func CreateWallet(cliCtx *cli.Context) (*Wallet, error) {
 }
 
 func createDirectKeymanagerWallet(cliCtx *cli.Context, wallet *Wallet) error {
+	if wallet == nil {
+		return errors.New("nil wallet")
+	}
 	if err := wallet.SaveWallet(); err != nil {
 		return errors.Wrap(err, "could not save wallet to disk")
 	}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This will prevent a panic in the case that wallet is nil.

**Which issues(s) does this PR fix?**

![Eel9-LCWkAQVfGK](https://user-images.githubusercontent.com/7246818/89329350-87ef9600-d643-11ea-9627-a349b784d548.jpg)


**Other notes for review**

I am not sure how this wallet could be nil, but it has been reported on twitter.
