### PR TITLE
Check for syncstatus before performing a voluntary exit

### DIFF
--- a/validator/accounts/BUILD.bazel
+++ b/validator/accounts/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "@com_github_urfave_cli_v2//:go_default_library",
         "@com_github_wealdtech_go_eth2_wallet_encryptor_keystorev4//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
     ],
 )
 

--- a/validator/accounts/accounts_exit.go
+++ b/validator/accounts/accounts_exit.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prysmaticlabs/prysm/validator/keymanager"
 	"github.com/urfave/cli/v2"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // PerformExitCfg for account voluntary exits.
@@ -56,6 +57,20 @@ func ExitAccountsCli(cliCtx *cli.Context, r io.Reader) error {
 	validatorClient, nodeClient, err := prepareClients(cliCtx)
 	if err != nil {
 		return err
+	}
+	if nodeClient == nil {
+		return errors.New("Could not prepare beacon node client")
+	}
+	syncStatus, err := (*nodeClient).GetSyncStatus(cliCtx.Context, &emptypb.Empty{})
+	if err != nil {
+		return err
+	}
+	if syncStatus == nil {
+		return errors.New("Could not get sync status")
+	}
+
+	if (*syncStatus).Syncing {
+		return errors.New("Could not perform exit: beacon node is syncing.")
 	}
 
 	cfg := PerformExitCfg{


### PR DESCRIPTION
Check if the beacon node is syncing before attempting to perform a voluntary exit as the current epoch will be wrong.

Fixes #9950 