### PR TITLE
Remove logging of password if fails

### DIFF
--- a/tools/sendDepositTx/sendDeposits.go
+++ b/tools/sendDepositTx/sendDeposits.go
@@ -182,7 +182,7 @@ func main() {
 			prefix := params.BeaconConfig().ValidatorPrivkeyFileName
 			validatorKeys, err = store.GetKeys(prysmKeystorePath, prefix, rawPassword, false /* warnOnFail */)
 			if err != nil {
-				log.WithField("path", prysmKeystorePath).WithField("password", rawPassword).Errorf("Could not get keys: %v", err)
+				log.WithField("path", prysmKeystorePath).Errorf("Could not get keys: %v", err)
 			}
 		}
 


### PR DESCRIPTION
Within the `sendDeposits` function, the raw password which loaded from a text file for use on the keystore, gets logged on failure. This PR removed the logging of password for security reasons 