### PR TITLE
Opt out `--use-check-point-cache`

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -257,9 +257,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Enabling roughtime sync")
 		cfg.EnableRoughtime = true
 	}
-	if ctx.Bool(checkPtInfoCache.Name) {
-		log.Warn("Using advance check point info cache")
-		cfg.UseCheckPointInfoCache = true
+	cfg.UseCheckPointInfoCache = true
+	if ctx.Bool(disableCheckPtInfoCache.Name) {
+		log.Warn("Disabling advanced check point info cache")
+		cfg.UseCheckPointInfoCache = false
 	}
 	Init(cfg)
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -165,15 +165,14 @@ var (
 		Name:  "enable-roughtime",
 		Usage: "Enables periodic roughtime syncs.",
 	}
-	checkPtInfoCache = &cli.BoolFlag{
-		Name:  "use-check-point-cache",
-		Usage: "Enables check point info caching",
+	disableCheckPtInfoCache = &cli.BoolFlag{
+		Name:  "disable-check-point-cache",
+		Usage: "Disables check point info caching",
 	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
-	checkPtInfoCache,
 	batchBlockVerify,
 	enableEth1DataMajorityVote,
 	enableAttBroadcastDiscoveryAttempts,
@@ -550,6 +549,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedCheckptInfoCache = &cli.BoolFlag{
+		Name:   "check-point-info-cache",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -626,6 +630,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedSlasherProviderFlag,
 	deprecatedEnableSlasherFlag,
 	deprecatedEnableFinalizedDepositsCache,
+	deprecatedCheckptInfoCache,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -682,7 +687,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	enableAttBroadcastDiscoveryAttempts,
 	enablePeerScorer,
 	enableRoughtime,
-	checkPtInfoCache,
+	disableCheckPtInfoCache,
 }...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -550,7 +550,7 @@ var (
 		Hidden: true,
 	}
 	deprecatedCheckptInfoCache = &cli.BoolFlag{
-		Name:   "check-point-info-cache",
+		Name:   "use-check-point-cache",
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}


### PR DESCRIPTION
Part of #7239

Make `--use-check-point-cache` a default flag. The opt out flag is `--disable-check-point-cache`. Check point info cache has been running in the while in the experimental cluster and in my local set up for over the month. Seeing both good and stable results