### PR TITLE
Reset hot state cache size to 32

### DIFF
--- a/beacon-chain/cache/hot_state_cache.go
+++ b/beacon-chain/cache/hot_state_cache.go
@@ -11,7 +11,7 @@ import (
 
 var (
 	// hotStateCacheSize defines the max number of hot state this can cache.
-	hotStateCacheSize = 16
+	hotStateCacheSize = 32
 	// Metrics
 	hotStateCacheHit = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "hot_state_cache_hit",


### PR DESCRIPTION
#7098 mistakenly reset hot state cache size from 32 to 16, this PR reverted that line of change.

This could be the reason and the fix for #7279 