### PR TITLE
Fix locks and fallback to db read if attestation history map is missing a pub key data

### DIFF
--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -113,7 +113,9 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		).Debug("Attempted slashable attestation details")
 		return
 	}
-
+	if err := v.SaveProtection(ctx, pubKey); err != nil {
+		log.WithError(err).Errorf("Could not save validator: %#x protection", pubKey)
+	}
 	attResp, err := v.validatorClient.ProposeAttestation(ctx, attestation)
 	if err != nil {
 		log.WithError(err).Error("Could not submit attestation to beacon node")
@@ -121,9 +123,6 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 			ValidatorAttestFailVec.WithLabelValues(fmtKey).Inc()
 		}
 		return
-	}
-	if err := v.SaveProtection(ctx, pubKey); err != nil {
-		log.WithError(err).Errorf("Could not save validator: %#x protection", pubKey)
 	}
 
 	if err := v.saveAttesterIndexToData(data, duty.ValidatorIndex); err != nil {

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -30,7 +30,7 @@ func (v *validator) preAttSignValidations(ctx context.Context, indexedAtt *ethpb
 		}
 		attesterHistory, ok = attesterHistoryMap[pubKey]
 		if !ok {
-			log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in post validation")
+			log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in pre validation")
 		}
 	}
 	_, sr, err := v.getDomainAndSigningRoot(ctx, indexedAtt.Data)

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -23,7 +23,7 @@ func (v *validator) preAttSignValidations(ctx context.Context, indexedAtt *ethpb
 	attesterHistory, ok := v.attesterHistoryByPubKey[pubKey]
 	v.attesterHistoryByPubKeyLock.RUnlock()
 	if !ok {
-		attestationMapMiss.Inc()
+		AttestationMapMiss.Inc()
 		attesterHistoryMap, err := v.db.AttestationHistoryForPubKeysV2(ctx, [][48]byte{pubKey})
 		if err != nil {
 			return errors.Wrap(err, "could not get attester history")
@@ -33,7 +33,7 @@ func (v *validator) preAttSignValidations(ctx context.Context, indexedAtt *ethpb
 			log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in pre validation")
 		}
 	} else {
-		attestationMapHit.Inc()
+		AttestationMapHit.Inc()
 	}
 	_, sr, err := v.getDomainAndSigningRoot(ctx, indexedAtt.Data)
 	if err != nil {
@@ -73,7 +73,7 @@ func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.Ind
 	defer v.attesterHistoryByPubKeyLock.Unlock()
 	attesterHistory, ok := v.attesterHistoryByPubKey[pubKey]
 	if !ok {
-		attestationMapMiss.Inc()
+		AttestationMapMiss.Inc()
 		attesterHistoryMap, err := v.db.AttestationHistoryForPubKeysV2(ctx, [][48]byte{pubKey})
 		if err != nil {
 			return errors.Wrap(err, "could not get attester history")
@@ -83,7 +83,7 @@ func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.Ind
 			log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in post validation")
 		}
 	} else {
-		attestationMapHit.Inc()
+		AttestationMapHit.Inc()
 	}
 	slashable, err := isNewAttSlashable(
 		ctx,

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -30,7 +30,7 @@ func (v *validator) preAttSignValidations(ctx context.Context, indexedAtt *ethpb
 		}
 		attesterHistory, ok = attesterHistoryMap[pubKey]
 		if !ok {
-			attesterHistory = kv.NewAttestationHistoryArray(0)
+			log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in post validation")
 		}
 	}
 	_, sr, err := v.getDomainAndSigningRoot(ctx, indexedAtt.Data)
@@ -77,7 +77,7 @@ func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.Ind
 		}
 		attesterHistory, ok = attesterHistoryMap[pubKey]
 		if !ok {
-			attesterHistory = kv.NewAttestationHistoryArray(0)
+			log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in post validation")
 		}
 	}
 	slashable, err := isNewAttSlashable(

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -32,9 +32,6 @@ func (v *validator) preAttSignValidations(ctx context.Context, indexedAtt *ethpb
 		if !ok {
 			attesterHistory = kv.NewAttestationHistoryArray(0)
 		}
-		v.attesterHistoryByPubKeyLock.Lock()
-		v.attesterHistoryByPubKey[pubKey] = attesterHistory
-		v.attesterHistoryByPubKeyLock.Unlock()
 	}
 	_, sr, err := v.getDomainAndSigningRoot(ctx, indexedAtt.Data)
 	if err != nil {
@@ -82,9 +79,6 @@ func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.Ind
 		if !ok {
 			attesterHistory = kv.NewAttestationHistoryArray(0)
 		}
-		v.attesterHistoryByPubKeyLock.Lock()
-		v.attesterHistoryByPubKey[pubKey] = attesterHistory
-		v.attesterHistoryByPubKeyLock.Unlock()
 	}
 	slashable, err := isNewAttSlashable(
 		ctx,

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -32,6 +32,7 @@ func (v *validator) preAttSignValidations(ctx context.Context, indexedAtt *ethpb
 		if !ok {
 			log.WithField("publicKey", fmtKey).Debug("Could not get local slashing protection data for validator in pre validation")
 		}
+
 	}
 	_, sr, err := v.getDomainAndSigningRoot(ctx, indexedAtt.Data)
 	if err != nil {
@@ -67,9 +68,10 @@ func (v *validator) preAttSignValidations(ctx context.Context, indexedAtt *ethpb
 
 func (v *validator) postAttSignUpdate(ctx context.Context, indexedAtt *ethpb.IndexedAttestation, pubKey [48]byte, signingRoot [32]byte) error {
 	fmtKey := fmt.Sprintf("%#x", pubKey[:])
-	v.attesterHistoryByPubKeyLock.RLock()
+	v.attesterHistoryByPubKeyLock.Lock()
+	defer v.attesterHistoryByPubKeyLock.Unlock()
 	attesterHistory, ok := v.attesterHistoryByPubKey[pubKey]
-	v.attesterHistoryByPubKeyLock.RUnlock()
+
 	if !ok {
 		attesterHistoryMap, err := v.db.AttestationHistoryForPubKeysV2(ctx, [][48]byte{pubKey})
 		if err != nil {

--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -14,6 +14,18 @@ import (
 )
 
 var (
+	// AttestationMapMiss used to track the success rate of historical
+	// attestation map for slashing detection flow.
+	AttestationMapHit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "attestation_history_map_hit",
+		Help: "The number of attestation history calls that are present in the map.",
+	})
+	// AttestationMapMiss used to track the use of the fallback db read when
+	// attestation map is being mutated while being used in the slashing detection flow.
+	AttestationMapMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "attestation_history_map_miss",
+		Help: "The number of attestation history calls that are'nt present in the map.",
+	})
 	// ValidatorStatusesGaugeVec used to track validator statuses by public key.
 	ValidatorStatusesGaugeVec = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/validator/client/mock_validator.go
+++ b/validator/client/mock_validator.go
@@ -119,12 +119,6 @@ func (fv *FakeValidator) LogValidatorGainsAndLosses(_ context.Context, _ uint64)
 	return nil
 }
 
-// SaveProtections for mocking.
-func (fv *FakeValidator) SaveProtections(_ context.Context) error {
-	fv.SaveProtectionsCalled = true
-	return nil
-}
-
 // ResetAttesterProtectionData for mocking.
 func (fv *FakeValidator) ResetAttesterProtectionData() {
 	fv.DeleteProtectionCalled = true

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -154,10 +154,11 @@ func run(ctx context.Context, v Validator) {
 				}
 			}
 			// Wait for all processes to complete, then report span complete.
-			wg.Wait()
-			v.LogAttestationsSubmitted()
+
 			go func() {
+				wg.Wait()
 				// Log this client performance in the previous epoch
+				v.LogAttestationsSubmitted()
 				if err := v.LogValidatorGainsAndLosses(slotCtx, slot); err != nil {
 					log.WithError(err).Error("Could not report validator's rewards/penalties")
 				}

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -33,7 +33,6 @@ type Validator interface {
 	ProposeBlock(ctx context.Context, slot uint64, pubKey [48]byte)
 	SubmitAggregateAndProof(ctx context.Context, slot uint64, pubKey [48]byte)
 	LogAttestationsSubmitted()
-	SaveProtections(ctx context.Context) error
 	ResetAttesterProtectionData()
 	UpdateDomainDataCaches(ctx context.Context, slot uint64)
 	WaitForWalletInitialization(ctx context.Context) error

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -154,10 +154,9 @@ func run(ctx context.Context, v Validator) {
 				}
 			}
 			// Wait for all processes to complete, then report span complete.
+			wg.Wait()
+			v.LogAttestationsSubmitted()
 			go func() {
-				wg.Wait()
-				v.ResetAttesterProtectionData()
-				v.LogAttestationsSubmitted()
 				// Log this client performance in the previous epoch
 				if err := v.LogValidatorGainsAndLosses(slotCtx, slot); err != nil {
 					log.WithError(err).Error("Could not report validator's rewards/penalties")

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -19,6 +19,8 @@ import (
 	ptypes "github.com/gogo/protobuf/types"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -78,6 +80,18 @@ type validator struct {
 	graffiti                           []byte
 	voteStats                          voteStats
 }
+
+var (
+	// Metrics.
+	attestationMapHit = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "attestation_history_map_hit",
+		Help: "The number of attestation history calls that are present in the map.",
+	})
+	attestationMapMiss = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "attestation_history_map_miss",
+		Help: "The number of attestation history calls that are'nt present in the map.",
+	})
+)
 
 // Done cleans up the validator.
 func (v *validator) Done() {

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -19,8 +19,6 @@ import (
 	ptypes "github.com/gogo/protobuf/types"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -80,18 +78,6 @@ type validator struct {
 	graffiti                           []byte
 	voteStats                          voteStats
 }
-
-var (
-	// Metrics.
-	attestationMapHit = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "attestation_history_map_hit",
-		Help: "The number of attestation history calls that are present in the map.",
-	})
-	attestationMapMiss = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "attestation_history_map_miss",
-		Help: "The number of attestation history calls that are'nt present in the map.",
-	})
-)
 
 // Done cleans up the validator.
 func (v *validator) Done() {

--- a/validator/db/kv/attestation_history_v2.go
+++ b/validator/db/kv/attestation_history_v2.go
@@ -189,7 +189,8 @@ func (store *Store) AttestationHistoryForPubKeysV2(ctx context.Context, publicKe
 			if len(enc) == 0 {
 				attestationHistory = NewAttestationHistoryArray(0)
 			} else {
-				attestationHistory = enc
+				attestationHistory = make(EncHistoryData, len(enc))
+				copy(attestationHistory, enc)
 			}
 			attestationHistoryForVals[key] = attestationHistory
 		}


### PR DESCRIPTION
This is a follow-up to #7935, the core cause of the error we have observed  "cannot find attesting history for pubkey" in the validator clients on Pyrmont. Was found to be the rewriting of attestationhistory map while some rolls (validator duties) are still using them. (the wait group is in the go routine)https://github.com/prysmaticlabs/prysm/blob/5889670cc74b83f5511f15aa3dc24e4155cf9150/validator/client/runner.go#L158
by removing `ResetAttesterProtectionData` https://github.com/prysmaticlabs/prysm/blob/5889670cc74b83f5511f15aa3dc24e4155cf9150/validator/client/runner.go#L160
we solved most of the cases but still at some extreme cases `v.UpdateProtections(ctx, slot)` was replacing the map content while some validators are still using them in their assignments
https://github.com/prysmaticlabs/prysm/blob/5889670cc74b83f5511f15aa3dc24e4155cf9150/validator/client/runner.go#L118

Added a fallback function to read from db in case a key (public key) history data is not found in the map 