### PR TITLE
Optimize Migration for new Attester Protection DB

### DIFF
--- a/validator/db/kv/BUILD.bazel
+++ b/validator/db/kv/BUILD.bazel
@@ -54,10 +54,13 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//shared/bytesutil:go_default_library",
+        "//shared/fileutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_golang_snappy//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@io_etcd_go_bbolt//:go_default_library",
     ],

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -113,6 +113,11 @@ func NewKVStore(ctx context.Context, dirPath string, pubKeys [][48]byte) (*Store
 		}
 	}
 
+	// Perform a special migration to an optimal attester protection DB schema.
+	if err := kv.migrateOptimalAttesterProtection(ctx); err != nil {
+		return nil, errors.Wrap(err, "could not migrate attester protection to more efficient format")
+	}
+
 	if err := kv.PruneAttestationsOlderThanCurrentWeakSubjectivity(ctx); err != nil {
 		return nil, errors.Wrap(err, "could not prune old attestations from DB")
 	}

--- a/validator/db/kv/migration.go
+++ b/validator/db/kv/migration.go
@@ -12,7 +12,6 @@ type migration func(*bolt.Tx) error
 
 var migrations = []migration{
 	migrateSnappyAttestationHistory,
-	migrateOptimalAttesterProtection,
 }
 
 // RunMigrations defined in the migrations array.

