### PR TITLE
Reject Duplicate Blocks From Being Saved

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -139,7 +139,6 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 				span.End()
 				continue
 			}
-
 			if err := s.chain.ReceiveBlock(ctx, b, blkRoot); err != nil {
 				log.Debugf("Could not process block from slot %d: %v", b.Block.Slot, err)
 				s.setBadBlock(ctx, blkRoot)
@@ -253,7 +252,13 @@ func (s *Service) deleteBlockFromPendingQueue(slot uint64, b *ethpb.SignedBeacon
 func (s *Service) insertBlockToPendingQueue(slot uint64, b *ethpb.SignedBeaconBlock) {
 	_, ok := s.slotToPendingBlocks[slot]
 	if ok {
-		s.slotToPendingBlocks[slot] = append(s.slotToPendingBlocks[slot], b)
+		blks := s.slotToPendingBlocks[slot]
+		for _, blk := range blks {
+			if proto.Equal(blk, b) {
+				return
+			}
+		}
+		s.slotToPendingBlocks[slot] = append(blks, b)
 		return
 	}
 	s.slotToPendingBlocks[slot] = []*ethpb.SignedBeaconBlock{b}

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -100,7 +100,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 	}
 	preState, err := s.chain.AttestationPreState(ctx, att)
 	if err != nil {
-		log.WithError(err).Error("Failed to retrieve pre state")
+		log.Error("Failed to retrieve pre state")
 		traceutil.AnnotateError(span, err)
 		return pubsub.ValidationIgnore
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In #7036 , we allow duplicate blocks to be inserted into the pending block cache. This PR fixes that and 
makes sure duplicates are rejected.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
