### PR TITLE
Compare strings using strings.EqualFold()

### DIFF
--- a/beacon-chain/db/restore.go
+++ b/beacon-chain/db/restore.go
@@ -29,7 +29,7 @@ func restore(cliCtx *cli.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "could not validate choice")
 		}
-		if strings.ToLower(resp) == "n" {
+		if strings.EqualFold(resp, "n") {
 			logrus.Info("Restore aborted")
 			return nil
 		}

--- a/shared/tos/tos.go
+++ b/shared/tos/tos.go
@@ -53,7 +53,7 @@ func VerifyTosAcceptedOrPrompt(ctx *cli.Context) error {
 	if err != nil {
 		return errors.New(acceptTosPromptErrText)
 	}
-	if strings.ToLower(input) != "accept" {
+	if !strings.EqualFold(input, "accept") {
 		return errors.New("you have to accept Terms and Conditions in order to continue")
 	}
 

--- a/slasher/db/restore.go
+++ b/slasher/db/restore.go
@@ -29,7 +29,7 @@ func restore(cliCtx *cli.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "could not validate choice")
 		}
-		if strings.ToLower(resp) == "n" {
+		if strings.EqualFold(resp, "n") {
 			logrus.Info("Restore aborted")
 			return nil
 		}

--- a/validator/accounts/accounts_delete.go
+++ b/validator/accounts/accounts_delete.go
@@ -66,7 +66,7 @@ func DeleteAccountCli(cliCtx *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			if strings.ToLower(resp) == "n" {
+			if strings.EqualFold(resp, "n") {
 				return nil
 			}
 		} else {
@@ -80,7 +80,7 @@ func DeleteAccountCli(cliCtx *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			if strings.ToLower(resp) == "n" {
+			if strings.EqualFold(resp, "n") {
 				return nil
 			}
 		}

--- a/validator/accounts/accounts_enable_disable.go
+++ b/validator/accounts/accounts_enable_disable.go
@@ -62,7 +62,7 @@ func DisableAccountsCli(cliCtx *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			if strings.ToLower(resp) == "n" {
+			if strings.EqualFold(resp, "n") {
 				return nil
 			}
 		} else {
@@ -76,7 +76,7 @@ func DisableAccountsCli(cliCtx *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			if strings.ToLower(resp) == "n" {
+			if strings.EqualFold(resp, "n") {
 				return nil
 			}
 		}
@@ -145,7 +145,7 @@ func EnableAccountsCli(cliCtx *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			if strings.ToLower(resp) == "n" {
+			if strings.EqualFold(resp, "n") {
 				return nil
 			}
 		} else {
@@ -159,7 +159,7 @@ func EnableAccountsCli(cliCtx *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			if strings.ToLower(resp) == "n" {
+			if strings.EqualFold(resp, "n") {
 				return nil
 			}
 		}

--- a/validator/accounts/accounts_exit.go
+++ b/validator/accounts/accounts_exit.go
@@ -126,7 +126,7 @@ func interact(cliCtx *cli.Context, r io.Reader, validatingPublicKeys [][48]byte)
 			if err != nil {
 				return nil, nil, err
 			}
-			if strings.ToLower(resp) == "n" {
+			if strings.EqualFold(resp, "n") {
 				return nil, nil, nil
 			}
 		} else {
@@ -142,7 +142,7 @@ func interact(cliCtx *cli.Context, r io.Reader, validatingPublicKeys [][48]byte)
 			if err != nil {
 				return nil, nil, err
 			}
-			if strings.ToLower(resp) == "n" {
+			if strings.EqualFold(resp, "n") {
 				return nil, nil, nil
 			}
 		}
@@ -162,7 +162,7 @@ func interact(cliCtx *cli.Context, r io.Reader, validatingPublicKeys [][48]byte)
 	if err != nil {
 		return nil, nil, err
 	}
-	if strings.ToLower(resp) == "n" {
+	if strings.EqualFold(resp, "n") {
 		return nil, nil, nil
 	}
 

--- a/validator/accounts/wallet_create.go
+++ b/validator/accounts/wallet_create.go
@@ -147,7 +147,7 @@ func extractWalletCreationConfigFromCli(cliCtx *cli.Context, keymanagerKind keym
 		if err != nil {
 			return nil, errors.Wrap(err, "could not validate choice")
 		}
-		if strings.ToLower(resp) == "y" {
+		if strings.EqualFold(resp, "y") {
 			mnemonicPassphrase, err := promptutil.InputPassword(
 				cliCtx,
 				flags.Mnemonic25thWordFileFlag,

--- a/validator/accounts/wallet_recover.go
+++ b/validator/accounts/wallet_recover.go
@@ -58,7 +58,7 @@ func RecoverWalletCli(cliCtx *cli.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "could not validate choice")
 		}
-		if strings.ToLower(resp) == "y" {
+		if strings.EqualFold(resp, "y") {
 			mnemonicPassphrase, err := promptutil.InputPassword(
 				cliCtx,
 				flags.Mnemonic25thWordFileFlag,

--- a/validator/db/restore.go
+++ b/validator/db/restore.go
@@ -28,7 +28,7 @@ func restore(cliCtx *cli.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "could not validate choice")
 		}
-		if strings.ToLower(resp) == "n" {
+		if strings.EqualFold(resp, "n") {
 			logrus.Info("Restore aborted")
 			return nil
 		}


### PR DESCRIPTION
**What type of PR is this?**

> Other / Cleanup

**What does this PR do? Why is it needed?**
- When comparing/matching unicode strings in a case-insensitive manner `strings.EqualFold()` should be used (it is more performant than manual turning string `ToLower()`, plus, it is intended for comparisons).
- This PR amends string comparisons to use `EqualFold()`.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
