### PR TITLE
Spectests: Refactor ssz_static tests to deduplicate code and test custom HTR

### DIFF
--- a/testing/spectest/shared/altair/ssz_static/BUILD.bazel
+++ b/testing/spectest/shared/altair/ssz_static/BUILD.bazel
@@ -10,9 +10,7 @@ go_library(
         "//beacon-chain/state/v2:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/require:go_default_library",
-        "//testing/spectest/utils:go_default_library",
-        "//testing/util:go_default_library",
+        "//testing/spectest/shared/common/ssz_static:go_default_library",
         "@com_github_ferranbt_fastssz//:go_default_library",
-        "@com_github_golang_snappy//:go_default_library",
     ],
 )

--- a/testing/spectest/shared/altair/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/altair/ssz_static/ssz_static.go
@@ -2,99 +2,35 @@ package ssz_static
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
-	"path"
 	"testing"
 
 	fssz "github.com/ferranbt/fastssz"
-	"github.com/golang/snappy"
 	stateAltair "github.com/prysmaticlabs/prysm/beacon-chain/state/v2"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/require"
-	"github.com/prysmaticlabs/prysm/testing/spectest/utils"
-	"github.com/prysmaticlabs/prysm/testing/util"
+	common "github.com/prysmaticlabs/prysm/testing/spectest/shared/common/ssz_static"
 )
-
-// SSZRoots --
-type SSZRoots struct {
-	Root        string `json:"root"`
-	SigningRoot string `json:"signing_root"`
-}
 
 // RunSSZStaticTests executes "ssz_static" tests.
 func RunSSZStaticTests(t *testing.T, config string) {
-	require.NoError(t, utils.SetConfig(t, config))
-	testFolders, _ := utils.TestFolders(t, config, "altair", "ssz_static")
-	for _, folder := range testFolders {
-		modePath := path.Join("ssz_static", folder.Name())
-		modeFolders, _ := utils.TestFolders(t, config, "altair", modePath)
-
-		for _, modeFolder := range modeFolders {
-			innerPath := path.Join(modePath, modeFolder.Name())
-			innerTestFolders, innerTestsFolderPath := utils.TestFolders(t, config, "altair", innerPath)
-
-			for _, innerFolder := range innerTestFolders {
-				t.Run(path.Join(modeFolder.Name(), folder.Name(), innerFolder.Name()), func(t *testing.T) {
-					serializedBytes, err := util.BazelFileBytes(innerTestsFolderPath, innerFolder.Name(), "serialized.ssz_snappy")
-					require.NoError(t, err)
-					serializedSSZ, err := snappy.Decode(nil /* dst */, serializedBytes)
-					require.NoError(t, err, "Failed to decompress")
-					object, err := UnmarshalledSSZ(t, serializedSSZ, folder.Name())
-					require.NoError(t, err, "Could not unmarshall serialized SSZ")
-
-					rootsYamlFile, err := util.BazelFileBytes(innerTestsFolderPath, innerFolder.Name(), "roots.yaml")
-					require.NoError(t, err)
-					rootsYaml := &SSZRoots{}
-					require.NoError(t, utils.UnmarshalYaml(rootsYamlFile, rootsYaml), "Failed to Unmarshal")
-
-					// Custom hash tree root for beacon state.
-					var htr func(interface{}) ([32]byte, error)
-					if _, ok := object.(*ethpb.BeaconStateAltair); ok {
-						htr = func(s interface{}) ([32]byte, error) {
-							beaconState, err := stateAltair.InitializeFromProto(s.(*ethpb.BeaconStateAltair))
-							require.NoError(t, err)
-							return beaconState.HashTreeRoot(context.Background())
-						}
-					} else {
-						htr = func(s interface{}) ([32]byte, error) {
-							sszObj, ok := s.(fssz.HashRoot)
-							if !ok {
-								return [32]byte{}, errors.New("could not get hash root, not compatible object")
-							}
-							return sszObj.HashTreeRoot()
-						}
-					}
-
-					root, err := htr(object)
-					require.NoError(t, err)
-					rootBytes, err := hex.DecodeString(rootsYaml.Root[2:])
-					require.NoError(t, err)
-					require.DeepEqual(t, rootBytes, root[:], "Did not receive expected hash tree root")
-
-					if rootsYaml.SigningRoot == "" {
-						return
-					}
-
-					var signingRoot [32]byte
-					if v, ok := object.(fssz.HashRoot); ok {
-						signingRoot, err = v.HashTreeRoot()
-					} else {
-						t.Fatal("object does not meet fssz.HashRoot")
-					}
-
-					require.NoError(t, err)
-					signingRootBytes, err := hex.DecodeString(rootsYaml.SigningRoot[2:])
-					require.NoError(t, err)
-					require.DeepEqual(t, signingRootBytes, signingRoot[:], "Did not receive expected signing root")
-				})
-			}
-		}
-	}
+	common.RunSSZStaticTests(t, config, "altair", unmarshalledSSZ, customHtr)
 }
 
