### PR TITLE
Warn users of upcoming breaking change to default value for eth1 provider flag

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -466,7 +466,8 @@ func (b *BeaconNode) registerPOWChainService() error {
 	}
 
 	if !b.cliCtx.IsSet(flags.HTTPWeb3ProviderFlag.Name) {
-		log.Warn("Using default ETH1 connection provided by Prysmatic Labs. Please consider running your own ETH1 node for better uptime, security, and decentralization of ETH2. Visit https://docs.prylabs.network/docs/prysm-usage/setup-eth1 for more information.")
+		log.Error("Using default ETH1 connection provided by Prysmatic Labs. Please consider running your own ETH1 node for better uptime, security, and decentralization of ETH2. Visit https://docs.prylabs.network/docs/prysm-usage/setup-eth1 for more information.")
+		log.Error("The default eth1 connection provided by Prysmatic Labs will no longer be the default in the next release! You will need to specify --http-web3provider. Please configure your node before the next release.")
 	}
 
 	cfg := &powchain.Web3ServiceConfig{


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

We are planning to remove this default value in the next release. This error level message gives users time to reconfigure their nodes before incurring a breaking change.

**Which issues(s) does this PR fix?**

Part of https://github.com/prysmaticlabs/prysm/issues/6884

**Other notes for review**
