### PR TITLE
Fix Change Wallet Password Logic

### DIFF
--- a/validator/keymanager/v2/direct/BUILD.bazel
+++ b/validator/keymanager/v2/direct/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//shared/interop:go_default_library",
         "//shared/params:go_default_library",
         "//shared/petnames:go_default_library",
-        "//shared/promptutil:go_default_library",
         "//validator/accounts/v2/iface:go_default_library",
         "//validator/keymanager/v2:go_default_library",
         "@com_github_fsnotify_fsnotify//:go_default_library",

--- a/validator/rpc/auth.go
+++ b/validator/rpc/auth.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/dgrijalva/jwt-go"
@@ -67,7 +68,10 @@ func (s *Server) Login(ctx context.Context, req *pb.AuthRequest) (*pb.AuthRespon
 		WalletDir:      defaultWalletPath,
 		WalletPassword: req.Password,
 	}); err != nil {
-		return nil, status.Error(codes.Internal, "Could not initialize wallet")
+		if strings.Contains(err.Error(), "invalid checksum") {
+			return nil, status.Error(codes.Unauthenticated, "Incorrect password")
+		}
+		return nil, status.Errorf(codes.Internal, "Could not initialize wallet: %v", err)
 	}
 	return s.sendAuthResponse()
 }

--- a/validator/rpc/wallet.go
+++ b/validator/rpc/wallet.go
@@ -165,6 +165,9 @@ func (s *Server) ChangePassword(ctx context.Context, req *pb.ChangePasswordReque
 			return nil, status.Error(codes.FailedPrecondition, "Not a valid direct keymanager")
 		}
 		s.wallet.SetPassword(req.Password)
+		if err := s.wallet.SaveHashedPassword(ctx); err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not save hashed password: %v", err)
+		}
 		if err := km.RefreshWalletPassword(ctx); err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not refresh wallet password: %v", err)
 		}
@@ -174,6 +177,9 @@ func (s *Server) ChangePassword(ctx context.Context, req *pb.ChangePasswordReque
 			return nil, status.Error(codes.FailedPrecondition, "Not a valid derived keymanager")
 		}
 		s.wallet.SetPassword(req.Password)
+		if err := s.wallet.SaveHashedPassword(ctx); err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not save hashed password: %v", err)
+		}
 		if err := km.RefreshWalletPassword(ctx); err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not refresh wallet password: %v", err)
 		}


### PR DESCRIPTION
This PR ensures the change wallet password logic functionality works by storing the new bcrypt hash in the wallet path upon modification