### PR TITLE
Add GenesisValidatorRoot to ChainStartResponse

### DIFF
--- a/beacon-chain/core/feed/state/events.go
+++ b/beacon-chain/core/feed/state/events.go
@@ -33,6 +33,8 @@ type BlockProcessedData struct {
 type ChainStartedData struct {
 	// StartTime is the time at which the chain started.
 	StartTime time.Time
+	// GenesisValidatorsRoot represents state.validators.HashTreeRoot().
+	GenesisValidatorsRoot []byte
 }
 
 // SyncedData is the data sent with Synced events.

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -228,7 +228,8 @@ func (s *Service) ProcessChainStart(genesisTime uint64, eth1BlockHash [32]byte, 
 	s.stateNotifier.StateFeed().Send(&feed.Event{
 		Type: statefeed.ChainStarted,
 		Data: &statefeed.ChainStartedData{
-			StartTime: chainStartTime,
+			StartTime:             chainStartTime,
+			GenesisValidatorsRoot: s.preGenesisState.GenesisValidatorRoot(),
 		},
 	})
 }

--- a/beacon-chain/rpc/validator/server.go
+++ b/beacon-chain/rpc/validator/server.go
@@ -164,8 +164,9 @@ func (vs *Server) WaitForChainStart(_ *ptypes.Empty, stream ethpb.BeaconNodeVali
 	}
 	if head != nil {
 		res := &ethpb.ChainStartResponse{
-			Started:     true,
-			GenesisTime: head.GenesisTime(),
+			Started:               true,
+			GenesisTime:           head.GenesisTime(),
+			GenesisValidatorsRoot: head.GenesisValidatorRoot(),
 		}
 		return stream.Send(res)
 	}
@@ -184,8 +185,9 @@ func (vs *Server) WaitForChainStart(_ *ptypes.Empty, stream ethpb.BeaconNodeVali
 				log.WithField("starttime", data.StartTime).Debug("Received chain started event")
 				log.Debug("Sending genesis time notification to connected validator clients")
 				res := &ethpb.ChainStartResponse{
-					Started:     true,
-					GenesisTime: uint64(data.StartTime.Unix()),
+					Started:               true,
+					GenesisTime:           uint64(data.StartTime.Unix()),
+					GenesisValidatorsRoot: head.GenesisValidatorRoot(),
 				}
 				return stream.Send(res)
 			}
@@ -197,8 +199,9 @@ func (vs *Server) WaitForChainStart(_ *ptypes.Empty, stream ethpb.BeaconNodeVali
 					return errors.New("event data is not type *statefeed.InitializedData")
 				}
 				res := &ethpb.ChainStartResponse{
-					Started:     true,
-					GenesisTime: uint64(data.StartTime.Unix()),
+					Started:               true,
+					GenesisTime:           uint64(data.StartTime.Unix()),
+					GenesisValidatorsRoot: head.GenesisValidatorRoot(),
 				}
 				return stream.Send(res)
 			}

--- a/beacon-chain/rpc/validator/server.go
+++ b/beacon-chain/rpc/validator/server.go
@@ -187,7 +187,7 @@ func (vs *Server) WaitForChainStart(_ *ptypes.Empty, stream ethpb.BeaconNodeVali
 				res := &ethpb.ChainStartResponse{
 					Started:               true,
 					GenesisTime:           uint64(data.StartTime.Unix()),
-					GenesisValidatorsRoot: head.GenesisValidatorRoot(),
+					GenesisValidatorsRoot: data.GenesisValidatorsRoot,
 				}
 				return stream.Send(res)
 			}
@@ -201,7 +201,7 @@ func (vs *Server) WaitForChainStart(_ *ptypes.Empty, stream ethpb.BeaconNodeVali
 				res := &ethpb.ChainStartResponse{
 					Started:               true,
 					GenesisTime:           uint64(data.StartTime.Unix()),
-					GenesisValidatorsRoot: head.GenesisValidatorRoot(),
+					GenesisValidatorsRoot: data.GenesisValidatorsRoot,
 				}
 				return stream.Send(res)
 			}

--- a/beacon-chain/rpc/validator/server_test.go
+++ b/beacon-chain/rpc/validator/server_test.go
@@ -403,13 +403,11 @@ func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 	exitRoutine := make(chan bool)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	genesisValRoot := chainService.GenesisValidatorRoot()
 	mockStream := mock.NewMockBeaconNodeValidator_WaitForChainStartServer(ctrl)
 	mockStream.EXPECT().Send(
 		&ethpb.ChainStartResponse{
-			Started:               true,
-			GenesisTime:           uint64(time.Unix(0, 0).Unix()),
-			GenesisValidatorsRoot: genesisValRoot[:],
+			Started:     true,
+			GenesisTime: uint64(time.Unix(0, 0).Unix()),
 		},
 	).Return(nil)
 	mockStream.EXPECT().Context().Return(context.Background())

