### PR TITLE
Move voluntary exit logging to `accounts_exit`

### DIFF
--- a/validator/accounts/cmd_accounts.go
+++ b/validator/accounts/cmd_accounts.go
@@ -2,9 +2,7 @@ package accounts
 
 import (
 	"os"
-	"strings"
 
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/tos"
@@ -198,11 +196,6 @@ this command outputs a deposit data string which is required to become a validat
 			Action: func(cliCtx *cli.Context) error {
 				featureconfig.ConfigureValidator(cliCtx)
 				if err := ExitAccountsCli(cliCtx, os.Stdin); err != nil {
-					msg := err.Error()
-					if strings.Contains(msg, blocks.ValidatorAlreadyExitedMsg) ||
-						strings.Contains(msg, blocks.ValidatorCannotExitYetMsg) {
-						log.Errorf("Could not perform voluntary exit: %s", msg)
-					}
 					log.Fatalf("Could not perform voluntary exit: %v", err)
 				}
 				return nil


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Moves voluntary exit logging into the correct place. Currently errors with stack traces are still logged out from `accounts_exit` even when validator couldn't be exited due to a non-critical reason.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A