### PR TITLE
Correct accounts and validator error messages

### DIFF
--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -162,7 +162,9 @@ func verifyExitConditions(validator *stateTrie.ReadOnlyValidator, currentSlot ui
 	}
 	// Verify the validator has not yet exited.
 	if validator.ExitEpoch() != params.BeaconConfig().FarFutureEpoch {
-		return fmt.Errorf("validator has already exited at epoch: %v", validator.ExitEpoch())
+		return fmt.Errorf(
+			"validator has already submitted an exit, which will take place at epoch: %v",
+			validator.ExitEpoch())
 	}
 	// Exits must specify an epoch when they become valid; they are not valid before then.
 	if currentEpoch < exit.Epoch {

--- a/beacon-chain/core/blocks/exit_test.go
+++ b/beacon-chain/core/blocks/exit_test.go
@@ -114,6 +114,36 @@ func TestProcessVoluntaryExits_NotActiveLongEnoughToExit(t *testing.T) {
 	assert.ErrorContains(t, want, err)
 }
 
+func TestProcessVoluntaryExits_ExitAlreadySubmitted(t *testing.T) {
+	exits := []*ethpb.SignedVoluntaryExit{
+		{
+			Exit: &ethpb.VoluntaryExit{
+				Epoch: 10,
+			},
+		},
+	}
+	registry := []*ethpb.Validator{
+		{
+			ExitEpoch: 10,
+		},
+	}
+	state, err := stateTrie.InitializeFromProto(&pb.BeaconState{
+		Validators: registry,
+		Slot:       0,
+	})
+	require.NoError(t, err)
+	b := testutil.NewBeaconBlock()
+	b.Block = &ethpb.BeaconBlock{
+		Body: &ethpb.BeaconBlockBody{
+			VoluntaryExits: exits,
+		},
+	}
+
+	want := "validator has already submitted an exit, which will take place at epoch: 10"
+	_, err = blocks.ProcessVoluntaryExits(context.Background(), state, b)
+	assert.ErrorContains(t, want, err)
+}
+
 func TestProcessVoluntaryExits_AppliesCorrectStatus(t *testing.T) {
 	exits := []*ethpb.SignedVoluntaryExit{
 		{

--- a/validator/keymanager/v2/direct/direct.go
+++ b/validator/keymanager/v2/direct/direct.go
@@ -471,7 +471,7 @@ func askUntilPasswordConfirms(
 	formattedPublicKey := fmt.Sprintf("%#x", bytesutil.Trunc(publicKey))
 	for {
 		password, err = promptutil.PasswordPrompt(
-			fmt.Sprintf("\nPlease try again, could not use password to import account %s", au.BrightGreen(formattedPublicKey)),
+			fmt.Sprintf("\nPlease try again, incorrect password for account %s", au.BrightGreen(formattedPublicKey)),
 			promptutil.NotEmpty,
 		)
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Corrects two error messages:
 - Accounts' `askUntilPasswordConfirms` function returns an error specific to importing accounts, even though it is used from other commands.
 - One validator exit precondition returns an error stating that an exit has already taken place, when in reality only the exit proposal has been submitted, and the exit itself is yet to happen.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
