### PR TITLE
Align `GetBlockV2` to API HTTP spec

### DIFF
--- a/beacon-chain/rpc/apimiddleware/BUILD.bazel
+++ b/beacon-chain/rpc/apimiddleware/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/rpc/eth/events:go_default_library",
+        "//proto/eth/v2:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/gateway:go_default_library",
         "//shared/grpcutils:go_default_library",
@@ -30,11 +31,13 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/rpc/eth/events:go_default_library",
+        "//proto/eth/v2:go_default_library",
         "//shared/bytesutil:go_default_library",
         "//shared/gateway:go_default_library",
         "//shared/grpcutils:go_default_library",
         "//shared/testutil/assert:go_default_library",
         "//shared/testutil/require:go_default_library",
+        "@com_github_gogo_protobuf//types:go_default_library",
         "@com_github_r3labs_sse//:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/apimiddleware/custom_hooks.go
+++ b/beacon-chain/rpc/apimiddleware/custom_hooks.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
+	ethpbv2 "github.com/prysmaticlabs/prysm/proto/eth/v2"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/gateway"
 )
@@ -128,4 +130,46 @@ func prepareValidatorAggregates(body []byte, responseContainer interface{}) (boo
 	}
 
 	return true, nil
+}
+
+type phase0BlockResponseJson struct {
+	Version string                    `json:"version"`
+	Data    *beaconBlockContainerJson `json:"data"`
+}
+
+type altairBlockResponseJson struct {
+	Version string                          `json:"version"`
+	Data    *beaconBlockAltairContainerJson `json:"data"`
+}
+
+func serializeV2Block(response interface{}) (bool, []byte, gateway.ErrorJson) {
+	respContainer, ok := response.(*blockV2ResponseJson)
+	if !ok {
+		return false, nil, gateway.InternalServerError(errors.New("container is not of the correct type"))
+	}
+
+	var actualRespContainer interface{}
+	if strings.EqualFold(respContainer.Version, strings.ToLower(ethpbv2.Version_PHASE0.String())) {
+		actualRespContainer = &phase0BlockResponseJson{
+			Version: respContainer.Version,
+			Data: &beaconBlockContainerJson{
+				Message:   respContainer.Data.Phase0Block,
+				Signature: respContainer.Data.Signature,
+			},
+		}
+	} else {
+		actualRespContainer = &altairBlockResponseJson{
+			Version: respContainer.Version,
+			Data: &beaconBlockAltairContainerJson{
+				Message:   respContainer.Data.AltairBlock,
+				Signature: respContainer.Data.Signature,
+			},
+		}
+	}
+
+	j, err := json.Marshal(actualRespContainer)
+	if err != nil {
+		return false, nil, gateway.InternalServerErrorWithMessage(err, "could not marshal response")
+	}
+	return true, j, nil
 }

--- a/beacon-chain/rpc/apimiddleware/custom_hooks_test.go
+++ b/beacon-chain/rpc/apimiddleware/custom_hooks_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gogo/protobuf/types"
+	ethpbv2 "github.com/prysmaticlabs/prysm/proto/eth/v2"
 	"github.com/prysmaticlabs/prysm/shared/bytesutil"
 	"github.com/prysmaticlabs/prysm/shared/gateway"
 	"github.com/prysmaticlabs/prysm/shared/testutil/assert"
@@ -228,4 +230,47 @@ func TestPrepareValidatorAggregates(t *testing.T) {
 	require.Equal(t, true, handled)
 	assert.DeepEqual(t, []string{"1", "2"}, container.Data.Validators)
 	require.DeepEqual(t, [][]string{{"3", "4"}, {"5"}}, container.Data.ValidatorAggregates)
+}
+
+func TestSerializeV2Block(t *testing.T) {
+	t.Run("Phase 0", func(t *testing.T) {
+		response := &blockV2ResponseJson{
+			Version: ethpbv2.Version_PHASE0.String(),
+			Data: &beaconBlockContainerV2Json{
+				Phase0Block: &beaconBlockJson{},
+				AltairBlock: nil,
+				Signature:   "sig",
+			},
+		}
+		ok, j, errJson := serializeV2Block(response)
+		require.Equal(t, nil, errJson)
+		require.Equal(t, true, ok)
+		require.NotNil(t, j)
+		require.NoError(t, json.Unmarshal(j, &phase0BlockResponseJson{}))
+	})
+
+	t.Run("Altair", func(t *testing.T) {
+		response := &blockV2ResponseJson{
+			Version: ethpbv2.Version_ALTAIR.String(),
+			Data: &beaconBlockContainerV2Json{
+				Phase0Block: nil,
+				AltairBlock: &beaconBlockAltairJson{},
+				Signature:   "sig",
+			},
+		}
+		ok, j, errJson := serializeV2Block(response)
+		require.Equal(t, nil, errJson)
+		require.Equal(t, true, ok)
+		require.NotNil(t, j)
+		require.NoError(t, json.Unmarshal(j, &altairBlockResponseJson{}))
+	})
+
+	t.Run("incorrect response type", func(t *testing.T) {
+		response := &types.Empty{}
+		ok, j, errJson := serializeV2Block(response)
+		require.Equal(t, false, ok)
+		require.Equal(t, 0, len(j))
+		require.NotNil(t, errJson)
+		assert.Equal(t, true, strings.Contains(errJson.Msg(), "container is not of the correct type"))
+	})
 }

