### PR TITLE
Use Bufio Large Buffer Instead of Scanner for Large Files in E2E

### DIFF
--- a/endtoend/helpers/helpers.go
+++ b/endtoend/helpers/helpers.go
@@ -25,6 +25,8 @@ const (
 	filePollingInterval = 500 * time.Millisecond
 	memoryHeapFileName  = "node_heap_%d.pb.gz"
 	cpuProfileFileName  = "node_cpu_profile_%d.pb.gz"
+	fileBufferSize      = 64 * 1024
+	maxFileBufferSize   = 1024 * 1024
 )
 
 // KillProcesses finds the passed in process IDs and kills the process.
@@ -79,8 +81,8 @@ func WaitForTextInFile(file *os.File, text string) error {
 			return fmt.Errorf("could not find requested text \"%s\" in logs:\n%s", text, contents)
 		case <-ticker.C:
 			fileScanner := bufio.NewScanner(file)
-			buf := make([]byte, 0, 64*1024)
-			fileScanner.Buffer(buf, 1024*1024)
+			buf := make([]byte, 0, fileBufferSize)
+			fileScanner.Buffer(buf, maxFileBufferSize)
 			for fileScanner.Scan() {
 				scanned := fileScanner.Text()
 				if strings.Contains(scanned, text) {

--- a/endtoend/helpers/helpers.go
+++ b/endtoend/helpers/helpers.go
@@ -78,18 +78,15 @@ func WaitForTextInFile(file *os.File, text string) error {
 			}
 			return fmt.Errorf("could not find requested text \"%s\" in logs:\n%s", text, contents)
 		case <-ticker.C:
-			fileScanner := bufio.NewScanner(file)
-			for fileScanner.Scan() {
-				scanned := fileScanner.Text()
-				if strings.Contains(scanned, text) {
+			r := bufio.NewReader(file)
+			line, err := r.ReadString('\n')
+			for err == nil {
+				if strings.Contains(line, text) {
 					return nil
 				}
+				line, err = r.ReadString('\n')
 			}
-			if err := fileScanner.Err(); err != nil {
-				return err
-			}
-			_, err := file.Seek(0, io.SeekStart)
-			if err != nil {
+			if err != io.EOF {
 				return err
 			}
 		}


### PR DESCRIPTION
Resolves #7253. This PR adds a more reasonably sized buffer for reading eth1 data files in e2e tests, resolving some issues on macos catalina.