### PR TITLE
Sync committee pool can retrieve without pop

### DIFF
--- a/beacon-chain/operations/synccommittee/contribution.go
+++ b/beacon-chain/operations/synccommittee/contribution.go
@@ -21,17 +21,23 @@ func (s *Store) SaveSyncCommitteeContribution(cont *prysmv2.SyncCommitteeContrib
 		return nilContributionErr
 	}
 
-	contributions, err := s.SyncCommitteeContributions(cont.Slot)
+	s.contributionLock.Lock()
+	defer s.contributionLock.Unlock()
+
+	item, err := s.contributionCache.PopByKey(syncCommitteeKey(cont.Slot))
 	if err != nil {
 		return err
 	}
 
-	s.contributionLock.Lock()
-	defer s.contributionLock.Unlock()
 	copied := copyutil.CopySyncCommitteeContribution(cont)
 
 	// Contributions exist in the queue. Append instead of insert new.
-	if contributions != nil {
+	if item != nil {
+		contributions, ok := item.Value.([]*prysmv2.SyncCommitteeContribution)
+		if !ok {
+			return errors.New("not typed []ethpb.SyncCommitteeContribution")
+		}
+
 		contributions = append(contributions, copied)
 		savedSyncCommitteeContributionTotal.Inc()
 		return s.contributionCache.Push(&queue.Item{
@@ -64,10 +70,10 @@ func (s *Store) SaveSyncCommitteeContribution(cont *prysmv2.SyncCommitteeContrib
 // SyncCommitteeContributions returns sync committee contributions by slot from the priority queue.
 // Upon retrieval, the contribution is removed from the queue.
 func (s *Store) SyncCommitteeContributions(slot types.Slot) ([]*prysmv2.SyncCommitteeContribution, error) {
-	s.contributionLock.Lock()
-	defer s.contributionLock.Unlock()
+	s.contributionLock.RLock()
+	defer s.contributionLock.RUnlock()
 
-	item, err := s.contributionCache.PopByKey(syncCommitteeKey(slot))
+	item, err := s.contributionCache.RetrieveByKey(syncCommitteeKey(slot))
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/operations/synccommittee/contribution.go
+++ b/beacon-chain/operations/synccommittee/contribution.go
@@ -73,10 +73,7 @@ func (s *Store) SyncCommitteeContributions(slot types.Slot) ([]*prysmv2.SyncComm
 	s.contributionLock.RLock()
 	defer s.contributionLock.RUnlock()
 
-	item, err := s.contributionCache.RetrieveByKey(syncCommitteeKey(slot))
-	if err != nil {
-		return nil, err
-	}
+	item := s.contributionCache.RetrieveByKey(syncCommitteeKey(slot))
 	if item == nil {
 		return nil, nil
 	}

--- a/beacon-chain/operations/synccommittee/contribution_test.go
+++ b/beacon-chain/operations/synccommittee/contribution_test.go
@@ -49,6 +49,56 @@ func TestSyncCommitteeContributionCache_RoundTrip(t *testing.T) {
 		{Slot: 3, SubcommitteeIndex: 1, Signature: []byte{'f'}},
 	}, conts)
 
+	conts, err = store.SyncCommitteeContributions(4)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeContribution{
+		{Slot: 4, SubcommitteeIndex: 0, Signature: []byte{'g'}},
+		{Slot: 4, SubcommitteeIndex: 1, Signature: []byte{'h'}},
+	}, conts)
+
+	conts, err = store.SyncCommitteeContributions(5)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeContribution{
+		{Slot: 5, SubcommitteeIndex: 0, Signature: []byte{'i'}},
+		{Slot: 5, SubcommitteeIndex: 1, Signature: []byte{'j'}},
+	}, conts)
+
+	conts, err = store.SyncCommitteeContributions(6)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeContribution{
+		{Slot: 6, SubcommitteeIndex: 0, Signature: []byte{'k'}},
+		{Slot: 6, SubcommitteeIndex: 1, Signature: []byte{'l'}},
+	}, conts)
+
+	// All the contributions should persist after get.
+	conts, err = store.SyncCommitteeContributions(1)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeContribution(nil), conts)
+	conts, err = store.SyncCommitteeContributions(2)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeContribution(nil), conts)
+
+	conts, err = store.SyncCommitteeContributions(3)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeContribution{
+		{Slot: 3, SubcommitteeIndex: 0, Signature: []byte{'e'}},
+		{Slot: 3, SubcommitteeIndex: 1, Signature: []byte{'f'}},
+	}, conts)
+
+	conts, err = store.SyncCommitteeContributions(4)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeContribution{
+		{Slot: 4, SubcommitteeIndex: 0, Signature: []byte{'g'}},
+		{Slot: 4, SubcommitteeIndex: 1, Signature: []byte{'h'}},
+	}, conts)
+
+	conts, err = store.SyncCommitteeContributions(5)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeContribution{
+		{Slot: 5, SubcommitteeIndex: 0, Signature: []byte{'i'}},
+		{Slot: 5, SubcommitteeIndex: 1, Signature: []byte{'j'}},
+	}, conts)
+
 	conts, err = store.SyncCommitteeContributions(6)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeContribution{

--- a/beacon-chain/operations/synccommittee/message.go
+++ b/beacon-chain/operations/synccommittee/message.go
@@ -63,10 +63,10 @@ func (s *Store) SaveSyncCommitteeMessage(msg *prysmv2.SyncCommitteeMessage) erro
 // SyncCommitteeMessages returns sync committee messages by slot from the priority queue.
 // Upon retrieval, the message is removed from the queue.
 func (s *Store) SyncCommitteeMessages(slot types.Slot) ([]*prysmv2.SyncCommitteeMessage, error) {
-	s.messageLock.Lock()
-	defer s.messageLock.Unlock()
+	s.messageLock.RLock()
+	defer s.messageLock.RUnlock()
 
-	item, err := s.messageCache.PopByKey(syncCommitteeKey(slot))
+	item, err := s.messageCache.RetrieveByKey(syncCommitteeKey(slot))
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/operations/synccommittee/message.go
+++ b/beacon-chain/operations/synccommittee/message.go
@@ -66,10 +66,7 @@ func (s *Store) SyncCommitteeMessages(slot types.Slot) ([]*prysmv2.SyncCommittee
 	s.messageLock.RLock()
 	defer s.messageLock.RUnlock()
 
-	item, err := s.messageCache.RetrieveByKey(syncCommitteeKey(slot))
-	if err != nil {
-		return nil, err
-	}
+	item := s.messageCache.RetrieveByKey(syncCommitteeKey(slot))
 	if item == nil {
 		return nil, nil
 	}

--- a/beacon-chain/operations/synccommittee/message_test.go
+++ b/beacon-chain/operations/synccommittee/message_test.go
@@ -49,6 +49,57 @@ func TestSyncCommitteeSignatureCache_RoundTrip(t *testing.T) {
 		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'f'}},
 	}, msgs)
 
