### PR TITLE
Fix Gossip Message ID Versioning

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -172,6 +172,7 @@ go_test(
         "@com_github_libp2p_go_libp2p_pubsub//pb:go_default_library",
         "@com_github_libp2p_go_libp2p_swarm//testing:go_default_library",
         "@com_github_multiformats_go_multiaddr//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -242,6 +242,7 @@ func convertTopicScores(topicMap map[string]*pubsub.TopicScoreSnapshot) map[stri
 	return newMap
 }
 
+// Extracts the relevant fork digest from the gossip topic.
 func ExtractGossipDigest(topic string) ([4]byte, error) {
 	splitParts := strings.Split(topic, "/")
 	parts := []string{}

--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -2,16 +2,21 @@ package p2p
 
 import (
 	"context"
+	"encoding/hex"
+	"strings"
 	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsub_pb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
 	"github.com/prysmaticlabs/prysm/cmd/beacon-chain/flags"
 	pbrpc "github.com/prysmaticlabs/prysm/proto/beacon/rpc/v1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/featureconfig"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
+	"github.com/prysmaticlabs/prysm/shared/p2putils"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
@@ -35,6 +40,11 @@ const (
 	// misc
 	randomSubD = 6 // random gossip target
 )
+
+var errInvalidTopic = errors.New("invalid topic format")
+
+// Specifies the fixed size context length.
+const digestLength = 4
 
 // JoinTopic will join PubSub topic, if not already joined.
 func (s *Service) JoinTopic(topic string, opts ...pubsub.TopicOpt) (*pubsub.Topic, error) {
@@ -132,7 +142,26 @@ func (s *Service) peerInspector(peerMap map[peer.ID]*pubsub.PeerScoreSnapshot) {
 //    Otherwise, set `message-id` to the first 20 bytes of the `SHA256` hash of
 //    the concatenation of `MESSAGE_DOMAIN_INVALID_SNAPPY` with the raw message data,
 //    i.e. `SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + message.data)[:20]`.
-func msgIDFunction(pmsg *pubsub_pb.Message) string {
+func (s *Service) msgIDFunction(pmsg *pubsub_pb.Message) string {
+	digest, err := ExtractGossipDigest(*pmsg.Topic)
+	if err != nil {
+		// Impossible condition that should
+		// never be hit.
+		msg := make([]byte, 20)
+		copy(msg, "invalid")
+		return string(msg)
+	}
+	_, fEpoch, err := p2putils.RetrieveForkDataFromDigest(digest, s.genesisValidatorsRoot)
+	if err != nil {
+		// Impossible condition that should
+		// never be hit.
+		msg := make([]byte, 20)
+		copy(msg, "invalid")
+		return string(msg)
+	}
+	if fEpoch >= params.BeaconConfig().AltairForkEpoch {
+		return s.altairMsgID(pmsg)
+	}
 	decodedData, err := encoder.DecodeSnappy(pmsg.Data, params.BeaconNetworkConfig().GossipMaxSize)
 	if err != nil {
 		combinedData := append(params.BeaconNetworkConfig().MessageDomainInvalidSnappy[:], pmsg.Data...)
@@ -140,6 +169,43 @@ func msgIDFunction(pmsg *pubsub_pb.Message) string {
 		return string(h[:20])
 	}
 	combinedData := append(params.BeaconNetworkConfig().MessageDomainValidSnappy[:], decodedData...)
+	h := hashutil.Hash(combinedData)
+	return string(h[:20])
+}
+
+// Spec:
+// The derivation of the message-id has changed starting with Altair to incorporate the message topic along with the message data.
+// These are fields of the Message Protobuf, and interpreted as empty byte strings if missing. The message-id MUST be the following
+// 20 byte value computed from the message:
+//
+// If message.data has a valid snappy decompression, set message-id to the first 20 bytes of the SHA256 hash of the concatenation of
+// the following data: MESSAGE_DOMAIN_VALID_SNAPPY, the length of the topic byte string (encoded as little-endian uint64), the topic
+// byte string, and the snappy decompressed message data: i.e. SHA256(MESSAGE_DOMAIN_VALID_SNAPPY + uint_to_bytes(uint64(len(message.topic)))
+// + message.topic + snappy_decompress(message.data))[:20]. Otherwise, set message-id to the first 20 bytes of the SHA256 hash of the concatenation
+// of the following data: MESSAGE_DOMAIN_INVALID_SNAPPY, the length of the topic byte string (encoded as little-endian uint64),
+// the topic byte string, and the raw message data: i.e. SHA256(MESSAGE_DOMAIN_INVALID_SNAPPY + uint_to_bytes(uint64(len(message.topic))) + message.topic + message.data)[:20].
+func (s *Service) altairMsgID(pmsg *pubsub_pb.Message) string {
+	topic := *pmsg.Topic
+	topicLen := uint64(len(topic))
+	topicLenBytes := bytesutil.Uint64ToBytesLittleEndian(topicLen)
+
+	decodedData, err := encoder.DecodeSnappy(pmsg.Data, params.BeaconNetworkConfig().GossipMaxSize)
+	if err != nil {
+		totalLength := len(params.BeaconNetworkConfig().MessageDomainInvalidSnappy) + len(topicLenBytes) + int(topicLen) + len(pmsg.Data)
+		combinedData := make([]byte, 0, totalLength)
+		combinedData = append(combinedData, params.BeaconNetworkConfig().MessageDomainInvalidSnappy[:]...)
+		combinedData = append(combinedData, topicLenBytes...)
+		combinedData = append(combinedData, topic...)
+		combinedData = append(combinedData, pmsg.Data...)
+		h := hashutil.Hash(combinedData)
+		return string(h[:20])
+	}
+	totalLength := len(params.BeaconNetworkConfig().MessageDomainValidSnappy) + len(topicLenBytes) + int(topicLen) + len(decodedData)
+	combinedData := make([]byte, 0, totalLength)
+	combinedData = append(combinedData, params.BeaconNetworkConfig().MessageDomainValidSnappy[:]...)
+	combinedData = append(combinedData, topicLenBytes...)
+	combinedData = append(combinedData, topic...)
+	combinedData = append(combinedData, decodedData...)
 	h := hashutil.Hash(combinedData)
 	return string(h[:20])
 }
@@ -174,4 +240,27 @@ func convertTopicScores(topicMap map[string]*pubsub.TopicScoreSnapshot) map[stri
 		}
 	}
 	return newMap
+}
+
+func ExtractGossipDigest(topic string) ([4]byte, error) {
+	splitParts := strings.Split(topic, "/")
+	parts := []string{}
+	for _, p := range splitParts {
+		if p == "" {
+			continue
+		}
+		parts = append(parts, p)
+	}
+	if len(parts) < 2 {
+		return [4]byte{}, errors.Wrapf(errInvalidTopic, "it only has %d parts: %v", len(parts), parts)
+	}
+	strDigest := parts[1]
+	digest, err := hex.DecodeString(strDigest)
+	if err != nil {
+		return [4]byte{}, err
+	}
+	if len(digest) != digestLength {
+		return [4]byte{}, errors.Errorf("invalid digest length wanted %d but got %d", digestLength, len(digest))
+	}
+	return bytesutil.ToBytes4(digest), nil
 }

--- a/beacon-chain/p2p/pubsub_test.go
+++ b/beacon-chain/p2p/pubsub_test.go
@@ -9,9 +9,12 @@ import (
 
 	"github.com/golang/snappy"
 	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
+	"github.com/pkg/errors"
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
 	testp2p "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
@@ -58,16 +61,112 @@ func TestService_PublishToTopicConcurrentMapWrite(t *testing.T) {
 }
 
 func TestMessageIDFunction_HashesCorrectly(t *testing.T) {
+	s := &Service{
+		cfg: &Config{
+			TCPPort: 0,
+			UDPPort: 0,
+		},
+		genesisTime:           time.Now(),
+		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
+	}
+	d, err := s.currentForkDigest()
+	assert.NoError(t, err)
+	tpc := fmt.Sprintf(BlockSubnetTopicFormat, d)
 	invalidSnappy := [32]byte{'J', 'U', 'N', 'K'}
-	pMsg := &pubsubpb.Message{Data: invalidSnappy[:]}
+	pMsg := &pubsubpb.Message{Data: invalidSnappy[:], Topic: &tpc}
 	hashedData := hashutil.Hash(append(params.BeaconNetworkConfig().MessageDomainInvalidSnappy[:], pMsg.Data...))
 	msgID := string(hashedData[:20])
-	assert.Equal(t, msgID, msgIDFunction(pMsg), "Got incorrect msg id")
+	assert.Equal(t, msgID, s.msgIDFunction(pMsg), "Got incorrect msg id")
 
 	validObj := [32]byte{'v', 'a', 'l', 'i', 'd'}
 	enc := snappy.Encode(nil, validObj[:])
-	nMsg := &pubsubpb.Message{Data: enc}
+	nMsg := &pubsubpb.Message{Data: enc, Topic: &tpc}
 	hashedData = hashutil.Hash(append(params.BeaconNetworkConfig().MessageDomainValidSnappy[:], validObj[:]...))
 	msgID = string(hashedData[:20])
-	assert.Equal(t, msgID, msgIDFunction(nMsg), "Got incorrect msg id")
+	assert.Equal(t, msgID, s.msgIDFunction(nMsg), "Got incorrect msg id")
+}
+
+func TestMessageIDFunction_HashesCorrectlyAltair(t *testing.T) {
+	s := &Service{
+		cfg: &Config{
+			TCPPort: 0,
+			UDPPort: 0,
+		},
+		genesisTime:           time.Now(),
+		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
+	}
+	d, err := helpers.ComputeForkDigest(params.BeaconConfig().AltairForkVersion, s.genesisValidatorsRoot)
+	assert.NoError(t, err)
+	tpc := fmt.Sprintf(BlockSubnetTopicFormat, d)
+	topicLen := uint64(len(tpc))
+	topicLenBytes := bytesutil.Uint64ToBytesLittleEndian(topicLen)
+	invalidSnappy := [32]byte{'J', 'U', 'N', 'K'}
+	pMsg := &pubsubpb.Message{Data: invalidSnappy[:], Topic: &tpc}
+	// Create object to hash
+	combinedObj := append(params.BeaconNetworkConfig().MessageDomainInvalidSnappy[:], topicLenBytes...)
+	combinedObj = append(combinedObj, tpc...)
+	combinedObj = append(combinedObj, pMsg.Data...)
+	hashedData := hashutil.Hash(combinedObj)
+	msgID := string(hashedData[:20])
+	assert.Equal(t, msgID, s.msgIDFunction(pMsg), "Got incorrect msg id")
+
+	validObj := [32]byte{'v', 'a', 'l', 'i', 'd'}
+	enc := snappy.Encode(nil, validObj[:])
+	nMsg := &pubsubpb.Message{Data: enc, Topic: &tpc}
+	// Create object to hash
+	combinedObj = append(params.BeaconNetworkConfig().MessageDomainValidSnappy[:], topicLenBytes...)
+	combinedObj = append(combinedObj, tpc...)
+	combinedObj = append(combinedObj, validObj[:]...)
+	hashedData = hashutil.Hash(combinedObj)
+	msgID = string(hashedData[:20])
+	assert.Equal(t, msgID, s.msgIDFunction(nMsg), "Got incorrect msg id")
+}
+
+func TestExtractGossipDigest(t *testing.T) {
+	tests := []struct {
+		name    string
+		topic   string
+		want    [4]byte
+		wantErr bool
+		error   error
+	}{
+		{
+			name:    "too short topic",
+			topic:   "/eth2/",
+			want:    [4]byte{},
+			wantErr: true,
+			error:   errors.New("invalid topic format"),
+		},
+		{
+			name:    "invalid digest in topic",
+			topic:   "/eth2/zzxxyyaa/beacon_block" + "/" + encoder.ProtocolSuffixSSZSnappy,
+			want:    [4]byte{},
+			wantErr: true,
+			error:   errors.New("encoding/hex: invalid byte"),
+		},
+		{
+			name:    "short digest",
+			topic:   fmt.Sprintf(BlockSubnetTopicFormat, []byte{0xb5, 0x30, 0x3f}) + "/" + encoder.ProtocolSuffixSSZSnappy,
+			want:    [4]byte{},
+			wantErr: true,
+			error:   errors.New("invalid digest length wanted"),
+		},
+		{
+			name:    "valid topic",
+			topic:   fmt.Sprintf(BlockSubnetTopicFormat, []byte{0xb5, 0x30, 0x3f, 0x2a}) + "/" + encoder.ProtocolSuffixSSZSnappy,
+			want:    [4]byte{0xb5, 0x30, 0x3f, 0x2a},
+			wantErr: false,
+			error:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractGossipDigest(tt.topic)
+			assert.Equal(t, err != nil, tt.wantErr)
+			if tt.wantErr {
+				assert.ErrorContains(t, tt.error.Error(), err)
+			}
+			assert.DeepEqual(t, tt.want, got)
+		})
+	}
 }

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -137,7 +137,7 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 	psOpts := []pubsub.Option{
 		pubsub.WithMessageSignaturePolicy(pubsub.StrictNoSign),
 		pubsub.WithNoAuthor(),
-		pubsub.WithMessageIdFn(msgIDFunction),
+		pubsub.WithMessageIdFn(s.msgIDFunction),
 		pubsub.WithSubscriptionFilter(s),
 		pubsub.WithPeerOutboundQueueSize(256),
 		pubsub.WithValidateQueueSize(256),

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -213,7 +213,6 @@ go_test(
         "@com_github_libp2p_go_libp2p_pubsub//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//pb:go_default_library",
         "@com_github_patrickmn_go_cache//:go_default_library",
-        "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/sync/decode_pubsub.go
+++ b/beacon-chain/sync/decode_pubsub.go
@@ -21,7 +21,7 @@ func (s *Service) decodePubsubMessage(msg *pubsub.Message) (ssz.Unmarshaler, err
 		return nil, errNilPubsubMessage
 	}
 	topic := *msg.Topic
-	fDigest, err := extractDigest(topic)
+	fDigest, err := p2p.ExtractGossipDigest(topic)
 	if err != nil {
 		return nil, errors.Wrapf(err, "extraction failed for topic: %s", topic)
 	}

--- a/beacon-chain/sync/decode_pubsub_test.go
+++ b/beacon-chain/sync/decode_pubsub_test.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/d4l3k/messagediff"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pb "github.com/libp2p/go-libp2p-pubsub/pb"
-	"github.com/pkg/errors"
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
@@ -88,7 +88,7 @@ func TestService_decodePubsubMessage(t *testing.T) {
 				tt.input.Message.Topic = &tt.topic
 			}
 			got, err := s.decodePubsubMessage(tt.input)
-			if err != tt.wantErr && !errors.Is(err, tt.wantErr) {
+			if err != tt.wantErr && !strings.Contains(err.Error(), tt.wantErr.Error()) {
 				t.Errorf("decodePubsubMessage() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}

--- a/beacon-chain/sync/fork_watcher.go
+++ b/beacon-chain/sync/fork_watcher.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/shared/p2putils"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/slotutil"
@@ -89,7 +90,7 @@ func (s *Service) checkForPreviousEpochFork(currEpoch types.Epoch) error {
 		// Run through all our current active topics and see
 		// if there are any subscriptions to be removed.
 		for _, t := range s.subHandler.allTopics() {
-			retDigest, err := digestFromTopic(t)
+			retDigest, err := p2p.ExtractGossipDigest(t)
 			if err != nil {
 				log.WithError(err).Error("Could not retrieve digest")
 				continue

--- a/beacon-chain/sync/subscription_topic_handler.go
+++ b/beacon-chain/sync/subscription_topic_handler.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 )
 
 // This is a subscription topic handler that is used to handle basic
@@ -26,7 +27,7 @@ func (s *subTopicHandler) addTopic(topic string, sub *pubsub.Subscription) {
 	s.Lock()
 	defer s.Unlock()
 	s.subTopics[topic] = sub
-	digest, err := digestFromTopic(topic)
+	digest, err := p2p.ExtractGossipDigest(topic)
 	if err != nil {
 		log.WithError(err).Error("Could not retrieve digest")
 		return
@@ -45,7 +46,7 @@ func (s *subTopicHandler) removeTopic(topic string) {
 	s.Lock()
 	defer s.Unlock()
 	delete(s.subTopics, topic)
-	digest, err := digestFromTopic(topic)
+	digest, err := p2p.ExtractGossipDigest(topic)
 	if err != nil {
 		log.WithError(err).Error("Could not retrieve digest")
 		return


### PR DESCRIPTION
**What type of PR is this?**

Altair Hard Fork Work

**What does this PR do? Why is it needed?**

- [x] From Altair onwards, all gossip messages are versioned with their topic baked into 
the generated id. Due to this change some refactoring had to be carried out.
- [x] Shift digest extraction method to `p2p` from `sync`.
- [x] Add in custom altair message id function.

**Which issues(s) does this PR fix?**

Part of #8638 

**Other notes for review**
