### PR TITLE
Protect Against Unsafe Coefficients

### DIFF
--- a/shared/bls/blst/signature.go
+++ b/shared/bls/blst/signature.go
@@ -204,6 +204,9 @@ func VerifyMultipleSignatures(sigs [][]byte, msgs [][32]byte, pubKeys []common.P
 		// Ignore error as the error will always be nil in `read` in math/rand.
 		randGen.Read(rbytes[:])
 		randLock.Unlock()
+		// Protect against the generator returning 0. Since the scalar value is
+		// derived from a big endian byte slice, we take the last byte.
+		rbytes[len(rbytes)-1] |= 0x01
 		scalar.FromBEndian(rbytes[:])
 	}
 	dummySig := new(blstSignature)


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] In the unlikely event we do receive a zero value from our RNG, we ensure it is non-zero. 

**Which issues(s) does this PR fix?**

Fixes #9098 

**Other notes for review**
