### PR TITLE
Add EIP-3076 Invariants for Proposer Slashing Protection

### DIFF
--- a/validator/client/propose_protect.go
+++ b/validator/client/propose_protect.go
@@ -27,7 +27,7 @@ func (v *validator) preBlockSignValidations(ctx context.Context, pubKey [48]byte
 	}
 	if exists && lowestSignedProposalSlot >= block.Slot {
 		return fmt.Errorf(
-			"could not sign block lower than lowest signed proposal in db, lowest signed proposal: %d >= block slot: %d",
+			"could not sign block with slot <= lowest signed slot in db, lowest signed slot: %d >= block slot: %d",
 			lowestSignedProposalSlot,
 			block.Slot,
 		)

--- a/validator/client/propose_protect_test.go
+++ b/validator/client/propose_protect_test.go
@@ -69,8 +69,12 @@ func TestPreBlockSignLocalValidation(t *testing.T) {
 	pubKeyBytes := [48]byte{}
 	copy(pubKeyBytes[:], validatorKey.PublicKey().Marshal())
 
+	// We save a proposal at slot 1 as our lowest proposal.
+	err := validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, 1, []byte{1})
+	require.NoError(t, err)
+
 	// We save a proposal at slot 10 with a dummy signing root.
-	err := validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, 10, []byte{1})
+	err = validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, 10, []byte{1})
 	require.NoError(t, err)
 	pubKey := [48]byte{}
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())


### PR DESCRIPTION
Part of #7813, this PR adds the following invariant to runtime:

`Refuse to sign any block with slot <= min(b.slot for b in data.signed_blocks if b.pubkey == proposer_pubkey)`
