### PR TITLE
Move read lock after hasHeadState

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -227,7 +227,6 @@ func (s *Service) CurrentFork() *pb.Fork {
 			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
 		}
 	}
-
 	return s.head.state.Fork()
 }
 

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -97,7 +97,7 @@ func (s *Service) PreviousJustifiedCheckpt() *ethpb.Checkpoint {
 
 // HeadSlot returns the slot of the head of the chain.
 func (s *Service) HeadSlot() uint64 {
-	if !s.hasHeadState() {
+	if !s.HasHeadState() {
 		return 0
 	}
 
@@ -131,7 +131,7 @@ func (s *Service) HeadRoot(ctx context.Context) ([]byte, error) {
 // If the head is nil from service struct,
 // it will attempt to get the head block from DB.
 func (s *Service) HeadBlock(ctx context.Context) (*ethpb.SignedBeaconBlock, error) {
-	if s.hasHeadState() {
+	if s.HasHeadState() {
 		return s.headBlock(), nil
 	}
 
@@ -145,7 +145,7 @@ func (s *Service) HeadState(ctx context.Context) (*state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "blockChain.HeadState")
 	defer span.End()
 
-	ok := s.hasHeadState()
+	ok := s.HasHeadState()
 	span.AddAttributes(trace.BoolAttribute("cache_hit", ok))
 
 	if ok {
@@ -157,7 +157,7 @@ func (s *Service) HeadState(ctx context.Context) (*state.BeaconState, error) {
 
 // HeadValidatorsIndices returns a list of active validator indices from the head view of a given epoch.
 func (s *Service) HeadValidatorsIndices(ctx context.Context, epoch uint64) ([]uint64, error) {
-	if !s.hasHeadState() {
+	if !s.HasHeadState() {
 		return []uint64{}, nil
 	}
 	return helpers.ActiveValidatorIndices(s.headState(ctx), epoch)
@@ -165,7 +165,7 @@ func (s *Service) HeadValidatorsIndices(ctx context.Context, epoch uint64) ([]ui
 
 // HeadSeed returns the seed from the head view of a given epoch.
 func (s *Service) HeadSeed(ctx context.Context, epoch uint64) ([32]byte, error) {
-	if !s.hasHeadState() {
+	if !s.HasHeadState() {
 		return [32]byte{}, nil
 	}
 
@@ -174,7 +174,7 @@ func (s *Service) HeadSeed(ctx context.Context, epoch uint64) ([32]byte, error) 
 
 // HeadGenesisValidatorRoot returns genesis validator root of the head state.
 func (s *Service) HeadGenesisValidatorRoot() [32]byte {
-	if !s.hasHeadState() {
+	if !s.HasHeadState() {
 		return [32]byte{}
 	}
 
@@ -183,13 +183,12 @@ func (s *Service) HeadGenesisValidatorRoot() [32]byte {
 
 // HeadETH1Data returns the eth1data of the current head state.
 func (s *Service) HeadETH1Data() *ethpb.Eth1Data {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
 	if !s.hasHeadState() {
 		return &ethpb.Eth1Data{}
 	}
-
-	// read lock starts here because `hasHeadState` calls the same read lock.
-	s.headLock.RLock()
-	defer s.headLock.RUnlock()
 
 	return s.head.state.Eth1Data()
 }
@@ -207,29 +206,27 @@ func (s *Service) GenesisTime() time.Time {
 // GenesisValidatorRoot returns the genesis validator
 // root of the chain.
 func (s *Service) GenesisValidatorRoot() [32]byte {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
 	if !s.hasHeadState() {
 		return [32]byte{}
 	}
-
-	// read lock starts here because `hasHeadState` calls the same read lock.
-	s.headLock.RLock()
-	defer s.headLock.RUnlock()
 
 	return bytesutil.ToBytes32(s.head.state.GenesisValidatorRoot())
 }
 
 // CurrentFork retrieves the latest fork information of the beacon chain.
 func (s *Service) CurrentFork() *pb.Fork {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
 	if !s.hasHeadState() {
 		return &pb.Fork{
 			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
 			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
 		}
 	}
-
-	// read lock starts here because `hasHeadState` calls the same read lock.
-	s.headLock.RLock()
-	defer s.headLock.RUnlock()
 
 	return s.head.state.Fork()
 }

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -183,12 +183,14 @@ func (s *Service) HeadGenesisValidatorRoot() [32]byte {
 
 // HeadETH1Data returns the eth1data of the current head state.
 func (s *Service) HeadETH1Data() *ethpb.Eth1Data {
-	s.headLock.RLock()
-	defer s.headLock.RUnlock()
-
 	if !s.hasHeadState() {
 		return &ethpb.Eth1Data{}
 	}
+
+	// read lock starts here because `hasHeadState` calls the same read lock.
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
 	return s.head.state.Eth1Data()
 }
 
@@ -205,26 +207,30 @@ func (s *Service) GenesisTime() time.Time {
 // GenesisValidatorRoot returns the genesis validator
 // root of the chain.
 func (s *Service) GenesisValidatorRoot() [32]byte {
-	s.headLock.RLock()
-	defer s.headLock.RUnlock()
-
 	if !s.hasHeadState() {
 		return [32]byte{}
 	}
+
+	// read lock starts here because `hasHeadState` calls the same read lock.
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
 	return bytesutil.ToBytes32(s.head.state.GenesisValidatorRoot())
 }
 
 // CurrentFork retrieves the latest fork information of the beacon chain.
 func (s *Service) CurrentFork() *pb.Fork {
-	s.headLock.RLock()
-	defer s.headLock.RUnlock()
-
 	if !s.hasHeadState() {
 		return &pb.Fork{
 			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
 			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
 		}
 	}
+
+	// read lock starts here because `hasHeadState` calls the same read lock.
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
 	return s.head.state.Fork()
 }
 

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -211,7 +211,6 @@ func (s *Service) GenesisValidatorRoot() [32]byte {
 	if !s.hasHeadState() {
 		return [32]byte{}
 	}
-
 	return bytesutil.ToBytes32(s.head.state.GenesisValidatorRoot())
 }
 

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -189,7 +189,6 @@ func (s *Service) HeadETH1Data() *ethpb.Eth1Data {
 	if !s.hasHeadState() {
 		return &ethpb.Eth1Data{}
 	}
-
 	return s.head.state.Eth1Data()
 }
 

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -228,11 +228,17 @@ func (s *Service) headGenesisValidatorRoot() [32]byte {
 	return bytesutil.ToBytes32(s.head.state.GenesisValidatorRoot())
 }
 
-// Returns true if head state exists.
-func (s *Service) hasHeadState() bool {
+// HasHeadState returns true if head state exists.
+func (s *Service) HasHeadState() bool {
 	s.headLock.RLock()
 	defer s.headLock.RUnlock()
 
+	return s.head != nil && s.head.state != nil
+}
+
+// Returns true if head state exists.
+// This is the lock free version.
+func (s *Service) hasHeadState() bool {
 	return s.head != nil && s.head.state != nil
 }
 

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -233,7 +233,7 @@ func (s *Service) HasHeadState() bool {
 	s.headLock.RLock()
 	defer s.headLock.RUnlock()
 
-	return s.head != nil && s.head.state != nil
+	return s.hasHeadState()
 }
 
 // Returns true if head state exists.


### PR DESCRIPTION
This fixes a bug raised in #7423. `hasHeadState` already calls the read lock so dead lock could happen. This moved read lock to after `hasHeadState`