### PR TITLE
Remove unused validator proto imports

### DIFF
--- a/proto/eth/service/key_management.proto
+++ b/proto/eth/service/key_management.proto
@@ -19,9 +19,6 @@ import "google/api/annotations.proto";
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/empty.proto";
 
-import "proto/eth/v1/validator.proto";
-import "proto/eth/v2/validator.proto";
-
 option csharp_namespace = "Ethereum.Eth.Service";
 option go_package = "github.com/prysmaticlabs/prysm/proto/eth/service";
 option java_multiple_files = true;


### PR DESCRIPTION
Fixes the following warnings when Bazel build validators

```
proto/eth/service/key_management.proto:22:1: warning: Import proto/eth/v1/validator.proto is unused.
proto/eth/service/key_management.proto:23:1: warning: Import proto/eth/v2/validator.proto is unused.
```