### PR TITLE
v1alpha1 validators: catch possible reqState nil case

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators.go
@@ -228,6 +228,9 @@ func (bs *Server) ListValidators(
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get requested state: %v", err)
 	}
+	if reqState == nil || reqState.IsNil() {
+		return nil, status.Error(codes.Internal, "requested state is nil")
+	}
 
 	s, err := helpers.StartSlot(requestedEpoch)
 	if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators.go
@@ -229,7 +229,7 @@ func (bs *Server) ListValidators(
 		return nil, status.Errorf(codes.Internal, "Could not get requested state: %v", err)
 	}
 	if reqState == nil || reqState.IsNil() {
-		return nil, status.Error(codes.Internal, "requested state is nil")
+		return nil, status.Error(codes.Internal, "Requested state is nil")
 	}
 
 	s, err := helpers.StartSlot(requestedEpoch)

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
@@ -453,7 +453,7 @@ func TestServer_ListValidators_reqStateIsNil(t *testing.T) {
 	}
 	// request uses HeadFetcher to get reqState.
 	req1 := &ethpb.ListValidatorsRequest{PageToken: strconv.Itoa(1), PageSize: 100}
-	wanted := "requested state is nil"
+	wanted := "Requested state is nil"
 	_, err := bs.ListValidators(context.Background(), req1)
 	assert.ErrorContains(t, wanted, err)
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The `reqState` variable can be `nil` at certain times even if the underlying request didn't return an error which causes a runtime error. This PR fixes the issue by verifying that the value isn't `nil` 

**Which issues(s) does this PR fix?**

Fixes #9161  

**Other notes for review**

None.