### PR TITLE
Altair Core Sync Committee Helper Functions

### DIFF
--- a/beacon-chain/core/helpers/committee.go
+++ b/beacon-chain/core/helpers/committee.go
@@ -17,10 +17,12 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
 	"github.com/prysmaticlabs/prysm/shared/sliceutil"
+	log "github.com/sirupsen/logrus"
 )
 
 var committeeCache = cache.NewCommitteesCache()
 var proposerIndicesCache = cache.NewProposerIndicesCache()
+var syncCommitteeCache = cache.NewSyncCommittee()
 
 // SlotCommitteeCount returns the number of crosslink committees of a slot. The
 // active validator count is provided as an argument rather than a imported implementation
@@ -271,26 +273,21 @@ func VerifyAttestationBitfieldLengths(state state.ReadOnlyBeaconState, att *ethp
 	return nil
 }
 
-// ShuffledIndices uses input beacon state and returns the shuffled indices of the input epoch,
-// the shuffled indices then can be used to break up into committees.
-func ShuffledIndices(s state.ReadOnlyBeaconState, epoch types.Epoch) ([]types.ValidatorIndex, error) {
-	seed, err := Seed(s, epoch, params.BeaconConfig().DomainBeaconAttester)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not get seed for epoch %d", epoch)
-	}
-
+// Returns the active indices and the total active balance of the validators in input `state` and during input `epoch`.
+func activeIndicesAndBalance(s state.ReadOnlyBeaconState, epoch types.Epoch) ([]types.ValidatorIndex, uint64, error) {
+	balances := uint64(0)
 	indices := make([]types.ValidatorIndex, 0, s.NumValidators())
 	if err := s.ReadFromEveryValidator(func(idx int, val state.ReadOnlyValidator) error {
 		if IsActiveValidatorUsingTrie(val, epoch) {
+			balances += val.EffectiveBalance()
 			indices = append(indices, types.ValidatorIndex(idx))
 		}
 		return nil
 	}); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	// UnshuffleList is used as an optimized implementation for raw speed.
-	return UnshuffleList(indices, seed)
+	return indices, balances, nil
 }
 
 // UpdateCommitteeCache gets called at the beginning of every epoch to cache the committee shuffled indices
@@ -306,7 +303,13 @@ func UpdateCommitteeCache(state state.ReadOnlyBeaconState, epoch types.Epoch) er
 			return nil
 		}
 
-		shuffledIndices, err := ShuffledIndices(state, e)
+		indices, balance, err := activeIndicesAndBalance(state, e)
+		if err != nil {
+			return err
+		}
+
+		// Get the shuffled indices based on the seed.
+		shuffledIndices, err := UnshuffleList(indices, seed)
 		if err != nil {
 			return err
 		}
@@ -322,11 +325,23 @@ func UpdateCommitteeCache(state state.ReadOnlyBeaconState, epoch types.Epoch) er
 			return sortedIndices[i] < sortedIndices[j]
 		})
 
+		// Only update active balance field in cache if it's current epoch.
+		// Using current epoch state to update next epoch field will cause insert an invalid
+		// active balance value.
+		b := &cache.Balance{}
+		if e == epoch {
+			b = &cache.Balance{
+				Exist: true,
+				Total: balance,
+			}
+		}
+
 		if err := committeeCache.AddCommitteeShuffledList(&cache.Committees{
 			ShuffledIndices: shuffledIndices,
 			CommitteeCount:  uint64(params.BeaconConfig().SlotsPerEpoch.Mul(count)),
 			Seed:            seed,
 			SortedIndices:   sortedIndices,
+			ActiveBalance:   b,
 		}); err != nil {
 			return err
 		}
@@ -383,10 +398,200 @@ func UpdateProposerIndicesInCache(state state.ReadOnlyBeaconState) error {
 	})
 }
 
