### PR TITLE
DB: add block roots test

### DIFF
--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -226,6 +226,28 @@ func TestStore_Blocks_FiltersCorrectly(t *testing.T) {
 	}
 }
 
+func TestStore_Blocks_VerifyBlockRoots(t *testing.T) {
+	ctx := context.Background()
+	db := setupDB(t)
+	b1 := testutil.NewBeaconBlock()
+	b1.Block.Slot = 1
+	r1, err := stateutil.BlockRoot(b1.Block)
+	require.NoError(t, err)
+	b2 := testutil.NewBeaconBlock()
+	b2.Block.Slot = 2
+	r2, err := stateutil.BlockRoot(b2.Block)
+	require.NoError(t, err)
+
+	require.NoError(t, db.SaveBlock(ctx, b1))
+	require.NoError(t, db.SaveBlock(ctx, b2))
+
+	filter := filters.NewFilter().SetStartSlot(b1.Block.Slot).SetEndSlot(b2.Block.Slot)
+	roots, err := db.BlockRoots(ctx, filter)
+	require.NoError(t, err)
+
+	assert.DeepEqual(t, [][32]byte{r1, r2}, roots)
+}
+
 func TestStore_Blocks_Retrieve_SlotRange(t *testing.T) {
 	db := setupDB(t)
 	totalBlocks := make([]*ethpb.SignedBeaconBlock, 500)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Test

**What does this PR do? Why is it needed?**
DB pkg has block roots test, but it only verified the length of the returned block roots, not the correctness of the block roots. This PR adds an additional test to verify the correctness of the block roots.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
