### PR TITLE
Run `/node/syncing` through API Middleware

### DIFF
--- a/beacon-chain/rpc/nodev1/node.go
+++ b/beacon-chain/rpc/nodev1/node.go
@@ -267,6 +267,7 @@ func (ns *Server) GetSyncStatus(ctx context.Context, _ *emptypb.Empty) (*ethpb.S
 		Data: &ethpb.SyncInfo{
 			HeadSlot:     headSlot,
 			SyncDistance: ns.GenesisTimeFetcher.CurrentSlot() - headSlot,
+			IsSyncing:    ns.SyncChecker.Syncing(),
 		},
 	}, nil
 }

--- a/beacon-chain/rpc/nodev1/node_test.go
+++ b/beacon-chain/rpc/nodev1/node_test.go
@@ -160,15 +160,19 @@ func TestSyncStatus(t *testing.T) {
 	err = state.SetSlot(100)
 	require.NoError(t, err)
 	chainService := &mock.ChainService{Slot: currentSlot, State: state}
+	syncChecker := &syncmock.Sync{}
+	syncChecker.IsSyncing = true
 
 	s := &Server{
 		HeadFetcher:        chainService,
 		GenesisTimeFetcher: chainService,
+		SyncChecker:        syncChecker,
 	}
 	resp, err := s.GetSyncStatus(context.Background(), &emptypb.Empty{})
 	require.NoError(t, err)
 	assert.Equal(t, types.Slot(100), resp.Data.HeadSlot)
 	assert.Equal(t, types.Slot(10), resp.Data.SyncDistance)
+	assert.Equal(t, true, resp.Data.IsSyncing)
 }
 
 func TestGetPeer(t *testing.T) {

--- a/shared/gateway/api_middleware.go
+++ b/shared/gateway/api_middleware.go
@@ -70,6 +70,7 @@ func (m *ApiProxyMiddleware) Run() error {
 	m.handleApiEndpoint("/eth/v1/node/peers/{peer_id}")
 	m.handleApiEndpoint("/eth/v1/node/peer_count")
 	m.handleApiEndpoint("/eth/v1/node/version")
+	m.handleApiEndpoint("/eth/v1/node/syncing")
 	m.handleApiEndpoint("/eth/v1/node/health")
 	m.handleApiEndpoint("/eth/v1/debug/beacon/states/{state_id}")
 	m.handleApiEndpoint("/eth/v1/debug/beacon/heads")
@@ -598,6 +599,8 @@ func getEndpointData(endpoint string) (endpointData, error) {
 		return endpointData{getResponse: &PeerCountResponseJson{}, err: &DefaultErrorJson{}}, nil
 	case "/eth/v1/node/version":
 		return endpointData{getResponse: &VersionResponseJson{}, err: &DefaultErrorJson{}}, nil
+	case "/eth/v1/node/syncing":
+		return endpointData{getResponse: &SyncingResponseJson{}, err: &DefaultErrorJson{}}, nil
 	case "/eth/v1/node/health":
 		return endpointData{err: &DefaultErrorJson{}}, nil
 	case "/eth/v1/debug/beacon/states/{state_id}":

--- a/shared/gateway/middleware_structs.go
+++ b/shared/gateway/middleware_structs.go
@@ -137,6 +137,11 @@ type VersionResponseJson struct {
 	Data *VersionJson `json:"data"`
 }
 
+// SyncingResponseJson is used in /node/syncing API endpoint.
+type SyncingResponseJson struct {
+	Data *SyncInfoJson `json:"data"`
+}
+
 // BeaconStateResponseJson is used in /debug/beacon/states/{state_id} API endpoint.
 type BeaconStateResponseJson struct {
 	Data *BeaconStateJson `json:"data"`
@@ -417,6 +422,13 @@ type ForkChoiceHeadJson struct {
 type DepositContractJson struct {
 	ChainId string `json:"chain_id"`
 	Address string `json:"address"`
+}
+
+// SyncInfoJson is a JSON representation of the sync info.
+type SyncInfoJson struct {
+	HeadSlot     string `json:"head_slot"`
+	SyncDistance string `json:"sync_distance"`
+	IsSyncing    bool   `json:"is_syncing"`
 }
 
 // ---------------


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

#8920 updated the ethereumapis dependency, which resulted in adding a missing `IsSyncing` field that should be added to the response of `/node/syncing`. This PR updates the gRPC function and runs the endpoint through API Middleware. 

**Which issues(s) does this PR fix?**

Part of API Middleware feature

**Other notes for review**

N/A
