### PR TITLE
Embed Config Pattern For Slasher, Slashing Protection

### DIFF
--- a/slasher/beaconclient/chain_data.go
+++ b/slasher/beaconclient/chain_data.go
@@ -20,7 +20,7 @@ func (s *Service) ChainHead(
 ) (*ethpb.ChainHead, error) {
 	ctx, span := trace.StartSpan(ctx, "beaconclient.ChainHead")
 	defer span.End()
-	res, err := s.beaconClient.GetChainHead(ctx, &ptypes.Empty{})
+	res, err := s.cfg.BeaconClient.GetChainHead(ctx, &ptypes.Empty{})
 	if err != nil || res == nil {
 		return nil, errors.Wrap(err, "Could not retrieve chain head or got nil chain head")
 	}
@@ -36,7 +36,7 @@ func (s *Service) GenesisValidatorsRoot(
 	defer span.End()
 
 	if s.genesisValidatorRoot == nil {
-		res, err := s.nodeClient.GetGenesis(ctx, &ptypes.Empty{})
+		res, err := s.cfg.NodeClient.GetGenesis(ctx, &ptypes.Empty{})
 		if err != nil {
 			return nil, errors.Wrap(err, "could not retrieve genesis data")
 		}
@@ -51,7 +51,7 @@ func (s *Service) GenesisValidatorsRoot(
 // Poll the beacon node every syncStatusPollingInterval until the node
 // is no longer syncing.
 func (s *Service) querySyncStatus(ctx context.Context) {
-	status, err := s.nodeClient.GetSyncStatus(ctx, &ptypes.Empty{})
+	status, err := s.cfg.NodeClient.GetSyncStatus(ctx, &ptypes.Empty{})
 	if err != nil {
 		log.WithError(err).Error("Could not fetch sync status")
 	}
@@ -65,7 +65,7 @@ func (s *Service) querySyncStatus(ctx context.Context) {
 	for {
 		select {
 		case <-ticker.C:
-			status, err := s.nodeClient.GetSyncStatus(ctx, &ptypes.Empty{})
+			status, err := s.cfg.NodeClient.GetSyncStatus(ctx, &ptypes.Empty{})
 			if err != nil {
 				log.WithError(err).Error("Could not fetch sync status")
 			}

--- a/slasher/beaconclient/chain_data_test.go
+++ b/slasher/beaconclient/chain_data_test.go
@@ -19,7 +19,7 @@ func TestService_ChainHead(t *testing.T) {
 	client := mock.NewMockBeaconChainClient(ctrl)
 
 	bs := Service{
-		beaconClient: client,
+		cfg: &Config{BeaconClient: client},
 	}
 	wanted := &ethpb.ChainHead{
 		HeadSlot:      4,
@@ -38,7 +38,7 @@ func TestService_GenesisValidatorsRoot(t *testing.T) {
 
 	client := mock.NewMockNodeClient(ctrl)
 	bs := Service{
-		nodeClient: client,
+		cfg: &Config{NodeClient: client},
 	}
 	wanted := &ethpb.Genesis{
 		GenesisValidatorsRoot: []byte("I am genesis"),
@@ -60,7 +60,7 @@ func TestService_QuerySyncStatus(t *testing.T) {
 	client := mock.NewMockNodeClient(ctrl)
 
 	bs := Service{
-		nodeClient: client,
+		cfg: &Config{NodeClient: client},
 	}
 	syncStatusPollingInterval = time.Millisecond
 	client.EXPECT().GetSyncStatus(gomock.Any(), gomock.Any()).Return(&ethpb.SyncStatus{

--- a/slasher/beaconclient/historical_data_retrieval.go
+++ b/slasher/beaconclient/historical_data_retrieval.go
@@ -27,7 +27,7 @@ func (s *Service) RequestHistoricalAttestations(
 		if res == nil {
 			res = &ethpb.ListIndexedAttestationsResponse{}
 		}
-		res, err = s.beaconClient.ListIndexedAttestations(ctx, &ethpb.ListIndexedAttestationsRequest{
+		res, err = s.cfg.BeaconClient.ListIndexedAttestations(ctx, &ethpb.ListIndexedAttestationsRequest{
 			QueryFilter: &ethpb.ListIndexedAttestationsRequest_Epoch{
 				Epoch: epoch,
 			},

--- a/slasher/beaconclient/historical_data_retrieval_test.go
+++ b/slasher/beaconclient/historical_data_retrieval_test.go
@@ -25,8 +25,10 @@ func TestService_RequestHistoricalAttestations(t *testing.T) {
 	client := mock.NewMockBeaconChainClient(ctrl)
 
 	bs := Service{
-		beaconClient: client,
-		slasherDB:    db,
+		cfg: &Config{
+			BeaconClient: client,
+			SlasherDB:    db,
+		},
 	}
 
 	numAtts := 1000

--- a/slasher/beaconclient/receivers_test.go
+++ b/slasher/beaconclient/receivers_test.go
@@ -21,8 +21,8 @@ func TestService_ReceiveBlocks(t *testing.T) {
 	client := mock.NewMockBeaconChainClient(ctrl)
 
 	bs := Service{
-		beaconClient: client,
-		blockFeed:    new(event.Feed),
+		cfg:       &Config{BeaconClient: client},
+		blockFeed: new(event.Feed),
 	}
 	stream := mock.NewMockBeaconChain_StreamBlocksClient(ctrl)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -46,7 +46,7 @@ func TestService_ReceiveAttestations(t *testing.T) {
 	client := mock.NewMockBeaconChainClient(ctrl)
 
 	bs := Service{
-		beaconClient:                client,
+		cfg:                         &Config{BeaconClient: client},
 		blockFeed:                   new(event.Feed),
 		receivedAttestationsBuffer:  make(chan *ethpb.IndexedAttestation, 1),
 		collectedAttestationsBuffer: make(chan []*ethpb.IndexedAttestation, 1),
@@ -78,9 +78,11 @@ func TestService_ReceiveAttestations_Batched(t *testing.T) {
 	client := mock.NewMockBeaconChainClient(ctrl)
 
 	bs := Service{
-		beaconClient:                client,
+		cfg: &Config{
+			BeaconClient: client,
+			SlasherDB:    testDB.SetupSlasherDB(t, false),
+		},
 		blockFeed:                   new(event.Feed),
-		slasherDB:                   testDB.SetupSlasherDB(t, false),
 		attestationFeed:             new(event.Feed),
 		receivedAttestationsBuffer:  make(chan *ethpb.IndexedAttestation, 1),
 		collectedAttestationsBuffer: make(chan []*ethpb.IndexedAttestation, 1),

--- a/slasher/beaconclient/submit.go
+++ b/slasher/beaconclient/submit.go
@@ -18,12 +18,12 @@ import (
 func (s *Service) subscribeDetectedProposerSlashings(ctx context.Context, ch chan *ethpb.ProposerSlashing) {
 	ctx, span := trace.StartSpan(ctx, "beaconclient.submitProposerSlashing")
 	defer span.End()
-	sub := s.proposerSlashingsFeed.Subscribe(ch)
+	sub := s.cfg.ProposerSlashingsFeed.Subscribe(ch)
 	defer sub.Unsubscribe()
 	for {
 		select {
 		case slashing := <-ch:
-			if _, err := s.beaconClient.SubmitProposerSlashing(ctx, slashing); err != nil {
+			if _, err := s.cfg.BeaconClient.SubmitProposerSlashing(ctx, slashing); err != nil {
 				log.Error(err)
 			}
 		case <-sub.Err():
@@ -43,14 +43,14 @@ func (s *Service) subscribeDetectedProposerSlashings(ctx context.Context, ch cha
 func (s *Service) subscribeDetectedAttesterSlashings(ctx context.Context, ch chan *ethpb.AttesterSlashing) {
 	ctx, span := trace.StartSpan(ctx, "beaconclient.submitAttesterSlashing")
 	defer span.End()
-	sub := s.attesterSlashingsFeed.Subscribe(ch)
+	sub := s.cfg.AttesterSlashingsFeed.Subscribe(ch)
 	defer sub.Unsubscribe()
 	for {
 		select {
 		case slashing := <-ch:
 			if slashing != nil && slashing.Attestation_1 != nil && slashing.Attestation_2 != nil {
 				slashableIndices := sliceutil.IntersectionUint64(slashing.Attestation_1.AttestingIndices, slashing.Attestation_2.AttestingIndices)
-				_, err := s.beaconClient.SubmitAttesterSlashing(ctx, slashing)
+				_, err := s.cfg.BeaconClient.SubmitAttesterSlashing(ctx, slashing)
 				if err == nil {
 					log.WithFields(logrus.Fields{
 						"sourceEpoch": slashing.Attestation_1.Data.Source.Epoch,

--- a/slasher/beaconclient/submit_test.go
+++ b/slasher/beaconclient/submit_test.go
@@ -19,8 +19,10 @@ func TestService_SubscribeDetectedProposerSlashings(t *testing.T) {
 	client := mock.NewMockBeaconChainClient(ctrl)
 
 	bs := Service{
-		beaconClient:          client,
-		proposerSlashingsFeed: new(event.Feed),
+		cfg: &Config{
+			BeaconClient:          client,
+			ProposerSlashingsFeed: new(event.Feed),
+		},
 	}
 
 	slashing := &ethpb.ProposerSlashing{
@@ -61,8 +63,10 @@ func TestService_SubscribeDetectedAttesterSlashings(t *testing.T) {
 	client := mock.NewMockBeaconChainClient(ctrl)
 
 	bs := Service{
-		beaconClient:          client,
-		attesterSlashingsFeed: new(event.Feed),
+		cfg: &Config{
+			BeaconClient:          client,
+			AttesterSlashingsFeed: new(event.Feed),
+		},
 	}
 
 	slashing := &ethpb.AttesterSlashing{

--- a/slasher/beaconclient/validator_retrieval.go
+++ b/slasher/beaconclient/validator_retrieval.go
@@ -43,7 +43,7 @@ func (s *Service) FindOrGetPublicKeys(
 	if notFound == 0 {
 		return validators, nil
 	}
-	vc, err := s.beaconClient.ListValidators(ctx, &ethpb.ListValidatorsRequest{
+	vc, err := s.cfg.BeaconClient.ListValidators(ctx, &ethpb.ListValidatorsRequest{
 		Indices: validatorIndices,
 	})
 	if err != nil {

--- a/slasher/beaconclient/validator_retrieval_test.go
+++ b/slasher/beaconclient/validator_retrieval_test.go
@@ -24,7 +24,7 @@ func TestService_RequestValidator(t *testing.T) {
 	validatorCache, err := cache.NewPublicKeyCache(0, nil)
 	require.NoError(t, err, "Could not create new cache")
 	bs := Service{
-		beaconClient:   client,
+		cfg:            &Config{BeaconClient: client},
 		publicKeyCache: validatorCache,
 	}
 	wanted := &ethpb.Validators{

--- a/slasher/detection/detect.go
+++ b/slasher/detection/detect.go
@@ -73,7 +73,7 @@ func (s *Service) DetectAttesterSlashings(
 		}
 	}
 	if len(slashings) > 0 {
-		if err := s.slasherDB.SaveAttesterSlashings(ctx, status.Active, slashings); err != nil {
+		if err := s.cfg.SlasherDB.SaveAttesterSlashings(ctx, status.Active, slashings); err != nil {
 			return nil, err
 		}
 	}
@@ -187,7 +187,7 @@ func (s *Service) mapResultsToAtts(ctx context.Context, results []*types.Detecti
 		if _, ok := resultsToAtts[resultKey]; ok {
 			continue
 		}
-		matchingAtts, err := s.slasherDB.IndexedAttestationsWithPrefix(ctx, result.SlashableEpoch, result.SigBytes[:])
+		matchingAtts, err := s.cfg.SlasherDB.IndexedAttestationsWithPrefix(ctx, result.SlashableEpoch, result.SigBytes[:])
 		if err != nil {
 			return nil, err
 		}
@@ -214,7 +214,7 @@ func isDoubleVote(incomingAtt, prevAtt *ethpb.IndexedAttestation) bool {
 // UpdateHighestAttestation updates to the db the highest source and target attestations for a each validator.
 func (s *Service) UpdateHighestAttestation(ctx context.Context, att *ethpb.IndexedAttestation) error {
 	for _, idx := range att.AttestingIndices {
-		h, err := s.slasherDB.HighestAttestation(ctx, idx)
+		h, err := s.cfg.SlasherDB.HighestAttestation(ctx, idx)
 		if err != nil {
 			return err
 		}
@@ -238,7 +238,7 @@ func (s *Service) UpdateHighestAttestation(ctx context.Context, att *ethpb.Index
 
 		// If it's not a new instance of HighestAttestation, changing it will also change the cached instance.
 		if update {
-			if err := s.slasherDB.SaveHighestAttestation(ctx, h); err != nil {
+			if err := s.cfg.SlasherDB.SaveHighestAttestation(ctx, h); err != nil {
 				return err
 			}
 		}

--- a/slasher/detection/detect_test.go
+++ b/slasher/detection/detect_test.go
@@ -173,7 +173,7 @@ func TestDetect_detectAttesterSlashings_Surround(t *testing.T) {
 			ctx := context.Background()
 			ds := Service{
 				ctx:                ctx,
-				slasherDB:          db,
+				cfg:                &Config{SlasherDB: db},
 				minMaxSpanDetector: attestations.NewSpanDetector(db),
 			}
 			require.NoError(t, db.SaveIndexedAttestations(ctx, tt.savedAtts))
@@ -324,7 +324,7 @@ func TestDetect_detectAttesterSlashings_Double(t *testing.T) {
 			ctx := context.Background()
 			ds := Service{
 				ctx:                ctx,
-				slasherDB:          db,
+				cfg:                &Config{SlasherDB: db},
 				minMaxSpanDetector: attestations.NewSpanDetector(db),
 			}
 			require.NoError(t, db.SaveIndexedAttestations(ctx, tt.savedAtts))
@@ -479,7 +479,7 @@ func TestDetect_updateHighestAttestation(t *testing.T) {
 			ctx := context.Background()
 			ds := Service{
 				ctx:               ctx,
-				slasherDB:         db,
+				cfg:               &Config{SlasherDB: db},
 				proposalsDetector: proposals.NewProposeDetector(db),
 			}
 			require.NoError(t, db.SaveHighestAttestation(ctx, tt.savedHighest))
@@ -537,7 +537,7 @@ func TestDetect_detectProposerSlashing(t *testing.T) {
 			ctx := context.Background()
 			ds := Service{
 				ctx:               ctx,
-				slasherDB:         db,
+				cfg:               &Config{SlasherDB: db},
 				proposalsDetector: proposals.NewProposeDetector(db),
 			}
 			require.NoError(t, db.SaveBlockHeader(ctx, tt.blk))
@@ -616,7 +616,7 @@ func TestDetect_detectProposerSlashingNoUpdate(t *testing.T) {
 			ctx := context.Background()
 			ds := Service{
 				ctx:               ctx,
-				slasherDB:         db,
+				cfg:               &Config{SlasherDB: db},
 				proposalsDetector: proposals.NewProposeDetector(db),
 			}
 			require.NoError(t, db.SaveBlockHeader(ctx, tt.blk))
@@ -632,8 +632,8 @@ func TestServer_MapResultsToAtts(t *testing.T) {
 	db := testDB.SetupSlasherDB(t, false)
 	ctx := context.Background()
 	ds := Service{
-		ctx:       ctx,
-		slasherDB: db,
+		ctx: ctx,
+		cfg: &Config{SlasherDB: db},
 	}
 	// 3 unique results, but 7 validators in total.
 	results := []*types.DetectionResult{
@@ -702,7 +702,7 @@ func TestServer_MapResultsToAtts(t *testing.T) {
 		},
 	}
 	for _, atts := range expectedResultsToAtts {
-		require.NoError(t, ds.slasherDB.SaveIndexedAttestations(ctx, atts))
+		require.NoError(t, ds.cfg.SlasherDB.SaveIndexedAttestations(ctx, atts))
 	}
 
 	resultsToAtts, err := ds.mapResultsToAtts(ctx, results)

--- a/slasher/detection/listeners.go
+++ b/slasher/detection/listeners.go
@@ -21,7 +21,7 @@ import (
 func (s *Service) detectIncomingBlocks(ctx context.Context, ch chan *ethpb.SignedBeaconBlock) {
 	ctx, span := trace.StartSpan(ctx, "detection.detectIncomingBlocks")
 	defer span.End()
-	sub := s.notifier.BlockFeed().Subscribe(ch)
+	sub := s.cfg.Notifier.BlockFeed().Subscribe(ch)
 	defer sub.Unsubscribe()
 	for {
 		select {
@@ -54,7 +54,7 @@ func (s *Service) detectIncomingBlocks(ctx context.Context, ch chan *ethpb.Signe
 func (s *Service) detectIncomingAttestations(ctx context.Context, ch chan *ethpb.IndexedAttestation) {
 	ctx, span := trace.StartSpan(ctx, "detection.detectIncomingAttestations")
 	defer span.End()
-	sub := s.notifier.AttestationFeed().Subscribe(ch)
+	sub := s.cfg.Notifier.AttestationFeed().Subscribe(ch)
 	defer sub.Unsubscribe()
 	for {
 		select {

--- a/slasher/detection/listeners_test.go
+++ b/slasher/detection/listeners_test.go
@@ -38,7 +38,7 @@ func TestService_DetectIncomingBlocks(t *testing.T) {
 	hook := logTest.NewGlobal()
 	db := testDB.SetupSlasherDB(t, false)
 	ds := Service{
-		notifier:          &mockNotifier{},
+		cfg:               &Config{Notifier: &mockNotifier{}},
 		proposalsDetector: proposals.NewProposeDetector(db),
 	}
 	blk := &ethpb.SignedBeaconBlock{
@@ -61,9 +61,11 @@ func TestService_DetectIncomingBlocks(t *testing.T) {
 func TestService_DetectIncomingAttestations(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ds := Service{
-		notifier:              &mockNotifier{},
-		minMaxSpanDetector:    &attestations.MockSpanDetector{},
-		attesterSlashingsFeed: new(event.Feed),
+		cfg: &Config{
+			Notifier:              &mockNotifier{},
+			AttesterSlashingsFeed: new(event.Feed),
+		},
+		minMaxSpanDetector: &attestations.MockSpanDetector{},
 	}
 	att := &ethpb.IndexedAttestation{
 		Data: &ethpb.AttestationData{

--- a/slasher/rpc/service.go
+++ b/slasher/rpc/service.go
@@ -26,18 +26,12 @@ import (
 // Service defines a server implementation of the gRPC Slasher service,
 // providing RPC endpoints for retrieving slashing proofs for malicious validators.
 type Service struct {
+	cfg             *Config
 	ctx             context.Context
 	cancel          context.CancelFunc
-	host            string
-	port            string
-	detector        *detection.Service
 	listener        net.Listener
 	grpcServer      *grpc.Server
-	slasherDB       db.Database
-	withCert        string
-	withKey         string
 	credentialError error
-	beaconclient    *beaconclient.Service
 }
 
 // Config options for the slasher node RPC server.
@@ -56,21 +50,15 @@ type Config struct {
 func NewService(ctx context.Context, cfg *Config) *Service {
 	ctx, cancel := context.WithCancel(ctx)
 	return &Service{
-		ctx:          ctx,
-		cancel:       cancel,
-		host:         cfg.Host,
-		port:         cfg.Port,
-		detector:     cfg.Detector,
-		slasherDB:    cfg.SlasherDB,
-		withCert:     cfg.CertFlag,
-		withKey:      cfg.KeyFlag,
-		beaconclient: cfg.BeaconClient,
+		cfg:    cfg,
+		ctx:    ctx,
+		cancel: cancel,
 	}
 }
 
 // Start the gRPC service.
 func (s *Service) Start() {
-	address := fmt.Sprintf("%s:%s", s.host, s.port)
+	address := fmt.Sprintf("%s:%s", s.cfg.Host, s.cfg.Port)
 	lis, err := net.Listen("tcp", address)
 	if err != nil {
 		log.Errorf("Could not listen to port in Start() %s: %v", address, err)
@@ -98,8 +86,8 @@ func (s *Service) Start() {
 	grpc_prometheus.EnableHandlingTimeHistogram()
 	// TODO(#791): Utilize a certificate for secure connections
 	// between beacon nodes and validator clients.
-	if s.withCert != "" && s.withKey != "" {
-		creds, err := credentials.NewServerTLSFromFile(s.withCert, s.withKey)
+	if s.cfg.CertFlag != "" && s.cfg.KeyFlag != "" {
+		creds, err := credentials.NewServerTLSFromFile(s.cfg.CertFlag, s.cfg.KeyFlag)
 		if err != nil {
 			log.Errorf("Could not load TLS keys: %s", err)
 			s.credentialError = err
@@ -114,9 +102,9 @@ func (s *Service) Start() {
 
 	slasherServer := &Server{
 		ctx:          s.ctx,
-		detector:     s.detector,
-		slasherDB:    s.slasherDB,
-		beaconClient: s.beaconclient,
+		detector:     s.cfg.Detector,
+		slasherDB:    s.cfg.SlasherDB,
+		beaconClient: s.cfg.BeaconClient,
 	}
 	slashpb.RegisterSlasherServer(s.grpcServer, slasherServer)
 
@@ -149,8 +137,8 @@ func (s *Service) Status() error {
 	if s.credentialError != nil {
 		return s.credentialError
 	}
-	if bs := s.beaconclient.Status(); bs != nil {
+	if bs := s.cfg.BeaconClient.Status(); bs != nil {
 		return bs
 	}
-	return s.detector.Status()
+	return s.cfg.Detector.Status()
 }

--- a/validator/slashing-protection/slasher_client_test.go
+++ b/validator/slashing-protection/slasher_client_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestGrpcHeaders(t *testing.T) {
 	s := &Service{
+		cfg:         &Config{},
 		ctx:         context.Background(),
 		grpcHeaders: []string{"first=value1", "second=value2"},
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
This pull request refactors the Service struct for the Slasher and the Validator Slashing Protection services by having a pointer to the Config struct as one of the fields, removing duplicated field declarations.

**Which issues(s) does this PR fix?**

Part of #8603

**Other notes for review**
Last batch of changes for #8603