### PR TITLE
Methods For StartEpoch and Slashing Helper Types for Optimized Slasher

### DIFF
--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -465,8 +465,8 @@ func (m *MinSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.E
 // If C = ChunkSize is 3 epochs per chunk, and we input start epoch of chunk 1 which is 3. The next start
 // epoch is the start epoch of chunk 2, which is epoch 6. This is computed as:
 //
-//  ((start_epoch / C)*C) - 1
-//  ((3 / 3)*3) - 1 = 3 - 1 = 2
+//  (start_epoch / C) + 1 * C
+//  (3 / 3) + 1 * 3 = 6
 //
 func (m *MaxSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch {
 	return types.Epoch(((uint64(startEpoch) / m.params.chunkSize) + 1) * m.params.chunkSize)

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -448,11 +448,11 @@ func (m *MaxSpanChunksSlice) StartEpoch(
 // If C = ChunkSize is 3 epochs per chunk, and we input start epoch of chunk 1 which is 3. The next start
 // epoch is the last epoch of chunk 0, which is epoch 2. This is computed as:
 //
-//  (start_epoch / C) * (C - 1)
-//  (3 / 3) * (3 - 1) = 1 * 2 = 2
+//  ((start_epoch / C)*C) - 1
+//  ((3 / 3)*3) - 1 = 3 - 1 = 2
 //
 func (m *MinSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch {
-	return types.Epoch((uint64(startEpoch)/m.params.chunkSize)*(m.params.chunkSize - 1))
+	return types.Epoch(((uint64(startEpoch) / m.params.chunkSize) * m.params.chunkSize) - 1)
 }
 
 // NextChunkStartEpoch given an epoch, determines the start epoch of the next chunk. For max
@@ -465,11 +465,11 @@ func (m *MinSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.E
 // If C = ChunkSize is 3 epochs per chunk, and we input start epoch of chunk 1 which is 3. The next start
 // epoch is the start epoch of chunk 2, which is epoch 6. This is computed as:
 //
-//  (start_epoch / C) + 1 * C
-//  (3 / 3) + 1 * 3 = 6
+//  ((start_epoch / C)*C) - 1
+//  ((3 / 3)*3) - 1 = 3 - 1 = 2
 //
 func (m *MaxSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch {
-	return types.Epoch(((uint64(startEpoch)/m.params.chunkSize) + 1) * m.params.chunkSize)
+	return types.Epoch(((uint64(startEpoch) / m.params.chunkSize) + 1) * m.params.chunkSize)
 }
 
 // Given a validator index and epoch, retrieves the target epoch at its specific

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -443,16 +443,23 @@ func (m *MaxSpanChunksSlice) StartEpoch(
 //
 //                       chunk0     chunk1     chunk2
 //                         |          |          |
-//  max_spans_val_i = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+//  max_spans_val_i = [[-, -, -], [-, -, -], [-, -, -]]
 //
 // If C = ChunkSize is 3 epochs per chunk, and we input start epoch of chunk 1 which is 3. The next start
 // epoch is the last epoch of chunk 0, which is epoch 2. This is computed as:
 //
-//  ((start_epoch / C)*C) - 1
-//  ((3 / 3)*3) - 1 = 3 - 1 = 2
+//  last_epoch(chunkIndex(startEpoch)-1)
+//  last_epoch(chunkIndex(3) - 1)
+//  last_epoch(1 - 1)
+//  last_epoch(0)
+//  2
 //
 func (m *MinSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch {
-	return types.Epoch(((uint64(startEpoch) / m.params.chunkSize) * m.params.chunkSize) - 1)
+	prevChunkIdx := m.params.chunkIndex(startEpoch)
+	if prevChunkIdx > 0 {
+		prevChunkIdx--
+	}
+	return m.params.lastEpoch(prevChunkIdx)
 }
 
 // NextChunkStartEpoch given an epoch, determines the start epoch of the next chunk. For max
@@ -464,12 +471,15 @@ func (m *MinSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.E
 //
 // If C = ChunkSize is 3 epochs per chunk, and we input start epoch of chunk 1 which is 3. The next start
 // epoch is the start epoch of chunk 2, which is epoch 6. This is computed as:
-//
-//  ((start_epoch / C) + 1) * C
-//  ((3 / 3) + 1) * 3 = 6
+
+//  first_epoch(chunkIndex(startEpoch)+1)
+//  first_epoch(chunkIndex(3)+1)
+//  first_epoch(1 + 1)
+//  first_epoch(2)
+//  6
 //
 func (m *MaxSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch {
-	return types.Epoch(((uint64(startEpoch) / m.params.chunkSize) + 1) * m.params.chunkSize)
+	return m.params.firstEpoch(m.params.chunkIndex(startEpoch) + 1)
 }
 
 // Given a validator index and epoch, retrieves the target epoch at its specific

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -465,8 +465,8 @@ func (m *MinSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.E
 // If C = ChunkSize is 3 epochs per chunk, and we input start epoch of chunk 1 which is 3. The next start
 // epoch is the start epoch of chunk 2, which is epoch 6. This is computed as:
 //
-//  (start_epoch / C) + 1 * C
-//  (3 / 3) + 1 * 3 = 6
+//  ((start_epoch / C) + 1) * C
+//  ((3 / 3) + 1) * 3 = 6
 //
 func (m *MaxSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch {
 	return types.Epoch(((uint64(startEpoch) / m.params.chunkSize) + 1) * m.params.chunkSize)

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -467,7 +467,7 @@ func (m *MinSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.E
 //
 //                       chunk0     chunk1     chunk2
 //                         |          |          |
-//  max_spans_val_i = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+//  max_spans_val_i = [[-, -, -], [-, -, -], [-, -, -]]
 //
 // If C = ChunkSize is 3 epochs per chunk, and we input start epoch of chunk 1 which is 3. The next start
 // epoch is the start epoch of chunk 2, which is epoch 6. This is computed as:

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -469,7 +469,7 @@ func (m *MinSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.E
 //  (3 / 3) + 1 * 3 = 6
 //
 func (m *MaxSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch {
-	return types.Epoch((uint64(startEpoch)/m.params.chunkSize + 1) * m.params.chunkSize)
+	return types.Epoch(((uint64(startEpoch)/m.params.chunkSize) + 1) * m.params.chunkSize)
 }
 
 // Given a validator index and epoch, retrieves the target epoch at its specific

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -25,14 +25,14 @@ type Chunker interface {
 		slasherDB db.Database,
 		validatorIdx types.ValidatorIndex,
 		attestation *slashertypes.CompactAttestation,
-	) (slashertypes.SlashingKind, error)
+	) (*slashertypes.Slashing, error)
 	Update(
-		chunkIdx uint64,
-		validatorIdx types.ValidatorIndex,
+		opts *chunkUpdateOptions,
 		startEpoch,
-		currentEpoch,
 		newTargetEpoch types.Epoch,
 	) (keepGoing bool, err error)
+	StartEpoch(sourceEpoch, currentEpoch types.Epoch) (epoch types.Epoch, exists bool)
+	NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch
 }
 
 // MinSpanChunksSlice represents a slice containing a chunk for K different validator's min spans.
@@ -177,27 +177,36 @@ func (m *MinSpanChunksSlice) CheckSlashable(
 	slasherDB db.Database,
 	validatorIdx types.ValidatorIndex,
 	attestation *slashertypes.CompactAttestation,
-) (slashertypes.SlashingKind, error) {
+) (*slashertypes.Slashing, error) {
 	sourceEpoch := types.Epoch(attestation.Source)
 	targetEpoch := types.Epoch(attestation.Target)
 	minTarget, err := chunkDataAtEpoch(m.params, m.data, validatorIdx, sourceEpoch)
 	if err != nil {
-		return slashertypes.NotSlashable, errors.Wrapf(
+		return &slashertypes.Slashing{Kind: slashertypes.NotSlashable}, errors.Wrapf(
 			err, "could not get min target for validator %d at epoch %d", validatorIdx, sourceEpoch,
 		)
 	}
 	if targetEpoch > minTarget {
 		existingAttRecord, err := slasherDB.AttestationRecordForValidator(ctx, validatorIdx, minTarget)
 		if err != nil {
-			return slashertypes.NotSlashable, err
+			return &slashertypes.Slashing{Kind: slashertypes.NotSlashable}, errors.Wrapf(
+				err, "could not get existing attestation record at target %d", minTarget,
+			)
 		}
 		if existingAttRecord != nil {
 			if sourceEpoch < types.Epoch(existingAttRecord.Source) {
-				return slashertypes.SurroundingVote, nil
+				return &slashertypes.Slashing{
+					Kind:            slashertypes.SurroundingVote,
+					ValidatorIndex:  validatorIdx,
+					PrevSourceEpoch: types.Epoch(existingAttRecord.Source),
+					PrevTargetEpoch: types.Epoch(existingAttRecord.Target),
+					SourceEpoch:     sourceEpoch,
+					TargetEpoch:     targetEpoch,
+				}, nil
 			}
 		}
 	}
-	return slashertypes.NotSlashable, nil
+	return &slashertypes.Slashing{Kind: slashertypes.NotSlashable}, nil
 }
 
 // CheckSlashable takes in a validator index and an incoming attestation
@@ -216,27 +225,36 @@ func (m *MaxSpanChunksSlice) CheckSlashable(
 	slasherDB db.Database,
 	validatorIdx types.ValidatorIndex,
 	attestation *slashertypes.CompactAttestation,
-) (slashertypes.SlashingKind, error) {
+) (*slashertypes.Slashing, error) {
 	sourceEpoch := types.Epoch(attestation.Source)
 	targetEpoch := types.Epoch(attestation.Target)
 	maxTarget, err := chunkDataAtEpoch(m.params, m.data, validatorIdx, sourceEpoch)
 	if err != nil {
-		return slashertypes.NotSlashable, errors.Wrapf(
+		return &slashertypes.Slashing{Kind: slashertypes.NotSlashable}, errors.Wrapf(
 			err, "could not get max target for validator %d at epoch %d", validatorIdx, sourceEpoch,
 		)
 	}
 	if targetEpoch < maxTarget {
 		existingAttRecord, err := slasherDB.AttestationRecordForValidator(ctx, validatorIdx, maxTarget)
 		if err != nil {
-			return slashertypes.NotSlashable, err
+			return &slashertypes.Slashing{Kind: slashertypes.NotSlashable}, errors.Wrapf(
+				err, "could not get existing attestation record at target %d", maxTarget,
+			)
 		}
 		if existingAttRecord != nil {
 			if types.Epoch(existingAttRecord.Source) < sourceEpoch {
-				return slashertypes.SurroundedVote, nil
+				return &slashertypes.Slashing{
+					Kind:            slashertypes.SurroundedVote,
+					ValidatorIndex:  validatorIdx,
+					PrevSourceEpoch: types.Epoch(existingAttRecord.Source),
+					PrevTargetEpoch: types.Epoch(existingAttRecord.Target),
+					SourceEpoch:     sourceEpoch,
+					TargetEpoch:     targetEpoch,
+				}, nil
 			}
 		}
 	}
-	return slashertypes.NotSlashable, nil
+	return &slashertypes.Slashing{Kind: slashertypes.NotSlashable}, nil
 }
 
 // Update a min span chunk for a validator index starting at the current epoch, e_c, then updating
@@ -295,32 +313,30 @@ func (m *MaxSpanChunksSlice) CheckSlashable(
 // to update, in our example, we stop at 2, which is still part of chunk 0, so no need
 // to jump to another min span chunks slice to perform updates.
 func (m *MinSpanChunksSlice) Update(
-	chunkIdx uint64,
-	validatorIdx types.ValidatorIndex,
+	opts *chunkUpdateOptions,
 	startEpoch,
-	currentEpoch,
 	newTargetEpoch types.Epoch,
 ) (keepGoing bool, err error) {
 	// The lowest epoch we need to update. This is a sliding window from (current epoch - H) where
 	// H is the history length a min span for a validator stores.
 	var minEpoch types.Epoch
-	if uint64(currentEpoch) > (m.params.historyLength - 1) {
-		minEpoch = currentEpoch.Sub(m.params.historyLength - 1)
+	if uint64(opts.currentEpoch) > (m.params.historyLength - 1) {
+		minEpoch = opts.currentEpoch.Sub(m.params.historyLength - 1)
 	}
 	epochInChunk := startEpoch
 	// We go down the chunk for the validator, updating every value starting at start_epoch down to min_epoch.
 	// As long as the epoch, e, in the same chunk index and e >= min_epoch, we proceed with
 	// a for loop.
-	for m.params.chunkIndex(epochInChunk) == chunkIdx && epochInChunk >= minEpoch {
+	for m.params.chunkIndex(epochInChunk) == opts.chunkIndex && epochInChunk >= minEpoch {
 		var chunkTarget types.Epoch
-		chunkTarget, err = chunkDataAtEpoch(m.params, m.data, validatorIdx, epochInChunk)
+		chunkTarget, err = chunkDataAtEpoch(m.params, m.data, opts.validatorIndex, epochInChunk)
 		if err != nil {
 			return
 		}
 		// If the newly incoming value is < the existing value, we update
 		// the data in the min span to meet with its definition.
 		if newTargetEpoch < chunkTarget {
-			if err = setChunkDataAtEpoch(m.params, m.data, validatorIdx, epochInChunk, newTargetEpoch); err != nil {
+			if err = setChunkDataAtEpoch(m.params, m.data, opts.validatorIndex, epochInChunk, newTargetEpoch); err != nil {
 				return
 			}
 		} else {
@@ -343,26 +359,24 @@ func (m *MinSpanChunksSlice) Update(
 // up to the current epoch according to the definition of max spans. If we need to continue updating
 // a next chunk, this function returns a boolean letting the caller know it should keep going.
 func (m *MaxSpanChunksSlice) Update(
-	chunkIdx uint64,
-	validatorIdx types.ValidatorIndex,
+	opts *chunkUpdateOptions,
 	startEpoch,
-	currentEpoch,
 	newTargetEpoch types.Epoch,
 ) (keepGoing bool, err error) {
 	epochInChunk := startEpoch
 	// We go down the chunk for the validator, updating every value starting at start_epoch up to.
 	// and including the current epoch as long as the epoch, e, in the same chunk index and e <= currentEpoch,
 	// we proceed with a for loop.
-	for m.params.chunkIndex(epochInChunk) == chunkIdx && epochInChunk <= currentEpoch {
+	for m.params.chunkIndex(epochInChunk) == opts.chunkIndex && epochInChunk <= opts.currentEpoch {
 		var chunkTarget types.Epoch
-		chunkTarget, err = chunkDataAtEpoch(m.params, m.data, validatorIdx, epochInChunk)
+		chunkTarget, err = chunkDataAtEpoch(m.params, m.data, opts.validatorIndex, epochInChunk)
 		if err != nil {
 			return
 		}
 		// If the newly incoming value is > the existing value, we update
 		// the data in the max span to meet with its definition.
 		if newTargetEpoch > chunkTarget {
-			if err = setChunkDataAtEpoch(m.params, m.data, validatorIdx, epochInChunk, newTargetEpoch); err != nil {
+			if err = setChunkDataAtEpoch(m.params, m.data, opts.validatorIndex, epochInChunk, newTargetEpoch); err != nil {
 				return
 			}
 		} else {
@@ -375,8 +389,80 @@ func (m *MaxSpanChunksSlice) Update(
 	}
 	// If the epoch to update now lies beyond the current chunk, then
 	// continue to the next chunk to update it.
-	keepGoing = epochInChunk <= currentEpoch
+	keepGoing = epochInChunk <= opts.currentEpoch
 	return
+}
+
+// StartEpoch given a source epoch and current epoch, determines the start epoch of
+// a min span chunk for use in chunk updates. To compute this value, we look at the difference between
+// H = HistoryLength and the current epoch. Then, we check if the source epoch > difference. If so,
+// then the start epoch is source epoch - 1.
+func (m *MinSpanChunksSlice) StartEpoch(
+	sourceEpoch, currentEpoch types.Epoch,
+) (epoch types.Epoch, exists bool) {
+	var difference uint64
+	if uint64(currentEpoch) > m.params.historyLength {
+		difference = uint64(currentEpoch) - m.params.historyLength
+	}
+	if uint64(sourceEpoch) <= difference {
+		return
+	}
+	if sourceEpoch == 0 {
+		return
+	}
+	epoch = sourceEpoch.Sub(1)
+	exists = true
+	return
+}
+
+// StartEpoch given a source epoch and current epoch, determines the start epoch of
+// a max span chunk for use in chunk updates. The source epoch cannot be >= the current epoch.
+func (m *MaxSpanChunksSlice) StartEpoch(
+	sourceEpoch, currentEpoch types.Epoch,
+) (epoch types.Epoch, exists bool) {
+	if sourceEpoch >= currentEpoch {
+		return
+	}
+	// Given max spans is a list of max targets for source epochs, the precondition is that
+	// every attestation's source epoch must be < than its target epoch. So the start epoch
+	// for updates is given as source epoch + 1.
+	epoch = sourceEpoch + 1
+	exists = true
+	return
+}
+
+// NextChunkStartEpoch given an epoch, determines the start epoch of the next chunk. For min
+// span chunks, this will be the last epoch of chunk index = (current chunk - 1). For example:
+//
+//                       chunk0     chunk1     chunk2
+//                         |          |          |
+//  max_spans_val_i = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+//
+// If C = ChunkSize is 3 epochs per chunk, and we input start epoch of chunk 1 which is 3. The next start
+// epoch is the last epoch of chunk 0, which is epoch 2. This is computed as:
+//
+//  (start_epoch / C) * (C - 1)
+//  (3 / 3) * (3 - 1) = 1 * 2 = 2
+//
+func (m *MinSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch {
+	return types.Epoch(uint64(startEpoch)/m.params.chunkSize*m.params.chunkSize - 1)
+}
+
+// NextChunkStartEpoch given an epoch, determines the start epoch of the next chunk. For max
+// span chunks, this will be the start epoch of chunk index = (current chunk + 1). For example:
+//
+//                       chunk0     chunk1     chunk2
+//                         |          |          |
+//  max_spans_val_i = [[0, 0, 0], [0, 0, 0], [0, 0, 0]]
+//
+// If C = ChunkSize is 3 epochs per chunk, and we input start epoch of chunk 1 which is 3. The next start
+// epoch is the start epoch of chunk 2, which is epoch 6. This is computed as:
+//
+//  (start_epoch / C) + 1 * C
+//  (3 / 3) + 1 * 3 = 6
+//
+func (m *MaxSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch {
+	return types.Epoch((uint64(startEpoch)/m.params.chunkSize + 1) * m.params.chunkSize)
 }
 
 // Given a validator index and epoch, retrieves the target epoch at its specific

--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -452,7 +452,7 @@ func (m *MaxSpanChunksSlice) StartEpoch(
 //  (3 / 3) * (3 - 1) = 1 * 2 = 2
 //
 func (m *MinSpanChunksSlice) NextChunkStartEpoch(startEpoch types.Epoch) types.Epoch {
-	return types.Epoch(uint64(startEpoch)/m.params.chunkSize*m.params.chunkSize - 1)
+	return types.Epoch((uint64(startEpoch)/m.params.chunkSize)*(m.params.chunkSize - 1))
 }
 
 // NextChunkStartEpoch given an epoch, determines the start epoch of the next chunk. For max

--- a/beacon-chain/slasher/chunks_test.go
+++ b/beacon-chain/slasher/chunks_test.go
@@ -442,6 +442,76 @@ func TestMaxSpanChunksSlice_Update_SingleChunk(t *testing.T) {
 	require.DeepEqual(t, want, chunk.Chunk())
 }
 
+func TestMinSpanChunksSlice_StartEpoch(t *testing.T) {
+	type fields struct {
+		params *Parameters
+		data   []uint16
+	}
+	type args struct {
+		sourceEpoch  types.Epoch
+		currentEpoch types.Epoch
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantEpoch  types.Epoch
+		wantExists bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MinSpanChunksSlice{
+				params: tt.fields.params,
+				data:   tt.fields.data,
+			}
+			gotEpoch, gotExists := m.StartEpoch(tt.args.sourceEpoch, tt.args.currentEpoch)
+			if gotEpoch != tt.wantEpoch {
+				t.Errorf("StartEpoch() gotEpoch = %v, want %v", gotEpoch, tt.wantEpoch)
+			}
+			if gotExists != tt.wantExists {
+				t.Errorf("StartEpoch() gotExists = %v, want %v", gotExists, tt.wantExists)
+			}
+		})
+	}
+}
+
+func TestMaxSpanChunksSlice_StartEpoch(t *testing.T) {
+	type fields struct {
+		params *Parameters
+		data   []uint16
+	}
+	type args struct {
+		sourceEpoch  types.Epoch
+		currentEpoch types.Epoch
+	}
+	tests := []struct {
+		name       string
+		fields     fields
+		args       args
+		wantEpoch  types.Epoch
+		wantExists bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MaxSpanChunksSlice{
+				params: tt.fields.params,
+				data:   tt.fields.data,
+			}
+			gotEpoch, gotExists := m.StartEpoch(tt.args.sourceEpoch, tt.args.currentEpoch)
+			if gotEpoch != tt.wantEpoch {
+				t.Errorf("StartEpoch() gotEpoch = %v, want %v", gotEpoch, tt.wantEpoch)
+			}
+			if gotExists != tt.wantExists {
+				t.Errorf("StartEpoch() gotExists = %v, want %v", gotExists, tt.wantExists)
+			}
+		})
+	}
+}
+
 func TestMinSpanChunksSlice_NextChunkStartEpoch(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/beacon-chain/slasher/chunks_test.go
+++ b/beacon-chain/slasher/chunks_test.go
@@ -366,6 +366,7 @@ func TestMaxSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 		validatorIndex: validatorIdx,
 	}
 	keepGoing, err = chunk.Update(opts, startEpoch, target)
+	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want = []uint16{1, 0, 0, 0, 0, 0}
 	require.DeepEqual(t, want, chunk.Chunk())

--- a/beacon-chain/slasher/chunks_test.go
+++ b/beacon-chain/slasher/chunks_test.go
@@ -112,13 +112,13 @@ func TestMinSpanChunksSlice_CheckSlashable(t *testing.T) {
 
 	// An attestation with source 1 and target 2 should not be slashable
 	// based on our min chunk for either validator.
-	kind, err := chunk.CheckSlashable(ctx, beaconDB, validatorIdx, att)
+	slashing, err := chunk.CheckSlashable(ctx, beaconDB, validatorIdx, att)
 	require.NoError(t, err)
-	require.Equal(t, slashertypes.NotSlashable, kind)
+	require.Equal(t, slashertypes.NotSlashable, slashing.Kind)
 
-	kind, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx.Sub(1), att)
+	slashing, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx.Sub(1), att)
 	require.NoError(t, err)
-	require.Equal(t, slashertypes.NotSlashable, kind)
+	require.Equal(t, slashertypes.NotSlashable, slashing.Kind)
 
 	// Next up we initialize an empty chunks slice and mark an attestation
 	// with (source 1, target 2) as attested.
@@ -129,7 +129,12 @@ func TestMinSpanChunksSlice_CheckSlashable(t *testing.T) {
 	chunkIdx := uint64(0)
 	startEpoch := target
 	currentEpoch := target
-	_, err = chunk.Update(chunkIdx, validatorIdx, startEpoch, currentEpoch, target)
+	opts := &chunkUpdateOptions{
+		chunkIndex:     chunkIdx,
+		currentEpoch:   currentEpoch,
+		validatorIndex: validatorIdx,
+	}
+	_, err = chunk.Update(opts, startEpoch, target)
 	require.NoError(t, err)
 
 	// Next up, we create a surrounding vote, but it should NOT be slashable
@@ -138,9 +143,9 @@ func TestMinSpanChunksSlice_CheckSlashable(t *testing.T) {
 	target = types.Epoch(3)
 	surroundingVote := createAttestation(source, target)
 
-	kind, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundingVote)
+	slashing, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundingVote)
 	require.NoError(t, err)
-	require.Equal(t, slashertypes.NotSlashable, kind)
+	require.Equal(t, slashertypes.NotSlashable, slashing.Kind)
 
 	// Next up, we save the old attestation record, then check if the
 	// surrounding vote is indeed slashable.
@@ -156,9 +161,9 @@ func TestMinSpanChunksSlice_CheckSlashable(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	kind, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundingVote)
+	slashing, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundingVote)
 	require.NoError(t, err)
-	require.Equal(t, slashertypes.SurroundingVote, kind)
+	require.Equal(t, slashertypes.SurroundingVote, slashing.Kind)
 }
 
 func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
@@ -194,13 +199,13 @@ func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
 
 	// An attestation with source 1 and target 2 should not be slashable
 	// based on our max chunk for either validator.
-	kind, err := chunk.CheckSlashable(ctx, beaconDB, validatorIdx, att)
+	slashing, err := chunk.CheckSlashable(ctx, beaconDB, validatorIdx, att)
 	require.NoError(t, err)
-	require.Equal(t, slashertypes.NotSlashable, kind)
+	require.Equal(t, slashertypes.NotSlashable, slashing.Kind)
 
-	kind, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx.Sub(1), att)
+	slashing, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx.Sub(1), att)
 	require.NoError(t, err)
-	require.Equal(t, slashertypes.NotSlashable, kind)
+	require.Equal(t, slashertypes.NotSlashable, slashing.Kind)
 
 	// Next up we initialize an empty chunks slice and mark an attestation
 	// with (source 0, target 3) as attested.
@@ -211,7 +216,12 @@ func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
 	chunkIdx := uint64(0)
 	startEpoch := source
 	currentEpoch := target
-	_, err = chunk.Update(chunkIdx, validatorIdx, startEpoch, currentEpoch, target)
+	opts := &chunkUpdateOptions{
+		chunkIndex:     chunkIdx,
+		currentEpoch:   currentEpoch,
+		validatorIndex: validatorIdx,
+	}
+	_, err = chunk.Update(opts, startEpoch, target)
 	require.NoError(t, err)
 
 	// Next up, we create a surrounded vote, but it should NOT be slashable
@@ -220,9 +230,9 @@ func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
 	target = types.Epoch(2)
 	surroundedVote := createAttestation(source, target)
 
-	kind, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundedVote)
+	slashing, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundedVote)
 	require.NoError(t, err)
-	require.Equal(t, slashertypes.NotSlashable, kind)
+	require.Equal(t, slashertypes.NotSlashable, slashing.Kind)
 
 	// Next up, we save the old attestation record, then check if the
 	// surroundedVote vote is indeed slashable.
@@ -238,9 +248,9 @@ func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	kind, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundedVote)
+	slashing, err = chunk.CheckSlashable(ctx, beaconDB, validatorIdx, surroundedVote)
 	require.NoError(t, err)
-	require.Equal(t, slashertypes.SurroundedVote, kind)
+	require.Equal(t, slashertypes.SurroundedVote, slashing.Kind)
 }
 
 func TestMinSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
@@ -288,7 +298,12 @@ func TestMinSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 	validatorIdx := types.ValidatorIndex(0)
 	startEpoch := target
 	currentEpoch := target
-	keepGoing, err := chunk.Update(chunkIdx, validatorIdx, startEpoch, currentEpoch, target)
+	opts := &chunkUpdateOptions{
+		chunkIndex:     chunkIdx,
+		currentEpoch:   currentEpoch,
+		validatorIndex: validatorIdx,
+	}
+	keepGoing, err := chunk.Update(opts, startEpoch, target)
 	require.NoError(t, err)
 
 	// We should keep going! We still have to update the data for chunk index 0.
@@ -302,7 +317,12 @@ func TestMinSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 	validatorIdx = types.ValidatorIndex(0)
 	startEpoch = types.Epoch(1)
 	currentEpoch = target
-	keepGoing, err = chunk.Update(chunkIdx, validatorIdx, startEpoch, currentEpoch, target)
+	opts = &chunkUpdateOptions{
+		chunkIndex:     chunkIdx,
+		currentEpoch:   currentEpoch,
+		validatorIndex: validatorIdx,
+	}
+	keepGoing, err = chunk.Update(opts, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want = []uint16{3, 2, math.MaxUint16, math.MaxUint16, math.MaxUint16, math.MaxUint16}
@@ -321,7 +341,12 @@ func TestMaxSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 	validatorIdx := types.ValidatorIndex(0)
 	startEpoch := types.Epoch(0)
 	currentEpoch := target
-	keepGoing, err := chunk.Update(chunkIdx, validatorIdx, startEpoch, currentEpoch, target)
+	opts := &chunkUpdateOptions{
+		chunkIndex:     chunkIdx,
+		currentEpoch:   currentEpoch,
+		validatorIndex: validatorIdx,
+	}
+	keepGoing, err := chunk.Update(opts, startEpoch, target)
 	require.NoError(t, err)
 
 	// We should keep going! We still have to update the data for chunk index 1.
@@ -335,8 +360,12 @@ func TestMaxSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 	validatorIdx = types.ValidatorIndex(0)
 	startEpoch = types.Epoch(2)
 	currentEpoch = target
-	keepGoing, err = chunk.Update(chunkIdx, validatorIdx, startEpoch, currentEpoch, target)
-	require.NoError(t, err)
+	opts = &chunkUpdateOptions{
+		chunkIndex:     chunkIdx,
+		currentEpoch:   currentEpoch,
+		validatorIndex: validatorIdx,
+	}
+	keepGoing, err = chunk.Update(opts, startEpoch, target)
 	require.Equal(t, false, keepGoing)
 	want = []uint16{1, 0, 0, 0, 0, 0}
 	require.DeepEqual(t, want, chunk.Chunk())
@@ -377,7 +406,12 @@ func TestMinSpanChunksSlice_Update_SingleChunk(t *testing.T) {
 	validatorIdx := types.ValidatorIndex(0)
 	startEpoch := target
 	currentEpoch := target
-	keepGoing, err := chunk.Update(chunkIdx, validatorIdx, startEpoch, currentEpoch, target)
+	opts := &chunkUpdateOptions{
+		chunkIndex:     chunkIdx,
+		currentEpoch:   currentEpoch,
+		validatorIndex: validatorIdx,
+	}
+	keepGoing, err := chunk.Update(opts, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want := []uint16{1, 0, math.MaxUint16, math.MaxUint16, math.MaxUint16, math.MaxUint16}
@@ -396,11 +430,88 @@ func TestMaxSpanChunksSlice_Update_SingleChunk(t *testing.T) {
 	validatorIdx := types.ValidatorIndex(0)
 	startEpoch := types.Epoch(0)
 	currentEpoch := target
-	keepGoing, err := chunk.Update(chunkIdx, validatorIdx, startEpoch, currentEpoch, target)
+	opts := &chunkUpdateOptions{
+		chunkIndex:     chunkIdx,
+		currentEpoch:   currentEpoch,
+		validatorIndex: validatorIdx,
+	}
+	keepGoing, err := chunk.Update(opts, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want := []uint16{3, 2, 1, 0, 0, 0, 0, 0}
 	require.DeepEqual(t, want, chunk.Chunk())
+}
+
+func TestMinSpanChunksSlice_NextChunkStartEpoch(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     *Parameters
+		startEpoch types.Epoch
+		want       types.Epoch
+	}{
+		{
+			name: "Start epoch 0",
+			params: &Parameters{
+				chunkSize: 3,
+			},
+			startEpoch: 0,
+			want:       math.MaxUint64,
+		},
+		{
+			name: "Start epoch of chunk 1 returns last epoch of chunk 0",
+			params: &Parameters{
+				chunkSize: 3,
+			},
+			startEpoch: 3,
+			want:       2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MinSpanChunksSlice{
+				params: tt.params,
+			}
+			if got := m.NextChunkStartEpoch(tt.startEpoch); got != tt.want {
+				t.Errorf("NextChunkStartEpoch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaxSpanChunksSlice_NextChunkStartEpoch(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     *Parameters
+		startEpoch types.Epoch
+		want       types.Epoch
+	}{
+		{
+			name: "Start epoch 0",
+			params: &Parameters{
+				chunkSize: 3,
+			},
+			startEpoch: 0,
+			want:       3,
+		},
+		{
+			name: "Start epoch of chunk 1 returns start epoch of chunk 2",
+			params: &Parameters{
+				chunkSize: 3,
+			},
+			startEpoch: 3,
+			want:       6,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MaxSpanChunksSlice{
+				params: tt.params,
+			}
+			if got := m.NextChunkStartEpoch(tt.startEpoch); got != tt.want {
+				t.Errorf("NextChunkStartEpoch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func Test_chunkDataAtEpoch_SetRetrieve(t *testing.T) {

--- a/beacon-chain/slasher/chunks_test.go
+++ b/beacon-chain/slasher/chunks_test.go
@@ -579,18 +579,29 @@ func TestMinSpanChunksSlice_NextChunkStartEpoch(t *testing.T) {
 		{
 			name: "Start epoch 0",
 			params: &Parameters{
-				chunkSize: 3,
+				chunkSize:     3,
+				historyLength: 4096,
 			},
 			startEpoch: 0,
-			want:       math.MaxUint64,
+			want:       2,
 		},
 		{
 			name: "Start epoch of chunk 1 returns last epoch of chunk 0",
 			params: &Parameters{
-				chunkSize: 3,
+				chunkSize:     3,
+				historyLength: 4096,
 			},
 			startEpoch: 3,
 			want:       2,
+		},
+		{
+			name: "Start epoch inside of chunk 2 returns last epoch of chunk 1",
+			params: &Parameters{
+				chunkSize:     3,
+				historyLength: 4096,
+			},
+			startEpoch: 8,
+			want:       5,
 		},
 	}
 	for _, tt := range tests {
@@ -615,7 +626,8 @@ func TestMaxSpanChunksSlice_NextChunkStartEpoch(t *testing.T) {
 		{
 			name: "Start epoch 0",
 			params: &Parameters{
-				chunkSize: 3,
+				chunkSize:     3,
+				historyLength: 4,
 			},
 			startEpoch: 0,
 			want:       3,
@@ -623,7 +635,8 @@ func TestMaxSpanChunksSlice_NextChunkStartEpoch(t *testing.T) {
 		{
 			name: "Start epoch of chunk 1 returns start epoch of chunk 2",
 			params: &Parameters{
-				chunkSize: 3,
+				chunkSize:     3,
+				historyLength: 4,
 			},
 			startEpoch: 3,
 			want:       6,

--- a/beacon-chain/slasher/chunks_test.go
+++ b/beacon-chain/slasher/chunks_test.go
@@ -443,70 +443,126 @@ func TestMaxSpanChunksSlice_Update_SingleChunk(t *testing.T) {
 }
 
 func TestMinSpanChunksSlice_StartEpoch(t *testing.T) {
-	type fields struct {
-		params *Parameters
-		data   []uint16
-	}
 	type args struct {
 		sourceEpoch  types.Epoch
 		currentEpoch types.Epoch
 	}
 	tests := []struct {
-		name       string
-		fields     fields
-		args       args
-		wantEpoch  types.Epoch
-		wantExists bool
+		name           string
+		params         *Parameters
+		args           args
+		wantEpoch      types.Epoch
+		shouldNotExist bool
 	}{
-		// TODO: Add test cases.
+		{
+			name:   "source_epoch == 0 returns false",
+			params: DefaultParams(),
+			args: args{
+				sourceEpoch: 0,
+			},
+			shouldNotExist: true,
+		},
+		{
+			name: "source_epoch == (current_epoch - HISTORY_LENGTH) returns false",
+			params: &Parameters{
+				historyLength: 3,
+			},
+			args: args{
+				sourceEpoch:  1,
+				currentEpoch: 4,
+			},
+			shouldNotExist: true,
+		},
+		{
+			name: "source_epoch < (current_epoch - HISTORY_LENGTH) returns false",
+			params: &Parameters{
+				historyLength: 3,
+			},
+			args: args{
+				sourceEpoch:  1,
+				currentEpoch: 5,
+			},
+			shouldNotExist: true,
+		},
+		{
+			name: "source_epoch > (current_epoch - HISTORY_LENGTH) returns true",
+			params: &Parameters{
+				historyLength: 3,
+			},
+			args: args{
+				sourceEpoch:  1,
+				currentEpoch: 3,
+			},
+			wantEpoch: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &MinSpanChunksSlice{
-				params: tt.fields.params,
-				data:   tt.fields.data,
+				params: tt.params,
 			}
 			gotEpoch, gotExists := m.StartEpoch(tt.args.sourceEpoch, tt.args.currentEpoch)
-			if gotEpoch != tt.wantEpoch {
-				t.Errorf("StartEpoch() gotEpoch = %v, want %v", gotEpoch, tt.wantEpoch)
+			if tt.shouldNotExist && gotExists {
+				t.Errorf("StartEpoch() gotExists false")
 			}
-			if gotExists != tt.wantExists {
-				t.Errorf("StartEpoch() gotExists = %v, want %v", gotExists, tt.wantExists)
+			if !tt.shouldNotExist && gotEpoch != tt.wantEpoch {
+				t.Errorf("StartEpoch() gotEpoch = %v, want %v", gotEpoch, tt.wantEpoch)
 			}
 		})
 	}
 }
 
 func TestMaxSpanChunksSlice_StartEpoch(t *testing.T) {
-	type fields struct {
-		params *Parameters
-		data   []uint16
-	}
 	type args struct {
 		sourceEpoch  types.Epoch
 		currentEpoch types.Epoch
 	}
 	tests := []struct {
-		name       string
-		fields     fields
-		args       args
-		wantEpoch  types.Epoch
-		wantExists bool
+		name           string
+		params         *Parameters
+		args           args
+		wantEpoch      types.Epoch
+		shouldNotExist bool
 	}{
-		// TODO: Add test cases.
+		{
+			name:   "source_epoch == current_epoch returns false",
+			params: DefaultParams(),
+			args: args{
+				sourceEpoch:  1,
+				currentEpoch: 1,
+			},
+			shouldNotExist: true,
+		},
+		{
+			name:   "source_epoch > current_epoch returns false",
+			params: DefaultParams(),
+			args: args{
+				sourceEpoch:  2,
+				currentEpoch: 1,
+			},
+			shouldNotExist: true,
+		},
+		{
+			name:   "source_epoch < current_epoch returns true",
+			params: DefaultParams(),
+			args: args{
+				sourceEpoch:  1,
+				currentEpoch: 2,
+			},
+			wantEpoch: 2,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &MaxSpanChunksSlice{
-				params: tt.fields.params,
-				data:   tt.fields.data,
+				params: tt.params,
 			}
 			gotEpoch, gotExists := m.StartEpoch(tt.args.sourceEpoch, tt.args.currentEpoch)
-			if gotEpoch != tt.wantEpoch {
-				t.Errorf("StartEpoch() gotEpoch = %v, want %v", gotEpoch, tt.wantEpoch)
+			if tt.shouldNotExist && gotExists {
+				t.Errorf("StartEpoch() gotExists false")
 			}
-			if gotExists != tt.wantExists {
-				t.Errorf("StartEpoch() gotExists = %v, want %v", gotExists, tt.wantExists)
+			if !tt.shouldNotExist && gotEpoch != tt.wantEpoch {
+				t.Errorf("StartEpoch() gotEpoch = %v, want %v", gotEpoch, tt.wantEpoch)
 			}
 		})
 	}

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -12,6 +12,7 @@ import (
 // loading, saving, and updating min/max span chunks.
 type chunkUpdateOptions struct {
 	kind                slashertypes.ChunkKind
+	chunkIndex          uint64
 	validatorChunkIndex uint64
 	currentEpoch        types.Epoch
 	latestEpochWritten  types.Epoch

--- a/beacon-chain/slasher/params.go
+++ b/beacon-chain/slasher/params.go
@@ -104,7 +104,7 @@ func (p *Parameters) lastEpoch(chunkIndex uint64) types.Epoch {
 //     val0     val1     val2
 //      |        |        |
 //   {     }  {     }  {     }
-//  [-, -, -, -, -, 2, 2, 2, 2]
+//  [-, -, -, -, -, -, -, -, -]
 //                        |-> epoch 1 for val2
 //
 func (p *Parameters) cellIndex(validatorIndex types.ValidatorIndex, epoch types.Epoch) uint64 {

--- a/beacon-chain/slasher/params.go
+++ b/beacon-chain/slasher/params.go
@@ -81,7 +81,7 @@ func (p *Parameters) firstEpoch(chunkIndex uint64) types.Epoch {
 //                     -> last epoch of chunk 1 equals 5
 //
 func (p *Parameters) lastEpoch(chunkIndex uint64) types.Epoch {
-	return types.Epoch(chunkIndex * p.chunkSize).Add(p.chunkSize - 1)
+	return p.firstEpoch(chunkIndex).Add(p.chunkSize - 1)
 }
 
 // Given a validator index, and epoch, we compute the exact index

--- a/beacon-chain/slasher/params.go
+++ b/beacon-chain/slasher/params.go
@@ -41,9 +41,10 @@ func DefaultParams() *Parameters {
 // if we are keeping 6 epochs worth of data, and we have chunks of size 2, then epoch
 // 4 will fall into chunk index (4 % 6) / 2 = 2.
 //
-//  span    = [2, 2, 2, 2, 2, 2]
-//  chunked = [[2, 2], [2, 2], [2, 2]]
+//  span    = [-, -, -, -, -, -]
+//  chunked = [[-, -], [-, -], [-, -]]
 //                              |-> epoch 4, chunk idx 2
+//
 func (p *Parameters) chunkIndex(epoch types.Epoch) uint64 {
 	return uint64(epoch.Mod(p.historyLength).Div(p.chunkSize))
 }
@@ -55,6 +56,34 @@ func (p *Parameters) validatorChunkIndex(validatorIndex types.ValidatorIndex) ui
 	return uint64(validatorIndex.Div(p.validatorChunkSize))
 }
 
+// Returns the epoch at the 0th index of a chunk at the specified chunk index.
+// For example, if we have chunks of length 3 and we ask to give us the
+// first epoch of chunk1, then:
+//
+//    chunk0      chunk1     chunk2
+//       |          |          |
+//  [[-, -, -], [-, -, -], [-, -, -], ...]
+//               |
+//               -> first epoch of chunk 1 equals 3
+//
+func (p *Parameters) firstEpoch(chunkIndex uint64) types.Epoch {
+	return types.Epoch(chunkIndex * p.chunkSize)
+}
+
+// Returns the epoch at the last index of a chunk at the specified chunk index.
+// For example, if we have chunks of length 3 and we ask to give us the
+// last epoch of chunk1, then:
+//
+//    chunk0      chunk1     chunk2
+//       |          |          |
+//  [[-, -, -], [-, -, -], [-, -, -], ...]
+//                     |
+//                     -> last epoch of chunk 1 equals 5
+//
+func (p *Parameters) lastEpoch(chunkIndex uint64) types.Epoch {
+	return types.Epoch(chunkIndex * p.chunkSize).Add(p.chunkSize - 1)
+}
+
 // Given a validator index, and epoch, we compute the exact index
 // into our flat slice on disk which stores K validators' chunks, each
 // chunk of size C. For example, if C = 3 and K = 3, the data we store
@@ -63,7 +92,7 @@ func (p *Parameters) validatorChunkIndex(validatorIndex types.ValidatorIndex) ui
 //     val0     val1     val2
 //      |        |        |
 //   {     }  {     }  {     }
-//  [2, 2, 2, 2, 2, 2, 2, 2, 2]
+//  [-, -, -, -, -, -, -, -, -]
 //
 // Then, figuring out the exact cell index for epoch 1 for validator 2 is computed
 // with (validatorIndex % K)*C + (epoch % C), which gives us:
@@ -75,7 +104,7 @@ func (p *Parameters) validatorChunkIndex(validatorIndex types.ValidatorIndex) ui
 //     val0     val1     val2
 //      |        |        |
 //   {     }  {     }  {     }
-//  [2, 2, 2, 2, 2, 2, 2, 2, 2]
+//  [-, -, -, -, -, 2, 2, 2, 2]
 //                        |-> epoch 1 for val2
 //
 func (p *Parameters) cellIndex(validatorIndex types.ValidatorIndex, epoch types.Epoch) uint64 {

--- a/beacon-chain/slasher/params_test.go
+++ b/beacon-chain/slasher/params_test.go
@@ -471,3 +471,67 @@ func TestParams_validatorIndicesInChunk(t *testing.T) {
 		})
 	}
 }
+
+func TestParameters_firstEpoch(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     *Parameters
+		chunkIndex uint64
+		want       types.Epoch
+	}{
+		{
+			name:       "first epoch of chunk 0 is 0",
+			params:     DefaultParams(),
+			chunkIndex: 0,
+			want:       0,
+		},
+		{
+			name: "with chunk_size = 3, first epoch of chunk 1 is 3",
+			params: &Parameters{
+				chunkSize: 3,
+			},
+			chunkIndex: 1,
+			want:       3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.params.firstEpoch(tt.chunkIndex); got != tt.want {
+				t.Errorf("firstEpoch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParameters_lastEpoch(t *testing.T) {
+	tests := []struct {
+		name       string
+		params     *Parameters
+		chunkIndex uint64
+		want       types.Epoch
+	}{
+		{
+			name: "with chunk_size = 3, last epoch of chunk 0 is 2",
+			params: &Parameters{
+				chunkSize: 3,
+			},
+			chunkIndex: 0,
+			want:       2,
+		},
+		{
+			name: "with chunk_size = 3, last epoch of chunk 1 is 5",
+			params: &Parameters{
+				chunkSize: 3,
+			},
+			chunkIndex: 1,
+			want:       5,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.params.lastEpoch(tt.chunkIndex); got != tt.want {
+				t.Errorf("lastEpoch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/beacon-chain/slasher/types/BUILD.bazel
+++ b/beacon-chain/slasher/types/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["types.go"],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types",
     visibility = ["//beacon-chain:__subpackages__"],
+    deps = ["@com_github_prysmaticlabs_eth2_types//:go_default_library"],
 )

--- a/beacon-chain/slasher/types/types.go
+++ b/beacon-chain/slasher/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+import types "github.com/prysmaticlabs/eth2-types"
+
 // ChunkKind to differentiate what kind of span we are working
 // with for slashing detection, either min or max span.
 type ChunkKind uint
@@ -16,6 +18,19 @@ type CompactAttestation struct {
 	Source           uint64
 	Target           uint64
 	SigningRoot      [32]byte
+}
+
+// Slashing represents a compact format with all the information
+// needed to understand a slashable offense in eth2.
+type Slashing struct {
+	Kind            SlashingKind
+	ValidatorIndex  types.ValidatorIndex
+	PrevSourceEpoch types.Epoch
+	PrevTargetEpoch types.Epoch
+	SourceEpoch     types.Epoch
+	TargetEpoch     types.Epoch
+	SigningRoot     types.Epoch
+	Slot            uint64
 }
 
 // SlashingKind is an enum representing the type of slashable


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

When performing slashing surround detection, we need to figure out the start epoch of a chunk we are updating. This differs depending on whether the chunk is a min span chunk or max span chunk. As such, we should add methods for this as part of the `Chunker` interface. Additionally, this PR adds a useful `Slashing` type which summarizes all the information about surround vote slashings.

**Which issues(s) does this PR fix?**

Part of #8331 
