### PR TITLE
Check before saving attestation to pool

### DIFF
--- a/beacon-chain/operations/attestations/kv/aggregated.go
+++ b/beacon-chain/operations/attestations/kv/aggregated.go
@@ -74,6 +74,14 @@ func (p *AttCaches) SaveAggregatedAttestation(att *ethpb.Attestation) error {
 	if !helpers.IsAggregated(att) {
 		return errors.New("attestation is not aggregated")
 	}
+	has, err := p.HasAggregatedAttestation(att)
+	if err != nil {
+		return err
+	}
+	if has {
+		return nil
+	}
+
 	r, err := hashFn(att.Data)
 	if err != nil {
 		return errors.Wrap(err, "could not tree hash attestation")

--- a/beacon-chain/operations/attestations/prune_expired.go
+++ b/beacon-chain/operations/attestations/prune_expired.go
@@ -14,6 +14,7 @@ func (s *Service) pruneAttsPool() {
 		select {
 		case <-ticker.C:
 			s.pruneExpiredAtts()
+			s.updateMetrics()
 		case <-s.ctx.Done():
 			log.Debug("Context closed, exiting routine")
 			ticker.Stop()


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Enhancement

**What does this PR do? Why is it needed?**
Check if the attestation already exists (bitfield overlaps) in pool before saving it to the pool. This is a cheap and nice way to reduce the size of attestation pool. I also found out that metric update was not used so I added the usage back.

Observed reduction in the attestation pool size
![Screen Shot 2020-08-06 at 10 22 49 AM](https://user-images.githubusercontent.com/21316537/89571192-2282dd00-d7dc-11ea-8677-c556eac71a8a.png)


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
