### PR TITLE
Add New Compiler Flags for BLST

### DIFF
--- a/shared/bls/blst/bls_benchmark_test.go
+++ b/shared/bls/blst/bls_benchmark_test.go
@@ -5,43 +5,12 @@ package blst_test
 import (
 	"testing"
 
-	"github.com/herumi/bls-eth-go-binary/bls"
-	"github.com/prysmaticlabs/prysm/shared/bls/herumi"
+	"github.com/prysmaticlabs/prysm/shared/bls/blst"
 	"github.com/prysmaticlabs/prysm/shared/bls/iface"
-	"github.com/prysmaticlabs/prysm/shared/hashutil"
 )
 
-func BenchmarkPairing(b *testing.B) {
-	if err := bls.Init(bls.BLS12_381); err != nil {
-		b.Fatal(err)
-	}
-	if err := bls.SetETHmode(bls.EthModeDraft07); err != nil {
-		panic(err)
-	}
-	newGt := &bls.GT{}
-	newG1 := &bls.G1{}
-	newG2 := &bls.G2{}
-
-	newGt.SetInt64(10)
-	hash := hashutil.Hash([]byte{})
-	err := newG1.HashAndMapTo(hash[:])
-	if err != nil {
-		b.Fatal(err)
-	}
-	err = newG2.HashAndMapTo(hash[:])
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	b.ResetTimer()
-	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
-		bls.Pairing(newGt, newG1, newG2)
-	}
-
-}
 func BenchmarkSignature_Verify(b *testing.B) {
-	sk := herumi.RandKey()
+	sk := blst.RandKey()
 
 	msg := []byte("Some msg")
 	sig := sk.Sign(msg)
@@ -62,13 +31,13 @@ func BenchmarkSignature_AggregateVerify(b *testing.B) {
 	var msgs [][32]byte
 	for i := 0; i < sigN; i++ {
 		msg := [32]byte{'s', 'i', 'g', 'n', 'e', 'd', byte(i)}
-		sk := herumi.RandKey()
+		sk := blst.RandKey()
 		sig := sk.Sign(msg[:])
 		pks = append(pks, sk.PublicKey())
 		sigs = append(sigs, sig)
 		msgs = append(msgs, msg)
 	}
-	aggregated := herumi.Aggregate(sigs)
+	aggregated := blst.Aggregate(sigs)
 
 	b.ResetTimer()
 	b.ReportAllocs()
@@ -80,12 +49,12 @@ func BenchmarkSignature_AggregateVerify(b *testing.B) {
 }
 
 func BenchmarkSecretKey_Marshal(b *testing.B) {
-	key := herumi.RandKey()
+	key := blst.RandKey()
 	d := key.Marshal()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := herumi.SecretKeyFromBytes(d)
+		_, err := blst.SecretKeyFromBytes(d)
 		_ = err
 	}
 }

--- a/third_party/blst/blst.BUILD
+++ b/third_party/blst/blst.BUILD
@@ -13,6 +13,7 @@ go_library(
         "-Ibindings",
         "-Isrc",
         "-D__BLST_PORTABLE__",
+        "-O",
     ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
             "-mno-avx",
@@ -70,6 +71,8 @@ cc_library(
         "build/assembly.S",
     ],
     copts = [
+            "-D__BLST_PORTABLE__",
+            "-O",
     ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
             "-mno-avx",

--- a/third_party/blst/blst.BUILD
+++ b/third_party/blst/blst.BUILD
@@ -12,6 +12,8 @@ go_library(
         "-D__BLST_CGO__",
         "-Ibindings",
         "-Isrc",
+        "-D__BLST_PORTABLE__",
+        "-O",
     ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
             "-mno-avx",

--- a/third_party/blst/blst.BUILD
+++ b/third_party/blst/blst.BUILD
@@ -13,7 +13,6 @@ go_library(
         "-Ibindings",
         "-Isrc",
         "-D__BLST_PORTABLE__",
-        "-O",
     ] + select({
         "@io_bazel_rules_go//go/platform:amd64": [
             "-mno-avx",


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Adds in the required C flags `-D__BLST_PORTABLE__` and `-O` to prevent 
crashes in `x86_64`. 
- [x] Fix Up Benchmarks.

**Which issues(s) does this PR fix?**

Part of #7312 

**Other notes for review**
