### PR TITLE
Add replay block count metric

### DIFF
--- a/beacon-chain/state/stategen/BUILD.bazel
+++ b/beacon-chain/state/stategen/BUILD.bazel
@@ -30,6 +30,8 @@ go_library(
         "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_client_go//tools/cache:go_default_library",


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Feature

**What does this PR do? Why is it needed?**
Adding a really useful histogram for replay block count. Replaying blocks for a state is a rare event, but when it happens, this provides node operator details on the full picture of the penalties.
```
# HELP replay_blocks_count The number of blocks to replay to generate a state
# TYPE replay_blocks_count histogram
replay_blocks_count_bucket{le="64"} 12
replay_blocks_count_bucket{le="256"} 18
replay_blocks_count_bucket{le="1024"} 27
replay_blocks_count_bucket{le="2048"} 27
replay_blocks_count_bucket{le="4096"} 27
replay_blocks_count_bucket{le="+Inf"} 27
replay_blocks_count_sum 7442
replay_blocks_count_count 27
```

<img width="1740" alt="Screen Shot 2020-08-19 at 9 03 59 PM" src="https://user-images.githubusercontent.com/21316537/90715591-84712700-e25f-11ea-919c-ed94921131ab.png">

