### PR TITLE
Fix loading historical blocks to replay cold state

### DIFF
--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -116,6 +116,7 @@ func (s *State) LoadBlocks(ctx context.Context, startSlot uint64, endSlot uint64
 	if err != nil {
 		return nil, err
 	}
+
 	blockRoots, err := s.beaconDB.BlockRoots(ctx, filter)
 	if err != nil {
 		return nil, err
@@ -327,24 +328,49 @@ func (s *State) processStateUpTo(ctx context.Context, state *state.BeaconState, 
 	if state.Slot() >= slot {
 		return state, nil
 	}
-
-	lastBlockRoot, lastBlockSlot, err := s.lastSavedBlock(ctx, slot)
+	_, lastBlockSlot, err := s.lastSavedBlock(ctx, slot)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get last saved block")
 	}
+
 	// Short circuit if no block was saved, replay using slots only.
 	if lastBlockSlot == 0 {
 		return s.ReplayBlocks(ctx, state, []*ethpb.SignedBeaconBlock{}, slot)
 	}
 
-	blks, err := s.LoadBlocks(ctx, state.Slot()+1, lastBlockSlot, lastBlockRoot)
+	blks, err := s.loadFinalizedBlocks(ctx, state.Slot()+1, lastBlockSlot)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not load blocks")
 	}
+
 	state, err = s.ReplayBlocks(ctx, state, blks, slot)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not replay blocks")
 	}
 
 	return state, nil
+}
+
+// Given the start slot and the end slot, this returns the finalized beacon blocks in between.
+// Since hot states don't have finalized blocks, this should ONLY be used for replaying cold state.
+func (s *State) loadFinalizedBlocks(ctx context.Context, startSlot uint64, endSlot uint64) ([]*ethpb.SignedBeaconBlock, error) {
+	f := filters.NewFilter().SetStartSlot(startSlot).SetEndSlot(endSlot)
+	bs, err := s.beaconDB.Blocks(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	bRoots, err := s.beaconDB.BlockRoots(ctx, f)
+	if err != nil {
+		return nil, err
+	}
+	if len(bs) != len(bRoots) {
+		return nil, errors.New("length of blocks and roots don't match")
+	}
+	fbs := make([]*ethpb.SignedBeaconBlock, 0, len(bs))
+	for i := len(bs) - 1; i >= 0; i-- {
+		if s.beaconDB.IsFinalizedBlock(ctx, bRoots[i]) {
+			fbs = append(fbs, bs[i])
+		}
+	}
+	return fbs, nil
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Bug fix


**What does this PR do? Why is it needed?**
We have a bug in the loading of historical blocks to replay cold state. We did not check whether the block is finalized before replaying the blocks. Block explorers often see sharp drop of participations and that's due to nodes started the replay using an orphaned block. More analyses: https://github.com/prysmaticlabs/prysm/issues/6927#issuecomment-671613484  

The fix was to implement `loadFinalizedBlocks` and use that for cold state generation

**Which issues(s) does this PR fix?**

Fixes #6927 

**Other notes for review**

Tested run time
