### PR TITLE
Log Error Logs Less Frequently

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -414,6 +414,8 @@ func (s *Service) waitForConnection() {
 	if errConnect != nil {
 		log.WithError(errConnect).Error("Could not connect to powchain endpoint")
 	}
+	// Use a custom logger to only log errors
+	// once in  a while.
 	logCounter := 0
 	errorLogger := func(err error, msg string) {
 		if logCounter > logThreshold {


### PR DESCRIPTION
**What type of PR is this?**

Log Display Clean Up

**What does this PR do? Why is it needed?**

In the event the connected eth1 node is down, the beacon node would constantly log dial errors. This instead makes those
logs much less frequent in order to stop the node from being spammed.

**Which issues(s) does this PR fix?**

None

**Other notes for review**
