### PR TITLE
Remove redundant err checking

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -310,10 +310,7 @@ func (s *Service) finalizedImpliesNewJustified(ctx context.Context, state *state
 	if !attestationutil.CheckPointIsEqual(s.justifiedCheckpt, state.CurrentJustifiedCheckpoint()) {
 		if state.CurrentJustifiedCheckpoint().Epoch > s.justifiedCheckpt.Epoch {
 			s.justifiedCheckpt = state.CurrentJustifiedCheckpoint()
-			if err := s.cacheJustifiedStateBalances(ctx, bytesutil.ToBytes32(s.justifiedCheckpt.Root)); err != nil {
-				return err
-			}
-			return nil
+			return s.cacheJustifiedStateBalances(ctx, bytesutil.ToBytes32(s.justifiedCheckpt.Root))
 		}
 
 		// Update justified if store justified is not in chain with finalized check point.

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -330,11 +330,7 @@ func (s *Service) Stop() error {
 	}
 
 	// Save initial sync cached blocks to the DB before stop.
-	if err := s.beaconDB.SaveBlocks(s.ctx, s.getInitSyncBlocks()); err != nil {
-		return err
-	}
-
-	return nil
+	return s.beaconDB.SaveBlocks(s.ctx, s.getInitSyncBlocks())
 }
 
 // Status always returns nil unless there is an error condition that causes

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -371,14 +371,10 @@ func UpdateProposerIndicesInCache(state *stateTrie.BeaconState, epoch uint64) er
 	if err != nil {
 		return err
 	}
-	if err := proposerIndicesCache.AddProposerIndices(&cache.ProposerIndices{
+	return proposerIndicesCache.AddProposerIndices(&cache.ProposerIndices{
 		BlockRoot:       bytesutil.ToBytes32(r),
 		ProposerIndices: proposerIndices,
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	})
 }
 
 // ClearCache clears the committee cache

--- a/beacon-chain/operations/attestations/prepare_forkchoice.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice.go
@@ -95,11 +95,7 @@ func (s *Service) aggregateAndSaveForkChoiceAtts(atts []*ethpb.Attestation) erro
 		return err
 	}
 
-	if err := s.pool.SaveForkchoiceAttestations(aggregatedAtts); err != nil {
-		return err
-	}
-
-	return nil
+	return s.pool.SaveForkchoiceAttestations(aggregatedAtts)
 }
 
 // This checks if the attestation has previously been aggregated for fork choice

--- a/beacon-chain/state/stategen/setter.go
+++ b/beacon-chain/state/stategen/setter.go
@@ -37,11 +37,8 @@ func (s *State) ForceCheckpoint(ctx context.Context, root []byte) error {
 	if err != nil {
 		return err
 	}
-	if err := s.beaconDB.SaveState(ctx, fs, root32); err != nil {
-		return err
-	}
 
-	return nil
+	return s.beaconDB.SaveState(ctx, fs, root32)
 }
 
 // SaveStateSummary saves the relevant state summary for a block and its corresponding state slot in the

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -295,11 +295,7 @@ func TestBlocksQueue_Loop(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				if err := mc.ReceiveBlock(ctx, block, root); err != nil {
-					return err
-				}
-
-				return nil
+				return mc.ReceiveBlock(ctx, block, root)
 			}
 
 			var blocks []*eth.SignedBeaconBlock

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -59,10 +59,7 @@ func (s *Service) sendGoodByeAndDisconnect(ctx context.Context, code uint64, id 
 			"peer":  id,
 		}).Debug("Could not send goodbye message to peer")
 	}
-	if err := s.p2p.Disconnect(id); err != nil {
-		return err
-	}
-	return nil
+	return s.p2p.Disconnect(id)
 }
 
 func (s *Service) sendGoodByeMessage(ctx context.Context, code uint64, id peer.ID) error {

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -271,12 +271,9 @@ func validateSelection(ctx context.Context, bs *stateTrie.BeaconState, data *eth
 		return fmt.Errorf("validator is not an aggregator for slot %d", data.Slot)
 	}
 
-	if err := helpers.ComputeDomainVerifySigningRoot(bs, validatorIndex,
-		helpers.SlotToEpoch(data.Slot), data.Slot, params.BeaconConfig().DomainSelectionProof, proof); err != nil {
-		return err
-	}
-
-	return nil
+	domain := params.BeaconConfig().DomainSelectionProof
+	epoch := helpers.SlotToEpoch(data.Slot)
+	return helpers.ComputeDomainVerifySigningRoot(bs, validatorIndex, epoch, data.Slot, domain, proof)
 }
 
 // This verifies aggregator signature over the signed aggregate and proof object.

--- a/endtoend/helpers/helpers.go
+++ b/endtoend/helpers/helpers.go
@@ -160,10 +160,7 @@ func WritePprofFiles(testDir string, index int) error {
 	}
 	url = fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/profile", e2e.TestParams.BeaconNodeRPCPort+50+index)
 	filePath = filepath.Join(testDir, fmt.Sprintf(cpuProfileFileName, index))
