### PR TITLE
Hydrate altair block

### DIFF
--- a/shared/testutil/BUILD.bazel
+++ b/shared/testutil/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//proto/eth/v1:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
         "//proto/eth/v1alpha1/wrapper:go_default_library",
+        "//proto/prysm/v2:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
         "//shared/testutil/assert:go_default_library",

--- a/shared/testutil/BUILD.bazel
+++ b/shared/testutil/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//proto/eth/v1:go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
         "//proto/eth/v1alpha1/wrapper:go_default_library",
+        "//proto/prysm/v2:go_default_library",
         "//shared/bls:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/hashutil:go_default_library",

--- a/shared/testutil/block.go
+++ b/shared/testutil/block.go
@@ -10,6 +10,7 @@ import (
 	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
 	v1 "github.com/prysmaticlabs/prysm/proto/eth/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	prysmv2 "github.com/prysmaticlabs/prysm/proto/prysm/v2"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -499,6 +500,59 @@ func HydrateV1BeaconBlockBody(b *v1.BeaconBlockBody) *v1.BeaconBlockBody {
 		b.Eth1Data = &v1.Eth1Data{
 			DepositRoot: make([]byte, 32),
 			BlockHash:   make([]byte, 32),
+		}
+	}
+	return b
+}
+
+// HydrateSignedBeaconBlockAltair hydrates a signed beacon block with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateSignedBeaconBlockAltair(b *prysmv2.SignedBeaconBlock) *prysmv2.SignedBeaconBlock {
+	if b.Signature == nil {
+		b.Signature = make([]byte, params.BeaconConfig().BLSSignatureLength)
+	}
+	b.Block = HydrateBeaconBlockAltair(b.Block)
+	return b
+}
+
+// HydrateBeaconBlockAltair hydrates a beacon block with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateBeaconBlockAltair(b *prysmv2.BeaconBlock) *prysmv2.BeaconBlock {
+	if b == nil {
+		b = &prysmv2.BeaconBlock{}
+	}
+	if b.ParentRoot == nil {
+		b.ParentRoot = make([]byte, 32)
+	}
+	if b.StateRoot == nil {
+		b.StateRoot = make([]byte, 32)
+	}
+	b.Body = HydrateBeaconBlockBodyAltair(b.Body)
+	return b
+}
+
+// HydrateBeaconBlockBodyAltair hydrates a beacon block body with correct field length sizes
+// to comply with fssz marshalling and unmarshalling rules.
+func HydrateBeaconBlockBodyAltair(b *prysmv2.BeaconBlockBody) *prysmv2.BeaconBlockBody {
+	if b == nil {
+		b = &prysmv2.BeaconBlockBody{}
+	}
+	if b.RandaoReveal == nil {
+		b.RandaoReveal = make([]byte, params.BeaconConfig().BLSSignatureLength)
+	}
+	if b.Graffiti == nil {
+		b.Graffiti = make([]byte, 32)
+	}
+	if b.Eth1Data == nil {
+		b.Eth1Data = &ethpb.Eth1Data{
+			DepositRoot: make([]byte, 32),
+			BlockHash:   make([]byte, 32),
+		}
+	}
+	if b.SyncAggregate == nil {
+		b.SyncAggregate = &prysmv2.SyncAggregate{
+			SyncCommitteeBits:      make([]byte, 64),
+			SyncCommitteeSignature: make([]byte, 96),
 		}
 	}
 	return b

--- a/shared/testutil/block_test.go
+++ b/shared/testutil/block_test.go
@@ -203,6 +203,8 @@ func TestHydrateV1SignedBeaconBlock_NoError(t *testing.T) {
 func TestHydrateV2SignedBeaconBlockAltair_NoError(t *testing.T) {
 	b := &v2.SignedBeaconBlockAltair{}
 	b = HydrateSignedBeaconBlockAltair(b)
+
+	// HTR should not error. It errors with incorrect field length sizes.
 	_, err := b.HashTreeRoot()
 	require.NoError(t, err)
 	_, err = b.Block.HashTreeRoot()

--- a/shared/testutil/block_test.go
+++ b/shared/testutil/block_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/prysmaticlabs/prysm/proto/eth/v1"
 	eth "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/proto/eth/v1alpha1/wrapper"
+	v2 "github.com/prysmaticlabs/prysm/proto/prysm/v2"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -191,6 +192,17 @@ func TestHydrateSignedBeaconBlock_NoError(t *testing.T) {
 func TestHydrateV1SignedBeaconBlock_NoError(t *testing.T) {
 	b := &v1.SignedBeaconBlock{}
 	b = HydrateV1SignedBeaconBlock(b)
+	_, err := b.HashTreeRoot()
+	require.NoError(t, err)
+	_, err = b.Block.HashTreeRoot()
+	require.NoError(t, err)
+	_, err = b.Block.Body.HashTreeRoot()
+	require.NoError(t, err)
+}
+
+func TestHydrateV2SignedBeaconBlockAltair_NoError(t *testing.T) {
+	b := &v2.SignedBeaconBlockAltair{}
+	b = HydrateSignedBeaconBlockAltair(b)
 	_, err := b.HashTreeRoot()
 	require.NoError(t, err)
 	_, err = b.Block.HashTreeRoot()


### PR DESCRIPTION
Adding functions to hydrate Altair versioned beacon blocks. These implementations are from the `hf1` branch