### PR TITLE
--curses=no for cleaner logs (no term refresh)

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -34,7 +34,7 @@ build --sandbox_tmpfs_path=/tmp
 build --verbose_failures
 build --announce_rc
 build --show_progress_rate_limit=5
-build --curses=yes --color=no
+build --curses=no --color=no
 build --keep_going
 build --test_output=errors
 build --flaky_test_attempts=5


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Our CI logs currently are very noisey, possibly due to bazel repeatedly writing updates to stdout :curses-style". This PR flips a relevant flag to see if output is improved.