### PR TITLE
Fixed Go-scanner version to v2.9.5

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,10 +32,9 @@ jobs:
           goimports-path: ./
 
       - name: Gosec security scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@35af340d07255059323f0c56a121a5e400be0b62
         with:
           args: '-exclude=G307 -exclude-dir=crypto/bls/herumi ./...'
-          tags: v2.9.5
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: GoImports checker
         id: goimports
-        uses: Jerome1337/goimports-action@v1.0.2
+        uses: Jerome1337/goimports-action@v1.0.3
         with:
           goimports-path: ./
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,12 +27,15 @@ jobs:
 
       - name: GoImports checker
         id: goimports
-        uses: Jerome1337/goimports-action@v1.0.3
+        uses: Jerome1337/goimports-action@v1.0.2
         with:
           goimports-path: ./
 
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      
       - name: Gosec security scanner
-        uses: securego/gosec@35af340d07255059323f0c56a121a5e400be0b62
+        uses: securego/gosec@v2.9.5
         with:
           args: '-exclude=G307 -exclude-dir=crypto/bls/herumi ./...'
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           goimports-path: ./
 
-      - name: Gosec security scanner
+      - name: Gosec security scan
         uses: securego/gosec@v2.9.5
         with:
           args: '-exclude=G307 -exclude-dir=crypto/bls/herumi ./...'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,10 +31,11 @@ jobs:
         with:
           goimports-path: ./
 
-      - name: Gosec security scan
-        uses: securego/gosec@v2.9.5
+      - name: Gosec security scanner
+        uses: securego/gosec@master
         with:
           args: '-exclude=G307 -exclude-dir=crypto/bls/herumi ./...'
+          tags: v2.9.5
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
           goimports-path: ./
 
       - name: Gosec security scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.9.5
         with:
           args: '-exclude=G307 -exclude-dir=crypto/bls/herumi ./...'
 


### PR DESCRIPTION
Hardcoded v2.9.5 in Actions pipeline

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Updating security scanner version in github-actions pipeline
> Uncomment one line below and remove others.

Other

**What does this PR do? Why is it needed?**

Github actions pipeline has been failing due to the updated security scanner version

**Which issues(s) does this PR fix?**

Go security scanner pipeline

Fixes #

**Other notes for review**
