### PR TITLE
Pubsub: fallback to ValidationIgnore in the event of a validation panic

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -164,6 +164,7 @@ go_test(
         "@com_github_kevinms_leakybucket_go//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//:go_default_library",
         "@com_github_libp2p_go_libp2p_core//network:go_default_library",
+        "@com_github_libp2p_go_libp2p_core//peer:go_default_library",
         "@com_github_libp2p_go_libp2p_core//protocol:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//pb:go_default_library",

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -166,8 +166,9 @@ func (s *Service) subscribeWithBase(base proto.Message, topic string, validator 
 // Wrap the pubsub validator with a metric monitoring function. This function increments the
 // appropriate counter if the particular message fails to validate.
 func wrapAndReportValidation(topic string, v pubsub.ValidatorEx) (string, pubsub.ValidatorEx) {
-	return topic, func(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
+	return topic, func(ctx context.Context, pid peer.ID, msg *pubsub.Message) (res pubsub.ValidationResult) {
 		defer messagehandler.HandlePanic(ctx, msg)
+		res = pubsub.ValidationIgnore // Default: ignore any message that panics.
 		ctx, cancel := context.WithTimeout(ctx, pubsubMessageTimeout)
 		defer cancel()
 		messageReceivedCounter.WithLabelValues(topic).Inc()


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The default value for ValidationResult is ValidationAccept.
This is not acceptable when a validation pipeline fails.
This PR sets the default value to ValidationIgnore.

**Which issues(s) does this PR fix?**

No known issue.

**Other notes for review**
