### PR TITLE
Log terminal total difficulty status

### DIFF
--- a/beacon-chain/powchain/BUILD.bazel
+++ b/beacon-chain/powchain/BUILD.bazel
@@ -120,6 +120,7 @@ go_test(
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_ethereum_go_ethereum//core/types:go_default_library",
         "@com_github_ethereum_go_ethereum//trie:go_default_library",
+        "@com_github_holiman_uint256//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/powchain/check_transition_config.go
+++ b/beacon-chain/powchain/check_transition_config.go
@@ -120,6 +120,9 @@ func (s *Service) logTtdStatus(ctx context.Context, ttd *uint256.Int) (bool, err
 	if err != nil {
 		return false, err
 	}
+	if latest == nil {
+		return false, errors.New("latest block is nil")
+	}
 	latestTtd, err := hexutil.DecodeBig(latest.TotalDifficulty)
 	if err != nil {
 		return false, err

--- a/beacon-chain/powchain/check_transition_config.go
+++ b/beacon-chain/powchain/check_transition_config.go
@@ -11,7 +11,7 @@ import (
 	"github.com/holiman/uint256"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
-	enginev1 "github.com/prysmaticlabs/prysm/beacon-chain/powchain/engine-api-client/v1"
+	v1 "github.com/prysmaticlabs/prysm/beacon-chain/powchain/engine-api-client/v1"
 	"github.com/prysmaticlabs/prysm/config/params"
 	pb "github.com/prysmaticlabs/prysm/proto/engine/v1"
 	"github.com/sirupsen/logrus"
@@ -81,7 +81,7 @@ func (s *Service) checkTransitionConfiguration(
 				return
 			}
 		case tm := <-ticker.C:
-			ctx, cancel := context.WithDeadline(ctx, tm.Add(enginev1.DefaultTimeout))
+			ctx, cancel := context.WithDeadline(ctx, tm.Add(v1.DefaultTimeout))
 			err = s.engineAPIClient.ExchangeTransitionConfiguration(ctx, cfg)
 			s.handleExchangeConfigurationError(err)
 			if !hasTtdReached {

--- a/beacon-chain/powchain/check_transition_config.go
+++ b/beacon-chain/powchain/check_transition_config.go
@@ -128,8 +128,8 @@ func (s *Service) logTtdStatus(ctx context.Context, ttd *uint256.Int) (bool, err
 		return true, nil
 	}
 	log.WithFields(logrus.Fields{
-		"latestTTD":     latestTtd.String(),
-		"transitionTTD": ttd.ToBig().String(),
-	}).Info("Total terminal difficulty has not been reached yet")
+		"latestDifficulty":   latestTtd.String(),
+		"terminalDifficulty": ttd.ToBig().String(),
+	}).Info("terminal difficulty has not been reached yet")
 	return false, nil
 }

--- a/beacon-chain/powchain/check_transition_config.go
+++ b/beacon-chain/powchain/check_transition_config.go
@@ -7,12 +7,14 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/holiman/uint256"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
 	v1 "github.com/prysmaticlabs/prysm/beacon-chain/powchain/engine-api-client/v1"
 	"github.com/prysmaticlabs/prysm/config/params"
 	pb "github.com/prysmaticlabs/prysm/proto/engine/v1"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -58,6 +60,7 @@ func (s *Service) checkTransitionConfiguration(
 	// This serves as a heartbeat to ensure the execution client and Prysm are ready for the
 	// Bellatrix hard-fork transition.
 	ticker := time.NewTicker(checkTransitionPollingInterval)
+	hasTtdReached := false
 	defer ticker.Stop()
 	sub := s.cfg.stateNotifier.StateFeed().Subscribe(blockNotifications)
 	defer sub.Unsubscribe()
@@ -80,6 +83,12 @@ func (s *Service) checkTransitionConfiguration(
 		case <-ticker.C:
 			err = s.engineAPIClient.ExchangeTransitionConfiguration(ctx, cfg)
 			s.handleExchangeConfigurationError(err)
+			if !hasTtdReached {
+				hasTtdReached, err = s.logTtdStatus(ctx, ttd)
+				if err != nil {
+					log.WithError(err).Error("Could not log ttd status")
+				}
+			}
 		}
 	}
 }
@@ -103,4 +112,24 @@ func (s *Service) handleExchangeConfigurationError(err error) {
 		return
 	}
 	log.WithError(err).Error("Could not check configuration values between execution and consensus client")
+}
+
+// Logs the terminal total difficulty status.
+func (s *Service) logTtdStatus(ctx context.Context, ttd *uint256.Int) (bool, error) {
+	latest, err := s.engineAPIClient.LatestExecutionBlock(ctx)
+	if err != nil {
+		return false, err
+	}
+	latestTtd, err := hexutil.DecodeBig(latest.TotalDifficulty)
+	if err != nil {
+		return false, err
+	}
+	if latestTtd.Cmp(ttd.ToBig()) >= 0 {
+		return true, nil
+	}
+	log.WithFields(logrus.Fields{
+		"latestTTD":     latestTtd.String(),
+		"transitionTTD": ttd.ToBig().String(),
+	}).Info("Total terminal difficulty has not been reached yet")
+	return false, nil
 }


### PR DESCRIPTION
Logs terminal total difficulty status on per `checkTransitionPollingInterval`. This is useful to find out how far we are away from reaching the terminal total difficulty 

```
[2022-03-30 09:06:10]  INFO powchain: Total terminal difficulty has not been reached yet latestTTD=6 transitionTTD=10
```