### PR TITLE
Add canonical flag to ListBlocks API response

### DIFF
--- a/beacon-chain/rpc/beacon/blocks.go
+++ b/beacon-chain/rpc/beacon/blocks.go
@@ -63,9 +63,14 @@ func (bs *Server) ListBlocks(
 			if err != nil {
 				return nil, err
 			}
+			canonical, err := bs.CanonicalFetcher.IsCanonical(ctx, root)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "Could not determine if block is canonical: %v", err)
+			}
 			containers[i] = &ethpb.BeaconBlockContainer{
 				Block:     b,
 				BlockRoot: root[:],
+				Canonical: canonical,
 			}
 		}
 
@@ -90,11 +95,16 @@ func (bs *Server) ListBlocks(
 		if err != nil {
 			return nil, err
 		}
+		canonical, err := bs.CanonicalFetcher.IsCanonical(ctx, root)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not determine if block is canonical: %v", err)
+		}
 
 		return &ethpb.ListBlocksResponse{
 			BlockContainers: []*ethpb.BeaconBlockContainer{{
 				Block:     blk,
-				BlockRoot: root[:]},
+				BlockRoot: root[:],
+				Canonical: canonical},
 			},
 			TotalSize: 1,
 		}, nil
@@ -126,9 +136,14 @@ func (bs *Server) ListBlocks(
 			if err != nil {
 				return nil, err
 			}
+			canonical, err := bs.CanonicalFetcher.IsCanonical(ctx, root)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "Could not determine if block is canonical: %v", err)
+			}
 			containers[i] = &ethpb.BeaconBlockContainer{
 				Block:     b,
 				BlockRoot: root[:],
+				Canonical: canonical,
 			}
 		}
 
