### PR TITLE
Fail early if block and state are diff versions

### DIFF
--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -189,6 +189,10 @@ func ProcessBlockNoVerifyAnySig(
 		return nil, nil, err
 	}
 
+	if state.Version() != signed.Block().Version() {
+		return nil, nil, fmt.Errorf("state and block are different version. %d != %d", state.Version(), signed.Block().Version())
+	}
+
 	blk := signed.Block()
 	state, err := ProcessBlockForStateRoot(ctx, state, signed)
 	if err != nil {

--- a/beacon-chain/core/transition/transition_no_verify_sig_test.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig_test.go
@@ -159,3 +159,12 @@ func TestCalculateStateRootAltair_OK(t *testing.T) {
 	require.NoError(t, err)
 	require.DeepNotEqual(t, params.BeaconConfig().ZeroHash, r)
 }
+
+func TestProcessBlockDifferentVersion(t *testing.T) {
+	beaconState, _ := testutil.DeterministicGenesisState(t, 64) // Phase 0 state
+	_, block := createFullAltairBlockWithOperations(t)
+	wsb, err := wrapper.WrappedAltairSignedBeaconBlock(block) // Altair block
+	require.NoError(t, err)
+	_, _, err = transition.ProcessBlockNoVerifyAnySig(context.Background(), beaconState, wsb)
+	require.ErrorContains(t, "state and block are different version. 0 != 1", err)
+}


### PR DESCRIPTION
# Description

`ProcessBlockNoVerifyAnySig` should fail early if beacon state and beacon block are on different version. Currently, it fails late until it processes attestations and ends up with a confusing error message such as `AppendCurrentEpochAttestations is not supported for hard fork 1 beacon state`... etc 