### PR TITLE
Return ERROR Status in ImportKeystores standard API endpoint if slashing protection fails

### DIFF
--- a/validator/rpc/standard_api.go
+++ b/validator/rpc/standard_api.go
@@ -73,7 +73,14 @@ func (s *Server) ImportKeystores(
 		if err := slashingprotection.ImportStandardProtectionJSON(
 			ctx, s.valDB, bytes.NewBuffer([]byte(req.SlashingProtection)),
 		); err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not import slashing protection JSON: %v", err)
+			statuses := make([]*ethpbservice.ImportedKeystoreStatus, len(req.Keystores))
+			for i := range statuses {
+				statuses[i] = &ethpbservice.ImportedKeystoreStatus{
+					Status:  ethpbservice.ImportedKeystoreStatus_ERROR,
+					Message: fmt.Sprintf("could not import slashing protection: %v", err),
+				}
+			}
+			return &ethpbservice.ImportKeystoresResponse{Statuses: statuses}, nil
 		}
 	}
 	statuses, err := importer.ImportKeystores(ctx, keystores, req.Passwords)

--- a/validator/rpc/standard_api_test.go
+++ b/validator/rpc/standard_api_test.go
@@ -134,17 +134,23 @@ func TestServer_ImportKeystores(t *testing.T) {
 		numKeystores := 5
 		password := "12345678"
 		encodedKeystores := make([]string, numKeystores)
+		passwords := make([]string, numKeystores)
 		for i := 0; i < numKeystores; i++ {
 			enc, err := json.Marshal(createRandomKeystore(t, password))
 			encodedKeystores[i] = string(enc)
 			require.NoError(t, err)
+			passwords[i] = password
 		}
-		_, err := s.ImportKeystores(context.Background(), &ethpbservice.ImportKeystoresRequest{
+		resp, err := s.ImportKeystores(context.Background(), &ethpbservice.ImportKeystoresRequest{
 			Keystores:          encodedKeystores,
-			Passwords:          []string{password},
+			Passwords:          passwords,
 			SlashingProtection: "foobar",
 		})
-		require.NotNil(t, err)
+		require.NoError(t, err)
+		require.Equal(t, numKeystores, len(resp.Statuses))
+		for _, st := range resp.Statuses {
+			require.Equal(t, ethpbservice.ImportedKeystoreStatus_ERROR, st.Status)
+		}
 	})
 	t.Run("returns proper statuses for keystores in request", func(t *testing.T) {
 		numKeystores := 5


### PR DESCRIPTION
If slashing protection import fails in ImportKeystores, we should not return a 500, but instead return a list of statuses with each status having the ERROR enum