### PR TITLE
Invert `attest-timely` flag

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -225,9 +225,10 @@ func ConfigureValidator(ctx *cli.Context) {
 		log.WithField(disableAttestingHistoryDBCache.Name, disableAttestingHistoryDBCache.Usage).Warn(enabledFeatureFlag)
 		cfg.DisableAttestingHistoryDBCache = true
 	}
-	if ctx.Bool(attestTimely.Name) {
-		log.WithField(attestTimely.Name, attestTimely.Usage).Warn(enabledFeatureFlag)
-		cfg.AttestTimely = true
+	cfg.AttestTimely = true
+	if ctx.Bool(disableAttestTimely.Name) {
+		log.WithField(disableAttestTimely.Name, disableAttestTimely.Usage).Warn(enabledFeatureFlag)
+		cfg.AttestTimely = false
 	}
 	if ctx.Bool(enableSlashingProtectionPruning.Name) {
 		log.WithField(enableSlashingProtectionPruning.Name, enableSlashingProtectionPruning.Usage).Warn(enabledFeatureFlag)

--- a/shared/featureconfig/deprecated_flags.go
+++ b/shared/featureconfig/deprecated_flags.go
@@ -37,6 +37,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedAttestingTimely = &cli.BoolFlag{
+		Name:   "attest-timely",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -46,4 +51,5 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedDisablePruningDepositProofs,
 	deprecatedDisableEth1DataMajorityVote,
 	deprecatedDisableBlst,
+	deprecatedAttestingTimely,
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -98,9 +98,9 @@ var (
 		Name:  "disable-broadcast-slashings",
 		Usage: "Disables broadcasting slashings submitted to the beacon node.",
 	}
-	attestTimely = &cli.BoolFlag{
-		Name:  "attest-timely",
-		Usage: "Fixes validator can attest timely after current block processes. See #8185 for more details",
+	disableAttestTimely = &cli.BoolFlag{
+		Name:  "disable-attest-timely",
+		Usage: "Disable attest timely, a fix where validator can attest timely after current block processes. See #8185 for more details",
 	}
 	enableNextSlotStateCache = &cli.BoolFlag{
 		Name:  "enable-next-slot-state-cache",
@@ -140,7 +140,7 @@ var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	Mainnet,
 	disableAccountsV2,
 	dynamicKeyReloadDebounceInterval,
-	attestTimely,
+	disableAttestTimely,
 	enableSlashingProtectionPruning,
 }...)
 


### PR DESCRIPTION
After discussion with @prestonvanloon, we should Invert `attest-timely` flag to improve validator performance. Prysm validators are constantly waiting 1/3 slot to broadcast