### PR TITLE
this is safer if a goroutine require fails

### DIFF
--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -1385,12 +1385,12 @@ func TestValidator_WaitForKeymanagerInitialization_Web(t *testing.T) {
 	}
 	wait := make(chan struct{})
 	go func() {
+		defer close(wait)
 		err = v.WaitForKeymanagerInitialization(ctx)
 		require.NoError(t, err)
 		km, err := v.Keymanager()
 		require.NoError(t, err)
 		require.NotNil(t, km)
-		close(wait)
 	}()
 
 	walletChan <- wallet.New(&wallet.Config{


### PR DESCRIPTION
Had an afterthought about #10343 - if one of the assert/requires in the goroutine fails, the channel might not get closed, which would make the test hang. This is safer.

**What type of PR is this?**

Bug fix