### PR TITLE
Replace bytes.Equal with assert.DeepEqual in tests

### DIFF
--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -51,9 +51,7 @@ func TestSaveHead_Different(t *testing.T) {
 
 	cachedRoot, err := service.HeadRoot(context.Background())
 	require.NoError(t, err)
-	if !bytes.Equal(cachedRoot, newRoot[:]) {
-		t.Error("Head did not change")
-	}
+	assert.DeepEqual(t, cachedRoot, newRoot[:], "Head did not change")
 	assert.DeepEqual(t, newHeadSignedBlock, service.headBlock(), "Head did not change")
 	assert.DeepEqual(t, headState.CloneInnerState(), service.headState(ctx).CloneInnerState(), "Head did not change")
 }

--- a/beacon-chain/core/blocks/randao_test.go
+++ b/beacon-chain/core/blocks/randao_test.go
@@ -1,7 +1,6 @@
 package blocks_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"testing"
@@ -64,13 +63,7 @@ func TestProcessRandao_SignatureVerifiesAndUpdatesLatestStateMixes(t *testing.T)
 	require.NoError(t, err, "Unexpected error processing block randao")
 	currentEpoch := helpers.CurrentEpoch(beaconState)
 	mix := newState.RandaoMixes()[currentEpoch%params.BeaconConfig().EpochsPerHistoricalVector]
