### PR TITLE
Removes attestation pool pruning from UnaggregatedAttestations getter

### DIFF
--- a/beacon-chain/operations/attestations/pool.go
+++ b/beacon-chain/operations/attestations/pool.go
@@ -25,6 +25,7 @@ type Pool interface {
 	UnaggregatedAttestations() ([]*ethpb.Attestation, error)
 	UnaggregatedAttestationsBySlotIndex(slot uint64, committeeIndex uint64) []*ethpb.Attestation
 	DeleteUnaggregatedAttestation(att *ethpb.Attestation) error
+	DeleteSeenUnaggregatedAttestations() (int, error)
 	UnaggregatedAttestationCount() int
 	// For attestations that were included in the block.
 	SaveBlockAttestation(att *ethpb.Attestation) error

--- a/beacon-chain/operations/attestations/prune_expired.go
+++ b/beacon-chain/operations/attestations/prune_expired.go
@@ -35,6 +35,9 @@ func (s *Service) pruneExpiredAtts() {
 		}
 	}
 
+	if _, err := s.pool.DeleteSeenUnaggregatedAttestations(); err == nil {
+		log.WithError(err).Error("Cannot delete seen attestations")
+	}
 	unAggregatedAtts, err := s.pool.UnaggregatedAttestations()
 	if err != nil {
 		log.WithError(err).Error("Could not get unaggregated attestations")


### PR DESCRIPTION
**What type of PR is this?**

Other/Refactoring

**What does this PR do? Why is it needed?**
- Currently, we remove seen attestations in `UnaggregatedAttestations()` getter:
https://github.com/prysmaticlabs/prysm/blob/c8e93f87893d41ce7335de0c1ae2c786283d516a/beacon-chain/operations/attestations/kv/unaggregated.go#L61-L65
- Conventionally, getters are to obtain data, not modify it -- otherwise it is a bit unintuitive: you request list of unaggregated attestations, and list gets trimmed (seen attestations are removed). If those seen attestations are unnecessary, and to be removed, then there should be a method specifically for that purpose. This PR introduces such a method.
- So, this PR:
  - [x] removes state amending code from `UnaggregatedAttestations()` getter (seen attestations are still **NOT** returned)
  - [x] adds new `DeleteSeenUnaggregatedAttestations()` method
  - [x] invokes newly defined method in `prune_expired.go`, so that seen attestations are removed, even before the check whether a given unaggregated attestation is expired or not is done.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- cc @terencechain 
