### PR TITLE
Align `SubmitPoolSyncCommitteeSignatures` to API HTTP spec

### DIFF
--- a/beacon-chain/rpc/apimiddleware/custom_hooks.go
+++ b/beacon-chain/rpc/apimiddleware/custom_hooks.go
@@ -84,6 +84,24 @@ func wrapBeaconCommitteeSubscriptionsArray(endpoint gateway.Endpoint, _ http.Res
 	return nil
 }
 
+// https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolSyncCommitteeSignatures expects posting a top-level array.
+// We make it more proto-friendly by wrapping it in a struct with a 'data' field.
+func wrapSyncCommitteeSignaturesArray(endpoint gateway.Endpoint, _ http.ResponseWriter, req *http.Request) gateway.ErrorJson {
+	if _, ok := endpoint.PostRequest.(*submitSyncCommitteeSignaturesRequestJson); ok {
+		data := make([]*syncCommitteeMessageJson, 0)
+		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
+			return gateway.InternalServerErrorWithMessage(err, "could not decode body")
+		}
+		j := &submitSyncCommitteeSignaturesRequestJson{Data: data}
+		b, err := json.Marshal(j)
+		if err != nil {
+			return gateway.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
+		}
+		req.Body = ioutil.NopCloser(bytes.NewReader(b))
+	}
+	return nil
+}
+
 // Posted graffiti needs to have length of 32 bytes, but client is allowed to send data of any length.
 func prepareGraffiti(endpoint gateway.Endpoint, _ http.ResponseWriter, _ *http.Request) gateway.ErrorJson {
 	if block, ok := endpoint.PostRequest.(*beaconBlockContainerJson); ok {

--- a/beacon-chain/rpc/apimiddleware/custom_hooks_test.go
+++ b/beacon-chain/rpc/apimiddleware/custom_hooks_test.go
@@ -92,10 +92,10 @@ func TestWrapSignedAggregateAndProofArray(t *testing.T) {
 
 		errJson := wrapSignedAggregateAndProofArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
-		wrappedAggss := &submitAggregateAndProofsRequestJson{}
-		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedAggss))
-		require.Equal(t, 1, len(wrappedAggss.Data), "wrong number of wrapped items")
-		assert.Equal(t, "sig", wrappedAggss.Data[0].Signature)
+		wrappedAggs := &submitAggregateAndProofsRequestJson{}
+		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedAggs))
+		require.Equal(t, 1, len(wrappedAggs.Data), "wrong number of wrapped items")
+		assert.Equal(t, "sig", wrappedAggs.Data[0].Signature)
 	})
 
 	t.Run("invalid_body", func(t *testing.T) {
@@ -136,14 +136,14 @@ func TestWrapBeaconCommitteeSubscriptionsArray(t *testing.T) {
 
 		errJson := wrapBeaconCommitteeSubscriptionsArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
-		wrappedAggss := &submitBeaconCommitteeSubscriptionsRequestJson{}
-		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedAggss))
-		require.Equal(t, 1, len(wrappedAggss.Data), "wrong number of wrapped items")
-		assert.Equal(t, "1", wrappedAggss.Data[0].ValidatorIndex)
-		assert.Equal(t, "1", wrappedAggss.Data[0].CommitteeIndex)
-		assert.Equal(t, "1", wrappedAggss.Data[0].CommitteesAtSlot)
-		assert.Equal(t, "1", wrappedAggss.Data[0].Slot)
-		assert.Equal(t, true, wrappedAggss.Data[0].IsAggregator)
+		wrappedSubs := &submitBeaconCommitteeSubscriptionsRequestJson{}
+		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedSubs))
+		require.Equal(t, 1, len(wrappedSubs.Data), "wrong number of wrapped items")
+		assert.Equal(t, "1", wrappedSubs.Data[0].ValidatorIndex)
+		assert.Equal(t, "1", wrappedSubs.Data[0].CommitteeIndex)
+		assert.Equal(t, "1", wrappedSubs.Data[0].CommitteesAtSlot)
+		assert.Equal(t, "1", wrappedSubs.Data[0].Slot)
+		assert.Equal(t, true, wrappedSubs.Data[0].IsAggregator)
 	})
 
 	t.Run("invalid_body", func(t *testing.T) {
@@ -156,6 +156,52 @@ func TestWrapBeaconCommitteeSubscriptionsArray(t *testing.T) {
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
 		errJson := wrapBeaconCommitteeSubscriptionsArray(endpoint, nil, request)
+		require.Equal(t, false, errJson == nil)
+		assert.Equal(t, true, strings.Contains(errJson.Msg(), "could not decode body"))
+		assert.Equal(t, http.StatusInternalServerError, errJson.StatusCode())
+	})
+}
+
+func TestWrapSyncCommitteeSignaturesArray(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		endpoint := gateway.Endpoint{
+			PostRequest: &submitSyncCommitteeSignaturesRequestJson{},
+		}
+		unwrappedSigs := []*syncCommitteeMessageJson{{
+			Slot:            "1",
+			BeaconBlockRoot: "root",
+			ValidatorIndex:  "1",
+			Signature:       "sig",
+		}}
+		unwrappedSigsJson, err := json.Marshal(unwrappedSigs)
+		require.NoError(t, err)
+
+		var body bytes.Buffer
+		_, err = body.Write(unwrappedSigsJson)
+		require.NoError(t, err)
+		request := httptest.NewRequest("POST", "http://foo.example", &body)
+
+		errJson := wrapSyncCommitteeSignaturesArray(endpoint, nil, request)
+		require.Equal(t, true, errJson == nil)
+		wrappedSigs := &submitSyncCommitteeSignaturesRequestJson{}
+		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedSigs))
+		require.Equal(t, 1, len(wrappedSigs.Data), "wrong number of wrapped items")
+		assert.Equal(t, "1", wrappedSigs.Data[0].Slot)
+		assert.Equal(t, "root", wrappedSigs.Data[0].BeaconBlockRoot)
+		assert.Equal(t, "1", wrappedSigs.Data[0].ValidatorIndex)
+		assert.Equal(t, "sig", wrappedSigs.Data[0].Signature)
+	})
+
+	t.Run("invalid_body", func(t *testing.T) {
+		endpoint := gateway.Endpoint{
+			PostRequest: &submitSyncCommitteeSignaturesRequestJson{},
+		}
+		var body bytes.Buffer
+		_, err := body.Write([]byte("invalid"))
+		require.NoError(t, err)
+		request := httptest.NewRequest("POST", "http://foo.example", &body)
+
+		errJson := wrapSyncCommitteeSignaturesArray(endpoint, nil, request)
 		require.Equal(t, false, errJson == nil)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "could not decode body"))
 		assert.Equal(t, http.StatusInternalServerError, errJson.StatusCode())

