### PR TITLE
Remove unused constant in round robin

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -21,8 +21,6 @@ import (
 const (
 	// counterSeconds is an interval over which an average rate will be calculated.
 	counterSeconds = 20
-	// refreshTime defines an interval at which suitable peer is checked during 2nd phase of sync.
-	refreshTime = 6 * time.Second
 )
 
 // blockReceiverFn defines block receiving function.


### PR DESCRIPTION
**What type of PR is this?**

> Other / Minor cleanup

**What does this PR do? Why is it needed?**
- Since 2nd phase of `init-sync` relies on queue now, `refreshTime` constant is redundant now.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
