### PR TITLE
Revert "Remove Top Jaeger Span Offenders"

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -118,6 +118,8 @@ func (s *Store) BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][32]b
 
 // HasBlock checks if a block by root exists in the db.
 func (s *Store) HasBlock(ctx context.Context, blockRoot [32]byte) bool {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasBlock")
+	defer span.End()
 	if v, ok := s.blockCache.Get(string(blockRoot[:])); v != nil && ok {
 		return true
 	}

--- a/beacon-chain/db/kv/state_summary.go
+++ b/beacon-chain/db/kv/state_summary.go
@@ -56,6 +56,8 @@ func (s *Store) StateSummary(ctx context.Context, blockRoot [32]byte) (*pb.State
 
 // HasStateSummary returns true if a state summary exists in DB.
 func (s *Store) HasStateSummary(ctx context.Context, blockRoot [32]byte) bool {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasStateSummary")
+	defer span.End()
 	enc, err := s.stateSummaryBytes(ctx, blockRoot)
 	if err != nil {
 		panic(err)
@@ -64,6 +66,9 @@ func (s *Store) HasStateSummary(ctx context.Context, blockRoot [32]byte) bool {
 }
 
 func (s *Store) stateSummaryBytes(ctx context.Context, blockRoot [32]byte) ([]byte, error) {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.stateSummaryBytes")
+	defer span.End()
+
 	var enc []byte
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(stateSummaryBucket)


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#7655

While these individual spans are very highly used, they are not necessarily causing issues at this time.
We'll keep them around until we have concrete evidence that this is a problem for beacon node operators.