### PR TITLE
Revert 7242: Opt out --use-check-point-cache

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -262,10 +262,9 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.Warn("Enabling peer scoring in P2P")
 		cfg.EnablePeerScorer = true
 	}
-	cfg.UseCheckPointInfoCache = true
-	if ctx.Bool(disableCheckPtInfoCache.Name) {
-		log.Warn("Disabling advanced check point info cache")
-		cfg.UseCheckPointInfoCache = false
+	if ctx.Bool(checkPtInfoCache.Name) {
+		log.Warn("Using advance check point info cache")
+		cfg.UseCheckPointInfoCache = true
 	}
 	if ctx.Bool(enableBlst.Name) {
 		log.Warn("Enabling new BLS library blst")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -170,14 +170,15 @@ var (
 		Name:  "enable-peer-scorer",
 		Usage: "Enable experimental P2P peer scorer",
 	}
-	disableCheckPtInfoCache = &cli.BoolFlag{
-		Name:  "disable-check-point-cache",
-		Usage: "Disables check point info caching",
+	checkPtInfoCache = &cli.BoolFlag{
+		Name:  "use-check-point-cache",
+		Usage: "Enables check point info caching",
 	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
+	checkPtInfoCache,
 	enableEth1DataMajorityVote,
 	enableAttBroadcastDiscoveryAttempts,
 	enablePeerScorer,
@@ -553,11 +554,6 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
-	deprecatedCheckptInfoCache = &cli.BoolFlag{
-		Name:   "use-check-point-cache",
-		Usage:  deprecatedUsage,
-		Hidden: true,
-	}
 	deprecatedBatchBlockVerify = &cli.BoolFlag{
 		Name:   "batch-block-verify",
 		Usage:  deprecatedUsage,
@@ -644,7 +640,6 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedSlasherProviderFlag,
 	deprecatedEnableSlasherFlag,
 	deprecatedEnableFinalizedDepositsCache,
-	deprecatedCheckptInfoCache,
 	deprecatedBatchBlockVerify,
 	deprecatedEnableRoughtime,
 }
@@ -706,7 +701,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	enableEth1DataMajorityVote,
 	enableAttBroadcastDiscoveryAttempts,
 	enablePeerScorer,
-	disableCheckPtInfoCache,
+	checkPtInfoCache,
 }...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
This PR reverts #7242. Users reported memory spikes. Let's revert it in the mean time we dive deep into this.

Unfortunately i could not auto revert due to merge conflict