### PR TITLE
Use BLS signature length config value

### DIFF
--- a/beacon-chain/core/blocks/attestation_test.go
+++ b/beacon-chain/core/blocks/attestation_test.go
@@ -271,7 +271,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 				Source: &ethpb.Checkpoint{},
 			}),
 			AttestingIndices: []uint64{1},
-			Signature:        make([]byte, 96),
+			Signature:        make([]byte, params.BeaconConfig().BLSSignatureLength),
 		}},
 		{attestation: &ethpb.IndexedAttestation{
 			Data: util.HydrateAttestationData(&ethpb.AttestationData{
@@ -280,7 +280,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 				},
 			}),
 			AttestingIndices: []uint64{47, 99, 101},
-			Signature:        make([]byte, 96),
+			Signature:        make([]byte, params.BeaconConfig().BLSSignatureLength),
 		}},
 		{attestation: &ethpb.IndexedAttestation{
 			Data: util.HydrateAttestationData(&ethpb.AttestationData{
@@ -289,7 +289,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 				},
 			}),
 			AttestingIndices: []uint64{21, 72},
-			Signature:        make([]byte, 96),
+			Signature:        make([]byte, params.BeaconConfig().BLSSignatureLength),
 		}},
 		{attestation: &ethpb.IndexedAttestation{
 			Data: util.HydrateAttestationData(&ethpb.AttestationData{
@@ -298,7 +298,7 @@ func TestVerifyIndexedAttestation_OK(t *testing.T) {
 				},
 			}),
 			AttestingIndices: []uint64{100, 121, 122},
-			Signature:        make([]byte, 96),
+			Signature:        make([]byte, params.BeaconConfig().BLSSignatureLength),
 		}},
 	}
 

--- a/beacon-chain/core/blocks/deposit_test.go
+++ b/beacon-chain/core/blocks/deposit_test.go
@@ -60,7 +60,7 @@ func TestProcessDeposits_MerkleBranchFailsVerification(t *testing.T) {
 		Data: &ethpb.Deposit_Data{
 			PublicKey:             bytesutil.PadTo([]byte{1, 2, 3}, 48),
 			WithdrawalCredentials: make([]byte, 32),
-			Signature:             make([]byte, 96),
+			Signature:             make([]byte, params.BeaconConfig().BLSSignatureLength),
 		},
 	}
 	leaf, err := deposit.Data.HashTreeRoot()
@@ -139,7 +139,7 @@ func TestProcessDeposits_RepeatedDeposit_IncreasesValidatorBalance(t *testing.T)
 			PublicKey:             sk.PublicKey().Marshal(),
 			Amount:                1000,
 			WithdrawalCredentials: make([]byte, 32),
-			Signature:             make([]byte, 96),
+			Signature:             make([]byte, params.BeaconConfig().BLSSignatureLength),
 		},
 	}
 	sr, err := signing.ComputeSigningRoot(deposit.Data, bytesutil.ToBytes(3, 32))

