### PR TITLE
Update Prysm Web to Use v1.0.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -362,9 +362,9 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "54ce527b83d092da01127f2e3816f4d5cfbab69354caba8537f1ea55889b6d7c",
+    sha256 = "0a3d94428ea28916276694c517b82b364122063fdbf924f54ee9ae0bc500289f",
     urls = [
-        "https://github.com/prysmaticlabs/prysm-web-ui/releases/download/v1.0.0-beta.4/prysm-web-ui.tar.gz",
+        "https://github.com/prysmaticlabs/prysm-web-ui/releases/download/v1.0.1/prysm-web-ui.tar.gz",
     ],
 )
 


### PR DESCRIPTION
This PR updates our prysm web UI checked-in assets to v1.0.1 https://github.com/prysmaticlabs/prysm-web-ui/releases/tag/v1.0.1. It is our first release in almost half a year thanks to the work from our new teammate, @james-prysm ! We are excited to bring an improved authentication experience and significant error fixes.