### PR TITLE
Support Domains For Discovery

### DIFF
--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -142,6 +142,19 @@ func (s *Service) createListener(
 			localNode.SetStaticIP(hostIP)
 		}
 	}
+	if s.cfg.HostDNS != "" {
+		host := s.cfg.HostDNS
+		ips, err := net.LookupIP(host)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not resolve host address")
+		}
+		if len(ips) > 0 {
+			// Use first IP returned from the
+			// resolver.
+			firstIP := ips[0]
+			localNode.SetFallbackIP(firstIP)
+		}
+	}
 	dv5Cfg := discover.Config{
 		PrivateKey: privKey,
 	}

--- a/beacon-chain/p2p/discovery_test.go
+++ b/beacon-chain/p2p/discovery_test.go
@@ -205,3 +205,24 @@ func TestStaticPeering_PeersAreAdded(t *testing.T) {
 	require.NoError(t, s.Stop())
 	exitRoutine <- true
 }
+
+func TestHostIsResolved(t *testing.T) {
+	// As defined in RFC 2606 , example.org is a
+	// reserved example domain name.
+	exampleHost := "example.org"
+	exampleIP := "93.184.216.34"
+
+	s := &Service{
+		cfg: &Config{
+			HostDNS: exampleHost,
+		},
+		genesisTime:           time.Now(),
+		genesisValidatorsRoot: []byte{'A'},
+	}
+	ip, key := createAddrAndPrivKey(t)
+	list, err := s.createListener(ip, key)
+	require.NoError(t, err)
+
+	newIP := list.Self().IP()
+	assert.Equal(t, exampleIP, newIP.String(), "Did not resolve to expected IP")
+}


### PR DESCRIPTION
**What type of PR is this?**

Feature Improvement

**What does this PR do? Why is it needed?**

- [x] Resolves provided domain to an IP and initializes local node with it. This is used for discovery to advertise with the current 
IP of the node.

**Which issues(s) does this PR fix?**

None

**Other notes for review**
