### PR TITLE
Implement SubmitVoluntaryExit and SubmitProposerSlashing in the beacon API

### DIFF
--- a/beacon-chain/operations/slashings/mock.go
+++ b/beacon-chain/operations/slashings/mock.go
@@ -30,8 +30,9 @@ func (m *PoolMock) InsertAttesterSlashing(_ context.Context, _ *state.BeaconStat
 }
 
 // InsertProposerSlashing --
-func (m *PoolMock) InsertProposerSlashing(_ context.Context, _ *state.BeaconState, _ *ethpb.ProposerSlashing) error {
-	panic("implement me")
+func (m *PoolMock) InsertProposerSlashing(_ context.Context, _ *state.BeaconState, slashing *ethpb.ProposerSlashing) error {
+	m.PendingPropSlashings = append(m.PendingPropSlashings, slashing)
+	return nil
 }
 
 // MarkIncludedAttesterSlashing --

--- a/beacon-chain/operations/voluntaryexits/mock.go
+++ b/beacon-chain/operations/voluntaryexits/mock.go
@@ -19,8 +19,8 @@ func (m *PoolMock) PendingExits(_ *beaconstate.BeaconState, _ types.Slot, _ bool
 }
 
 // InsertVoluntaryExit --
-func (*PoolMock) InsertVoluntaryExit(_ context.Context, _ *beaconstate.BeaconState, _ *eth.SignedVoluntaryExit) {
-	panic("implement me")
+func (m *PoolMock) InsertVoluntaryExit(_ context.Context, _ *beaconstate.BeaconState, exit *eth.SignedVoluntaryExit) {
+	m.Exits = append(m.Exits, exit)
 }
 
 // MarkIncluded --

--- a/beacon-chain/rpc/beaconv1/pool.go
+++ b/beacon-chain/rpc/beaconv1/pool.go
@@ -59,13 +59,13 @@ func (bs *Server) SubmitAttesterSlashing(ctx context.Context, req *ethpb.Atteste
 		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
 	}
 
-	v1Slashing := migration.V1AttSlashingToV1Alpha1(req)
-	err = blocks.VerifyAttesterSlashing(ctx, headState, v1Slashing)
+	alphaSlashing := migration.V1AttSlashingToV1Alpha1(req)
+	err = blocks.VerifyAttesterSlashing(ctx, headState, alphaSlashing)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Invalid attester slashing: %v", err)
 	}
 
-	err = bs.SlashingsPool.InsertAttesterSlashing(ctx, headState, v1Slashing)
+	err = bs.SlashingsPool.InsertAttesterSlashing(ctx, headState, alphaSlashing)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not insert attester slashing into pool: %v", err)
 	}
@@ -111,13 +111,13 @@ func (bs *Server) SubmitProposerSlashing(ctx context.Context, req *ethpb.Propose
 		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
 	}
 
-	v1Slashing := migration.V1ProposerSlashingToV1Alpha1(req)
-	err = blocks.VerifyProposerSlashing(headState, v1Slashing)
+	alphaSlashing := migration.V1ProposerSlashingToV1Alpha1(req)
+	err = blocks.VerifyProposerSlashing(headState, alphaSlashing)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Invalid proposer slashing: %v", err)
 	}
 
-	err = bs.SlashingsPool.InsertProposerSlashing(ctx, headState, v1Slashing)
+	err = bs.SlashingsPool.InsertProposerSlashing(ctx, headState, alphaSlashing)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not insert proposer slashing into pool: %v", err)
 	}
@@ -168,13 +168,13 @@ func (bs *Server) SubmitVoluntaryExit(ctx context.Context, req *ethpb.SignedVolu
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get exiting validator: %v", err)
 	}
-	v1Slashing := migration.V1ExitToV1Alpha1(req)
-	err = blocks.VerifyExitAndSignature(validator, headState.Slot(), headState.Fork(), v1Slashing, headState.GenesisValidatorRoot())
+	alphaExit := migration.V1ExitToV1Alpha1(req)
+	err = blocks.VerifyExitAndSignature(validator, headState.Slot(), headState.Fork(), alphaExit, headState.GenesisValidatorRoot())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Invalid voluntary exit: %v", err)
 	}
 
