### PR TITLE
Go syntax-repr in test assertions

### DIFF
--- a/shared/testutil/assert/assertions_test.go
+++ b/shared/testutil/assert/assertions_test.go
@@ -162,7 +162,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 			},
-			expectedErr: "Values are not equal, want: {42}, got: {41}",
+			expectedErr: "Values are not equal, want: struct { i int }{i:42}, got: struct { i int }{i:41}",
 		},
 		{
 			name: "custom error message",
@@ -172,7 +172,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				actual:   struct{ i int }{41},
 				msgs:     []interface{}{"Custom values are not equal"},
 			},
-			expectedErr: "Custom values are not equal, want: {42}, got: {41}",
+			expectedErr: "Custom values are not equal, want: struct { i int }{i:42}, got: struct { i int }{i:41}",
 		},
 		{
 			name: "custom error message with params",
@@ -182,7 +182,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				actual:   struct{ i int }{41},
 				msgs:     []interface{}{"Custom values are not equal (for slot %d)", 12},
 			},
-			expectedErr: "Custom values are not equal (for slot 12), want: {42}, got: {41}",
+			expectedErr: "Custom values are not equal (for slot 12), want: struct { i int }{i:42}, got: struct { i int }{i:41}",
 		},
 	}
 	for _, tt := range tests {

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -39,7 +39,7 @@ func DeepEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...
 	errMsg := parseMsg("Values are not equal", msg...)
 	if !reflect.DeepEqual(expected, actual) {
 		_, file, line, _ := runtime.Caller(2)
-		loggerFn("%s:%d %s, want: %v, got: %v", filepath.Base(file), line, errMsg, expected, actual)
+		loggerFn("%s:%d %s, want: %#v, got: %#v", filepath.Base(file), line, errMsg, expected, actual)
 	}
 }
 

--- a/shared/testutil/require/requires_test.go
+++ b/shared/testutil/require/requires_test.go
@@ -162,7 +162,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				expected: struct{ i int }{42},
 				actual:   struct{ i int }{41},
 			},
-			expectedErr: "Values are not equal, want: {42}, got: {41}",
+			expectedErr: "Values are not equal, want: struct { i int }{i:42}, got: struct { i int }{i:41}",
 		},
 		{
 			name: "custom error message",
@@ -172,7 +172,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				actual:   struct{ i int }{41},
 				msgs:     []interface{}{"Custom values are not equal"},
 			},
-			expectedErr: "Custom values are not equal, want: {42}, got: {41}",
+			expectedErr: "Custom values are not equal, want: struct { i int }{i:42}, got: struct { i int }{i:41}",
 		},
 		{
 			name: "custom error message with params",
@@ -182,7 +182,7 @@ func TestAssert_DeepEqual(t *testing.T) {
 				actual:   struct{ i int }{41},
 				msgs:     []interface{}{"Custom values are not equal (for slot %d)", 12},
 			},
-			expectedErr: "Custom values are not equal (for slot 12), want: {42}, got: {41}",
+			expectedErr: "Custom values are not equal (for slot 12), want: struct { i int }{i:42}, got: struct { i int }{i:41}",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

Other/Usability

**What does this PR do? Why is it needed?**
- More verbose output in `assert.DeepEqual()` and `require.DeepEqual()` (uses `%#v` instead of `%v` - so, Go-syntax representation of values will be returned).
- In `Equal()/NotEqual()` methods, we already include type info, so this PR introduces similar output to `DeepEqual()` calls.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- This functionality came handy when debugging list of `peer.IDs` in peer scorer, as `%#v` displays peer ids as strings, not encoded values.
