### PR TITLE
Adds DeepNotEqual assertion

### DIFF
--- a/shared/testutil/assert/assertions.go
+++ b/shared/testutil/assert/assertions.go
@@ -20,6 +20,11 @@ func DeepEqual(tb assertions.AssertionTestingTB, expected, actual interface{}, m
 	assertions.DeepEqual(tb.Errorf, expected, actual, msg...)
 }
 
+// DeepNotEqual compares values using DeepEqual.
+func DeepNotEqual(tb assertions.AssertionTestingTB, expected, actual interface{}, msg ...interface{}) {
+	assertions.DeepNotEqual(tb.Errorf, expected, actual, msg...)
+}
+
 // NoError asserts that error is nil.
 func NoError(tb assertions.AssertionTestingTB, err error, msg ...interface{}) {
 	assertions.NoError(tb.Errorf, err, msg...)

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -45,6 +45,15 @@ func DeepEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...
 	}
 }
 
+// DeepNotEqual compares values using DeepEqual.
+func DeepNotEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...interface{}) {
+	errMsg := parseMsg("Values are equal", msg...)
+	if reflect.DeepEqual(expected, actual) {
+		_, file, line, _ := runtime.Caller(2)
+		loggerFn("%s:%d %s, want: %#v, got: %#v", filepath.Base(file), line, errMsg, expected, actual)
+	}
+}
+
 // NoError asserts that error is nil.
 func NoError(loggerFn assertionLoggerFn, err error, msg ...interface{}) {
 	errMsg := parseMsg("Unexpected error", msg...)

--- a/shared/testutil/assertions/assertions_test.go
+++ b/shared/testutil/assertions/assertions_test.go
@@ -227,6 +227,75 @@ func TestAssert_DeepEqual(t *testing.T) {
 	}
 }
 
+func TestAssert_DeepNotEqual(t *testing.T) {
+	type args struct {
+		tb       *assertions.TBMock
+		expected interface{}
+		actual   interface{}
+		msgs     []interface{}
+	}
+	tests := []struct {
+		name        string
+		args        args
+		expectedErr string
+	}{
+		{
+			name: "equal values",
+			args: args{
+				tb:       &assertions.TBMock{},
+				expected: struct{ i int }{42},
+				actual:   struct{ i int }{42},
+			},
+			expectedErr: "Values are equal, want: struct { i int }{i:42}, got: struct { i int }{i:42}",
+		},
+		{
+			name: "non-equal values",
+			args: args{
+				tb:       &assertions.TBMock{},
+				expected: struct{ i int }{42},
+				actual:   struct{ i int }{41},
+			},
+		},
+		{
+			name: "custom error message",
+			args: args{
+				tb:       &assertions.TBMock{},
+				expected: struct{ i int }{42},
+				actual:   struct{ i int }{42},
+				msgs:     []interface{}{"Custom values are equal"},
+			},
+			expectedErr: "Custom values are equal, want: struct { i int }{i:42}, got: struct { i int }{i:42}",
+		},
+		{
+			name: "custom error message with params",
+			args: args{
+				tb:       &assertions.TBMock{},
+				expected: struct{ i int }{42},
+				actual:   struct{ i int }{42},
+				msgs:     []interface{}{"Custom values are equal (for slot %d)", 12},
+			},
+			expectedErr: "Custom values are equal (for slot 12), want: struct { i int }{i:42}, got: struct { i int }{i:42}",
+		},
+	}
+	for _, tt := range tests {
+		verify := func() {
+			if tt.expectedErr == "" && tt.args.tb.ErrorfMsg != "" {
+				t.Errorf("Unexpected error: %v", tt.args.tb.ErrorfMsg)
+			} else if !strings.Contains(tt.args.tb.ErrorfMsg, tt.expectedErr) {
+				t.Errorf("got: %q, want: %q", tt.args.tb.ErrorfMsg, tt.expectedErr)
+			}
+		}
+		t.Run(fmt.Sprintf("Assert/%s", tt.name), func(t *testing.T) {
+			assert.DeepNotEqual(tt.args.tb, tt.args.expected, tt.args.actual, tt.args.msgs...)
+			verify()
+		})
+		t.Run(fmt.Sprintf("Require/%s", tt.name), func(t *testing.T) {
+			require.DeepNotEqual(tt.args.tb, tt.args.expected, tt.args.actual, tt.args.msgs...)
+			verify()
+		})
+	}
+}
+
 func TestAssert_NoError(t *testing.T) {
 	type args struct {
 		tb   *assertions.TBMock

--- a/shared/testutil/require/requires.go
+++ b/shared/testutil/require/requires.go
@@ -20,6 +20,11 @@ func DeepEqual(tb assertions.AssertionTestingTB, expected, actual interface{}, m
 	assertions.DeepEqual(tb.Fatalf, expected, actual, msg...)
 }
 
+// DeepNotEqual compares values using DeepEqual.
+func DeepNotEqual(tb assertions.AssertionTestingTB, expected, actual interface{}, msg ...interface{}) {
+	assertions.DeepNotEqual(tb.Fatalf, expected, actual, msg...)
+}
+
 // NoError asserts that error is nil.
 func NoError(tb assertions.AssertionTestingTB, err error, msg ...interface{}) {
 	assertions.NoError(tb.Fatalf, err, msg...)


### PR DESCRIPTION
**What type of PR is this?**

Other/Tests

**What does this PR do? Why is it needed?**
- Adds `DeepNotEqual` assertion (we have `Equal/NotEqual` assertions, but only `DeepEqual` atm - for consistency, and because I needed on in #7003, this PR adds this extra assertion)

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
