### PR TITLE
Altair: Add `Eth2FastAggregateVerify`

### DIFF
--- a/beacon-chain/core/altair/block.go
+++ b/beacon-chain/core/altair/block.go
@@ -153,7 +153,7 @@ func ProcessSyncCommittee(state iface.BeaconStateAltair, sync *ethpb.SyncAggrega
 	if err != nil {
 		return nil, err
 	}
-	if !sig.FastAggregateVerify(votedKeys, r) {
+	if !sig.Eth2FastAggregateVerify(votedKeys, r) {
 		return nil, errors.New("could not verify sync committee signature")
 	}
 

--- a/shared/bls/blst/signature.go
+++ b/shared/bls/blst/signature.go
@@ -4,6 +4,7 @@
 package blst
 
 import (
+	"bytes"
 	"fmt"
 	"sync"
 
@@ -116,6 +117,33 @@ func (s *Signature) FastAggregateVerify(pubKeys []common.PublicKey, msg [32]byte
 	}
 	if len(pubKeys) == 0 {
 		return false
+	}
+	rawKeys := make([]*blstPublicKey, len(pubKeys))
+	for i := 0; i < len(pubKeys); i++ {
+		rawKeys[i] = pubKeys[i].(*PublicKey).p
+	}
+
+	return s.s.FastAggregateVerify(true, rawKeys, msg[:], dst)
+}
+
+// Eth2FastAggregateVerify implements a wrapper on top of bls's FastAggregateVerify. It accepts G2_POINT_AT_INFINITY signature
+// when pubkeys empty.
+//
+// Spec code:
+// def eth2_fast_aggregate_verify(pubkeys: Sequence[BLSPubkey], message: Bytes32, signature: BLSSignature) -> bool:
+//    """
+//    Wrapper to ``bls.FastAggregateVerify`` accepting the ``G2_POINT_AT_INFINITY`` signature when ``pubkeys`` is empty.
+//    """
+//    if len(pubkeys) == 0 and signature == G2_POINT_AT_INFINITY:
+//        return True
+//    return bls.FastAggregateVerify(pubkeys, message, signature)
+func (s *Signature) Eth2FastAggregateVerify(pubKeys []common.PublicKey, msg [32]byte) bool {
+	if featureconfig.Get().SkipBLSVerify {
+		return true
+	}
+	g2PointAtInfinity := make([]byte, 96)
+	if len(pubKeys) == 0 && bytes.Equal(s.Marshal(), g2PointAtInfinity) {
+		return true
 	}
 	rawKeys := make([]*blstPublicKey, len(pubKeys))
 	for i := 0; i < len(pubKeys); i++ {

--- a/shared/bls/blst/signature.go
+++ b/shared/bls/blst/signature.go
@@ -141,7 +141,7 @@ func (s *Signature) Eth2FastAggregateVerify(pubKeys []common.PublicKey, msg [32]
 	if featureconfig.Get().SkipBLSVerify {
 		return true
 	}
-	g2PointAtInfinity := make([]byte, 96)
+	g2PointAtInfinity := append([]byte{0xC0}, make([]byte, 95)...)
 	if len(pubKeys) == 0 && bytes.Equal(s.Marshal(), g2PointAtInfinity) {
 		return true
 	}

--- a/shared/bls/blst/signature_test.go
+++ b/shared/bls/blst/signature_test.go
@@ -94,6 +94,17 @@ func TestFastAggregateVerify_ReturnsFalseOnEmptyPubKeyList(t *testing.T) {
 	assert.Equal(t, false, aggSig.FastAggregateVerify(pubkeys, msg), "Expected FastAggregateVerify to return false with empty input ")
 }
 
+func TestFastAggregateVerify_ReturnsTrueOnG2PointAtInfinity(t *testing.T) {
+	var pubkeys []common.PublicKey
+	msg := [32]byte{'h', 'e', 'l', 'l', 'o'}
+
+	aggSig := NewAggregateSignature()
+	g2PointAtInfinity := append([]byte{0xC0}, make([]byte, 95)...)
+	aggSig, err := SignatureFromBytes(g2PointAtInfinity)
+	require.NoError(t, err)
+	assert.Equal(t, true, aggSig.Eth2FastAggregateVerify(pubkeys, msg))
+}
+
 func TestSignatureFromBytes(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/shared/bls/blst/stub.go
+++ b/shared/bls/blst/stub.go
@@ -73,6 +73,11 @@ func (s Signature) FastAggregateVerify(_ []common.PublicKey, _ [32]byte) bool {
 	panic(err)
 }
 
+// Eth2FastAggregateVerify -- stub
+func (s Signature) Eth2FastAggregateVerify(_ []common.PublicKey, _ [32]byte) bool {
+	panic(err)
+}
+
 // Marshal -- stub
 func (s Signature) Marshal() []byte {
 	panic(err)

--- a/shared/bls/common/interface.go
+++ b/shared/bls/common/interface.go
@@ -27,6 +27,7 @@ type Signature interface {
 	// Deprecated: Use FastAggregateVerify or use this method in spectests only.
 	AggregateVerify(pubKeys []PublicKey, msgs [][32]byte) bool
 	FastAggregateVerify(pubKeys []PublicKey, msg [32]byte) bool
+	Eth2FastAggregateVerify(pubKeys []PublicKey, msg [32]byte) bool
 	Marshal() []byte
 	Copy() Signature
 }

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -43,6 +43,9 @@ func (mockSignature) AggregateVerify([]bls.PublicKey, [][32]byte) bool {
 func (mockSignature) FastAggregateVerify([]bls.PublicKey, [32]byte) bool {
 	return true
 }
+func (mockSignature) Eth2FastAggregateVerify([]bls.PublicKey, [32]byte) bool {
+	return true
+}
 func (mockSignature) Marshal() []byte {
 	return make([]byte, 32)
 }


### PR DESCRIPTION
Part of #8638 

Add `Eth2FastAggregateVerify` implementation and use it for `ProcessSyncCommittee`. We were using the canonical `FastAggregateVerify` instead which caused spec test to fail