### PR TITLE
General Interop Fixes

### DIFF
--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -75,6 +75,7 @@ go_test(
         "//shared/testutil:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
+        "//shared/timeutils:go_default_library",
         "//shared/trieutil:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",

--- a/beacon-chain/core/altair/sync_committee.go
+++ b/beacon-chain/core/altair/sync_committee.go
@@ -172,7 +172,7 @@ func SyncSubCommitteePubkeys(syncCommittee *ethpb.SyncCommittee, subComIdx types
 //    modulo = max(1, SYNC_COMMITTEE_SIZE // SYNC_COMMITTEE_SUBNET_COUNT // TARGET_AGGREGATORS_PER_SYNC_SUBCOMMITTEE)
 //    return bytes_to_uint64(hash(signature)[0:8]) % modulo == 0
 func IsSyncCommitteeAggregator(sig []byte) (bool, error) {
-	if len(sig) != params.BeaconConfig().BLSPubkeyLength {
+	if len(sig) != params.BeaconConfig().BLSSignatureLength {
 		return false, errors.New("incorrect sig length")
 	}
 

--- a/beacon-chain/core/altair/sync_committee_test.go
+++ b/beacon-chain/core/altair/sync_committee_test.go
@@ -2,6 +2,7 @@ package altair_test
 
 import (
 	"testing"
+	"time"
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
@@ -10,7 +11,9 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bls"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+	"github.com/prysmaticlabs/prysm/shared/timeutils"
 )
 
 func TestSyncCommitteeIndices_CanGet(t *testing.T) {
@@ -275,6 +278,107 @@ func TestSyncSubCommitteePubkeys_CanGet(t *testing.T) {
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, com.Pubkeys[3*subCommSize:], sub)
 
+}
+
+func Test_ValidateSyncMessageTime(t *testing.T) {
+	if params.BeaconNetworkConfig().MaximumGossipClockDisparity < 200*time.Millisecond {
+		t.Fatal("This test expects the maximum clock disparity to be at least 200ms")
+	}
+
+	type args struct {
+		syncMessageSlot types.Slot
+		genesisTime     time.Time
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantedErr string
+	}{
+		{
+			name: "sync_message.slot == current_slot",
+			args: args{
+				syncMessageSlot: 15,
+				genesisTime:     timeutils.Now().Add(-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+			},
+		},
+		{
+			name: "sync_message.slot == current_slot, received in middle of slot",
+			args: args{
+				syncMessageSlot: 15,
+				genesisTime: timeutils.Now().Add(
+					-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
+				).Add(-(time.Duration(params.BeaconConfig().SecondsPerSlot/2) * time.Second)),
+			},
+		},
+		{
+			name: "sync_message.slot == current_slot, received 200ms early",
+			args: args{
+				syncMessageSlot: 16,
+				genesisTime: timeutils.Now().Add(
+					-16 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second,
+				).Add(-200 * time.Millisecond),
+			},
+		},
+		{
+			name: "sync_message.slot > current_slot",
+			args: args{
+				syncMessageSlot: 16,
+				genesisTime:     timeutils.Now().Add(-(15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)),
+			},
+			wantedErr: "sync message slot 16 not within allowable range of",
+		},
+		{
+			name: "sync_message.slot == current_slot+CLOCK_DISPARITY",
+			args: args{
+				syncMessageSlot: 100,
+				genesisTime:     timeutils.Now().Add(-(100*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second - params.BeaconNetworkConfig().MaximumGossipClockDisparity)),
+			},
+			wantedErr: "",
+		},
+		{
+			name: "sync_message.slot == current_slot+CLOCK_DISPARITY+200ms",
+			args: args{
+				syncMessageSlot: 100,
+				genesisTime:     timeutils.Now().Add(-(100*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second - params.BeaconNetworkConfig().MaximumGossipClockDisparity - 200*time.Millisecond)),
+			},
+			wantedErr: "sync message slot 100 not within allowable range of",
+		},
+		{
+			name: "sync_message.slot == current_slot-CLOCK_DISPARITY",
+			args: args{
+				syncMessageSlot: 100,
+				genesisTime:     timeutils.Now().Add(-(100*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second + params.BeaconNetworkConfig().MaximumGossipClockDisparity)),
+			},
+			wantedErr: "",
+		},
+		{
+			name: "sync_message.slot > current_slot+CLOCK_DISPARITY",
+			args: args{
+				syncMessageSlot: 101,
+				genesisTime:     timeutils.Now().Add(-(100*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second + params.BeaconNetworkConfig().MaximumGossipClockDisparity)),
+			},
+			wantedErr: "sync message slot 101 not within allowable range of",
+		},
+		{
+			name: "sync_message.slot is well beyond current slot",
+			args: args{
+				syncMessageSlot: 1 << 32,
+				genesisTime:     timeutils.Now().Add(-15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second),
+			},
+			wantedErr: "which exceeds max allowed value relative to the local clock",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := altair.ValidateSyncMessageTime(tt.args.syncMessageSlot, tt.args.genesisTime,
+				params.BeaconNetworkConfig().MaximumGossipClockDisparity)
+			if tt.wantedErr != "" {
+				assert.ErrorContains(t, tt.wantedErr, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
 func getState(t *testing.T, count uint64) *stateAltair.BeaconState {

--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
     ],
     deps = [
         "//beacon-chain/cache:go_default_library",
+        "//beacon-chain/core/altair:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
@@ -73,6 +74,7 @@ go_library(
         "@com_github_ferranbt_fastssz//:go_default_library",
         "@com_github_ipfs_go_ipfs_addr//:go_default_library",
         "@com_github_kevinms_leakybucket_go//:go_default_library",
+        "@com_github_kr_pretty//:go_default_library",
         "@com_github_libp2p_go_libp2p//:go_default_library",
         "@com_github_libp2p_go_libp2p//config:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/protocol/identify:go_default_library",

--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	ssz "github.com/ferranbt/fastssz"
@@ -46,10 +45,6 @@ func (s *Service) Broadcast(ctx context.Context, msg proto.Message) error {
 	if !ok {
 		traceutil.AnnotateError(span, ErrMessageNotMapped)
 		return ErrMessageNotMapped
-	}
-	if strings.Contains(topic, "beacon_block") {
-		ps := s.pubsub.ListPeers(fmt.Sprintf(topic, forkDigest) + s.Encoding().ProtocolSuffix())
-		log.Infof("topic: %s has %d peers: %v", fmt.Sprintf(topic, forkDigest)+s.Encoding().ProtocolSuffix(), len(ps), ps)
 	}
 	castMsg, ok := msg.(ssz.Marshaler)
 	if !ok {

--- a/beacon-chain/p2p/pubsub_filter.go
+++ b/beacon-chain/p2p/pubsub_filter.go
@@ -7,14 +7,19 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
-	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
 	"github.com/prysmaticlabs/prysm/shared/p2putils"
+	"github.com/prysmaticlabs/prysm/shared/params"
 )
 
 var _ pubsub.SubscriptionFilter = (*Service)(nil)
 
-const pubsubSubscriptionRequestLimit = 100
+// It is set at this limit to handle the possibility
+// of double topic subscriptions at fork boundaries.
+// -> 64 Attestation Subnets * 2.
+// -> 4 Sync Committee Subnets * 2.
+// -> Block,Aggregate,ProposerSlashing,AttesterSlashing,Exits,SyncContribution * 2.
+const pubsubSubscriptionRequestLimit = 200
 
 // CanSubscribe returns true if the topic is of interest and we could subscribe to it.
 func (s *Service) CanSubscribe(topic string) bool {
@@ -37,22 +42,12 @@ func (s *Service) CanSubscribe(topic string) bool {
 		log.WithError(err).Error("Could not determine fork digest")
 		return false
 	}
-	isForkNextEpoch, err := p2putils.IsForkNextEpoch(s.genesisTime, s.genesisValidatorsRoot)
+	digest, err := p2putils.ForkDigestFromEpoch(params.BeaconConfig().AltairForkEpoch, s.genesisValidatorsRoot)
 	if err != nil {
-		log.WithError(err).Error("Could not determine next fork epoch")
+		log.WithError(err).Error("Could not determine next fork digest")
 		return false
 	}
-	if isForkNextEpoch {
-		currEpoch := helpers.SlotToEpoch(helpers.CurrentSlot(uint64(s.genesisTime.Unix())))
-		digest, err := p2putils.ForkDigestFromEpoch(currEpoch+1, s.genesisValidatorsRoot)
-		if err != nil {
-			log.WithError(err).Error("Could not determine next fork digest")
-			return false
-		}
-		if parts[2] != fmt.Sprintf("%x", fd) && parts[2] != fmt.Sprintf("%x", digest) {
-			return false
-		}
-	} else if parts[2] != fmt.Sprintf("%x", fd) {
+	if parts[2] != fmt.Sprintf("%x", fd) && parts[2] != fmt.Sprintf("%x", digest) {
 		return false
 	}
 	if parts[4] != encoder.ProtocolSuffixSSZSnappy {

--- a/beacon-chain/p2p/sender.go
+++ b/beacon-chain/p2p/sender.go
@@ -10,6 +10,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/shared/traceutil"
+	"github.com/sirupsen/logrus"
 	"go.opencensus.io/trace"
 )
 
@@ -26,8 +27,10 @@ func (s *Service) Send(ctx context.Context, message interface{}, baseTopic strin
 	topic := baseTopic + s.Encoding().ProtocolSuffix()
 	span.AddAttributes(trace.StringAttribute("topic", topic))
 
-	log.WithField("topic", topic).Debugf("Sending RPC request to peer %s", pid.String())
-	log.WithField("request", pretty.Sprint(message)).Trace("Request parameters")
+	log.WithFields(logrus.Fields{
+		"topic":   topic,
+		"request": pretty.Sprint(message),
+	}).Tracef("Sending RPC request to peer %s", pid.String())
 
 	// Apply max dial timeout when opening a new stream.
 	ctx, cancel := context.WithTimeout(ctx, maxDialTimeout)

--- a/beacon-chain/p2p/sender.go
+++ b/beacon-chain/p2p/sender.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	ssz "github.com/ferranbt/fastssz"
+	"github.com/kr/pretty"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
@@ -24,6 +25,9 @@ func (s *Service) Send(ctx context.Context, message interface{}, baseTopic strin
 	}
 	topic := baseTopic + s.Encoding().ProtocolSuffix()
 	span.AddAttributes(trace.StringAttribute("topic", topic))
+
+	log.WithField("topic", topic).Debugf("Sending RPC request to peer %s", pid.String())
+	log.WithField("request", pretty.Sprint(message)).Trace("Request parameters")
 
 	// Apply max dial timeout when opening a new stream.
 	ctx, cancel := context.WithTimeout(ctx, maxDialTimeout)

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -129,10 +129,6 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 
 	s.host = h
 	s.host.RemoveStreamHandler(identify.IDDelta)
-	t, err := pubsub.NewJSONTracer("/home/nishant/randotracer.txt")
-	if err != nil {
-		return nil, err
-	}
 	// Gossipsub registration is done before we add in any new peers
 	// due to libp2p's gossipsub implementation not taking into
 	// account previously added peers when creating the gossipsub
@@ -147,7 +143,6 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 		pubsub.WithPeerScore(peerScoringParams()),
 		pubsub.WithPeerScoreInspect(s.peerInspector, time.Minute),
 		pubsub.WithGossipSubParams(pubsubGossipParam()),
-		pubsub.WithEventTracer(t),
 	}
 	// Set the pubsub global parameters that we require.
 	setPubSubParameters()

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -129,7 +129,10 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 
 	s.host = h
 	s.host.RemoveStreamHandler(identify.IDDelta)
-
+	t, err := pubsub.NewJSONTracer("/home/nishant/randotracer.txt")
+	if err != nil {
+		return nil, err
+	}
 	// Gossipsub registration is done before we add in any new peers
 	// due to libp2p's gossipsub implementation not taking into
 	// account previously added peers when creating the gossipsub
@@ -144,6 +147,7 @@ func NewService(ctx context.Context, cfg *Config) (*Service, error) {
 		pubsub.WithPeerScore(peerScoringParams()),
 		pubsub.WithPeerScoreInspect(s.peerInspector, time.Minute),
 		pubsub.WithGossipSubParams(pubsubGossipParam()),
+		pubsub.WithEventTracer(t),
 	}
 	// Set the pubsub global parameters that we require.
 	setPubSubParameters()

--- a/beacon-chain/p2p/subnets.go
+++ b/beacon-chain/p2p/subnets.go
@@ -22,6 +22,11 @@ var syncCommsSubnetCount = params.BeaconConfig().SyncCommitteeSubnetCount
 var attSubnetEnrKey = params.BeaconNetworkConfig().AttSubnetKey
 var syncCommsSubnetEnrKey = params.BeaconNetworkConfig().SyncCommsSubnetKey
 
+// The value used with the subnet, inorder
+// to create an appropriate key tor retrieve
+// the relevant lock.
+const syncLockerVal = 100
+
 // FindPeersWithSubnet performs a network search for peers
 // subscribed to a particular subnet. Then we try to connect
 // with those peers. This method will block until the required amount of
@@ -237,6 +242,13 @@ func syncBitvector(record *enr.Record) (bitfield.Bitvector4, error) {
 	return bitV, nil
 }
 
+// The subnet locker is a map which keeps track of all
+// mutexes stored per subnet. This locker is re-used
+// between both the attestation and sync subnets. In
+// order to differentiate between attestation and sync
+// subnets. Sync subnets are stored by (subnet+syncLockerVal). This
+// is to prevent conflicts while allowing both subnets
+// to use a single locker.
 func (s *Service) subnetLocker(i uint64) *sync.RWMutex {
 	s.subnetsLockLock.Lock()
 	defer s.subnetsLockLock.Unlock()

--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -107,6 +107,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
+        "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_trailofbits_go_mutexasserts//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",

--- a/beacon-chain/sync/fork_watcher.go
+++ b/beacon-chain/sync/fork_watcher.go
@@ -97,10 +97,7 @@ func (s *Service) checkForPreviousEpochFork(currEpoch types.Epoch) error {
 				continue
 			}
 			if retDigest == prevDigest {
-				if err := s.cfg.P2P.PubSub().UnregisterTopicValidator(t); err != nil {
-					log.WithError(err).Error("Could not unregister topic validator")
-				}
-				s.subHandler.removeTopic(t)
+				s.unSubscribeFromTopic(t)
 			}
 		}
 	}

--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/cmd/beacon-chain/flags"
 	pb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
@@ -20,6 +22,12 @@ var (
 			Help: "The number of peers subscribed to a given topic.",
 		}, []string{"topic"},
 	)
+	subscribedTopicPeerCount = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "p2p_subscribed_topic_peer_count",
+			Help: "The number of peers subscribed to topics that a host node is also subscribed to.",
+		}, []string{"topic"},
+	)
 	messageReceivedCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "p2p_message_received_total",
@@ -31,6 +39,13 @@ var (
 		prometheus.CounterOpts{
 			Name: "p2p_message_failed_validation_total",
 			Help: "Count of messages that failed validation.",
+		},
+		[]string{"topic"},
+	)
+	messageIgnoredValidationCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "p2p_message_ignored_validation_total",
+			Help: "Count of messages that were ignored in validation.",
 		},
 		[]string{"topic"},
 	)
@@ -69,11 +84,18 @@ func (s *Service) updateMetrics() {
 		log.WithError(err).Debugf("Could not compute fork digest")
 	}
 	indices := s.aggregatorSubnetIndices(s.cfg.Chain.CurrentSlot())
+	syncIndices := cache.SyncSubnetIDs.GetAllSubnets(helpers.SlotToEpoch(s.cfg.Chain.CurrentSlot()))
 	attTopic := p2p.GossipTypeMapping[reflect.TypeOf(&pb.Attestation{})]
+	syncTopic := p2p.GossipTypeMapping[reflect.TypeOf(&pb.SyncCommitteeMessage{})]
 	attTopic += s.cfg.P2P.Encoding().ProtocolSuffix()
+	syncTopic += s.cfg.P2P.Encoding().ProtocolSuffix()
 	if flags.Get().SubscribeToAllSubnets {
 		for i := uint64(0); i < params.BeaconNetworkConfig().AttestationSubnetCount; i++ {
 			formattedTopic := fmt.Sprintf(attTopic, digest, i)
+			topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.cfg.P2P.PubSub().ListPeers(formattedTopic))))
+		}
+		for i := uint64(0); i < params.BeaconConfig().SyncCommitteeSubnetCount; i++ {
+			formattedTopic := fmt.Sprintf(syncTopic, digest, i)
 			topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.cfg.P2P.PubSub().ListPeers(formattedTopic))))
 		}
 	} else {
@@ -81,12 +103,16 @@ func (s *Service) updateMetrics() {
 			formattedTopic := fmt.Sprintf(attTopic, digest, committeeIdx)
 			topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.cfg.P2P.PubSub().ListPeers(formattedTopic))))
 		}
+		for _, committeeIdx := range syncIndices {
+			formattedTopic := fmt.Sprintf(syncTopic, digest, committeeIdx)
+			topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.cfg.P2P.PubSub().ListPeers(formattedTopic))))
+		}
 	}
 
 	// We update all other gossip topics.
 	for _, topic := range p2p.AllTopics() {
 		// We already updated attestation subnet topics.
-		if strings.Contains(topic, "beacon_attestation") {
+		if strings.Contains(topic, p2p.GossipAttestationMessage) || strings.Contains(topic, p2p.GossipSyncCommitteeMessage) {
 			continue
 		}
 		topic += s.cfg.P2P.Encoding().ProtocolSuffix()
@@ -96,5 +122,9 @@ func (s *Service) updateMetrics() {
 		}
 		formattedTopic := fmt.Sprintf(topic, digest)
 		topicPeerCount.WithLabelValues(formattedTopic).Set(float64(len(s.cfg.P2P.PubSub().ListPeers(formattedTopic))))
+	}
+
+	for _, topic := range s.cfg.P2P.PubSub().GetTopics() {
+		subscribedTopicPeerCount.WithLabelValues(topic).Set(float64(len(s.cfg.P2P.PubSub().ListPeers(topic))))
 	}
 }

