### PR TITLE
Align sync committee pipelines to alpha8

### DIFF
--- a/beacon-chain/sync/validate_sync_contrbution_proof.go
+++ b/beacon-chain/sync/validate_sync_contrbution_proof.go
@@ -23,15 +23,15 @@ import (
 // validateSyncContributionAndProof verifies the aggregated signature and the selection proof is valid before forwarding to the
 // network and downstream services.
 func (s *Service) validateSyncContributionAndProof(ctx context.Context, pid peer.ID, msg *pubsub.Message) pubsub.ValidationResult {
+	ctx, span := trace.StartSpan(ctx, "sync.validateSyncContributionAndProof")
+	defer span.End()
+
+	// Accept the sync committee contribution if the contribution came from itself.
 	if pid == s.cfg.P2P.PeerID() {
 		return pubsub.ValidationAccept
 	}
 
-	ctx, span := trace.StartSpan(ctx, "sync.validateSyncContributionAndProof")
-	defer span.End()
-
-	// To process the following it requires the recent blocks to be present in the database, so we'll skip
-	// validating or processing aggregated attestations until fully synced.
+	// Ignore the sync committee contribution if the beacon node is syncing.
 	if s.cfg.InitialSync.Syncing() {
 		return pubsub.ValidationIgnore
 	}
@@ -46,32 +46,37 @@ func (s *Service) validateSyncContributionAndProof(ctx context.Context, pid peer
 	if !ok {
 		return pubsub.ValidationReject
 	}
-	if m.Message == nil {
+	if m == nil || m.Message == nil {
 		return pubsub.ValidationReject
 	}
 	if err := altair.ValidateNilSyncContribution(m); err != nil {
 		return pubsub.ValidationReject
 	}
 
+	// The contribution's `slot` is for the current slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance).
 	if err := helpers.VerifySlotTime(uint64(s.cfg.Chain.GenesisTime().Unix()), m.Message.Contribution.Slot, params.BeaconNetworkConfig().MaximumGossipClockDisparity); err != nil {
 		traceutil.AnnotateError(span, err)
 		return pubsub.ValidationIgnore
 	}
-	if !s.hasBlockAndState(ctx, bytesutil.ToBytes32(m.Message.Contribution.BlockRoot)) {
-		return pubsub.ValidationIgnore
-	}
+
+	// The subcommittee index is in the allowed range, i.e. `contribution.subcommittee_index` < `SYNC_COMMITTEE_SUBNET_COUNT`.
 	if m.Message.Contribution.SubcommitteeIndex >= params.BeaconConfig().SyncCommitteeSubnetCount {
 		return pubsub.ValidationReject
 	}
 
+	// The sync committee contribution is the first valid contribution received for the aggregator with index
+	// `contribution_and_proof.aggregator_index` for the slot `contribution.slot` and subcommittee index `contribution.subcommittee_index`.
 	if s.hasSeenSyncContributionIndexSlot(m.Message.Contribution.Slot, m.Message.AggregatorIndex, types.CommitteeIndex(m.Message.Contribution.SubcommitteeIndex)) {
 		return pubsub.ValidationIgnore
 	}
+
+	// The `contribution_and_proof.selection_proof` selects the validator as an aggregator for the slot.
 	if !altair.IsSyncCommitteeAggregator(m.Message.SelectionProof) {
 		return pubsub.ValidationReject
 	}
-	// This could be better, retrieving the state multiple times with copies can
-	// easily lead to higher resource consumption by the node.
+
+	// The aggregator's validator index is in the declared subcommittee of the current sync committee.
+	// This could be better, retrieving the state multiple times with copies can easily lead to higher resource consumption by the node.
 	blkState, err := s.cfg.StateGen.StateByRoot(ctx, bytesutil.ToBytes32(m.Message.Contribution.BlockRoot))
 	if err != nil {
 		traceutil.AnnotateError(span, err)
@@ -93,20 +98,24 @@ func (s *Service) validateSyncContributionAndProof(ctx context.Context, pid peer
 		return pubsub.ValidationIgnore
 	}
 	aggPubkey := aggregator.PublicKey()
-	keyIsValid := false
+	isValid := false
 	for _, pk := range syncPubkeys {
 		if bytes.Equal(pk, aggPubkey[:]) {
-			keyIsValid = true
+			isValid = true
 			break
 		}
 	}
-	if !keyIsValid {
+	if !isValid {
 		return pubsub.ValidationReject
 	}
+
+	// The `contribution_and_proof.selection_proof` is a valid signature of the `SyncAggregatorSelectionData`.
 	if err := altair.VerifySyncSelectionData(bState, m.Message); err != nil {
 		traceutil.AnnotateError(span, err)
 		return pubsub.ValidationReject
 	}
+
+	// The aggregator signature, `signed_contribution_and_proof.signature`, is valid.
 	d, err := helpers.Domain(bState.Fork(), helpers.SlotToEpoch(bState.Slot()), params.BeaconConfig().DomainContributionAndProof, bState.GenesisValidatorRoot())
 	if err != nil {
 		traceutil.AnnotateError(span, err)
@@ -116,9 +125,11 @@ func (s *Service) validateSyncContributionAndProof(ctx context.Context, pid peer
 		traceutil.AnnotateError(span, err)
 		return pubsub.ValidationReject
 	}
+
+	// The aggregate signature is valid for the message `beacon_block_root` and aggregate pubkey
+	// derived from the participation info in `aggregation_bits` for the subcommittee specified by the `contribution.subcommittee_index`.
 	activePubkeys := []bls.PublicKey{}
 	bVector := m.Message.Contribution.AggregationBits
-
 	for i, pk := range syncPubkeys {
 		if bVector.BitAt(uint64(i)) {
 			pubK, err := bls.PublicKeyFromBytes(pk)


### PR DESCRIPTION
This PR aligns sync committee (message/contribution) pipelines to alpha8. Change list:
 - `hasSeenSyncMessageIndexSlot`'s key mixed with subcommittee index
 -  removed has block and state requirement
 - added more commentary of individual checks 
 - added one more test case `is_syncing`, the general test coverages > 70%