### PR TITLE
Part of 3 of beacon state Altair pkg - copy and hash tree root 

### DIFF
--- a/beacon-chain/state/state-altair/BUILD.bazel
+++ b/beacon-chain/state/state-altair/BUILD.bazel
@@ -33,12 +33,15 @@ go_library(
         "//shared/hashutil:go_default_library",
         "//shared/htrutils:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/sliceutil:go_default_library",
         "@com_github_dgraph_io_ristretto//:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 
@@ -47,13 +50,21 @@ go_test(
     srcs = [
         "deprecated_getters_test.go",
         "deprecated_setters_test.go",
+        "field_trie_test.go",
         "getters_test.go",
+        "state_trie_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//beacon-chain/state/stateV0:go_default_library",
+        "//beacon-chain/state/stateutil:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
+        "//shared/bytesutil:go_default_library",
+        "//shared/params:go_default_library",
+        "//shared/testutil:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
     ],
 )

--- a/beacon-chain/state/state-altair/deprecated_setters.go
+++ b/beacon-chain/state/state-altair/deprecated_setters.go
@@ -2,6 +2,7 @@ package state_altair
 
 import (
 	"github.com/pkg/errors"
+	v1 "github.com/prysmaticlabs/ethereumapis/eth/v1"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 
@@ -23,4 +24,9 @@ func (b *BeaconState) AppendCurrentEpochAttestations(val *pbp2p.PendingAttestati
 // AppendPreviousEpochAttestations is not supported for HF1 beacon state.
 func (b *BeaconState) AppendPreviousEpochAttestations(val *pbp2p.PendingAttestation) error {
 	return errors.New("AppendPreviousEpochAttestations is not supported for hard fork 1 beacon state")
+}
+
+// ToProto is not supported for HF1 beacon state.
+func (b *BeaconState) ToProto() (*v1.BeaconState, error) {
+	return nil, errors.New("ToProto is not yet supported for hard fork 1 beacon state")
 }

--- a/beacon-chain/state/state-altair/field_trie_test.go
+++ b/beacon-chain/state/state-altair/field_trie_test.go
@@ -1,0 +1,84 @@
+package state_altair
+
+import (
+	"testing"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateV0"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestFieldTrie_NewTrie(t *testing.T) {
+	newState, _ := testutil.DeterministicGenesisState(t, 40)
+
+	// 5 represents the enum value of state roots
+	trie, err := NewFieldTrie(5, newState.StateRoots(), uint64(params.BeaconConfig().SlotsPerHistoricalRoot))
+	require.NoError(t, err)
+	root, err := stateV0.RootsArrayHashTreeRoot(newState.StateRoots(), uint64(params.BeaconConfig().SlotsPerHistoricalRoot), "StateRoots")
+	require.NoError(t, err)
+	newRoot, err := trie.TrieRoot()
+	require.NoError(t, err)
+	assert.Equal(t, root, newRoot)
+}
+
+func TestFieldTrie_RecomputeTrie(t *testing.T) {
+	newState, _ := testutil.DeterministicGenesisState(t, 32)
+	// 10 represents the enum value of validators
+	trie, err := NewFieldTrie(11, newState.Validators(), params.BeaconConfig().ValidatorRegistryLimit)
+	require.NoError(t, err)
+
+	changedIdx := []uint64{2, 29}
+	val1, err := newState.ValidatorAtIndex(10)
+	require.NoError(t, err)
+	val2, err := newState.ValidatorAtIndex(11)
+	require.NoError(t, err)
+	val1.Slashed = true
+	val1.ExitEpoch = 20
+
+	val2.Slashed = true
+	val2.ExitEpoch = 40
+
+	changedVals := []*ethpb.Validator{val1, val2}
+	require.NoError(t, newState.UpdateValidatorAtIndex(types.ValidatorIndex(changedIdx[0]), changedVals[0]))
+	require.NoError(t, newState.UpdateValidatorAtIndex(types.ValidatorIndex(changedIdx[1]), changedVals[1]))
+
+	expectedRoot, err := stateV0.ValidatorRegistryRoot(newState.Validators())
+	require.NoError(t, err)
+	root, err := trie.RecomputeTrie(changedIdx, newState.Validators())
+	require.NoError(t, err)
+	assert.Equal(t, expectedRoot, root)
+}
+
+func TestFieldTrie_CopyTrieImmutable(t *testing.T) {
+	newState, _ := testutil.DeterministicGenesisState(t, 32)
+	// 12 represents the enum value of randao mixes.
+	trie, err := stateV0.NewFieldTrie(13, newState.RandaoMixes(), uint64(params.BeaconConfig().EpochsPerHistoricalVector))
+	require.NoError(t, err)
+
+	newTrie := trie.CopyTrie()
+
+	changedIdx := []uint64{2, 29}
+
+	changedVals := [][32]byte{{'A', 'B'}, {'C', 'D'}}
+	require.NoError(t, newState.UpdateRandaoMixesAtIndex(changedIdx[0], changedVals[0][:]))
+	require.NoError(t, newState.UpdateRandaoMixesAtIndex(changedIdx[1], changedVals[1][:]))
+
+	root, err := trie.RecomputeTrie(changedIdx, newState.RandaoMixes())
+	require.NoError(t, err)
+	newRoot, err := newTrie.TrieRoot()
+	require.NoError(t, err)
+	if root == newRoot {
+		t.Errorf("Wanted roots to be different, but they are the same: %#x", root)
+	}
+}
+
+func Test_HandleEth1DataSlice_OutOfRange(t *testing.T) {
+	items := make([]*ethpb.Eth1Data, 1)
+	indices := []uint64{3}
+	_, err := handleEth1DataSlice(items, indices, false)
+	assert.ErrorContains(t, "index 3 greater than number of items in eth1 data slice 1", err)
+}

--- a/beacon-chain/state/state-altair/state_trie.go
+++ b/beacon-chain/state/state-altair/state_trie.go
@@ -191,7 +191,7 @@ func (b *BeaconState) HashTreeRoot(ctx context.Context) ([32]byte, error) {
 		if err != nil {
 			return [32]byte{}, err
 		}
-		layers := merkleize(fieldRoots)
+		layers := stateutil.Merkleize(fieldRoots)
 		b.merkleLayers = layers
 		b.dirtyFields = make(map[fieldIndex]interface{}, params.BeaconConfig().BeaconStateAltairFieldCount)
 	}
@@ -226,37 +226,6 @@ func (b *BeaconState) FieldReferencesCount() map[string]uint64 {
 		f.RUnlock()
 	}
 	return refMap
-}
-
-// Merkleize 32-byte leaves into a Merkle trie for its adequate depth, returning
-// the resulting layers of the trie based on the appropriate depth. This function
-// pads the leaves to a length of 32.
-func merkleize(leaves [][]byte) [][][]byte {
-	hashFunc := hashutil.CustomSHA256Hasher()
-	layers := make([][][]byte, htrutils.Depth(uint64(len(leaves)))+1)
-	for len(leaves) != 32 {
-		leaves = append(leaves, make([]byte, 32))
-	}
-	currentLayer := leaves
-	layers[0] = currentLayer
-
-	// We keep track of the hash layers of a Merkle trie until we reach
-	// the top layer of length 1, which contains the single root element.
-	//        [Root]      -> Top layer has length 1.
-	//    [E]       [F]   -> This layer has length 2.
-	// [A]  [B]  [C]  [D] -> The bottom layer has length 4 (needs to be a power of two).
-	i := 1
-	for len(currentLayer) > 1 && i < len(layers) {
-		layer := make([][]byte, 0)
-		for i := 0; i < len(currentLayer); i += 2 {
-			hashedChunk := hashFunc(append(currentLayer[i], currentLayer[i+1]...))
-			layer = append(layer, hashedChunk[:])
-		}
-		currentLayer = layer
-		layers[i] = currentLayer
-		i++
-	}
-	return layers
 }
 
 func (b *BeaconState) rootSelector(field fieldIndex) ([32]byte, error) {

--- a/beacon-chain/state/state-altair/state_trie.go
+++ b/beacon-chain/state/state-altair/state_trie.go
@@ -1,13 +1,22 @@
 package state_altair
 
 import (
+	"context"
+	"runtime"
+	"sort"
 	"sync"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pkg/errors"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/hashutil"
+	"github.com/prysmaticlabs/prysm/shared/htrutils"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/sliceutil"
+	"go.opencensus.io/trace"
 )
 
 // InitializeFromProto the beacon state from a protobuf representation.
@@ -58,4 +67,328 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconStateAltair) (*BeaconState, error
 	b.sharedFieldReferences[historicalRoots] = stateutil.NewRef(1)
 
 	return b, nil
+}
+
+// Copy returns a deep copy of the beacon state.
+func (b *BeaconState) Copy() iface.BeaconState {
+	if !b.hasInnerState() {
+		return nil
+	}
+
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+	fieldCount := params.BeaconConfig().BeaconStateAltairFieldCount
+	dst := &BeaconState{
+		state: &pbp2p.BeaconStateAltair{
+			// Primitive types, safe to copy.
+			GenesisTime:      b.state.GenesisTime,
+			Slot:             b.state.Slot,
+			Eth1DepositIndex: b.state.Eth1DepositIndex,
+
+			// Large arrays, infrequently changed, constant size.
+			RandaoMixes:   b.state.RandaoMixes,
+			StateRoots:    b.state.StateRoots,
+			BlockRoots:    b.state.BlockRoots,
+			Slashings:     b.state.Slashings,
+			Eth1DataVotes: b.state.Eth1DataVotes,
+
+			// Large arrays, increases over time.
+			Validators:                 b.state.Validators,
+			Balances:                   b.state.Balances,
+			HistoricalRoots:            b.state.HistoricalRoots,
+			PreviousEpochParticipation: b.state.PreviousEpochParticipation,
+			CurrentEpochParticipation:  b.state.CurrentEpochParticipation,
+			InactivityScores:           b.state.InactivityScores,
+
+			// Everything else, too small to be concerned about, constant size.
+			Fork:                        b.fork(),
+			LatestBlockHeader:           b.latestBlockHeader(),
+			Eth1Data:                    b.eth1Data(),
+			JustificationBits:           b.justificationBits(),
+			PreviousJustifiedCheckpoint: b.previousJustifiedCheckpoint(),
+			CurrentJustifiedCheckpoint:  b.currentJustifiedCheckpoint(),
+			FinalizedCheckpoint:         b.finalizedCheckpoint(),
+			GenesisValidatorsRoot:       b.genesisValidatorRoot(),
+			CurrentSyncCommittee:        b.CurrentSyncCommittee(),
+			NextSyncCommittee:           b.NextSyncCommittee(),
+		},
+		dirtyFields:           make(map[fieldIndex]interface{}, fieldCount),
+		dirtyIndices:          make(map[fieldIndex][]uint64, fieldCount),
+		rebuildTrie:           make(map[fieldIndex]bool, fieldCount),
+		sharedFieldReferences: make(map[fieldIndex]*stateutil.Reference, 11),
+		stateFieldLeaves:      make(map[fieldIndex]*FieldTrie, fieldCount),
+
+		// Copy on write validator index map.
+		valMapHandler: b.valMapHandler,
+	}
+
+	for field, ref := range b.sharedFieldReferences {
+		ref.AddRef()
+		dst.sharedFieldReferences[field] = ref
+	}
+
+	// Increment ref for validator map
+	b.valMapHandler.AddRef()
+
+	for i := range b.dirtyFields {
+		dst.dirtyFields[i] = true
+	}
+
+	for i := range b.dirtyIndices {
+		indices := make([]uint64, len(b.dirtyIndices[i]))
+		copy(indices, b.dirtyIndices[i])
+		dst.dirtyIndices[i] = indices
+	}
+
+	for i := range b.rebuildTrie {
+		dst.rebuildTrie[i] = true
+	}
+
+	for fldIdx, fieldTrie := range b.stateFieldLeaves {
+		dst.stateFieldLeaves[fldIdx] = fieldTrie
+		if fieldTrie.reference != nil {
+			fieldTrie.Lock()
+			fieldTrie.reference.AddRef()
+			fieldTrie.Unlock()
+		}
+	}
+
+	if b.merkleLayers != nil {
+		dst.merkleLayers = make([][][]byte, len(b.merkleLayers))
+		for i, layer := range b.merkleLayers {
+			dst.merkleLayers[i] = make([][]byte, len(layer))
+			for j, content := range layer {
+				dst.merkleLayers[i][j] = make([]byte, len(content))
+				copy(dst.merkleLayers[i][j], content)
+			}
+		}
+	}
+
+	// Finalizer runs when dst is being destroyed in garbage collection.
+	runtime.SetFinalizer(dst, func(b *BeaconState) {
+		for field, v := range b.sharedFieldReferences {
+			v.MinusRef()
+			if b.stateFieldLeaves[field].reference != nil {
+				b.stateFieldLeaves[field].reference.MinusRef()
+			}
+		}
+	})
+
+	return dst
+}
+
+// HashTreeRoot of the beacon state retrieves the Merkle root of the trie
+// representation of the beacon state based on the eth2 Simple Serialize specification.
+func (b *BeaconState) HashTreeRoot(ctx context.Context) ([32]byte, error) {
+	_, span := trace.StartSpan(ctx, "beaconStateAltair.HashTreeRoot")
+	defer span.End()
+
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	if b.merkleLayers == nil || len(b.merkleLayers) == 0 {
+		fieldRoots, err := computeFieldRoots(b.state)
+		if err != nil {
+			return [32]byte{}, err
+		}
+		layers := merkleize(fieldRoots)
+		b.merkleLayers = layers
+		b.dirtyFields = make(map[fieldIndex]interface{}, params.BeaconConfig().BeaconStateAltairFieldCount)
+	}
+
+	for field := range b.dirtyFields {
+		root, err := b.rootSelector(field)
+		if err != nil {
+			return [32]byte{}, err
+		}
+		b.merkleLayers[0][field] = root[:]
+		b.recomputeRoot(int(field))
+		delete(b.dirtyFields, field)
+	}
+	return bytesutil.ToBytes32(b.merkleLayers[len(b.merkleLayers)-1][0]), nil
+}
+
+// FieldReferencesCount returns the reference count held by each field. This
+// also includes the field trie held by each field.
+func (b *BeaconState) FieldReferencesCount() map[string]uint64 {
+	refMap := make(map[string]uint64)
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+	for i, f := range b.sharedFieldReferences {
+		refMap[i.String()] = uint64(f.Refs())
+	}
+	for i, f := range b.stateFieldLeaves {
+		numOfRefs := uint64(f.reference.Refs())
+		f.RLock()
+		if len(f.fieldLayers) != 0 {
+			refMap[i.String()+"_trie"] = numOfRefs
+		}
+		f.RUnlock()
+	}
+	return refMap
+}
+
+// Merkleize 32-byte leaves into a Merkle trie for its adequate depth, returning
+// the resulting layers of the trie based on the appropriate depth. This function
+// pads the leaves to a length of 32.
+func merkleize(leaves [][]byte) [][][]byte {
+	hashFunc := hashutil.CustomSHA256Hasher()
+	layers := make([][][]byte, htrutils.Depth(uint64(len(leaves)))+1)
+	for len(leaves) != 32 {
+		leaves = append(leaves, make([]byte, 32))
+	}
+	currentLayer := leaves
+	layers[0] = currentLayer
+
+	// We keep track of the hash layers of a Merkle trie until we reach
+	// the top layer of length 1, which contains the single root element.
+	//        [Root]      -> Top layer has length 1.
+	//    [E]       [F]   -> This layer has length 2.
+	// [A]  [B]  [C]  [D] -> The bottom layer has length 4 (needs to be a power of two).
+	i := 1
+	for len(currentLayer) > 1 && i < len(layers) {
+		layer := make([][]byte, 0)
+		for i := 0; i < len(currentLayer); i += 2 {
+			hashedChunk := hashFunc(append(currentLayer[i], currentLayer[i+1]...))
+			layer = append(layer, hashedChunk[:])
+		}
+		currentLayer = layer
+		layers[i] = currentLayer
+		i++
+	}
+	return layers
+}
+
+func (b *BeaconState) rootSelector(field fieldIndex) ([32]byte, error) {
+	hasher := hashutil.CustomSHA256Hasher()
+	switch field {
+	case genesisTime:
+		return htrutils.Uint64Root(b.state.GenesisTime), nil
+	case genesisValidatorRoot:
+		return bytesutil.ToBytes32(b.state.GenesisValidatorsRoot), nil
+	case slot:
+		return htrutils.Uint64Root(uint64(b.state.Slot)), nil
+	case eth1DepositIndex:
+		return htrutils.Uint64Root(b.state.Eth1DepositIndex), nil
+	case fork:
+		return htrutils.ForkRoot(b.state.Fork)
+	case latestBlockHeader:
+		return stateutil.BlockHeaderRoot(b.state.LatestBlockHeader)
+	case blockRoots:
+		if b.rebuildTrie[field] {
+			err := b.resetFieldTrie(field, b.state.BlockRoots, uint64(params.BeaconConfig().SlotsPerHistoricalRoot))
+			if err != nil {
+				return [32]byte{}, err
+			}
+			b.dirtyIndices[field] = []uint64{}
+			delete(b.rebuildTrie, field)
+			return b.stateFieldLeaves[field].TrieRoot()
+		}
+		return b.recomputeFieldTrie(blockRoots, b.state.BlockRoots)
+	case stateRoots:
+		if b.rebuildTrie[field] {
+			err := b.resetFieldTrie(field, b.state.StateRoots, uint64(params.BeaconConfig().SlotsPerHistoricalRoot))
+			if err != nil {
+				return [32]byte{}, err
+			}
+			b.dirtyIndices[field] = []uint64{}
+			delete(b.rebuildTrie, field)
+			return b.stateFieldLeaves[field].TrieRoot()
+		}
+		return b.recomputeFieldTrie(stateRoots, b.state.StateRoots)
+	case historicalRoots:
+		return htrutils.HistoricalRootsRoot(b.state.HistoricalRoots)
+	case eth1Data:
+		return eth1Root(hasher, b.state.Eth1Data)
+	case eth1DataVotes:
+		if b.rebuildTrie[field] {
+			err := b.resetFieldTrie(field, b.state.Eth1DataVotes, uint64(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(params.BeaconConfig().EpochsPerEth1VotingPeriod))))
+			if err != nil {
+				return [32]byte{}, err
+			}
+			b.dirtyIndices[field] = []uint64{}
+			delete(b.rebuildTrie, field)
+			return b.stateFieldLeaves[field].TrieRoot()
+		}
+		return b.recomputeFieldTrie(field, b.state.Eth1DataVotes)
+	case validators:
+		if b.rebuildTrie[field] {
+			err := b.resetFieldTrie(field, b.state.Validators, params.BeaconConfig().ValidatorRegistryLimit)
+			if err != nil {
+				return [32]byte{}, err
+			}
+			b.dirtyIndices[validators] = []uint64{}
+			delete(b.rebuildTrie, validators)
+			return b.stateFieldLeaves[field].TrieRoot()
+		}
+		return b.recomputeFieldTrie(validators, b.state.Validators)
+	case balances:
+		return stateutil.Uint64ListRootWithRegistryLimit(b.state.Balances)
+	case randaoMixes:
+		if b.rebuildTrie[field] {
+			err := b.resetFieldTrie(field, b.state.RandaoMixes, uint64(params.BeaconConfig().EpochsPerHistoricalVector))
+			if err != nil {
+				return [32]byte{}, err
+			}
+			b.dirtyIndices[field] = []uint64{}
+			delete(b.rebuildTrie, field)
+			return b.stateFieldLeaves[field].TrieRoot()
+		}
+		return b.recomputeFieldTrie(randaoMixes, b.state.RandaoMixes)
+	case slashings:
+		return htrutils.SlashingsRoot(b.state.Slashings)
+	case previousEpochParticipationBits:
+		return participationBitsRoot(b.state.PreviousEpochParticipation)
+	case currentEpochParticipationBits:
+		return participationBitsRoot(b.state.CurrentEpochParticipation)
+	case justificationBits:
+		return bytesutil.ToBytes32(b.state.JustificationBits), nil
+	case previousJustifiedCheckpoint:
+		return htrutils.CheckpointRoot(hasher, b.state.PreviousJustifiedCheckpoint)
+	case currentJustifiedCheckpoint:
+		return htrutils.CheckpointRoot(hasher, b.state.CurrentJustifiedCheckpoint)
+	case finalizedCheckpoint:
+		return htrutils.CheckpointRoot(hasher, b.state.FinalizedCheckpoint)
+	case inactivityScores:
+		return stateutil.Uint64ListRootWithRegistryLimit(b.state.InactivityScores)
+	case currentSyncCommittee:
+		return syncCommitteeRoot(b.state.CurrentSyncCommittee)
+	case nextSyncCommittee:
+		return syncCommitteeRoot(b.state.NextSyncCommittee)
+	}
+	return [32]byte{}, errors.New("invalid field index provided")
+}
+
+func (b *BeaconState) recomputeFieldTrie(index fieldIndex, elements interface{}) ([32]byte, error) {
+	fTrie := b.stateFieldLeaves[index]
+	if fTrie.reference.Refs() > 1 {
+		fTrie.Lock()
+		defer fTrie.Unlock()
+		fTrie.reference.MinusRef()
+		newTrie := fTrie.CopyTrie()
+		b.stateFieldLeaves[index] = newTrie
+		fTrie = newTrie
+	}
+	// remove duplicate indexes
+	b.dirtyIndices[index] = sliceutil.SetUint64(b.dirtyIndices[index])
+	// sort indexes again
+	sort.Slice(b.dirtyIndices[index], func(i int, j int) bool {
+		return b.dirtyIndices[index][i] < b.dirtyIndices[index][j]
+	})
+	root, err := fTrie.RecomputeTrie(b.dirtyIndices[index], elements)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	b.dirtyIndices[index] = []uint64{}
+	return root, nil
+}
+
+func (b *BeaconState) resetFieldTrie(index fieldIndex, elements interface{}, length uint64) error {
+	fTrie, err := NewFieldTrie(index, elements, length)
+	if err != nil {
+		return err
+	}
+	b.stateFieldLeaves[index] = fTrie
+	b.dirtyIndices[index] = []uint64{}
+	return nil
 }

--- a/beacon-chain/state/state-altair/state_trie_test.go
+++ b/beacon-chain/state/state-altair/state_trie_test.go
@@ -1,0 +1,96 @@
+package state_altair
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+)
+
+func TestValidatorMap_DistinctCopy(t *testing.T) {
+	count := uint64(100)
+	vals := make([]*ethpb.Validator, 0, count)
+	for i := uint64(1); i < count; i++ {
+		someRoot := [32]byte{}
+		someKey := [48]byte{}
+		copy(someRoot[:], strconv.Itoa(int(i)))
+		copy(someKey[:], strconv.Itoa(int(i)))
+		vals = append(vals, &ethpb.Validator{
+			PublicKey:                  someKey[:],
+			WithdrawalCredentials:      someRoot[:],
+			EffectiveBalance:           params.BeaconConfig().MaxEffectiveBalance,
+			Slashed:                    false,
+			ActivationEligibilityEpoch: 1,
+			ActivationEpoch:            1,
+			ExitEpoch:                  1,
+			WithdrawableEpoch:          1,
+		})
+	}
+	handler := stateutil.NewValMapHandler(vals)
+	newHandler := handler.Copy()
+	wantedPubkey := strconv.Itoa(22)
+	handler.Set(bytesutil.ToBytes48([]byte(wantedPubkey)), 27)
+	val1, _ := handler.Get(bytesutil.ToBytes48([]byte(wantedPubkey)))
+	val2, _ := newHandler.Get(bytesutil.ToBytes48([]byte(wantedPubkey)))
+	assert.NotEqual(t, val1, val2, "Values are supposed to be unequal due to copy")
+}
+
+func TestBeaconState_NoDeadlock(t *testing.T) {
+	count := uint64(100)
+	vals := make([]*ethpb.Validator, 0, count)
+	for i := uint64(1); i < count; i++ {
+		someRoot := [32]byte{}
+		someKey := [48]byte{}
+		copy(someRoot[:], strconv.Itoa(int(i)))
+		copy(someKey[:], strconv.Itoa(int(i)))
+		vals = append(vals, &ethpb.Validator{
+			PublicKey:                  someKey[:],
+			WithdrawalCredentials:      someRoot[:],
+			EffectiveBalance:           params.BeaconConfig().MaxEffectiveBalance,
+			Slashed:                    false,
+			ActivationEligibilityEpoch: 1,
+			ActivationEpoch:            1,
+			ExitEpoch:                  1,
+			WithdrawableEpoch:          1,
+		})
+	}
+	st, err := InitializeFromProtoUnsafe(&pb.BeaconStateAltair{
+		Validators: vals,
+	})
+	assert.NoError(t, err)
+
+	wg := new(sync.WaitGroup)
+
+	wg.Add(1)
+	go func() {
+		// Continuously lock and unlock the state
+		// by acquiring the lock.
+		for i := 0; i < 1000; i++ {
+			for _, f := range st.stateFieldLeaves {
+				f.Lock()
+				if len(f.fieldLayers) == 0 {
+					f.fieldLayers = make([][]*[32]byte, 10)
+				}
+				f.Unlock()
+				f.reference.AddRef()
+			}
+		}
+		wg.Done()
+	}()
+	// Constantly read from the offending portion
+	// of the code to ensure there is no possible
+	// recursive read locking.
+	for i := 0; i < 1000; i++ {
+		go func() {
+			_ = st.FieldReferencesCount()
+		}()
+	}
+	// Test will not terminate in the event of a deadlock.
+	wg.Wait()
+}


### PR DESCRIPTION
Follow up on #8658 

Add copy, hash tree root. Most of them are identical to existing ones. Will add commentary in code

Note: Some tests are missing and that will come in next part (For preview of tests, check out #8584). The reason that we can't do tests in this PR is because tests require the testutil functions. If we include them then the diff will be 3000+