### PR TITLE
Keymanager-Kind: fix cli kind parsing and allow for backward compatability

### DIFF
--- a/validator/accounts/wallet_create_test.go
+++ b/validator/accounts/wallet_create_test.go
@@ -270,3 +270,61 @@ func TestCreateWallet_Remote(t *testing.T) {
 	// We assert the created configuration was as desired.
 	assert.DeepEqual(t, wantCfg, cfg)
 }
+
+func TestInputKeymanagerKind(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    string
+		want    keymanager.Kind
+		wantErr bool
+	}{
+		{
+			name:    "local returns local kind",
+			args:    "local",
+			want:    keymanager.Local,
+			wantErr: false,
+		},
+		{
+			name:    "direct returns local kind",
+			args:    "direct",
+			want:    keymanager.Local,
+			wantErr: false,
+		},
+		{
+			name:    "imported returns local kind",
+			args:    "imported",
+			want:    keymanager.Local,
+			wantErr: false,
+		},
+		{
+			name:    "derived returns derived kind",
+			args:    "derived",
+			want:    keymanager.Derived,
+			wantErr: false,
+		},
+		{
+			name:    "remote returns remote kind",
+			args:    "remote",
+			want:    keymanager.Remote,
+			wantErr: false,
+		},
+		{
+			name:    "REMOTE (capitalized) returns remote kind",
+			args:    "REMOTE",
+			want:    keymanager.Remote,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := cli.App{}
+			set := flag.NewFlagSet("test", 0)
+			set.String(flags.KeymanagerKindFlag.Name, tt.args, "")
+			assert.NoError(t, set.Set(flags.KeymanagerKindFlag.Name, tt.args))
+			cliCtx := cli.NewContext(&app, set, nil)
+			got, err := inputKeymanagerKind(cliCtx)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want.String(), got.String())
+		})
+	}
+}

--- a/validator/keymanager/types.go
+++ b/validator/keymanager/types.go
@@ -86,7 +86,11 @@ func (k Kind) String() string {
 	case Derived:
 		return "derived"
 	case Local:
-		return "local"
+		// TODO(#10181) need a safe way to migrate away from using direct.
+		// function is used for directory creation, dangerous to change which may result in multiple directories.
+		// multiple directories will cause the isValid function to fail in wallet.go
+		// and may result in using a unintended wallet.
+		return "direct"
 	case Remote:
 		return "remote"
 	case Web3Signer:

--- a/validator/keymanager/types.go
+++ b/validator/keymanager/types.go
@@ -3,6 +3,7 @@ package keymanager
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/prysmaticlabs/prysm/async/event"
 	fieldparams "github.com/prysmaticlabs/prysm/config/fieldparams"
@@ -85,7 +86,7 @@ func (k Kind) String() string {
 	case Derived:
 		return "derived"
 	case Local:
-		return "direct"
+		return "local"
 	case Remote:
 		return "remote"
 	case Web3Signer:
@@ -97,10 +98,10 @@ func (k Kind) String() string {
 
 // ParseKind from a raw string, returning a keymanager kind.
 func ParseKind(k string) (Kind, error) {
-	switch k {
+	switch strings.ToLower(k) {
 	case "derived":
 		return Derived, nil
-	case "direct":
+	case "direct", "imported", "local":
 		return Local, nil
 	case "remote":
 		return Remote, nil


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.

Bug fix


**What does this PR do? Why is it needed?**

for the longest time, the wallet creation keymanager kind didn't match the type internally. introducing a fix to provide more flexibility while having backward compatibility for this keymanager kind check. users will be able to use the wallet creation more easily.

**Which issues(s) does this PR fix?**

Fixes #10181 

