### PR TITLE
Add Accept Terms of Use Flags to Accounts Commands

### DIFF
--- a/validator/accounts/cmd_accounts.go
+++ b/validator/accounts/cmd_accounts.go
@@ -31,6 +31,7 @@ this command outputs a deposit data string which is required to become a validat
 				featureconfig.MedallaTestnet,
 				featureconfig.SpadinaTestnet,
 				featureconfig.ZinkenTestnet,
+				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
 				return cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags)
@@ -55,6 +56,7 @@ this command outputs a deposit data string which is required to become a validat
 				featureconfig.MedallaTestnet,
 				featureconfig.SpadinaTestnet,
 				featureconfig.ZinkenTestnet,
+				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
 				return cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags)
@@ -80,6 +82,7 @@ this command outputs a deposit data string which is required to become a validat
 				featureconfig.MedallaTestnet,
 				featureconfig.SpadinaTestnet,
 				featureconfig.ZinkenTestnet,
+				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
 				return cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags)
@@ -109,6 +112,7 @@ this command outputs a deposit data string which is required to become a validat
 				featureconfig.MedallaTestnet,
 				featureconfig.SpadinaTestnet,
 				featureconfig.ZinkenTestnet,
+				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
 				return cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags)
@@ -135,6 +139,7 @@ this command outputs a deposit data string which is required to become a validat
 				featureconfig.MedallaTestnet,
 				featureconfig.SpadinaTestnet,
 				featureconfig.ZinkenTestnet,
+				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
 				return cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags)
@@ -166,6 +171,7 @@ this command outputs a deposit data string which is required to become a validat
 				featureconfig.MedallaTestnet,
 				featureconfig.SpadinaTestnet,
 				featureconfig.ZinkenTestnet,
+				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
 				return cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags)

--- a/validator/accounts/cmd_wallet.go
+++ b/validator/accounts/cmd_wallet.go
@@ -1,6 +1,7 @@
 package accounts
 
 import (
+	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/validator/flags"
 	"github.com/urfave/cli/v2"
@@ -29,6 +30,7 @@ var WalletCommands = &cli.Command{
 				featureconfig.MedallaTestnet,
 				featureconfig.SpadinaTestnet,
 				featureconfig.ZinkenTestnet,
+				cmd.AcceptTosFlag,
 			},
 			Action: func(cliCtx *cli.Context) error {
 				featureconfig.ConfigureValidator(cliCtx)
@@ -52,6 +54,7 @@ var WalletCommands = &cli.Command{
 				featureconfig.MedallaTestnet,
 				featureconfig.SpadinaTestnet,
 				featureconfig.ZinkenTestnet,
+				cmd.AcceptTosFlag,
 			},
 			Action: func(cliCtx *cli.Context) error {
 				featureconfig.ConfigureValidator(cliCtx)
@@ -74,6 +77,7 @@ var WalletCommands = &cli.Command{
 				featureconfig.MedallaTestnet,
 				featureconfig.SpadinaTestnet,
 				featureconfig.ZinkenTestnet,
+				cmd.AcceptTosFlag,
 			},
 			Action: func(cliCtx *cli.Context) error {
 				featureconfig.ConfigureValidator(cliCtx)


### PR DESCRIPTION
This PR adds the AcceptTosFlag to every validator account or wallet subcommand, as reported via issues in beta.0.rc