### PR TITLE
Add wallet file flag to edit-config command

### DIFF
--- a/validator/accounts/cmd_wallet.go
+++ b/validator/accounts/cmd_wallet.go
@@ -53,6 +53,7 @@ var WalletCommands = &cli.Command{
 			Usage: "edits a wallet configuration options, such as gRPC connection credentials and TLS certificates",
 			Flags: cmd.WrapFlags([]cli.Flag{
 				flags.WalletDirFlag,
+				flags.WalletPasswordFileFlag,
 				flags.GrpcRemoteAddressFlag,
 				flags.DisableRemoteSignerTlsFlag,
 				flags.RemoteSignerCertPathFlag,


### PR DESCRIPTION
**What type of PR is this?**
Improvement

**What does this PR do? Why is it needed?**
This PR adds the `--wallet-password-file` flag to enable non-interactive usage of the `wallet edit-config` command.

**Which issues(s) does this PR fix?**

Fixes #8355