### PR TITLE
Add Multilock Around Attest/Propose By Public Key

### DIFF
--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//shared/featureconfig:go_default_library",
         "//shared/grpcutils:go_default_library",
         "//shared/hashutil:go_default_library",
+        "//shared/mputil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/slotutil:go_default_library",
         "//shared/timeutils:go_default_library",

--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -13,6 +13,7 @@ import (
 	validatorpb "github.com/prysmaticlabs/prysm/proto/validator/accounts/v2"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
+	"github.com/prysmaticlabs/prysm/shared/mputil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
 	"github.com/prysmaticlabs/prysm/shared/timeutils"
@@ -25,6 +26,9 @@ import (
 // information in order to sign the block and include information about the validator's
 // participation in voting on the block.
 func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [48]byte) {
+	lock := mputil.NewMultilock(string(pubKey[:]))
+	lock.Lock()
+	defer lock.Unlock()
 	ctx, span := trace.StartSpan(ctx, "validator.SubmitAttestation")
 	defer span.End()
 	span.AddAttributes(trace.StringAttribute("validator", fmt.Sprintf("%#x", pubKey)))

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -12,6 +12,7 @@ import (
 	validatorpb "github.com/prysmaticlabs/prysm/proto/validator/accounts/v2"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/mputil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/timeutils"
 	"github.com/sirupsen/logrus"
@@ -34,6 +35,9 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 		log.Debug("Assigned to genesis slot, skipping proposal")
 		return
 	}
+	lock := mputil.NewMultilock(string(pubKey[:]))
+	lock.Lock()
+	defer lock.Unlock()
 	ctx, span := trace.StartSpan(ctx, "validator.ProposeBlock")
 	defer span.End()
 	fmtKey := fmt.Sprintf("%#x", pubKey[:])


### PR DESCRIPTION
This PR adds a multilock by public key around the attest and propose functions in the validator client, giving us greater safety around slashable offenses