### PR TITLE
 HF1: Add penalty config values

### DIFF
--- a/beacon-chain/rpc/beaconv1/config_test.go
+++ b/beacon-chain/rpc/beaconv1/config_test.go
@@ -61,13 +61,16 @@ func TestGetSpec(t *testing.T) {
 	config.WhistleBlowerRewardQuotient = 40
 	config.ProposerRewardQuotient = 41
 	config.InactivityPenaltyQuotient = 42
-	config.MinSlashingPenaltyQuotient = 43
-	config.ProportionalSlashingMultiplier = 44
-	config.MaxProposerSlashings = 45
-	config.MaxAttesterSlashings = 46
-	config.MaxAttestations = 47
-	config.MaxDeposits = 48
-	config.MaxVoluntaryExits = 49
+	config.InactivityPenaltyQuotientHF1 = 43
+	config.MinSlashingPenaltyQuotient = 44
+	config.MinSlashingPenaltyQuotientHF1 = 45
+	config.ProportionalSlashingMultiplier = 46
+	config.ProportionalSlashingMultiplierHF1 = 47
+	config.MaxProposerSlashings = 48
+	config.MaxAttesterSlashings = 49
+	config.MaxAttestations = 50
+	config.MaxDeposits = 51
+	config.MaxVoluntaryExits = 52
 
 	var dbp [4]byte
 	copy(dbp[:], []byte{'0', '0', '0', '1'})
@@ -97,7 +100,7 @@ func TestGetSpec(t *testing.T) {
 	resp, err := server.GetSpec(context.Background(), &pbtypes.Empty{})
 	require.NoError(t, err)
 
-	assert.Equal(t, 60, len(resp.Data))
+	assert.Equal(t, 62, len(resp.Data))
 	for k, v := range resp.Data {
 		switch k {
 		case "config_name":
@@ -192,20 +195,26 @@ func TestGetSpec(t *testing.T) {
 			assert.Equal(t, "41", v)
 		case "inactivity_penalty_quotient":
 			assert.Equal(t, "42", v)
-		case "min_slashing_penalty_quotient":
+		case "hf1_inactivity_penalty_quotient":
 			assert.Equal(t, "43", v)
-		case "proportional_slashing_multiplier":
+		case "min_slashing_penalty_quotient":
 			assert.Equal(t, "44", v)
-		case "max_proposer_slashings":
+		case "hf1_min_slashing_penalty_quotient":
 			assert.Equal(t, "45", v)
-		case "max_attester_slashings":
+		case "proportional_slashing_multiplier":
 			assert.Equal(t, "46", v)
-		case "max_attestations":
+		case "hf1_proportional_slashing_multiplier":
 			assert.Equal(t, "47", v)
-		case "max_deposits":
+		case "max_proposer_slashings":
 			assert.Equal(t, "48", v)
-		case "max_voluntary_exits":
+		case "max_attester_slashings":
 			assert.Equal(t, "49", v)
+		case "max_attestations":
+			assert.Equal(t, "50", v)
+		case "max_deposits":
+			assert.Equal(t, "51", v)
+		case "max_voluntary_exits":
+			assert.Equal(t, "52", v)
 		case "domain_beacon_proposer":
 			assert.Equal(t, "0x30303031", v)
 		case "domain_beacon_attester":

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -75,12 +75,15 @@ type BeaconChainConfig struct {
 	ValidatorRegistryLimit    uint64      `yaml:"VALIDATOR_REGISTRY_LIMIT" spec:"true"`     // ValidatorRegistryLimit defines the upper bound of validators can participate in eth2.
 
 	// Reward and penalty quotients constants.
-	BaseRewardFactor               uint64 `yaml:"BASE_REWARD_FACTOR" spec:"true"`               // BaseRewardFactor is used to calculate validator per-slot interest rate.
-	WhistleBlowerRewardQuotient    uint64 `yaml:"WHISTLEBLOWER_REWARD_QUOTIENT" spec:"true"`    // WhistleBlowerRewardQuotient is used to calculate whistle blower reward.
-	ProposerRewardQuotient         uint64 `yaml:"PROPOSER_REWARD_QUOTIENT" spec:"true"`         // ProposerRewardQuotient is used to calculate the reward for proposers.
-	InactivityPenaltyQuotient      uint64 `yaml:"INACTIVITY_PENALTY_QUOTIENT" spec:"true"`      // InactivityPenaltyQuotient is used to calculate the penalty for a validator that is offline.
-	MinSlashingPenaltyQuotient     uint64 `yaml:"MIN_SLASHING_PENALTY_QUOTIENT" spec:"true"`    // MinSlashingPenaltyQuotient is used to calculate the minimum penalty to prevent DoS attacks.
-	ProportionalSlashingMultiplier uint64 `yaml:"PROPORTIONAL_SLASHING_MULTIPLIER" spec:"true"` // ProportionalSlashingMultiplier is used as a multiplier on slashed penalties.
+	BaseRewardFactor                  uint64 `yaml:"BASE_REWARD_FACTOR" spec:"true"`                   // BaseRewardFactor is used to calculate validator per-slot interest rate.
+	WhistleBlowerRewardQuotient       uint64 `yaml:"WHISTLEBLOWER_REWARD_QUOTIENT" spec:"true"`        // WhistleBlowerRewardQuotient is used to calculate whistle blower reward.
+	ProposerRewardQuotient            uint64 `yaml:"PROPOSER_REWARD_QUOTIENT" spec:"true"`             // ProposerRewardQuotient is used to calculate the reward for proposers.
+	InactivityPenaltyQuotient         uint64 `yaml:"INACTIVITY_PENALTY_QUOTIENT" spec:"true"`          // InactivityPenaltyQuotient is used to calculate the penalty for a validator that is offline.
+	InactivityPenaltyQuotientHF1      uint64 `yaml:"HF1_INACTIVITY_PENALTY_QUOTIENT spec:true"`        // InactivityPenaltyQuotientHF1 is used after hard fork 1 to calculate the penalty for a validator that is offline.
+	MinSlashingPenaltyQuotient        uint64 `yaml:"MIN_SLASHING_PENALTY_QUOTIENT" spec:"true"`        // MinSlashingPenaltyQuotient is used to calculate the minimum penalty to prevent DoS attacks.
+	MinSlashingPenaltyQuotientHF1     uint64 `yaml:"HF1_MIN_SLASHING_PENALTY_QUOTIENT" spec:"true"`    // MinSlashingPenaltyQuotientHF1 is used after hard fork 1 to calculate the minimum penalty to prevent DoS attacks.
+	ProportionalSlashingMultiplier    uint64 `yaml:"PROPORTIONAL_SLASHING_MULTIPLIER" spec:"true"`     // ProportionalSlashingMultiplier is used as a multiplier on slashed penalties.
+	ProportionalSlashingMultiplierHF1 uint64 `yaml:"HF1_PROPORTIONAL_SLASHING_MULTIPLIER" spec:"true"` // ProportionalSlashingMultiplierHF1 is used after hard fork 1 as a multiplier on slashed penalties.
 
 	// Max operations per block constants.
 	MaxProposerSlashings uint64 `yaml:"MAX_PROPOSER_SLASHINGS" spec:"true"` // MaxProposerSlashings defines the maximum number of slashings of proposers possible in a block.

--- a/shared/params/loader_test.go
+++ b/shared/params/loader_test.go
@@ -76,8 +76,11 @@ func TestLoadConfigFileMainnet(t *testing.T) {
 		assert.Equal(t, c1.WhistleBlowerRewardQuotient, c2.WhistleBlowerRewardQuotient, "%s: WhistleBlowerRewardQuotient", name)
 		assert.Equal(t, c1.ProposerRewardQuotient, c2.ProposerRewardQuotient, "%s: ProposerRewardQuotient", name)
 		assert.Equal(t, c1.InactivityPenaltyQuotient, c2.InactivityPenaltyQuotient, "%s: InactivityPenaltyQuotient", name)
+		assert.Equal(t, c1.InactivityPenaltyQuotientHF1, c2.InactivityPenaltyQuotientHF1, "%s: InactivityPenaltyQuotient", name)
 		assert.Equal(t, c1.MinSlashingPenaltyQuotient, c2.MinSlashingPenaltyQuotient, "%s: MinSlashingPenaltyQuotient", name)
+		assert.Equal(t, c1.MinSlashingPenaltyQuotientHF1, c2.MinSlashingPenaltyQuotientHF1, "%s: MinSlashingPenaltyQuotient", name)
 		assert.Equal(t, c1.ProportionalSlashingMultiplier, c2.ProportionalSlashingMultiplier, "%s: ProportionalSlashingMultiplier", name)
+		assert.Equal(t, c1.ProportionalSlashingMultiplierHF1, c2.ProportionalSlashingMultiplierHF1, "%s: ProportionalSlashingMultiplier", name)
 
 		// Max operations per block.
 		assert.Equal(t, c1.MaxProposerSlashings, c2.MaxProposerSlashings, "%s: MaxProposerSlashings", name)

--- a/shared/params/loader_test.go
+++ b/shared/params/loader_test.go
@@ -76,11 +76,11 @@ func TestLoadConfigFileMainnet(t *testing.T) {
 		assert.Equal(t, c1.WhistleBlowerRewardQuotient, c2.WhistleBlowerRewardQuotient, "%s: WhistleBlowerRewardQuotient", name)
 		assert.Equal(t, c1.ProposerRewardQuotient, c2.ProposerRewardQuotient, "%s: ProposerRewardQuotient", name)
 		assert.Equal(t, c1.InactivityPenaltyQuotient, c2.InactivityPenaltyQuotient, "%s: InactivityPenaltyQuotient", name)
-		assert.Equal(t, c1.InactivityPenaltyQuotientHF1, c2.InactivityPenaltyQuotientHF1, "%s: InactivityPenaltyQuotient", name)
+		assert.Equal(t, c1.InactivityPenaltyQuotientHF1, c2.InactivityPenaltyQuotientHF1, "%s: InactivityPenaltyQuotientHF1", name)
 		assert.Equal(t, c1.MinSlashingPenaltyQuotient, c2.MinSlashingPenaltyQuotient, "%s: MinSlashingPenaltyQuotient", name)
-		assert.Equal(t, c1.MinSlashingPenaltyQuotientHF1, c2.MinSlashingPenaltyQuotientHF1, "%s: MinSlashingPenaltyQuotient", name)
+		assert.Equal(t, c1.MinSlashingPenaltyQuotientHF1, c2.MinSlashingPenaltyQuotientHF1, "%s: MinSlashingPenaltyQuotientHF1", name)
 		assert.Equal(t, c1.ProportionalSlashingMultiplier, c2.ProportionalSlashingMultiplier, "%s: ProportionalSlashingMultiplier", name)
-		assert.Equal(t, c1.ProportionalSlashingMultiplierHF1, c2.ProportionalSlashingMultiplierHF1, "%s: ProportionalSlashingMultiplier", name)
+		assert.Equal(t, c1.ProportionalSlashingMultiplierHF1, c2.ProportionalSlashingMultiplierHF1, "%s: ProportionalSlashingMultiplierHF1", name)
 
 		// Max operations per block.
 		assert.Equal(t, c1.MaxProposerSlashings, c2.MaxProposerSlashings, "%s: MaxProposerSlashings", name)

--- a/shared/params/mainnet_config.go
+++ b/shared/params/mainnet_config.go
@@ -122,12 +122,15 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	ValidatorRegistryLimit:    1099511627776,
 
 	// Reward and penalty quotients constants.
-	BaseRewardFactor:               64,
-	WhistleBlowerRewardQuotient:    512,
-	ProposerRewardQuotient:         8,
-	InactivityPenaltyQuotient:      67108864,
-	MinSlashingPenaltyQuotient:     128,
-	ProportionalSlashingMultiplier: 1,
+	BaseRewardFactor:                  64,
+	WhistleBlowerRewardQuotient:       512,
+	ProposerRewardQuotient:            8,
+	InactivityPenaltyQuotient:         67108864,
+	InactivityPenaltyQuotientHF1:      50331648,
+	MinSlashingPenaltyQuotient:        128,
+	MinSlashingPenaltyQuotientHF1:     64,
+	ProportionalSlashingMultiplier:    1,
+	ProportionalSlashingMultiplierHF1: 2,
 
 	// Max operations per block constants.
 	MaxProposerSlashings: 16,

--- a/shared/params/minimal_config.go
+++ b/shared/params/minimal_config.go
@@ -57,8 +57,11 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.WhistleBlowerRewardQuotient = 512
 	minimalConfig.ProposerRewardQuotient = 8
 	minimalConfig.InactivityPenaltyQuotient = 33554432
+	minimalConfig.InactivityPenaltyQuotientHF1 = 50331648
 	minimalConfig.MinSlashingPenaltyQuotient = 64
+	minimalConfig.MinSlashingPenaltyQuotientHF1 = 64
 	minimalConfig.ProportionalSlashingMultiplier = 2
+	minimalConfig.ProportionalSlashingMultiplierHF1 = 2
 
 	// Max operations per block
 	minimalConfig.MaxProposerSlashings = 16


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature: HF1

**What does this PR do? Why is it needed?**

Add 3 new HF1 penalty configs. Note that we do not override constants at forks and instead create a new value and define its usage.
```
InactivityPenaltyQuotientHF1: reduced from 2**26 (= 67,108,864) to 3 * 2**24 (= 50,331,648)
MinSlashingPenaltyQuotientHF1: increased from 1 to 2
ProportionalSlashingMultiplierHF1: reduced from 2**7 (= 128) to 2**6 (= 64)
```

The new config values certainly help to move toward maximum planned security, but do not yet reach those planned maximally punitive values. Those values will be put in before the merge.

