### PR TITLE
Remove deprecated `set_optimistic_to_valid` calls

### DIFF
--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -86,11 +86,6 @@ func (s *Service) updateHead(ctx context.Context, balances []uint64) error {
 		if err := s.insertBlockToForkChoiceStore(ctx, jb.Block(), headStartRoot, f, j); err != nil {
 			return err
 		}
-
-		// TODO(10261) send optimistic status
-		if err := s.cfg.ForkChoiceStore.SetOptimisticToValid(ctx, headStartRoot); err != nil {
-			return err
-		}
 	}
 
 	headRoot, err := s.cfg.ForkChoiceStore.Head(ctx, j.Epoch, headStartRoot, balances, f.Epoch)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -356,10 +356,6 @@ func (s *Service) handleBlockAfterBatchVerify(ctx context.Context, signed block.
 	if err := s.insertBlockToForkChoiceStore(ctx, b, blockRoot, fCheckpoint, jCheckpoint); err != nil {
 		return err
 	}
-	// TODO(10261) send optimistic status
-	if err := s.cfg.ForkChoiceStore.SetOptimisticToValid(ctx, blockRoot); err != nil {
-		return err
-	}
 
 	if err := s.cfg.BeaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{
 		Slot: signed.Block().Slot(),
@@ -475,14 +471,10 @@ func (s *Service) insertBlockToForkChoiceStore(ctx context.Context, blk block.Be
 		return err
 	}
 	// Feed in block to fork choice store.
-	if err := s.cfg.ForkChoiceStore.InsertOptimisticBlock(ctx,
+	return s.cfg.ForkChoiceStore.InsertOptimisticBlock(ctx,
 		blk.Slot(), root, bytesutil.ToBytes32(blk.ParentRoot()),
 		jCheckpoint.Epoch,
-		fCheckpoint.Epoch); err != nil {
-		return errors.Wrap(err, "could not process block for proto array fork choice")
-	}
-	// TODO(10261) send optimistic status
-	return s.cfg.ForkChoiceStore.SetOptimisticToValid(ctx, root)
+		fCheckpoint.Epoch)
 }
 
 // This saves post state info to DB or cache. This also saves post state info to fork choice store.

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -372,10 +372,6 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, blk block.B
 			fCheckpoint.Epoch); err != nil {
 			return errors.Wrap(err, "could not process block for proto array fork choice")
 		}
-		// TODO(10261) send optimistic status
-		if err := s.cfg.ForkChoiceStore.SetOptimisticToValid(ctx, r); err != nil {
-			return err
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
These `SetOptimisticToValid` have been deprecated and should be removed. We have cleaned them up in the `kiln` branch, let's clean do the same in the `develop` branch as well