### PR TITLE
Set `Content-Length` to zero for empty POST reponse

### DIFF
--- a/shared/gateway/api_middleware.go
+++ b/shared/gateway/api_middleware.go
@@ -172,7 +172,7 @@ func (m *ApiProxyMiddleware) handleApiPath(path string, endpointFactory Endpoint
 			}
 		}
 
-		if errJson := WriteMiddlewareResponseHeadersAndBody(req, grpcResponse, responseJson, w); errJson != nil {
+		if errJson := WriteMiddlewareResponseHeadersAndBody(grpcResponse, responseJson, w); errJson != nil {
 			WriteError(w, errJson, nil)
 			return
 		}

--- a/shared/gateway/api_middleware_processing.go
+++ b/shared/gateway/api_middleware_processing.go
@@ -168,7 +168,7 @@ func WriteMiddlewareResponseHeadersAndBody(req *http.Request, grpcResp *http.Res
 			}
 		}
 	}
-	if responseJson != nil {
+	if !GrpcResponseIsEmpty(responseJson) {
 		w.Header().Set("Content-Length", strconv.Itoa(len(responseJson)))
 		if statusCodeHeader != "" {
 			code, err := strconv.Atoi(statusCodeHeader)
@@ -183,6 +183,7 @@ func WriteMiddlewareResponseHeadersAndBody(req *http.Request, grpcResp *http.Res
 			return InternalServerErrorWithMessage(err, "could not write response message")
 		}
 	} else {
+		w.Header().Set("Content-Length", "0")
 		w.WriteHeader(grpcResp.StatusCode)
 	}
 	return nil

--- a/shared/gateway/api_middleware_processing.go
+++ b/shared/gateway/api_middleware_processing.go
@@ -154,7 +154,7 @@ func SerializeMiddlewareResponseIntoJson(responseContainer interface{}) (jsonRes
 }
 
 // WriteMiddlewareResponseHeadersAndBody populates headers and the body of the final response.
-func WriteMiddlewareResponseHeadersAndBody(req *http.Request, grpcResp *http.Response, responseJson []byte, w http.ResponseWriter) ErrorJson {
+func WriteMiddlewareResponseHeadersAndBody(grpcResp *http.Response, responseJson []byte, w http.ResponseWriter) ErrorJson {
 	var statusCodeHeader string
 	for h, vs := range grpcResp.Header {
 		// We don't want to expose any gRPC metadata in the HTTP response, so we skip forwarding metadata headers.

--- a/shared/gateway/api_middleware_processing_test.go
+++ b/shared/gateway/api_middleware_processing_test.go
@@ -360,6 +360,24 @@ func TestWriteMiddlewareResponseHeadersAndBody(t *testing.T) {
 		assert.Equal(t, 204, writer.Code)
 		assert.DeepEqual(t, responseJson, writer.Body.Bytes())
 	})
+
+	t.Run("POST_with_empty_json_body", func(t *testing.T) {
+		request := httptest.NewRequest("POST", "http://foo.example", &body)
+		response := &http.Response{
+			Header:     http.Header{},
+			StatusCode: 204,
+		}
+		responseJson, err := json.Marshal(struct{}{})
+		require.NoError(t, err)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+
+		errJson := WriteMiddlewareResponseHeadersAndBody(request, response, responseJson, writer)
+		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, 204, writer.Code)
+		assert.DeepEqual(t, []byte(nil), writer.Body.Bytes())
+		assert.Equal(t, "0", writer.Header()["Content-Length"][0])
+	})
 }
 
 func TestWriteError(t *testing.T) {

--- a/shared/gateway/api_middleware_processing_test.go
+++ b/shared/gateway/api_middleware_processing_test.go
@@ -261,10 +261,7 @@ func TestSerializeMiddlewareResponseIntoJson(t *testing.T) {
 }
 
 func TestWriteMiddlewareResponseHeadersAndBody(t *testing.T) {
-	var body bytes.Buffer
-
 	t.Run("GET", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", &body)
 		response := &http.Response{
 			Header: http.Header{
 				"Foo": []string{"foo"},
@@ -277,7 +274,7 @@ func TestWriteMiddlewareResponseHeadersAndBody(t *testing.T) {
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 
-		errJson := WriteMiddlewareResponseHeadersAndBody(request, response, responseJson, writer)
+		errJson := WriteMiddlewareResponseHeadersAndBody(response, responseJson, writer)
 		require.Equal(t, true, errJson == nil)
 		v, ok := writer.Header()["Foo"]
 		require.Equal(t, true, ok, "header not found")
@@ -292,7 +289,6 @@ func TestWriteMiddlewareResponseHeadersAndBody(t *testing.T) {
 	})
 
 	t.Run("GET_no_grpc_status_code_header", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", &body)
 		response := &http.Response{
 			Header:     http.Header{},
 			StatusCode: 204,
@@ -302,13 +298,12 @@ func TestWriteMiddlewareResponseHeadersAndBody(t *testing.T) {
 		require.NoError(t, err)
 		writer := httptest.NewRecorder()
 
-		errJson := WriteMiddlewareResponseHeadersAndBody(request, response, responseJson, writer)
+		errJson := WriteMiddlewareResponseHeadersAndBody(response, responseJson, writer)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, 204, writer.Code)
 	})
 
 	t.Run("GET_invalid_status_code", func(t *testing.T) {
-		request := httptest.NewRequest("GET", "http://foo.example", &body)
 		response := &http.Response{
 			Header: http.Header{},
 		}
@@ -321,14 +316,13 @@ func TestWriteMiddlewareResponseHeadersAndBody(t *testing.T) {
 		require.NoError(t, err)
 		writer := httptest.NewRecorder()
 
-		errJson := WriteMiddlewareResponseHeadersAndBody(request, response, responseJson, writer)
+		errJson := WriteMiddlewareResponseHeadersAndBody(response, responseJson, writer)
 		require.Equal(t, false, errJson == nil)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "could not parse status code"))
 		assert.Equal(t, http.StatusInternalServerError, errJson.StatusCode())
 	})
 
 	t.Run("POST", func(t *testing.T) {
-		request := httptest.NewRequest("POST", "http://foo.example", &body)
 		response := &http.Response{
 			Header:     http.Header{},
 			StatusCode: 204,
@@ -338,13 +332,12 @@ func TestWriteMiddlewareResponseHeadersAndBody(t *testing.T) {
 		require.NoError(t, err)
 		writer := httptest.NewRecorder()
 
-		errJson := WriteMiddlewareResponseHeadersAndBody(request, response, responseJson, writer)
+		errJson := WriteMiddlewareResponseHeadersAndBody(response, responseJson, writer)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, 204, writer.Code)
 	})
 
 	t.Run("POST_with_response_body", func(t *testing.T) {
-		request := httptest.NewRequest("POST", "http://foo.example", &body)
 		response := &http.Response{
 			Header:     http.Header{},
 			StatusCode: 204,
@@ -355,14 +348,13 @@ func TestWriteMiddlewareResponseHeadersAndBody(t *testing.T) {
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 
-		errJson := WriteMiddlewareResponseHeadersAndBody(request, response, responseJson, writer)
+		errJson := WriteMiddlewareResponseHeadersAndBody(response, responseJson, writer)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, 204, writer.Code)
 		assert.DeepEqual(t, responseJson, writer.Body.Bytes())
 	})
 
 	t.Run("POST_with_empty_json_body", func(t *testing.T) {
-		request := httptest.NewRequest("POST", "http://foo.example", &body)
 		response := &http.Response{
 			Header:     http.Header{},
 			StatusCode: 204,
@@ -372,7 +364,7 @@ func TestWriteMiddlewareResponseHeadersAndBody(t *testing.T) {
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 
-		errJson := WriteMiddlewareResponseHeadersAndBody(request, response, responseJson, writer)
+		errJson := WriteMiddlewareResponseHeadersAndBody(response, responseJson, writer)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, 204, writer.Code)
 		assert.DeepEqual(t, []byte(nil), writer.Body.Bytes())


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

grpc-gateway returns `{}` for successful POST responses with an `empty.Empty` return value. This has a length of 2 bytes, but we want to inform the client that the response length is `0` in such cases.

**Which issues(s) does this PR fix?**

Fixes #9531

**Other notes for review**

I also removed an unused param that Deepsource complained about.
