### PR TITLE
Move remaining non-struct fields out of the proto state

### DIFF
--- a/beacon-chain/core/altair/BUILD.bazel
+++ b/beacon-chain/core/altair/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/p2p/types:go_default_library",
         "//beacon-chain/state:go_default_library",
-        "//beacon-chain/state/custom-types:go_default_library",
         "//beacon-chain/state/v2:go_default_library",
         "//config/params:go_default_library",
         "//crypto/bls:go_default_library",

--- a/beacon-chain/core/transition/BUILD.bazel
+++ b/beacon-chain/core/transition/BUILD.bazel
@@ -35,7 +35,6 @@ go_library(
         "//beacon-chain/core/transition/interop:go_default_library",
         "//beacon-chain/core/validators:go_default_library",
         "//beacon-chain/state:go_default_library",
-        "//beacon-chain/state/custom-types:go_default_library",
         "//beacon-chain/state/v1:go_default_library",
         "//config/features:go_default_library",
         "//config/params:go_default_library",

--- a/beacon-chain/state/v1/field_roots.go
+++ b/beacon-chain/state/v1/field_roots.go
@@ -70,7 +70,7 @@ func (h *stateRootHasher) computeFieldRootsWithHasher(ctx context.Context, state
 	fieldRoots[0] = genesisRoot[:]
 
 	// Genesis validator root.
-	genesisValidatorsRoot := state.genesisValidatorRoot()
+	genesisValidatorsRoot := state.genesisValidatorRootInternal()
 	fieldRoots[1] = genesisValidatorsRoot[:]
 
 	// Slot root.
@@ -92,9 +92,9 @@ func (h *stateRootHasher) computeFieldRootsWithHasher(ctx context.Context, state
 	fieldRoots[4] = headerHashTreeRoot[:]
 
 	// BlockRoots array root.
-	bRoots := make([][]byte, len(state.blockRoots()))
+	bRoots := make([][]byte, len(state.blockRootsInternal()))
 	for i := range bRoots {
-		bRoots[i] = state.blockRoots()[i][:]
+		bRoots[i] = state.blockRootsInternal()[i][:]
 	}
 	blockRootsRoot, err := h.arraysRoot(bRoots, uint64(params.BeaconConfig().SlotsPerHistoricalRoot), "BlockRoots")
 	if err != nil {
@@ -103,9 +103,9 @@ func (h *stateRootHasher) computeFieldRootsWithHasher(ctx context.Context, state
 	fieldRoots[5] = blockRootsRoot[:]
 
 	// StateRoots array root.
-	sRoots := make([][]byte, len(state.stateRoots()))
+	sRoots := make([][]byte, len(state.stateRootsInternal()))
 	for i := range sRoots {
-		sRoots[i] = state.stateRoots()[i][:]
+		sRoots[i] = state.stateRootsInternal()[i][:]
 	}
 	stateRootsRoot, err := h.arraysRoot(sRoots, uint64(params.BeaconConfig().SlotsPerHistoricalRoot), "StateRoots")
 	if err != nil {
@@ -114,9 +114,9 @@ func (h *stateRootHasher) computeFieldRootsWithHasher(ctx context.Context, state
 	fieldRoots[6] = stateRootsRoot[:]
 
 	// HistoricalRoots slice root.
-	hRoots := make([][]byte, len(state.historicalRoots()))
+	hRoots := make([][]byte, len(state.historicalRootsInternal()))
 	for i := range hRoots {
-		hRoots[i] = state.historicalRoots()[i][:]
+		hRoots[i] = state.historicalRootsInternal()[i][:]
 	}
 	historicalRootsRt, err := ssz.ByteArrayRootWithLimit(hRoots, params.BeaconConfig().HistoricalRootsLimit)
 	if err != nil {
@@ -159,9 +159,9 @@ func (h *stateRootHasher) computeFieldRootsWithHasher(ctx context.Context, state
 	fieldRoots[12] = balancesRoot[:]
 
 	// RandaoMixes array root.
-	mixes := make([][]byte, len(state.randaoMixes()))
+	mixes := make([][]byte, len(state.randaoMixesInternal()))
 	for i := range mixes {
-		mixes[i] = state.randaoMixes()[i][:]
+		mixes[i] = state.randaoMixesInternal()[i][:]
 	}
 	randaoRootsRoot, err := h.arraysRoot(mixes, uint64(params.BeaconConfig().EpochsPerHistoricalVector), "RandaoMixes")
 	if err != nil {
@@ -191,7 +191,7 @@ func (h *stateRootHasher) computeFieldRootsWithHasher(ctx context.Context, state
 	fieldRoots[16] = currAttsRoot[:]
 
 	// JustificationBits root.
-	justifiedBitsRoot := bytesutil.ToBytes32(state.justificationBits())
+	justifiedBitsRoot := bytesutil.ToBytes32(state.justificationBitsInternal())
 	fieldRoots[17] = justifiedBitsRoot[:]
 
 	// PreviousJustifiedCheckpoint data structure root.

--- a/beacon-chain/state/v1/getters_block.go
+++ b/beacon-chain/state/v1/getters_block.go
@@ -54,24 +54,24 @@ func (b *BeaconState) BlockRoots() *[8192][32]byte {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.BlockRoots == nil {
+	if b.blockRoots == nil {
 		return nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	roots := [8192][32]byte(*b.blockRoots())
+	roots := [8192][32]byte(*b.blockRootsInternal())
 	return &roots
 }
 
-// blockRoots kept track of in the beacon state.
+// blockRootsInternal kept track of in the beacon state.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) blockRoots() *customtypes.StateRoots {
+func (b *BeaconState) blockRootsInternal() *customtypes.StateRoots {
 	if !b.hasInnerState() {
 		return nil
 	}
-	return b.state.BlockRoots
+	return b.blockRoots
 }
 
 // BlockRootAtIndex retrieves a specific block root based on an
@@ -80,7 +80,7 @@ func (b *BeaconState) BlockRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
 		return [32]byte{}, ErrNilInnerState
 	}
-	if b.state.BlockRoots == nil {
+	if b.blockRoots == nil {
 		return [32]byte{}, nil
 	}
 
@@ -97,9 +97,9 @@ func (b *BeaconState) blockRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
 		return [32]byte{}, ErrNilInnerState
 	}
-	bRoots := make([][]byte, len(b.state.BlockRoots))
+	bRoots := make([][]byte, len(b.blockRoots))
 	for i := range bRoots {
-		bRoots[i] = b.state.BlockRoots[i][:]
+		bRoots[i] = b.blockRoots[i][:]
 	}
 	root, err := bytesutil.SafeCopyRootAtIndex(bRoots, idx)
 	if err != nil {

--- a/beacon-chain/state/v1/getters_checkpoint.go
+++ b/beacon-chain/state/v1/getters_checkpoint.go
@@ -13,28 +13,28 @@ func (b *BeaconState) JustificationBits() bitfield.Bitvector4 {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.JustificationBits == nil {
+	if b.justificationBits == nil {
 		return nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.justificationBits()
+	return b.justificationBitsInternal()
 }
 
-// justificationBits marking which epochs have been justified in the beacon chain.
+// justificationBitsInternal marking which epochs have been justified in the beacon chain.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) justificationBits() bitfield.Bitvector4 {
+func (b *BeaconState) justificationBitsInternal() bitfield.Bitvector4 {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.JustificationBits == nil {
+	if b.justificationBits == nil {
 		return nil
 	}
 
-	res := make([]byte, len(b.state.JustificationBits.Bytes()))
-	copy(res, b.state.JustificationBits.Bytes())
+	res := make([]byte, len(b.justificationBits.Bytes()))
+	copy(res, b.justificationBits.Bytes())
 	return res
 }
 

--- a/beacon-chain/state/v1/getters_misc.go
+++ b/beacon-chain/state/v1/getters_misc.go
@@ -45,17 +45,17 @@ func (b *BeaconState) GenesisValidatorRoot() [32]byte {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.genesisValidatorRoot()
+	return b.genesisValidatorRootInternal()
 }
 
-// genesisValidatorRoot of the beacon state.
+// genesisValidatorRootInternal of the beacon state.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) genesisValidatorRoot() [32]byte {
+func (b *BeaconState) genesisValidatorRootInternal() [32]byte {
 	if !b.hasInnerState() {
 		return params.BeaconConfig().ZeroHash
 	}
 
-	return b.state.GenesisValidatorsRoot
+	return b.genesisValidatorsRoot
 }
 
 // Version of the beacon state. This method
@@ -128,23 +128,23 @@ func (b *BeaconState) HistoricalRoots() [][32]byte {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.HistoricalRoots == nil {
+	if b.historicalRoots == nil {
 		return nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.historicalRoots()
+	return b.historicalRootsInternal()
 }
 
-// historicalRoots based on epochs stored in the beacon state.
+// historicalRootsInternal based on epochs stored in the beacon state.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) historicalRoots() customtypes.HistoricalRoots {
+func (b *BeaconState) historicalRootsInternal() customtypes.HistoricalRoots {
 	if !b.hasInnerState() {
 		return nil
 	}
-	return bytesutil.SafeCopy2d32Bytes(b.state.HistoricalRoots)
+	return bytesutil.SafeCopy2d32Bytes(b.historicalRoots)
 }
 
 // balancesLength returns the length of the balances slice.

--- a/beacon-chain/state/v1/getters_randao.go
+++ b/beacon-chain/state/v1/getters_randao.go
@@ -10,25 +10,25 @@ func (b *BeaconState) RandaoMixes() *[65536][32]byte {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.RandaoMixes == nil {
+	if b.randaoMixes == nil {
 		return nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	mixes := [65536][32]byte(*b.randaoMixes())
+	mixes := [65536][32]byte(*b.randaoMixesInternal())
 	return &mixes
 }
 
-// randaoMixes of block proposers on the beacon chain.
+// randaoMixesInternal of block proposers on the beacon chain.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) randaoMixes() *customtypes.RandaoMixes {
+func (b *BeaconState) randaoMixesInternal() *customtypes.RandaoMixes {
 	if !b.hasInnerState() {
 		return nil
 	}
 
-	return b.state.RandaoMixes
+	return b.randaoMixes
 }
 
 // RandaoMixAtIndex retrieves a specific block root based on an
@@ -37,7 +37,7 @@ func (b *BeaconState) RandaoMixAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
 		return [32]byte{}, ErrNilInnerState
 	}
-	if b.state.RandaoMixes == nil {
+	if b.randaoMixes == nil {
 		return [32]byte{}, nil
 	}
 
@@ -55,9 +55,9 @@ func (b *BeaconState) randaoMixAtIndex(idx uint64) ([32]byte, error) {
 		return [32]byte{}, ErrNilInnerState
 	}
 
-	mixes := make([][]byte, len(b.state.RandaoMixes))
+	mixes := make([][]byte, len(b.randaoMixes))
 	for i := range mixes {
-		mixes[i] = b.state.RandaoMixes[i][:]
+		mixes[i] = b.randaoMixes[i][:]
 	}
 	root, err := bytesutil.SafeCopyRootAtIndex(mixes, idx)
 	if err != nil {
@@ -71,7 +71,7 @@ func (b *BeaconState) RandaoMixesLength() int {
 	if !b.hasInnerState() {
 		return 0
 	}
-	if b.state.RandaoMixes == nil {
+	if b.randaoMixes == nil {
 		return 0
 	}
 
@@ -87,9 +87,9 @@ func (b *BeaconState) randaoMixesLength() int {
 	if !b.hasInnerState() {
 		return 0
 	}
-	if b.state.RandaoMixes == nil {
+	if b.randaoMixes == nil {
 		return 0
 	}
 
-	return len(b.state.RandaoMixes)
+	return len(b.randaoMixes)
 }

--- a/beacon-chain/state/v1/getters_state.go
+++ b/beacon-chain/state/v1/getters_state.go
@@ -24,21 +24,15 @@ func (b *BeaconState) CloneInnerState() interface{} {
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	// TODO: Change this to something else, not sure what yet
+
 	return &ethpb.BeaconState{
-		GenesisValidatorsRoot:       b.genesisValidatorRoot(),
 		Fork:                        b.fork(),
 		LatestBlockHeader:           b.latestBlockHeader(),
-		BlockRoots:                  b.blockRoots(),
-		StateRoots:                  b.stateRoots(),
-		HistoricalRoots:             b.historicalRoots(),
 		Eth1Data:                    b.eth1Data(),
 		Eth1DataVotes:               b.eth1DataVotes(),
 		Validators:                  b.validators(),
-		RandaoMixes:                 b.randaoMixes(),
 		PreviousEpochAttestations:   b.previousEpochAttestations(),
 		CurrentEpochAttestations:    b.currentEpochAttestations(),
-		JustificationBits:           b.justificationBits(),
 		PreviousJustifiedCheckpoint: b.previousJustifiedCheckpoint(),
 		CurrentJustifiedCheckpoint:  b.currentJustifiedCheckpoint(),
 		FinalizedCheckpoint:         b.finalizedCheckpoint(),
@@ -56,24 +50,24 @@ func (b *BeaconState) StateRoots() *[8192][32]byte {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.StateRoots == nil {
+	if b.stateRoots == nil {
 		return nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	roots := [8192][32]byte(*b.stateRoots())
+	roots := [8192][32]byte(*b.stateRootsInternal())
 	return &roots
 }
 
-// StateRoots kept track of in the beacon state.
+// stateRootsInternal kept track of in the beacon state.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) stateRoots() *customtypes.StateRoots {
+func (b *BeaconState) stateRootsInternal() *customtypes.StateRoots {
 	if !b.hasInnerState() {
 		return nil
 	}
-	return b.state.StateRoots
+	return b.stateRoots
 }
 
 // StateRootAtIndex retrieves a specific state root based on an
@@ -82,7 +76,7 @@ func (b *BeaconState) StateRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
 		return [32]byte{}, ErrNilInnerState
 	}
-	if b.state.StateRoots == nil {
+	if b.stateRoots == nil {
 		return [32]byte{}, nil
 	}
 
@@ -99,9 +93,9 @@ func (b *BeaconState) stateRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
 		return [32]byte{}, ErrNilInnerState
 	}
-	sRoots := make([][]byte, len(b.state.StateRoots))
+	sRoots := make([][]byte, len(b.stateRoots))
 	for i := range sRoots {
-		sRoots[i] = b.state.StateRoots[i][:]
+		sRoots[i] = b.stateRoots[i][:]
 	}
 	root, err := bytesutil.SafeCopyRootAtIndex(sRoots, idx)
 	if err != nil {

--- a/beacon-chain/state/v1/setters_block.go
+++ b/beacon-chain/state/v1/setters_block.go
@@ -34,7 +34,7 @@ func (b *BeaconState) SetBlockRoots(val *[8192][32]byte) error {
 	b.sharedFieldReferences[blockRoots] = stateutil.NewRef(1)
 
 	roots := customtypes.StateRoots(*val)
-	b.state.BlockRoots = &roots
+	b.blockRoots = &roots
 	b.markFieldAsDirty(blockRoots)
 	b.rebuildTrie[blockRoots] = true
 	return nil
@@ -46,16 +46,16 @@ func (b *BeaconState) UpdateBlockRootAtIndex(idx uint64, blockRoot [32]byte) err
 	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
-	if uint64(len(b.state.BlockRoots)) <= idx {
+	if uint64(len(b.blockRoots)) <= idx {
 		return fmt.Errorf("invalid index provided %d", idx)
 	}
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	r := b.state.BlockRoots
+	r := b.blockRoots
 	if ref := b.sharedFieldReferences[blockRoots]; ref.Refs() > 1 {
 		// Copy elements in underlying array by reference.
-		roots := *b.state.BlockRoots
+		roots := *b.blockRoots
 		rootsCopy := roots
 		r = &rootsCopy
 		ref.MinusRef()
@@ -63,7 +63,7 @@ func (b *BeaconState) UpdateBlockRootAtIndex(idx uint64, blockRoot [32]byte) err
 	}
 
 	r[idx] = blockRoot
-	b.state.BlockRoots = r
+	b.blockRoots = r
 
 	b.markFieldAsDirty(blockRoots)
 	b.addDirtyIndices(blockRoots, []uint64{idx})

--- a/beacon-chain/state/v1/setters_checkpoint.go
+++ b/beacon-chain/state/v1/setters_checkpoint.go
@@ -13,7 +13,7 @@ func (b *BeaconState) SetJustificationBits(val bitfield.Bitvector4) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	b.state.JustificationBits = val
+	b.justificationBits = val
 	b.markFieldAsDirty(justificationBits)
 	return nil
 }

--- a/beacon-chain/state/v1/setters_misc.go
+++ b/beacon-chain/state/v1/setters_misc.go
@@ -53,7 +53,7 @@ func (b *BeaconState) SetGenesisValidatorRoot(val [32]byte) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	b.state.GenesisValidatorsRoot = val
+	b.genesisValidatorsRoot = val
 	b.markFieldAsDirty(genesisValidatorRoot)
 	return nil
 }
@@ -100,7 +100,7 @@ func (b *BeaconState) SetHistoricalRoots(val [][32]byte) error {
 	b.sharedFieldReferences[historicalRoots].MinusRef()
 	b.sharedFieldReferences[historicalRoots] = stateutil.NewRef(1)
 
-	b.state.HistoricalRoots = val
+	b.historicalRoots = val
 	b.markFieldAsDirty(historicalRoots)
 	return nil
 }
@@ -114,15 +114,15 @@ func (b *BeaconState) AppendHistoricalRoots(root [32]byte) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	roots := b.state.HistoricalRoots
+	roots := b.historicalRoots
 	if b.sharedFieldReferences[historicalRoots].Refs() > 1 {
-		roots = make([][32]byte, len(b.state.HistoricalRoots))
-		copy(roots, b.state.HistoricalRoots)
+		roots = make([][32]byte, len(b.historicalRoots))
+		copy(roots, b.historicalRoots)
 		b.sharedFieldReferences[historicalRoots].MinusRef()
 		b.sharedFieldReferences[historicalRoots] = stateutil.NewRef(1)
 	}
 
-	b.state.HistoricalRoots = append(roots, root)
+	b.historicalRoots = append(roots, root)
 	b.markFieldAsDirty(historicalRoots)
 	return nil
 }

--- a/beacon-chain/state/v1/setters_randao.go
+++ b/beacon-chain/state/v1/setters_randao.go
@@ -19,7 +19,7 @@ func (b *BeaconState) SetRandaoMixes(val *[65536][32]byte) error {
 	b.sharedFieldReferences[randaoMixes] = stateutil.NewRef(1)
 
 	mixes := customtypes.RandaoMixes(*val)
-	b.state.RandaoMixes = &mixes
+	b.randaoMixes = &mixes
 	b.markFieldAsDirty(randaoMixes)
 	b.rebuildTrie[randaoMixes] = true
 	return nil
@@ -31,16 +31,16 @@ func (b *BeaconState) UpdateRandaoMixesAtIndex(idx uint64, val [32]byte) error {
 	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
-	if uint64(len(b.state.RandaoMixes)) <= idx {
+	if uint64(len(b.randaoMixes)) <= idx {
 		return errors.Errorf("invalid index provided %d", idx)
 	}
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	mixes := b.state.RandaoMixes
+	mixes := b.randaoMixes
 	if refs := b.sharedFieldReferences[randaoMixes].Refs(); refs > 1 {
 		// Copy elements in underlying array by reference.
-		m := *b.state.RandaoMixes
+		m := *b.randaoMixes
 		mCopy := m
 		mixes = &mCopy
 		b.sharedFieldReferences[randaoMixes].MinusRef()
@@ -48,7 +48,7 @@ func (b *BeaconState) UpdateRandaoMixesAtIndex(idx uint64, val [32]byte) error {
 	}
 
 	mixes[idx] = val
-	b.state.RandaoMixes = mixes
+	b.randaoMixes = mixes
 	b.markFieldAsDirty(randaoMixes)
 	b.addDirtyIndices(randaoMixes, []uint64{idx})
 

--- a/beacon-chain/state/v1/setters_state.go
+++ b/beacon-chain/state/v1/setters_state.go
@@ -19,7 +19,7 @@ func (b *BeaconState) SetStateRoots(val *[8192][32]byte) error {
 	b.sharedFieldReferences[stateRoots] = stateutil.NewRef(1)
 
 	roots := customtypes.StateRoots(*val)
-	b.state.StateRoots = &roots
+	b.stateRoots = &roots
 	b.markFieldAsDirty(stateRoots)
 	b.rebuildTrie[stateRoots] = true
 	return nil
@@ -33,7 +33,7 @@ func (b *BeaconState) UpdateStateRootAtIndex(idx uint64, stateRoot [32]byte) err
 	}
 
 	b.lock.RLock()
-	if uint64(len(b.state.StateRoots)) <= idx {
+	if uint64(len(b.stateRoots)) <= idx {
 		b.lock.RUnlock()
 		return errors.Errorf("invalid index provided %d", idx)
 	}
@@ -43,10 +43,10 @@ func (b *BeaconState) UpdateStateRootAtIndex(idx uint64, stateRoot [32]byte) err
 	defer b.lock.Unlock()
 
 	// Check if we hold the only reference to the shared state roots slice.
-	r := b.state.StateRoots
+	r := b.stateRoots
 	if ref := b.sharedFieldReferences[stateRoots]; ref.Refs() > 1 {
 		// Copy elements in underlying array by reference.
-		roots := *b.state.StateRoots
+		roots := *b.stateRoots
 		rootsCopy := roots
 		r = &rootsCopy
 		ref.MinusRef()
@@ -54,7 +54,7 @@ func (b *BeaconState) UpdateStateRootAtIndex(idx uint64, stateRoot [32]byte) err
 	}
 
 	r[idx] = stateRoot
-	b.state.StateRoots = r
+	b.stateRoots = r
 
 	b.markFieldAsDirty(stateRoots)
 	b.addDirtyIndices(stateRoots, []uint64{idx})

--- a/beacon-chain/state/v1/state_trie.go
+++ b/beacon-chain/state/v1/state_trie.go
@@ -97,30 +97,35 @@ func (b *BeaconState) Copy() state.BeaconState {
 		// Large arrays, infrequently changed, constant size.
 		slashings: b.slashings,
 
+		// Large arrays, infrequently changed, constant size.
+		blockRoots:  b.blockRoots,
+		stateRoots:  b.stateRoots,
+		randaoMixes: b.randaoMixes,
+
 		// Large arrays, increases over time.
-		balances: b.balances,
+		balances:        b.balances,
+		historicalRoots: b.historicalRoots,
+
+		// Everything else, too small to be concerned about, constant size.
+		genesisValidatorsRoot: b.genesisValidatorsRoot,
+		justificationBits:     b.justificationBits,
+
 		state: &ethpb.BeaconState{
 			// Large arrays, infrequently changed, constant size.
-			RandaoMixes:               b.state.RandaoMixes,
-			StateRoots:                b.state.StateRoots,
-			BlockRoots:                b.state.BlockRoots,
 			PreviousEpochAttestations: b.state.PreviousEpochAttestations,
 			CurrentEpochAttestations:  b.state.CurrentEpochAttestations,
 			Eth1DataVotes:             b.state.Eth1DataVotes,
 
 			// Large arrays, increases over time.
-			Validators:      b.state.Validators,
-			HistoricalRoots: b.state.HistoricalRoots,
+			Validators: b.state.Validators,
 
 			// Everything else, too small to be concerned about, constant size.
 			Fork:                        b.fork(),
 			LatestBlockHeader:           b.latestBlockHeader(),
 			Eth1Data:                    b.eth1Data(),
-			JustificationBits:           b.justificationBits(),
 			PreviousJustifiedCheckpoint: b.previousJustifiedCheckpoint(),
 			CurrentJustifiedCheckpoint:  b.currentJustifiedCheckpoint(),
 			FinalizedCheckpoint:         b.finalizedCheckpoint(),
-			GenesisValidatorsRoot:       b.genesisValidatorRoot(),
 		},
 		dirtyFields:           make(map[types.FieldIndex]bool, fieldCount),
 		dirtyIndices:          make(map[types.FieldIndex][]uint64, fieldCount),
@@ -264,7 +269,7 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 	case genesisTime:
 		return ssz.Uint64Root(b.genesisTime), nil
 	case genesisValidatorRoot:
-		return b.state.GenesisValidatorsRoot, nil
+		return b.genesisValidatorsRoot, nil
 	case slot:
 		return ssz.Uint64Root(uint64(b.slot)), nil
 	case eth1DepositIndex:
@@ -275,28 +280,28 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 		return stateutil.BlockHeaderRoot(b.state.LatestBlockHeader)
 	case blockRoots:
 		if b.rebuildTrie[field] {
-			err := b.resetFieldTrie(field, b.state.BlockRoots, uint64(params.BeaconConfig().SlotsPerHistoricalRoot))
+			err := b.resetFieldTrie(field, b.blockRoots, uint64(params.BeaconConfig().SlotsPerHistoricalRoot))
 			if err != nil {
 				return [32]byte{}, err
 			}
 			delete(b.rebuildTrie, field)
 			return b.stateFieldLeaves[field].TrieRoot()
 		}
-		return b.recomputeFieldTrie(blockRoots, b.state.BlockRoots)
+		return b.recomputeFieldTrie(blockRoots, b.blockRoots)
 	case stateRoots:
 		if b.rebuildTrie[field] {
-			err := b.resetFieldTrie(field, b.state.StateRoots, uint64(params.BeaconConfig().SlotsPerHistoricalRoot))
+			err := b.resetFieldTrie(field, b.stateRoots, uint64(params.BeaconConfig().SlotsPerHistoricalRoot))
 			if err != nil {
 				return [32]byte{}, err
 			}
 			delete(b.rebuildTrie, field)
 			return b.stateFieldLeaves[field].TrieRoot()
 		}
-		return b.recomputeFieldTrie(stateRoots, b.state.StateRoots)
+		return b.recomputeFieldTrie(stateRoots, b.stateRoots)
 	case historicalRoots:
-		hRoots := make([][]byte, len(b.state.HistoricalRoots))
+		hRoots := make([][]byte, len(b.historicalRoots))
 		for i := range hRoots {
-			hRoots[i] = b.state.HistoricalRoots[i][:]
+			hRoots[i] = b.historicalRoots[i][:]
 		}
 		return ssz.ByteArrayRootWithLimit(hRoots, params.BeaconConfig().HistoricalRootsLimit)
 	case eth1Data:
@@ -329,14 +334,14 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 		return stateutil.Uint64ListRootWithRegistryLimit(b.balances)
 	case randaoMixes:
 		if b.rebuildTrie[field] {
-			err := b.resetFieldTrie(field, b.state.RandaoMixes, uint64(params.BeaconConfig().EpochsPerHistoricalVector))
+			err := b.resetFieldTrie(field, b.randaoMixes, uint64(params.BeaconConfig().EpochsPerHistoricalVector))
 			if err != nil {
 				return [32]byte{}, err
 			}
 			delete(b.rebuildTrie, field)
 			return b.stateFieldLeaves[field].TrieRoot()
 		}
-		return b.recomputeFieldTrie(randaoMixes, b.state.RandaoMixes)
+		return b.recomputeFieldTrie(randaoMixes, b.randaoMixes)
 	case slashings:
 		return ssz.SlashingsRoot(b.slashings)
 	case previousEpochAttestations:
@@ -368,7 +373,7 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 		}
 		return b.recomputeFieldTrie(field, b.state.CurrentEpochAttestations)
 	case justificationBits:
-		return bytesutil.ToBytes32(b.state.JustificationBits), nil
+		return bytesutil.ToBytes32(b.justificationBits), nil
 	case previousJustifiedCheckpoint:
 		return ssz.CheckpointRoot(hasher, b.state.PreviousJustifiedCheckpoint)
 	case currentJustifiedCheckpoint:

--- a/beacon-chain/state/v1/types.go
+++ b/beacon-chain/state/v1/types.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/pkg/errors"
 	eth2types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
+	customtypes "github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/fieldtrie"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/types"
@@ -43,10 +45,16 @@ var ErrNilInnerState = errors.New("nil inner state")
 // getters and setters for its respective values and helpful functions such as HashTreeRoot().
 type BeaconState struct {
 	genesisTime           uint64
+	genesisValidatorsRoot customtypes.Byte32
 	slot                  eth2types.Slot
+	blockRoots            *customtypes.StateRoots
+	stateRoots            *customtypes.StateRoots
+	historicalRoots       customtypes.HistoricalRoots
 	eth1DepositIndex      uint64
 	balances              []uint64
+	randaoMixes           *customtypes.RandaoMixes
 	slashings             []uint64
+	justificationBits     bitfield.Bitvector4
 	state                 *ethpb.BeaconState
 	lock                  sync.RWMutex
 	dirtyFields           map[types.FieldIndex]bool

--- a/beacon-chain/state/v2/getters_block.go
+++ b/beacon-chain/state/v2/getters_block.go
@@ -54,24 +54,24 @@ func (b *BeaconState) BlockRoots() *[8192][32]byte {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.BlockRoots == nil {
+	if b.blockRoots == nil {
 		return nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	roots := [8192][32]byte(*b.blockRoots())
+	roots := [8192][32]byte(*b.blockRootsInternal())
 	return &roots
 }
 
-// blockRoots kept track of in the beacon state.
+// blockRootsInternal kept track of in the beacon state.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) blockRoots() *customtypes.StateRoots {
+func (b *BeaconState) blockRootsInternal() *customtypes.StateRoots {
 	if !b.hasInnerState() {
 		return nil
 	}
-	return b.state.BlockRoots
+	return b.blockRoots
 }
 
 // BlockRootAtIndex retrieves a specific block root based on an
@@ -80,7 +80,7 @@ func (b *BeaconState) BlockRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
 		return [32]byte{}, ErrNilInnerState
 	}
-	if b.state.BlockRoots == nil {
+	if b.blockRoots == nil {
 		return [32]byte{}, nil
 	}
 
@@ -97,9 +97,9 @@ func (b *BeaconState) blockRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
 		return [32]byte{}, ErrNilInnerState
 	}
-	bRoots := make([][]byte, len(b.state.BlockRoots))
+	bRoots := make([][]byte, len(b.blockRoots))
 	for i := range bRoots {
-		bRoots[i] = b.state.BlockRoots[i][:]
+		bRoots[i] = b.blockRoots[i][:]
 	}
 	root, err := bytesutil.SafeCopyRootAtIndex(bRoots, idx)
 	if err != nil {

--- a/beacon-chain/state/v2/getters_checkpoint.go
+++ b/beacon-chain/state/v2/getters_checkpoint.go
@@ -13,28 +13,28 @@ func (b *BeaconState) JustificationBits() bitfield.Bitvector4 {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.JustificationBits == nil {
+	if b.justificationBits == nil {
 		return nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.justificationBits()
+	return b.justificationBitsInternal()
 }
 
-// justificationBits marking which epochs have been justified in the beacon chain.
+// justificationBitsInternal marking which epochs have been justified in the beacon chain.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) justificationBits() bitfield.Bitvector4 {
+func (b *BeaconState) justificationBitsInternal() bitfield.Bitvector4 {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.JustificationBits == nil {
+	if b.justificationBits == nil {
 		return nil
 	}
 
-	res := make([]byte, len(b.state.JustificationBits.Bytes()))
-	copy(res, b.state.JustificationBits.Bytes())
+	res := make([]byte, len(b.justificationBits.Bytes()))
+	copy(res, b.justificationBits.Bytes())
 	return res
 }
 

--- a/beacon-chain/state/v2/getters_misc.go
+++ b/beacon-chain/state/v2/getters_misc.go
@@ -42,17 +42,17 @@ func (b *BeaconState) GenesisValidatorRoot() [32]byte {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.genesisValidatorRoot()
+	return b.genesisValidatorRootInternal()
 }
 
-// genesisValidatorRoot of the beacon state.
+// genesisValidatorRootInternal of the beacon state.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) genesisValidatorRoot() [32]byte {
+func (b *BeaconState) genesisValidatorRootInternal() [32]byte {
 	if !b.hasInnerState() {
 		return params.BeaconConfig().ZeroHash
 	}
 
-	return b.state.GenesisValidatorsRoot
+	return b.genesisValidatorsRoot
 }
 
 // GenesisUnixTime returns the genesis time as time.Time.
@@ -171,23 +171,23 @@ func (b *BeaconState) HistoricalRoots() [][32]byte {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.HistoricalRoots == nil {
+	if b.historicalRoots == nil {
 		return nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	return b.historicalRoots()
+	return b.historicalRootsInternal()
 }
 
-// historicalRoots based on epochs stored in the beacon state.
+// historicalRootsInternal based on epochs stored in the beacon state.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) historicalRoots() customtypes.HistoricalRoots {
+func (b *BeaconState) historicalRootsInternal() customtypes.HistoricalRoots {
 	if !b.hasInnerState() {
 		return nil
 	}
-	return bytesutil.SafeCopy2d32Bytes(b.state.HistoricalRoots)
+	return bytesutil.SafeCopy2d32Bytes(b.historicalRoots)
 }
 
 // balancesLength returns the length of the balances slice.

--- a/beacon-chain/state/v2/getters_randao.go
+++ b/beacon-chain/state/v2/getters_randao.go
@@ -10,25 +10,25 @@ func (b *BeaconState) RandaoMixes() *[65536][32]byte {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.RandaoMixes == nil {
+	if b.randaoMixes == nil {
 		return nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	mixes := [65536][32]byte(*b.randaoMixes())
+	mixes := [65536][32]byte(*b.randaoMixesInternal())
 	return &mixes
 }
 
-// randaoMixes of block proposers on the beacon chain.
+// randaoMixesInternal of block proposers on the beacon chain.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) randaoMixes() *customtypes.RandaoMixes {
+func (b *BeaconState) randaoMixesInternal() *customtypes.RandaoMixes {
 	if !b.hasInnerState() {
 		return nil
 	}
 
-	return b.state.RandaoMixes
+	return b.randaoMixes
 }
 
 // RandaoMixAtIndex retrieves a specific block root based on an
@@ -37,7 +37,7 @@ func (b *BeaconState) RandaoMixAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
 		return [32]byte{}, ErrNilInnerState
 	}
-	if b.state.RandaoMixes == nil {
+	if b.randaoMixes == nil {
 		return [32]byte{}, nil
 	}
 
@@ -55,9 +55,9 @@ func (b *BeaconState) randaoMixAtIndex(idx uint64) ([32]byte, error) {
 		return [32]byte{}, ErrNilInnerState
 	}
 
-	mixes := make([][]byte, len(b.state.RandaoMixes))
+	mixes := make([][]byte, len(b.randaoMixes))
 	for i := range mixes {
-		mixes[i] = b.state.RandaoMixes[i][:]
+		mixes[i] = b.randaoMixes[i][:]
 	}
 	root, err := bytesutil.SafeCopyRootAtIndex(mixes, idx)
 	if err != nil {
@@ -71,7 +71,7 @@ func (b *BeaconState) RandaoMixesLength() int {
 	if !b.hasInnerState() {
 		return 0
 	}
-	if b.state.RandaoMixes == nil {
+	if b.randaoMixes == nil {
 		return 0
 	}
 
@@ -87,9 +87,9 @@ func (b *BeaconState) randaoMixesLength() int {
 	if !b.hasInnerState() {
 		return 0
 	}
-	if b.state.RandaoMixes == nil {
+	if b.randaoMixes == nil {
 		return 0
 	}
 
-	return len(b.state.RandaoMixes)
+	return len(b.randaoMixes)
 }

--- a/beacon-chain/state/v2/getters_state.go
+++ b/beacon-chain/state/v2/getters_state.go
@@ -24,19 +24,12 @@ func (b *BeaconState) CloneInnerState() interface{} {
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	// TODO: Change this to something else, not sure what yet
 	return &ethpb.BeaconStateAltair{
-		GenesisValidatorsRoot:       b.genesisValidatorRoot(),
 		Fork:                        b.fork(),
 		LatestBlockHeader:           b.latestBlockHeader(),
-		BlockRoots:                  b.blockRoots(),
-		StateRoots:                  b.stateRoots(),
-		HistoricalRoots:             b.historicalRoots(),
 		Eth1Data:                    b.eth1Data(),
 		Eth1DataVotes:               b.eth1DataVotes(),
 		Validators:                  b.validators(),
-		RandaoMixes:                 b.randaoMixes(),
-		JustificationBits:           b.justificationBits(),
 		PreviousJustifiedCheckpoint: b.previousJustifiedCheckpoint(),
 		CurrentJustifiedCheckpoint:  b.currentJustifiedCheckpoint(),
 		FinalizedCheckpoint:         b.finalizedCheckpoint(),
@@ -56,24 +49,24 @@ func (b *BeaconState) StateRoots() *[8192][32]byte {
 	if !b.hasInnerState() {
 		return nil
 	}
-	if b.state.StateRoots == nil {
+	if b.stateRoots == nil {
 		return nil
 	}
 
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	roots := [8192][32]byte(*b.stateRoots())
+	roots := [8192][32]byte(*b.stateRootsInternal())
 	return &roots
 }
 
-// StateRoots kept track of in the beacon state.
+// stateRootsInternal kept track of in the beacon state.
 // This assumes that a lock is already held on BeaconState.
-func (b *BeaconState) stateRoots() *customtypes.StateRoots {
+func (b *BeaconState) stateRootsInternal() *customtypes.StateRoots {
 	if !b.hasInnerState() {
 		return nil
 	}
-	return b.state.StateRoots
+	return b.stateRoots
 }
 
 // StateRootAtIndex retrieves a specific state root based on an
@@ -82,7 +75,7 @@ func (b *BeaconState) StateRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
 		return [32]byte{}, ErrNilInnerState
 	}
-	if b.state.StateRoots == nil {
+	if b.stateRoots == nil {
 		return [32]byte{}, nil
 	}
 
@@ -99,9 +92,9 @@ func (b *BeaconState) stateRootAtIndex(idx uint64) ([32]byte, error) {
 	if !b.hasInnerState() {
 		return [32]byte{}, ErrNilInnerState
 	}
-	sRoots := make([][]byte, len(b.state.BlockRoots))
+	sRoots := make([][]byte, len(b.stateRoots))
 	for i := range sRoots {
-		sRoots[i] = b.state.StateRoots[i][:]
+		sRoots[i] = b.stateRoots[i][:]
 	}
 	root, err := bytesutil.SafeCopyRootAtIndex(sRoots, idx)
 	if err != nil {

--- a/beacon-chain/state/v2/setters_block.go
+++ b/beacon-chain/state/v2/setters_block.go
@@ -34,7 +34,7 @@ func (b *BeaconState) SetBlockRoots(val *[8192][32]byte) error {
 	b.sharedFieldReferences[blockRoots] = stateutil.NewRef(1)
 
 	roots := customtypes.StateRoots(*val)
-	b.state.BlockRoots = &roots
+	b.blockRoots = &roots
 	b.markFieldAsDirty(blockRoots)
 	b.rebuildTrie[blockRoots] = true
 	return nil
@@ -46,16 +46,16 @@ func (b *BeaconState) UpdateBlockRootAtIndex(idx uint64, blockRoot [32]byte) err
 	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
-	if uint64(len(b.state.BlockRoots)) <= idx {
+	if uint64(len(b.blockRoots)) <= idx {
 		return fmt.Errorf("invalid index provided %d", idx)
 	}
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	r := b.state.BlockRoots
+	r := b.blockRoots
 	if ref := b.sharedFieldReferences[blockRoots]; ref.Refs() > 1 {
 		// Copy elements in underlying array by reference.
-		roots := *b.state.BlockRoots
+		roots := *b.blockRoots
 		rootsCopy := roots
 		r = &rootsCopy
 		ref.MinusRef()
@@ -63,7 +63,7 @@ func (b *BeaconState) UpdateBlockRootAtIndex(idx uint64, blockRoot [32]byte) err
 	}
 
 	r[idx] = blockRoot
-	b.state.BlockRoots = r
+	b.blockRoots = r
 
 	b.markFieldAsDirty(blockRoots)
 	b.addDirtyIndices(blockRoots, []uint64{idx})

--- a/beacon-chain/state/v2/setters_checkpoint.go
+++ b/beacon-chain/state/v2/setters_checkpoint.go
@@ -13,7 +13,7 @@ func (b *BeaconState) SetJustificationBits(val bitfield.Bitvector4) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	b.state.JustificationBits = val
+	b.justificationBits = val
 	b.markFieldAsDirty(justificationBits)
 	return nil
 }

--- a/beacon-chain/state/v2/setters_misc.go
+++ b/beacon-chain/state/v2/setters_misc.go
@@ -52,7 +52,7 @@ func (b *BeaconState) SetGenesisValidatorRoot(val [32]byte) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	b.state.GenesisValidatorsRoot = val
+	b.genesisValidatorsRoot = val
 	b.markFieldAsDirty(genesisValidatorRoot)
 	return nil
 }
@@ -99,7 +99,7 @@ func (b *BeaconState) SetHistoricalRoots(val [][32]byte) error {
 	b.sharedFieldReferences[historicalRoots].MinusRef()
 	b.sharedFieldReferences[historicalRoots] = stateutil.NewRef(1)
 
-	b.state.HistoricalRoots = val
+	b.historicalRoots = val
 	b.markFieldAsDirty(historicalRoots)
 	return nil
 }
@@ -113,15 +113,15 @@ func (b *BeaconState) AppendHistoricalRoots(root [32]byte) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	roots := b.state.HistoricalRoots
+	roots := b.historicalRoots
 	if b.sharedFieldReferences[historicalRoots].Refs() > 1 {
-		roots = make([][32]byte, len(b.state.HistoricalRoots))
-		copy(roots, b.state.HistoricalRoots)
+		roots = make([][32]byte, len(b.historicalRoots))
+		copy(roots, b.historicalRoots)
 		b.sharedFieldReferences[historicalRoots].MinusRef()
 		b.sharedFieldReferences[historicalRoots] = stateutil.NewRef(1)
 	}
 
-	b.state.HistoricalRoots = append(roots, root)
+	b.historicalRoots = append(roots, root)
 	b.markFieldAsDirty(historicalRoots)
 	return nil
 }

--- a/beacon-chain/state/v2/setters_randao.go
+++ b/beacon-chain/state/v2/setters_randao.go
@@ -19,7 +19,7 @@ func (b *BeaconState) SetRandaoMixes(val *[65536][32]byte) error {
 	b.sharedFieldReferences[randaoMixes] = stateutil.NewRef(1)
 
 	mixes := customtypes.RandaoMixes(*val)
-	b.state.RandaoMixes = &mixes
+	b.randaoMixes = &mixes
 	b.markFieldAsDirty(randaoMixes)
 	b.rebuildTrie[randaoMixes] = true
 	return nil
@@ -31,16 +31,16 @@ func (b *BeaconState) UpdateRandaoMixesAtIndex(idx uint64, val [32]byte) error {
 	if !b.hasInnerState() {
 		return ErrNilInnerState
 	}
-	if uint64(len(b.state.RandaoMixes)) <= idx {
+	if uint64(len(b.randaoMixes)) <= idx {
 		return errors.Errorf("invalid index provided %d", idx)
 	}
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	mixes := b.state.RandaoMixes
+	mixes := b.randaoMixes
 	if refs := b.sharedFieldReferences[randaoMixes].Refs(); refs > 1 {
 		// Copy elements in underlying array by reference.
-		m := *b.state.RandaoMixes
+		m := *b.randaoMixes
 		mCopy := m
 		mixes = &mCopy
 		b.sharedFieldReferences[randaoMixes].MinusRef()
@@ -48,7 +48,7 @@ func (b *BeaconState) UpdateRandaoMixesAtIndex(idx uint64, val [32]byte) error {
 	}
 
 	mixes[idx] = val
-	b.state.RandaoMixes = mixes
+	b.randaoMixes = mixes
 	b.markFieldAsDirty(randaoMixes)
 	b.addDirtyIndices(randaoMixes, []uint64{idx})
 

--- a/beacon-chain/state/v2/setters_state.go
+++ b/beacon-chain/state/v2/setters_state.go
@@ -19,7 +19,7 @@ func (b *BeaconState) SetStateRoots(val *[8192][32]byte) error {
 	b.sharedFieldReferences[stateRoots] = stateutil.NewRef(1)
 
 	roots := customtypes.StateRoots(*val)
-	b.state.StateRoots = &roots
+	b.stateRoots = &roots
 	b.markFieldAsDirty(stateRoots)
 	b.rebuildTrie[stateRoots] = true
 	return nil
@@ -33,7 +33,7 @@ func (b *BeaconState) UpdateStateRootAtIndex(idx uint64, stateRoot [32]byte) err
 	}
 
 	b.lock.RLock()
-	if uint64(len(b.state.StateRoots)) <= idx {
+	if uint64(len(b.stateRoots)) <= idx {
 		b.lock.RUnlock()
 		return errors.Errorf("invalid index provided %d", idx)
 	}
@@ -43,10 +43,10 @@ func (b *BeaconState) UpdateStateRootAtIndex(idx uint64, stateRoot [32]byte) err
 	defer b.lock.Unlock()
 
 	// Check if we hold the only reference to the shared state roots slice.
-	r := b.state.StateRoots
+	r := b.stateRoots
 	if ref := b.sharedFieldReferences[stateRoots]; ref.Refs() > 1 {
 		// Copy elements in underlying array by reference.
-		roots := *b.state.StateRoots
+		roots := *b.stateRoots
 		rootsCopy := roots
 		r = &rootsCopy
 		ref.MinusRef()
@@ -54,7 +54,7 @@ func (b *BeaconState) UpdateStateRootAtIndex(idx uint64, stateRoot [32]byte) err
 	}
 
 	r[idx] = stateRoot
-	b.state.StateRoots = r
+	b.stateRoots = r
 
 	b.markFieldAsDirty(stateRoots)
 	b.addDirtyIndices(stateRoots, []uint64{idx})

--- a/beacon-chain/state/v2/types.go
+++ b/beacon-chain/state/v2/types.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 	eth2types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/go-bitfield"
+	customtypes "github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/fieldtrie"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stateutil"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/types"
@@ -37,12 +39,18 @@ var ErrNilInnerState = errors.New("nil inner state")
 // getters and setters for its respective values and helpful functions such as HashTreeRoot().
 type BeaconState struct {
 	genesisTime                uint64
+	genesisValidatorsRoot      customtypes.Byte32
 	slot                       eth2types.Slot
+	blockRoots                 *customtypes.StateRoots
+	stateRoots                 *customtypes.StateRoots
+	historicalRoots            customtypes.HistoricalRoots
 	eth1DepositIndex           uint64
 	balances                   []uint64
+	randaoMixes                *customtypes.RandaoMixes
 	slashings                  []uint64
 	previousEpochParticipation []byte
 	currentEpochParticipation  []byte
+	justificationBits          bitfield.Bitvector4
 	inactivityScores           []uint64
 	state                      *ethpb.BeaconStateAltair
 	lock                       sync.RWMutex

--- a/proto/prysm/v1alpha1/beacon_state.pb.go
+++ b/proto/prysm/v1alpha1/beacon_state.pb.go
@@ -13,7 +13,6 @@ import (
 	proto "github.com/golang/protobuf/proto"
 	github_com_prysmaticlabs_eth2_types "github.com/prysmaticlabs/eth2-types"
 	github_com_prysmaticlabs_go_bitfield "github.com/prysmaticlabs/go-bitfield"
-	github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types "github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types"
 	_ "github.com/prysmaticlabs/prysm/proto/eth/ext"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -35,22 +34,16 @@ type BeaconState struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	GenesisValidatorsRoot       github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.Byte32          `protobuf:"bytes,1002,opt,name=genesis_validators_root,json=genesisValidatorsRoot,proto3" json:"genesis_validators_root,omitempty" cast-type:"github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types.Byte32" ssz-size:"32"`
-	Fork                        *Fork                                                                          `protobuf:"bytes,1004,opt,name=fork,proto3" json:"fork,omitempty"`
-	LatestBlockHeader           *BeaconBlockHeader                                                             `protobuf:"bytes,2001,opt,name=latest_block_header,json=latestBlockHeader,proto3" json:"latest_block_header,omitempty"`
-	BlockRoots                  *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots     `protobuf:"bytes,2002,opt,name=block_roots,json=blockRoots,proto3" json:"block_roots,omitempty" cast-type:"github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types.StateRoots" ssz-size:"8192,32"`
-	StateRoots                  *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots     `protobuf:"bytes,2003,opt,name=state_roots,json=stateRoots,proto3" json:"state_roots,omitempty" cast-type:"github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types.StateRoots" ssz-size:"8192,32"`
-	HistoricalRoots             github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.HistoricalRoots `protobuf:"bytes,2004,opt,name=historical_roots,json=historicalRoots,proto3" json:"historical_roots,omitempty" cast-type:"github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types.HistoricalRoots" ssz-max:"16777216" ssz-size:"?,32"`
-	Eth1Data                    *Eth1Data                                                                      `protobuf:"bytes,3001,opt,name=eth1_data,json=eth1Data,proto3" json:"eth1_data,omitempty"`
-	Eth1DataVotes               []*Eth1Data                                                                    `protobuf:"bytes,3002,rep,name=eth1_data_votes,json=eth1DataVotes,proto3" json:"eth1_data_votes,omitempty" ssz-max:"2048"`
-	Validators                  []*Validator                                                                   `protobuf:"bytes,4001,rep,name=validators,proto3" json:"validators,omitempty" ssz-max:"1099511627776"`
-	RandaoMixes                 *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.RandaoMixes    `protobuf:"bytes,5001,opt,name=randao_mixes,json=randaoMixes,proto3" json:"randao_mixes,omitempty" cast-type:"github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types.RandaoMixes" ssz-size:"65536,32"`
-	PreviousEpochAttestations   []*PendingAttestation                                                          `protobuf:"bytes,7001,rep,name=previous_epoch_attestations,json=previousEpochAttestations,proto3" json:"previous_epoch_attestations,omitempty" ssz-max:"4096"`
-	CurrentEpochAttestations    []*PendingAttestation                                                          `protobuf:"bytes,7002,rep,name=current_epoch_attestations,json=currentEpochAttestations,proto3" json:"current_epoch_attestations,omitempty" ssz-max:"4096"`
-	JustificationBits           github_com_prysmaticlabs_go_bitfield.Bitvector4                                `protobuf:"bytes,8001,opt,name=justification_bits,json=justificationBits,proto3" json:"justification_bits,omitempty" cast-type:"github.com/prysmaticlabs/go-bitfield.Bitvector4" ssz-size:"1"`
-	PreviousJustifiedCheckpoint *Checkpoint                                                                    `protobuf:"bytes,8002,opt,name=previous_justified_checkpoint,json=previousJustifiedCheckpoint,proto3" json:"previous_justified_checkpoint,omitempty"`
-	CurrentJustifiedCheckpoint  *Checkpoint                                                                    `protobuf:"bytes,8003,opt,name=current_justified_checkpoint,json=currentJustifiedCheckpoint,proto3" json:"current_justified_checkpoint,omitempty"`
-	FinalizedCheckpoint         *Checkpoint                                                                    `protobuf:"bytes,8004,opt,name=finalized_checkpoint,json=finalizedCheckpoint,proto3" json:"finalized_checkpoint,omitempty"`
+	Fork                        *Fork                 `protobuf:"bytes,1004,opt,name=fork,proto3" json:"fork,omitempty"`
+	LatestBlockHeader           *BeaconBlockHeader    `protobuf:"bytes,2001,opt,name=latest_block_header,json=latestBlockHeader,proto3" json:"latest_block_header,omitempty"`
+	Eth1Data                    *Eth1Data             `protobuf:"bytes,3001,opt,name=eth1_data,json=eth1Data,proto3" json:"eth1_data,omitempty"`
+	Eth1DataVotes               []*Eth1Data           `protobuf:"bytes,3002,rep,name=eth1_data_votes,json=eth1DataVotes,proto3" json:"eth1_data_votes,omitempty" ssz-max:"2048"`
+	Validators                  []*Validator          `protobuf:"bytes,4001,rep,name=validators,proto3" json:"validators,omitempty" ssz-max:"1099511627776"`
+	PreviousEpochAttestations   []*PendingAttestation `protobuf:"bytes,7001,rep,name=previous_epoch_attestations,json=previousEpochAttestations,proto3" json:"previous_epoch_attestations,omitempty" ssz-max:"4096"`
+	CurrentEpochAttestations    []*PendingAttestation `protobuf:"bytes,7002,rep,name=current_epoch_attestations,json=currentEpochAttestations,proto3" json:"current_epoch_attestations,omitempty" ssz-max:"4096"`
+	PreviousJustifiedCheckpoint *Checkpoint           `protobuf:"bytes,8002,opt,name=previous_justified_checkpoint,json=previousJustifiedCheckpoint,proto3" json:"previous_justified_checkpoint,omitempty"`
+	CurrentJustifiedCheckpoint  *Checkpoint           `protobuf:"bytes,8003,opt,name=current_justified_checkpoint,json=currentJustifiedCheckpoint,proto3" json:"current_justified_checkpoint,omitempty"`
+	FinalizedCheckpoint         *Checkpoint           `protobuf:"bytes,8004,opt,name=finalized_checkpoint,json=finalizedCheckpoint,proto3" json:"finalized_checkpoint,omitempty"`
 }
 
 func (x *BeaconState) Reset() {
@@ -85,13 +78,6 @@ func (*BeaconState) Descriptor() ([]byte, []int) {
 	return file_proto_prysm_v1alpha1_beacon_state_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *BeaconState) GetGenesisValidatorsRoot() github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.Byte32 {
-	if x != nil {
-		return x.GenesisValidatorsRoot
-	}
-	return github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.Byte32([32]byte{})
-}
-
 func (x *BeaconState) GetFork() *Fork {
 	if x != nil {
 		return x.Fork
@@ -104,27 +90,6 @@ func (x *BeaconState) GetLatestBlockHeader() *BeaconBlockHeader {
 		return x.LatestBlockHeader
 	}
 	return nil
-}
-
-func (x *BeaconState) GetBlockRoots() *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots {
-	if x != nil {
-		return x.BlockRoots
-	}
-	return (*github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots)(nil)
-}
-
-func (x *BeaconState) GetStateRoots() *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots {
-	if x != nil {
-		return x.StateRoots
-	}
-	return (*github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots)(nil)
-}
-
-func (x *BeaconState) GetHistoricalRoots() github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.HistoricalRoots {
-	if x != nil {
-		return x.HistoricalRoots
-	}
-	return github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.HistoricalRoots(nil)
 }
 
 func (x *BeaconState) GetEth1Data() *Eth1Data {
@@ -148,13 +113,6 @@ func (x *BeaconState) GetValidators() []*Validator {
 	return nil
 }
 
-func (x *BeaconState) GetRandaoMixes() *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.RandaoMixes {
-	if x != nil {
-		return x.RandaoMixes
-	}
-	return (*github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.RandaoMixes)(nil)
-}
-
 func (x *BeaconState) GetPreviousEpochAttestations() []*PendingAttestation {
 	if x != nil {
 		return x.PreviousEpochAttestations
@@ -167,13 +125,6 @@ func (x *BeaconState) GetCurrentEpochAttestations() []*PendingAttestation {
 		return x.CurrentEpochAttestations
 	}
 	return nil
-}
-
-func (x *BeaconState) GetJustificationBits() github_com_prysmaticlabs_go_bitfield.Bitvector4 {
-	if x != nil {
-		return x.JustificationBits
-	}
-	return github_com_prysmaticlabs_go_bitfield.Bitvector4(nil)
 }
 
 func (x *BeaconState) GetPreviousJustifiedCheckpoint() *Checkpoint {
@@ -201,22 +152,16 @@ type BeaconStateAltair struct {
 	state                       protoimpl.MessageState
 	sizeCache                   protoimpl.SizeCache
 	unknownFields               protoimpl.UnknownFields
-	GenesisValidatorsRoot       github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.Byte32          `protobuf:"bytes,1002,opt,name=genesis_validators_root,json=genesisValidatorsRoot,proto3" json:"genesis_validators_root,omitempty" cast-type:"github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types.Byte32" ssz-size:"32"`
-	Fork                        *Fork                                                                          `protobuf:"bytes,1004,opt,name=fork,proto3" json:"fork,omitempty"`
-	LatestBlockHeader           *BeaconBlockHeader                                                             `protobuf:"bytes,2001,opt,name=latest_block_header,json=latestBlockHeader,proto3" json:"latest_block_header,omitempty"`
-	BlockRoots                  *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots     `protobuf:"bytes,2002,opt,name=block_roots,json=blockRoots,proto3" json:"block_roots,omitempty" cast-type:"github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types.StateRoots" ssz-size:"8192,32"`
-	StateRoots                  *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots     `protobuf:"bytes,2003,opt,name=state_roots,json=stateRoots,proto3" json:"state_roots,omitempty" cast-type:"github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types.StateRoots" ssz-size:"8192,32"`
-	HistoricalRoots             github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.HistoricalRoots `protobuf:"bytes,2004,opt,name=historical_roots,json=historicalRoots,proto3" json:"historical_roots,omitempty" cast-type:"github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types.HistoricalRoots" ssz-max:"16777216" ssz-size:"?,32"`
-	Eth1Data                    *Eth1Data                                                                      `protobuf:"bytes,3001,opt,name=eth1_data,json=eth1Data,proto3" json:"eth1_data,omitempty"`
-	Eth1DataVotes               []*Eth1Data                                                                    `protobuf:"bytes,3002,rep,name=eth1_data_votes,json=eth1DataVotes,proto3" json:"eth1_data_votes,omitempty" ssz-max:"2048"`
-	Validators                  []*Validator                                                                   `protobuf:"varint,4002,rep,packed,name=balances,proto3" json:"balances,omitempty" ssz-max:"1099511627776"`
-	RandaoMixes                 *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.RandaoMixes    `protobuf:"bytes,5001,opt,name=randao_mixes,json=randaoMixes,proto3" json:"randao_mixes,omitempty" cast-type:"github.com/prysmaticlabs/prysm/beacon-chain/state/custom-types.RandaoMixes" ssz-size:"65536,32"`
-	JustificationBits           github_com_prysmaticlabs_go_bitfield.Bitvector4                                `protobuf:"bytes,8001,opt,name=justification_bits,json=justificationBits,proto3" json:"justification_bits,omitempty" cast-type:"github.com/prysmaticlabs/go-bitfield.Bitvector4" ssz-size:"1"`
-	PreviousJustifiedCheckpoint *Checkpoint                                                                    `protobuf:"bytes,8002,opt,name=previous_justified_checkpoint,json=previousJustifiedCheckpoint,proto3" json:"previous_justified_checkpoint,omitempty"`
-	CurrentJustifiedCheckpoint  *Checkpoint                                                                    `protobuf:"bytes,8003,opt,name=current_justified_checkpoint,json=currentJustifiedCheckpoint,proto3" json:"current_justified_checkpoint,omitempty"`
-	FinalizedCheckpoint         *Checkpoint                                                                    `protobuf:"bytes,8004,opt,name=finalized_checkpoint,json=finalizedCheckpoint,proto3" json:"finalized_checkpoint,omitempty"`
-	CurrentSyncCommittee        *SyncCommittee                                                                 `protobuf:"bytes,9002,opt,name=current_sync_committee,json=currentSyncCommittee,proto3" json:"current_sync_committee,omitempty"`
-	NextSyncCommittee           *SyncCommittee                                                                 `protobuf:"bytes,9003,opt,name=next_sync_committee,json=nextSyncCommittee,proto3" json:"next_sync_committee,omitempty"`
+	Fork                        *Fork              `protobuf:"bytes,1004,opt,name=fork,proto3" json:"fork,omitempty"`
+	LatestBlockHeader           *BeaconBlockHeader `protobuf:"bytes,2001,opt,name=latest_block_header,json=latestBlockHeader,proto3" json:"latest_block_header,omitempty"`
+	Eth1Data                    *Eth1Data          `protobuf:"bytes,3001,opt,name=eth1_data,json=eth1Data,proto3" json:"eth1_data,omitempty"`
+	Eth1DataVotes               []*Eth1Data        `protobuf:"bytes,3002,rep,name=eth1_data_votes,json=eth1DataVotes,proto3" json:"eth1_data_votes,omitempty" ssz-max:"2048"`
+	Validators                  []*Validator       `protobuf:"varint,4002,rep,packed,name=balances,proto3" json:"balances,omitempty" ssz-max:"1099511627776"`
+	PreviousJustifiedCheckpoint *Checkpoint        `protobuf:"bytes,8002,opt,name=previous_justified_checkpoint,json=previousJustifiedCheckpoint,proto3" json:"previous_justified_checkpoint,omitempty"`
+	CurrentJustifiedCheckpoint  *Checkpoint        `protobuf:"bytes,8003,opt,name=current_justified_checkpoint,json=currentJustifiedCheckpoint,proto3" json:"current_justified_checkpoint,omitempty"`
+	FinalizedCheckpoint         *Checkpoint        `protobuf:"bytes,8004,opt,name=finalized_checkpoint,json=finalizedCheckpoint,proto3" json:"finalized_checkpoint,omitempty"`
+	CurrentSyncCommittee        *SyncCommittee     `protobuf:"bytes,9002,opt,name=current_sync_committee,json=currentSyncCommittee,proto3" json:"current_sync_committee,omitempty"`
+	NextSyncCommittee           *SyncCommittee     `protobuf:"bytes,9003,opt,name=next_sync_committee,json=nextSyncCommittee,proto3" json:"next_sync_committee,omitempty"`
 }
 
 func (x *BeaconStateAltair) Reset() {
@@ -251,13 +196,6 @@ func (*BeaconStateAltair) Descriptor() ([]byte, []int) {
 	return file_proto_prysm_v1alpha1_beacon_state_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *BeaconStateAltair) GetGenesisValidatorsRoot() github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.Byte32 {
-	if x != nil {
-		return x.GenesisValidatorsRoot
-	}
-	return github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.Byte32([32]byte{})
-}
-
 func (x *BeaconStateAltair) GetFork() *Fork {
 	if x != nil {
 		return x.Fork
@@ -270,27 +208,6 @@ func (x *BeaconStateAltair) GetLatestBlockHeader() *BeaconBlockHeader {
 		return x.LatestBlockHeader
 	}
 	return nil
-}
-
-func (x *BeaconStateAltair) GetBlockRoots() *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots {
-	if x != nil {
-		return x.BlockRoots
-	}
-	return (*github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots)(nil)
-}
-
-func (x *BeaconStateAltair) GetStateRoots() *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots {
-	if x != nil {
-		return x.StateRoots
-	}
-	return (*github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.StateRoots)(nil)
-}
-
-func (x *BeaconStateAltair) GetHistoricalRoots() github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.HistoricalRoots {
-	if x != nil {
-		return x.HistoricalRoots
-	}
-	return github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.HistoricalRoots(nil)
 }
 
 func (x *BeaconStateAltair) GetEth1Data() *Eth1Data {
@@ -312,20 +229,6 @@ func (x *BeaconStateAltair) GetValidators() []*Validator {
 		return x.Validators
 	}
 	return nil
-}
-
-func (x *BeaconStateAltair) GetRandaoMixes() *github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.RandaoMixes {
-	if x != nil {
-		return x.RandaoMixes
-	}
-	return (*github_com_prysmaticlabs_prysm_beacon_chain_state_custom_types.RandaoMixes)(nil)
-}
-
-func (x *BeaconStateAltair) GetJustificationBits() github_com_prysmaticlabs_go_bitfield.Bitvector4 {
-	if x != nil {
-		return x.JustificationBits
-	}
-	return github_com_prysmaticlabs_go_bitfield.Bitvector4(nil)
 }
 
 func (x *BeaconStateAltair) GetPreviousJustifiedCheckpoint() *Checkpoint {

--- a/testing/util/BUILD.bazel
+++ b/testing/util/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/p2p/types:go_default_library",
         "//beacon-chain/state:go_default_library",
-        "//beacon-chain/state/custom-types:go_default_library",
         "//beacon-chain/state/v1:go_default_library",
         "//beacon-chain/state/v2:go_default_library",
         "//config/params:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

Refactoring

**What does this PR do? Why is it needed?**

Removes the following fields from the embedded protobuf beacon state and moves them to the Go struct:
- genesisValidatorsRoot
- blockRoots
- stateRoots
- historicalRoots
- randaoMixes
- justificationBits

**Which issues(s) does this PR fix?**

Part of #9820 

**Other notes for review**

`go build ./...` is successful.