### PR TITLE
Handle voting ties in BestFinalized()

### DIFF
--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -452,7 +452,7 @@ func (p *Status) BestFinalized(maxPeers int, ourFinalizedEpoch uint64) (uint64, 
 	var targetEpoch uint64
 	var mostVotes uint64
 	for epoch, count := range finalizedEpochVotes {
-		if count > mostVotes {
+		if count > mostVotes || (count == mostVotes && epoch > targetEpoch) {
 			mostVotes = count
 			targetEpoch = epoch
 		}

--- a/beacon-chain/p2p/peers/status_test.go
+++ b/beacon-chain/p2p/peers/status_test.go
@@ -651,6 +651,22 @@ func TestStatus_BestPeer(t *testing.T) {
 			targetEpoch:        6,
 			targetEpochSupport: 4,
 		},
+		{
+			name: "handle epoch ties",
+			peers: []*peerConfig{
+				{finalizedEpoch: 6, headSlot: 6 * params.BeaconConfig().SlotsPerEpoch},
+				{finalizedEpoch: 6, headSlot: 6 * params.BeaconConfig().SlotsPerEpoch},
+				{finalizedEpoch: 6, headSlot: 6 * params.BeaconConfig().SlotsPerEpoch},
+				{finalizedEpoch: 7, headSlot: 7 * params.BeaconConfig().SlotsPerEpoch},
+				{finalizedEpoch: 8, headSlot: 8 * params.BeaconConfig().SlotsPerEpoch},
+				{finalizedEpoch: 8, headSlot: 8 * params.BeaconConfig().SlotsPerEpoch},
+				{finalizedEpoch: 8, headSlot: 8 * params.BeaconConfig().SlotsPerEpoch},
+			},
+			ourFinalizedEpoch:  5,
+			limitPeers:         15,
+			targetEpoch:        8,
+			targetEpochSupport: 3,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**
- Another minor bug (sorry, should have spotted it in https://github.com/prysmaticlabs/prysm/pull/7619)
- Basically, if two (or more) epochs receive the same number of votes, then `targetEpoch` is not set to best/max finalized, but to arbitrary selected among those best scoring (we are looping using range, so whichever epoch comes first is selected).
- This PR resolves it + adds regression test.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
