### PR TITLE
Update TestMain() to use os.Exit()

### DIFF
--- a/beacon-chain/blockchain/blockchain_test.go
+++ b/beacon-chain/blockchain/blockchain_test.go
@@ -2,14 +2,18 @@ package blockchain
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/beacon-chain/cache/cache_test.go
+++ b/beacon-chain/cache/cache_test.go
@@ -1,13 +1,17 @@
 package cache
 
 import (
+	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 )
 
 func TestMain(m *testing.M) {
-	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableEth1DataVoteCache: true})
-	defer resetCfg()
-	m.Run()
+	run := func() int {
+		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableEth1DataVoteCache: true})
+		defer resetCfg()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/beacon-chain/core/epoch/spectest/spectest_test.go
+++ b/beacon-chain/core/epoch/spectest/spectest_test.go
@@ -1,17 +1,21 @@
 package spectest
 
 import (
+	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
 func TestMain(m *testing.M) {
-	prevConfig := params.BeaconConfig().Copy()
-	defer params.OverrideBeaconConfig(prevConfig)
-	c := params.BeaconConfig()
-	c.MinGenesisActiveValidatorCount = 16384
-	params.OverrideBeaconConfig(c)
+	run := func() int {
+		prevConfig := params.BeaconConfig().Copy()
+		defer params.OverrideBeaconConfig(prevConfig)
+		c := params.BeaconConfig()
+		c.MinGenesisActiveValidatorCount = 16384
+		params.OverrideBeaconConfig(c)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/beacon-chain/p2p/peers/peers_test.go
+++ b/beacon-chain/p2p/peers/peers_test.go
@@ -2,6 +2,7 @@ package peers_test
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
@@ -10,21 +11,24 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
-		EnablePeerScorer: true,
-	})
-	defer resetCfg()
+		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
+			EnablePeerScorer: true,
+		})
+		defer resetCfg()
 
-	resetFlags := flags.Get()
-	flags.Init(&flags.GlobalFlags{
-		BlockBatchLimit:            64,
-		BlockBatchLimitBurstFactor: 10,
-	})
-	defer func() {
-		flags.Init(resetFlags)
-	}()
-	m.Run()
+		resetFlags := flags.Get()
+		flags.Init(&flags.GlobalFlags{
+			BlockBatchLimit:            64,
+			BlockBatchLimitBurstFactor: 10,
+		})
+		defer func() {
+			flags.Init(resetFlags)
+		}()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/beacon-chain/p2p/peers/scorers/scorers_test.go
+++ b/beacon-chain/p2p/peers/scorers/scorers_test.go
@@ -3,6 +3,7 @@ package scorers_test
 import (
 	"io/ioutil"
 	"math"
+	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
@@ -12,23 +13,26 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
-		EnablePeerScorer: true,
-	})
-	defer resetCfg()
+		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
+			EnablePeerScorer: true,
+		})
+		defer resetCfg()
 
-	resetFlags := flags.Get()
-	flags.Init(&flags.GlobalFlags{
-		BlockBatchLimit:            64,
-		BlockBatchLimitBurstFactor: 10,
-	})
-	defer func() {
-		flags.Init(resetFlags)
-	}()
-	m.Run()
+		resetFlags := flags.Get()
+		flags.Init(&flags.GlobalFlags{
+			BlockBatchLimit:            64,
+			BlockBatchLimitBurstFactor: 10,
+		})
+		defer func() {
+			flags.Init(resetFlags)
+		}()
+		return m.Run()
+	}
+	os.Exit(run())
 }
 
 // roundScore returns score rounded in accordance with the score manager's rounding factor.

