### PR TITLE
Altair: Add sync committee spec test

### DIFF
--- a/spectest/mainnet/altair/operations/BUILD.bazel
+++ b/spectest/mainnet/altair/operations/BUILD.bazel
@@ -9,6 +9,7 @@ go_test(
         "block_header_test.go",
         "deposit_test.go",
         "proposer_slashing_test.go",
+        "sync_committee_test.go",
         "voluntary_exit_test.go",
     ],
     data = glob(["*.yaml"]) + [

--- a/spectest/mainnet/altair/operations/sync_committee_test.go
+++ b/spectest/mainnet/altair/operations/sync_committee_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMainnet_Altair_Operations_SyncCommittee(t *testing.T) {
+	operations.RunSyncCommitteeTest(t, "mainnet")
+}

--- a/spectest/minimal/altair/operations/BUILD.bazel
+++ b/spectest/minimal/altair/operations/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "block_header_test.go",
         "deposit_test.go",
         "proposer_slashing_test.go",
+        "sync_committee_test.go",
         "voluntary_exit_test.go",
     ],
     data = glob(["*.yaml"]) + [

--- a/spectest/minimal/altair/operations/sync_committee_test.go
+++ b/spectest/minimal/altair/operations/sync_committee_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/operations"
+)
+
+func TestMinimal_Altair_Operations_SyncCommittee(t *testing.T) {
+	operations.RunProposerSlashingTest(t, "minimal")
+}

--- a/spectest/shared/altair/operations/BUILD.bazel
+++ b/spectest/shared/altair/operations/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "deposit.go",
         "helpers.go",
         "proposer_slashing.go",
+        "sync_committee.go",
         "voluntary_exit.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/spectest/shared/altair/operations",

--- a/spectest/shared/altair/operations/sync_committee.go
+++ b/spectest/shared/altair/operations/sync_committee.go
@@ -1,0 +1,37 @@
+package operations
+
+import (
+	"context"
+	"path"
+	"testing"
+
+	"github.com/golang/snappy"
+	ethpb "github.com/prysmaticlabs/ethereumapis/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	"github.com/prysmaticlabs/prysm/shared/interfaces"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"github.com/prysmaticlabs/prysm/spectest/utils"
+)
+
+func RunSyncCommitteeTest(t *testing.T, config string) {
+	require.NoError(t, utils.SetConfig(t, config))
+	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/sync_committee/pyspec_tests")
+	for _, folder := range testFolders {
+		t.Run(folder.Name(), func(t *testing.T) {
+			folderPath := path.Join(testsFolderPath, folder.Name())
+			syncCommitteeFile, err := testutil.BazelFileBytes(folderPath, "sync_aggregate.ssz_snappy")
+			require.NoError(t, err)
+			syncCommitteeSSZ, err := snappy.Decode(nil /* dst */, syncCommitteeFile)
+			require.NoError(t, err, "Failed to decompress")
+			sc := &ethpb.SyncAggregate{}
+			require.NoError(t, sc.UnmarshalSSZ(syncCommitteeSSZ), "Failed to unmarshal")
+
+			body := &ethpb.BeaconBlockBodyAltair{SyncAggregate: sc}
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s iface.BeaconState, b interfaces.SignedBeaconBlock) (iface.BeaconState, error) {
+				return altair.ProcessSyncCommittee(s, body.SyncAggregate)
+			})
+		})
+	}
+}


### PR DESCRIPTION
Part of #8638 

Adding sync committee spec test:
https://github.com/ethereum/eth2.0-spec-tests/tree/master/tests/mainnet/altair/operations/sync_committee/pyspec_tests