### PR TITLE
Double java heap size for buildkite

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -22,7 +22,7 @@ build:remote-cache --incompatible_strict_action_env=true
 # Import workspace options.
 import %workspace%/.bazelrc
 
-startup --host_jvm_args=-Xmx1000m --host_jvm_args=-Xms1000m
+startup --host_jvm_args=-Xmx2g --host_jvm_args=-Xms2g
 query --repository_cache=/tmp/repositorycache
 query --experimental_repository_cache_hardlinks
 build --repository_cache=/tmp/repositorycache


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Increases java memory for bazel from 1g to 2g.

**Which issues(s) does this PR fix?**

Fixes issues with new spec tests in hf1 branch.
See: https://buildkite.com/prysmatic-labs/prysm/builds/51281 for a full run on top of hf1 with the new java opts set.

**Other notes for review**

I did not find the root cause of the issue, but I suspect it has to do with an increased number of files loaded into the action cache / memory when running spec tests.

Example failure that this resolves: https://buildkite.com/prysmatic-labs/prysm/builds/51275#40198df3-e5c9-4d07-b7e7-7db587d89551