### PR TITLE
Correct the semantics of `startEpoch` calculation in `registerSyncSubnet`

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/assignments.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/assignments.go
@@ -280,7 +280,7 @@ func registerSyncSubnet(currEpoch types.Epoch, syncPeriod uint64, pubkey []byte,
 	if status != ethpb.ValidatorStatus_ACTIVE && status != ethpb.ValidatorStatus_EXITING {
 		return
 	}
-	startEpoch := types.Epoch(syncPeriod) * params.BeaconConfig().EpochsPerSyncCommitteePeriod
+	startEpoch := types.Epoch(syncPeriod * uint64(params.BeaconConfig().EpochsPerSyncCommitteePeriod))
 	currPeriod := core.SyncCommitteePeriod(currEpoch)
 	endEpoch := startEpoch + params.BeaconConfig().EpochsPerSyncCommitteePeriod
 	_, _, ok, expTime := cache.SyncSubnetIDs.GetSyncCommitteeSubnets(pubkey, startEpoch)


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The way we calculate the start epoch in `registerSyncSubnet` is semantically incorrect because we convert a period to an epoch, which doesn't make sense. It threw me off a little when doing some API work.

Related: https://discord.com/channels/476244492043812875/483017808658169866/882552736778973184
