### PR TITLE
Block util: block header from block interface

### DIFF
--- a/shared/blockutil/BUILD.bazel
+++ b/shared/blockutil/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//proto/eth/v1alpha1:go_default_library",
+        "//proto/interfaces:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
     ],
 )
@@ -17,6 +18,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//proto/eth/v1alpha1:go_default_library",
+        "//proto/eth/v1alpha1/wrapper:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",

--- a/shared/blockutil/block_utils.go
+++ b/shared/blockutil/block_utils.go
@@ -35,10 +35,6 @@ func SignedBeaconBlockHeaderFromBlockInterface(sb interfaces.SignedBeaconBlock) 
 		return nil, errors.New("nil block")
 	}
 
-	bodyRoot, err := b.Body().HashTreeRoot()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get body root of block")
-	}
 	h, err := BeaconBlockHeaderFromBlockInterface(b)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get block header of block")

--- a/shared/blockutil/block_utils.go
+++ b/shared/blockutil/block_utils.go
@@ -3,6 +3,7 @@ package blockutil
 import (
 	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/proto/interfaces"
 )
 
 // SignedBeaconBlockHeaderFromBlock function to retrieve signed block header from block.
@@ -27,6 +28,28 @@ func SignedBeaconBlockHeaderFromBlock(block *ethpb.SignedBeaconBlock) (*ethpb.Si
 	}, nil
 }
 
+// SignedBeaconBlockHeaderFromBlockInterface function to retrieve signed block header from block.
+func SignedBeaconBlockHeaderFromBlockInterface(block interfaces.SignedBeaconBlock) (*ethpb.SignedBeaconBlockHeader, error) {
+	if block.Block().IsNil() || block.Block().Body().IsNil() {
+		return nil, errors.New("nil block")
+	}
+
+	bodyRoot, err := block.Block().Body().HashTreeRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get body root of block")
+	}
+	return &ethpb.SignedBeaconBlockHeader{
+		Header: &ethpb.BeaconBlockHeader{
+			Slot:          block.Block().Slot(),
+			ProposerIndex: block.Block().ProposerIndex(),
+			ParentRoot:    block.Block().ParentRoot(),
+			StateRoot:     block.Block().StateRoot(),
+			BodyRoot:      bodyRoot[:],
+		},
+		Signature: block.Signature(),
+	}, nil
+}
+
 // BeaconBlockHeaderFromBlock function to retrieve block header from block.
 func BeaconBlockHeaderFromBlock(block *ethpb.BeaconBlock) (*ethpb.BeaconBlockHeader, error) {
 	if block.Body == nil {
@@ -42,6 +65,25 @@ func BeaconBlockHeaderFromBlock(block *ethpb.BeaconBlock) (*ethpb.BeaconBlockHea
 		ProposerIndex: block.ProposerIndex,
 		ParentRoot:    block.ParentRoot,
 		StateRoot:     block.StateRoot,
+		BodyRoot:      bodyRoot[:],
+	}, nil
+}
+
+// BeaconBlockHeaderFromBlockInterface function to retrieve block header from block.
+func BeaconBlockHeaderFromBlockInterface(block interfaces.BeaconBlock) (*ethpb.BeaconBlockHeader, error) {
+	if block.Body().IsNil() {
+		return nil, errors.New("nil block body")
+	}
+
+	bodyRoot, err := block.Body().HashTreeRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get body root of block")
+	}
+	return &ethpb.BeaconBlockHeader{
+		Slot:          block.Slot(),
+		ProposerIndex: block.ProposerIndex(),
+		ParentRoot:    block.ParentRoot(),
+		StateRoot:     block.StateRoot(),
 		BodyRoot:      bodyRoot[:],
 	}, nil
 }

--- a/shared/blockutil/block_utils.go
+++ b/shared/blockutil/block_utils.go
@@ -44,7 +44,7 @@ func SignedBeaconBlockHeaderFromBlockInterface(sb interfaces.SignedBeaconBlock) 
 		return nil, errors.Wrap(err, "failed to get block header of block")
 	}
 	return &ethpb.SignedBeaconBlockHeader{
-		Header: h,
+		Header:    h,
 		Signature: sb.Signature(),
 	}, nil
 }

--- a/shared/blockutil/block_utils.go
+++ b/shared/blockutil/block_utils.go
@@ -29,24 +29,23 @@ func SignedBeaconBlockHeaderFromBlock(block *ethpb.SignedBeaconBlock) (*ethpb.Si
 }
 
 // SignedBeaconBlockHeaderFromBlockInterface function to retrieve signed block header from block.
