### PR TITLE
Fix --clear-db on Windows

### DIFF
--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/core/feed/state:go_default_library",
+        "//shared/cmd:go_default_library",
         "//shared/testutil:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -316,6 +316,9 @@ func (b *BeaconNode) startDB(cliCtx *cli.Context) error {
 	}
 	if clearDBConfirmed || forceClearDB {
 		log.Warning("Removing database")
+		if err := d.Close(); err != nil {
+			return errors.Wrap(err, "could not close db prior to clearing")
+		}
 		if err := d.ClearDB(); err != nil {
 			return errors.Wrap(err, "could not clear database")
 		}

--- a/beacon-chain/node/node_test.go
+++ b/beacon-chain/node/node_test.go
@@ -1,13 +1,17 @@
 package node
 
 import (
+	"crypto/rand"
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math/big"
 	"os"
+	"path/filepath"
 	"testing"
 
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
+	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -64,4 +68,26 @@ func TestBootStrapNodeFile(t *testing.T) {
 	assert.Equal(t, sampleNode0[2:], nodeList[0], "Unexpected nodes")
 	assert.Equal(t, sampleNode1[2:], nodeList[1], "Unexpected nodes")
 	assert.Equal(t, sampleNode2[2:], nodeList[2], "Unexpected nodes")
+}
+
+// TestClearDB tests clearing the database
+func TestClearDB(t *testing.T) {
+	hook := logTest.NewGlobal()
+
+	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	require.NoError(t, err, "Could not generate random number for file path")
+	tmp := filepath.Join(testutil.TempDir(), fmt.Sprintf("datadirtest%d", randPath))
+	require.NoError(t, os.RemoveAll(tmp))
+
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	set.String("datadir", tmp, "node data directory")
+	set.Bool(cmd.ForceClearDB.Name, true, "force clear db")
+
+	context := cli.NewContext(&app, set, nil)
+	_, err = NewBeaconNode(context)
+	require.NoError(t, err)
+
+	require.LogsContain(t, hook, "Removing database")
+	require.NoError(t, os.RemoveAll(tmp))
 }

--- a/slasher/node/BUILD.bazel
+++ b/slasher/node/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     srcs = ["node_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//shared/cmd:go_default_library",
         "//shared/testutil:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/slasher/node/node.go
+++ b/slasher/node/node.go
@@ -194,6 +194,9 @@ func (s *SlasherNode) startDB() error {
 	}
 	if clearDBConfirmed || forceClearDB {
 		log.Warning("Removing database")
+		if err := d.Close(); err != nil {
+			return errors.Wrap(err, "could not close db prior to clearing")
+		}
 		if err := d.ClearDB(); err != nil {
 			return err
 		}

--- a/slasher/node/node_test.go
+++ b/slasher/node/node_test.go
@@ -1,12 +1,16 @@
 package node
 
 import (
+	"crypto/rand"
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math/big"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 	"github.com/sirupsen/logrus"
@@ -41,5 +45,29 @@ func TestNodeClose_OK(t *testing.T) {
 	node.Close()
 
 	require.LogsContain(t, hook, "Stopping hash slinging slasher")
+	require.NoError(t, os.RemoveAll(tmp))
+}
+
+// TestClearDB tests clearing the database
+func TestClearDB(t *testing.T) {
+	hook := logTest.NewGlobal()
+
+	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	require.NoError(t, err, "Could not generate random number for file path")
+	tmp := filepath.Join(testutil.TempDir(), fmt.Sprintf("datadirtest%d", randPath))
+	require.NoError(t, os.RemoveAll(tmp))
+
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	set.String("datadir", tmp, "node data directory")
+	set.Bool(cmd.ForceClearDB.Name, true, "force clear db")
+
+	context := cli.NewContext(&app, set, nil)
+	slasherNode, err := NewSlasherNode(context)
+	require.NoError(t, err)
+
+	require.LogsContain(t, hook, "Removing database")
+	err = slasherNode.db.Close()
+	require.NoError(t, err)
 	require.NoError(t, os.RemoveAll(tmp))
 }

--- a/validator/node/BUILD.bazel
+++ b/validator/node/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "//validator/accounts/v1:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],
 )

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -516,7 +516,9 @@ func clearDB(dataDir string, force bool) error {
 		if err != nil {
 			return errors.Wrapf(err, "Could not create DB in dir %s", dataDir)
 		}
-		valDB.Close()
+		if err := valDB.Close(); err != nil {
+			return errors.Wrapf(err, "could not close DB in dir %s", dataDir)
+		}
 
 		log.Warning("Removing database")
 		if err := valDB.ClearDB(); err != nil {

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -516,6 +516,7 @@ func clearDB(dataDir string, force bool) error {
 		if err != nil {
 			return errors.Wrapf(err, "Could not create DB in dir %s", dataDir)
 		}
+		valDB.Close()
 
 		log.Warning("Removing database")
 		if err := valDB.ClearDB(); err != nil {

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -1,14 +1,19 @@
 package node
 
 import (
+	"crypto/rand"
 	"flag"
+	"fmt"
+	"math/big"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 	v1 "github.com/prysmaticlabs/prysm/validator/accounts/v1"
+	logTest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/urfave/cli/v2"
 )
 
@@ -33,4 +38,16 @@ func TestNode_Builds(t *testing.T) {
 	require.NoError(t, v1.NewValidatorAccount(dir, "1234"), "Could not create validator account")
 	_, err := NewValidatorClient(context)
 	require.NoError(t, err, "Failed to create ValidatorClient")
+}
+
+// TestClearDB tests clearing the database
+func TestClearDB(t *testing.T) {
+	hook := logTest.NewGlobal()
+	randPath, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	require.NoError(t, err, "Could not generate random number for file path")
+	tmp := filepath.Join(testutil.TempDir(), fmt.Sprintf("datadirtest%d", randPath))
+	require.NoError(t, os.RemoveAll(tmp))
+	err = clearDB(tmp, true)
+	require.NoError(t, err)
+	require.LogsContain(t, hook, "Removing database")
 }

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -36,8 +36,9 @@ func TestNode_Builds(t *testing.T) {
 	context := cli.NewContext(&app, set, nil)
 
 	require.NoError(t, v1.NewValidatorAccount(dir, "1234"), "Could not create validator account")
-	_, err := NewValidatorClient(context)
+	valClient, err := NewValidatorClient(context)
 	require.NoError(t, err, "Failed to create ValidatorClient")
+	valClient.db.Close()
 }
 
 // TestClearDB tests clearing the database

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -38,7 +38,8 @@ func TestNode_Builds(t *testing.T) {
 	require.NoError(t, v1.NewValidatorAccount(dir, "1234"), "Could not create validator account")
 	valClient, err := NewValidatorClient(context)
 	require.NoError(t, err, "Failed to create ValidatorClient")
-	valClient.db.Close()
+	err = valClient.db.Close()
+	require.NoError(t, err)
 }
 
 // TestClearDB tests clearing the database


### PR DESCRIPTION

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**
Fixes the issue where --clear-db in Windows leads to an error quoted in #7401 :

```
WARN node: Removing database
ERROR main: could not clear database: could not remove database file: remove C:\Users\Username\AppData\Roaming\Eth2\beaconchaindata/beaconchain.db: The process cannot access the file because it is being used by another process.
ERROR FAILED
```
This is in the validator, beacon-chain, as well as the slasher.

This is because on Linux, you can indeed os.Remove a file in use without the OS complaining-- this unlinks it from the containing directory but since a process has it open, the actual data on disk will remain until the process ends.  At the time the process exits, if there is no other reference to that data, it'll be moved to the chopping block.  On Windows, you cannot delete a file in use.  In master, the clearing DB code calls a function to delete the .db file and then soon afterwards, creates a new DB [file] which will indeed persist after the process ends.  But before it does the delete, it has a database with that file to-be-deleted DB file still open.

Example in the beacon-chain:

```
	if clearDBConfirmed || forceClearDB {
		log.Warning("Removing database")
		if err := d.ClearDB(); err != nil {
			return errors.Wrap(err, "could not clear database")
		}
		d, err = db.NewDB(dbPath, b.stateSummaryCache)
		if err != nil {
			return errors.Wrap(err, "could not create new database")
		}
	}
```

**Which issues(s) does this PR fix?**

Fixes #7401 

**Other notes for review**
