### PR TITLE
Remove chain of Invalid optimistic blocks

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/db:go_default_library",
         "//beacon-chain/db/filters:go_default_library",
+        "//beacon-chain/db/kv:go_default_library",
         "//beacon-chain/forkchoice:go_default_library",
         "//beacon-chain/forkchoice/protoarray:go_default_library",
         "//beacon-chain/operations/attestations:go_default_library",

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -133,8 +133,7 @@ func (s *Service) onBlock(ctx context.Context, signed block.SignedBeaconBlock, b
 			_, err = s.cfg.ExecutionEngineCaller.ExecutePayload(ctx, executionPayloadToExecutableData(payload))
 			switch err {
 			case powchain.ErrInvalidPayload:
-				// TODO_MERGE walk up the parent chain removing
-				// invalid blocks
+				s.removeInvalidChain(ctx, b)
 				return errors.Wrap(err, "could not sync block with invalid execution payload")
 			case powchain.ErrSyncing:
 				candidate, err := s.optimisticCandidateBlock(ctx, b)

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -59,6 +59,7 @@ type NoHeadAccessDatabase interface {
 	ReadOnlyDatabase
 
 	// Block related methods.
+	DeleteBlock(ctx context.Context, root [32]byte) error
 	SaveBlock(ctx context.Context, block block.SignedBeaconBlock) error
 	SaveBlocks(ctx context.Context, blocks []block.SignedBeaconBlock) error
 	SaveGenesisBlockRoot(ctx context.Context, blockRoot [32]byte) error

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -212,13 +212,13 @@ func (s *Store) DeleteBlock(ctx context.Context, root [32]byte) error {
 	defer span.End()
 
 	if err := s.DeleteState(ctx, root); err != nil {
-		return errDeleteFinalized
+		return ErrDeleteFinalized
 	}
 
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(finalizedBlockRootsIndexBucket)
 		if b := bkt.Get(root[:]); b != nil {
-			return errDeleteFinalized
+			return ErrDeleteFinalized
 		}
 
 		if err := tx.Bucket(blocksBucket).Delete(root[:]); err != nil {

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -190,17 +190,15 @@ func TestStore_DeleteBlock(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, b)
 	require.NoError(t, db.DeleteBlock(ctx, root2))
+	st, err = db.State(ctx, root2)
+	require.NoError(t, err)
+	require.Equal(t, st, nil)
 
 	b, err = db.Block(ctx, root2)
 	require.NoError(t, err)
 	require.Equal(t, b, nil)
-	defer func() {
-		if rec := recover(); rec == nil {
-			t.Errorf("delete finalized did not panic")
-		}
-	}()
 
-	require.ErrorIs(t, db.DeleteBlock(ctx, root), errFinalizedInvalid)
+	require.ErrorIs(t, db.DeleteBlock(ctx, root), errDeleteFinalized)
 
 }
 

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
 	"github.com/prysmaticlabs/prysm/config/params"
 	"github.com/prysmaticlabs/prysm/encoding/bytesutil"
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1/block"
 	"github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1/wrapper"
 	"github.com/prysmaticlabs/prysm/testing/assert"
@@ -161,6 +162,46 @@ func TestStore_BlocksHandleInvalidEndSlot(t *testing.T) {
 			assert.Equal(t, 1, len(requested), "Unexpected number of blocks received, only expected two")
 		})
 	}
+}
+
+func TestStore_DeleteBlock(t *testing.T) {
+	slotsPerEpoch := uint64(params.BeaconConfig().SlotsPerEpoch)
+	db := setupDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, db.SaveGenesisBlockRoot(ctx, genesisBlockRoot))
+	blks := makeBlocks(t, 0, slotsPerEpoch*4, genesisBlockRoot)
+	require.NoError(t, db.SaveBlocks(ctx, blks))
+
+	root, err := blks[slotsPerEpoch].Block().HashTreeRoot()
+	require.NoError(t, err)
+	cp := &ethpb.Checkpoint{
+		Epoch: 1,
+		Root:  root[:],
+	}
+	st, err := util.NewBeaconState()
+	require.NoError(t, err)
+	require.NoError(t, db.SaveState(ctx, st, root))
+	require.NoError(t, db.SaveFinalizedCheckpoint(ctx, cp))
+
+	root2, err := blks[4*slotsPerEpoch-2].Block().HashTreeRoot()
+	require.NoError(t, err)
+	b, err := db.Block(ctx, root2)
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	require.NoError(t, db.DeleteBlock(ctx, root2))
+
+	b, err = db.Block(ctx, root2)
+	require.NoError(t, err)
+	require.Equal(t, b, nil)
+	defer func() {
+		if rec := recover(); rec == nil {
+			t.Errorf("delete finalized did not panic")
+		}
+	}()
+
+	require.ErrorIs(t, db.DeleteBlock(ctx, root), errFinalizedInvalid)
+
 }
 
 func TestStore_GenesisBlock(t *testing.T) {

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -198,7 +198,7 @@ func TestStore_DeleteBlock(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, b, nil)
 
-	require.ErrorIs(t, db.DeleteBlock(ctx, root), errDeleteFinalized)
+	require.ErrorIs(t, db.DeleteBlock(ctx, root), ErrDeleteFinalized)
 
 }
 

--- a/beacon-chain/db/kv/error.go
+++ b/beacon-chain/db/kv/error.go
@@ -4,7 +4,7 @@ import "errors"
 
 // ErrFinalizedInvalid is raised when a block with an INVALID payload is
 // finalized
-var errFinalizedInvalid = errors.New("finalized block with invalid execution payload")
+var errDeleteFinalized = errors.New("cannot delete finalized block or state")
 
 // ErrNotFound can be used directly, or as a wrapped DBError, whenever a db method needs to
 // indicate that a value couldn't be found.

--- a/beacon-chain/db/kv/error.go
+++ b/beacon-chain/db/kv/error.go
@@ -2,6 +2,10 @@ package kv
 
 import "errors"
 
+// ErrFinalizedInvalid is raised when a block with an INVALID payload is
+// finalized
+var errFinalizedInvalid = errors.New("finalized block with invalid execution payload")
+
 // ErrNotFound can be used directly, or as a wrapped DBError, whenever a db method needs to
 // indicate that a value couldn't be found.
 var ErrNotFound = errors.New("not found in db")

--- a/beacon-chain/db/kv/error.go
+++ b/beacon-chain/db/kv/error.go
@@ -4,7 +4,7 @@ import "errors"
 
 // ErrFinalizedInvalid is raised when a block with an INVALID payload is
 // finalized
-var errDeleteFinalized = errors.New("cannot delete finalized block or state")
+var ErrDeleteFinalized = errors.New("cannot delete finalized block or state")
 
 // ErrNotFound can be used directly, or as a wrapped DBError, whenever a db method needs to
 // indicate that a value couldn't be found.


### PR DESCRIPTION
In the event that the EL catches up and returns INVALID, we walk up the chain removing all invalid parents. 