### PR TITLE
Small Comment Fix in Exchanging Transition Config

### DIFF
--- a/beacon-chain/powchain/engine-api-client/v1/client.go
+++ b/beacon-chain/powchain/engine-api-client/v1/client.go
@@ -119,7 +119,7 @@ func (c *Client) GetPayload(ctx context.Context, payloadId [8]byte) (*pb.Executi
 func (c *Client) ExchangeTransitionConfiguration(
 	ctx context.Context, cfg *pb.TransitionConfiguration,
 ) (*pb.TransitionConfiguration, error) {
-	// Terminal block number should be set to 0
+	// We set terminal block number to 0 as the parameter is not set on the consensus layer.
 	zeroBigNum := big.NewInt(0)
 	cfg.TerminalBlockNumber = zeroBigNum.Bytes()
 	result := &pb.TransitionConfiguration{}


### PR DESCRIPTION
This PR fixes a comment in our API client binding for engine_exchangeTransitionConfigurationV1 as specified in https://github.com/ethereum/execution-apis/pull/179