### PR TITLE
Apply inactivity when validator is slashed

### DIFF
--- a/beacon-chain/core/altair/epoch_precompute.go
+++ b/beacon-chain/core/altair/epoch_precompute.go
@@ -233,8 +233,8 @@ func attestationDelta(bal *precompute.Balance, v *precompute.Validator, prevEpoc
 		p += br * params.BeaconConfig().TimelyTargetWeight / params.BeaconConfig().WeightDenominator
 		p += br * params.BeaconConfig().TimelyHeadWeight / params.BeaconConfig().WeightDenominator
 
-		// Apply an additional penalty to validators that did not vote on the correct target.
-		if !v.IsPrevEpochTargetAttester {
+		// Apply an additional penalty to validators that did not vote on the correct target or slashed.
+		if !v.IsPrevEpochTargetAttester || v.IsSlashed {
 			// Increase validator's inactivity score by bias when validator didn't vote target.
 			v.InactivityScore += params.BeaconConfig().InactivityScoreBias
 


### PR DESCRIPTION
Part of #8638 

Credit to @rkapka, this was discovered in #8813. 

We should apply additional penalty during inactivity to slashed validators