### PR TITLE
Save Slashable Keys to Disk in the Validator Client

### DIFF
--- a/validator/db/iface/interface.go
+++ b/validator/db/iface/interface.go
@@ -37,9 +37,13 @@ type ValidatorDB interface {
 	SaveLowestSignedTargetEpoch(ctx context.Context, publicKey [48]byte, epoch uint64) error
 	SaveLowestSignedSourceEpoch(ctx context.Context, publicKey [48]byte, epoch uint64) error
 
-	// New attestation store methods.
+	// Attestation history related methods.
 	AttestationHistoryForPubKeysV2(ctx context.Context, publicKeys [][48]byte) (map[[48]byte]kv.EncHistoryData, error)
 	SaveAttestationHistoryForPubKeysV2(ctx context.Context, historyByPubKeys map[[48]byte]kv.EncHistoryData) error
 	SaveAttestationHistoryForPubKeyV2(ctx context.Context, pubKey [48]byte, history kv.EncHistoryData) error
 	AttestedPublicKeys(ctx context.Context) ([][48]byte, error)
+
+	// Methods to store and read slashable keys as detected by slashing protection imports.
+	SlashablePublicKeys(ctx context.Context) ([][48]byte, error)
+	SaveSlashablePublicKeys(ctx context.Context, publicKeys [][48]byte) error
 }

--- a/validator/db/kv/BUILD.bazel
+++ b/validator/db/kv/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "historical_attestations.go",
         "proposal_history_v2.go",
         "schema.go",
+        "slashable_keys.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/validator/db/kv",
     visibility = ["//validator:__subpackages__"],
