### PR TITLE
Use Pruning Sliding Window for Slasher

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -128,6 +128,9 @@ type SlasherDatabase interface {
 	AttestationRecordForValidator(
 		ctx context.Context, validatorIdx types.ValidatorIndex, targetEpoch types.Epoch,
 	) (*slashertypes.IndexedAttestationWrapper, error)
+	BlockProposalForValidator(
+		ctx context.Context, validatorIdx types.ValidatorIndex, slot types.Slot,
+	) (*slashertypes.SignedBlockHeaderWrapper, error)
 	CheckAttesterDoubleVotes(
 		ctx context.Context, attestations []*slashertypes.IndexedAttestationWrapper,
 	) ([]*slashertypes.AttesterDoubleVote, error)

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -137,11 +137,11 @@ type SlasherDatabase interface {
 	CheckDoubleBlockProposals(
 		ctx context.Context, proposals []*slashertypes.SignedBlockHeaderWrapper,
 	) ([]*eth.ProposerSlashing, error)
-	PruneAttestations(
-		ctx context.Context, currentEpoch, pruningEpochIncrements, historyLength types.Epoch,
+	PruneAttestationsAtEpoch(
+		ctx context.Context, minEpoch types.Epoch,
 	) error
-	PruneProposals(
-		ctx context.Context, currentEpoch, pruningEpochIncrements, historyLength types.Epoch,
+	PruneProposalsAtEpoch(
+		ctx context.Context, minEpoch types.Epoch,
 	) error
 	DatabasePath() string
 	ClearDB() error

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -58,7 +58,7 @@ func (s *Store) PruneAttestationsAtEpoch(
 			// We check the epoch from the current key in the database.
 			// If we have hit an epoch that is greater than the end epoch of the pruning process,
 			// we then completely exit the process as we are done.
-			if !uint64PrefixLessThanOrEqual(k, encodedEndPruneEpoch) {
+			if uint64PrefixGreaterThan(k, encodedEndPruneEpoch) {
 				return nil
 			}
 
@@ -126,7 +126,7 @@ func (s *Store) PruneProposalsAtEpoch(
 			// We check the slot from the current key in the database.
 			// If we have hit a slot that is greater than the end slot of the pruning process,
 			// we then completely exit the process as we are done.
-			if !uint64PrefixLessThanOrEqual(k, encodedEndPruneSlot) {
+			if uint64PrefixGreaterThan(k, encodedEndPruneSlot) {
 				return nil
 			}
 			// Proposals in the database look like this:
@@ -148,7 +148,7 @@ func slotFromProposalKey(key []byte) types.Slot {
 	return types.Slot(binary.LittleEndian.Uint64(key[:8]))
 }
 
-func uint64PrefixLessThanOrEqual(key, lessThan []byte) bool {
+func uint64PrefixGreaterThan(key, lessThan []byte) bool {
 	enc := key[:8]
-	return bytes.Compare(enc, lessThan) <= 0
+	return bytes.Compare(enc, lessThan) > 0
 }

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -41,7 +41,7 @@ func (s *Store) PruneAttestationsAtEpoch(
 		return nil
 	}
 
-	// If the lowest epoch is greater than or equal to the end pruning epoch,
+	// If the lowest epoch is greater than the end pruning epoch,
 	// there is nothing to prune, so we return early.
 	if lowestEpoch > minEpoch {
 		log.Debugf("Lowest epoch %d is > pruning epoch %d, nothing to prune", lowestEpoch, minEpoch)

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -33,8 +33,8 @@ func (s *Store) PruneAttestationsAtEpoch(
 
 	// If the lowest epoch is greater than or equal to the end pruning epoch,
 	// there is nothing to prune, so we return early.
-	if lowestEpoch >= minEpoch {
-		log.Debugf("Lowest epoch %d is >= pruning epoch %d, nothing to prune", lowestEpoch, minEpoch)
+	if lowestEpoch > minEpoch {
+		log.Debugf("Lowest epoch %d is > pruning epoch %d, nothing to prune", lowestEpoch, minEpoch)
 		return nil
 	}
 
@@ -48,7 +48,7 @@ func (s *Store) PruneAttestationsAtEpoch(
 			// We check the epoch from the current key in the database.
 			// If we have hit an epoch that is greater than the end epoch of the pruning process,
 			// we then completely exit the process as we are done.
-			if !uint64PrefixLessThan(k, encodedEndPruneEpoch) {
+			if !uint64PrefixLessThanOrEqual(k, encodedEndPruneEpoch) {
 				return nil
 			}
 
@@ -95,8 +95,8 @@ func (s *Store) PruneProposalsAtEpoch(
 
 	// If the lowest slot is greater than or equal to the end pruning slot,
 	// there is nothing to prune, so we return early.
-	if lowestSlot >= endPruneSlot {
-		log.Debugf("Lowest slot %d is >= pruning slot %d, nothing to prune", lowestSlot, endPruneSlot)
+	if lowestSlot > endPruneSlot {
+		log.Debugf("Lowest slot %d is > pruning slot %d, nothing to prune", lowestSlot, endPruneSlot)
 		return nil
 	}
 
@@ -109,7 +109,7 @@ func (s *Store) PruneProposalsAtEpoch(
 			// We check the slot from the current key in the database.
 			// If we have hit a slot that is greater than the end slot of the pruning process,
 			// we then completely exit the process as we are done.
-			if !uint64PrefixLessThan(k, encodedEndPruneSlot) {
+			if !uint64PrefixLessThanOrEqual(k, encodedEndPruneSlot) {
 				return nil
 			}
 			// Proposals in the database look like this:
@@ -133,7 +133,7 @@ func slotFromProposalKey(key []byte) types.Slot {
 	return types.Slot(binary.LittleEndian.Uint64(key[:8]))
 }
 
-func uint64PrefixLessThan(key, lessThan []byte) bool {
+func uint64PrefixLessThanOrEqual(key, lessThan []byte) bool {
 	enc := key[:8]
-	return bytes.Compare(enc, lessThan) < 0
+	return bytes.Compare(enc, lessThan) <= 0
 }

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -124,7 +124,7 @@ func (s *Store) PruneProposalsAtEpoch(
 		// We begin a pruning iteration at starting from the first item in the bucket.
 		proposalBkt := tx.Bucket(proposalRecordsBucket)
 		c := proposalBkt.Cursor()
-		// We begin a pruning iteration at starting from the first item in the bucket.
+		// We begin a pruning iteration starting from the first item in the bucket.
 		for k, _ := c.First(); k != nil; k, _ = c.Next() {
 			// We check the slot from the current key in the database.
 			// If we have hit a slot that is greater than the end slot of the pruning process,

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -11,20 +11,71 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-// PruneProposals prunes all proposal data older than currentEpoch - historyLength in
-// specified epoch increments. BoltDB cannot handle long-running transactions, so we instead
-// use a cursor-based mechanism to prune at pruningEpochIncrements by opening individual bolt
-// transactions for each pruning iteration.
-func (s *Store) PruneProposals(
-	ctx context.Context, currentEpoch, pruningEpochIncrements, historyLength types.Epoch,
+// PruneAttestationsAtEpoch deletes all attestations from the slasher DB with target epoch
+// less than or equal to the specified epoch.
+func (s *Store) PruneAttestationsAtEpoch(
+	ctx context.Context, minEpoch types.Epoch,
 ) error {
-	if currentEpoch < historyLength {
-		log.Debugf("Current epoch %d < history length %d, nothing to prune", currentEpoch, historyLength)
+	// We can prune everything less than the current epoch - history length.
+	encodedEndPruneEpoch := fssz.MarshalUint64([]byte{}, uint64(minEpoch))
+
+	// We retrieve the lowest stored epoch in the proposals bucket.
+	var lowestEpoch types.Epoch
+	if err := s.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(attestationDataRootsBucket)
+		c := bkt.Cursor()
+		k, _ := c.First()
+		lowestEpoch = types.Epoch(binary.LittleEndian.Uint64(k))
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// If the lowest epoch is greater than or equal to the end pruning epoch,
+	// there is nothing to prune, so we return early.
+	if lowestEpoch >= minEpoch {
+		log.Debugf("Lowest epoch %d is >= pruning epoch %d, nothing to prune", lowestEpoch, minEpoch)
 		return nil
 	}
-	// We can prune everything less than the current epoch - history length.
-	endEpoch := currentEpoch - historyLength
-	endPruneSlot, err := helpers.StartSlot(endEpoch)
+
+	return s.db.Update(func(tx *bolt.Tx) error {
+		rootsBkt := tx.Bucket(attestationDataRootsBucket)
+		attsBkt := tx.Bucket(attestationRecordsBucket)
+		c := rootsBkt.Cursor()
+
+		// We begin a pruning iteration at starting from the first item in the bucket.
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			// We check the epoch from the current key in the database.
+			// If we have hit an epoch that is greater than the end epoch of the pruning process,
+			// we then completely exit the process as we are done.
+			if !uint64PrefixLessThan(k, encodedEndPruneEpoch) {
+				return nil
+			}
+
+			// Attestation in the database look like this:
+			//  (target_epoch ++ _) => encode(attestation)
+			// so it is possible we have a few adjacent objects that have the same slot, such as
+			//  (target_epoch = 3 ++ _) => encode(attestation)
+			// so we only mark an epoch as pruned if the epoch of the current object
+			// under the cursor has changed.
+			if err := rootsBkt.Delete(k); err != nil {
+				return err
+			}
+			if err := attsBkt.Delete(v); err != nil {
+				return err
+			}
+			slasherAttestationsPrunedTotal.Inc()
+		}
+		return nil
+	})
+}
+
+// PruneProposalsAtEpoch deletes all proposals from the slasher DB with epoch
+// less than or equal to the specified epoch.
+func (s *Store) PruneProposalsAtEpoch(
+	ctx context.Context, minEpoch types.Epoch,
+) error {
+	endPruneSlot, err := helpers.StartSlot(minEpoch)
 	if err != nil {
 		return err
 	}
@@ -49,154 +100,33 @@ func (s *Store) PruneProposals(
 		return nil
 	}
 
-	// We prune in increments of `pruningEpochIncrements` at a time to prevent
-	// a long-running bolt transaction which overwhelms CPU and memory.
-	// While we still have epochs to prune based on a cursor, we continue the pruning process.
-	epochAtCursor := helpers.SlotToEpoch(lowestSlot)
-	for epochAtCursor < endEpoch {
-		// Each pruning iteration involves a unique bolt transaction. Given pruning can be
-		// a very expensive process which puts pressure on the database, we perform
-		// the process in a batch-based method using a cursor to proceed to the next batch.
-		log.Debugf("Pruned %d/%d epochs worth of proposals", epochAtCursor, endEpoch-1)
-		if err = s.db.Update(func(tx *bolt.Tx) error {
-			proposalBkt := tx.Bucket(proposalRecordsBucket)
-			c := proposalBkt.Cursor()
-
-			var lastPrunedEpoch, epochsPruned types.Epoch
-			// We begin a pruning iteration at starting from the first item in the bucket.
-			for k, _ := c.First(); k != nil; k, _ = c.Next() {
-				// We check the slot from the current key in the database.
-				// If we have hit a slot that is greater than the end slot of the pruning process,
-				// we then completely exit the process as we are done.
-				if !uint64PrefixLessThan(k, encodedEndPruneSlot) {
-					epochAtCursor = endEpoch
-					return nil
-				}
-				epochAtCursor = helpers.SlotToEpoch(slotFromProposalKey(k))
-
-				// Proposals in the database look like this:
-				//  (slot ++ validatorIndex) => encode(proposal)
-				// so it is possible we have a few adjacent objects that have the same slot, such as
-				//  (slot = 3 ++ validatorIndex = 0) => ...
-				//  (slot = 3 ++ validatorIndex = 1) => ...
-				//  (slot = 3 ++ validatorIndex = 2) => ...
-				// so we only mark an epoch as pruned if the epoch of the current object
-				// under the cursor has changed.
-				if err := proposalBkt.Delete(k); err != nil {
-					return err
-				}
-				if epochAtCursor == 0 {
-					epochsPruned = 1
-				} else if epochAtCursor > lastPrunedEpoch {
-					epochsPruned++
-					lastPrunedEpoch = epochAtCursor
-				}
-				slasherProposalsPrunedTotal.Inc()
-
-				// If we have pruned N epochs in this pruning iteration,
-				// we exit from the bolt transaction.
-				if epochsPruned >= pruningEpochIncrements {
-					return nil
-				}
+	return s.db.Update(func(tx *bolt.Tx) error {
+		// We begin a pruning iteration at starting from the first item in the bucket.
+		proposalBkt := tx.Bucket(proposalRecordsBucket)
+		c := proposalBkt.Cursor()
+		// We begin a pruning iteration at starting from the first item in the bucket.
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			// We check the slot from the current key in the database.
+			// If we have hit a slot that is greater than the end slot of the pruning process,
+			// we then completely exit the process as we are done.
+			if !uint64PrefixLessThan(k, encodedEndPruneSlot) {
+				return nil
 			}
-			return nil
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// PruneAttestations prunes all proposal data older than historyLength.
-func (s *Store) PruneAttestations(
-	ctx context.Context, currentEpoch, pruningEpochIncrements, historyLength types.Epoch,
-) error {
-	if currentEpoch < historyLength {
-		log.Debugf("Current epoch %d < history length %d, nothing to prune", currentEpoch, historyLength)
-		return nil
-	}
-	// We can prune everything less than the current epoch - history length.
-	endPruneEpoch := currentEpoch - historyLength
-	encodedEndPruneEpoch := fssz.MarshalUint64([]byte{}, uint64(endPruneEpoch))
-
-	// We retrieve the lowest stored epoch in the proposals bucket.
-	var lowestEpoch types.Epoch
-	if err := s.db.View(func(tx *bolt.Tx) error {
-		bkt := tx.Bucket(attestationDataRootsBucket)
-		c := bkt.Cursor()
-		k, _ := c.First()
-		lowestEpoch = types.Epoch(binary.LittleEndian.Uint64(k))
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	// If the lowest slot is greater than or equal to the end pruning slot,
-	// there is nothing to prune, so we return early.
-	if lowestEpoch >= endPruneEpoch {
-		log.Debugf("Lowest epoch %d is >= pruning epoch %d, nothing to prune", lowestEpoch, endPruneEpoch)
-		return nil
-	}
-
-	// We prune in increments of `pruningEpochIncrements` at a time to prevent
-	// a long-running bolt transaction which overwhelms CPU and memory.
-	// While we still have epochs to prune based on a cursor, we continue the pruning process.
-	epochAtCursor := lowestEpoch
-	for epochAtCursor < endPruneEpoch {
-		// Each pruning iteration involves a unique bolt transaction. Given pruning can be
-		// a very expensive process which puts pressure on the database, we perform
-		// the process in a batch-based method using a cursor to proceed to the next batch.
-		log.Debugf("Pruned %d/%d epochs worth of attestations", epochAtCursor, endPruneEpoch-1)
-		if err := s.db.Update(func(tx *bolt.Tx) error {
-			rootsBkt := tx.Bucket(attestationDataRootsBucket)
-			attsBkt := tx.Bucket(attestationRecordsBucket)
-			c := rootsBkt.Cursor()
-
-			var lastPrunedEpoch, epochsPruned types.Epoch
-			// We begin a pruning iteration at starting from the first item in the bucket.
-			for k, v := c.First(); k != nil; k, v = c.Next() {
-				// We check the epoch from the current key in the database.
-				// If we have hit an epoch that is greater than the end epoch of the pruning process,
-				// we then completely exit the process as we are done.
-				if !uint64PrefixLessThan(k, encodedEndPruneEpoch) {
-					epochAtCursor = endPruneEpoch
-					return nil
-				}
-
-				epochAtCursor = types.Epoch(binary.LittleEndian.Uint64(k))
-
-				// Attestation in the database look like this:
-				//  (target_epoch ++ _) => encode(attestation)
-				// so it is possible we have a few adjacent objects that have the same slot, such as
-				//  (target_epoch = 3 ++ _) => encode(attestation)
-				// so we only mark an epoch as pruned if the epoch of the current object
-				// under the cursor has changed.
-				if err := rootsBkt.Delete(k); err != nil {
-					return err
-				}
-				if err := attsBkt.Delete(v); err != nil {
-					return err
-				}
-				if epochAtCursor == 0 {
-					epochsPruned = 1
-				} else if epochAtCursor > lastPrunedEpoch {
-					epochsPruned++
-					lastPrunedEpoch = epochAtCursor
-				}
-				slasherAttestationsPrunedTotal.Inc()
-
-				// If we have pruned N epochs in this pruning iteration,
-				// we exit from the bolt transaction.
-				if epochsPruned >= pruningEpochIncrements {
-					return nil
-				}
+			// Proposals in the database look like this:
+			//  (slot ++ validatorIndex) => encode(proposal)
+			// so it is possible we have a few adjacent objects that have the same slot, such as
+			//  (slot = 3 ++ validatorIndex = 0) => ...
+			//  (slot = 3 ++ validatorIndex = 1) => ...
+			//  (slot = 3 ++ validatorIndex = 2) => ...
+			// so we only mark an epoch as pruned if the epoch of the current object
+			// under the cursor has changed.
+			if err := proposalBkt.Delete(k); err != nil {
+				return err
 			}
-			return nil
-		}); err != nil {
-			return err
+			slasherProposalsPrunedTotal.Inc()
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 func slotFromProposalKey(key []byte) types.Slot {

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -53,7 +53,7 @@ func (s *Store) PruneAttestationsAtEpoch(
 		attsBkt := tx.Bucket(attestationRecordsBucket)
 		c := rootsBkt.Cursor()
 
-		// We begin a pruning iteration at starting from the first item in the bucket.
+		// We begin a pruning iteration starting from the first item in the bucket.
 		for k, v := c.First(); k != nil; k, v = c.Next() {
 			// We check the epoch from the current key in the database.
 			// If we have hit an epoch that is greater than the end epoch of the pruning process,

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -21,14 +21,24 @@ func (s *Store) PruneAttestationsAtEpoch(
 
 	// We retrieve the lowest stored epoch in the proposals bucket.
 	var lowestEpoch types.Epoch
+	var hasData bool
 	if err := s.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(attestationDataRootsBucket)
 		c := bkt.Cursor()
 		k, _ := c.First()
+		if k == nil {
+			return nil
+		}
+		hasData = true
 		lowestEpoch = types.Epoch(binary.LittleEndian.Uint64(k))
 		return nil
 	}); err != nil {
 		return err
+	}
+
+	// If there is no data stored, just exit early.
+	if !hasData {
+		return nil
 	}
 
 	// If the lowest epoch is greater than or equal to the end pruning epoch,
@@ -83,14 +93,24 @@ func (s *Store) PruneProposalsAtEpoch(
 
 	// We retrieve the lowest stored slot in the proposals bucket.
 	var lowestSlot types.Slot
+	var hasData bool
 	if err = s.db.View(func(tx *bolt.Tx) error {
 		proposalBkt := tx.Bucket(proposalRecordsBucket)
 		c := proposalBkt.Cursor()
 		k, _ := c.First()
+		if k == nil {
+			return nil
+		}
+		hasData = true
 		lowestSlot = slotFromProposalKey(k)
 		return nil
 	}); err != nil {
 		return err
+	}
+
+	// If there is no data stored, just exit early.
+	if !hasData {
+		return nil
 	}
 
 	// If the lowest slot is greater than or equal to the end pruning slot,

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -19,7 +19,7 @@ func (s *Store) PruneAttestationsAtEpoch(
 	// We can prune everything less than the current epoch - history length.
 	encodedEndPruneEpoch := fssz.MarshalUint64([]byte{}, uint64(minEpoch))
 
-	// We retrieve the lowest stored epoch in the proposals bucket.
+	// We retrieve the lowest stored epoch in the attestations bucket.
 	var lowestEpoch types.Epoch
 	var hasData bool
 	if err := s.db.View(func(tx *bolt.Tx) error {

--- a/beacon-chain/db/slasherkv/pruning_test.go
+++ b/beacon-chain/db/slasherkv/pruning_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	types "github.com/prysmaticlabs/eth2-types"
-	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -15,28 +14,14 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-func TestStore_PruneProposals(t *testing.T) {
+func TestStore_PruneProposalsAtEpoch(t *testing.T) {
 	ctx := context.Background()
-
-	// If the current slot is less than the history length we track in slasher, there
-	// is nothing to prune yet, so we expect exiting early.
-	t.Run("current_epoch_less_than_history_length", func(t *testing.T) {
-		hook := logTest.NewGlobal()
-		beaconDB := setupDB(t)
-		epochPruningIncrements := types.Epoch(100)
-		currentEpoch := types.Epoch(1)
-		historyLength := types.Epoch(2)
-		err := beaconDB.PruneProposals(ctx, currentEpoch, epochPruningIncrements, historyLength)
-		require.NoError(t, err)
-		require.LogsContain(t, hook, "Current epoch 1 < history length 2, nothing to prune")
-	})
 
 	// If the lowest stored epoch in the database is >= the end epoch of the pruning process,
 	// there is nothing to prune, so we also expect exiting early.
 	t.Run("lowest_stored_epoch_greater_than_pruning_limit_epoch", func(t *testing.T) {
 		hook := logTest.NewGlobal()
 		beaconDB := setupDB(t)
-		epochPruningIncrements := types.Epoch(100)
 
 		// With a current epoch of 20 and a history length of 10, we should be pruning
 		// everything before epoch (20 - 10) = 10.
@@ -49,14 +34,7 @@ func TestStore_PruneProposals(t *testing.T) {
 
 		err = beaconDB.db.Update(func(tx *bolt.Tx) error {
 			bkt := tx.Bucket(proposalRecordsBucket)
-			key, err := keyForValidatorProposal(&slashertypes.SignedBlockHeaderWrapper{
-				SignedBeaconBlockHeader: &ethpb.SignedBeaconBlockHeader{
-					Header: &ethpb.BeaconBlockHeader{
-						Slot:          lowestStoredSlot,
-						ProposerIndex: 0,
-					},
-				},
-			})
+			key, err := keyForValidatorProposal(lowestStoredSlot+1, 0 /* proposer index */)
 			if err != nil {
 				return err
 			}
@@ -64,19 +42,15 @@ func TestStore_PruneProposals(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = beaconDB.PruneProposals(ctx, currentEpoch, epochPruningIncrements, historyLength)
+		err = beaconDB.PruneProposalsAtEpoch(ctx, pruningLimitEpoch)
 		require.NoError(t, err)
 		expectedLog := fmt.Sprintf(
-			"Lowest slot %d is >= pruning slot %d, nothing to prune", lowestStoredSlot, lowestStoredSlot,
+			"Lowest slot %d is > pruning slot %d, nothing to prune", lowestStoredSlot+1, lowestStoredSlot,
 		)
 		require.LogsContain(t, hook, expectedLog)
 	})
 
-	// Prune in increments until the cursor reaches the pruning limit epoch, and we expect
-	// that all the proposals written are deleted from the database, while those above the
-	// pruning limit epoch are kept intact.
-	t.Run("prune_in_full_increments_and_verify_deletions", func(t *testing.T) {
-		hook := logTest.NewGlobal()
+	t.Run("prune_and_verify_deletions", func(t *testing.T) {
 		beaconDB := setupDB(t)
 
 		config := params.BeaconConfig()
@@ -85,7 +59,6 @@ func TestStore_PruneProposals(t *testing.T) {
 		params.OverrideBeaconConfig(copyConfig)
 		defer params.OverrideBeaconConfig(config)
 
-		epochPruningIncrements := types.Epoch(2)
 		historyLength := types.Epoch(10)
 		currentEpoch := types.Epoch(20)
 		pruningLimitEpoch := currentEpoch - historyLength
@@ -101,7 +74,7 @@ func TestStore_PruneProposals(t *testing.T) {
 			require.NoError(t, err)
 			for j := startSlot; j < endSlot; j++ {
 				prop1 := createProposalWrapper(t, j, 0 /* proposer index */, []byte{0})
-				prop2 := createProposalWrapper(t, j, 2 /* proposer index */, []byte{1})
+				prop2 := createProposalWrapper(t, j, 1 /* proposer index */, []byte{1})
 				proposals = append(proposals, prop1, prop2)
 			}
 		}
@@ -109,13 +82,8 @@ func TestStore_PruneProposals(t *testing.T) {
 		require.NoError(t, beaconDB.SaveBlockProposals(ctx, proposals))
 
 		// We expect pruning completes without an issue and properly logs progress.
-		err := beaconDB.PruneProposals(ctx, currentEpoch, epochPruningIncrements, historyLength)
+		err := beaconDB.PruneProposalsAtEpoch(ctx, pruningLimitEpoch)
 		require.NoError(t, err)
-
-		for i := types.Epoch(0); i < pruningLimitEpoch; i++ {
-			wantedLog := fmt.Sprintf("Pruned %d/%d epochs", i, pruningLimitEpoch-1)
-			require.LogsContain(t, hook, wantedLog)
-		}
 
 		// Everything before epoch 10 should be deleted.
 		for i := types.Epoch(0); i < pruningLimitEpoch; i++ {
@@ -126,13 +94,11 @@ func TestStore_PruneProposals(t *testing.T) {
 				endSlot, err := helpers.StartSlot(i + 1)
 				require.NoError(t, err)
 				for j := startSlot; j < endSlot; j++ {
-					prop1 := createProposalWrapper(t, j, 0 /* proposer index */, []byte{0})
-					prop1Key, err := keyForValidatorProposal(prop1)
+					prop1Key, err := keyForValidatorProposal(j, 0)
 					if err != nil {
 						return err
 					}
-					prop2 := createProposalWrapper(t, j, 2 /* proposer index */, []byte{1})
-					prop2Key, err := keyForValidatorProposal(prop2)
+					prop2Key, err := keyForValidatorProposal(j, 1)
 					if err != nil {
 						return err
 					}
@@ -153,25 +119,11 @@ func TestStore_PruneProposals(t *testing.T) {
 func TestStore_PruneAttestations_OK(t *testing.T) {
 	ctx := context.Background()
 
-	// If the current slot is less than the history length we track in slasher, there
-	// is nothing to prune yet, so we expect exiting early.
-	t.Run("current_epoch_less_than_history_length", func(t *testing.T) {
-		hook := logTest.NewGlobal()
-		beaconDB := setupDB(t)
-		epochPruningIncrements := types.Epoch(100)
-		currentEpoch := types.Epoch(1)
-		historyLength := types.Epoch(2)
-		err := beaconDB.PruneAttestations(ctx, currentEpoch, epochPruningIncrements, historyLength)
-		require.NoError(t, err)
-		require.LogsContain(t, hook, "Current epoch 1 < history length 2, nothing to prune")
-	})
-
 	// If the lowest stored epoch in the database is >= the end epoch of the pruning process,
 	// there is nothing to prune, so we also expect exiting early.
 	t.Run("lowest_stored_epoch_greater_than_pruning_limit_epoch", func(t *testing.T) {
 		hook := logTest.NewGlobal()
 		beaconDB := setupDB(t)
-		epochPruningIncrements := types.Epoch(100)
 
 		// With a current epoch of 20 and a history length of 10, we should be pruning
 		// everything before epoch (20 - 10) = 10.
@@ -184,25 +136,21 @@ func TestStore_PruneAttestations_OK(t *testing.T) {
 		err := beaconDB.db.Update(func(tx *bolt.Tx) error {
 			bkt := tx.Bucket(attestationDataRootsBucket)
 			encIdx := encodeValidatorIndex(types.ValidatorIndex(0))
-			encodedTargetEpoch := encodeTargetEpoch(lowestStoredEpoch)
+			encodedTargetEpoch := encodeTargetEpoch(lowestStoredEpoch + 1)
 			key := append(encodedTargetEpoch, encIdx...)
 			return bkt.Put(key, []byte("hi"))
 		})
 		require.NoError(t, err)
 
-		err = beaconDB.PruneAttestations(ctx, currentEpoch, epochPruningIncrements, historyLength)
+		err = beaconDB.PruneAttestationsAtEpoch(ctx, pruningLimitEpoch)
 		require.NoError(t, err)
 		expectedLog := fmt.Sprintf(
-			"Lowest epoch %d is >= pruning epoch %d, nothing to prune", lowestStoredEpoch, lowestStoredEpoch,
+			"Lowest epoch %d is > pruning epoch %d, nothing to prune", lowestStoredEpoch+1, lowestStoredEpoch,
 		)
 		require.LogsContain(t, hook, expectedLog)
 	})
 
-	// Prune in increments until the cursor reaches the pruning limit epoch, and we expect
-	// that all the attestations written are deleted from the database, while those above the
-	// pruning limit epoch are kept intact.
-	t.Run("prune_in_full_increments_and_verify_deletions", func(t *testing.T) {
-		hook := logTest.NewGlobal()
+	t.Run("prune_and_verify_deletions", func(t *testing.T) {
 		beaconDB := setupDB(t)
 
 		config := params.BeaconConfig()
@@ -211,7 +159,6 @@ func TestStore_PruneAttestations_OK(t *testing.T) {
 		params.OverrideBeaconConfig(copyConfig)
 		defer params.OverrideBeaconConfig(config)
 
-		epochPruningIncrements := types.Epoch(2)
 		historyLength := types.Epoch(10)
 		currentEpoch := types.Epoch(20)
 		pruningLimitEpoch := currentEpoch - historyLength
@@ -241,14 +188,9 @@ func TestStore_PruneAttestations_OK(t *testing.T) {
 
 		require.NoError(t, beaconDB.SaveAttestationRecordsForValidators(ctx, attestations))
 
-		// We expect pruning completes without an issue and properly logs progress.
-		err := beaconDB.PruneAttestations(ctx, currentEpoch, epochPruningIncrements, historyLength)
+		// We expect pruning completes without an issue.
+		err := beaconDB.PruneAttestationsAtEpoch(ctx, pruningLimitEpoch)
 		require.NoError(t, err)
-
-		for i := types.Epoch(0); i < pruningLimitEpoch; i++ {
-			wantedLog := fmt.Sprintf("Pruned %d/%d epochs", i, pruningLimitEpoch-1)
-			require.LogsContain(t, hook, wantedLog)
-		}
 
 		// Everything before epoch 10 should be deleted.
 		for i := types.Epoch(0); i < pruningLimitEpoch; i++ {

--- a/beacon-chain/db/slasherkv/slasher.go
+++ b/beacon-chain/db/slasherkv/slasher.go
@@ -315,7 +315,7 @@ func (s *Store) CheckDoubleBlockProposals(
 func (s *Store) BlockProposalForValidator(
 	ctx context.Context, validatorIdx types.ValidatorIndex, slot types.Slot,
 ) (*slashertypes.SignedBlockHeaderWrapper, error) {
-	ctx, span := trace.StartSpan(ctx, "BeaconDB.ProposalRecordForValidator")
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.BlockProposalForValidator")
 	defer span.End()
 	var record *slashertypes.SignedBlockHeaderWrapper
 	key, err := keyForValidatorProposal(slot, validatorIdx)

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -190,8 +190,12 @@ func (s *Service) pruneSlasherData(ctx context.Context, slotTicker <-chan types.
 // we care about is 1, 2, 3, 4, so we can delete data for epoch 0.
 func (s *Service) pruneSlasherDataWithinSlidingWindow(ctx context.Context, currentEpoch types.Epoch) error {
 	var minEpoch types.Epoch
-	if currentEpoch > s.params.historyLength {
+	if currentEpoch >= s.params.historyLength {
 		minEpoch = currentEpoch - s.params.historyLength
+	} else {
+		// If the current epoch is less than the history length, we should not
+		// attempt to prune at all.
+		return nil
 	}
 	if err := s.serviceCfg.Database.PruneAttestationsAtEpoch(
 		ctx, minEpoch,

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -197,6 +197,10 @@ func (s *Service) pruneSlasherDataWithinSlidingWindow(ctx context.Context, curre
 		// attempt to prune at all.
 		return nil
 	}
+	log.WithFields(logrus.Fields{
+		"currentEpoch":          currentEpoch,
+		"pruningAllBeforeEpoch": minEpoch,
+	}).Debug("Pruning old attestations and proposals for slasher")
 	if err := s.serviceCfg.Database.PruneAttestationsAtEpoch(
 		ctx, minEpoch,
 	); err != nil {

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -202,10 +202,10 @@ func (s *Service) pruneSlasherDataWithinSlidingWindow(ctx context.Context, curre
 	); err != nil {
 		return errors.Wrap(err, "Could not prune attestations")
 	}
-	//if err := s.serviceCfg.Database.PruneProposalsAtEpoch(
-	//	ctx, minEpoch,
-	//); err != nil {
-	//	return errors.Wrap(err, "Could not prune proposals")
-	//}
+	if err := s.serviceCfg.Database.PruneProposalsAtEpoch(
+		ctx, minEpoch,
+	); err != nil {
+		return errors.Wrap(err, "Could not prune proposals")
+	}
 	return nil
 }

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	slashertypes "github.com/prysmaticlabs/prysm/beacon-chain/slasher/types"
@@ -168,29 +169,39 @@ func (s *Service) processQueuedBlocks(ctx context.Context, slotTicker <-chan typ
 	}
 }
 
+// Prunes slasher data on each slot tick to prevent unnecessary build-up of disk space usage.
 func (s *Service) pruneSlasherData(ctx context.Context, slotTicker <-chan types.Slot) {
 	for {
 		select {
 		case currentSlot := <-slotTicker:
-			if !helpers.IsEpochStart(currentSlot) {
-				continue
-			}
-			currentEpoch := helpers.SlotToEpoch(currentSlot)
-			if err := s.serviceCfg.Database.PruneAttestations(
-				ctx, currentEpoch, s.params.pruningEpochIncrements, s.params.historyLength,
-			); err != nil {
-				log.WithError(err).Error("Could not prune attestations")
-				continue
-			}
-
-			if err := s.serviceCfg.Database.PruneProposals(
-				ctx, currentEpoch, s.params.pruningEpochIncrements, s.params.historyLength,
-			); err != nil {
-				log.WithError(err).Error("Could not prune proposals")
+			if err := s.pruneSlasherDataWithinSlidingWindow(ctx, helpers.SlotToEpoch(currentSlot)); err != nil {
+				log.WithError(err).Error("Could not prune slasher data")
 				continue
 			}
 		case <-ctx.Done():
 			return
 		}
 	}
+}
+
+// Prunes slasher data by using a sliding window of [current_epoch - HISTORY_LENGTH, current_epoch].
+// All data before that window is unnecessary for slasher, so can be periodically deleted.
+// Say HISTORY_LENGTH is 4 and we have data for epochs 0, 1, 2, 3. Once we hit epoch 4, the sliding window
+// we care about is 1, 2, 3, 4, so we can delete data for epoch 0.
+func (s *Service) pruneSlasherDataWithinSlidingWindow(ctx context.Context, currentEpoch types.Epoch) error {
+	var minEpoch types.Epoch
+	if currentEpoch > s.params.historyLength {
+		minEpoch = currentEpoch - s.params.historyLength
+	}
+	if err := s.serviceCfg.Database.PruneAttestationsAtEpoch(
+		ctx, minEpoch,
+	); err != nil {
+		return errors.Wrap(err, "Could not prune attestations")
+	}
+	//if err := s.serviceCfg.Database.PruneProposalsAtEpoch(
+	//	ctx, minEpoch,
+	//); err != nil {
+	//	return errors.Wrap(err, "Could not prune proposals")
+	//}
+	return nil
 }

--- a/beacon-chain/slasher/receive.go
+++ b/beacon-chain/slasher/receive.go
@@ -189,9 +189,9 @@ func (s *Service) pruneSlasherData(ctx context.Context, slotTicker <-chan types.
 // Say HISTORY_LENGTH is 4 and we have data for epochs 0, 1, 2, 3. Once we hit epoch 4, the sliding window
 // we care about is 1, 2, 3, 4, so we can delete data for epoch 0.
 func (s *Service) pruneSlasherDataWithinSlidingWindow(ctx context.Context, currentEpoch types.Epoch) error {
-	var minEpoch types.Epoch
+	var maxPruningEpoch types.Epoch
 	if currentEpoch >= s.params.historyLength {
-		minEpoch = currentEpoch - s.params.historyLength
+		maxPruningEpoch = currentEpoch - s.params.historyLength
 	} else {
 		// If the current epoch is less than the history length, we should not
 		// attempt to prune at all.
@@ -199,15 +199,15 @@ func (s *Service) pruneSlasherDataWithinSlidingWindow(ctx context.Context, curre
 	}
 	log.WithFields(logrus.Fields{
 		"currentEpoch":          currentEpoch,
-		"pruningAllBeforeEpoch": minEpoch,
+		"pruningAllBeforeEpoch": maxPruningEpoch,
 	}).Debug("Pruning old attestations and proposals for slasher")
 	if err := s.serviceCfg.Database.PruneAttestationsAtEpoch(
-		ctx, minEpoch,
+		ctx, maxPruningEpoch,
 	); err != nil {
 		return errors.Wrap(err, "Could not prune attestations")
 	}
 	if err := s.serviceCfg.Database.PruneProposalsAtEpoch(
-		ctx, minEpoch,
+		ctx, maxPruningEpoch,
 	); err != nil {
 		return errors.Wrap(err, "Could not prune proposals")
 	}

--- a/beacon-chain/slasher/receive_test.go
+++ b/beacon-chain/slasher/receive_test.go
@@ -123,11 +123,10 @@ func TestService_pruneSlasherDataWithinSlidingWindow_ProposalsPruned(t *testing.
 	ctx := context.Background()
 
 	// Override beacon config to 1 slot per epoch for easier testing.
+	params2.SetupTestConfigCleanup(t)
 	config := params2.BeaconConfig()
-	configCopy := config.Copy()
-	configCopy.SlotsPerEpoch = 1
-	params2.OverrideBeaconConfig(configCopy)
-	defer params2.OverrideBeaconConfig(config)
+	config.SlotsPerEpoch = 1
+	params2.OverrideBeaconConfig(config)
 
 	params := DefaultParams()
 	params.historyLength = 4 // 4 epochs worth of history.


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Our new slasher in #8340 has serious performance issues when performing database pruning. For the purposes of slashing, we only care about data from the last N epochs where N is a safe weak subjectivity period, such as 4096 epochs. We should be pruning old data every slot to avoid accumulation of unnecessary info. Our current pruning algorithm has a serious bug in that it does as follows:

1. Run for 4096 epochs
2. Upon hitting epoch 4097, prune _everything_ before it

This is very dangerous and incorrect as a solution. Instead, we should be using a _sliding window_ between [current_epoch-HISTORY_LENGTH, current_epoch]. For example:

With `HISTORY_LENGTH = 4`, if we have epochs `0, 1, 2, 3` and we then reach epoch `4`, we should update the sliding window to `1, 2, 3, 4` and delete everything in epoch 0. This will drastically reduce the impact of pruning and retain correct logic.

**Which issues(s) does this PR fix?**

Part of #8331 
