### PR TITLE
Bazel: minimal build config alias

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -36,6 +36,9 @@ run --define blst_disabled=false
 build:blst_disabled --define blst_disabled=true
 build:blst_disabled --define gotags=blst_disabled
 
+build:minimal --//proto:network=minimal
+build:minimal --@io_bazel_rules_go//go/config:tags=minimal
+
 # Release flags
 build:release --compilation_mode=opt
 build:release --config=llvm


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Add a convenience alias for producing minimal builds.

Example:
```
bazel build --config=minimal //cmd/beacon-chain
```

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**
