### PR TITLE
Invert `proposer-atts-selection-using-max-cover` flag

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -186,9 +186,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.WithField(updateHeadTimely.Name, updateHeadTimely.Usage).Warn(enabledFeatureFlag)
 		cfg.UpdateHeadTimely = true
 	}
-	if ctx.Bool(proposerAttsSelectionUsingMaxCover.Name) {
-		log.WithField(proposerAttsSelectionUsingMaxCover.Name, proposerAttsSelectionUsingMaxCover.Usage).Warn(enabledFeatureFlag)
-		cfg.ProposerAttsSelectionUsingMaxCover = true
+	cfg.ProposerAttsSelectionUsingMaxCover = true
+	if ctx.Bool(disableProposerAttsSelectionUsingMaxCover.Name) {
+		log.WithField(disableProposerAttsSelectionUsingMaxCover.Name, disableProposerAttsSelectionUsingMaxCover.Usage).Warn(enabledFeatureFlag)
+		cfg.ProposerAttsSelectionUsingMaxCover = false
 	}
 	Init(cfg)
 }

--- a/shared/featureconfig/deprecated_flags.go
+++ b/shared/featureconfig/deprecated_flags.go
@@ -37,6 +37,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedProposerAttsSelectionUsingMaxCover = &cli.BoolFlag{
+		Name:   "proposer-atts-selection-using-max-cover",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -46,4 +51,5 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedDisablePruningDepositProofs,
 	deprecatedDisableEth1DataMajorityVote,
 	deprecatedDisableBlst,
+	deprecatedProposerAttsSelectionUsingMaxCover,
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -110,9 +110,9 @@ var (
 		Name:  "update-head-timely",
 		Usage: "Improves update head time by updating head right after state transition",
 	}
-	proposerAttsSelectionUsingMaxCover = &cli.BoolFlag{
-		Name:  "proposer-atts-selection-using-max-cover",
-		Usage: "Rely on max-cover algorithm when selecting attestations for proposer",
+	disableProposerAttsSelectionUsingMaxCover = &cli.BoolFlag{
+		Name:  "disable-proposer-atts-selection-using-max-cover",
+		Usage: "Disable max-cover algorithm when selecting attestations for proposer",
 	}
 	enableSlashingProtectionPruning = &cli.BoolFlag{
 		Name:  "enable-slashing-protection-pruning",
@@ -126,7 +126,6 @@ var devModeFlags = []cli.Flag{
 	enableNextSlotStateCache,
 	forceOptMaxCoverAggregationStategy,
 	updateHeadTimely,
-	proposerAttsSelectionUsingMaxCover,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -174,7 +173,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	enableNextSlotStateCache,
 	forceOptMaxCoverAggregationStategy,
 	updateHeadTimely,
-	proposerAttsSelectionUsingMaxCover,
+	disableProposerAttsSelectionUsingMaxCover,
 }...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
This PR inverts `ProposerAttsSelectionUsingMaxCover` flag to improve validator performance. This flag has also been tested for a while. It's part of `--dev`