### PR TITLE
Enforce min proposal slot slashing protection

### DIFF
--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -257,7 +257,9 @@ func TestProposeBlock_AllowsPastProposals(t *testing.T) {
 	defer finish()
 	pubKey := [48]byte{}
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-
+	// save 0 slot for public key as minimal slot.
+	err := validator.db.SaveProposalHistoryForSlot(context.Background(), pubKey[:], 0, []byte{1})
+	require.NoError(t, err)
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx
 		gomock.Any(), //epoch

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -303,7 +303,8 @@ func TestProposeBlock_AllowsSameEpoch(t *testing.T) {
 	defer finish()
 	pubKey := [48]byte{}
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-
+	err := validator.db.SaveProposalHistoryForSlot(context.Background(), pubKey[:], 0, []byte{1})
+	require.NoError(t, err)
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx
 		gomock.Any(), //epoch

--- a/validator/db/iface/interface.go
+++ b/validator/db/iface/interface.go
@@ -26,7 +26,7 @@ type ValidatorDB interface {
 	SaveProposalHistoryForEpoch(ctx context.Context, publicKey []byte, epoch uint64, history bitfield.Bitlist) error
 
 	// New data structure methods
-	ProposalHistoryForSlot(ctx context.Context, publicKey []byte, slot uint64) ([]byte, error)
+	ProposalHistoryForSlot(ctx context.Context, publicKey []byte, slot uint64) ([]byte, uint64, error)
 	SaveProposalHistoryForSlot(ctx context.Context, pubKey []byte, slot uint64, signingRoot []byte) error
 	SaveProposalHistoryForPubKeysV2(ctx context.Context, proposals map[[48]byte]kv.ProposalHistoryForPubkey) error
 

--- a/validator/db/kv/manage_test.go
+++ b/validator/db/kv/manage_test.go
@@ -196,7 +196,7 @@ func prepareStoreAttestations(store *Store, pubKeys [][48]byte) (map[[48]byte]ma
 
 func assertStore(t *testing.T, store *Store, pubKeys [][48]byte, expectedHistory *storeHistory) {
 	for _, key := range pubKeys {
-		proposalHistory, err := store.ProposalHistoryForSlot(context.Background(), key[:], 0)
+		proposalHistory, _, err := store.ProposalHistoryForSlot(context.Background(), key[:], 0)
 		require.NoError(t, err, "Retrieving proposal history failed for public key %v", key)
 		expectedProposals := expectedHistory.Proposals[key]
 		require.DeepEqual(t, expectedProposals, proposalHistory, "Proposals are incorrect")

--- a/validator/db/kv/proposal_history_v2_test.go
+++ b/validator/db/kv/proposal_history_v2_test.go
@@ -15,10 +15,11 @@ func TestProposalHistoryForSlot_InitializesNewPubKeys(t *testing.T) {
 	db := setupDB(t, pubkeys)
 
 	for _, pub := range pubkeys {
-		signingRoot, _, err := db.ProposalHistoryForSlot(context.Background(), pub[:], 0)
+		signingRoot, min, err := db.ProposalHistoryForSlot(context.Background(), pub[:], 0)
 		require.NoError(t, err)
 		expected := bytesutil.PadTo([]byte{}, 32)
 		require.DeepEqual(t, expected, signingRoot, "Expected proposal history slot signing root to be empty")
+		require.Equal(t, uint64(0), min)
 	}
 }
 
@@ -38,11 +39,12 @@ func TestSaveProposalHistoryForSlot_OK(t *testing.T) {
 
 	err := db.SaveProposalHistoryForSlot(context.Background(), pubkey[:], slot, []byte{1})
 	require.NoError(t, err, "Saving proposal history failed: %v")
-	signingRoot, _, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], slot)
+	signingRoot, min, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], slot)
 	require.NoError(t, err, "Failed to get proposal history")
 
 	require.NotNil(t, signingRoot)
 	require.DeepEqual(t, bytesutil.PadTo([]byte{1}, 32), signingRoot, "Expected DB to keep object the same")
+	require.Equal(t, slot, min)
 }
 
 func TestSaveProposalHistoryForSlot_Empty(t *testing.T) {
@@ -53,11 +55,12 @@ func TestSaveProposalHistoryForSlot_Empty(t *testing.T) {
 	emptySlot := uint64(120)
 	err := db.SaveProposalHistoryForSlot(context.Background(), pubkey[:], slot, []byte{1})
 	require.NoError(t, err, "Saving proposal history failed: %v")
-	signingRoot, _, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], emptySlot)
+	signingRoot, min, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], emptySlot)
 	require.NoError(t, err, "Failed to get proposal history")
 
 	require.NotNil(t, signingRoot)
 	require.DeepEqual(t, bytesutil.PadTo([]byte{}, 32), signingRoot, "Expected DB to keep object the same")