--- a/beacon-chain/rpc/validator/server_test.go
+++ b/beacon-chain/rpc/validator/server_test.go
@@ -388,6 +388,7 @@ func TestWaitForChainStart_HeadStateDoesNotExist(t *testing.T) {
 
 func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 	db, _ := dbutil.SetupDB(t)
+	genesisValidatorsRoot := bytesutil.ToBytes32([]byte("validators"))
 
 	hook := logTest.NewGlobal()
 	chainService := &mockChain.ChainService{}
@@ -406,8 +407,9 @@ func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 	mockStream := mock.NewMockBeaconNodeValidator_WaitForChainStartServer(ctrl)
 	mockStream.EXPECT().Send(
 		&ethpb.ChainStartResponse{
-			Started:     true,
-			GenesisTime: uint64(time.Unix(0, 0).Unix()),
+			Started:               true,
+			GenesisTime:           uint64(time.Unix(0, 0).Unix()),
+			GenesisValidatorsRoot: genesisValidatorsRoot[:],
 		},
 	).Return(nil)
 	mockStream.EXPECT().Context().Return(context.Background())
@@ -421,7 +423,8 @@ func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 		sent = Server.StateNotifier.StateFeed().Send(&feed.Event{
 			Type: statefeed.ChainStarted,
 			Data: &statefeed.ChainStartedData{
-				StartTime: time.Unix(0, 0),
+				StartTime:             time.Unix(0, 0),
+				GenesisValidatorsRoot: genesisValidatorsRoot[:],
 			},
 		})
 	}

