### PR TITLE
Create Bucket If Not Exists When Fetching Proposal History

### DIFF
--- a/validator/db/kv/proposal_history_v2.go
+++ b/validator/db/kv/proposal_history_v2.go
@@ -53,9 +53,9 @@ func (store *Store) ProposalHistoryForSlot(ctx context.Context, publicKey [48]by
 	signingRoot := [32]byte{}
 	err = store.view(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(newHistoricProposalsBucket)
-		valBucket := bucket.Bucket(publicKey[:])
-		if valBucket == nil {
-			return fmt.Errorf("validator history empty for public key: %#x", publicKey)
+		valBucket, err := bucket.CreateBucketIfNotExists(publicKey[:])
+		if err != nil {
+			return fmt.Errorf("could not create bucket for public key %#x", publicKey[:])
 		}
 		signingRootBytes := valBucket.Get(bytesutil.Uint64ToBytesBigEndian(slot))
 		if signingRootBytes == nil {

--- a/validator/db/kv/proposal_history_v2.go
+++ b/validator/db/kv/proposal_history_v2.go
@@ -51,7 +51,7 @@ func (store *Store) ProposalHistoryForSlot(ctx context.Context, publicKey [48]by
 	var err error
 	var proposalExists bool
 	signingRoot := [32]byte{}
-	err = store.view(func(tx *bolt.Tx) error {
+	err = store.update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(newHistoricProposalsBucket)
 		valBucket, err := bucket.CreateBucketIfNotExists(publicKey[:])
 		if err != nil {

--- a/validator/db/kv/proposal_history_v2_test.go
+++ b/validator/db/kv/proposal_history_v2_test.go
@@ -22,12 +22,13 @@ func TestProposalHistoryForSlot_InitializesNewPubKeys(t *testing.T) {
 	}
 }
 
-func TestNewProposalHistoryForSlot_NilDB(t *testing.T) {
+func TestNewProposalHistoryForSlot_ReturnsNilIfNoHistory(t *testing.T) {
 	valPubkey := [48]byte{1, 2, 3}
 	db := setupDB(t, [][48]byte{})
 
-	_, _, err := db.ProposalHistoryForSlot(context.Background(), valPubkey, 0)
-	require.ErrorContains(t, "validator history empty for public key", err, "Unexpected error for nil DB")
+	_, proposalExists, err := db.ProposalHistoryForSlot(context.Background(), valPubkey, 0)
+	require.NoError(t, err)
+	assert.Equal(t, false, proposalExists)
 }
 
 func TestSaveProposalHistoryForSlot_OK(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Users running in dappnode version v1.0.2 of prysm are seeing issues when proposing due to not having a proposal history. This PR creates the bucket if the data does not exist. This is a hotfix because it is blocking proposals on mainnet for several users.
