### PR TITLE
Beta.1: update `TargetAggregatorsPerSyncSubcommittee` to 16

### DIFF
--- a/shared/params/mainnet_config.go
+++ b/shared/params/mainnet_config.go
@@ -208,7 +208,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	WeightDenominator:  64,
 
 	// Validator related values.
-	TargetAggregatorsPerSyncSubcommittee: 4,
+	TargetAggregatorsPerSyncSubcommittee: 16,
 	SyncCommitteeSubnetCount:             4,
 
 	// Misc values.


### PR DESCRIPTION
Update `hf1` branch to `beta.1` release, which updates target sync committee aggregators to 16 constant

Reference: https://github.com/ethereum/eth2.0-specs/releases/tag/v1.1.0-beta.1