### PR TITLE
Request Headers From ETH1 Node Instead of Blocks

### DIFF
--- a/beacon-chain/powchain/block_cache.go
+++ b/beacon-chain/powchain/block_cache.go
@@ -14,9 +14,9 @@ import (
 )
 
 var (
-	// ErrNotABlockInfo will be returned when a cache object is not a pointer to
-	// a blockInfo struct.
-	ErrNotABlockInfo = errors.New("object is not a block info")
+	// ErrNotAHeaderInfo will be returned when a cache object is not a pointer to
+	// a headerInfo struct.
+	ErrNotAHeaderInfo = errors.New("object is not a header info")
 
 	// maxCacheSize is 2x of the follow distance for additional cache padding.
 	// Requests should be only accessing blocks within recent blocks within the
@@ -24,75 +24,75 @@ var (
 	maxCacheSize = 2 * params.BeaconConfig().Eth1FollowDistance
 
 	// Metrics
-	blockCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "powchain_block_cache_miss",
-		Help: "The number of block requests that aren't present in the cache.",
+	headerCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "powchain_header_cache_miss",
+		Help: "The number of header requests that aren't present in the cache.",
 	})
-	blockCacheHit = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "powchain_block_cache_hit",
-		Help: "The number of block requests that are present in the cache.",
+	headerCacheHit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "powchain_header_cache_hit",
+		Help: "The number of header requests that are present in the cache.",
 	})
-	blockCacheSize = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "powchain_block_cache_size",
-		Help: "The number of blocks in the block cache",
+	headerCacheSize = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "powchain_header_cache_size",
+		Help: "The number of headers in the header cache",
 	})
 )
 
