### PR TITLE
Add `timeSinceSlotStart` field to "Synced new block..." log

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -76,8 +76,9 @@ func (s *Service) ReceiveBlock(ctx context.Context, block *ethpb.SignedBeaconBlo
 	reportSlotMetrics(blockCopy.Block.Slot, s.HeadSlot(), s.CurrentSlot(), s.finalizedCheckpt)
 
 	// Log block sync status.
-	logBlockSyncStatus(blockCopy.Block, blockRoot, s.finalizedCheckpt)
-
+	if err := logBlockSyncStatus(blockCopy.Block, blockRoot, s.finalizedCheckpt, uint64(s.genesisTime.Unix())); err != nil {
+		return err
+	}
 	// Log state transition data.
 	logStateTransitionData(blockCopy.Block)
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Add 

**Which issues(s) does this PR fix?**

Add `timeSinceSlotStart` field to "Synced new block..." log, this enhances debugging capability for both propagation issue and attesting issue.

**Other notes for review**

![Screen Shot 2021-02-09 at 10 00 11 AM](https://user-images.githubusercontent.com/21316537/107407590-b355b080-6abe-11eb-99ff-296e99bbb58d.png)
