### PR TITLE
Allow Sending Interfaces Over Application Event Feeds

### DIFF
--- a/shared/event/feed.go
+++ b/shared/event/feed.go
@@ -98,6 +98,11 @@ func (f *Feed) typecheck(typ reflect.Type) bool {
 		f.etype = typ
 		return true
 	}
+	// In the event the feed's type is an actual interface, we
+	// perform an interface conformance check here.
+	if f.etype.Kind() == reflect.Interface && typ.Implements(f.etype) {
+		return true
+	}
 	return f.etype == typ
 }
 


### PR DESCRIPTION
This PR allows us to send interfaces, such as BeaconBlock and BeaconState over our internal event feed library, originally authored by the go-ethereum team. Currently, the event feed library only supports sending concrete types. Instead, we check if we are sending an interface and if the interface implements the concrete type over the feed we want to send to. Original author is @nisdas 