### PR TITLE
Green Altair e2e tests

### DIFF
--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -18,13 +18,13 @@ var (
 
 	// SyncCommitteeCacheMiss tracks the number of committee requests that aren't present in the cache.
 	SyncCommitteeCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "sync_committee_cache_miss",
-		Help: "The number of committee requests that aren't present in the cache.",
+		Name: "sync_committee_index_cache_miss",
+		Help: "The number of committee requests that aren't present in the sync committee index cache.",
 	})
 	// SyncCommitteeCacheHit tracks the number of committee requests that are in the cache.
 	SyncCommitteeCacheHit = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "sync_committee_cache_hit",
-		Help: "The number of committee requests that are present in the cache.",
+		Name: "sync_committee_index_cache_hit",
+		Help: "The number of committee requests that are present in the sync committee index cache.",
 	})
 )
 

--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
-load("@prysm//tools/go:def.bzl", "go_library")
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/beacon-chain/operations/synccommittee/BUILD.bazel
+++ b/beacon-chain/operations/synccommittee/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
-load("@prysm//tools/go:def.bzl", "go_library")
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/beacon-chain/rpc/prysm/v2/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v2/validator/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
-load("@prysm//tools/go:def.bzl", "go_library")
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/shared/p2putils/BUILD.bazel
+++ b/shared/p2putils/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
-load("@prysm//tools/go:def.bzl", "go_library")
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",

--- a/shared/p2putils/fork.go
+++ b/shared/p2putils/fork.go
@@ -82,25 +82,22 @@ func CreateForkDigest(
 func Fork(
 	targetEpoch types.Epoch,
 ) (*pb.Fork, error) {
-	// We retrieve a list of scheduled forks by epoch.
-	// We loop through the keys in this map to determine the current
-	// fork version based on the requested epoch.
-	retrievedForkVersion := bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion)
+	currentForkVersion := bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion)
 	previousForkVersion := bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion)
 	fSchedule := params.BeaconConfig().ForkVersionSchedule
-	scheduledForks := SortedForkVersions(fSchedule)
+	sortedForkVersions := SortedForkVersions(fSchedule)
 	forkEpoch := types.Epoch(0)
-	for _, forkVersion := range scheduledForks {
+	for _, forkVersion := range sortedForkVersions {
 		epoch := fSchedule[forkVersion]
-		if epoch <= targetEpoch {
-			previousForkVersion = retrievedForkVersion
-			retrievedForkVersion = forkVersion
+		if targetEpoch >= epoch {
+			previousForkVersion = currentForkVersion
+			currentForkVersion = forkVersion
 			forkEpoch = epoch
 		}
 	}
 	return &pb.Fork{
 		PreviousVersion: previousForkVersion[:],
-		CurrentVersion:  retrievedForkVersion[:],
+		CurrentVersion:  currentForkVersion[:],
 		Epoch:           forkEpoch,
 	}, nil
 }

--- a/shared/params/minimal_config.go
+++ b/shared/params/minimal_config.go
@@ -89,7 +89,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.AltairForkEpoch = math.MaxUint64
 	// Manually set fork version schedule here.
 	minimalConfig.ForkVersionSchedule = map[[4]byte]types.Epoch{
-		{0, 0, 0, 0}: 0,
+		{0, 0, 0, 1}: 0,
 		{1, 0, 0, 1}: math.MaxUint64,
 	}
 	minimalConfig.SyncCommitteeSize = 32

--- a/spectest/mainnet/altair/epoch_processing/BUILD.bazel
+++ b/spectest/mainnet/altair/epoch_processing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/spectest/mainnet/altair/finality/BUILD.bazel
+++ b/spectest/mainnet/altair/finality/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/spectest/mainnet/altair/fork_helper/BUILD.bazel
+++ b/spectest/mainnet/altair/fork_helper/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/spectest/mainnet/altair/fork_transition/BUILD.bazel
+++ b/spectest/mainnet/altair/fork_transition/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/spectest/mainnet/altair/operations/BUILD.bazel
+++ b/spectest/mainnet/altair/operations/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/spectest/mainnet/altair/rewards/BUILD.bazel
+++ b/spectest/mainnet/altair/rewards/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/spectest/mainnet/altair/sanity/BUILD.bazel
+++ b/spectest/mainnet/altair/sanity/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/spectest/mainnet/altair/ssz_static/BUILD.bazel
+++ b/spectest/mainnet/altair/ssz_static/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",

--- a/spectest/minimal/altair/epoch_processing/BUILD.bazel
+++ b/spectest/minimal/altair/epoch_processing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 # Requires --define ssz=minimal
 go_test(

--- a/spectest/minimal/altair/finality/BUILD.bazel
+++ b/spectest/minimal/altair/finality/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 # Requires --define ssz=minimal
 go_test(

--- a/spectest/minimal/altair/fork/BUILD.bazel
+++ b/spectest/minimal/altair/fork/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 # Requires --define ssz=minimal
 go_test(

--- a/spectest/minimal/altair/operations/BUILD.bazel
+++ b/spectest/minimal/altair/operations/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 # Requires --define ssz=minimal
 go_test(

--- a/spectest/minimal/altair/rewards/BUILD.bazel
+++ b/spectest/minimal/altair/rewards/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 # Requires --define ssz=minimal
 go_test(

--- a/spectest/minimal/altair/sanity/BUILD.bazel
+++ b/spectest/minimal/altair/sanity/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 # Requires --define ssz=minimal
 go_test(

--- a/spectest/minimal/altair/ssz_static/BUILD.bazel
+++ b/spectest/minimal/altair/ssz_static/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@prysm//tools/go:def.bzl", "go_test")
 
 # Requires --define ssz=minimal
 go_test(


### PR DESCRIPTION
Fixed e2e tests for Altair to be green. 

```go
minimalConfig.ForkVersionSchedule = map[[4]byte]types.Epoch{
		{0, 0, 0, 0}: 0, // Should have been {0, 0, 0, 1}
		{1, 0, 0, 1}: math.MaxUint64,
	}
```

Side changes, cleaned up `Fork()` implementation and ran gazelle which got changes from #9122 