### PR TITLE
Deprecate db.HeadState

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -94,6 +94,7 @@ type HeadAccessDatabase interface {
 	HeadBlock(ctx context.Context) (*eth.SignedBeaconBlock, error)
 	SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error
 	// State related methods.
+	// Deprecated: This method may return nil. Prefer to use HighestSlotStatesBelow.
 	HeadState(ctx context.Context) (*state.BeaconState, error)
 }
 

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -94,7 +94,8 @@ type HeadAccessDatabase interface {
 	HeadBlock(ctx context.Context) (*eth.SignedBeaconBlock, error)
 	SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error
 	// State related methods.
-	// Deprecated: This method may return nil. Prefer to use HighestSlotStatesBelow.
+	// Deprecated: This method may return nil. Prefer to use HighestSlotStatesBelow or
+	// blockchain.HeadFetcher.HeadState().
 	HeadState(ctx context.Context) (*state.BeaconState, error)
 }
 

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -36,6 +36,7 @@ func (s *Store) State(ctx context.Context, blockRoot [32]byte) (*state.BeaconSta
 }
 
 // HeadState returns the latest canonical state in beacon chain.
+// Deprecated: This method may return nil. Prefer to use HighestSlotStatesBelow.
 func (s *Store) HeadState(ctx context.Context) (*state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.HeadState")
 	defer span.End()

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -36,7 +36,8 @@ func (s *Store) State(ctx context.Context, blockRoot [32]byte) (*state.BeaconSta
 }
 
 // HeadState returns the latest canonical state in beacon chain.
-// Deprecated: This method may return nil. Prefer to use HighestSlotStatesBelow.
+// Deprecated: This method may return nil. Prefer to use HighestSlotStatesBelow
+// or blockchain.HeadFetcher.HeadState().
 func (s *Store) HeadState(ctx context.Context) (*state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.HeadState")
 	defer span.End()


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Marking this method as deprecated. Will remove in a follow up PR after #7648

**Which issues(s) does this PR fix?**

This fixes potential issues where a method is expecting the highest / head state in the database, but nothing is returned.

**Other notes for review**

Ever since stategen was introduced and less states were saved to the database, the HeadState method has been returning nil and causing issues. An example is PR #7648 where the caller of the method expected a state to be returned to fill the deposits cache. 