### PR TITLE
Add extra methods to shared/fileutil

### DIFF
--- a/shared/fileutil/fileutil.go
+++ b/shared/fileutil/fileutil.go
@@ -154,12 +154,12 @@ func CopyDir(src, dst string) error {
 	if dstExists {
 		return errors.New("destination directory already exists")
 	}
-	if err := MkdirAll(dst); err != nil {
-		return errors.Wrapf(err, "error creating directory: %s", dst)
-	}
 	fds, err := ioutil.ReadDir(src)
 	if err != nil {
 		return err
+	}
+	if err := MkdirAll(dst); err != nil {
+		return errors.Wrapf(err, "error creating directory: %s", dst)
 	}
 	for _, fd := range fds {
 		srcPath := path.Join(src, fd.Name())

--- a/shared/fileutil/fileutil.go
+++ b/shared/fileutil/fileutil.go
@@ -194,6 +194,7 @@ func DirsEqual(src, dst string) bool {
 
 // HashDir calculates and returns hash of directory: each file's hash is calculated and saved along
 // with the file name into the list, after which list is hashed to produce the final signature.
+// Implementation is based on https://github.com/golang/mod/blob/release-branch.go1.15/sumdb/dirhash/hash.go
 func HashDir(dir string) (string, error) {
 	files, err := DirFiles(dir)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
- Extracted from #8095 (and required by that PR), this PR adds the following extra methods (and their tests) to `shared/fileutil`:
  - `CopyDir(src, dst)` to copy directory files, recursively i.e. files w/i a given directory, and all its sub-directoriesl
  - `DirsEqual(dir1, dir2)` calculates directories checksums and returns whether  `dir1` and `dir2` have same contents.
  - `HashDir(dir)` calculates directory checksum/hash.
  - `DirFiles(dir)` returns list of files in directory, recursively.

**Which issues(s) does this PR fix?**

Part of #5660

**Other notes for review**
