### PR TITLE
Add `on_tick` from spec

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "init_sync_process_block.go",
         "log.go",
         "metrics.go",
+        "new_slot.go",
         "options.go",
         "process_attestation.go",
         "process_attestation_helpers.go",

--- a/beacon-chain/blockchain/new_slot.go
+++ b/beacon-chain/blockchain/new_slot.go
@@ -1,0 +1,67 @@
+package blockchain
+
+import (
+	"bytes"
+	"context"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/prysm/time/slots"
+)
+
+// NewSlot mimics the implementation of `on_tick` in fork choice consensus spec.
+// It resets the proposer boost root in fork choice, and it updates store's justified checkpoint
+// if a better checkpoint on the store's finalized checkpoint chain.
+// This should only be called at the start of every slot interval.
+//
+// Spec pseudocode definition:
+//    # Reset store.proposer_boost_root if this is a new slot
+//    if current_slot > previous_slot:
+//        store.proposer_boost_root = Root()
+//
+//    # Not a new epoch, return
+//    if not (current_slot > previous_slot and compute_slots_since_epoch_start(current_slot) == 0):
+//        return
+//
+//    # Update store.justified_checkpoint if a better checkpoint on the store.finalized_checkpoint chain
+//    if store.best_justified_checkpoint.epoch > store.justified_checkpoint.epoch:
+//        finalized_slot = compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)
+//        ancestor_at_finalized_slot = get_ancestor(store, store.best_justified_checkpoint.root, finalized_slot)
+//        if ancestor_at_finalized_slot == store.finalized_checkpoint.root:
+//            store.justified_checkpoint = store.best_justified_checkpoint
+func (s *Service) newSlot(ctx context.Context, slot types.Slot) error {
+	// Reset proposer boost root in fork choice.
+
+	// Return if it's not a new epoch.
+	if !slots.IsEpochStart(slot) {
+		return nil
+	}
+
+	// Update store.justified_checkpoint if a better checkpoint on the store.finalized_checkpoint chain
+	bj := s.store.BestJustifiedCheckpt()
+	if bj == nil {
+		return errNilBestJustifiedInStore
+	}
+	j := s.store.JustifiedCheckpt()
+	if j == nil {
+		return errNilJustifiedInStore
+	}
+	f := s.store.FinalizedCheckpt()
+	if f == nil {
+		return errNilFinalizedInStore
+	}
+	if bj.Epoch > j.Epoch {
+		finalizedSlot, err := slots.EpochStart(f.Epoch)
+		if err != nil {
+			return err
+		}
+		r, err := s.ancestor(ctx, bj.Root, finalizedSlot)
+		if err != nil {
+			return err
+		}
+		if bytes.Equal(r, f.Root) {
+			s.store.SetJustifiedCheckpt(bj)
+		}
+	}
+	return nil
+
+}

