### PR TITLE
Handle Finalized Deposit Insertion Better

### DIFF
--- a/beacon-chain/cache/depositcache/deposits_cache.go
+++ b/beacon-chain/cache/depositcache/deposits_cache.go
@@ -137,6 +137,22 @@ func (dc *DepositCache) InsertFinalizedDeposits(ctx context.Context, eth1Deposit
 
 	depositTrie := dc.finalizedDeposits.Deposits
 	insertIndex := int(dc.finalizedDeposits.MerkleTrieIndex + 1)
+
+	// Don't insert into finalized trie if there is no deposit to
+	// insert.
+	if len(dc.deposits) == 0 {
+		return
+	}
+	// In the event we have less deposits than we need to
+	// finalize we finalize till the index on which we do have it.
+	if len(dc.deposits) <= int(eth1DepositIndex) {
+		eth1DepositIndex = int64(len(dc.deposits)) - 1
+	}
+	// If we finalize to some lower deposit index, we
+	// ignore it.
+	if int(eth1DepositIndex) < insertIndex {
+		return
+	}
 	for _, d := range dc.deposits {
 		if d.Index <= dc.finalizedDeposits.MerkleTrieIndex {
 			continue


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Following on from #10511 , we harden our finalized deposit insertion method here. Some edge cases can be hit in the event the node is still waiting to fetch new deposit logs from its eth1 node and is processing blocks normally. This makes sure that we never revert the trie back to an older state, and only finalize as many deposits as there are stored in our deposit cache. 

**Which issues(s) does this PR fix?**

Resolves #10156 and fixes #10120

**Other notes for review**
