### PR TITLE
Altair: Add `ProcessSlots`

### DIFF
--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//shared/testutil/altair:__pkg__",
     ],
     deps = [
+        "//beacon-chain/cache:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/epoch:go_default_library",
         "//beacon-chain/core/epoch/precompute:go_default_library",
@@ -37,9 +38,11 @@ go_library(
         "//shared/hashutil:go_default_library",
         "//shared/mathutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/traceutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
     ],
 )

--- a/beacon-chain/core/altair/transition.go
+++ b/beacon-chain/core/altair/transition.go
@@ -2,13 +2,25 @@ package altair
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
+	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	e "github.com/prysmaticlabs/prysm/beacon-chain/core/epoch"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/epoch/precompute"
+	coreState "github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/traceutil"
+	log "github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
+
+// SkipSlotCache exists for the unlikely scenario that is a large gap between the head state and
+// the current slot. If the beacon chain were ever to be stalled for several epochs, it may be
+// difficult or impossible to compute the appropriate beacon state for assignments within a
+// reasonable amount of time.
+var SkipSlotCache = cache.NewSkipSlotCache()
 
 // ProcessEpoch describes the per epoch operations that are performed on the beacon state.
 // It's optimized by pre computing validator attested info and epoch total/attested balances upfront.
@@ -99,6 +111,106 @@ func ProcessEpoch(ctx context.Context, state iface.BeaconStateAltair) (iface.Bea
 	state, err = ProcessSyncCommitteeUpdates(state)
 	if err != nil {
 		return nil, err
+	}
+
+	return state, nil
+}
+
+// ProcessSlots process through skip slots and apply epoch transition when it's needed.
+//
+// Spec pseudocode definition:
+//  def process_slots(state: BeaconState, slot: Slot) -> None:
+//    assert state.slot < slot
+//    while state.slot < slot:
+//        process_slot(state)
+//        # Process epoch on the start slot of the next epoch
+//        if (state.slot + 1) % SLOTS_PER_EPOCH == 0:
+//            process_epoch(state)
+//        state.slot = Slot(state.slot + 1)
+func ProcessSlots(ctx context.Context, state iface.BeaconState, slot types.Slot) (iface.BeaconState, error) {
+	ctx, span := trace.StartSpan(ctx, "altair.ProcessSlots")
+	defer span.End()
+	if state == nil {
+		return nil, errors.New("nil state")
+	}
+	span.AddAttributes(trace.Int64Attribute("slots", int64(slot)-int64(state.Slot())))
+
+	// The block must have a higher slot than parent state.
+	if state.Slot() >= slot {
+		err := fmt.Errorf("expected state.slot %d < slot %d", state.Slot(), slot)
+		traceutil.AnnotateError(span, err)
+		return nil, err
+	}
+
+	highestSlot := state.Slot()
+	key, err := coreState.CacheKey(ctx, state)
+	if err != nil {
+		return nil, err
+	}
+
+	// Restart from cached value, if one exists.
+	cachedState, err := SkipSlotCache.Get(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if cachedState != nil && cachedState.Slot() < slot {
+		highestSlot = cachedState.Slot()
+		state = cachedState
+	}
+	if err := SkipSlotCache.MarkInProgress(key); errors.Is(err, cache.ErrAlreadyInProgress) {
+		cachedState, err = SkipSlotCache.Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		if cachedState != nil && cachedState.Slot() < slot {
+			highestSlot = cachedState.Slot()
+			state = cachedState
+		}
+	} else if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err := SkipSlotCache.MarkNotInProgress(key); err != nil {
+			traceutil.AnnotateError(span, err)
+			log.WithError(err).Error("Failed to mark skip slot no longer in progress")
+		}
+	}()
+
+	for state.Slot() < slot {
+		if ctx.Err() != nil {
+			traceutil.AnnotateError(span, ctx.Err())
+			// Cache last best value.
+			if highestSlot < state.Slot() {
+				if err := SkipSlotCache.Put(ctx, key, state); err != nil {
+					log.WithError(err).Error("Failed to put skip slot cache value")
+				}
+			}
+			return nil, ctx.Err()
+		}
+		state, err = coreState.ProcessSlot(ctx, state)
+		if err != nil {
+			traceutil.AnnotateError(span, err)
+			return nil, errors.Wrap(err, "could not process slot")
+		}
+		if coreState.CanProcessEpoch(state) {
+			state, err = ProcessEpoch(ctx, state)
+			if err != nil {
+				traceutil.AnnotateError(span, err)
+				return nil, errors.Wrap(err, "could not process epoch with optimizations")
+			}
+		}
+		if err := state.SetSlot(state.Slot() + 1); err != nil {
+			traceutil.AnnotateError(span, err)
+			return nil, errors.Wrap(err, "failed to increment state slot")
+		}
+	}
+
+	if highestSlot < state.Slot() {
+		if err := SkipSlotCache.Put(ctx, key, state); err != nil {
+			log.WithError(err).Error("Failed to put skip slot cache value")
+			traceutil.AnnotateError(span, err)
+		}
 	}
 
 	return state, nil

--- a/beacon-chain/core/altair/transition_test.go
+++ b/beacon-chain/core/altair/transition_test.go
@@ -1,4 +1,4 @@
-package altair
+package altair_test
 
 import (
 	"context"
@@ -8,10 +8,12 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
 	statealtair "github.com/prysmaticlabs/prysm/beacon-chain/state/state-altair"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateV0"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	altair2 "github.com/prysmaticlabs/prysm/shared/testutil/altair"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
@@ -30,7 +32,7 @@ func TestProcessEpoch_CanProcess(t *testing.T) {
 	}
 	s, err := statealtair.InitializeFromProto(base)
 	require.NoError(t, err)
-	newState, err := ProcessEpoch(context.Background(), s)
+	newState, err := altair.ProcessEpoch(context.Background(), s)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), newState.Slashings()[2], "Unexpected slashed balance")
 }
