### PR TITLE
Revert "Change sszutil DeepEqual to ignore unexported fields"

### DIFF
--- a/shared/sszutil/deep_equal.go
+++ b/shared/sszutil/deep_equal.go
@@ -109,13 +109,7 @@ func deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool, depth int) boo
 		return deepValueEqual(v1.Elem(), v2.Elem(), visited, depth+1)
 	case reflect.Struct:
 		for i, n := 0, v1.NumField(); i < n; i++ {
-			v1Field := v1.Field(i)
-			v2Field := v2.Field(i)
-			if !v1Field.CanInterface() || !v2Field.CanInterface() {
-				// Continue for unexported fields, since they cannot be read anyways.
-				continue
-			}
-			if !deepValueEqual(v1Field, v2Field, visited, depth+1) {
+			if !deepValueEqual(v1.Field(i), v2.Field(i), visited, depth+1) {
 				return false
 			}
 		}

--- a/shared/sszutil/deep_equal_test.go
+++ b/shared/sszutil/deep_equal_test.go
@@ -44,19 +44,6 @@ func TestDeepEqualStructs(t *testing.T) {
 	assert.Equal(t, false, sszutil.DeepEqual(store1, store3))
 }
 
-func TestDeepEqualStructs_Unexported(t *testing.T) {
-	type Store struct {
-		V1       uint64
-		V2       []byte
-		ignoreMe string
-	}
-	store1 := Store{uint64(1234), nil, "hi there"}
-	store2 := Store{uint64(1234), []byte{}, "oh hey"}
-	store3 := Store{uint64(4321), []byte{}, "wow"}
-	assert.Equal(t, true, sszutil.DeepEqual(store1, store2))
-	assert.Equal(t, false, sszutil.DeepEqual(store1, store3))
-}
-
 func TestDeepEqualProto(t *testing.T) {
 	var fork1, fork2 pb.Fork
 	assert.Equal(t, true, sszutil.DeepEqual(fork1, fork2))

--- a/shared/sszutil/deep_equal_test.go
+++ b/shared/sszutil/deep_equal_test.go
@@ -44,6 +44,19 @@ func TestDeepEqualStructs(t *testing.T) {
 	assert.Equal(t, false, sszutil.DeepEqual(store1, store3))
 }
 
+func TestDeepEqualStructs_Unexported(t *testing.T) {
+	type Store struct {
+		V1       uint64
+		V2       []byte
+		ignoreMe string
+	}
+	store1 := Store{uint64(1234), nil, "hi there"}
+	store2 := Store{uint64(1234), []byte{}, "hi there"}
+	store3 := Store{uint64(4321), []byte{}, "wow"}
+	assert.Equal(t, true, sszutil.DeepEqual(store1, store2))
+	assert.Equal(t, false, sszutil.DeepEqual(store1, store3))
+}
+
 func TestDeepEqualProto(t *testing.T) {
 	var fork1, fork2 pb.Fork
 	assert.Equal(t, true, sszutil.DeepEqual(fork1, fork2))


### PR DESCRIPTION
Partially reverts prysmaticlabs/prysm#8336. 

The original PR changes the behavior of ssz deep equal, which does not panic on all unexported fields. 
More context is needed in the original PR before this logic change can be released.