### PR TITLE
Hotfix for WaitForChainStart GenesisValidatorsRoot Check

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -145,8 +145,12 @@ func (v *validator) WaitForChainStart(ctx context.Context) error {
 			}
 		} else {
 			if !bytes.Equal(curGenValRoot, chainStartRes.GenesisValidatorsRoot) {
+				log.Errorf("The genesis validators root received from the beacon node does not match what is in " +
+					"your validator database. This could indicate that this is a database meant for another network. If " +
+					"you were previously running this validator database on another network, please run --clear-db to " +
+					"clear the database. If not, please file an issue at https://github.com/prysmaticlabs/prysm/issues")
 				return fmt.Errorf(
-					"received genesis validators root %#x did not match saved root %#x",
+					"genesis validators root from beacon node (%#x) does not match root saved in validator db (%#x)",
 					chainStartRes.GenesisValidatorsRoot,
 					curGenValRoot,
 				)

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -102,11 +102,11 @@ func TestWaitForChainStart_SetsGenesisInfo(t *testing.T) {
 
 	db := dbTest.SetupDB(t, [][48]byte{})
 	v := validator{
-		//keyManager:      testKeyManager,
 		validatorClient: client,
 		db:              db,
 	}
 
+	// Make sure its clean at the start.
 	savedGenValRoot, err := db.GenesisValidatorsRoot(context.Background())
 	require.NoError(t, err)
 	assert.DeepEqual(t, []byte(nil), savedGenValRoot, "Unexpected saved genesis validator root")
@@ -157,7 +157,6 @@ func TestWaitForChainStart_SetsGenesisInfo_IncorrectSecondTry(t *testing.T) {
 
 	db := dbTest.SetupDB(t, [][48]byte{})
 	v := validator{
-		//keyManager:      testKeyManager,
 		validatorClient: client,
 		db:              db,
 	}
@@ -185,6 +184,7 @@ func TestWaitForChainStart_SetsGenesisInfo_IncorrectSecondTry(t *testing.T) {
 	assert.NotNil(t, v.ticker, "Expected ticker to be set, received nil")
 
 	genesisValidatorsRoot = bytesutil.ToBytes32([]byte("badvalidators"))
+
 	// Make sure theres no errors running if its the same data.
 	client.EXPECT().WaitForChainStart(
 		gomock.Any(),

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -95,7 +95,7 @@ func generateMockStatusResponse(pubkeys [][]byte) *ethpb.ValidatorActivationResp
 	return &ethpb.ValidatorActivationResponse{Statuses: multipleStatus}
 }
 
-func TestWaitForChainStart_SetsChainStartGenesisTime(t *testing.T) {
+func TestWaitForChainStart_SetsGenesisInfo(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock.NewMockBeaconNodeValidatorClient(ctrl)
@@ -128,6 +128,73 @@ func TestWaitForChainStart_SetsChainStartGenesisTime(t *testing.T) {
 	assert.DeepEqual(t, genesisValidatorsRoot[:], savedGenValRoot, "Unexpected saved genesis validator root")
 	assert.Equal(t, genesis, v.genesisTime, "Unexpected chain start time")
 	assert.NotNil(t, v.ticker, "Expected ticker to be set, received nil")
+
+	// Make sure theres no errors running if its the same data.
+	client.EXPECT().WaitForChainStart(
+		gomock.Any(),
+		&ptypes.Empty{},
+	).Return(clientStream, nil)
+	clientStream.EXPECT().Recv().Return(
+		&ethpb.ChainStartResponse{
+			Started:               true,
+			GenesisTime:           genesis,
+			GenesisValidatorsRoot: genesisValidatorsRoot[:],
+		},
+		nil,
+	)
+	require.NoError(t, v.WaitForChainStart(context.Background()))
+}
+
+func TestWaitForChainStart_SetsGenesisInfo_IncorrectSecondTry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock.NewMockBeaconNodeValidatorClient(ctrl)
+
+	db := dbTest.SetupDB(t, [][48]byte{})
+	v := validator{
+		//keyManager:      testKeyManager,
+		validatorClient: client,
+		db:              db,
+	}
+	genesis := uint64(time.Unix(1, 0).Unix())
+	genesisValidatorsRoot := bytesutil.ToBytes32([]byte("validators"))
+	clientStream := mock.NewMockBeaconNodeValidator_WaitForChainStartClient(ctrl)
+	client.EXPECT().WaitForChainStart(
+		gomock.Any(),
+		&ptypes.Empty{},
+	).Return(clientStream, nil)
+	clientStream.EXPECT().Recv().Return(
+		&ethpb.ChainStartResponse{
+			Started:               true,
+			GenesisTime:           genesis,
+			GenesisValidatorsRoot: genesisValidatorsRoot[:],
+		},
+		nil,
+	)
+	require.NoError(t, v.WaitForChainStart(context.Background()))
+	savedGenValRoot, err := db.GenesisValidatorsRoot(context.Background())
+	require.NoError(t, err)
+
+	assert.DeepEqual(t, genesisValidatorsRoot[:], savedGenValRoot, "Unexpected saved genesis validator root")
+	assert.Equal(t, genesis, v.genesisTime, "Unexpected chain start time")
+	assert.NotNil(t, v.ticker, "Expected ticker to be set, received nil")
+
+	genesisValidatorsRoot = bytesutil.ToBytes32([]byte("badvalidators"))
+	// Make sure theres no errors running if its the same data.
+	client.EXPECT().WaitForChainStart(
+		gomock.Any(),
+		&ptypes.Empty{},
+	).Return(clientStream, nil)
+	clientStream.EXPECT().Recv().Return(
+		&ethpb.ChainStartResponse{
+			Started:               true,
+			GenesisTime:           genesis,
+			GenesisValidatorsRoot: genesisValidatorsRoot[:],
+		},
+		nil,
+	)
+	err = v.WaitForChainStart(context.Background())
+	require.ErrorContains(t, "did not match saved root", err)
 }
 
 func TestWaitForChainStart_ContextCanceled(t *testing.T) {

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -106,6 +106,11 @@ func TestWaitForChainStart_SetsGenesisInfo(t *testing.T) {
 		validatorClient: client,
 		db:              db,
 	}
+
+	savedGenValRoot, err := db.GenesisValidatorsRoot(context.Background())
+	require.NoError(t, err)
+	assert.DeepEqual(t, []byte(nil), savedGenValRoot, "Unexpected saved genesis validator root")
+
 	genesis := uint64(time.Unix(1, 0).Unix())
 	genesisValidatorsRoot := bytesutil.ToBytes32([]byte("validators"))
 	clientStream := mock.NewMockBeaconNodeValidator_WaitForChainStartClient(ctrl)
@@ -122,7 +127,7 @@ func TestWaitForChainStart_SetsGenesisInfo(t *testing.T) {
 		nil,
 	)
 	require.NoError(t, v.WaitForChainStart(context.Background()))
-	savedGenValRoot, err := db.GenesisValidatorsRoot(context.Background())
+	savedGenValRoot, err = db.GenesisValidatorsRoot(context.Background())
 	require.NoError(t, err)
 
 	assert.DeepEqual(t, genesisValidatorsRoot[:], savedGenValRoot, "Unexpected saved genesis validator root")
@@ -194,7 +199,7 @@ func TestWaitForChainStart_SetsGenesisInfo_IncorrectSecondTry(t *testing.T) {
 		nil,
 	)
 	err = v.WaitForChainStart(context.Background())
-	require.ErrorContains(t, "did not match saved root", err)
+	require.ErrorContains(t, "does not match root saved", err)
 }
 
 func TestWaitForChainStart_ContextCanceled(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
This PR is a hotfix for a mistake I made in #7855 

**What does this PR do? Why is it needed?**
Bug fix for where if a validator launches with a genesis validator root assigned, it crashes on startup.