### PR TITLE
Remove `fmt.Println` from committee cache

### DIFF
--- a/beacon-chain/cache/committee.go
+++ b/beacon-chain/cache/committee.go
@@ -5,7 +5,6 @@ package cache
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -122,7 +121,6 @@ func (c *CommitteeCache) ActiveIndices(ctx context.Context, seed [32]byte) ([]ty
 	if exists {
 		CommitteeCacheHit.Inc()
 	} else {
-		fmt.Println("cache miss active indices")
 		CommitteeCacheMiss.Inc()
 		return nil, nil
 	}


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

Removes an `fmt.Println` call from production code.