### PR TITLE
Fix long running e2e altair exception for previous release

### DIFF
--- a/testing/endtoend/minimal_e2e_test.go
+++ b/testing/endtoend/minimal_e2e_test.go
@@ -29,16 +29,15 @@ func e2eMinimal(t *testing.T, usePrysmSh bool) {
 	// Run for 10 epochs if not in long-running to confirm long-running has no issues.
 	var err error
 	epochsToRun := 10
-	if usePrysmSh {
-		// If using prysm.sh, run for 6 epochs.
-		// TODO(#9166): remove this block once v2 changes are live.
-		epochsToRun = 6
-	}
-
 	epochStr, longRunning := os.LookupEnv("E2E_EPOCHS")
 	if longRunning {
 		epochsToRun, err = strconv.Atoi(epochStr)
 		require.NoError(t, err)
+	}
+	if usePrysmSh {
+		// If using prysm.sh, run for only 6 epochs.
+		// TODO(#9166): remove this block once v2 changes are live.
+		epochsToRun = 6
 	}
 	const tracingEndpoint = "127.0.0.1:9411"
 	evals := []types.Evaluator{


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Previous release is still not Altair aware, so we can only run the long running e2e up to the 6th epoch. 
The environment variable for E2E_EPOCHS was overriding the hardcoded limitation for previous release and causing long running e2e to hang forever.

**Which issues(s) does this PR fix?**

**Other notes for review**
