### PR TITLE
Small API adjustments

### DIFF
--- a/api/gateway/apimiddleware/process_field.go
+++ b/api/gateway/apimiddleware/process_field.go
@@ -83,6 +83,7 @@ func hexToBase64Processor(v reflect.Value) error {
 
 func base64ToHexProcessor(v reflect.Value) error {
 	if v.String() == "" {
+		v.SetString("0x")
 		return nil
 	}
 	b, err := base64.StdEncoding.DecodeString(v.String())

--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -434,7 +434,7 @@ type executionPayloadJson struct {
 	GasUsed       string   `json:"gas_used"`
 	TimeStamp     string   `json:"timestamp"`
 	ExtraData     string   `json:"extra_data" hex:"true"`
-	BaseFeePerGas string   `json:"base_fee_per_gas" hex:"true"`
+	BaseFeePerGas string   `json:"base_fee_per_gas"`
 	BlockHash     string   `json:"block_hash" hex:"true"`
 	Transactions  []string `json:"transactions" hex:"true"`
 }
@@ -451,7 +451,7 @@ type executionPayloadHeaderJson struct {
 	GasUsed          string `json:"gas_used"`
 	TimeStamp        string `json:"timestamp"`
 	ExtraData        string `json:"extra_data" hex:"true"`
-	BaseFeePerGas    string `json:"base_fee_per_gas" hex:"true"`
+	BaseFeePerGas    string `json:"base_fee_per_gas"`
 	BlockHash        string `json:"block_hash" hex:"true"`
 	TransactionsRoot string `json:"transactions_root" hex:"true"`
 }


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Small API changes to align with the spec:
- return `0x` instead of empty strings when there is no hex data to return
- do not encode `base_fee_per_gas` as hex
