### PR TITLE
Iterate Through Validator Registry To Retrieve Validator Instead of HashMap

### DIFF
--- a/beacon-chain/state/stateV0/getters_validator.go
+++ b/beacon-chain/state/stateV0/getters_validator.go
@@ -117,16 +117,19 @@ func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (iface.
 
 // ValidatorIndexByPubkey returns a given validator by its 48-byte public key.
 func (b *BeaconState) ValidatorIndexByPubkey(key [48]byte) (types.ValidatorIndex, bool) {
-	if b == nil || b.state.Validators == nil {
+	if b.hasInnerState() || b.state.Validators == nil {
 		return 0, false
 	}
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	foundIndex := sort.Search(len(b.state.Validators), func(i int) bool {
+	numOfVals := len(b.state.Validators)
+	foundIndex := sort.Search(numOfVals, func(i int) bool {
 		return bytesutil.ToBytes48(b.state.Validators[i].PublicKey) == key
 	})
-	if foundIndex == len(b.state.Validators) {
+	// If the retrieved index is the number of validators it means
+	// the binary search was unsuccesful.
+	if foundIndex == numOfVals {
 		return types.ValidatorIndex(0), false
 	}
 	return types.ValidatorIndex(foundIndex), true

--- a/beacon-chain/state/stateV0/getters_validator.go
+++ b/beacon-chain/state/stateV0/getters_validator.go
@@ -123,7 +123,11 @@ func (b *BeaconState) ValidatorIndexByPubkey(key [48]byte) (types.ValidatorIndex
 	defer b.lock.RUnlock()
 
 	numOfVals := len(b.state.Validators)
+	// Exit early if there are no validators.
+	if numOfVals == 0 {
+		return types.ValidatorIndex(0), false
 
+	}
 	// Search backwards, starting from the latest added
 	// validator.
 	for i := numOfVals - 1; i >= 0; i-- {

--- a/beacon-chain/state/stateV0/getters_validator.go
+++ b/beacon-chain/state/stateV0/getters_validator.go
@@ -126,7 +126,7 @@ func (b *BeaconState) ValidatorIndexByPubkey(key [48]byte) (types.ValidatorIndex
 
 	// Search backwards, starting from the latest added
 	// validator.
-	for i := numOfVals - 1; i >= 0; i++ {
+	for i := numOfVals - 1; i >= 0; i-- {
 		if bytesutil.ToBytes48(b.state.Validators[i].PublicKey) == key {
 			return types.ValidatorIndex(i), true
 		}

--- a/beacon-chain/state/stateV0/setters_validator.go
+++ b/beacon-chain/state/stateV0/setters_validator.go
@@ -5,7 +5,6 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
-	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 )
 
 // SetValidators for the beacon state. Updates the entire
@@ -22,7 +21,6 @@ func (b *BeaconState) SetValidators(val []*ethpb.Validator) error {
 	b.sharedFieldReferences[validators] = stateutil.NewRef(1)
 	b.markFieldAsDirty(validators)
 	b.rebuildTrie[validators] = true
-	b.valMapHandler = stateutil.NewValMapHandler(b.state.Validators)
 	return nil
 }
 
@@ -194,14 +192,6 @@ func (b *BeaconState) AppendValidator(val *ethpb.Validator) error {
 	// append validator to slice
 	b.state.Validators = append(vals, val)
 	valIdx := types.ValidatorIndex(len(b.state.Validators) - 1)
-
-	// Copy if this is a shared validator map
-	if ref := b.valMapHandler.MapRef(); ref.Refs() > 1 {
-		valMap := b.valMapHandler.Copy()
-		ref.MinusRef()
-		b.valMapHandler = valMap
-	}
-	b.valMapHandler.Set(bytesutil.ToBytes48(val.PublicKey), valIdx)
 
 	b.markFieldAsDirty(validators)
 	b.addDirtyIndices(validators, []uint64{uint64(valIdx)})

--- a/beacon-chain/state/stateV0/state_trie.go
+++ b/beacon-chain/state/stateV0/state_trie.go
@@ -49,7 +49,6 @@ func InitializeFromProtoUnsafe(st *pbp2p.BeaconState) (*BeaconState, error) {
 		stateFieldLeaves:      make(map[fieldIndex]*FieldTrie, fieldCount),
 		sharedFieldReferences: make(map[fieldIndex]*stateutil.Reference, 10),
 		rebuildTrie:           make(map[fieldIndex]bool, fieldCount),
-		valMapHandler:         stateutil.NewValMapHandler(st.Validators),
 	}
 
 	for i := 0; i < fieldCount; i++ {
@@ -124,18 +123,12 @@ func (b *BeaconState) Copy() iface.BeaconState {
 		rebuildTrie:           make(map[fieldIndex]bool, fieldCount),
 		sharedFieldReferences: make(map[fieldIndex]*stateutil.Reference, 10),
 		stateFieldLeaves:      make(map[fieldIndex]*FieldTrie, fieldCount),
-
-		// Copy on write validator index map.
-		valMapHandler: b.valMapHandler,
 	}
 
 	for field, ref := range b.sharedFieldReferences {
 		ref.AddRef()
 		dst.sharedFieldReferences[field] = ref
 	}
-
-	// Increment ref for validator map
-	b.valMapHandler.AddRef()
 
 	for i := range b.dirtyFields {
 		dst.dirtyFields[i] = true

--- a/beacon-chain/state/stateV0/types.go
+++ b/beacon-chain/state/stateV0/types.go
@@ -85,7 +85,6 @@ type BeaconState struct {
 	dirtyIndices          map[fieldIndex][]uint64
 	stateFieldLeaves      map[fieldIndex]*FieldTrie
 	rebuildTrie           map[fieldIndex]bool
-	valMapHandler         *stateutil.ValidatorMapHandler
 	merkleLayers          [][][]byte
 	sharedFieldReferences map[fieldIndex]*stateutil.Reference
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature Cleanup

**What does this PR do? Why is it needed?**

- [x] In early testnets we utilized a validator map to keep track of all validator pubkeys and their respective indices. However with the current growth in mainnet state, maintaing a map is very expensive on memory with our current beacon state model and the benefits are arguably not worth it. This PR will increase the time complexity of retrieving validators from `O(1)` to `O(n)` . However the benefits on memory usage make this change more than worth it, as it completely removes memory spikes at an increased cost of processing blocks with deposits.

**Which issues(s) does this PR fix?**

Fixes #8483 

**Other notes for review**
