### PR TITLE
POW: remove context from log message

### DIFF
--- a/beacon-chain/node/registration/powchain.go
+++ b/beacon-chain/node/registration/powchain.go
@@ -18,11 +18,9 @@ func PowchainPreregistration(cliCtx *cli.Context) (depositContractAddress string
 
 	if cliCtx.String(flags.HTTPWeb3ProviderFlag.Name) == "" && len(cliCtx.StringSlice(flags.FallbackWeb3ProviderFlag.Name)) == 0 {
 		log.Error(
-			cliCtx.Context,
 			"No ETH1 node specified to run with the beacon node. Please consider running your own ETH1 node for better uptime, security, and decentralization of ETH2. Visit https://docs.prylabs.network/docs/prysm-usage/setup-eth1 for more information.",
 		)
 		log.Error(
-			cliCtx.Context,
 			"You will need to specify --http-web3provider and/or --fallback-web3provider to attach an eth1 node to the prysm node. Without an eth1 node block proposals for your validator will be affected and the beacon node will not be able to initialize the genesis state.",
 		)
 	}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Fixes a weird log message.

```
[2021-04-16 12:31:40] ERROR registration: context.BackgroundNo ETH1 node specified to run with the beacon node. Please consider running your own ETH1 node for better uptime, security, and decentralization of ETH2. Visit https://docs.prylabs.network/docs/prysm-usage/setup-eth1 for more information.
[2021-04-16 12:31:40] ERROR registration: context.BackgroundYou will need to specify --http-web3provider and/or --fallback-web3provider to attach an eth1 node to the prysm node. Without an eth1 node block proposals for your validator will be affected and the beacon node will not be able to initialize the genesis state.
```

**Which issues(s) does this PR fix?**

None filed, quick fix.

**Other notes for review**
