### PR TITLE
time pkg: can upgrade to merge helper

### DIFF
--- a/beacon-chain/core/time/slot_epoch.go
+++ b/beacon-chain/core/time/slot_epoch.go
@@ -60,6 +60,16 @@ func CanUpgradeToAltair(slot types.Slot) bool {
 	return epochStart && altairEpoch
 }
 
+// CanUpgradeToMerge returns true if the input `slot` can upgrade to Merge fork.
+//
+// Spec code:
+// If state.slot % SLOTS_PER_EPOCH == 0 and compute_epoch_at_slot(state.slot) == MERGE_FORK_EPOCH
+func CanUpgradeToMerge(slot types.Slot) bool {
+	epochStart := slots.IsEpochStart(slot)
+	mergeEpoch := slots.ToEpoch(slot) == params.BeaconConfig().MergeForkEpoch
+	return epochStart && mergeEpoch
+}
+
 // CanProcessEpoch checks the eligibility to process epoch.
 // The epoch can be processed at the end of the last slot of every epoch.
 //

--- a/beacon-chain/core/time/slot_epoch_test.go
+++ b/beacon-chain/core/time/slot_epoch_test.go
@@ -142,7 +142,7 @@ func TestCanUpgradeToMerge(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := CanUpgradeToMerge(tt.slot); got != tt.want {
-				t.Errorf("canUpgradeToAltair() = %v, want %v", got, tt.want)
+				t.Errorf("CanUpgradeToMerge() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/beacon-chain/core/time/slot_epoch_test.go
+++ b/beacon-chain/core/time/slot_epoch_test.go
@@ -114,6 +114,40 @@ func TestCanUpgradeToAltair(t *testing.T) {
 	}
 }
 
+func TestCanUpgradeToMerge(t *testing.T) {
+	bc := params.BeaconConfig()
+	bc.MergeForkEpoch = 5
+	params.OverrideBeaconConfig(bc)
+	tests := []struct {
+		name string
+		slot types.Slot
+		want bool
+	}{
+		{
+			name: "not epoch start",
+			slot: 1,
+			want: false,
+		},
+		{
+			name: "not merge epoch",
+			slot: params.BeaconConfig().SlotsPerEpoch,
+			want: false,
+		},
+		{
+			name: "merge epoch",
+			slot: types.Slot(params.BeaconConfig().MergeForkEpoch) * params.BeaconConfig().SlotsPerEpoch,
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanUpgradeToMerge(tt.slot); got != tt.want {
+				t.Errorf("canUpgradeToAltair() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCanProcessEpoch_TrueOnEpochsLastSlot(t *testing.T) {
 	tests := []struct {
 		slot            types.Slot


### PR DESCRIPTION
This PR adds a helper to check if input slot is merge upgrade ready which satisfy the following condition:

`state.slot % SLOTS_PER_EPOCH == 0 and compute_epoch_at_slot(state.slot) == MERGE_FORK_EPOCH`

This helper is used will `ProcessSlots` as seen in Altair:
https://github.com/prysmaticlabs/prysm/blob/develop/beacon-chain/core/transition/transition.go#L262