### PR TITLE
Fix Up Exits Pool Logic

### DIFF
--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -93,14 +93,13 @@ func TestService_ReceiveBlock(t *testing.T) {
 				),
 			},
 			check: func(t *testing.T, s *Service) {
-				var n int
-				for i := uint64(0); int(i) < genesis.NumValidators(); i++ {
-					if s.exitPool.HasBeenIncluded(i) {
-						n++
-					}
-				}
-				if n != 3 {
-					t.Errorf("Did not mark the correct number of exits. Got %d but wanted %d", n, 3)
+				pending := s.exitPool.PendingExits(genesis, 1, true /* no limit */)
+				if len(pending) != 0 {
+					t.Errorf(
+						"Did not mark the correct number of exits. Got %d pending but wanted %d",
+						len(pending),
+						0,
+					)
 				}
 			},
 		},

--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -78,7 +78,6 @@ func TestService_ReceiveBlock(t *testing.T) {
 				}
 			},
 		},
-
 		{
 			name: "updates exit pool",
 			args: args{

--- a/beacon-chain/operations/voluntaryexits/BUILD.bazel
+++ b/beacon-chain/operations/voluntaryexits/BUILD.bazel
@@ -30,7 +30,6 @@ go_test(
         "//beacon-chain/state:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/params:go_default_library",
-        "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/beacon-chain/operations/voluntaryexits/service.go
+++ b/beacon-chain/operations/voluntaryexits/service.go
@@ -73,7 +73,7 @@ func (p *Pool) InsertVoluntaryExit(ctx context.Context, state *beaconstate.Beaco
 		return
 	}
 
-	// Prevent any sort of duplicate exit from being seenExits.
+	// Prevent any sort of duplicate exit from being inserted.
 	if p.seenExits[exit.Exit.ValidatorIndex] {
 		return
 	}

--- a/beacon-chain/operations/voluntaryexits/service.go
+++ b/beacon-chain/operations/voluntaryexits/service.go
@@ -15,17 +15,15 @@ import (
 // Pool implements a struct to maintain pending and seen voluntary exits. This pool
 // is used by proposers to insert into new blocks.
 type Pool struct {
-	lock      sync.RWMutex
-	pending   []*ethpb.SignedVoluntaryExit
-	seenExits map[uint64]bool
+	lock    sync.RWMutex
+	pending []*ethpb.SignedVoluntaryExit
 }
 
 // NewPool accepts a head fetcher (for reading the validator set) and returns an initialized
 // voluntary exit pool.
 func NewPool() *Pool {
 	return &Pool{
-		pending:   make([]*ethpb.SignedVoluntaryExit, 0),
-		seenExits: make(map[uint64]bool),
+		pending: make([]*ethpb.SignedVoluntaryExit, 0),
 	}
 }
 
@@ -70,12 +68,7 @@ func (p *Pool) InsertVoluntaryExit(ctx context.Context, state *beaconstate.Beaco
 		return
 	}
 
-	// Prevent any sort of duplicate exits from being inserted.
-	if p.seenExits[exit.Exit.ValidatorIndex] {
-		return
-	}
 	existsInPending, index := existsInList(p.pending, exit.Exit.ValidatorIndex)
-
 	// If the item exists in the pending list and includes a more favorable, earlier
 	// exit epoch, we replace it in the pending list. If it exists but the prior condition is false,
 	// we simply return.
@@ -97,7 +90,6 @@ func (p *Pool) InsertVoluntaryExit(ctx context.Context, state *beaconstate.Beaco
 	sort.Slice(p.pending, func(i, j int) bool {
 		return p.pending[i].Exit.ValidatorIndex < p.pending[j].Exit.ValidatorIndex
 	})
-	p.seenExits[exit.Exit.ValidatorIndex] = true
 }
 
 // MarkIncluded is used when an exit has been included in a beacon block. Every block seen by this

--- a/beacon-chain/operations/voluntaryexits/service.go
+++ b/beacon-chain/operations/voluntaryexits/service.go
@@ -66,10 +66,7 @@ func (p *Pool) InsertVoluntaryExit(ctx context.Context, state *beaconstate.Beaco
 	defer p.lock.Unlock()
 
 	// Prevent malformed messages from being inserted.
-	if exit == nil {
-		return
-	}
-	if exit.Exit == nil {
+	if exit == nil || exit.Exit == nil {
 		return
 	}
 

--- a/beacon-chain/operations/voluntaryexits/service.go
+++ b/beacon-chain/operations/voluntaryexits/service.go
@@ -12,20 +12,20 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// Pool implements a struct to maintain pending and recently included voluntary exits. This pool
+// Pool implements a struct to maintain pending and recently seenExits voluntary exits. This pool
 // is used by proposers to insert into new blocks.
 type Pool struct {
-	lock     sync.RWMutex
-	pending  []*ethpb.SignedVoluntaryExit
-	included map[uint64]bool
+	lock      sync.RWMutex
+	pending   []*ethpb.SignedVoluntaryExit
+	seenExits map[uint64]bool
 }
 
 // NewPool accepts a head fetcher (for reading the validator set) and returns an initialized
 // voluntary exit pool.
 func NewPool() *Pool {
 	return &Pool{
-		pending:  make([]*ethpb.SignedVoluntaryExit, 0),
-		included: make(map[uint64]bool),
+		pending:   make([]*ethpb.SignedVoluntaryExit, 0),
+		seenExits: make(map[uint64]bool),
 	}
 }
 
@@ -46,7 +46,8 @@ func (p *Pool) PendingExits(state *beaconstate.BeaconState, slot uint64, noLimit
 		if e.Exit.Epoch > helpers.SlotToEpoch(slot) {
 			continue
 		}
-		if v, err := state.ValidatorAtIndexReadOnly(e.Exit.ValidatorIndex); err == nil && v.ExitEpoch() == params.BeaconConfig().FarFutureEpoch {
+		if v, err := state.ValidatorAtIndexReadOnly(e.Exit.ValidatorIndex); err == nil &&
+			v.ExitEpoch() == params.BeaconConfig().FarFutureEpoch {
 			pending = append(pending, e)
 		}
 	}
@@ -57,60 +58,50 @@ func (p *Pool) PendingExits(state *beaconstate.BeaconState, slot uint64, noLimit
 }
 
 // InsertVoluntaryExit into the pool. This method is a no-op if the pending exit already exists,
-// has been included recently, or the validator is already exited.
+// has been seenExits recently, or the validator is already exited.
 func (p *Pool) InsertVoluntaryExit(ctx context.Context, state *beaconstate.BeaconState, exit *ethpb.SignedVoluntaryExit) {
 	ctx, span := trace.StartSpan(ctx, "exitPool.InsertVoluntaryExit")
 	defer span.End()
-
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	// Has this validator index been included recently?
-	if p.included[exit.Exit.ValidatorIndex] {
+	// Prevent malformed messages from being inserted.
+	if exit == nil {
+		return
+	}
+	if exit.Exit == nil {
+		return
+	}
+
+	// Prevent any sort of duplicate exit from being seenExits.
+	if p.seenExits[exit.Exit.ValidatorIndex] {
 		return
 	}
 
 	// Has the validator been exited already?
-	if v, err := state.ValidatorAtIndexReadOnly(exit.Exit.ValidatorIndex); err != nil || v.ExitEpoch() != params.BeaconConfig().FarFutureEpoch {
+	if v, err := state.ValidatorAtIndexReadOnly(exit.Exit.ValidatorIndex); err != nil ||
+		v.ExitEpoch() != params.BeaconConfig().FarFutureEpoch {
 		return
 	}
 
-	// Does this validator exist in the list already? Use binary search to find the answer.
-	if found := sort.Search(len(p.pending), func(i int) bool {
-		e := p.pending[i].Exit
-		return e.ValidatorIndex == exit.Exit.ValidatorIndex
-	}); found != len(p.pending) {
-		// If an exit exists with this validator index, prefer one with an earlier exit epoch.
-		if p.pending[found].Exit.Epoch > exit.Exit.Epoch {
-			p.pending[found] = exit
-		}
-		return
-	}
-
-	// Insert into pending list and sort again.
+	// Insert into pending list and sort.
 	p.pending = append(p.pending, exit)
 	sort.Slice(p.pending, func(i, j int) bool {
 		return p.pending[i].Exit.ValidatorIndex < p.pending[j].Exit.ValidatorIndex
 	})
 }
 
-// MarkIncluded is used when an exit has been included in a beacon block. Every block seen by this
+// MarkIncluded is used when an exit has been seenExits in a beacon block. Every block seen by this
 // node should call this method to include the exit.
 func (p *Pool) MarkIncluded(exit *ethpb.SignedVoluntaryExit) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	i := sort.Search(len(p.pending), func(i int) bool {
-		return p.pending[i].Exit.ValidatorIndex == exit.Exit.ValidatorIndex
+	searchingFor := exit.Exit.ValidatorIndex
+	i := sort.Search(len(p.pending), func(j int) bool {
+		return p.pending[j].Exit.ValidatorIndex >= searchingFor
 	})
-	if i != len(p.pending) {
+	if i < len(p.pending) && p.pending[i].Exit.ValidatorIndex == searchingFor {
+		// Exit we want is present at p.pending[i], so we remove it.
 		p.pending = append(p.pending[:i], p.pending[i+1:]...)
 	}
-	p.included[exit.Exit.ValidatorIndex] = true
-}
-
-// HasBeenIncluded returns true if the pool has recorded that a validator index has been recorded.
-func (p *Pool) HasBeenIncluded(bIdx uint64) bool {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	return p.included[bIdx]
 }

--- a/beacon-chain/operations/voluntaryexits/service.go
+++ b/beacon-chain/operations/voluntaryexits/service.go
@@ -12,7 +12,7 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// Pool implements a struct to maintain pending and recently seenExits voluntary exits. This pool
+// Pool implements a struct to maintain pending and seen voluntary exits. This pool
 // is used by proposers to insert into new blocks.
 type Pool struct {
 	lock      sync.RWMutex
@@ -58,7 +58,7 @@ func (p *Pool) PendingExits(state *beaconstate.BeaconState, slot uint64, noLimit
 }
 
 // InsertVoluntaryExit into the pool. This method is a no-op if the pending exit already exists,
-// has been seenExits recently, or the validator is already exited.
+// or the validator is already exited.
 func (p *Pool) InsertVoluntaryExit(ctx context.Context, state *beaconstate.BeaconState, exit *ethpb.SignedVoluntaryExit) {
 	ctx, span := trace.StartSpan(ctx, "exitPool.InsertVoluntaryExit")
 	defer span.End()
@@ -91,8 +91,9 @@ func (p *Pool) InsertVoluntaryExit(ctx context.Context, state *beaconstate.Beaco
 	})
 }
 
-// MarkIncluded is used when an exit has been seenExits in a beacon block. Every block seen by this
-// node should call this method to include the exit.
+// MarkIncluded is used when an exit has been included in a beacon block. Every block seen by this
+// node should call this method to include the exit. This will remove the exit from
+// the pending exits slice.
 func (p *Pool) MarkIncluded(exit *ethpb.SignedVoluntaryExit) {
 	p.lock.Lock()
 	defer p.lock.Unlock()

--- a/beacon-chain/operations/voluntaryexits/service_test.go
+++ b/beacon-chain/operations/voluntaryexits/service_test.go
@@ -107,6 +107,36 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 			},
 		},
 		{
+			name: "Duplicate exit not in map but found in pending list",
+			fields: fields{
+				pending: []*ethpb.SignedVoluntaryExit{
+					{
+						Exit: &ethpb.VoluntaryExit{
+							Epoch:          12,
+							ValidatorIndex: 1,
+						},
+					},
+				},
+				seenExits: make(map[uint64]bool),
+			},
+			args: args{
+				exit: &ethpb.SignedVoluntaryExit{
+					Exit: &ethpb.VoluntaryExit{
+						Epoch:          12,
+						ValidatorIndex: 1,
+					},
+				},
+			},
+			want: []*ethpb.SignedVoluntaryExit{
+				{
+					Exit: &ethpb.VoluntaryExit{
+						Epoch:          12,
+						ValidatorIndex: 1,
+					},
+				},
+			},
+		},
+		{
 			name: "Duplicate validator index",
 			fields: fields{
 				pending: []*ethpb.SignedVoluntaryExit{

--- a/beacon-chain/operations/voluntaryexits/service_test.go
+++ b/beacon-chain/operations/voluntaryexits/service_test.go
@@ -15,8 +15,7 @@ import (
 
 func TestPool_InsertVoluntaryExit(t *testing.T) {
 	type fields struct {
-		pending   []*ethpb.SignedVoluntaryExit
-		seenExits map[uint64]bool
+		pending []*ethpb.SignedVoluntaryExit
 	}
 	type args struct {
 		exit *ethpb.SignedVoluntaryExit
@@ -30,8 +29,7 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 		{
 			name: "Prevent inserting nil exit",
 			fields: fields{
-				pending:   make([]*ethpb.SignedVoluntaryExit, 0),
-				seenExits: make(map[uint64]bool),
+				pending: make([]*ethpb.SignedVoluntaryExit, 0),
 			},
 			args: args{
 				exit: nil,
@@ -41,8 +39,7 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 		{
 			name: "Prevent inserting malformed exit",
 			fields: fields{
-				pending:   make([]*ethpb.SignedVoluntaryExit, 0),
-				seenExits: make(map[uint64]bool),
+				pending: make([]*ethpb.SignedVoluntaryExit, 0),
 			},
 			args: args{
 				exit: &ethpb.SignedVoluntaryExit{
@@ -54,8 +51,7 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 		{
 			name: "Empty list",
 			fields: fields{
-				pending:   make([]*ethpb.SignedVoluntaryExit, 0),
-				seenExits: make(map[uint64]bool),
+				pending: make([]*ethpb.SignedVoluntaryExit, 0),
 			},
 			args: args{
 				exit: &ethpb.SignedVoluntaryExit{
@@ -85,9 +81,6 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 						},
 					},
 				},
-				seenExits: map[uint64]bool{
-					1: true,
-				},
 			},
 			args: args{
 				exit: &ethpb.SignedVoluntaryExit{
@@ -107,7 +100,7 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 			},
 		},
 		{
-			name: "Duplicate exit not in map but found in pending list",
+			name: "Duplicate exit in pending list",
 			fields: fields{
 				pending: []*ethpb.SignedVoluntaryExit{
 					{
@@ -117,7 +110,6 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 						},
 					},
 				},
-				seenExits: make(map[uint64]bool),
 			},
 			args: args{
 				exit: &ethpb.SignedVoluntaryExit{
@@ -146,9 +138,6 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 							ValidatorIndex: 1,
 						},
 					},
-				},
-				seenExits: map[uint64]bool{
-					1: true,
 				},
 			},
 			args: args{
@@ -179,7 +168,6 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 						},
 					},
 				},
-				seenExits: make(map[uint64]bool),
 			},
 			args: args{
 				exit: &ethpb.SignedVoluntaryExit{
@@ -201,8 +189,7 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 		{
 			name: "Exit for already exited validator",
 			fields: fields{
-				pending:   []*ethpb.SignedVoluntaryExit{},
-				seenExits: make(map[uint64]bool),
+				pending: []*ethpb.SignedVoluntaryExit{},
 			},
 			args: args{
 				exit: &ethpb.SignedVoluntaryExit{
@@ -231,7 +218,6 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 						},
 					},
 				},
-				seenExits: make(map[uint64]bool),
 			},
 			args: args{
 				exit: &ethpb.SignedVoluntaryExit{
@@ -262,24 +248,6 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "Already seenExits",
-			fields: fields{
-				pending: make([]*ethpb.SignedVoluntaryExit, 0),
-				seenExits: map[uint64]bool{
-					1: true,
-				},
-			},
-			args: args{
-				exit: &ethpb.SignedVoluntaryExit{
-					Exit: &ethpb.VoluntaryExit{
-						Epoch:          12,
-						ValidatorIndex: 1,
-					},
-				},
-			},
-			want: []*ethpb.SignedVoluntaryExit{},
-		},
 	}
 	ctx := context.Background()
 	validators := []*ethpb.Validator{
@@ -299,8 +267,7 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Pool{
-				pending:   tt.fields.pending,
-				seenExits: tt.fields.seenExits,
+				pending: tt.fields.pending,
 			}
 			s, err := beaconstate.InitializeFromProtoUnsafe(&p2ppb.BeaconState{Validators: validators})
 			require.NoError(t, err)
@@ -366,8 +333,7 @@ func TestPool_MarkIncluded(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &Pool{
-				pending:   tt.fields.pending,
-				seenExits: tt.fields.included,
+				pending: tt.fields.pending,
 			}
 			p.MarkIncluded(tt.args.exit)
 			if len(p.pending) != len(tt.want.pending) {

--- a/beacon-chain/operations/voluntaryexits/service_test.go
+++ b/beacon-chain/operations/voluntaryexits/service_test.go
@@ -169,6 +169,36 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 			},
 		},
 		{
+			name: "Duplicate received with more favorable exit epoch",
+			fields: fields{
+				pending: []*ethpb.SignedVoluntaryExit{
+					{
+						Exit: &ethpb.VoluntaryExit{
+							Epoch:          12,
+							ValidatorIndex: 1,
+						},
+					},
+				},
+				seenExits: make(map[uint64]bool),
+			},
+			args: args{
+				exit: &ethpb.SignedVoluntaryExit{
+					Exit: &ethpb.VoluntaryExit{
+						Epoch:          4,
+						ValidatorIndex: 1,
+					},
+				},
+			},
+			want: []*ethpb.SignedVoluntaryExit{
+				{
+					Exit: &ethpb.VoluntaryExit{
+						Epoch:          4,
+						ValidatorIndex: 1,
+					},
+				},
+			},
+		},
+		{
 			name: "Exit for already exited validator",
 			fields: fields{
 				pending:   []*ethpb.SignedVoluntaryExit{},

--- a/beacon-chain/operations/voluntaryexits/service_test.go
+++ b/beacon-chain/operations/voluntaryexits/service_test.go
@@ -28,6 +28,30 @@ func TestPool_InsertVoluntaryExit(t *testing.T) {
 		want   []*ethpb.SignedVoluntaryExit
 	}{
 		{
+			name: "Prevent inserting nil exit",
+			fields: fields{
+				pending:   make([]*ethpb.SignedVoluntaryExit, 0),
+				seenExits: make(map[uint64]bool),
+			},
+			args: args{
+				exit: nil,
+			},
+			want: []*ethpb.SignedVoluntaryExit{},
+		},
+		{
+			name: "Prevent inserting malformed exit",
+			fields: fields{
+				pending:   make([]*ethpb.SignedVoluntaryExit, 0),
+				seenExits: make(map[uint64]bool),
+			},
+			args: args{
+				exit: &ethpb.SignedVoluntaryExit{
+					Exit: nil,
+				},
+			},
+			want: []*ethpb.SignedVoluntaryExit{},
+		},
+		{
 			name: "Empty list",
 			fields: fields{
 				pending:   make([]*ethpb.SignedVoluntaryExit, 0),


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

This is related to #7772. Our exits logic was needlessly complex, as all we needed to do is to check if an exit was already seen by the pool to reject it. Additionally, we needed to simplify further parts of the code in there and ensure our binary search is correct according to the Go stdlib.
