### PR TITLE
Validator: Remove optional and duplicated dialopts for streaming middleware

### DIFF
--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -123,17 +123,11 @@ func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, e
 // Start the validator service. Launches the main go routine for the validator
 // client.
 func (v *ValidatorService) Start() {
-	streamInterceptor := grpc.WithStreamInterceptor(middleware.ChainStreamClient(
-		grpc_opentracing.StreamClientInterceptor(),
-		grpc_prometheus.StreamClientInterceptor,
-		grpc_retry.StreamClientInterceptor(),
-	))
 	dialOpts := ConstructDialOptions(
 		v.maxCallRecvMsgSize,
 		v.withCert,
 		v.grpcRetries,
 		v.grpcRetryDelay,
-		streamInterceptor,
 	)
 	if dialOpts == nil {
 		return


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This stream interceptor is already defined in ConstructDialOptions. 

https://github.com/prysmaticlabs/prysm/blob/5a299ae6b72746a7ad319e05542d4ebff702abc0/validator/client/service.go#L258-L309

**Which issues(s) does this PR fix?**

None reported

**Other notes for review**
