### PR TITLE
Unexport protoarray forkchoice types

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -253,12 +253,12 @@ func (s *Service) updateRecentCanonicalBlocks(ctx context.Context, headRoot [32]
 		return nil
 	}
 
-	for node.Parent != protoarray.NonExistentNode {
+	for node.Parent() != protoarray.NonExistentNode {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		node = nodes[node.Parent]
-		s.recentCanonicalBlocks[node.Root] = true
+		node = nodes[node.Parent()]
+		s.recentCanonicalBlocks[node.Root()] = true
 	}
 
 	return nil

--- a/beacon-chain/blockchain/info.go
+++ b/beacon-chain/blockchain/info.go
@@ -51,21 +51,21 @@ func (s *Service) TreeHandler(w http.ResponseWriter, r *http.Request) {
 
 	for i := len(nodes) - 1; i >= 0; i-- {
 		// Construct label for each node.
-		slot := fmt.Sprintf("%d", nodes[i].Slot)
-		weight := fmt.Sprintf("%d", nodes[i].Weight/1e9) // Convert unit Gwei to unit ETH.
-		votes := fmt.Sprintf("%d", nodes[i].Weight/1e9/avgBalance)
+		slot := fmt.Sprintf("%d", nodes[i].Slot())
+		weight := fmt.Sprintf("%d", nodes[i].Weight()/1e9) // Convert unit Gwei to unit ETH.
+		votes := fmt.Sprintf("%d", nodes[i].Weight()/1e9/avgBalance)
 		index := fmt.Sprintf("%d", i)
-		g := nodes[i].Graffiti[:]
+		g := nodes[i].Graffiti()
 		graffiti := hex.EncodeToString(g[:8])
 		label := "slot: " + slot + "\n votes: " + votes + "\n weight: " + weight + "\n graffiti: " + graffiti
 		var dotN dot.Node
-		if nodes[i].Parent != ^uint64(0) {
+		if nodes[i].Parent() != ^uint64(0) {
 			dotN = graph.Node(index).Box().Attr("label", label)
 		}
 
-		if nodes[i].Slot == s.headSlot() &&
-			nodes[i].BestDescendant == ^uint64(0) &&
-			nodes[i].Parent != ^uint64(0) {
+		if nodes[i].Slot() == s.headSlot() &&
+			nodes[i].BestDescendant() == ^uint64(0) &&
+			nodes[i].Parent() != ^uint64(0) {
 			dotN = dotN.Attr("color", "green")
 		}
 
@@ -73,8 +73,8 @@ func (s *Service) TreeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for i := len(nodes) - 1; i >= 0; i-- {
-		if nodes[i].Parent != ^uint64(0) && nodes[i].Parent < uint64(len(dotNodes)) {
-			graph.Edge(*dotNodes[i], *dotNodes[nodes[i].Parent])
+		if nodes[i].Parent() != ^uint64(0) && nodes[i].Parent() < uint64(len(dotNodes)) {
+			graph.Edge(*dotNodes[i], *dotNodes[nodes[i].Parent()])
 		}
 	}
 

--- a/beacon-chain/forkchoice/protoarray/BUILD.bazel
+++ b/beacon-chain/forkchoice/protoarray/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "errors.go",
         "helpers.go",
         "metrics.go",
+        "node.go",
         "nodes.go",
         "store.go",
         "types.go",

--- a/beacon-chain/forkchoice/protoarray/ffg_update_test.go
+++ b/beacon-chain/forkchoice/protoarray/ffg_update_test.go
@@ -183,16 +183,16 @@ func TestFFGUpdates_TwoBranches(t *testing.T) {
 
 func setup(justifiedEpoch uint64, finalizedEpoch uint64) *ForkChoice {
 	f := New(0, 0, params.BeaconConfig().ZeroHash)
-	f.store.NodeIndices[params.BeaconConfig().ZeroHash] = 0
-	f.store.Nodes = append(f.store.Nodes, &Node{
-		Slot:           0,
-		Root:           params.BeaconConfig().ZeroHash,
-		Parent:         NonExistentNode,
-		JustifiedEpoch: justifiedEpoch,
-		FinalizedEpoch: finalizedEpoch,
-		BestChild:      NonExistentNode,
-		BestDescendant: NonExistentNode,
-		Weight:         0,
+	f.store.nodesIndices[params.BeaconConfig().ZeroHash] = 0
+	f.store.nodes = append(f.store.nodes, &Node{
+		slot:           0,
+		root:           params.BeaconConfig().ZeroHash,
+		parent:         NonExistentNode,
+		justifiedEpoch: justifiedEpoch,
+		finalizedEpoch: finalizedEpoch,
+		bestChild:      NonExistentNode,
+		bestDescendant: NonExistentNode,
+		weight:         0,
 	})
 
 	return f

--- a/beacon-chain/forkchoice/protoarray/helpers.go
+++ b/beacon-chain/forkchoice/protoarray/helpers.go
@@ -78,16 +78,16 @@ func copyNode(node *Node) *Node {
 	}
 
 	copiedRoot := [32]byte{}
-	copy(copiedRoot[:], node.Root[:])
+	copy(copiedRoot[:], node.root[:])
 
 	return &Node{
-		Slot:           node.Slot,
-		Root:           copiedRoot,
-		Parent:         node.Parent,
-		JustifiedEpoch: node.JustifiedEpoch,
-		FinalizedEpoch: node.FinalizedEpoch,
-		Weight:         node.Weight,
-		BestChild:      node.BestChild,
-		BestDescendant: node.BestDescendant,
+		slot:           node.slot,
+		root:           copiedRoot,
+		parent:         node.parent,
+		justifiedEpoch: node.justifiedEpoch,
+		finalizedEpoch: node.finalizedEpoch,
+		weight:         node.weight,
+		bestChild:      node.bestChild,
+		bestDescendant: node.bestDescendant,
 	}
 }

--- a/beacon-chain/forkchoice/protoarray/no_vote_test.go
+++ b/beacon-chain/forkchoice/protoarray/no_vote_test.go
@@ -82,7 +82,7 @@ func TestNoVote_CanFindHead(t *testing.T) {
 	//          |
 	//          5 <- starting from 5 with justified epoch 0 should error
 	r, err = f.Head(context.Background(), 1, indexToHash(5), balances, 1)
-	wanted := "head at slot 0 with weight 0 is not eligible, FinalizedEpoch 1 != 1, JustifiedEpoch 2 != 1"
+	wanted := "head at slot 0 with weight 0 is not eligible, finalizedEpoch 1 != 1, justifiedEpoch 2 != 1"
 	require.ErrorContains(t, wanted, err)
 
 	// Set the justified epoch to 2 and start block to 5 to verify head is 5.

--- a/beacon-chain/forkchoice/protoarray/node.go
+++ b/beacon-chain/forkchoice/protoarray/node.go
@@ -10,37 +10,37 @@ func (n *Node) Root() [32]byte {
 	return n.root
 }
 
-// parent of the fork choice node.
+// Parent of the fork choice node.
 func (n *Node) Parent() uint64 {
 	return n.parent
 }
 
-// justifiedEpoch of the fork choice node.
+// JustifiedEpoch of the fork choice node.
 func (n *Node) JustifiedEpoch() uint64 {
 	return n.justifiedEpoch
 }
 
-// finalizedEpoch of the fork choice node.
+// FinalizedEpoch of the fork choice node.
 func (n *Node) FinalizedEpoch() uint64 {
 	return n.finalizedEpoch
 }
 
-// weight of the fork choice node.
+// Weight of the fork choice node.
 func (n *Node) Weight() uint64 {
 	return n.weight
 }
 
-// bestChild of the fork choice node.
+// BestChild of the fork choice node.
 func (n *Node) BestChild() uint64 {
 	return n.bestChild
 }
 
-// bestDescendant of the fork choice node.
+// BestDescendant of the fork choice node.
 func (n *Node) BestDescendant() uint64 {
 	return n.bestDescendant
 }
 
-// graffiti of the fork choice node.
+// Graffiti of the fork choice node.
 func (n *Node) Graffiti() [32]byte {
 	return n.graffiti
 }

--- a/beacon-chain/forkchoice/protoarray/node.go
+++ b/beacon-chain/forkchoice/protoarray/node.go
@@ -1,0 +1,46 @@
+package protoarray
+
+// Slot of the fork choice node.
+func (n *Node) Slot() uint64 {
+	return n.slot
+}
+
+// Root of the fork choice node.
+func (n *Node) Root() [32]byte {
+	return n.root
+}
+
+// parent of the fork choice node.
+func (n *Node) Parent() uint64 {
+	return n.parent
+}
+
+// justifiedEpoch of the fork choice node.
+func (n *Node) JustifiedEpoch() uint64 {
+	return n.justifiedEpoch
+}
+
+// finalizedEpoch of the fork choice node.
+func (n *Node) FinalizedEpoch() uint64 {
+	return n.finalizedEpoch
+}
+
+// weight of the fork choice node.
+func (n *Node) Weight() uint64 {
+	return n.weight
+}
+
+// bestChild of the fork choice node.
+func (n *Node) BestChild() uint64 {
+	return n.bestChild
+}
+
+// bestDescendant of the fork choice node.
+func (n *Node) BestDescendant() uint64 {
+	return n.bestDescendant
+}
+
+// graffiti of the fork choice node.
+func (n *Node) Graffiti() [32]byte {
+	return n.graffiti
+}

--- a/beacon-chain/forkchoice/protoarray/nodes.go
+++ b/beacon-chain/forkchoice/protoarray/nodes.go
@@ -18,40 +18,40 @@ func (s *Store) head(ctx context.Context, justifiedRoot [32]byte) ([32]byte, err
 	defer span.End()
 
 	// Justified index has to be valid in node indices map, and can not be out of bound.
-	justifiedIndex, ok := s.NodeIndices[justifiedRoot]
+	justifiedIndex, ok := s.nodesIndices[justifiedRoot]
 	if !ok {
 		return [32]byte{}, errUnknownJustifiedRoot
 	}
-	if justifiedIndex >= uint64(len(s.Nodes)) {
+	if justifiedIndex >= uint64(len(s.nodes)) {
 		return [32]byte{}, errInvalidJustifiedIndex
 	}
 
-	justifiedNode := s.Nodes[justifiedIndex]
-	bestDescendantIndex := justifiedNode.BestDescendant
+	justifiedNode := s.nodes[justifiedIndex]
+	bestDescendantIndex := justifiedNode.bestDescendant
 	// If the justified node doesn't have a best descendent,
 	// the best node is itself.
 	if bestDescendantIndex == NonExistentNode {
 		bestDescendantIndex = justifiedIndex
 	}
-	if bestDescendantIndex >= uint64(len(s.Nodes)) {
+	if bestDescendantIndex >= uint64(len(s.nodes)) {
 		return [32]byte{}, errInvalidBestDescendantIndex
 	}
 
-	bestNode := s.Nodes[bestDescendantIndex]
+	bestNode := s.nodes[bestDescendantIndex]
 
 	if !s.viableForHead(bestNode) {
-		return [32]byte{}, fmt.Errorf("head at slot %d with weight %d is not eligible, FinalizedEpoch %d != %d, JustifiedEpoch %d != %d",
-			bestNode.Slot, bestNode.Weight/10e9, bestNode.FinalizedEpoch, s.FinalizedEpoch, bestNode.JustifiedEpoch, s.JustifiedEpoch)
+		return [32]byte{}, fmt.Errorf("head at slot %d with weight %d is not eligible, finalizedEpoch %d != %d, justifiedEpoch %d != %d",
+			bestNode.slot, bestNode.weight/10e9, bestNode.finalizedEpoch, s.finalizedEpoch, bestNode.justifiedEpoch, s.justifiedEpoch)
 	}
 
 	// Update metrics.
-	if bestNode.Root != lastHeadRoot {
+	if bestNode.root != lastHeadRoot {
 		headChangesCount.Inc()
-		headSlotNumber.Set(float64(bestNode.Slot))
-		lastHeadRoot = bestNode.Root
+		headSlotNumber.Set(float64(bestNode.slot))
+		lastHeadRoot = bestNode.root
 	}
 
-	return bestNode.Root, nil
+	return bestNode.root, nil
 }
 
 // insert registers a new block node to the fork choice store's node list.
@@ -69,34 +69,34 @@ func (s *Store) insert(ctx context.Context,
 	defer s.nodeIndicesLock.Unlock()
 
 	// Return if the block has been inserted into Store before.
-	if _, ok := s.NodeIndices[root]; ok {
+	if _, ok := s.nodesIndices[root]; ok {
 		return nil
 	}
 
-	index := len(s.Nodes)
-	parentIndex, ok := s.NodeIndices[parent]
+	index := len(s.nodes)
+	parentIndex, ok := s.nodesIndices[parent]
 	// Mark genesis block's parent as non existent.
 	if !ok {
 		parentIndex = NonExistentNode
 	}
 
 	n := &Node{
-		Slot:           slot,
-		Root:           root,
-		Graffiti:       graffiti,
-		Parent:         parentIndex,
-		JustifiedEpoch: justifiedEpoch,
-		FinalizedEpoch: finalizedEpoch,
-		BestChild:      NonExistentNode,
-		BestDescendant: NonExistentNode,
-		Weight:         0,
+		slot:           slot,
+		root:           root,
+		graffiti:       graffiti,
+		parent:         parentIndex,
+		justifiedEpoch: justifiedEpoch,
+		finalizedEpoch: finalizedEpoch,
+		bestChild:      NonExistentNode,
+		bestDescendant: NonExistentNode,
+		weight:         0,
 	}
 
-	s.NodeIndices[root] = uint64(index)
-	s.Nodes = append(s.Nodes, n)
+	s.nodesIndices[root] = uint64(index)
+	s.nodes = append(s.nodes, n)
 
 	// Update parent with the best child and descendent only if it's available.
-	if n.Parent != NonExistentNode {
+	if n.parent != NonExistentNode {
 		if err := s.updateBestChildAndDescendant(parentIndex, uint64(index)); err != nil {
 			return err
 		}
@@ -104,37 +104,37 @@ func (s *Store) insert(ctx context.Context,
 
 	// Update metrics.
 	processedBlockCount.Inc()
-	nodeCount.Set(float64(len(s.Nodes)))
+	nodeCount.Set(float64(len(s.nodes)))
 
 	return nil
 }
 
-// applyWeightChanges iterates backwards through the Nodes in store. It checks all Nodes parent
+// applyWeightChanges iterates backwards through the nodes in store. It checks all nodes parent
 // and its best child. For each node, it updates the weight with input delta and
-// back propagate the Nodes delta to its parents delta. After scoring changes,
+// back propagate the nodes delta to its parents delta. After scoring changes,
 // the best child is then updated along with best descendant.
 func (s *Store) applyWeightChanges(ctx context.Context, justifiedEpoch uint64, finalizedEpoch uint64, delta []int) error {
 	ctx, span := trace.StartSpan(ctx, "protoArrayForkChoice.applyWeightChanges")
 	defer span.End()
 
-	// The length of the Nodes can not be different than length of the delta.
-	if len(s.Nodes) != len(delta) {
+	// The length of the nodes can not be different than length of the delta.
+	if len(s.nodes) != len(delta) {
 		return errInvalidDeltaLength
 	}
 
 	// Update the justified / finalized epochs in store if necessary.
-	if s.JustifiedEpoch != justifiedEpoch || s.FinalizedEpoch != finalizedEpoch {
-		s.JustifiedEpoch = justifiedEpoch
-		s.FinalizedEpoch = finalizedEpoch
+	if s.justifiedEpoch != justifiedEpoch || s.finalizedEpoch != finalizedEpoch {
+		s.justifiedEpoch = justifiedEpoch
+		s.finalizedEpoch = finalizedEpoch
 	}
 
 	// Iterate backwards through all index to node in store.
-	for i := len(s.Nodes) - 1; i >= 0; i-- {
-		n := s.Nodes[i]
+	for i := len(s.nodes) - 1; i >= 0; i-- {
+		n := s.nodes[i]
 
 		// There is no need to adjust the balances or manage parent of the zero hash, it
 		// is an alias to the genesis block.
-		if n.Root == params.BeaconConfig().ZeroHash {
+		if n.root == params.BeaconConfig().ZeroHash {
 			continue
 		}
 
@@ -142,28 +142,28 @@ func (s *Store) applyWeightChanges(ctx context.Context, justifiedEpoch uint64, f
 
 		if nodeDelta < 0 {
 			// A node's weight can not be negative but the delta can be negative.
-			if int(n.Weight)+nodeDelta < 0 {
-				n.Weight = 0
+			if int(n.weight)+nodeDelta < 0 {
+				n.weight = 0
 			} else {
 				// Subtract node's weight.
-				n.Weight -= uint64(math.Abs(float64(nodeDelta)))
+				n.weight -= uint64(math.Abs(float64(nodeDelta)))
 			}
 		} else {
 			// Add node's weight.
-			n.Weight += uint64(nodeDelta)
+			n.weight += uint64(nodeDelta)
 		}
 
-		s.Nodes[i] = n
+		s.nodes[i] = n
 
 		// Update parent's best child and descendent if the node has a known parent.
-		if n.Parent != NonExistentNode {
+		if n.parent != NonExistentNode {
 			// Protection against node parent index out of bound. This should not happen.
-			if int(n.Parent) >= len(delta) {
+			if int(n.parent) >= len(delta) {
 				return errInvalidParentDelta
 			}
-			// Back propagate the Nodes delta to its parent.
-			delta[n.Parent] += nodeDelta
-			if err := s.updateBestChildAndDescendant(n.Parent, uint64(i)); err != nil {
+			// Back propagate the nodes delta to its parent.
+			delta[n.parent] += nodeDelta
+			if err := s.updateBestChildAndDescendant(n.parent, uint64(i)); err != nil {
 				return err
 			}
 		}
@@ -182,16 +182,16 @@ func (s *Store) applyWeightChanges(ctx context.Context, justifiedEpoch uint64, f
 // 4.)  The child is not the best child and does not become best child.
 func (s *Store) updateBestChildAndDescendant(parentIndex uint64, childIndex uint64) error {
 	// Protection against parent index out of bound, this should not happen.
-	if parentIndex >= uint64(len(s.Nodes)) {
+	if parentIndex >= uint64(len(s.nodes)) {
 		return errInvalidNodeIndex
 	}
-	parent := s.Nodes[parentIndex]
+	parent := s.nodes[parentIndex]
 
 	// Protection against child index out of bound, again this should not happen.
-	if childIndex >= uint64(len(s.Nodes)) {
+	if childIndex >= uint64(len(s.nodes)) {
 		return errInvalidNodeIndex
 	}
-	child := s.Nodes[childIndex]
+	child := s.nodes[childIndex]
 
 	// Is the child viable to become head? Based on justification and finalization rules.
 	childLeadsToViableHead, err := s.leadsToViableHead(child)
@@ -200,32 +200,32 @@ func (s *Store) updateBestChildAndDescendant(parentIndex uint64, childIndex uint
 	}
 
 	// Define 3 variables for the 3 outcomes mentioned above. This is to
-	// set `parent.BestChild` and `parent.bestDescendant` to. These
+	// set `parent.bestChild` and `parent.bestDescendant` to. These
 	// aliases are to assist readability.
 	changeToNone := []uint64{NonExistentNode, NonExistentNode}
-	bestDescendant := child.BestDescendant
+	bestDescendant := child.bestDescendant
 	if bestDescendant == NonExistentNode {
 		bestDescendant = childIndex
 	}
 	changeToChild := []uint64{childIndex, bestDescendant}
-	noChange := []uint64{parent.BestChild, parent.BestDescendant}
+	noChange := []uint64{parent.bestChild, parent.bestDescendant}
 	newParentChild := make([]uint64, 0)
 
-	if parent.BestChild != NonExistentNode {
-		if parent.BestChild == childIndex && !childLeadsToViableHead {
+	if parent.bestChild != NonExistentNode {
+		if parent.bestChild == childIndex && !childLeadsToViableHead {
 			// If the child is already the best child of the parent but it's not viable for head,
 			// we should remove it. (Outcome 1)
 			newParentChild = changeToNone
-		} else if parent.BestChild == childIndex {
+		} else if parent.bestChild == childIndex {
 			// If the child is already the best child of the parent, set it again to ensure best
 			// descendent of the parent is updated. (Outcome 2)
 			newParentChild = changeToChild
 		} else {
 			// Protection against parent's best child going out of bound.
-			if parent.BestChild > uint64(len(s.Nodes)) {
+			if parent.bestChild > uint64(len(s.nodes)) {
 				return errInvalidBestDescendantIndex
 			}
-			bestChild := s.Nodes[parent.BestChild]
+			bestChild := s.nodes[parent.bestChild]
 			// Is current parent's best child viable to be head? Based on justification and finalization rules.
 			bestChildLeadsToViableHead, err := s.leadsToViableHead(bestChild)
 			if err != nil {
@@ -238,17 +238,17 @@ func (s *Store) updateBestChildAndDescendant(parentIndex uint64, childIndex uint
 			} else if !childLeadsToViableHead && bestChildLeadsToViableHead {
 				// The child doesn't lead to a viable head, the current parent's best child does.
 				newParentChild = noChange
-			} else if child.Weight == bestChild.Weight {
+			} else if child.weight == bestChild.weight {
 				// If both are viable, compare their weights.
-				// Tie-breaker of equal weights by Root.
-				if bytes.Compare(child.Root[:], bestChild.Root[:]) > 0 {
+				// Tie-breaker of equal weights by root.
+				if bytes.Compare(child.root[:], bestChild.root[:]) > 0 {
 					newParentChild = changeToChild
 				} else {
 					newParentChild = noChange
 				}
 			} else {
 				// Choose winner by weight.
-				if child.Weight > bestChild.Weight {
+				if child.weight > bestChild.weight {
 					newParentChild = changeToChild
 				} else {
 					newParentChild = noChange
@@ -266,16 +266,16 @@ func (s *Store) updateBestChildAndDescendant(parentIndex uint64, childIndex uint
 	}
 
 	// Update parent with the outcome.
-	parent.BestChild = newParentChild[0]
-	parent.BestDescendant = newParentChild[1]
-	s.Nodes[parentIndex] = parent
+	parent.bestChild = newParentChild[0]
+	parent.bestDescendant = newParentChild[1]
+	s.nodes[parentIndex] = parent
 
 	return nil
 }
 
 // prune prunes the store with the new finalized root. The tree is only
 // pruned if the input finalized root are different than the one in stored and
-// the number of the Nodes in store has met prune threshold.
+// the number of the nodes in store has met prune threshold.
 func (s *Store) prune(ctx context.Context, finalizedRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "protoArrayForkChoice.prune")
 	defer span.End()
@@ -285,61 +285,61 @@ func (s *Store) prune(ctx context.Context, finalizedRoot [32]byte) error {
 
 	// The node would have seen finalized root or else it'd
 	// be able to prune it.
-	finalizedIndex, ok := s.NodeIndices[finalizedRoot]
+	finalizedIndex, ok := s.nodesIndices[finalizedRoot]
 	if !ok {
 		return errUnknownFinalizedRoot
 	}
 
-	// The number of the Nodes has not met the prune threshold.
+	// The number of the nodes has not met the prune threshold.
 	// Pruning at small numbers incurs more cost than benefit.
-	if finalizedIndex < s.PruneThreshold {
+	if finalizedIndex < s.pruneThreshold {
 		return nil
 	}
 
-	// Remove the key/values from indices mapping on to be pruned Nodes.
-	// These Nodes are before the finalized index.
+	// Remove the key/values from indices mapping on to be pruned nodes.
+	// These nodes are before the finalized index.
 	for i := uint64(0); i < finalizedIndex; i++ {
-		if int(i) >= len(s.Nodes) {
+		if int(i) >= len(s.nodes) {
 			return errInvalidNodeIndex
 		}
-		delete(s.NodeIndices, s.Nodes[i].Root)
+		delete(s.nodesIndices, s.nodes[i].root)
 	}
 
 	// Finalized index can not be greater than the length of the node.
-	if int(finalizedIndex) >= len(s.Nodes) {
+	if int(finalizedIndex) >= len(s.nodes) {
 		return errors.New("invalid finalized index")
 	}
-	s.Nodes = s.Nodes[finalizedIndex:]
+	s.nodes = s.nodes[finalizedIndex:]
 
 	// Adjust indices to node mapping.
-	for k, v := range s.NodeIndices {
-		s.NodeIndices[k] = v - finalizedIndex
+	for k, v := range s.nodesIndices {
+		s.nodesIndices[k] = v - finalizedIndex
 	}
 
-	// Iterate through existing Nodes and adjust its parent/child indices with the newly pruned layout.
-	for i, node := range s.Nodes {
-		if node.Parent != NonExistentNode {
+	// Iterate through existing nodes and adjust its parent/child indices with the newly pruned layout.
+	for i, node := range s.nodes {
+		if node.parent != NonExistentNode {
 			// If the node's parent is less than finalized index, set it to non existent.
-			if node.Parent >= finalizedIndex {
-				node.Parent -= finalizedIndex
+			if node.parent >= finalizedIndex {
+				node.parent -= finalizedIndex
 			} else {
-				node.Parent = NonExistentNode
+				node.parent = NonExistentNode
 			}
 		}
-		if node.BestChild != NonExistentNode {
-			if node.BestChild < finalizedIndex {
+		if node.bestChild != NonExistentNode {
+			if node.bestChild < finalizedIndex {
 				return errInvalidBestChildIndex
 			}
-			node.BestChild -= finalizedIndex
+			node.bestChild -= finalizedIndex
 		}
-		if node.BestDescendant != NonExistentNode {
-			if node.BestDescendant < finalizedIndex {
+		if node.bestDescendant != NonExistentNode {
+			if node.bestDescendant < finalizedIndex {
 				return errInvalidBestDescendantIndex
 			}
-			node.BestDescendant -= finalizedIndex
+			node.bestDescendant -= finalizedIndex
 		}
 
-		s.Nodes[i] = node
+		s.nodes[i] = node
 	}
 
 	prunedCount.Inc()
@@ -352,17 +352,17 @@ func (s *Store) prune(ctx context.Context, finalizedRoot [32]byte) error {
 // should not be viable to head.
 func (s *Store) leadsToViableHead(node *Node) (bool, error) {
 	var bestDescendentViable bool
-	bestDescendentIndex := node.BestDescendant
+	bestDescendentIndex := node.bestDescendant
 
 	// If the best descendant is not part of the leaves.
 	if bestDescendentIndex != NonExistentNode {
 		// Protection against out of bound, best descendent index can not be
-		// exceeds length of Nodes list.
-		if bestDescendentIndex >= uint64(len(s.Nodes)) {
+		// exceeds length of nodes list.
+		if bestDescendentIndex >= uint64(len(s.nodes)) {
 			return false, errInvalidBestDescendantIndex
 		}
 
-		bestDescendentNode := s.Nodes[bestDescendentIndex]
+		bestDescendentNode := s.nodes[bestDescendentIndex]
 		bestDescendentViable = s.viableForHead(bestDescendentNode)
 	}
 
@@ -376,8 +376,8 @@ func (s *Store) leadsToViableHead(node *Node) (bool, error) {
 func (s *Store) viableForHead(node *Node) bool {
 	// `node` is viable if its justified epoch and finalized epoch are the same as the one in `Store`.
 	// It's also viable if we are in genesis epoch.
-	justified := s.JustifiedEpoch == node.JustifiedEpoch || s.JustifiedEpoch == 0
-	finalized := s.FinalizedEpoch == node.FinalizedEpoch || s.FinalizedEpoch == 0
+	justified := s.justifiedEpoch == node.justifiedEpoch || s.justifiedEpoch == 0
+	finalized := s.finalizedEpoch == node.finalizedEpoch || s.finalizedEpoch == 0
 
 	return justified && finalized
 }

--- a/beacon-chain/forkchoice/protoarray/nodes_test.go
+++ b/beacon-chain/forkchoice/protoarray/nodes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestStore_Head_UnknownJustifiedRoot(t *testing.T) {
-	s := &Store{NodeIndices: make(map[[32]byte]uint64)}
+	s := &Store{nodesIndices: make(map[[32]byte]uint64)}
 
 	_, err := s.head(context.Background(), [32]byte{})
 	assert.ErrorContains(t, errUnknownJustifiedRoot.Error(), err)
@@ -20,7 +20,7 @@ func TestStore_Head_UnknownJustifiedIndex(t *testing.T) {
 	r := [32]byte{'A'}
 	indices := make(map[[32]byte]uint64)
 	indices[r] = 1
-	s := &Store{NodeIndices: indices}
+	s := &Store{nodesIndices: indices}
 
 	_, err := s.head(context.Background(), r)
 	assert.ErrorContains(t, errInvalidJustifiedIndex.Error(), err)
@@ -33,7 +33,7 @@ func TestStore_Head_Itself(t *testing.T) {
 
 	// Since the justified node does not have a best descendant so the best node
 	// is itself.
-	s := &Store{NodeIndices: indices, Nodes: []*Node{{Root: r, BestDescendant: NonExistentNode}}}
+	s := &Store{nodesIndices: indices, nodes: []*Node{{root: r, bestDescendant: NonExistentNode}}}
 	h, err := s.head(context.Background(), r)
 	require.NoError(t, err)
 	assert.Equal(t, r, h)
@@ -47,7 +47,7 @@ func TestStore_Head_BestDescendant(t *testing.T) {
 
 	// Since the justified node's best descendent is at index 1 and it's root is `best`,
 	// the head should be `best`.
-	s := &Store{NodeIndices: indices, Nodes: []*Node{{Root: r, BestDescendant: 1}, {Root: best}}}
+	s := &Store{nodesIndices: indices, nodes: []*Node{{root: r, bestDescendant: 1}, {root: best}}}
 	h, err := s.head(context.Background(), r)
 	require.NoError(t, err)
 	assert.Equal(t, best, h)
@@ -55,30 +55,30 @@ func TestStore_Head_BestDescendant(t *testing.T) {
 
 func TestStore_Insert_UnknownParent(t *testing.T) {
 	// The new node does not have a parent.
-	s := &Store{NodeIndices: make(map[[32]byte]uint64)}
+	s := &Store{nodesIndices: make(map[[32]byte]uint64)}
 	require.NoError(t, s.insert(context.Background(), 100, [32]byte{'A'}, [32]byte{'B'}, [32]byte{}, 1, 1))
-	assert.Equal(t, 1, len(s.Nodes), "Did not insert block")
-	assert.Equal(t, 1, len(s.NodeIndices), "Did not insert block")
-	assert.Equal(t, NonExistentNode, s.Nodes[0].Parent, "Incorrect parent")
-	assert.Equal(t, uint64(1), s.Nodes[0].JustifiedEpoch, "Incorrect justification")
-	assert.Equal(t, uint64(1), s.Nodes[0].FinalizedEpoch, "Incorrect finalization")
-	assert.Equal(t, [32]byte{'A'}, s.Nodes[0].Root, "Incorrect root")
+	assert.Equal(t, 1, len(s.nodes), "Did not insert block")
+	assert.Equal(t, 1, len(s.nodesIndices), "Did not insert block")
+	assert.Equal(t, NonExistentNode, s.nodes[0].parent, "Incorrect parent")
+	assert.Equal(t, uint64(1), s.nodes[0].justifiedEpoch, "Incorrect justification")
+	assert.Equal(t, uint64(1), s.nodes[0].finalizedEpoch, "Incorrect finalization")
+	assert.Equal(t, [32]byte{'A'}, s.nodes[0].root, "Incorrect root")
 }
 
 func TestStore_Insert_KnownParent(t *testing.T) {
 	// Similar to UnknownParent test, but this time the new node has a valid parent already in store.
 	// The new node builds on top of the parent.
-	s := &Store{NodeIndices: make(map[[32]byte]uint64)}
-	s.Nodes = []*Node{{}}
+	s := &Store{nodesIndices: make(map[[32]byte]uint64)}
+	s.nodes = []*Node{{}}
 	p := [32]byte{'B'}
-	s.NodeIndices[p] = 0
+	s.nodesIndices[p] = 0
 	require.NoError(t, s.insert(context.Background(), 100, [32]byte{'A'}, p, [32]byte{}, 1, 1))
-	assert.Equal(t, 2, len(s.Nodes), "Did not insert block")
-	assert.Equal(t, 2, len(s.NodeIndices), "Did not insert block")
-	assert.Equal(t, uint64(0), s.Nodes[1].Parent, "Incorrect parent")
-	assert.Equal(t, uint64(1), s.Nodes[1].JustifiedEpoch, "Incorrect justification")
-	assert.Equal(t, uint64(1), s.Nodes[1].FinalizedEpoch, "Incorrect finalization")
-	assert.Equal(t, [32]byte{'A'}, s.Nodes[1].Root, "Incorrect root")
+	assert.Equal(t, 2, len(s.nodes), "Did not insert block")
+	assert.Equal(t, 2, len(s.nodesIndices), "Did not insert block")
+	assert.Equal(t, uint64(0), s.nodes[1].parent, "Incorrect parent")
+	assert.Equal(t, uint64(1), s.nodes[1].justifiedEpoch, "Incorrect justification")
+	assert.Equal(t, uint64(1), s.nodes[1].finalizedEpoch, "Incorrect finalization")
+	assert.Equal(t, [32]byte{'A'}, s.nodes[1].root, "Incorrect root")
 }
 
 func TestStore_ApplyScoreChanges_InvalidDeltaLength(t *testing.T) {
@@ -94,228 +94,228 @@ func TestStore_ApplyScoreChanges_UpdateEpochs(t *testing.T) {
 
 	// The justified and finalized epochs in Store should be updated to 1 and 1 given the following input.
 	require.NoError(t, s.applyWeightChanges(context.Background(), 1, 1, []int{}))
-	assert.Equal(t, uint64(1), s.JustifiedEpoch, "Did not update justified epoch")
-	assert.Equal(t, uint64(1), s.FinalizedEpoch, "Did not update finalized epoch")
+	assert.Equal(t, uint64(1), s.justifiedEpoch, "Did not update justified epoch")
+	assert.Equal(t, uint64(1), s.finalizedEpoch, "Did not update finalized epoch")
 }
 
 func TestStore_ApplyScoreChanges_UpdateWeightsPositiveDelta(t *testing.T) {
-	// Construct 3 Nodes with weight 100 on each node. The 3 Nodes linked to each other.
-	s := &Store{Nodes: []*Node{
-		{Root: [32]byte{'A'}, Weight: 100},
-		{Root: [32]byte{'A'}, Weight: 100},
-		{Parent: 1, Root: [32]byte{'A'}, Weight: 100}}}
+	// Construct 3 nodes with weight 100 on each node. The 3 nodes linked to each other.
+	s := &Store{nodes: []*Node{
+		{root: [32]byte{'A'}, weight: 100},
+		{root: [32]byte{'A'}, weight: 100},
+		{parent: 1, root: [32]byte{'A'}, weight: 100}}}
 
 	// Each node gets one unique vote. The weight should look like 103 <- 102 <- 101 because
 	// they get propagated back.
 	require.NoError(t, s.applyWeightChanges(context.Background(), 0, 0, []int{1, 1, 1}))
-	assert.Equal(t, uint64(103), s.Nodes[0].Weight)
-	assert.Equal(t, uint64(102), s.Nodes[1].Weight)
-	assert.Equal(t, uint64(101), s.Nodes[2].Weight)
+	assert.Equal(t, uint64(103), s.nodes[0].weight)
+	assert.Equal(t, uint64(102), s.nodes[1].weight)
+	assert.Equal(t, uint64(101), s.nodes[2].weight)
 }
 
 func TestStore_ApplyScoreChanges_UpdateWeightsNegativeDelta(t *testing.T) {
-	// Construct 3 Nodes with weight 100 on each node. The 3 Nodes linked to each other.
-	s := &Store{Nodes: []*Node{
-		{Root: [32]byte{'A'}, Weight: 100},
-		{Root: [32]byte{'A'}, Weight: 100},
-		{Parent: 1, Root: [32]byte{'A'}, Weight: 100}}}
+	// Construct 3 nodes with weight 100 on each node. The 3 nodes linked to each other.
+	s := &Store{nodes: []*Node{
+		{root: [32]byte{'A'}, weight: 100},
+		{root: [32]byte{'A'}, weight: 100},
+		{parent: 1, root: [32]byte{'A'}, weight: 100}}}
 
 	// Each node gets one unique vote which contributes to negative delta.
 	// The weight should look like 97 <- 98 <- 99 because they get propagated back.
 	require.NoError(t, s.applyWeightChanges(context.Background(), 0, 0, []int{-1, -1, -1}))
-	assert.Equal(t, uint64(97), s.Nodes[0].Weight)
-	assert.Equal(t, uint64(98), s.Nodes[1].Weight)
-	assert.Equal(t, uint64(99), s.Nodes[2].Weight)
+	assert.Equal(t, uint64(97), s.nodes[0].weight)
+	assert.Equal(t, uint64(98), s.nodes[1].weight)
+	assert.Equal(t, uint64(99), s.nodes[2].weight)
 }
 
 func TestStore_ApplyScoreChanges_UpdateWeightsMixedDelta(t *testing.T) {
-	// Construct 3 Nodes with weight 100 on each node. The 3 Nodes linked to each other.
-	s := &Store{Nodes: []*Node{
-		{Root: [32]byte{'A'}, Weight: 100},
-		{Root: [32]byte{'A'}, Weight: 100},
-		{Parent: 1, Root: [32]byte{'A'}, Weight: 100}}}
+	// Construct 3 nodes with weight 100 on each node. The 3 nodes linked to each other.
+	s := &Store{nodes: []*Node{
+		{root: [32]byte{'A'}, weight: 100},
+		{root: [32]byte{'A'}, weight: 100},
+		{parent: 1, root: [32]byte{'A'}, weight: 100}}}
 
 	// Each node gets one mixed vote. The weight should look like 100 <- 200 <- 250.
 	require.NoError(t, s.applyWeightChanges(context.Background(), 0, 0, []int{-100, -50, 150}))
-	assert.Equal(t, uint64(100), s.Nodes[0].Weight)
-	assert.Equal(t, uint64(200), s.Nodes[1].Weight)
-	assert.Equal(t, uint64(250), s.Nodes[2].Weight)
+	assert.Equal(t, uint64(100), s.nodes[0].weight)
+	assert.Equal(t, uint64(200), s.nodes[1].weight)
+	assert.Equal(t, uint64(250), s.nodes[2].weight)
 }
 
 func TestStore_UpdateBestChildAndDescendant_RemoveChild(t *testing.T) {
 	// Make parent's best child equal's to input child index and child is not viable.
-	s := &Store{Nodes: []*Node{{BestChild: 1}, {}}, JustifiedEpoch: 1, FinalizedEpoch: 1}
+	s := &Store{nodes: []*Node{{bestChild: 1}, {}}, justifiedEpoch: 1, finalizedEpoch: 1}
 	require.NoError(t, s.updateBestChildAndDescendant(0, 1))
 
 	// Verify parent's best child and best descendant are `none`.
-	assert.Equal(t, NonExistentNode, s.Nodes[0].BestChild, "Did not get correct best child index")
-	assert.Equal(t, NonExistentNode, s.Nodes[0].BestDescendant, "Did not get correct best descendant index")
+	assert.Equal(t, NonExistentNode, s.nodes[0].bestChild, "Did not get correct best child index")
+	assert.Equal(t, NonExistentNode, s.nodes[0].bestDescendant, "Did not get correct best descendant index")
 }
 
 func TestStore_UpdateBestChildAndDescendant_UpdateDescendant(t *testing.T) {
 	// Make parent's best child equal to child index and child is viable.
-	s := &Store{Nodes: []*Node{{BestChild: 1}, {BestDescendant: NonExistentNode}}}
+	s := &Store{nodes: []*Node{{bestChild: 1}, {bestDescendant: NonExistentNode}}}
 	require.NoError(t, s.updateBestChildAndDescendant(0, 1))
 
 	// Verify parent's best child is the same and best descendant is not set to child index.
-	assert.Equal(t, uint64(1), s.Nodes[0].BestChild, "Did not get correct best child index")
-	assert.Equal(t, uint64(1), s.Nodes[0].BestDescendant, "Did not get correct best descendant index")
+	assert.Equal(t, uint64(1), s.nodes[0].bestChild, "Did not get correct best child index")
+	assert.Equal(t, uint64(1), s.nodes[0].bestDescendant, "Did not get correct best descendant index")
 }
 
 func TestStore_UpdateBestChildAndDescendant_ChangeChildByViability(t *testing.T) {
 	// Make parent's best child not equal to child index, child leads to viable index and
 	// parents best child doesnt lead to viable index.
 	s := &Store{
-		JustifiedEpoch: 1,
-		FinalizedEpoch: 1,
-		Nodes: []*Node{{BestChild: 1, JustifiedEpoch: 1, FinalizedEpoch: 1},
-			{BestDescendant: NonExistentNode},
-			{BestDescendant: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1}}}
+		justifiedEpoch: 1,
+		finalizedEpoch: 1,
+		nodes: []*Node{{bestChild: 1, justifiedEpoch: 1, finalizedEpoch: 1},
+			{bestDescendant: NonExistentNode},
+			{bestDescendant: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1}}}
 	require.NoError(t, s.updateBestChildAndDescendant(0, 2))
 
 	// Verify parent's best child and best descendant are set to child index.
-	assert.Equal(t, uint64(2), s.Nodes[0].BestChild, "Did not get correct best child index")
-	assert.Equal(t, uint64(2), s.Nodes[0].BestDescendant, "Did not get correct best descendant index")
+	assert.Equal(t, uint64(2), s.nodes[0].bestChild, "Did not get correct best child index")
+	assert.Equal(t, uint64(2), s.nodes[0].bestDescendant, "Did not get correct best descendant index")
 }
 
 func TestStore_UpdateBestChildAndDescendant_ChangeChildByWeight(t *testing.T) {
 	// Make parent's best child not equal to child index, child leads to viable index and
 	// parents best child leads to viable index but child has more weight than parent's best child.
 	s := &Store{
-		JustifiedEpoch: 1,
-		FinalizedEpoch: 1,
-		Nodes: []*Node{{BestChild: 1, JustifiedEpoch: 1, FinalizedEpoch: 1},
-			{BestDescendant: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1},
-			{BestDescendant: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1, Weight: 1}}}
+		justifiedEpoch: 1,
+		finalizedEpoch: 1,
+		nodes: []*Node{{bestChild: 1, justifiedEpoch: 1, finalizedEpoch: 1},
+			{bestDescendant: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1},
+			{bestDescendant: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1, weight: 1}}}
 	require.NoError(t, s.updateBestChildAndDescendant(0, 2))
 
 	// Verify parent's best child and best descendant are set to child index.
-	assert.Equal(t, uint64(2), s.Nodes[0].BestChild, "Did not get correct best child index")
-	assert.Equal(t, uint64(2), s.Nodes[0].BestDescendant, "Did not get correct best descendant index")
+	assert.Equal(t, uint64(2), s.nodes[0].bestChild, "Did not get correct best child index")
+	assert.Equal(t, uint64(2), s.nodes[0].bestDescendant, "Did not get correct best descendant index")
 }
 
 func TestStore_UpdateBestChildAndDescendant_ChangeChildAtLeaf(t *testing.T) {
 	// Make parent's best child to none and input child leads to viable index.
 	s := &Store{
-		JustifiedEpoch: 1,
-		FinalizedEpoch: 1,
-		Nodes: []*Node{{BestChild: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1},
-			{BestDescendant: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1},
-			{BestDescendant: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1}}}
+		justifiedEpoch: 1,
+		finalizedEpoch: 1,
+		nodes: []*Node{{bestChild: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1},
+			{bestDescendant: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1},
+			{bestDescendant: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1}}}
 	require.NoError(t, s.updateBestChildAndDescendant(0, 2))
 
 	// Verify parent's best child and best descendant are set to child index.
-	assert.Equal(t, uint64(2), s.Nodes[0].BestChild, "Did not get correct best child index")
-	assert.Equal(t, uint64(2), s.Nodes[0].BestDescendant, "Did not get correct best descendant index")
+	assert.Equal(t, uint64(2), s.nodes[0].bestChild, "Did not get correct best child index")
+	assert.Equal(t, uint64(2), s.nodes[0].bestDescendant, "Did not get correct best descendant index")
 }
 
 func TestStore_UpdateBestChildAndDescendant_NoChangeByViability(t *testing.T) {
 	// Make parent's best child not equal to child index, child leads to not viable index and
 	// parents best child leads to viable index.
 	s := &Store{
-		JustifiedEpoch: 1,
-		FinalizedEpoch: 1,
-		Nodes: []*Node{{BestChild: 1, JustifiedEpoch: 1, FinalizedEpoch: 1},
-			{BestDescendant: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1},
-			{BestDescendant: NonExistentNode}}}
+		justifiedEpoch: 1,
+		finalizedEpoch: 1,
+		nodes: []*Node{{bestChild: 1, justifiedEpoch: 1, finalizedEpoch: 1},
+			{bestDescendant: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1},
+			{bestDescendant: NonExistentNode}}}
 	require.NoError(t, s.updateBestChildAndDescendant(0, 2))
 
 	// Verify parent's best child and best descendant are not changed.
-	assert.Equal(t, uint64(1), s.Nodes[0].BestChild, "Did not get correct best child index")
-	assert.Equal(t, uint64(0), s.Nodes[0].BestDescendant, "Did not get correct best descendant index")
+	assert.Equal(t, uint64(1), s.nodes[0].bestChild, "Did not get correct best child index")
+	assert.Equal(t, uint64(0), s.nodes[0].bestDescendant, "Did not get correct best descendant index")
 }
 
 func TestStore_UpdateBestChildAndDescendant_NoChangeByWeight(t *testing.T) {
 	// Make parent's best child not equal to child index, child leads to viable index and
 	// parents best child leads to viable index but parent's best child has more weight.
 	s := &Store{
-		JustifiedEpoch: 1,
-		FinalizedEpoch: 1,
-		Nodes: []*Node{{BestChild: 1, JustifiedEpoch: 1, FinalizedEpoch: 1},
-			{BestDescendant: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1, Weight: 1},
-			{BestDescendant: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1}}}
+		justifiedEpoch: 1,
+		finalizedEpoch: 1,
+		nodes: []*Node{{bestChild: 1, justifiedEpoch: 1, finalizedEpoch: 1},
+			{bestDescendant: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1, weight: 1},
+			{bestDescendant: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1}}}
 	require.NoError(t, s.updateBestChildAndDescendant(0, 2))
 
 	// Verify parent's best child and best descendant are not changed.
-	assert.Equal(t, uint64(1), s.Nodes[0].BestChild, "Did not get correct best child index")
-	assert.Equal(t, uint64(0), s.Nodes[0].BestDescendant, "Did not get correct best descendant index")
+	assert.Equal(t, uint64(1), s.nodes[0].bestChild, "Did not get correct best child index")
+	assert.Equal(t, uint64(0), s.nodes[0].bestDescendant, "Did not get correct best descendant index")
 }
 
 func TestStore_UpdateBestChildAndDescendant_NoChangeAtLeaf(t *testing.T) {
 	// Make parent's best child to none and input child does not lead to viable index.
 	s := &Store{
-		JustifiedEpoch: 1,
-		FinalizedEpoch: 1,
-		Nodes: []*Node{{BestChild: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1},
-			{BestDescendant: NonExistentNode, JustifiedEpoch: 1, FinalizedEpoch: 1},
-			{BestDescendant: NonExistentNode}}}
+		justifiedEpoch: 1,
+		finalizedEpoch: 1,
+		nodes: []*Node{{bestChild: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1},
+			{bestDescendant: NonExistentNode, justifiedEpoch: 1, finalizedEpoch: 1},
+			{bestDescendant: NonExistentNode}}}
 	require.NoError(t, s.updateBestChildAndDescendant(0, 2))
 
 	// Verify parent's best child and best descendant are not changed.
-	assert.Equal(t, NonExistentNode, s.Nodes[0].BestChild, "Did not get correct best child index")
-	assert.Equal(t, uint64(0), s.Nodes[0].BestDescendant, "Did not get correct best descendant index")
+	assert.Equal(t, NonExistentNode, s.nodes[0].bestChild, "Did not get correct best child index")
+	assert.Equal(t, uint64(0), s.nodes[0].bestDescendant, "Did not get correct best descendant index")
 }
 
 func TestStore_Prune_LessThanThreshold(t *testing.T) {
-	// Define 100 Nodes in store.
+	// Define 100 nodes in store.
 	numOfNodes := 100
 	indices := make(map[[32]byte]uint64)
 	nodes := make([]*Node, 0)
 	for i := 0; i < numOfNodes; i++ {
 		indices[indexToHash(uint64(i))] = uint64(i)
-		nodes = append(nodes, &Node{Slot: uint64(i)})
+		nodes = append(nodes, &Node{slot: uint64(i)})
 	}
 
-	s := &Store{Nodes: nodes, NodeIndices: indices, PruneThreshold: 100}
+	s := &Store{nodes: nodes, nodesIndices: indices, pruneThreshold: 100}
 
 	// Finalized root is at index 99 so everything before 99 should be pruned,
 	// but PruneThreshold is at 100 so nothing will be pruned.
 	require.NoError(t, s.prune(context.Background(), indexToHash(99)))
-	assert.Equal(t, 100, len(s.Nodes), "Incorrect nodes count")
-	assert.Equal(t, 100, len(s.NodeIndices), "Incorrect node indices count")
+	assert.Equal(t, 100, len(s.nodes), "Incorrect nodes count")
+	assert.Equal(t, 100, len(s.nodesIndices), "Incorrect node indices count")
 }
 
 func TestStore_Prune_MoreThanThreshold(t *testing.T) {
-	// Define 100 Nodes in store.
+	// Define 100 nodes in store.
 	numOfNodes := 100
 	indices := make(map[[32]byte]uint64)
 	nodes := make([]*Node, 0)
 	for i := 0; i < numOfNodes; i++ {
 		indices[indexToHash(uint64(i))] = uint64(i)
-		nodes = append(nodes, &Node{Slot: uint64(i), Root: indexToHash(uint64(i)),
-			BestDescendant: NonExistentNode, BestChild: NonExistentNode})
+		nodes = append(nodes, &Node{slot: uint64(i), root: indexToHash(uint64(i)),
+			bestDescendant: NonExistentNode, bestChild: NonExistentNode})
 	}
 
-	s := &Store{Nodes: nodes, NodeIndices: indices}
+	s := &Store{nodes: nodes, nodesIndices: indices}
 
 	// Finalized root is at index 99 so everything before 99 should be pruned.
 	require.NoError(t, s.prune(context.Background(), indexToHash(99)))
-	assert.Equal(t, 1, len(s.Nodes), "Incorrect nodes count")
-	assert.Equal(t, 1, len(s.NodeIndices), "Incorrect node indices count")
+	assert.Equal(t, 1, len(s.nodes), "Incorrect nodes count")
+	assert.Equal(t, 1, len(s.nodesIndices), "Incorrect node indices count")
 }
 
 func TestStore_Prune_MoreThanOnce(t *testing.T) {
-	// Define 100 Nodes in store.
+	// Define 100 nodes in store.
 	numOfNodes := 100
 	indices := make(map[[32]byte]uint64)
 	nodes := make([]*Node, 0)
 	for i := 0; i < numOfNodes; i++ {
 		indices[indexToHash(uint64(i))] = uint64(i)
-		nodes = append(nodes, &Node{Slot: uint64(i), Root: indexToHash(uint64(i)),
-			BestDescendant: NonExistentNode, BestChild: NonExistentNode})
+		nodes = append(nodes, &Node{slot: uint64(i), root: indexToHash(uint64(i)),
+			bestDescendant: NonExistentNode, bestChild: NonExistentNode})
 	}
 
-	s := &Store{Nodes: nodes, NodeIndices: indices}
+	s := &Store{nodes: nodes, nodesIndices: indices}
 
 	// Finalized root is at index 11 so everything before 11 should be pruned.
 	require.NoError(t, s.prune(context.Background(), indexToHash(10)))
-	assert.Equal(t, 90, len(s.Nodes), "Incorrect nodes count")
-	assert.Equal(t, 90, len(s.NodeIndices), "Incorrect node indices count")
+	assert.Equal(t, 90, len(s.nodes), "Incorrect nodes count")
+	assert.Equal(t, 90, len(s.nodesIndices), "Incorrect node indices count")
 
 	// One more time.
 	require.NoError(t, s.prune(context.Background(), indexToHash(20)))
-	assert.Equal(t, 80, len(s.Nodes), "Incorrect nodes count")
-	assert.Equal(t, 80, len(s.NodeIndices), "Incorrect node indices count")
+	assert.Equal(t, 80, len(s.nodes), "Incorrect nodes count")
+	assert.Equal(t, 80, len(s.nodesIndices), "Incorrect node indices count")
 }
 func TestStore_LeadsToViableHead(t *testing.T) {
 	tests := []struct {
@@ -327,15 +327,15 @@ func TestStore_LeadsToViableHead(t *testing.T) {
 		{&Node{}, 0, 0, true},
 		{&Node{}, 1, 0, false},
 		{&Node{}, 0, 1, false},
-		{&Node{FinalizedEpoch: 1, JustifiedEpoch: 1}, 1, 1, true},
-		{&Node{FinalizedEpoch: 1, JustifiedEpoch: 1}, 2, 2, false},
-		{&Node{FinalizedEpoch: 3, JustifiedEpoch: 4}, 4, 3, true},
+		{&Node{finalizedEpoch: 1, justifiedEpoch: 1}, 1, 1, true},
+		{&Node{finalizedEpoch: 1, justifiedEpoch: 1}, 2, 2, false},
+		{&Node{finalizedEpoch: 3, justifiedEpoch: 4}, 4, 3, true},
 	}
 	for _, tc := range tests {
 		s := &Store{
-			JustifiedEpoch: tc.justifiedEpoch,
-			FinalizedEpoch: tc.finalizedEpoch,
-			Nodes:          []*Node{tc.n},
+			justifiedEpoch: tc.justifiedEpoch,
+			finalizedEpoch: tc.finalizedEpoch,
+			nodes:          []*Node{tc.n},
 		}
 		got, err := s.leadsToViableHead(tc.n)
 		require.NoError(t, err)
@@ -353,14 +353,14 @@ func TestStore_ViableForHead(t *testing.T) {
 		{&Node{}, 0, 0, true},
 		{&Node{}, 1, 0, false},
 		{&Node{}, 0, 1, false},
-		{&Node{FinalizedEpoch: 1, JustifiedEpoch: 1}, 1, 1, true},
-		{&Node{FinalizedEpoch: 1, JustifiedEpoch: 1}, 2, 2, false},
-		{&Node{FinalizedEpoch: 3, JustifiedEpoch: 4}, 4, 3, true},
+		{&Node{finalizedEpoch: 1, justifiedEpoch: 1}, 1, 1, true},
+		{&Node{finalizedEpoch: 1, justifiedEpoch: 1}, 2, 2, false},
+		{&Node{finalizedEpoch: 3, justifiedEpoch: 4}, 4, 3, true},
 	}
 	for _, tc := range tests {
 		s := &Store{
-			JustifiedEpoch: tc.justifiedEpoch,
-			FinalizedEpoch: tc.finalizedEpoch,
+			justifiedEpoch: tc.justifiedEpoch,
+			finalizedEpoch: tc.finalizedEpoch,
 		}
 		assert.Equal(t, tc.want, s.viableForHead(tc.n))
 	}
@@ -376,15 +376,15 @@ func TestStore_HasParent(t *testing.T) {
 		{r: [32]byte{'a'}, want: false},
 		{m: map[[32]byte]uint64{{'a'}: 0}, r: [32]byte{'a'}, want: false},
 		{m: map[[32]byte]uint64{{'a'}: 0}, r: [32]byte{'a'},
-			n: []*Node{{Parent: NonExistentNode}}, want: false},
+			n: []*Node{{parent: NonExistentNode}}, want: false},
 		{m: map[[32]byte]uint64{{'a'}: 0},
-			n: []*Node{{Parent: 0}}, r: [32]byte{'a'},
+			n: []*Node{{parent: 0}}, r: [32]byte{'a'},
 			want: true},
 	}
 	for _, tc := range tests {
 		f := &ForkChoice{store: &Store{
-			NodeIndices: tc.m,
-			Nodes:       tc.n,
+			nodesIndices: tc.m,
+			nodes:        tc.n,
 		}}
 		assert.Equal(t, tc.want, f.HasParent(tc.r))
 	}
@@ -393,18 +393,18 @@ func TestStore_HasParent(t *testing.T) {
 func TestStore_AncestorRoot(t *testing.T) {
 	ctx := context.Background()
 	f := &ForkChoice{store: &Store{}}
-	f.store.NodeIndices = map[[32]byte]uint64{}
+	f.store.nodesIndices = map[[32]byte]uint64{}
 	_, err := f.AncestorRoot(ctx, [32]byte{'a'}, 0)
 	assert.ErrorContains(t, "node does not exist", err)
-	f.store.NodeIndices[[32]byte{'a'}] = 0
+	f.store.nodesIndices[[32]byte{'a'}] = 0
 	_, err = f.AncestorRoot(ctx, [32]byte{'a'}, 0)
 	assert.ErrorContains(t, "node index out of range", err)
-	f.store.NodeIndices[[32]byte{'b'}] = 1
-	f.store.NodeIndices[[32]byte{'c'}] = 2
-	f.store.Nodes = []*Node{
-		{Slot: 1, Root: [32]byte{'a'}, Parent: NonExistentNode},
-		{Slot: 2, Root: [32]byte{'b'}, Parent: 0},
-		{Slot: 3, Root: [32]byte{'c'}, Parent: 1},
+	f.store.nodesIndices[[32]byte{'b'}] = 1
+	f.store.nodesIndices[[32]byte{'c'}] = 2
+	f.store.nodes = []*Node{
+		{slot: 1, root: [32]byte{'a'}, parent: NonExistentNode},
+		{slot: 2, root: [32]byte{'b'}, parent: 0},
+		{slot: 3, root: [32]byte{'c'}, parent: 1},
 	}
 
 	r, err := f.AncestorRoot(ctx, [32]byte{'c'}, 1)

--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -18,12 +18,12 @@ var lastHeadRoot [32]byte
 // New initializes a new fork choice store.
 func New(justifiedEpoch uint64, finalizedEpoch uint64, finalizedRoot [32]byte) *ForkChoice {
 	s := &Store{
-		JustifiedEpoch: justifiedEpoch,
-		FinalizedEpoch: finalizedEpoch,
+		justifiedEpoch: justifiedEpoch,
+		finalizedEpoch: finalizedEpoch,
 		finalizedRoot:  finalizedRoot,
-		Nodes:          make([]*Node, 0),
-		NodeIndices:    make(map[[32]byte]uint64),
-		PruneThreshold: defaultPruneThreshold,
+		nodes:          make([]*Node, 0),
+		nodesIndices:   make(map[[32]byte]uint64),
+		pruneThreshold: defaultPruneThreshold,
 	}
 
 	b := make([]uint64, 0)
@@ -45,7 +45,7 @@ func (f *ForkChoice) Head(ctx context.Context, justifiedEpoch uint64, justifiedR
 	// The only time it writes to node indices is inserting and pruning blocks from the store.
 	f.store.nodeIndicesLock.RLock()
 	defer f.store.nodeIndicesLock.RUnlock()
-	deltas, newVotes, err := computeDeltas(ctx, f.store.NodeIndices, f.votes, f.balances, newBalances)
+	deltas, newVotes, err := computeDeltas(ctx, f.store.nodesIndices, f.votes, f.balances, newBalances)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "Could not compute deltas")
 	}
@@ -99,13 +99,13 @@ func (f *ForkChoice) Prune(ctx context.Context, finalizedRoot [32]byte) error {
 	return f.store.prune(ctx, finalizedRoot)
 }
 
-// Nodes returns the copied list of block nodes in the fork choice store.
+// nodes returns the copied list of block nodes in the fork choice store.
 func (f *ForkChoice) Nodes() []*Node {
 	f.store.nodeIndicesLock.RLock()
 	defer f.store.nodeIndicesLock.RUnlock()
 
-	cpy := make([]*Node, len(f.store.Nodes))
-	copy(cpy, f.store.Nodes)
+	cpy := make([]*Node, len(f.store.nodes))
+	copy(cpy, f.store.nodes)
 	return cpy
 }
 
@@ -121,12 +121,12 @@ func (f *ForkChoice) Node(root [32]byte) *Node {
 	f.store.nodeIndicesLock.RLock()
 	defer f.store.nodeIndicesLock.RUnlock()
 
-	index, ok := f.store.NodeIndices[root]
+	index, ok := f.store.nodesIndices[root]
 	if !ok {
 		return nil
 	}
 
-	return copyNode(f.store.Nodes[index])
+	return copyNode(f.store.nodes[index])
 }
 
 // HasNode returns true if the node exists in fork choice store,
@@ -135,7 +135,7 @@ func (f *ForkChoice) HasNode(root [32]byte) bool {
 	f.store.nodeIndicesLock.RLock()
 	defer f.store.nodeIndicesLock.RUnlock()
 
-	_, ok := f.store.NodeIndices[root]
+	_, ok := f.store.nodesIndices[root]
 	return ok
 }
 
@@ -145,34 +145,63 @@ func (f *ForkChoice) HasParent(root [32]byte) bool {
 	f.store.nodeIndicesLock.RLock()
 	defer f.store.nodeIndicesLock.RUnlock()
 
-	i, ok := f.store.NodeIndices[root]
-	if !ok || i >= uint64(len(f.store.Nodes)) {
+	i, ok := f.store.nodesIndices[root]
+	if !ok || i >= uint64(len(f.store.nodes)) {
 		return false
 	}
 
-	return f.store.Nodes[i].Parent != NonExistentNode
+	return f.store.nodes[i].parent != NonExistentNode
 }
 
 // AncestorRoot returns the ancestor root of input block root at a given slot.
 func (f *ForkChoice) AncestorRoot(ctx context.Context, root [32]byte, slot uint64) ([]byte, error) {
-	i, ok := f.store.NodeIndices[root]
+	i, ok := f.store.nodesIndices[root]
 	if !ok {
 		return nil, errors.New("node does not exist")
 	}
-	if i >= uint64(len(f.store.Nodes)) {
+	if i >= uint64(len(f.store.nodes)) {
 		return nil, errors.New("node index out of range")
 	}
 
-	for f.store.Nodes[i].Slot > slot {
+	for f.store.nodes[i].slot > slot {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
 
-		i = f.store.Nodes[i].Parent
+		i = f.store.nodes[i].parent
 	}
-	if i >= uint64(len(f.store.Nodes)) {
+	if i >= uint64(len(f.store.nodes)) {
 		return nil, errors.New("node index out of range")
 	}
 
-	return f.store.Nodes[i].Root[:], nil
+	return f.store.nodes[i].root[:], nil
+}
+
+// PruneThreshold of fork choice store.
+func (s *Store) PruneThreshold() uint64 {
+	return s.pruneThreshold
+}
+
+// justifiedEpoch of fork choice store.
+func (s *Store) JustifiedEpoch() uint64 {
+	return s.justifiedEpoch
+}
+
+// finalizedEpoch of fork choice store.
+func (s *Store) FinalizedEpoch() uint64 {
+	return s.finalizedEpoch
+}
+
+// Nodes of fork choice store.
+func (s *Store) Nodes() []*Node {
+	s.nodeIndicesLock.RLock()
+	defer s.nodeIndicesLock.RUnlock()
+	return s.nodes
+}
+
+// NodesIndices of fork choice store.
+func (s *Store) NodesIndices() map[[32]byte]uint64 {
+	s.nodeIndicesLock.RLock()
+	defer s.nodeIndicesLock.RUnlock()
+	return s.nodesIndices
 }

--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -99,7 +99,7 @@ func (f *ForkChoice) Prune(ctx context.Context, finalizedRoot [32]byte) error {
 	return f.store.prune(ctx, finalizedRoot)
 }
 
-// nodes returns the copied list of block nodes in the fork choice store.
+// Nodes returns the copied list of block nodes in the fork choice store.
 func (f *ForkChoice) Nodes() []*Node {
 	f.store.nodeIndicesLock.RLock()
 	defer f.store.nodeIndicesLock.RUnlock()
@@ -182,12 +182,12 @@ func (s *Store) PruneThreshold() uint64 {
 	return s.pruneThreshold
 }
 
-// justifiedEpoch of fork choice store.
+// JustifiedEpoch of fork choice store.
 func (s *Store) JustifiedEpoch() uint64 {
 	return s.justifiedEpoch
 }
 
-// finalizedEpoch of fork choice store.
+// FinalizedEpoch of fork choice store.
 func (s *Store) FinalizedEpoch() uint64 {
 	return s.finalizedEpoch
 }

--- a/beacon-chain/forkchoice/protoarray/types.go
+++ b/beacon-chain/forkchoice/protoarray/types.go
@@ -11,27 +11,27 @@ type ForkChoice struct {
 
 // Store defines the fork choice store which includes block nodes and the last view of checkpoint information.
 type Store struct {
-	PruneThreshold  uint64              // do not prune tree unless threshold is reached.
-	JustifiedEpoch  uint64              // latest justified epoch in store.
-	FinalizedEpoch  uint64              // latest finalized epoch in store.
+	pruneThreshold  uint64              // do not prune tree unless threshold is reached.
+	justifiedEpoch  uint64              // latest justified epoch in store.
+	finalizedEpoch  uint64              // latest finalized epoch in store.
 	finalizedRoot   [32]byte            // latest finalized root in store.
-	Nodes           []*Node             // list of block nodes, each node is a representation of one block.
-	NodeIndices     map[[32]byte]uint64 // the root of block node and the Nodes index in the list.
+	nodes           []*Node             // list of block nodes, each node is a representation of one block.
+	nodesIndices    map[[32]byte]uint64 // the root of block node and the nodes index in the list.
 	nodeIndicesLock sync.RWMutex
 }
 
 // Node defines the individual block which includes its block parent, ancestor and how much weight accounted for it.
 // This is used as an array based stateful DAG for efficient fork choice look up.
 type Node struct {
-	Slot           uint64   // Slot of the block converted to the node.
-	Root           [32]byte // Root of the block converted to the node.
-	Parent         uint64   // Parent index of this node.
-	JustifiedEpoch uint64   // JustifiedEpoch of this node.
-	FinalizedEpoch uint64   // FinalizedEpoch of this node.
-	Weight         uint64   // Weight of this node.
-	BestChild      uint64   // BestChild index of this node.
-	BestDescendant uint64   // BestDescendant of this node.
-	Graffiti       [32]byte // Graffiti of the block node.
+	slot           uint64   // slot of the block converted to the node.
+	root           [32]byte // root of the block converted to the node.
+	parent         uint64   // parent index of this node.
+	justifiedEpoch uint64   // justifiedEpoch of this node.
+	finalizedEpoch uint64   // finalizedEpoch of this node.
+	weight         uint64   // weight of this node.
+	bestChild      uint64   // bestChild index of this node.
+	bestDescendant uint64   // bestDescendant of this node.
+	graffiti       [32]byte // graffiti of the block node.
 }
 
 // Vote defines an individual validator's vote.

--- a/beacon-chain/forkchoice/protoarray/vote_test.go
+++ b/beacon-chain/forkchoice/protoarray/vote_test.go
@@ -247,9 +247,9 @@ func TestVotes_CanFindHead(t *testing.T) {
 	assert.Equal(t, indexToHash(9), r, "Incorrect head for with justified epoch at 1")
 
 	// Verify pruning below the prune threshold does not affect head.
-	f.store.PruneThreshold = 1000
+	f.store.pruneThreshold = 1000
 	require.NoError(t, f.store.prune(context.Background(), indexToHash(5)))
-	assert.Equal(t, 11, len(f.store.Nodes), "Incorrect nodes length after prune")
+	assert.Equal(t, 11, len(f.store.nodes), "Incorrect nodes length after prune")
 
 	r, err = f.Head(context.Background(), 2, indexToHash(5), balances, 2)
 	require.NoError(t, err)
@@ -271,9 +271,9 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//          8
 	//         / \
 	//        9  10
-	f.store.PruneThreshold = 1
+	f.store.pruneThreshold = 1
 	require.NoError(t, f.store.prune(context.Background(), indexToHash(5)))
-	assert.Equal(t, 6, len(f.store.Nodes), "Incorrect nodes length after prune")
+	assert.Equal(t, 6, len(f.store.nodes), "Incorrect nodes length after prune")
 
 	r, err = f.Head(context.Background(), 2, indexToHash(5), balances, 2)
 	require.NoError(t, err)

--- a/beacon-chain/rpc/debug/forkchoice.go
+++ b/beacon-chain/rpc/debug/forkchoice.go
@@ -12,31 +12,32 @@ import (
 func (ds *Server) GetProtoArrayForkChoice(ctx context.Context, _ *ptypes.Empty) (*pbrpc.ProtoArrayForkChoiceResponse, error) {
 	store := ds.HeadFetcher.ProtoArrayStore()
 
-	nodes := store.Nodes
+	nodes := store.Nodes()
 	returnedNodes := make([]*pbrpc.ProtoArrayNode, len(nodes))
 
 	for i := 0; i < len(returnedNodes); i++ {
+		r := nodes[i].Root()
 		returnedNodes[i] = &pbrpc.ProtoArrayNode{
-			Slot:           nodes[i].Slot,
-			Root:           nodes[i].Root[:],
-			Parent:         nodes[i].Parent,
-			JustifiedEpoch: nodes[i].JustifiedEpoch,
-			FinalizedEpoch: nodes[i].FinalizedEpoch,
-			Weight:         nodes[i].Weight,
-			BestChild:      nodes[i].BestChild,
-			BestDescendant: nodes[i].BestDescendant,
+			Slot:           nodes[i].Slot(),
+			Root:           r[:],
+			Parent:         nodes[i].Parent(),
+			JustifiedEpoch: nodes[i].JustifiedEpoch(),
+			FinalizedEpoch: nodes[i].FinalizedEpoch(),
+			Weight:         nodes[i].Weight(),
+			BestChild:      nodes[i].BestChild(),
+			BestDescendant: nodes[i].BestDescendant(),
 		}
 	}
 
-	indices := make(map[string]uint64, len(store.NodeIndices))
-	for k, v := range store.NodeIndices {
+	indices := make(map[string]uint64, len(store.NodesIndices()))
+	for k, v := range store.NodesIndices() {
 		indices[hex.EncodeToString(k[:])] = v
 	}
 
 	return &pbrpc.ProtoArrayForkChoiceResponse{
-		PruneThreshold:  store.PruneThreshold,
-		JustifiedEpoch:  store.JustifiedEpoch,
-		FinalizedEpoch:  store.FinalizedEpoch,
+		PruneThreshold:  store.PruneThreshold(),
+		JustifiedEpoch:  store.JustifiedEpoch(),
+		FinalizedEpoch:  store.FinalizedEpoch(),
 		ProtoArrayNodes: returnedNodes,
 		Indices:         indices,
 	}, nil

--- a/beacon-chain/rpc/debug/forkchoice_test.go
+++ b/beacon-chain/rpc/debug/forkchoice_test.go
@@ -12,21 +12,11 @@ import (
 )
 
 func TestServer_GetForkChoice(t *testing.T) {
-	store := &protoarray.Store{
-		PruneThreshold: 1,
-		JustifiedEpoch: 2,
-		FinalizedEpoch: 3,
-		Nodes:          []*protoarray.Node{{Slot: 4, Root: [32]byte{'a'}}},
-	}
-
-	bs := &Server{
-		HeadFetcher: &mock.ChainService{ForkChoiceStore: store},
-	}
-
+	store := &protoarray.Store{}
+	bs := &Server{HeadFetcher: &mock.ChainService{ForkChoiceStore: store}}
 	res, err := bs.GetProtoArrayForkChoice(context.Background(), &ptypes.Empty{})
 	require.NoError(t, err)
-	assert.Equal(t, store.PruneThreshold, res.PruneThreshold, "Did not get wanted prune threshold")
-	assert.Equal(t, store.JustifiedEpoch, res.JustifiedEpoch, "Did not get wanted justified epoch")
-	assert.Equal(t, store.FinalizedEpoch, res.FinalizedEpoch, "Did not get wanted finalized epoch")
-	assert.Equal(t, store.Nodes[0].Slot, res.ProtoArrayNodes[0].Slot, "Did not get wanted node slot")
+	assert.Equal(t, store.PruneThreshold(), res.PruneThreshold, "Did not get wanted prune threshold")
+	assert.Equal(t, store.JustifiedEpoch(), res.JustifiedEpoch, "Did not get wanted justified epoch")
+	assert.Equal(t, store.FinalizedEpoch(), res.FinalizedEpoch, "Did not get wanted finalized epoch")
 }

--- a/go.sum
+++ b/go.sum
@@ -950,8 +950,6 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.4.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
-github.com/prometheus/client_golang v1.6.0 h1:YVPodQOcK15POxhgARIvnDRVpLcuK8mglnMrWfyrw6A=
-github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
 github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -965,14 +963,14 @@ github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
 github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
+github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.0.10/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
-github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
-github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
+github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.10.0 h1:If5rVCMTp6W2SiRAQFlbpJNgVlgMEd+U2GZckwK38ic=
@@ -1356,7 +1354,6 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200219091948-cb0a6d8edb6c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Clean up

**What does this PR do? Why is it needed?**
Currently Proto array fork choice exports all its node and store types. This is not a good practice and is not safe.
This PR un-exports all the types and implements proper getters around them.


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
