### PR TITLE
Revert "Use --http-web3provider for Execution Engine Connection"

### DIFF
--- a/beacon-chain/powchain/options.go
+++ b/beacon-chain/powchain/options.go
@@ -32,6 +32,14 @@ func WithHttpEndpoints(endpointStrings []string) Option {
 	}
 }
 
+// WithExecutionEndpoint for the execution node JSON-RPC endpoint.
+func WithExecutionEndpoint(endpoint string) Option {
+	return func(s *Service) error {
+		s.cfg.executionEndpoint = endpoint
+		return nil
+	}
+}
+
 // WithExecutionClientJWTSecret for authenticating the execution node JSON-RPC endpoint.
 func WithExecutionClientJWTSecret(jwtSecret []byte) Option {
 	return func(s *Service) error {

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -135,6 +135,7 @@ type config struct {
 	eth1HeaderReqLimit         uint64
 	beaconNodeStatsUpdater     BeaconNodeStatsUpdater
 	httpEndpoints              []network.Endpoint
+	executionEndpoint          string
 	executionEndpointJWTSecret []byte
 	currHttpEndpoint           network.Endpoint
 	finalizedStateAtStartup    state.BeaconState
@@ -212,6 +213,13 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		}
 	}
 
+	if err := s.initializeEngineAPIClient(ctx); err != nil {
+		return nil, errors.Wrap(err, "unable to initialize engine API client")
+	}
+
+	// Check transition configuration for the engine API client in the background.
+	go s.checkTransitionConfiguration(ctx)
+
 	if err := s.ensureValidPowchainData(ctx); err != nil {
 		return nil, errors.Wrap(err, "unable to validate powchain data")
 	}
@@ -246,14 +254,6 @@ func (s *Service) Start() {
 	if s.cfg.currHttpEndpoint.Url == "" {
 		return
 	}
-
-	if err := s.initializeEngineAPIClient(s.ctx); err != nil {
-		log.WithError(err).Fatal("unable to initialize engine API client")
-	}
-
-	// Check transition configuration for the engine API client in the background.
-	go s.checkTransitionConfiguration(s.ctx)
-
 	go func() {
 		s.isRunning = true
 		s.waitForConnection()
@@ -1058,10 +1058,13 @@ func (s *Service) ensureValidPowchainData(ctx context.Context) error {
 
 // Initializes a connection to the engine API if an execution provider endpoint is set.
 func (s *Service) initializeEngineAPIClient(ctx context.Context) error {
+	if s.cfg.executionEndpoint == "" {
+		return nil
+	}
 	opts := []engine.Option{
 		engine.WithJWTSecret(s.cfg.executionEndpointJWTSecret),
 	}
-	client, err := engine.New(ctx, s.cfg.currHttpEndpoint.Url, opts...)
+	client, err := engine.New(ctx, s.cfg.executionEndpoint, opts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -17,6 +17,12 @@ var (
 		Usage: "A mainchain web3 provider string http endpoint. Can contain auth header as well in the format --http-web3provider=\"https://goerli.infura.io/v3/xxxx,Basic xxx\" for project secret (base64 encoded) and --http-web3provider=\"https://goerli.infura.io/v3/xxxx,Bearer xxx\" for jwt use",
 		Value: "",
 	}
+	// ExecutionProvider provides an HTTP or IPC access endpoint to an ETH execution node.
+	ExecutionProviderFlag = &cli.StringFlag{
+		Name:  "execution-provider",
+		Usage: "An http endpoint for an Ethereum execution node",
+		Value: "",
+	}
 	// ExecutionJWTSecretFlag provides a path to a file containing a hex-encoded string representing a 32 byte secret
 	// used to authenticate with an execution node via HTTP. This is required if using an HTTP connection, otherwise all requests
 	// to execution nodes for consensus-related calls will fail. This is not required if using an IPC connection.

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -33,6 +33,7 @@ import (
 var appFlags = []cli.Flag{
 	flags.DepositContractFlag,
 	flags.HTTPWeb3ProviderFlag,
+	flags.ExecutionProviderFlag,
 	flags.ExecutionJWTSecretFlag,
 	flags.FallbackWeb3ProviderFlag,
 	flags.RPCHost,

--- a/cmd/beacon-chain/powchain/options.go
+++ b/cmd/beacon-chain/powchain/options.go
@@ -18,6 +18,7 @@ var log = logrus.WithField("prefix", "cmd-powchain")
 // FlagOptions for powchain service flag configurations.
 func FlagOptions(c *cli.Context) ([]powchain.Option, error) {
 	endpoints := parsePowchainEndpoints(c)
+	executionEndpoint := parseExecutionEndpoint(c)
 	jwtSecret, err := parseJWTSecretFromFile(c)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not read JWT secret file for authenticating execution API")
@@ -25,6 +26,9 @@ func FlagOptions(c *cli.Context) ([]powchain.Option, error) {
 	opts := []powchain.Option{
 		powchain.WithHttpEndpoints(endpoints),
 		powchain.WithEth1HeaderRequestLimit(c.Uint64(flags.Eth1HeaderReqLimit.Name)),
+	}
+	if executionEndpoint != "" {
+		opts = append(opts, powchain.WithExecutionEndpoint(executionEndpoint))
 	}
 	if len(jwtSecret) > 0 {
 		opts = append(opts, powchain.WithExecutionClientJWTSecret(jwtSecret))
@@ -80,4 +84,8 @@ func parsePowchainEndpoints(c *cli.Context) []string {
 	endpoints := []string{c.String(flags.HTTPWeb3ProviderFlag.Name)}
 	endpoints = append(endpoints, c.StringSlice(flags.FallbackWeb3ProviderFlag.Name)...)
 	return endpoints
+}
+
+func parseExecutionEndpoint(c *cli.Context) string {
+	return c.String(flags.ExecutionProviderFlag.Name)
 }

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -107,6 +107,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.GRPCGatewayPort,
 			flags.GPRCGatewayCorsDomain,
 			flags.HTTPWeb3ProviderFlag,
+			flags.ExecutionProviderFlag,
 			flags.ExecutionJWTSecretFlag,
 			flags.FallbackWeb3ProviderFlag,
 			flags.SetGCPercent,


### PR DESCRIPTION
Reverts prysmaticlabs/prysm#10307

Two issues:
```
- run time panic: 
github.com/prysmaticlabs/prysm/beacon-chain/blockchain.(*Service).notifyNewPayload(0xc0009949a0, {0x5a8ed98, 0xc0006c6390}, 0x2, 0x2, 0xc00a59ca50, 0xc00a59ca00, {0x5abff70, 0xc00a8cf5e0}, {0xde, ...})
```
- auth stops working:
```
time="2022-03-25 15:51:49" level=debug msg="Trying to dial endpoint: http://127.0.0.1:8551" prefix=powchain
time="2022-03-25 15:51:49" level=error msg="Could not connect to powchain endpoint: could not dial eth1 nodes: 403 Forbidden: missing token
" prefix=powchain
```

#10433 attempted to fix it but ran into the same auth issue and test issues. Let's revert this for now and review and test it thoroughly with the new one