### PR TITLE
Fail fast when using old define=ssz=<value>

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -24,11 +24,6 @@ build --sandbox_default_allow_network=false
 build --workspace_status_command=./scripts/workspace_status.sh
 build --stamp
 
-# Use mainnet protobufs at runtime
-run --define ssz=mainnet
-test --define ssz=mainnet
-build --define ssz=mainnet
-
 # Prevent PATH changes from rebuilding when switching from IDE to command line.
 build --incompatible_strict_action_env
 test --incompatible_strict_action_env

--- a/tools/ssz.bzl
+++ b/tools/ssz.bzl
@@ -5,7 +5,6 @@ load(
 )
 
 def _ssz_go_proto_library_impl(ctx):
-    print(ctx.var.get("ssz"))
     if ctx.var.get("ssz"):
         fail("--define=ssz=<value> is no longer supported, please use --//proto:network=<value>")
 

--- a/tools/ssz.bzl
+++ b/tools/ssz.bzl
@@ -5,6 +5,10 @@ load(
 )
 
 def _ssz_go_proto_library_impl(ctx):
+    print(ctx.var.get("ssz"))
+    if ctx.var.get("ssz"):
+        fail("--define=ssz=<value> is no longer supported, please use --//proto:network=<value>")
+
     if ctx.attr.go_proto != None:
         go_proto = ctx.attr.go_proto
         input_files = go_proto[OutputGroupInfo].go_generated_srcs.to_list()


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Since `--define=ssz=<value>` was changed in #9122, users may have been still using the old flag which has no effect or feedback.

**Which issues(s) does this PR fix?**


**Other notes for review**