--- a/beacon-chain/rpc/validator/server_test.go
+++ b/beacon-chain/rpc/validator/server_test.go
@@ -321,6 +321,7 @@ func TestWaitForChainStart_AlreadyStarted(t *testing.T) {
 	require.NoError(t, db.SaveState(ctx, trie, headBlockRoot))
 	require.NoError(t, db.SaveHeadBlockRoot(ctx, headBlockRoot))
 	genesisValidatorsRoot := bytesutil.ToBytes32([]byte("validators"))
+	require.NoError(t, trie.SetGenesisValidatorRoot(genesisValidatorsRoot[:]))
 
 	chainService := &mockChain.ChainService{State: trie, ValidatorsRoot: genesisValidatorsRoot}
 	Server := &Server{
@@ -348,7 +349,7 @@ func TestWaitForChainStart_AlreadyStarted(t *testing.T) {
 
 func TestWaitForChainStart_HeadStateDoesNotExist(t *testing.T) {
 	db, _ := dbutil.SetupDB(t)
-	genesisValidatorRoot := [32]byte{0x01, 0x02}
+	genesisValidatorRoot := params.BeaconConfig().ZeroHash
 
 	// Set head state to nil
 	chainService := &mockChain.ChainService{State: nil}

--- a/deps.bzl
+++ b/deps.bzl
@@ -2190,8 +2190,8 @@ def prysm_deps():
         name = "com_github_prysmaticlabs_ethereumapis",
         build_file_generation = "off",
         importpath = "github.com/prysmaticlabs/ethereumapis",
-        sum = "h1:bvsgNf1mHXFN5M+BYXqnWvceQkibz28Qo/x/jOs6wGc=",
-        version = "v0.0.0-20201116210408-3e6658264073",
+        sum = "h1:OUfQgEA6zB19I66EQ2nPtjdBbk+Vv7eCBf2+x3BTv5w=",
+        version = "v0.0.0-20201117145913-073714f478fb",
     )
     go_repository(
         name = "com_github_prysmaticlabs_go_bitfield",

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/tsdb v0.10.0 // indirect
 	github.com/protolambda/zssz v0.1.5
-	github.com/prysmaticlabs/ethereumapis v0.0.0-20201116210408-3e6658264073
+	github.com/prysmaticlabs/ethereumapis v0.0.0-20201117145913-073714f478fb
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20200618145306-2ae0807bef65
 	github.com/prysmaticlabs/go-ssz v0.0.0-20200612203617-6d5c9aa213ae
 	github.com/prysmaticlabs/prombbolt v0.0.0-20200324184628-09789ef63796

--- a/go.sum
+++ b/go.sum
@@ -965,8 +965,6 @@ github.com/protolambda/zssz v0.1.5 h1:7fjJjissZIIaa2QcvmhS/pZISMX21zVITt49sW1oue
 github.com/protolambda/zssz v0.1.5/go.mod h1:a4iwOX5FE7/JkKA+J/PH0Mjo9oXftN6P8NZyL28gpag=
 github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20201116135122-233538bfc3d8 h1:Fc6JMvJBFAAdI07o//gNgT5MiCCScpe1u/KM1A6MDGo=
 github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20201116135122-233538bfc3d8/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
-github.com/prysmaticlabs/ethereumapis v0.0.0-20201116210408-3e6658264073 h1:bvsgNf1mHXFN5M+BYXqnWvceQkibz28Qo/x/jOs6wGc=
-github.com/prysmaticlabs/ethereumapis v0.0.0-20201116210408-3e6658264073/go.mod h1:k7b2dxy6RppCG6kmOJkNOXzRpEoTdsPygc2aQhsUsZk=
 github.com/prysmaticlabs/ethereumapis v0.0.0-20201117145913-073714f478fb h1:OUfQgEA6zB19I66EQ2nPtjdBbk+Vv7eCBf2+x3BTv5w=
 github.com/prysmaticlabs/ethereumapis v0.0.0-20201117145913-073714f478fb/go.mod h1:k7b2dxy6RppCG6kmOJkNOXzRpEoTdsPygc2aQhsUsZk=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669 h1:cX6YRZnZ9sgMqM5U14llxUiXVNJ3u07Res1IIjTOgtI=

--- a/go.sum
+++ b/go.sum
@@ -967,6 +967,8 @@ github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20201116135122-233538bfc3d8 h1
 github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20201116135122-233538bfc3d8/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
 github.com/prysmaticlabs/ethereumapis v0.0.0-20201116210408-3e6658264073 h1:bvsgNf1mHXFN5M+BYXqnWvceQkibz28Qo/x/jOs6wGc=
 github.com/prysmaticlabs/ethereumapis v0.0.0-20201116210408-3e6658264073/go.mod h1:k7b2dxy6RppCG6kmOJkNOXzRpEoTdsPygc2aQhsUsZk=
+github.com/prysmaticlabs/ethereumapis v0.0.0-20201117145913-073714f478fb h1:OUfQgEA6zB19I66EQ2nPtjdBbk+Vv7eCBf2+x3BTv5w=
+github.com/prysmaticlabs/ethereumapis v0.0.0-20201117145913-073714f478fb/go.mod h1:k7b2dxy6RppCG6kmOJkNOXzRpEoTdsPygc2aQhsUsZk=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669 h1:cX6YRZnZ9sgMqM5U14llxUiXVNJ3u07Res1IIjTOgtI=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200618145306-2ae0807bef65 h1:hJfAWrlxx7SKpn4S/h2JGl2HHwA1a2wSS3HAzzZ0F+U=

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -105,6 +105,7 @@ func TestWaitForChainStart_SetsChainStartGenesisTime(t *testing.T) {
 		validatorClient: client,
 	}
 	genesis := uint64(time.Unix(1, 0).Unix())
+	genesisValidatorsRoot := bytesutil.ToBytes32([]byte("validators"))
 	clientStream := mock.NewMockBeaconNodeValidator_WaitForChainStartClient(ctrl)
 	client.EXPECT().WaitForChainStart(
 		gomock.Any(),
@@ -112,8 +113,9 @@ func TestWaitForChainStart_SetsChainStartGenesisTime(t *testing.T) {
 	).Return(clientStream, nil)
 	clientStream.EXPECT().Recv().Return(
 		&ethpb.ChainStartResponse{
-			Started:     true,
-			GenesisTime: genesis,
+			Started:               true,
+			GenesisTime:           genesis,
+			GenesisValidatorsRoot: genesisValidatorsRoot[:],
 		},
 		nil,
 	)
@@ -132,6 +134,7 @@ func TestWaitForChainStart_ContextCanceled(t *testing.T) {
 		validatorClient: client,
 	}
 	genesis := uint64(time.Unix(0, 0).Unix())
+	genesisValidatorsRoot := bytesutil.PadTo([]byte("validators"), 32)
 	clientStream := mock.NewMockBeaconNodeValidator_WaitForChainStartClient(ctrl)
 	client.EXPECT().WaitForChainStart(
 		gomock.Any(),
@@ -139,8 +142,9 @@ func TestWaitForChainStart_ContextCanceled(t *testing.T) {
 	).Return(clientStream, nil)
 	clientStream.EXPECT().Recv().Return(
 		&ethpb.ChainStartResponse{
-			Started:     true,
-			GenesisTime: genesis,
+			Started:               true,
+			GenesisTime:           genesis,
+			GenesisValidatorsRoot: genesisValidatorsRoot,
 		},
 		nil,
 	)


### PR DESCRIPTION
**What type of PR is this?**
API Modification

**What does this PR do? Why is it needed?**
This PR changes ChainStartResponse to include the GenesisValidatorsRoot for use in the validator client.