### PR TITLE
Add Safe Sub64 Method

### DIFF
--- a/math/math_helper.go
+++ b/math/math_helper.go
@@ -112,3 +112,12 @@ func Add64(a, b uint64) (uint64, error) {
 	}
 	return res, nil
 }
+
+// Sub64 subtracts two 64-bit unsigned integers and checks for errors.
+func Sub64(a, b uint64) (uint64, error) {
+	res, borrow := bits.Sub64(a, b, 0 /* borrow */)
+	if borrow > 0 {
+		return 0, errors.New("subtraction underflow")
+	}
+	return res, nil
+}

--- a/math/math_helper_test.go
+++ b/math/math_helper_test.go
@@ -4,7 +4,6 @@ import (
 	stdmath "math"
 	"testing"
 
-	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/math"
 	"github.com/prysmaticlabs/prysm/testing/require"
 )
@@ -357,7 +356,7 @@ func TestMath_Sub64(t *testing.T) {
 		{args: args{1 << 63, 2}, res: 9223372036854775806},
 	}
 	for _, tt := range tests {
-		got, err := types.Sub64(tt.args.a, tt.args.b)
+		got, err := math.Sub64(tt.args.a, tt.args.b)
 		if tt.err && err == nil {
 			t.Errorf("Sub64() Expected Error = %v, want error", tt.err)
 			continue

--- a/math/math_helper_test.go
+++ b/math/math_helper_test.go
@@ -4,6 +4,7 @@ import (
 	stdmath "math"
 	"testing"
 
+	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/math"
 	"github.com/prysmaticlabs/prysm/testing/require"
 )
@@ -329,6 +330,40 @@ func TestAdd64(t *testing.T) {
 		}
 		if tt.res != got {
 			t.Errorf("Add64() %v, want %v", got, tt.res)
+		}
+	}
+}
+
+func TestMath_Sub64(t *testing.T) {
+	type args struct {
+		a uint64
+		b uint64
+	}
+	tests := []struct {
+		args args
+		res  uint64
+		err  bool
+	}{
+		{args: args{1, 0}, res: 1},
+		{args: args{0, 1}, res: 0, err: true},
+		{args: args{1 << 32, 1}, res: 4294967295},
+		{args: args{1 << 32, 100}, res: 4294967196},
+		{args: args{1 << 31, 1 << 31}, res: 0},
+		{args: args{1 << 63, 1 << 63}, res: 0},
+		{args: args{1 << 63, 1}, res: 9223372036854775807},
+		{args: args{stdmath.MaxUint64, stdmath.MaxUint64}, res: 0},
+		{args: args{stdmath.MaxUint64 - 1, stdmath.MaxUint64}, res: 0, err: true},
+		{args: args{stdmath.MaxUint64, 0}, res: stdmath.MaxUint64},
+		{args: args{1 << 63, 2}, res: 9223372036854775806},
+	}
+	for _, tt := range tests {
+		got, err := types.Sub64(tt.args.a, tt.args.b)
+		if tt.err && err == nil {
+			t.Errorf("Sub64() Expected Error = %v, want error", tt.err)
+			continue
+		}
+		if tt.res != got {
+			t.Errorf("Sub64() %v, want %v", got, tt.res)
 		}
 	}
 }


### PR DESCRIPTION
Adds a safe math Sub64 method for uint64s in Prysm, brought up by @uncdr. We had safe add but no safe sub in Prysm to use generically