### PR TITLE
Ignore Analyzers Package in DeepSource Config

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,11 +1,13 @@
 version = 1
 
+exclude_patterns = ["tools/analyzers/**"]
+
 [[analyzers]]
 name = "go"
 enabled = true
 
-  [analyzers.meta]
-  import_paths = ["github.com/prysmaticlabs/prysm"]
+[analyzers.meta]
+import_paths = ["github.com/prysmaticlabs/prysm"]
 
 [[analyzers]]
 name = "test-coverage"


### PR DESCRIPTION
This PR ignores `tools/analyzers/**` in deep source, which always fails in some PRs because the analyzers package intentionally tries to create bad code that is static checked