### PR TITLE
Remove inital sync don't verify att sig flag

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -175,12 +175,7 @@ func (s *Service) onBlockInitialSyncStateTransition(ctx context.Context, signed 
 		return nil
 	}
 
-	var postState *stateTrie.BeaconState
-	if featureconfig.Get().InitSyncNoVerify {
-		postState, err = state.ExecuteStateTransitionNoVerifyAttSigs(ctx, preState, signed)
-	} else {
-		postState, err = state.ExecuteStateTransition(ctx, preState, signed)
-	}
+	postState, err := state.ExecuteStateTransition(ctx, preState, signed)
 	if err != nil {
 		return errors.Wrap(err, "could not execute state transition")
 	}

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -100,52 +100,6 @@ func ExecuteStateTransition(
 	return state, nil
 }
 
-// ExecuteStateTransitionNoVerifyAttSigs defines the procedure for a state transition function.
-// This does not validate any BLS signatures of attestations in a block, it is used for performing a state transition as quickly
-// as possible. This function should only be used when we can trust the data we're receiving entirely, such as
-// initial sync or for processing past accepted blocks.
-//
-// WARNING: This method does not validate any signatures in a block. This method also modifies the passed in state.
-//
-// Spec pseudocode definition:
-//  def state_transition(state: BeaconState, block: BeaconBlock, validate_state_root: bool=False) -> BeaconState:
-//    # Process slots (including those with no blocks) since block
-//    process_slots(state, block.slot)
-//    # Process block
-//    process_block(state, block)
-//    # Return post-state
-//    return state
-func ExecuteStateTransitionNoVerifyAttSigs(
-	ctx context.Context,
-	state *stateTrie.BeaconState,
-	signed *ethpb.SignedBeaconBlock,
-) (*stateTrie.BeaconState, error) {
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-	if signed == nil || signed.Block == nil {
-		return nil, errors.New("nil block")
-	}
-
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.ExecuteStateTransitionNoVerifyAttSigs")
-	defer span.End()
-	var err error
-
-	// Execute per slots transition.
-	state, err = ProcessSlots(ctx, state, signed.Block.Slot)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not process slot")
-	}
-
-	// Execute per block transition.
-	state, err = ProcessBlockNoVerifyAttSigs(ctx, state, signed)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not process block")
-	}
-
-	return state, nil
-}
-
 // ExecuteStateTransitionNoVerifyAnySig defines the procedure for a state transition function.
 // This does not validate any BLS signatures of attestations, block proposer signature, randao signature,
 // it is used for performing a state transition as quickly as possible. This function also returns a signature
@@ -423,52 +377,6 @@ func ProcessBlock(
 		if err != nil {
 			return nil, errors.Wrap(err, "Could not process block")
 		}
-	}
-
-	return state, nil
-}
-
-// ProcessBlockNoVerifyAttSigs creates a new, modified beacon state by applying block operation
-// transformations as defined in the Ethereum Serenity specification. It does not validate
-// block attestation signatures.
-//
-// Spec pseudocode definition:
-//
-//  def process_block(state: BeaconState, block: BeaconBlock) -> None:
-//    process_block_header(state, block)
-//    process_randao(state, block.body)
-//    process_eth1_data(state, block.body)
-//    process_operations(state, block.body)
-func ProcessBlockNoVerifyAttSigs(
-	ctx context.Context,
-	state *stateTrie.BeaconState,
-	signed *ethpb.SignedBeaconBlock,
-) (*stateTrie.BeaconState, error) {
-	ctx, span := trace.StartSpan(ctx, "beacon-chain.ChainService.state.ProcessBlockNoVerifyAttSigs")
-	defer span.End()
-
-	state, err := b.ProcessBlockHeader(ctx, state, signed)
-	if err != nil {
-		traceutil.AnnotateError(span, err)
-		return nil, errors.Wrap(err, "could not process block header")
-	}
-
-	state, err = b.ProcessRandao(ctx, state, signed)
-	if err != nil {
-		traceutil.AnnotateError(span, err)
-		return nil, errors.Wrap(err, "could not verify and process randao")
-	}
-
-	state, err = b.ProcessEth1DataInBlock(ctx, state, signed)
-	if err != nil {
-		traceutil.AnnotateError(span, err)
-		return nil, errors.Wrap(err, "could not process eth1 data")
-	}
-
-	state, err = ProcessOperationsNoVerifyAttsSigs(ctx, state, signed)
-	if err != nil {
-		traceutil.AnnotateError(span, err)
-		return nil, errors.Wrap(err, "could not process block operation")
 	}
 
 	return state, nil

--- a/beacon-chain/core/state/transition_fuzz_test.go
+++ b/beacon-chain/core/state/transition_fuzz_test.go
@@ -27,24 +27,6 @@ func TestFuzzExecuteStateTransition_1000(t *testing.T) {
 	}
 }
 
