### PR TITLE
Bazel: set alias targets to manual only

### DIFF
--- a/tools/target_migration.bzl
+++ b/tools/target_migration.bzl
@@ -4,4 +4,5 @@ def moved_targets(targets, new_package):
       name=target[1:],
       actual=new_package+target,
       deprecation="This target has moved to %s%s"%(new_package,target),
+      tags = ["manual"],
     )


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

These messages are annoying when running `bazel build //...`
```
target '//beacon-chain:beacon-chain' is deprecated: This target has moved to //cmd/beacon-chain:beacon-chain
```

**Which issues(s) does this PR fix?**

N/A - Cosmetic only

**Other notes for review**
