### PR TITLE
Use DeepSSZEqual to satisfy go tests

### DIFF
--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -5,16 +5,16 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"gopkg.in/d4l3k/messagediff.v1"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
-	"gopkg.in/d4l3k/messagediff.v1"
 )
 
 func TestState_CanSaveRetrieve(t *testing.T) {
@@ -57,7 +57,7 @@ func TestGenesisState_CanSaveRetrieve(t *testing.T) {
 
 	savedGenesisS, err := db.GenesisState(context.Background())
 	require.NoError(t, err)
-	assert.DeepEqual(t, st.InnerStateUnsafe(), savedGenesisS.InnerStateUnsafe(), "Did not retrieve saved state")
+	assert.DeepSSZEqual(t, st.InnerStateUnsafe(), savedGenesisS.InnerStateUnsafe(), "Did not retrieve saved state")
 	require.NoError(t, db.SaveGenesisBlockRoot(context.Background(), [32]byte{'C'}))
 }
 
@@ -197,15 +197,15 @@ func TestStore_SaveDeleteState_CanGetHighestBelow(t *testing.T) {
 
 	highest, err := db.HighestSlotStatesBelow(context.Background(), 2)
 	require.NoError(t, err)
-	assert.Equal(t, true, proto.Equal(highest[0].InnerStateUnsafe(), s0), "Did not retrieve saved state: %v != %v", highest, s0)
+	assert.DeepSSZEqual(t, highest[0].InnerStateUnsafe(), s0)
 
 	highest, err = db.HighestSlotStatesBelow(context.Background(), 101)
 	require.NoError(t, err)
-	assert.Equal(t, true, proto.Equal(highest[0].InnerStateUnsafe(), s1), "Did not retrieve saved state: %v != %v", highest, s1)
+	assert.DeepSSZEqual(t, highest[0].InnerStateUnsafe(), s1)
 
 	highest, err = db.HighestSlotStatesBelow(context.Background(), 1001)
 	require.NoError(t, err)
-	assert.Equal(t, true, proto.Equal(highest[0].InnerStateUnsafe(), s2), "Did not retrieve saved state: %v != %v", highest, s2)
+	assert.DeepSSZEqual(t, highest[0].InnerStateUnsafe(), s2)
 }
 
 func TestStore_GenesisState_CanGetHighestBelow(t *testing.T) {
@@ -230,14 +230,14 @@ func TestStore_GenesisState_CanGetHighestBelow(t *testing.T) {
 
 	highest, err := db.HighestSlotStatesBelow(context.Background(), 2)
 	require.NoError(t, err)
-	assert.Equal(t, true, proto.Equal(highest[0].InnerStateUnsafe(), st.InnerStateUnsafe()))
+	assert.DeepSSZEqual(t, highest[0].InnerStateUnsafe(), st.InnerStateUnsafe())
 
 	highest, err = db.HighestSlotStatesBelow(context.Background(), 1)
 	require.NoError(t, err)
-	assert.Equal(t, true, proto.Equal(highest[0].InnerStateUnsafe(), genesisState.InnerStateUnsafe()))
+	assert.DeepSSZEqual(t, highest[0].InnerStateUnsafe(), genesisState.InnerStateUnsafe())
 	highest, err = db.HighestSlotStatesBelow(context.Background(), 0)
 	require.NoError(t, err)
-	assert.Equal(t, true, proto.Equal(highest[0].InnerStateUnsafe(), genesisState.InnerStateUnsafe()))
+	assert.DeepSSZEqual(t, highest[0].InnerStateUnsafe(), genesisState.InnerStateUnsafe())
 }
 
 func TestStore_CleanUpDirtyStates_AboveThreshold(t *testing.T) {

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -7,14 +7,13 @@ import (
 
 	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	"gopkg.in/d4l3k/messagediff.v1"
-
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"gopkg.in/d4l3k/messagediff.v1"
 )
 
 func TestState_CanSaveRetrieve(t *testing.T) {

--- a/beacon-chain/db/restore_test.go
+++ b/beacon-chain/db/restore_test.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"testing"
 
+	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/kv"
 	"github.com/prysmaticlabs/prysm/shared/cmd"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
@@ -65,7 +66,7 @@ func TestRestore(t *testing.T) {
 	require.NoError(t, err)
 	headBlock, err := restoredDb.HeadBlock(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, uint64(5000), headBlock.Block.Slot, "Restored database has incorrect data")
+	assert.Equal(t, types.Slot(5000), headBlock.Block.Slot, "Restored database has incorrect data")
 	assert.LogsContain(t, logHook, "Restore completed successfully")
 
 }

--- a/beacon-chain/operations/attestations/kv/aggregated_test.go
+++ b/beacon-chain/operations/attestations/kv/aggregated_test.go
@@ -512,6 +512,6 @@ func TestKV_Aggregated_DuplicateAggregatedAttestations(t *testing.T) {
 	returned := cache.AggregatedAttestations()
 
 	// It should have only returned att2.
-	assert.DeepEqual(t, att2, returned[0], "Did not receive correct aggregated atts")
+	assert.DeepSSZEqual(t, att2, returned[0], "Did not receive correct aggregated atts")
 	assert.Equal(t, 1, len(returned), "Did not receive correct aggregated atts")
 }

--- a/beacon-chain/rpc/beacon/blocks_test.go
+++ b/beacon-chain/rpc/beacon/blocks_test.go
@@ -152,6 +152,9 @@ func TestServer_ListBlocks_Genesis_MultiBlocks(t *testing.T) {
 }
 
 func TestServer_ListBlocks_Pagination(t *testing.T) {
+	params.UseMinimalConfig()
+	defer params.UseMainnetConfig()
+
 	db := dbTest.SetupDB(t)
 	chain := &chainMock.ChainService{
 		CanonicalRoots: map[[32]byte]bool{},
@@ -357,8 +360,10 @@ func TestServer_GetChainHead_NoHeadBlock(t *testing.T) {
 }
 
 func TestServer_GetChainHead(t *testing.T) {
-	db := dbTest.SetupDB(t)
+	params.UseMinimalConfig()
+	defer params.UseMainnetConfig()
 
+	db := dbTest.SetupDB(t)
 	genBlock := testutil.NewBeaconBlock()
 	genBlock.Block.ParentRoot = bytesutil.PadTo([]byte{'G'}, 32)
 	require.NoError(t, db.SaveBlock(context.Background(), genBlock))

--- a/beacon-chain/rpc/beacon/validators_test.go
+++ b/beacon-chain/rpc/beacon/validators_test.go
@@ -1556,8 +1556,10 @@ func TestServer_GetValidatorParticipation_CurrentAndPrevEpoch(t *testing.T) {
 }
 
 func TestServer_GetValidatorParticipation_OrphanedUntilGenesis(t *testing.T) {
-	beaconDB := dbTest.SetupDB(t)
+	helpers.ClearCache()
+	params.UseMainnetConfig()
 
+	beaconDB := dbTest.SetupDB(t)
 	ctx := context.Background()
 	validatorCount := uint64(100)
 
@@ -1644,6 +1646,10 @@ func TestGetValidatorPerformance_Syncing(t *testing.T) {
 }
 
 func TestGetValidatorPerformance_OK(t *testing.T) {
+	helpers.ClearCache()
+	params.UseMinimalConfig()
+	defer params.UseMainnetConfig()
+
 	ctx := context.Background()
 	epoch := types.Epoch(1)
 	headState, err := testutil.NewBeaconState()
@@ -1916,9 +1922,9 @@ func TestServer_GetIndividualVotes_RequestFutureSlot(t *testing.T) {
 }
 
 func TestServer_GetIndividualVotes_ValidatorsDontExist(t *testing.T) {
-
 	params.UseMinimalConfig()
 	defer params.UseMainnetConfig()
+
 	beaconDB := dbTest.SetupDB(t)
 	ctx := context.Background()
 

--- a/beacon-chain/rpc/validator/aggregator_test.go
+++ b/beacon-chain/rpc/validator/aggregator_test.go
@@ -350,7 +350,7 @@ func TestSubmitAggregateAndProof_PreferOwnAttestation(t *testing.T) {
 
 	res, err := aggregatorServer.SubmitAggregateSelectionProof(ctx, req)
 	require.NoError(t, err)
-	assert.DeepEqual(t, att1, res.AggregateAndProof.Aggregate, "Did not receive wanted attestation")
+	assert.DeepSSZEqual(t, att1, res.AggregateAndProof.Aggregate, "Did not receive wanted attestation")
 }
 
 func TestSubmitAggregateAndProof_SelectsMostBitsWhenOwnAttestationNotPresent(t *testing.T) {
@@ -401,7 +401,7 @@ func TestSubmitAggregateAndProof_SelectsMostBitsWhenOwnAttestationNotPresent(t *
 
 	res, err := aggregatorServer.SubmitAggregateSelectionProof(ctx, req)
 	require.NoError(t, err)
-	assert.DeepEqual(t, att1, res.AggregateAndProof.Aggregate, "Did not receive wanted attestation")
+	assert.DeepSSZEqual(t, att1, res.AggregateAndProof.Aggregate, "Did not receive wanted attestation")
 }
 
 func TestSubmitSignedAggregateSelectionProof_ZeroHashesSignatures(t *testing.T) {

--- a/beacon-chain/state/stategen/epoch_boundary_state_cache_test.go
+++ b/beacon-chain/state/stategen/epoch_boundary_state_cache_test.go
@@ -35,7 +35,7 @@ func TestEpochBoundaryStateCache_CanSave(t *testing.T) {
 	got, exists, err = e.getByRoot([32]byte{'a'})
 	require.NoError(t, err)
 	assert.Equal(t, true, exists, "Should exist")
-	assert.DeepEqual(t, s.InnerStateUnsafe(), got.state.InnerStateUnsafe(), "Should have the same state")
+	assert.DeepSSZEqual(t, s.InnerStateUnsafe(), got.state.InnerStateUnsafe(), "Should have the same state")
 
 	got, exists, err = e.getBySlot(2)
 	require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestEpochBoundaryStateCache_CanSave(t *testing.T) {
 	got, exists, err = e.getBySlot(1)
 	require.NoError(t, err)
 	assert.Equal(t, true, exists, "Should exist")
-	assert.DeepEqual(t, s.InnerStateUnsafe(), got.state.InnerStateUnsafe(), "Should have the same state")
+	assert.DeepSSZEqual(t, s.InnerStateUnsafe(), got.state.InnerStateUnsafe(), "Should have the same state")
 }
 
 func TestEpochBoundaryStateCache_CanTrim(t *testing.T) {

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	types "github.com/prysmaticlabs/eth2-types"
+
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -36,9 +36,7 @@ func TestStateByRoot_ColdState(t *testing.T) {
 	require.NoError(t, service.beaconDB.SaveGenesisBlockRoot(ctx, bRoot))
 	loadedState, err := service.StateByRoot(ctx, bRoot)
 	require.NoError(t, err)
-	if !proto.Equal(loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe()) {
-		t.Error("Did not correctly save state")
-	}
+	require.DeepSSZEqual(t, loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe())
 }
 
 func TestStateByRoot_HotStateUsingEpochBoundaryCacheNoReplay(t *testing.T) {
@@ -97,9 +95,7 @@ func TestStateByRoot_HotStateCached(t *testing.T) {
 
 	loadedState, err := service.StateByRoot(ctx, r)
 	require.NoError(t, err)
-	if !proto.Equal(loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe()) {
-		t.Error("Did not correctly cache state")
-	}
+	require.DeepSSZEqual(t, loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe())
 }
 
 func TestStateByRootInitialSync_UseEpochStateCache(t *testing.T) {
@@ -133,9 +129,7 @@ func TestStateByRootInitialSync_UseCache(t *testing.T) {
 
 	loadedState, err := service.StateByRootInitialSync(ctx, r)
 	require.NoError(t, err)
-	if !proto.Equal(loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe()) {
-		t.Error("Did not correctly cache state")
-	}
+	require.DeepSSZEqual(t, loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe())
 	if service.hotStateCache.has(r) {
 		t.Error("Hot state cache was not invalidated")
 	}
@@ -234,10 +228,7 @@ func TestLoadeStateByRoot_Cached(t *testing.T) {
 	// This tests where hot state was already cached.
 	loadedState, err := service.loadStateByRoot(ctx, r)
 	require.NoError(t, err)
-
-	if !proto.Equal(loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe()) {
-		t.Error("Did not correctly cache state")
-	}
+	require.DeepSSZEqual(t, loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe())
 }
 
 func TestLoadeStateByRoot_FinalizedState(t *testing.T) {
@@ -261,10 +252,7 @@ func TestLoadeStateByRoot_FinalizedState(t *testing.T) {
 	// This tests where hot state was already cached.
 	loadedState, err := service.loadStateByRoot(ctx, gRoot)
 	require.NoError(t, err)
-
-	if !proto.Equal(loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe()) {
-		t.Error("Did not correctly retrieve finalized state")
-	}
+	require.DeepSSZEqual(t, loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe())
 }
 
 func TestLoadeStateByRoot_EpochBoundaryStateCanProcess(t *testing.T) {

--- a/beacon-chain/state/stategen/migrate_test.go
+++ b/beacon-chain/state/stategen/migrate_test.go
@@ -51,7 +51,7 @@ func TestMigrateToCold_HappyPath(t *testing.T) {
 
 	gotState, err := service.beaconDB.State(ctx, fRoot)
 	require.NoError(t, err)
-	assert.DeepEqual(t, beaconState.InnerStateUnsafe(), gotState.InnerStateUnsafe(), "Did not save state")
+	assert.DeepSSZEqual(t, beaconState.InnerStateUnsafe(), gotState.InnerStateUnsafe(), "Did not save state")
 	gotRoot := service.beaconDB.ArchivedPointRoot(ctx, stateSlot/service.slotsPerArchivedPoint)
 	assert.Equal(t, fRoot, gotRoot, "Did not save archived root")
 	lastIndex, err := service.beaconDB.LastArchivedSlot(ctx)

--- a/beacon-chain/state/stategen/replay_test.go
+++ b/beacon-chain/state/stategen/replay_test.go
@@ -364,7 +364,7 @@ func TestLastSavedState_Genesis(t *testing.T) {
 
 	savedState, err := s.lastSavedState(ctx, 0)
 	require.NoError(t, err)
-	require.DeepEqual(t, gState.InnerStateUnsafe(), savedState.InnerStateUnsafe())
+	require.DeepSSZEqual(t, gState.InnerStateUnsafe(), savedState.InnerStateUnsafe())
 }
 
 func TestLastSavedState_CanGet(t *testing.T) {
@@ -394,9 +394,7 @@ func TestLastSavedState_CanGet(t *testing.T) {
 
 	savedState, err := s.lastSavedState(ctx, s.finalizedInfo.slot+100)
 	require.NoError(t, err)
-	if !proto.Equal(st.InnerStateUnsafe(), savedState.InnerStateUnsafe()) {
-		t.Error("Did not save correct root")
-	}
+	require.DeepSSZEqual(t, st.InnerStateUnsafe(), savedState.InnerStateUnsafe())
 }
 
 func TestLastSavedState_NoSavedBlockState(t *testing.T) {

--- a/beacon-chain/state/stategen/service_test.go
+++ b/beacon-chain/state/stategen/service_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
@@ -30,10 +30,7 @@ func TestResume(t *testing.T) {
 
 	resumeState, err := service.Resume(ctx)
 	require.NoError(t, err)
-
-	if !proto.Equal(beaconState.InnerStateUnsafe(), resumeState.InnerStateUnsafe()) {
-		t.Error("Diff saved state")
-	}
+	require.DeepSSZEqual(t, beaconState.InnerStateUnsafe(), resumeState.InnerStateUnsafe())
 	assert.Equal(t, params.BeaconConfig().SlotsPerEpoch, service.finalizedInfo.slot, "Did not get watned slot")
 	assert.Equal(t, service.finalizedInfo.root, root, "Did not get wanted root")
 	assert.NotNil(t, service.finalizedState(), "Wanted a non nil finalized state")

--- a/beacon-chain/state/stategen/service_test.go
+++ b/beacon-chain/state/stategen/service_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"

--- a/beacon-chain/state/types_test.go
+++ b/beacon-chain/state/types_test.go
@@ -27,9 +27,7 @@ func TestBeaconState_ProtoBeaconStateCompatibility(t *testing.T) {
 	cloned, ok := proto.Clone(genesis).(*pb.BeaconState)
 	assert.Equal(t, true, ok, "Object is not of type *pb.BeaconState")
 	custom := customState.CloneInnerState()
-	if !proto.Equal(cloned, custom) {
-		t.Fatal("Cloned states did not match")
-	}
+	assert.DeepSSZEqual(t, cloned, custom)
 
 	r1, err := customState.HashTreeRoot(ctx)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Test

**What does this PR do? Why is it needed?**

Running go test pkg by pkg to get them to pass. This PR fixes
* Usages should have been `DeepSSZEqual`
* Configs should have been `UseMinimalConfig` 
* Slots should have been `types.Slot`

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A