### PR TITLE
Copy File More Efficiently

### DIFF
--- a/shared/fileutil/fileutil.go
+++ b/shared/fileutil/fileutil.go
@@ -173,17 +173,19 @@ func ReadFileAsBytes(filename string) ([]byte, error) {
 
 // CopyFile copy a file from source to destination path.
 func CopyFile(src, dst string) error {
-	input, err := ioutil.ReadFile(src)
+	if !FileExists(src) {
+		return errors.New("source file does not exist at provided path")
+	}
+	f, err := os.Open(src)
 	if err != nil {
 		return err
 	}
-
-	err = ioutil.WriteFile(dst, input, params.BeaconIoConfig().ReadWritePermissions)
+	dstFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, params.BeaconIoConfig().ReadWritePermissions)
 	if err != nil {
-		err := errors.Wrapf(err, "error creating file %s", dst)
 		return err
 	}
-	return nil
+	_, err = io.Copy(dstFile, f)
+	return err
 }
 
 // CopyDir copies contents of one directory into another, recursively.


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Instead of holding everything in memory we use the filesystem to copy the file as it is much more efficient 
to do that for larger files and prevents OOMs from happening during a database restoration.

**Which issues(s) does this PR fix?**

Fixes #8702

**Other notes for review**
