### PR TITLE
Revert "Invert `attest-timely` flag"

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -231,10 +231,9 @@ func ConfigureValidator(ctx *cli.Context) {
 		log.WithField(disableAttestingHistoryDBCache.Name, disableAttestingHistoryDBCache.Usage).Warn(enabledFeatureFlag)
 		cfg.DisableAttestingHistoryDBCache = true
 	}
-	cfg.AttestTimely = true
-	if ctx.Bool(disableAttestTimely.Name) {
-		log.WithField(disableAttestTimely.Name, disableAttestTimely.Usage).Warn(enabledFeatureFlag)
-		cfg.AttestTimely = false
+	if ctx.Bool(attestTimely.Name) {
+		log.WithField(attestTimely.Name, attestTimely.Usage).Warn(enabledFeatureFlag)
+		cfg.AttestTimely = true
 	}
 	if ctx.Bool(enableSlashingProtectionPruning.Name) {
 		log.WithField(enableSlashingProtectionPruning.Name, enableSlashingProtectionPruning.Usage).Warn(enabledFeatureFlag)

--- a/shared/featureconfig/deprecated_flags.go
+++ b/shared/featureconfig/deprecated_flags.go
@@ -37,11 +37,6 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
-	deprecatedAttestingTimely = &cli.BoolFlag{
-		Name:   "attest-timely",
-		Usage:  deprecatedUsage,
-		Hidden: true,
-	}
 	deprecatedProposerAttsSelectionUsingMaxCover = &cli.BoolFlag{
 		Name:   "proposer-atts-selection-using-max-cover",
 		Usage:  deprecatedUsage,
@@ -56,6 +51,5 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedDisablePruningDepositProofs,
 	deprecatedDisableEth1DataMajorityVote,
 	deprecatedDisableBlst,
-	deprecatedAttestingTimely,
 	deprecatedProposerAttsSelectionUsingMaxCover,
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -98,9 +98,9 @@ var (
 		Name:  "disable-broadcast-slashings",
 		Usage: "Disables broadcasting slashings submitted to the beacon node.",
 	}
-	disableAttestTimely = &cli.BoolFlag{
-		Name:  "disable-attest-timely",
-		Usage: "Disable attest timely, a fix where validator can attest timely after current block processes. See #8185 for more details",
+	attestTimely = &cli.BoolFlag{
+		Name:  "attest-timely",
+		Usage: "Fixes validator can attest timely after current block processes. See #8185 for more details",
 	}
 	enableNextSlotStateCache = &cli.BoolFlag{
 		Name:  "enable-next-slot-state-cache",
@@ -144,7 +144,7 @@ var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	Mainnet,
 	disableAccountsV2,
 	dynamicKeyReloadDebounceInterval,
-	disableAttestTimely,
+	attestTimely,
 	enableSlashingProtectionPruning,
 }...)
 


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#8827

Pending concrete data and release of sigp/lighthouse#2319, we are reverting the opt-in/out feature flag for attest-timely. 