### PR TITLE
Remove expensive validators only method

### DIFF
--- a/beacon-chain/blockchain/testing/BUILD.bazel
+++ b/beacon-chain/blockchain/testing/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//beacon-chain/forkchoice/protoarray:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
-        "//shared/bytesutil:go_default_library",
         "//shared/event:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/forkchoice/protoarray"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
@@ -376,34 +375,4 @@ func (ms *ChainService) VerifyFinalizedConsistency(_ context.Context, r []byte) 
 		return errors.New("Root and finalized store are not consistent")
 	}
 	return nil
-}
-
-// AttestationCheckPtInfo mocks AttestationCheckPtInfo and always returns nil.
-func (ms *ChainService) AttestationCheckPtInfo(_ context.Context, att *ethpb.Attestation) (*pb.CheckPtInfo, error) {
-	f := ms.State.Fork()
-	g := bytesutil.ToBytes32(ms.State.GenesisValidatorRoot())
-	seed, err := helpers.Seed(ms.State, helpers.SlotToEpoch(att.Data.Slot), params.BeaconConfig().DomainBeaconAttester)
-	if err != nil {
-		return nil, err
-	}
-	indices, err := helpers.ActiveValidatorIndices(ms.State, helpers.SlotToEpoch(att.Data.Slot))
-	if err != nil {
-		return nil, err
-	}
-	validators := ms.State.ValidatorsReadOnly()
-	pks := make([][]byte, len(validators))
-	for i := 0; i < len(pks); i++ {
-		pk := validators[i].PublicKey()
-		pks[i] = pk[:]
-	}
-
-	info := &pb.CheckPtInfo{
-		Fork:          f,
-		GenesisRoot:   g[:],
-		Seed:          seed[:],
-		ActiveIndices: indices,
-		PubKeys:       pks,
-	}
-
-	return info, nil
 }

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -585,27 +585,6 @@ func (b *BeaconState) validators() []*ethpb.Validator {
 	return res
 }
 
-// ValidatorsReadOnly returns validators participating in consensus on the beacon chain. This
-// method doesn't clone the respective validators and returns read only references to the validators.
-func (b *BeaconState) ValidatorsReadOnly() []*ReadOnlyValidator {
-	if !b.HasInnerState() {
-		return nil
-	}
-	if b.state.Validators == nil {
-		return nil
-	}
-
-	b.lock.RLock()
-	defer b.lock.RUnlock()
-
-	res := make([]*ReadOnlyValidator, len(b.state.Validators))
-	for i := 0; i < len(res); i++ {
-		val := b.state.Validators[i]
-		res[i] = &ReadOnlyValidator{validator: val}
-	}
-	return res
-}
-
 // ValidatorAtIndex is the validator at the provided index.
 func (b *BeaconState) ValidatorAtIndex(idx uint64) (*ethpb.Validator, error) {
 	if !b.HasInnerState() {

--- a/beacon-chain/state/getters_test.go
+++ b/beacon-chain/state/getters_test.go
@@ -53,7 +53,6 @@ func TestNilState_NoPanic(t *testing.T) {
 	_ = st.Eth1Data()
 	_ = st.Eth1DataVotes()
 	_ = st.Eth1DepositIndex()
-	_ = st.ValidatorsReadOnly()
 	_, err = st.ValidatorAtIndex(0)
 	_ = err
 	_, err = st.ValidatorAtIndexReadOnly(0)


### PR DESCRIPTION
As learned from previous incidents that `ValidatorsReadOnly(...` is not sufficient and should not be used. A better replacement is to use `state.ReadFromEveryValidator(...`

This PR removes `ValidatorsReadOnly(...` and updates its usages and methods in `validators_stream.go` to use `ValidatorsReadOnly(...` instead