### PR TITLE
Save and retrieve fee recipients for db

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -49,7 +49,8 @@ type ReadOnlyDatabase interface {
 	DepositContractAddress(ctx context.Context) ([]byte, error)
 	// Powchain operations.
 	PowchainData(ctx context.Context) (*ethpb.ETH1ChainData, error)
-
+	// Fee reicipients operations.
+	FeeRecipientByValidatorID(ctx context.Context, id uint64) (common.Address, error)
 	// origin checkpoint sync support
 	OriginBlockRoot(ctx context.Context) ([32]byte, error)
 }
@@ -79,6 +80,8 @@ type NoHeadAccessDatabase interface {
 	SavePowchainData(ctx context.Context, data *ethpb.ETH1ChainData) error
 	// Run any required database migrations.
 	RunMigrations(ctx context.Context) error
+	// Fee reicipients operations.
+	SaveFeeRecipientsByValidatorIDs(ctx context.Context, ids []uint64, addrs []common.Address) error
 
 	CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint types.Slot) error
 }

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
@@ -390,6 +391,44 @@ func (s *Store) HighestSlotBlocksBelow(ctx context.Context, slot types.Slot) ([]
 	}
 
 	return []block.SignedBeaconBlock{blk}, nil
+}
+
+// FeeRecipientByValidatorID returns the fee recipient for a validator id.
+// `ErrNotFoundFeeRecipient` is returned if the validator id is not found.
+func (s *Store) FeeRecipientByValidatorID(ctx context.Context, id uint64) (common.Address, error) {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.FeeRecipientByValidatorID")
+	defer span.End()
+	var addr []byte
+	err := s.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(feeRecipientBucket)
+		addr = bkt.Get(bytesutil.Uint64ToBytesBigEndian(id))
+		if addr == nil {
+			return errors.Wrapf(ErrNotFoundFeeRecipient, "validator id %d", id)
+		}
+		return nil
+	})
+	return common.BytesToAddress(addr), err
+}
+
+// SaveFeeRecipientsByValidatorIDs saves the fee recipients for validator ids.
+// Error is returned if `ids` and `recipients` are not the same length.
+func (s *Store) SaveFeeRecipientsByValidatorIDs(ctx context.Context, ids []uint64, feeRecipients []common.Address) error {
+	_, span := trace.StartSpan(ctx, "BeaconDB.SaveFeeRecipientByValidatorID")
+	defer span.End()
+
+	if len(ids) != len(feeRecipients) {
+		return errors.New("validatorIDs and feeRecipients must be the same length")
+	}
+
+	return s.db.Update(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(feeRecipientBucket)
+		for i, id := range ids {
+			if err := bkt.Put(bytesutil.Uint64ToBytesBigEndian(id), feeRecipients[i].Bytes()); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // blockRootsByFilter retrieves the block roots given the filter criteria.

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db/filters"
 	"github.com/prysmaticlabs/prysm/config/params"
@@ -588,4 +590,28 @@ func TestStore_BlocksBySlot_BlockRootsBySlot(t *testing.T) {
 			assert.Equal(t, true, hasBlockRoots, "Expected no block roots")
 		})
 	}
+}
+
+func TestStore_FeeRecipientByValidatorID(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+	ids := []uint64{0, 0, 0}
+	feeRecipients := []common.Address{{}, {}, {}, {}}
+	require.ErrorContains(t, "validatorIDs and feeRecipients must be the same length", db.SaveFeeRecipientsByValidatorIDs(ctx, ids, feeRecipients))
+
+	ids = []uint64{0, 1, 2}
+	feeRecipients = []common.Address{{'a'}, {'b'}, {'c'}}
+	require.NoError(t, db.SaveFeeRecipientsByValidatorIDs(ctx, ids, feeRecipients))
+	f, err := db.FeeRecipientByValidatorID(ctx, 0)
+	require.NoError(t, err)
+	require.Equal(t, common.Address{'a'}, f)
+	f, err = db.FeeRecipientByValidatorID(ctx, 1)
+	require.NoError(t, err)
+	require.Equal(t, common.Address{'b'}, f)
+	f, err = db.FeeRecipientByValidatorID(ctx, 2)
+	require.NoError(t, err)
+	require.Equal(t, common.Address{'c'}, f)
+	_, err = db.FeeRecipientByValidatorID(ctx, 3)
+	want := errors.Wrap(ErrNotFoundFeeRecipient, "validator id 3")
+	require.Equal(t, want.Error(), err.Error())
 }

--- a/beacon-chain/db/kv/error.go
+++ b/beacon-chain/db/kv/error.go
@@ -12,3 +12,6 @@ var ErrNotFoundState = errors.Wrap(ErrNotFound, "state not found")
 
 // ErrNotFoundOriginBlockRoot is an error specifically for the origin block root getter
 var ErrNotFoundOriginBlockRoot = errors.Wrap(ErrNotFound, "OriginBlockRoot")
+
+// ErrNotFoundFeeRecipient is a not found error specifically for the fee recipient getter
+var ErrNotFoundFeeRecipient = errors.Wrap(ErrNotFound, "fee recipient")

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -191,6 +191,8 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 			newStateServiceCompatibleBucket,
 			// Migrations
 			migrationsBucket,
+
+			feeRecipientBucket,
 		)
 	}); err != nil {
 		log.WithField("elapsed", time.Since(start)).Error("Failed to update db and create buckets")

--- a/beacon-chain/db/kv/schema.go
+++ b/beacon-chain/db/kv/schema.go
@@ -18,6 +18,7 @@ var (
 	checkpointBucket        = []byte("check-point")
 	powchainBucket          = []byte("powchain")
 	stateValidatorsBucket   = []byte("state-validators")
+	feeRecipientBucket      = []byte("fee-recipient")
 	validatedTips           = []byte("validated-synced-tips")
 
 	// Deprecated: This bucket was migrated in PR 6461. Do not use, except for migrations.


### PR DESCRIPTION
Adds DB methods to enable beacon node to save and retrieve fee recipients by validator Id in database

Design doc: https://prysmaticlabs.notion.site/Fee-Recipient-Design-1329e0d722984a568ce116e626370706