### PR TITLE
Fix Panic When Accessing State Frequently

### DIFF
--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -132,10 +132,9 @@ func (s *Store) HasState(ctx context.Context, blockRoot [32]byte) bool {
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(stateBucket)
 		stBytes := bkt.Get(blockRoot[:])
-		if len(stBytes) == 0 {
-			return nil
+		if len(stBytes) > 0 {
+			hasState = true
 		}
-		hasState = true
 		return nil
 	})
 	if err != nil {

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -204,7 +204,16 @@ func (s *Store) stateBytes(ctx context.Context, blockRoot [32]byte) ([]byte, err
 	var dst []byte
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(stateBucket)
-		dst = bkt.Get(blockRoot[:])
+		stBytes := bkt.Get(blockRoot[:])
+		if len(stBytes) == 0 {
+			return nil
+		}
+		// Due to https://github.com/boltdb/bolt/issues/204, we need to
+		// allocate a byte slice separately in the transaction or there
+		// is the possibility of a panic when accessing that particular
+		// area of memory.
+		dst = make([]byte, len(stBytes))
+		copy(dst, stBytes)
 		return nil
 	})
 	return dst, err


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Allocates separately, so as to prevent panics from occurring due to changes in memory mapping. 
- [x] For `HasState`, it inlines the method so as to prevent unnecessary allocation during checking for state 
existence.

**Which issues(s) does this PR fix?**

Fixes #8886

**Other notes for review**
