### PR TITLE
Fixes e2e "chain started" check

### DIFF
--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -253,6 +253,7 @@ func (s *Service) registerHandlers() {
 					stateSub.Unsubscribe()
 					time.Sleep(timeutils.Until(data.StartTime))
 				}
+				log.WithField("starttime", data.StartTime).Debug("Chain started in sync service")
 				s.chainStarted = true
 			}
 		case <-s.ctx.Done():

--- a/endtoend/endtoend_test.go
+++ b/endtoend/endtoend_test.go
@@ -58,7 +58,7 @@ func runEndToEndTest(t *testing.T, config *types.E2EConfig) {
 	beaconLogFile, err := os.Open(path.Join(e2e.TestParams.LogPath, fmt.Sprintf(e2e.BeaconNodeLogFileName, 0)))
 	require.NoError(t, err)
 	t.Run("chain started", func(t *testing.T) {
-		require.NoError(t, helpers.WaitForTextInFile(beaconLogFile, "Chain started within the last epoch"), "Chain did not start")
+		require.NoError(t, helpers.WaitForTextInFile(beaconLogFile, "Chain started in sync service"), "Chain did not start")
 	})
 
 	// Failing early in case chain doesn't start.


### PR DESCRIPTION
**What type of PR is this?**

> Other / e2e fix

**What does this PR do? Why is it needed?**
- Currently we rely on `Chain started within the last epoch` message, to decide whether chain has started or not. However, that message is produced by init-sync, and produced not when chain is started but when genesis is in future or current slot is within 0th epoch: 
https://github.com/prysmaticlabs/prysm/blob/b09b1f3fa5851f90c7757aac5695450d289cd140/beacon-chain/sync/initial-sync/service.go#L95-L118
- As you can see (scroll down) above, `s.chainStarted` is not even reached when the checked message is triggered.
- Instead this PR, emits a `Chain started in sync service` in **normal sync** service, and then in e2e test checks for that message.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- cc @0xKiwi 
