### PR TITLE
Move API param handling to separate file

### DIFF
--- a/shared/gateway/BUILD.bazel
+++ b/shared/gateway/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "api_middleware_structs.go",
         "gateway.go",
         "log.go",
+        "param_handling.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/shared/gateway",
     visibility = [
@@ -37,6 +38,7 @@ go_test(
     srcs = [
         "api_middleware_processing_test.go",
         "gateway_test.go",
+        "param_handling_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/shared/gateway/api_middleware_processing.go
+++ b/shared/gateway/api_middleware_processing.go
@@ -14,9 +14,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
-	butil "github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/grpcutils"
 	"github.com/wealdtech/go-bytesutil"
 )
@@ -68,88 +66,6 @@ func (m *ApiProxyMiddleware) PrepareRequestForProxying(endpoint Endpoint, req *h
 		return errJson
 	}
 	return HandleQueryParameters(req, endpoint.GetRequestQueryParams)
-}
-
-// HandleURLParameters processes URL parameters, allowing parameterized URLs to be safely and correctly proxied to grpc-gateway.
-func HandleURLParameters(url string, req *http.Request, literals []string) ErrorJson {
-	segments := strings.Split(url, "/")
-
-segmentsLoop:
-	for i, s := range segments {
-		// We only care about segments which are parameterized.
-		if isRequestParam(s) {
-			// Don't do anything with parameters which should be forwarded literally to gRPC.
-			for _, l := range literals {
-				if s == "{"+l+"}" {
-					continue segmentsLoop
-				}
-			}
-
-			routeVar := mux.Vars(req)[s[1:len(s)-1]]
-			bRouteVar := []byte(routeVar)
-			isHex, err := butil.IsHex(bRouteVar)
-			if err != nil {
-				e := errors.Wrapf(err, "could not process URL parameter")
-				return &DefaultErrorJson{Message: e.Error(), Code: http.StatusInternalServerError}
-			}
-			if isHex {
-				bRouteVar, err = bytesutil.FromHexString(string(bRouteVar))
-				if err != nil {
-					e := errors.Wrapf(err, "could not process URL parameter")
-					return &DefaultErrorJson{Message: e.Error(), Code: http.StatusInternalServerError}
-				}
-			}
-			// Converting hex to base64 may result in a value which malforms the URL.
-			// We use URLEncoding to safely escape such values.
-			base64RouteVar := base64.URLEncoding.EncodeToString(bRouteVar)
-
-			// Merge segments back into the full URL.
-			splitPath := strings.Split(req.URL.Path, "/")
-			splitPath[i] = base64RouteVar
-			req.URL.Path = strings.Join(splitPath, "/")
-		}
-	}
-	return nil
-}
-
-// HandleQueryParameters processes query parameters, allowing them to be safely and correctly proxied to grpc-gateway.
-func HandleQueryParameters(req *http.Request, params []QueryParam) ErrorJson {
-	queryParams := req.URL.Query()
-
-	for key, vals := range queryParams {
-		for _, p := range params {
-			if key == p.Name {
-				if p.Hex {
-					queryParams.Del(key)
-					for _, v := range vals {
-						b := []byte(v)
-						isHex, err := butil.IsHex(b)
-						if err != nil {
-							e := errors.Wrapf(err, "could not process query parameter")
-							return &DefaultErrorJson{Message: e.Error(), Code: http.StatusInternalServerError}
-						}
-						if isHex {
-							b, err = bytesutil.FromHexString(v)
-							if err != nil {
-								e := errors.Wrapf(err, "could not process query parameter")
-								return &DefaultErrorJson{Message: e.Error(), Code: http.StatusInternalServerError}
-							}
-						}
-						queryParams.Add(key, base64.URLEncoding.EncodeToString(b))
-					}
-				}
-				if p.Enum {
-					queryParams.Del(key)
-					for _, v := range vals {
-						// gRPC expects uppercase enum values.
-						queryParams.Add(key, strings.ToUpper(v))
-					}
-				}
-			}
-		}
-	}
-	req.URL.RawQuery = queryParams.Encode()
-	return nil
 }
 
 // ProxyRequest proxies the request to grpc-gateway.
@@ -316,12 +232,6 @@ func Cleanup(grpcResponseBody io.ReadCloser) ErrorJson {
 		return &DefaultErrorJson{Message: e.Error(), Code: http.StatusInternalServerError}
 	}
 	return nil
-}
-
-// isRequestParam verifies whether the passed string is a request parameter.
-// Request parameters are enclosed in { and }.
-func isRequestParam(s string) bool {
-	return len(s) > 2 && s[0] == '{' && s[len(s)-1] == '}'
 }
 
 // processField calls each processor function on any field that has the matching tag set.

