### PR TITLE
Check block attestation length for operation pool

### DIFF
--- a/beacon-chain/operations/attestations/kv/block.go
+++ b/beacon-chain/operations/attestations/kv/block.go
@@ -25,7 +25,7 @@ func (p *AttCaches) SaveBlockAttestation(att *ethpb.Attestation) error {
 
 	// Ensure that this attestation is not already fully contained in an existing attestation.
 	for _, a := range atts {
-		if a.AggregationBits.Contains(att.AggregationBits) {
+		if a.AggregationBits.Len() == att.AggregationBits.Len() && a.AggregationBits.Contains(att.AggregationBits) {
 			return nil
 		}
 	}

--- a/beacon-chain/operations/attestations/kv/block_test.go
+++ b/beacon-chain/operations/attestations/kv/block_test.go
@@ -16,7 +16,8 @@ func TestKV_BlockAttestation_CanSaveRetrieve(t *testing.T) {
 	att1 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 1, BeaconBlockRoot: make([]byte, 32), Target: &ethpb.Checkpoint{Root: make([]byte, 32)}, Source: &ethpb.Checkpoint{Root: make([]byte, 32)}}, AggregationBits: bitfield.Bitlist{0b1101}}
 	att2 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 2, BeaconBlockRoot: make([]byte, 32), Target: &ethpb.Checkpoint{Root: make([]byte, 32)}, Source: &ethpb.Checkpoint{Root: make([]byte, 32)}}, AggregationBits: bitfield.Bitlist{0b1101}}
 	att3 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 3, BeaconBlockRoot: make([]byte, 32), Target: &ethpb.Checkpoint{Root: make([]byte, 32)}, Source: &ethpb.Checkpoint{Root: make([]byte, 32)}}, AggregationBits: bitfield.Bitlist{0b1101}}
-	atts := []*ethpb.Attestation{att1, att2, att3}
+	att4 := &ethpb.Attestation{Data: &ethpb.AttestationData{Slot: 3, BeaconBlockRoot: make([]byte, 32), Target: &ethpb.Checkpoint{Root: make([]byte, 32)}, Source: &ethpb.Checkpoint{Root: make([]byte, 32)}}, AggregationBits: bitfield.Bitlist{0b11011}} // Diff bit length should not panic.
+	atts := []*ethpb.Attestation{att1, att2, att3, att4}
 
 	for _, att := range atts {
 		require.NoError(t, cache.SaveBlockAttestation(att))


### PR DESCRIPTION
If there's block attestations with the same data but different bit lenghts, it will cause panic when inserting block attestations in to operation pool. This PR prevents it by using a length check.