### PR TITLE
Reverse error condition.

### DIFF
--- a/beacon-chain/operations/attestations/prune_expired.go
+++ b/beacon-chain/operations/attestations/prune_expired.go
@@ -35,7 +35,7 @@ func (s *Service) pruneExpiredAtts() {
 		}
 	}
 
-	if _, err := s.pool.DeleteSeenUnaggregatedAttestations(); err == nil {
+	if _, err := s.pool.DeleteSeenUnaggregatedAttestations(); err != nil {
 		log.WithError(err).Error("Cannot delete seen attestations")
 	}
 	unAggregatedAtts, err := s.pool.UnaggregatedAttestations()


### PR DESCRIPTION
A recent commit added an error condition which was inverted, resulting in log output being seen:

```
[2020-09-11 20:18:38] ERROR pool/attestations: Cannot delete seen attestations error=<nil>
[2020-09-11 20:18:50] ERROR pool/attestations: Cannot delete seen attestations error=<nil>
[2020-09-11 20:19:02] ERROR pool/attestations: Cannot delete seen attestations error=<nil>
[2020-09-11 20:19:14] ERROR pool/attestations: Cannot delete seen attestations error=<nil>
```

This fixes the error condition to only report if an error is present.