### PR TITLE
Remove validator pubkey to index map

### DIFF
--- a/beacon-chain/rpc/prysm/v2/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v2/validator/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/blockchain/testing:go_default_library",
+        "//beacon-chain/core/altair:go_default_library",
         "//beacon-chain/core/blocks:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/db/testing:go_default_library",

--- a/beacon-chain/rpc/prysm/v2/validator/proposer_test.go
+++ b/beacon-chain/rpc/prysm/v2/validator/proposer_test.go
@@ -7,6 +7,7 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/go-bitfield"
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	dbutil "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
@@ -82,6 +83,9 @@ func TestProposer_GetBlock_OK(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	beaconState, privKeys := testutil.DeterministicGenesisStateAltair(t, 64)
+	committee, err := altair.NextSyncCommittee(beaconState)
+	require.NoError(t, err)
+	require.NoError(t, beaconState.SetCurrentSyncCommittee(committee))
 
 	stateRoot, err := beaconState.HashTreeRoot(ctx)
 	require.NoError(t, err, "Could not hash genesis state")


### PR DESCRIPTION
This is an optimization PR over `runtime.assign`.   Whenever a node processes a block, it processes the `SyncAggregate` object. The node naively constructs a map that consists of every validator public key to every validator index in state. This is expensive and turns out to be unnecessary. The look up can be done individually via `state.ValidatorIndexByPubkey`. The saving here is removing 190k sized validator map and 190k lookups down to 512 lookups.

Before the fix:
![Screen Shot 2021-07-09 at 7 40 31 AM](https://user-images.githubusercontent.com/21316537/125332020-94717980-e2fd-11eb-9aad-7035054b48d4.png)

After the fix: