### PR TITLE
Remove duplicated --slots-per-archive-point in help menu

### DIFF
--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -105,7 +105,6 @@ var appHelpFlagGroups = []flagGroup{
 			flags.BlockBatchLimit,
 			flags.BlockBatchLimitBurstFactor,
 			flags.EnableDebugRPCEndpoints,
-			flags.SlotsPerArchivedPoint,
 			flags.HistoricalSlasherNode,
 			flags.ChainID,
 			flags.NetworkID,


### PR DESCRIPTION
`SlotsPerArchivedPoint` was already defined in L103. This removes the duplication
