### PR TITLE
Clean up state pkg's getter and setter

### DIFF
--- a/beacon-chain/state/BUILD.bazel
+++ b/beacon-chain/state/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "setters.go",
         "state_trie.go",
         "types.go",
+        "validator_getters.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/state",
     visibility = [

--- a/beacon-chain/state/doc.go
+++ b/beacon-chain/state/doc.go
@@ -13,7 +13,7 @@
 //
 //  func (b *BeaconState) Foo() uint64 {
 //    // Short-circuit conditions.
-//    if !b.HasInnerState() {
+//    if !b.hasInnerState() {
 //      return 0
 //    }
 //
@@ -27,7 +27,7 @@
 //
 //  func (b *BeaconState) foo() uint64 {
 //    // Short-circuit conditions.
-//    if !b.HasInnerState() {
+//    if !b.hasInnerState() {
 //      return 0
 //    }
 //

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"time"
 
 	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -13,91 +12,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
-
-// EffectiveBalance returns the effective balance of the
-// read only validator.
-func (v ReadOnlyValidator) EffectiveBalance() uint64 {
-	if v.IsNil() {
-		return 0
-	}
-	return v.validator.EffectiveBalance
-}
-
-// ActivationEligibilityEpoch returns the activation eligibility epoch of the
-// read only validator.
-func (v ReadOnlyValidator) ActivationEligibilityEpoch() types.Epoch {
-	if v.IsNil() {
-		return 0
-	}
-	return v.validator.ActivationEligibilityEpoch
-}
-
-// ActivationEpoch returns the activation epoch of the
-// read only validator.
-func (v ReadOnlyValidator) ActivationEpoch() types.Epoch {
-	if v.IsNil() {
-		return 0
-	}
-	return v.validator.ActivationEpoch
-}
-
-// WithdrawableEpoch returns the withdrawable epoch of the
-// read only validator.
-func (v ReadOnlyValidator) WithdrawableEpoch() types.Epoch {
-	if v.IsNil() {
-		return 0
-	}
-	return v.validator.WithdrawableEpoch
-}
-
-// ExitEpoch returns the exit epoch of the
-// read only validator.
-func (v ReadOnlyValidator) ExitEpoch() types.Epoch {
-	if v.IsNil() {
-		return 0
-	}
-	return v.validator.ExitEpoch
-}
-
-// PublicKey returns the public key of the
-// read only validator.
-func (v ReadOnlyValidator) PublicKey() [48]byte {
-	if v.IsNil() {
-		return [48]byte{}
-	}
-	var pubkey [48]byte
-	copy(pubkey[:], v.validator.PublicKey)
-	return pubkey
-}
-
-// WithdrawalCredentials returns the withdrawal credentials of the
-// read only validator.
-func (v ReadOnlyValidator) WithdrawalCredentials() []byte {
-	creds := make([]byte, len(v.validator.WithdrawalCredentials))
-	copy(creds, v.validator.WithdrawalCredentials)
-	return creds
-}
-
-// Slashed returns the read only validator is slashed.
-func (v ReadOnlyValidator) Slashed() bool {
-	if v.IsNil() {
-		return false
-	}
-	return v.validator.Slashed
-}
-
-// CopyValidator returns the copy of the read only validator.
-func (v ReadOnlyValidator) CopyValidator() *ethpb.Validator {
-	if v.IsNil() {
-		return nil
-	}
-	return CopyValidator(v.validator)
-}
-
-// CopyValidator returns the copy of the read only validator.
-func (v ReadOnlyValidator) IsNil() bool {
-	return v.validator == nil
-}
 
 // InnerStateUnsafe returns the pointer value of the underlying
 // beacon state proto object, bypassing immutability. Use with care.
@@ -141,15 +55,15 @@ func (b *BeaconState) CloneInnerState() *pbp2p.BeaconState {
 	}
 }
 
-// HasInnerState detects if the internal reference to the state data structure
+// hasInnerState detects if the internal reference to the state data structure
 // is populated correctly. Returns false if nil.