-func TestFuzzExecuteStateTransitionNoVerifyAttSigs_1000(t *testing.T) {
-	SkipSlotCache.Disable()
-	defer SkipSlotCache.Enable()
-	ctx := context.Background()
-	state := &stateTrie.BeaconState{}
-	sb := &ethpb.SignedBeaconBlock{}
-	fuzzer := fuzz.NewWithSeed(0)
-	fuzzer.NilChance(0.1)
-	for i := 0; i < 1000; i++ {
-		fuzzer.Fuzz(state)
-		fuzzer.Fuzz(sb)
-		s, err := ExecuteStateTransitionNoVerifyAttSigs(ctx, state, sb)
-		if err != nil && s != nil {
-			t.Fatalf("state should be nil on err. found: %v on error: %v for state: %v and signed block: %v", s, err, state, sb)
-		}
-	}
-}
-
 func TestFuzzCalculateStateRoot_1000(t *testing.T) {
 	SkipSlotCache.Disable()
 	defer SkipSlotCache.Enable()
@@ -109,24 +91,6 @@ func TestFuzzProcessBlock_1000(t *testing.T) {
 		fuzzer.Fuzz(state)
 		fuzzer.Fuzz(sb)
 		s, err := ProcessBlock(ctx, state, sb)
-		if err != nil && s != nil {
-			t.Fatalf("state should be nil on err. found: %v on error: %v for signed block: %v", s, err, sb)
-		}
-	}
-}
-
-func TestFuzzProcessBlockNoVerifyAttSigs_1000(t *testing.T) {
-	SkipSlotCache.Disable()
-	defer SkipSlotCache.Enable()
-	ctx := context.Background()
-	state := &stateTrie.BeaconState{}
-	sb := &ethpb.SignedBeaconBlock{}
-	fuzzer := fuzz.NewWithSeed(0)
-	fuzzer.NilChance(0.1)
-	for i := 0; i < 1000; i++ {
-		fuzzer.Fuzz(state)
-		fuzzer.Fuzz(sb)
-		s, err := ProcessBlockNoVerifyAttSigs(ctx, state, sb)
 		if err != nil && s != nil {
 			t.Fatalf("state should be nil on err. found: %v on error: %v for signed block: %v", s, err, sb)
 		}

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -43,7 +43,6 @@ type Flags struct {
 
 	// Feature related flags.
 	WriteSSZStateTransitions                   bool // WriteSSZStateTransitions to tmp directory.
-	InitSyncNoVerify                           bool // InitSyncNoVerify when initial syncing w/o verifying block's contents.
 	DisableDynamicCommitteeSubnets             bool // Disables dynamic attestation committee subnets via p2p.
 	SkipBLSVerify                              bool // Skips BLS verification across the runtime.
 	EnableBlst                                 bool // Enables new BLS library from supranational.
@@ -186,11 +185,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.Bool(disableSSZCache.Name) {
 		log.Warn("Disabled ssz cache")
 		cfg.EnableSSZCache = false
-	}
-	cfg.InitSyncNoVerify = false
-	if ctx.Bool(disableInitSyncVerifyEverythingFlag.Name) {
-		log.Warn("Initial syncing while verifying only the block proposer signatures.")
-		cfg.InitSyncNoVerify = true
 	}
 	if ctx.Bool(skipBLSVerifyFlag.Name) {
 		log.Warn("UNSAFE: Skipping BLS verification at runtime")

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -70,12 +70,6 @@ var (
 		Name:  "kafka-url",
 		Usage: "Stream attestations and blocks to specified kafka servers. This field is used for bootstrap.servers kafka config field.",
 	}
-	disableInitSyncVerifyEverythingFlag = &cli.BoolFlag{
-		Name: "disable-initial-sync-verify-all-signatures",
-		Usage: "Initial sync to finalized checkpoint with verifying block's signature, RANDAO " +
-			"and attestation's aggregated signatures. With this flag, only the proposer " +
-			"signature is verified until the node reaches the end of the finalized chain.",
-	}
 	cacheFilteredBlockTreeFlag = &cli.BoolFlag{
 		Name: "cache-filtered-block-tree",
 		Usage: "Cache filtered block tree by maintaining it rather than continually recalculating on the fly, " +
@@ -690,7 +684,6 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	disableForkChoiceUnsafeFlag,
 	disableDynamicCommitteeSubnets,
 	disableSSZCache,
-	disableInitSyncVerifyEverythingFlag,
 	skipBLSVerifyFlag,
 	kafkaBootstrapServersFlag,
 	enableBackupWebhookFlag,


### PR DESCRIPTION
Part of #7515 

This PR removes `disable-initial-sync-verify-all-signatures`. This is a very unsafe flag and we shouldn't have it for beta. This was nice to delete, it enabled us to delete old methods such as `ProcessBlockNoVerifyAttSigs` and `ExecuteStateTransitionNoVerifyAttSigs`