### PR TITLE
Improve Slashing Protection for V1, More Tests and Observability

### DIFF
--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/sirupsen/logrus"
+
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/validator/db/kv"
@@ -27,12 +29,24 @@ func (v *validator) preAttSignValidations(ctx context.Context, indexedAtt *ethpb
 		log.WithError(err).Error("Could not get domain and signing root from attestation")
 		return err
 	}
-	if ok && isNewAttSlashable(ctx, attesterHistory, indexedAtt.Data.Source.Epoch, indexedAtt.Data.Target.Epoch, sr) {
-		if v.emitAccountMetrics {
-			ValidatorAttestFailVec.WithLabelValues(fmtKey).Inc()
+	if ok {
+		slashable, err := isNewAttSlashable(
+			ctx,
+			attesterHistory,
+			indexedAtt.Data.Source.Epoch,
+			indexedAtt.Data.Target.Epoch,
+			sr,
+		)
+		if err != nil {
+			return errors.Wrap(err, "could not check if attestation is slashable")
 		}
-		return errors.New(failedAttLocalProtectionErr)
-	} else if !ok {
+		if slashable {
+			if v.emitAccountMetrics {
+				ValidatorAttestFailVec.WithLabelValues(fmtKey).Inc()
+			}
+			return errors.New(failedAttLocalProtectionErr)
+		}
+	} else {
 		log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in pre validation")
 	}
 
@@ -53,14 +67,35 @@ func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.Ind
 	defer v.attesterHistoryByPubKeyLock.Unlock()
 	attesterHistory, ok := v.attesterHistoryByPubKey[pubKey]
 	if ok {
-		if isNewAttSlashable(ctx, attesterHistory, indexedAtt.Data.Source.Epoch, indexedAtt.Data.Target.Epoch, signingRoot) {
+		slashable, err := isNewAttSlashable(
+			ctx,
+			attesterHistory,
+			indexedAtt.Data.Source.Epoch,
+			indexedAtt.Data.Target.Epoch,
+			signingRoot,
+		)
+		if err != nil {
+			return errors.Wrap(err, "could not check if attestation is slashable")
+		}
+		if slashable {
 			if v.emitAccountMetrics {
 				ValidatorAttestFailVec.WithLabelValues(fmtKey).Inc()
 			}
 			return errors.New(failedAttLocalProtectionErr)
 		}
-		attesterHistory = markAttestationForTargetEpoch(ctx, attesterHistory, indexedAtt.Data.Source.Epoch, indexedAtt.Data.Target.Epoch, signingRoot)
-		v.attesterHistoryByPubKey[pubKey] = attesterHistory
+		newHistory, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(
+			ctx,
+			attesterHistory,
+			indexedAtt.Data.Target.Epoch,
+			&kv.HistoryData{
+				Source:      indexedAtt.Data.Source.Epoch,
+				SigningRoot: signingRoot[:],
+			},
+		)
+		if err != nil {
+			return errors.Wrapf(err, "could not mark epoch %d as attested", indexedAtt.Data.Target.Epoch)
+		}
+		v.attesterHistoryByPubKey[pubKey] = newHistory
 	} else {
 		log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in post validation")
 	}
@@ -78,114 +113,140 @@ func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.Ind
 
 // isNewAttSlashable uses the attestation history to determine if an attestation of sourceEpoch
 // and targetEpoch would be slashable. It can detect double, surrounding, and surrounded votes.
-func isNewAttSlashable(ctx context.Context, history kv.EncHistoryData, sourceEpoch, targetEpoch uint64, signingRoot [32]byte) bool {
+func isNewAttSlashable(
+	ctx context.Context,
+	history kv.EncHistoryData,
+	sourceEpoch,
+	targetEpoch uint64,
+	signingRoot [32]byte,
+) (bool, error) {
 	if history == nil {
-		return false
+		return false, nil
 	}
 	wsPeriod := params.BeaconConfig().WeakSubjectivityPeriod
 	// Previously pruned, we should return false.
 	latestEpochWritten, err := history.GetLatestEpochWritten(ctx)
 	if err != nil {
 		log.WithError(err).Error("Could not get latest epoch written from encapsulated data")
-		return false
+		return false, err
 	}
 
 	if latestEpochWritten >= wsPeriod && targetEpoch <= latestEpochWritten-wsPeriod { //Underflow protected older then weak subjectivity check.
-		return false
+		return false, nil
 	}
 
 	// Check if there has already been a vote for this target epoch.
 	hd, err := history.GetTargetData(ctx, targetEpoch)
 	if err != nil {
-		log.WithError(err).Errorf("Could not get target data for target epoch: %d", targetEpoch)
-		return false
+		return false, errors.Wrapf(err, "could not get target data for epoch: %d", targetEpoch)
 	}
 	if !hd.IsEmpty() && !bytes.Equal(signingRoot[:], hd.SigningRoot) {
-		return true
+		return true, nil
 	}
 
-	// Check if the new attestation would be surrounding another attestation.
+	isSurround, err := isSurroundVote(ctx, history, latestEpochWritten, sourceEpoch, targetEpoch)
+	if err != nil {
+		return false, errors.Wrap(err, "could not check if attestation is surround vote")
+	}
+	return isSurround, nil
+}
+
+func isSurroundVote(
+	ctx context.Context,
+	history kv.EncHistoryData,
+	latestEpochWritten,
+	sourceEpoch,
+	targetEpoch uint64,
+) (bool, error) {
 	for i := sourceEpoch; i <= targetEpoch; i++ {
-		// Unattested for epochs are marked as (*kv.HistoryData)(nil).
-		historyBoundary := safeTargetToSource(ctx, history, i)
-		if historyBoundary.IsEmpty() {
+		historicalAtt, err := checkHistoryAtTargetEpoch(ctx, history, latestEpochWritten, i)
+		if err != nil {
+			return false, errors.Wrapf(err, "could not check historical attestation at target epoch: %d", i)
+		}
+		if historicalAtt.IsEmpty() {
 			continue
 		}
-		if historyBoundary.Source > sourceEpoch {
-			return true
+		if historicalAtt.Source > sourceEpoch {
+			continue
+		}
+		prevTarget := i
+		prevSource := historicalAtt.Source
+		if surroundingPrevAttestation(prevSource, prevTarget, sourceEpoch, targetEpoch) {
+			// Surrounding attestation caught.
+			log.WithFields(logrus.Fields{
+				"targetEpoch":                   targetEpoch,
+				"sourceEpoch":                   sourceEpoch,
+				"previouslyAttestedTargetEpoch": prevTarget,
+				"previouslyAttestedSourceEpoch": prevSource,
+			}).Warn("Attempted to submit a surrounding attestation, but blocked by slashing protection")
+			return true, nil
 		}
 	}
 
 	// Check if the new attestation is being surrounded.
 	for i := targetEpoch; i <= latestEpochWritten; i++ {
-		h := safeTargetToSource(ctx, history, i)
-		if h.IsEmpty() {
+		historicalAtt, err := checkHistoryAtTargetEpoch(ctx, history, latestEpochWritten, i)
+		if err != nil {
+			return false, errors.Wrapf(err, "could not check historical attestation at target epoch: %d", i)
+		}
+		if historicalAtt.IsEmpty() {
 			continue
 		}
-		if h.Source < sourceEpoch {
-			return true
+		if historicalAtt.Source > sourceEpoch {
+			continue
+		}
+		prevTarget := i
+		prevSource := historicalAtt.Source
+		if surroundedByPrevAttestation(prevSource, prevTarget, sourceEpoch, targetEpoch) {
+			// Surrounded attestation caught.
+			log.WithFields(logrus.Fields{
+				"targetEpoch":                   targetEpoch,
+				"sourceEpoch":                   sourceEpoch,
+				"previouslyAttestedTargetEpoch": prevTarget,
+				"previouslyAttestedSourceEpoch": prevSource,
+			}).Warn("Attempted to submit a surrounded attestation, but blocked by slashing protection")
+			return true, nil
 		}
 	}
-
-	return false
+	return false, nil
 }
 
-// markAttestationForTargetEpoch returns the modified attestation history with the passed-in epochs marked
-// as attested for. This is done to prevent the validator client from signing any slashable attestations.
-func markAttestationForTargetEpoch(ctx context.Context, history kv.EncHistoryData, sourceEpoch, targetEpoch uint64, signingRoot [32]byte) kv.EncHistoryData {
-	if history == nil {
-		return nil
-	}
+func surroundedByPrevAttestation(prevSource, prevTarget, newSource, newTarget uint64) bool {
+	return prevSource < newSource && newTarget < prevTarget
+}
+
+func surroundingPrevAttestation(prevSource, prevTarget, newSource, newTarget uint64) bool {
+	return newSource < prevSource && prevTarget < newTarget
+}
+
+// Checks that the difference between the latest epoch written and
+// target epoch is greater than or equal to the weak subjectivity period.
+func differenceOutsideWeakSubjectivityBounds(latestEpochWritten, targetEpoch uint64) bool {
 	wsPeriod := params.BeaconConfig().WeakSubjectivityPeriod
-	latestEpochWritten, err := history.GetLatestEpochWritten(ctx)
-	if err != nil {
-		log.WithError(err).Error("Could not get latest epoch written from encapsulated data")
-		return nil
-	}
-	if targetEpoch > latestEpochWritten {
-		// If the target epoch to mark is ahead of latest written epoch, override the old targets and mark the requested epoch.
-		// Limit the overwriting to one weak subjectivity period as further is not needed.
-		maxToWrite := latestEpochWritten + wsPeriod
-		for i := latestEpochWritten + 1; i < targetEpoch && i <= maxToWrite; i++ {
-			history, err = history.SetTargetData(ctx, i%wsPeriod, &kv.HistoryData{Source: params.BeaconConfig().FarFutureEpoch})
-			if err != nil {
-				log.WithError(err).Error("Could not set target to the encapsulated data")
-				return nil
-			}
-		}
-		history, err = history.SetLatestEpochWritten(ctx, targetEpoch)
-		if err != nil {
-			log.WithError(err).Error("Could not set latest epoch written to the encapsulated data")
-			return nil
-		}
-	}
-	history, err = history.SetTargetData(ctx, targetEpoch%wsPeriod, &kv.HistoryData{Source: sourceEpoch, SigningRoot: signingRoot[:]})
-	if err != nil {
-		log.WithError(err).Error("Could not set target to the encapsulated data")
-		return nil
-	}
-	return history
+	return latestEpochWritten >= wsPeriod && targetEpoch <= latestEpochWritten-wsPeriod
 }
 
 // safeTargetToSource makes sure the epoch accessed is within bounds, and if it's not it at
 // returns the "default" nil value.
-func safeTargetToSource(ctx context.Context, history kv.EncHistoryData, targetEpoch uint64) *kv.HistoryData {
+// Returns the actual attesting history at a specified target epoch.
+// The response is nil if there was no attesting history at that epoch.
+func checkHistoryAtTargetEpoch(
+	ctx context.Context,
+	history kv.EncHistoryData,
+	latestEpochWritten,
+	targetEpoch uint64,
+) (*kv.HistoryData, error) {
 	wsPeriod := params.BeaconConfig().WeakSubjectivityPeriod
-	latestEpochWritten, err := history.GetLatestEpochWritten(ctx)
-	if err != nil {
-		log.WithError(err).Error("Could not get latest epoch written from encapsulated data")
-		return nil
+	if differenceOutsideWeakSubjectivityBounds(latestEpochWritten, targetEpoch) {
+		return nil, nil
 	}
+	// Ignore target epoch is > latest written.
 	if targetEpoch > latestEpochWritten {
-		return nil
+		return nil, nil
 	}
-	if latestEpochWritten >= wsPeriod && targetEpoch < latestEpochWritten-wsPeriod { //Underflow protected older then weak subjectivity check.
-		return nil
-	}
-	hd, err := history.GetTargetData(ctx, targetEpoch%wsPeriod)
+	historicalAtt, err := history.GetTargetData(ctx, targetEpoch%wsPeriod)
 	if err != nil {
-		log.WithError(err).Errorf("Could not get target data for target epoch: %d", targetEpoch)
-		return nil
+		return nil, errors.Wrapf(err, "could not get target data for target epoch: %d", targetEpoch)
 	}
-	return hd
+	return historicalAtt, nil
 }

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -7,11 +7,10 @@ import (
 
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	"github.com/sirupsen/logrus"
-
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/validator/db/kv"
+	"github.com/sirupsen/logrus"
 )
 
 var failedAttLocalProtectionErr = "attempted to make slashable attestation, rejected by local slashing protection"
@@ -141,6 +140,11 @@ func isNewAttSlashable(
 		return false, errors.Wrapf(err, "could not get target data for epoch: %d", targetEpoch)
 	}
 	if !hd.IsEmpty() && !bytes.Equal(signingRoot[:], hd.SigningRoot) {
+		log.WithFields(logrus.Fields{
+			"signingRoot":                   fmt.Sprintf("%#x", signingRoot),
+			"targetEpoch":                   targetEpoch,
+			"previouslyAttestedSigningRoot": fmt.Sprintf("%#x", hd.SigningRoot),
+		}).Warn("Attempted to submit a double vote, but blocked by slashing protection")
 		return true, nil
 	}
 

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -166,9 +166,6 @@ func isSurroundVote(
 		if historicalAtt.IsEmpty() {
 			continue
 		}
-		if historicalAtt.Source > sourceEpoch {
-			continue
-		}
 		prevTarget := i
 		prevSource := historicalAtt.Source
 		if surroundingPrevAttestation(prevSource, prevTarget, sourceEpoch, targetEpoch) {
@@ -190,9 +187,6 @@ func isSurroundVote(
 			return false, errors.Wrapf(err, "could not check historical attestation at target epoch: %d", i)
 		}
 		if historicalAtt.IsEmpty() {
-			continue
-		}
-		if historicalAtt.Source > sourceEpoch {
 			continue
 		}
 		prevTarget := i

--- a/validator/client/attest_protect_test.go
+++ b/validator/client/attest_protect_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -168,7 +169,12 @@ func TestAttestationHistory_BlocksDoubleAttestation(t *testing.T) {
 	newAttSource := uint64(0)
 	newAttTarget := uint64(3)
 	sr1 := [32]byte{1}
-	history = markAttestationForTargetEpoch(ctx, history, newAttSource, newAttTarget, sr1)
+	newHist, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(ctx, history, newAttTarget, &kv.HistoryData{
+		Source:      newAttSource,
+		SigningRoot: sr1[:],
+	})
+	require.NoError(t, err)
+	history = newHist
 	lew, err := history.GetLatestEpochWritten(ctx)
 	require.NoError(t, err)
 	require.Equal(t, newAttTarget, lew, "Unexpected latest epoch written")
@@ -177,7 +183,9 @@ func TestAttestationHistory_BlocksDoubleAttestation(t *testing.T) {
 	sr2 := [32]byte{2}
 	newAttSource = uint64(1)
 	newAttTarget = uint64(3)
-	if !isNewAttSlashable(ctx, history, newAttSource, newAttTarget, sr2) {
+	slashable, err := isNewAttSlashable(ctx, history, newAttSource, newAttTarget, sr2)
+	require.NoError(t, err)
+	if !slashable {
 		t.Fatalf("Expected attestation of source %d and target %d to be considered slashable", newAttSource, newAttTarget)
 	}
 }
@@ -294,15 +302,27 @@ func TestAttestationHistory_Prunes(t *testing.T) {
 	history := kv.NewAttestationHistoryArray(0)
 
 	// Try an attestation on totally unmarked history, should not be slashable.
-	require.Equal(t, false, isNewAttSlashable(ctx, history, 0, wsPeriod+5, signingRoot), "Should not be slashable")
+	slashable, err := isNewAttSlashable(ctx, history, 0, wsPeriod+5, signingRoot)
+	require.NoError(t, err)
+	require.Equal(t, false, slashable, "Should not be slashable")
 
 	// Mark attestations spanning epochs 0 to 3 and 6 to 9.
 	prunedNewAttSource := uint64(0)
 	prunedNewAttTarget := uint64(3)
-	history = markAttestationForTargetEpoch(ctx, history, prunedNewAttSource, prunedNewAttTarget, signingRoot)
+	newHist, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(ctx, history, prunedNewAttTarget, &kv.HistoryData{
+		Source:      prunedNewAttSource,
+		SigningRoot: signingRoot[:],
+	})
+	require.NoError(t, err)
+	history = newHist
 	newAttSource := prunedNewAttSource + 6
 	newAttTarget := prunedNewAttTarget + 6
-	history = markAttestationForTargetEpoch(ctx, history, newAttSource, newAttTarget, signingRoot2)
+	newHist, err = kv.MarkAllAsAttestedSinceLatestWrittenEpoch(ctx, history, newAttTarget, &kv.HistoryData{
+		Source:      newAttSource,
+		SigningRoot: signingRoot2[:],
+	})
+	require.NoError(t, err)
+	history = newHist
 	lte, err := history.GetLatestEpochWritten(ctx)
 	require.NoError(t, err)
 	require.Equal(t, newAttTarget, lte, "Unexpected latest epoch")
@@ -310,24 +330,39 @@ func TestAttestationHistory_Prunes(t *testing.T) {
 	// Mark an attestation spanning epochs 54000 to 54003.
 	farNewAttSource := newAttSource + wsPeriod
 	farNewAttTarget := newAttTarget + wsPeriod
-	history = markAttestationForTargetEpoch(ctx, history, farNewAttSource, farNewAttTarget, signingRoot3)
+	newHist, err = kv.MarkAllAsAttestedSinceLatestWrittenEpoch(ctx, history, farNewAttTarget, &kv.HistoryData{
+		Source:      farNewAttSource,
+		SigningRoot: signingRoot3[:],
+	})
+	require.NoError(t, err)
+	history = newHist
 	lte, err = history.GetLatestEpochWritten(ctx)
 	require.NoError(t, err)
 	require.Equal(t, farNewAttTarget, lte, "Unexpected latest epoch")
 
-	require.Equal(t, (*kv.HistoryData)(nil), safeTargetToSource(ctx, history, prunedNewAttTarget), "Unexpectedly marked attestation")
-	require.Equal(t, farNewAttSource, safeTargetToSource(ctx, history, farNewAttTarget).Source, "Unexpectedly marked attestation")
+	histAtt, err := checkHistoryAtTargetEpoch(ctx, history, lte, prunedNewAttTarget)
+	require.NoError(t, err)
+	require.Equal(t, (*kv.HistoryData)(nil), histAtt, "Unexpectedly marked attestation")
+	histAtt, err = checkHistoryAtTargetEpoch(ctx, history, lte, farNewAttTarget)
+	require.NoError(t, err)
+	require.Equal(t, farNewAttSource, histAtt.Source, "Unexpectedly marked attestation")
 
 	// Try an attestation from existing source to outside prune, should slash.
-	if !isNewAttSlashable(ctx, history, newAttSource, farNewAttTarget, signingRoot4) {
+	slashable, err = isNewAttSlashable(ctx, history, newAttSource, farNewAttTarget, signingRoot4)
+	require.NoError(t, err)
+	if !slashable {
 		t.Fatalf("Expected attestation of source %d, target %d to be considered slashable", newAttSource, farNewAttTarget)
 	}
 	// Try an attestation from before existing target to outside prune, should slash.
-	if !isNewAttSlashable(ctx, history, newAttTarget-1, farNewAttTarget, signingRoot4) {
+	slashable, err = isNewAttSlashable(ctx, history, newAttTarget-1, farNewAttTarget, signingRoot4)
+	require.NoError(t, err)
+	if !slashable {
 		t.Fatalf("Expected attestation of source %d, target %d to be considered slashable", newAttTarget-1, farNewAttTarget)
 	}
 	// Try an attestation larger than pruning amount, should slash.
-	if !isNewAttSlashable(ctx, history, 0, farNewAttTarget+5, signingRoot4) {
+	slashable, err = isNewAttSlashable(ctx, history, 0, farNewAttTarget+5, signingRoot4)
+	require.NoError(t, err)
+	if !slashable {
 		t.Fatalf("Expected attestation of source 0, target %d to be considered slashable", farNewAttTarget+5)
 	}
 }
@@ -340,7 +375,12 @@ func TestAttestationHistory_BlocksSurroundedAttestation(t *testing.T) {
 	signingRoot := [32]byte{1}
 	newAttSource := uint64(0)
 	newAttTarget := uint64(3)
-	history = markAttestationForTargetEpoch(ctx, history, newAttSource, newAttTarget, signingRoot)
+	newHist, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(ctx, history, newAttTarget, &kv.HistoryData{
+		Source:      newAttSource,
+		SigningRoot: signingRoot[:],
+	})
+	require.NoError(t, err)
+	history = newHist
 	lte, err := history.GetLatestEpochWritten(ctx)
 	require.NoError(t, err)
 	require.Equal(t, newAttTarget, lte)
@@ -348,7 +388,9 @@ func TestAttestationHistory_BlocksSurroundedAttestation(t *testing.T) {
 	// Try an attestation that should be slashable (being surrounded) spanning epochs 1 to 2.
 	newAttSource = uint64(1)
 	newAttTarget = uint64(2)
-	require.Equal(t, true, isNewAttSlashable(ctx, history, newAttSource, newAttTarget, signingRoot), "Expected slashable attestation")
+	slashable, err := isNewAttSlashable(ctx, history, newAttSource, newAttTarget, signingRoot)
+	require.NoError(t, err)
+	require.Equal(t, true, slashable, "Expected slashable attestation")
 }
 
 func TestAttestationHistory_BlocksSurroundingAttestation(t *testing.T) {
@@ -359,7 +401,12 @@ func TestAttestationHistory_BlocksSurroundingAttestation(t *testing.T) {
 	// Mark an attestation spanning epochs 1 to 2.
 	newAttSource := uint64(1)
 	newAttTarget := uint64(2)
-	history = markAttestationForTargetEpoch(ctx, history, newAttSource, newAttTarget, signingRoot)
+	newHist, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(ctx, history, newAttTarget, &kv.HistoryData{
+		Source:      newAttSource,
+		SigningRoot: signingRoot[:],
+	})
+	require.NoError(t, err)
+	history = newHist
 	lte, err := history.GetLatestEpochWritten(ctx)
 	require.NoError(t, err)
 	require.Equal(t, newAttTarget, lte)
@@ -370,5 +417,346 @@ func TestAttestationHistory_BlocksSurroundingAttestation(t *testing.T) {
 	// Try an attestation that should be slashable (surrounding) spanning epochs 0 to 3.
 	newAttSource = uint64(0)
 	newAttTarget = uint64(3)
-	require.Equal(t, true, isNewAttSlashable(ctx, history, newAttSource, newAttTarget, signingRoot))
+	slashable, err := isNewAttSlashable(ctx, history, newAttSource, newAttTarget, signingRoot)
+	require.NoError(t, err)
+	require.Equal(t, true, slashable)
+}
+
+func Test_isSurroundVote(t *testing.T) {
+	ctx := context.Background()
+	source := uint64(1)
+	target := uint64(4)
+	history := kv.NewAttestationHistoryArray(0)
+	signingRoot1 := bytesutil.PadTo([]byte{1}, 32)
+	hist, err := history.SetTargetData(ctx, target, &kv.HistoryData{
+		Source:      source,
+		SigningRoot: signingRoot1,
+	})
+	require.NoError(t, err)
+	history = hist
+	tests := []struct {
+		name               string
+		history            kv.EncHistoryData
+		latestEpochWritten uint64
+		sourceEpoch        uint64
+		targetEpoch        uint64
+		want               bool
+		wantErr            bool
+	}{
+		{
+			name:               "ignores attestations outside of weak subjectivity bounds",
+			history:            kv.NewAttestationHistoryArray(0),
+			latestEpochWritten: 2 * params.BeaconConfig().WeakSubjectivityPeriod,
+			targetEpoch:        params.BeaconConfig().WeakSubjectivityPeriod,
+			sourceEpoch:        params.BeaconConfig().WeakSubjectivityPeriod,
+			want:               false,
+		},
+		{
+			name:               "detects surrounding attestations",
+			history:            history,
+			latestEpochWritten: target,
+			targetEpoch:        target + 1,
+			sourceEpoch:        source - 1,
+			want:               true,
+		},
+		{
+			name:               "detects surrounded attestations",
+			history:            history,
+			latestEpochWritten: target,
+			targetEpoch:        target - 1,
+			sourceEpoch:        source + 1,
+			want:               true,
+		},
+		{
+			name:               "new attestation source == old source, but new target < old target",
+			history:            history,
+			latestEpochWritten: target,
+			targetEpoch:        target - 1,
+			sourceEpoch:        source,
+			want:               false,
+		},
+		{
+			name:               "new attestation source > old source, but new target == old target",
+			history:            history,
+			latestEpochWritten: target,
+			targetEpoch:        target,
+			sourceEpoch:        source + 1,
+			want:               false,
+		},
+		{
+			name:               "new attestation source and targets equal to old one",
+			history:            history,
+			latestEpochWritten: target,
+			targetEpoch:        target,
+			sourceEpoch:        source,
+			want:               false,
+		},
+		{
+			name:               "new attestation source == old source, but new target > old target",
+			history:            history,
+			latestEpochWritten: target,
+			targetEpoch:        target + 1,
+			sourceEpoch:        source,
+			want:               false,
+		},
+		{
+			name:               "new attestation source < old source, but new target == old target",
+			history:            history,
+			latestEpochWritten: target,
+			targetEpoch:        target,
+			sourceEpoch:        source - 1,
+			want:               false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isSurroundVote(ctx, tt.history, tt.latestEpochWritten, tt.sourceEpoch, tt.targetEpoch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isSurroundVote() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("isSurroundVote() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_surroundedByPrevAttestation(t *testing.T) {
+	type args struct {
+		oldSource uint64
+		oldTarget uint64
+		newSource uint64
+		newTarget uint64
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "0 values returns false",
+			args: args{
+				oldSource: 0,
+				oldTarget: 0,
+				newSource: 0,
+				newTarget: 0,
+			},
+			want: false,
+		},
+		{
+			name: "new attestation is surrounded by an old one",
+			args: args{
+				oldSource: 2,
+				oldTarget: 6,
+				newSource: 3,
+				newTarget: 5,
+			},
+			want: true,
+		},
+		{
+			name: "new attestation source and targets equal to old one",
+			args: args{
+				oldSource: 3,
+				oldTarget: 5,
+				newSource: 3,
+				newTarget: 5,
+			},
+			want: false,
+		},
+		{
+			name: "new attestation source == old source, but new target < old target",
+			args: args{
+				oldSource: 3,
+				oldTarget: 5,
+				newSource: 3,
+				newTarget: 4,
+			},
+			want: false,
+		},
+		{
+			name: "new attestation source > old source, but new target == old target",
+			args: args{
+				oldSource: 3,
+				oldTarget: 5,
+				newSource: 4,
+				newTarget: 5,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := surroundedByPrevAttestation(tt.args.oldSource, tt.args.oldTarget, tt.args.newSource, tt.args.newTarget); got != tt.want {
+				t.Errorf("surroundedByPrevAttestation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_surroundingPrevAttestation(t *testing.T) {
+	type args struct {
+		oldSource uint64
+		oldTarget uint64
+		newSource uint64
+		newTarget uint64
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "0 values returns false",
+			args: args{
+				oldSource: 0,
+				oldTarget: 0,
+				newSource: 0,
+				newTarget: 0,
+			},
+			want: false,
+		},
+		{
+			name: "new attestation is surrounding an old one",
+			args: args{
+				oldSource: 3,
+				oldTarget: 5,
+				newSource: 2,
+				newTarget: 6,
+			},
+			want: true,
+		},
+		{
+			name: "new attestation source and targets equal to old one",
+			args: args{
+				oldSource: 3,
+				oldTarget: 5,
+				newSource: 3,
+				newTarget: 5,
+			},
+			want: false,
+		},
+		{
+			name: "new attestation source == old source, but new target > old target",
+			args: args{
+				oldSource: 3,
+				oldTarget: 5,
+				newSource: 3,
+				newTarget: 6,
+			},
+			want: false,
+		},
+		{
+			name: "new attestation source < old source, but new target == old target",
+			args: args{
+				oldSource: 3,
+				oldTarget: 5,
+				newSource: 2,
+				newTarget: 5,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := surroundingPrevAttestation(tt.args.oldSource, tt.args.oldTarget, tt.args.newSource, tt.args.newTarget); got != tt.want {
+				t.Errorf("surroundingPrevAttestation() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_checkHistoryAtTargetEpoch(t *testing.T) {
+	ctx := context.Background()
+	history := kv.NewAttestationHistoryArray(0)
+	signingRoot1 := bytesutil.PadTo([]byte{1}, 32)
+	hist, err := history.SetTargetData(ctx, 1, &kv.HistoryData{
+		Source:      0,
+		SigningRoot: signingRoot1,
+	})
+	require.NoError(t, err)
+	history = hist
+	tests := []struct {
+		name               string
+		history            kv.EncHistoryData
+		latestEpochWritten uint64
+		targetEpoch        uint64
+		want               *kv.HistoryData
+		wantErr            bool
+	}{
+		{
+			name:               "ignores difference in epochs outside of weak subjectivity bounds",
+			history:            kv.NewAttestationHistoryArray(0),
+			latestEpochWritten: 2 * params.BeaconConfig().WeakSubjectivityPeriod,
+			targetEpoch:        params.BeaconConfig().WeakSubjectivityPeriod,
+			want:               nil,
+			wantErr:            false,
+		},
+		{
+			name:               "ignores target epoch > latest written epoch",
+			history:            kv.NewAttestationHistoryArray(0),
+			latestEpochWritten: params.BeaconConfig().WeakSubjectivityPeriod,
+			targetEpoch:        params.BeaconConfig().WeakSubjectivityPeriod + 1,
+			want:               nil,
+			wantErr:            false,
+		},
+		{
+			name:               "target epoch == latest written epoch should return correct results",
+			history:            history,
+			latestEpochWritten: 1,
+			targetEpoch:        1,
+			want: &kv.HistoryData{
+				Source:      0,
+				SigningRoot: signingRoot1,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := checkHistoryAtTargetEpoch(ctx, tt.history, tt.latestEpochWritten, tt.targetEpoch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkHistoryAtTargetEpoch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("checkHistoryAtTargetEpoch() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_differenceOutsideWeakSubjectivityBounds(t *testing.T) {
+	tests := []struct {
+		name               string
+		want               bool
+		latestEpochWritten uint64
+		targetEpoch        uint64
+	}{
+		{
+			name:               "difference of weak subjectivity period - 1 returns false",
+			latestEpochWritten: (2 * params.BeaconConfig().WeakSubjectivityPeriod) - 1,
+			targetEpoch:        params.BeaconConfig().WeakSubjectivityPeriod,
+			want:               false,
+		},
+		{
+			name:               "difference of weak subjectivity period returns true",
+			latestEpochWritten: 2 * params.BeaconConfig().WeakSubjectivityPeriod,
+			targetEpoch:        params.BeaconConfig().WeakSubjectivityPeriod,
+			want:               true,
+		},
+		{
+			name:               "difference > weak subjectivity period returns true",
+			latestEpochWritten: (2 * params.BeaconConfig().WeakSubjectivityPeriod) + 1,
+			targetEpoch:        params.BeaconConfig().WeakSubjectivityPeriod,
+			want:               true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := differenceOutsideWeakSubjectivityBounds(tt.latestEpochWritten, tt.targetEpoch); got != tt.want {
+				t.Errorf("differenceOutsideWeakSubjectivityBounds() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -67,7 +67,9 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 	}
 
 	if err := v.preBlockSignValidations(ctx, pubKey, b); err != nil {
-		log.WithField("slot", b.Slot).WithError(err).Error("Failed block safety check")
+		log.WithFields(
+			blockLogFields(pubKey, b, nil),
+		).WithError(err).Error("Failed block slashing protection check")
 		return
 	}
 
@@ -86,7 +88,9 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 	}
 
 	if err := v.postBlockSignUpdate(ctx, pubKey, blk, domain); err != nil {
-		log.WithField("slot", blk.Block.Slot).WithError(err).Error("Failed post block signing validations")
+		log.WithFields(
+			blockLogFields(pubKey, b, sig),
+		).WithError(err).Error("Failed block slashing protection check")
 		return
 	}
 

--- a/validator/client/propose_protect.go
+++ b/validator/client/propose_protect.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/blockutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/sirupsen/logrus"
 )
 
 var failedPreBlockSignLocalErr = "attempted to sign a double proposal, block rejected by local protection"
@@ -82,4 +83,16 @@ func (v *validator) postBlockSignUpdate(ctx context.Context, pubKey [48]byte, bl
 		return errors.Wrap(err, "failed to save updated proposal history")
 	}
 	return nil
+}
+
+func blockLogFields(pubKey [48]byte, blk *ethpb.BeaconBlock, sig []byte) logrus.Fields {
+	fields := logrus.Fields{
+		"proposerPublicKey": fmt.Sprintf("%#x", pubKey),
+		"proposerIndex":     blk.ProposerIndex,
+		"blockSlot":         blk.Slot,
+	}
+	if sig != nil {
+		fields["signature"] = fmt.Sprintf("%#x", sig)
+	}
+	return fields
 }

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -801,10 +801,21 @@ func TestSaveProtections_OK(t *testing.T) {
 		attesterHistoryByPubKey: cleanHistories,
 	}
 
+	sr := [32]byte{1}
 	history1 := cleanHistories[pubKey1]
-	history1 = markAttestationForTargetEpoch(ctx, history1, 0, 1, [32]byte{1})
+	newHist, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(ctx, history1, 1, &kv.HistoryData{
+		Source:      0,
+		SigningRoot: sr[:],
+	})
+	require.NoError(t, err)
+	history1 = newHist
 
-	history2 := markAttestationForTargetEpoch(ctx, history1, 2, 3, [32]byte{2})
+	sr2 := [32]byte{2}
+	history2, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(ctx, history1, 3, &kv.HistoryData{
+		Source:      2,
+		SigningRoot: sr2[:],
+	})
+	require.NoError(t, err)
 
 	cleanHistories[pubKey1] = history1
 	cleanHistories[pubKey2] = history2
@@ -835,7 +846,13 @@ func TestSaveProtection_OK(t *testing.T) {
 	}
 
 	history1 := cleanHistories[pubKey1]
-	history1 = markAttestationForTargetEpoch(ctx, history1, 0, 1, [32]byte{1})
+	sr := [32]byte{1}
+	newHist, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(ctx, history1, 1, &kv.HistoryData{
+		Source:      0,
+		SigningRoot: sr[:],
+	})
+	require.NoError(t, err)
+	history1 = newHist
 
 	cleanHistories[pubKey1] = history1
 


### PR DESCRIPTION

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Slashing protection, in current `master`, lives with some really serious problems. Although most of these issues are patched in #7848, that PR needs time to be tested in pre-production environments before making into the master branch due to how radical it is and how much it changes. Unfortunately, we still have some bugs today in detecting surround votes, which we have observed today in our internal infrastructure. The issues are with respect to false positives, meaning that local slashing protection detects certain attestations as slashable which are not. Moreover, **we do not have enough logs available to help us understand the problem**. This PR adds the following changes:

- [x] Add a Debug log containing all attestation details in case local slashing protection detects a surround vote or double vote, same for beacon blocks
- [x] Add more informative logic about why the offense detected is a surround vote or double vote
- [x] Refactor our logic which checks whether something is a surround vote or not, ensuring we have full unit tests for _all possible permutations of surround votes_
- [x] Ensure we do not have dangerous variable shadowing the underlying method which marks all epochs up to a certain target epoch as attested
- [x] Add comprehensive tests to ensure we are within the weak subjectivity period when checking slashable attestations
- [x] Add better error handling