--- a/beacon-chain/core/blocks/genesis.go
+++ b/beacon-chain/core/blocks/genesis.go
@@ -16,7 +16,7 @@ func NewGenesisBlock(stateRoot []byte) *ethpb.SignedBeaconBlock {
 			ParentRoot: zeroHash,
 			StateRoot:  bytesutil.PadTo(stateRoot, 32),
 			Body: &ethpb.BeaconBlockBody{
-				RandaoReveal: make([]byte, 96),
+				RandaoReveal: make([]byte, params.BeaconConfig().BLSSignatureLength),
 				Eth1Data: &ethpb.Eth1Data{
 					DepositRoot: make([]byte, 32),
 					BlockHash:   make([]byte, 32),

--- a/beacon-chain/core/blocks/proposer_slashing_test.go
+++ b/beacon-chain/core/blocks/proposer_slashing_test.go
@@ -105,7 +105,7 @@ func TestProcessProposerSlashings_ValidatorNotSlashable(t *testing.T) {
 					Slot:          0,
 					BodyRoot:      []byte("foo"),
 				},
-				Signature: bytesutil.PadTo([]byte("A"), 96),
+				Signature: bytesutil.PadTo([]byte("A"), params.BeaconConfig().BLSSignatureLength),
 			},
 			Header_2: &ethpb.SignedBeaconBlockHeader{
 				Header: &ethpb.BeaconBlockHeader{
@@ -113,7 +113,7 @@ func TestProcessProposerSlashings_ValidatorNotSlashable(t *testing.T) {
 					Slot:          0,
 					BodyRoot:      []byte("bar"),
 				},
-				Signature: bytesutil.PadTo([]byte("B"), 96),
+				Signature: bytesutil.PadTo([]byte("B"), params.BeaconConfig().BLSSignatureLength),
 			},
 		},
 	}

--- a/beacon-chain/operations/attestations/kv/unaggregated_test.go
+++ b/beacon-chain/operations/attestations/kv/unaggregated_test.go
@@ -9,6 +9,7 @@ import (
 	fssz "github.com/ferranbt/fastssz"
 	c "github.com/patrickmn/go-cache"
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/prysmaticlabs/prysm/config/params"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/assert"
 	"github.com/prysmaticlabs/prysm/testing/require"
@@ -66,7 +67,7 @@ func TestKV_Unaggregated_SaveUnaggregatedAttestation(t *testing.T) {
 			assert.Equal(t, 0, len(cache.unAggregatedAtt), "Invalid start pool, atts: %d", len(cache.unAggregatedAtt))
 
 			if tt.att != nil && tt.att.Signature == nil {
-				tt.att.Signature = make([]byte, 96)
+				tt.att.Signature = make([]byte, params.BeaconConfig().BLSSignatureLength)
 			}
 
 			err := cache.SaveUnaggregatedAttestation(tt.att)

--- a/beacon-chain/operations/attestations/prune_expired_test.go
+++ b/beacon-chain/operations/attestations/prune_expired_test.go
@@ -30,14 +30,14 @@ func TestPruneExpired_Ticker(t *testing.T) {
 	ad2 := util.HydrateAttestationData(&ethpb.AttestationData{Slot: 1})
 
 	atts := []*ethpb.Attestation{
-		{Data: ad1, AggregationBits: bitfield.Bitlist{0b1000, 0b1}, Signature: make([]byte, 96)},
-		{Data: ad2, AggregationBits: bitfield.Bitlist{0b1000, 0b1}, Signature: make([]byte, 96)},
+		{Data: ad1, AggregationBits: bitfield.Bitlist{0b1000, 0b1}, Signature: make([]byte, params.BeaconConfig().BLSSignatureLength)},
+		{Data: ad2, AggregationBits: bitfield.Bitlist{0b1000, 0b1}, Signature: make([]byte, params.BeaconConfig().BLSSignatureLength)},
 	}
 	require.NoError(t, s.cfg.Pool.SaveUnaggregatedAttestations(atts))
 	require.Equal(t, 2, s.cfg.Pool.UnaggregatedAttestationCount(), "Unexpected number of attestations")
 	atts = []*ethpb.Attestation{
-		{Data: ad1, AggregationBits: bitfield.Bitlist{0b1101, 0b1}, Signature: make([]byte, 96)},
-		{Data: ad2, AggregationBits: bitfield.Bitlist{0b1101, 0b1}, Signature: make([]byte, 96)},
+		{Data: ad1, AggregationBits: bitfield.Bitlist{0b1101, 0b1}, Signature: make([]byte, params.BeaconConfig().BLSSignatureLength)},
+		{Data: ad2, AggregationBits: bitfield.Bitlist{0b1101, 0b1}, Signature: make([]byte, params.BeaconConfig().BLSSignatureLength)},
 	}
 	require.NoError(t, s.cfg.Pool.SaveAggregatedAttestations(atts))
 	assert.Equal(t, 2, s.cfg.Pool.AggregatedAttestationCount())

--- a/beacon-chain/powchain/deposit_test.go
+++ b/beacon-chain/powchain/deposit_test.go
@@ -189,7 +189,7 @@ func TestProcessDeposit_IncompleteDeposit(t *testing.T) {
 		Data: &ethpb.Deposit_Data{
 			Amount:                params.BeaconConfig().EffectiveBalanceIncrement, // incomplete deposit
 			WithdrawalCredentials: bytesutil.PadTo([]byte("testing"), 32),
-			Signature:             bytesutil.PadTo([]byte("test"), 96),
+			Signature:             bytesutil.PadTo([]byte("test"), params.BeaconConfig().BLSSignatureLength),
 		},
 	}
 

--- a/beacon-chain/rpc/eth/validator/validator_test.go
+++ b/beacon-chain/rpc/eth/validator/validator_test.go
@@ -869,7 +869,7 @@ func TestProduceAttestationData(t *testing.T) {
 func TestGetAggregateAttestation(t *testing.T) {
 	ctx := context.Background()
 	root1 := bytesutil.PadTo([]byte("root1"), 32)
-	sig1 := bytesutil.PadTo([]byte("sig1"), 96)
+	sig1 := bytesutil.PadTo([]byte("sig1"), params.BeaconConfig().BLSSignatureLength)
 	attSlot1 := &ethpbalpha.Attestation{
 		AggregationBits: []byte{0, 1},
 		Data: &ethpbalpha.AttestationData{
@@ -888,7 +888,7 @@ func TestGetAggregateAttestation(t *testing.T) {
 		Signature: sig1,
 	}
 	root2_1 := bytesutil.PadTo([]byte("root2_1"), 32)
-	sig2_1 := bytesutil.PadTo([]byte("sig2_1"), 96)
+	sig2_1 := bytesutil.PadTo([]byte("sig2_1"), params.BeaconConfig().BLSSignatureLength)
 	attSlot2_1 := &ethpbalpha.Attestation{
 		AggregationBits: []byte{0, 1, 1},
 		Data: &ethpbalpha.AttestationData{
@@ -907,7 +907,7 @@ func TestGetAggregateAttestation(t *testing.T) {
 		Signature: sig2_1,
 	}
 	root2_2 := bytesutil.PadTo([]byte("root2_2"), 32)
-	sig2_2 := bytesutil.PadTo([]byte("sig2_2"), 96)
+	sig2_2 := bytesutil.PadTo([]byte("sig2_2"), params.BeaconConfig().BLSSignatureLength)
 	attSlot2_2 := &ethpbalpha.Attestation{
 		AggregationBits: []byte{0, 1, 1, 1},
 		Data: &ethpbalpha.AttestationData{
@@ -966,7 +966,7 @@ func TestGetAggregateAttestation(t *testing.T) {
 func TestGetAggregateAttestation_SameSlotAndRoot_ReturnMostAggregationBits(t *testing.T) {
 	ctx := context.Background()
 	root := bytesutil.PadTo([]byte("root"), 32)
-	sig := bytesutil.PadTo([]byte("sig"), 96)
+	sig := bytesutil.PadTo([]byte("sig"), params.BeaconConfig().BLSSignatureLength)
 	att1 := &ethpbalpha.Attestation{
 		AggregationBits: []byte{0, 1},
 		Data: &ethpbalpha.AttestationData{
@@ -1305,8 +1305,8 @@ func TestSubmitAggregateAndProofs(t *testing.T) {
 	c.MaximumGossipClockDisparity = time.Hour
 	params.OverrideBeaconNetworkConfig(c)
 	root := bytesutil.PadTo([]byte("root"), 32)
-	sig := bytesutil.PadTo([]byte("sig"), 96)
-	proof := bytesutil.PadTo([]byte("proof"), 96)
+	sig := bytesutil.PadTo([]byte("sig"), params.BeaconConfig().BLSSignatureLength)
+	proof := bytesutil.PadTo([]byte("proof"), params.BeaconConfig().BLSSignatureLength)
 	att := &ethpbv1.Attestation{
 		AggregationBits: []byte{0, 1},
 		Data: &ethpbv1.AttestationData{

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/attestations_test.go
@@ -121,7 +121,7 @@ func TestServer_ListAttestations_NoPagination(t *testing.T) {
 		blockExample := util.NewBeaconBlock()
 		blockExample.Block.Body.Attestations = []*ethpb.Attestation{
 			{
-				Signature: make([]byte, 96),
+				Signature: make([]byte, params.BeaconConfig().BLSSignatureLength),
 				Data: &ethpb.AttestationData{
 					Target:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("root"), 32)},
 					Source:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("root"), 32)},
@@ -180,7 +180,7 @@ func TestServer_ListAttestations_FiltersCorrectly(t *testing.T) {
 										Slot: 3,
 									},
 									AggregationBits: bitfield.Bitlist{0b11},
-									Signature:       bytesutil.PadTo([]byte("sig"), 96),
+									Signature:       bytesutil.PadTo([]byte("sig"), params.BeaconConfig().BLSSignatureLength),
 								},
 							},
 						},
@@ -206,7 +206,7 @@ func TestServer_ListAttestations_FiltersCorrectly(t *testing.T) {
 									Slot: 4 + params.BeaconConfig().SlotsPerEpoch,
 								},
 								AggregationBits: bitfield.Bitlist{0b11},
-								Signature:       bytesutil.PadTo([]byte("sig"), 96),
+								Signature:       bytesutil.PadTo([]byte("sig"), params.BeaconConfig().BLSSignatureLength),
 							},
 						},
 					},
@@ -233,7 +233,7 @@ func TestServer_ListAttestations_FiltersCorrectly(t *testing.T) {
 										Slot: 4,
 									},
 									AggregationBits: bitfield.Bitlist{0b11},
-									Signature:       bytesutil.PadTo([]byte("sig"), 96),
+									Signature:       bytesutil.PadTo([]byte("sig"), params.BeaconConfig().BLSSignatureLength),
 								},
 							},
 						},
@@ -381,7 +381,7 @@ func TestServer_ListAttestations_Pagination_OutOfRange(t *testing.T) {
 								Slot:            i,
 							},
 							AggregationBits: bitfield.Bitlist{0b11},
-							Signature:       make([]byte, 96),
+							Signature:       make([]byte, params.BeaconConfig().BLSSignatureLength),
 						},
 					},
 				},
@@ -434,7 +434,7 @@ func TestServer_ListAttestations_Pagination_DefaultPageSize(t *testing.T) {
 					Source:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("root"), 32)},
 					Slot:            i,
 				},
-				Signature:       bytesutil.PadTo([]byte("root"), 96),
+				Signature:       bytesutil.PadTo([]byte("root"), params.BeaconConfig().BLSSignatureLength),
 				AggregationBits: bitfield.Bitlist{0b11},
 			},
 		}
@@ -512,7 +512,7 @@ func TestServer_ListIndexedAttestations_GenesisEpoch(t *testing.T) {
 		blockExample := util.NewBeaconBlock()
 		blockExample.Block.Body.Attestations = []*ethpb.Attestation{
 			{
-				Signature: make([]byte, 96),
+				Signature: make([]byte, params.BeaconConfig().BLSSignatureLength),
 				Data: &ethpb.AttestationData{
 					BeaconBlockRoot: make([]byte, 32),
 					Target: &ethpb.Checkpoint{
@@ -706,7 +706,7 @@ func TestServer_AttestationPool_Pagination_OutOfRange(t *testing.T) {
 				Target:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte{1}, 32)},
 			},
 			AggregationBits: bitfield.Bitlist{0b1101},
-			Signature:       bytesutil.PadTo([]byte{1}, 96),
+			Signature:       bytesutil.PadTo([]byte{1}, params.BeaconConfig().BLSSignatureLength),
 		},
 		{
 			Data: &ethpb.AttestationData{
@@ -716,7 +716,7 @@ func TestServer_AttestationPool_Pagination_OutOfRange(t *testing.T) {
 				Target:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte{2}, 32)},
 			},
 			AggregationBits: bitfield.Bitlist{0b1101},
-			Signature:       bytesutil.PadTo([]byte{2}, 96),
+			Signature:       bytesutil.PadTo([]byte{2}, params.BeaconConfig().BLSSignatureLength),
 		},
 		{
 			Data: &ethpb.AttestationData{
@@ -726,7 +726,7 @@ func TestServer_AttestationPool_Pagination_OutOfRange(t *testing.T) {
 				Target:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte{3}, 32)},
 			},
 			AggregationBits: bitfield.Bitlist{0b1101},
-			Signature:       bytesutil.PadTo([]byte{3}, 96),
+			Signature:       bytesutil.PadTo([]byte{3}, params.BeaconConfig().BLSSignatureLength),
 		},
 	}
 	require.NoError(t, bs.AttestationsPool.SaveAggregatedAttestations(atts))

--- a/beacon-chain/rpc/prysm/v1alpha1/debug/block_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/debug/block_test.go
@@ -72,7 +72,7 @@ func TestServer_GetAttestationInclusionSlot(t *testing.T) {
 			Slot:            1,
 		},
 		AggregationBits: bitfield.Bitlist{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
-		Signature:       make([]byte, 96),
+		Signature:       make([]byte, params.BeaconConfig().BLSSignatureLength),
 	}
 	b := util.NewBeaconBlock()
 	b.Block.Slot = 2

--- a/beacon-chain/sync/pending_attestations_queue_test.go
+++ b/beacon-chain/sync/pending_attestations_queue_test.go
@@ -160,7 +160,7 @@ func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
 			AggregationBits: bitfield.Bitlist{0x02},
 			Data:            util.HydrateAttestationData(&ethpb.AttestationData{}),
 		},
-		SelectionProof: make([]byte, 96),
+		SelectionProof: make([]byte, params.BeaconConfig().BLSSignatureLength),
 	}
 
 	b := util.NewBeaconBlock()
