### PR TITLE
Spectest: Improve test size and timeouts

### DIFF
--- a/testing/spectest/mainnet/altair/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/finality/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     size = "medium",
+    timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",
@@ -10,5 +11,4 @@ go_test(
     shard_count = 4,
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/altair/finality:go_default_library"],
-    timeout = "short",
 )

--- a/testing/spectest/mainnet/altair/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/finality/BUILD.bazel
@@ -10,4 +10,5 @@ go_test(
     shard_count = 4,
     tags = ["spectest"],
     deps = ["//testing/spectest/shared/altair/finality:go_default_library"],
+    timeout = "short",
 )

--- a/testing/spectest/mainnet/altair/fork_transition/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/fork_transition/BUILD.bazel
@@ -2,6 +2,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
+    timeout = "short",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/testing/spectest/mainnet/altair/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/forkchoice/BUILD.bazel
@@ -2,6 +2,8 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
+    size = "enormous",
+    timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",
@@ -12,6 +14,4 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
-    size = "enormous",
-    timeout = "short",
 )

--- a/testing/spectest/mainnet/altair/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/forkchoice/BUILD.bazel
@@ -12,4 +12,6 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
+    size = "enormous",
+    timeout = "short",
 )

--- a/testing/spectest/mainnet/altair/random/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/random/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     size = "medium",
+    timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/testing/spectest/mainnet/altair/sanity/BUILD.bazel
+++ b/testing/spectest/mainnet/altair/sanity/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     size = "medium",
+    timeout = "short",
     srcs = [
         "blocks_test.go",
         "sanity_test.go",

--- a/testing/spectest/mainnet/bellatrix/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/finality/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     size = "medium",
+    timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/testing/spectest/mainnet/bellatrix/fork_transition/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/fork_transition/BUILD.bazel
@@ -2,6 +2,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["transition_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/testing/spectest/mainnet/bellatrix/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/forkchoice/BUILD.bazel
@@ -2,6 +2,8 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
+    size = "enormous",
+    timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",
@@ -12,6 +14,4 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
-        size = "enormous",
-    timeout = "short",
 )

--- a/testing/spectest/mainnet/bellatrix/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/forkchoice/BUILD.bazel
@@ -12,4 +12,6 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
+        size = "enormous",
+    timeout = "short",
 )

--- a/testing/spectest/mainnet/bellatrix/sanity/BUILD.bazel
+++ b/testing/spectest/mainnet/bellatrix/sanity/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     size = "medium",
+    timeout = "short",
     srcs = [
         "blocks_test.go",
         "slots_test.go",

--- a/testing/spectest/mainnet/phase0/finality/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/finality/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     size = "medium",
+    timeout = "short",
     srcs = ["finality_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/testing/spectest/mainnet/phase0/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/forkchoice/BUILD.bazel
@@ -2,6 +2,8 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
+    size = "enormous",
+    timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",
@@ -12,6 +14,4 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
-    size = "enormous",
-    timeout = "short",
 )

--- a/testing/spectest/mainnet/phase0/forkchoice/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/forkchoice/BUILD.bazel
@@ -12,4 +12,6 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
+    size = "enormous",
+    timeout = "short",
 )

--- a/testing/spectest/mainnet/phase0/random/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/random/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     size = "medium",
+    timeout = "short",
     srcs = ["random_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/testing/spectest/mainnet/phase0/sanity/BUILD.bazel
+++ b/testing/spectest/mainnet/phase0/sanity/BUILD.bazel
@@ -3,6 +3,7 @@ load("@prysm//tools/go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     size = "medium",
+    timeout = "short",
     srcs = [
         "blocks_test.go",
         "sanity_test.go",

--- a/testing/spectest/minimal/altair/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/altair/forkchoice/BUILD.bazel
@@ -16,4 +16,6 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
+    size = "enormous",
+    timeout = "short",
 )

--- a/testing/spectest/minimal/altair/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/altair/forkchoice/BUILD.bazel
@@ -2,6 +2,8 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
+    size = "enormous",
+    timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_minimal//:test_data",
@@ -16,6 +18,4 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
-    size = "enormous",
-    timeout = "short",
 )

--- a/testing/spectest/minimal/bellatrix/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/forkchoice/BUILD.bazel
@@ -16,4 +16,6 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
+    size = "enormous",
+    timeout = "short",
 )

--- a/testing/spectest/minimal/bellatrix/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/bellatrix/forkchoice/BUILD.bazel
@@ -2,6 +2,8 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
+    size = "enormous",
+    timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_minimal//:test_data",
@@ -16,6 +18,4 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
-    size = "enormous",
-    timeout = "short",
 )

--- a/testing/spectest/minimal/phase0/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/phase0/forkchoice/BUILD.bazel
@@ -16,4 +16,6 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
+    size = "enormous",
+    timeout = "short",
 )

--- a/testing/spectest/minimal/phase0/forkchoice/BUILD.bazel
+++ b/testing/spectest/minimal/phase0/forkchoice/BUILD.bazel
@@ -2,6 +2,8 @@ load("@prysm//tools/go:def.bzl", "go_test")
 
 go_test(
     name = "go_default_test",
+    size = "enormous",
+    timeout = "short",
     srcs = ["forkchoice_test.go"],
     data = glob(["*.yaml"]) + [
         "@consensus_spec_tests_minimal//:test_data",
@@ -16,6 +18,4 @@ go_test(
         "//runtime/version:go_default_library",
         "//testing/spectest/shared/common/forkchoice:go_default_library",
     ],
-    size = "enormous",
-    timeout = "short",
 )

--- a/testing/spectest/shared/common/ssz_static/BUILD.bazel
+++ b/testing/spectest/shared/common/ssz_static/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
+    size = "small",
     srcs = ["ssz_static_example_test.go"],
     deps = [
         ":go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Marking forkchoice tests as "enormous" so that bazel knows these tests need at least 800mb of RAM. This will allow bazel to better schedule jobs on the host machine. I.e. if the host only has 2Gb of RAM, but 8 cores CPU then it would only schedule at most 3 enormous jobs in parallel.

This may result in slightly longer CI runs but the overall flakes should be reduced.

**Which issues(s) does this PR fix?**

**Other notes for review**
