### PR TITLE
Add previous epoch participation metrics

### DIFF
--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -80,13 +80,21 @@ var (
 		Name: "field_references",
 		Help: "The number of states a particular field is shared with.",
 	}, []string{"state"})
-	totalEligibleBalances = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "total_eligible_balances",
-		Help: "The total amount of ether, in gwei, that is eligible for voting of previous epoch",
+	prevEpochActiveBalances = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "beacon_prev_epoch_active_gwei",
+		Help: "The total amount of ether, in gwei, that was active for voting of previous epoch",
 	})
-	totalVotedTargetBalances = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "total_voted_target_balances",
+	prevEpochSourceBalances = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "beacon_prev_epoch_source_gwei",
+		Help: "The total amount of ether, in gwei, that has been used in voting attestation source of previous epoch",
+	})
+	prevEpochTargetBalances = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "beacon_prev_epoch_target_gwei",
 		Help: "The total amount of ether, in gwei, that has been used in voting attestation target of previous epoch",
+	})
+	prevEpochHeadBalances = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "beacon_prev_epoch_head_gwei",
+		Help: "The total amount of ether, in gwei, that has been used in voting attestation head of previous epoch",
 	})
 	reorgCount = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "beacon_reorg_total",
@@ -106,6 +114,15 @@ var (
 			Buckets: []float64{1, 2, 3, 4, 6, 32, 64},
 		},
 	)
+	// TODO(7141): Remove deprecated metrics below.
+	totalEligibleBalances = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "total_eligible_balances",
+		Help: "The total amount of ether, in gwei, that is eligible for voting of previous epoch",
+	})
+	totalVotedTargetBalances = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "total_voted_target_balances",
+		Help: "The total amount of ether, in gwei, that has been used in voting attestation target of previous epoch",
+	})
 )
 
 // reportSlotMetrics reports slot related metrics.
@@ -205,6 +222,10 @@ func reportEpochMetrics(state *stateTrie.BeaconState) {
 	if precompute.Balances != nil {
 		totalEligibleBalances.Set(float64(precompute.Balances.ActivePrevEpoch))
 		totalVotedTargetBalances.Set(float64(precompute.Balances.PrevEpochTargetAttested))
+		prevEpochActiveBalances.Set(float64(precompute.Balances.ActivePrevEpoch))
+		prevEpochSourceBalances.Set(float64(precompute.Balances.PrevEpochAttested))
+		prevEpochTargetBalances.Set(float64(precompute.Balances.PrevEpochTargetAttested))
+		prevEpochHeadBalances.Set(float64(precompute.Balances.PrevEpochHeadAttested))
 	}
 	refMap := state.FieldReferencesCount()
 	for name, val := range refMap {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**
Adding these metrics as we found them useful in other clients. 
- beacon_prev_epoch_active_gwei
- beacon_prev_epoch_source_gwei
- beacon_prev_epoch_target_gwei
- beacon_prev_epoch_head_gwei

The metrics tracking doc: https://hackmd.io/D5FmoeFZScim_squBFl8oA

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
