### PR TITLE
Use state root for state summary object

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -296,7 +296,7 @@ func (s *Service) handleBlockAfterBatchVerify(ctx context.Context, signed *ethpb
 	if err := s.insertBlockToForkChoiceStore(ctx, b, blockRoot, fCheckpoint, jCheckpoint); err != nil {
 		return err
 	}
-	s.stateGen.SaveStateSummary(ctx, signed, blockRoot)
+	s.stateGen.SaveStateSummary(ctx, signed, blockRoot, bytesutil.ToBytes32(b.StateRoot))
 
 	// Rate limit how many blocks (2 epochs worth of blocks) a node keeps in the memory.
 	if uint64(len(s.getInitSyncBlocks())) > initialSyncBlockCacheSize {

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -166,7 +166,7 @@ func TestStore_OnBlockBatch(t *testing.T) {
 
 	blks[0].Block.ParentRoot = gRoot[:]
 	require.NoError(t, db.SaveBlock(context.Background(), blks[0]))
-	require.NoError(t, service.stateGen.SaveState(ctx, blkRoots[0], firstState))
+	require.NoError(t, service.stateGen.SaveState(ctx, blkRoots[0], bytesutil.ToBytes32(blks[0].Block.StateRoot), firstState))
 	_, _, err = service.onBlockBatch(ctx, blks[1:], blkRoots[1:])
 	require.NoError(t, err)
 }
@@ -263,7 +263,7 @@ func TestCachedPreState_CanGetFromStateSummary(t *testing.T) {
 	b.Block.Slot = 1
 	b.Block.ParentRoot = gRoot[:]
 	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{Slot: 1, Root: gRoot[:]}))
-	require.NoError(t, service.stateGen.SaveState(ctx, gRoot, s))
+	require.NoError(t, service.stateGen.SaveState(ctx, gRoot, bytesutil.ToBytes32(b.Block.StateRoot), s))
 	require.NoError(t, service.verifyBlkPreState(ctx, b.Block))
 }
 
@@ -300,7 +300,7 @@ func TestCachedPreState_CanGetFromDB(t *testing.T) {
 	s, err := stateTrie.InitializeFromProto(&pb.BeaconState{Slot: 1})
 	require.NoError(t, err)
 	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &pb.StateSummary{Slot: 1, Root: gRoot[:]}))
-	require.NoError(t, service.stateGen.SaveState(ctx, gRoot, s))
+	require.NoError(t, service.stateGen.SaveState(ctx, gRoot, bytesutil.ToBytes32(b.Block.StateRoot), s))
 	require.NoError(t, service.verifyBlkPreState(ctx, b.Block))
 }
 

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -118,7 +118,7 @@ func setupBeaconChain(t *testing.T, beaconDB db.Database, sc *cache.StateSummary
 	}
 
 	// Safe a state in stategen to purposes of testing a service stop / shutdown.
-	require.NoError(t, cfg.StateGen.SaveState(ctx, bytesutil.ToBytes32(bState.FinalizedCheckpoint().Root), bState))
+	require.NoError(t, cfg.StateGen.SaveState(ctx, bytesutil.ToBytes32(bState.FinalizedCheckpoint().Root), [32]byte{}, bState))
 
 	chainService, err := NewService(ctx, cfg)
 	require.NoError(t, err, "Unable to setup chain service")
