### PR TITLE
Remove copy when push to priority queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,6 @@ require (
 	github.com/manifoldco/promptui v0.7.0
 	github.com/minio/highwayhash v1.0.1
 	github.com/minio/sha256-simd v1.0.0
-	github.com/mitchellh/copystructure v1.2.0
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d

--- a/go.sum
+++ b/go.sum
@@ -859,8 +859,6 @@ github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
-github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
-github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
@@ -872,8 +870,6 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mitchellh/mapstructure v1.3.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
-github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/shared/queue/BUILD.bazel
+++ b/shared/queue/BUILD.bazel
@@ -5,5 +5,4 @@ go_library(
     srcs = ["priority_queue.go"],
     importpath = "github.com/prysmaticlabs/prysm/shared/queue",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_mitchellh_copystructure//:go_default_library"],
 )

--- a/shared/queue/priority_queue.go
+++ b/shared/queue/priority_queue.go
@@ -12,8 +12,6 @@ import (
 	"container/heap"
 	"errors"
 	"sync"
-
-	"github.com/mitchellh/copystructure"
 )
 
 // ErrEmpty is returned for queues with no items
@@ -107,7 +105,8 @@ func (pq *PriorityQueue) Pop() (*Item, error) {
 // method that calls heap.Push, so consumers do not need to invoke heap
 // functions directly. Items must have unique Keys, and Items in the queue
 // cannot be updated. To modify an Item, users must first remove it and re-push
-// it after modifications
+// it after modifications. Item does not get copied before pushing on to the queue,
+// it's up to the caller to copy the item.
 func (pq *PriorityQueue) Push(i *Item) error {
 	if i == nil || i.Key == "" {
 		return errors.New("error adding item: Item Key is required")
@@ -119,19 +118,9 @@ func (pq *PriorityQueue) Push(i *Item) error {
 	if _, ok := pq.dataMap[i.Key]; ok {
 		return ErrDuplicateItem
 	}
-	// Copy the item value(s) so that modifications to the source item does not
-	// affect the item on the queue
-	clone, err := copystructure.Copy(i)
-	if err != nil {
-		return err
-	}
 
-	var ok bool
-	pq.dataMap[i.Key], ok = clone.(*Item)
-	if !ok {
-		return errors.New("unknown type")
-	}
-	heap.Push(&pq.data, clone)
+	pq.dataMap[i.Key] = i
+	heap.Push(&pq.data, i)
 	return nil
 }
 


### PR DESCRIPTION
<img width="1258" alt="Screen Shot 2021-06-22 at 3 45 12 PM" src="https://user-images.githubusercontent.com/21316537/123008554-ed3d9a00-d36f-11eb-9171-148730d7718a.png">

The priority queue uses `copystructure.Copy` underneath when we push an item on to the queue. As seen from the flame, it's expensive due to reflect and many things. This PR removes the copy on push given the copy is done by the caller in `SaveSyncCommitteeMessage`

Also squeezed in a minor refactor for `SaveSyncCommitteeMessage` to avoid potential dead lock