### PR TITLE
Fix `BaseReward` calculation

### DIFF
--- a/beacon-chain/core/altair/epoch_precompute.go
+++ b/beacon-chain/core/altair/epoch_precompute.go
@@ -175,7 +175,7 @@ func attestationDelta(bal *precompute.Balance, v *precompute.Validator, prevEpoc
 
 	ebi := params.BeaconConfig().EffectiveBalanceIncrement
 	eb := v.CurrentEpochEffectiveBalance
-	br := eb * params.BeaconConfig().BaseRewardFactor / mathutil.IntegerSquareRoot(bal.ActiveCurrentEpoch)
+	br := (eb / ebi) * (ebi * params.BeaconConfig().BaseRewardFactor / mathutil.IntegerSquareRoot(bal.ActiveCurrentEpoch))
 	activeCurrentEpochIncrements := bal.ActiveCurrentEpoch / ebi
 
 	r, p = uint64(0), uint64(0)


### PR DESCRIPTION
Base reward in spec is defined as 

```python
(state.validators[index].effective_balance // EFFECTIVE_BALANCE_INCREMENT) * Gwei(EFFECTIVE_BALANCE_INCREMENT * BASE_REWARD_FACTOR // integer_squareroot(get_total_active_balance(state)))
```

I thought I could cross out `EFFECTIVE_BALANCE_INCREMENT` but found it the hard way during spec test 😢 