### PR TITLE
Small changes in API Middleware

### DIFF
--- a/api/gateway/apimiddleware/api_middleware.go
+++ b/api/gateway/apimiddleware/api_middleware.go
@@ -26,11 +26,11 @@ type EndpointFactory interface {
 // Endpoint is a representation of an API HTTP endpoint that should be proxied by the middleware.
 type Endpoint struct {
 	Path               string          // The path of the HTTP endpoint.
+	GetResponse        interface{}     // The struct corresponding to the JSON structure used in a GET response.
 	PostRequest        interface{}     // The struct corresponding to the JSON structure used in a POST request.
 	PostResponse       interface{}     // The struct corresponding to the JSON structure used in a POST response.
 	RequestURLLiterals []string        // Names of URL parameters that should not be base64-encoded.
 	RequestQueryParams []QueryParam    // Query parameters of the request.
-	GetResponse        interface{}     // The struct corresponding to the JSON structure used in a GET response.
 	Err                ErrorJson       // The struct corresponding to the error that should be returned in case of a request failure.
 	Hooks              HookCollection  // A collection of functions that can be invoked at various stages of the request/response cycle.
 	CustomHandlers     []CustomHandler // Functions that will be executed instead of the default request/response behaviour.

--- a/beacon-chain/rpc/apimiddleware/custom_hooks.go
+++ b/beacon-chain/rpc/apimiddleware/custom_hooks.go
@@ -16,128 +16,156 @@ import (
 
 // https://ethereum.github.io/beacon-apis/#/Beacon/submitPoolAttestations expects posting a top-level array.
 // We make it more proto-friendly by wrapping it in a struct with a 'data' field.
-func wrapAttestationsArray(endpoint apimiddleware.Endpoint, _ http.ResponseWriter, req *http.Request) apimiddleware.ErrorJson {
+func wrapAttestationsArray(
+	endpoint apimiddleware.Endpoint,
+	_ http.ResponseWriter,
+	req *http.Request,
+) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
 	if _, ok := endpoint.PostRequest.(*submitAttestationRequestJson); ok {
 		atts := make([]*attestationJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&atts); err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
 		j := &submitAttestationRequestJson{Data: atts}
 		b, err := json.Marshal(j)
 		if err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
 		}
 		req.Body = ioutil.NopCloser(bytes.NewReader(b))
 	}
-	return nil
+	return true, nil
 }
 
 // Some endpoints e.g. https://ethereum.github.io/beacon-apis/#/Validator/getAttesterDuties expect posting a top-level array.
 // We make it more proto-friendly by wrapping it in a struct with an 'Index' field.
-func wrapValidatorIndicesArray(endpoint apimiddleware.Endpoint, _ http.ResponseWriter, req *http.Request) apimiddleware.ErrorJson {
+func wrapValidatorIndicesArray(
+	endpoint apimiddleware.Endpoint,
+	_ http.ResponseWriter,
+	req *http.Request,
+) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
 	if _, ok := endpoint.PostRequest.(*dutiesRequestJson); ok {
 		indices := make([]string, 0)
 		if err := json.NewDecoder(req.Body).Decode(&indices); err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
 		j := &dutiesRequestJson{Index: indices}
 		b, err := json.Marshal(j)
 		if err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
 		}
 		req.Body = ioutil.NopCloser(bytes.NewReader(b))
 	}
-	return nil
+	return true, nil
 }
 
 // https://ethereum.github.io/beacon-apis/#/Validator/publishAggregateAndProofs expects posting a top-level array.
 // We make it more proto-friendly by wrapping it in a struct with a 'data' field.
-func wrapSignedAggregateAndProofArray(endpoint apimiddleware.Endpoint, _ http.ResponseWriter, req *http.Request) apimiddleware.ErrorJson {
+func wrapSignedAggregateAndProofArray(
+	endpoint apimiddleware.Endpoint,
+	_ http.ResponseWriter,
+	req *http.Request,
+) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
 	if _, ok := endpoint.PostRequest.(*submitAggregateAndProofsRequestJson); ok {
 		data := make([]*signedAggregateAttestationAndProofJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
 		j := &submitAggregateAndProofsRequestJson{Data: data}
 		b, err := json.Marshal(j)
 		if err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
 		}
 		req.Body = ioutil.NopCloser(bytes.NewReader(b))
 	}
-	return nil
+	return true, nil
 }
 
 // https://ethereum.github.io/beacon-apis/#/Validator/prepareBeaconCommitteeSubnet expects posting a top-level array.
 // We make it more proto-friendly by wrapping it in a struct with a 'data' field.
-func wrapBeaconCommitteeSubscriptionsArray(endpoint apimiddleware.Endpoint, _ http.ResponseWriter, req *http.Request) apimiddleware.ErrorJson {
+func wrapBeaconCommitteeSubscriptionsArray(
+	endpoint apimiddleware.Endpoint,
+	_ http.ResponseWriter,
+	req *http.Request,
+) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
 	if _, ok := endpoint.PostRequest.(*submitBeaconCommitteeSubscriptionsRequestJson); ok {
 		data := make([]*beaconCommitteeSubscribeJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
 		j := &submitBeaconCommitteeSubscriptionsRequestJson{Data: data}
 		b, err := json.Marshal(j)
 		if err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
 		}
 		req.Body = ioutil.NopCloser(bytes.NewReader(b))
 	}
-	return nil
+	return true, nil
 }
 
 // https://ethereum.github.io/beacon-APIs/#/Validator/prepareSyncCommitteeSubnets expects posting a top-level array.
 // We make it more proto-friendly by wrapping it in a struct with a 'data' field.
-func wrapSyncCommitteeSubscriptionsArray(endpoint apimiddleware.Endpoint, _ http.ResponseWriter, req *http.Request) apimiddleware.ErrorJson {
+func wrapSyncCommitteeSubscriptionsArray(
+	endpoint apimiddleware.Endpoint,
+	_ http.ResponseWriter,
+	req *http.Request,
+) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
 	if _, ok := endpoint.PostRequest.(*submitSyncCommitteeSubscriptionRequestJson); ok {
 		data := make([]*syncCommitteeSubscriptionJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
 		j := &submitSyncCommitteeSubscriptionRequestJson{Data: data}
 		b, err := json.Marshal(j)
 		if err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
 		}
 		req.Body = ioutil.NopCloser(bytes.NewReader(b))
 	}
-	return nil
+	return true, nil
 }
 
 // https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolSyncCommitteeSignatures expects posting a top-level array.
 // We make it more proto-friendly by wrapping it in a struct with a 'data' field.
-func wrapSyncCommitteeSignaturesArray(endpoint apimiddleware.Endpoint, _ http.ResponseWriter, req *http.Request) apimiddleware.ErrorJson {
+func wrapSyncCommitteeSignaturesArray(
+	endpoint apimiddleware.Endpoint,
+	_ http.ResponseWriter,
+	req *http.Request,
+) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
 	if _, ok := endpoint.PostRequest.(*submitSyncCommitteeSignaturesRequestJson); ok {
 		data := make([]*syncCommitteeMessageJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
 		j := &submitSyncCommitteeSignaturesRequestJson{Data: data}
 		b, err := json.Marshal(j)
 		if err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
 		}
 		req.Body = ioutil.NopCloser(bytes.NewReader(b))
 	}
-	return nil
+	return true, nil
 }
 
 // https://ethereum.github.io/beacon-APIs/#/Validator/publishContributionAndProofs expects posting a top-level array.
 // We make it more proto-friendly by wrapping it in a struct with a 'data' field.
-func wrapSignedContributionAndProofsArray(endpoint apimiddleware.Endpoint, _ http.ResponseWriter, req *http.Request) apimiddleware.ErrorJson {
+func wrapSignedContributionAndProofsArray(
+	endpoint apimiddleware.Endpoint,
+	_ http.ResponseWriter,
+	req *http.Request,
+) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
 	if _, ok := endpoint.PostRequest.(*submitContributionAndProofsRequestJson); ok {
 		data := make([]*signedContributionAndProofJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
 		j := &submitContributionAndProofsRequestJson{Data: data}
 		b, err := json.Marshal(j)
 		if err != nil {
-			return apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
+			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
 		}
 		req.Body = ioutil.NopCloser(bytes.NewReader(b))
 	}
-	return nil
+	return true, nil
 }
 
 // Posted graffiti needs to have length of 32 bytes, but client is allowed to send data of any length.
@@ -164,7 +192,7 @@ type tempSyncSubcommitteeValidatorsJson struct {
 
 // https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.0.0#/Beacon/getEpochSyncCommittees returns validator_aggregates as a nested array.
 // grpc-gateway returns a struct with nested fields which we have to transform into a plain 2D array.
-func prepareValidatorAggregates(body []byte, responseContainer interface{}) (bool, apimiddleware.ErrorJson) {
+func prepareValidatorAggregates(body []byte, responseContainer interface{}) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
 	tempContainer := &tempSyncCommitteesResponseJson{}
 	if err := json.Unmarshal(body, tempContainer); err != nil {
 		return false, apimiddleware.InternalServerErrorWithMessage(err, "could not unmarshal response into temp container")
@@ -183,7 +211,7 @@ func prepareValidatorAggregates(body []byte, responseContainer interface{}) (boo
 		container.Data.ValidatorAggregates[i] = dstValAgg
 	}
 
-	return true, nil
+	return false, nil
 }
 
 type phase0BlockResponseJson struct {
@@ -196,7 +224,7 @@ type altairBlockResponseJson struct {
 	Data    *signedBeaconBlockAltairContainerJson `json:"data"`
 }
 
-func serializeV2Block(response interface{}) (bool, []byte, apimiddleware.ErrorJson) {
+func serializeV2Block(response interface{}) (apimiddleware.RunDefault, []byte, apimiddleware.ErrorJson) {
 	respContainer, ok := response.(*blockV2ResponseJson)
 	if !ok {
 		return false, nil, apimiddleware.InternalServerError(errors.New("container is not of the correct type"))
@@ -225,7 +253,7 @@ func serializeV2Block(response interface{}) (bool, []byte, apimiddleware.ErrorJs
 	if err != nil {
 		return false, nil, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal response")
 	}
-	return true, j, nil
+	return false, j, nil
 }
 
 type phase0StateResponseJson struct {
@@ -238,7 +266,7 @@ type altairStateResponseJson struct {
 	Data    *beaconStateV2Json `json:"data"`
 }
 
-func serializeV2State(response interface{}) (bool, []byte, apimiddleware.ErrorJson) {
+func serializeV2State(response interface{}) (apimiddleware.RunDefault, []byte, apimiddleware.ErrorJson) {
 	respContainer, ok := response.(*beaconStateV2ResponseJson)
 	if !ok {
 		return false, nil, apimiddleware.InternalServerError(errors.New("container is not of the correct type"))
@@ -261,7 +289,7 @@ func serializeV2State(response interface{}) (bool, []byte, apimiddleware.ErrorJs
 	if err != nil {
 		return false, nil, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal response")
 	}
-	return true, j, nil
+	return false, j, nil
 }
 
 type phase0ProduceBlockResponseJson struct {
@@ -274,7 +302,7 @@ type altairProduceBlockResponseJson struct {
 	Data    *beaconBlockAltairJson `json:"data"`
 }
 
-func serializeProducedV2Block(response interface{}) (bool, []byte, apimiddleware.ErrorJson) {
+func serializeProducedV2Block(response interface{}) (apimiddleware.RunDefault, []byte, apimiddleware.ErrorJson) {
 	respContainer, ok := response.(*produceBlockResponseV2Json)
 	if !ok {
 		return false, nil, apimiddleware.InternalServerError(errors.New("container is not of the correct type"))
@@ -297,5 +325,5 @@ func serializeProducedV2Block(response interface{}) (bool, []byte, apimiddleware
 	if err != nil {
 		return false, nil, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal response")
 	}
-	return true, j, nil
+	return false, j, nil
 }

--- a/beacon-chain/rpc/apimiddleware/custom_hooks_test.go
+++ b/beacon-chain/rpc/apimiddleware/custom_hooks_test.go
@@ -30,8 +30,9 @@ func TestWrapAttestationArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapAttestationsArray(endpoint, nil, request)
+		runDefault, errJson := wrapAttestationsArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
 		wrappedAtts := &submitAttestationRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedAtts))
 		require.Equal(t, 1, len(wrappedAtts.Data), "wrong number of wrapped items")
@@ -47,8 +48,9 @@ func TestWrapAttestationArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapAttestationsArray(endpoint, nil, request)
+		runDefault, errJson := wrapAttestationsArray(endpoint, nil, request)
 		require.Equal(t, false, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "could not decode body"))
 		assert.Equal(t, http.StatusInternalServerError, errJson.StatusCode())
 	})
@@ -68,13 +70,30 @@ func TestWrapValidatorIndicesArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapValidatorIndicesArray(endpoint, nil, request)
+		runDefault, errJson := wrapValidatorIndicesArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
 		wrappedIndices := &dutiesRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedIndices))
 		require.Equal(t, 2, len(wrappedIndices.Index), "wrong number of wrapped items")
 		assert.Equal(t, "1", wrappedIndices.Index[0])
 		assert.Equal(t, "2", wrappedIndices.Index[1])
+	})
+
+	t.Run("invalid_body", func(t *testing.T) {
+		endpoint := apimiddleware.Endpoint{
+			PostRequest: &dutiesRequestJson{},
+		}
+		var body bytes.Buffer
+		_, err := body.Write([]byte("invalid"))
+		require.NoError(t, err)
+		request := httptest.NewRequest("POST", "http://foo.example", &body)
+
+		runDefault, errJson := wrapValidatorIndicesArray(endpoint, nil, request)
+		require.Equal(t, false, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(false), runDefault)
+		assert.Equal(t, true, strings.Contains(errJson.Msg(), "could not decode body"))
+		assert.Equal(t, http.StatusInternalServerError, errJson.StatusCode())
 	})
 }
 
@@ -92,8 +111,9 @@ func TestWrapSignedAggregateAndProofArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapSignedAggregateAndProofArray(endpoint, nil, request)
+		runDefault, errJson := wrapSignedAggregateAndProofArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
 		wrappedAggs := &submitAggregateAndProofsRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedAggs))
 		require.Equal(t, 1, len(wrappedAggs.Data), "wrong number of wrapped items")
@@ -109,8 +129,9 @@ func TestWrapSignedAggregateAndProofArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapSignedAggregateAndProofArray(endpoint, nil, request)
+		runDefault, errJson := wrapSignedAggregateAndProofArray(endpoint, nil, request)
 		require.Equal(t, false, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "could not decode body"))
 		assert.Equal(t, http.StatusInternalServerError, errJson.StatusCode())
 	})
@@ -136,8 +157,9 @@ func TestWrapBeaconCommitteeSubscriptionsArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapBeaconCommitteeSubscriptionsArray(endpoint, nil, request)
+		runDefault, errJson := wrapBeaconCommitteeSubscriptionsArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
 		wrappedSubs := &submitBeaconCommitteeSubscriptionsRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedSubs))
 		require.Equal(t, 1, len(wrappedSubs.Data), "wrong number of wrapped items")
