### PR TITLE
Fix spec diff with comments. Fixes #7856

### DIFF
--- a/shared/params/mainnet_config.go
+++ b/shared/params/mainnet_config.go
@@ -82,7 +82,14 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	MinEpochsToInactivityPenalty:     4,
 	Eth1FollowDistance:               2048,
 	SafeSlotsToUpdateJustified:       8,
-	SecondsPerETH1Block:              13,
+
+	// While eth1 mainnet block times are closer to 13s, we must conform with other clients in
+	// order to vote on the correct eth1 blocks.
+	//
+	// Additional context: https://github.com/ethereum/eth2.0-specs/issues/2132
+	// Bug prompting this change: https://github.com/prysmaticlabs/prysm/issues/7856
+	// Future optimization: https://github.com/prysmaticlabs/prysm/issues/7739
+	SecondsPerETH1Block: 14,
 
 	// State list length constants.
 	EpochsPerHistoricalVector: 65536,


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The eth1 block time is used to compute the eth1data voting window. We must match with other clients
or mainnet will have a difficult time voting on eth1data.

**Which issues(s) does this PR fix?**

Fixes #7856

**Other notes for review**

Do not merge without approval from @nisdas. 
I think this also affects how we fetch block headers.
