### PR TITLE
Active balance: calculate epoch outside of loop

### DIFF
--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -48,8 +48,9 @@ func TotalBalance(state iface.ReadOnlyValidators, indices []types.ValidatorIndex
 //    return get_total_balance(state, set(get_active_validator_indices(state, get_current_epoch(state))))
 func TotalActiveBalance(state iface.ReadOnlyBeaconState) (uint64, error) {
 	total := uint64(0)
+	epoch := SlotToEpoch(state.Slot())
 	if err := state.ReadFromEveryValidator(func(idx int, val iface.ReadOnlyValidator) error {
-		if IsActiveValidatorUsingTrie(val, SlotToEpoch(state.Slot())) {
+		if IsActiveValidatorUsingTrie(val, epoch) {
 			total += val.EffectiveBalance()
 		}
 		return nil


### PR DESCRIPTION
This PR optimizes `TotalActiveBalance` by moving `SlotToEpoch(state.Slot()))` out side of the `ReadFromEveryValidator` loop. Every time `state.Slot()` is involved, it must obtain a beacon state read lock and that's obviously not efficient obtaining one instance of read lock for every validator (190k as of today)

![Screen Shot 2021-07-12 at 10 16 04 AM](https://user-images.githubusercontent.com/21316537/125334926-c6d0a600-e300-11eb-93bc-512b019d43fe.png)
