### PR TITLE
Implement SubmitAttesterSlashing in the beacon API

### DIFF
--- a/beacon-chain/operations/slashings/mock.go
+++ b/beacon-chain/operations/slashings/mock.go
@@ -14,31 +14,32 @@ type PoolMock struct {
 }
 
 // PendingAttesterSlashings --
-func (m *PoolMock) PendingAttesterSlashings(ctx context.Context, state *state.BeaconState, noLimit bool) []*ethpb.AttesterSlashing {
+func (m *PoolMock) PendingAttesterSlashings(_ context.Context, _ *state.BeaconState, _ bool) []*ethpb.AttesterSlashing {
 	return m.PendingAttSlashings
 }
 
 // PendingProposerSlashings --
-func (m *PoolMock) PendingProposerSlashings(ctx context.Context, state *state.BeaconState, noLimit bool) []*ethpb.ProposerSlashing {
+func (m *PoolMock) PendingProposerSlashings(_ context.Context, _ *state.BeaconState, _ bool) []*ethpb.ProposerSlashing {
 	return m.PendingPropSlashings
 }
 
 // InsertAttesterSlashing --
-func (m *PoolMock) InsertAttesterSlashing(ctx context.Context, state *state.BeaconState, slashing *ethpb.AttesterSlashing) error {
-	panic("implement me")
+func (m *PoolMock) InsertAttesterSlashing(_ context.Context, _ *state.BeaconState, slashing *ethpb.AttesterSlashing) error {
+	m.PendingAttSlashings = append(m.PendingAttSlashings, slashing)
+	return nil
 }
 
 // InsertProposerSlashing --
-func (m *PoolMock) InsertProposerSlashing(ctx context.Context, state *state.BeaconState, slashing *ethpb.ProposerSlashing) error {
+func (m *PoolMock) InsertProposerSlashing(_ context.Context, _ *state.BeaconState, _ *ethpb.ProposerSlashing) error {
 	panic("implement me")
 }
 
 // MarkIncludedAttesterSlashing --
-func (m *PoolMock) MarkIncludedAttesterSlashing(as *ethpb.AttesterSlashing) {
+func (m *PoolMock) MarkIncludedAttesterSlashing(_ *ethpb.AttesterSlashing) {
 	panic("implement me")
 }
 
 // MarkIncludedProposerSlashing --
-func (m *PoolMock) MarkIncludedProposerSlashing(ps *ethpb.ProposerSlashing) {
+func (m *PoolMock) MarkIncludedProposerSlashing(_ *ethpb.ProposerSlashing) {
 	panic("implement me")
 }

--- a/beacon-chain/rpc/beaconv1/BUILD.bazel
+++ b/beacon-chain/rpc/beaconv1/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//beacon-chain/blockchain:go_default_library",
         "//beacon-chain/cache/depositcache:go_default_library",
+        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/block:go_default_library",
         "//beacon-chain/core/feed/operation:go_default_library",
@@ -35,6 +36,7 @@ go_library(
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/migration:go_default_library",
         "//shared/bytesutil:go_default_library",
+        "//shared/featureconfig:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_gogo_protobuf//types:go_default_library",
@@ -61,6 +63,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/db/testing:go_default_library",
         "//beacon-chain/operations/slashings:go_default_library",
@@ -70,6 +73,7 @@ go_test(
         "//beacon-chain/state/stategen:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//proto/migration:go_default_library",
+        "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",

--- a/proto/migration/BUILD.bazel
+++ b/proto/migration/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@prysm//tools/go:def.bzl", "go_library")
 
 go_library(
@@ -9,6 +10,20 @@ go_library(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["migration_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//shared/bytesutil:go_default_library",
+        "//shared/testutil:go_default_library",
+        "//shared/testutil/assert:go_default_library",
+        "//shared/testutil/require:go_default_library",
+        "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
     ],
 )

--- a/proto/migration/BUILD.bazel
+++ b/proto/migration/BUILD.bazel
@@ -12,4 +12,3 @@ go_library(
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
     ],
 )
-

--- a/proto/migration/BUILD.bazel
+++ b/proto/migration/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@prysm//tools/go:def.bzl", "go_library")
 
 go_library(
@@ -14,16 +13,3 @@ go_library(
     ],
 )
 
-go_test(
-    name = "go_default_test",
-    srcs = ["migration_test.go"],
-    embed = [":go_default_library"],
-    deps = [
-        "//shared/bytesutil:go_default_library",
-        "//shared/testutil:go_default_library",
-        "//shared/testutil/assert:go_default_library",
-        "//shared/testutil/require:go_default_library",
-        "@com_github_prysmaticlabs_eth2_types//:go_default_library",
-        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
-    ],
-)

--- a/proto/migration/migration.go
+++ b/proto/migration/migration.go
@@ -135,3 +135,46 @@ func V1Alpha1ExitToV1(v1alpha1Exit *ethpb_alpha.SignedVoluntaryExit) *ethpb.Sign
 		Signature: v1alpha1Exit.Signature,
 	}
 }
+
+// V1IndexedAttToV1Alpha1 converts a v1 indexed attestation to v1alpha1.
+func V1IndexedAttToV1Alpha1(v1Att *ethpb.IndexedAttestation) *ethpb_alpha.IndexedAttestation {
+	if v1Att == nil {
+		return &ethpb_alpha.IndexedAttestation{}
+	}
+	return &ethpb_alpha.IndexedAttestation{
+		AttestingIndices: v1Att.AttestingIndices,
+		Data:             V1AttDataToV1Alpha1(v1Att.Data),
+		Signature:        v1Att.Signature,
+	}
+}
+
+// V1AttDataToV1Alpha1 converts a v1 attestation data to v1alpha1.
+func V1AttDataToV1Alpha1(v1AttData *ethpb.AttestationData) *ethpb_alpha.AttestationData {
+	if v1AttData == nil || v1AttData.Source == nil || v1AttData.Target == nil {
+		return &ethpb_alpha.AttestationData{}
+	}
+	return &ethpb_alpha.AttestationData{
+		Slot:            v1AttData.Slot,
+		CommitteeIndex:  v1AttData.CommitteeIndex,
+		BeaconBlockRoot: v1AttData.BeaconBlockRoot,
+		Source: &ethpb_alpha.Checkpoint{
+			Root:  v1AttData.Source.Root,
+			Epoch: v1AttData.Source.Epoch,
+		},
+		Target: &ethpb_alpha.Checkpoint{
+			Root:  v1AttData.Target.Root,
+			Epoch: v1AttData.Target.Epoch,
+		},
+	}
+}
+
+// V1AttSlashingToV1Alpha1 converts a v1 attester slashing to v1alpha1.
+func V1AttSlashingToV1Alpha1(v1Slashing *ethpb.AttesterSlashing) *ethpb_alpha.AttesterSlashing {
+	if v1Slashing == nil {
+		return &ethpb_alpha.AttesterSlashing{}
+	}
+	return &ethpb_alpha.AttesterSlashing{
+		Attestation_1: V1IndexedAttToV1Alpha1(v1Slashing.Attestation_1),
+		Attestation_2: V1IndexedAttToV1Alpha1(v1Slashing.Attestation_2),
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Feature

What does this PR do? Why is it needed?

This PR implements beacon API's `SubmitAttesterSlashing` method according to the spec: https://ethereum.github.io/eth2.0-APIs/#/Beacon/submitPoolAttesterSlashings

Which issues(s) does this PR fix?

Part of #7510

Other notes for review

This PR does not contain tests for code added to the `migration` package. This will be included in a separate PR.
