### PR TITLE
Update `Transactions` and `ExtraData` non empty check

### DIFF
--- a/beacon-chain/core/blocks/payload.go
+++ b/beacon-chain/core/blocks/payload.go
@@ -156,15 +156,3 @@ func isEmptyHeader(h *ethpb.ExecutionPayloadHeader) bool {
 	return true
 }
 
-func EmptyPayload() *ethpb.ExecutionPayload {
-	return &ethpb.ExecutionPayload{
-		ParentHash:    make([]byte, fieldparams.RootLength),
-		FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
-		StateRoot:     make([]byte, fieldparams.RootLength),
-		ReceiptRoot:   make([]byte, fieldparams.RootLength),
-		LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
-		Random:        make([]byte, fieldparams.RootLength),
-		BaseFeePerGas: make([]byte, fieldparams.RootLength),
-		BlockHash:     make([]byte, fieldparams.RootLength),
-	}
-}

--- a/beacon-chain/core/blocks/payload.go
+++ b/beacon-chain/core/blocks/payload.go
@@ -25,7 +25,7 @@ func MergeComplete(st state.BeaconState) (bool, error) {
 }
 
 // IsMergeBlock returns true if the input block is the terminal merge block.
-// Meaning the header header in beacon state is  `ExecutionPayloadHeader()` (i.e. empty).
+// Meaning the header in beacon state is  `ExecutionPayloadHeader()` (i.e. empty).
 // And the input block has a non-empty header.
 //
 // Spec code:
@@ -89,10 +89,10 @@ func isEmptyPayload(p *ethpb.ExecutionPayload) bool {
 	if !bytes.Equal(p.BlockHash, make([]byte, fieldparams.RootLength)) {
 		return false
 	}
-	if p.Transactions != nil {
+	if len(p.Transactions) != 0 {
 		return false
 	}
-	if p.ExtraData != nil {
+	if len(p.ExtraData) != 0 {
 		return false
 	}
 	if p.BlockNumber != 0 {
@@ -138,7 +138,7 @@ func isEmptyHeader(h *ethpb.ExecutionPayloadHeader) bool {
 	if !bytes.Equal(h.TransactionsRoot, make([]byte, fieldparams.RootLength)) {
 		return false
 	}
-	if h.ExtraData != nil {
+	if len(h.ExtraData) != 0 {
 		return false
 	}
 	if h.BlockNumber != 0 {
@@ -154,4 +154,17 @@ func isEmptyHeader(h *ethpb.ExecutionPayloadHeader) bool {
 		return false
 	}
 	return true
+}
+
+func EmptyPayload() *ethpb.ExecutionPayload {
+	return &ethpb.ExecutionPayload{
+		ParentHash:    make([]byte, fieldparams.RootLength),
+		FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+		StateRoot:     make([]byte, fieldparams.RootLength),
+		ReceiptRoot:   make([]byte, fieldparams.RootLength),
+		LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+		Random:        make([]byte, fieldparams.RootLength),
+		BaseFeePerGas: make([]byte, fieldparams.RootLength),
+		BlockHash:     make([]byte, fieldparams.RootLength),
+	}
 }

--- a/beacon-chain/core/blocks/payload.go
+++ b/beacon-chain/core/blocks/payload.go
@@ -155,4 +155,3 @@ func isEmptyHeader(h *ethpb.ExecutionPayloadHeader) bool {
 	}
 	return true
 }
-

--- a/beacon-chain/core/blocks/payload_test.go
+++ b/beacon-chain/core/blocks/payload_test.go
@@ -431,6 +431,7 @@ func emptyPayloadHeader() *ethpb.ExecutionPayloadHeader {
 		BaseFeePerGas:    make([]byte, fieldparams.RootLength),
 		BlockHash:        make([]byte, fieldparams.RootLength),
 		TransactionsRoot: make([]byte, fieldparams.RootLength),
+		ExtraData:        make([]byte, 0),
 	}
 }
 
@@ -444,5 +445,7 @@ func emptyPayload() *ethpb.ExecutionPayload {
 		Random:        make([]byte, fieldparams.RootLength),
 		BaseFeePerGas: make([]byte, fieldparams.RootLength),
 		BlockHash:     make([]byte, fieldparams.RootLength),
+		Transactions:  make([][]byte, 0),
+		ExtraData:     make([]byte, 0),
 	}
 }


### PR DESCRIPTION
`Transactions` and `ExtraData` are `List` when checking non-empty. Using nil is insufficient as they often come back as initialized and empty. This PR fixes it along with the unit tests