### PR TITLE
Introduce helper function for adding context metadata from gRPC headers

### DIFF
--- a/shared/grpcutils/BUILD.bazel
+++ b/shared/grpcutils/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@prysm//tools/go:def.bzl", "go_library")
 
 go_library(
@@ -8,6 +9,18 @@ go_library(
     deps = [
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//metadata:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["grpcutils_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//shared/testutil/assert:go_default_library",
+        "//shared/testutil/require:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@org_golang_google_grpc//metadata:go_default_library",
     ],
 )

--- a/shared/grpcutils/grpcutils.go
+++ b/shared/grpcutils/grpcutils.go
@@ -52,8 +52,8 @@ func LogGRPCStream(ctx context.Context, sd *grpc.StreamDesc, conn *grpc.ClientCo
 
 // AppendHeadersToOutgoingContext parses the provided GRPC headers
 // and attaches them to the provided context.
-func AppendHeaders(parent context.Context, headers string) context.Context {
-	for _, h := range strings.Split(headers, ",") {
+func AppendHeaders(parent context.Context, headers []string) context.Context {
+	for _, h := range headers {
 		if h != "" {
 			keyValue := strings.Split(h, "=")
 			if len(keyValue) < 2 {

--- a/shared/grpcutils/grpcutils.go
+++ b/shared/grpcutils/grpcutils.go
@@ -2,6 +2,7 @@ package grpcutils
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -47,4 +48,20 @@ func LogGRPCStream(ctx context.Context, sd *grpc.StreamDesc, conn *grpc.ClientCo
 		WithField("method", method).
 		Debug("gRPC stream started.")
 	return strm, err
+}
+
+// AppendHeadersToOutgoingContext parses the provided GRPC headers
+// and attaches them to the provided context.
+func AppendHeaders(parent context.Context, headers string) context.Context {
+	for _, h := range strings.Split(headers, ",") {
+		if h != "" {
+			keyValue := strings.Split(h, "=")
+			if len(keyValue) < 2 {
+				logrus.Warnf("Incorrect gRPC header flag format. Skipping %v", keyValue[0])
+				continue
+			}
+			parent = metadata.AppendToOutgoingContext(parent, keyValue[0], strings.Join(keyValue[1:], "="))
+		}
+	}
+	return parent
 }

--- a/shared/grpcutils/grpcutils.go
+++ b/shared/grpcutils/grpcutils.go
@@ -10,9 +10,16 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// LogGRPCRequests this method logs the gRPC backend as well as request duration when the log level is set to debug
+// LogRequests logs the gRPC backend as well as request duration when the log level is set to debug
 // or higher.
-func LogGRPCRequests(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+func LogRequests(
+	ctx context.Context,
+	method string, req,
+	reply interface{},
+	cc *grpc.ClientConn,
+	invoker grpc.UnaryInvoker,
+	opts ...grpc.CallOption,
+) error {
 	// Shortcut when debug logging is not enabled.
 	if logrus.GetLevel() < logrus.DebugLevel {
 		return invoker(ctx, method, req, reply, cc, opts...)
@@ -31,8 +38,15 @@ func LogGRPCRequests(ctx context.Context, method string, req, reply interface{},
 	return err
 }
 
-// LogGRPCStream to print the method at DEBUG level at the start of the stream.
-func LogGRPCStream(ctx context.Context, sd *grpc.StreamDesc, conn *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+// LogStream prints the method at DEBUG level at the start of the stream.
+func LogStream(
+	ctx context.Context,
+	sd *grpc.StreamDesc,
+	conn *grpc.ClientConn,
+	method string,
+	streamer grpc.Streamer,
+	opts ...grpc.CallOption,
+) (grpc.ClientStream, error) {
 	// Shortcut when debug logging is not enabled.
 	if logrus.GetLevel() < logrus.DebugLevel {
 		return streamer(ctx, sd, conn, method, opts...)

--- a/shared/grpcutils/grpcutils.go
+++ b/shared/grpcutils/grpcutils.go
@@ -64,7 +64,7 @@ func LogStream(
 	return strm, err
 }
 
-// AppendHeadersToOutgoingContext parses the provided GRPC headers
+// AppendHeaders parses the provided GRPC headers
 // and attaches them to the provided context.
 func AppendHeaders(parent context.Context, headers []string) context.Context {
 	for _, h := range headers {

--- a/shared/grpcutils/grpcutils_test.go
+++ b/shared/grpcutils/grpcutils_test.go
@@ -1,0 +1,57 @@
+package grpcutils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	logTest "github.com/sirupsen/logrus/hooks/test"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestAppendHeaders(t *testing.T) {
+	t.Run("One header", func(t *testing.T) {
+		ctx := AppendHeaders(context.Background(), "first=value1")
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.Equal(t, true, ok, "Failed to read context metadata")
+		require.Equal(t, 1, md.Len(), "Metadata contains wrong number of values")
+		assert.Equal(t, "value1", md.Get("first")[0])
+	})
+
+	t.Run("Multiple headers", func(t *testing.T) {
+		ctx := AppendHeaders(context.Background(), "first=value1,second=value2")
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.Equal(t, true, ok, "Failed to read context metadata")
+		require.Equal(t, 2, md.Len(), "Metadata contains wrong number of values")
+		assert.Equal(t, "value1", md.Get("first")[0])
+		assert.Equal(t, "value2", md.Get("second")[0])
+	})
+
+	t.Run("One empty header", func(t *testing.T) {
+		ctx := AppendHeaders(context.Background(), "first=value1,,second=value2")
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.Equal(t, true, ok, "Failed to read context metadata")
+		require.Equal(t, 2, md.Len(), "Metadata contains wrong number of values")
+		assert.Equal(t, "value1", md.Get("first")[0])
+		assert.Equal(t, "value2", md.Get("second")[0])
+	})
+
+	t.Run("Incorrect header", func(t *testing.T) {
+		logHook := logTest.NewGlobal()
+		ctx := AppendHeaders(context.Background(), "first=value1,second")
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.Equal(t, true, ok, "Failed to read context metadata")
+		require.Equal(t, 1, md.Len(), "Metadata contains wrong number of values")
+		assert.Equal(t, "value1", md.Get("first")[0])
+		assert.LogsContain(t, logHook, "Skipping second")
+	})
+
+	t.Run("Header value with equal sign", func(t *testing.T) {
+		ctx := AppendHeaders(context.Background(), "first=value=1")
+		md, ok := metadata.FromOutgoingContext(ctx)
+		require.Equal(t, true, ok, "Failed to read context metadata")
+		require.Equal(t, 1, md.Len(), "Metadata contains wrong number of values")
+		assert.Equal(t, "value=1", md.Get("first")[0])
+	})
+}

--- a/shared/grpcutils/grpcutils_test.go
+++ b/shared/grpcutils/grpcutils_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAppendHeaders(t *testing.T) {
 	t.Run("One header", func(t *testing.T) {
-		ctx := AppendHeaders(context.Background(), "first=value1")
+		ctx := AppendHeaders(context.Background(), []string{"first=value1"})
 		md, ok := metadata.FromOutgoingContext(ctx)
 		require.Equal(t, true, ok, "Failed to read context metadata")
 		require.Equal(t, 1, md.Len(), "Metadata contains wrong number of values")
@@ -20,7 +20,7 @@ func TestAppendHeaders(t *testing.T) {
 	})
 
 	t.Run("Multiple headers", func(t *testing.T) {
-		ctx := AppendHeaders(context.Background(), "first=value1,second=value2")
+		ctx := AppendHeaders(context.Background(), []string{"first=value1", "second=value2"})
 		md, ok := metadata.FromOutgoingContext(ctx)
 		require.Equal(t, true, ok, "Failed to read context metadata")
 		require.Equal(t, 2, md.Len(), "Metadata contains wrong number of values")
@@ -29,17 +29,16 @@ func TestAppendHeaders(t *testing.T) {
 	})
 
 	t.Run("One empty header", func(t *testing.T) {
-		ctx := AppendHeaders(context.Background(), "first=value1,,second=value2")
+		ctx := AppendHeaders(context.Background(), []string{"first=value1", ""})
 		md, ok := metadata.FromOutgoingContext(ctx)
 		require.Equal(t, true, ok, "Failed to read context metadata")
-		require.Equal(t, 2, md.Len(), "Metadata contains wrong number of values")
+		require.Equal(t, 1, md.Len(), "Metadata contains wrong number of values")
 		assert.Equal(t, "value1", md.Get("first")[0])
-		assert.Equal(t, "value2", md.Get("second")[0])
 	})
 
 	t.Run("Incorrect header", func(t *testing.T) {
 		logHook := logTest.NewGlobal()
-		ctx := AppendHeaders(context.Background(), "first=value1,second")
+		ctx := AppendHeaders(context.Background(), []string{"first=value1", "second"})
 		md, ok := metadata.FromOutgoingContext(ctx)
 		require.Equal(t, true, ok, "Failed to read context metadata")
 		require.Equal(t, 1, md.Len(), "Metadata contains wrong number of values")
@@ -48,7 +47,7 @@ func TestAppendHeaders(t *testing.T) {
 	})
 
 	t.Run("Header value with equal sign", func(t *testing.T) {
-		ctx := AppendHeaders(context.Background(), "first=value=1")
+		ctx := AppendHeaders(context.Background(), []string{"first=value=1"})
 		md, ok := metadata.FromOutgoingContext(ctx)
 		require.Equal(t, true, ok, "Failed to read context metadata")
 		require.Equal(t, 1, md.Len(), "Metadata contains wrong number of values")

--- a/slasher/beaconclient/service.go
+++ b/slasher/beaconclient/service.go
@@ -164,13 +164,13 @@ func (s *Service) Start() {
 			grpc_opentracing.StreamClientInterceptor(),
 			grpc_prometheus.StreamClientInterceptor,
 			grpc_retry.StreamClientInterceptor(),
-			grpcutils.LogGRPCStream,
+			grpcutils.LogStream,
 		)),
 		grpc.WithUnaryInterceptor(middleware.ChainUnaryClient(
 			grpc_opentracing.UnaryClientInterceptor(),
 			grpc_prometheus.UnaryClientInterceptor,
 			grpc_retry.UnaryClientInterceptor(),
-			grpcutils.LogGRPCRequests,
+			grpcutils.LogRequests,
 		)),
 	}
 	conn, err := grpc.DialContext(s.ctx, s.provider, beaconOpts...)

--- a/validator/accounts/BUILD.bazel
+++ b/validator/accounts/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//shared/cmd:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/fileutil:go_default_library",
+        "//shared/grpcutils:go_default_library",
         "//shared/petnames:go_default_library",
         "//shared/promptutil:go_default_library",
         "//shared/tos:go_default_library",
@@ -54,7 +55,6 @@ go_library(
         "@com_github_urfave_cli_v2//:go_default_library",
         "@com_github_wealdtech_go_eth2_wallet_encryptor_keystorev4//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
-        "@org_golang_google_grpc//metadata:go_default_library",
     ],
 )
 

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -65,7 +65,6 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
-        "@org_golang_google_grpc//metadata:go_default_library",
         "@org_golang_google_grpc//resolver:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
     ],

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -38,7 +38,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 		log.Debug("Assigned to genesis slot, skipping proposal")
 		return
 	}
-	lock := mputil.NewMultilock(string(rune(roleProposer)), string(pubKey[:]))
+	lock := mputil.NewMultilock(string(roleProposer), string(pubKey[:]))
 	lock.Lock()
 	defer lock.Unlock()
 	ctx, span := trace.StartSpan(ctx, "validator.ProposeBlock")

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -38,7 +38,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot uint64, pubKey [48]by
 		log.Debug("Assigned to genesis slot, skipping proposal")
 		return
 	}
-	lock := mputil.NewMultilock(string(roleProposer), string(pubKey[:]))
+	lock := mputil.NewMultilock(string(rune(roleProposer)), string(pubKey[:]))
 	lock.Lock()
 	defer lock.Unlock()
 	ctx, span := trace.StartSpan(ctx, "validator.ProposeBlock")

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -28,7 +28,6 @@ import (
 	"go.opencensus.io/plugin/ocgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/metadata"
 )
 
 // SyncChecker is able to determine if a beacon node is currently
@@ -138,16 +137,7 @@ func (v *ValidatorService) Start() {
 		return
 	}
 
-	for _, hdr := range v.grpcHeaders {
-		if hdr != "" {
-			ss := strings.Split(hdr, "=")
-			if len(ss) < 2 {
-				log.Warnf("Incorrect gRPC header flag format. Skipping %v", ss[0])
-				continue
-			}
-			v.ctx = metadata.AppendToOutgoingContext(v.ctx, ss[0], strings.Join(ss[1:], "="))
-		}
-	}
+	v.ctx = grpcutils.AppendHeaders(v.ctx, v.grpcHeaders)
 
 	conn, err := grpc.DialContext(v.ctx, v.endpoint, dialOpts...)
 	if err != nil {

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -290,10 +290,10 @@ func ConstructDialOptions(
 			grpc_opentracing.UnaryClientInterceptor(),
 			grpc_prometheus.UnaryClientInterceptor,
 			grpc_retry.UnaryClientInterceptor(),
-			grpcutils.LogGRPCRequests,
+			grpcutils.LogRequests,
 		)),
 		grpc.WithChainStreamInterceptor(
-			grpcutils.LogGRPCStream,
+			grpcutils.LogStream,
 			grpc_opentracing.StreamClientInterceptor(),
 			grpc_prometheus.StreamClientInterceptor,
 			grpc_retry.StreamClientInterceptor(),

--- a/validator/rpc/BUILD.bazel
+++ b/validator/rpc/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//shared/event:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/fileutil:go_default_library",
+        "//shared/grpcutils:go_default_library",
         "//shared/logutil:go_default_library",
         "//shared/pagination:go_default_library",
         "//shared/petnames:go_default_library",

--- a/validator/rpc/beacon.go
+++ b/validator/rpc/beacon.go
@@ -2,7 +2,6 @@ package rpc
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	ptypes "github.com/gogo/protobuf/types"
@@ -14,9 +13,9 @@ import (
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	healthpb "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/validator/accounts/v2"
+	"github.com/prysmaticlabs/prysm/shared/grpcutils"
 	"github.com/prysmaticlabs/prysm/validator/client"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 // Initialize a client connect to a beacon node gRPC endpoint.
@@ -36,16 +35,9 @@ func (s *Server) registerBeaconClient() error {
 	if dialOpts == nil {
 		return errors.New("no dial options for beacon chain gRPC client")
 	}
-	for _, hdr := range s.clientGrpcHeaders {
-		if hdr != "" {
-			ss := strings.Split(hdr, "=")
-			if len(ss) < 2 {
-				log.Warnf("Incorrect gRPC header flag format. Skipping %v", ss[0])
-				continue
-			}
-			s.ctx = metadata.AppendToOutgoingContext(s.ctx, ss[0], strings.Join(ss[1:], "="))
-		}
-	}
+
+	s.ctx = grpcutils.AppendHeaders(s.ctx, s.clientGrpcHeaders)
+
 	conn, err := grpc.DialContext(s.ctx, s.beaconClientEndpoint, dialOpts...)
 	if err != nil {
 		return errors.Wrapf(err, "could not dial endpoint: %s", s.beaconClientEndpoint)

--- a/validator/rpc/beacon_test.go
+++ b/validator/rpc/beacon_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc/metadata"
-
 	ptypes "github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
@@ -15,6 +13,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/mock"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestGetBeaconStatus_NotConnected(t *testing.T) {

--- a/validator/rpc/beacon_test.go
+++ b/validator/rpc/beacon_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc/metadata"
+
 	ptypes "github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
@@ -77,4 +79,17 @@ func TestGetBeaconStatus_OK(t *testing.T) {
 		},
 	}
 	assert.DeepEqual(t, want, resp)
+}
+
+func TestGrpcHeaders(t *testing.T) {
+	s := &Server{
+		ctx:               context.Background(),
+		clientGrpcHeaders: []string{"first=value1", "second=value2"},
+	}
+	err := s.registerBeaconClient()
+	require.NoError(t, err)
+	md, _ := metadata.FromOutgoingContext(s.ctx)
+	require.Equal(t, 2, md.Len(), "Metadata contains wrong number of values")
+	assert.Equal(t, "value1", md.Get("first")[0])
+	assert.Equal(t, "value2", md.Get("second")[0])
 }

--- a/validator/slashing-protection/BUILD.bazel
+++ b/validator/slashing-protection/BUILD.bazel
@@ -36,7 +36,6 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//connectivity:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
-        "@org_golang_google_grpc//metadata:go_default_library",
     ],
 )
 
@@ -45,6 +44,7 @@ go_test(
     srcs = [
         "cli_import_export_test.go",
         "external_test.go",
+        "slasher_client_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
@@ -60,5 +60,6 @@ go_test(
         "//validator/testing:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
+        "@org_golang_google_grpc//metadata:go_default_library",
     ],
 )

--- a/validator/slashing-protection/slasher_client.go
+++ b/validator/slashing-protection/slasher_client.go
@@ -100,7 +100,7 @@ func (s *Service) startSlasherClient() ethsl.SlasherClient {
 			grpc_opentracing.UnaryClientInterceptor(),
 			grpc_prometheus.UnaryClientInterceptor,
 			grpc_retry.UnaryClientInterceptor(),
-			grpcutils.LogGRPCRequests,
+			grpcutils.LogRequests,
 		)),
 	}
 	conn, err := grpc.DialContext(s.ctx, s.endpoint, opts...)

--- a/validator/slashing-protection/slasher_client.go
+++ b/validator/slashing-protection/slasher_client.go
@@ -17,7 +17,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/metadata"
 )
 
 // Service represents a service to manage the validator
@@ -83,24 +82,13 @@ func (s *Service) startSlasherClient() ethsl.SlasherClient {
 		log.Warn("You are using an insecure slasher gRPC connection! Please provide a certificate and key to use a secure connection.")
 	}
 
-	md := make(metadata.MD)
-	for _, hdr := range s.grpcHeaders {
-		if hdr != "" {
-			ss := strings.Split(hdr, "=")
-			if len(ss) != 2 {
-				log.Warnf("Incorrect gRPC header flag format. Skipping %v", hdr)
-				continue
-			}
-			md.Set(ss[0], ss[1])
-		}
-	}
+	s.ctx = grpcutils.AppendHeaders(s.ctx, s.grpcHeaders)
 
 	opts := []grpc.DialOption{
 		dialOpt,
 		grpc.WithDefaultCallOptions(
 			grpc_retry.WithMax(s.grpcRetries),
 			grpc_retry.WithBackoff(grpc_retry.BackoffLinear(s.grpcRetryDelay)),
-			grpc.Header(&md),
 		),
 		grpc.WithStatsHandler(&ocgrpc.ClientHandler{}),
 		grpc.WithStreamInterceptor(middleware.ChainStreamClient(

--- a/validator/slashing-protection/slasher_client_test.go
+++ b/validator/slashing-protection/slasher_client_test.go
@@ -1,0 +1,22 @@
+package slashingprotection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestGrpcHeaders(t *testing.T) {
+	s := &Service{
+		ctx:         context.Background(),
+		grpcHeaders: []string{"first=value1", "second=value2"},
+	}
+	s.startSlasherClient()
+	md, _ := metadata.FromOutgoingContext(s.ctx)
+	require.Equal(t, 2, md.Len(), "Metadata contains wrong number of values")
+	assert.Equal(t, "value1", md.Get("first")[0])
+	assert.Equal(t, "value2", md.Get("second")[0])
+}


### PR DESCRIPTION
**What type of PR is this?**

Refactor

**What does this PR do? Why is it needed?**

https://github.com/prysmaticlabs/prysm/pull/8334 includes adding gRPC headers to context metadata. This is basically the same code repeated for the 4th time in the repo. This PR:
- introduces a new helper function in the `grpcutils` package that should be used moving forward
- changes existing header manipulation code to use the new helper
- does a small clean-up to the `grpcutils` package

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
