### PR TITLE
Use hot state cache for replay

### DIFF
--- a/beacon-chain/state/stategen/hot.go
+++ b/beacon-chain/state/stategen/hot.go
@@ -180,6 +180,11 @@ func (s *State) lastAncestorState(ctx context.Context, root [32]byte) (*state.Be
 			return s.beaconDB.GenesisState(ctx)
 		}
 
+		// Does the state exist in the hot state cache.
+		if s.hotStateCache.Has(parentRoot) {
+			return s.hotStateCache.Get(parentRoot), nil
+		}
+
 		// Does the state exist in finalized info cache.
 		if s.isFinalizedRoot(parentRoot) {
 			return s.finalizedState(), nil


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Feature

**What does this PR do? Why is it needed?**
When the node is recursively searching back for an ancestor state, it checks if the state exists in:
1. DB
2. Epoch boundary cache
3. Finalized check point

This PR adds check for hot state cache. This is a nice gimme with 0 cost.

**Which issues(s) does this PR fix?**

Fixes # N/A

**Other notes for review**
Tested run time