### PR TITLE
Make Validator Accounts List Use Functional Options

### DIFF
--- a/cmd/validator/accounts/BUILD.bazel
+++ b/cmd/validator/accounts/BUILD.bazel
@@ -2,7 +2,10 @@ load("@prysm//tools/go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["accounts.go"],
+    srcs = [
+        "accounts.go",
+        "list.go",
+    ],
     importpath = "github.com/prysmaticlabs/prysm/cmd/validator/accounts",
     visibility = ["//visibility:public"],
     deps = [
@@ -11,6 +14,11 @@ go_library(
         "//config/features:go_default_library",
         "//runtime/tos:go_default_library",
         "//validator/accounts:go_default_library",
+        "//validator/accounts/iface:go_default_library",
+        "//validator/accounts/wallet:go_default_library",
+        "//validator/client:go_default_library",
+        "//validator/keymanager:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],

--- a/cmd/validator/accounts/accounts.go
+++ b/cmd/validator/accounts/accounts.go
@@ -70,11 +70,14 @@ var Commands = &cli.Command{
 				if err := cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags); err != nil {
 					return err
 				}
-				return tos.VerifyTosAcceptedOrPrompt(cliCtx)
+				if err := tos.VerifyTosAcceptedOrPrompt(cliCtx); err != nil {
+					return err
+				}
+				features.ConfigureValidator(cliCtx)
+				return nil
 			},
 			Action: func(cliCtx *cli.Context) error {
-				features.ConfigureValidator(cliCtx)
-				if err := accounts.ListAccountsCli(cliCtx); err != nil {
+				if err := accountsList(cliCtx); err != nil {
 					log.Fatalf("Could not list accounts: %v", err)
 				}
 				return nil
@@ -83,7 +86,7 @@ var Commands = &cli.Command{
 		{
 			Name: "backup",
 			Description: "backup accounts into EIP-2335 compliant keystore.json files zipped into a backup.zip file " +
-				"at a desired output directory. Accounts to backup can also " +
+				"at a desired output directory. AccountsCLIManager to backup can also " +
 				"be specified programmatically via a --backup-for-public-keys flag which specifies a comma-separated " +
 				"list of hex string public keys",
 			Flags: cmd.WrapFlags([]cli.Flag{

--- a/cmd/validator/accounts/accounts.go
+++ b/cmd/validator/accounts/accounts.go
@@ -86,7 +86,7 @@ var Commands = &cli.Command{
 		{
 			Name: "backup",
 			Description: "backup accounts into EIP-2335 compliant keystore.json files zipped into a backup.zip file " +
-				"at a desired output directory. AccountsCLIManager to backup can also " +
+				"at a desired output directory. Accounts to backup can also " +
 				"be specified programmatically via a --backup-for-public-keys flag which specifies a comma-separated " +
 				"list of hex string public keys",
 			Flags: cmd.WrapFlags([]cli.Flag{

--- a/cmd/validator/accounts/list.go
+++ b/cmd/validator/accounts/list.go
@@ -1,0 +1,70 @@
+package accounts
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/cmd"
+	"github.com/prysmaticlabs/prysm/cmd/validator/flags"
+	"github.com/prysmaticlabs/prysm/validator/accounts"
+	"github.com/prysmaticlabs/prysm/validator/accounts/iface"
+	"github.com/prysmaticlabs/prysm/validator/accounts/wallet"
+	"github.com/prysmaticlabs/prysm/validator/client"
+	"github.com/prysmaticlabs/prysm/validator/keymanager"
+	"github.com/urfave/cli/v2"
+)
+
+func accountsList(c *cli.Context) error {
+	w, km, err := walletWithKeymanager(c)
+	if err != nil {
+		return err
+	}
+	dialOpts := client.ConstructDialOptions(
+		c.Int(cmd.GrpcMaxCallRecvMsgSizeFlag.Name),
+		c.String(flags.CertFlag.Name),
+		c.Uint(flags.GrpcRetriesFlag.Name),
+		c.Duration(flags.GrpcRetryDelayFlag.Name),
+	)
+	grpcHeaders := strings.Split(c.String(flags.GrpcHeadersFlag.Name), ",")
+
+	opts := []accounts.Option{
+		accounts.WithWallet(w),
+		accounts.WithKeymanager(km),
+		accounts.WithGRPCDialOpts(dialOpts),
+		accounts.WithBeaconRPCProvider(c.String(flags.BeaconRPCProviderFlag.Name)),
+		accounts.WithGRPCHeaders(grpcHeaders),
+	}
+	if c.IsSet(flags.ShowDepositDataFlag.Name) {
+		opts = append(opts, accounts.WithShowDepositData())
+	}
+	if c.IsSet(flags.ShowPrivateKeysFlag.Name) {
+		opts = append(opts, accounts.WithShowPrivateKeys())
+	}
+	if c.IsSet(flags.ListValidatorIndices.Name) {
+		opts = append(opts, accounts.WithListValidatorIndices())
+	}
+	acc, err := accounts.NewCLIManager(c.Context, opts...)
+	if err != nil {
+		return err
+	}
+	return acc.List(
+		c.Context,
+	)
+}
+
+func walletWithKeymanager(c *cli.Context) (*wallet.Wallet, keymanager.IKeymanager, error) {
+	w, err := wallet.OpenWalletOrElseCli(c, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
+		return nil, wallet.ErrNoWalletFound
+	})
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "could not open wallet")
+	}
+	km, err := w.InitializeKeymanager(c.Context, iface.InitKeymanagerConfig{ListenForChanges: false})
+	if err != nil && strings.Contains(err.Error(), keymanager.IncorrectPasswordErrMsg) {
+		return nil, nil, errors.New("wrong wallet password entered")
+	}
+	if err != nil {
+		return nil, nil, errors.Wrap(err, accounts.ErrCouldNotInitializeKeymanager)
+	}
+	return w, km, nil
+}

--- a/validator/accounts/BUILD.bazel
+++ b/validator/accounts/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "accounts_list.go",
         "doc.go",
         "log.go",
+        "options.go",
         "wallet_create.go",
         "wallet_edit.go",
         "wallet_recover.go",

--- a/validator/accounts/iface/BUILD.bazel
+++ b/validator/accounts/iface/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["wallet.go"],
     importpath = "github.com/prysmaticlabs/prysm/validator/accounts/iface",
     visibility = [
+        "//cmd:__subpackages__",
         "//validator:__pkg__",
         "//validator:__subpackages__",
     ],

--- a/validator/accounts/options.go
+++ b/validator/accounts/options.go
@@ -1,0 +1,100 @@
+package accounts
+
+import (
+	"context"
+
+	"github.com/prysmaticlabs/prysm/validator/accounts/wallet"
+	"github.com/prysmaticlabs/prysm/validator/keymanager"
+	"google.golang.org/grpc"
+)
+
+// NewCLIManager allows for managing validator accounts via CLI commands.
+func NewCLIManager(_ context.Context, opts ...Option) (*AccountsCLIManager, error) {
+	acc := &AccountsCLIManager{}
+	for _, opt := range opts {
+		if err := opt(acc); err != nil {
+			return nil, err
+		}
+	}
+	return acc, nil
+}
+
+// AccountsCLIManager defines a struct capable of performing various validator
+// wallet account operations via the command line.
+type AccountsCLIManager struct {
+	wallet               *wallet.Wallet
+	keymanager           keymanager.IKeymanager
+	showDepositData      bool
+	showPrivateKeys      bool
+	listValidatorIndices bool
+	dialOpts             []grpc.DialOption
+	grpcHeaders          []string
+	beaconRPCProvider    string
+}
+
+// Option type for configuring the accounts cli manager.
+type Option func(acc *AccountsCLIManager) error
+
+// WithWallet provides a wallet to the accounts cli manager.
+func WithWallet(wallet *wallet.Wallet) Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.wallet = wallet
+		return nil
+	}
+}
+
+// WithKeymanager provides a keymanager to the accounts cli manager.
+func WithKeymanager(km keymanager.IKeymanager) Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.keymanager = km
+		return nil
+	}
+}
+
+// WithShowDepositData enables displaying deposit data in the accounts cli manager.
+func WithShowDepositData() Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.showDepositData = true
+		return nil
+	}
+}
+
+// WithShowPrivateKeys enables displaying private keys in the accounts cli manager.
+func WithShowPrivateKeys() Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.showPrivateKeys = true
+		return nil
+	}
+}
+
+// WithListValidatorIndices enables displaying validator indices in the accounts cli manager.
+func WithListValidatorIndices() Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.listValidatorIndices = true
+		return nil
+	}
+}
+
+// WithGRPCDialOpts adds grpc opts needed to connect to beacon nodes in the accounts cli manager.
+func WithGRPCDialOpts(opts []grpc.DialOption) Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.dialOpts = opts
+		return nil
+	}
+}
+
+// WithGRPCHeaders adds grpc headers used when connecting to beacon nodes in the accounts cli manager.
+func WithGRPCHeaders(headers []string) Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.grpcHeaders = headers
+		return nil
+	}
+}
+
+// WithBeaconRPCProvider provides a beacon node endpoint to the accounts cli manager.
+func WithBeaconRPCProvider(provider string) Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.beaconRPCProvider = provider
+		return nil
+	}
+}

