### PR TITLE
Return an error if no eth1 endpoint defined and we do not have genesis state

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -215,6 +215,13 @@ func NewService(ctx context.Context, config *Web3ServiceConfig) (*Service, error
 			return nil, errors.Wrap(err, "could not initialize caches")
 		}
 	}
+
+	// If the chain has not started already and we don't have access to eth1 nodes, we will not be
+	// able to generate the genesis state.
+	if !s.chainStartData.Chainstarted && s.httpEndpoint == "" {
+		return nil, errors.New("cannot create genesis state: no eth1 http endpoint defined")
+	}
+
 	return s, nil
 }
 

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -153,6 +153,35 @@ func TestStart_OK(t *testing.T) {
 	web3Service.cancel()
 }
 
+func TestStart_NoHTTPEndpointDefinedFails_WithoutChainStarted(t *testing.T) {
+	beaconDB, _ := dbutil.SetupDB(t)
+	testAcc, err := contracts.Setup()
+	require.NoError(t, err, "Unable to set up simulated backend")
+	_, err = NewService(context.Background(), &Web3ServiceConfig{
+		HTTPEndPoint:    "", // No endpoint defined!
+		DepositContract: testAcc.ContractAddr,
+		BeaconDB:        beaconDB,
+	})
+	require.ErrorContains(t, "cannot create genesis state: no eth1 http endpoint defined", err)
+}
+
+func TestStart_NoHTTPEndpointDefinedSucceeds_WithChainStarted(t *testing.T) {
+	beaconDB, _ := dbutil.SetupDB(t)
+	testAcc, err := contracts.Setup()
+	require.NoError(t, err, "Unable to set up simulated backend")
+
+	require.NoError(t, beaconDB.SavePowchainData(context.Background(), &protodb.ETH1ChainData{
+		ChainstartData: &protodb.ChainStartData{Chainstarted: true},
+		Trie:           &protodb.SparseMerkleTrie{},
+	}))
+	_, err = NewService(context.Background(), &Web3ServiceConfig{
+		HTTPEndPoint:    "", // No endpoint defined!
+		DepositContract: testAcc.ContractAddr,
+		BeaconDB:        beaconDB,
+	})
+	require.NoError(t, err)
+}
+
 func TestStop_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
 	testAcc, err := contracts.Setup()


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR gives users more immediate feedback if they did not provide eth1 node and have not already synced a genesis state.

**Which issues(s) does this PR fix?**

Follow up to #7120 

**Other notes for review**
