### PR TITLE
Verify Attestation Time Correctly

### DIFF
--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//shared/bytesutil:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/hashutil:go_default_library",
+        "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/roughtime:go_default_library",
         "//shared/sliceutil:go_default_library",

--- a/beacon-chain/core/helpers/attestation.go
+++ b/beacon-chain/core/helpers/attestation.go
@@ -124,7 +124,13 @@ func ComputeSubnetFromCommitteeAndSlot(activeValCount, comIdx, attSlot uint64) u
 //   valid_attestation_slot = 98
 // In the attestation must be within the range of 95 to 100 in the example above.
 func ValidateAttestationTime(attSlot uint64, genesisTime time.Time) error {
-	attTime := genesisTime.Add(time.Duration(attSlot*params.BeaconConfig().SecondsPerSlot) * time.Second)
+	if err := ValidateSlotClock(attSlot, uint64(genesisTime.Unix())); err != nil {
+		return err
+	}
+	attTime, err := SlotToTime(uint64(genesisTime.Unix()), attSlot)
+	if err != nil {
+		return err
+	}
 	currentSlot := SlotsSince(genesisTime)
 
 	// A clock disparity allows for minor tolerances outside of the expected range. This value is
@@ -141,9 +147,11 @@ func ValidateAttestationTime(attSlot uint64, genesisTime time.Time) error {
 	if currentSlot > params.BeaconNetworkConfig().AttestationPropagationSlotRange {
 		lowerBoundsSlot = currentSlot - params.BeaconNetworkConfig().AttestationPropagationSlotRange
 	}
-	lowerBounds := genesisTime.Add(
-		time.Duration(lowerBoundsSlot*params.BeaconConfig().SecondsPerSlot) * time.Second,
-	).Add(-clockDisparity)
+	lowerTime, err := SlotToTime(uint64(genesisTime.Unix()), lowerBoundsSlot)
+	if err != nil {
+		return err
+	}
+	lowerBounds := lowerTime.Add(-clockDisparity)
 
 	// Verify attestation slot within the time range.
 	if attTime.Before(lowerBounds) || attTime.After(upperBounds) {

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -215,6 +215,14 @@ func Test_ValidateAttestationTime(t *testing.T) {
 				).Add(200 * time.Millisecond),
 			},
 		},
+		{
+			name: "attestation.slot is well beyond current slot",
+			args: args{
+				attSlot:     1 << 32,
+				genesisTime: roughtime.Now().Add(-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+			},
+			wantedErr: "which exceeds max allowed value relative to the local clock",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/beacon-chain/core/helpers/slot_epoch.go
+++ b/beacon-chain/core/helpers/slot_epoch.go
@@ -1,13 +1,12 @@
 package helpers
 
 import (
-	"errors"
 	"fmt"
-	"math"
-	"math/bits"
 	"time"
 
+	"github.com/pkg/errors"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
+	"github.com/prysmaticlabs/prysm/shared/mathutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/roughtime"
 )
@@ -76,9 +75,9 @@ func NextEpoch(state *stateTrie.BeaconState) uint64 {
 //    """
 //    return Slot(epoch * SLOTS_PER_EPOCH)
 func StartSlot(epoch uint64) (uint64, error) {
-	overflows, slot := bits.Mul64(epoch, params.BeaconConfig().SlotsPerEpoch)
-	if overflows > 0 {
-		return slot, errors.New("start slot calculation overflows")
+	slot, err := mathutil.Mul64(epoch, params.BeaconConfig().SlotsPerEpoch)
+	if err != nil {
+		return slot, errors.Errorf("start slot calculation overflows: %v", err)
 	}
 	return slot, nil
 }
@@ -107,11 +106,10 @@ func VerifySlotTime(genesisTime uint64, slot uint64, timeTolerance time.Duration
 		return err
 	}
 
-	maxPossibleSlot := CurrentSlot(genesisTime) + MaxSlotBuffer
-	// Defensive check to ensure that we only process slots up to a hard limit
-	// from our local clock.
-	if slot > maxPossibleSlot {
-		return fmt.Errorf("slot %d > %d which exceeds max allowed value relative to the local clock", slot, maxPossibleSlot)
+	// Defensive check to ensure unreasonable slots are rejected
+	// straight away.
+	if err := ValidateSlotClock(slot, genesisTime); err != nil {
+		return err
 	}
 
 	currentTime := roughtime.Now()
@@ -125,16 +123,20 @@ func VerifySlotTime(genesisTime uint64, slot uint64, timeTolerance time.Duration
 
 // SlotToTime takes the given slot and genesis time to determine the start time of the slot.
 func SlotToTime(genesisTimeSec uint64, slot uint64) (time.Time, error) {
-	if slot >= math.MaxInt64/params.BeaconConfig().SecondsPerSlot {
-		return time.Unix(0, 0), fmt.Errorf("slot (%d) is in the far distant future", slot)
+	timeSinceGenesis, err := mathutil.Mul64(slot, params.BeaconConfig().SecondsPerSlot)
+	if err != nil {
+		return time.Unix(0, 0), fmt.Errorf("slot (%d) is in the far distant future: %v", slot, err)
 	}
-	timeSinceGenesis := slot * params.BeaconConfig().SecondsPerSlot
-	return time.Unix(int64(genesisTimeSec+timeSinceGenesis), 0), nil
+	sTime, err := mathutil.Add64(genesisTimeSec, timeSinceGenesis)
+	if err != nil {
+		return time.Unix(0, 0), fmt.Errorf("slot (%d) is in the far distant future: %v", slot, err)
+	}
+	return time.Unix(int64(sTime), 0), nil
 }
 
 // SlotsSince computes the number of time slots that have occurred since the given timestamp.
 func SlotsSince(time time.Time) uint64 {
-	return uint64(roughtime.Since(time).Seconds()) / params.BeaconConfig().SecondsPerSlot
+	return CurrentSlot(uint64(time.Unix()))
 }
 
 // CurrentSlot returns the current slot as determined by the local clock and
@@ -146,6 +148,19 @@ func CurrentSlot(genesisTimeSec uint64) uint64 {
 		return 0
 	}
 	return uint64(now-genesis) / params.BeaconConfig().SecondsPerSlot
+}
+
+// ValidateSlotClock validates a provided slot against the local
+// clock to ensure slots that are unreasonable are returned with
+// an error.
+func ValidateSlotClock(slot uint64, genesisTimeSec uint64) error {
+	maxPossibleSlot := CurrentSlot(genesisTimeSec) + MaxSlotBuffer
+	// Defensive check to ensure that we only process slots up to a hard limit
+	// from our local clock.
+	if slot > maxPossibleSlot {
+		return fmt.Errorf("slot %d > %d which exceeds max allowed value relative to the local clock", slot, maxPossibleSlot)
+	}
+	return nil
 }
 
 // GenesisTime prioritizes to return the genesis time in config unless the config

--- a/beacon-chain/core/helpers/slot_epoch_test.go
+++ b/beacon-chain/core/helpers/slot_epoch_test.go
@@ -349,3 +349,12 @@ func TestGenesisTime(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSlotClock_HandlesBadSlot(t *testing.T) {
+	genTime := roughtime.Now().Add(-1 * time.Duration(MaxSlotBuffer) * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second).Unix()
+
+	assert.NoError(t, ValidateSlotClock(MaxSlotBuffer, uint64(genTime)), "unexpected error validating slot")
+	assert.NoError(t, ValidateSlotClock(2*MaxSlotBuffer, uint64(genTime)), "unexpected error validating slot")
+	assert.ErrorContains(t, "which exceeds max allowed value relative to the local clock", ValidateSlotClock(2*MaxSlotBuffer+1, uint64(genTime)), "no error from bad slot")
+	assert.ErrorContains(t, "which exceeds max allowed value relative to the local clock", ValidateSlotClock(1<<63, uint64(genTime)), "no error from bad slot")
+}

--- a/shared/mathutil/math_helper.go
+++ b/shared/mathutil/math_helper.go
@@ -2,7 +2,9 @@
 package mathutil
 
 import (
+	"errors"
 	"math"
+	"math/bits"
 )
 
 // Common square root values.
@@ -89,4 +91,26 @@ func Min(a uint64, b uint64) uint64 {
 		return a
 	}
 	return b
+}
+
+// Mul64 multiples 2 64-bit unsigned integers and checks if they
+// lead to an overflow. If they do not, it returns the result
+// without an error.
+func Mul64(a, b uint64) (uint64, error) {
+	overflows, val := bits.Mul64(a, b)
+	if overflows > 0 {
+		return 0, errors.New("multiplication overflows")
+	}
+	return val, nil
+}
+
+// Add64 adds 2 64-bit unsigned integers and checks if they
+// lead to an overflow. If they do not, it returns the result
+// without an error.
+func Add64(a, b uint64) (uint64, error) {
+	res, carry := bits.Add64(a, b, 0 /* carry */)
+	if carry > 0 {
+		return 0, errors.New("addition overflows")
+	}
+	return res, nil
 }

--- a/shared/mathutil/math_helper_test.go
+++ b/shared/mathutil/math_helper_test.go
@@ -1,6 +1,7 @@
 package mathutil_test
 
 import (
+	"math"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/mathutil"
@@ -277,5 +278,69 @@ func TestMinValue(t *testing.T) {
 	}
 	for _, tt := range tests {
 		require.Equal(t, tt.result, mathutil.Min(tt.a, tt.b))
+	}
+}
+
+func TestMul64(t *testing.T) {
+	type args struct {
+		a uint64
+		b uint64
+	}
+	tests := []struct {
+		args args
+		res  uint64
+		err  bool
+	}{
+		{args: args{0, 1}, res: 0, err: false},
+		{args: args{1 << 32, 1}, res: 1 << 32, err: false},
+		{args: args{1 << 32, 100}, res: 429496729600, err: false},
+		{args: args{1 << 32, 1 << 31}, res: 9223372036854775808, err: false},
+		{args: args{1 << 32, 1 << 32}, res: 0, err: true},
+		{args: args{1 << 62, 2}, res: 9223372036854775808, err: false},
+		{args: args{1 << 62, 4}, res: 0, err: true},
+		{args: args{1 << 63, 1}, res: 9223372036854775808, err: false},
+		{args: args{1 << 63, 2}, res: 0, err: true},
+	}
+	for _, tt := range tests {
+		got, err := mathutil.Mul64(tt.args.a, tt.args.b)
+		if tt.err && err == nil {
+			t.Errorf("Mul64() Expected Error = %v, want error", tt.err)
+			continue
+		}
+		if tt.res != got {
+			t.Errorf("Mul64() %v, want %v", got, tt.res)
+		}
+	}
+}
+
+func TestAdd64(t *testing.T) {
+	type args struct {
+		a uint64
+		b uint64
+	}
+	tests := []struct {
+		args args
+		res  uint64
+		err  bool
+	}{
+		{args: args{0, 1}, res: 1, err: false},
+		{args: args{1 << 32, 1}, res: 4294967297, err: false},
+		{args: args{1 << 32, 100}, res: 4294967396, err: false},
+		{args: args{1 << 31, 1 << 31}, res: 4294967296, err: false},
+		{args: args{1 << 63, 1 << 63}, res: 0, err: true},
+		{args: args{1 << 63, 1}, res: 9223372036854775809, err: false},
+		{args: args{math.MaxUint64, 1}, res: 0, err: true},
+		{args: args{math.MaxUint64, 0}, res: math.MaxUint64, err: false},
+		{args: args{1 << 63, 2}, res: 9223372036854775810, err: false},
+	}
+	for _, tt := range tests {
+		got, err := mathutil.Add64(tt.args.a, tt.args.b)
+		if tt.err && err == nil {
+			t.Errorf("Add64() Expected Error = %v, want error", tt.err)
+			continue
+		}
+		if tt.res != got {
+			t.Errorf("Add64() %v, want %v", got, tt.res)
+		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Rewrites slot time helper to utilize our math multiplication/addition functions which confer overflow
protection
- [x] Add tests for these new math helpers.
- [x] Add a new helper to validate a slot relative to the local clock time to cast off ridiculous slot numbers.

**Which issues(s) does this PR fix?**


**Other notes for review**
