### PR TITLE
Implement Generic ProposeBeaconBlock Function for RPC

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -151,15 +151,21 @@ func (vs *Server) GetBlock(ctx context.Context, req *ethpb.BlockRequest) (*ethpb
 
 // ProposeBeaconBlock is called by a proposer during its assigned slot to create a block in an attempt
 // to get it processed by the beacon node as the canonical head.
-// This method will DEPRECATE ProposeBlock once implemented.
 func (vs *Server) ProposeBeaconBlock(ctx context.Context, req *ethpb.GenericSignedBeaconBlock) (*ethpb.ProposeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "Unimplemented")
+	blk := req.Block.(block.SignedBeaconBlock)
+	return vs.proposeGenericBeaconBlock(ctx, blk)
 }
 
 // ProposeBlock is called by a proposer during its assigned slot to create a block in an attempt
 // to get it processed by the beacon node as the canonical head.
+//
+// DEPRECATED: Use ProposeBeaconBlock instead.
 func (vs *Server) ProposeBlock(ctx context.Context, rBlk *ethpb.SignedBeaconBlock) (*ethpb.ProposeResponse, error) {
 	blk := wrapper.WrappedPhase0SignedBeaconBlock(rBlk)
+	return vs.proposeGenericBeaconBlock(ctx, blk)
+}
+
+func (vs *Server) proposeGenericBeaconBlock(ctx context.Context, blk block.SignedBeaconBlock) (*ethpb.ProposeResponse, error) {
 	root, err := blk.Block().HashTreeRoot()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not tree hash block: %v", err)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
@@ -272,6 +272,7 @@ func TestProposer_ProposeBlock_Altair_OK(t *testing.T) {
 	blockToPropose.Block.ParentRoot = bsRoot[:]
 	blk := &ethpb.GenericSignedBeaconBlock_Altair{Altair: blockToPropose}
 	wrapped, err := wrapper.WrappedAltairSignedBeaconBlock(blockToPropose)
+	require.NoError(t, err)
 	require.NoError(t, db.SaveBlock(ctx, wrapped))
 	_, err = proposerServer.ProposeBeaconBlock(context.Background(), &ethpb.GenericSignedBeaconBlock{Block: blk})
 	assert.NoError(t, err, "Could not propose block correctly")

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
@@ -235,7 +235,8 @@ func TestProposer_ProposeBlock_Phase0_OK(t *testing.T) {
 	req.Block.Slot = 5
 	req.Block.ParentRoot = bsRoot[:]
 	require.NoError(t, db.SaveBlock(ctx, wrapper.WrappedPhase0SignedBeaconBlock(req)))
-	_, err = proposerServer.ProposeBlock(context.Background(), req)
+	blk := &ethpb.GenericSignedBeaconBlock_Phase0{Phase0: req}
+	_, err = proposerServer.ProposeBeaconBlock(context.Background(), &ethpb.GenericSignedBeaconBlock{Block: blk})
 	assert.NoError(t, err, "Could not propose block correctly")
 }
 
@@ -249,7 +250,7 @@ func TestProposer_ProposeBlock_Altair_OK(t *testing.T) {
 	require.NoError(t, db.SaveBlock(context.Background(), wrapper.WrappedPhase0SignedBeaconBlock(genesis)), "Could not save genesis block")
 
 	numDeposits := uint64(64)
-	beaconState, _ := testutil.DeterministicGenesisState(t, numDeposits)
+	beaconState, _ := testutil.DeterministicGenesisStateAltair(t, numDeposits)
 	bsRoot, err := beaconState.HashTreeRoot(ctx)
 	require.NoError(t, err)
 	genesisRoot, err := genesis.Block.HashTreeRoot()
@@ -266,11 +267,13 @@ func TestProposer_ProposeBlock_Altair_OK(t *testing.T) {
 		BlockNotifier:     c.BlockNotifier(),
 		P2P:               mockp2p.NewTestP2P(t),
 	}
-	req := testutil.NewBeaconBlock()
-	req.Block.Slot = 5
-	req.Block.ParentRoot = bsRoot[:]
-	require.NoError(t, db.SaveBlock(ctx, wrapper.WrappedPhase0SignedBeaconBlock(req)))
-	_, err = proposerServer.ProposeBlock(context.Background(), req)
+	blockToPropose := testutil.NewBeaconBlockAltair()
+	blockToPropose.Block.Slot = 5
+	blockToPropose.Block.ParentRoot = bsRoot[:]
+	blk := &ethpb.GenericSignedBeaconBlock_Altair{Altair: blockToPropose}
+	wrapped, err := wrapper.WrappedAltairSignedBeaconBlock(blockToPropose)
+	require.NoError(t, db.SaveBlock(ctx, wrapped))
+	_, err = proposerServer.ProposeBeaconBlock(context.Background(), &ethpb.GenericSignedBeaconBlock{Block: blk})
 	assert.NoError(t, err, "Could not propose block correctly")
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
@@ -204,7 +204,42 @@ func TestProposer_GetBlock_AddsUnaggregatedAtts(t *testing.T) {
 	assert.Equal(t, false, hasUnaggregatedAtt, "Expected block to not have unaggregated attestation")
 }
 
-func TestProposer_ProposeBlock_OK(t *testing.T) {
+func TestProposer_ProposeBlock_Phase0_OK(t *testing.T) {
+	db := dbutil.SetupDB(t)
+	ctx := context.Background()
+	params.SetupTestConfigCleanup(t)
+	params.OverrideBeaconConfig(params.MainnetConfig())
+
+	genesis := testutil.NewBeaconBlock()
+	require.NoError(t, db.SaveBlock(context.Background(), wrapper.WrappedPhase0SignedBeaconBlock(genesis)), "Could not save genesis block")
+
+	numDeposits := uint64(64)
+	beaconState, _ := testutil.DeterministicGenesisState(t, numDeposits)
+	bsRoot, err := beaconState.HashTreeRoot(ctx)
+	require.NoError(t, err)
+	genesisRoot, err := genesis.Block.HashTreeRoot()
+	require.NoError(t, err)
+	require.NoError(t, db.SaveState(ctx, beaconState, genesisRoot), "Could not save genesis state")
+
+	c := &mock.ChainService{Root: bsRoot[:], State: beaconState}
+	proposerServer := &Server{
+		ChainStartFetcher: &mockPOW.POWChain{},
+		Eth1InfoFetcher:   &mockPOW.POWChain{},
+		Eth1BlockFetcher:  &mockPOW.POWChain{},
+		BlockReceiver:     c,
+		HeadFetcher:       c,
+		BlockNotifier:     c.BlockNotifier(),
+		P2P:               mockp2p.NewTestP2P(t),
+	}
+	req := testutil.NewBeaconBlock()
+	req.Block.Slot = 5
+	req.Block.ParentRoot = bsRoot[:]
+	require.NoError(t, db.SaveBlock(ctx, wrapper.WrappedPhase0SignedBeaconBlock(req)))
+	_, err = proposerServer.ProposeBlock(context.Background(), req)
+	assert.NoError(t, err, "Could not propose block correctly")
+}
+
+func TestProposer_ProposeBlock_Altair_OK(t *testing.T) {
 	db := dbutil.SetupDB(t)
 	ctx := context.Background()
 	params.SetupTestConfigCleanup(t)


### PR DESCRIPTION
Adds a generic ProposeBeaconBlock function which can handle both Altair and phase 0 blocks using protobuf oneofs. This is important for hf1