@@ -37,6 +38,7 @@ go_test(
         "genesis_test.go",
         "historical_attestations_test.go",
         "proposal_history_v2_test.go",
+        "slashable_keys_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -95,6 +95,7 @@ func NewKVStore(dirPath string, pubKeys [][48]byte) (*Store, error) {
 			lowestSignedTargetBucket,
 			lowestSignedProposalsBucket,
 			highestSignedProposalsBucket,
+			slashablePublicKeysBucket,
 		)
 	}); err != nil {
 		return nil, err

--- a/validator/db/kv/schema.go
+++ b/validator/db/kv/schema.go
@@ -5,12 +5,11 @@ var (
 	genesisInfoBucket = []byte("genesis-info-bucket")
 
 	// Validator slashing protection from double proposals.
-	historicProposalsBucket = []byte("proposal-history-bucket")
-	// Validator slashing protection from double proposals.
+	historicProposalsBucket    = []byte("proposal-history-bucket")
 	newHistoricProposalsBucket = []byte("proposal-history-bucket-interchange")
+
 	// Validator slashing protection from slashable attestations.
-	historicAttestationsBucket = []byte("attestation-history-bucket")
-	// New Validator slashing protection from slashable attestations.
+	historicAttestationsBucket    = []byte("attestation-history-bucket")
 	newHistoricAttestationsBucket = []byte("attestation-history-bucket-interchange")
 
 	// Buckets for lowest signed source and target epoch for individual validator.
@@ -20,6 +19,9 @@ var (
 	// Lowest and highest signed proposals.
 	lowestSignedProposalsBucket  = []byte("lowest-signed-proposals-bucket")
 	highestSignedProposalsBucket = []byte("highest-signed-proposals-bucket")
+
+	// Slashable public keys bucket.
+	slashablePublicKeysBucket = []byte("slashable-public-keys")
 
 	// Genesis validators root bucket key.
 	genesisValidatorsRootKey = []byte("genesis-val-root")

--- a/validator/db/kv/slashable_keys.go
+++ b/validator/db/kv/slashable_keys.go
@@ -1,0 +1,34 @@
+package kv
+
+import (
+	"context"
+	"fmt"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+func (s *Store) SlashablePublicKeys(ctx context.Context) ([][48]byte, error) {
+	var genValRoot []byte
+	err := s.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(genesisInfoBucket)
+		enc := bkt.Get(genesisValidatorsRootKey)
+		if len(enc) == 0 {
+			return nil
+		}
+		genValRoot = enc
+		return nil
+	})
+	return nil, err
+}
+func (s *Store) SaveSlashablePublicKeys(ctx context.Context) ([][48]byte, error) {
+	err := s.db.Update(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(genesisInfoBucket)
+		enc := bkt.Get(genesisValidatorsRootKey)
+		if len(enc) != 0 {
+			return fmt.Errorf("cannot overwite existing genesis validators root: %#x", enc)
+		}
+		return bkt.Put(genesisValidatorsRootKey, nil)
+	})
+	_ = err
+	return nil, nil
+}

--- a/validator/db/kv/slashable_keys.go
+++ b/validator/db/kv/slashable_keys.go
@@ -2,33 +2,42 @@ package kv
 
 import (
 	"context"
-	"fmt"
 
 	bolt "go.etcd.io/bbolt"
+	"go.opencensus.io/trace"
 )
 
 func (s *Store) SlashablePublicKeys(ctx context.Context) ([][48]byte, error) {
-	var genValRoot []byte
-	err := s.db.View(func(tx *bolt.Tx) error {
-		bkt := tx.Bucket(genesisInfoBucket)
-		enc := bkt.Get(genesisValidatorsRootKey)
-		if len(enc) == 0 {
+	ctx, span := trace.StartSpan(ctx, "Validator.SlashablePublicKeys")
+	defer span.End()
+	var err error
+	publicKeys := make([][48]byte, 0)
+	err = s.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(slashablePublicKeysBucket)
+		return bucket.ForEach(func(key []byte, _ []byte) error {
+			if key != nil {
+				pubKeyBytes := [48]byte{}
+				copy(pubKeyBytes[:], key)
+				publicKeys = append(publicKeys, pubKeyBytes)
+			}
 			return nil
+		})
+	})
+	return publicKeys, err
+}
+
+func (s *Store) SaveSlashablePublicKeys(ctx context.Context, publicKeys [][48]byte) error {
+	ctx, span := trace.StartSpan(ctx, "Validator.SaveSlashablePublicKeys")
+	defer span.End()
+	return s.db.Update(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(slashablePublicKeysBucket)
+		for _, pubKey := range publicKeys {
+			// We write the public key to disk in the bucket. The value written for the key does not
+			// matter as we'll only be looking at the keys in the bucket when fetching from disk.
+			if err := bkt.Put(pubKey[:], []byte{1}); err != nil {
+				return err
+			}
 		}
-		genValRoot = enc
 		return nil
 	})
-	return nil, err
-}
-func (s *Store) SaveSlashablePublicKeys(ctx context.Context) ([][48]byte, error) {
-	err := s.db.Update(func(tx *bolt.Tx) error {
-		bkt := tx.Bucket(genesisInfoBucket)
-		enc := bkt.Get(genesisValidatorsRootKey)
-		if len(enc) != 0 {
-			return fmt.Errorf("cannot overwite existing genesis validators root: %#x", enc)
-		}
-		return bkt.Put(genesisValidatorsRootKey, nil)
-	})
-	_ = err
-	return nil, nil
 }

--- a/validator/db/kv/slashable_keys.go
+++ b/validator/db/kv/slashable_keys.go
@@ -7,6 +7,8 @@ import (
 	"go.opencensus.io/trace"
 )
 
+// SlashablePublicKeys returns keys that were marked as slashable during EIP-3076 slashing
+// protection imports, ensuring that we can prevent these keys from having duties at runtime.
 func (s *Store) SlashablePublicKeys(ctx context.Context) ([][48]byte, error) {
 	ctx, span := trace.StartSpan(ctx, "Validator.SlashablePublicKeys")
 	defer span.End()
@@ -26,6 +28,8 @@ func (s *Store) SlashablePublicKeys(ctx context.Context) ([][48]byte, error) {
 	return publicKeys, err
 }
 
+// SaveSlashablePublicKeys stores a list of slashable public keys that
+// were determined during EIP-3076 slashing protection imports.
 func (s *Store) SaveSlashablePublicKeys(ctx context.Context, publicKeys [][48]byte) error {
 	ctx, span := trace.StartSpan(ctx, "Validator.SaveSlashablePublicKeys")
 	defer span.End()

--- a/validator/db/kv/slashable_keys_test.go
+++ b/validator/db/kv/slashable_keys_test.go
@@ -1,0 +1,42 @@
+package kv
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestStore_SlashablePublicKeys(t *testing.T) {
+	ctx := context.Background()
+	numValidators := 100
+	publicKeys := make([][48]byte, numValidators)
+	for i := 0; i < numValidators; i++ {
+		key := [48]byte{}
+		copy(key[:], fmt.Sprintf("%d", i))
+		publicKeys[i] = key
+	}
+
+	// No slashable keys returns empty.
+	validatorDB := setupDB(t, publicKeys)
+	received, err := validatorDB.SlashablePublicKeys(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(received))
+
+	// Save half of the public keys as as slashable and attempt to retrieve.
+	err = validatorDB.SaveSlashablePublicKeys(ctx, publicKeys[:50])
+	require.NoError(t, err)
+	received, err = validatorDB.SlashablePublicKeys(ctx)
+
+	// Keys are not guaranteed to be ordered, so we create a map for comparisons.
+	want := make(map[[48]byte]bool)
+	for _, pubKey := range publicKeys[:50] {
+		want[pubKey] = true
+	}
+	for _, pubKey := range received {
+		ok := want[pubKey]
+		require.Equal(t, true, ok)
+	}
+}

--- a/validator/db/kv/slashable_keys_test.go
+++ b/validator/db/kv/slashable_keys_test.go
@@ -29,6 +29,7 @@ func TestStore_SlashablePublicKeys(t *testing.T) {
 	err = validatorDB.SaveSlashablePublicKeys(ctx, publicKeys[:50])
 	require.NoError(t, err)
 	received, err = validatorDB.SlashablePublicKeys(ctx)
+	require.NoError(t, err)
 
 	// Keys are not guaranteed to be ordered, so we create a map for comparisons.
 	want := make(map[[48]byte]bool)

--- a/validator/slashing-protection/local/standard-protection-format/import.go
+++ b/validator/slashing-protection/local/standard-protection-format/import.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/validator/db"
 	"github.com/prysmaticlabs/prysm/validator/db/kv"
-	"github.com/prysmaticlabs/prysm/validator/slashing-protection/local/attesting-history"
+	attestinghistory "github.com/prysmaticlabs/prysm/validator/slashing-protection/local/attesting-history"
 )
 
 // ImportStandardProtectionJSON takes in EIP-3076 compliant JSON file used for slashing protection
@@ -81,19 +81,11 @@ func ImportStandardProtectionJSON(ctx context.Context, validatorDB db.Database, 
 	if err != nil {
 		return errors.Wrap(err, "could not filter slashable attester public keys from JSON data")
 	}
-	slashableKeys := make([][48]byte, 0, len(slashableAttesterKeys)+len(slashableProposerKeys))
 	for _, pubKey := range slashableProposerKeys {
 		delete(proposalHistoryByPubKey, pubKey)
-		slashableKeys = append(slashableKeys, pubKey)
 	}
 	for _, pubKey := range slashableAttesterKeys {
 		delete(attestingHistoryByPubKey, pubKey)
-		slashableKeys = append(slashableKeys, pubKey)
-	}
-
-	// Save keys that were found to be slashable.
-	if err := validatorDB.SaveSlashablePublicKeys(ctx, slashableKeys); err != nil {
-		return err
 	}
 
 	// We save the histories to disk as atomic operations, ensuring that this only occurs

--- a/validator/slashing-protection/local/standard-protection-format/import.go
+++ b/validator/slashing-protection/local/standard-protection-format/import.go
@@ -81,11 +81,19 @@ func ImportStandardProtectionJSON(ctx context.Context, validatorDB db.Database, 
 	if err != nil {
 		return errors.Wrap(err, "could not filter slashable attester public keys from JSON data")
 	}
+	slashableKeys := make([][48]byte, 0, len(slashableAttesterKeys)+len(slashableProposerKeys))
 	for _, pubKey := range slashableProposerKeys {
 		delete(proposalHistoryByPubKey, pubKey)
+		slashableKeys = append(slashableKeys, pubKey)
 	}
 	for _, pubKey := range slashableAttesterKeys {
 		delete(attestingHistoryByPubKey, pubKey)
+		slashableKeys = append(slashableKeys, pubKey)
+	}
+
+	// Save keys that were found to be slashable.
+	if err := validatorDB.SaveSlashablePublicKeys(ctx, slashableKeys); err != nil {
+		return err
 	}
 
 	// We save the histories to disk as atomic operations, ensuring that this only occurs


### PR DESCRIPTION
This is part of #7813. This PR adds DB methods to save and retrieve slashable keys to and from disk. This is used during slashing protection JSON imports, in case we find any keys that are slashable from the incoming JSON. In the next PR, we can call these DB methods at runtime to prevent those blacklisted keys from performing duties in the validator client.

The scope of this PR is only the DB methods with tests.