### PR TITLE
Add Network Flags to Slashing Protection Export Command

### DIFF
--- a/cmd/validator/slashing-protection/slashing-protection.go
+++ b/cmd/validator/slashing-protection/slashing-protection.go
@@ -21,6 +21,10 @@ var Commands = &cli.Command{
 			Flags: cmd.WrapFlags([]cli.Flag{
 				cmd.DataDirFlag,
 				flags.SlashingProtectionExportDirFlag,
+				features.Mainnet,
+				features.PyrmontTestnet,
+				features.PraterTestnet,
+				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
 				if err := cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags); err != nil {


### PR DESCRIPTION
Fixes #9905 by adding the --prater, --pyrmont, --mainnet flags to slashing protection exports. A user was mentioning that adding `--prater` to the slashing protection export command still logs "Running on Ethereum consensus mainnet" instead of prater. This is scary to a user.