-// ClearCache clears the committee cache
+// ClearCache clears the beacon committee cache and sync committee cache.
 func ClearCache() {
 	committeeCache = cache.NewCommitteesCache()
 	proposerIndicesCache = cache.NewProposerIndicesCache()
+	syncCommitteeCache = cache.NewSyncCommittee()
+}
+
+// IsCurrentPeriodSyncCommittee returns true if the input validator index belongs in the current period sync committee
+// along with the sync committee root.
+// 1.) Checks if the public key exists in the sync committee cache
+// 2.) If 1 fails, checks if the public key exists in the input current sync committee object
+func IsCurrentPeriodSyncCommittee(
+	st state.BeaconStateAltair, valIdx types.ValidatorIndex,
+) (bool, error) {
+	root, err := syncPeriodBoundaryRoot(st)
+	if err != nil {
+		return false, err
+	}
+	indices, err := syncCommitteeCache.CurrentPeriodIndexPosition(bytesutil.ToBytes32(root), valIdx)
+	if err == cache.ErrNonExistingSyncCommitteeKey {
+		val, err := st.ValidatorAtIndex(valIdx)
+		if err != nil {
+			return false, nil
+		}
+		committee, err := st.CurrentSyncCommittee()
+		if err != nil {
+			return false, err
+		}
+
+		// Fill in the cache on miss.
+		go func() {
+			if err := syncCommitteeCache.UpdatePositionsInCommittee(bytesutil.ToBytes32(root), st); err != nil {
+				log.Errorf("Could not fill sync committee cache on miss: %v", err)
+			}
+		}()
+
+		return len(findSubCommitteeIndices(val.PublicKey, committee.Pubkeys)) > 0, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return len(indices) > 0, nil
+}
+
+// IsNextPeriodSyncCommittee returns true if the input validator index belongs in the next period sync committee
+// along with the sync period boundary root.
+// 1.) Checks if the public key exists in the sync committee cache
+// 2.) If 1 fails, checks if the public key exists in the input next sync committee object
+func IsNextPeriodSyncCommittee(
+	st state.BeaconStateAltair, valIdx types.ValidatorIndex,
+) (bool, error) {
+	root, err := syncPeriodBoundaryRoot(st)
+	if err != nil {
+		return false, err
+	}
+	indices, err := syncCommitteeCache.NextPeriodIndexPosition(bytesutil.ToBytes32(root), valIdx)
+	if err == cache.ErrNonExistingSyncCommitteeKey {
+		val, err := st.ValidatorAtIndex(valIdx)
+		if err != nil {
+			return false, nil
+		}
+		committee, err := st.NextSyncCommittee()
+		if err != nil {
+			return false, err
+		}
+		return len(findSubCommitteeIndices(val.PublicKey, committee.Pubkeys)) > 0, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return len(indices) > 0, nil
+}
+
+// CurrentPeriodSyncSubcommitteeIndices returns the subcommittee indices of the
+// current period sync committee for input validator.
+func CurrentPeriodSyncSubcommitteeIndices(
+	st state.BeaconStateAltair, valIdx types.ValidatorIndex,
+) ([]types.CommitteeIndex, error) {
+	root, err := syncPeriodBoundaryRoot(st)
+	if err != nil {
+		return nil, err
+	}
+	indices, err := syncCommitteeCache.CurrentPeriodIndexPosition(bytesutil.ToBytes32(root), valIdx)
+	if err == cache.ErrNonExistingSyncCommitteeKey {
+		val, err := st.ValidatorAtIndex(valIdx)
+		if err != nil {
+			return nil, nil
+		}
+		committee, err := st.CurrentSyncCommittee()
+		if err != nil {
+			return nil, err
+		}
+
+		// Fill in the cache on miss.
+		go func() {
+			if err := syncCommitteeCache.UpdatePositionsInCommittee(bytesutil.ToBytes32(root), st); err != nil {
+				log.Errorf("Could not fill sync committee cache on miss: %v", err)
+			}
+		}()
+
+		return findSubCommitteeIndices(val.PublicKey, committee.Pubkeys), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return indices, nil
+}
+
+// NextPeriodSyncSubcommitteeIndices returns the subcommittee indices of the next period sync committee for input validator.
+func NextPeriodSyncSubcommitteeIndices(
+	st state.BeaconStateAltair, valIdx types.ValidatorIndex,
+) ([]types.CommitteeIndex, error) {
+	root, err := syncPeriodBoundaryRoot(st)
+	if err != nil {
+		return nil, err
+	}
+	indices, err := syncCommitteeCache.NextPeriodIndexPosition(bytesutil.ToBytes32(root), valIdx)
+	if err == cache.ErrNonExistingSyncCommitteeKey {
+		val, err := st.ValidatorAtIndex(valIdx)
+		if err != nil {
+			return nil, nil
+		}
+		committee, err := st.NextSyncCommittee()
+		if err != nil {
+			return nil, err
+		}
+		return findSubCommitteeIndices(val.PublicKey, committee.Pubkeys), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return indices, nil
+}
+
+// UpdateSyncCommitteeCache updates sync committee cache.
+// It uses `state`'s latest block header root as key. To avoid miss usage, it disallows
+// block header with state root zeroed out.
+func UpdateSyncCommitteeCache(st state.BeaconStateAltair) error {
+	nextSlot := st.Slot() + 1
+	if nextSlot%params.BeaconConfig().SlotsPerEpoch != 0 {
+		return errors.New("not at the end of the epoch to update cache")
+	}
+	if SlotToEpoch(nextSlot)%params.BeaconConfig().EpochsPerSyncCommitteePeriod != 0 {
+		return errors.New("not at sync committee period boundary to update cache")
+	}
+
+	header := st.LatestBlockHeader()
+	if bytes.Equal(header.StateRoot, params.BeaconConfig().ZeroHash[:]) {
+		return errors.New("zero hash state root can't be used to update cache")
+	}
+
+	prevBlockRoot, err := header.HashTreeRoot()
+	if err != nil {
+		return err
+	}
+
+	return syncCommitteeCache.UpdatePositionsInCommittee(prevBlockRoot, st)
+}
+
+// Loop through `pubKeys` for matching `pubKey` and get the indices where it matches.
+func findSubCommitteeIndices(pubKey []byte, pubKeys [][]byte) []types.CommitteeIndex {
+	var indices []types.CommitteeIndex
+	for i, k := range pubKeys {
+		if bytes.Equal(k, pubKey) {
+			indices = append(indices, types.CommitteeIndex(i))
+		}
+	}
+	return indices
+}
+
+// Retrieve the current sync period boundary root by calculating sync period start epoch
+// and calling `BlockRoot`.
+// It uses the boundary slot - 1 for block root. (Ex: SlotsPerEpoch * EpochsPerSyncCommitteePeriod - 1)
+func syncPeriodBoundaryRoot(st state.ReadOnlyBeaconState) ([]byte, error) {
+	// Can't call `BlockRoot` until the first slot.
+	if st.Slot() == params.BeaconConfig().GenesisSlot {
+		return params.BeaconConfig().ZeroHash[:], nil
+	}
+
+	startEpoch, err := SyncCommitteePeriodStartEpoch(CurrentEpoch(st))
+	if err != nil {
+		return nil, err
+	}
+	startEpochSlot, err := StartSlot(startEpoch)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prevent underflow
+	if startEpochSlot >= 1 {
+		startEpochSlot--
+	}
+
+	return BlockRootAtSlot(st, startEpochSlot)
 }
 
 // This computes proposer indices of the current epoch and returns a list of proposer indices,

--- a/beacon-chain/core/helpers/committee_test.go
+++ b/beacon-chain/core/helpers/committee_test.go
@@ -2,15 +2,16 @@ package helpers
 
 import (
 	"fmt"
-	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	v2 "github.com/prysmaticlabs/prysm/beacon-chain/state/v2"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
-	statepb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/hashutil"
 	"github.com/prysmaticlabs/prysm/shared/params"
@@ -35,7 +36,7 @@ func TestComputeCommittee_WithoutCache(t *testing.T) {
 		}
 	}
 
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		Slot:        200,
 		BlockRoots:  make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot),
@@ -91,7 +92,7 @@ func TestVerifyBitfieldLength_OK(t *testing.T) {
 func TestCommitteeAssignments_CannotRetrieveFutureEpoch(t *testing.T) {
 	ClearCache()
 	epoch := types.Epoch(1)
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Slot: 0, // Epoch 0.
 	})
 	require.NoError(t, err)
@@ -111,7 +112,7 @@ func TestCommitteeAssignments_NoProposerForSlot0(t *testing.T) {
 			ExitEpoch:       params.BeaconConfig().FarFutureEpoch,
 		}
 	}
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		Slot:        2 * params.BeaconConfig().SlotsPerEpoch, // epoch 2
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
@@ -142,7 +143,7 @@ func TestCommitteeAssignments_CanRetrieve(t *testing.T) {
 		}
 	}
 
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		Slot:        2 * params.BeaconConfig().SlotsPerEpoch, // epoch 2
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
@@ -219,7 +220,7 @@ func TestCommitteeAssignments_CannotRetrieveFuture(t *testing.T) {
 		}
 	}
 
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		Slot:        2 * params.BeaconConfig().SlotsPerEpoch, // epoch 2
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
@@ -243,7 +244,7 @@ func TestCommitteeAssignments_EverySlotHasMin1Proposer(t *testing.T) {
 			ExitEpoch:       params.BeaconConfig().FarFutureEpoch,
 		}
 	}
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		Slot:        2 * params.BeaconConfig().SlotsPerEpoch, // epoch 2
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
@@ -280,7 +281,7 @@ func TestVerifyAttestationBitfieldLengths_OK(t *testing.T) {
 		}
 	}
 
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		RandaoMixes: activeRoots,
 	})
