### PR TITLE
Detection Further Helpers and Types for Attester Slashing Detection

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -10,7 +10,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prysmaticlabs/eth2-types"
 	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
+	"github.com/prysmaticlabs/prysm/beacon-chain/slasher"
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/proto/beacon/db"
@@ -100,11 +102,10 @@ type NoHeadAccessDatabase interface {
 	SaveLatestEpochAttestedForValidators(
 		ctx context.Context, validatorIndices []types.ValidatorIndex, epoch types.Epoch,
 	) error
-	SaveAttestationRecordForValidator(
+	SaveAttestationRecordsForValidators(
 		ctx context.Context,
-		validatorIdx types.ValidatorIndex,
-		signingRoot [32]byte,
-		attestation *eth.IndexedAttestation,
+		validatorIndices []types.ValidatorIndex,
+		attestations []*slasher.CompactAttestation,
 	) error
 	SaveSlasherChunks(
 		ctx context.Context, kind slashertypes.ChunkKind, chunkKeys []uint64, chunks [][]uint16,

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -10,9 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prysmaticlabs/eth2-types"
 	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
-	"github.com/prysmaticlabs/prysm/beacon-chain/slasher"
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/proto/beacon/db"
@@ -65,7 +63,7 @@ type ReadOnlyDatabase interface {
 	) (types.Epoch, bool, error)
 	AttestationRecordForValidator(
 		ctx context.Context, validatorIdx types.ValidatorIndex, targetEpoch types.Epoch,
-	) (*slashertypes.AttestationRecord, error)
+	) (*slashertypes.CompactAttestation, error)
 	LoadSlasherChunk(
 		ctx context.Context, kind slashertypes.ChunkKind, diskKey uint64,
 	) ([]uint16, bool, error)
@@ -105,7 +103,7 @@ type NoHeadAccessDatabase interface {
 	SaveAttestationRecordsForValidators(
 		ctx context.Context,
 		validatorIndices []types.ValidatorIndex,
-		attestations []*slasher.CompactAttestation,
+		attestations []*slashertypes.CompactAttestation,
 	) error
 	SaveSlasherChunks(
 		ctx context.Context, kind slashertypes.ChunkKind, chunkKeys []uint64, chunks [][]uint16,

--- a/beacon-chain/db/kv/slasher.go
+++ b/beacon-chain/db/kv/slasher.go
@@ -7,10 +7,9 @@ import (
 
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/prysmaticlabs/eth2-types"
+	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	bolt "go.etcd.io/bbolt"
 	"go.opencensus.io/trace"
-
-	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 )
 
 // LatestEpochAttestedForValidator given a validator index returns the latest

--- a/beacon-chain/db/kv/slasher_test.go
+++ b/beacon-chain/db/kv/slasher_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	types "github.com/prysmaticlabs/eth2-types"
-	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -22,14 +22,11 @@ func TestStore_AttestationRecordForValidator_SaveRetrieve(t *testing.T) {
 	require.Equal(t, true, attRecord == nil)
 
 	sr := [32]byte{1}
-	err = beaconDB.SaveAttestationRecordForValidator(ctx, valIdx, sr, &ethpb.IndexedAttestation{
-		Data: &ethpb.AttestationData{
-			Target: &ethpb.Checkpoint{
-				Epoch: target,
-			},
-			Source: &ethpb.Checkpoint{
-				Epoch: source,
-			},
+	err = beaconDB.SaveAttestationRecordsForValidators(ctx, []types.ValidatorIndex{valIdx}, []*slashertypes.CompactAttestation{
+		{
+			Target:      target,
+			Source:      source,
+			SigningRoot: sr,
 		},
 	})
 	require.NoError(t, err)

--- a/beacon-chain/db/kv/slasher_test.go
+++ b/beacon-chain/db/kv/slasher_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	types "github.com/prysmaticlabs/eth2-types"
-
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -24,7 +24,7 @@ type Chunker interface {
 		ctx context.Context,
 		slasherDB db.Database,
 		validatorIdx types.ValidatorIndex,
-		attestation *CompactAttestation,
+		attestation *slashertypes.CompactAttestation,
 	) (slashertypes.SlashingKind, error)
 	Update(
 		chunkIdx uint64,
@@ -176,7 +176,7 @@ func (m *MinSpanChunksSlice) CheckSlashable(
 	ctx context.Context,
 	slasherDB db.Database,
 	validatorIdx types.ValidatorIndex,
-	attestation *CompactAttestation,
+	attestation *slashertypes.CompactAttestation,
 ) (slashertypes.SlashingKind, error) {
 	sourceEpoch := types.Epoch(attestation.Source)
 	targetEpoch := types.Epoch(attestation.Target)
@@ -215,7 +215,7 @@ func (m *MaxSpanChunksSlice) CheckSlashable(
 	ctx context.Context,
 	slasherDB db.Database,
 	validatorIdx types.ValidatorIndex,
-	attestation *CompactAttestation,
+	attestation *slashertypes.CompactAttestation,
 ) (slashertypes.SlashingKind, error) {
 	sourceEpoch := types.Epoch(attestation.Source)
 	targetEpoch := types.Epoch(attestation.Target)

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
-
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 )
@@ -25,7 +24,7 @@ type Chunker interface {
 		ctx context.Context,
 		slasherDB db.Database,
 		validatorIdx types.ValidatorIndex,
-		attestation *compactAttestation,
+		attestation *CompactAttestation,
 	) (slashertypes.SlashingKind, error)
 	Update(
 		chunkIdx uint64,
@@ -177,10 +176,10 @@ func (m *MinSpanChunksSlice) CheckSlashable(
 	ctx context.Context,
 	slasherDB db.Database,
 	validatorIdx types.ValidatorIndex,
-	attestation *compactAttestation,
+	attestation *CompactAttestation,
 ) (slashertypes.SlashingKind, error) {
-	sourceEpoch := types.Epoch(attestation.source)
-	targetEpoch := types.Epoch(attestation.target)
+	sourceEpoch := types.Epoch(attestation.Source)
+	targetEpoch := types.Epoch(attestation.Target)
 	minTarget, err := chunkDataAtEpoch(m.params, m.data, validatorIdx, sourceEpoch)
 	if err != nil {
 		return slashertypes.NotSlashable, errors.Wrapf(
@@ -216,10 +215,10 @@ func (m *MaxSpanChunksSlice) CheckSlashable(
 	ctx context.Context,
 	slasherDB db.Database,
 	validatorIdx types.ValidatorIndex,
-	attestation *compactAttestation,
+	attestation *CompactAttestation,
 ) (slashertypes.SlashingKind, error) {
-	sourceEpoch := types.Epoch(attestation.source)
-	targetEpoch := types.Epoch(attestation.target)
+	sourceEpoch := types.Epoch(attestation.Source)
+	targetEpoch := types.Epoch(attestation.Target)
 	maxTarget, err := chunkDataAtEpoch(m.params, m.data, validatorIdx, sourceEpoch)
 	if err != nil {
 		return slashertypes.NotSlashable, errors.Wrapf(

--- a/beacon-chain/slasher/chunks_test.go
+++ b/beacon-chain/slasher/chunks_test.go
@@ -144,7 +144,7 @@ func TestMinSpanChunksSlice_CheckSlashable(t *testing.T) {
 
 	// Next up, we save the old attestation record, then check if the
 	// surrounding vote is indeed slashable.
-	attRecord := &CompactAttestation{
+	attRecord := &slashertypes.CompactAttestation{
 		Source:      att.Source,
 		Target:      att.Target,
 		SigningRoot: [32]byte{1},
@@ -152,7 +152,7 @@ func TestMinSpanChunksSlice_CheckSlashable(t *testing.T) {
 	err = beaconDB.SaveAttestationRecordsForValidators(
 		ctx,
 		[]types.ValidatorIndex{validatorIdx},
-		[]*CompactAttestation{attRecord},
+		[]*slashertypes.CompactAttestation{attRecord},
 	)
 	require.NoError(t, err)
 
@@ -226,7 +226,7 @@ func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
 
 	// Next up, we save the old attestation record, then check if the
 	// surroundedVote vote is indeed slashable.
-	attRecord := &CompactAttestation{
+	attRecord := &slashertypes.CompactAttestation{
 		Source:      att.Source,
 		Target:      att.Target,
 		SigningRoot: [32]byte{1},
@@ -234,7 +234,7 @@ func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
 	err = beaconDB.SaveAttestationRecordsForValidators(
 		ctx,
 		[]types.ValidatorIndex{validatorIdx},
-		[]*CompactAttestation{attRecord},
+		[]*slashertypes.CompactAttestation{attRecord},
 	)
 	require.NoError(t, err)
 
@@ -438,8 +438,8 @@ func Test_chunkDataAtEpoch_SetRetrieve(t *testing.T) {
 	assert.Equal(t, targetEpoch, received)
 }
 
-func createAttestation(source, target types.Epoch) *CompactAttestation {
-	return &CompactAttestation{
+func createAttestation(source, target types.Epoch) *slashertypes.CompactAttestation {
+	return &slashertypes.CompactAttestation{
 		Source: uint64(source),
 		Target: uint64(target),
 	}

--- a/beacon-chain/slasher/chunks_test.go
+++ b/beacon-chain/slasher/chunks_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	types "github.com/prysmaticlabs/eth2-types"
-	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	dbtest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
@@ -145,17 +144,16 @@ func TestMinSpanChunksSlice_CheckSlashable(t *testing.T) {
 
 	// Next up, we save the old attestation record, then check if the
 	// surrounding vote is indeed slashable.
-	indexedAtt := &ethpb.IndexedAttestation{
-		Data: &ethpb.AttestationData{
-			Source: &ethpb.Checkpoint{
-				Epoch: att.source,
-			},
-			Target: &ethpb.Checkpoint{
-				Epoch: att.target,
-			},
-		},
+	attRecord := &CompactAttestation{
+		Source:      att.Source,
+		Target:      att.Target,
+		SigningRoot: [32]byte{1},
 	}
-	err = beaconDB.SaveAttestationRecordForValidator(ctx, validatorIdx, [32]byte{1}, indexedAtt)
+	err = beaconDB.SaveAttestationRecordsForValidators(
+		ctx,
+		[]types.ValidatorIndex{validatorIdx},
+		[]*CompactAttestation{attRecord},
+	)
 	require.NoError(t, err)
 
 	kind, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundingVote)
@@ -228,17 +226,16 @@ func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
 
 	// Next up, we save the old attestation record, then check if the
 	// surroundedVote vote is indeed slashable.
-	indexedAtt := &ethpb.IndexedAttestation{
-		Data: &ethpb.AttestationData{
-			Source: &ethpb.Checkpoint{
-				Epoch: att.source,
-			},
-			Target: &ethpb.Checkpoint{
-				Epoch: att.target,
-			},
-		},
+	attRecord := &CompactAttestation{
+		Source:      att.Source,
+		Target:      att.Target,
+		SigningRoot: [32]byte{1},
 	}
-	err = beaconDB.SaveAttestationRecordForValidator(ctx, validatorIdx, [32]byte{1}, indexedAtt)
+	err = beaconDB.SaveAttestationRecordsForValidators(
+		ctx,
+		[]types.ValidatorIndex{validatorIdx},
+		[]*CompactAttestation{attRecord},
+	)
 	require.NoError(t, err)
 
 	kind, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundedVote)
@@ -441,9 +438,9 @@ func Test_chunkDataAtEpoch_SetRetrieve(t *testing.T) {
 	assert.Equal(t, targetEpoch, received)
 }
 
-func createAttestation(source, target types.Epoch) *compactAttestation {
-	return &compactAttestation{
-		source: uint64(source),
-		target: uint64(target),
+func createAttestation(source, target types.Epoch) *CompactAttestation {
+	return &CompactAttestation{
+		Source: uint64(source),
+		Target: uint64(target),
 	}
 }

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -17,7 +17,7 @@ func (s *Service) processQueuedAttestations(ctx context.Context, epochTicker <-c
 		case currentEpoch := <-epochTicker:
 			s.queueLock.Lock()
 			atts := s.attestationQueue
-			s.attestationQueue = make([]*compactAttestation, 0)
+			s.attestationQueue = make([]*CompactAttestation, 0)
 			s.queueLock.Unlock()
 			log.WithFields(logrus.Fields{
 				"currentEpoch": currentEpoch,
@@ -37,7 +37,7 @@ func (s *Service) processQueuedAttestations(ctx context.Context, epochTicker <-c
 // as the current epoch in time, we perform slashing detection over the batch.
 // TODO(#8331): Implement.
 func (s *Service) detectAttestationBatch(
-	atts []*compactAttestation, validatorChunkIndex uint64, currentEpoch types.Epoch,
+	atts []*CompactAttestation, validatorChunkIndex uint64, currentEpoch types.Epoch,
 ) {
 
 }
@@ -47,12 +47,12 @@ func (s *Service) detectAttestationBatch(
 // concurrently, and also allowing us to effectively use a single 2D chunk
 // for slashing detection through this logical grouping.
 func (s *Service) groupByValidatorChunkIndex(
-	attestations []*compactAttestation,
-) map[uint64][]*compactAttestation {
-	groupedAttestations := make(map[uint64][]*compactAttestation)
+	attestations []*CompactAttestation,
+) map[uint64][]*CompactAttestation {
+	groupedAttestations := make(map[uint64][]*CompactAttestation)
 	for _, att := range attestations {
 		validatorChunkIndices := make(map[uint64]bool)
-		for _, validatorIdx := range att.attestingIndices {
+		for _, validatorIdx := range att.AttestingIndices {
 			validatorChunkIndex := s.params.validatorChunkIndex(types.ValidatorIndex(validatorIdx))
 			validatorChunkIndices[validatorChunkIndex] = true
 		}

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	types "github.com/prysmaticlabs/eth2-types"
+	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -17,7 +18,7 @@ func (s *Service) processQueuedAttestations(ctx context.Context, epochTicker <-c
 		case currentEpoch := <-epochTicker:
 			s.queueLock.Lock()
 			atts := s.attestationQueue
-			s.attestationQueue = make([]*CompactAttestation, 0)
+			s.attestationQueue = make([]*slashertypes.CompactAttestation, 0)
 			s.queueLock.Unlock()
 			log.WithFields(logrus.Fields{
 				"currentEpoch": currentEpoch,
@@ -37,7 +38,7 @@ func (s *Service) processQueuedAttestations(ctx context.Context, epochTicker <-c
 // as the current epoch in time, we perform slashing detection over the batch.
 // TODO(#8331): Implement.
 func (s *Service) detectAttestationBatch(
-	atts []*CompactAttestation, validatorChunkIndex uint64, currentEpoch types.Epoch,
+	atts []*slashertypes.CompactAttestation, validatorChunkIndex uint64, currentEpoch types.Epoch,
 ) {
 
 }
@@ -47,9 +48,9 @@ func (s *Service) detectAttestationBatch(
 // concurrently, and also allowing us to effectively use a single 2D chunk
 // for slashing detection through this logical grouping.
 func (s *Service) groupByValidatorChunkIndex(
-	attestations []*CompactAttestation,
-) map[uint64][]*CompactAttestation {
-	groupedAttestations := make(map[uint64][]*CompactAttestation)
+	attestations []*slashertypes.CompactAttestation,
+) map[uint64][]*slashertypes.CompactAttestation {
+	groupedAttestations := make(map[uint64][]*slashertypes.CompactAttestation)
 	for _, att := range attestations {
 		validatorChunkIndices := make(map[uint64]bool)
 		for _, validatorIdx := range att.AttestingIndices {
@@ -64,4 +65,14 @@ func (s *Service) groupByValidatorChunkIndex(
 		}
 	}
 	return groupedAttestations
+}
+
+// Group attestations by the chunk index their source epoch corresponds to.
+func (s *Service) groupByChunkIndex(attestations []*slashertypes.CompactAttestation) map[uint64][]*slashertypes.CompactAttestation {
+	attestationsByChunkIndex := make(map[uint64][]*slashertypes.CompactAttestation)
+	for _, att := range attestations {
+		chunkIdx := s.params.chunkIndex(types.Epoch(att.Source))
+		attestationsByChunkIndex[chunkIdx] = append(attestationsByChunkIndex[chunkIdx], att)
+	}
+	return attestationsByChunkIndex
 }

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
@@ -13,35 +14,35 @@ func TestService_groupByValidatorChunkIndex(t *testing.T) {
 	tests := []struct {
 		name   string
 		params *Parameters
-		atts   []*CompactAttestation
-		want   map[uint64][]*CompactAttestation
+		atts   []*slashertypes.CompactAttestation
+		want   map[uint64][]*slashertypes.CompactAttestation
 	}{
 		{
 			name:   "No attestations returns empty map",
 			params: DefaultParams(),
-			atts:   make([]*CompactAttestation, 0),
-			want:   make(map[uint64][]*CompactAttestation),
+			atts:   make([]*slashertypes.CompactAttestation, 0),
+			want:   make(map[uint64][]*slashertypes.CompactAttestation),
 		},
 		{
 			name: "Groups multiple attestations belonging to single validator chunk",
 			params: &Parameters{
 				validatorChunkSize: 2,
 			},
-			atts: []*CompactAttestation{
+			atts: []*slashertypes.CompactAttestation{
 				{
-					attestingIndices: []uint64{0, 1},
+					AttestingIndices: []uint64{0, 1},
 				},
 				{
-					attestingIndices: []uint64{0, 1},
+					AttestingIndices: []uint64{0, 1},
 				},
 			},
-			want: map[uint64][]*CompactAttestation{
+			want: map[uint64][]*slashertypes.CompactAttestation{
 				0: {
 					{
-						attestingIndices: []uint64{0, 1},
+						AttestingIndices: []uint64{0, 1},
 					},
 					{
-						attestingIndices: []uint64{0, 1},
+						AttestingIndices: []uint64{0, 1},
 					},
 				},
 			},
@@ -51,25 +52,25 @@ func TestService_groupByValidatorChunkIndex(t *testing.T) {
 			params: &Parameters{
 				validatorChunkSize: 2,
 			},
-			atts: []*CompactAttestation{
+			atts: []*slashertypes.CompactAttestation{
 				{
-					attestingIndices: []uint64{0, 2, 4},
+					AttestingIndices: []uint64{0, 2, 4},
 				},
 			},
-			want: map[uint64][]*CompactAttestation{
+			want: map[uint64][]*slashertypes.CompactAttestation{
 				0: {
 					{
-						attestingIndices: []uint64{0, 2, 4},
+						AttestingIndices: []uint64{0, 2, 4},
 					},
 				},
 				1: {
 					{
-						attestingIndices: []uint64{0, 2, 4},
+						AttestingIndices: []uint64{0, 2, 4},
 					},
 				},
 				2: {
 					{
-						attestingIndices: []uint64{0, 2, 4},
+						AttestingIndices: []uint64{0, 2, 4},
 					},
 				},
 			},
@@ -87,15 +88,97 @@ func TestService_groupByValidatorChunkIndex(t *testing.T) {
 	}
 }
 
+func TestService_groupByChunkIndex(t *testing.T) {
+	tests := []struct {
+		name   string
+		params *Parameters
+		atts   []*slashertypes.CompactAttestation
+		want   map[uint64][]*slashertypes.CompactAttestation
+	}{
+		{
+			name:   "No attestations returns empty map",
+			params: DefaultParams(),
+			atts:   make([]*slashertypes.CompactAttestation, 0),
+			want:   make(map[uint64][]*slashertypes.CompactAttestation),
+		},
+		{
+			name: "Groups multiple attestations belonging to single chunk",
+			params: &Parameters{
+				chunkSize: 2,
+			},
+			atts: []*slashertypes.CompactAttestation{
+				{
+					Source: 0,
+				},
+				{
+					Source: 1,
+				},
+			},
+			want: map[uint64][]*slashertypes.CompactAttestation{
+				0: {
+					{
+						Source: 0,
+					},
+					{
+						Source: 1,
+					},
+				},
+			},
+		},
+		{
+			name: "Groups multiple attestations belonging to multiple chunks",
+			params: &Parameters{
+				chunkSize: 2,
+			},
+			atts: []*slashertypes.CompactAttestation{
+				{
+					Source: 0,
+				},
+				{
+					Source: 1,
+				},
+				{
+					Source: 2,
+				},
+			},
+			want: map[uint64][]*slashertypes.CompactAttestation{
+				0: {
+					{
+						Source: 0,
+					},
+					{
+						Source: 1,
+					},
+				},
+				1: {
+					{
+						Source: 2,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				params: tt.params,
+			}
+			if got := s.groupByChunkIndex(tt.atts); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("groupByChunkIndex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestService_processQueuedAttestations(t *testing.T) {
 	hook := logTest.NewGlobal()
 	s := &Service{
 		params: DefaultParams(),
-		attestationQueue: []*CompactAttestation{
+		attestationQueue: []*slashertypes.CompactAttestation{
 			{
-				attestingIndices: []uint64{0, 1},
-				source:           0,
-				target:           1,
+				AttestingIndices: []uint64{0, 1},
+				Source:           0,
+				Target:           1,
 			},
 		},
 	}

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -104,7 +104,8 @@ func TestService_groupByChunkIndex(t *testing.T) {
 		{
 			name: "Groups multiple attestations belonging to single chunk",
 			params: &Parameters{
-				chunkSize: 2,
+				chunkSize:     2,
+				historyLength: 3,
 			},
 			atts: []*slashertypes.CompactAttestation{
 				{
@@ -128,7 +129,8 @@ func TestService_groupByChunkIndex(t *testing.T) {
 		{
 			name: "Groups multiple attestations belonging to multiple chunks",
 			params: &Parameters{
-				chunkSize: 2,
+				chunkSize:     2,
+				historyLength: 3,
 			},
 			atts: []*slashertypes.CompactAttestation{
 				{

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -13,21 +13,21 @@ func TestService_groupByValidatorChunkIndex(t *testing.T) {
 	tests := []struct {
 		name   string
 		params *Parameters
-		atts   []*compactAttestation
-		want   map[uint64][]*compactAttestation
+		atts   []*CompactAttestation
+		want   map[uint64][]*CompactAttestation
 	}{
 		{
 			name:   "No attestations returns empty map",
 			params: DefaultParams(),
-			atts:   make([]*compactAttestation, 0),
-			want:   make(map[uint64][]*compactAttestation),
+			atts:   make([]*CompactAttestation, 0),
+			want:   make(map[uint64][]*CompactAttestation),
 		},
 		{
 			name: "Groups multiple attestations belonging to single validator chunk",
 			params: &Parameters{
 				validatorChunkSize: 2,
 			},
-			atts: []*compactAttestation{
+			atts: []*CompactAttestation{
 				{
 					attestingIndices: []uint64{0, 1},
 				},
@@ -35,7 +35,7 @@ func TestService_groupByValidatorChunkIndex(t *testing.T) {
 					attestingIndices: []uint64{0, 1},
 				},
 			},
-			want: map[uint64][]*compactAttestation{
+			want: map[uint64][]*CompactAttestation{
 				0: {
 					{
 						attestingIndices: []uint64{0, 1},
@@ -51,12 +51,12 @@ func TestService_groupByValidatorChunkIndex(t *testing.T) {
 			params: &Parameters{
 				validatorChunkSize: 2,
 			},
-			atts: []*compactAttestation{
+			atts: []*CompactAttestation{
 				{
 					attestingIndices: []uint64{0, 2, 4},
 				},
 			},
-			want: map[uint64][]*compactAttestation{
+			want: map[uint64][]*CompactAttestation{
 				0: {
 					{
 						attestingIndices: []uint64{0, 2, 4},
@@ -91,7 +91,7 @@ func TestService_processQueuedAttestations(t *testing.T) {
 	hook := logTest.NewGlobal()
 	s := &Service{
 		params: DefaultParams(),
-		attestationQueue: []*compactAttestation{
+		attestationQueue: []*CompactAttestation{
 			{
 				attestingIndices: []uint64{0, 1},
 				source:           0,

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 )
 
 // Receive indexed attestations from some source event feed,

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -20,10 +20,10 @@ func (s *Service) receiveAttestations(ctx context.Context) {
 			if !validateAttestationIntegrity(att) {
 				continue
 			}
-			compactAtt := &compactAttestation{
-				attestingIndices: att.AttestingIndices,
-				source:           att.Data.Source.Epoch,
-				target:           att.Data.Target.Epoch,
+			compactAtt := &CompactAttestation{
+				AttestingIndices: att.AttestingIndices,
+				Source:           att.Data.Source.Epoch,
+				Target:           att.Data.Target.Epoch,
 			}
 			s.queueLock.Lock()
 			s.attestationQueue = append(s.attestationQueue, compactAtt)

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -20,7 +20,7 @@ func (s *Service) receiveAttestations(ctx context.Context) {
 			if !validateAttestationIntegrity(att) {
 				continue
 			}
-			compactAtt := &CompactAttestation{
+			compactAtt := &slashertypes.CompactAttestation{
 				AttestingIndices: att.AttestingIndices,
 				Source:           att.Data.Source.Epoch,
 				Target:           att.Data.Target.Epoch,

--- a/beacon-chain/slasher/receive_test.go
+++ b/beacon-chain/slasher/receive_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
@@ -50,7 +51,7 @@ func TestSlasher_receiveAttestations_OK(t *testing.T) {
 	s.indexedAttsChan <- att2
 	cancel()
 	<-exitChan
-	wanted := []*CompactAttestation{
+	wanted := []*slashertypes.CompactAttestation{
 		{
 			AttestingIndices: att1.AttestingIndices,
 			Source:           att1.Data.Source.Epoch,
@@ -102,7 +103,7 @@ func TestSlasher_receiveAttestations_OnlyValidAttestations(t *testing.T) {
 	<-exitChan
 	// Expect only a single, valid attestation was added to the queue.
 	require.Equal(t, 1, len(s.attestationQueue))
-	wanted := []*CompactAttestation{
+	wanted := []*slashertypes.CompactAttestation{
 		{
 			AttestingIndices: validAtt.AttestingIndices,
 			Source:           validAtt.Data.Source.Epoch,

--- a/beacon-chain/slasher/receive_test.go
+++ b/beacon-chain/slasher/receive_test.go
@@ -50,16 +50,16 @@ func TestSlasher_receiveAttestations_OK(t *testing.T) {
 	s.indexedAttsChan <- att2
 	cancel()
 	<-exitChan
-	wanted := []*compactAttestation{
+	wanted := []*CompactAttestation{
 		{
-			attestingIndices: att1.AttestingIndices,
-			source:           att1.Data.Source.Epoch,
-			target:           att1.Data.Target.Epoch,
+			AttestingIndices: att1.AttestingIndices,
+			Source:           att1.Data.Source.Epoch,
+			Target:           att1.Data.Target.Epoch,
 		},
 		{
-			attestingIndices: att2.AttestingIndices,
-			source:           att2.Data.Source.Epoch,
-			target:           att2.Data.Target.Epoch,
+			AttestingIndices: att2.AttestingIndices,
+			Source:           att2.Data.Source.Epoch,
+			Target:           att2.Data.Target.Epoch,
 		},
 	}
 	require.DeepEqual(t, wanted, s.attestationQueue)
@@ -102,11 +102,11 @@ func TestSlasher_receiveAttestations_OnlyValidAttestations(t *testing.T) {
 	<-exitChan
 	// Expect only a single, valid attestation was added to the queue.
 	require.Equal(t, 1, len(s.attestationQueue))
-	wanted := []*compactAttestation{
+	wanted := []*CompactAttestation{
 		{
-			attestingIndices: validAtt.AttestingIndices,
-			source:           validAtt.Data.Source.Epoch,
-			target:           validAtt.Data.Target.Epoch,
+			AttestingIndices: validAtt.AttestingIndices,
+			Source:           validAtt.Data.Source.Epoch,
+			Target:           validAtt.Data.Target.Epoch,
 		},
 	}
 	require.DeepEqual(t, wanted, s.attestationQueue)

--- a/beacon-chain/slasher/service.go
+++ b/beacon-chain/slasher/service.go
@@ -13,12 +13,13 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
 )
 
-// A compact attestation containing only the required information
+// CompactAttestation containing only the required information
 // for attester slashing detection.
-type compactAttestation struct {
-	attestingIndices []uint64
-	source           uint64
-	target           uint64
+type CompactAttestation struct {
+	AttestingIndices []uint64
+	Source           uint64
+	Target           uint64
+	SigningRoot      [32]byte
 }
 
 // ServiceConfig for the slasher service in the beacon node.
@@ -36,7 +37,7 @@ type Service struct {
 	serviceCfg       *ServiceConfig
 	indexedAttsChan  chan *ethpb.IndexedAttestation
 	queueLock        sync.Mutex
-	attestationQueue []*compactAttestation
+	attestationQueue []*CompactAttestation
 	ctx              context.Context
 	cancel           context.CancelFunc
 	genesisTime      time.Time
@@ -49,7 +50,7 @@ func New(ctx context.Context, srvCfg *ServiceConfig) (*Service, error) {
 		params:           DefaultParams(),
 		serviceCfg:       srvCfg,
 		indexedAttsChan:  make(chan *ethpb.IndexedAttestation, 1),
-		attestationQueue: make([]*compactAttestation, 0),
+		attestationQueue: make([]*CompactAttestation, 0),
 		ctx:              ctx,
 		cancel:           cancel,
 		genesisTime:      time.Now(),

--- a/beacon-chain/slasher/service.go
+++ b/beacon-chain/slasher/service.go
@@ -8,19 +8,11 @@ import (
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
+	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
 )
-
-// CompactAttestation containing only the required information
-// for attester slashing detection.
-type CompactAttestation struct {
-	AttestingIndices []uint64
-	Source           uint64
-	Target           uint64
-	SigningRoot      [32]byte
-}
 
 // ServiceConfig for the slasher service in the beacon node.
 // This struct allows us to specify required dependencies and
@@ -37,7 +29,7 @@ type Service struct {
 	serviceCfg       *ServiceConfig
 	indexedAttsChan  chan *ethpb.IndexedAttestation
 	queueLock        sync.Mutex
-	attestationQueue []*CompactAttestation
+	attestationQueue []*slashertypes.CompactAttestation
 	ctx              context.Context
 	cancel           context.CancelFunc
 	genesisTime      time.Time
@@ -50,7 +42,7 @@ func New(ctx context.Context, srvCfg *ServiceConfig) (*Service, error) {
 		params:           DefaultParams(),
 		serviceCfg:       srvCfg,
 		indexedAttsChan:  make(chan *ethpb.IndexedAttestation, 1),
-		attestationQueue: make([]*CompactAttestation, 0),
+		attestationQueue: make([]*slashertypes.CompactAttestation, 0),
 		ctx:              ctx,
 		cancel:           cancel,
 		genesisTime:      time.Now(),

--- a/beacon-chain/slasher/types/types.go
+++ b/beacon-chain/slasher/types/types.go
@@ -9,13 +9,13 @@ const (
 	MaxSpan
 )
 
-// AttestationRecord encapsulating all the necessary
-// information we need to store in the database for slasher
-// to properly perform slashing detection.
-type AttestationRecord struct {
-	Source      uint64
-	Target      uint64
-	SigningRoot [32]byte
+// CompactAttestation containing only the required information
+// for attester slashing detection.
+type CompactAttestation struct {
+	AttestingIndices []uint64
+	Source           uint64
+	Target           uint64
+	SigningRoot      [32]byte
 }
 
 // SlashingKind is an enum representing the type of slashable


### PR DESCRIPTION
Part of #8331, this PR defines a few more useful types and slashing detection helpers, such as a CompactAttestation type used for the minimal information we need to perform slashing detection on attestations