### PR TITLE
Call FCU on update head after process attestation

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -173,20 +173,21 @@ func (s *Service) spawnProcessAttestationsRoutine(stateFeed *event.Feed) {
 
 // This calls notify Forkchoice Update in the event that the head has changed
 func (s *Service) notifyEngineIfChangedHead(prevHead [32]byte) {
-	if s.headRoot() != prevHead {
-		finalized := s.store.FinalizedCheckpt()
-		if finalized == nil {
-			log.WithError(errNilFinalizedInStore).Error("could not get finalized checkpoint")
-			return
-		}
-		_, err := s.notifyForkchoiceUpdate(s.ctx,
-			s.headBlock().Block(),
-			s.headRoot(),
-			bytesutil.ToBytes32(finalized.Root),
-		)
-		if err != nil {
-			log.WithError(err).Error("could not notify forkchoice update")
-		}
+	if s.headRoot() == prevHead {
+		return
+	}
+	finalized := s.store.FinalizedCheckpt()
+	if finalized == nil {
+		log.WithError(errNilFinalizedInStore).Error("could not get finalized checkpoint")
+		return
+	}
+	_, err := s.notifyForkchoiceUpdate(s.ctx,
+		s.headBlock().Block(),
+		s.headRoot(),
+		bytesutil.ToBytes32(finalized.Root),
+	)
+	if err != nil {
+		log.WithError(err).Error("could not notify forkchoice update")
 	}
 }
 

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -161,8 +161,24 @@ func (s *Service) spawnProcessAttestationsRoutine(stateFeed *event.Feed) {
 					log.WithError(err).Errorf("Unable to get justified balances for root %v", justified.Root)
 					continue
 				}
+				prevHead := s.headRoot()
 				if err := s.updateHead(s.ctx, balances); err != nil {
 					log.WithError(err).Warn("Resolving fork due to new attestation")
+				}
+				if s.headRoot() != prevHead {
+					finalized := s.store.FinalizedCheckpt()
+					if finalized == nil {
+						log.WithError(errNilFinalizedInStore).Error("Could not get finalized checkpoint")
+						continue
+					}
+					_, err := s.notifyForkchoiceUpdate(s.ctx,
+						s.headBlock().Block(),
+						s.headRoot(),
+						bytesutil.ToBytes32(finalized.Root),
+					)
+					if err != nil {
+						log.WithError(err).Error("could not notify forkchoice update")
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Notify the engine if head is changed after processing attestations mid slot. This ensures that optimistic status of the head slot is correct 