### PR TITLE
Update  `IsOptimistic ` to always false

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -334,7 +334,8 @@ func (s *Service) HeadValidatorIndexToPublicKey(_ context.Context, index types.V
 func (s *Service) IsOptimistic(ctx context.Context) (bool, error) {
 	s.headLock.RLock()
 	defer s.headLock.RUnlock()
-	return s.cfg.ForkChoiceStore.Optimistic(ctx, s.head.root, s.head.slot)
+	// TODO(10242): Optimistic status is always false until the merge. Use real optimistic status from forkchoice when ready.
+	return false, nil
 }
 
 // IsOptimisticForRoot takes the root and slot as aguments instead of the current head

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -357,6 +357,10 @@ func TestService_HeadValidatorIndexToPublicKeyNil(t *testing.T) {
 }
 
 func TestService_IsOptimistic(t *testing.T) {
+	cfg := params.BeaconConfig()
+	cfg.BellatrixForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
 	ctx := context.Background()
 	c := &Service{cfg: &config{ForkChoiceStore: protoarray.New(0, 0, [32]byte{})}, head: &head{slot: 101, root: [32]byte{'b'}}}
 	require.NoError(t, c.cfg.ForkChoiceStore.ProcessBlock(ctx, 100, [32]byte{'a'}, [32]byte{}, [32]byte{}, 0, 0))

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -357,6 +357,7 @@ func TestService_HeadValidatorIndexToPublicKeyNil(t *testing.T) {
 }
 
 func TestService_IsOptimistic(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig()
 	cfg.BellatrixForkEpoch = 0
 	params.OverrideBeaconConfig(cfg)

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -367,6 +367,14 @@ func TestService_IsOptimistic(t *testing.T) {
 	require.Equal(t, true, opt)
 }
 
+func TestService_IsOptimisticBeforeBellatrix(t *testing.T) {
+	ctx := context.Background()
+	c := &Service{genesisTime: time.Now()}
+	opt, err := c.IsOptimistic(ctx)
+	require.NoError(t, err)
+	require.Equal(t, false, opt)
+}
+
 func TestService_IsOptimisticForRoot(t *testing.T) {
 	ctx := context.Background()
 	c := &Service{cfg: &config{ForkChoiceStore: protoarray.New(0, 0, [32]byte{})}, head: &head{slot: 101, root: [32]byte{'b'}}}


### PR DESCRIPTION
The optimistic status will always be `false` until the merge happens. So we should just hard code return false for now with a `TODO`, and then we can merge PRs like #10274 into `develop.`