### PR TITLE
Improve description of `datadir` flag

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -33,7 +33,7 @@ var (
 		Usage: "Logging verbosity (trace, debug, info=default, warn, error, fatal, panic)",
 		Value: "info",
 	}
-	// DataDirFlag defines a path on disk.
+	// DataDirFlag defines a path on disk where Prysm databases are stored.
 	DataDirFlag = &cli.StringFlag{
 		Name:  "datadir",
 		Usage: "Data directory for the databases",


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

The current description of `datadir` flag says

> Data directory for the databases and keystore

but we do not store keystores in the data directory. Keystores are managed in the wallet directory via the `wallet-dir` flag.