### PR TITLE
Make `until_epoch` exclusive in `PrepareSyncCommitteeSubnets`

### DIFF
--- a/beacon-chain/rpc/eth/validator/validator.go
+++ b/beacon-chain/rpc/eth/validator/validator.go
@@ -486,16 +486,16 @@ func (vs *Server) SubmitSyncCommitteeSubscription(ctx context.Context, req *ethp
 	startEpoch := types.Epoch(currPeriod * uint64(params.BeaconConfig().EpochsPerSyncCommitteePeriod))
 
 	for i, sub := range req.Data {
-		if sub.UntilEpoch < currEpoch {
-			return nil, status.Errorf(codes.InvalidArgument, "Epoch for subscription at index %d is in the past. It must be at least %d", i, currEpoch)
+		if sub.UntilEpoch <= currEpoch {
+			return nil, status.Errorf(codes.InvalidArgument, "Epoch for subscription at index %d is in the past. It must be at least %d", i, currEpoch+1)
 		}
 		maxValidEpoch := startEpoch + params.BeaconConfig().EpochsPerSyncCommitteePeriod
-		if sub.UntilEpoch > maxValidEpoch {
+		if sub.UntilEpoch > maxValidEpoch+1 {
 			return nil, status.Errorf(
 				codes.InvalidArgument,
 				"Epoch for subscription at index %d is too far in the future. It can be at most %d",
 				i,
-				maxValidEpoch,
+				maxValidEpoch+1,
 			)
 		}
 	}

--- a/beacon-chain/rpc/eth/validator/validator_test.go
+++ b/beacon-chain/rpc/eth/validator/validator_test.go
@@ -1101,8 +1101,6 @@ func TestSubmitSyncCommitteeSubscription(t *testing.T) {
 	require.NoError(t, err)
 	bs, err := sharedtestutil.GenesisBeaconState(context.Background(), deposits, 0, eth1Data)
 	require.NoError(t, err, "Could not set up genesis state")
-	// Set state to epoch 1.
-	require.NoError(t, bs.SetSlot(params.BeaconConfig().SlotsPerEpoch))
 	genesisRoot, err := genesis.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not get signing root")
 	roots := make([][]byte, params.BeaconConfig().SlotsPerHistoricalRoot)
@@ -1215,7 +1213,7 @@ func TestSubmitSyncCommitteeSubscription(t *testing.T) {
 				{
 					ValidatorIndex:       0,
 					SyncCommitteeIndices: []uint64{},
-					UntilEpoch:           params.BeaconConfig().EpochsPerSyncCommitteePeriod + 1,
+					UntilEpoch:           params.BeaconConfig().EpochsPerSyncCommitteePeriod + 2,
 				},
 			},
 		}

--- a/proto/eth/v2/validator.proto
+++ b/proto/eth/v2/validator.proto
@@ -65,7 +65,7 @@ message SyncCommitteeSubscription {
   // The sync committee indices to be subscribed to.
   repeated uint64 sync_committee_indices = 2;
 
-  // The final epoch that the specified validator requires the subscription for.
+  // The final epoch (exclusive value) that the specified validator requires the subscription for.
   uint64 until_epoch = 3 [(ethereum.eth.ext.cast_type) = "github.com/prysmaticlabs/eth2-types.Epoch"];
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

After some discussion on Discord, it has been decided that `until_epoch` used in `PrepareSyncCommitteeSubnets` will be exclusive: https://github.com/ethereum/beacon-APIs/pull/165/files. This PR introduces the necessary changes.

**Which issues(s) does this PR fix?**

Part of #7510
