### PR TITLE
Revert "Fix Attest early if valid block is received before 4 seconds"

### DIFF
--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -93,7 +93,6 @@ go_test(
         "//shared:go_default_library",
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
-        "//shared/event:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/mock:go_default_library",
         "//shared/params:go_default_library",

--- a/validator/client/mock_validator.go
+++ b/validator/client/mock_validator.go
@@ -186,6 +186,3 @@ func (fv *FakeValidator) AllValidatorsAreExited(ctx context.Context) (bool, erro
 	}
 	return ctx.Value(allValidatorsAreExitedCtxKey).(bool), nil
 }
-
-// ReceiveBlocks for mocking
-func (fv *FakeValidator) ReceiveBlocks(ctx context.Context) {}

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -36,7 +36,6 @@ type Validator interface {
 	UpdateDomainDataCaches(ctx context.Context, slot uint64)
 	WaitForWalletInitialization(ctx context.Context) error
 	AllValidatorsAreExited(ctx context.Context) (bool, error)
-	ReceiveBlocks(ctx context.Context)
 }
 
 // Run the main validator routine. This routine exits if the context is
@@ -71,8 +70,6 @@ func run(ctx context.Context, v Validator) {
 	if err := v.WaitForActivation(ctx); err != nil {
 		log.Fatalf("Could not wait for validator activation: %v", err)
 	}
-	go v.ReceiveBlocks(ctx)
-
 	headSlot, err := v.CanonicalHeadSlot(ctx)
 	if err != nil {
 		log.Fatalf("Could not get current canonical head slot: %v", err)

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -195,7 +195,6 @@ func (v *ValidatorService) Start() {
 		voteStats:                      voteStats{startEpoch: ^uint64(0)},
 		useWeb:                         v.useWeb,
 		walletInitializedFeed:          v.walletInitializedFeed,
-		blockFeed:                      new(event.Feed),
 		graffitiStruct:                 v.graffitiStruct,
 		logDutyCountDown:               v.logDutyCountDown,
 	}

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -69,9 +69,7 @@ type validator struct {
 	aggregatedSlotCommitteeIDCacheLock sync.Mutex
 	prevBalanceLock                    sync.RWMutex
 	walletInitializedFeed              *event.Feed
-	blockFeed                          *event.Feed
 	genesisTime                        uint64
-	highestValidSlot                   uint64
 	domainDataCache                    *ristretto.Cache
 	aggregatedSlotCommitteeIDCache     *lru.Cache
 	ticker                             *slotutil.SlotTicker
@@ -236,37 +234,6 @@ func (v *validator) SlasherReady(ctx context.Context) error {
 		}
 	}
 	return nil
-}
-
-// ReceiveBlocks starts a gRPC client stream listener to obtain
-// blocks from the beacon node. Upon receiving a block, the service
-// broadcasts it to a feed for other usages to subscribe to.
-func (v *validator) ReceiveBlocks(ctx context.Context) {
-	stream, err := v.beaconClient.StreamBlocks(ctx, &ethpb.StreamBlocksRequest{VerifiedOnly: true})
-	if err != nil {
-		log.WithError(err).Error("Failed to retrieve blocks stream")
-		return
-	}
-
-	for {
-		if ctx.Err() == context.Canceled {
-			log.WithError(ctx.Err()).Error("Context canceled - shutting down blocks receiver")
-			return
-		}
-		res, err := stream.Recv()
-		if err != nil {
-			log.WithError(err).Error("Could not receive blocks from beacon node")
-			return
-		}
-		if res == nil || res.Block == nil {
-			continue
-		}
-		if res.Block.Slot > v.highestValidSlot {
-			v.highestValidSlot = res.Block.Slot
-		}
-
-		v.blockFeed.Send(res)
-	}
 }
 
 func (v *validator) checkAndLogValidatorStatus(validatorStatuses []*ethpb.ValidatorActivationResponse_Status) bool {


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#8197

Rationale: We need #8206 to go in v1.0.6 first before rolling this into v1.0.7. This is to avoid incompatibility. Someone could update this only on validator without applying #8206 to the beacon node