### PR TITLE
Load Synced Tips when starting from Finalized State

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -187,6 +187,18 @@ func (s *Service) startFromSavedState(saved state.BeaconState) error {
 	store := protoarray.New(justified.Epoch, finalized.Epoch, bytesutil.ToBytes32(finalized.Root))
 	s.cfg.ForkChoiceStore = store
 
+	// Initialize synced tips
+	tips, err := s.cfg.BeaconDB.ValidatedTips(s.ctx)
+	if err != nil {
+		return errors.Wrap(err, "could not get synced tips")
+	}
+	if len(tips) == 0 {
+		tips[originRoot] = saved.Slot()
+	}
+	if err := s.cfg.ForkChoiceStore.SetSyncedTips(tips); err != nil {
+		return errors.Wrap(err, "could not set synced tips")
+	}
+
 	ss, err := slots.EpochStart(finalized.Epoch)
 	if err != nil {
 		return errors.Wrap(err, "could not get start slot of finalized epoch")

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -60,6 +60,7 @@ type Getter interface {
 // SyncTipper returns sync tips related information.
 type SyncTipper interface {
 	SyncedTips() map[[32]byte]types.Slot
+	SetSyncedTips(tips map[[32]byte]types.Slot) error
 	UpdateSyncedTipsWithValidRoot(ctx context.Context, root [32]byte) error
 	UpdateSyncedTipsWithInvalidRoot(ctx context.Context, root [32]byte) error
 }

--- a/beacon-chain/forkchoice/protoarray/errors.go
+++ b/beacon-chain/forkchoice/protoarray/errors.go
@@ -11,3 +11,4 @@ var errInvalidBestDescendantIndex = errors.New("best descendant index is invalid
 var errInvalidParentDelta = errors.New("parent delta is invalid")
 var errInvalidNodeDelta = errors.New("node delta is invalid")
 var errInvalidDeltaLength = errors.New("delta length is invalid")
+var errInvalidSyncedTips = errors.New("invalid synced tips")

--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -40,6 +40,21 @@ func New(justifiedEpoch, finalizedEpoch types.Epoch, finalizedRoot [32]byte) *Fo
 	return &ForkChoice{store: s, balances: b, votes: v, syncedTips: st}
 }
 
+// SetSyncedTips sets the synced and validated tips from the passed map
+func (f *ForkChoice) SetSyncedTips(tips map[[32]byte]types.Slot) error {
+	if len(tips) == 0 {
+		return errInvalidSyncedTips
+	}
+	newTips := make(map[[32]byte]types.Slot, len(tips))
+	for k, v := range tips {
+		newTips[k] = v
+	}
+	f.syncedTips.Lock()
+	defer f.syncedTips.Unlock()
+	f.syncedTips.validatedTips = newTips
+	return nil
+}
+
 // SyncedTips returns the synced and validated tips from the fork choice store.
 func (f *ForkChoice) SyncedTips() map[[32]byte]types.Slot {
 	f.syncedTips.RLock()

--- a/beacon-chain/forkchoice/protoarray/store_test.go
+++ b/beacon-chain/forkchoice/protoarray/store_test.go
@@ -600,6 +600,20 @@ func TestStore_LeadsToViableHead(t *testing.T) {
 	}
 }
 
+func TestStore_SetSyncedTips(t *testing.T) {
+	f := setup(1, 1)
+	tips := make(map[[32]byte]types.Slot)
+	require.ErrorIs(t, errInvalidSyncedTips, f.SetSyncedTips(tips))
+	tips[bytesutil.ToBytes32([]byte{'a'})] = 1
+	require.NoError(t, f.SetSyncedTips(tips))
+	f.syncedTips.RLock()
+	defer f.syncedTips.RUnlock()
+	require.Equal(t, 1, len(f.syncedTips.validatedTips))
+	slot, ok := f.syncedTips.validatedTips[bytesutil.ToBytes32([]byte{'a'})]
+	require.Equal(t, true, ok)
+	require.Equal(t, types.Slot(1), slot)
+}
+
 func TestStore_ViableForHead(t *testing.T) {
 	tests := []struct {
 		n              *Node


### PR DESCRIPTION
This PR loads synced tips from DB to Fork Choice when launching the node. If we are starting from a saved state and no synced tips are found on DB, then we assume the saved state's block was fully validated. 