### PR TITLE
Add nil check for validator db migration

### DIFF
--- a/validator/db/kv/migration_source_target_epochs_bucket.go
+++ b/validator/db/kv/migration_source_target_epochs_bucket.go
@@ -51,6 +51,9 @@ func (s *Store) migrateSourceTargetEpochsBucketUp(ctx context.Context) error {
 			bkt := tx.Bucket(pubKeysBucket)
 			for _, pubKey := range batch {
 				pkb := bkt.Bucket(pubKey)
+				if pkb == nil {
+					continue
+				}
 				sourceBucket := pkb.Bucket(attestationSourceEpochsBucket)
 				if sourceBucket == nil {
 					return nil

--- a/validator/db/kv/migration_source_target_epochs_bucket.go
+++ b/validator/db/kv/migration_source_target_epochs_bucket.go
@@ -56,7 +56,7 @@ func (s *Store) migrateSourceTargetEpochsBucketUp(ctx context.Context) error {
 				}
 				sourceBucket := pkb.Bucket(attestationSourceEpochsBucket)
 				if sourceBucket == nil {
-					return nil
+					continue
 				}
 				targetBucket, err := pkb.CreateBucketIfNotExists(attestationTargetEpochsBucket)
 				if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Prevents a panic like the one below.

```
10:48:29" level=error msg="Runtime panic: runtime error: invalid memory address or nil pointer dereference
goroutine 1 [running]:
runtime/debug.Stack(0xc002a87318, 0x33c360, 0x1b5a730)
    GOROOT/src/runtime/debug/stack.go:24 +0x9f
main.main.func3()
    validator/main.go:180 +0x6a
panic(0x33c360, 0x1b5a730)
    GOROOT/src/runtime/panic.go:969 +0x1b9
go.etcd.io/bbolt.(*Bucket).Bucket(0x0, 0x1b82f70, 0x18, 0x18, 0x0)
    external/io_etcd_go_bbolt/bucket.go:97 +0x37
github.com/prysmaticlabs/prysm/validator/db/kv.(*Store).migrateSourceTargetEpochsBucketUp.func2(0xc0000ec0e0, 0x1, 0xc0000ec0e0)
    validator/db/kv/migration_source_target_epochs_bucket.go:54 +0x113
go.etcd.io/bbolt.(*DB).Update(0xc0011b2400, 0xc002a87710, 0x0, 0x0)
    external/io_etcd_go_bbolt/db.go:694 +0x96
github.com/prysmaticlabs/prysm/validator/db/kv.(*Store).migrateSourceTargetEpochsBucketUp(0xc001234cc0, 0x67fce0, 0xc0001ac020, 0x0, 0x0)
    validator/db/kv/migration_source_target_epochs_bucket.go:50 +0x1b0
github.com/prysmaticlabs/prysm/validator/db/kv.(*Store).RunUpMigrations(0xc001234cc0, 0x67fce0, 0xc0001ac020, 0x2c, 0xc0010318e8)
    validator/db/kv/migration.go:23 +0x7a
github.com/prysmaticlabs/prysm/validator/node.(*ValidatorClient).initializeForWeb(0xc0001b31a0, 0xc001234b40, 0xc001031d90, 0x1)
    validator/node/node.go:324 +0x745
github.com/prysmaticlabs/prysm/validator/node.NewValidatorClient(0xc001234b40, 0x0, 0x0, 0xc00011f6e0)
    validator/node/node.go:103 +0x465
main.startNode(0xc001234b40, 0xc00011f600, 0x0)
    validator/main.go:39 +0x4c
github.com/urfave/cli/v2.(*App).RunContext(0xc001224000, 0x67fce0, 0xc0001ac020, 0xc0001b2120, 0x6, 0x6, 0x0, 0x0)
```

**Which issues(s) does this PR fix?**

None reported

**Other notes for review**

Also continue instead of return if a source bucket is nil.