### PR TITLE
fix(grpcHeaders): accept values with "=" symbols

### DIFF
--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -105,5 +105,6 @@ go_test(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@in_gopkg_d4l3k_messagediff_v1//:go_default_library",
+        "@org_golang_google_grpc//metadata:go_default_library",
     ],
 )

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -144,11 +144,11 @@ func (v *ValidatorService) Start() {
 	for _, hdr := range v.grpcHeaders {
 		if hdr != "" {
 			ss := strings.Split(hdr, "=")
-			if len(ss) != 2 {
-				log.Warnf("Incorrect gRPC header flag format. Skipping %v", hdr)
+			if len(ss) < 2 {
+				log.Warnf("Incorrect gRPC header flag format. Skipping %v", ss[0])
 				continue
 			}
-			v.ctx = metadata.AppendToOutgoingContext(v.ctx, ss[0], ss[1])
+			v.ctx = metadata.AppendToOutgoingContext(v.ctx, ss[0], strings.Join(ss[1:], "="))
 		}
 	}
 

--- a/validator/client/service_test.go
+++ b/validator/client/service_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 	logTest "github.com/sirupsen/logrus/hooks/test"
+	"google.golang.org/grpc/metadata"
 )
 
 var _ shared.Service = (*ValidatorService)(nil)
@@ -67,4 +69,39 @@ func TestLifecycle_Insecure(t *testing.T) {
 func TestStatus_NoConnectionError(t *testing.T) {
 	validatorService := &ValidatorService{}
 	assert.ErrorContains(t, "no connection", validatorService.Status())
+}
+
+func TestStart_GrpcHeaders(t *testing.T) {
+	hook := logTest.NewGlobal()
+	// Use canceled context so that the run function exits immediately.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	for input, output := range map[string][]string{
+		"should-break": []string{},
+		"key=value":    []string{"key", "value"},
+		"":             []string{},
+		",":            []string{},
+		"key=value,Authorization=Q=": []string{
+			"key", "value", "Authorization", "Q=",
+		},
+		"Authorization=this is a valid value": []string{
+			"Authorization", "this is a valid value",
+		},
+	} {
+		validatorService := &ValidatorService{
+			ctx:         ctx,
+			cancel:      cancel,
+			endpoint:    "merkle tries",
+			grpcHeaders: strings.Split(input, ","),
+		}
+		validatorService.Start()
+		md, _ := metadata.FromOutgoingContext(validatorService.ctx)
+		if input == "should-break" {
+			require.LogsContain(t, hook, "Incorrect gRPC header flag format. Skipping should-break")
+		} else if len(output) == 0 {
+			require.DeepEqual(t, md, metadata.MD(nil))
+		} else {
+			require.DeepEqual(t, md, metadata.Pairs(output...))
+		}
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Before this commit, it was not possible to pass in base64-encoded
content as a header value if it contained an equals sign. This commit
changes the behavior slightly. Rather than ignore key/value pairs where
the value happens to have an equals sign, we assume the first equals
sign delimits the key from the value and pass in the rest of the value
as-is.

Also, instead of printing the header name along with its value, we only
print the name, so there is less risk of leaking information into logs
that shouldn't be there.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

This has not been tested in the context of the full validator client.
Instead, a small example was made to demonstrate the feasibility. The
example is shown here:

```go
package main

import (
	"log"
	"os"
	"strings"

	"github.com/davecgh/go-spew/spew"
	"github.com/urfave/cli/v2"
)

type Config struct {
	GrpcHeadersFlag string
}

func main() {
	app := &cli.App{
		Action: func(c *cli.Context) error {
			for _, hdr := range strings.Split(c.String("grpc-headers"), ",") {
				if hdr != "" {
					ss := strings.Split(hdr, "=")
					spew.Dump(ss[0])
					spew.Dump(strings.Join(ss[1:], "="))
				}
			}
			return nil
		},
		Flags: []cli.Flag{
			&cli.StringFlag{
				Name: "grpc-headers",
				Usage: "A comma-separated list of key value pairs to pass as gRPC headers for all gRPC " +
					"calls. Example: --grpc-headers=key=value",
			},
		},
	}

	err := app.Run(os.Args)
	if err != nil {
		log.Fatal(err)
	}
}
```

Example invocation:

```command
❯ go run main.go --grpc-headers=key=value,Authorization="Basic $(echo -n hello:world | base64)"
(string) (len=3) "key"
(string) (len=5) "value"
(string) (len=13) "Authorization"
(string) (len=22) "Basic aGVsbG86d29ybGQ="
```
