### PR TITLE
Altair: sync committee cache

### DIFF
--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -14,15 +14,16 @@ go_library(
         "proposer_indices_type.go",
         "skip_slot_cache.go",
         "subnet_ids.go",
-        "sync_committee.go",
     ] + select({
         "//fuzz:fuzzing_enabled": [
             "committee_disabled.go",
             "proposer_indices_disabled.go",
+            "sync_committee_disabled.go",
         ],
         "//conditions:default": [
             "committee.go",
             "proposer_indices.go",
+            "sync_committee.go",
         ],
     }),
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/cache",

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
     ],
     deps = [
         "//beacon-chain/state/interface:go_default_library",
-        "//beacon-chain/state/state-altair:go_default_library",
         "//beacon-chain/state/stateV0:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/hashutil:go_default_library",
@@ -61,6 +60,7 @@ go_test(
         "proposer_indices_test.go",
         "skip_slot_cache_test.go",
         "subnet_ids_test.go",
+        "sync_committee_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
@@ -69,6 +69,7 @@ go_test(
         "//proto/beacon/p2p/v1:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
+        "//shared/testutil/altair:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_gogo_protobuf//proto:go_default_library",

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -32,7 +32,9 @@ go_library(
     ],
     deps = [
         "//beacon-chain/state/interface:go_default_library",
+        "//beacon-chain/state/state-altair:go_default_library",
         "//beacon-chain/state/stateV0:go_default_library",
+        "//shared/bytesutil:go_default_library",
         "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/sliceutil:go_default_library",

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "proposer_indices_type.go",
         "skip_slot_cache.go",
         "subnet_ids.go",
-        "sync_committee.go"
+        "sync_committee.go",
     ] + select({
         "//fuzz:fuzzing_enabled": [
             "committee_disabled.go",

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "proposer_indices_type.go",
         "skip_slot_cache.go",
         "subnet_ids.go",
+        "sync_committee.go"
     ] + select({
         "//fuzz:fuzzing_enabled": [
             "committee_disabled.go",

--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -1,3 +1,5 @@
+// +build !libfuzzer
+
 package cache
 
 import (

--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -137,10 +137,12 @@ func (s *SyncCommitteeCache) UpdatePositionsInCommittee(state iface.BeaconStateA
 		return err
 	}
 
-	s.cache.Add(&syncCommitteeIndexPosition{
+	if err := s.cache.Add(&syncCommitteeIndexPosition{
 		currentSyncCommitteeRoot: r,
 		vIndexToPositionMap:      positionsMap,
-	})
+	}); err != nil {
+		return err
+	}
 	trim(s.cache, maxSyncCommitteeSize)
 
 	return nil

--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -17,20 +17,20 @@ var maxSyncCommitteeSize = uint64(3) // Allows 3 forks to happen around `EPOCHS_
 // It is thread safe with concurrent read write.
 type SyncCommitteeCache struct {
 	cache *cache.FIFO
-	lock sync.RWMutex
+	lock  sync.RWMutex
 }
 
 // Index position of all validators in sync committee where `currentSyncCommitteeRoot` is the key and `vIndexToPositionMap` is value.
 // Inside `vIndexToPositionMap`, validator positions are cached where key is the 48byte public key and the value is the `positionInCommittee` struct.
 type syncCommitteeIndexPosition struct {
 	currentSyncCommitteeRoot [32]byte
-	vIndexToPositionMap map[[48]byte]*positionInCommittee
+	vIndexToPositionMap      map[[48]byte]*positionInCommittee
 }
 
 // Index position of individual validator of current epoch and previous epoch sync committee.
 type positionInCommittee struct {
 	currentEpoch []uint64
-	nextEpoch []uint64
+	nextEpoch    []uint64
 }
 
 // NewSyncCommittee initializes and returns a new SyncCommitteeCache.
@@ -139,7 +139,7 @@ func (s *SyncCommitteeCache) UpdatePositionsInCommittee(state iface.BeaconStateA
 
 	s.cache.Add(&syncCommitteeIndexPosition{
 		currentSyncCommitteeRoot: r,
-		vIndexToPositionMap: positionsMap,
+		vIndexToPositionMap:      positionsMap,
 	})
 	trim(s.cache, maxSyncCommitteeSize)
 

--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -1,0 +1,125 @@
+package cache
+
+import (
+	"errors"
+	"sync"
+
+	statealtair "github.com/prysmaticlabs/prysm/beacon-chain/state/state-altair"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"k8s.io/client-go/tools/cache"
+)
+
+// errNonExistingSyncCommitteeKey will be returned when key does not exists.
+var errNonExistingSyncCommitteeKey = errors.New("does not exist sync committee key")
+
+type SyncCommitteeCache struct {
+	cache *cache.FIFO
+	lock sync.RWMutex
+}
+
+type syncCommitteeItem struct {
+	currentSyncCommitteeRoot [32]byte
+	assignment map[[48]byte]*indexPositionInCommittee
+}
+
+type indexPositionInCommittee struct {
+	currentEpoch []uint64
+	nextEpoch []uint64
+}
+
+func NewSyncCommittee() *SyncCommitteeCache {
+	return &SyncCommitteeCache{
+		cache: cache.NewFIFO(keyFn),
+	}
+}
+
+func keyFn(obj interface{}) (string, error) {
+	info, ok := obj.(*syncCommitteeItem)
+	if !ok {
+		return "", errors.New("obj is not syncCommitteeItem")
+	}
+
+	return string(info.currentSyncCommitteeRoot[:]), nil
+}
+
+
+func (s *SyncCommitteeCache) CurrentEpochIndexPosition(root [32]byte, pubKey [48]byte) ([]uint64, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	pos, err := s.idxPositionInCommittee(root, pubKey)
+	if err != nil {
+		return nil, err
+	}
+	if pos == nil {
+		return []uint64{}, nil
+	}
+	return pos.currentEpoch, nil
+}
+
+func (s *SyncCommitteeCache) NextEpochIndexPosition(root [32]byte, pubKey [48]byte) ([]uint64, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	pos, err := s.idxPositionInCommittee(root, pubKey)
+	if err != nil {
+		return nil, err
+	}
+	if pos == nil {
+		return []uint64{}, nil
+	}
+	return pos.nextEpoch, nil
+}
+
+func (s *SyncCommitteeCache) idxPositionInCommittee(root [32]byte, pubKey [48]byte) (*indexPositionInCommittee, error) {
+	obj, exists, err := s.cache.GetByKey(key(root))
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, errNonExistingSyncCommitteeKey
+	}
+	item, ok := obj.(*syncCommitteeItem)
+	if !ok {
+		return nil, errors.New("obj is not syncCommitteeItem")
+	}
+	idxInCommittee, ok := item.assignment[pubKey]
+	if !ok {
+		return nil, nil
+	}
+	return idxInCommittee, nil
+}
+
+func (s *SyncCommitteeCache) UpdateEpochAssignment(state *statealtair.BeaconState) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	csc, err := state.CurrentSyncCommittee()
+	if err != nil {
+		return err
+	}
+	newAssignment := make(map[[48]byte]*indexPositionInCommittee)
+	for i, pubkey := range csc.Pubkeys {
+		p := bytesutil.ToBytes48(pubkey)
+		if _, ok := newAssignment[p]; !ok {
+			m := &indexPositionInCommittee{currentEpoch: []uint64{uint64(i)}}
+			newAssignment[p] = m
+		} else {
+			newAssignment[p].currentEpoch = append(newAssignment[p].currentEpoch, uint64(i))
+		}
+	}
+
+	nsc, err := state.NextSyncCommittee()
+	if err != nil {
+		return err
+	}
+	for i, pubkey := range nsc.Pubkeys {
+		p := bytesutil.ToBytes48(pubkey)
+		if _, ok := newAssignment[p]; !ok {
+			m := &indexPositionInCommittee{currentEpoch: []uint64{uint64(i)}}
+			newAssignment[p] = m
+		} else {
+			newAssignment[p].currentEpoch = append(newAssignment[p].currentEpoch, uint64(i))
+		}
+	}
+}

--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -102,9 +102,6 @@ func (s *SyncCommitteeCache) idxPositionInCommittee(root [32]byte, pubKey [48]by
 // current epoch and next epoch. This should be called when `current_sync_committee` and `next_sync_committee`
 // change and that happens every `EPOCHS_PER_SYNC_COMMITTEE_PERIOD`.
 func (s *SyncCommitteeCache) UpdatePositionsInCommittee(state iface.BeaconStateAltair) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	csc, err := state.CurrentSyncCommittee()
 	if err != nil {
 		return err
@@ -138,6 +135,9 @@ func (s *SyncCommitteeCache) UpdatePositionsInCommittee(state iface.BeaconStateA
 	if err != nil {
 		return err
 	}
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
 
 	if err := s.cache.Add(&syncCommitteeIndexPosition{
 		currentSyncCommitteeRoot: r,

--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -4,46 +4,45 @@ import (
 	"errors"
 	"sync"
 
-	statealtair "github.com/prysmaticlabs/prysm/beacon-chain/state/state-altair"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"k8s.io/client-go/tools/cache"
 )
 
-var errNonExistingSyncCommitteeKey = errors.New("does not exist sync committee key")
-var errNotSyncCommitteeIndexPosition = errors.New("obj is not syncCommitteeIndexPosition struct")
-var maxSyncCommitteeSize = uint64(3)
+var ErrNonExistingSyncCommitteeKey = errors.New("does not exist sync committee key")
+var errNotSyncCommitteeIndexPosition = errors.New("not syncCommitteeIndexPosition struct")
+var maxSyncCommitteeSize = uint64(3) // Allows 3 forks to happen around `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` boundary.
 
+// SyncCommitteeCache utilizes a FIFO cache to sufficiently cache validator position within sync committee.
+// It is thread safe with concurrent read write.
 type SyncCommitteeCache struct {
 	cache *cache.FIFO
 	lock sync.RWMutex
 }
 
+// Index position of all validators in sync committee where `currentSyncCommitteeRoot` is the key and `vIndexToPositionMap` is value.
+// Inside `vIndexToPositionMap`, validator positions are cached where key is the 48byte public key and the value is the `positionInCommittee` struct.
 type syncCommitteeIndexPosition struct {
 	currentSyncCommitteeRoot [32]byte
 	vIndexToPositionMap map[[48]byte]*positionInCommittee
 }
 
+// Index position of individual validator of current epoch and previous epoch sync committee.
 type positionInCommittee struct {
 	currentEpoch []uint64
 	nextEpoch []uint64
 }
 
+// NewSyncCommittee initializes and returns a new SyncCommitteeCache.
 func NewSyncCommittee() *SyncCommitteeCache {
 	return &SyncCommitteeCache{
 		cache: cache.NewFIFO(keyFn),
 	}
 }
 
-func keyFn(obj interface{}) (string, error) {
-	info, ok := obj.(*syncCommitteeIndexPosition)
-	if !ok {
-		return "", errNotSyncCommitteeIndexPosition
-	}
-
-	return string(info.currentSyncCommitteeRoot[:]), nil
-}
-
-
+// CurrentEpochIndexPosition returns current epoch index position of validator pubKey with respect with sync committee.
+// If the input pubKey has no assignment, an empty list will be returned.
+// If the input root does not exist in cache, ErrNonExistingSyncCommitteeKey is returned. Then performing manual checking of state for index position in state is recommended.
 func (s *SyncCommitteeCache) CurrentEpochIndexPosition(root [32]byte, pubKey [48]byte) ([]uint64, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
@@ -55,9 +54,13 @@ func (s *SyncCommitteeCache) CurrentEpochIndexPosition(root [32]byte, pubKey [48
 	if pos == nil {
 		return []uint64{}, nil
 	}
+
 	return pos.currentEpoch, nil
 }
 
+// NextEpochIndexPosition returns next epoch index position of validator pubKey in respect with sync committee.
+// If the input pubKey has no assignment, an empty list will be returned.
+// If the input root does not exist in cache, ErrNonExistingSyncCommitteeKey is returned. Then performing manual checking of state for index position in state is recommended.
 func (s *SyncCommitteeCache) NextEpochIndexPosition(root [32]byte, pubKey [48]byte) ([]uint64, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
@@ -72,13 +75,15 @@ func (s *SyncCommitteeCache) NextEpochIndexPosition(root [32]byte, pubKey [48]by
 	return pos.nextEpoch, nil
 }
 
+// Helper function for `CurrentEpochIndexPosition` and `NextEpochIndexPosition` to return a mapping
+// of validator pubKey to its index(s) position.
 func (s *SyncCommitteeCache) idxPositionInCommittee(root [32]byte, pubKey [48]byte) (*positionInCommittee, error) {
 	obj, exists, err := s.cache.GetByKey(key(root))
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
-		return nil, errNonExistingSyncCommitteeKey
+		return nil, ErrNonExistingSyncCommitteeKey
 	}
 	item, ok := obj.(*syncCommitteeIndexPosition)
 	if !ok {
@@ -91,7 +96,10 @@ func (s *SyncCommitteeCache) idxPositionInCommittee(root [32]byte, pubKey [48]by
 	return idxInCommittee, nil
 }
 
-func (s *SyncCommitteeCache) UpdatePositionsInCommittee(state *statealtair.BeaconState) error {
+// UpdatePositionsInCommittee updates caching of validators position in sync committee in respect to
+// current epoch and next epoch. This should be called when `current_sync_committee` and `next_sync_committee`
+// change and that happens every `EPOCHS_PER_SYNC_COMMITTEE_PERIOD`.
+func (s *SyncCommitteeCache) UpdatePositionsInCommittee(state iface.BeaconStateAltair) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -136,4 +144,16 @@ func (s *SyncCommitteeCache) UpdatePositionsInCommittee(state *statealtair.Beaco
 	trim(s.cache, maxSyncCommitteeSize)
 
 	return nil
+}
+
+// Given the `syncCommitteeIndexPosition` object, this returns the key of the object.
+// The key is the `currentSyncCommitteeRoot` within the field.
+// Error gets returned if input does not comply with `currentSyncCommitteeRoot` object.
+func keyFn(obj interface{}) (string, error) {
+	info, ok := obj.(*syncCommitteeIndexPosition)
+	if !ok {
+		return "", errNotSyncCommitteeIndexPosition
+	}
+
+	return string(info.currentSyncCommitteeRoot[:]), nil
 }

--- a/beacon-chain/cache/sync_committee_disabled.go
+++ b/beacon-chain/cache/sync_committee_disabled.go
@@ -1,0 +1,31 @@
+// +build libfuzzer
+
+package cache
+
+import (
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+)
+
+// FakeSyncCommitteeCache is a fake `SyncCommitteeCache` to satisfy fuzzing.
+type FakeSyncCommitteeCache struct {
+}
+
+// NewSyncCommittee initializes and returns a new SyncCommitteeCache.
+func NewSyncCommittee() *FakeSyncCommitteeCache {
+	return &FakeSyncCommitteeCache{}
+}
+
+// CurrentEpochIndexPosition -- fake.
+func (s *FakeSyncCommitteeCache) CurrentEpochIndexPosition(root [32]byte, pubKey [48]byte) ([]uint64, error) {
+	return nil, nil
+}
+
+// NextEpochIndexPosition -- fake.
+func (s *FakeSyncCommitteeCache) NextEpochIndexPosition(root [32]byte, pubKey [48]byte) ([]uint64, error) {
+	return nil, nil
+}
+
+// UpdatePositionsInCommittee -- fake.
+func (s *FakeSyncCommitteeCache) UpdatePositionsInCommittee(state iface.BeaconStateAltair) error {
+	return nil
+}

--- a/beacon-chain/cache/sync_committee_test.go
+++ b/beacon-chain/cache/sync_committee_test.go
@@ -1,0 +1,183 @@
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil/altair"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestSyncCommitteeCache_CanUpdateAndRetrieve(t *testing.T) {
+	tests := []struct {
+		name    string
+		currentSyncCommittee *pb.SyncCommittee
+		nextSyncCommittee *pb.SyncCommittee
+		currentSyncMap map[[48]byte][]uint64
+		nextSyncMap map[[48]byte][]uint64
+	}{
+		{
+			name:                 "only current epoch",
+			currentSyncCommittee: convertToCommittee([][]byte{{1},{2},{3},{2},{2}}),
+			nextSyncCommittee: convertToCommittee([][]byte{}),
+			currentSyncMap: map[[48]byte][]uint64{
+				[48]byte{1}: {0},
+				[48]byte{2}: {1, 3, 4},
+				[48]byte{3}: {2},
+			},
+			nextSyncMap: map[[48]byte][]uint64{
+				[48]byte{1}: {},
+				[48]byte{2}: {},
+				[48]byte{3}: {},
+			},
+		},
+		{
+			name:                 "only next epoch",
+			currentSyncCommittee: convertToCommittee([][]byte{}),
+			nextSyncCommittee:    convertToCommittee([][]byte{{1},{2},{3},{2},{2}}),
+			currentSyncMap: map[[48]byte][]uint64{
+				[48]byte{1}: {},
+				[48]byte{2}: {},
+				[48]byte{3}: {},
+			},
+			nextSyncMap: map[[48]byte][]uint64{
+				[48]byte{1}: {0},
+				[48]byte{2}: {1, 3, 4},
+				[48]byte{3}: {2},
+			},
+		},
+		{
+			name:                 "some current epoch and some next epoch",
+			currentSyncCommittee: convertToCommittee([][]byte{{1},{2},{3},{2},{2}}),
+			nextSyncCommittee:    convertToCommittee([][]byte{{7},{6},{5},{4},{7}}),
+			currentSyncMap: map[[48]byte][]uint64{
+				[48]byte{1}: {0},
+				[48]byte{2}: {1, 3, 4},
+				[48]byte{3}: {2},
+			},
+			nextSyncMap: map[[48]byte][]uint64{
+				[48]byte{7}: {0,4},
+				[48]byte{6}: {1},
+				[48]byte{5}: {2},
+				[48]byte{4}: {3},
+			},
+		},
+		{
+			name:                 "some current epoch and some next epoch duplicated across",
+			currentSyncCommittee: convertToCommittee([][]byte{{1},{2},{3},{2},{2}}),
+			nextSyncCommittee:    convertToCommittee([][]byte{{2},{1},{3},{2},{1}}),
+			currentSyncMap: map[[48]byte][]uint64{
+				[48]byte{1}: {0},
+				[48]byte{2}: {1, 3, 4},
+				[48]byte{3}: {2},
+			},
+			nextSyncMap: map[[48]byte][]uint64{
+				[48]byte{1}: {1,4},
+				[48]byte{2}: {0,3},
+				[48]byte{3}: {2},
+			},
+		},
+		{
+			name:                 "all duplicated",
+			currentSyncCommittee: convertToCommittee([][]byte{{100},{100},{100},{100}}),
+			nextSyncCommittee:    convertToCommittee([][]byte{{100},{100},{100},{100}}),
+			currentSyncMap: map[[48]byte][]uint64{
+				[48]byte{100}: {0,1,2,3},
+			},
+			nextSyncMap: map[[48]byte][]uint64{
+				[48]byte{100}: {0,1,2,3},
+			},
+		},
+		{
+			name:                 "unknown keys",
+			currentSyncCommittee: convertToCommittee([][]byte{{100},{100},{100},{100}}),
+			nextSyncCommittee:    convertToCommittee([][]byte{{100},{100},{100},{100}}),
+			currentSyncMap: map[[48]byte][]uint64{
+				[48]byte{1}: {},
+			},
+			nextSyncMap: map[[48]byte][]uint64{
+				[48]byte{1}: {},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, _ := altair.DeterministicGenesisStateAltair(t, 64)
+			require.NoError(t, s.SetCurrentSyncCommittee(tt.currentSyncCommittee))
+			require.NoError(t, s.SetNextSyncCommittee(tt.nextSyncCommittee))
+			cache := cache.NewSyncCommittee()
+			require.NoError(t, cache.UpdatePositionsInCommittee(s))
+			csc, err := s.CurrentSyncCommittee()
+			require.NoError(t, err)
+			r, err := csc.HashTreeRoot()
+			require.NoError(t, err)
+			for key, indices := range tt.currentSyncMap {
+				pos, err := cache.CurrentEpochIndexPosition(r, key)
+				require.NoError(t, err)
+				require.DeepEqual(t, indices, pos)
+			}
+			for key, indices := range tt.nextSyncMap {
+				pos, err := cache.NextEpochIndexPosition(r, key)
+				require.NoError(t, err)
+				require.DeepEqual(t, indices, pos)
+			}
+		})
+	}
+}
+
+func TestSyncCommitteeCache_RootDoesNotExist(t *testing.T) {
+	c := cache.NewSyncCommittee()
+	_, err := c.CurrentEpochIndexPosition([32]byte{}, [48]byte{})
+	require.Equal(t, cache.ErrNonExistingSyncCommitteeKey, err)
+}
+
+func TestSyncCommitteeCache_CanRotate(t *testing.T) {
+	c := cache.NewSyncCommittee()
+	s, _ := altair.DeterministicGenesisStateAltair(t, 64)
+	require.NoError(t, s.SetCurrentSyncCommittee(convertToCommittee([][]byte{{1}})))
+	require.NoError(t, c.UpdatePositionsInCommittee(s))
+
+	csc, err := s.CurrentSyncCommittee()
+	require.NoError(t, err)
+	r, err := csc.HashTreeRoot()
+	require.NoError(t, err)
+
+	require.NoError(t, s.SetCurrentSyncCommittee(convertToCommittee([][]byte{{2}})))
+	require.NoError(t, c.UpdatePositionsInCommittee(s))
+	require.NoError(t, s.SetCurrentSyncCommittee(convertToCommittee([][]byte{{3}})))
+	require.NoError(t, c.UpdatePositionsInCommittee(s))
+	require.NoError(t, s.SetCurrentSyncCommittee(convertToCommittee([][]byte{{4}})))
+	require.NoError(t, c.UpdatePositionsInCommittee(s))
+
+	_, err = c.CurrentEpochIndexPosition(r, [48]byte{})
+	require.Equal(t, cache.ErrNonExistingSyncCommitteeKey, err)
+
+	csc, err = s.CurrentSyncCommittee()
+	require.NoError(t, err)
+	r, err = csc.HashTreeRoot()
+	require.NoError(t, err)
+	_, err = c.CurrentEpochIndexPosition(r, [48]byte{})
+	require.NoError(t, err)
+}
+
+func convertToCommittee(inputKeys [][]byte) *pb.SyncCommittee {
+	var pubKeys [][]byte
+	for i := uint64(0); i < params.BeaconConfig().SyncCommitteeSize; i++ {
+		if i < uint64(len(inputKeys)) {
+			pubKeys = append(pubKeys, bytesutil.PadTo(inputKeys[i], params.BeaconConfig().BLSPubkeyLength))
+		} else {
+			pubKeys = append(pubKeys, bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength))
+		}
+	}
+	var aggregatedKeys [][]byte
+	for i := uint64(0); i < (params.BeaconConfig().SyncCommitteeSize / params.BeaconConfig().SyncPubkeysPerAggregate); i++ {
+		aggregatedKeys = append(aggregatedKeys, bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength))
+	}
+	return &pb.SyncCommittee{
+		Pubkeys: pubKeys,
+		PubkeyAggregates: aggregatedKeys,
+	}
+}

--- a/beacon-chain/cache/sync_committee_test.go
+++ b/beacon-chain/cache/sync_committee_test.go
@@ -13,16 +13,16 @@ import (
 
 func TestSyncCommitteeCache_CanUpdateAndRetrieve(t *testing.T) {
 	tests := []struct {
-		name    string
+		name                 string
 		currentSyncCommittee *pb.SyncCommittee
-		nextSyncCommittee *pb.SyncCommittee
-		currentSyncMap map[[48]byte][]uint64
-		nextSyncMap map[[48]byte][]uint64
+		nextSyncCommittee    *pb.SyncCommittee
+		currentSyncMap       map[[48]byte][]uint64
+		nextSyncMap          map[[48]byte][]uint64
 	}{
 		{
 			name:                 "only current epoch",
-			currentSyncCommittee: convertToCommittee([][]byte{{1},{2},{3},{2},{2}}),
-			nextSyncCommittee: convertToCommittee([][]byte{}),
+			currentSyncCommittee: convertToCommittee([][]byte{{1}, {2}, {3}, {2}, {2}}),
+			nextSyncCommittee:    convertToCommittee([][]byte{}),
 			currentSyncMap: map[[48]byte][]uint64{
 				[48]byte{1}: {0},
 				[48]byte{2}: {1, 3, 4},
@@ -37,7 +37,7 @@ func TestSyncCommitteeCache_CanUpdateAndRetrieve(t *testing.T) {
 		{
 			name:                 "only next epoch",
 			currentSyncCommittee: convertToCommittee([][]byte{}),
-			nextSyncCommittee:    convertToCommittee([][]byte{{1},{2},{3},{2},{2}}),
+			nextSyncCommittee:    convertToCommittee([][]byte{{1}, {2}, {3}, {2}, {2}}),
 			currentSyncMap: map[[48]byte][]uint64{
 				[48]byte{1}: {},
 				[48]byte{2}: {},
@@ -51,15 +51,15 @@ func TestSyncCommitteeCache_CanUpdateAndRetrieve(t *testing.T) {
 		},
 		{
 			name:                 "some current epoch and some next epoch",
-			currentSyncCommittee: convertToCommittee([][]byte{{1},{2},{3},{2},{2}}),
-			nextSyncCommittee:    convertToCommittee([][]byte{{7},{6},{5},{4},{7}}),
+			currentSyncCommittee: convertToCommittee([][]byte{{1}, {2}, {3}, {2}, {2}}),
+			nextSyncCommittee:    convertToCommittee([][]byte{{7}, {6}, {5}, {4}, {7}}),
 			currentSyncMap: map[[48]byte][]uint64{
 				[48]byte{1}: {0},
 				[48]byte{2}: {1, 3, 4},
 				[48]byte{3}: {2},
 			},
 			nextSyncMap: map[[48]byte][]uint64{
-				[48]byte{7}: {0,4},
+				[48]byte{7}: {0, 4},
 				[48]byte{6}: {1},
 				[48]byte{5}: {2},
 				[48]byte{4}: {3},
@@ -67,34 +67,34 @@ func TestSyncCommitteeCache_CanUpdateAndRetrieve(t *testing.T) {
 		},
 		{
 			name:                 "some current epoch and some next epoch duplicated across",
-			currentSyncCommittee: convertToCommittee([][]byte{{1},{2},{3},{2},{2}}),
-			nextSyncCommittee:    convertToCommittee([][]byte{{2},{1},{3},{2},{1}}),
+			currentSyncCommittee: convertToCommittee([][]byte{{1}, {2}, {3}, {2}, {2}}),
+			nextSyncCommittee:    convertToCommittee([][]byte{{2}, {1}, {3}, {2}, {1}}),
 			currentSyncMap: map[[48]byte][]uint64{
 				[48]byte{1}: {0},
 				[48]byte{2}: {1, 3, 4},
 				[48]byte{3}: {2},
 			},
 			nextSyncMap: map[[48]byte][]uint64{
-				[48]byte{1}: {1,4},
-				[48]byte{2}: {0,3},
+				[48]byte{1}: {1, 4},
+				[48]byte{2}: {0, 3},
 				[48]byte{3}: {2},
 			},
 		},
 		{
 			name:                 "all duplicated",
-			currentSyncCommittee: convertToCommittee([][]byte{{100},{100},{100},{100}}),
-			nextSyncCommittee:    convertToCommittee([][]byte{{100},{100},{100},{100}}),
+			currentSyncCommittee: convertToCommittee([][]byte{{100}, {100}, {100}, {100}}),
+			nextSyncCommittee:    convertToCommittee([][]byte{{100}, {100}, {100}, {100}}),
 			currentSyncMap: map[[48]byte][]uint64{
-				[48]byte{100}: {0,1,2,3},
+				[48]byte{100}: {0, 1, 2, 3},
 			},
 			nextSyncMap: map[[48]byte][]uint64{
-				[48]byte{100}: {0,1,2,3},
+				[48]byte{100}: {0, 1, 2, 3},
 			},
 		},
 		{
 			name:                 "unknown keys",
-			currentSyncCommittee: convertToCommittee([][]byte{{100},{100},{100},{100}}),
-			nextSyncCommittee:    convertToCommittee([][]byte{{100},{100},{100},{100}}),
+			currentSyncCommittee: convertToCommittee([][]byte{{100}, {100}, {100}, {100}}),
+			nextSyncCommittee:    convertToCommittee([][]byte{{100}, {100}, {100}, {100}}),
 			currentSyncMap: map[[48]byte][]uint64{
 				[48]byte{1}: {},
 			},
@@ -177,7 +177,7 @@ func convertToCommittee(inputKeys [][]byte) *pb.SyncCommittee {
 		aggregatedKeys = append(aggregatedKeys, bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength))
 	}
 	return &pb.SyncCommittee{
-		Pubkeys: pubKeys,
+		Pubkeys:          pubKeys,
 		PubkeyAggregates: aggregatedKeys,
 	}
 }


### PR DESCRIPTION
Part of #8638 

Adding a sync committee cache for facilitate 
 - Quick lookup whether validator is part of sync committee for current epoch or next epoch
 - Quick lookup the validator index position with respect to sync committee

Having this cache enables cheap compute for functions like `is_assigned_to_sync_committee` and `compute_subnets_for_sync_committee` and `get_sync_committee_selection_proof`