### PR TITLE
Fix missing space in error message in account list

### DIFF
--- a/validator/accounts/wallet/wallet.go
+++ b/validator/accounts/wallet/wallet.go
@@ -47,7 +47,7 @@ const (
 var (
 	// ErrNoWalletFound signifies there was no wallet directory found on-disk.
 	ErrNoWalletFound = errors.New(
-		"no wallet found. You can create a new wallet with validator wallet create." +
+		"no wallet found. You can create a new wallet with validator wallet create. " +
 			"If you already did, perhaps you created a wallet in a custom directory, which you can specify using " +
 			"--wallet-dir=/path/to/my/wallet",
 	)


### PR DESCRIPTION
When validating account list, there was a missing space. This fixes that nitpick.