@@ -42,7 +44,51 @@ func TestFuzzProcessEpoch_1000(t *testing.T) {
 	fuzzer.NilChance(0.1)
 	for i := 0; i < 1000; i++ {
 		fuzzer.Fuzz(state)
-		s, err := ProcessEpoch(ctx, state)
+		s, err := altair.ProcessEpoch(ctx, state)
+		if err != nil && s != nil {
+			t.Fatalf("state should be nil on err. found: %v on error: %v for state: %v", s, err, state)
+		}
+	}
+}
+
+func TestProcessSlots_CanProcess(t *testing.T) {
+	s, _ := altair2.DeterministicGenesisStateAltair(t, params.BeaconConfig().MaxValidatorsPerCommittee)
+	slot := types.Slot(100)
+	newState, err := altair.ProcessSlots(context.Background(), s, slot)
+	require.NoError(t, err)
+	require.Equal(t, slot, newState.Slot())
+}
+
+func TestProcessSlots_SameSlotAsParentState(t *testing.T) {
+	slot := types.Slot(2)
+	parentState, err := stateV0.InitializeFromProto(&pb.BeaconState{Slot: slot})
+	require.NoError(t, err)
+
+	_, err = altair.ProcessSlots(context.Background(), parentState, slot)
+	require.ErrorContains(t, "expected state.slot 2 < slot 2", err)
+}
+
+func TestProcessSlots_LowerSlotAsParentState(t *testing.T) {
+	slot := types.Slot(2)
+	parentState, err := stateV0.InitializeFromProto(&pb.BeaconState{Slot: slot})
+	require.NoError(t, err)
+
+	_, err = altair.ProcessSlots(context.Background(), parentState, slot-1)
+	require.ErrorContains(t, "expected state.slot 2 < slot 1", err)
+}
+
+func TestFuzzProcessSlots_1000(t *testing.T) {
+	altair.SkipSlotCache.Disable()
+	defer altair.SkipSlotCache.Enable()
+	ctx := context.Background()
+	state := &statealtair.BeaconState{}
+	slot := types.Slot(0)
+	fuzzer := fuzz.NewWithSeed(0)
+	fuzzer.NilChance(0.1)
+	for i := 0; i < 1000; i++ {
+		fuzzer.Fuzz(state)
+		fuzzer.Fuzz(&slot)
+		s, err := altair.ProcessSlots(ctx, state, slot)
 		if err != nil && s != nil {
 			t.Fatalf("state should be nil on err. found: %v on error: %v for state: %v", s, err, state)
 		}

--- a/beacon-chain/core/state/skip_slot_cache.go
+++ b/beacon-chain/core/state/skip_slot_cache.go
@@ -19,7 +19,7 @@ var SkipSlotCache = cache.NewSkipSlotCache()
 // The key for skip slot cache is mixed between state root and state slot.
 // state root is in the mix to defend against different forks with same skip slots
 // to hit the same cache. We don't want beacon states mixed up between different chains.
-func cacheKey(ctx context.Context, state iface.ReadOnlyBeaconState) ([32]byte, error) {
+func CacheKey(ctx context.Context, state iface.ReadOnlyBeaconState) ([32]byte, error) {
 	bh := state.LatestBlockHeader()
 	if bh == nil {
 		return [32]byte{}, errors.New("block head in state can't be nil")

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -229,7 +229,7 @@ func ProcessSlots(ctx context.Context, state iface.BeaconState, slot types.Slot)
 	}
 
 	highestSlot := state.Slot()
-	key, err := cacheKey(ctx, state)
+	key, err := CacheKey(ctx, state)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add `ProcessSlots` for Altair. This is the same implementation as phase 0 except using Altair version of `ProcessEpoch`