### PR TITLE
Fix Nasty Finalization Bug

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "//config/params:go_default_library",
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//math:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/eth/v1:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Previously we were inserting deposits into our finalized trie via our deposit count(voted eth1data) instead of the eth1 deposit index in the state. The side effect of this is that when we do try to fetch non-finalized deposits for our trie we end up using the wrong merkle index, which leads to us fetching insufficient deposits in order to complete the whole trie in the event our deposit count(from voted eth1data) does not match up with the eth1 deposit index in the state. This can lead to proposers rebuilding the trie in periods where there are a lot of large amount of deposits being added in.

**Which issues(s) does this PR fix?**

Fixes #10156 and Resolves #10120

**Other notes for review**
