### PR TITLE
Update error usage patterns to go1.13+

### DIFF
--- a/beacon-chain/core/helpers/slot_epoch.go
+++ b/beacon-chain/core/helpers/slot_epoch.go
@@ -139,11 +139,11 @@ func VerifySlotTime(genesisTime, slot uint64, timeTolerance time.Duration) error
 func SlotToTime(genesisTimeSec, slot uint64) (time.Time, error) {
 	timeSinceGenesis, err := mathutil.Mul64(slot, params.BeaconConfig().SecondsPerSlot)
 	if err != nil {
-		return time.Unix(0, 0), fmt.Errorf("slot (%d) is in the far distant future: %v", slot, err)
+		return time.Unix(0, 0), fmt.Errorf("slot (%d) is in the far distant future: %w", slot, err)
 	}
 	sTime, err := mathutil.Add64(genesisTimeSec, timeSinceGenesis)
 	if err != nil {
-		return time.Unix(0, 0), fmt.Errorf("slot (%d) is in the far distant future: %v", slot, err)
+		return time.Unix(0, 0), fmt.Errorf("slot (%d) is in the far distant future: %w", slot, err)
 	}
 	return time.Unix(int64(sTime), 0), nil
 }

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -294,7 +294,7 @@ func ProcessSlots(ctx context.Context, state *stateTrie.BeaconState, slot uint64
 		highestSlot = cachedState.Slot()
 		state = cachedState
 	}
