### PR TITLE
Don't include orphaned atts

### DIFF
--- a/beacon-chain/rpc/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/beacon/BUILD.bazel
@@ -36,7 +36,6 @@ go_library(
         "//beacon-chain/powchain:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
-        "//beacon-chain/state/stateutil:go_default_library",
         "//beacon-chain/sync:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/aggregation/attestations:go_default_library",

--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -11,10 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
-	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
 	statetrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
-	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
@@ -485,8 +482,6 @@ func (bs *Server) GetValidatorParticipation(
 		return nil, status.Error(codes.Internal, "Could not get state")
 	}
 
-	requestedState, err = bs.appendNonFinalizedBlockAttsToState(ctx, requestedState, requestedEpoch)
-
 	v, b, err := precompute.New(ctx, requestedState)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "Could not set up pre compute instance")
@@ -517,45 +512,6 @@ func (bs *Server) GetValidatorParticipation(
 			PreviousEpochHeadAttestingGwei:   b.PrevEpochHeadAttested,
 		},
 	}, nil
-}
-
-// This appends non finalized block atts to state. To replay for a state, a node does not replay non canonical
-// nor finalized blocks. To count participation, this includes the attestations from the orphaned block to state.
-func (bs *Server) appendNonFinalizedBlockAttsToState(ctx context.Context, s *statetrie.BeaconState, e uint64) (*statetrie.BeaconState, error) {
-	start := helpers.StartSlot(e)
-	end := helpers.StartSlot(e + 1)
-	f := filters.NewFilter().SetStartSlot(start).SetEndSlot(end)
-	blks, err := bs.BeaconDB.Blocks(ctx, f)
-	if err != nil {
-		return nil, err
-	}
-
-	nonFinalizedBlks := make([]*ethpb.SignedBeaconBlock, 0, len(blks))
-	for i := len(blks) - 1; i >= 0; i-- {
-		r, err := stateutil.BlockRoot(blks[i].Block)
-		if err != nil {
-			return nil, err
-		}
-		if !bs.BeaconDB.IsFinalizedBlock(ctx, r) {
-			nonFinalizedBlks = append(nonFinalizedBlks, blks[i])
-		}
-	}
-	for _, b := range nonFinalizedBlks {
-		for _, a := range b.Block.Body.Attestations {
-			if a.Data.Target.Epoch == e {
-				pa := &pb.PendingAttestation{
-					Data:            a.Data,
-					AggregationBits: a.AggregationBits,
-					InclusionDelay:  params.BeaconConfig().FarFutureEpoch,
-				}
-				if err := s.AppendPreviousEpochAttestations(pa); err != nil {
-					return nil, err
-				}
-			}
-		}
-	}
-
-	return s, nil
 }
 
 // GetValidatorQueue retrieves the current validator queue information.

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -1879,26 +1879,3 @@ func TestServer_GetIndividualVotes_Working(t *testing.T) {
 	}
 	assert.DeepEqual(t, wanted, res, "Unexpected response")
 }
-
-func TestServer_appendNonFinalizedBlockAttsToState(t *testing.T) {
-	db, _ := dbTest.SetupDB(t)
-	ctx := context.Background()
-	bs := &Server{
-		BeaconDB: db,
-	}
-	e := uint64(1)
-	b1 := testutil.NewBeaconBlock()
-	b1.Block.Slot = e * params.BeaconConfig().SlotsPerEpoch
-	a1 := testutil.NewAttestation()
-	a1.Data.Target.Epoch = 1
-	b1.Block.Body.Attestations = []*ethpb.Attestation{a1}
-	b2 := testutil.NewBeaconBlock()
-	b2.Block.Slot = e*params.BeaconConfig().SlotsPerEpoch + 1
-	b2.Block.Body.Attestations = []*ethpb.Attestation{a1}
-	require.NoError(t, db.SaveBlock(ctx, b1))
-	require.NoError(t, db.SaveBlock(ctx, b2))
-	s := testutil.NewBeaconState()
-	got, err := bs.appendNonFinalizedBlockAttsToState(ctx, s, e)
-	require.NoError(t, err)
-	require.Equal(t, 2, len(got.PreviousEpochAttestations()))
-}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**
I had an incorrect assumption that we should include in orphaned attestations for participation. Danny pointed out that is wrong and i have been thinking and agreed it is wrong. Although it wouldn't change the outcome much because `process_epoch` would have rejected orphaned atts, but it's unnecessary work for the node.

Reference: https://github.com/prysmaticlabs/prysm/issues/7116#issuecomment-682204891
