### PR TITLE
Remove redundant error return from filterPeers()

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -276,25 +276,21 @@ func (f *blocksFetcher) fetchBlocksFromPeer(
 	ctx, span := trace.StartSpan(ctx, "initialsync.fetchBlocksFromPeer")
 	defer span.End()
 
-	var blocks []*eth.SignedBeaconBlock
-	peers, err := f.filterPeers(ctx, peers, peersPercentagePerRequest)
-	if err != nil {
-		return blocks, "", err
-	}
+	peers = f.filterPeers(ctx, peers, peersPercentagePerRequest)
 	req := &p2ppb.BeaconBlocksByRangeRequest{
 		StartSlot: start,
 		Count:     count,
 		Step:      1,
 	}
 	for i := 0; i < len(peers); i++ {
-		if blocks, err = f.requestBlocks(ctx, req, peers[i]); err == nil {
+		if blocks, err := f.requestBlocks(ctx, req, peers[i]); err == nil {
 			if featureconfig.Get().EnablePeerScorer {
 				f.p2p.Peers().Scorers().BlockProviderScorer().Touch(peers[i])
 			}
 			return blocks, peers[i], err
 		}
 	}
-	return blocks, "", errNoPeersAvailable
+	return nil, "", errNoPeersAvailable
 }
 
 // requestBlocks is a wrapper for handling BeaconBlocksByRangeRequest requests/streams.

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_peers_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_peers_test.go
@@ -181,12 +181,11 @@ func TestBlocksFetcher_filterPeers(t *testing.T) {
 				pids = append(pids, pid.ID)
 				fetcher.rateLimiter.Add(pid.ID.String(), pid.usedCapacity)
 			}
-			got, err := fetcher.filterPeers(context.Background(), pids, tt.args.peersPercentage)
-			require.NoError(t, err)
+			pids = fetcher.filterPeers(context.Background(), pids, tt.args.peersPercentage)
 			// Re-arrange peers with the same remaining capacity, deterministically .
 			// They are deliberately shuffled - so that on the same capacity any of
 			// such peers can be selected. That's why they are sorted here.
-			sort.SliceStable(got, func(i, j int) bool {
+			sort.SliceStable(pids, func(i, j int) bool {
 				cap1 := fetcher.rateLimiter.Remaining(pids[i].String())
 				cap2 := fetcher.rateLimiter.Remaining(pids[j].String())
 				if cap1 == cap2 {
@@ -194,7 +193,7 @@ func TestBlocksFetcher_filterPeers(t *testing.T) {
 				}
 				return i < j
 			})
-			assert.DeepEqual(t, tt.want, got)
+			assert.DeepEqual(t, tt.want, pids)
 		})
 	}
 }
@@ -345,7 +344,7 @@ func TestBlocksFetcher_filterScoredPeers(t *testing.T) {
 			var filteredPIDs []peer.ID
 			var err error
 			for i := 0; i < 1000; i++ {
-				filteredPIDs, err = fetcher.filterPeers(context.Background(), peerIDs, tt.args.peersPercentage)
+				filteredPIDs = fetcher.filterPeers(context.Background(), peerIDs, tt.args.peersPercentage)
 				if len(filteredPIDs) <= 1 {
 					break
 				}

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_utils.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_utils.go
@@ -35,10 +35,7 @@ func (f *blocksFetcher) nonSkippedSlotAfter(ctx context.Context, slot uint64) (u
 	}
 
 	// Transform peer list to avoid eclipsing (filter, shuffle, trim).
-	peers, err := f.filterPeers(ctx, peers, peersPercentagePerRequest)
-	if err != nil {
-		return 0, err
-	}
+	peers = f.filterPeers(ctx, peers, peersPercentagePerRequest)
 	if len(peers) == 0 {
 		return 0, errNoPeersAvailable
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Other / Cleanup

**What does this PR do? Why is it needed?**
- `filterPeers()` in `init-sync` always returns `nil` for error, making that return type redundant. It is removed as unnecessary complicating the API and serving no purpose.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
