### PR TITLE
Return Err in Wallet.HasDir function

### DIFF
--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -701,7 +701,7 @@ func hasDir(dirPath string) (bool, error) {
 		return false, nil
 	}
 	if info == nil {
-		return false, nil
+		return false, err
 	}
 	return info.IsDir(), err
 }

--- a/validator/accounts/v2/wallet.go
+++ b/validator/accounts/v2/wallet.go
@@ -700,6 +700,9 @@ func hasDir(dirPath string) (bool, error) {
 	if os.IsNotExist(err) {
 		return false, nil
 	}
+	if info == nil {
+		return false, nil
+	}
 	return info.IsDir(), err
 }
 


### PR DESCRIPTION
No tracking issue - this simply returns an error from the helper function hasDir in wallet.go for accounts v2, originally from #6857