### PR TITLE
Remove stack trace from eth1 connection errors

### DIFF
--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -511,7 +511,7 @@ func (s *Service) waitForConnection() {
 	logCounter := 0
 	errorLogger := func(err error, msg string) {
 		if logCounter > logThreshold {
-			log.WithError(err).Error(msg)
+			log.Errorf("%s: %v", msg, err)
 			logCounter = 0
 		}
 		logCounter++


### PR DESCRIPTION
**What type of PR is this?**
Log cleanup 

**What does this PR do? Why is it needed?**
This PR fixes #8852, by removing stack traces from eth1 connection errors as they confuse users and aren't very helpful for these types of issues.