### PR TITLE
Add missing mainet spec test

### DIFF
--- a/beacon-chain/core/epoch/spectest/rewards_and_penalties_mainnet_test.go
+++ b/beacon-chain/core/epoch/spectest/rewards_and_penalties_mainnet_test.go
@@ -1,0 +1,9 @@
+package spectest
+
+import (
+	"testing"
+)
+
+func TestRewardsAndPenaltiesMainnet(t *testing.T) {
+	runRewardsAndPenaltiesTests(t, "mainnet")
+}


### PR DESCRIPTION
Discovered in #7469 but fixing in master to reduce line count.

It came to my attention that we were missing rewards and penalties mainnet spec test under epoch. We only had miminal spec test. 😱 