### PR TITLE
Prevent zero hashes signatures in `SubmitSignedAggregateSelectionProof`

### DIFF
--- a/beacon-chain/rpc/validator/aggregator.go
+++ b/beacon-chain/rpc/validator/aggregator.go
@@ -1,6 +1,7 @@
 package validator
 
 import (
+	"bytes"
 	"context"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -111,6 +112,11 @@ func (as *Server) SubmitSignedAggregateSelectionProof(ctx context.Context, req *
 	if req.SignedAggregateAndProof == nil || req.SignedAggregateAndProof.Message == nil ||
 		req.SignedAggregateAndProof.Message.Aggregate == nil || req.SignedAggregateAndProof.Message.Aggregate.Data == nil {
 		return nil, status.Error(codes.InvalidArgument, "Signed aggregate request can't be nil")
+	}
+	emptySig := make([]byte, params.BeaconConfig().BLSSignatureLength)
+	if bytes.Equal(req.SignedAggregateAndProof.Signature, emptySig) ||
+		bytes.Equal(req.SignedAggregateAndProof.Message.SelectionProof, emptySig) {
+		return nil, status.Error(codes.InvalidArgument, "Signed signatures can't be zero hashes")
 	}
 
 	if err := as.P2P.Broadcast(ctx, req.SignedAggregateAndProof); err != nil {

--- a/beacon-chain/rpc/validator/aggregator_test.go
+++ b/beacon-chain/rpc/validator/aggregator_test.go
@@ -399,3 +399,33 @@ func TestSubmitAggregateAndProof_SelectsMostBitsWhenOwnAttestationNotPresent(t *
 	require.NoError(t, err)
 	assert.DeepEqual(t, att1, res.AggregateAndProof.Aggregate, "Did not receive wanted attestation")
 }
+
+func TestSubmitSignedAggregateSelectionProof_ZeroHashesSignatures(t *testing.T) {
+	aggregatorServer := &Server{}
+	req := &ethpb.SignedAggregateSubmitRequest{
+		SignedAggregateAndProof: &ethpb.SignedAggregateAttestationAndProof{
+			Signature: make([]byte, params.BeaconConfig().BLSSignatureLength),
+			Message: &ethpb.AggregateAttestationAndProof{
+				Aggregate: &ethpb.Attestation{
+					Data: &ethpb.AttestationData{},
+				},
+			},
+		},
+	}
+	_, err := aggregatorServer.SubmitSignedAggregateSelectionProof(context.Background(), req)
+	require.ErrorContains(t, "Signed signatures can't be zero hashes", err)
+
+	req = &ethpb.SignedAggregateSubmitRequest{
+		SignedAggregateAndProof: &ethpb.SignedAggregateAttestationAndProof{
+			Signature: []byte{'a'},
+			Message: &ethpb.AggregateAttestationAndProof{
+				Aggregate: &ethpb.Attestation{
+					Data: &ethpb.AttestationData{},
+				},
+				SelectionProof: make([]byte, params.BeaconConfig().BLSSignatureLength),
+			},
+		},
+	}
+	_, err = aggregatorServer.SubmitSignedAggregateSelectionProof(context.Background(), req)
+	require.ErrorContains(t, "Signed signatures can't be zero hashes", err)
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

`SubmitSignedAggregateSelectionProof` in aggregator RPC server should block attestations with zero hashes signatures