### PR TITLE
Max-cover: optimized implementation based on Bitlist64

### DIFF
--- a/shared/aggregation/BUILD.bazel
+++ b/shared/aggregation/BUILD.bazel
@@ -27,7 +27,6 @@ go_test(
         "//shared/aggregation/testing:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",
-        "//shared/testutil/require:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
     ],
 )

--- a/shared/aggregation/BUILD.bazel
+++ b/shared/aggregation/BUILD.bazel
@@ -18,11 +18,16 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["maxcover_test.go"],
+    srcs = [
+        "maxcover_bench_test.go",
+        "maxcover_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//shared/aggregation/testing:go_default_library",
+        "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",
+        "//shared/testutil/require:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
     ],
 )

--- a/shared/aggregation/maxcover.go
+++ b/shared/aggregation/maxcover.go
@@ -145,10 +145,10 @@ func MaxCover(candidates []*bitfield.Bitlist64, k int, allowOverlaps bool) (sele
 
 			// Filter out overlapping candidates (if overlapping is not allowed).
 			wrongLen := coveredBits.Len() != candidates[idx].Len()
-			overlaps := func(idx uint64) bool {
-				return coveredBits.Overlaps(candidates[idx])
+			overlaps := func(idx int) bool {
+				return !allowOverlaps && coveredBits.Overlaps(candidates[idx])
 			}
-			if wrongLen || (!allowOverlaps && overlaps(uint64(idx))) {
+			if wrongLen || overlaps(idx) {
 				usableCandidates.SetBitAt(uint64(idx), false)
 				continue
 			}

--- a/shared/aggregation/maxcover.go
+++ b/shared/aggregation/maxcover.go
@@ -95,6 +95,82 @@ func (mc *MaxCoverProblem) Cover(k int, allowOverlaps bool) (*Aggregation, error
 	return solution, nil
 }
 
+// MaxCover finds the k-cover of Maximum Coverage problem.
+func MaxCover(candidates []*bitfield.Bitlist64, k int, allowOverlaps bool) (selected, coverage *bitfield.Bitlist64, err error) {
+	if len(candidates) == 0 {
+		return nil, nil, errors.Wrap(ErrInvalidMaxCoverProblem, "cannot calculate set coverage")
+	}
+	if len(candidates) < k {
+		k = len(candidates)
+	}
+
+	// Track usable candidates, and candidates selected for coverage as two bitlists.
+	// This allows to filter incoming candidate list without any extra re-allocations.
+	selectedCandidates := bitfield.NewBitlist64(uint64(len(candidates)))
+	usableCandidates := bitfield.NewBitlist64(uint64(len(candidates))).Not()
+
+	coveredBits := bitfield.NewBitlist64(candidates[0].Len())
+	remainingBits := union(candidates)
+	if remainingBits == nil {
+		return nil, nil, errors.Wrap(ErrInvalidMaxCoverProblem, "empty bitlists")
+	}
+
+	attempts := 0
+	ret := bitfield.NewBitlist64(candidates[0].Len())
+	indices := make([]int, usableCandidates.Count())
+	for selectedCandidates.Count() < uint64(k) && usableCandidates.Count() > 0 {
+		// Safe-guard, each iteration should come with at least one candidate selected.
+		if attempts > k {
+			break
+		}
+		attempts += 1
+
+		// Greedy select the next best candidate (from usable ones) to cover the remaining bits maximally.
+		maxScore := uint64(0)
+		bestIdx := uint64(0)
+		indices = indices[0:usableCandidates.Count()]
+		usableCandidates.NoAllocBitIndices(indices)
+		for _, idx := range indices {
+			// Score is calculated by taking into account uncovered bits only.
+			score := uint64(0)
+			if candidates[idx].Len() == remainingBits.Len() {
+				score = candidates[idx].AndCount(remainingBits)
+			}
+
+			// Filter out zero-score candidates.
+			if score == 0 {
+				usableCandidates.SetBitAt(uint64(idx), false)
+				continue
+			}
+
+			// Filter out overlapping candidates (if overlapping is not allowed).
+			wrongLen := coveredBits.Len() != candidates[idx].Len()
+			overlaps := func(idx uint64) bool {
+				return coveredBits.Overlaps(candidates[idx])
+			}
+			if wrongLen || (!allowOverlaps && overlaps(uint64(idx))) {
+				usableCandidates.SetBitAt(uint64(idx), false)
+				continue
+			}
+
+			// Track the candidate with the best score.
+			if score > maxScore {
+				maxScore = score
+				bestIdx = uint64(idx)
+			}
+		}
+		// Process greedy selected candidate.
+		if maxScore > 0 {
+			coveredBits.NoAllocOr(candidates[bestIdx], coveredBits)
+			selectedCandidates.SetBitAt(bestIdx, true)
+			candidates[bestIdx].NoAllocNot(ret)
+			remainingBits.NoAllocAnd(ret, remainingBits)
+			usableCandidates.SetBitAt(bestIdx, false)
+		}
+	}
+	return selectedCandidates, coveredBits, nil
+}
+
 // score updates scores of candidates, taking into account the uncovered elements only.
 func (cl *MaxCoverCandidates) score(uncovered bitfield.Bitlist) *MaxCoverCandidates {
 	for i := 0; i < len(*cl); i++ {
@@ -147,6 +223,19 @@ func (cl *MaxCoverCandidates) union() bitfield.Bitlist {
 	for i := 0; i < len(*cl); i++ {
 		if *(*cl)[i].bits != nil && ret.Len() == (*cl)[i].bits.Len() {
 			ret = ret.Or(*(*cl)[i].bits)
+		}
+	}
+	return ret
+}
+
+func union(candidates []*bitfield.Bitlist64) *bitfield.Bitlist64 {
+	if len(candidates) == 0 || candidates[0].Len() == 0 {
+		return nil
+	}
+	ret := bitfield.NewBitlist64(candidates[0].Len())
+	for _, bl := range candidates {
+		if ret.Len() == bl.Len() {
+			ret.NoAllocOr(bl, ret)
 		}
 	}
 	return ret

--- a/shared/aggregation/maxcover.go
+++ b/shared/aggregation/maxcover.go
@@ -105,10 +105,10 @@ func MaxCover(candidates []*bitfield.Bitlist64, k int, allowOverlaps bool) (sele
 	}
 
 	// Track usable candidates, and candidates selected for coverage as two bitlists.
-	// This allows to filter incoming candidate list without any extra re-allocations.
 	selectedCandidates := bitfield.NewBitlist64(uint64(len(candidates)))
 	usableCandidates := bitfield.NewBitlist64(uint64(len(candidates))).Not()
 
+	// Track bits covered so far as a bitlist.
 	coveredBits := bitfield.NewBitlist64(candidates[0].Len())
 	remainingBits := union(candidates)
 	if remainingBits == nil {
@@ -116,7 +116,7 @@ func MaxCover(candidates []*bitfield.Bitlist64, k int, allowOverlaps bool) (sele
 	}
 
 	attempts := 0
-	ret := bitfield.NewBitlist64(candidates[0].Len())
+	tmpBitlist := bitfield.NewBitlist64(candidates[0].Len()) // Used as return param for NoAlloc*() methods.
 	indices := make([]int, usableCandidates.Count())
 	for selectedCandidates.Count() < uint64(k) && usableCandidates.Count() > 0 {
 		// Safe-guard, each iteration should come with at least one candidate selected.
@@ -163,8 +163,8 @@ func MaxCover(candidates []*bitfield.Bitlist64, k int, allowOverlaps bool) (sele
 		if maxScore > 0 {
 			coveredBits.NoAllocOr(candidates[bestIdx], coveredBits)
 			selectedCandidates.SetBitAt(bestIdx, true)
-			candidates[bestIdx].NoAllocNot(ret)
-			remainingBits.NoAllocAnd(ret, remainingBits)
+			candidates[bestIdx].NoAllocNot(tmpBitlist)
+			remainingBits.NoAllocAnd(tmpBitlist, remainingBits)
 			usableCandidates.SetBitAt(bestIdx, false)
 		}
 	}

--- a/shared/aggregation/maxcover_bench_test.go
+++ b/shared/aggregation/maxcover_bench_test.go
@@ -1,176 +1,102 @@
 package aggregation
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/prysmaticlabs/go-bitfield"
 	aggtesting "github.com/prysmaticlabs/prysm/shared/aggregation/testing"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
-
-func BenchmarkMaxCoverProblem_Cover(b *testing.B) {
-	problemSet := func() MaxCoverCandidates {
-		// test vectors originally from:
-		// https://github.com/sigp/lighthouse/blob/master/beacon_node/operation_pool/src/max_cover.rs
-		return MaxCoverCandidates{
-			{0, &bitfield.Bitlist{0b00000100, 0b1}, 0, false},
-			{1, &bitfield.Bitlist{0b00011011, 0b1}, 0, false},
-			{2, &bitfield.Bitlist{0b00011011, 0b1}, 0, false},
-			{3, &bitfield.Bitlist{0b00000001, 0b1}, 0, false},
-			{4, &bitfield.Bitlist{0b00011010, 0b1}, 0, false},
-		}
-	}
-	type args struct {
-		k             int
-		candidates    MaxCoverCandidates
-		allowOverlaps bool
-	}
-	tests := []struct {
-		name      string
-		args      args
-		want      *Aggregation
-		wantedErr string
-	}{
-		{
-			name:      "nil problem",
-			args:      args{},
-			wantedErr: ErrInvalidMaxCoverProblem.Error(),
-		},
-		{
-			name: "k=0",
-			args: args{k: 0, candidates: problemSet()},
-			want: &Aggregation{
-				Coverage: bitfield.Bitlist{0b0000000, 0b1},
-				Keys:     []int{},
-			},
-		},
-		{
-			name: "k=1",
-			args: args{k: 1, candidates: problemSet()},
-			want: &Aggregation{
-				Coverage: bitfield.Bitlist{0b0011011, 0b1},
-				Keys:     []int{1},
-			},
-		},
-		{
-			name: "k=2",
-			args: args{k: 2, candidates: problemSet()},
-			want: &Aggregation{
-				Coverage: bitfield.Bitlist{0b0011111, 0b1},
-				Keys:     []int{1, 0},
-			},
-		},
-		{
-			name: "k=3",
-			args: args{k: 3, candidates: problemSet()},
-			want: &Aggregation{
-				Coverage: bitfield.Bitlist{0b0011111, 0b1},
-				Keys:     []int{1, 0},
-			},
-		},
-		{
-			name: "k=5",
-			args: args{k: 5, candidates: problemSet()},
-			want: &Aggregation{
-				Coverage: bitfield.Bitlist{0b0011111, 0b1},
-				Keys:     []int{1, 0},
-			},
-		},
-		{
-			name: "k=50",
-			args: args{k: 50, candidates: problemSet()},
-			want: &Aggregation{
-				Coverage: bitfield.Bitlist{0b0011111, 0b1},
-				Keys:     []int{1, 0},
-			},
-		},
-		{
-			name: "suboptimal", // Greedy algorithm selects: 0, 2, 3, while 1,4,5 is optimal.
-			args: args{k: 3, candidates: MaxCoverCandidates{
-				{0, &bitfield.Bitlist{0b00000000, 0b00011111, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000001, 0b11100000, 0b1}, 0, false},
-				{3, &bitfield.Bitlist{0b00000110, 0b00000000, 0b1}, 0, false},
-				{1, &bitfield.Bitlist{0b00110000, 0b01110000, 0b1}, 0, false},
-				{4, &bitfield.Bitlist{0b00000110, 0b10001100, 0b1}, 0, false},
-				{5, &bitfield.Bitlist{0b01001001, 0b00000011, 0b1}, 0, false},
-			}},
-			want: &Aggregation{
-				Coverage: bitfield.Bitlist{0b00000111, 0b11111111, 0b1},
-				Keys:     []int{0, 2, 3},
-			},
-		},
-		{
-			name: "allow overlaps",
-			args: args{k: 5, allowOverlaps: true, candidates: MaxCoverCandidates{
-				{0, &bitfield.Bitlist{0b00000000, 0b00000001, 0b11111110, 0b1}, 0, false},
-				{1, &bitfield.Bitlist{0b00000000, 0b00001110, 0b00001110, 0b1}, 0, false},
-				{2, &bitfield.Bitlist{0b00000000, 0b01110000, 0b01110000, 0b1}, 0, false},
-				{3, &bitfield.Bitlist{0b00000111, 0b10000001, 0b10000000, 0b1}, 0, false},
-				{4, &bitfield.Bitlist{0b00000000, 0b00000110, 0b00000110, 0b1}, 0, false},
-				{5, &bitfield.Bitlist{0b00000000, 0b00000001, 0b01100010, 0b1}, 0, false},
-				{6, &bitfield.Bitlist{0b00001000, 0b00001000, 0b10000010, 0b1}, 0, false},
-			}},
-			want: &Aggregation{
-				Coverage: bitfield.Bitlist{0b00001111, 0xff, 0b11111110, 0b1},
-				Keys:     []int{0, 3, 1, 2, 6},
-			},
-		},
-	}
-	copyCandidates := func(candidates MaxCoverCandidates) MaxCoverCandidates {
-		copyCandidates := make(MaxCoverCandidates, 0, len(candidates))
-		for _, candidate := range candidates {
-			copyCandidates = append(copyCandidates, NewMaxCoverCandidate(candidate.key, candidate.bits))
-		}
-		return copyCandidates
-	}
-	for _, tt := range tests {
-		b.Run(tt.name, func(b *testing.B) {
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				mc := &MaxCoverProblem{
-					Candidates: copyCandidates(tt.args.candidates),
-				}
-				got, err := mc.Cover(tt.args.k, tt.args.allowOverlaps)
-				if tt.wantedErr != "" {
-					require.ErrorContains(b, tt.wantedErr, err)
-				} else {
-					require.NoError(b, err)
-					require.DeepEqual(b, tt.want, got)
-				}
-			}
-		})
-	}
-}
 
 func BenchmarkMaxCoverProblem_MaxCover(b *testing.B) {
 	bitlistLen := params.BeaconConfig().MaxValidatorsPerCommittee
 	tests := []struct {
-		name          string
 		numCandidates uint64
 		numMarkedBits uint64
 		allowOverlaps bool
 	}{
 		{
-			name:          "128_attestations_with_single_bit_set",
+			numCandidates: 32,
+			numMarkedBits: 1,
+		},
+		{
 			numCandidates: 128,
+			numMarkedBits: 1,
+		},
+		{
+			numCandidates: 256,
+			numMarkedBits: 1,
+		},
+		{
+			numCandidates: 32,
 			numMarkedBits: 8,
 		},
 		{
-			name:          "1024_attestations_with_single_bit_set",
 			numCandidates: 1024,
 			numMarkedBits: 8,
 		},
 		{
-			name:          "2048_attestations_with_single_bit_set",
 			numCandidates: 2048,
 			numMarkedBits: 8,
 		},
+		{
+			numCandidates: 1024,
+			numMarkedBits: 32,
+		},
+		{
+			numCandidates: 2048,
+			numMarkedBits: 32,
+		},
+		{
+			numCandidates: 1024,
+			numMarkedBits: 128,
+		},
+		{
+			numCandidates: 2048,
+			numMarkedBits: 128,
+		},
+		{
+			numCandidates: 1024,
+			numMarkedBits: 512,
+		},
+		{
+			numCandidates: 2048,
+			numMarkedBits: 512,
+		},
 	}
 	for _, tt := range tests {
-		bitlists := aggtesting.Bitlists64WithSingleBitSet(tt.numCandidates, bitlistLen)
-		b.Run(tt.name, func(b *testing.B) {
-			b.ResetTimer()
+		name := fmt.Sprintf("%d_attestations_with_%d_bit(s)_set", tt.numCandidates, tt.numMarkedBits)
+		b.Run(fmt.Sprintf("cur_%s", name), func(b *testing.B) {
+			b.StopTimer()
+			var bitlists []bitfield.Bitlist
+			if tt.numMarkedBits == 1 {
+				bitlists = aggtesting.BitlistsWithSingleBitSet(tt.numCandidates, bitlistLen)
+			} else {
+				bitlists = aggtesting.BitlistsWithMultipleBitSet(b, tt.numCandidates, bitlistLen, tt.numMarkedBits)
+
+			}
+			b.StartTimer()
+			for i := 0; i < b.N; i++ {
+				candidates := make([]*MaxCoverCandidate, len(bitlists))
+				for i := 0; i < len(bitlists); i++ {
+					candidates[i] = NewMaxCoverCandidate(i, &bitlists[i])
+				}
+				mc := &MaxCoverProblem{Candidates: candidates}
+				_, err := mc.Cover(len(bitlists), tt.allowOverlaps)
+				_ = err
+			}
+		})
+		b.Run(fmt.Sprintf("new_%s", name), func(b *testing.B) {
+			b.StopTimer()
+			var bitlists []*bitfield.Bitlist64
+			if tt.numMarkedBits == 1 {
+				bitlists = aggtesting.Bitlists64WithSingleBitSet(tt.numCandidates, bitlistLen)
+			} else {
+				bitlists = aggtesting.Bitlists64WithMultipleBitSet(b, tt.numCandidates, bitlistLen, tt.numMarkedBits)
+
+			}
+			b.StartTimer()
 			for i := 0; i < b.N; i++ {
 				_, _, err := MaxCover(bitlists, len(bitlists), tt.allowOverlaps)
 				_ = err

--- a/shared/aggregation/maxcover_bench_test.go
+++ b/shared/aggregation/maxcover_bench_test.go
@@ -1,0 +1,180 @@
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/go-bitfield"
+	aggtesting "github.com/prysmaticlabs/prysm/shared/aggregation/testing"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func BenchmarkMaxCoverProblem_Cover(b *testing.B) {
+	problemSet := func() MaxCoverCandidates {
+		// test vectors originally from:
+		// https://github.com/sigp/lighthouse/blob/master/beacon_node/operation_pool/src/max_cover.rs
+		return MaxCoverCandidates{
+			{0, &bitfield.Bitlist{0b00000100, 0b1}, 0, false},
+			{1, &bitfield.Bitlist{0b00011011, 0b1}, 0, false},
+			{2, &bitfield.Bitlist{0b00011011, 0b1}, 0, false},
+			{3, &bitfield.Bitlist{0b00000001, 0b1}, 0, false},
+			{4, &bitfield.Bitlist{0b00011010, 0b1}, 0, false},
+		}
+	}
+	type args struct {
+		k             int
+		candidates    MaxCoverCandidates
+		allowOverlaps bool
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      *Aggregation
+		wantedErr string
+	}{
+		{
+			name:      "nil problem",
+			args:      args{},
+			wantedErr: ErrInvalidMaxCoverProblem.Error(),
+		},
+		{
+			name: "k=0",
+			args: args{k: 0, candidates: problemSet()},
+			want: &Aggregation{
+				Coverage: bitfield.Bitlist{0b0000000, 0b1},
+				Keys:     []int{},
+			},
+		},
+		{
+			name: "k=1",
+			args: args{k: 1, candidates: problemSet()},
+			want: &Aggregation{
+				Coverage: bitfield.Bitlist{0b0011011, 0b1},
+				Keys:     []int{1},
+			},
+		},
+		{
+			name: "k=2",
+			args: args{k: 2, candidates: problemSet()},
+			want: &Aggregation{
+				Coverage: bitfield.Bitlist{0b0011111, 0b1},
+				Keys:     []int{1, 0},
+			},
+		},
+		{
+			name: "k=3",
+			args: args{k: 3, candidates: problemSet()},
+			want: &Aggregation{
+				Coverage: bitfield.Bitlist{0b0011111, 0b1},
+				Keys:     []int{1, 0},
+			},
+		},
+		{
+			name: "k=5",
+			args: args{k: 5, candidates: problemSet()},
+			want: &Aggregation{
+				Coverage: bitfield.Bitlist{0b0011111, 0b1},
+				Keys:     []int{1, 0},
+			},
+		},
+		{
+			name: "k=50",
+			args: args{k: 50, candidates: problemSet()},
+			want: &Aggregation{
+				Coverage: bitfield.Bitlist{0b0011111, 0b1},
+				Keys:     []int{1, 0},
+			},
+		},
+		{
+			name: "suboptimal", // Greedy algorithm selects: 0, 2, 3, while 1,4,5 is optimal.
+			args: args{k: 3, candidates: MaxCoverCandidates{
+				{0, &bitfield.Bitlist{0b00000000, 0b00011111, 0b1}, 0, false},
+				{2, &bitfield.Bitlist{0b00000001, 0b11100000, 0b1}, 0, false},
+				{3, &bitfield.Bitlist{0b00000110, 0b00000000, 0b1}, 0, false},
+				{1, &bitfield.Bitlist{0b00110000, 0b01110000, 0b1}, 0, false},
+				{4, &bitfield.Bitlist{0b00000110, 0b10001100, 0b1}, 0, false},
+				{5, &bitfield.Bitlist{0b01001001, 0b00000011, 0b1}, 0, false},
+			}},
+			want: &Aggregation{
+				Coverage: bitfield.Bitlist{0b00000111, 0b11111111, 0b1},
+				Keys:     []int{0, 2, 3},
+			},
+		},
+		{
+			name: "allow overlaps",
+			args: args{k: 5, allowOverlaps: true, candidates: MaxCoverCandidates{
+				{0, &bitfield.Bitlist{0b00000000, 0b00000001, 0b11111110, 0b1}, 0, false},
+				{1, &bitfield.Bitlist{0b00000000, 0b00001110, 0b00001110, 0b1}, 0, false},
+				{2, &bitfield.Bitlist{0b00000000, 0b01110000, 0b01110000, 0b1}, 0, false},
+				{3, &bitfield.Bitlist{0b00000111, 0b10000001, 0b10000000, 0b1}, 0, false},
+				{4, &bitfield.Bitlist{0b00000000, 0b00000110, 0b00000110, 0b1}, 0, false},
+				{5, &bitfield.Bitlist{0b00000000, 0b00000001, 0b01100010, 0b1}, 0, false},
+				{6, &bitfield.Bitlist{0b00001000, 0b00001000, 0b10000010, 0b1}, 0, false},
+			}},
+			want: &Aggregation{
+				Coverage: bitfield.Bitlist{0b00001111, 0xff, 0b11111110, 0b1},
+				Keys:     []int{0, 3, 1, 2, 6},
+			},
+		},
+	}
+	copyCandidates := func(candidates MaxCoverCandidates) MaxCoverCandidates {
+		copyCandidates := make(MaxCoverCandidates, 0, len(candidates))
+		for _, candidate := range candidates {
+			copyCandidates = append(copyCandidates, NewMaxCoverCandidate(candidate.key, candidate.bits))
+		}
+		return copyCandidates
+	}
+	for _, tt := range tests {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				mc := &MaxCoverProblem{
+					Candidates: copyCandidates(tt.args.candidates),
+				}
+				got, err := mc.Cover(tt.args.k, tt.args.allowOverlaps)
+				if tt.wantedErr != "" {
+					require.ErrorContains(b, tt.wantedErr, err)
+				} else {
+					require.NoError(b, err)
+					require.DeepEqual(b, tt.want, got)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMaxCoverProblem_MaxCover(b *testing.B) {
+	bitlistLen := params.BeaconConfig().MaxValidatorsPerCommittee
+	tests := []struct {
+		name          string
+		numCandidates uint64
+		numMarkedBits uint64
+		allowOverlaps bool
+	}{
+		{
+			name:          "128_attestations_with_single_bit_set",
+			numCandidates: 128,
+			numMarkedBits: 8,
+		},
+		{
+			name:          "1024_attestations_with_single_bit_set",
+			numCandidates: 1024,
+			numMarkedBits: 8,
+		},
+		{
+			name:          "2048_attestations_with_single_bit_set",
+			numCandidates: 2048,
+			numMarkedBits: 8,
+		},
+	}
+	for _, tt := range tests {
+		bitlists := aggtesting.Bitlists64WithSingleBitSet(tt.numCandidates, bitlistLen)
+		b.Run(tt.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _, err := MaxCover(bitlists, len(bitlists), tt.allowOverlaps)
+				_ = err
+			}
+		})
+	}
+}

--- a/shared/aggregation/testing/bitlistutils.go
+++ b/shared/aggregation/testing/bitlistutils.go
@@ -58,6 +58,23 @@ func BitlistsWithMultipleBitSet(t testing.TB, n, length, count uint64) []bitfiel
 	return lists
 }
 
+// Bitlists64WithMultipleBitSet creates list of bitlists with random n bits set.
+func Bitlists64WithMultipleBitSet(t testing.TB, n, length, count uint64) []*bitfield.Bitlist64 {
+	seed := timeutils.Now().UnixNano()
+	t.Logf("Bitlists64WithMultipleBitSet random seed: %v", seed)
+	rand.Seed(seed)
+	lists := make([]*bitfield.Bitlist64, n)
+	for i := uint64(0); i < n; i++ {
+		b := bitfield.NewBitlist64(length)
+		keys := rand.Perm(int(length))
+		for _, key := range keys[:count] {
+			b.SetBitAt(uint64(key), true)
+		}
+		lists[i] = b
+	}
+	return lists
+}
+
 // MakeAttestationsFromBitlists creates list of bitlists from list of attestations.
 func MakeAttestationsFromBitlists(bl []bitfield.Bitlist) []*ethpb.Attestation {
 	atts := make([]*ethpb.Attestation, len(bl))

--- a/shared/aggregation/testing/bitlistutils.go
+++ b/shared/aggregation/testing/bitlistutils.go
@@ -30,6 +30,17 @@ func BitlistsWithSingleBitSet(n, length uint64) []bitfield.Bitlist {
 	return lists
 }
 
+// Bitlists64WithSingleBitSet creates list of bitlists with a single bit set in each.
+func Bitlists64WithSingleBitSet(n, length uint64) []*bitfield.Bitlist64 {
+	lists := make([]*bitfield.Bitlist64, n)
+	for i := uint64(0); i < n; i++ {
+		b := bitfield.NewBitlist64(length)
+		b.SetBitAt(i%length, true)
+		lists[i] = b
+	}
+	return lists
+}
+
 // BitlistsWithMultipleBitSet creates list of bitlists with random n bits set.
 func BitlistsWithMultipleBitSet(t testing.TB, n, length, count uint64) []bitfield.Bitlist {
 	seed := timeutils.Now().UnixNano()


### PR DESCRIPTION
**What type of PR is this?**

> Other / Optimization

**What does this PR do? Why is it needed?**
- Adds `aggregation.MaxCover()` function (which will outdate the `MaxCoverProblem.Cover()` -- and overall, `MaxCoverProblem` struct).
- This new implementation relies on optmized `bitfield.Bitlist64` heavily (both for bitwise operations and for tracking processed attestations -- there `Bitlist64` is used as bitmap/bitset).
- Adds necessary unit tests.
- Adds bechnmark tests comparing our current (`MaxCoverProblem`-based) implementation and the new, optimized, one.

**Which issues(s) does this PR fix?**

Extracted from #7938

**Other notes for review**
Benchmark (`cur_` is the current implementation, `new_` is this PR's implementation, ~x8-10 improvement):
![image](https://user-images.githubusercontent.com/188194/106127140-4ca3cf00-616f-11eb-99a0-d54673079e72.png)


**Note:** ❗  Also, please, notice number of allocations in the new implementation - it is constant for all test cases!