### PR TITLE
validator: Fix flaky test TestServer_RefreshJWTSecretOnFileChange

### DIFF
--- a/validator/rpc/auth_token_test.go
+++ b/validator/rpc/auth_token_test.go
@@ -71,6 +71,9 @@ func TestServer_RefreshJWTSecretOnFileChange(t *testing.T) {
 	defer cancel()
 	go srv.refreshAuthTokenFromFileChanges(ctx, authTokenPath)
 
+	// Wait for service to be ready.
+	time.Sleep(time.Millisecond * 250)
+
 	// Update the auth token file with a new secret.
 	require.NoError(t, CreateAuthToken(walletDir, "localhost:7500"))
 


### PR DESCRIPTION

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This test failed 30% of the time (30/100) due to the file change happening before the fs watcher go routine had a chance to monitor fs changes.

**Which issues(s) does this PR fix?**

**Other notes for review**
