### PR TITLE
Remove Top Jaeger Span Offenders

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -118,8 +118,6 @@ func (s *Store) BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][32]b
 
 // HasBlock checks if a block by root exists in the db.
 func (s *Store) HasBlock(ctx context.Context, blockRoot [32]byte) bool {
-	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasBlock")
-	defer span.End()
 	if v, ok := s.blockCache.Get(string(blockRoot[:])); v != nil && ok {
 		return true
 	}

--- a/beacon-chain/db/kv/state_summary.go
+++ b/beacon-chain/db/kv/state_summary.go
@@ -56,8 +56,6 @@ func (s *Store) StateSummary(ctx context.Context, blockRoot [32]byte) (*pb.State
 
 // HasStateSummary returns true if a state summary exists in DB.
 func (s *Store) HasStateSummary(ctx context.Context, blockRoot [32]byte) bool {
-	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasStateSummary")
-	defer span.End()
 	enc, err := s.stateSummaryBytes(ctx, blockRoot)
 	if err != nil {
 		panic(err)
@@ -66,9 +64,6 @@ func (s *Store) HasStateSummary(ctx context.Context, blockRoot [32]byte) bool {
 }
 
 func (s *Store) stateSummaryBytes(ctx context.Context, blockRoot [32]byte) ([]byte, error) {
-	ctx, span := trace.StartSpan(ctx, "BeaconDB.stateSummaryBytes")
-	defer span.End()
-
 	var enc []byte
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(stateSummaryBucket)


### PR DESCRIPTION
![Screenshot_from_2020-10-27_21-02-00](https://user-images.githubusercontent.com/5572669/97391542-70742200-18ad-11eb-98ed-6b0c85b9f09e.png)

**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

This PR removes top spans in jaeger, which account for top 3 of all requests, launching a ton of goroutines for span collection, namely:

HasStateSummary
stateSummaryBytes
HasBlock

These functions are fairly simple DB lookups, so it will not be disruptive if we remove their spans to our monitoring pipelines.
