### PR TITLE
Two more gossip validations for unaggregated atts subnet

### DIFF
--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -123,7 +123,6 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 
 		// Verify number of aggregation bits matches the committee size.
 		if err := helpers.VerifyBitfieldLength(att.AggregationBits, uint64(len(committee))); err != nil {
-			fmt.Println(err)
 			return pubsub.ValidationReject
 		}
 

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -105,8 +105,13 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		if err != nil {
 			return pubsub.ValidationIgnore
 		}
-		// Is the attestation subnet correct.
+		// Is the attestation committee ID within the expected range.
 		indices := c.ActiveIndices
+		count := helpers.SlotCommitteeCount(uint64(len(indices)))
+		if att.Data.CommitteeIndex > count {
+			return pubsub.ValidationReject
+		}
+		// Is the attestation subnet correct.
 		subnet := helpers.ComputeSubnetForAttestation(uint64(len(indices)), att)
 		if !strings.HasPrefix(originalTopic, fmt.Sprintf(format, digest, subnet)) {
 			return pubsub.ValidationReject
@@ -115,6 +120,13 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		if err != nil {
 			return pubsub.ValidationIgnore
 		}
+
+		// Verify number of aggregation bits matches the committee size.
+		if err := helpers.VerifyBitfieldLength(att.AggregationBits, uint64(len(committee))); err != nil {
+			fmt.Println(err)
+			return pubsub.ValidationReject
+		}
+
 		// Is the attestation bitfield correct.
 		if att.AggregationBits.Count() != 1 || att.AggregationBits.BitIndices()[0] >= len(committee) {
 			return pubsub.ValidationReject
@@ -141,8 +153,13 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		traceutil.AnnotateError(span, err)
 		return pubsub.ValidationIgnore
 	}
-	subnet := helpers.ComputeSubnetForAttestation(valCount, att)
 
+	count := helpers.SlotCommitteeCount(valCount)
+	if att.Data.CommitteeIndex > count {
+		return pubsub.ValidationReject
+	}
+
+	subnet := helpers.ComputeSubnetForAttestation(valCount, att)
 	if !strings.HasPrefix(originalTopic, fmt.Sprintf(format, digest, subnet)) {
 		return pubsub.ValidationReject
 	}
@@ -151,6 +168,11 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 	if err != nil {
 		traceutil.AnnotateError(span, err)
 		return pubsub.ValidationIgnore
+	}
+
+	// Verify number of aggregation bits matches the committee size.
+	if err := helpers.VerifyBitfieldLength(att.AggregationBits, uint64(len(committee))); err != nil {
+		return pubsub.ValidationReject
 	}
 
 	// Attestation must be unaggregated and the bit index must exist in the range of committee indices.

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -79,7 +79,7 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 		{
 			name: "valid attestation signature",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: validBlockRoot[:],
 					CommitteeIndex:  0,
@@ -98,7 +98,7 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 		{
 			name: "already seen",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: validBlockRoot[:],
 					CommitteeIndex:  0,
@@ -114,7 +114,7 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 		{
 			name: "invalid beacon block",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: invalidRoot[:],
 					CommitteeIndex:  0,
@@ -127,11 +127,26 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 			validAttestationSignature: true,
 			want:                      false,
 		},
-
+		{
+			name: "committee index exceeds committee length",
+			msg: &ethpb.Attestation{
+				AggregationBits: bitfield.Bitlist{0b101},
+				Data: &ethpb.AttestationData{
+					BeaconBlockRoot: validBlockRoot[:],
+					CommitteeIndex:  4,
+					Slot:            1,
+					Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+					Source:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+				},
+			},
+			topic:                     fmt.Sprintf("/eth2/%x/beacon_attestation_2", digest),
+			validAttestationSignature: true,
+			want:                      false,
+		},
 		{
 			name: "wrong committee index",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: validBlockRoot[:],
 					CommitteeIndex:  2,
@@ -163,7 +178,7 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 		{
 			name: "missing block",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: bytesutil.PadTo([]byte("missing"), 32),
 					CommitteeIndex:  1,
@@ -179,7 +194,7 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 		{
 			name: "invalid attestation",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: validBlockRoot[:],
 					CommitteeIndex:  1,
@@ -196,6 +211,7 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			helpers.ClearCache()
 			chain.ValidAttestation = tt.validAttestationSignature
 			if tt.validAttestationSignature {
 				com, err := helpers.BeaconCommitteeFromState(savedState, tt.msg.Data.Slot, tt.msg.Data.CommitteeIndex)
@@ -287,7 +303,7 @@ func TestService_validateCommitteeIndexBeaconAttestationUseCheckptCache(t *testi
 		{
 			name: "valid attestation signature",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: validBlockRoot[:],
 					CommitteeIndex:  0,
@@ -306,7 +322,7 @@ func TestService_validateCommitteeIndexBeaconAttestationUseCheckptCache(t *testi
 		{
 			name: "already seen",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: validBlockRoot[:],
 					CommitteeIndex:  0,
@@ -322,7 +338,7 @@ func TestService_validateCommitteeIndexBeaconAttestationUseCheckptCache(t *testi
 		{
 			name: "invalid beacon block",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: invalidRoot[:],
 					CommitteeIndex:  0,
@@ -335,11 +351,26 @@ func TestService_validateCommitteeIndexBeaconAttestationUseCheckptCache(t *testi
 			validAttestationSignature: true,
 			want:                      false,
 		},
-
+		{
+			name: "committee index exceeds committee length",
+			msg: &ethpb.Attestation{
+				AggregationBits: bitfield.Bitlist{0b101},
+				Data: &ethpb.AttestationData{
+					BeaconBlockRoot: validBlockRoot[:],
+					CommitteeIndex:  4,
+					Slot:            1,
+					Target:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+					Source:          &ethpb.Checkpoint{Root: make([]byte, 32)},
+				},
+			},
+			topic:                     fmt.Sprintf("/eth2/%x/beacon_attestation_2", digest),
+			validAttestationSignature: true,
+			want:                      false,
+		},
 		{
 			name: "wrong committee index",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: validBlockRoot[:],
 					CommitteeIndex:  2,
@@ -355,7 +386,7 @@ func TestService_validateCommitteeIndexBeaconAttestationUseCheckptCache(t *testi
 		{
 			name: "already aggregated",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1011},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: validBlockRoot[:],
 					CommitteeIndex:  1,
@@ -371,7 +402,7 @@ func TestService_validateCommitteeIndexBeaconAttestationUseCheckptCache(t *testi
 		{
 			name: "missing block",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: bytesutil.PadTo([]byte("missing"), 32),
 					CommitteeIndex:  1,
@@ -387,7 +418,7 @@ func TestService_validateCommitteeIndexBeaconAttestationUseCheckptCache(t *testi
 		{
 			name: "invalid attestation",
 			msg: &ethpb.Attestation{
-				AggregationBits: bitfield.Bitlist{0b1010},
+				AggregationBits: bitfield.Bitlist{0b101},
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: validBlockRoot[:],
 					CommitteeIndex:  1,


### PR DESCRIPTION
Part of #7274 

Added to more gossip validations as specified in https://github.com/ethereum/eth2.0-specs/pull/2030

Also tested run time