### PR TITLE
Spec tests: improve readability of rewards tests output

### DIFF
--- a/spectest/shared/phase0/rewards/rewards_penalties.go
+++ b/spectest/shared/phase0/rewards/rewards_penalties.go
@@ -49,8 +49,7 @@ func RunPrecomputeRewardsAndPenaltiesTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testTypes := []string{"basic", "leak", "random"}
 	for _, testType := range testTypes {
-		testPath := fmt.Sprintf("rewards/%s/pyspec_tests", testType)
-		testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", testPath)
+		testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", fmt.Sprintf("rewards/%s/pyspec_tests", testType))
 		t.Run(testType, func(t *testing.T) {
 			for _, folder := range testFolders {
 				helpers.ClearCache()

--- a/spectest/shared/phase0/rewards/rewards_penalties.go
+++ b/spectest/shared/phase0/rewards/rewards_penalties.go
@@ -50,15 +50,13 @@ func RunPrecomputeRewardsAndPenaltiesTests(t *testing.T, config string) {
 	testTypes := []string{"basic", "leak", "random"}
 	for _, testType := range testTypes {
 		testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", fmt.Sprintf("rewards/%s/pyspec_tests", testType))
-		t.Run(testType, func(t *testing.T) {
-			for _, folder := range testFolders {
-				helpers.ClearCache()
-				t.Run(folder.Name(), func(t *testing.T) {
-					folderPath := path.Join(testsFolderPath, folder.Name())
-					runPrecomputeRewardsAndPenaltiesTest(t, folderPath)
-				})
-			}
-		})
+		for _, folder := range testFolders {
+			helpers.ClearCache()
+			t.Run(fmt.Sprintf("%v/%v", testType, folder.Name()), func(t *testing.T) {
+				folderPath := path.Join(testsFolderPath, folder.Name())
+				runPrecomputeRewardsAndPenaltiesTest(t, folderPath)
+			})
+		}
 	}
 }
 

--- a/spectest/shared/phase0/rewards/rewards_penalties.go
+++ b/spectest/shared/phase0/rewards/rewards_penalties.go
@@ -3,6 +3,7 @@ package rewards
 import (
 	"context"
 	"encoding/binary"
+	"fmt"
 	"path"
 	"reflect"
 	"testing"
@@ -45,13 +46,12 @@ var deltaFiles = []string{
 
 // RunPrecomputeRewardsAndPenaltiesTests executes "rewards/{basic, leak, random}" tests.
 func RunPrecomputeRewardsAndPenaltiesTests(t *testing.T, config string) {
-	require.NoError(t, utils.SetConfig(t, config))
-	testPaths := []string{"rewards/basic/pyspec_tests", "rewards/leak/pyspec_tests", "rewards/random/pyspec_tests"}
+	testPaths := []string{"basic", "leak", "random"}
 	for _, testPath := range testPaths {
-		testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", testPath)
+		testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", path.Join("rewards", testPath, "pyspec_tests"))
 		for _, folder := range testFolders {
 			helpers.ClearCache()
-			t.Run(folder.Name(), func(t *testing.T) {
+			t.Run(fmt.Sprintf("%v/%v", testPath, folder.Name()), func(t *testing.T) {
 				folderPath := path.Join(testsFolderPath, folder.Name())
 				runPrecomputeRewardsAndPenaltiesTest(t, folderPath)
 			})

--- a/spectest/shared/phase0/rewards/rewards_penalties.go
+++ b/spectest/shared/phase0/rewards/rewards_penalties.go
@@ -46,16 +46,20 @@ var deltaFiles = []string{
 
 // RunPrecomputeRewardsAndPenaltiesTests executes "rewards/{basic, leak, random}" tests.
 func RunPrecomputeRewardsAndPenaltiesTests(t *testing.T, config string) {
-	testPaths := []string{"basic", "leak", "random"}
-	for _, testPath := range testPaths {
-		testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", path.Join("rewards", testPath, "pyspec_tests"))
-		for _, folder := range testFolders {
-			helpers.ClearCache()
-			t.Run(fmt.Sprintf("%v/%v", testPath, folder.Name()), func(t *testing.T) {
-				folderPath := path.Join(testsFolderPath, folder.Name())
-				runPrecomputeRewardsAndPenaltiesTest(t, folderPath)
-			})
-		}
+	require.NoError(t, utils.SetConfig(t, config))
+	testTypes := []string{"basic", "leak", "random"}
+	for _, testType := range testTypes {
+		testPath := fmt.Sprintf("rewards/%s/pyspec_tests", testType)
+		testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", testPath)
+		t.Run(testType, func(t *testing.T) {
+			for _, folder := range testFolders {
+				helpers.ClearCache()
+				t.Run(folder.Name(), func(t *testing.T) {
+					folderPath := path.Join(testsFolderPath, folder.Name())
+					runPrecomputeRewardsAndPenaltiesTest(t, folderPath)
+				})
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

> Other / Cleanup

**What does this PR do? Why is it needed?**
- When working for rewards tests for Altair (in #8818), I've noticed that test outputs do not feature what type/subcategory of "rewards" tests is being run:
![image](https://user-images.githubusercontent.com/188194/116264233-cd7c6200-a782-11eb-92e0-8e7a98a5cfa6.png)

- This small PR updates output of those tests:
![image](https://user-images.githubusercontent.com/188194/116264137-b8073800-a782-11eb-89ac-469c5ff6c3b3.png)


**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
