### PR TITLE
Use a more human readable message for non-interactive environments

### DIFF
--- a/shared/cmd/password_reader.go
+++ b/shared/cmd/password_reader.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 
 	"golang.org/x/crypto/ssh/terminal"
 )
+
+// ErrNonInteractiveTerminal occurs when the StdInPasswordReader is used in a non-interactive
+// environment.
+var ErrNonInteractiveTerminal = errors.New("terminal is input is non-interactive")
 
 // PasswordReader reads a password from a mock or stdin.
 type PasswordReader interface {
@@ -17,6 +22,9 @@ type StdInPasswordReader struct {
 
 // ReadPassword reads a password from stdin.
 func (pr StdInPasswordReader) ReadPassword() (string, error) {
-	pwd, error := terminal.ReadPassword(int(os.Stdin.Fd()))
-	return string(pwd), error
+	if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+		return "", ErrNonInteractiveTerminal
+	}
+	pwd, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	return string(pwd), err
 }

--- a/validator/accounts/v1/account.go
+++ b/validator/accounts/v1/account.go
@@ -228,6 +228,11 @@ func HandleEmptyKeystoreFlags(cliCtx *cli.Context, confirmPassword bool) (string
 	if passphrase == "" {
 		log.Info("Please enter the password for your private keys")
 		enteredPassphrase, err := cmd.EnterPassword(confirmPassword, cmd.StdInPasswordReader{})
+		// Log a message is the user is running in non-interactive terminal.
+		if errors.Cause(err) == cmd.ErrNonInteractiveTerminal {
+			log.Errorf("Unable to read password from terminal in non-interactive "+
+				"environment. Please run with flag --%s=/path/to/password.txt", flags.PasswordFlag.Name)
+		}
 		if err != nil {
 			return path, enteredPassphrase, errors.Wrap(err, "could not read entered passphrase")
 		}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Some users are seeing confusing errors with no feedback on how to correct it.

Example:
```
validator     | time="2020-08-06 16:34:04" level=info msg="(wallet directory) /data/wallets" prefix=accounts-v2
validator     | time="2020-08-06 16:34:04" level=fatal msg="Could not read existing keymanager for wallet: could not initialize direct keymanager: could not initialize keys cache: could not confirm password via prompt: could not read account password: inappropriate ioctl for device" prefix=node
```

**Which issues(s) does this PR fix?**

**Other notes for review**
