### PR TITLE
Slasher span cache size flag

### DIFF
--- a/slasher/flags/flags.go
+++ b/slasher/flags/flags.go
@@ -51,4 +51,10 @@ var (
 		Name:  "enable-historical-detection",
 		Usage: "Enables historical attestation detection for the slasher. Requires --historical-slasher-node on the beacon node.",
 	}
+	// SpanCacheSize is a flag that sets the size of span cache.
+	SpanCacheSize = &cli.IntFlag{
+		Name:  "spans-cache-size",
+		Usage: "Sets the span cache size.",
+		Value: 256,
+	}
 )

--- a/slasher/main.go
+++ b/slasher/main.go
@@ -69,6 +69,7 @@ var appFlags = []cli.Flag{
 	flags.BeaconCertFlag,
 	flags.BeaconRPCProviderFlag,
 	flags.EnableHistoricalDetectionFlag,
+	flags.SpanCacheSize,
 }
 
 func init() {

--- a/slasher/node/node.go
+++ b/slasher/node/node.go
@@ -168,7 +168,9 @@ func (s *SlasherNode) startDB() error {
 	clearDB := s.cliCtx.Bool(cmd.ClearDB.Name)
 	forceClearDB := s.cliCtx.Bool(cmd.ForceClearDB.Name)
 	dbPath := path.Join(baseDir, slasherDBName)
-	cfg := &kv.Config{}
+	spanCacheSize := s.cliCtx.Int(flags.SpanCacheSize.Name)
+	cfg := &kv.Config{SpanCacheSize: spanCacheSize}
+	log.Infof("Span cache size has been set to: %d", spanCacheSize)
 	d, err := db.NewDB(dbPath, cfg)
 	if err != nil {
 		return err

--- a/slasher/usage.go
+++ b/slasher/usage.go
@@ -83,6 +83,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.RPCHost,
 			flags.BeaconRPCProviderFlag,
 			flags.EnableHistoricalDetectionFlag,
+			flags.SpanCacheSize,
 		},
 	},
 	{


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
On times of no finality spreads between source and target epoch can be great. as a result many spans have to be updated on the slasher. When trying to run validator `--enable-external-slasher-protection` the time it take for the slasher to update the spans is critical and therefore relevant spans must be cached. this pr adds a flag that sets slasher span cache size to enable people to run slasher protection at times like this by using more memory to cache spans

**Which issues(s) does this PR fix?**

Fixes #7030
