### PR TITLE
Use eth2-types SSZUint64

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -88,6 +88,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
+        "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/p2p/rpc_topic_mappings.go
+++ b/beacon-chain/p2p/rpc_topic_mappings.go
@@ -4,7 +4,8 @@ import (
 	"reflect"
 
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
+	types "github.com/prysmaticlabs/eth2-types"
+	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 
@@ -31,7 +32,7 @@ var RPCTopicMappings = map[string]interface{}{
 	RPCStatusTopic:        new(pb.Status),
 	RPCGoodByeTopic:       new(types.SSZUint64),
 	RPCBlocksByRangeTopic: new(pb.BeaconBlocksByRangeRequest),
-	RPCBlocksByRootTopic:  new(types.BeaconBlockByRootsReq),
+	RPCBlocksByRootTopic:  new(p2ptypes.BeaconBlockByRootsReq),
 	RPCPingTopic:          new(types.SSZUint64),
 	RPCMetaDataTopic:      new(interface{}),
 }

--- a/beacon-chain/p2p/types/BUILD.bazel
+++ b/beacon-chain/p2p/types/BUILD.bazel
@@ -16,10 +16,10 @@ go_library(
         "//validator/client:__pkg__",
     ],
     deps = [
-        "//shared/htrutils:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_ferranbt_fastssz//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prysmaticlabs_eth2_types//:go_default_library",
     ],
 )
 

--- a/beacon-chain/p2p/types/rpc_goodbye_codes.go
+++ b/beacon-chain/p2p/types/rpc_goodbye_codes.go
@@ -1,7 +1,11 @@
 package types
 
+import (
+	types "github.com/prysmaticlabs/eth2-types"
+)
+
 // RPCGoodbyeCode represents goodbye code, used in sync package.