+	msgs, err = store.SyncCommitteeMessages(4)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{
+		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'g'}},
+		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'h'}},
+	}, msgs)
+
+	msgs, err = store.SyncCommitteeMessages(5)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{
+		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'i'}},
+		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'j'}},
+	}, msgs)
+
+	msgs, err = store.SyncCommitteeMessages(6)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{
+		{Slot: 6, ValidatorIndex: 0, Signature: []byte{'k'}},
+		{Slot: 6, ValidatorIndex: 1, Signature: []byte{'l'}},
+	}, msgs)
+
+	// Messages should persist after retrieval.
+	msgs, err = store.SyncCommitteeMessages(1)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage(nil), msgs)
+
+	msgs, err = store.SyncCommitteeMessages(2)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage(nil), msgs)
+
+	msgs, err = store.SyncCommitteeMessages(3)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{
+		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'e'}},
+		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'f'}},
+	}, msgs)
+
+	msgs, err = store.SyncCommitteeMessages(4)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{
+		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'g'}},
+		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'h'}},
+	}, msgs)
+
+	msgs, err = store.SyncCommitteeMessages(5)
+	require.NoError(t, err)
+	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{
+		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'i'}},
+		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'j'}},
+	}, msgs)
+
 	msgs, err = store.SyncCommitteeMessages(6)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{

--- a/beacon-chain/operations/synccommittee/message_test.go
+++ b/beacon-chain/operations/synccommittee/message_test.go
@@ -52,15 +52,15 @@ func TestSyncCommitteeSignatureCache_RoundTrip(t *testing.T) {
 	msgs, err = store.SyncCommitteeMessages(4)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{
-		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'g'}},
-		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'h'}},
+		{Slot: 4, ValidatorIndex: 0, Signature: []byte{'g'}},
+		{Slot: 4, ValidatorIndex: 1, Signature: []byte{'h'}},
 	}, msgs)
 
 	msgs, err = store.SyncCommitteeMessages(5)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{
-		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'i'}},
-		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'j'}},
+		{Slot: 5, ValidatorIndex: 0, Signature: []byte{'i'}},
+		{Slot: 5, ValidatorIndex: 1, Signature: []byte{'j'}},
 	}, msgs)
 
 	msgs, err = store.SyncCommitteeMessages(6)
