### PR TITLE
Codecov: ignore all mock files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -30,4 +30,4 @@ comment:
 
 ignore:
   - "**/*.pb.go"
-  - "**/*_mock.go"
+  - "**/*mock*.go"


### PR DESCRIPTION
**What type of PR is this?**

Testing

**What does this PR do? Why is it needed?**

The current codecov configuration ignores all files with `_mock` suffix, but only generated files have such names. All other mock files are *prefixed* with `mock`. This change ignores all files whose names contain `mock`. It's very unlikely that a regular file will be named like that.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
