### PR TITLE
Filter Errored Keys from Returned Slashing Protection History in Standard API

### DIFF
--- a/validator/rpc/standard_api.go
+++ b/validator/rpc/standard_api.go
@@ -91,13 +91,13 @@ func (s *Server) DeleteKeystores(
 		return nil, status.Errorf(codes.Internal, "Could not delete keys: %v", err)
 	}
 	// We select keys that were deleted for retrieving slashing protection history.
-	keysToFilter := make([][]byte, 0, len(req.PublicKeys))
+	filteredKeys := make([][]byte, 0, len(req.PublicKeys))
 	for i, st := range statuses {
 		if st.Status != ethpbservice.DeletedKeystoreStatus_ERROR {
-			keysToFilter = append(keysToFilter, req.PublicKeys[i])
+			filteredKeys = append(filteredKeys, req.PublicKeys[i])
 		}
 	}
-	exportedHistory, err := slashingprotection.ExportStandardProtectionJSON(ctx, s.valDB, keysToFilter...)
+	exportedHistory, err := slashingprotection.ExportStandardProtectionJSON(ctx, s.valDB, filteredKeys...)
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,

--- a/validator/slashing-protection-history/export.go
+++ b/validator/slashing-protection-history/export.go
@@ -19,10 +19,10 @@ import (
 func ExportStandardProtectionJSON(
 	ctx context.Context,
 	validatorDB db.Database,
-	keysToFilter ...[]byte,
+	filteredKeys ...[]byte,
 ) (*format.EIPSlashingProtectionFormat, error) {
-	keysFilterMap := make(map[string]bool, len(keysToFilter))
-	for _, k := range keysToFilter {
+	keysFilterMap := make(map[string]bool, len(filteredKeys))
+	for _, k := range filteredKeys {
 		keysFilterMap[string(k)] = true
 	}
 	interchangeJSON := &format.EIPSlashingProtectionFormat{}
@@ -58,7 +58,7 @@ func ExportStandardProtectionJSON(
 		len(proposedPublicKeys), "Extracting signed blocks by validator public key",
 	)
 	for _, pubKey := range proposedPublicKeys {
-		if _, ok := keysFilterMap[string(pubKey[:])]; len(keysToFilter) > 0 && !ok {
+		if _, ok := keysFilterMap[string(pubKey[:])]; len(filteredKeys) > 0 && !ok {
 			continue
 		}
 		pubKeyHex, err := pubKeyToHexString(pubKey[:])
@@ -84,7 +84,7 @@ func ExportStandardProtectionJSON(
 		len(attestedPublicKeys), "Extracting signed attestations by validator public key",
 	)
 	for _, pubKey := range attestedPublicKeys {
-		if _, ok := keysFilterMap[string(pubKey[:])]; len(keysToFilter) > 0 && !ok {
+		if _, ok := keysFilterMap[string(pubKey[:])]; len(filteredKeys) > 0 && !ok {
 			continue
 		}
 		pubKeyHex, err := pubKeyToHexString(pubKey[:])


### PR DESCRIPTION
As part of the validator keymanager API, in the `DeleteKeystores` endpoint: when we attempt to delete some keystores, say `a, b, c`, and a single keystore `b`, has an ERROR status when deleting, and `a, c` are deleted successfully, we only want to return slashing protection history for `a, c`. 

**NOTES**: The Prysm delete keystores underlying logic never returns an error, so it is not possible to add a unit test for this logic, unfortunately. Nevertheless, we should still implement the expected behavior.