### PR TITLE
Sync: send received attestations over feed at right places

### DIFF
--- a/beacon-chain/sync/subscriber_beacon_aggregate_proof.go
+++ b/beacon-chain/sync/subscriber_beacon_aggregate_proof.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed/operation"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 )
 
@@ -23,15 +21,6 @@ func (s *Service) beaconAggregateProofSubscriber(_ context.Context, msg proto.Me
 	if a.Message.Aggregate == nil || a.Message.Aggregate.Data == nil {
 		return errors.New("nil aggregate")
 	}
-
-	// Broadcast the aggregated attestation on a feed to notify other services in the beacon node
-	// of a received aggregated attestation.
-	s.attestationNotifier.OperationFeed().Send(&feed.Event{
-		Type: operation.AggregatedAttReceived,
-		Data: &operation.AggregatedAttReceivedData{
-			Attestation: a.Message,
-		},
-	})
 
 	// An unaggregated attestation can make it here. It’s valid, the aggregator it just itself, although it means poor performance for the subnet.
 	if !helpers.IsAggregated(a.Message.Aggregate) {

--- a/beacon-chain/sync/subscriber_beacon_attestation.go
+++ b/beacon-chain/sync/subscriber_beacon_attestation.go
@@ -9,8 +9,6 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed/operation"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
@@ -34,15 +32,6 @@ func (s *Service) committeeIndexBeaconAttestationSubscriber(_ context.Context, m
 	if exists {
 		return nil
 	}
-
-	// Broadcast the unaggregated attestation on a feed to notify other services in the beacon node
-	// of a received unaggregated attestation.
-	s.attestationNotifier.OperationFeed().Send(&feed.Event{
-		Type: operation.UnaggregatedAttReceived,
-		Data: &operation.UnAggregatedAttReceivedData{
-			Attestation: a,
-		},
-	})
 
 	return s.attPool.SaveUnaggregatedAttestation(a)
 }

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -10,6 +10,8 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed/operation"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
@@ -52,6 +54,15 @@ func (s *Service) validateAggregateAndProof(ctx context.Context, pid peer.ID, ms
 	if err := helpers.ValidateNilAttestation(m.Message.Aggregate); err != nil {
 		return pubsub.ValidationReject
 	}
+
+	// Broadcast the aggregated attestation on a feed to notify other services in the beacon node
+	// of a received aggregated attestation.
+	s.attestationNotifier.OperationFeed().Send(&feed.Event{
+		Type: operation.AggregatedAttReceived,
+		Data: &operation.AggregatedAttReceivedData{
+			Attestation: m.Message,
+		},
+	})
 
 	if err := helpers.ValidateSlotTargetEpoch(m.Message.Aggregate.Data); err != nil {
 		return pubsub.ValidationReject

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -189,6 +189,7 @@ func TestValidateAggregateAndProof_NotWithinSlotRange(t *testing.T) {
 		},
 		attPool:              attestations.NewPool(),
 		seenAttestationCache: c,
+		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -269,6 +270,7 @@ func TestValidateAggregateAndProof_ExistedInPool(t *testing.T) {
 			State: beaconState},
 		seenAttestationCache: c,
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
+		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -361,6 +363,7 @@ func TestValidateAggregateAndProof_CanValidate(t *testing.T) {
 			}},
 		attPool:              attestations.NewPool(),
 		seenAttestationCache: c,
+		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -452,6 +455,7 @@ func TestVerifyIndexInCommittee_SeenAggregatorEpoch(t *testing.T) {
 
 		attPool:              attestations.NewPool(),
 		seenAttestationCache: c,
+		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -558,6 +562,7 @@ func TestValidateAggregateAndProof_BadBlock(t *testing.T) {
 			}},
 		attPool:              attestations.NewPool(),
 		seenAttestationCache: c,
+		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -648,6 +653,7 @@ func TestValidateAggregateAndProof_RejectWhenAttEpochDoesntEqualTargetEpoch(t *t
 			}},
 		attPool:              attestations.NewPool(),
 		seenAttestationCache: c,
+		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -43,6 +43,7 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 		chain:                chain,
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
 		seenAttestationCache: c,
+		attestationNotifier:  (&mockChain.ChainService{}).OperationNotifier(),
 	}
 	err = s.initCaches()
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

To send attestations over feed for type `AggregatedAttReceived`, the attestations should be sent when it is arrived, not after it is verified.

Beacon block has this correct in `validate_beacon_block.go`

**Which issues(s) does this PR fix?**

Compliment #8602

**Other notes for review**

There's no risk with this move, there's no real usage around operation feed `AggregatedAttReceived` except for `StreamAttestations` and that is used for old slasher which verifies attestation again upon receiving 
