### PR TITLE
Sync: fix panic and check blocks + roots lengths

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -138,7 +138,12 @@ func (s *Service) writeBlockRangeToStream(ctx context.Context, startSlot, endSlo
 	}
 	// Filter and sort our retrieved blocks, so that
 	// we only return valid sets of blocks.
-	blks, roots = s.dedupBlocksAndRoots(blks, roots)
+	blks, roots, err = s.dedupBlocksAndRoots(blks, roots)
+	if err != nil {
+		s.writeErrorResponseToStream(responseCodeServerError, genericError, stream)
+		traceutil.AnnotateError(span, err)
+		return err
+	}
 	blks, roots = s.sortBlocksAndRoots(blks, roots)
 	for i, b := range blks {
 		if b == nil || b.Block == nil {

--- a/beacon-chain/sync/utils.go
+++ b/beacon-chain/sync/utils.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"errors"
 	"sort"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -28,7 +29,11 @@ func (s sortedObj) Len() int {
 }
 
 // removes duplicates from provided blocks and roots.
-func (s *Service) dedupBlocksAndRoots(blks []*ethpb.SignedBeaconBlock, roots [][32]byte) ([]*ethpb.SignedBeaconBlock, [][32]byte) {
+func (s *Service) dedupBlocksAndRoots(blks []*ethpb.SignedBeaconBlock, roots [][32]byte) ([]*ethpb.SignedBeaconBlock, [][32]byte, error) {
+	if len(blks) != len(roots) {
+		return nil, nil, errors.New("input blks and roots are diff lengths")
+	}
+
 	// Remove duplicate blocks received
 	rootMap := make(map[[32]byte]bool, len(blks))
 	newBlks := make([]*ethpb.SignedBeaconBlock, 0, len(blks))
@@ -41,7 +46,7 @@ func (s *Service) dedupBlocksAndRoots(blks []*ethpb.SignedBeaconBlock, roots [][
 		newRoots = append(newRoots, roots[i])
 		newBlks = append(newBlks, blks[i])
 	}
-	return newBlks, newRoots
+	return newBlks, newRoots, nil
 }
 
 // sort the provided blocks and roots in ascending order. This method assumes that the size of

--- a/beacon-chain/sync/utils_test.go
+++ b/beacon-chain/sync/utils_test.go
@@ -6,6 +6,7 @@ import (
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
 func TestSortedObj_SortBlocksRoots(t *testing.T) {
@@ -66,7 +67,8 @@ func TestSortedObj_NoDuplicates(t *testing.T) {
 
 	r := &Service{}
 
-	newBlks, newRoots := r.dedupBlocksAndRoots(blks, roots)
+	newBlks, newRoots, err := r.dedupBlocksAndRoots(blks, roots)
+	require.NoError(t, err)
 
 	rootMap := make(map[[32]byte]bool)
 	for i, b := range newBlks {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Bug fix


**What does this PR do? Why is it needed?**

This can panic if the input blocks and roots are different lengths.

```
 panic: runtime error: index out of range [146] with length 146

goroutine 31903 [running]:
github.com/prysmaticlabs/prysm/beacon-chain/sync.(*Service).dedupBlocksAndRoots(0xc00012e000, 0xc079ec2800, 0x92, 0x100, 0xc013976000, 0x93, 0x100, 0x0, 0x0, 0xc0136a2d80, ...)
        beacon-chain/sync/utils.go:42 +0x505
github.com/prysmaticlabs/prysm/beacon-chain/sync.(*Service).writeBlockRangeToStream(0xc00012e000, 0x1dda6a0, 0xc06a405320, 0x1325f, 0x1345e, 0x1, 0x1df3860, 0xc04efce700, 0x0, 0x0)
        beacon-chain/sync/rpc_beacon_blocks_by_range.go:141 +0x646
github.com/prysmaticlabs/prysm/beacon-chain/sync.(*Service).beaconBlocksByRangeRPCHandler(0xc00012e000, 0x1dda5e0, 0xc017baa500, 0x196d880, 0xc017baa4c0, 0x1df3860, 0xc04efce700, 0x0, 0x0)
        beacon-chain/sync/rpc_beacon_blocks_by_range.go:81 +0x7f8
github.com/prysmaticlabs/prysm/beacon-chain/sync.(*Service).registerRPC.func1(0x1df3860, 0xc04efce700)
        beacon-chain/sync/rpc.go:124 +0xeb7
github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandler.func1(0xc01368f600, 0x3a, 0x28d94fe8, 0xc04efce700, 0x1, 0x0)
        external/com_github_libp2p_go_libp2p/p2p/host/basic/basic_host.go:566 +0xa4
created by github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newStreamHandler
        external/com_github_libp2p_go_libp2p/p2p/host/basic/basic_host.go:416 +0x643 
```
**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
