### PR TITLE
Add and use genesis time in config

### DIFF
--- a/beacon-chain/blockchain/process_attestation.go
+++ b/beacon-chain/blockchain/process_attestation.go
@@ -73,7 +73,7 @@ func (s *Service) onAttestation(ctx context.Context, a *ethpb.Attestation) ([]ui
 		return nil, err
 	}
 
-	genesisTime := baseState.GenesisTime()
+	genesisTime := helpers.GenesisTime(baseState)
 
 	// Verify attestation target is from current epoch or previous epoch.
 	if err := s.verifyAttTargetEpoch(ctx, genesisTime, uint64(roughtime.Now().Unix()), tgt); err != nil {

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -49,7 +49,7 @@ func (s *Service) getBlockPreState(ctx context.Context, b *ethpb.BeaconBlock) (*
 	}
 
 	// Verify block slot time is not from the future.
-	if err := helpers.VerifySlotTime(preState.GenesisTime(), b.Slot, params.BeaconNetworkConfig().MaximumGossipClockDisparity); err != nil {
+	if err := helpers.VerifySlotTime(helpers.GenesisTime(preState), b.Slot, params.BeaconNetworkConfig().MaximumGossipClockDisparity); err != nil {
 		return nil, err
 	}
 

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -150,8 +150,8 @@ func (s *Service) Start() {
 	// If the chain has already been initialized, simply start the block processing routine.
 	if beaconState != nil {
 		log.Info("Blockchain data already exists in DB, initializing...")
-		s.genesisTime = time.Unix(int64(beaconState.GenesisTime()), 0)
-		s.opsService.SetGenesisTime(beaconState.GenesisTime())
+		s.genesisTime = time.Unix(int64(helpers.GenesisTime(beaconState)), 0)
+		s.opsService.SetGenesisTime(helpers.GenesisTime(beaconState))
 		if err := s.initializeChainInfo(s.ctx); err != nil {
 			log.Fatalf("Could not set up chain info: %v", err)
 		}
@@ -285,7 +285,7 @@ func (s *Service) initializeBeaconChain(
 		return nil, err
 	}
 
-	s.opsService.SetGenesisTime(genesisState.GenesisTime())
+	s.opsService.SetGenesisTime(helpers.GenesisTime(genesisState))
 
 	return genesisState, nil
 }

--- a/beacon-chain/core/helpers/slot_epoch.go
+++ b/beacon-chain/core/helpers/slot_epoch.go
@@ -119,6 +119,15 @@ func SlotsSince(time time.Time) uint64 {
 	return uint64(roughtime.Since(time).Seconds()) / params.BeaconConfig().SecondsPerSlot
 }
 
+// GenesisTime prioritizes to return the genesis time in config unless the config
+// genesis time is 0. Then it returns the genesis time in state.
+func GenesisTime(state *stateTrie.BeaconState) uint64 {
+	if params.BeaconConfig().GenesisTime == 0 {
+		return state.GenesisTime()
+	}
+	return params.BeaconConfig().GenesisTime
+}
+
 // RoundUpToNearestEpoch rounds up the provided slot value to the nearest epoch.
 func RoundUpToNearestEpoch(slot uint64) uint64 {
 	if slot%params.BeaconConfig().SlotsPerEpoch != 0 {

--- a/beacon-chain/core/helpers/slot_epoch_test.go
+++ b/beacon-chain/core/helpers/slot_epoch_test.go
@@ -284,3 +284,39 @@ func TestVerifySlotTime(t *testing.T) {
 		})
 	}
 }
+
+func TestGenesisTime(t *testing.T) {
+	type args struct {
+		configTime uint64
+		stateTime  uint64
+	}
+	tests := []struct {
+		name string
+		args args
+		want uint64
+	}{
+		{
+			name: "Use config genesis time",
+			args: args{configTime: 1, stateTime: 2},
+			want: 1,
+		},
+		{
+			name: "Use state genesis time",
+			args: args{configTime: 0, stateTime: 2},
+			want: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := params.BeaconConfig()
+			c.GenesisTime = tt.args.configTime
+			params.OverrideBeaconConfig(c)
+			s := &pb.BeaconState{GenesisTime: tt.args.stateTime}
+			state, err := beaconstate.InitializeFromProto(s)
+			require.NoError(t, err)
+			if got := GenesisTime(state); got != tt.want {
+				t.Errorf("GenesisTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/beacon-chain/rpc/beacon/validators_stream.go
+++ b/beacon-chain/rpc/beacon/validators_stream.go
@@ -119,7 +119,7 @@ func (bs *Server) StreamValidatorsInfo(stream ethpb.BeaconChain_StreamValidators
 		eth1BlocktimesMutex: &sync.RWMutex{},
 		currentEpoch:        headState.Slot() / params.BeaconConfig().SlotsPerEpoch,
 		stream:              stream,
-		genesisTime:         headState.GenesisTime(),
+		genesisTime:         helpers.GenesisTime(headState),
 	}
 	defer infostream.stateSub.Unsubscribe()
 

--- a/beacon-chain/rpc/validator/status.go
+++ b/beacon-chain/rpc/validator/status.go
@@ -264,7 +264,7 @@ func (vs *Server) depositBlockSlot(ctx context.Context, beaconState *stateTrie.B
 	votingPeriod := time.Duration(period*params.BeaconConfig().SecondsPerSlot) * time.Second
 	timeToInclusion := eth1UnixTime.Add(votingPeriod)
 
-	eth2Genesis := time.Unix(int64(beaconState.GenesisTime()), 0)
+	eth2Genesis := time.Unix(int64(helpers.GenesisTime(beaconState)), 0)
 
 	if eth2Genesis.After(timeToInclusion) {
 		depositBlockSlot = 0

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -113,7 +113,7 @@ func (s *Service) Start() {
 		}
 		stateSub.Unsubscribe()
 	} else {
-		genesis = time.Unix(int64(headState.GenesisTime()), 0)
+		genesis = time.Unix(int64(helpers.GenesisTime(headState)), 0)
 	}
 
 	if genesis.After(roughtime.Now()) {
@@ -196,7 +196,7 @@ func (s *Service) Resync() error {
 	if err != nil {
 		return errors.Wrap(err, "could not retrieve head state")
 	}
-	genesis := time.Unix(int64(headState.GenesisTime()), 0)
+	genesis := time.Unix(int64(helpers.GenesisTime(headState)), 0)
 
 	s.waitForMinimumPeers()
 	err = s.roundRobinSync(genesis)

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -26,10 +26,11 @@ type BeaconChainConfig struct {
 	ShuffleRoundCount              uint64 `yaml:"SHUFFLE_ROUND_COUNT"`                // ShuffleRoundCount is used for retrieving the permuted index.
 	MinGenesisActiveValidatorCount uint64 `yaml:"MIN_GENESIS_ACTIVE_VALIDATOR_COUNT"` // MinGenesisActiveValidatorCount defines how many validator deposits needed to kick off beacon chain.
 	MinGenesisTime                 uint64 `yaml:"MIN_GENESIS_TIME"`                   // MinGenesisTime is the time that needed to pass before kicking off beacon chain.
-	TargetAggregatorsPerCommittee  uint64 `yaml:"TARGET_AGGREGATORS_PER_COMMITTEE"`   // TargetAggregatorsPerCommittee defines the number of aggregators inside one committee.
-	HysteresisQuotient             uint64 `yaml:"HYSTERESIS_QUOTIENT"`                // HysteresisQuotient defines the hysteresis quotient for effective balance calculations.
-	HysteresisDownwardMultiplier   uint64 `yaml:"HYSTERESIS_DOWNWARD_MULTIPLIER"`     // HysteresisDownwardMultiplier defines the hysteresis downward multiplier for effective balance calculations.
-	HysteresisUpwardMultiplier     uint64 `yaml:"HYSTERESIS_UPWARD_MULTIPLIER"`       // HysteresisUpwardMultiplier defines the hysteresis upward multiplier for effective balance calculations.
+	GenesisTime                    uint64 // GenesisTime of the beacon chain, defaults to 0.
+	TargetAggregatorsPerCommittee  uint64 `yaml:"TARGET_AGGREGATORS_PER_COMMITTEE"` // TargetAggregatorsPerCommittee defines the number of aggregators inside one committee.
+	HysteresisQuotient             uint64 `yaml:"HYSTERESIS_QUOTIENT"`              // HysteresisQuotient defines the hysteresis quotient for effective balance calculations.
+	HysteresisDownwardMultiplier   uint64 `yaml:"HYSTERESIS_DOWNWARD_MULTIPLIER"`   // HysteresisDownwardMultiplier defines the hysteresis downward multiplier for effective balance calculations.
+	HysteresisUpwardMultiplier     uint64 `yaml:"HYSTERESIS_UPWARD_MULTIPLIER"`     // HysteresisUpwardMultiplier defines the hysteresis upward multiplier for effective balance calculations.
 
 	// Gwei value constants.
 	MinDepositAmount          uint64 `yaml:"MIN_DEPOSIT_AMOUNT"`          // MinDepositAmount is the maximal amount of Gwei a validator can send to the deposit contract at once.

--- a/shared/params/testnet_medalla_config.go
+++ b/shared/params/testnet_medalla_config.go
@@ -28,6 +28,7 @@ func MedallaConfig() *BeaconChainConfig {
 	cfg := MainnetConfig().Copy()
 	cfg.MinGenesisTime = 1596546000
 	cfg.GenesisForkVersion = []byte{0x00, 0x00, 0x00, 0x01}
+	cfg.GenesisTime = 1596546008
 	return cfg
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Feature


**What does this PR do? Why is it needed?**
This PR created and utilized `params.BeaconChain().GenesisTime` to reference in validator client and beacon chain, if available. Added a helper to check If the genesis time is available for the given network and fallback to the original design of reading `state.GenesisTime`.

**Which issues(s) does this PR fix?**

Fixes #6545

**Other notes for review**
Tested run time