### PR TITLE
Skip initial roughtime result when `EnableRoughtime` is disabled

### DIFF
--- a/shared/roughtime/roughtime.go
+++ b/shared/roughtime/roughtime.go
@@ -58,7 +58,7 @@ func init() {
 }
 
 func recalibrateRoughtime() {
-	if featureconfig.Get().EnableRoughtime {
+	if !featureconfig.Get().EnableRoughtime {
 		return
 	}
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix


**What does this PR do? Why is it needed?**
Even when `EnableRoughtime` was disabled, it still runs through the following code:
```go
	// Log Debug Results.
	for _, res := range results {
		if res.Error() != nil {
			log.Errorf("Could not get rough time result: %v", res.Error())
			continue
		}
		log.WithFields(logrus.Fields{
			"Server Name": res.Server.Name,
			"Midpoint":    res.Midpoint,
			"Delay":       res.Delay,
			"Radius":      res.Roughtime.Radius,
		}).Debug("Response received from roughtime server")
	}
```

This PR makes it exit earlier when `EnableRoughtime` is false in function `recalibrateRoughtime()`

**Which issues(s) does this PR fix?**

Fixes #7183

**Other notes for review**
