### PR TITLE
Use store in blockchain service

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
     deps = [
         "//async:go_default_library",
         "//async/event:go_default_library",
+        "//beacon-chain/blockchain/store:go_default_library",
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/cache/depositcache:go_default_library",
         "//beacon-chain/core/altair:go_default_library",

--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "chain_info.go",
+        "error.go",
         "head.go",
         "head_sync_committee_info.go",
         "info.go",

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -77,31 +77,34 @@ type FinalizationFetcher interface {
 	PreviousJustifiedCheckpt() *ethpb.Checkpoint
 }
 
-// FinalizedCheckpt returns the latest finalized checkpoint from head state.
+// FinalizedCheckpt returns the latest finalized checkpoint from chain store.
 func (s *Service) FinalizedCheckpt() *ethpb.Checkpoint {
-	if s.finalizedCheckpt == nil {
+	cp := s.store.FinalizedCheckpt()
+	if cp == nil {
 		return &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
 	}
 
-	return ethpb.CopyCheckpoint(s.finalizedCheckpt)
+	return ethpb.CopyCheckpoint(cp)
 }
 
-// CurrentJustifiedCheckpt returns the current justified checkpoint from head state.
+// CurrentJustifiedCheckpt returns the current justified checkpoint from chain store.
 func (s *Service) CurrentJustifiedCheckpt() *ethpb.Checkpoint {
-	if s.justifiedCheckpt == nil {
+	cp := s.store.JustifiedCheckpt()
+	if cp == nil {
 		return &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
 	}
 
-	return ethpb.CopyCheckpoint(s.justifiedCheckpt)
+	return ethpb.CopyCheckpoint(cp)
 }
 
-// PreviousJustifiedCheckpt returns the previous justified checkpoint from head state.
+// PreviousJustifiedCheckpt returns the previous justified checkpoint from chain store.
 func (s *Service) PreviousJustifiedCheckpt() *ethpb.Checkpoint {
-	if s.prevJustifiedCheckpt == nil {
+	cp := s.store.PrevJustifiedCheckpt()
+	if cp == nil {
 		return &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
 	}
 
-	return ethpb.CopyCheckpoint(s.prevJustifiedCheckpt)
+	return ethpb.CopyCheckpoint(cp)
 }
 
 // HeadSlot returns the slot of the head of the chain.

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -45,7 +45,7 @@ func TestFinalizedCheckpt_CanRetrieve(t *testing.T) {
 
 	cp := &ethpb.Checkpoint{Epoch: 5, Root: bytesutil.PadTo([]byte("foo"), 32)}
 	c := setupBeaconChain(t, beaconDB)
-	c.finalizedCheckpt = cp
+	c.store.SetFinalizedCheckpt(cp)
 
 	assert.Equal(t, cp.Epoch, c.FinalizedCheckpt().Epoch, "Unexpected finalized epoch")
 }
@@ -56,7 +56,7 @@ func TestFinalizedCheckpt_GenesisRootOk(t *testing.T) {
 	genesisRoot := [32]byte{'A'}
 	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}
 	c := setupBeaconChain(t, beaconDB)
-	c.finalizedCheckpt = cp
+	c.store.SetFinalizedCheckpt(cp)
 	c.originBlockRoot = genesisRoot
 	assert.DeepEqual(t, c.originBlockRoot[:], c.FinalizedCheckpt().Root)
 }
@@ -67,7 +67,7 @@ func TestCurrentJustifiedCheckpt_CanRetrieve(t *testing.T) {
 	c := setupBeaconChain(t, beaconDB)
 	assert.Equal(t, params.BeaconConfig().ZeroHash, bytesutil.ToBytes32(c.CurrentJustifiedCheckpt().Root), "Unexpected justified epoch")
 	cp := &ethpb.Checkpoint{Epoch: 6, Root: bytesutil.PadTo([]byte("foo"), 32)}
-	c.justifiedCheckpt = cp
+	c.store.SetJustifiedCheckpt(cp)
 	assert.Equal(t, cp.Epoch, c.CurrentJustifiedCheckpt().Epoch, "Unexpected justified epoch")
 }
 
@@ -77,7 +77,7 @@ func TestJustifiedCheckpt_GenesisRootOk(t *testing.T) {
 	c := setupBeaconChain(t, beaconDB)
 	genesisRoot := [32]byte{'B'}
 	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}
-	c.justifiedCheckpt = cp
+	c.store.SetJustifiedCheckpt(cp)
 	c.originBlockRoot = genesisRoot
 	assert.DeepEqual(t, c.originBlockRoot[:], c.CurrentJustifiedCheckpt().Root)
 }
@@ -88,7 +88,7 @@ func TestPreviousJustifiedCheckpt_CanRetrieve(t *testing.T) {
 	cp := &ethpb.Checkpoint{Epoch: 7, Root: bytesutil.PadTo([]byte("foo"), 32)}
 	c := setupBeaconChain(t, beaconDB)
 	assert.Equal(t, params.BeaconConfig().ZeroHash, bytesutil.ToBytes32(c.CurrentJustifiedCheckpt().Root), "Unexpected justified epoch")
-	c.prevJustifiedCheckpt = cp
+	c.store.SetPrevJustifiedCheckpt(cp)
 	assert.Equal(t, cp.Epoch, c.PreviousJustifiedCheckpt().Epoch, "Unexpected previous justified epoch")
 }
 
@@ -98,7 +98,7 @@ func TestPrevJustifiedCheckpt_GenesisRootOk(t *testing.T) {
 	genesisRoot := [32]byte{'C'}
 	cp := &ethpb.Checkpoint{Root: genesisRoot[:]}
 	c := setupBeaconChain(t, beaconDB)
-	c.prevJustifiedCheckpt = cp
+	c.store.SetPrevJustifiedCheckpt(cp)
 	c.originBlockRoot = genesisRoot
 	assert.DeepEqual(t, c.originBlockRoot[:], c.PreviousJustifiedCheckpt().Root)
 }

--- a/beacon-chain/blockchain/error.go
+++ b/beacon-chain/blockchain/error.go
@@ -1,0 +1,12 @@
+package blockchain
+
+import "github.com/pkg/errors"
+
+var (
+	// errNilJustifiedInStore is returned when a nil justified checkpt is returned from store.
+	errNilJustifiedInStore = errors.New("nil justified checkpoint returned from store")
+	// errNilBestJustifiedInStore is returned when a nil justified checkpt is returned from store.
+	errNilBestJustifiedInStore = errors.New("nil best justified checkpoint returned from store")
+	// errNilFinalizedInStore is returned when a nil finalized checkpt is returned from store.
+	errNilFinalizedInStore = errors.New("nil finalized checkpoint returned from store")
+)

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -40,13 +40,15 @@ func (s *Service) updateHead(ctx context.Context, balances []uint64) error {
 	// To get the proper head update, a node first checks its best justified
 	// can become justified. This is designed to prevent bounce attack and
 	// ensure head gets its best justified info.
-	if s.bestJustifiedCheckpt.Epoch > s.justifiedCheckpt.Epoch {
-		s.justifiedCheckpt = s.bestJustifiedCheckpt
+	bestJustified := s.store.BestJustifiedCheckpt()
+	justified := s.store.JustifiedCheckpt()
+	if bestJustified.Epoch > justified.Epoch {
+		s.store.SetJustifiedCheckpt(bestJustified)
 	}
 
 	// Get head from the fork choice service.
-	f := s.finalizedCheckpt
-	j := s.justifiedCheckpt
+	f := s.store.FinalizedCheckpt()
+	j := s.store.JustifiedCheckpt()
 	// To get head before the first justified epoch, the fork choice will start with origin root
 	// instead of zero hashes.
 	headStartRoot := bytesutil.ToBytes32(j.Root)

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -41,14 +41,26 @@ func (s *Service) updateHead(ctx context.Context, balances []uint64) error {
 	// can become justified. This is designed to prevent bounce attack and
 	// ensure head gets its best justified info.
 	bestJustified := s.store.BestJustifiedCheckpt()
+	if bestJustified == nil {
+		return errNilBestJustifiedInStore
+	}
 	justified := s.store.JustifiedCheckpt()
+	if justified == nil {
+		return errNilJustifiedInStore
+	}
 	if bestJustified.Epoch > justified.Epoch {
 		s.store.SetJustifiedCheckpt(bestJustified)
 	}
 
 	// Get head from the fork choice service.
 	f := s.store.FinalizedCheckpt()
+	if f == nil {
+		return errNilFinalizedInStore
+	}
 	j := s.store.JustifiedCheckpt()
+	if j == nil {
+		return errNilJustifiedInStore
+	}
 	// To get head before the first justified epoch, the fork choice will start with origin root
 	// instead of zero hashes.
 	headStartRoot := bytesutil.ToBytes32(j.Root)

--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -143,9 +143,9 @@ func TestUpdateHead_MissingJustifiedRoot(t *testing.T) {
 	r, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 
-	service.justifiedCheckpt = &ethpb.Checkpoint{Root: r[:]}
-	service.finalizedCheckpt = &ethpb.Checkpoint{}
-	service.bestJustifiedCheckpt = &ethpb.Checkpoint{}
+	service.store.SetJustifiedCheckpt(&ethpb.Checkpoint{Root: r[:]})
+	service.store.SetFinalizedCheckpt(&ethpb.Checkpoint{})
+	service.store.SetBestJustifiedCheckpt(&ethpb.Checkpoint{})
 
 	require.NoError(t, service.updateHead(context.Background(), []uint64{}))
 }

--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -179,10 +179,10 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 	r := [32]byte{'g'}
 	require.NoError(t, service.cfg.BeaconDB.SaveState(ctx, s, r))
 
-	service.justifiedCheckpt = &ethpb.Checkpoint{Root: r[:]}
-	service.bestJustifiedCheckpt = &ethpb.Checkpoint{Root: r[:]}
-	service.finalizedCheckpt = &ethpb.Checkpoint{Root: r[:]}
-	service.prevFinalizedCheckpt = &ethpb.Checkpoint{Root: r[:]}
+	service.store.SetJustifiedCheckpt(&ethpb.Checkpoint{Root: r[:]})
+	service.store.SetBestJustifiedCheckpt(&ethpb.Checkpoint{Root: r[:]})
+	service.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Root: r[:]})
+	service.store.SetPrevFinalizedCheckpt(&ethpb.Checkpoint{Root: r[:]})
 
 	r = bytesutil.ToBytes32([]byte{'A'})
 	cp1 := &ethpb.Checkpoint{Epoch: 1, Root: bytesutil.PadTo([]byte{'A'}, fieldparams.RootLength)}
@@ -213,10 +213,10 @@ func TestStore_SaveCheckpointState(t *testing.T) {
 	assert.Equal(t, 2*params.BeaconConfig().SlotsPerEpoch, s2.Slot(), "Unexpected state slot")
 
 	require.NoError(t, s.SetSlot(params.BeaconConfig().SlotsPerEpoch+1))
-	service.justifiedCheckpt = &ethpb.Checkpoint{Root: r[:]}
-	service.bestJustifiedCheckpt = &ethpb.Checkpoint{Root: r[:]}
-	service.finalizedCheckpt = &ethpb.Checkpoint{Root: r[:]}
-	service.prevFinalizedCheckpt = &ethpb.Checkpoint{Root: r[:]}
+	service.store.SetJustifiedCheckpt(&ethpb.Checkpoint{Root: r[:]})
+	service.store.SetBestJustifiedCheckpt(&ethpb.Checkpoint{Root: r[:]})
+	service.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Root: r[:]})
+	service.store.SetPrevFinalizedCheckpt(&ethpb.Checkpoint{Root: r[:]})
 	cp3 := &ethpb.Checkpoint{Epoch: 1, Root: bytesutil.PadTo([]byte{'C'}, fieldparams.RootLength)}
 	require.NoError(t, service.cfg.BeaconDB.SaveState(ctx, s, bytesutil.ToBytes32([]byte{'C'})))
 	require.NoError(t, service.cfg.BeaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bytesutil.PadTo([]byte{'C'}, fieldparams.RootLength)}))
