### PR TITLE
fix TestValidator_WaitForKeymanagerInitialization_Web race

### DIFF
--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -1383,17 +1383,20 @@ func TestValidator_WaitForKeymanagerInitialization_Web(t *testing.T) {
 		walletInitializedFeed:   &event.Feed{},
 		walletIntializedChannel: walletChan,
 	}
+	wait := make(chan struct{})
 	go func() {
 		err = v.WaitForKeymanagerInitialization(ctx)
 		require.NoError(t, err)
 		km, err := v.Keymanager()
 		require.NoError(t, err)
 		require.NotNil(t, km)
+		close(wait)
 	}()
 
 	walletChan <- wallet.New(&wallet.Config{
 		KeymanagerKind: keymanager.Local,
 	})
+	<- wait
 }
 
 func TestValidator_WaitForKeymanagerInitialization_Interop(t *testing.T) {

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -1396,7 +1396,7 @@ func TestValidator_WaitForKeymanagerInitialization_Web(t *testing.T) {
 	walletChan <- wallet.New(&wallet.Config{
 		KeymanagerKind: keymanager.Local,
 	})
-	<- wait
+	<-wait
 }
 
 func TestValidator_WaitForKeymanagerInitialization_Interop(t *testing.T) {


### PR DESCRIPTION
This test is flaky because it spawns a goroutine that may try to read from the db after it is closed. This change uses a channel to force the containing test method to wait until the goroutine finishes.

**What type of PR is this?**
Bug fix