### PR TITLE
Remove database field from v1alpha1 validator server

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/state:go_default_library",
         "//beacon-chain/core/state/interop:go_default_library",
-        "//beacon-chain/db:go_default_library",
         "//beacon-chain/operations/attestations:go_default_library",
         "//beacon-chain/operations/slashings:go_default_library",
         "//beacon-chain/operations/voluntaryexits:go_default_library",

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
@@ -50,11 +50,6 @@ func TestGetDuties_OK(t *testing.T) {
 		indices[i] = uint64(i)
 	}
 
-	pubkeysAs48ByteType := make([][48]byte, len(pubKeys))
-	for i, pk := range pubKeys {
-		pubkeysAs48ByteType[i] = bytesutil.ToBytes48(pk)
-	}
-
 	chain := &mockChain.ChainService{
 		State: bs, Root: genesisRoot[:], Genesis: time.Now(),
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
-	dbutil "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
 	ethpbv1 "github.com/prysmaticlabs/prysm/proto/eth/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
@@ -33,8 +32,6 @@ func pubKey(i uint64) []byte {
 }
 
 func TestGetDuties_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
-
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
 	deposits, _, err := testutil.DeterministicDepositsAndKeys(depChainStart)
@@ -62,7 +59,6 @@ func TestGetDuties_OK(t *testing.T) {
 		State: bs, Root: genesisRoot[:], Genesis: time.Now(),
 	}
 	vs := &Server{
-		BeaconDB:    db,
 		HeadFetcher: chain,
 		TimeFetcher: chain,
 		SyncChecker: &mockSync.Sync{IsSyncing: false},
@@ -118,8 +114,6 @@ func TestGetDuties_SlotOutOfUpperBound(t *testing.T) {
 }
 
 func TestGetDuties_CurrentEpoch_ShouldNotFail(t *testing.T) {
-	db := dbutil.SetupDB(t)
-
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
 	deposits, _, err := testutil.DeterministicDepositsAndKeys(depChainStart)
@@ -145,7 +139,6 @@ func TestGetDuties_CurrentEpoch_ShouldNotFail(t *testing.T) {
 		State: bState, Root: genesisRoot[:], Genesis: time.Now(),
 	}
 	vs := &Server{
-		BeaconDB:    db,
 		HeadFetcher: chain,
 		TimeFetcher: chain,
 		SyncChecker: &mockSync.Sync{IsSyncing: false},
@@ -161,8 +154,6 @@ func TestGetDuties_CurrentEpoch_ShouldNotFail(t *testing.T) {
 }
 
 func TestGetDuties_MultipleKeys_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
-
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := uint64(64)
 
@@ -186,7 +177,6 @@ func TestGetDuties_MultipleKeys_OK(t *testing.T) {
 		State: bs, Root: genesisRoot[:], Genesis: time.Now(),
 	}
 	vs := &Server{
-		BeaconDB:    db,
 		HeadFetcher: chain,
 		TimeFetcher: chain,
 		SyncChecker: &mockSync.Sync{IsSyncing: false},
@@ -225,8 +215,6 @@ func TestStreamDuties_SyncNotReady(t *testing.T) {
 }
 
 func TestStreamDuties_OK(t *testing.T) {
-	db := dbutil.SetupDB(t)
-
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
 	deposits, _, err := testutil.DeterministicDepositsAndKeys(depChainStart)
@@ -256,7 +244,6 @@ func TestStreamDuties_OK(t *testing.T) {
 	}
 	vs := &Server{
 		Ctx:           ctx,
-		BeaconDB:      db,
 		HeadFetcher:   &mockChain.ChainService{State: bs, Root: genesisRoot[:]},
 		SyncChecker:   &mockSync.Sync{IsSyncing: false},
 		TimeFetcher:   c,
@@ -285,8 +272,6 @@ func TestStreamDuties_OK(t *testing.T) {
 }
 
 func TestStreamDuties_OK_ChainReorg(t *testing.T) {
-	db := dbutil.SetupDB(t)
-
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := params.BeaconConfig().MinGenesisActiveValidatorCount
 	deposits, _, err := testutil.DeterministicDepositsAndKeys(depChainStart)
@@ -316,7 +301,6 @@ func TestStreamDuties_OK_ChainReorg(t *testing.T) {
 	}
 	vs := &Server{
 		Ctx:           ctx,
-		BeaconDB:      db,
 		HeadFetcher:   &mockChain.ChainService{State: bs, Root: genesisRoot[:]},
 		SyncChecker:   &mockSync.Sync{IsSyncing: false},
 		TimeFetcher:   c,
@@ -369,7 +353,6 @@ func TestAssignValidatorToSubnet(t *testing.T) {
 }
 
 func BenchmarkCommitteeAssignment(b *testing.B) {
-	db := dbutil.SetupDB(b)
 
 	genesis := testutil.NewBeaconBlock()
 	depChainStart := uint64(8192 * 2)
@@ -390,7 +373,6 @@ func BenchmarkCommitteeAssignment(b *testing.B) {
 	}
 
 	vs := &Server{
-		BeaconDB:    db,
 		HeadFetcher: &mockChain.ChainService{State: bs, Root: genesisRoot[:]},
 		SyncChecker: &mockSync.Sync{IsSyncing: false},
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/exit_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/exit_test.go
@@ -11,12 +11,10 @@ import (
 	opfeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/operation"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/state"
-	dbutil "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/voluntaryexits"
 	mockp2p "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
 	mockSync "github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync/testing"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
-	"github.com/prysmaticlabs/prysm/proto/eth/v1alpha1/wrapper"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"
@@ -25,7 +23,6 @@ import (
 )
 
 func TestProposeExit_Notification(t *testing.T) {
-	db := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	deposits, keys, err := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
@@ -35,7 +32,6 @@ func TestProposeExit_Notification(t *testing.T) {
 	epoch := types.Epoch(2048)
 	require.NoError(t, beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(epoch))))
 	block := testutil.NewBeaconBlock()
-	require.NoError(t, db.SaveBlock(ctx, wrapper.WrappedPhase0SignedBeaconBlock(block)), "Could not save genesis block")
 	genesisRoot, err := block.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not get signing root")
 
@@ -44,7 +40,6 @@ func TestProposeExit_Notification(t *testing.T) {
 	genesisTime := time.Now().Add(time.Duration(-100*offset) * time.Second)
 	mockChainService := &mockChain.ChainService{State: beaconState, Root: genesisRoot[:], Genesis: genesisTime}
 	server := &Server{
-		BeaconDB:          db,
 		HeadFetcher:       mockChainService,
 		SyncChecker:       &mockSync.Sync{IsSyncing: false},
 		TimeFetcher:       mockChainService,
@@ -96,7 +91,6 @@ func TestProposeExit_Notification(t *testing.T) {
 }
 
 func TestProposeExit_NoPanic(t *testing.T) {
-	db := dbutil.SetupDB(t)
 	ctx := context.Background()
 
 	deposits, keys, err := testutil.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
@@ -106,7 +100,6 @@ func TestProposeExit_NoPanic(t *testing.T) {
 	epoch := types.Epoch(2048)
 	require.NoError(t, beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(epoch))))
 	block := testutil.NewBeaconBlock()
-	require.NoError(t, db.SaveBlock(ctx, wrapper.WrappedPhase0SignedBeaconBlock(block)), "Could not save genesis block")
 	genesisRoot, err := block.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not get signing root")
 
@@ -115,7 +108,6 @@ func TestProposeExit_NoPanic(t *testing.T) {
 	genesisTime := time.Now().Add(time.Duration(-100*offset) * time.Second)
 	mockChainService := &mockChain.ChainService{State: beaconState, Root: genesisRoot[:], Genesis: genesisTime}
 	server := &Server{
-		BeaconDB:          db,
 		HeadFetcher:       mockChainService,
 		SyncChecker:       &mockSync.Sync{IsSyncing: false},
 		TimeFetcher:       mockChainService,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
@@ -56,7 +56,6 @@ func TestProposer_GetBlock_OK(t *testing.T) {
 	require.NoError(t, db.SaveHeadBlockRoot(ctx, parentRoot), "Could not save genesis state")
 
 	proposerServer := &Server{
-		BeaconDB:          db,
 		HeadFetcher:       &mock.ChainService{State: beaconState, Root: parentRoot[:]},
 		SyncChecker:       &mockSync.Sync{IsSyncing: false},
 		BlockReceiver:     &mock.ChainService{},
@@ -138,7 +137,6 @@ func TestProposer_GetBlock_AddsUnaggregatedAtts(t *testing.T) {
 	require.NoError(t, db.SaveHeadBlockRoot(ctx, parentRoot), "Could not save genesis state")
 
 	proposerServer := &Server{
-		BeaconDB:          db,
 		HeadFetcher:       &mock.ChainService{State: beaconState, Root: parentRoot[:]},
 		SyncChecker:       &mockSync.Sync{IsSyncing: false},
 		BlockReceiver:     &mock.ChainService{},
@@ -224,7 +222,6 @@ func TestProposer_ProposeBlock_OK(t *testing.T) {
 
 	c := &mock.ChainService{Root: bsRoot[:], State: beaconState}
 	proposerServer := &Server{
-		BeaconDB:          db,
 		ChainStartFetcher: &mockPOW.POWChain{},
 		Eth1InfoFetcher:   &mockPOW.POWChain{},
 		Eth1BlockFetcher:  &mockPOW.POWChain{},
@@ -261,7 +258,6 @@ func TestProposer_ComputeStateRoot_OK(t *testing.T) {
 	require.NoError(t, db.SaveHeadBlockRoot(ctx, parentRoot), "Could not save genesis state")
 
 	proposerServer := &Server{
-		BeaconDB:          db,
 		ChainStartFetcher: &mockPOW.POWChain{},
 		Eth1InfoFetcher:   &mockPOW.POWChain{},
 		Eth1BlockFetcher:  &mockPOW.POWChain{},
@@ -1813,13 +1809,9 @@ func TestProposer_Eth1Data_MajorityVote(t *testing.T) {
 }
 
 func TestProposer_FilterAttestation(t *testing.T) {
-	db := dbutil.SetupDB(t)
-	ctx := context.Background()
-
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.MainnetConfig())
 	genesis := testutil.NewBeaconBlock()
-	require.NoError(t, db.SaveBlock(context.Background(), wrapper.WrappedPhase0SignedBeaconBlock(genesis)), "Could not save genesis block")
 
 	numValidators := uint64(64)
 	state, privKeys := testutil.DeterministicGenesisState(t, numValidators)
@@ -1828,8 +1820,6 @@ func TestProposer_FilterAttestation(t *testing.T) {
 
 	genesisRoot, err := genesis.Block.HashTreeRoot()
 	require.NoError(t, err)
-	require.NoError(t, db.SaveState(ctx, state, genesisRoot), "Could not save genesis state")
-	require.NoError(t, db.SaveHeadBlockRoot(ctx, genesisRoot), "Could not save genesis state")
 
 	tests := []struct {
 		name         string
@@ -1905,7 +1895,6 @@ func TestProposer_FilterAttestation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			proposerServer := &Server{
-				BeaconDB:    db,
 				AttPool:     attestations.NewPool(),
 				HeadFetcher: &mock.ChainService{State: state, Root: genesisRoot[:]},
 			}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -16,7 +16,6 @@ import (
 	opfeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/operation"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/slashings"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/voluntaryexits"
@@ -39,7 +38,6 @@ import (
 // and more.
 type Server struct {
 	Ctx                    context.Context
-	BeaconDB               db.NoHeadAccessDatabase
 	AttestationCache       *cache.AttestationCache
 	HeadFetcher            blockchain.HeadFetcher
 	ForkFetcher            blockchain.ForkFetcher

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -167,7 +167,6 @@ func (s *Service) Start() {
 
 	validatorServer := &validatorv1alpha1.Server{
 		Ctx:                    s.ctx,
-		BeaconDB:               s.cfg.BeaconDB,
 		AttestationCache:       cache.NewAttestationCache(),
 		AttPool:                s.cfg.AttestationsPool,
 		ExitPool:               s.cfg.ExitPool,


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

v1alpha1 validator server's `BeaconDB` is not used anywhere outside tests, therefore it is safe to remove it.
