### PR TITLE
Save Attestations in Slasher's History During Remote Protection

### DIFF
--- a/beacon-chain/slasher/rpc.go
+++ b/beacon-chain/slasher/rpc.go
@@ -52,7 +52,8 @@ func (s *Service) IsSlashableAttestation(
 		return nil, status.Errorf(codes.Internal, "Could not check if attestation is slashable: %v", err)
 	}
 	if len(attesterSlashings) == 0 {
-		// Save the attestation record to our database.
+		// If the incoming attestations are not slashable, we mark them as saved in
+		// slasher's DB storage to help us with future detection.
 		if err := s.serviceCfg.Database.SaveAttestationRecordsForValidators(
 			ctx, []*slashertypes.IndexedAttestationWrapper{indexedAttWrapper}, s.params.historyLength,
 		); err != nil {

--- a/beacon-chain/slasher/rpc.go
+++ b/beacon-chain/slasher/rpc.go
@@ -47,18 +47,17 @@ func (s *Service) IsSlashableAttestation(
 		SigningRoot:        dataRoot,
 	}
 
-	// Save the attestation record to our database.
-	if err := s.serviceCfg.Database.SaveAttestationRecordsForValidators(
-		ctx, []*slashertypes.IndexedAttestationWrapper{indexedAttWrapper}, s.params.historyLength,
-	); err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not save attestation records to DB: %v", err)
-	}
-
 	attesterSlashings, err := s.checkSlashableAttestations(ctx, []*slashertypes.IndexedAttestationWrapper{indexedAttWrapper})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not check if attestation is slashable: %v", err)
 	}
 	if len(attesterSlashings) == 0 {
+		// Save the attestation record to our database.
+		if err := s.serviceCfg.Database.SaveAttestationRecordsForValidators(
+			ctx, []*slashertypes.IndexedAttestationWrapper{indexedAttWrapper}, s.params.historyLength,
+		); err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not save attestation records to DB: %v", err)
+		}
 		return nil, nil
 	}
 	return attesterSlashings, nil

--- a/beacon-chain/slasher/rpc.go
+++ b/beacon-chain/slasher/rpc.go
@@ -46,6 +46,14 @@ func (s *Service) IsSlashableAttestation(
 		IndexedAttestation: attestation,
 		SigningRoot:        dataRoot,
 	}
+
+	// Save the attestation record to our database.
+	if err := s.serviceCfg.Database.SaveAttestationRecordsForValidators(
+		ctx, []*slashertypes.IndexedAttestationWrapper{indexedAttWrapper}, s.params.historyLength,
+	); err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not save attestation records to DB: %v", err)
+	}
+
 	attesterSlashings, err := s.checkSlashableAttestations(ctx, []*slashertypes.IndexedAttestationWrapper{indexedAttWrapper})
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not check if attestation is slashable: %v", err)


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Currently, using remote slashing protection for attestations does not save the attestations it receives in slasher's history. This means remote slashing protection is pointless because it will not be able to check an incoming, *slashable* attestation is slashable with respect to a previous attestation slasher has seen.

Even with this change, any found slashings by remote slashing protection **will not** be forward to the operations pool. We do not want to slash our own validator.

**Which issues(s) does this PR fix?**

Part of #8331 