### PR TITLE
Fix `GetValidatorParticipation` slot to epoch conversion

### DIFF
--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -469,7 +469,7 @@ func (bs *Server) GetValidatorActiveSetChanges(
 func (bs *Server) GetValidatorParticipation(
 	ctx context.Context, req *ethpb.GetValidatorParticipationRequest,
 ) (*ethpb.ValidatorParticipationResponse, error) {
-	currentSlot := helpers.SlotToEpoch(bs.GenesisTimeFetcher.CurrentSlot())
+	currentSlot := bs.GenesisTimeFetcher.CurrentSlot()
 	currentEpoch := helpers.SlotToEpoch(currentSlot)
 
 	var requestedEpoch uint64
@@ -811,13 +811,17 @@ func (bs *Server) GetIndividualVotes(
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not pre compute attestations: %v", err)
 	}
-	vals := requestedState.ValidatorsReadOnly()
 	for _, index := range filteredIndices {
 		if index >= uint64(len(v)) {
 			votes = append(votes, &ethpb.IndividualVotesRespond_IndividualVote{ValidatorIndex: index})
 			continue
 		}
-		pb := vals[index].PublicKey()
+		val, err := requestedState.ValidatorAtIndexReadOnly(index)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not retrieve validator: %v", err)
+
+		}
+		pb := val.PublicKey()
 		votes = append(votes, &ethpb.IndividualVotesRespond_IndividualVote{
 			Epoch:                            req.Epoch,
 			PublicKey:                        pb[:],

--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -811,17 +811,13 @@ func (bs *Server) GetIndividualVotes(
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not pre compute attestations: %v", err)
 	}
+	vals := requestedState.ValidatorsReadOnly()
 	for _, index := range filteredIndices {
 		if index >= uint64(len(v)) {
 			votes = append(votes, &ethpb.IndividualVotesRespond_IndividualVote{ValidatorIndex: index})
 			continue
 		}
-		val, err := requestedState.ValidatorAtIndexReadOnly(index)
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not retrieve validator: %v", err)
-
-		}
-		pb := val.PublicKey()
+		pb := vals[index].PublicKey()
 		votes = append(votes, &ethpb.IndividualVotesRespond_IndividualVote{
 			Epoch:                            req.Epoch,
 			PublicKey:                        pb[:],

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -1415,7 +1415,7 @@ func TestServer_GetValidatorParticipation_UnknownState(t *testing.T) {
 	ctx := context.Background()
 	headState := testutil.NewBeaconState()
 	require.NoError(t, headState.SetSlot(0))
-	epoch := uint64(10)
+	epoch := uint64(50)
 	slots := epoch * params.BeaconConfig().SlotsPerEpoch
 	bs := &Server{
 		BeaconDB: db,


### PR DESCRIPTION
`GetValidatorParticipation` has a bad slot to epoch conversion:
```
currentSlot := helpers.SlotToEpoch(bs.GenesisTimeFetcher.CurrentSlot())
currentEpoch := helpers.SlotToEpoch(currentSlot)
```

should have been:
```
currentSlot := bs.GenesisTimeFetcher.CurrentSlot()
currentEpoch := helpers.SlotToEpoch(currentSlot)
```