### PR TITLE
Altair: Process sync committee updates for epoch transition

### DIFF
--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "block.go",
         "deposit.go",
+        "epoch.go",
         "state.go",
         "sync_committee.go",
     ],
@@ -40,6 +41,7 @@ go_test(
         "block_test.go",
         "deposit_fuzz_test.go",
         "deposit_test.go",
+        "epoch_test.go",
         "state_fuzz_test.go",
         "state_test.go",
         "sync_committee_test.go",

--- a/beacon-chain/core/altair/epoch.go
+++ b/beacon-chain/core/altair/epoch.go
@@ -1,0 +1,36 @@
+package altair
+
+import (
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/params"
+)
+
+// ProcessSyncClientCommitteeUpdates processes sync client committee updates for the beacon state.
+//
+// Spec code:
+// def process_sync_committee_updates(state: BeaconState) -> None:
+//    next_epoch = get_current_epoch(state) + Epoch(1)
+//    if next_epoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0:
+//        state.current_sync_committee = state.next_sync_committee
+//        state.next_sync_committee = get_sync_committee(state, next_epoch + EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
+func ProcessSyncCommitteeUpdates(beaconState iface.BeaconStateAltair) (iface.BeaconStateAltair, error) {
+	nextEpoch := helpers.NextEpoch(beaconState)
+	if nextEpoch%params.BeaconConfig().EpochsPerSyncCommitteePeriod == 0 {
+		currentSyncCommittee, err := beaconState.NextSyncCommittee()
+		if err != nil {
+			return nil, err
+		}
+		if err := beaconState.SetCurrentSyncCommittee(currentSyncCommittee); err != nil {
+			return nil, err
+		}
+		nextCommittee, err := SyncCommittee(beaconState, helpers.CurrentEpoch(beaconState)+params.BeaconConfig().EpochsPerSyncCommitteePeriod)
+		if err != nil {
+			return nil, err
+		}
+		if err := beaconState.SetNextSyncCommittee(nextCommittee); err != nil {
+			return nil, err
+		}
+	}
+	return beaconState, nil
+}

--- a/beacon-chain/core/altair/epoch_test.go
+++ b/beacon-chain/core/altair/epoch_test.go
@@ -1,0 +1,43 @@
+package altair_test
+
+import (
+	"testing"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	altairState "github.com/prysmaticlabs/prysm/shared/testutil/altair"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestProcessSyncCommitteeUpdates_CanRotate(t *testing.T) {
+	s, _ := altairState.DeterministicGenesisStateAltair(t, params.BeaconConfig().MaxValidatorsPerCommittee)
+	postState, err := altair.ProcessSyncCommitteeUpdates(s)
+	require.NoError(t, err)
+	current, err := postState.CurrentSyncCommittee()
+	require.NoError(t, err)
+	next, err := postState.NextSyncCommittee()
+	require.NoError(t, err)
+	require.DeepEqual(t, current, next)
+
+	require.NoError(t, s.SetSlot(params.BeaconConfig().SlotsPerEpoch))
+	postState, err = altair.ProcessSyncCommitteeUpdates(s)
+	require.NoError(t, err)
+	c, err := postState.CurrentSyncCommittee()
+	require.NoError(t, err)
+	n, err := postState.NextSyncCommittee()
+	require.NoError(t, err)
+	require.DeepEqual(t, current, c)
+	require.DeepEqual(t, next, n)
+
+	require.NoError(t, s.SetSlot(types.Slot(params.BeaconConfig().EpochsPerSyncCommitteePeriod)*params.BeaconConfig().SlotsPerEpoch-1))
+	postState, err = altair.ProcessSyncCommitteeUpdates(s)
+	require.NoError(t, err)
+	c, err = postState.CurrentSyncCommittee()
+	require.NoError(t, err)
+	n, err = postState.NextSyncCommittee()
+	require.NoError(t, err)
+	require.NotEqual(t, current, c)
+	require.NotEqual(t, next, c)
+	require.DeepEqual(t, next, c)
+}

--- a/beacon-chain/state/interface/altair.go
+++ b/beacon-chain/state/interface/altair.go
@@ -6,7 +6,9 @@ import pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 type BeaconStateAltair interface {
 	BeaconState
 	CurrentSyncCommittee() (*pbp2p.SyncCommittee, error)
+	NextSyncCommittee() (*pbp2p.SyncCommittee, error)
 	SetCurrentSyncCommittee(val *pbp2p.SyncCommittee) error
+	SetNextSyncCommittee(val *pbp2p.SyncCommittee) error
 	CurrentEpochParticipation() ([]byte, error)
 	PreviousEpochParticipation() ([]byte, error)
 	InactivityScores() ([]uint64, error)

--- a/beacon-chain/state/interface/phase0.go
+++ b/beacon-chain/state/interface/phase0.go
@@ -208,4 +208,6 @@ type FutureForkStub interface {
 	InactivityScores() ([]uint64, error)
 	CurrentSyncCommittee() (*pbp2p.SyncCommittee, error)
 	SetCurrentSyncCommittee(val *pbp2p.SyncCommittee) error
+	NextSyncCommittee() (*pbp2p.SyncCommittee, error)
+	SetNextSyncCommittee(val *pbp2p.SyncCommittee) error
 }

--- a/beacon-chain/state/stateV0/unsupported_getters.go
+++ b/beacon-chain/state/stateV0/unsupported_getters.go
@@ -5,22 +5,27 @@ import (
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 )
 
-// CurrentEpochParticipation is not supported for HF1 beacon state.
+// CurrentEpochParticipation is not supported for phase 0 beacon state.
 func (b *BeaconState) CurrentEpochParticipation() ([]byte, error) {
-	return nil, errors.New("CurrentEpochParticipation is not supported for hard fork 1 beacon state")
+	return nil, errors.New("CurrentEpochParticipation is not supported for phase 0 beacon state")
 }
 
-// PreviousEpochParticipation is not supported for HF1 beacon state.
+// PreviousEpochParticipation is not supported for phase 0 beacon state.
 func (b *BeaconState) PreviousEpochParticipation() ([]byte, error) {
-	return nil, errors.New("PreviousEpochParticipation is not supported for hard fork 1 beacon state")
+	return nil, errors.New("PreviousEpochParticipation is not supported for phase 0 beacon state")
 }
 
-// InactivityScores is not supported for HF1 beacon state.
+// InactivityScores is not supported for phase 0 beacon state.
 func (b *BeaconState) InactivityScores() ([]uint64, error) {
-	return nil, errors.New("InactivityScores is not supported for hard fork 1 beacon state")
+	return nil, errors.New("InactivityScores is not supported for phase 0 beacon state")
 }
 
-// CurrentSyncCommittee is not supported for HF1 beacon state.
+// CurrentSyncCommittee is not supported for phase 0 beacon state.
 func (b *BeaconState) CurrentSyncCommittee() (*pbp2p.SyncCommittee, error) {
-	return nil, errors.New("CurrentSyncCommittee is not supported for hard fork 1 beacon state")
+	return nil, errors.New("CurrentSyncCommittee is not supported for phase 0 beacon state")
+}
+
+// NextSyncCommittee is not supported for phase 0 beacon state.
+func (b *BeaconState) NextSyncCommittee() (*pbp2p.SyncCommittee, error) {
+	return nil, errors.New("NextSyncCommittee is not supported for phase 0 beacon state")
 }

--- a/beacon-chain/state/stateV0/unsupported_setters.go
+++ b/beacon-chain/state/stateV0/unsupported_setters.go
@@ -24,3 +24,8 @@ func (b *BeaconState) AppendInactivityScore(s uint64) error {
 func (b *BeaconState) SetCurrentSyncCommittee(val *pbp2p.SyncCommittee) error {
 	return errors.New("SetCurrentSyncCommittee is not supported for phase 0 beacon state")
 }
+
+// SetNextSyncCommittee is not supported for phase 0 beacon state.
+func (b *BeaconState) SetNextSyncCommittee(val *pbp2p.SyncCommittee) error {
+	return errors.New("SetNextSyncCommittee is not supported for phase 0 beacon state")
+}


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

Add process sync committees update for epoch transition in Altair:

```python
def process_sync_committee_updates(state: BeaconState) -> None:
    next_epoch = get_current_epoch(state) + Epoch(1)
    if next_epoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD == 0:
        state.current_sync_committee = state.next_sync_committee
        state.next_sync_committee = get_sync_committee(state, next_epoch + EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
```
https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#sync-committee-updates

**Which issues(s) does this PR fix?**

Part of #8638 

**Other notes for review**
