### PR TITLE
Parallelized Double Vote Detection in Slasher With Disk-Space Efficient Schema

### DIFF
--- a/beacon-chain/db/slasherkv/BUILD.bazel
+++ b/beacon-chain/db/slasherkv/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_etcd_go_bbolt//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
 

--- a/beacon-chain/db/slasherkv/slasher_test.go
+++ b/beacon-chain/db/slasherkv/slasher_test.go
@@ -3,6 +3,7 @@ package slasherkv
 import (
 	"context"
 	"encoding/binary"
+	"math/rand"
 	"reflect"
 	"testing"
 
@@ -438,6 +439,38 @@ func BenchmarkHighestAttestations(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := beaconDB.HighestAttestations(ctx, allIndices)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkStore_CheckDoubleBlockProposals(b *testing.B) {
+	b.StopTimer()
+	count := 10000
+	valsPerAtt := 100
+	indicesPerAtt := make([][]uint64, count)
+	for i := 0; i < count; i++ {
+		indicesForAtt := make([]uint64, valsPerAtt)
+		for r := i * count; r < valsPerAtt*(i+1); r++ {
+			indicesForAtt[i] = uint64(r)
+		}
+		indicesPerAtt[i] = indicesForAtt
+	}
+	atts := make([]*slashertypes.IndexedAttestationWrapper, count)
+	for i := 0; i < count; i++ {
+		atts[i] = createAttestationWrapper(types.Epoch(i), types.Epoch(i+2), indicesPerAtt[i], []byte{})
+	}
+
+	ctx := context.Background()
+	beaconDB := setupDB(b)
+	require.NoError(b, beaconDB.SaveAttestationRecordsForValidators(ctx, atts))
+
+	// shuffle attestations
+	rand.Shuffle(count, func(i, j int) { atts[i], atts[j] = atts[j], atts[i] })
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := beaconDB.CheckAttesterDoubleVotes(ctx, atts)
 		require.NoError(b, err)
 	}
 }

--- a/beacon-chain/db/slasherkv/slasher_test.go
+++ b/beacon-chain/db/slasherkv/slasher_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"reflect"
+	"sort"
 	"testing"
 
 	ssz "github.com/ferranbt/fastssz"
@@ -111,6 +112,9 @@ func TestStore_CheckAttesterDoubleVotes(t *testing.T) {
 	}
 	doubleVotes, err := beaconDB.CheckAttesterDoubleVotes(ctx, slashableAtts)
 	require.NoError(t, err)
+	sort.SliceStable(doubleVotes, func(i, j int) bool {
+		return uint64(doubleVotes[i].ValidatorIndex) < uint64(doubleVotes[j].ValidatorIndex)
+	})
 	require.DeepEqual(t, wanted, doubleVotes)
 }
 


### PR DESCRIPTION
This PR is part of #8331. It also uses concurrency to improve double vote detection from #8927 but keeps a disk-space-efficient schema. The schema from 8927 ended up using up too much disk space in testnet trials.