### PR TITLE
Ensure Default Wallet Password Permissions Are Consistent

### DIFF
--- a/shared/fileutil/fileutil.go
+++ b/shared/fileutil/fileutil.go
@@ -104,6 +104,16 @@ func HasDir(dirPath string) (bool, error) {
 	return info.IsDir(), err
 }
 
+// HasReadWritePermissions checks if file at a path has proper
+// 0600 permissions set.
+func HasReadWritePermissions(itemPath string) (bool, error) {
+	info, err := os.Stat(itemPath)
+	if err != nil {
+		return false, err
+	}
+	return info.Mode() == params.BeaconIoConfig().ReadWritePermissions, nil
+}
+
 // FileExists returns true if a file is not a directory and exists
 // at the specified path.
 func FileExists(filename string) bool {


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Summarizing the issue found by a contributor:

> If Prysm is started with --web and --write-wallet-password-on-web-onboarding it will store the wallet password in ~/.eth2validators/prysm-wallet-v2/walletpassword.txt after onboarding is completed, and this is later used to unlock the wallet when starting Prysm with the --web flag. File permissions are set correctly at file creation (0600), but Prysm will continue to start in the event that permissions are later adjusted to be readable by any user on the server.
Starting Prysm with --wallet-password-file and pointing to a wallet password file with incorrect file permissions also allows Prysm to start.
Given that this file contains sensitive data (cleartext version of the wallet password) it is advised to not allow Prysm to start if the file permissions are incorrectly set, similar to how SSH deals with private keys.
