### PR TITLE
Do Not Unset Rate Limiter Before Node Shutdown

### DIFF
--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -166,7 +166,6 @@ func (s *Service) Stop() error {
 	defer func() {
 		if s.rateLimiter != nil {
 			s.rateLimiter.free()
-			s.rateLimiter = newRateLimiter(s.p2p)
 		}
 	}()
 	defer s.cancel()


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

We were setting the value of the rate limiter when shutting down our beacon node in the sync service's `Stop()` function to `nil`, leading to panics as the node was still attempting to use the rate limiter in some instances right before closing. This PR instead removes that line.

**Which issues(s) does this PR fix?**

Fixes #6897