--- a/beacon-chain/sync/rpc_metadata_test.go
+++ b/beacon-chain/sync/rpc_metadata_test.go
@@ -2,7 +2,6 @@ package sync
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -17,7 +16,6 @@ import (
 	db "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	p2ptest "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
-	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
 	pb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1/metadata"
 	"github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1/wrapper"
@@ -189,11 +187,11 @@ func TestMetadataRPCHandler_SendsMetadataAltair(t *testing.T) {
 	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
 		defer wg.Done()
 		err := r2.metaDataHandler(context.Background(), new(interface{}), stream)
-		assert.ErrorContains(t, fmt.Sprintf("stream version of %s doesn't match provided version %s", p2p.SchemaVersionV2, p2p.SchemaVersionV1), err)
+		assert.NoError(t, err)
 	})
 
 	_, err := r.sendMetaDataRequest(context.Background(), p2.BHost.ID())
-	assert.ErrorContains(t, types.ErrGeneric.Error(), err)
+	assert.NoError(t, err)
 
 	if testutil.WaitTimeout(&wg, 1*time.Second) {
 		t.Fatal("Did not receive stream within 1 sec")

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -178,10 +178,7 @@ func (s *Service) Stop() error {
 	}
 	// Deregister Topic Subscribers.
 	for _, t := range s.cfg.P2P.PubSub().GetTopics() {
-		if err := s.cfg.P2P.PubSub().UnregisterTopicValidator(t); err != nil {
-			log.Errorf("Could not successfully unregister for topic %s: %v", t, err)
-		}
-		s.subHandler.removeTopic(t)
+		s.unSubscribeFromTopic(t)
 	}
 	defer s.cancel()
 	return nil

--- a/beacon-chain/sync/subscription_topic_handler.go
+++ b/beacon-chain/sync/subscription_topic_handler.go
@@ -82,3 +82,9 @@ func (s *subTopicHandler) allTopics() []string {
 	}
 	return topics
 }
