### PR TITLE
State: Refactor `Reference` and `ValidatorMapHandler` to stateutil pkg

### DIFF
--- a/beacon-chain/state/BUILD.bazel
+++ b/beacon-chain/state/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//tools/pcli:__pkg__",
     ],
     deps = [
-        "//beacon-chain/core/state/stateutils:go_default_library",
         "//beacon-chain/state/interface:go_default_library",
         "//beacon-chain/state/stateutil:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",

--- a/beacon-chain/state/field_trie.go
+++ b/beacon-chain/state/field_trie.go
@@ -17,7 +17,7 @@ import (
 // trie of the particular field.
 type FieldTrie struct {
 	*sync.Mutex
-	*reference
+	reference   *stateutil.Reference
 	fieldLayers [][]*[32]byte
 	field       fieldIndex
 }
@@ -29,7 +29,7 @@ func NewFieldTrie(field fieldIndex, elements interface{}, length uint64) (*Field
 	if elements == nil {
 		return &FieldTrie{
 			field:     field,
-			reference: &reference{refs: 1},
+			reference: stateutil.NewRef(1),
 			Mutex:     new(sync.Mutex),
 		}, nil
 	}
@@ -46,14 +46,14 @@ func NewFieldTrie(field fieldIndex, elements interface{}, length uint64) (*Field
 		return &FieldTrie{
 			fieldLayers: stateutil.ReturnTrieLayer(fieldRoots, length),
 			field:       field,
-			reference:   &reference{refs: 1},
+			reference:   stateutil.NewRef(1),
 			Mutex:       new(sync.Mutex),
 		}, nil
 	case compositeArray:
 		return &FieldTrie{
 			fieldLayers: stateutil.ReturnTrieLayerVariable(fieldRoots, length),
 			field:       field,
-			reference:   &reference{refs: 1},
+			reference:   stateutil.NewRef(1),
 			Mutex:       new(sync.Mutex),
 		}, nil
 	default:
@@ -105,7 +105,7 @@ func (f *FieldTrie) CopyTrie() *FieldTrie {
 	if f.fieldLayers == nil {
 		return &FieldTrie{
 			field:     f.field,
-			reference: &reference{refs: 1},
+			reference: stateutil.NewRef(1),
 			Mutex:     new(sync.Mutex),
 		}
 	}
@@ -117,7 +117,7 @@ func (f *FieldTrie) CopyTrie() *FieldTrie {
 	return &FieldTrie{
 		fieldLayers: dstFieldTrie,
 		field:       f.field,
-		reference:   &reference{refs: 1},
+		reference:   stateutil.NewRef(1),
 		Mutex:       new(sync.Mutex),
 	}
 }

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -524,23 +524,23 @@ func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (iface.
 
 // ValidatorIndexByPubkey returns a given validator by its 48-byte public key.
 func (b *BeaconState) ValidatorIndexByPubkey(key [48]byte) (types.ValidatorIndex, bool) {
-	if b == nil || b.valMapHandler == nil || b.valMapHandler.valIdxMap == nil {
+	if b == nil || b.valMapHandler == nil || b.valMapHandler.IsNil() {
 		return 0, false
 	}
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	idx, ok := b.valMapHandler.valIdxMap[key]
+	idx, ok := b.valMapHandler.Get(key)
 	return idx, ok
 }
 
 func (b *BeaconState) validatorIndexMap() map[[48]byte]types.ValidatorIndex {
-	if b == nil || b.valMapHandler == nil || b.valMapHandler.valIdxMap == nil {
+	if b == nil || b.valMapHandler == nil || b.valMapHandler.IsNil() {
 		return map[[48]byte]types.ValidatorIndex{}
 	}
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.valMapHandler.copy().valIdxMap
+	return b.valMapHandler.Copy().ValidatorIndexMap()
 }
 
 // PubkeyAtIndex returns the pubkey at the given

--- a/beacon-chain/state/references_test.go
+++ b/beacon-chain/state/references_test.go
@@ -20,24 +20,24 @@ func TestStateReferenceSharing_Finalizer(t *testing.T) {
 
 	a, err := InitializeFromProtoUnsafe(&p2ppb.BeaconState{RandaoMixes: [][]byte{[]byte("foo")}})
 	require.NoError(t, err)
-	assert.Equal(t, uint(1), a.sharedFieldReferences[randaoMixes].refs, "Expected a single reference for RANDAO mixes")
+	assert.Equal(t, uint(1), a.sharedFieldReferences[randaoMixes].Refs(), "Expected a single reference for RANDAO mixes")
 
 	func() {
 		// Create object in a different scope for GC
 		b := a.Copy()
-		assert.Equal(t, uint(2), a.sharedFieldReferences[randaoMixes].refs, "Expected 2 references to RANDAO mixes")
+		assert.Equal(t, uint(2), a.sharedFieldReferences[randaoMixes].Refs(), "Expected 2 references to RANDAO mixes")
 		_ = b
 	}()
 
 	runtime.GC() // Should run finalizer on object b
-	assert.Equal(t, uint(1), a.sharedFieldReferences[randaoMixes].refs, "Expected 1 shared reference to RANDAO mixes!")
+	assert.Equal(t, uint(1), a.sharedFieldReferences[randaoMixes].Refs(), "Expected 1 shared reference to RANDAO mixes!")
 
 	copied := a.Copy()
 	b, ok := copied.(*BeaconState)
 	require.Equal(t, true, ok)
-	assert.Equal(t, uint(2), b.sharedFieldReferences[randaoMixes].refs, "Expected 2 shared references to RANDAO mixes")
+	assert.Equal(t, uint(2), b.sharedFieldReferences[randaoMixes].Refs(), "Expected 2 shared references to RANDAO mixes")
 	require.NoError(t, b.UpdateRandaoMixesAtIndex(0, []byte("bar")))
-	if b.sharedFieldReferences[randaoMixes].refs != 1 || a.sharedFieldReferences[randaoMixes].refs != 1 {
+	if b.sharedFieldReferences[randaoMixes].Refs() != 1 || a.sharedFieldReferences[randaoMixes].Refs() != 1 {
 		t.Error("Expected 1 shared reference to RANDAO mix for both a and b")
 	}
 }
@@ -318,7 +318,7 @@ func TestValidatorReferences_RemainsConsistent(t *testing.T) {
 // assertRefCount checks whether reference count for a given state
 // at a given index is equal to expected amount.
 func assertRefCount(t *testing.T, b *BeaconState, idx fieldIndex, want uint) {
-	if cnt := b.sharedFieldReferences[idx].refs; cnt != want {
+	if cnt := b.sharedFieldReferences[idx].Refs(); cnt != want {
 		t.Errorf("Unexpected count of references for index %d, want: %v, got: %v", idx, want, cnt)
 	}
 }

--- a/beacon-chain/state/state_trie.go
+++ b/beacon-chain/state/state_trie.go
@@ -37,9 +37,9 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconState) (*BeaconState, error) {
 		dirtyFields:           make(map[fieldIndex]interface{}, fieldCount),
 		dirtyIndices:          make(map[fieldIndex][]uint64, fieldCount),
 		stateFieldLeaves:      make(map[fieldIndex]*FieldTrie, fieldCount),
-		sharedFieldReferences: make(map[fieldIndex]*reference, 10),
+		sharedFieldReferences: make(map[fieldIndex]*stateutil.Reference, 10),
 		rebuildTrie:           make(map[fieldIndex]bool, fieldCount),
-		valMapHandler:         newValHandler(st.Validators),
+		valMapHandler:         stateutil.NewValMapHandler(st.Validators),
 	}
 
 	for i := 0; i < fieldCount; i++ {
@@ -48,22 +48,22 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconState) (*BeaconState, error) {
 		b.dirtyIndices[fieldIndex(i)] = []uint64{}
 		b.stateFieldLeaves[fieldIndex(i)] = &FieldTrie{
 			field:     fieldIndex(i),
-			reference: &reference{refs: 1},
+			reference: stateutil.NewRef(1),
 			Mutex:     new(sync.Mutex),
 		}
 	}
 
 	// Initialize field reference tracking for shared data.
-	b.sharedFieldReferences[randaoMixes] = &reference{refs: 1}
-	b.sharedFieldReferences[stateRoots] = &reference{refs: 1}
-	b.sharedFieldReferences[blockRoots] = &reference{refs: 1}
-	b.sharedFieldReferences[previousEpochAttestations] = &reference{refs: 1}
-	b.sharedFieldReferences[currentEpochAttestations] = &reference{refs: 1}
-	b.sharedFieldReferences[slashings] = &reference{refs: 1}
-	b.sharedFieldReferences[eth1DataVotes] = &reference{refs: 1}
-	b.sharedFieldReferences[validators] = &reference{refs: 1}
-	b.sharedFieldReferences[balances] = &reference{refs: 1}
-	b.sharedFieldReferences[historicalRoots] = &reference{refs: 1}
+	b.sharedFieldReferences[randaoMixes] = stateutil.NewRef(1)
+	b.sharedFieldReferences[stateRoots] = stateutil.NewRef(1)
+	b.sharedFieldReferences[blockRoots] = stateutil.NewRef(1)
+	b.sharedFieldReferences[previousEpochAttestations] = stateutil.NewRef(1)
+	b.sharedFieldReferences[currentEpochAttestations] = stateutil.NewRef(1)
+	b.sharedFieldReferences[slashings] = stateutil.NewRef(1)
+	b.sharedFieldReferences[eth1DataVotes] = stateutil.NewRef(1)
+	b.sharedFieldReferences[validators] = stateutil.NewRef(1)
+	b.sharedFieldReferences[balances] = stateutil.NewRef(1)
+	b.sharedFieldReferences[historicalRoots] = stateutil.NewRef(1)
 
 	return b, nil
 }
@@ -111,7 +111,7 @@ func (b *BeaconState) Copy() iface.BeaconState {
 		dirtyFields:           make(map[fieldIndex]interface{}, fieldCount),
 		dirtyIndices:          make(map[fieldIndex][]uint64, fieldCount),
 		rebuildTrie:           make(map[fieldIndex]bool, fieldCount),
-		sharedFieldReferences: make(map[fieldIndex]*reference, 10),
+		sharedFieldReferences: make(map[fieldIndex]*stateutil.Reference, 10),
 		stateFieldLeaves:      make(map[fieldIndex]*FieldTrie, fieldCount),
 
 		// Copy on write validator index map.
@@ -124,7 +124,7 @@ func (b *BeaconState) Copy() iface.BeaconState {
 	}
 
 	// Increment ref for validator map
-	b.valMapHandler.mapRef.AddRef()
+	b.valMapHandler.AddRef()
 
 	for i := range b.dirtyFields {
 		dst.dirtyFields[i] = true
@@ -144,7 +144,7 @@ func (b *BeaconState) Copy() iface.BeaconState {
 		dst.stateFieldLeaves[fldIdx] = fieldTrie
 		if fieldTrie.reference != nil {
 			fieldTrie.Lock()
-			fieldTrie.AddRef()
+			fieldTrie.reference.AddRef()
 			fieldTrie.Unlock()
 		}
 	}
@@ -165,7 +165,7 @@ func (b *BeaconState) Copy() iface.BeaconState {
 		for field, v := range b.sharedFieldReferences {
 			v.MinusRef()
 			if b.stateFieldLeaves[field].reference != nil {
-				b.stateFieldLeaves[field].MinusRef()
+				b.stateFieldLeaves[field].reference.MinusRef()
 			}
 		}
 	})
@@ -214,8 +214,8 @@ func (b *BeaconState) FieldReferencesCount() map[string]uint64 {
 		refMap[i.String()] = uint64(f.Refs())
 	}
 	for i, f := range b.stateFieldLeaves {
-		numOfRefs := uint64(f.Refs())
-		f.lock.RLock()
+		numOfRefs := uint64(f.reference.Refs())
+		f.RLock()
 		if len(f.fieldLayers) != 0 {
 			refMap[i.String()+"_trie"] = numOfRefs
 		}
@@ -369,10 +369,10 @@ func (b *BeaconState) rootSelector(field fieldIndex) ([32]byte, error) {
 
 func (b *BeaconState) recomputeFieldTrie(index fieldIndex, elements interface{}) ([32]byte, error) {
 	fTrie := b.stateFieldLeaves[index]
-	if fTrie.Refs() > 1 {
+	if fTrie.reference.Refs() > 1 {
 		fTrie.Lock()
 		defer fTrie.Unlock()
-		fTrie.MinusRef()
+		fTrie.reference.MinusRef()
 		newTrie := fTrie.CopyTrie()
 		b.stateFieldLeaves[index] = newTrie
 		fTrie = newTrie

--- a/beacon-chain/state/state_trie.go
+++ b/beacon-chain/state/state_trie.go
@@ -215,11 +215,11 @@ func (b *BeaconState) FieldReferencesCount() map[string]uint64 {
 	}
 	for i, f := range b.stateFieldLeaves {
 		numOfRefs := uint64(f.reference.Refs())
-		f.RLock()
+		f.Lock()
 		if len(f.fieldLayers) != 0 {
 			refMap[i.String()+"_trie"] = numOfRefs
 		}
-		f.lock.RUnlock()
+		f.Unlock()
 	}
 	return refMap
 }

--- a/beacon-chain/state/stateutil/BUILD.bazel
+++ b/beacon-chain/state/stateutil/BUILD.bazel
@@ -7,8 +7,10 @@ go_library(
         "arrays.go",
         "attestations.go",
         "blocks.go",
+        "reference.go",
         "state_root.go",
         "trie_helpers.go",
+        "validator_map_handler.go",
         "validators.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil",
@@ -25,6 +27,7 @@ go_library(
         "//validator/client:__pkg__",
     ],
     deps = [
+        "//beacon-chain/core/state/stateutils:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/featureconfig:go_default_library",
@@ -34,6 +37,7 @@ go_library(
         "//shared/trieutil:go_default_library",
         "@com_github_dgraph_io_ristretto//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
     ],
 )
@@ -43,6 +47,7 @@ go_test(
     srcs = [
         "attestations_test.go",
         "benchmark_test.go",
+        "reference_bench_test.go",
         "state_root_test.go",
         "stateutil_test.go",
         "trie_helpers_test.go",

--- a/beacon-chain/state/stateutil/reference.go
+++ b/beacon-chain/state/stateutil/reference.go
@@ -1,0 +1,45 @@
+package stateutil
+
+import "sync"
+
+// Reference structs are shared across BeaconState copies to understand when the state must use
+// copy-on-write for shared fields or may modify a field in place when it holds the only reference
+// to the field value. References are tracked in a map of fieldIndex -> *reference. Whenever a state
+// releases their reference to the field value, they must decrement the refs. Likewise whenever a
+// copy is performed then the state must increment the refs counter.
+type Reference struct {
+	refs uint
+	lock sync.RWMutex
+}
+
+// NewRef initializes the Reference struct.
+func NewRef(refs uint) *Reference {
+	return &Reference{
+		refs: refs,
+	}
+}
+
+// Refs returns the reference number.
+func (r *Reference) Refs() uint {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.refs
+}
+
+// AddRef adds 1 to the reference number.
+func (r *Reference) AddRef() {
+	r.lock.Lock()
+	r.refs++
+	r.lock.Unlock()
+}
+
+// MinusRef subtracts 1 to the reference number.
+func (r *Reference) MinusRef() {
+	r.lock.Lock()
+	// Do not reduce further if object
+	// already has 0 reference to prevent underflow.
+	if r.refs > 0 {
+		r.refs--
+	}
+	r.lock.Unlock()
+}

--- a/beacon-chain/state/stateutil/reference_bench_test.go
+++ b/beacon-chain/state/stateutil/reference_bench_test.go
@@ -1,4 +1,4 @@
-package state
+package stateutil
 
 import (
 	"math"
@@ -6,7 +6,7 @@ import (
 )
 
 func BenchmarkReference_MinusRef(b *testing.B) {
-	ref := &reference{
+	ref := &Reference{
 		refs: math.MaxUint64,
 	}
 	for i := 0; i < b.N; i++ {

--- a/beacon-chain/state/stateutil/validator_map_handler.go
+++ b/beacon-chain/state/stateutil/validator_map_handler.go
@@ -26,6 +26,21 @@ func (v *ValidatorMapHandler) AddRef() {
 	v.mapRef.AddRef()
 }
 
+// ValidatorIndexMap returns the validator index map.
+func (v *ValidatorMapHandler) ValidatorIndexMap() map[[48]byte]types.ValidatorIndex {
+	return v.valIdxMap
+}
+
+// MapRef returns the map reference.
+func (v *ValidatorMapHandler) MapRef() *Reference {
+	return v.mapRef
+}
+
+// IsNil returns true if the underlying validator index map is nil.
+func (v *ValidatorMapHandler) IsNil() bool {
+	return v.mapRef == nil
+}
+
 // Copy the whole map and returns a map handler with the copied map.
 func (v *ValidatorMapHandler) Copy() *ValidatorMapHandler {
 	if v == nil || v.valIdxMap == nil {
@@ -39,4 +54,18 @@ func (v *ValidatorMapHandler) Copy() *ValidatorMapHandler {
 		valIdxMap: m,
 		mapRef:    &Reference{refs: 1},
 	}
+}
+
+// Get the validator index using the corresponding public key.
+func (v *ValidatorMapHandler) Get(key [48]byte) (types.ValidatorIndex, bool) {
+	idx, ok := v.valIdxMap[key]
+	if !ok {
+		return 0, false
+	}
+	return idx, true
+}
+
+// Set the validator index using the corresponding public key.
+func (v *ValidatorMapHandler) Set(key [48]byte, index types.ValidatorIndex) {
+	v.valIdxMap[key] = index
 }

--- a/beacon-chain/state/stateutil/validator_map_handler.go
+++ b/beacon-chain/state/stateutil/validator_map_handler.go
@@ -1,0 +1,42 @@
+package stateutil
+
+import (
+	types "github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	coreutils "github.com/prysmaticlabs/prysm/beacon-chain/core/state/stateutils"
+)
+
+// ValidatorMapHandler is a container to hold the map and a reference tracker for how many
+// states shared this.
+type ValidatorMapHandler struct {
+	valIdxMap map[[48]byte]types.ValidatorIndex
+	mapRef    *Reference
+}
+
+// NewValMapHandler returns a new validator map handler.
+func NewValMapHandler(vals []*ethpb.Validator) *ValidatorMapHandler {
+	return &ValidatorMapHandler{
+		valIdxMap: coreutils.ValidatorIndexMap(vals),
+		mapRef:    &Reference{refs: 1},
+	}
+}
+
+// Copy the whole map and returns a map handler with the copied map.
+func (v *ValidatorMapHandler) AddRef() {
+	v.mapRef.AddRef()
+}
+
+// Copy the whole map and returns a map handler with the copied map.
+func (v *ValidatorMapHandler) Copy() *ValidatorMapHandler {
+	if v == nil || v.valIdxMap == nil {
+		return &ValidatorMapHandler{valIdxMap: map[[48]byte]types.ValidatorIndex{}, mapRef: new(Reference)}
+	}
+	m := make(map[[48]byte]types.ValidatorIndex, len(v.valIdxMap))
+	for k, v := range v.valIdxMap {
+		m[k] = v
+	}
+	return &ValidatorMapHandler{
+		valIdxMap: m,
+		mapRef:    &Reference{refs: 1},
+	}
+}

--- a/beacon-chain/state/validator_getters.go
+++ b/beacon-chain/state/validator_getters.go
@@ -2,7 +2,14 @@ package state
 
 import (
 	types "github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 )
+
+// ReadOnlyValidator returns a wrapper that only allows fields from a validator
+// to be read, and prevents any modification of internal validator fields.
+type ReadOnlyValidator struct {
+	validator *ethpb.Validator
+}
 
 // EffectiveBalance returns the effective balance of the
 // read only validator.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Cleanup

**What does this PR do? Why is it needed?**

Clean up `state` pkg in anticipation for future hard fork state. The goal is to extract some of the common usages into `stateutil` pkg

- Move `Reference` to `stateutil` pkg so it can be reused
- Move `ValidatorMapHandler` to `stateutil` pkg so it can be reused

Open question for previous author, do we need proper locking around `ValidatorMapHandler`? There wasn't any to begin with

Testing: Been running 10 pyrmont validators. So far so good