@@ -89,15 +89,15 @@ func TestSyncCommitteeSignatureCache_RoundTrip(t *testing.T) {
 	msgs, err = store.SyncCommitteeMessages(4)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{
-		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'g'}},
-		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'h'}},
+		{Slot: 4, ValidatorIndex: 0, Signature: []byte{'g'}},
+		{Slot: 4, ValidatorIndex: 1, Signature: []byte{'h'}},
 	}, msgs)
 
 	msgs, err = store.SyncCommitteeMessages(5)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, []*prysmv2.SyncCommitteeMessage{
-		{Slot: 3, ValidatorIndex: 0, Signature: []byte{'i'}},
-		{Slot: 3, ValidatorIndex: 1, Signature: []byte{'j'}},
+		{Slot: 5, ValidatorIndex: 0, Signature: []byte{'i'}},
+		{Slot: 5, ValidatorIndex: 1, Signature: []byte{'j'}},
 	}, msgs)
 
 	msgs, err = store.SyncCommitteeMessages(6)

--- a/shared/queue/priority_queue.go
+++ b/shared/queue/priority_queue.go
@@ -151,13 +151,13 @@ func (pq *PriorityQueue) PopByKey(key string) (*Item, error) {
 
 // RetrieveByKey searches the queue for an item with the given key and returns it
 // from the queue if found. Returns nil if not found.
-func (pq *PriorityQueue) RetrieveByKey(key string) (*Item, error) {
+func (pq *PriorityQueue) RetrieveByKey(key string) *Item {
 	pq.lock.Lock()
 	defer pq.lock.Unlock()
 
 	item, ok := pq.dataMap[key]
 	if !ok {
-		return nil, nil
+		return nil
 	}
 
 	// Remove the item the heap and then re insert it back.
@@ -166,11 +166,11 @@ func (pq *PriorityQueue) RetrieveByKey(key string) (*Item, error) {
 
 	if itemRaw != nil {
 		if i, ok := itemRaw.(*Item); ok {
-			return i, nil
+			return i
 		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 // Len returns the number of items in the queue data structure. Do not use this

--- a/shared/queue/priority_queue.go
+++ b/shared/queue/priority_queue.go
@@ -149,6 +149,30 @@ func (pq *PriorityQueue) PopByKey(key string) (*Item, error) {
 	return nil, nil
 }
 
+// RetrieveByKey searches the queue for an item with the given key and returns it
+// from the queue if found. Returns nil if not found.
+func (pq *PriorityQueue) RetrieveByKey(key string) (*Item, error) {
+	pq.lock.Lock()
+	defer pq.lock.Unlock()
+
+	item, ok := pq.dataMap[key]
+	if !ok {
+		return nil, nil
+	}
+
+	// Remove the item the heap and then re insert it back.
+	itemRaw := heap.Remove(&pq.data, item.index)
+	heap.Push(&pq.data, itemRaw)
+
+	if itemRaw != nil {
+		if i, ok := itemRaw.(*Item); ok {
+			return i, nil
+		}
+	}
+
+	return nil, nil
+}
+
 // Len returns the number of items in the queue data structure. Do not use this
 // method directly on the queue, use PriorityQueue.Len() instead.
 func (q queue) Len() int { return len(q) }

--- a/shared/queue/priority_queue_test.go
+++ b/shared/queue/priority_queue_test.go
@@ -206,9 +206,9 @@ func TestPriorityQueue_RetrieveByKey(t *testing.T) {
 
 	popKeys := []int{2, 4, 7, 1, 0}
 	for _, i := range popKeys {
-		item, err := pq.RetrieveByKey(fmt.Sprintf("item-%d", i))
-		if err != nil {
-			t.Fatalf("failed to pop item-%d, \n\terr: %s\n\titem: %#v", i, err, item)
+		item := pq.RetrieveByKey(fmt.Sprintf("item-%d", i))
+		if item == nil {
+			t.Fatalf("failed to pop item-%d, \n\titem: %#v", i, item)
 		}
 	}
 

--- a/shared/queue/priority_queue_test.go
+++ b/shared/queue/priority_queue_test.go
@@ -184,6 +184,50 @@ func TestPriorityQueue_PopByKey(t *testing.T) {
 	testValidateInternalData(t, pq, len(tc)-len(popKeys)-1, true)
 }
 
+func TestPriorityQueue_RetrieveByKey(t *testing.T) {
+	pq := New()
+
+	tc := testCases()
+	for _, i := range tc {
+		if err := pq.Push(i); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// grab the top priority item, to capture it's value for checking later
+	item, err := pq.Pop()
+	require.NoError(t, err)
+	oldPriority := item.Priority
+	oldKey := item.Key
+
+	// push the item back on, so it gets retrieved with RetrieveByKey and we verify
+	// the top item does not change.
+	require.NoError(t, pq.Push(item))
+
+	popKeys := []int{2, 4, 7, 1, 0}
+	for _, i := range popKeys {
+		item, err := pq.RetrieveByKey(fmt.Sprintf("item-%d", i))
+		if err != nil {
+			t.Fatalf("failed to pop item-%d, \n\terr: %s\n\titem: %#v", i, err, item)
+		}
+	}
+
+	testValidateInternalData(t, pq, len(tc), false)
+
+	// grab the top priority item again, to compare with the top item priority
+	// from above. They should be the same
+	item, err = pq.Pop()
+	require.NoError(t, err)
+	newPriority := item.Priority
+	newKey := item.Key
+
+	if oldPriority != newPriority && oldKey != newKey {
+		t.Fatalf("expected old/new key and priority to be the same, got (%s/%s) and (%d/%d)", oldKey, newKey, oldPriority, newPriority)
+	}
+
+	testValidateInternalData(t, pq, len(tc)-1, true)
+}
+
 // testValidateInternalData checks the internal data structure of the PriorityQueue
 // and verifies that items are in-sync. Use drain only at the end of a test,
 // because it will mutate the input queue


### PR DESCRIPTION
Sync committee object pool saves and retrieves objects using the priority queue. For retrieve, it uses the method `PopByKey`.  Using pop has an unintended consequence. By definition pop removes object on return and this does not fit our use case. In spec, there's multiple aggregators across multiple subcommittees. It means after aggregator at subcommittee 0 retrieve objects at slot N, it will empty the queue for slot N and leave aggregators at subcommittee 1,2,3 with nothing to aggregate.

To solve this we implement a new method `RetrieveByKey` for the priority queue. The method returns the object without removing the object from the queue.

Note: pool is still correctly getting pruned based on save. It gets trimmed after `syncCommitteeMaxQueueSize` is reached.