### PR TITLE
Altair: Slashing for block and epoch

### DIFF
--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "epoch.go",
         "state.go",
         "sync_committee.go",
+        "validator.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/core/altair",
     visibility = [
@@ -21,6 +22,7 @@ go_library(
         "//beacon-chain/core/epoch:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
+        "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/p2p/types:go_default_library",
         "//beacon-chain/state/interface:go_default_library",
         "//beacon-chain/state/state-altair:go_default_library",
@@ -50,6 +52,7 @@ go_test(
         "state_fuzz_test.go",
         "state_test.go",
         "sync_committee_test.go",
+        "validator_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/beacon-chain/core/altair/epoch.go
+++ b/beacon-chain/core/altair/epoch.go
@@ -1,8 +1,12 @@
 package altair
 
 import (
+	"github.com/pkg/errors"
+	types "github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/mathutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
@@ -53,4 +57,55 @@ func ProcessParticipationFlagUpdates(beaconState iface.BeaconStateAltair) (iface
 		return nil, err
 	}
 	return beaconState, nil
+}
+
+// ProcessSlashings processes the slashed validators during epoch processing,
+// The function is modified to use PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR.
+//
+// Spec code:
+//  def process_slashings(state: BeaconState) -> None:
+//    epoch = get_current_epoch(state)
+//    total_balance = get_total_active_balance(state)
+//    adjusted_total_slashing_balance = min(sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR, total_balance)
+//    for index, validator in enumerate(state.validators):
+//        if validator.slashed and epoch + EPOCHS_PER_SLASHINGS_VECTOR // 2 == validator.withdrawable_epoch:
+//            increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from penalty numerator to avoid uint64 overflow
+//            penalty_numerator = validator.effective_balance // increment * adjusted_total_slashing_balance
+//            penalty = penalty_numerator // total_balance * increment
+//            decrease_balance(state, ValidatorIndex(index), penalty)
+//            decrease_balance(state, ValidatorIndex(index), penalty)
+func ProcessSlashings(state iface.BeaconState) (iface.BeaconState, error) {
+	currentEpoch := helpers.CurrentEpoch(state)
+	totalBalance, err := helpers.TotalActiveBalance(state)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get total active balance")
+	}
+
+	// Compute slashed balances in the current epoch
+	exitLength := params.BeaconConfig().EpochsPerSlashingsVector
+
+	// Compute the sum of state slashings
+	slashings := state.Slashings()
+	totalSlashing := uint64(0)
+	for _, slashing := range slashings {
+		totalSlashing += slashing
+	}
+
+	// a callback is used here to apply the following actions  to all validators
+	// below equally.
+	increment := params.BeaconConfig().EffectiveBalanceIncrement
+	minSlashing := mathutil.Min(totalSlashing*params.BeaconConfig().ProportionalSlashingMultiplierAltair, totalBalance)
+	err = state.ApplyToEveryValidator(func(idx int, val *ethpb.Validator) (bool, *ethpb.Validator, error) {
+		correctEpoch := (currentEpoch + exitLength/2) == val.WithdrawableEpoch
+		if val.Slashed && correctEpoch {
+			penaltyNumerator := val.EffectiveBalance / increment * minSlashing
+			penalty := penaltyNumerator / totalBalance * increment
+			if err := helpers.DecreaseBalance(state, types.ValidatorIndex(idx), penalty); err != nil {
+				return false, val, err
+			}
+			return true, val, nil
+		}
+		return false, val, nil
+	})
+	return state, err
 }

--- a/beacon-chain/core/altair/epoch_test.go
+++ b/beacon-chain/core/altair/epoch_test.go
@@ -1,12 +1,18 @@
 package altair_test
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/gogo/protobuf/proto"
 	types "github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	stateAltair "github.com/prysmaticlabs/prysm/beacon-chain/state/state-altair"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	altairState "github.com/prysmaticlabs/prysm/shared/testutil/altair"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
@@ -70,4 +76,90 @@ func TestProcessParticipationFlagUpdates_CanRotate(t *testing.T) {
 	p, err = s.PreviousEpochParticipation()
 	require.NoError(t, err)
 	require.DeepEqual(t, newC, p)
+}
+
+func TestProcessSlashings_NotSlashed(t *testing.T) {
+	base := &pb.BeaconStateAltair{
+		Slot:       0,
+		Validators: []*ethpb.Validator{{Slashed: true}},
+		Balances:   []uint64{params.BeaconConfig().MaxEffectiveBalance},
+		Slashings:  []uint64{0, 1e9},
+	}
+	s, err := stateAltair.InitializeFromProto(base)
+	require.NoError(t, err)
+	newState, err := altair.ProcessSlashings(s)
+	require.NoError(t, err)
+	wanted := params.BeaconConfig().MaxEffectiveBalance
+	assert.Equal(t, wanted, newState.Balances()[0], "Unexpected slashed balance")
+}
+
+func TestProcessSlashings_SlashedLess(t *testing.T) {
+	tests := []struct {
+		state *pb.BeaconStateAltair
+		want  uint64
+	}{
+		{
+			state: &pb.BeaconStateAltair{
+				Validators: []*ethpb.Validator{
+					{Slashed: true,
+						WithdrawableEpoch: params.BeaconConfig().EpochsPerSlashingsVector / 2,
+						EffectiveBalance:  params.BeaconConfig().MaxEffectiveBalance},
+					{ExitEpoch: params.BeaconConfig().FarFutureEpoch, EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance}},
+				Balances:  []uint64{params.BeaconConfig().MaxEffectiveBalance, params.BeaconConfig().MaxEffectiveBalance},
+				Slashings: []uint64{0, 1e9},
+			},
+			want: uint64(30000000000),
+		},
+		{
+			state: &pb.BeaconStateAltair{
+				Validators: []*ethpb.Validator{
+					{Slashed: true,
+						WithdrawableEpoch: params.BeaconConfig().EpochsPerSlashingsVector / 2,
+						EffectiveBalance:  params.BeaconConfig().MaxEffectiveBalance},
+					{ExitEpoch: params.BeaconConfig().FarFutureEpoch, EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
+					{ExitEpoch: params.BeaconConfig().FarFutureEpoch, EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
+				},
+				Balances:  []uint64{params.BeaconConfig().MaxEffectiveBalance, params.BeaconConfig().MaxEffectiveBalance},
+				Slashings: []uint64{0, 1e9},
+			},
+			want: uint64(31000000000),
+		},
+		{
+			state: &pb.BeaconStateAltair{
+				Validators: []*ethpb.Validator{
+					{Slashed: true,
+						WithdrawableEpoch: params.BeaconConfig().EpochsPerSlashingsVector / 2,
+						EffectiveBalance:  params.BeaconConfig().MaxEffectiveBalance},
+					{ExitEpoch: params.BeaconConfig().FarFutureEpoch, EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
+					{ExitEpoch: params.BeaconConfig().FarFutureEpoch, EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
+				},
+				Balances:  []uint64{params.BeaconConfig().MaxEffectiveBalance, params.BeaconConfig().MaxEffectiveBalance},
+				Slashings: []uint64{0, 2 * 1e9},
+			},
+			want: uint64(30000000000),
+		},
+		{
+			state: &pb.BeaconStateAltair{
+				Validators: []*ethpb.Validator{
+					{Slashed: true,
+						WithdrawableEpoch: params.BeaconConfig().EpochsPerSlashingsVector / 2,
+						EffectiveBalance:  params.BeaconConfig().MaxEffectiveBalance - params.BeaconConfig().EffectiveBalanceIncrement},
+					{ExitEpoch: params.BeaconConfig().FarFutureEpoch, EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance - params.BeaconConfig().EffectiveBalanceIncrement}},
+				Balances:  []uint64{params.BeaconConfig().MaxEffectiveBalance - params.BeaconConfig().EffectiveBalanceIncrement, params.BeaconConfig().MaxEffectiveBalance - params.BeaconConfig().EffectiveBalanceIncrement},
+				Slashings: []uint64{0, 1e9},
+			},
+			want: uint64(29000000000),
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprint(i), func(t *testing.T) {
+			original := proto.Clone(tt.state)
+			s, err := stateAltair.InitializeFromProto(tt.state)
+			require.NoError(t, err)
+			newState, err := altair.ProcessSlashings(s)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, newState.Balances()[0], "ProcessSlashings({%v}) = newState; newState.Balances[0] = %d", original, newState.Balances()[0])
+		})
+	}
 }

--- a/beacon-chain/core/altair/validator.go
+++ b/beacon-chain/core/altair/validator.go
@@ -1,0 +1,86 @@
+package altair
+
+import (
+	"github.com/pkg/errors"
+	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/params"
+)
+
+// SlashValidator with slashed index.
+// The function  is modified to use MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR and use PROPOSER_WEIGHT when calculating the proposer reward.
+//
+// def slash_validator(state: BeaconState,
+//                    slashed_index: ValidatorIndex,
+//                    whistleblower_index: ValidatorIndex=None) -> None:
+//    """
+//    Slash the validator with index ``slashed_index``.
+//    """
+//    epoch = get_current_epoch(state)
+//    initiate_validator_exit(state, slashed_index)
+//    validator = state.validators[slashed_index]
+//    validator.slashed = True
+//    validator.withdrawable_epoch = max(validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR))
+//    state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
+//    decrease_balance(state, slashed_index, validator.effective_balance // MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR)
+//
+//    # Apply proposer and whistleblower rewards
+//    proposer_index = get_beacon_proposer_index(state)
+//    if whistleblower_index is None:
+//        whistleblower_index = proposer_index
+//    whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
+//    proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)
+//    increase_balance(state, proposer_index, proposer_reward)
+//    increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
+func SlashValidator(state iface.BeaconState, slashedIdx types.ValidatorIndex) (iface.BeaconState, error) {
+	state, err := validators.InitiateValidatorExit(state, slashedIdx)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
+	}
+	currentEpoch := helpers.SlotToEpoch(state.Slot())
+	validator, err := state.ValidatorAtIndex(slashedIdx)
+	if err != nil {
+		return nil, err
+	}
+	validator.Slashed = true
+	maxWithdrawableEpoch := types.MaxEpoch(validator.WithdrawableEpoch, currentEpoch+params.BeaconConfig().EpochsPerSlashingsVector)
+	validator.WithdrawableEpoch = maxWithdrawableEpoch
+
+	if err := state.UpdateValidatorAtIndex(slashedIdx, validator); err != nil {
+		return nil, err
+	}
+
+	// The slashing amount is represented by epochs per slashing vector. The validator's effective balance is then applied to that amount.
+	slashings := state.Slashings()
+	currentSlashing := slashings[currentEpoch%params.BeaconConfig().EpochsPerSlashingsVector]
+	if err := state.UpdateSlashingsAtIndex(
+		uint64(currentEpoch%params.BeaconConfig().EpochsPerSlashingsVector),
+		currentSlashing+validator.EffectiveBalance,
+	); err != nil {
+		return nil, err
+	}
+	if err := helpers.DecreaseBalance(state, slashedIdx, validator.EffectiveBalance/params.BeaconConfig().MinSlashingPenaltyQuotientAltair); err != nil {
+		return nil, err
+	}
+
+	proposerIdx, err := helpers.BeaconProposerIndex(state)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get proposer idx")
+	}
+
+	// In this implementation, proposer is the whistleblower.
+	whistleBlowerIdx := proposerIdx
+	whistleblowerReward := validator.EffectiveBalance / params.BeaconConfig().WhistleBlowerRewardQuotient
+	proposerReward := whistleblowerReward * params.BeaconConfig().ProposerWeight / params.BeaconConfig().WeightDenominator
+	err = helpers.IncreaseBalance(state, proposerIdx, proposerReward)
+	if err != nil {
+		return nil, err
+	}
+	err = helpers.IncreaseBalance(state, whistleBlowerIdx, whistleblowerReward-proposerReward)
+	if err != nil {
+		return nil, err
+	}
+	return state, nil
+}

--- a/beacon-chain/core/altair/validator_test.go
+++ b/beacon-chain/core/altair/validator_test.go
@@ -1,0 +1,69 @@
+package altair_test
+
+import (
+	"testing"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	stateAltair "github.com/prysmaticlabs/prysm/beacon-chain/state/state-altair"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestSlashValidator_OK(t *testing.T) {
+	validatorCount := params.BeaconConfig().MinGenesisActiveValidatorCount
+	registry := make([]*ethpb.Validator, 0, validatorCount)
+	balances := make([]uint64, 0, validatorCount)
+	for i := uint64(0); i < validatorCount; i++ {
+		registry = append(registry, &ethpb.Validator{
+			ActivationEpoch:  0,
+			ExitEpoch:        params.BeaconConfig().FarFutureEpoch,
+			EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance,
+		})
+		balances = append(balances, params.BeaconConfig().MaxEffectiveBalance)
+	}
+
+	base := &pb.BeaconStateAltair{
+		Validators:  registry,
+		Slashings:   make([]uint64, params.BeaconConfig().EpochsPerSlashingsVector),
+		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
+		Balances:    balances,
+	}
+	state, err := stateAltair.InitializeFromProto(base)
+	require.NoError(t, err)
+
+	slashedIdx := types.ValidatorIndex(2)
+
+	proposer, err := helpers.BeaconProposerIndex(state)
+	require.NoError(t, err, "Could not get proposer")
+	proposerBal, err := state.BalanceAtIndex(proposer)
+	require.NoError(t, err)
+	slashedState, err := altair.SlashValidator(state, slashedIdx)
+	require.NoError(t, err, "Could not slash validator")
+	state, ok := slashedState.(*stateAltair.BeaconState)
+	require.Equal(t, true, ok)
+
+	v, err := state.ValidatorAtIndex(slashedIdx)
+	require.NoError(t, err)
+	assert.Equal(t, true, v.Slashed, "Validator not slashed despite supposed to being slashed")
+	assert.Equal(t, helpers.CurrentEpoch(state)+params.BeaconConfig().EpochsPerSlashingsVector, v.WithdrawableEpoch, "Withdrawable epoch not the expected value")
+
+	maxBalance := params.BeaconConfig().MaxEffectiveBalance
+	slashedBalance := state.Slashings()[state.Slot().Mod(uint64(params.BeaconConfig().EpochsPerSlashingsVector))]
+	assert.Equal(t, maxBalance, slashedBalance, "Slashed balance isnt the expected amount")
+
+	whistleblowerReward := slashedBalance / params.BeaconConfig().WhistleBlowerRewardQuotient
+	bal, err := state.BalanceAtIndex(proposer)
+	require.NoError(t, err)
+	// The proposer is the whistleblower in phase 0.
+	assert.Equal(t, proposerBal+whistleblowerReward, bal, "Did not get expected balance for proposer")
+	bal, err = state.BalanceAtIndex(slashedIdx)
+	require.NoError(t, err)
+	v, err = state.ValidatorAtIndex(slashedIdx)
+	require.NoError(t, err)
+	assert.Equal(t, maxBalance-(v.EffectiveBalance/params.BeaconConfig().MinSlashingPenaltyQuotientAltair), bal, "Did not get expected balance for slashed validator")
+}


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

Add process slashing for block and epoch for Altair:

```python
def process_slashings(state: BeaconState) -> None:
    epoch = get_current_epoch(state)
    total_balance = get_total_active_balance(state)
    adjusted_total_slashing_balance = min(sum(state.slashings) * PROPORTIONAL_SLASHING_MULTIPLIER_ALTAIR, total_balance)
    for index, validator in enumerate(state.validators):
        if validator.slashed and epoch + EPOCHS_PER_SLASHINGS_VECTOR // 2 == validator.withdrawable_epoch:
            increment = EFFECTIVE_BALANCE_INCREMENT  # Factored out from penalty numerator to avoid uint64 overflow
            penalty_numerator = validator.effective_balance // increment * adjusted_total_slashing_balance
            penalty = penalty_numerator // total_balance * increment
            decrease_balance(state, ValidatorIndex(index), penalty)

def slash_validator(state: BeaconState,
                    slashed_index: ValidatorIndex,
                    whistleblower_index: ValidatorIndex=None) -> None:
    """
    Slash the validator with index ``slashed_index``.
    """
    epoch = get_current_epoch(state)
    initiate_validator_exit(state, slashed_index)
    validator = state.validators[slashed_index]
    validator.slashed = True
    validator.withdrawable_epoch = max(validator.withdrawable_epoch, Epoch(epoch + EPOCHS_PER_SLASHINGS_VECTOR))
    state.slashings[epoch % EPOCHS_PER_SLASHINGS_VECTOR] += validator.effective_balance
    decrease_balance(state, slashed_index, validator.effective_balance // MIN_SLASHING_PENALTY_QUOTIENT_ALTAIR)

    # Apply proposer and whistleblower rewards
    proposer_index = get_beacon_proposer_index(state)
    if whistleblower_index is None:
        whistleblower_index = proposer_index
    whistleblower_reward = Gwei(validator.effective_balance // WHISTLEBLOWER_REWARD_QUOTIENT)
    proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)
    increase_balance(state, proposer_index, proposer_reward)
    increase_balance(state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward))
```
https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#beacon-state-mutators

**Which issues(s) does this PR fix?**
Part of #8638 
