### PR TITLE
Fix param naming in BestNonFinalized

### DIFF
--- a/beacon-chain/p2p/peers/status.go
+++ b/beacon-chain/p2p/peers/status.go
@@ -482,19 +482,19 @@ func (p *Status) BestFinalized(maxPeers int, ourFinalizedEpoch uint64) (uint64, 
 	return targetEpoch, potentialPIDs
 }
 
-// BestNonFinalized returns the highest known epoch, which is higher than ours, and is shared
-// by at least minPeers.
-func (p *Status) BestNonFinalized(minPeers int, ourFinalizedEpoch uint64) (uint64, []peer.ID) {
+// BestNonFinalized returns the highest known epoch, higher than ours,
+// and is shared by at least minPeers.
+func (p *Status) BestNonFinalized(minPeers int, ourHeadEpoch uint64) (uint64, []peer.ID) {
 	connected := p.Connected()
 	epochVotes := make(map[uint64]uint64)
 	pidEpoch := make(map[peer.ID]uint64, len(connected))
 	pidHead := make(map[peer.ID]uint64, len(connected))
 	potentialPIDs := make([]peer.ID, 0, len(connected))
 
-	ourFinalizedSlot := ourFinalizedEpoch * params.BeaconConfig().SlotsPerEpoch
+	ourHeadSlot := ourHeadEpoch * params.BeaconConfig().SlotsPerEpoch
 	for _, pid := range connected {
 		peerChainState, err := p.ChainState(pid)
-		if err == nil && peerChainState != nil && peerChainState.HeadSlot > ourFinalizedSlot {
+		if err == nil && peerChainState != nil && peerChainState.HeadSlot > ourHeadSlot {
 			epoch := helpers.SlotToEpoch(peerChainState.HeadSlot)
 			epochVotes[epoch]++
 			pidEpoch[pid] = epoch


### PR DESCRIPTION
**What type of PR is this?**

> Other / Cleanup

**What does this PR do? Why is it needed?**
- `BestNonFinalized(minPeers int, ourFinalizedEpoch uint64)` function uses misleading param name `ourFinalizedEpoch`, while in reality head epoch is expected -- `ourHeadEpoch`, and peers having higher head than ours are returned.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
