### PR TITLE
Update Go-Ethereum Dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,10 +60,10 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "209b1a3a4719f3bf613f787fb97389c9aaea195d633d9485c40ed1de18c059f1",
-    strip_prefix = "bazel-gazelle-97d00015cfacc708d88e382f08eab8a1a31c3bef",
+    sha256 = "1f4fc1d91826ec436ae04833430626f4cc02c20bb0a813c0c2f3c4c421307b1d",
+    strip_prefix = "bazel-gazelle-e368a11b76e92932122d824970dc0ce5feb9c349",
     urls = [
-        "https://github.com/bazelbuild/bazel-gazelle/archive/97d00015cfacc708d88e382f08eab8a1a31c3bef.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/archive/e368a11b76e92932122d824970dc0ce5feb9c349.tar.gz",
     ],
 )
 

--- a/deps.bzl
+++ b/deps.bzl
@@ -601,7 +601,7 @@ def prysm_deps():
     # Note: The keep directives help gazelle leave this alone.
     go_repository(
         name = "com_github_ethereum_go_ethereum",
-        commit = "974cbc1dd92e929f7856092b29d3f725dfab9803",  # keep
+        commit = "013fd65b37916db69a9972226235d3063c3c83a7",  # keep
         importpath = "github.com/ethereum/go-ethereum",  # keep
         # Note: go-ethereum is not bazel-friendly with regards to cgo. We have a
         # a fork that has resolved these issues by disabling HID/USB support and

--- a/go.mod
+++ b/go.mod
@@ -137,6 +137,6 @@ require (
 	k8s.io/utils v0.0.0-20200520001619-278ece378a50 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20201016095414-974cbc1dd92e
+replace github.com/ethereum/go-ethereum => github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20201113091623-013fd65b3791
 
 replace github.com/json-iterator/go => github.com/prestonvanloon/go v1.1.7-0.20190722034630-4f2e55fcf87b

--- a/go.sum
+++ b/go.sum
@@ -965,8 +965,8 @@ github.com/prometheus/tsdb v0.10.0 h1:If5rVCMTp6W2SiRAQFlbpJNgVlgMEd+U2GZckwK38i
 github.com/prometheus/tsdb v0.10.0/go.mod h1:oi49uRhEe9dPUTlS3JRZOwJuVi6tmh10QSgwXEyGCt4=
 github.com/protolambda/zssz v0.1.5 h1:7fjJjissZIIaa2QcvmhS/pZISMX21zVITt49sW1ouek=
 github.com/protolambda/zssz v0.1.5/go.mod h1:a4iwOX5FE7/JkKA+J/PH0Mjo9oXftN6P8NZyL28gpag=
-github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20201016095414-974cbc1dd92e h1:+AspXGWVJzMtcy24DkGEJqut1grik397nnb7JybNBy8=
-github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20201016095414-974cbc1dd92e/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
+github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20201113091623-013fd65b3791 h1:6C+VhYdUuy784LPc9t/FuAptmlYcrf5pYjXKPj93ko8=
+github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20201113091623-013fd65b3791/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
 github.com/prysmaticlabs/ethereumapis v0.0.0-20201003171600-a72e5f77d233 h1:dGeuKeaXxCepTbwsz7kYSfP1yazw1uRMn58CqNCcPP4=
 github.com/prysmaticlabs/ethereumapis v0.0.0-20201003171600-a72e5f77d233/go.mod h1:k7b2dxy6RppCG6kmOJkNOXzRpEoTdsPygc2aQhsUsZk=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669 h1:cX6YRZnZ9sgMqM5U14llxUiXVNJ3u07Res1IIjTOgtI=


### PR DESCRIPTION
**What type of PR is this?**

Feature Addition

**What does this PR do? Why is it needed?**

 - [x] Updates our geth fork following on from #7800 .
-  [x] Updates Gazelle to be in line with our updated `rules_go`

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
