### PR TITLE
Attestation aggregation: removes redundant code from max-cover benchmarks

### DIFF
--- a/shared/aggregation/attestations/attestations_bench_test.go
+++ b/shared/aggregation/attestations/attestations_bench_test.go
@@ -30,63 +30,42 @@ func BenchmarkAggregateAttestations_Aggregate(b *testing.B) {
 	tests := []struct {
 		name   string
 		inputs []bitfield.Bitlist
-		want   []bitfield.Bitlist
 	}{
 		{
 			name:   "64 attestations with single bit set",
 			inputs: aggtesting.BitlistsWithSingleBitSet(64, bitlistLen),
-			want: []bitfield.Bitlist{
-				aggtesting.BitlistWithAllBitsSet(64),
-			},
 		},
 		{
 			name:   "64 attestations with 8 random bits set",
 			inputs: aggtesting.BitlistsWithMultipleBitSet(b, 64, bitlistLen, 8),
-			want: []bitfield.Bitlist{
-				aggtesting.BitlistWithAllBitsSet(64),
-			},
 		},
 		{
 			name:   "64 attestations with 16 random bits set",
 			inputs: aggtesting.BitlistsWithMultipleBitSet(b, 64, bitlistLen, 16),
-			want: []bitfield.Bitlist{
-				aggtesting.BitlistWithAllBitsSet(64),
-			},
 		},
 		{
 			name:   "64 attestations with 32 random bits set",
 			inputs: aggtesting.BitlistsWithMultipleBitSet(b, 64, bitlistLen, 32),
-			want: []bitfield.Bitlist{
-				aggtesting.BitlistWithAllBitsSet(64),
-			},
+		},
+		{
+			name:   "256 attestations with 32 random bits set",
+			inputs: aggtesting.BitlistsWithMultipleBitSet(b, 256, bitlistLen, 32),
 		},
 		{
 			name:   "128 attestations with single bit set",
 			inputs: aggtesting.BitlistsWithSingleBitSet(128, bitlistLen),
-			want: []bitfield.Bitlist{
-				aggtesting.BitlistWithAllBitsSet(128),
-			},
 		},
 		{
 			name:   "256 attestations with single bit set",
 			inputs: aggtesting.BitlistsWithSingleBitSet(256, bitlistLen),
-			want: []bitfield.Bitlist{
-				aggtesting.BitlistWithAllBitsSet(256),
-			},
 		},
 		{
 			name:   "512 attestations with single bit set",
 			inputs: aggtesting.BitlistsWithSingleBitSet(512, bitlistLen),
-			want: []bitfield.Bitlist{
-				aggtesting.BitlistWithAllBitsSet(512),
-			},
 		},
 		{
 			name:   "1024 attestations with single bit set",
 			inputs: aggtesting.BitlistsWithSingleBitSet(1024, bitlistLen),
-			want: []bitfield.Bitlist{
-				aggtesting.BitlistWithAllBitsSet(1024),
-			},
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

> Other / Cleanup

**What does this PR do? Why is it needed?**
- Removes redundant/unused code from the attestation aggregation benchmarks.

**Which issues(s) does this PR fix?**

Part of #7871

**Other notes for review**
- Extracted from #7938

