### PR TITLE
Add beaconState RotateAttestations API method

### DIFF
--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -324,10 +324,7 @@ func ProcessFinalUpdates(state iface.BeaconState) (iface.BeaconState, error) {
 	}
 
 	// Rotate current and previous epoch attestations.
-	if err := state.SetPreviousEpochAttestations(state.CurrentEpochAttestations()); err != nil {
-		return nil, err
-	}
-	if err := state.SetCurrentEpochAttestations([]*pb.PendingAttestation{}); err != nil {
+	if err := state.RotateAttestations(); err != nil {
 		return nil, err
 	}
 	return state, nil

--- a/beacon-chain/state/interface/phase0.go
+++ b/beacon-chain/state/interface/phase0.go
@@ -193,4 +193,5 @@ type WriteOnlyAttestations interface {
 	SetCurrentEpochAttestations(val []*pbp2p.PendingAttestation) error
 	AppendCurrentEpochAttestations(val *pbp2p.PendingAttestation) error
 	AppendPreviousEpochAttestations(val *pbp2p.PendingAttestation) error
+	RotateAttestations() error
 }

--- a/beacon-chain/state/stateV0/BUILD.bazel
+++ b/beacon-chain/state/stateV0/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "getters_test.go",
         "helpers_test.go",
         "references_test.go",
+        "setters_test.go",
         "state_test.go",
         "state_trie_test.go",
         "types_test.go",

--- a/beacon-chain/state/stateV0/setters_test.go
+++ b/beacon-chain/state/stateV0/setters_test.go
@@ -1,0 +1,23 @@
+package stateV0
+
+import (
+	"testing"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	eth "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestBeaconState_RotateAttestations(t *testing.T) {
+	st, err := InitializeFromProto(&pb.BeaconState{
+		Slot:                      1,
+		CurrentEpochAttestations:  []*pb.PendingAttestation{{Data: &eth.AttestationData{Slot: 456}}},
+		PreviousEpochAttestations: []*pb.PendingAttestation{{Data: &eth.AttestationData{Slot: 123}}},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, st.RotateAttestations())
+	require.Equal(t, 0, len(st.CurrentEpochAttestations()))
+	require.Equal(t, types.Slot(456), st.PreviousEpochAttestations()[0].Data.Slot)
+}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This is a minor refactoring to streamline a bit for Altair. In Altair, we have a similar rotation of participation in the state where the previous epoch participation is set to the current epoch participation.

The idea here is that another minor refactoring for Altair could rename this to an even more generic "RotateParticipation" which would apply to both v0 and v1 states. 

This is also less copying and lock contention.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
