### PR TITLE
Boost proposer later

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -111,16 +111,16 @@ func (s *Service) onBlock(ctx context.Context, signed block.SignedBeaconBlock, b
 		return errors.Wrap(err, "could not verify new payload")
 	}
 
+	// TODO(10261) Check optimistic status
+	if err := s.savePostStateInfo(ctx, blockRoot, signed, postState, false /* reg sync */, false /*optimistic sync*/); err != nil {
+		return err
+	}
+
 	// We add a proposer score boost to fork choice for the block root if applicable, right after
 	// running a successful state transition for the block.
 	if err := s.cfg.ForkChoiceStore.BoostProposerRoot(
 		ctx, signed.Block().Slot(), blockRoot, s.genesisTime,
 	); err != nil {
-		return err
-	}
-
-	// TODO(10261) Check optimistic status
-	if err := s.savePostStateInfo(ctx, blockRoot, signed, postState, false /* reg sync */, false /*optimistic sync*/); err != nil {
 		return err
 	}
 

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -229,6 +229,24 @@ func TestStore_OnBlock_DoublyLinkedTree(t *testing.T) {
 	}
 }
 
+func TestStore_OnBlock_ProposerBoostEarly(t *testing.T) {
+	ctx := context.Background()
+
+	beaconDB := testDB.SetupDB(t)
+	fcs := doublylinkedtree.New(0, 0)
+	opts := []Option{
+		WithStateGen(stategen.New(beaconDB)),
+		WithForkChoiceStore(fcs),
+	}
+
+	service, err := NewService(ctx, opts...)
+	require.NoError(t, err)
+	require.NoError(t, service.cfg.ForkChoiceStore.BoostProposerRoot(ctx, 0, [32]byte{'A'}, time.Now()))
+	_, err = service.cfg.ForkChoiceStore.Head(ctx, 0,
+		params.BeaconConfig().ZeroHash, []uint64{}, 0)
+	require.ErrorContains(t, "could not apply proposer boost score: invalid proposer boost root", err)
+}
+
 func TestStore_OnBlockBatch_ProtoArray(t *testing.T) {
 	ctx := context.Background()
 	beaconDB := testDB.SetupDB(t)


### PR DESCRIPTION
This PR fixes an old bug in prysm where we were applying proposer boost before inserting the block in fork-choice. This results in the proposer boost being ignored  if we update the weights between applying it and inserting the block. The new doubly linked tree approach loudly errors in this situation instead of ignoring the proposer boost. 

credits to @nisdas for raising the alarm and helping debugging this. 