### PR TITLE
Fixes flaky TestBlocksFetcher_nonSkippedSlotAfter test

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher_utils_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_utils_test.go
@@ -105,8 +105,9 @@ func TestBlocksFetcher_nonSkippedSlotAfter(t *testing.T) {
 		}()
 		if testutil.WaitTimeout(&wg, 5*time.Second) {
 			t.Errorf("Isolated non-skipped slot not found in %d iterations: %v", i, expectedSlot)
+		} else {
+			log.Debugf("Isolated non-skipped slot found in %d iterations", i)
 		}
-		log.Debugf("Isolated non-skipped slot found in %d iterations", i)
 	})
 
 	t.Run("no peers with higher target epoch available", func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**
- Since non-skipped slot is located using random sampling of future epochs, number of rounds in non-deterministic (normally 100 rounds cap is more than enough, but from time to time this is not enough -- and test fails).
- Instead of counting rounds, 5 seconds time cap is used (normally, completes in less than a second, occasionally spiking to 2 seconds). I've run the test for 1000 rounds, several times (with previous code ~ 1 out of every 20 tests were failing, with new time cap -- no failures were produced, so we are more robust now).

**Which issues(s) does this PR fix?**

Fixes #8201

**Other notes for review**
