### PR TITLE
Remove redundant checks in `processAttestation`

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
-	"github.com/prysmaticlabs/prysm/shared/timeutils"
 	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
@@ -135,18 +134,8 @@ func (s *Service) processAttestation(subscribedToStateEvents chan struct{}) {
 					continue
 				}
 
-				hasState := s.stateGen.StateSummaryExists(ctx, bytesutil.ToBytes32(a.Data.BeaconBlockRoot))
-				hasBlock := s.hasBlock(ctx, bytesutil.ToBytes32(a.Data.BeaconBlockRoot))
-				if !(hasState && hasBlock) {
-					continue
-				}
-
 				if err := s.attPool.DeleteForkchoiceAttestation(a); err != nil {
 					log.WithError(err).Error("Could not delete fork choice attestation in pool")
-				}
-
-				if !s.verifyCheckpointEpoch(a.Data.Target) {
-					continue
 				}
 
 				if err := s.ReceiveAttestationNoPubsub(ctx, a); err != nil {
@@ -161,24 +150,4 @@ func (s *Service) processAttestation(subscribedToStateEvents chan struct{}) {
 			}
 		}
 	}
-}
-
-// This verifies the epoch of input checkpoint is within current epoch and previous epoch
-// with respect to current time. Returns true if it's within, false if it's not.
-func (s *Service) verifyCheckpointEpoch(c *ethpb.Checkpoint) bool {
-	now := uint64(timeutils.Now().Unix())
-	genesisTime := uint64(s.genesisTime.Unix())
-	currentSlot := (now - genesisTime) / params.BeaconConfig().SecondsPerSlot
-	currentEpoch := helpers.SlotToEpoch(currentSlot)
-
-	var prevEpoch uint64
-	if currentEpoch > 1 {
-		prevEpoch = currentEpoch - 1
-	}
-
-	if c.Epoch != prevEpoch && c.Epoch != currentEpoch {
-		return false
-	}
-
-	return true
 }

--- a/beacon-chain/blockchain/receive_attestation_test.go
+++ b/beacon-chain/blockchain/receive_attestation_test.go
@@ -9,20 +9,8 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
-
-func TestVerifyCheckpointEpoch_Ok(t *testing.T) {
-	helpers.ClearCache()
-	db, sc := testDB.SetupDB(t)
-
-	chainService := setupBeaconChain(t, db, sc)
-	chainService.genesisTime = time.Now()
-
-	assert.Equal(t, true, chainService.verifyCheckpointEpoch(&ethpb.Checkpoint{Root: make([]byte, 32)}))
-	assert.Equal(t, false, chainService.verifyCheckpointEpoch(&ethpb.Checkpoint{Epoch: 1}))
-}
 
 func TestAttestationCheckPtState_FarFutureSlot(t *testing.T) {
 	helpers.ClearCache()


### PR DESCRIPTION
Removing the following redundant checks in `processAttestations`. Not only these checks are redundant, they always cause harm. Rationales:
 * This is duplicated. These checks are already implemented in sync validation pipelines and core processing logic.
 * This is bad. When these checks fail and the loop continue on, it assumes fork choice attestations could forever get stuck in the pool and draining the compute to loop over and over again. In fact we should fail out load, and delete the invalid attestations from the pool