### PR TITLE
Add missing error handling in slasher

### DIFF
--- a/slasher/rpc/server.go
+++ b/slasher/rpc/server.go
@@ -108,6 +108,7 @@ func (ss *Server) IsSlashableAttestation(ctx context.Context, req *ethpb.Indexed
 		}
 		if err := ss.detector.UpdateSpans(ctx, req); err != nil {
 			log.WithError(err).Error("could not update spans")
+			return nil, status.Errorf(codes.Internal, "failed to update spans: %v: %v", req, err)
 		}
 	}
 	return &slashpb.AttesterSlashingResponse{


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
when no slashing were found in `IsSlashableAttestation` endpoint and update spans failed it didn't return an error

