### PR TITLE
Remove test assertion that reads a package-level variable

### DIFF
--- a/validator/accounts/accounts_import_test.go
+++ b/validator/accounts/accounts_import_test.go
@@ -103,18 +103,6 @@ func TestImport_DuplicateKeys(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	keymanager, err := imported.NewKeymanager(
-		cliCtx.Context,
-		&imported.SetupConfig{
-			Wallet: w,
-		},
-	)
-	require.NoError(t, err)
-
-	// Make sure there are no accounts at the start.
-	accounts, err := keymanager.ValidatingAccountNames()
-	require.NoError(t, err)
-	assert.Equal(t, len(accounts), 0)
 
 	// Create a key and then copy it to create a duplicate
 	_, keystorePath := createKeystore(t, keysDir)

--- a/validator/accounts/accounts_import_test.go
+++ b/validator/accounts/accounts_import_test.go
@@ -115,7 +115,7 @@ func TestImport_DuplicateKeys(t *testing.T) {
 
 	require.NoError(t, ImportAccountsCli(cliCtx))
 
-	w, err = wallet.OpenWallet(cliCtx.Context, &wallet.Config{
+	_, err = wallet.OpenWallet(cliCtx.Context, &wallet.Config{
 		WalletDir:      walletDir,
 		WalletPassword: password,
 	})


### PR DESCRIPTION
**What type of PR is this?**

Test fix

**What does this PR do? Why is it needed?**

`TestImport_DuplicateKeys` currently asserts the value of a package-level variable, which causes the test output to be non-deterministic. This PR removes the assert from the test. We create a new wallet and keymanager, therefore verifying whether there are no accounts is not necessary.

**Which issues(s) does this PR fix?**

Fixes all PRs ;-)

**Other notes for review**

N/A
