### PR TITLE
Enable Sync Evaluator For E2E

### DIFF
--- a/endtoend/minimal_e2e_test.go
+++ b/endtoend/minimal_e2e_test.go
@@ -53,6 +53,7 @@ func e2eMinimal(t *testing.T, usePrysmSh bool) {
 			ev.MetricsCheck,
 			ev.ValidatorsAreActive,
 			ev.ValidatorsParticipating,
+			ev.ValidatorSyncParticipation,
 			ev.FinalizationOccurs,
 			ev.ProcessesDepositsInBlocks,
 			ev.VerifyBlockGraffiti,


### PR DESCRIPTION
**What type of PR is this?**

E2E Addition

**What does this PR do? Why is it needed?**

- [x] Adds back and enables the sync evaluator so that we can track sync committee participation better.
- [x] Fix a panic that was triggered in E2E during the altair fork transition.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
