### PR TITLE
Fix error handing for block v2 endpoints

### DIFF
--- a/beacon-chain/rpc/eth/beacon/blocks.go
+++ b/beacon-chain/rpc/eth/beacon/blocks.go
@@ -233,8 +233,9 @@ func (bs *Server) GetBlockV2(ctx context.Context, req *ethpbv2.BlockRequestV2) (
 	defer span.End()
 
 	blk, phase0Blk, err := bs.blocksFromId(ctx, req.BlockId)
+	err = handleGetBlock(blk, err)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get block: %v", err)
+		return nil, err
 	}
 	if phase0Blk != nil {
 		v1Blk, err := migration.SignedBeaconBlock(blk)
@@ -272,8 +273,9 @@ func (bs *Server) GetBlockSSZV2(ctx context.Context, req *ethpbv2.BlockRequestV2
 	defer span.End()
 
 	blk, phase0Blk, err := bs.blocksFromId(ctx, req.BlockId)
+	err = handleGetBlock(blk, err)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get block: %v", err)
+		return nil, err
 	}
 	if phase0Blk != nil {
 		signedBeaconBlock, err := migration.SignedBeaconBlock(blk)

--- a/beacon-chain/rpc/eth/beacon/blocks.go
+++ b/beacon-chain/rpc/eth/beacon/blocks.go
@@ -46,7 +46,7 @@ func (bs *Server) GetBlockHeader(ctx context.Context, req *ethpbv1.BlockRequest)
 	defer span.End()
 
 	blk, err := bs.blockFromBlockID(ctx, req.BlockId)
-	err = handleGetBlock(blk, err)
+	err = handleGetBlockError(blk, err)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (bs *Server) GetBlock(ctx context.Context, req *ethpbv1.BlockRequest) (*eth
 	defer span.End()
 
 	blk, err := bs.blockFromBlockID(ctx, req.BlockId)
-	err = handleGetBlock(blk, err)
+	err = handleGetBlockError(blk, err)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (bs *Server) GetBlockSSZ(ctx context.Context, req *ethpbv1.BlockRequest) (*
 	defer span.End()
 
 	blk, err := bs.blockFromBlockID(ctx, req.BlockId)
-	err = handleGetBlock(blk, err)
+	err = handleGetBlockError(blk, err)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (bs *Server) GetBlockV2(ctx context.Context, req *ethpbv2.BlockRequestV2) (
 	defer span.End()
 
 	blk, phase0Blk, err := bs.blocksFromId(ctx, req.BlockId)
-	err = handleGetBlock(blk, err)
+	err = handleGetBlockError(blk, err)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ func (bs *Server) GetBlockSSZV2(ctx context.Context, req *ethpbv2.BlockRequestV2
 	defer span.End()
 
 	blk, phase0Blk, err := bs.blocksFromId(ctx, req.BlockId)
-	err = handleGetBlock(blk, err)
+	err = handleGetBlockError(blk, err)
 	if err != nil {
 		return nil, err
 	}
@@ -424,7 +424,7 @@ func (bs *Server) blocksFromId(ctx context.Context, blockId []byte) (
 	err error,
 ) {
 	blk, err := bs.blockFromBlockID(ctx, blockId)
-	err = handleGetBlock(blk, err)
+	err = handleGetBlockError(blk, err)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -502,7 +502,7 @@ func (bs *Server) blockFromBlockID(ctx context.Context, blockId []byte) (block.S
 	return blk, nil
 }
 
-func handleGetBlock(blk block.SignedBeaconBlock, err error) error {
+func handleGetBlockError(blk block.SignedBeaconBlock, err error) error {
 	if invalidBlockIdErr, ok := err.(*blockIdParseError); ok {
 		return status.Errorf(codes.InvalidArgument, "Invalid block ID: %v", invalidBlockIdErr)
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Block v2 endpoints did not correctly handle errors when fetching a block. They always returned the `Internal` status code.