### PR TITLE
Testutil: Reset deposit cache internally

### DIFF
--- a/beacon-chain/core/blocks/block_regression_test.go
+++ b/beacon-chain/core/blocks/block_regression_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestProcessAttesterSlashings_RegressionSlashableIndices(t *testing.T) {
-	testutil.ResetCache()
+
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 5500)
 	for _, vv := range beaconState.Validators() {
 		vv.WithdrawableEpoch = types.Epoch(params.BeaconConfig().SlotsPerEpoch)

--- a/beacon-chain/core/blocks/deposit_test.go
+++ b/beacon-chain/core/blocks/deposit_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestProcessDeposits_SameValidatorMultipleDepositsSameBlock(t *testing.T) {
 	// Same validator created 3 valid deposits within the same block
-	testutil.ResetCache()
+
 	dep, _, err := testutil.DeterministicDepositsAndKeysSameValidator(3)
 	require.NoError(t, err)
 	eth1Data, err := testutil.DeterministicEth1Data(len(dep))
@@ -275,10 +275,9 @@ func TestProcessDeposit_SkipsInvalidDeposit(t *testing.T) {
 }
 
 func TestPreGenesisDeposits_SkipInvalidDeposit(t *testing.T) {
-	testutil.ResetCache()
+
 	dep, _, err := testutil.DeterministicDepositsAndKeys(100)
 	require.NoError(t, err)
-	defer testutil.ResetCache()
 	dep[0].Data.Signature = make([]byte, 96)
 	trie, _, err := testutil.DepositTrieFromDeposits(dep)
 	require.NoError(t, err)

--- a/beacon-chain/core/blocks/header_test.go
+++ b/beacon-chain/core/blocks/header_test.go
@@ -71,7 +71,7 @@ func TestProcessBlockHeader_ImproperBlockSlot(t *testing.T) {
 }
 
 func TestProcessBlockHeader_WrongProposerSig(t *testing.T) {
-	testutil.ResetCache()
+
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 100)
 	require.NoError(t, beaconState.SetLatestBlockHeader(testutil.HydrateBeaconHeader(&ethpb.BeaconBlockHeader{
 		Slot: 9,

--- a/beacon-chain/core/blocks/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestProcessProposerSlashings_UnmatchedHeaderSlots(t *testing.T) {
-	testutil.ResetCache()
+
 	beaconState, _ := testutil.DeterministicGenesisState(t, 20)
 	currentSlot := types.Slot(0)
 	slashings := []*ethpb.ProposerSlashing{
@@ -55,7 +55,7 @@ func TestProcessProposerSlashings_UnmatchedHeaderSlots(t *testing.T) {
 }
 
 func TestProcessProposerSlashings_SameHeaders(t *testing.T) {
-	testutil.ResetCache()
+
 	beaconState, _ := testutil.DeterministicGenesisState(t, 2)
 	currentSlot := types.Slot(0)
 	slashings := []*ethpb.ProposerSlashing{
@@ -276,7 +276,7 @@ func TestVerifyProposerSlashing(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testutil.ResetCache()
+
 			sk := sks[tt.args.slashing.Header_1.Header.ProposerIndex]
 			d, err := helpers.Domain(tt.args.beaconState.Fork(), helpers.SlotToEpoch(tt.args.slashing.Header_1.Header.Slot), params.BeaconConfig().DomainBeaconProposer, tt.args.beaconState.GenesisValidatorRoot())
 			require.NoError(t, err)

--- a/beacon-chain/powchain/deposit_test.go
+++ b/beacon-chain/powchain/deposit_test.go
@@ -138,7 +138,7 @@ func TestProcessDeposit_InvalidSignature(t *testing.T) {
 	err = web3Service.processDeposit(context.Background(), eth1Data, deposits[0])
 	require.NoError(t, err)
 
-	require.LogsContain(t, hook, pubKeyErr)
+	require.LogsContain(t, hook, "could not verify deposit data signature: could not convert bytes to signature")
 }
 
 func TestProcessDeposit_UnableToVerify(t *testing.T) {

--- a/beacon-chain/powchain/deposit_test.go
+++ b/beacon-chain/powchain/deposit_test.go
@@ -150,7 +150,6 @@ func TestProcessDeposit_UnableToVerify(t *testing.T) {
 	})
 	require.NoError(t, err, "unable to setup web3 ETH1.0 chain service")
 	web3Service = setDefaultMocks(web3Service)
-	testutil.ResetCache()
 
 	deposits, keys, err := testutil.DeterministicDepositsAndKeys(1)
 	require.NoError(t, err)
@@ -245,7 +244,6 @@ func TestProcessDeposit_AllDepositedSuccessfully(t *testing.T) {
 	})
 	require.NoError(t, err, "unable to setup web3 ETH1.0 chain service")
 	web3Service = setDefaultMocks(web3Service)
-	testutil.ResetCache()
 
 	deposits, keys, err := testutil.DeterministicDepositsAndKeys(10)
 	require.NoError(t, err)

--- a/beacon-chain/powchain/log_processing_test.go
+++ b/beacon-chain/powchain/log_processing_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestProcessDepositLog_OK(t *testing.T) {
 	hook := logTest.NewGlobal()
-	testutil.ResetCache()
+
 	testAcc, err := contracts.Setup()
 	require.NoError(t, err, "Unable to set up simulated backend")
 
@@ -45,7 +45,7 @@ func TestProcessDepositLog_OK(t *testing.T) {
 	require.NoError(t, err)
 
 	testAcc.Backend.Commit()
-	testutil.ResetCache()
+
 	deposits, _, err := testutil.DeterministicDepositsAndKeys(1)
 	require.NoError(t, err)
 
@@ -110,7 +110,6 @@ func TestProcessDepositLog_InsertsPendingDeposit(t *testing.T) {
 
 	testAcc.Backend.Commit()
 
-	testutil.ResetCache()
 	deposits, _, err := testutil.DeterministicDepositsAndKeys(1)
 	require.NoError(t, err)
 	_, depositRoots, err := testutil.DeterministicDepositTrie(len(deposits))
@@ -166,7 +165,6 @@ func TestUnpackDepositLogData_OK(t *testing.T) {
 
 	testAcc.Backend.Commit()
 
-	testutil.ResetCache()
 	deposits, _, err := testutil.DeterministicDepositsAndKeys(1)
 	require.NoError(t, err)
 	_, depositRoots, err := testutil.DeterministicDepositTrie(len(deposits))
@@ -224,7 +222,6 @@ func TestProcessETH2GenesisLog_8DuplicatePubkeys(t *testing.T) {
 	testAcc.Backend.Commit()
 	require.NoError(t, testAcc.Backend.AdjustTime(time.Duration(int64(time.Now().Nanosecond()))))
 
-	testutil.ResetCache()
 	deposits, _, err := testutil.DeterministicDepositsAndKeys(1)
 	require.NoError(t, err)
 	_, depositRoots, err := testutil.DeterministicDepositTrie(len(deposits))
@@ -294,7 +291,6 @@ func TestProcessETH2GenesisLog(t *testing.T) {
 	testAcc.Backend.Commit()
 	require.NoError(t, testAcc.Backend.AdjustTime(time.Duration(int64(time.Now().Nanosecond()))))
 
-	testutil.ResetCache()
 	deposits, _, err := testutil.DeterministicDepositsAndKeys(uint64(depositsReqForChainStart))
 	require.NoError(t, err)
 	_, roots, err := testutil.DeterministicDepositTrie(len(deposits))

--- a/beacon-chain/rpc/validator/assignments_test.go
+++ b/beacon-chain/rpc/validator/assignments_test.go
@@ -165,7 +165,7 @@ func TestGetDuties_MultipleKeys_OK(t *testing.T) {
 
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := uint64(64)
-	testutil.ResetCache()
+
 	deposits, _, err := testutil.DeterministicDepositsAndKeys(depChainStart)
 	require.NoError(t, err)
 	eth1Data, err := testutil.DeterministicEth1Data(len(deposits))

--- a/beacon-chain/rpc/validator/exit_test.go
+++ b/beacon-chain/rpc/validator/exit_test.go
@@ -27,7 +27,7 @@ import (
 func TestProposeExit_Notification(t *testing.T) {
 	db := dbutil.SetupDB(t)
 	ctx := context.Background()
-	testutil.ResetCache()
+
 	deposits, keys, err := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
 	require.NoError(t, err)
 	beaconState, err := state.GenesisBeaconState(ctx, deposits, 0, &ethpb.Eth1Data{BlockHash: make([]byte, 32)})
@@ -98,7 +98,7 @@ func TestProposeExit_Notification(t *testing.T) {
 func TestProposeExit_NoPanic(t *testing.T) {
 	db := dbutil.SetupDB(t)
 	ctx := context.Background()
-	testutil.ResetCache()
+
 	deposits, keys, err := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
 	require.NoError(t, err)
 	beaconState, err := state.GenesisBeaconState(ctx, deposits, 0, &ethpb.Eth1Data{BlockHash: make([]byte, 32)})

--- a/beacon-chain/rpc/validator/proposer_test.go
+++ b/beacon-chain/rpc/validator/proposer_test.go
@@ -40,7 +40,6 @@ func TestProposer_GetBlock_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
 	ctx := context.Background()
 
-	testutil.ResetCache()
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, 64)

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -60,7 +60,7 @@ func TestProcessPendingAtts_HasBlockSaveUnAggregatedAtt(t *testing.T) {
 	db := dbtest.SetupDB(t)
 	p1 := p2ptest.NewTestP2P(t)
 	validators := uint64(256)
-	testutil.ResetCache()
+
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, validators)
 
 	sb := testutil.NewBeaconBlock()
@@ -185,7 +185,7 @@ func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	validators := uint64(256)
-	testutil.ResetCache()
+
 	_, privKeys := testutil.DeterministicGenesisState(t, validators)
 	aggBits := bitfield.NewBitlist(8)
 	aggBits.SetBitAt(1, true)
@@ -253,7 +253,7 @@ func TestProcessPendingAtts_HasBlockSaveAggregatedAtt(t *testing.T) {
 	db := dbtest.SetupDB(t)
 	p1 := p2ptest.NewTestP2P(t)
 	validators := uint64(256)
-	testutil.ResetCache()
+
 	beaconState, privKeys := testutil.DeterministicGenesisState(t, validators)
 
 	sb := testutil.NewBeaconBlock()

--- a/endtoend/BUILD.bazel
+++ b/endtoend/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
         "//endtoend/types:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
         "//shared/params:go_default_library",
-        "//shared/testutil:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",

--- a/endtoend/minimal_e2e_test.go
+++ b/endtoend/minimal_e2e_test.go
@@ -10,7 +10,6 @@ import (
 	e2eParams "github.com/prysmaticlabs/prysm/endtoend/params"
 	"github.com/prysmaticlabs/prysm/endtoend/types"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 

--- a/endtoend/minimal_e2e_test.go
+++ b/endtoend/minimal_e2e_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestEndToEnd_MinimalConfig(t *testing.T) {
-	testutil.ResetCache()
+
 	params.UseE2EConfig()
 	require.NoError(t, e2eParams.Init(e2eParams.StandardBeaconCount))
 

--- a/endtoend/minimal_slashing_e2e_test.go
+++ b/endtoend/minimal_slashing_e2e_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestEndToEnd_Slashing_MinimalConfig(t *testing.T) {
 	t.Skip("To be replaced with the new slasher implementation")
-	testutil.ResetCache()
+
 	params.UseE2EConfig()
 	require.NoError(t, e2eParams.Init(e2eParams.StandardBeaconCount))
 

--- a/endtoend/minimal_slashing_e2e_test.go
+++ b/endtoend/minimal_slashing_e2e_test.go
@@ -7,7 +7,6 @@ import (
 	e2eParams "github.com/prysmaticlabs/prysm/endtoend/params"
 	"github.com/prysmaticlabs/prysm/endtoend/types"
 	"github.com/prysmaticlabs/prysm/shared/params"
-	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 

--- a/shared/testutil/deposits.go
+++ b/shared/testutil/deposits.go
@@ -32,6 +32,7 @@ var trie *trieutil.SparseMerkleTrie
 // if all secret keys for n validators are required then numDeposits
 // should be n+1.
 func DeterministicDepositsAndKeys(numDeposits uint64) ([]*ethpb.Deposit, []bls.SecretKey, error) {
+	resetCache()
 	lock.Lock()
 	defer lock.Unlock()
 	var err error
@@ -247,6 +248,7 @@ func DeterministicEth1Data(size int) (*ethpb.Eth1Data, error) {
 
 // DeterministicGenesisState returns a genesis state made using the deterministic deposits.
 func DeterministicGenesisState(t testing.TB, numValidators uint64) (iface.BeaconState, []bls.SecretKey) {
+	resetCache()
 	deposits, privKeys, err := DeterministicDepositsAndKeys(numValidators)
 	if err != nil {
 		t.Fatal(errors.Wrapf(err, "failed to get %d deposits", numValidators))
@@ -259,7 +261,7 @@ func DeterministicGenesisState(t testing.TB, numValidators uint64) (iface.Beacon
 	if err != nil {
 		t.Fatal(errors.Wrapf(err, "failed to get genesis beacon state of %d validators", numValidators))
 	}
-	ResetCache()
+
 	return beaconState, privKeys
 }
 
@@ -287,8 +289,8 @@ func DepositTrieFromDeposits(deposits []*ethpb.Deposit) (*trieutil.SparseMerkleT
 	return depositTrie, roots, nil
 }
 
-// ResetCache clears out the old trie, private keys and deposits.
-func ResetCache() {
+// resetCache clears out the old trie, private keys and deposits.
+func resetCache() {
 	trie = nil
 	privKeys = []bls.SecretKey{}
 	cachedDeposits = []*ethpb.Deposit{}
@@ -298,6 +300,7 @@ func ResetCache() {
 // of the same validator. This is for negative test cases such as same deposits from same validators in a block don't
 // result in duplicated validator indices.
 func DeterministicDepositsAndKeysSameValidator(numDeposits uint64) ([]*ethpb.Deposit, []bls.SecretKey, error) {
+	resetCache()
 	lock.Lock()
 	defer lock.Unlock()
 	var err error

--- a/shared/testutil/deposits_test.go
+++ b/shared/testutil/deposits_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestSetupInitialDeposits_1024Entries(t *testing.T) {
 	entries := 1
-	ResetCache()
+	resetCache()
 	deposits, privKeys, err := DeterministicDepositsAndKeys(uint64(entries))
 	require.NoError(t, err)
 	_, depositDataRoots, err := DeterministicDepositTrie(len(deposits))
@@ -51,7 +51,7 @@ func TestSetupInitialDeposits_1024Entries(t *testing.T) {
 	}
 
 	entries = 1024
-	ResetCache()
+	resetCache()
 	deposits, privKeys, err = DeterministicDepositsAndKeys(uint64(entries))
 	require.NoError(t, err)
 	_, depositDataRoots, err = DeterministicDepositTrie(len(deposits))
@@ -101,7 +101,7 @@ func TestSetupInitialDeposits_1024Entries(t *testing.T) {
 
 func TestDepositsWithBalance_MatchesDeterministic(t *testing.T) {
 	entries := 64
-	ResetCache()
+	resetCache()
 	balances := make([]uint64, entries)
 	for i := 0; i < entries; i++ {
 		balances[i] = params.BeaconConfig().MaxEffectiveBalance
@@ -128,7 +128,7 @@ func TestDepositsWithBalance_MatchesDeterministic(t *testing.T) {
 
 func TestDepositsWithBalance_MatchesDeterministic_Cached(t *testing.T) {
 	entries := 32
-	ResetCache()
+	resetCache()
 	// Cache half of the deposit cache.
 	_, _, err := DeterministicDepositsAndKeys(uint64(entries))
 	require.NoError(t, err)
@@ -164,7 +164,7 @@ func TestDepositsWithBalance_MatchesDeterministic_Cached(t *testing.T) {
 
 func TestSetupInitialDeposits_1024Entries_PartialDeposits(t *testing.T) {
 	entries := 1
-	ResetCache()
+	resetCache()
 	balances := make([]uint64, entries)
 	for i := 0; i < entries; i++ {
 		balances[i] = params.BeaconConfig().MaxEffectiveBalance / 2
@@ -202,7 +202,7 @@ func TestSetupInitialDeposits_1024Entries_PartialDeposits(t *testing.T) {
 	}
 
 	entries = 1024
-	ResetCache()
+	resetCache()
 	balances = make([]uint64, entries)
 	for i := 0; i < entries; i++ {
 		balances[i] = params.BeaconConfig().MaxEffectiveBalance / 2


### PR DESCRIPTION
Reset test utility's deposit cache. The usage of `ResetCache()`, `DeterministicDepositsAndKeys()`, `DeterministicGenesisState()` and `DeterministicDepositsAndKeysSameValidator()` are fragmented.

We shouldn't rely on the test case implementer to know and manually reset the cache every time. Often, they will spend a long time figuring why setup doesn't work, this is not trivial to debug