### PR TITLE
Do Not Run Transition Configuration Check if Bellatrix Is Unset

### DIFF
--- a/beacon-chain/powchain/check_transition_config.go
+++ b/beacon-chain/powchain/check_transition_config.go
@@ -3,6 +3,7 @@ package powchain
 import (
 	"context"
 	"errors"
+	"math"
 	"math/big"
 	"time"
 
@@ -24,6 +25,10 @@ var (
 // If there are any discrepancies, we must log errors to ensure users can resolve
 //the problem and be ready for the merge transition.
 func (s *Service) checkTransitionConfiguration(ctx context.Context) {
+	// If Bellatrix fork epoch is not set, we do not run this check.
+	if params.BeaconConfig().BellatrixForkEpoch == math.MaxUint64 {
+		return
+	}
 	if s.engineAPIClient == nil {
 		return
 	}

--- a/beacon-chain/powchain/check_transition_config_test.go
+++ b/beacon-chain/powchain/check_transition_config_test.go
@@ -8,11 +8,17 @@ import (
 
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/powchain/engine-api-client/v1"
 	"github.com/prysmaticlabs/prysm/beacon-chain/powchain/engine-api-client/v1/mocks"
+	"github.com/prysmaticlabs/prysm/config/params"
 	"github.com/prysmaticlabs/prysm/testing/require"
 	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func Test_checkTransitionConfiguration(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	cfg := params.BeaconConfig().Copy()
+	cfg.BellatrixForkEpoch = 0
+	params.OverrideBeaconConfig(cfg)
+
 	ctx := context.Background()
 	hook := logTest.NewGlobal()
 


### PR DESCRIPTION
This PR prevents running transition configuration checks if the Bellatrix epoch is not yet set in our configuration