### PR TITLE
Refactor `on_attestation` return signature

### DIFF
--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -114,7 +114,7 @@ func TestStore_OnAttestation_ErrorConditions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := service.onAttestation(ctx, tt.a)
+			err := service.onAttestation(ctx, tt.a)
 			if tt.wantedErr != "" {
 				assert.ErrorContains(t, tt.wantedErr, err)
 			} else {
@@ -146,11 +146,7 @@ func TestStore_OnAttestation_Ok(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, service.beaconDB.SaveState(ctx, copied, tRoot))
 	require.NoError(t, service.forkChoiceStore.ProcessBlock(ctx, 0, tRoot, tRoot, tRoot, 1, 1))
-	indices, err := service.onAttestation(ctx, att[0])
-	require.NoError(t, err)
-	wanted, err := helpers.BeaconCommitteeFromState(copied, 0, 0)
-	require.NoError(t, err)
-	require.DeepEqual(t, wanted, indices)
+	require.NoError(t, service.onAttestation(ctx, att[0]))
 }
 
 func TestStore_SaveCheckpointState(t *testing.T) {

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -36,7 +36,7 @@ func (s *Service) ReceiveAttestationNoPubsub(ctx context.Context, att *ethpb.Att
 	defer span.End()
 
 	if err := s.onAttestation(ctx, att); err != nil {
-		errors.Wrap(err, "could not process attestation")
+		return errors.Wrap(err, "could not process attestation")
 	}
 
 	if err := s.updateHead(ctx, s.getJustifiedBalances()); err != nil {

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -35,9 +35,8 @@ func (s *Service) ReceiveAttestationNoPubsub(ctx context.Context, att *ethpb.Att
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.blockchain.ReceiveAttestationNoPubsub")
 	defer span.End()
 
-	_, err := s.onAttestation(ctx, att)
-	if err != nil {
-		return errors.Wrap(err, "could not process attestation")
+	if err := s.onAttestation(ctx, att); err != nil {
+		errors.Wrap(err, "could not process attestation")
 	}
 
 	if err := s.updateHead(ctx, s.getJustifiedBalances()); err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Clean up

**What does this PR do? Why is it needed?**
`on_attestation` returns `([]uint64, error)`. The attesting indices `[]uint64` was never used. This PR removes it

**Which issues(s) does this PR fix?**

Fixes # N/A

**Other notes for review**
N/A