### PR TITLE
Add metrics per keys for next scheduled attestation and proposal 

### DIFF
--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -172,6 +172,28 @@ var (
 			"pubkey",
 		},
 	)
+	// ValidatorNextAttestationSlotGaugeVec used to track validator statuses by public key.
+	ValidatorNextAttestationSlotGaugeVec = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "validator",
+			Name:      "next_attestation_slot",
+			Help:      "validator next scheduled attestation slot",
+		},
+		[]string{
+			"pubkey",
+		},
+	)
+	// ValidatorNextProposalSlotGaugeVec used to track validator statuses by public key.
+	ValidatorNextProposalSlotGaugeVec = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "validator",
+			Name:      "next_proposal_slot",
+			Help:      "validator next scheduled proposal slot",
+		},
+		[]string{
+			"pubkey",
+		},
+	)
 )
 
 // LogValidatorGainsAndLosses logs important metrics related to this validator client's

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -630,6 +630,7 @@ func (v *validator) logDuties(slot types.Slot, duties []*ethpb.DutiesResponse_Du
 	for i := range attesterKeys {
 		attesterKeys[i] = make([]string, 0)
 	}
+	validatorKeysLookup := make(map[string]string)
 	proposerKeys := make([]string, params.BeaconConfig().SlotsPerEpoch)
 	slotOffset := slot - (slot % params.BeaconConfig().SlotsPerEpoch)
 	var totalAttestingKeys uint64
@@ -651,6 +652,7 @@ func (v *validator) logDuties(slot types.Slot, duties []*ethpb.DutiesResponse_Du
 			log.WithField("duty", duty).Warn("Invalid attester slot")
 		} else {
 			attesterKeys[duty.AttesterSlot-slotOffset] = append(attesterKeys[duty.AttesterSlot-slotOffset], validatorKey)
+			validatorKeysLookup[validatorKey] = fmt.Sprintf("%#x", duty.PublicKey)
 			totalAttestingKeys++
 		}
 
@@ -665,6 +667,11 @@ func (v *validator) logDuties(slot types.Slot, duties []*ethpb.DutiesResponse_Du
 	}
 	for i := types.Slot(0); i < params.BeaconConfig().SlotsPerEpoch; i++ {
 		if len(attesterKeys[i]) > 0 {
+			for _, truncKey := range attesterKeys[i] {
+				if key, ok := validatorKeysLookup[truncKey]; ok {
+					ValidatorNextAttestationSlotGaugeVec.WithLabelValues(key).Set(float64(slotOffset + i))
+				}
+			}
 			log.WithFields(logrus.Fields{
 				"slot":                  slotOffset + i,
 				"slotInEpoch":           (slotOffset + i) % params.BeaconConfig().SlotsPerEpoch,
@@ -674,6 +681,9 @@ func (v *validator) logDuties(slot types.Slot, duties []*ethpb.DutiesResponse_Du
 			}).Info("Attestation schedule")
 		}
 		if proposerKeys[i] != "" {
+			if key, ok := validatorKeysLookup[proposerKeys[i]]; ok {
+				ValidatorNextProposalSlotGaugeVec.WithLabelValues(key).Set(float64(slotOffset + i))
+			}
 			log.WithField("slot", slotOffset+i).WithField("pubKey", proposerKeys[i]).Info("Proposal schedule")
 		}
 	}

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -652,7 +652,9 @@ func (v *validator) logDuties(slot types.Slot, duties []*ethpb.DutiesResponse_Du
 		} else {
 			attesterKeys[duty.AttesterSlot-slotOffset] = append(attesterKeys[duty.AttesterSlot-slotOffset], validatorKey)
 			totalAttestingKeys++
-			ValidatorNextAttestationSlotGaugeVec.WithLabelValues(validatorNotTruncatedKey).Set(float64(duty.AttesterSlot))
+			if v.emitAccountMetrics {
+				ValidatorNextAttestationSlotGaugeVec.WithLabelValues(validatorNotTruncatedKey).Set(float64(duty.AttesterSlot))
+			}
 		}
 
 		for _, proposerSlot := range duty.ProposerSlots {
@@ -662,7 +664,9 @@ func (v *validator) logDuties(slot types.Slot, duties []*ethpb.DutiesResponse_Du
 			} else {
 				proposerKeys[proposerIndex] = validatorKey
 			}
-			ValidatorNextProposalSlotGaugeVec.WithLabelValues(validatorNotTruncatedKey).Set(float64(proposerSlot))
+			if v.emitAccountMetrics {
+				ValidatorNextProposalSlotGaugeVec.WithLabelValues(validatorNotTruncatedKey).Set(float64(proposerSlot))
+			}
 		}
 	}
 	for i := types.Slot(0); i < params.BeaconConfig().SlotsPerEpoch; i++ {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

This PR adds metrics for the next scheduled proposal and attestation slot, per keys.
This information is available today as a log line, it would be more convenient to have it as a metric, because it would allows programmatic automation, such as when to schedule the next validator restart/maintenance.

**Which issues(s) does this PR fix?**
-

**Other notes for review**

Re-opening of #8526 
