### PR TITLE
Add Latest Slasher KV Methods to DB Subpackage

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -138,12 +138,12 @@ type SlasherDatabase interface {
 	CheckDoubleBlockProposals(
 		ctx context.Context, proposals []*slashertypes.SignedBlockHeaderWrapper,
 	) ([]*eth.ProposerSlashing, error)
-	PruneAttestations(
-		ctx context.Context, currentEpoch, pruningEpochIncrements, historyLength types.Epoch,
-	) error
-	PruneProposals(
-		ctx context.Context, currentEpoch, pruningEpochIncrements, historyLength types.Epoch,
-	) error
+	PruneAttestationsAtEpoch(
+		ctx context.Context, maxEpoch types.Epoch,
+	) (numPruned uint, err error)
+	PruneProposalsAtEpoch(
+		ctx context.Context, maxEpoch types.Epoch,
+	) (numPruned uint, err error)
 	DatabasePath() string
 	ClearDB() error
 }

--- a/beacon-chain/db/slasherkv/BUILD.bazel
+++ b/beacon-chain/db/slasherkv/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//proto/prysm/v1alpha1:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/fileutil:go_default_library",
-        "//shared/hashutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_ferranbt_fastssz//:go_default_library",
         "@com_github_golang_snappy//:go_default_library",
