### PR TITLE
Update delete state(s) functions

### DIFF
--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -182,7 +182,11 @@ func TestEnableSaveHotStateToDB_Disabled(t *testing.T) {
 	db, _ := testDB.SetupDB(t)
 	service := New(db, cache.NewStateSummaryCache())
 	service.saveHotStateDB.enabled = true
-	service.saveHotStateDB.savedStateRoots = [][32]byte{{'a'}}
+	b := testutil.NewBeaconBlock()
+	require.NoError(t, db.SaveBlock(ctx, b))
+	r, err := b.Block.HashTreeRoot()
+	require.NoError(t, err)
+	service.saveHotStateDB.savedStateRoots = [][32]byte{r}
 	require.NoError(t, service.DisableSaveHotStateToDB(ctx))
 	require.LogsContain(t, hook, "Exiting mode to save hot states in DB")
 	require.Equal(t, false, service.saveHotStateDB.enabled)


### PR DESCRIPTION
This PR improves on the design for the delete state functions:

* Currently `DeleteStates` put everything under 1 TX, that means it either all works or none of it works
* For `DeleteStates`, Instead of doing one big update, it's better to do one at a time
* This PR refactored `DeleteStates` to `DeleteState` without the cursor, and updated `DeleteStates` to just call `DeleteState`