### PR TITLE
Forkchoice: update read only lock to regular lock

### DIFF
--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -45,10 +45,9 @@ func (f *ForkChoice) Head(ctx context.Context, justifiedEpoch uint64, justifiedR
 
 	newBalances := justifiedStateBalances
 
-	// Using the read lock is ok here, rest of the operations below is read only.
-	// The only time it writes to node indices is inserting and pruning blocks from the store.
-	f.store.nodesLock.RLock()
-	defer f.store.nodesLock.RUnlock()
+	// Using the write lock here because `updateCanonicalNodes` that gets called subsequently requires a write operation.
+	f.store.nodesLock.Lock()
+	defer f.store.nodesLock.Unlock()
 	deltas, newVotes, err := computeDeltas(ctx, f.store.nodesIndices, f.votes, f.balances, newBalances)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "Could not compute deltas")


### PR DESCRIPTION
The following concurrent read write was reported by @dv8silencer . This PR fixes it by updating the previous read only lock to a regular lock.

```
fatal error: concurrent map read and map write

goroutine 23503376 [running]:
runtime.throw(0x19e229d, 0x21)
        GOROOT/src/runtime/panic.go:1116 +0x72 fp=0xc05468a500 sp=0xc05468a4d0 pc=0x459722
runtime.mapaccess1(0x1759760, 0xc0445000f0, 0xc05468a568, 0xc05b60bc00)
        GOROOT/src/runtime/map.go:411 +0x24b fp=0xc05468a540 sp=0xc05468a500 pc=0x432cab
github.com/prysmaticlabs/prysm/beacon-chain/forkchoice/protoarray.(*ForkChoice).IsCanonical(0xc0444df130, 0x7c60daf2f555100a, 0xbf5198380528c79f, 0x46415d76849e4988, 0xf3ba6b8aff39bdfc, 0x46415d76849e4900)
        beacon-chain/forkchoice/protoarray/store.go:167 +0xb0 fp=0xc05468a5a8 sp=0xc05468a540 pc=0xd96390
github.com/prysmaticlabs/prysm/beacon-chain/blockchain.(*Service).IsCanonical(0xc00000c5a0, 0x1dbcc80, 0xc07640df50, 0x7c60daf2f555100a, 0xbf5198380528c79f, 0x46415d76849e4988, 0xf3ba6b8aff39bdfc, 0xc05468a601, 0x0, 0x0)
        beacon-chain/blockchain/chain_info.go:259 +0xb8 fp=0xc05468a5f8 sp=0xc05468a5a8 pc=0x132ad78
github.com/prysmaticlabs/prysm/beacon-chain/sync.(*Service).filterBlocks(0xc0006e8600, 0x1dbcc80, 0xc07640df50, 0xc04114d040, 0x26, 0x26, 0xc03264c500, 0x26, 0x26, 0xc062a25d80, ...)
        beacon-chain/sync/rpc_beacon_blocks_by_range.go:221 +0x2a5 fp=0xc05468a718 sp=0xc05468a5f8 pc=0x13ec7b5
github.com/prysmaticlabs/prysm/beacon-chain/sync.(*Service).writeBlockRangeToStream(0xc0006e8600, 0x1dbcc80, 0xc07640df50, 0x7a13f, 0x7a17e, 0x1, 0xc05468ae00, 0x1dd63e0, 0xc06abcfdc0, 0x0, ...)
        beacon-chain/sync/rpc_beacon_blocks_by_range.go:157 +0x74c fp=0xc05468ad40 sp=0xc05468a718 pc=0x13eb65c
github.com/prysmaticlabs/prysm/beacon-chain/sync.(*Service).beaconBlocksByRangeRPCHandler(0xc0006e8600, 0x1dbcbc0, 0xc05844bb80, 0x194ef00, 0xc05844bb40, 0x1dd63e0, 0xc06abcfdc0, 0x0, 0x0)
        beacon-chain/sync/rpc_beacon_blocks_by_range.go:89 +0x82a fp=0xc05468b118 sp=0xc05468ad40 pc=0x13ea8da
github.com/prysmaticlabs/prysm/beacon-chain/sync.(*Service).beaconBlocksByRangeRPCHandler-fm(0x1dbcc80, 0xc07640de60, 0x194ef00, 0xc05844bb40, 0x1dd63e0, 0xc06abcfdc0, 0x0, 0x1dbcc80)
        beacon-chain/sync/rpc_beacon_blocks_by_range.go:20 +0x69 fp=0xc05468b170 sp=0xc05468b118 pc=0x140c839
github.com/prysmaticlabs/prysm/beacon-chain/sync.(*Service).registerRPC.func1(0x1dd63e0, 0xc06abcfdc0)
        beacon-chain/sync/rpc.go:124 +0xea3 fp=0xc05468bf60 sp=0xc05468b170 pc=0x1406313
github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandler.func1(0xc058455480, 0x3a, 0x7f897c0c4828, 0xc06abcfdc0, 0x1, 0x0)
        external/com_github_libp2p_go_libp2p/p2p/host/basic/basic_host.go:566 +0x9d fp=0xc05468bfb0 sp=0xc05468bf60 pc=0x1167e8d
runtime.goexit()
        GOROOT/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc05468bfb8 sp=0xc05468bfb0 pc=0x48ca11
created by github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newStreamHandler
        external/com_github_libp2p_go_libp2p/p2p/host/basic/basic_host.go:416 +0x63c

goroutine 1 [chan receive, 311 minutes]:
github.com/prysmaticlabs/prysm/beacon-chain/node.(*BeaconNode).Start(0xc00021cc60)
        beacon-chain/node/node.go:270 +0x1dc
main.startNode(0xc0007198c0, 0xc000112b00, 0x0)
        beacon-chain/main.go:202 +0xe8
github.com/urfave/cli/v2.(*App).RunContext(0xc000b02600, 0x1dbcc00, 0xc0000400d0, 0xc00003c0f0, 0xf, 0xf, 0x0, 0x0)
```