### PR TITLE
Handle Deposit Prune Proof Panic

### DIFF
--- a/beacon-chain/cache/depositcache/deposits_cache.go
+++ b/beacon-chain/cache/depositcache/deposits_cache.go
@@ -244,7 +244,7 @@ func (dc *DepositCache) PruneProofs(ctx context.Context, untilDepositIndex int64
 	dc.depositsLock.Lock()
 	defer dc.depositsLock.Unlock()
 
-	if untilDepositIndex > int64(len(dc.deposits)) {
+	if untilDepositIndex >= int64(len(dc.deposits)) {
 		untilDepositIndex = int64(len(dc.deposits) - 1)
 	}
 

--- a/beacon-chain/cache/depositcache/deposits_cache_test.go
+++ b/beacon-chain/cache/depositcache/deposits_cache_test.go
@@ -700,6 +700,49 @@ func TestPruneProofs_PruneAllWhenDepositIndexTooBig(t *testing.T) {
 	assert.DeepEqual(t, ([][]byte)(nil), dc.deposits[3].Deposit.Proof)
 }
 
+func TestPruneProofs_CorrectlyHandleLastIndex(t *testing.T) {
+	dc, err := New()
+	require.NoError(t, err)
+
+	deposits := []struct {
+		blkNum  uint64
+		deposit *ethpb.Deposit
+		index   int64
+	}{
+		{
+			blkNum:  0,
+			deposit: &ethpb.Deposit{Proof: makeDepositProof()},
+			index:   0,
+		},
+		{
+			blkNum:  0,
+			deposit: &ethpb.Deposit{Proof: makeDepositProof()},
+			index:   1,
+		},
+		{
+			blkNum:  0,
+			deposit: &ethpb.Deposit{Proof: makeDepositProof()},
+			index:   2,
+		},
+		{
+			blkNum:  0,
+			deposit: &ethpb.Deposit{Proof: makeDepositProof()},
+			index:   3,
+		},
+	}
+
+	for _, ins := range deposits {
+		dc.InsertDeposit(context.Background(), ins.deposit, ins.blkNum, ins.index, [32]byte{})
+	}
+
+	require.NoError(t, dc.PruneProofs(context.Background(), 4))
+
+	assert.DeepEqual(t, ([][]byte)(nil), dc.deposits[0].Deposit.Proof)
+	assert.DeepEqual(t, ([][]byte)(nil), dc.deposits[1].Deposit.Proof)
+	assert.DeepEqual(t, ([][]byte)(nil), dc.deposits[2].Deposit.Proof)
+	assert.DeepEqual(t, ([][]byte)(nil), dc.deposits[3].Deposit.Proof)
+}
+
 func makeDepositProof() [][]byte {
 	proof := make([][]byte, int(params.BeaconConfig().DepositContractTreeDepth)+1)
 	for i := range proof {


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Fixes and off by 1 error when pruning deposit proofs, the method did not 
correctly handle the last possible index to prune and instead panicked.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