@@ -157,8 +179,9 @@ func TestWrapBeaconCommitteeSubscriptionsArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapBeaconCommitteeSubscriptionsArray(endpoint, nil, request)
+		runDefault, errJson := wrapBeaconCommitteeSubscriptionsArray(endpoint, nil, request)
 		require.Equal(t, false, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "could not decode body"))
 		assert.Equal(t, http.StatusInternalServerError, errJson.StatusCode())
 	})
@@ -189,8 +212,9 @@ func TestWrapSyncCommitteeSubscriptionsArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapSyncCommitteeSubscriptionsArray(endpoint, nil, request)
+		runDefault, errJson := wrapSyncCommitteeSubscriptionsArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
 		wrappedSubs := &submitSyncCommitteeSubscriptionRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedSubs))
 		require.Equal(t, 2, len(wrappedSubs.Data), "wrong number of wrapped items")
@@ -210,8 +234,9 @@ func TestWrapSyncCommitteeSubscriptionsArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapSyncCommitteeSubscriptionsArray(endpoint, nil, request)
+		runDefault, errJson := wrapSyncCommitteeSubscriptionsArray(endpoint, nil, request)
 		require.Equal(t, false, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "could not decode body"))
 		assert.Equal(t, http.StatusInternalServerError, errJson.StatusCode())
 	})
