### PR TITLE
Increase default peer limit from 30 to 45

### DIFF
--- a/shared/cmd/flags.go
+++ b/shared/cmd/flags.go
@@ -150,7 +150,7 @@ var (
 	P2PMaxPeers = &cli.IntFlag{
 		Name:  "p2p-max-peers",
 		Usage: "The max number of p2p peers to maintain.",
-		Value: 30,
+		Value: 45,
 	}
 	// P2PAllowList defines a CIDR subnet to exclusively allow connections.
 	P2PAllowList = &cli.StringFlag{


### PR DESCRIPTION
**What type of PR is this?**

Peering Cleanup

**What does this PR do? Why is it needed?**

- [x] A long overdue change, this bumps up the default peer limit to 45 from 30. Any user running a validator might eventually run into issues with only 30 peers. This gives a larger buffer for the average solo staker, so that they can find peers in subnets.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
