### PR TITLE
Amend DepositNumberAndRootAtHeight Function to Fix Off-By-One

### DIFF
--- a/beacon-chain/cache/depositcache/deposits_cache.go
+++ b/beacon-chain/cache/depositcache/deposits_cache.go
@@ -176,7 +176,7 @@ func (dc *DepositCache) DepositsNumberAndRootAtHeight(ctx context.Context, block
 	defer dc.depositsLock.RUnlock()
 	for i := len(dc.deposits) - 1; i >= 0; i-- {
 		if dc.deposits[i].Eth1BlockHeight <= blockHeight.Uint64() {
-			return uint64(dc.deposits[i].Index), bytesutil.ToBytes32(dc.deposits[i].DepositRoot)
+			return uint64(dc.deposits[i].Index) + 1, bytesutil.ToBytes32(dc.deposits[i].DepositRoot)
 		}
 	}
 	return 0, params.BeaconConfig().ZeroHash

--- a/beacon-chain/cache/depositcache/deposits_cache.go
+++ b/beacon-chain/cache/depositcache/deposits_cache.go
@@ -167,20 +167,19 @@ func (dc *DepositCache) AllDeposits(ctx context.Context, untilBlk *big.Int) []*e
 	return deposits
 }
 
-// DepositsNumberAndRootAtHeight returns number of deposits made prior to blockheight and the
-// root that corresponds to the latest deposit at that blockheight.
+// DepositsNumberAndRootAtHeight returns the number of deposits that exist at a specified
+// block height. If no deposits are found at that block height, we return the number of deposits
+// at the first block height we find right beneath it. If nothing is found at all, we return 0 and
+// the empty root.
 func (dc *DepositCache) DepositsNumberAndRootAtHeight(ctx context.Context, blockHeight *big.Int) (uint64, [32]byte) {
-	ctx, span := trace.StartSpan(ctx, "DepositsCache.DepositsNumberAndRootAtHeight")
-	defer span.End()
 	dc.depositsLock.RLock()
 	defer dc.depositsLock.RUnlock()
-	heightIdx := sort.Search(len(dc.deposits), func(i int) bool { return dc.deposits[i].Eth1BlockHeight > blockHeight.Uint64() })
-	// send the deposit root of the empty trie, if eth1follow distance is greater than the time of the earliest
-	// deposit.
-	if heightIdx == 0 {
-		return 0, [32]byte{}
+	for i := len(dc.deposits) - 1; i >= 0; i-- {
+		if dc.deposits[i].Eth1BlockHeight <= blockHeight.Uint64() {
+			return uint64(dc.deposits[i].Index), bytesutil.ToBytes32(dc.deposits[i].DepositRoot)
+		}
 	}
-	return uint64(heightIdx), bytesutil.ToBytes32(dc.deposits[heightIdx-1].DepositRoot)
+	return 0, params.BeaconConfig().ZeroHash
 }
 
 // DepositByPubkey looks through historical deposits and finds one which contains

--- a/beacon-chain/cache/depositcache/deposits_cache_test.go
+++ b/beacon-chain/cache/depositcache/deposits_cache_test.go
@@ -162,22 +162,22 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 10,
-				Index:           1,
+				Index:           0,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 10,
-				Index:           2,
+				Index:           1,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 11,
-				Index:           3,
+				Index:           2,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 13,
-				Index:           4,
+				Index:           3,
 				Deposit:         &ethpb.Deposit{},
 				DepositRoot:     wantedRoot,
 			},
@@ -193,7 +193,7 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 10,
-				Index:           1,
+				Index:           0,
 				Deposit:         &ethpb.Deposit{},
 				DepositRoot:     wantedRoot,
 			},
@@ -209,18 +209,18 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 8,
-				Index:           1,
+				Index:           0,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 9,
-				Index:           2,
+				Index:           1,
 				Deposit:         &ethpb.Deposit{},
 				DepositRoot:     wantedRoot,
 			},
 			{
 				Eth1BlockHeight: 11,
-				Index:           3,
+				Index:           2,
 				Deposit:         &ethpb.Deposit{},
 			},
 		}
@@ -235,7 +235,7 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 8,
-				Index:           1,
+				Index:           0,
 				Deposit:         &ethpb.Deposit{},
 				DepositRoot:     wantedRoot,
 			},
@@ -251,7 +251,7 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 8,
-				Index:           1,
+				Index:           0,
 				Deposit:         &ethpb.Deposit{},
 				DepositRoot:     wantedRoot,
 			},
@@ -267,28 +267,28 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 8,
-				Index:           1,
+				Index:           0,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 8,
-				Index:           2,
+				Index:           1,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 9,
-				Index:           3,
+				Index:           2,
 				Deposit:         &ethpb.Deposit{},
 				DepositRoot:     wantedRoot,
 			},
 			{
 				Eth1BlockHeight: 10,
-				Index:           4,
+				Index:           3,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 10,
-				Index:           5,
+				Index:           4,
 				Deposit:         &ethpb.Deposit{},
 			},
 		}

