### PR TITLE
Update to spec test beta3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -258,7 +258,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    sha256 = "6a039696cefe9c1a35f677d118880afa71bbd487f75110a943618872ccdde170",
+    sha256 = "cea2a6c91d565660f54735f6be2bdea2ef91fe8ac71bff8f37866ae3a0f3af8a",
     strip_prefix = "consensus-specs-" + consensus_spec_version[1:],
     url = "https://github.com/ethereum/consensus-specs/archive/refs/tags/%s.tar.gz" % consensus_spec_version,
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -197,7 +197,7 @@ filegroup(
     url = "https://github.com/eth2-clients/slashing-protection-interchange-tests/archive/b8413ca42dc92308019d0d4db52c87e9e125c4e9.tar.gz",
 )
 
-consensus_spec_version = "v1.1.0-beta.1"
+consensus_spec_version = "v1.1.0-beta.3"
 
 http_archive(
     name = "consensus_spec_tests_general",
@@ -211,7 +211,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    sha256 = "e9b4cc60a3e676c6b4a9348424e44cff1ebada603ffb31b0df600dbd70e7fbf6",
+    sha256 = "9a60392cbf06e2a6e17e46d8bdca3d56b9db7e261fad6085db6851f9b5b35008",
     url = "https://github.com/ethereum/consensus-spec-tests/releases/download/%s/general.tar.gz" % consensus_spec_version,
 )
 
@@ -227,7 +227,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    sha256 = "cf82dc729ffe7b924f852e57d1973e1a6377c5b52acc903c953277fa9b4e6de8",
+    sha256 = "4df4d4c56c95853d423ac48e886c3d5fa258c39c47267c0c6afdc8566fa8c323",
     url = "https://github.com/ethereum/consensus-spec-tests/releases/download/%s/minimal.tar.gz" % consensus_spec_version,
 )
 
@@ -243,7 +243,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    sha256 = "6c6792375b81858037014e282d28a64b0cf12e12daf16054265c85403b8b329f",
+    sha256 = "bc8a081beeeef5bf49aa903c431a86409acd6876f02bf23f44d92f7e70c1d9e9",
     url = "https://github.com/ethereum/consensus-spec-tests/releases/download/%s/mainnet.tar.gz" % consensus_spec_version,
 )
 