@@ -169,7 +169,7 @@ func TestProcessPendingAtts_NoBroadcastWithBadSignature(t *testing.T) {
 	require.NoError(t, r.cfg.DB.SaveBlock(context.Background(), wrapper.WrappedPhase0SignedBeaconBlock(b)))
 	require.NoError(t, r.cfg.DB.SaveState(context.Background(), s, r32))
 
-	r.blkRootToPendingAtts[r32] = []*ethpb.SignedAggregateAttestationAndProof{{Message: a, Signature: make([]byte, 96)}}
+	r.blkRootToPendingAtts[r32] = []*ethpb.SignedAggregateAttestationAndProof{{Message: a, Signature: make([]byte, params.BeaconConfig().BLSSignatureLength)}}
 	require.NoError(t, r.processPendingAtts(context.Background()))
 
 	assert.Equal(t, false, p1.BroadcastCalled, "Broadcasted bad aggregate")

--- a/beacon-chain/sync/subscriber_beacon_aggregate_proof_test.go
+++ b/beacon-chain/sync/subscriber_beacon_aggregate_proof_test.go
@@ -8,6 +8,7 @@ import (
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/operations/attestations"
 	lruwrpr "github.com/prysmaticlabs/prysm/cache/lru"
+	"github.com/prysmaticlabs/prysm/config/params"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/assert"
 	"github.com/prysmaticlabs/prysm/testing/require"
@@ -30,7 +31,7 @@ func TestBeaconAggregateProofSubscriber_CanSaveAggregatedAttestation(t *testing.
 			}),
 			AggregatorIndex: 100,
 		},
