### PR TITLE
Save cached state summaries on Stop()

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -332,6 +332,11 @@ func (s *Service) Stop() error {
 		}
 	}
 
+	// Save cached state summaries to the DB before stop.
+	if err := s.stateGen.SaveStateSummariesToDB(s.ctx); err != nil {
+		return err
+	}
+
 	// Save initial sync cached blocks to the DB before stop.
 	return s.beaconDB.SaveBlocks(s.ctx, s.getInitSyncBlocks())
 }

--- a/beacon-chain/state/stategen/migrate.go
+++ b/beacon-chain/state/stategen/migrate.go
@@ -107,10 +107,9 @@ func (s *State) MigrateToCold(ctx context.Context, fRoot [32]byte) error {
 	}
 
 	// Migrate all state summary objects from state summary cache to DB.
-	if err := s.beaconDB.SaveStateSummaries(ctx, s.stateSummaryCache.GetAll()); err != nil {
+	if err := s.SaveStateSummariesToDB(ctx); err != nil {
 		return err
 	}
-	s.stateSummaryCache.Clear()
 
 	// Update finalized info in memory.
 	fInfo, ok, err := s.epochBoundaryStateCache.getByRoot(fRoot)

--- a/beacon-chain/state/stategen/setter.go
+++ b/beacon-chain/state/stategen/setter.go
@@ -43,6 +43,17 @@ func (s *State) ForceCheckpoint(ctx context.Context, root []byte) error {
 	return s.beaconDB.SaveState(ctx, fs, root32)
 }
 
+// SaveStateSummariesToDB saves cached state summaries to DB.
+func (s *State) SaveStateSummariesToDB(ctx context.Context) error {
+	ctx, span := trace.StartSpan(ctx, "stateGen.SaveStateSummariesToDB")
+	defer span.End()
+	if err := s.beaconDB.SaveStateSummaries(ctx, s.stateSummaryCache.GetAll()); err != nil {
+		return err
+	}
+	s.stateSummaryCache.Clear()
+	return nil
+}
+
 // SaveStateSummary saves the relevant state summary for a block and its corresponding state slot in the
 // state summary cache.
 func (s *State) SaveStateSummary(_ context.Context, blk *ethpb.SignedBeaconBlock, blockRoot [32]byte) {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix


**What does this PR do? Why is it needed?**
One thing i realized as I was auditing state summary usages is that we do not save cached state summary objects upon shutting down beacon node. This triggers an asymmetric behavior where the beacon block is in the DB but state summary object is not in the DB on the very next restart

