### PR TITLE
Miscellaneous Docs Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 This is the core repository for Prysm, a [Golang](https://golang.org/) implementation of the Ethereum 2.0 client specifications developed by [Prysmatic Labs](https://prysmaticlabs.com).
 
 ### Getting Started
-A detailed set of installation and usage instructions as well as breakdowns of each individual component are available in the [official documentation portal](https://docs.prylabs.network). If you still have questions, feel free to stop by either our [Discord](https://discord.gg/KSA7rPr) or [Gitter](https://gitter.im/prysmaticlabs/geth-sharding?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) and a member of the team or our community will be happy to assist you.
+A detailed set of installation and usage instructions as well as breakdowns of each individual component are available in the [official documentation portal](https://
+docs.prylabs.network). If you still have questions, feel free to stop by either our [Discord](https://discord.gg/KSA7rPr) or [Gitter](https://gitter.im/prysmaticlabs/geth-sharding?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) and a member of the team or our community will be happy to assist you.
 
 ### Come join the testnet!
 Participation is now open to the public for our Ethereum 2.0 phase 0 testnet release. Visit [prylabs.net](https://prylabs.net) for more information on the project or to sign up as a validator on the network. You can visualize the nodes in the network on [eth2stats.io](https://eth2stats.io), explore validator rewards/penalties via Bitfly's block explorer: [beaconcha.in](https://beaconcha.in), and follow the latest blocks added to the chain on [Etherscan](https://beacon.etherscan.io).

--- a/validator/accounts/accounts_exit.go
+++ b/validator/accounts/accounts_exit.go
@@ -154,7 +154,8 @@ func interact(cliCtx *cli.Context, r io.Reader, validatingPublicKeys [][48]byte)
 		"Please navigate to the following website and make sure you understand the current implications " +
 		"of a voluntary exit before making the final decision:"
 	promptURL := au.Blue("https://docs.prylabs.network/docs/wallet/exiting-a-validator/#withdrawal-delay-warning")
-	promptQuestion := "If you still want to continue with the voluntary exit, please input the passphrase from the above URL"
+	promptQuestion := "If you still want to continue with the voluntary exit, please input a phrase found at the end " +
+		"of the page from the above URL"
 	promptText := fmt.Sprintf("%s\n%s\n%s\n%s", promptHeader, promptDescription, promptURL, promptQuestion)
 	resp, err := promptutil.ValidatePrompt(r, promptText, func(input string) error {
 		return promptutil.ValidatePhrase(input, exitPassphrase)

--- a/validator/accounts/wallet_create.go
+++ b/validator/accounts/wallet_create.go
@@ -49,7 +49,7 @@ func CreateAndSaveWalletCli(cliCtx *cli.Context) (*wallet.Wallet, error) {
 
 	w, err := CreateWalletWithKeymanager(cliCtx.Context, createWalletConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not create wallet with keymanager")
+		return nil, errors.Wrap(err, "could not create wallet")
 	}
 	return w, nil
 }

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -103,7 +103,7 @@ func (v *validator) WaitForWalletInitialization(ctx context.Context) error {
 				ctx, true, /* skipMnemonicConfirm */
 			)
 			if err != nil {
-				return errors.Wrap(err, "could not read keymanager for wallet")
+				return errors.Wrap(err, "could not read keymanager")
 			}
 			v.keyManager = keyManager
 			return nil

--- a/validator/rpc/accounts.go
+++ b/validator/rpc/accounts.go
@@ -97,7 +97,7 @@ func (s *Server) DeleteAccounts(
 		return nil, status.Error(codes.InvalidArgument, "No public keys specified to delete")
 	}
 	if s.wallet == nil || s.keymanager == nil {
-		return nil, status.Error(codes.FailedPrecondition, "No wallet nor keymanager found")
+		return nil, status.Error(codes.FailedPrecondition, "No wallet found")
 	}
 	if s.wallet.KeymanagerKind() != keymanager.Imported {
 		return nil, status.Error(codes.FailedPrecondition, "Only imported wallets can delete accounts")


### PR DESCRIPTION
This PR fixes a few minor things regarding docs in Prysm:
- The language for voluntary exits was not clear. People were asked to enter a 'passphrase' found in the docs page, but to some stakers, it sounded like they needed to enter their wallet password. We clarify this bit further in this PR
- Remove mentions of 'keymanager' in logs in the validator client, as users shouldn't be aware of what that is. Users should only need to know about wallets and that wallets can have different "kinds" such as remote, HD, and imported