### PR TITLE
Fix error formatting inside fmt.Errorf

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -261,7 +261,7 @@ func (f *blocksFetcher) handleRequest(ctx context.Context, start, count uint64) 
 	if f.mode == modeStopOnFinalizedEpoch {
 		highestFinalizedSlot := uint64(targetEpoch+1) * params.BeaconConfig().SlotsPerEpoch
 		if start > highestFinalizedSlot {
-			response.err = fmt.Errorf("%v, slot: %d, highest finalized slot: %d",
+			response.err = fmt.Errorf("%w, slot: %d, highest finalized slot: %d",
 				errSlotIsTooHigh, start, highestFinalizedSlot)
 			return response
 		}

--- a/validator/accounts/wallet_create.go
+++ b/validator/accounts/wallet_create.go
@@ -262,7 +262,7 @@ func inputKeymanagerKind(cliCtx *cli.Context) (keymanager.Kind, error) {
 	}
 	selection, _, err := promptSelect.Run()
 	if err != nil {
-		return keymanager.Imported, fmt.Errorf("could not select wallet type: %v", prompt.FormatPromptError(err))
+		return keymanager.Imported, fmt.Errorf("could not select wallet type: %w", prompt.FormatPromptError(err))
 	}
 	return keymanager.Kind(selection), nil
 }

--- a/validator/slashing-protection/local/standard-protection-format/import.go
+++ b/validator/slashing-protection/local/standard-protection-format/import.go
@@ -9,7 +9,7 @@ import (
 	"io/ioutil"
 
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/eth2-types"
+	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/slashutil"
@@ -152,7 +152,7 @@ func validateMetadata(ctx context.Context, validatorDB db.Database, interchangeJ
 	// the imported slashing protection JSON was created on a different chain.
 	gvr, err := RootFromHex(interchangeJSON.Metadata.GenesisValidatorsRoot)
 	if err != nil {
-		return fmt.Errorf("%#x is not a valid root: %v", interchangeJSON.Metadata.GenesisValidatorsRoot, err)
+		return fmt.Errorf("%#x is not a valid root: %w", interchangeJSON.Metadata.GenesisValidatorsRoot, err)
 	}
 	dbGvr, err := validatorDB.GenesisValidatorsRoot(ctx)
 	if err != nil {
@@ -191,7 +191,7 @@ func parseBlocksForUniquePublicKeys(data []*format.ProtectionData) (map[[48]byte
 	for _, validatorData := range data {
 		pubKey, err := PubKeyFromHex(validatorData.Pubkey)
 		if err != nil {
-			return nil, fmt.Errorf("%s is not a valid public key: %v", validatorData.Pubkey, err)
+			return nil, fmt.Errorf("%s is not a valid public key: %w", validatorData.Pubkey, err)
 		}
 		for _, sBlock := range validatorData.SignedBlocks {
 			if sBlock == nil {
@@ -223,7 +223,7 @@ func parseAttestationsForUniquePublicKeys(data []*format.ProtectionData) (map[[4
 	for _, validatorData := range data {
 		pubKey, err := PubKeyFromHex(validatorData.Pubkey)
 		if err != nil {
-			return nil, fmt.Errorf("%s is not a valid public key: %v", validatorData.Pubkey, err)
+			return nil, fmt.Errorf("%s is not a valid public key: %w", validatorData.Pubkey, err)
 		}
 		for _, sAtt := range validatorData.SignedAttestations {
 			if sAtt == nil {
@@ -316,14 +316,14 @@ func transformSignedBlocks(ctx context.Context, signedBlocks []*format.SignedBlo
 	for i, proposal := range signedBlocks {
 		slot, err := Uint64FromString(proposal.Slot)
 		if err != nil {
-			return nil, fmt.Errorf("%d is not a valid slot: %v", slot, err)
+			return nil, fmt.Errorf("%d is not a valid slot: %w", slot, err)
 		}
 		var signingRoot [32]byte
 		// Signing roots are optional in the standard JSON file.
 		if proposal.SigningRoot != "" {
 			signingRoot, err = RootFromHex(proposal.SigningRoot)
 			if err != nil {
-				return nil, fmt.Errorf("%#x is not a valid root: %v", signingRoot, err)
+				return nil, fmt.Errorf("%#x is not a valid root: %w", signingRoot, err)
 			}
 		}
 		proposals[i] = kv.Proposal{
@@ -341,18 +341,18 @@ func transformSignedAttestations(pubKey [48]byte, atts []*format.SignedAttestati
 	for _, attestation := range atts {
 		target, err := EpochFromString(attestation.TargetEpoch)
 		if err != nil {
-			return nil, fmt.Errorf("%d is not a valid epoch: %v", target, err)
+			return nil, fmt.Errorf("%d is not a valid epoch: %w", target, err)
 		}
 		source, err := EpochFromString(attestation.SourceEpoch)
 		if err != nil {
-			return nil, fmt.Errorf("%d is not a valid epoch: %v", source, err)
+			return nil, fmt.Errorf("%d is not a valid epoch: %w", source, err)
 		}
 		var signingRoot [32]byte
 		// Signing roots are optional in the standard JSON file.
 		if attestation.SigningRoot != "" {
 			signingRoot, err = RootFromHex(attestation.SigningRoot)
 			if err != nil {
-				return nil, fmt.Errorf("%#x is not a valid root: %v", signingRoot, err)
+				return nil, fmt.Errorf("%#x is not a valid root: %w", signingRoot, err)
 			}
 		}
 		historicalAtts = append(historicalAtts, &kv.AttestationRecord{


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

We should use `%w` when formatting errors inside `fmt.Errorf`. This PR fixes a few occurrences.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
