### PR TITLE
Remove Ristretto Cache For Public Keys

### DIFF
--- a/crypto/bls/blst/BUILD.bazel
+++ b/crypto/bls/blst/BUILD.bazel
@@ -125,6 +125,7 @@ go_library(
             "//config/fieldparams:go_default_library",
             "//config/params:go_default_library",
             "//crypto/rand:go_default_library",
+            "//cache/lru:go_default_library",
             "@com_github_dgraph_io_ristretto//:go_default_library",
             "@com_github_pkg_errors//:go_default_library",
             "@com_github_supranational_blst//:go_default_library",
@@ -227,7 +228,7 @@ go_test(
     deps = [
         ":go_default_library",
         "//crypto/bls/common:go_default_library",
-        "//encoding/bytesutil:go_default_library",
         "//crypto/hash:go_default_library",
+        "//encoding/bytesutil:go_default_library",
     ],
 )


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

The ristretto Cache requires strings as keys, this requires an expensive byte to string conversion each time we want to retrieve the decompressed public key. This PR uses an LRU cache instead and uses the public key in its `[48]byte` form as the key. This has a few advantages, we don't have to allocate a public key string each time we want to access the decompressed public key. 

This is done by taking advantage of a new addition in go 1.17 which allows us to cast an array from a slice provided the slice is of the appropriate size. This is checked at the start of the function, where we make sure that the slice is of the correct size. Given that doing this is essentially zero-cost, this is more memory efficient compared to our current method.
 
**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
