### PR TITLE
Add Justifications for Gosec Ignored

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
           goimports-path: ./
 
       - name: Gosec security scanner
-        uses: securego/gosec@v2.9.0
+        uses: securego/gosec@master
         with:
           args: '-exclude=G307 -exclude-dir=crypto/bls/herumi ./...'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
           goimports-path: ./
 
       - name: Gosec security scanner
-        uses: securego/gosec@v2.9.3
+        uses: securego/gosec@v2.9.0
         with:
           args: '-exclude=G307 -exclude-dir=crypto/bls/herumi ./...'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
           goimports-path: ./
 
       - name: Gosec security scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.9.3
         with:
           args: '-exclude=G307 -exclude-dir=crypto/bls/herumi ./...'
 

--- a/crypto/bls/blst/signature.go
+++ b/crypto/bls/blst/signature.go
@@ -208,7 +208,7 @@ func VerifyMultipleSignatures(sigs [][]byte, msgs [][32]byte, pubKeys []common.P
 	randFunc := func(scalar *blst.Scalar) {
 		var rbytes [scalarBytes]byte
 		randLock.Lock()
-		randGen.Read(rbytes[:]) /* #nosec G104 -- Error will always be nil in `read` in math/rand */
+		randGen.Read(rbytes[:]) // #nosec G104 -- Error will always be nil in `read` in math/rand
 		randLock.Unlock()
 		// Protect against the generator returning 0. Since the scalar value is
 		// derived from a big endian byte slice, we take the last byte.

--- a/crypto/bls/blst/signature.go
+++ b/crypto/bls/blst/signature.go
@@ -1,3 +1,4 @@
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && !blst_disabled
 // +build linux,amd64 linux,arm64 darwin,amd64 darwin,arm64 windows,amd64
 // +build !blst_disabled
 
@@ -207,8 +208,7 @@ func VerifyMultipleSignatures(sigs [][]byte, msgs [][32]byte, pubKeys []common.P
 	randFunc := func(scalar *blst.Scalar) {
 		var rbytes [scalarBytes]byte
 		randLock.Lock()
-		// Ignore error as the error will always be nil in `read` in math/rand.
-		randGen.Read(rbytes[:]) /* #nosec G104 */
+		randGen.Read(rbytes[:]) /* #nosec G104 -- Error will always be nil in `read` in math/rand */
 		randLock.Unlock()
 		// Protect against the generator returning 0. Since the scalar value is
 		// derived from a big endian byte slice, we take the last byte.

--- a/crypto/keystore/keystore.go
+++ b/crypto/keystore/keystore.go
@@ -55,8 +55,7 @@ type Keystore struct {
 // GetKey from file using the filename path and a decryption password.
 func (_ Keystore) GetKey(filename, password string) (*Key, error) {
 	// Load the key from the keystore and decrypt its contents
-	// #nosec G304 -- ReadFile is safe
-	keyJSON, err := ioutil.ReadFile(filename)
+	keyJSON, err := ioutil.ReadFile(filename) // #nosec G304 -- ReadFile is safe
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/keystore/keystore.go
+++ b/crypto/keystore/keystore.go
@@ -55,7 +55,7 @@ type Keystore struct {
 // GetKey from file using the filename path and a decryption password.
 func (_ Keystore) GetKey(filename, password string) (*Key, error) {
 	// Load the key from the keystore and decrypt its contents
-	// #nosec G304
+	// #nosec G304 -- ReadFile is safe
 	keyJSON, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err

--- a/crypto/rand/rand.go
+++ b/crypto/rand/rand.go
@@ -40,7 +40,7 @@ import (
 type source struct{}
 
 var lock sync.RWMutex
-var _ mrand.Source64 = (*source)(nil) /* #nosec G404 */
+var _ mrand.Source64 = (*source)(nil) /* #nosec G404 -- This ensures we meet the interface */
 
 // Seed does nothing when crypto/rand is used as source.
 func (_ *source) Seed(_ int64) {}
@@ -71,7 +71,7 @@ type Rand = mrand.Rand /* #nosec G404 */
 // Use it for everything where crypto secure non-deterministic randomness is required. Performance
 // takes a hit, so use sparingly.
 func NewGenerator() *Rand {
-	return mrand.New(&source{}) /* #nosec G404 */
+	return mrand.New(&source{}) /* #nosec G404 -- excluded */
 }
 
 // NewDeterministicGenerator returns a random generator which is only seeded with crypto/rand,
@@ -82,5 +82,5 @@ func NewGenerator() *Rand {
 // can be potentially predicted even without knowledge of the underlying seed.
 func NewDeterministicGenerator() *Rand {
 	randGen := NewGenerator()
-	return mrand.New(mrand.NewSource(randGen.Int63())) /* #nosec G404 */
+	return mrand.New(mrand.NewSource(randGen.Int63())) /* #nosec G404 -- excluded */
 }

--- a/crypto/rand/rand.go
+++ b/crypto/rand/rand.go
@@ -40,7 +40,7 @@ import (
 type source struct{}
 
 var lock sync.RWMutex
-var _ mrand.Source64 = (*source)(nil) /* #nosec G404 -- This ensures we meet the interface */
+var _ mrand.Source64 = (*source)(nil) // #nosec G404 -- This ensures we meet the interface
 
 // Seed does nothing when crypto/rand is used as source.
 func (_ *source) Seed(_ int64) {}
@@ -63,7 +63,7 @@ func (_ *source) Uint64() (val uint64) {
 }
 
 // Rand is alias for underlying random generator.
-type Rand = mrand.Rand /* #nosec G404 */
+type Rand = mrand.Rand // #nosec G404
 
 // NewGenerator returns a new generator that uses random values from crypto/rand as a source
 // (cryptographically secure random number generator).
@@ -71,7 +71,7 @@ type Rand = mrand.Rand /* #nosec G404 */
 // Use it for everything where crypto secure non-deterministic randomness is required. Performance
 // takes a hit, so use sparingly.
 func NewGenerator() *Rand {
-	return mrand.New(&source{}) /* #nosec G404 -- excluded */
+	return mrand.New(&source{}) // #nosec G404 -- excluded
 }
 
 // NewDeterministicGenerator returns a random generator which is only seeded with crypto/rand,
@@ -82,5 +82,5 @@ func NewGenerator() *Rand {
 // can be potentially predicted even without knowledge of the underlying seed.
 func NewDeterministicGenerator() *Rand {
 	randGen := NewGenerator()
-	return mrand.New(mrand.NewSource(randGen.Int63())) /* #nosec G404 -- excluded */
+	return mrand.New(mrand.NewSource(randGen.Int63())) // #nosec G404 -- excluded
 }

--- a/encoding/ssz/deep_equal.go
+++ b/encoding/ssz/deep_equal.go
@@ -13,8 +13,8 @@ import (
 // checks in progress are true when it reencounters them.
 // Visited comparisons are stored in a map indexed by visit.
 type visit struct {
-	a1  unsafe.Pointer /* #nosec G103 -- Test use only */
-	a2  unsafe.Pointer /* #nosec G103 -- Test use only */
+	a1  unsafe.Pointer // #nosec G103 -- Test use only
+	a2  unsafe.Pointer // #nosec G103 -- Test use only
 	typ reflect.Type
 }
 
@@ -48,8 +48,8 @@ func deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool, depth int) boo
 	}
 
 	if v1.CanAddr() && v2.CanAddr() && hard(v1.Kind()) {
-		addr1 := unsafe.Pointer(v1.UnsafeAddr()) /* #nosec G103 -- Test compare only */
-		addr2 := unsafe.Pointer(v2.UnsafeAddr()) /* #nosec G103 -- Test compare only */
+		addr1 := unsafe.Pointer(v1.UnsafeAddr()) // #nosec G103 -- Test compare only
+		addr2 := unsafe.Pointer(v2.UnsafeAddr()) // #nosec G103 -- Test compare only
 
 		if uintptr(addr1) > uintptr(addr2) {
 			// Canonicalize order to reduce number of entries in visited.
@@ -139,8 +139,8 @@ func deepValueEqualExportedOnly(v1, v2 reflect.Value, visited map[visit]bool, de
 	}
 
 	if v1.CanAddr() && v2.CanAddr() && hard(v1.Kind()) {
-		addr1 := unsafe.Pointer(v1.UnsafeAddr()) /* #nosec G103 -- Test compare only */
-		addr2 := unsafe.Pointer(v2.UnsafeAddr()) /* #nosec G103 -- Test compare only */
+		addr1 := unsafe.Pointer(v1.UnsafeAddr()) // #nosec G103 -- Test compare only
+		addr2 := unsafe.Pointer(v2.UnsafeAddr()) // #nosec G103 -- Test compare only
 		if uintptr(addr1) > uintptr(addr2) {
 			// Canonicalize order to reduce number of entries in visited.
 			// Assumes non-moving garbage collector.

--- a/encoding/ssz/deep_equal.go
+++ b/encoding/ssz/deep_equal.go
@@ -13,8 +13,8 @@ import (
 // checks in progress are true when it reencounters them.
 // Visited comparisons are stored in a map indexed by visit.
 type visit struct {
-	a1  unsafe.Pointer /* #nosec G103 */
-	a2  unsafe.Pointer /* #nosec G103 */
+	a1  unsafe.Pointer /* #nosec G103 -- Test use only */
+	a2  unsafe.Pointer /* #nosec G103 -- Test use only */
 	typ reflect.Type
 }
 
@@ -48,8 +48,8 @@ func deepValueEqual(v1, v2 reflect.Value, visited map[visit]bool, depth int) boo
 	}
 
 	if v1.CanAddr() && v2.CanAddr() && hard(v1.Kind()) {
-		addr1 := unsafe.Pointer(v1.UnsafeAddr()) /* #nosec G103 */
-		addr2 := unsafe.Pointer(v2.UnsafeAddr()) /* #nosec G103 */
+		addr1 := unsafe.Pointer(v1.UnsafeAddr()) /* #nosec G103 -- Test compare only */
+		addr2 := unsafe.Pointer(v2.UnsafeAddr()) /* #nosec G103 -- Test compare only */
 
 		if uintptr(addr1) > uintptr(addr2) {
 			// Canonicalize order to reduce number of entries in visited.
@@ -139,8 +139,8 @@ func deepValueEqualExportedOnly(v1, v2 reflect.Value, visited map[visit]bool, de
 	}
 
 	if v1.CanAddr() && v2.CanAddr() && hard(v1.Kind()) {
-		addr1 := unsafe.Pointer(v1.UnsafeAddr()) /* #nosec G103 */
-		addr2 := unsafe.Pointer(v2.UnsafeAddr()) /* #nosec G103 */
+		addr1 := unsafe.Pointer(v1.UnsafeAddr()) /* #nosec G103 -- Test compare only */
+		addr2 := unsafe.Pointer(v2.UnsafeAddr()) /* #nosec G103 -- Test compare only */
 		if uintptr(addr1) > uintptr(addr2) {
 			// Canonicalize order to reduce number of entries in visited.
 			// Assumes non-moving garbage collector.

--- a/runtime/prereqs/prereq.go
+++ b/runtime/prereqs/prereq.go
@@ -27,7 +27,7 @@ var (
 
 // execShellOutputFunc passes a command and args to exec.CommandContext and returns the result as a string
 func execShellOutputFunc(ctx context.Context, command string, args ...string) (string, error) {
-	result, err := exec.CommandContext(ctx, command, args...).Output() /* #nosec G204 */
+	result, err := exec.CommandContext(ctx, command, args...).Output() // #nosec G204
 	if err != nil {
 		return "", errors.Wrap(err, "error in command execution")
 	}

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -129,7 +129,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 	args = append(args, features.E2EBeaconChainFlags...)
 	args = append(args, config.BeaconFlags...)
 
-	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 */
+	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 -- Safe */
 	// Write stdout and stderr to log files.
 	stdout, err := os.Create(path.Join(e2e.TestParams.LogPath, fmt.Sprintf("beacon_node_%d_stdout.log", index)))
 	if err != nil {

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -129,7 +129,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 	args = append(args, features.E2EBeaconChainFlags...)
 	args = append(args, config.BeaconFlags...)
 
-	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 -- Safe */
+	cmd := exec.CommandContext(ctx, binaryPath, args...) // #nosec G204 -- Safe
 	// Write stdout and stderr to log files.
 	stdout, err := os.Create(path.Join(e2e.TestParams.LogPath, fmt.Sprintf("beacon_node_%d_stdout.log", index)))
 	if err != nil {

--- a/testing/endtoend/components/boot_node.go
+++ b/testing/endtoend/components/boot_node.go
@@ -55,7 +55,7 @@ func (node *BootNode) Start(ctx context.Context) error {
 		"--debug",
 	}
 
-	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 */
+	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 -- Safe */
 	cmd.Stdout = stdOutFile
 	cmd.Stderr = stdOutFile
 	log.Infof("Starting boot node with flags: %s", strings.Join(args[1:], " "))

--- a/testing/endtoend/components/boot_node.go
+++ b/testing/endtoend/components/boot_node.go
@@ -55,7 +55,7 @@ func (node *BootNode) Start(ctx context.Context) error {
 		"--debug",
 	}
 
-	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 -- Safe */
+	cmd := exec.CommandContext(ctx, binaryPath, args...) // #nosec G204 -- Safe
 	cmd.Stdout = stdOutFile
 	cmd.Stderr = stdOutFile
 	log.Infof("Starting boot node with flags: %s", strings.Join(args[1:], " "))

--- a/testing/endtoend/components/eth1.go
+++ b/testing/endtoend/components/eth1.go
@@ -81,7 +81,7 @@ func (node *Eth1Node) Start(ctx context.Context) error {
 		"--dev.period=2",
 		"--ipcdisable",
 	}
-	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 */
+	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 -- Safe */
 	file, err := helpers.DeleteAndCreateFile(e2e.TestParams.LogPath, "eth1.log")
 	if err != nil {
 		return err
@@ -109,7 +109,7 @@ func (node *Eth1Node) Start(ctx context.Context) error {
 		return err
 	}
 	keystorePath := path.Join(eth1Path, fmt.Sprintf("keystore/%s", strings.TrimSpace(string(fileName))))
-	jsonBytes, err := ioutil.ReadFile(keystorePath) // #nosec G304
+	jsonBytes, err := ioutil.ReadFile(keystorePath) // #nosec G304 -- ReadFile is safe
 	if err != nil {
 		return err
 	}

--- a/testing/endtoend/components/eth1.go
+++ b/testing/endtoend/components/eth1.go
@@ -81,7 +81,7 @@ func (node *Eth1Node) Start(ctx context.Context) error {
 		"--dev.period=2",
 		"--ipcdisable",
 	}
-	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 -- Safe */
+	cmd := exec.CommandContext(ctx, binaryPath, args...) // #nosec G204 -- Safe
 	file, err := helpers.DeleteAndCreateFile(e2e.TestParams.LogPath, "eth1.log")
 	if err != nil {
 		return err
@@ -104,7 +104,7 @@ func (node *Eth1Node) Start(ctx context.Context) error {
 	web3 := ethclient.NewClient(client)
 
 	// Access the dev account keystore to deploy the contract.
-	fileName, err := exec.Command("ls", path.Join(eth1Path, "keystore")).Output() /* #nosec G204 */
+	fileName, err := exec.Command("ls", path.Join(eth1Path, "keystore")).Output() // #nosec G204
 	if err != nil {
 		return err
 	}

--- a/testing/endtoend/components/validator.go
+++ b/testing/endtoend/components/validator.go
@@ -155,7 +155,7 @@ func (v *ValidatorNode) Start(ctx context.Context) error {
 		log.Warning("Using latest release validator via prysm.sh")
 	}
 
-	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 */
+	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 -- Safe */
 
 	// Write stdout and stderr to log files.
 	stdout, err := os.Create(path.Join(e2e.TestParams.LogPath, fmt.Sprintf("validator_%d_stdout.log", index)))

--- a/testing/endtoend/components/validator.go
+++ b/testing/endtoend/components/validator.go
@@ -155,7 +155,7 @@ func (v *ValidatorNode) Start(ctx context.Context) error {
 		log.Warning("Using latest release validator via prysm.sh")
 	}
 
-	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 -- Safe */
+	cmd := exec.CommandContext(ctx, binaryPath, args...) // #nosec G204 -- Safe
 
 	// Write stdout and stderr to log files.
 	stdout, err := os.Create(path.Join(e2e.TestParams.LogPath, fmt.Sprintf("validator_%d_stdout.log", index)))

--- a/testing/endtoend/helpers/helpers.go
+++ b/testing/endtoend/helpers/helpers.go
@@ -162,7 +162,7 @@ func WritePprofFiles(testDir string, index int) error {
 }
 
 func writeURLRespAtPath(url, filePath string) error {
-	resp, err := http.Get(url) /* #nosec G107 */
+	resp, err := http.Get(url) /* #nosec G107 -- Safe, used internally */
 	if err != nil {
 		return err
 	}

--- a/testing/endtoend/helpers/helpers.go
+++ b/testing/endtoend/helpers/helpers.go
@@ -162,7 +162,7 @@ func WritePprofFiles(testDir string, index int) error {
 }
 
 func writeURLRespAtPath(url, filePath string) error {
-	resp, err := http.Get(url) /* #nosec G107 -- Safe, used internally */
+	resp, err := http.Get(url) // #nosec G107 -- Safe, used internally
 	if err != nil {
 		return err
 	}

--- a/tools/specs-checker/download.go
+++ b/tools/specs-checker/download.go
@@ -50,7 +50,7 @@ func getAndSaveFile(specDocUrl, outFilePath string) error {
 	}()
 
 	// Download spec doc.
-	resp, err := http.Get(specDocUrl) /* #nosec G107 */
+	resp, err := http.Get(specDocUrl) /* #nosec G107 -- False positive */
 	if err != nil {
 		return err
 	}

--- a/tools/specs-checker/download.go
+++ b/tools/specs-checker/download.go
@@ -50,7 +50,7 @@ func getAndSaveFile(specDocUrl, outFilePath string) error {
 	}()
 
 	// Download spec doc.
-	resp, err := http.Get(specDocUrl) /* #nosec G107 -- False positive */
+	resp, err := http.Get(specDocUrl) // #nosec G107 -- False positive
 	if err != nil {
 		return err
 	}

--- a/validator/accounts/wallet_recover.go
+++ b/validator/accounts/wallet_recover.go
@@ -23,14 +23,14 @@ import (
 
 const (
 	phraseWordCount = 24
-	/* #nosec G101 -- Not sensitive data */
+	// #nosec G101 -- Not sensitive data
 	newMnemonicPassphraseYesNoText = "(Advanced) Do you want to setup a '25th word' passphrase for your mnemonic? [y/n]"
-	/* #nosec G101 -- Not sensitive data */
+	// #nosec G101 -- Not sensitive data
 	newMnemonicPassphrasePromptText = "(Advanced) Setup a passphrase '25th word' for your mnemonic " +
 		"(WARNING: You cannot recover your keys from your mnemonic if you forget this passphrase!)"
-	/* #nosec G101 -- Not sensitive data */
+	// #nosec G101 -- Not sensitive data
 	mnemonicPassphraseYesNoText = "(Advanced) Do you have an optional '25th word' passphrase for your mnemonic? [y/n]"
-	/* #nosec G101 -- Not sensitive data */
+	// #nosec G101 -- Not sensitive data
 	mnemonicPassphrasePromptText = "(Advanced) Enter the '25th word' passphrase for your mnemonic"
 )
 

--- a/validator/accounts/wallet_recover.go
+++ b/validator/accounts/wallet_recover.go
@@ -23,14 +23,14 @@ import (
 
 const (
 	phraseWordCount = 24
-	/* #nosec G101 */
+	/* #nosec G101 -- Not sensitive data */
 	newMnemonicPassphraseYesNoText = "(Advanced) Do you want to setup a '25th word' passphrase for your mnemonic? [y/n]"
-	/* #nosec G101 */
+	/* #nosec G101 -- Not sensitive data */
 	newMnemonicPassphrasePromptText = "(Advanced) Setup a passphrase '25th word' for your mnemonic " +
 		"(WARNING: You cannot recover your keys from your mnemonic if you forget this passphrase!)"
-	/* #nosec G101 */
+	/* #nosec G101 -- Not sensitive data */
 	mnemonicPassphraseYesNoText = "(Advanced) Do you have an optional '25th word' passphrase for your mnemonic? [y/n]"
-	/* #nosec G101 */
+	/* #nosec G101 -- Not sensitive data */
 	mnemonicPassphrasePromptText = "(Advanced) Enter the '25th word' passphrase for your mnemonic"
 )
 
@@ -152,7 +152,7 @@ func RecoverWallet(ctx context.Context, cfg *RecoverWalletConfig) (*wallet.Walle
 func inputMnemonic(cliCtx *cli.Context) (mnemonicPhrase string, err error) {
 	if cliCtx.IsSet(flags.MnemonicFileFlag.Name) {
 		mnemonicFilePath := cliCtx.String(flags.MnemonicFileFlag.Name)
-		data, err := ioutil.ReadFile(mnemonicFilePath) // #nosec G304
+		data, err := ioutil.ReadFile(mnemonicFilePath) // #nosec G304 -- ReadFile is safe
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Gosec, one of our Github action workflows, changed a few hours ago with a release that had breaking changes. To resolve, we add justification to nosec rules defined in Prysm.
