### PR TITLE
Improve error message when creating a wallet in place of one that already exists

### DIFF
--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -3,9 +3,11 @@ package v2
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/manifoldco/promptui"
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/shared/fileutil"
 	"github.com/prysmaticlabs/prysm/shared/promptutil"
 	"github.com/prysmaticlabs/prysm/validator/accounts/v2/prompt"
 	"github.com/prysmaticlabs/prysm/validator/accounts/v2/wallet"
@@ -36,12 +38,17 @@ func CreateAndSaveWalletCli(cliCtx *cli.Context) (*wallet.Wallet, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = wallet.Exists(createWalletConfig.WalletCfg.WalletDir)
-	if err != wallet.ErrNoWalletFound {
-		if err != nil {
-			return nil, err
-		}
-		return nil, errors.New("a directory already exists at this location. Please input an" +
+
+	extractedWalletDir := createWalletConfig.WalletCfg.WalletDir
+	extractedKeymanagerKind := createWalletConfig.WalletCfg.KeymanagerKind
+	accountsPath := filepath.Join(extractedWalletDir, extractedKeymanagerKind.String())
+	ok, err := fileutil.HasDir(accountsPath)
+	if err != nil {
+		return nil, err
+	}
+	// This wallet type already exists
+	if ok {
+		return nil, errors.New("a wallet of this type already exists at this location. Please input an" +
 			" alternative location for the new wallet or remove the current wallet")
 	}
 	return CreateWalletWithKeymanager(cliCtx.Context, createWalletConfig)

--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -39,9 +39,9 @@ func CreateAndSaveWalletCli(cliCtx *cli.Context) (*wallet.Wallet, error) {
 		return nil, err
 	}
 
-	walletDir := createWalletConfig.WalletCfg.WalletDir
-	keymanagerKind = createWalletConfig.WalletCfg.KeymanagerKind
-	accountsPath := filepath.Join(walletDir, keymanagerKind.String())
+	dir := createWalletConfig.WalletCfg.WalletDir
+	kmKind := createWalletConfig.WalletCfg.KeymanagerKind
+	accountsPath := filepath.Join(dir, kmKind.String())
 	ok, err := fileutil.HasDir(accountsPath)
 	if err != nil {
 		return nil, err

--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -39,9 +39,9 @@ func CreateAndSaveWalletCli(cliCtx *cli.Context) (*wallet.Wallet, error) {
 		return nil, err
 	}
 
-	extractedWalletDir := createWalletConfig.WalletCfg.WalletDir
-	extractedKeymanagerKind := createWalletConfig.WalletCfg.KeymanagerKind
-	accountsPath := filepath.Join(extractedWalletDir, extractedKeymanagerKind.String())
+	walletDir := createWalletConfig.WalletCfg.WalletDir
+	keymanagerKind := createWalletConfig.WalletCfg.KeymanagerKind
+	accountsPath := filepath.Join(walletDir, keymanagerKind.String())
 	ok, err := fileutil.HasDir(accountsPath)
 	if err != nil {
 		return nil, err

--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -36,6 +36,14 @@ func CreateAndSaveWalletCli(cliCtx *cli.Context) (*wallet.Wallet, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = wallet.Exists(createWalletConfig.WalletCfg.WalletDir)
+	if err != wallet.ErrNoWalletFound {
+		if err != nil {
+			return nil, err
+		}
+		return nil, errors.New("a directory already exists at this location. Please input an" +
+			" alternative location for the new wallet or remove the current wallet")
+	}
 	return CreateWalletWithKeymanager(cliCtx.Context, createWalletConfig)
 }
 

--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -40,7 +40,7 @@ func CreateAndSaveWalletCli(cliCtx *cli.Context) (*wallet.Wallet, error) {
 	}
 
 	walletDir := createWalletConfig.WalletCfg.WalletDir
-	keymanagerKind := createWalletConfig.WalletCfg.KeymanagerKind
+	keymanagerKind = createWalletConfig.WalletCfg.KeymanagerKind
 	accountsPath := filepath.Join(walletDir, keymanagerKind.String())
 	ok, err := fileutil.HasDir(accountsPath)
 	if err != nil {

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -234,8 +234,7 @@ func TestCreateWallet_WalletAlreadyExists(t *testing.T) {
 	// We attempt to create another wallet of the same type at the same location. We expect an error.
 	_, err = CreateAndSaveWalletCli(cliCtx)
 	require.ErrorContains(t, "a wallet of this type already exists at this location. Please input an"+
-		" alternative location for the new wallet or remove the current wallet", err,
-		"Creating a wallet of the same type at an existing wallet location should return error")
+		" alternative location for the new wallet or remove the current wallet", err)
 
 	cliCtx = setupWalletCtx(t, &testWalletConfig{
 		walletDir:          walletDir,
@@ -246,8 +245,7 @@ func TestCreateWallet_WalletAlreadyExists(t *testing.T) {
 
 	// We attempt to create another wallet of different type at the same location. We don't expect an error.
 	_, err = CreateAndSaveWalletCli(cliCtx)
-	require.NoError(t, err, "Creating a wallet of a different type at an existing wallet location"+
-		" should not return a error")
+	require.NoError(t, err)
 }
 
 // TestCorrectPassphrase_Derived makes sure the wallet created uses the provided passphrase

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -243,7 +243,7 @@ func TestCreateWallet_WalletAlreadyExists(t *testing.T) {
 		keymanagerKind:     v2keymanager.Direct,
 	})
 
-	// We attempt to create another wallet of different type at the same location.  We don't expect an error.
+	// We attempt to create another wallet of different type at the same location. We don't expect an error.
 	_, err = CreateAndSaveWalletCli(cliCtx)
 	require.Equal(t, nil, err,
 		"Creating a wallet of a different type at an existing wallet location should not return a error")

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -217,8 +217,8 @@ func TestCreateWallet_Derived(t *testing.T) {
 	assert.DeepEqual(t, derived.DefaultKeymanagerOpts(), cfg)
 }
 
-// TestCreateWallet_ifExistingWallet checks for expected error if trying to create a wallet where they is already one.
-func TestCreateWallet_ifExistingWallet(t *testing.T) {
+// TestCreateWallet_IfExistingWallet checks for expected error if trying to create a wallet where they is already one.
+func TestCreateWallet_IfExistingWallet(t *testing.T) {
 	walletDir, passwordsDir, passwordFile := setupWalletAndPasswordsDir(t)
 	cliCtx := setupWalletCtx(t, &testWalletConfig{
 		walletDir:          walletDir,

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -233,7 +233,8 @@ func TestCreateWallet_WalletAlreadyExists(t *testing.T) {
 
 	// We attempt to create another wallet of the same type at the same location. We expect an error.
 	_, err = CreateAndSaveWalletCli(cliCtx)
-	require.NotEqual(t, nil, err,
+	require.ErrorContains(t, "a wallet of this type already exists at this location. Please input an"+
+		" alternative location for the new wallet or remove the current wallet", err,
 		"Creating a wallet of the same type at an existing wallet location should return error")
 
 	cliCtx = setupWalletCtx(t, &testWalletConfig{
@@ -245,8 +246,8 @@ func TestCreateWallet_WalletAlreadyExists(t *testing.T) {
 
 	// We attempt to create another wallet of different type at the same location. We don't expect an error.
 	_, err = CreateAndSaveWalletCli(cliCtx)
-	require.Equal(t, nil, err,
-		"Creating a wallet of a different type at an existing wallet location should not return a error")
+	require.NoError(t, err, "Creating a wallet of a different type at an existing wallet location"+
+		" should not return a error")
 }
 
 // TestCorrectPassphrase_Derived makes sure the wallet created uses the provided passphrase

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -217,7 +217,7 @@ func TestCreateWallet_Derived(t *testing.T) {
 	assert.DeepEqual(t, derived.DefaultKeymanagerOpts(), cfg)
 }
 
-// TestCreateWallet_IfExistingWallet checks for expected error if trying to create a wallet where they is already one.
+// TestCreateWallet_WalletAlreadyExists checks for expected error if trying to create a wallet when there is one already.
 func TestCreateWallet_IfExistingWallet(t *testing.T) {
 	walletDir, passwordsDir, passwordFile := setupWalletAndPasswordsDir(t)
 	cliCtx := setupWalletCtx(t, &testWalletConfig{

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -217,7 +217,7 @@ func TestCreateWallet_Derived(t *testing.T) {
 	assert.DeepEqual(t, derived.DefaultKeymanagerOpts(), cfg)
 }
 
-// TestCreateWallet_ifExistingWallet checks for expected error if create wallet is issued at site of current wallet.
+// TestCreateWallet_ifExistingWallet checks for expected error if trying to create a wallet where they is already one.
 func TestCreateWallet_ifExistingWallet(t *testing.T) {
 	walletDir, passwordsDir, passwordFile := setupWalletAndPasswordsDir(t)
 	cliCtx := setupWalletCtx(t, &testWalletConfig{
@@ -231,7 +231,7 @@ func TestCreateWallet_ifExistingWallet(t *testing.T) {
 	_, err := CreateAndSaveWalletCli(cliCtx)
 	require.NoError(t, err)
 
-	// We attempt to create another wallet at the same location.  We expect an error.
+	// We attempt to create another wallet of the same type at the same location.  We expect an error.
 	_, err = CreateAndSaveWalletCli(cliCtx)
 	require.NotEqual(t, nil, err,
 		"Creating a wallet of the same type at an existing wallet location should return error")
@@ -247,7 +247,6 @@ func TestCreateWallet_ifExistingWallet(t *testing.T) {
 	_, err = CreateAndSaveWalletCli(cliCtx)
 	require.Equal(t, nil, err,
 		"Creating a wallet of a different type at an existing wallet location should not return a error")
-
 }
 
 // TestCorrectPassphrase_Derived makes sure the wallet created uses the provided passphrase

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -231,7 +231,7 @@ func TestCreateWallet_WalletAlreadyExists(t *testing.T) {
 	_, err := CreateAndSaveWalletCli(cliCtx)
 	require.NoError(t, err)
 
-	// We attempt to create another wallet of the same type at the same location.  We expect an error.
+	// We attempt to create another wallet of the same type at the same location. We expect an error.
 	_, err = CreateAndSaveWalletCli(cliCtx)
 	require.NotEqual(t, nil, err,
 		"Creating a wallet of the same type at an existing wallet location should return error")

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -218,7 +218,7 @@ func TestCreateWallet_Derived(t *testing.T) {
 }
 
 // TestCreateWallet_WalletAlreadyExists checks for expected error if trying to create a wallet when there is one already.
-func TestCreateWallet_IfExistingWallet(t *testing.T) {
+func TestCreateWallet_WalletAlreadyExists(t *testing.T) {
 	walletDir, passwordsDir, passwordFile := setupWalletAndPasswordsDir(t)
 	cliCtx := setupWalletCtx(t, &testWalletConfig{
 		walletDir:          walletDir,


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**
Currently, if you invoke wallet-v2 create with a wallet directory targeting a location that already has a wallet, it simply tries to use the provided [new wallet] password to unlock the old wallet without actually overwriting the old wallet.  A silent overwrite is not desirable either.  If the provided password mismatches with the old wallet's password, you get an error message:

`[2020-09-17 12:20:42] FATAL accounts-v2: Could not create a wallet: could not initialize wallet with derived keymanager: could not initialize keymanager: could not initialize derived keymanager: could not decrypt seed configuration with password: invalid checksum`

If the password provided for the new wallet matches the one needed to unlock the one already there, you get this:

`INFO accounts-v2: Successfully created HD wallet and saved configuration to disk. Make a new validator account with ./prysm.sh validator accounts-2 create --wallet-dir=/root/.eth2validators/prysm-wallet-v2`

Which is not accurate.  Also, in this case the keymanageropts.json file ends up overwritten in the code flow by a default one.

This PR makes it so that if wallet-v2 create is invoked to create the same **type** of wallet already present, it will stop and output an error message: 

> a wallet of this type already exists at this location. Please input an alternative location for the new wallet or remove the current wallet

**Which issues(s) does this PR fix?**

Fixes #7264 

**Other notes for review**
Has a regression test.