### PR TITLE
Validator DB cleanup: remove obsolete buckets

### DIFF
--- a/validator/db/kv/attestation_history_v2.go
+++ b/validator/db/kv/attestation_history_v2.go
@@ -16,7 +16,7 @@ func (store *Store) AttestedPublicKeys(ctx context.Context) ([][48]byte, error) 
 	var err error
 	attestedPublicKeys := make([][48]byte, 0)
 	err = store.view(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(newHistoricAttestationsBucket)
+		bucket := tx.Bucket(historicAttestationsBucket)
 		return bucket.ForEach(func(key []byte, _ []byte) error {
 			pubKeyBytes := [48]byte{}
 			copy(pubKeyBytes[:], key)
@@ -42,7 +42,7 @@ func (store *Store) AttestationHistoryForPubKeyV2(ctx context.Context, publicKey
 	var err error
 	var attestationHistory EncHistoryData
 	err = store.view(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(newHistoricAttestationsBucket)
+		bucket := tx.Bucket(historicAttestationsBucket)
 		enc := bucket.Get(publicKey[:])
 		if len(enc) == 0 {
 			attestationHistory = NewAttestationHistoryArray(0)
@@ -63,7 +63,7 @@ func (store *Store) SaveAttestationHistoryForPubKeyV2(ctx context.Context, pubKe
 	ctx, span := trace.StartSpan(ctx, "Validator.SaveAttestationHistoryForPubKeyV2")
 	defer span.End()
 	err := store.update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(newHistoricAttestationsBucket)
+		bucket := tx.Bucket(historicAttestationsBucket)
 		return bucket.Put(pubKey[:], history)
 	})
 	if !featureconfig.Get().DisableAttestingHistoryDBCache {

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -96,10 +96,8 @@ func NewKVStore(ctx context.Context, dirPath string, pubKeys [][48]byte) (*Store
 		return createBuckets(
 			tx,
 			genesisInfoBucket,
-			historicProposalsBucket,
 			historicAttestationsBucket,
-			newHistoricAttestationsBucket,
-			newHistoricProposalsBucket,
+			historicProposalsBucket,
 			lowestSignedSourceBucket,
 			lowestSignedTargetBucket,
 			lowestSignedProposalsBucket,
@@ -135,7 +133,7 @@ func NewKVStore(ctx context.Context, dirPath string, pubKeys [][48]byte) (*Store
 // UpdatePublicKeysBuckets for a specified list of keys.
 func (store *Store) UpdatePublicKeysBuckets(pubKeys [][48]byte) error {
 	return store.update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(newHistoricProposalsBucket)
+		bucket := tx.Bucket(historicProposalsBucket)
 		for _, pubKey := range pubKeys {
 			if _, err := bucket.CreateBucketIfNotExists(pubKey[:]); err != nil {
 				return errors.Wrap(err, "failed to create proposal history bucket")

--- a/validator/db/kv/proposal_history_v2.go
+++ b/validator/db/kv/proposal_history_v2.go
@@ -30,7 +30,7 @@ func (store *Store) ProposedPublicKeys(ctx context.Context) ([][48]byte, error) 
 	var err error
 	proposedPublicKeys := make([][48]byte, 0)
 	err = store.view(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(newHistoricProposalsBucket)
+		bucket := tx.Bucket(historicProposalsBucket)
 		return bucket.ForEach(func(key []byte, _ []byte) error {
 			pubKeyBytes := [48]byte{}
 			copy(pubKeyBytes[:], key)
@@ -52,7 +52,7 @@ func (store *Store) ProposalHistoryForSlot(ctx context.Context, publicKey [48]by
 	var proposalExists bool
 	signingRoot := [32]byte{}
 	err = store.update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(newHistoricProposalsBucket)
+		bucket := tx.Bucket(historicProposalsBucket)
 		valBucket, err := bucket.CreateBucketIfNotExists(publicKey[:])
 		if err != nil {
 			return fmt.Errorf("could not create bucket for public key %#x", publicKey[:])
@@ -76,7 +76,7 @@ func (store *Store) SaveProposalHistoryForSlot(ctx context.Context, pubKey [48]b
 	defer span.End()
 
 	err := store.update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(newHistoricProposalsBucket)
+		bucket := tx.Bucket(historicProposalsBucket)
 		valBucket, err := bucket.CreateBucketIfNotExists(pubKey[:])
 		if err != nil {
 			return fmt.Errorf("could not create bucket for public key %#x", pubKey)

--- a/validator/db/kv/schema.go
+++ b/validator/db/kv/schema.go
@@ -5,13 +5,9 @@ var (
 	genesisInfoBucket = []byte("genesis-info-bucket")
 
 	// Validator slashing protection from double proposals.
-	historicProposalsBucket = []byte("proposal-history-bucket")
-	// Validator slashing protection from double proposals.
-	newHistoricProposalsBucket = []byte("proposal-history-bucket-interchange")
-	// Validator slashing protection from slashable attestations.
-	historicAttestationsBucket = []byte("attestation-history-bucket")
+	historicProposalsBucket = []byte("proposal-history-bucket-interchange")
 	// New Validator slashing protection from slashable attestations.
-	newHistoricAttestationsBucket = []byte("attestation-history-bucket-interchange")
+	historicAttestationsBucket = []byte("attestation-history-bucket-interchange")
 
 	// Buckets for lowest signed source and target epoch for individual validator.
 	lowestSignedSourceBucket = []byte("lowest-signed-source-bucket")


### PR DESCRIPTION
**What type of PR is this?**

Other (code health)

**What does this PR do? Why is it needed?**

These buckets are not used and have not been used since before v1.0.0

**Which issues(s) does this PR fix?**

N/A - clean up

**Other notes for review**

Minor renaming to remove the "new" prefix from the appropriate buckets.