-	bs.VoluntaryExitsPool.InsertVoluntaryExit(ctx, headState, v1Slashing)
+	bs.VoluntaryExitsPool.InsertVoluntaryExit(ctx, headState, alphaExit)
 	if err := bs.Broadcaster.Broadcast(ctx, req); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not broadcast voluntary exit object: %v", err)
 	}

--- a/beacon-chain/rpc/beaconv1/pool_test.go
+++ b/beacon-chain/rpc/beaconv1/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/types"
+	eth2types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1"
 	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	chainMock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
@@ -312,5 +313,106 @@ func TestSubmitAttesterSlashing_InvalidSlashing(t *testing.T) {
 
 	_, err = s.SubmitAttesterSlashing(ctx, slashing)
 	require.ErrorContains(t, "Invalid attester slashing", err)
+	assert.Equal(t, false, broadcaster.BroadcastCalled)
+}
+
+func TestSubmitProposerSlashing_Ok(t *testing.T) {
+	ctx := context.Background()
+
+	_, keys, err := testutil.DeterministicDepositsAndKeys(1)
+	require.NoError(t, err)
+	validator := &eth.Validator{
+		ExitEpoch:             params.BeaconConfig().FarFutureEpoch,
+		PublicKey:             keys[0].PublicKey().Marshal(),
+		WithdrawalCredentials: make([]byte, 32),
+		WithdrawableEpoch:     eth2types.Epoch(1),
+	}
+	state, err := testutil.NewBeaconState(func(state *pb.BeaconState) {
+		state.Validators = []*eth.Validator{validator}
+	})
+	require.NoError(t, err)
+
+	slashing := &ethpb.ProposerSlashing{
+		Header_1: &ethpb.SignedBeaconBlockHeader{
+			Header: &ethpb.BeaconBlockHeader{
+				Slot:          1,
+				ProposerIndex: 0,
+				ParentRoot:    bytesutil.PadTo([]byte("parentroot1"), 32),
+				StateRoot:     bytesutil.PadTo([]byte("stateroot1"), 32),
+				BodyRoot:      bytesutil.PadTo([]byte("bodyroot1"), 32),
+			},
+			Signature: make([]byte, 96),
+		},
+		Header_2: &ethpb.SignedBeaconBlockHeader{
+			Header: &ethpb.BeaconBlockHeader{
+				Slot:          1,
+				ProposerIndex: 0,
+				ParentRoot:    bytesutil.PadTo([]byte("parentroot2"), 32),
+				StateRoot:     bytesutil.PadTo([]byte("stateroot2"), 32),
+				BodyRoot:      bytesutil.PadTo([]byte("bodyroot2"), 32),
+			},
+			Signature: make([]byte, 96),
+		},
+	}
+
+	for _, h := range []*ethpb.SignedBeaconBlockHeader{slashing.Header_1, slashing.Header_2} {
+		sb, err := helpers.ComputeDomainAndSign(
+			state,
+			helpers.SlotToEpoch(h.Header.Slot),
+			h.Header,
+			params.BeaconConfig().DomainBeaconProposer,
+			keys[0],
+		)
+		require.NoError(t, err)
+		sig, err := bls.SignatureFromBytes(sb)
+		require.NoError(t, err)
+		h.Signature = sig.Marshal()
+	}
+
+	broadcaster := &p2pMock.MockBroadcaster{}
+	s := &Server{
+		ChainInfoFetcher: &chainMock.ChainService{State: state},
+		SlashingsPool:    &slashings.PoolMock{},
+		Broadcaster:      broadcaster,
+	}
+
+	_, err = s.SubmitProposerSlashing(ctx, slashing)
+	require.NoError(t, err)
+	pendingSlashings := s.SlashingsPool.PendingProposerSlashings(ctx, state, true)
+	require.Equal(t, 1, len(pendingSlashings))
+	assert.DeepEqual(t, migration.V1ProposerSlashingToV1Alpha1(slashing), pendingSlashings[0])
+	assert.Equal(t, true, broadcaster.BroadcastCalled)
+}
+
+func TestSubmitProposerSlashing_InvalidSlashing(t *testing.T) {
+	ctx := context.Background()
+	state, err := testutil.NewBeaconState()
+	require.NoError(t, err)
+
+	header := &ethpb.SignedBeaconBlockHeader{
+		Header: &ethpb.BeaconBlockHeader{
+			Slot:          1,
+			ProposerIndex: 0,
+			ParentRoot:    bytesutil.PadTo([]byte("parentroot1"), 32),
+			StateRoot:     bytesutil.PadTo([]byte("stateroot1"), 32),
+			BodyRoot:      bytesutil.PadTo([]byte("bodyroot1"), 32),
+		},
+		Signature: make([]byte, 96),
+	}
+
+	slashing := &ethpb.ProposerSlashing{
+		Header_1: header,
+		Header_2: header,
+	}
+
+	broadcaster := &p2pMock.MockBroadcaster{}
+	s := &Server{
+		ChainInfoFetcher: &chainMock.ChainService{State: state},
+		SlashingsPool:    &slashings.PoolMock{},
+		Broadcaster:      broadcaster,
+	}
+
+	_, err = s.SubmitProposerSlashing(ctx, slashing)
+	require.ErrorContains(t, "Invalid proposer slashing", err)
 	assert.Equal(t, false, broadcaster.BroadcastCalled)
 }

