### PR TITLE
BeaconState: Expose MarshalSSZ

### DIFF
--- a/beacon-chain/core/state/interop/write_state_to_disk.go
+++ b/beacon-chain/core/state/interop/write_state_to_disk.go
@@ -17,7 +17,7 @@ func WriteStateToDisk(state iface.ReadOnlyBeaconState) {
 	}
 	fp := path.Join(os.TempDir(), fmt.Sprintf("beacon_state_%d.ssz", state.Slot()))
 	log.Warnf("Writing state to disk at %s", fp)
-	enc, err := state.InnerStateUnsafe().MarshalSSZ()
+	enc, err := state.MarshalSSZ()
 	if err != nil {
 		log.WithError(err).Error("Failed to ssz encode state")
 		return

--- a/beacon-chain/rpc/debug/state.go
+++ b/beacon-chain/rpc/debug/state.go
@@ -32,7 +32,7 @@ func (ds *Server) GetBeaconState(
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not compute state by slot: %v", err)
 		}
-		encoded, err := st.CloneInnerState().MarshalSSZ()
+		encoded, err := st.MarshalSSZ()
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not ssz encode beacon state: %v", err)
 		}
@@ -44,7 +44,7 @@ func (ds *Server) GetBeaconState(
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not compute state by block root: %v", err)
 		}
-		encoded, err := st.CloneInnerState().MarshalSSZ()
+		encoded, err := st.MarshalSSZ()
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not ssz encode beacon state: %v", err)
 		}

--- a/beacon-chain/rpc/debug/state_test.go
+++ b/beacon-chain/rpc/debug/state_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestServer_GetBeaconState(t *testing.T) {
-
 	db := dbTest.SetupDB(t)
 	ctx := context.Background()
 	st, err := testutil.NewBeaconState()
@@ -43,7 +42,7 @@ func TestServer_GetBeaconState(t *testing.T) {
 	}
 	res, err := bs.GetBeaconState(ctx, req)
 	require.NoError(t, err)
-	wanted, err := st.CloneInnerState().MarshalSSZ()
+	wanted, err := st.MarshalSSZ()
 	require.NoError(t, err)
 	assert.DeepEqual(t, wanted, res.Encoded)
 	req = &pbrpc.BeaconStateRequest{
@@ -57,7 +56,6 @@ func TestServer_GetBeaconState(t *testing.T) {
 }
 
 func TestServer_GetBeaconState_RequestFutureSlot(t *testing.T) {
-
 	ds := &Server{GenesisTimeFetcher: &mock.ChainService{}}
 	req := &pbrpc.BeaconStateRequest{
 		QueryFilter: &pbrpc.BeaconStateRequest_Slot{

--- a/beacon-chain/state/getters.go
+++ b/beacon-chain/state/getters.go
@@ -1027,3 +1027,11 @@ func (b *BeaconState) safeCopyCheckpoint(input *ethpb.Checkpoint) *ethpb.Checkpo
 
 	return CopyCheckpoint(input)
 }
+
+// MarshalSSZ marshals the underlying beacon state to bytes.
+func (b *BeaconState) MarshalSSZ() ([]byte, error) {
+	if !b.hasInnerState() {
+		return nil, errors.New("nil beacon state")
+	}
+	return b.state.MarshalSSZ()
+}

--- a/beacon-chain/state/getters_test.go
+++ b/beacon-chain/state/getters_test.go
@@ -113,3 +113,11 @@ func TestBeaconState_MatchPreviousJustifiedCheckpt(t *testing.T) {
 	beaconState.state = nil
 	require.Equal(t, false, beaconState.MatchPreviousJustifiedCheckpoint(c1))
 }
+
+func TestBeaconState_MarshalSSZ_NilState(t *testing.T) {
+	s, err := InitializeFromProto(&pb.BeaconState{})
+	require.NoError(t, err)
+	s.state = nil
+	_, err = s.MarshalSSZ()
+	require.ErrorContains(t, "nil beacon state", err)
+}

--- a/beacon-chain/state/interface/interface.go
+++ b/beacon-chain/state/interface/interface.go
@@ -40,6 +40,7 @@ type ReadOnlyBeaconState interface {
 	HistoricalRoots() [][]byte
 	Slashings() []uint64
 	FieldReferencesCount() map[string]uint64
+	MarshalSSZ() ([]byte, error)
 }
 
 // WriteOnlyBeaconState defines a struct which only has write access to beacon state methods.

--- a/shared/testutil/state_test.go
+++ b/shared/testutil/state_test.go
@@ -12,7 +12,7 @@ import (
 func TestNewBeaconState(t *testing.T) {
 	st, err := NewBeaconState()
 	require.NoError(t, err)
-	b, err := st.InnerStateUnsafe().MarshalSSZ()
+	b, err := st.MarshalSSZ()
 	require.NoError(t, err)
 	got := &pb.BeaconState{}
 	require.NoError(t, got.UnmarshalSSZ(b))

--- a/tools/benchmark-files-gen/main.go
+++ b/tools/benchmark-files-gen/main.go
@@ -148,7 +148,7 @@ func generateMarshalledFullStateAndBlock() error {
 		return err
 	}
 
-	beaconBytes, err := beaconState.InnerStateUnsafe().MarshalSSZ()
+	beaconBytes, err := beaconState.MarshalSSZ()
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func generate2FullEpochState() error {
 		}
 	}
 
-	beaconBytes, err := beaconState.InnerStateUnsafe().MarshalSSZ()
+	beaconBytes, err := beaconState.MarshalSSZ()
 	if err != nil {
 		return err
 	}

--- a/tools/interop/export-genesis/main.go
+++ b/tools/interop/export-genesis/main.go
@@ -37,7 +37,7 @@ func main() {
 	if gs == nil {
 		panic("nil genesis state")
 	}
-	b, err := gs.InnerStateUnsafe().MarshalSSZ()
+	b, err := gs.MarshalSSZ()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

It seems anti pattern to always have to do:
```go
InnerStateUnsafe().MarshalSSZ()
CloneInnerState().MarshalSSZ()
```

Where we should just define the `MarshalSSZ` for beacon state and hide implementation detail

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

Discovered in #8584 