### PR TITLE
Revert "Ignore Syncing Freelist For Validator DB"

### DIFF
--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -118,7 +118,6 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 	boltDB, err := bolt.Open(datafile, params.BeaconIoConfig().ReadWritePermissions, &bolt.Options{
 		Timeout:         params.BeaconIoConfig().BoltTimeout,
 		InitialMmapSize: config.InitialMMapSize,
-		NoFreelistSync:  true,
 	})
 	if err != nil {
 		if errors.Is(err, bolt.ErrTimeout) {


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#8601

The original PR seems to have caused major issues with freelist sync, in Pyrmont. Specifically, without keeping a freelist in sync, the bolt db will spend a large amount of time reconstructing the freelist on start up. This exceeded 2 hours in Pyrmont test environment.