### PR TITLE
Verify interface compliance using typed nil instead of dereferencing and conversion

### DIFF
--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -18,9 +18,9 @@ import (
 )
 
 // Ensure Service implements chain info interface.
-var _ = ChainInfoFetcher(&Service{})
-var _ = TimeFetcher(&Service{})
-var _ = ForkFetcher(&Service{})
+var _ ChainInfoFetcher = (*Service)(nil)
+var _ TimeFetcher = (*Service)(nil)
+var _ ForkFetcher = (*Service)(nil)
 
 func TestFinalizedCheckpt_Nil(t *testing.T) {
 	db, sc := testDB.SetupDB(t)

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -67,7 +67,7 @@ func (mb *mockBroadcaster) BroadcastAttestation(_ context.Context, _ uint64, _ *
 	return nil
 }
 
-var _ = p2p.Broadcaster(&mockBroadcaster{})
+var _ p2p.Broadcaster = (*mockBroadcaster)(nil)
 
 func setupBeaconChain(t *testing.T, beaconDB db.Database, sc *cache.StateSummaryCache) *Service {
 	endpoint := "http://127.0.0.1"

--- a/beacon-chain/cache/depositcache/deposits_cache_test.go
+++ b/beacon-chain/cache/depositcache/deposits_cache_test.go
@@ -19,7 +19,7 @@ import (
 
 const nilDepositErr = "Ignoring nil deposit insertion"
 
-var _ = DepositFetcher(&DepositCache{})
+var _ DepositFetcher = (*DepositCache)(nil)
 
 func TestInsertDeposit_LogsOnNilDepositInsertion(t *testing.T) {
 	hook := logTest.NewGlobal()

--- a/beacon-chain/cache/depositcache/pending_deposits_test.go
+++ b/beacon-chain/cache/depositcache/pending_deposits_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 )
 
-var _ = PendingDepositsFetcher(&DepositCache{})
+var _ PendingDepositsFetcher = (*DepositCache)(nil)
 
 func TestInsertPendingDeposit_OK(t *testing.T) {
 	dc := DepositCache{}

--- a/beacon-chain/db/db_test.go
+++ b/beacon-chain/db/db_test.go
@@ -2,4 +2,4 @@ package db
 
 import "github.com/prysmaticlabs/prysm/beacon-chain/db/kv"
 
-var _ = Database(&kv.Store{})
+var _ Database = (*kv.Store)(nil)

--- a/beacon-chain/db/kafka/export_wrapper.go
+++ b/beacon-chain/db/kafka/export_wrapper.go
@@ -20,7 +20,7 @@ import (
 	_ "gopkg.in/confluentinc/confluent-kafka-go.v1/kafka/librdkafka" // Required for c++ kafka library.
 )
 
-var _ = iface.Database(&Exporter{})
+var _ iface.Database = (*Exporter)(nil)
 var log = logrus.WithField("prefix", "exporter")
 var marshaler = &jsonpb.Marshaler{}
 

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -17,7 +17,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-var _ = iface.Database(&Store{})
+var _ iface.Database = (*Store)(nil)
 
 const (
 	// VotesCacheSize with 1M validators will be 8MB.

--- a/beacon-chain/gateway/gateway.go
+++ b/beacon-chain/gateway/gateway.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 )
 
-var _ = shared.Service(&Gateway{})
+var _ shared.Service = (*Gateway)(nil)
 
 // Gateway is the gRPC gateway to serve HTTP JSON traffic as a proxy and forward
 // it to the beacon-chain gRPC server.

--- a/beacon-chain/interop-cold-start/service.go
+++ b/beacon-chain/interop-cold-start/service.go
@@ -22,9 +22,9 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
 )
 
-var _ = shared.Service(&Service{})
-var _ = depositcache.DepositFetcher(&Service{})
-var _ = powchain.ChainStartFetcher(&Service{})
+var _ shared.Service = (*Service)(nil)
+var _ depositcache.DepositFetcher = (*Service)(nil)
+var _ powchain.ChainStartFetcher = (*Service)(nil)
 
 // Service spins up an client interoperability service that handles responsibilities such
 // as kickstarting a genesis state for the beacon node from cli flags or a genesis.ssz file.

--- a/beacon-chain/node/node_test.go
+++ b/beacon-chain/node/node_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 // Ensure BeaconNode implements interfaces.
-var _ = statefeed.Notifier(&BeaconNode{})
+var _ statefeed.Notifier = (*BeaconNode)(nil)
 
 // Test that beacon chain node can close.
 func TestNodeClose_OK(t *testing.T) {

--- a/beacon-chain/operations/attestations/pool_test.go
+++ b/beacon-chain/operations/attestations/pool_test.go
@@ -4,4 +4,4 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations/kv"
 )
 
-var _ = Pool(&kv.AttCaches{})
+var _ Pool = (*kv.AttCaches)(nil)

--- a/beacon-chain/p2p/encoder/ssz.go
+++ b/beacon-chain/p2p/encoder/ssz.go
@@ -14,7 +14,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
-var _ = NetworkEncoding(&SszNetworkEncoder{})
+var _ NetworkEncoding = (*SszNetworkEncoder)(nil)
 
 // MaxGossipSize allowed for gossip messages.
 var MaxGossipSize = params.BeaconNetworkConfig().GossipMaxSize // 1 Mib

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -37,7 +37,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
 )
 
-var _ = shared.Service(&Service{})
+var _ shared.Service = (*Service)(nil)
 
 // In the event that we are at our peer limit, we
 // stop looking for new peers and instead poll

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -27,10 +27,10 @@ import (
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
-var _ = ChainStartFetcher(&Service{})
-var _ = ChainInfoFetcher(&Service{})
-var _ = POWBlockFetcher(&Service{})
-var _ = Chain(&Service{})
+var _ ChainStartFetcher = (*Service)(nil)
+var _ ChainInfoFetcher = (*Service)(nil)
+var _ POWBlockFetcher = (*Service)(nil)
+var _ Chain = (*Service)(nil)
 
 type goodLogger struct {
 	backend *backends.SimulatedBackend

--- a/beacon-chain/rpc/beaconv1/server_test.go
+++ b/beacon-chain/rpc/beaconv1/server_test.go
@@ -2,4 +2,4 @@ package beaconv1
 
 import ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1"
 
-var _ = ethpb.BeaconChainServer(&Server{})
+var _ ethpb.BeaconChainServer = (*Server)(nil)

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var _ = shared.Service(&Service{})
+var _ shared.Service = (*Service)(nil)
 
 // blockchainService defines the interface for interaction with block chain service.
 type blockchainService interface {

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -32,7 +32,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/timeutils"
 )
 
-var _ = shared.Service(&Service{})
+var _ shared.Service = (*Service)(nil)
 
 const rangeLimit = 1024
 const seenBlockSize = 1000

--- a/shared/rand/rand.go
+++ b/shared/rand/rand.go
@@ -37,7 +37,7 @@ import (
 
 type source struct{}
 
-var _ = mrand.Source64(&source{})
+var _ mrand.Source64 = (*source)(nil)
 
 // Seed does nothing when crypto/rand is used as source.
 func (s *source) Seed(seed int64) {}

--- a/shared/slotutil/slotticker_test.go
+++ b/shared/slotutil/slotticker_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-var _ = Ticker(&SlotTicker{})
+var _ Ticker = (*SlotTicker)(nil)
 
 func TestSlotTicker(t *testing.T) {
 	ticker := &SlotTicker{

--- a/shared/slotutil/testing/mock_test.go
+++ b/shared/slotutil/testing/mock_test.go
@@ -2,4 +2,4 @@ package testing
 
 import "github.com/prysmaticlabs/prysm/shared/slotutil"
 
-var _ = slotutil.Ticker(&MockTicker{})
+var _ slotutil.Ticker = (*MockTicker)(nil)

--- a/slasher/db/db_test.go
+++ b/slasher/db/db_test.go
@@ -2,4 +2,4 @@ package db
 
 import "github.com/prysmaticlabs/prysm/slasher/db/kv"
 
-var _ = Database(&kv.Store{})
+var _ Database = (*kv.Store)(nil)

--- a/slasher/detection/attestations/mock_spanner.go
+++ b/slasher/detection/attestations/mock_spanner.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prysmaticlabs/prysm/slasher/detection/attestations/types"
 )
 
-var _ = iface.SpanDetector(&MockSpanDetector{})
+var _ iface.SpanDetector = (*MockSpanDetector)(nil)
 
 // MockSpanDetector defines a struct which can detect slashable
 // attestation offenses by tracking validator min-max

--- a/slasher/detection/attestations/spanner.go
+++ b/slasher/detection/attestations/spanner.go
@@ -35,7 +35,7 @@ var (
 // TODO(#5040): Remove lookback and handle min spans properly.
 const epochLookback = 128
 
-var _ = iface.SpanDetector(&SpanDetector{})
+var _ iface.SpanDetector = (*SpanDetector)(nil)
 
 // SpanDetector defines a struct which can detect slashable
 // attestation offenses by tracking validator min-max

--- a/slasher/detection/proposals/detector_test.go
+++ b/slasher/detection/proposals/detector_test.go
@@ -13,7 +13,7 @@ import (
 	testDetect "github.com/prysmaticlabs/prysm/slasher/detection/testing"
 )
 
-var _ = iface.ProposalsDetector(&ProposeDetector{})
+var _ iface.ProposalsDetector = (*ProposeDetector)(nil)
 
 func TestProposalsDetector_DetectSlashingsForBlockHeaders(t *testing.T) {
 	type testStruct struct {

--- a/tools/cluster-pk-manager/server/server_test.go
+++ b/tools/cluster-pk-manager/server/server_test.go
@@ -4,4 +4,4 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/cluster"
 )
 
-var _ = pb.PrivateKeyServiceServer(&server{})
+var _ pb.PrivateKeyServiceServer = (*server)(nil)

--- a/validator/client/mock_validator.go
+++ b/validator/client/mock_validator.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/timeutils"
 )
 
-var _ = Validator(&FakeValidator{})
+var _ Validator = (*FakeValidator)(nil)
 
 // FakeValidator for mocking.
 type FakeValidator struct {

--- a/validator/client/service_test.go
+++ b/validator/client/service_test.go
@@ -17,7 +17,7 @@ import (
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
-var _ = shared.Service(&ValidatorService{})
+var _ shared.Service = (*ValidatorService)(nil)
 var validatorKey *keystore.Key
 var validatorPubKey [48]byte
 var keyMap map[[48]byte]*keystore.Key

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -28,7 +28,7 @@ func init() {
 	logrus.SetOutput(ioutil.Discard)
 }
 
-var _ = Validator(&validator{})
+var _ Validator = (*validator)(nil)
 
 const cancelledCtx = "context has been canceled"
 

--- a/validator/rpc/accounts_test.go
+++ b/validator/rpc/accounts_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/prysmaticlabs/prysm/validator/keymanager/v2/derived"
 )
 
-var _ = accountCreator(&mockAccountCreator{})
+var _ accountCreator = (*mockAccountCreator)(nil)
 
 type mockAccountCreator struct {
 	data   *ethpb.Deposit_Data

--- a/validator/rpc/server_test.go
+++ b/validator/rpc/server_test.go
@@ -4,4 +4,4 @@ import (
 	pb "github.com/prysmaticlabs/prysm/proto/validator/accounts/v2"
 )
 
-var _ = pb.AuthServer(&Server{})
+var _ pb.AuthServer = (*Server)(nil)


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
I've noticed that we use the following pattern to verify that a given struct's pointer implements an interface:
```golang
var _ = ChainInfoFetcher(&Service{})
```
Basically, we create an object and try to convert it into `_` using interface. The very same effect is conventionally achieved using the following pattern:
```golang
var _ ChainInfoFetcher = (*Service)(nil)
```
It checks the interface compliance, but does so rather more elegantly, by trying to assign to a var `_` (of a given interface type) **typed nil** value (we need a zero value of asserted type on the right side of `=`, which is `nil` for pointers).

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
