### PR TITLE
Revert "Pipelines for `ProcessBlockNoVerifyAttSigs` and `ProcessBlockStateRoot`"

### DIFF
--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -114,13 +114,13 @@ func TestFuzzEth1DataHasEnoughSupport_10000(t *testing.T) {
 func TestFuzzProcessBlockHeaderNoVerify_10000(t *testing.T) {
 	fuzzer := fuzz.NewWithSeed(0)
 	state := &ethereum_beacon_p2p_v1.BeaconState{}
-	block := &eth.SignedBeaconBlock{}
+	block := &eth.BeaconBlock{}
 
 	for i := 0; i < 10000; i++ {
 		fuzzer.Fuzz(state)
 		fuzzer.Fuzz(block)
 		s, err := beaconstate.InitializeFromProtoUnsafe(state)
-		_, err = ProcessBlockHeaderNoVerify(context.Background(), s, block)
+		_, err = ProcessBlockHeaderNoVerify(s, block)
 		_ = err
 	}
 }
@@ -144,15 +144,15 @@ func TestFuzzProcessRandao_10000(t *testing.T) {
 func TestFuzzProcessRandaoNoVerify_10000(t *testing.T) {
 	fuzzer := fuzz.NewWithSeed(0)
 	state := &ethereum_beacon_p2p_v1.BeaconState{}
-	sb := &eth.SignedBeaconBlock{}
+	blockBody := &eth.BeaconBlockBody{}
 
 	for i := 0; i < 10000; i++ {
 		fuzzer.Fuzz(state)
-		fuzzer.Fuzz(sb)
+		fuzzer.Fuzz(blockBody)
 		s, err := beaconstate.InitializeFromProtoUnsafe(state)
-		r, err := ProcessRandaoNoVerify(context.Background(), s, sb)
+		r, err := ProcessRandaoNoVerify(s, blockBody)
 		if err != nil && r != nil {
-			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, sb)
+			t.Fatalf("return value should be nil on err. found: %v on error: %v for state: %v and block: %v", r, err, state, blockBody)
 		}
 	}
 }

--- a/beacon-chain/core/blocks/header.go
+++ b/beacon-chain/core/blocks/header.go
@@ -41,7 +41,7 @@ func ProcessBlockHeader(
 	beaconState *stateTrie.BeaconState,
 	block *ethpb.SignedBeaconBlock,
 ) (*stateTrie.BeaconState, error) {
-	beaconState, err := ProcessBlockHeaderNoVerify(ctx, beaconState, block)
+	beaconState, err := ProcessBlockHeaderNoVerify(beaconState, block.Block)
 	if err != nil {
 		return nil, err
 	}
@@ -80,15 +80,12 @@ func ProcessBlockHeader(
 //    proposer = state.validators[get_beacon_proposer_index(state)]
 //    assert not proposer.slashed
 func ProcessBlockHeaderNoVerify(
-	ctx context.Context,
 	beaconState *stateTrie.BeaconState,
-	signedBlock *ethpb.SignedBeaconBlock,
+	block *ethpb.BeaconBlock,
 ) (*stateTrie.BeaconState, error) {
-	if signedBlock == nil || signedBlock.Block == nil {
+	if block == nil {
 		return nil, errors.New("nil block")
 	}
-	block := signedBlock.Block
-
 	if beaconState.Slot() != block.Slot {
 		return nil, fmt.Errorf("state slot: %d is different than block slot: %d", beaconState.Slot(), block.Slot)
 	}

--- a/beacon-chain/core/blocks/randao.go
+++ b/beacon-chain/core/blocks/randao.go
@@ -43,7 +43,7 @@ func ProcessRandao(
 		return nil, errors.Wrap(err, "could not verify block randao")
 	}
 
-	beaconState, err = ProcessRandaoNoVerify(ctx, beaconState, b)
+	beaconState, err = ProcessRandaoNoVerify(beaconState, body)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process randao")
 	}
@@ -60,15 +60,9 @@ func ProcessRandao(
 //             hash(body.randao_reveal))
 //     )
 func ProcessRandaoNoVerify(
-	ctx context.Context,
 	beaconState *stateTrie.BeaconState,
-	b *ethpb.SignedBeaconBlock,
+	body *ethpb.BeaconBlockBody,
 ) (*stateTrie.BeaconState, error) {
-	if b.Block == nil || b.Block.Body == nil {
-		return nil, errors.New("block and block body can't be nil")
-	}
-	body := b.Block.Body
-
 	currentEpoch := helpers.SlotToEpoch(beaconState.Slot())
 	// If block randao passed verification, we XOR the state's latest randao mix with the block's
 	// randao and update the state's corresponding latest randao mix value.

--- a/beacon-chain/core/blocks/spectest/block_header_test.go
+++ b/beacon-chain/core/blocks/spectest/block_header_test.go
@@ -1,7 +1,6 @@
 package spectest
 
 import (
-	"context"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -47,7 +46,7 @@ func runBlockHeaderTest(t *testing.T, config string) {
 			}
 
 			// Spectest blocks are not signed, so we'll call NoVerify to skip sig verification.
-			beaconState, err := blocks.ProcessBlockHeaderNoVerify(context.Background(), preBeaconState, &ethpb.SignedBeaconBlock{Block: block})
+			beaconState, err := blocks.ProcessBlockHeaderNoVerify(preBeaconState, block)
 			if postSSZExists {
 				require.NoError(t, err)
 

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -42,34 +42,6 @@ var processingPipeline = []processFunc{
 	b.ProcessVoluntaryExits,
 }
 
-// This defines the processing block routine with the exception of not verifying any attestation signatures.
-// This is used during initial syncing with the flag `--disable-initial-sync-verify-all-signatures`
-var processingPipelineNoVerifyAttSigs = []processFunc{
-	b.ProcessBlockHeader,
-	b.ProcessRandao,
-	b.ProcessEth1DataInBlock,
-	VerifyOperationLengths,
-	b.ProcessProposerSlashings,
-	b.ProcessAttesterSlashings,
-	b.ProcessAttestationsNoVerifySignature,
-	b.ProcessDeposits,
-	b.ProcessVoluntaryExits,
-}
-
-// This defines the processing block routine for compute state root.
-// This is used to serve proposer for constructing a beacon block to fill in state root field.
-var processingPipelineStateRoot = []processFunc{
-	b.ProcessBlockHeaderNoVerify,
-	b.ProcessRandaoNoVerify,
-	b.ProcessEth1DataInBlock,
-	VerifyOperationLengths,
-	b.ProcessProposerSlashings,
-	b.ProcessAttesterSlashings,
-	b.ProcessAttestationsNoVerifySignature,
-	b.ProcessDeposits,
-	b.ProcessVoluntaryExits,
-}
-
 // ExecuteStateTransition defines the procedure for a state transition function.
 //
 // Spec pseudocode definition:
@@ -475,33 +447,28 @@ func ProcessBlockNoVerifyAttSigs(
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock")
 	defer span.End()
 
-	var err error
-	for _, p := range processingPipelineNoVerifyAttSigs {
-		state, err = p(ctx, state, signed)
-		if err != nil {
-			return nil, errors.Wrap(err, "Could not process block")
-		}
+	state, err := b.ProcessBlockHeader(ctx, state, signed)
+	if err != nil {
+		traceutil.AnnotateError(span, err)
+		return nil, errors.Wrap(err, "could not process block header")
 	}
 
-	return state, nil
-}
+	state, err = b.ProcessRandao(ctx, state, signed)
+	if err != nil {
+		traceutil.AnnotateError(span, err)
+		return nil, errors.Wrap(err, "could not verify and process randao")
+	}
 
-// ProcessBlockForStateRoot processes the state for state root computation. It skips proposer signature
-// and randao signature verifications.
-func ProcessBlockForStateRoot(
-	ctx context.Context,
-	state *stateTrie.BeaconState,
-	signed *ethpb.SignedBeaconBlock,
-) (*stateTrie.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock")
-	defer span.End()
+	state, err = b.ProcessEth1DataInBlock(ctx, state, signed)
+	if err != nil {
+		traceutil.AnnotateError(span, err)
+		return nil, errors.Wrap(err, "could not process eth1 data")
+	}
 
-	var err error
-	for _, p := range processingPipelineStateRoot {
-		state, err = p(ctx, state, signed)
-		if err != nil {
-			return nil, errors.Wrap(err, "Could not process block")
-		}
+	state, err = ProcessOperationsNoVerifyAttsSigs(ctx, state, signed)
+	if err != nil {
+		traceutil.AnnotateError(span, err)
+		return nil, errors.Wrap(err, "could not process block operation")
 	}
 
 	return state, nil
@@ -527,7 +494,7 @@ func ProcessBlockNoVerifyAnySig(
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock")
 	defer span.End()
 
-	state, err := b.ProcessBlockHeaderNoVerify(ctx, state, signed)
+	state, err := b.ProcessBlockHeaderNoVerify(state, signed.Block)
 	if err != nil {
 		traceutil.AnnotateError(span, err)
 		return nil, nil, errors.Wrap(err, "could not process block header")
@@ -542,7 +509,7 @@ func ProcessBlockNoVerifyAnySig(
 		traceutil.AnnotateError(span, err)
 		return nil, nil, errors.Wrap(err, "could not retrieve randao signature set")
 	}
-	state, err = b.ProcessRandaoNoVerify(ctx, state, signed)
+	state, err = b.ProcessRandaoNoVerify(state, signed.Block.Body)
 	if err != nil {
 		traceutil.AnnotateError(span, err)
 		return nil, nil, errors.Wrap(err, "could not verify and process randao")
@@ -738,5 +705,42 @@ func ProcessEpochPrecompute(ctx context.Context, state *stateTrie.BeaconState) (
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process final updates")
 	}
+	return state, nil
+}
+
+// ProcessBlockForStateRoot processes the state for state root computation. It skips proposer signature
+// and randao signature verifications.
+func ProcessBlockForStateRoot(
+	ctx context.Context,
+	state *stateTrie.BeaconState,
+	signed *ethpb.SignedBeaconBlock,
+) (*stateTrie.BeaconState, error) {
+	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlock")
+	defer span.End()
+
+	state, err := b.ProcessBlockHeaderNoVerify(state, signed.Block)
+	if err != nil {
+		traceutil.AnnotateError(span, err)
+		return nil, errors.Wrap(err, "could not process block header")
+	}
+
+	state, err = b.ProcessRandaoNoVerify(state, signed.Block.Body)
+	if err != nil {
+		traceutil.AnnotateError(span, err)
+		return nil, errors.Wrap(err, "could not verify and process randao")
+	}
+
+	state, err = b.ProcessEth1DataInBlock(ctx, state, signed)
+	if err != nil {
+		traceutil.AnnotateError(span, err)
+		return nil, errors.Wrap(err, "could not process eth1 data")
+	}
+
+	state, err = ProcessOperationsNoVerifyAttsSigs(ctx, state, signed)
+	if err != nil {
+		traceutil.AnnotateError(span, err)
+		return nil, errors.Wrap(err, "could not process block operation")
+	}
+
 	return state, nil
 }

--- a/fuzz/block_header_fuzz.go
+++ b/fuzz/block_header_fuzz.go
@@ -1,9 +1,6 @@
 package fuzz
 
 import (
-	"context"
-
-	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	prylabs_testing "github.com/prysmaticlabs/prysm/fuzz/testing"
@@ -25,7 +22,7 @@ func BeaconFuzzBlockHeader(b []byte) ([]byte, bool) {
 	if err != nil {
 		return fail(err)
 	}
-	post, err := blocks.ProcessBlockHeaderNoVerify(context.Background(), st, &ethpb.SignedBeaconBlock{Block: input.Block})
+	post, err := blocks.ProcessBlockHeaderNoVerify(st, input.Block)
 	if err != nil {
 		return fail(err)
 	}


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#7180

Saw in the local running node with latest master, block proposal failed to calculate state root due to incorrect deposit count. I suspect this is the offender. This needs more testing in the run time in especially with block proposals using full deposits. Will revert this for today's release.

cc on call @rauljordan 