### PR TITLE
Pin Base Images 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -76,9 +76,9 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "59d5b42ac315e7eadffa944e86e90c2990110a1c8075f1cd145f487e999d22b3",
-    strip_prefix = "rules_docker-0.17.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.17.0/rules_docker-v0.17.0.tar.gz"],
+    sha256 = "1f4e59843b61981a96835dc4ac377ad4da9f8c334ebe5e0bb3f58f80c09735f4",
+    strip_prefix = "rules_docker-0.19.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.19.0/rules_docker-v0.19.0.tar.gz"],
 )
 
 http_archive(
@@ -137,6 +137,34 @@ container_repositories()
 load(
     "@io_bazel_rules_docker//container:container.bzl",
     "container_pull",
+)
+
+container_pull(
+    name = "cc_image_base",
+    digest = "sha256:2c4bb6b7236db0a55ec54ba8845e4031f5db2be957ac61867872bf42e56c4deb",
+    registry = "gcr.io",
+    repository = "distroless/cc",
+)
+
+container_pull(
+    name = "cc_debug_image_base",
+    digest = "sha256:3680c61e81f68fc00bfb5e1ec65e8e678aaafa7c5f056bc2681c29527ebbb30c",
+    registry = "gcr.io",
+    repository = "distroless/cc",
+)
+
+container_pull(
+    name = "go_image_base",
+    digest = "sha256:ba7a315f86771332e76fa9c3d423ecfdbb8265879c6f1c264d6fff7d4fa460a4",
+    registry = "gcr.io",
+    repository = "distroless/base",
+)
+
+container_pull(
+    name = "go_debug_image_base",
+    digest = "sha256:efd8711717d9e9b5d0dbb20ea10876dab0609c923bc05321b912f9239090ca80",
+    registry = "gcr.io",
+    repository = "distroless/base",
 )
 
 container_pull(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_docker//contrib:passwd.bzl", "passwd_entry", "passwd_file")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//cc:image.bzl", CC_DEFAULT_BASE = "DEFAULT_BASE")
-load("@io_bazel_rules_docker//go:image.bzl", GO_DEFAULT_BASE = "DEFAULT_BASE")
 load("//tools:build_settings.bzl", "base_image")
 
 sh_binary(
@@ -49,6 +47,20 @@ pkg_tar(
     package_dir = "etc",
     tags = ["manual"],
 )
+
+CC_DEFAULT_BASE = select({
+    "@io_bazel_rules_docker//:debug": "@cc_debug_image_base//image",
+    "@io_bazel_rules_docker//:fastbuild": "@cc_image_base//image",
+    "@io_bazel_rules_docker//:optimized": "@cc_image_base//image",
+    "//conditions:default": "@cc_image_base//image",
+})
+
+GO_DEFAULT_BASE = select({
+    "@io_bazel_rules_docker//:debug": "@go_debug_image_base//image",
+    "@io_bazel_rules_docker//:fastbuild": "@go_image_base//image",
+    "@io_bazel_rules_docker//:optimized": "@go_image_base//image",
+    "//conditions:default": "@go_image_base//image",
+})
 
 # Include it in our base image as a tar.
 container_image(


### PR DESCRIPTION
**What type of PR is this?**

Clean Up 

**What does this PR do? Why is it needed?**

- [x] Fixes the distroless images instead of relying on `rules_docker` to constantly have them updated. This allows us to update
the images as we see fit instead of waiting for a it from upstream. 

**Which issues(s) does this PR fix?**

Fixes #9674 

**Other notes for review**
