### PR TITLE
Update slashing to use config value

### DIFF
--- a/beacon-chain/core/epoch/precompute/slashing.go
+++ b/beacon-chain/core/epoch/precompute/slashing.go
@@ -21,7 +21,7 @@ func ProcessSlashingsPrecompute(state *stateTrie.BeaconState, pBal *Balance) err
 		totalSlashing += slashing
 	}
 
-	minSlashing := mathutil.Min(totalSlashing*3, pBal.ActiveCurrentEpoch)
+	minSlashing := mathutil.Min(totalSlashing*params.BeaconConfig().ProportionalSlashingMultiplier, pBal.ActiveCurrentEpoch)
 	epochToWithdraw := currentEpoch + exitLength/2
 	increment := params.BeaconConfig().EffectiveBalanceIncrement
 	validatorFunc := func(idx int, val *ethpb.Validator) (bool, error) {


### PR DESCRIPTION
This was caught and fixed in #7469 

This does not affect v0.12.x and medalla since the config value is 3. I wanted to merge this fix into master to lower the line diff counts for 7469. 