### PR TITLE
Update genesis time and deposit contract

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -82,7 +82,7 @@ var (
 	ContractDeploymentBlock = &cli.IntFlag{
 		Name:  "contract-deployment-block",
 		Usage: "The eth1 block in which the deposit contract was deployed.",
-		Value: 2844925,
+		Value: 11184524,
 	}
 	// SetGCPercent is the percentage of current live allocations at which the garbage collector is to run.
 	SetGCPercent = &cli.IntFlag{

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -133,10 +133,8 @@ func configureTestnet(ctx *cli.Context, cfg *Flags) {
 		params.UseZinkenNetworkConfig()
 		cfg.ZinkenTestnet = true
 	} else {
-		log.Warn("--<testnet> flag is not specified (default: Medalla), this will become required from next release! ")
-		params.UseMedallaConfig()
-		params.UseMedallaNetworkConfig()
-		cfg.MedallaTestnet = true
+		log.Warn("--<testnet> flag is not specified (default: Mainnet), this will become required from next release! ")
+		params.UseMainnetConfig()
 	}
 }
 

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -133,7 +133,7 @@ func configureTestnet(ctx *cli.Context, cfg *Flags) {
 		params.UseZinkenNetworkConfig()
 		cfg.ZinkenTestnet = true
 	} else {
-		log.Warn("--<testnet> flag is not specified (default: Mainnet), this will become required from next release! ")
+		log.Warn("Running on ETH2 Mainnet")
 		params.UseMainnetConfig()
 	}
 }

--- a/shared/params/mainnet_config.go
+++ b/shared/params/mainnet_config.go
@@ -32,9 +32,9 @@ var mainnetNetworkConfig = &NetworkConfig{
 	ETH2Key:                           "eth2",
 	AttSubnetKey:                      "attnets",
 	ContractDeploymentBlock:           0,
-	DepositContractAddress:            "0x", // To be updated once the mainnet contract is deployed.
-	ChainID:                           1,    // Chain ID of eth1 mainnet.
-	NetworkID:                         1,    // Network ID of eth1 mainnet.
+	DepositContractAddress:            "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+	ChainID:                           1, // Chain ID of eth1 mainnet.
+	NetworkID:                         1, // Network ID of eth1 mainnet.
 	BootstrapNodes:                    []string{},
 }
 
@@ -53,7 +53,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	ChurnLimitQuotient:             1 << 16,
 	ShuffleRoundCount:              90,
 	MinGenesisActiveValidatorCount: 16384,
-	MinGenesisTime:                 0, // Zero until a proper time is decided.
+	MinGenesisTime:                 1606824000, // Dec 1, 2020, 12pm UTC.
 	TargetAggregatorsPerCommittee:  16,
 	HysteresisQuotient:             4,
 	HysteresisDownwardMultiplier:   1,

--- a/shared/params/mainnet_config.go
+++ b/shared/params/mainnet_config.go
@@ -31,7 +31,7 @@ var mainnetNetworkConfig = &NetworkConfig{
 	MessageDomainValidSnappy:          [4]byte{01, 00, 00, 00},
 	ETH2Key:                           "eth2",
 	AttSubnetKey:                      "attnets",
-	ContractDeploymentBlock:           0,
+	ContractDeploymentBlock:           11184524, // Note: contract was deployed in block 11052984 but no transactions were sent until 11184524.
 	DepositContractAddress:            "0x00000000219ab540356cBB839Cbe05303d7705Fa",
 	ChainID:                           1, // Chain ID of eth1 mainnet.
 	NetworkID:                         1, // Network ID of eth1 mainnet.

--- a/shared/params/network_config.go
+++ b/shared/params/network_config.go
@@ -6,11 +6,6 @@ import (
 	"github.com/mohae/deepcopy"
 )
 
-func init() {
-	// Using medalla as the default configuration for now.
-	UseMedallaNetworkConfig()
-}
-
 // NetworkConfig defines the spec based network parameters.
 type NetworkConfig struct {
 	GossipMaxSize                     uint64        `yaml:"GOSSIP_MAX_SIZE"`                       // GossipMaxSize is the maximum allowed size of uncompressed gossip messages.


### PR DESCRIPTION
This PR updates genesis time, contract deployment block and deposit contract address to mainnet values It also flips mainnet values to default.
Reference: https://github.com/ethereum/eth2.0-specs/pull/2082

Note:
`ETH1_FOLLOW_DISTANCE`, `GENESIS_DELAY`, `EPOCHS_PER_ETH1_VOTING_PERIOD`, `INACTIVITY_PENALTY_QUOTIENT`, `MIN_SLASHING_PENALTY_QUOTIENT`, `PROPORTIONAL_SLASHING_MULTIPLIER` did not get updated to mainnet because they are consensus breaking. Those updates will come from #7469