-// UnmarshalledSSZ unmarshalls serialized input.
-func UnmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (interface{}, error) {
+func customHtr(t *testing.T, htrs []common.HTR, object interface{}) []common.HTR {
+	switch object.(type) {
+	case *ethpb.BeaconStateAltair:
+		htrs = append(htrs, func(s interface{}) ([32]byte, error) {
+			beaconState, err := stateAltair.InitializeFromProto(s.(*ethpb.BeaconStateAltair))
+			require.NoError(t, err)
+			return beaconState.HashTreeRoot(context.Background())
+		})
+	}
+	return htrs
+}
+
+// unmarshalledSSZ unmarshalls serialized input.
+func unmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (interface{}, error) {
 	var obj interface{}
 	switch folderName {
 	case "Attestation":

--- a/testing/spectest/shared/bellatrix/ssz_static/BUILD.bazel
+++ b/testing/spectest/shared/bellatrix/ssz_static/BUILD.bazel
@@ -10,9 +10,7 @@ go_library(
         "//beacon-chain/state/v3:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/require:go_default_library",
-        "//testing/spectest/utils:go_default_library",
-        "//testing/util:go_default_library",
+        "//testing/spectest/shared/common/ssz_static:go_default_library",
         "@com_github_ferranbt_fastssz//:go_default_library",
-        "@com_github_golang_snappy//:go_default_library",
     ],
 )

--- a/testing/spectest/shared/bellatrix/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/bellatrix/ssz_static/ssz_static.go
@@ -2,99 +2,35 @@ package ssz_static
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
-	"path"
 	"testing"
 
 	fssz "github.com/ferranbt/fastssz"
-	"github.com/golang/snappy"
 	v3 "github.com/prysmaticlabs/prysm/beacon-chain/state/v3"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/require"
-	"github.com/prysmaticlabs/prysm/testing/spectest/utils"
-	"github.com/prysmaticlabs/prysm/testing/util"
+	common "github.com/prysmaticlabs/prysm/testing/spectest/shared/common/ssz_static"
 )
-
-// SSZRoots --
-type SSZRoots struct {
-	Root        string `json:"root"`
-	SigningRoot string `json:"signing_root"`
-}
 
 // RunSSZStaticTests executes "ssz_static" tests.
 func RunSSZStaticTests(t *testing.T, config string) {
-	require.NoError(t, utils.SetConfig(t, config))
-	testFolders, _ := utils.TestFolders(t, config, "bellatrix", "ssz_static")
-	for _, folder := range testFolders {
-		modePath := path.Join("ssz_static", folder.Name())
-		modeFolders, _ := utils.TestFolders(t, config, "bellatrix", modePath)
-
-		for _, modeFolder := range modeFolders {
-			innerPath := path.Join(modePath, modeFolder.Name())
-			innerTestFolders, innerTestsFolderPath := utils.TestFolders(t, config, "bellatrix", innerPath)
-
-			for _, innerFolder := range innerTestFolders {
-				t.Run(path.Join(modeFolder.Name(), folder.Name(), innerFolder.Name()), func(t *testing.T) {
-					serializedBytes, err := util.BazelFileBytes(innerTestsFolderPath, innerFolder.Name(), "serialized.ssz_snappy")
-					require.NoError(t, err)
-					serializedSSZ, err := snappy.Decode(nil /* dst */, serializedBytes)
-					require.NoError(t, err, "Failed to decompress")
-					object, err := UnmarshalledSSZ(t, serializedSSZ, folder.Name())
-					require.NoError(t, err, "Could not unmarshall serialized SSZ")
-
-					rootsYamlFile, err := util.BazelFileBytes(innerTestsFolderPath, innerFolder.Name(), "roots.yaml")
-					require.NoError(t, err)
-					rootsYaml := &SSZRoots{}
-					require.NoError(t, utils.UnmarshalYaml(rootsYamlFile, rootsYaml), "Failed to Unmarshal")
-
-					// Custom hash tree root for beacon state.
-					var htr func(interface{}) ([32]byte, error)
-					if _, ok := object.(*ethpb.BeaconStateBellatrix); ok {
-						htr = func(s interface{}) ([32]byte, error) {
-							beaconState, err := v3.InitializeFromProto(s.(*ethpb.BeaconStateBellatrix))
-							require.NoError(t, err)
-							return beaconState.HashTreeRoot(context.Background())
-						}
-					} else {
-						htr = func(s interface{}) ([32]byte, error) {
-							sszObj, ok := s.(fssz.HashRoot)
-							if !ok {
-								return [32]byte{}, errors.New("could not get hash root, not compatible object")
-							}
-							return sszObj.HashTreeRoot()
-						}
-					}
-
-					root, err := htr(object)
-					require.NoError(t, err)
-					rootBytes, err := hex.DecodeString(rootsYaml.Root[2:])
-					require.NoError(t, err)
-					require.DeepEqual(t, rootBytes, root[:], "Did not receive expected hash tree root")
-
-					if rootsYaml.SigningRoot == "" {
-						return
-					}
-
-					var signingRoot [32]byte
-					if v, ok := object.(fssz.HashRoot); ok {
-						signingRoot, err = v.HashTreeRoot()
-					} else {
-						t.Fatal("object does not meet fssz.HashRoot")
-					}
-
-					require.NoError(t, err)
-					signingRootBytes, err := hex.DecodeString(rootsYaml.SigningRoot[2:])
-					require.NoError(t, err)
-					require.DeepEqual(t, signingRootBytes, signingRoot[:], "Did not receive expected signing root")
-				})
-			}
-		}
-	}
+	common.RunSSZStaticTests(t, config, "bellatrix", unmarshalledSSZ, customHtr)
 }
 
-// UnmarshalledSSZ unmarshalls serialized input.
-func UnmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (interface{}, error) {
+func customHtr(t *testing.T, htrs []common.HTR, object interface{}) []common.HTR {
+	switch object.(type) {
+	case *ethpb.BeaconStateBellatrix:
+		htrs = append(htrs, func(s interface{}) ([32]byte, error) {
+			beaconState, err := v3.InitializeFromProto(s.(*ethpb.BeaconStateBellatrix))
+			require.NoError(t, err)
+			return beaconState.HashTreeRoot(context.Background())
+		})
+	}
+	return htrs
+}
+
+// unmarshalledSSZ unmarshalls serialized input.
+func unmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (interface{}, error) {
 	var obj interface{}
 	switch folderName {
 	case "ExecutionPayload":

--- a/testing/spectest/shared/common/ssz_static/BUILD.bazel
+++ b/testing/spectest/shared/common/ssz_static/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    testonly = True,
+    srcs = [
+        "ssz_static.go",
+        "types.go",
+    ],
+    importpath = "github.com/prysmaticlabs/prysm/testing/spectest/shared/common/ssz_static",
+    visibility = ["//testing/spectest:__subpackages__"],
+    deps = [
+        "//testing/require:go_default_library",
+        "//testing/spectest/utils:go_default_library",
+        "//testing/util:go_default_library",
+        "@com_github_ferranbt_fastssz//:go_default_library",
+        "@com_github_golang_snappy//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["ssz_static_example_test.go"],
+    deps = [
+        ":go_default_library",
+        "//beacon-chain/state/v1:go_default_library",
+        "//proto/prysm/v1alpha1:go_default_library",
+        "//testing/require:go_default_library",
+        "@com_github_ferranbt_fastssz//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+    ],
+)

--- a/testing/spectest/shared/common/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/common/ssz_static/ssz_static.go
@@ -1,0 +1,111 @@
+package ssz_static
+
+import (
+	"encoding/hex"
+	"errors"
+	"path"
+	"testing"
+
+	fssz "github.com/ferranbt/fastssz"
+	"github.com/golang/snappy"
+	"github.com/prysmaticlabs/prysm/testing/require"
+	"github.com/prysmaticlabs/prysm/testing/spectest/utils"
+	"github.com/prysmaticlabs/prysm/testing/util"
+)
+
+// RunSSZStaticTests executes "ssz_static" tests for the given fork of phase using the provided
+// unmarshaller to hydrate serialized test data into go struct pointers and also applies any custom
+// HTR methods via the customHTR callback.
+func RunSSZStaticTests(t *testing.T, config, forkOrPhase string, unmarshaller Unmarshaller, customHtr CustomHTRAdder) {
+	require.NoError(t, utils.SetConfig(t, config))
+	testFolders, _ := utils.TestFolders(t, config, forkOrPhase, "ssz_static")
+
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s", config, forkOrPhase)
+	}
+
+	for _, folder := range testFolders {
+		modePath := path.Join("ssz_static", folder.Name())
+		modeFolders, _ := utils.TestFolders(t, config, forkOrPhase, modePath)
+
+		if len(modeFolders) == 0 {
+			t.Fatalf("No test folders found for %s/%s/%s", config, forkOrPhase, folder.Name())
+		}
+
+		for _, modeFolder := range modeFolders {
+			innerPath := path.Join(modePath, modeFolder.Name())
+			innerTestFolders, innerTestsFolderPath := utils.TestFolders(t, config, forkOrPhase, innerPath)
+
+			if len(innerTestFolders) == 0 {
+				t.Fatalf("No test folders found for %s/%s/%s/%s", config, forkOrPhase, folder.Name(), modeFolder.Name())
+			}
+
+			for _, innerFolder := range innerTestFolders {
+				t.Run(path.Join(modeFolder.Name(), folder.Name(), innerFolder.Name()), func(t *testing.T) {
+					serializedBytes, err := util.BazelFileBytes(innerTestsFolderPath, innerFolder.Name(), "serialized.ssz_snappy")
+					require.NoError(t, err)
+					serializedSSZ, err := snappy.Decode(nil /* dst */, serializedBytes)
+					require.NoError(t, err, "Failed to decompress")
+					object, err := unmarshaller(t, serializedSSZ, folder.Name())
+					require.NoError(t, err, "Could not unmarshall serialized SSZ")
+
+					rootsYamlFile, err := util.BazelFileBytes(innerTestsFolderPath, innerFolder.Name(), "roots.yaml")
+					require.NoError(t, err)
+					rootsYaml := &SSZRoots{}
+					require.NoError(t, utils.UnmarshalYaml(rootsYamlFile, rootsYaml), "Failed to Unmarshal")
+
+					// All types support fastssz generated code, but may also include a custom HTR method.
+					var htrs []HTR
+					htrs = append(htrs, func(s interface{}) ([32]byte, error) {
+						sszObj, ok := s.(fssz.HashRoot)
+						if !ok {
+							return [32]byte{}, errors.New("could not get hash root, not compatible object")
+						}
+						return sszObj.HashTreeRoot()
+					})
+
+					// Apply custom HTR methods, if any.
+					if customHtr != nil {
+						htrs = customHtr(t, htrs, object)
+					}
+
+					if len(htrs) == 0 {
+						t.Fatal("no HTRs to run")
+					}
+
+					for i, htr := range htrs {
+						var testName string
+						if i == 0 { // First HTR test is fastssz generated code.
+							testName = "fastssz"
+						} else {
+							testName = "custom"
+						}
+						t.Run(testName, func(t *testing.T) {
+							root, err := htr(object)
+							require.NoError(t, err)
+							rootBytes, err := hex.DecodeString(rootsYaml.Root[2:])
+							require.NoError(t, err)
+							require.DeepEqual(t, rootBytes, root[:], "Did not receive expected hash tree root")
+
+							if rootsYaml.SigningRoot == "" {
+								return
+							}
+
+							var signingRoot [32]byte
+							if v, ok := object.(fssz.HashRoot); ok {
+								signingRoot, err = v.HashTreeRoot()
+							} else {
+								t.Fatal("object does not meet fssz.HashRoot")
+							}
+
+							require.NoError(t, err)
+							signingRootBytes, err := hex.DecodeString(rootsYaml.SigningRoot[2:])
+							require.NoError(t, err)
+							require.DeepEqual(t, signingRootBytes, signingRoot[:], "Did not receive expected signing root")
+						})
+					}
+				})
+			}
+		}
+	}
+}

--- a/testing/spectest/shared/common/ssz_static/ssz_static_example_test.go
+++ b/testing/spectest/shared/common/ssz_static/ssz_static_example_test.go
@@ -30,7 +30,7 @@ func ExampleRunSSZStaticTests() {
 			t.Skip("Unused type")
 			return nil, nil
 		default:
-			return nil, fmt.Errorsf("unsupported type: %s", objectName)
+			return nil, fmt.Errorf("unsupported type: %s", objectName)
 		}
 		var err error
 		if o, ok := obj.(fssz.Unmarshaler); ok {

--- a/testing/spectest/shared/common/ssz_static/ssz_static_example_test.go
+++ b/testing/spectest/shared/common/ssz_static/ssz_static_example_test.go
@@ -2,6 +2,7 @@ package ssz_static_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	fssz "github.com/ferranbt/fastssz"
@@ -29,7 +30,7 @@ func ExampleRunSSZStaticTests() {
 			t.Skip("Unused type")
 			return nil, nil
 		default:
-			return nil, errors.New("unsupported type")
+			return nil, fmt.Errorsf("unsupported type: %s", objectName)
 		}
 		var err error
 		if o, ok := obj.(fssz.Unmarshaler); ok {

--- a/testing/spectest/shared/common/ssz_static/ssz_static_example_test.go
+++ b/testing/spectest/shared/common/ssz_static/ssz_static_example_test.go
@@ -1,0 +1,69 @@
+package ssz_static_test
+
+import (
+	"context"
+	"testing"
+
+	fssz "github.com/ferranbt/fastssz"
+	"github.com/pkg/errors"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/testing/require"
+	common "github.com/prysmaticlabs/prysm/testing/spectest/shared/common/ssz_static"
+)
+
+func ExampleRunSSZStaticTests() {
+	// Define an unmarshaller to select the correct go type based on the string
+	// name provided in spectests and then populate it with the serialized bytes.
+	unmarshaller := func(t *testing.T, serializedBytes []byte, objectName string) (interface{}, error) {
+		var obj interface{}
+		switch objectName {
+		case "Attestation":
+			obj = &ethpb.Attestation{}
+		case "BeaconState":
+			obj = &ethpb.BeaconState{}
+		case "Eth1Block":
+			// Some types may not apply to prysm, but exist in the spec test folders. It is OK to
+			// skip these tests with a valid justification. Otherwise, the test should fail with an
+			// unsupported type.
+			t.Skip("Unused type")
+			return nil, nil
+		default:
+			return nil, errors.New("unsupported type")
+		}
+		var err error
+		if o, ok := obj.(fssz.Unmarshaler); ok {
+			err = o.UnmarshalSSZ(serializedBytes)
+		} else {
+			err = errors.New("could not unmarshal object, not a fastssz compatible object")
+		}
+		return obj, err
+	}
+
+	// Optional: define a method to add custom HTR methods for a given object.
+	// This argument may be nil if your test does not require custom HTR methods.
+	// Most commonly, this is used when a handwritten HTR method with specialized caching
+	// is used and you want to ensure it passes spectests.
+	customHTR := func(t *testing.T, htrs []common.HTR, object interface{}) []common.HTR {
+		switch object.(type) {
+		case *ethpb.BeaconState:
+			htrs = append(htrs, func(s interface{}) ([32]byte, error) {
+				beaconState, err := v1.InitializeFromProto(s.(*ethpb.BeaconState))
+				require.NoError(t, err)
+				return beaconState.HashTreeRoot(context.TODO())
+			})
+		}
+		return htrs
+	}
+
+	var t *testing.T
+	// common.RunSSZStaticTests will run all of the tests found in the spec test folder with the
+	// given config and forkOrPhase. It will then use the unmarshaller to hydrate the types and
+	// ensure that fastssz generated methods match the expected results. It will also test custom
+	// HTR methods if provided.
+	common.RunSSZStaticTests(t,
+		"mainnet", // Network configuration
+		"phase0",  // Fork or phase
+		unmarshaller,
+		customHTR) // nil customHTR is acceptable.
+}

--- a/testing/spectest/shared/common/ssz_static/types.go
+++ b/testing/spectest/shared/common/ssz_static/types.go
@@ -1,0 +1,19 @@
+package ssz_static
+
+import (
+	"testing"
+)
+
+type HTR func(interface{}) ([32]byte, error)
+
+// SSZRoots is the format used to read spectest test data.
+type SSZRoots struct {
+	Root        string `json:"root"`
+	SigningRoot string `json:"signing_root"`
+}
+
+// Unmarshaller determines the correct type per ObjectName and then hydrates the object from the
+// serializedBytes. This method may call t.Skip if the type is not supported.
+type Unmarshaller func(t *testing.T, serializedBytes []byte, objectName string) (interface{}, error)
+
+type CustomHTRAdder func(t *testing.T, htrs []HTR, object interface{}) []HTR

--- a/testing/spectest/shared/common/ssz_static/types.go
+++ b/testing/spectest/shared/common/ssz_static/types.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 )
 
+// HTR is the HashTreeRoot function signature.
 type HTR func(interface{}) ([32]byte, error)
 
 // SSZRoots is the format used to read spectest test data.
@@ -16,4 +17,6 @@ type SSZRoots struct {
 // serializedBytes. This method may call t.Skip if the type is not supported.
 type Unmarshaller func(t *testing.T, serializedBytes []byte, objectName string) (interface{}, error)
 
+// CustomHTRAdder adds any custom HTR methods for the given object. This method should return a HTR
+// slice with the custom HTR method applied.
 type CustomHTRAdder func(t *testing.T, htrs []HTR, object interface{}) []HTR

--- a/testing/spectest/shared/phase0/ssz_static/BUILD.bazel
+++ b/testing/spectest/shared/phase0/ssz_static/BUILD.bazel
@@ -10,9 +10,7 @@ go_library(
         "//beacon-chain/state/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/require:go_default_library",
-        "//testing/spectest/utils:go_default_library",
-        "//testing/util:go_default_library",
+        "//testing/spectest/shared/common/ssz_static:go_default_library",
         "@com_github_ferranbt_fastssz//:go_default_library",
-        "@com_github_golang_snappy//:go_default_library",
     ],
 )

--- a/testing/spectest/shared/phase0/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/phase0/ssz_static/ssz_static.go
@@ -12,12 +12,6 @@ import (
 	common "github.com/prysmaticlabs/prysm/testing/spectest/shared/common/ssz_static"
 )
 
-// SSZRoots --
-type SSZRoots struct {
-	Root        string `json:"root"`
-	SigningRoot string `json:"signing_root"`
-}
-
 // RunSSZStaticTests executes "ssz_static" tests.
 func RunSSZStaticTests(t *testing.T, config string) {
 	common.RunSSZStaticTests(t, config, "phase0", unmarshalledSSZ, customHtr)

--- a/testing/spectest/shared/phase0/ssz_static/ssz_static.go
+++ b/testing/spectest/shared/phase0/ssz_static/ssz_static.go
@@ -2,18 +2,14 @@ package ssz_static
 
 import (
 	"context"
-	"encoding/hex"
 	"errors"
-	"path"
 	"testing"
 
 	fssz "github.com/ferranbt/fastssz"
-	"github.com/golang/snappy"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/state/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/require"
-	"github.com/prysmaticlabs/prysm/testing/spectest/utils"
-	"github.com/prysmaticlabs/prysm/testing/util"
+	common "github.com/prysmaticlabs/prysm/testing/spectest/shared/common/ssz_static"
 )
 
 // SSZRoots --
@@ -24,79 +20,25 @@ type SSZRoots struct {
 
 // RunSSZStaticTests executes "ssz_static" tests.
 func RunSSZStaticTests(t *testing.T, config string) {
-	require.NoError(t, utils.SetConfig(t, config))
-	testFolders, _ := utils.TestFolders(t, config, "phase0", "ssz_static")
-	for _, folder := range testFolders {
-		modePath := path.Join("ssz_static", folder.Name())
-		modeFolders, _ := utils.TestFolders(t, config, "phase0", modePath)
-
-		for _, modeFolder := range modeFolders {
-			innerPath := path.Join(modePath, modeFolder.Name())
-			innerTestFolders, innerTestsFolderPath := utils.TestFolders(t, config, "phase0", innerPath)
-
-			for _, innerFolder := range innerTestFolders {
-				t.Run(path.Join(modeFolder.Name(), folder.Name(), innerFolder.Name()), func(t *testing.T) {
-					serializedBytes, err := util.BazelFileBytes(innerTestsFolderPath, innerFolder.Name(), "serialized.ssz_snappy")
-					require.NoError(t, err)
-					serializedSSZ, err := snappy.Decode(nil /* dst */, serializedBytes)
-					require.NoError(t, err, "Failed to decompress")
-					object, err := UnmarshalledSSZ(t, serializedSSZ, folder.Name())
-					require.NoError(t, err, "Could not unmarshall serialized SSZ")
-
-					rootsYamlFile, err := util.BazelFileBytes(innerTestsFolderPath, innerFolder.Name(), "roots.yaml")
-					require.NoError(t, err)
-					rootsYaml := &SSZRoots{}
-					require.NoError(t, utils.UnmarshalYaml(rootsYamlFile, rootsYaml), "Failed to Unmarshal")
-
-					// Custom hash tree root for beacon state.
-					var htr func(interface{}) ([32]byte, error)
-					if _, ok := object.(*ethpb.BeaconState); ok {
-						htr = func(s interface{}) ([32]byte, error) {
-							beaconState, err := v1.InitializeFromProto(s.(*ethpb.BeaconState))
-							require.NoError(t, err)
-							return beaconState.HashTreeRoot(context.Background())
-						}
-					} else {
-						htr = func(s interface{}) ([32]byte, error) {
-							sszObj, ok := s.(fssz.HashRoot)
-							if !ok {
-								return [32]byte{}, errors.New("could not get hash root, not compatible object")
-							}
-							return sszObj.HashTreeRoot()
-						}
-					}
-
-					root, err := htr(object)
-					require.NoError(t, err)
-					rootBytes, err := hex.DecodeString(rootsYaml.Root[2:])
-					require.NoError(t, err)
-					require.DeepEqual(t, rootBytes, root[:], "Did not receive expected hash tree root")
-
-					if rootsYaml.SigningRoot == "" {
-						return
-					}
-
-					var signingRoot [32]byte
-					if v, ok := object.(fssz.HashRoot); ok {
-						signingRoot, err = v.HashTreeRoot()
-					} else {
-						t.Fatal("object does not meet fssz.HashRoot")
-					}
-
-					require.NoError(t, err)
-					signingRootBytes, err := hex.DecodeString(rootsYaml.SigningRoot[2:])
-					require.NoError(t, err)
-					require.DeepEqual(t, signingRootBytes, signingRoot[:], "Did not receive expected signing root")
-				})
-			}
-		}
-	}
+	common.RunSSZStaticTests(t, config, "phase0", unmarshalledSSZ, customHtr)
 }
 
-// UnmarshalledSSZ unmarshalls serialized input.
-func UnmarshalledSSZ(t *testing.T, serializedBytes []byte, folderName string) (interface{}, error) {
+func customHtr(t *testing.T, htrs []common.HTR, object interface{}) []common.HTR {
+	switch object.(type) {
+	case *ethpb.BeaconState:
+		htrs = append(htrs, func(s interface{}) ([32]byte, error) {
+			beaconState, err := v1.InitializeFromProto(s.(*ethpb.BeaconState))
+			require.NoError(t, err)
+			return beaconState.HashTreeRoot(context.TODO())
+		})
+	}
+	return htrs
+}
+
+// unmarshalledSSZ unmarshalls serialized input.
+func unmarshalledSSZ(t *testing.T, serializedBytes []byte, objectName string) (interface{}, error) {
 	var obj interface{}
-	switch folderName {
+	switch objectName {
 	case "Attestation":
 		obj = &ethpb.Attestation{}
 	case "AttestationData":


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

There was a ton of duplicated code across spectest for ssz static. This duplicated code is hard to maintain and will only get worse as more forks or phases are implemented.
This PR generalizes ssz static tests such that different phases or forks can reuse the same code to their advantage.

**Which issues(s) does this PR fix?**

Part of investigation of #9402 and https://github.com/ferranbt/fastssz/issues/67

**Other notes for review**o

Test names for ssz_static now have a suffix to explain the type of code run, i.e. fastssz or custom HTR.

```
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_0
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_0/fastssz
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_0/custom
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_1
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_1/fastssz
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_1/custom
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_2
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_2/fastssz
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_2/custom
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_3
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_3/fastssz
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_3/custom
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_4
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_4/fastssz
=== RUN   TestMainnet_Altair_SSZStatic/ssz_random/BeaconState/case_4/custom
```

Note: delta shows a net increase in LOC, this is because I added godoc examples on how to use this refactored code. Also added some test validation to ensure misconfiguration issues were surfaced earlier.