### PR TITLE
Minor clean up on mixing length root

### DIFF
--- a/beacon-chain/state/stateutil/validator_root.go
+++ b/beacon-chain/state/stateutil/validator_root.go
@@ -84,7 +84,7 @@ func Uint64ListRootWithRegistryLimit(balances []uint64) ([32]byte, error) {
 		return [32]byte{}, errors.Wrap(err, "could not compute balances merkleization")
 	}
 
-	balancesLengthRoot := make([]byte, 8)
+	balancesLengthRoot := make([]byte, 32)
 	binary.LittleEndian.PutUint64(balancesLengthRoot, uint64(len(balances)))
 	return htrutils.MixInLength(balancesRootsRoot, balancesLengthRoot), nil
 }

--- a/beacon-chain/state/stateutil/validator_root.go
+++ b/beacon-chain/state/stateutil/validator_root.go
@@ -1,7 +1,6 @@
 package stateutil
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -84,13 +83,10 @@ func Uint64ListRootWithRegistryLimit(balances []uint64) ([32]byte, error) {
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute balances merkleization")
 	}
-	balancesRootsBuf := new(bytes.Buffer)
-	if err := binary.Write(balancesRootsBuf, binary.LittleEndian, uint64(len(balances))); err != nil {
-		return [32]byte{}, errors.Wrap(err, "could not marshal balances length")
-	}
-	balancesRootsBufRoot := make([]byte, 32)
-	copy(balancesRootsBufRoot, balancesRootsBuf.Bytes())
-	return htrutils.MixInLength(balancesRootsRoot, balancesRootsBufRoot), nil
+
+	balancesLengthRoot := make([]byte, 8)
+	binary.LittleEndian.PutUint64(balancesLengthRoot, uint64(len(balances)))
+	return htrutils.MixInLength(balancesRootsRoot, balancesLengthRoot), nil
 }
 
 // ValidatorEncKey returns the encoded key in bytes of input `validator`,


### PR DESCRIPTION
Cleaning up on how we mix length root in `Uint64ListRootWithRegistryLimit ` by improving usages around `PutUint64`