### PR TITLE
Properly initialize replayer builder for rpc

### DIFF
--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -291,6 +291,7 @@ func (s *Service) Start() {
 			ChainInfoFetcher:   s.cfg.ChainInfoFetcher,
 			GenesisTimeFetcher: s.cfg.GenesisTimeFetcher,
 			StateGenService:    s.cfg.StateGen,
+			ReplayerBuilder:    ch,
 		},
 		HeadFetcher:             s.cfg.HeadFetcher,
 		VoluntaryExitsPool:      s.cfg.ExitPool,


### PR DESCRIPTION
Fixes the following panic

```
time="2022-03-24 20:05:16" level=error msg="gRPC panicked!" error="runtime error: invalid memory address or nil pointer dereference" stack="goroutine 903228 [running]:
runtime/debug.Stack()
	GOROOT/src/runtime/debug/stack.go:24 +0x65
github.com/prysmaticlabs/prysm/monitoring/tracing.RecoveryHandlerFunc({0xb17a98, 0xc0101cec90}, {0x3b8200, 0x2bfe9a0})
	monitoring/tracing/recovery_interceptor_option.go:29 +0x1f7
github.com/grpc-ecosystem/go-grpc-middleware/recovery.recoverFrom({0xb17a98, 0xc0101cec90}, {0x3b8200, 0x2bfe9a0}, 0xc005b8b3a8)
	external/com_github_grpc_ecosystem_go_grpc_middleware/recovery/interceptors.go:61 +0x36
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1.1()
	external/com_github_grpc_ecosystem_go_grpc_middleware/recovery/interceptors.go:29 +0x7b
panic({0x3b8200, 0x2bfe9a0})
	GOROOT/src/runtime/panic.go:1038 +0x215
github.com/prysmaticlabs/prysm/beacon-chain/rpc/statefetcher.(*StateProvider).StateBySlot(0xc00060c9b0, {0xb17a98, 0xc0101cef60}, 0x0)
	beacon-chain/rpc/statefetcher/fetcher.go:206 +0xe2
github.com/prysmaticlabs/prysm/beacon-chain/rpc/statefetcher.(*StateProvider).State(0xc00060c9b0, {0xb17a98, 0xc0101cef60}, {0xc00f75cc18, 0x1d, 0x8})
	beacon-chain/rpc/statefetcher/fetcher.go:139 +0x425
github.com/prysmaticlabs/prysm/beacon-chain/rpc/eth/beacon.(*Server).GetFinalityCheckpoints(0xc003f480e0, {0xb17a98, 0xc0101cef30}, 0xc014288fc0)
	beacon-chain/rpc/eth/beacon/state.go:118 +0x10b
github.com/prysmaticlabs/prysm/proto/eth/service._BeaconChain_GetFinalityCheckpoints_Handler.func1({0xb17a98, 0xc0101cef30}, {0x475080, 0xc014288fc0})
	bazel-out/k8-opt/bin/proto/eth/service/go_proto_/github.com/prysmaticlabs/prysm/proto/eth/service/beacon_chain_service.pb.go:1001 +0x78
github.com/prysmaticlabs/prysm/beacon-chain/rpc.(*Service).validatorUnaryConnectionInterceptor(0xc0101cec90, {0xb17a98, 0xc0101cef30}, {0x475080, 0xc014288fc0}, 0xae4520, 0xc00f76e3a8)
	beacon-chain/rpc/service.go:387 +0x50
```