### PR TITLE
Max-cover: minor optimizations

### DIFF
--- a/shared/aggregation/attestations/maxcover_test.go
+++ b/shared/aggregation/attestations/maxcover_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAggregateAttestations_MaxCover_NewMaxCover(t *testing.T) {
+	t.Skip("skipped for now")
 	type args struct {
 		atts []*ethpb.Attestation
 	}
@@ -80,13 +81,7 @@ func TestAggregateAttestations_MaxCover_NewMaxCover(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewMaxCover(tt.args.atts)
-			if tt.wantedErr != "" {
-				assert.ErrorContains(t, tt.wantedErr, err)
-			} else {
-				assert.NoError(t, err)
-				assert.DeepEqual(t, tt.want, got)
-			}
+			assert.DeepEqual(t, tt.want, NewMaxCover(tt.args.atts))
 		})
 	}
 }

--- a/shared/aggregation/attestations/maxcover_test.go
+++ b/shared/aggregation/attestations/maxcover_test.go
@@ -10,39 +10,27 @@ import (
 )
 
 func TestAggregateAttestations_MaxCover_NewMaxCover(t *testing.T) {
-	t.Skip("skipped for now")
 	type args struct {
 		atts []*ethpb.Attestation
 	}
 	tests := []struct {
-		name      string
-		args      args
-		want      *aggregation.MaxCoverProblem
-		wantedErr string
+		name string
+		args args
+		want *aggregation.MaxCoverProblem
 	}{
 		{
 			name: "nil attestations",
 			args: args{
 				atts: nil,
 			},
-			wantedErr: ErrInvalidAttestationCount.Error(),
+			want: &aggregation.MaxCoverProblem{Candidates: []*aggregation.MaxCoverCandidate{}},
 		},
 		{
 			name: "no attestations",
 			args: args{
 				atts: []*ethpb.Attestation{},
 			},
-			wantedErr: ErrInvalidAttestationCount.Error(),
-		},
-		{
-			name: "attestations of different bitlist length",
-			args: args{
-				atts: []*ethpb.Attestation{
-					{AggregationBits: bitfield.NewBitlist(64)},
-					{AggregationBits: bitfield.NewBitlist(128)},
-				},
-			},
-			wantedErr: aggregation.ErrBitsDifferentLen.Error(),
+			want: &aggregation.MaxCoverProblem{Candidates: []*aggregation.MaxCoverCandidate{}},
 		},
 		{
 			name: "single attestation",


### PR DESCRIPTION
**What type of PR is this?**

> Other / Optimization

**What does this PR do? Why is it needed?**
- This PR improves performance of the max-cover aggregation w/o any major changes (in follow-up PR the new optimized `Bitlist64` based implementation of max-cover will be pushed).
- Optimizations include:
   - Getting rid of **redundant** bit length validation, as we validate once, when aggregation starts, see:
https://github.com/prysmaticlabs/prysm/blob/9cc1438ea9ad1a08151cfc5787ad29f7f9fcb225/shared/aggregation/attestations/maxcover.go#L25-L30
   - Replacing manual list merging with simple call to `append()`
   - Using a filtering w/o allocation (see [how it works in Slice Tricks](https://github.com/golang/go/wiki/SliceTricks#filtering-without-allocating)

**Which issues(s) does this PR fix?**

Part of #7871, extracted from #7938

**Other notes for review**

Original benchmark:
![image](https://user-images.githubusercontent.com/188194/105388001-2b9b2580-5c27-11eb-9127-b6e98c54c0db.png)


After applying this PR's patch:
![image](https://user-images.githubusercontent.com/188194/105388147-5be2c400-5c27-11eb-9e3b-d2b1f3e89e52.png)

