### PR TITLE
eth2 api: use balance instead of effective balance

### DIFF
--- a/beacon-chain/rpc/eth/beacon/validator.go
+++ b/beacon-chain/rpc/eth/beacon/validator.go
@@ -191,9 +191,9 @@ func (bs *Server) ListCommittees(ctx context.Context, req *ethpb.StateCommittees
 func valContainersByRequestIds(state state.BeaconState, validatorIds [][]byte) ([]*ethpb.ValidatorContainer, error) {
 	epoch := slots.ToEpoch(state.Slot())
 	var valContainers []*ethpb.ValidatorContainer
+	allBalances := state.Balances()
 	if len(validatorIds) == 0 {
 		allValidators := state.Validators()
-		allBalances := state.Balances()
 		valContainers = make([]*ethpb.ValidatorContainer, len(allValidators))
 		for i, validator := range allValidators {
 			readOnlyVal, err := v1.NewValidator(validator)
@@ -249,7 +249,7 @@ func valContainersByRequestIds(state state.BeaconState, validatorIds [][]byte) (
 			}
 			valContainers = append(valContainers, &ethpb.ValidatorContainer{
 				Index:     valIndex,
-				Balance:   v1Validator.EffectiveBalance,
+				Balance:   allBalances[valIndex],
 				Status:    subStatus,
 				Validator: v1Validator,
 			})

--- a/beacon-chain/rpc/eth/beacon/validator_test.go
+++ b/beacon-chain/rpc/eth/beacon/validator_test.go
@@ -438,7 +438,13 @@ func TestListValidatorBalances(t *testing.T) {
 	ctx := context.Background()
 
 	var st state.BeaconState
-	st, _ = util.DeterministicGenesisState(t, 8192)
+	count := uint64(8192)
+	st, _ = util.DeterministicGenesisState(t, count)
+	balances := make([]uint64, count)
+	for i := uint64(0); i < count; i++ {
+		balances[i] = i
+	}
+	require.NoError(t, st.SetBalances(balances))
 
 	t.Run("Head List Validators Balance by index", func(t *testing.T) {
 		s := Server{
@@ -456,7 +462,7 @@ func TestListValidatorBalances(t *testing.T) {
 		require.NoError(t, err)
 		for i, val := range resp.Data {
 			assert.Equal(t, idNums[i], val.Index)
-			assert.Equal(t, params.BeaconConfig().MaxEffectiveBalance, val.Balance)
+			assert.Equal(t, balances[val.Index], val.Balance)
 		}
 	})
 
@@ -479,7 +485,7 @@ func TestListValidatorBalances(t *testing.T) {
 		require.NoError(t, err)
 		for i, val := range resp.Data {
 			assert.Equal(t, idNums[i], val.Index)
-			assert.Equal(t, params.BeaconConfig().MaxEffectiveBalance, val.Balance)
+			assert.Equal(t, balances[val.Index], val.Balance)
 		}
 	})
 
@@ -501,7 +507,7 @@ func TestListValidatorBalances(t *testing.T) {
 		require.NoError(t, err)
 		for i, val := range resp.Data {
 			assert.Equal(t, idNums[i], val.Index)
-			assert.Equal(t, params.BeaconConfig().MaxEffectiveBalance, val.Balance)
+			assert.Equal(t, balances[val.Index], val.Balance)
 		}
 	})
 }


### PR DESCRIPTION
Fixes #9721

Use balance instead of effective balance for `/eth/v1/beacon/states/{state_id}/validators` and `/eth/v1/beacon/states/{state_id}/validator_balances` end points