### PR TITLE
Check attestation slot before broadcast

### DIFF
--- a/beacon-chain/rpc/validator/aggregator.go
+++ b/beacon-chain/rpc/validator/aggregator.go
@@ -119,6 +119,11 @@ func (as *Server) SubmitSignedAggregateSelectionProof(ctx context.Context, req *
 		return nil, status.Error(codes.InvalidArgument, "Signed signatures can't be zero hashes")
 	}
 
+	// As a preventive measure, a beacon node shouldn't broadcast an attestation whose slot is out of range.
+	if err := helpers.ValidateAttestationTime(req.SignedAggregateAndProof.Message.Aggregate.Data.Slot, as.GenesisTimeFetcher.GenesisTime()); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "Attestation slot is no longer valid from current time")
+	}
+
 	if err := as.P2P.Broadcast(ctx, req.SignedAggregateAndProof); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not broadcast signed aggregated attestation: %v", err)
 	}

--- a/beacon-chain/rpc/validator/aggregator_test.go
+++ b/beacon-chain/rpc/validator/aggregator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-bitfield"
@@ -428,4 +429,22 @@ func TestSubmitSignedAggregateSelectionProof_ZeroHashesSignatures(t *testing.T) 
 	}
 	_, err = aggregatorServer.SubmitSignedAggregateSelectionProof(context.Background(), req)
 	require.ErrorContains(t, "Signed signatures can't be zero hashes", err)
+}
+
+func TestSubmitSignedAggregateSelectionProof_InvalidSlot(t *testing.T) {
+	c := &mock.ChainService{Genesis: time.Now()}
+	aggregatorServer := &Server{GenesisTimeFetcher: c}
+	req := &ethpb.SignedAggregateSubmitRequest{
+		SignedAggregateAndProof: &ethpb.SignedAggregateAttestationAndProof{
+			Signature: []byte{'a'},
+			Message: &ethpb.AggregateAttestationAndProof{
+				SelectionProof: []byte{'a'},
+				Aggregate: &ethpb.Attestation{
+					Data: &ethpb.AttestationData{Slot: 1000},
+				},
+			},
+		},
+	}
+	_, err := aggregatorServer.SubmitSignedAggregateSelectionProof(context.Background(), req)
+	require.ErrorContains(t, "Attestation slot is no longer valid from current time", err)
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**
Check attestation slot time before broadcast. It was reported that Prysm nodes have attestations with invalid slot range that are floating over the wire. Implementing this as a preventive measure.

**Which issues(s) does this PR fix?**

Fixes # N/A

**Other notes for review**
Tested run time


cc: @nisdas if this doesn't fix it, then we know the problem is on the sync side + pending attestation queue

We also can do this for unaggregated attestation but i don't think it's necessary (yet)