@@ -368,38 +369,6 @@ func TestVerifyAttestationBitfieldLengths_OK(t *testing.T) {
 	}
 }
 
-func TestShuffledIndices_ShuffleRightLength(t *testing.T) {
-	valiatorCount := 1000
-	validators := make([]*ethpb.Validator, valiatorCount)
-	indices := make([]uint64, valiatorCount)
-	for i := 0; i < valiatorCount; i++ {
-		validators[i] = &ethpb.Validator{
-			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
-		}
-		indices[i] = uint64(i)
-	}
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
-		Validators:  validators,
-		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
-	})
-	require.NoError(t, err)
-	// Test for current epoch
-	shuffledIndices, err := ShuffledIndices(state, 0)
-	require.NoError(t, err)
-	assert.Equal(t, valiatorCount, len(shuffledIndices), "Incorrect shuffled indices count")
-	if reflect.DeepEqual(indices, shuffledIndices) {
-		t.Error("Shuffling did not happen")
-	}
-
-	// Test for next epoch
-	shuffledIndices, err = ShuffledIndices(state, 1)
-	require.NoError(t, err)
-	assert.Equal(t, valiatorCount, len(shuffledIndices), "Incorrect shuffled indices count")
-	if reflect.DeepEqual(indices, shuffledIndices) {
-		t.Error("Shuffling did not happen")
-	}
-}
-
 func TestUpdateCommitteeCache_CanUpdate(t *testing.T) {
 	ClearCache()
 	validatorCount := params.BeaconConfig().MinGenesisActiveValidatorCount
@@ -407,11 +376,12 @@ func TestUpdateCommitteeCache_CanUpdate(t *testing.T) {
 	indices := make([]types.ValidatorIndex, validatorCount)
 	for i := types.ValidatorIndex(0); uint64(i) < validatorCount; i++ {
 		validators[i] = &ethpb.Validator{
-			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+			ExitEpoch:        params.BeaconConfig().FarFutureEpoch,
+			EffectiveBalance: 1,
 		}
 		indices[i] = i
 	}
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	})
@@ -426,6 +396,13 @@ func TestUpdateCommitteeCache_CanUpdate(t *testing.T) {
 	indices, err = committeeCache.Committee(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(epoch)), seed, idx)
 	require.NoError(t, err)
 	assert.Equal(t, params.BeaconConfig().TargetCommitteeSize, uint64(len(indices)), "Did not save correct indices lengths")