--- a/proto/migration/migration.go
+++ b/proto/migration/migration.go
@@ -153,6 +153,20 @@ func V1Alpha1ExitToV1(v1alpha1Exit *ethpb_alpha.SignedVoluntaryExit) *ethpb.Sign
 	}
 }
 
+// V1ExitToV1Alpha1 converts a v1 SignedVoluntaryExit to v1alpha1.
+func V1ExitToV1Alpha1(v1Exit *ethpb.SignedVoluntaryExit) *ethpb_alpha.SignedVoluntaryExit {
+	if v1Exit == nil || v1Exit.Exit == nil {
+		return &ethpb_alpha.SignedVoluntaryExit{}
+	}
+	return &ethpb_alpha.SignedVoluntaryExit{
+		Exit: &ethpb_alpha.VoluntaryExit{
+			Epoch:          v1Exit.Exit.Epoch,
+			ValidatorIndex: v1Exit.Exit.ValidatorIndex,
+		},
+		Signature: v1Exit.Signature,
+	}
+}
+
 // V1IndexedAttToV1Alpha1 converts a v1 indexed attestation to v1alpha1.
 func V1IndexedAttToV1Alpha1(v1Att *ethpb.IndexedAttestation) *ethpb_alpha.IndexedAttestation {
 	if v1Att == nil {

--- a/proto/migration/migration.go
+++ b/proto/migration/migration.go
@@ -111,6 +111,23 @@ func V1Alpha1SignedHeaderToV1(v1alpha1Hdr *ethpb_alpha.SignedBeaconBlockHeader) 
 	}
 }
 