@@ -349,8 +349,7 @@ func TestVerifyFinalizedConsistency_InconsistentRoot(t *testing.T) {
 	r32, err := b32.Block.HashTreeRoot()
 	require.NoError(t, err)
 
-	service.finalizedCheckpt = &ethpb.Checkpoint{Epoch: 1}
-
+	service.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Epoch: 1})
 	b33 := util.NewBeaconBlock()
 	b33.Block.Slot = 33
 	b33.Block.ParentRoot = r32[:]
@@ -375,7 +374,7 @@ func TestVerifyFinalizedConsistency_OK(t *testing.T) {
 	r32, err := b32.Block.HashTreeRoot()
 	require.NoError(t, err)
 
-	service.finalizedCheckpt = &ethpb.Checkpoint{Epoch: 1, Root: r32[:]}
+	service.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Root: r32[:], Epoch: 1})
 
 	b33 := util.NewBeaconBlock()
 	b33.Block.Slot = 33
@@ -400,7 +399,7 @@ func TestVerifyFinalizedConsistency_IsCanonical(t *testing.T) {
 	r32, err := b32.Block.HashTreeRoot()
 	require.NoError(t, err)
 
-	service.finalizedCheckpt = &ethpb.Checkpoint{Epoch: 1, Root: r32[:]}
+	service.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Root: r32[:], Epoch: 1})
 
 	b33 := util.NewBeaconBlock()
 	b33.Block.Slot = 33

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -135,25 +135,27 @@ func (s *Service) onBlock(ctx context.Context, signed block.SignedBeaconBlock, b
 	}
 
 	// Update justified check point.
