### PR TITLE
Add Balance Read Lock When Aggregating Validator Metrics

### DIFF
--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -447,10 +447,12 @@ func (v *validator) UpdateLogAggregateStats(resp *ethpb.ValidatorPerformanceResp
 	log.WithFields(epochSummaryFields).Info("Previous epoch aggregated voting summary")
 
 	var totalStartBal, totalPrevBal uint64
+	v.prevBalanceLock.RLock()
 	for i, val := range v.startBalances {
 		totalStartBal += val
 		totalPrevBal += v.prevBalance[i]
 	}
+	v.prevBalanceLock.RUnlock()
 
 	if totalStartBal == 0 || summary.totalAttestedCount == 0 {
 		log.Error("Failed to print launch summary: one or more divisors is 0")


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Adds in a read lock to prevent multiple routines from accessing our `prevBalance` map for both reading and writing.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
