### PR TITLE
Fix wallet check for Windows by addresses differences in error message text

### DIFF
--- a/validator/accounts/v2/wallet/wallet.go
+++ b/validator/accounts/v2/wallet/wallet.go
@@ -130,7 +130,8 @@ func IsValid(walletDir string) (bool, error) {
 	}
 	f, err := os.Open(expanded)
 	if err != nil {
-		if strings.Contains(err.Error(), "no such file") {
+		if strings.Contains(err.Error(), "no such file") ||
+			strings.Contains(err.Error(), "cannot find the path") {
 			return false, nil
 		}
 		return false, err


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**
`accounts-v2 import --key-dir /path/to/keys` if there is no existing wallet directory fails with

`FATAL accounts-v2: Could not import accounts: could not initialize wallet: could not check if wallet exists: could not check if dir is valid: open C:\Users\dv8si\AppData\Roaming\Eth2Validators\prysm-wallet-v2: The system cannot find the path specified.`

In accounts/v2/wallet/wallet.go within isValid() there is this code:

```
	if err != nil {
		if strings.Contains(err.Error(), "no such file") {
			return false, nil
		}
		return false, err
	}
```

For both Linux and Windows, if the directory does not exist (this circumstance), the error returned is of type *os.PathError but the text differs:

"no such file or director" (Linux)
"The system cannot find the path specified." (Windows)

This PR changes the code to account for that.

**Which issues(s) does this PR fix?**

Fixes #7455 

**Other notes for review**
