### PR TITLE
Update sendDepositTx tool

### DIFF
--- a/tools/sendDepositTx/README.md
+++ b/tools/sendDepositTx/README.md
@@ -31,7 +31,7 @@ This is a utility to help users deploy deposit contract for running their own be
 To use private key with default RPC:
 
 ```
-bazel run //tools/sendDepositTx -- --httpPath=https://goerli.prylabs.net --keystoreUTCPath /path/to/keystore --passwordFile /path/to/password --depositDelay 2  --depositContract 0x767E9ef9610Abb992099b0994D5e0c164C0813Ab
+bazel run //tools/sendDepositTx -- --httpPath=https://goerli.prylabs.net --keystoreUTCPath /path/to/keystore --passwordFile /path/to/password --depositDelay 2  --depositContract 0x07b39f4fde4a38bace212b546dac87c58dfe3fdc
 
 ```
 

--- a/tools/sendDepositTx/README.md
+++ b/tools/sendDepositTx/README.md
@@ -1,6 +1,6 @@
 ## Utility to Deploy Deposit Contract
 
-This is a utility to help users deploy deposit contract for running their own beacon chain node in a local containerized set up. To run the utility, it assumes there is a running geth node as a separate process attached to proof-of-work main chain. The utility will deploy the validator registration contract and print out the contract address. Users will pass the contract address to the beacon chain node to monitor when they have been conducted to become an active validator.
+This is a utility to help users deploy deposit contract for running their own beacon chain node in a local containerized set up. The utility will deploy the validator registration contract and print out the contract address. Users will pass the contract address to the beacon chain node to monitor when they have been conducted to become an active validator.
 
 ### Usage
 

--- a/tools/sendDepositTx/sendDeposits.go
+++ b/tools/sendDepositTx/sendDeposits.go
@@ -48,6 +48,8 @@ func main() {
 	customFormatter.FullTimestamp = true
 	logrus.SetFormatter(customFormatter)
 
+	params.UseMedallaConfig()
+
 	app := cli.App{}
 	app.Name = "sendDepositTx"
 	app.Usage = "this is a util to send deposit transactions"


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one line below and remove others.
>
Bug fix
> Feature
Documentation
> Other

**What does this PR do? Why is it needed?**

The `sendDepositTx` tool is outdated. This PR updates the tool to use Medalla beacon config and updates README
to reflect the current status in terms of geth node being no longer necessary and an updated Deposit Contract Address
in the example.

**Which issues(s) does this PR fix?**

Fixes #6971

**Other notes for review**
