### PR TITLE
Add Helpers Required for Attestation Slashing Detection, Begin Detection Framework

### DIFF
--- a/beacon-chain/slasher/BUILD.bazel
+++ b/beacon-chain/slasher/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "chunks.go",
+        "detect_attestations.go",
         "doc.go",
         "log.go",
         "params.go",
@@ -17,6 +18,8 @@ go_library(
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/slasher/types:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/params:go_default_library",
+        "//shared/slotutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/beacon-chain/slasher/BUILD.bazel
+++ b/beacon-chain/slasher/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "chunks_test.go",
+        "detect_attestations_test.go",
         "params_test.go",
         "receive_test.go",
         "service_test.go",

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
-	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 )
@@ -25,7 +25,7 @@ type Chunker interface {
 		ctx context.Context,
 		slasherDB db.Database,
 		validatorIdx types.ValidatorIndex,
-		attestation *ethpb.IndexedAttestation,
+		attestation *compactAttestation,
 	) (slashertypes.SlashingKind, error)
 	Update(
 		chunkIdx uint64,
@@ -177,10 +177,10 @@ func (m *MinSpanChunksSlice) CheckSlashable(
 	ctx context.Context,
 	slasherDB db.Database,
 	validatorIdx types.ValidatorIndex,
-	attestation *ethpb.IndexedAttestation,
+	attestation *compactAttestation,
 ) (slashertypes.SlashingKind, error) {
-	sourceEpoch := types.Epoch(attestation.Data.Source.Epoch)
-	targetEpoch := types.Epoch(attestation.Data.Target.Epoch)
+	sourceEpoch := types.Epoch(attestation.source)
+	targetEpoch := types.Epoch(attestation.target)
 	minTarget, err := chunkDataAtEpoch(m.params, m.data, validatorIdx, sourceEpoch)
 	if err != nil {
 		return slashertypes.NotSlashable, errors.Wrapf(
@@ -216,10 +216,10 @@ func (m *MaxSpanChunksSlice) CheckSlashable(
 	ctx context.Context,
 	slasherDB db.Database,
 	validatorIdx types.ValidatorIndex,
-	attestation *ethpb.IndexedAttestation,
+	attestation *compactAttestation,
 ) (slashertypes.SlashingKind, error) {
-	sourceEpoch := types.Epoch(attestation.Data.Source.Epoch)
-	targetEpoch := types.Epoch(attestation.Data.Target.Epoch)
+	sourceEpoch := types.Epoch(attestation.source)
+	targetEpoch := types.Epoch(attestation.target)
 	maxTarget, err := chunkDataAtEpoch(m.params, m.data, validatorIdx, sourceEpoch)
 	if err != nil {
 		return slashertypes.NotSlashable, errors.Wrapf(

--- a/beacon-chain/slasher/chunks_test.go
+++ b/beacon-chain/slasher/chunks_test.go
@@ -145,7 +145,17 @@ func TestMinSpanChunksSlice_CheckSlashable(t *testing.T) {
 
 	// Next up, we save the old attestation record, then check if the
 	// surrounding vote is indeed slashable.
-	err = beaconDB.SaveAttestationRecordForValidator(ctx, validatorIdx, [32]byte{1}, att)
+	indexedAtt := &ethpb.IndexedAttestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{
+				Epoch: att.source,
+			},
+			Target: &ethpb.Checkpoint{
+				Epoch: att.target,
+			},
+		},
+	}
+	err = beaconDB.SaveAttestationRecordForValidator(ctx, validatorIdx, [32]byte{1}, indexedAtt)
 	require.NoError(t, err)
 
 	kind, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundingVote)
@@ -218,7 +228,17 @@ func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
 
 	// Next up, we save the old attestation record, then check if the
 	// surroundedVote vote is indeed slashable.
-	err = beaconDB.SaveAttestationRecordForValidator(ctx, validatorIdx, [32]byte{1}, att)
+	indexedAtt := &ethpb.IndexedAttestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{
+				Epoch: att.source,
+			},
+			Target: &ethpb.Checkpoint{
+				Epoch: att.target,
+			},
+		},
+	}
+	err = beaconDB.SaveAttestationRecordForValidator(ctx, validatorIdx, [32]byte{1}, indexedAtt)
 	require.NoError(t, err)
 
 	kind, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundedVote)
@@ -421,15 +441,9 @@ func Test_chunkDataAtEpoch_SetRetrieve(t *testing.T) {
 	assert.Equal(t, targetEpoch, received)
 }
 
-func createAttestation(source, target types.Epoch) *ethpb.IndexedAttestation {
-	return &ethpb.IndexedAttestation{
-		Data: &ethpb.AttestationData{
-			Source: &ethpb.Checkpoint{
-				Epoch: uint64(source),
-			},
-			Target: &ethpb.Checkpoint{
-				Epoch: uint64(target),
-			},
-		},
+func createAttestation(source, target types.Epoch) *compactAttestation {
+	return &compactAttestation{
+		source: uint64(source),
+		target: uint64(target),
 	}
 }

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/sirupsen/logrus"
 )
 
 // Process queued attestations every time an epoch ticker fires. We retrieve
@@ -18,7 +19,10 @@ func (s *Service) processQueuedAttestations(ctx context.Context, epochTicker <-c
 			atts := s.attestationQueue
 			s.attestationQueue = make([]*compactAttestation, 0)
 			s.queueLock.Unlock()
-			log.Infof("Epoch %d reached, processing %d queued atts for slashing detection", currentEpoch, len(atts))
+			log.WithFields(logrus.Fields{
+				"currentEpoch": currentEpoch,
+				"numAtts":      len(atts),
+			}).Info("Epoch reached, processing queued atts for slashing detection")
 			groupedAtts := s.groupByValidatorChunkIndex(atts)
 			for validatorChunkIdx, attsBatch := range groupedAtts {
 				s.detectAttestationBatch(attsBatch, validatorChunkIdx, types.Epoch(currentEpoch))

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -14,8 +14,10 @@ func (s *Service) processQueuedAttestations(ctx context.Context, epochTicker <-c
 	for {
 		select {
 		case currentEpoch := <-epochTicker:
+			s.queueLock.Lock()
 			atts := s.attestationQueue
 			s.attestationQueue = make([]*compactAttestation, 0)
+			s.queueLock.Unlock()
 			log.Infof("Epoch %d reached, processing %d queued atts for slashing detection", currentEpoch, len(atts))
 			groupedAtts := s.groupByValidatorChunkIndex(atts)
 			for validatorChunkIdx, attsBatch := range groupedAtts {

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -30,7 +30,7 @@ func (s *Service) processQueuedAttestations(ctx context.Context, epochTicker <-c
 
 // Given a list of attestations all corresponding to a validator chunk index as well
 // as the current epoch in time, we perform slashing detection over the batch.
-// TODO(Raul): Implement.
+// TODO(#8331): Implement.
 func (s *Service) detectAttestationBatch(
 	atts []*ethpb.IndexedAttestation, validatorChunkIndex uint64, currentEpoch types.Epoch,
 ) {

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -1,0 +1,61 @@
+package slasher
+
+import (
+	"context"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/slotutil"
+)
+
+func (s *Service) processQueuedAttestations(ctx context.Context) {
+	secondsPerEpoch := params.BeaconConfig().SecondsPerSlot * params.BeaconConfig().SlotsPerEpoch
+	ticker := slotutil.GetEpochTicker(s.genesisTime, secondsPerEpoch)
+	defer ticker.Done()
+	for {
+		select {
+		case currentEpoch := <-ticker.C():
+			atts := s.attQueue.dequeue()
+			log.Infof("Epoch %d reached, processing %d queued atts", currentEpoch, len(atts))
+			if !validateAttestations(atts) {
+				// TODO: Defer is ready at a future time.
+				continue
+			}
+			// Group by validator index and process batches.
+			// TODO: Perform concurrently with wait groups...?
+			groupedAtts := s.groupByValidatorChunkIndex(atts)
+			for validatorChunkIdx, attBatch := range groupedAtts {
+				s.detectAttestationBatch(validatorChunkIdx, attBatch, currentEpoch)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *Service) detectAttestationBatch(
+	validatorChunkIdx uint64, atts []*ethpb.IndexedAttestation, currentEpoch types.Epoch,
+) {
+
+}
+
+func (s *Service) groupByValidatorChunkIndex(
+	attestations []*ethpb.IndexedAttestation,
+) map[uint64][]*ethpb.IndexedAttestation {
+	groupedAttestations := make(map[uint64][]*ethpb.IndexedAttestation)
+	for _, att := range attestations {
+		subqueueIndices := make(map[uint64]bool)
+		for _, validatorIdx := range att.AttestingIndices {
+			chunkIdx := s.params.validatorChunkIndex(types.ValidatorIndex(validatorIdx))
+			subqueueIndices[chunkIdx] = true
+		}
+		for subqueueIdx := range subqueueIndices {
+			groupedAttestations[subqueueIdx] = append(
+				groupedAttestations[subqueueIdx],
+				att,
+			)
+		}
+	}
+	return groupedAttestations
+}

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -5,44 +5,44 @@ import (
 	"reflect"
 	"testing"
 
-	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	logTest "github.com/sirupsen/logrus/hooks/test"
+
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 )
 
 func TestService_groupByValidatorChunkIndex(t *testing.T) {
 	tests := []struct {
 		name   string
 		params *Parameters
-		atts   []*ethpb.IndexedAttestation
-		want   map[uint64][]*ethpb.IndexedAttestation
+		atts   []*compactAttestation
+		want   map[uint64][]*compactAttestation
 	}{
 		{
 			name:   "No attestations returns empty map",
 			params: DefaultParams(),
-			atts:   make([]*ethpb.IndexedAttestation, 0),
-			want:   make(map[uint64][]*ethpb.IndexedAttestation),
+			atts:   make([]*compactAttestation, 0),
+			want:   make(map[uint64][]*compactAttestation),
 		},
 		{
 			name: "Groups multiple attestations belonging to single validator chunk",
 			params: &Parameters{
 				validatorChunkSize: 2,
 			},
-			atts: []*ethpb.IndexedAttestation{
+			atts: []*compactAttestation{
 				{
-					AttestingIndices: []uint64{0, 1},
+					attestingIndices: []uint64{0, 1},
 				},
 				{
-					AttestingIndices: []uint64{0, 1},
+					attestingIndices: []uint64{0, 1},
 				},
 			},
-			want: map[uint64][]*ethpb.IndexedAttestation{
+			want: map[uint64][]*compactAttestation{
 				0: {
 					{
-						AttestingIndices: []uint64{0, 1},
+						attestingIndices: []uint64{0, 1},
 					},
 					{
-						AttestingIndices: []uint64{0, 1},
+						attestingIndices: []uint64{0, 1},
 					},
 				},
 			},
@@ -52,25 +52,25 @@ func TestService_groupByValidatorChunkIndex(t *testing.T) {
 			params: &Parameters{
 				validatorChunkSize: 2,
 			},
-			atts: []*ethpb.IndexedAttestation{
+			atts: []*compactAttestation{
 				{
-					AttestingIndices: []uint64{0, 2, 4},
+					attestingIndices: []uint64{0, 2, 4},
 				},
 			},
-			want: map[uint64][]*ethpb.IndexedAttestation{
+			want: map[uint64][]*compactAttestation{
 				0: {
 					{
-						AttestingIndices: []uint64{0, 2, 4},
+						attestingIndices: []uint64{0, 2, 4},
 					},
 				},
 				1: {
 					{
-						AttestingIndices: []uint64{0, 2, 4},
+						attestingIndices: []uint64{0, 2, 4},
 					},
 				},
 				2: {
 					{
-						AttestingIndices: []uint64{0, 2, 4},
+						attestingIndices: []uint64{0, 2, 4},
 					},
 				},
 			},
@@ -92,17 +92,11 @@ func TestService_processQueuedAttestations(t *testing.T) {
 	hook := logTest.NewGlobal()
 	s := &Service{
 		params: DefaultParams(),
-		attestationQueue: []*ethpb.IndexedAttestation{
+		attestationQueue: []*compactAttestation{
 			{
-				AttestingIndices: []uint64{0, 1},
-				Data: &ethpb.AttestationData{
-					Source: &ethpb.Checkpoint{
-						Epoch: 0,
-					},
-					Target: &ethpb.Checkpoint{
-						Epoch: 1,
-					},
-				},
+				attestingIndices: []uint64{0, 1},
+				source:           0,
+				target:           1,
 			},
 		},
 	}

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -1,0 +1,99 @@
+package slasher
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+)
+
+func TestService_groupByValidatorChunkIndex(t *testing.T) {
+	tests := []struct {
+		name   string
+		params *Parameters
+		atts   []*ethpb.IndexedAttestation
+		want   map[uint64][]*ethpb.IndexedAttestation
+	}{
+		{
+			name:   "No attestations returns empty map",
+			params: DefaultParams(),
+			atts:   make([]*ethpb.IndexedAttestation, 0),
+			want:   make(map[uint64][]*ethpb.IndexedAttestation),
+		},
+		{
+			name: "Groups multiple attestations belonging to single validator chunk",
+			params: &Parameters{
+				validatorChunkSize: 2,
+			},
+			atts: []*ethpb.IndexedAttestation{
+				{
+					AttestingIndices: []uint64{0, 1},
+				},
+				{
+					AttestingIndices: []uint64{0, 1},
+				},
+			},
+			want: map[uint64][]*ethpb.IndexedAttestation{
+				0: {
+					{
+						AttestingIndices: []uint64{0, 1},
+					},
+					{
+						AttestingIndices: []uint64{0, 1},
+					},
+				},
+			},
+		},
+		{
+			name: "Groups single attestation belonging to multiple validator chunk",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				params: tt.params,
+			}
+			if got := s.groupByValidatorChunkIndex(tt.atts); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("groupByValidatorChunkIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestService_processQueuedAttestations(t *testing.T) {
+	type fields struct {
+		params           *Parameters
+		serviceCfg       *ServiceConfig
+		indexedAttsChan  chan *ethpb.IndexedAttestation
+		attestationQueue []*ethpb.IndexedAttestation
+		ctx              context.Context
+		cancel           context.CancelFunc
+		genesisTime      time.Time
+	}
+	type args struct {
+		ctx         context.Context
+		epochTicker <-chan uint64
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				params:           tt.fields.params,
+				serviceCfg:       tt.fields.serviceCfg,
+				indexedAttsChan:  tt.fields.indexedAttsChan,
+				attestationQueue: tt.fields.attestationQueue,
+				ctx:              tt.fields.ctx,
+				cancel:           tt.fields.cancel,
+				genesisTime:      tt.fields.genesisTime,
+			}
+		})
+	}
+}

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -5,9 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	logTest "github.com/sirupsen/logrus/hooks/test"
-
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func TestService_groupByValidatorChunkIndex(t *testing.T) {
@@ -112,5 +111,5 @@ func TestService_processQueuedAttestations(t *testing.T) {
 	tickerChan <- 0
 	cancel()
 	<-exitChan
-	assert.LogsContain(t, hook, "Epoch 0 reached, processing 1 queued")
+	assert.LogsContain(t, hook, "Epoch reached, processing queued")
 }

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -10,10 +10,7 @@ func (s *Service) receiveAttestations(ctx context.Context) {
 		select {
 		case att := <-s.indexedAttsChan:
 			log.Infof("Got attestation with indices %v", att.AttestingIndices)
-			groupedAtts := s.groupByValidatorChunkIndex(atts)
-			for subqueueIdx, atts := range groupedAtts {
-				s.detectAttestationBatch(subqueueIdx, atts, currentEpoch)
-			}
+			s.attestationQueue = append(s.attestationQueue, att)
 		case err := <-sub.Err():
 			log.WithError(err).Debug("Subscriber closed with error")
 			return

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -10,6 +10,10 @@ func (s *Service) receiveAttestations(ctx context.Context) {
 		select {
 		case att := <-s.indexedAttsChan:
 			log.Infof("Got attestation with indices %v", att.AttestingIndices)
+			groupedAtts := s.groupByValidatorChunkIndex(atts)
+			for subqueueIdx, atts := range groupedAtts {
+				s.detectAttestationBatch(subqueueIdx, atts, currentEpoch)
+			}
 		case err := <-sub.Err():
 			log.WithError(err).Debug("Subscriber closed with error")
 			return

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -16,7 +16,7 @@ func (s *Service) receiveAttestations(ctx context.Context) {
 	for {
 		select {
 		case att := <-s.indexedAttsChan:
-			// TODO(Raul): Defer attestations from the future for later processing.
+			// TODO(#8331): Defer attestations from the future for later processing.
 			if !validateAttestationIntegrity(att) {
 				continue
 			}

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -25,7 +25,9 @@ func (s *Service) receiveAttestations(ctx context.Context) {
 				source:           att.Data.Source.Epoch,
 				target:           att.Data.Target.Epoch,
 			}
+			s.queueLock.Lock()
 			s.attestationQueue = append(s.attestationQueue, compactAtt)
+			s.queueLock.Unlock()
 		case err := <-sub.Err():
 			log.WithError(err).Debug("Subscriber closed with error")
 			return

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -1,7 +1,14 @@
 package slasher
 
-import "context"
+import (
+	"context"
 
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+)
+
+// Receive indexed attestations from some source event feed,
+// validating their integrity before appending them to an attestation queue
+// for batch processing in a separate routine.
 func (s *Service) receiveAttestations(ctx context.Context) {
 	sub := s.serviceCfg.IndexedAttsFeed.Subscribe(s.indexedAttsChan)
 	defer close(s.indexedAttsChan)
@@ -9,7 +16,10 @@ func (s *Service) receiveAttestations(ctx context.Context) {
 	for {
 		select {
 		case att := <-s.indexedAttsChan:
-			log.Infof("Got attestation with indices %v", att.AttestingIndices)
+			// TODO(Raul): Defer attestations from the future for later processing.
+			if !validateAttestationIntegrity(att) {
+				continue
+			}
 			s.attestationQueue = append(s.attestationQueue, att)
 		case err := <-sub.Err():
 			log.WithError(err).Debug("Subscriber closed with error")
@@ -18,4 +28,14 @@ func (s *Service) receiveAttestations(ctx context.Context) {
 			return
 		}
 	}
+}
+
+// Validates the attestation data integrity, ensuring we have no nil values for
+// source, epoch, and that the source epoch of the attestation must be less than
+// the target epoch, which is a precondition for performing slashing detection.
+func validateAttestationIntegrity(att *ethpb.IndexedAttestation) bool {
+	if att == nil || att.Data == nil || att.Data.Source == nil || att.Data.Target == nil {
+		return false
+	}
+	return att.Data.Source.Epoch < att.Data.Target.Epoch
 }

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -20,7 +20,12 @@ func (s *Service) receiveAttestations(ctx context.Context) {
 			if !validateAttestationIntegrity(att) {
 				continue
 			}
-			s.attestationQueue = append(s.attestationQueue, att)
+			compactAtt := &compactAttestation{
+				attestingIndices: att.AttestingIndices,
+				source:           att.Data.Source.Epoch,
+				target:           att.Data.Target.Epoch,
+			}
+			s.attestationQueue = append(s.attestationQueue, compactAtt)
 		case err := <-sub.Err():
 			log.WithError(err).Debug("Subscriber closed with error")
 			return

--- a/beacon-chain/slasher/receive_test.go
+++ b/beacon-chain/slasher/receive_test.go
@@ -2,17 +2,14 @@ package slasher
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
-	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
-func TestSlasher_receiveAttestations(t *testing.T) {
-	hook := logTest.NewGlobal()
+func TestSlasher_receiveAttestations_OK(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Service{
 		serviceCfg: &ServiceConfig{
@@ -27,14 +24,164 @@ func TestSlasher_receiveAttestations(t *testing.T) {
 	}()
 	firstIndices := []uint64{1, 2, 3}
 	secondIndices := []uint64{4, 5, 6}
-	s.indexedAttsChan <- &ethpb.IndexedAttestation{
+	att1 := &ethpb.IndexedAttestation{
 		AttestingIndices: firstIndices,
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{
+				Epoch: 1,
+			},
+			Target: &ethpb.Checkpoint{
+				Epoch: 2,
+			},
+		},
 	}
+	att2 := &ethpb.IndexedAttestation{
+		AttestingIndices: secondIndices,
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{
+				Epoch: 1,
+			},
+			Target: &ethpb.Checkpoint{
+				Epoch: 2,
+			},
+		},
+	}
+	s.indexedAttsChan <- att1
+	s.indexedAttsChan <- att2
+	cancel()
+	<-exitChan
+	require.DeepEqual(t, s.attestationQueue, []*ethpb.IndexedAttestation{att1, att2})
+}
+
+func TestSlasher_receiveAttestations_OnlyValidAttestations(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Service{
+		serviceCfg: &ServiceConfig{
+			IndexedAttsFeed: new(event.Feed),
+		},
+		indexedAttsChan: make(chan *ethpb.IndexedAttestation),
+	}
+	exitChan := make(chan struct{})
+	go func() {
+		s.receiveAttestations(ctx)
+		exitChan <- struct{}{}
+	}()
+	firstIndices := []uint64{1, 2, 3}
+	secondIndices := []uint64{4, 5, 6}
+	// Add a valid attestation.
+	validAtt := &ethpb.IndexedAttestation{
+		AttestingIndices: firstIndices,
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{
+				Epoch: 1,
+			},
+			Target: &ethpb.Checkpoint{
+				Epoch: 2,
+			},
+		},
+	}
+	s.indexedAttsChan <- validAtt
+	// Send an invalid, bad attestation which will not
+	// pass integrity checks at it has invalid attestation data.
 	s.indexedAttsChan <- &ethpb.IndexedAttestation{
 		AttestingIndices: secondIndices,
 	}
 	cancel()
 	<-exitChan
-	require.LogsContain(t, hook, fmt.Sprintf("Got attestation with indices %v", firstIndices))
-	require.LogsContain(t, hook, fmt.Sprintf("Got attestation with indices %v", secondIndices))
+	// Expect only a single, valid attestation was added to the queue.
+	require.Equal(t, 1, len(s.attestationQueue))
+	require.DeepEqual(t, s.attestationQueue[0], validAtt)
+}
+
+func Test_validateAttestationIntegrity(t *testing.T) {
+	tests := []struct {
+		name string
+		att  *ethpb.IndexedAttestation
+		want bool
+	}{
+		{
+			name: "Nil attestation returns false",
+			att:  nil,
+			want: false,
+		},
+		{
+			name: "Nil attestation data returns false",
+			att:  &ethpb.IndexedAttestation{},
+			want: false,
+		},
+		{
+			name: "Nil attestation source and target returns false",
+			att: &ethpb.IndexedAttestation{
+				Data: &ethpb.AttestationData{},
+			},
+			want: false,
+		},
+		{
+			name: "Nil attestation source and good target returns false",
+			att: &ethpb.IndexedAttestation{
+				Data: &ethpb.AttestationData{
+					Target: &ethpb.Checkpoint{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Nil attestation target and good source returns false",
+			att: &ethpb.IndexedAttestation{
+				Data: &ethpb.AttestationData{
+					Source: &ethpb.Checkpoint{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Source > target returns false",
+			att: &ethpb.IndexedAttestation{
+				Data: &ethpb.AttestationData{
+					Source: &ethpb.Checkpoint{
+						Epoch: 1,
+					},
+					Target: &ethpb.Checkpoint{
+						Epoch: 0,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Source == target returns false",
+			att: &ethpb.IndexedAttestation{
+				Data: &ethpb.AttestationData{
+					Source: &ethpb.Checkpoint{
+						Epoch: 1,
+					},
+					Target: &ethpb.Checkpoint{
+						Epoch: 1,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Source < target returns true",
+			att: &ethpb.IndexedAttestation{
+				Data: &ethpb.AttestationData{
+					Source: &ethpb.Checkpoint{
+						Epoch: 1,
+					},
+					Target: &ethpb.Checkpoint{
+						Epoch: 2,
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := validateAttestationIntegrity(tt.att); got != tt.want {
+				t.Errorf("validateAttestationIntegrity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/beacon-chain/slasher/receive_test.go
+++ b/beacon-chain/slasher/receive_test.go
@@ -50,7 +50,19 @@ func TestSlasher_receiveAttestations_OK(t *testing.T) {
 	s.indexedAttsChan <- att2
 	cancel()
 	<-exitChan
-	require.DeepEqual(t, s.attestationQueue, []*ethpb.IndexedAttestation{att1, att2})
+	wanted := []*compactAttestation{
+		{
+			attestingIndices: att1.AttestingIndices,
+			source:           att1.Data.Source.Epoch,
+			target:           att1.Data.Target.Epoch,
+		},
+		{
+			attestingIndices: att2.AttestingIndices,
+			source:           att2.Data.Source.Epoch,
+			target:           att2.Data.Target.Epoch,
+		},
+	}
+	require.DeepEqual(t, wanted, s.attestationQueue)
 }
 
 func TestSlasher_receiveAttestations_OnlyValidAttestations(t *testing.T) {
@@ -90,7 +102,14 @@ func TestSlasher_receiveAttestations_OnlyValidAttestations(t *testing.T) {
 	<-exitChan
 	// Expect only a single, valid attestation was added to the queue.
 	require.Equal(t, 1, len(s.attestationQueue))
-	require.DeepEqual(t, s.attestationQueue[0], validAtt)
+	wanted := []*compactAttestation{
+		{
+			attestingIndices: validAtt.AttestingIndices,
+			source:           validAtt.Data.Source.Epoch,
+			target:           validAtt.Data.Target.Epoch,
+		},
+	}
+	require.DeepEqual(t, wanted, s.attestationQueue)
 }
 
 func Test_validateAttestationIntegrity(t *testing.T) {

--- a/beacon-chain/slasher/service.go
+++ b/beacon-chain/slasher/service.go
@@ -3,6 +3,7 @@ package slasher
 
 import (
 	"context"
+	"time"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
@@ -25,6 +26,7 @@ type Service struct {
 	indexedAttsChan chan *ethpb.IndexedAttestation
 	ctx             context.Context
 	cancel          context.CancelFunc
+	genesisTime     time.Time
 }
 
 // New instantiates a new slasher from configuration values.
@@ -36,6 +38,7 @@ func New(ctx context.Context, srvCfg *ServiceConfig) (*Service, error) {
 		indexedAttsChan: make(chan *ethpb.IndexedAttestation, 1),
 		ctx:             ctx,
 		cancel:          cancel,
+		genesisTime:     time.Now(),
 	}, nil
 }
 

--- a/endtoend/endtoend_test.go
+++ b/endtoend/endtoend_test.go
@@ -97,7 +97,7 @@ func runEndToEndTest(t *testing.T, config *types.E2EConfig) {
 	// Offsetting the ticker from genesis so it ticks in the middle of an epoch, in order to keep results consistent.
 	tickingStartTime := genesisTime.Add(middleOfEpoch)
 
-	ticker := helpers.NewEpochTicker(tickingStartTime, epochSeconds)
+	ticker := slotutil.NewEpochTicker(tickingStartTime, epochSeconds)
 	for currentEpoch := range ticker.C() {
 		for _, evaluator := range config.Evaluators {
 			// Only run if the policy says so.

--- a/endtoend/helpers/BUILD.bazel
+++ b/endtoend/helpers/BUILD.bazel
@@ -3,15 +3,11 @@ load("@prysm//tools/go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     testonly = True,
-    srcs = [
-        "epochTimer.go",
-        "helpers.go",
-    ],
+    srcs = ["helpers.go"],
     importpath = "github.com/prysmaticlabs/prysm/endtoend/helpers",
     visibility = ["//endtoend:__subpackages__"],
     deps = [
         "//endtoend/params:go_default_library",
         "//endtoend/types:go_default_library",
-        "//shared/timeutils:go_default_library",
     ],
 )

--- a/shared/slotutil/BUILD.bazel
+++ b/shared/slotutil/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "countdown.go",
+        "epochticker.go",
         "slotticker.go",
         "slottime.go",
     ],
@@ -22,6 +23,7 @@ go_test(
     size = "small",
     srcs = [
         "countdown_test.go",
+        "epochticker_test.go",
         "slotticker_test.go",
         "slottime_test.go",
         "slotutil_test.go",

--- a/shared/slotutil/epochticker.go
+++ b/shared/slotutil/epochticker.go
@@ -1,4 +1,4 @@
-package helpers
+package slotutil
 
 import (
 	"time"

--- a/shared/slotutil/epochticker_test.go
+++ b/shared/slotutil/epochticker_test.go
@@ -1,0 +1,111 @@
+package slotutil
+
+import (
+	"testing"
+	"time"
+)
+
+var _ Ticker = (*EpochTicker)(nil)
+
+func TestEpochTicker(t *testing.T) {
+	ticker := &EpochTicker{
+		c:    make(chan uint64),
+		done: make(chan struct{}),
+	}
+	defer ticker.Done()
+
+	var sinceDuration time.Duration
+	since := func(time.Time) time.Duration {
+		return sinceDuration
+	}
+
+	var untilDuration time.Duration
+	until := func(time.Time) time.Duration {
+		return untilDuration
+	}
+
+	var tick chan time.Time
+	after := func(time.Duration) <-chan time.Time {
+		return tick
+	}
+
+	genesisTime := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
+	secondsPerEpoch := uint64(8)
+
+	// Test when the ticker starts immediately after genesis time.
+	sinceDuration = 1 * time.Second
+	untilDuration = 7 * time.Second
+	// Make this a buffered channel to prevent a deadlock since
+	// the other goroutine calls a function in this goroutine.
+	tick = make(chan time.Time, 2)
+	ticker.start(genesisTime, secondsPerEpoch, since, until, after)
+
+	// Tick once.
+	tick <- time.Now()
+	slot := <-ticker.C()
+	if slot != 0 {
+		t.Fatalf("Expected %d, got %d", 0, slot)
+	}
+
+	// Tick twice.
+	tick <- time.Now()
+	slot = <-ticker.C()
+	if slot != 1 {
+		t.Fatalf("Expected %d, got %d", 1, slot)
+	}
+
+	// Tick thrice.
+	tick <- time.Now()
+	slot = <-ticker.C()
+	if slot != 2 {
+		t.Fatalf("Expected %d, got %d", 2, slot)
+	}
+}
+
+func TestEpochTickerGenesis(t *testing.T) {
+	ticker := &EpochTicker{
+		c:    make(chan uint64),
+		done: make(chan struct{}),
+	}
+	defer ticker.Done()
+
+	var sinceDuration time.Duration
+	since := func(time.Time) time.Duration {
+		return sinceDuration
+	}
+
+	var untilDuration time.Duration
+	until := func(time.Time) time.Duration {
+		return untilDuration
+	}
+
+	var tick chan time.Time
+	after := func(time.Duration) <-chan time.Time {
+		return tick
+	}
+
+	genesisTime := time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)
+	secondsPerEpoch := uint64(8)
+
+	// Test when the ticker starts before genesis time.
+	sinceDuration = -1 * time.Second
+	untilDuration = 1 * time.Second
+	// Make this a buffered channel to prevent a deadlock since
+	// the other goroutine calls a function in this goroutine.
+	tick = make(chan time.Time, 2)
+	ticker.start(genesisTime, secondsPerEpoch, since, until, after)
+
+	// Tick once.
+	tick <- time.Now()
+	slot := <-ticker.C()
+	if slot != 0 {
+		t.Fatalf("Expected %d, got %d", 0, slot)
+	}
+
+	// Tick twice.
+	tick <- time.Now()
+	slot = <-ticker.C()
+	if slot != 1 {
+		t.Fatalf("Expected %d, got %d", 1, slot)
+	}
+}

--- a/shared/slotutil/epochticker_test.go
+++ b/shared/slotutil/epochticker_test.go
@@ -35,6 +35,7 @@ func TestEpochTicker(t *testing.T) {
 	// Test when the ticker starts immediately after genesis time.
 	sinceDuration = 1 * time.Second
 	untilDuration = 7 * time.Second
+
 	// Make this a buffered channel to prevent a deadlock since
 	// the other goroutine calls a function in this goroutine.
 	tick = make(chan time.Time, 2)
@@ -42,23 +43,16 @@ func TestEpochTicker(t *testing.T) {
 
 	// Tick once.
 	tick <- time.Now()
-	slot := <-ticker.C()
-	if slot != 0 {
-		t.Fatalf("Expected %d, got %d", 0, slot)
+	epoch := <-ticker.C()
+	if epoch != 1 {
+		t.Fatalf("Expected %d, got %d", 1, epoch)
 	}
 
 	// Tick twice.
 	tick <- time.Now()
-	slot = <-ticker.C()
-	if slot != 1 {
-		t.Fatalf("Expected %d, got %d", 1, slot)
-	}
-
-	// Tick thrice.
-	tick <- time.Now()
-	slot = <-ticker.C()
-	if slot != 2 {
-		t.Fatalf("Expected %d, got %d", 2, slot)
+	epoch = <-ticker.C()
+	if epoch != 2 {
+		t.Fatalf("Expected %d, got %d", 2, epoch)
 	}
 }
 
@@ -97,15 +91,15 @@ func TestEpochTickerGenesis(t *testing.T) {
 
 	// Tick once.
 	tick <- time.Now()
-	slot := <-ticker.C()
-	if slot != 0 {
-		t.Fatalf("Expected %d, got %d", 0, slot)
+	epoch := <-ticker.C()
+	if epoch != 0 {
+		t.Fatalf("Expected %d, got %d", 0, epoch)
 	}
 
 	// Tick twice.
 	tick <- time.Now()
-	slot = <-ticker.C()
-	if slot != 1 {
-		t.Fatalf("Expected %d, got %d", 1, slot)
+	epoch = <-ticker.C()
+	if epoch != 1 {
+		t.Fatalf("Expected %d, got %d", 1, epoch)
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Part of #8331, this PR adds a few helper functions and tests required before we actually implement the detection algorithm for attester slashings. Namely, it adds the logic of batching attestations by validator chunk index, processing batches per epoch using an epoch ticker, and adding comprehensive tests for this new logic. It adds a `NewEpochTicker` function to our shared/slotutil package for further use, as it is also used by e2e tests. We mark the actual `detectAttestationBatch` function as a stub.
