### PR TITLE
Double Block Slashing Detection for Optimized Slasher

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -67,6 +67,9 @@ type ReadOnlyDatabase interface {
 	LoadSlasherChunks(
 		ctx context.Context, kind slashertypes.ChunkKind, diskKeys []uint64,
 	) ([][]uint16, []bool, error)
+	ExistingBlockProposals(
+		ctx context.Context, proposals []*slashertypes.CompactBeaconBlock,
+	) ([]*slashertypes.DoubleBlockProposal, error)
 }
 
 // NoHeadAccessDatabase defines a struct without access to chain head data.
@@ -108,10 +111,9 @@ type NoHeadAccessDatabase interface {
 	SaveSlasherChunks(
 		ctx context.Context, kind slashertypes.ChunkKind, chunkKeys []uint64, chunks [][]uint16,
 	) error
-	CheckAndUpdateForSlashableProposals(
-		ctx context.Context, proposals []*slashertypes.CompactBeaconBlock,
-	) ([]*slashertypes.CompactBeaconBlock, error)
-
+	SaveBlockProposals(
+		ctx context.Context, proposal []*slashertypes.CompactBeaconBlock,
+	) error
 	// Run any required database migrations.
 	RunMigrations(ctx context.Context) error
 

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -67,7 +67,7 @@ type ReadOnlyDatabase interface {
 	LoadSlasherChunks(
 		ctx context.Context, kind slashertypes.ChunkKind, diskKeys []uint64,
 	) ([][]uint16, []bool, error)
-	ExistingBlockProposals(
+	CheckDoubleBlockProposals(
 		ctx context.Context, proposals []*slashertypes.CompactBeaconBlock,
 	) ([]*slashertypes.DoubleBlockProposal, error)
 }

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -108,6 +108,9 @@ type NoHeadAccessDatabase interface {
 	SaveSlasherChunks(
 		ctx context.Context, kind slashertypes.ChunkKind, chunkKeys []uint64, chunks [][]uint16,
 	) error
+	CheckAndUpdateForSlashableProposals(
+		ctx context.Context, proposals []*slashertypes.CompactBeaconBlock,
+	) ([]*slashertypes.CompactBeaconBlock, error)
 
 	// Run any required database migrations.
 	RunMigrations(ctx context.Context) error

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -305,11 +305,18 @@ func (e Exporter) SaveAttestationRecordsForValidators(
 	return e.db.SaveAttestationRecordsForValidators(ctx, validatorIndices, attestations)
 }
 
-// CheckAndUpdateForSlashableProposals -- passthrough
-func (e Exporter) CheckAndUpdateForSlashableProposals(
+// ExistingBlockProposals -- passthrough
+func (e Exporter) ExistingBlockProposals(
 	ctx context.Context, proposals []*slashertypes.CompactBeaconBlock,
-) ([]*slashertypes.CompactBeaconBlock, error) {
-	return e.db.CheckAndUpdateForSlashableProposals(ctx, proposals)
+) ([]*slashertypes.ExistingBlockProposal, error) {
+	return e.db.ExistingBlockProposals(ctx, proposals)
+}
+
+// SaveBlockProposals -- passthrough
+func (e Exporter) SaveBlockProposals(
+	ctx context.Context, proposals []*slashertypes.CompactBeaconBlock,
+) error {
+	return e.db.SaveBlockProposals(ctx, proposals)
 }
 
 // SaveSlasherChunks -- passthrough

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -308,7 +308,7 @@ func (e Exporter) SaveAttestationRecordsForValidators(
 // ExistingBlockProposals -- passthrough
 func (e Exporter) ExistingBlockProposals(
 	ctx context.Context, proposals []*slashertypes.CompactBeaconBlock,
-) ([]*slashertypes.ExistingBlockProposal, error) {
+) ([]*slashertypes.DoubleBlockProposal, error) {
 	return e.db.ExistingBlockProposals(ctx, proposals)
 }
 

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -306,10 +306,10 @@ func (e Exporter) SaveAttestationRecordsForValidators(
 }
 
 // ExistingBlockProposals -- passthrough
-func (e Exporter) ExistingBlockProposals(
+func (e Exporter) CheckDoubleBlockProposals(
 	ctx context.Context, proposals []*slashertypes.CompactBeaconBlock,
 ) ([]*slashertypes.DoubleBlockProposal, error) {
-	return e.db.ExistingBlockProposals(ctx, proposals)
+	return e.db.CheckDoubleBlockProposals(ctx, proposals)
 }
 
 // SaveBlockProposals -- passthrough

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -305,6 +305,13 @@ func (e Exporter) SaveAttestationRecordsForValidators(
 	return e.db.SaveAttestationRecordsForValidators(ctx, validatorIndices, attestations)
 }
 
+// CheckAndUpdateForSlashableProposals -- passthrough
+func (e Exporter) CheckAndUpdateForSlashableProposals(
+	ctx context.Context, proposals []*slashertypes.CompactBeaconBlock,
+) ([]*slashertypes.CompactBeaconBlock, error) {
+	return e.db.CheckAndUpdateForSlashableProposals(ctx, proposals)
+}
+
 // SaveSlasherChunks -- passthrough
 func (e Exporter) SaveSlasherChunks(
 	ctx context.Context, kind slashertypes.ChunkKind, chunkKeys []uint64, chunks [][]uint16,

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -305,7 +305,7 @@ func (e Exporter) SaveAttestationRecordsForValidators(
 	return e.db.SaveAttestationRecordsForValidators(ctx, validatorIndices, attestations)
 }
 
-// ExistingBlockProposals -- passthrough
+// CheckDoubleBlockProposals -- passthrough
 func (e Exporter) CheckDoubleBlockProposals(
 	ctx context.Context, proposals []*slashertypes.CompactBeaconBlock,
 ) ([]*slashertypes.DoubleBlockProposal, error) {

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -46,6 +46,8 @@ var blockedBuckets = [][]byte{
 	blockParentRootIndicesBucket,
 	blockSlotIndicesBucket,
 	finalizedBlockRootsIndexBucket,
+	proposalRecordsBucket,
+	attestationRecordsBucket,
 }
 
 // Config for the bolt db kv store.
@@ -148,6 +150,7 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 			// Slasher buckets.
 			attestedEpochsByValidator,
 			attestationRecordsBucket,
+			proposalRecordsBucket,
 			slasherChunksBucket,
 			// Migrations
 			migrationsBucket,

--- a/beacon-chain/db/kv/schema.go
+++ b/beacon-chain/db/kv/schema.go
@@ -53,6 +53,7 @@ var (
 	// Slasher buckets.
 	attestedEpochsByValidator = []byte("attested-epochs-by-validator")
 	attestationRecordsBucket  = []byte("attestation-records")
+	proposalRecordsBucket     = []byte("proposal-records")
 	slasherChunksBucket       = []byte("slasher-chunks")
 
 	// Migrations

--- a/beacon-chain/db/kv/slasher.go
+++ b/beacon-chain/db/kv/slasher.go
@@ -8,11 +8,10 @@ import (
 
 	ssz "github.com/ferranbt/fastssz"
 	types "github.com/prysmaticlabs/eth2-types"
-	bolt "go.etcd.io/bbolt"
-	"go.opencensus.io/trace"
-
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	bolt "go.etcd.io/bbolt"
+	"go.opencensus.io/trace"
 )
 
 // LatestEpochAttestedForValidator given a validator index returns the latest

--- a/beacon-chain/db/kv/slasher.go
+++ b/beacon-chain/db/kv/slasher.go
@@ -206,7 +206,7 @@ func (s *Store) CheckAndUpdateForSlashableProposals(
 ) ([]*slashertypes.CompactBeaconBlock, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.CheckAndUpdateForSlashableProposals")
 	defer span.End()
-	existingProposals := make([]*slashertypes.CompactBeaconBlock, len(proposals))
+	existingProposals := make([]*slashertypes.CompactBeaconBlock, 0, len(proposals))
 	err := s.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(slasherChunksBucket)
 		for _, proposal := range proposals {

--- a/beacon-chain/db/kv/slasher.go
+++ b/beacon-chain/db/kv/slasher.go
@@ -208,7 +208,7 @@ func (s *Store) CheckAndUpdateForSlashableProposals(
 	defer span.End()
 	existingProposals := make([]*slashertypes.CompactBeaconBlock, 0, len(proposals))
 	err := s.db.Update(func(tx *bolt.Tx) error {
-		bkt := tx.Bucket(slasherChunksBucket)
+		bkt := tx.Bucket(proposalRecordsBucket)
 		for _, proposal := range proposals {
 			key, err := keyForValidatorProposal(proposal)
 			if err != nil {

--- a/beacon-chain/db/kv/slasher.go
+++ b/beacon-chain/db/kv/slasher.go
@@ -10,7 +10,6 @@ import (
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
-
 	bolt "go.etcd.io/bbolt"
 	"go.opencensus.io/trace"
 )

--- a/beacon-chain/db/kv/slasher_test.go
+++ b/beacon-chain/db/kv/slasher_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	types "github.com/prysmaticlabs/eth2-types"
-
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"

--- a/beacon-chain/db/kv/slasher_test.go
+++ b/beacon-chain/db/kv/slasher_test.go
@@ -6,6 +6,7 @@ import (
 
 	types "github.com/prysmaticlabs/eth2-types"
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
@@ -120,7 +121,7 @@ func TestStore_SlasherChunk_SaveRetrieve(t *testing.T) {
 	}
 }
 
-func TestStore_CheckAndUpdateForSlashableProposals(t *testing.T) {
+func TestStore_ExistingBlockProposals(t *testing.T) {
 	ctx := context.Background()
 	beaconDB := setupDB(t)
 	proposals := []*slashertypes.CompactBeaconBlock{
@@ -140,44 +141,27 @@ func TestStore_CheckAndUpdateForSlashableProposals(t *testing.T) {
 			SigningRoot:   [32]byte{1},
 		},
 	}
-	// First time writing should return empty existing proposals.
-	existingProposals, err := beaconDB.CheckAndUpdateForSlashableProposals(ctx, proposals)
+	// First time checking should return empty existing proposals.
+	existingProposals, err := beaconDB.ExistingBlockProposals(ctx, proposals)
 	require.NoError(t, err)
 	require.Equal(t, len(proposals), len(existingProposals))
 	for _, existing := range existingProposals {
-		require.Equal(t, true, existing == nil)
+		require.DeepEqual(t, params.BeaconConfig().ZeroHash, existing.ExistingSigningRoot)
 	}
 
-	// Second time writing same proposals but all with different signing root should
-	// return the existing proposals.
+	// We then save the block proposals to disk.
+	err = beaconDB.SaveBlockProposals(ctx, proposals)
+	require.NoError(t, err)
+
+	// Second time checking same proposals but all with different signing root should
+	// return the existing proposals with different signing roots.
 	proposals[0].SigningRoot = [32]byte{2}
 	proposals[1].SigningRoot = [32]byte{2}
 	proposals[2].SigningRoot = [32]byte{2}
-	existingProposals, err = beaconDB.CheckAndUpdateForSlashableProposals(ctx, proposals)
+	existingProposals, err = beaconDB.ExistingBlockProposals(ctx, proposals)
 	require.NoError(t, err)
 	require.Equal(t, len(proposals), len(existingProposals))
 	for i, existing := range existingProposals {
-		require.Equal(t, proposals[i].Slot, existing.Slot)
-		require.Equal(t, proposals[i].ProposerIndex, existing.ProposerIndex)
-		require.DeepNotEqual(t, proposals[i].SigningRoot, existing.SigningRoot)
-	}
-
-	// Second time writing same proposals but with only a single having a
-	// different signing root should return the existing proposals.
-	proposals[0].SigningRoot = [32]byte{1}
-	proposals[1].SigningRoot = [32]byte{2} // Different signing root.
-	proposals[2].SigningRoot = [32]byte{1}
-	existingProposals, err = beaconDB.CheckAndUpdateForSlashableProposals(ctx, proposals)
-	require.NoError(t, err)
-	require.Equal(t, len(proposals), len(existingProposals))
-
-	for i, existing := range existingProposals {
-		require.Equal(t, proposals[i].Slot, existing.Slot)
-		require.Equal(t, proposals[i].ProposerIndex, existing.ProposerIndex)
-		if i == 1 {
-			require.DeepNotEqual(t, proposals[i].SigningRoot, existing.SigningRoot)
-		} else {
-			require.DeepEqual(t, proposals[i].SigningRoot, existing.SigningRoot)
-		}
+		require.DeepNotEqual(t, proposals[i].SigningRoot, existing.ExistingSigningRoot)
 	}
 }

--- a/beacon-chain/slasher/BUILD.bazel
+++ b/beacon-chain/slasher/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "chunks.go",
         "detect_attestations.go",
+        "detect_blocks.go",
         "doc.go",
         "helpers.go",
         "log.go",
@@ -33,6 +34,7 @@ go_test(
     srcs = [
         "chunks_test.go",
         "detect_attestations_test.go",
+        "detect_blocks_test.go",
         "helpers_test.go",
         "params_test.go",
         "receive_test.go",

--- a/beacon-chain/slasher/BUILD.bazel
+++ b/beacon-chain/slasher/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//beacon-chain/db/testing:go_default_library",
         "//beacon-chain/slasher/types:go_default_library",
         "//shared/event:go_default_library",
+        "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",

--- a/beacon-chain/slasher/detect_blocks.go
+++ b/beacon-chain/slasher/detect_blocks.go
@@ -20,6 +20,8 @@ func (s *Service) detectSlashableBlocks(
 		if existing == nil {
 			continue
 		}
+		// If there is an existing record for a validator proposal, check if the existing
+		// record has a different signing root than the incoming one.
 		if existing.SigningRoot != proposedBlocks[i].SigningRoot {
 			// TODO(#8331): Send over an event feed.
 			logSlashingEvent(&slashertypes.Slashing{

--- a/beacon-chain/slasher/detect_blocks.go
+++ b/beacon-chain/slasher/detect_blocks.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	types "github.com/prysmaticlabs/eth2-types"
-
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 )
 

--- a/beacon-chain/slasher/detect_blocks.go
+++ b/beacon-chain/slasher/detect_blocks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	types "github.com/prysmaticlabs/eth2-types"
+
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 )
 

--- a/beacon-chain/slasher/detect_blocks.go
+++ b/beacon-chain/slasher/detect_blocks.go
@@ -51,9 +51,7 @@ func (s *Service) checkDoubleProposalsOnDisk(
 		logDoubleProposal(proposedBlocks[i], doubleProposal.ExistingSigningRoot)
 		// If a proposer is found to have committed a slashable offense, we delete
 		// them from the safe proposers map.
-		if _, ok := safeProposers[doubleProposal.ProposerIndex]; ok {
-			delete(safeProposers, doubleProposal.ProposerIndex)
-		}
+		delete(safeProposers, doubleProposal.ProposerIndex)
 	}
 	// We save all the proposals that are determined "safe" and not-slashable to our database.
 	safeProposals := make([]*slashertypes.CompactBeaconBlock, 0, len(safeProposers))

--- a/beacon-chain/slasher/detect_blocks.go
+++ b/beacon-chain/slasher/detect_blocks.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	types "github.com/prysmaticlabs/eth2-types"
-
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 )
 

--- a/beacon-chain/slasher/detect_blocks.go
+++ b/beacon-chain/slasher/detect_blocks.go
@@ -2,8 +2,8 @@ package slasher
 
 import (
 	"context"
+	"fmt"
 
-	types "github.com/prysmaticlabs/eth2-types"
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 )
 
@@ -12,26 +12,43 @@ func (s *Service) detectSlashableBlocks(
 	ctx context.Context,
 	proposedBlocks []*slashertypes.CompactBeaconBlock,
 ) error {
-	existingProposals, err := s.serviceCfg.Database.CheckAndUpdateForSlashableProposals(ctx, proposedBlocks)
+	// We check if there are any slashable double proposals in the input list
+	// of proposals with respect to each other.
+	existingProposals := make(map[string][32]byte)
+	for i, proposal := range proposedBlocks {
+		key := fmt.Sprintf("%d:%d", proposal.Slot, proposal.ProposerIndex)
+		existingSigningRoot, ok := existingProposals[key]
+		if !ok {
+			existingProposals[key] = proposal.SigningRoot
+			continue
+		}
+		if isDoubleProposal(proposedBlocks[i].SigningRoot, existingSigningRoot) {
+			logDoubleProposal(proposedBlocks[i], existingSigningRoot)
+		}
+	}
+	// We check if there are any slashable double proposals in the input list
+	// of proposals with respect to our database.
+	return s.checkDoubleProposalsOnDisk(ctx, proposedBlocks)
+}
+
+func (s *Service) checkDoubleProposalsOnDisk(
+	ctx context.Context, proposedBlocks []*slashertypes.CompactBeaconBlock,
+) error {
+	existingProposals, err := s.serviceCfg.Database.ExistingBlockProposals(ctx, proposedBlocks)
 	if err != nil {
 		return err
 	}
+	newBlockProposals := make([]*slashertypes.CompactBeaconBlock, 0)
 	for i, existing := range existingProposals {
 		if existing == nil {
 			continue
 		}
-		// If there is an existing record for a validator proposal, check if the existing
-		// record has a different signing root than the incoming one.
-		if existing.SigningRoot != proposedBlocks[i].SigningRoot {
-			// TODO(#8331): Send over an event feed.
-			logSlashingEvent(&slashertypes.Slashing{
-				Kind:            slashertypes.DoubleProposal,
-				ValidatorIndex:  types.ValidatorIndex(proposedBlocks[i].ProposerIndex),
-				SigningRoot:     proposedBlocks[i].SigningRoot,
-				PrevSigningRoot: existing.SigningRoot,
-				Slot:            proposedBlocks[i].Slot,
-			})
+		if isDoubleProposal(proposedBlocks[i].SigningRoot, existing.ExistingSigningRoot) {
+			logDoubleProposal(proposedBlocks[i], existing.ExistingSigningRoot)
+		} else {
+			// If there is no existing block proposal, we append to a list of confirmed, new proposals.
+			newBlockProposals = append(newBlockProposals, proposedBlocks[i])
 		}
 	}
-	return nil
+	return s.serviceCfg.Database.SaveBlockProposals(ctx, newBlockProposals)
 }

--- a/beacon-chain/slasher/detect_blocks.go
+++ b/beacon-chain/slasher/detect_blocks.go
@@ -31,6 +31,8 @@ func (s *Service) detectSlashableBlocks(
 	return s.checkDoubleProposalsOnDisk(ctx, proposedBlocks)
 }
 
+// Check for double proposals in our database given a list of incoming block proposals.
+// For the proposals that were not slashable, we save them to the database.
 func (s *Service) checkDoubleProposalsOnDisk(
 	ctx context.Context, proposedBlocks []*slashertypes.CompactBeaconBlock,
 ) error {

--- a/beacon-chain/slasher/detect_blocks.go
+++ b/beacon-chain/slasher/detect_blocks.go
@@ -1,0 +1,35 @@
+package slasher
+
+import (
+	"context"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
+)
+
+// Given a list of blocks, check if they are slashable for the validators involved.
+func (s *Service) detectSlashableBlocks(
+	ctx context.Context,
+	proposedBlocks []*slashertypes.CompactBeaconBlock,
+) error {
+	existingProposals, err := s.serviceCfg.Database.CheckAndUpdateForSlashableProposals(ctx, proposedBlocks)
+	if err != nil {
+		return err
+	}
+	for i, existing := range existingProposals {
+		if existing == nil {
+			continue
+		}
+		if existing.SigningRoot != proposedBlocks[i].SigningRoot {
+			// TODO(#8331): Send over an event feed.
+			logSlashingEvent(&slashertypes.Slashing{
+				Kind:            slashertypes.DoubleProposal,
+				ValidatorIndex:  types.ValidatorIndex(proposedBlocks[i].ProposerIndex),
+				SigningRoot:     proposedBlocks[i].SigningRoot,
+				PrevSigningRoot: existing.SigningRoot,
+				Slot:            proposedBlocks[i].Slot,
+			})
+		}
+	}
+	return nil
+}

--- a/beacon-chain/slasher/detect_blocks_test.go
+++ b/beacon-chain/slasher/detect_blocks_test.go
@@ -1,0 +1,1 @@
+package slasher

--- a/beacon-chain/slasher/detect_blocks_test.go
+++ b/beacon-chain/slasher/detect_blocks_test.go
@@ -50,7 +50,7 @@ func Test_processQueuedBlocks_DetectsDoubleProposals(t *testing.T) {
 			SigningRoot:   [32]byte{2},
 		},
 	}
-	currentEpoch := types.Epoch(4)
+	currentEpoch := types.Epoch(0)
 	currentEpochChan <- currentEpoch
 	cancel()
 	<-exitChan

--- a/beacon-chain/slasher/detect_blocks_test.go
+++ b/beacon-chain/slasher/detect_blocks_test.go
@@ -1,1 +1,94 @@
 package slasher
+
+import (
+	"context"
+	"testing"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	dbtest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
+	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	logTest "github.com/sirupsen/logrus/hooks/test"
+)
+
+func Test_processQueuedBlocks_DetectsDoubleProposals(t *testing.T) {
+	hook := logTest.NewGlobal()
+	beaconDB := dbtest.SetupDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Service{
+		serviceCfg: &ServiceConfig{
+			Database: beaconDB,
+		},
+		params:            DefaultParams(),
+		beaconBlocksQueue: make([]*slashertypes.CompactBeaconBlock, 0),
+	}
+	currentEpochChan := make(chan types.Epoch, 0)
+	exitChan := make(chan struct{})
+	go func() {
+		s.processQueuedBlocks(ctx, currentEpochChan)
+		exitChan <- struct{}{}
+	}()
+	s.beaconBlocksQueue = []*slashertypes.CompactBeaconBlock{
+		{
+			Slot:          4,
+			ProposerIndex: 1,
+			SigningRoot:   [32]byte{1},
+		},
+		{
+			Slot:          4,
+			ProposerIndex: 1,
+			SigningRoot:   [32]byte{1},
+		},
+		{
+			Slot:          4,
+			ProposerIndex: 1,
+			SigningRoot:   [32]byte{1},
+		},
+		{
+			Slot:          4,
+			ProposerIndex: 1,
+			SigningRoot:   [32]byte{2},
+		},
+	}
+	currentEpoch := types.Epoch(4)
+	currentEpochChan <- currentEpoch
+	cancel()
+	<-exitChan
+	require.LogsContain(t, hook, "Proposer double proposal slashing")
+}
+
+func Test_processQueuedBlocks_NotSlashable(t *testing.T) {
+	hook := logTest.NewGlobal()
+	beaconDB := dbtest.SetupDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Service{
+		serviceCfg: &ServiceConfig{
+			Database: beaconDB,
+		},
+		params:            DefaultParams(),
+		beaconBlocksQueue: make([]*slashertypes.CompactBeaconBlock, 0),
+	}
+	currentEpochChan := make(chan types.Epoch, 0)
+	exitChan := make(chan struct{})
+	go func() {
+		s.processQueuedBlocks(ctx, currentEpochChan)
+		exitChan <- struct{}{}
+	}()
+	s.beaconBlocksQueue = []*slashertypes.CompactBeaconBlock{
+		{
+			Slot:          4,
+			ProposerIndex: 1,
+			SigningRoot:   [32]byte{1},
+		},
+		{
+			Slot:          4,
+			ProposerIndex: 1,
+			SigningRoot:   [32]byte{1},
+		},
+	}
+	currentEpoch := types.Epoch(4)
+	currentEpochChan <- currentEpoch
+	cancel()
+	<-exitChan
+	require.LogsDoNotContain(t, hook, "Proposer double proposal slashing")
+}

--- a/beacon-chain/slasher/detect_blocks_test.go
+++ b/beacon-chain/slasher/detect_blocks_test.go
@@ -22,7 +22,7 @@ func Test_processQueuedBlocks_DetectsDoubleProposals(t *testing.T) {
 		params:            DefaultParams(),
 		beaconBlocksQueue: make([]*slashertypes.CompactBeaconBlock, 0),
 	}
-	currentEpochChan := make(chan types.Epoch, 0)
+	currentEpochChan := make(chan types.Epoch)
 	exitChan := make(chan struct{})
 	go func() {
 		s.processQueuedBlocks(ctx, currentEpochChan)
@@ -68,7 +68,7 @@ func Test_processQueuedBlocks_NotSlashable(t *testing.T) {
 		params:            DefaultParams(),
 		beaconBlocksQueue: make([]*slashertypes.CompactBeaconBlock, 0),
 	}
-	currentEpochChan := make(chan types.Epoch, 0)
+	currentEpochChan := make(chan types.Epoch)
 	exitChan := make(chan struct{})
 	go func() {
 		s.processQueuedBlocks(ctx, currentEpochChan)

--- a/beacon-chain/slasher/helpers.go
+++ b/beacon-chain/slasher/helpers.go
@@ -71,6 +71,13 @@ func logSlashingEvent(slashing *slashertypes.Slashing) {
 			"sourceEpoch":     slashing.SourceEpoch,
 			"targetEpoch":     slashing.TargetEpoch,
 		}).Info("Attester surrounded vote slashing")
+	case slashertypes.DoubleProposal:
+		log.WithFields(logrus.Fields{
+			"validatorIndex":  slashing.ValidatorIndex,
+			"slot":            slashing.Slot,
+			"prevSigningRoot": fmt.Sprintf("%#x", slashing.PrevSigningRoot),
+			"signingRoot":     fmt.Sprintf("%#x", slashing.SigningRoot),
+		}).Info("Proposer double proposal slashing")
 	default:
 		return
 	}

--- a/beacon-chain/slasher/helpers.go
+++ b/beacon-chain/slasher/helpers.go
@@ -6,6 +6,7 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/sirupsen/logrus"
 )
 
@@ -81,6 +82,28 @@ func logSlashingEvent(slashing *slashertypes.Slashing) {
 	default:
 		return
 	}
+}
+
+// Log a double block proposal slashing given an incoming proposal and existing proposal signing root.
+func logDoubleProposal(incomingProposal *slashertypes.CompactBeaconBlock, existingSigningRoot [32]byte) {
+	logSlashingEvent(&slashertypes.Slashing{
+		Kind:            slashertypes.DoubleProposal,
+		ValidatorIndex:  types.ValidatorIndex(incomingProposal.ProposerIndex),
+		SigningRoot:     incomingProposal.SigningRoot,
+		PrevSigningRoot: existingSigningRoot,
+		Slot:            incomingProposal.Slot,
+	})
+}
+
+// If an existing signing root does not match an incoming proposal signing root,
+// we then have a double block proposer slashing event.
+func isDoubleProposal(incomingSigningRoot, existingSigningRoot [32]byte) bool {
+	// If the existing signing root is the zero hash, we do not consider
+	// this a double proposal.
+	if existingSigningRoot == params.BeaconConfig().ZeroHash {
+		return false
+	}
+	return incomingSigningRoot != existingSigningRoot
 }
 
 // Validates the attestation data integrity, ensuring we have no nil values for

--- a/beacon-chain/slasher/helpers_test.go
+++ b/beacon-chain/slasher/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	logTest "github.com/sirupsen/logrus/hooks/test"
 
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
+	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
@@ -302,6 +303,50 @@ func Test_validateAttestationIntegrity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := validateAttestationIntegrity(tt.att); got != tt.want {
 				t.Errorf("validateAttestationIntegrity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isDoubleProposal(t *testing.T) {
+	type args struct {
+		incomingSigningRoot [32]byte
+		existingSigningRoot [32]byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Existing signing root empty returns false",
+			args: args{
+				incomingSigningRoot: [32]byte{1},
+				existingSigningRoot: params.BeaconConfig().ZeroHash,
+			},
+			want: false,
+		},
+		{
+			name: "Existing signing root non-empty and equal to incoming returns false",
+			args: args{
+				incomingSigningRoot: [32]byte{1},
+				existingSigningRoot: [32]byte{1},
+			},
+			want: false,
+		},
+		{
+			name: "Existing signing root non-empty and not-equal to incoming returns true",
+			args: args{
+				incomingSigningRoot: [32]byte{1},
+				existingSigningRoot: [32]byte{2},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDoubleProposal(tt.args.incomingSigningRoot, tt.args.existingSigningRoot); got != tt.want {
+				t.Errorf("isDoubleProposal() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -49,7 +49,7 @@ func (s *Service) receiveBlocks(ctx context.Context) {
 		case blockHeader := <-s.beaconBlocksChan:
 			// TODO(#8331): Defer blocks from the future for later processing.
 			compactBlock := &slashertypes.CompactBeaconBlock{
-				ProposerIndex: blockHeader.ProposerIndex,
+				ProposerIndex: types.ValidatorIndex(blockHeader.ProposerIndex),
 				Slot:          blockHeader.Slot,
 			}
 			s.blockQueueLock.Lock()

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -120,6 +120,10 @@ func (s *Service) processQueuedBlocks(ctx context.Context, epochTicker <-chan ty
 				"currentEpoch": currentEpoch,
 				"numBlocks":    len(blocks),
 			}).Info("Epoch reached, processing queued blocks for slashing detection")
+			if err := s.detectSlashableBlocks(ctx, blocks); err != nil {
+				log.WithError(err).Error("Could not detect slashable blocks")
+				continue
+			}
 		case <-ctx.Done():
 			return
 		}

--- a/beacon-chain/slasher/receive_test.go
+++ b/beacon-chain/slasher/receive_test.go
@@ -142,10 +142,10 @@ func TestSlasher_receiveBlocks_OK(t *testing.T) {
 	<-exitChan
 	wanted := []*slashertypes.CompactBeaconBlock{
 		{
-			ProposerIndex: block1.ProposerIndex,
+			ProposerIndex: types.ValidatorIndex(block1.ProposerIndex),
 		},
 		{
-			ProposerIndex: block2.ProposerIndex,
+			ProposerIndex: types.ValidatorIndex(block2.ProposerIndex),
 		},
 	}
 	require.DeepEqual(t, wanted, s.beaconBlocksQueue)

--- a/beacon-chain/slasher/types/types.go
+++ b/beacon-chain/slasher/types/types.go
@@ -22,6 +22,8 @@ type CompactAttestation struct {
 
 // DoubleBlockProposal containing an incoming and an existing proposal's signing root.
 type DoubleBlockProposal struct {
+	Slot                types.Slot
+	ProposerIndex       types.ValidatorIndex
 	IncomingSigningRoot [32]byte
 	ExistingSigningRoot [32]byte
 }
@@ -29,7 +31,7 @@ type DoubleBlockProposal struct {
 // CompactBeaconBlock containing only the required information
 // for proposer slashing detection.
 type CompactBeaconBlock struct {
-	ProposerIndex uint64
+	ProposerIndex types.ValidatorIndex
 	Slot          types.Slot
 	SigningRoot   [32]byte
 }

--- a/beacon-chain/slasher/types/types.go
+++ b/beacon-chain/slasher/types/types.go
@@ -37,8 +37,9 @@ type Slashing struct {
 	PrevTargetEpoch types.Epoch
 	SourceEpoch     types.Epoch
 	TargetEpoch     types.Epoch
-	SigningRoot     types.Epoch
-	Slot            uint64
+	SigningRoot     [32]byte
+	PrevSigningRoot [32]byte
+	Slot            types.Slot
 }
 
 // SlashingKind is an enum representing the type of slashable
@@ -50,6 +51,7 @@ const (
 	DoubleVote
 	SurroundingVote
 	SurroundedVote
+	DoubleProposal
 )
 
 func (k SlashingKind) String() string {

--- a/beacon-chain/slasher/types/types.go
+++ b/beacon-chain/slasher/types/types.go
@@ -20,6 +20,11 @@ type CompactAttestation struct {
 	SigningRoot      [32]byte
 }
 
+type DoubleBlockProposal struct {
+	IncomingSigningRoot [32]byte
+	ExistingSigningRoot [32]byte
+}
+
 // CompactBeaconBlock containing only the required information
 // for proposer slashing detection.
 type CompactBeaconBlock struct {

--- a/beacon-chain/slasher/types/types.go
+++ b/beacon-chain/slasher/types/types.go
@@ -20,6 +20,7 @@ type CompactAttestation struct {
 	SigningRoot      [32]byte
 }
 
+// DoubleBlockProposal containing an incoming and an existing proposal's signing root.
 type DoubleBlockProposal struct {
 	IncomingSigningRoot [32]byte
 	ExistingSigningRoot [32]byte


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Part of #8331. This PR adds the logic to detect double blocks in our optimized slasher. The approach is a simple batch call that checks for existing block proposals for a list of incoming (proposer_index, slot) items. If the existing proposals have a different signing root, we detect a proposer slashing.
