### PR TITLE
Remove Historical State Representation Flag From Dev

### DIFF
--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -141,7 +141,6 @@ var devModeFlags = []cli.Flag{
 	enableLargerGossipHistory,
 	enableNextSlotStateCache,
 	forceOptMaxCoverAggregationStategy,
-	enableHistoricalSpaceRepresentation,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

- [x] Given that efficient historical representation flag is a one way journey with regards to migration, we do not add it to dev. As if
any user does run `--dev` there is no way to revert the changes from a bug in the new feature.
  
**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