+
+func (s *subTopicHandler) subForTopic(topic string) *pubsub.Subscription {
+	s.RLock()
+	defer s.RUnlock()
+	return s.subTopics[topic]
+}

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -141,7 +141,7 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 	}
 
 	// Handle block when the parent is unknown.
-	if !s.cfg.DB.HasBlock(ctx, bytesutil.ToBytes32(blk.Block().ParentRoot())) {
+	if !s.cfg.DB.HasBlock(ctx, bytesutil.ToBytes32(blk.Block().ParentRoot())) && !s.cfg.Chain.HasInitSyncBlock(bytesutil.ToBytes32(blk.Block().ParentRoot())) {
 		s.pendingQueueLock.Lock()
 		if err := s.insertBlockToPendingQueue(blk.Block().Slot(), blk, blockRoot); err != nil {
 			s.pendingQueueLock.Unlock()

--- a/beacon-chain/sync/validate_sync_committee_message.go
+++ b/beacon-chain/sync/validate_sync_committee_message.go
@@ -9,6 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	p2ptypes "github.com/prysmaticlabs/prysm/beacon-chain/p2p/types"
@@ -54,7 +55,7 @@ func (s *Service) validateSyncCommitteeMessage(ctx context.Context, pid peer.ID,
 	}
 
 	// The message's `slot` is for the current slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
-	if err := helpers.VerifySlotTime(uint64(s.cfg.Chain.GenesisTime().Unix()), m.Slot, params.BeaconNetworkConfig().MaximumGossipClockDisparity); err != nil {
+	if err := altair.ValidateSyncMessageTime(m.Slot, s.cfg.Chain.GenesisTime(), params.BeaconNetworkConfig().MaximumGossipClockDisparity); err != nil {
 		traceutil.AnnotateError(span, err)
 		return pubsub.ValidationIgnore
 	}

--- a/validator/client/sync_committee_test.go
+++ b/validator/client/sync_committee_test.go
@@ -349,6 +349,8 @@ func TestSubmitSignedContributionAndProof_CouldNotSubmitContribution(t *testing.
 			SignatureDomain: make([]byte, 32),
 		}, nil)
 
+	aggBits := bitfield.NewBitvector128()
+	aggBits.SetBitAt(0, true)
 	m.validatorClient.EXPECT().GetSyncCommitteeContribution(
 		gomock.Any(), // ctx
 		&ethpb.SyncCommitteeContributionRequest{
@@ -359,7 +361,7 @@ func TestSubmitSignedContributionAndProof_CouldNotSubmitContribution(t *testing.
 	).Return(&ethpb.SyncCommitteeContribution{
 		BlockRoot:       make([]byte, 32),
 		Signature:       make([]byte, 96),
-		AggregationBits: bitfield.NewBitvector128(),
+		AggregationBits: aggBits,
 	}, nil)
 
 	m.validatorClient.EXPECT().
@@ -425,6 +427,8 @@ func TestSubmitSignedContributionAndProof_Ok(t *testing.T) {
 			SignatureDomain: make([]byte, 32),
 		}, nil)
 
+	aggBits := bitfield.NewBitvector128()
+	aggBits.SetBitAt(0, true)
 	m.validatorClient.EXPECT().GetSyncCommitteeContribution(
 		gomock.Any(), // ctx
 		&ethpb.SyncCommitteeContributionRequest{
@@ -435,7 +439,7 @@ func TestSubmitSignedContributionAndProof_Ok(t *testing.T) {
 	).Return(&ethpb.SyncCommitteeContribution{
 		BlockRoot:       make([]byte, 32),
 		Signature:       make([]byte, 96),
-		AggregationBits: bitfield.NewBitvector128(),
+		AggregationBits: aggBits,
 	}, nil)
 
 	m.validatorClient.EXPECT().


### PR DESCRIPTION
**What type of PR is this?**

Bug Fixes

**What does this PR do? Why is it needed?**

As part of hardening prysm for the upcoming Altair hardfork, multiple short lived testnets were run with other clients. During the course of these testnets, some edge cases were revealed in prysm which would cause a lot of difficulties with regard to subscription/unsubscription at the fork boundary. This PR addresses the following issues.

- [x] Fixes Edge cases in Topic Subscription/Unsubscription at the fork boundary.
- [x] Handles blocks stored in the `initial-sync` cache, when performing gossip block verification.
- [x] Fixes a lot of subtle bugs found in broadcasting of attestations/sync subnets.
- [x] Employs a strict sync committee slot check with added in regression tests.
- [x] Adds in various metrics to improve gossip topic visibility.
- [x] Clean up of a few other things in `sync`. 
- [x] Appropriately discard messages which are from an older fork.

**Which issues(s) does this PR fix?**

Part of #8638 

**Other notes for review**