-
-	if bytes.Equal(mix, params.BeaconConfig().ZeroHash[:]) {
-		t.Errorf(
-			"Expected empty signature to be overwritten by randao reveal, received %v",
-			params.BeaconConfig().EmptySignature,
-		)
-	}
+	assert.DeepNotEqual(t, params.BeaconConfig().ZeroHash[:], mix, "Expected empty signature to be overwritten by randao reveal")
 }
 
 func TestRandaoSignatureSet_OK(t *testing.T) {

--- a/beacon-chain/core/state/skip_slot_cache_test.go
+++ b/beacon-chain/core/state/skip_slot_cache_test.go
@@ -137,7 +137,7 @@ func TestSkipSlotCache_ConcurrentMixup(t *testing.T) {
 		roots := outState.StateRoots()
 		gotRoot := roots[problemSlot]
 		if i%2 == 0 {
-			assert.DeepEqual(t, expectedRoot1[:], gotRoot, "unexpected root on chain 1")
+			assert.DeepEqual(t, expectedRoot1[:], gotRoot, "Unexpected root on chain 1")
 		} else {
 			assert.DeepEqual(t, expectedRoot2[:], gotRoot, "unexpected root on chain 2")
 		}

--- a/beacon-chain/core/state/skip_slot_cache_test.go
+++ b/beacon-chain/core/state/skip_slot_cache_test.go
@@ -5,13 +5,12 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
-
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	beaconstate "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/sszutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 

--- a/beacon-chain/core/state/skip_slot_cache_test.go
+++ b/beacon-chain/core/state/skip_slot_cache_test.go
@@ -114,7 +114,7 @@ func TestSkipSlotCache_ConcurrentMixup(t *testing.T) {
 	tmp1, err := state.ProcessSlots(context.Background(), expected1.Copy(), problemSlot+1)
 	require.NoError(t, err)
 	gotRoot := tmp1.StateRoots()[problemSlot]
-	require.DeepEqual(t, expectedRoot1[:], gotRoot, "state roots for chain 1 are bad, expected root doesn't match")
+	require.DeepEqual(t, expectedRoot1[:], gotRoot, "State roots for chain 1 are bad, expected root doesn't match")
 
 	expected2, err := state.ProcessSlots(context.Background(), state2.Copy(), problemSlot)
 	require.NoError(t, err)

--- a/beacon-chain/core/state/skip_slot_cache_test.go
+++ b/beacon-chain/core/state/skip_slot_cache_test.go
@@ -1,10 +1,11 @@
 package state_test
 
 import (
-	"bytes"
 	"context"
 	"sync"
 	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	beaconstate "github.com/prysmaticlabs/prysm/beacon-chain/state"
@@ -113,9 +114,8 @@ func TestSkipSlotCache_ConcurrentMixup(t *testing.T) {
 
 	tmp1, err := state.ProcessSlots(context.Background(), expected1.Copy(), problemSlot+1)
 	require.NoError(t, err)
-	if gotRoot := tmp1.StateRoots()[problemSlot]; !bytes.Equal(gotRoot, expectedRoot1[:]) {
-		t.Fatalf("state roots for chain 1 are bad, expected root doesn't match: %x <> %x", gotRoot, expectedRoot1[:])
-	}
+	gotRoot := tmp1.StateRoots()[problemSlot]
+	require.DeepEqual(t, expectedRoot1[:], gotRoot, "state roots for chain 1 are bad, expected root doesn't match")
 
 	expected2, err := state.ProcessSlots(context.Background(), state2.Copy(), problemSlot)
 	require.NoError(t, err)
@@ -125,9 +125,8 @@ func TestSkipSlotCache_ConcurrentMixup(t *testing.T) {
 
 	tmp2, err := state.ProcessSlots(context.Background(), expected2.Copy(), problemSlot+1)
 	require.NoError(t, err)
-	if gotRoot := tmp2.StateRoots()[problemSlot]; !bytes.Equal(gotRoot, expectedRoot2[:]) {
-		t.Fatalf("state roots for chain 2 are bad, expected root doesn't match %x <> %x", gotRoot, expectedRoot2[:])
-	}
+	gotRoot = tmp2.StateRoots()[problemSlot]
+	require.DeepEqual(t, expectedRoot2[:], gotRoot, "state roots for chain 2 are bad, expected root doesn't match")
 
 	var wg sync.WaitGroup
 	wg.Add(len(setups))
@@ -139,13 +138,9 @@ func TestSkipSlotCache_ConcurrentMixup(t *testing.T) {
 		roots := outState.StateRoots()
 		gotRoot := roots[problemSlot]
 		if i%2 == 0 {
-			if !bytes.Equal(gotRoot, expectedRoot1[:]) {
-				t.Errorf("unexpected root on chain 1, item %3d: %x", i, gotRoot)
-			}
+			assert.DeepEqual(t, expectedRoot1[:], gotRoot, "unexpected root on chain 1")
 		} else {
-			if !bytes.Equal(gotRoot, expectedRoot2[:]) {
-				t.Errorf("unexpected root on chain 2, item %3d: %x", i, gotRoot)
-			}
+			assert.DeepEqual(t, expectedRoot2[:], gotRoot, "unexpected root on chain 2")
 		}
 		wg.Done()
 	}

--- a/beacon-chain/core/state/skip_slot_cache_test.go
+++ b/beacon-chain/core/state/skip_slot_cache_test.go
@@ -139,7 +139,7 @@ func TestSkipSlotCache_ConcurrentMixup(t *testing.T) {
 		if i%2 == 0 {
 			assert.DeepEqual(t, expectedRoot1[:], gotRoot, "Unexpected root on chain 1")
 		} else {
-			assert.DeepEqual(t, expectedRoot2[:], gotRoot, "unexpected root on chain 2")
+			assert.DeepEqual(t, expectedRoot2[:], gotRoot, "Unexpected root on chain 2")
 		}
 		wg.Done()
 	}

--- a/beacon-chain/core/state/skip_slot_cache_test.go
+++ b/beacon-chain/core/state/skip_slot_cache_test.go
@@ -125,7 +125,7 @@ func TestSkipSlotCache_ConcurrentMixup(t *testing.T) {
 	tmp2, err := state.ProcessSlots(context.Background(), expected2.Copy(), problemSlot+1)
 	require.NoError(t, err)
 	gotRoot = tmp2.StateRoots()[problemSlot]
-	require.DeepEqual(t, expectedRoot2[:], gotRoot, "state roots for chain 2 are bad, expected root doesn't match")
+	require.DeepEqual(t, expectedRoot2[:], gotRoot, "State roots for chain 2 are bad, expected root doesn't match")
 
 	var wg sync.WaitGroup
 	wg.Add(len(setups))

--- a/beacon-chain/core/state/transition_test.go
+++ b/beacon-chain/core/state/transition_test.go
@@ -1,7 +1,6 @@
 package state_test
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"fmt"
@@ -101,9 +100,7 @@ func TestExecuteStateTransition_FullProcess(t *testing.T) {
 
 	mix, err := beaconState.RandaoMixAtIndex(1)
 	require.NoError(t, err)
-	if bytes.Equal(mix, oldMix) {
-		t.Errorf("Did not expect new and old randao mix to equal, %#x == %#x", mix, oldMix)
-	}
+	assert.DeepNotEqual(t, oldMix, mix, "Did not expect new and old randao mix to equal")
 }
 
 func TestExecuteStateTransitionNoVerify_FullProcess(t *testing.T) {

--- a/beacon-chain/db/kv/migration_archived_index_test.go
+++ b/beacon-chain/db/kv/migration_archived_index_test.go
@@ -1,7 +1,6 @@
 package kv
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -34,9 +33,7 @@ func Test_migrateArchivedIndex(t *testing.T) {
 			eval: func(t *testing.T, db *bbolt.DB) {
 				err := db.View(func(tx *bbolt.Tx) error {
 					v := tx.Bucket(archivedRootBucket).Get(bytesutil.Uint64ToBytesLittleEndian(2048))
-					if !bytes.Equal(v, []byte("foo")) {
-						return fmt.Errorf("did not receive correct data for key 2048, wanted 'foo' got %s", v)
-					}
+					assert.DeepEqual(t, []byte("foo"), v, "did not receive correct data for key 2048")
 					return nil
 				})
 				assert.NoError(t, err)
@@ -66,9 +63,8 @@ func Test_migrateArchivedIndex(t *testing.T) {
 			eval: func(t *testing.T, db *bbolt.DB) {
 				err := db.View(func(tx *bbolt.Tx) error {
 					k := uint64(2048)
-					if v := tx.Bucket(stateSlotIndicesBucket).Get(bytesutil.Uint64ToBytesBigEndian(k)); !bytes.Equal(v, []byte("foo")) {
-						return fmt.Errorf("did not receive correct data for key %d, wanted 'foo' got %v", k, v)
-					}
+					v := tx.Bucket(stateSlotIndicesBucket).Get(bytesutil.Uint64ToBytesBigEndian(k))
+					assert.DeepEqual(t, []byte("foo"), v, fmt.Sprintf("did not receive correct data for key %d", k))
 					return nil
 				})
 				assert.NoError(t, err)

--- a/beacon-chain/db/kv/migration_archived_index_test.go
+++ b/beacon-chain/db/kv/migration_archived_index_test.go
@@ -64,7 +64,7 @@ func Test_migrateArchivedIndex(t *testing.T) {
 				err := db.View(func(tx *bbolt.Tx) error {
 					k := uint64(2048)
 					v := tx.Bucket(stateSlotIndicesBucket).Get(bytesutil.Uint64ToBytesBigEndian(k))
-					assert.DeepEqual(t, []byte("foo"), v, fmt.Sprintf("did not receive correct data for key %d", k))
+					assert.DeepEqual(t, []byte("foo"), v, "Did not receive correct data for key %d", k)
 					return nil
 				})
 				assert.NoError(t, err)

--- a/beacon-chain/db/kv/migration_archived_index_test.go
+++ b/beacon-chain/db/kv/migration_archived_index_test.go
@@ -2,7 +2,6 @@ package kv
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"

--- a/beacon-chain/db/kv/migration_archived_index_test.go
+++ b/beacon-chain/db/kv/migration_archived_index_test.go
@@ -32,7 +32,7 @@ func Test_migrateArchivedIndex(t *testing.T) {
 			eval: func(t *testing.T, db *bbolt.DB) {
 				err := db.View(func(tx *bbolt.Tx) error {
 					v := tx.Bucket(archivedRootBucket).Get(bytesutil.Uint64ToBytesLittleEndian(2048))
-					assert.DeepEqual(t, []byte("foo"), v, "did not receive correct data for key 2048")
+					assert.DeepEqual(t, []byte("foo"), v, "Did not receive correct data for key 2048")
 					return nil
 				})
 				assert.NoError(t, err)

--- a/beacon-chain/db/kv/migration_block_slot_index_test.go
+++ b/beacon-chain/db/kv/migration_block_slot_index_test.go
@@ -47,7 +47,7 @@ func Test_migrateBlockSlotIndex(t *testing.T) {
 				err := db.View(func(tx *bbolt.Tx) error {
 					k := uint64(2048)
 					v := tx.Bucket(blockSlotIndicesBucket).Get(bytesutil.Uint64ToBytesBigEndian(k))
-					assert.DeepEqual(t, []byte("foo"), v, fmt.Sprintf("did not receive correct data for key %d", k))
+					assert.DeepEqual(t, []byte("foo"), v, "Did not receive correct data for key %d", k)
 					return nil
 				})
 				assert.NoError(t, err)

--- a/beacon-chain/db/kv/migration_block_slot_index_test.go
+++ b/beacon-chain/db/kv/migration_block_slot_index_test.go
@@ -1,7 +1,6 @@
 package kv
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"

--- a/beacon-chain/db/kv/migration_block_slot_index_test.go
+++ b/beacon-chain/db/kv/migration_block_slot_index_test.go
@@ -1,7 +1,6 @@
 package kv
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 
@@ -30,9 +29,7 @@ func Test_migrateBlockSlotIndex(t *testing.T) {
 			eval: func(t *testing.T, db *bbolt.DB) {
 				err := db.View(func(tx *bbolt.Tx) error {
 					v := tx.Bucket(blockSlotIndicesBucket).Get([]byte("2048"))
-					if !bytes.Equal(v, []byte("foo")) {
-						return fmt.Errorf("did not receive correct data for key 2048, wanted 'foo' got %s", v)
-					}
+					assert.DeepEqual(t, []byte("foo"), v, "did not receive correct data for key 2048")
 					return nil
 				})
 				assert.NoError(t, err)
@@ -49,9 +46,8 @@ func Test_migrateBlockSlotIndex(t *testing.T) {
 			eval: func(t *testing.T, db *bbolt.DB) {
 				err := db.View(func(tx *bbolt.Tx) error {
 					k := uint64(2048)
-					if v := tx.Bucket(blockSlotIndicesBucket).Get(bytesutil.Uint64ToBytesBigEndian(k)); !bytes.Equal(v, []byte("foo")) {
-						return fmt.Errorf("did not receive correct data for key %d, wanted 'foo' got %v", k, v)
-					}
+					v := tx.Bucket(blockSlotIndicesBucket).Get(bytesutil.Uint64ToBytesBigEndian(k))
+					assert.DeepEqual(t, []byte("foo"), v, fmt.Sprintf("did not receive correct data for key %d", k))
 					return nil
 				})
 				assert.NoError(t, err)

--- a/beacon-chain/db/kv/migration_block_slot_index_test.go
+++ b/beacon-chain/db/kv/migration_block_slot_index_test.go
@@ -28,7 +28,7 @@ func Test_migrateBlockSlotIndex(t *testing.T) {
 			eval: func(t *testing.T, db *bbolt.DB) {
 				err := db.View(func(tx *bbolt.Tx) error {
 					v := tx.Bucket(blockSlotIndicesBucket).Get([]byte("2048"))
-					assert.DeepEqual(t, []byte("foo"), v, "did not receive correct data for key 2048")
+					assert.DeepEqual(t, []byte("foo"), v, "Did not receive correct data for key 2048")
 					return nil
 				})
 				assert.NoError(t, err)

--- a/beacon-chain/p2p/fork_test.go
+++ b/beacon-chain/p2p/fork_test.go
@@ -1,7 +1,6 @@
 package p2p
 
 import (
-	"bytes"
 	"context"
 	"math/rand"
 	"os"
@@ -249,12 +248,8 @@ func TestDiscv5_AddRetrieveForkEntryENR(t *testing.T) {
 
 	resp, err := retrieveForkEntry(localNode.Node().Record())
 	require.NoError(t, err)
-	if !bytes.Equal(resp.CurrentForkDigest, want[:]) {
-		t.Errorf("Wanted fork digest: %v, received %v", want, resp.CurrentForkDigest)
-	}
-	if !bytes.Equal(resp.NextForkVersion, nextForkVersion) {
-		t.Errorf("Wanted next fork version: %v, received %v", nextForkVersion, resp.NextForkVersion)
-	}
+	assert.DeepEqual(t, want[:], resp.CurrentForkDigest)
+	assert.DeepEqual(t, nextForkVersion, resp.NextForkVersion)
 	assert.Equal(t, nextForkEpoch, resp.NextForkEpoch, "Unexpected next fork epoch")
 }
 
@@ -273,7 +268,7 @@ func TestAddForkEntry_Genesis(t *testing.T) {
 	require.NoError(t, err)
 	forkEntry, err := retrieveForkEntry(localNode.Node().Record())
 	require.NoError(t, err)
-	if !bytes.Equal(forkEntry.NextForkVersion, params.BeaconConfig().GenesisForkVersion) {
-		t.Errorf("Wanted Next Fork Version to be equal to genesis fork version, instead got %#x", forkEntry.NextForkVersion)
-	}
+	assert.DeepEqual(t,
+		params.BeaconConfig().GenesisForkVersion, forkEntry.NextForkVersion,
+		"Wanted Next Fork Version to be equal to genesis fork version")
 }

--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -1,12 +1,13 @@
 package p2p
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"io/ioutil"
 	"net"
 	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 
 	gethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -40,9 +41,7 @@ func TestPrivateKeyLoading(t *testing.T) {
 	require.NoError(t, err)
 	newRaw, err := newPkey.Raw()
 	require.NoError(t, err)
-	if !bytes.Equal(newRaw, rawBytes) {
-		t.Errorf("Private keys do not match got %#x but wanted %#x", rawBytes, newRaw)
-	}
+	assert.DeepEqual(t, rawBytes, newRaw, "Private keys do not match")
 }
 
 func TestIPV6Support(t *testing.T) {

--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -7,13 +7,12 @@ import (
 	"net"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
-
 	gethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 

--- a/beacon-chain/p2p/types/types_test.go
+++ b/beacon-chain/p2p/types/types_test.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"bytes"
 	"encoding/hex"
 	"testing"
 
@@ -132,11 +131,11 @@ func TestSSZUint64(t *testing.T) {
 
 			serializedBytes, err := s.MarshalSSZ()
 			require.NoError(t, err)
-			require.Equal(t, true, bytes.Equal(serializedBytes, tt.serializedBytes), "serialized does not equal")
+			require.DeepEqual(t, tt.serializedBytes, serializedBytes)
 
 			htr, err := s.HashTreeRoot()
 			require.NoError(t, err)
-			require.Equal(t, true, bytes.Equal(htr[:], tt.root), "root does not equal")
+			require.DeepEqual(t, tt.root, htr[:])
 		})
 	}
 }
@@ -172,7 +171,7 @@ func TestSSZBytes_HashTreeRoot(t *testing.T) {
 			s := SSZBytes(tt.actualValue)
 			htr, err := s.HashTreeRoot()
 			require.NoError(t, err)
-			require.Equal(t, true, bytes.Equal(htr[:], tt.root), "root does not equal")
+			require.DeepEqual(t, tt.root, htr[:])
 		})
 	}
 }

--- a/beacon-chain/rpc/beaconv1/blocks_test.go
+++ b/beacon-chain/rpc/beaconv1/blocks_test.go
@@ -1,7 +1,6 @@
 package beaconv1
 
 import (
-	"bytes"
 	"context"
 	"reflect"
 	"testing"
@@ -488,10 +487,7 @@ func TestServer_GetBlockRoot(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-
-			if !bytes.Equal(blockRootResp.Data.Root, tt.want) {
-				t.Errorf("Expected hashes to equal, expected: %#x, received: %#x", tt.want, blockRootResp.Data.Root)
-			}
+			assert.DeepEqual(t, tt.want, blockRootResp.Data.Root)
 		})
 	}
 }

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"bytes"
 	"context"
 	"math/big"
 	"testing"
@@ -1284,9 +1283,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("first")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("highest count at earliest valid time - choose highest count", func(t *testing.T) {
@@ -1321,9 +1318,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("earliest")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("highest count at latest valid time - choose highest count", func(t *testing.T) {
@@ -1358,9 +1353,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("latest")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("highest count before range - choose highest count within range", func(t *testing.T) {
@@ -1396,9 +1389,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("first")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("highest count after range - choose highest count within range", func(t *testing.T) {
@@ -1434,9 +1425,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("first")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("highest count on unknown block - choose known block with highest count", func(t *testing.T) {
@@ -1472,9 +1461,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("first")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("no blocks in range - choose current eth1data", func(t *testing.T) {
@@ -1504,9 +1491,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("current")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("no votes in range - choose most recent block", func(t *testing.T) {
@@ -1542,9 +1527,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 
 		expectedHash := make([]byte, 32)
 		copy(expectedHash, "second")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("no votes - choose more recent block", func(t *testing.T) {
@@ -1574,9 +1557,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 
 		expectedHash := make([]byte, 32)
 		copy(expectedHash, "latest")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("no votes and more recent block has less deposits - choose current eth1data", func(t *testing.T) {
@@ -1607,9 +1588,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("current")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("same count - choose more recent block", func(t *testing.T) {
@@ -1644,9 +1623,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("second")
-		if !bytes.Equal(hash, expectedHash) {
-			t.Errorf("Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
-		}
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("highest count on block with less deposits - choose another block", func(t *testing.T) {
@@ -1682,7 +1659,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("second")
-		assert.Equal(t, true, bytes.Equal(hash, expectedHash), "Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("only one block at earliest valid time - choose this block", func(t *testing.T) {
@@ -1712,7 +1689,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("earliest")
-		assert.Equal(t, true, bytes.Equal(hash, expectedHash), "Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("vote on last block before range - choose next block", func(t *testing.T) {
@@ -1747,7 +1724,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 
 		expectedHash := make([]byte, 32)
 		copy(expectedHash, "first")
-		assert.Equal(t, true, bytes.Equal(hash, expectedHash), "Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 
 	t.Run("no deposits - choose chain start eth1data", func(t *testing.T) {
@@ -1785,7 +1762,7 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 		hash := majorityVoteEth1Data.BlockHash
 
 		expectedHash := []byte("eth1data")
-		assert.Equal(t, true, bytes.Equal(hash, expectedHash), "Chosen eth1data for block hash %v vs expected %v", hash, expectedHash)
+		assert.DeepEqual(t, expectedHash, hash)
 	})
 }
 

--- a/beacon-chain/state/state_trie_test.go
+++ b/beacon-chain/state/state_trie_test.go
@@ -155,12 +155,8 @@ func TestBeaconState_HashTreeRoot(t *testing.T) {
 			if err == nil && tt.error != "" {
 				t.Errorf("Expected error, expected %v, recevied %v", tt.error, err)
 			}
-			if bytes.Equal(root[:], []byte{}) {
-				t.Error("Received empty hash tree root")
-			}
-			if !bytes.Equal(root[:], genericHTR[:]) {
-				t.Error("Expected hash tree root to match generic")
-			}
+			assert.DeepNotEqual(t, []byte{}, root[:], "Received empty hash tree root")
+			assert.DeepEqual(t, genericHTR[:], root[:], "Expected hash tree root to match generic")
 			if len(oldHTR) != 0 && bytes.Equal(root[:], oldHTR) {
 				t.Errorf("Expected HTR to change, received %#x == old %#x", root, oldHTR)
 			}
@@ -226,12 +222,8 @@ func TestBeaconState_HashTreeRoot_FieldTrie(t *testing.T) {
 			if err == nil && tt.error != "" {
 				t.Errorf("Expected error, expected %v, recevied %v", tt.error, err)
 			}
-			if bytes.Equal(root[:], []byte{}) {
-				t.Error("Received empty hash tree root")
-			}
-			if !bytes.Equal(root[:], genericHTR[:]) {
-				t.Error("Expected hash tree root to match generic")
-			}
+			assert.DeepNotEqual(t, []byte{}, root[:], "Received empty hash tree root")
+			assert.DeepEqual(t, genericHTR[:], root[:], "Expected hash tree root to match generic")
 			if len(oldHTR) != 0 && bytes.Equal(root[:], oldHTR) {
 				t.Errorf("Expected HTR to change, received %#x == old %#x", root, oldHTR)
 			}

--- a/beacon-chain/state/stateutil/attestations_test.go
+++ b/beacon-chain/state/stateutil/attestations_test.go
@@ -1,7 +1,6 @@
 package stateutil
 
 import (
-	"bytes"
 	"testing"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -28,9 +27,7 @@ func TestAttestationDataRoot_EqualGeneric(t *testing.T) {
 	dataHtr, err := AttestationDataRoot(attData)
 	require.NoError(t, err)
 
-	if !bytes.Equal(genericHtr[:], dataHtr[:]) {
-		t.Fatalf("Expected %#x, received %#x", genericHtr, dataHtr)
-	}
+	require.DeepEqual(t, genericHtr[:], dataHtr[:])
 }
 
 func BenchmarkAttestationDataRoot(b *testing.B) {

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	"bytes"
 	"context"
 	"sync"
 	"testing"
@@ -64,9 +63,7 @@ func TestStatusRPCHandler_Disconnects_OnForkVersionMismatch(t *testing.T) {
 		expectSuccess(t, stream)
 		out := &pb.Status{}
 		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		if !bytes.Equal(out.FinalizedRoot, root[:]) {
-			t.Errorf("Expected finalized root of %#x but got %#x", root, out.FinalizedRoot)
-		}
+		assert.DeepEqual(t, root[:], out.FinalizedRoot)
 		assert.NoError(t, stream.Close())
 	})
 
@@ -130,9 +127,7 @@ func TestStatusRPCHandler_ConnectsOnGenesis(t *testing.T) {
 		expectSuccess(t, stream)
 		out := &pb.Status{}
 		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
-		if !bytes.Equal(out.FinalizedRoot, root[:]) {
-			t.Errorf("Expected finalized root of %#x but got %#x", root, out.FinalizedRoot)
-		}
+		assert.DeepEqual(t, root[:], out.FinalizedRoot)
 	})
 
 	stream1, err := p1.BHost.NewStream(context.Background(), p2.BHost.ID(), pcl)

--- a/beacon-chain/sync/rpc_test.go
+++ b/beacon-chain/sync/rpc_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
-
 	libp2pcore "github.com/libp2p/go-libp2p-core"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
@@ -16,6 +14,7 @@ import (
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
 	p2ppb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 

--- a/beacon-chain/sync/rpc_test.go
+++ b/beacon-chain/sync/rpc_test.go
@@ -1,11 +1,12 @@
 package sync
 
 import (
-	"bytes"
 	"context"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 
 	libp2pcore "github.com/libp2p/go-libp2p-core"
 	"github.com/libp2p/go-libp2p-core/network"
@@ -61,9 +62,7 @@ func TestRegisterRPC_ReceivesValidMessage(t *testing.T) {
 		if !ok {
 			t.Error("Object is not of type *pb.TestSimpleMessage")
 		}
-		if !bytes.Equal(m.CurrentVersion, []byte("fooo")) {
-			t.Errorf("Unexpected incoming message: %+v", m)
-		}
+		assert.DeepEqual(t, []byte("fooo"), m.CurrentVersion, "Unexpected incoming message")
 		wg.Done()
 
 		return nil


### PR DESCRIPTION
**What type of PR is this?**

Test cleanup

**What does this PR do? Why is it needed?**

`assert.DeepEqual` works with byte arrays, which means we can replace `bytes.Equal` assertions in tests with our library.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A