### PR TITLE
Fix sync commitee endpoint

### DIFF
--- a/beacon-chain/rpc/eth/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/eth/beacon/BUILD.bazel
@@ -110,6 +110,8 @@ go_test(
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_wealdtech_go_bytesutil//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",
+        "@org_golang_google_grpc//codes:go_default_library",
+        "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/eth/beacon/sync_committee_test.go
+++ b/beacon-chain/rpc/eth/beacon/sync_committee_test.go
@@ -1,7 +1,9 @@
 package beacon
 
 import (
+	"bytes"
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +16,7 @@ import (
 	mockp2p "github.com/prysmaticlabs/prysm/beacon-chain/p2p/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/rpc/prysm/v1alpha1/validator"
 	"github.com/prysmaticlabs/prysm/beacon-chain/rpc/testutil"
+	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/config/params"
 	"github.com/prysmaticlabs/prysm/encoding/bytesutil"
 	ethpbv2 "github.com/prysmaticlabs/prysm/proto/eth/v2"
@@ -23,6 +26,8 @@ import (
 	"github.com/prysmaticlabs/prysm/testing/util"
 	bytesutil2 "github.com/wealdtech/go-bytesutil"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func Test_currentCommitteeIndicesFromState(t *testing.T) {
@@ -185,6 +190,28 @@ func TestListSyncCommittees(t *testing.T) {
 	}
 }
 
+type futureSyncMockFetcher struct {
+	BeaconState     state.BeaconState
+	BeaconStateRoot []byte
+}
+
+func (m *futureSyncMockFetcher) State(_ context.Context, stateId []byte) (state.BeaconState, error) {
+	expectedRequest := []byte(strconv.FormatUint(uint64(0), 10))
+	res := bytes.Compare(stateId, expectedRequest)
+	if res != 0 {
+		return nil, status.Errorf(
+			codes.Internal,
+			"Requested wrong epoch for next sync committee, expected: %#x, received: %#x",
+			expectedRequest,
+			stateId,
+		)
+	}
+	return m.BeaconState, nil
+}
+func (m *futureSyncMockFetcher) StateRoot(context.Context, []byte) ([]byte, error) {
+	return m.BeaconStateRoot, nil
+}
+
 func TestListSyncCommitteesFuture(t *testing.T) {
 	ctx := context.Background()
 	st, _ := util.DeterministicGenesisStateAltair(t, params.BeaconConfig().SyncCommitteeSize)
@@ -202,7 +229,7 @@ func TestListSyncCommitteesFuture(t *testing.T) {
 		GenesisTimeFetcher: &testutil.MockGenesisTimeFetcher{
 			Genesis: time.Now(),
 		},
-		StateFetcher: &testutil.MockFetcher{
+		StateFetcher: &futureSyncMockFetcher{
 			BeaconState: st,
 		},
 	}


### PR DESCRIPTION
In the back and forth to #9945 a bug was introduced in the logic to request future sync committees. This fixes that. 