### PR TITLE
Fix `eth_getBlockByHash` call

### DIFF
--- a/beacon-chain/powchain/engine-api-client/v1/client.go
+++ b/beacon-chain/powchain/engine-api-client/v1/client.go
@@ -125,7 +125,7 @@ func (c *Client) LatestExecutionBlock(ctx context.Context) (*pb.ExecutionBlock, 
 // eth_blockByHash via JSON-RPC.
 func (c *Client) ExecutionBlockByHash(ctx context.Context, hash common.Hash) (*pb.ExecutionBlock, error) {
 	result := &pb.ExecutionBlock{}
-	err := c.rpc.CallContext(ctx, result, ExecutionBlockByHashMethod, hash)
+	err := c.rpc.CallContext(ctx, result, ExecutionBlockByHashMethod, hash, false /* no full transaction objects */)
 	return result, handleRPCError(err)
 }
 


### PR DESCRIPTION
Fixes 

```
WARN [02-11|18:06:25.051] Served eth_getBlockByHash                conn=127.0.0.1:50629 reqid=44 duration="11.896µs"  err="missing value for required argument 1"
```