### PR TITLE
Remove Saving Of Target And Source Epoch

### DIFF
--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -67,14 +67,8 @@ func (v *validator) slashableAttestationCheck(
 		return errors.Wrapf(err, "could not save attestation history for public key: %#x", pubKey)
 	}
 
-	// Save source and target epochs to satisfy EIP3076 requirements.
-	// The DB methods below will replace the lowest epoch in DB if necessary.
-	if err := v.db.SaveLowestSignedSourceEpoch(ctx, pubKey, indexedAtt.Data.Source.Epoch); err != nil {
-		return err
-	}
-	if err := v.db.SaveLowestSignedTargetEpoch(ctx, pubKey, indexedAtt.Data.Target.Epoch); err != nil {
-		return err
-	}
+	// TODO(#7813): Add back the saving of lowest target and lowest source epoch
+	// after we have implemented batch saving of attestation metadata.
 	if featureconfig.Get().SlasherProtection && v.protector != nil {
 		if !v.protector.CheckAttestationSafety(ctx, indexedAtt) {
 			if v.emitAccountMetrics {

--- a/validator/client/attest_protect_test.go
+++ b/validator/client/attest_protect_test.go
@@ -80,6 +80,7 @@ func Test_slashableAttestationCheck_Allowed(t *testing.T) {
 }
 
 func Test_slashableAttestationCheck_UpdatesLowestSignedEpochs(t *testing.T) {
+	t.Skip("Skipped till #8100, when we will save lowest source and target epochs again.")
 	config := &featureconfig.Flags{
 		SlasherProtection: true,
 	}


### PR DESCRIPTION
**What type of PR is this?**

Feature Cleanup

**What does this PR do? Why is it needed?**

- [x] This reverts the saving of Attestation Source and Target Epoch for the current moment, this will be implemented again 
in #8100 once it has been well tested and merged in.

**Which issues(s) does this PR fix?**

N.A 

**Other notes for review**
