### PR TITLE
Export Inclusion Distance to Prometheus

### DIFF
--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -96,6 +96,50 @@ var (
 			"pubkey",
 		},
 	)
+	// ValidatorInclusionSlotsGaugeVec used to keep track of validator inclusion slots by public key.
+	ValidatorInclusionSlotsGaugeVec = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "validator",
+			Name:      "inclusion_slot",
+			Help:      "Inclusion slot of last attestation.",
+		},
+		[]string{
+			"pubkey",
+		},
+	)
+	// ValidatorCorrectlyVotedSourceGaugeVec used to keep track of validator's accuracy on voting source by public key.
+	ValidatorCorrectlyVotedSourceGaugeVec = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "validator",
+			Name:      "correctly_voted_source",
+			Help:      "True if correctly voted source in last attestation.",
+		},
+		[]string{
+			"pubkey",
+		},
+	)
+	// ValidatorCorrectlyVotedTargetGaugeVec used to keep track of validator's accuracy on voting target by public key.
+	ValidatorCorrectlyVotedTargetGaugeVec = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "validator",
+			Name:      "correctly_voted_target",
+			Help:      "True if correctly voted target in last attestation.",
+		},
+		[]string{
+			"pubkey",
+		},
+	)
+	// ValidatorCorrectlyVotedHeadGaugeVec used to keep track of validator's accuracy on voting target by public key.
+	ValidatorCorrectlyVotedHeadGaugeVec = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "validator",
+			Name:      "correctly_voted_head",
+			Help:      "True if correctly voted head in last attestation.",
+		},
+		[]string{
+			"pubkey",
+		},
+	)
 	// ValidatorAttestSuccessVec used to count successful attestations.
 	ValidatorAttestSuccessVec = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -207,6 +251,23 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 			if v.emitAccountMetrics {
 				ValidatorBalancesGaugeVec.WithLabelValues(fmtKey).Set(newBalance)
 				ValidatorInclusionDistancesGaugeVec.WithLabelValues(fmtKey).Set(float64(resp.InclusionDistances[i]))
+				ValidatorInclusionSlotsGaugeVec.WithLabelValues(fmtKey).Set(float64(resp.InclusionSlots[i]))
+				if resp.CorrectlyVotedSource[i] {
+					ValidatorCorrectlyVotedSourceGaugeVec.WithLabelValues(fmtKey).Set(1)
+				} else {
+					ValidatorCorrectlyVotedSourceGaugeVec.WithLabelValues(fmtKey).Set(0)
+				}
+				if resp.CorrectlyVotedTarget[i] {
+					ValidatorCorrectlyVotedTargetGaugeVec.WithLabelValues(fmtKey).Set(1)
+				} else {
+					ValidatorCorrectlyVotedTargetGaugeVec.WithLabelValues(fmtKey).Set(0)
+				}
+				if resp.CorrectlyVotedHead[i] {
+					ValidatorCorrectlyVotedHeadGaugeVec.WithLabelValues(fmtKey).Set(1)
+				} else {
+					ValidatorCorrectlyVotedHeadGaugeVec.WithLabelValues(fmtKey).Set(0)
+				}
+
 			}
 		}
 		v.prevBalance[pubKeyBytes] = resp.BalancesBeforeEpochTransition[i]

--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -161,7 +161,7 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 		for _, missingPubKey := range resp.MissingValidators {
 			fmtKey := fmt.Sprintf("%#x", missingPubKey)
 			ValidatorBalancesGaugeVec.WithLabelValues(fmtKey).Set(0)
-			ValidatorInclusionDistancesGaugeVec.WithLabelValues(fmtKey).Set(0)
+			ValidatorInclusionDistancesGaugeVec.WithLabelValues(fmtKey).Set(1)
 		}
 	}
 

--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -85,6 +85,17 @@ var (
 			"pubkey",
 		},
 	)
+	// ValidatorInclusionDistancesGaugeVec used to keep track of validator inclusion distances by public key.
+	ValidatorInclusionDistancesGaugeVec = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "validator",
+			Name:      "inclusion_distance",
+			Help:      "Inclusion distance of last attestation.",
+		},
+		[]string{
+			"pubkey",
+		},
+	)
 	// ValidatorAttestSuccessVec used to count successful attestations.
 	ValidatorAttestSuccessVec = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -150,6 +161,7 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 		for _, missingPubKey := range resp.MissingValidators {
 			fmtKey := fmt.Sprintf("%#x", missingPubKey)
 			ValidatorBalancesGaugeVec.WithLabelValues(fmtKey).Set(0)
+			ValidatorInclusionDistancesGaugeVec.WithLabelValues(fmtKey).Set(0)
 		}
 	}
 
@@ -195,6 +207,7 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 			}).Info("Previous epoch voting summary")
 			if v.emitAccountMetrics {
 				ValidatorBalancesGaugeVec.WithLabelValues(fmtKey).Set(newBalance)
+				ValidatorInclusionDistancesGaugeVec.WithLabelValues(fmtKey).Set(float64(resp.InclusionDistances[i]))
 			}
 		}
 		v.prevBalance[pubKeyBytes] = resp.BalancesBeforeEpochTransition[i]

--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -161,7 +161,6 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot uint64)
 		for _, missingPubKey := range resp.MissingValidators {
 			fmtKey := fmt.Sprintf("%#x", missingPubKey)
 			ValidatorBalancesGaugeVec.WithLabelValues(fmtKey).Set(0)
-			ValidatorInclusionDistancesGaugeVec.WithLabelValues(fmtKey).Set(1)
 		}
 	}
 


### PR DESCRIPTION
Export Inclusion distances and related metrics to Prometheus. 

I found these metrics to be useful to track locally performance while the explorers were having difficulty during non-finality