### PR TITLE
Fix updateCanonicalNodes

### DIFF
--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -339,6 +339,16 @@ func (s *Store) updateCanonicalNodes(ctx context.Context, root [32]byte) error {
 	n := s.nodes[i]
 	p := n.parent
 
+	// Every node after the parent and before the new canonical node cannot
+	// be cannonical
+	if p == NonExistentNode {
+		return nil
+	}
+	for j := p + 1; j < i; j++ {
+		nonCanonicalNode := s.nodes[j]
+		delete(s.canonicalNodes, nonCanonicalNode.root)
+	}
+
 	for p != NonExistentNode {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -332,38 +332,39 @@ func (s *Store) updateCanonicalNodes(ctx context.Context, root [32]byte) error {
 	defer span.End()
 
 	// Set the input node to canonical.
-	s.canonicalNodes[root] = true
-
-	// Get the input's parent node index.
 	i := s.nodesIndices[root]
-	n := s.nodes[i]
-	p := n.parent
-
-	// Every node after the parent and before the new canonical node cannot
-	// be cannonical
-	if p == NonExistentNode {
-		return nil
-	}
-	for j := p + 1; j < i; j++ {
-		nonCanonicalNode := s.nodes[j]
-		delete(s.canonicalNodes, nonCanonicalNode.root)
-	}
-
-	for p != NonExistentNode {
+	var newCanonicalRoots [][32]byte
+	var n *Node
+	for i != NonExistentNode {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 
 		// Get the parent node, if the node is already in canonical mapping,
 		// we can be sure rest of the ancestors are canonical. Exit early.
-		n = s.nodes[p]
+		n = s.nodes[i]
 		if s.canonicalNodes[n.root] {
 			break
 		}
 
 		// Set parent node to canonical. Repeat until parent node index is undefined.
-		s.canonicalNodes[n.root] = true
-		p = n.parent
+		newCanonicalRoots = append(newCanonicalRoots, n.root)
+		i = n.parent
+	}
+
+	// i is either NonExistentNode or has the index of the last canonical
+	// node before the last head update.
+	if i == NonExistentNode {
+		s.canonicalNodes = make(map[[fieldparams.RootLength]byte]bool)
+	} else {
+		for j := i + 1; j < uint64(len(s.nodes)); j++ {
+			nonCanonicalNode := s.nodes[j]
+			delete(s.canonicalNodes, nonCanonicalNode.root)
+		}
+	}
+
+	for _, canonicalRoot := range newCanonicalRoots {
+		s.canonicalNodes[canonicalRoot] = true
 	}
 
 	return nil

--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -358,8 +358,7 @@ func (s *Store) updateCanonicalNodes(ctx context.Context, root [32]byte) error {
 		s.canonicalNodes = make(map[[fieldparams.RootLength]byte]bool)
 	} else {
 		for j := i + 1; j < uint64(len(s.nodes)); j++ {
-			nonCanonicalNode := s.nodes[j]
-			delete(s.canonicalNodes, nonCanonicalNode.root)
+			delete(s.canonicalNodes, s.nodes[j].root)
 		}
 	}
 

--- a/beacon-chain/forkchoice/protoarray/store_test.go
+++ b/beacon-chain/forkchoice/protoarray/store_test.go
@@ -117,12 +117,11 @@ func TestStore_Head_UnknownJustifiedIndex(t *testing.T) {
 
 func TestStore_Head_Itself(t *testing.T) {
 	r := [32]byte{'A'}
-	indices := make(map[[32]byte]uint64)
-	indices[r] = 0
+	indices := map[[32]byte]uint64{r: 0}
 
 	// Since the justified node does not have a best descendant so the best node
 	// is itself.
-	s := &Store{nodesIndices: indices, nodes: []*Node{{root: r, bestDescendant: NonExistentNode}}, canonicalNodes: make(map[[32]byte]bool)}
+	s := &Store{nodesIndices: indices, nodes: []*Node{{root: r, parent: NonExistentNode, bestDescendant: NonExistentNode}}, canonicalNodes: make(map[[32]byte]bool)}
 	h, err := s.head(context.Background(), r)
 	require.NoError(t, err)
 	assert.Equal(t, r, h)
@@ -131,12 +130,11 @@ func TestStore_Head_Itself(t *testing.T) {
 func TestStore_Head_BestDescendant(t *testing.T) {
 	r := [32]byte{'A'}
 	best := [32]byte{'B'}
-	indices := make(map[[32]byte]uint64)
-	indices[r] = 0
+	indices := map[[32]byte]uint64{r: 0, best: 1}
 
 	// Since the justified node's best descendant is at index 1, and its root is `best`,
 	// the head should be `best`.
-	s := &Store{nodesIndices: indices, nodes: []*Node{{root: r, bestDescendant: 1}, {root: best}}, canonicalNodes: make(map[[32]byte]bool)}
+	s := &Store{nodesIndices: indices, nodes: []*Node{{root: r, bestDescendant: 1, parent: NonExistentNode}, {root: best, parent: 0}}, canonicalNodes: make(map[[32]byte]bool)}
 	h, err := s.head(context.Background(), r)
 	require.NoError(t, err)
 	assert.Equal(t, best, h)
@@ -146,9 +144,9 @@ func TestStore_Head_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	r := [32]byte{'A'}
 	best := [32]byte{'B'}
-	indices := make(map[[32]byte]uint64)
-	indices[r] = 0
-	s := &Store{nodesIndices: indices, nodes: []*Node{{root: r, bestDescendant: 1}, {root: best}}, canonicalNodes: make(map[[32]byte]bool)}
+	indices := map[[32]byte]uint64{r: 0, best: 1}
+
+	s := &Store{nodesIndices: indices, nodes: []*Node{{root: r, parent: NonExistentNode, bestDescendant: 1}, {root: best, parent: 0}}, canonicalNodes: make(map[[32]byte]bool)}
 	cancel()
 	_, err := s.head(ctx, r)
 	require.ErrorContains(t, "context canceled", err)
@@ -770,6 +768,7 @@ func TestStore_UpdateCanonicalNodes_RemoveOldCanonical(t *testing.T) {
 		[32]byte{'b'}: 1,
 		[32]byte{'c'}: 2,
 		[32]byte{'d'}: 3,
+		[32]byte{'e'}: 4,
 	}
 
 	f.store.nodes = []*Node{
@@ -777,14 +776,16 @@ func TestStore_UpdateCanonicalNodes_RemoveOldCanonical(t *testing.T) {
 		{slot: 2, root: [32]byte{'b'}, parent: 0},
 		{slot: 3, root: [32]byte{'c'}, parent: 1},
 		{slot: 4, root: [32]byte{'d'}, parent: 1},
+		{slot: 5, root: [32]byte{'e'}, parent: 3},
 	}
 	require.NoError(t, f.store.updateCanonicalNodes(ctx, [32]byte{'c'}))
 	require.Equal(t, 3, len(f.store.canonicalNodes))
-	require.NoError(t, f.store.updateCanonicalNodes(ctx, [32]byte{'d'}))
-	require.Equal(t, 3, len(f.store.canonicalNodes))
+	require.NoError(t, f.store.updateCanonicalNodes(ctx, [32]byte{'e'}))
+	require.Equal(t, 4, len(f.store.canonicalNodes))
 	require.Equal(t, true, f.IsCanonical([32]byte{'a'}))
 	require.Equal(t, true, f.IsCanonical([32]byte{'b'}))
 	require.Equal(t, true, f.IsCanonical([32]byte{'d'}))
+	require.Equal(t, true, f.IsCanonical([32]byte{'e'}))
 	_, ok := f.store.canonicalNodes[[32]byte{'c'}]
 	require.Equal(t, false, ok)
 }


### PR DESCRIPTION
This PR fixes a bug in fork choice where we would consider canonical some orphaned blocks. 