### PR TITLE
Clean duplicated topic field in debug log

### DIFF
--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -105,7 +105,7 @@ func (s *Service) subscribeWithBase(topic string, validator pubsub.ValidatorEx, 
 		// Any error subscribing to a PubSub topic would be the result of a misconfiguration of
 		// libp2p PubSub library or a subscription request to a topic that fails to match the topic
 		// subscription filter.
-		log.WithError(err).WithField("topic", topic).Error("Could not subscribe topic")
+		log.WithError(err).Error("Could not subscribe topic")
 		return nil
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**
There was an unnecessary `WithField` statement in the log for "Could not subscribe topic"

**Which issues(s) does this PR fix?**

N/A