### PR TITLE
Set test timeout on //beacon-chain/rpc/validator:go_default_test. Sometimes exceeds 800s otherwise

### DIFF
--- a/beacon-chain/rpc/validator/BUILD.bazel
+++ b/beacon-chain/rpc/validator/BUILD.bazel
@@ -69,6 +69,7 @@ go_library(
 # gazelle:exclude proposer_utils_bench_test.go
 go_test(
     name = "go_default_test",
+    timeout = "moderate",
     srcs = [
         "aggregator_test.go",
         "assignments_test.go",


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

I noticed an issue where buildkite will timeout on this test exceeding 800s.

**Which issues(s) does this PR fix?**

Fixes angry developers.

**Other notes for review**

moderate is 5 minute timeout. See: https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes-tests
