### PR TITLE
Clarify `No Wallet Found` Error Messages

### DIFF
--- a/validator/accounts/accounts_backup.go
+++ b/validator/accounts/accounts_backup.go
@@ -42,7 +42,9 @@ const (
 func BackupAccountsCli(cliCtx *cli.Context) error {
 	w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
 		return nil, errors.New(
-			"no wallet found, nothing to backup. Create a new wallet by running wallet create",
+			"no wallet found, no accounts to backup. " +
+				"Perhaps you created a wallet in a custom directory, which you can specify using " +
+				"--wallet-dir=/path/to/my/wallet",
 		)
 	})
 	if err != nil {

--- a/validator/accounts/accounts_backup.go
+++ b/validator/accounts/accounts_backup.go
@@ -41,11 +41,7 @@ const (
 // keystore.json files, which are compatible with importing in other eth2 clients.
 func BackupAccountsCli(cliCtx *cli.Context) error {
 	w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
-		return nil, errors.New(
-			"no wallet found, no accounts to backup. " +
-				"Perhaps you created a wallet in a custom directory, which you can specify using " +
-				"--wallet-dir=/path/to/my/wallet",
-		)
+		return nil, wallet.ErrNoWalletFound
 	})
 	if err != nil {
 		return errors.Wrap(err, "could not initialize wallet")

--- a/validator/accounts/accounts_delete.go
+++ b/validator/accounts/accounts_delete.go
@@ -28,11 +28,7 @@ type DeleteAccountConfig struct {
 // This function uses the CLI to extract necessary values.
 func DeleteAccountCli(cliCtx *cli.Context) error {
 	w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
-		return nil, errors.New(
-			"no wallet found, no accounts to delete. " +
-				"Perhaps you created a wallet in a custom directory, which you can specify using " +
-				"--wallet-dir=/path/to/my/wallet",
-		)
+		return nil, wallet.ErrNoWalletFound
 	})
 	if err != nil {
 		return errors.Wrap(err, "could not open wallet")

--- a/validator/accounts/accounts_delete.go
+++ b/validator/accounts/accounts_delete.go
@@ -29,7 +29,9 @@ type DeleteAccountConfig struct {
 func DeleteAccountCli(cliCtx *cli.Context) error {
 	w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
 		return nil, errors.New(
-			"no wallet found, nothing to delete",
+			"no wallet found, no accounts to delete. " +
+				"Perhaps you created a wallet in a custom directory, which you can specify using " +
+				"--wallet-dir=/path/to/my/wallet",
 		)
 	})
 	if err != nil {

--- a/validator/accounts/accounts_exit.go
+++ b/validator/accounts/accounts_exit.go
@@ -76,11 +76,7 @@ func ExitAccountsCli(cliCtx *cli.Context, r io.Reader) error {
 
 func prepareWallet(cliCtx *cli.Context) ([][48]byte, keymanager.IKeymanager, error) {
 	w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
-		return nil, errors.New(
-			"no wallet found, no accounts to exit. " +
-				"Perhaps you created a wallet in a custom directory, which you can specify using " +
-				"--wallet-dir=/path/to/my/wallet",
-		)
+		return nil, wallet.ErrNoWalletFound
 	})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "could not open wallet")

--- a/validator/accounts/accounts_exit.go
+++ b/validator/accounts/accounts_exit.go
@@ -77,7 +77,9 @@ func ExitAccountsCli(cliCtx *cli.Context, r io.Reader) error {
 func prepareWallet(cliCtx *cli.Context) ([][48]byte, keymanager.IKeymanager, error) {
 	w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
 		return nil, errors.New(
-			"no wallet found, no accounts to exit",
+			"no wallet found, no accounts to exit. " +
+				"Perhaps you created a wallet in a custom directory, which you can specify using " +
+				"--wallet-dir=/path/to/my/wallet",
 		)
 	})
 	if err != nil {

--- a/validator/accounts/accounts_list.go
+++ b/validator/accounts/accounts_list.go
@@ -21,11 +21,7 @@ import (
 // ListAccountsCli displays all available validator accounts in a Prysm wallet.
 func ListAccountsCli(cliCtx *cli.Context) error {
 	w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
-		return nil, errors.New(
-			"no wallet found, no accounts to list. " +
-				"Perhaps you created a wallet in a custom directory, which you can specify using " +
-				"--wallet-dir=/path/to/my/wallet",
-		)
+		return nil, wallet.ErrNoWalletFound
 	})
 	if err != nil {
 		return errors.Wrap(err, "could not open wallet")

--- a/validator/accounts/accounts_list.go
+++ b/validator/accounts/accounts_list.go
@@ -22,7 +22,9 @@ import (
 func ListAccountsCli(cliCtx *cli.Context) error {
 	w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
 		return nil, errors.New(
-			"no wallet found, no accounts to list",
+			"no wallet found, no accounts to list. " +
+				"Perhaps you created a wallet in a custom directory, which you can specify using " +
+				"--wallet-dir=/path/to/my/wallet",
 		)
 	})
 	if err != nil {

--- a/validator/accounts/wallet/wallet.go
+++ b/validator/accounts/wallet/wallet.go
@@ -49,7 +49,9 @@ const (
 var (
 	// ErrNoWalletFound signifies there was no wallet directory found on-disk.
 	ErrNoWalletFound = errors.New(
-		"no wallet found at path, please create a new wallet using `./prysm.sh validator wallet create`",
+		"no wallet found. You can create a new wallet with validator wallet create." +
+			"If you already did, perhaps you created a wallet in a custom directory, which you can specify using " +
+			"--wallet-dir=/path/to/my/wallet",
 	)
 	// KeymanagerKindSelections as friendly text.
 	KeymanagerKindSelections = map[keymanager.Kind]string{

--- a/validator/accounts/wallet/wallet_test.go
+++ b/validator/accounts/wallet/wallet_test.go
@@ -140,7 +140,7 @@ func Test_IsValid_RandomFiles(t *testing.T) {
 	require.NoError(t, os.MkdirAll(path, params.BeaconIoConfig().ReadWriteExecutePermissions), "Failed to create directory")
 
 	valid, err = wallet.IsValid(path)
-	require.ErrorContains(t, "no wallet found at path", err)
+	require.ErrorContains(t, "no wallet found", err)
 	require.Equal(t, false, valid)
 
 	walletDir := filepath.Join(path, "direct")

--- a/validator/accounts/wallet_edit.go
+++ b/validator/accounts/wallet_edit.go
@@ -16,11 +16,7 @@ import (
 // for HD wallets, and more.
 func EditWalletConfigurationCli(cliCtx *cli.Context) error {
 	w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
-		return nil, errors.New(
-			"no wallet found, no configuration to edit. " +
-				"Perhaps you created a wallet in a custom directory, which you can specify using " +
-				"--wallet-dir=/path/to/my/wallet",
-		)
+		return nil, wallet.ErrNoWalletFound
 	})
 	if err != nil {
 		return errors.Wrap(err, "could not open wallet")

--- a/validator/accounts/wallet_edit.go
+++ b/validator/accounts/wallet_edit.go
@@ -17,7 +17,9 @@ import (
 func EditWalletConfigurationCli(cliCtx *cli.Context) error {
 	w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
 		return nil, errors.New(
-			"no wallet found, no configuration to edit",
+			"no wallet found, no configuration to edit. " +
+				"Perhaps you created a wallet in a custom directory, which you can specify using " +
+				"--wallet-dir=/path/to/my/wallet",
 		)
 	})
 	if err != nil {

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -170,11 +170,7 @@ func (s *ValidatorClient) initializeFromCLI(cliCtx *cli.Context) error {
 	} else {
 		// Read the wallet from the specified path.
 		w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
-			return nil, errors.New(
-				"no wallet found, create a new one with validator wallet create. " +
-					"Perhaps you created a wallet in a custom directory, which you can specify using " +
-					"--wallet-dir=/path/to/my/wallet",
-			)
+			return nil, wallet.ErrNoWalletFound
 		})
 		if err != nil {
 			return errors.Wrap(err, "could not open wallet")

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -170,7 +170,11 @@ func (s *ValidatorClient) initializeFromCLI(cliCtx *cli.Context) error {
 	} else {
 		// Read the wallet from the specified path.
 		w, err := wallet.OpenWalletOrElseCli(cliCtx, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
-			return nil, errors.New("no wallet found, create a new one with validator wallet create")
+			return nil, errors.New(
+				"no wallet found, create a new one with validator wallet create. " +
+					"Perhaps you created a wallet in a custom directory, which you can specify using " +
+					"--wallet-dir=/path/to/my/wallet",
+			)
 		})
 		if err != nil {
 			return errors.Wrap(err, "could not open wallet")

--- a/validator/rpc/wallet.go
+++ b/validator/rpc/wallet.go
@@ -23,7 +23,6 @@ import (
 const (
 	checkExistsErrMsg   = "Could not check if wallet exists"
 	checkValidityErrMsg = "Could not check if wallet is valid"
-	noWalletMsg         = "No wallet found at path"
 	invalidWalletMsg    = "Directory does not contain a valid wallet"
 )
 


### PR DESCRIPTION
Some stakers find it confusing that they create a wallet, then run `prysm validator` but they see a `no wallet found` error message, missing that they had probably created a custom wallet directory. This error is now changed to give them the following info: 

```go
"no wallet found, no accounts to delete. Perhaps you created a wallet in a custom directory, which you can specify using --wallet-dir=/path/to/my/wallet"
```