--- a/shared/gateway/api_middleware_processing_test.go
+++ b/shared/gateway/api_middleware_processing_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/prysmaticlabs/prysm/shared/grpcutils"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -137,88 +136,6 @@ func TestPrepareRequestForProxying(t *testing.T) {
 	assert.Equal(t, "http", request.URL.Scheme)
 	assert.Equal(t, middleware.GatewayAddress, request.URL.Host)
 	assert.Equal(t, "", request.RequestURI)
-}
-
-func TestHandleURLParameters(t *testing.T) {
-	var body bytes.Buffer
-
-	t.Run("no_params", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example/bar", &body)
-
-		errJson := HandleURLParameters("/not_param", request, []string{})
-		require.Equal(t, true, errJson == nil)
-		assert.Equal(t, "/bar", request.URL.Path)
-	})
-
-	t.Run("with_params", func(t *testing.T) {
-		muxVars := make(map[string]string)
-		muxVars["bar_param"] = "bar"
-		muxVars["quux_param"] = "quux"
-		request := httptest.NewRequest("GET", "http://foo.example/bar/baz/quux", &body)
-		request = mux.SetURLVars(request, muxVars)
-
-		errJson := HandleURLParameters("/{bar_param}/not_param/{quux_param}", request, []string{})
-		require.Equal(t, true, errJson == nil)
-		assert.Equal(t, "/YmFy/baz/cXV1eA==", request.URL.Path)
-	})
-
-	t.Run("with_literal", func(t *testing.T) {
-		muxVars := make(map[string]string)
-		muxVars["bar_param"] = "bar"
-		request := httptest.NewRequest("GET", "http://foo.example/bar/baz", &body)
-		request = mux.SetURLVars(request, muxVars)
-
-		errJson := HandleURLParameters("/{bar_param}/not_param/", request, []string{"bar_param"})
-		require.Equal(t, true, errJson == nil)
-		assert.Equal(t, "/bar/baz", request.URL.Path)
-	})
-
-	t.Run("with_hex", func(t *testing.T) {
-		muxVars := make(map[string]string)
-		muxVars["hex_param"] = "0x626172"
-		request := httptest.NewRequest("GET", "http://foo.example/0x626172/baz", &body)
-		request = mux.SetURLVars(request, muxVars)
-
-		errJson := HandleURLParameters("/{hex_param}/not_param/", request, []string{})
-		require.Equal(t, true, errJson == nil)
-		assert.Equal(t, "/YmFy/baz", request.URL.Path)
-	})
-}
-
-func TestHandleQueryParameters(t *testing.T) {
-	var body bytes.Buffer
-
-	t.Run("regular_params", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example?bar=bar&baz=baz", &body)
-
-		errJson := HandleQueryParameters(request, []QueryParam{{Name: "bar"}, {Name: "baz"}})
-		require.Equal(t, true, errJson == nil)
-		query := request.URL.Query()
-		v, ok := query["bar"]
-		require.Equal(t, true, ok, "query param not found")
-		require.Equal(t, 1, len(v), "wrong number of query param values")
-		assert.Equal(t, "bar", v[0])
-		v, ok = query["baz"]
-		require.Equal(t, true, ok, "query param not found")
-		require.Equal(t, 1, len(v), "wrong number of query param values")
-		assert.Equal(t, "baz", v[0])
-	})
-
-	t.Run("hex_and_enum_params", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example?hex=0x626172&baz=baz", &body)
-
-		errJson := HandleQueryParameters(request, []QueryParam{{Name: "hex", Hex: true}, {Name: "baz", Enum: true}})
-		require.Equal(t, true, errJson == nil)
-		query := request.URL.Query()
-		v, ok := query["hex"]
-		require.Equal(t, true, ok, "query param not found")
-		require.Equal(t, 1, len(v), "wrong number of query param values")
-		assert.Equal(t, "YmFy", v[0])
-		v, ok = query["baz"]
-		require.Equal(t, true, ok, "query param not found")
-		require.Equal(t, 1, len(v), "wrong number of query param values")
-		assert.Equal(t, "BAZ", v[0])
-	})
 }
 
 func TestReadGrpcResponseBody(t *testing.T) {
@@ -473,22 +390,4 @@ func TestWriteError(t *testing.T) {
 		WriteError(httptest.NewRecorder(), &testErrorJson{}, responseHeader)
 		assert.LogsContain(t, logHook, "Could not unmarshal custom error message")
 	})
