### PR TITLE
Add fallback check to sync committee helper

### DIFF
--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -11,10 +11,10 @@ go_library(
         "committees.go",
         "common.go",
         "doc.go",
+        "error.go",
         "proposer_indices_type.go",
         "skip_slot_cache.go",
         "subnet_ids.go",
-        "error.go",
     ] + select({
         "//fuzz:fuzzing_enabled": [
             "committee_disabled.go",

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "proposer_indices_type.go",
         "skip_slot_cache.go",
         "subnet_ids.go",
+        "error.go",
     ] + select({
         "//fuzz:fuzzing_enabled": [
             "committee_disabled.go",

--- a/beacon-chain/cache/error.go
+++ b/beacon-chain/cache/error.go
@@ -1,0 +1,9 @@
+package cache
+
+import "errors"
+
+// Sync committee cache related errors
+
+// ErrNonExistingSyncCommitteeKey when sync committee key (root) does not exist in cache.
+var ErrNonExistingSyncCommitteeKey = errors.New("does not exist sync committee key")
+var errNotSyncCommitteeIndexPosition = errors.New("not syncCommitteeIndexPosition struct")

--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -3,7 +3,6 @@
 package cache
 
 import (
-	"errors"
 	"sync"
 
 	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
@@ -11,8 +10,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-var ErrNonExistingSyncCommitteeKey = errors.New("does not exist sync committee key")
-var errNotSyncCommitteeIndexPosition = errors.New("not syncCommitteeIndexPosition struct")
 var maxSyncCommitteeSize = uint64(3) // Allows 3 forks to happen around `EPOCHS_PER_SYNC_COMMITTEE_PERIOD` boundary.
 
 // SyncCommitteeCache utilizes a FIFO cache to sufficiently cache validator position within sync committee.

--- a/beacon-chain/cache/sync_committee_disabled.go
+++ b/beacon-chain/cache/sync_committee_disabled.go
@@ -6,8 +6,6 @@ import (
 	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
 )
 
-var ErrNonExistingSyncCommitteeKey = errors.New("does not exist sync committee key")
-
 // FakeSyncCommitteeCache is a fake `SyncCommitteeCache` to satisfy fuzzing.
 type FakeSyncCommitteeCache struct {
 }

--- a/beacon-chain/cache/sync_committee_disabled.go
+++ b/beacon-chain/cache/sync_committee_disabled.go
@@ -6,6 +6,8 @@ import (
 	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
 )
 
+var ErrNonExistingSyncCommitteeKey = errors.New("does not exist sync committee key")
+
 // FakeSyncCommitteeCache is a fake `SyncCommitteeCache` to satisfy fuzzing.
 type FakeSyncCommitteeCache struct {
 }

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
@@ -392,20 +393,52 @@ func ClearCache() {
 }
 
 // IsCurrentEpochSyncCommittee returns true if the input public key belongs in the current epoch sync committee along with the sync committee root.
-func IsCurrentEpochSyncCommittee(root [32]byte, pubKey [48]byte) (bool, error) {
-	indices, err := syncCommitteeCache.CurrentEpochIndexPosition(root, pubKey)
+// 1.) Checks if the public key exists in the sync committee cache
+// 2.) If 1 fails, checks if the public key exists in the input current sync committee object
+func IsCurrentEpochSyncCommittee(committee *pb.SyncCommittee, pubKey [48]byte) (bool, error) {
+	root, err := committee.HashTreeRoot()
 	if err != nil {
 		return false, err
 	}
+	indices, err := syncCommitteeCache.CurrentEpochIndexPosition(root, pubKey)
+	// If committee root does not exist in cache, perform manual lookup of pubkeys in committee to find match.
+	if err == cache.ErrNonExistingSyncCommitteeKey {
+		for _, k := range committee.Pubkeys {
+			if bytes.Equal(k, pubKey[:]) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
 	return len(indices) > 0, nil
 }
 
 // IsNextEpochSyncCommittee returns true if the input public key belongs in the next epoch sync committee along with the sync committee root.
-func IsNextEpochSyncCommittee(root [32]byte, pubKey [48]byte) (bool, error) {
-	indices, err := syncCommitteeCache.NextEpochIndexPosition(root, pubKey)
+// 1.) Checks if the public key exists in the sync committee cache
+// 2.) If 1 fails, checks if the public key exists in the input next sync committee object
+func IsNextEpochSyncCommittee(committee *pb.SyncCommittee, pubKey [48]byte) (bool, error) {
+	root, err := committee.HashTreeRoot()
 	if err != nil {
 		return false, err
 	}
+	indices, err := syncCommitteeCache.NextEpochIndexPosition(root, pubKey)
+	// If committee root does not exist in cache, perform manual lookup of pubkeys in committee to find match.
+	if err == cache.ErrNonExistingSyncCommitteeKey {
+		for _, k := range committee.Pubkeys {
+			if bytes.Equal(k, pubKey[:]) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
 	return len(indices) > 0, nil
 }
 

--- a/beacon-chain/operations/synccommittee/BUILD.bazel
+++ b/beacon-chain/operations/synccommittee/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//proto/eth/v1alpha1:go_default_library",
         "//shared/copyutil:go_default_library",
-        "//shared/hashutil:go_default_library",
         "//shared/queue:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",


### PR DESCRIPTION
Add fall back checks to is in sync committee helper. It ensures when there is a cache miss, it also checks the input committee object for a public key match