@@ -30,6 +29,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_etcd_go_bbolt//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
 

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -88,7 +88,7 @@ func (s *Store) PruneProposalsAtEpoch(
 	ctx context.Context, maxEpoch types.Epoch,
 ) (numPruned uint, err error) {
 	var endPruneSlot types.Slot
-	endPruneSlot, err = helpers.StartSlot(maxEpoch)
+	endPruneSlot, err = helpers.EndSlot(maxEpoch)
 	if err != nil {
 		return
 	}

--- a/beacon-chain/db/slasherkv/pruning.go
+++ b/beacon-chain/db/slasherkv/pruning.go
@@ -11,199 +11,153 @@ import (
 	bolt "go.etcd.io/bbolt"
 )
 
-// PruneProposals prunes all proposal data older than currentEpoch - historyLength in
-// specified epoch increments. BoltDB cannot handle long-running transactions, so we instead
-// use a cursor-based mechanism to prune at pruningEpochIncrements by opening individual bolt
-// transactions for each pruning iteration.
-func (s *Store) PruneProposals(
-	ctx context.Context, currentEpoch, pruningEpochIncrements, historyLength types.Epoch,
-) error {
-	if currentEpoch < historyLength {
-		log.Debugf("Current epoch %d < history length %d, nothing to prune", currentEpoch, historyLength)
-		return nil
-	}
+// PruneAttestationsAtEpoch deletes all attestations from the slasher DB with target epoch
+// less than or equal to the specified epoch.
+func (s *Store) PruneAttestationsAtEpoch(
+	ctx context.Context, maxEpoch types.Epoch,
+) (numPruned uint, err error) {
 	// We can prune everything less than the current epoch - history length.
-	endEpoch := currentEpoch - historyLength
-	endPruneSlot, err := helpers.StartSlot(endEpoch)
+	encodedEndPruneEpoch := fssz.MarshalUint64([]byte{}, uint64(maxEpoch))
+
+	// We retrieve the lowest stored epoch in the attestations bucket.
+	var lowestEpoch types.Epoch
+	var hasData bool
+	if err = s.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(attestationDataRootsBucket)
+		c := bkt.Cursor()
+		k, _ := c.First()
+		if k == nil {
+			return nil
+		}
+		hasData = true
+		lowestEpoch = types.Epoch(binary.LittleEndian.Uint64(k))
+		return nil
+	}); err != nil {
+		return
+	}
+
+	// If there is no data stored, just exit early.
+	if !hasData {
+		return
+	}
+
+	// If the lowest epoch is greater than the end pruning epoch,
+	// there is nothing to prune, so we return early.
+	if lowestEpoch > maxEpoch {
+		log.Debugf("Lowest epoch %d is > pruning epoch %d, nothing to prune", lowestEpoch, maxEpoch)
+		return
+	}
+
+	if err = s.db.Update(func(tx *bolt.Tx) error {
+		signingRootsBkt := tx.Bucket(attestationDataRootsBucket)
+		attRecordsBkt := tx.Bucket(attestationRecordsBucket)
+		c := signingRootsBkt.Cursor()
+
+		// We begin a pruning iteration starting from the first item in the bucket.
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			// We check the epoch from the current key in the database.
+			// If we have hit an epoch that is greater than the end epoch of the pruning process,
+			// we then completely exit the process as we are done.
+			if uint64PrefixGreaterThan(k, encodedEndPruneEpoch) {
+				return nil
+			}
+
+			// Attestation in the database look like this:
+			//  (target_epoch ++ _) => encode(attestation)
+			// so it is possible we have a few adjacent objects that have the same slot, such as
+			//  (target_epoch = 3 ++ _) => encode(attestation)
+			if err := signingRootsBkt.Delete(k); err != nil {
+				return err
+			}
+			if err := attRecordsBkt.Delete(v); err != nil {
+				return err
+			}
+			slasherAttestationsPrunedTotal.Inc()
+			numPruned++
+		}
+		return nil
+	}); err != nil {
+		return
+	}
+	return
+}
+
+// PruneProposalsAtEpoch deletes all proposals from the slasher DB with epoch
+// less than or equal to the specified epoch.
+func (s *Store) PruneProposalsAtEpoch(
+	ctx context.Context, maxEpoch types.Epoch,
+) (numPruned uint, err error) {
+	var endPruneSlot types.Slot
+	endPruneSlot, err = helpers.StartSlot(maxEpoch)
 	if err != nil {
-		return err
+		return
 	}
 	encodedEndPruneSlot := fssz.MarshalUint64([]byte{}, uint64(endPruneSlot))
 
 	// We retrieve the lowest stored slot in the proposals bucket.
 	var lowestSlot types.Slot
+	var hasData bool
 	if err = s.db.View(func(tx *bolt.Tx) error {
 		proposalBkt := tx.Bucket(proposalRecordsBucket)
 		c := proposalBkt.Cursor()
 		k, _ := c.First()
+		if k == nil {
+			return nil
+		}
+		hasData = true
 		lowestSlot = slotFromProposalKey(k)
 		return nil
 	}); err != nil {
-		return err
+		return
 	}
 
-	// If the lowest slot is greater than or equal to the end pruning slot,
+	// If there is no data stored, just exit early.
+	if !hasData {
+		return
+	}
+
+	// If the lowest slot is greater than the end pruning slot,
 	// there is nothing to prune, so we return early.
-	if lowestSlot >= endPruneSlot {
-		log.Debugf("Lowest slot %d is >= pruning slot %d, nothing to prune", lowestSlot, endPruneSlot)
-		return nil
+	if lowestSlot > endPruneSlot {
+		log.Debugf("Lowest slot %d is > pruning slot %d, nothing to prune", lowestSlot, endPruneSlot)
+		return
 	}
 
-	// We prune in increments of `pruningEpochIncrements` at a time to prevent
-	// a long-running bolt transaction which overwhelms CPU and memory.
-	// While we still have epochs to prune based on a cursor, we continue the pruning process.
-	epochAtCursor := helpers.SlotToEpoch(lowestSlot)
-	for epochAtCursor < endEpoch {
-		// Each pruning iteration involves a unique bolt transaction. Given pruning can be
-		// a very expensive process which puts pressure on the database, we perform
-		// the process in a batch-based method using a cursor to proceed to the next batch.
-		log.Debugf("Pruned %d/%d epochs worth of proposals", epochAtCursor, endEpoch-1)
-		if err = s.db.Update(func(tx *bolt.Tx) error {
-			proposalBkt := tx.Bucket(proposalRecordsBucket)
-			c := proposalBkt.Cursor()
-
-			var lastPrunedEpoch, epochsPruned types.Epoch
-			// We begin a pruning iteration at starting from the first item in the bucket.
-			for k, _ := c.First(); k != nil; k, _ = c.Next() {
-				// We check the slot from the current key in the database.
-				// If we have hit a slot that is greater than the end slot of the pruning process,
-				// we then completely exit the process as we are done.
-				if !uint64PrefixLessThan(k, encodedEndPruneSlot) {
-					epochAtCursor = endEpoch
-					return nil
-				}
-				epochAtCursor = helpers.SlotToEpoch(slotFromProposalKey(k))
-
-				// Proposals in the database look like this:
-				//  (slot ++ validatorIndex) => encode(proposal)
-				// so it is possible we have a few adjacent objects that have the same slot, such as
-				//  (slot = 3 ++ validatorIndex = 0) => ...
-				//  (slot = 3 ++ validatorIndex = 1) => ...
-				//  (slot = 3 ++ validatorIndex = 2) => ...
-				// so we only mark an epoch as pruned if the epoch of the current object
-				// under the cursor has changed.
-				if err := proposalBkt.Delete(k); err != nil {
-					return err
-				}
-				if epochAtCursor == 0 {
-					epochsPruned = 1
-				} else if epochAtCursor > lastPrunedEpoch {
-					epochsPruned++
-					lastPrunedEpoch = epochAtCursor
-				}
-				slasherProposalsPrunedTotal.Inc()
-
-				// If we have pruned N epochs in this pruning iteration,
-				// we exit from the bolt transaction.
-				if epochsPruned >= pruningEpochIncrements {
-					return nil
-				}
+	if err = s.db.Update(func(tx *bolt.Tx) error {
+		proposalBkt := tx.Bucket(proposalRecordsBucket)
+		c := proposalBkt.Cursor()
+		// We begin a pruning iteration starting from the first item in the bucket.
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			// We check the slot from the current key in the database.
+			// If we have hit a slot that is greater than the end slot of the pruning process,
+			// we then completely exit the process as we are done.
+			if uint64PrefixGreaterThan(k, encodedEndPruneSlot) {
+				return nil
 			}
-			return nil
-		}); err != nil {
-			return err
+			// Proposals in the database look like this:
+			//  (slot ++ validatorIndex) => encode(proposal)
+			// so it is possible we have a few adjacent objects that have the same slot, such as
+			//  (slot = 3 ++ validatorIndex = 0) => ...
+			//  (slot = 3 ++ validatorIndex = 1) => ...
+			//  (slot = 3 ++ validatorIndex = 2) => ...
+			if err := proposalBkt.Delete(k); err != nil {
+				return err
+			}
+			slasherProposalsPrunedTotal.Inc()
+			numPruned++
 		}
-	}
-	return nil
-}
-
-// PruneAttestations prunes all proposal data older than historyLength.
-func (s *Store) PruneAttestations(
-	ctx context.Context, currentEpoch, pruningEpochIncrements, historyLength types.Epoch,
-) error {
-	if currentEpoch < historyLength {
-		log.Debugf("Current epoch %d < history length %d, nothing to prune", currentEpoch, historyLength)
-		return nil
-	}
-	// We can prune everything less than the current epoch - history length.
-	endPruneEpoch := currentEpoch - historyLength
-	encodedEndPruneEpoch := fssz.MarshalUint64([]byte{}, uint64(endPruneEpoch))
-
-	// We retrieve the lowest stored epoch in the proposals bucket.
-	var lowestEpoch types.Epoch
-	if err := s.db.View(func(tx *bolt.Tx) error {
-		bkt := tx.Bucket(attestationDataRootsBucket)
-		c := bkt.Cursor()
-		k, _ := c.First()
-		lowestEpoch = types.Epoch(binary.LittleEndian.Uint64(k))
 		return nil
 	}); err != nil {
-		return err
+		return
 	}
-
-	// If the lowest slot is greater than or equal to the end pruning slot,
-	// there is nothing to prune, so we return early.
-	if lowestEpoch >= endPruneEpoch {
-		log.Debugf("Lowest epoch %d is >= pruning epoch %d, nothing to prune", lowestEpoch, endPruneEpoch)
-		return nil
-	}
-
-	// We prune in increments of `pruningEpochIncrements` at a time to prevent
-	// a long-running bolt transaction which overwhelms CPU and memory.
-	// While we still have epochs to prune based on a cursor, we continue the pruning process.
-	epochAtCursor := lowestEpoch
-	for epochAtCursor < endPruneEpoch {
-		// Each pruning iteration involves a unique bolt transaction. Given pruning can be
-		// a very expensive process which puts pressure on the database, we perform
-		// the process in a batch-based method using a cursor to proceed to the next batch.
-		log.Debugf("Pruned %d/%d epochs worth of attestations", epochAtCursor, endPruneEpoch-1)
-		if err := s.db.Update(func(tx *bolt.Tx) error {
-			rootsBkt := tx.Bucket(attestationDataRootsBucket)
-			attsBkt := tx.Bucket(attestationRecordsBucket)
-			c := rootsBkt.Cursor()
-
-			var lastPrunedEpoch, epochsPruned types.Epoch
-			// We begin a pruning iteration at starting from the first item in the bucket.
-			for k, v := c.First(); k != nil; k, v = c.Next() {
-				// We check the epoch from the current key in the database.
-				// If we have hit an epoch that is greater than the end epoch of the pruning process,
-				// we then completely exit the process as we are done.
-				if !uint64PrefixLessThan(k, encodedEndPruneEpoch) {
-					epochAtCursor = endPruneEpoch
-					return nil
-				}
-
-				epochAtCursor = types.Epoch(binary.LittleEndian.Uint64(k))
-
-				// Attestation in the database look like this:
-				//  (target_epoch ++ _) => encode(attestation)
-				// so it is possible we have a few adjacent objects that have the same slot, such as
-				//  (target_epoch = 3 ++ _) => encode(attestation)
-				// so we only mark an epoch as pruned if the epoch of the current object
-				// under the cursor has changed.
-				if err := rootsBkt.Delete(k); err != nil {
-					return err
-				}
-				if err := attsBkt.Delete(v); err != nil {
-					return err
-				}
-				if epochAtCursor == 0 {
-					epochsPruned = 1
-				} else if epochAtCursor > lastPrunedEpoch {
-					epochsPruned++
-					lastPrunedEpoch = epochAtCursor
-				}
-				slasherAttestationsPrunedTotal.Inc()
-
-				// If we have pruned N epochs in this pruning iteration,
-				// we exit from the bolt transaction.
-				if epochsPruned >= pruningEpochIncrements {
-					return nil
-				}
-			}
-			return nil
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
+	return
 }
 
 func slotFromProposalKey(key []byte) types.Slot {
 	return types.Slot(binary.LittleEndian.Uint64(key[:8]))
 }
 
-func uint64PrefixLessThan(key, lessThan []byte) bool {
+func uint64PrefixGreaterThan(key, lessThan []byte) bool {
 	enc := key[:8]
-	return bytes.Compare(enc, lessThan) < 0
+	return bytes.Compare(enc, lessThan) > 0
 }

--- a/beacon-chain/db/slasherkv/pruning_test.go
+++ b/beacon-chain/db/slasherkv/pruning_test.go
@@ -29,7 +29,7 @@ func TestStore_PruneProposalsAtEpoch(t *testing.T) {
 		historyLength := types.Epoch(10)
 
 		pruningLimitEpoch := currentEpoch - historyLength
-		lowestStoredSlot, err := helpers.StartSlot(pruningLimitEpoch)
+		lowestStoredSlot, err := helpers.EndSlot(pruningLimitEpoch)
 		require.NoError(t, err)
 
 		err = beaconDB.db.Update(func(tx *bolt.Tx) error {

--- a/beacon-chain/db/slasherkv/slasher_test.go
+++ b/beacon-chain/db/slasherkv/slasher_test.go
@@ -3,7 +3,9 @@ package slasherkv
 import (
 	"context"
 	"encoding/binary"
+	"math/rand"
 	"reflect"
+	"sort"
 	"testing"
 
 	ssz "github.com/ferranbt/fastssz"
@@ -73,13 +75,13 @@ func TestStore_CheckAttesterDoubleVotes(t *testing.T) {
 	beaconDB := setupDB(t)
 	err := beaconDB.SaveAttestationRecordsForValidators(ctx, []*slashertypes.IndexedAttestationWrapper{
 		createAttestationWrapper(2, 3, []uint64{0, 1}, []byte{1}),
-		createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{1}),
+		createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{3}),
 	})
 	require.NoError(t, err)
 
 	slashableAtts := []*slashertypes.IndexedAttestationWrapper{
 		createAttestationWrapper(2, 3, []uint64{0, 1}, []byte{2}), // Different signing root.
-		createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{2}), // Different signing root.
+		createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{4}), // Different signing root.
 	}
 
 	wanted := []*slashertypes.AttesterDoubleVote{
@@ -98,19 +100,28 @@ func TestStore_CheckAttesterDoubleVotes(t *testing.T) {
 		{
 			ValidatorIndex:         2,
 			Target:                 4,
-			PrevAttestationWrapper: createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{1}),
-			AttestationWrapper:     createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{2}),
+			PrevAttestationWrapper: createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{3}),
+			AttestationWrapper:     createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{4}),
 		},
 		{
 			ValidatorIndex:         3,
 			Target:                 4,
-			PrevAttestationWrapper: createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{1}),
-			AttestationWrapper:     createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{2}),
+			PrevAttestationWrapper: createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{3}),
+			AttestationWrapper:     createAttestationWrapper(3, 4, []uint64{2, 3}, []byte{4}),
 		},
 	}
 	doubleVotes, err := beaconDB.CheckAttesterDoubleVotes(ctx, slashableAtts)
 	require.NoError(t, err)
-	require.DeepEqual(t, wanted, doubleVotes)
+	sort.SliceStable(doubleVotes, func(i, j int) bool {
+		return uint64(doubleVotes[i].ValidatorIndex) < uint64(doubleVotes[j].ValidatorIndex)
+	})
+	require.Equal(t, len(wanted), len(doubleVotes))
+	for i, double := range doubleVotes {
+		require.DeepEqual(t, wanted[i].ValidatorIndex, double.ValidatorIndex)
+		require.DeepEqual(t, wanted[i].Target, double.Target)
+		require.DeepEqual(t, wanted[i].PrevAttestationWrapper, double.PrevAttestationWrapper)
+		require.DeepEqual(t, wanted[i].AttestationWrapper, double.AttestationWrapper)
+	}
 }
 
 func TestStore_SlasherChunk_SaveRetrieve(t *testing.T) {
@@ -334,9 +345,9 @@ func TestStore_HighestAttestations(t *testing.T) {
 			name: "should get highest att for multiple with diff histories",
 			attestationsInDB: []*slashertypes.IndexedAttestationWrapper{
 				createAttestationWrapper(0, 3, []uint64{2}, []byte{1}),
-				createAttestationWrapper(1, 4, []uint64{3}, []byte{1}),
-				createAttestationWrapper(2, 3, []uint64{4}, []byte{1}),
-				createAttestationWrapper(5, 6, []uint64{5}, []byte{1}),
+				createAttestationWrapper(1, 4, []uint64{3}, []byte{2}),
+				createAttestationWrapper(2, 3, []uint64{4}, []byte{3}),
+				createAttestationWrapper(5, 6, []uint64{5}, []byte{4}),
 			},
 			indices: []types.ValidatorIndex{2, 3, 4, 5},
 			expected: []*slashpb.HighestAttestation{
@@ -366,9 +377,9 @@ func TestStore_HighestAttestations(t *testing.T) {
 			name: "should get correct highest att for multiple shared atts with diff histories",
 			attestationsInDB: []*slashertypes.IndexedAttestationWrapper{
 				createAttestationWrapper(1, 4, []uint64{2, 3}, []byte{1}),
-				createAttestationWrapper(2, 5, []uint64{3, 5}, []byte{1}),
-				createAttestationWrapper(4, 5, []uint64{1, 2}, []byte{1}),
-				createAttestationWrapper(6, 7, []uint64{5}, []byte{1}),
+				createAttestationWrapper(2, 5, []uint64{3, 5}, []byte{2}),
+				createAttestationWrapper(4, 5, []uint64{1, 2}, []byte{3}),
+				createAttestationWrapper(6, 7, []uint64{5}, []byte{4}),
 			},
 			indices: []types.ValidatorIndex{2, 3, 4, 5},
 			expected: []*slashpb.HighestAttestation{
@@ -438,6 +449,38 @@ func BenchmarkHighestAttestations(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		_, err := beaconDB.HighestAttestations(ctx, allIndices)
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkStore_CheckDoubleBlockProposals(b *testing.B) {
+	b.StopTimer()
+	count := 10000
+	valsPerAtt := 100
+	indicesPerAtt := make([][]uint64, count)
+	for i := 0; i < count; i++ {
+		indicesForAtt := make([]uint64, valsPerAtt)
+		for r := i * count; r < valsPerAtt*(i+1); r++ {
+			indicesForAtt[i] = uint64(r)
+		}
+		indicesPerAtt[i] = indicesForAtt
+	}
+	atts := make([]*slashertypes.IndexedAttestationWrapper, count)
+	for i := 0; i < count; i++ {
+		atts[i] = createAttestationWrapper(types.Epoch(i), types.Epoch(i+2), indicesPerAtt[i], []byte{})
+	}
+
+	ctx := context.Background()
+	beaconDB := setupDB(b)
+	require.NoError(b, beaconDB.SaveAttestationRecordsForValidators(ctx, atts))
+
+	// shuffle attestations
+	rand.Shuffle(count, func(i, j int) { atts[i], atts[j] = atts[j], atts[i] })
+
+	b.ReportAllocs()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := beaconDB.CheckAttesterDoubleVotes(ctx, atts)
 		require.NoError(b, err)
 	}
 }


### PR DESCRIPTION
Part of #8331, this PR adds some latest key-value store methods, especially regarding pruning and fetching of slasher double votes, into the `develop` branch from current code in `feature/slasher`. This is part of an effort to reduce the final diff size of `feature/slasher` in preparation for Prysm v2.

These changes **DO NOT AFFECT** runtime, as the new slasher is not yet live.

The changes include:
- A much simpler way of pruning attestations and proposals now that the schema is simpler
- Efficient way of checking for proposer double votes using a better schema and concurrency