### PR TITLE
Some improvements to proposer cache

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -375,7 +375,12 @@ func (s *Service) handleEpochBoundary(ctx context.Context, postState *stateTrie.
 		if err := helpers.UpdateCommitteeCache(postState, helpers.NextEpoch(postState)); err != nil {
 			return err
 		}
-		if err := helpers.UpdateProposerIndicesInCache(postState, helpers.NextEpoch(postState)); err != nil {
+		copied := postState.Copy()
+		copied, err := state.ProcessSlots(ctx, copied, copied.Slot()+1)
+		if err != nil {
+			return err
+		}
+		if err := helpers.UpdateProposerIndicesInCache(postState); err != nil {
 			return err
 		}
 	} else if postState.Slot() >= s.nextEpochBoundarySlot {
@@ -393,7 +398,7 @@ func (s *Service) handleEpochBoundary(ctx context.Context, postState *stateTrie.
 		if err := helpers.UpdateCommitteeCache(postState, helpers.CurrentEpoch(postState)); err != nil {
 			return err
 		}
-		if err := helpers.UpdateProposerIndicesInCache(postState, helpers.CurrentEpoch(postState)); err != nil {
+		if err := helpers.UpdateProposerIndicesInCache(postState); err != nil {
 			return err
 		}
 	}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -380,7 +380,7 @@ func (s *Service) handleEpochBoundary(ctx context.Context, postState *stateTrie.
 		if err != nil {
 			return err
 		}
-		if err := helpers.UpdateProposerIndicesInCache(postState); err != nil {
+		if err := helpers.UpdateProposerIndicesInCache(copied); err != nil {
 			return err
 		}
 	} else if postState.Slot() >= s.nextEpochBoundarySlot {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -324,7 +324,7 @@ func (s *Service) initializeBeaconChain(
 	if err := helpers.UpdateCommitteeCache(genesisState, 0 /* genesis epoch */); err != nil {
 		return nil, err
 	}
-	if err := helpers.UpdateProposerIndicesInCache(genesisState, 0 /* genesis epoch */); err != nil {
+	if err := helpers.UpdateProposerIndicesInCache(genesisState); err != nil {
 		return nil, err
 	}
 

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -331,15 +331,15 @@ func UpdateCommitteeCache(state *stateTrie.BeaconState, epoch types.Epoch) error
 }
 
 // UpdateProposerIndicesInCache updates proposer indices entry of the committee cache.
-func UpdateProposerIndicesInCache(state *stateTrie.BeaconState, epoch types.Epoch) error {
+func UpdateProposerIndicesInCache(state *stateTrie.BeaconState) error {
 	// The cache uses the state root at the (current epoch - 2)'s slot as key. (e.g. for epoch 2, the key is root at slot 31)
 	// Which is the reason why we skip genesis epoch.
-	if epoch <= params.BeaconConfig().GenesisEpoch+params.BeaconConfig().MinSeedLookahead {
+	if CurrentEpoch(state) <= params.BeaconConfig().GenesisEpoch+params.BeaconConfig().MinSeedLookahead {
 		return nil
 	}
 
 	// Use state root from (current_epoch - 1 - lookahead))
-	wantedEpoch := epoch - 1
+	wantedEpoch := CurrentEpoch(state) - 1
 	if wantedEpoch >= params.BeaconConfig().MinSeedLookahead {
 		wantedEpoch -= params.BeaconConfig().MinSeedLookahead
 	}
@@ -364,7 +364,7 @@ func UpdateProposerIndicesInCache(state *stateTrie.BeaconState, epoch types.Epoc
 		return nil
 	}
 
-	indices, err := ActiveValidatorIndices(state, epoch)
+	indices, err := ActiveValidatorIndices(state, CurrentEpoch(state))
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -339,7 +339,7 @@ func UpdateProposerIndicesInCache(state *stateTrie.BeaconState, epoch types.Epoc
 	}
 
 	// Use state root from (current_epoch - 1 - lookahead))
-	wantedEpoch := PrevEpoch(state)
+	wantedEpoch := epoch - 1
 	if wantedEpoch >= params.BeaconConfig().MinSeedLookahead {
 		wantedEpoch -= params.BeaconConfig().MinSeedLookahead
 	}

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -659,9 +659,3 @@ func TestPrecomputeProposerIndices_Ok(t *testing.T) {
 	}
 	assert.DeepEqual(t, wantedProposerIndices, proposerIndices, "Did not precompute proposer indices correctly")
 }
-
-func TestUpdateProposerIndicesInCache_SlotOutOfBound(t *testing.T) {
-	err := UpdateProposerIndicesInCache(&beaconstate.BeaconState{}, 2)
-	want := "out of bound"
-	require.ErrorContains(t, want, err)
-}

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -204,7 +204,7 @@ func BeaconProposerIndex(state *stateTrie.BeaconState) (uint64, error) {
 				}
 				return proposerIndices[state.Slot()%params.BeaconConfig().SlotsPerEpoch], nil
 			}
-			if err := UpdateProposerIndicesInCache(state, e); err != nil {
+			if err := UpdateProposerIndicesInCache(state); err != nil {
 				return 0, errors.Wrap(err, "could not update committee cache")
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Clean up

**What does this PR do? Why is it needed?**

Update proposer cache took two arguments:
```go
UpdateProposerIndicesInCache(state *stateTrie.BeaconState, epoch types.Epoch)
```

One argument would have been better to avoid fragmentation: 
```go
UpdateProposerIndicesInCache(state *stateTrie.BeaconState)
```

With this change:
* The `epoch` (i.e. `helpers.CurrentEpoch(state)`)  should have been derived from the state instead of allowing caller to dictate.  
* `postState` should also be advancing one slot to `UpdateProposerIndicesInCache` since it is one slot behind


**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

This was discovered in #8319. With this, e2e test in #8319 passes
