### PR TITLE
Health Endpoints Not Registered in Validator gRPC Gateway Fix

### DIFF
--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -483,6 +483,7 @@ func (c *ValidatorClient) registerRPCGatewayService(cliCtx *cli.Context) error {
 		validatorpb.RegisterAuthHandler,
 		validatorpb.RegisterWalletHandler,
 		pb.RegisterHealthHandler,
+		validatorpb.RegisterHealthHandler,
 		validatorpb.RegisterAccountsHandler,
 		validatorpb.RegisterBeaconHandler,
 		validatorpb.RegisterSlashingProtectionHandler,


### PR DESCRIPTION
/v2/validator/health/version and all other health endpoints were gone in v2.0.0. During the grpc gateway refactor, the health endpoints were not registered in the validator client. This PR fixes the issue.