### PR TITLE
Use state slot to verify exit signature

### DIFF
--- a/beacon-chain/rpc/validator/exit.go
+++ b/beacon-chain/rpc/validator/exit.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	opfeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/operation"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -34,7 +33,7 @@ func (vs *Server) ProposeExit(ctx context.Context, req *ethpb.SignedVoluntaryExi
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, "validator index exceeds validator set length")
 	}
-	if err := blocks.VerifyExitAndSignature(val, helpers.StartSlot(req.Exit.Epoch), s.Fork(), req, s.GenesisValidatorRoot()); err != nil {
+	if err := blocks.VerifyExitAndSignature(val, s.Slot(), s.Fork(), req, s.GenesisValidatorRoot()); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/beacon-chain/rpc/validator/exit_test.go
+++ b/beacon-chain/rpc/validator/exit_test.go
@@ -100,6 +100,8 @@ func TestProposeExit_NoPanic(t *testing.T) {
 	require.NoError(t, err)
 	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{BlockHash: make([]byte, 32)})
 	require.NoError(t, err)
+	epoch := uint64(2048)
+	require.NoError(t, beaconState.SetSlot(epoch*params.BeaconConfig().SlotsPerEpoch))
 	block := testutil.NewBeaconBlock()
 	require.NoError(t, db.SaveBlock(ctx, block), "Could not save genesis block")
 	genesisRoot, err := block.Block.HashTreeRoot()
@@ -129,7 +131,6 @@ func TestProposeExit_NoPanic(t *testing.T) {
 	require.ErrorContains(t, "voluntary exit does not exist", err, "Expected error for no exit existing")
 
 	// Send the request, expect a result on the state feed.
-	epoch := uint64(2048)
 	validatorIndex := uint64(0)
 	req = &ethpb.SignedVoluntaryExit{
 		Exit: &ethpb.VoluntaryExit{

--- a/beacon-chain/rpc/validator/exit_test.go
+++ b/beacon-chain/rpc/validator/exit_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
-func TestSub(t *testing.T) {
+func TestProposeExit_Notification(t *testing.T) {
 	db, _ := dbutil.SetupDB(t)
 	ctx := context.Background()
 	testutil.ResetCache()
@@ -30,6 +30,8 @@ func TestSub(t *testing.T) {
 	require.NoError(t, err)
 	beaconState, err := state.GenesisBeaconState(deposits, 0, &ethpb.Eth1Data{BlockHash: make([]byte, 32)})
 	require.NoError(t, err)
+	epoch := uint64(2048)
+	require.NoError(t, beaconState.SetSlot(epoch*params.BeaconConfig().SlotsPerEpoch))
 	block := testutil.NewBeaconBlock()
 	require.NoError(t, db.SaveBlock(ctx, block), "Could not save genesis block")
 	genesisRoot, err := block.Block.HashTreeRoot()
@@ -55,7 +57,6 @@ func TestSub(t *testing.T) {
 	defer opSub.Unsubscribe()
 
 	// Send the request, expect a result on the state feed.
-	epoch := uint64(2048)
 	validatorIndex := uint64(0)
 	req := &ethpb.SignedVoluntaryExit{
 		Exit: &ethpb.VoluntaryExit{

--- a/beacon-chain/sync/validate_voluntary_exit.go
+++ b/beacon-chain/sync/validate_voluntary_exit.go
@@ -7,7 +7,6 @@ import (
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
-	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/traceutil"
 	"go.opencensus.io/trace"
 )
@@ -53,7 +52,6 @@ func (s *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *p
 		return pubsub.ValidationIgnore
 	}
 
-	exitedEpochSlot := exit.Exit.Epoch * params.BeaconConfig().SlotsPerEpoch
 	if exit.Exit.ValidatorIndex >= uint64(headState.NumValidators()) {
 		return pubsub.ValidationReject
 	}
@@ -61,7 +59,7 @@ func (s *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *p
 	if err != nil {
 		return pubsub.ValidationIgnore
 	}
-	if err := blocks.VerifyExitAndSignature(val, exitedEpochSlot, headState.Fork(), exit, headState.GenesisValidatorRoot()); err != nil {
+	if err := blocks.VerifyExitAndSignature(val, headState.Slot(), headState.Fork(), exit, headState.GenesisValidatorRoot()); err != nil {
 		return pubsub.ValidationReject
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
Spec calls for using state slot to verify exit signature, not the slot in the exit object itself.

**Which issues(s) does this PR fix?**

Fixes # N/A

**Other notes for review**
