### PR TITLE
Lock Only When Needed When Fetching Attesting History

### DIFF
--- a/validator/db/kv/attestation_history_v2.go
+++ b/validator/db/kv/attestation_history_v2.go
@@ -34,12 +34,12 @@ func (store *Store) AttestationHistoryForPubKeyV2(ctx context.Context, publicKey
 	ctx, span := trace.StartSpan(ctx, "Validator.AttestationHistoryForPubKeyV2")
 	defer span.End()
 	if !featureconfig.Get().DisableAttestingHistoryDBCache {
-		store.lock.Lock()
+		store.lock.RLock()
 		if history, ok := store.attestingHistoriesByPubKey[publicKey]; ok {
-			store.lock.Unlock()
+			store.lock.RUnlock()
 			return history, nil
 		}
-		store.lock.Unlock()
+		store.lock.RUnlock()
 	}
 	var err error
 	var attestationHistory EncHistoryData

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -24,7 +24,7 @@ var ProtectionDbFileName = "validator.db"
 type Store struct {
 	db                         *bolt.DB
 	databasePath               string
-	lock                       sync.Mutex
+	lock                       sync.RWMutex
 	attestingHistoriesByPubKey map[[48]byte]EncHistoryData
 }
 


### PR DESCRIPTION
No tracking issue, this PR simply locks around map access in retrieving attesting history to prevent significant lock contention when running a large amount of validators