### PR TITLE
Fill out `Version` for SSZ block

### DIFF
--- a/beacon-chain/rpc/eth/beacon/blocks.go
+++ b/beacon-chain/rpc/eth/beacon/blocks.go
@@ -327,7 +327,7 @@ func (bs *Server) GetBlockSSZV2(ctx context.Context, req *ethpbv2.BlockRequestV2
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not marshal block into SSZ: %v", err)
 		}
-		return &ethpbv2.BlockSSZResponseV2{Data: sszBlock}, nil
+		return &ethpbv2.BlockSSZResponseV2{Version: ethpbv2.Version_PHASE0, Data: sszBlock}, nil
 	}
 	altairBlk, err := blk.PbAltairBlock()
 	if err != nil {
@@ -345,7 +345,7 @@ func (bs *Server) GetBlockSSZV2(ctx context.Context, req *ethpbv2.BlockRequestV2
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not marshal block into SSZ: %v", err)
 	}
-	return &ethpbv2.BlockSSZResponseV2{Data: sszData}, nil
+	return &ethpbv2.BlockSSZResponseV2{Version: ethpbv2.Version_ALTAIR, Data: sszData}, nil
 }
 
 // GetBlockRoot retrieves hashTreeRoot of BeaconBlock/BeaconBlockHeader.

--- a/beacon-chain/rpc/eth/beacon/blocks_test.go
+++ b/beacon-chain/rpc/eth/beacon/blocks_test.go
@@ -773,6 +773,7 @@ func TestServer_GetBlockSSZV2(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, resp)
 		assert.DeepEqual(t, sszBlock, resp.Data)
+		assert.Equal(t, ethpbv2.Version_PHASE0, resp.Version)
 	})
 
 	t.Run("Altair", func(t *testing.T) {
@@ -811,6 +812,7 @@ func TestServer_GetBlockSSZV2(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, resp)
 		assert.DeepEqual(t, sszBlock, resp.Data)
+		assert.Equal(t, ethpbv2.Version_ALTAIR, resp.Version)
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The `Version` field is currently not populated when returning SSZ-serialized blocks, resulting in the default `phase0` value for every block.
