### PR TITLE
Update sync committee cache using block root at boundary slot - 1 

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -533,6 +533,7 @@ func findSubCommitteeIndices(pubKey []byte, pubKeys [][]byte) []uint64 {
 
 // Retrieve the current sync period boundary root by calculating sync period start epoch
 // and calling `BlockRoot`.
+// It uses the boundary slot - 1 for block root. (Ex: SlotsPerEpoch * EpochsPerSyncCommitteePeriod - 1)
 func syncPeriodBoundaryRoot(state iface.ReadOnlyBeaconState) ([]byte, error) {
 	// Can't call `BlockRoot` until the first slot.
 	if state.Slot() == params.BeaconConfig().GenesisSlot {

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -990,3 +990,19 @@ func TestNextEpochSyncSubcommitteeIndices_DoesNotExist(t *testing.T) {
 	require.NoError(t, err)
 	require.DeepEqual(t, []uint64(nil), index)
 }
+
+func TestUpdateSyncCommitteeCache_BadSlot(t *testing.T) {
+	state, err := v1.InitializeFromProto(&pb.BeaconState{
+		Slot: 1,
+	})
+	require.NoError(t, err)
+	err = UpdateSyncCommitteeCache(state)
+	require.ErrorContains(t, "not at the end of the epoch to update cache", err)
+
+	state, err = v1.InitializeFromProto(&pb.BeaconState{
+		Slot: params.BeaconConfig().SlotsPerEpoch - 1,
+	})
+	require.NoError(t, err)
+	err = UpdateSyncCommitteeCache(state)
+	require.ErrorContains(t, "not at sync committee period boundary to update cache", err)
+}

--- a/beacon-chain/core/state/transition.go
+++ b/beacon-chain/core/state/transition.go
@@ -302,9 +302,6 @@ func ProcessSlots(ctx context.Context, state iface.BeaconState, slot types.Slot)
 			if err != nil {
 				return nil, err
 			}
-			if err := helpers.UpdateSyncCommitteeCache(state); err != nil {
-				return nil, err
-			}
 		}
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
@@ -135,6 +135,7 @@ func TestGetAltairDuties_SyncCommitteeOK(t *testing.T) {
 		pubKeys[i] = deposits[i].Data.PublicKey
 		indices[i] = uint64(i)
 	}
+	require.NoError(t, bs.SetSlot(params.BeaconConfig().SlotsPerEpoch*types.Slot(params.BeaconConfig().EpochsPerSyncCommitteePeriod)-1))
 	require.NoError(t, helpers.UpdateSyncCommitteeCache(bs))
 
 	pubkeysAs48ByteType := make([][48]byte, len(pubKeys))

--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -212,9 +212,6 @@ func processSlotsStateGen(ctx context.Context, state iface.BeaconState, slot typ
 			if err != nil {
 				return nil, err
 			}
-			if err := helpers.UpdateSyncCommitteeCache(state); err != nil {
-				return nil, err
-			}
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a sync committee cache update bug. It now updates the cache at boundary slot - 1 and uses the block root at boundary slot - 1. Before it uses block root at boundary slot which introduces a subtle bug where the update cache and get cache have off by one

Note that I removed the update at fork boundary. This will be addressed in the next PR which we will implement fill on miss. This is absolutely needed due to restart