--- a/beacon-chain/rpc/apimiddleware/endpoint_factory.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory.go
@@ -29,6 +29,7 @@ func (f *BeaconEndpointFactory) Paths() []string {
 		"/eth/v1/beacon/headers/{block_id}",
 		"/eth/v1/beacon/blocks",
 		"/eth/v1/beacon/blocks/{block_id}",
+		"/eth/v2/beacon/blocks/{block_id}",
 		"/eth/v1/beacon/blocks/{block_id}/root",
 		"/eth/v1/beacon/blocks/{block_id}/attestations",
 		"/eth/v1/beacon/pool/attestations",
@@ -100,6 +101,11 @@ func (f *BeaconEndpointFactory) Create(path string) (*gateway.Endpoint, error) {
 	case "/eth/v1/beacon/blocks/{block_id}":
 		endpoint.GetResponse = &blockResponseJson{}
 		endpoint.CustomHandlers = []gateway.CustomHandler{handleGetBeaconBlockSSZ}
+	case "/eth/v2/beacon/blocks/{block_id}":
+		endpoint.GetResponse = &blockV2ResponseJson{}
+		endpoint.Hooks = gateway.HookCollection{
+			OnPreSerializeMiddlewareResponseIntoJson: []func(interface{}) (bool, []byte, gateway.ErrorJson){serializeV2Block},
+		}
 	case "/eth/v1/beacon/blocks/{block_id}/root":
 		endpoint.GetResponse = &blockRootResponseJson{}
 	case "/eth/v1/beacon/blocks/{block_id}/attestations":

--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -81,6 +81,12 @@ type blockResponseJson struct {
 	Data *beaconBlockContainerJson `json:"data"`
 }
 
+// blockV2ResponseJson is used in /v2/beacon/blocks/{block_id} API endpoint.
+type blockV2ResponseJson struct {
+	Version string                      `json:"version" enum:"true"`
+	Data    *beaconBlockContainerV2Json `json:"data"`
+}
+
 // blockRootResponseJson is used in /beacon/blocks/{block_id}/root API endpoint.
 type blockRootResponseJson struct {
 	Data *blockRootContainerJson `json:"data"`
@@ -265,6 +271,42 @@ type beaconBlockBodyJson struct {
 	Attestations      []*attestationJson         `json:"attestations"`
 	Deposits          []*depositJson             `json:"deposits"`
 	VoluntaryExits    []*signedVoluntaryExitJson `json:"voluntary_exits"`
+}
+
+type beaconBlockContainerV2Json struct {
+	Phase0Block *beaconBlockJson       `json:"phase0Block"`
+	AltairBlock *beaconBlockAltairJson `json:"altairBlock"`
+	Signature   string                 `json:"signature" hex:"true"`
+}
+
+type beaconBlockAltairContainerJson struct {
+	Message   *beaconBlockAltairJson `json:"message"`
+	Signature string                 `json:"signature" hex:"true"`
+}
+
+type beaconBlockAltairJson struct {
+	Slot          string                     `json:"slot"`
+	ProposerIndex string                     `json:"proposer_index"`
+	ParentRoot    string                     `json:"parent_root" hex:"true"`
+	StateRoot     string                     `json:"state_root" hex:"true"`
+	Body          *beaconBlockBodyAltairJson `json:"body"`
+}
+
+type beaconBlockBodyAltairJson struct {
+	RandaoReveal      string                     `json:"randao_reveal" hex:"true"`
+	Eth1Data          *eth1DataJson              `json:"eth1_data"`
+	Graffiti          string                     `json:"graffiti" hex:"true"`
+	ProposerSlashings []*proposerSlashingJson    `json:"proposer_slashings"`
+	AttesterSlashings []*attesterSlashingJson    `json:"attester_slashings"`
+	Attestations      []*attestationJson         `json:"attestations"`
+	Deposits          []*depositJson             `json:"deposits"`
+	VoluntaryExits    []*signedVoluntaryExitJson `json:"voluntary_exits"`
+	SyncAggregate     *syncAggregateJson         `json:"sync_aggregate"`
+}
+
+type syncAggregateJson struct {
+	SyncCommitteeBits      string `json:"sync_committee_bits" hex:"true"`
+	SyncCommitteeSignature string `json:"sync_committee_signature" hex:"true"`
 }
 
 type blockHeaderContainerJson struct {


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Adding the HTTP part of `GetBlockV2`: https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2

Main thing to notice is that the example returns one of two version of the block in a way that is not in line with how gRPC returns `oneof` values. That's why a custom handler function was needed.
