### PR TITLE
Update golang to 1.18.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -176,7 +176,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.17.6",
+    go_version = "1.18.1",
     nogo = "@//:nogo",
 )
 


### PR DESCRIPTION
New security fix: https://groups.google.com/g/golang-announce/c/vtbMjE04kPk/m/xE-FGxCXCAAJ