### PR TITLE
Fix gazelle warning when `fuzzing_enabled` is not provided

### DIFF
--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@prysm//tools/go:def.bzl", "go_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
+# gazelle:ignore committee_disabled.go committee.go
 go_library(
     name = "go_default_library",
     srcs = [

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@prysm//tools/go:def.bzl", "go_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
-# gazelle:ignore committee_disabled.go committee.go
+# gazelle:ignore committee_disabled.go
 go_library(
     name = "go_default_library",
     srcs = [


### PR DESCRIPTION
**What type of PR is this?**

> Other/Toolset improve

**What does this PR do? Why is it needed?**
- When running `bazel run //:gazelle`, I see the following gazelle warning:
![image](https://user-images.githubusercontent.com/188194/93469336-0739e000-f8f9-11ea-8f74-da1249e415b9.png)
- This PR makes sure that when `fuzzing_enabled` flag is not set, `bazel run //:gazelle` doesn't emit any warnings.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
