### PR TITLE
Fix 'headSlot' log statement in init-sync

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -87,8 +87,8 @@ func (s *Service) syncToFinalizedEpoch(ctx context.Context, genesis time.Time) e
 	}
 
 	log.WithFields(logrus.Fields{
-		"syncedSlot": s.cfg.Chain.HeadSlot(),
-		"currentSlot":   helpers.SlotsSince(genesis),
+		"syncedSlot":  s.cfg.Chain.HeadSlot(),
+		"currentSlot": helpers.SlotsSince(genesis),
 	}).Info("Synced to finalized epoch - now syncing blocks up to current head")
 	if err := queue.stop(); err != nil {
 		log.WithError(err).Debug("Error stopping queue")
@@ -114,8 +114,8 @@ func (s *Service) syncToNonFinalizedEpoch(ctx context.Context, genesis time.Time
 		s.processFetchedDataRegSync(ctx, genesis, s.cfg.Chain.HeadSlot(), data)
 	}
 	log.WithFields(logrus.Fields{
-		"syncedSlot": s.cfg.Chain.HeadSlot(),
-		"currentSlot":   helpers.SlotsSince(genesis),
+		"syncedSlot":  s.cfg.Chain.HeadSlot(),
+		"currentSlot": helpers.SlotsSince(genesis),
 	}).Info("Synced to head of chain")
 	if err := queue.stop(); err != nil {
 		log.WithError(err).Debug("Error stopping queue")

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -88,7 +88,7 @@ func (s *Service) syncToFinalizedEpoch(ctx context.Context, genesis time.Time) e
 
 	log.WithFields(logrus.Fields{
 		"syncedSlot": s.cfg.Chain.HeadSlot(),
-		"headSlot":   helpers.SlotsSince(genesis),
+		"currentSlot":   helpers.SlotsSince(genesis),
 	}).Info("Synced to finalized epoch - now syncing blocks up to current head")
 	if err := queue.stop(); err != nil {
 		log.WithError(err).Debug("Error stopping queue")
@@ -115,7 +115,7 @@ func (s *Service) syncToNonFinalizedEpoch(ctx context.Context, genesis time.Time
 	}
 	log.WithFields(logrus.Fields{
 		"syncedSlot": s.cfg.Chain.HeadSlot(),
-		"headSlot":   helpers.SlotsSince(genesis),
+		"currentSlot":   helpers.SlotsSince(genesis),
 	}).Info("Synced to head of chain")
 	if err := queue.stop(); err != nil {
 		log.WithError(err).Debug("Error stopping queue")


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Minor cosmetic fix. This prevents confusion about thinking the beacon node's head slot is the current slot.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
