### PR TITLE
Use strings builder for attester lock key

### DIFF
--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -34,7 +35,10 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 
 	v.waitOneThirdOrValidBlock(ctx, slot)
 
-	lock := mputil.NewMultilock(string(roleAttester), string(pubKey[:]))
+	var b strings.Builder
+	b.WriteByte(byte(roleAttester))
+	b.Write(pubKey[:])
+	lock := mputil.NewMultilock(b.String())
 	lock.Lock()
 	defer lock.Unlock()
 

--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -36,8 +36,15 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot uint64, pubKey [
 	v.waitOneThirdOrValidBlock(ctx, slot)
 
 	var b strings.Builder
-	b.WriteByte(byte(roleAttester))
-	b.Write(pubKey[:])
+	if err := b.WriteByte(byte(roleAttester)); err != nil {
+		log.WithError(err).Error("Could not write role byte for lock key")
+		return
+	}
+	_, err := b.Write(pubKey[:])
+	if err != nil {
+		log.WithError(err).Error("Could not write pubkey bytes for lock key")
+		return
+	}
 	lock := mputil.NewMultilock(b.String())
 	lock.Lock()
 	defer lock.Unlock()


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Minor improvement

**What does this PR do? Why is it needed?**

Use strings builder to construct lock key for attesting. It is more performant than casting. It's about 70% faster and 10% less bytes per allocation. 

```go
BenchmarkTwoInputs-12    	 2901903	       397 ns/op	     432 B/op	       7 allocs/op
BenchmarkOneInputWithConcat-12    	 3710899	       316 ns/op	     448 B/op	       7 allocs/op
BenchmarkOneInputWithStringBuilder-12    	 4719397	       245 ns/op	     408 B/op	       7 allocs/op


func BenchmarkTwoInputs(b *testing.B) {
	pubKey := [48]byte{'a'}
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		mputil.NewMultilock(fmt.Sprint(roleAttester), string(pubKey[:]))
	}
}

func BenchmarkOneInputWithConcat(b *testing.B) {
	pubKey := [48]byte{'a'}
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		mputil.NewMultilock(fmt.Sprint(roleAttester) + string(pubKey[:]))
	}
}

func BenchmarkOneInputWithStringBuilder(b *testing.B) {
	pubKey := [48]byte{'a'}
	b.ReportAllocs()
	for i := 0; i < b.N; i++ {
		var b strings.Builder
		b.WriteByte(byte(roleAttester))
		b.Write(pubKey[:])
		mputil.NewMultilock(b.String())
	}
}
```

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
Leaving proposing side untouched because it's less relevant 