### PR TITLE
Add Flag To Disable Initial Sync

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -119,6 +119,12 @@ var (
 		Usage: "The factor by which block batch limit may increase on burst.",
 		Value: 10,
 	}
+	// DisableSync disables a node from syncing at start-up. Instead the node enters regular sync
+	// immediately.
+	DisableSync = &cli.BoolFlag{
+		Name:  "disable-sync",
+		Usage: "Starts the beacon node without entering initial sync and instead exits to regular sync immediately.",
+	}
 	// EnableDebugRPCEndpoints as /v1/beacon/state.
 	EnableDebugRPCEndpoints = &cli.BoolFlag{
 		Name:  "enable-debug-rpc-endpoints",

--- a/beacon-chain/flags/config.go
+++ b/beacon-chain/flags/config.go
@@ -10,6 +10,7 @@ import (
 // beacon node.
 type GlobalFlags struct {
 	UnsafeSync                 bool
+	DisableSync                bool
 	DisableDiscv5              bool
 	MinimumSyncPeers           int
 	BlockBatchLimit            int
@@ -35,12 +36,9 @@ func Init(c *GlobalFlags) {
 // based on the provided cli context.
 func ConfigureGlobalFlags(ctx *cli.Context) {
 	cfg := &GlobalFlags{}
-	if ctx.Bool(UnsafeSync.Name) {
-		cfg.UnsafeSync = true
-	}
-	if ctx.Bool(DisableDiscv5.Name) {
-		cfg.DisableDiscv5 = true
-	}
+	cfg.UnsafeSync = ctx.Bool(UnsafeSync.Name)
+	cfg.DisableSync = ctx.Bool(DisableSync.Name)
+	cfg.DisableDiscv5 = ctx.Bool(DisableDiscv5.Name)
 	cfg.BlockBatchLimit = ctx.Int(BlockBatchLimit.Name)
 	cfg.BlockBatchLimitBurstFactor = ctx.Int(BlockBatchLimitBurstFactor.Name)
 	configureMinimumPeers(ctx, cfg)

--- a/beacon-chain/flags/config.go
+++ b/beacon-chain/flags/config.go
@@ -36,8 +36,14 @@ func Init(c *GlobalFlags) {
 // based on the provided cli context.
 func ConfigureGlobalFlags(ctx *cli.Context) {
 	cfg := &GlobalFlags{}
-	cfg.UnsafeSync = ctx.Bool(UnsafeSync.Name)
-	cfg.DisableSync = ctx.Bool(DisableSync.Name)
+	if ctx.Bool(UnsafeSync.Name) {
+		log.Warn("Using Unsafe Sync flag, it is insecure to use this flag with your beacon node.")
+		cfg.UnsafeSync = true
+	}
+	if ctx.Bool(DisableSync.Name) {
+		log.Warn("Using Disable Sync flag, using this flag on a live network might lead to adverse consequences.")
+		cfg.DisableSync = true
+	}
 	cfg.DisableDiscv5 = ctx.Bool(DisableDiscv5.Name)
 	cfg.BlockBatchLimit = ctx.Int(BlockBatchLimit.Name)
 	cfg.BlockBatchLimitBurstFactor = ctx.Int(BlockBatchLimitBurstFactor.Name)

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -39,6 +39,7 @@ var appFlags = []cli.Flag{
 	flags.ContractDeploymentBlock,
 	flags.SetGCPercent,
 	flags.UnsafeSync,
+	flags.DisableSync,
 	flags.DisableDiscv5,
 	flags.BlockBatchLimit,
 	flags.BlockBatchLimitBurstFactor,

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -116,6 +116,18 @@ func (s *Service) Start() {
 		genesis = time.Unix(int64(headState.GenesisTime()), 0)
 	}
 
+	if flags.Get().DisableSync {
+		s.synced = true
+		s.stateNotifier.StateFeed().Send(&feed.Event{
+			Type: statefeed.Synced,
+			Data: &statefeed.SyncedData{
+				StartTime: genesis,
+			},
+		})
+		log.WithField("genesisTime", genesis).Info("Due to Sync Being Disabled, entering regular sync immediately.")
+		return
+	}
+
 	if genesis.After(roughtime.Now()) {
 		s.synced = true
 		s.stateNotifier.StateFeed().Send(&feed.Event{

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -98,6 +98,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.HTTPWeb3ProviderFlag,
 			flags.SetGCPercent,
 			flags.UnsafeSync,
+			flags.DisableSync,
 			flags.SlotsPerArchivedPoint,
 			flags.DisableDiscv5,
 			flags.BlockBatchLimit,


### PR DESCRIPTION
**What type of PR is this?**

New Flag

**What does this PR do? Why is it needed?**

- [x] For testing purposes some users would like to only have one node running. This PR allows a node to 'skip' 
initial sync and enter regular sync immediately.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
