### PR TITLE
Add Config To Yaml Function

### DIFF
--- a/config/params/BUILD.bazel
+++ b/config/params/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
     race = "on",
     deps = [
         ":go_default_library",
+        "//io/file:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/config/params/loader.go
+++ b/config/params/loader.go
@@ -2,6 +2,7 @@ package params
 
 import (
 	"encoding/hex"
+	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -143,4 +144,39 @@ func ReplaceHexStringWithYAMLFormat(line string) []string {
 		parts[1] = string(fixedByte)
 	}
 	return parts
+}
+
+// ConfigToYaml takes a provided config and outputs its contents
+// in yaml. This allows prysm's custom configs to be read by other clients.
+func ConfigToYaml(cfg *BeaconChainConfig) []byte {
+	lines := []string{}
+	lines = append(lines, fmt.Sprintf("PRESET_BASE: '%s'", cfg.PresetBase))
+	lines = append(lines, fmt.Sprintf("CONFIG_NAME: '%s'", cfg.ConfigName))
+	lines = append(lines, fmt.Sprintf("MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: %d", cfg.MinGenesisActiveValidatorCount))
+	lines = append(lines, fmt.Sprintf("GENESIS_DELAY: %d", cfg.GenesisDelay))
+	lines = append(lines, fmt.Sprintf("MIN_GENESIS_TIME: %d", cfg.MinGenesisTime))
+	lines = append(lines, fmt.Sprintf("GENESIS_FORK_VERSION: %#x", cfg.GenesisForkVersion))
+	lines = append(lines, fmt.Sprintf("CHURN_LIMIT_QUOTIENT: %d", cfg.ChurnLimitQuotient))
+	lines = append(lines, fmt.Sprintf("SECONDS_PER_SLOT: %d", cfg.SecondsPerSlot))
+	lines = append(lines, fmt.Sprintf("SLOTS_PER_EPOCH: %d", cfg.SlotsPerEpoch))
+	lines = append(lines, fmt.Sprintf("SECONDS_PER_ETH1_BLOCK: %d", cfg.SecondsPerETH1Block))
+	lines = append(lines, fmt.Sprintf("ETH1_FOLLOW_DISTANCE: %d", cfg.Eth1FollowDistance))
+	lines = append(lines, fmt.Sprintf("EPOCHS_PER_ETH1_VOTING_PERIOD: %d", cfg.EpochsPerEth1VotingPeriod))
+	lines = append(lines, fmt.Sprintf("SHARD_COMMITTEE_PERIOD: %d", cfg.ShardCommitteePeriod))
+	lines = append(lines, fmt.Sprintf("MIN_VALIDATOR_WITHDRAWABILITY_DELAY: %d", cfg.MinValidatorWithdrawabilityDelay))
+	lines = append(lines, fmt.Sprintf("MAX_SEED_LOOKAHEAD: %d", cfg.MaxSeedLookahead))
+	lines = append(lines, fmt.Sprintf("EJECTION_BALANCE: %d", cfg.EjectionBalance))
+	lines = append(lines, fmt.Sprintf("MIN_PER_EPOCH_CHURN_LIMIT: %d", cfg.MinPerEpochChurnLimit))
+	lines = append(lines, fmt.Sprintf("DEPOSIT_CHAIN_ID: %d", cfg.DepositChainID))
+	lines = append(lines, fmt.Sprintf("DEPOSIT_NETWORK_ID: %d", cfg.DepositNetworkID))
+	lines = append(lines, fmt.Sprintf("ALTAIR_FORK_EPOCH: %d", cfg.AltairForkEpoch))
+	lines = append(lines, fmt.Sprintf("ALTAIR_FORK_VERSION: %#x", cfg.AltairForkVersion))
+	lines = append(lines, fmt.Sprintf("INACTIVITY_SCORE_BIAS: %d", cfg.InactivityScoreBias))
+	lines = append(lines, fmt.Sprintf("INACTIVITY_SCORE_RECOVERY_RATE: %d", cfg.InactivityScoreRecoveryRate))
+	lines = append(lines, fmt.Sprintf("TERMINAL_TOTAL_DIFFICULTY: %d", cfg.TerminalTotalDifficulty))
+	lines = append(lines, fmt.Sprintf("TERMINAL_BLOCK_HASH: %#x", cfg.TerminalBlockHash))
+	lines = append(lines, fmt.Sprintf("TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH: %d", cfg.TerminalBlockHashActivationEpoch))
+
+	yamlFile := []byte(strings.Join(lines, "\n"))
+	return yamlFile
 }

--- a/config/params/loader_test.go
+++ b/config/params/loader_test.go
@@ -3,12 +3,14 @@ package params_test
 import (
 	"io/ioutil"
 	"path"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
 	"github.com/prysmaticlabs/prysm/config/params"
+	"github.com/prysmaticlabs/prysm/io/file"
 	"github.com/prysmaticlabs/prysm/testing/assert"
 	"github.com/prysmaticlabs/prysm/testing/require"
 	"gopkg.in/yaml.v2"
@@ -216,6 +218,19 @@ func Test_replaceHexStringWithYAMLFormat(t *testing.T) {
 			t.Errorf("expected conversion to be: %v got: %v", line.wanted, res)
 		}
 	}
+}
+
+func TestConfigParityYaml(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	testDir := bazel.TestTmpDir()
+	yamlDir := filepath.Join(testDir, "config.yaml")
+
+	testCfg := params.E2ETestConfig()
+	yamlObj := params.ConfigToYaml(testCfg)
+	assert.NoError(t, file.WriteFile(yamlDir, yamlObj))
+
+	params.LoadChainConfigFile(yamlDir)
+	assert.DeepEqual(t, params.BeaconConfig(), testCfg)
 }
 
 // configFilePath sets the proper config and returns the relevant


### PR DESCRIPTION
**What type of PR is this?**

Feature Helper

**What does this PR do? Why is it needed?**

This is split off from #10020, @prestonvanloon mentioned earlier in https://github.com/prysmaticlabs/prysm/pull/10020#issuecomment-1024480859 that there was overlap between the yaml generation work in there and #10123 . This PR splits it out from the parent PR so that it can be reviewed separately and used. This PR allows a yaml file to be generated from a provided beacon config object. This is useful in e2e as we can provide other clients with a custom config.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