+// V1SignedHeaderToV1Alpha1 converts a v1 signed beacon block header to v1alpha1.
+func V1SignedHeaderToV1Alpha1(v1Header *ethpb.SignedBeaconBlockHeader) *ethpb_alpha.SignedBeaconBlockHeader {
+	if v1Header == nil || v1Header.Header == nil {
+		return &ethpb_alpha.SignedBeaconBlockHeader{}
+	}
+	return &ethpb_alpha.SignedBeaconBlockHeader{
+		Header: &ethpb_alpha.BeaconBlockHeader{
+			Slot:          v1Header.Header.Slot,
+			ProposerIndex: v1Header.Header.ProposerIndex,
+			ParentRoot:    v1Header.Header.ParentRoot,
+			StateRoot:     v1Header.Header.StateRoot,
+			BodyRoot:      v1Header.Header.BodyRoot,
+		},
+		Signature: v1Header.Signature,
+	}
+}
+
 // V1Alpha1ProposerSlashingToV1 converts a v1alpha1 proposer slashing to v1.
 func V1Alpha1ProposerSlashingToV1(v1alpha1Slashing *ethpb_alpha.ProposerSlashing) *ethpb.ProposerSlashing {
 	if v1alpha1Slashing == nil {
@@ -176,5 +193,16 @@ func V1AttSlashingToV1Alpha1(v1Slashing *ethpb.AttesterSlashing) *ethpb_alpha.At
 	return &ethpb_alpha.AttesterSlashing{
 		Attestation_1: V1IndexedAttToV1Alpha1(v1Slashing.Attestation_1),
 		Attestation_2: V1IndexedAttToV1Alpha1(v1Slashing.Attestation_2),
+	}
+}
+
+// V1ProposerSlashingToV1Alpha1 converts a v1 proposer slashing to v1alpha1.
+func V1ProposerSlashingToV1Alpha1(v1Slashing *ethpb.ProposerSlashing) *ethpb_alpha.ProposerSlashing {
+	if v1Slashing == nil {
+		return &ethpb_alpha.ProposerSlashing{}
+	}
+	return &ethpb_alpha.ProposerSlashing{
+		Header_1: V1SignedHeaderToV1Alpha1(v1Slashing.Header_1),
+		Header_2: V1SignedHeaderToV1Alpha1(v1Slashing.Header_2),
 	}
 }

--- a/proto/migration/migration_test.go
+++ b/proto/migration/migration_test.go
@@ -1,0 +1,44 @@
+package migration
+
+import (
+	"testing"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+var (
+	slot           = types.Slot(1)
+	validatorIndex = types.ValidatorIndex(1)
+	parentRoot     = bytesutil.PadTo([]byte("parentroot"), 32)
+	stateRoot      = bytesutil.PadTo([]byte("stateroot"), 32)
+	signature      = bytesutil.PadTo([]byte("signature"), 96)
+	bodyRoot       = bytesutil.PadTo([]byte("bodyroot"), 32)
+)
+
+func Test_V1ProposerSlashingToV1Alpha1(t *testing.T) {
+	v1Header := &ethpb.SignedBeaconBlockHeader{
+		Header: &ethpb.BeaconBlockHeader{
+			Slot:          slot,
+			ProposerIndex: validatorIndex,
+			ParentRoot:    parentRoot,
+			StateRoot:     stateRoot,
+			BodyRoot:      bodyRoot,
+		},
+		Signature: signature,
+	}
+	v1Slashing := &ethpb.ProposerSlashing{
+		Header_1: v1Header,
+		Header_2: v1Header,
+	}
+
+	alphaSlashing := V1ProposerSlashingToV1Alpha1(v1Slashing)
+	alphaRoot, err := alphaSlashing.HashTreeRoot()
+	require.NoError(t, err)
+	v1Root, err := v1Slashing.HashTreeRoot()
+	require.NoError(t, err)
+	assert.DeepEqual(t, alphaRoot, v1Root)
+}

--- a/proto/migration/migration_test.go
+++ b/proto/migration/migration_test.go
@@ -166,6 +166,23 @@ func Test_V1Alpha1ExitToV1(t *testing.T) {
 	assert.DeepEqual(t, alphaRoot, v1Root)
 }
 
+func Test_V1ExitToV1Alpha1(t *testing.T) {
+	v1Exit := &ethpb.SignedVoluntaryExit{
+		Exit: &ethpb.VoluntaryExit{
+			Epoch:          epoch,
+			ValidatorIndex: validatorIndex,
+		},
+		Signature: signature,
+	}
+
+	alphaExit := V1ExitToV1Alpha1(v1Exit)
+	alphaRoot, err := alphaExit.HashTreeRoot()
+	require.NoError(t, err)
+	v1Root, err := v1Exit.HashTreeRoot()
+	require.NoError(t, err)
+	assert.DeepEqual(t, alphaRoot, v1Root)
+}
+
 func Test_V1AttSlashingToV1Alpha1(t *testing.T) {
 	v1Attestation := &ethpb.IndexedAttestation{
 		AttestingIndices: attestingIndices,


### PR DESCRIPTION
**What type of PR is this?**

Feature

What does this PR do? Why is it needed?

This PR implements beacon API's `SubmitVoluntaryExit` and `SubmitProposerSlashing` methods according to the spec: https://ethereum.github.io/eth2.0-APIs/#/Beacon

Which issues(s) does this PR fix?

Part of #7510

Other notes for review

Very similar to #8515 
