### PR TITLE
Altair: process attestation for block

### DIFF
--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -4,6 +4,7 @@ load("@prysm//tools/go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "attestation.go",
         "block.go",
         "deposit.go",
         "state.go",
@@ -16,6 +17,7 @@ go_library(
     ],
     deps = [
         "//beacon-chain/core/blocks:go_default_library",
+        "//beacon-chain/core/epoch:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/p2p/types:go_default_library",
@@ -23,6 +25,7 @@ go_library(
         "//beacon-chain/state/state-altair:go_default_library",
         "//beacon-chain/state/stateV0:go_default_library",
         "//proto/beacon/p2p/v1:go_default_library",
+        "//shared/attestationutil:go_default_library",
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/hashutil:go_default_library",
@@ -31,6 +34,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/altair/attestation.go
+++ b/beacon-chain/core/altair/attestation.go
@@ -208,22 +208,21 @@ func ProcessAttestationNoVerifySignature(
 }
 
 // This returns the matching statues for attestation data's source target and head.
-func matchingStatus(beaconState iface.BeaconState, data *ethpb.AttestationData, cp *ethpb.Checkpoint) (matchingSource, matchingTarget, matchingHead, error) {
-	s := attestationutil.CheckPointIsEqual(data.Source, cp)
+func matchingStatus(beaconState iface.BeaconState, data *ethpb.AttestationData, cp *ethpb.Checkpoint) (s matchingSource, t matchingTarget, h matchingHead, err error) {
+	s = matchingSource(attestationutil.CheckPointIsEqual(data.Source, cp))
 
 	r, err := helpers.BlockRoot(beaconState, data.Target.Epoch)
 	if err != nil {
 		return false, false, false, err
 	}
-	t := bytes.Equal(r, data.Target.Root)
+	t = matchingTarget(bytes.Equal(r, data.Target.Root))
 
 	r, err = helpers.BlockRootAtSlot(beaconState, data.Slot)
 	if err != nil {
 		return false, false, false, err
 	}
-	h := bytes.Equal(r, data.BeaconBlockRoot)
-
-	return matchingSource(s), matchingTarget(t), matchingHead(h), nil
+	h = matchingHead(bytes.Equal(r, data.BeaconBlockRoot))
+	return
 }
 
 // This rewards proposer by increasing proposer's balance with input reward numerator and calculated reward denominator.

--- a/beacon-chain/core/altair/attestation.go
+++ b/beacon-chain/core/altair/attestation.go
@@ -1,0 +1,251 @@
+package altair
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/pkg/errors"
+	types "github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/epoch"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/attestationutil"
+	"github.com/prysmaticlabs/prysm/shared/mathutil"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"go.opencensus.io/trace"
+)
+
+type matchingTarget bool
+type matchingSource bool
+type matchingHead bool
+
+// ProcessAttestations applies processing operations to a block's inner attestation
+// records.
+func ProcessAttestations(
+	ctx context.Context,
+	beaconState iface.BeaconState,
+	b *ethpb.SignedBeaconBlock,
+) (iface.BeaconState, error) {
+	if err := helpers.VerifyNilBeaconBlock(b); err != nil {
+		return nil, err
+	}
+
+	var err error
+	for idx, attestation := range b.Block.Body.Attestations {
+		beaconState, err = ProcessAttestation(ctx, beaconState, attestation)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not verify attestation at index %d in block", idx)
+		}
+	}
+	return beaconState, nil
+}
+
+// ProcessAttestation verifies an input attestation can pass through processing using the given beacon state.
+//
+// Spec code:
+//  def process_attestation(state: BeaconState, attestation: Attestation) -> None:
+//    data = attestation.data
+//    assert data.target.epoch in (get_previous_epoch(state), get_current_epoch(state))
+//    assert data.target.epoch == compute_epoch_at_slot(data.slot)
+//    assert data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot <= data.slot + SLOTS_PER_EPOCH
+//    assert data.index < get_committee_count_per_slot(state, data.target.epoch)
+//
+//    committee = get_beacon_committee(state, data.slot, data.index)
+//    assert len(attestation.aggregation_bits) == len(committee)
+//
+//    if data.target.epoch == get_current_epoch(state):
+//        epoch_participation = state.current_epoch_participation
+//        justified_checkpoint = state.current_justified_checkpoint
+//    else:
+//        epoch_participation = state.previous_epoch_participation
+//        justified_checkpoint = state.previous_justified_checkpoint
+//
+//    # Matching roots
+//    is_matching_head = data.beacon_block_root == get_block_root_at_slot(state, data.slot)
+//    is_matching_source = data.source == justified_checkpoint
+//    is_matching_target = data.target.root == get_block_root(state, data.target.epoch)
+//    assert is_matching_source
+//
+//    # Verify signature
+//    assert is_valid_indexed_attestation(state, get_indexed_attestation(state, attestation))
+//
+//    # Participation flag indices
+//    participation_flag_indices = []
+//    if is_matching_head and is_matching_target and state.slot == data.slot + MIN_ATTESTATION_INCLUSION_DELAY:
+//        participation_flag_indices.append(TIMELY_HEAD_FLAG_INDEX)
+//    if is_matching_source and state.slot <= data.slot + integer_squareroot(SLOTS_PER_EPOCH):
+//        participation_flag_indices.append(TIMELY_SOURCE_FLAG_INDEX)
+//    if is_matching_target and state.slot <= data.slot + SLOTS_PER_EPOCH:
+//        participation_flag_indices.append(TIMELY_TARGET_FLAG_INDEX)
+//
+//    # Update epoch participation flags
+//    proposer_reward_numerator = 0
+//    for index in get_attesting_indices(state, data, attestation.aggregation_bits):
+//        for flag_index, weight in get_flag_indices_and_weights():
+//            if flag_index in participation_flag_indices and not has_flag(epoch_participation[index], flag_index):
+//                epoch_participation[index] = add_flag(epoch_participation[index], flag_index)
+//                proposer_reward_numerator += get_base_reward(state, index) * weight
+//
+//    # Reward proposer
+//    proposer_reward_denominator = (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT) * WEIGHT_DENOMINATOR // PROPOSER_WEIGHT
+//    proposer_reward = Gwei(proposer_reward_numerator // proposer_reward_denominator)
+//    increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
+func ProcessAttestation(
+	ctx context.Context,
+	beaconState iface.BeaconStateAltair,
+	att *ethpb.Attestation,
+) (iface.BeaconStateAltair, error) {
+	beaconState, err := ProcessAttestationNoVerifySignature(ctx, beaconState, att)
+	if err != nil {
+		return nil, err
+	}
+	return beaconState, blocks.VerifyAttestationSignature(ctx, beaconState, att)
+}
+
+// ProcessAttestationNoVerifySignature processes the attestation without verifying the attestation signature. This
+// method is used to validate attestations whose signatures have already been verified or will be verified later.
+func ProcessAttestationNoVerifySignature(
+	ctx context.Context,
+	beaconState iface.BeaconStateAltair,
+	att *ethpb.Attestation,
+) (iface.BeaconStateAltair, error) {
+	ctx, span := trace.StartSpan(ctx, "core.ProcessAttestationNoVerifySignature")
+	defer span.End()
+
+	if err := blocks.VerifyAttestationNoVerifySignature(ctx, beaconState, att); err != nil {
+		return nil, err
+	}
+
+	currEpoch := helpers.CurrentEpoch(beaconState)
+	data := att.Data
+	var justifiedCheckpt *ethpb.Checkpoint
+	var epochParticipation []byte
+	var err error
+	if data.Target.Epoch == currEpoch {
+		justifiedCheckpt = beaconState.CurrentJustifiedCheckpoint()
+		epochParticipation, err = beaconState.CurrentEpochParticipation()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		justifiedCheckpt = beaconState.PreviousJustifiedCheckpoint()
+		epochParticipation, err = beaconState.PreviousEpochParticipation()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Get matching participation flags.
+	matchingSource, matchingTarget, matchingHead, err := matchingStatus(beaconState, data, justifiedCheckpt)
+	if err != nil {
+		return nil, err
+	}
+	if !matchingSource {
+		return nil, errors.New("source epoch does not match")
+	}
+
+	// Process matched participation flags.
+	participatedFlags := make(map[uint8]bool)
+	headFlagIndex := params.BeaconConfig().TimelyHeadFlagIndex
+	sourceFlagIndex := params.BeaconConfig().TimelySourceFlagIndex
+	targetFlagIndex := params.BeaconConfig().TimelyTargetFlagIndex
+	matchingSourceTarget := bool(matchingHead) && bool(matchingTarget)
+	if matchingSourceTarget && beaconState.Slot() == data.Slot+params.BeaconConfig().MinAttestationInclusionDelay {
+		participatedFlags[headFlagIndex] = true
+	}
+	if matchingSource && beaconState.Slot() <= data.Slot.Add(mathutil.IntegerSquareRoot(uint64(params.BeaconConfig().SlotsPerEpoch))) {
+		participatedFlags[sourceFlagIndex] = true
+	}
+	if matchingTarget && beaconState.Slot() <= data.Slot+params.BeaconConfig().SlotsPerEpoch {
+		participatedFlags[targetFlagIndex] = true
+	}
+
+	committee, err := helpers.BeaconCommitteeFromState(beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+	if err != nil {
+		return nil, err
+	}
+	indices, err := attestationutil.AttestingIndices(att.AggregationBits, committee)
+	if err != nil {
+		return nil, err
+	}
+	proposerRewardNumerator := uint64(0)
+	for _, index := range indices {
+		br, err := epoch.BaseReward(beaconState, types.ValidatorIndex(index))
+		if err != nil {
+			return nil, err
+		}
+		if participatedFlags[headFlagIndex] && !HasValidatorFlag(epochParticipation[index], headFlagIndex) {
+			epochParticipation[index] = AddValidatorFlag(epochParticipation[index], headFlagIndex)
+			proposerRewardNumerator += br * params.BeaconConfig().TimelyHeadWeight
+		}
+		if participatedFlags[sourceFlagIndex] && !HasValidatorFlag(epochParticipation[index], sourceFlagIndex) {
+			epochParticipation[index] = AddValidatorFlag(epochParticipation[index], sourceFlagIndex)
+			proposerRewardNumerator += br * params.BeaconConfig().TimelySourceWeight
+		}
+		if participatedFlags[targetFlagIndex] && !HasValidatorFlag(epochParticipation[index], targetFlagIndex) {
+			epochParticipation[index] = AddValidatorFlag(epochParticipation[index], targetFlagIndex)
+			proposerRewardNumerator += br * params.BeaconConfig().TimelyTargetWeight
+		}
+	}
+
+	if data.Target.Epoch == currEpoch {
+		if err := beaconState.SetCurrentParticipationBits(epochParticipation); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := beaconState.SetPreviousParticipationBits(epochParticipation); err != nil {
+			return nil, err
+		}
+	}
+
+	// Reward proposer.
+	if err := rewardProposer(beaconState, proposerRewardNumerator); err != nil {
+		return nil, err
+	}
+	return beaconState, nil
+}
+
+// This returns the matching statues for attestation data's source target and head.
+func matchingStatus(beaconState iface.BeaconState, data *ethpb.AttestationData, cp *ethpb.Checkpoint) (matchingSource, matchingTarget, matchingHead, error) {
+	s := attestationutil.CheckPointIsEqual(data.Source, cp)
+
+	r, err := helpers.BlockRoot(beaconState, data.Target.Epoch)
+	if err != nil {
+		return false, false, false, err
+	}
+	t := bytes.Equal(r, data.Target.Root)
+
+	r, err = helpers.BlockRootAtSlot(beaconState, data.Slot)
+	if err != nil {
+		return false, false, false, err
+	}
+	h := bytes.Equal(r, data.BeaconBlockRoot)
+
+	return matchingSource(s), matchingTarget(t), matchingHead(h), nil
+}
+
+// This rewards proposer by increasing proposer's balance with input reward numerator and calculated reward denominator.
+func rewardProposer(beaconState iface.BeaconState, proposerRewardNumerator uint64) error {
+	proposerRewardDenominator := (params.BeaconConfig().WeightDenominator - params.BeaconConfig().ProposerWeight) * params.BeaconConfig().WeightDenominator / params.BeaconConfig().ProposerWeight
+	proposerReward := proposerRewardNumerator / proposerRewardDenominator
+	i, err := helpers.BeaconProposerIndex(beaconState)
+	if err != nil {
+		return err
+	}
+	if err := helpers.IncreaseBalance(beaconState, i, proposerReward); err != nil {
+		return err
+	}
+	return nil
+}
+
+// HasValidatorFlag returns true if the flag at position has set.
+func HasValidatorFlag(flag uint8, flagPosition uint8) bool {
+	return ((flag >> flagPosition) & 1) == 1
+}
+
+// AddValidatorFlag adds new validator flag to existing one.
+func AddValidatorFlag(flag uint8, flagPosition uint8) uint8 {
+	return flag | (1 << flagPosition)
+}

--- a/beacon-chain/core/altair/attestation_test.go
+++ b/beacon-chain/core/altair/attestation_test.go
@@ -1,0 +1,309 @@
+package altair_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/go-bitfield"
+	altair "github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/attestationutil"
+	"github.com/prysmaticlabs/prysm/shared/bls"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	altairTest "github.com/prysmaticlabs/prysm/shared/testutil/altair"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestProcessAttestations_InclusionDelayFailure(t *testing.T) {
+	attestations := []*ethpb.Attestation{
+		testutil.HydrateAttestation(&ethpb.Attestation{
+			Data: &ethpb.AttestationData{
+				Target: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
+				Slot:   5,
+			},
+		}),
+	}
+	b := testutil.NewBeaconBlock()
+	b.Block = &ethpb.BeaconBlock{
+		Body: &ethpb.BeaconBlockBody{
+			Attestations: attestations,
+		},
+	}
+	beaconState, _ := altairTest.DeterministicGenesisStateAltair(t, 100)
+
+	want := fmt.Sprintf(
+		"attestation slot %d + inclusion delay %d > state slot %d",
+		attestations[0].Data.Slot,
+		params.BeaconConfig().MinAttestationInclusionDelay,
+		beaconState.Slot(),
+	)
+	_, err := altair.ProcessAttestations(context.Background(), beaconState, b)
+	require.ErrorContains(t, want, err)
+}
+
+func TestProcessAttestations_NeitherCurrentNorPrevEpoch(t *testing.T) {
+	att := testutil.HydrateAttestation(&ethpb.Attestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
+			Target: &ethpb.Checkpoint{Epoch: 0}}})
+
+	b := testutil.NewBeaconBlock()
+	b.Block = &ethpb.BeaconBlock{
+		Body: &ethpb.BeaconBlockBody{
+			Attestations: []*ethpb.Attestation{att},
+		},
+	}
+	beaconState, _ := altairTest.DeterministicGenesisStateAltair(t, 100)
+	err := beaconState.SetSlot(beaconState.Slot() + params.BeaconConfig().SlotsPerEpoch*4 + params.BeaconConfig().MinAttestationInclusionDelay)
+	require.NoError(t, err)
+	pfc := beaconState.PreviousJustifiedCheckpoint()
+	pfc.Root = []byte("hello-world")
+	require.NoError(t, beaconState.SetPreviousJustifiedCheckpoint(pfc))
+	require.NoError(t, beaconState.AppendPreviousEpochAttestations(&pb.PendingAttestation{}))
+
+	want := fmt.Sprintf(
+		"expected target epoch (%d) to be the previous epoch (%d) or the current epoch (%d)",
+		att.Data.Target.Epoch,
+		helpers.PrevEpoch(beaconState),
+		helpers.CurrentEpoch(beaconState),
+	)
+	_, err = altair.ProcessAttestations(context.Background(), beaconState, b)
+	require.ErrorContains(t, want, err)
+}
+
+func TestProcessAttestations_CurrentEpochFFGDataMismatches(t *testing.T) {
+	attestations := []*ethpb.Attestation{
+		{
+			Data: &ethpb.AttestationData{
+				Target: &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
+				Source: &ethpb.Checkpoint{Epoch: 1, Root: make([]byte, 32)},
+			},
+			AggregationBits: bitfield.Bitlist{0x09},
+		},
+	}
+	b := testutil.NewBeaconBlock()
+	b.Block = &ethpb.BeaconBlock{
+		Body: &ethpb.BeaconBlockBody{
+			Attestations: attestations,
+		},
+	}
+	beaconState, _ := altairTest.DeterministicGenesisStateAltair(t, 100)
+	require.NoError(t, beaconState.SetSlot(beaconState.Slot()+params.BeaconConfig().MinAttestationInclusionDelay))
+	cfc := beaconState.CurrentJustifiedCheckpoint()
+	cfc.Root = []byte("hello-world")
+	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(cfc))
+	require.NoError(t, beaconState.AppendCurrentEpochAttestations(&pb.PendingAttestation{}))
+
+	want := "source check point not equal to current justified checkpoint"
+	_, err := altair.ProcessAttestations(context.Background(), beaconState, b)
+	require.ErrorContains(t, want, err)
+	b.Block.Body.Attestations[0].Data.Source.Epoch = helpers.CurrentEpoch(beaconState)
+	b.Block.Body.Attestations[0].Data.Source.Root = []byte{}
+	_, err = altair.ProcessAttestations(context.Background(), beaconState, b)
+	require.ErrorContains(t, want, err)
+}
+
+func TestProcessAttestations_PrevEpochFFGDataMismatches(t *testing.T) {
+	beaconState, _ := altairTest.DeterministicGenesisStateAltair(t, 100)
+
+	aggBits := bitfield.NewBitlist(3)
+	aggBits.SetBitAt(0, true)
+	attestations := []*ethpb.Attestation{
+		{
+			Data: &ethpb.AttestationData{
+				Source: &ethpb.Checkpoint{Epoch: 1, Root: make([]byte, 32)},
+				Target: &ethpb.Checkpoint{Epoch: 1, Root: make([]byte, 32)},
+				Slot:   params.BeaconConfig().SlotsPerEpoch,
+			},
+			AggregationBits: aggBits,
+		},
+	}
+	b := testutil.NewBeaconBlock()
+	b.Block = &ethpb.BeaconBlock{
+		Body: &ethpb.BeaconBlockBody{
+			Attestations: attestations,
+		},
+	}
+
+	err := beaconState.SetSlot(beaconState.Slot() + 2*params.BeaconConfig().SlotsPerEpoch)
+	require.NoError(t, err)
+	pfc := beaconState.PreviousJustifiedCheckpoint()
+	pfc.Root = []byte("hello-world")
+	require.NoError(t, beaconState.SetPreviousJustifiedCheckpoint(pfc))
+	require.NoError(t, beaconState.AppendPreviousEpochAttestations(&pb.PendingAttestation{}))
+
+	want := "source check point not equal to previous justified checkpoint"
+	_, err = altair.ProcessAttestations(context.Background(), beaconState, b)
+	require.ErrorContains(t, want, err)
+	b.Block.Body.Attestations[0].Data.Source.Epoch = helpers.PrevEpoch(beaconState)
+	b.Block.Body.Attestations[0].Data.Target.Epoch = helpers.PrevEpoch(beaconState)
+	b.Block.Body.Attestations[0].Data.Source.Root = []byte{}
+	_, err = altair.ProcessAttestations(context.Background(), beaconState, b)
+	require.ErrorContains(t, want, err)
+}
+
+func TestProcessAttestations_InvalidAggregationBitsLength(t *testing.T) {
+	beaconState, _ := altairTest.DeterministicGenesisStateAltair(t, 100)
+
+	aggBits := bitfield.NewBitlist(4)
+	att := &ethpb.Attestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Epoch: 0, Root: []byte("hello-world")},
+			Target: &ethpb.Checkpoint{Epoch: 0}},
+		AggregationBits: aggBits,
+	}
+
+	b := testutil.NewBeaconBlock()
+	b.Block = &ethpb.BeaconBlock{
+		Body: &ethpb.BeaconBlockBody{
+			Attestations: []*ethpb.Attestation{att},
+		},
+	}
+
+	err := beaconState.SetSlot(beaconState.Slot() + params.BeaconConfig().MinAttestationInclusionDelay)
+	require.NoError(t, err)
+
+	cfc := beaconState.CurrentJustifiedCheckpoint()
+	cfc.Root = []byte("hello-world")
+	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(cfc))
+	require.NoError(t, beaconState.AppendCurrentEpochAttestations(&pb.PendingAttestation{}))
+
+	expected := "failed to verify aggregation bitfield: wanted participants bitfield length 3, got: 4"
+	_, err = altair.ProcessAttestations(context.Background(), beaconState, b)
+	require.ErrorContains(t, expected, err)
+}
+
+func TestProcessAttestations_OK(t *testing.T) {
+	beaconState, privKeys := altairTest.DeterministicGenesisStateAltair(t, 100)
+
+	aggBits := bitfield.NewBitlist(3)
+	aggBits.SetBitAt(0, true)
+	var mockRoot [32]byte
+	copy(mockRoot[:], "hello-world")
+	att := testutil.HydrateAttestation(&ethpb.Attestation{
+		Data: &ethpb.AttestationData{
+			Source: &ethpb.Checkpoint{Root: mockRoot[:]},
+			Target: &ethpb.Checkpoint{Root: mockRoot[:]},
+		},
+		AggregationBits: aggBits,
+	})
+
+	cfc := beaconState.CurrentJustifiedCheckpoint()
+	cfc.Root = mockRoot[:]
+	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(cfc))
+
+	committee, err := helpers.BeaconCommitteeFromState(beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+	require.NoError(t, err)
+	attestingIndices, err := attestationutil.AttestingIndices(att.AggregationBits, committee)
+	require.NoError(t, err)
+	sigs := make([]bls.Signature, len(attestingIndices))
+	for i, indice := range attestingIndices {
+		sb, err := helpers.ComputeDomainAndSign(beaconState, 0, att.Data, params.BeaconConfig().DomainBeaconAttester, privKeys[indice])
+		require.NoError(t, err)
+		sig, err := bls.SignatureFromBytes(sb)
+		require.NoError(t, err)
+		sigs[i] = sig
+	}
+	att.Signature = bls.AggregateSignatures(sigs).Marshal()
+
+	block := testutil.NewBeaconBlock()
+	block.Block.Body.Attestations = []*ethpb.Attestation{att}
+
+	err = beaconState.SetSlot(beaconState.Slot() + params.BeaconConfig().MinAttestationInclusionDelay)
+	require.NoError(t, err)
+	_, err = altair.ProcessAttestations(context.Background(), beaconState, block)
+	require.NoError(t, err)
+}
+
+func TestProcessAttestationNoVerify_SourceTargetHead(t *testing.T) {
+	beaconState, _ := altairTest.DeterministicGenesisStateAltair(t, 64)
+	err := beaconState.SetSlot(beaconState.Slot() + params.BeaconConfig().MinAttestationInclusionDelay)
+	require.NoError(t, err)
+
+	aggBits := bitfield.NewBitlist(2)
+	aggBits.SetBitAt(0, true)
+	aggBits.SetBitAt(1, true)
+	r, err := helpers.BlockRootAtSlot(beaconState, 0)
+	require.NoError(t, err)
+	att := &ethpb.Attestation{
+		Data: &ethpb.AttestationData{
+			BeaconBlockRoot: r,
+			Source:          &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
+			Target:          &ethpb.Checkpoint{Epoch: 0, Root: make([]byte, 32)},
+		},
+		AggregationBits: aggBits,
+	}
+	zeroSig := [96]byte{}
+	att.Signature = zeroSig[:]
+
+	ckp := beaconState.CurrentJustifiedCheckpoint()
+	copy(ckp.Root, make([]byte, 32))
+	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(ckp))
+
+	beaconState, err = altair.ProcessAttestationNoVerifySignature(context.Background(), beaconState, att)
+	require.NoError(t, err)
+
+	p, err := beaconState.CurrentEpochParticipation()
+	require.NoError(t, err)
+
+	committee, err := helpers.BeaconCommitteeFromState(beaconState, att.Data.Slot, att.Data.CommitteeIndex)
+	require.NoError(t, err)
+	indices, err := attestationutil.AttestingIndices(att.AggregationBits, committee)
+	require.NoError(t, err)
+	for _, index := range indices {
+		require.Equal(t, true, altair.HasValidatorFlag(p[index], params.BeaconConfig().TimelyHeadFlagIndex))
+		require.Equal(t, true, altair.HasValidatorFlag(p[index], params.BeaconConfig().TimelyTargetFlagIndex))
+		require.Equal(t, true, altair.HasValidatorFlag(p[index], params.BeaconConfig().TimelySourceFlagIndex))
+	}
+}
+
+func TestValidatorFlag_AddHas(t *testing.T) {
+	tests := []struct {
+		name          string
+		set           []uint8
+		expectedTrue  []uint8
+		expectedFalse []uint8
+	}{
+		{name: "none",
+			set:           []uint8{},
+			expectedTrue:  []uint8{},
+			expectedFalse: []uint8{params.BeaconConfig().TimelySourceFlagIndex, params.BeaconConfig().TimelyTargetFlagIndex, params.BeaconConfig().TimelyHeadFlagIndex},
+		},
+		{
+			name:          "source",
+			set:           []uint8{params.BeaconConfig().TimelySourceFlagIndex},
+			expectedTrue:  []uint8{params.BeaconConfig().TimelySourceFlagIndex},
+			expectedFalse: []uint8{params.BeaconConfig().TimelyTargetFlagIndex, params.BeaconConfig().TimelyHeadFlagIndex},
+		},
+		{
+			name:          "source, target",
+			set:           []uint8{params.BeaconConfig().TimelySourceFlagIndex, params.BeaconConfig().TimelyTargetFlagIndex},
+			expectedTrue:  []uint8{params.BeaconConfig().TimelySourceFlagIndex, params.BeaconConfig().TimelyTargetFlagIndex},
+			expectedFalse: []uint8{params.BeaconConfig().TimelyHeadFlagIndex},
+		},
+		{name: "source, target, head",
+			set:           []uint8{params.BeaconConfig().TimelySourceFlagIndex, params.BeaconConfig().TimelyTargetFlagIndex, params.BeaconConfig().TimelyHeadFlagIndex},
+			expectedTrue:  []uint8{params.BeaconConfig().TimelySourceFlagIndex, params.BeaconConfig().TimelyTargetFlagIndex, params.BeaconConfig().TimelyHeadFlagIndex},
+			expectedFalse: []uint8{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := uint8(0)
+			for _, f := range tt.set {
+				b = altair.AddValidatorFlag(b, f)
+			}
+			for _, f := range tt.expectedFalse {
+				require.Equal(t, false, altair.HasValidatorFlag(b, f))
+			}
+			for _, f := range tt.expectedTrue {
+				require.Equal(t, true, altair.HasValidatorFlag(b, f))
+			}
+		})
+	}
+}

