### PR TITLE
Remove unused ClosestPowerOf2 method

### DIFF
--- a/shared/mathutil/math_helper.go
+++ b/shared/mathutil/math_helper.go
@@ -67,16 +67,6 @@ func PowerOf2(n uint64) uint64 {
 	return 1 << n
 }
 
-// ClosestPowerOf2 returns an integer that is the closest
-// power of 2 that is less than or equal to the argument.
-func ClosestPowerOf2(n uint64) uint64 {
-	if n == 0 {
-		return uint64(1)
-	}
-	exponent := math.Floor(math.Log2(float64(n)))
-	return PowerOf2(uint64(exponent))
-}
-
 // Max returns the larger integer of the two
 // given ones.This is used over the Max function
 // in the standard math library because that max function

--- a/shared/mathutil/math_helper_test.go
+++ b/shared/mathutil/math_helper_test.go
@@ -195,33 +195,6 @@ func TestPowerOf2(t *testing.T) {
 	}
 }
 
-func TestClosestPowerOf2(t *testing.T) {
-	tests := []struct {
-		a uint64
-		b uint64
-	}{
-		{
-			a: 10,
-			b: 8,
-		},
-		{
-			a: 300,
-			b: 256,
-		},
-		{
-			a: 1200,
-			b: 1024,
-		},
-		{
-			a: 4500,
-			b: 4096,
-		},
-	}
-	for _, tt := range tests {
-		require.Equal(t, tt.b, mathutil.ClosestPowerOf2(tt.a))
-	}
-}
-
 func TestMaxValue(t *testing.T) {
 	tests := []struct {
 		a      uint64


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This method is unused and may have an precision loss issue with values over 52 bits.

**Which issues(s) does this PR fix?**

Fixes #8989

**Other notes for review**
