### PR TITLE
Disable Libp2p Protocols

### DIFF
--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -48,7 +48,9 @@ func (s *Service) buildOptions(ip net.IP, priKey *ecdsa.PrivateKey) []libp2p.Opt
 	}
 	if cfg.RelayNodeAddr != "" {
 		options = append(options, libp2p.AddrsFactory(withRelayAddrs(cfg.RelayNodeAddr)))
-		options = append(options, libp2p.EnableRelay())
+	} else {
+		// Disable relay if it has not been set.
+		options = append(options, libp2p.DisableRelay())
 	}
 	if cfg.HostAddress != "" {
 		options = append(options, libp2p.AddrsFactory(func(addrs []ma.Multiaddr) []ma.Multiaddr {
@@ -72,6 +74,8 @@ func (s *Service) buildOptions(ip net.IP, priKey *ecdsa.PrivateKey) []libp2p.Opt
 			return addrs
 		}))
 	}
+	// Disable Ping Service.
+	options = append(options, libp2p.Ping(false))
 	return options
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Feature Removal

**What does this PR do? Why is it needed?**

- [x] Removes unecessary libp2p services from being instantiated, it removes the relay service and ping service from being
instantiated in the event it is not set. This is to reduce the burden on stream handling for the node.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
