### PR TITLE
Add `Eth2FastAggregateVerify`

### DIFF
--- a/shared/bls/blst/signature_test.go
+++ b/shared/bls/blst/signature_test.go
@@ -94,6 +94,41 @@ func TestFastAggregateVerify_ReturnsFalseOnEmptyPubKeyList(t *testing.T) {
 	assert.Equal(t, false, aggSig.FastAggregateVerify(pubkeys, msg), "Expected FastAggregateVerify to return false with empty input ")
 }
 
+func TestEth2FastAggregateVerify(t *testing.T) {
+	pubkeys := make([]common.PublicKey, 0, 100)
+	sigs := make([]common.Signature, 0, 100)
+	msg := [32]byte{'h', 'e', 'l', 'l', 'o'}
+	for i := 0; i < 100; i++ {
+		priv, err := RandKey()
+		require.NoError(t, err)
+		pub := priv.PublicKey()
+		sig := priv.Sign(msg[:])
+		pubkeys = append(pubkeys, pub)
+		sigs = append(sigs, sig)
+	}
+	aggSig := AggregateSignatures(sigs)
+	assert.Equal(t, true, aggSig.Eth2FastAggregateVerify(pubkeys, msg), "Signature did not verify")
+
+}
+
+func TestEth2FastAggregateVerify_ReturnsFalseOnEmptyPubKeyList(t *testing.T) {
+	var pubkeys []common.PublicKey
+	msg := [32]byte{'h', 'e', 'l', 'l', 'o'}
+
+	aggSig := NewAggregateSignature()
+	assert.Equal(t, false, aggSig.Eth2FastAggregateVerify(pubkeys, msg), "Expected Eth2FastAggregateVerify to return false with empty input ")
+}
+
+func TestEth2FastAggregateVerify_ReturnsTrueOnG2PointAtInfinity(t *testing.T) {
+	var pubkeys []common.PublicKey
+	msg := [32]byte{'h', 'e', 'l', 'l', 'o'}
+
+	g2PointAtInfinity := append([]byte{0xC0}, make([]byte, 95)...)
+	aggSig, err := SignatureFromBytes(g2PointAtInfinity)
+	require.NoError(t, err)
+	assert.Equal(t, true, aggSig.Eth2FastAggregateVerify(pubkeys, msg))
+}
+
 func TestSignatureFromBytes(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/shared/bls/blst/stub.go
+++ b/shared/bls/blst/stub.go
@@ -73,6 +73,11 @@ func (s Signature) FastAggregateVerify(_ []common.PublicKey, _ [32]byte) bool {
 	panic(err)
 }
 
+// Eth2FastAggregateVerify -- stub
+func (s Signature) Eth2FastAggregateVerify(_ []common.PublicKey, _ [32]byte) bool {
+	panic(err)
+}
+
 // Marshal -- stub
 func (s Signature) Marshal() []byte {
 	panic(err)

--- a/shared/bls/common/interface.go
+++ b/shared/bls/common/interface.go
@@ -26,6 +26,7 @@ type Signature interface {
 	// Deprecated: Use FastAggregateVerify or use this method in spectests only.
 	AggregateVerify(pubKeys []PublicKey, msgs [][32]byte) bool
 	FastAggregateVerify(pubKeys []PublicKey, msg [32]byte) bool
+	Eth2FastAggregateVerify(pubKeys []PublicKey, msg [32]byte) bool
 	Marshal() []byte
 	Copy() Signature
 }


### PR DESCRIPTION
This PR adds `Eth2FastAggregateVerify` which was introduced in Altair, It is a wrapper on top of `FastAggregateVerify`. It accepts `G2_POINT_AT_INFINITY` signature.