### PR TITLE
Encode empty `extra_data` as "0x" and `base_fee_per_gas` as Uint256 i…

### DIFF
--- a/api/gateway/apimiddleware/process_field.go
+++ b/api/gateway/apimiddleware/process_field.go
@@ -3,6 +3,7 @@ package apimiddleware
 import (
 	"encoding/base64"
 	"fmt"
+	"math/big"
 	"reflect"
 	"strconv"
 	"strings"
@@ -73,6 +74,10 @@ func processField(s interface{}, processors []fieldProcessor) error {
 }
 
 func hexToBase64Processor(v reflect.Value) error {
+	if v.String() == "0x" {
+		v.SetString("")
+		return nil
+	}
 	b, err := bytesutil.FromHexString(v.String())
 	if err != nil {
 		return err
@@ -83,6 +88,8 @@ func hexToBase64Processor(v reflect.Value) error {
 
 func base64ToHexProcessor(v reflect.Value) error {
 	if v.String() == "" {
+		// Empty hex values are represented as "0x".
+		v.SetString("0x")
 		return nil
 	}
 	b, err := base64.StdEncoding.DecodeString(v.String())
@@ -90,6 +97,52 @@ func base64ToHexProcessor(v reflect.Value) error {
 		return err
 	}
 	v.SetString(hexutil.Encode(b))
+	return nil
+}
+
+func base64ToUint256Processor(v reflect.Value) error {
+	if v.String() == "" {
+		return nil
+	}
+	littleEndian, err := base64.StdEncoding.DecodeString(v.String())
+	if err != nil {
+		return err
+	}
+	if len(littleEndian) != 32 {
+		return errors.New("invalid length for Uint256")
+	}
+
+	// Integers are stored as little-endian, but
+	// big.Int expects big-endian. So we need to reverse
+	// the byte order before decoding.
+	var bigEndian [32]byte
+	for i := 0; i < len(littleEndian); i++ {
+		bigEndian[i] = littleEndian[len(littleEndian)-1-i]
+	}
+	var uint256 big.Int
+	uint256.SetBytes(bigEndian[:])
+	v.SetString(uint256.String())
+	return nil
+}
+
+func uint256ToBase64Processor(v reflect.Value) error {
+	if v.String() == "" {
+		return nil
+	}
+	uint256, ok := new(big.Int).SetString(v.String(), 10)
+	if !ok {
+		return fmt.Errorf("could not parse Uint256 '%s'", v.String())
+	}
+	bigEndian := uint256.Bytes()
+
+	// Integers are stored as little-endian, but
+	// big.Int gives big-endian. So we need to reverse
+	// the byte order before encoding.
+	var littleEndian [32]byte
+	for i := 0; i < len(bigEndian); i++ {
+		littleEndian[i] = bigEndian[len(bigEndian)-1-i]
+	}
+	v.SetString(base64.StdEncoding.EncodeToString(littleEndian[:]))
 	return nil
 }
 

--- a/api/gateway/apimiddleware/process_request.go
+++ b/api/gateway/apimiddleware/process_request.go
@@ -38,6 +38,10 @@ func ProcessRequestContainerFields(requestContainer interface{}) ErrorJson {
 			tag: "hex",
 			f:   hexToBase64Processor,
 		},
+		{
+			tag: "uint256",
+			f:   uint256ToBase64Processor,
+		},
 	}); err != nil {
 		return InternalServerErrorWithMessage(err, "could not process request data")
 	}
@@ -153,6 +157,10 @@ func ProcessMiddlewareResponseFields(responseContainer interface{}) ErrorJson {
 		{
 			tag: "time",
 			f:   timeToUnixProcessor,
+		},
+		{
+			tag: "uint256",
+			f:   base64ToUint256Processor,
 		},
 	}); err != nil {
 		return InternalServerErrorWithMessage(err, "could not process response data")

--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -434,7 +434,7 @@ type executionPayloadJson struct {
 	GasUsed       string   `json:"gas_used"`
 	TimeStamp     string   `json:"timestamp"`
 	ExtraData     string   `json:"extra_data" hex:"true"`
-	BaseFeePerGas string   `json:"base_fee_per_gas" hex:"true"`
+	BaseFeePerGas string   `json:"base_fee_per_gas" uint256:"true"`
 	BlockHash     string   `json:"block_hash" hex:"true"`
 	Transactions  []string `json:"transactions" hex:"true"`
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

*This PR is a resubmission of #10525 that targets `develop`.*

Fixes JSON representation of 2 `ExecutionPayload` fields in the Beacon API to align with the spec and allow VC<->BN interoperability with other clients.

- Encode empty hex values (which `extra_data` often is) as "0x" instead of "" ([spec](https://github.com/ethereum/beacon-APIs/blob/4aeeb165bc5f9695938bb2f84170d1f92ce16bf5/types/primitive.yaml#L89-L93))
- Encode/decode `base_fee_per_gas` as Uint256 instead of hex ([spec](https://github.com/ethereum/beacon-APIs/blob/4aeeb165bc5f9695938bb2f84170d1f92ce16bf5/types/bellatrix/execution_payload.yaml#L29-L30))

**Other notes for review**

I've successfully proposed a block on Kiln with this PR (using a Beacon API-based VC), but this needs tests regardless.

Open to suggestions 🙂