### PR TITLE
Altair: "operations" spec tests

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+spectest/minimal/altair

--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//beacon-chain:__subpackages__",
         "//shared/testutil:__pkg__",
         "//shared/testutil/altair:__pkg__",
+        "//spectest:__subpackages__",
     ],
     deps = [
         "//beacon-chain/cache:go_default_library",

--- a/beacon-chain/state/state-altair/BUILD.bazel
+++ b/beacon-chain/state/state-altair/BUILD.bazel
@@ -21,7 +21,10 @@ go_library(
         "validator_getters.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/state/state-altair",
-    visibility = ["//beacon-chain:__subpackages__"],
+    visibility = [
+        "//beacon-chain:__subpackages__",
+        "//spectest:__subpackages__",
+    ],
     deps = [
         "//beacon-chain/p2p/types:go_default_library",
         "//beacon-chain/state/interface:go_default_library",

--- a/spectest/mainnet/altair/operations/BUILD.bazel
+++ b/spectest/mainnet/altair/operations/BUILD.bazel
@@ -6,6 +6,7 @@ go_test(
     srcs = [
         "attestation_test.go",
         "attester_slashing_test.go",
+        "block_header_test.go",
     ],
     data = glob(["*.yaml"]) + [
         "@eth2_spec_tests_mainnet//:test_data",

--- a/spectest/mainnet/altair/operations/BUILD.bazel
+++ b/spectest/mainnet/altair/operations/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["attestation_test.go"],
+    data = glob(["*.yaml"]) + [
+        "@eth2_spec_tests_mainnet//:test_data",
+    ],
+    shard_count = 4,
+    tags = ["spectest"],
+    deps = ["//spectest/shared/altair/operations:go_default_library"],
+)

--- a/spectest/mainnet/altair/operations/BUILD.bazel
+++ b/spectest/mainnet/altair/operations/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "attester_slashing_test.go",
         "block_header_test.go",
         "deposit_test.go",
+        "proposer_slashing_test.go",
     ],
     data = glob(["*.yaml"]) + [
         "@eth2_spec_tests_mainnet//:test_data",

--- a/spectest/mainnet/altair/operations/BUILD.bazel
+++ b/spectest/mainnet/altair/operations/BUILD.bazel
@@ -3,7 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["attestation_test.go"],
+    srcs = [
+        "attestation_test.go",
+        "attester_slashing_test.go",
+    ],
     data = glob(["*.yaml"]) + [
         "@eth2_spec_tests_mainnet//:test_data",
     ],

--- a/spectest/mainnet/altair/operations/BUILD.bazel
+++ b/spectest/mainnet/altair/operations/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "block_header_test.go",
         "deposit_test.go",
         "proposer_slashing_test.go",
+        "voluntary_exit_test.go",
     ],
     data = glob(["*.yaml"]) + [
         "@eth2_spec_tests_mainnet//:test_data",

--- a/spectest/mainnet/altair/operations/BUILD.bazel
+++ b/spectest/mainnet/altair/operations/BUILD.bazel
@@ -7,6 +7,7 @@ go_test(
         "attestation_test.go",
         "attester_slashing_test.go",
         "block_header_test.go",
+        "deposit_test.go",
     ],
     data = glob(["*.yaml"]) + [
         "@eth2_spec_tests_mainnet//:test_data",

--- a/spectest/mainnet/altair/operations/attestation_test.go
+++ b/spectest/mainnet/altair/operations/attestation_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMainnet_Altair_Operations_Attestation(t *testing.T) {
+	operations.RunAttestationTest(t, "mainnet")
+}

--- a/spectest/mainnet/altair/operations/attester_slashing_test.go
+++ b/spectest/mainnet/altair/operations/attester_slashing_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMainnet_Altair_Operations_AttesterSlashing(t *testing.T) {
+	operations.RunAttesterSlashingTest(t, "mainnet")
+}

--- a/spectest/mainnet/altair/operations/block_header_test.go
+++ b/spectest/mainnet/altair/operations/block_header_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMainnet_Altair_Operations_BlockHeader(t *testing.T) {
+	operations.RunBlockHeaderTest(t, "mainnet")
+}

--- a/spectest/mainnet/altair/operations/deposit_test.go
+++ b/spectest/mainnet/altair/operations/deposit_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMainnet_Altair_Operations_Deposit(t *testing.T) {
+	operations.RunDepositTest(t, "mainnet")
+}

--- a/spectest/mainnet/altair/operations/proposer_slashing_test.go
+++ b/spectest/mainnet/altair/operations/proposer_slashing_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMainnet_Altair_Operations_ProposerSlashing(t *testing.T) {
+	operations.RunProposerSlashingTest(t, "mainnet")
+}

--- a/spectest/mainnet/altair/operations/voluntary_exit_test.go
+++ b/spectest/mainnet/altair/operations/voluntary_exit_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMainnet_Altair_Operations_VoluntaryExit(t *testing.T) {
+	operations.RunVoluntaryExitTest(t, "mainnet")
+}

--- a/spectest/minimal/altair/operations/BUILD.bazel
+++ b/spectest/minimal/altair/operations/BUILD.bazel
@@ -4,7 +4,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["attestation_test.go"],
+    srcs = [
+        "attestation_test.go",
+        "attester_slashing_test.go",
+    ],
     data = glob(["*.yaml"]) + [
         "@eth2_spec_tests_minimal//:test_data",
     ],

--- a/spectest/minimal/altair/operations/BUILD.bazel
+++ b/spectest/minimal/altair/operations/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "attestation_test.go",
         "attester_slashing_test.go",
         "block_header_test.go",
+        "deposit_test.go",
     ],
     data = glob(["*.yaml"]) + [
         "@eth2_spec_tests_minimal//:test_data",

--- a/spectest/minimal/altair/operations/BUILD.bazel
+++ b/spectest/minimal/altair/operations/BUILD.bazel
@@ -7,6 +7,7 @@ go_test(
     srcs = [
         "attestation_test.go",
         "attester_slashing_test.go",
+        "block_header_test.go",
     ],
     data = glob(["*.yaml"]) + [
         "@eth2_spec_tests_minimal//:test_data",

--- a/spectest/minimal/altair/operations/BUILD.bazel
+++ b/spectest/minimal/altair/operations/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "block_header_test.go",
         "deposit_test.go",
         "proposer_slashing_test.go",
+        "voluntary_exit_test.go",
     ],
     data = glob(["*.yaml"]) + [
         "@eth2_spec_tests_minimal//:test_data",

--- a/spectest/minimal/altair/operations/BUILD.bazel
+++ b/spectest/minimal/altair/operations/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+# Requires --define ssz=minimal
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["attestation_test.go"],
+    data = glob(["*.yaml"]) + [
+        "@eth2_spec_tests_minimal//:test_data",
+    ],
+    tags = [
+        "manual",
+        "minimal",
+        "spectest",
+    ],
+    deps = ["//spectest/shared/altair/operations:go_default_library"],
+)

--- a/spectest/minimal/altair/operations/BUILD.bazel
+++ b/spectest/minimal/altair/operations/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "attester_slashing_test.go",
         "block_header_test.go",
         "deposit_test.go",
+        "proposer_slashing_test.go",
     ],
     data = glob(["*.yaml"]) + [
         "@eth2_spec_tests_minimal//:test_data",

--- a/spectest/minimal/altair/operations/attestation_test.go
+++ b/spectest/minimal/altair/operations/attestation_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMinimal_Altair_Operations_Attestation(t *testing.T) {
+	operations.RunAttestationTest(t, "minimal")
+}

--- a/spectest/minimal/altair/operations/attester_slashing_test.go
+++ b/spectest/minimal/altair/operations/attester_slashing_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMinimal_Altair_Operations_AttesterSlashing(t *testing.T) {
+	operations.RunAttesterSlashingTest(t, "minimal")
+}

--- a/spectest/minimal/altair/operations/block_header_test.go
+++ b/spectest/minimal/altair/operations/block_header_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMinimal_Altair_Operations_BlockHeader(t *testing.T) {
+	operations.RunBlockHeaderTest(t, "minimal")
+}

--- a/spectest/minimal/altair/operations/deposit_test.go
+++ b/spectest/minimal/altair/operations/deposit_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMinimal_Altair_Operations_Deposit(t *testing.T) {
+	operations.RunDepositTest(t, "minimal")
+}

--- a/spectest/minimal/altair/operations/proposer_slashing_test.go
+++ b/spectest/minimal/altair/operations/proposer_slashing_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMinimal_Altair_Operations_ProposerSlashing(t *testing.T) {
+	operations.RunProposerSlashingTest(t, "minimal")
+}

--- a/spectest/minimal/altair/operations/voluntary_exit_test.go
+++ b/spectest/minimal/altair/operations/voluntary_exit_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMinimal_Altair_Operations_VoluntaryExit(t *testing.T) {
+	operations.RunVoluntaryExitTest(t, "minimal")
+}

--- a/spectest/shared/altair/operations/BUILD.bazel
+++ b/spectest/shared/altair/operations/BUILD.bazel
@@ -5,12 +5,14 @@ go_library(
     testonly = True,
     srcs = [
         "attestation.go",
+        "attester_slashing.go",
         "helpers.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/spectest/shared/altair/operations",
     visibility = ["//spectest:__subpackages__"],
     deps = [
         "//beacon-chain/core/altair:go_default_library",
+        "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/state/interface:go_default_library",
         "//beacon-chain/state/state-altair:go_default_library",

--- a/spectest/shared/altair/operations/BUILD.bazel
+++ b/spectest/shared/altair/operations/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    testonly = True,
+    srcs = [
+        "attestation.go",
+        "helpers.go",
+    ],
+    importpath = "github.com/prysmaticlabs/prysm/spectest/shared/altair/operations",
+    visibility = ["//spectest:__subpackages__"],
+    deps = [
+        "//beacon-chain/core/altair:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
+        "//beacon-chain/state/interface:go_default_library",
+        "//beacon-chain/state/state-altair:go_default_library",
+        "//proto/beacon/p2p/v1:go_default_library",
+        "//shared/testutil:go_default_library",
+        "//shared/testutil/require:go_default_library",
+        "//spectest/utils:go_default_library",
+        "@com_github_gogo_protobuf//proto:go_default_library",
+        "@com_github_golang_snappy//:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
+        "@in_gopkg_d4l3k_messagediff_v1//:go_default_library",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+    ],
+)

--- a/spectest/shared/altair/operations/BUILD.bazel
+++ b/spectest/shared/altair/operations/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "block_header.go",
         "deposit.go",
         "helpers.go",
+        "proposer_slashing.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/spectest/shared/altair/operations",
     visibility = ["//spectest:__subpackages__"],

--- a/spectest/shared/altair/operations/BUILD.bazel
+++ b/spectest/shared/altair/operations/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "attestation.go",
         "attester_slashing.go",
+        "block_header.go",
         "helpers.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/spectest/shared/altair/operations",

--- a/spectest/shared/altair/operations/BUILD.bazel
+++ b/spectest/shared/altair/operations/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "deposit.go",
         "helpers.go",
         "proposer_slashing.go",
+        "voluntary_exit.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/spectest/shared/altair/operations",
     visibility = ["//spectest:__subpackages__"],

--- a/spectest/shared/altair/operations/BUILD.bazel
+++ b/spectest/shared/altair/operations/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "attestation.go",
         "attester_slashing.go",
         "block_header.go",
+        "deposit.go",
         "helpers.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/spectest/shared/altair/operations",

--- a/spectest/shared/altair/operations/attestation.go
+++ b/spectest/shared/altair/operations/attestation.go
@@ -1,0 +1,32 @@
+package operations
+
+import (
+	"path"
+	"testing"
+
+	"github.com/golang/snappy"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"github.com/prysmaticlabs/prysm/spectest/utils"
+)
+
+func RunAttestationTest(t *testing.T, config string) {
+	require.NoError(t, utils.SetConfig(t, config))
+	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/attestation/pyspec_tests")
+	for _, folder := range testFolders {
+		t.Run(folder.Name(), func(t *testing.T) {
+			folderPath := path.Join(testsFolderPath, folder.Name())
+			attestationFile, err := testutil.BazelFileBytes(folderPath, "attestation.ssz_snappy")
+			require.NoError(t, err)
+			attestationSSZ, err := snappy.Decode(nil /* dst */, attestationFile)
+			require.NoError(t, err, "Failed to decompress")
+			att := &ethpb.Attestation{}
+			require.NoError(t, att.UnmarshalSSZ(attestationSSZ), "Failed to unmarshal")
+
+			body := &ethpb.BeaconBlockBody{Attestations: []*ethpb.Attestation{att}}
+			RunBlockOperationTest(t, folderPath, body, altair.ProcessAttestations)
+		})
+	}
+}

--- a/spectest/shared/altair/operations/attester_slashing.go
+++ b/spectest/shared/altair/operations/attester_slashing.go
@@ -1,0 +1,37 @@
+package operations
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/golang/snappy"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"github.com/prysmaticlabs/prysm/spectest/utils"
+)
+
+func RunAttesterSlashingTest(t *testing.T, config string) {
+	require.NoError(t, utils.SetConfig(t, config))
+	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/attester_slashing/pyspec_tests")
+	for _, folder := range testFolders {
+		t.Run(folder.Name(), func(t *testing.T) {
+			folderPath := path.Join(testsFolderPath, folder.Name())
+			attSlashingFile, err := testutil.BazelFileBytes(folderPath, "attester_slashing.ssz_snappy")
+			require.NoError(t, err)
+			attSlashingSSZ, err := snappy.Decode(nil /* dst */, attSlashingFile)
+			require.NoError(t, err, "Failed to decompress")
+			attSlashing := &ethpb.AttesterSlashing{}
+			require.NoError(t, attSlashing.UnmarshalSSZ(attSlashingSSZ), "Failed to unmarshal")
+
+			body := &ethpb.BeaconBlockBody{AttesterSlashings: []*ethpb.AttesterSlashing{attSlashing}}
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s iface.BeaconState, b *ethpb.SignedBeaconBlock) (iface.BeaconState, error) {
+				return blocks.ProcessAttesterSlashings(ctx, s, b.Block.Body.AttesterSlashings, altair.SlashValidator)
+			})
+		})
+	}
+}

--- a/spectest/shared/altair/operations/block_header.go
+++ b/spectest/shared/altair/operations/block_header.go
@@ -1,0 +1,84 @@
+package operations
+
+import (
+	"io/ioutil"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
+	stateAltair "github.com/prysmaticlabs/prysm/beacon-chain/state/state-altair"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"github.com/prysmaticlabs/prysm/spectest/utils"
+	"gopkg.in/d4l3k/messagediff.v1"
+)
+
+func RunBlockHeaderTest(t *testing.T, config string) {
+	require.NoError(t, utils.SetConfig(t, config))
+	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/block_header/pyspec_tests")
+	for _, folder := range testFolders {
+		t.Run(folder.Name(), func(t *testing.T) {
+			blockFile, err := testutil.BazelFileBytes(testsFolderPath, folder.Name(), "block.ssz_snappy")
+			require.NoError(t, err)
+			blockSSZ, err := snappy.Decode(nil /* dst */, blockFile)
+			require.NoError(t, err, "Failed to decompress")
+			block := &ethpb.BeaconBlockAltair{}
+			require.NoError(t, block.UnmarshalSSZ(blockSSZ), "Failed to unmarshal")
+
+			preBeaconStateFile, err := testutil.BazelFileBytes(testsFolderPath, folder.Name(), "pre.ssz_snappy")
+			require.NoError(t, err)
+			preBeaconStateSSZ, err := snappy.Decode(nil /* dst */, preBeaconStateFile)
+			require.NoError(t, err, "Failed to decompress")
+			preBeaconStateBase := &pb.BeaconStateAltair{}
+			require.NoError(t, preBeaconStateBase.UnmarshalSSZ(preBeaconStateSSZ), "Failed to unmarshal")
+			preBeaconState, err := stateAltair.InitializeFromProto(preBeaconStateBase)
+			require.NoError(t, err)
+
+			// If the post.ssz is not present, it means the test should fail on our end.
+			postSSZFilepath, err := bazel.Runfile(path.Join(testsFolderPath, folder.Name(), "post.ssz_snappy"))
+			postSSZExists := true
+			if err != nil && strings.Contains(err.Error(), "could not locate file") {
+				postSSZExists = false
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Spectest blocks are not signed, so we'll call NoVerify to skip sig verification.
+			bodyRoot, err := block.Body.HashTreeRoot()
+			require.NoError(t, err)
+			beaconState, err := blocks.ProcessBlockHeaderNoVerify(preBeaconState, block.Slot, block.ProposerIndex, block.ParentRoot, bodyRoot[:])
+			if postSSZExists {
+				require.NoError(t, err)
+
+				postBeaconStateFile, err := ioutil.ReadFile(postSSZFilepath)
+				require.NoError(t, err)
+				postBeaconStateSSZ, err := snappy.Decode(nil /* dst */, postBeaconStateFile)
+				require.NoError(t, err, "Failed to decompress")
+
+				postBeaconState := &pb.BeaconStateAltair{}
+				require.NoError(t, postBeaconState.UnmarshalSSZ(postBeaconStateSSZ), "Failed to unmarshal")
+				pbState, err := stateAltair.ProtobufBeaconState(beaconState.CloneInnerState())
+				require.NoError(t, err)
+				if !proto.Equal(pbState, postBeaconState) {
+					diff, _ := messagediff.PrettyDiff(beaconState.CloneInnerState(), postBeaconState)
+					t.Log(diff)
+					t.Fatal("Post state does not match expected")
+				}
+			} else {
+				// Note: This doesn't test anything worthwhile. It essentially tests
+				// that *any* error has occurred, not any specific error.
+				if err == nil {
+					t.Fatal("Did not fail when expected")
+				}
+				t.Logf("Expected failure; failure reason = %v", err)
+				return
+			}
+		})
+	}
+}

--- a/spectest/shared/altair/operations/deposit.go
+++ b/spectest/shared/altair/operations/deposit.go
@@ -1,0 +1,37 @@
+package operations
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/golang/snappy"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"github.com/prysmaticlabs/prysm/spectest/utils"
+)
+
+func RunDepositTest(t *testing.T, config string) {
+	require.NoError(t, utils.SetConfig(t, config))
+	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/deposit/pyspec_tests")
+	for _, folder := range testFolders {
+		t.Run(folder.Name(), func(t *testing.T) {
+			folderPath := path.Join(testsFolderPath, folder.Name())
+			depositFile, err := testutil.BazelFileBytes(folderPath, "deposit.ssz_snappy")
+			require.NoError(t, err)
+			depositSSZ, err := snappy.Decode(nil /* dst */, depositFile)
+			require.NoError(t, err, "Failed to decompress")
+			deposit := &ethpb.Deposit{}
+			require.NoError(t, deposit.UnmarshalSSZ(depositSSZ), "Failed to unmarshal")
+
+			body := &ethpb.BeaconBlockBody{Deposits: []*ethpb.Deposit{deposit}}
+			processDepositsFunc := func(ctx context.Context, s iface.BeaconState, b *ethpb.SignedBeaconBlock) (iface.BeaconState, error) {
+				return altair.ProcessDeposits(ctx, s, b.Block.Body.Deposits)
+			}
+			RunBlockOperationTest(t, folderPath, body, processDepositsFunc)
+		})
+	}
+}

--- a/spectest/shared/altair/operations/helpers.go
+++ b/spectest/shared/altair/operations/helpers.go
@@ -1,0 +1,85 @@
+package operations
+
+import (
+	"context"
+	"io/ioutil"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	stateAltair "github.com/prysmaticlabs/prysm/beacon-chain/state/state-altair"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"gopkg.in/d4l3k/messagediff.v1"
+)
+
+type blockOperation func(context.Context, iface.BeaconState, *ethpb.SignedBeaconBlock) (iface.BeaconState, error)
+
+// RunBlockOperationTest takes in the prestate and the beacon block body, processes it through the
+// passed in block operation function and checks the post state with the expected post state.
+func RunBlockOperationTest(
+	t *testing.T,
+	folderPath string,
+	body *ethpb.BeaconBlockBody,
+	operationFn blockOperation,
+) {
+	preBeaconStateFile, err := testutil.BazelFileBytes(path.Join(folderPath, "pre.ssz_snappy"))
+	require.NoError(t, err)
+	preBeaconStateSSZ, err := snappy.Decode(nil /* dst */, preBeaconStateFile)
+	require.NoError(t, err, "Failed to decompress")
+	preStateBase := &pb.BeaconStateAltair{}
+	if err := preStateBase.UnmarshalSSZ(preBeaconStateSSZ); err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+	preState, err := stateAltair.InitializeFromProto(preStateBase)
+	require.NoError(t, err)
+
+	// If the post.ssz is not present, it means the test should fail on our end.
+	postSSZFilepath, err := bazel.Runfile(path.Join(folderPath, "post.ssz_snappy"))
+	postSSZExists := true
+	if err != nil && strings.Contains(err.Error(), "could not locate file") {
+		postSSZExists = false
+	} else if err != nil {
+		t.Fatal(err)
+	}
+
+	helpers.ClearCache()
+	b := testutil.NewBeaconBlock()
+	b.Block.Body = body
+	beaconState, err := operationFn(context.Background(), preState, b)
+	if postSSZExists {
+		require.NoError(t, err)
+
+		postBeaconStateFile, err := ioutil.ReadFile(postSSZFilepath)
+		require.NoError(t, err)
+		postBeaconStateSSZ, err := snappy.Decode(nil /* dst */, postBeaconStateFile)
+		require.NoError(t, err, "Failed to decompress")
+
+		postBeaconState := &pb.BeaconStateAltair{}
+		if err := postBeaconState.UnmarshalSSZ(postBeaconStateSSZ); err != nil {
+			t.Fatalf("Failed to unmarshal: %v", err)
+		}
+		pbState, err := stateAltair.ProtobufBeaconState(beaconState.InnerStateUnsafe())
+		require.NoError(t, err)
+		if !proto.Equal(pbState, postBeaconState) {
+			diff, _ := messagediff.PrettyDiff(beaconState.InnerStateUnsafe(), postBeaconState)
+			t.Log(diff)
+			t.Fatal("Post state does not match expected")
+		}
+	} else {
+		// Note: This doesn't test anything worthwhile. It essentially tests
+		// that *any* error has occurred, not any specific error.
+		if err == nil {
+			t.Fatal("Did not fail when expected")
+		}
+		t.Logf("Expected failure; failure reason = %v", err)
+		return
+	}
+}

--- a/spectest/shared/altair/operations/proposer_slashing.go
+++ b/spectest/shared/altair/operations/proposer_slashing.go
@@ -1,0 +1,37 @@
+package operations
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/golang/snappy"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"github.com/prysmaticlabs/prysm/spectest/utils"
+)
+
+func RunProposerSlashingTest(t *testing.T, config string) {
+	require.NoError(t, utils.SetConfig(t, config))
+	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/proposer_slashing/pyspec_tests")
+	for _, folder := range testFolders {
+		t.Run(folder.Name(), func(t *testing.T) {
+			folderPath := path.Join(testsFolderPath, folder.Name())
+			proposerSlashingFile, err := testutil.BazelFileBytes(folderPath, "proposer_slashing.ssz_snappy")
+			require.NoError(t, err)
+			proposerSlashingSSZ, err := snappy.Decode(nil /* dst */, proposerSlashingFile)
+			require.NoError(t, err, "Failed to decompress")
+			proposerSlashing := &ethpb.ProposerSlashing{}
+			require.NoError(t, proposerSlashing.UnmarshalSSZ(proposerSlashingSSZ), "Failed to unmarshal")
+
+			body := &ethpb.BeaconBlockBody{ProposerSlashings: []*ethpb.ProposerSlashing{proposerSlashing}}
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s iface.BeaconState, b *ethpb.SignedBeaconBlock) (iface.BeaconState, error) {
+				return blocks.ProcessProposerSlashings(ctx, s, b.Block.Body.ProposerSlashings, altair.SlashValidator)
+			})
+		})
+	}
+}

--- a/spectest/shared/altair/operations/voluntary_exit.go
+++ b/spectest/shared/altair/operations/voluntary_exit.go
@@ -1,0 +1,36 @@
+package operations
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/golang/snappy"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"github.com/prysmaticlabs/prysm/spectest/utils"
+)
+
+func RunVoluntaryExitTest(t *testing.T, config string) {
+	require.NoError(t, utils.SetConfig(t, config))
+	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/voluntary_exit/pyspec_tests")
+	for _, folder := range testFolders {
+		t.Run(folder.Name(), func(t *testing.T) {
+			folderPath := path.Join(testsFolderPath, folder.Name())
+			exitFile, err := testutil.BazelFileBytes(folderPath, "voluntary_exit.ssz_snappy")
+			require.NoError(t, err)
+			exitSSZ, err := snappy.Decode(nil /* dst */, exitFile)
+			require.NoError(t, err, "Failed to decompress")
+			voluntaryExit := &ethpb.SignedVoluntaryExit{}
+			require.NoError(t, voluntaryExit.UnmarshalSSZ(exitSSZ), "Failed to unmarshal")
+
+			body := &ethpb.BeaconBlockBody{VoluntaryExits: []*ethpb.SignedVoluntaryExit{voluntaryExit}}
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s iface.BeaconState, b *ethpb.SignedBeaconBlock) (iface.BeaconState, error) {
+				return blocks.ProcessVoluntaryExits(ctx, s, b.Block.Body.VoluntaryExits)
+			})
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

> Other / Tests

**What does this PR do? Why is it needed?**
- Implements `mainnet/altair/operations` tests (see [specs](https://github.com/ethereum/eth2.0-spec-tests/tree/master/tests/mainnet/altair/operations))
- Adds `spectest/minimal/altair` to `.bazelignore` for time being (minimal tests are included in this PR, they are just not run i.e. ignored). Once I figure out what is wrong with minimal config SSZ unmarshalling, single PR enabling all the Altair minimal tests (in `operations`, `epoch_processing` etc) will be added.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
