### PR TITLE
Fix execution block's base fee endianness marshal/unmarshal

### DIFF
--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -74,7 +74,7 @@ func (e *ExecutionBlock) MarshalJSON() ([]byte, error) {
 	size := new(big.Int).SetBytes(e.Size)
 	sizeHex := hexutil.EncodeBig(size)
 
-	baseFee := new(big.Int).SetBytes(e.BaseFeePerGas)
+	baseFee := new(big.Int).SetBytes(bytesutil.ReverseByteOrder(e.BaseFeePerGas))
 	baseFeeHex := hexutil.EncodeBig(baseFee)
 	return json.Marshal(executionBlockJSON{
 		Number:           numHex,
@@ -143,7 +143,7 @@ func (e *ExecutionBlock) UnmarshalJSON(enc []byte) error {
 	if err != nil {
 		return err
 	}
-	e.BaseFeePerGas = baseFee.Bytes()
+	e.BaseFeePerGas = bytesutil.PadTo(bytesutil.ReverseByteOrder(baseFee.Bytes()), fieldparams.RootLength)
 	transactions := make([][]byte, len(dec.Transactions))
 	for i, tx := range dec.Transactions {
 		transactions[i] = tx

--- a/proto/engine/v1/json_marshal_unmarshal_test.go
+++ b/proto/engine/v1/json_marshal_unmarshal_test.go
@@ -123,6 +123,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		require.DeepEqual(t, [][]byte{[]byte("hi")}, payloadPb.Transactions)
 	})
 	t.Run("execution block", func(t *testing.T) {
+		baseFeePerGas := big.NewInt(1770307273)
 		jsonPayload := &enginev1.ExecutionBlock{
 			Number:           []byte("100"),
 			Hash:             []byte("hash"),
@@ -138,7 +139,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 			GasLimit:         3,
 			GasUsed:          4,
 			Timestamp:        5,
-			BaseFeePerGas:    bytesutil.PadTo([]byte{1, 2, 3, 4}, fieldparams.RootLength),
+			BaseFeePerGas:    baseFeePerGas.Bytes(),
 			Size:             []byte("7"),
 			ExtraData:        []byte("extraData"),
 			MixHash:          []byte("mixHash"),
@@ -164,7 +165,7 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 		require.DeepEqual(t, uint64(3), payloadPb.GasLimit)
 		require.DeepEqual(t, uint64(4), payloadPb.GasUsed)
 		require.DeepEqual(t, uint64(5), payloadPb.Timestamp)
-		require.DeepEqual(t, bytesutil.PadTo([]byte{1, 2, 3, 4}, fieldparams.RootLength), payloadPb.BaseFeePerGas)
+		require.DeepEqual(t, bytesutil.PadTo(baseFeePerGas.Bytes(), fieldparams.RootLength), payloadPb.BaseFeePerGas)
 		require.DeepEqual(t, []byte("7"), payloadPb.Size)
 		require.DeepEqual(t, []byte("extraData"), payloadPb.ExtraData)
 		require.DeepEqual(t, []byte("mixHash"), payloadPb.MixHash)


### PR DESCRIPTION
Execution block's base fee per gas marshal / unmarshal uses the incorrect endianness. This PR fixes it and improves upon the test