### PR TITLE
RPC: healthz should return an error when the node is syncing

### DIFF
--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -4,6 +4,7 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"sync"
@@ -337,6 +338,9 @@ func (s *Service) Stop() error {
 
 // Status returns nil or credentialError
 func (s *Service) Status() error {
+	if s.syncService.Syncing() {
+		return errors.New("syncing")
+	}
 	if s.credentialError != nil {
 		return s.credentialError
 	}

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -45,7 +45,7 @@ func TestLifecycle_OK(t *testing.T) {
 
 func TestStatus_CredentialError(t *testing.T) {
 	credentialErr := errors.New("credentialError")
-	s := &Service{credentialError: credentialErr}
+	s := &Service{credentialError: credentialErr, SyncService: &mockSync.Sync{IsSyncing: false}}
 
 	assert.ErrorContains(t, s.credentialError.Error(), s.Status())
 }

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -45,7 +45,7 @@ func TestLifecycle_OK(t *testing.T) {
 
 func TestStatus_CredentialError(t *testing.T) {
 	credentialErr := errors.New("credentialError")
-	s := &Service{credentialError: credentialErr, SyncService: &mockSync.Sync{IsSyncing: false}}
+	s := &Service{credentialError: credentialErr, syncService: &mockSync.Sync{IsSyncing: false}}
 
 	assert.ErrorContains(t, s.credentialError.Error(), s.Status())
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The beacon node should not report healthy when syncing.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
