### PR TITLE
Add faster method for determining committee size

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -91,11 +91,11 @@ func BeaconCommitteeFromState(state *stateTrie.BeaconState, slot, committeeIndex
 }
 
 func BeaconCommitteeSizeFromState(state *stateTrie.BeaconState, slot, committeeIndex uint64) (uint64, error) {
-	activeValidators, err := ActiveValidatorIndices(state, SlotToEpoch(slot))
+	activeValidators, err := ActiveValidatorCount(state, SlotToEpoch(slot))
 	if err != nil {
 		return 0, err
 	}
-	activeValidatorCount := uint64(len(activeValidators))
+	activeValidatorCount := activeValidators
 	return activeValidatorCount / params.BeaconConfig().SlotsPerEpoch / SlotCommitteeCount(uint64(state.NumValidators())), nil
 }
 

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -90,6 +90,15 @@ func BeaconCommitteeFromState(state *stateTrie.BeaconState, slot, committeeIndex
 	return BeaconCommittee(activeIndices, seed, slot, committeeIndex)
 }
 
+func BeaconCommitteeSizeFromState(state *stateTrie.BeaconState, slot, committeeIndex uint64) (uint64, error) {
+	activeValidators, err := ActiveValidatorIndices(state, SlotToEpoch(slot))
+	if err != nil {
+		return 0, err
+	}
+	activeValidatorCount := uint64(len(activeValidators))
+	return activeValidatorCount / params.BeaconConfig().SlotsPerEpoch / SlotCommitteeCount(uint64(state.NumValidators())), nil
+}
+
 // BeaconCommittee returns the crosslink committee of a given slot and committee index. The
 // validator indices and seed are provided as an argument rather than a imported implementation
 // from the spec definition. Having them as an argument allows for cheaper computation run time.

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -98,9 +98,9 @@ func BeaconCommitteeSizeFromState(state *stateTrie.BeaconState, slot, committeeI
 	}
 	committeesPerSlot := SlotCommitteeCount(c)
 	slotCommitteeIndex := committeeIndex + (slot%params.BeaconConfig().SlotsPerEpoch)*committeesPerSlot
-	totalCommitteesCount := committeesPerSlot * params.BeaconConfig().SlotsPerEpoch
-	start := sliceutil.SplitOffset(c, totalCommitteesCount, slotCommitteeIndex)
-	end := sliceutil.SplitOffset(c, totalCommitteesCount, slotCommitteeIndex+1)
+	epochCommitteesCount := committeesPerSlot * params.BeaconConfig().SlotsPerEpoch
+	start := sliceutil.SplitOffset(c, epochCommitteesCount, slotCommitteeIndex)
+	end := sliceutil.SplitOffset(c, epochCommitteesCount, slotCommitteeIndex+1)
 	return end - start, nil
 }
 

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -727,7 +727,7 @@ func TestBeaconCommitteeSizeFromState(t *testing.T) {
 				t.Fatal(err)
 			}
 			if uint64(len(committee)) != got {
-				t.Errorf("Committee count does not match results from BeaconCommitteeFromState. got=%d, wanted=%d", got, len(committee))
+				t.Errorf("Committee size does not match results from BeaconCommitteeFromState. got=%d, wanted=%d", got, len(committee))
 			}
 		})
 	}

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -666,13 +666,14 @@ func TestUpdateProposerIndicesInCache_CouldNotGetActiveIndices(t *testing.T) {
 }
 
 func TestBeaconCommitteeSizeFromState(t *testing.T) {
+	// Initialize state with an imperfect amount of validators to demonstrate differences in
+	// committee sizes.
 	validators := make([]*ethpb.Validator, params.BeaconConfig().MinGenesisActiveValidatorCount + 55)
 	for i := 0; i < len(validators); i++ {
 		validators[i] = &ethpb.Validator{
 			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
 		}
 	}
-
 	st, err := beaconstate.InitializeFromProto(&pb.BeaconState{
 		Validators:  validators,
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

We currently compute the whole committee then take the length of that list. 
Alternatively, we could simply compute the expected committee size for a given committee index.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
