### PR TITLE
Disable No Freelist Sync In Backups

### DIFF
--- a/beacon-chain/db/kv/backup.go
+++ b/beacon-chain/db/kv/backup.go
@@ -47,7 +47,7 @@ func (s *Store) Backup(ctx context.Context, outputDir string, permissionOverride
 	copyDB, err := bolt.Open(
 		backupPath,
 		params.BeaconIoConfig().ReadWritePermissions,
-		&bolt.Options{NoFreelistSync: true, NoSync: true, Timeout: params.BeaconIoConfig().BoltTimeout, FreelistType: bolt.FreelistMapType},
+		&bolt.Options{NoSync: true, Timeout: params.BeaconIoConfig().BoltTimeout, FreelistType: bolt.FreelistMapType},
 	)
 	if err != nil {
 		return err
@@ -114,6 +114,5 @@ func (s *Store) Backup(ctx context.Context, outputDir string, permissionOverride
 	// Re-enable sync to allow bolt to fsync
 	// again.
 	copyDB.NoSync = false
-	copyDB.NoFreelistSync = false
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] This can lead to extremely long recovery times when running a node from a fresh backup as bolt has to traverse
through all the buckets in the db to rebuild the freelist. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
