### PR TITLE
Fee Recipient : ux log fixes and prevent validator from calling beacon node if flags are not provided.

### DIFF
--- a/validator/accounts/testing/mock.go
+++ b/validator/accounts/testing/mock.go
@@ -179,7 +179,7 @@ func (_ MockValidator) CheckDoppelGanger(_ context.Context) error {
 	panic("implement me")
 }
 
-// PrepareBeaconProposer for mocking
+// UpdateFeeRecipient for mocking
 func (_ MockValidator) UpdateFeeRecipient(_ context.Context, _ keymanager.IKeymanager) error {
 	panic("implement me")
 }

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -48,53 +48,53 @@ type GenesisFetcher interface {
 // ValidatorService represents a service to manage the validator client
 // routine.
 type ValidatorService struct {
-	useWeb                      bool
-	emitAccountMetrics          bool
-	logValidatorBalances        bool
-	logDutyCountDown            bool
-	interopKeysConfig           *local.InteropKeymanagerConfig
-	conn                        *grpc.ClientConn
-	grpcRetryDelay              time.Duration
-	grpcRetries                 uint
-	maxCallRecvMsgSize          int
-	cancel                      context.CancelFunc
-	walletInitializedFeed       *event.Feed
-	wallet                      *wallet.Wallet
-	graffitiStruct              *graffiti.Graffiti
-	dataDir                     string
-	withCert                    string
-	endpoint                    string
-	ctx                         context.Context
-	validator                   iface.Validator
-	db                          db.Database
-	grpcHeaders                 []string
-	graffiti                    []byte
-	web3SignerConfig            *remote_web3signer.SetupConfig
-	prepareBeaconProposalConfig *validator_service_config.FeeRecipientConfig
+	useWeb                bool
+	emitAccountMetrics    bool
+	logValidatorBalances  bool
+	logDutyCountDown      bool
+	interopKeysConfig     *local.InteropKeymanagerConfig
+	conn                  *grpc.ClientConn
+	grpcRetryDelay        time.Duration
+	grpcRetries           uint
+	maxCallRecvMsgSize    int
+	cancel                context.CancelFunc
+	walletInitializedFeed *event.Feed
+	wallet                *wallet.Wallet
+	graffitiStruct        *graffiti.Graffiti
+	dataDir               string
+	withCert              string
+	endpoint              string
+	ctx                   context.Context
+	validator             iface.Validator
+	db                    db.Database
+	grpcHeaders           []string
+	graffiti              []byte
+	web3SignerConfig      *remote_web3signer.SetupConfig
+	feeRecipientConfig    *validator_service_config.FeeRecipientConfig
 }
 
 // Config for the validator service.
 type Config struct {
-	UseWeb                      bool
-	LogValidatorBalances        bool
-	EmitAccountMetrics          bool
-	LogDutyCountDown            bool
-	InteropKeysConfig           *local.InteropKeymanagerConfig
-	Wallet                      *wallet.Wallet
-	WalletInitializedFeed       *event.Feed
-	GrpcRetriesFlag             uint
-	GrpcMaxCallRecvMsgSizeFlag  int
-	GrpcRetryDelay              time.Duration
-	GraffitiStruct              *graffiti.Graffiti
-	Validator                   iface.Validator
-	ValDB                       db.Database
-	CertFlag                    string
-	DataDir                     string
-	GrpcHeadersFlag             string
-	GraffitiFlag                string
-	Endpoint                    string
-	Web3SignerConfig            *remote_web3signer.SetupConfig
-	PrepareBeaconProposalConfig *validator_service_config.FeeRecipientConfig
+	UseWeb                     bool
+	LogValidatorBalances       bool
+	EmitAccountMetrics         bool
+	LogDutyCountDown           bool
+	InteropKeysConfig          *local.InteropKeymanagerConfig
+	Wallet                     *wallet.Wallet
+	WalletInitializedFeed      *event.Feed
+	GrpcRetriesFlag            uint
+	GrpcMaxCallRecvMsgSizeFlag int
+	GrpcRetryDelay             time.Duration
+	GraffitiStruct             *graffiti.Graffiti
+	Validator                  iface.Validator
+	ValDB                      db.Database
+	CertFlag                   string
+	DataDir                    string
+	GrpcHeadersFlag            string
+	GraffitiFlag               string
+	Endpoint                   string
+	Web3SignerConfig           *remote_web3signer.SetupConfig
+	FeeRecipientConfig         *validator_service_config.FeeRecipientConfig
 }
 
 // NewValidatorService creates a new validator service for the service
@@ -102,28 +102,28 @@ type Config struct {
 func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	return &ValidatorService{
-		ctx:                         ctx,
-		cancel:                      cancel,
-		endpoint:                    cfg.Endpoint,
-		withCert:                    cfg.CertFlag,
-		dataDir:                     cfg.DataDir,
-		graffiti:                    []byte(cfg.GraffitiFlag),
-		logValidatorBalances:        cfg.LogValidatorBalances,
-		emitAccountMetrics:          cfg.EmitAccountMetrics,
-		maxCallRecvMsgSize:          cfg.GrpcMaxCallRecvMsgSizeFlag,
-		grpcRetries:                 cfg.GrpcRetriesFlag,
-		grpcRetryDelay:              cfg.GrpcRetryDelay,
-		grpcHeaders:                 strings.Split(cfg.GrpcHeadersFlag, ","),
-		validator:                   cfg.Validator,
-		db:                          cfg.ValDB,
-		wallet:                      cfg.Wallet,
-		walletInitializedFeed:       cfg.WalletInitializedFeed,
-		useWeb:                      cfg.UseWeb,
-		interopKeysConfig:           cfg.InteropKeysConfig,
-		graffitiStruct:              cfg.GraffitiStruct,
-		logDutyCountDown:            cfg.LogDutyCountDown,
-		web3SignerConfig:            cfg.Web3SignerConfig,
-		prepareBeaconProposalConfig: cfg.PrepareBeaconProposalConfig,
+		ctx:                   ctx,
+		cancel:                cancel,
+		endpoint:              cfg.Endpoint,
+		withCert:              cfg.CertFlag,
+		dataDir:               cfg.DataDir,
+		graffiti:              []byte(cfg.GraffitiFlag),
+		logValidatorBalances:  cfg.LogValidatorBalances,
+		emitAccountMetrics:    cfg.EmitAccountMetrics,
+		maxCallRecvMsgSize:    cfg.GrpcMaxCallRecvMsgSizeFlag,
+		grpcRetries:           cfg.GrpcRetriesFlag,
+		grpcRetryDelay:        cfg.GrpcRetryDelay,
+		grpcHeaders:           strings.Split(cfg.GrpcHeadersFlag, ","),
+		validator:             cfg.Validator,
+		db:                    cfg.ValDB,
+		wallet:                cfg.Wallet,
+		walletInitializedFeed: cfg.WalletInitializedFeed,
+		useWeb:                cfg.UseWeb,
+		interopKeysConfig:     cfg.InteropKeysConfig,
+		graffitiStruct:        cfg.GraffitiStruct,
+		logDutyCountDown:      cfg.LogDutyCountDown,
+		web3SignerConfig:      cfg.Web3SignerConfig,
+		feeRecipientConfig:    cfg.FeeRecipientConfig,
 	}, nil
 }
 
@@ -205,7 +205,7 @@ func (v *ValidatorService) Start() {
 		eipImportBlacklistedPublicKeys: slashablePublicKeys,
 		logDutyCountDown:               v.logDutyCountDown,
 		Web3SignerConfig:               v.web3SignerConfig,
-		prepareBeaconProposalConfig:    v.prepareBeaconProposalConfig,
+		feeRecipientConfig:             v.feeRecipientConfig,
 		walletIntializedChannel:        make(chan *wallet.Wallet, 1),
 	}
 	// To resolve a race condition at startup due to the interface

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -247,7 +247,7 @@ func (fv *FakeValidator) HandleKeyReload(_ context.Context, newKeys [][fieldpara
 func (_ *FakeValidator) SubmitSignedContributionAndProof(_ context.Context, _ types.Slot, _ [fieldparams.BLSPubkeyLength]byte) {
 }
 
-// PrepareBeaconProposer for mocking
+// UpdateFeeRecipient for mocking
 func (_ *FakeValidator) UpdateFeeRecipient(_ context.Context, _ keymanager.IKeymanager) error {
 	return nil
 }

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -939,7 +939,7 @@ func (v *validator) logDuties(slot types.Slot, duties []*ethpb.DutiesResponse_Du
 // UpdateFeeRecipient calls the prepareBeaconProposer RPC to set the fee recipient.
 func (v *validator) UpdateFeeRecipient(ctx context.Context, km keymanager.IKeymanager) error {
 	if v.feeRecipientConfig == nil {
-		log.Warnln("Fee recipient config not set, skipping fee recipient update. Beacon node will use its own configuration")
+		log.Warnln("Fee recipient config not set, skipping fee recipient update. Validator will continue proposing using beacon node specified fee recipient.")
 		return nil
 	}
 	if km == nil {

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -94,7 +94,7 @@ type validator struct {
 	graffiti                           []byte
 	voteStats                          voteStats
 	Web3SignerConfig                   *remote_web3signer.SetupConfig
-	prepareBeaconProposalConfig        *validator_service_config.FeeRecipientConfig
+	feeRecipientConfig                 *validator_service_config.FeeRecipientConfig
 	walletIntializedChannel            chan *wallet.Wallet
 }
 
@@ -938,6 +938,10 @@ func (v *validator) logDuties(slot types.Slot, duties []*ethpb.DutiesResponse_Du
 
 // UpdateFeeRecipient calls the prepareBeaconProposer RPC to set the fee recipient.
 func (v *validator) UpdateFeeRecipient(ctx context.Context, km keymanager.IKeymanager) error {
+	if v.feeRecipientConfig == nil {
+		log.Warnln("Fee recipient config not set, skipping fee recipient update. Beacon node will use its own configuration")
+		return nil
+	}
 	if km == nil {
 		return errors.New("keymanager is nil when calling PrepareBeaconProposer")
 	}
@@ -981,12 +985,12 @@ func (v *validator) feeRecipients(ctx context.Context, pubkeys [][fieldparams.BL
 			validatorIndex = ind
 			v.pubkeyToValidatorIndex[key] = validatorIndex
 		}
-		if v.prepareBeaconProposalConfig.ProposeConfig != nil {
-			option, ok := v.prepareBeaconProposalConfig.ProposeConfig[key]
+		if v.feeRecipientConfig.ProposeConfig != nil {
+			option, ok := v.feeRecipientConfig.ProposeConfig[key]
 			if option != nil && ok {
 				feeRecipient = option.FeeRecipient
 			} else {
-				feeRecipient = v.prepareBeaconProposalConfig.DefaultConfig.FeeRecipient
+				feeRecipient = v.feeRecipientConfig.DefaultConfig.FeeRecipient
 			}
 		}
 		validatorToFeeRecipientArray = append(validatorToFeeRecipientArray, &ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -364,7 +364,7 @@ func TestWaitMultipleActivation_LogsActivationEpochOK(t *testing.T) {
 		keyManager:             km,
 		genesisTime:            1,
 		pubkeyToValidatorIndex: map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex{pubKey: 1},
-		prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+		feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 			ProposeConfig: nil,
 			DefaultConfig: &validator_service_config.FeeRecipientOptions{
 				FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"),
@@ -408,7 +408,7 @@ func TestWaitActivation_NotAllValidatorsActivatedOK(t *testing.T) {
 		keyManager:             km,
 		genesisTime:            1,
 		pubkeyToValidatorIndex: map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex{pubKey: 1},
-		prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+		feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 			ProposeConfig: nil,
 			DefaultConfig: &validator_service_config.FeeRecipientOptions{
 				FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"),
@@ -1477,7 +1477,7 @@ func TestValidator_UdpateFeeRecipient(t *testing.T) {
 				require.NoError(t, err)
 				keys, err := km.FetchValidatingPublicKeys(ctx)
 				require.NoError(t, err)
-				v.prepareBeaconProposalConfig = &validator_service_config.FeeRecipientConfig{
+				v.feeRecipientConfig = &validator_service_config.FeeRecipientConfig{
 					ProposeConfig: nil,
 					DefaultConfig: &validator_service_config.FeeRecipientOptions{
 						FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -1490,6 +1490,25 @@ func TestValidator_UdpateFeeRecipient(t *testing.T) {
 					Index: 1,
 				}, nil)
 
+				return &v
+			},
+		},
+		{
+			name: " Skip if no config",
+			validatorSetter: func(t *testing.T) *validator {
+
+				v := validator{
+					validatorClient:        client,
+					db:                     db,
+					pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
+					useWeb:                 false,
+					interopKeysConfig: &local.InteropKeymanagerConfig{
+						NumValidatorKeys: 1,
+						Offset:           1,
+					},
+				}
+				err := v.WaitForKeymanagerInitialization(ctx)
+				require.NoError(t, err)
 				return &v
 			},
 		},
@@ -1509,7 +1528,7 @@ func TestValidator_UdpateFeeRecipient(t *testing.T) {
 				}
 				err := v.WaitForKeymanagerInitialization(ctx)
 				require.NoError(t, err)
-				v.prepareBeaconProposalConfig = &validator_service_config.FeeRecipientConfig{
+				v.feeRecipientConfig = &validator_service_config.FeeRecipientConfig{
 					ProposeConfig: nil,
 					DefaultConfig: &validator_service_config.FeeRecipientOptions{
 						FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -1558,7 +1577,7 @@ func TestValidator_UdpateFeeRecipient(t *testing.T) {
 				config[keys[0]] = &validator_service_config.FeeRecipientOptions{
 					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
 				}
-				v.prepareBeaconProposalConfig = &validator_service_config.FeeRecipientConfig{
+				v.feeRecipientConfig = &validator_service_config.FeeRecipientConfig{
 					ProposeConfig: config,
 					DefaultConfig: &validator_service_config.FeeRecipientOptions{
 						FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -1597,7 +1616,7 @@ func TestValidator_UdpateFeeRecipient(t *testing.T) {
 				config[keys[0]] = &validator_service_config.FeeRecipientOptions{
 					FeeRecipient: common.Address{},
 				}
-				v.prepareBeaconProposalConfig = &validator_service_config.FeeRecipientConfig{
+				v.feeRecipientConfig = &validator_service_config.FeeRecipientConfig{
 					ProposeConfig: config,
 					DefaultConfig: &validator_service_config.FeeRecipientOptions{
 						FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -1634,7 +1653,7 @@ func TestValidator_UdpateFeeRecipient(t *testing.T) {
 				config[keys[0]] = &validator_service_config.FeeRecipientOptions{
 					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
 				}
-				v.prepareBeaconProposalConfig = &validator_service_config.FeeRecipientConfig{
+				v.feeRecipientConfig = &validator_service_config.FeeRecipientConfig{
 					ProposeConfig: config,
 					DefaultConfig: &validator_service_config.FeeRecipientOptions{
 						FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),

--- a/validator/client/wait_for_activation.go
+++ b/validator/client/wait_for_activation.go
@@ -131,11 +131,11 @@ func (v *validator) waitForActivation(ctx context.Context, accountsChangedChan <
 
 				valActivated := v.checkAndLogValidatorStatus(statuses)
 				if valActivated {
+					logActiveValidatorStatus(statuses)
 					// Set properties on the beacon node like the fee recipient for validators that are being used & active.
 					if err := v.UpdateFeeRecipient(ctx, remoteKm); err != nil {
 						return err
 					}
-					logActiveValidatorStatus(statuses)
 				} else {
 					continue
 				}
@@ -179,11 +179,11 @@ func (v *validator) waitForActivation(ctx context.Context, accountsChangedChan <
 
 				valActivated := v.checkAndLogValidatorStatus(statuses)
 				if valActivated {
+					logActiveValidatorStatus(statuses)
 					// Set properties on the beacon node like the fee recipient for validators that are being used & active.
 					if err := v.UpdateFeeRecipient(ctx, v.keyManager); err != nil {
 						return err
 					}
-					logActiveValidatorStatus(statuses)
 				} else {
 					continue
 				}

--- a/validator/client/wait_for_activation_test.go
+++ b/validator/client/wait_for_activation_test.go
@@ -80,7 +80,7 @@ func TestWaitActivation_StreamSetupFails_AttemptsToReconnect(t *testing.T) {
 		validatorClient:        client,
 		keyManager:             km,
 		pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-		prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+		feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 			ProposeConfig: nil,
 			DefaultConfig: &validator_service_config.FeeRecipientOptions{
 				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -119,7 +119,7 @@ func TestWaitForActivation_ReceiveErrorFromStream_AttemptsReconnection(t *testin
 		validatorClient:        client,
 		keyManager:             km,
 		pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-		prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+		feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 			ProposeConfig: nil,
 			DefaultConfig: &validator_service_config.FeeRecipientOptions{
 				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -163,7 +163,7 @@ func TestWaitActivation_LogsActivationEpochOK(t *testing.T) {
 		keyManager:             km,
 		genesisTime:            1,
 		pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-		prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+		feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 			ProposeConfig: nil,
 			DefaultConfig: &validator_service_config.FeeRecipientOptions{
 				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -206,7 +206,7 @@ func TestWaitForActivation_Exiting(t *testing.T) {
 		keyManager:             km,
 		genesisTime:            1,
 		pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-		prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+		feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 			ProposeConfig: nil,
 			DefaultConfig: &validator_service_config.FeeRecipientOptions{
 				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -256,7 +256,7 @@ func TestWaitForActivation_RefetchKeys(t *testing.T) {
 		keyManager:             km,
 		genesisTime:            1,
 		pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-		prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+		feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 			ProposeConfig: nil,
 			DefaultConfig: &validator_service_config.FeeRecipientOptions{
 				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -308,7 +308,7 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 			keyManager:             km,
 			genesisTime:            1,
 			pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-			prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+			feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 				ProposeConfig: nil,
 				DefaultConfig: &validator_service_config.FeeRecipientOptions{
 					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -389,7 +389,7 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 			keyManager:             km,
 			genesisTime:            1,
 			pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-			prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+			feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 				ProposeConfig: nil,
 				DefaultConfig: &validator_service_config.FeeRecipientOptions{
 					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -477,7 +477,7 @@ func TestWaitForActivation_RemoteKeymanager(t *testing.T) {
 			keyManager:             &km,
 			ticker:                 ticker,
 			pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-			prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+			feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 				ProposeConfig: nil,
 				DefaultConfig: &validator_service_config.FeeRecipientOptions{
 					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
@@ -544,7 +544,7 @@ func TestWaitForActivation_RemoteKeymanager(t *testing.T) {
 			keyManager:             &remoteKm,
 			ticker:                 ticker,
 			pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-			prepareBeaconProposalConfig: &validator_service_config.FeeRecipientConfig{
+			feeRecipientConfig: &validator_service_config.FeeRecipientConfig{
 				ProposeConfig: nil,
 				DefaultConfig: &validator_service_config.FeeRecipientOptions{
 					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -447,7 +447,7 @@ func TestFeeRecipientConfig(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name: "Default Fee Recipient",
+			name: "No flags set means empty config",
 			args: args{
 				feeRecipientFlagValues: &feeRecipientFlag{
 					dir:        "",
@@ -456,12 +456,7 @@ func TestFeeRecipientConfig(t *testing.T) {
 				},
 			},
 			want: func() *validator_service_config.FeeRecipientConfig {
-				return &validator_service_config.FeeRecipientConfig{
-					ProposeConfig: nil,
-					DefaultConfig: &validator_service_config.FeeRecipientOptions{
-						FeeRecipient: common.HexToAddress("0x0000000000000000000000000000000000000000"),
-					},
-				}
+				return nil
 			},
 			wantErr: "",
 		},


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Bug fix

relates to #10404 
relates to #10292 
**What does this PR do? Why is it needed?**
This pr improves the user experience of logs for fee recipients as well as prevents the validator client from sending anything to the beacon node if no flags are used from the validator client. The beacon node will continue to run with its own fee recipient values.