-		Signature: make([]byte, 96),
+		Signature: make([]byte, params.BeaconConfig().BLSSignatureLength),
 	}
 	require.NoError(t, r.beaconAggregateProofSubscriber(context.Background(), a))
 	assert.DeepSSZEqual(t, []*ethpb.Attestation{a.Message.Aggregate}, r.cfg.AttPool.AggregatedAttestations(), "Did not save aggregated attestation")
@@ -49,7 +50,7 @@ func TestBeaconAggregateProofSubscriber_CanSaveUnaggregatedAttestation(t *testin
 		Message: &ethpb.AggregateAttestationAndProof{
 			Aggregate: util.HydrateAttestation(&ethpb.Attestation{
 				AggregationBits: bitfield.Bitlist{0x03},
-				Signature:       make([]byte, 96),
+				Signature:       make([]byte, params.BeaconConfig().BLSSignatureLength),
 			}),
 			AggregatorIndex: 100,
 		},

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -69,7 +69,7 @@ func TestSubscribe_ReceivesValidMessage(t *testing.T) {
 	}, p2pService.Digest)
 	r.markForChainStart()
 
-	p2pService.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, 96)})
+	p2pService.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, params.BeaconConfig().BLSSignatureLength)})
 
 	if util.WaitTimeout(&wg, time.Second) {
 		t.Fatal("Did not receive PubSub in 1 second")
@@ -247,7 +247,7 @@ func TestSubscribe_HandlesPanic(t *testing.T) {
 		panic("bad")
 	}, p.Digest)
 	r.markForChainStart()
