### PR TITLE
Resolve Deep Source Warnings

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -41,11 +41,13 @@ var eth1DataNotification bool
 
 const eth1dataTimeout = 2 * time.Second
 
+// skipcq: SCT-U1000
 type eth1DataSingleVote struct {
 	eth1Data    *ethpb.Eth1Data
 	blockHeight *big.Int
 }
 
+// skipcq: SCT-U1000
 type eth1DataAggregatedVote struct {
 	data  eth1DataSingleVote
 	votes int
@@ -300,6 +302,7 @@ func (vs *Server) slotStartTime(slot types.Slot) uint64 {
 	return helpers.VotingPeriodStartTime(startTime, slot)
 }
 
+// skipcq: SCT-U1000
 func (vs *Server) inRangeVotes(ctx context.Context,
 	beaconState iface.ReadOnlyBeaconState,
 	firstValidBlockNumber, lastValidBlockNumber *big.Int) ([]eth1DataSingleVote, error) {
@@ -327,6 +330,7 @@ func (vs *Server) inRangeVotes(ctx context.Context,
 	return inRangeVotes, nil
 }
 
+// skipcq: SCT-U1000
 func chosenEth1DataMajorityVote(votes []eth1DataSingleVote) eth1DataAggregatedVote {
 	var voteCount []eth1DataAggregatedVote
 	for _, singleVote := range votes {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -41,13 +41,13 @@ var eth1DataNotification bool
 
 const eth1dataTimeout = 2 * time.Second
 
-// skipcq: SCT-1000
+// skipcq: SCC-U1000
 type eth1DataSingleVote struct {
 	eth1Data    *ethpb.Eth1Data
 	blockHeight *big.Int
 }
 
-// skipcq: SCT-1000
+// skipcq: SCC-U1000
 type eth1DataAggregatedVote struct {
 	data  eth1DataSingleVote
 	votes int
@@ -302,7 +302,7 @@ func (vs *Server) slotStartTime(slot types.Slot) uint64 {
 	return helpers.VotingPeriodStartTime(startTime, slot)
 }
 
-// skipcq: SCT-1000
+// skipcq: SCC-U1000
 func (vs *Server) inRangeVotes(ctx context.Context,
 	beaconState iface.ReadOnlyBeaconState,
 	firstValidBlockNumber, lastValidBlockNumber *big.Int) ([]eth1DataSingleVote, error) {
@@ -330,7 +330,7 @@ func (vs *Server) inRangeVotes(ctx context.Context,
 	return inRangeVotes, nil
 }
 
-// skipcq: SCT-1000
+// skipcq: SCC-U1000
 func chosenEth1DataMajorityVote(votes []eth1DataSingleVote) eth1DataAggregatedVote {
 	var voteCount []eth1DataAggregatedVote
 	for _, singleVote := range votes {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -41,13 +41,13 @@ var eth1DataNotification bool
 
 const eth1dataTimeout = 2 * time.Second
 
-// skipcq: SCT-U1000
+// skipcq: SCT-1000
 type eth1DataSingleVote struct {
 	eth1Data    *ethpb.Eth1Data
 	blockHeight *big.Int
 }
 
-// skipcq: SCT-U1000
+// skipcq: SCT-1000
 type eth1DataAggregatedVote struct {
 	data  eth1DataSingleVote
 	votes int
@@ -302,7 +302,7 @@ func (vs *Server) slotStartTime(slot types.Slot) uint64 {
 	return helpers.VotingPeriodStartTime(startTime, slot)
 }
 
-// skipcq: SCT-U1000
+// skipcq: SCT-1000
 func (vs *Server) inRangeVotes(ctx context.Context,
 	beaconState iface.ReadOnlyBeaconState,
 	firstValidBlockNumber, lastValidBlockNumber *big.Int) ([]eth1DataSingleVote, error) {
@@ -330,7 +330,7 @@ func (vs *Server) inRangeVotes(ctx context.Context,
 	return inRangeVotes, nil
 }
 
-// skipcq: SCT-U1000
+// skipcq: SCT-1000
 func chosenEth1DataMajorityVote(votes []eth1DataSingleVote) eth1DataAggregatedVote {
 	var voteCount []eth1DataAggregatedVote
 	for _, singleVote := range votes {

--- a/beacon-chain/sync/subscriber_sync_committee.go
+++ b/beacon-chain/sync/subscriber_sync_committee.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// skipcq: SCT-1000
+// skipcq: SCT-U1000
 func (s *Service) syncCommitteeSubscriber(_ context.Context, msg proto.Message) error {
 	m, ok := msg.(*prysmv2.SyncCommitteeMessage)
 	if !ok {

--- a/beacon-chain/sync/subscriber_sync_committee.go
+++ b/beacon-chain/sync/subscriber_sync_committee.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// skipcq: SCT-1000
 func (s *Service) syncCommitteeSubscriber(_ context.Context, msg proto.Message) error {
 	m, ok := msg.(*prysmv2.SyncCommitteeMessage)
 	if !ok {

--- a/beacon-chain/sync/subscriber_sync_committee.go
+++ b/beacon-chain/sync/subscriber_sync_committee.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// skipcq: SCT-1000
+// skipcq: SCC-U1000
 func (s *Service) syncCommitteeSubscriber(_ context.Context, msg proto.Message) error {
 	m, ok := msg.(*prysmv2.SyncCommitteeMessage)
 	if !ok {

--- a/beacon-chain/sync/subscriber_sync_committee.go
+++ b/beacon-chain/sync/subscriber_sync_committee.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// skipcq: SCT-U1000
+// skipcq: SCT-1000
 func (s *Service) syncCommitteeSubscriber(_ context.Context, msg proto.Message) error {
 	m, ok := msg.(*prysmv2.SyncCommitteeMessage)
 	if !ok {

--- a/beacon-chain/sync/subscriber_sync_contribution_proof.go
+++ b/beacon-chain/sync/subscriber_sync_contribution_proof.go
@@ -11,7 +11,7 @@ import (
 
 // syncContributionAndProofSubscriber forwards the incoming validated sync contributions and proof to the
 // contribution pool for processing.
-// skipcq: SCT-1000
+// skipcq: SCC-U1000
 func (s *Service) syncContributionAndProofSubscriber(_ context.Context, msg proto.Message) error {
 	a, ok := msg.(*prysmv2.SignedContributionAndProof)
 	if !ok {

--- a/beacon-chain/sync/subscriber_sync_contribution_proof.go
+++ b/beacon-chain/sync/subscriber_sync_contribution_proof.go
@@ -11,6 +11,7 @@ import (
 
 // syncContributionAndProofSubscriber forwards the incoming validated sync contributions and proof to the
 // contribution pool for processing.
+// skipcq: SCT-U1000
 func (s *Service) syncContributionAndProofSubscriber(_ context.Context, msg proto.Message) error {
 	a, ok := msg.(*prysmv2.SignedContributionAndProof)
 	if !ok {

--- a/beacon-chain/sync/subscriber_sync_contribution_proof.go
+++ b/beacon-chain/sync/subscriber_sync_contribution_proof.go
@@ -11,7 +11,7 @@ import (
 
 // syncContributionAndProofSubscriber forwards the incoming validated sync contributions and proof to the
 // contribution pool for processing.
-// skipcq: SCT-U1000
+// skipcq: SCT-1000
 func (s *Service) syncContributionAndProofSubscriber(_ context.Context, msg proto.Message) error {
 	a, ok := msg.(*prysmv2.SignedContributionAndProof)
 	if !ok {

--- a/shared/bls/blst/public_key.go
+++ b/shared/bls/blst/public_key.go
@@ -57,7 +57,7 @@ func AggregatePublicKeys(pubs [][]byte) (common.PublicKey, error) {
 	if featureconfig.Get().SkipBLSVerify {
 		return &PublicKey{}, nil
 	}
-	if pubs == nil || len(pubs) == 0 {
+	if len(pubs) == 0 {
 		return nil, errors.New("nil or empty public keys")
 	}
 	agg := new(blstAggregatePublicKey)

--- a/validator/client/aggregate.go
+++ b/validator/client/aggregate.go
@@ -116,7 +116,7 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot types.Slot
 }
 
 // Signs input slot with domain selection proof. This is used to create the signature for aggregator selection.
-func (v *validator) signSlotWithSelectionProof(ctx context.Context, pubKey [48]byte, slot types.Slot) (signature []byte, error error) {
+func (v *validator) signSlotWithSelectionProof(ctx context.Context, pubKey [48]byte, slot types.Slot) ([]byte, error) {
 	domain, err := v.domainData(ctx, helpers.SlotToEpoch(slot), params.BeaconConfig().DomainSelectionProof[:])
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
No tracking issue. This PR resolves a few deep source warnings that make every branch targeting `hf1` red. This is due to unused code we have regarding eth1 data voting and a few other small deep source issues