--- a/beacon-chain/rpc/apimiddleware/endpoint_factory.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory.go
@@ -35,6 +35,7 @@ func (f *BeaconEndpointFactory) Paths() []string {
 		"/eth/v1/beacon/pool/attester_slashings",
 		"/eth/v1/beacon/pool/proposer_slashings",
 		"/eth/v1/beacon/pool/voluntary_exits",
+		"/eth/v1/beacon/pool/sync_committees",
 		"/eth/v1/node/identity",
 		"/eth/v1/node/peers",
 		"/eth/v1/node/peers/{peer_id}",
@@ -121,6 +122,11 @@ func (f *BeaconEndpointFactory) Create(path string) (*gateway.Endpoint, error) {
 	case "/eth/v1/beacon/pool/voluntary_exits":
 		endpoint.PostRequest = &signedVoluntaryExitJson{}
 		endpoint.GetResponse = &voluntaryExitsPoolResponseJson{}
+	case "/eth/v1/beacon/pool/sync_committees":
+		endpoint.PostRequest = &submitSyncCommitteeSignaturesRequestJson{}
+		endpoint.Hooks = gateway.HookCollection{
+			OnPreDeserializeRequestBodyIntoContainer: []gateway.Hook{wrapSyncCommitteeSignaturesArray},
+		}
 	case "/eth/v1/node/identity":
 		endpoint.GetResponse = &identityResponseJson{}
 	case "/eth/v1/node/peers":

--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -116,6 +116,11 @@ type voluntaryExitsPoolResponseJson struct {
 	Data []*signedVoluntaryExitJson `json:"data"`
 }
 
+// submitSyncCommitteeSignaturesRequestJson is used in /beacon/pool/sync_committees API endpoint.
+type submitSyncCommitteeSignaturesRequestJson struct {
+	Data []*syncCommitteeMessageJson `json:"data"`
+}
+
 // identityResponseJson is used in /node/identity API endpoint.
 type identityResponseJson struct {
 	Data *identityJson `json:"data"`
@@ -347,6 +352,13 @@ type signedVoluntaryExitJson struct {
 type voluntaryExitJson struct {
 	Epoch          string `json:"epoch"`
 	ValidatorIndex string `json:"validator_index"`
+}
+
+type syncCommitteeMessageJson struct {
+	Slot            string `json:"slot"`
+	BeaconBlockRoot string `json:"beacon_block_root" hex:"true"`
+	ValidatorIndex  string `json:"validator_index"`
+	Signature       string `json:"signature" hex:"true"`
 }
 
 type identityJson struct {


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Adding the HTTP part of `SubmitPoolSyncCommitteeSignatures`: https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolSyncCommitteeSignatures

Main thing to notice is that the example posted value is a top-level array, which is not supported by grpc-gateway. That's why a custom handler function was needed.