--- a/beacon-chain/core/altair/epoch_precompute.go
+++ b/beacon-chain/core/altair/epoch_precompute.go
@@ -155,7 +155,7 @@ func ProcessEpochParticipation(
 	sourceIdx := cfg.TimelySourceFlagIndex
 	headIdx := cfg.TimelyHeadFlagIndex
 	for i, b := range cp {
-		if HasValidatorFlag(b, targetIdx) && vals[i].IsActivePrevEpoch {
+		if HasValidatorFlag(b, targetIdx) && vals[i].IsActiveCurrentEpoch {
 			vals[i].IsCurrentEpochTargetAttester = true
 		}
 	}
@@ -164,13 +164,13 @@ func ProcessEpochParticipation(
 		return nil, nil, err
 	}
 	for i, b := range pp {
-		if HasValidatorFlag(b, sourceIdx) && vals[i].IsActiveCurrentEpoch {
+		if HasValidatorFlag(b, sourceIdx) && vals[i].IsActivePrevEpoch {
 			vals[i].IsPrevEpochAttester = true
 		}
-		if HasValidatorFlag(b, targetIdx) && vals[i].IsActiveCurrentEpoch {
+		if HasValidatorFlag(b, targetIdx) && vals[i].IsActivePrevEpoch {
 			vals[i].IsPrevEpochTargetAttester = true
 		}
-		if HasValidatorFlag(b, headIdx) && vals[i].IsActiveCurrentEpoch {
+		if HasValidatorFlag(b, headIdx) && vals[i].IsActivePrevEpoch {
 			vals[i].IsPrevEpochHeadAttester = true
 		}
 	}

--- a/beacon-chain/core/altair/epoch_precompute.go
+++ b/beacon-chain/core/altair/epoch_precompute.go
@@ -129,6 +129,14 @@ func ProcessInactivityScores(
 
 // ProcessEpochParticipation processes the epoch participation in state and updates individual validator's pre computes,
 // it also tracks and updates epoch attesting balances.
+// Spec code:
+// if epoch == get_current_epoch(state):
+//        epoch_participation = state.current_epoch_participation
+//    else:
+//        epoch_participation = state.previous_epoch_participation
+//    active_validator_indices = get_active_validator_indices(state, epoch)
+//    participating_indices = [i for i in active_validator_indices if has_flag(epoch_participation[i], flag_index)]
+//    return set(filter(lambda index: not state.validators[index].slashed, participating_indices))
 func ProcessEpochParticipation(
 	ctx context.Context,
 	state state.BeaconState,
@@ -147,7 +155,7 @@ func ProcessEpochParticipation(
 	sourceIdx := cfg.TimelySourceFlagIndex
 	headIdx := cfg.TimelyHeadFlagIndex
 	for i, b := range cp {
-		if HasValidatorFlag(b, targetIdx) {
+		if HasValidatorFlag(b, targetIdx) && vals[i].IsActivePrevEpoch {
 			vals[i].IsCurrentEpochTargetAttester = true
 		}
 	}
@@ -156,13 +164,13 @@ func ProcessEpochParticipation(
 		return nil, nil, err
 	}
 	for i, b := range pp {
-		if HasValidatorFlag(b, sourceIdx) {
+		if HasValidatorFlag(b, sourceIdx) && vals[i].IsActiveCurrentEpoch {
 			vals[i].IsPrevEpochAttester = true
 		}
-		if HasValidatorFlag(b, targetIdx) {
+		if HasValidatorFlag(b, targetIdx) && vals[i].IsActiveCurrentEpoch {
 			vals[i].IsPrevEpochTargetAttester = true
 		}
-		if HasValidatorFlag(b, headIdx) {
+		if HasValidatorFlag(b, headIdx) && vals[i].IsActiveCurrentEpoch {
 			vals[i].IsPrevEpochHeadAttester = true
 		}
 	}

--- a/beacon-chain/core/altair/epoch_precompute_test.go
+++ b/beacon-chain/core/altair/epoch_precompute_test.go
@@ -128,9 +128,9 @@ func TestProcessEpochParticipation_InactiveValidator(t *testing.T) {
 	st, err := stateAltair.InitializeFromProto(&ethpb.BeaconStateAltair{
 		Slot: 2 * params.BeaconConfig().SlotsPerEpoch,
 		Validators: []*ethpb.Validator{
-			{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},
-			{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance, ExitEpoch: 1},
-			{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance, ExitEpoch: params.BeaconConfig().FarFutureEpoch},
+			{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance},                                                  // Inactive
+			{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance, ExitEpoch: 2},                                    // Inactive current epoch, active previous epoch
+			{EffectiveBalance: params.BeaconConfig().MaxEffectiveBalance, ExitEpoch: params.BeaconConfig().FarFutureEpoch}, // Active
 		},
 		CurrentEpochParticipation: []byte{
 			generateParticipation(params.BeaconConfig().TimelySourceFlagIndex),
@@ -157,7 +157,9 @@ func TestProcessEpochParticipation_InactiveValidator(t *testing.T) {
 	}, validators[0])
 	require.DeepEqual(t, &precompute.Validator{
 		IsActiveCurrentEpoch:         false,
-		IsActivePrevEpoch:            false,
+		IsActivePrevEpoch:            true,
+		IsPrevEpochAttester:          true,
+		IsPrevEpochTargetAttester:    true,
 		IsWithdrawableCurrentEpoch:   true,
 		CurrentEpochEffectiveBalance: params.BeaconConfig().MaxEffectiveBalance,
 	}, validators[1])
@@ -171,9 +173,9 @@ func TestProcessEpochParticipation_InactiveValidator(t *testing.T) {
 		IsPrevEpochTargetAttester:    true,
 		IsPrevEpochHeadAttester:      true,
 	}, validators[2])
-	require.Equal(t, params.BeaconConfig().MaxEffectiveBalance, balance.PrevEpochAttested)
+	require.Equal(t, balance.PrevEpochAttested, 2*params.BeaconConfig().MaxEffectiveBalance)
 	require.Equal(t, balance.CurrentEpochTargetAttested, params.BeaconConfig().MaxEffectiveBalance)
-	require.Equal(t, balance.PrevEpochTargetAttested, params.BeaconConfig().MaxEffectiveBalance)
+	require.Equal(t, balance.PrevEpochTargetAttested, 2*params.BeaconConfig().MaxEffectiveBalance)
 	require.Equal(t, balance.PrevEpochHeadAttested, params.BeaconConfig().MaxEffectiveBalance)
 }
 

--- a/beacon-chain/core/altair/epoch_precompute_test.go
+++ b/beacon-chain/core/altair/epoch_precompute_test.go
@@ -144,6 +144,7 @@ func TestProcessEpochParticipation_InactiveValidator(t *testing.T) {
 		},
 		InactivityScores: []uint64{0, 0, 0},
 	})
+	require.NoError(t, err)
 	validators, balance, err := InitializeEpochValidators(context.Background(), st)
 	require.NoError(t, err)
 	validators, balance, err = ProcessEpochParticipation(context.Background(), st, balance, validators)

--- a/spectest/mainnet/altair/random/BUILD.bazel
+++ b/spectest/mainnet/altair/random/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@prysm//tools/go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["random_test.go"],
+    data = glob(["*.yaml"]) + [
+        "@consensus_spec_tests_mainnet//:test_data",
+    ],
+    tags = ["spectest"],
+    deps = ["//spectest/shared/altair/sanity:go_default_library"],
+)

--- a/spectest/mainnet/altair/random/random_test.go
+++ b/spectest/mainnet/altair/random/random_test.go
@@ -1,0 +1,11 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/sanity"
+)
+
+func TestMainnet_Altair_Random(t *testing.T) {
+	sanity.RunBlockProcessingTest(t, "mainnet", "random/random/pyspec_tests")
+}

--- a/spectest/mainnet/altair/sanity/blocks_test.go
+++ b/spectest/mainnet/altair/sanity/blocks_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMainnet_Altair_Sanity_Blocks(t *testing.T) {
-	sanity.RunBlockProcessingTest(t, "mainnet")
+	sanity.RunBlockProcessingTest(t, "mainnet", "sanity/blocks/pyspec_tests")
 }

--- a/spectest/mainnet/phase0/random/BUILD.bazel
+++ b/spectest/mainnet/phase0/random/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@prysm//tools/go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["random_test.go"],
+    data = glob(["*.yaml"]) + [
+        "@consensus_spec_tests_mainnet//:test_data",
+    ],
+    tags = ["spectest"],
+    deps = ["//spectest/shared/phase0/sanity:go_default_library"],
+)

--- a/spectest/mainnet/phase0/random/random_test.go
+++ b/spectest/mainnet/phase0/random/random_test.go
@@ -1,0 +1,11 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/phase0/sanity"
+)
+
+func TestMainnet_Phase0_Random(t *testing.T) {
+	sanity.RunBlockProcessingTest(t, "mainnet", "random/random/pyspec_tests")
+}

--- a/spectest/mainnet/phase0/sanity/blocks_test.go
+++ b/spectest/mainnet/phase0/sanity/blocks_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMainnet_Phase0_Sanity_Blocks(t *testing.T) {
-	sanity.RunBlockProcessingTest(t, "mainnet")
+	sanity.RunBlockProcessingTest(t, "mainnet", "sanity/blocks/pyspec_tests")
 }

--- a/spectest/minimal/altair/random/BUILD.bazel
+++ b/spectest/minimal/altair/random/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@prysm//tools/go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["random_test.go"],
+    data = glob(["*.yaml"]) + [
+        "@consensus_spec_tests_minimal//:test_data",
+    ],
+    eth_network = "minimal",
+    tags = ["spectest"],
+    deps = ["//spectest/shared/altair/sanity:go_default_library"],
+)

--- a/spectest/minimal/altair/random/random_test.go
+++ b/spectest/minimal/altair/random/random_test.go
@@ -1,0 +1,11 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/altair/sanity"
+)
+
+func TestMinimal_Altair_Random(t *testing.T) {
+	sanity.RunBlockProcessingTest(t, "minimal", "random/random/pyspec_tests")
+}

--- a/spectest/minimal/altair/sanity/blocks_test.go
+++ b/spectest/minimal/altair/sanity/blocks_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMinimal_Altair_Sanity_Blocks(t *testing.T) {
-	sanity.RunBlockProcessingTest(t, "minimal")
+	sanity.RunBlockProcessingTest(t, "minimal", "sanity/blocks/pyspec_tests")
 }

--- a/spectest/minimal/phase0/random/BUILD.bazel
+++ b/spectest/minimal/phase0/random/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@prysm//tools/go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["random_test.go"],
+    data = glob(["*.yaml"]) + [
+        "@consensus_spec_tests_minimal//:test_data",
+    ],
+    eth_network = "minimal",
+    tags = [
+        "minimal",
+        "spectest",
+    ],
+    deps = ["//spectest/shared/phase0/sanity:go_default_library"],
+)

--- a/spectest/minimal/phase0/random/random_test.go
+++ b/spectest/minimal/phase0/random/random_test.go
@@ -1,0 +1,11 @@
+package random
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/spectest/shared/phase0/sanity"
+)
+
+func TestMinimal_Phase0_Random(t *testing.T) {
+	sanity.RunBlockProcessingTest(t, "minimal", "random/random/pyspec_tests")
+}

--- a/spectest/minimal/phase0/sanity/blocks_test.go
+++ b/spectest/minimal/phase0/sanity/blocks_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMinimal_Phase0_Sanity_Blocks(t *testing.T) {
-	sanity.RunBlockProcessingTest(t, "minimal")
+	sanity.RunBlockProcessingTest(t, "minimal", "sanity/blocks/pyspec_tests")
 }

--- a/spectest/shared/altair/sanity/BUILD.bazel
+++ b/spectest/shared/altair/sanity/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//shared/testutil:go_default_library",
         "//shared/testutil/require:go_default_library",
         "//spectest/utils:go_default_library",
+        "@com_github_d4l3k_messagediff//:go_default_library",
         "@com_github_golang_snappy//:go_default_library",
         "@in_gopkg_d4l3k_messagediff_v1//:go_default_library",
         "@io_bazel_rules_go//go/tools/bazel:go_default_library",

--- a/spectest/shared/altair/sanity/block_processing.go
+++ b/spectest/shared/altair/sanity/block_processing.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/d4l3k/messagediff"
 	"github.com/golang/snappy"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	core "github.com/prysmaticlabs/prysm/beacon-chain/core/state"
@@ -20,7 +21,6 @@ import (
 	"github.com/prysmaticlabs/prysm/shared/testutil/require"
 	"github.com/prysmaticlabs/prysm/spectest/utils"
 	"google.golang.org/protobuf/proto"
-	"gopkg.in/d4l3k/messagediff.v1"
 )
 
 func init() {
@@ -28,10 +28,10 @@ func init() {
 }
 
 // RunBlockProcessingTest executes "sanity/blocks" tests.
-func RunBlockProcessingTest(t *testing.T, config string) {
+func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
-	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "sanity/blocks/pyspec_tests")
+	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", folderPath)
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			helpers.ClearCache()

--- a/spectest/shared/phase0/sanity/block_processing.go
+++ b/spectest/shared/phase0/sanity/block_processing.go
@@ -28,7 +28,7 @@ func init() {
 }
 
 // RunBlockProcessingTest executes "sanity/blocks" tests.
-func RunBlockProcessingTest(t *testing.T, config, folderPath string,) {
+func RunBlockProcessingTest(t *testing.T, config, folderPath string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", folderPath)

--- a/spectest/shared/phase0/sanity/block_processing.go
+++ b/spectest/shared/phase0/sanity/block_processing.go
@@ -28,10 +28,10 @@ func init() {
 }
 
 // RunBlockProcessingTest executes "sanity/blocks" tests.
-func RunBlockProcessingTest(t *testing.T, config string) {
+func RunBlockProcessingTest(t *testing.T, config, folderPath string,) {
 	require.NoError(t, utils.SetConfig(t, config))
 
-	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "sanity/blocks/pyspec_tests")
+	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", folderPath)
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			helpers.ClearCache()


### PR DESCRIPTION
# Description
This PR updates spec test to beta3 which included a new spec test format/folder `random`. While integrating the new spec test `random`, a bug was discovered where `ProcessEpochParticipation` processes flag indices for incorrectly marks **inactive** validators as true. In other words, for `get_unslashed_participating_indice`:

```python
# Spec:
active_validator_indices = get_active_validator_indices(state, epoch)
participating_indices = [i for i in active_validator_indices if has_flag(epoch_participation[i], flag_index)]
# Our implementation:
participating_indices = [i for i in state.validators if has_flag(epoch_participation[i], flag_index)]
```

Side note: `RunBlockProcessingTest` was refactored to use `folder_path` to it could be reused for `random` spec tests

Credit: Thanks @ralexstokes and team for the spec tests and helped with the debug