### PR TITLE
Ignore G307 for Gosec

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Gosec security scanner
         uses: securego/gosec@master
         with:
-          args: '-exclude-dir=crypto/bls/herumi ./...'
+          args: '-exclude=G307 -exclude-dir=crypto/bls/herumi ./...'
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v2


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] The gosec analyzer has started failing PRs for false positives(G307). All our errors for file closes are checked(enforced by `errCheck` analyzer.) This PR ignores it for now until gosec has a solution that fixes this in its following releases. 
 
**Which issues(s) does this PR fix?**

https://github.com/securego/gosec/issues/714

**Other notes for review**