--- a/beacon-chain/powchain/powchain_test.go
+++ b/beacon-chain/powchain/powchain_test.go
@@ -2,14 +2,18 @@ package powchain
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/beacon-chain/rpc/beacon/beacon_test.go
+++ b/beacon-chain/rpc/beacon/beacon_test.go
@@ -1,6 +1,7 @@
 package beacon
 
 import (
+	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
@@ -8,18 +9,21 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Use minimal config to reduce test setup time.
-	prevConfig := params.BeaconConfig().Copy()
-	defer params.OverrideBeaconConfig(prevConfig)
-	params.OverrideBeaconConfig(params.MinimalSpecConfig())
+	run := func() int {
+		// Use minimal config to reduce test setup time.
+		prevConfig := params.BeaconConfig().Copy()
+		defer params.OverrideBeaconConfig(prevConfig)
+		params.OverrideBeaconConfig(params.MinimalSpecConfig())
 
-	resetFlags := flags.Get()
-	flags.Init(&flags.GlobalFlags{
-		MinimumSyncPeers: 30,
-	})
-	defer func() {
-		flags.Init(resetFlags)
-	}()
+		resetFlags := flags.Get()
+		flags.Init(&flags.GlobalFlags{
+			MinimumSyncPeers: 30,
+		})
+		defer func() {
+			flags.Init(resetFlags)
+		}()
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/beacon-chain/rpc/validator/validator_test.go
+++ b/beacon-chain/rpc/validator/validator_test.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -9,12 +10,15 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
-	// Use minimal config to reduce test setup time.
-	prevConfig := params.BeaconConfig().Copy()
-	defer params.OverrideBeaconConfig(prevConfig)
-	params.OverrideBeaconConfig(params.MinimalSpecConfig())
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
+		// Use minimal config to reduce test setup time.
+		prevConfig := params.BeaconConfig().Copy()
+		defer params.OverrideBeaconConfig(prevConfig)
+		params.OverrideBeaconConfig(params.MinimalSpecConfig())
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/beacon-chain/state/stateutil/stateutil_test.go
+++ b/beacon-chain/state/stateutil/stateutil_test.go
@@ -1,13 +1,17 @@
 package stateutil_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 )
 
 func TestMain(m *testing.M) {
-	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableSSZCache: true})
-	defer resetCfg()
-	m.Run()
+	run := func() int {
+		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableSSZCache: true})
+		defer resetCfg()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/beacon-chain/sync/initial-sync/initial_sync_test.go
+++ b/beacon-chain/sync/initial-sync/initial_sync_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -52,24 +53,27 @@ type peerData struct {
 }
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
-		EnablePeerScorer: true,
-	})
-	defer resetCfg()
+		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
+			EnablePeerScorer: true,
+		})
+		defer resetCfg()
 
-	resetFlags := flags.Get()
-	flags.Init(&flags.GlobalFlags{
-		BlockBatchLimit:            64,
-		BlockBatchLimitBurstFactor: 10,
-	})
-	defer func() {
-		flags.Init(resetFlags)
-	}()
+		resetFlags := flags.Get()
+		flags.Init(&flags.GlobalFlags{
+			BlockBatchLimit:            64,
+			BlockBatchLimitBurstFactor: 10,
+		})
+		defer func() {
+			flags.Init(resetFlags)
+		}()
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }
 
 func initializeTestServices(t *testing.T, blocks []uint64, peers []*peerData) (*mock.ChainService, *p2pt.TestP2P, db.Database) {

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -316,8 +316,8 @@ func TestService_markSynced(t *testing.T) {
 		StateNotifier: mc.StateNotifier(),
 	})
 	require.NotNil(t, s)
-	assert.Equal(t, false, s.chainStarted)
-	assert.Equal(t, false, s.synced)
+	assert.Equal(t, false, s.chainStarted.IsSet())
+	assert.Equal(t, false, s.synced.IsSet())
 	assert.Equal(t, true, s.Syncing())
 	assert.NoError(t, s.Status())
 	s.chainStarted.Set()

--- a/beacon-chain/sync/rate_limiter.go
+++ b/beacon-chain/sync/rate_limiter.go
@@ -81,14 +81,6 @@ func (l *limiter) validateRequest(stream network.Stream, amt uint64) error {
 	}
 	if amt > uint64(remaining) {
 		l.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
-		if l.p2p.Peers().IsBad(stream.Conn().RemotePeer()) {
-			log.Debug("Disconnecting bad peer")
-			defer func() {
-				if err := l.p2p.Disconnect(stream.Conn().RemotePeer()); err != nil {
-					log.WithError(err).Debug("Failed to disconnect peer")
-				}
-			}()
-		}
 		writeErrorResponseToStream(responseCodeInvalidRequest, rateLimitedError, stream, l.p2p)
 		return errors.New(rateLimitedError)
 	}

