### PR TITLE
Update log test and `ChainInfoFetcher` interface

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -24,6 +24,7 @@ type ChainInfoFetcher interface {
 	FinalizationFetcher
 	GenesisFetcher
 	CanonicalFetcher
+	ForkFetcher
 }
 
 // TimeFetcher retrieves the Ethereum consensus data that's related to time.

--- a/beacon-chain/blockchain/log_test.go
+++ b/beacon-chain/blockchain/log_test.go
@@ -12,52 +12,53 @@ import (
 func Test_logStateTransitionData(t *testing.T) {
 	tests := []struct {
 		name string
-		b    *ethpb.BeaconBlock
+		b    interfaces.BeaconBlock
 		want string
 	}{
 		{name: "empty block body",
-			b:    &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{}},
+			b:    interfaces.WrappedPhase0BeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{}}),
 			want: "\"Finished applying state transition\" prefix=blockchain slot=0",
 		},
 		{name: "has attestation",
-			b:    &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{Attestations: []*ethpb.Attestation{{}}}},
+			b:    interfaces.WrappedPhase0BeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{Attestations: []*ethpb.Attestation{{}}}}),
 			want: "\"Finished applying state transition\" attestations=1 prefix=blockchain slot=0",
 		},
 		{name: "has deposit",
-			b: &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
-				Attestations: []*ethpb.Attestation{{}},
-				Deposits:     []*ethpb.Deposit{{}}}},
+			b: interfaces.WrappedPhase0BeaconBlock(
+				&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
+					Attestations: []*ethpb.Attestation{{}},
+					Deposits:     []*ethpb.Deposit{{}}}}),
 			want: "\"Finished applying state transition\" attestations=1 deposits=1 prefix=blockchain slot=0",
 		},
 		{name: "has attester slashing",
-			b: &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
-				AttesterSlashings: []*ethpb.AttesterSlashing{{}}}},
+			b: interfaces.WrappedPhase0BeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
+				AttesterSlashings: []*ethpb.AttesterSlashing{{}}}}),
 			want: "\"Finished applying state transition\" attesterSlashings=1 prefix=blockchain slot=0",
 		},
 		{name: "has proposer slashing",
-			b: &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
-				ProposerSlashings: []*ethpb.ProposerSlashing{{}}}},
+			b: interfaces.WrappedPhase0BeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
+				ProposerSlashings: []*ethpb.ProposerSlashing{{}}}}),
 			want: "\"Finished applying state transition\" prefix=blockchain proposerSlashings=1 slot=0",
 		},
 		{name: "has exit",
-			b: &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
-				VoluntaryExits: []*ethpb.SignedVoluntaryExit{{}}}},
+			b: interfaces.WrappedPhase0BeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
+				VoluntaryExits: []*ethpb.SignedVoluntaryExit{{}}}}),
 			want: "\"Finished applying state transition\" prefix=blockchain slot=0 voluntaryExits=1",
 		},
 		{name: "has everything",
-			b: &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
+			b: interfaces.WrappedPhase0BeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
 				Attestations:      []*ethpb.Attestation{{}},
 				Deposits:          []*ethpb.Deposit{{}},
 				AttesterSlashings: []*ethpb.AttesterSlashing{{}},
 				ProposerSlashings: []*ethpb.ProposerSlashing{{}},
-				VoluntaryExits:    []*ethpb.SignedVoluntaryExit{{}}}},
+				VoluntaryExits:    []*ethpb.SignedVoluntaryExit{{}}}}),
 			want: "\"Finished applying state transition\" attestations=1 attesterSlashings=1 deposits=1 prefix=blockchain proposerSlashings=1 slot=0 voluntaryExits=1",
 		},
 	}
 	for _, tt := range tests {
 		hook := logTest.NewGlobal()
 		t.Run(tt.name, func(t *testing.T) {
-			logStateTransitionData(interfaces.WrappedPhase0BeaconBlock(tt.b))
+			logStateTransitionData(tt.b)
 			require.LogsContain(t, hook, tt.want)
 		})
 	}


### PR DESCRIPTION
This PR brings in `blockchain` pkg specific changes from `hf1` branch
 - Added `ForkFetcher` to `ChainInfoFetcher` interface
 - Updated `Test_logStateTransitionData` to use proper interface