### PR TITLE
Web UI Fix for Prysm V2.0.0

### DIFF
--- a/api/gateway/gateway.go
+++ b/api/gateway/gateway.go
@@ -133,7 +133,7 @@ func (g *Gateway) Start() {
 	corsMux := g.corsMiddleware(g.router)
 
 	if g.muxHandler != nil {
-		g.router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		g.router.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			g.muxHandler(corsMux, w, r)
 		})
 	}


### PR DESCRIPTION
V2.0.0 of Prysm migrated to using gorilla/mux instead of net/http for a default handler for our web UI and various aspects of our grpc gateway. Gorilla has a different way of handling wildcard paths compared to the stdlib. In gorilla, we need to do:

```
g.router.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
	g.muxHandler(corsMux, w, r)
})
```
Instead of
```
g.router.HandlerFunc("/", func(w http.ResponseWriter, r *http.Request) {
	g.muxHandler(corsMux, w, r)
})
```
This PR fixes the problem and allows the web ui to load