### PR TITLE
Add Peer Scorer to Dev Mode

### DIFF
--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -134,7 +134,6 @@ var (
 
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
-	enableLargerGossipHistory,
 	enablePeerScorer,
 }
 

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -135,6 +135,7 @@ var (
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
 	enableLargerGossipHistory,
+	enablePeerScorer,
 }
 
 // ValidatorFlags contains a list of all the feature flags that apply to the validator client.


### PR DESCRIPTION
**What type of PR is this?**

Flag Addition

**What does this PR do? Why is it needed?**

With #9717 being merged in, we can now add in our peer scorer to be part of our dev flags.

- [x] Removes larger gossip history flag as it isn't something that will be the default any time soon.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