--- a/validator/db/kv/migration_optimal_attester_protection.go
+++ b/validator/db/kv/migration_optimal_attester_protection.go
@@ -3,7 +3,6 @@ package kv
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/golang/snappy"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -30,11 +29,9 @@ func (store *Store) migrateOptimalAttesterProtection(ctx context.Context) error 
 		bkt := tx.Bucket(historicAttestationsBucket)
 		numKeys = bkt.Stats().KeyN
 		if err := bkt.ForEach(func(k, v []byte) error {
-			fmt.Println("Looping through every key...")
 			if v == nil {
 				return nil
 			}
-			fmt.Println("Creating att buckets")
 			bucket := tx.Bucket(pubKeysBucket)
 			pkBucket, err := bucket.CreateBucketIfNotExists(k)
 			if err != nil {

--- a/validator/db/kv/migration_optimal_attester_protection_test.go
+++ b/validator/db/kv/migration_optimal_attester_protection_test.go
@@ -3,71 +3,35 @@ package kv
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/golang/snappy"
-	bolt "go.etcd.io/bbolt"
-
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/fileutil"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	bolt "go.etcd.io/bbolt"
 )
-
-func TestMemory_migrateOptimalAttesterProtection(t *testing.T) {
-	ctx := context.Background()
-	numValidators := 2000
-	pubKeys := make([][48]byte, numValidators)
-	for i := 0; i < numValidators; i++ {
-		var pk [48]byte
-		copy(pk[:], fmt.Sprintf("%d", i))
-		pubKeys[i] = pk
-	}
-	validatorDB := setupDB(t, pubKeys)
-	history := NewAttestationHistoryArray(0)
-	// Attest all epochs from genesis to 8500 (similar to mainnet).
-	numEpochs := uint64(11425)
-	for i := uint64(1); i <= numEpochs; i++ {
-		var sr [32]byte
-		copy(sr[:], fmt.Sprintf("%d", i))
-		newHist, err := history.SetTargetData(ctx, i, &HistoryData{
-			Source:      i - 1,
-			SigningRoot: sr[:],
-		})
-		require.NoError(t, err)
-		history = newHist
-	}
-	newHist, err := history.SetLatestEpochWritten(ctx, numEpochs)
-	require.NoError(t, err)
-	enc := snappy.Encode(nil /*dst*/, newHist)
-
-	err = validatorDB.setupHistoryForTest(pubKeys, enc)
-	require.NoError(t, err)
-
-	// Attempt a migration.
-	fmt.Printf("Attempting migration for %d validators each attesting %d epochs\n", numValidators, numEpochs)
-	start := time.Now()
-	require.NoError(t, validatorDB.migrateTxCommit())
-	end := time.Now()
-	fmt.Printf("Migration complete, took %v\n", end.Sub(start))
-}
 
 func Test_migrateOptimalAttesterProtection(t *testing.T) {
 	tests := []struct {
 		name  string
-		setup func(t *testing.T, db *bolt.DB)
-		eval  func(t *testing.T, db *bolt.DB)
+		setup func(t *testing.T, validatorDB *Store)
+		eval  func(t *testing.T, validatorDB *Store)
 	}{
 		{
 			name: "only runs once",
-			setup: func(t *testing.T, db *bolt.DB) {
-				err := db.Update(func(tx *bolt.Tx) error {
+			setup: func(t *testing.T, validatorDB *Store) {
+				err := validatorDB.update(func(tx *bolt.Tx) error {
 					return tx.Bucket(migrationsBucket).Put(migrationOptimalAttesterProtectionKey, migrationCompleted)
 				})
 				require.NoError(t, err)
 			},
-			eval: func(t *testing.T, db *bolt.DB) {
-				err := db.View(func(tx *bolt.Tx) error {
+			eval: func(t *testing.T, validatorDB *Store) {
+				err := validatorDB.view(func(tx *bolt.Tx) error {
 					data := tx.Bucket(migrationsBucket).Get(migrationOptimalAttesterProtectionKey)
 					require.DeepEqual(t, data, migrationCompleted)
 					return nil
@@ -77,7 +41,7 @@ func Test_migrateOptimalAttesterProtection(t *testing.T) {
 		},
 		{
 			name: "populates optimized schema buckets",
-			setup: func(t *testing.T, db *bolt.DB) {
+			setup: func(t *testing.T, validatorDB *Store) {
 				ctx := context.Background()
 				pubKey := [48]byte{1}
 				history := NewAttestationHistoryArray(0)
@@ -96,17 +60,17 @@ func Test_migrateOptimalAttesterProtection(t *testing.T) {
 				newHist, err := history.SetLatestEpochWritten(ctx, numEpochs)
 				require.NoError(t, err)
 
-				err = db.Update(func(tx *bolt.Tx) error {
+				err = validatorDB.update(func(tx *bolt.Tx) error {
 					bucket := tx.Bucket(historicAttestationsBucket)
 					enc := snappy.Encode(nil /*dst*/, newHist)
 					return bucket.Put(pubKey[:], enc)
 				})
 				require.NoError(t, err)
 			},
-			eval: func(t *testing.T, db *bolt.DB) {
+			eval: func(t *testing.T, validatorDB *Store) {
 				// Verify we indeed have the data for all epochs
 				// since genesis to epoch 50 under the new schema.
-				err := db.View(func(tx *bolt.Tx) error {
+				err := validatorDB.view(func(tx *bolt.Tx) error {
 					pubKey := [48]byte{1}
 					bucket := tx.Bucket(pubKeysBucket)
 					pkBucket := bucket.Bucket(pubKey[:])
@@ -137,7 +101,7 @@ func Test_migrateOptimalAttesterProtection(t *testing.T) {
 		},
 		{
 			name: "partial data saved for both types still completes the migration successfully",
-			setup: func(t *testing.T, db *bolt.DB) {
+			setup: func(t *testing.T, validatorDB *Store) {
 				ctx := context.Background()
 				pubKey := [48]byte{1}
 				history := NewAttestationHistoryArray(0)
@@ -156,7 +120,7 @@ func Test_migrateOptimalAttesterProtection(t *testing.T) {
 				newHist, err := history.SetLatestEpochWritten(ctx, numEpochs)
 				require.NoError(t, err)
 
-				err = db.Update(func(tx *bolt.Tx) error {
+				err = validatorDB.update(func(tx *bolt.Tx) error {
 					bucket := tx.Bucket(historicAttestationsBucket)
 					enc := snappy.Encode(nil /*dst*/, newHist)
 					return bucket.Put(pubKey[:], enc)
@@ -164,10 +128,10 @@ func Test_migrateOptimalAttesterProtection(t *testing.T) {
 				require.NoError(t, err)
 
 				// Run the migration.
-				require.NoError(t, db.Update(migrateOptimalAttesterProtection))
+				require.NoError(t, validatorDB.migrateOptimalAttesterProtection(ctx))
 
 				// Then delete the migration completed key.
-				err = db.Update(func(tx *bolt.Tx) error {
+				err = validatorDB.update(func(tx *bolt.Tx) error {
 					mb := tx.Bucket(migrationsBucket)
 					return mb.Delete(migrationOptimalAttesterProtectionKey)
 				})
@@ -184,17 +148,17 @@ func Test_migrateOptimalAttesterProtection(t *testing.T) {
 				newHist, err = newHist.SetLatestEpochWritten(ctx, numEpochs+1)
 				require.NoError(t, err)
 
-				err = db.Update(func(tx *bolt.Tx) error {
+				err = validatorDB.update(func(tx *bolt.Tx) error {
 					bucket := tx.Bucket(historicAttestationsBucket)
 					enc := snappy.Encode(nil /*dst*/, newHist)
 					return bucket.Put(pubKey[:], enc)
 				})
 				require.NoError(t, err)
 			},
-			eval: func(t *testing.T, db *bolt.DB) {
+			eval: func(t *testing.T, validatorDB *Store) {
 				// Verify we indeed have the data for all epochs
 				// since genesis to epoch 50+1 under the new schema.
-				err := db.View(func(tx *bolt.Tx) error {
+				err := validatorDB.view(func(tx *bolt.Tx) error {
 					pubKey := [48]byte{1}
 					bucket := tx.Bucket(pubKeysBucket)
 					pkBucket := bucket.Bucket(pubKey[:])
@@ -226,10 +190,59 @@ func Test_migrateOptimalAttesterProtection(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			db := setupDB(t, nil).db
-			tt.setup(t, db)
-			assert.NoError(t, db.Update(migrateOptimalAttesterProtection), "migrateOptimalAttesterProtection(tx) error")
-			tt.eval(t, db)
+			validatorDB, err := setupDBWithoutMigration(t.TempDir())
+			require.NoError(t, err, "Failed to instantiate DB")
+			t.Cleanup(func() {
+				require.NoError(t, validatorDB.Close(), "Failed to close database")
+				require.NoError(t, validatorDB.ClearDB(), "Failed to clear database")
+			})
+			tt.setup(t, validatorDB)
+			require.NoError(t, validatorDB.migrateOptimalAttesterProtection(context.Background()))
+			tt.eval(t, validatorDB)
 		})
 	}
+}
+
+func setupDBWithoutMigration(dirPath string) (*Store, error) {
+	hasDir, err := fileutil.HasDir(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	if !hasDir {
+		if err := fileutil.MkdirAll(dirPath); err != nil {
+			return nil, err
+		}
+	}
+	datafile := filepath.Join(dirPath, ProtectionDbFileName)
+	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{Timeout: params.BeaconIoConfig().BoltTimeout})
+	if err != nil {
+		if errors.Is(err, bolt.ErrTimeout) {
+			return nil, errors.New("cannot obtain database lock, database may be in use by another process")
+		}
+		return nil, err
+	}
+
+	kv := &Store{
+		db:                         boltDB,
+		databasePath:               dirPath,
+		attestingHistoriesByPubKey: make(map[[48]byte]EncHistoryData),
+	}
+
+	if err := kv.db.Update(func(tx *bolt.Tx) error {
+		return createBuckets(
+			tx,
+			genesisInfoBucket,
+			historicAttestationsBucket,
+			historicProposalsBucket,
+			lowestSignedSourceBucket,
+			lowestSignedTargetBucket,
+			lowestSignedProposalsBucket,
+			highestSignedProposalsBucket,
+			pubKeysBucket,
+			migrationsBucket,
+		)
+	}); err != nil {
+		return nil, err
+	}
+	return kv, prometheus.Register(createBoltCollector(kv.db))
 }


### PR DESCRIPTION
Follow-up to #8212, which was taking almost 10Gb for 1000 validators, we need a way to optimize how we perform a db migration to the optimal format for attester protection. Thanks to @nisdas for this logic, he was able to reduce it to 140Mb for around 2000 validators by splitting the migration into multiple boltdb transactions.