### PR TITLE
Revert "Logging with `PadLevelText` to true"

### DIFF
--- a/beacon-chain/BUILD.bazel
+++ b/beacon-chain/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "@com_github_joonix_log//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
+        "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",
     ],
 )
 

--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/version"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 
 var appFlags = []cli.Flag{
@@ -124,13 +125,12 @@ func main() {
 		format := ctx.String(cmd.LogFormat.Name)
 		switch format {
 		case "text":
-			formatter := new(logrus.TextFormatter)
+			formatter := new(prefixed.TextFormatter)
 			formatter.TimestampFormat = "2006-01-02 15:04:05"
 			formatter.FullTimestamp = true
 			// If persistent log files are written - we disable the log messages coloring because
 			// the colors are ANSI codes and seen as gibberish in the log files.
 			formatter.DisableColors = ctx.String(cmd.LogFileName.Name) != ""
-			formatter.PadLevelText = true
 			logrus.SetFormatter(formatter)
 		case "fluentd":
 			f := joonix.NewFormatter()

--- a/validator/BUILD.bazel
+++ b/validator/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "@com_github_joonix_log//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
+        "@com_github_x_cray_logrus_prefixed_formatter//:go_default_library",
     ],
 )
 

--- a/validator/main.go
+++ b/validator/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prysmaticlabs/prysm/validator/node"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 
 var log = logrus.WithField("prefix", "main")
@@ -118,13 +119,12 @@ func main() {
 		format := ctx.String(cmd.LogFormat.Name)
 		switch format {
 		case "text":
-			formatter := new(logrus.TextFormatter)
+			formatter := new(prefixed.TextFormatter)
 			formatter.TimestampFormat = "2006-01-02 15:04:05"
 			formatter.FullTimestamp = true
 			// If persistent log files are written - we disable the log messages coloring because
 			// the colors are ANSI codes and seen as Gibberish in the log files.
 			formatter.DisableColors = ctx.String(cmd.LogFileName.Name) != ""
-			formatter.PadLevelText = true
 			logrus.SetFormatter(formatter)
 		case "fluentd":
 			f := joonix.NewFormatter()


### PR DESCRIPTION
Received late feedbacks from 2 that preferred the old format. The color and prefix placements were the main concerns. Given these late feedbacks, we were not at unanimous decision as we once thought. Reverting for the time being and exploring better alternates that will satisfy the both worlds