### PR TITLE
Make grpc-headers flag work

### DIFF
--- a/validator/accounts/accounts_exit.go
+++ b/validator/accounts/accounts_exit.go
@@ -173,7 +173,6 @@ func prepareClients(cliCtx *cli.Context) (*ethpb.BeaconNodeValidatorClient, *eth
 	dialOpts := client.ConstructDialOptions(
 		cliCtx.Int(cmd.GrpcMaxCallRecvMsgSizeFlag.Name),
 		cliCtx.String(flags.CertFlag.Name),
-		strings.Split(cliCtx.String(flags.GrpcHeadersFlag.Name), ","),
 		cliCtx.Uint(flags.GrpcRetriesFlag.Name),
 		cliCtx.Duration(flags.GrpcRetryDelayFlag.Name),
 	)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The validator client service currently uses a `grpc.Header` call option to send headers, but no headers are being sent. According to https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#receiving-metadata, `grpc.Header` should be used to retrieve headers from responses. 

This PR fixes the issue by applying practices described in https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#sending-metadata.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
