### PR TITLE
Add sync committee metrics for operation pool

### DIFF
--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -37,7 +37,7 @@ func logStateTransitionData(b interfaces.BeaconBlock) {
 	if b.Version() == version.Altair {
 		agg, err := b.Body().SyncAggregate()
 		if err == nil {
-			log = log.WithField("syncAggBitsCount", agg.SyncCommitteeBits.Count())
+			log = log.WithField("syncBitsCount", agg.SyncCommitteeBits.Count())
 		}
 	}
 	log.Info("Finished applying state transition")

--- a/beacon-chain/operations/synccommittee/BUILD.bazel
+++ b/beacon-chain/operations/synccommittee/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "error.go",
         "kv.go",
         "message.go",
+        "metric.go",
         "pool.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/operations/synccommittee",
@@ -16,6 +17,8 @@ go_library(
         "//shared/copyutil:go_default_library",
         "//shared/queue:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
     ],
 )

--- a/beacon-chain/operations/synccommittee/contribution.go
+++ b/beacon-chain/operations/synccommittee/contribution.go
@@ -33,6 +33,7 @@ func (s *Store) SaveSyncCommitteeContribution(cont *prysmv2.SyncCommitteeContrib
 	// Contributions exist in the queue. Append instead of insert new.
 	if contributions != nil {
 		contributions = append(contributions, copied)
+		savedSyncCommitteeContributionTotal.Inc()
 		return s.contributionCache.Push(&queue.Item{
 			Key:      syncCommitteeKey(cont.Slot),
 			Value:    contributions,
@@ -48,6 +49,7 @@ func (s *Store) SaveSyncCommitteeContribution(cont *prysmv2.SyncCommitteeContrib
 	}); err != nil {
 		return err
 	}
+	savedSyncCommitteeContributionTotal.Inc()
 
 	// Trim contributions in queue down to syncCommitteeMaxQueueSize.
 	if s.contributionCache.Len() > syncCommitteeMaxQueueSize {

--- a/beacon-chain/operations/synccommittee/message.go
+++ b/beacon-chain/operations/synccommittee/message.go
@@ -32,6 +32,7 @@ func (s *Store) SaveSyncCommitteeMessage(msg *prysmv2.SyncCommitteeMessage) erro
 		}
 
 		messages = append(messages, copied)
+		savedSyncCommitteeMessageTotal.Inc()
 		return s.messageCache.Push(&queue.Item{
 			Key:      syncCommitteeKey(msg.Slot),
 			Value:    messages,
@@ -47,6 +48,7 @@ func (s *Store) SaveSyncCommitteeMessage(msg *prysmv2.SyncCommitteeMessage) erro
 	}); err != nil {
 		return err
 	}
+	savedSyncCommitteeMessageTotal.Inc()
 
 	// Trim messages in queue down to syncCommitteeMaxQueueSize.
 	if s.messageCache.Len() > syncCommitteeMaxQueueSize {

--- a/beacon-chain/operations/synccommittee/metric.go
+++ b/beacon-chain/operations/synccommittee/metric.go
@@ -1,0 +1,17 @@
+package synccommittee
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	savedSyncCommitteeMessageTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "saved_sync_committee_message_total",
+		Help: "The number of saved sync committee message total.",
+	})
+	savedSyncCommitteeContributionTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "saved_sync_committee_contribution_total",
+		Help: "The number of saved sync committee contribution total.",
+	})
+)

--- a/validator/client/sync_committee.go
+++ b/validator/client/sync_committee.go
@@ -158,6 +158,7 @@ func (v *validator) SubmitSignedContributionAndProof(ctx context.Context, slot t
 			"blockRoot":         fmt.Sprintf("%#x", bytesutil.Trunc(contributionAndProof.Contribution.BlockRoot)),
 			"subcommitteeIndex": contributionAndProof.Contribution.SubcommitteeIndex,
 			"aggregatorIndex":   contributionAndProof.AggregatorIndex,
+			"bitsCount":         contributionAndProof.Contribution.AggregationBits.Count(),
 		}).Info("Submitted new sync contribution and proof")
 	}
 }


### PR DESCRIPTION
Adding more metrics for saving sync committee message/contribution for the operation pool. This makes it easy to observe whether sync pipeline or sync validator duties are working as a whole