### PR TITLE
Fail Immediately if Importing Accounts from Empty Directory

### DIFF
--- a/validator/accounts/v2/accounts_import.go
+++ b/validator/accounts/v2/accounts_import.go
@@ -74,6 +74,9 @@ func ImportAccount(cliCtx *cli.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "could not read dir")
 		}
+		if len(files) == 0 {
+			return fmt.Errorf("directory %s has no files, cannot import from it", keysDir)
+		}
 		for i := 0; i < len(files); i++ {
 			if files[i].IsDir() {
 				continue


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What does this PR do? Why is it needed?**

We should fail the import if we are importing from an empty directory instead of just showing `successfully imported 0 accounts`

**Which issues(s) does this PR fix?**

Fixes #6860
