### PR TITLE
fixes #8848 -- scrape validator_(total|active)

### DIFF
--- a/shared/clientstats/BUILD.bazel
+++ b/shared/clientstats/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "@com_github_prometheus_client_model//go:go_default_library",
         "@com_github_prometheus_prom2json//:go_default_library",
+        "@com_github_prysmaticlabs_ethereumapis//eth/v1alpha1:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

Adds the `validator_total` and `validator_active` metrics to the client-stats metrics scraper.

**Which issues(s) does this PR fix?**

Fixes #8848 

**Other notes for review**

that's it, thanks!
