### PR TITLE
Update enable-debug-rpc-endpoints help message

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -132,7 +132,7 @@ var (
 	// EnableDebugRPCEndpoints as /v1/beacon/state.
 	EnableDebugRPCEndpoints = &cli.BoolFlag{
 		Name:  "enable-debug-rpc-endpoints",
-		Usage: "Enables the debug rpc service, containing utility endpoints such as /eth/v1alpha1/beacon/state. Requires --new-state-mgmt",
+		Usage: "Enables the debug rpc service, containing utility endpoints such as /eth/v1alpha1/beacon/state.",
 	}
 	// HistoricalSlasherNode is a set of beacon node flags required for performing historical detection with a slasher.
 	HistoricalSlasherNode = &cli.BoolFlag{


### PR DESCRIPTION
`--new-state-mgmt` is on by default