### PR TITLE
Move ErrNilValidatorsInState from one in each state version to a common one

### DIFF
--- a/beacon-chain/state/BUILD.bazel
+++ b/beacon-chain/state/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "altair.go",
+        "error.go",
         "phase0.go",
         "prometheus.go",
     ],

--- a/beacon-chain/state/error.go
+++ b/beacon-chain/state/error.go
@@ -1,0 +1,9 @@
+package state
+
+import "errors"
+
+var (
+	// ErrNilValidatorsInState returns when accessing validators in the state while the state has a
+	// nil slice for the validators field.
+	ErrNilValidatorsInState = errors.New("state has nil validator slice")
+)

--- a/beacon-chain/state/state-native/v1/getters_validator.go
+++ b/beacon-chain/state/state-native/v1/getters_validator.go
@@ -17,12 +17,6 @@ type ValidatorIndexOutOfRangeError struct {
 	message string
 }
 
-var (
-	// ErrNilValidatorsInState returns when accessing validators in the state while the state has a
-	// nil slice for the validators field.
-	ErrNilValidatorsInState = errors.New("state has nil validator slice")
-)
-
 // NewValidatorIndexOutOfRangeError creates a new error instance.
 func NewValidatorIndexOutOfRangeError(index types.ValidatorIndex) ValidatorIndexOutOfRangeError {
 	return ValidatorIndexOutOfRangeError{
@@ -121,7 +115,7 @@ func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (state.
 		return nil, ErrNilInnerState
 	}
 	if b.state.Validators == nil {
-		return nil, ErrNilValidatorsInState
+		return nil, state.ErrNilValidatorsInState
 	}
 	if uint64(len(b.state.Validators)) <= uint64(idx) {
 		e := NewValidatorIndexOutOfRangeError(idx)

--- a/beacon-chain/state/state-native/v1/getters_validator_test.go
+++ b/beacon-chain/state/state-native/v1/getters_validator_test.go
@@ -3,6 +3,7 @@ package v1_test
 import (
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/state-native/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/assert"
@@ -16,5 +17,5 @@ func TestBeaconState_ValidatorAtIndexReadOnly_HandlesNilSlice(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = st.ValidatorAtIndexReadOnly(0)
-	assert.Equal(t, v1.ErrNilValidatorsInState, err)
+	assert.Equal(t, state.ErrNilValidatorsInState, err)
 }

--- a/beacon-chain/state/state-native/v2/BUILD.bazel
+++ b/beacon-chain/state/state-native/v2/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/state-native/v1:go_default_library",
         "//beacon-chain/state/stateutil:go_default_library",
         "//beacon-chain/state/types:go_default_library",

--- a/beacon-chain/state/state-native/v2/getters_validator.go
+++ b/beacon-chain/state/state-native/v2/getters_validator.go
@@ -18,12 +18,6 @@ type ValidatorIndexOutOfRangeError struct {
 	message string
 }
 
-var (
-	// ErrNilValidatorsInState returns when accessing validators in the state while the state has a
-	// nil slice for the validators field.
-	ErrNilValidatorsInState = errors.New("state has nil validator slice")
-)
-
 // NewValidatorIndexOutOfRangeError creates a new error instance.
 func NewValidatorIndexOutOfRangeError(index types.ValidatorIndex) ValidatorIndexOutOfRangeError {
 	return ValidatorIndexOutOfRangeError{
@@ -122,7 +116,7 @@ func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (state.
 		return nil, ErrNilInnerState
 	}
 	if b.state.Validators == nil {
-		return nil, ErrNilValidatorsInState
+		return nil, state.ErrNilValidatorsInState
 	}
 	if uint64(len(b.state.Validators)) <= uint64(idx) {
 		e := NewValidatorIndexOutOfRangeError(idx)

--- a/beacon-chain/state/state-native/v2/getters_validator_test.go
+++ b/beacon-chain/state/state-native/v2/getters_validator_test.go
@@ -3,6 +3,7 @@ package v2_test
 import (
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/state-native/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/assert"
@@ -16,5 +17,5 @@ func TestBeaconState_ValidatorAtIndexReadOnly_HandlesNilSlice(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = st.ValidatorAtIndexReadOnly(0)
-	assert.Equal(t, v1.ErrNilValidatorsInState, err)
+	assert.Equal(t, state.ErrNilValidatorsInState, err)
 }

--- a/beacon-chain/state/state-native/v3/BUILD.bazel
+++ b/beacon-chain/state/state-native/v3/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/state-native/v1:go_default_library",
         "//beacon-chain/state/stateutil:go_default_library",
         "//beacon-chain/state/types:go_default_library",

--- a/beacon-chain/state/state-native/v3/getters_validator.go
+++ b/beacon-chain/state/state-native/v3/getters_validator.go
@@ -18,12 +18,6 @@ type ValidatorIndexOutOfRangeError struct {
 	message string
 }
 
-var (
-	// ErrNilValidatorsInState returns when accessing validators in the state while the state has a
-	// nil slice for the validators field.
-	ErrNilValidatorsInState = errors.New("state has nil validator slice")
-)
-
 // NewValidatorIndexOutOfRangeError creates a new error instance.
 func NewValidatorIndexOutOfRangeError(index types.ValidatorIndex) ValidatorIndexOutOfRangeError {
 	return ValidatorIndexOutOfRangeError{
@@ -122,7 +116,7 @@ func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (state.
 		return nil, ErrNilInnerState
 	}
 	if b.state.Validators == nil {
-		return nil, ErrNilValidatorsInState
+		return nil, state.ErrNilValidatorsInState
 	}
 	if uint64(len(b.state.Validators)) <= uint64(idx) {
 		e := NewValidatorIndexOutOfRangeError(idx)

--- a/beacon-chain/state/state-native/v3/getters_validator_test.go
+++ b/beacon-chain/state/state-native/v3/getters_validator_test.go
@@ -3,6 +3,7 @@ package v3_test
 import (
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/state-native/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/assert"
@@ -16,5 +17,5 @@ func TestBeaconState_ValidatorAtIndexReadOnly_HandlesNilSlice(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = st.ValidatorAtIndexReadOnly(0)
-	assert.Equal(t, v1.ErrNilValidatorsInState, err)
+	assert.Equal(t, state.ErrNilValidatorsInState, err)
 }

--- a/beacon-chain/state/v1/getters_validator.go
+++ b/beacon-chain/state/v1/getters_validator.go
@@ -17,12 +17,6 @@ type ValidatorIndexOutOfRangeError struct {
 	message string
 }
 
-var (
-	// ErrNilValidatorsInState returns when accessing validators in the state while the state has a
-	// nil slice for the validators field.
-	ErrNilValidatorsInState = errors.New("state has nil validator slice")
-)
-
 // NewValidatorIndexOutOfRangeError creates a new error instance.
 func NewValidatorIndexOutOfRangeError(index types.ValidatorIndex) ValidatorIndexOutOfRangeError {
 	return ValidatorIndexOutOfRangeError{
@@ -121,7 +115,7 @@ func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (state.
 		return nil, ErrNilInnerState
 	}
 	if b.state.Validators == nil {
-		return nil, ErrNilValidatorsInState
+		return nil, state.ErrNilValidatorsInState
 	}
 	if uint64(len(b.state.Validators)) <= uint64(idx) {
 		e := NewValidatorIndexOutOfRangeError(idx)

--- a/beacon-chain/state/v1/getters_validator_test.go
+++ b/beacon-chain/state/v1/getters_validator_test.go
@@ -3,6 +3,7 @@ package v1_test
 import (
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/assert"
@@ -16,5 +17,5 @@ func TestBeaconState_ValidatorAtIndexReadOnly_HandlesNilSlice(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = st.ValidatorAtIndexReadOnly(0)
-	assert.Equal(t, v1.ErrNilValidatorsInState, err)
+	assert.Equal(t, state.ErrNilValidatorsInState, err)
 }

--- a/beacon-chain/state/v2/BUILD.bazel
+++ b/beacon-chain/state/v2/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stateutil:go_default_library",
         "//beacon-chain/state/types:go_default_library",
         "//beacon-chain/state/v1:go_default_library",

--- a/beacon-chain/state/v2/getters_validator.go
+++ b/beacon-chain/state/v2/getters_validator.go
@@ -18,12 +18,6 @@ type ValidatorIndexOutOfRangeError struct {
 	message string
 }
 
-var (
-	// ErrNilValidatorsInState returns when accessing validators in the state while the state has a
-	// nil slice for the validators field.
-	ErrNilValidatorsInState = errors.New("state has nil validator slice")
-)
-
 // NewValidatorIndexOutOfRangeError creates a new error instance.
 func NewValidatorIndexOutOfRangeError(index types.ValidatorIndex) ValidatorIndexOutOfRangeError {
 	return ValidatorIndexOutOfRangeError{
@@ -122,7 +116,7 @@ func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (state.
 		return nil, ErrNilInnerState
 	}
 	if b.state.Validators == nil {
-		return nil, ErrNilValidatorsInState
+		return nil, state.ErrNilValidatorsInState
 	}
 	if uint64(len(b.state.Validators)) <= uint64(idx) {
 		e := NewValidatorIndexOutOfRangeError(idx)

--- a/beacon-chain/state/v2/getters_validator_test.go
+++ b/beacon-chain/state/v2/getters_validator_test.go
@@ -3,6 +3,7 @@ package v2_test
 import (
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/assert"
@@ -16,5 +17,5 @@ func TestBeaconState_ValidatorAtIndexReadOnly_HandlesNilSlice(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = st.ValidatorAtIndexReadOnly(0)
-	assert.Equal(t, v1.ErrNilValidatorsInState, err)
+	assert.Equal(t, state.ErrNilValidatorsInState, err)
 }

--- a/beacon-chain/state/v3/BUILD.bazel
+++ b/beacon-chain/state/v3/BUILD.bazel
@@ -73,6 +73,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stateutil:go_default_library",
         "//beacon-chain/state/types:go_default_library",
         "//beacon-chain/state/v1:go_default_library",

--- a/beacon-chain/state/v3/getters_validator.go
+++ b/beacon-chain/state/v3/getters_validator.go
@@ -18,12 +18,6 @@ type ValidatorIndexOutOfRangeError struct {
 	message string
 }
 
-var (
-	// ErrNilValidatorsInState returns when accessing validators in the state while the state has a
-	// nil slice for the validators field.
-	ErrNilValidatorsInState = errors.New("state has nil validator slice")
-)
-
 // NewValidatorIndexOutOfRangeError creates a new error instance.
 func NewValidatorIndexOutOfRangeError(index types.ValidatorIndex) ValidatorIndexOutOfRangeError {
 	return ValidatorIndexOutOfRangeError{
@@ -122,7 +116,7 @@ func (b *BeaconState) ValidatorAtIndexReadOnly(idx types.ValidatorIndex) (state.
 		return nil, ErrNilInnerState
 	}
 	if b.state.Validators == nil {
-		return nil, ErrNilValidatorsInState
+		return nil, state.ErrNilValidatorsInState
 	}
 	if uint64(len(b.state.Validators)) <= uint64(idx) {
 		e := NewValidatorIndexOutOfRangeError(idx)

--- a/beacon-chain/state/v3/getters_validator_test.go
+++ b/beacon-chain/state/v3/getters_validator_test.go
@@ -3,6 +3,7 @@ package v3_test
 import (
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/assert"
@@ -16,5 +17,5 @@ func TestBeaconState_ValidatorAtIndexReadOnly_HandlesNilSlice(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = st.ValidatorAtIndexReadOnly(0)
-	assert.Equal(t, v1.ErrNilValidatorsInState, err)
+	assert.Equal(t, state.ErrNilValidatorsInState, err)
 }


### PR DESCRIPTION
**What type of PR is this?**
Refactor 

**What does this PR do? Why is it needed?**

To increase DRY and enable DRY in tests and other users of the Beacon Chain state package,
an error that was duplicated unnecessarily in each version of the state is moved to the root
Beacon Chain state package.


**Which issues(s) does this PR fix?**

Related and blocks #10047 

**Other notes for review**

None