### PR TITLE
Use remote cache in CI

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -9,7 +9,7 @@
 #build:remote-cache --strategy=Genrule=standalone
 
 # Prysm specific remote-cache properties.
-#build:remote-cache --disk_cache=
+build:remote-cache --disk_cache=
 #build:remote-cache --remote_download_minimal
 
 # Import workspace options.

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -2,7 +2,7 @@
 # across machines, developers, and workspaces.
 # 
 # This config is loaded from https://github.com/bazelbuild/bazel-toolchains/blob/master/bazelrc/latest.bazelrc
-build:remote-cache --remote_timeout=3600
+#build:remote-cache --remote_timeout=3600
 #build:remote-cache --spawn_strategy=standalone
 #build:remote-cache --strategy=Javac=standalone
 #build:remote-cache --strategy=Closure=standalone
@@ -10,7 +10,7 @@ build:remote-cache --remote_timeout=3600
 
 # Prysm specific remote-cache properties.
 #build:remote-cache --disk_cache=
-build:remote-cache --remote_download_minimal
+#build:remote-cache --remote_download_minimal
 
 # Import workspace options.
 import %workspace%/.bazelrc

--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -31,6 +31,7 @@ build --curses=yes --color=no
 build --keep_going
 build --test_output=errors
 build --flaky_test_attempts=5
+build --remote_local_fallback --remote_cache=grpc://bazel-remote-cache:9092
 # Disabled race detection due to unstable test results under constrained environment build kite
 # build --features=race
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Since the builders / workers are ephemeral, a stable remote cache should significantly reduce build times in CI.
I have been running this setup locally for about a week and noticed a great improvement when switching branches and cross compiling.  

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

Follow up to #8111.