### PR TITLE
More Precise Metrics E2E

### DIFF
--- a/endtoend/evaluators/BUILD.bazel
+++ b/endtoend/evaluators/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//shared/p2putils:go_default_library",
         "//shared/params:go_default_library",
         "//shared/sliceutil:go_default_library",
+        "//shared/slotutil:go_default_library",
         "//shared/testutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",


### PR DESCRIPTION
Our current e2e test has some significant issues in the metrics evaluator, which checks for a difference between the head slot and the time-based slot. We had some flakiness as we were reading the time-based slot from a metrics file rather than computing it from the genesis time. This PR will hopefully reduce flakes in e2e.