### PR TITLE
Remove Default Prylabs ETH1 Endpoint

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -11,7 +11,7 @@ var (
 	HTTPWeb3ProviderFlag = &cli.StringFlag{
 		Name:  "http-web3provider",
 		Usage: "A mainchain web3 provider string http endpoint",
-		Value: "https://goerli.prylabs.net",
+		Value: "",
 	}
 	// DepositContractFlag defines a flag for the deposit contract address.
 	DepositContractFlag = &cli.StringFlag{

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -473,9 +473,9 @@ func (b *BeaconNode) registerPOWChainService() error {
 		log.Fatalf("Invalid deposit contract address given: %s", depAddress)
 	}
 
-	if !b.cliCtx.IsSet(flags.HTTPWeb3ProviderFlag.Name) {
-		log.Error("Using default ETH1 connection provided by Prysmatic Labs. Please consider running your own ETH1 node for better uptime, security, and decentralization of ETH2. Visit https://docs.prylabs.network/docs/prysm-usage/setup-eth1 for more information.")
-		log.Error("The default eth1 connection provided by Prysmatic Labs will no longer be the default in the next release! You will need to specify --http-web3provider. Please configure your node before the next release.")
+	if b.cliCtx.String(flags.HTTPWeb3ProviderFlag.Name) == "" {
+		log.Error("No ETH1 node specified to run with the beacon node. Please consider running your own ETH1 node for better uptime, security, and decentralization of ETH2. Visit https://docs.prylabs.network/docs/prysm-usage/setup-eth1 for more information.")
+		log.Error("You will need to specify --http-web3provider to attach an eth1 node to the prysm node. Without an eth1 node block proposals for your validator will be affected and the beacon node will not be able to initialize the genesis state.")
 	}
 
 	cfg := &powchain.Web3ServiceConfig{

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -220,6 +220,10 @@ func NewService(ctx context.Context, config *Web3ServiceConfig) (*Service, error
 
 // Start a web3 service's main event loop.
 func (s *Service) Start() {
+	// Exit early if eth1 endpoint is not set.
+	if s.httpEndpoint == "" {
+		return
+	}
 	go func() {
 		s.waitForConnection()
 		s.run(s.ctx.Done())


### PR DESCRIPTION
**What type of PR is this?**

Feature Addition

**What does this PR do? Why is it needed?**

- [x] Removes the default eth1 endpoint which is hosted by Prysmatic Labs.
- [x] Change error message to state consequences of not running your own eth1 node.

**Which issues(s) does this PR fix?**

Fixes #6884 

**Other notes for review**