@@ -236,8 +261,9 @@ func TestWrapSyncCommitteeSignaturesArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapSyncCommitteeSignaturesArray(endpoint, nil, request)
+		runDefault, errJson := wrapSyncCommitteeSignaturesArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
 		wrappedSigs := &submitSyncCommitteeSignaturesRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedSigs))
 		require.Equal(t, 1, len(wrappedSigs.Data), "wrong number of wrapped items")
@@ -256,8 +282,9 @@ func TestWrapSyncCommitteeSignaturesArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapSyncCommitteeSignaturesArray(endpoint, nil, request)
+		runDefault, errJson := wrapSyncCommitteeSignaturesArray(endpoint, nil, request)
 		require.Equal(t, false, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "could not decode body"))
 		assert.Equal(t, http.StatusInternalServerError, errJson.StatusCode())
 	})
@@ -296,8 +323,9 @@ func TestWrapSignedContributionAndProofsArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapSignedContributionAndProofsArray(endpoint, nil, request)
+		runDefault, errJson := wrapSignedContributionAndProofsArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
 		wrapped := &submitContributionAndProofsRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrapped))
 		require.Equal(t, 2, len(wrapped.Data), "wrong number of wrapped items")
@@ -323,8 +351,9 @@ func TestWrapSignedContributionAndProofsArray(t *testing.T) {
 		require.NoError(t, err)
 		request := httptest.NewRequest("POST", "http://foo.example", &body)
 
-		errJson := wrapSignedContributionAndProofsArray(endpoint, nil, request)
+		runDefault, errJson := wrapSignedContributionAndProofsArray(endpoint, nil, request)
 		require.Equal(t, false, errJson == nil)
+		assert.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "could not decode body"))
 		assert.Equal(t, http.StatusInternalServerError, errJson.StatusCode())
 	})
