### PR TITLE
Altair: Process sync committee 

### DIFF
--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -4,6 +4,7 @@ load("@prysm//tools/go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "block.go",
         "deposit.go",
         "state.go",
         "sync_committee.go",
@@ -17,6 +18,7 @@ go_library(
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
+        "//beacon-chain/p2p/types:go_default_library",
         "//beacon-chain/state/interface:go_default_library",
         "//beacon-chain/state/state-altair:go_default_library",
         "//beacon-chain/state/stateV0:go_default_library",
@@ -24,6 +26,7 @@ go_library(
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/hashutil:go_default_library",
+        "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
@@ -34,6 +37,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "block_test.go",
         "deposit_fuzz_test.go",
         "deposit_test.go",
         "state_fuzz_test.go",
@@ -44,6 +48,7 @@ go_test(
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
+        "//beacon-chain/p2p/types:go_default_library",
         "//beacon-chain/state/state-altair:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bls:go_default_library",
@@ -51,6 +56,7 @@ go_test(
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil:go_default_library",
+        "//shared/testutil/altair:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "//shared/trieutil:go_default_library",
@@ -58,5 +64,6 @@ go_test(
         "@com_github_google_gofuzz//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
     ],
 )

--- a/beacon-chain/core/altair/block.go
+++ b/beacon-chain/core/altair/block.go
@@ -1,0 +1,107 @@
+package altair
+
+import (
+	"errors"
+
+	"github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/epoch"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	p2pType "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/params"
+)
+
+// ProcessSyncCommittee verifies sync committee aggregate signature signing over the previous slot block root.
+//
+// Spec code:
+// def process_sync_committee(state: BeaconState, aggregate: SyncAggregate) -> None:
+//    # Verify sync committee aggregate signature signing over the previous slot block root
+//    committee_pubkeys = state.current_sync_committee.pubkeys
+//    participant_pubkeys = [pubkey for pubkey, bit in zip(committee_pubkeys, aggregate.sync_committee_bits) if bit]
+//    previous_slot = max(state.slot, Slot(1)) - Slot(1)
+//    domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(previous_slot))
+//    signing_root = compute_signing_root(get_block_root_at_slot(state, previous_slot), domain)
+//    assert eth2_fast_aggregate_verify(participant_pubkeys, signing_root, aggregate.sync_committee_signature)
+//
+//    # Compute participant and proposer rewards
+//    total_active_increments = get_total_active_balance(state) // EFFECTIVE_BALANCE_INCREMENT
+//    total_base_rewards = Gwei(get_base_reward_per_increment(state) * total_active_increments)
+//    max_participant_rewards = Gwei(total_base_rewards * SYNC_REWARD_WEIGHT // WEIGHT_DENOMINATOR // SLOTS_PER_EPOCH)
+//    participant_reward = Gwei(max_participant_rewards // SYNC_COMMITTEE_SIZE)
+//    proposer_reward = Gwei(participant_reward * PROPOSER_WEIGHT // (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT))
+//
+//    # Apply participant and proposer rewards
+//    committee_indices = get_sync_committee_indices(state, get_current_epoch(state))
+//    participant_indices = [index for index, bit in zip(committee_indices, aggregate.sync_committee_bits) if bit]
+//    for participant_index in participant_indices:
+//        increase_balance(state, participant_index, participant_reward)
+//        increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
+func ProcessSyncCommittee(state iface.BeaconStateAltair, sync *ethpb.SyncAggregate) (iface.BeaconStateAltair, error) {
+	committeeIndices, err := SyncCommitteeIndices(state, helpers.CurrentEpoch(state))
+	if err != nil {
+		return nil, err
+	}
+	committeeKeys := state.CurrentSyncCommittee().Pubkeys
+	votedKeys := make([]bls.PublicKey, 0, len(committeeKeys))
+	votedIndices := make([]types.ValidatorIndex, 0, len(committeeKeys))
+	for i := uint64(0); i < sync.SyncCommitteeBits.Len(); i++ {
+		if sync.SyncCommitteeBits.BitAt(i) {
+			pubKey, err := bls.PublicKeyFromBytes(committeeKeys[i])
+			if err != nil {
+				return nil, err
+			}
+			votedKeys = append(votedKeys, pubKey)
+			votedIndices = append(votedIndices, committeeIndices[i])
+		}
+	}
+	ps := helpers.PrevSlot(state.Slot())
+	d, err := helpers.Domain(state.Fork(), helpers.SlotToEpoch(ps), params.BeaconConfig().DomainSyncCommittee, state.GenesisValidatorRoot())
+	if err != nil {
+		return nil, err
+	}
+	pbr, err := helpers.BlockRootAtSlot(state, ps)
+	if err != nil {
+		return nil, err
+	}
+	sszBytes := p2pType.SSZBytes(pbr)
+	r, err := helpers.ComputeSigningRoot(&sszBytes, d)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := bls.SignatureFromBytes(body.SyncCommitteeSignature)
+	if err != nil {
+		return nil, err
+	}
+	if !sig.FastAggregateVerify(votedKeys, r) {
+		return nil, errors.New("could not verify sync committee signature")
+	}
+
+	proposerRewards := uint64(0)
+	aCount, err := helpers.ActiveValidatorCount(state, helpers.CurrentEpoch(state))
+	if err != nil {
+		return nil, err
+	}
+	for _, index := range votedIndices {
+		br, err := epoch.BaseReward(state, index)
+		if err != nil {
+			return nil, err
+		}
+		proposerReward := br / params.BeaconConfig().ProposerRewardQuotient
+		maxReward := br - proposerReward
+		r := maxReward * aCount / uint64(len(committeeIndices)) / uint64(params.BeaconConfig().SlotsPerEpoch)
+		if err := helpers.IncreaseBalance(state, index, r); err != nil {
+			return nil, err
+		}
+		proposerRewards += proposerReward
+	}
+	proposerIndex, err := helpers.BeaconProposerIndex(state)
+	if err != nil {
+		return nil, err
+	}
+	if err := helpers.IncreaseBalance(state, proposerIndex, proposerRewards); err != nil {
+		return nil, err
+	}
+	return state, nil
+}

--- a/beacon-chain/core/altair/block.go
+++ b/beacon-chain/core/altair/block.go
@@ -116,6 +116,8 @@ func ProcessSyncCommittee(state iface.BeaconStateAltair, sync *ethpb.SyncAggrega
 	return state, nil
 }
 
+// This returns the base reward per increment for the beacon state.
+//
 // def get_base_reward_per_increment(state: BeaconState) -> Gwei:
 //    return Gwei(EFFECTIVE_BALANCE_INCREMENT * BASE_REWARD_FACTOR // integer_squareroot(get_total_active_balance(state))
 func baseRewardPerIncrement(activeBalance uint64) uint64 {

--- a/beacon-chain/core/altair/block_test.go
+++ b/beacon-chain/core/altair/block_test.go
@@ -26,7 +26,6 @@ func TestProcessSyncCommittee_OK(t *testing.T) {
 	for i := range syncBits {
 		syncBits[i] = 0xff
 	}
-	beaconState.RotateAttestations()
 	indices, err := altair.SyncCommitteeIndices(beaconState, helpers.CurrentEpoch(beaconState))
 	require.NoError(t, err)
 	ps := helpers.PrevSlot(beaconState.Slot())

--- a/beacon-chain/core/altair/block_test.go
+++ b/beacon-chain/core/altair/block_test.go
@@ -1,0 +1,91 @@
+package altair_test
+
+import (
+	"testing"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	p2pType "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
+	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	altairTest "github.com/prysmaticlabs/prysm/shared/testutil/altair"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestProcessSyncCommittee_OK(t *testing.T) {
+	beaconState, privKeys := altairTest.DeterministicGenesisStateAltair(t, params.BeaconConfig().MaxValidatorsPerCommittee)
+	require.NoError(t, beaconState.SetSlot(1))
+	committee, err := altair.SyncCommittee(beaconState, helpers.CurrentEpoch(beaconState))
+	require.NoError(t, err)
+	require.NoError(t, beaconState.SetCurrentSyncCommittee(committee))
+
+	syncBits := bitfield.NewBitvector1024()
+	for i := range syncBits {
+		syncBits[i] = 0xff
+	}
+	beaconState.RotateAttestations()
+	indices, err := altair.SyncCommitteeIndices(beaconState, helpers.CurrentEpoch(beaconState))
+	require.NoError(t, err)
+	ps := helpers.PrevSlot(beaconState.Slot())
+	pbr, err := helpers.BlockRootAtSlot(beaconState, ps)
+	require.NoError(t, err)
+	sigs := make([]bls.Signature, len(indices))
+	for i, indice := range indices {
+		b := p2pType.SSZBytes(pbr)
+		sb, err := helpers.ComputeDomainAndSign(beaconState, helpers.CurrentEpoch(beaconState), &b, params.BeaconConfig().DomainSyncCommittee, privKeys[indice])
+		require.NoError(t, err)
+		sig, err := bls.SignatureFromBytes(sb)
+		require.NoError(t, err)
+		sigs[i] = sig
+	}
+	aggregatedSig := bls.AggregateSignatures(sigs).Marshal()
+	syncAggregate := &ethpb.SyncAggregate{
+		SyncCommitteeBits:      syncBits,
+		SyncCommitteeSignature: aggregatedSig,
+	}
+
+	beaconState, err = altair.ProcessSyncCommittee(beaconState, syncAggregate)
+	require.NoError(t, err)
+
+	// Use a non-sync committee index to compare profitability.
+	syncCommittee := make(map[types.ValidatorIndex]bool)
+	for _, index := range indices {
+		syncCommittee[index] = true
+	}
+	nonSyncIndex := types.ValidatorIndex(params.BeaconConfig().MaxValidatorsPerCommittee + 1)
+	for i := types.ValidatorIndex(0); uint64(i) < params.BeaconConfig().MaxValidatorsPerCommittee; i++ {
+		if !syncCommittee[i] {
+			nonSyncIndex = i
+			break
+		}
+	}
+
+	// Sync committee should be more profitable than non sync committee
+	balances := beaconState.Balances()
+	require.Equal(t, true, balances[indices[0]] > balances[nonSyncIndex])
+
+	// Proposer should be more profitable than rest of the sync committee
+	proposerIndex, err := helpers.BeaconProposerIndex(beaconState)
+	require.NoError(t, err)
+	require.Equal(t, true, balances[proposerIndex] > balances[indices[0]])
+
+	// Sync committee should have the same profits, except you are a proposer
+	for i := 1; i < len(indices); i++ {
+		if proposerIndex == indices[i-1] || proposerIndex == indices[i] {
+			continue
+		}
+		require.Equal(t, balances[indices[i-1]], balances[indices[i]])
+	}
+
+	// Increased balance validator count should equal to sync committee count
+	increased := uint64(0)
+	for _, balance := range balances {
+		if balance > params.BeaconConfig().MaxEffectiveBalance {
+			increased++
+		}
+	}
+	require.Equal(t, params.BeaconConfig().SyncCommitteeSize, increased)
+}

--- a/beacon-chain/core/helpers/slot_epoch.go
+++ b/beacon-chain/core/helpers/slot_epoch.go
@@ -193,3 +193,11 @@ func VotingPeriodStartTime(genesis uint64, slot types.Slot) uint64 {
 	startTime := uint64((slot - slot.ModSlot(slots)).Mul(params.BeaconConfig().SecondsPerSlot))
 	return genesis + startTime
 }
+
+// PrevSlot returns previous slot, with an exception in slot 0 to prevent underflow.
+func PrevSlot(slot types.Slot) types.Slot {
+	if slot > 0 {
+		return slot.Sub(1)
+	}
+	return 0
+}

--- a/beacon-chain/core/helpers/slot_epoch_test.go
+++ b/beacon-chain/core/helpers/slot_epoch_test.go
@@ -345,3 +345,39 @@ func TestValidateSlotClock_HandlesBadSlot(t *testing.T) {
 	assert.ErrorContains(t, "which exceeds max allowed value relative to the local clock", ValidateSlotClock(types.Slot(2*MaxSlotBuffer+1), uint64(genTime)), "no error from bad slot")
 	assert.ErrorContains(t, "which exceeds max allowed value relative to the local clock", ValidateSlotClock(1<<63, uint64(genTime)), "no error from bad slot")
 }
+
+func TestPrevSlot(t *testing.T) {
+	tests := []struct {
+		name string
+		slot types.Slot
+		want types.Slot
+	}{
+		{
+			name: "no underflow",
+			slot: 0,
+			want: 0,
+		},
+		{
+			name: "slot 1",
+			slot: 1,
+			want: 0,
+		},
+		{
+			name: "slot 2",
+			slot: 2,
+			want: 1,
+		},
+		{
+			name: "max",
+			slot: 1<<64 - 1,
+			want: 1<<64 - 1 - 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := PrevSlot(tt.slot); got != tt.want {
+				t.Errorf("PrevSlot() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/beacon-chain/rpc/beaconv1/config_test.go
+++ b/beacon-chain/rpc/beaconv1/config_test.go
@@ -114,7 +114,7 @@ func TestGetSpec(t *testing.T) {
 	resp, err := server.GetSpec(context.Background(), &pbtypes.Empty{})
 	require.NoError(t, err)
 
-	assert.Equal(t, 80, len(resp.Data))
+	assert.Equal(t, 81, len(resp.Data))
 	for k, v := range resp.Data {
 		switch k {
 		case "config_name":
@@ -263,6 +263,8 @@ func TestGetSpec(t *testing.T) {
 			assert.Equal(t, "68", v)
 		case "proportional_slashing_multiplier_altair":
 			assert.Equal(t, "69", v)
+		case "proposer_weight":
+			assert.Equal(t, "8", v)
 		case "domain_beacon_proposer":
 			assert.Equal(t, "0x30303031", v)
 		case "domain_beacon_attester":

--- a/beacon-chain/state/interface/altair.go
+++ b/beacon-chain/state/interface/altair.go
@@ -5,7 +5,8 @@ import pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 // BeaconStateAltair has read and write access to beacon state methods.
 type BeaconStateAltair interface {
 	BeaconState
-	CurrentSyncCommittee() *pbp2p.SyncCommittee
+	CurrentSyncCommittee() (*pbp2p.SyncCommittee, error)
+	SetCurrentSyncCommittee(val *pbp2p.SyncCommittee) error
 	CurrentEpochParticipation() ([]byte, error)
 	PreviousEpochParticipation() ([]byte, error)
 	InactivityScores() ([]uint64, error)

--- a/beacon-chain/state/interface/altair.go
+++ b/beacon-chain/state/interface/altair.go
@@ -1,8 +1,11 @@
 package iface
 
+import pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+
 // BeaconStateAltair has read and write access to beacon state methods.
 type BeaconStateAltair interface {
 	BeaconState
+	CurrentSyncCommittee() *pbp2p.SyncCommittee
 	CurrentEpochParticipation() ([]byte, error)
 	PreviousEpochParticipation() ([]byte, error)
 	InactivityScores() ([]uint64, error)

--- a/beacon-chain/state/interface/phase0.go
+++ b/beacon-chain/state/interface/phase0.go
@@ -206,4 +206,6 @@ type FutureForkStub interface {
 	CurrentEpochParticipation() ([]byte, error)
 	PreviousEpochParticipation() ([]byte, error)
 	InactivityScores() ([]uint64, error)
+	CurrentSyncCommittee() (*pbp2p.SyncCommittee, error)
+	SetCurrentSyncCommittee(val *pbp2p.SyncCommittee) error
 }

--- a/beacon-chain/state/state-altair/getters.go
+++ b/beacon-chain/state/state-altair/getters.go
@@ -993,35 +993,35 @@ func (b *BeaconState) nextSyncCommittee() *pbp2p.SyncCommittee {
 }
 
 // CurrentSyncCommittee of the current sync committee in beacon chain state.
-func (b *BeaconState) CurrentSyncCommittee() *pbp2p.SyncCommittee {
+func (b *BeaconState) CurrentSyncCommittee() (*pbp2p.SyncCommittee, error) {
 	if !b.hasInnerState() {
-		return nil
+		return nil, nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
 	if b.state.CurrentSyncCommittee == nil {
-		return nil
+		return nil, nil
 	}
 
-	return b.currentSyncCommittee()
+	return b.currentSyncCommittee(), nil
 }
 
 // NextSyncCommittee of the next sync committee in beacon chain state.
-func (b *BeaconState) NextSyncCommittee() *pbp2p.SyncCommittee {
+func (b *BeaconState) NextSyncCommittee() (*pbp2p.SyncCommittee, error) {
 	if !b.hasInnerState() {
-		return nil
+		return nil, nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
 	if b.state.NextSyncCommittee == nil {
-		return nil
+		return nil, nil
 	}
 
-	return b.nextSyncCommittee()
+	return b.nextSyncCommittee(), nil
 }
 
 // CurrentEpochParticipation corresponding to participation bits on the beacon chain.

--- a/beacon-chain/state/state-altair/getters_test.go
+++ b/beacon-chain/state/state-altair/getters_test.go
@@ -83,8 +83,10 @@ func TestNilState_NoPanic(t *testing.T) {
 	_ = err
 	_, err = st.InactivityScores()
 	_ = err
-	_ = st.CurrentSyncCommittee()
-	_ = st.NextSyncCommittee()
+	_, err = st.CurrentSyncCommittee()
+	_ = err
+	_, err = st.NextSyncCommittee()
+	_ = err
 }
 
 func TestReadOnlyValidator_NoPanic(t *testing.T) {

--- a/beacon-chain/state/state-altair/state_trie.go
+++ b/beacon-chain/state/state-altair/state_trie.go
@@ -78,6 +78,7 @@ func (b *BeaconState) Copy() iface.BeaconState {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 	fieldCount := params.BeaconConfig().BeaconStateAltairFieldCount
+
 	dst := &BeaconState{
 		state: &pbp2p.BeaconStateAltair{
 			// Primitive types, safe to copy.
@@ -109,8 +110,8 @@ func (b *BeaconState) Copy() iface.BeaconState {
 			CurrentJustifiedCheckpoint:  b.currentJustifiedCheckpoint(),
 			FinalizedCheckpoint:         b.finalizedCheckpoint(),
 			GenesisValidatorsRoot:       b.genesisValidatorRoot(),
-			CurrentSyncCommittee:        b.CurrentSyncCommittee(),
-			NextSyncCommittee:           b.NextSyncCommittee(),
+			CurrentSyncCommittee:        b.currentSyncCommittee(),
+			NextSyncCommittee:           b.nextSyncCommittee(),
 		},
 		dirtyFields:           make(map[fieldIndex]interface{}, fieldCount),
 		dirtyIndices:          make(map[fieldIndex][]uint64, fieldCount),

--- a/beacon-chain/state/stateV0/unsupported_getters.go
+++ b/beacon-chain/state/stateV0/unsupported_getters.go
@@ -2,6 +2,7 @@ package stateV0
 
 import (
 	"github.com/pkg/errors"
+	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 
 // CurrentEpochParticipation is not supported for HF1 beacon state.
@@ -17,4 +18,9 @@ func (b *BeaconState) PreviousEpochParticipation() ([]byte, error) {
 // InactivityScores is not supported for HF1 beacon state.
 func (b *BeaconState) InactivityScores() ([]uint64, error) {
 	return nil, errors.New("InactivityScores is not supported for hard fork 1 beacon state")
+}
+
+// CurrentSyncCommittee is not supported for HF1 beacon state.
+func (b *BeaconState) CurrentSyncCommittee() (*pbp2p.SyncCommittee, error) {
+	return nil, errors.New("CurrentSyncCommittee is not supported for hard fork 1 beacon state")
 }

--- a/beacon-chain/state/stateV0/unsupported_setters.go
+++ b/beacon-chain/state/stateV0/unsupported_setters.go
@@ -2,6 +2,7 @@ package stateV0
 
 import (
 	"github.com/pkg/errors"
+	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 
 // AppendCurrentParticipationBits is not supported for phase 0 beacon state.
@@ -17,4 +18,9 @@ func (b *BeaconState) AppendPreviousParticipationBits(val byte) error {
 // AppendInactivityScore is not supported for phase 0 beacon state.
 func (b *BeaconState) AppendInactivityScore(s uint64) error {
 	return errors.New("AppendInactivityScore is not supported for phase 0 beacon state")
+}
+
+// SetCurrentSyncCommittee is not supported for phase 0 beacon state.
+func (b *BeaconState) SetCurrentSyncCommittee(val *pbp2p.SyncCommittee) error {
+	return errors.New("SetCurrentSyncCommittee is not supported for phase 0 beacon state")
 }

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -146,6 +146,7 @@ type BeaconChainConfig struct {
 	TimelyTargetWeight uint64 `yaml:"TIMELY_TARGET_WEIGHT" spec:"true"` // TimelyTargetWeight for rewards and penalties.
 	SyncRewardWeight   uint64 `yaml:"SYNC_REWARD_WEIGHT" spec:"true"`   // SyncRewardWeight for rewards and penalties.
 	WeightDenominator  uint64 `yaml:"WEIGHT_DENOMINATOR" spec:"true"`   // WeightDenominator for rewards and penalties.
+	ProposerWeight     uint64 `yaml:"PROPOSER_WEIGHT" spec:"true"`      // ProposerWeight for rewards and penalties.
 
 	// Validator related.
 	TargetAggregatorsPerSyncSubcommittee uint64 `yaml:"TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE" spec:"true"` // TargetAggregatorsPerSyncSubcommittee for aggregating in sync committee.

--- a/shared/params/mainnet_config.go
+++ b/shared/params/mainnet_config.go
@@ -193,6 +193,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	TimelySourceWeight: 12,
 	TimelyTargetWeight: 24,
 	SyncRewardWeight:   8,
+	ProposerWeight:     8,
 	WeightDenominator:  64,
 
 	// Validator related values.


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

Add process sync committee for beacon block for Altair:

```python
def process_sync_committee(state: BeaconState, aggregate: SyncAggregate) -> None:
    # Verify sync committee aggregate signature signing over the previous slot block root
    committee_pubkeys = state.current_sync_committee.pubkeys
    participant_pubkeys = [pubkey for pubkey, bit in zip(committee_pubkeys, aggregate.sync_committee_bits) if bit]
    previous_slot = max(state.slot, Slot(1)) - Slot(1)
    domain = get_domain(state, DOMAIN_SYNC_COMMITTEE, compute_epoch_at_slot(previous_slot))
    signing_root = compute_signing_root(get_block_root_at_slot(state, previous_slot), domain)
    assert eth2_fast_aggregate_verify(participant_pubkeys, signing_root, aggregate.sync_committee_signature)

    # Compute participant and proposer rewards
    total_active_increments = get_total_active_balance(state) // EFFECTIVE_BALANCE_INCREMENT
    total_base_rewards = Gwei(get_base_reward_per_increment(state) * total_active_increments)
    max_participant_rewards = Gwei(total_base_rewards * SYNC_REWARD_WEIGHT // WEIGHT_DENOMINATOR // SLOTS_PER_EPOCH)
    participant_reward = Gwei(max_participant_rewards // SYNC_COMMITTEE_SIZE)
    proposer_reward = Gwei(participant_reward * PROPOSER_WEIGHT // (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT))

    # Apply participant and proposer rewards
    committee_indices = get_sync_committee_indices(state, get_current_epoch(state))
    participant_indices = [index for index, bit in zip(committee_indices, aggregate.sync_committee_bits) if bit]
    for participant_index in participant_indices:
        increase_balance(state, participant_index, participant_reward)
        increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
```

https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#sync-committee-processing

**Which issues(s) does this PR fix?**

Part of #8638 

**Other notes for review**
