### PR TITLE
Max-cover: remove redundant dedup routine

### DIFF
--- a/shared/aggregation/attestations/maxcover.go
+++ b/shared/aggregation/attestations/maxcover.go
@@ -44,7 +44,7 @@ func MaxCoverAttestationAggregation(atts []*ethpb.Attestation) ([]*ethpb.Attesta
 			}
 			return aggregated.merge(unaggregated), err
 		}
-		solution, err := maxCover.Cover(len(atts), false /* allowOverlaps */, false /* allowDuplicates */)
+		solution, err := maxCover.Cover(len(atts), false /* allowOverlaps */)
 		if err != nil {
 			return aggregated.merge(unaggregated), err
 		}

--- a/shared/aggregation/maxcover.go
+++ b/shared/aggregation/maxcover.go
@@ -51,16 +51,12 @@ func NewMaxCoverCandidate(key int, bits *bitfield.Bitlist) *MaxCoverCandidate {
 
 // Cover calculates solution to Maximum k-Cover problem in O(knm), where
 // n is number of candidates and m is a length of bitlist in each candidate.
-func (mc *MaxCoverProblem) Cover(k int, allowOverlaps, allowDuplicates bool) (*Aggregation, error) {
+func (mc *MaxCoverProblem) Cover(k int, allowOverlaps bool) (*Aggregation, error) {
 	if len(mc.Candidates) == 0 {
 		return nil, errors.Wrap(ErrInvalidMaxCoverProblem, "cannot calculate set coverage")
 	}
 	if len(mc.Candidates) < k {
 		k = len(mc.Candidates)
-	}
-
-	if !allowDuplicates {
-		mc.Candidates.dedup(allowOverlaps)
 	}
 
 	solution := &Aggregation{
@@ -154,28 +150,6 @@ func (cl *MaxCoverCandidates) union() bitfield.Bitlist {
 		}
 	}
 	return ret
-}
-
-// dedup removes duplicate candidates (ones with the same bits set on).
-func (cl *MaxCoverCandidates) dedup(allowOverlaps bool) *MaxCoverCandidates {
-	if len(*cl) < 2 {
-		return cl
-	}
-	uncoveredBits := cl.union()
-	if uncoveredBits == nil {
-		return cl
-	}
-	cl.score(uncoveredBits).sort()
-	for i := 1; i < len(*cl); i++ {
-		if (*cl)[i-1].bits.Len() != (*cl)[i].bits.Len() {
-			continue
-		}
-		nonOverlappingBits := (*cl)[i-1].bits.Xor(*(*cl)[i].bits)
-		if (*cl)[i-1].score == (*cl)[i].score && nonOverlappingBits.Count() == 0 {
-			(*cl)[i-1].processed = true
-		}
-	}
-	return cl.filter(bitfield.NewBitlist((*cl)[0].bits.Len()), allowOverlaps)
 }
 
 // String provides string representation of a candidate.

--- a/shared/aggregation/maxcover_test.go
+++ b/shared/aggregation/maxcover_test.go
@@ -356,181 +356,6 @@ func TestMaxCover_MaxCoverCandidates_score(t *testing.T) {
 	}
 }
 
-func TestMaxCover_MaxCoverCandidates_dedup(t *testing.T) {
-	var problem MaxCoverCandidates
-	tests := []struct {
-		name string
-		cl   MaxCoverCandidates
-		want *MaxCoverCandidates
-	}{
-		{
-			name: "nil list",
-			cl:   nil,
-			want: &problem,
-		},
-		{
-			name: "empty list",
-			cl:   MaxCoverCandidates{},
-			want: &MaxCoverCandidates{},
-		},
-		{
-			name: "single item",
-			cl: MaxCoverCandidates{
-				{0, &bitfield.Bitlist{}, 5, false},
-			},
-			want: &MaxCoverCandidates{
-				{0, &bitfield.Bitlist{}, 5, false},
-			},
-		},
-		{
-			name: "two items nil bitlists",
-			cl: MaxCoverCandidates{
-				{0, nil, 0, false},
-				{0, nil, 0, false},
-			},
-			want: &MaxCoverCandidates{
-				{0, nil, 0, false},
-				{0, nil, 0, false},
-			},
-		},
-		{
-			name: "two items empty bitlists",
-			cl: MaxCoverCandidates{
-				{0, &bitfield.Bitlist{}, 0, false},
-				{0, &bitfield.Bitlist{}, 0, false},
-			},
-			want: &MaxCoverCandidates{
-				{0, &bitfield.Bitlist{}, 0, false},
-				{0, &bitfield.Bitlist{}, 0, false},
-			},
-		},
-		{
-			name: "two items no duplicates",
-			cl: MaxCoverCandidates{
-				{0, &bitfield.Bitlist{0xfe, 0x01}, 0, false},
-				{0, &bitfield.Bitlist{0xff, 0x01}, 0, false},
-			},
-			want: &MaxCoverCandidates{
-				{0, &bitfield.Bitlist{0xff, 0x01}, 8, false},
-				{0, &bitfield.Bitlist{0xfe, 0x01}, 7, false},
-			},
-		},
-		{
-			name: "two items with duplicates",
-			cl: MaxCoverCandidates{
-				{0, &bitfield.Bitlist{0xba, 0x01}, 0, false},
-				{0, &bitfield.Bitlist{0xba, 0x01}, 0, false},
-			},
-			want: &MaxCoverCandidates{
-				{0, &bitfield.Bitlist{0xba, 0x01}, 5, false},
-			},
-		},
-		{
-			name: "sorted no duplicates",
-			cl: MaxCoverCandidates{
-				{3, &bitfield.Bitlist{0b11001111, 0b1}, 0, false},
-				{5, &bitfield.Bitlist{0b01101101, 0b1}, 0, false},
-				{4, &bitfield.Bitlist{0b00001111, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-				{1, &bitfield.Bitlist{0b00000001, 0b1}, 0, false},
-			},
-			want: &MaxCoverCandidates{
-				{3, &bitfield.Bitlist{0b11001111, 0b1}, 6, false},
-				{5, &bitfield.Bitlist{0b01101101, 0b1}, 5, false},
-				{4, &bitfield.Bitlist{0b00001111, 0b1}, 4, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 2, false},
-				{1, &bitfield.Bitlist{0b00000001, 0b1}, 1, false},
-			},
-		},
-		{
-			name: "sorted with duplicates",
-			cl: MaxCoverCandidates{
-				{3, &bitfield.Bitlist{0b11001111, 0b1}, 0, false},
-				{5, &bitfield.Bitlist{0b01101101, 0b1}, 0, false},
-				{5, &bitfield.Bitlist{0b01101101, 0b1}, 0, false},
-				{5, &bitfield.Bitlist{0b01101101, 0b1}, 0, false},
-				{4, &bitfield.Bitlist{0b00001111, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-				{1, &bitfield.Bitlist{0b00000001, 0b1}, 0, false},
-			},
-			want: &MaxCoverCandidates{
-				{3, &bitfield.Bitlist{0b11001111, 0b1}, 6, false},
-				{5, &bitfield.Bitlist{0b01101101, 0b1}, 5, false},
-				{4, &bitfield.Bitlist{0b00001111, 0b1}, 4, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 2, false},
-				{1, &bitfield.Bitlist{0b00000001, 0b1}, 1, false},
-			},
-		},
-		{
-			name: "all equal",
-			cl: MaxCoverCandidates{
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-			},
-			want: &MaxCoverCandidates{
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 2, false},
-			},
-		},
-		{
-			name: "unsorted no duplicates",
-			cl: MaxCoverCandidates{
-				{5, &bitfield.Bitlist{0b01101101, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-				{4, &bitfield.Bitlist{0b00001111, 0b1}, 0, false},
-				{1, &bitfield.Bitlist{0b00000001, 0b1}, 0, false},
-				{3, &bitfield.Bitlist{0b11001111, 0b1}, 0, false},
-			},
-			want: &MaxCoverCandidates{
-				{3, &bitfield.Bitlist{0b11001111, 0b1}, 6, false},
-				{5, &bitfield.Bitlist{0b01101101, 0b1}, 5, false},
-				{4, &bitfield.Bitlist{0b00001111, 0b1}, 4, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 2, false},
-				{1, &bitfield.Bitlist{0b00000001, 0b1}, 1, false},
-			},
-		},
-		{
-			name: "unsorted with duplicates",
-			cl: MaxCoverCandidates{
-				{4, &bitfield.Bitlist{0b00001111, 0b1}, 0, false},
-				{3, &bitfield.Bitlist{0b11001111, 0b1}, 0, false},
-				{4, &bitfield.Bitlist{0b00001111, 0b1}, 0, false},
-				{4, &bitfield.Bitlist{0b00001111, 0b1}, 0, false},
-				{1, &bitfield.Bitlist{0b00000001, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 0, false},
-				{3, &bitfield.Bitlist{0b11001111, 0b1}, 0, false},
-				{1, &bitfield.Bitlist{0b00000001, 0b1}, 0, false},
-				{5, &bitfield.Bitlist{0b01101101, 0b1}, 0, false},
-			},
-			want: &MaxCoverCandidates{
-				{3, &bitfield.Bitlist{0b11001111, 0b1}, 6, false},
-				{5, &bitfield.Bitlist{0b01101101, 0b1}, 5, false},
-				{4, &bitfield.Bitlist{0b00001111, 0b1}, 4, false},
-				{2, &bitfield.Bitlist{0b00000011, 0b1}, 2, false},
-				{1, &bitfield.Bitlist{0b00000001, 0b1}, 1, false},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := tt.cl.dedup(false)
-			sort.Slice(*got, func(i, j int) bool {
-				if (*got)[i].score == (*got)[j].score {
-					return (*got)[i].key < (*got)[j].key
-				}
-				return (*got)[i].score > (*got)[j].score
-			})
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("dedup() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestMaxCover_MaxCoverProblem_Cover(t *testing.T) {
 	problemSet := func() MaxCoverCandidates {
 		// test vectors originally from:
@@ -544,10 +369,9 @@ func TestMaxCover_MaxCoverProblem_Cover(t *testing.T) {
 		}
 	}
 	type args struct {
-		k               int
-		candidates      MaxCoverCandidates
-		allowOverlaps   bool
-		allowDuplicates bool
+		k             int
+		candidates    MaxCoverCandidates
+		allowOverlaps bool
 	}
 	tests := []struct {
 		name      string
@@ -574,7 +398,7 @@ func TestMaxCover_MaxCoverProblem_Cover(t *testing.T) {
 		},
 		{
 			name: "k=0",
-			args: args{k: 0, candidates: problemSet(), allowDuplicates: true},
+			args: args{k: 0, candidates: problemSet()},
 			want: &Aggregation{
 				Coverage: bitfield.Bitlist{0b0000000, 0b1},
 				Keys:     []int{},
@@ -582,7 +406,7 @@ func TestMaxCover_MaxCoverProblem_Cover(t *testing.T) {
 		},
 		{
 			name: "k=1",
-			args: args{k: 1, candidates: problemSet(), allowDuplicates: true},
+			args: args{k: 1, candidates: problemSet()},
 			want: &Aggregation{
 				Coverage: bitfield.Bitlist{0b0011011, 0b1},
 				Keys:     []int{1},
@@ -590,7 +414,7 @@ func TestMaxCover_MaxCoverProblem_Cover(t *testing.T) {
 		},
 		{
 			name: "k=2",
-			args: args{k: 2, candidates: problemSet(), allowDuplicates: true},
+			args: args{k: 2, candidates: problemSet()},
 			want: &Aggregation{
 				Coverage: bitfield.Bitlist{0b0011111, 0b1},
 				Keys:     []int{1, 0},
@@ -598,7 +422,7 @@ func TestMaxCover_MaxCoverProblem_Cover(t *testing.T) {
 		},
 		{
 			name: "k=3",
-			args: args{k: 3, candidates: problemSet(), allowDuplicates: true},
+			args: args{k: 3, candidates: problemSet()},
 			want: &Aggregation{
 				Coverage: bitfield.Bitlist{0b0011111, 0b1},
 				Keys:     []int{1, 0},
@@ -606,7 +430,7 @@ func TestMaxCover_MaxCoverProblem_Cover(t *testing.T) {
 		},
 		{
 			name: "k=5",
-			args: args{k: 5, candidates: problemSet(), allowDuplicates: true},
+			args: args{k: 5, candidates: problemSet()},
 			want: &Aggregation{
 				Coverage: bitfield.Bitlist{0b0011111, 0b1},
 				Keys:     []int{1, 0},
@@ -614,7 +438,7 @@ func TestMaxCover_MaxCoverProblem_Cover(t *testing.T) {
 		},
 		{
 			name: "k=50",
-			args: args{k: 50, candidates: problemSet(), allowDuplicates: true},
+			args: args{k: 50, candidates: problemSet()},
 			want: &Aggregation{
 				Coverage: bitfield.Bitlist{0b0011111, 0b1},
 				Keys:     []int{1, 0},
@@ -657,7 +481,7 @@ func TestMaxCover_MaxCoverProblem_Cover(t *testing.T) {
 			mc := &MaxCoverProblem{
 				Candidates: tt.args.candidates,
 			}
-			got, err := mc.Cover(tt.args.k, tt.args.allowOverlaps, tt.args.allowDuplicates)
+			got, err := mc.Cover(tt.args.k, tt.args.allowOverlaps)
 			if tt.wantedErr != "" {
 				assert.ErrorContains(t, tt.wantedErr, err)
 			} else {


### PR DESCRIPTION
**What type of PR is this?**

> Other / Optimization

**What does this PR do? Why is it needed?**
- Extracted from #7938
- This PR removes redundant deduplication routine from max cover function:
  - Duplicate items do not have any effect on the resultant cover, and are effectively excluded by greedy selection routine (we are selecting based on **uncovered** bits, and any duplicate coming second to that selection procedure, will hence have a zero score and excluded).
  - Deduplication is certainly not a part of algorithm anyway, so if one wants to dedup - it must be done outside the max-cover functionality (and we, indeed, are checking for attestation duplicates when adding unaggregated attestations to attestation pool).

**Which issues(s) does this PR fix?**

Part of #7871

**Other notes for review**
