### PR TITLE
Simplify API beacon pool tests

### DIFF
--- a/beacon-chain/rpc/beaconv1/pool_test.go
+++ b/beacon-chain/rpc/beaconv1/pool_test.go
@@ -207,9 +207,7 @@ func TestSubmitAttesterSlashing_Ok(t *testing.T) {
 	_, keys, err := testutil.DeterministicDepositsAndKeys(1)
 	require.NoError(t, err)
 	validator := &eth.Validator{
-		ExitEpoch:             params.BeaconConfig().FarFutureEpoch,
-		PublicKey:             keys[0].PublicKey().Marshal(),
-		WithdrawalCredentials: make([]byte, 32),
+		PublicKey: keys[0].PublicKey().Marshal(),
 	}
 	state, err := testutil.NewBeaconState(func(state *pb.BeaconState) {
 		state.Validators = []*eth.Validator{validator}
@@ -322,10 +320,8 @@ func TestSubmitProposerSlashing_Ok(t *testing.T) {
 	_, keys, err := testutil.DeterministicDepositsAndKeys(1)
 	require.NoError(t, err)
 	validator := &eth.Validator{
-		ExitEpoch:             params.BeaconConfig().FarFutureEpoch,
-		PublicKey:             keys[0].PublicKey().Marshal(),
-		WithdrawalCredentials: make([]byte, 32),
-		WithdrawableEpoch:     eth2types.Epoch(1),
+		PublicKey:         keys[0].PublicKey().Marshal(),
+		WithdrawableEpoch: eth2types.Epoch(1),
 	}
 	state, err := testutil.NewBeaconState(func(state *pb.BeaconState) {
 		state.Validators = []*eth.Validator{validator}
@@ -423,9 +419,8 @@ func TestSubmitVoluntaryExit_Ok(t *testing.T) {
 	_, keys, err := testutil.DeterministicDepositsAndKeys(1)
 	require.NoError(t, err)
 	validator := &eth.Validator{
-		ExitEpoch:             params.BeaconConfig().FarFutureEpoch,
-		PublicKey:             keys[0].PublicKey().Marshal(),
-		WithdrawalCredentials: make([]byte, 32),
+		ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+		PublicKey: keys[0].PublicKey().Marshal(),
 	}
 	state, err := testutil.NewBeaconState(func(state *pb.BeaconState) {
 		state.Validators = []*eth.Validator{validator}
@@ -469,9 +464,8 @@ func TestSubmitVoluntaryExit_InvalidValidatorIndex(t *testing.T) {
 	_, keys, err := testutil.DeterministicDepositsAndKeys(1)
 	require.NoError(t, err)
 	validator := &eth.Validator{
-		ExitEpoch:             params.BeaconConfig().FarFutureEpoch,
-		PublicKey:             keys[0].PublicKey().Marshal(),
-		WithdrawalCredentials: make([]byte, 32),
+		ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+		PublicKey: keys[0].PublicKey().Marshal(),
 	}
 	state, err := testutil.NewBeaconState(func(state *pb.BeaconState) {
 		state.Validators = []*eth.Validator{validator}
@@ -504,9 +498,8 @@ func TestSubmitVoluntaryExit_InvalidExit(t *testing.T) {
 	_, keys, err := testutil.DeterministicDepositsAndKeys(1)
 	require.NoError(t, err)
 	validator := &eth.Validator{
-		ExitEpoch:             params.BeaconConfig().FarFutureEpoch,
-		PublicKey:             keys[0].PublicKey().Marshal(),
-		WithdrawalCredentials: make([]byte, 32),
+		ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+		PublicKey: keys[0].PublicKey().Marshal(),
 	}
 	state, err := testutil.NewBeaconState(func(state *pb.BeaconState) {
 		state.Validators = []*eth.Validator{validator}

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -12,7 +12,7 @@ type BeaconChainConfig struct {
 	// Constants (non-configurable)
 	GenesisSlot              types.Slot  `yaml:"GENESIS_SLOT"`                // GenesisSlot represents the first canonical slot number of the beacon chain.
 	GenesisEpoch             types.Epoch `yaml:"GENESIS_EPOCH"`               // GenesisEpoch represents the first canonical epoch number of the beacon chain.
-	FarFutureEpoch           types.Epoch `yaml:"FAR_FUTURE_EPOCH"`            // FarFutureEpoch represents a epoch extremely far away in the future used as the default penalization slot for validators.
+	FarFutureEpoch           types.Epoch `yaml:"FAR_FUTURE_EPOCH"`            // FarFutureEpoch represents a epoch extremely far away in the future used as the default penalization epoch for validators.
 	FarFutureSlot            types.Slot  `yaml:"FAR_FUTURE_SLOT"`             // FarFutureSlot represents a slot extremely far away in the future.
 	BaseRewardsPerEpoch      uint64      `yaml:"BASE_REWARDS_PER_EPOCH"`      // BaseRewardsPerEpoch is used to calculate the per epoch rewards.
 	DepositContractTreeDepth uint64      `yaml:"DEPOSIT_CONTRACT_TREE_DEPTH"` // DepositContractTreeDepth depth of the Merkle trie of deposits in the validator deposit contract on the PoW chain.


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

It simplifies validator configuration in tests. Some fields were unnecessarily initialized making tests harder to read.

It also corrects the comment of `FarFutureEpoch` configuration param.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