-	currJustifiedEpoch := s.justifiedCheckpt.Epoch
+	justified := s.store.JustifiedCheckpt()
+	currJustifiedEpoch := justified.Epoch
 	if postState.CurrentJustifiedCheckpoint().Epoch > currJustifiedEpoch {
 		if err := s.updateJustified(ctx, postState); err != nil {
 			return err
 		}
 	}
 
-	newFinalized := postState.FinalizedCheckpointEpoch() > s.finalizedCheckpt.Epoch
+	finalized := s.store.FinalizedCheckpt()
+	newFinalized := postState.FinalizedCheckpointEpoch() > finalized.Epoch
 	if newFinalized {
 		if err := s.finalizedImpliesNewJustified(ctx, postState); err != nil {
 			return errors.Wrap(err, "could not save new justified")
 		}
-		s.prevFinalizedCheckpt = s.finalizedCheckpt
-		s.finalizedCheckpt = postState.FinalizedCheckpoint()
+		s.store.SetPrevFinalizedCheckpt(finalized)
+		s.store.SetFinalizedCheckpt(postState.FinalizedCheckpoint())
 	}
 
-	balances, err := s.justifiedBalances.get(ctx, bytesutil.ToBytes32(s.justifiedCheckpt.Root))
+	balances, err := s.justifiedBalances.get(ctx, bytesutil.ToBytes32(justified.Root))
 	if err != nil {
-		msg := fmt.Sprintf("could not read balances for state w/ justified checkpoint %#x", s.justifiedCheckpt.Root)
+		msg := fmt.Sprintf("could not read balances for state w/ justified checkpoint %#x", justified.Root)
 		return errors.Wrap(err, msg)
 	}
 	if err := s.updateHead(ctx, balances); err != nil {
@@ -332,19 +334,21 @@ func (s *Service) handleBlockAfterBatchVerify(ctx context.Context, signed block.
 		s.clearInitSyncBlocks()
 	}
 
-	if jCheckpoint.Epoch > s.justifiedCheckpt.Epoch {
+	justified := s.store.JustifiedCheckpt()
+	if jCheckpoint.Epoch > justified.Epoch {
 		if err := s.updateJustifiedInitSync(ctx, jCheckpoint); err != nil {
 			return err
 		}
 	}
 
+	finalized := s.store.FinalizedCheckpt()
 	// Update finalized check point. Prune the block cache and helper caches on every new finalized epoch.
-	if fCheckpoint.Epoch > s.finalizedCheckpt.Epoch {
+	if fCheckpoint.Epoch > finalized.Epoch {
 		if err := s.updateFinalized(ctx, fCheckpoint); err != nil {
 			return err
 		}
-		s.prevFinalizedCheckpt = s.finalizedCheckpt
-		s.finalizedCheckpt = fCheckpoint
+		s.store.SetPrevFinalizedCheckpt(finalized)
+		s.store.SetFinalizedCheckpt(fCheckpoint)
 	}
 	return nil
 }

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -136,6 +136,9 @@ func (s *Service) onBlock(ctx context.Context, signed block.SignedBeaconBlock, b
 
 	// Update justified check point.
 	justified := s.store.JustifiedCheckpt()
+	if justified == nil {
+		return errNilJustifiedInStore
+	}
 	currJustifiedEpoch := justified.Epoch
 	if postState.CurrentJustifiedCheckpoint().Epoch > currJustifiedEpoch {
 		if err := s.updateJustified(ctx, postState); err != nil {
@@ -144,6 +147,9 @@ func (s *Service) onBlock(ctx context.Context, signed block.SignedBeaconBlock, b
 	}
 
 	finalized := s.store.FinalizedCheckpt()
+	if finalized == nil {
+		return errNilFinalizedInStore
+	}
 	newFinalized := postState.FinalizedCheckpointEpoch() > finalized.Epoch
 	if newFinalized {
 		if err := s.finalizedImpliesNewJustified(ctx, postState); err != nil {
@@ -335,6 +341,9 @@ func (s *Service) handleBlockAfterBatchVerify(ctx context.Context, signed block.
 	}
 
 	justified := s.store.JustifiedCheckpt()
+	if justified == nil {
+		return errNilJustifiedInStore
+	}
 	if jCheckpoint.Epoch > justified.Epoch {
 		if err := s.updateJustifiedInitSync(ctx, jCheckpoint); err != nil {
 			return err
@@ -342,6 +351,9 @@ func (s *Service) handleBlockAfterBatchVerify(ctx context.Context, signed block.
 	}
 
 	finalized := s.store.FinalizedCheckpt()
+	if finalized == nil {
+		return errNilFinalizedInStore
+	}
 	// Update finalized check point. Prune the block cache and helper caches on every new finalized epoch.
 	if fCheckpoint.Epoch > finalized.Epoch {
 		if err := s.updateFinalized(ctx, fCheckpoint); err != nil {

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -88,6 +88,9 @@ func (s *Service) VerifyFinalizedConsistency(ctx context.Context, root []byte) e
 	}
 
 	f := s.FinalizedCheckpt()
+	if f == nil {
+		return errNilFinalizedInStore
+	}
 	ss, err := slots.EpochStart(f.Epoch)
 	if err != nil {
 		return err
@@ -144,6 +147,10 @@ func (s *Service) spawnProcessAttestationsRoutine(stateFeed *event.Feed) {
 				s.processAttestations(s.ctx)
 
 				justified := s.store.JustifiedCheckpt()
+				if justified == nil {
+					log.WithError(errNilJustifiedInStore).Error("Could not get justified checkpoint")
+					continue
+				}
 				balances, err := s.justifiedBalances.get(s.ctx, bytesutil.ToBytes32(justified.Root))
 				if err != nil {
 					log.WithError(err).Errorf("Unable to get justified balances for root %v", justified.Root)

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -143,9 +143,10 @@ func (s *Service) spawnProcessAttestationsRoutine(stateFeed *event.Feed) {
 				}
 				s.processAttestations(s.ctx)
 
-				balances, err := s.justifiedBalances.get(s.ctx, bytesutil.ToBytes32(s.justifiedCheckpt.Root))
+				justified := s.store.JustifiedCheckpt()
+				balances, err := s.justifiedBalances.get(s.ctx, bytesutil.ToBytes32(justified.Root))
 				if err != nil {
-					log.WithError(err).Errorf("Unable to get justified balances for root %v", s.justifiedCheckpt.Root)
+					log.WithError(err).Errorf("Unable to get justified balances for root %v", justified.Root)
 					continue
 				}
 				if err := s.updateHead(s.ctx, balances); err != nil {

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -53,10 +53,11 @@ func (s *Service) ReceiveBlock(ctx context.Context, block block.SignedBeaconBloc
 	}
 
 	// Reports on block and fork choice metrics.
-	reportSlotMetrics(blockCopy.Block().Slot(), s.HeadSlot(), s.CurrentSlot(), s.finalizedCheckpt)
+	finalized := s.store.FinalizedCheckpt()
+	reportSlotMetrics(blockCopy.Block().Slot(), s.HeadSlot(), s.CurrentSlot(), finalized)
 
 	// Log block sync status.
-	if err := logBlockSyncStatus(blockCopy.Block(), blockRoot, s.finalizedCheckpt, receivedTime, uint64(s.genesisTime.Unix())); err != nil {
+	if err := logBlockSyncStatus(blockCopy.Block(), blockRoot, finalized, receivedTime, uint64(s.genesisTime.Unix())); err != nil {
 		return err
 	}
 	// Log state transition data.
@@ -98,13 +99,14 @@ func (s *Service) ReceiveBlockBatch(ctx context.Context, blocks []block.SignedBe
 		})
 
 		// Reports on blockCopy and fork choice metrics.
-		reportSlotMetrics(blockCopy.Block().Slot(), s.HeadSlot(), s.CurrentSlot(), s.finalizedCheckpt)
+		finalized := s.store.FinalizedCheckpt()
+		reportSlotMetrics(blockCopy.Block().Slot(), s.HeadSlot(), s.CurrentSlot(), finalized)
 	}
 
 	if err := s.cfg.BeaconDB.SaveBlocks(ctx, s.getInitSyncBlocks()); err != nil {
 		return err
 	}
-	if err := s.wsVerifier.VerifyWeakSubjectivity(s.ctx, s.finalizedCheckpt.Epoch); err != nil {
+	if err := s.wsVerifier.VerifyWeakSubjectivity(s.ctx, s.store.FinalizedCheckpt().Epoch); err != nil {
 		// log.Fatalf will prevent defer from being called
 		span.End()
 		// Exit run time if the node failed to verify weak subjectivity checkpoint.
@@ -148,8 +150,9 @@ func (s *Service) checkSaveHotStateDB(ctx context.Context) error {
 	currentEpoch := slots.ToEpoch(s.CurrentSlot())
 	// Prevent `sinceFinality` going underflow.
 	var sinceFinality types.Epoch
-	if currentEpoch > s.finalizedCheckpt.Epoch {
-		sinceFinality = currentEpoch - s.finalizedCheckpt.Epoch
+	finalized := s.store.FinalizedCheckpt()
+	if currentEpoch > finalized.Epoch {
+		sinceFinality = currentEpoch - finalized.Epoch
 	}
 
 	if sinceFinality >= epochsSinceFinalitySaveHotStateDB {

--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -140,7 +140,7 @@ func TestService_ReceiveBlock(t *testing.T) {
 			require.NoError(t, err)
 			gRoot, err := gBlk.Block().HashTreeRoot()
 			require.NoError(t, err)
-			s.finalizedCheckpt = &ethpb.Checkpoint{Root: gRoot[:]}
+			s.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Root: gRoot[:]})
 			root, err := tt.args.block.Block.HashTreeRoot()
 			require.NoError(t, err)
 			err = s.ReceiveBlock(ctx, wrapper.WrappedPhase0SignedBeaconBlock(tt.args.block), root)
@@ -178,7 +178,7 @@ func TestService_ReceiveBlockUpdateHead(t *testing.T) {
 	require.NoError(t, err)
 	gRoot, err := gBlk.Block().HashTreeRoot()
 	require.NoError(t, err)
-	s.finalizedCheckpt = &ethpb.Checkpoint{Root: gRoot[:]}
+	s.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Root: gRoot[:]})
 	root, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	wg := sync.WaitGroup{}
@@ -257,7 +257,7 @@ func TestService_ReceiveBlockBatch(t *testing.T) {
 
 			gRoot, err := gBlk.Block().HashTreeRoot()
 			require.NoError(t, err)
-			s.finalizedCheckpt = &ethpb.Checkpoint{Root: gRoot[:]}
+			s.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Root: gRoot[:]})
 			root, err := tt.args.block.Block.HashTreeRoot()
 			require.NoError(t, err)
 			blks := []block.SignedBeaconBlock{wrapper.WrappedPhase0SignedBeaconBlock(tt.args.block)}
@@ -295,7 +295,7 @@ func TestCheckSaveHotStateDB_Enabling(t *testing.T) {
 	require.NoError(t, err)
 	st := params.BeaconConfig().SlotsPerEpoch.Mul(uint64(epochsSinceFinalitySaveHotStateDB))
 	s.genesisTime = time.Now().Add(time.Duration(-1*int64(st)*int64(params.BeaconConfig().SecondsPerSlot)) * time.Second)
-	s.finalizedCheckpt = &ethpb.Checkpoint{}
+	s.store.SetFinalizedCheckpt(&ethpb.Checkpoint{})
 
 	require.NoError(t, s.checkSaveHotStateDB(context.Background()))
 	assert.LogsContain(t, hook, "Entering mode to save hot states in DB")
@@ -306,7 +306,7 @@ func TestCheckSaveHotStateDB_Disabling(t *testing.T) {
 	opts := testServiceOptsWithDB(t)
 	s, err := NewService(context.Background(), opts...)
 	require.NoError(t, err)
-	s.finalizedCheckpt = &ethpb.Checkpoint{}
+	s.store.SetFinalizedCheckpt(&ethpb.Checkpoint{})
 	require.NoError(t, s.checkSaveHotStateDB(context.Background()))
 	s.genesisTime = time.Now()
 
@@ -319,7 +319,7 @@ func TestCheckSaveHotStateDB_Overflow(t *testing.T) {
 	opts := testServiceOptsWithDB(t)
 	s, err := NewService(context.Background(), opts...)
 	require.NoError(t, err)
-	s.finalizedCheckpt = &ethpb.Checkpoint{Epoch: 10000000}
+	s.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Epoch: 10000000})
 	s.genesisTime = time.Now()
 
 	require.NoError(t, s.checkSaveHotStateDB(context.Background()))

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/async/event"
+	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain/store"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache/depositcache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/feed"
@@ -54,11 +55,6 @@ type Service struct {
 	headLock    sync.RWMutex
 	// originBlockRoot is the genesis root, or weak subjectivity checkpoint root, depending on how the node is initialized
 	originBlockRoot       [32]byte
-	justifiedCheckpt      *ethpb.Checkpoint
-	prevJustifiedCheckpt  *ethpb.Checkpoint
-	bestJustifiedCheckpt  *ethpb.Checkpoint
-	finalizedCheckpt      *ethpb.Checkpoint
-	prevFinalizedCheckpt  *ethpb.Checkpoint
 	nextEpochBoundarySlot types.Slot
 	boundaryRoots         [][32]byte
 	checkpointStateCache  *cache.CheckpointStateCache
@@ -66,6 +62,7 @@ type Service struct {
 	initSyncBlocksLock    sync.RWMutex
 	justifiedBalances     *stateBalanceCache
 	wsVerifier            *WeakSubjectivityVerifier
+	store                 *store.Store
 }
 
 // config options for the service.
@@ -99,6 +96,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		checkpointStateCache: cache.NewCheckpointStateCache(),
 		initSyncBlocks:       make(map[[32]byte]block.SignedBeaconBlock),
 		cfg:                  &config{},
+		store:                &store.Store{},
 	}
 	for _, opt := range opts {
 		if err := opt(srv); err != nil {
@@ -180,21 +178,16 @@ func (s *Service) startFromSavedState(saved state.BeaconState) error {
 	if err != nil {
 		return errors.Wrap(err, "could not get justified checkpoint")
 	}
-	s.prevJustifiedCheckpt = ethpb.CopyCheckpoint(justified)
-	s.bestJustifiedCheckpt = ethpb.CopyCheckpoint(justified)
-	s.justifiedCheckpt = ethpb.CopyCheckpoint(justified)
-
 	finalized, err := s.cfg.BeaconDB.FinalizedCheckpoint(s.ctx)
 	if err != nil {
 		return errors.Wrap(err, "could not get finalized checkpoint")
 	}
-	s.prevFinalizedCheckpt = ethpb.CopyCheckpoint(finalized)
-	s.finalizedCheckpt = ethpb.CopyCheckpoint(finalized)
+	s.store = store.New(justified, finalized)
 
 	store := protoarray.New(justified.Epoch, finalized.Epoch, bytesutil.ToBytes32(finalized.Root))
 	s.cfg.ForkChoiceStore = store
 
-	ss, err := slots.EpochStart(s.finalizedCheckpt.Epoch)
+	ss, err := slots.EpochStart(finalized.Epoch)
 	if err != nil {
 		return errors.Wrap(err, "could not get start slot of finalized epoch")
 	}
@@ -204,14 +197,14 @@ func (s *Service) startFromSavedState(saved state.BeaconState) error {
 			"startSlot": ss,
 			"endSlot":   h.Slot(),
 		}).Info("Loading blocks to fork choice store, this may take a while.")
-		if err := s.fillInForkChoiceMissingBlocks(s.ctx, h, s.finalizedCheckpt, s.justifiedCheckpt); err != nil {
+		if err := s.fillInForkChoiceMissingBlocks(s.ctx, h, finalized, justified); err != nil {
 			return errors.Wrap(err, "could not fill in fork choice store missing blocks")
 		}
 	}
 
 	// not attempting to save initial sync blocks here, because there shouldn't be any until
 	// after the statefeed.Initialized event is fired (below)
-	if err := s.wsVerifier.VerifyWeakSubjectivity(s.ctx, s.finalizedCheckpt.Epoch); err != nil {
+	if err := s.wsVerifier.VerifyWeakSubjectivity(s.ctx, finalized.Epoch); err != nil {
 		// Exit run time if the node failed to verify weak subjectivity checkpoint.
 		return errors.Wrap(err, "could not verify initial checkpoint provided for chain sync")
 	}
@@ -446,12 +439,7 @@ func (s *Service) saveGenesisData(ctx context.Context, genesisState state.Beacon
 
 	// Finalized checkpoint at genesis is a zero hash.
 	genesisCheckpoint := genesisState.FinalizedCheckpoint()
-
-	s.justifiedCheckpt = ethpb.CopyCheckpoint(genesisCheckpoint)
-	s.prevJustifiedCheckpt = ethpb.CopyCheckpoint(genesisCheckpoint)
-	s.bestJustifiedCheckpt = ethpb.CopyCheckpoint(genesisCheckpoint)
-	s.finalizedCheckpt = ethpb.CopyCheckpoint(genesisCheckpoint)
-	s.prevFinalizedCheckpt = ethpb.CopyCheckpoint(genesisCheckpoint)
+	s.store = store.New(genesisCheckpoint, genesisCheckpoint)
 
 	if err := s.cfg.ForkChoiceStore.ProcessBlock(ctx,
 		genesisBlk.Block().Slot(),

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prysmaticlabs/prysm/async/event"
+	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain/store"
 	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache/depositcache"
 	b "github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
@@ -253,8 +254,8 @@ func TestChainService_CorrectGenesisRoots(t *testing.T) {
 	// Test the start function.
 	chainService.Start()
 
-	require.DeepEqual(t, blkRoot[:], chainService.finalizedCheckpt.Root, "Finalize Checkpoint root is incorrect")
-	require.DeepEqual(t, params.BeaconConfig().ZeroHash[:], chainService.justifiedCheckpt.Root, "Justified Checkpoint root is incorrect")
+	require.DeepEqual(t, blkRoot[:], chainService.store.FinalizedCheckpt().Root, "Finalize Checkpoint root is incorrect")
+	require.DeepEqual(t, params.BeaconConfig().ZeroHash[:], chainService.store.JustifiedCheckpt().Root, "Justified Checkpoint root is incorrect")
 
 	require.NoError(t, chainService.Stop(), "Unable to stop chain service")
 
@@ -449,9 +450,10 @@ func TestHasBlock_ForkChoiceAndDB(t *testing.T) {
 	ctx := context.Background()
 	beaconDB := testDB.SetupDB(t)
 	s := &Service{
-		cfg:              &config{ForkChoiceStore: protoarray.New(0, 0, [32]byte{}), BeaconDB: beaconDB},
-		finalizedCheckpt: &ethpb.Checkpoint{Root: make([]byte, 32)},
+		cfg:   &config{ForkChoiceStore: protoarray.New(0, 0, [32]byte{}), BeaconDB: beaconDB},
+		store: &store.Store{},
 	}
+	s.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Epoch: 0, Root: params.BeaconConfig().ZeroHash[:]})
 	block := util.NewBeaconBlock()
 	r, err := block.Block.HashTreeRoot()
 	require.NoError(t, err)
@@ -515,9 +517,10 @@ func BenchmarkHasBlockForkChoiceStore(b *testing.B) {
 	ctx := context.Background()
 	beaconDB := testDB.SetupDB(b)
 	s := &Service{
-		cfg:              &config{ForkChoiceStore: protoarray.New(0, 0, [32]byte{}), BeaconDB: beaconDB},
-		finalizedCheckpt: &ethpb.Checkpoint{Root: make([]byte, 32)},
+		cfg:   &config{ForkChoiceStore: protoarray.New(0, 0, [32]byte{}), BeaconDB: beaconDB},
+		store: &store.Store{},
 	}
+	s.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Epoch: 0, Root: params.BeaconConfig().ZeroHash[:]})
 	block := &ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{}}}
 	r, err := block.Block.HashTreeRoot()
 	require.NoError(b, err)

--- a/beacon-chain/blockchain/store/BUILD.bazel
+++ b/beacon-chain/blockchain/store/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
+        "new.go",
         "setter_getter.go",
         "type.go",
     ],
@@ -14,7 +15,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["setter_getter_test.go"],
+    srcs = [
+        "new_test.go",
+        "setter_getter_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//proto/prysm/v1alpha1:go_default_library",

--- a/beacon-chain/blockchain/store/new.go
+++ b/beacon-chain/blockchain/store/new.go
@@ -1,0 +1,15 @@
+package store
+
+import (
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+)
+
+func New(justifiedCheckpt *ethpb.Checkpoint, finalizedCheckpt *ethpb.Checkpoint) *Store {
+	return &Store{
+		justifiedCheckpt:     justifiedCheckpt,
+		prevJustifiedCheckpt: justifiedCheckpt,
+		bestJustifiedCheckpt: justifiedCheckpt,
+		finalizedCheckpt:     finalizedCheckpt,
+		prevFinalizedCheckpt: finalizedCheckpt,
+	}
+}

--- a/beacon-chain/blockchain/store/new_test.go
+++ b/beacon-chain/blockchain/store/new_test.go
@@ -1,0 +1,25 @@
+package store
+
+import (
+	"testing"
+
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/testing/require"
+)
+
+func TestNew(t *testing.T) {
+	j := &ethpb.Checkpoint{
+		Epoch: 0,
+		Root:  []byte("hi"),
+	}
+	f := &ethpb.Checkpoint{
+		Epoch: 0,
+		Root:  []byte("hello"),
+	}
+	s := New(j, f)
+	require.DeepSSZEqual(t, s.JustifiedCheckpt(), j)
+	require.DeepSSZEqual(t, s.BestJustifiedCheckpt(), j)
+	require.DeepSSZEqual(t, s.PrevJustifiedCheckpt(), j)
+	require.DeepSSZEqual(t, s.FinalizedCheckpt(), f)
+	require.DeepSSZEqual(t, s.PrevFinalizedCheckpt(), f)
+}

--- a/beacon-chain/blockchain/store/setter_getter.go
+++ b/beacon-chain/blockchain/store/setter_getter.go
@@ -2,71 +2,71 @@ package store
 
 import ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 
-// PrevJustifiedCheckpt returns the previous justified checkpoint in the store.
-func (s *store) PrevJustifiedCheckpt() *ethpb.Checkpoint {
+// PrevJustifiedCheckpt returns the previous justified checkpoint in the Store.
+func (s *Store) PrevJustifiedCheckpt() *ethpb.Checkpoint {
 	s.RLock()
 	defer s.RUnlock()
 	return s.prevJustifiedCheckpt
 }
 
-// BestJustifiedCheckpt returns the best justified checkpoint in the store.
-func (s *store) BestJustifiedCheckpt() *ethpb.Checkpoint {
+// BestJustifiedCheckpt returns the best justified checkpoint in the Store.
+func (s *Store) BestJustifiedCheckpt() *ethpb.Checkpoint {
 	s.RLock()
 	defer s.RUnlock()
 	return s.bestJustifiedCheckpt
 }
 
-// JustifiedCheckpt returns the justified checkpoint in the store.
-func (s *store) JustifiedCheckpt() *ethpb.Checkpoint {
+// JustifiedCheckpt returns the justified checkpoint in the Store.
+func (s *Store) JustifiedCheckpt() *ethpb.Checkpoint {
 	s.RLock()
 	defer s.RUnlock()
 	return s.justifiedCheckpt
 }
 
-// PrevFinalizedCheckpt returns the previous finalized checkpoint in the store.
-func (s *store) PrevFinalizedCheckpt() *ethpb.Checkpoint {
+// PrevFinalizedCheckpt returns the previous finalized checkpoint in the Store.
+func (s *Store) PrevFinalizedCheckpt() *ethpb.Checkpoint {
 	s.RLock()
 	defer s.RUnlock()
 	return s.prevFinalizedCheckpt
 }
 
-// FinalizedCheckpt returns the finalized checkpoint in the store.
-func (s *store) FinalizedCheckpt() *ethpb.Checkpoint {
+// FinalizedCheckpt returns the finalized checkpoint in the Store.
+func (s *Store) FinalizedCheckpt() *ethpb.Checkpoint {
 	s.RLock()
 	defer s.RUnlock()
 	return s.finalizedCheckpt
 }
 
-// SetPrevJustifiedCheckpt sets the previous justified checkpoint in the store.
-func (s *store) SetPrevJustifiedCheckpt(cp *ethpb.Checkpoint) {
+// SetPrevJustifiedCheckpt sets the previous justified checkpoint in the Store.
+func (s *Store) SetPrevJustifiedCheckpt(cp *ethpb.Checkpoint) {
 	s.Lock()
 	defer s.Unlock()
 	s.prevJustifiedCheckpt = cp
 }
 
-// SetBestJustifiedCheckpt sets the best justified checkpoint in the store.
-func (s *store) SetBestJustifiedCheckpt(cp *ethpb.Checkpoint) {
+// SetBestJustifiedCheckpt sets the best justified checkpoint in the Store.
+func (s *Store) SetBestJustifiedCheckpt(cp *ethpb.Checkpoint) {
 	s.Lock()
 	defer s.Unlock()
 	s.bestJustifiedCheckpt = cp
 }
 
-// SetJustifiedCheckpt sets the justified checkpoint in the store.
-func (s *store) SetJustifiedCheckpt(cp *ethpb.Checkpoint) {
+// SetJustifiedCheckpt sets the justified checkpoint in the Store.
+func (s *Store) SetJustifiedCheckpt(cp *ethpb.Checkpoint) {
 	s.Lock()
 	defer s.Unlock()
 	s.justifiedCheckpt = cp
 }
 
-// SetFinalizedCheckpt sets the finalized checkpoint in the store.
-func (s *store) SetFinalizedCheckpt(cp *ethpb.Checkpoint) {
+// SetFinalizedCheckpt sets the finalized checkpoint in the Store.
+func (s *Store) SetFinalizedCheckpt(cp *ethpb.Checkpoint) {
 	s.Lock()
 	defer s.Unlock()
 	s.finalizedCheckpt = cp
 }
 
-// SetPrevFinalizedCheckpt sets the previous finalized checkpoint in the store.
-func (s *store) SetPrevFinalizedCheckpt(cp *ethpb.Checkpoint) {
+// SetPrevFinalizedCheckpt sets the previous finalized checkpoint in the Store.
+func (s *Store) SetPrevFinalizedCheckpt(cp *ethpb.Checkpoint) {
 	s.Lock()
 	defer s.Unlock()
 	s.prevFinalizedCheckpt = cp

--- a/beacon-chain/blockchain/store/setter_getter_test.go
+++ b/beacon-chain/blockchain/store/setter_getter_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func Test_store_PrevJustifiedCheckpt(t *testing.T) {
-	s := &store{}
+	s := &Store{}
 	var cp *ethpb.Checkpoint
 	require.Equal(t, cp, s.PrevJustifiedCheckpt())
 	cp = &ethpb.Checkpoint{Epoch: 1, Root: []byte{'a'}}
@@ -17,7 +17,7 @@ func Test_store_PrevJustifiedCheckpt(t *testing.T) {
 }
 
 func Test_store_BestJustifiedCheckpt(t *testing.T) {
-	s := &store{}
+	s := &Store{}
 	var cp *ethpb.Checkpoint
 	require.Equal(t, cp, s.BestJustifiedCheckpt())
 	cp = &ethpb.Checkpoint{Epoch: 1, Root: []byte{'a'}}
@@ -26,7 +26,7 @@ func Test_store_BestJustifiedCheckpt(t *testing.T) {
 }
 
 func Test_store_JustifiedCheckpt(t *testing.T) {
-	s := &store{}
+	s := &Store{}
 	var cp *ethpb.Checkpoint
 	require.Equal(t, cp, s.JustifiedCheckpt())
 	cp = &ethpb.Checkpoint{Epoch: 1, Root: []byte{'a'}}
@@ -35,7 +35,7 @@ func Test_store_JustifiedCheckpt(t *testing.T) {
 }
 
 func Test_store_FinalizedCheckpt(t *testing.T) {
-	s := &store{}
+	s := &Store{}
 	var cp *ethpb.Checkpoint
 	require.Equal(t, cp, s.FinalizedCheckpt())
 	cp = &ethpb.Checkpoint{Epoch: 1, Root: []byte{'a'}}
@@ -44,7 +44,7 @@ func Test_store_FinalizedCheckpt(t *testing.T) {
 }
 
 func Test_store_PrevFinalizedCheckpt(t *testing.T) {
-	s := &store{}
+	s := &Store{}
 	var cp *ethpb.Checkpoint
 	require.Equal(t, cp, s.PrevFinalizedCheckpt())
 	cp = &ethpb.Checkpoint{Epoch: 1, Root: []byte{'a'}}

--- a/beacon-chain/blockchain/store/type.go
+++ b/beacon-chain/blockchain/store/type.go
@@ -6,7 +6,7 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 )
 
-// store is defined in the fork choice consensus spec for tracking current time and various versions of checkpoints.
+// Store is defined in the fork choice consensus spec for tracking current time and various versions of checkpoints.
 //
 // Spec code:
 // class Store(object):
@@ -16,7 +16,7 @@ import (
 //    finalized_checkpoint: Checkpoint
 //    best_justified_checkpoint: Checkpoint
 //    proposerBoostRoot: Root
-type store struct {
+type Store struct {
 	justifiedCheckpt     *ethpb.Checkpoint
 	finalizedCheckpt     *ethpb.Checkpoint
 	bestJustifiedCheckpt *ethpb.Checkpoint

--- a/beacon-chain/blockchain/weak_subjectivity_checks_test.go
+++ b/beacon-chain/blockchain/weak_subjectivity_checks_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain/store"
 	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
 	fieldparams "github.com/prysmaticlabs/prysm/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/encoding/bytesutil"
@@ -67,11 +68,12 @@ func TestService_VerifyWeakSubjectivityRoot(t *testing.T) {
 			wv, err := NewWeakSubjectivityVerifier(tt.checkpt, beaconDB)
 			require.NoError(t, err)
 			s := &Service{
-				cfg:              &config{BeaconDB: beaconDB, WeakSubjectivityCheckpt: tt.checkpt},
-				finalizedCheckpt: &ethpb.Checkpoint{Epoch: tt.finalizedEpoch},
-				wsVerifier:       wv,
+				cfg:        &config{BeaconDB: beaconDB, WeakSubjectivityCheckpt: tt.checkpt},
+				store:      &store.Store{},
+				wsVerifier: wv,
 			}
-			err = s.wsVerifier.VerifyWeakSubjectivity(context.Background(), s.finalizedCheckpt.Epoch)
+			s.store.SetFinalizedCheckpt(&ethpb.Checkpoint{Epoch: tt.finalizedEpoch})
+			err = s.wsVerifier.VerifyWeakSubjectivity(context.Background(), s.store.FinalizedCheckpt().Epoch)
 			if tt.wantErr == nil {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
This PR replaces the newly implemented concurrent safe version of the blockchain store (#10118) in blockchain service. For the reviewers, please cross-check on there's no typo with the replacements (ie, justified, prev/best justified, finalized, and prev finalized)