### PR TITLE
Revert "Sync: Dont ban block roots for context.DeadlineExceeded"

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -131,9 +131,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 
 		if err := s.chain.ReceiveBlock(ctx, b, blkRoot); err != nil {
 			log.Debugf("Could not process block from slot %d: %v", b.Block.Slot, err)
-			if err != context.DeadlineExceeded {
-				s.setBadBlock(blkRoot)
-			}
+			s.setBadBlock(blkRoot)
 			traceutil.AnnotateError(span, err)
 		}
 

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -32,9 +32,7 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 
 	if err := s.chain.ReceiveBlock(ctx, signed, root); err != nil {
 		interop.WriteBlockToDisk(signed, true /*failed*/)
-		if err != context.DeadlineExceeded {
-			s.setBadBlock(root)
-		}
+		s.setBadBlock(root)
 		return err
 	}
 


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#7016

We never return `context.DeadlineExceeded` as the error, it is always wrapped. So the original PR does not do anything helpful.