### PR TITLE
Update TestMain(): do not call os.Exit() explicitly

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,10 +89,10 @@ http_archive(
         # nogo check fails for certain third_party dependencies.
         "//third_party:io_bazel_rules_go.patch",
     ],
-    sha256 = "207fad3e6689135c5d8713e5a17ba9d1290238f47b9ba545b63d9303406209c6",
+    sha256 = "81eff5df9077783b18e93d0c7ff990d8ad7a3b8b3ca5b785e1c483aacdb342d7",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.7/rules_go-v0.24.7.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.7/rules_go-v0.24.7.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.9/rules_go-v0.24.9.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.9/rules_go-v0.24.9.tar.gz",
     ],
 )
 
@@ -156,7 +156,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.15.5",
+    go_version = "1.15.6",
     nogo = "@//:nogo",
 )
 

--- a/beacon-chain/blockchain/blockchain_test.go
+++ b/beacon-chain/blockchain/blockchain_test.go
@@ -2,18 +2,14 @@ package blockchain
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }

--- a/beacon-chain/cache/cache_test.go
+++ b/beacon-chain/cache/cache_test.go
@@ -1,17 +1,13 @@
 package cache
 
 import (
-	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableEth1DataVoteCache: true})
-		defer resetCfg()
-		return m.Run()
-	}
-	os.Exit(run())
+	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableEth1DataVoteCache: true})
+	defer resetCfg()
+	m.Run()
 }

--- a/beacon-chain/core/epoch/spectest/spectest_test.go
+++ b/beacon-chain/core/epoch/spectest/spectest_test.go
@@ -1,21 +1,17 @@
 package spectest
 
 import (
-	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		prevConfig := params.BeaconConfig().Copy()
-		defer params.OverrideBeaconConfig(prevConfig)
-		c := params.BeaconConfig()
-		c.MinGenesisActiveValidatorCount = 16384
-		params.OverrideBeaconConfig(c)
+	prevConfig := params.BeaconConfig().Copy()
+	defer params.OverrideBeaconConfig(prevConfig)
+	c := params.BeaconConfig()
+	c.MinGenesisActiveValidatorCount = 16384
+	params.OverrideBeaconConfig(c)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }

--- a/beacon-chain/p2p/peers/peers_test.go
+++ b/beacon-chain/p2p/peers/peers_test.go
@@ -2,7 +2,6 @@ package peers_test
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
@@ -11,24 +10,21 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
-			EnablePeerScorer: true,
-		})
-		defer resetCfg()
+	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
+		EnablePeerScorer: true,
+	})
+	defer resetCfg()
 
-		resetFlags := flags.Get()
-		flags.Init(&flags.GlobalFlags{
-			BlockBatchLimit:            64,
-			BlockBatchLimitBurstFactor: 10,
-		})
-		defer func() {
-			flags.Init(resetFlags)
-		}()
-		return m.Run()
-	}
-	os.Exit(run())
+	resetFlags := flags.Get()
+	flags.Init(&flags.GlobalFlags{
+		BlockBatchLimit:            64,
+		BlockBatchLimitBurstFactor: 10,
+	})
+	defer func() {
+		flags.Init(resetFlags)
+	}()
+	m.Run()
 }

--- a/beacon-chain/p2p/peers/scorers/scorers_test.go
+++ b/beacon-chain/p2p/peers/scorers/scorers_test.go
@@ -3,7 +3,6 @@ package scorers_test
 import (
 	"io/ioutil"
 	"math"
-	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
@@ -13,26 +12,23 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
-			EnablePeerScorer: true,
-		})
-		defer resetCfg()
+	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
+		EnablePeerScorer: true,
+	})
+	defer resetCfg()
 
-		resetFlags := flags.Get()
-		flags.Init(&flags.GlobalFlags{
-			BlockBatchLimit:            64,
-			BlockBatchLimitBurstFactor: 10,
-		})
-		defer func() {
-			flags.Init(resetFlags)
-		}()
-		return m.Run()
-	}
-	os.Exit(run())
+	resetFlags := flags.Get()
+	flags.Init(&flags.GlobalFlags{
+		BlockBatchLimit:            64,
+		BlockBatchLimitBurstFactor: 10,
+	})
+	defer func() {
+		flags.Init(resetFlags)
+	}()
+	m.Run()
 }
 
 // roundScore returns score rounded in accordance with the score manager's rounding factor.

--- a/beacon-chain/powchain/powchain_test.go
+++ b/beacon-chain/powchain/powchain_test.go
@@ -2,18 +2,14 @@ package powchain
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }

--- a/beacon-chain/rpc/beacon/beacon_test.go
+++ b/beacon-chain/rpc/beacon/beacon_test.go
@@ -1,7 +1,6 @@
 package beacon
 
 import (
-	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
@@ -9,21 +8,18 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		// Use minimal config to reduce test setup time.
-		prevConfig := params.BeaconConfig().Copy()
-		defer params.OverrideBeaconConfig(prevConfig)
-		params.OverrideBeaconConfig(params.MinimalSpecConfig())
+	// Use minimal config to reduce test setup time.
+	prevConfig := params.BeaconConfig().Copy()
+	defer params.OverrideBeaconConfig(prevConfig)
+	params.OverrideBeaconConfig(params.MinimalSpecConfig())
 
-		resetFlags := flags.Get()
-		flags.Init(&flags.GlobalFlags{
-			MinimumSyncPeers: 30,
-		})
-		defer func() {
-			flags.Init(resetFlags)
-		}()
+	resetFlags := flags.Get()
+	flags.Init(&flags.GlobalFlags{
+		MinimumSyncPeers: 30,
+	})
+	defer func() {
+		flags.Init(resetFlags)
+	}()
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }

