### PR TITLE
Mitigate potential overflow. ethereum/eth2.0-specs#2129

### DIFF
--- a/beacon-chain/core/helpers/block.go
+++ b/beacon-chain/core/helpers/block.go
@@ -1,6 +1,8 @@
 package helpers
 
 import (
+	"math"
+
 	"github.com/pkg/errors"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -17,6 +19,9 @@ import (
 //    assert slot < state.slot <= slot + SLOTS_PER_HISTORICAL_ROOT
 //    return state.block_roots[slot % SLOTS_PER_HISTORICAL_ROOT]
 func BlockRootAtSlot(state *stateTrie.BeaconState, slot uint64) ([]byte, error) {
+	if math.MaxUint64-slot < params.BeaconConfig().SlotsPerHistoricalRoot {
+		return []byte{}, errors.New("slot overflows uint64")
+	}
 	if slot >= state.Slot() || state.Slot() > slot+params.BeaconConfig().SlotsPerHistoricalRoot {
 		return []byte{}, errors.Errorf("slot %d out of bounds", slot)
 	}

--- a/beacon-chain/core/helpers/block_test.go
+++ b/beacon-chain/core/helpers/block_test.go
@@ -2,6 +2,7 @@ package helpers_test
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
@@ -100,6 +101,11 @@ func TestBlockRootAtSlot_OutOfBounds(t *testing.T) {
 			slot:        1,
 			stateSlot:   params.BeaconConfig().SlotsPerHistoricalRoot + 2,
 			expectedErr: "slot 1 out of bounds",
+		},
+		{
+			slot:        math.MaxUint64 - 5,
+			stateSlot:   0, // Doesn't matter
+			expectedErr: "slot overflows uint64",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

There is a potential, albeit unlikely, risk of an overflow for `get_block_root_at_slot`. 
`compute_start_slot_at_epoch` already had overflow protection, so this exploit is probably not reproducable in any production code path.

**Which issues(s) does this PR fix?**

Fixes https://github.com/ethereum/eth2.0-specs/issues/2129 for Prysm.

**Other notes for review**

I did not test at runtime or sync with this change. 
