### PR TITLE
Do not reuse endpoint struct between API Middleware requests

### DIFF
--- a/api/gateway/apimiddleware/api_middleware.go
+++ b/api/gateway/apimiddleware/api_middleware.go
@@ -89,12 +89,13 @@ func (m *ApiProxyMiddleware) ServeHTTP(w http.ResponseWriter, req *http.Request)
 
 // WithMiddleware wraps the given endpoint handler with the middleware logic.
 func (m *ApiProxyMiddleware) WithMiddleware(path string) http.HandlerFunc {
-	endpoint, err := m.EndpointCreator.Create(path)
-	if err != nil {
-		log.WithError(err).Errorf("Could not create endpoint for path: %s", path)
-		return nil
-	}
 	return func(w http.ResponseWriter, req *http.Request) {
+		endpoint, err := m.EndpointCreator.Create(path)
+		if err != nil {
+			log.WithError(err).Errorf("Could not create endpoint for path: %s", path)
+			return
+		}
+
 		for _, handler := range endpoint.CustomHandlers {
 			if handler(m, *endpoint, w, req) {
 				return


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The `endpoint` variable is captured by the func returned from `WithMiddleware`, resulting in the same memory address being reused between API calls. This causes race conditions when multiple requests are issues simultaneously.

**Which issues(s) does this PR fix?**

Fixes #10050

**Other notes for review**
