### PR TITLE
Various code cleanups

### DIFF
--- a/beacon-chain/db/kv/backup.go
+++ b/beacon-chain/db/kv/backup.go
@@ -61,14 +61,14 @@ func (s *Store) Backup(ctx context.Context, outputDir string) error {
 	}()
 	// Prefetch all keys of buckets, and inner keys in a
 	// bucket to use less memory usage when backing up.
-	bucketKeys := [][]byte{}
+	var bucketKeys [][]byte
 	bucketMap := make(map[string][][]byte)
 	err = s.db.View(func(tx *bolt.Tx) error {
 		return tx.ForEach(func(name []byte, b *bolt.Bucket) error {
 			newName := make([]byte, len(name))
 			copy(newName, name)
 			bucketKeys = append(bucketKeys, newName)
-			innerKeys := [][]byte{}
+			var innerKeys [][]byte
 			err := b.ForEach(func(k, v []byte) error {
 				if k == nil {
 					return nil

--- a/beacon-chain/rpc/validator/attester.go
+++ b/beacon-chain/rpc/validator/attester.go
@@ -232,7 +232,7 @@ func (vs *Server) SubscribeCommitteeSubnets(ctx context.Context, req *ethpb.Comm
 			}
 			currEpoch = helpers.SlotToEpoch(req.Slots[i])
 		}
-		subnet := helpers.ComputeSubnetFromCommitteeAndSlot(currValsLen, types.CommitteeIndex(req.CommitteeIds[i]), req.Slots[i])
+		subnet := helpers.ComputeSubnetFromCommitteeAndSlot(currValsLen, req.CommitteeIds[i], req.Slots[i])
 		cache.SubnetIDs.AddAttesterSubnetID(req.Slots[i], subnet)
 		if req.IsAggregator[i] {
 			cache.SubnetIDs.AddAggregatorSubnetID(req.Slots[i], subnet)

--- a/beacon-chain/state/stateV0/setters_attestation_test.go
+++ b/beacon-chain/state/stateV0/setters_attestation_test.go
@@ -62,11 +62,11 @@ func TestAppendBeyondIndicesLimit(t *testing.T) {
 		assert.NoError(t, st.AppendValidator(&eth.Validator{}))
 	}
 	assert.Equal(t, false, st.rebuildTrie[validators])
-	assert.NotEqual(t, len(st.dirtyIndices[validators]), int(0))
+	assert.NotEqual(t, len(st.dirtyIndices[validators]), 0)
 
 	for i := 0; i < indicesLimit; i++ {
 		assert.NoError(t, st.AppendValidator(&eth.Validator{}))
 	}
 	assert.Equal(t, true, st.rebuildTrie[validators])
-	assert.Equal(t, len(st.dirtyIndices[validators]), int(0))
+	assert.Equal(t, len(st.dirtyIndices[validators]), 0)
 }

--- a/cmd/client-stats/flags/flags.go
+++ b/cmd/client-stats/flags/flags.go
@@ -7,22 +7,22 @@ import (
 )
 
 var (
-	// BeaconCertFlag defines a flag for the beacon api certificate.
+	// ValidatorMetricsURLFlag defines a flag for the URL to the validator /metrics prometheus endpoint to scrape.
 	ValidatorMetricsURLFlag = &cli.StringFlag{
 		Name:  "validator-metrics-url",
 		Usage: "Full URL to the validator /metrics prometheus endpoint to scrape. eg http://localhost:8081/metrics",
 	}
-	// BeaconRPCProviderFlag defines a flag for the beacon host ip or address.
+	// BeaconnodeMetricsURLFlag defines a flag for the URL to the beacon-node /metrics prometheus endpoint to scraps.
 	BeaconnodeMetricsURLFlag = &cli.StringFlag{
 		Name:  "beacon-node-metrics-url",
 		Usage: "Full URL to the beacon-node /metrics prometheus endpoint to scrape. eg http://localhost:8080/metrics",
 	}
-	// CertFlag defines a flag for the node's TLS certificate.
+	// ClientStatsAPIURLFlag defines a flag for the URL to the client stats endpoint where collected metrics should be sent.
 	ClientStatsAPIURLFlag = &cli.StringFlag{
 		Name:  "clientstats-api-url",
 		Usage: "Full URL to the client stats endpoint where collected metrics should be sent.",
 	}
-	// CertFlag defines a flag for the node's TLS certificate.
+	// ScrapeIntervalFlag defines a flag for the frequency of scraping.
 	ScrapeIntervalFlag = &cli.DurationFlag{
 		Name:  "scrape-interval",
 		Usage: "Frequency of scraping expressed as a duration, eg 2m or 1m5s. Default is 60s.",

--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -191,20 +191,6 @@ var (
 		Usage: "Comma-separated list of public key hex strings to specify which validator accounts to delete",
 		Value: "",
 	}
-	// DisablePublicKeysFlag defines a comma-separated list of hex string public keys
-	// for accounts which a user desires to disable for their wallet.
-	DisablePublicKeysFlag = &cli.StringFlag{
-		Name:  "disable-public-keys",
-		Usage: "Comma-separated list of public key hex strings to specify which validator accounts to disable",
-		Value: "",
-	}
-	// EnablePublicKeysFlag defines a comma-separated list of hex string public keys
-	// for accounts which a user desires to enable for their wallet.
-	EnablePublicKeysFlag = &cli.StringFlag{
-		Name:  "enable-public-keys",
-		Usage: "Comma-separated list of public key hex strings to specify which validator accounts to enable",
-		Value: "",
-	}
 	// BackupPublicKeysFlag defines a comma-separated list of hex string public keys
 	// for accounts which a user desires to backup from their wallet.
 	BackupPublicKeysFlag = &cli.StringFlag{

--- a/shared/clientstats/scrapers.go
+++ b/shared/clientstats/scrapers.go
@@ -118,13 +118,13 @@ type metricMap map[string]*dto.MetricFamily
 func (mm metricMap) getFamily(name string) (*dto.MetricFamily, error) {
 	f, ok := mm[name]
 	if !ok {
-		return nil, fmt.Errorf("Scraper did not find metric family %s", name)
+		return nil, fmt.Errorf("scraper did not find metric family %s", name)
 	}
 	return f, nil
 }
 
 var now = time.Now // var hook for tests to overwrite
-var nanosPerMilli = (int64(time.Millisecond) / int64(time.Nanosecond))
+var nanosPerMilli = int64(time.Millisecond) / int64(time.Nanosecond)
 
 func populateAPIMessage(processName string) APIMessage {
 	return APIMessage{

--- a/shared/gateway/gateway.go
+++ b/shared/gateway/gateway.go
@@ -53,7 +53,7 @@ type Gateway struct {
 	allowedOrigins          []string
 }
 
-// New returns a new gateway server which translates HTTP into gRPC.
+// NewValidator returns a new gateway server which translates HTTP into gRPC.
 // Accepts a context.
 func NewValidator(
 	ctx context.Context,
@@ -71,7 +71,7 @@ func NewValidator(
 	}
 }
 
-// New returns a new gateway server which translates HTTP into gRPC.
+// NewBeacon returns a new gateway server which translates HTTP into gRPC.
 // Accepts a context and optional http.ServeMux.
 func NewBeacon(
 	ctx context.Context,

--- a/tools/analyzers/ineffassign/ineffassign.go
+++ b/tools/analyzers/ineffassign/ineffassign.go
@@ -342,7 +342,7 @@ func (bld *builder) swtch(stmt ast.Stmt, cases []ast.Stmt) {
 			}
 		}
 
-		parents := []*block{}
+		var parents []*block
 		if c.List != nil {
 			parents = append(parents, list)
 		}

--- a/validator/accounts/wallet/wallet.go
+++ b/validator/accounts/wallet/wallet.go
@@ -28,7 +28,7 @@ const (
 	KeymanagerConfigFileName = "keymanageropts.json"
 	// NewWalletPasswordPromptText for wallet creation.
 	NewWalletPasswordPromptText = "New wallet password"
-	// WalletPasswordPromptText for wallet unlocking.
+	// PasswordPromptText for wallet unlocking.
 	PasswordPromptText = "Wallet password"
 	// ConfirmPasswordPromptText for confirming a wallet password.
 	ConfirmPasswordPromptText = "Confirm password"

--- a/validator/client/iface/validator.go
+++ b/validator/client/iface/validator.go
@@ -20,9 +20,9 @@ const (
 	RoleUnknown ValidatorRole = iota
 	// RoleAttester means that the validator should submit an attestation.
 	RoleAttester
-	// RoleAttester means that the validator should propose a block.
+	// RoleProposer means that the validator should propose a block.
 	RoleProposer
-	// RoleAttester means that the validator should submit an aggregation and proof.
+	// RoleAggregator means that the validator should submit an aggregation and proof.
 	RoleAggregator
 )
 

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -39,7 +39,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot types.Slot, pubKey [4
 		log.Debug("Assigned to genesis slot, skipping proposal")
 		return
 	}
-	lock := mputil.NewMultilock(string(rune(iface.RoleProposer)), string(pubKey[:]))
+	lock := mputil.NewMultilock(string(iface.RoleProposer), string(pubKey[:]))
 	lock.Lock()
 	defer lock.Unlock()
 	ctx, span := trace.StartSpan(ctx, "validator.ProposeBlock")

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -650,7 +650,7 @@ func TestRolesAt_OK(t *testing.T) {
 	roleMap, err := v.RolesAt(context.Background(), 1)
 	require.NoError(t, err)
 
-	assert.Equal(t, iface.ValidatorRole(iface.RoleAttester), roleMap[bytesutil.ToBytes48(validatorKey.PublicKey().Marshal())][0])
+	assert.Equal(t, iface.RoleAttester, roleMap[bytesutil.ToBytes48(validatorKey.PublicKey().Marshal())][0])
 }
 
 func TestRolesAt_DoesNotAssignProposer_Slot0(t *testing.T) {
@@ -676,7 +676,7 @@ func TestRolesAt_DoesNotAssignProposer_Slot0(t *testing.T) {
 	roleMap, err := v.RolesAt(context.Background(), 0)
 	require.NoError(t, err)
 
-	assert.Equal(t, iface.ValidatorRole(iface.RoleAttester), roleMap[bytesutil.ToBytes48(validatorKey.PublicKey().Marshal())][0])
+	assert.Equal(t, iface.RoleAttester, roleMap[bytesutil.ToBytes48(validatorKey.PublicKey().Marshal())][0])
 }
 
 func TestCheckAndLogValidatorStatus_OK(t *testing.T) {

--- a/validator/db/kv/deprecated_attester_protection.go
+++ b/validator/db/kv/deprecated_attester_protection.go
@@ -58,7 +58,7 @@ func emptyHistoryData() *deprecatedHistoryData {
 // newDeprecatedAttestingHistory creates a new encapsulated attestation history byte array
 // sized by the latest epoch written.
 func newDeprecatedAttestingHistory(target types.Epoch) deprecatedEncodedAttestingHistory {
-	relativeTarget := types.Epoch(target % params.BeaconConfig().WeakSubjectivityPeriod)
+	relativeTarget := target % params.BeaconConfig().WeakSubjectivityPeriod
 	historyDataSize := (relativeTarget + 1) * historySize
 	arraySize := latestEpochWrittenSize + historyDataSize
 	en := make(deprecatedEncodedAttestingHistory, arraySize)

--- a/validator/db/kv/prune_attester_protection.go
+++ b/validator/db/kv/prune_attester_protection.go
@@ -17,7 +17,7 @@ import (
 func (s *Store) PruneAttestations(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "Validator.PruneAttestations")
 	defer span.End()
-	pubkeys := [][]byte{}
+	var pubkeys [][]byte
 	err := s.view(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(pubKeysBucket)
 		return bucket.ForEach(func(pubKey []byte, _ []byte) error {


### PR DESCRIPTION
Performed a round of code cleanups. Fixed the following:
- Comment of exported elements started with incorrect name
- Error string should not be capitalized
- Unused declarations
- Redundant casting
- Redundant parentheses