+	require.Equal(t, slot, min)
 }
 
 func TestSaveProposalHistoryForSlot_Overwrites(t *testing.T) {

--- a/validator/db/kv/proposal_history_v2_test.go
+++ b/validator/db/kv/proposal_history_v2_test.go
@@ -34,14 +34,18 @@ func TestNewProposalHistoryForSlot_NilDB(t *testing.T) {
 func TestSaveProposalHistoryForSlot_OK(t *testing.T) {
 	pubkey := [48]byte{3}
 	db := setupDB(t, [][48]byte{pubkey})
+	emptySigningRoot := make([]byte, 32)
 
 	slot := uint64(2)
-
-	err := db.SaveProposalHistoryForSlot(context.Background(), pubkey[:], slot, []byte{1})
-	require.NoError(t, err, "Saving proposal history failed: %v")
+	// test min slot that is not set doesnt block
 	signingRoot, min, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], slot)
 	require.NoError(t, err, "Failed to get proposal history")
-
+	require.DeepEqual(t, emptySigningRoot, signingRoot)
+	require.Equal(t, uint64(0), min)
+	err = db.SaveProposalHistoryForSlot(context.Background(), pubkey[:], slot, []byte{1})
+	require.NoError(t, err, "Saving proposal history failed: %v")
+	signingRoot, min, err = db.ProposalHistoryForSlot(context.Background(), pubkey[:], slot)
+	require.NoError(t, err, "Failed to get proposal history")
 	require.NotNil(t, signingRoot)
 	require.DeepEqual(t, bytesutil.PadTo([]byte{1}, 32), signingRoot, "Expected DB to keep object the same")
 	require.Equal(t, slot, min)

--- a/validator/db/kv/proposal_history_v2_test.go
+++ b/validator/db/kv/proposal_history_v2_test.go
@@ -15,7 +15,7 @@ func TestProposalHistoryForSlot_InitializesNewPubKeys(t *testing.T) {
 	db := setupDB(t, pubkeys)
 
 	for _, pub := range pubkeys {
-		signingRoot, err := db.ProposalHistoryForSlot(context.Background(), pub[:], 0)
+		signingRoot, _, err := db.ProposalHistoryForSlot(context.Background(), pub[:], 0)
 		require.NoError(t, err)
 		expected := bytesutil.PadTo([]byte{}, 32)
 		require.DeepEqual(t, expected, signingRoot, "Expected proposal history slot signing root to be empty")
@@ -26,7 +26,7 @@ func TestNewProposalHistoryForSlot_NilDB(t *testing.T) {
 	valPubkey := [48]byte{1, 2, 3}
 	db := setupDB(t, [][48]byte{})
 
-	_, err := db.ProposalHistoryForSlot(context.Background(), valPubkey[:], 0)
+	_, _, err := db.ProposalHistoryForSlot(context.Background(), valPubkey[:], 0)
 	require.ErrorContains(t, "validator history empty for public key", err, "Unexpected error for nil DB")
 }
 
@@ -38,7 +38,7 @@ func TestSaveProposalHistoryForSlot_OK(t *testing.T) {
 
 	err := db.SaveProposalHistoryForSlot(context.Background(), pubkey[:], slot, []byte{1})
 	require.NoError(t, err, "Saving proposal history failed: %v")
-	signingRoot, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], slot)
+	signingRoot, _, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], slot)
 	require.NoError(t, err, "Failed to get proposal history")
 
 	require.NotNil(t, signingRoot)
