### PR TITLE
Disallows bitlist duplicates in seen_bits cache

### DIFF
--- a/beacon-chain/operations/attestations/kv/seen_bits.go
+++ b/beacon-chain/operations/attestations/kv/seen_bits.go
@@ -19,7 +19,16 @@ func (p *AttCaches) insertSeenBit(att *ethpb.Attestation) error {
 		if !ok {
 			return errors.New("could not convert to bitlist type")
 		}
-		seenBits = append(seenBits, att.AggregationBits)
+		alreadyExists := false
+		for _, bit := range seenBits {
+			if bit.Len() == att.AggregationBits.Len() && bit.Contains(att.AggregationBits) {
+				alreadyExists = true
+				break
+			}
+		}
+		if !alreadyExists {
+			seenBits = append(seenBits, att.AggregationBits)
+		}
 		p.seenAtt.Set(string(r[:]), seenBits, cache.DefaultExpiration /* one epoch */)
 		return nil
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
- If you push the very same attestation multiple times, it gets added to "hasSeen" cache multiple times, which is unnecessary.
- If item is already in cache, cache doesn't grow - but expiration time gets updated (so cache will remember the item for a longer period of time)

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- cc @terencechain 
