### PR TITLE
Embed Config Pattern for Sync Services

### DIFF
--- a/beacon-chain/sync/decode_pubsub.go
+++ b/beacon-chain/sync/decode_pubsub.go
@@ -17,7 +17,7 @@ func (s *Service) decodePubsubMessage(msg *pubsub.Message) (proto.Message, error
 		return nil, errNilPubsubMessage
 	}
 	topic := *msg.Topic
-	topic = strings.TrimSuffix(topic, s.p2p.Encoding().ProtocolSuffix())
+	topic = strings.TrimSuffix(topic, s.cfg.P2P.Encoding().ProtocolSuffix())
 	topic, err := s.replaceForkDigest(topic)
 	if err != nil {
 		return nil, err
@@ -27,7 +27,7 @@ func (s *Service) decodePubsubMessage(msg *pubsub.Message) (proto.Message, error
 		return nil, p2p.ErrMessageNotMapped
 	}
 	m := proto.Clone(base)
-	if err := s.p2p.Encoding().DecodeGossip(msg.Data, m); err != nil {
+	if err := s.cfg.P2P.Encoding().DecodeGossip(msg.Data, m); err != nil {
 		return nil, err
 	}
 	return m, nil

--- a/beacon-chain/sync/decode_pubsub_test.go
+++ b/beacon-chain/sync/decode_pubsub_test.go
@@ -68,7 +68,7 @@ func TestService_decodePubsubMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Service{
-				p2p: p2ptesting.NewTestP2P(t),
+				cfg: &Config{P2P: p2ptesting.NewTestP2P(t)},
 			}
 			if tt.topic != "" {
 				if tt.input == nil {

--- a/beacon-chain/sync/error.go
+++ b/beacon-chain/sync/error.go
@@ -19,7 +19,7 @@ var responseCodeInvalidRequest = byte(0x01)
 var responseCodeServerError = byte(0x02)
 
 func (s *Service) generateErrorResponse(code byte, reason string) ([]byte, error) {
-	return createErrorResponse(code, reason, s.p2p)
+	return createErrorResponse(code, reason, s.cfg.P2P)
 }
 
 // ReadStatusCode response from a RPC stream.

--- a/beacon-chain/sync/error_test.go
+++ b/beacon-chain/sync/error_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRegularSync_generateErrorResponse(t *testing.T) {
 	r := &Service{
-		p2p: p2ptest.NewTestP2P(t),
+		cfg: &Config{P2P: p2ptest.NewTestP2P(t)},
 	}
 	data, err := r.generateErrorResponse(responseCodeServerError, "something bad happened")
 	require.NoError(t, err)
@@ -23,6 +23,6 @@ func TestRegularSync_generateErrorResponse(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, responseCodeServerError, b[0], "The first byte was not the status code")
 	msg := &types.ErrorMessage{}
-	require.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(buf, msg))
+	require.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(buf, msg))
 	assert.Equal(t, "something bad happened", string(*msg), "Received the wrong message")
 }

--- a/beacon-chain/sync/fuzz_exports.go
+++ b/beacon-chain/sync/fuzz_exports.go
@@ -18,22 +18,12 @@ func NewRegularSyncFuzz(cfg *Config) *Service {
 	rLimiter := newRateLimiter(cfg.P2P)
 	ctx, cancel := context.WithCancel(context.Background())
 	r := &Service{
+		cfg:                  cfg,
 		ctx:                  ctx,
 		cancel:               cancel,
-		db:                   cfg.DB,
-		p2p:                  cfg.P2P,
-		attPool:              cfg.AttPool,
-		exitPool:             cfg.ExitPool,
-		slashingPool:         cfg.SlashingPool,
-		chain:                cfg.Chain,
-		initialSync:          cfg.InitialSync,
-		attestationNotifier:  cfg.AttestationNotifier,
 		slotToPendingBlocks:  gcache.New(time.Second, 2*time.Second),
 		seenPendingBlocks:    make(map[[32]byte]bool),
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
-		stateNotifier:        cfg.StateNotifier,
-		blockNotifier:        cfg.BlockNotifier,
-		stateGen:             cfg.StateGen,
 		rateLimiter:          rLimiter,
 	}
 

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -194,14 +194,13 @@ func TestService_waitForStateInitialization(t *testing.T) {
 	newService := func(ctx context.Context, mc *mock.ChainService) *Service {
 		ctx, cancel := context.WithCancel(ctx)
 		s := &Service{
-			ctx:           ctx,
-			cancel:        cancel,
-			chain:         mc,
-			synced:        abool.New(),
-			chainStarted:  abool.New(),
-			stateNotifier: mc.StateNotifier(),
-			counter:       ratecounter.NewRateCounter(counterSeconds * time.Second),
-			genesisChan:   make(chan time.Time),
+			cfg:          &Config{Chain: mc, StateNotifier: mc.StateNotifier()},
+			ctx:          ctx,
+			cancel:       cancel,
+			synced:       abool.New(),
+			chainStarted: abool.New(),
+			counter:      ratecounter.NewRateCounter(counterSeconds * time.Second),
+			genesisChan:  make(chan time.Time),
 		}
 		return s
 	}
@@ -253,12 +252,12 @@ func TestService_waitForStateInitialization(t *testing.T) {
 		go func() {
 			time.AfterFunc(500*time.Millisecond, func() {
 				// Send invalid event at first.
-				s.stateNotifier.StateFeed().Send(&feed.Event{
+				s.cfg.StateNotifier.StateFeed().Send(&feed.Event{
 					Type: statefeed.Initialized,
 					Data: &statefeed.BlockProcessedData{},
 				})
 				// Send valid event.
-				s.stateNotifier.StateFeed().Send(&feed.Event{
+				s.cfg.StateNotifier.StateFeed().Send(&feed.Event{
 					Type: statefeed.Initialized,
 					Data: &statefeed.InitializedData{
 						StartTime:             expectedGenesisTime,
@@ -284,7 +283,7 @@ func TestService_waitForStateInitialization(t *testing.T) {
 		defer cancel()
 		s := newService(ctx, &mock.ChainService{})
 		// Initialize mock feed
-		_ = s.stateNotifier.StateFeed()
+		_ = s.cfg.StateNotifier.StateFeed()
 
 		expectedGenesisTime := time.Now().Add(60 * time.Second)
 		wg := &sync.WaitGroup{}
@@ -298,7 +297,7 @@ func TestService_waitForStateInitialization(t *testing.T) {
 		go func() {
 			time.AfterFunc(500*time.Millisecond, func() {
 				// Send valid event.
-				s.stateNotifier.StateFeed().Send(&feed.Event{
+				s.cfg.StateNotifier.StateFeed().Send(&feed.Event{
 					Type: statefeed.Initialized,
 					Data: &statefeed.InitializedData{
 						StartTime:             expectedGenesisTime,
@@ -339,7 +338,7 @@ func TestService_markSynced(t *testing.T) {
 	var receivedGenesisTime time.Time
 
 	stateChannel := make(chan *feed.Event, 1)
-	stateSub := s.stateNotifier.StateFeed().Subscribe(stateChannel)
+	stateSub := s.cfg.StateNotifier.StateFeed().Subscribe(stateChannel)
 	defer stateSub.Unsubscribe()
 
 	wg := &sync.WaitGroup{}
@@ -407,7 +406,7 @@ func TestService_Resync(t *testing.T) {
 			},
 			assert: func(s *Service) {
 				assert.LogsContain(t, hook, "Resync attempt complete")
-				assert.Equal(t, types.Slot(160), s.chain.HeadSlot())
+				assert.Equal(t, types.Slot(160), s.cfg.Chain.HeadSlot())
 			},
 		},
 	}
@@ -428,7 +427,7 @@ func TestService_Resync(t *testing.T) {
 				StateNotifier: mc.StateNotifier(),
 			})
 			assert.NotNil(t, s)
-			assert.Equal(t, types.Slot(0), s.chain.HeadSlot())
+			assert.Equal(t, types.Slot(0), s.cfg.Chain.HeadSlot())
 			err := s.Resync()
 			if tt.wantedErr != "" {
 				assert.ErrorContains(t, tt.wantedErr, err)

--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -60,7 +60,7 @@ var (
 func (s *Service) updateMetrics() {
 	// do not update metrics if genesis time
 	// has not been initialized
-	if s.chain.GenesisTime().IsZero() {
+	if s.cfg.Chain.GenesisTime().IsZero() {
 		return
 	}
 	// We update the dynamic subnet topics.
@@ -68,18 +68,18 @@ func (s *Service) updateMetrics() {
 	if err != nil {
 		log.WithError(err).Debugf("Could not compute fork digest")
 	}
-	indices := s.aggregatorSubnetIndices(s.chain.CurrentSlot())
+	indices := s.aggregatorSubnetIndices(s.cfg.Chain.CurrentSlot())
 	attTopic := p2p.GossipTypeMapping[reflect.TypeOf(&pb.Attestation{})]
-	attTopic += s.p2p.Encoding().ProtocolSuffix()
+	attTopic += s.cfg.P2P.Encoding().ProtocolSuffix()
 	if flags.Get().SubscribeToAllSubnets {
 		for i := uint64(0); i < params.BeaconNetworkConfig().AttestationSubnetCount; i++ {
 			formattedTopic := fmt.Sprintf(attTopic, digest, i)
-			topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.p2p.PubSub().ListPeers(formattedTopic))))
+			topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.cfg.P2P.PubSub().ListPeers(formattedTopic))))
 		}
 	} else {
 		for _, committeeIdx := range indices {
 			formattedTopic := fmt.Sprintf(attTopic, digest, committeeIdx)
-			topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.p2p.PubSub().ListPeers(formattedTopic))))
+			topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.cfg.P2P.PubSub().ListPeers(formattedTopic))))
 		}
 	}
 
@@ -89,12 +89,12 @@ func (s *Service) updateMetrics() {
 		if strings.Contains(topic, "beacon_attestation") {
 			continue
 		}
-		topic += s.p2p.Encoding().ProtocolSuffix()
+		topic += s.cfg.P2P.Encoding().ProtocolSuffix()
 		if !strings.Contains(topic, "%x") {
-			topicPeerCount.WithLabelValues(topic).Set(float64(len(s.p2p.PubSub().ListPeers(topic))))
+			topicPeerCount.WithLabelValues(topic).Set(float64(len(s.cfg.P2P.PubSub().ListPeers(topic))))
 			continue
 		}
 		formattedTopic := fmt.Sprintf(topic, digest)
-		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.p2p.PubSub().ListPeers(formattedTopic))))
+		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.cfg.P2P.PubSub().ListPeers(formattedTopic))))
 	}
 }

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -45,7 +45,7 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 	// Before a node processes pending attestations queue, it verifies
 	// the attestations in the queue are still valid. Attestations will
 	// be deleted from the queue if invalid (ie. getting staled from falling too many slots behind).
-	s.validatePendingAtts(ctx, s.chain.CurrentSlot())
+	s.validatePendingAtts(ctx, s.cfg.Chain.CurrentSlot())
 
 	s.pendingAttsLock.RLock()
 	roots := make([][32]byte, 0, len(s.blkRootToPendingAtts))
@@ -61,7 +61,7 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 		attestations := s.blkRootToPendingAtts[bRoot]
 		s.pendingAttsLock.RUnlock()
 		// has the pending attestation's missing block arrived and the node processed block yet?
-		if s.db.HasBlock(ctx, bRoot) && (s.db.HasState(ctx, bRoot) || s.db.HasStateSummary(ctx, bRoot)) {
+		if s.cfg.DB.HasBlock(ctx, bRoot) && (s.cfg.DB.HasState(ctx, bRoot) || s.cfg.DB.HasStateSummary(ctx, bRoot)) {
 			for _, signedAtt := range attestations {
 				att := signedAtt.Message
 				// The pending attestations can arrive in both aggregated and unaggregated forms,
@@ -71,14 +71,14 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 					// validation steps.
 					aggValid := s.validateAggregatedAtt(ctx, signedAtt) == pubsub.ValidationAccept
 					if s.validateBlockInAttestation(ctx, signedAtt) && aggValid {
-						if err := s.attPool.SaveAggregatedAttestation(att.Aggregate); err != nil {
+						if err := s.cfg.AttPool.SaveAggregatedAttestation(att.Aggregate); err != nil {
 							log.WithError(err).Debug("Could not save aggregate attestation")
 							continue
 						}
 						s.setAggregatorIndexEpochSeen(att.Aggregate.Data.Target.Epoch, att.AggregatorIndex)
 
 						// Broadcasting the signed attestation again once a node is able to process it.
-						if err := s.p2p.Broadcast(ctx, signedAtt); err != nil {
+						if err := s.cfg.P2P.Broadcast(ctx, signedAtt); err != nil {
 							log.WithError(err).Debug("Could not broadcast")
 						}
 					}
@@ -86,15 +86,15 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 					// This is an important validation before retrieving attestation pre state to defend against
 					// attestation's target intentionally reference checkpoint that's long ago.
 					// Verify current finalized checkpoint is an ancestor of the block defined by the attestation's beacon block root.
-					if err := s.chain.VerifyFinalizedConsistency(ctx, att.Aggregate.Data.BeaconBlockRoot); err != nil {
+					if err := s.cfg.Chain.VerifyFinalizedConsistency(ctx, att.Aggregate.Data.BeaconBlockRoot); err != nil {
 						log.WithError(err).Debug("Could not verify finalized consistency")
 						continue
 					}
-					if err := s.chain.VerifyLmdFfgConsistency(ctx, att.Aggregate); err != nil {
+					if err := s.cfg.Chain.VerifyLmdFfgConsistency(ctx, att.Aggregate); err != nil {
 						log.WithError(err).Debug("Could not verify FFG consistency")
 						continue
 					}
-					preState, err := s.chain.AttestationPreState(ctx, att.Aggregate)
+					preState, err := s.cfg.Chain.AttestationPreState(ctx, att.Aggregate)
 					if err != nil {
 						log.WithError(err).Debug("Could not retrieve attestation prestate")
 						continue
@@ -102,7 +102,7 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 
 					valid := s.validateUnaggregatedAttWithState(ctx, att.Aggregate, preState)
 					if valid == pubsub.ValidationAccept {
-						if err := s.attPool.SaveUnaggregatedAttestation(att.Aggregate); err != nil {
+						if err := s.cfg.AttPool.SaveUnaggregatedAttestation(att.Aggregate); err != nil {
 							log.WithError(err).Debug("Could not save unaggregated attestation")
 							continue
 						}
@@ -114,7 +114,7 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 							continue
 						}
 						// Broadcasting the signed attestation again once a node is able to process it.
-						if err := s.p2p.BroadcastAttestation(ctx, helpers.ComputeSubnetForAttestation(valCount, signedAtt.Message.Aggregate), signedAtt.Message.Aggregate); err != nil {
+						if err := s.cfg.P2P.BroadcastAttestation(ctx, helpers.ComputeSubnetForAttestation(valCount, signedAtt.Message.Aggregate), signedAtt.Message.Aggregate); err != nil {
 							log.WithError(err).Debug("Could not broadcast")
 						}
 					}
@@ -132,7 +132,7 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 		} else {
 			// Pending attestation's missing block has not arrived yet.
 			log.WithFields(logrus.Fields{
-				"currentSlot": s.chain.CurrentSlot(),
+				"currentSlot": s.cfg.Chain.CurrentSlot(),
 				"attSlot":     attestations[0].Message.Aggregate.Data.Slot,
 				"attCount":    len(attestations),
 				"blockRoot":   hex.EncodeToString(bytesutil.Trunc(bRoot[:])),

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -42,9 +42,7 @@ func TestProcessPendingAtts_NoBlockRequestBlock(t *testing.T) {
 	p1.Peers().SetChainState(p2.PeerID(), &pb.Status{})
 
 	r := &Service{
-		p2p:                  p1,
-		db:                   db,
-		chain:                &mock.ChainService{Genesis: timeutils.Now(), FinalizedCheckPoint: &ethpb.Checkpoint{}},
+		cfg:                  &Config{P2P: p1, DB: db, Chain: &mock.ChainService{Genesis: timeutils.Now(), FinalizedCheckPoint: &ethpb.Checkpoint{}}},
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
 		chainStarted:         abool.New(),
 	}
@@ -110,35 +108,37 @@ func TestProcessPendingAtts_HasBlockSaveUnAggregatedAtt(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p: p1,
-		db:  db,
-		chain: &mock.ChainService{Genesis: time.Now(),
-			State: beaconState,
-			FinalizedCheckPoint: &ethpb.Checkpoint{
-				Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
-				Epoch: 0,
-			}},
+		cfg: &Config{
+			P2P: p1,
+			DB:  db,
+			Chain: &mock.ChainService{Genesis: time.Now(),
+				State: beaconState,
+				FinalizedCheckPoint: &ethpb.Checkpoint{
+					Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
+					Epoch: 0,
+				}},
+			AttPool: attestations.NewPool(),
+		},
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
-		attPool:              attestations.NewPool(),
 		seenAttestationCache: c,
 	}
 
 	sb = testutil.NewBeaconBlock()
 	r32, err := sb.Block.HashTreeRoot()
 	require.NoError(t, err)
-	require.NoError(t, r.db.SaveBlock(context.Background(), sb))
+	require.NoError(t, r.cfg.DB.SaveBlock(context.Background(), sb))
 	s, err := testutil.NewBeaconState()
 	require.NoError(t, err)
-	require.NoError(t, r.db.SaveState(context.Background(), s, r32))
+	require.NoError(t, r.cfg.DB.SaveState(context.Background(), s, r32))
 
 	r.blkRootToPendingAtts[r32] = []*ethpb.SignedAggregateAttestationAndProof{{Message: aggregateAndProof, Signature: aggreSig}}
 	require.NoError(t, r.processPendingAtts(context.Background()))
 
-	atts, err := r.attPool.UnaggregatedAttestations()
+	atts, err := r.cfg.AttPool.UnaggregatedAttestations()
 	require.NoError(t, err)
 	assert.Equal(t, 1, len(atts), "Did not save unaggregated att")
 	assert.DeepEqual(t, att, atts[0], "Incorrect saved att")
-	assert.Equal(t, 0, len(r.attPool.AggregatedAttestations()), "Did save aggregated att")
+	assert.Equal(t, 0, len(r.cfg.AttPool.AggregatedAttestations()), "Did save aggregated att")
 	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")
 }
 
@@ -148,11 +148,13 @@ func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
 
 	s, _ := testutil.DeterministicGenesisState(t, 256)
 	r := &Service{
-		p2p:                  p1,
-		db:                   db,
-		chain:                &mock.ChainService{State: s, Genesis: timeutils.Now(), FinalizedCheckPoint: &ethpb.Checkpoint{Root: make([]byte, 32)}},
+		cfg: &Config{
+			P2P:     p1,
+			DB:      db,
+			Chain:   &mock.ChainService{State: s, Genesis: timeutils.Now(), FinalizedCheckPoint: &ethpb.Checkpoint{Root: make([]byte, 32)}},
+			AttPool: attestations.NewPool(),
+		},
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
-		attPool:              attestations.NewPool(),
 	}
 
 	priv, err := bls.RandKey()
@@ -169,15 +171,15 @@ func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
 	b := testutil.NewBeaconBlock()
 	r32, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
-	require.NoError(t, r.db.SaveBlock(context.Background(), b))
-	require.NoError(t, r.db.SaveState(context.Background(), s, r32))
+	require.NoError(t, r.cfg.DB.SaveBlock(context.Background(), b))
+	require.NoError(t, r.cfg.DB.SaveState(context.Background(), s, r32))
 
 	r.blkRootToPendingAtts[r32] = []*ethpb.SignedAggregateAttestationAndProof{{Message: a, Signature: make([]byte, 96)}}
 	require.NoError(t, r.processPendingAtts(context.Background()))
 
 	assert.Equal(t, false, p1.BroadcastCalled, "Broadcasted bad aggregate")
 	// Clear pool.
-	err = r.attPool.DeleteUnaggregatedAttestation(a.Aggregate)
+	err = r.cfg.AttPool.DeleteUnaggregatedAttestation(a.Aggregate)
 	require.NoError(t, err)
 
 	validators := uint64(256)
@@ -223,16 +225,18 @@ func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r = &Service{
-		p2p: p1,
-		db:  db,
-		chain: &mock.ChainService{Genesis: time.Now(),
-			State: s,
-			FinalizedCheckPoint: &ethpb.Checkpoint{
-				Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
-				Epoch: 0,
-			}},
+		cfg: &Config{
+			P2P: p1,
+			DB:  db,
+			Chain: &mock.ChainService{Genesis: time.Now(),
+				State: s,
+				FinalizedCheckPoint: &ethpb.Checkpoint{
+					Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
+					Epoch: 0,
+				}},
+			AttPool: attestations.NewPool(),
+		},
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
-		attPool:              attestations.NewPool(),
 		seenAttestationCache: c,
 	}
 
@@ -301,33 +305,35 @@ func TestProcessPendingAtts_HasBlockSaveAggregatedAtt(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p: p1,
-		db:  db,
-		chain: &mock.ChainService{Genesis: time.Now(),
-			State: beaconState,
-			FinalizedCheckPoint: &ethpb.Checkpoint{
-				Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
-				Epoch: 0,
-			}},
+		cfg: &Config{
+			P2P: p1,
+			DB:  db,
+			Chain: &mock.ChainService{Genesis: time.Now(),
+				State: beaconState,
+				FinalizedCheckPoint: &ethpb.Checkpoint{
+					Root:  aggregateAndProof.Aggregate.Data.BeaconBlockRoot,
+					Epoch: 0,
+				}},
+			AttPool: attestations.NewPool(),
+		},
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
-		attPool:              attestations.NewPool(),
 		seenAttestationCache: c,
 	}
 
 	sb = testutil.NewBeaconBlock()
 	r32, err := sb.Block.HashTreeRoot()
 	require.NoError(t, err)
-	require.NoError(t, r.db.SaveBlock(context.Background(), sb))
+	require.NoError(t, r.cfg.DB.SaveBlock(context.Background(), sb))
 	s, err := testutil.NewBeaconState()
 	require.NoError(t, err)
-	require.NoError(t, r.db.SaveState(context.Background(), s, r32))
+	require.NoError(t, r.cfg.DB.SaveState(context.Background(), s, r32))
 
 	r.blkRootToPendingAtts[r32] = []*ethpb.SignedAggregateAttestationAndProof{{Message: aggregateAndProof, Signature: aggreSig}}
 	require.NoError(t, r.processPendingAtts(context.Background()))
 
-	assert.Equal(t, 1, len(r.attPool.AggregatedAttestations()), "Did not save aggregated att")
-	assert.DeepEqual(t, att, r.attPool.AggregatedAttestations()[0], "Incorrect saved att")
-	atts, err := r.attPool.UnaggregatedAttestations()
+	assert.Equal(t, 1, len(r.cfg.AttPool.AggregatedAttestations()), "Did not save aggregated att")
+	assert.DeepEqual(t, att, r.cfg.AttPool.AggregatedAttestations()[0], "Incorrect saved att")
+	atts, err := r.cfg.AttPool.UnaggregatedAttestations()
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(atts), "Did save aggregated att")
 	require.LogsContain(t, hook, "Verified and saved pending attestations to pool")

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -17,7 +17,7 @@ func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 	ctx, cancel := context.WithTimeout(ctx, respTimeout)
 	defer cancel()
 
-	_, err := SendBeaconBlocksByRootRequest(ctx, s.p2p, id, blockRoots, func(blk *ethpb.SignedBeaconBlock) error {
+	_, err := SendBeaconBlocksByRootRequest(ctx, s.cfg.P2P, id, blockRoots, func(blk *ethpb.SignedBeaconBlock) error {
 		blkRoot, err := blk.Block.HashTreeRoot()
 		if err != nil {
 			return err
@@ -62,7 +62,7 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 	s.rateLimiter.add(stream, int64(len(blockRoots)))
 
 	for _, root := range blockRoots {
-		blk, err := s.db.Block(ctx, root)
+		blk, err := s.cfg.DB.Block(ctx, root)
 		if err != nil {
 			log.WithError(err).Debug("Could not fetch block")
 			s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)

--- a/beacon-chain/sync/rpc_chunked_response.go
+++ b/beacon-chain/sync/rpc_chunked_response.go
@@ -14,7 +14,7 @@ import (
 // response_chunk ::= | <result> | <encoding-dependent-header> | <encoded-payload>
 func (s *Service) chunkWriter(stream libp2pcore.Stream, msg interface{}) error {
 	SetStreamWriteDeadline(stream, defaultWriteDuration)
-	return WriteChunk(stream, s.p2p.Encoding(), msg)
+	return WriteChunk(stream, s.cfg.P2P.Encoding(), msg)
 }
 
 // WriteChunk object to stream.

--- a/beacon-chain/sync/rpc_goodbye_test.go
+++ b/beacon-chain/sync/rpc_goodbye_test.go
@@ -27,8 +27,10 @@ func TestGoodByeRPCHandler_Disconnects_With_Peer(t *testing.T) {
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
 	r := &Service{
-		db:          d,
-		p2p:         p1,
+		cfg: &Config{
+			DB:  d,
+			P2P: p1,
+		},
 		rateLimiter: newRateLimiter(p1),
 	}
 
@@ -70,8 +72,10 @@ func TestGoodByeRPCHandler_BackOffPeer(t *testing.T) {
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
 	r := &Service{
-		db:          d,
-		p2p:         p1,
+		cfg: &Config{
+			DB:  d,
+			P2P: p1,
+		},
 		rateLimiter: newRateLimiter(p1),
 	}
 
@@ -143,8 +147,10 @@ func TestSendGoodbye_SendsMessage(t *testing.T) {
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
 	r := &Service{
-		db:          d,
-		p2p:         p1,
+		cfg: &Config{
+			DB:  d,
+			P2P: p1,
+		},
 		rateLimiter: newRateLimiter(p1),
 	}
 	failureCode := p2ptypes.GoodbyeCodeClientShutdown
@@ -158,7 +164,7 @@ func TestSendGoodbye_SendsMessage(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
 		out := new(types.SSZUint64)
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		assert.Equal(t, failureCode, *out)
 		assert.NoError(t, stream.Close())
 	})
@@ -185,8 +191,10 @@ func TestSendGoodbye_DisconnectWithPeer(t *testing.T) {
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
 	r := &Service{
-		db:          d,
-		p2p:         p1,
+		cfg: &Config{
+			DB:  d,
+			P2P: p1,
+		},
 		rateLimiter: newRateLimiter(p1),
 	}
 	failureCode := p2ptypes.GoodbyeCodeClientShutdown
@@ -200,7 +208,7 @@ func TestSendGoodbye_DisconnectWithPeer(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
 		out := new(types.SSZUint64)
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		assert.Equal(t, failureCode, *out)
 		assert.NoError(t, stream.Close())
 	})

--- a/beacon-chain/sync/rpc_metadata.go
+++ b/beacon-chain/sync/rpc_metadata.go
@@ -22,7 +22,7 @@ func (s *Service) metaDataHandler(_ context.Context, _ interface{}, stream libp2
 	if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
 		return err
 	}
-	_, err := s.p2p.Encoding().EncodeWithMaxLength(stream, s.p2p.Metadata())
+	_, err := s.cfg.P2P.Encoding().EncodeWithMaxLength(stream, s.cfg.P2P.Metadata())
 	if err != nil {
 		return err
 	}
@@ -34,21 +34,21 @@ func (s *Service) sendMetaDataRequest(ctx context.Context, id peer.ID) (*pb.Meta
 	ctx, cancel := context.WithTimeout(ctx, respTimeout)
 	defer cancel()
 
-	stream, err := s.p2p.Send(ctx, new(interface{}), p2p.RPCMetaDataTopic, id)
+	stream, err := s.cfg.P2P.Send(ctx, new(interface{}), p2p.RPCMetaDataTopic, id)
 	if err != nil {
 		return nil, err
 	}
 	defer closeStream(stream, log)
-	code, errMsg, err := ReadStatusCode(stream, s.p2p.Encoding())
+	code, errMsg, err := ReadStatusCode(stream, s.cfg.P2P.Encoding())
 	if err != nil {
 		return nil, err
 	}
 	if code != 0 {
-		s.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
+		s.cfg.P2P.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 		return nil, errors.New(errMsg)
 	}
 	msg := new(pb.MetaData)
-	if err := s.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
+	if err := s.cfg.P2P.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
 		return nil, err
 	}
 	return msg, nil

--- a/beacon-chain/sync/rpc_ping_test.go
+++ b/beacon-chain/sync/rpc_ping_test.go
@@ -38,8 +38,10 @@ func TestPingRPCHandler_ReceivesPing(t *testing.T) {
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
 	r := &Service{
-		db:          d,
-		p2p:         p1,
+		cfg: &Config{
+			DB:  d,
+			P2P: p1,
+		},
 		rateLimiter: newRateLimiter(p1),
 	}
 
@@ -56,7 +58,7 @@ func TestPingRPCHandler_ReceivesPing(t *testing.T) {
 		defer wg.Done()
 		expectSuccess(t, stream)
 		out := new(types.SSZUint64)
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		assert.Equal(t, uint64(2), uint64(*out))
 	})
 	stream1, err := p1.BHost.NewStream(context.Background(), p2.BHost.ID(), pcl)
@@ -93,8 +95,10 @@ func TestPingRPCHandler_SendsPing(t *testing.T) {
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
 	r := &Service{
-		db:          d,
-		p2p:         p1,
+		cfg: &Config{
+			DB:  d,
+			P2P: p1,
+		},
 		rateLimiter: newRateLimiter(p1),
 	}
 
@@ -105,8 +109,10 @@ func TestPingRPCHandler_SendsPing(t *testing.T) {
 	p2.Peers().SetMetadata(p1.BHost.ID(), p1.LocalMetadata)
 
 	r2 := &Service{
-		db:          d,
-		p2p:         p2,
+		cfg: &Config{
+			DB:  d,
+			P2P: p2,
+		},
 		rateLimiter: newRateLimiter(p2),
 	}
 	// Setup streams
@@ -119,7 +125,7 @@ func TestPingRPCHandler_SendsPing(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
 		out := new(types.SSZUint64)
-		assert.NoError(t, r2.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r2.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		assert.Equal(t, uint64(2), uint64(*out))
 		assert.NoError(t, r2.pingHandler(context.Background(), out, stream))
 	})
@@ -154,8 +160,10 @@ func TestPingRPCHandler_BadSequenceNumber(t *testing.T) {
 	// Set up a head state in the database with data we expect.
 	d := db.SetupDB(t)
 	r := &Service{
-		db:          d,
-		p2p:         p1,
+		cfg: &Config{
+			DB:  d,
+			P2P: p1,
+		},
 		rateLimiter: newRateLimiter(p1),
 	}
 

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -38,21 +38,25 @@ func TestStatusRPCHandler_Disconnects_OnForkVersionMismatch(t *testing.T) {
 	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 	root := [32]byte{'C'}
 
-	r := &Service{p2p: p1,
+	r := &Service{
+		cfg: &Config{
+			P2P: p1,
+			Chain: &mock.ChainService{
+				Fork: &pb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				FinalizedCheckPoint: &ethpb.Checkpoint{
+					Epoch: 0,
+					Root:  root[:],
+				},
+				Genesis:        time.Now(),
+				ValidatorsRoot: [32]byte{'A'},
+				Root:           make([]byte, 32),
+			},
+		},
 		rateLimiter: newRateLimiter(p1),
-		chain: &mock.ChainService{
-			Fork: &pb.Fork{
-				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-			},
-			FinalizedCheckPoint: &ethpb.Checkpoint{
-				Epoch: 0,
-				Root:  root[:],
-			},
-			Genesis:        time.Now(),
-			ValidatorsRoot: [32]byte{'A'},
-			Root:           make([]byte, 32),
-		}}
+	}
 	pcl := protocol.ID("/testing")
 	topic := string(pcl)
 	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, false)
@@ -63,7 +67,7 @@ func TestStatusRPCHandler_Disconnects_OnForkVersionMismatch(t *testing.T) {
 		defer wg.Done()
 		expectSuccess(t, stream)
 		out := &pb.Status{}
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		assert.DeepEqual(t, root[:], out.FinalizedRoot)
 		assert.NoError(t, stream.Close())
 	})
@@ -76,7 +80,7 @@ func TestStatusRPCHandler_Disconnects_OnForkVersionMismatch(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl2, func(stream network.Stream) {
 		defer wg2.Done()
 		msg := new(types.SSZUint64)
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, msg))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, msg))
 		assert.Equal(t, p2ptypes.GoodbyeCodeWrongNetwork, *msg)
 		assert.NoError(t, stream.Close())
 	})
@@ -102,21 +106,25 @@ func TestStatusRPCHandler_ConnectsOnGenesis(t *testing.T) {
 	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
 	root := [32]byte{}
 
-	r := &Service{p2p: p1,
+	r := &Service{
+		cfg: &Config{
+			P2P: p1,
+			Chain: &mock.ChainService{
+				Fork: &pb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				FinalizedCheckPoint: &ethpb.Checkpoint{
+					Epoch: 0,
+					Root:  params.BeaconConfig().ZeroHash[:],
+				},
+				Genesis:        time.Now(),
+				ValidatorsRoot: [32]byte{'A'},
+				Root:           make([]byte, 32),
+			},
+		},
 		rateLimiter: newRateLimiter(p1),
-		chain: &mock.ChainService{
-			Fork: &pb.Fork{
-				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
-			},
-			FinalizedCheckPoint: &ethpb.Checkpoint{
-				Epoch: 0,
-				Root:  params.BeaconConfig().ZeroHash[:],
-			},
-			Genesis:        time.Now(),
-			ValidatorsRoot: [32]byte{'A'},
-			Root:           make([]byte, 32),
-		}}
+	}
 	pcl := protocol.ID("/testing")
 	topic := string(pcl)
 	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(1, 1, false)
@@ -127,7 +135,7 @@ func TestStatusRPCHandler_ConnectsOnGenesis(t *testing.T) {
 		defer wg.Done()
 		expectSuccess(t, stream)
 		out := &pb.Status{}
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		assert.DeepEqual(t, root[:], out.FinalizedRoot)
 	})
 
@@ -177,19 +185,21 @@ func TestStatusRPCHandler_ReturnsHelloMessage(t *testing.T) {
 	genTime := time.Now().Unix() - totalSec
 
 	r := &Service{
-		p2p: p1,
-		chain: &mock.ChainService{
-			State:               genesisState,
-			FinalizedCheckPoint: finalizedCheckpt,
-			Root:                headRoot[:],
-			Fork: &pb.Fork{
-				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		cfg: &Config{
+			P2P: p1,
+			Chain: &mock.ChainService{
+				State:               genesisState,
+				FinalizedCheckPoint: finalizedCheckpt,
+				Root:                headRoot[:],
+				Fork: &pb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				ValidatorsRoot: [32]byte{'A'},
+				Genesis:        time.Unix(genTime, 0),
 			},
-			ValidatorsRoot: [32]byte{'A'},
-			Genesis:        time.Unix(genTime, 0),
+			DB: db,
 		},
-		db:          db,
 		rateLimiter: newRateLimiter(p1),
 	}
 	digest, err := r.forkDigest()
@@ -205,7 +215,7 @@ func TestStatusRPCHandler_ReturnsHelloMessage(t *testing.T) {
 		defer wg.Done()
 		expectSuccess(t, stream)
 		out := &pb.Status{}
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		expected := &pb.Status{
 			ForkDigest:     digest[:],
 			HeadSlot:       genesisState.Slot(),
@@ -260,19 +270,21 @@ func TestHandshakeHandlers_Roundtrip(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, db.SaveGenesisBlockRoot(context.Background(), finalizedRoot))
 	r := &Service{
-		p2p: p1,
-		chain: &mock.ChainService{
-			State:               st,
-			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
-			Fork: &pb.Fork{
-				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		cfg: &Config{
+			P2P: p1,
+			Chain: &mock.ChainService{
+				State:               st,
+				FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
+				Fork: &pb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				Genesis:        time.Now(),
+				ValidatorsRoot: [32]byte{'A'},
+				Root:           make([]byte, 32),
 			},
-			Genesis:        time.Now(),
-			ValidatorsRoot: [32]byte{'A'},
-			Root:           make([]byte, 32),
+			DB: db,
 		},
-		db:          db,
 		ctx:         context.Background(),
 		rateLimiter: newRateLimiter(p1),
 	}
@@ -280,10 +292,12 @@ func TestHandshakeHandlers_Roundtrip(t *testing.T) {
 	require.NoError(t, err)
 
 	r2 := &Service{
-		chain: &mock.ChainService{
-			FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
+		cfg: &Config{
+			Chain: &mock.ChainService{
+				FinalizedCheckPoint: &ethpb.Checkpoint{Epoch: 0, Root: finalizedRoot[:]},
+			},
+			P2P: p2,
 		},
-		p2p:         p2,
 		rateLimiter: newRateLimiter(p2),
 	}
 	p2.Digest, err = r.forkDigest()
@@ -300,13 +314,13 @@ func TestHandshakeHandlers_Roundtrip(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
 		out := &pb.Status{}
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		log.WithField("status", out).Warn("received status")
 		resp := &pb.Status{HeadSlot: 100, HeadRoot: make([]byte, 32), ForkDigest: p2.Digest[:],
 			FinalizedRoot: finalizedRoot[:], FinalizedEpoch: 0}
 		_, err := stream.Write([]byte{responseCodeSuccess})
 		assert.NoError(t, err)
-		_, err = r.p2p.Encoding().EncodeWithMaxLength(stream, resp)
+		_, err = r.cfg.P2P.Encoding().EncodeWithMaxLength(stream, resp)
 		assert.NoError(t, err)
 		log.WithField("status", out).Warn("sending status")
 		if err := stream.Close(); err != nil {
@@ -322,7 +336,7 @@ func TestHandshakeHandlers_Roundtrip(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg2.Done()
 		out := new(types.SSZUint64)
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		assert.Equal(t, uint64(2), uint64(*out))
 		assert.NoError(t, r2.pingHandler(context.Background(), out, stream))
 		assert.NoError(t, stream.Close())
@@ -390,17 +404,19 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 	}
 
 	r := &Service{
-		p2p: p1,
-		chain: &mock.ChainService{
-			State:               genesisState,
-			FinalizedCheckPoint: finalizedCheckpt,
-			Root:                headRoot[:],
-			Fork: &pb.Fork{
-				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		cfg: &Config{
+			P2P: p1,
+			Chain: &mock.ChainService{
+				State:               genesisState,
+				FinalizedCheckPoint: finalizedCheckpt,
+				Root:                headRoot[:],
+				Fork: &pb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				Genesis:        time.Now(),
+				ValidatorsRoot: [32]byte{'A'},
 			},
-			Genesis:        time.Now(),
-			ValidatorsRoot: [32]byte{'A'},
 		},
 		ctx:         context.Background(),
 		rateLimiter: newRateLimiter(p1),
@@ -415,7 +431,7 @@ func TestStatusRPCRequest_RequestSent(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
 		out := &pb.Status{}
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		digest, err := r.forkDigest()
 		assert.NoError(t, err)
 		expected := &pb.Status{
@@ -470,36 +486,40 @@ func TestStatusRPCRequest_FinalizedBlockExists(t *testing.T) {
 	totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
 	genTime := time.Now().Unix() - totalSec
 	r := &Service{
-		p2p: p1,
-		chain: &mock.ChainService{
-			State:               genesisState,
-			FinalizedCheckPoint: finalizedCheckpt,
-			Root:                headRoot[:],
-			Fork: &pb.Fork{
-				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		cfg: &Config{
+			P2P: p1,
+			Chain: &mock.ChainService{
+				State:               genesisState,
+				FinalizedCheckPoint: finalizedCheckpt,
+				Root:                headRoot[:],
+				Fork: &pb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				Genesis:        time.Unix(genTime, 0),
+				ValidatorsRoot: [32]byte{'A'},
 			},
-			Genesis:        time.Unix(genTime, 0),
-			ValidatorsRoot: [32]byte{'A'},
 		},
 		ctx:         context.Background(),
 		rateLimiter: newRateLimiter(p1),
 	}
 
 	r2 := &Service{
-		p2p: p1,
-		chain: &mock.ChainService{
-			State:               genesisState,
-			FinalizedCheckPoint: finalizedCheckpt,
-			Root:                headRoot[:],
-			Fork: &pb.Fork{
-				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		cfg: &Config{
+			P2P: p1,
+			Chain: &mock.ChainService{
+				State:               genesisState,
+				FinalizedCheckPoint: finalizedCheckpt,
+				Root:                headRoot[:],
+				Fork: &pb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				Genesis:        time.Unix(genTime, 0),
+				ValidatorsRoot: [32]byte{'A'},
 			},
-			Genesis:        time.Unix(genTime, 0),
-			ValidatorsRoot: [32]byte{'A'},
+			DB: db,
 		},
-		db:          db,
 		ctx:         context.Background(),
 		rateLimiter: newRateLimiter(p1),
 	}
@@ -513,7 +533,7 @@ func TestStatusRPCRequest_FinalizedBlockExists(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
 		out := &pb.Status{}
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		assert.NoError(t, r2.validateStatusMessage(context.Background(), out))
 	})
 
@@ -639,36 +659,41 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 		totalSec := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(epoch) * params.BeaconConfig().SecondsPerSlot))
 		genTime := time.Now().Unix() - int64(totalSec)
 		r := &Service{
-			p2p: p1,
-			chain: &mock.ChainService{
-				State:               nState,
-				FinalizedCheckPoint: remoteFinalizedChkpt,
-				Root:                rHeadRoot[:],
-				Fork: &pb.Fork{
-					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+			cfg: &Config{
+				P2P: p1,
+				Chain: &mock.ChainService{
+					State:               nState,
+					FinalizedCheckPoint: remoteFinalizedChkpt,
+					Root:                rHeadRoot[:],
+					Fork: &pb.Fork{
+						PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+						CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+					},
+					Genesis:        time.Unix(genTime, 0),
+					ValidatorsRoot: [32]byte{'A'},
 				},
-				Genesis:        time.Unix(genTime, 0),
-				ValidatorsRoot: [32]byte{'A'},
 			},
 			ctx:         context.Background(),
 			rateLimiter: newRateLimiter(p1),
 		}
 
 		r2 := &Service{
-			p2p: p2,
-			chain: &mock.ChainService{
-				State:               nState,
-				FinalizedCheckPoint: finalizedCheckpt,
-				Root:                headRoot[:],
-				Fork: &pb.Fork{
-					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+			cfg: &Config{
+				P2P: p2,
+				Chain: &mock.ChainService{
+					State:               nState,
+					FinalizedCheckPoint: finalizedCheckpt,
+					Root:                headRoot[:],
+					Fork: &pb.Fork{
+						PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+						CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+					},
+					Genesis:        time.Unix(genTime, 0),
+					ValidatorsRoot: [32]byte{'A'},
 				},
-				Genesis:        time.Unix(genTime, 0),
-				ValidatorsRoot: [32]byte{'A'},
+				DB: db,
 			},
-			db:          db,
+
 			ctx:         context.Background(),
 			rateLimiter: newRateLimiter(p1),
 		}
@@ -682,7 +707,7 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 		p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 			defer wg.Done()
 			out := &pb.Status{}
-			assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+			assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 			assert.Equal(t, tt.expectError, r2.validateStatusMessage(context.Background(), out) != nil)
 		})
 
@@ -721,18 +746,21 @@ func TestStatusRPCRequest_BadPeerHandshake(t *testing.T) {
 	}
 
 	r := &Service{
-		p2p: p1,
-		chain: &mock.ChainService{
-			State:               genesisState,
-			FinalizedCheckPoint: finalizedCheckpt,
-			Root:                headRoot[:],
-			Fork: &pb.Fork{
-				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		cfg: &Config{
+			P2P: p1,
+			Chain: &mock.ChainService{
+				State:               genesisState,
+				FinalizedCheckPoint: finalizedCheckpt,
+				Root:                headRoot[:],
+				Fork: &pb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				Genesis:        time.Now(),
+				ValidatorsRoot: [32]byte{'A'},
 			},
-			Genesis:        time.Now(),
-			ValidatorsRoot: [32]byte{'A'},
 		},
+
 		ctx:         context.Background(),
 		rateLimiter: newRateLimiter(p1),
 	}
@@ -748,7 +776,7 @@ func TestStatusRPCRequest_BadPeerHandshake(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
 		out := &pb.Status{}
-		assert.NoError(t, r.p2p.Encoding().DecodeWithMaxLength(stream, out))
+		assert.NoError(t, r.cfg.P2P.Encoding().DecodeWithMaxLength(stream, out))
 		expected := &pb.Status{
 			ForkDigest:     []byte{1, 1, 1, 1},
 			HeadSlot:       genesisState.Slot(),
@@ -759,7 +787,7 @@ func TestStatusRPCRequest_BadPeerHandshake(t *testing.T) {
 		if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
 			log.WithError(err).Debug("Could not write to stream")
 		}
-		_, err := r.p2p.Encoding().EncodeWithMaxLength(stream, expected)
+		_, err := r.cfg.P2P.Encoding().EncodeWithMaxLength(stream, expected)
 		assert.NoError(t, err)
 	})
 
@@ -798,16 +826,18 @@ func TestStatusRPC_ValidGenesisMessage(t *testing.T) {
 		Root:  finalizedRoot[:],
 	}
 	r := &Service{
-		chain: &mock.ChainService{
-			State:               genesisState,
-			FinalizedCheckPoint: finalizedCheckpt,
-			Root:                headRoot[:],
-			Fork: &pb.Fork{
-				PreviousVersion: params.BeaconConfig().GenesisForkVersion,
-				CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		cfg: &Config{
+			Chain: &mock.ChainService{
+				State:               genesisState,
+				FinalizedCheckPoint: finalizedCheckpt,
+				Root:                headRoot[:],
+				Fork: &pb.Fork{
+					PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+					CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+				},
+				Genesis:        time.Now(),
+				ValidatorsRoot: [32]byte{'A'},
 			},
-			Genesis:        time.Now(),
-			ValidatorsRoot: [32]byte{'A'},
 		},
 		ctx: context.Background(),
 	}
@@ -878,12 +908,14 @@ func TestShouldResync(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, headState.SetSlot(tt.args.headSlot))
 		r := &Service{
-			chain: &mock.ChainService{
-				State:   headState,
-				Genesis: tt.args.genesis,
+			cfg: &Config{
+				Chain: &mock.ChainService{
+					State:   headState,
+					Genesis: tt.args.genesis,
+				},
+				InitialSync: &mockSync.Sync{IsSyncing: tt.args.syncing},
 			},
-			ctx:         context.Background(),
-			initialSync: &mockSync.Sync{IsSyncing: tt.args.syncing},
+			ctx: context.Background(),
 		}
 		t.Run(tt.name, func(t *testing.T) {
 			if got := r.shouldReSync(); got != tt.want {

--- a/beacon-chain/sync/rpc_test.go
+++ b/beacon-chain/sync/rpc_test.go
@@ -50,7 +50,7 @@ func TestRegisterRPC_ReceivesValidMessage(t *testing.T) {
 	p2p := p2ptest.NewTestP2P(t)
 	r := &Service{
 		ctx:         context.Background(),
-		p2p:         p2p,
+		cfg:         &Config{P2P: p2p},
 		rateLimiter: newRateLimiter(p2p),
 	}
 

--- a/beacon-chain/sync/service_test.go
+++ b/beacon-chain/sync/service_test.go
@@ -26,11 +26,13 @@ func TestService_StatusZeroEpoch(t *testing.T) {
 	bState, err := stateV0.InitializeFromProto(&pb.BeaconState{Slot: 0})
 	require.NoError(t, err)
 	r := &Service{
-		p2p:         p2ptest.NewTestP2P(t),
-		initialSync: new(mockSync.Sync),
-		chain: &mockChain.ChainService{
-			Genesis: time.Now(),
-			State:   bState,
+		cfg: &Config{
+			P2P:         p2ptest.NewTestP2P(t),
+			InitialSync: new(mockSync.Sync),
+			Chain: &mockChain.ChainService{
+				Genesis: time.Now(),
+				State:   bState,
+			},
 		},
 		chainStarted: abool.New(),
 	}
@@ -46,18 +48,20 @@ func TestSyncHandlers_WaitToSync(t *testing.T) {
 		ValidatorsRoot: [32]byte{'A'},
 	}
 	r := Service{
-		ctx:           context.Background(),
-		p2p:           p2p,
-		chain:         chainService,
-		stateNotifier: chainService.StateNotifier(),
-		chainStarted:  abool.New(),
-		initialSync:   &mockSync.Sync{IsSyncing: false},
+		ctx: context.Background(),
+		cfg: &Config{
+			P2P:           p2p,
+			Chain:         chainService,
+			StateNotifier: chainService.StateNotifier(),
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+		},
+		chainStarted: abool.New(),
 	}
 
 	topic := "/eth2/%x/beacon_block"
 	go r.registerHandlers()
 	time.Sleep(100 * time.Millisecond)
-	i := r.stateNotifier.StateFeed().Send(&feed.Event{
+	i := r.cfg.StateNotifier.StateFeed().Send(&feed.Event{
 		Type: statefeed.Initialized,
 		Data: &statefeed.InitializedData{
 			StartTime: time.Now(),
@@ -87,18 +91,20 @@ func TestSyncHandlers_WaitForChainStart(t *testing.T) {
 		ValidatorsRoot: [32]byte{'A'},
 	}
 	r := Service{
-		ctx:                 context.Background(),
-		p2p:                 p2p,
-		chain:               chainService,
-		stateNotifier:       chainService.StateNotifier(),
-		initialSync:         &mockSync.Sync{IsSyncing: false},
+		ctx: context.Background(),
+		cfg: &Config{
+			P2P:           p2p,
+			Chain:         chainService,
+			StateNotifier: chainService.StateNotifier(),
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+		},
 		chainStarted:        abool.New(),
 		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
 	}
 
 	go r.registerHandlers()
 	time.Sleep(100 * time.Millisecond)
-	i := r.stateNotifier.StateFeed().Send(&feed.Event{
+	i := r.cfg.StateNotifier.StateFeed().Send(&feed.Event{
 		Type: statefeed.Initialized,
 		Data: &statefeed.InitializedData{
 			StartTime: time.Now().Add(2 * time.Second),
@@ -121,18 +127,20 @@ func TestSyncHandlers_WaitTillSynced(t *testing.T) {
 		ValidatorsRoot: [32]byte{'A'},
 	}
 	r := Service{
-		ctx:           context.Background(),
-		p2p:           p2p,
-		chain:         chainService,
-		stateNotifier: chainService.StateNotifier(),
-		initialSync:   &mockSync.Sync{IsSyncing: false},
-		chainStarted:  abool.New(),
+		ctx: context.Background(),
+		cfg: &Config{
+			P2P:           p2p,
+			Chain:         chainService,
+			StateNotifier: chainService.StateNotifier(),
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+		},
+		chainStarted: abool.New(),
 	}
 
 	topic := "/eth2/%x/beacon_block"
 	go r.registerHandlers()
 	time.Sleep(100 * time.Millisecond)
-	i := r.stateNotifier.StateFeed().Send(&feed.Event{
+	i := r.cfg.StateNotifier.StateFeed().Send(&feed.Event{
 		Type: statefeed.Initialized,
 		Data: &statefeed.InitializedData{
 			StartTime: time.Now(),
@@ -150,9 +158,9 @@ func TestSyncHandlers_WaitTillSynced(t *testing.T) {
 	msg.Block.ParentRoot = testutil.Random32Bytes(t)
 	msg.Signature = sk.Sign([]byte("data")).Marshal()
 	p2p.Digest, err = r.forkDigest()
-	r.blockNotifier = chainService.BlockNotifier()
+	r.cfg.BlockNotifier = chainService.BlockNotifier()
 	blockChan := make(chan feed.Event, 1)
-	sub := r.blockNotifier.BlockFeed().Subscribe(blockChan)
+	sub := r.cfg.BlockNotifier.BlockFeed().Subscribe(blockChan)
 
 	require.NoError(t, err)
 	p2p.ReceivePubSub(topic, msg)
@@ -163,7 +171,7 @@ func TestSyncHandlers_WaitTillSynced(t *testing.T) {
 
 	assert.Equal(t, 0, len(blockChan), "block was received by sync service despite not being fully synced")
 
-	i = r.stateNotifier.StateFeed().Send(&feed.Event{
+	i = r.cfg.StateNotifier.StateFeed().Send(&feed.Event{
 		Type: statefeed.Synced,
 		Data: &statefeed.SyncedData{
 			StartTime: time.Now(),
@@ -196,18 +204,20 @@ func TestSyncService_StopCleanly(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	r := Service{
-		ctx:           ctx,
-		cancel:        cancel,
-		p2p:           p2p,
-		chain:         chainService,
-		stateNotifier: chainService.StateNotifier(),
-		initialSync:   &mockSync.Sync{IsSyncing: false},
-		chainStarted:  abool.New(),
+		ctx:    ctx,
+		cancel: cancel,
+		cfg: &Config{
+			P2P:           p2p,
+			Chain:         chainService,
+			StateNotifier: chainService.StateNotifier(),
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+		},
+		chainStarted: abool.New(),
 	}
 
 	go r.registerHandlers()
 	time.Sleep(100 * time.Millisecond)
-	i := r.stateNotifier.StateFeed().Send(&feed.Event{
+	i := r.cfg.StateNotifier.StateFeed().Send(&feed.Event{
 		Type: statefeed.Initialized,
 		Data: &statefeed.InitializedData{
 			StartTime: time.Now(),
@@ -225,7 +235,7 @@ func TestSyncService_StopCleanly(t *testing.T) {
 	time.Sleep(2 * time.Second)
 	require.Equal(t, true, r.chainStarted.IsSet(), "Did not receive chain start event.")
 
-	i = r.stateNotifier.StateFeed().Send(&feed.Event{
+	i = r.cfg.StateNotifier.StateFeed().Send(&feed.Event{
 		Type: statefeed.Synced,
 		Data: &statefeed.SyncedData{
 			StartTime: time.Now(),
@@ -237,14 +247,14 @@ func TestSyncService_StopCleanly(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	require.NotEqual(t, 0, len(r.p2p.PubSub().GetTopics()))
-	require.NotEqual(t, 0, len(r.p2p.Host().Mux().Protocols()))
+	require.NotEqual(t, 0, len(r.cfg.P2P.PubSub().GetTopics()))
+	require.NotEqual(t, 0, len(r.cfg.P2P.Host().Mux().Protocols()))
 
 	// Both pubsub and rpc topcis should be unsubscribed.
 	require.NoError(t, r.Stop())
 
 	// Sleep to allow pubsub topics to be deregistered.
 	time.Sleep(1 * time.Second)
-	require.Equal(t, 0, len(r.p2p.PubSub().GetTopics()))
-	require.Equal(t, 0, len(r.p2p.Host().Mux().Protocols()))
+	require.Equal(t, 0, len(r.cfg.P2P.PubSub().GetTopics()))
+	require.Equal(t, 0, len(r.cfg.P2P.Host().Mux().Protocols()))
 }

--- a/beacon-chain/sync/subscriber_beacon_aggregate_proof.go
+++ b/beacon-chain/sync/subscriber_beacon_aggregate_proof.go
@@ -24,8 +24,8 @@ func (s *Service) beaconAggregateProofSubscriber(_ context.Context, msg proto.Me
 
 	// An unaggregated attestation can make it here. It’s valid, the aggregator it just itself, although it means poor performance for the subnet.
 	if !helpers.IsAggregated(a.Message.Aggregate) {
-		return s.attPool.SaveUnaggregatedAttestation(a.Message.Aggregate)
+		return s.cfg.AttPool.SaveUnaggregatedAttestation(a.Message.Aggregate)
 	}
 
-	return s.attPool.SaveAggregatedAttestation(a.Message.Aggregate)
+	return s.cfg.AttPool.SaveAggregatedAttestation(a.Message.Aggregate)
 }

--- a/beacon-chain/sync/subscriber_beacon_aggregate_proof_test.go
+++ b/beacon-chain/sync/subscriber_beacon_aggregate_proof_test.go
@@ -18,9 +18,11 @@ func TestBeaconAggregateProofSubscriber_CanSaveAggregatedAttestation(t *testing.
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		attPool:              attestations.NewPool(),
+		cfg: &Config{
+			AttPool:             attestations.NewPool(),
+			AttestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+		},
 		seenAttestationCache: c,
-		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 
 	a := &ethpb.SignedAggregateAttestationAndProof{
@@ -33,16 +35,18 @@ func TestBeaconAggregateProofSubscriber_CanSaveAggregatedAttestation(t *testing.
 		Signature: make([]byte, 96),
 	}
 	require.NoError(t, r.beaconAggregateProofSubscriber(context.Background(), a))
-	assert.DeepEqual(t, []*ethpb.Attestation{a.Message.Aggregate}, r.attPool.AggregatedAttestations(), "Did not save aggregated attestation")
+	assert.DeepEqual(t, []*ethpb.Attestation{a.Message.Aggregate}, r.cfg.AttPool.AggregatedAttestations(), "Did not save aggregated attestation")
 }
 
 func TestBeaconAggregateProofSubscriber_CanSaveUnaggregatedAttestation(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		attPool:              attestations.NewPool(),
+		cfg: &Config{
+			AttPool:             attestations.NewPool(),
+			AttestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+		},
 		seenAttestationCache: c,
-		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 
 	a := &ethpb.SignedAggregateAttestationAndProof{
@@ -56,7 +60,7 @@ func TestBeaconAggregateProofSubscriber_CanSaveUnaggregatedAttestation(t *testin
 	}
 	require.NoError(t, r.beaconAggregateProofSubscriber(context.Background(), a))
 
-	atts, err := r.attPool.UnaggregatedAttestations()
+	atts, err := r.cfg.AttPool.UnaggregatedAttestations()
 	require.NoError(t, err)
 	assert.DeepEqual(t, []*ethpb.Attestation{a.Message.Aggregate}, atts, "Did not save unaggregated attestation")
 }

--- a/beacon-chain/sync/subscriber_beacon_attestation.go
+++ b/beacon-chain/sync/subscriber_beacon_attestation.go
@@ -25,7 +25,7 @@ func (s *Service) committeeIndexBeaconAttestationSubscriber(_ context.Context, m
 	}
 	s.setSeenCommitteeIndicesSlot(a.Data.Slot, a.Data.CommitteeIndex, a.AggregationBits)
 
-	exists, err := s.attPool.HasAggregatedAttestation(a)
+	exists, err := s.cfg.AttPool.HasAggregatedAttestation(a)
 	if err != nil {
 		return errors.Wrap(err, "Could not determine if attestation pool has this atttestation")
 	}
@@ -33,7 +33,7 @@ func (s *Service) committeeIndexBeaconAttestationSubscriber(_ context.Context, m
 		return nil
 	}
 
-	return s.attPool.SaveUnaggregatedAttestation(a)
+	return s.cfg.AttPool.SaveUnaggregatedAttestation(a)
 }
 
 func (s *Service) persistentSubnetIndices() []uint64 {

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -29,7 +29,7 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 		return err
 	}
 
-	if err := s.chain.ReceiveBlock(ctx, signed, root); err != nil {
+	if err := s.cfg.Chain.ReceiveBlock(ctx, signed, root); err != nil {
 		interop.WriteBlockToDisk(signed, true /*failed*/)
 		s.setBadBlock(ctx, root)
 		return err
@@ -49,12 +49,12 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 func (s *Service) deleteAttsInPool(atts []*ethpb.Attestation) error {
 	for _, att := range atts {
 		if helpers.IsAggregated(att) {
-			if err := s.attPool.DeleteAggregatedAttestation(att); err != nil {
+			if err := s.cfg.AttPool.DeleteAggregatedAttestation(att); err != nil {
 				return err
 			}
 		} else {
 			// Ideally there's shouldn't be any unaggregated attestation in the block.
-			if err := s.attPool.DeleteUnaggregatedAttestation(att); err != nil {
+			if err := s.cfg.AttPool.DeleteUnaggregatedAttestation(att); err != nil {
 				return err
 			}
 		}

--- a/beacon-chain/sync/subscriber_beacon_blocks_test.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks_test.go
@@ -18,23 +18,23 @@ import (
 
 func TestDeleteAttsInPool(t *testing.T) {
 	r := &Service{
-		attPool: attestations.NewPool(),
+		cfg: &Config{AttPool: attestations.NewPool()},
 	}
 
 	att1 := testutil.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b1101}})
 	att2 := testutil.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b1110}})
 	att3 := testutil.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b1011}})
 	att4 := testutil.HydrateAttestation(&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0b1001}})
-	require.NoError(t, r.attPool.SaveAggregatedAttestation(att1))
-	require.NoError(t, r.attPool.SaveAggregatedAttestation(att2))
-	require.NoError(t, r.attPool.SaveAggregatedAttestation(att3))
-	require.NoError(t, r.attPool.SaveUnaggregatedAttestation(att4))
+	require.NoError(t, r.cfg.AttPool.SaveAggregatedAttestation(att1))
+	require.NoError(t, r.cfg.AttPool.SaveAggregatedAttestation(att2))
+	require.NoError(t, r.cfg.AttPool.SaveAggregatedAttestation(att3))
+	require.NoError(t, r.cfg.AttPool.SaveUnaggregatedAttestation(att4))
 
 	// Seen 1, 3 and 4 in block.
 	require.NoError(t, r.deleteAttsInPool([]*ethpb.Attestation{att1, att3, att4}))
 
 	// Only 2 should remain.
-	assert.DeepEqual(t, []*ethpb.Attestation{att2}, r.attPool.AggregatedAttestations(), "Did not get wanted attestations")
+	assert.DeepEqual(t, []*ethpb.Attestation{att2}, r.cfg.AttPool.AggregatedAttestations(), "Did not get wanted attestations")
 }
 
 func TestService_beaconBlockSubscriber(t *testing.T) {
@@ -65,10 +65,10 @@ func TestService_beaconBlockSubscriber(t *testing.T) {
 			},
 			wantedErr: "nil inner state",
 			check: func(t *testing.T, s *Service) {
-				if s.attPool.AggregatedAttestationCount() == 0 {
+				if s.cfg.AttPool.AggregatedAttestationCount() == 0 {
 					t.Error("Expected at least 1 aggregated attestation in the pool")
 				}
-				if s.attPool.UnaggregatedAttestationCount() == 0 {
+				if s.cfg.AttPool.UnaggregatedAttestationCount() == 0 {
 					t.Error("Expected at least 1 unaggregated attestation in the pool")
 				}
 			},
@@ -78,19 +78,21 @@ func TestService_beaconBlockSubscriber(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			db := dbtest.SetupDB(t)
 			s := &Service{
-				chain: &chainMock.ChainService{
-					DB:   db,
-					Root: make([]byte, 32),
+				cfg: &Config{
+					Chain: &chainMock.ChainService{
+						DB:   db,
+						Root: make([]byte, 32),
+					},
+					AttPool: attestations.NewPool(),
 				},
-				attPool: attestations.NewPool(),
 			}
 			assert.NoError(t, s.initCaches())
 			// Set up attestation pool.
 			for _, att := range pooledAttestations {
 				if helpers.IsAggregated(att) {
-					assert.NoError(t, s.attPool.SaveAggregatedAttestation(att))
+					assert.NoError(t, s.cfg.AttPool.SaveAggregatedAttestation(att))
 				} else {
-					assert.NoError(t, s.attPool.SaveUnaggregatedAttestation(att))
+					assert.NoError(t, s.cfg.AttPool.SaveUnaggregatedAttestation(att))
 				}
 			}
 			// Perform method under test call.

--- a/beacon-chain/sync/subscriber_handlers.go
+++ b/beacon-chain/sync/subscriber_handlers.go
@@ -20,11 +20,11 @@ func (s *Service) voluntaryExitSubscriber(ctx context.Context, msg proto.Message
 	}
 	s.setExitIndexSeen(ve.Exit.ValidatorIndex)
 
-	headState, err := s.chain.HeadState(ctx)
+	headState, err := s.cfg.Chain.HeadState(ctx)
 	if err != nil {
 		return err
 	}
-	s.exitPool.InsertVoluntaryExit(ctx, headState, ve)
+	s.cfg.ExitPool.InsertVoluntaryExit(ctx, headState, ve)
 	return nil
 }
 
@@ -37,11 +37,11 @@ func (s *Service) attesterSlashingSubscriber(ctx context.Context, msg proto.Mess
 	aSlashing1IsNil := aSlashing == nil || aSlashing.Attestation_1 == nil || aSlashing.Attestation_1.AttestingIndices == nil
 	aSlashing2IsNil := aSlashing == nil || aSlashing.Attestation_2 == nil || aSlashing.Attestation_2.AttestingIndices == nil
 	if !aSlashing1IsNil && !aSlashing2IsNil {
-		headState, err := s.chain.HeadState(ctx)
+		headState, err := s.cfg.Chain.HeadState(ctx)
 		if err != nil {
 			return err
 		}
-		if err := s.slashingPool.InsertAttesterSlashing(ctx, headState, aSlashing); err != nil {
+		if err := s.cfg.SlashingPool.InsertAttesterSlashing(ctx, headState, aSlashing); err != nil {
 			return errors.Wrap(err, "could not insert attester slashing into pool")
 		}
 		s.setAttesterSlashingIndicesSeen(aSlashing.Attestation_1.AttestingIndices, aSlashing.Attestation_2.AttestingIndices)
@@ -58,11 +58,11 @@ func (s *Service) proposerSlashingSubscriber(ctx context.Context, msg proto.Mess
 	header1IsNil := pSlashing == nil || pSlashing.Header_1 == nil || pSlashing.Header_1.Header == nil
 	header2IsNil := pSlashing == nil || pSlashing.Header_2 == nil || pSlashing.Header_2.Header == nil
 	if !header1IsNil && !header2IsNil {
-		headState, err := s.chain.HeadState(ctx)
+		headState, err := s.cfg.Chain.HeadState(ctx)
 		if err != nil {
 			return err
 		}
-		if err := s.slashingPool.InsertProposerSlashing(ctx, headState, pSlashing); err != nil {
+		if err := s.cfg.SlashingPool.InsertProposerSlashing(ctx, headState, pSlashing); err != nil {
 			return errors.Wrap(err, "could not insert proposer slashing into pool")
 		}
 		s.setProposerSlashingIndexSeen(pSlashing.Header_1.Header.ProposerIndex)

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -113,13 +113,15 @@ func TestValidateAggregateAndProof_NoBlock(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p:                  p,
-		db:                   db,
-		initialSync:          &mockSync.Sync{IsSyncing: false},
-		attPool:              attestations.NewPool(),
+		cfg: &Config{
+			P2P:         p,
+			DB:          db,
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+			AttPool:     attestations.NewPool(),
+			Chain:       &mock.ChainService{},
+		},
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
 		seenAttestationCache: c,
-		chain:                &mock.ChainService{},
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -180,16 +182,18 @@ func TestValidateAggregateAndProof_NotWithinSlotRange(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p:         p,
-		db:          db,
-		initialSync: &mockSync.Sync{IsSyncing: false},
-		chain: &mock.ChainService{
-			Genesis: time.Now(),
-			State:   beaconState,
+		cfg: &Config{
+			P2P:         p,
+			DB:          db,
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+			Chain: &mock.ChainService{
+				Genesis: time.Now(),
+				State:   beaconState,
+			},
+			AttPool:             attestations.NewPool(),
+			AttestationNotifier: (&mock.ChainService{}).OperationNotifier(),
 		},
-		attPool:              attestations.NewPool(),
 		seenAttestationCache: c,
-		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -262,15 +266,17 @@ func TestValidateAggregateAndProof_ExistedInPool(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		attPool:     attestations.NewPool(),
-		p2p:         p,
-		db:          db,
-		initialSync: &mockSync.Sync{IsSyncing: false},
-		chain: &mock.ChainService{Genesis: time.Now(),
-			State: beaconState},
+		cfg: &Config{
+			AttPool:     attestations.NewPool(),
+			P2P:         p,
+			DB:          db,
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+			Chain: &mock.ChainService{Genesis: time.Now(),
+				State: beaconState},
+			AttestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+		},
 		seenAttestationCache: c,
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
-		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -287,7 +293,7 @@ func TestValidateAggregateAndProof_ExistedInPool(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, r.attPool.SaveBlockAttestation(att))
+	require.NoError(t, r.cfg.AttPool.SaveBlockAttestation(att))
 	if r.validateAggregateAndProof(context.Background(), "", msg) == pubsub.ValidationAccept {
 		t.Error("Expected validate to fail")
 	}
@@ -351,19 +357,21 @@ func TestValidateAggregateAndProof_CanValidate(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p:         p,
-		db:          db,
-		initialSync: &mockSync.Sync{IsSyncing: false},
-		chain: &mock.ChainService{Genesis: time.Now(),
-			State:            beaconState,
-			ValidAttestation: true,
-			FinalizedCheckPoint: &ethpb.Checkpoint{
-				Epoch: 0,
-				Root:  att.Data.BeaconBlockRoot,
-			}},
-		attPool:              attestations.NewPool(),
+		cfg: &Config{
+			P2P:         p,
+			DB:          db,
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+			Chain: &mock.ChainService{Genesis: time.Now(),
+				State:            beaconState,
+				ValidAttestation: true,
+				FinalizedCheckPoint: &ethpb.Checkpoint{
+					Epoch: 0,
+					Root:  att.Data.BeaconBlockRoot,
+				}},
+			AttPool:             attestations.NewPool(),
+			AttestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+		},
 		seenAttestationCache: c,
-		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -441,21 +449,23 @@ func TestVerifyIndexInCommittee_SeenAggregatorEpoch(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p:         p,
-		db:          db,
-		initialSync: &mockSync.Sync{IsSyncing: false},
-		chain: &mock.ChainService{Genesis: time.Now(),
-			ValidatorsRoot:   [32]byte{'A'},
-			State:            beaconState,
-			ValidAttestation: true,
-			FinalizedCheckPoint: &ethpb.Checkpoint{
-				Epoch: 0,
-				Root:  signedAggregateAndProof.Message.Aggregate.Data.BeaconBlockRoot,
-			}},
+		cfg: &Config{
+			P2P:         p,
+			DB:          db,
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+			Chain: &mock.ChainService{Genesis: time.Now(),
+				ValidatorsRoot:   [32]byte{'A'},
+				State:            beaconState,
+				ValidAttestation: true,
+				FinalizedCheckPoint: &ethpb.Checkpoint{
+					Epoch: 0,
+					Root:  signedAggregateAndProof.Message.Aggregate.Data.BeaconBlockRoot,
+				}},
 
-		attPool:              attestations.NewPool(),
+			AttPool:             attestations.NewPool(),
+			AttestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+		},
 		seenAttestationCache: c,
-		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -551,18 +561,20 @@ func TestValidateAggregateAndProof_BadBlock(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p:         p,
-		db:          db,
-		initialSync: &mockSync.Sync{IsSyncing: false},
-		chain: &mock.ChainService{Genesis: time.Now(),
-			State:            beaconState,
-			ValidAttestation: true,
-			FinalizedCheckPoint: &ethpb.Checkpoint{
-				Epoch: 0,
-			}},
-		attPool:              attestations.NewPool(),
+		cfg: &Config{
+			P2P:         p,
+			DB:          db,
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+			Chain: &mock.ChainService{Genesis: time.Now(),
+				State:            beaconState,
+				ValidAttestation: true,
+				FinalizedCheckPoint: &ethpb.Checkpoint{
+					Epoch: 0,
+				}},
+			AttPool:             attestations.NewPool(),
+			AttestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+		},
 		seenAttestationCache: c,
-		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)
@@ -641,19 +653,21 @@ func TestValidateAggregateAndProof_RejectWhenAttEpochDoesntEqualTargetEpoch(t *t
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p:         p,
-		db:          db,
-		initialSync: &mockSync.Sync{IsSyncing: false},
-		chain: &mock.ChainService{Genesis: time.Now(),
-			State:            beaconState,
-			ValidAttestation: true,
-			FinalizedCheckPoint: &ethpb.Checkpoint{
-				Epoch: 0,
-				Root:  att.Data.BeaconBlockRoot,
-			}},
-		attPool:              attestations.NewPool(),
+		cfg: &Config{
+			P2P:         p,
+			DB:          db,
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+			Chain: &mock.ChainService{Genesis: time.Now(),
+				State:            beaconState,
+				ValidAttestation: true,
+				FinalizedCheckPoint: &ethpb.Checkpoint{
+					Epoch: 0,
+					Root:  att.Data.BeaconBlockRoot,
+				}},
+			AttPool:             attestations.NewPool(),
+			AttestationNotifier: (&mock.ChainService{}).OperationNotifier(),
+		},
 		seenAttestationCache: c,
-		attestationNotifier:  (&mock.ChainService{}).OperationNotifier(),
 	}
 	err = r.initCaches()
 	require.NoError(t, err)

--- a/beacon-chain/sync/validate_attester_slashing.go
+++ b/beacon-chain/sync/validate_attester_slashing.go
@@ -17,12 +17,12 @@ import (
 func (s *Service) validateAttesterSlashing(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
 	// Validation runs on publish (not just subscriptions), so we should approve any message from
 	// ourselves.
-	if pid == s.p2p.PeerID() {
+	if pid == s.cfg.P2P.PeerID() {
 		return pubsub.ValidationAccept
 	}
 
 	// The head state will be too far away to validate any slashing.
-	if s.initialSync.Syncing() {
+	if s.cfg.InitialSync.Syncing() {
 		return pubsub.ValidationIgnore
 	}
 
@@ -47,7 +47,7 @@ func (s *Service) validateAttesterSlashing(ctx context.Context, pid peer.ID, msg
 		return pubsub.ValidationIgnore
 	}
 
-	headState, err := s.chain.HeadState(ctx)
+	headState, err := s.cfg.Chain.HeadState(ctx)
 	if err != nil {
 		return pubsub.ValidationIgnore
 	}

--- a/beacon-chain/sync/validate_attester_slashing_test.go
+++ b/beacon-chain/sync/validate_attester_slashing_test.go
@@ -80,9 +80,11 @@ func TestValidateAttesterSlashing_ValidSlashing(t *testing.T) {
 	slashing, s := setupValidAttesterSlashing(t)
 
 	r := &Service{
-		p2p:                       p,
-		chain:                     &mock.ChainService{State: s},
-		initialSync:               &mockSync.Sync{IsSyncing: false},
+		cfg: &Config{
+			P2P:         p,
+			Chain:       &mock.ChainService{State: s},
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+		},
 		seenAttesterSlashingCache: make(map[uint64]bool),
 	}
 
@@ -108,8 +110,10 @@ func TestValidateAttesterSlashing_CanFilter(t *testing.T) {
 	ctx := context.Background()
 
 	r := &Service{
-		p2p:                       p,
-		initialSync:               &mockSync.Sync{IsSyncing: false},
+		cfg: &Config{
+			P2P:         p,
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+		},
 		seenAttesterSlashingCache: make(map[uint64]bool),
 	}
 
@@ -166,9 +170,11 @@ func TestValidateAttesterSlashing_ContextTimeout(t *testing.T) {
 	defer cancel()
 
 	r := &Service{
-		p2p:                       p,
-		chain:                     &mock.ChainService{State: state},
-		initialSync:               &mockSync.Sync{IsSyncing: false},
+		cfg: &Config{
+			P2P:         p,
+			Chain:       &mock.ChainService{State: state},
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+		},
 		seenAttesterSlashingCache: make(map[uint64]bool),
 	}
 
@@ -194,9 +200,11 @@ func TestValidateAttesterSlashing_Syncing(t *testing.T) {
 	slashing, s := setupValidAttesterSlashing(t)
 
 	r := &Service{
-		p2p:         p,
-		chain:       &mock.ChainService{State: s},
-		initialSync: &mockSync.Sync{IsSyncing: true},
+		cfg: &Config{
+			P2P:         p,
+			Chain:       &mock.ChainService{State: s},
+			InitialSync: &mockSync.Sync{IsSyncing: true},
+		},
 	}
 
 	buf := new(bytes.Buffer)

--- a/beacon-chain/sync/validate_beacon_attestation_test.go
+++ b/beacon-chain/sync/validate_beacon_attestation_test.go
@@ -37,13 +37,15 @@ func TestService_validateCommitteeIndexBeaconAttestation(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	s := &Service{
-		initialSync:          &mockSync.Sync{IsSyncing: false},
-		p2p:                  p,
-		db:                   db,
-		chain:                chain,
+		cfg: &Config{
+			InitialSync:         &mockSync.Sync{IsSyncing: false},
+			P2P:                 p,
+			DB:                  db,
+			Chain:               chain,
+			AttestationNotifier: (&mockChain.ChainService{}).OperationNotifier(),
+		},
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
 		seenAttestationCache: c,
-		attestationNotifier:  (&mockChain.ChainService{}).OperationNotifier(),
 	}
 	err = s.initCaches()
 	require.NoError(t, err)

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -57,13 +57,15 @@ func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 			Epoch: 0,
 		}}
 	r := &Service{
-		db:             db,
-		p2p:            p,
-		initialSync:    &mockSync.Sync{IsSyncing: false},
-		chain:          chainService,
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+		},
 		seenBlockCache: c,
 		badBlockCache:  c2,
-		blockNotifier:  chainService.BlockNotifier(),
 	}
 
 	buf := new(bytes.Buffer)
@@ -96,13 +98,15 @@ func TestValidateBeaconBlockPubSub_BlockAlreadyPresentInDB(t *testing.T) {
 	require.NoError(t, err)
 	chainService := &mock.ChainService{Genesis: time.Now()}
 	r := &Service{
-		db:             db,
-		p2p:            p,
-		initialSync:    &mockSync.Sync{IsSyncing: false},
-		chain:          chainService,
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+		},
 		seenBlockCache: c,
 		badBlockCache:  c2,
-		blockNotifier:  chainService.BlockNotifier(),
 	}
 
 	buf := new(bytes.Buffer)
@@ -154,16 +158,18 @@ func TestValidateBeaconBlockPubSub_CanRecoverStateSummary(t *testing.T) {
 		},
 	}
 	r := &Service{
-		db:                  db,
-		p2p:                 p,
-		initialSync:         &mockSync.Sync{IsSyncing: false},
-		chain:               chainService,
-		blockNotifier:       chainService.BlockNotifier(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+			StateGen:      stateGen,
+		},
 		seenBlockCache:      c,
 		badBlockCache:       c2,
 		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
 		seenPendingBlocks:   make(map[[32]byte]bool),
-		stateGen:            stateGen,
 	}
 	buf := new(bytes.Buffer)
 	_, err = p.Encoding().EncodeGossip(buf, msg)
@@ -215,16 +221,18 @@ func TestValidateBeaconBlockPubSub_ValidProposerSignature(t *testing.T) {
 		},
 	}
 	r := &Service{
-		db:                  db,
-		p2p:                 p,
-		initialSync:         &mockSync.Sync{IsSyncing: false},
-		chain:               chainService,
-		blockNotifier:       chainService.BlockNotifier(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+			StateGen:      stateGen,
+		},
 		seenBlockCache:      c,
 		badBlockCache:       c2,
 		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
 		seenPendingBlocks:   make(map[[32]byte]bool),
-		stateGen:            stateGen,
 	}
 	buf := new(bytes.Buffer)
 	_, err = p.Encoding().EncodeGossip(buf, msg)
@@ -278,16 +286,18 @@ func TestValidateBeaconBlockPubSub_WithLookahead(t *testing.T) {
 			Epoch: 0,
 		}}
 	r := &Service{
-		db:                  db,
-		p2p:                 p,
-		initialSync:         &mockSync.Sync{IsSyncing: false},
-		chain:               chainService,
-		blockNotifier:       chainService.BlockNotifier(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+			StateGen:      stateGen,
+		},
 		seenBlockCache:      c,
 		badBlockCache:       c2,
 		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
 		seenPendingBlocks:   make(map[[32]byte]bool),
-		stateGen:            stateGen,
 	}
 	buf := new(bytes.Buffer)
 	_, err = p.Encoding().EncodeGossip(buf, msg)
@@ -341,17 +351,18 @@ func TestValidateBeaconBlockPubSub_AdvanceEpochsForState(t *testing.T) {
 			Epoch: 0,
 		}}
 	r := &Service{
-		db:                  db,
-		p2p:                 p,
-		initialSync:         &mockSync.Sync{IsSyncing: false},
-		chain:               chainService,
-		blockNotifier:       chainService.BlockNotifier(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+			StateGen:      stateGen,
+		},
 		seenBlockCache:      c,
 		badBlockCache:       c2,
 		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
 		seenPendingBlocks:   make(map[[32]byte]bool),
-
-		stateGen: stateGen,
 	}
 	buf := new(bytes.Buffer)
 	_, err = p.Encoding().EncodeGossip(buf, msg)
@@ -385,11 +396,13 @@ func TestValidateBeaconBlockPubSub_Syncing(t *testing.T) {
 			Epoch: 0,
 		}}
 	r := &Service{
-		db:            db,
-		p2p:           p,
-		initialSync:   &mockSync.Sync{IsSyncing: true},
-		chain:         chainService,
-		blockNotifier: chainService.BlockNotifier(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: true},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+		},
 	}
 
 	buf := new(bytes.Buffer)
@@ -425,12 +438,14 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromFuture(t *testing.T) {
 	require.NoError(t, err)
 	chainService := &mock.ChainService{Genesis: time.Now()}
 	r := &Service{
-		p2p:                 p,
-		db:                  db,
+		cfg: &Config{
+			P2P:           p,
+			DB:            db,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+		},
 		chainStarted:        abool.New(),
-		initialSync:         &mockSync.Sync{IsSyncing: false},
-		chain:               chainService,
-		blockNotifier:       chainService.BlockNotifier(),
 		seenBlockCache:      c,
 		badBlockCache:       c2,
 		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
@@ -476,11 +491,13 @@ func TestValidateBeaconBlockPubSub_RejectBlocksFromThePast(t *testing.T) {
 		},
 	}
 	r := &Service{
-		db:             db,
-		p2p:            p,
-		initialSync:    &mockSync.Sync{IsSyncing: false},
-		chain:          chainService,
-		blockNotifier:  chainService.BlockNotifier(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+		},
 		seenBlockCache: c,
 		badBlockCache:  c2,
 	}
@@ -531,11 +548,13 @@ func TestValidateBeaconBlockPubSub_SeenProposerSlot(t *testing.T) {
 		},
 	}
 	r := &Service{
-		db:                  db,
-		p2p:                 p,
-		initialSync:         &mockSync.Sync{IsSyncing: false},
-		chain:               chainService,
-		blockNotifier:       chainService.BlockNotifier(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+		},
 		seenBlockCache:      c,
 		badBlockCache:       c2,
 		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
@@ -576,14 +595,16 @@ func TestValidateBeaconBlockPubSub_FilterByFinalizedEpoch(t *testing.T) {
 	c2, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		db:             db,
-		p2p:            p,
-		chain:          chain,
-		blockNotifier:  chain.BlockNotifier(),
-		attPool:        attestations.NewPool(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			Chain:         chain,
+			BlockNotifier: chain.BlockNotifier(),
+			AttPool:       attestations.NewPool(),
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+		},
 		seenBlockCache: c,
 		badBlockCache:  c2,
-		initialSync:    &mockSync.Sync{IsSyncing: false},
 	}
 
 	b := testutil.NewBeaconBlock()
@@ -654,16 +675,18 @@ func TestValidateBeaconBlockPubSub_ParentNotFinalizedDescendant(t *testing.T) {
 		VerifyBlkDescendantErr: errors.New("not part of finalized chain"),
 	}
 	r := &Service{
-		db:                  db,
-		p2p:                 p,
-		initialSync:         &mockSync.Sync{IsSyncing: false},
-		chain:               chainService,
-		blockNotifier:       chainService.BlockNotifier(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+			StateGen:      stateGen,
+		},
 		seenBlockCache:      c,
 		badBlockCache:       c2,
 		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
 		seenPendingBlocks:   make(map[[32]byte]bool),
-		stateGen:            stateGen,
 	}
 	buf := new(bytes.Buffer)
 	_, err = p.Encoding().EncodeGossip(buf, msg)
@@ -717,16 +740,18 @@ func TestValidateBeaconBlockPubSub_InvalidParentBlock(t *testing.T) {
 			Epoch: 0,
 		}}
 	r := &Service{
-		db:                  db,
-		p2p:                 p,
-		initialSync:         &mockSync.Sync{IsSyncing: false},
-		chain:               chainService,
-		blockNotifier:       chainService.BlockNotifier(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+			StateGen:      stateGen,
+		},
 		seenBlockCache:      c,
 		badBlockCache:       c2,
 		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
 		seenPendingBlocks:   make(map[[32]byte]bool),
-		stateGen:            stateGen,
 	}
 	buf := new(bytes.Buffer)
 	_, err = p.Encoding().EncodeGossip(buf, msg)
@@ -816,16 +841,18 @@ func TestValidateBeaconBlockPubSub_RejectEvilBlocksFromFuture(t *testing.T) {
 		},
 	}
 	r := &Service{
-		db:                  db,
-		p2p:                 p,
-		initialSync:         &mockSync.Sync{IsSyncing: false},
-		chain:               chainService,
-		blockNotifier:       chainService.BlockNotifier(),
+		cfg: &Config{
+			DB:            db,
+			P2P:           p,
+			InitialSync:   &mockSync.Sync{IsSyncing: false},
+			Chain:         chainService,
+			BlockNotifier: chainService.BlockNotifier(),
+			StateGen:      stateGen,
+		},
 		seenBlockCache:      c,
 		badBlockCache:       c2,
 		slotToPendingBlocks: gcache.New(time.Second, 2*time.Second),
 		seenPendingBlocks:   make(map[[32]byte]bool),
-		stateGen:            stateGen,
 	}
 
 	buf := new(bytes.Buffer)

--- a/beacon-chain/sync/validate_proposer_slashing.go
+++ b/beacon-chain/sync/validate_proposer_slashing.go
@@ -17,12 +17,12 @@ import (
 func (s *Service) validateProposerSlashing(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
 	// Validation runs on publish (not just subscriptions), so we should approve any message from
 	// ourselves.
-	if pid == s.p2p.PeerID() {
+	if pid == s.cfg.P2P.PeerID() {
 		return pubsub.ValidationAccept
 	}
 
 	// The head state will be too far away to validate any slashing.
-	if s.initialSync.Syncing() {
+	if s.cfg.InitialSync.Syncing() {
 		return pubsub.ValidationIgnore
 	}
 
@@ -48,7 +48,7 @@ func (s *Service) validateProposerSlashing(ctx context.Context, pid peer.ID, msg
 		return pubsub.ValidationIgnore
 	}
 
-	headState, err := s.chain.HeadState(ctx)
+	headState, err := s.cfg.Chain.HeadState(ctx)
 	if err != nil {
 		return pubsub.ValidationIgnore
 	}

--- a/beacon-chain/sync/validate_proposer_slashing_test.go
+++ b/beacon-chain/sync/validate_proposer_slashing_test.go
@@ -116,9 +116,11 @@ func TestValidateProposerSlashing_ValidSlashing(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p:                       p,
-		chain:                     &mock.ChainService{State: s},
-		initialSync:               &mockSync.Sync{IsSyncing: false},
+		cfg: &Config{
+			P2P:         p,
+			Chain:       &mock.ChainService{State: s},
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+		},
 		seenProposerSlashingCache: c,
 	}
 
@@ -153,9 +155,11 @@ func TestValidateProposerSlashing_ContextTimeout(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p:                       p,
-		chain:                     &mock.ChainService{State: state},
-		initialSync:               &mockSync.Sync{IsSyncing: false},
+		cfg: &Config{
+			P2P:         p,
+			Chain:       &mock.ChainService{State: state},
+			InitialSync: &mockSync.Sync{IsSyncing: false},
+		},
 		seenProposerSlashingCache: c,
 	}
 
@@ -180,9 +184,11 @@ func TestValidateProposerSlashing_Syncing(t *testing.T) {
 	slashing, s := setupValidProposerSlashing(t)
 
 	r := &Service{
-		p2p:         p,
-		chain:       &mock.ChainService{State: s},
-		initialSync: &mockSync.Sync{IsSyncing: true},
+		cfg: &Config{
+			P2P:         p,
+			Chain:       &mock.ChainService{State: s},
+			InitialSync: &mockSync.Sync{IsSyncing: true},
+		},
 	}
 
 	buf := new(bytes.Buffer)

--- a/beacon-chain/sync/validate_voluntary_exit.go
+++ b/beacon-chain/sync/validate_voluntary_exit.go
@@ -17,12 +17,12 @@ import (
 func (s *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
 	// Validation runs on publish (not just subscriptions), so we should approve any message from
 	// ourselves.
-	if pid == s.p2p.PeerID() {
+	if pid == s.cfg.P2P.PeerID() {
 		return pubsub.ValidationAccept
 	}
 
 	// The head state will be too far away to validate any voluntary exit.
-	if s.initialSync.Syncing() {
+	if s.cfg.InitialSync.Syncing() {
 		return pubsub.ValidationIgnore
 	}
 
@@ -48,7 +48,7 @@ func (s *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *p
 		return pubsub.ValidationIgnore
 	}
 
-	headState, err := s.chain.HeadState(ctx)
+	headState, err := s.cfg.Chain.HeadState(ctx)
 	if err != nil {
 		return pubsub.ValidationIgnore
 	}

--- a/beacon-chain/sync/validate_voluntary_exit_test.go
+++ b/beacon-chain/sync/validate_voluntary_exit_test.go
@@ -76,11 +76,13 @@ func TestValidateVoluntaryExit_ValidExit(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p: p,
-		chain: &mock.ChainService{
-			State: s,
+		cfg: &Config{
+			P2P: p,
+			Chain: &mock.ChainService{
+				State: s,
+			},
+			InitialSync: &mockSync.Sync{IsSyncing: false},
 		},
-		initialSync:   &mockSync.Sync{IsSyncing: false},
 		seenExitCache: c,
 	}
 
@@ -109,11 +111,13 @@ func TestValidateVoluntaryExit_InvalidExitSlot(t *testing.T) {
 	c, err := lru.New(10)
 	require.NoError(t, err)
 	r := &Service{
-		p2p: p,
-		chain: &mock.ChainService{
-			State: s,
+		cfg: &Config{
+			P2P: p,
+			Chain: &mock.ChainService{
+				State: s,
+			},
+			InitialSync: &mockSync.Sync{IsSyncing: false},
 		},
-		initialSync:   &mockSync.Sync{IsSyncing: false},
 		seenExitCache: c,
 	}
 
@@ -138,11 +142,13 @@ func TestValidateVoluntaryExit_ValidExit_Syncing(t *testing.T) {
 	exit, s := setupValidExit(t)
 
 	r := &Service{
-		p2p: p,
-		chain: &mock.ChainService{
-			State: s,
+		cfg: &Config{
+			P2P: p,
+			Chain: &mock.ChainService{
+				State: s,
+			},
+			InitialSync: &mockSync.Sync{IsSyncing: true},
 		},
-		initialSync: &mockSync.Sync{IsSyncing: true},
 	}
 	buf := new(bytes.Buffer)
 	_, err := p.Encoding().EncodeGossip(buf, exit)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
This pull request refactors the Service struct for the Sync and Initial Sync services by having a pointer to the Config struct as one of the fields, removing duplicated field declarations.


**Which issues(s) does this PR fix?**

Part of #8603

**Other notes for review**
See #8618, #8635 for PR of Config embedding for other services