### PR TITLE
Attestation aggregation: maxcover vs naive aggregation effectiveness test

### DIFF
--- a/shared/aggregation/attestations/BUILD.bazel
+++ b/shared/aggregation/attestations/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     deps = [
         "//shared/aggregation:go_default_library",
         "//shared/aggregation/testing:go_default_library",
+        "//shared/bls:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",

--- a/shared/aggregation/attestations/attestations_test.go
+++ b/shared/aggregation/attestations/attestations_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prysmaticlabs/go-ssz"
 	"github.com/prysmaticlabs/prysm/shared/aggregation"
 	aggtesting "github.com/prysmaticlabs/prysm/shared/aggregation/testing"
+	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
@@ -242,6 +243,83 @@ func TestAggregateAttestations_Aggregate(t *testing.T) {
 			})
 			defer resetCfg()
 			runner()
+		})
+	}
+}
+
+func TestAggregateAttestations_PerformanceComparison(t *testing.T) {
+	// Tests below are examples of cases where max-cover's greedy approach outperforms the original
+	// naive aggregation (which is very much dependent on order in which items are fed into it).
+	tests := []struct {
+		name     string
+		bitsList [][]byte
+	}{
+		{
+			name: "test1",
+			bitsList: [][]byte{
+				{0b00000100, 0b1},
+				{0b00000010, 0b1},
+				{0b00000001, 0b1},
+				{0b00011001, 0b1},
+			},
+		},
+		{
+			name: "test2",
+			bitsList: [][]byte{
+				{0b10010001, 0b1},
+				{0b00100000, 0b1},
+				{0b01101110, 0b1},
+			},
+		},
+		{
+			name: "test3",
+			bitsList: [][]byte{
+				{0b00100000, 0b00000011, 0b1},
+				{0b00011100, 0b11000000, 0b1},
+				{0b11111100, 0b00000000, 0b1},
+				{0b00000011, 0b10000000, 0b1},
+				{0b11100011, 0b00000000, 0b1},
+			},
+		},
+	}
+
+	scoreAtts := func(atts []*ethpb.Attestation) uint64 {
+		score := uint64(0)
+		sort.Slice(atts, func(i, j int) bool {
+			return atts[i].AggregationBits.Count() > atts[j].AggregationBits.Count()
+		})
+		// Score the best aggregate.
+		if len(atts) > 0 {
+			score = atts[0].AggregationBits.Count()
+		}
+		return score
+	}
+
+	generateAtts := func(bitsList [][]byte) []*ethpb.Attestation {
+		sign := bls.NewAggregateSignature().Marshal()
+		atts := make([]*ethpb.Attestation, 0)
+		for _, b := range bitsList {
+			atts = append(atts, &ethpb.Attestation{
+				AggregationBits: b,
+				Signature:       sign,
+			})
+		}
+		return atts
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			atts, err := NaiveAttestationAggregation(generateAtts(tt.bitsList))
+			require.NoError(t, err)
+			score1 := scoreAtts(atts)
+
+			atts, err = MaxCoverAttestationAggregation(generateAtts(tt.bitsList))
+			require.NoError(t, err)
+			score2 := scoreAtts(atts)
+
+			t.Logf("native = %d, max-cover: %d\n", score1, score2)
+			assert.Equal(t, true, score1 <= score2,
+				"max-cover failed to produce higher score (naive: %d, max-cover: %d)", score1, score2)
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
 - Naive aggregation heavily depends on the order of incoming partial attestations, this PR includes unit test confirming max-cover's better score regardless of the order items come in.
- Part of #7871

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
- Extracted from #7938
- cc @terencechain 