### PR TITLE
Check initial sync block is descendent of current finalized block

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -46,11 +46,6 @@ func (s *Service) getBlockPreState(ctx context.Context, b *ethpb.BeaconBlock) (*
 		return nil, err
 	}
 
-	// Verify block is a descendent of a finalized block.
-	if err := s.VerifyBlkDescendant(ctx, bytesutil.ToBytes32(b.ParentRoot)); err != nil {
-		return nil, err
-	}
-
 	// Verify block is later than the finalized epoch slot.
 	if err := s.verifyBlkFinalizedSlot(b); err != nil {
 		return nil, err
@@ -71,6 +66,11 @@ func (s *Service) verifyBlkPreState(ctx context.Context, b *ethpb.BeaconBlock) e
 	if !s.stateGen.StateSummaryExists(ctx, parentRoot) && !s.beaconDB.HasBlock(ctx, parentRoot) {
 		return errors.New("could not reconstruct parent state")
 	}
+
+	if err := s.VerifyBlkDescendant(ctx, bytesutil.ToBytes32(b.ParentRoot)); err != nil {
+		return err
+	}
+
 	has, err := s.stateGen.HasState(ctx, parentRoot)
 	if err != nil {
 		return err

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -75,12 +75,12 @@ func TestStore_OnBlock(t *testing.T) {
 			name: "block is from the future",
 			blk: func() *ethpb.SignedBeaconBlock {
 				b := testutil.NewBeaconBlock()
-				b.Block.ParentRoot = randomParentRoot[:]
+				b.Block.ParentRoot = randomParentRoot2
 				b.Block.Slot = params.BeaconConfig().FarFutureEpoch
 				return b
 			}(),
 			s:             st.Copy(),
-			wantErrString: "far distant future",
+			wantErrString: "is in the far distant future",
 		},
 		{
 			name: "could not get finalized block",
@@ -135,6 +135,13 @@ func TestStore_OnBlockBatch(t *testing.T) {
 	genesisStateRoot := [32]byte{}
 	genesis := blocks.NewGenesisBlock(genesisStateRoot[:])
 	assert.NoError(t, db.SaveBlock(ctx, genesis))
+	gRoot, err := genesis.Block.HashTreeRoot()
+	require.NoError(t, err)
+	service.finalizedCheckpt = &ethpb.Checkpoint{
+		Root: gRoot[:],
+	}
+	service.forkChoiceStore = protoarray.New(0, 0, [32]byte{})
+	service.saveInitSyncBlock(gRoot, genesis)
 
 	st, keys := testutil.DeterministicGenesisState(t, 64)
 
@@ -153,9 +160,12 @@ func TestStore_OnBlockBatch(t *testing.T) {
 		}
 		root, err := b.Block.HashTreeRoot()
 		require.NoError(t, err)
+		service.saveInitSyncBlock(root, b)
 		blks = append(blks, b)
 		blkRoots = append(blkRoots, root)
 	}
+
+	blks[0].Block.ParentRoot = gRoot[:]
 	require.NoError(t, db.SaveBlock(context.Background(), blks[0]))
 	require.NoError(t, service.stateGen.SaveState(ctx, blkRoots[0], firstState))
 	_, _, err = service.onBlockBatch(ctx, blks[1:], blkRoots[1:])
@@ -226,7 +236,6 @@ func TestShouldUpdateJustified_ReturnFalse(t *testing.T) {
 }
 
 func TestCachedPreState_CanGetFromStateSummary(t *testing.T) {
-
 	ctx := context.Background()
 	db, sc := testDB.SetupDB(t)
 
@@ -239,17 +248,27 @@ func TestCachedPreState_CanGetFromStateSummary(t *testing.T) {
 
 	s, err := stateTrie.InitializeFromProto(&pb.BeaconState{Slot: 1, GenesisValidatorsRoot: params.BeaconConfig().ZeroHash[:]})
 	require.NoError(t, err)
-	r := [32]byte{'A'}
+
+	genesisStateRoot := [32]byte{}
+	genesis := blocks.NewGenesisBlock(genesisStateRoot[:])
+	assert.NoError(t, db.SaveBlock(ctx, genesis))
+	gRoot, err := genesis.Block.HashTreeRoot()
+	require.NoError(t, err)
+	service.finalizedCheckpt = &ethpb.Checkpoint{
+		Root: gRoot[:],
+	}
+	service.forkChoiceStore = protoarray.New(0, 0, [32]byte{})
+	service.saveInitSyncBlock(gRoot, genesis)
+
 	b := testutil.NewBeaconBlock()
 	b.Block.Slot = 1
-	b.Block.ParentRoot = r[:]
-	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{Slot: 1, Root: r[:]}))
-	require.NoError(t, service.stateGen.SaveState(ctx, r, s))
+	b.Block.ParentRoot = gRoot[:]
+	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{Slot: 1, Root: gRoot[:]}))
+	require.NoError(t, service.stateGen.SaveState(ctx, gRoot, s))
 	require.NoError(t, service.verifyBlkPreState(ctx, b.Block))
 }
 
 func TestCachedPreState_CanGetFromDB(t *testing.T) {
-
 	ctx := context.Background()
 	db, sc := testDB.SetupDB(t)
 
@@ -260,20 +279,29 @@ func TestCachedPreState_CanGetFromDB(t *testing.T) {
 	service, err := NewService(ctx, cfg)
 	require.NoError(t, err)
 
-	r := [32]byte{'A'}
+	genesisStateRoot := [32]byte{}
+	genesis := blocks.NewGenesisBlock(genesisStateRoot[:])
+	assert.NoError(t, db.SaveBlock(ctx, genesis))
+	gRoot, err := genesis.Block.HashTreeRoot()
+	require.NoError(t, err)
+	service.finalizedCheckpt = &ethpb.Checkpoint{
+		Root: gRoot[:],
+	}
+	service.forkChoiceStore = protoarray.New(0, 0, [32]byte{})
+	service.saveInitSyncBlock(gRoot, genesis)
+
 	b := testutil.NewBeaconBlock()
 	b.Block.Slot = 1
-	b.Block.ParentRoot = r[:]
-
-	service.finalizedCheckpt = &ethpb.Checkpoint{Root: r[:]}
+	service.finalizedCheckpt = &ethpb.Checkpoint{Root: gRoot[:]}
 	err = service.verifyBlkPreState(ctx, b.Block)
 	wanted := "could not reconstruct parent state"
 	assert.ErrorContains(t, wanted, err)
 
+	b.Block.ParentRoot = gRoot[:]
 	s, err := stateTrie.InitializeFromProto(&pb.BeaconState{Slot: 1})
 	require.NoError(t, err)
-	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{Slot: 1, Root: r[:]}))
-	require.NoError(t, service.stateGen.SaveState(ctx, r, s))
+	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{Slot: 1, Root: gRoot[:]}))
+	require.NoError(t, service.stateGen.SaveState(ctx, gRoot, s))
 	require.NoError(t, service.verifyBlkPreState(ctx, b.Block))
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Bug fix


**What does this PR do? Why is it needed?**
Initial sync code path was subjected to an attack where block could link to parent that's far back in the history. The reason was we did not verify block descendent in `verifyBlkPreState`. This PR moved it from `getBlockPreState` (not initial sync code path) to `verifyBlkPreState` (both initial sync and regular sync code path). 

**Other notes for review**
Tested run time with validator. And tested run time syncing from genesis