### PR TITLE
Dynamic Reloading of Keys on Any FSNotify Event

### DIFF
--- a/validator/keymanager/imported/refresh.go
+++ b/validator/keymanager/imported/refresh.go
@@ -83,9 +83,7 @@ func (dr *Keymanager) listenForAccountChanges(ctx context.Context) {
 		case event := <-watcher.Events:
 			// If a file was modified, we attempt to read that file
 			// and parse it into our accounts store.
-			if event.Op&fsnotify.Write == fsnotify.Write {
-				fileChangesChan <- event
-			}
+			fileChangesChan <- event
 		case err := <-watcher.Errors:
 			log.WithError(err).Errorf("Could not watch for file changes for: %s", accountsFilePath)
 		case <-ctx.Done():

--- a/validator/keymanager/imported/refresh_test.go
+++ b/validator/keymanager/imported/refresh_test.go
@@ -6,14 +6,13 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
-
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 	mock "github.com/prysmaticlabs/prysm/validator/accounts/testing"
+	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
 )
 
 func TestImportedKeymanager_reloadAccountsFromKeystore_NoKeys(t *testing.T) {


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

This PR attempts to reload validating keys from a file in a debounced manner if any fsnotify event is triggered, rather than just writes. The current approach would prevent symbolic links from reloading keys into the validator client. We throw errors if we attempt to reload a bad keystore or a keystore with empty keys.

**Which issues(s) does this PR fix?**

Fixes #7732 

