### PR TITLE
Allow E2E To Run Control Tests

### DIFF
--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -140,7 +140,11 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 	if config.UsePprof {
 		args = append(args, "--pprof", fmt.Sprintf("--pprofport=%d", e2e.TestParams.Ports.PrysmBeaconNodePprofPort+index))
 	}
-	args = append(args, features.E2EBeaconChainFlags...)
+	// Only add in the feature flags if we either aren't performing a control test
+	// on our features or the beacon index is a power of 2.
+	if !config.TestFeature || index%2 == 0 {
+		args = append(args, features.E2EBeaconChainFlags...)
+	}
 	args = append(args, config.BeaconFlags...)
 
 	cmd := exec.CommandContext(ctx, binaryPath, args...) // #nosec G204 -- Safe

--- a/testing/endtoend/mainnet_e2e_test.go
+++ b/testing/endtoend/mainnet_e2e_test.go
@@ -64,6 +64,7 @@ func e2eMainnet(t *testing.T, usePrysmSh bool) {
 		ValidatorFlags:          []string{},
 		EpochsToRun:             uint64(epochsToRun),
 		TestSync:                true,
+		TestFeature:             true,
 		TestDeposits:            true,
 		UseFixedPeerIDs:         true,
 		UseValidatorCrossClient: crossClient,

--- a/testing/endtoend/minimal_e2e_test.go
+++ b/testing/endtoend/minimal_e2e_test.go
@@ -94,6 +94,7 @@ func e2eMinimal(t *testing.T, args *testArgs) {
 		ValidatorFlags:      []string{},
 		EpochsToRun:         uint64(epochsToRun),
 		TestSync:            true,
+		TestFeature:         true,
 		TestDeposits:        true,
 		UsePrysmShValidator: args.usePrysmSh,
 		UsePprof:            !longRunning,

--- a/testing/endtoend/minimal_slashing_e2e_test.go
+++ b/testing/endtoend/minimal_slashing_e2e_test.go
@@ -25,6 +25,7 @@ func TestEndToEnd_Slasher_MinimalConfig(t *testing.T) {
 		ValidatorFlags: []string{},
 		EpochsToRun:    4,
 		TestSync:       false,
+		TestFeature:    false,
 		TestDeposits:   false,
 		Evaluators: []types.Evaluator{
 			ev.PeersConnect,

--- a/testing/endtoend/types/types.go
+++ b/testing/endtoend/types/types.go
@@ -12,6 +12,7 @@ import (
 // E2EConfig defines the struct for all configurations needed for E2E testing.
 type E2EConfig struct {
 	TestSync                bool
+	TestFeature             bool
 	UsePrysmShValidator     bool
 	UsePprof                bool
 	UseWeb3RemoteSigner     bool


### PR DESCRIPTION
**What type of PR is this?**

E2E Addition

**What does this PR do? Why is it needed?**

Currently our E2E runs all our feature flags by default, however there are times when we do want our default path as a 'control' so that we can compare a beacon node running new features with our default one and make sure that both nodes can function side by side.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
