### PR TITLE
Return Finalized State Early from StateByRoot

### DIFF
--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -193,6 +193,11 @@ func (s *State) loadStateByRoot(ctx context.Context, blockRoot [32]byte) (*state
 		return nil, errUnknownBoundaryState
 	}
 
+	// Return state early if we are retrieving it from our finalized state cache.
+	if startState.Slot() == targetSlot {
+		return startState, nil
+	}
+
 	blks, err := s.LoadBlocks(ctx, startState.Slot()+1, targetSlot, bytesutil.ToBytes32(summary.Root))
 	if err != nil {
 		return nil, errors.Wrap(err, "could not load blocks for hot state using root")


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Returns the state early in the event we are retrieving our finalized state from our ancestor method in 
`loadStateByRoot` .

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
