### PR TITLE
E2e test: stricter participation check

### DIFF
--- a/testing/endtoend/evaluators/metrics.go
+++ b/testing/endtoend/evaluators/metrics.go
@@ -122,7 +122,7 @@ func metricsTest(conns ...*grpc.ClientConn) error {
 		}
 		timeSlot := slots.SlotsSinceGenesis(genesisResp.GenesisTime.AsTime())
 		if uint64(chainHead.HeadSlot) != uint64(timeSlot) {
-			return fmt.Errorf("expected metrics slot to equal chain head slot, expected %d, received %d", chainHead.HeadSlot, timeSlot)
+			return fmt.Errorf("expected metrics slot to equal chain head slot, expected %d, received %d", timeSlot, chainHead.HeadSlot)
 		}
 
 		for _, test := range metricLessThanTests {

--- a/testing/endtoend/evaluators/validator.go
+++ b/testing/endtoend/evaluators/validator.go
@@ -16,9 +16,9 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
-var expectedParticipation = 0.95 // 95% participation to make room for minor issues.
+var expectedParticipation = float64(1)
 
-var expectedSyncParticipation = 0.95 // 95% participation for sync committee members.
+var expectedSyncParticipation = float64(1)
 
 // ValidatorsAreActive ensures the expected amount of validators are active.
 var ValidatorsAreActive = types.Evaluator{


### PR DESCRIPTION
# Description

Up both attestation and sync aggregate participation requirement from 95% to 100%. There's no legitimate reason why e2e tests can't achieve 100% for both, whilst it's easy to hide potential bugs when it settles for less