### PR TITLE
Final update: only copy validator which effective balance has an update

### DIFF
--- a/beacon-chain/core/epoch/BUILD.bazel
+++ b/beacon-chain/core/epoch/BUILD.bazel
@@ -15,8 +15,6 @@ go_library(
         "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
-        "@com_github_prometheus_client_golang//prometheus:go_default_library",
-        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
     ],
 )

--- a/beacon-chain/core/epoch/BUILD.bazel
+++ b/beacon-chain/core/epoch/BUILD.bazel
@@ -15,6 +15,8 @@ go_library(
         "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
     ],
 )

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -249,7 +249,7 @@ func ProcessFinalUpdates(state *stateTrie.BeaconState) (*stateTrie.BeaconState, 
 
 	bals := state.Balances()
 	vals := state.ValidatorsReadOnly()
-	var updates []uint64
+	var indicesToBeUpdated []uint64
 	for i, v := range vals {
 		if v == nil {
 			return nil, fmt.Errorf("validator %d is nil in state", i)
@@ -259,7 +259,7 @@ func ProcessFinalUpdates(state *stateTrie.BeaconState) (*stateTrie.BeaconState, 
 		}
 		balance := bals[i]
 		if balance+downwardThreshold < v.EffectiveBalance() || v.EffectiveBalance()+upwardThreshold < balance {
-			updates = append(updates, uint64(i))
+			indicesToBeUpdated = append(indicesToBeUpdated, uint64(i))
 		}
 	}
 
@@ -283,7 +283,7 @@ func ProcessFinalUpdates(state *stateTrie.BeaconState) (*stateTrie.BeaconState, 
 		return false, nil
 	}
 
-	if err := state.ApplyToEveryValidatorModified(updates, validatorFunc); err != nil {
+	if err := state.ApplyToEveryValidatorModified(indicesToBeUpdated, validatorFunc); err != nil {
 		return nil, err
 	}
 

--- a/beacon-chain/state/setters.go
+++ b/beacon-chain/state/setters.go
@@ -348,6 +348,8 @@ func (b *BeaconState) ApplyToEveryValidatorModified(indices []uint64, f func(idx
 	for _, i := range indices {
 		m[i] = true
 	}
+
+	// Only copy validators that are `indices`.
 	v := make([]*ethpb.Validator, len(b.state.Validators))
 	for i := 0; i < len(v); i++ {
 		if m[uint64(i)] {

--- a/beacon-chain/state/setters.go
+++ b/beacon-chain/state/setters.go
@@ -344,7 +344,6 @@ func (b *BeaconState) ApplyToEveryValidatorModified(indices []uint64, f func(idx
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
-
 	m := make(map[uint64]bool)
 	for _, i := range indices {
 		m[i] = true
@@ -357,15 +356,8 @@ func (b *BeaconState) ApplyToEveryValidatorModified(indices []uint64, f func(idx
 			v[i] = b.state.Validators[i]
 		}
 	}
-
-	if ref := b.sharedFieldReferences[validators]; ref.Refs() > 1 {
-		// Perform a copy since this is a shared reference and we don't want to mutate others.
-		v = b.validators()
-
-		ref.MinusRef()
-		b.sharedFieldReferences[validators] = &reference{refs: 1}
-	}
 	b.lock.Unlock()
+
 	var changedVals []uint64
 	for i, val := range v {
 		changed, err := f(i, val)


### PR DESCRIPTION
Related #7585 

Whenever there's one validator that requires effective balance change, the node **copies** the **whole** validator list. While this is acceptable early on, it becomes as a big bottleneck as more validators get introduced into the state. See latest heap:

<img width="1746" alt="Screen Shot 2020-10-21 at 7 54 12 PM" src="https://user-images.githubusercontent.com/21316537/96911916-62aa4100-1456-11eb-83e9-c198ef64d7ba.png">


I measured there's only 2k out of 80k validators that require effective balance change on per epoch interval, which means in the current Medalla testnet ~98% of the validator copy in ProcessFinalUpdates` can be eliminated. This can be a huge reduction!

This PR went with an approach to input a list of validator indices `[]uint64` that requires effective balance update and `ApplyToEveryValidatorModified` will only copy based on those validator indices. Since I'm not too familiar with `state pkg` in particular how we handle references, I want to open this PR to gather feedbacks

I did verify with this approach I could reduce most of the `ProcessFinalUpdates` flame
<img width="1616" alt="Screen Shot 2020-10-21 at 3 37 43 PM" src="https://user-images.githubusercontent.com/21316537/96794617-5e791780-13b3-11eb-829e-16853caf11c3.png">


