### PR TITLE
Provide TLS certificate to gRPC gateway

### DIFF
--- a/beacon-chain/gateway/BUILD.bazel
+++ b/beacon-chain/gateway/BUILD.bazel
@@ -23,5 +23,6 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//connectivity:go_default_library",
+        "@org_golang_google_grpc//credentials:go_default_library",
     ],
 )

--- a/beacon-chain/gateway/gateway.go
+++ b/beacon-chain/gateway/gateway.go
@@ -164,7 +164,6 @@ func (g *Gateway) dial(ctx context.Context, network, addr string) (*grpc.ClientC
 // "addr" must be a valid TCP address with a port number.
 func (g *Gateway) dialTCP(ctx context.Context, addr string) (*grpc.ClientConn, error) {
 	security := grpc.WithInsecure()
-	log.WithField("remoteCert", g.remoteCert).Info("Dialing")
 	if len(g.remoteCert) > 0 {
 		creds, err := credentials.NewClientTLSFromFile(g.remoteCert, "")
 		if err != nil {

--- a/beacon-chain/gateway/gateway.go
+++ b/beacon-chain/gateway/gateway.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials"
 )
 
 var _ shared.Service = (*Gateway)(nil)
@@ -27,6 +28,7 @@ type Gateway struct {
 	cancel                  context.CancelFunc
 	gatewayAddr             string
 	remoteAddr              string
+	remoteCert              string
 	server                  *http.Server
 	mux                     *http.ServeMux
 	allowedOrigins          []string
@@ -123,6 +125,7 @@ func (g *Gateway) Stop() error {
 func New(
 	ctx context.Context,
 	remoteAddress,
+	remoteCert,
 	gatewayAddress string,
 	mux *http.ServeMux,
 	allowedOrigins []string,
@@ -135,6 +138,7 @@ func New(
 
 	return &Gateway{
 		remoteAddr:              remoteAddress,
+		remoteCert:              remoteCert,
 		gatewayAddr:             gatewayAddress,
 		ctx:                     ctx,
 		mux:                     mux,
@@ -159,8 +163,17 @@ func (g *Gateway) dial(ctx context.Context, network, addr string) (*grpc.ClientC
 // dialTCP creates a client connection via TCP.
 // "addr" must be a valid TCP address with a port number.
 func (g *Gateway) dialTCP(ctx context.Context, addr string) (*grpc.ClientConn, error) {
+	security := grpc.WithInsecure()
+	log.WithField("remoteCert", g.remoteCert).Info("Dialing")
+	if len(g.remoteCert) > 0 {
+		creds, err := credentials.NewClientTLSFromFile(g.remoteCert, "")
+		if err != nil {
+			return nil, err
+		}
+		security = grpc.WithTransportCredentials(creds)
+	}
 	opts := []grpc.DialOption{
-		grpc.WithInsecure(),
+		security,
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(int(g.maxCallRecvMsgSize))),
 	}
 

--- a/beacon-chain/gateway/server/main.go
+++ b/beacon-chain/gateway/server/main.go
@@ -39,6 +39,7 @@ func main() {
 	gw := gateway.New(
 		context.Background(),
 		*beaconRPC,
+		"", // remoteCert
 		fmt.Sprintf("%s:%d", *host, *port),
 		mux,
 		strings.Split(*allowedOrigins, ","),

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -700,10 +700,12 @@ func (b *BeaconNode) registerGRPCGateway() error {
 	gatewayAddress := fmt.Sprintf("%s:%d", gatewayHost, gatewayPort)
 	allowedOrigins := strings.Split(b.cliCtx.String(flags.GPRCGatewayCorsDomain.Name), ",")
 	enableDebugRPCEndpoints := b.cliCtx.Bool(flags.EnableDebugRPCEndpoints.Name)
+	selfCert := b.cliCtx.String(flags.CertFlag.Name)
 	return b.services.RegisterService(
 		gateway.New(
 			b.ctx,
 			selfAddress,
+			selfCert,
 			gatewayAddress,
 			nil, /*optional mux*/
 			allowedOrigins,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

gRPC gateway is effectively a gRPC client that connects to the beacon node. The gRPC gateway needs the TLS certificate if the beacon node is serving gRPC with TLS.

**Which issues(s) does this PR fix?**

Fixes #8414 

**Other notes for review**

I had to generate an SSL cert with `subjectAltName = IP:127.0.0.1` or gRPC client was complaining.

Tested by accessing `http://127.0.0.1:3500/eth/v1alpha1/node/version` and `:8080/healthz` without issue.
