### PR TITLE
Do not register API Middleware with validator gateway

### DIFF
--- a/beacon-chain/rpc/apimiddleware/endpoint_factory.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory.go
@@ -9,6 +9,10 @@ import (
 type BeaconEndpointFactory struct {
 }
 
+func (f *BeaconEndpointFactory) IsNil() bool {
+	return f == nil
+}
+
 // Paths is a collection of all valid beacon chain API paths.
 func (f *BeaconEndpointFactory) Paths() []string {
 	return []string{

--- a/shared/gateway/api_middleware.go
+++ b/shared/gateway/api_middleware.go
@@ -23,6 +23,7 @@ type ApiProxyMiddleware struct {
 type EndpointFactory interface {
 	Create(path string) (*Endpoint, error)
 	Paths() []string
+	IsNil() bool
 }
 
 // Endpoint is a representation of an API HTTP endpoint that should be proxied by the middleware.

--- a/shared/gateway/gateway.go
+++ b/shared/gateway/gateway.go
@@ -231,7 +231,7 @@ func (g *Gateway) Start() {
 		}
 	}()
 
-	if g.apiMiddlewareAddr != "" && g.apiMiddlewareEndpointFactory != nil {
+	if g.apiMiddlewareAddr != "" && g.apiMiddlewareEndpointFactory.IsNil() {
 		go g.registerApiMiddleware()
 	}
 }

--- a/shared/gateway/gateway.go
+++ b/shared/gateway/gateway.go
@@ -231,7 +231,7 @@ func (g *Gateway) Start() {
 		}
 	}()
 
-	if g.apiMiddlewareAddr != "" && !g.apiMiddlewareEndpointFactory.IsNil() {
+	if g.apiMiddlewareAddr != "" && g.apiMiddlewareEndpointFactory != nil && !g.apiMiddlewareEndpointFactory.IsNil() {
 		go g.registerApiMiddleware()
 	}
 }

--- a/shared/gateway/gateway.go
+++ b/shared/gateway/gateway.go
@@ -231,7 +231,9 @@ func (g *Gateway) Start() {
 		}
 	}()
 
-	go g.registerApiMiddleware()
+	if g.apiMiddlewareAddr != "" && g.apiMiddlewareEndpointFactory != nil {
+		go g.registerApiMiddleware()
+	}
 }
 
 // Status of grpc gateway. Returns an error if this service is unhealthy.

--- a/shared/gateway/gateway.go
+++ b/shared/gateway/gateway.go
@@ -231,7 +231,7 @@ func (g *Gateway) Start() {
 		}
 	}()
 
-	if g.apiMiddlewareAddr != "" && g.apiMiddlewareEndpointFactory.IsNil() {
+	if g.apiMiddlewareAddr != "" && !g.apiMiddlewareEndpointFactory.IsNil() {
 		go g.registerApiMiddleware()
 	}
 }

--- a/shared/gateway/gateway_test.go
+++ b/shared/gateway/gateway_test.go
@@ -81,6 +81,7 @@ func TestValidatorGateway_StartStop(t *testing.T) {
 	validatorGateway.Start()
 	go func() {
 		require.LogsContain(t, hook, "Starting gRPC gateway")
+		require.LogsDoNotContain(t, hook, "Starting API middleware")
 	}()
 
 	err := validatorGateway.Stop()


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Validator client does not need the API Middleware. It does not provide configuration required to properly register the middleware. This causes the validator client to fail on startup.  

The bug fix makes sure that the API Middleware is registered only when proper configuration is provided.

**Which issues(s) does this PR fix?**

Fixes the validator client

**Other notes for review**

N/A
