### PR TITLE
Invert `next-slot-state-cache` flag

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -178,9 +178,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.WithField(disableBroadcastSlashingFlag.Name, disableBroadcastSlashingFlag.Usage).Warn(enabledFeatureFlag)
 		cfg.DisableBroadcastSlashings = true
 	}
-	if ctx.Bool(enableNextSlotStateCache.Name) {
-		log.WithField(enableNextSlotStateCache.Name, enableNextSlotStateCache.Usage).Warn(enabledFeatureFlag)
-		cfg.EnableNextSlotStateCache = true
+	cfg.EnableNextSlotStateCache = true
+	if ctx.Bool(disableNextSlotStateCache.Name) {
+		log.WithField(disableNextSlotStateCache.Name, disableNextSlotStateCache.Usage).Warn(enabledFeatureFlag)
+		cfg.EnableNextSlotStateCache = false
 	}
 	if ctx.Bool(updateHeadTimely.Name) {
 		log.WithField(updateHeadTimely.Name, updateHeadTimely.Usage).Warn(enabledFeatureFlag)

--- a/shared/featureconfig/deprecated_flags.go
+++ b/shared/featureconfig/deprecated_flags.go
@@ -37,6 +37,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableNextSlotCache = &cli.BoolFlag{
+		Name:   "enable-next-slot-state-cache",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -46,4 +51,5 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedDisablePruningDepositProofs,
 	deprecatedDisableEth1DataMajorityVote,
 	deprecatedDisableBlst,
+	deprecatedEnableNextSlotCache,
 }

--- a/shared/featureconfig/deprecated_flags.go
+++ b/shared/featureconfig/deprecated_flags.go
@@ -39,9 +39,9 @@ var (
 	}
 	deprecatedEnableNextSlotCache = &cli.BoolFlag{
 		Name:   "enable-next-slot-state-cache",
-    Usage:  deprecatedUsage,
+		Usage:  deprecatedUsage,
 		Hidden: true,
-  }
+	}
 	deprecatedProposerAttsSelectionUsingMaxCover = &cli.BoolFlag{
 		Name:   "proposer-atts-selection-using-max-cover",
 		Usage:  deprecatedUsage,

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -102,9 +102,9 @@ var (
 		Name:  "attest-timely",
 		Usage: "Fixes validator can attest timely after current block processes. See #8185 for more details",
 	}
-	enableNextSlotStateCache = &cli.BoolFlag{
-		Name:  "enable-next-slot-state-cache",
-		Usage: "Improves attesting and proposing efficiency by caching the next slot state at the end of the current slot",
+	disableNextSlotStateCache = &cli.BoolFlag{
+		Name:  "disable-next-slot-state-cache",
+		Usage: "Disable caching of the next slot state at the end of the current slot",
 	}
 	updateHeadTimely = &cli.BoolFlag{
 		Name:  "update-head-timely",
@@ -123,7 +123,6 @@ var (
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
 	enableLargerGossipHistory,
-	enableNextSlotStateCache,
 	forceOptMaxCoverAggregationStategy,
 	updateHeadTimely,
 	proposerAttsSelectionUsingMaxCover,
@@ -171,7 +170,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	enableLargerGossipHistory,
 	checkPtInfoCache,
 	disableBroadcastSlashingFlag,
-	enableNextSlotStateCache,
+	disableNextSlotStateCache,
 	forceOptMaxCoverAggregationStategy,
 	updateHeadTimely,
 	proposerAttsSelectionUsingMaxCover,


### PR DESCRIPTION
This PR inverts `next-slot-state-cache` flag to improve validator performance. This flag has also been tested for a while. It's part of --dev