### PR TITLE
Remove Missing Logs Method

### DIFF
--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -76,7 +76,6 @@ go_test(
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
-        "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/db/testing:go_default_library",
         "//beacon-chain/powchain/testing:go_default_library",

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -30,7 +30,6 @@ var (
 	depositEventSignature = hashutil.HashKeccak256([]byte("DepositEvent(bytes,bytes,bytes,bytes,bytes)"))
 )
 
-const eth1LookBackPeriod = 100
 const eth1DataSavingInterval = 100
 const maxTolerableDifference = 50
 const defaultEth1HeaderReqLimit = uint64(1000)

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -117,13 +117,7 @@ func (s *Service) ProcessDepositLog(ctx context.Context, depositLog gethTypes.Lo
 
 	if index != s.lastReceivedMerkleIndex+1 {
 		missedDepositLogsCount.Inc()
-		if s.requestingOldLogs {
-			return errors.New("received incorrect merkle index")
-		}
-		if err := s.requestMissingLogs(ctx, depositLog.BlockNumber, index-1); err != nil {
-			return errors.Wrap(err, "could not get correct merkle index")
-		}
-
+		return errors.Errorf("received incorrect merkle index: wanted %d but got %d", s.lastReceivedMerkleIndex+1, index)
 	}
 	s.lastReceivedMerkleIndex = index
 
@@ -408,50 +402,6 @@ func (s *Service) requestBatchedHeadersAndLogs(ctx context.Context) error {
 		s.latestEth1Data.LastRequestedBlock = i
 	}
 
-	return nil
-}
-
-// requestMissingLogs requests any logs that were missed by requesting from previous blocks
-// until the current block(exclusive).
-func (s *Service) requestMissingLogs(ctx context.Context, blkNumber uint64, wantedIndex int64) error {
-	// Prevent this method from being called recursively
-	s.requestingOldLogs = true
-	defer func() {
-		s.requestingOldLogs = false
-	}()
-	// We request from the last requested block till the current block(exclusive)
-	beforeCurrentBlk := big.NewInt(int64(blkNumber) - 1)
-	startBlock := s.latestEth1Data.LastRequestedBlock + 1
-	for {
-		err := s.processBlksInRange(ctx, startBlock, beforeCurrentBlk.Uint64())
-		if err != nil {
-			return err
-		}
-
-		if s.lastReceivedMerkleIndex == wantedIndex {
-			break
-		}
-
-		// If the required logs still do not exist after the lookback period, then we return an error.
-		if startBlock < s.latestEth1Data.LastRequestedBlock-eth1LookBackPeriod {
-			return fmt.Errorf(
-				"latest index observed is not accurate, wanted %d, but received  %d",
-				wantedIndex,
-				s.lastReceivedMerkleIndex,
-			)
-		}
-		startBlock--
-	}
-	return nil
-}
-
-func (s *Service) processBlksInRange(ctx context.Context, startBlk, endBlk uint64) error {
-	for i := startBlk; i <= endBlk; i++ {
-		err := s.ProcessETH1Block(ctx, big.NewInt(int64(i)))
-		if err != nil {
-			return err
-		}
-	}
 	return nil
 }
 

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -9,11 +9,9 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache/depositcache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	mockPOW "github.com/prysmaticlabs/prysm/beacon-chain/powchain/testing"
@@ -22,7 +20,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
-	"github.com/prysmaticlabs/prysm/shared/trieutil"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
@@ -550,92 +547,6 @@ func TestProcessETH2GenesisLog_LargePeriodOfNoLogs(t *testing.T) {
 	require.LogsDoNotContain(t, hook, "Receipt root from log doesn't match the root saved in memory")
 	require.LogsDoNotContain(t, hook, "Invalid timestamp from log")
 	require.LogsContain(t, hook, "Minimum number of validators reached for beacon-chain to start")
-
-	hook.Reset()
-}
-
-func TestWeb3ServiceProcessDepositLog_RequestMissedDeposits(t *testing.T) {
-	hook := logTest.NewGlobal()
-	testAcc, err := contracts.Setup()
-	require.NoError(t, err, "Unable to set up simulated backend")
-	beaconDB := testDB.SetupDB(t)
-	depositCache, err := depositcache.New()
-	require.NoError(t, err)
-
-	web3Service, err := NewService(context.Background(), &Web3ServiceConfig{
-		HttpEndpoints:   []string{endpoint},
-		DepositContract: testAcc.ContractAddr,
-		BeaconDB:        beaconDB,
-		DepositCache:    depositCache,
-	})
-	require.NoError(t, err, "unable to setup web3 ETH1.0 chain service")
-	web3Service = setDefaultMocks(web3Service)
-	web3Service.depositContractCaller, err = contracts.NewDepositContractCaller(testAcc.ContractAddr, testAcc.Backend)
-	require.NoError(t, err)
-	web3Service.httpLogger = testAcc.Backend
-	params.SetupTestConfigCleanup(t)
-	bConfig := params.MinimalSpecConfig()
-	bConfig.MinGenesisTime = 0
-	params.OverrideBeaconConfig(bConfig)
-
-	testAcc.Backend.Commit()
-	require.NoError(t, testAcc.Backend.AdjustTime(time.Duration(int64(time.Now().Nanosecond()))))
-	depositsWanted := 10
-	testutil.ResetCache()
-	deposits, _, err := testutil.DeterministicDepositsAndKeys(uint64(depositsWanted))
-	require.NoError(t, err)
-	_, depositRoots, err := testutil.DeterministicDepositTrie(len(deposits))
-	require.NoError(t, err)
-
-	for i := 0; i < depositsWanted; i++ {
-		data := deposits[i].Data
-		testAcc.TxOpts.Value = contracts.Amount32Eth()
-		testAcc.TxOpts.GasLimit = 1000000
-		_, err = testAcc.Contract.Deposit(testAcc.TxOpts, data.PublicKey, data.WithdrawalCredentials, data.Signature, depositRoots[i])
-		require.NoError(t, err, "Could not deposit to deposit contract")
-
-		testAcc.Backend.Commit()
-	}
-
-	query := ethereum.FilterQuery{
-		Addresses: []common.Address{
-			web3Service.cfg.DepositContract,
-		},
-	}
-
-	logs, err := testAcc.Backend.FilterLogs(web3Service.ctx, query)
-	require.NoError(t, err, "Unable to retrieve logs")
-	require.Equal(t, depositsWanted, len(logs), "Did not receive enough logs")
-
-	logsToBeProcessed := append(logs[:depositsWanted-3], logs[depositsWanted-2:]...)
-	// we purposely miss processing the middle two logs so that the service, re-requests them
-	for _, log := range logsToBeProcessed {
-		err = web3Service.ProcessLog(context.Background(), log)
-		require.NoError(t, err)
-		web3Service.latestEth1Data.LastRequestedBlock = log.BlockNumber
-	}
-
-	assert.Equal(t, int64(depositsWanted-1), web3Service.lastReceivedMerkleIndex, "missing logs were not re-requested")
-
-	web3Service.lastReceivedMerkleIndex = -1
-	web3Service.latestEth1Data.LastRequestedBlock = 0
-	genSt, err := state.EmptyGenesisState()
-	require.NoError(t, err)
-	web3Service.preGenesisState = genSt
-	require.NoError(t, web3Service.preGenesisState.SetEth1Data(&ethpb.Eth1Data{}))
-	web3Service.chainStartData.ChainstartDeposits = []*ethpb.Deposit{}
-	web3Service.depositTrie, err = trieutil.NewTrie(params.BeaconConfig().DepositContractTreeDepth)
-	require.NoError(t, err)
-
-	logsToBeProcessed = append(logs[:depositsWanted-8], logs[depositsWanted-2:]...)
-	// We purposely miss processing the middle 7 logs so that the service, re-requests them.
-	for _, log := range logsToBeProcessed {
-		err = web3Service.ProcessLog(context.Background(), log)
-		require.NoError(t, err)
-		web3Service.latestEth1Data.LastRequestedBlock = log.BlockNumber
-	}
-
-	assert.Equal(t, int64(depositsWanted-1), web3Service.lastReceivedMerkleIndex, "missing logs were not re-requested")
 
 	hook.Reset()
 }

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -126,7 +126,6 @@ type RPCClient interface {
 // Validator Registration Contract on the ETH1.0 chain to kick off the beacon
 // chain's validator registration process.
 type Service struct {
-	requestingOldLogs       bool
 	connectedETH1           bool
 	isRunning               bool
 	processingLock          sync.RWMutex


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

 - [x] In the event we receive out of order deposit logs, we simply return an error rather than attempting a backtrack of the
 missing deposit logs. This helps simplify our code and also resolves a potential nested RLock found in the course of building a RLock analyzer in #8775 . By removing the related methods, we treat a skipped index as a failure condition from the currently connected eth1 node.
 
**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
