### PR TITLE
Ensure `aggregateAndProofSig` returns when err'ing

### DIFF
--- a/validator/client/aggregate.go
+++ b/validator/client/aggregate.go
@@ -78,6 +78,7 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot uint64, pu
 	sig, err := v.aggregateAndProofSig(ctx, pubKey, res.AggregateAndProof)
 	if err != nil {
 		log.Errorf("Could not sign aggregate and proof: %v", err)
+		return
 	}
 	_, err = v.validatorClient.SubmitSignedAggregateSelectionProof(ctx, &ethpb.SignedAggregateSubmitRequest{
 		SignedAggregateAndProof: &ethpb.SignedAggregateAttestationAndProof{

--- a/validator/client/aggregate_test.go
+++ b/validator/client/aggregate_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -25,6 +26,49 @@ func TestSubmitAggregateAndProof_GetDutiesRequestFailure(t *testing.T) {
 	validator.SubmitAggregateAndProof(context.Background(), 0, validatorPubKey)
 
 	require.LogsContain(t, hook, "Could not fetch validator assignment")
+}
+
+func TestSubmitAggregateAndProof_SignFails(t *testing.T) {
+	validator, m, finish := setup(t)
+	defer finish()
+	validator.duties = &ethpb.DutiesResponse{
+		Duties: []*ethpb.DutiesResponse_Duty{
+			{
+				PublicKey: validatorKey.PublicKey.Marshal(),
+			},
+		},
+	}
+
+	m.validatorClient.EXPECT().DomainData(
+		gomock.Any(), // ctx
+		gomock.Any(), // epoch
+	).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+
+	m.validatorClient.EXPECT().SubmitAggregateSelectionProof(
+		gomock.Any(), // ctx
+		gomock.AssignableToTypeOf(&ethpb.AggregateSelectionRequest{}),
+	).Return(&ethpb.AggregateSelectionResponse{
+		AggregateAndProof: &ethpb.AggregateAttestationAndProof{
+			AggregatorIndex: 0,
+			Aggregate: &ethpb.Attestation{
+				Data: &ethpb.AttestationData{
+					BeaconBlockRoot: make([]byte, 32),
+					Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+					Source:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+				},
+				Signature:       make([]byte, 96),
+				AggregationBits: make([]byte, 1),
+			},
+			SelectionProof: make([]byte, 96),
+		},
+	}, nil)
+
+	m.validatorClient.EXPECT().DomainData(
+		gomock.Any(), // ctx
+		gomock.Any(), // epoch
+	).Return(&ethpb.DomainResponse{SignatureDomain: nil}, errors.New("bad domain root"))
+
+	validator.SubmitAggregateAndProof(context.Background(), 0, validatorPubKey)
 }
 
 func TestSubmitAggregateAndProof_Ok(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix


**What does this PR do? Why is it needed?**
`aggregateAndProofSig ` did not return upon errors. This PR added the return for that

**Which issues(s) does this PR fix?**

Fixes # N/A

**Other notes for review**