-	if err := SkipSlotCache.MarkInProgress(key); err == cache.ErrAlreadyInProgress {
+	if err := SkipSlotCache.MarkInProgress(key); errors.Is(err, cache.ErrAlreadyInProgress) {
 		cachedState, err = SkipSlotCache.Get(ctx, key)
 		if err != nil {
 			return nil, err

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -52,7 +52,7 @@ func NewKVStore(dirPath string, stateSummaryCache *cache.StateSummaryCache) (*St
 	datafile := path.Join(dirPath, databaseFileName)
 	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: 1 * time.Second, InitialMmapSize: 10e6})
 	if err != nil {
-		if err == bolt.ErrTimeout {
+		if errors.Is(err, bolt.ErrTimeout) {
 			return nil, errors.New("cannot obtain database lock, database may be in use by another process")
 		}
 		return nil, err

--- a/beacon-chain/p2p/handshake.go
+++ b/beacon-chain/p2p/handshake.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -110,7 +111,7 @@ func (s *Service) AddConnectionHandler(reqFunc func(ctx context.Context, id peer
 					}
 
 					// If peer hasn't sent a status request, we disconnect with them
-					if _, err := s.peers.ChainState(remotePeer); err == peerdata.ErrPeerUnknown {
+					if _, err := s.peers.ChainState(remotePeer); errors.Is(err, peerdata.ErrPeerUnknown) {
 						disconnectFromPeer()
 						return
 					}

--- a/beacon-chain/rpc/beacon/validators_stream.go
+++ b/beacon-chain/rpc/beacon/validators_stream.go
@@ -132,7 +132,7 @@ func (is *infostream) handleConnection() error {
 	go func() {
 		for {
 			msg, err := is.stream.Recv()
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				return
 			}
 			if err != nil {

--- a/beacon-chain/rpc/validator/attester.go
+++ b/beacon-chain/rpc/validator/attester.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	ptypes "github.com/gogo/protobuf/types"
@@ -51,7 +52,7 @@ func (vs *Server) GetAttestationData(ctx context.Context, req *ethpb.Attestation
 	}
 
 	if err := vs.AttestationCache.MarkInProgress(req); err != nil {
-		if err == cache.ErrAlreadyInProgress {
+		if errors.Is(err, cache.ErrAlreadyInProgress) {
 			res, err := vs.AttestationCache.Get(ctx, req)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "Could not retrieve data from attestation cache: %v", err)

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -364,7 +364,7 @@ func (f *blocksFetcher) requestBlocks(
 	for i := uint64(0); ; i++ {
 		isFirstChunk := i == 0
 		blk, err := prysmsync.ReadChunkedBlock(stream, f.p2p, isFirstChunk)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -202,7 +202,7 @@ func (q *blocksQueue) loop() {
 						"start":                     fsm.start,
 						"error":                     err.Error(),
 					}).Debug("Can not trigger event")
-					if err == errNoRequiredPeers {
+					if errors.Is(err, errNoRequiredPeers) {
 						forceExit := q.exitConditions.noRequiredPeersErrRetries > noRequiredPeersErrMaxRetries
 						if q.mode == modeStopOnFinalizedEpoch || forceExit {
 							q.cancel()

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -31,7 +31,7 @@ func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 	for i := 0; i < len(*blockRoots); i++ {
 		isFirstChunk := i == 0
 		blk, err := ReadChunkedBlock(stream, s.p2p, isFirstChunk)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		// Exit if peer sends more than max request blocks.

--- a/beacon-chain/sync/rpc_ping.go
+++ b/beacon-chain/sync/rpc_ping.go
@@ -33,7 +33,7 @@ func (s *Service) pingHandler(_ context.Context, msg interface{}, stream libp2pc
 	valid, err := s.validateSequenceNum(*m, stream.Conn().RemotePeer())
 	if err != nil {
 		// Descore peer for giving us a bad sequence number.
-		if err == errInvalidSequenceNum {
+		if errors.Is(err, errInvalidSequenceNum) {
 			s.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 			s.writeErrorResponseToStream(responseCodeInvalidRequest, seqError, stream)
 		}
@@ -122,7 +122,7 @@ func (s *Service) sendPingRequest(ctx context.Context, id peer.ID) error {
 	valid, err := s.validateSequenceNum(*msg, stream.Conn().RemotePeer())
 	if err != nil {
 		// Descore peer for giving us a bad sequence number.
-		if err == errInvalidSequenceNum {
+		if errors.Is(err, errInvalidSequenceNum) {
 			s.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 		}
 		return err

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -156,7 +156,7 @@ func (s *Service) sendRPCStatusRequest(ctx context.Context, id peer.ID) error {
 	if err != nil {
 		s.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 		// Disconnect if on a wrong fork.
-		if err == errWrongForkDigestVersion {
+		if errors.Is(err, errWrongForkDigestVersion) {
 			if err := s.sendGoodByeAndDisconnect(ctx, codeWrongNetwork, stream.Conn().RemotePeer()); err != nil {
 				return err
 			}

--- a/shared/aggregation/attestations/maxcover.go
+++ b/shared/aggregation/attestations/maxcover.go
@@ -32,7 +32,7 @@ func MaxCoverAttestationAggregation(atts []*ethpb.Attestation) ([]*ethpb.Attesta
 		// Find maximum non-overlapping coverage.
 		maxCover, err := NewMaxCover(unaggregated)
 		if err != nil {
-			if err == aggregation.ErrBitsDifferentLen {
+			if errors.Is(err, aggregation.ErrBitsDifferentLen) {
 				return atts, nil
 			}
 			return aggregated.merge(unaggregated), err

--- a/shared/prometheus/content_negotiation.go
+++ b/shared/prometheus/content_negotiation.go
@@ -41,7 +41,7 @@ func writeResponse(w http.ResponseWriter, r *http.Request, response generatedRes
 			return fmt.Errorf("unexpected data: %v", response.Data)
 		}
 		if _, err := w.Write(buf.Bytes()); err != nil {
-			return fmt.Errorf("could not write response body: %v", err)
+			return fmt.Errorf("could not write response body: %w", err)
 		}
 	case contentTypeJSON:
 		w.Header().Set("Content-Type", contentTypeJSON)

--- a/shared/promptutil/prompt.go
+++ b/shared/promptutil/prompt.go
@@ -148,12 +148,12 @@ func InputPassword(
 	for !hasValidPassword {
 		password, err = PasswordPrompt(promptText, passwordValidator)
 		if err != nil {
-			return "", fmt.Errorf("could not read password: %v", err)
+			return "", fmt.Errorf("could not read password: %w", err)
 		}
 		if shouldConfirmPassword {
 			passwordConfirmation, err := PasswordPrompt(confirmText, passwordValidator)
 			if err != nil {
-				return "", fmt.Errorf("could not read password confirmation: %v", err)
+				return "", fmt.Errorf("could not read password confirmation: %w", err)
 			}
 			if password != passwordConfirmation {
 				log.Error("Passwords do not match")

--- a/slasher/beaconclient/receivers.go
+++ b/slasher/beaconclient/receivers.go
@@ -35,7 +35,7 @@ func (bs *Service) ReceiveBlocks(ctx context.Context) {
 	for {
 		res, err := stream.Recv()
 		// If the stream is closed, we stop the loop.
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		// If context is canceled we stop the loop.
@@ -103,7 +103,7 @@ func (bs *Service) ReceiveAttestations(ctx context.Context) {
 	for {
 		res, err := stream.Recv()
 		// If the stream is closed, we stop the loop.
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			log.Info("Attestation stream closed")
 			break
 		}

--- a/slasher/db/kv/kv.go
+++ b/slasher/db/kv/kv.go
@@ -90,7 +90,7 @@ func NewKVStore(dirPath string, cfg *Config) (*Store, error) {
 	datafile := path.Join(dirPath, databaseFileName)
 	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: params.BeaconIoConfig().BoltTimeout})
 	if err != nil {
-		if err == bolt.ErrTimeout {
+		if errors.Is(err, bolt.ErrTimeout) {
 			return nil, errors.New("cannot obtain database lock, database may be in use by another process")
 		}
 		return nil, err

--- a/tools/cluster-pk-manager/server/server.go
+++ b/tools/cluster-pk-manager/server/server.go
@@ -223,7 +223,7 @@ func (s *server) checkDepositTxs(ctx context.Context, txMap map[*keystore.Key]*t
 	pks := make([][]byte, 0, len(txMap))
 	for k, tx := range txMap {
 		receipt, err := s.client.TransactionReceipt(ctx, tx.Hash())
-		if err == ethereum.NotFound {
+		if errors.Is(err, ethereum.NotFound) {
 			// tx still not processed yet.
 			continue
 		}

--- a/validator/accounts/v1/account.go
+++ b/validator/accounts/v1/account.go
@@ -149,7 +149,7 @@ func Exists(keystorePath string, assertNonEmpty bool) (bool, error) {
 
 	if assertNonEmpty {
 		_, err = f.Readdirnames(1) // Or f.Readdir(1)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return false, nil
 		}
 	}

--- a/validator/accounts/v2/accounts_import.go
+++ b/validator/accounts/v2/accounts_import.go
@@ -176,7 +176,7 @@ func ImportAccountsCli(cliCtx *cli.Context) error {
 			"Enter the password for your imported accounts", promptutil.NotEmpty,
 		)
 		if err != nil {
-			return fmt.Errorf("could not read account password: %v", err)
+			return fmt.Errorf("could not read account password: %w", err)
 		}
 	}
 	fmt.Println("Importing accounts, this may take a while...")

--- a/validator/accounts/v2/wallet/wallet.go
+++ b/validator/accounts/v2/wallet/wallet.go
@@ -536,13 +536,13 @@ func inputPassword(
 	for !hasValidPassword {
 		walletPassword, err = promptutil.PasswordPrompt(promptText, passwordValidator)
 		if err != nil {
-			return "", fmt.Errorf("could not read account password: %v", err)
+			return "", fmt.Errorf("could not read account password: %w", err)
 		}
 
 		if confirmPassword {
 			passwordConfirmation, err := promptutil.PasswordPrompt(ConfirmPasswordPromptText, passwordValidator)
 			if err != nil {
-				return "", fmt.Errorf("could not read password confirmation: %v", err)
+				return "", fmt.Errorf("could not read password confirmation: %w", err)
 			}
 			if walletPassword != passwordConfirmation {
 				log.Error("Passwords do not match")

--- a/validator/accounts/v2/wallet/wallet.go
+++ b/validator/accounts/v2/wallet/wallet.go
@@ -109,7 +109,7 @@ func Exists(walletDir string) (bool, error) {
 		return false, errors.Wrap(err, "could not parse wallet directory")
 	}
 	isValid, err := IsValid(walletDir)
-	if err == ErrNoWalletFound {
+	if errors.Is(err, ErrNoWalletFound) {
 		return false, nil
 	} else if err != nil {
 		return false, errors.Wrap(err, "could not check if dir is valid")
@@ -169,7 +169,7 @@ func OpenWalletOrElseCli(cliCtx *cli.Context, otherwise func(cliCtx *cli.Context
 		return otherwise(cliCtx)
 	}
 	isValid, err := IsValid(cliCtx.String(flags.WalletDirFlag.Name))
-	if err == ErrNoWalletFound {
+	if errors.Is(err, ErrNoWalletFound) {
 		return otherwise(cliCtx)
 	}
 	if err != nil {
@@ -222,7 +222,7 @@ func OpenWallet(_ context.Context, cfg *Config) (*Wallet, error) {
 	}
 	valid, err := IsValid(cfg.WalletDir)
 	// ErrNoWalletFound represents both a directory that does not exist as well as an empty directory
-	if err == ErrNoWalletFound {
+	if errors.Is(err, ErrNoWalletFound) {
 		return nil, ErrNoWalletFound
 	}
 	if err != nil {

--- a/validator/accounts/v2/wallet_recover.go
+++ b/validator/accounts/v2/wallet_recover.go
@@ -177,7 +177,7 @@ func inputMnemonic(cliCtx *cli.Context) (string, error) {
 		},
 	)
 	if err != nil {
-		return "", fmt.Errorf("could not get mnemonic language: %v", err)
+		return "", fmt.Errorf("could not get mnemonic language: %w", err)
 	}
 	bip39.SetWordList(allowedLanguages[selectedLanguage])
 	mnemonicPhrase, err := promptutil.ValidatePrompt(
@@ -185,7 +185,7 @@ func inputMnemonic(cliCtx *cli.Context) (string, error) {
 		"Enter the seed phrase for the wallet you would like to recover",
 		validateMnemonic)
 	if err != nil {
-		return "", fmt.Errorf("could not get mnemonic phrase: %v", err)
+		return "", fmt.Errorf("could not get mnemonic phrase: %w", err)
 	}
 	return mnemonicPhrase, nil
 }

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -263,7 +263,7 @@ func (v *validator) WaitForActivation(ctx context.Context) error {
 	for {
 		res, err := stream.Recv()
 		// If the stream is closed, we stop the loop.
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		// If context is canceled we stop the loop.

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -64,7 +64,7 @@ func NewKVStore(dirPath string, pubKeys [][48]byte) (*Store, error) {
 	datafile := filepath.Join(dirPath, ProtectionDbFileName)
 	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: params.BeaconIoConfig().BoltTimeout})
 	if err != nil {
-		if err == bolt.ErrTimeout {
+		if errors.Is(err, bolt.ErrTimeout) {
 			return nil, errors.New("cannot obtain database lock, database may be in use by another process")
 		}
 		return nil, err
@@ -105,7 +105,7 @@ func GetKVStore(directory string) (*Store, error) {
 	}
 	boltDb, err := bolt.Open(fileName, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: params.BeaconIoConfig().BoltTimeout})
 	if err != nil {
-		if err == bolt.ErrTimeout {
+		if errors.Is(err, bolt.ErrTimeout) {
 			return nil, errors.New("cannot obtain database lock, database may be in use by another process")
 		}
 		return nil, err

--- a/validator/rpc/auth.go
+++ b/validator/rpc/auth.go
@@ -133,7 +133,7 @@ func (s *Server) initializeWallet(ctx context.Context, cfg *wallet.Config) error
 		return wallet.ErrNoWalletFound
 	}
 	valid, err := wallet.IsValid(cfg.WalletDir)
-	if err == wallet.ErrNoWalletFound {
+	if errors.Is(err, wallet.ErrNoWalletFound) {
 		return wallet.ErrNoWalletFound
 	}
 	if err != nil {

--- a/validator/rpc/wallet.go
+++ b/validator/rpc/wallet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -183,7 +184,7 @@ func (s *Server) WalletConfig(ctx context.Context, _ *ptypes.Empty) (*pb.WalletR
 		return &pb.WalletResponse{}, nil
 	}
 	valid, err := wallet.IsValid(s.walletDir)
-	if err == wallet.ErrNoWalletFound {
+	if errors.Is(err, wallet.ErrNoWalletFound) {
 		return &pb.WalletResponse{}, nil
 	}
 	if err != nil {
@@ -255,7 +256,7 @@ func (s *Server) ChangePassword(ctx context.Context, req *pb.ChangePasswordReque
 		return nil, status.Errorf(codes.FailedPrecondition, noWalletMsg)
 	}
 	valid, err := wallet.IsValid(s.walletDir)
-	if err == wallet.ErrNoWalletFound {
+	if errors.Is(err, wallet.ErrNoWalletFound) {
 		return nil, status.Errorf(codes.FailedPrecondition, noWalletMsg)
 	}
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

> Other / Cleanup

**What does this PR do? Why is it needed?**
- In Golang 1.13 extra method for wrapping errors (see https://golang.org/pkg/errors/ for details) has been introduced.
- So, it is generally preferred, to use `errors.Is(err, errType)` instead of `err == errType` when comparing non-nil errors to some type (as former is able to unwrap wrapped errors and compare correctly).
- Additionally, instead of passing the original error in conventional `fmt.Errorf("sth wrong: %v", err)`, it is better to wrap the error using new verb `%w` (just `%v -> %w` is enough i.e. `fmt.Errorf("sth wrong: %w", err)`), as that way client code can get access to the original error (unwrap) if necessary.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- **IMP:** Since we are using `github.com/pkg/errors` to wrap errors, there are relatively few places with `fmt.Errorf()`. Existing code, which relies on that custom package, is not touched. For future code, however, *if stack trace is not required* it is probably worth considering using `fmt.Errorf("custom msg: %w", err)` to wrap errors.

