### PR TITLE
Remove mutated fields from slasher args

### DIFF
--- a/beacon-chain/slasher/chunks.go
+++ b/beacon-chain/slasher/chunks.go
@@ -28,6 +28,7 @@ type Chunker interface {
 	) (*slashertypes.Slashing, error)
 	Update(
 		args *chunkUpdateArgs,
+		validatorIndex types.ValidatorIndex,
 		startEpoch,
 		newTargetEpoch types.Epoch,
 	) (keepGoing bool, err error)
@@ -314,6 +315,7 @@ func (m *MaxSpanChunksSlice) CheckSlashable(
 // to jump to another min span chunks slice to perform updates.
 func (m *MinSpanChunksSlice) Update(
 	args *chunkUpdateArgs,
+	validatorIndex types.ValidatorIndex,
 	startEpoch,
 	newTargetEpoch types.Epoch,
 ) (keepGoing bool, err error) {
@@ -329,14 +331,14 @@ func (m *MinSpanChunksSlice) Update(
 	// a for loop.
 	for m.params.chunkIndex(epochInChunk) == args.chunkIndex && epochInChunk >= minEpoch {
 		var chunkTarget types.Epoch
-		chunkTarget, err = chunkDataAtEpoch(m.params, m.data, args.validatorIndex, epochInChunk)
+		chunkTarget, err = chunkDataAtEpoch(m.params, m.data, validatorIndex, epochInChunk)
 		if err != nil {
 			return
 		}
 		// If the newly incoming value is < the existing value, we update
 		// the data in the min span to meet with its definition.
 		if newTargetEpoch < chunkTarget {
-			if err = setChunkDataAtEpoch(m.params, m.data, args.validatorIndex, epochInChunk, newTargetEpoch); err != nil {
+			if err = setChunkDataAtEpoch(m.params, m.data, validatorIndex, epochInChunk, newTargetEpoch); err != nil {
 				return
 			}
 		} else {
@@ -360,6 +362,7 @@ func (m *MinSpanChunksSlice) Update(
 // a next chunk, this function returns a boolean letting the caller know it should keep going.
 func (m *MaxSpanChunksSlice) Update(
 	args *chunkUpdateArgs,
+	validatorIndex types.ValidatorIndex,
 	startEpoch,
 	newTargetEpoch types.Epoch,
 ) (keepGoing bool, err error) {
@@ -369,14 +372,14 @@ func (m *MaxSpanChunksSlice) Update(
 	// we proceed with a for loop.
 	for m.params.chunkIndex(epochInChunk) == args.chunkIndex && epochInChunk <= args.currentEpoch {
 		var chunkTarget types.Epoch
-		chunkTarget, err = chunkDataAtEpoch(m.params, m.data, args.validatorIndex, epochInChunk)
+		chunkTarget, err = chunkDataAtEpoch(m.params, m.data, validatorIndex, epochInChunk)
 		if err != nil {
 			return
 		}
 		// If the newly incoming value is > the existing value, we update
 		// the data in the max span to meet with its definition.
 		if newTargetEpoch > chunkTarget {
-			if err = setChunkDataAtEpoch(m.params, m.data, args.validatorIndex, epochInChunk, newTargetEpoch); err != nil {
+			if err = setChunkDataAtEpoch(m.params, m.data, validatorIndex, epochInChunk, newTargetEpoch); err != nil {
 				return
 			}
 		} else {

--- a/beacon-chain/slasher/chunks_test.go
+++ b/beacon-chain/slasher/chunks_test.go
@@ -130,11 +130,10 @@ func TestMinSpanChunksSlice_CheckSlashable(t *testing.T) {
 	startEpoch := target
 	currentEpoch := target
 	args := &chunkUpdateArgs{
-		chunkIndex:     chunkIdx,
-		currentEpoch:   currentEpoch,
-		validatorIndex: validatorIdx,
+		chunkIndex:   chunkIdx,
+		currentEpoch: currentEpoch,
 	}
-	_, err = chunk.Update(args, startEpoch, target)
+	_, err = chunk.Update(args, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 
 	// Next up, we create a surrounding vote, but it should NOT be slashable
@@ -217,11 +216,10 @@ func TestMaxSpanChunksSlice_CheckSlashable(t *testing.T) {
 	startEpoch := source
 	currentEpoch := target
 	args := &chunkUpdateArgs{
-		chunkIndex:     chunkIdx,
-		currentEpoch:   currentEpoch,
-		validatorIndex: validatorIdx,
+		chunkIndex:   chunkIdx,
+		currentEpoch: currentEpoch,
 	}
-	_, err = chunk.Update(args, startEpoch, target)
+	_, err = chunk.Update(args, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 
 	// Next up, we create a surrounded vote, but it should NOT be slashable
@@ -299,11 +297,10 @@ func TestMinSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 	startEpoch := target
 	currentEpoch := target
 	args := &chunkUpdateArgs{
-		chunkIndex:     chunkIdx,
-		currentEpoch:   currentEpoch,
-		validatorIndex: validatorIdx,
+		chunkIndex:   chunkIdx,
+		currentEpoch: currentEpoch,
 	}
-	keepGoing, err := chunk.Update(args, startEpoch, target)
+	keepGoing, err := chunk.Update(args, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 
 	// We should keep going! We still have to update the data for chunk index 0.
@@ -318,11 +315,10 @@ func TestMinSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 	startEpoch = types.Epoch(1)
 	currentEpoch = target
 	args = &chunkUpdateArgs{
-		chunkIndex:     chunkIdx,
-		currentEpoch:   currentEpoch,
-		validatorIndex: validatorIdx,
+		chunkIndex:   chunkIdx,
+		currentEpoch: currentEpoch,
 	}
-	keepGoing, err = chunk.Update(args, startEpoch, target)
+	keepGoing, err = chunk.Update(args, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want = []uint16{3, 2, math.MaxUint16, math.MaxUint16, math.MaxUint16, math.MaxUint16}
@@ -342,11 +338,10 @@ func TestMaxSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 	startEpoch := types.Epoch(0)
 	currentEpoch := target
 	args := &chunkUpdateArgs{
-		chunkIndex:     chunkIdx,
-		currentEpoch:   currentEpoch,
-		validatorIndex: validatorIdx,
+		chunkIndex:   chunkIdx,
+		currentEpoch: currentEpoch,
 	}
-	keepGoing, err := chunk.Update(args, startEpoch, target)
+	keepGoing, err := chunk.Update(args, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 
 	// We should keep going! We still have to update the data for chunk index 1.
@@ -361,11 +356,10 @@ func TestMaxSpanChunksSlice_Update_MultipleChunks(t *testing.T) {
 	startEpoch = types.Epoch(2)
 	currentEpoch = target
 	args = &chunkUpdateArgs{
-		chunkIndex:     chunkIdx,
-		currentEpoch:   currentEpoch,
-		validatorIndex: validatorIdx,
+		chunkIndex:   chunkIdx,
+		currentEpoch: currentEpoch,
 	}
-	keepGoing, err = chunk.Update(args, startEpoch, target)
+	keepGoing, err = chunk.Update(args, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want = []uint16{1, 0, 0, 0, 0, 0}
@@ -408,11 +402,10 @@ func TestMinSpanChunksSlice_Update_SingleChunk(t *testing.T) {
 	startEpoch := target
 	currentEpoch := target
 	args := &chunkUpdateArgs{
-		chunkIndex:     chunkIdx,
-		currentEpoch:   currentEpoch,
-		validatorIndex: validatorIdx,
+		chunkIndex:   chunkIdx,
+		currentEpoch: currentEpoch,
 	}
-	keepGoing, err := chunk.Update(args, startEpoch, target)
+	keepGoing, err := chunk.Update(args, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want := []uint16{1, 0, math.MaxUint16, math.MaxUint16, math.MaxUint16, math.MaxUint16}
@@ -432,11 +425,10 @@ func TestMaxSpanChunksSlice_Update_SingleChunk(t *testing.T) {
 	startEpoch := types.Epoch(0)
 	currentEpoch := target
 	args := &chunkUpdateArgs{
-		chunkIndex:     chunkIdx,
-		currentEpoch:   currentEpoch,
-		validatorIndex: validatorIdx,
+		chunkIndex:   chunkIdx,
+		currentEpoch: currentEpoch,
 	}
-	keepGoing, err := chunk.Update(args, startEpoch, target)
+	keepGoing, err := chunk.Update(args, validatorIdx, startEpoch, target)
 	require.NoError(t, err)
 	require.Equal(t, false, keepGoing)
 	want := []uint16{3, 2, 1, 0, 0, 0, 0, 0}

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -101,9 +101,8 @@ func Test_applyAttestationForValidator_MinSpanChunk(t *testing.T) {
 	currentEpoch := types.Epoch(3)
 	validatorIdx := types.ValidatorIndex(0)
 	args := &chunkUpdateArgs{
-		chunkIndex:     chunkIdx,
-		currentEpoch:   currentEpoch,
-		validatorIndex: validatorIdx,
+		chunkIndex:   chunkIdx,
+		currentEpoch: currentEpoch,
 	}
 	chunksByChunkIdx := map[uint64]Chunker{
 		chunkIdx: chunk,
@@ -116,6 +115,7 @@ func Test_applyAttestationForValidator_MinSpanChunk(t *testing.T) {
 	slashing, err := srv.applyAttestationForValidator(
 		ctx,
 		args,
+		validatorIdx,
 		chunksByChunkIdx,
 		att,
 	)
@@ -136,6 +136,7 @@ func Test_applyAttestationForValidator_MinSpanChunk(t *testing.T) {
 	slashing, err = srv.applyAttestationForValidator(
 		ctx,
 		args,
+		validatorIdx,
 		chunksByChunkIdx,
 		slashableAtt,
 	)
@@ -160,9 +161,8 @@ func Test_applyAttestationForValidator_MaxSpanChunk(t *testing.T) {
 	currentEpoch := types.Epoch(3)
 	validatorIdx := types.ValidatorIndex(0)
 	args := &chunkUpdateArgs{
-		chunkIndex:     chunkIdx,
-		currentEpoch:   currentEpoch,
-		validatorIndex: validatorIdx,
+		chunkIndex:   chunkIdx,
+		currentEpoch: currentEpoch,
 	}
 	chunksByChunkIdx := map[uint64]Chunker{
 		chunkIdx: chunk,
@@ -175,6 +175,7 @@ func Test_applyAttestationForValidator_MaxSpanChunk(t *testing.T) {
 	slashing, err := srv.applyAttestationForValidator(
 		ctx,
 		args,
+		validatorIdx,
 		chunksByChunkIdx,
 		att,
 	)
@@ -195,6 +196,7 @@ func Test_applyAttestationForValidator_MaxSpanChunk(t *testing.T) {
 	slashing, err = srv.applyAttestationForValidator(
 		ctx,
 		args,
+		validatorIdx,
 		chunksByChunkIdx,
 		slashableAtt,
 	)


### PR DESCRIPTION
**What type of PR is this?**

Refactor

**What does this PR do? Why is it needed?**

`args` struct should not be mutated inside functions. It is passed as a pointer, therefore mutating it can cause bugs if the struct is reused after calling a function with such side-effects.

There are 2 possible ways to fix this: pass copies of the struct or remove the mutated fields. I opted for the latter, as `args` are to me like options - a read-only collection of information that the function can make use of.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
