### PR TITLE
Batch Attestation Records and Flush All at Once in Validator DB

### DIFF
--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -43,7 +43,7 @@ func (v *validator) slashableAttestationCheck(
 		return errors.Wrap(err, failedAttLocalProtectionErr)
 	}
 
-	if err := v.db.ApplyAttestationForPubKey(ctx, pubKey, signingRoot, indexedAtt); err != nil {
+	if err := v.db.SaveAttestationForPubKey(ctx, pubKey, signingRoot, indexedAtt); err != nil {
 		return errors.Wrap(err, "could not save attestation history for validator public key")
 	}
 

--- a/validator/db/iface/interface.go
+++ b/validator/db/iface/interface.go
@@ -41,7 +41,7 @@ type ValidatorDB interface {
 	CheckSlashableAttestation(
 		ctx context.Context, pubKey [48]byte, signingRoot [32]byte, att *ethpb.IndexedAttestation,
 	) (kv.SlashingKind, error)
-	ApplyAttestationForPubKey(
+	SaveAttestationForPubKey(
 		ctx context.Context, pubKey [48]byte, signingRoot [32]byte, att *ethpb.IndexedAttestation,
 	) error
 }

--- a/validator/db/kv/BUILD.bazel
+++ b/validator/db/kv/BUILD.bazel
@@ -63,6 +63,8 @@ go_test(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@io_etcd_go_bbolt//:go_default_library",
     ],
 )

--- a/validator/db/kv/BUILD.bazel
+++ b/validator/db/kv/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
         "//shared/bytesutil:go_default_library",
+        "//shared/event:go_default_library",
         "//shared/fileutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/progressutil:go_default_library",

--- a/validator/db/kv/BUILD.bazel
+++ b/validator/db/kv/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "db.go",
         "genesis.go",
         "historical_attestations.go",
+        "log.go",
         "migration.go",
         "migration_optimal_attester_protection.go",
         "migration_snappy_history.go",

--- a/validator/db/kv/attester_protection.go
+++ b/validator/db/kv/attester_protection.go
@@ -185,7 +185,7 @@ func (store *Store) flushAttestationRecords() {
 	}
 	// Forward the error, if any, to all subscribers via an event feed.
 	// We use a struct wrapper around the error as the event feed
-	// cannot handle sending a raw `nil` in case there is not error.
+	// cannot handle sending a raw `nil` in case there is no error.
 	store.batchAttestationsFlushedFeed.Send(saveAttestationsResponse{
 		err: err,
 	})

--- a/validator/db/kv/attester_protection.go
+++ b/validator/db/kv/attester_protection.go
@@ -104,10 +104,9 @@ func (store *Store) CheckSlashableAttestation(
 	return slashKind, err
 }
 
-// ApplyAttestationForPubKey applies an attestation for a validator public
-// key by storing its signing root under the appropriate bucket as well
-// as its source and target epochs for future slashing protection checks.
-func (store *Store) ApplyAttestationForPubKey(
+// SaveAttestationForPubKey saves an attestation for a validator public
+// key for local validator slashing protection.
+func (store *Store) SaveAttestationForPubKey(
 	ctx context.Context, pubKey [48]byte, signingRoot [32]byte, att *ethpb.IndexedAttestation,
 ) error {
 	store.batchedAttestationsChan <- &attestationRecord{

--- a/validator/db/kv/attester_protection.go
+++ b/validator/db/kv/attester_protection.go
@@ -167,10 +167,12 @@ func (store *Store) batchAttestationWrites(ctx context.Context) {
 // of the result of the save operation.
 func (store *Store) flushAttestationRecords() {
 	err := store.saveAttestationRecords(store.batchedAttestations)
+	// If there was no error, we reset the batched attestations slice.
 	if err == nil {
 		log.Debug("Successfully flushed batched attestations to DB")
 		store.batchedAttestations = make([]*attestationRecord, 0, ATTESTATION_BATCH_CAPACITY)
 	}
+	// Forward the error, if any, to all subscribers via an event feed.
 	store.batchAttestationsFlushedFeed.Send(err)
 }
 

--- a/validator/db/kv/attester_protection.go
+++ b/validator/db/kv/attester_protection.go
@@ -142,13 +142,17 @@ func (store *Store) batchAttestationWrites(ctx context.Context) {
 		case v := <-store.batchedAttestationsChan:
 			store.batchedAttestations = append(store.batchedAttestations, v)
 			if len(store.batchedAttestations) == ATTESTATION_BATCH_CAPACITY {
-				log.Debug("Reached max capacity of batched attestations, flushing to DB")
+				log.WithField("numRecords", ATTESTATION_BATCH_CAPACITY).Debug(
+					"Reached max capacity of batched attestation records, flushing to DB",
+				)
 				store.flushAttestationRecords()
 				timer.Reset(ATTESTATION_BATCH_WRITE_INTERVAL)
 			}
 		case <-timer.C:
 			if len(store.batchedAttestations) > 0 {
-				log.Debug("Batched attestations write interval reached, flushing to DB")
+				log.WithField("numRecords", len(store.batchedAttestations)).Debug(
+					"Batched attestation records write interval reached, flushing to DB",
+				)
 				store.flushAttestationRecords()
 			}
 			timer.Reset(ATTESTATION_BATCH_WRITE_INTERVAL)

--- a/validator/db/kv/attester_protection.go
+++ b/validator/db/kv/attester_protection.go
@@ -184,6 +184,8 @@ func (store *Store) flushAttestationRecords() {
 		store.batchedAttestations = make([]*attestationRecord, 0, ATTESTATION_BATCH_CAPACITY)
 	}
 	// Forward the error, if any, to all subscribers via an event feed.
+	// We use a struct wrapper around the error as the event feed
+	// cannot handle sending a raw `nil` in case there is not error.
 	store.batchAttestationsFlushedFeed.Send(saveAttestationsResponse{
 		err: err,
 	})

--- a/validator/db/kv/attester_protection.go
+++ b/validator/db/kv/attester_protection.go
@@ -142,19 +142,19 @@ func (store *Store) SaveAttestationForPubKey(
 
 // Meant to run as a background routine, this function checks whether:
 // (a) we have reached a max capacity of batched attestations in the Store or
-// (b) ATTESTATION_BATCH_WRITE_INTERVAL has passed
+// (b) attestationBatchWriteInterval has passed
 // Based on whichever comes first, this function then proceeds
 // to flush the attestations to the DB all at once in a single boltDB
 // transaction for efficiency. Then, batched attestations slice is emptied out.
 func (store *Store) batchAttestationWrites(ctx context.Context) {
-	ticker := time.NewTicker(ATTESTATION_BATCH_WRITE_INTERVAL)
+	ticker := time.NewTicker(attestationBatchWriteInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case v := <-store.batchedAttestationsChan:
 			store.batchedAttestations = append(store.batchedAttestations, v)
-			if len(store.batchedAttestations) == ATTESTATION_BATCH_CAPACITY {
-				log.WithField("numRecords", ATTESTATION_BATCH_CAPACITY).Debug(
+			if len(store.batchedAttestations) == attestationBatchCapacity {
+				log.WithField("numRecords", attestationBatchCapacity).Debug(
 					"Reached max capacity of batched attestation records, flushing to DB",
 				)
 				store.flushAttestationRecords()
@@ -181,7 +181,7 @@ func (store *Store) flushAttestationRecords() {
 	// If there was no error, we reset the batched attestations slice.
 	if err == nil {
 		log.Debug("Successfully flushed batched attestations to DB")
-		store.batchedAttestations = make([]*attestationRecord, 0, ATTESTATION_BATCH_CAPACITY)
+		store.batchedAttestations = make([]*attestationRecord, 0, attestationBatchCapacity)
 	}
 	// Forward the error, if any, to all subscribers via an event feed.
 	// We use a struct wrapper around the error as the event feed

--- a/validator/db/kv/attester_protection_test.go
+++ b/validator/db/kv/attester_protection_test.go
@@ -61,7 +61,7 @@ func TestStore_CheckSlashableAttestation_DoubleVote(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validatorDB.ApplyAttestationForPubKey(
+			err := validatorDB.SaveAttestationForPubKey(
 				ctx,
 				pubKeys[0],
 				tt.existingSigningRoot,

--- a/validator/db/kv/attester_protection_test.go
+++ b/validator/db/kv/attester_protection_test.go
@@ -164,7 +164,7 @@ func TestSaveAttestationForPubKey_BatchWrites_FullCapacity(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	numValidators := ATTESTATION_BATCH_CAPACITY
+	numValidators := attestationBatchCapacity
 	pubKeys := make([][48]byte, numValidators)
 	validatorDB := setupDB(t, pubKeys)
 
@@ -221,7 +221,7 @@ func TestSaveAttestationForPubKey_BatchWrites_LowCapacity_TimerReached(t *testin
 	// of batch attestation processing. This will allow us to
 	// test force flushing to the DB based on a timer instead
 	// of the max capacity being reached.
-	numValidators := ATTESTATION_BATCH_CAPACITY / 2
+	numValidators := attestationBatchCapacity / 2
 	pubKeys := make([][48]byte, numValidators)
 	validatorDB := setupDB(t, pubKeys)
 

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/fileutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -22,7 +23,10 @@ const (
 )
 
 // ProtectionDbFileName Validator slashing protection db file name.
-var ProtectionDbFileName = "validator.db"
+var (
+	ProtectionDbFileName = "validator.db"
+	log                  = logrus.WithField("prefix", "db")
+)
 
 // Store defines an implementation of the Prysm Database interface
 // using BoltDB as the underlying persistent kv-store for eth2.

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/fileutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"github.com/sirupsen/logrus"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -32,7 +31,6 @@ const (
 // ProtectionDbFileName Validator slashing protection db file name.
 var (
 	ProtectionDbFileName = "validator.db"
-	log                  = logrus.WithField("prefix", "db")
 )
 
 // Store defines an implementation of the Prysm Database interface

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -18,7 +18,14 @@ import (
 )
 
 const (
-	ATTESTATION_BATCH_CAPACITY       = 2048
+	// How many attestation records we can hold in memory
+	// before we flush them to the database. Roughly corresponds
+	// to the max number of keys per validator client, but there is no
+	// detriment if there are more keys than this capacity, as attestations
+	// for those keys will simply be flushed at the next flush interval.
+	ATTESTATION_BATCH_CAPACITY = 2048
+	// How often we will flush attestation records to the database
+	// from a batch kept in memory for slashing protection.
 	ATTESTATION_BATCH_WRITE_INTERVAL = time.Millisecond * 100
 )
 

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -23,10 +23,10 @@ const (
 	// to the max number of keys per validator client, but there is no
 	// detriment if there are more keys than this capacity, as attestations
 	// for those keys will simply be flushed at the next flush interval.
-	ATTESTATION_BATCH_CAPACITY = 2048
+	attestationBatchCapacity = 2048
 	// How often we will flush attestation records to the database
 	// from a batch kept in memory for slashing protection.
-	ATTESTATION_BATCH_WRITE_INTERVAL = time.Millisecond * 100
+	attestationBatchWriteInterval = time.Millisecond * 100
 )
 
 // ProtectionDbFileName Validator slashing protection db file name.
@@ -106,8 +106,8 @@ func NewKVStore(ctx context.Context, dirPath string, pubKeys [][48]byte) (*Store
 	kv := &Store{
 		db:                           boltDB,
 		databasePath:                 dirPath,
-		batchedAttestations:          make([]*attestationRecord, 0, ATTESTATION_BATCH_CAPACITY),
-		batchedAttestationsChan:      make(chan *attestationRecord, ATTESTATION_BATCH_CAPACITY),
+		batchedAttestations:          make([]*attestationRecord, 0, attestationBatchCapacity),
+		batchedAttestationsChan:      make(chan *attestationRecord, attestationBatchCapacity),
 		batchAttestationsFlushedFeed: new(event.Feed),
 	}
 

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	ATTESTATION_BATCH_CAPACITY       = 4096
+	ATTESTATION_BATCH_CAPACITY       = 2048
 	ATTESTATION_BATCH_WRITE_INTERVAL = time.Millisecond * 100
 )
 

--- a/validator/db/kv/db_test.go
+++ b/validator/db/kv/db_test.go
@@ -2,10 +2,19 @@ package kv
 
 import (
 	"context"
+	"io/ioutil"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"github.com/sirupsen/logrus"
 )
+
+func TestMain(m *testing.M) {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
+
+	m.Run()
+}
 
 // setupDB instantiates and returns a DB instance for the validator client.
 func setupDB(t testing.TB, pubkeys [][48]byte) *Store {

--- a/validator/db/kv/historical_attestations.go
+++ b/validator/db/kv/historical_attestations.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	log "github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
 

--- a/validator/db/kv/log.go
+++ b/validator/db/kv/log.go
@@ -1,0 +1,7 @@
+package kv
+
+import "github.com/sirupsen/logrus"
+
+var (
+	log = logrus.WithField("prefix", "db")
+)

--- a/validator/db/kv/migration_optimal_attester_protection_test.go
+++ b/validator/db/kv/migration_optimal_attester_protection_test.go
@@ -223,9 +223,8 @@ func setupDBWithoutMigration(dirPath string) (*Store, error) {
 	}
 
 	kv := &Store{
-		db:                         boltDB,
-		databasePath:               dirPath,
-		attestingHistoriesByPubKey: make(map[[48]byte]EncHistoryData),
+		db:           boltDB,
+		databasePath: dirPath,
 	}
 
 	if err := kv.db.Update(func(tx *bolt.Tx) error {

--- a/validator/slashing-protection/local/standard-protection-format/import.go
+++ b/validator/slashing-protection/local/standard-protection-format/import.go
@@ -108,7 +108,7 @@ func ImportStandardProtectionJSON(ctx context.Context, validatorDB db.Database, 
 					},
 				},
 			}
-			if err := validatorDB.ApplyAttestationForPubKey(ctx, pubKey, att.signingRoot, indexedAtt); err != nil {
+			if err := validatorDB.SaveAttestationForPubKey(ctx, pubKey, att.signingRoot, indexedAtt); err != nil {
 				return errors.Wrap(err, "could not save attestation from imported JSON to database")
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Part of #8242, the new attester protection methods have a serious flaw when running many validating keys, as all of them will attempt to acquire the boltDB write lock and lead to significant contention. Instead of every single attestation being its own boltDB transaction, we do the following:

When a validator attempts to save an attestation record to the DB:
1. We send the attestation over a channel and also subscribe to a feed that will notify us when the saving is complete. Block until we are notified.
2. We run a routine in the background which batches these channel receives into a slice
3. If a certain amount of time passes or if the max capacity of the slice is reached, **whichever comes first**, we save the batched attestations in a single bolt transaction
4. Once flushing completes, we notify all listeners to unblock them

This approach preserves **atomicity**, as saving will be required before the validator proceeds with submitting the attestation to the beacon node. It is simply a layer of abstraction that improves efficiency.

### Parameter discussion

There are two important parameters in this PR we should discuss that affect the effectiveness of these changes.

```go
const (
	ATTESTATION_BATCH_WRITE_INTERVAL = time.Millisecond * 100
	ATTESTATION_BATCH_CAPACITY       = 2048
)
```
The first parameter, `ATTESTATION_BATCH_WRITE_INTERVAL` corresponds to how often we will force flush attestation records to the validator DB. This means that every 100 milliseconds, we will always try to save batched attestations `if len(atts) > 0`. 

The second parameter, `ATTESTATION_BATCH_CAPACITY` describes how many attestations are held in a slice in memory before they are force flushed to the DB. If we hit this capacity, we will always attempt to force flush. 2048 is selected as a default because that's as high a number of keys we can imagine a single validator client will run on mainnet.

Given an attestation record is represented as:

```go
type attestationRecord struct {
  target uint64
  source uint64
  signingRoot [32]byte
  pubKey [48]byte
}
```
storing max 2048 x 96 bytes in memory before flushing totals to around 196kb, which is negligible.

`ATTESTATION_BATCH_CAPACITY` roughly corresponds to the max number of validating keys we expect a validator client to be running at the same time. If we are running more than this capacity, any leftover attestations will have to enter the next batch and be saved at the next `ATTESTATION_BATCH_WRITE_INTERVAL`. The `ATTESTATION_BATCH_WRITE_INTERVAL` corresponds to an acceptable interval at which we can process batches. 100ms is short enough that the flushing will feel like a simple, synchronous update instead.
