### PR TITLE
Slashing precompute: Only apply slashings to state if there are slashings to apply

### DIFF
--- a/beacon-chain/core/epoch/precompute/slashing.go
+++ b/beacon-chain/core/epoch/precompute/slashing.go
@@ -37,7 +37,7 @@ func ProcessSlashingsPrecompute(state *stateTrie.BeaconState, pBal *Balance) err
 		return false, nil
 	}
 
-	if len(slashings) == 0 {
+	if totalSlashing == 0 {
 		return nil
 	}
 	return state.ApplyToEveryValidator(validatorFunc)

--- a/beacon-chain/core/epoch/precompute/slashing.go
+++ b/beacon-chain/core/epoch/precompute/slashing.go
@@ -37,5 +37,8 @@ func ProcessSlashingsPrecompute(state *stateTrie.BeaconState, pBal *Balance) err
 		return false, nil
 	}
 
+	if len(slashings) == 0 {
+		return nil
+	}
 	return state.ApplyToEveryValidator(validatorFunc)
 }

--- a/beacon-chain/core/epoch/precompute/slashing_test.go
+++ b/beacon-chain/core/epoch/precompute/slashing_test.go
@@ -93,6 +93,18 @@ func TestProcessSlashingsPrecompute_SlashedLess(t *testing.T) {
 			// 3000000000 = (32  * 1e9 - 1*1e9)         / (1 * 1e9) * (3*1e9)             / (31*1e9)             * (1 * 1e9)
 			want: uint64(28000000000), // 31 * 1e9 - 3000000000
 		},
+		{ // Test for no slashings.
+			state: &pb.BeaconState{
+				Validators: []*ethpb.Validator{
+					{Slashed: true,
+						WithdrawableEpoch: params.BeaconConfig().EpochsPerSlashingsVector / 2,
+						EffectiveBalance:  params.BeaconConfig().MaxEffectiveBalance},
+					{ExitEpoch: params.BeaconConfig().FarFutureEpoch, EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance}},
+				Balances:  []uint64{params.BeaconConfig().MaxEffectiveBalance, params.BeaconConfig().MaxEffectiveBalance},
+				Slashings: []uint64{},
+			},
+			want: uint64(32000000000),
+		},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

As title describes.

**Which issues(s) does this PR fix?**

This reduces memory footprint by reducing unnecessary calls to ApplyToEveryValidator which has an expensive copy of all validators.

**Other notes for review**
