### PR TITLE
Change early exit error message

### DIFF
--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -146,9 +146,10 @@ func verifyExitConditions(validator iface.ReadOnlyValidator, currentSlot types.S
 	// Verify the validator has been active long enough.
 	if currentEpoch < validator.ActivationEpoch()+params.BeaconConfig().ShardCommitteePeriod {
 		return fmt.Errorf(
-			"%s: %d epochs vs required %d epochs",
+			"%s: %d of %d epochs. Validator will be eligible for exit at epoch %d.",
 			ValidatorCannotExitYetMsg,
-			currentEpoch,
+			currentEpoch-validator.ActivationEpoch(),
+			params.BeaconConfig().ShardCommitteePeriod,
 			validator.ActivationEpoch()+params.BeaconConfig().ShardCommitteePeriod,
 		)
 	}


### PR DESCRIPTION
Currently when exiting a validator before the required threshold of `SHARD_COMMITTEE_PERIOD` epochs, the message is a bit misleading, eg:

``` 
    WARN accounts: Could not perform voluntary exit for account 0x974dc2826f2d: failed to propose voluntary exit: rpc error: code = InvalidArgument desc = validator has not been active long enough to exit: 187 epochs vs required 384 epochs
```

which can be read as "the validator has been active for 187 epochs and 384 are required. While in fact 187 is the current epoch and 384 is the epoch at which the validator becomes eligible for exit in the above example. In this example the validator was active for only 64 epochs. 

This PR changes the message for 

```
    validator has not been active long enough to exit: 64 of 256 epochs. Validator will be eligible for exit at epoch 384.
```
