### PR TITLE
Fix struct type used when sending beacon committee subscriptions

### DIFF
--- a/beacon-chain/rpc/apimiddleware/endpoint_factory.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory.go
@@ -164,7 +164,7 @@ func (f *BeaconEndpointFactory) Create(path string) (*gateway.Endpoint, error) {
 		endpoint.GetResponse = &aggregateAttestationResponseJson{}
 		endpoint.RequestQueryParams = []gateway.QueryParam{{Name: "attestation_data_root", Hex: true}, {Name: "slot"}}
 	case "/eth/v1/validator/beacon_committee_subscriptions":
-		endpoint.PostRequest = &submitAggregateAndProofsRequestJson{}
+		endpoint.PostRequest = &submitBeaconCommitteeSubscriptionsRequestJson{}
 		endpoint.Hooks = gateway.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: []gateway.Hook{wrapBeaconCommitteeSubscriptionsArray},
 		}


### PR DESCRIPTION
#9324 by mistake modified the struct type used for `/eth/v1/validator/beacon_committee_subscriptions` endpoint. This PR reverts the code back to the correct struct.

Fixes #9423