-func (b *BeaconState) HasInnerState() bool {
+func (b *BeaconState) hasInnerState() bool {
 	return b != nil && b.state != nil
 }
 
 // GenesisTime of the beacon state as a uint64.
 func (b *BeaconState) GenesisTime() uint64 {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 
@@ -162,7 +76,7 @@ func (b *BeaconState) GenesisTime() uint64 {
 // genesisTime of the beacon state as a uint64.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) genesisTime() uint64 {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 
@@ -171,7 +85,7 @@ func (b *BeaconState) genesisTime() uint64 {
 
 // GenesisValidatorRoot of the beacon state.
 func (b *BeaconState) GenesisValidatorRoot() []byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.GenesisValidatorsRoot == nil {
@@ -187,7 +101,7 @@ func (b *BeaconState) GenesisValidatorRoot() []byte {
 // genesisValidatorRoot of the beacon state.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) genesisValidatorRoot() []byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.GenesisValidatorsRoot == nil {
@@ -199,31 +113,9 @@ func (b *BeaconState) genesisValidatorRoot() []byte {
 	return root
 }
 
-// GenesisUnixTime returns the genesis time as time.Time.
-func (b *BeaconState) GenesisUnixTime() time.Time {
-	if !b.HasInnerState() {
-		return time.Unix(0, 0)
-	}
-
-	b.lock.RLock()
-	defer b.lock.RUnlock()
-
-	return b.genesisUnixTime()
-}
-
-// genesisUnixTime returns the genesis time as time.Time.
-// This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) genesisUnixTime() time.Time {
-	if !b.HasInnerState() {
-		return time.Unix(0, 0)
-	}
-
-	return time.Unix(int64(b.state.GenesisTime), 0)
-}
-
 // Slot of the current beacon chain state.
 func (b *BeaconState) Slot() types.Slot {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 
@@ -236,7 +128,7 @@ func (b *BeaconState) Slot() types.Slot {
 // slot of the current beacon chain state.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) slot() types.Slot {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 
@@ -245,7 +137,7 @@ func (b *BeaconState) slot() types.Slot {
 
 // Fork version of the beacon chain.
 func (b *BeaconState) Fork() *pbp2p.Fork {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Fork == nil {
@@ -261,7 +153,7 @@ func (b *BeaconState) Fork() *pbp2p.Fork {
 // fork version of the beacon chain.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) fork() *pbp2p.Fork {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Fork == nil {
@@ -281,7 +173,7 @@ func (b *BeaconState) fork() *pbp2p.Fork {
 
 // LatestBlockHeader stored within the beacon state.
 func (b *BeaconState) LatestBlockHeader() *ethpb.BeaconBlockHeader {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.LatestBlockHeader == nil {
@@ -297,7 +189,7 @@ func (b *BeaconState) LatestBlockHeader() *ethpb.BeaconBlockHeader {
 // latestBlockHeader stored within the beacon state.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) latestBlockHeader() *ethpb.BeaconBlockHeader {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.LatestBlockHeader == nil {
@@ -322,33 +214,9 @@ func (b *BeaconState) latestBlockHeader() *ethpb.BeaconBlockHeader {
 	return hdr
 }
 
-// ParentRoot is a convenience method to access state.LatestBlockRoot.ParentRoot.
-func (b *BeaconState) ParentRoot() [32]byte {
-	if !b.HasInnerState() {
-		return [32]byte{}
-	}
-
-	b.lock.RLock()
-	defer b.lock.RUnlock()
-
-	return b.parentRoot()
-}
-
-// parentRoot is a convenience method to access state.LatestBlockRoot.ParentRoot.
-// This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) parentRoot() [32]byte {
-	if !b.HasInnerState() {
-		return [32]byte{}
-	}
-
-	parentRoot := [32]byte{}
-	copy(parentRoot[:], b.state.LatestBlockHeader.ParentRoot)
-	return parentRoot
-}
-
 // BlockRoots kept track of in the beacon state.
 func (b *BeaconState) BlockRoots() [][]byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.BlockRoots == nil {
@@ -364,7 +232,7 @@ func (b *BeaconState) BlockRoots() [][]byte {
 // blockRoots kept track of in the beacon state.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) blockRoots() [][]byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	return b.safeCopy2DByteSlice(b.state.BlockRoots)
@@ -373,7 +241,7 @@ func (b *BeaconState) blockRoots() [][]byte {
 // BlockRootAtIndex retrieves a specific block root based on an
 // input index value.
 func (b *BeaconState) BlockRootAtIndex(idx uint64) ([]byte, error) {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil, ErrNilInnerState
 	}
 	if b.state.BlockRoots == nil {
@@ -390,7 +258,7 @@ func (b *BeaconState) BlockRootAtIndex(idx uint64) ([]byte, error) {
 // input index value.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) blockRootAtIndex(idx uint64) ([]byte, error) {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil, ErrNilInnerState
 	}
 	return b.safeCopyBytesAtIndex(b.state.BlockRoots, idx)
@@ -398,7 +266,7 @@ func (b *BeaconState) blockRootAtIndex(idx uint64) ([]byte, error) {
 
 // StateRoots kept track of in the beacon state.
 func (b *BeaconState) StateRoots() [][]byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.StateRoots == nil {
@@ -414,7 +282,7 @@ func (b *BeaconState) StateRoots() [][]byte {
 // StateRoots kept track of in the beacon state.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) stateRoots() [][]byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	return b.safeCopy2DByteSlice(b.state.StateRoots)
@@ -423,7 +291,7 @@ func (b *BeaconState) stateRoots() [][]byte {
 // StateRootAtIndex retrieves a specific state root based on an
 // input index value.
 func (b *BeaconState) StateRootAtIndex(idx uint64) ([]byte, error) {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil, ErrNilInnerState
 	}
 	if b.state.StateRoots == nil {
@@ -440,7 +308,7 @@ func (b *BeaconState) StateRootAtIndex(idx uint64) ([]byte, error) {
 // input index value.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) stateRootAtIndex(idx uint64) ([]byte, error) {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil, ErrNilInnerState
 	}
 	return b.safeCopyBytesAtIndex(b.state.StateRoots, idx)
@@ -448,7 +316,7 @@ func (b *BeaconState) stateRootAtIndex(idx uint64) ([]byte, error) {
 
 // HistoricalRoots based on epochs stored in the beacon state.
 func (b *BeaconState) HistoricalRoots() [][]byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.HistoricalRoots == nil {
@@ -464,7 +332,7 @@ func (b *BeaconState) HistoricalRoots() [][]byte {
 // historicalRoots based on epochs stored in the beacon state.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) historicalRoots() [][]byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	return b.safeCopy2DByteSlice(b.state.HistoricalRoots)
@@ -472,7 +340,7 @@ func (b *BeaconState) historicalRoots() [][]byte {
 
 // Eth1Data corresponding to the proof-of-work chain information stored in the beacon state.
 func (b *BeaconState) Eth1Data() *ethpb.Eth1Data {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Eth1Data == nil {
@@ -488,7 +356,7 @@ func (b *BeaconState) Eth1Data() *ethpb.Eth1Data {
 // eth1Data corresponding to the proof-of-work chain information stored in the beacon state.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) eth1Data() *ethpb.Eth1Data {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Eth1Data == nil {
@@ -501,7 +369,7 @@ func (b *BeaconState) eth1Data() *ethpb.Eth1Data {
 // Eth1DataVotes corresponds to votes from eth2 on the canonical proof-of-work chain
 // data retrieved from eth1.
 func (b *BeaconState) Eth1DataVotes() []*ethpb.Eth1Data {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Eth1DataVotes == nil {
@@ -518,7 +386,7 @@ func (b *BeaconState) Eth1DataVotes() []*ethpb.Eth1Data {
 // data retrieved from eth1.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) eth1DataVotes() []*ethpb.Eth1Data {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Eth1DataVotes == nil {
@@ -535,7 +403,7 @@ func (b *BeaconState) eth1DataVotes() []*ethpb.Eth1Data {
 // Eth1DepositIndex corresponds to the index of the deposit made to the
 // validator deposit contract at the time of this state's eth1 data.
 func (b *BeaconState) Eth1DepositIndex() uint64 {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 
@@ -549,7 +417,7 @@ func (b *BeaconState) Eth1DepositIndex() uint64 {
 // validator deposit contract at the time of this state's eth1 data.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) eth1DepositIndex() uint64 {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 
@@ -558,7 +426,7 @@ func (b *BeaconState) eth1DepositIndex() uint64 {
 
 // Validators participating in consensus on the beacon chain.
 func (b *BeaconState) Validators() []*ethpb.Validator {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Validators == nil {
@@ -574,7 +442,7 @@ func (b *BeaconState) Validators() []*ethpb.Validator {
 // validators participating in consensus on the beacon chain.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) validators() []*ethpb.Validator {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Validators == nil {
@@ -596,7 +464,7 @@ func (b *BeaconState) validators() []*ethpb.Validator {
 // This assumes that a lock is already held on BeaconState. This does not
 // copy fully and instead just copies the reference.
 func (b *BeaconState) validatorsReferences() []*ethpb.Validator {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Validators == nil {
@@ -617,7 +485,7 @@ func (b *BeaconState) validatorsReferences() []*ethpb.Validator {
 
 // ValidatorAtIndex is the validator at the provided index.
 func (b *BeaconState) ValidatorAtIndex(idx types.ValidatorIndex) (*ethpb.Validator, error) {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil, ErrNilInnerState
 	}
 	if b.state.Validators == nil {
@@ -637,7 +505,7 @@ func (b *BeaconState) ValidatorAtIndex(idx types.ValidatorIndex) (*ethpb.Validat
 // ValidatorAtIndexReadOnly is the validator at the provided index. This method
 // doesn't clone the validator.
 func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (ReadOnlyValidator, error) {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ReadOnlyValidator{}, ErrNilInnerState
 	}
 	if b.state.Validators == nil {
@@ -677,7 +545,7 @@ func (b *BeaconState) validatorIndexMap() map[[48]byte]types.ValidatorIndex {
 // PubkeyAtIndex returns the pubkey at the given
 // validator index.
 func (b *BeaconState) PubkeyAtIndex(idx types.ValidatorIndex) [48]byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return [48]byte{}
 	}
 	if uint64(idx) >= uint64(len(b.state.Validators)) {
@@ -694,7 +562,7 @@ func (b *BeaconState) PubkeyAtIndex(idx types.ValidatorIndex) [48]byte {
 
 // NumValidators returns the size of the validator registry.
 func (b *BeaconState) NumValidators() int {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 	b.lock.RLock()
@@ -706,7 +574,7 @@ func (b *BeaconState) NumValidators() int {
 // ReadFromEveryValidator reads values from every validator and applies it to the provided function.
 // Warning: This method is potentially unsafe, as it exposes the actual validator registry.
 func (b *BeaconState) ReadFromEveryValidator(f func(idx int, val ReadOnlyValidator) error) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	if b.state.Validators == nil {
@@ -727,7 +595,7 @@ func (b *BeaconState) ReadFromEveryValidator(f func(idx int, val ReadOnlyValidat
 
 // Balances of validators participating in consensus on the beacon chain.
 func (b *BeaconState) Balances() []uint64 {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Balances == nil {
@@ -743,7 +611,7 @@ func (b *BeaconState) Balances() []uint64 {
 // balances of validators participating in consensus on the beacon chain.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) balances() []uint64 {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Balances == nil {
@@ -757,7 +625,7 @@ func (b *BeaconState) balances() []uint64 {
 
 // BalanceAtIndex of validator with the provided index.
 func (b *BeaconState) BalanceAtIndex(idx types.ValidatorIndex) (uint64, error) {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0, ErrNilInnerState
 	}
 	if b.state.Balances == nil {
@@ -775,7 +643,7 @@ func (b *BeaconState) BalanceAtIndex(idx types.ValidatorIndex) (uint64, error) {
 
 // BalancesLength returns the length of the balances slice.
 func (b *BeaconState) BalancesLength() int {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 	if b.state.Balances == nil {
@@ -791,7 +659,7 @@ func (b *BeaconState) BalancesLength() int {
 // balancesLength returns the length of the balances slice.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) balancesLength() int {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 	if b.state.Balances == nil {
@@ -803,7 +671,7 @@ func (b *BeaconState) balancesLength() int {
 
 // RandaoMixes of block proposers on the beacon chain.
 func (b *BeaconState) RandaoMixes() [][]byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.RandaoMixes == nil {
@@ -819,7 +687,7 @@ func (b *BeaconState) RandaoMixes() [][]byte {
 // randaoMixes of block proposers on the beacon chain.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) randaoMixes() [][]byte {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 
@@ -829,7 +697,7 @@ func (b *BeaconState) randaoMixes() [][]byte {
 // RandaoMixAtIndex retrieves a specific block root based on an
 // input index value.
 func (b *BeaconState) RandaoMixAtIndex(idx uint64) ([]byte, error) {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil, ErrNilInnerState
 	}
 	if b.state.RandaoMixes == nil {
@@ -846,7 +714,7 @@ func (b *BeaconState) RandaoMixAtIndex(idx uint64) ([]byte, error) {
 // input index value.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) randaoMixAtIndex(idx uint64) ([]byte, error) {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil, ErrNilInnerState
 	}
 
@@ -855,7 +723,7 @@ func (b *BeaconState) randaoMixAtIndex(idx uint64) ([]byte, error) {
 
 // RandaoMixesLength returns the length of the randao mixes slice.
 func (b *BeaconState) RandaoMixesLength() int {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 	if b.state.RandaoMixes == nil {
@@ -871,7 +739,7 @@ func (b *BeaconState) RandaoMixesLength() int {
 // randaoMixesLength returns the length of the randao mixes slice.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) randaoMixesLength() int {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 	if b.state.RandaoMixes == nil {
@@ -883,7 +751,7 @@ func (b *BeaconState) randaoMixesLength() int {
 
 // Slashings of validators on the beacon chain.
 func (b *BeaconState) Slashings() []uint64 {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Slashings == nil {
@@ -899,7 +767,7 @@ func (b *BeaconState) Slashings() []uint64 {
 // slashings of validators on the beacon chain.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) slashings() []uint64 {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.Slashings == nil {
@@ -913,7 +781,7 @@ func (b *BeaconState) slashings() []uint64 {
 
 // PreviousEpochAttestations corresponding to blocks on the beacon chain.
 func (b *BeaconState) PreviousEpochAttestations() []*pbp2p.PendingAttestation {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.PreviousEpochAttestations == nil {
@@ -929,7 +797,7 @@ func (b *BeaconState) PreviousEpochAttestations() []*pbp2p.PendingAttestation {
 // previousEpochAttestations corresponding to blocks on the beacon chain.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) previousEpochAttestations() []*pbp2p.PendingAttestation {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 
@@ -938,7 +806,7 @@ func (b *BeaconState) previousEpochAttestations() []*pbp2p.PendingAttestation {
 
 // CurrentEpochAttestations corresponding to blocks on the beacon chain.
 func (b *BeaconState) CurrentEpochAttestations() []*pbp2p.PendingAttestation {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.CurrentEpochAttestations == nil {
@@ -954,7 +822,7 @@ func (b *BeaconState) CurrentEpochAttestations() []*pbp2p.PendingAttestation {
 // currentEpochAttestations corresponding to blocks on the beacon chain.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) currentEpochAttestations() []*pbp2p.PendingAttestation {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 
@@ -963,7 +831,7 @@ func (b *BeaconState) currentEpochAttestations() []*pbp2p.PendingAttestation {
 
 // JustificationBits marking which epochs have been justified in the beacon chain.
 func (b *BeaconState) JustificationBits() bitfield.Bitvector4 {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.JustificationBits == nil {
@@ -979,7 +847,7 @@ func (b *BeaconState) JustificationBits() bitfield.Bitvector4 {
 // justificationBits marking which epochs have been justified in the beacon chain.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) justificationBits() bitfield.Bitvector4 {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.JustificationBits == nil {
@@ -993,7 +861,7 @@ func (b *BeaconState) justificationBits() bitfield.Bitvector4 {
 
 // PreviousJustifiedCheckpoint denoting an epoch and block root.
 func (b *BeaconState) PreviousJustifiedCheckpoint() *ethpb.Checkpoint {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.PreviousJustifiedCheckpoint == nil {
@@ -1009,7 +877,7 @@ func (b *BeaconState) PreviousJustifiedCheckpoint() *ethpb.Checkpoint {
 // previousJustifiedCheckpoint denoting an epoch and block root.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) previousJustifiedCheckpoint() *ethpb.Checkpoint {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 
@@ -1018,7 +886,7 @@ func (b *BeaconState) previousJustifiedCheckpoint() *ethpb.Checkpoint {
 
 // CurrentJustifiedCheckpoint denoting an epoch and block root.
 func (b *BeaconState) CurrentJustifiedCheckpoint() *ethpb.Checkpoint {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.CurrentJustifiedCheckpoint == nil {
@@ -1034,7 +902,7 @@ func (b *BeaconState) CurrentJustifiedCheckpoint() *ethpb.Checkpoint {
 // currentJustifiedCheckpoint denoting an epoch and block root.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) currentJustifiedCheckpoint() *ethpb.Checkpoint {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 
@@ -1044,7 +912,7 @@ func (b *BeaconState) currentJustifiedCheckpoint() *ethpb.Checkpoint {
 // MatchCurrentJustifiedCheckpoint returns true if input justified checkpoint matches
 // the current justified checkpoint in state.
 func (b *BeaconState) MatchCurrentJustifiedCheckpoint(c *ethpb.Checkpoint) bool {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return false
 	}
 	if b.state.CurrentJustifiedCheckpoint == nil {
@@ -1060,7 +928,7 @@ func (b *BeaconState) MatchCurrentJustifiedCheckpoint(c *ethpb.Checkpoint) bool 
 // MatchPreviousJustifiedCheckpoint returns true if the input justified checkpoint matches
 // the previous justified checkpoint in state.
 func (b *BeaconState) MatchPreviousJustifiedCheckpoint(c *ethpb.Checkpoint) bool {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return false
 	}
 	if b.state.PreviousJustifiedCheckpoint == nil {
@@ -1075,7 +943,7 @@ func (b *BeaconState) MatchPreviousJustifiedCheckpoint(c *ethpb.Checkpoint) bool
 
 // FinalizedCheckpoint denoting an epoch and block root.
 func (b *BeaconState) FinalizedCheckpoint() *ethpb.Checkpoint {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 	if b.state.FinalizedCheckpoint == nil {
@@ -1091,7 +959,7 @@ func (b *BeaconState) FinalizedCheckpoint() *ethpb.Checkpoint {
 // finalizedCheckpoint denoting an epoch and block root.
 // This assumes that a lock is already held on BeaconState.
 func (b *BeaconState) finalizedCheckpoint() *ethpb.Checkpoint {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 
@@ -1100,7 +968,7 @@ func (b *BeaconState) finalizedCheckpoint() *ethpb.Checkpoint {
 
 // FinalizedCheckpointEpoch returns the epoch value of the finalized checkpoint.
 func (b *BeaconState) FinalizedCheckpointEpoch() types.Epoch {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return 0
 	}
 	if b.state.FinalizedCheckpoint == nil {

--- a/beacon-chain/state/getters_test.go
+++ b/beacon-chain/state/getters_test.go
@@ -40,12 +40,10 @@ func TestNilState_NoPanic(t *testing.T) {
 	// retrieve elements from nil state
 	_ = st.GenesisTime()
 	_ = st.GenesisValidatorRoot()
-	_ = st.GenesisUnixTime()
 	_ = st.GenesisValidatorRoot()
 	_ = st.Slot()
 	_ = st.Fork()
 	_ = st.LatestBlockHeader()
-	_ = st.ParentRoot()
 	_ = st.BlockRoots()
 	_, err := st.BlockRootAtIndex(0)
 	_ = err
@@ -82,7 +80,6 @@ func TestNilState_NoPanic(t *testing.T) {
 func TestReadOnlyValidator_NoPanic(t *testing.T) {
 	v := &ReadOnlyValidator{}
 	assert.Equal(t, false, v.Slashed(), "Expected not slashed")
-	assert.Equal(t, (*eth.Validator)(nil), v.CopyValidator(), "Expected nil result")
 }
 
 func TestReadOnlyValidator_ActivationEligibilityEpochNoPanic(t *testing.T) {

--- a/beacon-chain/state/setters.go
+++ b/beacon-chain/state/setters.go
@@ -56,7 +56,7 @@ func (b *BeaconState) SetGenesisValidatorRoot(val []byte) error {
 
 // SetSlot for the beacon state.
 func (b *BeaconState) SetSlot(val types.Slot) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -69,7 +69,7 @@ func (b *BeaconState) SetSlot(val types.Slot) error {
 
 // SetFork version for the beacon chain.
 func (b *BeaconState) SetFork(val *pbp2p.Fork) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -86,7 +86,7 @@ func (b *BeaconState) SetFork(val *pbp2p.Fork) error {
 
 // SetLatestBlockHeader in the beacon state.
 func (b *BeaconState) SetLatestBlockHeader(val *ethpb.BeaconBlockHeader) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -100,7 +100,7 @@ func (b *BeaconState) SetLatestBlockHeader(val *ethpb.BeaconBlockHeader) error {
 // SetBlockRoots for the beacon state. Updates the entire
 // list to a new value by overwriting the previous one.
 func (b *BeaconState) SetBlockRoots(val [][]byte) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -118,7 +118,7 @@ func (b *BeaconState) SetBlockRoots(val [][]byte) error {
 // UpdateBlockRootAtIndex for the beacon state. Updates the block root
 // at a specific index to a new value.
 func (b *BeaconState) UpdateBlockRootAtIndex(idx uint64, blockRoot [32]byte) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	if uint64(len(b.state.BlockRoots)) <= idx {
@@ -147,7 +147,7 @@ func (b *BeaconState) UpdateBlockRootAtIndex(idx uint64, blockRoot [32]byte) err
 // SetStateRoots for the beacon state. Updates the state roots
 // to a new value by overwriting the previous value.
 func (b *BeaconState) SetStateRoots(val [][]byte) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -165,7 +165,7 @@ func (b *BeaconState) SetStateRoots(val [][]byte) error {
 // UpdateStateRootAtIndex for the beacon state. Updates the state root
 // at a specific index to a new value.
 func (b *BeaconState) UpdateStateRootAtIndex(idx uint64, stateRoot [32]byte) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 
@@ -200,7 +200,7 @@ func (b *BeaconState) UpdateStateRootAtIndex(idx uint64, stateRoot [32]byte) err
 // SetHistoricalRoots for the beacon state. Updates the entire
 // list to a new value by overwriting the previous one.
 func (b *BeaconState) SetHistoricalRoots(val [][]byte) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -216,7 +216,7 @@ func (b *BeaconState) SetHistoricalRoots(val [][]byte) error {
 
 // SetEth1Data for the beacon state.
 func (b *BeaconState) SetEth1Data(val *ethpb.Eth1Data) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -230,7 +230,7 @@ func (b *BeaconState) SetEth1Data(val *ethpb.Eth1Data) error {
 // SetEth1DataVotes for the beacon state. Updates the entire
 // list to a new value by overwriting the previous one.
 func (b *BeaconState) SetEth1DataVotes(val []*ethpb.Eth1Data) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -248,7 +248,7 @@ func (b *BeaconState) SetEth1DataVotes(val []*ethpb.Eth1Data) error {
 // AppendEth1DataVotes for the beacon state. Appends the new value
 // to the the end of list.
 func (b *BeaconState) AppendEth1DataVotes(val *ethpb.Eth1Data) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -271,7 +271,7 @@ func (b *BeaconState) AppendEth1DataVotes(val *ethpb.Eth1Data) error {
 
 // SetEth1DepositIndex for the beacon state.
 func (b *BeaconState) SetEth1DepositIndex(val uint64) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -285,7 +285,7 @@ func (b *BeaconState) SetEth1DepositIndex(val uint64) error {
 // SetValidators for the beacon state. Updates the entire
 // to a new value by overwriting the previous one.
 func (b *BeaconState) SetValidators(val []*ethpb.Validator) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -306,7 +306,7 @@ func (b *BeaconState) SetValidators(val []*ethpb.Validator) error {
 // ApplyToEveryValidator applies the provided callback function to each validator in the
 // validator registry.
 func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val *ethpb.Validator) (bool, *ethpb.Validator, error)) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -342,7 +342,7 @@ func (b *BeaconState) ApplyToEveryValidator(f func(idx int, val *ethpb.Validator
 // UpdateValidatorAtIndex for the beacon state. Updates the validator
 // at a specific index to a new value.
 func (b *BeaconState) UpdateValidatorAtIndex(idx types.ValidatorIndex, val *ethpb.Validator) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	if uint64(len(b.state.Validators)) <= uint64(idx) {
@@ -366,24 +366,10 @@ func (b *BeaconState) UpdateValidatorAtIndex(idx types.ValidatorIndex, val *ethp
 	return nil
 }
 
-// SetValidatorIndexByPubkey updates the validator index mapping maintained internally to
-// a given input 48-byte, public key.
-func (b *BeaconState) SetValidatorIndexByPubkey(pubKey [48]byte, validatorIndex types.ValidatorIndex) {
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	if ref := b.valMapHandler.mapRef; ref.Refs() > 1 {
-		valMap := b.valMapHandler.copy()
-		ref.MinusRef()
-		b.valMapHandler = valMap
-	}
-	b.valMapHandler.valIdxMap[pubKey] = validatorIndex
-}
-
 // SetBalances for the beacon state. Updates the entire
 // list to a new value by overwriting the previous one.
 func (b *BeaconState) SetBalances(val []uint64) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -400,7 +386,7 @@ func (b *BeaconState) SetBalances(val []uint64) error {
 // UpdateBalancesAtIndex for the beacon state. This method updates the balance
 // at a specific index to a new value.
 func (b *BeaconState) UpdateBalancesAtIndex(idx types.ValidatorIndex, val uint64) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	if uint64(len(b.state.Balances)) <= uint64(idx) {
@@ -425,7 +411,7 @@ func (b *BeaconState) UpdateBalancesAtIndex(idx types.ValidatorIndex, val uint64
 // SetRandaoMixes for the beacon state. Updates the entire
 // randao mixes to a new value by overwriting the previous one.
 func (b *BeaconState) SetRandaoMixes(val [][]byte) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -443,7 +429,7 @@ func (b *BeaconState) SetRandaoMixes(val [][]byte) error {
 // UpdateRandaoMixesAtIndex for the beacon state. Updates the randao mixes
 // at a specific index to a new value.
 func (b *BeaconState) UpdateRandaoMixesAtIndex(idx uint64, val []byte) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	if uint64(len(b.state.RandaoMixes)) <= idx {
@@ -472,7 +458,7 @@ func (b *BeaconState) UpdateRandaoMixesAtIndex(idx uint64, val []byte) error {
 // SetSlashings for the beacon state. Updates the entire
 // list to a new value by overwriting the previous one.
 func (b *BeaconState) SetSlashings(val []uint64) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -489,7 +475,7 @@ func (b *BeaconState) SetSlashings(val []uint64) error {
 // UpdateSlashingsAtIndex for the beacon state. Updates the slashings
 // at a specific index to a new value.
 func (b *BeaconState) UpdateSlashingsAtIndex(idx, val uint64) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	if uint64(len(b.state.Slashings)) <= idx {
@@ -516,7 +502,7 @@ func (b *BeaconState) UpdateSlashingsAtIndex(idx, val uint64) error {
 // SetPreviousEpochAttestations for the beacon state. Updates the entire
 // list to a new value by overwriting the previous one.
 func (b *BeaconState) SetPreviousEpochAttestations(val []*pbp2p.PendingAttestation) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -534,7 +520,7 @@ func (b *BeaconState) SetPreviousEpochAttestations(val []*pbp2p.PendingAttestati
 // SetCurrentEpochAttestations for the beacon state. Updates the entire
 // list to a new value by overwriting the previous one.
 func (b *BeaconState) SetCurrentEpochAttestations(val []*pbp2p.PendingAttestation) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -552,7 +538,7 @@ func (b *BeaconState) SetCurrentEpochAttestations(val []*pbp2p.PendingAttestatio
 // AppendHistoricalRoots for the beacon state. Appends the new value
 // to the the end of list.
 func (b *BeaconState) AppendHistoricalRoots(root [32]byte) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -574,7 +560,7 @@ func (b *BeaconState) AppendHistoricalRoots(root [32]byte) error {
 // AppendCurrentEpochAttestations for the beacon state. Appends the new value
 // to the the end of list.
 func (b *BeaconState) AppendCurrentEpochAttestations(val *pbp2p.PendingAttestation) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -598,7 +584,7 @@ func (b *BeaconState) AppendCurrentEpochAttestations(val *pbp2p.PendingAttestati
 // AppendPreviousEpochAttestations for the beacon state. Appends the new value
 // to the the end of list.
 func (b *BeaconState) AppendPreviousEpochAttestations(val *pbp2p.PendingAttestation) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -622,7 +608,7 @@ func (b *BeaconState) AppendPreviousEpochAttestations(val *pbp2p.PendingAttestat
 // AppendValidator for the beacon state. Appends the new value
 // to the the end of list.
 func (b *BeaconState) AppendValidator(val *ethpb.Validator) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -655,7 +641,7 @@ func (b *BeaconState) AppendValidator(val *ethpb.Validator) error {
 // AppendBalance for the beacon state. Appends the new value
 // to the the end of list.
 func (b *BeaconState) AppendBalance(bal uint64) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -675,7 +661,7 @@ func (b *BeaconState) AppendBalance(bal uint64) error {
 
 // SetJustificationBits for the beacon state.
 func (b *BeaconState) SetJustificationBits(val bitfield.Bitvector4) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -688,7 +674,7 @@ func (b *BeaconState) SetJustificationBits(val bitfield.Bitvector4) error {
 
 // SetPreviousJustifiedCheckpoint for the beacon state.
 func (b *BeaconState) SetPreviousJustifiedCheckpoint(val *ethpb.Checkpoint) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -701,7 +687,7 @@ func (b *BeaconState) SetPreviousJustifiedCheckpoint(val *ethpb.Checkpoint) erro
 
 // SetCurrentJustifiedCheckpoint for the beacon state.
 func (b *BeaconState) SetCurrentJustifiedCheckpoint(val *ethpb.Checkpoint) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()
@@ -714,7 +700,7 @@ func (b *BeaconState) SetCurrentJustifiedCheckpoint(val *ethpb.Checkpoint) error
 
 // SetFinalizedCheckpoint for the beacon state.
 func (b *BeaconState) SetFinalizedCheckpoint(val *ethpb.Checkpoint) error {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
 	b.lock.Lock()

--- a/beacon-chain/state/state_trie.go
+++ b/beacon-chain/state/state_trie.go
@@ -69,7 +69,7 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconState) (*BeaconState, error) {
 
 // Copy returns a deep copy of the beacon state.
 func (b *BeaconState) Copy() *BeaconState {
-	if !b.HasInnerState() {
+	if !b.hasInnerState() {
 		return nil
 	}
 

--- a/beacon-chain/state/validator_getters.go
+++ b/beacon-chain/state/validator_getters.go
@@ -1,0 +1,82 @@
+package state
+
+import (
+	types "github.com/prysmaticlabs/eth2-types"
+)
+
+// EffectiveBalance returns the effective balance of the
+// read only validator.
+func (v ReadOnlyValidator) EffectiveBalance() uint64 {
+	if v.IsNil() {
+		return 0
+	}
+	return v.validator.EffectiveBalance
+}
+
+// ActivationEligibilityEpoch returns the activation eligibility epoch of the
+// read only validator.
+func (v ReadOnlyValidator) ActivationEligibilityEpoch() types.Epoch {
+	if v.IsNil() {
+		return 0
+	}
+	return v.validator.ActivationEligibilityEpoch
+}
+
+// ActivationEpoch returns the activation epoch of the
+// read only validator.
+func (v ReadOnlyValidator) ActivationEpoch() types.Epoch {
+	if v.IsNil() {
+		return 0
+	}
+	return v.validator.ActivationEpoch
+}
+
+// WithdrawableEpoch returns the withdrawable epoch of the
+// read only validator.
+func (v ReadOnlyValidator) WithdrawableEpoch() types.Epoch {
+	if v.IsNil() {
+		return 0
+	}
+	return v.validator.WithdrawableEpoch
+}
+
+// ExitEpoch returns the exit epoch of the
+// read only validator.
+func (v ReadOnlyValidator) ExitEpoch() types.Epoch {
+	if v.IsNil() {
+		return 0
+	}
+	return v.validator.ExitEpoch
+}
+
+// PublicKey returns the public key of the
+// read only validator.
+func (v ReadOnlyValidator) PublicKey() [48]byte {
+	if v.IsNil() {
+		return [48]byte{}
+	}
+	var pubkey [48]byte
+	copy(pubkey[:], v.validator.PublicKey)
+	return pubkey
+}
+
+// WithdrawalCredentials returns the withdrawal credentials of the
+// read only validator.
+func (v ReadOnlyValidator) WithdrawalCredentials() []byte {
+	creds := make([]byte, len(v.validator.WithdrawalCredentials))
+	copy(creds, v.validator.WithdrawalCredentials)
+	return creds
+}
+
+// Slashed returns the read only validator is slashed.
+func (v ReadOnlyValidator) Slashed() bool {
+	if v.IsNil() {
+		return false
+	}
+	return v.validator.Slashed
+}
+
+// CopyValidator returns the copy of the read only validator.
+func (v ReadOnlyValidator) IsNil() bool {
+	return v.validator == nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
> Cleanup

**What does this PR do? Why is it needed?**
Before we use interface for state pkg's getter and setter, I want to do one round of clean up. Changes:
* `HasInnerState()` can be private `hasInnerState()`
*  Getter's `GenesisUnixTime` and `ParentRoot` are not used. They dont seem to have much use cases so deleting them
*  Setter's `SetValidatorIndexByPubkey` is not used. Deleting it
*  Validator read only getter's `CopyValidator()` is not used. Deleting it
* Move validator read only getter's to `validator_getter.go` to stay lean

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A