### PR TITLE
Altair: process participation flag update for epoch

### DIFF
--- a/beacon-chain/core/altair/epoch.go
+++ b/beacon-chain/core/altair/epoch.go
@@ -34,3 +34,23 @@ func ProcessSyncCommitteeUpdates(beaconState iface.BeaconStateAltair) (iface.Bea
 	}
 	return beaconState, nil
 }
+
+// ProcessParticipationFlagUpdates processes participation flag updates by rotating current to previous.
+//
+// Spec code:
+// def process_participation_flag_updates(state: BeaconState) -> None:
+//    state.previous_epoch_participation = state.current_epoch_participation
+//    state.current_epoch_participation = [ParticipationFlags(0b0000_0000) for _ in range(len(state.validators))]
+func ProcessParticipationFlagUpdates(beaconState iface.BeaconStateAltair) (iface.BeaconStateAltair, error) {
+	c, err := beaconState.CurrentEpochParticipation()
+	if err != nil {
+		return nil, err
+	}
+	if err := beaconState.SetPreviousParticipationBits(c); err != nil {
+		return nil, err
+	}
+	if err := beaconState.SetCurrentParticipationBits(make([]byte, beaconState.NumValidators())); err != nil {
+		return nil, err
+	}
+	return beaconState, nil
+}

--- a/beacon-chain/core/altair/epoch_test.go
+++ b/beacon-chain/core/altair/epoch_test.go
@@ -41,3 +41,33 @@ func TestProcessSyncCommitteeUpdates_CanRotate(t *testing.T) {
 	require.NotEqual(t, next, n)
 	require.DeepEqual(t, next, c)
 }
+
+func TestProcessParticipationFlagUpdates_CanRotate(t *testing.T) {
+	s, _ := altairState.DeterministicGenesisStateAltair(t, params.BeaconConfig().MaxValidatorsPerCommittee)
+	c, err := s.CurrentEpochParticipation()
+	require.NoError(t, err)
+	require.DeepEqual(t, make([]byte, params.BeaconConfig().MaxValidatorsPerCommittee), c)
+	p, err := s.PreviousEpochParticipation()
+	require.NoError(t, err)
+	require.DeepEqual(t, make([]byte, params.BeaconConfig().MaxValidatorsPerCommittee), p)
+
+	newC := []byte{'a'}
+	newP := []byte{'b'}
+	require.NoError(t, s.SetCurrentParticipationBits(newC))
+	require.NoError(t, s.SetPreviousParticipationBits(newP))
+	c, err = s.CurrentEpochParticipation()
+	require.NoError(t, err)
+	require.DeepEqual(t, newC, c)
+	p, err = s.PreviousEpochParticipation()
+	require.NoError(t, err)
+	require.DeepEqual(t, newP, p)
+
+	s, err = altair.ProcessParticipationFlagUpdates(s)
+	require.NoError(t, err)
+	c, err = s.CurrentEpochParticipation()
+	require.NoError(t, err)
+	require.DeepEqual(t, make([]byte, params.BeaconConfig().MaxValidatorsPerCommittee), c)
+	p, err = s.PreviousEpochParticipation()
+	require.NoError(t, err)
+	require.DeepEqual(t, newC, p)
+}


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

Add process participation flags for epoch in Altair:

```python
def process_participation_flag_updates(state: BeaconState) -> None:
    state.previous_epoch_participation = state.current_epoch_participation
    state.current_epoch_participation = [ParticipationFlags(0b0000_0000) for _ in range(len(state.validators))]
```
https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#participation-flags-updates

**Which issues(s) does this PR fix?**
Part of #8638 
