### PR TITLE
Fallback to DB When Retrieving Missing Chunk in Optimized Slasher

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -58,7 +58,7 @@ type ReadOnlyDatabase interface {
 	// Powchain operations.
 	PowchainData(ctx context.Context) (*db.ETH1ChainData, error)
 	// Slasher operations.
-	LatestEpochAttestedForValidators(
+	LastCurrentEpochForValidators(
 		ctx context.Context, validatorIndices []types.ValidatorIndex,
 	) ([]*slashertypes.AttestedEpochForValidator, error)
 	AttestationRecordForValidator(
@@ -103,7 +103,7 @@ type NoHeadAccessDatabase interface {
 	// Powchain operations.
 	SavePowchainData(ctx context.Context, data *db.ETH1ChainData) error
 	// Slasher operations.
-	SaveLatestEpochAttestedForValidators(
+	SaveCurrentEpochForValidators(
 		ctx context.Context, validatorIndices []types.ValidatorIndex, epoch types.Epoch,
 	) error
 	SaveAttestationRecordsForValidators(

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -58,7 +58,7 @@ type ReadOnlyDatabase interface {
 	// Powchain operations.
 	PowchainData(ctx context.Context) (*db.ETH1ChainData, error)
 	// Slasher operations.
-	LastCurrentEpochForValidators(
+	LastEpochWrittenForValidators(
 		ctx context.Context, validatorIndices []types.ValidatorIndex,
 	) ([]*slashertypes.AttestedEpochForValidator, error)
 	AttestationRecordForValidator(
@@ -103,7 +103,7 @@ type NoHeadAccessDatabase interface {
 	// Powchain operations.
 	SavePowchainData(ctx context.Context, data *db.ETH1ChainData) error
 	// Slasher operations.
-	SaveCurrentEpochForValidators(
+	SaveLastEpochWrittenForValidators(
 		ctx context.Context, validatorIndices []types.ValidatorIndex, epoch types.Epoch,
 	) error
 	SaveAttestationRecordsForValidators(

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -269,10 +269,10 @@ func (e Exporter) CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint 
 }
 
 // LatestEpochAttestedForValidator -- passthrough
-func (e Exporter) LatestEpochAttestedForValidators(
+func (e Exporter) LastCurrentEpochForValidators(
 	ctx context.Context, validatorIndices []types.ValidatorIndex,
 ) ([]*slashertypes.AttestedEpochForValidator, error) {
-	return e.db.LatestEpochAttestedForValidators(ctx, validatorIndices)
+	return e.db.LastCurrentEpochForValidators(ctx, validatorIndices)
 }
 
 // AttestationRecordForValidator -- passthrough
@@ -297,10 +297,10 @@ func (e Exporter) LoadSlasherChunks(
 }
 
 // SaveLatestEpochAttestedForValidators -- passthrough
-func (e Exporter) SaveLatestEpochAttestedForValidators(
+func (e Exporter) SaveCurrentEpochForValidators(
 	ctx context.Context, validatorIndices []types.ValidatorIndex, epoch types.Epoch,
 ) error {
-	return e.db.SaveLatestEpochAttestedForValidators(ctx, validatorIndices, epoch)
+	return e.db.SaveCurrentEpochForValidators(ctx, validatorIndices, epoch)
 }
 
 // SaveAttestationRecordForValidator -- passthrough

--- a/beacon-chain/db/kafka/passthrough.go
+++ b/beacon-chain/db/kafka/passthrough.go
@@ -268,11 +268,11 @@ func (e Exporter) CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint 
 	return e.db.RunMigrations(ctx)
 }
 
-// LatestEpochAttestedForValidator -- passthrough
-func (e Exporter) LastCurrentEpochForValidators(
+// LastEpochWrittenForValidator -- passthrough
+func (e Exporter) LastEpochWrittenForValidators(
 	ctx context.Context, validatorIndices []types.ValidatorIndex,
 ) ([]*slashertypes.AttestedEpochForValidator, error) {
-	return e.db.LastCurrentEpochForValidators(ctx, validatorIndices)
+	return e.db.LastEpochWrittenForValidators(ctx, validatorIndices)
 }
 
 // AttestationRecordForValidator -- passthrough
@@ -296,11 +296,11 @@ func (e Exporter) LoadSlasherChunks(
 	return e.db.LoadSlasherChunks(ctx, kind, diskKeys)
 }
 
-// SaveLatestEpochAttestedForValidators -- passthrough
-func (e Exporter) SaveCurrentEpochForValidators(
+// SaveLastEpochWrittenForValidators -- passthrough
+func (e Exporter) SaveLastEpochWrittenForValidators(
 	ctx context.Context, validatorIndices []types.ValidatorIndex, epoch types.Epoch,
 ) error {
-	return e.db.SaveCurrentEpochForValidators(ctx, validatorIndices, epoch)
+	return e.db.SaveLastEpochWrittenForValidators(ctx, validatorIndices, epoch)
 }
 
 // SaveAttestationRecordForValidator -- passthrough

--- a/beacon-chain/db/kv/slasher.go
+++ b/beacon-chain/db/kv/slasher.go
@@ -15,10 +15,10 @@ import (
 
 // LatestEpochAttestedForValidator given a validator index returns the latest
 // epoch we have recorded the validator attested for.
-func (s *Store) LatestEpochAttestedForValidators(
+func (s *Store) LastCurrentEpochForValidators(
 	ctx context.Context, validatorIndices []types.ValidatorIndex,
 ) ([]*slashertypes.AttestedEpochForValidator, error) {
-	ctx, span := trace.StartSpan(ctx, "BeaconDB.LatestEpochAttestedForValidators")
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.LastCurrentEpochForValidators")
 	defer span.End()
 	attestedEpochs := make([]*slashertypes.AttestedEpochForValidator, 0)
 	err := s.db.View(func(tx *bolt.Tx) error {
@@ -47,19 +47,19 @@ func (s *Store) LatestEpochAttestedForValidators(
 
 // SaveLatestEpochAttestedForValidators updates the latest epoch a slice
 // of validator indices has attested to.
-func (s *Store) SaveLatestEpochAttestedForValidators(
+func (s *Store) SaveCurrentEpochForValidators(
 	ctx context.Context, validatorIndices []types.ValidatorIndex, epoch types.Epoch,
 ) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveLatestEpochAttestedForValidator")
 	defer span.End()
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(attestedEpochsByValidator)
+		val, err := epoch.MarshalSSZ()
+		if err != nil {
+			return err
+		}
 		for _, valIdx := range validatorIndices {
 			key, err := valIdx.MarshalSSZ()
-			if err != nil {
-				return err
-			}
-			val, err := epoch.MarshalSSZ()
 			if err != nil {
 				return err
 			}

--- a/beacon-chain/db/kv/slasher.go
+++ b/beacon-chain/db/kv/slasher.go
@@ -13,12 +13,12 @@ import (
 	"go.opencensus.io/trace"
 )
 
-// LatestEpochAttestedForValidator given a validator index returns the latest
+// LastEpochWrittenForValidator given a validator index returns the latest
 // epoch we have recorded the validator attested for.
-func (s *Store) LastCurrentEpochForValidators(
+func (s *Store) LastEpochWrittenForValidators(
 	ctx context.Context, validatorIndices []types.ValidatorIndex,
 ) ([]*slashertypes.AttestedEpochForValidator, error) {
-	ctx, span := trace.StartSpan(ctx, "BeaconDB.LastCurrentEpochForValidators")
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.LastEpochWrittenForValidators")
 	defer span.End()
 	attestedEpochs := make([]*slashertypes.AttestedEpochForValidator, 0)
 	err := s.db.View(func(tx *bolt.Tx) error {
@@ -45,12 +45,12 @@ func (s *Store) LastCurrentEpochForValidators(
 	return attestedEpochs, err
 }
 
-// SaveLatestEpochAttestedForValidators updates the latest epoch a slice
+// SaveLastEpochWrittenForValidators updates the latest epoch a slice
 // of validator indices has attested to.
-func (s *Store) SaveCurrentEpochForValidators(
+func (s *Store) SaveLastEpochWrittenForValidators(
 	ctx context.Context, validatorIndices []types.ValidatorIndex, epoch types.Epoch,
 ) error {
-	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveLatestEpochAttestedForValidator")
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveLastEpochWrittenForValidators")
 	defer span.End()
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(attestedEpochsByValidator)

--- a/beacon-chain/db/kv/slasher_test.go
+++ b/beacon-chain/db/kv/slasher_test.go
@@ -35,20 +35,20 @@ func TestStore_AttestationRecordForValidator_SaveRetrieve(t *testing.T) {
 	assert.DeepEqual(t, sr, attRecord.SigningRoot)
 }
 
-func TestStore_LatestEpochAttestedForValidators(t *testing.T) {
+func TestStore_LastEpochWrittenForValidators(t *testing.T) {
 	ctx := context.Background()
 	beaconDB := setupDB(t)
 	indices := []types.ValidatorIndex{1, 2, 3}
 	epoch := types.Epoch(5)
 
-	attestedEpochs, err := beaconDB.LastCurrentEpochForValidators(ctx, indices)
+	attestedEpochs, err := beaconDB.LastEpochWrittenForValidators(ctx, indices)
 	require.NoError(t, err)
 	require.Equal(t, true, len(attestedEpochs) == 0)
 
-	err = beaconDB.SaveCurrentEpochForValidators(ctx, indices, epoch)
+	err = beaconDB.SaveLastEpochWrittenForValidators(ctx, indices, epoch)
 	require.NoError(t, err)
 
-	retrievedEpochs, err := beaconDB.LastCurrentEpochForValidators(ctx, indices)
+	retrievedEpochs, err := beaconDB.LastEpochWrittenForValidators(ctx, indices)
 	require.NoError(t, err)
 	require.Equal(t, len(indices), len(retrievedEpochs))
 

--- a/beacon-chain/db/kv/slasher_test.go
+++ b/beacon-chain/db/kv/slasher_test.go
@@ -41,14 +41,14 @@ func TestStore_LatestEpochAttestedForValidators(t *testing.T) {
 	indices := []types.ValidatorIndex{1, 2, 3}
 	epoch := types.Epoch(5)
 
-	attestedEpochs, err := beaconDB.LatestEpochAttestedForValidators(ctx, indices)
+	attestedEpochs, err := beaconDB.LastCurrentEpochForValidators(ctx, indices)
 	require.NoError(t, err)
 	require.Equal(t, true, len(attestedEpochs) == 0)
 
-	err = beaconDB.SaveLatestEpochAttestedForValidators(ctx, indices, epoch)
+	err = beaconDB.SaveCurrentEpochForValidators(ctx, indices, epoch)
 	require.NoError(t, err)
 
-	retrievedEpochs, err := beaconDB.LatestEpochAttestedForValidators(ctx, indices)
+	retrievedEpochs, err := beaconDB.LastCurrentEpochForValidators(ctx, indices)
 	require.NoError(t, err)
 	require.Equal(t, len(indices), len(retrievedEpochs))
 

--- a/beacon-chain/slasher/BUILD.bazel
+++ b/beacon-chain/slasher/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//shared/testutil/require:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
     ],
 )

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -79,7 +79,7 @@ func (s *Service) detectSlashableAttestations(
 
 	// Update the latest written epoch for all involved validator indices.
 	validatorIndices := s.params.validatorIndicesInChunk(args.validatorChunkIndex)
-	return s.serviceCfg.Database.SaveCurrentEpochForValidators(ctx, validatorIndices, args.currentEpoch)
+	return s.serviceCfg.Database.SaveLastEpochWrittenForValidators(ctx, validatorIndices, args.currentEpoch)
 }
 
 // Check for attester slashing double votes by looking at every single validator index
@@ -228,7 +228,7 @@ func (s *Service) determineChunksToUpdateForValidators(
 ) (chunkIndices []uint64, err error) {
 	ctx, span := trace.StartSpan(ctx, "Slasher.determineChunksToUpdateForValidators")
 	defer span.End()
-	lastCurrentEpochs, err := s.serviceCfg.Database.LastCurrentEpochForValidators(ctx, validatorIndices)
+	lastCurrentEpochs, err := s.serviceCfg.Database.LastEpochWrittenForValidators(ctx, validatorIndices)
 	if err != nil {
 		return
 	}

--- a/beacon-chain/slasher/detect_attestations.go
+++ b/beacon-chain/slasher/detect_attestations.go
@@ -79,7 +79,7 @@ func (s *Service) detectSlashableAttestations(
 
 	// Update the latest written epoch for all involved validator indices.
 	validatorIndices := s.params.validatorIndicesInChunk(args.validatorChunkIndex)
-	return s.serviceCfg.Database.SaveLatestEpochAttestedForValidators(ctx, validatorIndices, args.currentEpoch)
+	return s.serviceCfg.Database.SaveCurrentEpochForValidators(ctx, validatorIndices, args.currentEpoch)
 }
 
 // Check for attester slashing double votes by looking at every single validator index
@@ -228,27 +228,26 @@ func (s *Service) determineChunksToUpdateForValidators(
 ) (chunkIndices []uint64, err error) {
 	ctx, span := trace.StartSpan(ctx, "Slasher.determineChunksToUpdateForValidators")
 	defer span.End()
-	attestedEpochs, err := s.serviceCfg.Database.LatestEpochAttestedForValidators(ctx, validatorIndices)
+	lastCurrentEpochs, err := s.serviceCfg.Database.LastCurrentEpochForValidators(ctx, validatorIndices)
 	if err != nil {
 		return
 	}
+
+	// Initialize the last epoch written for each validator to 0.
+	lastCurrentEpochByValidator := make(map[types.ValidatorIndex]types.Epoch, len(validatorIndices))
+	for _, valIdx := range validatorIndices {
+		lastCurrentEpochByValidator[valIdx] = 0
+	}
+	for _, lastEpoch := range lastCurrentEpochs {
+		lastCurrentEpochByValidator[lastEpoch.ValidatorIndex] = lastEpoch.Epoch
+	}
+
+	// For every single validator and their last written current epoch, we determine
+	// the chunk indices we need to update based on all the chunks between the last
+	// epoch written and the current epoch, inclusive.
 	chunkIndicesToUpdate := make(map[uint64]bool)
 
-	// Initialize the latest epoch attested for each validator to 0.
-	latestEpochAttestedByValidator := make(map[types.ValidatorIndex]types.Epoch, len(validatorIndices))
-	for _, valIdx := range validatorIndices {
-		latestEpochAttestedByValidator[valIdx] = 0
-	}
-	// If we have indeed attested an epoch, we update that value in
-	// the map from the previous step.
-	for _, attestedEpoch := range attestedEpochs {
-		latestEpochAttestedByValidator[attestedEpoch.ValidatorIndex] = attestedEpoch.Epoch
-	}
-
-	// For every single validator and their latest epoch attested, we determine
-	// the chunk indices we need to update based on all the chunks between the latest
-	// epoch written and the current epoch, inclusive.
-	for _, epoch := range latestEpochAttestedByValidator {
+	for _, epoch := range lastCurrentEpochByValidator {
 		latestEpochWritten := epoch
 		for latestEpochWritten <= args.currentEpoch {
 			chunkIdx := s.params.chunkIndex(latestEpochWritten)
@@ -279,11 +278,9 @@ func (s *Service) applyAttestationForValidator(
 	sourceEpoch := attestation.IndexedAttestation.Data.Source.Epoch
 	targetEpoch := attestation.IndexedAttestation.Data.Target.Epoch
 	chunkIdx := s.params.chunkIndex(sourceEpoch)
-	chunk, ok := chunksByChunkIdx[chunkIdx]
-	if !ok {
-		// It is possible we receive an attestation corresponding to a chunk index
-		// we are not yet updating, so we ignore.
-		return nil, nil
+	chunk, err := s.getChunk(ctx, args, chunksByChunkIdx, chunkIdx)
+	if err != nil {
+		return nil, err
 	}
 
 	// Check slashable, if so, return the slashing.
@@ -315,9 +312,9 @@ func (s *Service) applyAttestationForValidator(
 	// keep updating chunks.
 	for {
 		chunkIdx = s.params.chunkIndex(startEpoch)
-		chunk, ok = chunksByChunkIdx[chunkIdx]
-		if !ok {
-			return nil, fmt.Errorf("chunk at chunk index %d not found", chunkIdx)
+		chunk, err := s.getChunk(ctx, args, chunksByChunkIdx, chunkIdx)
+		if err != nil {
+			return nil, err
 		}
 		keepGoing, err := chunk.Update(
 			&chunkUpdateArgs{
@@ -340,6 +337,30 @@ func (s *Service) applyAttestationForValidator(
 		startEpoch = chunk.NextChunkStartEpoch(startEpoch)
 	}
 	return nil, nil
+}
+
+// Retrieves a chunk at a chunk index from a map. If such chunk does not exist, which
+// should be rare (occurring when we receive an attestation with source and target epochs
+// that span multiple chunk indices), then we fallback to fetching from disk.
+func (s *Service) getChunk(
+	ctx context.Context,
+	args *chunkUpdateArgs,
+	chunksByChunkIdx map[uint64]Chunker,
+	chunkIdx uint64,
+) (Chunker, error) {
+	chunk, ok := chunksByChunkIdx[chunkIdx]
+	if ok {
+		return chunk, nil
+	}
+	// We can ensure we load the appropriate chunk we need by fetching from the DB.
+	diskChunks, err := s.loadChunks(ctx, args, []uint64{chunkIdx})
+	if err != nil {
+		return nil, err
+	}
+	if chunk, ok := diskChunks[chunkIdx]; ok {
+		return chunk, nil
+	}
+	return nil, fmt.Errorf("could not retrieve chunk at chunk index %d from disk", chunkIdx)
 }
 
 // Load chunks for a specified list of chunk indices. We attempt to load it from the database.

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -37,7 +37,7 @@ func Test_determineChunksToUpdateForValidators_FromLatestWrittenEpoch(t *testing
 
 	// Set the latest written epoch for validators to current epoch - 1.
 	latestWrittenEpoch := currentEpoch - 1
-	err := beaconDB.SaveCurrentEpochForValidators(ctx, validators, latestWrittenEpoch)
+	err := beaconDB.SaveLastEpochWrittenForValidators(ctx, validators, latestWrittenEpoch)
 	require.NoError(t, err)
 
 	// Because the validators have no recorded latest epoch written in the database,

--- a/beacon-chain/slasher/detect_attestations_test.go
+++ b/beacon-chain/slasher/detect_attestations_test.go
@@ -37,7 +37,7 @@ func Test_determineChunksToUpdateForValidators_FromLatestWrittenEpoch(t *testing
 
 	// Set the latest written epoch for validators to current epoch - 1.
 	latestWrittenEpoch := currentEpoch - 1
-	err := beaconDB.SaveLatestEpochAttestedForValidators(ctx, validators, latestWrittenEpoch)
+	err := beaconDB.SaveCurrentEpochForValidators(ctx, validators, latestWrittenEpoch)
 	require.NoError(t, err)
 
 	// Because the validators have no recorded latest epoch written in the database,

--- a/beacon-chain/slasher/detect_blocks_test.go
+++ b/beacon-chain/slasher/detect_blocks_test.go
@@ -31,12 +31,14 @@ func Test_processQueuedBlocks_DetectsDoubleProposals(t *testing.T) {
 		s.processQueuedBlocks(ctx, currentEpochChan)
 		exitChan <- struct{}{}
 	}()
+	s.blockQueueLock.Lock()
 	s.beaconBlocksQueue = []*slashertypes.SignedBlockHeaderWrapper{
 		createProposalWrapper(4, 1, []byte{1}),
 		createProposalWrapper(4, 1, []byte{1}),
 		createProposalWrapper(4, 1, []byte{1}),
 		createProposalWrapper(4, 1, []byte{2}),
 	}
+	s.blockQueueLock.Unlock()
 	currentEpoch := types.Epoch(0)
 	currentEpochChan <- currentEpoch
 	cancel()
@@ -61,10 +63,12 @@ func Test_processQueuedBlocks_NotSlashable(t *testing.T) {
 		s.processQueuedBlocks(ctx, currentEpochChan)
 		exitChan <- struct{}{}
 	}()
+	s.blockQueueLock.Lock()
 	s.beaconBlocksQueue = []*slashertypes.SignedBlockHeaderWrapper{
 		createProposalWrapper(4, 1, []byte{1}),
 		createProposalWrapper(4, 1, []byte{1}),
 	}
+	s.blockQueueLock.Unlock()
 	currentEpoch := types.Epoch(4)
 	currentEpochChan <- currentEpoch
 	cancel()

--- a/beacon-chain/slasher/receive_test.go
+++ b/beacon-chain/slasher/receive_test.go
@@ -240,6 +240,7 @@ func Test_processQueuedAttestations_MultipleChunkIndices(t *testing.T) {
 			source = i - 1
 			target = i
 		}
+		s.attestationQueueLock.Lock()
 		s.attestationQueue = []*slashertypes.CompactAttestation{
 			{
 				AttestingIndices: []uint64{0},
@@ -247,6 +248,7 @@ func Test_processQueuedAttestations_MultipleChunkIndices(t *testing.T) {
 				Target:           target,
 			},
 		}
+		s.attestationQueueLock.Unlock()
 		currentEpochChan <- i
 	}
 

--- a/beacon-chain/slasher/receive_test.go
+++ b/beacon-chain/slasher/receive_test.go
@@ -245,7 +245,6 @@ func Test_processQueuedAttestations_MultipleChunkIndices(t *testing.T) {
 		var sr [32]byte
 		copy(sr[:], fmt.Sprintf("%d", i))
 		att := createAttestationWrapper(source, target, []uint64{0}, sr[:])
-		t.Log(params.chunkIndex(source))
 		s.attestationQueue = []*slashertypes.IndexedAttestationWrapper{att}
 		s.attestationQueueLock.Unlock()
 		currentEpochChan <- i

--- a/beacon-chain/slasher/service_test.go
+++ b/beacon-chain/slasher/service_test.go
@@ -2,11 +2,20 @@ package slasher
 
 import (
 	"context"
+	"io/ioutil"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/event"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"github.com/sirupsen/logrus"
 )
+
+func TestMain(m *testing.M) {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(ioutil.Discard)
+
+	m.Run()
+}
 
 func TestService_StartStop(t *testing.T) {
 	srv, err := New(context.Background(), &ServiceConfig{


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Currently, slasher chunks for min/max spans in the optimized slasher implementation track only 16 epochs at a time. Our code works fine until we get an attestation that spans multple chunks, in which we get an issue of "chunk not found", and then slasher failing to work as expected for its entire duration.

The issue can be reproduced by creating an attestation with source 15 and target 16. This attestation lives in 2 different chunk indices, and our current approach could not handle this. As a solution, we fallback to the DB to retrieve a chunk if we get an attestation across chunk boundaries for ease of access.

**Which issues(s) does this PR fix?**

Part of #8331 

**Other notes for review**

It seems that some slasher tests were also flakey, because we should be using mutexes in the lock as the tests directly deal with concurrency. This allowed the tests to always pass. Specifically, some tests had `processAttestations()` running in the background, but modifying the queue without acquiring the lock in another goroutine.
