### PR TITLE
Check if initial sync service has been initialized

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -127,7 +127,7 @@ func (s *Service) Stop() error {
 
 // Status of initial sync.
 func (s *Service) Status() error {
-	if s.synced.IsNotSet() && s.chainStarted.IsSet() {
+	if s.Syncing() {
 		return errors.New("syncing")
 	}
 	return nil
@@ -136,6 +136,11 @@ func (s *Service) Status() error {
 // Syncing returns true if initial sync is still running.
 func (s *Service) Syncing() bool {
 	return s.synced.IsNotSet()
+}
+
+// Initialized returns true if initial sync has been started.
+func (s *Service) Initialized() bool {
+	return s.chainStarted.IsSet()
 }
 
 // Resync allows a node to start syncing again if it has fallen

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -327,8 +327,9 @@ func TestService_markSynced(t *testing.T) {
 	assert.Equal(t, false, s.chainStarted.IsSet())
 	assert.Equal(t, false, s.synced.IsSet())
 	assert.Equal(t, true, s.Syncing())
-	assert.NoError(t, s.Status())
+	assert.ErrorContains(t, "syncing", s.Status())
 	s.chainStarted.Set()
+	assert.Equal(t, true, s.Syncing())
 	assert.ErrorContains(t, "syncing", s.Status())
 
 	expectedGenesisTime := time.Unix(358544700, 0)
@@ -359,6 +360,7 @@ func TestService_markSynced(t *testing.T) {
 	}
 	assert.Equal(t, expectedGenesisTime, receivedGenesisTime)
 	assert.Equal(t, false, s.Syncing())
+	assert.NoError(t, s.Status())
 }
 
 func TestService_Resync(t *testing.T) {
@@ -435,4 +437,12 @@ func TestService_Resync(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestService_Initialized(t *testing.T) {
+	s := NewService(context.Background(), &Config{})
+	s.chainStarted.Set()
+	assert.Equal(t, true, s.Initialized())
+	s.chainStarted.UnSet()
+	assert.Equal(t, false, s.Initialized())
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Allows to check whether the initial sync service has been initialized. This is required for node APIs, specifically returning 503 from https://ethereum.github.io/eth2.0-APIs/#/Node/getHealth

**Which issues(s) does this PR fix?**

Needed for #7510 

**Other notes for review**

I also aligned the implementation of `Status` with `Syncing` after a discussion with @farazdagi
