### PR TITLE
Update NextPowerOf2() and PrevPowerOf2() funcs

### DIFF
--- a/shared/trieutil/helpers.go
+++ b/shared/trieutil/helpers.go
@@ -49,7 +49,7 @@ func NextPowerOf2(n int) int {
 //    else:
 //        return 2 * get_power_of_two_floor(x // 2)
 func PrevPowerOf2(n int) int {
-	if n <=1 {
+	if n <= 1 {
 		return 1
 	}
 	if n == 2 {

--- a/shared/trieutil/helpers.go
+++ b/shared/trieutil/helpers.go
@@ -10,16 +10,23 @@ import (
 // NextPowerOf2 returns the next power of 2 >= the input
 //
 // Spec pseudocode definition:
-//   def get_next_power_of_two(x: int) -> int:
+//   def get_power_of_two_ceil(x: int) -> int:
 //    """
-//    Get next power of 2 >= the input.
+//    Get the power of 2 for given input, or the closest higher power of 2 if the input is not a power of 2.
+//    Commonly used for "how many nodes do I need for a bottom tree layer fitting x elements?"
+//    Example: 0->1, 1->1, 2->2, 3->4, 4->4, 5->8, 6->8, 7->8, 8->8, 9->16.
 //    """
-//    if x <= 2:
-//        return x
+//    if x <= 1:
+//        return 1
+//    elif x == 2:
+//        return 2
 //    else:
-//        return 2 * get_next_power_of_two((x + 1) // 2)
+//        return 2 * get_power_of_two_ceil((x + 1) // 2)
 func NextPowerOf2(n int) int {
-	if n <= 2 {
+	if n <= 1 {
+		return 1
+	}
+	if n == 2 {
 		return n
 	}
 	return 2 * NextPowerOf2((n+1)/2)
@@ -28,16 +35,24 @@ func NextPowerOf2(n int) int {
 // PrevPowerOf2 returns the previous power of 2 >= the input
 //
 // Spec pseudocode definition:
-//   def get_previous_power_of_two(x: int) -> int:
+//   def get_power_of_two_floor(x: int) -> int:
 //    """
-//    Get the previous power of 2 >= the input.
+//    Get the power of 2 for given input, or the closest lower power of 2 if the input is not a power of 2.
+//    The zero case is a placeholder and not used for math with generalized indices.
+//    Commonly used for "what power of two makes up the root bit of the generalized index?"
+//    Example: 0->1, 1->1, 2->2, 3->2, 4->4, 5->4, 6->4, 7->4, 8->8, 9->8
 //    """
-//    if x <= 2:
+//    if x <= 1:
+//        return 1
+//    if x == 2:
 //        return x
 //    else:
-//        return 2 * get_previous_power_of_two(x // 2)
+//        return 2 * get_power_of_two_floor(x // 2)
 func PrevPowerOf2(n int) int {
-	if n <= 2 {
+	if n <=1 {
+		return 1
+	}
+	if n == 2 {
 		return n
 	}
 	return 2 * PrevPowerOf2(n/2)
@@ -95,7 +110,7 @@ func MerkleTree(leaves [][]byte) [][]byte {
 //    """
 //    o = GeneralizedIndex(1)
 //    for i in indices:
-//        o = GeneralizedIndex(o * get_previous_power_of_two(i) + (i - get_previous_power_of_two(i)))
+//        o = GeneralizedIndex(o * get_power_of_two_floor(i) + (i - get_power_of_two_floor(i)))
 //    return o
 func ConcatGeneralizedIndices(indices []int) int {
 	index := 1

--- a/shared/trieutil/helpers_test.go
+++ b/shared/trieutil/helpers_test.go
@@ -12,7 +12,7 @@ func TestNextPowerOf2(t *testing.T) {
 		input  int
 		result int
 	}{
-		{input: 0, result: 0},
+		{input: 0, result: 1},
 		{input: 1, result: 1},
 		{input: 2, result: 2},
 		{input: 3, result: 4},
@@ -32,7 +32,7 @@ func TestPrevPowerOf2(t *testing.T) {
 		input  int
 		result int
 	}{
-		{input: 0, result: 0},
+		{input: 0, result: 1},
 		{input: 1, result: 1},
 		{input: 2, result: 2},
 		{input: 3, result: 2},


### PR DESCRIPTION
**What type of PR is this?**

> Other / Update per specs

**What does this PR do? Why is it needed?**
- In this PR not only specs comment is updated, to reflect the current specs, but the code is also updated as for `get_power_of_two_ceil(0)` and `get_power_of_two_floor(0)` expected output value (in the current specs) is 1, not 0.
- This shouldn't change anything as those functions are hardly called with 0 as input, but still should be updated to reflect the current specs.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
