### PR TITLE
Add transition blk proposer preparation

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -49,7 +49,6 @@ func (vs *Server) getExecutionPayload(ctx context.Context, slot types.Slot, vIdx
 		payloadIDCacheHit.Inc()
 		return vs.ExecutionEngineCaller.GetPayload(ctx, pid)
 	}
-	payloadIDCacheMiss.Inc()
 
 	st, err := vs.HeadFetcher.HeadState(ctx)
 	if err != nil {
@@ -85,6 +84,7 @@ func (vs *Server) getExecutionPayload(ctx context.Context, slot types.Slot, vIdx
 			return emptyPayload(), nil
 		}
 	}
+	payloadIDCacheMiss.Inc()
 
 	t, err := slots.ToTime(st.GenesisTime(), slot)
 	if err != nil {


### PR DESCRIPTION
Today prysm provides advance notice to EE when it knows it has a validator that will produce a block in the next slot. This ensures the EE has enough time to build a payload with a desirable set of transactions to maximize profit. 

This edge case only applies to the transition terminal block. If the terminal block has been found, we should use the exact mechanism to notify the EE where `headBlockHash` is the terminal block hash. 

This is not critical, but it's about rewards, so we should take it seriously.