### PR TITLE
Use proper read lock for `FieldTrie`

### DIFF
--- a/beacon-chain/state/field_trie.go
+++ b/beacon-chain/state/field_trie.go
@@ -16,7 +16,7 @@ import (
 // FieldTrie is the representation of the representative
 // trie of the particular field.
 type FieldTrie struct {
-	*sync.Mutex
+	*sync.RWMutex
 	*reference
 	fieldLayers [][]*[32]byte
 	field       fieldIndex
@@ -30,7 +30,7 @@ func NewFieldTrie(field fieldIndex, elements interface{}, length uint64) (*Field
 		return &FieldTrie{
 			field:     field,
 			reference: &reference{refs: 1},
-			Mutex:     new(sync.Mutex),
+			RWMutex:   new(sync.RWMutex),
 		}, nil
 	}
 	datType, ok := fieldMap[field]
@@ -47,14 +47,14 @@ func NewFieldTrie(field fieldIndex, elements interface{}, length uint64) (*Field
 			fieldLayers: stateutil.ReturnTrieLayer(fieldRoots, length),
 			field:       field,
 			reference:   &reference{refs: 1},
-			Mutex:       new(sync.Mutex),
+			RWMutex:     new(sync.RWMutex),
 		}, nil
 	case compositeArray:
 		return &FieldTrie{
 			fieldLayers: stateutil.ReturnTrieLayerVariable(fieldRoots, length),
 			field:       field,
 			reference:   &reference{refs: 1},
-			Mutex:       new(sync.Mutex),
+			RWMutex:     new(sync.RWMutex),
 		}, nil
 	default:
 		return nil, errors.Errorf("unrecognized data type in field map: %v", reflect.TypeOf(datType).Name())
@@ -106,7 +106,7 @@ func (f *FieldTrie) CopyTrie() *FieldTrie {
 		return &FieldTrie{
 			field:     f.field,
 			reference: &reference{refs: 1},
-			Mutex:     new(sync.Mutex),
+			RWMutex:   new(sync.RWMutex),
 		}
 	}
 	dstFieldTrie := make([][]*[32]byte, len(f.fieldLayers))
@@ -118,7 +118,7 @@ func (f *FieldTrie) CopyTrie() *FieldTrie {
 		fieldLayers: dstFieldTrie,
 		field:       f.field,
 		reference:   &reference{refs: 1},
-		Mutex:       new(sync.Mutex),
+		RWMutex:     new(sync.RWMutex),
 	}
 }
 

--- a/beacon-chain/state/state_trie.go
+++ b/beacon-chain/state/state_trie.go
@@ -49,7 +49,7 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconState) (*BeaconState, error) {
 		b.stateFieldLeaves[fieldIndex(i)] = &FieldTrie{
 			field:     fieldIndex(i),
 			reference: &reference{refs: 1},
-			Mutex:     new(sync.Mutex),
+			RWMutex:   new(sync.RWMutex),
 		}
 	}
 
@@ -215,11 +215,11 @@ func (b *BeaconState) FieldReferencesCount() map[string]uint64 {
 	}
 	for i, f := range b.stateFieldLeaves {
 		numOfRefs := uint64(f.Refs())
-		f.lock.RLock()
+		f.RLock()
 		if len(f.fieldLayers) != 0 {
 			refMap[i.String()+"_trie"] = numOfRefs
 		}
-		f.lock.RUnlock()
+		f.RUnlock()
 	}
 	return refMap
 }


### PR DESCRIPTION
In `FieldReferencesCount()`, we call `f.Refs()` which uses the `reference` lock

Then it calls `len(f.fieldLayers)` which uses the `reference` lock again. Instead it should be using `FieldTrie` lock.

```go
// FieldTrie is the representation of the representative trie of the particular field.
type FieldTrie struct {
	*sync.RWMutex // <- We should use this lock
	*reference
	fieldLayers [][]*[32]byte // <- When reading this
	field       fieldIndex
}

type reference struct {
	refs uint
	lock sync.RWMutex // <- We SHOULD NOT use this lock
}
```

Note that I changed `FieldTrie`'s lock to `RWMutex` to gain read locking