### PR TITLE
State balance cache: handle input zeros

### DIFF
--- a/beacon-chain/blockchain/state_balance_cache.go
+++ b/beacon-chain/blockchain/state_balance_cache.go
@@ -73,7 +73,8 @@ func (c *stateBalanceCache) update(ctx context.Context, justifiedRoot [32]byte) 
 func (c *stateBalanceCache) get(ctx context.Context, justifiedRoot [32]byte) ([]uint64, error) {
 	c.Lock()
 	defer c.Unlock()
-	if justifiedRoot == c.root {
+
+	if justifiedRoot != [32]byte{} && justifiedRoot == c.root {
 		stateBalanceCacheHit.Inc()
 		return c.balances, nil
 	}

--- a/beacon-chain/blockchain/state_balance_cache_test.go
+++ b/beacon-chain/blockchain/state_balance_cache_test.go
@@ -150,7 +150,6 @@ func TestStateBalanceCache(t *testing.T) {
 		{
 			sbc: &stateBalanceCache{
 				stateGen: &mockStateByRooter{
-					//state: generateTestValidators(1, testWithBadEpoch),
 					err: sentinelCacheMiss,
 				},
 				root: bytesutil.ToBytes32([]byte{'B'}),
@@ -203,6 +202,18 @@ func TestStateBalanceCache(t *testing.T) {
 			balances: allValidBalances,
 			root:     bytesutil.ToBytes32([]byte{'A'}),
 			name:     "happy path",
+		},
+		{
+			sbc: &stateBalanceCache{
+				stateGen: &mockStateByRooter{
+					state: testStateFixture(
+						testStateWithSlot(99),
+						testStateWithValidators(allValidValidators)),
+				},
+			},
+			balances: allValidBalances,
+			root:     [32]byte{},
+			name:     "zero root",
 		},
 	}
 	ctx := context.Background()


### PR DESCRIPTION
The state balance cache's `get` returns the cached balances when input root matches the cached root.  The cache is initialized with: 
```GO
	balances []uint64
	root     [32]byte
```

When someone inputs `[32]byte{}` the cache will return `[]uint64`. Such behavior is dangerous and could hide away edge cases. Instead, we should disallow returning a default value, and pass the default value to `update` to let it process or fail