### PR TITLE
Disallow sync committee cache update if state root is 0s

### DIFF
--- a/beacon-chain/core/altair/epoch_spec_test.go
+++ b/beacon-chain/core/altair/epoch_spec_test.go
@@ -10,6 +10,7 @@ import (
 	stateAltair "github.com/prysmaticlabs/prysm/beacon-chain/state/v2"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
@@ -19,6 +20,12 @@ import (
 
 func TestProcessSyncCommitteeUpdates_CanRotate(t *testing.T) {
 	s, _ := testutil.DeterministicGenesisStateAltair(t, params.BeaconConfig().MaxValidatorsPerCommittee)
+	h := &ethpb.BeaconBlockHeader{
+		StateRoot:  bytesutil.PadTo([]byte{'a'}, 32),
+		ParentRoot: bytesutil.PadTo([]byte{'b'}, 32),
+		BodyRoot:   bytesutil.PadTo([]byte{'c'}, 32),
+	}
+	require.NoError(t, s.SetLatestBlockHeader(h))
 	postState, err := altair.ProcessSyncCommitteeUpdates(s)
 	require.NoError(t, err)
 	current, err := postState.CurrentSyncCommittee()

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -1022,3 +1022,13 @@ func TestUpdateSyncCommitteeCache_BadSlot(t *testing.T) {
 	err = UpdateSyncCommitteeCache(state)
 	require.ErrorContains(t, "not at sync committee period boundary to update cache", err)
 }
+
+func TestUpdateSyncCommitteeCache_BadRoot(t *testing.T) {
+	state, err := v1.InitializeFromProto(&pb.BeaconState{
+		Slot:              types.Slot(params.BeaconConfig().EpochsPerSyncCommitteePeriod)*params.BeaconConfig().SlotsPerEpoch - 1,
+		LatestBlockHeader: &ethpb.BeaconBlockHeader{StateRoot: params.BeaconConfig().ZeroHash[:]},
+	})
+	require.NoError(t, err)
+	err = UpdateSyncCommitteeCache(state)
+	require.ErrorContains(t, "zero hash state root can't be used to update cache", err)
+}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
@@ -122,6 +122,12 @@ func TestGetAltairDuties_SyncCommitteeOK(t *testing.T) {
 	eth1Data, err := testutil.DeterministicEth1Data(len(deposits))
 	require.NoError(t, err)
 	bs, err := testutil.GenesisBeaconState(context.Background(), deposits, 0, eth1Data)
+	h := &ethpb.BeaconBlockHeader{
+		StateRoot:  bytesutil.PadTo([]byte{'a'}, 32),
+		ParentRoot: bytesutil.PadTo([]byte{'b'}, 32),
+		BodyRoot:   bytesutil.PadTo([]byte{'c'}, 32),
+	}
+	require.NoError(t, bs.SetLatestBlockHeader(h))
 	require.NoError(t, err, "Could not setup genesis bs")
 	genesisRoot, err := genesis.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not get signing root")


### PR DESCRIPTION
`UpdateSyncCommitteeCache` returns error if latest block header's state root is zero hash. This implements an additional layer of defense to prevent callers corrupting the cache.