--- a/beacon-chain/core/altair/attestation_test.go
+++ b/beacon-chain/core/altair/attestation_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 	altair "github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/attestationutil"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -63,7 +62,6 @@ func TestProcessAttestations_NeitherCurrentNorPrevEpoch(t *testing.T) {
 	pfc := beaconState.PreviousJustifiedCheckpoint()
 	pfc.Root = []byte("hello-world")
 	require.NoError(t, beaconState.SetPreviousJustifiedCheckpoint(pfc))
-	require.NoError(t, beaconState.AppendPreviousEpochAttestations(&pb.PendingAttestation{}))
 
 	want := fmt.Sprintf(
 		"expected target epoch (%d) to be the previous epoch (%d) or the current epoch (%d)",
@@ -96,7 +94,6 @@ func TestProcessAttestations_CurrentEpochFFGDataMismatches(t *testing.T) {
 	cfc := beaconState.CurrentJustifiedCheckpoint()
 	cfc.Root = []byte("hello-world")
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(cfc))
-	require.NoError(t, beaconState.AppendCurrentEpochAttestations(&pb.PendingAttestation{}))
 
 	want := "source check point not equal to current justified checkpoint"
 	_, err := altair.ProcessAttestations(context.Background(), beaconState, b)
@@ -134,7 +131,6 @@ func TestProcessAttestations_PrevEpochFFGDataMismatches(t *testing.T) {
 	pfc := beaconState.PreviousJustifiedCheckpoint()
 	pfc.Root = []byte("hello-world")
 	require.NoError(t, beaconState.SetPreviousJustifiedCheckpoint(pfc))
-	require.NoError(t, beaconState.AppendPreviousEpochAttestations(&pb.PendingAttestation{}))
 
 	want := "source check point not equal to previous justified checkpoint"
 	_, err = altair.ProcessAttestations(context.Background(), beaconState, b)
@@ -170,7 +166,6 @@ func TestProcessAttestations_InvalidAggregationBitsLength(t *testing.T) {
 	cfc := beaconState.CurrentJustifiedCheckpoint()
 	cfc.Root = []byte("hello-world")
 	require.NoError(t, beaconState.SetCurrentJustifiedCheckpoint(cfc))
-	require.NoError(t, beaconState.AppendCurrentEpochAttestations(&pb.PendingAttestation{}))
 
 	expected := "failed to verify aggregation bitfield: wanted participants bitfield length 3, got: 4"
 	_, err = altair.ProcessAttestations(context.Background(), beaconState, b)

--- a/beacon-chain/rpc/beaconv1/config_test.go
+++ b/beacon-chain/rpc/beaconv1/config_test.go
@@ -230,11 +230,11 @@ func TestGetSpec(t *testing.T) {
 		case "max_voluntary_exits":
 			assert.Equal(t, "52", v)
 		case "timely_head_flag_index":
-			assert.Equal(t, "53", v)
+			assert.Equal(t, "0x35", v)
 		case "timely_source_flag_index":
-			assert.Equal(t, "54", v)
+			assert.Equal(t, "0x36", v)
 		case "timely_target_flag_index":
-			assert.Equal(t, "55", v)
+			assert.Equal(t, "0x37", v)
 		case "timely_head_weight":
 			assert.Equal(t, "56", v)
 		case "timely_source_weight":

--- a/beacon-chain/state/interface/altair.go
+++ b/beacon-chain/state/interface/altair.go
@@ -13,4 +13,6 @@ type BeaconStateAltair interface {
 	AppendCurrentParticipationBits(val byte) error
 	AppendPreviousParticipationBits(val byte) error
 	AppendInactivityScore(s uint64) error
+	SetPreviousParticipationBits(val []byte) error
+	SetCurrentParticipationBits(val []byte) error
 }

--- a/beacon-chain/state/interface/phase0.go
+++ b/beacon-chain/state/interface/phase0.go
@@ -208,4 +208,6 @@ type FutureForkStub interface {
 	InactivityScores() ([]uint64, error)
 	CurrentSyncCommittee() (*pbp2p.SyncCommittee, error)
 	SetCurrentSyncCommittee(val *pbp2p.SyncCommittee) error
+	SetPreviousParticipationBits(val []byte) error
+	SetCurrentParticipationBits(val []byte) error
 }

--- a/beacon-chain/state/state-altair/deprecated_setters.go
+++ b/beacon-chain/state/state-altair/deprecated_setters.go
@@ -26,6 +26,11 @@ func (b *BeaconState) AppendPreviousEpochAttestations(val *pbp2p.PendingAttestat
 	return errors.New("AppendPreviousEpochAttestations is not supported for hard fork 1 beacon state")
 }
 
+// RotateAttestations is not supported for HF1 beacon state.
+func (b *BeaconState) RotateAttestations() error {
+	return errors.New("RotateAttestations is not supported for hard fork 1 beacon state")
+}
+
 // ToProto is not supported for HF1 beacon state.
 func (b *BeaconState) ToProto() (*v1.BeaconState, error) {
 	return nil, errors.New("ToProto is not yet supported for hard fork 1 beacon state")

--- a/beacon-chain/state/state-altair/setters.go
+++ b/beacon-chain/state/state-altair/setters.go
@@ -497,12 +497,14 @@ func (b *BeaconState) UpdateSlashingsAtIndex(idx, val uint64) error {
 	return nil
 }
 
-// setPreviousParticipationBits for the beacon state. Updates the entire
+// SetPreviousParticipationBits for the beacon state. Updates the entire
 // list to a new value by overwriting the previous one.
-func (b *BeaconState) setPreviousParticipationBits(val []byte) error {
+func (b *BeaconState) SetPreviousParticipationBits(val []byte) error {
 	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
+	b.lock.Lock()
+	defer b.lock.Unlock()
 
 	b.sharedFieldReferences[previousEpochParticipationBits].MinusRef()
 	b.sharedFieldReferences[previousEpochParticipationBits] = stateutil.NewRef(1)
@@ -513,12 +515,14 @@ func (b *BeaconState) setPreviousParticipationBits(val []byte) error {
 	return nil
 }
 
-// setCurrentParticipationBits for the beacon state. Updates the entire
+// SetCurrentParticipationBits for the beacon state. Updates the entire
 // list to a new value by overwriting the previous one.
-func (b *BeaconState) setCurrentParticipationBits(val []byte) error {
+func (b *BeaconState) SetCurrentParticipationBits(val []byte) error {
 	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
+	b.lock.Lock()
+	defer b.lock.Unlock()
 
 	b.sharedFieldReferences[currentEpochParticipationBits].MinusRef()
 	b.sharedFieldReferences[currentEpochParticipationBits] = stateutil.NewRef(1)
@@ -527,21 +531,6 @@ func (b *BeaconState) setCurrentParticipationBits(val []byte) error {
 	b.markFieldAsDirty(currentEpochParticipationBits)
 	b.rebuildTrie[currentEpochParticipationBits] = true
 	return nil
-}
-
-// RotateAttestations sets the previous epoch participation to the current epoch participation and
-// then clears the current epoch participation.
-func (b *BeaconState) RotateAttestations() error {
-	if !b.hasInnerState() {
-		return ErrNilInnerState
-	}
-	b.lock.Lock()
-	defer b.lock.Unlock()
-
-	if err := b.setPreviousParticipationBits(b.currentEpochParticipation()); err != nil {
-		return err
-	}
-	return b.setCurrentParticipationBits([]byte{})
 }
 
 // AppendHistoricalRoots for the beacon state. Appends the new value

--- a/beacon-chain/state/stateV0/unsupported_setters.go
+++ b/beacon-chain/state/stateV0/unsupported_setters.go
@@ -24,3 +24,13 @@ func (b *BeaconState) AppendInactivityScore(s uint64) error {
 func (b *BeaconState) SetCurrentSyncCommittee(val *pbp2p.SyncCommittee) error {
 	return errors.New("SetCurrentSyncCommittee is not supported for phase 0 beacon state")
 }
+
+// SetPreviousParticipationBits is not supported for phase 0 beacon state.
+func (b *BeaconState) SetPreviousParticipationBits(val []byte) error {
+	return errors.New("SetPreviousParticipationBits is not supported for phase 0 beacon state")
+}
+
+// SetCurrentParticipationBits is not supported for phase 0 beacon state.
+func (b *BeaconState) SetCurrentParticipationBits(val []byte) error {
+	return errors.New("SetCurrentParticipationBits is not supported for phase 0 beacon state")
+}

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -136,9 +136,9 @@ type BeaconChainConfig struct {
 
 	// New values introduced in Altair hard fork 1.
 	// Participation flag indices.
-	TimelyHeadFlagIndex   int `yaml:"TIMELY_HEAD_FLAG_INDEX" spec:"true"`   // TimelyHeadFlagIndex for participation bits.
-	TimelySourceFlagIndex int `yaml:"TIMELY_SOURCE_FLAG_INDEX" spec:"true"` // TimelySourceFlagIndex for participation bits.
-	TimelyTargetFlagIndex int `yaml:"TIMELY_TARGET_FLAG_INDEX" spec:"true"` // TimelyTargetFlagIndex for participation bits.
+	TimelyHeadFlagIndex   uint8 `yaml:"TIMELY_HEAD_FLAG_INDEX" spec:"true"`   // TimelyHeadFlagIndex for participation bits.
+	TimelySourceFlagIndex uint8 `yaml:"TIMELY_SOURCE_FLAG_INDEX" spec:"true"` // TimelySourceFlagIndex for participation bits.
+	TimelyTargetFlagIndex uint8 `yaml:"TIMELY_TARGET_FLAG_INDEX" spec:"true"` // TimelyTargetFlagIndex for participation bits.
 
 	// Incentivization weights.
 	TimelyHeadWeight   uint64 `yaml:"TIMELY_HEAD_WEIGHT" spec:"true"`   // TimelyHeadWeight for rewards and penalties.


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

Add process attestation for beacon block in Altair:

```python
def process_attestation(state: BeaconState, attestation: Attestation) -> None:
    data = attestation.data
    assert data.target.epoch in (get_previous_epoch(state), get_current_epoch(state))
    assert data.target.epoch == compute_epoch_at_slot(data.slot)
    assert data.slot + MIN_ATTESTATION_INCLUSION_DELAY <= state.slot <= data.slot + SLOTS_PER_EPOCH
    assert data.index < get_committee_count_per_slot(state, data.target.epoch)

    committee = get_beacon_committee(state, data.slot, data.index)
    assert len(attestation.aggregation_bits) == len(committee)

    if data.target.epoch == get_current_epoch(state):
        epoch_participation = state.current_epoch_participation
        justified_checkpoint = state.current_justified_checkpoint
    else:
        epoch_participation = state.previous_epoch_participation
        justified_checkpoint = state.previous_justified_checkpoint

    # Matching roots
    is_matching_head = data.beacon_block_root == get_block_root_at_slot(state, data.slot)
    is_matching_source = data.source == justified_checkpoint
    is_matching_target = data.target.root == get_block_root(state, data.target.epoch)
    assert is_matching_source

    # Verify signature
    assert is_valid_indexed_attestation(state, get_indexed_attestation(state, attestation))

    # Participation flag indices
    participation_flag_indices = []
    if is_matching_head and is_matching_target and state.slot == data.slot + MIN_ATTESTATION_INCLUSION_DELAY:
        participation_flag_indices.append(TIMELY_HEAD_FLAG_INDEX)
    if is_matching_source and state.slot <= data.slot + integer_squareroot(SLOTS_PER_EPOCH):
        participation_flag_indices.append(TIMELY_SOURCE_FLAG_INDEX)
    if is_matching_target and state.slot <= data.slot + SLOTS_PER_EPOCH:
        participation_flag_indices.append(TIMELY_TARGET_FLAG_INDEX)

    # Update epoch participation flags
    proposer_reward_numerator = 0
    for index in get_attesting_indices(state, data, attestation.aggregation_bits):
        for flag_index, weight in get_flag_indices_and_weights():
            if flag_index in participation_flag_indices and not has_flag(epoch_participation[index], flag_index):
                epoch_participation[index] = add_flag(epoch_participation[index], flag_index)
                proposer_reward_numerator += get_base_reward(state, index) * weight

    # Reward proposer
    proposer_reward_denominator = (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT) * WEIGHT_DENOMINATOR // PROPOSER_WEIGHT
    proposer_reward = Gwei(proposer_reward_numerator // proposer_reward_denominator)
    increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
```
https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#modified-process_attestation

**Which issues(s) does this PR fix?**

Part of #8638 

**Other notes for review**