### PR TITLE
Revert "Invert `next-slot-state-cache` flag"

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -179,10 +179,9 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		log.WithField(disableBroadcastSlashingFlag.Name, disableBroadcastSlashingFlag.Usage).Warn(enabledFeatureFlag)
 		cfg.DisableBroadcastSlashings = true
 	}
-	cfg.EnableNextSlotStateCache = true
-	if ctx.Bool(disableNextSlotStateCache.Name) {
-		log.WithField(disableNextSlotStateCache.Name, disableNextSlotStateCache.Usage).Warn(enabledFeatureFlag)
-		cfg.EnableNextSlotStateCache = false
+	if ctx.Bool(enableNextSlotStateCache.Name) {
+		log.WithField(enableNextSlotStateCache.Name, enableNextSlotStateCache.Usage).Warn(enabledFeatureFlag)
+		cfg.EnableNextSlotStateCache = true
 	}
 	if ctx.Bool(updateHeadTimely.Name) {
 		log.WithField(updateHeadTimely.Name, updateHeadTimely.Usage).Warn(enabledFeatureFlag)

--- a/shared/featureconfig/deprecated_flags.go
+++ b/shared/featureconfig/deprecated_flags.go
@@ -37,11 +37,6 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
-	deprecatedEnableNextSlotCache = &cli.BoolFlag{
-		Name:   "enable-next-slot-state-cache",
-		Usage:  deprecatedUsage,
-		Hidden: true,
-	}
 	deprecatedProposerAttsSelectionUsingMaxCover = &cli.BoolFlag{
 		Name:   "proposer-atts-selection-using-max-cover",
 		Usage:  deprecatedUsage,
@@ -56,6 +51,5 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedDisablePruningDepositProofs,
 	deprecatedDisableEth1DataMajorityVote,
 	deprecatedDisableBlst,
-	deprecatedEnableNextSlotCache,
 	deprecatedProposerAttsSelectionUsingMaxCover,
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -102,9 +102,9 @@ var (
 		Name:  "attest-timely",
 		Usage: "Fixes validator can attest timely after current block processes. See #8185 for more details",
 	}
-	disableNextSlotStateCache = &cli.BoolFlag{
-		Name:  "disable-next-slot-state-cache",
-		Usage: "Disable caching of the next slot state at the end of the current slot",
+	enableNextSlotStateCache = &cli.BoolFlag{
+		Name:  "enable-next-slot-state-cache",
+		Usage: "Improves attesting and proposing efficiency by caching the next slot state at the end of the current slot",
 	}
 	updateHeadTimely = &cli.BoolFlag{
 		Name:  "update-head-timely",
@@ -127,6 +127,7 @@ var (
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
 	enableLargerGossipHistory,
+	enableNextSlotStateCache,
 	forceOptMaxCoverAggregationStategy,
 	updateHeadTimely,
 	enableOptimizedBalanceUpdate,
@@ -174,7 +175,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	enableLargerGossipHistory,
 	checkPtInfoCache,
 	disableBroadcastSlashingFlag,
-	disableNextSlotStateCache,
+	enableNextSlotStateCache,
 	forceOptMaxCoverAggregationStategy,
 	updateHeadTimely,
 	disableProposerAttsSelectionUsingMaxCover,


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#8830

@nisdas pointed out he is seeing 30% memory inc in latest develop and suspects this is the cause. It's seems sane to revert this before the release 