### PR TITLE
Identical expression comparison analyzer

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -108,6 +108,7 @@ nogo(
         "//tools/analyzers/cryptorand:go_tool_library",
         "//tools/analyzers/errcheck:go_tool_library",
         "//tools/analyzers/featureconfig:go_tool_library",
+        "//tools/analyzers/comparesame:go_tool_library",
     ] + select({
         # nogo checks that fail with coverage enabled.
         ":coverage_enabled": [],

--- a/nogo_config.json
+++ b/nogo_config.json
@@ -109,5 +109,11 @@
       "shared/rand/rand\\.go": "Abstracts CSPRNGs for common use",
       "shared/aggregation/testing/bitlistutils.go": "Test-only package"
     }
+  },
+  "comparesame": {
+    "exclude_files": {
+      "external/.*": "Third party code",
+      "rules_go_work-.*": "Third party code"
+    }
   }
 }

--- a/tools/analyzers/comparesame/BUILD.bazel
+++ b/tools/analyzers/comparesame/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_tool_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["analyzer.go"],
+    importpath = "github.com/prysmaticlabs/prysm/tools/analyzers/comparesame",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_x_tools//go/analysis:go_default_library",
+        "@org_golang_x_tools//go/analysis/passes/inspect:go_default_library",
+        "@org_golang_x_tools//go/ast/inspector:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["analyzer_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@org_golang_x_tools//go/analysis/analysistest:go_default_library"],
+)
+
+go_tool_library(
+    name = "go_tool_library",
+    srcs = ["analyzer.go"],
+    importpath = "github.com/prysmaticlabs/prysm/tools/analyzers/comparesame",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@org_golang_x_tools//go/analysis:go_tool_library",
+        "@org_golang_x_tools//go/analysis/passes/inspect:go_tool_library",
+        "@org_golang_x_tools//go/ast/inspector:go_tool_library",
+    ],
+)

--- a/tools/analyzers/comparesame/analyzer.go
+++ b/tools/analyzers/comparesame/analyzer.go
@@ -1,0 +1,61 @@
+package comparesame
+
+import (
+	"bytes"
+	"errors"
+	"go/ast"
+	"go/printer"
+	"go/token"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Doc explaining the tool.
+const Doc = "Tool to detect comparison (==, !=, >=, <=, >, <) of identical boolean expressions."
+
+const messageTemplate = "Boolean expression has identical expressions on both sides. The result is always %v."
+
+// Analyzer runs static analysis.
+var Analyzer = &analysis.Analyzer{
+	Name:     "comparesame",
+	Doc:      Doc,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      run,
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	inspect, ok := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+	if !ok {
+		return nil, errors.New("analyzer is not type *inspector.Inspector")
+	}
+
+	nodeFilter := []ast.Node{
+		(*ast.BinaryExpr)(nil),
+	}
+
+	inspect.Preorder(nodeFilter, func(node ast.Node) {
+		expr := node.(*ast.BinaryExpr)
+		switch expr.Op {
+		case token.EQL, token.NEQ, token.GEQ, token.LEQ, token.GTR, token.LSS:
+			var xBuf, yBuf bytes.Buffer
+			if err := printer.Fprint(&xBuf, pass.Fset, expr.X); err != nil {
+				pass.Reportf(expr.X.Pos(), err.Error())
+			}
+			if err := printer.Fprint(&yBuf, pass.Fset, expr.Y); err != nil {
+				pass.Reportf(expr.Y.Pos(), err.Error())
+			}
+			if xBuf.String() == yBuf.String() {
+				switch expr.Op {
+				case token.EQL, token.NEQ, token.GEQ, token.LEQ:
+					pass.Reportf(expr.OpPos, messageTemplate, true)
+				case token.GTR, token.LSS:
+					pass.Reportf(expr.OpPos, messageTemplate, false)
+				}
+			}
+		}
+	})
+
+	return nil, nil
+}

--- a/tools/analyzers/comparesame/analyzer_test.go
+++ b/tools/analyzers/comparesame/analyzer_test.go
@@ -1,0 +1,11 @@
+package comparesame
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+)
+
+func TestAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), Analyzer)
+}

--- a/tools/analyzers/comparesame/testdata/BUILD.bazel
+++ b/tools/analyzers/comparesame/testdata/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["compare_len.go"],
+    importpath = "github.com/prysmaticlabs/prysm/tools/analyzers/comparesame/testdata",
+    visibility = ["//visibility:public"],
+)

--- a/tools/analyzers/comparesame/testdata/compare_len.go
+++ b/tools/analyzers/comparesame/testdata/compare_len.go
@@ -1,0 +1,37 @@
+package testdata
+
+func Equal() {
+	x := []string{"a"}
+	if len(x) == len(x) { // want "Boolean expression has identical expressions on both sides. The result is always true."
+	}
+}
+
+func NotEqual() {
+	x := []string{"a"}
+	if len(x) != len(x) { // want "Boolean expression has identical expressions on both sides. The result is always true."
+	}
+}
+
+func GreaterThanOrEqual() {
+	x := []string{"a"}
+	if len(x) >= len(x) { // want "Boolean expression has identical expressions on both sides. The result is always true."
+	}
+}
+
+func LessThanOrEqual() {
+	x := []string{"a"}
+	if len(x) <= len(x) { // want "Boolean expression has identical expressions on both sides. The result is always true."
+	}
+}
+
+func GreaterThan() {
+	x := []string{"a"}
+	if len(x) > len(x) { // want "Boolean expression has identical expressions on both sides. The result is always false."
+	}
+}
+
+func LessThan() {
+	x := []string{"a"}
+	if len(x) < len(x) { // want "Boolean expression has identical expressions on both sides. The result is always false."
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Tool

**What does this PR do? Why is it needed?**

This PR introduces a static code analyzer that reports a diagnostic when a boolean comparison expression (`==`, `!=`, `>=`, `<=`, `>`, `<`) is comparing two identical expressions. Occurrences of such code have been found here: https://deepsource.io/gh/rkapka/prysm/issue/SCC-SA4000/occurrences. This is especially bad in tests because an assertion such as `x == x` will always pass, even if the tested code becomes broken.

**Which issues(s) does this PR fix?**

Part of #6747 

**Other notes for review**

This PR will likely fail to build because of the mentioned occurrences. Please add commits to this branch with fixes because I don't know what the correct expressions should be.