### PR TITLE
Fix next epoch sync duty calculation

### DIFF
--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -43,10 +43,10 @@ type syncCommitteeIndexPosition struct {
 	vIndexToPositionMap      map[types.ValidatorIndex]*positionInCommittee
 }
 
-// Index position of individual validator of current epoch and previous epoch sync committee.
+// Index position of individual validator of current period and previous period sync committee.
 type positionInCommittee struct {
-	currentEpoch []uint64
-	nextEpoch    []uint64
+	currentPeriod []uint64
+	nextPeriod    []uint64
 }
 
 // NewSyncCommittee initializes and returns a new SyncCommitteeCache.
@@ -56,11 +56,11 @@ func NewSyncCommittee() *SyncCommitteeCache {
 	}
 }
 
-// CurrentEpochIndexPosition returns current epoch index position of a validator index with respect with
+// CurrentPeriodIndexPosition returns current period index position of a validator index with respect with
 // sync committee. If the input validator index has no assignment, an empty list will be returned.
 // If the input root does not exist in cache, ErrNonExistingSyncCommitteeKey is returned.
 // Then performing manual checking of state for index position in state is recommended.
-func (s *SyncCommitteeCache) CurrentEpochIndexPosition(root [32]byte, valIdx types.ValidatorIndex) ([]uint64, error) {
+func (s *SyncCommitteeCache) CurrentPeriodIndexPosition(root [32]byte, valIdx types.ValidatorIndex) ([]uint64, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
@@ -72,14 +72,14 @@ func (s *SyncCommitteeCache) CurrentEpochIndexPosition(root [32]byte, valIdx typ
 		return []uint64{}, nil
 	}
 
-	return pos.currentEpoch, nil
+	return pos.currentPeriod, nil
 }
 
-// NextEpochIndexPosition returns next epoch index position of a validator index in respect with sync committee.
+// NextPeriodIndexPosition returns next period index position of a validator index in respect with sync committee.
 // If the input validator index has no assignment, an empty list will be returned.
 // If the input root does not exist in cache, ErrNonExistingSyncCommitteeKey is returned.
 // Then performing manual checking of state for index position in state is recommended.
-func (s *SyncCommitteeCache) NextEpochIndexPosition(root [32]byte, valIdx types.ValidatorIndex) ([]uint64, error) {
+func (s *SyncCommitteeCache) NextPeriodIndexPosition(root [32]byte, valIdx types.ValidatorIndex) ([]uint64, error) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 
@@ -90,10 +90,10 @@ func (s *SyncCommitteeCache) NextEpochIndexPosition(root [32]byte, valIdx types.
 	if pos == nil {
 		return []uint64{}, nil
 	}
-	return pos.nextEpoch, nil
+	return pos.nextPeriod, nil
 }
 
-// Helper function for `CurrentEpochIndexPosition` and `NextEpochIndexPosition` to return a mapping
+// Helper function for `CurrentPeriodIndexPosition` and `NextPeriodIndexPosition` to return a mapping
 // of validator index to its index(s) position in the sync committee.
 func (s *SyncCommitteeCache) idxPositionInCommittee(
 	root [32]byte, valIdx types.ValidatorIndex,
@@ -135,10 +135,10 @@ func (s *SyncCommitteeCache) UpdatePositionsInCommittee(syncCommitteeBoundaryRoo
 			continue
 		}
 		if _, ok := positionsMap[validatorIndex]; !ok {
-			m := &positionInCommittee{currentEpoch: []uint64{uint64(i)}, nextEpoch: []uint64{}}
+			m := &positionInCommittee{currentPeriod: []uint64{uint64(i)}, nextPeriod: []uint64{}}
 			positionsMap[validatorIndex] = m
 		} else {
-			positionsMap[validatorIndex].currentEpoch = append(positionsMap[validatorIndex].currentEpoch, uint64(i))
+			positionsMap[validatorIndex].currentPeriod = append(positionsMap[validatorIndex].currentPeriod, uint64(i))
 		}
 	}
 
@@ -153,10 +153,10 @@ func (s *SyncCommitteeCache) UpdatePositionsInCommittee(syncCommitteeBoundaryRoo
 			continue
 		}
 		if _, ok := positionsMap[validatorIndex]; !ok {
-			m := &positionInCommittee{nextEpoch: []uint64{uint64(i)}, currentEpoch: []uint64{}}
+			m := &positionInCommittee{nextPeriod: []uint64{uint64(i)}, currentPeriod: []uint64{}}
 			positionsMap[validatorIndex] = m
 		} else {
-			positionsMap[validatorIndex].nextEpoch = append(positionsMap[validatorIndex].nextEpoch, uint64(i))
+			positionsMap[validatorIndex].nextPeriod = append(positionsMap[validatorIndex].nextPeriod, uint64(i))
 		}
 	}
 

--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -43,7 +43,7 @@ type syncCommitteeIndexPosition struct {
 	vIndexToPositionMap      map[types.ValidatorIndex]*positionInCommittee
 }
 
-// Index position of individual validator of current period and previous period sync committee.
+// Index position of individual validator of current period and next period sync committee.
 type positionInCommittee struct {
 	currentPeriod []uint64
 	nextPeriod    []uint64

--- a/beacon-chain/cache/sync_committee_disabled.go
+++ b/beacon-chain/cache/sync_committee_disabled.go
@@ -17,12 +17,12 @@ func NewSyncCommittee() *FakeSyncCommitteeCache {
 }
 
 // CurrentPeriodIndexPosition -- fake.
-func (s *FakeSyncCommitteeCache) CurrentEpochIndexPosition(root [32]byte, valIdx types.ValidatorIndex) ([]uint64, error) {
+func (s *FakeSyncCommitteeCache) CurrentPeriodIndexPosition(root [32]byte, valIdx types.ValidatorIndex) ([]uint64, error) {
 	return nil, nil
 }
 
 // NextPeriodIndexPosition -- fake.
-func (s *FakeSyncCommitteeCache) NextEpochIndexPosition(root [32]byte, valIdx types.ValidatorIndex) ([]uint64, error) {
+func (s *FakeSyncCommitteeCache) NextPeriodIndexPosition(root [32]byte, valIdx types.ValidatorIndex) ([]uint64, error) {
 	return nil, nil
 }
 

--- a/beacon-chain/cache/sync_committee_disabled.go
+++ b/beacon-chain/cache/sync_committee_disabled.go
@@ -16,12 +16,12 @@ func NewSyncCommittee() *FakeSyncCommitteeCache {
 	return &FakeSyncCommitteeCache{}
 }
 
-// CurrentEpochIndexPosition -- fake.
+// CurrentPeriodIndexPosition -- fake.
 func (s *FakeSyncCommitteeCache) CurrentEpochIndexPosition(root [32]byte, valIdx types.ValidatorIndex) ([]uint64, error) {
 	return nil, nil
 }
 
-// NextEpochIndexPosition -- fake.
+// NextPeriodIndexPosition -- fake.
 func (s *FakeSyncCommitteeCache) NextEpochIndexPosition(root [32]byte, valIdx types.ValidatorIndex) ([]uint64, error) {
 	return nil, nil
 }

--- a/beacon-chain/cache/sync_committee_test.go
+++ b/beacon-chain/cache/sync_committee_test.go
@@ -167,12 +167,12 @@ func TestSyncCommitteeCache_CanUpdateAndRetrieve(t *testing.T) {
 			r := [32]byte{'a'}
 			require.NoError(t, cache.UpdatePositionsInCommittee(r, s))
 			for key, indices := range tt.currentSyncMap {
-				pos, err := cache.CurrentEpochIndexPosition(r, key)
+				pos, err := cache.CurrentPeriodIndexPosition(r, key)
 				require.NoError(t, err)
 				require.DeepEqual(t, indices, pos)
 			}
 			for key, indices := range tt.nextSyncMap {
-				pos, err := cache.NextEpochIndexPosition(r, key)
+				pos, err := cache.NextPeriodIndexPosition(r, key)
 				require.NoError(t, err)
 				require.DeepEqual(t, indices, pos)
 			}
@@ -182,7 +182,7 @@ func TestSyncCommitteeCache_CanUpdateAndRetrieve(t *testing.T) {
 
 func TestSyncCommitteeCache_RootDoesNotExist(t *testing.T) {
 	c := cache.NewSyncCommittee()
-	_, err := c.CurrentEpochIndexPosition([32]byte{}, 0)
+	_, err := c.CurrentPeriodIndexPosition([32]byte{}, 0)
 	require.Equal(t, cache.ErrNonExistingSyncCommitteeKey, err)
 }
 
@@ -198,10 +198,10 @@ func TestSyncCommitteeCache_CanRotate(t *testing.T) {
 	require.NoError(t, s.SetCurrentSyncCommittee(convertToCommittee([][]byte{{4}})))
 	require.NoError(t, c.UpdatePositionsInCommittee([32]byte{'d'}, s))
 
-	_, err := c.CurrentEpochIndexPosition([32]byte{'a'}, 0)
+	_, err := c.CurrentPeriodIndexPosition([32]byte{'a'}, 0)
 	require.Equal(t, cache.ErrNonExistingSyncCommitteeKey, err)
 
-	_, err = c.CurrentEpochIndexPosition([32]byte{'c'}, 0)
+	_, err = c.CurrentPeriodIndexPosition([32]byte{'c'}, 0)
 	require.NoError(t, err)
 }
 

--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -405,18 +405,18 @@ func ClearCache() {
 	syncCommitteeCache = cache.NewSyncCommittee()
 }
 
-// IsCurrentEpochSyncCommittee returns true if the input validator index belongs in the current epoch sync committee
+// IsCurrentPeriodSyncCommittee returns true if the input validator index belongs in the current period sync committee
 // along with the sync committee root.
 // 1.) Checks if the public key exists in the sync committee cache
 // 2.) If 1 fails, checks if the public key exists in the input current sync committee object
-func IsCurrentEpochSyncCommittee(
+func IsCurrentPeriodSyncCommittee(
 	st iface.BeaconStateAltair, valIdx types.ValidatorIndex,
 ) (bool, error) {
 	root, err := syncPeriodBoundaryRoot(st)
 	if err != nil {
 		return false, err
 	}
-	indices, err := syncCommitteeCache.CurrentEpochIndexPosition(bytesutil.ToBytes32(root), valIdx)
+	indices, err := syncCommitteeCache.CurrentPeriodIndexPosition(bytesutil.ToBytes32(root), valIdx)
 	if err == cache.ErrNonExistingSyncCommitteeKey {
 		val, err := st.ValidatorAtIndex(valIdx)
 		if err != nil {
@@ -442,18 +442,18 @@ func IsCurrentEpochSyncCommittee(
 	return len(indices) > 0, nil
 }
 
-// IsNextEpochSyncCommittee returns true if the input validator index belongs in the next epoch sync committee
-// along with the sync committee root.
+// IsNextPeriodSyncCommittee returns true if the input validator index belongs in the next period sync committee
+// along with the sync period boundary root.
 // 1.) Checks if the public key exists in the sync committee cache
 // 2.) If 1 fails, checks if the public key exists in the input next sync committee object
-func IsNextEpochSyncCommittee(
+func IsNextPeriodSyncCommittee(
 	st iface.BeaconStateAltair, valIdx types.ValidatorIndex,
 ) (bool, error) {
 	root, err := syncPeriodBoundaryRoot(st)
 	if err != nil {
 		return false, err
 	}
-	indices, err := syncCommitteeCache.NextEpochIndexPosition(bytesutil.ToBytes32(root), valIdx)
+	indices, err := syncCommitteeCache.NextPeriodIndexPosition(bytesutil.ToBytes32(root), valIdx)
 	if err == cache.ErrNonExistingSyncCommitteeKey {
 		val, err := st.ValidatorAtIndex(valIdx)
 		if err != nil {
@@ -471,16 +471,16 @@ func IsNextEpochSyncCommittee(
 	return len(indices) > 0, nil
 }
 
-// CurrentEpochSyncSubcommitteeIndices returns the subcommittee indices of the
-// current epoch sync committee for input validator.
-func CurrentEpochSyncSubcommitteeIndices(
+// CurrentPeriodSyncSubcommitteeIndices returns the subcommittee indices of the
+// current period sync committee for input validator.
+func CurrentPeriodSyncSubcommitteeIndices(
 	st iface.BeaconStateAltair, valIdx types.ValidatorIndex,
 ) ([]uint64, error) {
 	root, err := syncPeriodBoundaryRoot(st)
 	if err != nil {
 		return nil, err
 	}
-	indices, err := syncCommitteeCache.CurrentEpochIndexPosition(bytesutil.ToBytes32(root), valIdx)
+	indices, err := syncCommitteeCache.CurrentPeriodIndexPosition(bytesutil.ToBytes32(root), valIdx)
 	if err == cache.ErrNonExistingSyncCommitteeKey {
 		val, err := st.ValidatorAtIndex(valIdx)
 		if err != nil {
@@ -506,15 +506,15 @@ func CurrentEpochSyncSubcommitteeIndices(
 	return indices, nil
 }
 
-// NextEpochSyncSubcommitteeIndices returns the subcommittee indices of the next epoch sync committee for input validator.
-func NextEpochSyncSubcommitteeIndices(
+// NextPeriodSyncSubcommitteeIndices returns the subcommittee indices of the next period sync committee for input validator.
+func NextPeriodSyncSubcommitteeIndices(
 	st iface.BeaconStateAltair, valIdx types.ValidatorIndex,
 ) ([]uint64, error) {
 	root, err := syncPeriodBoundaryRoot(st)
 	if err != nil {
 		return nil, err
 	}
-	indices, err := syncCommitteeCache.NextEpochIndexPosition(bytesutil.ToBytes32(root), valIdx)
+	indices, err := syncCommitteeCache.NextPeriodIndexPosition(bytesutil.ToBytes32(root), valIdx)
 	if err == cache.ErrNonExistingSyncCommitteeKey {
 		val, err := st.ValidatorAtIndex(valIdx)
 		if err != nil {

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -663,7 +663,7 @@ func TestIsCurrentEpochSyncCommittee_UsingCache(t *testing.T) {
 	r := [32]byte{'a'}
 	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
 
-	ok, err := IsCurrentEpochSyncCommittee(state, 0)
+	ok, err := IsCurrentPeriodSyncCommittee(state, 0)
 	require.NoError(t, err)
 	require.Equal(t, true, ok)
 }
@@ -689,7 +689,7 @@ func TestIsCurrentEpochSyncCommittee_UsingCommittee(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	ok, err := IsCurrentEpochSyncCommittee(state, 0)
+	ok, err := IsCurrentPeriodSyncCommittee(state, 0)
 	require.NoError(t, err)
 	require.Equal(t, true, ok)
 }
@@ -715,7 +715,7 @@ func TestIsCurrentEpochSyncCommittee_DoesNotExist(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	ok, err := IsCurrentEpochSyncCommittee(state, 12390192)
+	ok, err := IsCurrentPeriodSyncCommittee(state, 12390192)
 	require.NoError(t, err)
 	require.Equal(t, false, ok)
 }
@@ -745,7 +745,7 @@ func TestIsNextEpochSyncCommittee_UsingCache(t *testing.T) {
 	r := [32]byte{'a'}
 	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
 
-	ok, err := IsNextEpochSyncCommittee(state, 0)
+	ok, err := IsNextPeriodSyncCommittee(state, 0)
 	require.NoError(t, err)
 	require.Equal(t, true, ok)
 }
@@ -771,7 +771,7 @@ func TestIsNextEpochSyncCommittee_UsingCommittee(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	ok, err := IsNextEpochSyncCommittee(state, 0)
+	ok, err := IsNextPeriodSyncCommittee(state, 0)
 	require.NoError(t, err)
 	require.Equal(t, true, ok)
 }
@@ -797,7 +797,7 @@ func TestIsNextEpochSyncCommittee_DoesNotExist(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	ok, err := IsNextEpochSyncCommittee(state, 120391029)
+	ok, err := IsNextPeriodSyncCommittee(state, 120391029)
 	require.NoError(t, err)
 	require.Equal(t, false, ok)
 }
@@ -827,7 +827,7 @@ func TestCurrentEpochSyncSubcommitteeIndices_UsingCache(t *testing.T) {
 	r := [32]byte{'a'}
 	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
 
-	index, err := CurrentEpochSyncSubcommitteeIndices(state, 0)
+	index, err := CurrentPeriodSyncSubcommitteeIndices(state, 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []uint64{0}, index)
 }
@@ -857,17 +857,17 @@ func TestCurrentEpochSyncSubcommitteeIndices_UsingCommittee(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test that cache was empty.
-	_, err = syncCommitteeCache.CurrentEpochIndexPosition(bytesutil.ToBytes32(root), 0)
+	_, err = syncCommitteeCache.CurrentPeriodIndexPosition(bytesutil.ToBytes32(root), 0)
 	require.Equal(t, cache.ErrNonExistingSyncCommitteeKey, err)
 
 	// Test that helper can retrieve the index given empty cache.
-	index, err := CurrentEpochSyncSubcommitteeIndices(state, 0)
+	index, err := CurrentPeriodSyncSubcommitteeIndices(state, 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []uint64{0}, index)
 
 	// Test that cache was able to fill on miss.
 	time.Sleep(100 * time.Millisecond)
-	index, err = syncCommitteeCache.CurrentEpochIndexPosition(bytesutil.ToBytes32(root), 0)
+	index, err = syncCommitteeCache.CurrentPeriodIndexPosition(bytesutil.ToBytes32(root), 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []uint64{0}, index)
 }
@@ -894,7 +894,7 @@ func TestCurrentEpochSyncSubcommitteeIndices_DoesNotExist(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	index, err := CurrentEpochSyncSubcommitteeIndices(state, 129301923)
+	index, err := CurrentPeriodSyncSubcommitteeIndices(state, 129301923)
 	require.NoError(t, err)
 	require.DeepEqual(t, []uint64(nil), index)
 }
@@ -924,7 +924,7 @@ func TestNextEpochSyncSubcommitteeIndices_UsingCache(t *testing.T) {
 	r := [32]byte{'a'}
 	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
 
-	index, err := NextEpochSyncSubcommitteeIndices(state, 0)
+	index, err := NextPeriodSyncSubcommitteeIndices(state, 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []uint64{0}, index)
 }
@@ -950,7 +950,7 @@ func TestNextEpochSyncSubcommitteeIndices_UsingCommittee(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	index, err := NextEpochSyncSubcommitteeIndices(state, 0)
+	index, err := NextPeriodSyncSubcommitteeIndices(state, 0)
 	require.NoError(t, err)
 	require.DeepEqual(t, []uint64{0}, index)
 }
@@ -977,7 +977,7 @@ func TestNextEpochSyncSubcommitteeIndices_DoesNotExist(t *testing.T) {
 	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
 	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
 
-	index, err := NextEpochSyncSubcommitteeIndices(state, 21093019)
+	index, err := NextPeriodSyncSubcommitteeIndices(state, 21093019)
 	require.NoError(t, err)
 	require.DeepEqual(t, []uint64(nil), index)
 }

--- a/beacon-chain/p2p/types/object_mapping.go
+++ b/beacon-chain/p2p/types/object_mapping.go
@@ -39,7 +39,7 @@ var (
 // reset maps and reinitialize them.
 func InitializeDataMaps() {
 	// Reset our block map.
-	BlockMap = map[[4]byte]func() (interfaces.SignedBeaconBlock, error) {
+	BlockMap = map[[4]byte]func() (interfaces.SignedBeaconBlock, error){
 		bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion): func() (interfaces.SignedBeaconBlock, error) {
 			return wrapperv1.WrappedPhase0SignedBeaconBlock(&eth.SignedBeaconBlock{}), nil
 		},

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/assignments.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/assignments.go
@@ -204,6 +204,9 @@ func (vs *Server) duties(ctx context.Context, req *ethpb.DutiesRequest) (*ethpb.
 			nextSlotEpoch := helpers.SlotToEpoch(s.Slot() + 1)
 			currentEpoch := helpers.CurrentEpoch(s)
 
+			// Next epoch sync committee duty is assigned with next period sync committee only during
+			// sync period epoch boundary (ie. EPOCHS_PER_SYNC_COMMITTEE_PERIOD - 1). Else wise
+			// next epoch sync committee duty is the same as current epoch.
 			if helpers.SyncCommitteePeriod(nextSlotEpoch) == helpers.SyncCommitteePeriod(currentEpoch)+1 {
 				nsc, err := s.NextSyncCommittee()
 				if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/assignments.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/assignments.go
@@ -193,23 +193,31 @@ func (vs *Server) duties(ctx context.Context, req *ethpb.DutiesRequest) (*ethpb.
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "Could not get current sync committee: %v", err)
 			}
-			assignment.IsSyncCommittee, err = helpers.IsCurrentEpochSyncCommittee(s, idx)
+			assignment.IsSyncCommittee, err = helpers.IsCurrentPeriodSyncCommittee(s, idx)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "Could not determine current epoch sync committee: %v", err)
 			}
 			if assignment.IsSyncCommittee {
 				assignValidatorToSyncSubnet(req.Epoch, syncCommPeriod, pubKey, csc, assignment.Status)
 			}
-			nsc, err := s.NextSyncCommittee()
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "Could not get next sync committee: %v", err)
-			}
-			nextAssignment.IsSyncCommittee, err = helpers.IsNextEpochSyncCommittee(s, idx)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "Could not determine next epoch sync committee: %v", err)
-			}
-			if nextAssignment.IsSyncCommittee {
-				assignValidatorToSyncSubnet(req.Epoch, syncCommPeriod+1, pubKey, nsc, nextAssignment.Status)
+
+			nextSlotEpoch := helpers.SlotToEpoch(s.Slot() + 1)
+			currentEpoch := helpers.CurrentEpoch(s)
+
+			if helpers.SyncCommitteePeriod(nextSlotEpoch) == helpers.SyncCommitteePeriod(currentEpoch)+1 {
+				nsc, err := s.NextSyncCommittee()
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "Could not get next sync committee: %v", err)
+				}
+				nextAssignment.IsSyncCommittee, err = helpers.IsNextPeriodSyncCommittee(s, idx)
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "Could not determine next epoch sync committee: %v", err)
+				}
+				if nextAssignment.IsSyncCommittee {
+					assignValidatorToSyncSubnet(req.Epoch, syncCommPeriod+1, pubKey, nsc, nextAssignment.Status)
+				}
+			} else {
+				nextAssignment.IsSyncCommittee = assignment.IsSyncCommittee
 			}
 		}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
@@ -189,7 +189,7 @@ func TestGetAltairDuties_SyncCommitteeOK(t *testing.T) {
 		assert.Equal(t, res.CurrentEpochDuties[i].IsSyncCommittee, res.NextEpochDuties[i].IsSyncCommittee)
 	}
 
-	// Current epoch and next epoch duties should be equal at the sync period epoch boundary.
+	// Current epoch and next epoch duties should not be equal at the sync period epoch boundary.
 	req = &ethpb.DutiesRequest{
 		PublicKeys: pubKeys,
 		Epoch:      params.BeaconConfig().EpochsPerSyncCommitteePeriod - 1,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/assignments_test.go
@@ -139,8 +139,9 @@ func TestGetAltairDuties_SyncCommitteeOK(t *testing.T) {
 		pubkeysAs48ByteType[i] = bytesutil.ToBytes48(pk)
 	}
 
+	slot := uint64(params.BeaconConfig().SlotsPerEpoch) * uint64(params.BeaconConfig().EpochsPerSyncCommitteePeriod) * params.BeaconConfig().SecondsPerSlot
 	chain := &mockChain.ChainService{
-		State: bs, Root: genesisRoot[:], Genesis: time.Now(),
+		State: bs, Root: genesisRoot[:], Genesis: time.Now().Add(time.Duration(-1*int64(slot-1)) * time.Second),
 	}
 	vs := &Server{
 		HeadFetcher:     chain,
@@ -184,6 +185,19 @@ func TestGetAltairDuties_SyncCommitteeOK(t *testing.T) {
 	}
 	for i := 0; i < len(res.CurrentEpochDuties); i++ {
 		assert.Equal(t, true, res.CurrentEpochDuties[i].IsSyncCommittee)
+		// Current epoch and next epoch duties should be equal before the sync period epoch boundary.
+		assert.Equal(t, res.CurrentEpochDuties[i].IsSyncCommittee, res.NextEpochDuties[i].IsSyncCommittee)
+	}
+
+	// Current epoch and next epoch duties should be equal at the sync period epoch boundary.
+	req = &ethpb.DutiesRequest{
+		PublicKeys: pubKeys,
+		Epoch:      params.BeaconConfig().EpochsPerSyncCommitteePeriod - 1,
+	}
+	res, err = vs.GetDuties(context.Background(), req)
+	require.NoError(t, err, "Could not call epoch committee assignment")
+	for i := 0; i < len(res.CurrentEpochDuties); i++ {
+		assert.NotEqual(t, res.CurrentEpochDuties[i].IsSyncCommittee, res.NextEpochDuties[i].IsSyncCommittee)
 	}
 }
 

--- a/beacon-chain/rpc/prysm/v2/validator/sync_committee.go
+++ b/beacon-chain/rpc/prysm/v2/validator/sync_committee.go
@@ -118,7 +118,7 @@ func (vs *Server) syncSubcommitteeIndex(
 	}
 	switch {
 	case helpers.SyncCommitteePeriod(nextSlotEpoch) == helpers.SyncCommitteePeriod(currentEpoch):
-		indices, err := helpers.CurrentEpochSyncSubcommitteeIndices(headState, valIdx)
+		indices, err := helpers.CurrentPeriodSyncSubcommitteeIndices(headState, valIdx)
 		if err != nil {
 			return nil, err
 		}
@@ -127,7 +127,7 @@ func (vs *Server) syncSubcommitteeIndex(
 		}, nil
 	// At sync committee period boundary, validator should sample the next epoch sync committee.
 	case helpers.SyncCommitteePeriod(nextSlotEpoch) == helpers.SyncCommitteePeriod(currentEpoch)+1:
-		indices, err := helpers.NextEpochSyncSubcommitteeIndices(headState, valIdx)
+		indices, err := helpers.NextPeriodSyncSubcommitteeIndices(headState, valIdx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixed a bug when validator requests beacon node for duties at slot epoch boundary -1 (ie. every `N * SLOTS_PER_EPOCH-1`), beacon node incorrectly responds sync committee duties based on next period, instead of current period. The only time beacon node should respond based on next period is epochs per sync committee period multiply epoch boundary - 1 (ie. every `N * SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD-1`)

While fixing the bug, I also fixed much of the bad usage of terminology where `epoch` and `period` are mixed up