--- a/beacon-chain/sync/sync_test.go
+++ b/beacon-chain/sync/sync_test.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
@@ -9,17 +10,19 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	resetFlags := flags.Get()
-	flags.Init(&flags.GlobalFlags{
-		BlockBatchLimit:            64,
-		BlockBatchLimitBurstFactor: 10,
-	})
-	defer func() {
-		flags.Init(resetFlags)
-	}()
-
-	m.Run()
+		resetFlags := flags.Get()
+		flags.Init(&flags.GlobalFlags{
+			BlockBatchLimit:            64,
+			BlockBatchLimitBurstFactor: 10,
+		})
+		defer func() {
+			flags.Init(resetFlags)
+		}()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/shared/aggregation/attestations/attestations_test.go
+++ b/shared/aggregation/attestations/attestations_test.go
@@ -3,6 +3,7 @@ package attestations
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"sort"
 	"testing"
 
@@ -19,13 +20,16 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
-	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
-		AttestationAggregationStrategy: string(MaxCoverAggregation),
-	})
-	defer resetCfg()
-	m.Run()
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
+		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
+			AttestationAggregationStrategy: string(MaxCoverAggregation),
+		})
+		defer resetCfg()
+		return m.Run()
+	}
+	os.Exit(run())
 }
 
 func TestAggregateAttestations_AggregatePair(t *testing.T) {

--- a/shared/slotutil/slotutil_test.go
+++ b/shared/slotutil/slotutil_test.go
@@ -2,14 +2,18 @@ package slotutil
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/slasher/beaconclient/service_test.go
+++ b/slasher/beaconclient/service_test.go
@@ -2,6 +2,7 @@ package beaconclient
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -13,8 +14,11 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/slasher/db/kv/kv_test.go
+++ b/slasher/db/kv/kv_test.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -9,10 +10,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }
 
 func setupDB(t testing.TB) *Store {

--- a/slasher/detection/attestations/attestations_test.go
+++ b/slasher/detection/attestations/attestations_test.go
@@ -2,14 +2,18 @@ package attestations
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/slasher/detection/proposals/proposals_test.go
+++ b/slasher/detection/proposals/proposals_test.go
@@ -2,14 +2,18 @@ package proposals
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/slasher/node/node_test.go
+++ b/slasher/node/node_test.go
@@ -16,10 +16,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }
 
 // Test that slasher node can close.

--- a/slasher/rpc/rpc_test.go
+++ b/slasher/rpc/rpc_test.go
@@ -2,14 +2,18 @@ package rpc
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }

--- a/tools/bootnode/bootnode_test.go
+++ b/tools/bootnode/bootnode_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -19,10 +20,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }
 
 func TestBootnode_OK(t *testing.T) {

--- a/tools/sendDepositTx/sendDeposits_test.go
+++ b/tools/sendDepositTx/sendDeposits_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -22,10 +23,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logrus.SetLevel(logrus.DebugLevel)
-	logrus.SetOutput(ioutil.Discard)
+	run := func() int {
+		logrus.SetLevel(logrus.DebugLevel)
+		logrus.SetOutput(ioutil.Discard)
 
-	m.Run()
+		return m.Run()
+	}
+	os.Exit(run())
 }
 
 func sendDeposits(t *testing.T, testAcc *contracts.TestAccount,


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
- https://github.com/prysmaticlabs/prysm/pull/7761 updated usage of `TestMain()`
- However, `rules_go` does not support that yet: https://github.com/bazelbuild/rules_go/pull/2716
- This PR updates `TestMain()` back to rely on `os.Exit()` and fixes tests that weren't discovered due to the issue with `rules_go`.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
