### PR TITLE
No length check in AggregatePublicKeys

### DIFF
--- a/shared/bls/blst/public_key.go
+++ b/shared/bls/blst/public_key.go
@@ -58,7 +58,7 @@ func AggregatePublicKeys(pubs [][]byte) (common.PublicKey, error) {
 		return &PublicKey{}, nil
 	}
 	if pubs == nil || len(pubs) == 0 {
-		return nil, errors.New("Public keys passed is nil or empty")
+		return nil, errors.New("nil or empty public keys")
 	}
 	agg := new(blstAggregatePublicKey)
 	mulP1 := make([]*blstPublicKey, 0, len(pubs))

--- a/shared/bls/blst/public_key.go
+++ b/shared/bls/blst/public_key.go
@@ -57,6 +57,9 @@ func AggregatePublicKeys(pubs [][]byte) (common.PublicKey, error) {
 	if featureconfig.Get().SkipBLSVerify {
 		return &PublicKey{}, nil
 	}
+	if pubs == nil || len(pubs) == 0 {
+		return nil, errors.New("Public keys passed is nil or empty")
+	}
 	agg := new(blstAggregatePublicKey)
 	mulP1 := make([]*blstPublicKey, 0, len(pubs))
 	for _, pubkey := range pubs {

--- a/shared/bls/blst/public_key_test.go
+++ b/shared/bls/blst/public_key_test.go
@@ -80,5 +80,5 @@ func TestPublicKey_Copy(t *testing.T) {
 func TestPublicKeysEmpty(t *testing.T) {
 	pubs := [][]byte{}
 	_, err := blst.AggregatePublicKeys(pubs)
-	require.ErrorContains(t, "Public keys passed is nil or empty", err)
+	require.ErrorContains(t, "nil or empty public keys", err)
 }

--- a/shared/bls/blst/public_key_test.go
+++ b/shared/bls/blst/public_key_test.go
@@ -76,3 +76,9 @@ func TestPublicKey_Copy(t *testing.T) {
 
 	require.DeepEqual(t, pubkeyA.Marshal(), pubkeyBytes, "Pubkey was mutated after copy")
 }
+
+func TestPublicKeysEmpty(t *testing.T) {
+	pubs := [][]byte{}
+	_, err := blst.AggregatePublicKeys(pubs)
+	require.ErrorContains(t, "Public keys passed is nil or empty", err)
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**
AggregatePublicKeys returns a true if pubkeys(its args) is nil or empty. A check was added. 

**Which issues(s) does this PR fix?**
fixes  #9091 


**Other notes for review**