@@ -335,7 +335,7 @@ func TestChainService_SaveHeadNoDB(t *testing.T) {
 	r, err := b.HashTreeRoot()
 	require.NoError(t, err)
 	newState := testutil.NewBeaconState()
-	require.NoError(t, s.stateGen.SaveState(ctx, r, newState))
+	require.NoError(t, s.stateGen.SaveState(ctx, r, [32]byte{}, newState))
 	require.NoError(t, s.saveHeadNoDB(ctx, b, r, newState))
 
 	newB, err := s.beaconDB.HeadBlock(ctx)

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -1810,7 +1810,7 @@ func TestServer_GetIndividualVotes_ValidatorsDontExist(t *testing.T) {
 	gRoot, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	gen := stategen.New(db, sc)
-	require.NoError(t, gen.SaveState(ctx, gRoot, beaconState))
+	require.NoError(t, gen.SaveState(ctx, gRoot, bytesutil.ToBytes32(b.Block.StateRoot), beaconState))
 	require.NoError(t, db.SaveState(ctx, beaconState, gRoot))
 	require.NoError(t, db.SaveGenesisBlockRoot(ctx, gRoot))
 	bs := &Server{
@@ -1905,7 +1905,7 @@ func TestServer_GetIndividualVotes_Working(t *testing.T) {
 	gRoot, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	gen := stategen.New(db, sc)
-	require.NoError(t, gen.SaveState(ctx, gRoot, beaconState))
+	require.NoError(t, gen.SaveState(ctx, gRoot, bytesutil.ToBytes32(b.Block.StateRoot), beaconState))
 	require.NoError(t, db.SaveState(ctx, beaconState, gRoot))
 	require.NoError(t, db.SaveGenesisBlockRoot(ctx, gRoot))
 	bs := &Server{

--- a/beacon-chain/rpc/debug/BUILD.bazel
+++ b/beacon-chain/rpc/debug/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//beacon-chain/p2p/testing:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
         "//proto/beacon/rpc/v1:go_default_library",
+        "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
         "//shared/testutil/assert:go_default_library",

--- a/beacon-chain/rpc/debug/block_test.go
+++ b/beacon-chain/rpc/debug/block_test.go
@@ -59,7 +59,7 @@ func TestServer_GetAttestationInclusionSlot(t *testing.T) {
 
 	s, _ := testutil.DeterministicGenesisState(t, 2048)
 	tr := [32]byte{'a'}
-	require.NoError(t, bs.StateGen.SaveState(ctx, tr, s))
+	require.NoError(t, bs.StateGen.SaveState(ctx, tr, [32]byte{}, s))
 	c, err := helpers.BeaconCommitteeFromState(s, 1, 0)
 	require.NoError(t, err)
 

--- a/beacon-chain/rpc/debug/state_test.go
+++ b/beacon-chain/rpc/debug/state_test.go
@@ -8,6 +8,7 @@ import (
 	dbTest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
 	pbrpc "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -26,7 +27,7 @@ func TestServer_GetBeaconState(t *testing.T) {
 	gRoot, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	gen := stategen.New(db, sc)
-	require.NoError(t, gen.SaveState(ctx, gRoot, st))
+	require.NoError(t, gen.SaveState(ctx, gRoot, bytesutil.ToBytes32(b.Block.StateRoot), st))
 	require.NoError(t, db.SaveState(ctx, st, gRoot))
 	bs := &Server{
 		StateGen:           gen,

--- a/beacon-chain/state/stategen/setter.go
+++ b/beacon-chain/state/stategen/setter.go
@@ -45,11 +45,11 @@ func (s *State) ForceCheckpoint(ctx context.Context, root []byte) error {
 
 // SaveStateSummary saves the relevant state summary for a block and its corresponding state slot in the
 // state summary cache.
-func (s *State) SaveStateSummary(_ context.Context, blk *ethpb.SignedBeaconBlock, blockRoot [32]byte) {
+func (s *State) SaveStateSummary(_ context.Context, blk *ethpb.SignedBeaconBlock, blockRoot [32]byte, stateRoot [32]byte) {
 	// Save State summary
 	s.stateSummaryCache.Put(blockRoot, &pb.StateSummary{
 		Slot: blk.Block.Slot,
-		Root: blockRoot[:],
+		Root: stateRoot[:],
 	})
 }
 
@@ -92,7 +92,7 @@ func (s *State) saveStateByRoot(ctx context.Context, blockRoot [32]byte, state *
 	// On an intermediate slots, save the hot state summary.
 	s.stateSummaryCache.Put(blockRoot, &pb.StateSummary{
 		Slot: state.Slot(),
-		Root: blockRoot[:],
+		Root: state.StateRoots(),
 	})
 
 	// Store the copied state in the hot state cache.

--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -24,7 +24,7 @@ func TestSaveState_HotStateCanBeSaved(t *testing.T) {
 	require.NoError(t, beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch))
 
 	r := [32]byte{'a'}
-	require.NoError(t, service.SaveState(ctx, r, beaconState))
+	require.NoError(t, service.SaveState(ctx, r, [32]byte{}, beaconState))
 
 	// Should save both state and state summary.
 	_, ok, err := service.epochBoundaryStateCache.getByRoot(r)
@@ -46,7 +46,7 @@ func TestSaveState_HotStateCached(t *testing.T) {
 	// Cache the state prior.
 	r := [32]byte{'a'}
 	service.hotStateCache.Put(r, beaconState)
-	require.NoError(t, service.SaveState(ctx, r, beaconState))
+	require.NoError(t, service.SaveState(ctx, r, [32]byte{}, beaconState))
 
 	// Should not save the state and state summary.
 	assert.Equal(t, false, service.beaconDB.HasState(ctx, r), "Should not have saved the state")
@@ -85,7 +85,7 @@ func TestSaveState_AlreadyHas(t *testing.T) {
 
 	// Pre cache the hot state.
 	service.hotStateCache.Put(r, beaconState)
-	require.NoError(t, service.saveStateByRoot(ctx, r, beaconState))
+	require.NoError(t, service.SaveState(ctx, r, [32]byte{}, beaconState))
 
 	// Should not save the state and state summary.
 	assert.Equal(t, false, service.beaconDB.HasState(ctx, r), "Should not have saved the state")
@@ -102,7 +102,7 @@ func TestSaveState_CanSaveOnEpochBoundary(t *testing.T) {
 	require.NoError(t, beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch))
 	r := [32]byte{'A'}
 
-	require.NoError(t, service.saveStateByRoot(ctx, r, beaconState))
+	require.NoError(t, service.SaveState(ctx, r, [32]byte{}, beaconState))
 
 	// Should save both state and state summary.
 	_, ok, err := service.epochBoundaryStateCache.getByRoot(r)
@@ -127,7 +127,7 @@ func TestSaveState_NoSaveNotEpochBoundary(t *testing.T) {
 	gRoot, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	require.NoError(t, db.SaveGenesisBlockRoot(ctx, gRoot))
-	require.NoError(t, service.SaveState(ctx, r, beaconState))
+	require.NoError(t, service.SaveState(ctx, r, [32]byte{}, beaconState))
 
 	// Should only save state summary.
 	assert.Equal(t, false, service.beaconDB.HasState(ctx, r), "Should not have saved the state")
@@ -147,7 +147,7 @@ func TestSaveState_CanSaveHotStateToDB(t *testing.T) {
 	require.NoError(t, beaconState.SetSlot(defaultHotStateDBInterval))
 
 	r := [32]byte{'A'}
-	require.NoError(t, service.saveStateByRoot(ctx, r, beaconState))
+	require.NoError(t, service.SaveState(ctx, r, [32]byte{}, beaconState))
 
 	require.LogsContain(t, hook, "Saving hot state to DB")
 	// Should have saved in DB.

--- a/proto/beacon/p2p/v1/types.proto
+++ b/proto/beacon/p2p/v1/types.proto
@@ -75,7 +75,7 @@ message HistoricalBatch {
 message StateSummary {
   // The slot of the state.
   uint64 slot = 1;
-  // The block root of the state.
+  // The state root of the post state after processing the block of the given slot.
   bytes root = 2;
 }
 


### PR DESCRIPTION
State summary object was `blockRoot => {slot, blockRoot}`   This PR updates the state summary object to `blockRoot => {slot, stateRoot}` for eth2api to use.

Fortunately `blockRoot.blockRoot` was never used, there's no risk for updating this on existing testnets. The question is whether it's necessary to include a migration script for converting old `blockRoot.blockRoot` to new `blockRoot.stateRoot`. To answer this we'll have to look at eth2api completion date and whether that this would used for Medalla