### PR TITLE
Simplify Terms of Service Log

### DIFF
--- a/shared/tos/tos.go
+++ b/shared/tos/tos.go
@@ -26,7 +26,7 @@ TERMS AND CONDITIONS: https://github.com/prysmaticlabs/prysm/blob/master/TERMS_O
 
 Type "accept" to accept this terms and conditions [accept/decline]:`
 	acceptTosPromptErrText = `Could not scan text input, if you are trying to run in non-interactive environment, you
-should use --accept-terms-of-use flag (only once) after reading the terms and conditions here: 
+can use the --accept-terms-of-use flag after reading the terms and conditions here: 
 https://github.com/prysmaticlabs/prysm/blob/master/TERMS_OF_SERVICE.md`
 )
 


### PR DESCRIPTION
No tracking issue, this PR simplifies the terms of service logs. Some users thought that saying `you should use the --accept-terms-of-use only once` meant there was a risk to using it again