### PR TITLE
Turn init-sync FSM logs to trace level

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -191,10 +191,9 @@ func (q *blocksQueue) loop() {
 
 		log.WithFields(logrus.Fields{
 			"highestExpectedSlot":       q.highestExpectedSlot,
-			"noRequiredPeersErrRetries": q.exitConditions.noRequiredPeersErrRetries,
 			"headSlot":                  q.headFetcher.HeadSlot(),
-			"state":                     q.smm,
-		}).Debug("tick")
+			"state":                     q.smm.String(),
+		}).Trace("tick")
 
 		select {
 		case <-ticker.C:

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -190,9 +190,9 @@ func (q *blocksQueue) loop() {
 		}
 
 		log.WithFields(logrus.Fields{
-			"highestExpectedSlot":       q.highestExpectedSlot,
-			"headSlot":                  q.headFetcher.HeadSlot(),
-			"state":                     q.smm.String(),
+			"highestExpectedSlot": q.highestExpectedSlot,
+			"headSlot":            q.headFetcher.HeadSlot(),
+			"state":               q.smm.String(),
 		}).Trace("tick")
 
 		select {


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
- FSM's `tick` logs are too frequent, turn them to traces.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
