### PR TITLE
Fix testing for attestation pools endpoint

### DIFF
--- a/beacon-chain/rpc/beaconv1/pool.go
+++ b/beacon-chain/rpc/beaconv1/pool.go
@@ -2,7 +2,6 @@ package beaconv1
 
 import (
 	"context"
-	"fmt"
 
 	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1"
 	ethpb_alpha "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
@@ -29,7 +28,6 @@ func (bs *Server) ListPoolAttestations(ctx context.Context, req *ethpb.Attestati
 	attestations = append(attestations, unaggAtts...)
 	isEmptyReq := req.Slot == nil && req.CommitteeIndex == nil
 	if isEmptyReq {
-		fmt.Println("return all")
 		allAtts := make([]*ethpb.Attestation, len(attestations))
 		for i, att := range attestations {
 			allAtts[i] = migration.V1Alpha1AttestationToV1(att)

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -167,6 +167,7 @@ func parseMsg(defaultMsg string, msg ...interface{}) string {
 
 func isDeepEqual(expected, actual interface{}) bool {
 	_, isProto := expected.(proto.Message)
+	fmt.Println("This is: ", isProto)
 	if isProto {
 		return proto.Equal(expected.(proto.Message), actual.(proto.Message))
 	}

--- a/shared/testutil/assertions/assertions.go
+++ b/shared/testutil/assertions/assertions.go
@@ -167,7 +167,6 @@ func parseMsg(defaultMsg string, msg ...interface{}) string {
 
 func isDeepEqual(expected, actual interface{}) bool {
 	_, isProto := expected.(proto.Message)
-	fmt.Println("This is: ", isProto)
 	if isProto {
 		return proto.Equal(expected.(proto.Message), actual.(proto.Message))
 	}


### PR DESCRIPTION
**What type of PR is this?**
Test fix

**What does this PR do? Why is it needed?**
This PR is a follow up for #8902 which fixes the testing methodology as before we had assumed the results from `attestationPool.AggregatedAttestations()` to follow the same order as input, but this was not the case. 

This also improves testing coverage to include unaggregated attestations.