### PR TITLE
Prevent Slashable Public Keys from Having Duties at Runtime

### DIFF
--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -181,6 +181,16 @@ func (v *ValidatorService) Start() {
 		return
 	}
 
+	sPubKeys, err := v.db.SlashablePublicKeys(v.ctx)
+	if err != nil {
+		log.Errorf("Could not read slashable public keys from disk: %v", err)
+		return
+	}
+	slashablePublicKeys := make(map[[48]byte]bool)
+	for _, pubKey := range sPubKeys {
+		slashablePublicKeys[pubKey] = true
+	}
+
 	v.validator = &validator{
 		db:                             v.db,
 		validatorClient:                ethpb.NewBeaconNodeValidatorClient(v.conn),
@@ -200,6 +210,7 @@ func (v *ValidatorService) Start() {
 		useWeb:                         v.useWeb,
 		walletInitializedFeed:          v.walletInitializedFeed,
 		graffitiStruct:                 v.graffitiStruct,
+		slashablePublicKeys:            slashablePublicKeys,
 	}
 	go run(v.ctx, v.validator)
 	go v.recheckKeys(v.ctx)

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -728,7 +728,8 @@ func TestUpdateDuties_OK(t *testing.T) {
 	assert.Equal(t, resp.Duties[0].ValidatorIndex, v.duties.Duties[0].ValidatorIndex, "Unexpected validator assignments")
 }
 
-func TestUpdateDuties_OK_FilterSlahablePublicKeys_AllKeys(t *testing.T) {
+func TestUpdateDuties_OK_FilterSlahablePublicKeys(t *testing.T) {
+	hook := logTest.NewGlobal()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock.NewMockBeaconNodeValidatorClient(ctrl)
@@ -736,34 +737,26 @@ func TestUpdateDuties_OK_FilterSlahablePublicKeys_AllKeys(t *testing.T) {
 
 	numValidators := 10
 	keysMap := make(map[[48]byte]bls.SecretKey)
+	slashablePublicKeys := make(map[[48]byte]bool)
 	for i := 0; i < numValidators; i++ {
 		priv, err := bls.RandKey()
 		require.NoError(t, err)
 		pubKey := [48]byte{}
 		copy(pubKey[:], priv.PublicKey().Marshal())
 		keysMap[pubKey] = priv
+		slashablePublicKeys[pubKey] = true
 	}
-
-	slashablePublicKeys :=
 
 	km := &mockKeymanager{
 		keysMap: keysMap,
 	}
 	resp := &ethpb.DutiesResponse{
-		Duties: []*ethpb.DutiesResponse_Duty{
-			{
-				AttesterSlot:   params.BeaconConfig().SlotsPerEpoch,
-				ValidatorIndex: 200,
-				CommitteeIndex: 100,
-				Committee:      []uint64{0, 1, 2, 3},
-				PublicKey:      []byte("testPubKey_1"),
-				ProposerSlots:  []uint64{params.BeaconConfig().SlotsPerEpoch + 1},
-			},
-		},
+		Duties: []*ethpb.DutiesResponse_Duty{},
 	}
 	v := validator{
-		keyManager:      km,
-		validatorClient: client,
+		keyManager:          km,
+		validatorClient:     client,
+		slashablePublicKeys: slashablePublicKeys,
 	}
 	client.EXPECT().GetDuties(
 		gomock.Any(),
@@ -781,10 +774,9 @@ func TestUpdateDuties_OK_FilterSlahablePublicKeys_AllKeys(t *testing.T) {
 	).Return(nil, nil)
 
 	require.NoError(t, v.UpdateDuties(context.Background(), slot), "Could not update assignments")
-	assert.Equal(t, params.BeaconConfig().SlotsPerEpoch+1, v.duties.Duties[0].ProposerSlots[0], "Unexpected validator assignments")
-	assert.Equal(t, params.BeaconConfig().SlotsPerEpoch, v.duties.Duties[0].AttesterSlot, "Unexpected validator assignments")
-	assert.Equal(t, resp.Duties[0].CommitteeIndex, v.duties.Duties[0].CommitteeIndex, "Unexpected validator assignments")
-	assert.Equal(t, resp.Duties[0].ValidatorIndex, v.duties.Duties[0].ValidatorIndex, "Unexpected validator assignments")
+	for range slashablePublicKeys {
+		assert.LogsContain(t, hook, "Not including slashable public key in request")
+	}
 }
 
 func TestUpdateProtections_OK(t *testing.T) {

--- a/validator/slashing-protection/local/standard-protection-format/import.go
+++ b/validator/slashing-protection/local/standard-protection-format/import.go
@@ -81,11 +81,19 @@ func ImportStandardProtectionJSON(ctx context.Context, validatorDB db.Database, 
 	if err != nil {
 		return errors.Wrap(err, "could not filter slashable attester public keys from JSON data")
 	}
+
+	slashablePublicKeys := make([][48]byte, 0, len(slashableAttesterKeys)+len(slashableProposerKeys))
 	for _, pubKey := range slashableProposerKeys {
 		delete(proposalHistoryByPubKey, pubKey)
+		slashablePublicKeys = append(slashablePublicKeys, pubKey)
 	}
 	for _, pubKey := range slashableAttesterKeys {
 		delete(attestingHistoryByPubKey, pubKey)
+		slashablePublicKeys = append(slashablePublicKeys, pubKey)
+	}
+
+	if err := validatorDB.SaveSlashablePublicKeys(ctx, slashablePublicKeys); err != nil {
+		return errors.Wrap(err, "could not save slashable public keys to database")
 	}
 
 	// We save the histories to disk as atomic operations, ensuring that this only occurs


### PR DESCRIPTION
Part of #7813, this PR prevents us from updating duties for public keys that are determined slashable in our database as part of slashing protection EIP-3076 imports. During UpdateDuties() in the validator client, we prevent requesting duties for validator keys that are considered slashable in our validator database, and we log a warning to the user.