### PR TITLE
Bump Up Peers In Subnet

### DIFF
--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -179,6 +179,6 @@ var (
 	MinPeersPerSubnet = &cli.Uint64Flag{
 		Name:  "minimum-peers-per-subnet",
 		Usage: "Sets the minimum number of peers that a node will attempt to peer with that are subscribed to a subnet.",
-		Value: 4,
+		Value: 6,
 	}
 )


### PR DESCRIPTION
**What type of PR is this?**

Config Change

**What does this PR do? Why is it needed?**

- [x] Increases the default number of peers in a subnet from `4` to `6`. This will allow nodes
to target for a higher number of peers in a subnet.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
