### PR TITLE
Allow exiting validators to attest

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -331,7 +331,7 @@ func (v *validator) checkAndLogValidatorStatus(validatorStatuses []*ethpb.Valida
 					"activationEpoch": status.Status.ActivationEpoch,
 				}).Info("Waiting for activation")
 			}
-		case ethpb.ValidatorStatus_ACTIVE:
+		case ethpb.ValidatorStatus_ACTIVE, ethpb.ValidatorStatus_EXITING:
 			validatorActivated = true
 		case ethpb.ValidatorStatus_EXITED:
 			log.Info("Validator exited")


### PR DESCRIPTION
When launching the validator client, if the validator is exiting (in the queue) this PR allows for it to continue attesting. 

Fixes #7745 

Note: not tested, that's why it is a draft still. 