### PR TITLE
Update bitfield dependency

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -2579,8 +2579,8 @@ def prysm_deps():
     go_repository(
         name = "com_github_prysmaticlabs_go_bitfield",
         importpath = "github.com/prysmaticlabs/go-bitfield",
-        sum = "h1:teHQyJxTD1ZOLmdnIgNYFBruxZX9Cjo/NlSU2AmumwI=",
-        version = "v0.0.0-20210120104942-c3214972eb2e",
+        sum = "h1:SMro7Z5L2ACvcKREIVJDn8LvoVTY1TY2rTlPJmDlUWc=",
+        version = "v0.0.0-20210121075346-fee7b721f342",
     )
 
     go_repository(

--- a/go.mod
+++ b/go.mod
@@ -84,7 +84,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/tsdb v0.10.0 // indirect
 	github.com/prysmaticlabs/ethereumapis v0.0.0-20210115110118-c595a4e0c0a5
-	github.com/prysmaticlabs/go-bitfield v0.0.0-20210120104942-c3214972eb2e
+	github.com/prysmaticlabs/go-bitfield v0.0.0-20210121075346-fee7b721f342
 	github.com/prysmaticlabs/prombbolt v0.0.0-20200324184628-09789ef63796
 	github.com/rs/cors v1.7.0
 	github.com/schollz/progressbar/v3 v3.3.4

--- a/go.sum
+++ b/go.sum
@@ -1109,8 +1109,8 @@ github.com/prysmaticlabs/ethereumapis v0.0.0-20210115110118-c595a4e0c0a5 h1:roqX
 github.com/prysmaticlabs/ethereumapis v0.0.0-20210115110118-c595a4e0c0a5/go.mod h1:k7b2dxy6RppCG6kmOJkNOXzRpEoTdsPygc2aQhsUsZk=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669 h1:cX6YRZnZ9sgMqM5U14llxUiXVNJ3u07Res1IIjTOgtI=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
-github.com/prysmaticlabs/go-bitfield v0.0.0-20210120104942-c3214972eb2e h1:teHQyJxTD1ZOLmdnIgNYFBruxZX9Cjo/NlSU2AmumwI=
-github.com/prysmaticlabs/go-bitfield v0.0.0-20210120104942-c3214972eb2e/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
+github.com/prysmaticlabs/go-bitfield v0.0.0-20210121075346-fee7b721f342 h1:SMro7Z5L2ACvcKREIVJDn8LvoVTY1TY2rTlPJmDlUWc=
+github.com/prysmaticlabs/go-bitfield v0.0.0-20210121075346-fee7b721f342/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=
 github.com/prysmaticlabs/prombbolt v0.0.0-20200324184628-09789ef63796 h1:bVD46NhbqEE6bsIqj42TCS3ELUdumti3WfAw9DXNtkg=
 github.com/prysmaticlabs/prombbolt v0.0.0-20200324184628-09789ef63796/go.mod h1:5JkKm84FcLZQPNuHwjX8Mtd5emni/PH5CylWCNqnKos=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
- Updates dependency to https://github.com/prysmaticlabs/go-bitfield/commit/fee7b721f3425d0435b145e58f21ad219560af4e (implements unused bit clearing in `Not()`)

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
