### PR TITLE
Allow beacon-chain to start without a defined Eth1 endpoint

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -257,12 +257,13 @@ func (s *Service) Start() {
 			log.Fatal(err)
 		}
 		if genState == nil {
-			log.Fatal("cannot create genesis state: no eth1 http endpoint defined")
+			log.Warn("cannot create genesis state: no eth1 http endpoint defined")
 		}
 	}
 
-	// Exit early if eth1 endpoint is not set.
+	// Print a warning if eth1 endpoint is not set and return early
 	if s.currHttpEndpoint == "" {
+		log.Warn("no eth1 endpoint defined")
 		return
 	}
 	go func() {

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -147,7 +147,7 @@ func TestStart_OK(t *testing.T) {
 	web3Service.cancel()
 }
 
-func TestStart_NoHTTPEndpointDefinedFails_WithoutChainStarted(t *testing.T) {
+func TestStart_NoHTTPEndpointDefinedWarns_WithoutChainStarted(t *testing.T) {
 	hook := logTest.NewGlobal()
 	beaconDB := dbutil.SetupDB(t)
 	testAcc, err := contracts.Setup()
@@ -167,7 +167,7 @@ func TestStart_NoHTTPEndpointDefinedFails_WithoutChainStarted(t *testing.T) {
 	}()
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
-	// Expect Start function to fail from a fatal call due
+	// Expect Start function to Warn from a fatal call due
 	// to no state existing.
 	go func() {
 		defer func() {


### PR DESCRIPTION
Allow powchain service to continue even if `genState == nil`. 

Fixes #8209 