-	p.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, 96)})
+	p.ReceivePubSub(topic, &pb.SignedVoluntaryExit{Exit: &pb.VoluntaryExit{Epoch: 55}, Signature: make([]byte, params.BeaconConfig().BLSSignatureLength)})
 
 	if util.WaitTimeout(&wg, time.Second) {
 		t.Fatal("Did not receive PubSub in 1 second")

--- a/beacon-chain/sync/validate_aggregate_proof_test.go
+++ b/beacon-chain/sync/validate_aggregate_proof_test.go
@@ -106,11 +106,11 @@ func TestValidateAggregateAndProof_NoBlock(t *testing.T) {
 	})
 
 	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
-		SelectionProof:  bytesutil.PadTo([]byte{'A'}, 96),
+		SelectionProof:  bytesutil.PadTo([]byte{'A'}, params.BeaconConfig().BLSSignatureLength),
 		Aggregate:       att,
 		AggregatorIndex: 0,
 	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, 96)}
+	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, params.BeaconConfig().BLSSignatureLength)}
 
 	c := lruwrpr.New(10)
 	r := &Service{
@@ -169,14 +169,14 @@ func TestValidateAggregateAndProof_NotWithinSlotRange(t *testing.T) {
 			Target:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
 		},
 		AggregationBits: aggBits,
-		Signature:       make([]byte, 96),
+		Signature:       make([]byte, params.BeaconConfig().BLSSignatureLength),
 	}
 
 	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
 		Aggregate:      att,
