### PR TITLE
Remove unused import

### DIFF
--- a/proto/prysm/v1alpha1/validator-client/keymanager.proto
+++ b/proto/prysm/v1alpha1/validator-client/keymanager.proto
@@ -6,7 +6,6 @@ import "proto/prysm/v1alpha1/attestation.proto";
 import "proto/prysm/v1alpha1/beacon_block.proto";
 import "proto/prysm/v1alpha1/beacon_state.proto";
 import "proto/prysm/v1alpha1/sync_committee.proto";
-import "proto/prysm/v1alpha1/validator.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 


### PR DESCRIPTION
Removes unused import in `keymanager.proto`, gets rid of annoying warning every time when build:
`proto/prysm/v1alpha1/validator-client/keymanager.proto:9:1: warning: Import proto/prysm/v1alpha1/validator.proto is unused.`