### PR TITLE
Fix an epoch offset for sync committee rotation

### DIFF
--- a/beacon-chain/core/altair/epoch_spec.go
+++ b/beacon-chain/core/altair/epoch_spec.go
@@ -28,7 +28,7 @@ func ProcessSyncCommitteeUpdates(beaconState iface.BeaconStateAltair) (iface.Bea
 		if err := beaconState.SetCurrentSyncCommittee(currentSyncCommittee); err != nil {
 			return nil, err
 		}
-		nextCommittee, err := SyncCommittee(beaconState, helpers.CurrentEpoch(beaconState)+params.BeaconConfig().EpochsPerSyncCommitteePeriod)
+		nextCommittee, err := SyncCommittee(beaconState, nextEpoch+params.BeaconConfig().EpochsPerSyncCommitteePeriod)
 		if err != nil {
 			return nil, err
 		}

--- a/beacon-chain/core/altair/epoch_spec_test.go
+++ b/beacon-chain/core/altair/epoch_spec_test.go
@@ -8,6 +8,7 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	stateAltair "github.com/prysmaticlabs/prysm/beacon-chain/state/state-altair"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -46,6 +47,11 @@ func TestProcessSyncCommitteeUpdates_CanRotate(t *testing.T) {
 	require.NotEqual(t, current, c)
 	require.NotEqual(t, next, n)
 	require.DeepEqual(t, next, c)
+
+	// Test boundary condition.
+	boundaryCommittee, err := altair.SyncCommittee(s, helpers.CurrentEpoch(s)+params.BeaconConfig().EpochsPerSyncCommitteePeriod)
+	require.NoError(t, err)
+	require.DeepNotEqual(t, boundaryCommittee, n)
 }
 
 func TestProcessParticipationFlagUpdates_CanRotate(t *testing.T) {


### PR DESCRIPTION
Part of #8638 

Fix an epoch offset for sync committee rotation in Altair. Discovered and verified using spec test in #8831