### PR TITLE
add metrics for synced tips

### DIFF
--- a/beacon-chain/forkchoice/protoarray/metrics.go
+++ b/beacon-chain/forkchoice/protoarray/metrics.go
@@ -48,4 +48,16 @@ var (
 			Help: "The number of times pruning happened.",
 		},
 	)
+	lastSyncedTipSlot = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "proto_array_last_synced_tip",
+			Help: "The slot of the last fully validated block added to the proto array.",
+		},
+	)
+	syncedTipsCount = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "proto_array_synced_tips_count",
+			Help: "The number of elements in the syncedTips structure.",
+		},
+	)
 )

--- a/beacon-chain/forkchoice/protoarray/optimistic_sync.go
+++ b/beacon-chain/forkchoice/protoarray/optimistic_sync.go
@@ -135,7 +135,8 @@ func (f *ForkChoice) UpdateSyncedTipsWithValidRoot(ctx context.Context, root [32
 
 	// Cache root and slot to validated tips
 	newTips := make(map[[32]byte]types.Slot)
-	newTips[root] = node.slot
+	newValidSlot := node.slot
+	newTips[root] = newValidSlot
 
 	// Compute the full valid path from the given node to its previous synced tip
 	// This path will now consist of fully validated blocks. Notice that
@@ -205,6 +206,8 @@ func (f *ForkChoice) UpdateSyncedTipsWithValidRoot(ctx context.Context, root [32
 	}
 
 	f.syncedTips.validatedTips = newTips
+	lastSyncedTipSlot.Set(float64(newValidSlot))
+	syncedTipsCount.Set(float64(len(newTips)))
 	return nil
 }
 
@@ -314,5 +317,6 @@ func (f *ForkChoice) UpdateSyncedTipsWithInvalidRoot(ctx context.Context, root [
 		}
 	}
 	delete(f.syncedTips.validatedTips, parentRoot)
+	syncedTipsCount.Set(float64(len(f.syncedTips.validatedTips)))
 	return nil
 }

--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -675,7 +675,7 @@ func (s *Store) prune(ctx context.Context, finalizedRoot [32]byte, syncedTips *o
 
 	s.nodes = canonicalNodes
 	prunedCount.Inc()
-
+	syncedTipsCount.Set(float64(len(syncedTips.validatedTips)))
 	return nil
 }
 


### PR DESCRIPTION
Add prometheus gauges for the number of synced tips and the slot of the last fully validated block added to fork choice. 