### PR TITLE
Handle nil header properly in powchain service tests

### DIFF
--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -83,7 +83,11 @@ func (g *goodFetcher) HeaderByHash(ctx context.Context, hash common.Hash) (*geth
 			Number: big.NewInt(0),
 		}, nil
 	}
-	return g.backend.Blockchain().GetHeaderByHash(hash), nil
+	header := g.backend.Blockchain().GetHeaderByHash(hash)
+	if header == nil {
+		return nil, errors.New("nil header returned")
+	}
+	return header, nil
 
 }
 
@@ -94,10 +98,16 @@ func (g *goodFetcher) HeaderByNumber(ctx context.Context, number *big.Int) (*get
 			Time:   150,
 		}, nil
 	}
+	var header *gethTypes.Header
 	if number == nil {
-		return g.backend.Blockchain().CurrentHeader(), nil
+		header = g.backend.Blockchain().CurrentHeader()
+	} else {
+		header = g.backend.Blockchain().GetHeaderByNumber(number.Uint64())
 	}
-	return g.backend.Blockchain().GetHeaderByNumber(number.Uint64()), nil
+	if header == nil {
+		return nil, errors.New("nil header returned")
+	}
+	return header, nil
 }
 
 func (g *goodFetcher) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {


### PR DESCRIPTION
**What type of PR is this?**

> Other / Audit recommendations

**What does this PR do? Why is it needed?**
- Item 14 ToB audit.
- Handles not only ` HeaderByNumber()` reported by audit, but `HeaderByHash()` (it has the very same issue).

**Which issues(s) does this PR fix?**

Part of #7410

**Other notes for review**
- As a side-note: honestly, the `safelyHandlePanic()` looks lot like Horus heresy to avg. Golang dev:
```golang
// safelyHandleHeader will recover and log any panic that occurs from the
// block
func safelyHandlePanic() {
	if r := recover(); r != nil {
		log.WithFields(logrus.Fields{
			"r": r,
		}).Error("Panicked when handling data from ETH 1.0 Chain! Recovering...")

		debug.PrintStack()
	}
}
// processBlockHeader adds a newly observed eth1 block to the block cache and
// updates the latest blockHeight, blockHash, and blockTime properties of the service.
func (s *Service) processBlockHeader(header *gethTypes.Header) {
	defer safelyHandlePanic()
        // skip ...
}
func (s *Service) handleETH1FollowDistance() {
	defer safelyHandlePanic()
        // skip ...
}
```
Are we absolutely sure that `processBlockHeader()` and `handleETH1FollowDistance()` are still need recovering from panics for error handling (does Geth code panics randomly?).
