### PR TITLE
e2e: fix trace_sync http handler registration

### DIFF
--- a/testing/endtoend/components/tracing_sink.go
+++ b/testing/endtoend/components/tracing_sink.go
@@ -54,7 +54,7 @@ func (ts *TracingSink) Started() <-chan struct{} {
 func (ts *TracingSink) initializeSink() {
 	mux := &http.ServeMux{}
 	ts.server = &http.Server{
-		Addr: ts.endpoint,
+		Addr:    ts.endpoint,
 		Handler: mux,
 	}
 	defer func() {

--- a/testing/endtoend/components/tracing_sink.go
+++ b/testing/endtoend/components/tracing_sink.go
@@ -52,7 +52,11 @@ func (ts *TracingSink) Started() <-chan struct{} {
 
 // Initialize an http handler that writes all requests to a file.
 func (ts *TracingSink) initializeSink() {
-	ts.server = &http.Server{Addr: ts.endpoint}
+	mux := &http.ServeMux{}
+	ts.server = &http.Server{
+		Addr: ts.endpoint,
+		Handler: mux,
+	}
 	defer func() {
 		if err := ts.server.Close(); err != nil {
 			log.WithError(err).Error("Failed to close http server")
@@ -69,8 +73,7 @@ func (ts *TracingSink) initializeSink() {
 			log.WithError(err).Error("Could not close stdout file")
 		}
 	}
-
-	http.HandleFunc("/", func(_ http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/", func(_ http.ResponseWriter, r *http.Request) {
 		if err := captureRequest(stdOutFile, r); err != nil {
 			log.WithError(err).Error("Failed to capture http request")
 			return


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

When running the e2e test simultaneously (opposed to in parallel), the http server registers a global handler for "/" multiple times and leads to this panic.

```
panic: http: multiple registrations for /

goroutine 158739 [running]: 
net/http.(*ServeMux).Handle(0x1f86340, 0x16cc328, 0x1, 0x16eb840, 0xc000376550)
        GOROOT/src/net/http/server.go:2464 +0x2c5
net/http.(*ServeMux).HandleFunc(...)
        GOROOT/src/net/http/server.go:2501
net/http.HandleFunc(...)                                                       
        GOROOT/src/net/http/server.go:2513
github.com/prysmaticlabs/prysm/testing/endtoend/components.(*TracingSink).initializeSink(0xc0001bc880)
        testing/endtoend/components/tracing_sink.go:73 +0x36e
created by github.com/prysmaticlabs/prysm/testing/endtoend/components.(*TracingSink).Start                                                                                                   
        testing/endtoend/components/tracing_sink.go:43 +0x3f   
```

**Which issues(s) does this PR fix?**

See description.

**Other notes for review**

