### PR TITLE
Do not stop on error loading synced tips

### DIFF
--- a/beacon-chain/blockchain/optimistic_sync.go
+++ b/beacon-chain/blockchain/optimistic_sync.go
@@ -3,6 +3,7 @@ package blockchain
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/config/params"
@@ -36,16 +37,17 @@ func (s *Service) optimisticCandidateBlock(ctx context.Context, blk block.Beacon
 // loadSyncedTips loads a previously saved synced Tips from DB
 // if no synced tips are saved, then it creates one from the given
 // root and slot number.
-func (s *Service) loadSyncedTips(root [32]byte, slot types.Slot) {
+func (s *Service) loadSyncedTips(root [32]byte, slot types.Slot) error {
 	// Initialize synced tips
 	tips, err := s.cfg.BeaconDB.ValidatedTips(s.ctx)
 	if err != nil || len(tips) == 0 {
 		tips[root] = slot
 		if err != nil {
-			log.WithError(err).Error("could not read synced tips from DB")
+			log.WithError(err).Warn("could not read synced tips from DB, using finalized checkpoint as synced tip")
 		}
 	}
 	if err := s.cfg.ForkChoiceStore.SetSyncedTips(tips); err != nil {
-		log.WithError(err).Error("could not save synced tips to fork choice")
+		return errors.Wrap(err, "could not set synced tips")
 	}
+	return nil
 }

--- a/beacon-chain/blockchain/optimistic_sync.go
+++ b/beacon-chain/blockchain/optimistic_sync.go
@@ -43,7 +43,7 @@ func (s *Service) loadSyncedTips(root [32]byte, slot types.Slot) error {
 	if err != nil || len(tips) == 0 {
 		tips[root] = slot
 		if err != nil {
-			log.WithError(err).Warn("could not read synced tips from DB, using finalized checkpoint as synced tip")
+			log.WithError(err).Warn("Could not read synced tips from DB, using finalized checkpoint as synced tip")
 		}
 	}
 	if err := s.cfg.ForkChoiceStore.SetSyncedTips(tips); err != nil {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -187,7 +187,9 @@ func (s *Service) startFromSavedState(saved state.BeaconState) error {
 	store := protoarray.New(justified.Epoch, finalized.Epoch, bytesutil.ToBytes32(finalized.Root))
 	s.cfg.ForkChoiceStore = store
 
-	s.loadSyncedTips(originRoot, saved.Slot())
+	if err := s.loadSyncedTips(originRoot, saved.Slot()); err != nil {
+		return err
+	}
 
 	ss, err := slots.EpochStart(finalized.Epoch)
 	if err != nil {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -187,9 +187,7 @@ func (s *Service) startFromSavedState(saved state.BeaconState) error {
 	store := protoarray.New(justified.Epoch, finalized.Epoch, bytesutil.ToBytes32(finalized.Root))
 	s.cfg.ForkChoiceStore = store
 
-	if err := s.loadSyncedTips(originRoot, saved.Slot()); err != nil {
-		return err
-	}
+	s.loadSyncedTips(originRoot, saved.Slot())
 
 	ss, err := slots.EpochStart(finalized.Epoch)
 	if err != nil {


### PR DESCRIPTION
In the event that there is an error reading synced tips from  DB  at launch or setting them in Fork Choice Store, do not stop the blockchain package from loading, just log the error and revert back to the last finalized state. Notice that most probably this error will surface somewhere else though. 

Credits to @rkapka for noticing that synced tips are not necessary for the node to function. 