### PR TITLE
Add lock around feature config

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -20,6 +20,8 @@ The process for implementing new features using this package is as follows:
 package featureconfig
 
 import (
+	"sync"
+
 	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
@@ -91,9 +93,13 @@ type Flags struct {
 }
 
 var featureConfig *Flags
+var featureConfigLock sync.RWMutex
 
 // Get retrieves feature config.
 func Get() *Flags {
+	featureConfigLock.RLock()
+	defer featureConfigLock.RUnlock()
+
 	if featureConfig == nil {
 		return &Flags{}
 	}
@@ -102,6 +108,9 @@ func Get() *Flags {
 
 // Init sets the global config equal to the config that is passed in.
 func Init(c *Flags) {
+	featureConfigLock.Lock()
+	defer featureConfigLock.Unlock()
+
 	featureConfig = c
 }
 


### PR DESCRIPTION
The feature config variable that points to a Flags struct has no lock around it. This variable is modified in some threads and read in others with no synchronization. Concurrent access to shared resources can lead to undefined behavior and possibly data corruption. This PR added a lock around it