### PR TITLE
Validator client logs time left to next duty

### DIFF
--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
         "aggregate_test.go",
         "attest_protect_test.go",
         "attest_test.go",
+        "log_test.go",
         "metrics_test.go",
         "propose_protect_test.go",
         "propose_test.go",

--- a/validator/client/log.go
+++ b/validator/client/log.go
@@ -2,9 +2,13 @@ package client
 
 import (
 	"fmt"
+	"time"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/timeutils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -33,4 +37,44 @@ func (v *validator) LogAttestationsSubmitted() {
 	}
 
 	v.attLogs = make(map[[32]byte]*attSubmitted)
+}
+
+func (v *validator) LogNextDutyCountDown(slot uint64) error {
+	var nextDutySlot uint64
+	var role string
+	for _, duty := range v.duties.CurrentEpochDuties {
+		if duty.AttesterSlot > slot && (nextDutySlot > duty.AttesterSlot || nextDutySlot == 0) {
+			nextDutySlot = duty.AttesterSlot
+			role = "attester"
+		}
+		for _, proposerSlot := range duty.ProposerSlots {
+			if proposerSlot > slot && (nextDutySlot > proposerSlot || nextDutySlot == 0) {
+				nextDutySlot = proposerSlot
+				role = "proposer"
+			}
+		}
+	}
+
+	if nextDutySlot == 0 {
+		log.WithField("slotInEpoch", slot%params.BeaconConfig().SlotsPerEpoch).Info("No duty until next epoch")
+	} else {
+		nextDutyTime, err := helpers.SlotToTime(v.genesisTime, nextDutySlot)
+		if err != nil {
+			return err
+		}
+		timeLeft := time.Duration(nextDutyTime.Unix() - timeutils.Now().Unix()).Nanoseconds()
+		// There is not much value to log if time left is less than one slot.
+		if uint64(timeLeft) >= params.BeaconConfig().SecondsPerSlot {
+			log.WithFields(
+				logrus.Fields{
+					"role":        role,
+					"currentSlot": slot,
+					"dutySlot":    nextDutySlot,
+					"slotInEpoch": slot % params.BeaconConfig().SlotsPerEpoch,
+					"secondsLeft": timeLeft,
+				}).Info("Next duty")
+		}
+	}
+
+	return nil
 }

--- a/validator/client/log.go
+++ b/validator/client/log.go
@@ -39,7 +39,7 @@ func (v *validator) LogAttestationsSubmitted() {
 	v.attLogs = make(map[[32]byte]*attSubmitted)
 }
 
-func (v *validator) LogNextDutyCountDown(slot uint64) error {
+func (v *validator) LogNextDutyTimeLeft(slot uint64) error {
 	var nextDutySlot uint64
 	var role string
 	for _, duty := range v.duties.CurrentEpochDuties {

--- a/validator/client/log_test.go
+++ b/validator/client/log_test.go
@@ -17,7 +17,7 @@ func TestLogNextDutyCountDown_NoDuty(t *testing.T) {
 			{AttesterSlot: 120},
 		}},
 	}
-	require.NoError(t, v.LogNextDutyCountDown(121))
+	require.NoError(t, v.LogNextDutyTimeLeft(121))
 	require.LogsContain(t, hook, "No duty until next epoch")
 }
 
@@ -30,7 +30,7 @@ func TestLogNextDutyCountDown_HasDutyAttester(t *testing.T) {
 			{AttesterSlot: 120},
 		}},
 	}
-	require.NoError(t, v.LogNextDutyCountDown(115))
+	require.NoError(t, v.LogNextDutyTimeLeft(115))
 	require.LogsContain(t, hook, "\"Next duty\" currentSlot=115 dutySlot=120 prefix=validator role=attester")
 }
 
@@ -43,6 +43,6 @@ func TestLogNextDutyCountDown_HasDutyProposer(t *testing.T) {
 			{AttesterSlot: 120},
 		}},
 	}
-	require.NoError(t, v.LogNextDutyCountDown(101))
+	require.NoError(t, v.LogNextDutyTimeLeft(101))
 	require.LogsContain(t, hook, "\"Next duty\" currentSlot=101 dutySlot=105 prefix=validator role=proposer")
 }

