### PR TITLE
100% Bucket Fill Percent for Validator Slashing Protection Buckets

### DIFF
--- a/validator/db/kv/attester_protection.go
+++ b/validator/db/kv/attester_protection.go
@@ -350,11 +350,13 @@ func (s *Store) saveAttestationRecords(ctx context.Context, atts []*AttestationR
 	defer span.End()
 	return s.update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(pubKeysBucket)
+		bucket.FillPercent = 1.0
 		for _, att := range atts {
 			pkBucket, err := bucket.CreateBucketIfNotExists(att.PubKey[:])
 			if err != nil {
 				return errors.Wrap(err, "could not create public key bucket")
 			}
+			pkBucket.FillPercent = 1.0
 			sourceEpochBytes := bytesutil.EpochToBytesBigEndian(att.Source)
 			targetEpochBytes := bytesutil.EpochToBytesBigEndian(att.Target)
 
@@ -362,6 +364,7 @@ func (s *Store) saveAttestationRecords(ctx context.Context, atts []*AttestationR
 			if err != nil {
 				return errors.Wrap(err, "could not create signing roots bucket")
 			}
+			signingRootsBucket.FillPercent = 1.0
 			if err := signingRootsBucket.Put(targetEpochBytes, att.SigningRoot[:]); err != nil {
 				return errors.Wrapf(err, "could not save signing signing root for epoch %d", att.Target)
 			}
@@ -369,6 +372,7 @@ func (s *Store) saveAttestationRecords(ctx context.Context, atts []*AttestationR
 			if err != nil {
 				return errors.Wrap(err, "could not create source epochs bucket")
 			}
+			sourceEpochsBucket.FillPercent = 1.0
 
 			// There can be multiple attested target epochs per source epoch.
 			// If a previous list exists, we append to that list with the incoming target epoch.

--- a/validator/db/kv/proposer_protection.go
+++ b/validator/db/kv/proposer_protection.go
@@ -104,10 +104,12 @@ func (s *Store) SaveProposalHistoryForSlot(ctx context.Context, pubKey [48]byte,
 
 	err := s.update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(historicProposalsBucket)
+		bucket.FillPercent = 1.0
 		valBucket, err := bucket.CreateBucketIfNotExists(pubKey[:])
 		if err != nil {
 			return fmt.Errorf("could not create bucket for public key %#x", pubKey)
 		}
+		valBucket.FillPercent = 1.0
 
 		// If the incoming slot is lower than the lowest signed proposal slot, override.
 		lowestSignedBkt := tx.Bucket(lowestSignedProposalsBucket)


### PR DESCRIPTION
No tracking issue. BoltDB has a transaction parameter for buckets known as `FillPercent`. Apparently, this can be very inefficient to leave at a default value for append-only workloads: https://github.com/boltdb/bolt/issues/163. As such, we set this percentage to 100% for important buckets we care about.