### PR TITLE
Reduce locking time in `recomputeFieldTrie`

### DIFF
--- a/beacon-chain/state/v1/state_trie.go
+++ b/beacon-chain/state/v1/state_trie.go
@@ -509,9 +509,9 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 
 func (b *BeaconState) recomputeFieldTrie(index types.FieldIndex, elements interface{}) ([32]byte, error) {
 	fTrie := b.stateFieldLeaves[index]
-	// We can't use trie trie's mutex because the trie's variable gets reassigned,
+	// We can't lock the trie directly because the trie's variable gets reassigned,
 	// and therefore we would call Unlock() on a different object.
-	fTrieMutex := b.stateFieldLeaves[index].RWMutex
+	fTrieMutex := fTrie.RWMutex
 	if fTrie.FieldReference().Refs() > 1 {
 		fTrieMutex.Lock()
 		fTrie.FieldReference().MinusRef()

--- a/beacon-chain/state/v1/state_trie.go
+++ b/beacon-chain/state/v1/state_trie.go
@@ -509,13 +509,14 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 
 func (b *BeaconState) recomputeFieldTrie(index types.FieldIndex, elements interface{}) ([32]byte, error) {
 	fTrie := b.stateFieldLeaves[index]
+	fTrieMutex := b.stateFieldLeaves[index].RWMutex
 	if fTrie.FieldReference().Refs() > 1 {
-		fTrie.Lock()
-		defer fTrie.Unlock()
+		fTrieMutex.Lock()
 		fTrie.FieldReference().MinusRef()
 		newTrie := fTrie.CopyTrie()
 		b.stateFieldLeaves[index] = newTrie
 		fTrie = newTrie
+		fTrieMutex.Unlock()
 	}
 	// remove duplicate indexes
 	b.dirtyIndices[index] = sliceutil.SetUint64(b.dirtyIndices[index])

--- a/beacon-chain/state/v1/state_trie.go
+++ b/beacon-chain/state/v1/state_trie.go
@@ -509,6 +509,8 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 
 func (b *BeaconState) recomputeFieldTrie(index types.FieldIndex, elements interface{}) ([32]byte, error) {
 	fTrie := b.stateFieldLeaves[index]
+	// We can't use trie trie's mutex because the trie's variable gets reassigned,
+	// and therefore we would call Unlock() on a different object.
 	fTrieMutex := b.stateFieldLeaves[index].RWMutex
 	if fTrie.FieldReference().Refs() > 1 {
 		fTrieMutex.Lock()


### PR DESCRIPTION
**What type of PR is this?**

Optimisation

**What does this PR do? Why is it needed?**

Assume `if fTrie.FieldReference().Refs() > 1` is true in `recomputeFieldTrie`.  If this is the case then `RecomputeTrie` is called on a different trie object (because of the reassignment `fTrie = newTrie`) and we can safely release the old trie object right after the reassignment. There is no need to wait for `recomputeFieldTrie` to complete.

**Which issues(s) does this PR fix?**

Part of #8785