-}
-
-func TestIsRequestParam(t *testing.T) {
-	tests := []struct {
-		s string
-		b bool
-	}{
-		{"", false},
-		{"{", false},
-		{"}", false},
-		{"{}", false},
-		{"{x}", true},
-		{"{very_long_parameter_name_with_underscores}", true},
-	}
-	for _, tt := range tests {
-		b := isRequestParam(tt.s)
-		assert.Equal(t, tt.b, b)
-	}
 }

--- a/shared/gateway/param_handling.go
+++ b/shared/gateway/param_handling.go
@@ -1,0 +1,100 @@
+package gateway
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+	butil "github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/wealdtech/go-bytesutil"
+)
+
+// HandleURLParameters processes URL parameters, allowing parameterized URLs to be safely and correctly proxied to grpc-gateway.
+func HandleURLParameters(url string, req *http.Request, literals []string) ErrorJson {
+	segments := strings.Split(url, "/")
+
+segmentsLoop:
+	for i, s := range segments {
+		// We only care about segments which are parameterized.
+		if isRequestParam(s) {
+			// Don't do anything with parameters which should be forwarded literally to gRPC.
+			for _, l := range literals {
+				if s == "{"+l+"}" {
+					continue segmentsLoop
+				}
+			}
+
+			routeVar := mux.Vars(req)[s[1:len(s)-1]]
+			bRouteVar := []byte(routeVar)
+			isHex, err := butil.IsHex(bRouteVar)
+			if err != nil {
+				e := errors.Wrapf(err, "could not process URL parameter")
+				return &DefaultErrorJson{Message: e.Error(), Code: http.StatusInternalServerError}
+			}
+			if isHex {
+				bRouteVar, err = bytesutil.FromHexString(string(bRouteVar))
+				if err != nil {
+					e := errors.Wrapf(err, "could not process URL parameter")
+					return &DefaultErrorJson{Message: e.Error(), Code: http.StatusInternalServerError}
+				}
+			}
+			// Converting hex to base64 may result in a value which malforms the URL.
+			// We use URLEncoding to safely escape such values.
+			base64RouteVar := base64.URLEncoding.EncodeToString(bRouteVar)
+
+			// Merge segments back into the full URL.
+			splitPath := strings.Split(req.URL.Path, "/")
+			splitPath[i] = base64RouteVar
+			req.URL.Path = strings.Join(splitPath, "/")
+		}
+	}
+	return nil
+}
+
+// HandleQueryParameters processes query parameters, allowing them to be safely and correctly proxied to grpc-gateway.
+func HandleQueryParameters(req *http.Request, params []QueryParam) ErrorJson {
+	queryParams := req.URL.Query()
+
+	for key, vals := range queryParams {
+		for _, p := range params {
+			if key == p.Name {
+				if p.Hex {
+					queryParams.Del(key)
+					for _, v := range vals {
+						b := []byte(v)
+						isHex, err := butil.IsHex(b)
+						if err != nil {
+							e := errors.Wrapf(err, "could not process query parameter")
+							return &DefaultErrorJson{Message: e.Error(), Code: http.StatusInternalServerError}
+						}
+						if isHex {
+							b, err = bytesutil.FromHexString(v)
+							if err != nil {
+								e := errors.Wrapf(err, "could not process query parameter")
+								return &DefaultErrorJson{Message: e.Error(), Code: http.StatusInternalServerError}
+							}
+						}
+						queryParams.Add(key, base64.URLEncoding.EncodeToString(b))
+					}
+				}
+				if p.Enum {
+					queryParams.Del(key)
+					for _, v := range vals {
+						// gRPC expects uppercase enum values.
+						queryParams.Add(key, strings.ToUpper(v))
+					}
+				}
+			}
+		}
+	}
+	req.URL.RawQuery = queryParams.Encode()
+	return nil
+}
+
+// isRequestParam verifies whether the passed string is a request parameter.
+// Request parameters are enclosed in { and }.
+func isRequestParam(s string) bool {
+	return len(s) > 2 && s[0] == '{' && s[len(s)-1] == '}'
+}

