### PR TITLE
Set Empty Epochs in Between Attestations as FAR_FUTURE_EPOCH in Attesting History

### DIFF
--- a/validator/db/kv/historical_attestations.go
+++ b/validator/db/kv/historical_attestations.go
@@ -109,17 +109,21 @@ func (hd EncHistoryData) GetTargetData(ctx context.Context, target uint64) (*His
 	return history, nil
 }
 
+// SetTargetDate updates the attesting history since the last written epoch up to and including
+// the one specified in the input arguments. Epochs in between are marked as unattested by setting their
+// source epoch to FAR_FUTURE_EPOCH.
 func (hd EncHistoryData) SetTargetData(ctx context.Context, target uint64, historyData *HistoryData) (EncHistoryData, error) {
 	if err := hd.assertSize(); err != nil {
 		return nil, err
 	}
 	// Cursor for the location to write target epoch to.
-	// Modulus of target epoch  X weak subjectivity period in order to have maximum size to the encapsulated data array.
 	cursorToWrite := latestEpochWrittenSize + (target%params.BeaconConfig().WeakSubjectivityPeriod)*historySize
 	if uint64(len(hd)) < cursorToWrite+historySize {
 		start := uint64(len(hd))
 		ext := make([]byte, cursorToWrite+historySize-uint64(len(hd)))
 		hd = append(hd, ext...)
+		// We need to mark the epochs in between the latest written one and the newest one
+		// we are writing as not attested by setting the source epoch to FAR_FUTURE_EPOCH.
 		for i := start; i < uint64(len(hd)); i += historySize {
 			copy(
 				hd[i:i+sourceSize],

--- a/validator/db/kv/historical_attestations_test.go
+++ b/validator/db/kv/historical_attestations_test.go
@@ -73,6 +73,7 @@ func TestSetTargetData_MarksUnattestedEpochsInBetween(t *testing.T) {
 		Source:      0,
 		SigningRoot: sr1[:],
 	})
+	require.NoError(t, err)
 
 	// We mark target 50, source 49 as attested.
 	sr2 := [32]byte{}

--- a/validator/db/kv/historical_attestations_test.go
+++ b/validator/db/kv/historical_attestations_test.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -60,6 +61,21 @@ func TestGetTargetData(t *testing.T) {
 	require.NoError(t, err)
 	var nilHist *HistoryData
 	require.Equal(t, nilHist, td)
+}
+
+func TestSetTargetData_MarksUnattestedEpochsInBetween(t *testing.T) {
+	ctx := context.Background()
+	h1 := NewAttestationHistoryArray(0)
+	sr2 := [32]byte{}
+	copy(sr2[:], "2")
+	h3, err := h1.SetTargetData(ctx, 5, &HistoryData{
+		Source:      0,
+		SigningRoot: sr2[:],
+	})
+	require.NoError(t, err)
+	data, err := h3.GetTargetData(ctx, 3)
+	require.NoError(t, err)
+	fmt.Println(data)
 }
 
 func TestSetTargetData(t *testing.T) {

--- a/validator/slashing-protection/local/standard-protection-format/round_trip_test.go
+++ b/validator/slashing-protection/local/standard-protection-format/round_trip_test.go
@@ -162,10 +162,12 @@ func TestImportInterchangeData_OK_SavesBlacklistedPublicKeys(t *testing.T) {
 		&protectionFormat.SignedAttestation{
 			TargetEpoch: "800",
 			SourceEpoch: "805",
+			SigningRoot: fmt.Sprintf("%#x", [32]byte{4}),
 		},
 		&protectionFormat.SignedAttestation{
 			TargetEpoch: "801",
 			SourceEpoch: "804",
+			SigningRoot: fmt.Sprintf("%#x", [32]byte{5}),
 		},
 	)
 


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

It turns out that when we mark an epoch as attested in our attestation history, we were also marking all epochs in between that epoch the last written one with zero values. Instead, we should mark those epochs as FAR_FUTURE_EPOCH.

**Which issues(s) does this PR fix?**

Part of #7813 
