### PR TITLE
Add Mutex and Block Profiling

### DIFF
--- a/beacon-chain/main.go
+++ b/beacon-chain/main.go
@@ -98,6 +98,8 @@ var appFlags = []cli.Flag{
 	debug.MemProfileRateFlag,
 	debug.CPUProfileFlag,
 	debug.TraceFlag,
+	debug.BlockProfileRateFlag,
+	debug.MutexProfileFractionFlag,
 	cmd.LogFileName,
 	cmd.EnableUPnPFlag,
 	cmd.ConfigFileFlag,

--- a/beacon-chain/usage.go
+++ b/beacon-chain/usage.go
@@ -83,6 +83,8 @@ var appHelpFlagGroups = []flagGroup{
 			debug.MemProfileRateFlag,
 			debug.CPUProfileFlag,
 			debug.TraceFlag,
+			debug.BlockProfileRateFlag,
+			debug.MutexProfileFractionFlag,
 		},
 	},
 	{

--- a/shared/debug/debug.go
+++ b/shared/debug/debug.go
@@ -68,6 +68,16 @@ var (
 		Usage: "Turn on memory profiling with the given rate",
 		Value: runtime.MemProfileRate,
 	}
+	// MutexProfileFractionFlag to specify the mutex profiling rate.
+	MutexProfileFractionFlag = &cli.IntFlag{
+		Name:  "mutexprofilefraction",
+		Usage: "Turn on mutex profiling with the given rate",
+	}
+	// BlockProfileRateFlag to specify the block profiling rate.
+	BlockProfileRateFlag = &cli.IntFlag{
+		Name:  "blockprofilerate",
+		Usage: "Turn on block profiling with the given rate",
+	}
 	// CPUProfileFlag to specify where to write the CPU profile.
 	CPUProfileFlag = &cli.StringFlag{
 		Name:  "cpuprofile",
@@ -312,6 +322,12 @@ func expandHome(p string) string {
 func Setup(ctx *cli.Context) error {
 	// profiling, tracing
 	runtime.MemProfileRate = ctx.Int(MemProfileRateFlag.Name)
+	if ctx.IsSet(BlockProfileRateFlag.Name) {
+		runtime.SetBlockProfileRate(ctx.Int(BlockProfileRateFlag.Name))
+	}
+	if ctx.IsSet(MutexProfileFractionFlag.Name) {
+		runtime.SetMutexProfileFraction(ctx.Int(MutexProfileFractionFlag.Name))
+	}
 	if traceFile := ctx.String(TraceFlag.Name); traceFile != "" {
 		if err := Handler.StartGoTrace(TraceFlag.Name); err != nil {
 			return err

--- a/validator/main.go
+++ b/validator/main.go
@@ -95,6 +95,8 @@ var appFlags = []cli.Flag{
 	debug.MemProfileRateFlag,
 	debug.CPUProfileFlag,
 	debug.TraceFlag,
+	debug.BlockProfileRateFlag,
+	debug.MutexProfileFractionFlag,
 	cmd.AcceptTosFlag,
 }
 

--- a/validator/usage.go
+++ b/validator/usage.go
@@ -76,6 +76,8 @@ var appHelpFlagGroups = []flagGroup{
 			debug.MemProfileRateFlag,
 			debug.CPUProfileFlag,
 			debug.TraceFlag,
+			debug.BlockProfileRateFlag,
+			debug.MutexProfileFractionFlag,
 		},
 	},
 	{


### PR DESCRIPTION
This PR adds the --blockprofilerate and --mutexprofilefraction flags to both beacon node and validator client