### PR TITLE
Add More Default CORS Domains to the gRPC Gateway

### DIFF
--- a/beacon-chain/flags/base.go
+++ b/beacon-chain/flags/base.go
@@ -69,7 +69,7 @@ var (
 		Name: "grpc-gateway-corsdomain",
 		Usage: "Comma separated list of domains from which to accept cross origin requests " +
 			"(browser enforced). This flag has no effect if not used with --grpc-gateway-port.",
-		Value: "http://localhost:4242,http://127.0.0.1:4242,http://localhost:4200",
+		Value: "http://localhost:4242,http://127.0.0.1:4242,http://localhost:4200,http://0.0.0.0:4242,http://0.0.0.0:4200",
 	}
 	// MinSyncPeers specifies the required number of successful peer handshakes in order
 	// to start syncing with external peers.

--- a/validator/flags/flags.go
+++ b/validator/flags/flags.go
@@ -117,8 +117,7 @@ var (
 		Name: "grpc-gateway-corsdomain",
 		Usage: "Comma separated list of domains from which to accept cross origin requests " +
 			"(browser enforced). This flag has no effect if not used with --grpc-gateway-port.",
-		Value: "http://localhost:4242,http://127.0.0.1:4242,http://localhost:4200",
-	}
+		Value: "http://localhost:4242,http://127.0.0.1:4242,http://localhost:4200,http://0.0.0.0:4242,http://0.0.0.0:4200"}
 	// MonitoringPortFlag defines the http port used to serve prometheus metrics.
 	MonitoringPortFlag = &cli.IntFlag{
 		Name:  "monitoring-port",


### PR DESCRIPTION
No tracking issue, but this PR helps improve the experience of running the prysm-web-ui in a dockerized environment by adding support for 0.0.0.0 in the grpc gateway cors domains for the beacon node and validator client