### PR TITLE
Simplify nil assignments

### DIFF
--- a/beacon-chain/cache/checkpoint_state_test.go
+++ b/beacon-chain/cache/checkpoint_state_test.go
@@ -27,7 +27,7 @@ func TestCheckpointStateCache_StateByCheckpoint(t *testing.T) {
 
 	state, err := cache.StateByCheckpoint(cp1)
 	require.NoError(t, err)
-	assert.Equal(t, (iface.BeaconState)(nil), state, "Expected state not to exist in empty cache")
+	assert.Equal(t, iface.BeaconState(nil), state, "Expected state not to exist in empty cache")
 
 	require.NoError(t, cache.AddCheckpointState(cp1, st))
 

--- a/beacon-chain/cache/skip_slot_cache_test.go
+++ b/beacon-chain/cache/skip_slot_cache_test.go
@@ -19,7 +19,7 @@ func TestSkipSlotCache_RoundTrip(t *testing.T) {
 	r := [32]byte{'a'}
 	state, err := c.Get(ctx, r)
 	require.NoError(t, err)
-	assert.Equal(t, (iface.BeaconState)(nil), state, "Empty cache returned an object")
+	assert.Equal(t, iface.BeaconState(nil), state, "Empty cache returned an object")
 
 	require.NoError(t, c.MarkInProgress(r))
 

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -40,7 +40,7 @@ func TestState_CanSaveRetrieve(t *testing.T) {
 
 	savedS, err = db.State(context.Background(), [32]byte{'B'})
 	require.NoError(t, err)
-	assert.Equal(t, (iface.ReadOnlyBeaconState)(nil), savedS, "Unsaved state should've been nil")
+	assert.Equal(t, iface.ReadOnlyBeaconState(nil), savedS, "Unsaved state should've been nil")
 }
 
 func TestGenesisState_CanSaveRetrieve(t *testing.T) {

--- a/beacon-chain/state/stategen/hot_state_cache_test.go
+++ b/beacon-chain/state/stategen/hot_state_cache_test.go
@@ -14,7 +14,7 @@ func TestHotStateCache_RoundTrip(t *testing.T) {
 	c := newHotStateCache()
 	root := [32]byte{'A'}
 	state := c.get(root)
-	assert.Equal(t, (iface.BeaconState)(nil), state)
+	assert.Equal(t, iface.BeaconState(nil), state)
 	assert.Equal(t, false, c.has(root), "Empty cache has an object")
 
 	state, err := stateTrie.InitializeFromProto(&pb.BeaconState{


### PR DESCRIPTION
**What type of PR is this?**

> Other / Cleanup

**What does this PR do? Why is it needed?**
- Removes redundant parentheses around interface, when we need nil value of it

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
