### PR TITLE
Always Update Attesting History If Not Slashable

### DIFF
--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -114,6 +114,10 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		return
 	}
 
+	if err := v.SaveProtection(ctx, pubKey); err != nil {
+		log.WithError(err).Errorf("Could not save validator: %#x protection", pubKey)
+	}
+
 	attResp, err := v.validatorClient.ProposeAttestation(ctx, attestation)
 	if err != nil {
 		log.WithError(err).Error("Could not submit attestation to beacon node")
@@ -121,9 +125,6 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 			ValidatorAttestFailVec.WithLabelValues(fmtKey).Inc()
 		}
 		return
-	}
-	if err := v.SaveProtection(ctx, pubKey); err != nil {
-		log.WithError(err).Errorf("Could not save validator: %#x protection", pubKey)
 	}
 
 	if err := v.saveAttesterIndexToData(data, duty.ValidatorIndex); err != nil {

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -82,22 +82,22 @@ func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.Ind
 			}
 			return errors.New(failedAttLocalProtectionErr)
 		}
-		newHistory, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(
-			ctx,
-			attesterHistory,
-			indexedAtt.Data.Target.Epoch,
-			&kv.HistoryData{
-				Source:      indexedAtt.Data.Source.Epoch,
-				SigningRoot: signingRoot[:],
-			},
-		)
-		if err != nil {
-			return errors.Wrapf(err, "could not mark epoch %d as attested", indexedAtt.Data.Target.Epoch)
-		}
-		v.attesterHistoryByPubKey[pubKey] = newHistory
 	} else {
 		log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in post validation")
 	}
+	newHistory, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(
+		ctx,
+		attesterHistory,
+		indexedAtt.Data.Target.Epoch,
+		&kv.HistoryData{
+			Source:      indexedAtt.Data.Source.Epoch,
+			SigningRoot: signingRoot[:],
+		},
+	)
+	if err != nil {
+		return errors.Wrapf(err, "could not mark epoch %d as attested", indexedAtt.Data.Target.Epoch)
+	}
+	v.attesterHistoryByPubKey[pubKey] = newHistory
 
 	if featureconfig.Get().SlasherProtection && v.protector != nil {
 		if !v.protector.CommitAttestation(ctx, indexedAtt) {

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -82,22 +82,36 @@ func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.Ind
 			}
 			return errors.New(failedAttLocalProtectionErr)
 		}
+		newHistory, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(
+			ctx,
+			attesterHistory,
+			indexedAtt.Data.Target.Epoch,
+			&kv.HistoryData{
+				Source:      indexedAtt.Data.Source.Epoch,
+				SigningRoot: signingRoot[:],
+			},
+		)
+		if err != nil {
+			return errors.Wrapf(err, "could not mark epoch %d as attested", indexedAtt.Data.Target.Epoch)
+		}
+		v.attesterHistoryByPubKey[pubKey] = newHistory
 	} else {
 		log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in post validation")
+		history := kv.NewAttestationHistoryArray(indexedAtt.Data.Target.Epoch)
+		newHistory, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(
+			ctx,
+			history,
+			indexedAtt.Data.Target.Epoch,
+			&kv.HistoryData{
+				Source:      indexedAtt.Data.Source.Epoch,
+				SigningRoot: signingRoot[:],
+			},
+		)
+		if err != nil {
+			return errors.Wrapf(err, "could not mark epoch %d as attested", indexedAtt.Data.Target.Epoch)
+		}
+		v.attesterHistoryByPubKey[pubKey] = newHistory
 	}
-	newHistory, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(
-		ctx,
-		attesterHistory,
-		indexedAtt.Data.Target.Epoch,
-		&kv.HistoryData{
-			Source:      indexedAtt.Data.Source.Epoch,
-			SigningRoot: signingRoot[:],
-		},
-	)
-	if err != nil {
-		return errors.Wrapf(err, "could not mark epoch %d as attested", indexedAtt.Data.Target.Epoch)
-	}
-	v.attesterHistoryByPubKey[pubKey] = newHistory
 
 	if featureconfig.Get().SlasherProtection && v.protector != nil {
 		if !v.protector.CommitAttestation(ctx, indexedAtt) {

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -64,6 +64,7 @@ func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.Ind
 	fmtKey := fmt.Sprintf("%#x", pubKey[:])
 	v.attesterHistoryByPubKeyLock.Lock()
 	defer v.attesterHistoryByPubKeyLock.Unlock()
+	var newHistory kv.EncHistoryData
 	attesterHistory, ok := v.attesterHistoryByPubKey[pubKey]
 	if ok {
 		slashable, err := isNewAttSlashable(
@@ -82,36 +83,24 @@ func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.Ind
 			}
 			return errors.New(failedAttLocalProtectionErr)
 		}
-		newHistory, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(
-			ctx,
-			attesterHistory,
-			indexedAtt.Data.Target.Epoch,
-			&kv.HistoryData{
-				Source:      indexedAtt.Data.Source.Epoch,
-				SigningRoot: signingRoot[:],
-			},
-		)
-		if err != nil {
-			return errors.Wrapf(err, "could not mark epoch %d as attested", indexedAtt.Data.Target.Epoch)
-		}
-		v.attesterHistoryByPubKey[pubKey] = newHistory
+		newHistory = attesterHistory
 	} else {
 		log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in post validation")
-		history := kv.NewAttestationHistoryArray(indexedAtt.Data.Target.Epoch)
-		newHistory, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(
-			ctx,
-			history,
-			indexedAtt.Data.Target.Epoch,
-			&kv.HistoryData{
-				Source:      indexedAtt.Data.Source.Epoch,
-				SigningRoot: signingRoot[:],
-			},
-		)
-		if err != nil {
-			return errors.Wrapf(err, "could not mark epoch %d as attested", indexedAtt.Data.Target.Epoch)
-		}
-		v.attesterHistoryByPubKey[pubKey] = newHistory
+		newHistory = kv.NewAttestationHistoryArray(indexedAtt.Data.Target.Epoch)
 	}
+	updatedHistory, err := kv.MarkAllAsAttestedSinceLatestWrittenEpoch(
+		ctx,
+		newHistory,
+		indexedAtt.Data.Target.Epoch,
+		&kv.HistoryData{
+			Source:      indexedAtt.Data.Source.Epoch,
+			SigningRoot: signingRoot[:],
+		},
+	)
+	if err != nil {
+		return errors.Wrapf(err, "could not mark epoch %d as attested", indexedAtt.Data.Target.Epoch)
+	}
+	v.attesterHistoryByPubKey[pubKey] = updatedHistory
 
 	if featureconfig.Get().SlasherProtection && v.protector != nil {
 		if !v.protector.CommitAttestation(ctx, indexedAtt) {


### PR DESCRIPTION
Follow up to #7934, this PR ensures we update the attesting history if an attestation is not found to be slashable. Additionally, we save the protection data to DB _before_ we attest rather than afterwards