### PR TITLE
Update Eth1 Data Saving Interval

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -30,7 +30,7 @@ var (
 	depositEventSignature = hash.HashKeccak256([]byte("DepositEvent(bytes,bytes,bytes,bytes,bytes)"))
 )
 
-const eth1DataSavingInterval = 100
+const eth1DataSavingInterval = 1000
 const maxTolerableDifference = 50
 const defaultEth1HeaderReqLimit = uint64(1000)
 const depositlogRequestLimit = 10000


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

- [x] In order to reduce disk i/o from writes of eth1 specific data we can reduce the interval to 1000. This will prevent 
unnecessarily amount of writes from being carried out. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