--- a/beacon-chain/cache/depositcache/deposits_cache_test.go
+++ b/beacon-chain/cache/depositcache/deposits_cache_test.go
@@ -155,30 +155,36 @@ func TestAllDeposits_FiltersDepositUpToAndIncludingBlockNumber(t *testing.T) {
 }
 
 func TestDepositsNumberAndRootAtHeight(t *testing.T) {
+	wantedRoot := bytesutil.PadTo([]byte("root"), 32)
 	t.Run("requesting_last_item_works", func(t *testing.T) {
 		dc, err := New()
 		require.NoError(t, err)
-
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 10,
+				Index:           1,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 10,
+				Index:           2,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 11,
+				Index:           3,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 13,
+				Index:           4,
 				Deposit:         &ethpb.Deposit{},
+				DepositRoot:     wantedRoot,
 			},
 		}
-		n, _ := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(13))
+		n, root := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(13))
 		assert.Equal(t, 4, int(n))
+		require.DeepEqual(t, wantedRoot, root[:])
 	})
 	t.Run("only_one_item", func(t *testing.T) {
 		dc, err := New()
@@ -187,11 +193,14 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 10,
+				Index:           1,
 				Deposit:         &ethpb.Deposit{},
+				DepositRoot:     wantedRoot,
 			},
 		}
-		n, _ := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(10))
+		n, root := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(10))
 		assert.Equal(t, 1, int(n))
+		require.DeepEqual(t, wantedRoot, root[:])
 	})
 	t.Run("none_at_height_some_below", func(t *testing.T) {
 		dc, err := New()
@@ -200,19 +209,24 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 8,
+				Index:           1,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 9,
+				Index:           2,
 				Deposit:         &ethpb.Deposit{},
+				DepositRoot:     wantedRoot,
 			},
 			{
 				Eth1BlockHeight: 11,
+				Index:           3,
 				Deposit:         &ethpb.Deposit{},
 			},
 		}
-		n, _ := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(10))
+		n, root := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(10))
 		assert.Equal(t, 2, int(n))
+		require.DeepEqual(t, wantedRoot, root[:])
 	})
 	t.Run("none_at_height_none_below", func(t *testing.T) {
 		dc, err := New()
@@ -221,11 +235,14 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 8,
+				Index:           1,
 				Deposit:         &ethpb.Deposit{},
+				DepositRoot:     wantedRoot,
 			},
 		}
-		n, _ := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(7))
+		n, root := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(7))
 		assert.Equal(t, 0, int(n))
+		require.DeepEqual(t, params.BeaconConfig().ZeroHash, root)
 	})
 	t.Run("none_at_height_one_below", func(t *testing.T) {
 		dc, err := New()
@@ -234,11 +251,14 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 8,
+				Index:           1,
 				Deposit:         &ethpb.Deposit{},
+				DepositRoot:     wantedRoot,
 			},
 		}
-		n, _ := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(10))
+		n, root := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(10))
 		assert.Equal(t, 1, int(n))
+		require.DeepEqual(t, wantedRoot, root[:])
 	})
 	t.Run("some_greater_some_lower", func(t *testing.T) {
 		dc, err := New()
@@ -247,27 +267,34 @@ func TestDepositsNumberAndRootAtHeight(t *testing.T) {
 		dc.deposits = []*dbpb.DepositContainer{
 			{
 				Eth1BlockHeight: 8,
+				Index:           1,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 8,
+				Index:           2,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 9,
+				Index:           3,
+				Deposit:         &ethpb.Deposit{},
+				DepositRoot:     wantedRoot,
+			},
+			{
+				Eth1BlockHeight: 10,
+				Index:           4,
 				Deposit:         &ethpb.Deposit{},
 			},
 			{
 				Eth1BlockHeight: 10,
-				Deposit:         &ethpb.Deposit{},
-			},
-			{
-				Eth1BlockHeight: 10,
+				Index:           5,
 				Deposit:         &ethpb.Deposit{},
 			},
 		}
-		n, _ := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(9))
+		n, root := dc.DepositsNumberAndRootAtHeight(context.Background(), big.NewInt(9))
 		assert.Equal(t, 3, int(n))
+		require.DeepEqual(t, wantedRoot, root[:])
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

In summary, there was a serious incident affecting eth2 mainnet this past evening CST, which affected block proposals from Prysm validators throughout an eth1 voting period. This bug was causing Prysm nodes to vote in an incorrect eth1 data due to an off-by-one error through an edge case in the Go standard library.

In summary, we have the following problem:
```go
items := []int{1, 2, 2, 2, 3, 4, 4, 5}
```
and we use binary search from the Go standard library `sort` package, `sort.Search`, to find the index of an element `x` such that `items[i] > x`. However, the [official Go docs](https://golang.org/pkg/sort/#Search) for `sort.Search` state the following:

```
func Search(n int, f func(int) bool) int
Search uses binary search to find and return the smallest index i in [0, n) at which f(i) is true, 
assuming that on the range [0, n), f(i) == true implies f(i+1) == true. That is, Search requires that f is
false for some (possibly empty) prefix of the input range [0, n) and then true for the (possibly empty) remainder; 
Search returns the first true index. If there is no such index, Search returns n. 
(Note that the "not found" return value is not -1 as in, for instance, strings.Index.)
Search calls f(i) only for i in the range [0, n).
```

That is, the function returns the index in `[0, n)`, which means the upper limit is *not-inclusive*. If we wanted to return 5 (because total number of deposits start counting at 1) for searching for 5, we would *not* receive the expected value using the stdlib.

This led to an issue in determining the number of deposits at a given block height if said edge-case condition was met.

**Which issues(s) does this PR fix?**

Fixes #8298 