### PR TITLE
Add verbosity to aggregation logs

### DIFF
--- a/beacon-chain/monitor/process_attestation.go
+++ b/beacon-chain/monitor/process_attestation.go
@@ -198,6 +198,13 @@ func (s *Service) processAggregatedAttestation(ctx context.Context, att *ethpb.A
 	if s.trackedIndex(att.AggregatorIndex) {
 		log.WithFields(logrus.Fields{
 			"ValidatorIndex": att.AggregatorIndex,
+			"Slot":           att.Aggregate.Data.Slot,
+			"BeaconBlockRoot": fmt.Sprintf("%#x", bytesutil.Trunc(
+				att.Aggregate.Data.BeaconBlockRoot)),
+			"SourceRoot:": fmt.Sprintf("%#x", bytesutil.Trunc(
+				att.Aggregate.Data.Source.Root)),
+			"TargetRoot:": fmt.Sprintf("%#x", bytesutil.Trunc(
+				att.Aggregate.Data.Target.Root)),
 		}).Info("Processed attestation aggregation")
 		aggregatedPerf := s.aggregatedPerformance[att.AggregatorIndex]
 		aggregatedPerf.totalAggregations++

--- a/beacon-chain/monitor/process_attestation.go
+++ b/beacon-chain/monitor/process_attestation.go
@@ -197,8 +197,8 @@ func (s *Service) processAggregatedAttestation(ctx context.Context, att *ethpb.A
 	defer s.Unlock()
 	if s.trackedIndex(att.AggregatorIndex) {
 		log.WithFields(logrus.Fields{
-			"ValidatorIndex": att.AggregatorIndex,
-			"Slot":           att.Aggregate.Data.Slot,
+			"AggregatorIndex": att.AggregatorIndex,
+			"Slot":            att.Aggregate.Data.Slot,
 			"BeaconBlockRoot": fmt.Sprintf("%#x", bytesutil.Trunc(
 				att.Aggregate.Data.BeaconBlockRoot)),
 			"SourceRoot:": fmt.Sprintf("%#x", bytesutil.Trunc(

--- a/beacon-chain/monitor/process_attestation_test.go
+++ b/beacon-chain/monitor/process_attestation_test.go
@@ -211,7 +211,7 @@ func TestProcessAggregatedAttestationStateNotCached(t *testing.T) {
 		},
 	}
 	s.processAggregatedAttestation(ctx, att)
-	require.LogsContain(t, hook, "\"Processed attestation aggregation\" BeaconBlockRoot=0x000000000000 Slot=1 SourceRoot:=0x68656c6c6f2d TargetRoot:=0x68656c6c6f2d ValidatorIndex=2 prefix=monitor")
+	require.LogsContain(t, hook, "\"Processed attestation aggregation\" AggregatorIndex=2 BeaconBlockRoot=0x000000000000 Slot=1 SourceRoot:=0x68656c6c6f2d TargetRoot:=0x68656c6c6f2d prefix=monitor")
 	require.LogsContain(t, hook, "Skipping agregated attestation due to state not found in cache")
 	logrus.SetLevel(logrus.InfoLevel)
 }
@@ -249,7 +249,7 @@ func TestProcessAggregatedAttestationStateCached(t *testing.T) {
 
 	require.NoError(t, s.config.StateGen.SaveState(ctx, root, state))
 	s.processAggregatedAttestation(ctx, att)
-	require.LogsContain(t, hook, "\"Processed attestation aggregation\" BeaconBlockRoot=0x68656c6c6f2d Slot=1 SourceRoot:=0x68656c6c6f2d TargetRoot:=0x68656c6c6f2d ValidatorIndex=2 prefix=monitor")
+	require.LogsContain(t, hook, "\"Processed attestation aggregation\" AggregatorIndex=2 BeaconBlockRoot=0x68656c6c6f2d Slot=1 SourceRoot:=0x68656c6c6f2d TargetRoot:=0x68656c6c6f2d prefix=monitor")
 	require.LogsContain(t, hook, "\"Processed aggregated attestation\" Head=0x68656c6c6f2d Slot=1 Source=0x68656c6c6f2d Target=0x68656c6c6f2d ValidatorIndex=2 prefix=monitor")
 	require.LogsDoNotContain(t, hook, "\"Processed aggregated attestation\" Head=0x68656c6c6f2d Slot=1 Source=0x68656c6c6f2d Target=0x68656c6c6f2d ValidatorIndex=12 prefix=monitor")
 }

--- a/beacon-chain/monitor/process_attestation_test.go
+++ b/beacon-chain/monitor/process_attestation_test.go
@@ -211,7 +211,7 @@ func TestProcessAggregatedAttestationStateNotCached(t *testing.T) {
 		},
 	}
 	s.processAggregatedAttestation(ctx, att)
-	require.LogsContain(t, hook, "\"Processed attestation aggregation\" ValidatorIndex=2 prefix=monitor")
+	require.LogsContain(t, hook, "\"Processed attestation aggregation\" BeaconBlockRoot=0x000000000000 Slot=1 SourceRoot:=0x68656c6c6f2d TargetRoot:=0x68656c6c6f2d ValidatorIndex=2 prefix=monitor")
 	require.LogsContain(t, hook, "Skipping agregated attestation due to state not found in cache")
 	logrus.SetLevel(logrus.InfoLevel)
 }
@@ -249,7 +249,7 @@ func TestProcessAggregatedAttestationStateCached(t *testing.T) {
 
 	require.NoError(t, s.config.StateGen.SaveState(ctx, root, state))
 	s.processAggregatedAttestation(ctx, att)
-	require.LogsContain(t, hook, "\"Processed attestation aggregation\" ValidatorIndex=2 prefix=monitor")
+	require.LogsContain(t, hook, "\"Processed attestation aggregation\" BeaconBlockRoot=0x68656c6c6f2d Slot=1 SourceRoot:=0x68656c6c6f2d TargetRoot:=0x68656c6c6f2d ValidatorIndex=2 prefix=monitor")
 	require.LogsContain(t, hook, "\"Processed aggregated attestation\" Head=0x68656c6c6f2d Slot=1 Source=0x68656c6c6f2d Target=0x68656c6c6f2d ValidatorIndex=2 prefix=monitor")
 	require.LogsDoNotContain(t, hook, "\"Processed aggregated attestation\" Head=0x68656c6c6f2d Slot=1 Source=0x68656c6c6f2d Target=0x68656c6c6f2d ValidatorIndex=12 prefix=monitor")
 }


### PR DESCRIPTION
Testing on Prater at runtime move from 

`"Processed attestation aggregation" ValidatorIndex=2 prefix=monitor`

To

`""Processed attestation aggregation" BeaconBlockRoot=0x68656c6c6f2d Slot=1 SourceRoot:=0x68656c6c6f2d TargetRoot:=0x68656c6c6f2d ValidatorIndex=2 prefix=monitor`