### PR TITLE
Fix Powchain Genesis

### DIFF
--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -193,10 +193,13 @@ func TestStart_NoHTTPEndpointDefinedSucceeds_WithGenesisState(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, beaconDB.SaveState(context.Background(), st, genRoot))
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(context.Background(), genRoot))
+	depositCache, err := depositcache.New()
+	require.NoError(t, err)
 	s, err := NewService(context.Background(), &Web3ServiceConfig{
 		HTTPEndpoints:   []string{""}, // No endpoint defined!
 		DepositContract: testAcc.ContractAddr,
 		BeaconDB:        beaconDB,
+		DepositCache:    depositCache,
 	})
 	require.NoError(t, err)
 

--- a/beacon-chain/powchain/service_test.go
+++ b/beacon-chain/powchain/service_test.go
@@ -587,3 +587,27 @@ func Test_batchRequestHeaders_UnderflowChecks(t *testing.T) {
 	_, err = srv.batchRequestHeaders(start, end)
 	require.ErrorContains(t, "cannot be >", err)
 }
+
+func TestService_EnsureConsistentPowchainData(t *testing.T) {
+	beaconDB := dbutil.SetupDB(t)
+	cache, err := depositcache.New()
+	require.NoError(t, err)
+
+	s1, err := NewService(context.Background(), &Web3ServiceConfig{
+		BeaconDB:     beaconDB,
+		DepositCache: cache,
+	})
+	require.NoError(t, err)
+	genState, err := testutil.NewBeaconState()
+	require.NoError(t, err)
+	assert.NoError(t, genState.SetSlot(1000))
+
+	require.NoError(t, s1.cfg.BeaconDB.SaveGenesisData(context.Background(), genState))
+	require.NoError(t, s1.ensureValidPowchainData(context.Background()))
+
+	eth1Data, err := s1.cfg.BeaconDB.PowchainData(context.Background())
+	assert.NoError(t, err)
+
+	assert.NotNil(t, eth1Data)
+	assert.Equal(t, true, eth1Data.ChainstartData.Chainstarted)
+}


### PR DESCRIPTION
**What type of PR is this?**

Feature Cleanup

**What does this PR do? Why is it needed?**

- [x] The embedded genesis state leads to to our powchain service being in an inconsistent state. Due the the powchain service, being unable to determine genesis as it isn't aware of the embedded state, it might prevent it from being able to fetch deposit logs correctly an in order.
- [x] PR adds in a custom method to ensure any saved powchain data is valid in the event of an embedded genesis state.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
