### PR TITLE
Remove spurious ETH1 not connected logs when near chainstart

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -898,9 +898,12 @@ func (s *Service) cacheHeadersForEth1DataVote(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	start, err := s.determineEarliestVotingBlock(ctx, end)
-	if err != nil {
-		return err
+	start := uint64(0)
+	if end != 0 {
+		start, err = s.determineEarliestVotingBlock(ctx, end)
+		if err != nil {
+			return err
+		}
 	}
 	// We call batchRequestHeaders for its header caching side-effect, so we don't need the return value.
 	_, err = s.batchRequestHeaders(start, end)


### PR DESCRIPTION
When the followBlockHeight is zero we should only request the genesis block only. 

Perhaps a better fix would be to fix `determineEarliestVotingBlock` so that if the `earlestValidTime` is earlier that ETH1 genesis, then we should return the genesis hash, but this requires knowledge of the eth1 genesis, which is ugly