### PR TITLE
Initialize the Engine API Client in the Beacon Chain's Powchain Service

### DIFF
--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/db:go_default_library",
+        "//beacon-chain/powchain/engine-api-client/v1:go_default_library",
         "//beacon-chain/powchain/types:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",

--- a/beacon-chain/powchain/engine-api-client/v1/client.go
+++ b/beacon-chain/powchain/engine-api-client/v1/client.go
@@ -36,6 +36,18 @@ type ForkchoiceUpdatedResponse struct {
 	PayloadId *pb.PayloadIDBytes `json:"payloadId"`
 }
 
+// EngineCaller defines a client that can interact with an Ethereum
+// execution node's engine service via JSON-RPC.
+type EngineCaller interface {
+	NewPayload(ctx context.Context, payload *pb.ExecutionPayload) (*pb.PayloadStatus, error)
+	ForkchoiceUpdated(
+		ctx context.Context, state *pb.ForkchoiceState, attrs *pb.PayloadAttributes,
+	) (*ForkchoiceUpdatedResponse, error)
+	GetPayload(ctx context.Context, payloadId [8]byte) (*pb.ExecutionPayload, error)
+	LatestExecutionBlock(ctx context.Context) (*pb.ExecutionBlock, error)
+	ExecutionBlockByHash(ctx context.Context, hash common.Hash) (*pb.ExecutionBlock, error)
+}
+
 // Client defines a new engine API client for the Prysm consensus node
 // to interact with an Ethereum execution node.
 type Client struct {

--- a/beacon-chain/powchain/engine-api-client/v1/client_test.go
+++ b/beacon-chain/powchain/engine-api-client/v1/client_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/prysmaticlabs/prysm/testing/require"
 )
 
+var _ = EngineCaller(&Client{})
+
 func TestClient_IPC(t *testing.T) {
 	server := newTestIPCServer(t)
 	defer server.Stop()

--- a/beacon-chain/powchain/options.go
+++ b/beacon-chain/powchain/options.go
@@ -32,6 +32,14 @@ func WithHttpEndpoints(endpointStrings []string) Option {
 	}
 }
 
+// WithExecutionEndpoint for the execution node JSON-RPC endpoint.
+func WithExecutionEndpoint(endpoint string) Option {
+	return func(s *Service) error {
+		s.cfg.executionEndpoint = endpoint
+		return nil
+	}
+}
+
 // WithDepositContractAddress for the deposit contract.
 func WithDepositContractAddress(addr common.Address) Option {
 	return func(s *Service) error {

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -211,7 +211,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		}
 	}
 
