### PR TITLE
Simplify State HTR Operations

### DIFF
--- a/beacon-chain/state/stateutil/eth1_root.go
+++ b/beacon-chain/state/stateutil/eth1_root.go
@@ -81,23 +81,19 @@ func Eth1DatasEncKey(eth1Datas []*ethpb.Eth1Data) ([32]byte, error) {
 // Eth1DatasRoot returns the hash tree root of input `eth1Datas`.
 func Eth1DatasRoot(eth1Datas []*ethpb.Eth1Data) ([32]byte, error) {
 	hasher := hash.CustomSHA256Hasher()
-	eth1VotesRoots := make([][]byte, 0)
+	eth1VotesRoots := make([][32]byte, 0)
 	for i := 0; i < len(eth1Datas); i++ {
 		eth1, err := Eth1DataRootWithHasher(hasher, eth1Datas[i])
 		if err != nil {
 			return [32]byte{}, errors.Wrap(err, "could not compute eth1data merkleization")
 		}
-		eth1VotesRoots = append(eth1VotesRoots, eth1[:])
-	}
-	eth1Chunks, err := ssz.Pack(eth1VotesRoots)
-	if err != nil {
-		return [32]byte{}, errors.Wrap(err, "could not chunk eth1 votes roots")
+		eth1VotesRoots = append(eth1VotesRoots, eth1)
 	}
 
-	eth1VotesRootsRoot, err := ssz.BitwiseMerkleize(
+	eth1VotesRootsRoot, err := ssz.BitwiseMerkleizeArrays(
 		hasher,
-		eth1Chunks,
-		uint64(len(eth1Chunks)),
+		eth1VotesRoots,
+		uint64(len(eth1VotesRoots)),
 		uint64(params.BeaconConfig().SlotsPerEpoch.Mul(uint64(params.BeaconConfig().EpochsPerEth1VotingPeriod))),
 	)
 	if err != nil {

--- a/beacon-chain/state/stateutil/sync_committee.root.go
+++ b/beacon-chain/state/stateutil/sync_committee.root.go
@@ -45,5 +45,5 @@ func merkleizePubkey(hasher ssz.HashFn, pubkey []byte) ([32]byte, error) {
 	if err != nil {
 		return [32]byte{}, err
 	}
-	return ssz.BitwiseMerkleize(hasher, chunks, uint64(len(chunks)), uint64(len(chunks)))
+	return ssz.BitwiseMerkleizeArrays(hasher, chunks, uint64(len(chunks)), uint64(len(chunks)))
 }

--- a/beacon-chain/state/stateutil/validator_root.go
+++ b/beacon-chain/state/stateutil/validator_root.go
@@ -45,7 +45,7 @@ func ValidatorRootWithHasher(hasher ssz.HashFn, validator *ethpb.Validator) ([32
 		if err != nil {
 			return [32]byte{}, err
 		}
-		pubKeyRoot, err := ssz.BitwiseMerkleize(hasher, pubKeyChunks, uint64(len(pubKeyChunks)), uint64(len(pubKeyChunks)))
+		pubKeyRoot, err := ssz.BitwiseMerkleizeArrays(hasher, pubKeyChunks, uint64(len(pubKeyChunks)), uint64(len(pubKeyChunks)))
 		if err != nil {
 			return [32]byte{}, err
 		}
@@ -79,7 +79,7 @@ func Uint64ListRootWithRegistryLimit(balances []uint64) ([32]byte, error) {
 			balLimit = uint64(len(balances))
 		}
 	}
-	balancesRootsRoot, err := ssz.BitwiseMerkleize(hasher, balancesChunks, uint64(len(balancesChunks)), balLimit)
+	balancesRootsRoot, err := ssz.BitwiseMerkleizeArrays(hasher, balancesChunks, uint64(len(balancesChunks)), balLimit)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute balances merkleization")
 	}

--- a/encoding/ssz/htrutils.go
+++ b/encoding/ssz/htrutils.go
@@ -88,5 +88,5 @@ func SlashingsRoot(slashings []uint64) ([32]byte, error) {
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not pack slashings into chunks")
 	}
-	return BitwiseMerkleize(hash.CustomSHA256Hasher(), slashingChunks, uint64(len(slashingChunks)), uint64(len(slashingChunks)))
+	return BitwiseMerkleizeArrays(hash.CustomSHA256Hasher(), slashingChunks, uint64(len(slashingChunks)), uint64(len(slashingChunks)))
 }


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

- [x] Currently we have a util which packs a 2d-byte slice into a separate 2d byte slice. This operation is redundant and potentially bug prone for a slice of byte roots as they are already in the appropriate format. Also as a side effect, it has
normalized a 2d byte-slice as the canonical way to represent leaves, when it is incorrect. This PR tries to revert this 
back to an implementation that is clearer and represents the intent/purpose of field merkelization in the state better.  

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
