### PR TITLE
Better naming for constructor funcs

### DIFF
--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -101,7 +101,7 @@ func setupBeaconChain(t *testing.T, beaconDB db.Database, sc *cache.StateSummary
 	opsService, err := attestations.NewService(ctx, &attestations.Config{Pool: attestations.NewPool()})
 	require.NoError(t, err)
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	cfg := &Config{

--- a/beacon-chain/cache/depositcache/deposits_cache.go
+++ b/beacon-chain/cache/depositcache/deposits_cache.go
@@ -58,8 +58,8 @@ type DepositCache struct {
 	chainStartPubkeys  map[string]bool
 }
 
-// NewDepositCache instantiates a new deposit cache
-func NewDepositCache() (*DepositCache, error) {
+// New instantiates a new deposit cache
+func New() (*DepositCache, error) {
 	finalizedDepositsTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	if err != nil {
 		return nil, err

--- a/beacon-chain/cache/depositcache/deposits_cache_test.go
+++ b/beacon-chain/cache/depositcache/deposits_cache_test.go
@@ -23,7 +23,7 @@ var _ = DepositFetcher(&DepositCache{})
 
 func TestInsertDeposit_LogsOnNilDepositInsertion(t *testing.T) {
 	hook := logTest.NewGlobal()
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	dc.InsertDeposit(context.Background(), nil, 1, 0, [32]byte{})
@@ -33,7 +33,7 @@ func TestInsertDeposit_LogsOnNilDepositInsertion(t *testing.T) {
 }
 
 func TestInsertDeposit_MaintainsSortedOrderByIndex(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	insertions := []struct {
@@ -75,7 +75,7 @@ func TestInsertDeposit_MaintainsSortedOrderByIndex(t *testing.T) {
 }
 
 func TestAllDeposits_ReturnsAllDeposits(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	deposits := []*dbpb.DepositContainer{
@@ -115,7 +115,7 @@ func TestAllDeposits_ReturnsAllDeposits(t *testing.T) {
 }
 
 func TestAllDeposits_FiltersDepositUpToAndIncludingBlockNumber(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	deposits := []*dbpb.DepositContainer{
@@ -155,7 +155,7 @@ func TestAllDeposits_FiltersDepositUpToAndIncludingBlockNumber(t *testing.T) {
 }
 
 func TestDepositsNumberAndRootAtHeight_ReturnsAppropriateCountAndRoot(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	dc.deposits = []*dbpb.DepositContainer{
@@ -238,7 +238,7 @@ func TestDepositsNumberAndRootAtHeight_ReturnsAppropriateCountAndRoot(t *testing
 }
 
 func TestDepositsNumberAndRootAtHeight_ReturnsEmptyTrieIfBlockHeightLessThanOldestDeposit(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	dc.deposits = []*dbpb.DepositContainer{
@@ -272,7 +272,7 @@ func TestDepositsNumberAndRootAtHeight_ReturnsEmptyTrieIfBlockHeightLessThanOlde
 }
 
 func TestDepositByPubkey_ReturnsFirstMatchingDeposit(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	dc.deposits = []*dbpb.DepositContainer{
@@ -329,7 +329,7 @@ func TestDepositByPubkey_ReturnsFirstMatchingDeposit(t *testing.T) {
 }
 
 func TestFinalizedDeposits_DepositsCachedCorrectly(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	finalizedDeposits := []*dbpb.DepositContainer{
@@ -393,7 +393,7 @@ func TestFinalizedDeposits_DepositsCachedCorrectly(t *testing.T) {
 }
 
 func TestFinalizedDeposits_UtilizesPreviouslyCachedDeposits(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	oldFinalizedDeposits := []*dbpb.DepositContainer{
@@ -451,7 +451,7 @@ func TestFinalizedDeposits_UtilizesPreviouslyCachedDeposits(t *testing.T) {
 }
 
 func TestFinalizedDeposits_InitializedCorrectly(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	finalizedDeposits := dc.finalizedDeposits
@@ -461,7 +461,7 @@ func TestFinalizedDeposits_InitializedCorrectly(t *testing.T) {
 }
 
 func TestNonFinalizedDeposits_ReturnsAllNonFinalizedDeposits(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	finalizedDeposits := []*dbpb.DepositContainer{
@@ -518,7 +518,7 @@ func TestNonFinalizedDeposits_ReturnsAllNonFinalizedDeposits(t *testing.T) {
 }
 
 func TestNonFinalizedDeposits_ReturnsNonFinalizedDepositsUpToBlockNumber(t *testing.T) {
-	dc, err := NewDepositCache()
+	dc, err := New()
 	require.NoError(t, err)
 
 	finalizedDeposits := []*dbpb.DepositContainer{

--- a/beacon-chain/interop-cold-start/service.go
+++ b/beacon-chain/interop-cold-start/service.go
@@ -48,10 +48,10 @@ type Config struct {
 	GenesisPath   string
 }
 
-// NewColdStartService is an interoperability testing service to inject a deterministically generated genesis state
+// NewService is an interoperability testing service to inject a deterministically generated genesis state
 // into the beacon chain database and running services at start up. This service should not be used in production
 // as it does not have any value other than ease of use for testing purposes.
-func NewColdStartService(ctx context.Context, cfg *Config) *Service {
+func NewService(ctx context.Context, cfg *Config) *Service {
 	log.Warn("Saving generated genesis state in database for interop testing")
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -546,7 +546,7 @@ func (b *BeaconNode) registerInitialSyncService() error {
 		return err
 	}
 
-	is := initialsync.NewInitialSync(b.ctx, &initialsync.Config{
+	is := initialsync.NewService(b.ctx, &initialsync.Config{
 		DB:            b.db,
 		Chain:         chainService,
 		P2P:           b.fetchP2P(),

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -651,7 +651,7 @@ func (b *BeaconNode) registerPrometheusService() error {
 
 	additionalHandlers = append(additionalHandlers, prometheus.Handler{Path: "/tree", Handler: c.TreeHandler})
 
-	service := prometheus.NewPrometheusService(
+	service := prometheus.NewService(
 		fmt.Sprintf("%s:%d", b.cliCtx.String(cmd.MonitoringHostFlag.Name), b.cliCtx.Int(flags.MonitoringPortFlag.Name)),
 		b.services,
 		additionalHandlers...,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -327,7 +327,7 @@ func (b *BeaconNode) startDB(cliCtx *cli.Context) error {
 
 	b.db = d
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	if err != nil {
 		return errors.Wrap(err, "could not create deposit cache")
 	}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -33,7 +33,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/powchain"
 	"github.com/prysmaticlabs/prysm/beacon-chain/rpc"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
-	prysmsync "github.com/prysmaticlabs/prysm/beacon-chain/sync"
+	regularsync "github.com/prysmaticlabs/prysm/beacon-chain/sync"
 	initialsync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync"
 	"github.com/prysmaticlabs/prysm/shared"
 	"github.com/prysmaticlabs/prysm/shared/cmd"
@@ -516,7 +516,7 @@ func (b *BeaconNode) registerSyncService() error {
 		return err
 	}
 
-	rs := prysmsync.NewRegularSync(b.ctx, &prysmsync.Config{
+	rs := regularsync.NewService(b.ctx, &regularsync.Config{
 		DB:                  b.db,
 		P2P:                 b.fetchP2P(),
 		Chain:               chainService,

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -691,7 +691,7 @@ func (b *BeaconNode) registerInteropServices() error {
 	genesisStatePath := b.cliCtx.String(flags.InteropGenesisStateFlag.Name)
 
 	if genesisValidators > 0 || genesisStatePath != "" {
-		svc := interopcoldstart.NewColdStartService(b.ctx, &interopcoldstart.Config{
+		svc := interopcoldstart.NewService(b.ctx, &interopcoldstart.Config{
 			GenesisTime:   genesisTime,
 			NumValidators: genesisValidators,
 			BeaconDB:      b.db,

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -43,7 +43,7 @@ func TestProcessDepositLog_OK(t *testing.T) {
 	require.NoError(t, err, "Unable to set up simulated backend")
 
 	beaconDB, _ := testDB.SetupDB(t)
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
@@ -107,7 +107,7 @@ func TestProcessDepositLog_InsertsPendingDeposit(t *testing.T) {
 	testAcc, err := contracts.Setup()
 	require.NoError(t, err, "Unable to set up simulated backend")
 	beaconDB, _ := testDB.SetupDB(t)
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
@@ -217,7 +217,7 @@ func TestProcessETH2GenesisLog_8DuplicatePubkeys(t *testing.T) {
 	testAcc, err := contracts.Setup()
 	require.NoError(t, err, "Unable to set up simulated backend")
 	beaconDB, _ := testDB.SetupDB(t)
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
@@ -288,7 +288,7 @@ func TestProcessETH2GenesisLog(t *testing.T) {
 	testAcc, err := contracts.Setup()
 	require.NoError(t, err, "Unable to set up simulated backend")
 	beaconDB, _ := testDB.SetupDB(t)
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
@@ -377,7 +377,7 @@ func TestProcessETH2GenesisLog_CorrectNumOfDeposits(t *testing.T) {
 	testAcc, err := contracts.Setup()
 	require.NoError(t, err, "Unable to set up simulated backend")
 	kvStore, _ := testDB.SetupDB(t)
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
@@ -472,7 +472,7 @@ func TestWeb3ServiceProcessDepositLog_RequestMissedDeposits(t *testing.T) {
 	testAcc, err := contracts.Setup()
 	require.NoError(t, err, "Unable to set up simulated backend")
 	beaconDB, _ := testDB.SetupDB(t)
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
@@ -624,7 +624,7 @@ func TestCheckForChainstart_NoValidator(t *testing.T) {
 }
 
 func newPowchainService(t *testing.T, eth1Backend *contracts.TestAccount, beaconDB db.Database) *Service {
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{

--- a/beacon-chain/rpc/validator/assignments_test.go
+++ b/beacon-chain/rpc/validator/assignments_test.go
@@ -51,7 +51,7 @@ func TestGetDuties_NextEpoch_CantFindValidatorIdx(t *testing.T) {
 	chain := &mockChain.ChainService{
 		State: beaconState, Root: genesisRoot[:], Genesis: time.Now(),
 	}
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	vs := &Server{

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -438,7 +438,7 @@ func TestProposer_PendingDeposits_OutsideEth1FollowWindow(t *testing.T) {
 		},
 	}
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
@@ -573,7 +573,7 @@ func TestProposer_PendingDeposits_FollowsCorrectEth1Block(t *testing.T) {
 		},
 	}
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
@@ -673,7 +673,7 @@ func TestProposer_PendingDeposits_CantReturnBelowStateEth1DepositIndex(t *testin
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	for _, dp := range append(readyDeposits, recentDeposits...) {
@@ -769,7 +769,7 @@ func TestProposer_PendingDeposits_CantReturnMoreThanMax(t *testing.T) {
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	for _, dp := range append(readyDeposits, recentDeposits...) {
@@ -863,7 +863,7 @@ func TestProposer_PendingDeposits_CantReturnMoreThanDepositCount(t *testing.T) {
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	for _, dp := range append(readyDeposits, recentDeposits...) {
@@ -972,7 +972,7 @@ func TestProposer_DepositTrie_UtilizesCachedFinalizedDeposits(t *testing.T) {
 		},
 	}
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
@@ -1058,7 +1058,7 @@ func TestProposer_Eth1Data_NoBlockExists(t *testing.T) {
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	for _, dp := range deps {
@@ -1113,7 +1113,7 @@ func TestProposer_Eth1Data(t *testing.T) {
 
 	headState := testutil.NewBeaconState()
 	require.NoError(t, headState.SetEth1Data(&ethpb.Eth1Data{DepositCount: 55}))
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	ps := &Server{
@@ -1157,7 +1157,7 @@ func TestProposer_Eth1Data_SmallerDepositCount(t *testing.T) {
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	for _, dp := range deps {
@@ -1250,7 +1250,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err)
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 	depositCache.InsertDeposit(context.Background(), dc.Deposit, dc.Eth1BlockHeight, dc.Index, depositTrie.Root())
 
@@ -1767,7 +1767,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 			BlockHash: []byte("eth1data"),
 		}
 
-		depositCache, err := depositcache.NewDepositCache()
+		depositCache, err := depositcache.New()
 		require.NoError(t, err)
 
 		beaconState, err := beaconstate.InitializeFromProto(&pbp2p.BeaconState{
@@ -1952,7 +1952,7 @@ func Benchmark_Eth1Data(b *testing.B) {
 		},
 	}
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(b, err)
 
 	for i, dp := range deposits {
@@ -2063,7 +2063,7 @@ func TestProposer_Deposits_ReturnsEmptyList_IfLatestEth1DataEqGenesisEth1Block(t
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
 
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	for _, dp := range append(readyDeposits, recentDeposits...) {

--- a/beacon-chain/rpc/validator/server_test.go
+++ b/beacon-chain/rpc/validator/server_test.go
@@ -69,7 +69,7 @@ func TestWaitForActivation_ContextClosed(t *testing.T) {
 	require.NoError(t, err, "Could not get signing root")
 
 	ctx, cancel := context.WithCancel(context.Background())
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	vs := &Server{
@@ -145,7 +145,7 @@ func TestWaitForActivation_ValidatorOriginallyExists(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 10 /*blockNum*/, 0, depositTrie.Root())

--- a/beacon-chain/rpc/validator/status_test.go
+++ b/beacon-chain/rpc/validator/status_test.go
@@ -33,7 +33,7 @@ func TestValidatorStatus_DepositedEth1(t *testing.T) {
 	pubKey1 := deposit.Data.PublicKey
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())
@@ -78,7 +78,7 @@ func TestValidatorStatus_Deposited(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())
@@ -130,7 +130,7 @@ func TestValidatorStatus_PartiallyDeposited(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())
@@ -202,7 +202,7 @@ func TestValidatorStatus_Pending(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())
@@ -249,7 +249,7 @@ func TestValidatorStatus_Active(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())
@@ -340,7 +340,7 @@ func TestValidatorStatus_Exiting(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())
@@ -400,7 +400,7 @@ func TestValidatorStatus_Slashing(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())
@@ -464,7 +464,7 @@ func TestValidatorStatus_Exited(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())
@@ -493,7 +493,7 @@ func TestValidatorStatus_Exited(t *testing.T) {
 func TestValidatorStatus_UnknownStatus(t *testing.T) {
 	db, _ := dbutil.SetupDB(t)
 	pubKey := pubKey(1)
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	stateObj, err := stateTrie.InitializeFromProtoUnsafe(&pbp2p.BeaconState{
@@ -549,7 +549,7 @@ func TestActivationStatus_OK(t *testing.T) {
 	dep := deposits[0]
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, dep, 10 /*blockNum*/, 0, depositTrie.Root())
@@ -667,7 +667,7 @@ func TestValidatorStatus_CorrectActivationQueue(t *testing.T) {
 
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	for i := 0; i < 6; i++ {
@@ -724,7 +724,7 @@ func TestDepositBlockSlotAfterGenesisTime(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())
@@ -787,7 +787,7 @@ func TestDepositBlockSlotBeforeGenesisTime(t *testing.T) {
 	}
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())
@@ -882,7 +882,7 @@ func TestMultipleValidatorStatus_Pubkeys(t *testing.T) {
 	require.NoError(t, err, "Could not get signing root")
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	dep := deposits[0]
@@ -1049,7 +1049,7 @@ func TestValidatorStatus_Invalid(t *testing.T) {
 	deposit.Data.Signature = deposit.Data.Signature[1:]
 	depositTrie, err := trieutil.NewTrie(int(params.BeaconConfig().DepositContractTreeDepth))
 	require.NoError(t, err, "Could not setup deposit trie")
-	depositCache, err := depositcache.NewDepositCache()
+	depositCache, err := depositcache.New()
 	require.NoError(t, err)
 
 	depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, depositTrie.Root())

--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -322,7 +322,7 @@ func TestService_processBlock(t *testing.T) {
 	err = beaconDB.SaveBlock(context.Background(), genesisBlk)
 	require.NoError(t, err)
 	st := testutil.NewBeaconState()
-	s := NewInitialSync(context.Background(), &Config{
+	s := NewService(context.Background(), &Config{
 		P2P: p2pt.NewTestP2P(t),
 		DB:  beaconDB,
 		Chain: &mock.ChainService{
@@ -381,7 +381,7 @@ func TestService_processBlockBatch(t *testing.T) {
 	err = beaconDB.SaveBlock(context.Background(), genesisBlk)
 	require.NoError(t, err)
 	st := testutil.NewBeaconState()
-	s := NewInitialSync(context.Background(), &Config{
+	s := NewService(context.Background(), &Config{
 		P2P: p2pt.NewTestP2P(t),
 		DB:  beaconDB,
 		Chain: &mock.ChainService{

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -58,9 +58,9 @@ type Service struct {
 	lastProcessedSlot uint64
 }
 
-// NewInitialSync configures the initial sync service responsible for bringing the node up to the
+// NewService configures the initial sync service responsible for bringing the node up to the
 // latest head of the blockchain.
-func NewInitialSync(ctx context.Context, cfg *Config) *Service {
+func NewService(ctx context.Context, cfg *Config) *Service {
 	ctx, cancel := context.WithCancel(ctx)
 	return &Service{
 		ctx:           ctx,

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -31,7 +31,7 @@ func TestService_InitStartStop(t *testing.T) {
 	defer cancel()
 
 	mc, p2p, db := initializeTestServices(t, []uint64{}, []*peerData{})
-	s := NewInitialSync(ctx, &Config{
+	s := NewService(ctx, &Config{
 		P2P:   p2p,
 		DB:    db,
 		Chain: mc,
@@ -51,7 +51,7 @@ func TestService_waitForStateInitialization(t *testing.T) {
 	require.NoError(t, err)
 
 	newService := func(ctx context.Context, mc *mock.ChainService) *Service {
-		s := NewInitialSync(ctx, &Config{
+		s := NewService(ctx, &Config{
 			P2P:           p2pt.NewTestP2P(t),
 			DB:            beaconDB,
 			Chain:         mc,

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -111,8 +111,8 @@ type Service struct {
 	stateGen                  *stategen.State
 }
 
-// NewRegularSync service.
-func NewRegularSync(ctx context.Context, cfg *Config) *Service {
+// NewService initializes new regular sync service.
+func NewService(ctx context.Context, cfg *Config) *Service {
 	rLimiter := newRateLimiter(cfg.P2P)
 	ctx, cancel := context.WithCancel(ctx)
 	r := &Service{

--- a/fuzz/rpc_status_fuzz.go
+++ b/fuzz/rpc_status_fuzz.go
@@ -12,7 +12,7 @@ import (
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
-	"github.com/prysmaticlabs/prysm/beacon-chain/sync"
+	regularsync "github.com/prysmaticlabs/prysm/beacon-chain/sync"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -45,7 +45,7 @@ func init() {
 	if err := p.Connect(info); err != nil {
 		panic(errors.Wrap(err, "could not connect to peer"))
 	}
-	sync.NewRegularSync(context.Background(), &sync.Config{
+	regularsync.NewService(context.Background(), &regularsync.Config{
 		P2P:          p,
 		DB:           nil,
 		AttPool:      nil,

--- a/shared/keystore/key_test.go
+++ b/shared/keystore/key_test.go
@@ -36,7 +36,7 @@ func TestMarshalAndUnmarshal(t *testing.T) {
 func TestStoreRandomKey(t *testing.T) {
 	tempDir, teardown := setupTempKeystoreDir(t)
 	defer teardown()
-	ks := &Store{
+	ks := &Keystore{
 		keysDirPath: tempDir,
 		scryptN:     LightScryptN,
 		scryptP:     LightScryptP,

--- a/shared/keystore/keystore.go
+++ b/shared/keystore/keystore.go
@@ -45,16 +45,16 @@ var (
 	ErrDecrypt = errors.New("could not decrypt key with given passphrase")
 )
 
-// Store defines a keystore with a directory path and scrypt values.
-type Store struct {
+// Keystore defines a keystore with a directory path and scrypt values.
+type Keystore struct {
 	keysDirPath string
 	scryptN     int
 	scryptP     int
 }
 
-// NewKeystore from a directory.
-func NewKeystore(directory string) Store {
-	return Store{
+// New creates a new keystore from a directory.
+func New(directory string) Keystore {
+	return Keystore{
 		keysDirPath: directory,
 		scryptN:     StandardScryptN,
 		scryptP:     StandardScryptP,
@@ -62,7 +62,7 @@ func NewKeystore(directory string) Store {
 }
 
 // GetKey from file using the filename path and a decryption password.
-func (ks Store) GetKey(filename, password string) (*Key, error) {
+func (ks Keystore) GetKey(filename, password string) (*Key, error) {
 	// Load the key from the keystore and decrypt its contents
 	// #nosec G304
 	keyJSON, err := ioutil.ReadFile(filename)
@@ -74,7 +74,7 @@ func (ks Store) GetKey(filename, password string) (*Key, error) {
 
 // GetKeys from directory using the prefix to filter relevant files
 // and a decryption password.
-func (ks Store) GetKeys(directory, filePrefix, password string, warnOnFail bool) (map[string]*Key, error) {
+func (ks Keystore) GetKeys(directory, filePrefix, password string, warnOnFail bool) (map[string]*Key, error) {
 	// Load the key from the keystore and decrypt its contents
 	// #nosec G304
 	files, err := ioutil.ReadDir(directory)
@@ -116,7 +116,7 @@ func (ks Store) GetKeys(directory, filePrefix, password string, warnOnFail bool)
 }
 
 // StoreKey in filepath and encrypt it with a password.
-func (ks Store) StoreKey(filename string, key *Key, auth string) error {
+func (ks Keystore) StoreKey(filename string, key *Key, auth string) error {
 	keyJSON, err := EncryptKey(key, auth, ks.scryptN, ks.scryptP)
 	if err != nil {
 		return err
@@ -125,7 +125,7 @@ func (ks Store) StoreKey(filename string, key *Key, auth string) error {
 }
 
 // JoinPath joins the filename with the keystore directory path.
-func (ks Store) JoinPath(filename string) string {
+func (ks Keystore) JoinPath(filename string) string {
 	if filepath.IsAbs(filename) {
 		return filename
 	}

--- a/shared/keystore/keystore_test.go
+++ b/shared/keystore/keystore_test.go
@@ -20,7 +20,7 @@ import (
 func TestStoreAndGetKey(t *testing.T) {
 	tempDir, teardown := setupTempKeystoreDir(t)
 	defer teardown()
-	ks := &Store{
+	ks := &Keystore{
 		keysDirPath: tempDir,
 		scryptN:     LightScryptN,
 		scryptP:     LightScryptP,
@@ -38,7 +38,7 @@ func TestStoreAndGetKey(t *testing.T) {
 func TestStoreAndGetKeys(t *testing.T) {
 	tempDir, teardown := setupTempKeystoreDir(t)
 	defer teardown()
-	ks := &Store{
+	ks := &Keystore{
 		keysDirPath: tempDir,
 		scryptN:     LightScryptN,
 		scryptP:     LightScryptP,
@@ -84,7 +84,7 @@ func TestEncryptDecryptKey(t *testing.T) {
 func TestGetSymlinkedKeys(t *testing.T) {
 	tempDir, teardown := setupTempKeystoreDir(t)
 	defer teardown()
-	ks := &Store{
+	ks := &Keystore{
 		scryptN: LightScryptN,
 		scryptP: LightScryptP,
 	}

--- a/shared/prometheus/logrus_collector_test.go
+++ b/shared/prometheus/logrus_collector_test.go
@@ -24,7 +24,7 @@ type logger interface {
 }
 
 func TestLogrusCollector(t *testing.T) {
-	service := prometheus.NewPrometheusService(addr, nil)
+	service := prometheus.NewService(addr, nil)
 	hook := prometheus.NewLogrusCollector()
 	log.AddHook(hook)
 	go service.Start()

--- a/shared/prometheus/service.go
+++ b/shared/prometheus/service.go
@@ -34,9 +34,9 @@ type Handler struct {
 	Handler func(http.ResponseWriter, *http.Request)
 }
 
-// NewPrometheusService sets up a new instance for a given address host:port.
+// NewService sets up a new instance for a given address host:port.
 // An empty host will match with any IP so an address like ":2121" is perfectly acceptable.
-func NewPrometheusService(addr string, svcRegistry *shared.ServiceRegistry, additionalHandlers ...Handler) *Service {
+func NewService(addr string, svcRegistry *shared.ServiceRegistry, additionalHandlers ...Handler) *Service {
 	s := &Service{svcRegistry: svcRegistry}
 
 	mux := http.NewServeMux()

--- a/shared/prometheus/service_test.go
+++ b/shared/prometheus/service_test.go
@@ -21,7 +21,7 @@ func init() {
 }
 
 func TestLifecycle(t *testing.T) {
-	prometheusService := NewPrometheusService(":2112", nil)
+	prometheusService := NewService(":2112", nil)
 	prometheusService.Start()
 	// Give service time to start.
 	time.Sleep(time.Second)
@@ -60,7 +60,7 @@ func TestHealthz(t *testing.T) {
 	registry := shared.NewServiceRegistry()
 	m := &mockService{}
 	require.NoError(t, registry.RegisterService(m), "Failed to register service")
-	s := NewPrometheusService("" /*addr*/, registry)
+	s := NewService("" /*addr*/, registry)
 
 	req, err := http.NewRequest("GET", "/healthz", nil /*reader*/)
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestContentNegotiation(t *testing.T) {
 		registry := shared.NewServiceRegistry()
 		m := &mockService{}
 		require.NoError(t, registry.RegisterService(m), "Failed to register service")
-		s := NewPrometheusService("", registry)
+		s := NewService("", registry)
 
 		req, err := http.NewRequest("GET", "/healthz", nil /* body */)
 		require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestContentNegotiation(t *testing.T) {
 		m := &mockService{}
 		m.status = errors.New("something is wrong")
 		require.NoError(t, registry.RegisterService(m), "Failed to register service")
-		s := NewPrometheusService("", registry)
+		s := NewService("", registry)
 
 		req, err := http.NewRequest("GET", "/healthz", nil /* body */)
 		require.NoError(t, err)

--- a/slasher/beaconclient/service.go
+++ b/slasher/beaconclient/service.go
@@ -75,8 +75,8 @@ type Config struct {
 	NodeClient            ethpb.NodeClient
 }
 
-// NewBeaconClientService instantiation.
-func NewBeaconClientService(ctx context.Context, cfg *Config) (*Service, error) {
+// NewService instantiation.
+func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	_ = cancel // govet fix for lost cancel. Cancel is handled in service.Stop()
 	publicKeyCache, err := cache.NewPublicKeyCache(0, nil)

--- a/slasher/detection/service.go
+++ b/slasher/detection/service.go
@@ -76,8 +76,8 @@ type Config struct {
 	HistoricalDetection   bool
 }
 
-// NewDetectionService instantiation.
-func NewDetectionService(ctx context.Context, cfg *Config) *Service {
+// NewService instantiation.
+func NewService(ctx context.Context, cfg *Config) *Service {
 	ctx, cancel := context.WithCancel(ctx)
 	return &Service{
 		ctx:                   ctx,

--- a/slasher/node/node.go
+++ b/slasher/node/node.go
@@ -225,7 +225,7 @@ func (s *SlasherNode) registerDetectionService() error {
 	if err := s.services.FetchService(&bs); err != nil {
 		panic(err)
 	}
-	ds := detection.NewDetectionService(s.ctx, &detection.Config{
+	ds := detection.NewService(s.ctx, &detection.Config{
 		Notifier:              bs,
 		SlasherDB:             s.db,
 		BeaconClient:          bs,

--- a/slasher/node/node.go
+++ b/slasher/node/node.go
@@ -155,7 +155,7 @@ func (s *SlasherNode) Close() {
 }
 
 func (s *SlasherNode) registerPrometheusService() error {
-	service := prometheus.NewPrometheusService(
+	service := prometheus.NewService(
 		fmt.Sprintf("%s:%d", s.cliCtx.String(cmd.MonitoringHostFlag.Name), s.cliCtx.Int(flags.MonitoringPortFlag.Name)),
 		s.services,
 	)

--- a/slasher/node/node.go
+++ b/slasher/node/node.go
@@ -207,7 +207,7 @@ func (s *SlasherNode) registerBeaconClientService() error {
 		beaconProvider = flags.BeaconRPCProviderFlag.Value
 	}
 
-	bs, err := beaconclient.NewBeaconClientService(s.ctx, &beaconclient.Config{
+	bs, err := beaconclient.NewService(s.ctx, &beaconclient.Config{
 		BeaconCert:            beaconCert,
 		SlasherDB:             s.db,
 		BeaconProvider:        beaconProvider,

--- a/slasher/rpc/server_test.go
+++ b/slasher/rpc/server_test.go
@@ -63,7 +63,7 @@ func TestServer_IsSlashableAttestation(t *testing.T) {
 
 	bcCfg := &beaconclient.Config{BeaconClient: bClient, NodeClient: nClient, SlasherDB: db}
 	bs, err := beaconclient.NewService(ctx, bcCfg)
-	ds := detection.NewDetectionService(ctx, cfg)
+	ds := detection.NewService(ctx, cfg)
 	server := Server{ctx: ctx, detector: ds, slasherDB: db, beaconClient: bs}
 	nClient.EXPECT().GetGenesis(gomock.Any(), gomock.Any()).Return(wantedGenesis, nil).AnyTimes()
 	bClient.EXPECT().ListValidators(
@@ -165,7 +165,7 @@ func TestServer_IsSlashableAttestationNoUpdate(t *testing.T) {
 
 	bcCfg := &beaconclient.Config{BeaconClient: bClient, NodeClient: nClient, SlasherDB: db}
 	bs, err := beaconclient.NewService(ctx, bcCfg)
-	ds := detection.NewDetectionService(ctx, cfg)
+	ds := detection.NewService(ctx, cfg)
 	server := Server{ctx: ctx, detector: ds, slasherDB: db, beaconClient: bs}
 	slashings, err := server.IsSlashableAttestation(ctx, savedAttestation)
 	require.NoError(t, err, "Got error while trying to detect slashing")
@@ -223,7 +223,7 @@ func TestServer_IsSlashableBlock(t *testing.T) {
 
 	bcCfg := &beaconclient.Config{BeaconClient: bClient, NodeClient: nClient, SlasherDB: db}
 	bs, err := beaconclient.NewService(ctx, bcCfg)
-	ds := detection.NewDetectionService(ctx, cfg)
+	ds := detection.NewService(ctx, cfg)
 	server := Server{ctx: ctx, detector: ds, slasherDB: db, beaconClient: bs}
 
 	wg := sync.WaitGroup{}
@@ -311,7 +311,7 @@ func TestServer_IsSlashableBlockNoUpdate(t *testing.T) {
 	savedBlock.Signature = marshalledSig
 	bcCfg := &beaconclient.Config{BeaconClient: bClient, NodeClient: nClient, SlasherDB: db}
 	bs, err := beaconclient.NewService(ctx, bcCfg)
-	ds := detection.NewDetectionService(ctx, cfg)
+	ds := detection.NewService(ctx, cfg)
 	server := Server{ctx: ctx, detector: ds, slasherDB: db, beaconClient: bs}
 	slashings, err := server.IsSlashableBlock(ctx, savedBlock)
 	require.NoError(t, err, "Got error while trying to detect slashing")

--- a/slasher/rpc/server_test.go
+++ b/slasher/rpc/server_test.go
@@ -62,7 +62,7 @@ func TestServer_IsSlashableAttestation(t *testing.T) {
 	require.NoError(t, err)
 
 	bcCfg := &beaconclient.Config{BeaconClient: bClient, NodeClient: nClient, SlasherDB: db}
-	bs, err := beaconclient.NewBeaconClientService(ctx, bcCfg)
+	bs, err := beaconclient.NewService(ctx, bcCfg)
 	ds := detection.NewDetectionService(ctx, cfg)
 	server := Server{ctx: ctx, detector: ds, slasherDB: db, beaconClient: bs}
 	nClient.EXPECT().GetGenesis(gomock.Any(), gomock.Any()).Return(wantedGenesis, nil).AnyTimes()
@@ -164,7 +164,7 @@ func TestServer_IsSlashableAttestationNoUpdate(t *testing.T) {
 	savedAttestation.Signature = marshalledSig
 
 	bcCfg := &beaconclient.Config{BeaconClient: bClient, NodeClient: nClient, SlasherDB: db}
-	bs, err := beaconclient.NewBeaconClientService(ctx, bcCfg)
+	bs, err := beaconclient.NewService(ctx, bcCfg)
 	ds := detection.NewDetectionService(ctx, cfg)
 	server := Server{ctx: ctx, detector: ds, slasherDB: db, beaconClient: bs}
 	slashings, err := server.IsSlashableAttestation(ctx, savedAttestation)
@@ -222,7 +222,7 @@ func TestServer_IsSlashableBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	bcCfg := &beaconclient.Config{BeaconClient: bClient, NodeClient: nClient, SlasherDB: db}
-	bs, err := beaconclient.NewBeaconClientService(ctx, bcCfg)
+	bs, err := beaconclient.NewService(ctx, bcCfg)
 	ds := detection.NewDetectionService(ctx, cfg)
 	server := Server{ctx: ctx, detector: ds, slasherDB: db, beaconClient: bs}
 
@@ -310,7 +310,7 @@ func TestServer_IsSlashableBlockNoUpdate(t *testing.T) {
 	marshalledSig := blockSig.Marshal()
 	savedBlock.Signature = marshalledSig
 	bcCfg := &beaconclient.Config{BeaconClient: bClient, NodeClient: nClient, SlasherDB: db}
-	bs, err := beaconclient.NewBeaconClientService(ctx, bcCfg)
+	bs, err := beaconclient.NewService(ctx, bcCfg)
 	ds := detection.NewDetectionService(ctx, cfg)
 	server := Server{ctx: ctx, detector: ds, slasherDB: db, beaconClient: bs}
 	slashings, err := server.IsSlashableBlock(ctx, savedBlock)

--- a/tools/sendDepositTx/sendDeposits.go
+++ b/tools/sendDepositTx/sendDeposits.go
@@ -177,7 +177,7 @@ func main() {
 			validatorKeys[hex.EncodeToString(validatorKey.PublicKey.Marshal())] = validatorKey
 		} else {
 			// Load from keystore
-			store := prysmKeyStore.NewKeystore(prysmKeystorePath)
+			store := prysmKeyStore.New(prysmKeystorePath)
 			rawPassword := loadTextFromFile(passwordFile)
 			prefix := params.BeaconConfig().ValidatorPrivkeyFileName
 			validatorKeys, err = store.GetKeys(prysmKeystorePath, prefix, rawPassword, false /* warnOnFail */)

--- a/validator/accounts/v1/account.go
+++ b/validator/accounts/v1/account.go
@@ -33,7 +33,7 @@ var errFailedToCloseManyDb = errors.New("failed to close one or more databases")
 // DecryptKeysFromKeystore extracts a set of validator private keys from
 // an encrypted keystore directory and a password string.
 func DecryptKeysFromKeystore(directory string, filePrefix string, password string) (map[string]*keystore.Key, error) {
-	ks := keystore.NewKeystore(directory)
+	ks := keystore.New(directory)
 	validatorKeys, err := ks.GetKeys(directory, filePrefix, password, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get private key")
@@ -51,7 +51,7 @@ func VerifyAccountNotExists(directory string, password string) error {
 	validatorKeyFile := params.BeaconConfig().ValidatorPrivkeyFileName
 	// First, if the keystore already exists, throws an error as there can only be
 	// one keystore per validator client.
-	ks := keystore.NewKeystore(directory)
+	ks := keystore.New(directory)
 	if _, err := ks.GetKeys(directory, shardWithdrawalKeyFile, password, false); err == nil {
 		return fmt.Errorf("keystore at path already exists: %s", shardWithdrawalKeyFile)
 	}
@@ -72,7 +72,7 @@ func NewValidatorAccount(directory string, password string) error {
 	log.Info(`Thanks, we are generating your keystore now, this could take a while...`)
 	shardWithdrawalKeyFile := directory + params.BeaconConfig().WithdrawalPrivkeyFileName
 	validatorKeyFile := directory + params.BeaconConfig().ValidatorPrivkeyFileName
-	ks := keystore.NewKeystore(directory)
+	ks := keystore.New(directory)
 	// If the keystore does not exists at the path, we create a new one for the validator.
 	shardWithdrawalKey, err := keystore.NewKey()
 	if err != nil {
@@ -325,7 +325,7 @@ func changePasswordForKeyType(keystorePath string, filePrefix string, oldPasswor
 		return errors.Wrap(err, "failed to decrypt keys")
 	}
 
-	keyStore := keystore.NewKeystore(keystorePath)
+	keyStore := keystore.New(keystorePath)
 	for _, key := range keys {
 		keyFileName := keystorePath + filePrefix + hex.EncodeToString(key.PublicKey.Marshal())[:12]
 		if err := keyStore.StoreKey(keyFileName, key, newPassword); err != nil {

--- a/validator/accounts/v1/account_test.go
+++ b/validator/accounts/v1/account_test.go
@@ -38,7 +38,7 @@ func TestNewValidatorAccount_AccountExists(t *testing.T) {
 	}()
 	validatorKey, err := keystore.NewKey()
 	require.NoError(t, err, "Cannot create new key")
-	ks := keystore.NewKeystore(directory)
+	ks := keystore.New(directory)
 	err = ks.StoreKey(directory+params.BeaconConfig().ValidatorPrivkeyFileName, validatorKey, "")
 	require.NoError(t, err, "Unable to store key")
 	require.NoError(t, NewValidatorAccount(directory, "passsword123"), "Should support multiple keys")
@@ -110,7 +110,7 @@ func TestChangePassword_KeyEncryptedWithNewPassword(t *testing.T) {
 
 	validatorKey, err := keystore.NewKey()
 	require.NoError(t, err, "Cannot create new key")
-	ks := keystore.NewKeystore(directory)
+	ks := keystore.New(directory)
 	err = ks.StoreKey(directory+params.BeaconConfig().ValidatorPrivkeyFileName, validatorKey, oldPassword)
 	require.NoError(t, err, "Unable to store key")
 
@@ -134,7 +134,7 @@ func TestChangePassword_KeyNotMatchingOldPasswordNotEncryptedWithNewPassword(t *
 
 	validatorKey, err := keystore.NewKey()
 	require.NoError(t, err, "Cannot create new key")
-	ks := keystore.NewKeystore(directory)
+	ks := keystore.New(directory)
 	err = ks.StoreKey(directory+params.BeaconConfig().ValidatorPrivkeyFileName, validatorKey, "notmatching")
 	require.NoError(t, err, "Unable to store key")
 

--- a/validator/accounts/v2/accounts_import.go
+++ b/validator/accounts/v2/accounts_import.go
@@ -82,7 +82,7 @@ func ImportAccountsCli(cliCtx *cli.Context) error {
 		if err != nil {
 			return nil, err
 		}
-		w := wallet.NewWallet(&wallet.Config{
+		w := wallet.New(&wallet.Config{
 			KeymanagerKind: cfg.WalletCfg.KeymanagerKind,
 			WalletDir:      cfg.WalletCfg.WalletDir,
 			WalletPassword: cfg.WalletCfg.WalletPassword,

--- a/validator/accounts/v2/wallet/wallet.go
+++ b/validator/accounts/v2/wallet/wallet.go
@@ -89,8 +89,8 @@ type Wallet struct {
 	accountsChangedFeed *event.Feed
 }
 
-// NewWallet creates a struct from config values.
-func NewWallet(cfg *Config) *Wallet {
+// New creates a struct from config values.
+func New(cfg *Config) *Wallet {
 	accountsPath := filepath.Join(cfg.WalletDir, cfg.KeymanagerKind.String())
 	return &Wallet{
 		walletDir:      cfg.WalletDir,

--- a/validator/accounts/v2/wallet_create.go
+++ b/validator/accounts/v2/wallet_create.go
@@ -65,7 +65,7 @@ func CreateWalletWithKeymanager(ctx context.Context, cfg *CreateWalletConfig) (*
 			return nil, errors.Wrap(err, "could not check if wallet exists")
 		}
 	}
-	w := wallet.NewWallet(&wallet.Config{
+	w := wallet.New(&wallet.Config{
 		WalletDir:      cfg.WalletCfg.WalletDir,
 		KeymanagerKind: cfg.WalletCfg.KeymanagerKind,
 		WalletPassword: cfg.WalletCfg.WalletPassword,

--- a/validator/accounts/v2/wallet_create_test.go
+++ b/validator/accounts/v2/wallet_create_test.go
@@ -134,7 +134,7 @@ func TestCreateOrOpenWallet(t *testing.T) {
 		if err != nil {
 			return nil, err
 		}
-		w := wallet.NewWallet(&wallet.Config{
+		w := wallet.New(&wallet.Config{
 			KeymanagerKind: cfg.WalletCfg.KeymanagerKind,
 			WalletDir:      cfg.WalletCfg.WalletDir,
 			WalletPassword: cfg.WalletCfg.WalletPassword,
@@ -266,7 +266,7 @@ func TestCorrectPassphrase_Derived(t *testing.T) {
 	_, err := CreateAndSaveWalletCli(cliCtx)
 	require.Equal(t, nil, err, "error in CreateAndSaveWalletCli()")
 
-	w := wallet.NewWallet(&wallet.Config{
+	w := wallet.New(&wallet.Config{
 		WalletDir:      walletDir,
 		KeymanagerKind: v2keymanager.Derived,
 	})

--- a/validator/accounts/v2/wallet_recover.go
+++ b/validator/accounts/v2/wallet_recover.go
@@ -84,7 +84,7 @@ func RecoverWalletCli(cliCtx *cli.Context) error {
 
 // RecoverWallet uses a menmonic seed phrase to recover a wallet into the path provided.
 func RecoverWallet(ctx context.Context, cfg *RecoverWalletConfig) (*wallet.Wallet, error) {
-	w := wallet.NewWallet(&wallet.Config{
+	w := wallet.New(&wallet.Config{
 		WalletDir:      cfg.WalletDir,
 		KeymanagerKind: v2keymanager.Derived,
 		WalletPassword: cfg.WalletPassword,

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -363,7 +363,7 @@ func (s *ValidatorClient) registerSlasherClientService() error {
 	maxCallRecvMsgSize := s.cliCtx.Int(cmd.GrpcMaxCallRecvMsgSizeFlag.Name)
 	grpcRetries := s.cliCtx.Uint(flags.GrpcRetriesFlag.Name)
 	grpcRetryDelay := s.cliCtx.Duration(flags.GrpcRetryDelayFlag.Name)
-	sp, err := slashing_protection.NewSlashingProtectionService(s.cliCtx.Context, &slashing_protection.Config{
+	sp, err := slashing_protection.NewService(s.cliCtx.Context, &slashing_protection.Config{
 		Endpoint:                   endpoint,
 		CertFlag:                   cert,
 		GrpcMaxCallRecvMsgSizeFlag: maxCallRecvMsgSize,

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -303,7 +303,7 @@ func (s *ValidatorClient) initializeForWeb(cliCtx *cli.Context) error {
 }
 
 func (s *ValidatorClient) registerPrometheusService() error {
-	service := prometheus.NewPrometheusService(
+	service := prometheus.NewService(
 		fmt.Sprintf("%s:%d", s.cliCtx.String(cmd.MonitoringHostFlag.Name), s.cliCtx.Int(flags.MonitoringPortFlag.Name)),
 		s.services,
 	)

--- a/validator/slashing-protection/slasher_client.go
+++ b/validator/slashing-protection/slasher_client.go
@@ -46,9 +46,9 @@ type Config struct {
 	GrpcHeadersFlag            string
 }
 
-// NewSlashingProtectionService creates a new validator service for the service
+// NewService creates a new validator service for the service
 // registry.
-func NewSlashingProtectionService(ctx context.Context, cfg *Config) (*Service, error) {
+func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	return &Service{
 		ctx:                ctx,


### PR DESCRIPTION
**What type of PR is this?**

> Other / Better naming for initializing funcs

**What does this PR do? Why is it needed?**
- A package name and its contents' names are coupled, since client code uses them together. Therefore, conventionally, we prefer the following:
  - `initsync.NewService()` instead of `initsync.NewInitSyncService()` (both to avoid stuttering and because when some constructor returns type `T`, if type doesn't coincide with package name it is conventional to name it `NewT()`, not `NewSomePartOfPackageNameT()`). For the most of our services, we do indeed have `service.NewService()` - for those diverging, this PR provides a fix.
  - When package name and returned type do indeed coincide, the conventional naming is just `New()`. That's instead of `wallet.NewWallet()` (for function that returns `*Wallet` i.e. name of returned type and package coincide), we'd prefer `wallet.New()` (and expect it return `Wallet` or `*Wallet). This PR fixes number of such occurrences.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- For more info, please, see https://blog.golang.org/package-names
