### PR TITLE
Validate Big Number Strings Better

### DIFF
--- a/shared/bls/BUILD.bazel
+++ b/shared/bls/BUILD.bazel
@@ -26,6 +26,8 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//shared/bls/common:go_default_library",
+        "//shared/rand:go_default_library",
+        "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
     ],
 )

--- a/shared/bls/bls.go
+++ b/shared/bls/bls.go
@@ -30,10 +30,8 @@ func SecretKeyFromBigNum(s string) (SecretKey, error) {
 		return nil, errors.New("could not set big int from string")
 	}
 	bts := num.Bytes()
-	// Pad key at the start with zero bytes to make it into a 32 byte key.
-	if len(bts) < 32 {
-		emptyBytes := make([]byte, 32-len(bts))
-		bts = append(emptyBytes, bts...)
+	if len(bts) != 32 {
+		return nil, errors.Errorf("provided big number string sets to a key unequal to 32 bytes: %d != 32", len(bts))
 	}
 	return SecretKeyFromBytes(bts)
 }

--- a/shared/bls/bls_test.go
+++ b/shared/bls/bls_test.go
@@ -1,9 +1,12 @@
 package bls
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/shared/bls/common"
+	"github.com/prysmaticlabs/prysm/shared/rand"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
@@ -26,5 +29,33 @@ func TestDisallowZeroPublicKeys_AggregatePubkeys(t *testing.T) {
 	t.Run("blst", func(t *testing.T) {
 		_, err := AggregatePublicKeys([][]byte{common.InfinitePublicKey[:], common.InfinitePublicKey[:]})
 		require.Equal(t, common.ErrInfinitePubKey, err)
+	})
+}
+
+func TestValidateSecretKeyString(t *testing.T) {
+	t.Run("blst", func(t *testing.T) {
+		zeroNum := new(big.Int).SetUint64(0)
+		_, err := SecretKeyFromBigNum(zeroNum.String())
+		assert.ErrorContains(t, "provided big number string sets to a key unequal to 32 bytes", err)
+
+		rGen := rand.NewDeterministicGenerator()
+
+		randBytes := make([]byte, 40)
+		n, err := rGen.Read(randBytes)
+		assert.NoError(t, err)
+		assert.Equal(t, n, len(randBytes))
+		rBigNum := new(big.Int).SetBytes(randBytes)
+
+		// Expect larger than expected key size to fail.
+		_, err = SecretKeyFromBigNum(rBigNum.String())
+		assert.ErrorContains(t, "provided big number string sets to a key unequal to 32 bytes", err)
+
+		key, err := RandKey()
+		assert.NoError(t, err)
+		rBigNum = new(big.Int).SetBytes(key.Marshal())
+
+		// Expect correct size to pass.
+		_, err = SecretKeyFromBigNum(rBigNum.String())
+		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Removes the arbitrary padding of bytes to provided big number strings. 
- [x] Add unit test. 


**Which issues(s) does this PR fix?**

Resolves #8819 

**Other notes for review**
