### PR TITLE
Initialize `VoluntaryExitsPool` and `BlockReceiver` in rpc server

### DIFF
--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -253,6 +253,7 @@ func (s *Service) Start() {
 		BlockNotifier:       s.cfg.BlockNotifier,
 		AttestationNotifier: s.cfg.OperationNotifier,
 		Broadcaster:         s.cfg.Broadcaster,
+		BlockReceiver:       s.cfg.BlockReceiver,
 		StateGenService:     s.cfg.StateGen,
 		SyncChecker:         s.cfg.SyncService,
 		StateFetcher: statefetcher.StateProvider{

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -261,6 +261,7 @@ func (s *Service) Start() {
 			GenesisTimeFetcher: s.cfg.GenesisTimeFetcher,
 			StateGenService:    s.cfg.StateGen,
 		},
+		VoluntaryExitsPool: s.cfg.ExitPool,
 	}
 	ethpb.RegisterNodeServer(s.grpcServer, nodeServer)
 	ethpbv1.RegisterBeaconNodeServer(s.grpcServer, nodeServerV1)


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Listing pooled voluntary exits through the API results in nil reference because the pool is not initialized anywhere. This PR adds the initialization code.

Update: The same thing fixed for `BlockReceiver`.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