@@ -53,7 +53,7 @@ func TestSaveProposalHistoryForSlot_Empty(t *testing.T) {
 	emptySlot := uint64(120)
 	err := db.SaveProposalHistoryForSlot(context.Background(), pubkey[:], slot, []byte{1})
 	require.NoError(t, err, "Saving proposal history failed: %v")
-	signingRoot, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], emptySlot)
+	signingRoot, _, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], emptySlot)
 	require.NoError(t, err, "Failed to get proposal history")
 
 	require.NotNil(t, signingRoot)
@@ -84,7 +84,7 @@ func TestSaveProposalHistoryForSlot_Overwrites(t *testing.T) {
 		db := setupDB(t, [][48]byte{pubkey})
 		err := db.SaveProposalHistoryForSlot(context.Background(), pubkey[:], 0, tt.signingRoot)
 		require.NoError(t, err, "Saving proposal history failed")
-		signingRoot, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], 0)
+		signingRoot, _, err := db.ProposalHistoryForSlot(context.Background(), pubkey[:], 0)
 		require.NoError(t, err, "Failed to get proposal history")
 
 		require.NotNil(t, signingRoot)
@@ -142,12 +142,12 @@ func TestPruneProposalHistoryBySlot_OK(t *testing.T) {
 		}
 
 		for _, slot := range tt.removedSlots {
-			sr, err := db.ProposalHistoryForSlot(context.Background(), pubKey[:], slot)
+			sr, _, err := db.ProposalHistoryForSlot(context.Background(), pubKey[:], slot)
 			require.NoError(t, err, "Failed to get proposal history")
 			require.DeepEqual(t, bytesutil.PadTo([]byte{}, 32), sr, "Unexpected difference in bytes for epoch %d", slot)
 		}
 		for _, slot := range tt.storedSlots {
-			sr, err := db.ProposalHistoryForSlot(context.Background(), pubKey[:], slot)
+			sr, _, err := db.ProposalHistoryForSlot(context.Background(), pubKey[:], slot)
 			require.NoError(t, err, "Failed to get proposal history")
 			require.DeepEqual(t, signedRoot, sr, "Unexpected difference in bytes for epoch %d", slot)
 		}
@@ -182,12 +182,12 @@ func TestStore_ImportProposalHistory(t *testing.T) {
 
 	for slot := uint64(0); slot <= lastIndex; slot++ {
 		if _, ok := proposedSlots[slot]; ok {
-			root, err := db.ProposalHistoryForSlot(ctx, pubkey[:], slot)
+			root, _, err := db.ProposalHistoryForSlot(ctx, pubkey[:], slot)
 			require.NoError(t, err)
 			require.DeepEqual(t, bytesutil.PadTo([]byte{1}, 32), root, "slot: %d", slot)
 			continue
 		}
-		root, err := db.ProposalHistoryForSlot(ctx, pubkey[:], slot)
+		root, _, err := db.ProposalHistoryForSlot(ctx, pubkey[:], slot)
 		require.NoError(t, err)
 		require.DeepEqual(t, bytesutil.PadTo([]byte{}, 32), root)
 	}

--- a/validator/db/kv/schema.go
+++ b/validator/db/kv/schema.go
@@ -14,4 +14,6 @@ var (
 	historicAttestationsBucket = []byte("attestation-history-bucket")
 	// New Validator slashing protection from slashable attestations.
 	newHistoricAttestationsBucket = []byte("attestation-history-bucket-interchange")
+	// Key to minimal proposal signing slot in proposal bucket.
+	minimalProposalSlotKey = []byte("minimal-proposal-signing-slot")
 )


### PR DESCRIPTION
Feature

**What does this PR do? Why is it needed?**
This pr conform to the interchange format EIP by considering a request to sign slot that is lower then min signed slot as slashable
**Which issues(s) does this PR fix?**

Part of #7813

**Other notes for review**
