### PR TITLE
Accounts V2: Implement Backup for Derived Keymanager

### DIFF
--- a/validator/accounts/v2/accounts_backup.go
+++ b/validator/accounts/v2/accounts_backup.go
@@ -105,8 +105,13 @@ func BackupAccounts(cliCtx *cli.Context) error {
 		if !ok {
 			return errors.New("could not assert keymanager interface to concrete type")
 		}
-		_ = km
+		keystoresToBackup, err = km.ExtractKeystores(ctx, filteredPubKeys, backupsPassword)
+		if err != nil {
+			return errors.Wrap(err, "could not backup accounts for derived keymanager")
+		}
 		return nil
+	case v2keymanager.Remote:
+		return errors.New("backing up keys is not supported for a remote keymanager")
 	default:
 		return errors.New("keymanager kind not supported")
 	}

--- a/validator/keymanager/v2/derived/BUILD.bazel
+++ b/validator/keymanager/v2/derived/BUILD.bazel
@@ -4,6 +4,7 @@ load("@prysm//tools/go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "backup.go",
         "derived.go",
         "mnemonic.go",
     ],
@@ -23,6 +24,7 @@ go_library(
         "//shared/rand:go_default_library",
         "//validator/accounts/v2/iface:go_default_library",
         "//validator/flags:go_default_library",
+        "//validator/keymanager/v2:go_default_library",
         "@com_github_google_uuid//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -36,6 +38,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "backup_test.go",
         "derived_test.go",
         "mnemonic_test.go",
     ],

--- a/validator/keymanager/v2/derived/backup.go
+++ b/validator/keymanager/v2/derived/backup.go
@@ -1,0 +1,53 @@
+package derived
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	v2keymanager "github.com/prysmaticlabs/prysm/validator/keymanager/v2"
+	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
+)
+
+// ExtractKeystores retrieves the secret keys for specified public keys
+// in the function input, encrypts them using the specified password,
+// and returns their respective EIP-2335 keystores.
+func (dr *Keymanager) ExtractKeystores(
+	ctx context.Context, publicKeys []bls.PublicKey, password string,
+) ([]*v2keymanager.Keystore, error) {
+	encryptor := keystorev4.New()
+	keystores := make([]*v2keymanager.Keystore, len(publicKeys))
+	for i, pk := range publicKeys {
+		pubKeyBytes := pk.Marshal()
+		secretKey, ok := dr.keysCache[bytesutil.ToBytes48(pubKeyBytes)]
+		if !ok {
+			return nil, fmt.Errorf(
+				"secret key for public key %#x not found in cache",
+				pubKeyBytes,
+			)
+		}
+		cryptoFields, err := encryptor.Encrypt(secretKey.Marshal(), password)
+		if err != nil {
+			return nil, errors.Wrapf(
+				err,
+				"could not encrypt secret key for public key %#x",
+				pubKeyBytes,
+			)
+		}
+		id, err := uuid.NewRandom()
+		if err != nil {
+			return nil, err
+		}
+		keystores[i] = &v2keymanager.Keystore{
+			Crypto:  cryptoFields,
+			ID:      id.String(),
+			Pubkey:  fmt.Sprintf("%x", pubKeyBytes),
+			Version: encryptor.Version(),
+			Name:    encryptor.Name(),
+		}
+	}
+	return keystores, nil
+}

--- a/validator/keymanager/v2/derived/backup_test.go
+++ b/validator/keymanager/v2/derived/backup_test.go
@@ -1,4 +1,4 @@
-package direct
+package derived
 
 import (
 	"context"
@@ -11,7 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
-func TestDirectKeymanager_ExtractKeystores(t *testing.T) {
+func TestDerivedKeymanager_ExtractKeystores(t *testing.T) {
 	dr := &Keymanager{
 		keysCache: make(map[[48]byte]bls.SecretKey),
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR implements the backup functionality for HD wallets in Prysm, making it easy to call `prysm.sh validator accounts-v2 backup` and select the accounts one wishes to backup as a zip file containing keystore.json files for each validating key.

**Which issues(s) does this PR fix?**

Fixes #6969
