### PR TITLE
Adding a new method in HeaderFetcher

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -55,6 +55,7 @@ type HeadFetcher interface {
 	ProtoArrayStore() *protoarray.Store
 	ChainHeads() ([][32]byte, []types.Slot)
 	IsOptimistic(ctx context.Context) (bool, error)
+	IsOptimisticForRoot(ctx context.Context, root [32]byte, slot types.Slot) (bool, error)
 	HeadSyncCommitteeFetcher
 	HeadDomainFetcher
 }
@@ -334,6 +335,12 @@ func (s *Service) IsOptimistic(ctx context.Context) (bool, error) {
 	s.headLock.RLock()
 	defer s.headLock.RUnlock()
 	return s.cfg.ForkChoiceStore.Optimistic(ctx, s.head.root, s.head.slot)
+}
+
+// IsOptimisticForRoot takes the root and slot as aguments instead of the current head
+// and returns true if it is optimistic.
+func (s *Service) IsOptimisticForRoot(ctx context.Context, root [32]byte, slot types.Slot) (bool, error) {
+	return s.cfg.ForkChoiceStore.Optimistic(ctx, root, slot)
 }
 
 // SetGenesisTime sets the genesis time of beacon chain.

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -366,3 +366,14 @@ func TestService_IsOptimistic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, true, opt)
 }
+
+func TestService_IsOptimisticForRoot(t *testing.T) {
+	ctx := context.Background()
+	c := &Service{cfg: &config{ForkChoiceStore: protoarray.New(0, 0, [32]byte{})}, head: &head{slot: 101, root: [32]byte{'b'}}}
+	require.NoError(t, c.cfg.ForkChoiceStore.ProcessBlock(ctx, 100, [32]byte{'a'}, [32]byte{}, [32]byte{}, 0, 0))
+	require.NoError(t, c.cfg.ForkChoiceStore.ProcessBlock(ctx, 101, [32]byte{'b'}, [32]byte{'a'}, [32]byte{}, 0, 0))
+
+	opt, err := c.IsOptimisticForRoot(ctx, [32]byte{'a'}, 100)
+	require.NoError(t, err)
+	require.Equal(t, true, opt)
+}

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -444,3 +444,8 @@ func (s *ChainService) HeadSyncContributionProofDomain(_ context.Context, _ type
 func (s *ChainService) IsOptimistic(_ context.Context) (bool, error) {
 	return false, nil
 }
+
+// IsOptimisticForRoot mocks the same method in the chain service.
+func (s *ChainService) IsOptimisticForRoot(_ context.Context, _ [32]byte, _ types.Slot) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
This PR adds a variation fo already existing `IsOptimistic` method. The already present function check only if the head is optimistic, this can be used to check is other root,slot combination is optimistic also.