### PR TITLE
Update "Requesting parent block..." to debug level

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -113,7 +113,7 @@ func (s *Service) processPendingBlocks(ctx context.Context) error {
 				log.WithFields(logrus.Fields{
 					"currentSlot": b.Block.Slot,
 					"parentRoot":  hex.EncodeToString(bytesutil.Trunc(b.Block.ParentRoot)),
-				}).Info("Requesting parent block")
+				}).Debug("Requesting parent block")
 				parentRoots = append(parentRoots, bytesutil.ToBytes32(b.Block.ParentRoot))
 
 				span.End()


### PR DESCRIPTION
Update "Requesting parent block..." to `debug` level. It's more appropriate given the verbosity and lack of actions required from consumer