### PR TITLE
Deprecate enableSyncBacktracking flag

### DIFF
--- a/beacon-chain/sync/initial-sync/BUILD.bazel
+++ b/beacon-chain/sync/initial-sync/BUILD.bazel
@@ -33,7 +33,6 @@ go_library(
         "//shared:go_default_library",
         "//shared/abool:go_default_library",
         "//shared/bytesutil:go_default_library",
-        "//shared/featureconfig:go_default_library",
         "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/rand:go_default_library",

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	beaconsync "github.com/prysmaticlabs/prysm/beacon-chain/sync"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/sirupsen/logrus"
 )
 
@@ -418,7 +417,7 @@ func (q *blocksQueue) onProcessSkippedEvent(ctx context.Context) eventHandlerFn 
 
 		// All machines are skipped, FSMs need reset.
 		startSlot := q.chain.HeadSlot() + 1
-		if featureconfig.Get().EnableSyncBacktracking && q.mode == modeNonConstrained && startSlot > bestFinalizedSlot {
+		if q.mode == modeNonConstrained && startSlot > bestFinalizedSlot {
 			q.staleEpochs[helpers.SlotToEpoch(startSlot)]++
 			// If FSMs have been reset enough times, try to explore alternative forks.
 			if q.staleEpochs[helpers.SlotToEpoch(startSlot)] >= maxResetAttempts {

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -17,7 +17,6 @@ import (
 	p2pt "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
 	beaconsync "github.com/prysmaticlabs/prysm/beacon-chain/sync"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
-	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
@@ -1024,11 +1023,6 @@ func TestBlocksQueue_onCheckStaleEvent(t *testing.T) {
 }
 
 func TestBlocksQueue_stuckInUnfavourableFork(t *testing.T) {
-	resetCfg := featureconfig.InitWithReset(&featureconfig.Flags{
-		EnableSyncBacktracking: true,
-	})
-	defer resetCfg()
-
 	beaconDB := dbtest.SetupDB(t)
 	p2p := p2pt.NewTestP2P(t)
 

--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -44,7 +44,6 @@ type Flags struct {
 	EnableEth1DataMajorityVote         bool // EnableEth1DataMajorityVote uses the Voting With The Majority algorithm to vote for eth1data.
 	EnablePeerScorer                   bool // EnablePeerScorer enables experimental peer scoring in p2p.
 	EnablePruningDepositProofs         bool // EnablePruningDepositProofs enables pruning deposit proofs which significantly reduces the size of a deposit
-	EnableSyncBacktracking             bool // EnableSyncBacktracking enables backtracking algorithm when searching for alternative forks during initial sync.
 	EnableLargerGossipHistory          bool // EnableLargerGossipHistory increases the gossip history we store in our caches.
 	WriteWalletPasswordOnWebOnboarding bool // WriteWalletPasswordOnWebOnboarding writes the password to disk after Prysm web signup.
 	DisableAttestingHistoryDBCache     bool // DisableAttestingHistoryDBCache for the validator client increases disk reads/writes.
@@ -176,11 +175,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.Bool(disablePruningDepositProofs.Name) {
 		log.Warn("Disabling pruning deposit proofs")
 		cfg.EnablePruningDepositProofs = false
-	}
-	cfg.EnableSyncBacktracking = true
-	if ctx.Bool(disableSyncBacktracking.Name) {
-		log.Warn("Disabling init-sync backtracking algorithm")
-		cfg.EnableSyncBacktracking = false
 	}
 	if ctx.Bool(enableLargerGossipHistory.Name) {
 		log.Warn("Using a larger gossip history for the node")

--- a/shared/featureconfig/deprecated_flags.go
+++ b/shared/featureconfig/deprecated_flags.go
@@ -12,14 +12,8 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
-	deprecatedDisableSyncBacktracking = &cli.StringFlag{
-		Name:   "enable-sync-backtracking",
-		Usage:  deprecatedUsage,
-		Hidden: true,
-	}
 )
 
 var deprecatedFlags = []cli.Flag{
 	exampleDeprecatedFeatureFlag,
-	deprecatedDisableSyncBacktracking,
 }

--- a/shared/featureconfig/deprecated_flags.go
+++ b/shared/featureconfig/deprecated_flags.go
@@ -12,8 +12,20 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableSyncBacktracking = &cli.StringFlag{
+		Name:   "enable-sync-backtracking",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
+	deprecatedDisableSyncBacktracking = &cli.StringFlag{
+		Name:   "disable-sync-backtracking",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
 	exampleDeprecatedFeatureFlag,
+	deprecatedEnableSyncBacktracking,
+	deprecatedDisableSyncBacktracking,
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -78,10 +78,6 @@ var (
 		Usage: "Disables pruning deposit proofs when they are no longer needed." +
 			"This will probably significantly increase the amount of memory taken up by deposits.",
 	}
-	disableSyncBacktracking = &cli.BoolFlag{
-		Name:  "disable-sync-backtracking",
-		Usage: "Disable alternative fork exploration backtracking algorithm",
-	}
 	enableLargerGossipHistory = &cli.BoolFlag{
 		Name:  "enable-larger-gossip-history",
 		Usage: "Enables the node to store a larger amount of gossip messages in its cache.",
@@ -163,7 +159,6 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	enableLargerGossipHistory,
 	checkPtInfoCache,
 	disablePruningDepositProofs,
-	disableSyncBacktracking,
 	disableBroadcastSlashingFlag,
 	enableNextSlotStateCache,
 }...)


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**
- Exploration of alternative forks has been tested in Pyrmont, and made it to the tagged release. Time to deprecate the flag.

**Which issues(s) does this PR fix?**

Fixes #7734

**Other notes for review**
