### PR TITLE
Remove listen for ChainStarted in WaitForChainStart

### DIFF
--- a/beacon-chain/core/feed/state/events.go
+++ b/beacon-chain/core/feed/state/events.go
@@ -33,8 +33,6 @@ type BlockProcessedData struct {
 type ChainStartedData struct {
 	// StartTime is the time at which the chain started.
 	StartTime time.Time
-	// GenesisValidatorsRoot represents state.validators.HashTreeRoot().
-	GenesisValidatorsRoot []byte
 }
 
 // SyncedData is the data sent with Synced events.

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -228,8 +228,7 @@ func (s *Service) ProcessChainStart(genesisTime uint64, eth1BlockHash [32]byte, 
 	s.stateNotifier.StateFeed().Send(&feed.Event{
 		Type: statefeed.ChainStarted,
 		Data: &statefeed.ChainStartedData{
-			StartTime:             chainStartTime,
-			GenesisValidatorsRoot: s.preGenesisState.GenesisValidatorRoot(),
+			StartTime: chainStartTime,
 		},
 	})
 }

--- a/beacon-chain/rpc/validator/server.go
+++ b/beacon-chain/rpc/validator/server.go
@@ -182,6 +182,8 @@ func (vs *Server) WaitForChainStart(_ *ptypes.Empty, stream ethpb.BeaconNodeVali
 				if !ok {
 					return errors.New("event data is not type *statefeed.InitializedData")
 				}
+				log.WithField("starttime", data.StartTime).Debug("Received chain started event")
+				log.Debug("Sending genesis time notification to connected validator clients")
 				res := &ethpb.ChainStartResponse{
 					Started:               true,
 					GenesisTime:           uint64(data.StartTime.Unix()),

--- a/beacon-chain/rpc/validator/server.go
+++ b/beacon-chain/rpc/validator/server.go
@@ -177,22 +177,6 @@ func (vs *Server) WaitForChainStart(_ *ptypes.Empty, stream ethpb.BeaconNodeVali
 	for {
 		select {
 		case event := <-stateChannel:
-			if event.Type == statefeed.ChainStarted {
-				data, ok := event.Data.(*statefeed.ChainStartedData)
-				if !ok {
-					return errors.New("event data is not type *statefeed.ChainStartData")
-				}
-				log.WithField("starttime", data.StartTime).Debug("Received chain started event")
-				log.Debug("Sending genesis time notification to connected validator clients")
-				res := &ethpb.ChainStartResponse{
-					Started:               true,
-					GenesisTime:           uint64(data.StartTime.Unix()),
-					GenesisValidatorsRoot: data.GenesisValidatorsRoot,
-				}
-				return stream.Send(res)
-			}
-			// Handle race condition in the event the blockchain
-			// service isn't initialized in time and the saved head state is nil.
 			if event.Type == statefeed.Initialized {
 				data, ok := event.Data.(*statefeed.InitializedData)
 				if !ok {

--- a/beacon-chain/rpc/validator/server_test.go
+++ b/beacon-chain/rpc/validator/server_test.go
@@ -388,8 +388,6 @@ func TestWaitForChainStart_HeadStateDoesNotExist(t *testing.T) {
 
 func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 	db, _ := dbutil.SetupDB(t)
-	genesisValidatorsRoot := bytesutil.ToBytes32([]byte("validators"))
-
 	hook := logTest.NewGlobal()
 	chainService := &mockChain.ChainService{}
 	Server := &Server{
@@ -407,9 +405,8 @@ func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 	mockStream := mock.NewMockBeaconNodeValidator_WaitForChainStartServer(ctrl)
 	mockStream.EXPECT().Send(
 		&ethpb.ChainStartResponse{
-			Started:               true,
-			GenesisTime:           uint64(time.Unix(0, 0).Unix()),
-			GenesisValidatorsRoot: genesisValidatorsRoot[:],
+			Started:     true,
+			GenesisTime: uint64(time.Unix(0, 0).Unix()),
 		},
 	).Return(nil)
 	mockStream.EXPECT().Context().Return(context.Background())
@@ -423,8 +420,7 @@ func TestWaitForChainStart_NotStartedThenLogFired(t *testing.T) {
 		sent = Server.StateNotifier.StateFeed().Send(&feed.Event{
 			Type: statefeed.ChainStarted,
 			Data: &statefeed.ChainStartedData{
-				StartTime:             time.Unix(0, 0),
-				GenesisValidatorsRoot: genesisValidatorsRoot[:],
+				StartTime: time.Unix(0, 0),
 			},
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
This PR removes the ChainStarted event form the WaitForChainStart and removes the GenesisValidatorsRoot from the event as well.