### PR TITLE
BLS: Deprecate usage of AggregateVerify

### DIFF
--- a/shared/bls/blst/signature.go
+++ b/shared/bls/blst/signature.go
@@ -61,9 +61,11 @@ func (s *Signature) Verify(pubKey common.PublicKey, msg []byte) bool {
 	return s.s.Verify(false, pubKey.(*PublicKey).p, false, msg, dst)
 }
 
-// AggregateVerify verifies each public key against its respective message.
-// This is vulnerable to rogue public-key attack. Each user must
-// provide a proof-of-knowledge of the public key.
+// AggregateVerify verifies each public key against its respective message. This is vulnerable to
+// rogue public-key attack. Each user must provide a proof-of-knowledge of the public key.
+//
+// Note: The msgs must be distinct. For maximum performance, this method does not ensure distinct
+// messages.
 //
 // In IETF draft BLS specification:
 // AggregateVerify((PK_1, message_1), ..., (PK_n, message_n),
@@ -73,7 +75,9 @@ func (s *Signature) Verify(pubKey common.PublicKey, msg []byte) bool {
 //      outputs INVALID otherwise.
 //
 // In ETH2.0 specification:
-// def AggregateVerify(pairs: Sequence[PK: BLSPubkey, message: Bytes], signature: BLSSignature) -> boo
+// def AggregateVerify(pairs: Sequence[PK: BLSPubkey, message: Bytes], signature: BLSSignature) -> bool
+//
+// Deprecated: Use FastAggregateVerify or use this method in spectests only.
 func (s *Signature) AggregateVerify(pubKeys []common.PublicKey, msgs [][32]byte) bool {
 	if featureconfig.Get().SkipBLSVerify {
 		return true

--- a/shared/bls/common/interface.go
+++ b/shared/bls/common/interface.go
@@ -24,6 +24,7 @@ type PublicKey interface {
 // Signature represents a BLS signature.
 type Signature interface {
 	Verify(pubKey PublicKey, msg []byte) bool
+	// Deprecated: Use FastAggregateVerify or use this method in spectests only.
 	AggregateVerify(pubKeys []PublicKey, msgs [][32]byte) bool
 	FastAggregateVerify(pubKeys []PublicKey, msg [32]byte) bool
 	Marshal() []byte

--- a/shared/bls/herumi/signature.go
+++ b/shared/bls/herumi/signature.go
@@ -53,9 +53,11 @@ func (s *Signature) Verify(pubKey common.PublicKey, msg []byte) bool {
 	return s.s.VerifyByte(pubKey.(*PublicKey).p, msg)
 }
 
-// AggregateVerify verifies each public key against its respective message.
-// This is vulnerable to rogue public-key attack. Each user must
-// provide a proof-of-knowledge of the public key.
+// AggregateVerify verifies each public key against its respective message. This is vulnerable to
+// rogue public-key attack. Each user must provide a proof-of-knowledge of the public key.
+//
+// Note: The msgs must be distinct. For maximum performance, this method does not ensure distinct
+// messages.
 //
 // In IETF draft BLS specification:
 // AggregateVerify((PK_1, message_1), ..., (PK_n, message_n),
@@ -65,7 +67,8 @@ func (s *Signature) Verify(pubKey common.PublicKey, msg []byte) bool {
 //      outputs INVALID otherwise.
 //
 // In ETH2.0 specification:
-// def AggregateVerify(pairs: Sequence[PK: BLSPubkey, message: Bytes], signature: BLSSignature) -> boo
+// def AggregateVerify(pairs: Sequence[PK: BLSPubkey, message: Bytes], signature: BLSSignature) -> bool
+// Deprecated: Use FastAggregateVerify or use this method in spectests only.
 func (s *Signature) AggregateVerify(pubKeys []common.PublicKey, msgs [][32]byte) bool {
 	if featureconfig.Get().SkipBLSVerify {
 		return true


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

AggregateVerify is not used in production code.
AggregateVerify does not match BLS spec exactly in that it does not check that all `msgs` are distinct. 

If possible, we could remove AggregateVerify. However, it seems critical for some spectests.

**Which issues(s) does this PR fix?**

N/A.

**Other notes for review**
