### PR TITLE
stateutil: Remove duplicated MerkleizeTrieLeaves method

### DIFF
--- a/beacon-chain/state/fieldtrie/field_trie.go
+++ b/beacon-chain/state/fieldtrie/field_trie.go
@@ -42,8 +42,12 @@ func NewFieldTrie(field types.FieldIndex, dataType types.DataType, elements inte
 	}
 	switch dataType {
 	case types.BasicArray:
+		fl, err := stateutil.ReturnTrieLayer(fieldRoots, length)
+		if err != nil {
+			return nil, err
+		}
 		return &FieldTrie{
-			fieldLayers: stateutil.ReturnTrieLayer(fieldRoots, length),
+			fieldLayers: fl,
 			field:       field,
 			dataType:    dataType,
 			reference:   stateutil.NewRef(1),

--- a/beacon-chain/state/stateutil/trie_helpers_test.go
+++ b/beacon-chain/state/stateutil/trie_helpers_test.go
@@ -24,7 +24,8 @@ func TestReturnTrieLayer_OK(t *testing.T) {
 	for _, rt := range blockRts {
 		roots = append(roots, bytesutil.ToBytes32(rt))
 	}
-	layers := stateutil.ReturnTrieLayer(roots, uint64(len(roots)))
+	layers, err := stateutil.ReturnTrieLayer(roots, uint64(len(roots)))
+	assert.NoError(t, err)
 	newRoot := *layers[len(layers)-1][0]
 	assert.Equal(t, root, newRoot)
 }
@@ -55,7 +56,8 @@ func TestRecomputeFromLayer_FixedSizedArray(t *testing.T) {
 	for _, rt := range blockRts {
 		roots = append(roots, bytesutil.ToBytes32(rt))
 	}
-	layers := stateutil.ReturnTrieLayer(roots, uint64(len(roots)))
+	layers, err := stateutil.ReturnTrieLayer(roots, uint64(len(roots)))
+	require.NoError(t, err)
 
 	changedIdx := []uint64{24, 41}
 	changedRoots := [][32]byte{{'A', 'B', 'C'}, {'D', 'E', 'F'}}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

There were two "MerkleizeTrieLeaves" that were nearly identical. 
The public method ensured that the hashlayer length was always a power of 2 while the private one did not. 

A follow up PR is to error check for chunkBuffer.Writer and verify that the static analysis for errcheck is working properly since these unhandled errors are not blocking/alerting users at build time.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

This is a finding from Dr. Artem Vorobiev (artem@prysmaticlabs.com).
