### PR TITLE
Sync committee cache: fill on miss

### DIFF
--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
+	log "github.com/sirupsen/logrus"
 )
 
 var committeeCache = cache.NewCommitteesCache()
@@ -412,6 +413,14 @@ func IsCurrentEpochSyncCommittee(
 		if err != nil {
 			return false, err
 		}
+
+		// Fill in the cache on miss.
+		go func() {
+			if err := syncCommitteeCache.UpdatePositionsInCommittee(bytesutil.ToBytes32(root), st); err != nil {
+				log.Errorf("Could not fill sync committee cache on miss: %v", err)
+			}
+		}()
+
 		return len(findSubCommitteeIndices(val.PublicKey, committee.Pubkeys)) > 0, nil
 	}
 	if err != nil {
@@ -468,6 +477,14 @@ func CurrentEpochSyncSubcommitteeIndices(
 		if err != nil {
 			return nil, err
 		}
+
+		// Fill in the cache on miss.
+		go func() {
+			if err := syncCommitteeCache.UpdatePositionsInCommittee(bytesutil.ToBytes32(root), st); err != nil {
+				log.Errorf("Could not fill sync committee cache on miss: %v", err)
+			}
+		}()
+
 		return findSubCommitteeIndices(val.PublicKey, committee.Pubkeys), nil
 	}
 	if err != nil {

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -9,6 +9,7 @@ import (
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	v2 "github.com/prysmaticlabs/prysm/beacon-chain/state/v2"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
@@ -877,12 +878,17 @@ func TestCurrentEpochSyncSubcommitteeIndices_UsingCommittee(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
+	root, err := syncPeriodBoundaryRoot(state)
+	require.NoError(t, err)
+
+	// Test that cache was empty.
+	_, err = syncCommitteeCache.CurrentEpochIndexPosition(bytesutil.ToBytes32(root), 0)
+	require.Equal(t, cache.ErrNonExistingSyncCommitteeKey, err)
+
+	// Test that helper can retrieve the index given empty cache.
 	index, err := CurrentEpochSyncSubcommitteeIndices(state, 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []uint64{0}, index)
-
-	root, err := syncPeriodBoundaryRoot(state)
-	require.NoError(t, err)
 
 	// Test that cache was able to fill on miss.
 	time.Sleep(100 * time.Millisecond)

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/go-bitfield"
@@ -877,6 +878,15 @@ func TestCurrentEpochSyncSubcommitteeIndices_UsingCommittee(t *testing.T) {
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
 	index, err := CurrentEpochSyncSubcommitteeIndices(state, 0)
+	require.NoError(t, err)
+	require.DeepEqual(t, []uint64{0}, index)
+
+	root, err := syncPeriodBoundaryRoot(state)
+	require.NoError(t, err)
+
+	// Test that cache was able to fill on miss.
+	time.Sleep(100 * time.Millisecond)
+	index, err = syncCommitteeCache.CurrentEpochIndexPosition(bytesutil.ToBytes32(root), 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []uint64{0}, index)
 }


### PR DESCRIPTION
When using sync committee cache, and calling `IsCurrentEpochSyncCommittee` or `CurrentEpochSyncSubcommitteeIndices`, if there's a cache miss, we should fill the cache on the miss. This PR implements that functionality with a test.

Note: In test, I used a minor sleep (100ms) to ensure that go routine for the cache cache fill gets finished. Happy to hear whether there's a better solution for this