### PR TITLE
`RandaoSignatureSet` to not return state

### DIFF
--- a/beacon-chain/core/blocks/randao_test.go
+++ b/beacon-chain/core/blocks/randao_test.go
@@ -86,7 +86,7 @@ func TestRandaoSignatureSet_OK(t *testing.T) {
 		},
 	}
 
-	set, _, err := blocks.RandaoSignatureSet(beaconState, block.Body)
+	set, err := blocks.RandaoSignatureSet(beaconState, block.Body)
 	require.NoError(t, err)
 	verified, err := set.Verify()
 	require.NoError(t, err)

--- a/beacon-chain/core/blocks/signature.go
+++ b/beacon-chain/core/blocks/signature.go
@@ -92,16 +92,16 @@ func BlockSignatureSet(beaconState *stateTrie.BeaconState, block *ethpb.SignedBe
 // from a block and its corresponding state.
 func RandaoSignatureSet(beaconState *stateTrie.BeaconState,
 	body *ethpb.BeaconBlockBody,
-) (*bls.SignatureSet, *stateTrie.BeaconState, error) {
+) (*bls.SignatureSet, error) {
 	buf, proposerPub, domain, err := randaoSigningData(beaconState)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	set, err := retrieveSignatureSet(buf, proposerPub, body.RandaoReveal, domain)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return set, beaconState, nil
+	return set, nil
 }
 
 // retrieves the randao related signing data from the state.

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -415,7 +415,7 @@ func ProcessBlockNoVerifyAnySig(
 		traceutil.AnnotateError(span, err)
 		return nil, nil, errors.Wrap(err, "could not retrieve block signature set")
 	}
-	rSet, state, err := b.RandaoSignatureSet(state, signed.Block.Body)
+	rSet, err := b.RandaoSignatureSet(state, signed.Block.Body)
 	if err != nil {
 		traceutil.AnnotateError(span, err)
 		return nil, nil, errors.Wrap(err, "could not retrieve randao signature set")


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Cleanup

**What does this PR do? Why is it needed?**

`RandaoSignatureSet` does not need to return beacon state, this PR cleans it up

**Which issues(s) does this PR fix?**

Fixes # N/A

**Other notes for review**
