### PR TITLE
Use map to reject seen pending block

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -94,8 +94,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 				}
 				// Remove block from queue.
 				s.pendingQueueLock.Lock()
-				s.deleteBlockFromPendingQueue(slot, b)
-				delete(s.seenPendingBlocks, blkRoot)
+				s.deleteBlockFromPendingQueue(slot, b, blkRoot)
 				s.pendingQueueLock.Unlock()
 				span.End()
 				continue
@@ -151,8 +150,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 			}
 
 			s.pendingQueueLock.Lock()
-			s.deleteBlockFromPendingQueue(slot, b)
-			delete(s.seenPendingBlocks, blkRoot)
+			s.deleteBlockFromPendingQueue(slot, b, blkRoot)
 			s.pendingQueueLock.Unlock()
 
 			log.WithFields(logrus.Fields{
@@ -200,8 +198,7 @@ func (s *Service) validatePendingSlots() error {
 					return err
 				}
 				oldBlockRoots[root] = true
-				s.deleteBlockFromPendingQueue(slot, b)
-				delete(s.seenPendingBlocks, root)
+				s.deleteBlockFromPendingQueue(slot, b, root)
 				continue
 			}
 			// don't process old blocks
@@ -211,8 +208,7 @@ func (s *Service) validatePendingSlots() error {
 					return err
 				}
 				oldBlockRoots[blkRoot] = true
-				s.deleteBlockFromPendingQueue(slot, b)
-				delete(s.seenPendingBlocks, blkRoot)
+				s.deleteBlockFromPendingQueue(slot, b, blkRoot)
 			}
 		}
 	}
@@ -228,7 +224,7 @@ func (s *Service) clearPendingSlots() {
 
 // Delete block from the list from the pending queue using the slot as key.
 // Note: this helper is not thread safe.
-func (s *Service) deleteBlockFromPendingQueue(slot uint64, b *ethpb.SignedBeaconBlock) {
+func (s *Service) deleteBlockFromPendingQueue(slot uint64, b *ethpb.SignedBeaconBlock, r [32]byte) {
 	blks, ok := s.slotToPendingBlocks[slot]
 	if !ok {
 		return
@@ -245,21 +241,22 @@ func (s *Service) deleteBlockFromPendingQueue(slot uint64, b *ethpb.SignedBeacon
 		return
 	}
 	s.slotToPendingBlocks[slot] = newBlks
+	delete(s.seenPendingBlocks, r)
 }
 
 // Insert block to the list in the pending queue using the slot as key.
 // Note: this helper is not thread safe.
-func (s *Service) insertBlockToPendingQueue(slot uint64, b *ethpb.SignedBeaconBlock) {
+func (s *Service) insertBlockToPendingQueue(slot uint64, b *ethpb.SignedBeaconBlock, r [32]byte) {
+	if s.seenPendingBlocks[r] {
+		return
+	}
+
 	_, ok := s.slotToPendingBlocks[slot]
 	if ok {
 		blks := s.slotToPendingBlocks[slot]
-		for _, blk := range blks {
-			if proto.Equal(blk, b) {
-				return
-			}
-		}
 		s.slotToPendingBlocks[slot] = append(blks, b)
-		return
+	} else {
+		s.slotToPendingBlocks[slot] = []*ethpb.SignedBeaconBlock{b}
 	}
-	s.slotToPendingBlocks[slot] = []*ethpb.SignedBeaconBlock{b}
+	s.seenPendingBlocks[r] = true
 }

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -48,8 +48,7 @@ func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 			return err
 		}
 		s.pendingQueueLock.Lock()
-		s.insertBlockToPendingQueue(blk.Block.Slot, blk)
-		s.seenPendingBlocks[blkRoot] = true
+		s.insertBlockToPendingQueue(blk.Block.Slot, blk, blkRoot)
 		s.pendingQueueLock.Unlock()
 
 	}

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -26,6 +26,10 @@ func (s *Service) validateAggregateAndProof(ctx context.Context, pid peer.ID, ms
 		return pubsub.ValidationAccept
 	}
 
+	if true {
+		return pubsub.ValidationIgnore
+	}
+
 	ctx, span := trace.StartSpan(ctx, "sync.validateAggregateAndProof")
 	defer span.End()
 

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -26,10 +26,6 @@ func (s *Service) validateAggregateAndProof(ctx context.Context, pid peer.ID, ms
 		return pubsub.ValidationAccept
 	}
 
-	if true {
-		return pubsub.ValidationIgnore
-	}
-
 	ctx, span := trace.StartSpan(ctx, "sync.validateAggregateAndProof")
 	defer span.End()
 

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -110,8 +110,7 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 	// Handle block when the parent is unknown.
 	if !s.db.HasBlock(ctx, bytesutil.ToBytes32(blk.Block.ParentRoot)) {
 		s.pendingQueueLock.Lock()
-		s.insertBlockToPendingQueue(blk.Block.Slot, blk)
-		s.seenPendingBlocks[blockRoot] = true
+		s.insertBlockToPendingQueue(blk.Block.Slot, blk, blockRoot)
 		s.pendingQueueLock.Unlock()
 		return pubsub.ValidationIgnore
 	}


### PR DESCRIPTION
Minor improvement from #7044

This PR uses intended `seenPendingBlock` mapping to reject duplicated block in insertion method. Also updated the APIs for insertion and deletion to include block root we can update seenPendingBlock` mapping within the method to avoid disparity. 

I also updated the tests. Now the test results look more realistic than before