### PR TITLE
Fix JSON Marshal/Unmarshal for Execution Block

### DIFF
--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -30,7 +30,7 @@ func (b *PayloadIDBytes) UnmarshalJSON(enc []byte) error {
 }
 
 type executionBlockJSON struct {
-	Number           *big.Int        `json:"number"`
+	Number           string          `json:"number"`
 	Hash             hexutil.Bytes   `json:"hash"`
 	ParentHash       hexutil.Bytes   `json:"parentHash"`
 	Sha3Uncles       hexutil.Bytes   `json:"sha3Uncles"`
@@ -39,16 +39,16 @@ type executionBlockJSON struct {
 	TransactionsRoot hexutil.Bytes   `json:"transactionsRoot"`
 	ReceiptsRoot     hexutil.Bytes   `json:"receiptsRoot"`
 	LogsBloom        hexutil.Bytes   `json:"logsBloom"`
-	Difficulty       *big.Int        `json:"difficulty"`
-	TotalDifficulty  *big.Int        `json:"totalDifficulty"`
+	Difficulty       string          `json:"difficulty"`
+	TotalDifficulty  string          `json:"totalDifficulty"`
 	GasLimit         hexutil.Uint64  `json:"gasLimit"`
 	GasUsed          hexutil.Uint64  `json:"gasUsed"`
 	Timestamp        hexutil.Uint64  `json:"timestamp"`
-	BaseFeePerGas    *big.Int        `json:"baseFeePerGas"`
+	BaseFeePerGas    string          `json:"baseFeePerGas"`
 	ExtraData        hexutil.Bytes   `json:"extraData"`
 	MixHash          hexutil.Bytes   `json:"mixHash"`
 	Nonce            hexutil.Bytes   `json:"nonce"`
-	Size             *big.Int        `json:"size"`
+	Size             string          `json:"size"`
 	Transactions     []hexutil.Bytes `json:"transactions"`
 	Uncles           []hexutil.Bytes `json:"uncles"`
 }
@@ -64,28 +64,22 @@ func (e *ExecutionBlock) MarshalJSON() ([]byte, error) {
 	for i, ucl := range e.Uncles {
 		uncles[i] = ucl
 	}
-	num, err := hexutil.DecodeBig(fmt.Sprintf("%#x", e.Number))
-	if err != nil {
-		return nil, err
-	}
-	diff, err := hexutil.DecodeBig(fmt.Sprintf("%#x", e.Difficulty))
-	if err != nil {
-		return nil, err
-	}
-	totalDiff, err := hexutil.DecodeBig(fmt.Sprintf("%#x", e.TotalDifficulty))
-	if err != nil {
-		return nil, err
-	}
-	size, err := hexutil.DecodeBig(fmt.Sprintf("%#x", e.Size))
-	if err != nil {
-		return nil, err
-	}
-	baseFee, err := hexutil.DecodeBig(fmt.Sprintf("%#x", e.BaseFeePerGas))
-	if err != nil {
-		return nil, err
-	}
+	num := new(big.Int).SetBytes(e.Number)
+	numHex := hexutil.EncodeBig(num)
+
+	diff := new(big.Int).SetBytes(e.Difficulty)
+	diffHex := hexutil.EncodeBig(diff)
+
+	totalDiff := new(big.Int).SetBytes(e.TotalDifficulty)
+	totalDiffHex := hexutil.EncodeBig(totalDiff)
+
+	size := new(big.Int).SetBytes(e.Size)
+	sizeHex := hexutil.EncodeBig(size)
+
+	baseFee := new(big.Int).SetBytes(e.BaseFeePerGas)
+	baseFeeHex := hexutil.EncodeBig(baseFee)
 	return json.Marshal(executionBlockJSON{
-		Number:           num,
+		Number:           numHex,
 		Hash:             e.Hash,
 		ParentHash:       e.ParentHash,
 		Sha3Uncles:       e.Sha3Uncles,
@@ -94,16 +88,16 @@ func (e *ExecutionBlock) MarshalJSON() ([]byte, error) {
 		TransactionsRoot: e.TransactionsRoot,
 		ReceiptsRoot:     e.ReceiptsRoot,
 		LogsBloom:        e.LogsBloom,
-		Difficulty:       diff,
-		TotalDifficulty:  totalDiff,
+		Difficulty:       diffHex,
+		TotalDifficulty:  totalDiffHex,
 		GasLimit:         hexutil.Uint64(e.GasLimit),
 		GasUsed:          hexutil.Uint64(e.GasUsed),
 		Timestamp:        hexutil.Uint64(e.Timestamp),
 		ExtraData:        e.ExtraData,
 		MixHash:          e.MixHash,
 		Nonce:            e.Nonce,
-		Size:             size,
-		BaseFeePerGas:    baseFee,
+		Size:             sizeHex,
+		BaseFeePerGas:    baseFeeHex,
 		Transactions:     transactions,
 		Uncles:           uncles,
 	})
@@ -117,7 +111,11 @@ func (e *ExecutionBlock) UnmarshalJSON(enc []byte) error {
 		return err
 	}
 	*e = ExecutionBlock{}
-	e.Number = dec.Number.Bytes()
+	num, err := hexutil.DecodeBig(dec.Number)
+	if err != nil {
+		return err
+	}
+	e.Number = num.Bytes()
 	e.Hash = dec.Hash
 	e.ParentHash = dec.ParentHash
 	e.Sha3Uncles = dec.Sha3Uncles
@@ -126,16 +124,32 @@ func (e *ExecutionBlock) UnmarshalJSON(enc []byte) error {
 	e.TransactionsRoot = dec.TransactionsRoot
 	e.ReceiptsRoot = dec.ReceiptsRoot
 	e.LogsBloom = dec.LogsBloom
-	e.Difficulty = dec.Difficulty.Bytes()
-	e.TotalDifficulty = dec.TotalDifficulty.Bytes()
+	diff, err := hexutil.DecodeBig(dec.Difficulty)
+	if err != nil {
+		return err
+	}
+	e.Difficulty = diff.Bytes()
+	totalDiff, err := hexutil.DecodeBig(dec.TotalDifficulty)
+	if err != nil {
+		return err
+	}
+	e.TotalDifficulty = totalDiff.Bytes()
 	e.GasLimit = uint64(dec.GasLimit)
 	e.GasUsed = uint64(dec.GasUsed)
 	e.Timestamp = uint64(dec.Timestamp)
 	e.ExtraData = dec.ExtraData
 	e.MixHash = dec.MixHash
 	e.Nonce = dec.Nonce
-	e.Size = dec.Size.Bytes()
-	e.BaseFeePerGas = dec.BaseFeePerGas.Bytes()
+	size, err := hexutil.DecodeBig(dec.Size)
+	if err != nil {
+		return err
+	}
+	e.Size = size.Bytes()
+	baseFee, err := hexutil.DecodeBig(dec.BaseFeePerGas)
+	if err != nil {
+		return err
+	}
+	e.BaseFeePerGas = baseFee.Bytes()
 	transactions := make([][]byte, len(dec.Transactions))
 	for i, tx := range dec.Transactions {
 		transactions[i] = tx


### PR DESCRIPTION
This PR fixes issues found when attempting to unmarshal execution blocks during interop testing for the merge.

```
could not get latest execution block: got an unexpected error: math/big: cannot unmarshal "\"0x3b9aca00\"" into a *big.Int
```
This issue was previously seen with execution payloads, and it turns out the code for execution blocks did not match the logic of execution payloads. This PR fixes the problem