### PR TITLE
Add prometheus metrics for level=fatal log messages

### DIFF
--- a/shared/prometheus/logrus_collector.go
+++ b/shared/prometheus/logrus_collector.go
@@ -14,7 +14,7 @@ type LogrusCollector struct {
 }
 
 var (
-	supportedLevels = []logrus.Level{logrus.InfoLevel, logrus.WarnLevel, logrus.ErrorLevel}
+	supportedLevels = []logrus.Level{logrus.InfoLevel, logrus.WarnLevel, logrus.ErrorLevel, logrus.FatalLevel}
 	counterVec      = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "log_entries_total",
 		Help: "Total number of log messages.",

--- a/shared/prometheus/logrus_collector_test.go
+++ b/shared/prometheus/logrus_collector_test.go
@@ -43,9 +43,11 @@ func TestLogrusCollector(t *testing.T) {
 		{"info message with empty prefix", 3, 3, "", log.InfoLevel},
 		{"warn message with empty prefix", 2, 2, "", log.WarnLevel},
 		{"error message with empty prefix", 1, 1, "", log.ErrorLevel},
+		{"fatal message with empty prefix", 1, 1, "", log.FatalLevel},
 		{"error message with prefix", 1, 1, "foo", log.ErrorLevel},
 		{"info message with prefix", 3, 3, "foo", log.InfoLevel},
 		{"warn message with prefix", 2, 2, "foo", log.WarnLevel},
+		{"fatal message with prefix", 2, 2, "foo", log.FatalLevel},
 	}
 
 	for _, tt := range tests {
@@ -104,5 +106,7 @@ func logExampleMessage(logger logger, level log.Level) {
 		logger.Warn("Warning message!")
 	case log.ErrorLevel:
 		logger.Error("Error message!!")
+	case log.FatalLevel:
+		logger.Error("Fatal message!!")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
It adds tracking Prometheus metrics for log level fatal, which could be valuable to monitor if anything bad is happening to our nodes.

**Which issues(s) does this PR fix?**
N/A

**Other notes for review**
N/A