+
+	// Total active balance should be `MinGenesisActiveValidatorCount` given each validator has effective balance of 1.
+	seed, err = Seed(state, 0, params.BeaconConfig().DomainBeaconAttester)
+	require.NoError(t, err)
+	balance, err := committeeCache.ActiveBalance(seed)
+	require.NoError(t, err)
+	require.Equal(t, validatorCount, balance)
 }
 
 func BenchmarkComputeCommittee300000_WithPreCache(b *testing.B) {
@@ -435,7 +412,7 @@ func BenchmarkComputeCommittee300000_WithPreCache(b *testing.B) {
 			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
 		}
 	}
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	})
@@ -469,7 +446,7 @@ func BenchmarkComputeCommittee3000000_WithPreCache(b *testing.B) {
 			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
 		}
 	}
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	})
@@ -503,7 +480,7 @@ func BenchmarkComputeCommittee128000_WithOutPreCache(b *testing.B) {
 			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
 		}
 	}
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	})
@@ -538,7 +515,7 @@ func BenchmarkComputeCommittee1000000_WithOutCache(b *testing.B) {
 			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
 		}
 	}
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	})
@@ -573,7 +550,7 @@ func BenchmarkComputeCommittee4000000_WithOutCache(b *testing.B) {
 			ExitEpoch: params.BeaconConfig().FarFutureEpoch,
 		}
 	}
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	})
@@ -610,7 +587,7 @@ func TestBeaconCommitteeFromState_UpdateCacheForPreviousEpoch(t *testing.T) {
 		}
 	}
 
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Slot:        params.BeaconConfig().SlotsPerEpoch,
 		Validators:  validators,
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
@@ -635,7 +612,7 @@ func TestPrecomputeProposerIndices_Ok(t *testing.T) {
 		}
 	}
 