-func SignedBeaconBlockHeaderFromBlockInterface(block interfaces.SignedBeaconBlock) (*ethpb.SignedBeaconBlockHeader, error) {
-	if block.Block().IsNil() || block.Block().Body().IsNil() {
+func SignedBeaconBlockHeaderFromBlockInterface(sb interfaces.SignedBeaconBlock) (*ethpb.SignedBeaconBlockHeader, error) {
+	b := sb.Block()
+	if b.IsNil() || b.Body().IsNil() {
 		return nil, errors.New("nil block")
 	}
 
-	bodyRoot, err := block.Block().Body().HashTreeRoot()
+	bodyRoot, err := b.Body().HashTreeRoot()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get body root of block")
 	}
+	h, err := BeaconBlockHeaderFromBlockInterface(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get block header of block")
+	}
 	return &ethpb.SignedBeaconBlockHeader{
-		Header: &ethpb.BeaconBlockHeader{
-			Slot:          block.Block().Slot(),
-			ProposerIndex: block.Block().ProposerIndex(),
-			ParentRoot:    block.Block().ParentRoot(),
-			StateRoot:     block.Block().StateRoot(),
-			BodyRoot:      bodyRoot[:],
-		},
-		Signature: block.Signature(),
+		Header: h,
+		Signature: sb.Signature(),
 	}, nil
 }
 

--- a/shared/blockutil/block_utils_test.go
+++ b/shared/blockutil/block_utils_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	eth "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/proto/eth/v1alpha1/wrapper"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
@@ -43,6 +44,43 @@ func TestBeaconBlockHeaderFromBlock(t *testing.T) {
 	}
 
 	bh, err := BeaconBlockHeaderFromBlock(blk)
+	require.NoError(t, err)
+	assert.DeepEqual(t, want, bh)
+}
+
+func TestBeaconBlockHeaderFromBlockInterface(t *testing.T) {
+	hashLen := 32
+	blk := &eth.BeaconBlock{
+		Slot:          200,
+		ProposerIndex: 2,
+		ParentRoot:    bytesutil.PadTo([]byte("parent root"), hashLen),
+		StateRoot:     bytesutil.PadTo([]byte("state root"), hashLen),
+		Body: &eth.BeaconBlockBody{
+			Eth1Data: &eth.Eth1Data{
+				BlockHash:    bytesutil.PadTo([]byte("block hash"), hashLen),
+				DepositRoot:  bytesutil.PadTo([]byte("deposit root"), hashLen),
+				DepositCount: 1,
+			},
+			RandaoReveal:      bytesutil.PadTo([]byte("randao"), params.BeaconConfig().BLSSignatureLength),
+			Graffiti:          bytesutil.PadTo([]byte("teehee"), hashLen),
+			ProposerSlashings: []*eth.ProposerSlashing{},
+			AttesterSlashings: []*eth.AttesterSlashing{},
+			Attestations:      []*eth.Attestation{},
+			Deposits:          []*eth.Deposit{},
+			VoluntaryExits:    []*eth.SignedVoluntaryExit{},
+		},
+	}
+	bodyRoot, err := blk.Body.HashTreeRoot()
+	require.NoError(t, err)
+	want := &eth.BeaconBlockHeader{
+		Slot:          blk.Slot,
+		ProposerIndex: blk.ProposerIndex,
+		ParentRoot:    blk.ParentRoot,
+		StateRoot:     blk.StateRoot,
+		BodyRoot:      bodyRoot[:],
+	}
+
+	bh, err := BeaconBlockHeaderFromBlockInterface(wrapper.WrappedPhase0BeaconBlock(blk))
 	require.NoError(t, err)
 	assert.DeepEqual(t, want, bh)
 }
@@ -96,6 +134,47 @@ func TestSignedBeaconBlockHeaderFromBlock(t *testing.T) {
 	}
 
 	bh, err := SignedBeaconBlockHeaderFromBlock(blk)
+	require.NoError(t, err)
+	assert.DeepEqual(t, want, bh)
+}
+
+func TestSignedBeaconBlockHeaderFromBlockInterface(t *testing.T) {
+	hashLen := 32
+	blk := &eth.SignedBeaconBlock{Block: &eth.BeaconBlock{
+		Slot:          200,
+		ProposerIndex: 2,
+		ParentRoot:    bytesutil.PadTo([]byte("parent root"), hashLen),
+		StateRoot:     bytesutil.PadTo([]byte("state root"), hashLen),
+		Body: &eth.BeaconBlockBody{
+			Eth1Data: &eth.Eth1Data{
+				BlockHash:    bytesutil.PadTo([]byte("block hash"), hashLen),
+				DepositRoot:  bytesutil.PadTo([]byte("deposit root"), hashLen),
+				DepositCount: 1,
+			},
+			RandaoReveal:      bytesutil.PadTo([]byte("randao"), params.BeaconConfig().BLSSignatureLength),
+			Graffiti:          bytesutil.PadTo([]byte("teehee"), hashLen),
+			ProposerSlashings: []*eth.ProposerSlashing{},
+			AttesterSlashings: []*eth.AttesterSlashing{},
+			Attestations:      []*eth.Attestation{},
+			Deposits:          []*eth.Deposit{},
+			VoluntaryExits:    []*eth.SignedVoluntaryExit{},
+		},
+	},
+		Signature: bytesutil.PadTo([]byte("signature"), params.BeaconConfig().BLSSignatureLength),
+	}
+	bodyRoot, err := blk.Block.Body.HashTreeRoot()
+	require.NoError(t, err)
+	want := &eth.SignedBeaconBlockHeader{Header: &eth.BeaconBlockHeader{
+		Slot:          blk.Block.Slot,
+		ProposerIndex: blk.Block.ProposerIndex,
+		ParentRoot:    blk.Block.ParentRoot,
+		StateRoot:     blk.Block.StateRoot,
+		BodyRoot:      bodyRoot[:],
+	},
+		Signature: blk.Signature,
+	}
+
+	bh, err := SignedBeaconBlockHeaderFromBlockInterface(wrapper.WrappedPhase0SignedBeaconBlock(blk))
 	require.NoError(t, err)
 	assert.DeepEqual(t, want, bh)
 }


### PR DESCRIPTION
Add (signed) block header from block interface implementations. These are from `hf1` branch and I added the tests separately 