### PR TITLE
Better locks in fork choice

### DIFF
--- a/beacon-chain/forkchoice/protoarray/BUILD.bazel
+++ b/beacon-chain/forkchoice/protoarray/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "helpers_test.go",
         "no_vote_test.go",
         "nodes_test.go",
+        "store_test.go",
         "vote_test.go",
     ],
     embed = [":go_default_library"],

--- a/beacon-chain/forkchoice/protoarray/BUILD.bazel
+++ b/beacon-chain/forkchoice/protoarray/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+        "@com_github_trailofbits_go_mutexasserts//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
     ],
 )

--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -2,6 +2,7 @@ package protoarray
 
 import (
 	"context"
+	"encoding/hex"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -44,7 +45,9 @@ func (f *ForkChoice) Head(ctx context.Context, justifiedEpoch uint64, justifiedR
 	newBalances := justifiedStateBalances
 
 	f.votesLock.Lock()
+	f.store.nodeIndicesLock.RLock()
 	deltas, newVotes, err := computeDeltas(ctx, f.store.nodesIndices, f.votes, f.balances, newBalances)
+	f.store.nodeIndicesLock.RUnlock()
 	if err != nil {
 		f.votesLock.Unlock()
 		return [32]byte{}, errors.Wrap(err, "Could not compute deltas")
@@ -222,9 +225,14 @@ func (s *Store) Nodes() []*Node {
 	return s.nodes
 }
 
-// NodesIndices of fork choice store.
-func (s *Store) NodesIndices() map[[32]byte]uint64 {
+// NodesIndices of fork choice store, representing the map key as the hex encoded string of the 32
+// byte root. Note: hex strings are prefixed with `0x`.
+func (s *Store) NodesIndices() map[string]uint64 {
 	s.nodesLock.RLock()
 	defer s.nodesLock.RUnlock()
-	return s.nodesIndices
+	indices := make(map[string]uint64, len(s.nodesIndices))
+	for k, v := range s.nodesIndices {
+		indices["0x"+hex.EncodeToString(k[:])] = v
+	}
+	return indices
 }

--- a/beacon-chain/forkchoice/protoarray/store_test.go
+++ b/beacon-chain/forkchoice/protoarray/store_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestStore_NodesIndices(t *testing.T) {
 	type fields struct {
-		nodesIndices       map[[32]byte]uint64
+		nodesIndices map[[32]byte]uint64
 	}
 	tests := []struct {
 		name   string
@@ -33,7 +33,7 @@ func TestStore_NodesIndices(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Store{
-				nodesIndices:       tt.fields.nodesIndices,
+				nodesIndices: tt.fields.nodesIndices,
 			}
 			if got := s.NodesIndices(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NodesIndices() = %v, want %v", got, tt.want)

--- a/beacon-chain/forkchoice/protoarray/store_test.go
+++ b/beacon-chain/forkchoice/protoarray/store_test.go
@@ -1,0 +1,43 @@
+package protoarray
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+)
+
+func TestStore_NodesIndices(t *testing.T) {
+	type fields struct {
+		nodesIndices       map[[32]byte]uint64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   map[string]uint64
+	}{
+		{
+			name: "converts 32 byte key to hex string",
+			fields: fields{
+				nodesIndices: map[[32]byte]uint64{
+					bytesutil.ToBytes32([]byte{0x01}): 1,
+					bytesutil.ToBytes32([]byte{0x02}): 2,
+				},
+			},
+			want: map[string]uint64{
+				"0x0100000000000000000000000000000000000000000000000000000000000000": 1,
+				"0x0200000000000000000000000000000000000000000000000000000000000000": 2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Store{
+				nodesIndices:       tt.fields.nodesIndices,
+			}
+			if got := s.NodesIndices(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NodesIndices() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/beacon-chain/forkchoice/protoarray/types.go
+++ b/beacon-chain/forkchoice/protoarray/types.go
@@ -12,14 +12,16 @@ type ForkChoice struct {
 
 // Store defines the fork choice store which includes block nodes and the last view of checkpoint information.
 type Store struct {
-	pruneThreshold uint64              // do not prune tree unless threshold is reached.
-	justifiedEpoch uint64              // latest justified epoch in store.
-	finalizedEpoch uint64              // latest finalized epoch in store.
-	finalizedRoot  [32]byte            // latest finalized root in store.
-	nodes          []*Node             // list of block nodes, each node is a representation of one block.
-	nodesIndices   map[[32]byte]uint64 // the root of block node and the nodes index in the list.
-	canonicalNodes map[[32]byte]bool   // the canonical block nodes.
-	nodesLock      sync.RWMutex
+	pruneThreshold     uint64              // do not prune tree unless threshold is reached.
+	justifiedEpoch     uint64              // latest justified epoch in store.
+	finalizedEpoch     uint64              // latest finalized epoch in store.
+	finalizedRoot      [32]byte            // latest finalized root in store.
+	nodes              []*Node             // list of block nodes, each node is a representation of one block.
+	nodesIndices       map[[32]byte]uint64 // the root of block node and the nodes index in the list.
+	canonicalNodes     map[[32]byte]bool   // the canonical block nodes.
+	nodesLock          sync.RWMutex
+	nodeIndicesLock    sync.RWMutex
+	canonicalNodesLock sync.RWMutex
 }
 
 // Node defines the individual block which includes its block parent, ancestor and how much weight accounted for it.

--- a/beacon-chain/rpc/debug/forkchoice.go
+++ b/beacon-chain/rpc/debug/forkchoice.go
@@ -2,7 +2,6 @@ package debug
 
 import (
 	"context"
-	"encoding/hex"
 
 	ptypes "github.com/gogo/protobuf/types"
 	pbrpc "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
@@ -29,16 +28,11 @@ func (ds *Server) GetProtoArrayForkChoice(_ context.Context, _ *ptypes.Empty) (*
 		}
 	}
 
-	indices := make(map[string]uint64, len(store.NodesIndices()))
-	for k, v := range store.NodesIndices() {
-		indices[hex.EncodeToString(k[:])] = v
-	}
-
 	return &pbrpc.ProtoArrayForkChoiceResponse{
 		PruneThreshold:  store.PruneThreshold(),
 		JustifiedEpoch:  store.JustifiedEpoch(),
 		FinalizedEpoch:  store.FinalizedEpoch(),
 		ProtoArrayNodes: returnedNodes,
-		Indices:         indices,
+		Indices:         store.NodesIndices(),
 	}, nil
 }

--- a/deps.bzl
+++ b/deps.bzl
@@ -3654,3 +3654,9 @@ def prysm_deps():
         sum = "h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=",
         version = "v1.5.1",
     )
+    go_repository(
+        name = "com_github_trailofbits_go_mutexasserts",
+        importpath = "github.com/trailofbits/go-mutexasserts",
+        sum = "h1:8LRP+2JK8piIUU16ZDgWDXwjJcuJNTtCzadjTZj8Jf0=",
+        version = "v0.0.0-20200708152505-19999e7d3cef",
+    )

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/status-im/keycard-go v0.0.0-20200402102358-957c09536969 // indirect
 	github.com/stretchr/testify v1.6.1
 	github.com/supranational/blst v0.1.2-alpha.1.0.20200917144033-cd0847a7580b
+	github.com/trailofbits/go-mutexasserts v0.0.0-20200708152505-19999e7d3cef
 	github.com/tyler-smith/go-bip39 v1.0.2
 	github.com/urfave/cli/v2 v2.2.0
 	github.com/wealdtech/go-bytesutil v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1008,6 +1008,8 @@ github.com/templexxx/cpufeat v0.0.0-20180724012125-cef66df7f161/go.mod h1:wM7WEv
 github.com/templexxx/xor v0.0.0-20191217153810-f85b25db303b/go.mod h1:5XA7W9S6mni3h5uvOC75dA3m9CCCaS83lltmc0ukdi4=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tjfoc/gmsm v1.3.0/go.mod h1:HaUcFuY0auTiaHB9MHFGCPx5IaLhTUd2atbCFBQXn9w=
+github.com/trailofbits/go-mutexasserts v0.0.0-20200708152505-19999e7d3cef h1:8LRP+2JK8piIUU16ZDgWDXwjJcuJNTtCzadjTZj8Jf0=
+github.com/trailofbits/go-mutexasserts v0.0.0-20200708152505-19999e7d3cef/go.mod h1:+SV/613m53DNAmlXPTWGZhIyt4E/qDvn9g/lOPRiy0A=
 github.com/tyler-smith/go-bip39 v1.0.1-0.20181017060643-dbb3b84ba2ef/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=
 github.com/tyler-smith/go-bip39 v1.0.2 h1:+t3w+KwLXO6154GNJY+qUtIxLTmFjfUmpguQT1OlOT8=
 github.com/tyler-smith/go-bip39 v1.0.2/go.mod h1:sJ5fKU0s6JVwZjjcUEX2zFOnvq0ASQ2K9Zr6cf67kNs=


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Forkchoice service has three fields that should require lock access. However, some methods do not need to access all three fields so sharing a common lock for all three fields may increase lock contention. 

This PR adds locks for each field and enforces assumptions that a lock is held in inner methods. 

**Which issues(s) does this PR fix?**

None reported yet.

**Other notes for review**
