### PR TITLE
Update synccommittee spectest

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -834,10 +834,10 @@ def prysm_deps():
         name = "com_github_ferranbt_fastssz",
         importpath = "github.com/ferranbt/fastssz",
         nofuzz = True,
-        sum = "h1:R8HHtp9wrae6trZA2lgJtOhghKl16lWY4cG0l7hH8CM=",
-        version = "v0.0.0-20210719200358-90640294cb9c",
+        replace = "github.com/kasey/fastssz",
+        sum = "h1:YRvuOn9bfoTjEkjSV/dSpoGivTYgZgspUM3jHNbWZvA=",
+        version = "v0.0.0-20210817214512-ff5a488a0e94",
     )
-
     go_repository(
         name = "com_github_fjl_memsize",
         importpath = "github.com/fjl/memsize",

--- a/go.mod
+++ b/go.mod
@@ -138,3 +138,5 @@ replace github.com/json-iterator/go => github.com/prestonvanloon/go v1.1.7-0.201
 
 // See https://github.com/prysmaticlabs/grpc-gateway/issues/2
 replace github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/prysmaticlabs/grpc-gateway/v2 v2.3.1-0.20210702154020-550e1cd83ec1
+
+replace github.com/ferranbt/fastssz => github.com/kasey/fastssz v0.0.0-20210817214512-ff5a488a0e94

--- a/go.sum
+++ b/go.sum
@@ -268,9 +268,6 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
-github.com/ferranbt/fastssz v0.0.0-20210120143747-11b9eff30ea9/go.mod h1:DyEu2iuLBnb/T51BlsiO3yLYdJC6UbGMrIkqK1KmQxM=
-github.com/ferranbt/fastssz v0.0.0-20210719200358-90640294cb9c h1:R8HHtp9wrae6trZA2lgJtOhghKl16lWY4cG0l7hH8CM=
-github.com/ferranbt/fastssz v0.0.0-20210719200358-90640294cb9c/go.mod h1:DyEu2iuLBnb/T51BlsiO3yLYdJC6UbGMrIkqK1KmQxM=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5 h1:FtmdgXiUlNeRsoNMFlKLDt+S+6hbjVMEW6RGQ7aUf7c=
 github.com/fjl/memsize v0.0.0-20190710130421-bcb5799ab5e5/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
@@ -616,6 +613,8 @@ github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2vi
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
+github.com/kasey/fastssz v0.0.0-20210817214512-ff5a488a0e94 h1:YRvuOn9bfoTjEkjSV/dSpoGivTYgZgspUM3jHNbWZvA=
+github.com/kasey/fastssz v0.0.0-20210817214512-ff5a488a0e94/go.mod h1:DyEu2iuLBnb/T51BlsiO3yLYdJC6UbGMrIkqK1KmQxM=
 github.com/kevinms/leakybucket-go v0.0.0-20200115003610-082473db97ca h1:qNtd6alRqd3qOdPrKXMZImV192ngQ0WSh1briEO33Tk=
 github.com/kevinms/leakybucket-go v0.0.0-20200115003610-082473db97ca/go.mod h1:ph+C5vpnCcQvKBwJwKLTK3JLNGnBXYlG7m7JjoC/zYA=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/spectest/shared/altair/ssz_static/ssz_static.go
+++ b/spectest/shared/altair/ssz_static/ssz_static.go
@@ -161,8 +161,7 @@ func UnmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (i
 	case "SyncAggregatorSelectionData":
 		obj = &ethpb.SyncAggregatorSelectionData{}
 	case "SyncCommittee":
-		t.Skip("TODO(8638): fssz bug, using custom HTR so state works")
-		return nil, nil
+		obj = &ethpb.SyncCommittee{}
 	case "LightClientSnapshot":
 		t.Skip("not a beacon node type, this is a light node type")
 		return nil, nil


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
SyncCommittee.Pubkeys contains byte arrays that are 48 bytes long (sha256). There is a bug in fastssz (ferranbt/fastssz#43) where the generated code fails to right-pad the value to a chunk-aligned boundary before adding to a byte array for HTR computation. This PR updates prysm generated code using the fix for computing hash tree root, as well as temporarily pointing at a branch in my fork of fastssz so that bazel codegen runs also use the correct codegen version. The spec test for SyncCommittee has been updated to use the fixed generated type and I have confirmed that the spec tests all pass now via running `bazel test //spectest/mainnet/altair/ssz_static:go_default_test --test_output=streamed --test_arg=-test.v --test_arg=-test.failfast --cache_test_results=no --test_filter= --test_tag_filters=spectest`