### PR TITLE
Update Spadina fork version to 0x02

### DIFF
--- a/shared/params/testnet_spadina_config.go
+++ b/shared/params/testnet_spadina_config.go
@@ -24,7 +24,7 @@ func UseSpadinaConfig() {
 func SpadinaConfig() *BeaconChainConfig {
 	cfg := MainnetConfig().Copy()
 	cfg.MinGenesisTime = 1601380800
-	cfg.GenesisForkVersion = []byte{0x00, 0x00, 0x00, 0x00}
+	cfg.GenesisForkVersion = []byte{0x00, 0x00, 0x00, 0x02}
 	cfg.MinGenesisActiveValidatorCount = 1024
 	return cfg
 }


### PR DESCRIPTION
Spadina's fork version is `0x00000002`, not `0x00000000`

Reference: https://github.com/goerli/medalla/tree/master/spadina