### PR TITLE
Add locks around head getters

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -183,6 +183,9 @@ func (s *Service) HeadGenesisValidatorRoot() [32]byte {
 
 // HeadETH1Data returns the eth1data of the current head state.
 func (s *Service) HeadETH1Data() *ethpb.Eth1Data {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
 	if !s.hasHeadState() {
 		return &ethpb.Eth1Data{}
 	}
@@ -202,6 +205,9 @@ func (s *Service) GenesisTime() time.Time {
 // GenesisValidatorRoot returns the genesis validator
 // root of the chain.
 func (s *Service) GenesisValidatorRoot() [32]byte {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
 	if !s.hasHeadState() {
 		return [32]byte{}
 	}
@@ -210,6 +216,9 @@ func (s *Service) GenesisValidatorRoot() [32]byte {
 
 // CurrentFork retrieves the latest fork information of the beacon chain.
 func (s *Service) CurrentFork() *pb.Fork {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
 	if !s.hasHeadState() {
 		return &pb.Fork{
 			PreviousVersion: params.BeaconConfig().GenesisForkVersion,


### PR DESCRIPTION
Part of #7412 

A few methods in `chain_info` do not have read locks when reading `head` from service store