--- a/validator/accounts/wallet/BUILD.bazel
+++ b/validator/accounts/wallet/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     ],
     importpath = "github.com/prysmaticlabs/prysm/validator/accounts/wallet",
     visibility = [
+        "//cmd:__subpackages__",
         "//tools:__subpackages__",
         "//validator:__subpackages__",
     ],

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -19,7 +19,10 @@ go_library(
         "wait_for_activation.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/validator/client",
-    visibility = ["//validator:__subpackages__"],
+    visibility = [
+        "//validator:__subpackages__",
+        "//cmd:__subpackages__"
+    ],
     deps = [
         "//api/grpc:go_default_library",
         "//async:go_default_library",

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -20,8 +20,8 @@ go_library(
     ],
     importpath = "github.com/prysmaticlabs/prysm/validator/client",
     visibility = [
+        "//cmd:__subpackages__",
         "//validator:__subpackages__",
-        "//cmd:__subpackages__"
     ],
     deps = [
         "//api/grpc:go_default_library",

--- a/validator/keymanager/BUILD.bazel
+++ b/validator/keymanager/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = [
         "//tools:__subpackages__",
         "//validator:__pkg__",
+        "//cmd:__pkg__",
         "//validator:__subpackages__",
     ],
     deps = [

--- a/validator/keymanager/BUILD.bazel
+++ b/validator/keymanager/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     ],
     importpath = "github.com/prysmaticlabs/prysm/validator/keymanager",
     visibility = [
-        "//cmd:__pkg__",
+        "//cmd:__subpackages__",
         "//tools:__subpackages__",
         "//validator:__pkg__",
         "//validator:__subpackages__",

--- a/validator/keymanager/BUILD.bazel
+++ b/validator/keymanager/BUILD.bazel
@@ -8,9 +8,9 @@ go_library(
     ],
     importpath = "github.com/prysmaticlabs/prysm/validator/keymanager",
     visibility = [
+        "//cmd:__pkg__",
         "//tools:__subpackages__",
         "//validator:__pkg__",
-        "//cmd:__pkg__",
         "//validator:__subpackages__",
     ],
     deps = [


### PR DESCRIPTION
As part of a greater refactor to rethink the concept of a `Keymanager` in Prysm discussed [here](https://www.notion.so/900393aa4cb243f5aead5578c8e801d7), we want to introduce better separation of concerns in the validator client, especially when it comes to dealing with account management. The main functions that let users perform operations on accounts via the CLI are super convoluted pieces of code that parse CLI arguments and have a ton of duplicated logic around initializing a wallet. Instead, we should be abstracting that away to the actual CLI entry point and using functional options to configure these functions. This PR starts by changing `AccountsListCLI` to not take in a cli context, but instead use functional options and a cleaner approach. This will be applied to every exported function in `validator/accounts`