### PR TITLE
Add pyrmont hard fork config

### DIFF
--- a/shared/params/testnet_pyrmont_config.go
+++ b/shared/params/testnet_pyrmont_config.go
@@ -1,5 +1,7 @@
 package params
 
+import "math"
+
 // UsePyrmontNetworkConfig uses the Pyrmont specific
 // network config.
 func UsePyrmontNetworkConfig() {
@@ -26,6 +28,12 @@ func PyrmontConfig() *BeaconChainConfig {
 	cfg.GenesisDelay = 432000
 	cfg.ConfigName = ConfigNames[Pyrmont]
 	cfg.GenesisForkVersion = []byte{0x00, 0x00, 0x20, 0x09}
+	cfg.AltairForkVersion = []byte{0x01, 0x00, 0x20, 0x09}
+	cfg.AltairForkEpoch = 61650
+	cfg.MergeForkVersion = []byte{0x02, 0x00, 0x20, 0x09}
+	cfg.MergeForkEpoch = math.MaxUint64
+	cfg.ShardingForkVersion = []byte{0x03, 0x00, 0x20, 0x09}
+	cfg.ShardingForkEpoch = math.MaxUint64
 	cfg.SecondsPerETH1Block = 14
 	cfg.DepositChainID = 5
 	cfg.DepositNetworkID = 5


### PR DESCRIPTION
Add pyrmont fork version and epoch to config. Please cross check the values here:
https://github.com/eth2-clients/eth2-networks/pull/56/files

I left out values such as `INACTIVITY_SCORE_RECOVERY_RATE` and `CHURN_LIMIT_QUOTIENT`... because they are still the same as mainnet. The diff only reflected changes from config to preset based format