### PR TITLE
Warn About Deprecation of Accounts-V1 Within the Next 2 Releases

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -322,6 +322,11 @@ func ConfigureValidator(ctx *cli.Context) {
 	cfg.EnableAccountsV2 = true
 	if ctx.Bool(disableAccountsV2.Name) {
 		log.Warn("Disabling v2 of Prysm validator accounts")
+		log.Error(
+			"Accounts v1 will be fully deprecated in Prysm within the next 2 releases! If you are still " +
+				"using this functionality, please begin to upgrade by creating a v2 wallet. More information can be " +
+				"found in our docs portal https://docs.prylabs.network/docs/wallet/introduction/",
+		)
 		cfg.EnableAccountsV2 = false
 	}
 	if ctx.Bool(enableExternalSlasherProtectionFlag.Name) {


### PR DESCRIPTION
This PR adds a log warning the user that accounts-v2 will be deprecated soon and they must upgrade to accounts-v2 within the next 2 releases. At that point, accounts-v2 will become the only supported mechanism. For mainnet, we will likely rename the command to simply: `accounts`