### PR TITLE
Wait for one third before grabbing the lock

### DIFF
--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -31,6 +31,9 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 	ctx, span := trace.StartSpan(ctx, "validator.SubmitAttestation")
 	defer span.End()
 	span.AddAttributes(trace.StringAttribute("validator", fmt.Sprintf("%#x", pubKey)))
+
+	v.waitOneThirdOrValidBlock(ctx, slot)
+
 	lock := mputil.NewMultilock(string(pubKey[:]))
 	lock.Lock()
 	defer lock.Unlock()
@@ -49,8 +52,6 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 		log.Debug("Empty committee for validator duty, not attesting")
 		return
 	}
-
-	v.waitOneThirdOrValidBlock(ctx, slot)
 
 	req := &ethpb.AttestationDataRequest{
 		Slot:           slot,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix


**What does this PR do? Why is it needed?**

There's no reason to grab the attester lock before waiting 1/3 slot. At worst this would cause a lock contention when proposer and attester are perform together in the same slot

**Which issues(s) does this PR fix?**

Fixes #8346 

**Other notes for review**
N/A