### PR TITLE
Add Pubkey Metrics To Measure Cache Miss and Hits

### DIFF
--- a/shared/bls/blst/BUILD.bazel
+++ b/shared/bls/blst/BUILD.bazel
@@ -113,6 +113,8 @@ go_library(
             "//shared/rand:go_default_library",
             "@com_github_dgraph_io_ristretto//:go_default_library",
             "@com_github_pkg_errors//:go_default_library",
+            "@com_github_prometheus_client_golang//prometheus:go_default_library",
+            "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
             "@com_github_supranational_blst//:go_default_library",
         ],
         "//conditions:default": ["//shared/bls/common:go_default_library"],

--- a/shared/bls/blst/public_key.go
+++ b/shared/bls/blst/public_key.go
@@ -19,13 +19,13 @@ import (
 var (
 	pubkeyCacheHit = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "pubkey_cache_hit",
+			Name: "blst_pubkey_cache_hit",
 			Help: "Number of times pubkey cache has a hit.",
 		},
 	)
 	pubkeyCacheMiss = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "pubkey_cache_miss",
+			Name: "blst_pubkey_cache_miss",
 			Help: "Number of times pubkey cache has a miss.",
 		},
 	)

--- a/shared/bls/herumi/BUILD.bazel
+++ b/shared/bls/herumi/BUILD.bazel
@@ -24,6 +24,8 @@ go_library(
         "//shared/rand:go_default_library",
         "@com_github_dgraph_io_ristretto//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@herumi_bls_eth_go_binary//:go_default_library",
     ],
 )

--- a/shared/bls/herumi/public_key.go
+++ b/shared/bls/herumi/public_key.go
@@ -6,17 +6,34 @@ import (
 	"github.com/dgraph-io/ristretto"
 	bls12 "github.com/herumi/bls-eth-go-binary/bls"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prysmaticlabs/prysm/shared/bls/common"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
-var maxKeys = int64(100000)
-var pubkeyCache, _ = ristretto.NewCache(&ristretto.Config{
-	NumCounters: maxKeys,
-	MaxCost:     1 << 22, // ~4mb is cache max size
-	BufferItems: 64,
-})
+var (
+	pubkeyCacheHit = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "pubkey_cache_hit",
+			Help: "Number of times pubkey cache has a hit.",
+		},
+	)
+	pubkeyCacheMiss = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "pubkey_cache_miss",
+			Help: "Number of times pubkey cache has a miss.",
+		},
+	)
+	// Max keys for our LFU cache.
+	maxKeys        = int64(100000)
+	pubkeyCache, _ = ristretto.NewCache(&ristretto.Config{
+		NumCounters: maxKeys,
+		MaxCost:     1 << 22, // ~4mb is cache max size
+		BufferItems: 64,
+	})
+)
 
 // PublicKey used in the BLS signature scheme.
 type PublicKey struct {
@@ -32,8 +49,11 @@ func PublicKeyFromBytes(pubKey []byte) (common.PublicKey, error) {
 		return nil, fmt.Errorf("public key must be %d bytes", params.BeaconConfig().BLSPubkeyLength)
 	}
 	if cv, ok := pubkeyCache.Get(string(pubKey)); ok {
+		pubkeyCacheHit.Inc()
 		return cv.(*PublicKey).Copy(), nil
 	}
+	pubkeyCacheMiss.Inc()
+
 	p := &bls12.PublicKey{}
 	err := p.Deserialize(pubKey)
 	if err != nil {

--- a/shared/bls/herumi/public_key.go
+++ b/shared/bls/herumi/public_key.go
@@ -16,13 +16,13 @@ import (
 var (
 	pubkeyCacheHit = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "pubkey_cache_hit",
+			Name: "herumi_pubkey_cache_hit",
 			Help: "Number of times pubkey cache has a hit.",
 		},
 	)
 	pubkeyCacheMiss = promauto.NewCounter(
 		prometheus.CounterOpts{
-			Name: "pubkey_cache_miss",
+			Name: "herumi_pubkey_cache_miss",
 			Help: "Number of times pubkey cache has a miss.",
 		},
 	)


### PR DESCRIPTION
**What type of PR is this?**

Feature Addition

**What does this PR do? Why is it needed?**

- [x] Adds in pubkey metrics to measure cache miss and hit ratios. In Pyrmont, sync was 50% slower
because our cache wasn't able to hold 100,000 validator pubkeys. Given the low-cost of it, having
a metric to measure hit and miss ratios is useful.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
