### PR TITLE
Enable prune canonical attestation

### DIFF
--- a/shared/featureconfig/config.go
+++ b/shared/featureconfig/config.go
@@ -201,9 +201,10 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 		logEnabled(correctlyInsertOrphanedAtts)
 		cfg.CorrectlyInsertOrphanedAtts = true
 	}
-	if ctx.Bool(correctlyPruneCanonicalAtts.Name) {
-		logEnabled(correctlyPruneCanonicalAtts)
-		cfg.CorrectlyPruneCanonicalAtts = true
+	cfg.CorrectlyPruneCanonicalAtts = true
+	if ctx.Bool(disableCorrectlyPruneCanonicalAtts.Name) {
+		logDisabled(disableCorrectlyPruneCanonicalAtts)
+		cfg.CorrectlyPruneCanonicalAtts = false
 	}
 	cfg.EnableActiveBalanceCache = true
 	if ctx.Bool(disableActiveBalanceCache.Name) {

--- a/shared/featureconfig/deprecated_flags.go
+++ b/shared/featureconfig/deprecated_flags.go
@@ -18,9 +18,16 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+
+	deprecatedCorrectlyPruneCanonicalAtts = &cli.BoolFlag{
+		Name:   "correctly-prune-canonical-atts",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
 	exampleDeprecatedFeatureFlag,
 	deprecatedEnableActiveBalanceCache,
+	deprecatedCorrectlyPruneCanonicalAtts,
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -126,9 +126,9 @@ var (
 		Usage: "This fixes a bug where orphaned attestations don't get reinserted back to mem pool. This improves validator profitability and overall network health," +
 			"see issue #9441 for further detail",
 	}
-	correctlyPruneCanonicalAtts = &cli.BoolFlag{
-		Name: "correctly-prune-canonical-atts",
-		Usage: "This fixes a bug where any block attestations can get incorrectly pruned. This improves validator profitability and overall network health," +
+	disableCorrectlyPruneCanonicalAtts = &cli.BoolFlag{
+		Name: "disable-correctly-prune-canonical-atts",
+		Usage: "Disable the fixe for bug where any block attestations can get incorrectly pruned, which improves validator profitability and overall network health," +
 			"see issue #9443 for further detail",
 	}
 	disableActiveBalanceCache = &cli.BoolFlag{
@@ -143,7 +143,6 @@ var devModeFlags = []cli.Flag{
 	enableNextSlotStateCache,
 	forceOptMaxCoverAggregationStategy,
 	correctlyInsertOrphanedAtts,
-	correctlyPruneCanonicalAtts,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.
@@ -193,7 +192,7 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	disableOptimizedBalanceUpdate,
 	enableHistoricalSpaceRepresentation,
 	correctlyInsertOrphanedAtts,
-	correctlyPruneCanonicalAtts,
+	disableCorrectlyPruneCanonicalAtts,
 	disableActiveBalanceCache,
 }...)
 
@@ -203,6 +202,5 @@ var E2EBeaconChainFlags = []string{
 	"--dev",
 	"--use-check-point-cache",
 	"--correctly-insert-orphaned-atts",
-	"--correctly-prune-canonical-atts",
 	"--enable-active-balance-cache",
 }

--- a/shared/featureconfig/flags.go
+++ b/shared/featureconfig/flags.go
@@ -128,7 +128,7 @@ var (
 	}
 	disableCorrectlyPruneCanonicalAtts = &cli.BoolFlag{
 		Name: "disable-correctly-prune-canonical-atts",
-		Usage: "Disable the fixe for bug where any block attestations can get incorrectly pruned, which improves validator profitability and overall network health," +
+		Usage: "Disable the fix for bug where any block attestations can get incorrectly pruned, which improves validator profitability and overall network health," +
 			"see issue #9443 for further detail",
 	}
 	disableActiveBalanceCache = &cli.BoolFlag{


### PR DESCRIPTION
# Description
Flips feature to enable pruning of canonical attestation. This feature is required for testnet support and will be a requirement for v2.0.0.