### PR TITLE
Update int -> string conversion to make go test happy

### DIFF
--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -1,6 +1,7 @@
 package epoch_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -249,7 +250,7 @@ func TestProcessSlashings_SlashedLess(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		t.Run(string(i), func(t *testing.T) {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			original := proto.Clone(tt.state)
 			s, err := state.InitializeFromProto(tt.state)
 			require.NoError(t, err)

--- a/beacon-chain/core/epoch/precompute/slashing_test.go
+++ b/beacon-chain/core/epoch/precompute/slashing_test.go
@@ -1,6 +1,7 @@
 package precompute_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -111,7 +112,7 @@ func TestProcessSlashingsPrecompute_SlashedLess(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		t.Run(string(i), func(t *testing.T) {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			ab := uint64(0)
 			for i, b := range tt.state.Balances {
 				// Skip validator 0 since it's slashed


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Clean up

**What does this PR do? Why is it needed?**

Fixes a go test complain:
`conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)`


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
