### PR TITLE
Remove Non Spec Config Variables

### DIFF
--- a/beacon-chain/p2p/fork.go
+++ b/beacon-chain/p2p/fork.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -94,21 +93,10 @@ func addForkEntry(
 	if timeutils.Now().Before(genesisTime) {
 		currentEpoch = 0
 	}
-	fork, err := p2putils.Fork(currentEpoch)
-	if err != nil {
-		return nil, err
-	}
-
-	nextForkEpoch := params.BeaconConfig().NextForkEpoch
-	nextForkVersion := params.BeaconConfig().NextForkVersion
-	// Set to the current fork version if our next fork is not planned.
-	if nextForkEpoch == math.MaxUint64 || nextForkEpoch <= currentEpoch {
-		nextForkVersion = fork.CurrentVersion
-		nextForkEpoch = math.MaxUint64
-	}
+	nextForkVersion, nextForkEpoch := p2putils.NextForkData(currentEpoch)
 	enrForkID := &pb.ENRForkID{
 		CurrentForkDigest: digest[:],
-		NextForkVersion:   nextForkVersion,
+		NextForkVersion:   nextForkVersion[:],
 		NextForkEpoch:     nextForkEpoch,
 	}
 	enc, err := enrForkID.MarshalSSZ()

--- a/beacon-chain/p2p/fork_test.go
+++ b/beacon-chain/p2p/fork_test.go
@@ -144,7 +144,7 @@ func TestStartDiscv5_SameForkDigests_DifferentNextForkData(t *testing.T) {
 
 		c := params.BeaconConfig()
 		nextForkEpoch := types.Epoch(i)
-		c.NextForkEpoch = nextForkEpoch
+		c.ForkVersionSchedule[[4]byte{'A', 'B', 'C', 'D'}] = nextForkEpoch
 		params.OverrideBeaconConfig(c)
 
 		// We give every peer a different genesis validators root, which
@@ -215,8 +215,6 @@ func TestDiscv5_AddRetrieveForkEntryENR(t *testing.T) {
 	}
 	nextForkEpoch := types.Epoch(1)
 	nextForkVersion := []byte{0, 0, 0, 1}
-	c.NextForkEpoch = nextForkEpoch
-	c.NextForkVersion = nextForkVersion
 	params.OverrideBeaconConfig(c)
 
 	genesisTime := time.Now()

--- a/beacon-chain/p2p/fork_test.go
+++ b/beacon-chain/p2p/fork_test.go
@@ -253,6 +253,7 @@ func TestDiscv5_AddRetrieveForkEntryENR(t *testing.T) {
 }
 
 func TestAddForkEntry_Genesis(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
 	temp := t.TempDir()
 	randNum := rand.Int()
 	tempPath := path.Join(temp, strconv.Itoa(randNum))
@@ -261,6 +262,11 @@ func TestAddForkEntry_Genesis(t *testing.T) {
 	require.NoError(t, err, "Could not get private key")
 	db, err := enode.OpenDB("")
 	require.NoError(t, err)
+
+	bCfg := params.BeaconConfig()
+	bCfg.ForkVersionSchedule = map[[4]byte]types.Epoch{}
+	bCfg.ForkVersionSchedule[bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion)] = bCfg.GenesisEpoch
+	params.OverrideBeaconConfig(bCfg)
 
 	localNode := enode.NewLocalNode(db, pkey)
 	localNode, err = addForkEntry(localNode, time.Now().Add(10*time.Second), bytesutil.PadTo([]byte{'A', 'B', 'C', 'D'}, 32))

--- a/shared/p2putils/fork.go
+++ b/shared/p2putils/fork.go
@@ -137,7 +137,7 @@ func NextForkData(currEpoch types.Epoch) ([4]byte, types.Epoch) {
 		}
 		// In the event the retrieved epoch is less than
 		// our current epoch, we mark the previous
-		// fork's version as the next fork version..
+		// fork's version as the next fork version.
 		if epoch <= currEpoch {
 			// The next fork version is updated to
 			// always include the most current fork version.

--- a/shared/p2putils/fork.go
+++ b/shared/p2putils/fork.go
@@ -119,7 +119,8 @@ func RetrieveForkDataFromDigest(digest [4]byte, genesisValidatorsRoot []byte) ([
 	return [4]byte{}, 0, errors.Errorf("no fork exists for a digest of %#x", digest)
 }
 
-// NextForkData retrieves the next fork data.
+// NextForkData retrieves the next fork data according to the
+// provided current epoch.
 func NextForkData(currEpoch types.Epoch) ([4]byte, types.Epoch) {
 	fSchedule := params.BeaconConfig().ForkVersionSchedule
 	sortedForkVersions := SortedForkVersions(fSchedule)

--- a/shared/p2putils/fork.go
+++ b/shared/p2putils/fork.go
@@ -125,22 +125,20 @@ func NextForkData(currEpoch types.Epoch) ([4]byte, types.Epoch) {
 	sortedForkVersions := SortedForkVersions(fSchedule)
 	nextForkEpoch := types.Epoch(math.MaxUint64)
 	nextForkVersion := [4]byte{}
-	previousForkHappened := false
 	for _, forkVersion := range sortedForkVersions {
 		epoch := fSchedule[forkVersion]
 		// If we get an epoch larger than out current epoch
 		// we set this as our next fork epoch and exit the
 		// loop.
-		if previousForkHappened && epoch > currEpoch {
+		if epoch > currEpoch {
 			nextForkEpoch = epoch
 			nextForkVersion = forkVersion
 			break
 		}
 		// In the event the retrieved epoch is less than
 		// our current epoch, we mark the previous
-		// fork as having happened.
+		// fork's version as the next fork version..
 		if epoch <= currEpoch {
-			previousForkHappened = true
 			// The next fork version is updated to
 			// always include the most current fork version.
 			nextForkVersion = forkVersion

--- a/shared/params/config.go
+++ b/shared/params/config.go
@@ -130,8 +130,6 @@ type BeaconChainConfig struct {
 	GenesisForkVersion  []byte                  `yaml:"GENESIS_FORK_VERSION" spec:"true"` // GenesisForkVersion is used to track fork version between state transitions.
 	AltairForkVersion   []byte                  `yaml:"ALTAIR_FORK_VERSION" spec:"true"`  // AltairForkVersion is used to represent the fork version for altair.
 	AltairForkEpoch     types.Epoch             `yaml:"ALTAIR_FORK_EPOCH" spec:"true"`    // AltairForkEpoch is used to represent the assigned fork epoch for altair.
-	NextForkVersion     []byte                  `yaml:"NEXT_FORK_VERSION"`                // NextForkVersion is used to track the upcoming fork version, if any.
-	NextForkEpoch       types.Epoch             `yaml:"NEXT_FORK_EPOCH"`                  // NextForkEpoch is used to track the epoch of the next fork, if any.
 	ForkVersionSchedule map[[4]byte]types.Epoch // Schedule of fork epochs by version.
 
 	// Weak subjectivity values.

--- a/shared/params/mainnet_config.go
+++ b/shared/params/mainnet_config.go
@@ -186,9 +186,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	// Fork related values.
 	GenesisForkVersion: []byte{0, 0, 0, 0},
 	AltairForkVersion:  []byte{1, 0, 0, 0},
-	AltairForkEpoch:    altairForkEpoch,    // Set to Max Uint64 for now.
-	NextForkVersion:    []byte{1, 0, 0, 0}, // Set to GenesisForkVersion unless there is a scheduled fork
-	NextForkEpoch:      altairForkEpoch,    // Set to FarFutureEpoch unless there is a scheduled fork.
+	AltairForkEpoch:    altairForkEpoch, // Set to Max Uint64 for now.
 	ForkVersionSchedule: map[[4]byte]types.Epoch{
 		{0, 0, 0, 0}: genesisForkEpoch,
 		{1, 0, 0, 0}: altairForkEpoch,


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

- [x] Currently in our config, there are non spec variables which denote the next fork epoch and version. However given 
that we are using our fork schedule to determine the correct fork order, having this variables are a source on confusion. Therefore this PR removes them and fixes all usages to ultimately use our current fork schedule.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
