### PR TITLE
Update Altair proposer reward quotient

### DIFF
--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -61,10 +61,12 @@ func ProcessAttesterSlashings(
 			if helpers.IsSlashableValidator(val.ActivationEpoch(), val.WithdrawableEpoch(), val.Slashed(), currentEpoch) {
 				cfg := params.BeaconConfig()
 				slashingQuotient := cfg.MinSlashingPenaltyQuotient
+				proposerRewardQuotient := cfg.ProposerRewardQuotient
 				if beaconState.Version() == version.Altair {
 					slashingQuotient = cfg.MinSlashingPenaltyQuotientAltair
+					proposerRewardQuotient = cfg.WeightDenominator / cfg.ProposerRewardQuotient
 				}
-				beaconState, err = slashFunc(beaconState, types.ValidatorIndex(validatorIndex), slashingQuotient, cfg.ProposerRewardQuotient)
+				beaconState, err = slashFunc(beaconState, types.ValidatorIndex(validatorIndex), slashingQuotient, proposerRewardQuotient)
 				if err != nil {
 					return nil, errors.Wrapf(err, "could not slash validator index %d",
 						validatorIndex)

--- a/beacon-chain/core/blocks/attester_slashing.go
+++ b/beacon-chain/core/blocks/attester_slashing.go
@@ -64,7 +64,7 @@ func ProcessAttesterSlashings(
 				proposerRewardQuotient := cfg.ProposerRewardQuotient
 				if beaconState.Version() == version.Altair {
 					slashingQuotient = cfg.MinSlashingPenaltyQuotientAltair
-					proposerRewardQuotient = cfg.WeightDenominator / cfg.ProposerRewardQuotient
+					proposerRewardQuotient = cfg.WeightDenominator / cfg.ProposerWeight
 				}
 				beaconState, err = slashFunc(beaconState, types.ValidatorIndex(validatorIndex), slashingQuotient, proposerRewardQuotient)
 				if err != nil {

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -57,10 +57,12 @@ func ProcessProposerSlashings(
 		}
 		cfg := params.BeaconConfig()
 		slashingQuotient := cfg.MinSlashingPenaltyQuotient
+		proposerRewardQuotient := cfg.ProposerRewardQuotient
 		if beaconState.Version() == version.Altair {
 			slashingQuotient = cfg.MinSlashingPenaltyQuotientAltair
+			proposerRewardQuotient = cfg.WeightDenominator / cfg.ProposerRewardQuotient
 		}
-		beaconState, err = slashFunc(beaconState, slashing.Header_1.Header.ProposerIndex, slashingQuotient, cfg.ProposerRewardQuotient)
+		beaconState, err = slashFunc(beaconState, slashing.Header_1.Header.ProposerIndex, slashingQuotient, proposerRewardQuotient)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not slash proposer index %d", slashing.Header_1.Header.ProposerIndex)
 		}

--- a/beacon-chain/core/blocks/proposer_slashing.go
+++ b/beacon-chain/core/blocks/proposer_slashing.go
@@ -60,7 +60,7 @@ func ProcessProposerSlashings(
 		proposerRewardQuotient := cfg.ProposerRewardQuotient
 		if beaconState.Version() == version.Altair {
 			slashingQuotient = cfg.MinSlashingPenaltyQuotientAltair
-			proposerRewardQuotient = cfg.WeightDenominator / cfg.ProposerRewardQuotient
+			proposerRewardQuotient = cfg.WeightDenominator / cfg.ProposerWeight
 		}
 		beaconState, err = slashFunc(beaconState, slashing.Header_1.Header.ProposerIndex, slashingQuotient, proposerRewardQuotient)
 		if err != nil {


### PR DESCRIPTION
`PROPOSER_REWARD_QUOTIENT` was still on phase0 value for altair.

In phase0, we have: 
` proposer_reward = Gwei(whistleblower_reward // PROPOSER_REWARD_QUOTIENT)`
source:  https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#slash_validator

in altair, we should have:
`proposer_reward = Gwei(whistleblower_reward * PROPOSER_WEIGHT // WEIGHT_DENOMINATOR)`
source: https://github.com/ethereum/eth2.0-specs/blob/dev/specs/altair/beacon-chain.md#modified-slash_validator

Please cross check on my math whether the ordering matters