### PR TITLE
Do not rely on peer order in `TestDebugServer_ListPeers`

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/debug/p2p_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/debug/p2p_test.go
@@ -40,11 +40,19 @@ func TestDebugServer_ListPeers(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, len(res.Responses))
 
-	assert.Equal(t, int(ethpb.PeerDirection_INBOUND), int(res.Responses[0].Direction), "Expected 1st peer to be an inbound")
+	direction1 := res.Responses[0].Direction
+	direction2 := res.Responses[1].Direction
+	assert.Equal(t,
+		true,
+		direction1 == ethpb.PeerDirection_INBOUND || direction2 == ethpb.PeerDirection_INBOUND,
+		"Expected an inbound peer")
+	assert.Equal(t,
+		true,
+		direction1 == ethpb.PeerDirection_OUTBOUND || direction2 == ethpb.PeerDirection_OUTBOUND,
+		"Expected an outbound peer")
 	if len(res.Responses[0].ListeningAddresses) == 0 {
 		t.Errorf("Expected 1st peer to have a multiaddress, instead they have no addresses")
 	}
-	assert.Equal(t, ethpb.PeerDirection_OUTBOUND, res.Responses[1].Direction, "Expected 2st peer to be an outbound connection")
 	if len(res.Responses[1].ListeningAddresses) == 0 {
 		t.Errorf("Expected 2nd peer to have a multiaddress, instead they have no addresses")
 	}


### PR DESCRIPTION
**What type of PR is this?**

Tests

**What does this PR do? Why is it needed?**

`TestDebugServer_ListPeers` sometimes fails because the order of returned peers does not match test asserts. This change removes any assumptions about peer ordering.
