### PR TITLE
Add API Middleware Support for Fee Recipients Endpoint

### DIFF
--- a/beacon-chain/rpc/apimiddleware/endpoint_factory.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory.go
@@ -63,6 +63,7 @@ func (_ *BeaconEndpointFactory) Paths() []string {
 		"/eth/v1/validator/aggregate_and_proofs",
 		"/eth/v1/validator/sync_committee_contribution",
 		"/eth/v1/validator/contribution_and_proofs",
+		"/eth/v1/validator/prepare_beacon_proposer",
 	}
 }
 
@@ -237,6 +238,11 @@ func (_ *BeaconEndpointFactory) Create(path string) (*apimiddleware.Endpoint, er
 		endpoint.PostRequest = &submitContributionAndProofsRequestJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapSignedContributionAndProofsArray,
+		}
+	case "/eth/v1/validator/prepare_beacon_proposer":
+		endpoint.PostRequest = &feeRecipientsRequestJSON{}
+		endpoint.Hooks = apimiddleware.HookCollection{
+			OnPreDeserializeRequestBodyIntoContainer: wrapFeeRecipientsArray,
 		}
 	default:
 		return nil, errors.New("invalid path")

--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -19,6 +19,11 @@ type genesisResponse_GenesisJson struct {
 	GenesisForkVersion    string `json:"genesis_fork_version" hex:"true"`
 }
 
