### PR TITLE
Warn Users if Slashing Protection History is Empty

### DIFF
--- a/cmd/validator/slashing-protection/export.go
+++ b/cmd/validator/slashing-protection/export.go
@@ -71,12 +71,14 @@ func exportSlashingProtectionJSON(cliCtx *cli.Context) error {
 	// Check if JSON data is empty and issue a warning about common problems to the user.
 	if eipJSON == nil || len(eipJSON.Data) == 0 {
 		log.Warnf(
-			"No slashing protection data was found in the %s directory. "+
-				"This may be because your validator database is stored in a --datadir which could be a different "+
+			"No slashing protection data was found in the %s directory. This is either because (1) your "+
+				"validator client does not have any history of blocks or attestations yet, or (2) "+
+				"this may be because your validator database is stored in a --datadir which could be a different "+
 				"directory than the --wallet-dir you set when running your validator. You might have an empty "+
 				"validator.db in your --wallet-dir that was created by accident in a previous Prysm version. "+
 				"Check if the directory you are passing in has a validator.db file in it and then run "+
-				"the command with right directory",
+				"the command with right directory. Also, check if your --wallet-dir is different from your --datadir "+
+				"when you ran your Prysm validator",
 			dataDir,
 		)
 	}

--- a/cmd/validator/slashing-protection/export.go
+++ b/cmd/validator/slashing-protection/export.go
@@ -67,6 +67,20 @@ func exportSlashingProtectionJSON(cliCtx *cli.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "could not export slashing protection history")
 	}
+
+	// Check if JSON data is empty and issue a warning about common problems to the user.
+	if eipJSON == nil || len(eipJSON.Data) == 0 {
+		log.Warnf(
+			"No slashing protection data was found in the %s directory. "+
+				"This may be because your validator database is stored in a --datadir which could be a different "+
+				"directory than the --wallet-dir you set when running your validator. You might have an empty "+
+				"validator.db in your --wallet-dir that was created by accident in a previous Prysm version. "+
+				"Check if the directory you are passing in has a validator.db file in it and then run "+
+				"the command with right directory",
+			dataDir,
+		)
+	}
+
 	outputDir, err := userprompt.InputDirectory(
 		cliCtx,
 		"Enter your desired output directory for your slashing protection history file",

--- a/cmd/validator/slashing-protection/export.go
+++ b/cmd/validator/slashing-protection/export.go
@@ -70,7 +70,7 @@ func exportSlashingProtectionJSON(cliCtx *cli.Context) error {
 
 	// Check if JSON data is empty and issue a warning about common problems to the user.
 	if eipJSON == nil || len(eipJSON.Data) == 0 {
-		log.Warnf(
+		log.Fatalf(
 			"No slashing protection data was found in the %s directory. This is either because (1) your "+
 				"validator client does not have any history of blocks or attestations yet, or (2) "+
 				"this may be because your validator database is stored in a --datadir which could be a different "+


### PR DESCRIPTION
Fixes #9897. The dappnode team was running into a curious issue where they were seeing an empty slashing protection history exported, as reported in #9897. They were running their validator with a command like this:

```
validator \
  --prater \
  --datadir=/root/.eth2 \
  --wallet-dir=/root/.eth2validators \
  --rpc-host 0.0.0.0 \
```

and then trying to export their slashing protection history with:
```
validator slashing-protection export --datadir=/root/.eth2validators
```
Note that they set their --datadir as `/root/.eth2` when running, which is different than what they are trying to export. They should have received some kind of warning if this was the case. This PR adds the necessary warning and explanation to users in case this situation happens.

**NOTE TO REVIEWERS**
Currently, if a validator.db is not found in the specified directory when attempting an export, the current code does throw an error. However, seems like it did not in dappnode's case. My belief is that dappnode had an old, probably empty validator.db in their --wallet-dir and their real validator.db in their --datadir, leading to the issue. This is really hard to write a test case for. We will have to confirm this warning is triggered on dappnode's side before merging.