-	if err := writeURLRespAtPath(url, filePath); err != nil {
-		return err
-	}
-	return nil
+	return writeURLRespAtPath(url, filePath)
 }
 
 func writeURLRespAtPath(url string, filePath string) error {

--- a/shared/keystore/key.go
+++ b/shared/keystore/key.go
@@ -161,10 +161,7 @@ func storeNewRandomKey(ks keyStore, password string) error {
 	if err != nil {
 		return err
 	}
-	if err := ks.StoreKey(ks.JoinPath(keyFileName(key.PublicKey)), key, password); err != nil {
-		return err
-	}
-	return nil
+	return ks.StoreKey(ks.JoinPath(keyFileName(key.PublicKey)), key, password)
 }
 
 func writeKeyFile(file string, content []byte) error {

--- a/slasher/detection/attestations/spanner.go
+++ b/slasher/detection/attestations/spanner.go
@@ -162,10 +162,7 @@ func (s *SpanDetector) UpdateSpans(ctx context.Context, att *ethpb.IndexedAttest
 	if err := s.updateMinSpan(ctx, att); err != nil {
 		return err
 	}
-	if err := s.updateMaxSpan(ctx, att); err != nil {
-		return err
-	}
-	return nil
+	return s.updateMaxSpan(ctx, att)
 }
 
 // saveSigBytes saves the first 2 bytes of the signature for the att we're updating the spans to.

--- a/slasher/rpc/service.go
+++ b/slasher/rpc/service.go
@@ -155,8 +155,5 @@ func (s *Service) Status() error {
 	if bs := s.beaconclient.Status(); bs != nil {
 		return bs
 	}
-	if ds := s.detector.Status(); ds != nil {
-		return ds
-	}
-	return nil
+	return s.detector.Status()
 }

--- a/tools/benchmark-files-gen/main.go
+++ b/tools/benchmark-files-gen/main.go
@@ -77,10 +77,7 @@ func generateGenesisBeaconState() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(path.Join(*outputDir, benchutil.GenesisFileName), beaconBytes, 0644); err != nil {
-		return err
-	}
-	return nil
+	return ioutil.WriteFile(path.Join(*outputDir, benchutil.GenesisFileName), beaconBytes, 0644)
 }
 
 func generateMarshalledFullStateAndBlock() error {
@@ -167,10 +164,8 @@ func generateMarshalledFullStateAndBlock() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(path.Join(*outputDir, benchutil.FullBlockFileName), blockBytes, 0644); err != nil {
-		return err
-	}
-	return nil
+
+	return ioutil.WriteFile(path.Join(*outputDir, benchutil.FullBlockFileName), blockBytes, 0644)
 }
 
 func generate2FullEpochState() error {
@@ -204,10 +199,8 @@ func generate2FullEpochState() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(path.Join(*outputDir, benchutil.BState2EpochFileName), beaconBytes, 0644); err != nil {
-		return err
-	}
-	return nil
+
+	return ioutil.WriteFile(path.Join(*outputDir, benchutil.BState2EpochFileName), beaconBytes, 0644)
 }
 
 func genesisBeaconState() (*stateTrie.BeaconState, error) {

--- a/validator/db/kv/manage.go
+++ b/validator/db/kv/manage.go
@@ -201,11 +201,7 @@ func createSplitTargetStores(
 
 			if err := newStore.update(func(tx *bolt.Tx) error {
 				attestationsBucket := tx.Bucket(historicAttestationsBucket)
-				if err := addAttestations(attestationsBucket, pubKeyAttestations); err != nil {
-					return err
-				}
-
-				return nil
+				return addAttestations(attestationsBucket, pubKeyAttestations)
 			}); err != nil {
 				return err
 			}

--- a/validator/db/kv/new_proposal_history.go
+++ b/validator/db/kv/new_proposal_history.go
@@ -51,10 +51,7 @@ func (store *Store) SaveProposalHistoryForSlot(ctx context.Context, pubKey []byt
 		if err := valBucket.Put(bytesutil.Uint64ToBytesBigEndian(slot), signingRoot); err != nil {
 			return err
 		}
-		if err := pruneProposalHistoryBySlot(valBucket, slot); err != nil {
-			return err
-		}
-		return nil
+		return pruneProposalHistoryBySlot(valBucket, slot)
 	})
 	return err
 }

--- a/validator/db/kv/proposal_history.go
+++ b/validator/db/kv/proposal_history.go
@@ -53,10 +53,7 @@ func (store *Store) SaveProposalHistoryForEpoch(ctx context.Context, pubKey []by
 		if err := valBucket.Put(bytesutil.Bytes8(epoch), slotBits); err != nil {
 			return err
 		}
-		if err := pruneProposalHistory(valBucket, epoch); err != nil {
-			return err
-		}
-		return nil
+		return pruneProposalHistory(valBucket, epoch)
 	})
 	return err
 }


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
- Removes redundant error checking (when `if err { return err } else { return nil }` can be simplified to `return err`). This issue has been [found by DS](https://deepsource.io/gh/prysmaticlabs/prysm/issue/RVV-B0005/occurrences)

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
