### PR TITLE
Improves asyncutils/Debounce

### DIFF
--- a/shared/asyncutil/BUILD.bazel
+++ b/shared/asyncutil/BUILD.bazel
@@ -12,4 +12,8 @@ go_test(
     name = "go_default_test",
     srcs = ["debounce_test.go"],
     embed = [":go_default_library"],
+    deps = [
+        "//shared/testutil/assert:go_default_library",
+        "//shared/testutil/require:go_default_library",
+    ],
 )

--- a/shared/asyncutil/BUILD.bazel
+++ b/shared/asyncutil/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
     srcs = ["debounce_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//shared/testutil:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
     ],

--- a/shared/asyncutil/debounce.go
+++ b/shared/asyncutil/debounce.go
@@ -8,22 +8,38 @@ import (
 // Debounce events fired over a channel by a specified duration, ensuring no events
 // are handled until a certain interval of time has passed.
 func Debounce(ctx context.Context, interval time.Duration, eventsChan <-chan interface{}, handler func(interface{})) {
-	for event := range eventsChan {
-	loop:
-		for {
-			// If an event is received, wait the specified interval before calling the
-			// handler.
-			// If another event is received before the interval has passed, store
-			// it and reset the timer.
-			select {
-			// Do nothing until we can handle the events after the debounce interval.
-			case event = <-eventsChan:
-			case <-time.After(interval):
-				handler(event)
-				break loop
-			case <-ctx.Done():
-				return
+	var timer *time.Timer
+	defer func() {
+		if timer != nil {
+			timer.Stop()
+		}
+	}()
+	for {
+		select {
+		// Wait until an event is triggered.
+		case event := <-eventsChan:
+			timer = time.NewTimer(interval)
+		loop:
+			for {
+				// If an event is received, wait the specified interval before calling the handler.
+				// If another event is received before the interval has passed, store
+				// it and reset the timer.
+				select {
+				case event = <-eventsChan:
+					// Reset timer.
+					timer.Stop()
+					timer = time.NewTimer(interval)
+				case <-timer.C:
+					// Stop the current timer, handle the request, and wait for more events.
+					timer.Stop()
+					handler(event)
+					break loop
+				case <-ctx.Done():
+					return
+				}
 			}
+		case <-ctx.Done():
+			return
 		}
 	}
 }

--- a/shared/asyncutil/debounce_test.go
+++ b/shared/asyncutil/debounce_test.go
@@ -4,9 +4,66 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
-func TestDebounce(t *testing.T) {
+func TestDebounce_NoEvents(t *testing.T) {
+	eventsChan := make(chan interface{}, 100)
+	ctx, cancel := context.WithCancel(context.Background())
+	interval := time.Second
+	timesHandled := 0
+	go func() {
+		time.AfterFunc(interval*2, func() {
+			t.Fatalf("Test should have exited by now, timed out")
+		})
+	}()
+	go func() {
+		time.AfterFunc(interval, func() {
+			cancel()
+		})
+	}()
+	Debounce(ctx, interval, eventsChan, func(event interface{}) {
+		timesHandled++
+	})
+	assert.Equal(t, 0, timesHandled, "Wrong number of handled calls")
+}
+
+func TestDebounce_CtxClosing(t *testing.T) {
+	eventsChan := make(chan interface{}, 100)
+	ctx, cancel := context.WithCancel(context.Background())
+	interval := time.Second
+	timesHandled := 0
+	go func() {
+		ticker := time.NewTicker(time.Millisecond * 100)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				eventsChan <- struct{}{}
+			}
+		}
+	}()
+	go func() {
+		time.AfterFunc(interval*2, func() {
+			t.Fatalf("Test should have exited by now, timed out")
+		})
+	}()
+	go func() {
+		time.AfterFunc(interval, func() {
+			cancel()
+		})
+	}()
+	Debounce(ctx, interval, eventsChan, func(event interface{}) {
+		timesHandled++
+	})
+	assert.Equal(t, 0, timesHandled, "Wrong number of handled calls")
+}
+
+func TestDebounce_SingleHandlerInvocation(t *testing.T) {
 	eventsChan := make(chan interface{}, 100)
 	ctx, cancel := context.WithCancel(context.Background())
 	interval := time.Second
@@ -17,11 +74,34 @@ func TestDebounce(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		eventsChan <- struct{}{}
 	}
-	time.Sleep(interval)
-	cancel()
 	// We should expect 100 rapid fire changes to only have caused
 	// 1 handler to trigger after the debouncing period.
-	if timesHandled != 1 {
-		t.Errorf("Expected 1 handler call, received %d", timesHandled)
+	time.Sleep(interval * 2)
+	assert.Equal(t, 1, timesHandled, "Wrong number of handled calls")
+	cancel()
+}
+
+func TestDebounce_MultipleHandlerInvocation(t *testing.T) {
+	eventsChan := make(chan interface{}, 100)
+	ctx, cancel := context.WithCancel(context.Background())
+	interval := time.Second
+	timesHandled := 0
+	go Debounce(ctx, interval, eventsChan, func(event interface{}) {
+		timesHandled++
+	})
+	for i := 0; i < 100; i++ {
+		eventsChan <- struct{}{}
 	}
+	require.Equal(t, 0, timesHandled, "Events must prevent from handler execution")
+
+	// By this time the first event should be triggered.
+	time.Sleep(2 * time.Second)
+	assert.Equal(t, 1, timesHandled, "Wrong number of handled calls")
+
+	// Second event.
+	eventsChan <- struct{}{}
+	time.Sleep(2 * time.Second)
+	assert.Equal(t, 2, timesHandled, "Wrong number of handled calls")
+
+	cancel()
 }


### PR DESCRIPTION
**What type of PR is this?**

Other/Refactoring/Minor fixing

**What does this PR do? Why is it needed?**
- [x] Better implementation of context cancelling: context cancelling channel was listened only in inner loop, making it impossible to get out of the function if no incoming events are sent (in this PR: we can create debouncer, never send any event to it, and on context cancellation -- debouncer stops and returns).
- [x] `time.After` aggregated timer channels, and depending on the rate of incoming events it might be a problem (too many resources to garbage collect). I've changed routine to use explicit `time.Timer.C` instead -- so at the moment only a single timer channel is open at a time. And when we need to reset (on every incoming event), previous timer is stopped, and new timer is created (which is exactly what happened when we used `time.After()` with additional benefit of stopping the previous timer before creating a new one).
- [x] Fixes race condition in test: if you run tests many times over, eventually you will step into failed test (when timer is almost triggered, but not fast enough and test assertions already is testing the result).
- [x] Tests all the scenarios fully (no events, cancelling using inner loop, cancelling using outer loop, single handler invocation, multiple invocations -- to make sure that debouncer's outer loop works correctly).

**Which issues(s) does this PR fix?**


**Other notes for review**
- cc @rauljordan 