### PR TITLE
Remove unused `SlotSignature` function

### DIFF
--- a/beacon-chain/core/helpers/attestation.go
+++ b/beacon-chain/core/helpers/attestation.go
@@ -6,31 +6,11 @@ import (
 	"time"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/timeutils"
 )
-
-// SlotSignature returns the signed signature of the hash tree root of input slot.
-//
-// Spec pseudocode definition:
-//   def get_slot_signature(state: BeaconState, slot: Slot, privkey: int) -> BLSSignature:
-//    domain = get_domain(state, DOMAIN_SELECTION_PROOF, compute_epoch_at_slot(slot))
-//    signing_root = compute_signing_root(slot, domain)
-//    return bls.Sign(privkey, signing_root)
-func SlotSignature(state *stateTrie.BeaconState, slot uint64, privKey bls.SecretKey) (bls.Signature, error) {
-	d, err := Domain(state.Fork(), CurrentEpoch(state), params.BeaconConfig().DomainBeaconAttester, state.GenesisValidatorRoot())
-	if err != nil {
-		return nil, err
-	}
-	s, err := ComputeSigningRoot(slot, d)
-	if err != nil {
-		return nil, err
-	}
-	return privKey.Sign(s[:]), nil
-}
 
 // IsAggregator returns true if the signature is from the input validator. The committee
 // count is provided as an argument rather than direct implementation from spec. Having

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -18,27 +18,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/timeutils"
 )
 
-func TestAttestation_SlotSignature(t *testing.T) {
-	priv := bls.RandKey()
-	pub := priv.PublicKey()
-	state, err := beaconstate.InitializeFromProto(&pb.BeaconState{
-		Validators: []*ethpb.Validator{{PublicKey: pub.Marshal()}},
-		Fork: &pb.Fork{
-			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-			Epoch:           0,
-		},
-		Slot: 100,
-	})
-	require.NoError(t, err)
-	slot := uint64(101)
-
-	sig, err := helpers.SlotSignature(state, slot, priv)
-	require.NoError(t, err)
-	require.NoError(t, helpers.ComputeDomainVerifySigningRoot(state, 0, helpers.CurrentEpoch(state), slot,
-		params.BeaconConfig().DomainBeaconAttester, sig.Marshal()))
-}
-
 func TestAttestation_IsAggregator(t *testing.T) {
 	t.Run("aggregator", func(t *testing.T) {
 		beaconState, privKeys := testutil.DeterministicGenesisState(t, 100)


### PR DESCRIPTION
`SlotSignature` is not used in run time and has a bug. This PR removes it.