### PR TITLE
Round robin: half open interval in syncToFinalizedEpoch

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -69,10 +69,6 @@ func (s *Service) syncToFinalizedEpoch(ctx context.Context, genesis time.Time) e
 	if err != nil {
 		return err
 	}
-	// Step back one slot, to the last slot of the finalized epoch (we're at first slot of the next epoch).
-	if highestFinalizedSlot > 0 {
-		highestFinalizedSlot--
-	}
 	if s.chain.HeadSlot() >= highestFinalizedSlot {
 		// No need to sync, already synced to the finalized slot.
 		log.Debug("Already synced to finalized epoch")


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
- @shayzluf raised concerns about not including the last slot when reviewing #7999, so I've decided to double-check it.
- Since it is conventional in Golang is to use half-opened intervals for slices/ranges i.e. `[start, end)` (end not included), it is better to set highest expected slot for `syncToFinalizedEpoch` to be the start slot of the first non-finalized epoch (so, no need to step-back which was introduced in #7999, and **this PR reverts that change**)

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- Moreover, it seems that this step-back produces occasional issue with the current init-sync tests. It is not the problem of the code itself, rather than fragile tests, though. As I am reviewing tests right now, will make sure I look into that as well.
