### PR TITLE
Use state by root to get finalized state

### DIFF
--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -78,7 +78,7 @@ func (s *State) Resume(ctx context.Context) (*state.BeaconState, error) {
 	if fRoot == params.BeaconConfig().ZeroHash {
 		return s.beaconDB.GenesisState(ctx)
 	}
-	fState, err := s.beaconDB.State(ctx, fRoot)
+	fState, err := s.StateByRoot(ctx, fRoot)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use `stategen` to retrieve finalized state instead of `db`.  When using `db` to retrieve state, it could return `nil`