### PR TITLE
Release lock before return `validatedTips`

### DIFF
--- a/beacon-chain/forkchoice/protoarray/optimistic_sync.go
+++ b/beacon-chain/forkchoice/protoarray/optimistic_sync.go
@@ -47,6 +47,7 @@ func (f *ForkChoice) Optimistic(ctx context.Context, root [32]byte, slot types.S
 	f.syncedTips.RLock()
 	_, ok := f.syncedTips.validatedTips[root]
 	if ok {
+		f.syncedTips.RUnlock()
 		return false, nil
 	}
 	f.syncedTips.RUnlock()

--- a/beacon-chain/forkchoice/protoarray/optimistic_sync_test.go
+++ b/beacon-chain/forkchoice/protoarray/optimistic_sync_test.go
@@ -200,6 +200,10 @@ func TestOptimistic(t *testing.T) {
 	op, err = f.Optimistic(ctx, nodeK.root, nodeK.slot)
 	require.NoError(t, err)
 	require.Equal(t, op, true)
+
+	// request a write Lock to synced Tips regression #10289
+	f.syncedTips.Lock()
+	defer f.syncedTips.Unlock()
 }
 
 // This tests the algorithm to update syncedTips


### PR DESCRIPTION
We need to release the read lock before the return after reading `validatedTips`