-	if err := s.initializeEngineAPIClient(); err != nil {
+	if err := s.initializeEngineAPIClient(ctx); err != nil {
 		return nil, errors.Wrap(err, "unable to initialize engine API client")
 	}
 

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -27,6 +27,7 @@ import (
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/transition"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
+	engine "github.com/prysmaticlabs/prysm/beacon-chain/powchain/engine-api-client/v1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/powchain/types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state/stategen"
@@ -133,6 +134,7 @@ type config struct {
 	eth1HeaderReqLimit      uint64
 	beaconNodeStatsUpdater  BeaconNodeStatsUpdater
 	httpEndpoints           []network.Endpoint
+	executionEndpoint       string
 	currHttpEndpoint        network.Endpoint
 	finalizedStateAtStartup state.BeaconState
 }
@@ -153,6 +155,7 @@ type Service struct {
 	headTicker              *time.Ticker
 	httpLogger              bind.ContractFilterer
 	eth1DataFetcher         RPCDataFetcher
+	engineAPIClient         *engine.Client
 	rpcClient               RPCClient
 	headerCache             *headerCache // cache to store block hash/block height.
 	latestEth1Data          *ethpb.LatestETH1Data
@@ -206,6 +209,10 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		if err := opt(s); err != nil {
 			return nil, err
 		}
+	}
+
+	if err := s.initializeEngineAPIClient(); err != nil {
+		return nil, errors.Wrap(err, "unable to initialize engine API client")
 	}
 
 	if err := s.ensureValidPowchainData(ctx); err != nil {
@@ -296,6 +303,12 @@ func (s *Service) Status() error {
 		return s.runError
 	}
 	return nil
+}
+
+// EngineAPIClient returns the associated engine API client to interact
+// with an execution node via JSON-RPC.
+func (s *Service) EngineAPIClient() *engine.Client {
+	return s.engineAPIClient
 }
 
 func (s *Service) updateBeaconNodeStats() {
@@ -1070,6 +1083,19 @@ func (s *Service) ensureValidPowchainData(ctx context.Context) error {
 		}
 		return s.cfg.beaconDB.SavePowchainData(ctx, eth1Data)
 	}
+	return nil
+}
+
+// Initializes a connection to the engine API if an execution provider endpoint is set.
+func (s *Service) initializeEngineAPIClient(ctx context.Context) error {
+	if s.cfg.executionEndpoint == "" {
+		return nil
+	}
+	client, err := engine.New(ctx, s.cfg.executionEndpoint)
+	if err != nil {
+		return err
+	}
+	s.engineAPIClient = client
 	return nil
 }
 

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -17,7 +17,7 @@ var (
 		Usage: "A mainchain web3 provider string http endpoint. Can contain auth header as well in the format --http-web3provider=\"https://goerli.infura.io/v3/xxxx,Basic xxx\" for project secret (base64 encoded) and --http-web3provider=\"https://goerli.infura.io/v3/xxxx,Bearer xxx\" for jwt use",
 		Value: "",
 	}
-	// ExecutionProvider provides an HTTP access endpoint to an ETH execution node.
+	// ExecutionProvider provides an HTTP or IPC access endpoint to an ETH execution node.
 	ExecutionProviderFlag = &cli.StringFlag{
 		Name:  "execution-provider",
 		Usage: "An http endpoint for an Ethereum execution node",

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -17,6 +17,12 @@ var (
 		Usage: "A mainchain web3 provider string http endpoint. Can contain auth header as well in the format --http-web3provider=\"https://goerli.infura.io/v3/xxxx,Basic xxx\" for project secret (base64 encoded) and --http-web3provider=\"https://goerli.infura.io/v3/xxxx,Bearer xxx\" for jwt use",
 		Value: "",
 	}
+	// ExecutionProvider provides an HTTP access endpoint to an ETH execution node.
+	ExecutionProviderFlag = &cli.StringFlag{
+		Name:  "execution-provider",
+		Usage: "An http endpoint for an Ethereum execution node",
+		Value: "",
+	}
 	// FallbackWeb3ProviderFlag provides a fallback endpoint to an ETH 1.0 RPC.
 	FallbackWeb3ProviderFlag = &cli.StringSliceFlag{
 		Name:  "fallback-web3provider",

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -33,6 +33,7 @@ import (
 var appFlags = []cli.Flag{
 	flags.DepositContractFlag,
 	flags.HTTPWeb3ProviderFlag,
+	flags.ExecutionProviderFlag,
 	flags.FallbackWeb3ProviderFlag,
 	flags.RPCHost,
 	flags.RPCPort,

--- a/cmd/beacon-chain/powchain/options.go
+++ b/cmd/beacon-chain/powchain/options.go
@@ -11,15 +11,19 @@ var log = logrus.WithField("prefix", "cmd-powchain")
 
 // FlagOptions for powchain service flag configurations.
 func FlagOptions(c *cli.Context) ([]powchain.Option, error) {
-	endpoints := parseHttpEndpoints(c)
+	endpoints := parsePowchainEndpoints(c)
+	executionEndpoint := parseExecutionEndpoint(c)
 	opts := []powchain.Option{
 		powchain.WithHttpEndpoints(endpoints),
 		powchain.WithEth1HeaderRequestLimit(c.Uint64(flags.Eth1HeaderReqLimit.Name)),
 	}
+	if executionEndpoint != "" {
+		opts = append(opts, powchain.WithExecutionEndpoint(executionEndpoint))
+	}
 	return opts, nil
 }
 
-func parseHttpEndpoints(c *cli.Context) []string {
+func parsePowchainEndpoints(c *cli.Context) []string {
 	if c.String(flags.HTTPWeb3ProviderFlag.Name) == "" && len(c.StringSlice(flags.FallbackWeb3ProviderFlag.Name)) == 0 {
 		log.Error(
 			"No ETH1 node specified to run with the beacon node. " +
@@ -36,4 +40,8 @@ func parseHttpEndpoints(c *cli.Context) []string {
 	endpoints := []string{c.String(flags.HTTPWeb3ProviderFlag.Name)}
 	endpoints = append(endpoints, c.StringSlice(flags.FallbackWeb3ProviderFlag.Name)...)
 	return endpoints
+}
+
+func parseExecutionEndpoint(c *cli.Context) string {
+	return c.String(flags.ExecutionProviderFlag.Name)
 }

--- a/cmd/beacon-chain/powchain/options_test.go
+++ b/cmd/beacon-chain/powchain/options_test.go
@@ -23,7 +23,7 @@ func TestPowchainCmd(t *testing.T) {
 	set.Var(&fallback, flags.FallbackWeb3ProviderFlag.Name, "")
 	ctx := cli.NewContext(&app, set, nil)
 
-	endpoints := parseHttpEndpoints(ctx)
+	endpoints := parsePowchainEndpoints(ctx)
 	assert.DeepEqual(t, []string{"primary", "fallback1", "fallback2"}, endpoints)
 }
 
@@ -35,6 +35,6 @@ func TestPowchainPreregistration_EmptyWeb3Provider(t *testing.T) {
 	fallback := cli.StringSlice{}
 	set.Var(&fallback, flags.FallbackWeb3ProviderFlag.Name, "")
 	ctx := cli.NewContext(&app, set, nil)
-	parseHttpEndpoints(ctx)
+	parsePowchainEndpoints(ctx)
 	assert.LogsContain(t, hook, "No ETH1 node specified to run with the beacon node")
 }

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -106,6 +106,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.GRPCGatewayPort,
 			flags.GPRCGatewayCorsDomain,
 			flags.HTTPWeb3ProviderFlag,
+			flags.ExecutionProviderFlag,
 			flags.FallbackWeb3ProviderFlag,
 			flags.SetGCPercent,
 			flags.HeadSync,


### PR DESCRIPTION
This PR adds support for the engine API client via a flag `--execution-provider` in the beacon node. This exposes a getter called `EngineAPIClient()` in the powchain service. This client implement the `EngineCaller` interface defined as:
```go
type EngineCaller interface {
	NewPayload(ctx context.Context, payload *pb.ExecutionPayload) (*pb.PayloadStatus, error)
	ForkchoiceUpdated(
		ctx context.Context, state *pb.ForkchoiceState, attrs *pb.PayloadAttributes,
	) (*ForkchoiceUpdatedResponse, error)
	GetPayload(ctx context.Context, payloadId [8]byte) (*pb.ExecutionPayload, error)
	LatestExecutionBlock(ctx context.Context) (*pb.ExecutionBlock, error)
	ExecutionBlockByHash(ctx context.Context, hash common.Hash) (*pb.ExecutionBlock, error)
}
```