### PR TITLE
Do not use proto casing in `v1alpha1` API JSON fields

### DIFF
--- a/shared/gateway/gateway.go
+++ b/shared/gateway/gateway.go
@@ -122,7 +122,6 @@ func (g *Gateway) Start() {
 		gwruntime.WithMarshalerOption(gwruntime.MIMEWildcard, &gwruntime.HTTPBodyMarshaler{
 			Marshaler: &gwruntime.JSONPb{
 				MarshalOptions: protojson.MarshalOptions{
-					UseProtoNames:   true,
 					EmitUnpopulated: true,
 				},
 				UnmarshalOptions: protojson.UnmarshalOptions{


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

https://github.com/prysmaticlabs/prysm/pull/8697 introduced a breaking change to `v1alpha1` APIs. JSON output was modified from `camelCase` to `snake_case`, thus breaking the Web UI.

**Which issues(s) does this PR fix?**

Hotfix

**Other notes for review**

N/A
