### PR TITLE
Print the underlying error when attestation fails to get pre state

### DIFF
--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -154,7 +154,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 
 	preState, err := s.chain.AttestationPreState(ctx, att)
 	if err != nil {
-		log.Error("Failed to retrieve pre state")
+		log.WithError(err).Error("Failed to retrieve pre state")
 		traceutil.AnnotateError(span, err)
 		return pubsub.ValidationIgnore
 	}


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

As title describes. From the logs, the message isn't helpful for troubleshooting without knowing the underlying error.

**Which issues(s) does this PR fix?**

**Other notes for review**
