### PR TITLE
Fix out of bound check in `AncestorRoot`

### DIFF
--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -169,9 +169,10 @@ func (f *ForkChoice) AncestorRoot(ctx context.Context, root [32]byte, slot uint6
 		}
 
 		i = f.store.nodes[i].parent
-	}
-	if i >= uint64(len(f.store.nodes)) {
-		return nil, errors.New("node index out of range")
+
+		if i >= uint64(len(f.store.nodes)) {
+			return nil, errors.New("node index out of range")
+		}
 	}
 
 	return f.store.nodes[i].root[:], nil


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix


**What does this PR do? Why is it needed?**
Moved out of bound check within the correct scope in forkchoice pkg's `AncestorRoot`


**Which issues(s) does this PR fix?**

Fixes #7156 

**Other notes for review**
