### PR TITLE
Fix Bazel Reference For Go-Ethereum

### DIFF
--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -83,6 +83,7 @@ go_test(
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
+        "@com_github_ethereum_go_ethereum//trie:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",

--- a/beacon-chain/powchain/block_reader_test.go
+++ b/beacon-chain/powchain/block_reader_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/trie"
 	dbutil "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	mockPOW "github.com/prysmaticlabs/prysm/beacon-chain/powchain/testing"
 	contracts "github.com/prysmaticlabs/prysm/contracts/deposit-contract"
@@ -117,6 +118,7 @@ func TestBlockExists_ValidHash(t *testing.T) {
 		[]*gethTypes.Transaction{},
 		[]*gethTypes.Header{},
 		[]*gethTypes.Receipt{},
+		new(trie.Trie),
 	)
 
 	exists, height, err := web3Service.BlockExists(context.Background(), block.Hash())

--- a/deps.bzl
+++ b/deps.bzl
@@ -54,15 +54,15 @@ def prysm_deps():
         build_file_generation = "off",
         importpath = "github.com/prysmaticlabs/bazel-go-ethereum",
         replace = "github.com/ethereum/go-ethereum",
-        sum = "h1:9JrPtwqCvV38DXYaHbB855KUIHYMwjJBE88lL8lMu8Q=",
-        version = "v0.0.0-20200626171358-a933315235ec",
+        sum = "h1:yoOj4FD6uNdWDjgZqlKGxmUYnR6tI9zN1NrE8tJ3/xE=",
+        version = "v0.0.0-20200922100503-3794d0d7ca25",
     )
 
     # Note: It is required to define com_github_ethereum_go_ethereum like this for some reason...
     # Note: The keep directives help gazelle leave this alone.
     go_repository(
         name = "com_github_ethereum_go_ethereum",
-        commit = "82ea6953710decd73e89ca368c309e732233e39a",  # keep
+        commit = "3794d0d7ca257542c40a8c55e35fe218cc216717",  # keep
         importpath = "github.com/ethereum/go-ethereum",  # keep
         # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
         # a fork that has resolved these issues by disabling HID/USB support and


### PR DESCRIPTION
**What type of PR is this?**

Update Dependency

**What does this PR do? Why is it needed?**

- [x] Updates Go-ethereum dependency in bazel, which was missing from #7303 . The previous PR only 
updated for our `go.mod` file and its related transitive deps.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