-		SelectionProof: make([]byte, 96),
+		SelectionProof: make([]byte, params.BeaconConfig().BLSSignatureLength),
 	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, 96)}
+	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, params.BeaconConfig().BLSSignatureLength)}
 
 	require.NoError(t, beaconState.SetGenesisTime(uint64(time.Now().Unix())))
 
@@ -253,14 +253,14 @@ func TestValidateAggregateAndProof_ExistedInPool(t *testing.T) {
 			Target:          &ethpb.Checkpoint{Epoch: 0, Root: bytesutil.PadTo([]byte("hello-world"), 32)},
 		},
 		AggregationBits: aggBits,
-		Signature:       make([]byte, 96),
+		Signature:       make([]byte, params.BeaconConfig().BLSSignatureLength),
 	}
 
 	aggregateAndProof := &ethpb.AggregateAttestationAndProof{
 		Aggregate:      att,
-		SelectionProof: make([]byte, 96),
+		SelectionProof: make([]byte, params.BeaconConfig().BLSSignatureLength),
 	}
-	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, 96)}
+	signedAggregateAndProof := &ethpb.SignedAggregateAttestationAndProof{Message: aggregateAndProof, Signature: make([]byte, params.BeaconConfig().BLSSignatureLength)}
 
 	require.NoError(t, beaconState.SetGenesisTime(uint64(time.Now().Unix())))
 	r := &Service{

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -60,7 +60,7 @@ func TestValidateBeaconBlockPubSub_InvalidSignature(t *testing.T) {
 	msg.Block.ParentRoot = bRoot[:]
 	msg.Block.Slot = 1
 	msg.Block.ProposerIndex = proposerIdx
-	msg.Signature = bytesutil.PadTo([]byte("fake"), 96)
+	msg.Signature = bytesutil.PadTo([]byte("fake"), params.BeaconConfig().BLSSignatureLength)
 
 	stateGen := stategen.New(db)
 	chainService := &mock.ChainService{Genesis: time.Unix(time.Now().Unix()-int64(params.BeaconConfig().SecondsPerSlot), 0),

--- a/proto/testing/tags_test.go
+++ b/proto/testing/tags_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestSSZTagSize(t *testing.T) {
-	sigSize := 96
+	sigSize := params.BeaconConfig().BLSSignatureLength
 	pubKeySize := 48
 	rootSize := 32
 

--- a/validator/client/slashing_protection_interchange_test.go
+++ b/validator/client/slashing_protection_interchange_test.go
@@ -145,7 +145,7 @@ func TestEIP3076SpecTests(t *testing.T) {
 							Target:          &ethpb.Checkpoint{Epoch: target, Root: make([]byte, 32)},
 							Source:          &ethpb.Checkpoint{Epoch: source, Root: make([]byte, 32)},
 						},
-						Signature: make([]byte, 96),
+						Signature: make([]byte, params.BeaconConfig().BLSSignatureLength),
 					}
 
 					var signingRoot [32]byte

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -1282,7 +1282,7 @@ func createAttestation(source, target types.Epoch) *ethpb.IndexedAttestation {
 			},
 			BeaconBlockRoot: make([]byte, 32),
 		},
-		Signature: make([]byte, 96),
+		Signature: make([]byte, params.BeaconConfig().BLSSignatureLength),
 	}
 }
 


### PR DESCRIPTION
Clean up. Use `BeaconConfig().BLSSignatureLength` instead of hard coded magic number 96