### PR TITLE
Add: wss payload block hash as last default

### DIFF
--- a/beacon-chain/blockchain/optimistic_sync_test.go
+++ b/beacon-chain/blockchain/optimistic_sync_test.go
@@ -807,6 +807,7 @@ func TestService_getFinalizedPayloadHash(t *testing.T) {
 	b := util.NewBeaconBlockBellatrix()
 	b.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("hi"), 32)
 	blk, err := wrapper.WrappedSignedBeaconBlock(b)
+	require.NoError(t, err)
 	r, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	require.NoError(t, service.cfg.BeaconDB.SaveBlock(ctx, blk))
@@ -818,6 +819,7 @@ func TestService_getFinalizedPayloadHash(t *testing.T) {
 	b = util.NewBeaconBlockBellatrix()
 	b.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("hello"), 32)
 	blk, err = wrapper.WrappedSignedBeaconBlock(b)
+	require.NoError(t, err)
 	r, err = b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	service.initSyncBlocks[r] = blk
@@ -829,6 +831,7 @@ func TestService_getFinalizedPayloadHash(t *testing.T) {
 	b = util.NewBeaconBlockBellatrix()
 	b.Block.Body.ExecutionPayload.BlockHash = bytesutil.PadTo([]byte("howdy"), 32)
 	blk, err = wrapper.WrappedSignedBeaconBlock(b)
+	require.NoError(t, err)
 	r, err = b.Block.HashTreeRoot()
 	require.NoError(t, err)
 	require.NoError(t, service.cfg.BeaconDB.SaveBlock(ctx, blk))
@@ -839,7 +842,7 @@ func TestService_getFinalizedPayloadHash(t *testing.T) {
 
 	// None of the above should error
 	require.NoError(t, service.cfg.BeaconDB.SaveOriginCheckpointBlockRoot(ctx, [32]byte{'a'}))
-	r, err = service.getFinalizedPayloadHash(ctx, [32]byte{'a'})
+	_, err = service.getFinalizedPayloadHash(ctx, [32]byte{'a'})
 	require.ErrorContains(t, "does not exist in the db or our cache", err)
 }
 

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -105,6 +105,7 @@ type HeadAccessDatabase interface {
 
 	// initialization method needed for origin checkpoint sync
 	SaveOrigin(ctx context.Context, serState, serBlock []byte) error
+	SaveOriginCheckpointBlockRoot(ctx context.Context, blockRoot [32]byte) error
 	SaveBackfillBlockRoot(ctx context.Context, blockRoot [32]byte) error
 }
 


### PR DESCRIPTION
Discovered in #10387 

During wss, the node may not have finalized block in DB. The node should use wss block as finalized block and use the payload hash as finalized hash