### PR TITLE
beacon-chain/state/v1: ReadOnlyValidator wrapper constructor method

### DIFF
--- a/beacon-chain/core/blocks/attestation_regression_test.go
+++ b/beacon-chain/core/blocks/attestation_regression_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/params"

--- a/beacon-chain/core/blocks/attestation_test.go
+++ b/beacon-chain/core/blocks/attestation_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/proto/eth/v1alpha1/wrapper"

--- a/beacon-chain/core/blocks/attester_slashing_test.go
+++ b/beacon-chain/core/blocks/attester_slashing_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bls"

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -7,7 +7,7 @@ import (
 	fuzz "github.com/google/gofuzz"
 	types "github.com/prysmaticlabs/eth2-types"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	eth "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/proto/eth/v1alpha1/wrapper"
@@ -434,7 +434,7 @@ func TestFuzzProcessVoluntaryExitsNoVerify_10000(t *testing.T) {
 func TestFuzzVerifyExit_10000(t *testing.T) {
 	fuzzer := fuzz.NewWithSeed(0)
 	ve := &eth.SignedVoluntaryExit{}
-	val := v1.ReadOnlyValidator{}
+	val := v1.NewValidator(nil)
 	fork := &pb.Fork{}
 	var slot types.Slot
 

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -10,6 +10,7 @@ import (
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	eth "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/proto/eth/v1alpha1/wrapper"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
@@ -434,7 +435,8 @@ func TestFuzzProcessVoluntaryExitsNoVerify_10000(t *testing.T) {
 func TestFuzzVerifyExit_10000(t *testing.T) {
 	fuzzer := fuzz.NewWithSeed(0)
 	ve := &eth.SignedVoluntaryExit{}
-	val := v1.NewValidator(nil)
+	val, err := v1.NewValidator(&ethpb.Validator{})
+	_ = err
 	fork := &pb.Fork{}
 	var slot types.Slot
 

--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -442,7 +442,7 @@ func TestFuzzVerifyExit_10000(t *testing.T) {
 
 	for i := 0; i < 10000; i++ {
 		fuzzer.Fuzz(ve)
-		fuzzer.Fuzz(&val)
+		fuzzer.Fuzz(val)
 		fuzzer.Fuzz(fork)
 		fuzzer.Fuzz(&slot)
 		err := VerifyExitAndSignature(val, slot, fork, ve, params.BeaconConfig().ZeroHash[:])

--- a/beacon-chain/core/blocks/deposit_test.go
+++ b/beacon-chain/core/blocks/deposit_test.go
@@ -7,7 +7,7 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bls"

--- a/beacon-chain/core/blocks/eth1_data_test.go
+++ b/beacon-chain/core/blocks/eth1_data_test.go
@@ -7,7 +7,7 @@ import (
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"

--- a/beacon-chain/core/blocks/exit_test.go
+++ b/beacon-chain/core/blocks/exit_test.go
@@ -7,7 +7,7 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bls"

--- a/beacon-chain/core/blocks/proposer_slashing_regression_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_regression_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"

--- a/beacon-chain/core/blocks/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	v "github.com/prysmaticlabs/prysm/beacon-chain/core/validators"
 	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bls"

--- a/beacon-chain/core/helpers/attestation_test.go
+++ b/beacon-chain/core/helpers/attestation_test.go
@@ -7,7 +7,7 @@ import (
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bls"

--- a/beacon-chain/core/helpers/block_test.go
+++ b/beacon-chain/core/helpers/block_test.go
@@ -7,7 +7,7 @@ import (
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -8,7 +8,7 @@ import (
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/go-bitfield"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"

--- a/beacon-chain/core/helpers/randao_test.go
+++ b/beacon-chain/core/helpers/randao_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	types "github.com/prysmaticlabs/eth2-types"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"

--- a/beacon-chain/core/helpers/rewards_penalties_test.go
+++ b/beacon-chain/core/helpers/rewards_penalties_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	types "github.com/prysmaticlabs/eth2-types"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/params"

--- a/beacon-chain/core/helpers/slot_epoch_test.go
+++ b/beacon-chain/core/helpers/slot_epoch_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	types "github.com/prysmaticlabs/eth2-types"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -695,20 +695,6 @@ func TestComputeProposerIndex(t *testing.T) {
 			},
 			want: 7,
 		},
-		{
-			name: "nil_validator",
-			args: args{
-				validators: []*ethpb.Validator{
-					{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
-					{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
-					{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
-					{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
-				},
-				indices: []types.ValidatorIndex{0, 1, 2, 3, 4},
-				seed:    seed,
-			},
-			want: 4,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -719,9 +705,8 @@ func TestComputeProposerIndex(t *testing.T) {
 			if tt.wantedErr != "" {
 				assert.ErrorContains(t, tt.wantedErr, err)
 				return
-			} else {
-				assert.NoError(t, err, "received unexpected error")
 			}
+			assert.NoError(t, err, "received unexpected error")
 			assert.Equal(t, tt.want, got, "ComputeProposerIndex()")
 		})
 	}

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -6,7 +6,7 @@ import (
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
@@ -701,7 +701,6 @@ func TestComputeProposerIndex(t *testing.T) {
 				validators: []*ethpb.Validator{
 					{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
 					{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
-					nil, // Should never happen, but would cause a panic when it does happen.
 					{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
 					{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
 				},
@@ -720,6 +719,8 @@ func TestComputeProposerIndex(t *testing.T) {
 			if tt.wantedErr != "" {
 				assert.ErrorContains(t, tt.wantedErr, err)
 				return
+			} else {
+				assert.NoError(t, err, "received unexpected error")
 			}
 			assert.Equal(t, tt.want, got, "ComputeProposerIndex()")
 		})

--- a/beacon-chain/state/v1/BUILD.bazel
+++ b/beacon-chain/state/v1/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "field_trie_test.go",
         "getters_test.go",
         "helpers_test.go",
+        "readonly_validator_test.go",
         "references_test.go",
         "setters_attestation_test.go",
         "state_test.go",

--- a/beacon-chain/state/v1/BUILD.bazel
+++ b/beacon-chain/state/v1/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "getters_randao.go",
         "getters_state.go",
         "getters_validator.go",
+        "readonly_validator.go",
         "setters_attestation.go",
         "setters_block.go",
         "setters_checkpoint.go",
@@ -27,7 +28,6 @@ go_library(
         "types.go",
         "unsupported_getters.go",
         "unsupported_setters.go",
-        "validator_getters.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/beacon-chain/state/v1",
     visibility = [

--- a/beacon-chain/state/v1/BUILD.bazel
+++ b/beacon-chain/state/v1/BUILD.bazel
@@ -75,6 +75,7 @@ go_test(
     srcs = [
         "field_trie_test.go",
         "getters_test.go",
+        "getters_validator_test.go",
         "helpers_test.go",
         "readonly_validator_test.go",
         "references_test.go",

--- a/beacon-chain/state/v1/field_trie_test.go
+++ b/beacon-chain/state/v1/field_trie_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	types "github.com/prysmaticlabs/eth2-types"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil"

--- a/beacon-chain/state/v1/getters_test.go
+++ b/beacon-chain/state/v1/getters_test.go
@@ -79,12 +79,12 @@ func TestNilState_NoPanic(t *testing.T) {
 }
 
 func TestReadOnlyValidator_NoPanic(t *testing.T) {
-	v := &ReadOnlyValidator{}
+	v := NewValidator(nil)
 	assert.Equal(t, false, v.Slashed(), "Expected not slashed")
 }
 
 func TestReadOnlyValidator_ActivationEligibilityEpochNoPanic(t *testing.T) {
-	v := &ReadOnlyValidator{}
+	v := NewValidator(nil)
 	assert.Equal(t, types.Epoch(0), v.ActivationEligibilityEpoch(), "Expected 0 and not panic")
 }
 

--- a/beacon-chain/state/v1/getters_test.go
+++ b/beacon-chain/state/v1/getters_test.go
@@ -78,16 +78,6 @@ func TestNilState_NoPanic(t *testing.T) {
 	_ = st.FinalizedCheckpoint()
 }
 
-func TestReadOnlyValidator_NoPanic(t *testing.T) {
-	v := NewValidator(nil)
-	assert.Equal(t, false, v.Slashed(), "Expected not slashed")
-}
-
-func TestReadOnlyValidator_ActivationEligibilityEpochNoPanic(t *testing.T) {
-	v := NewValidator(nil)
-	assert.Equal(t, types.Epoch(0), v.ActivationEligibilityEpoch(), "Expected 0 and not panic")
-}
-
 func TestBeaconState_MatchCurrentJustifiedCheckpt(t *testing.T) {
 	c1 := &eth.Checkpoint{Epoch: 1}
 	c2 := &eth.Checkpoint{Epoch: 2}

--- a/beacon-chain/state/v1/getters_validator.go
+++ b/beacon-chain/state/v1/getters_validator.go
@@ -120,20 +120,20 @@ func (b *BeaconState) ValidatorAtIndex(idx types.ValidatorIndex) (*ethpb.Validat
 // doesn't clone the validator.
 func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (iface.ReadOnlyValidator, error) {
 	if !b.hasInnerState() {
-		return ReadOnlyValidator{}, ErrNilInnerState
+		return nil, ErrNilInnerState
 	}
 	if b.state.Validators == nil {
-		return ReadOnlyValidator{}, nil
+		return nil, nil
 	}
 	if uint64(len(b.state.Validators)) <= uint64(idx) {
 		e := NewValidatorIndexOutOfRangeError(idx)
-		return ReadOnlyValidator{}, &e
+		return nil, &e
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return ReadOnlyValidator{b.state.Validators[idx]}, nil
+	return NewValidator(b.state.Validators[idx]), nil
 }
 
 // ValidatorIndexByPubkey returns a given validator by its 48-byte public key.
@@ -195,7 +195,7 @@ func (b *BeaconState) ReadFromEveryValidator(f func(idx int, val iface.ReadOnlyV
 	b.lock.RUnlock()
 
 	for i, v := range validators {
-		err := f(i, ReadOnlyValidator{validator: v})
+		err := f(i, NewValidator(v))
 		if err != nil {
 			return err
 		}

--- a/beacon-chain/state/v1/getters_validator.go
+++ b/beacon-chain/state/v1/getters_validator.go
@@ -133,7 +133,7 @@ func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (iface.
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return NewValidator(b.state.Validators[idx]), nil
+	return NewValidator(b.state.Validators[idx])
 }
 
 // ValidatorIndexByPubkey returns a given validator by its 48-byte public key.
@@ -195,8 +195,11 @@ func (b *BeaconState) ReadFromEveryValidator(f func(idx int, val iface.ReadOnlyV
 	b.lock.RUnlock()
 
 	for i, v := range validators {
-		err := f(i, NewValidator(v))
+		v, err := NewValidator(v)
 		if err != nil {
+			return err
+		}
+		if err := f(i, v); err != nil {
 			return err
 		}
 	}

--- a/beacon-chain/state/v1/getters_validator.go
+++ b/beacon-chain/state/v1/getters_validator.go
@@ -25,7 +25,13 @@ type ValidatorIndexOutOfRangeError struct {
 	message string
 }
 
-// NewStateNotFoundError creates a new error instance.
+var (
+	// ErrNilValidatorsInState returns when accessing validators in the state while the state has a
+	// nil slice for the validators field.
+	ErrNilValidatorsInState = errors.New("state has nil validator slice")
+)
+
+// NewValidatorIndexOutOfRangeError creates a new error instance.
 func NewValidatorIndexOutOfRangeError(index types.ValidatorIndex) ValidatorIndexOutOfRangeError {
 	return ValidatorIndexOutOfRangeError{
 		message: fmt.Sprintf("index %d out of range", index),
@@ -123,7 +129,7 @@ func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (iface.
 		return nil, ErrNilInnerState
 	}
 	if b.state.Validators == nil {
-		return nil, nil
+		return nil, ErrNilValidatorsInState
 	}
 	if uint64(len(b.state.Validators)) <= uint64(idx) {
 		e := NewValidatorIndexOutOfRangeError(idx)

--- a/beacon-chain/state/v1/getters_validator_test.go
+++ b/beacon-chain/state/v1/getters_validator_test.go
@@ -1,0 +1,20 @@
+package v1_test
+
+import (
+	"testing"
+
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestBeaconState_ValidatorAtIndexReadOnly_HandlesNilSlice(t *testing.T) {
+	st, err := v1.InitializeFromProtoUnsafe(&pb.BeaconState{
+		Validators: nil,
+	})
+	require.NoError(t, err)
+
+	_, err = st.ValidatorAtIndexReadOnly(0)
+	assert.Equal(t, v1.ErrNilValidatorsInState, err)
+}

--- a/beacon-chain/state/v1/readonly_validator.go
+++ b/beacon-chain/state/v1/readonly_validator.go
@@ -1,8 +1,15 @@
 package v1
 
 import (
+	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
+	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+)
+
+var (
+	// ErrNilWrappedValidator returns when caller attempts to wrap a nil pointer validator.
+	ErrNilWrappedValidator = errors.New("nil validator cannot be wrapped as readonly")
 )
 
 // readOnlyValidator returns a wrapper that only allows fields from a validator
@@ -11,64 +18,52 @@ type readOnlyValidator struct {
 	validator *ethpb.Validator
 }
 
+var _ = iface.ReadOnlyValidator(&readOnlyValidator{})
+
 // NewValidator initializes the read only wrapper for validator.
-func NewValidator(v *ethpb.Validator) *readOnlyValidator {
-	return &readOnlyValidator{
+func NewValidator(v *ethpb.Validator) (iface.ReadOnlyValidator, error) {
+	rov := &readOnlyValidator{
 		validator: v,
 	}
+	if rov.IsNil() {
+		return nil, ErrNilWrappedValidator
+	}
+	return rov, nil
 }
 
 // EffectiveBalance returns the effective balance of the
 // read only validator.
 func (v readOnlyValidator) EffectiveBalance() uint64 {
-	if v.IsNil() {
-		return 0
-	}
 	return v.validator.EffectiveBalance
 }
 
 // ActivationEligibilityEpoch returns the activation eligibility epoch of the
 // read only validator.
 func (v readOnlyValidator) ActivationEligibilityEpoch() types.Epoch {
-	if v.IsNil() {
-		return 0
-	}
 	return v.validator.ActivationEligibilityEpoch
 }
 
 // ActivationEpoch returns the activation epoch of the
 // read only validator.
 func (v readOnlyValidator) ActivationEpoch() types.Epoch {
-	if v.IsNil() {
-		return 0
-	}
 	return v.validator.ActivationEpoch
 }
 
 // WithdrawableEpoch returns the withdrawable epoch of the
 // read only validator.
 func (v readOnlyValidator) WithdrawableEpoch() types.Epoch {
-	if v.IsNil() {
-		return 0
-	}
 	return v.validator.WithdrawableEpoch
 }
 
 // ExitEpoch returns the exit epoch of the
 // read only validator.
 func (v readOnlyValidator) ExitEpoch() types.Epoch {
-	if v.IsNil() {
-		return 0
-	}
 	return v.validator.ExitEpoch
 }
 
 // PublicKey returns the public key of the
 // read only validator.
 func (v readOnlyValidator) PublicKey() [48]byte {
-	if v.IsNil() {
-		return [48]byte{}
-	}
 	var pubkey [48]byte
 	copy(pubkey[:], v.validator.PublicKey)
 	return pubkey
@@ -84,9 +79,6 @@ func (v readOnlyValidator) WithdrawalCredentials() []byte {
 
 // Slashed returns the read only validator is slashed.
 func (v readOnlyValidator) Slashed() bool {
-	if v.IsNil() {
-		return false
-	}
 	return v.validator.Slashed
 }
 

--- a/beacon-chain/state/v1/readonly_validator.go
+++ b/beacon-chain/state/v1/readonly_validator.go
@@ -5,22 +5,22 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 )
 
-// ReadOnlyValidator returns a wrapper that only allows fields from a validator
+// readOnlyValidator returns a wrapper that only allows fields from a validator
 // to be read, and prevents any modification of internal validator fields.
-type ReadOnlyValidator struct {
+type readOnlyValidator struct {
 	validator *ethpb.Validator
 }
 
 // NewValidator initializes the read only wrapper for validator.
-func NewValidator(v *ethpb.Validator) *ReadOnlyValidator {
-	return &ReadOnlyValidator{
+func NewValidator(v *ethpb.Validator) *readOnlyValidator {
+	return &readOnlyValidator{
 		validator: v,
 	}
 }
 
 // EffectiveBalance returns the effective balance of the
 // read only validator.
-func (v ReadOnlyValidator) EffectiveBalance() uint64 {
+func (v readOnlyValidator) EffectiveBalance() uint64 {
 	if v.IsNil() {
 		return 0
 	}
@@ -29,7 +29,7 @@ func (v ReadOnlyValidator) EffectiveBalance() uint64 {
 
 // ActivationEligibilityEpoch returns the activation eligibility epoch of the
 // read only validator.
-func (v ReadOnlyValidator) ActivationEligibilityEpoch() types.Epoch {
+func (v readOnlyValidator) ActivationEligibilityEpoch() types.Epoch {
 	if v.IsNil() {
 		return 0
 	}
@@ -38,7 +38,7 @@ func (v ReadOnlyValidator) ActivationEligibilityEpoch() types.Epoch {
 
 // ActivationEpoch returns the activation epoch of the
 // read only validator.
-func (v ReadOnlyValidator) ActivationEpoch() types.Epoch {
+func (v readOnlyValidator) ActivationEpoch() types.Epoch {
 	if v.IsNil() {
 		return 0
 	}
@@ -47,7 +47,7 @@ func (v ReadOnlyValidator) ActivationEpoch() types.Epoch {
 
 // WithdrawableEpoch returns the withdrawable epoch of the
 // read only validator.
-func (v ReadOnlyValidator) WithdrawableEpoch() types.Epoch {
+func (v readOnlyValidator) WithdrawableEpoch() types.Epoch {
 	if v.IsNil() {
 		return 0
 	}
@@ -56,7 +56,7 @@ func (v ReadOnlyValidator) WithdrawableEpoch() types.Epoch {
 
 // ExitEpoch returns the exit epoch of the
 // read only validator.
-func (v ReadOnlyValidator) ExitEpoch() types.Epoch {
+func (v readOnlyValidator) ExitEpoch() types.Epoch {
 	if v.IsNil() {
 		return 0
 	}
@@ -65,7 +65,7 @@ func (v ReadOnlyValidator) ExitEpoch() types.Epoch {
 
 // PublicKey returns the public key of the
 // read only validator.
-func (v ReadOnlyValidator) PublicKey() [48]byte {
+func (v readOnlyValidator) PublicKey() [48]byte {
 	if v.IsNil() {
 		return [48]byte{}
 	}
@@ -76,14 +76,14 @@ func (v ReadOnlyValidator) PublicKey() [48]byte {
 
 // WithdrawalCredentials returns the withdrawal credentials of the
 // read only validator.
-func (v ReadOnlyValidator) WithdrawalCredentials() []byte {
+func (v readOnlyValidator) WithdrawalCredentials() []byte {
 	creds := make([]byte, len(v.validator.WithdrawalCredentials))
 	copy(creds, v.validator.WithdrawalCredentials)
 	return creds
 }
 
 // Slashed returns the read only validator is slashed.
-func (v ReadOnlyValidator) Slashed() bool {
+func (v readOnlyValidator) Slashed() bool {
 	if v.IsNil() {
 		return false
 	}
@@ -91,6 +91,6 @@ func (v ReadOnlyValidator) Slashed() bool {
 }
 
 // IsNil returns true if the validator is nil.
-func (v ReadOnlyValidator) IsNil() bool {
+func (v readOnlyValidator) IsNil() bool {
 	return v.validator == nil
 }

--- a/beacon-chain/state/v1/readonly_validator_test.go
+++ b/beacon-chain/state/v1/readonly_validator_test.go
@@ -1,0 +1,73 @@
+package v1_test
+
+import (
+	"testing"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestReadOnlyValidator_ReturnsErrorOnNil(t *testing.T) {
+	if _, err := v1.NewValidator(nil); err != v1.ErrNilWrappedValidator {
+		t.Errorf("Wrong error returned. Got %v, wanted %v", err, v1.ErrNilWrappedValidator)
+	}
+}
+
+func TestReadOnlyValidator_EffectiveBalance(t *testing.T) {
+	bal := uint64(234)
+	v, err := v1.NewValidator(&ethpb.Validator{EffectiveBalance: bal})
+	require.NoError(t, err)
+	assert.Equal(t, bal, v.EffectiveBalance())
+}
+
+func TestReadOnlyValidator_ActivationEligibilityEpoch(t *testing.T) {
+	epoch := types.Epoch(234)
+	v, err := v1.NewValidator(&ethpb.Validator{ActivationEligibilityEpoch: epoch})
+	require.NoError(t, err)
+	assert.Equal(t, epoch, v.ActivationEligibilityEpoch())
+}
+
+func TestReadOnlyValidator_ActivationEpoch(t *testing.T) {
+	epoch := types.Epoch(234)
+	v, err := v1.NewValidator(&ethpb.Validator{ActivationEpoch: epoch})
+	require.NoError(t, err)
+	assert.Equal(t, epoch, v.ActivationEpoch())
+}
+
+func TestReadOnlyValidator_WithdrawableEpoch(t *testing.T) {
+	epoch := types.Epoch(234)
+	v, err := v1.NewValidator(&ethpb.Validator{WithdrawableEpoch: epoch})
+	require.NoError(t, err)
+	assert.Equal(t, epoch, v.WithdrawableEpoch())
+}
+
+func TestReadOnlyValidator_ExitEpoch(t *testing.T) {
+	epoch := types.Epoch(234)
+	v, err := v1.NewValidator(&ethpb.Validator{ExitEpoch: epoch})
+	require.NoError(t, err)
+	assert.Equal(t, epoch, v.ExitEpoch())
+}
+
+func TestReadOnlyValidator_PublicKey(t *testing.T) {
+	key := [48]byte{0xFA, 0xCC}
+	v, err := v1.NewValidator(&ethpb.Validator{PublicKey: key[:]})
+	require.NoError(t, err)
+	assert.Equal(t, key, v.PublicKey())
+}
+
+func TestReadOnlyValidator_WithdrawalCredentials(t *testing.T) {
+	creds := []byte{0xFA, 0xCC}
+	v, err := v1.NewValidator(&ethpb.Validator{WithdrawalCredentials: creds})
+	require.NoError(t, err)
+	assert.DeepEqual(t, creds, v.WithdrawalCredentials())
+}
+
+func TestReadOnlyValidator_Slashed(t *testing.T) {
+	slashed := true
+	v, err := v1.NewValidator(&ethpb.Validator{Slashed: slashed})
+	require.NoError(t, err)
+	assert.Equal(t, slashed, v.Slashed())
+}

--- a/beacon-chain/state/v1/state_trie_test.go
+++ b/beacon-chain/state/v1/state_trie_test.go
@@ -8,7 +8,7 @@ import (
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/go-bitfield"
 	iface "github.com/prysmaticlabs/prysm/beacon-chain/state/interface"
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pbp2p "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	eth "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"

--- a/beacon-chain/state/v1/types_test.go
+++ b/beacon-chain/state/v1/types_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	pb "github.com/prysmaticlabs/prysm/proto/beacon/p2p/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"

--- a/beacon-chain/state/v1/validator_getters.go
+++ b/beacon-chain/state/v1/validator_getters.go
@@ -11,6 +11,13 @@ type ReadOnlyValidator struct {
 	validator *ethpb.Validator
 }
 
+// NewValidator initializes the read only wrapper for validator.
+func NewValidator(v *ethpb.Validator) *ReadOnlyValidator {
+	return &ReadOnlyValidator{
+		validator: v,
+	}
+}
+
 // EffectiveBalance returns the effective balance of the
 // read only validator.
 func (v ReadOnlyValidator) EffectiveBalance() uint64 {


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Required for Altair / hf1 branch. 

**Which issues(s) does this PR fix?**

**Other notes for review**

Key changes:
- v1.readOnlyValidator package private
- v1.NewValidator return the interface for ease of use
- v1.NewValidator returns an error when attempting to wrap a nil validator
- v1.(*BeaconState).ValidatorAtIndexReadOnly returns an error when trying to access a validator from a state with a nil slice for validators

GoImports punished me for some reason. :shrug: 