### PR TITLE
Move migration to end of `ReceiveBlock`

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -235,11 +235,6 @@ func (s *Service) updateFinalized(ctx context.Context, cp *ethpb.Checkpoint) err
 	s.prevFinalizedCheckpt = s.finalizedCheckpt
 	s.finalizedCheckpt = cp
 
-	fRoot := bytesutil.ToBytes32(cp.Root)
-	if err := s.stateGen.MigrateToCold(ctx, fRoot); err != nil {
-		return errors.Wrap(err, "could not migrate to cold")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
This is an extension of #7055

If migrations were to time out again, #7055 ensured that the node will save the finalized root in DB but it does not guarantee the rest of the `ReceiveBlock` functions will complete. Some of these functions are arguably important:
- Update committee cache
- Update proposer cache
- Clean up operation pool
- Run Fork choice
- Update fork choice store
- Save fork choice head to DB

This PR ensures that all the functions above can complete by moving migration to the end of the `ReceiveBlock`

**Which issues(s) does this PR fix?**

Follow up on #7055

**Other notes for review**
