### PR TITLE
Blockchain Service Sync Committee Changes

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "chain_info.go",
         "head.go",
+        "head_sync_committee_info.go",
         "info.go",
         "init_sync_process_block.go",
         "log.go",
@@ -26,6 +27,7 @@ go_library(
     deps = [
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/cache/depositcache:go_default_library",
+        "//beacon-chain/core/altair:go_default_library",
         "//beacon-chain/core/epoch/precompute:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",
@@ -42,6 +44,7 @@ go_library(
         "//beacon-chain/powchain:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
+        "//beacon-chain/state/v2:go_default_library",
         "//cmd/beacon-chain/flags:go_default_library",
         "//proto/eth/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
@@ -57,6 +60,7 @@ go_library(
         "//shared/timeutils:go_default_library",
         "//shared/traceutil:go_default_library",
         "@com_github_emicklei_dot//:go_default_library",
+        "@com_github_hashicorp_golang_lru//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -24,6 +24,8 @@ type ChainInfoFetcher interface {
 	GenesisFetcher
 	CanonicalFetcher
 	ForkFetcher
+	TimeFetcher
+	HeadDomainFetcher
 }
 
 // TimeFetcher retrieves the Ethereum consensus data that's related to time.
@@ -48,8 +50,12 @@ type HeadFetcher interface {
 	HeadSeed(ctx context.Context, epoch types.Epoch) ([32]byte, error)
 	HeadGenesisValidatorRoot() [32]byte
 	HeadETH1Data() *ethpb.Eth1Data
+	HeadPublicKeyToValidatorIndex(ctx context.Context, pubKey [48]byte) (types.ValidatorIndex, bool)
+	HeadValidatorIndexToPublicKey(ctx context.Context, index types.ValidatorIndex) ([48]byte, error)
 	ProtoArrayStore() *protoarray.Store
 	ChainHeads() ([][32]byte, []types.Slot)
+	HeadSyncCommitteeFetcher
+	HeadDomainFetcher
 }
 
 // ForkFetcher retrieves the current fork information of the Ethereum beacon chain.

--- a/beacon-chain/blockchain/head_sync_committee_info.go
+++ b/beacon-chain/blockchain/head_sync_committee_info.go
@@ -1,0 +1,188 @@
+package blockchain
+
+import (
+	"context"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	core "github.com/prysmaticlabs/prysm/beacon-chain/core/state"
+	"github.com/prysmaticlabs/prysm/beacon-chain/state"
+	stateAltair "github.com/prysmaticlabs/prysm/beacon-chain/state/v2"
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/params"
+)
+
+// HeadSyncCommitteeFetcher is the interface that wraps the head sync committee related functions.
+// The head sync committee functions return callers sync committee indices and public keys with respect to current head state.
+type HeadSyncCommitteeFetcher interface {
+	HeadCurrentSyncCommitteeIndices(ctx context.Context, index types.ValidatorIndex, slot types.Slot) ([]types.CommitteeIndex, error)
+	HeadNextSyncCommitteeIndices(ctx context.Context, index types.ValidatorIndex, slot types.Slot) ([]types.CommitteeIndex, error)
+	HeadSyncCommitteePubKeys(ctx context.Context, slot types.Slot, committeeIndex types.CommitteeIndex) ([][]byte, error)
+}
+
+// HeadDomainFetcher is the interface that wraps the head sync domain related functions.
+// The head sync committee domain functions return callers domain data with respect to slot and head state.
+type HeadDomainFetcher interface {
+	HeadSyncCommitteeDomain(ctx context.Context, slot types.Slot) ([]byte, error)
+	HeadSyncSelectionProofDomain(ctx context.Context, slot types.Slot) ([]byte, error)
+	HeadSyncContributionProofDomain(ctx context.Context, slot types.Slot) ([]byte, error)
+}
+
+// HeadSyncCommitteeDomain returns the head sync committee domain using current head state advanced up to `slot`.
+func (s *Service) HeadSyncCommitteeDomain(ctx context.Context, slot types.Slot) ([]byte, error) {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
+	return s.domainWithHeadState(ctx, slot, params.BeaconConfig().DomainSyncCommittee)
+}
+
+// HeadSyncSelectionProofDomain returns the head sync committee domain using current head state advanced up to `slot`.
+func (s *Service) HeadSyncSelectionProofDomain(ctx context.Context, slot types.Slot) ([]byte, error) {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
+	return s.domainWithHeadState(ctx, slot, params.BeaconConfig().DomainSyncCommitteeSelectionProof)
+}
+
+// HeadSyncContributionProofDomain returns the head sync committee domain using current head state advanced up to `slot`.
+func (s *Service) HeadSyncContributionProofDomain(ctx context.Context, slot types.Slot) ([]byte, error) {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
+	return s.domainWithHeadState(ctx, slot, params.BeaconConfig().DomainContributionAndProof)
+}
+
+// HeadCurrentSyncCommitteeIndices returns the input validator `index`'s position indices in the current sync committee with respect to `slot`.
+// Head state advanced up to `slot` is used for calculation.
+func (s *Service) HeadCurrentSyncCommitteeIndices(ctx context.Context, index types.ValidatorIndex, slot types.Slot) ([]types.CommitteeIndex, error) {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
+	headState, err := s.getSyncCommitteeHeadState(ctx, slot)
+	if err != nil {
+		return nil, err
+	}
+	return helpers.CurrentPeriodSyncSubcommitteeIndices(headState, index)
+}
+
+// HeadNextSyncCommitteeIndices returns the input validator `index`'s position indices in the next sync committee with respect to `slot`.
+// Head state advanced up to `slot` is used for calculation.
+func (s *Service) HeadNextSyncCommitteeIndices(ctx context.Context, index types.ValidatorIndex, slot types.Slot) ([]types.CommitteeIndex, error) {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
+	headState, err := s.getSyncCommitteeHeadState(ctx, slot)
+	if err != nil {
+		return nil, err
+	}
+	return helpers.NextPeriodSyncSubcommitteeIndices(headState, index)
+}
+
+// HeadSyncCommitteePubKeys returns the head sync committee public keys with respect to `slot` and subcommittee index `committeeIndex`.
+// Head state advanced up to `slot` is used for calculation.
+func (s *Service) HeadSyncCommitteePubKeys(ctx context.Context, slot types.Slot, committeeIndex types.CommitteeIndex) ([][]byte, error) {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
+	headState, err := s.getSyncCommitteeHeadState(ctx, slot)
+	if err != nil {
+		return nil, err
+	}
+
+	nextSlotEpoch := helpers.SlotToEpoch(headState.Slot() + 1)
+	currEpoch := helpers.SlotToEpoch(headState.Slot())
+
+	var syncCommittee *ethpb.SyncCommittee
+	if helpers.SyncCommitteePeriod(currEpoch) == helpers.SyncCommitteePeriod(nextSlotEpoch) {
+		syncCommittee, err = headState.CurrentSyncCommittee()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		syncCommittee, err = headState.NextSyncCommittee()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return altair.SyncSubCommitteePubkeys(syncCommittee, committeeIndex)
+}
+
+// returns calculated domain using input `domain` and `slot`.
+func (s *Service) domainWithHeadState(ctx context.Context, slot types.Slot, domain [4]byte) ([]byte, error) {
+	headState, err := s.getSyncCommitteeHeadState(ctx, slot)
+	if err != nil {
+		return nil, err
+	}
+	return helpers.Domain(headState.Fork(), helpers.SlotToEpoch(headState.Slot()), domain, headState.GenesisValidatorRoot())
+}
+
+// returns the head state that is advanced up to `slot`. It utilizes the cache `syncCommitteeHeadState` by retrieving using `slot` as key.
+// For the cache miss, it processes head state up to slot and fill the cache with `slot` as key.
+func (s *Service) getSyncCommitteeHeadState(ctx context.Context, slot types.Slot) (state.BeaconState, error) {
+	var headState state.BeaconState
+	var err error
+
+	// If there's already a head state exists with the request slot, we don't need to process slots.
+	cachedState := syncCommitteeHeadStateCache.get(slot)
+	if cachedState != nil && !cachedState.IsNil() {
+		syncHeadStateHit.Inc()
+		headState = cachedState
+	} else {
+		headState, err = s.HeadState(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if slot > headState.Slot() {
+			headState, err = core.ProcessSlots(ctx, headState, slot)
+			if err != nil {
+				return nil, err
+			}
+		}
+		syncHeadStateMiss.Inc()
+		syncCommitteeHeadStateCache.add(slot, headState)
+	}
+
+	return headState, nil
+}
+
+var syncCommitteeHeadStateCache = newSyncCommitteeHeadState()
+
+// syncCommitteeHeadState to caches latest head state requested by the sync committee participant.
+type syncCommitteeHeadState struct {
+	cache *lru.Cache
+	lock  sync.RWMutex
+}
+
+// newSyncCommitteeHeadState initializes the lru cache for `syncCommitteeHeadState` with size of 1.
+func newSyncCommitteeHeadState() *syncCommitteeHeadState {
+	c, err := lru.New(1) // only need size of 1 to avoid redundant state copy, HTR, and process slots.
+	if err != nil {
+		panic(err)
+	}
+	return &syncCommitteeHeadState{cache: c}
+}
+
+// add `slot` as key and `state` as value onto the lru cache.
+func (c *syncCommitteeHeadState) add(slot types.Slot, state state.BeaconState) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.cache.Add(slot, state)
+}
+
+// get `state` using `slot` as key. Return nil if nothing is found.
+func (c *syncCommitteeHeadState) get(slot types.Slot) state.BeaconState {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	val, exists := c.cache.Get(slot)
+	if !exists {
+		return nil
+	}
+	if val == nil {
+		return nil
+	}
+	return val.(*stateAltair.BeaconState)
+}

--- a/beacon-chain/blockchain/head_sync_committee_info_test.go
+++ b/beacon-chain/blockchain/head_sync_committee_info_test.go
@@ -1,0 +1,108 @@
+package blockchain
+
+import (
+	"context"
+	"testing"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil"
+	"github.com/prysmaticlabs/prysm/shared/testutil/require"
+)
+
+func TestService_HeadCurrentSyncCommitteeIndices(t *testing.T) {
+	s, _ := testutil.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
+	c := &Service{}
+	c.head = &head{state: s}
+
+	// Process slot up to `EpochsPerSyncCommitteePeriod` so it can `ProcessSyncCommitteeUpdates`.
+	slot := uint64(params.BeaconConfig().EpochsPerSyncCommitteePeriod)*uint64(params.BeaconConfig().SlotsPerEpoch) + 1
+	indices, err := c.HeadCurrentSyncCommitteeIndices(context.Background(), 0, types.Slot(slot))
+	require.NoError(t, err)
+
+	// NextSyncCommittee becomes CurrentSyncCommittee so it should be empty by default.
+	require.Equal(t, 0, len(indices))
+}
+
+func TestService_HeadNextSyncCommitteeIndices(t *testing.T) {
+	s, _ := testutil.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
+	c := &Service{}
+	c.head = &head{state: s}
+
+	// Process slot up to `EpochsPerSyncCommitteePeriod` so it can `ProcessSyncCommitteeUpdates`.
+	slot := uint64(params.BeaconConfig().EpochsPerSyncCommitteePeriod)*uint64(params.BeaconConfig().SlotsPerEpoch) + 1
+	indices, err := c.HeadNextSyncCommitteeIndices(context.Background(), 0, types.Slot(slot))
+	require.NoError(t, err)
+
+	// NextSyncCommittee should be be empty after `ProcessSyncCommitteeUpdates`. Validator should get indices.
+	require.NotEqual(t, 0, len(indices))
+}
+
+func TestService_HeadSyncCommitteePubKeys(t *testing.T) {
+	s, _ := testutil.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
+	c := &Service{}
+	c.head = &head{state: s}
+
+	// Process slot up to 2 * `EpochsPerSyncCommitteePeriod` so it can run `ProcessSyncCommitteeUpdates` twice.
+	slot := uint64(2*params.BeaconConfig().EpochsPerSyncCommitteePeriod)*uint64(params.BeaconConfig().SlotsPerEpoch) + 1
+	pubkeys, err := c.HeadSyncCommitteePubKeys(context.Background(), types.Slot(slot), 0)
+	require.NoError(t, err)
+
+	// Any subcommittee should match the subcommittee size.
+	subCommitteeSize := params.BeaconConfig().SyncCommitteeSize / params.BeaconConfig().SyncCommitteeSubnetCount
+	require.Equal(t, int(subCommitteeSize), len(pubkeys))
+}
+
+func TestService_HeadSyncCommitteeDomain(t *testing.T) {
+	s, _ := testutil.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
+	c := &Service{}
+	c.head = &head{state: s}
+
+	wanted, err := helpers.Domain(s.Fork(), helpers.SlotToEpoch(s.Slot()), params.BeaconConfig().DomainSyncCommittee, s.GenesisValidatorRoot())
+	require.NoError(t, err)
+
+	d, err := c.HeadSyncCommitteeDomain(context.Background(), 0)
+	require.NoError(t, err)
+
+	require.DeepEqual(t, wanted, d)
+}
+
+func TestService_HeadSyncContributionProofDomain(t *testing.T) {
+	s, _ := testutil.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
+	c := &Service{}
+	c.head = &head{state: s}
+
+	wanted, err := helpers.Domain(s.Fork(), helpers.SlotToEpoch(s.Slot()), params.BeaconConfig().DomainContributionAndProof, s.GenesisValidatorRoot())
+	require.NoError(t, err)
+
+	d, err := c.HeadSyncContributionProofDomain(context.Background(), 0)
+	require.NoError(t, err)
+
+	require.DeepEqual(t, wanted, d)
+}
+
+func TestService_HeadSyncSelectionProofDomain(t *testing.T) {
+	s, _ := testutil.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)
+	c := &Service{}
+	c.head = &head{state: s}
+
+	wanted, err := helpers.Domain(s.Fork(), helpers.SlotToEpoch(s.Slot()), params.BeaconConfig().DomainSyncCommitteeSelectionProof, s.GenesisValidatorRoot())
+	require.NoError(t, err)
+
+	d, err := c.HeadSyncSelectionProofDomain(context.Background(), 0)
+	require.NoError(t, err)
+
+	require.DeepEqual(t, wanted, d)
+}
+
+func TestSyncCommitteeHeadStateCache_RoundTrip(t *testing.T) {
+	c := newSyncCommitteeHeadState()
+	beaconState, _ := testutil.DeterministicGenesisStateAltair(t, 100)
+	require.NoError(t, beaconState.SetSlot(100))
+	cachedState := c.get(101)
+	require.Equal(t, nil, cachedState)
+	c.add(101, beaconState)
+	cachedState = c.get(101)
+	require.DeepEqual(t, beaconState, cachedState)
+}

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
-	statepb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1/block"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/event"
@@ -42,7 +41,7 @@ type ChainService struct {
 	Genesis                     time.Time
 	ValidatorsRoot              [32]byte
 	CanonicalRoots              map[[32]byte]bool
-	Fork                        *statepb.Fork
+	Fork                        *ethpb.Fork
 	ETH1Data                    *ethpb.Eth1Data
 	DB                          db.Database
 	stateNotifier               statefeed.Notifier
@@ -52,6 +51,13 @@ type ChainService struct {
 	ForkChoiceStore             *protoarray.Store
 	VerifyBlkDescendantErr      error
 	Slot                        *types.Slot // Pointer because 0 is a useful value, so checking against it can be incorrect.
+	CurrentSyncCommitteeIndices []types.CommitteeIndex
+	NextSyncCommitteeIndices    []types.CommitteeIndex
+	SyncCommitteeDomain         []byte
+	SyncSelectionProofDomain    []byte
+	SyncContributionProofDomain []byte
+	PublicKey                   [48]byte
+	SyncCommitteePubkeys        [][]byte
 }
 
 // StateNotifier mocks the same method in the chain service.
@@ -259,7 +265,7 @@ func (s *ChainService) HeadState(context.Context) (state.BeaconState, error) {
 }
 
 // CurrentFork mocks HeadState method in chain service.
-func (s *ChainService) CurrentFork() *statepb.Fork {
+func (s *ChainService) CurrentFork() *ethpb.Fork {
 	return s.Fork
 }
 
@@ -392,4 +398,44 @@ func (s *ChainService) ChainHeads() ([][32]byte, []types.Slot) {
 			bytesutil.ToBytes32(bytesutil.PadTo([]byte("bar"), 32)),
 		},
 		[]types.Slot{0, 1}
+}
+
+// HeadPublicKeyToValidatorIndex mocks HeadPublicKeyToValidatorIndex and always return 0 and true.
+func (s *ChainService) HeadPublicKeyToValidatorIndex(ctx context.Context, pubKey [48]byte) (types.ValidatorIndex, bool) {
+	return 0, true
+}
+
+// HeadValidatorIndexToPublicKey mocks HeadValidatorIndexToPublicKey and always return empty and nil.
+func (s *ChainService) HeadValidatorIndexToPublicKey(ctx context.Context, index types.ValidatorIndex) ([48]byte, error) {
+	return s.PublicKey, nil
+}
+
+// HeadCurrentSyncCommitteeIndices mocks HeadCurrentSyncCommitteeIndices and always return `CurrentSyncCommitteeIndices`.
+func (s *ChainService) HeadCurrentSyncCommitteeIndices(ctx context.Context, index types.ValidatorIndex, slot types.Slot) ([]types.CommitteeIndex, error) {
+	return s.CurrentSyncCommitteeIndices, nil
+}
+
+// HeadNextSyncCommitteeIndices mocks HeadNextSyncCommitteeIndices and always return `HeadNextSyncCommitteeIndices`.
+func (s *ChainService) HeadNextSyncCommitteeIndices(ctx context.Context, index types.ValidatorIndex, slot types.Slot) ([]types.CommitteeIndex, error) {
+	return s.NextSyncCommitteeIndices, nil
+}
+
+// HeadSyncCommitteePubKeys mocks HeadSyncCommitteePubKeys and always return empty nil.
+func (s *ChainService) HeadSyncCommitteePubKeys(ctx context.Context, slot types.Slot, committeeIndex types.CommitteeIndex) ([][]byte, error) {
+	return s.SyncCommitteePubkeys, nil
+}
+
+// HeadSyncCommitteeDomain mocks HeadSyncCommitteeDomain and always return empty nil.
+func (s *ChainService) HeadSyncCommitteeDomain(ctx context.Context, slot types.Slot) ([]byte, error) {
+	return s.SyncCommitteeDomain, nil
+}
+
+// HeadSyncSelectionProofDomain mocks HeadSyncSelectionProofDomain and always return empty nil.
+func (s *ChainService) HeadSyncSelectionProofDomain(ctx context.Context, slot types.Slot) ([]byte, error) {
+	return s.SyncSelectionProofDomain, nil
+}
+
+// HeadSyncContributionProofDomain mocks HeadSyncContributionProofDomain and always return empty nil.
+func (s *ChainService) HeadSyncContributionProofDomain(ctx context.Context, slot types.Slot) ([]byte, error) {
+	return s.SyncContributionProofDomain, nil
 }


### PR DESCRIPTION
Part of #8638, this PR adds in sync-committee changes into the `blockchain` service as methods in the `ChainHeadFetcher` interface, allowing services in Prysm to retrieve data such as the current head sync committee and the next sync committee properly. Review these changes carefully and please raise any questions as needed.

These changes come from the `hf1` branch