### PR TITLE
Bring Eth2FastAggregateVerify Inline With the Spec

### DIFF
--- a/crypto/bls/blst/signature.go
+++ b/crypto/bls/blst/signature.go
@@ -118,7 +118,11 @@ func (s *Signature) FastAggregateVerify(pubKeys []common.PublicKey, msg [32]byte
 	if len(pubKeys) == 0 {
 		return false
 	}
-	return s.innerFastAggregateVerify(pubKeys, msg)
+	rawKeys := make([]*blstPublicKey, len(pubKeys))
+	for i := 0; i < len(pubKeys); i++ {
+		rawKeys[i] = pubKeys[i].(*PublicKey).p
+	}
+	return s.s.FastAggregateVerify(true, rawKeys, msg[:], dst)
 }
 
 // Eth2FastAggregateVerify implements a wrapper on top of bls's FastAggregateVerify. It accepts G2_POINT_AT_INFINITY signature
@@ -139,19 +143,7 @@ func (s *Signature) Eth2FastAggregateVerify(pubKeys []common.PublicKey, msg [32]
 	if len(pubKeys) == 0 && bytes.Equal(s.Marshal(), common.InfiniteSignature[:]) {
 		return true
 	}
-	// Return early if we encounter an empty pubkey list.
-	if len(pubKeys) == 0 {
-		return false
-	}
-	return s.innerFastAggregateVerify(pubKeys, msg)
-}
-
-func (s *Signature) innerFastAggregateVerify(pubKeys []common.PublicKey, msg [32]byte) bool {
-	rawKeys := make([]*blstPublicKey, len(pubKeys))
-	for i := 0; i < len(pubKeys); i++ {
-		rawKeys[i] = pubKeys[i].(*PublicKey).p
-	}
-	return s.s.FastAggregateVerify(true, rawKeys, msg[:], dst)
+	return s.FastAggregateVerify(pubKeys, msg)
 }
 
 // NewAggregateSignature creates a blank aggregate signature.

--- a/crypto/bls/blst/signature.go
+++ b/crypto/bls/blst/signature.go
@@ -139,6 +139,10 @@ func (s *Signature) Eth2FastAggregateVerify(pubKeys []common.PublicKey, msg [32]
 	if len(pubKeys) == 0 && bytes.Equal(s.Marshal(), common.InfiniteSignature[:]) {
 		return true
 	}
+	// Return early if we encounter an empty pubkey list.
+	if len(pubKeys) == 0 {
+		return false
+	}
 	return s.innerFastAggregateVerify(pubKeys, msg)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Security Cleanup

**What does this PR do? Why is it needed?**

- [x] Remove `innerFastAggregateVerify` and instead simply call `FastAggregateVerify` to be inline with the spec more closely. This results in an extra call to check `SkipBLSVerify` , but it is fine for the current case.  

**Which issues(s) does this PR fix?**

Fixes #9737 

**Other notes for review**
