### PR TITLE
Allow Optional Signing Roots in Proposal History

### DIFF
--- a/validator/client/propose_protect.go
+++ b/validator/client/propose_protect.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
@@ -10,7 +9,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/blockutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
-	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
 )
 
@@ -20,15 +18,17 @@ var failedPostBlockSignErr = "made a double proposal, considered slashable by re
 
 func (v *validator) preBlockSignValidations(ctx context.Context, pubKey [48]byte, block *ethpb.BeaconBlock) error {
 	fmtKey := fmt.Sprintf("%#x", pubKey[:])
-	signingRoot, err := v.db.ProposalHistoryForSlot(ctx, pubKey, block.Slot)
+	_, exists, err := v.db.ProposalHistoryForSlot(ctx, pubKey, block.Slot)
 	if err != nil {
 		if v.emitAccountMetrics {
 			ValidatorProposeFailVec.WithLabelValues(fmtKey).Inc()
 		}
 		return errors.Wrap(err, "failed to get proposal history")
 	}
-	// If the bit for the current slot is marked, do not propose.
-	if !bytes.Equal(signingRoot, params.BeaconConfig().ZeroHash[:]) {
+	// If a proposal exists in our history for the slot, we assume it is slashable.
+	// TODO(#7848): Add a more sophisticated strategy where if we indeed have the signing root,
+	// only blocks that have a conflicting signing root with a historical proposal are slashable.
+	if exists {
 		if v.emitAccountMetrics {
 			ValidatorProposeFailVec.WithLabelValues(fmtKey).Inc()
 		}

--- a/validator/client/propose_protect_test.go
+++ b/validator/client/propose_protect_test.go
@@ -27,15 +27,32 @@ func TestPreBlockSignLocalValidation(t *testing.T) {
 	}
 	pubKeyBytes := [48]byte{}
 	copy(pubKeyBytes[:], validatorKey.PublicKey().Marshal())
+
+	// We save a proposal at slot 10 with a dummy signing root.
 	err := validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, 10, []byte{1})
 	require.NoError(t, err)
 	pubKey := [48]byte{}
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
+
+	// We expect the same block sent out should return slashable error.
 	err = validator.preBlockSignValidations(context.Background(), pubKey, block)
 	require.ErrorContains(t, failedPreBlockSignLocalErr, err)
+
+	// We save a proposal at slot 11 with a nil signing root.
+	block.Slot = 11
+	err = validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, block.Slot, nil)
+	require.NoError(t, err)
+
+	// We expect the same block sent out should return slashable error even
+	// if we had a nil signing root stored in the database.
+	err = validator.preBlockSignValidations(context.Background(), pubKey, block)
+	require.ErrorContains(t, failedPreBlockSignLocalErr, err)
+
+	// A block with a different slot for which we do not have a proposing history
+	// should not be failing validation.
 	block.Slot = 9
 	err = validator.preBlockSignValidations(context.Background(), pubKey, block)
-	require.NoError(t, err, "Expected allowed attestation not to throw error")
+	require.NoError(t, err, "Expected allowed block not to throw error")
 }
 
 func TestPreBlockSignValidation(t *testing.T) {

--- a/validator/db/iface/interface.go
+++ b/validator/db/iface/interface.go
@@ -28,7 +28,7 @@ type ValidatorDB interface {
 	LowestSignedProposal(ctx context.Context, publicKey [48]byte) (uint64, error)
 
 	// New data structure methods
-	ProposalHistoryForSlot(ctx context.Context, publicKey [48]byte, slot uint64) ([]byte, error)
+	ProposalHistoryForSlot(ctx context.Context, publicKey [48]byte, slot uint64) ([32]byte, bool, error)
 	SaveProposalHistoryForSlot(ctx context.Context, pubKey [48]byte, slot uint64, signingRoot []byte) error
 
 	// Attester protection related methods.

--- a/validator/db/kv/manage_test.go
+++ b/validator/db/kv/manage_test.go
@@ -196,10 +196,10 @@ func prepareStoreAttestations(store *Store, pubKeys [][48]byte) (map[[48]byte]ma
 
 func assertStore(t *testing.T, store *Store, pubKeys [][48]byte, expectedHistory *storeHistory) {
 	for _, key := range pubKeys {
-		proposalHistory, err := store.ProposalHistoryForSlot(context.Background(), key, 0)
+		proposalHistory, _, err := store.ProposalHistoryForSlot(context.Background(), key, 0)
 		require.NoError(t, err, "Retrieving proposal history failed for public key %v", key)
 		expectedProposals := expectedHistory.Proposals[key]
-		require.DeepEqual(t, expectedProposals, proposalHistory, "Proposals are incorrect")
+		require.DeepEqual(t, expectedProposals, proposalHistory[:], "Proposals are incorrect")
 	}
 
 	attestationHistory, err := store.AttestationHistoryForPubKeys(context.Background(), pubKeys)

--- a/validator/db/kv/proposal_history_v2.go
+++ b/validator/db/kv/proposal_history_v2.go
@@ -14,28 +14,31 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// ProposalHistoryForSlot accepts a validator public key and returns the corresponding signing root.
-// Returns nil if there is no proposal history for the validator at this slot.
-func (store *Store) ProposalHistoryForSlot(ctx context.Context, publicKey [48]byte, slot uint64) ([]byte, error) {
+// ProposalHistoryForSlot accepts a validator public key and returns the corresponding signing root as well
+// as a boolean that tells us if we have a proposal history stored at the slot. It is possible we have proposed
+// a slot but stored a nil signing root, so the boolean helps give full information.
+func (store *Store) ProposalHistoryForSlot(ctx context.Context, publicKey [48]byte, slot uint64) ([32]byte, bool, error) {
 	ctx, span := trace.StartSpan(ctx, "Validator.ProposalHistoryForSlot")
 	defer span.End()
 
 	var err error
-	signingRoot := make([]byte, 32)
+	var proposalExists bool
+	signingRoot := [32]byte{}
 	err = store.view(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(newhistoricProposalsBucket)
 		valBucket := bucket.Bucket(publicKey[:])
 		if valBucket == nil {
 			return fmt.Errorf("validator history empty for public key: %#x", publicKey)
 		}
-		sr := valBucket.Get(bytesutil.Uint64ToBytesBigEndian(slot))
-		if len(sr) == 0 {
+		signingRootBytes := valBucket.Get(bytesutil.Uint64ToBytesBigEndian(slot))
+		if signingRootBytes == nil {
 			return nil
 		}
-		copy(signingRoot, sr)
+		proposalExists = true
+		copy(signingRoot[:], signingRootBytes)
 		return nil
 	})
-	return signingRoot, err
+	return signingRoot, proposalExists, err
 }
 
 // SaveProposalHistoryForSlot saves the proposal history for the requested validator public key.

--- a/validator/slashing-protection/local/standard-protection-format/import_test.go
+++ b/validator/slashing-protection/local/standard-protection-format/import_test.go
@@ -86,11 +86,11 @@ func TestStore_ImportInterchangeData_BadFormat_PreventsDBWrites(t *testing.T) {
 		)
 		proposals := proposalHistory[i].Proposals
 		for _, proposal := range proposals {
-			receivedProposalSigningRoot, err := validatorDB.ProposalHistoryForSlot(ctx, publicKeys[i], proposal.Slot)
+			receivedProposalSigningRoot, _, err := validatorDB.ProposalHistoryForSlot(ctx, publicKeys[i], proposal.Slot)
 			require.NoError(t, err)
 			require.DeepEqual(
 				t,
-				params.BeaconConfig().ZeroHash[:],
+				params.BeaconConfig().ZeroHash,
 				receivedProposalSigningRoot,
 				"Imported proposal signing root is different than the empty default",
 			)
@@ -131,11 +131,11 @@ func TestStore_ImportInterchangeData_OK(t *testing.T) {
 		)
 		proposals := proposalHistory[i].Proposals
 		for _, proposal := range proposals {
-			receivedProposalSigningRoot, err := validatorDB.ProposalHistoryForSlot(ctx, publicKeys[i], proposal.Slot)
+			receivedProposalSigningRoot, _, err := validatorDB.ProposalHistoryForSlot(ctx, publicKeys[i], proposal.Slot)
 			require.NoError(t, err)
 			require.DeepEqual(
 				t,
-				receivedProposalSigningRoot,
+				receivedProposalSigningRoot[:],
 				proposal.SigningRoot,
 				"Imported proposals are different then the generated ones",
 			)


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR amends our `ProposalHistoryForSlot` method to return (signingRoot [32]byte, exists bool, err error) to align with the requirements of the slashing interchange standard https://ethereum-magicians.org/t/eip-3076-validator-client-interchange-format-slashing-protection/4883 EIP. It is possible we have a proposal history stored in the DB, but with a nil signing root. We handle this with a boolean.

**Which issues(s) does this PR fix?**

Part of #7813 
