### PR TITLE
Ignore Syncing Freelist For Validator DB

### DIFF
--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -118,6 +118,7 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{
 		Timeout:         params.BeaconIoConfig().BoltTimeout,
 		InitialMmapSize: config.InitialMMapSize,
+		NoFreelistSync:  true,
 	})
 	if err != nil {
 		if errors.Is(err, bolt.ErrTimeout) {


### PR DESCRIPTION
**What type of PR is this?**

Feature Improvement

**What does this PR do? Why is it needed?**

- [x] If a database has undergone a significant amount of deletion of old keys/buckets , a significant portion of
it will be a freelist. Constantly syncing the freelist on each write is wasteful and has a non trivial impact on performance. 
This PR allows a validator db to skip syncing the freelist for each write, which will be useful for large users running with a lot of validators.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
