### PR TITLE
Testutil: Can generate attestation at epoch boundary

### DIFF
--- a/shared/testutil/attestation.go
+++ b/shared/testutil/attestation.go
@@ -41,15 +41,16 @@ func NewAttestation() *ethpb.Attestation {
 //
 // If you request 4 attestations, but there are 8 committees, you will get 4 fully aggregated attestations.
 func GenerateAttestations(bState *stateTrie.BeaconState, privs []bls.SecretKey, numToGen, slot uint64, randomRoot bool) ([]*ethpb.Attestation, error) {
-	currentEpoch := helpers.SlotToEpoch(slot)
 	var attestations []*ethpb.Attestation
 	generateHeadState := false
+
 	bState = bState.Copy()
 	if slot > bState.Slot() {
 		// Going back a slot here so there's no inclusion delay issues.
 		slot--
 		generateHeadState = true
 	}
+	currentEpoch := helpers.SlotToEpoch(slot)
 
 	targetRoot := make([]byte, 32)
 	var headRoot []byte

--- a/shared/testutil/attestation.go
+++ b/shared/testutil/attestation.go
@@ -43,7 +43,6 @@ func NewAttestation() *ethpb.Attestation {
 func GenerateAttestations(bState *stateTrie.BeaconState, privs []bls.SecretKey, numToGen, slot uint64, randomRoot bool) ([]*ethpb.Attestation, error) {
 	var attestations []*ethpb.Attestation
 	generateHeadState := false
-
 	bState = bState.Copy()
 	if slot > bState.Slot() {
 		// Going back a slot here so there's no inclusion delay issues.

--- a/shared/testutil/attestation_test.go
+++ b/shared/testutil/attestation_test.go
@@ -32,3 +32,9 @@ func TestHydrateIndexedAttestation(t *testing.T) {
 	_, err = a.Data.HashTreeRoot()
 	require.NoError(t, err)
 }
+
+func TestGenerateAttestations_EpochBoundary(t *testing.T) {
+	gs, pk := DeterministicGenesisState(t, 32)
+	_, err := GenerateAttestations(gs, pk, 1, params.BeaconConfig().SlotsPerEpoch, false)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix


**What does this PR do? Why is it needed?**

Fixes a bug in `GenerateAttestations` in pkg `testutil`.  `GenerateAttestations` works by decreasing input slot (n) by 1 (n-1), this ensures computed attestation has the on time property for the current slot. The `currentEpoch` which is used to calculate target root should respect the (n-1) property, or else at the epoch boundary slot we will be getting epoch out of bound. (ex: input slot 32, attestation slot 31, the epoch suppose to be 0 but it's 1)

**Which issues(s) does this PR fix?**

No issue. Discovered while writing blockchain unit tests.

**Other notes for review**

Only touches test code
