### PR TITLE
Use latest block header + slot as skip slot cache key

### DIFF
--- a/beacon-chain/core/state/skip_slot_cache.go
+++ b/beacon-chain/core/state/skip_slot_cache.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"errors"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	beaconstate "github.com/prysmaticlabs/prysm/beacon-chain/state"
@@ -19,7 +20,11 @@ var SkipSlotCache = cache.NewSkipSlotCache()
 // state root is in the mix to defend against different forks with same skip slots
 // to hit the same cache. We don't want beacon states mixed up between different chains.
 func cacheKey(ctx context.Context, state *beaconstate.BeaconState) ([32]byte, error) {
-	r, err := state.HashTreeRoot(ctx)
+	bh := state.LatestBlockHeader()
+	if bh == nil {
+		return [32]byte{}, errors.New("block head in state can't be nil")
+	}
+	r, err := bh.HashTreeRoot()
 	if err != nil {
 		return [32]byte{}, err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature


**What does this PR do? Why is it needed?**

Having to HTR for beacon state for skip slot cache key is inefficient. See flame graphs:
* During initial sync 
![Screen Shot 2021-02-12 at 9 05 12 AM](https://user-images.githubusercontent.com/21316537/107804110-5ead7200-6d18-11eb-8d0b-98c0a353ddaf.png)


* Regular run time
![Screen Shot 2021-02-12 at 9 06 23 AM](https://user-images.githubusercontent.com/21316537/107803890-18f0a980-6d18-11eb-8731-d70f608089f4.png)


Instead we can do better by HTR the latest block header and hash it with current state slot. This should be much nicer to the memory


**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A