### PR TITLE
Fixes NotNil assertion

### DIFF
--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -347,16 +347,15 @@ func TestStore_UpdateCheckpointState(t *testing.T) {
 
 	epoch := uint64(1)
 	baseState, _ := testutil.DeterministicGenesisState(t, 1)
-	require.NoError(t, baseState.SetSlot(epoch*params.BeaconConfig().SlotsPerEpoch))
 	checkpoint := &ethpb.Checkpoint{Epoch: epoch, Root: bytesutil.PadTo([]byte("hi"), 32)}
 	require.NoError(t, service.beaconDB.SaveState(ctx, baseState, bytesutil.ToBytes32(checkpoint.Root)))
 	returned, err := service.getAttPreState(ctx, checkpoint)
 	require.NoError(t, err)
-	assert.Equal(t, returned.Slot(), baseState.Slot(), "Incorrectly returned base state")
+	assert.Equal(t, returned.Slot(), checkpoint.Epoch*params.BeaconConfig().SlotsPerEpoch, "Incorrectly returned base state")
 
 	cached, err := service.checkpointState.StateByCheckpoint(checkpoint)
 	require.NoError(t, err)
-	assert.NotNil(t, cached, "State should have been cached")
+	assert.Equal(t, returned.Slot(), cached.Slot(), "State should have been cached")
 
 	epoch = uint64(2)
 	newCheckpoint := &ethpb.Checkpoint{Epoch: epoch, Root: bytesutil.PadTo([]byte("bye"), 32)}

--- a/shared/testutil/assertions/BUILD.bazel
+++ b/shared/testutil/assertions/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
     deps = [
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -86,7 +86,6 @@ func isNil(obj interface{}) bool {
 	if obj == nil {
 		return true
 	}
-
 	value := reflect.ValueOf(obj)
 	switch value.Kind() {
 	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -74,11 +74,25 @@ func ErrorContains(loggerFn assertionLoggerFn, want string, err error, msg ...in
 
 // NotNil asserts that passed value is not nil.
 func NotNil(loggerFn assertionLoggerFn, obj interface{}, msg ...interface{}) {
-	if obj == nil {
+	if isNil(obj) {
 		errMsg := parseMsg("Unexpected nil value", msg...)
 		_, file, line, _ := runtime.Caller(2)
 		loggerFn("%s:%d %s", filepath.Base(file), line, errMsg)
 	}
+}
+
+// isNil checks that underlying value of obj is nil.
+func isNil(obj interface{}) bool {
+	if obj == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(obj)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		return value.IsNil()
+	}
+	return false
 }
 
 // LogsContain checks whether a given substring is a part of logs. If flag=false, inverse is checked.

--- a/shared/testutil/assertions/assertions_test.go
+++ b/shared/testutil/assertions/assertions_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assertions"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -463,6 +464,7 @@ func Test_NotNil(t *testing.T) {
 		obj  interface{}
 		msgs []interface{}
 	}
+	var nilBlock *eth.SignedBeaconBlock = nil
 	tests := []struct {
 		name        string
 		args        args
@@ -498,6 +500,14 @@ func Test_NotNil(t *testing.T) {
 				obj: "some value",
 			},
 			expectedErr: "",
+		},
+		{
+			name: "nil value of dynamic type",
+			args: args{
+				tb:  &assertions.TBMock{},
+				obj: nilBlock,
+			},
+			expectedErr: "Unexpected nil value",
 		},
 	}
 	for _, tt := range tests {

--- a/shared/testutil/assertions/assertions_test.go
+++ b/shared/testutil/assertions/assertions_test.go
@@ -509,6 +509,13 @@ func Test_NotNil(t *testing.T) {
 			},
 			expectedErr: "Unexpected nil value",
 		},
+		{
+			name: "make sure that assertion works for basic type",
+			args: args{
+				tb:  &assertions.TBMock{},
+				obj: 15,
+			},
+		},
 	}
 	for _, tt := range tests {
 		verify := func() {

--- a/slasher/db/kv/block_header_test.go
+++ b/slasher/db/kv/block_header_test.go
@@ -186,7 +186,8 @@ func TestPruneHistoryBlkHdr(t *testing.T) {
 			require.NotNil(t, bha)
 			require.DeepEqual(t, tt.bh, bha[0], "Should return bh")
 		} else {
-			require.NotNil(t, bha, "Block header should have been pruned")
+			require.Equal(t, 0, len(bha), "Block header should have been pruned")
+			require.DeepEqual(t, []*ethpb.SignedBeaconBlockHeader(nil), bha, "Block header should have been pruned")
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**
- @nisdas has discovered (the hard way, unfortunately) an ugly bug in our `NotNil()` assertion (it didn't fail when pointer with underlying nil value was passed in, as in that case simple `obj == nil` comparison is NOT enough).
- This PR fixes it:
```golang
var nilBlock *eth.SignedBeaconBlock = nil
assert.NotNil(t, nilBlock) // assertion fails
require.NotNil(t, nilBlock) // assertion fails
```

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- This PR also has fixes to two tests `TestStore_UpdateCheckpointState ` and `TestPruneHistoryBlkHdr ` which have been reported as correct only because of a bug in `NotNil()`
