### PR TITLE
Make Eth APIs flag name implementation agnostic

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -645,12 +645,12 @@ func (b *BeaconNode) registerGRPCGateway() error {
 		return nil
 	}
 	gatewayPort := b.cliCtx.Int(flags.GRPCGatewayPort.Name)
-	apiMiddlewarePort := b.cliCtx.Int(flags.ApiMiddlewarePort.Name)
+	ethApiPort := b.cliCtx.Int(flags.EthApiPort.Name)
 	gatewayHost := b.cliCtx.String(flags.GRPCGatewayHost.Name)
 	rpcHost := b.cliCtx.String(flags.RPCHost.Name)
 	selfAddress := fmt.Sprintf("%s:%d", rpcHost, b.cliCtx.Int(flags.RPCPort.Name))
 	gatewayAddress := fmt.Sprintf("%s:%d", gatewayHost, gatewayPort)
-	apiMiddlewareAddress := fmt.Sprintf("%s:%d", gatewayHost, apiMiddlewarePort)
+	apiMiddlewareAddress := fmt.Sprintf("%s:%d", gatewayHost, ethApiPort)
 	allowedOrigins := strings.Split(b.cliCtx.String(flags.GPRCGatewayCorsDomain.Name), ",")
 	enableDebugRPCEndpoints := b.cliCtx.Bool(flags.EnableDebugRPCEndpoints.Name)
 	selfCert := b.cliCtx.String(flags.CertFlag.Name)

--- a/beacon-chain/server/main.go
+++ b/beacon-chain/server/main.go
@@ -20,7 +20,7 @@ import (
 var (
 	beaconRPC               = flag.String("beacon-rpc", "localhost:4000", "Beacon chain gRPC endpoint")
 	port                    = flag.Int("port", 8000, "Port to serve on")
-	apiMiddlewarePort       = flag.Int("port", 8001, "Port to serve API middleware on")
+	EthApiPort              = flag.Int("port", 8001, "Port to serve Ethereum API on")
 	host                    = flag.String("host", "127.0.0.1", "Host to serve on")
 	debug                   = flag.Bool("debug", false, "Enable debug logging")
 	allowedOrigins          = flag.String("corsdomain", "localhost:4242", "A comma separated list of CORS domains to allow")
@@ -48,7 +48,7 @@ func main() {
 		fmt.Sprintf("%s:%d", *host, *port),
 	).WithAllowedOrigins(strings.Split(*allowedOrigins, ",")).
 		WithMaxCallRecvMsgSize(uint64(*grpcMaxMsgSize)).
-		WithApiMiddleware(fmt.Sprintf("%s:%d", *host, *apiMiddlewarePort), &apimiddleware.BeaconEndpointFactory{})
+		WithApiMiddleware(fmt.Sprintf("%s:%d", *host, *EthApiPort), &apimiddleware.BeaconEndpointFactory{})
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/swagger/", gateway.SwaggerServer())

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -70,11 +70,11 @@ var (
 		Usage: "The port on which the gateway server runs on",
 		Value: 3500,
 	}
-	// ApiMiddlewarePort specifies the port for an HTTP proxy server which acts as a middleware between Ethereum consensus API clients and Prysm's gRPC gateway.
-	// The middleware serves JSON values conforming to the specification: https://ethereum.github.io/eth2.0-APIs/
-	ApiMiddlewarePort = &cli.IntFlag{
-		Name:  "api-middleware-port",
-		Usage: "The port on which the API middleware runs on",
+	// EthApiPort specifies the port which runs the official Ethereum REST API.
+	// Serves JSON values conforming to the specification: https://ethereum.github.io/eth2.0-APIs/
+	EthApiPort = &cli.IntFlag{
+		Name:  "eth-api-port",
+		Usage: "The port which exposes a REST API conforming to the official Ethereum API specification.",
 		Value: 3501,
 	}
 	// GPRCGatewayCorsDomain serves preflight requests when serving gRPC JSON gateway.

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -39,7 +39,7 @@ var appFlags = []cli.Flag{
 	flags.DisableGRPCGateway,
 	flags.GRPCGatewayHost,
 	flags.GRPCGatewayPort,
-	flags.ApiMiddlewarePort,
+	flags.EthApiPort,
 	flags.GPRCGatewayCorsDomain,
 	flags.MinSyncPeers,
 	flags.ContractDeploymentBlock,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -102,7 +102,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.DisableGRPCGateway,
 			flags.GRPCGatewayHost,
 			flags.GRPCGatewayPort,
-			flags.ApiMiddlewarePort,
+			flags.EthApiPort,
 			flags.GPRCGatewayCorsDomain,
 			flags.HTTPWeb3ProviderFlag,
 			flags.FallbackWeb3ProviderFlag,

--- a/endtoend/components/beacon_node.go
+++ b/endtoend/components/beacon_node.go
@@ -112,7 +112,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 		fmt.Sprintf("--%s=%d", cmdshared.P2PTCPPort.Name, e2e.TestParams.BeaconNodeRPCPort+index+20),
 		fmt.Sprintf("--%s=%d", flags.MonitoringPortFlag.Name, e2e.TestParams.BeaconNodeMetricsPort+index),
 		fmt.Sprintf("--%s=%d", flags.GRPCGatewayPort.Name, e2e.TestParams.BeaconNodeRPCPort+index+40),
-		fmt.Sprintf("--%s=%d", flags.ApiMiddlewarePort.Name, e2e.TestParams.BeaconNodeRPCPort+index+30),
+		fmt.Sprintf("--%s=%d", flags.EthApiPort.Name, e2e.TestParams.BeaconNodeRPCPort+index+30),
 		fmt.Sprintf("--%s=%d", flags.ContractDeploymentBlock.Name, 0),
 		fmt.Sprintf("--%s=%d", cmdshared.RPCMaxPageSizeFlag.Name, params.BeaconConfig().MinGenesisActiveValidatorCount),
 		fmt.Sprintf("--%s=%s", cmdshared.BootstrapNode.Name, enr),


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

`api-middleware-port` is the current name of the flag which specifies the port to serve HTTP JSON conforming to the official Eth2 APIs. API Middleware is an implementation detail and the flag name should rather describe the functionality. This PR renames it to `eth-api-port`. If we replace the API Middleware with something else in the future, the flag name will still be up-to-date.
