### PR TITLE
Log out that all validators are exited

### DIFF
--- a/validator/client/mock_validator.go
+++ b/validator/client/mock_validator.go
@@ -176,3 +176,8 @@ func (fv *FakeValidator) PubkeysToIndices(_ context.Context) map[[48]byte]uint64
 func (fv *FakeValidator) PubkeysToStatuses(_ context.Context) map[[48]byte]ethpb.ValidatorStatus {
 	return fv.PubkeysToStatusesMap
 }
+
+// AllValidatorsAreExited for mocking
+func (fv *FakeValidator) AllValidatorsAreExited(_ context.Context) (bool, error) {
+	return false, nil
+}

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -37,6 +37,7 @@ type Validator interface {
 	SaveProtections(ctx context.Context) error
 	UpdateDomainDataCaches(ctx context.Context, slot uint64)
 	WaitForWalletInitialization(ctx context.Context) error
+	AllValidatorsAreExited(ctx context.Context) (bool, error)
 }
 
 // Run the main validator routine. This routine exits if the context is
@@ -84,6 +85,10 @@ func run(ctx context.Context, v Validator) {
 	if err := v.UpdateDuties(ctx, headSlot); err != nil {
 		handleAssignmentError(err, headSlot)
 	}
+
+	// We initially assume not all validators are exited
+	allExited := false
+
 	for {
 		ctx, span := trace.StartSpan(ctx, "validator.processSlot")
 
@@ -94,6 +99,19 @@ func run(ctx context.Context, v Validator) {
 			return // Exit if context is canceled.
 		case slot := <-v.NextSlot():
 			span.AddAttributes(trace.Int64Attribute("slot", int64(slot)))
+
+			if allExited {
+				log.Info("All validators are exited, no more work to perform...")
+				continue
+			}
+			allExited, err = v.AllValidatorsAreExited(ctx)
+			if err != nil {
+				log.WithError(err).Error("Could not check if validators are exited")
+			}
+			if allExited {
+				continue
+			}
+
 			deadline := v.SlotDeadline(slot)
 			slotCtx, cancel := context.WithDeadline(ctx, deadline)
 			// Report this validator client's rewards and penalties throughout its lifecycle.

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -586,6 +586,31 @@ func (v *validator) UpdateDomainDataCaches(ctx context.Context, slot uint64) {
 	}
 }
 
+// AllValidatorsAreExited informs whether all validators have already exited.
+func (v *validator) AllValidatorsAreExited(ctx context.Context) (bool, error) {
+	validatingKeys, err := v.keyManager.FetchValidatingPublicKeys(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "could not fetch validating keys")
+	}
+	var publicKeys [][]byte
+	for _, key := range validatingKeys {
+		publicKeys = append(publicKeys, key[:])
+	}
+	request := &ethpb.MultipleValidatorStatusRequest{
+		PublicKeys: publicKeys,
+	}
+	response, err := v.validatorClient.MultipleValidatorStatus(ctx, request)
+	if err != nil {
+		return false, err
+	}
+	for _, status := range response.Statuses {
+		if status.Status != ethpb.ValidatorStatus_EXITED {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 func (v *validator) domainData(ctx context.Context, epoch uint64, domain []byte) (*ethpb.DomainResponse, error) {
 	v.domainDataLock.Lock()
 	defer v.domainDataLock.Unlock()

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -930,3 +930,45 @@ func TestCheckAndLogValidatorStatus_OK(t *testing.T) {
 		})
 	}
 }
+
+func TestAllValidatorsAreExited_AllExited(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock.NewMockBeaconNodeValidatorClient(ctrl)
+
+	statuses := []*ethpb.ValidatorStatusResponse{
+		{Status: ethpb.ValidatorStatus_EXITED},
+		{Status: ethpb.ValidatorStatus_EXITED},
+	}
+
+	client.EXPECT().MultipleValidatorStatus(
+		gomock.Any(), // ctx
+		gomock.Any(), // request
+	).Return(&ethpb.MultipleValidatorStatusResponse{Statuses: statuses}, nil /*err*/)
+
+	v := validator{keyManager: &mockKeymanager{}, validatorClient: client}
+	exited, err := v.AllValidatorsAreExited(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, true, exited)
+}
+
+func TestAllValidatorsAreExited_NotAllExited(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock.NewMockBeaconNodeValidatorClient(ctrl)
+
+	statuses := []*ethpb.ValidatorStatusResponse{
+		{Status: ethpb.ValidatorStatus_ACTIVE},
+		{Status: ethpb.ValidatorStatus_EXITED},
+	}
+
+	client.EXPECT().MultipleValidatorStatus(
+		gomock.Any(), // ctx
+		gomock.Any(), // request
+	).Return(&ethpb.MultipleValidatorStatusResponse{Statuses: statuses}, nil /*err*/)
+
+	v := validator{keyManager: &mockKeymanager{}, validatorClient: client}
+	exited, err := v.AllValidatorsAreExited(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, false, exited)
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Logs out information that all validators are exited instead of trying to get duties, which resulted in error messages.

**Which issues(s) does this PR fix?**

Fixes #7538

**Other notes for review**

N/A
