### PR TITLE
Faster Doppelganger Check

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/status_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/status_test.go
@@ -1170,25 +1170,10 @@ func TestServer_CheckDoppelGanger(t *testing.T) {
 			svSetup: func(t *testing.T) (*Server, *ethpb.DoppelGangerRequest, *ethpb.DoppelGangerResponse) {
 				mockGen := stategen.NewMockService()
 
-				hs, ps, os, keys := createStateSetup(t, 4, mockGen)
-				// Previous Epoch State
-				for i := 10; i < 15; i++ {
-					bal, err := ps.BalanceAtIndex(types.ValidatorIndex(i))
-					assert.NoError(t, err)
-					// Add 100 gwei, to mock an active validator
-					assert.NoError(t, ps.UpdateBalancesAtIndex(types.ValidatorIndex(i), bal-1000000000))
-				}
-
-				// Older Epoch State
-				for i := 10; i < 15; i++ {
-					bal, err := os.BalanceAtIndex(types.ValidatorIndex(i))
-					assert.NoError(t, err)
-					// Add 200 gwei, to mock an active validator
-					assert.NoError(t, os.UpdateBalancesAtIndex(types.ValidatorIndex(i), bal-2000000000))
-				}
+				hs, _, _, keys := createStateSetup(t, 4, mockGen)
 
 				vs := &Server{
-					StateGen: mockGen,
+					StateGen: nil,
 					HeadFetcher: &mockChain.ChainService{
 						State: hs,
 					},


### PR DESCRIPTION
**What type of PR is this?**

Feature Improvement

**What does this PR do? Why is it needed?**

In the event all the keys provided to the rpc method have been recently observed, we choose to exit 
the method early. The reason this is done is because performing state regeneration is expensive 
and doing it for 2 states can take time. This allows validators to perform quicker restarts which is 
required when updating the validator client software. 

Additionally this PR also modifies a test case to check for this particular situation.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