+// feeRecipientsRequestJson is used in /validator/prepare_beacon_proposers API endpoint.
+type feeRecipientsRequestJSON struct {
+	Recipients []*feeRecipientJson `json:"recipients"`
+}
+
 // stateRootResponseJson is used in /beacon/states/{state_id}/root API endpoint.
 type stateRootResponseJson struct {
 	Data *stateRootResponse_StateRootJson `json:"data"`
@@ -469,6 +474,11 @@ type indexedAttestationJson struct {
 	AttestingIndices []string             `json:"attesting_indices"`
 	Data             *attestationDataJson `json:"data"`
 	Signature        string               `json:"signature" hex:"true"`
+}
+
+type feeRecipientJson struct {
+	ValidatorIndex string `json:"validator_index"`
+	FeeRecipient   string `json:"fee_recipient" hex:"true"`
 }
 
 type attestationJson struct {

--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -477,7 +477,7 @@ type indexedAttestationJson struct {
 }
 
 type feeRecipientJson struct {
-	ValidatorIndex string `json:"validator_index"`
+	ValidatorIndex uint64 `json:"validator_index"`
 	FeeRecipient   string `json:"fee_recipient" hex:"true"`
 }
 

--- a/beacon-chain/rpc/eth/validator/validator.go
+++ b/beacon-chain/rpc/eth/validator/validator.go
@@ -334,19 +334,24 @@ func (vs *Server) PrepareBeaconProposer(
 ) (*emptypb.Empty, error) {
 	_, span := trace.StartSpan(ctx, "validator.PrepareBeaconProposer")
 	defer span.End()
-	var FeeRecipients []common.Address
-	var ValidatorIndices []types.ValidatorIndex
+	var feeRecipients []common.Address
+	var validatorIndices []types.ValidatorIndex
+	recipientIndicesStrings := ""
 	for _, recipientContainer := range request.Recipients {
 		recipient := hexutil.Encode(recipientContainer.FeeRecipient)
 		if !common.IsHexAddress(recipient) {
 			return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("Invalid fee recipient address: %v", recipient))
 		}
-		FeeRecipients = append(FeeRecipients, common.BytesToAddress(recipientContainer.FeeRecipient))
-		ValidatorIndices = append(ValidatorIndices, recipientContainer.ValidatorIndex)
+		feeRecipients = append(feeRecipients, common.BytesToAddress(recipientContainer.FeeRecipient))
+		validatorIndices = append(validatorIndices, recipientContainer.ValidatorIndex)
+		recipientIndicesStrings += fmt.Sprintf("%d,", recipientContainer.ValidatorIndex)
 	}
-	if err := vs.V1Alpha1Server.BeaconDB.SaveFeeRecipientsByValidatorIDs(ctx, ValidatorIndices, FeeRecipients); err != nil {
+	if err := vs.V1Alpha1Server.BeaconDB.SaveFeeRecipientsByValidatorIDs(ctx, validatorIndices, feeRecipients); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not save fee recipients: %v", err)
 	}
+	log.WithFields(log.Fields{
+		"validatorIndices": recipientIndicesStrings,
+	}).Info("Updated fee recipient addresses for validator indices")
 	return &emptypb.Empty{}, nil
 }
 

--- a/beacon-chain/rpc/eth/validator/validator.go
+++ b/beacon-chain/rpc/eth/validator/validator.go
@@ -336,7 +336,6 @@ func (vs *Server) PrepareBeaconProposer(
 	defer span.End()
 	var feeRecipients []common.Address
 	var validatorIndices []types.ValidatorIndex
-	recipientIndicesStrings := ""
 	for _, recipientContainer := range request.Recipients {
 		recipient := hexutil.Encode(recipientContainer.FeeRecipient)
 		if !common.IsHexAddress(recipient) {
@@ -344,13 +343,12 @@ func (vs *Server) PrepareBeaconProposer(
 		}
 		feeRecipients = append(feeRecipients, common.BytesToAddress(recipientContainer.FeeRecipient))
 		validatorIndices = append(validatorIndices, recipientContainer.ValidatorIndex)
-		recipientIndicesStrings += fmt.Sprintf("%d,", recipientContainer.ValidatorIndex)
 	}
 	if err := vs.V1Alpha1Server.BeaconDB.SaveFeeRecipientsByValidatorIDs(ctx, validatorIndices, feeRecipients); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not save fee recipients: %v", err)
 	}
 	log.WithFields(log.Fields{
-		"validatorIndices": recipientIndicesStrings,
+		"validatorIndices": validatorIndices,
 	}).Info("Updated fee recipient addresses for validator indices")
 	return &emptypb.Empty{}, nil
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -125,19 +125,24 @@ func (vs *Server) PrepareBeaconProposer(
 ) (*emptypb.Empty, error) {
 	_, span := trace.StartSpan(ctx, "validator.PrepareBeaconProposer")
 	defer span.End()
-	var FeeRecipients []common.Address
-	var ValidatorIndices []types.ValidatorIndex
+	var feeRecipients []common.Address
+	var validatorIndices []types.ValidatorIndex
+	recipientIndicesStrings := ""
 	for _, recipientContainer := range request.Recipients {
 		recipient := hexutil.Encode(recipientContainer.FeeRecipient)
 		if !common.IsHexAddress(recipient) {
 			return nil, status.Errorf(codes.InvalidArgument, fmt.Sprintf("Invalid fee recipient address: %v", recipient))
 		}
-		FeeRecipients = append(FeeRecipients, common.BytesToAddress(recipientContainer.FeeRecipient))
-		ValidatorIndices = append(ValidatorIndices, recipientContainer.ValidatorIndex)
+		feeRecipients = append(feeRecipients, common.BytesToAddress(recipientContainer.FeeRecipient))
+		validatorIndices = append(validatorIndices, recipientContainer.ValidatorIndex)
+		recipientIndicesStrings += fmt.Sprintf("%d,", recipientContainer.ValidatorIndex)
 	}
-	if err := vs.BeaconDB.SaveFeeRecipientsByValidatorIDs(ctx, ValidatorIndices, FeeRecipients); err != nil {
+	if err := vs.BeaconDB.SaveFeeRecipientsByValidatorIDs(ctx, validatorIndices, feeRecipients); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not save fee recipients: %v", err)
 	}
+	log.WithFields(logrus.Fields{
+		"validatorIndices": recipientIndicesStrings,
+	}).Info("Updated fee recipient addresses for validator indices")
 	return &emptypb.Empty{}, nil
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -127,7 +127,6 @@ func (vs *Server) PrepareBeaconProposer(
 	defer span.End()
 	var feeRecipients []common.Address
 	var validatorIndices []types.ValidatorIndex
-	recipientIndicesStrings := ""
 	for _, recipientContainer := range request.Recipients {
 		recipient := hexutil.Encode(recipientContainer.FeeRecipient)
 		if !common.IsHexAddress(recipient) {
@@ -135,13 +134,12 @@ func (vs *Server) PrepareBeaconProposer(
 		}
 		feeRecipients = append(feeRecipients, common.BytesToAddress(recipientContainer.FeeRecipient))
 		validatorIndices = append(validatorIndices, recipientContainer.ValidatorIndex)
-		recipientIndicesStrings += fmt.Sprintf("%d,", recipientContainer.ValidatorIndex)
 	}
 	if err := vs.BeaconDB.SaveFeeRecipientsByValidatorIDs(ctx, validatorIndices, feeRecipients); err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not save fee recipients: %v", err)
 	}
 	log.WithFields(logrus.Fields{
-		"validatorIndices": recipientIndicesStrings,
+		"validatorIndices": validatorIndices,
 	}).Info("Updated fee recipient addresses for validator indices")
 	return &emptypb.Empty{}, nil
 }


### PR DESCRIPTION
This PR adds API middleware support for the fee recipient endpoint in Prysm for the standard API. This allows Prysm to support the API standard, which defines the endpoint using REST HTTP.

With this PR, one can now run:
```
curl -d '[{"fee_recipient": "0x9b984d5a03980d8dc0a24506c968465424c81dbe", "validator_index": 5}]' -X POST -H 'Content-Type: application/json' http://localhost:3500/eth/v1/validator/prepare_beacon_proposer
```
and it will update the fee recipients for execution payloads in Prysm