@@ -149,10 +164,15 @@ func (bs *Server) ListBlocks(
 		if err != nil {
 			return nil, err
 		}
+		canonical, err := bs.CanonicalFetcher.IsCanonical(ctx, root)
+		if err != nil {
+			return nil, err
+		}
 		containers := []*ethpb.BeaconBlockContainer{
 			{
 				Block:     genBlk,
 				BlockRoot: root[:],
+				Canonical: canonical,
 			},
 		}
 

--- a/beacon-chain/rpc/beacon/blocks.go
+++ b/beacon-chain/rpc/beacon/blocks.go
@@ -164,15 +164,11 @@ func (bs *Server) ListBlocks(
 		if err != nil {
 			return nil, err
 		}
-		canonical, err := bs.CanonicalFetcher.IsCanonical(ctx, root)
-		if err != nil {
-			return nil, err
-		}
 		containers := []*ethpb.BeaconBlockContainer{
 			{
 				Block:     genBlk,
 				BlockRoot: root[:],
-				Canonical: canonical,
+				Canonical: true,
 			},
 		}
 

--- a/beacon-chain/rpc/beacon/blocks_test.go
+++ b/beacon-chain/rpc/beacon/blocks_test.go
@@ -71,14 +71,10 @@ func TestServer_ListBlocks_NoResults(t *testing.T) {
 
 func TestServer_ListBlocks_Genesis(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	chain := &chainMock.ChainService{
-		CanonicalRoots: map[[32]byte]bool{},
-	}
 	ctx := context.Background()
 
 	bs := &Server{
-		BeaconDB:         db,
-		CanonicalFetcher: chain,
+		BeaconDB: db,
 	}
 
 	// Should throw an error if no genesis block is found.
@@ -97,7 +93,6 @@ func TestServer_ListBlocks_Genesis(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.SaveBlock(ctx, blk))
 	require.NoError(t, db.SaveGenesisBlockRoot(ctx, root))
-	chain.CanonicalRoots[root] = true
 	wanted := &ethpb.ListBlocksResponse{
 		BlockContainers: []*ethpb.BeaconBlockContainer{
 			{
@@ -122,14 +117,10 @@ func TestServer_ListBlocks_Genesis(t *testing.T) {
 
 func TestServer_ListBlocks_Genesis_MultiBlocks(t *testing.T) {
 	db := dbTest.SetupDB(t)
-	chain := &chainMock.ChainService{
-		CanonicalRoots: map[[32]byte]bool{},
-	}
 	ctx := context.Background()
 
 	bs := &Server{
-		BeaconDB:         db,
-		CanonicalFetcher: chain,
+		BeaconDB: db,
 	}
 	// Should return the proper genesis block if it exists.
 	parentRoot := [32]byte{1, 2, 3}
@@ -139,7 +130,6 @@ func TestServer_ListBlocks_Genesis_MultiBlocks(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.SaveBlock(ctx, blk))
 	require.NoError(t, db.SaveGenesisBlockRoot(ctx, root))
-	chain.CanonicalRoots[root] = true
 
 	count := uint64(100)
 	blks := make([]*ethpb.SignedBeaconBlock, count)

--- a/beacon-chain/rpc/beacon/blocks_test.go
+++ b/beacon-chain/rpc/beacon/blocks_test.go
@@ -71,10 +71,14 @@ func TestServer_ListBlocks_NoResults(t *testing.T) {
 
 func TestServer_ListBlocks_Genesis(t *testing.T) {
 	db := dbTest.SetupDB(t)
+	chain := &chainMock.ChainService{
+		CanonicalRoots: map[[32]byte]bool{},
+	}
 	ctx := context.Background()
 
 	bs := &Server{
-		BeaconDB: db,
+		BeaconDB:         db,
+		CanonicalFetcher: chain,
 	}
 
 	// Should throw an error if no genesis block is found.
@@ -93,11 +97,13 @@ func TestServer_ListBlocks_Genesis(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.SaveBlock(ctx, blk))
 	require.NoError(t, db.SaveGenesisBlockRoot(ctx, root))
+	chain.CanonicalRoots[root] = true
 	wanted := &ethpb.ListBlocksResponse{
 		BlockContainers: []*ethpb.BeaconBlockContainer{
 			{
 				Block:     blk,
 				BlockRoot: root[:],
+				Canonical: true,
 			},
 		},
 		NextPageToken: "0",
@@ -116,10 +122,14 @@ func TestServer_ListBlocks_Genesis(t *testing.T) {
 
 func TestServer_ListBlocks_Genesis_MultiBlocks(t *testing.T) {
 	db := dbTest.SetupDB(t)
+	chain := &chainMock.ChainService{
+		CanonicalRoots: map[[32]byte]bool{},
+	}
 	ctx := context.Background()
 
 	bs := &Server{
-		BeaconDB: db,
+		BeaconDB:         db,
+		CanonicalFetcher: chain,
 	}
 	// Should return the proper genesis block if it exists.
 	parentRoot := [32]byte{1, 2, 3}
@@ -129,17 +139,15 @@ func TestServer_ListBlocks_Genesis_MultiBlocks(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.SaveBlock(ctx, blk))
 	require.NoError(t, db.SaveGenesisBlockRoot(ctx, root))
+	chain.CanonicalRoots[root] = true
 
 	count := uint64(100)
 	blks := make([]*ethpb.SignedBeaconBlock, count)
-	blkContainers := make([]*ethpb.BeaconBlockContainer, count)
 	for i := uint64(0); i < count; i++ {
 		b := testutil.NewBeaconBlock()
 		b.Block.Slot = i
-		root, err := b.Block.HashTreeRoot()
 		require.NoError(t, err)
 		blks[i] = b
-		blkContainers[i] = &ethpb.BeaconBlockContainer{Block: b, BlockRoot: root[:]}
 	}
 	require.NoError(t, db.SaveBlocks(ctx, blks))
 
@@ -154,6 +162,9 @@ func TestServer_ListBlocks_Genesis_MultiBlocks(t *testing.T) {
 
 func TestServer_ListBlocks_Pagination(t *testing.T) {
 	db := dbTest.SetupDB(t)
+	chain := &chainMock.ChainService{
+		CanonicalRoots: map[[32]byte]bool{},
+	}
 	ctx := context.Background()
 
 	count := uint64(100)
@@ -164,13 +175,21 @@ func TestServer_ListBlocks_Pagination(t *testing.T) {
 		b.Block.Slot = i
 		root, err := b.Block.HashTreeRoot()
 		require.NoError(t, err)
+		chain.CanonicalRoots[root] = true
 		blks[i] = b
-		blkContainers[i] = &ethpb.BeaconBlockContainer{Block: b, BlockRoot: root[:]}
+		blkContainers[i] = &ethpb.BeaconBlockContainer{Block: b, BlockRoot: root[:], Canonical: true}
 	}
 	require.NoError(t, db.SaveBlocks(ctx, blks))
 
+	orphanedBlk := testutil.NewBeaconBlock()
+	orphanedBlk.Block.Slot = 300
+	orphanedBlkRoot, err := orphanedBlk.Block.HashTreeRoot()
+	require.NoError(t, err)
+	require.NoError(t, db.SaveBlock(ctx, orphanedBlk))
+
 	bs := &Server{
-		BeaconDB: db,
+		BeaconDB:         db,
+		CanonicalFetcher: chain,
 	}
 
 	root6, err := blks[6].Block.HashTreeRoot()
@@ -188,7 +207,8 @@ func TestServer_ListBlocks_Pagination(t *testing.T) {
 				BlockContainers: []*ethpb.BeaconBlockContainer{{Block: testutil.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{
 					Block: &ethpb.BeaconBlock{
 						Slot: 5}}),
-					BlockRoot: blkContainers[5].BlockRoot}},
+					BlockRoot: blkContainers[5].BlockRoot,
+					Canonical: blkContainers[5].Canonical}},
 				NextPageToken: "",
 				TotalSize:     1}},
 		{req: &ethpb.ListBlocksRequest{
@@ -199,14 +219,16 @@ func TestServer_ListBlocks_Pagination(t *testing.T) {
 				BlockContainers: []*ethpb.BeaconBlockContainer{{Block: testutil.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{
 					Block: &ethpb.BeaconBlock{
 						Slot: 6}}),
-					BlockRoot: blkContainers[6].BlockRoot}},
+					BlockRoot: blkContainers[6].BlockRoot,
+					Canonical: blkContainers[6].Canonical}},
 				TotalSize: 1}},
 		{req: &ethpb.ListBlocksRequest{QueryFilter: &ethpb.ListBlocksRequest_Root{Root: root6[:]}},
 			res: &ethpb.ListBlocksResponse{
 				BlockContainers: []*ethpb.BeaconBlockContainer{{Block: testutil.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{
 					Block: &ethpb.BeaconBlock{
 						Slot: 6}}),
-					BlockRoot: blkContainers[6].BlockRoot}},
+					BlockRoot: blkContainers[6].BlockRoot,
+					Canonical: blkContainers[6].Canonical}},
 				TotalSize: 1}},
 		{req: &ethpb.ListBlocksRequest{
 			PageToken:   strconv.Itoa(0),
@@ -240,6 +262,18 @@ func TestServer_ListBlocks_Pagination(t *testing.T) {
 				BlockContainers: blkContainers[96:100],
 				NextPageToken:   "",
 				TotalSize:       int32(params.BeaconConfig().SlotsPerEpoch / 2)}},
+		{req: &ethpb.ListBlocksRequest{
+			PageToken:   strconv.Itoa(0),
+			QueryFilter: &ethpb.ListBlocksRequest_Slot{Slot: 300},
+			PageSize:    3},
+			res: &ethpb.ListBlocksResponse{
+				BlockContainers: []*ethpb.BeaconBlockContainer{{Block: testutil.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{
+					Block: &ethpb.BeaconBlock{
+						Slot: 300}}),
+					BlockRoot: orphanedBlkRoot[:],
+					Canonical: false}},
+				NextPageToken: "",
+				TotalSize:     1}},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Adding `canonical` flag to `/eth/v1alpha1/beacon/blocks` so client can identify if the block is orphaned.

**Which issues(s) does this PR fix?**

Fixes #8064 

**Other notes for review**
