### PR TITLE
Slasher: Optimize span marshal and unmarshal

### DIFF
--- a/slasher/beaconclient/submit.go
+++ b/slasher/beaconclient/submit.go
@@ -59,7 +59,7 @@ func (bs *Service) subscribeDetectedAttesterSlashings(ctx context.Context, ch ch
 					}).Info("Found a valid attester slashing! Submitting to beacon node")
 				} else if strings.Contains(err.Error(), helpers.ErrSigFailedToVerify.Error()) {
 					log.WithError(err).Errorf("Could not submit attester slashing with indices %v", slashableIndices)
-				} else {
+				} else if !strings.Contains(err.Error(), "is not slashable") {
 					log.WithError(err).Errorf("Could not slash validators with indices %v", slashableIndices)
 				}
 			}

--- a/slasher/detection/attestations/types/epoch_store_test.go
+++ b/slasher/detection/attestations/types/epoch_store_test.go
@@ -235,6 +235,40 @@ func BenchmarkEpochStore_Save(b *testing.B) {
 	})
 }
 
+func BenchmarkSpan_Marshal(b *testing.B) {
+	span := &types.Span{
+		MinSpan:     40,
+		MaxSpan:     60,
+		SigBytes:    [2]byte{5, 10},
+		HasAttested: true,
+	}
+	b.ReportAllocs()
+	var bytes []byte
+	for i := 0; i < b.N; i++ {
+		bytes = span.Marshal()
+	}
+	fmt.Println(bytes)
+}
+
+func BenchmarkSpan_Unmarshal(b *testing.B) {
+	span := types.Span{
+		MinSpan:     40,
+		MaxSpan:     60,
+		SigBytes:    [2]byte{5, 10},
+		HasAttested: true,
+	}
+	marshaled := span.Marshal()
+	b.ReportAllocs()
+	var err error
+	for i := 0; i < b.N; i++ {
+		span, err = types.UnmarshalSpan(marshaled)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	fmt.Println(span)
+}
+
 func generateEpochStore(t testing.TB, n uint64) (*types.EpochStore, map[uint64]types.Span) {
 	epochStore, err := types.NewEpochStore([]byte{})
 	require.NoError(t, err)


### PR DESCRIPTION
**What type of PR is this?**
Optimization

**What does this PR do? Why is it needed?**
This PR is a rough attempt at optimizing these often used functions by making sure they can inline and don't take up additional memory, results below:
```
BenchmarkSpan_Marshal_Old-8         29820471                37.1 ns/op            16 B/op          2 allocs/op
BenchmarkSpan_Unmarshal_New-8       137652634                9.81 ns/op            0 B/op          0 allocs/op
```
```
BenchmarkSpan_Marshal_New-8         80018118                15.3 ns/op             8 B/op          1 allocs/op
BenchmarkSpan_Unmarshal_New-8       171897799                6.51 ns/op            0 B/op          0 allocs/op
``` 

These changes could be controversial so let me know if these changes shouldn't be considered.