### PR TITLE
Asserts response invariants in beaconBlocksByRange

### DIFF
--- a/beacon-chain/sync/initial-sync/initial_sync_test.go
+++ b/beacon-chain/sync/initial-sync/initial_sync_test.go
@@ -172,7 +172,7 @@ func connectPeer(t *testing.T, host *p2pt.TestP2P, datum *peerData, peerStatus *
 		req := &p2ppb.BeaconBlocksByRangeRequest{}
 		assert.NoError(t, p.Encoding().DecodeWithMaxLength(stream, req))
 
-		requestedBlocks := makeSequence(req.StartSlot, req.StartSlot+(req.Count*req.Step))
+		requestedBlocks := makeSequence(req.StartSlot, req.StartSlot+((req.Count-1)*req.Step))
 
 		// Expected failure range
 		if len(sliceutil.IntersectionUint64(datum.failureSlots, requestedBlocks)) > 0 {


### PR DESCRIPTION
**What type of PR is this?**

> Other/Fix Mock

**What does this PR do? Why is it needed?**
- When implementing more strict validation/control on blocks returned from `init-sync` queue, I've discovered some failing tests. Those failures where because of a more strict assertions:
  - returned block slots from `BeaconBlocksByRange()` MUST be within `[start, start+count*step)` range
  - number of returned blocks, MUST be less or equal to `count`
- I've written a regression test `TestRPCBeaconBlocksByRange_EnforceResponseInvariants()` which proved that our `beaconBlocksByRangeRPCHandler` works correctly and honours invariants. After a bit of digging, the problem was discovered to be with our mock code i.e. on production invariants are honoured, but in our tests we are off by one.
- This PR fixes mock, and retains that regression test.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
