### PR TITLE
Spectest: increase sizes from small to medium

### DIFF
--- a/spectest/mainnet/altair/finality/BUILD.bazel
+++ b/spectest/mainnet/altair/finality/BUILD.bazel
@@ -2,7 +2,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    size = "small",
+    size = "medium",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/spectest/mainnet/altair/random/BUILD.bazel
+++ b/spectest/mainnet/altair/random/BUILD.bazel
@@ -2,7 +2,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    size = "small",
+    size = "medium",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/spectest/mainnet/altair/sanity/BUILD.bazel
+++ b/spectest/mainnet/altair/sanity/BUILD.bazel
@@ -2,7 +2,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "blocks_test.go",
         "slots_test.go",

--- a/spectest/mainnet/phase0/finality/BUILD.bazel
+++ b/spectest/mainnet/phase0/finality/BUILD.bazel
@@ -2,7 +2,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    size = "small",
+    size = "medium",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/spectest/mainnet/phase0/random/BUILD.bazel
+++ b/spectest/mainnet/phase0/random/BUILD.bazel
@@ -2,7 +2,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    size = "small",
+    size = "medium",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/spectest/mainnet/phase0/sanity/BUILD.bazel
+++ b/spectest/mainnet/phase0/sanity/BUILD.bazel
@@ -2,7 +2,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "blocks_test.go",
         "slots_test.go",


### PR DESCRIPTION
# Description

In ci/cd, spectests are timing out 80% of the time. The 3 most common ones to timeout are `random`, `sanity` and `finality`