### PR TITLE
Ensure finalized root can't be zeros

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -199,7 +199,7 @@ func (s *Service) StartFromSavedState(saved state.BeaconState) error {
 		store = protoarray.New(justified.Epoch, finalized.Epoch, fRoot)
 	}
 	s.cfg.ForkChoiceStore = store
-	fb, err := s.cfg.BeaconDB.Block(s.ctx, fRoot)
+	fb, err := s.cfg.BeaconDB.Block(s.ctx, s.ensureRootNotZeros(fRoot))
 	if err != nil {
 		return errors.Wrap(err, "could not get finalized checkpoint block")
 	}


### PR DESCRIPTION
Before the first finalized epoch, the finalized root may be zeros in some places. This ensures that we don't pass in zeros to get the finalized block in DB 