@@ -391,9 +420,9 @@ func TestPrepareValidatorAggregates(t *testing.T) {
 	require.NoError(t, err)
 
 	container := &syncCommitteesResponseJson{}
-	handled, errJson := prepareValidatorAggregates(bodyJson, container)
+	runDefault, errJson := prepareValidatorAggregates(bodyJson, container)
 	require.Equal(t, nil, errJson)
-	require.Equal(t, true, handled)
+	require.Equal(t, apimiddleware.RunDefault(false), runDefault)
 	assert.DeepEqual(t, []string{"1", "2"}, container.Data.Validators)
 	require.DeepEqual(t, [][]string{{"3", "4"}, {"5"}}, container.Data.ValidatorAggregates)
 }
@@ -414,9 +443,9 @@ func TestSerializeV2Block(t *testing.T) {
 				Signature:   "sig",
 			},
 		}
-		ok, j, errJson := serializeV2Block(response)
+		runDefault, j, errJson := serializeV2Block(response)
 		require.Equal(t, nil, errJson)
-		require.Equal(t, true, ok)
+		require.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		require.NotNil(t, j)
 		resp := &phase0BlockResponseJson{}
 		require.NoError(t, json.Unmarshal(j, resp))
@@ -445,9 +474,9 @@ func TestSerializeV2Block(t *testing.T) {
 				Signature: "sig",
 			},
 		}