-type RPCGoodbyeCode = SSZUint64
+type RPCGoodbyeCode = types.SSZUint64
 
 const (
 	// Spec defined codes.

--- a/beacon-chain/p2p/types/types.go
+++ b/beacon-chain/p2p/types/types.go
@@ -6,7 +6,6 @@ package types
 import (
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/shared/htrutils"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
@@ -14,53 +13,7 @@ const rootLength = 32
 
 const maxErrorLength = 256
 
-// SSZUint64 is a uint64 type that satisfies the fast-ssz interface.
-type SSZUint64 uint64
-
-// SizeSSZ returns the size of the serialized representation.
-func (s *SSZUint64) SizeSSZ() int {
-	return 8
-}
-
-// MarshalSSZTo marshals the uint64 with the provided byte slice.
-func (s *SSZUint64) MarshalSSZTo(dst []byte) ([]byte, error) {
-	marshalledObj, err := s.MarshalSSZ()
-	if err != nil {
-		return nil, err
-	}
-	return append(dst, marshalledObj...), nil
-}
-
-// MarshalSSZ Marshals the uint64 type into the serialized object.
-func (s *SSZUint64) MarshalSSZ() ([]byte, error) {
-	marshalledObj := ssz.MarshalUint64([]byte{}, uint64(*s))
-	return marshalledObj, nil
-}
-
-// UnmarshalSSZ unmarshals the provided bytes buffer into the
-// uint64 object.
-func (s *SSZUint64) UnmarshalSSZ(buf []byte) error {
-	if len(buf) != s.SizeSSZ() {
-		return errors.Errorf("expected buffer with length of %d but received length %d", s.SizeSSZ(), len(buf))
-	}
-	*s = SSZUint64(ssz.UnmarshallUint64(buf))
-	return nil
-}
-
-// HashTreeRoot hashes the uint64 object following the SSZ standard.
-func (s *SSZUint64) HashTreeRoot() ([32]byte, error) {
-	return htrutils.Uint64Root(uint64(*s)), nil
-}
-
-// HashTreeRootWith hashes the uint64 object with the given hasher.
-func (s *SSZUint64) HashTreeRootWith(hh *ssz.Hasher) error {
-	indx := hh.Index()
-	hh.PutUint64(uint64(*s))
-	hh.Merkleize(indx)
-	return nil
-}
-
-// SSZUint64 is a bytes slice that satisfies the fast-ssz interface.
+// SSZBytes is a bytes slice that satisfies the fast-ssz interface.
 type SSZBytes []byte
 
 // HashTreeRoot hashes the uint64 object following the SSZ standard.

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/peers"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
-	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/abool"
 	"github.com/prysmaticlabs/prysm/shared/attestationutil"
@@ -95,7 +94,7 @@ func TestProcessPendingAtts_HasBlockSaveUnAggregatedAtt(t *testing.T) {
 
 	// Arbitrary aggregator index for testing purposes.
 	aggregatorIndex := committee[0]
-	sszUint := p2ptypes.SSZUint64(att.Data.Slot)
+	sszUint := types.SSZUint64(att.Data.Slot)
 	sig, err := helpers.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
 	require.NoError(t, err)
 	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
@@ -210,7 +209,7 @@ func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
 
 	// Arbitrary aggregator index for testing purposes.
 	aggregatorIndex := committee[0]
-	sszSlot := p2ptypes.SSZUint64(att.Data.Slot)
+	sszSlot := types.SSZUint64(att.Data.Slot)
 	sig, err := helpers.ComputeDomainAndSign(s, 0, &sszSlot, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
 	require.NoError(t, err)
 	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
@@ -287,7 +286,7 @@ func TestProcessPendingAtts_HasBlockSaveAggregatedAtt(t *testing.T) {
 
 	// Arbitrary aggregator index for testing purposes.
 	aggregatorIndex := committee[0]
-	sszUint := p2ptypes.SSZUint64(att.Data.Slot)
+	sszUint := types.SSZUint64(att.Data.Slot)
 	sig, err := helpers.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[aggregatorIndex])
 	require.NoError(t, err)
 	aggregateAndProof := &ethpb.AggregateAttestationAndProof{

--- a/beacon-chain/sync/rpc_goodbye_test.go
+++ b/beacon-chain/sync/rpc_goodbye_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kevinms/leakybucket-go"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/protocol"
+	types "github.com/prysmaticlabs/eth2-types"
 	db "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
 	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
@@ -156,7 +157,7 @@ func TestSendGoodbye_SendsMessage(t *testing.T) {
 	wg.Add(1)
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
-		out := new(p2ptypes.SSZUint64)
+		out := new(types.SSZUint64)
 		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
 		assert.Equal(t, failureCode, *out)
 		assert.NoError(t, stream.Close())
@@ -198,7 +199,7 @@ func TestSendGoodbye_DisconnectWithPeer(t *testing.T) {
 	wg.Add(1)
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
-		out := new(p2ptypes.SSZUint64)
+		out := new(types.SSZUint64)
 		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
 		assert.Equal(t, failureCode, *out)
 		assert.NoError(t, stream.Close())

--- a/beacon-chain/sync/rpc_ping.go
+++ b/beacon-chain/sync/rpc_ping.go
@@ -8,8 +8,9 @@ import (
 
 	libp2pcore "github.com/libp2p/go-libp2p-core"
 	"github.com/libp2p/go-libp2p-core/peer"
+	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
-	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
+	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
 	"github.com/prysmaticlabs/prysm/shared/timeutils"
 )
 
@@ -28,9 +29,9 @@ func (s *Service) pingHandler(_ context.Context, msg interface{}, stream libp2pc
 	valid, err := s.validateSequenceNum(*m, stream.Conn().RemotePeer())
 	if err != nil {
 		// Descore peer for giving us a bad sequence number.
-		if errors.Is(err, types.ErrInvalidSequenceNum) {
+		if errors.Is(err, p2ptypes.ErrInvalidSequenceNum) {
 			s.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
-			s.writeErrorResponseToStream(responseCodeInvalidRequest, types.ErrInvalidSequenceNum.Error(), stream)
+			s.writeErrorResponseToStream(responseCodeInvalidRequest, p2ptypes.ErrInvalidSequenceNum.Error(), stream)
 		}
 		return err
 	}
@@ -59,7 +60,7 @@ func (s *Service) pingHandler(_ context.Context, msg interface{}, stream libp2pc
 			// We cannot compare errors directly as the stream muxer error
 			// type isn't compatible with the error we have, so a direct
 			// equality checks fails.
-			if !strings.Contains(err.Error(), types.ErrIODeadline.Error()) {
+			if !strings.Contains(err.Error(), p2ptypes.ErrIODeadline.Error()) {
 				log.WithField("peer", stream.Conn().RemotePeer()).WithError(err).Debug("Could not send metadata request")
 			}
 			return
@@ -101,7 +102,7 @@ func (s *Service) sendPingRequest(ctx context.Context, id peer.ID) error {
 	valid, err := s.validateSequenceNum(*msg, stream.Conn().RemotePeer())
 	if err != nil {
 		// Descore peer for giving us a bad sequence number.
-		if errors.Is(err, types.ErrInvalidSequenceNum) {
+		if errors.Is(err, p2ptypes.ErrInvalidSequenceNum) {
 			s.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 		}
 		return err
@@ -130,7 +131,7 @@ func (s *Service) validateSequenceNum(seq types.SSZUint64, id peer.ID) (bool, er
 	}
 	// Return error on invalid sequence number.
 	if md.SeqNumber > uint64(seq) {
-		return false, types.ErrInvalidSequenceNum
+		return false, p2ptypes.ErrInvalidSequenceNum
 	}
 	return md.SeqNumber == uint64(seq), nil
 }

--- a/beacon-chain/sync/rpc_ping_test.go
+++ b/beacon-chain/sync/rpc_ping_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kevinms/leakybucket-go"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/protocol"
+	types "github.com/prysmaticlabs/eth2-types"
 	db "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
 	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
@@ -54,13 +55,13 @@ func TestPingRPCHandler_ReceivesPing(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
 		expectSuccess(t, stream)
-		out := new(p2ptypes.SSZUint64)
+		out := new(types.SSZUint64)
 		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
 		assert.Equal(t, uint64(2), uint64(*out))
 	})
 	stream1, err := p1.BHost.NewStream(context.Background(), p2.BHost.ID(), pcl)
 	require.NoError(t, err)
-	seqNumber := p2ptypes.SSZUint64(2)
+	seqNumber := types.SSZUint64(2)
 
 	assert.NoError(t, r.pingHandler(context.Background(), &seqNumber, stream1))
 
@@ -117,7 +118,7 @@ func TestPingRPCHandler_SendsPing(t *testing.T) {
 	wg.Add(1)
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
-		out := new(p2ptypes.SSZUint64)
+		out := new(types.SSZUint64)
 		assert.NoError(t, r2.p2p.Encoding().DecodeWithMaxLength(stream, out))
 		assert.Equal(t, uint64(2), uint64(*out))
 		assert.NoError(t, r2.pingHandler(context.Background(), out, stream))
@@ -180,7 +181,7 @@ func TestPingRPCHandler_BadSequenceNumber(t *testing.T) {
 	stream1, err := p1.BHost.NewStream(context.Background(), p2.BHost.ID(), pcl)
 	require.NoError(t, err)
 
-	wantedSeq := p2ptypes.SSZUint64(p2.LocalMetadata.SeqNumber)
+	wantedSeq := types.SSZUint64(p2.LocalMetadata.SeqNumber)
 	err = r.pingHandler(context.Background(), &wantedSeq, stream1)
 	assert.ErrorContains(t, p2ptypes.ErrInvalidSequenceNum.Error(), err)
 

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -75,7 +75,7 @@ func TestStatusRPCHandler_Disconnects_OnForkVersionMismatch(t *testing.T) {
 	wg2.Add(1)
 	p2.BHost.SetStreamHandler(pcl2, func(stream network.Stream) {
 		defer wg2.Done()
-		msg := new(p2ptypes.SSZUint64)
+		msg := new(types.SSZUint64)
 		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, msg))
 		assert.Equal(t, p2ptypes.GoodbyeCodeWrongNetwork, *msg)
 		assert.NoError(t, stream.Close())
@@ -321,7 +321,7 @@ func TestHandshakeHandlers_Roundtrip(t *testing.T) {
 	wg2.Add(1)
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg2.Done()
-		out := new(p2ptypes.SSZUint64)
+		out := new(types.SSZUint64)
 		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
 		assert.Equal(t, uint64(2), uint64(*out))
 		assert.NoError(t, r2.pingHandler(context.Background(), out, stream))

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
-	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -263,7 +262,7 @@ func validateSelectionIndex(ctx context.Context, bs *stateTrie.BeaconState, data
 	if err != nil {
 		return nil, err
 	}
-	sszUint := p2ptypes.SSZUint64(data.Slot)
+	sszUint := types.SSZUint64(data.Slot)
 	root, err := helpers.ComputeSigningRoot(&sszUint, d)
 	if err != nil {
 		return nil, err

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
-	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
 	"github.com/prysmaticlabs/prysm/shared/attestationutil"
 	"github.com/prysmaticlabs/prysm/shared/bls"
@@ -334,7 +333,7 @@ func TestValidateAggregateAndProof_CanValidate(t *testing.T) {
 	}
 	att.Signature = bls.AggregateSignatures(sigs).Marshal()
 	ai := committee[0]
-	sszUint := p2ptypes.SSZUint64(att.Data.Slot)
+	sszUint := types.SSZUint64(att.Data.Slot)
 	sig, err := helpers.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
 	require.NoError(t, err)
 	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
@@ -423,7 +422,7 @@ func TestVerifyIndexInCommittee_SeenAggregatorEpoch(t *testing.T) {
 	}
 	att.Signature = bls.AggregateSignatures(sigs).Marshal()
 	ai := committee[0]
-	sszUint := p2ptypes.SSZUint64(att.Data.Slot)
+	sszUint := types.SSZUint64(att.Data.Slot)
 	sig, err := helpers.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
 	require.NoError(t, err)
 	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
@@ -531,7 +530,7 @@ func TestValidateAggregateAndProof_BadBlock(t *testing.T) {
 	}
 	att.Signature = bls.AggregateSignatures(sigs).Marshal()
 	ai := committee[0]
-	sszUint := p2ptypes.SSZUint64(att.Data.Slot)
+	sszUint := types.SSZUint64(att.Data.Slot)
 	sig, err := helpers.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
 	require.NoError(t, err)
 
@@ -621,7 +620,7 @@ func TestValidateAggregateAndProof_RejectWhenAttEpochDoesntEqualTargetEpoch(t *t
 	}
 	att.Signature = bls.AggregateSignatures(sigs).Marshal()
 	ai := committee[0]
-	sszUint := p2ptypes.SSZUint64(att.Data.Slot)
+	sszUint := types.SSZUint64(att.Data.Slot)
 	sig, err := helpers.ComputeDomainAndSign(beaconState, 0, &sszUint, params.BeaconConfig().DomainSelectionProof, privKeys[ai])
 	require.NoError(t, err)
 	aggregateAndProof := &ethpb.AggregateAttestationAndProof{

--- a/deps.bzl
+++ b/deps.bzl
@@ -2571,8 +2571,8 @@ def prysm_deps():
     go_repository(
         name = "com_github_prysmaticlabs_eth2_types",
         importpath = "github.com/prysmaticlabs/eth2-types",
-        sum = "h1:6ooFkN9g9oAJq+VZWseIpj/tQqyVU0DuLFs66Ro43BQ=",
-        version = "v0.0.0-20210210115503-cf4ec6600a2d",
+        sum = "h1:b4WxLSz1KzkEdF/DPcog9gIKN9d9YAFgbZO1hqjNrW0=",
+        version = "v0.0.0-20210219172114-1da477c09a06",
     )
     go_repository(
         name = "com_github_prysmaticlabs_ethereumapis",

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/prometheus/procfs v0.3.0 // indirect
 	github.com/prometheus/tsdb v0.10.0 // indirect
-	github.com/prysmaticlabs/eth2-types v0.0.0-20210210115503-cf4ec6600a2d
+	github.com/prysmaticlabs/eth2-types v0.0.0-20210219172114-1da477c09a06
 	github.com/prysmaticlabs/ethereumapis v0.0.0-20210218195742-a393edb60549
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20210202205921-7fcea7c45dc8
 	github.com/prysmaticlabs/prombbolt v0.0.0-20210126082820-9b7adba6db7c

--- a/go.sum
+++ b/go.sum
@@ -1026,8 +1026,8 @@ github.com/prometheus/tsdb v0.10.0/go.mod h1:oi49uRhEe9dPUTlS3JRZOwJuVi6tmh10QSg
 github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20210222122116-71d15f72c132 h1:UB0glz/7DDQQvx8uh6CEpZ++dYa6G6WzjQe6Ev3PI2g=
 github.com/prysmaticlabs/bazel-go-ethereum v0.0.0-20210222122116-71d15f72c132/go.mod h1:JIfVb6esrqALTExdz9hRYvrP0xBDf6wCncIu1hNwHpM=
 github.com/prysmaticlabs/eth2-types v0.0.0-20210127031309-22cbe426eba6/go.mod h1:kOmQ/zdobQf7HUohDTifDNFEZfNaSCIY5fkONPL+dWU=
-github.com/prysmaticlabs/eth2-types v0.0.0-20210210115503-cf4ec6600a2d h1:6ooFkN9g9oAJq+VZWseIpj/tQqyVU0DuLFs66Ro43BQ=
-github.com/prysmaticlabs/eth2-types v0.0.0-20210210115503-cf4ec6600a2d/go.mod h1:kOmQ/zdobQf7HUohDTifDNFEZfNaSCIY5fkONPL+dWU=
+github.com/prysmaticlabs/eth2-types v0.0.0-20210219172114-1da477c09a06 h1:b4WxLSz1KzkEdF/DPcog9gIKN9d9YAFgbZO1hqjNrW0=
+github.com/prysmaticlabs/eth2-types v0.0.0-20210219172114-1da477c09a06/go.mod h1:kOmQ/zdobQf7HUohDTifDNFEZfNaSCIY5fkONPL+dWU=
 github.com/prysmaticlabs/ethereumapis v0.0.0-20210218195742-a393edb60549 h1:GhzZ3sO2ZiuJxxm3dyBps+tDaVu3q7xMdJD2yJXyuDs=
 github.com/prysmaticlabs/ethereumapis v0.0.0-20210218195742-a393edb60549/go.mod h1:YS3iOCGE+iVDE007GHWtj+UoPK9hyYA7Fo4mSDNTtiY=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20200322041314-62c2aee71669/go.mod h1:hCwmef+4qXWjv0jLDbQdWnL0Ol7cS7/lCSS26WR+u6s=

--- a/shared/testutil/BUILD.bazel
+++ b/shared/testutil/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
-        "//beacon-chain/p2p/types:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bls:go_default_library",
@@ -56,7 +55,6 @@ go_test(
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/core/state/stateutils:go_default_library",
-        "//beacon-chain/p2p/types:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",

--- a/shared/testutil/helpers.go
+++ b/shared/testutil/helpers.go
@@ -10,7 +10,6 @@ import (
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
-	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
 	stateTrie "github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -28,7 +27,7 @@ func RandaoReveal(beaconState *stateTrie.BeaconState, epoch types.Epoch, privKey
 	binary.LittleEndian.PutUint64(buf, uint64(epoch))
 
 	// We make the previous validator's index sign the message instead of the proposer.
-	sszEpoch := p2ptypes.SSZUint64(epoch)
+	sszEpoch := types.SSZUint64(epoch)
 	return helpers.ComputeDomainAndSign(beaconState, epoch, &sszEpoch, params.BeaconConfig().DomainRandao, privKeys[proposerIdx])
 }
 

--- a/shared/testutil/helpers_test.go
+++ b/shared/testutil/helpers_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/binary"
 	"testing"
 
+	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -46,7 +46,7 @@ func TestRandaoReveal(t *testing.T) {
 	buf := make([]byte, 32)
 	binary.LittleEndian.PutUint64(buf, uint64(epoch))
 	// We make the previous validator's index sign the message instead of the proposer.
-	sszUint := p2ptypes.SSZUint64(epoch)
+	sszUint := types.SSZUint64(epoch)
 	epochSignature, err := helpers.ComputeDomainAndSign(beaconState, epoch, &sszUint, params.BeaconConfig().DomainRandao, privKeys[proposerIdx])
 	require.NoError(t, err)
 

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -22,7 +22,6 @@ go_library(
     visibility = ["//validator:__subpackages__"],
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
-        "//beacon-chain/p2p/types:go_default_library",
         "//proto/validator/accounts/v2:go_default_library",
         "//shared/blockutil:go_default_library",
         "//shared/bls:go_default_library",

--- a/validator/client/aggregate.go
+++ b/validator/client/aggregate.go
@@ -8,7 +8,6 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
 	validatorpb "github.com/prysmaticlabs/prysm/proto/validator/accounts/v2"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -125,7 +124,7 @@ func (v *validator) signSlot(ctx context.Context, pubKey [48]byte, slot types.Sl
 	}
 
 	var sig bls.Signature
-	sszUint := p2ptypes.SSZUint64(slot)
+	sszUint := types.SSZUint64(slot)
 	root, err := helpers.ComputeSigningRoot(&sszUint, domain.SignatureDomain)
 	if err != nil {
 		return nil, err

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -11,7 +11,6 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
 	validatorpb "github.com/prysmaticlabs/prysm/proto/validator/accounts/v2"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -202,7 +201,7 @@ func (v *validator) signRandaoReveal(ctx context.Context, pubKey [48]byte, epoch
 	}
 
 	var randaoReveal bls.Signature
-	sszUint := p2ptypes.SSZUint64(epoch)
+	sszUint := types.SSZUint64(epoch)
 	root, err := helpers.ComputeSigningRoot(&sszUint, domain.SignatureDomain)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Follow up of discussion here: https://github.com/prysmaticlabs/prysm/pull/8257#discussion_r556770945. `p2p/types` defined some basic `SSZType` and are extracted to `sszutil/types` as they are not specific to `p2p`. This PR used `SSZUint64` from `eth2-types`.

**Which issues(s) does this PR fix?**

**Other notes for review**

@nisdas' [suggestion](https://github.com/prysmaticlabs/prysm/pull/8464#pullrequestreview-592825149).