### PR TITLE
Fix state alias v3

### DIFF
--- a/beacon-chain/core/execution/upgrade.go
+++ b/beacon-chain/core/execution/upgrade.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/time"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
-	v2 "github.com/prysmaticlabs/prysm/beacon-chain/state/v3"
+	"github.com/prysmaticlabs/prysm/beacon-chain/state/v3"
 	"github.com/prysmaticlabs/prysm/config/params"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 )
@@ -82,5 +82,5 @@ func UpgradeToMerge(ctx context.Context, state state.BeaconState) (state.BeaconS
 		},
 	}
 
-	return v2.InitializeFromProto(s)
+	return v3.InitializeFromProto(s)
 }


### PR DESCRIPTION
It's confusing that the import of `github.com/prysmaticlabs/prysm/beacon-chain/state/v3` has an alias to v2