### PR TITLE
Monitor aggregated logs

### DIFF
--- a/beacon-chain/monitor/process_block_test.go
+++ b/beacon-chain/monitor/process_block_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/altair"
@@ -228,4 +229,18 @@ func TestProcessBlock_AllEventsTrackedVals(t *testing.T) {
 	require.LogsContain(t, hook, wanted2)
 	require.LogsContain(t, hook, wanted3)
 	require.LogsContain(t, hook, wanted4)
+}
+
+func TestLogAggregatedPerformance(t *testing.T) {
+	hook := logTest.NewGlobal()
+	s := setupService(t)
+
+	s.logAggregatedPerformance()
+	time.Sleep(3000 * time.Millisecond)
+	wanted := "\"Aggregated performance since launch\" AttestationInclusion=\"80.00%\"" +
+		" AverageInclusionDistance=1.2 BalanceChangePct=\"0.95%\" CorrectlyVotedHeadPct=\"66.67%\" " +
+		"CorrectlyVotedSourcePct=\"91.67%\" CorrectlyVotedTargetPct=\"100.00%\" StartBalance=31700000000 " +
+		"StartEpoch=0 TotalAggregations=0 TotalProposedBlocks=1 TotalRequested=15 TotalSyncContributions=0 " +
+		"ValidatorIndex=1 prefix=monitor"
+	require.LogsContain(t, hook, wanted)
 }

--- a/beacon-chain/monitor/service_test.go
+++ b/beacon-chain/monitor/service_test.go
@@ -65,7 +65,19 @@ func setupService(t *testing.T) *Service {
 		},
 	}
 	aggregatedPerformance := map[types.ValidatorIndex]ValidatorAggregatedPerformance{
-		1:  {},
+		1: {
+			startEpoch:                     0,
+			startBalance:                   31700000000,
+			totalAttestedCount:             12,
+			totalRequestedCount:            15,
+			totalDistance:                  14,
+			totalCorrectHead:               8,
+			totalCorrectSource:             11,
+			totalCorrectTarget:             12,
+			totalProposedCount:             1,
+			totalSyncComitteeContributions: 0,
+			totalSyncComitteeAggregations:  0,
+		},
 		2:  {},
 		12: {},
 		15: {},


### PR DESCRIPTION
Adds an "aggregated since launch"  logging every 5 epochs. 

```
"Aggregated performance since launch" AttestationInclusion="80.00%" AverageInclusionDistance=1.2 BalanceChangePct="0.95%" CorrectlyVotedHeadPct="66.67%" CorrectlyVotedSourcePct="91.67%" CorrectlyVotedTargetPct="100.00%" StartBalance=31700000000 StartEpoch=0 TotalAggregations=0 TotalProposedBlocks=1 TotalRequested=15 TotalSyncContributions=0 ValidatorIndex=1 prefix=monitor
```
