### PR TITLE
ran gofmt @ v1.17, these are the resulting changes

### DIFF
--- a/beacon-chain/blockchain/chain_info_norace_test.go
+++ b/beacon-chain/blockchain/chain_info_norace_test.go
@@ -22,7 +22,7 @@ func TestHeadSlot_DataRace(t *testing.T) {
 		require.NoError(t, s.saveHead(context.Background(), [32]byte{}))
 	}()
 	s.HeadSlot()
-	<- wait
+	<-wait
 }
 
 func TestHeadRoot_DataRace(t *testing.T) {
@@ -38,7 +38,7 @@ func TestHeadRoot_DataRace(t *testing.T) {
 	}()
 	_, err := s.HeadRoot(context.Background())
 	require.NoError(t, err)
-	<- wait
+	<-wait
 }
 
 func TestHeadBlock_DataRace(t *testing.T) {
@@ -54,7 +54,7 @@ func TestHeadBlock_DataRace(t *testing.T) {
 	}()
 	_, err := s.HeadBlock(context.Background())
 	require.NoError(t, err)
-	<- wait
+	<-wait
 }
 
 func TestHeadState_DataRace(t *testing.T) {
@@ -69,5 +69,5 @@ func TestHeadState_DataRace(t *testing.T) {
 	}()
 	_, err := s.HeadState(context.Background())
 	require.NoError(t, err)
-	<- wait
+	<-wait
 }

