### PR TITLE
Increase Validation Queue

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -141,6 +141,7 @@ func New(ctx context.Context, cfg *Config) (*Service, error) {
 		pubsub.WithMessageIdFn(msgIDFunction),
 		pubsub.WithSubscriptionFilter(s),
 		pubsub.WithPeerOutboundQueueSize(256),
+		pubsub.WithValidateQueueSize(256),
 	}
 	// Add gossip scoring options.
 	if featureconfig.Get().EnablePeerScorer {


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Libp2p drops broadcasted messages if the validation queue is full. This can lead to perfectly valid messages being
completely dropped. While the proper behaviour would actually to not drop any outbound messages from the host at all, this will require an upstream change to patch in. For now we increase the validation queue size to deal with it and bring the size in parity with our outbound queue size.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
