### PR TITLE
Simplify handling hex state ID

### DIFF
--- a/beacon-chain/rpc/beaconv1/state.go
+++ b/beacon-chain/rpc/beaconv1/state.go
@@ -137,11 +137,7 @@ func (bs *Server) stateRoot(ctx context.Context, stateId []byte) ([]byte, error)
 	case "justified":
 		root, err = bs.justifiedStateRoot(ctx)
 	default:
-		ok, matchErr := bytesutil.IsBytes32Hex(stateId)
-		if matchErr != nil {
-			return nil, errors.Wrap(err, "could not parse ID")
-		}
-		if ok {
+		if len(stateId) == 32 {
 			root, err = bs.stateRootByHex(ctx, stateId)
 		} else {
 			slotNumber, parseErr := strconv.ParseUint(stateIdString, 10, 64)

--- a/beacon-chain/rpc/statefetcher/fetcher.go
+++ b/beacon-chain/rpc/statefetcher/fetcher.go
@@ -67,11 +67,7 @@ func (p *StateProvider) State(ctx context.Context, stateId []byte) (iface.Beacon
 			return nil, errors.Wrap(err, "could not get justified state")
 		}
 	default:
-		ok, matchErr := bytesutil.IsBytes32Hex(stateId)
-		if matchErr != nil {
-			return nil, errors.Wrap(err, "could not parse ID")
-		}
-		if ok {
+		if len(stateId) == 32 {
 			s, err = p.stateByHex(ctx, stateId)
 		} else {
 			slotNumber, parseErr := strconv.ParseUint(stateIdString, 10, 64)


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Changes the way state API endpoints treat incoming hex values of state ID. Currently they assume hex values contain the `0x` prefix, but since we receive a byte array it's more reasonable to send only the state ID. This change will make state endpoint behave in the same way as block endpoints.

The `0x` prefix will be removed by the HTTP proxy server before forwarding the request.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A
