### PR TITLE
Return `[32]byte` from `(...)AtIndex` functions

### DIFF
--- a/beacon-chain/cache/active_balance.go
+++ b/beacon-chain/cache/active_balance.go
@@ -108,7 +108,7 @@ func balanceCacheKey(st state.ReadOnlyBeaconState) (string, error) {
 	// Mix in current epoch
 	b := make([]byte, 8)
 	binary.LittleEndian.PutUint64(b, uint64(currentEpoch))
-	key := append(r, b...)
+	key := append(r[:], b...)
 
 	// Mix in validator count
 	b = make([]byte, 8)

--- a/beacon-chain/core/blocks/randao.go
+++ b/beacon-chain/core/blocks/randao.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/config/params"
 	"github.com/prysmaticlabs/prysm/crypto/hash"
-	"github.com/prysmaticlabs/prysm/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1/block"
 	"github.com/prysmaticlabs/prysm/time/slots"
 )
@@ -79,7 +78,7 @@ func ProcessRandaoNoVerify(
 	for i, x := range blockRandaoReveal {
 		latestMixSlice[i] ^= x
 	}
-	if err := beaconState.UpdateRandaoMixesAtIndex(uint64(currentEpoch%latestMixesLength), bytesutil.ToBytes32(latestMixSlice)); err != nil {
+	if err := beaconState.UpdateRandaoMixesAtIndex(uint64(currentEpoch%latestMixesLength), latestMixSlice); err != nil {
 		return nil, err
 	}
 	return beaconState, nil

--- a/beacon-chain/core/helpers/block.go
+++ b/beacon-chain/core/helpers/block.go
@@ -44,7 +44,11 @@ func BlockRootAtSlot(state state.ReadOnlyBeaconState, slot types.Slot) ([]byte, 
 	if slot >= state.Slot() || state.Slot() > slot+params.BeaconConfig().SlotsPerHistoricalRoot {
 		return []byte{}, errors.Errorf("slot %d out of bounds", slot)
 	}
-	return state.BlockRootAtIndex(uint64(slot % params.BeaconConfig().SlotsPerHistoricalRoot))
+	root, err := state.BlockRootAtIndex(uint64(slot % params.BeaconConfig().SlotsPerHistoricalRoot))
+	if err != nil {
+		return nil, err
+	}
+	return root[:], err
 }
 
 // StateRootAtSlot returns the cached state root at that particular slot. If no state
@@ -53,7 +57,11 @@ func StateRootAtSlot(state state.ReadOnlyBeaconState, slot types.Slot) ([]byte, 
 	if slot >= state.Slot() || state.Slot() > slot+params.BeaconConfig().SlotsPerHistoricalRoot {
 		return []byte{}, errors.Errorf("slot %d out of bounds", slot)
 	}
-	return state.StateRootAtIndex(uint64(slot % params.BeaconConfig().SlotsPerHistoricalRoot))
+	root, err := state.StateRootAtIndex(uint64(slot % params.BeaconConfig().SlotsPerHistoricalRoot))
+	if err != nil {
+		return nil, err
+	}
+	return root[:], err
 }
 
 // BlockRoot returns the block root stored in the BeaconState for epoch start slot.

--- a/beacon-chain/core/helpers/randao.go
+++ b/beacon-chain/core/helpers/randao.go
@@ -46,5 +46,9 @@ func Seed(state state.ReadOnlyBeaconState, epoch types.Epoch, domain [bls.Domain
 //    """
 //    return state.randao_mixes[epoch % EPOCHS_PER_HISTORICAL_VECTOR]
 func RandaoMix(state state.ReadOnlyBeaconState, epoch types.Epoch) ([]byte, error) {
-	return state.RandaoMixAtIndex(uint64(epoch % params.BeaconConfig().EpochsPerHistoricalVector))
+	root, err := state.RandaoMixAtIndex(uint64(epoch % params.BeaconConfig().EpochsPerHistoricalVector))
+	if err != nil {
+		return nil, err
+	}
+	return root[:], err
 }

--- a/beacon-chain/state/phase0.go
+++ b/beacon-chain/state/phase0.go
@@ -111,19 +111,19 @@ type ReadOnlyCheckpoint interface {
 // ReadOnlyBlockRoots defines a struct which only has read access to block roots methods.
 type ReadOnlyBlockRoots interface {
 	BlockRoots() *[8192][32]byte
-	BlockRootAtIndex(idx uint64) ([]byte, error)
+	BlockRootAtIndex(idx uint64) ([32]byte, error)
 }
 
 // ReadOnlyStateRoots defines a struct which only has read access to state roots methods.
 type ReadOnlyStateRoots interface {
 	StateRoots() *[8192][32]byte
-	StateRootAtIndex(idx uint64) ([]byte, error)
+	StateRootAtIndex(idx uint64) ([32]byte, error)
 }
 
 // ReadOnlyRandaoMixes defines a struct which only has read access to randao mixes methods.
 type ReadOnlyRandaoMixes interface {
 	RandaoMixes() *[65536][32]byte
-	RandaoMixAtIndex(idx uint64) ([]byte, error)
+	RandaoMixAtIndex(idx uint64) ([32]byte, error)
 	RandaoMixesLength() int
 }
 

--- a/beacon-chain/state/v1/getters_block.go
+++ b/beacon-chain/state/v1/getters_block.go
@@ -76,12 +76,12 @@ func (b *BeaconState) blockRoots() *customtypes.StateRoots {
 
 // BlockRootAtIndex retrieves a specific block root based on an
 // input index value.
-func (b *BeaconState) BlockRootAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) BlockRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 	if b.state.BlockRoots == nil {
-		return nil, nil
+		return [32]byte{}, nil
 	}
 
 	b.lock.RLock()
@@ -93,13 +93,17 @@ func (b *BeaconState) BlockRootAtIndex(idx uint64) ([]byte, error) {
 // blockRootAtIndex retrieves a specific block root based on an
 // input index value.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) blockRootAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) blockRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 	bRoots := make([][]byte, len(b.state.BlockRoots))
 	for i := range bRoots {
 		bRoots[i] = b.state.BlockRoots[i][:]
 	}
-	return bytesutil.SafeCopyRootAtIndex(bRoots, idx)
+	root, err := bytesutil.SafeCopyRootAtIndex(bRoots, idx)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return bytesutil.ToBytes32(root), nil
 }

--- a/beacon-chain/state/v1/getters_randao.go
+++ b/beacon-chain/state/v1/getters_randao.go
@@ -33,12 +33,12 @@ func (b *BeaconState) randaoMixes() *customtypes.RandaoMixes {
 
 // RandaoMixAtIndex retrieves a specific block root based on an
 // input index value.
-func (b *BeaconState) RandaoMixAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) RandaoMixAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 	if b.state.RandaoMixes == nil {
-		return nil, nil
+		return [32]byte{}, nil
 	}
 
 	b.lock.RLock()
@@ -50,16 +50,20 @@ func (b *BeaconState) RandaoMixAtIndex(idx uint64) ([]byte, error) {
 // randaoMixAtIndex retrieves a specific block root based on an
 // input index value.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) randaoMixAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) randaoMixAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 
 	mixes := make([][]byte, len(b.state.RandaoMixes))
 	for i := range mixes {
 		mixes[i] = b.state.RandaoMixes[i][:]
 	}
-	return bytesutil.SafeCopyRootAtIndex(mixes, idx)
+	root, err := bytesutil.SafeCopyRootAtIndex(mixes, idx)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return bytesutil.ToBytes32(root), nil
 }
 
 // RandaoMixesLength returns the length of the randao mixes slice.

--- a/beacon-chain/state/v1/getters_state.go
+++ b/beacon-chain/state/v1/getters_state.go
@@ -82,12 +82,12 @@ func (b *BeaconState) stateRoots() *customtypes.StateRoots {
 
 // StateRootAtIndex retrieves a specific state root based on an
 // input index value.
-func (b *BeaconState) StateRootAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) StateRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 	if b.state.StateRoots == nil {
-		return nil, nil
+		return [32]byte{}, nil
 	}
 
 	b.lock.RLock()
@@ -99,15 +99,19 @@ func (b *BeaconState) StateRootAtIndex(idx uint64) ([]byte, error) {
 // stateRootAtIndex retrieves a specific state root based on an
 // input index value.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) stateRootAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) stateRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 	sRoots := make([][]byte, len(b.state.StateRoots))
 	for i := range sRoots {
 		sRoots[i] = b.state.StateRoots[i][:]
 	}
-	return bytesutil.SafeCopyRootAtIndex(sRoots, idx)
+	root, err := bytesutil.SafeCopyRootAtIndex(sRoots, idx)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return bytesutil.ToBytes32(root), nil
 }
 
 // MarshalSSZ marshals the underlying beacon state to bytes.

--- a/beacon-chain/state/v2/getters_block.go
+++ b/beacon-chain/state/v2/getters_block.go
@@ -76,12 +76,12 @@ func (b *BeaconState) blockRoots() *customtypes.StateRoots {
 
 // BlockRootAtIndex retrieves a specific block root based on an
 // input index value.
-func (b *BeaconState) BlockRootAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) BlockRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 	if b.state.BlockRoots == nil {
-		return nil, nil
+		return [32]byte{}, nil
 	}
 
 	b.lock.RLock()
@@ -93,13 +93,17 @@ func (b *BeaconState) BlockRootAtIndex(idx uint64) ([]byte, error) {
 // blockRootAtIndex retrieves a specific block root based on an
 // input index value.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) blockRootAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) blockRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 	bRoots := make([][]byte, len(b.state.BlockRoots))
 	for i := range bRoots {
 		bRoots[i] = b.state.BlockRoots[i][:]
 	}
-	return bytesutil.SafeCopyRootAtIndex(bRoots, idx)
+	root, err := bytesutil.SafeCopyRootAtIndex(bRoots, idx)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return bytesutil.ToBytes32(root), nil
 }

--- a/beacon-chain/state/v2/getters_randao.go
+++ b/beacon-chain/state/v2/getters_randao.go
@@ -33,12 +33,12 @@ func (b *BeaconState) randaoMixes() *customtypes.RandaoMixes {
 
 // RandaoMixAtIndex retrieves a specific block root based on an
 // input index value.
-func (b *BeaconState) RandaoMixAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) RandaoMixAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 	if b.state.RandaoMixes == nil {
-		return nil, nil
+		return [32]byte{}, nil
 	}
 
 	b.lock.RLock()
@@ -50,16 +50,20 @@ func (b *BeaconState) RandaoMixAtIndex(idx uint64) ([]byte, error) {
 // randaoMixAtIndex retrieves a specific block root based on an
 // input index value.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) randaoMixAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) randaoMixAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 
 	mixes := make([][]byte, len(b.state.RandaoMixes))
 	for i := range mixes {
 		mixes[i] = b.state.RandaoMixes[i][:]
 	}
-	return bytesutil.SafeCopyRootAtIndex(mixes, idx)
+	root, err := bytesutil.SafeCopyRootAtIndex(mixes, idx)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return bytesutil.ToBytes32(root), nil
 }
 
 // RandaoMixesLength returns the length of the randao mixes slice.

--- a/beacon-chain/state/v2/getters_state.go
+++ b/beacon-chain/state/v2/getters_state.go
@@ -85,12 +85,12 @@ func (b *BeaconState) stateRoots() *customtypes.StateRoots {
 
 // StateRootAtIndex retrieves a specific state root based on an
 // input index value.
-func (b *BeaconState) StateRootAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) StateRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 	if b.state.StateRoots == nil {
-		return nil, nil
+		return [32]byte{}, nil
 	}
 
 	b.lock.RLock()
@@ -102,15 +102,19 @@ func (b *BeaconState) StateRootAtIndex(idx uint64) ([]byte, error) {
 // stateRootAtIndex retrieves a specific state root based on an
 // input index value.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) stateRootAtIndex(idx uint64) ([]byte, error) {
+func (b *BeaconState) stateRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
-		return nil, ErrNilInnerState
+		return [32]byte{}, ErrNilInnerState
 	}
 	sRoots := make([][]byte, len(b.state.BlockRoots))
 	for i := range sRoots {
 		sRoots[i] = b.state.StateRoots[i][:]
 	}
-	return bytesutil.SafeCopyRootAtIndex(sRoots, idx)
+	root, err := bytesutil.SafeCopyRootAtIndex(sRoots, idx)
+	if err != nil {
+		return [32]byte{}, err
+	}
+	return bytesutil.ToBytes32(root), nil
 }
 
 // MarshalSSZ marshals the underlying beacon state to bytes.


### PR DESCRIPTION
**What type of PR is this?**

Refactoring

**What does this PR do? Why is it needed?**

As mentioned in https://github.com/prysmaticlabs/prysm/pull/9861#discussion_r743503630, `(...)AtIndex` functions should return `[32]byte` intead of `[]byte`. This PR updated these functions.

**Which issues(s) does this PR fix?**

Part of #9820 

**Other notes for review**

`go build ./...` is successful.
