### PR TITLE
End-to-End Test Suite For Synced Slasher Node

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -590,6 +590,10 @@ func (b *BeaconNode) registerSlasherService() error {
 	if err := b.services.FetchService(&chainService); err != nil {
 		return err
 	}
+	var syncService *initialsync.Service
+	if err := b.services.FetchService(&syncService); err != nil {
+		return err
+	}
 
 	slasherSrv, err := slasher.New(b.ctx, &slasher.ServiceConfig{
 		IndexedAttestationsFeed: b.slasherAttestationsFeed,
@@ -600,6 +604,7 @@ func (b *BeaconNode) registerSlasherService() error {
 		StateGen:                b.stateGen,
 		SlashingPoolInserter:    b.slashingsPool,
 		HeadStateFetcher:        chainService,
+		SyncChecker:             syncService,
 	})
 	if err != nil {
 		return err

--- a/endtoend/BUILD.bazel
+++ b/endtoend/BUILD.bazel
@@ -10,8 +10,8 @@ go_test(
         "endtoend_test.go",
         "minimal_e2e_test.go",
         "slasher_e2e_test.go",
-        "slasher_sync_e2e_test.go",
         "slasher_simulator_e2e_test.go",
+        "slasher_sync_e2e_test.go",
     ],
     args = ["-test.v"],
     data = [

--- a/endtoend/BUILD.bazel
+++ b/endtoend/BUILD.bazel
@@ -9,7 +9,8 @@ go_test(
     srcs = [
         "endtoend_test.go",
         "minimal_e2e_test.go",
-        "minimal_slashing_e2e_test.go",
+        "slasher_e2e_test.go",
+        "slasher_sync_e2e_test.go",
         "slasher_simulator_e2e_test.go",
     ],
     args = ["-test.v"],

--- a/endtoend/evaluators/finality.go
+++ b/endtoend/evaluators/finality.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	ethtypes "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/endtoend/policies"
 	"github.com/prysmaticlabs/prysm/endtoend/types"
 	eth "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
@@ -14,10 +15,12 @@ import (
 
 // FinalizationOccurs is an evaluator to make sure finalization is performing as it should.
 // Requires to be run after at least 4 epochs have passed.
-var FinalizationOccurs = types.Evaluator{
-	Name:       "finalizes_at_epoch_%d",
-	Policy:     policies.AfterNthEpoch(3),
-	Evaluation: finalizationOccurs,
+var FinalizationOccurs = func(epoch ethtypes.Epoch) types.Evaluator {
+	return types.Evaluator{
+		Name:       "finalizes_at_epoch_%d",
+		Policy:     policies.AfterNthEpoch(epoch),
+		Evaluation: finalizationOccurs,
+	}
 }
 
 func finalizationOccurs(conns ...*grpc.ClientConn) error {

--- a/endtoend/evaluators/node.go
+++ b/endtoend/evaluators/node.go
@@ -39,7 +39,7 @@ var HealthzCheck = e2etypes.Evaluator{
 
 // FinishedSyncing returns whether the beacon node with the given rpc port has finished syncing.
 var FinishedSyncing = e2etypes.Evaluator{
-	Name:       "finished_syncing",
+	Name:       "finished_syncing_%d",
 	Policy:     policies.AllEpochs,
 	Evaluation: finishedSyncing,
 }
@@ -47,7 +47,7 @@ var FinishedSyncing = e2etypes.Evaluator{
 // AllNodesHaveSameHead ensures all nodes have the same head epoch. Checks finality and justification as well.
 // Not checking head block root as it may change irregularly for the validator connected nodes.
 var AllNodesHaveSameHead = e2etypes.Evaluator{
-	Name:       "all_nodes_have_same_head",
+	Name:       "all_nodes_have_same_head_%d",
 	Policy:     policies.AllEpochs,
 	Evaluation: allNodesHaveSameHead,
 }

--- a/endtoend/evaluators/slashing.go
+++ b/endtoend/evaluators/slashing.go
@@ -20,32 +20,40 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-// InjectDoubleVote broadcasts a double vote into the beacon node pool for the slasher to detect.
-var InjectDoubleVote = e2eTypes.Evaluator{
-	Name:       "inject_double_vote_%d",
-	Policy:     policies.OnEpoch(1),
-	Evaluation: insertDoubleAttestationIntoPool,
+// InjectDoubleVoteOnEpoch broadcasts a double vote into the beacon node pool for the slasher to detect.
+var InjectDoubleVoteOnEpoch = func(n types.Epoch) e2eTypes.Evaluator {
+	return e2eTypes.Evaluator{
+		Name:       "inject_double_vote_%d",
+		Policy:     policies.OnEpoch(n),
+		Evaluation: insertDoubleAttestationIntoPool,
+	}
 }
 
-// ProposeDoubleBlock broadcasts a double block to the beacon node for the slasher to detect.
-var ProposeDoubleBlock = e2eTypes.Evaluator{
-	Name:       "propose_double_block_%d",
-	Policy:     policies.OnEpoch(1),
-	Evaluation: proposeDoubleBlock,
+// InjectDoubleBlockOnEpoch proposes a double block to the beacon node for the slasher to detect.
+var InjectDoubleBlockOnEpoch = func(n types.Epoch) e2eTypes.Evaluator {
+	return e2eTypes.Evaluator{
+		Name:       "inject_double_block_%d",
+		Policy:     policies.OnEpoch(n),
+		Evaluation: proposeDoubleBlock,
+	}
 }
 
-// ValidatorsSlashed ensures the expected amount of validators are slashed.
-var ValidatorsSlashed = e2eTypes.Evaluator{
-	Name:       "validators_slashed_epoch_%d",
-	Policy:     policies.AfterNthEpoch(2),
-	Evaluation: validatorsSlashed,
+// ValidatorsSlashedAfterEpoch ensures the expected amount of validators are slashed.
+var ValidatorsSlashedAfterEpoch = func(n types.Epoch) e2eTypes.Evaluator {
+	return e2eTypes.Evaluator{
+		Name:       "validators_slashed_epoch_%d",
+		Policy:     policies.AfterNthEpoch(n),
+		Evaluation: validatorsSlashed,
+	}
 }
 
-// SlashedValidatorsLoseBalance checks if the validators slashed lose the right balance.
-var SlashedValidatorsLoseBalance = e2eTypes.Evaluator{
-	Name:       "slashed_validators_lose_valance_epoch_%d",
-	Policy:     policies.AfterNthEpoch(4),
-	Evaluation: validatorsLoseBalance,
+// SlashedValidatorsLoseBalanceAfterEpoch checks if the validators slashed lose the right balance.
+var SlashedValidatorsLoseBalanceAfterEpoch = func(n types.Epoch) e2eTypes.Evaluator {
+	return e2eTypes.Evaluator{
+		Name:       "slashed_validators_lose_valance_epoch_%d",
+		Policy:     policies.AfterNthEpoch(n),
+		Evaluation: validatorsLoseBalance,
+	}
 }
 
 var slashedIndices []uint64

--- a/endtoend/evaluators/validator.go
+++ b/endtoend/evaluators/validator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	ethtypes "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/endtoend/policies"
 	"github.com/prysmaticlabs/prysm/endtoend/types"
 	eth "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
@@ -22,10 +23,12 @@ var ValidatorsAreActive = types.Evaluator{
 }
 
 // ValidatorsParticipating ensures the expected amount of validators are active.
-var ValidatorsParticipating = types.Evaluator{
-	Name:       "validators_participating_epoch_%d",
-	Policy:     policies.AfterNthEpoch(2),
-	Evaluation: validatorsParticipating,
+var ValidatorsParticipatingAtEpoch = func(epoch ethtypes.Epoch) types.Evaluator {
+	return types.Evaluator{
+		Name:       "validators_participating_epoch_%d",
+		Policy:     policies.AfterNthEpoch(epoch),
+		Evaluation: validatorsParticipating,
+	}
 }
 
 func validatorsAreActive(conns ...*grpc.ClientConn) error {

--- a/endtoend/minimal_e2e_test.go
+++ b/endtoend/minimal_e2e_test.go
@@ -41,6 +41,7 @@ func e2eMinimal(t *testing.T, usePrysmSh bool) {
 		},
 		ValidatorFlags:      []string{},
 		EpochsToRun:         uint64(epochsToRun),
+		EpochsToRunPostSync: 1,
 		TestSync:            true,
 		TestDeposits:        true,
 		UsePrysmShValidator: usePrysmSh,
@@ -50,8 +51,8 @@ func e2eMinimal(t *testing.T, usePrysmSh bool) {
 			ev.HealthzCheck,
 			ev.MetricsCheck,
 			ev.ValidatorsAreActive,
-			ev.ValidatorsParticipating,
-			ev.FinalizationOccurs,
+			ev.ValidatorsParticipatingAtEpoch(2),
+			ev.FinalizationOccurs(3),
 			ev.ProcessesDepositsInBlocks,
 			ev.VerifyBlockGraffiti,
 			ev.ActivatesDepositedValidators,
@@ -61,6 +62,10 @@ func e2eMinimal(t *testing.T, usePrysmSh bool) {
 			ev.ValidatorsVoteWithTheMajority,
 			ev.ColdStateCheckpoint,
 			ev.ApiVerifyValidators,
+		},
+		PostSyncEvaluators: []types.Evaluator{
+			ev.FinishedSyncing,
+			ev.AllNodesHaveSameHead,
 		},
 	}
 

--- a/endtoend/slasher_e2e_test.go
+++ b/endtoend/slasher_e2e_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 )
 
-func TestEndToEnd_Slashing_MinimalConfig(t *testing.T) {
+func TestEndToEnd_Slasher_MinimalConfig(t *testing.T) {
 	params.UseE2EConfig()
 	require.NoError(t, e2eParams.Init(e2eParams.StandardBeaconCount))
 

--- a/endtoend/slasher_e2e_test.go
+++ b/endtoend/slasher_e2e_test.go
@@ -25,10 +25,10 @@ func TestEndToEnd_Slasher_MinimalConfig(t *testing.T) {
 		Evaluators: []types.Evaluator{
 			ev.PeersConnect,
 			ev.HealthzCheck,
-			ev.ValidatorsSlashed,
-			ev.SlashedValidatorsLoseBalance,
-			ev.InjectDoubleVote,
-			ev.ProposeDoubleBlock,
+			ev.ValidatorsSlashedAfterEpoch(4),
+			ev.SlashedValidatorsLoseBalanceAfterEpoch(4),
+			ev.InjectDoubleVoteOnEpoch(2),
+			ev.InjectDoubleBlockOnEpoch(2),
 		},
 	}
 

--- a/endtoend/slasher_sync_e2e_test.go
+++ b/endtoend/slasher_sync_e2e_test.go
@@ -30,7 +30,6 @@ func TestEndToEnd_Slasher_Sync_MinimalConfig(t *testing.T) {
 		TestDeposits:        false,
 		Evaluators: []types.Evaluator{
 			ev.HealthzCheck,
-			ev.MetricsCheck,
 			ev.ValidatorsAreActive,
 			ev.ValidatorsParticipatingAtEpoch(2),
 			ev.FinalizationOccurs(3),
@@ -42,7 +41,7 @@ func TestEndToEnd_Slasher_Sync_MinimalConfig(t *testing.T) {
 			ev.AllNodesHaveSameHead,
 			ev.ValidatorsParticipatingAtEpoch(6), // Validators should still be participating.
 			ev.ValidatorsSlashedAfterEpoch(5),    // We expect validators are slashed.
-			// ev.SlashedValidatorsLoseBalanceAfterEpoch(5),
+			ev.SlashedValidatorsLoseBalanceAfterEpoch(5),
 		},
 	}
 

--- a/endtoend/slasher_sync_e2e_test.go
+++ b/endtoend/slasher_sync_e2e_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestEndToEnd_Slasher_Sync_MinimalConfig(t *testing.T) {
+	t.Skip("Skipping until functionality is written that makes this pass")
 	params.UseE2EConfig()
 
 	// We start some beacon nodes to test with and attach validators to.

--- a/endtoend/slasher_sync_e2e_test.go
+++ b/endtoend/slasher_sync_e2e_test.go
@@ -1,0 +1,50 @@
+package endtoend
+
+import (
+	"testing"
+
+	ev "github.com/prysmaticlabs/prysm/endtoend/evaluators"
+	e2eParams "github.com/prysmaticlabs/prysm/endtoend/params"
+	"github.com/prysmaticlabs/prysm/endtoend/types"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestEndToEnd_Slasher_Sync_MinimalConfig(t *testing.T) {
+	params.UseE2EConfig()
+
+	// We start some beacon nodes to test with and attach validators to.
+	// Then, we test chain sync by running a single beacon node which
+	// will have the --slasher flag set to true.
+	require.NoError(t, e2eParams.Init(2))
+
+	testConfig := &types.E2EConfig{
+		// Only the syncing beacon node should have the --slasher flag enabled.
+		SyncingBeaconFlags: []string{
+			"--slasher",
+		},
+		ValidatorFlags:      []string{},
+		EpochsToRun:         4,    // Normally run a node for 4 epochs.
+		EpochsToRunPostSync: 3,    // Sync a node, then run that node for 3 more epochs.
+		TestSync:            true, // We want to test a second beacon node with --slasher syncing the chain.
+		TestDeposits:        false,
+		Evaluators: []types.Evaluator{
+			ev.HealthzCheck,
+			ev.MetricsCheck,
+			ev.ValidatorsAreActive,
+			ev.ValidatorsParticipatingAtEpoch(2),
+			ev.FinalizationOccurs(3),
+			ev.InjectDoubleVoteOnEpoch(3),
+			ev.InjectDoubleBlockOnEpoch(3),
+		},
+		PostSyncEvaluators: []types.Evaluator{
+			ev.FinishedSyncing,
+			ev.AllNodesHaveSameHead,
+			ev.ValidatorsParticipatingAtEpoch(6), // Validators should still be participating.
+			ev.ValidatorsSlashedAfterEpoch(5),    // We expect validators are slashed.
+			// ev.SlashedValidatorsLoseBalanceAfterEpoch(5),
+		},
+	}
+
+	newTestRunner(t, testConfig).run()
+}

--- a/endtoend/slasher_sync_e2e_test.go
+++ b/endtoend/slasher_sync_e2e_test.go
@@ -27,7 +27,6 @@ func TestEndToEnd_Slasher_Sync_MinimalConfig(t *testing.T) {
 		EpochsToRun:         4,    // Normally run a node for 4 epochs.
 		EpochsToRunPostSync: 3,    // Sync a node, then run that node for 3 more epochs.
 		TestSync:            true, // We want to test a second beacon node with --slasher syncing the chain.
-		TestDeposits:        false,
 		Evaluators: []types.Evaluator{
 			ev.HealthzCheck,
 			ev.ValidatorsAreActive,
@@ -39,9 +38,9 @@ func TestEndToEnd_Slasher_Sync_MinimalConfig(t *testing.T) {
 		PostSyncEvaluators: []types.Evaluator{
 			ev.FinishedSyncing,
 			ev.AllNodesHaveSameHead,
-			ev.ValidatorsParticipatingAtEpoch(6), // Validators should still be participating.
-			ev.ValidatorsSlashedAfterEpoch(5),    // We expect validators are slashed.
-			ev.SlashedValidatorsLoseBalanceAfterEpoch(5),
+			ev.ValidatorsParticipatingAtEpoch(6),         // Validators should still be participating.
+			ev.ValidatorsSlashedAfterEpoch(5),            // We expect validators are slashed.
+			ev.SlashedValidatorsLoseBalanceAfterEpoch(5), // We expect slashed validator will lose balance.
 		},
 	}
 

--- a/endtoend/slasher_sync_e2e_test.go
+++ b/endtoend/slasher_sync_e2e_test.go
@@ -27,6 +27,7 @@ func TestEndToEnd_Slasher_Sync_MinimalConfig(t *testing.T) {
 		EpochsToRun:         4,    // Normally run a node for 4 epochs.
 		EpochsToRunPostSync: 3,    // Sync a node, then run that node for 3 more epochs.
 		TestSync:            true, // We want to test a second beacon node with --slasher syncing the chain.
+		TestDeposits:        false,
 		Evaluators: []types.Evaluator{
 			ev.HealthzCheck,
 			ev.ValidatorsAreActive,

--- a/endtoend/types/types.go
+++ b/endtoend/types/types.go
@@ -12,13 +12,16 @@ import (
 // E2EConfig defines the struct for all configurations needed for E2E testing.
 type E2EConfig struct {
 	BeaconFlags         []string
+	SyncingBeaconFlags  []string // Flags for a beacon node that will attempt to sync after e2e evaluation.
 	ValidatorFlags      []string
 	EpochsToRun         uint64
+	EpochsToRunPostSync uint64
 	TestSync            bool
 	TestDeposits        bool
 	UsePprof            bool
 	UsePrysmShValidator bool
-	Evaluators          []Evaluator
+	Evaluators          []Evaluator // Evaluators that run on regular beacon nodes in the E2E test.
+	PostSyncEvaluators  []Evaluator // Evaluators that will be run after a beacon node syncs.
 }
 
 // Evaluator defines the structure of the evaluators used to


### PR DESCRIPTION
## Background

We believe there is a gap in slasher where if

(a) There are beacon nodes and validators running
(b) Some validator, `v`, produces an attestation before some epoch, `N`
(c) A beacon node with --slasher joins the network after epoch `N` and syncs the chain
(d) Validator `v` produces a slashable offense after epoch `N`

The slasher from part (c) did not join until after epoch `N`, therefore slasher did not have a record of validator `v` producing a slashable offense. This would mean slasher would **not** catch the offense from part (d). We believe this can be resolved by performing a backfilling routine from the epoch slasher syncs to minus `WEAK_SUBJECTIVITY_PERIOD` epochs to populate its history.

To prove this, we can start with an end-to-end test which demonstrates the scenario above.

**What does this PR do? Why is it needed?**

This PR adds an end-to-end test suite for running a beacon node + validators and _then_ syncing a beacon node and evaluating policies on the synced node. Currently, we have a primitive way of doing this that does not allow much customization on testing the synced node.

Using the addition mentioned above, this PR also sets up an example end-to-end test which

(a) Runs beacon nodes and validators
(b) At some epoch `N`, we sync a new beacon node with --slasher from peers
(c) Some validator produces a slashable offense after epoch `N`
(d) We expect slasher **will not catch** the slashable offense in its current form

A red test is a successful result of this PR. The plan is to then turn that test **green** in another PR.

**Which issues(s) does this PR fix?**

Part of #8331 

**NOTE**: Marked as draft until this test becomes green after adding the slasher backfilling logic