### PR TITLE
Altair: Update sync committee cache

### DIFF
--- a/beacon-chain/core/altair/epoch_spec.go
+++ b/beacon-chain/core/altair/epoch_spec.go
@@ -35,6 +35,9 @@ func ProcessSyncCommitteeUpdates(beaconState iface.BeaconStateAltair) (iface.Bea
 		if err := beaconState.SetNextSyncCommittee(nextCommittee); err != nil {
 			return nil, err
 		}
+		if err := helpers.UpdateSyncCommitteeCache(beaconState); err != nil {
+			return nil, err
+		}
 	}
 	return beaconState, nil
 }

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -302,6 +302,9 @@ func ProcessSlots(ctx context.Context, state iface.BeaconState, slot types.Slot)
 			if err != nil {
 				return nil, err
 			}
+			if err := helpers.UpdateSyncCommitteeCache(state); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/beacon-chain/operations/synccommittee/BUILD.bazel
+++ b/beacon-chain/operations/synccommittee/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//proto/eth/v1alpha1:go_default_library",
         "//shared/copyutil:go_default_library",
-        "//shared/hashutil:go_default_library",
         "//shared/queue:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -193,7 +193,6 @@ func run(ctx context.Context, v iface.Validator) {
 						case iface.RoleAggregator:
 							v.SubmitAggregateAndProof(slotCtx, slot, pubKey)
 						case iface.RoleSyncCommittee:
-							log.Infof("Performing in sync committee! %#x", pubKey)
 							// TODO(8638): Implement submit sync committee message.
 						case iface.RoleUnknown:
 							log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKey[:]))).Trace("No active roles, doing nothing")

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -193,6 +193,7 @@ func run(ctx context.Context, v iface.Validator) {
 						case iface.RoleAggregator:
 							v.SubmitAggregateAndProof(slotCtx, slot, pubKey)
 						case iface.RoleSyncCommittee:
+							log.Infof("Performing in sync committee! %#x", pubKey)
 							// TODO(8638): Implement submit sync committee message.
 						case iface.RoleUnknown:
 							log.WithField("pubKey", fmt.Sprintf("%#x", bytesutil.Trunc(pubKey[:]))).Trace("No active roles, doing nothing")


### PR DESCRIPTION
We haven't inserted update sync committee cache to run time code path. This PR does it.

Update sync committee cache when:
 - Update sync committee at every `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` interval
 - Upgrade beacon state from phase 0 to Altair