--- a/beacon-chain/blockchain/chain_info_norace_test.go
+++ b/beacon-chain/blockchain/chain_info_norace_test.go
@@ -16,10 +16,13 @@ func TestHeadSlot_DataRace(t *testing.T) {
 	s := &Service{
 		cfg: &config{BeaconDB: beaconDB},
 	}
+	wait := make(chan struct{})
 	go func() {
+		defer close(wait)
 		require.NoError(t, s.saveHead(context.Background(), [32]byte{}))
 	}()
 	s.HeadSlot()
+	<- wait
 }
 
 func TestHeadRoot_DataRace(t *testing.T) {
@@ -28,11 +31,14 @@ func TestHeadRoot_DataRace(t *testing.T) {
 		cfg:  &config{BeaconDB: beaconDB, StateGen: stategen.New(beaconDB)},
 		head: &head{root: [32]byte{'A'}},
 	}
+	wait := make(chan struct{})
 	go func() {
+		defer close(wait)
 		require.NoError(t, s.saveHead(context.Background(), [32]byte{}))
 	}()
 	_, err := s.HeadRoot(context.Background())
 	require.NoError(t, err)
+	<- wait
 }
 
 func TestHeadBlock_DataRace(t *testing.T) {
@@ -41,11 +47,14 @@ func TestHeadBlock_DataRace(t *testing.T) {
 		cfg:  &config{BeaconDB: beaconDB, StateGen: stategen.New(beaconDB)},
 		head: &head{block: wrapper.WrappedPhase0SignedBeaconBlock(&ethpb.SignedBeaconBlock{})},
 	}
+	wait := make(chan struct{})
 	go func() {
+		defer close(wait)
 		require.NoError(t, s.saveHead(context.Background(), [32]byte{}))
 	}()
 	_, err := s.HeadBlock(context.Background())
 	require.NoError(t, err)
+	<- wait
 }
 
 func TestHeadState_DataRace(t *testing.T) {
@@ -53,9 +62,12 @@ func TestHeadState_DataRace(t *testing.T) {
 	s := &Service{
 		cfg: &config{BeaconDB: beaconDB, StateGen: stategen.New(beaconDB)},
 	}
+	wait := make(chan struct{})
 	go func() {
+		defer close(wait)
 		require.NoError(t, s.saveHead(context.Background(), [32]byte{}))
 	}()
 	_, err := s.HeadState(context.Background())
 	require.NoError(t, err)
+	<- wait
 }

--- a/beacon-chain/blockchain/checktags_test.go
+++ b/beacon-chain/blockchain/checktags_test.go
@@ -1,3 +1,4 @@
+//go:build !develop
 // +build !develop
 
 package blockchain

--- a/beacon-chain/cache/active_balance_disabled.go
+++ b/beacon-chain/cache/active_balance_disabled.go
@@ -1,3 +1,4 @@
+//go:build fuzz
 // +build fuzz
 
 package cache

--- a/beacon-chain/cache/committee_disabled.go
+++ b/beacon-chain/cache/committee_disabled.go
@@ -1,3 +1,4 @@
+//go:build fuzz
 // +build fuzz
 
 // This file is used in fuzzer builds to bypass global committee caches.

--- a/beacon-chain/cache/proposer_indices.go
+++ b/beacon-chain/cache/proposer_indices.go
@@ -1,3 +1,4 @@
+//go:build !fuzz
 // +build !fuzz
 
 package cache

--- a/beacon-chain/cache/proposer_indices_disabled.go
+++ b/beacon-chain/cache/proposer_indices_disabled.go
@@ -1,3 +1,4 @@
+//go:build fuzz
 // +build fuzz
 
 // This file is used in fuzzer builds to bypass proposer indices caches.

--- a/beacon-chain/cache/sync_committee.go
+++ b/beacon-chain/cache/sync_committee.go
@@ -1,3 +1,4 @@
+//go:build !fuzz
 // +build !fuzz
 
 package cache

--- a/beacon-chain/cache/sync_committee_disabled.go
+++ b/beacon-chain/cache/sync_committee_disabled.go
@@ -1,3 +1,4 @@
+//go:build fuzz
 // +build fuzz
 
 package cache

--- a/beacon-chain/state/state-native/v1/beacon_state_mainnet.go
+++ b/beacon-chain/state/state-native/v1/beacon_state_mainnet.go
@@ -1,3 +1,4 @@
+//go:build !minimal
 // +build !minimal
 
 package v1

--- a/beacon-chain/state/state-native/v1/beacon_state_mainnet_test.go
+++ b/beacon-chain/state/state-native/v1/beacon_state_mainnet_test.go
@@ -1,3 +1,4 @@
+//go:build !minimal
 // +build !minimal
 
 package v1

--- a/beacon-chain/state/state-native/v1/beacon_state_minimal.go
+++ b/beacon-chain/state/state-native/v1/beacon_state_minimal.go
@@ -1,3 +1,4 @@
+//go:build minimal
 // +build minimal
 
 package v1

--- a/beacon-chain/state/state-native/v1/beacon_state_minimal_test.go
+++ b/beacon-chain/state/state-native/v1/beacon_state_minimal_test.go
@@ -1,3 +1,4 @@
+//go:build minimal
 // +build minimal
 
 package v1

--- a/beacon-chain/state/state-native/v2/beacon_state_mainnet.go
+++ b/beacon-chain/state/state-native/v2/beacon_state_mainnet.go
@@ -1,3 +1,4 @@
+//go:build !minimal
 // +build !minimal
 
 package v2

--- a/beacon-chain/state/state-native/v2/beacon_state_mainnet_test.go
+++ b/beacon-chain/state/state-native/v2/beacon_state_mainnet_test.go
@@ -1,3 +1,4 @@
+//go:build !minimal
 // +build !minimal
 
 package v2

--- a/beacon-chain/state/state-native/v2/beacon_state_minimal.go
+++ b/beacon-chain/state/state-native/v2/beacon_state_minimal.go
@@ -1,3 +1,4 @@
+//go:build minimal
 // +build minimal
 
 package v2

--- a/beacon-chain/state/state-native/v2/beacon_state_minimal_test.go
+++ b/beacon-chain/state/state-native/v2/beacon_state_minimal_test.go
@@ -1,3 +1,4 @@
+//go:build minimal
 // +build minimal
 
 package v2

--- a/beacon-chain/state/state-native/v3/beacon_state_mainnet.go
+++ b/beacon-chain/state/state-native/v3/beacon_state_mainnet.go
@@ -1,3 +1,4 @@
+//go:build !minimal
 // +build !minimal
 
 package v3

--- a/beacon-chain/state/state-native/v3/beacon_state_mainnet_test.go
+++ b/beacon-chain/state/state-native/v3/beacon_state_mainnet_test.go
@@ -1,3 +1,4 @@
+//go:build !minimal
 // +build !minimal
 
 package v3

--- a/beacon-chain/state/state-native/v3/beacon_state_minimal.go
+++ b/beacon-chain/state/state-native/v3/beacon_state_minimal.go
@@ -1,3 +1,4 @@
+//go:build minimal
 // +build minimal
 
 package v3

--- a/beacon-chain/state/state-native/v3/beacon_state_minimal_test.go
+++ b/beacon-chain/state/state-native/v3/beacon_state_minimal_test.go
@@ -1,3 +1,4 @@
+//go:build minimal
 // +build minimal
 
 package v3

--- a/config/fieldparams/mainnet.go
+++ b/config/fieldparams/mainnet.go
@@ -1,3 +1,4 @@
+//go:build !minimal
 // +build !minimal
 
 package field_params

--- a/config/fieldparams/mainnet_test.go
+++ b/config/fieldparams/mainnet_test.go
@@ -1,3 +1,4 @@
+//go:build !minimal
 // +build !minimal
 
 package field_params_test

--- a/config/fieldparams/minimal.go
+++ b/config/fieldparams/minimal.go
@@ -1,3 +1,4 @@
+//go:build minimal
 // +build minimal
 
 package field_params

--- a/config/fieldparams/minimal_test.go
+++ b/config/fieldparams/minimal_test.go
@@ -1,3 +1,4 @@
+//go:build minimal
 // +build minimal
 
 package field_params_test

--- a/config/params/checktags_test.go
+++ b/config/params/checktags_test.go
@@ -1,3 +1,4 @@
+//go:build !develop
 // +build !develop
 
 package params_test

--- a/config/params/config_utils_develop.go
+++ b/config/params/config_utils_develop.go
@@ -1,3 +1,4 @@
+//go:build develop
 // +build develop
 
 package params

--- a/config/params/config_utils_prod.go
+++ b/config/params/config_utils_prod.go
@@ -1,3 +1,4 @@
+//go:build !develop
 // +build !develop
 
 package params

--- a/crypto/bls/blst/aliases.go
+++ b/crypto/bls/blst/aliases.go
@@ -1,3 +1,4 @@
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && !blst_disabled
 // +build linux,amd64 linux,arm64 darwin,amd64 darwin,arm64 windows,amd64
 // +build !blst_disabled
 

--- a/crypto/bls/blst/bls_benchmark_test.go
+++ b/crypto/bls/blst/bls_benchmark_test.go
@@ -1,3 +1,4 @@
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && !blst_disabled
 // +build linux,amd64 linux,arm64 darwin,amd64 darwin,arm64 windows,amd64
 // +build !blst_disabled
 

--- a/crypto/bls/blst/init.go
+++ b/crypto/bls/blst/init.go
@@ -1,3 +1,4 @@
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && !blst_disabled
 // +build linux,amd64 linux,arm64 darwin,amd64 darwin,arm64 windows,amd64
 // +build !blst_disabled
 

--- a/crypto/bls/blst/public_key.go
+++ b/crypto/bls/blst/public_key.go
@@ -1,3 +1,4 @@
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && !blst_disabled
 // +build linux,amd64 linux,arm64 darwin,amd64 darwin,arm64 windows,amd64
 // +build !blst_disabled
 

--- a/crypto/bls/blst/public_key_test.go
+++ b/crypto/bls/blst/public_key_test.go
@@ -1,3 +1,4 @@
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && !blst_disabled
 // +build linux,amd64 linux,arm64 darwin,amd64 darwin,arm64 windows,amd64
 // +build !blst_disabled
 

--- a/crypto/bls/blst/secret_key.go
+++ b/crypto/bls/blst/secret_key.go
@@ -1,3 +1,4 @@
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && !blst_disabled
 // +build linux,amd64 linux,arm64 darwin,amd64 darwin,arm64 windows,amd64
 // +build !blst_disabled
 

--- a/crypto/bls/blst/secret_key_test.go
+++ b/crypto/bls/blst/secret_key_test.go
@@ -1,3 +1,4 @@
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && !blst_disabled
 // +build linux,amd64 linux,arm64 darwin,amd64 darwin,arm64 windows,amd64
 // +build !blst_disabled
 

--- a/crypto/bls/blst/signature.go
+++ b/crypto/bls/blst/signature.go
@@ -1,3 +1,4 @@
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && !blst_disabled
 // +build linux,amd64 linux,arm64 darwin,amd64 darwin,arm64 windows,amd64
 // +build !blst_disabled
 

--- a/crypto/bls/blst/signature_test.go
+++ b/crypto/bls/blst/signature_test.go
@@ -1,3 +1,4 @@
+//go:build ((linux && amd64) || (linux && arm64) || (darwin && amd64) || (darwin && arm64) || (windows && amd64)) && !blst_disabled
 // +build linux,amd64 linux,arm64 darwin,amd64 darwin,arm64 windows,amd64
 // +build !blst_disabled
 

--- a/crypto/bls/blst/stub.go
+++ b/crypto/bls/blst/stub.go
@@ -1,4 +1,5 @@
-// +build  blst_disabled fuzz
+//go:build blst_disabled || fuzz
+// +build blst_disabled fuzz
 
 package blst
 

--- a/monitoring/journald/journald.go
+++ b/monitoring/journald/journald.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package journald

--- a/monitoring/journald/journald_linux.go
+++ b/monitoring/journald/journald_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package journald

--- a/proto/eth/v1/attestation.pb.gw.go
+++ b/proto/eth/v1/attestation.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v1/beacon_block.pb.gw.go
+++ b/proto/eth/v1/beacon_block.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v1/beacon_chain.pb.gw.go
+++ b/proto/eth/v1/beacon_chain.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v1/beacon_state.pb.gw.go
+++ b/proto/eth/v1/beacon_state.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v1/events.pb.gw.go
+++ b/proto/eth/v1/events.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v1/node.pb.gw.go
+++ b/proto/eth/v1/node.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v1/validator.pb.gw.go
+++ b/proto/eth/v1/validator.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v2/beacon_block.pb.gw.go
+++ b/proto/eth/v2/beacon_block.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v2/beacon_state.pb.gw.go
+++ b/proto/eth/v2/beacon_state.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v2/sync_committee.pb.gw.go
+++ b/proto/eth/v2/sync_committee.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v2/validator.pb.gw.go
+++ b/proto/eth/v2/validator.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/eth/v2/version.pb.gw.go
+++ b/proto/eth/v2/version.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/attestation.pb.gw.go
+++ b/proto/prysm/v1alpha1/attestation.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/beacon_block.pb.gw.go
+++ b/proto/prysm/v1alpha1/beacon_block.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/beacon_state.pb.gw.go
+++ b/proto/prysm/v1alpha1/beacon_state.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/finalized_block_root_container.pb.gw.go
+++ b/proto/prysm/v1alpha1/finalized_block_root_container.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/p2p_messages.pb.gw.go
+++ b/proto/prysm/v1alpha1/p2p_messages.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/powchain.pb.gw.go
+++ b/proto/prysm/v1alpha1/powchain.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/sync_committee.pb.gw.go
+++ b/proto/prysm/v1alpha1/sync_committee.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore

--- a/proto/prysm/v1alpha1/sync_committee_mainnet.go
+++ b/proto/prysm/v1alpha1/sync_committee_mainnet.go
@@ -1,3 +1,4 @@
+//go:build !minimal
 // +build !minimal
 
 package eth

--- a/proto/prysm/v1alpha1/sync_committee_minimal.go
+++ b/proto/prysm/v1alpha1/sync_committee_minimal.go
@@ -1,3 +1,4 @@
+//go:build minimal
 // +build minimal
 
 package eth

--- a/proto/testing/gocast.go
+++ b/proto/testing/gocast.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package testing

--- a/runtime/debug/cgo_symbolizer.go
+++ b/runtime/debug/cgo_symbolizer.go
@@ -1,3 +1,4 @@
+//go:build cgosymbolizer_enabled
 // +build cgosymbolizer_enabled
 
 package debug


### PR DESCRIPTION
Go updated the formatting for build tags in the [1.17 release](https://github.com/golang/go/issues/41184), but these changes aren't reflected currently in the codebase. The impact of this is that running gofmt creates a bunch of noisy diffs.

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

These changes keep popping up when I run gofmt using a 1.17. I want to commit separately to reduce noise. 

**Other notes for review**

Based on go.mod we should all safely be on go version >= 1.17. 