### PR TITLE
Better Handling of Subscriber Errors in Logs Streams

### DIFF
--- a/beacon-chain/rpc/node/server.go
+++ b/beacon-chain/rpc/node/server.go
@@ -225,7 +225,10 @@ func (ns *Server) ListPeers(ctx context.Context, _ *ptypes.Empty) (*ethpb.Peers,
 func (ns *Server) StreamBeaconLogs(_ *ptypes.Empty, stream pb.Health_StreamBeaconLogsServer) error {
 	ch := make(chan []byte, ns.StreamLogsBufferSize)
 	sub := ns.LogsStreamer.LogsFeed().Subscribe(ch)
-	defer sub.Unsubscribe()
+	defer func() {
+		sub.Unsubscribe()
+		close(ch)
+	}()
 
 	recentLogs := ns.LogsStreamer.GetLastFewLogs()
 	logStrings := make([]string, len(recentLogs))

--- a/beacon-chain/rpc/node/server.go
+++ b/beacon-chain/rpc/node/server.go
@@ -224,7 +224,6 @@ func (ns *Server) ListPeers(ctx context.Context, _ *ptypes.Empty) (*ethpb.Peers,
 // StreamBeaconLogs from the beacon node via a gRPC server-side stream.
 func (ns *Server) StreamBeaconLogs(_ *ptypes.Empty, stream pb.Health_StreamBeaconLogsServer) error {
 	ch := make(chan []byte, ns.StreamLogsBufferSize)
-	defer close(ch)
 	sub := ns.LogsStreamer.LogsFeed().Subscribe(ch)
 	defer sub.Unsubscribe()
 
@@ -247,6 +246,8 @@ func (ns *Server) StreamBeaconLogs(_ *ptypes.Empty, stream pb.Health_StreamBeaco
 			if err := stream.Send(resp); err != nil {
 				return status.Errorf(codes.Unavailable, "Could not send over stream: %v", err)
 			}
+		case err := <-sub.Err():
+			return status.Errorf(codes.Canceled, "Subscriber error, closing: %v", err)
 		case <-stream.Context().Done():
 			return status.Error(codes.Canceled, "Context canceled")
 		}

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -259,7 +259,7 @@ func (s *Service) Start() {
 	}
 	nodeServer := &node.Server{
 		LogsStreamer:         logutil.NewStreamServer(),
-		StreamLogsBufferSize: 100, // Enough to handle bursts of beacon node logs for gRPC streaming.
+		StreamLogsBufferSize: 1000, // Enough to handle bursts of beacon node logs for gRPC streaming.
 		BeaconDB:             s.beaconDB,
 		Server:               s.grpcServer,
 		SyncChecker:          s.syncService,

--- a/validator/rpc/health.go
+++ b/validator/rpc/health.go
@@ -82,7 +82,6 @@ func (s *Server) StreamBeaconLogs(req *ptypes.Empty, stream pb.Health_StreamBeac
 // StreamValidatorLogs from the validator client via a gRPC server-side stream.
 func (s *Server) StreamValidatorLogs(_ *ptypes.Empty, stream pb.Health_StreamValidatorLogsServer) error {
 	ch := make(chan []byte, s.streamLogsBufferSize)
-	defer close(ch)
 	sub := s.logsStreamer.LogsFeed().Subscribe(ch)
 	defer sub.Unsubscribe()
 
@@ -107,6 +106,8 @@ func (s *Server) StreamValidatorLogs(_ *ptypes.Empty, stream pb.Health_StreamVal
 			}
 		case <-s.ctx.Done():
 			return status.Error(codes.Canceled, "Context canceled")
+		case err := <-sub.Err():
+			return status.Errorf(codes.Canceled, "Subscriber error, closing: %v", err)
 		case <-stream.Context().Done():
 			return status.Error(codes.Canceled, "Context canceled")
 		}

--- a/validator/rpc/health.go
+++ b/validator/rpc/health.go
@@ -83,7 +83,10 @@ func (s *Server) StreamBeaconLogs(req *ptypes.Empty, stream pb.Health_StreamBeac
 func (s *Server) StreamValidatorLogs(_ *ptypes.Empty, stream pb.Health_StreamValidatorLogsServer) error {
 	ch := make(chan []byte, s.streamLogsBufferSize)
 	sub := s.logsStreamer.LogsFeed().Subscribe(ch)
-	defer sub.Unsubscribe()
+	defer func() {
+		sub.Unsubscribe()
+		defer close(ch)
+	}()
 
 	recentLogs := s.logsStreamer.GetLastFewLogs()
 	logStrings := make([]string, len(recentLogs))


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Thanks to @nisdas, after doing some investigation of why the beacon node gets into a deadlock when running the web ui, he was able to identify the following offender:

```
#    0x14d760f    reflect.rselect+0x38f                                        GOROOT/src/runtime/select.go:566
#    0x151773b    reflect.Select+0x19b                                        GOROOT/src/reflect/value.go:2260
#    0x1f2ca44    github.com/prysmaticlabs/prysm/shared/event.(*Feed).Send+0x5a4                    shared/event/feed.go:170
#    0x24caab2    github.com/prysmaticlabs/prysm/shared/logutil.(*StreamServer).Write+0x72            shared/logutil/stream.go:69
#    0x152ad66    io.(*multiWriter).Write+0x86
```

Essentially, the subscriber to the event feed where beacon node logs are being sent to is blocked and does not get unblocked at all.

```go
func (ns *Server) StreamBeaconLogs(_ *ptypes.Empty, stream pb.Health_StreamBeaconLogsServer) error {
    ch := make(chan []byte, ns.StreamLogsBufferSize)
    defer close(ch)
    sub := ns.LogsStreamer.LogsFeed().Subscribe(ch)
    defer sub.Unsubscribe()
```

We believe the buffer size is too small, and also, we should not be defer closing a buffered channel this way in a grpc call. Additionally, we were **not handling** a select case for subscriber errors. If there was ever an error in the subscription, we would never exit the function and likely that's where the beacon node logs were getting stuck without our awareness.

**Which issues(s) does this PR fix?**

Fixes #8430
