### PR TITLE
Use Only Checkpoint Cache for Processing Attestations

### DIFF
--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -54,18 +54,13 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (stat
 				return nil, errors.Wrapf(err, "could not process slots up to epoch %d", c.Epoch)
 			}
 		}
-		if err := s.checkpointStateCache.AddCheckpointState(c, baseState); err != nil {
-			return nil, errors.Wrap(err, "could not saved checkpoint state to cache")
-		}
-		return baseState, nil
 	}
-
 	// Sharing the same state across caches is perfectly fine here, the fetching
 	// of attestation prestate is by far the most accessed state fetching pattern in
 	// the beacon node. An extra state instance cached isn't an issue in the bigger
 	// picture.
 	if err := s.checkpointStateCache.AddCheckpointState(c, baseState); err != nil {
-		return nil, errors.Wrap(err, "could not saved checkpoint state to cache")
+		return nil, errors.Wrap(err, "could not save checkpoint state to cache")
 	}
 	return baseState, nil
 

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -60,16 +60,12 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (stat
 		return baseState, nil
 	}
 
-	// To avoid sharing the same state across checkpoint state cache and hot state cache,
-	// we don't add the state to check point cache.
-	has, err := s.cfg.StateGen.HasStateInCache(ctx, bytesutil.ToBytes32(c.Root))
-	if err != nil {
-		return nil, err
-	}
-	if !has {
-		if err := s.checkpointStateCache.AddCheckpointState(c, baseState); err != nil {
-			return nil, errors.Wrap(err, "could not saved checkpoint state to cache")
-		}
+	// Sharing the same state across caches is perfectly fine here, the fetching
+	// of attestation prestate is by far the most accessed state fetching pattern in
+	// the beacon node. An extra state instance cached isn't an issue in the bigger
+	// picture.
+	if err := s.checkpointStateCache.AddCheckpointState(c, baseState); err != nil {
+		return nil, errors.Wrap(err, "could not saved checkpoint state to cache")
 	}
 	return baseState, nil
 


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] In the event of a cache miss, we always store the regenerated state into the checkpoint cache.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
