### PR TITLE
Skip e2e test for previous implementation of slasher

### DIFF
--- a/endtoend/minimal_slashing_e2e_test.go
+++ b/endtoend/minimal_slashing_e2e_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestEndToEnd_Slashing_MinimalConfig(t *testing.T) {
+	t.Skip("To be replaced with the new slasher implementation")
 	testutil.ResetCache()
 	params.UseE2EConfig()
 	require.NoError(t, e2eParams.Init(e2eParams.StandardBeaconCount))


### PR DESCRIPTION
**What type of PR is this?**

> Other / Cleanup

**What does this PR do? Why is it needed?**
- After discussion with Raul, we've concluded that the current e2e test for slasher should be skipped:
  -  the implementation is to be replaced by the new in-beacon slasher developed in [feature/slasher](https://github.com/prysmaticlabs/prysm/tree/feature/slasher) and to be released soon.
  - current test is flaky 

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