--- a/beacon-chain/blockchain/new_slot_test.go
+++ b/beacon-chain/blockchain/new_slot_test.go
@@ -1,0 +1,100 @@
+package blockchain
+
+import (
+	"context"
+	"testing"
+
+	types "github.com/prysmaticlabs/eth2-types"
+	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain/store"
+	testDB "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
+	"github.com/prysmaticlabs/prysm/beacon-chain/forkchoice/protoarray"
+	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
+	"github.com/prysmaticlabs/prysm/config/params"
+	"github.com/prysmaticlabs/prysm/encoding/bytesutil"
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/testing/require"
+)
+
+func TestService_newSlot(t *testing.T) {
+	beaconDB := testDB.SetupDB(t)
+	fcs := protoarray.New(0, 0, [32]byte{})
+	opts := []Option{
+		WithDatabase(beaconDB),
+		WithStateGen(stategen.New(beaconDB)),
+		WithForkChoiceStore(fcs),
+	}
+	ctx := context.Background()
+
+	require.NoError(t, fcs.ProcessBlock(ctx, 0, [32]byte{}, [32]byte{}, [32]byte{}, 0, 0))        // genesis
+	require.NoError(t, fcs.ProcessBlock(ctx, 32, [32]byte{'a'}, [32]byte{}, [32]byte{}, 0, 0))    // finalized
+	require.NoError(t, fcs.ProcessBlock(ctx, 64, [32]byte{'b'}, [32]byte{'a'}, [32]byte{}, 0, 0)) // justified
+	require.NoError(t, fcs.ProcessBlock(ctx, 96, [32]byte{'c'}, [32]byte{'a'}, [32]byte{}, 0, 0)) // best justified
+	require.NoError(t, fcs.ProcessBlock(ctx, 97, [32]byte{'d'}, [32]byte{}, [32]byte{}, 0, 0))    // bad
+
+	type args struct {
+		slot          types.Slot
+		finalized     *ethpb.Checkpoint
+		justified     *ethpb.Checkpoint
+		bestJustified *ethpb.Checkpoint
+		shouldEqual   bool
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "Not epoch boundary. No change",
+			args: args{
+				slot:          params.BeaconConfig().SlotsPerEpoch + 1,
+				finalized:     &ethpb.Checkpoint{Epoch: 1, Root: bytesutil.PadTo([]byte{'a'}, 32)},
+				justified:     &ethpb.Checkpoint{Epoch: 2, Root: bytesutil.PadTo([]byte{'b'}, 32)},
+				bestJustified: &ethpb.Checkpoint{Epoch: 3, Root: bytesutil.PadTo([]byte{'c'}, 32)},
+				shouldEqual:   false,
+			},
+		},
+		{
+			name: "Justified higher than best justified. No change",
+			args: args{
+				slot:          params.BeaconConfig().SlotsPerEpoch,
+				finalized:     &ethpb.Checkpoint{Epoch: 1, Root: bytesutil.PadTo([]byte{'a'}, 32)},
+				justified:     &ethpb.Checkpoint{Epoch: 3, Root: bytesutil.PadTo([]byte{'b'}, 32)},
+				bestJustified: &ethpb.Checkpoint{Epoch: 2, Root: bytesutil.PadTo([]byte{'c'}, 32)},
+				shouldEqual:   false,
+			},
+		},
+		{
+			name: "Best justified not on the same chain as finalized. No change",
+			args: args{
+				slot:          params.BeaconConfig().SlotsPerEpoch,
+				finalized:     &ethpb.Checkpoint{Epoch: 1, Root: bytesutil.PadTo([]byte{'a'}, 32)},
+				justified:     &ethpb.Checkpoint{Epoch: 2, Root: bytesutil.PadTo([]byte{'b'}, 32)},
+				bestJustified: &ethpb.Checkpoint{Epoch: 3, Root: bytesutil.PadTo([]byte{'d'}, 32)},
+				shouldEqual:   false,
+			},
+		},
+		{
+			name: "Best justified on the same chain as finalized. Yes change",
+			args: args{
+				slot:          params.BeaconConfig().SlotsPerEpoch,
+				finalized:     &ethpb.Checkpoint{Epoch: 1, Root: bytesutil.PadTo([]byte{'a'}, 32)},
+				justified:     &ethpb.Checkpoint{Epoch: 2, Root: bytesutil.PadTo([]byte{'b'}, 32)},
+				bestJustified: &ethpb.Checkpoint{Epoch: 3, Root: bytesutil.PadTo([]byte{'c'}, 32)},
+				shouldEqual:   true,
+			},
+		},
+	}
+	for _, test := range tests {
+		service, err := NewService(ctx, opts...)
+		require.NoError(t, err)
+		store := store.New(test.args.justified, test.args.finalized)
+		store.SetBestJustifiedCheckpt(test.args.bestJustified)
+		service.store = store
+
+		require.NoError(t, service.newSlot(ctx, test.args.slot))
+		if test.args.shouldEqual {
+			require.DeepSSZEqual(t, service.store.BestJustifiedCheckpt(), service.store.JustifiedCheckpt())
+		} else {
+			require.DeepNotSSZEqual(t, service.store.BestJustifiedCheckpt(), service.store.JustifiedCheckpt())
+		}
+	}
+}

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -139,6 +139,11 @@ func (s *Service) spawnProcessAttestationsRoutine(stateFeed *event.Feed) {
 			case <-s.ctx.Done():
 				return
 			case <-st.C():
+				if err := s.newSlot(s.ctx, s.CurrentSlot()); err != nil {
+					log.WithError(err).Error("Could not process new slot")
+					return
+				}
+
 				// Continue when there's no fork choice attestation, there's nothing to process and update head.
 				// This covers the condition when the node is still initial syncing to the head of the chain.
 				if s.cfg.AttPool.ForkchoiceAttestationCount() == 0 {


### PR DESCRIPTION
This PR implements the `on_tick` function in spec to reset the proposer boost and update the justified checkpoint. This is the last blocker before merging #10083 