-		ok, j, errJson := serializeV2Block(response)
+		runDefault, j, errJson := serializeV2Block(response)
 		require.Equal(t, nil, errJson)
-		require.Equal(t, true, ok)
+		require.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		require.NotNil(t, j)
 		resp := &altairBlockResponseJson{}
 		require.NoError(t, json.Unmarshal(j, resp))
@@ -463,8 +492,8 @@ func TestSerializeV2Block(t *testing.T) {
 
 	t.Run("incorrect response type", func(t *testing.T) {
 		response := &types.Empty{}
-		ok, j, errJson := serializeV2Block(response)
-		require.Equal(t, false, ok)
+		runDefault, j, errJson := serializeV2Block(response)
+		require.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		require.Equal(t, 0, len(j))
 		require.NotNil(t, errJson)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "container is not of the correct type"))
@@ -480,9 +509,9 @@ func TestSerializeV2State(t *testing.T) {
 				AltairState: nil,
 			},
 		}
-		ok, j, errJson := serializeV2State(response)
+		runDefault, j, errJson := serializeV2State(response)
 		require.Equal(t, nil, errJson)
-		require.Equal(t, true, ok)
+		require.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		require.NotNil(t, j)
 		require.NoError(t, json.Unmarshal(j, &phase0StateResponseJson{}))
 	})
