### PR TITLE
CI: nostamp config for better cache hits

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -43,3 +43,7 @@ build --flaky_test_attempts=5
 
 # Disable flaky test detection for fuzzing.
 test:fuzz --flaky_test_attempts=1
+
+# Better caching
+build:nostamp --nostamp
+build:nostamp --workspace_status_command=./hack/workspace_status_ci.sh

--- a/hack/workspace_status_ci.sh
+++ b/hack/workspace_status_ci.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Note: The STABLE_ prefix will force a relink when the value changes when using rules_go x_defs.
+
+echo STABLE_GIT_COMMIT "continuous-integration"
+echo DATE "now"
+echo DATE_UNIX "0"
+echo DOCKER_TAG "ci-foo"
+echo STABLE_GIT_TAG "c1000deadbeef"


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Our continous integration uses a centralized cache server. However, many of the cache entries are missed when different agents have different STABLE stamp data.
This PR hardcodes these parameters such that the CI step can define `--config=nostamp` and have a much higher cache hit ratio.

**Which issues(s) does this PR fix?**

N/A - should improve PR build times

**Other notes for review**
