### PR TITLE
Peer count node api

### DIFF
--- a/beacon-chain/rpc/nodev1/node.go
+++ b/beacon-chain/rpc/nodev1/node.go
@@ -211,7 +211,16 @@ func (ns *Server) PeerCount(ctx context.Context, _ *ptypes.Empty) (*ethpb.PeerCo
 	ctx, span := trace.StartSpan(ctx, "nodev1.PeerCount")
 	defer span.End()
 
-	return nil, errors.New("unimplemented")
+	peerStatus := ns.PeersFetcher.Peers()
+
+	return &ethpb.PeerCountResponse{
+		Data: &ethpb.PeerCountResponse_PeerCount{
+			Disconnected:  uint64(len(peerStatus.Disconnected())),
+			Connecting:    uint64(len(peerStatus.Connecting())),
+			Connected:     uint64(len(peerStatus.Connected())),
+			Disconnecting: uint64(len(peerStatus.Disconnecting())),
+		},
+	}, nil
 }
 
 // GetVersion requests that the beacon node identify information about its implementation in a


### PR DESCRIPTION
**What type of PR is this?**

Feature

What does this PR do? Why is it needed?

This PR implements Node API's `PeerCount` method according to the spec: https://ethereum.github.io/eth2.0-APIs/#/Node/getPeerCount

Which issues(s) does this PR fix?

Part of #7510

Other notes for review
N/A
