### PR TITLE
p2p: report status failure when no genesis time is set after start

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -274,6 +274,9 @@ func (s *Service) Status() error {
 	if s.startupErr != nil {
 		return s.startupErr
 	}
+	if s.genesisTime.IsZero() {
+		return errors.New("no genesis time set")
+	}
 	return nil
 }
 

--- a/beacon-chain/p2p/service_test.go
+++ b/beacon-chain/p2p/service_test.go
@@ -136,6 +136,16 @@ func TestService_Status_NotRunning(t *testing.T) {
 	assert.ErrorContains(t, "not running", s.Status(), "Status returned wrong error")
 }
 
+func TestService_Status_NoGenesisTimeSet(t *testing.T) {
+	s := &Service{started: true}
+	s.dv5Listener = &mockListener{}
+	assert.ErrorContains(t, "no genesis time set", s.Status(), "Status returned wrong error")
+
+	s.genesisTime = time.Now()
+
+	assert.NoError(t, s.Status(), "Status returned error")
+}
+
 func TestListenForNewNodes(t *testing.T) {
 	// Setup bootnode.
 	notifier := &mock.MockStateNotifier{}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Seeing an issue in altair-devnet-3 where the genesis time in p2p appears to be unset. This status error makes such a problem more obvious.

**Which issues(s) does this PR fix?**

**Other notes for review**
