### PR TITLE
Update bitfield dependency

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -2586,8 +2586,8 @@ def prysm_deps():
     go_repository(
         name = "com_github_prysmaticlabs_go_bitfield",
         importpath = "github.com/prysmaticlabs/go-bitfield",
-        sum = "h1:T86rPg76THT+xHx54zNu/4dgR3gWDm3VTdYocAj1NCE=",
-        version = "v0.0.0-20210107162333-9e9cf77d4921",
+        sum = "h1:kz6f7jK49W9jPrxNH/4ezoPgFPGb18MI+YJHoSA52xk=",
+        version = "v0.0.0-20210120055809-a490c91c5a59",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/prometheus/tsdb v0.10.0 // indirect
 	github.com/protolambda/zssz v0.1.5
 	github.com/prysmaticlabs/ethereumapis v0.0.0-20210105190001-13193818c0df
-	github.com/prysmaticlabs/go-bitfield v0.0.0-20210107162333-9e9cf77d4921
+	github.com/prysmaticlabs/go-bitfield v0.0.0-20210120055809-a490c91c5a59
 	github.com/prysmaticlabs/go-ssz v0.0.0-20200612203617-6d5c9aa213ae
 	github.com/prysmaticlabs/prombbolt v0.0.0-20200324184628-09789ef63796
 	github.com/rs/cors v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1111,8 +1111,8 @@ github.com/prysmaticlabs/ethereumapis v0.0.0-20210105190001-13193818c0df h1:69UR
 github.com/prysmaticlabs/ethereumapis v0.0.0-20210105190001-13193818c0df/go.mod h1:k7b2dxy6RppCG6kmOJkNOXzRpEoTdsPygc2aQhsUsZk=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669 h1:cX6YRZnZ9sgMqM5U14llxUiXVNJ3u07Res1IIjTOgtI=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
-github.com/prysmaticlabs/go-bitfield v0.0.0-20210107162333-9e9cf77d4921 h1:T86rPg76THT+xHx54zNu/4dgR3gWDm3VTdYocAj1NCE=
-github.com/prysmaticlabs/go-bitfield v0.0.0-20210107162333-9e9cf77d4921/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
+github.com/prysmaticlabs/go-bitfield v0.0.0-20210120055809-a490c91c5a59 h1:kz6f7jK49W9jPrxNH/4ezoPgFPGb18MI+YJHoSA52xk=
+github.com/prysmaticlabs/go-bitfield v0.0.0-20210120055809-a490c91c5a59/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
 github.com/prysmaticlabs/go-ssz v0.0.0-20200612203617-6d5c9aa213ae h1:7qd0Af1ozWKBU3c93YW2RH+/09hJns9+ftqWUZyts9c=
 github.com/prysmaticlabs/go-ssz v0.0.0-20200612203617-6d5c9aa213ae/go.mod h1:VecIJZrewdAuhVckySLFt2wAAHRME934bSDurP8ftkc=
 github.com/prysmaticlabs/prombbolt v0.0.0-20200324184628-09789ef63796 h1:bVD46NhbqEE6bsIqj42TCS3ELUdumti3WfAw9DXNtkg=


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
- Updates dependency to [https://github.com/prysmaticlabs/go-bitfield/commit/a490c91c5a59d5b4f523ba559ac4d89d8c4feca5](https://github.com/prysmaticlabs/go-bitfield/commit/a490c91c5a59d5b4f523ba559ac4d89d8c4feca5) (where support for `Bitlist64` has been added)

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
