### PR TITLE
Do Not Recommend --ssl-no-revoke When Downloading Prysm Scripts

### DIFF
--- a/prysm.bat
+++ b/prysm.bat
@@ -47,7 +47,7 @@ if %WinOS%==64BIT (
 mkdir %wrapper_dir%
 
 REM get_prysm_version - Find the latest Prysm version available for download.
-(for /f %%i in ('curl -f -s https://prysmaticlabs.com/releases/latest') do set prysm_version=%%i) || (echo [31mERROR: Starting prysm requires an internet connection. If you are being blocked by your antivirus, you can re-run with --ssl-no-revoke [0m && exit /b 1)
+(for /f %%i in ('curl -f -s https://prysmaticlabs.com/releases/latest') do set prysm_version=%%i) || (echo [31mERROR: Starting prysm requires an internet connection. If you are being blocked by your antivirus, you can download the beacon chain and validator executables from our releases page on Github here https://github.com/prysmaticlabs/prysm/releases/ [0m && exit /b 1)
 echo [37mLatest prysm release is %prysm_version%.[0m
 IF defined USE_PRYSM_VERSION (
     echo [33mdetected variable USE_PRYSM_VERSION=%USE_PRYSM_VERSION%[0m

--- a/prysm.sh
+++ b/prysm.sh
@@ -107,7 +107,7 @@ function get_prysm_version() {
     else
         # Find the latest Prysm version available for download.
         readonly reason="automatically selected latest available version"
-        prysm_version=$(curl -f -s https://prysmaticlabs.com/releases/latest) || (color "31" "Starting prysm requires an internet connection. If you are being blocked by your antivirus, you can re-run with --ssl-no-revoke" && exit 1)
+        prysm_version=$(curl -f -s https://prysmaticlabs.com/releases/latest) || (color "31" "Starting prysm requires an internet connection. If you are being blocked by your antivirus, you can download the beacon chain and validator executables from our releases page on Github here https://github.com/prysmaticlabs/prysm/releases/" && exit 1)
         readonly prysm_version
     fi
 }


### PR DESCRIPTION
This fixes #7552, which tells the user to rerun the prysm.sh or bat script with `--ssl-no-revoke` if blocked by their antivirus. This is confusing as users will try `prysm.sh beacon-chain --ssl-no-revoke` and get failures. Instead, if users are faced with this problem we recommend them to download the executables from our releases page directly.