### PR TITLE
Properly Handle Duplicate Public Key Entries in Slashing Interchange Imports

### DIFF
--- a/validator/slashing-protection/local/standard-protection-format/BUILD.bazel
+++ b/validator/slashing-protection/local/standard-protection-format/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//validator:__subpackages__"],
     deps = [
         "//shared/bytesutil:go_default_library",
-        "//shared/hashutil:go_default_library",
         "//validator/db:go_default_library",
         "//validator/db/kv:go_default_library",
         "//validator/slashing-protection/local/attesting-history:go_default_library",

--- a/validator/slashing-protection/local/standard-protection-format/import.go
+++ b/validator/slashing-protection/local/standard-protection-format/import.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/validator/db"
 	"github.com/prysmaticlabs/prysm/validator/db/kv"
 	attestinghistory "github.com/prysmaticlabs/prysm/validator/slashing-protection/local/attesting-history"
@@ -41,11 +40,11 @@ func ImportStandardProtectionJSON(ctx context.Context, validatorDB db.Database, 
 
 	// We need to handle duplicate public keys in the JSON file, with potentially
 	// different signing histories for both attestations and blocks.
-	signedBlocksByPubKey, err := parseUniqueSignedBlocksByPubKey(interchangeJSON.Data)
+	signedBlocksByPubKey, err := parseBlocksForUniquePublicKeys(interchangeJSON.Data)
 	if err != nil {
 		return errors.Wrap(err, "could not parse unique entries for blocks by public key")
 	}
-	signedAttsByPubKey, err := parseUniqueSignedAttestationsByPubKey(interchangeJSON.Data)
+	signedAttsByPubKey, err := parseAttestationsForUniquePublicKeys(interchangeJSON.Data)
 	if err != nil {
 		return errors.Wrap(err, "could not parse unique entries for attestations by public key")
 	}
@@ -146,10 +145,22 @@ func validateMetadata(ctx context.Context, validatorDB db.Database, interchangeJ
 	return nil
 }
 
-// We create a map of pubKey -> []*SignedBlock. Then, we keep a map of observed hashes of
-// signed blocks. If we observe a new hash, we insert those signed blocks for processing.
-func parseUniqueSignedBlocksByPubKey(data []*ProtectionData) (map[[48]byte][]*SignedBlock, error) {
-	seenHashes := make(map[[32]byte]bool)
+// We create a map of pubKey -> []*SignedBlock. Then, for each public key we observe,
+// we append to this map. This allows us to handle valid input JSON data such as:
+//
+// "0x2932232930: {
+//   SignedBlocks: [Slot: 5, Slot: 6, Slot: 7],
+//  },
+// "0x2932232930: {
+//   SignedBlocks: [Slot: 5, Slot: 10, Slot: 11],
+//  }
+//
+// Which should be properly parsed as:
+//
+// "0x2932232930: {
+//   SignedBlocks: [Slot: 5, Slot: 5, Slot: 6, Slot: 7, Slot: 10, Slot: 11],
+//  }
+func parseBlocksForUniquePublicKeys(data []*ProtectionData) (map[[48]byte][]*SignedBlock, error) {
 	signedBlocksByPubKey := make(map[[48]byte][]*SignedBlock)
 	for _, validatorData := range data {
 		pubKey, err := pubKeyFromHex(validatorData.Pubkey)
@@ -160,26 +171,28 @@ func parseUniqueSignedBlocksByPubKey(data []*ProtectionData) (map[[48]byte][]*Si
 			if sBlock == nil {
 				continue
 			}
-			encoded, err := json.Marshal(sBlock)
-			if err != nil {
-				return nil, err
-			}
-			// Namespace the hash by the public key and the encoded block.
-			h := hashutil.Hash(append(pubKey[:], encoded...))
-			if _, ok := seenHashes[h]; ok {
-				continue
-			}
-			seenHashes[h] = true
 			signedBlocksByPubKey[pubKey] = append(signedBlocksByPubKey[pubKey], sBlock)
 		}
 	}
 	return signedBlocksByPubKey, nil
 }
 
-// We create a map of pubKey -> []*SignedAttestation. Then, we keep a map of observed hashes of
-// signed attestations. If we observe a new hash, we insert those signed attestations for processing.
-func parseUniqueSignedAttestationsByPubKey(data []*ProtectionData) (map[[48]byte][]*SignedAttestation, error) {
-	seenHashes := make(map[[32]byte]bool)
+// We create a map of pubKey -> []*SignedAttestation. Then, for each public key we observe,
+// we append to this map. This allows us to handle valid input JSON data such as:
+//
+// "0x2932232930: {
+//   SignedAttestations: [{Source: 5, Target: 6}, {Source: 6, Target: 7}],
+//  },
+// "0x2932232930: {
+//   SignedAttestations: [{Source: 5, Target: 6}],
+//  }
+//
+// Which should be properly parsed as:
+//
+// "0x2932232930: {
+//   SignedAttestations: [{Source: 5, Target: 6}, {Source: 5, Target: 6}, {Source: 6, Target: 7}],
+//  }
+func parseAttestationsForUniquePublicKeys(data []*ProtectionData) (map[[48]byte][]*SignedAttestation, error) {
 	signedAttestationsByPubKey := make(map[[48]byte][]*SignedAttestation)
 	for _, validatorData := range data {
 		pubKey, err := pubKeyFromHex(validatorData.Pubkey)
@@ -190,16 +203,6 @@ func parseUniqueSignedAttestationsByPubKey(data []*ProtectionData) (map[[48]byte
 			if sAtt == nil {
 				continue
 			}
-			encoded, err := json.Marshal(sAtt)
-			if err != nil {
-				return nil, err
-			}
-			// Namespace the hash by the public key and the encoded block.
-			h := hashutil.Hash(append(pubKey[:], encoded...))
-			if _, ok := seenHashes[h]; ok {
-				continue
-			}
-			seenHashes[h] = true
 			signedAttestationsByPubKey[pubKey] = append(signedAttestationsByPubKey[pubKey], sAtt)
 		}
 	}

--- a/validator/slashing-protection/local/standard-protection-format/import_test.go
+++ b/validator/slashing-protection/local/standard-protection-format/import_test.go
@@ -334,6 +334,10 @@ func Test_parseUniqueSignedBlocksByPubKey(t *testing.T) {
 						Slot:        "1",
 						SigningRoot: fmt.Sprintf("%x", roots[0]),
 					},
+					{
+						Slot:        "1",
+						SigningRoot: fmt.Sprintf("%x", roots[0]),
+					},
 				},
 			},
 		},
@@ -378,6 +382,10 @@ func Test_parseUniqueSignedBlocksByPubKey(t *testing.T) {
 						SigningRoot: fmt.Sprintf("%x", roots[1]),
 					},
 					{
+						Slot:        "2",
+						SigningRoot: fmt.Sprintf("%x", roots[1]),
+					},
+					{
 						Slot:        "3",
 						SigningRoot: fmt.Sprintf("%x", roots[2]),
 					},
@@ -387,13 +395,13 @@ func Test_parseUniqueSignedBlocksByPubKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseUniqueSignedBlocksByPubKey(tt.data)
+			got, err := parseBlocksForUniquePublicKeys(tt.data)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("parseUniqueSignedBlocksByPubKey() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("parseBlocksForUniquePublicKeys() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseUniqueSignedBlocksByPubKey() got = %v, want %v", got, tt.want)
+				t.Errorf("parseBlocksForUniquePublicKeys() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -450,7 +458,7 @@ func Test_parseUniqueSignedAttestationsByPubKey(t *testing.T) {
 			},
 		},
 		{
-			name: "same blocks but different public keys are parsed correctly",
+			name: "same attestations but different public keys are parsed correctly",
 			data: []*ProtectionData{
 				{
 					Pubkey: fmt.Sprintf("%x", pubKeys[0]),
@@ -503,7 +511,7 @@ func Test_parseUniqueSignedAttestationsByPubKey(t *testing.T) {
 			},
 		},
 		{
-			name: "disjoint sets of signed blocks by the same public key are parsed correctly",
+			name: "disjoint sets of signed attestations by the same public key are parsed correctly",
 			data: []*ProtectionData{
 				{
 					Pubkey: fmt.Sprintf("%x", pubKeys[0]),
@@ -579,6 +587,10 @@ func Test_parseUniqueSignedAttestationsByPubKey(t *testing.T) {
 						SourceEpoch: "1",
 						SigningRoot: fmt.Sprintf("%x", roots[0]),
 					},
+					{
+						SourceEpoch: "1",
+						SigningRoot: fmt.Sprintf("%x", roots[0]),
+					},
 				},
 			},
 		},
@@ -623,6 +635,10 @@ func Test_parseUniqueSignedAttestationsByPubKey(t *testing.T) {
 						SigningRoot: fmt.Sprintf("%x", roots[1]),
 					},
 					{
+						SourceEpoch: "2",
+						SigningRoot: fmt.Sprintf("%x", roots[1]),
+					},
+					{
 						SourceEpoch: "3",
 						SigningRoot: fmt.Sprintf("%x", roots[2]),
 					},
@@ -632,13 +648,13 @@ func Test_parseUniqueSignedAttestationsByPubKey(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseUniqueSignedAttestationsByPubKey(tt.data)
+			got, err := parseAttestationsForUniquePublicKeys(tt.data)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("parseUniqueSignedAttestationsByPubKey() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("parseAttestationsForUniquePublicKeys() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseUniqueSignedAttestationsByPubKey() got = %v, want %v", got, tt.want)
+				t.Errorf("parseAttestationsForUniquePublicKeys() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

The EIP standard for EIP-3076 slashing interchange requires us to properly handle entries in the JSON with duplicate public keys, such as:

```
"0x2932232930: {
  SignedBlocks: [Slot: 5, Slot: 6, Slot: 7],
},
"0x2932232930: {
  SignedBlocks: [Slot: 5, Slot: 10, Slot: 11],
},
```
Even if the data in them is the same, we should still process all those entries and not deduplicate. The current approach deduplicates, potentially missing slashable data.

**Which issues(s) does this PR fix?**

Part of #7813 
