### PR TITLE
Fix panic issues on beacon node shutdown

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -155,11 +155,9 @@ func NewBeaconNode(cliCtx *cli.Context) (*BeaconNode, error) {
 
 	registry := shared.NewServiceRegistry()
 
-	ctx, cancel := context.WithCancel(cliCtx.Context)
 	beacon := &BeaconNode{
 		cliCtx:            cliCtx,
-		ctx:               ctx,
-		cancel:            cancel,
+		ctx:               cliCtx.Context,
 		services:          registry,
 		stop:              make(chan struct{}),
 		stateFeed:         new(event.Feed),
@@ -279,7 +277,6 @@ func (b *BeaconNode) Close() {
 	defer b.lock.Unlock()
 
 	log.Info("Stopping beacon node")
-	b.cancel() // Cancel the beacon node struct's context.
 	b.services.StopAll()
 	if err := b.db.Close(); err != nil {
 		log.Errorf("Failed to close database: %v", err)
@@ -306,7 +303,7 @@ func (b *BeaconNode) startDB(cliCtx *cli.Context) error {
 	}
 	clearDBConfirmed := false
 	if clearDB && !forceClearDB {
-		actionText := "This will delete your beacon chain data base stored in your data directory. " +
+		actionText := "This will delete your beacon chain database stored in your data directory. " +
 			"Your database backups will not be removed - do you want to proceed? (Y/N)"
 		deniedText := "Database will not be deleted. No changes have been made."
 		clearDBConfirmed, err = cmd.ConfirmAction(actionText, deniedText)

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -62,7 +62,6 @@ const testSkipPowFlag = "test-skip-pow"
 type BeaconNode struct {
 	cliCtx            *cli.Context
 	ctx               context.Context
-	cancel            context.CancelFunc
 	services          *shared.ServiceRegistry
 	lock              sync.RWMutex
 	stop              chan struct{} // Channel to wait for termination notifications.

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -207,7 +207,7 @@ func (s *Service) Start() {
 			s.privKey,
 		)
 		if err != nil {
-			log.WithError(err).Error("Failed to start discovery")
+			log.WithError(err).Fatal("Failed to start discovery")
 			s.startupErr = err
 			return
 		}

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -207,7 +207,7 @@ func (s *Service) Start() {
 			s.privKey,
 		)
 		if err != nil {
-			log.WithError(err).Fatal("Failed to start discovery")
+			log.WithError(err).Error("Failed to start discovery")
 			s.startupErr = err
 			return
 		}

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -109,6 +109,9 @@ func (s *Service) Start() {
 	}
 	s.waitForMinimumPeers()
 	if err := s.roundRobinSync(genesis); err != nil {
+		if errors.Is(s.ctx.Err(), context.Canceled) {
+			return
+		}
 		panic(err)
 	}
 	log.Infof("Synced up to slot %d", s.chain.HeadSlot())


### PR DESCRIPTION
What type of PR is this?

Bug fix

What does this PR do? Why is it needed?

Fixes a few panics and allows services to gracefully recover when shutting down the beacon node.

Which issues(s) does this PR fix?

Fixes #6924

**Other notes for review**

N/A
