### PR TITLE
Fix Checking of Minimal Preset

### DIFF
--- a/config/params/loader.go
+++ b/config/params/loader.go
@@ -32,7 +32,10 @@ func LoadChainConfigFile(chainConfigFileName string) {
 		if strings.HasPrefix(line, "CONFIG_NAME") {
 			hasConfigName = true
 		}
-		if strings.HasPrefix(line, "PRESET_BASE: 'minimal'") || strings.HasPrefix(line, "# Minimal preset") {
+		if strings.HasPrefix(line, "PRESET_BASE: 'minimal'") ||
+			strings.HasPrefix(line, `PRESET_BASE: "minimal"`) ||
+			strings.HasPrefix(line, "PRESET_BASE: minimal") ||
+			strings.HasPrefix(line, "# Minimal preset") {
 			conf = MinimalSpecConfig().Copy()
 		}
 		if !strings.HasPrefix(line, "#") && strings.Contains(line, "0x") {


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] If a yaml file has a string value declared with `''` or no quotes at all prysm will ignore it. This isn't correct as that is valid yaml. 

cc @z3n-chada :) 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
