### PR TITLE
Fix race condition in TestService_Initialized

### DIFF
--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -443,7 +443,9 @@ func TestService_Resync(t *testing.T) {
 }
 
 func TestService_Initialized(t *testing.T) {
-	s := NewService(context.Background(), &Config{})
+	s := NewService(context.Background(), &Config{
+		StateNotifier: &mock.MockStateNotifier{},
+	})
 	s.chainStarted.Set()
 	assert.Equal(t, true, s.Initialized())
 	s.chainStarted.UnSet()


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**
- When one runs test using bazel (our CI does) no issue occurs i.e. `bazel test //beacon-chain/sync/initial-sync:go_default_test --test_arg=-test.v --test_output=streamed --test_arg=-test.failfast --test_filter=TestService_Initialized` works just fine.
- However, when run using `go test ./beacon-chain/sync/initial-sync -v -failfast -run TestService_Initialized` goroutines are executed in a way that segmentation fault is always reproduced (nil `StateNotifier`):
![image](https://user-images.githubusercontent.com/188194/110846547-f1f8a980-82bc-11eb-9b07-ea8071b0669b.png)

It seems that `waitForStateInitialization()` makes to its execution in `go test` and doesn't in `bazel test`, hence issue with `go test`


**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

