### PR TITLE
Move attestation protection call after signing

### DIFF
--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -15,8 +15,7 @@ import (
 )
 
 var failedAttLocalProtectionErr = "attempted to make slashable attestation, rejected by local slashing protection"
-var failedPreAttSignExternalErr = "attempted to make slashable attestation, rejected by external slasher service"
-var failedPostAttSignExternalErr = "external slasher service detected a slashable attestation"
+var failedPostAttSignExternalErr = "attempted to make slashable attestation, rejected by external slasher service"
 
 // Checks if an attestation is slashable by comparing it with the attesting
 // history for the given public key in our DB. If it is not, we then update the history

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -70,12 +70,6 @@ func (v *validator) slashableAttestationCheck(
 	// TODO(#7813): Add back the saving of lowest target and lowest source epoch
 	// after we have implemented batch saving of attestation metadata.
 	if featureconfig.Get().SlasherProtection && v.protector != nil {
-		if !v.protector.CheckAttestationSafety(ctx, indexedAtt) {
-			if v.emitAccountMetrics {
-				ValidatorAttestFailVecSlasher.WithLabelValues(fmtKey).Inc()
-			}
-			return errors.New(failedPreAttSignExternalErr)
-		}
 		if !v.protector.CommitAttestation(ctx, indexedAtt) {
 			if v.emitAccountMetrics {
 				ValidatorAttestFailVecSlasher.WithLabelValues(fmtKey).Inc()

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -16,7 +16,7 @@ import (
 
 var failedAttLocalProtectionErr = "attempted to make slashable attestation, rejected by local slashing protection"
 var failedPreAttSignExternalErr = "attempted to make slashable attestation, rejected by external slasher service"
-var failedPostAttSignExternalErr = "external slasher service detected a submitted slashable attestation"
+var failedPostAttSignExternalErr = "external slasher service detected a slashable attestation"
 
 // Checks if an attestation is slashable by comparing it with the attesting
 // history for the given public key in our DB. If it is not, we then update the history

--- a/validator/client/attest_protect_test.go
+++ b/validator/client/attest_protect_test.go
@@ -44,7 +44,7 @@ func Test_slashableAttestationCheck(t *testing.T) {
 	mockProtector := &mockSlasher.MockProtector{AllowAttestation: false}
 	validator.protector = mockProtector
 	err := validator.slashableAttestationCheck(context.Background(), att, pubKey, [32]byte{})
-	require.ErrorContains(t, failedPreAttSignExternalErr, err)
+	require.ErrorContains(t, failedPostAttSignExternalErr, err)
 	mockProtector.AllowAttestation = true
 	err = validator.slashableAttestationCheck(context.Background(), att, pubKey, [32]byte{})
 	require.NoError(t, err, "Expected allowed attestation not to throw error")

--- a/validator/client/attest_test.go
+++ b/validator/client/attest_test.go
@@ -204,7 +204,7 @@ func TestAttestToBlockHead_BlocksDoubleAtt(t *testing.T) {
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx
 		gomock.Any(), // epoch
-	).Times(3).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+	).Times(4).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
 
 	m.validatorClient.EXPECT().ProposeAttestation(
 		gomock.Any(), // ctx
@@ -256,7 +256,7 @@ func TestAttestToBlockHead_BlocksSurroundAtt(t *testing.T) {
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx
 		gomock.Any(), // epoch
-	).Times(3).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+	).Times(4).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
 
 	m.validatorClient.EXPECT().ProposeAttestation(
 		gomock.Any(), // ctx
@@ -300,7 +300,7 @@ func TestAttestToBlockHead_BlocksSurroundedAtt(t *testing.T) {
 	m.validatorClient.EXPECT().DomainData(
 		gomock.Any(), // ctx
 		gomock.Any(), // epoch
-	).Times(3).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+	).Times(4).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
 
 	m.validatorClient.EXPECT().ProposeAttestation(
 		gomock.Any(), // ctx


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix


**What does this PR do? Why is it needed?**
When we introduced #8086 we removed the redundant call for attestation slashing protection and combined the external slashing checks. This change introduced a problem as external slashing protection using slasher `IsSlashableAttestation` grpc endpoint require signed attestation as an input(slashing can not be proved without signed attestation)

slasher endpoint `IsSlashableAttestationNoUpdate` could not be used as it doesn't update the spans in db and will break the correctness of future slashing detections if used.

This pr :
- move the attastation protection check down the flow after signing 
- remove redundent check as validation is also being done when calling `IsSlashableAttestation` endpoint

**Which issues(s) does this PR fix?**

Fixes #8208

