### PR TITLE
Update init-sync FSM

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -223,7 +223,7 @@ func (q *blocksQueue) loop() {
 				}
 				// Do garbage collection, and advance sliding window forward.
 				if q.headFetcher.HeadSlot() >= fsm.start+blocksPerRequest-1 {
-					highestStartBlock, err := q.smm.highestStartBlock()
+					highestStartSlot, err := q.smm.highestStartSlot()
 					if err != nil {
 						log.WithError(err).Debug("Cannot obtain highest epoch state number")
 						continue
@@ -232,7 +232,7 @@ func (q *blocksQueue) loop() {
 						log.WithError(err).Debug("Can not remove state machine")
 					}
 					if len(q.smm.machines) < lookaheadSteps {
-						q.smm.addStateMachine(highestStartBlock + blocksPerRequest)
+						q.smm.addStateMachine(highestStartSlot + blocksPerRequest)
 					}
 				}
 			}

--- a/beacon-chain/sync/initial-sync/fsm.go
+++ b/beacon-chain/sync/initial-sync/fsm.go
@@ -72,25 +72,25 @@ func (smm *stateMachineManager) addEventHandler(event eventID, state stateID, fn
 }
 
 // addStateMachine allocates memory for new FSM.
-func (smm *stateMachineManager) addStateMachine(start uint64) *stateMachine {
-	smm.machines[start] = &stateMachine{
+func (smm *stateMachineManager) addStateMachine(startSlot uint64) *stateMachine {
+	smm.machines[startSlot] = &stateMachine{
 		smm:     smm,
-		start:   start,
+		start:   startSlot,
 		state:   stateNew,
 		blocks:  []*eth.SignedBeaconBlock{},
 		updated: timeutils.Now(),
 	}
 	smm.recalculateMachineAttribs()
-	return smm.machines[start]
+	return smm.machines[startSlot]
 }
 
 // removeStateMachine frees memory of a processed/finished FSM.
-func (smm *stateMachineManager) removeStateMachine(start uint64) error {
-	if _, ok := smm.machines[start]; !ok {
-		return fmt.Errorf("state for machine %v is not found", start)
+func (smm *stateMachineManager) removeStateMachine(startSlot uint64) error {
+	if _, ok := smm.machines[startSlot]; !ok {
+		return fmt.Errorf("state for machine %v is not found", startSlot)
 	}
-	smm.machines[start].blocks = nil
-	delete(smm.machines, start)
+	smm.machines[startSlot].blocks = nil
+	delete(smm.machines, startSlot)
 	smm.recalculateMachineAttribs()
 	return nil
 }

--- a/beacon-chain/sync/initial-sync/fsm.go
+++ b/beacon-chain/sync/initial-sync/fsm.go
@@ -118,14 +118,14 @@ func (smm *stateMachineManager) recalculateMachineAttribs() {
 	smm.keys = keys
 }
 
-// findStateMachine returns a state machine for a given start block (if exists).
-func (smm *stateMachineManager) findStateMachine(startBlock uint64) (*stateMachine, bool) {
-	fsm, ok := smm.machines[startBlock]
+// findStateMachine returns a state machine for a given start slot (if exists).
+func (smm *stateMachineManager) findStateMachine(startSlot uint64) (*stateMachine, bool) {
+	fsm, ok := smm.machines[startSlot]
 	return fsm, ok
 }
 
-// highestStartBlock returns the start block number for the latest known state machine.
-func (smm *stateMachineManager) highestStartBlock() (uint64, error) {
+// highestStartSlot returns the start slot for the latest known state machine.
+func (smm *stateMachineManager) highestStartSlot() (uint64, error) {
 	if len(smm.keys) == 0 {
 		return 0, errors.New("no state machine exist")
 	}
@@ -176,12 +176,12 @@ func (m *stateMachine) trigger(event eventID, data interface{}) error {
 	return nil
 }
 
-// isFirst checks whether a given machine has the lowest start block.
+// isFirst checks whether a given machine has the lowest start slot.
 func (m *stateMachine) isFirst() bool {
 	return m.start == (*m.smm).keys[0]
 }
 
-// isLast checks whether a given machine has the highest start block.
+// isLast checks whether a given machine has the highest start slot.
 func (m *stateMachine) isLast() bool {
 	return m.start == (*m.smm).keys[len((*m.smm).keys)-1]
 }
@@ -201,7 +201,7 @@ func (s stateID) String() string {
 		stateSent:       "sent",
 	}
 	if _, ok := states[s]; !ok {
-		return ""
+		return "stateUnknown"
 	}
 	return states[s]
 }
@@ -213,7 +213,7 @@ func (e eventID) String() string {
 		eventDataReceived: "dataReceived",
 	}
 	if _, ok := events[e]; !ok {
-		return ""
+		return "eventUnknown"
 	}
 	return events[e]
 }

--- a/beacon-chain/sync/initial-sync/fsm_test.go
+++ b/beacon-chain/sync/initial-sync/fsm_test.go
@@ -45,11 +45,13 @@ func TestStateMachineManager_String(t *testing.T) {
 func TestStateMachine_StateIDString(t *testing.T) {
 	stateIDs := []stateID{stateNew, stateScheduled, stateDataParsed, stateSkipped, stateSent}
 	assert.Equal(t, "[new scheduled dataParsed skipped sent]", fmt.Sprintf("%v", stateIDs))
+	assert.Equal(t, "stateUnknown", stateID(15).String())
 }
 
 func TestStateMachine_EventIDString(t *testing.T) {
 	eventIDs := []eventID{eventTick, eventDataReceived}
 	assert.Equal(t, "[tick dataReceived]", fmt.Sprintf("%v", eventIDs))
+	assert.Equal(t, "eventUnknown", eventID(15).String())
 }
 
 func TestStateMachineManager_addEventHandler(t *testing.T) {
@@ -308,16 +310,16 @@ func TestStateMachineManager_findStateMachine(t *testing.T) {
 
 func TestStateMachineManager_highestStartBlock(t *testing.T) {
 	smm := newStateMachineManager()
-	_, err := smm.highestStartBlock()
+	_, err := smm.highestStartSlot()
 	assert.ErrorContains(t, "no state machine exist", err)
 	smm.addStateMachine(64)
 	smm.addStateMachine(128)
 	smm.addStateMachine(196)
-	start, err := smm.highestStartBlock()
+	start, err := smm.highestStartSlot()
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(196), start, "Incorrect highest start block")
 	assert.NoError(t, smm.removeStateMachine(196))
-	start, err = smm.highestStartBlock()
+	start, err = smm.highestStartSlot()
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(128), start, "Incorrect highest start block")
 }

--- a/beacon-chain/sync/initial-sync/fsm_test.go
+++ b/beacon-chain/sync/initial-sync/fsm_test.go
@@ -224,8 +224,8 @@ func TestStateMachineManager_QueueLoop(t *testing.T) {
 	smm.addStateMachine(64)
 	smm.addStateMachine(512)
 
-	assertState := func(startBlock uint64, state stateID) {
-		fsm, ok := smm.findStateMachine(startBlock)
+	assertState := func(startSlot uint64, state stateID) {
+		fsm, ok := smm.findStateMachine(startSlot)
 		require.Equal(t, true, ok, "State machine not found")
 		assert.Equal(t, state, fsm.state, "Unexpected state machine state")
 	}
@@ -299,16 +299,16 @@ func TestStateMachineManager_findStateMachine(t *testing.T) {
 	smm.addStateMachine(256)
 	smm.addStateMachine(128)
 	if fsm, ok := smm.findStateMachine(128); !ok || fsm.start != 128 {
-		t.Errorf("unexpected start block: %v, want: %v", fsm.start, 122)
+		t.Errorf("unexpected start slot: %v, want: %v", fsm.start, 122)
 	}
 	if fsm, ok := smm.findStateMachine(512); !ok || fsm.start != 512 {
-		t.Errorf("unexpected start block: %v, want: %v", fsm.start, 512)
+		t.Errorf("unexpected start slot: %v, want: %v", fsm.start, 512)
 	}
 	keys := []uint64{64, 128, 196, 256, 512}
 	assert.DeepEqual(t, smm.keys, keys, "Keys not sorted")
 }
 
-func TestStateMachineManager_highestStartBlock(t *testing.T) {
+func TestStateMachineManager_highestStartSlot(t *testing.T) {
 	smm := newStateMachineManager()
 	_, err := smm.highestStartSlot()
 	assert.ErrorContains(t, "no state machine exist", err)
@@ -317,11 +317,11 @@ func TestStateMachineManager_highestStartBlock(t *testing.T) {
 	smm.addStateMachine(196)
 	start, err := smm.highestStartSlot()
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(196), start, "Incorrect highest start block")
+	assert.Equal(t, uint64(196), start, "Incorrect highest start slot")
 	assert.NoError(t, smm.removeStateMachine(196))
 	start, err = smm.highestStartSlot()
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(128), start, "Incorrect highest start block")
+	assert.Equal(t, uint64(128), start, "Incorrect highest start slot")
 }
 
 func TestStateMachineManager_allMachinesInState(t *testing.T) {
@@ -433,7 +433,7 @@ func TestStateMachine_isFirstLast(t *testing.T) {
 	checkFirst(m3, false)
 	checkLast(m3, true)
 
-	// Add machine with lower start block - shouldn't be marked as last.
+	// Add machine with lower start slot - shouldn't be marked as last.
 	m4 := smm.addStateMachine(196)
 	checkFirst(m1, true)
 	checkLast(m1, false)
@@ -444,7 +444,7 @@ func TestStateMachine_isFirstLast(t *testing.T) {
 	checkFirst(m4, false)
 	checkLast(m4, false)
 
-	// Add machine with lowest start block - should be marked as first.
+	// Add machine with lowest start slot - should be marked as first.
 	m5 := smm.addStateMachine(32)
 	checkFirst(m1, false)
 	checkLast(m1, false)


### PR DESCRIPTION
**What type of PR is this?**

> Other / Cleanup

**What does this PR do? Why is it needed?**
- While working on new init-sync algorithm in #7564 (one capable to traverse multiple branches during non-finality), minor cleanup was attempted, where it didn't require too much of time/effort.
- This PR updates FSM, to use block/slot terminology more cleanly. It doesn't change any algorithmic logic, but since FSMs were designed to be slot based (not block based), API has been updated to reflect that.
- Additionally, improves test coverage slightly.


**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- Filed as separate PR, to make sure that #7564 is not overly cluttered.
