### PR TITLE
GetDuties: Refactor assignment status to deduplicate status computation

### DIFF
--- a/beacon-chain/rpc/validator/assignments.go
+++ b/beacon-chain/rpc/validator/assignments.go
@@ -155,13 +155,15 @@ func (vs *Server) duties(ctx context.Context, req *ethpb.DutiesRequest) (*ethpb.
 		}
 		idx, ok := s.ValidatorIndexByPubkey(bytesutil.ToBytes48(pubKey))
 		if ok {
+			status := assignmentStatus(s, idx)
+
 			assignment.ValidatorIndex = idx
-			assignment.Status = assignmentStatus(s, idx)
+			assignment.Status = status
 			assignment.ProposerSlots = proposerIndexToSlots[idx]
 
 			// The next epoch has no lookup for proposer indexes.
 			nextAssignment.ValidatorIndex = idx
-			nextAssignment.Status = assignmentStatus(s, idx)
+			nextAssignment.Status = status
 
 			ca, ok := committeeAssignments[idx]
 			if ok {


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Investigating performance issues with GetDuties and found this duplicated call for validator status.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

I did not run this or test this in any testnet. 