--- a/beacon-chain/rpc/validator/validator_test.go
+++ b/beacon-chain/rpc/validator/validator_test.go
@@ -2,7 +2,6 @@ package validator
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -10,15 +9,12 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
-		// Use minimal config to reduce test setup time.
-		prevConfig := params.BeaconConfig().Copy()
-		defer params.OverrideBeaconConfig(prevConfig)
-		params.OverrideBeaconConfig(params.MinimalSpecConfig())
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
+	// Use minimal config to reduce test setup time.
+	prevConfig := params.BeaconConfig().Copy()
+	defer params.OverrideBeaconConfig(prevConfig)
+	params.OverrideBeaconConfig(params.MinimalSpecConfig())
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }

--- a/beacon-chain/state/stateutil/stateutil_test.go
+++ b/beacon-chain/state/stateutil/stateutil_test.go
@@ -1,17 +1,13 @@
 package stateutil_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableSSZCache: true})
-		defer resetCfg()
-		return m.Run()
-	}
-	os.Exit(run())
+	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{EnableSSZCache: true})
+	defer resetCfg()
+	m.Run()
 }

--- a/beacon-chain/sync/initial-sync/initial_sync_test.go
+++ b/beacon-chain/sync/initial-sync/initial_sync_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -53,27 +52,24 @@ type peerData struct {
 }
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
-			EnablePeerScorer: true,
-		})
-		defer resetCfg()
+	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
+		EnablePeerScorer: true,
+	})
+	defer resetCfg()
 
-		resetFlags := flags.Get()
-		flags.Init(&flags.GlobalFlags{
-			BlockBatchLimit:            64,
-			BlockBatchLimitBurstFactor: 10,
-		})
-		defer func() {
-			flags.Init(resetFlags)
-		}()
+	resetFlags := flags.Get()
+	flags.Init(&flags.GlobalFlags{
+		BlockBatchLimit:            64,
+		BlockBatchLimitBurstFactor: 10,
+	})
+	defer func() {
+		flags.Init(resetFlags)
+	}()
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }
 
 func initializeTestServices(t *testing.T, blocks []uint64, peers []*peerData) (*mock.ChainService, *p2pt.TestP2P, db.Database) {

--- a/beacon-chain/sync/sync_test.go
+++ b/beacon-chain/sync/sync_test.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/flags"
@@ -10,19 +9,16 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		resetFlags := flags.Get()
-		flags.Init(&flags.GlobalFlags{
-			BlockBatchLimit:            64,
-			BlockBatchLimitBurstFactor: 10,
-		})
-		defer func() {
-			flags.Init(resetFlags)
-		}()
-		return m.Run()
-	}
-	os.Exit(run())
+	resetFlags := flags.Get()
+	flags.Init(&flags.GlobalFlags{
+		BlockBatchLimit:            64,
+		BlockBatchLimitBurstFactor: 10,
+	})
+	defer func() {
+		flags.Init(resetFlags)
+	}()
+	m.Run()
 }

--- a/shared/aggregation/attestations/attestations_test.go
+++ b/shared/aggregation/attestations/attestations_test.go
@@ -3,7 +3,6 @@ package attestations
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"sort"
 	"testing"
 
@@ -20,16 +19,13 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
-		resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
-			AttestationAggregationStrategy: string(MaxCoverAggregation),
-		})
-		defer resetCfg()
-		return m.Run()
-	}
-	os.Exit(run())
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
+	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
+		AttestationAggregationStrategy: string(MaxCoverAggregation),
+	})
+	defer resetCfg()
+	m.Run()
 }
 
 func TestAggregateAttestations_AggregatePair(t *testing.T) {

--- a/shared/slotutil/slotutil_test.go
+++ b/shared/slotutil/slotutil_test.go
@@ -2,18 +2,14 @@ package slotutil
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }

--- a/slasher/beaconclient/service_test.go
+++ b/slasher/beaconclient/service_test.go
@@ -2,7 +2,6 @@ package beaconclient
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -14,11 +13,8 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }

--- a/slasher/db/kv/kv_test.go
+++ b/slasher/db/kv/kv_test.go
@@ -2,7 +2,6 @@ package kv
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -10,13 +9,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }
 
 func setupDB(t testing.TB) *Store {

--- a/slasher/detection/attestations/attestations_test.go
+++ b/slasher/detection/attestations/attestations_test.go
@@ -2,18 +2,14 @@ package attestations
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }

--- a/slasher/detection/proposals/proposals_test.go
+++ b/slasher/detection/proposals/proposals_test.go
@@ -2,18 +2,14 @@ package proposals
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }

--- a/slasher/node/node_test.go
+++ b/slasher/node/node_test.go
@@ -16,13 +16,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }
 
 // Test that slasher node can close.

--- a/slasher/rpc/rpc_test.go
+++ b/slasher/rpc/rpc_test.go
@@ -2,18 +2,14 @@ package rpc
 
 import (
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }

--- a/tools/bootnode/bootnode_test.go
+++ b/tools/bootnode/bootnode_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -20,13 +19,10 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	run := func() int {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetOutput(ioutil.Discard)
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
 
-		return m.Run()
-	}
-	os.Exit(run())
+	m.Run()
 }
 
 func TestBootnode_OK(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
- Due to issue in `rules_go` we had to wrap `TestMain` contents into local functions (see #7814)
- The issue has been resolved in `rules_go` (#8045), so we can get rid of those wrapper fn's.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

