### PR TITLE
Process optimistic blocks whose parent are also optimistic

### DIFF
--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -167,11 +167,11 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 
 	err = s.validateBeaconBlock(ctx, blk, blockRoot)
 	if err != nil {
-		// If the parent is optimistic, be gracious and don't penalize the peer.
-		if errors.Is(ErrOptimisticParent, err) {
-			return pubsub.ValidationIgnore, err
+		// If the parent is optimistic, process the block as usual
+		// This also does not penalize a peer which sends optimistic blocks
+		if !errors.Is(ErrOptimisticParent, err) {
+			return pubsub.ValidationReject, err
 		}
-		return pubsub.ValidationReject, err
 	}
 
 	// Record attribute of valid block.


### PR DESCRIPTION
This PR allows processing of blocks, whose parent are also optimistic. At the same time not de-scoring the peer. 