### PR TITLE
Fix off by one in DB

### DIFF
--- a/beacon-chain/db/kv/finalized_block_roots.go
+++ b/beacon-chain/db/kv/finalized_block_roots.go
@@ -58,7 +58,7 @@ func (s *Store) updateFinalizedBlockRoots(ctx context.Context, tx *bolt.Tx, chec
 
 	blockRoots, err := s.BlockRoots(ctx, filters.NewFilter().
 		SetStartEpoch(previousFinalizedCheckpoint.Epoch).
-		SetEndEpoch(checkpoint.Epoch+1),
+		SetEndEpoch(checkpoint.Epoch),
 	)
 	if err != nil {
 		tracing.AnnotateError(span, err)
@@ -128,7 +128,7 @@ func (s *Store) updateFinalizedBlockRoots(ctx context.Context, tx *bolt.Tx, chec
 	}
 
 	// Upsert blocks from the current finalized epoch.
-	roots, err := s.BlockRoots(ctx, filters.NewFilter().SetStartEpoch(checkpoint.Epoch).SetEndEpoch(checkpoint.Epoch+1))
+	roots, err := s.BlockRoots(ctx, filters.NewFilter().SetStartEpoch(checkpoint.Epoch).SetEndEpoch(checkpoint.Epoch))
 	if err != nil {
 		tracing.AnnotateError(span, err)
 		return err

--- a/beacon-chain/db/kv/finalized_block_roots_test.go
+++ b/beacon-chain/db/kv/finalized_block_roots_test.go
@@ -94,7 +94,7 @@ func TestStore_DanglingNonCanonicalBlock(t *testing.T) {
 	root, err = blks[2*slotsPerEpoch-1].Block().HashTreeRoot()
 	require.NoError(t, err)
 	assert.Equal(t, false, db.IsFinalizedBlock(ctx, root), "Block at slot 63 was considered finalized in the index")
-	// All blocks up to slotsPerEpoch*3 should be in the finalized index.
+	// All blocks from slotsPerEpoch*3 to slotsPerEpoch*4 should not be in the finalized index.
 	for i := slotsPerEpoch; i < 2*slotsPerEpoch; i++ {
 		root, err := blks2[i].Block().HashTreeRoot()
 		require.NoError(t, err)


### PR DESCRIPTION
The following issue is caused by an off-by-one in the current reindexing algorithm of prysm, This PR includes a fix and a unit test for the following situation

Consider the following chain of blocks

```
0 -- 1 -- ... -- 62 -- 64 -- 65 -- ... -- 127
                  \
                    -- 63
```
That is, the last block of Epoch 1 is orphaned. 

1. We finalize Epoch 1. At this point all blocks 0 -- 63 should be considered Final, this is currently OK on prysm
2. At this point blocks 64--95 should be considered not final. This is the bug being fixed in this PR, currently prysm would consider those blocks final in the index. 
3. We finalize Epoch 2. At this point all blocks 64 -- 95 should be final, blocks 96 -- 127 should not be final (again same bug being fixed here)
4. After finalizing Epoch 2, we check that block 63 is no longer considered final, while all blocks 0--62 are still considered final
