### PR TITLE
Add Custom Deadline for Slot Progression

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -109,9 +109,11 @@ func (s *Service) onBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock, 
 	if featureconfig.Get().EnableNextSlotStateCache {
 		go func() {
 			// Use a custom deadline here, since this method runs asynchronously.
-			ctx, cancel := context.WithTimeout(context.Background(), slotDeadline)
+			// We ignore the parent method's context and instead create a new one
+			// with a custom deadline, therefore using the background context instead.
+			slotCtx, cancel := context.WithTimeout(context.Background(), slotDeadline)
 			defer cancel()
-			if err := state.UpdateNextSlotCache(ctx, blockRoot[:], postState); err != nil {
+			if err := state.UpdateNextSlotCache(slotCtx, blockRoot[:], postState); err != nil {
 				log.WithError(err).Debug("could not update next slot state cache")
 			}
 		}()

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -17,6 +18,9 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"go.opencensus.io/trace"
 )
+
+// A custom slot deadline for processing state slots in our cache.
+const slotDeadline = 5 * time.Second
 
 // This defines size of the upper bound for initial sync block cache.
 var initialSyncBlockCacheSize = 2 * params.BeaconConfig().SlotsPerEpoch
@@ -104,6 +108,9 @@ func (s *Service) onBlock(ctx context.Context, signed *ethpb.SignedBeaconBlock, 
 	// Updating next slot state cache can happen in the background. It shouldn't block rest of the process.
 	if featureconfig.Get().EnableNextSlotStateCache {
 		go func() {
+			// Use a custom deadline here, since this method runs asynchronously.
+			ctx, cancel := context.WithTimeout(context.Background(), slotDeadline)
+			defer cancel()
 			if err := state.UpdateNextSlotCache(ctx, blockRoot[:], postState); err != nil {
 				log.WithError(err).Debug("could not update next slot state cache")
 			}

--- a/beacon-chain/core/state/trailing_slot_state_cache.go
+++ b/beacon-chain/core/state/trailing_slot_state_cache.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -15,6 +16,9 @@ type nextSlotCache struct {
 	root  []byte
 	state *state.BeaconState
 }
+
+// A custom slot deadline for processing state slots.
+const slotDeadline = 5 * time.Second
 
 var (
 	nsc nextSlotCache
@@ -48,6 +52,10 @@ func NextSlotState(ctx context.Context, root []byte) (*state.BeaconState, error)
 // by calling `ProcessSlots`, it also saves the input root for later look up.
 // This is useful to call after successfully processing a block.
 func UpdateNextSlotCache(ctx context.Context, root []byte, state *state.BeaconState) error {
+	// Use a custom deadline here, since this method runs asynchronously.
+	ctx, cancel := context.WithTimeout(context.Background(), slotDeadline)
+	defer cancel()
+
 	// Advancing one slot by using a copied state.
 	copied := state.Copy()
 	copied, err := ProcessSlots(ctx, copied, copied.Slot()+1)

--- a/beacon-chain/core/state/trailing_slot_state_cache.go
+++ b/beacon-chain/core/state/trailing_slot_state_cache.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"sync"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -16,9 +15,6 @@ type nextSlotCache struct {
 	root  []byte
 	state *state.BeaconState
 }
-
-// A custom slot deadline for processing state slots.
-const slotDeadline = 5 * time.Second
 
 var (
 	nsc nextSlotCache
@@ -52,10 +48,6 @@ func NextSlotState(ctx context.Context, root []byte) (*state.BeaconState, error)
 // by calling `ProcessSlots`, it also saves the input root for later look up.
 // This is useful to call after successfully processing a block.
 func UpdateNextSlotCache(ctx context.Context, root []byte, state *state.BeaconState) error {
-	// Use a custom deadline here, since this method runs asynchronously.
-	ctx, cancel := context.WithTimeout(context.Background(), slotDeadline)
-	defer cancel()
-
 	// Advancing one slot by using a copied state.
 	copied := state.Copy()
 	copied, err := ProcessSlots(ctx, copied, copied.Slot()+1)


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Fixes context deadlines when updating the trailing slot cache. There is a race currently in the beacon node
when updating the cache, as the context used can be canceled prematurely before the state has had a chance to 
advance. This instead uses a custom deadline so that it doesn't exit prematurely.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
