### PR TITLE
Opt out --batch-block-verify

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -237,9 +237,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Disabling new beacon state locks")
 		cfg.NewBeaconStateLocks = false
 	}
-	if ctx.Bool(batchBlockVerify.Name) {
-		log.Warn("Performing batch block verification when syncing.")
-		cfg.BatchBlockVerify = true
+	cfg.BatchBlockVerify = true
+	if ctx.Bool(disableBatchBlockVerify.Name) {
+		log.Warn("Disabling batch block verification when syncing.")
+		cfg.BatchBlockVerify = false
 	}
 	if ctx.Bool(initSyncVerbose.Name) {
 		log.Warn("Logging every processed block during initial syncing.")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -137,9 +137,9 @@ var (
 		Name:  "disable-new-beacon-state-locks",
 		Usage: "Disable new beacon state locking",
 	}
-	batchBlockVerify = &cli.BoolFlag{
-		Name:  "batch-block-verify",
-		Usage: "When enabled we will perform full signature verification of blocks in batches instead of singularly.",
+	disableBatchBlockVerify = &cli.BoolFlag{
+		Name:  "disable-batch-block-verify",
+		Usage: "Disable full signature verification of blocks in batches instead of singularly.",
 	}
 	initSyncVerbose = &cli.BoolFlag{
 		Name:  "init-sync-verbose",
@@ -177,7 +177,6 @@ var (
 
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
-	batchBlockVerify,
 	enableEth1DataMajorityVote,
 	enableAttBroadcastDiscoveryAttempts,
 	enablePeerScorer,
@@ -558,6 +557,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedBatchBlockVerify = &cli.BoolFlag{
+		Name:   "batch-block-verify",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -635,6 +639,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedEnableSlasherFlag,
 	deprecatedEnableFinalizedDepositsCache,
 	deprecatedCheckptInfoCache,
+	deprecatedBatchBlockVerify,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -686,7 +691,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	AltonaTestnet,
 	OnyxTestnet,
 	spadinaTestnet,
-	batchBlockVerify,
+	disableBatchBlockVerify,
 	initSyncVerbose,
 	disableFinalizedDepositsCache,
 	enableEth1DataMajorityVote,


### PR DESCRIPTION
Part of #7243 

Make `--batch-verify-block` a default flag. The opt out flag is `--disable-batch-verify-block` Batch verify has been running in the while in `exp` mode in a while. We observed both great and stable results