### PR TITLE
Fix panic that happens if you wallet-v2 recover 1 account

### DIFF
--- a/validator/accounts/v2/wallet_recover.go
+++ b/validator/accounts/v2/wallet_recover.go
@@ -114,7 +114,7 @@ func RecoverWallet(ctx context.Context, cfg *RecoverWalletConfig) (*wallet.Walle
 		if _, err := km.CreateAccount(ctx, true /*logAccountInfo*/); err != nil {
 			return nil, errors.Wrap(err, "could not create account in wallet")
 		}
-		return nil, nil
+		return w, nil
 	}
 	for i := int64(0); i < cfg.NumAccounts; i++ {
 		if _, err := km.CreateAccount(ctx, false /*logAccountInfo*/); err != nil {

--- a/validator/accounts/v2/wallet_recover_test.go
+++ b/validator/accounts/v2/wallet_recover_test.go
@@ -81,3 +81,42 @@ func TestRecoverDerivedWallet(t *testing.T) {
 	require.Equal(t, len(names), int(numAccounts))
 
 }
+
+// TestRecoverDerivedWallet_OneAccount is a test for regression in cases where the number of accounts recovered is 1
+func TestRecoverDerivedWallet_OneAccount(t *testing.T) {
+	testDir := testutil.TempDir()
+	walletDir := filepath.Join(testDir, walletDirName)
+	exportDir := filepath.Join(testDir, exportDirName)
+	defer func() {
+		assert.NoError(t, os.RemoveAll(walletDir))
+		assert.NoError(t, os.RemoveAll(exportDir))
+	}()
+
+	passwordFilePath := filepath.Join(testDir, passwordFileName)
+	require.NoError(t, ioutil.WriteFile(passwordFilePath, []byte(password), os.ModePerm))
+	mnemonicFilePath := filepath.Join(testDir, mnemonicFileName)
+	require.NoError(t, ioutil.WriteFile(mnemonicFilePath, []byte(mnemonic), os.ModePerm))
+
+	numAccounts := int64(1)
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	set.String(flags.WalletDirFlag.Name, walletDir, "")
+	set.String(flags.WalletPasswordFileFlag.Name, passwordFilePath, "")
+	set.String(flags.KeymanagerKindFlag.Name, v2keymanager.Derived.String(), "")
+	set.String(flags.MnemonicFileFlag.Name, mnemonicFilePath, "")
+	set.Int64(flags.NumAccountsFlag.Name, numAccounts, "")
+	assert.NoError(t, set.Set(flags.WalletDirFlag.Name, walletDir))
+	assert.NoError(t, set.Set(flags.WalletPasswordFileFlag.Name, passwordFilePath))
+	assert.NoError(t, set.Set(flags.KeymanagerKindFlag.Name, v2keymanager.Derived.String()))
+	assert.NoError(t, set.Set(flags.MnemonicFileFlag.Name, mnemonicFilePath))
+	assert.NoError(t, set.Set(flags.NumAccountsFlag.Name, strconv.Itoa(int(numAccounts))))
+	cliCtx := cli.NewContext(&app, set, nil)
+
+	require.NoError(t, RecoverWalletCli(cliCtx))
+
+	_, err := wallet.OpenWallet(cliCtx.Context, &wallet.Config{
+		WalletDir:      walletDir,
+		WalletPassword: password,
+	})
+	assert.NoError(t, err)
+}

--- a/validator/accounts/v2/wallet_recover_test.go
+++ b/validator/accounts/v2/wallet_recover_test.go
@@ -86,10 +86,8 @@ func TestRecoverDerivedWallet(t *testing.T) {
 func TestRecoverDerivedWallet_OneAccount(t *testing.T) {
 	testDir := testutil.TempDir()
 	walletDir := filepath.Join(testDir, walletDirName)
-	exportDir := filepath.Join(testDir, exportDirName)
 	defer func() {
 		assert.NoError(t, os.RemoveAll(walletDir))
-		assert.NoError(t, os.RemoveAll(exportDir))
 	}()
 
 	passwordFilePath := filepath.Join(testDir, passwordFileName)


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix

**What does this PR do? Why is it needed?**
Fixes #7350 :  In the logic, there is differing behavior between if NumAccounts == 1 or !=1 primarily for console output purposes.  But in the case of NumAccounts ==1 there is a return of nil,nil where it should be w, nil instead

**Other notes for review**
None