-	state, err := v1.InitializeFromProto(&statepb.BeaconState{
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Validators:  validators,
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 	})
@@ -658,4 +635,374 @@ func TestPrecomputeProposerIndices_Ok(t *testing.T) {
 		wantedProposerIndices = append(wantedProposerIndices, index)
 	}
 	assert.DeepEqual(t, wantedProposerIndices, proposerIndices, "Did not precompute proposer indices correctly")
+}
+
+func TestIsCurrentEpochSyncCommittee_UsingCache(t *testing.T) {
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	ClearCache()
+	r := [32]byte{'a'}
+	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
+
+	ok, err := IsCurrentPeriodSyncCommittee(state, 0)
+	require.NoError(t, err)
+	require.Equal(t, true, ok)
+}
+
+func TestIsCurrentEpochSyncCommittee_UsingCommittee(t *testing.T) {
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	ok, err := IsCurrentPeriodSyncCommittee(state, 0)
+	require.NoError(t, err)
+	require.Equal(t, true, ok)
+}
+
+func TestIsCurrentEpochSyncCommittee_DoesNotExist(t *testing.T) {
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	ok, err := IsCurrentPeriodSyncCommittee(state, 12390192)
+	require.NoError(t, err)
+	require.Equal(t, false, ok)
+}
+
+func TestIsNextEpochSyncCommittee_UsingCache(t *testing.T) {
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	ClearCache()
+	r := [32]byte{'a'}
+	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
+
+	ok, err := IsNextPeriodSyncCommittee(state, 0)
+	require.NoError(t, err)
+	require.Equal(t, true, ok)
+}
+
+func TestIsNextEpochSyncCommittee_UsingCommittee(t *testing.T) {
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	ok, err := IsNextPeriodSyncCommittee(state, 0)
+	require.NoError(t, err)
+	require.Equal(t, true, ok)
+}
+
+func TestIsNextEpochSyncCommittee_DoesNotExist(t *testing.T) {
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	ok, err := IsNextPeriodSyncCommittee(state, 120391029)
+	require.NoError(t, err)
+	require.Equal(t, false, ok)
+}
+
+func TestCurrentEpochSyncSubcommitteeIndices_UsingCache(t *testing.T) {
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	ClearCache()
+	r := [32]byte{'a'}
+	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
+
+	index, err := CurrentPeriodSyncSubcommitteeIndices(state, 0)
+	require.NoError(t, err)
+	require.DeepEqual(t, []types.CommitteeIndex{0}, index)
+}
+
+func TestCurrentEpochSyncSubcommitteeIndices_UsingCommittee(t *testing.T) {
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	root, err := syncPeriodBoundaryRoot(state)
+	require.NoError(t, err)
+
+	// Test that cache was empty.
+	_, err = syncCommitteeCache.CurrentPeriodIndexPosition(bytesutil.ToBytes32(root), 0)
+	require.Equal(t, cache.ErrNonExistingSyncCommitteeKey, err)
+
+	// Test that helper can retrieve the index given empty cache.
+	index, err := CurrentPeriodSyncSubcommitteeIndices(state, 0)
+	require.NoError(t, err)
+	require.DeepEqual(t, []types.CommitteeIndex{0}, index)
+
+	// Test that cache was able to fill on miss.
+	time.Sleep(100 * time.Millisecond)
+	index, err = syncCommitteeCache.CurrentPeriodIndexPosition(bytesutil.ToBytes32(root), 0)
+	require.NoError(t, err)
+	require.DeepEqual(t, []types.CommitteeIndex{0}, index)
+}
+
+func TestCurrentEpochSyncSubcommitteeIndices_DoesNotExist(t *testing.T) {
+	ClearCache()
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	index, err := CurrentPeriodSyncSubcommitteeIndices(state, 129301923)
+	require.NoError(t, err)
+	require.DeepEqual(t, []types.CommitteeIndex(nil), index)
+}
+
+func TestNextEpochSyncSubcommitteeIndices_UsingCache(t *testing.T) {
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	ClearCache()
+	r := [32]byte{'a'}
+	require.NoError(t, err, syncCommitteeCache.UpdatePositionsInCommittee(r, state))
+
+	index, err := NextPeriodSyncSubcommitteeIndices(state, 0)
+	require.NoError(t, err)
+	require.DeepEqual(t, []types.CommitteeIndex{0}, index)
+}
+
+func TestNextEpochSyncSubcommitteeIndices_UsingCommittee(t *testing.T) {
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	index, err := NextPeriodSyncSubcommitteeIndices(state, 0)
+	require.NoError(t, err)
+	require.DeepEqual(t, []types.CommitteeIndex{0}, index)
+}
+
+func TestNextEpochSyncSubcommitteeIndices_DoesNotExist(t *testing.T) {
+	ClearCache()
+	validators := make([]*ethpb.Validator, params.BeaconConfig().SyncCommitteeSize)
+	syncCommittee := &ethpb.SyncCommittee{
+		AggregatePubkey: bytesutil.PadTo([]byte{}, params.BeaconConfig().BLSPubkeyLength),
+	}
+	for i := 0; i < len(validators); i++ {
+		k := make([]byte, 48)
+		copy(k, strconv.Itoa(i))
+		validators[i] = &ethpb.Validator{
+			PublicKey: k,
+		}
+		syncCommittee.Pubkeys = append(syncCommittee.Pubkeys, bytesutil.PadTo(k, 48))
+	}
+
+	state, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
+		Validators: validators,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetCurrentSyncCommittee(syncCommittee))
+	require.NoError(t, state.SetNextSyncCommittee(syncCommittee))
+
+	index, err := NextPeriodSyncSubcommitteeIndices(state, 21093019)
+	require.NoError(t, err)
+	require.DeepEqual(t, []types.CommitteeIndex(nil), index)
+}
+
+func TestUpdateSyncCommitteeCache_BadSlot(t *testing.T) {
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
+		Slot: 1,
+	})
+	require.NoError(t, err)
+	err = UpdateSyncCommitteeCache(state)
+	require.ErrorContains(t, "not at the end of the epoch to update cache", err)
+
+	state, err = v1.InitializeFromProto(&ethpb.BeaconState{
+		Slot: params.BeaconConfig().SlotsPerEpoch - 1,
+	})
+	require.NoError(t, err)
+	err = UpdateSyncCommitteeCache(state)
+	require.ErrorContains(t, "not at sync committee period boundary to update cache", err)
+}
+
+func TestUpdateSyncCommitteeCache_BadRoot(t *testing.T) {
+	state, err := v1.InitializeFromProto(&ethpb.BeaconState{
+		Slot:              types.Slot(params.BeaconConfig().EpochsPerSyncCommitteePeriod)*params.BeaconConfig().SlotsPerEpoch - 1,
+		LatestBlockHeader: &ethpb.BeaconBlockHeader{StateRoot: params.BeaconConfig().ZeroHash[:]},
+	})
+	require.NoError(t, err)
+	err = UpdateSyncCommitteeCache(state)
+	require.ErrorContains(t, "zero hash state root can't be used to update cache", err)
 }


### PR DESCRIPTION
**What type of PR is this?**

> Core feature work

- [x] Adds a `IsCurrentPeriodSyncCommittee` function which returns true if the input validator index belongs in the current period sync committee along with the sync committee root
- [x] Adds a `NextPeriodSyncSubcommitteeIndices` returning the subcommittee indices of the next period sync committee for input validator
- [x] Adds a `UpdateSyncCommitteeCache` function

**Which issues(s) does this PR fix?**

Part of #8638 