### PR TITLE
Block interface's Copy() to return interface

### DIFF
--- a/shared/interfaces/BUILD.bazel
+++ b/shared/interfaces/BUILD.bazel
@@ -3,7 +3,6 @@ load("@prysm//tools/go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
-        "altair_block_wrapper.go",
         "block_interface.go",
         "phase0_block_wrapper.go",
     ],

--- a/shared/interfaces/altair_block_wrapper.go
+++ b/shared/interfaces/altair_block_wrapper.go
@@ -1,1 +1,0 @@
-package interfaces

--- a/shared/interfaces/block_interface.go
+++ b/shared/interfaces/block_interface.go
@@ -12,7 +12,7 @@ type SignedBeaconBlock interface {
 	Block() BeaconBlock
 	Signature() []byte
 	IsNil() bool
-	Copy() Phase0SignedBeaconBlock
+	Copy() SignedBeaconBlock
 	MarshalSSZ() ([]byte, error)
 	Proto() proto.Message
 	PbPhase0Block() (*ethpb.SignedBeaconBlock, error)

--- a/shared/interfaces/phase0_block_wrapper.go
+++ b/shared/interfaces/phase0_block_wrapper.go
@@ -38,7 +38,7 @@ func (w Phase0SignedBeaconBlock) IsNil() bool {
 
 // Copy performs a deep copy of the signed beacon block
 // object.
-func (w Phase0SignedBeaconBlock) Copy() Phase0SignedBeaconBlock {
+func (w Phase0SignedBeaconBlock) Copy() SignedBeaconBlock {
 	return WrappedPhase0SignedBeaconBlock(copyutil.CopySignedBeaconBlock(w.b))
 }
 


### PR DESCRIPTION
Block interface's copy should return interface type or else it can't be extensible with different versions of block