### PR TITLE
testutil: Add NotEmpty method

### DIFF
--- a/shared/testutil/assert/assertions.go
+++ b/shared/testutil/assert/assertions.go
@@ -65,3 +65,9 @@ func LogsContain(tb assertions.AssertionTestingTB, hook *test.Hook, want string,
 func LogsDoNotContain(tb assertions.AssertionTestingTB, hook *test.Hook, want string, msg ...interface{}) {
 	assertions.LogsContain(tb.Errorf, hook, want, false, msg...)
 }
+
+// NotEmpty checks that the object fields are not empty. This method also checks all of the
+// pointer fields to ensure none of those fields are empty.
+func NotEmpty(tb assertions.AssertionTestingTB, obj interface{}, msg ...interface{}) {
+	assertions.NotEmpty(tb.Errorf, obj, msg...)
+}

--- a/shared/testutil/assertions/BUILD.bazel
+++ b/shared/testutil/assertions/BUILD.bazel
@@ -19,9 +19,11 @@ go_test(
     deps = [
         ":go_default_library",
         "//proto/eth/v1alpha1:go_default_library",
+        "//proto/testing:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )

--- a/shared/testutil/assertions/assertions_test.go
+++ b/shared/testutil/assertions/assertions_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 
 	eth "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	testpb "github.com/prysmaticlabs/prysm/proto/testing"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assertions"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func Test_Equal(t *testing.T) {
@@ -788,6 +790,176 @@ func Test_LogsContainDoNotContain(t *testing.T) {
 			} else {
 				require.LogsDoNotContain(tt.args.tb, hook, tt.args.want, tt.args.msgs...)
 			}
+			verify()
+		})
+	}
+}
+
+func TestAssert_NotEmpty(t *testing.T) {
+	type args struct {
+		tb     *assertions.TBMock
+		input  interface{}
+		actual interface{}
+		msgs   []interface{}
+	}
+	tests := []struct {
+		name        string
+		args        args
+		expectedErr string
+	}{
+		{
+			name: "literal value int",
+			args: args{
+				tb:    &assertions.TBMock{},
+				input: 42,
+			},
+		}, {
+			name: "literal value int",
+			args: args{
+				tb:    &assertions.TBMock{},
+				input: 0,
+			},
+			expectedErr: "empty/zero field: int",
+		}, {
+			name: "literal value slice",
+			args: args{
+				tb:    &assertions.TBMock{},
+				input: []uint64{42},
+			},
+		}, {
+			name: "literal value string",
+			args: args{
+				tb:    &assertions.TBMock{},
+				input: "42",
+			},
+		}, {
+			name: "simple populated struct",
+			args: args{
+				tb: &assertions.TBMock{},
+				input: struct {
+					foo int
+					bar string
+				}{
+					foo: 42,
+					bar: "42",
+				},
+			},
+		}, {
+			name: "simple partially empty struct",
+			args: args{
+				tb: &assertions.TBMock{},
+				input: struct {
+					foo int
+					bar string
+				}{
+					bar: "42",
+				},
+			},
+			expectedErr: "empty/zero field: .foo",
+		}, {
+			name: "simple empty struct",
+			args: args{
+				tb: &assertions.TBMock{},
+				input: struct {
+					foo int
+					bar string
+				}{},
+			},
+			expectedErr: "empty/zero field",
+		}, {
+			name: "simple populated protobuf",
+			args: args{
+				tb: &assertions.TBMock{},
+				input: &testpb.Puzzle{
+					Challenge: "what do you get when protobufs have internal fields?",
+					Answer:    "Complicated reflect logic!",
+				},
+			},
+		}, {
+			name: "simple partially empty protobuf",
+			args: args{
+				tb: &assertions.TBMock{},
+				input: &testpb.Puzzle{
+					Challenge: "what do you get when protobufs have internal fields?",
+				},
+			},
+			expectedErr: "empty/zero field: Puzzle.Answer",
+		}, {
+			name: "complex populated protobuf",
+			args: args{
+				tb: &assertions.TBMock{},
+				input: &testpb.AddressBook{
+					People: []*testpb.Person{
+						&testpb.Person{
+							Name:  "Foo",
+							Id:    42,
+							Email: "foo@bar.com",
+							Phones: []*testpb.Person_PhoneNumber{
+								&testpb.Person_PhoneNumber{
+									Number: "+1 111-111-1111",
+									Type:   testpb.Person_WORK, // Note: zero'th enum value will count as empty.
+								},
+							},
+							LastUpdated: timestamppb.Now(),
+						},
+					},
+				},
+			},
+		}, {
+			name: "complex partially empty protobuf with empty slices",
+			args: args{
+				tb: &assertions.TBMock{},
+				input: &testpb.AddressBook{
+					People: []*testpb.Person{
+						&testpb.Person{
+							Name:        "Foo",
+							Id:          42,
+							Email:       "foo@bar.com",
+							Phones:      []*testpb.Person_PhoneNumber{},
+							LastUpdated: timestamppb.Now(),
+						},
+					},
+				},
+			},
+			expectedErr: "empty/zero field: AddressBook.People.Phones",
+		}, {
+			name: "complex partially empty protobuf with empty string",
+			args: args{
+				tb: &assertions.TBMock{},
+				input: &testpb.AddressBook{
+					People: []*testpb.Person{
+						&testpb.Person{
+							Name:  "Foo",
+							Id:    42,
+							Email: "",
+							Phones: []*testpb.Person_PhoneNumber{
+								&testpb.Person_PhoneNumber{
+									Number: "+1 111-111-1111",
+									Type:   testpb.Person_WORK, // Note: zero'th enum value will count as empty.
+								},
+							},
+							LastUpdated: timestamppb.Now(),
+						},
+					},
+				},
+			},
+			expectedErr: "empty/zero field: AddressBook.People.Email",
+		},
+	}
+	for _, tt := range tests {
+		verify := func() {
+			if tt.expectedErr == "" && tt.args.tb.ErrorfMsg != "" {
+				t.Errorf("Unexpected error: %v", tt.args.tb.ErrorfMsg)
+			} else if !strings.Contains(tt.args.tb.ErrorfMsg, tt.expectedErr) {
+				t.Errorf("got: %q, want: %q", tt.args.tb.ErrorfMsg, tt.expectedErr)
+			}
+		}
+		t.Run(fmt.Sprintf("Assert/%s", tt.name), func(t *testing.T) {
+			assert.NotEmpty(tt.args.tb, tt.args.input, tt.args.msgs...)
+			verify()
+		})
+		t.Run(fmt.Sprintf("Require/%s", tt.name), func(t *testing.T) {
+			require.NotEmpty(tt.args.tb, tt.args.input, tt.args.msgs...)
 			verify()
 		})
 	}

--- a/shared/testutil/require/requires.go
+++ b/shared/testutil/require/requires.go
@@ -65,3 +65,9 @@ func LogsContain(tb assertions.AssertionTestingTB, hook *test.Hook, want string,
 func LogsDoNotContain(tb assertions.AssertionTestingTB, hook *test.Hook, want string, msg ...interface{}) {
 	assertions.LogsContain(tb.Fatalf, hook, want, false, msg...)
 }
+
+// NotEmpty checks that the object fields are not empty. This method also checks all of the
+// pointer fields to ensure none of those fields are empty.
+func NotEmpty(tb assertions.AssertionTestingTB, obj interface{}, msg ...interface{}) {
+	assertions.NotEmpty(tb.Fatalf, obj, msg...)
+}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Functionality to help us test copy methods and ensure that structs are not empty.

The idea behind this PR is that we may want some copy method that has hand written copy methods. If the underlying struct where ever extended to add new fields, the copy methods would no longer be a full copy. With these test assertions, we can write copy methods and assert that all fields are populate. In the event that new fields are added to some struct, tests will suddenly start failing as an indicator that the copy methods also need to be updated with the struct extensions.


**Which issues(s) does this PR fix?**

**Other notes for review**
