### PR TITLE
Improve Mirror Bash Script for EthereumAPIs

### DIFF
--- a/scripts/mirror-ethereumapis.sh
+++ b/scripts/mirror-ethereumapis.sh
@@ -1,61 +1,59 @@
 #!/usr/bin/env bash
 #
-# This script accepts the following parameters:
-#
-# * tag
-# * github_api_token
-#
 # Script to mirror a tag from Prysm into EthereumAPIs protocol buffers
 #
 # Example:
 #
-# mirror-ethereumapis.sh github_api_token=TOKEN tag=v1.3.0
+# mirror-ethereumapis.sh
 #
 set -e
-
-# Check dependencies.
-# skipcq: SH-2034
-export xargs=$(which gxargs || which xargs)
 
 # Validate settings.
 [ "$TRACE" ] && set -x
 
-CONFIG=$*
-
-for line in $CONFIG; do
-  eval "$line"
-done
-
-# Define variables.
+## Define variables.
 GH_API="https://api.github.com"
 GH_REPO="$GH_API/repos/prysmaticlabs/ethereumapis"
 
-AUTH="Authorization: token $github_api_token"
-# skipcq: SH-2034
+AUTH="Authorization: token $GITHUB_SECRET_ACCESS_TOKEN"
+## skipcq: SH-2034
 export WGET_ARGS="--content-disposition --auth-no-challenge --no-cookie"
-# skipcq: SH-2034
+## skipcq: SH-2034
 export CURL_ARGS="-LJO#"
 
-# Validate token.
+## Validate token.
 curl -o /dev/null -sH "$AUTH" "$GH_REPO" || { echo "Error: Invalid repo, token or network issue!";  exit 1; }
-
-git config --global user.email contact@prysmaticlabs.com
-git config --global user.name prylabsbot
-git config --global url."https://git:'$github_api_token'@github.com/".insteadOf "git@github.com/"
 
 # Clone ethereumapis and prysm
 git clone https://github.com/prysmaticlabs/prysm /tmp/prysm/
 git clone https://github.com/prysmaticlabs/ethereumapis /tmp/ethereumapis/
 
 # Checkout the release tag in prysm and copy over protos
-cd /tmp/prysm && git checkout "$tag"
-cp -Rf /tmp/prysm/proto/eth /tmp/ethereumapis
+cd /tmp/prysm && git checkout "$BUILDKITE_COMMIT"
+
+# Copy proto files, go files, and markdown files
+find proto/eth \( -name '*.go' -o -name '*.proto' -o -name '*.md' \) -print0 |
+    while IFS= read -r -d '' line; do
+        item_path=$(dirname "$line")
+        mkdir -p /tmp/ethereumapis"${item_path#*proto}" && cp "$line" /tmp/ethereumapis"${line#*proto}"
+    done
+
 cd /tmp/ethereumapis || exit
 
-# Replace imports in go files and proto files as needed
+## Replace imports in go files and proto files as needed
 find ./eth -name '*.go' -print0 |
     while IFS= read -r -d '' line; do
         sed -i 's/prysm\/proto\/eth/ethereumapis\/eth/g' "$line"
+    done
+
+find ./eth -name '*.go' -print0 |
+    while IFS= read -r -d '' line; do
+        sed -i 's/proto\/eth/eth/g' "$line"
+    done
+
+find ./eth -name '*.go' -print0 |
+    while IFS= read -r -d '' line; do
+        sed -i 's/proto_eth/eth/g' "$line"
     done
 
 find ./eth -name '*.proto' -print0 |
@@ -63,7 +61,20 @@ find ./eth -name '*.proto' -print0 |
         sed -i 's/"proto\/eth/"eth/g' "$line"
     done
 
+find ./eth -name '*.proto' -print0 |
+    while IFS= read -r -d '' line; do
+        sed -i 's/prysmaticlabs\/prysm\/proto\/eth/prysmaticlabs\/ethereumapis\/eth/g' "$line"
+    done
+
+if git diff-index --quiet HEAD --; then
+   echo "nothing to push, exiting early"
+   exit
+else
+   echo "changes detected, commiting and pushing to ethereumapis"
+fi
+
 # Push to the mirror repository
 git add --all
-git commit -am "'$tag'"
+GIT_AUTHOR_EMAIL=contact@prysmaticlabs.com GIT_AUTHOR_NAME=prysm-bot git commit -am "Mirrored from github.com/prysmaticlabs/prysm@$BUILDKITE_COMMIT"
+git remote set-url origin https://prylabs:$GITHUB_SECRET_ACCESS_TOKEN@github.com/prylabs/ethereumapis.git
 git push origin master

--- a/scripts/mirror-ethereumapis.sh
+++ b/scripts/mirror-ethereumapis.sh
@@ -76,5 +76,5 @@ fi
 # Push to the mirror repository
 git add --all
 GIT_AUTHOR_EMAIL=contact@prysmaticlabs.com GIT_AUTHOR_NAME=prysm-bot git commit -am "Mirrored from github.com/prysmaticlabs/prysm@$BUILDKITE_COMMIT"
-git remote set-url origin https://prylabs:$GITHUB_SECRET_ACCESS_TOKEN@github.com/prylabs/ethereumapis.git
+git remote set-url origin https://prylabs:"$GITHUB_SECRET_ACCESS_TOKEN"@github.com/prylabs/ethereumapis.git
 git push origin master


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

Improves the ethereumapis mirror script with the following improvements:

- Copies over only proto, go files, and markdown files
- Does not push if diff is empty
- Replaces remaining import changes
- Does not override global git config