### PR TITLE
Handle pre state Altair with valid payload

### DIFF
--- a/beacon-chain/blockchain/optimistic_sync.go
+++ b/beacon-chain/blockchain/optimistic_sync.go
@@ -122,7 +122,9 @@ func (s *Service) notifyNewPayload(ctx context.Context, preStateVersion int, hea
 
 	// During the transition event, the transition block should be verified for sanity.
 	if isPreBellatrix(preStateVersion) {
-		return s.validateMergeBlock(ctx, blk) // Handle case where pre-state is Altair but block contains payload.
+		// Handle case where pre-state is Altair but block contains payload.
+		// To reach here, the block must have contained a valid payload.
+		return s.validateMergeBlock(ctx, blk)
 	}
 	atTransition, err := blocks.IsMergeTransitionBlockUsingPayloadHeader(header, body)
 	if err != nil {

--- a/beacon-chain/blockchain/optimistic_sync.go
+++ b/beacon-chain/blockchain/optimistic_sync.go
@@ -122,7 +122,7 @@ func (s *Service) notifyNewPayload(ctx context.Context, preStateVersion int, hea
 
 	// During the transition event, the transition block should be verified for sanity.
 	if isPreBellatrix(preStateVersion) {
-		return nil
+		return s.validateMergeBlock(ctx, blk) // Handle case where pre-state is Altair but block contains payload.
 	}
 	atTransition, err := blocks.IsMergeTransitionBlockUsingPayloadHeader(header, body)
 	if err != nil {

--- a/beacon-chain/blockchain/optimistic_sync_test.go
+++ b/beacon-chain/blockchain/optimistic_sync_test.go
@@ -188,6 +188,13 @@ func Test_NotifyNewPayload(t *testing.T) {
 			},
 		},
 	}
+	a := &ethpb.SignedBeaconBlockAltair{
+		Block: &ethpb.BeaconBlockAltair{
+			Body: &ethpb.BeaconBlockBodyAltair{},
+		},
+	}
+	altairBlk, err := wrapper.WrappedSignedBeaconBlock(a)
+	require.NoError(t, err)
 	bellatrixBlk, err := wrapper.WrappedSignedBeaconBlock(blk)
 	require.NoError(t, err)
 	service, err := NewService(ctx, opts...)
@@ -238,10 +245,29 @@ func Test_NotifyNewPayload(t *testing.T) {
 			errString:     "could not validate execution payload from execution engine: payload status is INVALID",
 		},
 		{
-			name:      "altair pre state",
+			name:      "altair pre state, altair block",
 			postState: bellatrixState,
 			preState:  altairState,
-			blk:       bellatrixBlk,
+			blk:       altairBlk,
+		},
+		{
+			name:      "altair pre state, happy case",
+			postState: bellatrixState,
+			preState:  altairState,
+			blk: func() block.SignedBeaconBlock {
+				blk := &ethpb.SignedBeaconBlockBellatrix{
+					Block: &ethpb.BeaconBlockBellatrix{
+						Body: &ethpb.BeaconBlockBodyBellatrix{
+							ExecutionPayload: &v1.ExecutionPayload{
+								ParentHash: bytesutil.PadTo([]byte{'a'}, fieldparams.RootLength),
+							},
+						},
+					},
+				}
+				b, err := wrapper.WrappedSignedBeaconBlock(blk)
+				require.NoError(t, err)
+				return b
+			}(),
 		},
 		{
 			name:      "could not get merge block",
@@ -304,27 +330,29 @@ func Test_NotifyNewPayload(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		engine := &mockEngineService{newPayloadError: tt.newPayloadErr, blks: map[[32]byte]*v1.ExecutionBlock{}}
-		engine.blks[[32]byte{'a'}] = &v1.ExecutionBlock{
-			ParentHash:      bytesutil.PadTo([]byte{'b'}, fieldparams.RootLength),
-			TotalDifficulty: "0x2",
-		}
-		engine.blks[[32]byte{'b'}] = &v1.ExecutionBlock{
-			ParentHash:      bytesutil.PadTo([]byte{'3'}, fieldparams.RootLength),
-			TotalDifficulty: "0x1",
-		}
-		service.cfg.ExecutionEngineCaller = engine
-		var payload *ethpb.ExecutionPayloadHeader
-		if tt.preState.Version() == version.Bellatrix {
-			payload, err = tt.preState.LatestExecutionPayloadHeader()
-			require.NoError(t, err)
-		}
-		err := service.notifyNewPayload(ctx, tt.preState.Version(), payload, tt.postState, tt.blk)
-		if tt.errString != "" {
-			require.ErrorContains(t, tt.errString, err)
-		} else {
-			require.NoError(t, err)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			engine := &mockEngineService{newPayloadError: tt.newPayloadErr, blks: map[[32]byte]*v1.ExecutionBlock{}}
+			engine.blks[[32]byte{'a'}] = &v1.ExecutionBlock{
+				ParentHash:      bytesutil.PadTo([]byte{'b'}, fieldparams.RootLength),
+				TotalDifficulty: "0x2",
+			}
+			engine.blks[[32]byte{'b'}] = &v1.ExecutionBlock{
+				ParentHash:      bytesutil.PadTo([]byte{'3'}, fieldparams.RootLength),
+				TotalDifficulty: "0x1",
+			}
+			service.cfg.ExecutionEngineCaller = engine
+			var payload *ethpb.ExecutionPayloadHeader
+			if tt.preState.Version() == version.Bellatrix {
+				payload, err = tt.preState.LatestExecutionPayloadHeader()
+				require.NoError(t, err)
+			}
+			err := service.notifyNewPayload(ctx, tt.preState.Version(), payload, tt.postState, tt.blk)
+			if tt.errString != "" {
+				require.ErrorContains(t, tt.errString, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
There are two cases where we need to `validate_merge_block`:
1. When `is_merge_transition_block` returns true. This means beacon state contains an empty payload header and beacon block contains a non-empty payload
2. When beacon state is Altair version and beacon block contains a non-empty payload header

(2) is an extremely unlikely case but the protocol and the implementation should consider. This PR fixes (2) to make sure it actually validates instead of returning nil. I verified it successfully validates in local interop with Altair pre-state and non-empty payload block.

Reference: https://github.com/ethereum/consensus-specs/pull/2831