--- a/validator/client/log_test.go
+++ b/validator/client/log_test.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"testing"
+
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	logTest "github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestLogNextDutyCountDown_NoDuty(t *testing.T) {
+	hook := logTest.NewGlobal()
+	v := &validator{
+		duties: &ethpb.DutiesResponse{CurrentEpochDuties: []*ethpb.DutiesResponse_Duty{
+			{AttesterSlot: 100, ProposerSlots: []uint64{105}},
+			{AttesterSlot: 110},
+			{AttesterSlot: 120},
+		}},
+	}
+	require.NoError(t, v.LogNextDutyCountDown(121))
+	require.LogsContain(t, hook, "No duty until next epoch")
+}
+
+func TestLogNextDutyCountDown_HasDutyAttester(t *testing.T) {
+	hook := logTest.NewGlobal()
+	v := &validator{
+		duties: &ethpb.DutiesResponse{CurrentEpochDuties: []*ethpb.DutiesResponse_Duty{
+			{AttesterSlot: 100, ProposerSlots: []uint64{105}},
+			{AttesterSlot: 110},
+			{AttesterSlot: 120},
+		}},
+	}
+	require.NoError(t, v.LogNextDutyCountDown(115))
+	require.LogsContain(t, hook, "\"Next duty\" currentSlot=115 dutySlot=120 prefix=validator role=attester")
+}
+
+func TestLogNextDutyCountDown_HasDutyProposer(t *testing.T) {
+	hook := logTest.NewGlobal()
+	v := &validator{
+		duties: &ethpb.DutiesResponse{CurrentEpochDuties: []*ethpb.DutiesResponse_Duty{
+			{AttesterSlot: 100, ProposerSlots: []uint64{105}},
+			{AttesterSlot: 110},
+			{AttesterSlot: 120},
+		}},
+	}
+	require.NoError(t, v.LogNextDutyCountDown(101))
+	require.LogsContain(t, hook, "\"Next duty\" currentSlot=101 dutySlot=105 prefix=validator role=proposer")
+}

--- a/validator/client/mock_validator.go
+++ b/validator/client/mock_validator.go
@@ -152,7 +152,7 @@ func (fv *FakeValidator) SubmitAggregateAndProof(_ context.Context, _ uint64, _ 
 func (fv *FakeValidator) LogAttestationsSubmitted() {}
 
 // LogNextDutyCountDown for mocking.
-func (fv *FakeValidator) LogNextDutyCountDown(slot uint64) error {
+func (fv *FakeValidator) LogNextDutyTimeLeft(slot uint64) error {
 	return nil
 }
 

--- a/validator/client/mock_validator.go
+++ b/validator/client/mock_validator.go
@@ -151,6 +151,11 @@ func (fv *FakeValidator) SubmitAggregateAndProof(_ context.Context, _ uint64, _ 
 // LogAttestationsSubmitted for mocking.
 func (fv *FakeValidator) LogAttestationsSubmitted() {}
 
+// LogNextDutyCountDown for mocking.
+func (fv *FakeValidator) LogNextDutyCountDown(slot uint64) error {
+	return nil
+}
+
 // UpdateDomainDataCaches for mocking.
 func (fv *FakeValidator) UpdateDomainDataCaches(context.Context, uint64) {}
 

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -33,7 +33,7 @@ type Validator interface {
 	ProposeBlock(ctx context.Context, slot uint64, pubKey [48]byte)
 	SubmitAggregateAndProof(ctx context.Context, slot uint64, pubKey [48]byte)
 	LogAttestationsSubmitted()
-	LogNextDutyCountDown(slot uint64) error
+	LogNextDutyTimeLeft(slot uint64) error
 	ResetAttesterProtectionData()
 	UpdateDomainDataCaches(ctx context.Context, slot uint64)
 	WaitForWalletInitialization(ctx context.Context) error
@@ -163,7 +163,7 @@ func run(ctx context.Context, v Validator) {
 				if err := v.LogValidatorGainsAndLosses(slotCtx, slot); err != nil {
 					log.WithError(err).Error("Could not report validator's rewards/penalties")
 				}
-				if err := v.LogNextDutyCountDown(slot); err != nil {
+				if err := v.LogNextDutyTimeLeft(slot); err != nil {
 					log.WithError(err).Error("Could not report next count down")
 				}
 				span.End()

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -33,6 +33,7 @@ type Validator interface {
 	ProposeBlock(ctx context.Context, slot uint64, pubKey [48]byte)
 	SubmitAggregateAndProof(ctx context.Context, slot uint64, pubKey [48]byte)
 	LogAttestationsSubmitted()
+	LogNextDutyCountDown(slot uint64) error
 	ResetAttesterProtectionData()
 	UpdateDomainDataCaches(ctx context.Context, slot uint64)
 	WaitForWalletInitialization(ctx context.Context) error
@@ -161,6 +162,9 @@ func run(ctx context.Context, v Validator) {
 				v.LogAttestationsSubmitted()
 				if err := v.LogValidatorGainsAndLosses(slotCtx, slot); err != nil {
 					log.WithError(err).Error("Could not report validator's rewards/penalties")
+				}
+				if err := v.LogNextDutyCountDown(slot); err != nil {
+					log.WithError(err).Error("Could not report next count down")
 				}
 				span.End()
 			}()


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR adds a log to validator client on per slot basis to for how much time is left until next duty. If there's no duty until end of the epoch, it logs appropriately.  

<img width="897" alt="Screen Shot 2020-12-09 at 8 07 42 PM" src="https://user-images.githubusercontent.com/21316537/101811111-812fce80-3ace-11eb-92c7-725f08d9b5d8.png">

**Which issues(s) does this PR fix?**

Fixes #8056 

**Other notes for review**
I tested with my 5 validators in Pyrmont and tested with 4000 validators in interop mode. Profiled validator client to ensure there's no bottleneck