### PR TITLE
Fix sha after v0.12.3 tarballs were re-uploaded. Unskip test to resolve #7277.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -231,7 +231,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    sha256 = "9e5c4b335e3854195019d9569341ab500aa7621b045858efd830fce9dddf27f9",
+    sha256 = "72c2f561db879ddcdf729fef93d10e0f9162b4cf3a697c513ef8935b93f6165a",
     url = "https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.12.3/minimal.tar.gz",
 )
 
@@ -247,7 +247,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    sha256 = "556d90a495e3f13f269741cb6c4ad060f529fe2adf82efccb83833d172c1bf93",
+    sha256 = "63eca02503692a0b6a2d7b70118e0dd62dff094153a3a542af6dbea721841b0d",
     url = "https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.12.3/mainnet.tar.gz",
 )
 

--- a/proto/testing/ssz_static_mainnet_test.go
+++ b/proto/testing/ssz_static_mainnet_test.go
@@ -5,6 +5,5 @@ import (
 )
 
 func TestSZZStatic_Mainnet(t *testing.T) {
-	t.Skip("Skipped due to upstream configuration bug. See: https://github.com/prysmaticlabs/prysm/issues/7277")
 	runSSZStaticTests(t, "mainnet")
 }


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The tarballs for v0.12.3 spectests were re-uploaded with different data. The sha256 of these files has changed.

**Which issues(s) does this PR fix?**

Fixes #7277

**Other notes for review**

See: https://github.com/ethereum/eth2.0-specs/issues/2076
