### PR TITLE
Explicit Password Requirements

### DIFF
--- a/shared/promptutil/prompt.go
+++ b/shared/promptutil/prompt.go
@@ -143,7 +143,7 @@ func InputPassword(
 		return enteredPassword, nil
 	}
 	if strings.Contains(strings.ToLower(promptText), "new wallet") {
-		fmt.Println("Password requirements: at least 8 characters, 1 number, and 1 special character. " +
+		fmt.Println("Password requirements: at least 8 characters including at least 1 alphabetical character, 1 number, and 1 unicode special character. " +
 			"Must not be a common password nor easy to guess")
 	}
 	var hasValidPassword bool

--- a/shared/promptutil/prompt.go
+++ b/shared/promptutil/prompt.go
@@ -142,6 +142,10 @@ func InputPassword(
 		}
 		return enteredPassword, nil
 	}
+	if strings.Contains(strings.ToLower(promptText), "new wallet") {
+		fmt.Println("Password requirements: at least 8 characters, 1 number, and 1 special character. " +
+			"Must not be a common password nor easy to guess")
+	}
 	var hasValidPassword bool
 	var password string
 	var err error

--- a/shared/promptutil/validate.go
+++ b/shared/promptutil/validate.go
@@ -17,7 +17,10 @@ const (
 	minPasswordScore = 2
 )
 
-var errIncorrectPhrase = errors.New("input does not match wanted phrase")
+var (
+	errIncorrectPhrase = errors.New("input does not match wanted phrase")
+	passwordReqsError  = errors.New("password must have at least 8 characters, at least 1 alphabetical character, 1 unicode symbol, and 1 number")
+)
 
 // NotEmpty is a validation function to make sure the input given isn't empty and is valid unicode.
 func NotEmpty(input string) error {
@@ -101,10 +104,7 @@ func ValidatePasswordInput(input string) error {
 		}
 	}
 	if !(hasMinLen && hasLetter && hasNumber && hasSpecial) {
-		return errors.New(
-			"password must have at least 8 characters, at least 1 alphabetical character, " +
-				"1 unicode symbol, and 1 number",
-		)
+		return passwordReqsError
 	}
 	strength := strongPasswords.PasswordStrength(input, nil)
 	if strength.Score < minPasswordScore {

--- a/shared/promptutil/validate.go
+++ b/shared/promptutil/validate.go
@@ -91,7 +91,7 @@ func ValidatePasswordInput(input string) error {
 			unicode.IsNumber(char) ||
 			unicode.IsPunct(char) ||
 			unicode.IsSymbol(char)):
-			return errors.New("password must only contain alphanumeric characters, punctuation, or symbols")
+			return errors.New("password must only contain unicode alphanumeric characters, numbers, or unicode symbols")
 		case unicode.IsLetter(char):
 			hasLetter = true
 		case unicode.IsNumber(char):
@@ -102,7 +102,8 @@ func ValidatePasswordInput(input string) error {
 	}
 	if !(hasMinLen && hasLetter && hasNumber && hasSpecial) {
 		return errors.New(
-			"password must have more than 8 characters, at least 1 special character, and 1 number",
+			"password must have at least 8 characters, at least 1 alphabetical character, " +
+				"1 unicode symbol, and 1 number",
 		)
 	}
 	strength := strongPasswords.PasswordStrength(input, nil)

--- a/shared/promptutil/validate_test.go
+++ b/shared/promptutil/validate_test.go
@@ -18,17 +18,17 @@ func TestValidatePasswordInput(t *testing.T) {
 		{
 			name:      "no numbers nor special characters",
 			input:     "abcdefghijklmnopqrs",
-			wantedErr: "password must have more than 8 characters, at least 1 special character, and 1 number",
+			wantedErr: passwordReqsError.Error(),
 		},
 		{
 			name:      "number and letters but no special characters",
 			input:     "abcdefghijklmnopqrs2020",
-			wantedErr: "password must have more than 8 characters, at least 1 special character, and 1 number",
+			wantedErr: passwordReqsError.Error(),
 		},
 		{
 			name:      "numbers, letters, special characters, but too short",
 			input:     "abc2$",
-			wantedErr: "password must have more than 8 characters, at least 1 special character, and 1 number",
+			wantedErr: passwordReqsError.Error(),
 		},
 		{
 			name:  "proper length and strong password",
@@ -50,6 +50,11 @@ func TestValidatePasswordInput(t *testing.T) {
 		{
 			name:  "allow underscores",
 			input: "jXl!q5pkQn_syT6dbJ3X5plQ_9_iqJCTr_*UIoaDu#b6GYJD##^GI3qniKdr240f",
+		},
+		{
+			name:      "only numbers and symbols should fail",
+			input:     "123493489223423_23923929",
+			wantedErr: passwordReqsError.Error(),
 		},
 	}
 	for _, tt := range tests {

--- a/shared/promptutil/validate_test.go
+++ b/shared/promptutil/validate_test.go
@@ -43,6 +43,14 @@ func TestValidatePasswordInput(t *testing.T) {
 			name:  "allow spaces",
 			input: "x*329293@aAJSD i22903saj",
 		},
+		{
+			name:  "strong password from LastPass",
+			input: "jXl!q5pkQnXsyT6dbJ3X5plQ!9%iqJCTr&*UIoaDu#b6GYJD##^GI3qniKdr240f",
+		},
+		{
+			name:  "allow underscores",
+			input: "jXl!q5pkQn_syT6dbJ3X5plQ_9_iqJCTr_*UIoaDu#b6GYJD##^GI3qniKdr240f",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

This PR states explicit password requirements on startup for wallets, and adds more test cases to ensure passwords with many kinds of characters such as those generated by LastPass.
- We should specify that passwords need to have 1 alphabetical character, 1 number, 1 unicode symbol, and at least length 8
- We should add test cases for passwords that are numbers only
- We should add test cases for long passwords such as those from LastPass

**Which issues(s) does this PR fix?**

Fixes #7483