### PR TITLE
use urfave defaulting method for correct help text

### DIFF
--- a/cmd/client-stats/flags/flags.go
+++ b/cmd/client-stats/flags/flags.go
@@ -3,6 +3,8 @@
 package flags
 
 import (
+	"time"
+
 	"github.com/urfave/cli/v2"
 )
 
@@ -25,6 +27,7 @@ var (
 	// ScrapeIntervalFlag defines a flag for the frequency of scraping.
 	ScrapeIntervalFlag = &cli.DurationFlag{
 		Name:  "scrape-interval",
-		Usage: "Frequency of scraping expressed as a duration, eg 2m or 1m5s. Default is 60s.",
+		Usage: "Frequency of scraping expressed as a duration, eg 2m or 1m5s.",
+		Value: 60 * time.Second,
 	}
 )

--- a/cmd/client-stats/main.go
+++ b/cmd/client-stats/main.go
@@ -28,7 +28,6 @@ var appFlags = []cli.Flag{
 	flags.ClientStatsAPIURLFlag,
 	flags.ScrapeIntervalFlag,
 }
-var scrapeInterval = 60 * time.Second
 
 func main() {
 	app := cli.App{}
@@ -101,10 +100,6 @@ func main() {
 }
 
 func run(ctx *cli.Context) error {
-	if ctx.IsSet(flags.ScrapeIntervalFlag.Name) {
-		scrapeInterval = ctx.Duration(flags.ScrapeIntervalFlag.Name)
-	}
-
 	var upd clientstats.Updater
 	if ctx.IsSet(flags.ClientStatsAPIURLFlag.Name) {
 		u := ctx.String(flags.ClientStatsAPIURLFlag.Name)
@@ -124,7 +119,7 @@ func run(ctx *cli.Context) error {
 		scrapers = append(scrapers, clientstats.NewValidatorScraper(u))
 	}
 
-	ticker := time.NewTicker(scrapeInterval)
+	ticker := time.NewTicker(ctx.Duration(flags.ScrapeIntervalFlag.Name))
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Fixes help text for the client-stats `--scrape-interval` flag. With this change the flag parsing library knows the intended default value so that it is correctly displayed in generated `--help` text.

**Which issues(s) does this PR fix?**

n/a -- quick fix, reported by Preston

**Other notes for review**
