### PR TITLE
isCanonical for slot 0 should return true

### DIFF
--- a/beacon-chain/rpc/beacon/validators.go
+++ b/beacon-chain/rpc/beacon/validators.go
@@ -859,6 +859,10 @@ func (bs *Server) GetIndividualVotes(
 // if the input slot has a skip block, false is returned,
 // if the input slot has more than one block, an error is returned.
 func (bs *Server) isSlotCanonical(ctx context.Context, slot uint64) (bool, error) {
+	if slot == 0 {
+		return true, nil
+	}
+
 	hasBlockRoots, roots, err := bs.BeaconDB.BlockRootsBySlot(ctx, slot)
 	if err != nil {
 		return false, err

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -2142,3 +2142,11 @@ func TestServer_isSlotCanonical(t *testing.T) {
 		}
 	}
 }
+
+func TestServer_isSlotCanonicalForSlot0(t *testing.T) {
+	ctx := context.Background()
+	bs := &Server{}
+	c, err := bs.isSlotCanonical(ctx, 0)
+	require.NoError(t, err)
+	require.Equal(t, true, c)
+}


### PR DESCRIPTION
**What type of PR is this?**

> Enhancement

**What does this PR do? Why is it needed?**

Immediately return `true` from `isSlotCanonical` when `slot=0`, so it doesn't need to reach the DB and found that the block root matches genesis block root. It is a followup PR of the discussion here: https://github.com/prysmaticlabs/prysm/pull/8184#issuecomment-752143115

**Which issues(s) does this PR fix?**

**Other notes for review**
