### PR TITLE
Change Back Read-Only Validator Declaration

### DIFF
--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -400,17 +400,18 @@ func TestFuzzProcessVoluntaryExitsNoVerify_10000(t *testing.T) {
 func TestFuzzVerifyExit_10000(t *testing.T) {
 	fuzzer := fuzz.NewWithSeed(0)
 	ve := &eth.SignedVoluntaryExit{}
-	val, err := v1.NewValidator(&ethpb.Validator{})
-	_ = err
+	rawVal := &ethpb.Validator{}
 	fork := &ethpb.Fork{}
 	var slot types.Slot
 
 	for i := 0; i < 10000; i++ {
 		fuzzer.Fuzz(ve)
-		fuzzer.Fuzz(val)
+		fuzzer.Fuzz(rawVal)
 		fuzzer.Fuzz(fork)
 		fuzzer.Fuzz(&slot)
-		err := VerifyExitAndSignature(val, slot, fork, ve, params.BeaconConfig().ZeroHash[:])
+		val, err := v1.NewValidator(&ethpb.Validator{})
+		_ = err
+		err = VerifyExitAndSignature(val, slot, fork, ve, params.BeaconConfig().ZeroHash[:])
 		_ = err
 	}
 }

--- a/beacon-chain/state/v1/readonly_validator.go
+++ b/beacon-chain/state/v1/readonly_validator.go
@@ -18,11 +18,11 @@ type readOnlyValidator struct {
 	validator *ethpb.Validator
 }
 
-var _ = state.ReadOnlyValidator(&readOnlyValidator{})
+var _ = state.ReadOnlyValidator(readOnlyValidator{})
 
 // NewValidator initializes the read only wrapper for validator.
 func NewValidator(v *ethpb.Validator) (state.ReadOnlyValidator, error) {
-	rov := &readOnlyValidator{
+	rov := readOnlyValidator{
 		validator: v,
 	}
 	if rov.IsNil() {


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Previously in #7710, we had determined that declaring read only validators as pointers rather than the struct was a poor idea, as all these object end up on the heap and lead to more work being done by the gc. In our altair branch, we unfortunately 
reverted this change and it was merged into develop in #9221. This reverts the change back to our old format.

- [x] Remove read-only validator pointer declaration. 
 
**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
