### PR TITLE
Introduce base structure for services

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
+        "//shared:go_default_library",
         "//shared/attestationutil:go_default_library",
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -111,10 +111,10 @@ func (s *Service) processAttestation(subscribedToStateEvents chan struct{}) {
 	st := slotutil.GetSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)
 	for {
 		select {
-		case <-s.ctx.Done():
+		case <-s.base.Ctx.Done():
 			return
 		case <-st.C():
-			ctx := s.ctx
+			ctx := s.base.Ctx
 			atts := s.attPool.ForkchoiceAttestations()
 			for _, a := range atts {
 				// Based on the spec, don't process the attestation until the subsequent slot.

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -154,7 +154,7 @@ func (s *Service) ReceiveBlockBatch(ctx context.Context, blocks []*ethpb.SignedB
 		reportSlotMetrics(blockCopy.Block.Slot, s.HeadSlot(), s.CurrentSlot(), s.finalizedCheckpt)
 	}
 
-	if err := s.VerifyWeakSubjectivityRoot(s.ctx); err != nil {
+	if err := s.VerifyWeakSubjectivityRoot(s.base.Ctx); err != nil {
 		// log.Fatalf will prevent defer from being called
 		span.End()
 		// Exit run time if the node failed to verify weak subjectivity checkpoint.

--- a/shared/service_registry.go
+++ b/shared/service_registry.go
@@ -3,6 +3,7 @@
 package shared
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -21,6 +22,30 @@ type Service interface {
 	Stop() error
 	// Returns error if the service is not considered healthy.
 	Status() error
+}
+
+// ServiceBase TODO
+type ServiceBase struct {
+	Ctx    context.Context    // Ctx TODO
+	cancel context.CancelFunc // YOU SHALT NOT CANCEL
+}
+
+// Stop TODO
+func (s *ServiceBase) Stop() {
+	defer func() {
+		if s.cancel != nil {
+			s.cancel()
+		}
+	}()
+}
+
+// NewServiceBase TODO
+func NewServiceBase(ctx context.Context) *ServiceBase {
+	ctx, cancel := context.WithCancel(ctx)
+	return &ServiceBase{
+		Ctx:    ctx,
+		cancel: cancel,
+	}
 }
 
 // ServiceRegistry provides a useful pattern for managing services.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

At the moment all services contain a context `ctx` and a cancellation function `cancel`, as well as some "standard" code to instantiate these values and cancel the context in the `Stop` function. The reason why I wrote "standard" in parenthesis is because different services use different approaches, leading to inconsistent code for the exact same functionality.

Examples:

```
if s.cancel != nil {
    s.cancel()
}
```
```
defer s.cancel()
```
```
if s.cancel != nil {
    defer s.cancel()
}
```

Moreover, it's easy for an `s.cancel()` piece of code to go unnoticed during a code review, and calling `s.cancel()` manually is always a mistake. `Stop()` should be invoked instead because it may contain necessary cleanup code.

This PR introduces a `ServiceBase` struct which should be nested inside each service. It handles the boilerplate work of context cancelling, so that service implementers only need to invoke `s.base.Stop()` at the beginning of the service's `Stop()` function to make sure they handle cancelling correctly. It also does not allow to cancel the context directly from external code, making it necessary to invoke `Stop()` instead. Another benefit of this approach is that it will be easy to extend services in the future if we want to ensure consistent and common behavior - just place the relevant code in `ServiceBase`.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