@@ -495,16 +524,16 @@ func TestSerializeV2State(t *testing.T) {
 				AltairState: &beaconStateV2Json{},
 			},
 		}
-		ok, j, errJson := serializeV2State(response)
+		runDefault, j, errJson := serializeV2State(response)
 		require.Equal(t, nil, errJson)
-		require.Equal(t, true, ok)
+		require.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		require.NotNil(t, j)
 		require.NoError(t, json.Unmarshal(j, &altairStateResponseJson{}))
 	})
 
 	t.Run("incorrect response type", func(t *testing.T) {
-		ok, j, errJson := serializeV2State(&types.Empty{})
-		require.Equal(t, false, ok)
+		runDefault, j, errJson := serializeV2State(&types.Empty{})
+		require.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		require.Equal(t, 0, len(j))
 		require.NotNil(t, errJson)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "container is not of the correct type"))
@@ -526,9 +555,9 @@ func TestSerializeProduceV2Block(t *testing.T) {
 				AltairBlock: nil,
 			},
 		}
-		ok, j, errJson := serializeProducedV2Block(response)
+		runDefault, j, errJson := serializeProducedV2Block(response)
 		require.Equal(t, nil, errJson)
-		require.Equal(t, true, ok)
+		require.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		require.NotNil(t, j)
 		resp := &phase0ProduceBlockResponseJson{}
 		require.NoError(t, json.Unmarshal(j, resp))
@@ -556,9 +585,9 @@ func TestSerializeProduceV2Block(t *testing.T) {
 				},
 			},
 		}
-		ok, j, errJson := serializeProducedV2Block(response)
+		runDefault, j, errJson := serializeProducedV2Block(response)
 		require.Equal(t, nil, errJson)
-		require.Equal(t, true, ok)
+		require.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		require.NotNil(t, j)
 		resp := &altairProduceBlockResponseJson{}
 		require.NoError(t, json.Unmarshal(j, resp))
@@ -574,8 +603,8 @@ func TestSerializeProduceV2Block(t *testing.T) {
 
 	t.Run("incorrect response type", func(t *testing.T) {
 		response := &types.Empty{}
-		ok, j, errJson := serializeProducedV2Block(response)
-		require.Equal(t, false, ok)
+		runDefault, j, errJson := serializeProducedV2Block(response)
+		require.Equal(t, apimiddleware.RunDefault(false), runDefault)
 		require.Equal(t, 0, len(j))
 		require.NotNil(t, errJson)
 		assert.Equal(t, true, strings.Contains(errJson.Msg(), "container is not of the correct type"))


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

- Adds a custom `RunDefault` type which is an alias for `bool`. This is done to improve readability.
- Unifies pre hooks, so that they can all specify whether to run the default logic. 
- Adds a missing unit test.
- Reorder `Endpoint` fields for better readability.
