### PR TITLE
Optimizes error message parsing in testutils

### DIFF
--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -20,8 +20,8 @@ type assertionLoggerFn func(string, ...interface{})
 
 // Equal compares values using comparison operator.
 func Equal(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...interface{}) {
-	errMsg := parseMsg("Values are not equal", msg...)
 	if expected != actual {
+		errMsg := parseMsg("Values are not equal", msg...)
 		_, file, line, _ := runtime.Caller(2)
 		loggerFn("%s:%d %s, want: %[4]v (%[4]T), got: %[5]v (%[5]T)", filepath.Base(file), line, errMsg, expected, actual)
 	}
@@ -29,8 +29,8 @@ func Equal(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...inte
 
 // NotEqual compares values using comparison operator.
 func NotEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...interface{}) {
-	errMsg := parseMsg("Values are equal", msg...)
 	if expected == actual {
+		errMsg := parseMsg("Values are equal", msg...)
 		_, file, line, _ := runtime.Caller(2)
 		loggerFn("%s:%d %s, both values are equal: %[4]v (%[4]T)", filepath.Base(file), line, errMsg, expected)
 	}
@@ -38,8 +38,8 @@ func NotEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...i
 
 // DeepEqual compares values using DeepEqual.
 func DeepEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...interface{}) {
-	errMsg := parseMsg("Values are not equal", msg...)
 	if !reflect.DeepEqual(expected, actual) {
+		errMsg := parseMsg("Values are not equal", msg...)
 		_, file, line, _ := runtime.Caller(2)
 		loggerFn("%s:%d %s, want: %#v, got: %#v", filepath.Base(file), line, errMsg, expected, actual)
 	}
@@ -47,8 +47,8 @@ func DeepEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...
 
 // DeepNotEqual compares values using DeepEqual.
 func DeepNotEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...interface{}) {
-	errMsg := parseMsg("Values are equal", msg...)
 	if reflect.DeepEqual(expected, actual) {
+		errMsg := parseMsg("Values are equal", msg...)
 		_, file, line, _ := runtime.Caller(2)
 		loggerFn("%s:%d %s, want: %#v, got: %#v", filepath.Base(file), line, errMsg, expected, actual)
 	}
@@ -56,8 +56,8 @@ func DeepNotEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg 
 
 // NoError asserts that error is nil.
 func NoError(loggerFn assertionLoggerFn, err error, msg ...interface{}) {
-	errMsg := parseMsg("Unexpected error", msg...)
 	if err != nil {
+		errMsg := parseMsg("Unexpected error", msg...)
 		_, file, line, _ := runtime.Caller(2)
 		loggerFn("%s:%d %s: %v", filepath.Base(file), line, errMsg, err)
 	}
@@ -65,8 +65,8 @@ func NoError(loggerFn assertionLoggerFn, err error, msg ...interface{}) {
 
 // ErrorContains asserts that actual error contains wanted message.
 func ErrorContains(loggerFn assertionLoggerFn, want string, err error, msg ...interface{}) {
-	errMsg := parseMsg("Expected error not returned", msg...)
 	if err == nil || !strings.Contains(err.Error(), want) {
+		errMsg := parseMsg("Expected error not returned", msg...)
 		_, file, line, _ := runtime.Caller(2)
 		loggerFn("%s:%d %s, got: %v, want: %s", filepath.Base(file), line, errMsg, err, want)
 	}
@@ -74,8 +74,8 @@ func ErrorContains(loggerFn assertionLoggerFn, want string, err error, msg ...in
 
 // NotNil asserts that passed value is not nil.
 func NotNil(loggerFn assertionLoggerFn, obj interface{}, msg ...interface{}) {
-	errMsg := parseMsg("Unexpected nil value", msg...)
 	if obj == nil {
+		errMsg := parseMsg("Unexpected nil value", msg...)
 		_, file, line, _ := runtime.Caller(2)
 		loggerFn("%s:%d %s", filepath.Base(file), line, errMsg)
 	}


### PR DESCRIPTION
**What type of PR is this?**

Other/Optimization

**What does this PR do? Why is it needed?**
- No need to parse message passed to test assertions, up until that assertion is triggered (if assertion is not failed, message will never be used -- no point to parse it).

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- This issue was noticed when transforming the following code:
```golang
if err != nil && s != nil {
    t.Fatalf("state should be nil on err. found: %v on error: %v for state: %v and block: %v", s, err, state, block)
}
```
to 
```golang
require.Equal(t, false, err != nil && s != nil, 
        "state should be nil on err. found: %v on error: %v for state: %v and block: %v", s, err, state, block)
```
Custom error message contained `%v` for `state` object which wasn't properly inited (code above is from fuzz testing), and on tests long list of the following warnings was produced:
```
2020/08/24 16:39:59 proto: textWriter unindented too far
2020/08/24 16:39:59 proto: textWriter unindented too far
2020/08/24 16:39:59 proto: textWriter unindented too far
2020/08/24 16:39:59 proto: textWriter unindented too far
2020/08/24 16:39:59 proto: textWriter unindented too far
2020/08/24 16:39:59 proto: textWriter unindented too far
2020/08/24 16:39:59 proto: textWriter unindented too far
2020/08/24 16:39:59 proto: textWriter unindented too far
2020/08/24 16:39:59 proto: textWriter unindented too far
```
Once, moved within assertion condition, message processing works as expected.

