### PR TITLE
Update rules_go to v0.24.9 and golang to v1.15.6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,10 +89,10 @@ http_archive(
         # nogo check fails for certain third_party dependencies.
         "//third_party:io_bazel_rules_go.patch",
     ],
-    sha256 = "207fad3e6689135c5d8713e5a17ba9d1290238f47b9ba545b63d9303406209c6",
+    sha256 = "81eff5df9077783b18e93d0c7ff990d8ad7a3b8b3ca5b785e1c483aacdb342d7",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.7/rules_go-v0.24.7.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.7/rules_go-v0.24.7.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.9/rules_go-v0.24.9.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.9/rules_go-v0.24.9.tar.gz",
     ],
 )
 
@@ -156,7 +156,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.15.5",
+    go_version = "1.15.6",
     nogo = "@//:nogo",
 )
 


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
- `rules_go v0.24.9` https://github.com/bazelbuild/rules_go/releases/tag/v0.24.9 (which has an important fix for `TestMain()` https://github.com/bazelbuild/rules_go/pull/2716 I'll file a separate PR updating our `TestMain()s`).
- `golang v1.15.6`

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
I've confirmed that the issue we had with `TestMain()` due to bug in `rules_go` is fixed indeed:
![image](https://user-images.githubusercontent.com/188194/101177485-e7dd6400-3658-11eb-90fe-0c587d73bbe1.png)
