### PR TITLE
Implement `/beacon/headers` API endpoint (#8904)

### DIFF
--- a/shared/gateway/api_middleware.go
+++ b/shared/gateway/api_middleware.go
@@ -63,6 +63,7 @@ func (m *ApiProxyMiddleware) Run() error {
 	m.handleApiEndpoint("/eth/v1/beacon/states/{state_id}/validators/{validator_id}")
 	m.handleApiEndpoint("/eth/v1/beacon/states/{state_id}/validator_balances")
 	m.handleApiEndpoint("/eth/v1/beacon/states/{state_id}/committees")
+	m.handleApiEndpoint("/eth/v1/beacon/headers")
 	m.handleApiEndpoint("/eth/v1/beacon/headers/{block_id}")
 	m.handleApiEndpoint("/eth/v1/beacon/blocks")
 	m.handleApiEndpoint("/eth/v1/beacon/blocks/{block_id}")
@@ -612,6 +613,12 @@ func getEndpointData(endpoint string) (endpointData, error) {
 		return endpointData{
 			getRequestQueryParams: []queryParam{{name: "epoch"}, {name: "index"}, {name: "slot"}},
 			getResponse:           &StateCommitteesResponseJson{},
+			err:                   &DefaultErrorJson{},
+		}, nil
+	case "/eth/v1/beacon/headers":
+		return endpointData{
+			getRequestQueryParams: []queryParam{{name: "slot"}, {name: "parent_root", hex: true}},
+			getResponse:           &BlockHeadersResponseJson{},
 			err:                   &DefaultErrorJson{},
 		}, nil
 	case "/eth/v1/beacon/headers/{block_id}":

--- a/shared/gateway/middleware_structs.go
+++ b/shared/gateway/middleware_structs.go
@@ -59,6 +59,11 @@ type StateCommitteesResponseJson struct {
 	Data []*CommitteeJson `json:"data"`
 }
 
+// BlockHeadersResponseJson is used in /beacon/headers API endpoint.
+type BlockHeadersResponseJson struct {
+	Data []*BlockHeaderContainerJson `json:"data"`
+}
+
 // BlockHeaderResponseJson is used in /beacon/headers/{block_id} API endpoint.
 type BlockHeaderResponseJson struct {
 	Data *BlockHeaderContainerJson `json:"data"`


### PR DESCRIPTION
This PR implements the https://ethereum.github.io/eth2.0-APIs/#/Beacon/getBlockHeaders API endpoint.

It is a part of the API Middleware feature.