### PR TITLE
Remove redundant attribute in validator test

### DIFF
--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -272,7 +272,6 @@ func TestExitedValidatorIndices(t *testing.T) {
 	}{
 		{
 			state: &pb.BeaconState{
-				Slot: helpers.SlotToEpoch(1),
 				Validators: []*ethpb.Validator{
 					{
 						EffectiveBalance:  params.BeaconConfig().MaxEffectiveBalance,
@@ -295,7 +294,6 @@ func TestExitedValidatorIndices(t *testing.T) {
 		},
 		{
 			state: &pb.BeaconState{
-				Slot: helpers.SlotToEpoch(1),
 				Validators: []*ethpb.Validator{
 					{
 						EffectiveBalance:  params.BeaconConfig().MaxEffectiveBalance,
@@ -308,7 +306,6 @@ func TestExitedValidatorIndices(t *testing.T) {
 		},
 		{
 			state: &pb.BeaconState{
-				Slot: helpers.SlotToEpoch(1),
 				Validators: []*ethpb.Validator{
 					{
 						EffectiveBalance:  params.BeaconConfig().MaxEffectiveBalance,

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -155,7 +155,6 @@ func TestActivatedValidatorIndices(t *testing.T) {
 	}{
 		{
 			state: &pb.BeaconState{
-				Slot: 0,
 				Validators: []*ethpb.Validator{
 					{
 						ActivationEpoch: 0,
@@ -178,7 +177,6 @@ func TestActivatedValidatorIndices(t *testing.T) {
 		},
 		{
 			state: &pb.BeaconState{
-				Slot: 0,
 				Validators: []*ethpb.Validator{
 					{
 						ActivationEpoch: helpers.ActivationExitEpoch(10),
@@ -189,7 +187,6 @@ func TestActivatedValidatorIndices(t *testing.T) {
 		},
 		{
 			state: &pb.BeaconState{
-				Slot: 0,
 				Validators: []*ethpb.Validator{
 					{
 						ActivationEpoch: 0,
@@ -215,7 +212,6 @@ func TestSlashedValidatorIndices(t *testing.T) {
 	}{
 		{
 			state: &pb.BeaconState{
-				Slot: 0,
 				Validators: []*ethpb.Validator{
 					{
 						WithdrawableEpoch: params.BeaconConfig().EpochsPerSlashingsVector,
@@ -235,7 +231,6 @@ func TestSlashedValidatorIndices(t *testing.T) {
 		},
 		{
 			state: &pb.BeaconState{
-				Slot: 0,
 				Validators: []*ethpb.Validator{
 					{
 						WithdrawableEpoch: params.BeaconConfig().EpochsPerSlashingsVector,
@@ -246,7 +241,6 @@ func TestSlashedValidatorIndices(t *testing.T) {
 		},
 		{
 			state: &pb.BeaconState{
-				Slot: 0,
 				Validators: []*ethpb.Validator{
 					{
 						WithdrawableEpoch: params.BeaconConfig().EpochsPerSlashingsVector,


### PR DESCRIPTION
**What type of PR is this?**

> Other / Test cleanup

**What does this PR do? Why is it needed?**
- **Very minor** thing spotted when testing type hardening: epoch was being assigned to slot (`helpers.SlotToEpoch()` returns epoch, but value was assigned to `BeaconState.Slot`).
- Ironically, no value is required at all: default value works ok (so settling for 0th slot is ok). 

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- Removed other `Slot: 0` attributes for consistency.
