### PR TITLE
Middleware: Support handling of case insensitive enums

### DIFF
--- a/shared/gateway/api_middleware.go
+++ b/shared/gateway/api_middleware.go
@@ -118,6 +118,10 @@ func (m *ApiProxyMiddleware) handleApiEndpoint(endpoint string) {
 					tag: "hex",
 					f:   hexToBase64Processor,
 				},
+				{
+					tag: "enum",
+					f:   lowercaseToEnumProcessor,
+				},
 			}); err != nil {
 				e := fmt.Errorf("could not process request data: %w", err)
 				writeError(writer, &DefaultErrorJson{Message: e.Error(), Code: http.StatusInternalServerError}, nil)
@@ -554,6 +558,11 @@ func base64ToHexProcessor(v reflect.Value) error {
 		return err
 	}
 	v.SetString(hexutil.Encode(b))
+	return nil
+}
+
+func lowercaseToEnumProcessor(v reflect.Value) error {
+	v.SetString(strings.ToUpper(v.String()))
 	return nil
 }
 

--- a/shared/gateway/api_middleware.go
+++ b/shared/gateway/api_middleware.go
@@ -593,7 +593,7 @@ func getEndpointData(endpoint string) (endpointData, error) {
 	case "/eth/v1/beacon/states/{state_id}/finality_checkpoints":
 		return endpointData{getResponse: &StateFinalityCheckpointResponseJson{}, err: &DefaultErrorJson{}}, nil
 	case "/eth/v1/beacon/states/{state_id}/validators":
-		return endpointData{getResponse: &StateValidatorsResponseJson{}, err: &DefaultErrorJson{}}, nil
+		return endpointData{postRequest: &StateValidatorsRequestJson{}, getResponse: &StateValidatorsResponseJson{}, err: &DefaultErrorJson{}}, nil
 	case "/eth/v1/beacon/states/{state_id}/validators/{validator_id}":
 		return endpointData{getResponse: &StateValidatorResponseJson{}, err: &DefaultErrorJson{}}, nil
 	case "/eth/v1/beacon/states/{state_id}/validator_balances":

--- a/shared/gateway/middleware_structs.go
+++ b/shared/gateway/middleware_structs.go
@@ -371,11 +371,17 @@ type ForkJson struct {
 	Epoch           string `json:"epoch"`
 }
 
+type StateValidatorsRequestJson struct {
+	StateId string   `json:"state_id" hex:"true"`
+	Id      []string `json:"id" hex:"true"`
+	Status  []string `json:"status" enum:"true"`
+}
+
 // ValidatorContainerJson is a JSON representation of a validator container.
 type ValidatorContainerJson struct {
 	Index     string         `json:"index"`
 	Balance   string         `json:"balance"`
-	Status    string         `json:"status"`
+	Status    string         `json:"status" enum:"true"`
 	Validator *ValidatorJson `json:"validator"`
 }
 


### PR DESCRIPTION
**What type of PR is this?**
Feature 

**What does this PR do? Why is it needed?**
Part of #7510, this PR adds support for enums to be passed in as any case, the endpoint now supports case insensitive enums (through the middleware) by converting any input for enums to all lowercase.