### PR TITLE
Revert "Subscriber: use target epoch for hasSeen cache"

### DIFF
--- a/beacon-chain/sync/subscriber_beacon_attestation.go
+++ b/beacon-chain/sync/subscriber_beacon_attestation.go
@@ -24,7 +24,7 @@ func (s *Service) committeeIndexBeaconAttestationSubscriber(ctx context.Context,
 	if a.Data == nil {
 		return errors.New("nil attestation")
 	}
-	s.setSeenCommitteeIndicesEpoch(a.Data.Target.Epoch, a.Data.CommitteeIndex, a.AggregationBits)
+	s.setSeenCommitteeIndicesSlot(a.Data.Slot, a.Data.CommitteeIndex, a.AggregationBits)
 
 	exists, err := s.attPool.HasAggregatedAttestation(a)
 	if err != nil {

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -69,8 +69,8 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		return pubsub.ValidationIgnore
 	}
 
-	// Verify this the first attestation received for the participating validator for the target epoch.
-	if s.hasSeenCommitteeIndicesEpoch(att.Data.Target.Epoch, att.Data.CommitteeIndex, att.AggregationBits) {
+	// Verify this the first attestation received for the participating validator for the slot.
+	if s.hasSeenCommitteeIndicesSlot(att.Data.Slot, att.Data.CommitteeIndex, att.AggregationBits) {
 		return pubsub.ValidationIgnore
 	}
 	// Reject an attestation if it references an invalid block.
@@ -138,28 +138,28 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		}
 	}
 
-	s.setSeenCommitteeIndicesEpoch(att.Data.Target.Epoch, att.Data.CommitteeIndex, att.AggregationBits)
+	s.setSeenCommitteeIndicesSlot(att.Data.Slot, att.Data.CommitteeIndex, att.AggregationBits)
 
 	msg.ValidatorData = att
 
 	return pubsub.ValidationAccept
 }
 
-// Returns true if the attestation was already seen for the participating validator for the target epoch.
-func (s *Service) hasSeenCommitteeIndicesEpoch(epoch uint64, committeeID uint64, aggregateBits []byte) bool {
+// Returns true if the attestation was already seen for the participating validator for the slot.
+func (s *Service) hasSeenCommitteeIndicesSlot(slot uint64, committeeID uint64, aggregateBits []byte) bool {
 	s.seenAttestationLock.RLock()
 	defer s.seenAttestationLock.RUnlock()
-	b := append(bytesutil.Bytes32(epoch), bytesutil.Bytes32(committeeID)...)
+	b := append(bytesutil.Bytes32(slot), bytesutil.Bytes32(committeeID)...)
 	b = append(b, aggregateBits...)
 	_, seen := s.seenAttestationCache.Get(string(b))
 	return seen
 }
 
-// Set committee's indices and target epoch as seen for incoming attestations.
-func (s *Service) setSeenCommitteeIndicesEpoch(epoch uint64, committeeID uint64, aggregateBits []byte) {
+// Set committee's indices and slot as seen for incoming attestations.
+func (s *Service) setSeenCommitteeIndicesSlot(slot uint64, committeeID uint64, aggregateBits []byte) {
 	s.seenAttestationLock.Lock()
 	defer s.seenAttestationLock.Unlock()
-	b := append(bytesutil.Bytes32(epoch), bytesutil.Bytes32(committeeID)...)
+	b := append(bytesutil.Bytes32(slot), bytesutil.Bytes32(committeeID)...)
 	b = append(b, aggregateBits...)
 	s.seenAttestationCache.Add(string(b), true)
 }


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#6908

I was notified that #6908 has caused e2e to flake more than usual with the following failures: 
```
    TestEndToEnd_MinimalConfig/validators_participating_epoch_14: endtoend_test.go:117: evaluation failed for epoch 14: validator participation was below for epoch 13, expected 0.950000, received: 0.946996
```

Let's revert it for the time being and debug