### PR TITLE
Blocks filtering should return genesis when startSlot=0 and endSlot=0

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -442,6 +442,11 @@ func fetchBlockRootsBySlotRange(
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.fetchBlockRootsBySlotRange")
 	defer span.End()
 
+	// Return nothing when all slot parameters are missing
+	if startSlotEncoded == nil && endSlotEncoded == nil && startEpochEncoded == nil && endEpochEncoded == nil {
+		return [][]byte{}, nil
+	}
+
 	var startSlot, endSlot, step uint64
 	var ok bool
 	if startSlot, ok = startSlotEncoded.(uint64); !ok {
@@ -475,10 +480,6 @@ func fetchBlockRootsBySlotRange(
 	}
 	if endSlot < startSlot {
 		return nil, errInvalidSlotRange
-	}
-	// Return nothing with an end slot of 0.
-	if endSlot == 0 {
-		return [][]byte{}, nil
 	}
 	rootsRange := (endSlot - startSlot) / step
 	roots := make([][]byte, 0, rootsRange)

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -118,7 +118,7 @@ func TestStore_BlocksHandleZeroCase(t *testing.T) {
 	zeroFilter := filters.NewFilter().SetStartSlot(0).SetEndSlot(0)
 	retrieved, _, err := db.Blocks(ctx, zeroFilter)
 	require.NoError(t, err)
-	assert.Equal(t, 0, len(retrieved), "Unexpected number of blocks received, expected none")
+	assert.Equal(t, 1, len(retrieved), "Unexpected number of blocks received, expected one")
 }
 
 func TestStore_BlocksHandleInvalidEndSlot(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

It is a follow up on the finding here: https://github.com/prysmaticlabs/prysm/pull/8184#issuecomment-752040000
`db.Blocks` filtering will return `[][]byte{}` if `endSlot=0`, which seems to be intended before for the case that no slot related parameters are set. But it is legitimate to query `startSlot=0 and endSlot=0` for the genesis block, this PR fixes this behaviour. Also, instead of checking `endSlot=0`, it checks if any slot related parameters are set at the beginning, if not, return empty slice.

**Which issues(s) does this PR fix?**

**Other notes for review**

We have `db.getBlocksBySlot` now for getting blocks for particular slot so there is not much chance to query with filter `startSlot=0 and endSlot=0`