### PR TITLE
Update snappy to fix ARM64 with go.1.16 (Reverts #8538)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -60,10 +60,10 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "1f4fc1d91826ec436ae04833430626f4cc02c20bb0a813c0c2f3c4c421307b1d",
-    strip_prefix = "bazel-gazelle-e368a11b76e92932122d824970dc0ce5feb9c349",
+    sha256 = "222e49f034ca7a1d1231422cdb67066b885819885c356673cb1f72f748a3c9d4",
     urls = [
-        "https://github.com/bazelbuild/bazel-gazelle/archive/e368a11b76e92932122d824970dc0ce5feb9c349.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.3/bazel-gazelle-v0.22.3.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.3/bazel-gazelle-v0.22.3.tar.gz",
     ],
 )
 
@@ -156,7 +156,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.15.7",
+    go_version = "1.16",
     nogo = "@//:nogo",
 )
 

--- a/beacon-chain/core/state/stateutils/BUILD.bazel
+++ b/beacon-chain/core/state/stateutils/BUILD.bazel
@@ -20,8 +20,8 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = ["validator_index_map_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//beacon-chain/state:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",

--- a/beacon-chain/p2p/peers/peerdata/BUILD.bazel
+++ b/beacon-chain/p2p/peers/peerdata/BUILD.bazel
@@ -20,8 +20,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["store_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_libp2p_go_libp2p_core//peer:go_default_library",

--- a/beacon-chain/p2p/peers/scorers/BUILD.bazel
+++ b/beacon-chain/p2p/peers/scorers/BUILD.bazel
@@ -36,8 +36,8 @@ go_test(
         "scorers_test.go",
         "service_test.go",
     ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//beacon-chain/flags:go_default_library",
         "//beacon-chain/p2p/peers:go_default_library",
         "//beacon-chain/p2p/peers/peerdata:go_default_library",

--- a/contracts/deposit-contract/BUILD.bazel
+++ b/contracts/deposit-contract/BUILD.bazel
@@ -31,8 +31,8 @@ go_test(
         "depositContract_test.go",
         "deposit_tree_test.go",
     ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//shared/interop:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",

--- a/deps.bzl
+++ b/deps.bzl
@@ -168,6 +168,7 @@ def prysm_deps():
         sum = "h1:pv34s756C4pEXnjgPfGYgdhg/ZdajGhyOvzx8k+23nw=",
         version = "v0.0.0-20170710044230-e206f873d14a",
     )
+
     go_repository(
         name = "com_github_aws_aws_lambda_go",
         importpath = "github.com/aws/aws-lambda-go",
@@ -1059,6 +1060,10 @@ def prysm_deps():
         importpath = "github.com/googleapis/gnostic",
         sum = "h1:rVsPeBmXbYv4If/cumu1AzZPwV58q433hvONV1UEZoI=",
         version = "v0.1.0",
+        build_naming_convention = "go_default_library",
+        build_directives = [
+            "gazelle:resolve go github.com/googleapis/gnostic/extensions //extensions:go_default_library",
+        ],
     )
     go_repository(
         name = "com_github_gophercloud_gophercloud",
@@ -2860,6 +2865,7 @@ def prysm_deps():
         sum = "h1:njlZPzLwU639dk2kqnCPPv+wNjq7Xb6EfUxe/oX0/NM=",
         version = "v0.0.0-20180906055917-c99c65617cd3",
     )
+
     go_repository(
         name = "com_github_streadway_amqp",
         importpath = "github.com/streadway/amqp",
@@ -3394,6 +3400,7 @@ def prysm_deps():
         importpath = "k8s.io/client-go",
         sum = "h1:QaJzz92tsN67oorwzmoB0a9r9ZVHuD5ryjbCKP0U22k=",
         version = "v0.18.3",
+        build_naming_convention = "go_default_library",
     )
     go_repository(
         name = "io_k8s_gengo",

--- a/deps.bzl
+++ b/deps.bzl
@@ -969,8 +969,8 @@ def prysm_deps():
     go_repository(
         name = "com_github_golang_snappy",
         importpath = "github.com/golang/snappy",
-        sum = "h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=",
-        version = "v0.0.2",
+        sum = "h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=",
+        version = "v0.0.3",
     )
     go_repository(
         name = "com_github_google_btree",
@@ -1031,12 +1031,6 @@ def prysm_deps():
     )
 
     go_repository(
-        name = "com_github_google_shlex",
-        importpath = "github.com/google/shlex",
-        sum = "h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=",
-        version = "v0.0.0-20191202100458-e7afc7fbc510",
-    )
-    go_repository(
         name = "com_github_google_uuid",
         importpath = "github.com/google/uuid",
         sum = "h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=",
@@ -1057,13 +1051,13 @@ def prysm_deps():
     )
     go_repository(
         name = "com_github_googleapis_gnostic",
-        importpath = "github.com/googleapis/gnostic",
-        sum = "h1:rVsPeBmXbYv4If/cumu1AzZPwV58q433hvONV1UEZoI=",
-        version = "v0.1.0",
-        build_naming_convention = "go_default_library",
         build_directives = [
             "gazelle:resolve go github.com/googleapis/gnostic/extensions //extensions:go_default_library",
         ],
+        build_naming_convention = "go_default_library",
+        importpath = "github.com/googleapis/gnostic",
+        sum = "h1:rVsPeBmXbYv4If/cumu1AzZPwV58q433hvONV1UEZoI=",
+        version = "v0.1.0",
     )
     go_repository(
         name = "com_github_gophercloud_gophercloud",
@@ -3397,10 +3391,10 @@ def prysm_deps():
     go_repository(
         name = "io_k8s_client_go",
         build_extra_args = ["-exclude=vendor"],
+        build_naming_convention = "go_default_library",
         importpath = "k8s.io/client-go",
         sum = "h1:QaJzz92tsN67oorwzmoB0a9r9ZVHuD5ryjbCKP0U22k=",
         version = "v0.18.3",
-        build_naming_convention = "go_default_library",
     )
     go_repository(
         name = "io_k8s_gengo",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prysmaticlabs/prysm
 
-go 1.15
+go 1.16
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/golang/gddo v0.0.0-20200528160355-8d077c1d8f4c
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
-	github.com/golang/snappy v0.0.2
+	github.com/golang/snappy v0.0.3
 	github.com/google/gofuzz v1.2.0
 	github.com/google/gopacket v1.1.19 // indirect
 	github.com/google/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1657,7 +1657,6 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8l
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2-0.20200707131729-196ae77b8a26/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.2 h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=
-github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=

--- a/shared/attestationutil/BUILD.bazel
+++ b/shared/attestationutil/BUILD.bazel
@@ -21,8 +21,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["attestation_utils_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",

--- a/shared/bytesutil/BUILD.bazel
+++ b/shared/bytesutil/BUILD.bazel
@@ -16,8 +16,8 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = ["bytes_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",

--- a/shared/depositutil/BUILD.bazel
+++ b/shared/depositutil/BUILD.bazel
@@ -22,8 +22,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["deposit_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bls:go_default_library",

--- a/shared/fileutil/BUILD.bazel
+++ b/shared/fileutil/BUILD.bazel
@@ -16,8 +16,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["fileutil_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",

--- a/shared/hashutil/BUILD.bazel
+++ b/shared/hashutil/BUILD.bazel
@@ -26,8 +26,8 @@ go_test(
         "hash_test.go",
         "merkleRoot_test.go",
     ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//proto/testing:go_default_library",
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",

--- a/shared/htrutils/BUILD.bazel
+++ b/shared/htrutils/BUILD.bazel
@@ -33,8 +33,8 @@ go_test(
         "htrutils_test.go",
         "merkleize_test.go",
     ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/testutil/assert:go_default_library",

--- a/shared/interop/BUILD.bazel
+++ b/shared/interop/BUILD.bazel
@@ -33,8 +33,8 @@ go_test(
     data = [
         "keygen_test_vector.yaml",
     ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",

--- a/shared/iputils/BUILD.bazel
+++ b/shared/iputils/BUILD.bazel
@@ -12,9 +12,9 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = ["external_ip_test.go"],
+    embed = [":go_default_library"],
     tags = ["requires-network"],
     deps = [
-        ":go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
     ],

--- a/shared/mathutil/BUILD.bazel
+++ b/shared/mathutil/BUILD.bazel
@@ -12,8 +12,6 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = ["math_helper_test.go"],
-    deps = [
-        ":go_default_library",
-        "//shared/testutil/require:go_default_library",
-    ],
+    embed = [":go_default_library"],
+    deps = ["//shared/testutil/require:go_default_library"],
 )

--- a/shared/messagehandler/BUILD.bazel
+++ b/shared/messagehandler/BUILD.bazel
@@ -17,8 +17,8 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = ["messagehandler_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/shared/pagination/BUILD.bazel
+++ b/shared/pagination/BUILD.bazel
@@ -15,8 +15,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["pagination_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
     ],

--- a/shared/runutil/BUILD.bazel
+++ b/shared/runutil/BUILD.bazel
@@ -12,5 +12,5 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["every_test.go"],
-    deps = [":go_default_library"],
+    embed = [":go_default_library"],
 )

--- a/shared/sliceutil/BUILD.bazel
+++ b/shared/sliceutil/BUILD.bazel
@@ -16,8 +16,6 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = ["slice_test.go"],
-    deps = [
-        ":go_default_library",
-        "@com_github_prysmaticlabs_eth2_types//:go_default_library",
-    ],
+    embed = [":go_default_library"],
+    deps = ["@com_github_prysmaticlabs_eth2_types//:go_default_library"],
 )

--- a/shared/sszutil/BUILD.bazel
+++ b/shared/sszutil/BUILD.bazel
@@ -16,8 +16,8 @@ go_test(
     name = "go_default_test",
     size = "small",
     srcs = ["deep_equal_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/shared/testutil/assertions/BUILD.bazel
+++ b/shared/testutil/assertions/BUILD.bazel
@@ -17,8 +17,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["assertions_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",

--- a/slasher/detection/attestations/types/BUILD.bazel
+++ b/slasher/detection/attestations/types/BUILD.bazel
@@ -22,8 +22,8 @@ go_test(
         "epoch_store_test.go",
         "types_test.go",
     ],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "//slasher/db/testing:go_default_library",

--- a/validator/accounts/wallet/BUILD.bazel
+++ b/validator/accounts/wallet/BUILD.bazel
@@ -28,8 +28,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["wallet_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/validator/keymanager/BUILD.bazel
+++ b/validator/keymanager/BUILD.bazel
@@ -20,8 +20,8 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = ["types_test.go"],
+    embed = [":go_default_library"],
     deps = [
-        ":go_default_library",
         "//validator/keymanager/derived:go_default_library",
         "//validator/keymanager/imported:go_default_library",
         "//validator/keymanager/remote:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

go 1.16 had some register changes for ARM64 as a performance improvement. This broke snappy v0.0.2. 

- [x] Revert #8538 to restore go 1.16 upgrade #8521 
- [x] Update snappy to v0.0.3

**Which issues(s) does this PR fix?**

Fixes #8537 as a long term solution.

**Other notes for review**

See: https://github.com/golang/snappy/pull/56