### PR TITLE
Add and use `HasStateInCache`

### DIFF
--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -47,7 +47,9 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (*sta
 		return baseState, nil
 	}
 
-	has, err := s.stateGen.HasState(ctx, bytesutil.ToBytes32(c.Root))
+	// To avoid sharing the same state across checkpoint state cache and hot state cache,
+	// we don't add the state to check point cache.
+	has, err := s.stateGen.HasStateInCache(ctx, bytesutil.ToBytes32(c.Root))
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -13,10 +13,7 @@ import (
 
 // HasState returns true if the state exists in cache or in DB.
 func (s *State) HasState(ctx context.Context, blockRoot [32]byte) (bool, error) {
-	if s.hotStateCache.Has(blockRoot) {
-		return true, nil
-	}
-	_, has, err := s.epochBoundaryStateCache.getByRoot(blockRoot)
+	has, err := s.HasStateInCache(ctx, blockRoot)
 	if err != nil {
 		return false, err
 	}
@@ -24,6 +21,18 @@ func (s *State) HasState(ctx context.Context, blockRoot [32]byte) (bool, error) 
 		return true, nil
 	}
 	return s.beaconDB.HasState(ctx, blockRoot), nil
+}
+
+// HasStateInCache returns true if the state exists in cache.
+func (s *State) HasStateInCache(ctx context.Context, blockRoot [32]byte) (bool, error) {
+	if s.hotStateCache.Has(blockRoot) {
+		return true, nil
+	}
+	_, has, err := s.epochBoundaryStateCache.getByRoot(blockRoot)
+	if err != nil {
+		return false, err
+	}
+	return has, nil
 }
 
 // StateByRoot retrieves the state using input block root.


### PR DESCRIPTION
This ensures we still can fill in checkpoint state cache if the state exists in DB. If the state exists in hot state or state summary cache then we don't fill it in.