### PR TITLE
Display More Info for Validating Keys on Startup

### DIFF
--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -210,6 +211,8 @@ func (v *ValidatorService) Status() error {
 }
 
 func (v *ValidatorService) recheckKeys(ctx context.Context) {
+	var validatingKeys [][48]byte
+	var err error
 	if featureconfig.Get().EnableAccountsV2 {
 		if v.useWeb {
 			initializedChan := make(chan *wallet.Wallet)
@@ -224,7 +227,7 @@ func (v *ValidatorService) recheckKeys(ctx context.Context) {
 			}
 			v.keyManagerV2 = keyManagerV2
 		}
-		validatingKeys, err := v.keyManagerV2.FetchValidatingPublicKeys(ctx)
+		validatingKeys, err = v.keyManagerV2.FetchValidatingPublicKeys(ctx)
 		if err != nil {
 			log.WithError(err).Debug("Could not fetch validating keys")
 		}
@@ -233,13 +236,18 @@ func (v *ValidatorService) recheckKeys(ctx context.Context) {
 		}
 		go recheckValidatingKeysBucket(ctx, v.db, v.keyManagerV2)
 	} else {
-		validatingKeys, err := v.keyManager.FetchValidatingKeys()
+		validatingKeys, err = v.keyManager.FetchValidatingKeys()
 		if err != nil {
 			log.WithError(err).Debug("Could not fetch validating keys")
 		}
 		if err := v.db.UpdatePublicKeysBuckets(validatingKeys); err != nil {
 			log.WithError(err).Debug("Could not update public keys buckets")
 		}
+	}
+	for _, key := range validatingKeys {
+		log.WithField(
+			"publicKey", fmt.Sprintf("%#x", bytesutil.Trunc(key[:])),
+		).Info("Validating for public key")
 	}
 }
 

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -174,6 +174,10 @@ func (s *ValidatorClient) initializeFromCLI(cliCtx *cli.Context) error {
 				return errors.Wrap(err, "could not open wallet")
 			}
 			s.wallet = w
+			log.WithFields(logrus.Fields{
+				"wallet":          w.AccountsDir(),
+				"keymanager-kind": w.KeymanagerKind().String(),
+			}).Info("Opened validator wallet")
 			keyManagerV2, err = w.InitializeKeymanager(
 				cliCtx.Context, false, /* skipMnemonicConfirm */
 			)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Currently, starting a validator client did not offer any visual feedback to the user for their wallet nor their validating keys. This PR adds more detailed logging:

```
[2020-09-25 12:20:28]  INFO node: Opened validator wallet keymanager-kind=derived wallet=/Users/me/Library/Eth2Validators/prysm-wallet-v2/derived
[2020-09-25 12:20:28]  INFO validator: Waiting for beacon chain start log from the ETH 1.0 deposit contract
[2020-09-25 12:20:28]  INFO validator: Beacon chain started genesisTime=2020-08-04 08:00:08 -0500 CDT
[2020-09-25 12:20:28]  INFO validator: Validating for public key publicKey=0x97558e9caf74
[2020-09-25 12:20:28]  INFO validator: Validating for public key publicKey=0xa5a1a09918d2
[2020-09-25 12:20:28]  INFO validator: Validating for public key publicKey=0x9375f594151d
```

**Which issues(s) does this PR fix?**

Fixes #7319