### PR TITLE
Fix IPV6 Address Retrieval

### DIFF
--- a/shared/iputils/external_ip.go
+++ b/shared/iputils/external_ip.go
@@ -3,6 +3,7 @@ package iputils
 
 import (
 	"net"
+	"sort"
 )
 
 // ExternalIPv4 returns the first IPv4 available.
@@ -84,11 +85,20 @@ func retrieveIPAddrs() ([]net.IP, error) {
 			case *net.IPAddr:
 				ip = v.IP
 			}
-			if ip == nil || ip.IsLoopback() {
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
 				continue
 			}
 			ipAddrs = append(ipAddrs, ip)
 		}
 	}
-	return ipAddrs, nil
+	return SortAddresses(ipAddrs), nil
+}
+
+// SortAddresses sorts a set of addresses in the order of
+// ipv4 -> ipv6.
+func SortAddresses(ipAddrs []net.IP) []net.IP {
+	sort.Slice(ipAddrs, func(i, j int) bool {
+		return ipAddrs[i].To4() != nil && ipAddrs[j].To4() == nil
+	})
+	return ipAddrs
 }

--- a/shared/iputils/external_ip_test.go
+++ b/shared/iputils/external_ip_test.go
@@ -30,3 +30,20 @@ func TestRetrieveIP(t *testing.T) {
 		t.Errorf("An invalid IP was retrieved: %s", ip)
 	}
 }
+
+func TestSortAddresses(t *testing.T) {
+	testAddresses := []net.IP{
+		{0xff, 0x02, 0xAA, 0, 0x1F, 0, 0, 0, 0, 0, 0x02, 0x2E, 0, 0, 0x36, 0x45},
+		{0xff, 0x02, 0xAA, 0, 0x1F, 0, 0x2E, 0, 0, 0x36, 0x45, 0, 0, 0, 0, 0x02},
+		{0xAA, 0x11, 0x33, 0x19},
+		{0x01, 0xBF, 0x33, 0x10},
+		{0x03, 0x89, 0x33, 0x13},
+	}
+
+	sortedAddrs := iputils.SortAddresses(testAddresses)
+	assert.Equal(t, true, sortedAddrs[0].To4() != nil, "expected ipv4 address")
+	assert.Equal(t, true, sortedAddrs[1].To4() != nil, "expected ipv4 address")
+	assert.Equal(t, true, sortedAddrs[2].To4() != nil, "expected ipv4 address")
+	assert.Equal(t, true, sortedAddrs[3].To16() != nil && sortedAddrs[3].To4() == nil, "expected ipv6 address")
+	assert.Equal(t, true, sortedAddrs[4].To16() != nil && sortedAddrs[4].To4() == nil, "expected ipv6 address")
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Due to #6363 , IP address retrieval was broken in Mac OS Catalina due to the node 
trying to bind to a link-local unicast address.

- [x] Ignore link-local unicast addresses when reading addresses from the network interface.
- [x] Sort addresses retrieved by favouring ipv4 addresses.
- [x] Add unit test for the above.

**Which issues(s) does this PR fix?**

Fixes #7250 

**Other notes for review**
