### PR TITLE
Sync: Dont ban block roots for context.DeadlineExceeded

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -131,7 +131,9 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 
 		if err := s.chain.ReceiveBlock(ctx, b, blkRoot); err != nil {
 			log.Debugf("Could not process block from slot %d: %v", b.Block.Slot, err)
-			s.setBadBlock(blkRoot)
+			if err != context.DeadlineExceeded {
+				s.setBadBlock(blkRoot)
+			}
 			traceutil.AnnotateError(span, err)
 		}
 

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -32,7 +32,9 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 
 	if err := s.chain.ReceiveBlock(ctx, signed, root); err != nil {
 		interop.WriteBlockToDisk(signed, true /*failed*/)
-		s.setBadBlock(root)
+		if err != context.DeadlineExceeded {
+			s.setBadBlock(root)
+		}
 		return err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

In the current state of Medalla, it is not unreasonable for a block to fail processing while under load. 
We shouldn't ban these block roots at this moment or potentially find the client stuck, out of sync.

**Which issues(s) does this PR fix?**

Not reported.

**Other notes for review**

Suggested by @nisdas that this might be an issue.