-// blockInfo specifies the block information in the ETH 1.0 chain.
-type blockInfo struct {
+// headerInfo specifies the block information in the ETH 1.0 chain.
+type headerInfo struct {
 	Number *big.Int
 	Hash   common.Hash
 	Time   uint64
 }
 
-func blockToBlockInfo(blk *gethTypes.Block) *blockInfo {
-	return &blockInfo{
-		Hash:   blk.Hash(),
-		Number: blk.Number(),
-		Time:   blk.Time(),
+func headerToHeaderInfo(hdr *gethTypes.Header) *headerInfo {
+	return &headerInfo{
+		Hash:   hdr.Hash(),
+		Number: new(big.Int).Set(hdr.Number),
+		Time:   hdr.Time,
 	}
 }
 
-// hashKeyFn takes the hex string representation as the key for a blockInfo.
+// hashKeyFn takes the hex string representation as the key for a headerInfo.
 func hashKeyFn(obj interface{}) (string, error) {
-	bInfo, ok := obj.(*blockInfo)
+	bInfo, ok := obj.(*headerInfo)
 	if !ok {
-		return "", ErrNotABlockInfo
+		return "", ErrNotAHeaderInfo
 	}
 
 	return bInfo.Hash.Hex(), nil
 }
 
 // heightKeyFn takes the string representation of the block number as the key
-// for a blockInfo.
+// for a headerInfo.
 func heightKeyFn(obj interface{}) (string, error) {
-	bInfo, ok := obj.(*blockInfo)
+	bInfo, ok := obj.(*headerInfo)
 	if !ok {
-		return "", ErrNotABlockInfo
+		return "", ErrNotAHeaderInfo
 	}
 
 	return bInfo.Number.String(), nil
 }
 
-// blockCache struct with two queues for looking up by hash or by block height.
-type blockCache struct {
+// headerCache struct with two queues for looking up by hash or by block height.
+type headerCache struct {
 	hashCache   *cache.FIFO
 	heightCache *cache.FIFO
 	lock        sync.RWMutex
 }
 
-// newBlockCache creates a new block cache for storing/accessing blockInfo from
+// newHeaderCache creates a new block cache for storing/accessing headerInfo from
 // memory.
-func newBlockCache() *blockCache {
-	return &blockCache{
+func newHeaderCache() *headerCache {
+	return &headerCache{
 		hashCache:   cache.NewFIFO(hashKeyFn),
 		heightCache: cache.NewFIFO(heightKeyFn),
 	}
 }
 
-// BlockInfoByHash fetches blockInfo by its block hash. Returns true with a
-// reference to the block info, if exists. Otherwise returns false, nil.
-func (b *blockCache) BlockInfoByHash(hash common.Hash) (bool, *blockInfo, error) {
+// HeaderInfoByHash fetches headerInfo by its header hash. Returns true with a
+// reference to the header info, if exists. Otherwise returns false, nil.
+func (b *headerCache) HeaderInfoByHash(hash common.Hash) (bool, *headerInfo, error) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
@@ -102,23 +102,23 @@ func (b *blockCache) BlockInfoByHash(hash common.Hash) (bool, *blockInfo, error)
 	}
 
 	if exists {
-		blockCacheHit.Inc()
+		headerCacheHit.Inc()
 	} else {
-		blockCacheMiss.Inc()
+		headerCacheMiss.Inc()
 		return false, nil, nil
 	}
 
-	bInfo, ok := obj.(*blockInfo)
+	bInfo, ok := obj.(*headerInfo)
 	if !ok {
-		return false, nil, ErrNotABlockInfo
+		return false, nil, ErrNotAHeaderInfo
 	}
 
 	return true, bInfo, nil
 }
 
-// BlockInfoByHeight fetches blockInfo by its block number. Returns true with a
-// reference to the block info, if exists. Otherwise returns false, nil.
-func (b *blockCache) BlockInfoByHeight(height *big.Int) (bool, *blockInfo, error) {
+// HeaderInfoByHeight fetches headerInfo by its header number. Returns true with a
+// reference to the header info, if exists. Otherwise returns false, nil.
+func (b *headerCache) HeaderInfoByHeight(height *big.Int) (bool, *headerInfo, error) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
@@ -128,42 +128,42 @@ func (b *blockCache) BlockInfoByHeight(height *big.Int) (bool, *blockInfo, error
 	}
 
 	if exists {
-		blockCacheHit.Inc()
+		headerCacheHit.Inc()
 	} else {
-		blockCacheMiss.Inc()
+		headerCacheMiss.Inc()
 		return false, nil, nil
 	}
 
-	bInfo, ok := obj.(*blockInfo)
+	hInfo, ok := obj.(*headerInfo)
 	if !ok {
-		return false, nil, ErrNotABlockInfo
+		return false, nil, ErrNotAHeaderInfo
 	}
 
-	return exists, bInfo, nil
+	return exists, hInfo, nil
 }
 
-// AddBlock adds a blockInfo object to the cache. This method also trims the
-// least recently added block info if the cache size has reached the max cache
-// size limit. This method should be called in sequential block number order if
-// the desired behavior is that the blocks with the highest block number should
+// AddHeader adds a headerInfo object to the cache. This method also trims the
+// least recently added header info if the cache size has reached the max cache
+// size limit. This method should be called in sequential header number order if
+// the desired behavior is that the blocks with the highest header number should
 // be present in the cache.
-func (b *blockCache) AddBlock(blk *gethTypes.Block) error {
+func (b *headerCache) AddHeader(hdr *gethTypes.Header) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	bInfo := blockToBlockInfo(blk)
+	hInfo := headerToHeaderInfo(hdr)
 
-	if err := b.hashCache.AddIfNotPresent(bInfo); err != nil {
+	if err := b.hashCache.AddIfNotPresent(hInfo); err != nil {
 		return err
 	}
-	if err := b.heightCache.AddIfNotPresent(bInfo); err != nil {
+	if err := b.heightCache.AddIfNotPresent(hInfo); err != nil {
 		return err
 	}
 
 	trim(b.hashCache, maxCacheSize)
 	trim(b.heightCache, maxCacheSize)
 
-	blockCacheSize.Set(float64(len(b.hashCache.ListKeys())))
+	headerCacheSize.Set(float64(len(b.hashCache.ListKeys())))
 
 	return nil
 }

--- a/beacon-chain/powchain/block_cache.go
+++ b/beacon-chain/powchain/block_cache.go
@@ -38,7 +38,7 @@ var (
 	})
 )
 
-// headerInfo specifies the block information in the ETH 1.0 chain.
+// headerInfo specifies the block header information in the ETH 1.0 chain.
 type headerInfo struct {
 	Number *big.Int
 	Hash   common.Hash
@@ -55,15 +55,15 @@ func headerToHeaderInfo(hdr *gethTypes.Header) *headerInfo {
 
 // hashKeyFn takes the hex string representation as the key for a headerInfo.
 func hashKeyFn(obj interface{}) (string, error) {
-	bInfo, ok := obj.(*headerInfo)
+	hInfo, ok := obj.(*headerInfo)
 	if !ok {
 		return "", ErrNotAHeaderInfo
 	}
 
-	return bInfo.Hash.Hex(), nil
+	return hInfo.Hash.Hex(), nil
 }
 
-// heightKeyFn takes the string representation of the block number as the key
+// heightKeyFn takes the string representation of the block header number as the key
 // for a headerInfo.
 func heightKeyFn(obj interface{}) (string, error) {
 	bInfo, ok := obj.(*headerInfo)

--- a/beacon-chain/powchain/block_cache.go
+++ b/beacon-chain/powchain/block_cache.go
@@ -66,12 +66,12 @@ func hashKeyFn(obj interface{}) (string, error) {
 // heightKeyFn takes the string representation of the block header number as the key
 // for a headerInfo.
 func heightKeyFn(obj interface{}) (string, error) {
-	bInfo, ok := obj.(*headerInfo)
+	hInfo, ok := obj.(*headerInfo)
 	if !ok {
 		return "", ErrNotAHeaderInfo
 	}
 
-	return bInfo.Number.String(), nil
+	return hInfo.Number.String(), nil
 }
 
 // headerCache struct with two queues for looking up by hash or by block height.
@@ -108,12 +108,12 @@ func (b *headerCache) HeaderInfoByHash(hash common.Hash) (bool, *headerInfo, err
 		return false, nil, nil
 	}
 
-	bInfo, ok := obj.(*headerInfo)
+	hInfo, ok := obj.(*headerInfo)
 	if !ok {
 		return false, nil, ErrNotAHeaderInfo
 	}
 
-	return true, bInfo, nil
+	return true, hInfo, nil
 }
 
 // HeaderInfoByHeight fetches headerInfo by its header number. Returns true with a

--- a/beacon-chain/powchain/block_cache_test.go
+++ b/beacon-chain/powchain/block_cache_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 func TestHashKeyFn_OK(t *testing.T) {
-	bInfo := &headerInfo{
+	hInfo := &headerInfo{
 		Hash: common.HexToHash("0x0123456"),
 	}
 
-	key, err := hashKeyFn(bInfo)
+	key, err := hashKeyFn(hInfo)
 	require.NoError(t, err)
-	assert.Equal(t, bInfo.Hash.Hex(), key)
+	assert.Equal(t, hInfo.Hash.Hex(), key)
 }
 
 func TestHashKeyFn_InvalidObj(t *testing.T) {
@@ -26,13 +26,13 @@ func TestHashKeyFn_InvalidObj(t *testing.T) {
 }
 
 func TestHeightKeyFn_OK(t *testing.T) {
-	bInfo := &headerInfo{
+	hInfo := &headerInfo{
 		Number: big.NewInt(555),
 	}
 
-	key, err := heightKeyFn(bInfo)
+	key, err := heightKeyFn(hInfo)
 	require.NoError(t, err)
-	assert.Equal(t, bInfo.Number.String(), key)
+	assert.Equal(t, hInfo.Number.String(), key)
 }
 
 func TestHeightKeyFn_InvalidObj(t *testing.T) {

--- a/beacon-chain/powchain/block_cache_test.go
+++ b/beacon-chain/powchain/block_cache_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestHashKeyFn_OK(t *testing.T) {
-	bInfo := &blockInfo{
+	bInfo := &headerInfo{
 		Hash: common.HexToHash("0x0123456"),
 	}
 
@@ -22,11 +22,11 @@ func TestHashKeyFn_OK(t *testing.T) {
 
 func TestHashKeyFn_InvalidObj(t *testing.T) {
 	_, err := hashKeyFn("bad")
-	assert.Equal(t, ErrNotABlockInfo, err)
+	assert.Equal(t, ErrNotAHeaderInfo, err)
 }
 
 func TestHeightKeyFn_OK(t *testing.T) {
-	bInfo := &blockInfo{
+	bInfo := &headerInfo{
 		Number: big.NewInt(555),
 	}
 
@@ -37,50 +37,50 @@ func TestHeightKeyFn_OK(t *testing.T) {
 
 func TestHeightKeyFn_InvalidObj(t *testing.T) {
 	_, err := heightKeyFn("bad")
-	assert.Equal(t, ErrNotABlockInfo, err)
+	assert.Equal(t, ErrNotAHeaderInfo, err)
 }
 
 func TestBlockCache_byHash(t *testing.T) {
-	cache := newBlockCache()
+	cache := newHeaderCache()
 
 	header := &gethTypes.Header{
 		ParentHash: common.HexToHash("0x12345"),
 		Number:     big.NewInt(55),
 	}
 
-	exists, _, err := cache.BlockInfoByHash(header.Hash())
+	exists, _, err := cache.HeaderInfoByHash(header.Hash())
 	require.NoError(t, err)
 	assert.Equal(t, false, exists, "Expected block info not to exist in empty cache")
 
-	err = cache.AddBlock(gethTypes.NewBlockWithHeader(header))
+	err = cache.AddHeader(header)
 	require.NoError(t, err)
 
-	exists, fetchedInfo, err := cache.BlockInfoByHash(header.Hash())
+	exists, fetchedInfo, err := cache.HeaderInfoByHash(header.Hash())
 	require.NoError(t, err)
-	assert.Equal(t, true, exists, "Expected blockInfo to exist")
+	assert.Equal(t, true, exists, "Expected headerInfo to exist")
 	assert.Equal(t, 0, fetchedInfo.Number.Cmp(header.Number), "Expected fetched info number to be equal")
 	assert.Equal(t, header.Hash(), fetchedInfo.Hash, "Expected hash to be equal")
 
 }
 
 func TestBlockCache_byHeight(t *testing.T) {
-	cache := newBlockCache()
+	cache := newHeaderCache()
 
 	header := &gethTypes.Header{
 		ParentHash: common.HexToHash("0x12345"),
 		Number:     big.NewInt(55),
 	}
 
-	exists, _, err := cache.BlockInfoByHeight(header.Number)
+	exists, _, err := cache.HeaderInfoByHeight(header.Number)
 	require.NoError(t, err)
 	assert.Equal(t, false, exists, "Expected block info not to exist in empty cache")
 
-	err = cache.AddBlock(gethTypes.NewBlockWithHeader(header))
+	err = cache.AddHeader(header)
 	require.NoError(t, err)
 
-	exists, fetchedInfo, err := cache.BlockInfoByHeight(header.Number)
+	exists, fetchedInfo, err := cache.HeaderInfoByHeight(header.Number)
 	require.NoError(t, err)
-	assert.Equal(t, true, exists, "Expected blockInfo to exist")
+	assert.Equal(t, true, exists, "Expected headerInfo to exist")
 
 	assert.Equal(t, 0, fetchedInfo.Number.Cmp(header.Number), "Expected fetched info number to be equal")
 	assert.Equal(t, header.Hash(), fetchedInfo.Hash, "Expected hash to be equal")
@@ -88,13 +88,13 @@ func TestBlockCache_byHeight(t *testing.T) {
 }
 
 func TestBlockCache_maxSize(t *testing.T) {
-	cache := newBlockCache()
+	cache := newHeaderCache()
 
 	for i := int64(0); i < int64(maxCacheSize+10); i++ {
 		header := &gethTypes.Header{
 			Number: big.NewInt(i),
 		}
-		err := cache.AddBlock(gethTypes.NewBlockWithHeader(header))
+		err := cache.AddHeader(header)
 		require.NoError(t, err)
 
 	}

--- a/beacon-chain/powchain/block_reader.go
+++ b/beacon-chain/powchain/block_reader.go
@@ -15,7 +15,7 @@ func (s *Service) BlockExists(ctx context.Context, hash common.Hash) (bool, *big
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.web3service.BlockExists")
 	defer span.End()
 
-	if exists, blkInfo, err := s.blockCache.BlockInfoByHash(hash); exists || err != nil {
+	if exists, blkInfo, err := s.headerCache.HeaderInfoByHash(hash); exists || err != nil {
 		if err != nil {
 			return false, nil, err
 		}
@@ -23,16 +23,16 @@ func (s *Service) BlockExists(ctx context.Context, hash common.Hash) (bool, *big
 		return true, blkInfo.Number, nil
 	}
 	span.AddAttributes(trace.BoolAttribute("blockCacheHit", false))
-	block, err := s.eth1DataFetcher.BlockByHash(ctx, hash)
+	header, err := s.eth1DataFetcher.HeaderByHash(ctx, hash)
 	if err != nil {
 		return false, big.NewInt(0), errors.Wrap(err, "could not query block with given hash")
 	}
 
-	if err := s.blockCache.AddBlock(block); err != nil {
+	if err := s.headerCache.AddHeader(header); err != nil {
 		return false, big.NewInt(0), err
 	}
 
-	return true, block.Number(), nil
+	return true, new(big.Int).Set(header.Number), nil
 }
 
 // BlockHashByHeight returns the block hash of the block at the given height.
@@ -40,33 +40,33 @@ func (s *Service) BlockHashByHeight(ctx context.Context, height *big.Int) (commo
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.web3service.BlockHashByHeight")
 	defer span.End()
 
-	if exists, blkInfo, err := s.blockCache.BlockInfoByHeight(height); exists || err != nil {
+	if exists, hInfo, err := s.headerCache.HeaderInfoByHeight(height); exists || err != nil {
 		if err != nil {
 			return [32]byte{}, err
 		}
-		span.AddAttributes(trace.BoolAttribute("blockCacheHit", true))
-		return blkInfo.Hash, nil
+		span.AddAttributes(trace.BoolAttribute("headerCacheHit", true))
+		return hInfo.Hash, nil
 	}
-	span.AddAttributes(trace.BoolAttribute("blockCacheHit", false))
-	block, err := s.eth1DataFetcher.BlockByNumber(ctx, height)
+	span.AddAttributes(trace.BoolAttribute("headerCacheHit", false))
+	header, err := s.eth1DataFetcher.HeaderByNumber(ctx, height)
 	if err != nil {
-		return [32]byte{}, errors.Wrap(err, fmt.Sprintf("could not query block with height %d", height.Uint64()))
+		return [32]byte{}, errors.Wrap(err, fmt.Sprintf("could not query header with height %d", height.Uint64()))
 	}
-	if err := s.blockCache.AddBlock(block); err != nil {
+	if err := s.headerCache.AddHeader(header); err != nil {
 		return [32]byte{}, err
 	}
-	return block.Hash(), nil
+	return header.Hash(), nil
 }
 
 // BlockTimeByHeight fetches an eth1.0 block timestamp by its height.
 func (s *Service) BlockTimeByHeight(ctx context.Context, height *big.Int) (uint64, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.web3service.BlockTimeByHeight")
 	defer span.End()
-	block, err := s.eth1DataFetcher.BlockByNumber(ctx, height)
+	header, err := s.eth1DataFetcher.HeaderByNumber(ctx, height)
 	if err != nil {
 		return 0, errors.Wrap(err, fmt.Sprintf("could not query block with height %d", height.Uint64()))
 	}
-	return block.Time(), nil
+	return header.Time, nil
 }
 
 // BlockNumberByTimestamp returns the most recent block number up to a given timestamp.
@@ -77,30 +77,30 @@ func (s *Service) BlockNumberByTimestamp(ctx context.Context, time uint64) (*big
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.web3service.BlockByTimestamp")
 	defer span.End()
 
-	head, err := s.eth1DataFetcher.BlockByNumber(ctx, nil)
+	head, err := s.eth1DataFetcher.HeaderByNumber(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	for bn := head.Number(); ; bn = big.NewInt(0).Sub(bn, big.NewInt(1)) {
+	for bn := head.Number; ; bn = big.NewInt(0).Sub(bn, big.NewInt(1)) {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
 
-		exists, info, err := s.blockCache.BlockInfoByHeight(bn)
+		exists, info, err := s.headerCache.HeaderInfoByHeight(bn)
 		if err != nil {
 			return nil, err
 		}
 
 		if !exists {
-			blk, err := s.eth1DataFetcher.BlockByNumber(ctx, bn)
+			blk, err := s.eth1DataFetcher.HeaderByNumber(ctx, bn)
 			if err != nil {
 				return nil, err
 			}
-			if err := s.blockCache.AddBlock(blk); err != nil {
+			if err := s.headerCache.AddHeader(blk); err != nil {
 				return nil, err
 			}
-			info = blockToBlockInfo(blk)
+			info = headerToHeaderInfo(blk)
 		}
 
 		if info.Time <= time {

--- a/beacon-chain/powchain/block_reader.go
+++ b/beacon-chain/powchain/block_reader.go
@@ -15,12 +15,12 @@ func (s *Service) BlockExists(ctx context.Context, hash common.Hash) (bool, *big
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.web3service.BlockExists")
 	defer span.End()
 
-	if exists, blkInfo, err := s.headerCache.HeaderInfoByHash(hash); exists || err != nil {
+	if exists, hdrInfo, err := s.headerCache.HeaderInfoByHash(hash); exists || err != nil {
 		if err != nil {
 			return false, nil, err
 		}
 		span.AddAttributes(trace.BoolAttribute("blockCacheHit", true))
-		return true, blkInfo.Number, nil
+		return true, hdrInfo.Number, nil
 	}
 	span.AddAttributes(trace.BoolAttribute("blockCacheHit", false))
 	header, err := s.eth1DataFetcher.HeaderByHash(ctx, hash)

--- a/beacon-chain/powchain/block_reader_test.go
+++ b/beacon-chain/powchain/block_reader_test.go
@@ -66,9 +66,9 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 	assert.Equal(t, hexutil.Encode(web3Service.latestEth1Data.BlockHash), header.Hash().Hex())
 	assert.Equal(t, web3Service.latestEth1Data.BlockTime, header.Time)
 
-	blockInfoExistsInCache, info, err := web3Service.headerCache.HeaderInfoByHash(bytesutil.ToBytes32(web3Service.latestEth1Data.BlockHash))
+	headerInfoExistsInCache, info, err := web3Service.headerCache.HeaderInfoByHash(bytesutil.ToBytes32(web3Service.latestEth1Data.BlockHash))
 	require.NoError(t, err)
-	assert.Equal(t, true, blockInfoExistsInCache, "Expected block info to exist in cache")
+	assert.Equal(t, true, headerInfoExistsInCache, "Expected block info to exist in cache")
 	assert.Equal(t, bytesutil.ToBytes32(info.Hash[:]), bytesutil.ToBytes32(web3Service.latestEth1Data.BlockHash))
 
 }

--- a/beacon-chain/powchain/block_reader_test.go
+++ b/beacon-chain/powchain/block_reader_test.go
@@ -66,7 +66,7 @@ func TestLatestMainchainInfo_OK(t *testing.T) {
 	assert.Equal(t, hexutil.Encode(web3Service.latestEth1Data.BlockHash), header.Hash().Hex())
 	assert.Equal(t, web3Service.latestEth1Data.BlockTime, header.Time)
 
-	blockInfoExistsInCache, info, err := web3Service.blockCache.BlockInfoByHash(bytesutil.ToBytes32(web3Service.latestEth1Data.BlockHash))
+	blockInfoExistsInCache, info, err := web3Service.headerCache.HeaderInfoByHash(bytesutil.ToBytes32(web3Service.latestEth1Data.BlockHash))
 	require.NoError(t, err)
 	assert.Equal(t, true, blockInfoExistsInCache, "Expected block info to exist in cache")
 	assert.Equal(t, bytesutil.ToBytes32(info.Hash[:]), bytesutil.ToBytes32(web3Service.latestEth1Data.BlockHash))
@@ -84,22 +84,18 @@ func TestBlockHashByHeight_ReturnsHash(t *testing.T) {
 	web3Service = setDefaultMocks(web3Service)
 	ctx := context.Background()
 
-	block := gethTypes.NewBlock(
-		&gethTypes.Header{
-			Number: big.NewInt(15),
-			Time:   150,
-		},
-		[]*gethTypes.Transaction{},
-		[]*gethTypes.Header{},
-		[]*gethTypes.Receipt{},
-	)
-	wanted := block.Hash()
+	header := &gethTypes.Header{
+		Number: big.NewInt(15),
+		Time:   150,
+	}
+
+	wanted := header.Hash()
 
 	hash, err := web3Service.BlockHashByHeight(ctx, big.NewInt(0))
 	require.NoError(t, err, "Could not get block hash with given height")
 	require.DeepEqual(t, wanted.Bytes(), hash.Bytes(), "Block hash did not equal expected hash")
 
-	exists, _, err := web3Service.blockCache.BlockInfoByHash(wanted)
+	exists, _, err := web3Service.headerCache.HeaderInfoByHash(wanted)
 	require.NoError(t, err)
 	require.Equal(t, true, exists, "Expected block info to be cached")
 }
@@ -128,7 +124,7 @@ func TestBlockExists_ValidHash(t *testing.T) {
 	require.Equal(t, true, exists)
 	require.Equal(t, 0, height.Cmp(block.Number()))
 
-	exists, _, err = web3Service.blockCache.BlockInfoByHeight(height)
+	exists, _, err = web3Service.headerCache.HeaderInfoByHeight(height)
 	require.NoError(t, err)
 	require.Equal(t, true, exists, "Expected block to be cached")
 
@@ -158,22 +154,17 @@ func TestBlockExists_UsesCachedBlockInfo(t *testing.T) {
 	// nil eth1DataFetcher would panic if cached value not used
 	web3Service.eth1DataFetcher = nil
 
-	block := gethTypes.NewBlock(
-		&gethTypes.Header{
-			Number: big.NewInt(0),
-		},
-		[]*gethTypes.Transaction{},
-		[]*gethTypes.Header{},
-		[]*gethTypes.Receipt{},
-	)
+	header := &gethTypes.Header{
+		Number: big.NewInt(0),
+	}
 
-	err = web3Service.blockCache.AddBlock(block)
+	err = web3Service.headerCache.AddHeader(header)
 	require.NoError(t, err)
 
-	exists, height, err := web3Service.BlockExists(context.Background(), block.Hash())
+	exists, height, err := web3Service.BlockExists(context.Background(), header.Hash())
 	require.NoError(t, err, "Could not get block hash with given height")
 	require.Equal(t, true, exists)
-	require.Equal(t, 0, height.Cmp(block.Number()))
+	require.Equal(t, 0, height.Cmp(header.Number))
 }
 
 func TestBlockNumberByTimestamp(t *testing.T) {

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -102,8 +102,7 @@ type Client interface {
 // fetching eth1 data from the clients.
 type RPCDataFetcher interface {
 	HeaderByNumber(ctx context.Context, number *big.Int) (*gethTypes.Header, error)
-	BlockByNumber(ctx context.Context, number *big.Int) (*gethTypes.Block, error)
-	BlockByHash(ctx context.Context, hash common.Hash) (*gethTypes.Block, error)
+	HeaderByHash(ctx context.Context, hash common.Hash) (*gethTypes.Header, error)
 	SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error)
 }
 
@@ -133,7 +132,7 @@ type Service struct {
 	httpLogger              bind.ContractFilterer
 	eth1DataFetcher         RPCDataFetcher
 	rpcClient               RPCClient
-	blockCache              *blockCache // cache to store block hash/block height.
+	headerCache             *headerCache // cache to store block hash/block height.
 	latestEth1Data          *protodb.LatestETH1Data
 	depositContractCaller   *contracts.DepositContractCaller
 	depositRoot             []byte
@@ -181,7 +180,7 @@ func NewService(ctx context.Context, config *Web3ServiceConfig) (*Service, error
 			BlockHash:          []byte{},
 			LastRequestedBlock: 0,
 		},
-		blockCache:             newBlockCache(),
+		headerCache:            newHeaderCache(),
 		depositContractAddress: config.DepositContract,
 		stateNotifier:          config.StateNotifier,
 		depositTrie:            depositTrie,
@@ -529,7 +528,7 @@ func (s *Service) processBlockHeader(header *gethTypes.Header) {
 		"blockHash":   hexutil.Encode(s.latestEth1Data.BlockHash),
 	}).Debug("Latest eth1 chain event")
 
-	if err := s.blockCache.AddBlock(gethTypes.NewBlockWithHeader(header)); err != nil {
+	if err := s.headerCache.AddHeader(header); err != nil {
 		s.runError = err
 		log.Errorf("Unable to add block data to cache %v", err)
 	}
@@ -550,7 +549,7 @@ func (s *Service) batchRequestHeaders(startBlock uint64, endBlock uint64) ([]*ge
 		err := error(nil)
 		elems = append(elems, gethRPC.BatchElem{
 			Method: "eth_getBlockByNumber",
-			Args:   []interface{}{hexutil.EncodeBig(big.NewInt(int64(i))), true},
+			Args:   []interface{}{hexutil.EncodeBig(big.NewInt(int64(i))), false},
 			Result: header,
 			Error:  err,
 		})
@@ -568,7 +567,7 @@ func (s *Service) batchRequestHeaders(startBlock uint64, endBlock uint64) ([]*ge
 	}
 	for _, h := range headers {
 		if h != nil {
-			if err := s.blockCache.AddBlock(gethTypes.NewBlockWithHeader(h)); err != nil {
+			if err := s.headerCache.AddHeader(h); err != nil {
 				return nil, err
 			}
 		}

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -72,44 +72,24 @@ type goodFetcher struct {
 	backend *backends.SimulatedBackend
 }
 
-func (g *goodFetcher) BlockByHash(ctx context.Context, hash common.Hash) (*gethTypes.Block, error) {
+func (g *goodFetcher) HeaderByHash(ctx context.Context, hash common.Hash) (*gethTypes.Header, error) {
 	if bytes.Equal(hash.Bytes(), common.BytesToHash([]byte{0}).Bytes()) {
 		return nil, fmt.Errorf("expected block hash to be nonzero %v", hash)
 	}
 	if g.backend == nil {
-		return gethTypes.NewBlock(
-			&gethTypes.Header{
-				Number: big.NewInt(0),
-			},
-			[]*gethTypes.Transaction{},
-			[]*gethTypes.Header{},
-			[]*gethTypes.Receipt{},
-		), nil
+		return &gethTypes.Header{
+			Number: big.NewInt(0),
+		}, nil
 	}
-	return g.backend.Blockchain().GetBlockByHash(hash), nil
+	return g.backend.Blockchain().GetHeaderByHash(hash), nil
 
-}
-
-func (g *goodFetcher) BlockByNumber(ctx context.Context, number *big.Int) (*gethTypes.Block, error) {
-	if g.backend == nil {
-		return gethTypes.NewBlock(
-			&gethTypes.Header{
-				Number: big.NewInt(15),
-				Time:   150,
-			},
-			[]*gethTypes.Transaction{},
-			[]*gethTypes.Header{},
-			[]*gethTypes.Receipt{},
-		), nil
-	}
-
-	return g.backend.Blockchain().GetBlockByNumber(number.Uint64()), nil
 }
 
 func (g *goodFetcher) HeaderByNumber(ctx context.Context, number *big.Int) (*gethTypes.Header, error) {
 	if g.backend == nil {
 		return &gethTypes.Header{
-			Number: big.NewInt(0),
+			Number: big.NewInt(15),
+			Time:   150,
 		}, nil
 	}
 	if number == nil {


### PR DESCRIPTION
**What type of PR is this?**

Feature Improvement

**What does this PR do? Why is it needed?**

- [x] Currently we request full blocks from the eth1 node, when we have no requirement for a block's respective transactions. 
All the data we require is stored in block headers and contract logs.
- [x] Changes all references to headers instead of blocks.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
