### PR TITLE
Add SafeSlotsToImportOptimistically beacon configuration flag

### DIFF
--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -45,6 +45,14 @@ func configureHistoricalSlasher(cliCtx *cli.Context) {
 	}
 }
 
+func configureSafeSlotsToImportOptimistically(cliCtx *cli.Context) {
+	if cliCtx.IsSet(flags.SafeSlotsToImportOptimistically.Name) {
+		c := params.BeaconConfig()
+		c.SafeSlotsToImportOptimistically = types.Slot(cliCtx.Int(flags.SafeSlotsToImportOptimistically.Name))
+		params.OverrideBeaconConfig(c)
+	}
+}
+
 func configureSlotsPerArchivedPoint(cliCtx *cli.Context) {
 	if cliCtx.IsSet(flags.SlotsPerArchivedPoint.Name) {
 		c := params.BeaconConfig()

--- a/beacon-chain/node/config_test.go
+++ b/beacon-chain/node/config_test.go
@@ -37,6 +37,20 @@ func TestConfigureHistoricalSlasher(t *testing.T) {
 	)
 }
 
+func TestConfigureSafeSlotsToImportOptimistically(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	set.Int(flags.SafeSlotsToImportOptimistically.Name, 0, "")
+	require.NoError(t, set.Set(flags.SafeSlotsToImportOptimistically.Name, strconv.Itoa(128)))
+	cliCtx := cli.NewContext(&app, set, nil)
+
+	configureSafeSlotsToImportOptimistically(cliCtx)
+
+	assert.Equal(t, types.Slot(128), params.BeaconConfig().SafeSlotsToImportOptimistically)
+}
+
 func TestConfigureSlotsPerArchivedPoint(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -114,6 +114,7 @@ func New(cliCtx *cli.Context, opts ...Option) (*BeaconNode, error) {
 	flags.ConfigureGlobalFlags(cliCtx)
 	configureChainConfig(cliCtx)
 	configureHistoricalSlasher(cliCtx)
+	configureSafeSlotsToImportOptimistically(cliCtx)
 	configureSlotsPerArchivedPoint(cliCtx)
 	configureEth1Config(cliCtx)
 	configureNetwork(cliCtx)

--- a/beacon-chain/rpc/eth/beacon/config_test.go
+++ b/beacon-chain/rpc/eth/beacon/config_test.go
@@ -31,6 +31,7 @@ func TestGetSpec(t *testing.T) {
 	config.HysteresisQuotient = 9
 	config.HysteresisDownwardMultiplier = 10
 	config.HysteresisUpwardMultiplier = 11
+	config.SafeSlotsToImportOptimistically = 128
 	config.SafeSlotsToUpdateJustified = 12
 	config.Eth1FollowDistance = 13
 	config.TargetAggregatorsPerCommittee = 14
@@ -130,7 +131,7 @@ func TestGetSpec(t *testing.T) {
 	resp, err := server.GetSpec(context.Background(), &emptypb.Empty{})
 	require.NoError(t, err)
 
-	assert.Equal(t, 99, len(resp.Data))
+	assert.Equal(t, 100, len(resp.Data))
 	for k, v := range resp.Data {
 		switch k {
 		case "CONFIG_NAME":
@@ -341,6 +342,8 @@ func TestGetSpec(t *testing.T) {
 			assert.Equal(t, "70", v)
 		case "INTERVALS_PER_SLOT":
 			assert.Equal(t, "3", v)
+		case "SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY":
+			assert.Equal(t, "128", v)
 		default:
 			t.Errorf("Incorrect key: %s", k)
 		}

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -110,6 +110,14 @@ var (
 		Name:  "head-sync",
 		Usage: "Starts the beacon node with the previously saved head state instead of finalized state.",
 	}
+	// SafeSlotsToImportOptimistically specifies the number of slots that a
+	// node should wait before being able to optimistically sync blocks
+	// across the merge boundary
+	SafeSlotsToImportOptimistically = &cli.IntFlag{
+		Name:  "safe-slots-to-import-optimistically",
+		Usage: "The number of slots to wait before optimistically syncing a block without enabled execution.",
+		Value: 128,
+	}
 	// SlotsPerArchivedPoint specifies the number of slots between the archived points, to save beacon state in the cold
 	// section of beaconDB.
 	SlotsPerArchivedPoint = &cli.IntFlag{

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -61,6 +61,7 @@ type BeaconChainConfig struct {
 	MinEpochsToInactivityPenalty     types.Epoch `yaml:"MIN_EPOCHS_TO_INACTIVITY_PENALTY" spec:"true"`    // MinEpochsToInactivityPenalty defines the minimum amount of epochs since finality to begin penalizing inactivity.
 	Eth1FollowDistance               uint64      `yaml:"ETH1_FOLLOW_DISTANCE" spec:"true"`                // Eth1FollowDistance is the number of eth1.0 blocks to wait before considering a new deposit for voting. This only applies after the chain as been started.
 	SafeSlotsToUpdateJustified       types.Slot  `yaml:"SAFE_SLOTS_TO_UPDATE_JUSTIFIED" spec:"true"`      // SafeSlotsToUpdateJustified is the minimal slots needed to update justified check point.
+	SafeSlotsToImportOptimistically  types.Slot  `yaml:"SAFE_SLOTS_TO_IMPORT_OPTIMISTICALLY" spec:"true"` // SafeSlotsToImportOptimistically is the minimal number of slots to wait before importing optimistically a pre-merge block
 	SecondsPerETH1Block              uint64      `yaml:"SECONDS_PER_ETH1_BLOCK" spec:"true"`              // SecondsPerETH1Block is the approximate time for a single eth1 block to be produced.
 
 	// Fork choice algorithm constants.


### PR DESCRIPTION
This PR adds a new beacon chain configuration flag `SafeSlotsToImportOptimistically`. It is user configurable via the beacon-chain CLI flag `safe-slots-to-import-optimistically` 