### PR TITLE
Fix grpc client connected... logging

### DIFF
--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -382,7 +382,7 @@ func (s *Service) logNewClientConnection(ctx context.Context) {
 		if !s.connectedRPCClients[clientInfo.Addr] {
 			log.WithFields(logrus.Fields{
 				"addr": clientInfo.Addr.String(),
-			}).Infof("NewService gRPC client connected to beacon node")
+			}).Infof("gRPC client connected to beacon node")
 			s.connectedRPCClients[clientInfo.Addr] = true
 		}
 	}


### PR DESCRIPTION
Fix `gRPC client connected to beacon node` logging to exclude a typo `NewService`.