### PR TITLE
Update P2PUtils And Parameters From Altair

### DIFF
--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -29,7 +29,7 @@ func (s *Service) Broadcast(ctx context.Context, msg proto.Message) error {
 	ctx, cancel := context.WithTimeout(ctx, twoSlots)
 	defer cancel()
 
-	forkDigest, err := s.forkDigest()
+	forkDigest, err := s.currentForkDigest()
 	if err != nil {
 		err := errors.Wrap(err, "could not retrieve fork digest")
 		traceutil.AnnotateError(span, err)
@@ -48,7 +48,7 @@ func (s *Service) Broadcast(ctx context.Context, msg proto.Message) error {
 func (s *Service) BroadcastAttestation(ctx context.Context, subnet uint64, att *eth.Attestation) error {
 	ctx, span := trace.StartSpan(ctx, "p2p.BroadcastAttestation")
 	defer span.End()
-	forkDigest, err := s.forkDigest()
+	forkDigest, err := s.currentForkDigest()
 	if err != nil {
 		err := errors.Wrap(err, "could not retrieve fork digest")
 		traceutil.AnnotateError(span, err)

--- a/beacon-chain/p2p/broadcaster_test.go
+++ b/beacon-chain/p2p/broadcaster_test.go
@@ -55,7 +55,7 @@ func TestService_Broadcast(t *testing.T) {
 	topic := "/eth2/%x/testing"
 	// Set a test gossip mapping for testpb.TestSimpleMessage.
 	GossipTypeMapping[reflect.TypeOf(msg)] = topic
-	digest, err := p.forkDigest()
+	digest, err := p.currentForkDigest()
 	require.NoError(t, err)
 	topic = fmt.Sprintf(topic, digest)
 
@@ -169,7 +169,7 @@ func TestService_BroadcastAttestation(t *testing.T) {
 
 	topic := AttestationSubnetTopicFormat
 	GossipTypeMapping[reflect.TypeOf(msg)] = topic
-	digest, err := p.forkDigest()
+	digest, err := p.currentForkDigest()
 	require.NoError(t, err)
 	topic = fmt.Sprintf(topic, digest, subnet)
 
@@ -326,7 +326,7 @@ func TestService_BroadcastAttestationWithDiscoveryAttempts(t *testing.T) {
 	msg := testutil.HydrateAttestation(&eth.Attestation{AggregationBits: bitfield.NewBitlist(7)})
 	topic := AttestationSubnetTopicFormat
 	GossipTypeMapping[reflect.TypeOf(msg)] = topic
-	digest, err := p.forkDigest()
+	digest, err := p.currentForkDigest()
 	require.NoError(t, err)
 	topic = fmt.Sprintf(topic, digest, subnet)
 

--- a/beacon-chain/p2p/fork.go
+++ b/beacon-chain/p2p/fork.go
@@ -3,11 +3,11 @@ package p2p
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	pb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/p2putils"
@@ -20,16 +20,12 @@ import (
 var eth2ENRKey = params.BeaconNetworkConfig().ETH2Key
 
 // ForkDigest returns the current fork digest of
-// the node.
-func (s *Service) forkDigest() ([4]byte, error) {
-	if s.currentForkDigest != [4]byte{} {
-		return s.currentForkDigest, nil
+// the node according to the local clock.
+func (s *Service) currentForkDigest() ([4]byte, error) {
+	if !s.isInitialized() {
+		return [4]byte{}, errors.New("state is not initialized")
 	}
-	fd, err := p2putils.CreateForkDigest(s.genesisTime, s.genesisValidatorsRoot)
-	if err != nil {
-		s.currentForkDigest = fd
-	}
-	return fd, err
+	return p2putils.CreateForkDigest(s.genesisTime, s.genesisValidatorsRoot)
 }
 
 // Compares fork ENRs between an incoming peer's record and our node's
@@ -97,20 +93,10 @@ func addForkEntry(
 	if timeutils.Now().Before(genesisTime) {
 		currentEpoch = 0
 	}
-	fork, err := p2putils.Fork(currentEpoch)
-	if err != nil {
-		return nil, err
-	}
-
-	nextForkEpoch := params.BeaconConfig().NextForkEpoch
-	nextForkVersion := params.BeaconConfig().NextForkVersion
-	// Set to the current fork version if our next fork is not planned.
-	if nextForkEpoch == math.MaxUint64 {
-		nextForkVersion = fork.CurrentVersion
-	}
+	nextForkVersion, nextForkEpoch := p2putils.NextForkData(currentEpoch)
 	enrForkID := &pb.ENRForkID{
 		CurrentForkDigest: digest[:],
-		NextForkVersion:   nextForkVersion,
+		NextForkVersion:   nextForkVersion[:],
 		NextForkEpoch:     nextForkEpoch,
 	}
 	enc, err := enrForkID.MarshalSSZ()

--- a/beacon-chain/p2p/fork.go
+++ b/beacon-chain/p2p/fork.go
@@ -93,7 +93,10 @@ func addForkEntry(
 	if timeutils.Now().Before(genesisTime) {
 		currentEpoch = 0
 	}
-	nextForkVersion, nextForkEpoch := p2putils.NextForkData(currentEpoch)
+	nextForkVersion, nextForkEpoch, err := p2putils.NextForkData(currentEpoch)
+	if err != nil {
+		return nil, err
+	}
 	enrForkID := &pb.ENRForkID{
 		CurrentForkDigest: digest[:],
 		NextForkVersion:   nextForkVersion[:],

--- a/beacon-chain/p2p/pubsub_filter.go
+++ b/beacon-chain/p2p/pubsub_filter.go
@@ -30,7 +30,7 @@ func (s *Service) CanSubscribe(topic string) bool {
 	if parts[1] != "eth2" {
 		return false
 	}
-	fd, err := s.forkDigest()
+	fd, err := s.currentForkDigest()
 	if err != nil {
 		log.WithError(err).Error("Could not determine fork digest")
 		return false

--- a/beacon-chain/p2p/pubsub_filter_test.go
+++ b/beacon-chain/p2p/pubsub_filter_test.go
@@ -14,7 +14,9 @@ import (
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
+	"github.com/prysmaticlabs/prysm/shared/p2putils"
 	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/timeutils"
 	"github.com/stretchr/testify/require"
 )
@@ -22,6 +24,10 @@ import (
 func TestService_CanSubscribe(t *testing.T) {
 	currentFork := [4]byte{0x01, 0x02, 0x03, 0x04}
 	validProtocolSuffix := "/" + encoder.ProtocolSuffixSSZSnappy
+	genesisTime := time.Now()
+	valRoot := [32]byte{}
+	digest, err := p2putils.CreateForkDigest(genesisTime, valRoot[:])
+	assert.NoError(t, err)
 	type test struct {
 		name  string
 		topic string
@@ -30,7 +36,7 @@ func TestService_CanSubscribe(t *testing.T) {
 	tests := []test{
 		{
 			name:  "block topic on current fork",
-			topic: fmt.Sprintf(BlockSubnetTopicFormat, currentFork) + validProtocolSuffix,
+			topic: fmt.Sprintf(BlockSubnetTopicFormat, digest) + validProtocolSuffix,
 			want:  true,
 		},
 		{
@@ -60,17 +66,17 @@ func TestService_CanSubscribe(t *testing.T) {
 		},
 		{
 			name:  "bad prefix",
-			topic: fmt.Sprintf("/eth3/%x/foobar", currentFork) + validProtocolSuffix,
+			topic: fmt.Sprintf("/eth3/%x/foobar", digest) + validProtocolSuffix,
 			want:  false,
 		},
 		{
 			name:  "topic not in gossip mapping",
-			topic: fmt.Sprintf("/eth2/%x/foobar", currentFork) + validProtocolSuffix,
+			topic: fmt.Sprintf("/eth2/%x/foobar", digest) + validProtocolSuffix,
 			want:  false,
 		},
 		{
 			name:  "att subnet topic on current fork",
-			topic: fmt.Sprintf(AttestationSubnetTopicFormat, currentFork, 55 /*subnet*/) + validProtocolSuffix,
+			topic: fmt.Sprintf(AttestationSubnetTopicFormat, digest, 55 /*subnet*/) + validProtocolSuffix,
 			want:  true,
 		},
 		{
@@ -82,7 +88,7 @@ func TestService_CanSubscribe(t *testing.T) {
 
 	// Ensure all gossip topic mappings pass validation.
 	for topic := range GossipTopicMappings {
-		formatting := []interface{}{currentFork}
+		formatting := []interface{}{digest}
 
 		// Special case for attestation subnets which have a second formatting placeholder.
 		if topic == AttestationSubnetTopicFormat {
@@ -99,9 +105,8 @@ func TestService_CanSubscribe(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Service{
-				currentForkDigest:     currentFork,
-				genesisValidatorsRoot: make([]byte, 32),
-				genesisTime:           time.Now(),
+				genesisValidatorsRoot: valRoot[:],
+				genesisTime:           genesisTime,
 			}
 			if got := s.CanSubscribe(tt.topic); got != tt.want {
 				t.Errorf("CanSubscribe(%s) = %v, want %v", tt.topic, got, tt.want)
@@ -204,8 +209,11 @@ func TestGossipTopicMapping_scanfcheck_GossipTopicFormattingSanityCheck(t *testi
 }
 
 func TestService_FilterIncomingSubscriptions(t *testing.T) {
-	currentFork := [4]byte{0x01, 0x02, 0x03, 0x04}
 	validProtocolSuffix := "/" + encoder.ProtocolSuffixSSZSnappy
+	genesisTime := time.Now()
+	valRoot := [32]byte{}
+	digest, err := p2putils.CreateForkDigest(genesisTime, valRoot[:])
+	assert.NoError(t, err)
 	type args struct {
 		id   peer.ID
 		subs []*pubsubpb.RPC_SubOpts
@@ -241,7 +249,7 @@ func TestService_FilterIncomingSubscriptions(t *testing.T) {
 							return &b
 						}(),
 						Topicid: func() *string {
-							s := fmt.Sprintf(BlockSubnetTopicFormat, currentFork) + validProtocolSuffix
+							s := fmt.Sprintf(BlockSubnetTopicFormat, digest) + validProtocolSuffix
 							return &s
 						}(),
 					},
@@ -255,7 +263,7 @@ func TestService_FilterIncomingSubscriptions(t *testing.T) {
 						return &b
 					}(),
 					Topicid: func() *string {
-						s := fmt.Sprintf(BlockSubnetTopicFormat, currentFork) + validProtocolSuffix
+						s := fmt.Sprintf(BlockSubnetTopicFormat, digest) + validProtocolSuffix
 						return &s
 					}(),
 				},
@@ -271,7 +279,7 @@ func TestService_FilterIncomingSubscriptions(t *testing.T) {
 							return &b
 						}(),
 						Topicid: func() *string {
-							s := fmt.Sprintf(BlockSubnetTopicFormat, currentFork) + validProtocolSuffix
+							s := fmt.Sprintf(BlockSubnetTopicFormat, digest) + validProtocolSuffix
 							return &s
 						}(),
 					},
@@ -281,7 +289,7 @@ func TestService_FilterIncomingSubscriptions(t *testing.T) {
 							return &b
 						}(),
 						Topicid: func() *string {
-							s := fmt.Sprintf(BlockSubnetTopicFormat, currentFork) + validProtocolSuffix
+							s := fmt.Sprintf(BlockSubnetTopicFormat, digest) + validProtocolSuffix
 							return &s
 						}(),
 					},
@@ -295,7 +303,7 @@ func TestService_FilterIncomingSubscriptions(t *testing.T) {
 						return &b
 					}(),
 					Topicid: func() *string {
-						s := fmt.Sprintf(BlockSubnetTopicFormat, currentFork) + validProtocolSuffix
+						s := fmt.Sprintf(BlockSubnetTopicFormat, digest) + validProtocolSuffix
 						return &s
 					}(),
 				},
@@ -305,9 +313,8 @@ func TestService_FilterIncomingSubscriptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Service{
-				currentForkDigest:     currentFork,
-				genesisValidatorsRoot: make([]byte, 32),
-				genesisTime:           time.Now(),
+				genesisValidatorsRoot: valRoot[:],
+				genesisTime:           genesisTime,
 			}
 			got, err := s.FilterIncomingSubscriptions(tt.args.id, tt.args.subs)
 			if (err != nil) != tt.wantErr {

--- a/beacon-chain/p2p/pubsub_filter_test.go
+++ b/beacon-chain/p2p/pubsub_filter_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/p2putils"
-	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
 	"github.com/prysmaticlabs/prysm/shared/timeutils"
 	"github.com/stretchr/testify/require"
@@ -358,13 +357,4 @@ func TestService_MonitorsStateForkUpdates(t *testing.T) {
 
 	require.True(t, s.isInitialized())
 	require.NotEmpty(t, s.currentForkDigest)
-}
-
-func TestService_doesntSupportForksYet(t *testing.T) {
-	// Part of phase 1 will include a state transition which updates the state's fork. In phase 0,
-	// there are no forks or fork schedule planned. As such, we'll work on supporting fork upgrades
-	// in phase 1 changes.
-	if len(params.BeaconConfig().ForkVersionSchedule) > 0 {
-		t.Fatal("pubsub subscription filters do not support fork schedule (yet)")
-	}
 }

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -56,7 +56,6 @@ var maxDialTimeout = params.BeaconNetworkConfig().RespTimeout
 type Service struct {
 	started               bool
 	isPreGenesis          bool
-	currentForkDigest     [4]byte
 	pingMethod            func(ctx context.Context, id peer.ID) error
 	cancel                context.CancelFunc
 	cfg                   *Config
@@ -397,7 +396,7 @@ func (s *Service) awaitStateInitialized() {
 				}
 				s.genesisTime = data.StartTime
 				s.genesisValidatorsRoot = data.GenesisValidatorsRoot
-				_, err := s.forkDigest() // initialize fork digest cache
+				_, err := s.currentForkDigest() // initialize fork digest cache
 				if err != nil {
 					log.WithError(err).Error("Could not initialize fork digest")
 				}

--- a/beacon-chain/rpc/eth/v1/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/eth/v1/beacon/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//shared/copyutil:go_default_library",
         "//shared/featureconfig:go_default_library",
         "//shared/grpcutils:go_default_library",
+        "//shared/p2putils:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/shared/p2putils/BUILD.bazel
+++ b/shared/p2putils/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@prysm//tools/go:def.bzl", "go_library")
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -8,8 +8,22 @@ go_library(
     deps = [
         "//beacon-chain/core/helpers:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
+        "//shared/bytesutil:go_default_library",
         "//shared/params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_prysmaticlabs_eth2_types//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["fork_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//beacon-chain/core/helpers:go_default_library",
+        "//proto/prysm/v1alpha1:go_default_library",
+        "//shared/params:go_default_library",
+        "//shared/testutil/assert:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
     ],
 )

--- a/shared/p2putils/fork.go
+++ b/shared/p2putils/fork.go
@@ -2,14 +2,53 @@
 package p2putils
 
 import (
+	"math"
+	"sort"
 	"time"
 
 	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
-	statepb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 )
+
+// IsForkNextEpoch checks if an alloted fork is in the following epoch.
+func IsForkNextEpoch(genesisTime time.Time, genesisValidatorsRoot []byte) (bool, error) {
+	if genesisTime.IsZero() {
+		return false, errors.New("genesis time is not set")
+	}
+	if len(genesisValidatorsRoot) == 0 {
+		return false, errors.New("genesis validators root is not set")
+	}
+	currentSlot := helpers.SlotsSince(genesisTime)
+	currentEpoch := helpers.SlotToEpoch(currentSlot)
+	fSchedule := params.BeaconConfig().ForkVersionSchedule
+	scheduledForks := SortedForkVersions(fSchedule)
+	isForkEpoch := false
+	for _, forkVersion := range scheduledForks {
+		epoch := fSchedule[forkVersion]
+		if currentEpoch+1 == epoch {
+			isForkEpoch = true
+			break
+		}
+	}
+	return isForkEpoch, nil
+}
+
+// ForkDigestFromEpoch retrieves the fork digest from the current schedule determined
+// by the provided epoch.
+func ForkDigestFromEpoch(currentEpoch types.Epoch, genesisValidatorsRoot []byte) ([4]byte, error) {
+	if len(genesisValidatorsRoot) == 0 {
+		return [4]byte{}, errors.New("genesis validators root is not set")
+	}
+	forkData, err := Fork(currentEpoch)
+	if err != nil {
+		return [4]byte{}, err
+	}
+	return helpers.ComputeForkDigest(forkData.CurrentVersion, genesisValidatorsRoot)
+}
 
 // CreateForkDigest creates a fork digest from a genesis time and genesis
 // validators root, utilizing the current slot to determine
@@ -43,24 +82,83 @@ func CreateForkDigest(
 // returns the active fork version during this epoch.
 func Fork(
 	targetEpoch types.Epoch,
-) (*statepb.Fork, error) {
-	// We retrieve a list of scheduled forks by epoch.
-	// We loop through the keys in this map to determine the current
-	// fork version based on the requested epoch.
-	retrievedForkVersion := params.BeaconConfig().GenesisForkVersion
-	previousForkVersion := params.BeaconConfig().GenesisForkVersion
-	scheduledForks := params.BeaconConfig().ForkVersionSchedule
+) (*ethpb.Fork, error) {
+	currentForkVersion := bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion)
+	previousForkVersion := bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion)
+	fSchedule := params.BeaconConfig().ForkVersionSchedule
+	sortedForkVersions := SortedForkVersions(fSchedule)
 	forkEpoch := types.Epoch(0)
-	for epoch, forkVersion := range scheduledForks {
-		if epoch <= targetEpoch {
-			previousForkVersion = retrievedForkVersion
-			retrievedForkVersion = forkVersion
+	for _, forkVersion := range sortedForkVersions {
+		epoch := fSchedule[forkVersion]
+		if targetEpoch >= epoch {
+			previousForkVersion = currentForkVersion
+			currentForkVersion = forkVersion
 			forkEpoch = epoch
 		}
 	}
-	return &statepb.Fork{
-		PreviousVersion: previousForkVersion,
-		CurrentVersion:  retrievedForkVersion,
+	return &ethpb.Fork{
+		PreviousVersion: previousForkVersion[:],
+		CurrentVersion:  currentForkVersion[:],
 		Epoch:           forkEpoch,
 	}, nil
+}
+
+// RetrieveForkDataFromDigest performs the inverse, where it tries to determine the fork version
+// and epoch from a provided digest by looping through our current fork schedule.
+func RetrieveForkDataFromDigest(digest [4]byte, genesisValidatorsRoot []byte) ([4]byte, types.Epoch, error) {
+	fSchedule := params.BeaconConfig().ForkVersionSchedule
+	for v, e := range fSchedule {
+		rDigest, err := helpers.ComputeForkDigest(v[:], genesisValidatorsRoot)
+		if err != nil {
+			return [4]byte{}, 0, err
+		}
+		if rDigest == digest {
+			return v, e, nil
+		}
+	}
+	return [4]byte{}, 0, errors.Errorf("no fork exists for a digest of %#x", digest)
+}
+
+// NextForkData retrieves the next fork data according to the
+// provided current epoch.
+func NextForkData(currEpoch types.Epoch) ([4]byte, types.Epoch) {
+	fSchedule := params.BeaconConfig().ForkVersionSchedule
+	sortedForkVersions := SortedForkVersions(fSchedule)
+	nextForkEpoch := types.Epoch(math.MaxUint64)
+	nextForkVersion := [4]byte{}
+	for _, forkVersion := range sortedForkVersions {
+		epoch := fSchedule[forkVersion]
+		// If we get an epoch larger than out current epoch
+		// we set this as our next fork epoch and exit the
+		// loop.
+		if epoch > currEpoch {
+			nextForkEpoch = epoch
+			nextForkVersion = forkVersion
+			break
+		}
+		// In the event the retrieved epoch is less than
+		// our current epoch, we mark the previous
+		// fork's version as the next fork version.
+		if epoch <= currEpoch {
+			// The next fork version is updated to
+			// always include the most current fork version.
+			nextForkVersion = forkVersion
+		}
+	}
+	return nextForkVersion, nextForkEpoch
+}
+
+// SortedForkVersions sorts the provided fork schedule in ascending order
+// by epoch.
+func SortedForkVersions(forkSchedule map[[4]byte]types.Epoch) [][4]byte {
+	sortedVersions := make([][4]byte, len(forkSchedule))
+	i := 0
+	for k := range forkSchedule {
+		sortedVersions[i] = k
+		i++
+	}
+	sort.Slice(sortedVersions, func(a, b int) bool {
+		return forkSchedule[sortedVersions[a]] < forkSchedule[sortedVersions[b]]
+	})
+	return sortedVersions
 }

--- a/shared/p2putils/fork_test.go
+++ b/shared/p2putils/fork_test.go
@@ -1,0 +1,365 @@
+package p2putils
+
+import (
+	"math"
+	"reflect"
+	"testing"
+	"time"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/shared/params"
+	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
+)
+
+func TestFork(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	tests := []struct {
+		name        string
+		targetEpoch types.Epoch
+		want        *ethpb.Fork
+		wantErr     bool
+		setConfg    func()
+	}{
+		{
+			name:        "genesis fork",
+			targetEpoch: 0,
+			want: &ethpb.Fork{
+				Epoch:           0,
+				CurrentVersion:  []byte{'A', 'B', 'C', 'D'},
+				PreviousVersion: []byte{'A', 'B', 'C', 'D'},
+			},
+			wantErr: false,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+		{
+			name:        "altair pre-fork",
+			targetEpoch: 0,
+			want: &ethpb.Fork{
+				Epoch:           0,
+				CurrentVersion:  []byte{'A', 'B', 'C', 'D'},
+				PreviousVersion: []byte{'A', 'B', 'C', 'D'},
+			},
+			wantErr: false,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.AltairForkVersion = []byte{'A', 'B', 'C', 'F'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+		{
+			name:        "altair on fork",
+			targetEpoch: 10,
+			want: &ethpb.Fork{
+				Epoch:           10,
+				CurrentVersion:  []byte{'A', 'B', 'C', 'F'},
+				PreviousVersion: []byte{'A', 'B', 'C', 'D'},
+			},
+			wantErr: false,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.AltairForkVersion = []byte{'A', 'B', 'C', 'F'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+
+		{
+			name:        "altair post fork",
+			targetEpoch: 10,
+			want: &ethpb.Fork{
+				Epoch:           10,
+				CurrentVersion:  []byte{'A', 'B', 'C', 'F'},
+				PreviousVersion: []byte{'A', 'B', 'C', 'D'},
+			},
+			wantErr: false,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.AltairForkVersion = []byte{'A', 'B', 'C', 'F'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+
+		{
+			name:        "3 forks, pre-fork",
+			targetEpoch: 20,
+			want: &ethpb.Fork{
+				Epoch:           10,
+				CurrentVersion:  []byte{'A', 'B', 'C', 'F'},
+				PreviousVersion: []byte{'A', 'B', 'C', 'D'},
+			},
+			wantErr: false,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+					{'A', 'B', 'C', 'Z'}: 100,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+		{
+			name:        "3 forks, on fork",
+			targetEpoch: 100,
+			want: &ethpb.Fork{
+				Epoch:           100,
+				CurrentVersion:  []byte{'A', 'B', 'C', 'Z'},
+				PreviousVersion: []byte{'A', 'B', 'C', 'F'},
+			},
+			wantErr: false,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+					{'A', 'B', 'C', 'Z'}: 100,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setConfg()
+			got, err := Fork(tt.targetEpoch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Fork() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Fork() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetrieveForkDataFromDigest(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+	cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+		{'A', 'B', 'C', 'D'}: 0,
+		{'A', 'B', 'C', 'F'}: 10,
+		{'A', 'B', 'C', 'Z'}: 100,
+	}
+	params.OverrideBeaconConfig(cfg)
+	genValRoot := [32]byte{'A', 'B', 'C', 'D'}
+	digest, err := helpers.ComputeForkDigest([]byte{'A', 'B', 'C', 'F'}, genValRoot[:])
+	assert.NoError(t, err)
+
+	version, epoch, err := RetrieveForkDataFromDigest(digest, genValRoot[:])
+	assert.NoError(t, err)
+	assert.Equal(t, [4]byte{'A', 'B', 'C', 'F'}, version)
+	assert.Equal(t, epoch, types.Epoch(10))
+
+	digest, err = helpers.ComputeForkDigest([]byte{'A', 'B', 'C', 'Z'}, genValRoot[:])
+	assert.NoError(t, err)
+
+	version, epoch, err = RetrieveForkDataFromDigest(digest, genValRoot[:])
+	assert.NoError(t, err)
+	assert.Equal(t, [4]byte{'A', 'B', 'C', 'Z'}, version)
+	assert.Equal(t, epoch, types.Epoch(100))
+}
+
+func TestIsForkNextEpoch(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig()
+	cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+	cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+		{'A', 'B', 'C', 'D'}: 0,
+		{'A', 'B', 'C', 'F'}: 10,
+		{'A', 'B', 'C', 'Z'}: 100,
+	}
+	genTimeCreator := func(epoch types.Epoch) time.Time {
+		return time.Now().Add(-time.Duration(uint64(params.BeaconConfig().SlotsPerEpoch)*uint64(epoch)*params.BeaconConfig().SecondsPerSlot) * time.Second)
+	}
+	// Is at Fork Epoch
+	genesisTime := genTimeCreator(10)
+	genRoot := [32]byte{'A'}
+
+	isFork, err := IsForkNextEpoch(genesisTime, genRoot[:])
+	assert.NoError(t, err)
+	assert.Equal(t, false, isFork)
+
+	// Is right before fork epoch
+	genesisTime = genTimeCreator(9)
+
+	isFork, err = IsForkNextEpoch(genesisTime, genRoot[:])
+	assert.NoError(t, err)
+	assert.Equal(t, true, isFork)
+
+	// Is at fork epoch
+	genesisTime = genTimeCreator(100)
+
+	isFork, err = IsForkNextEpoch(genesisTime, genRoot[:])
+	assert.NoError(t, err)
+	assert.Equal(t, false, isFork)
+
+	genesisTime = genTimeCreator(99)
+
+	// Is right before fork epoch.
+	isFork, err = IsForkNextEpoch(genesisTime, genRoot[:])
+	assert.NoError(t, err)
+	assert.Equal(t, true, isFork)
+}
+
+func TestNextForkData(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	tests := []struct {
+		name              string
+		setConfg          func()
+		currEpoch         types.Epoch
+		wantedForkVerison [4]byte
+		wantedEpoch       types.Epoch
+	}{
+		{
+			name:              "genesis fork",
+			currEpoch:         0,
+			wantedForkVerison: [4]byte{'A', 'B', 'C', 'D'},
+			wantedEpoch:       math.MaxUint64,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+		{
+			name:              "altair pre-fork",
+			currEpoch:         5,
+			wantedForkVerison: [4]byte{'A', 'B', 'C', 'F'},
+			wantedEpoch:       10,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.AltairForkVersion = []byte{'A', 'B', 'C', 'F'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+		{
+			name:              "altair on fork",
+			currEpoch:         10,
+			wantedForkVerison: [4]byte{'A', 'B', 'C', 'F'},
+			wantedEpoch:       math.MaxUint64,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.AltairForkVersion = []byte{'A', 'B', 'C', 'F'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+
+		{
+			name:              "altair post fork",
+			currEpoch:         20,
+			wantedForkVerison: [4]byte{'A', 'B', 'C', 'F'},
+			wantedEpoch:       math.MaxUint64,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.AltairForkVersion = []byte{'A', 'B', 'C', 'F'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+
+		{
+			name:              "3 forks, pre-fork, 1st fork",
+			currEpoch:         5,
+			wantedForkVerison: [4]byte{'A', 'B', 'C', 'F'},
+			wantedEpoch:       10,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+					{'A', 'B', 'C', 'Z'}: 100,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+		{
+			name:              "3 forks, pre-fork, 2nd fork",
+			currEpoch:         50,
+			wantedForkVerison: [4]byte{'A', 'B', 'C', 'Z'},
+			wantedEpoch:       100,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+					{'A', 'B', 'C', 'Z'}: 100,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+		{
+			name:              "3 forks, on fork",
+			currEpoch:         100,
+			wantedForkVerison: [4]byte{'A', 'B', 'C', 'Z'},
+			wantedEpoch:       math.MaxUint64,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{
+					{'A', 'B', 'C', 'D'}: 0,
+					{'A', 'B', 'C', 'F'}: 10,
+					{'A', 'B', 'C', 'Z'}: 100,
+				}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setConfg()
+			fVersion, fEpoch := NextForkData(tt.currEpoch)
+			if fVersion != tt.wantedForkVerison {
+				t.Errorf("NextForkData() fork version = %v, want %v", fVersion, tt.wantedForkVerison)
+			}
+			if fEpoch != tt.wantedEpoch {
+				t.Errorf("NextForkData() fork epoch = %v, want %v", fEpoch, tt.wantedEpoch)
+			}
+		})
+	}
+}

--- a/shared/p2putils/fork_test.go
+++ b/shared/p2putils/fork_test.go
@@ -23,6 +23,22 @@ func TestFork(t *testing.T) {
 		setConfg    func()
 	}{
 		{
+			name:        "no fork",
+			targetEpoch: 0,
+			want: &ethpb.Fork{
+				Epoch:           0,
+				CurrentVersion:  []byte{'A', 'B', 'C', 'D'},
+				PreviousVersion: []byte{'A', 'B', 'C', 'D'},
+			},
+			wantErr: false,
+			setConfg: func() {
+				cfg := params.BeaconConfig()
+				cfg.GenesisForkVersion = []byte{'A', 'B', 'C', 'D'}
+				cfg.ForkVersionSchedule = map[[4]byte]types.Epoch{}
+				params.OverrideBeaconConfig(cfg)
+			},
+		},
+		{
 			name:        "genesis fork",
 			targetEpoch: 0,
 			want: &ethpb.Fork{
@@ -353,7 +369,8 @@ func TestNextForkData(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setConfg()
-			fVersion, fEpoch := NextForkData(tt.currEpoch)
+			fVersion, fEpoch, err := NextForkData(tt.currEpoch)
+			assert.NoError(t, err)
 			if fVersion != tt.wantedForkVerison {
 				t.Errorf("NextForkData() fork version = %v, want %v", fVersion, tt.wantedForkVerison)
 			}

--- a/shared/params/BUILD.bazel
+++ b/shared/params/BUILD.bazel
@@ -39,8 +39,7 @@ go_test(
         "loader_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@eth2_spec_tests_mainnet//:test_data",
-        "@eth2_spec_tests_minimal//:test_data",
+        "@eth2_spec//:spec_data",
     ],
     embed = [":go_default_library"],
     gotags = ["develop"],

--- a/shared/params/BUILD.bazel
+++ b/shared/params/BUILD.bazel
@@ -39,7 +39,8 @@ go_test(
         "loader_test.go",
     ],
     data = glob(["*.yaml"]) + [
-        "@eth2_spec//:spec_data",
+        "@eth2_spec_tests_mainnet//:test_data",
+        "@eth2_spec_tests_minimal//:test_data",
     ],
     embed = [":go_default_library"],
     gotags = ["develop"],

--- a/shared/params/loader.go
+++ b/shared/params/loader.go
@@ -16,6 +16,8 @@ func LoadChainConfigFile(chainConfigFileName string) {
 	if err != nil {
 		log.WithError(err).Fatal("Failed to read chain config file.")
 	}
+	// Default to using mainnet.
+	conf := MainnetConfig().Copy()
 	// Convert 0x hex inputs to fixed bytes arrays
 	lines := strings.Split(string(yamlFile), "\n")
 	for i, line := range lines {
@@ -23,13 +25,16 @@ func LoadChainConfigFile(chainConfigFileName string) {
 		if strings.HasPrefix(line, "DEPOSIT_CONTRACT_ADDRESS") {
 			continue
 		}
+		if strings.HasPrefix(line, "PRESET_BASE: 'minimal'") {
+			conf = MinimalSpecConfig().Copy()
+		}
+
 		if !strings.HasPrefix(line, "#") && strings.Contains(line, "0x") {
 			parts := replaceHexStringWithYAMLFormat(line)
 			lines[i] = strings.Join(parts, "\n")
 		}
 	}
 	yamlFile = []byte(strings.Join(lines, "\n"))
-	conf := MainnetConfig().Copy()
 	if err := yaml.UnmarshalStrict(yamlFile, conf); err != nil {
 		if _, ok := err.(*yaml.TypeError); !ok {
 			log.WithError(err).Fatal("Failed to parse chain config yaml file.")

--- a/shared/params/loader_test.go
+++ b/shared/params/loader_test.go
@@ -125,14 +125,14 @@ func TestLoadConfigFileMainnet(t *testing.T) {
 	}
 
 	t.Run("mainnet", func(t *testing.T) {
-		mainnetConfigFile := configFilePath(t, "mainnet")
+		mainnetConfigFile := deprecatedConfigFilePath(t, "mainnet")
 		LoadChainConfigFile(mainnetConfigFile)
 		fields := fieldsFromYaml(t, mainnetConfigFile)
 		assertVals("mainnet", fields, MainnetConfig(), BeaconConfig())
 	})
 
 	t.Run("minimal", func(t *testing.T) {
-		minimalConfigFile := configFilePath(t, "minimal")
+		minimalConfigFile := deprecatedConfigFilePath(t, "minimal")
 		LoadChainConfigFile(minimalConfigFile)
 		fields := fieldsFromYaml(t, minimalConfigFile)
 		assertVals("minimal", fields, MinimalSpecConfig(), BeaconConfig())
@@ -243,6 +243,17 @@ func presetsFilePath(t *testing.T, config string) string {
 	filepath, err := bazel.Runfile("external/eth2_spec")
 	require.NoError(t, err)
 	configFilePath := path.Join(filepath, "presets", config, "phase0.yaml")
+	return configFilePath
+}
+
+// Deprecated: This sets the proper config and returns the relevant
+// config file path from eth2-spec-tests directory. From altair onwards
+// we use the other methods to retrieve the spec config.
+func deprecatedConfigFilePath(t *testing.T, config string) string {
+	configFolderPath := path.Join("tests", config)
+	filepath, err := bazel.Runfile(configFolderPath)
+	require.NoError(t, err)
+	configFilePath := path.Join(filepath, "config", "phase0.yaml")
 	return configFilePath
 }
 

--- a/shared/params/loader_test.go
+++ b/shared/params/loader_test.go
@@ -125,14 +125,14 @@ func TestLoadConfigFileMainnet(t *testing.T) {
 	}
 
 	t.Run("mainnet", func(t *testing.T) {
-		mainnetConfigFile := ConfigFilePath(t, "mainnet")
+		mainnetConfigFile := configFilePath(t, "mainnet")
 		LoadChainConfigFile(mainnetConfigFile)
 		fields := fieldsFromYaml(t, mainnetConfigFile)
 		assertVals("mainnet", fields, MainnetConfig(), BeaconConfig())
 	})
 
 	t.Run("minimal", func(t *testing.T) {
-		minimalConfigFile := ConfigFilePath(t, "minimal")
+		minimalConfigFile := configFilePath(t, "minimal")
 		LoadChainConfigFile(minimalConfigFile)
 		fields := fieldsFromYaml(t, minimalConfigFile)
 		assertVals("minimal", fields, MinimalSpecConfig(), BeaconConfig())
@@ -228,13 +228,21 @@ func Test_replaceHexStringWithYAMLFormat(t *testing.T) {
 	}
 }
 
-// ConfigFilePath sets the proper config and returns the relevant
+// configFilePath sets the proper config and returns the relevant
 // config file path from eth2-spec-tests directory.
-func ConfigFilePath(t *testing.T, config string) string {
-	configFolderPath := path.Join("tests", config)
-	filepath, err := bazel.Runfile(configFolderPath)
+func configFilePath(t *testing.T, config string) string {
+	filepath, err := bazel.Runfile("external/eth2_spec")
 	require.NoError(t, err)
-	configFilePath := path.Join(filepath, "config", "phase0.yaml")
+	configFilePath := path.Join(filepath, "configs", config+".yaml")
+	return configFilePath
+}
+
+// presetsFilePath sets the proper preset and returns the relevant
+// preset file path from eth2-spec-tests directory.
+func presetsFilePath(t *testing.T, config string) string {
+	filepath, err := bazel.Runfile("external/eth2_spec")
+	require.NoError(t, err)
+	configFilePath := path.Join(filepath, "presets", config, "phase0.yaml")
 	return configFilePath
 }
 

--- a/shared/params/mainnet_config.go
+++ b/shared/params/mainnet_config.go
@@ -19,6 +19,8 @@ func UseMainnetConfig() {
 }
 
 const (
+	// Genesis Fork Epoch for the mainnet config.
+	genesisForkEpoch = 0
 	// Altair Fork Epoch for mainnet config.
 	// Placeholder until fork epoch is decided.
 	mainnetAltairForkEpoch = math.MaxUint64
@@ -172,6 +174,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	SlotsPerArchivedPoint:       2048,
 	GenesisCountdownInterval:    time.Minute,
 	ConfigName:                  ConfigNames[Mainnet],
+	PresetBase:                  "mainnet",
 	BeaconStateFieldCount:       21,
 	BeaconStateAltairFieldCount: 24,
 
@@ -184,13 +187,18 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	SafetyDecay: 10,
 
 	// Fork related values.
-	GenesisForkVersion:  []byte{0, 0, 0, 0},
-	AltairForkVersion:   []byte{1, 0, 0, 0},
-	NextForkVersion:     []byte{1, 0, 0, 0}, // Set to altair fork version.
-	AltairForkEpoch:     mainnetAltairForkEpoch,
-	NextForkEpoch:       mainnetAltairForkEpoch, // Set to altair fork epoch.
-	ForkVersionSchedule: map[types.Epoch][]byte{
-		// TODO(): To be updated for Altair.
+	GenesisForkVersion:          []byte{0, 0, 0, 0},
+	AltairForkVersion:           []byte{1, 0, 0, 0},
+	AltairForkEpoch:             mainnetAltairForkEpoch,
+	MergeForkVersion:            []byte{2, 0, 0, 0},
+	MergeForkEpoch:              math.MaxUint64,
+	ShardingForkVersion:         []byte{3, 0, 0, 0},
+	ShardingForkEpoch:           math.MaxUint64,
+	MinAnchorPowBlockDifficulty: 4294967296,
+	ForkVersionSchedule: map[[4]byte]types.Epoch{
+		{0, 0, 0, 0}: genesisForkEpoch,
+		{1, 0, 0, 0}: mainnetAltairForkEpoch,
+		// Any further forks must be specified here by their epoch number.
 	},
 
 	// New values introduced in Altair hard fork 1.
@@ -208,7 +216,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	WeightDenominator:  64,
 
 	// Validator related values.
-	TargetAggregatorsPerSyncSubcommittee: 4,
+	TargetAggregatorsPerSyncSubcommittee: 16,
 	SyncCommitteeSubnetCount:             4,
 
 	// Misc values.

--- a/shared/params/minimal_config.go
+++ b/shared/params/minimal_config.go
@@ -3,6 +3,7 @@ package params
 import (
 	"math"
 
+	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 )
 
@@ -87,6 +88,15 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	// New Altair params
 	minimalConfig.AltairForkVersion = []byte{1, 0, 0, 1} // Highest byte set to 0x01 to avoid collisions with mainnet versioning
 	minimalConfig.AltairForkEpoch = math.MaxUint64
+	minimalConfig.MergeForkVersion = []byte{2, 0, 0, 1}
+	minimalConfig.MergeForkEpoch = math.MaxUint64
+	minimalConfig.ShardingForkVersion = []byte{3, 0, 0, 1}
+	minimalConfig.ShardingForkEpoch = math.MaxUint64
+	// Manually set fork version schedule here.
+	minimalConfig.ForkVersionSchedule = map[[4]byte]types.Epoch{
+		{0, 0, 0, 1}: 0,
+		{1, 0, 0, 1}: math.MaxUint64,
+	}
 	minimalConfig.SyncCommitteeSize = 32
 	minimalConfig.InactivityScoreBias = 4
 	minimalConfig.EpochsPerSyncCommitteePeriod = 8
@@ -97,6 +107,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.DepositContractAddress = "0x1234567890123456789012345678901234567890"
 
 	minimalConfig.ConfigName = ConfigNames[Minimal]
+	minimalConfig.PresetBase = "minimal"
 
 	return minimalConfig
 }

--- a/shared/params/testnet_e2e_config.go
+++ b/shared/params/testnet_e2e_config.go
@@ -1,5 +1,9 @@
 package params
 
+// AltairE2EForkEpoch is the pre-determined altair fork epoch in our
+// E2E test.
+const AltairE2EForkEpoch = 6
+
 // UseE2EConfig for beacon chain services.
 func UseE2EConfig() {
 	beaconConfig = E2ETestConfig()
@@ -34,6 +38,9 @@ func E2ETestConfig() *BeaconChainConfig {
 	// PoW parameters.
 	e2eConfig.DepositChainID = 1337   // Chain ID of eth1 dev net.
 	e2eConfig.DepositNetworkID = 1337 // Network ID of eth1 dev net.
+
+	// Altair Fork Parameters.
+	e2eConfig.AltairForkEpoch = AltairE2EForkEpoch
 
 	// Prysm constants.
 	e2eConfig.ConfigName = ConfigNames[EndToEnd]


### PR DESCRIPTION
**What type of PR is this?**

Altair Work

**What does this PR do? Why is it needed?**

- [x] Updates our develop branch with altair specific parameters introduced.
- [x] Update branch with all the new methods introduced for p2putils.
- [x] Also fixes some bugs from config loading.

This updates the parameters to the latest ones introduced in the spec as of `v1.1.0-beta.2`. The biggest change is the change of
the target aggregators being increased to 16 from 4. This was introduced in `beta.1` .

For our changes in`p2putils`, the majority of the methods introduced are to help with fork versioning. These methods help determine the fork digest in a particular epoch, the fork digest in the next epoch, retrieving the fork data from a particular digest
and changes in our fork schedule structure to allow for a more accurate versioning scheme.

We also update our config with the merge and sharding specific parameters here to keep it in parity with how our current spec
configs are written. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
