### PR TITLE
Move timings of synced block to debug level

### DIFF
--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -41,12 +41,12 @@ func logBlockSyncStatus(block *ethpb.BeaconBlock, blockRoot [32]byte, finalized 
 		return err
 	}
 	log.WithFields(logrus.Fields{
-		"slot":                      block.Slot,
-		"slotInEpoch":               block.Slot % params.BeaconConfig().SlotsPerEpoch,
-		"block":                     fmt.Sprintf("0x%s...", hex.EncodeToString(blockRoot[:])[:8]),
-		"epoch":                     helpers.SlotToEpoch(block.Slot),
-		"finalizedEpoch":            finalized.Epoch,
-		"finalizedRoot":             fmt.Sprintf("0x%s...", hex.EncodeToString(finalized.Root)[:8]),
+		"slot":           block.Slot,
+		"slotInEpoch":    block.Slot % params.BeaconConfig().SlotsPerEpoch,
+		"block":          fmt.Sprintf("0x%s...", hex.EncodeToString(blockRoot[:])[:8]),
+		"epoch":          helpers.SlotToEpoch(block.Slot),
+		"finalizedEpoch": finalized.Epoch,
+		"finalizedRoot":  fmt.Sprintf("0x%s...", hex.EncodeToString(finalized.Root)[:8]),
 	}).Info("Synced new block")
 	log.WithFields(logrus.Fields{
 		"slot":                      block.Slot,

--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -52,6 +52,6 @@ func logBlockSyncStatus(block *ethpb.BeaconBlock, blockRoot [32]byte, finalized 
 		"slot":                      block.Slot,
 		"sinceSlotStartTime":        timeutils.Now().Sub(startTime),
 		"chainServiceProcessedTime": timeutils.Now().Sub(receivedTime),
-	}).Debug("Timings for synced block")
+	}).Debug("Sync new block times")
 	return nil
 }

--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -47,8 +47,11 @@ func logBlockSyncStatus(block *ethpb.BeaconBlock, blockRoot [32]byte, finalized 
 		"epoch":                     helpers.SlotToEpoch(block.Slot),
 		"finalizedEpoch":            finalized.Epoch,
 		"finalizedRoot":             fmt.Sprintf("0x%s...", hex.EncodeToString(finalized.Root)[:8]),
+	}).Info("Synced new block")
+	log.WithFields(logrus.Fields{
+		"slot":                      block.Slot,
 		"sinceSlotStartTime":        timeutils.Now().Sub(startTime),
 		"chainServiceProcessedTime": timeutils.Now().Sub(receivedTime),
-	}).Info("Synced new block")
+	}).Debug("Timings for synced block")
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

Enhancement

**What does this PR do? Why is it needed?**

Moves the timing-related fields in the log message "Synced new block" to a debug level message "Timings for synced block". 

Pros: 

- Less cluttering on the Info level message

Cons:

- Increase in debug size as it adds an entire new message every 12 seconds. 

See https://discord.com/channels/476244492043812875/483017808658169866/812858407203504129