### PR TITLE
Fee recipient flag rename for beacon node

### DIFF
--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -108,12 +108,12 @@ func configureInteropConfig(cliCtx *cli.Context) {
 }
 
 func configureExecutionSetting(cliCtx *cli.Context) error {
-	if !cliCtx.IsSet(flags.FeeRecipient.Name) {
+	if !cliCtx.IsSet(flags.SuggestedFeeRecipient.Name) {
 		return nil
 	}
 
 	c := params.BeaconConfig()
-	ha := cliCtx.String(flags.FeeRecipient.Name)
+	ha := cliCtx.String(flags.SuggestedFeeRecipient.Name)
 	if !common.IsHexAddress(ha) {
 		return fmt.Errorf("%s is not a valid fee recipient address", ha)
 	}

--- a/beacon-chain/node/config_test.go
+++ b/beacon-chain/node/config_test.go
@@ -90,19 +90,19 @@ func TestConfigureExecutionSetting(t *testing.T) {
 
 	app := cli.App{}
 	set := flag.NewFlagSet("test", 0)
-	set.String(flags.FeeRecipient.Name, "", "")
-	require.NoError(t, set.Set(flags.FeeRecipient.Name, "0xB"))
+	set.String(flags.SuggestedFeeRecipient.Name, "", "")
+	require.NoError(t, set.Set(flags.SuggestedFeeRecipient.Name, "0xB"))
 	cliCtx := cli.NewContext(&app, set, nil)
 	err := configureExecutionSetting(cliCtx)
 	require.ErrorContains(t, "0xB is not a valid fee recipient address", err)
 
-	require.NoError(t, set.Set(flags.FeeRecipient.Name, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+	require.NoError(t, set.Set(flags.SuggestedFeeRecipient.Name, "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
 	cliCtx = cli.NewContext(&app, set, nil)
 	err = configureExecutionSetting(cliCtx)
 	require.NoError(t, err)
 	assert.Equal(t, common.HexToAddress("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), params.BeaconConfig().DefaultFeeRecipient)
 
-	require.NoError(t, set.Set(flags.FeeRecipient.Name, "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+	require.NoError(t, set.Set(flags.SuggestedFeeRecipient.Name, "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
 	cliCtx = cli.NewContext(&app, set, nil)
 	err = configureExecutionSetting(cliCtx)
 	require.NoError(t, err)

--- a/cmd/beacon-chain/flags/BUILD.bazel
+++ b/cmd/beacon-chain/flags/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     ],
     deps = [
         "//cmd:go_default_library",
+        "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -3,9 +3,9 @@
 package flags
 
 import (
-	"encoding/hex"
 	"strings"
 
+	fieldparams "github.com/prysmaticlabs/prysm/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/config/params"
 	"github.com/urfave/cli/v2"
 )
@@ -219,7 +219,7 @@ var (
 	// SuggestedFeeRecipient specifies the fee recipient for the transaction fees.
 	SuggestedFeeRecipient = &cli.StringFlag{
 		Name:  "suggested-fee-recipient",
-		Usage: "Post bellatrix, this address will receive the transaction fees produced by any blocks from this node. Default to junk whilst bellatrix is in development state. Validator Client can override this value through the preparebeaconproposer api.",
-		Value: hex.EncodeToString([]byte("0x0000000000000000000000000000000000000001")),
+		Usage: "Post bellatrix, this address will receive the transaction fees produced by any blocks from this node. Default to junk whilst bellatrix is in development state. Validator client can override this value through the preparebeaconproposer api.",
+		Value: fieldparams.EthBurnAddressHex,
 	}
 )

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -216,10 +216,10 @@ var (
 		Usage: "Sets the minimum number of peers that a node will attempt to peer with that are subscribed to a subnet.",
 		Value: 6,
 	}
-	// FeeRecipient specifies the fee recipient for the transaction fees.
-	FeeRecipient = &cli.StringFlag{
-		Name:  "fee-recipient",
-		Usage: "Post bellatrix, this address will receive the transaction fees produced by any blocks from this node. Default to junk whilst bellatrix is in development state.",
+	// SuggestedFeeRecipient specifies the fee recipient for the transaction fees.
+	SuggestedFeeRecipient = &cli.StringFlag{
+		Name:  "suggested-fee-recipient",
+		Usage: "Post bellatrix, this address will receive the transaction fees produced by any blocks from this node. Default to junk whilst bellatrix is in development state. Validator Client can override this value through the preparebeaconproposer api.",
 		Value: hex.EncodeToString([]byte("0x0000000000000000000000000000000000000001")),
 	}
 )

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -67,7 +67,7 @@ var appFlags = []cli.Flag{
 	flags.Eth1HeaderReqLimit,
 	flags.GenesisStatePath,
 	flags.MinPeersPerSubnet,
-	flags.FeeRecipient,
+	flags.SuggestedFeeRecipient,
 	cmd.EnableBackupWebhookFlag,
 	cmd.BackupWebhookOutputDir,
 	cmd.MinimalConfigFlag,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -131,7 +131,7 @@ var appHelpFlagGroups = []flagGroup{
 	{
 		Name: "merge",
 		Flags: []cli.Flag{
-			flags.FeeRecipient,
+			flags.SuggestedFeeRecipient,
 		},
 	},
 	{


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

Part of #10292

**What does this PR do? Why is it needed?**
renames fee-recipient flag to suggested-fee-recipient to match the validator client's name for the flag, also switches to use the burn address constant.