--- a/shared/gateway/param_handling_test.go
+++ b/shared/gateway/param_handling_test.go
@@ -1,0 +1,111 @@
+package gateway
+
+import (
+	"bytes"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestHandleURLParameters(t *testing.T) {
+	var body bytes.Buffer
+
+	t.Run("no_params", func(t *testing.T) {
+		request := httptest.NewRequest("GET", "http://foo.example/bar", &body)
+
+		errJson := HandleURLParameters("/not_param", request, []string{})
+		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, "/bar", request.URL.Path)
+	})
+
+	t.Run("with_params", func(t *testing.T) {
+		muxVars := make(map[string]string)
+		muxVars["bar_param"] = "bar"
+		muxVars["quux_param"] = "quux"
+		request := httptest.NewRequest("GET", "http://foo.example/bar/baz/quux", &body)
+		request = mux.SetURLVars(request, muxVars)
+
+		errJson := HandleURLParameters("/{bar_param}/not_param/{quux_param}", request, []string{})
+		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, "/YmFy/baz/cXV1eA==", request.URL.Path)
+	})
+
+	t.Run("with_literal", func(t *testing.T) {
+		muxVars := make(map[string]string)
+		muxVars["bar_param"] = "bar"
+		request := httptest.NewRequest("GET", "http://foo.example/bar/baz", &body)
+		request = mux.SetURLVars(request, muxVars)
+
+		errJson := HandleURLParameters("/{bar_param}/not_param/", request, []string{"bar_param"})
+		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, "/bar/baz", request.URL.Path)
+	})
+
+	t.Run("with_hex", func(t *testing.T) {
+		muxVars := make(map[string]string)
+		muxVars["hex_param"] = "0x626172"
+		request := httptest.NewRequest("GET", "http://foo.example/0x626172/baz", &body)
+		request = mux.SetURLVars(request, muxVars)
+
+		errJson := HandleURLParameters("/{hex_param}/not_param/", request, []string{})
+		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, "/YmFy/baz", request.URL.Path)
+	})
+}
+
+func TestHandleQueryParameters(t *testing.T) {
+	var body bytes.Buffer
+
+	t.Run("regular_params", func(t *testing.T) {
+		request := httptest.NewRequest("GET", "http://foo.example?bar=bar&baz=baz", &body)
+
+		errJson := HandleQueryParameters(request, []QueryParam{{Name: "bar"}, {Name: "baz"}})
+		require.Equal(t, true, errJson == nil)
+		query := request.URL.Query()
+		v, ok := query["bar"]
+		require.Equal(t, true, ok, "query param not found")
+		require.Equal(t, 1, len(v), "wrong number of query param values")
+		assert.Equal(t, "bar", v[0])
+		v, ok = query["baz"]
+		require.Equal(t, true, ok, "query param not found")
+		require.Equal(t, 1, len(v), "wrong number of query param values")
+		assert.Equal(t, "baz", v[0])
+	})
+
+	t.Run("hex_and_enum_params", func(t *testing.T) {
+		request := httptest.NewRequest("GET", "http://foo.example?hex=0x626172&baz=baz", &body)
+
+		errJson := HandleQueryParameters(request, []QueryParam{{Name: "hex", Hex: true}, {Name: "baz", Enum: true}})
+		require.Equal(t, true, errJson == nil)
+		query := request.URL.Query()
+		v, ok := query["hex"]
+		require.Equal(t, true, ok, "query param not found")
+		require.Equal(t, 1, len(v), "wrong number of query param values")
+		assert.Equal(t, "YmFy", v[0])
+		v, ok = query["baz"]
+		require.Equal(t, true, ok, "query param not found")
+		require.Equal(t, 1, len(v), "wrong number of query param values")
+		assert.Equal(t, "BAZ", v[0])
+	})
+}
+
+func TestIsRequestParam(t *testing.T) {
+	tests := []struct {
+		s string
+		b bool
+	}{
+		{"", false},
+		{"{", false},
+		{"}", false},
+		{"{}", false},
+		{"{x}", true},
+		{"{very_long_parameter_name_with_underscores}", true},
+	}
+	for _, tt := range tests {
+		b := isRequestParam(tt.s)
+		assert.Equal(t, tt.b, b)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

Moves parameter handling related functions to a separate file. The `api_middleware_processing.go` file is quite big already and we will have some more param-related code coming soon.
