### PR TITLE
Remove chain not started error

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -339,6 +339,9 @@ func (s *Service) Stop() error {
 // Status always returns nil unless there is an error condition that causes
 // this service to be unhealthy.
 func (s *Service) Status() error {
+	if s.genesisRoot == params.BeaconConfig().ZeroHash {
+		return errors.New("genesis state has not been created")
+	}
 	if runtime.NumGoroutine() > s.maxRoutines {
 		return fmt.Errorf("too many goroutines %d", runtime.NumGoroutine())
 	}

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -196,9 +196,6 @@ func (s *Service) Stop() error {
 
 // Status of the currently running regular sync service.
 func (s *Service) Status() error {
-	if s.initialSync.Syncing() {
-		return errors.New("waiting for initial sync")
-	}
 	// If our head slot is on a previous epoch and our peers are reporting their head block are
 	// in the most recent epoch, then we might be out of sync.
 	if headEpoch := helpers.SlotToEpoch(s.chain.HeadSlot()); headEpoch+1 < helpers.SlotToEpoch(s.chain.CurrentSlot()) &&

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -196,9 +196,6 @@ func (s *Service) Stop() error {
 
 // Status of the currently running regular sync service.
 func (s *Service) Status() error {
-	if s.chainStarted.IsNotSet() {
-		return errors.New("chain not yet started")
-	}
 	if s.initialSync.Syncing() {
 		return errors.New("waiting for initial sync")
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix

**What does this PR do? Why is it needed?**

It's not appropriate for sync to return this error even if chain has not started, instead blockchain chain service should return the error while it is processing deposits to determine the genesis state. After this fix:
```
When processing deposits (before genesis state):
*prometheus.Service: OK
*p2p.Service: OK
*attestations.Service: OK
*initialsync.Service: OK
*sync.Service: OK
*gateway.Gateway: OK
*powchain.Service: OK
*blockchain.Service: ERROR genesis state has not been created
*rpc.Service: OK

After processing deposits (during sync):
*powchain.Service: OK
*blockchain.Service: OK
*p2p.Service: OK
*initialsync.Service: ERROR syncing
*sync.Service: ERROR out of sync
*rpc.Service: OK
*gateway.Gateway: OK
*prometheus.Service: OK
*attestations.Service: OK
```


**Which issues(s) does this PR fix?**

Fixes #6682

**Other notes for review**
