### PR TITLE
Remove Proposer Selection Feature

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/state"
-	"github.com/prysmaticlabs/prysm/config/features"
 	"github.com/prysmaticlabs/prysm/config/params"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1/attestation/aggregation"
@@ -117,16 +116,7 @@ func (a proposerAtts) sortByProfitability() (proposerAtts, error) {
 	if len(a) < 2 {
 		return a, nil
 	}
-	if features.Get().ProposerAttsSelectionUsingMaxCover {
-		return a.sortByProfitabilityUsingMaxCover()
-	}
-	sort.Slice(a, func(i, j int) bool {
-		if a[i].Data.Slot == a[j].Data.Slot {
-			return a[i].AggregationBits.Count() > a[j].AggregationBits.Count()
-		}
-		return a[i].Data.Slot > a[j].Data.Slot
-	})
-	return a, nil
+	return a.sortByProfitabilityUsingMaxCover()
 }
 
 // sortByProfitabilityUsingMaxCover orders attestations by highest slot and by highest aggregation bit count.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_attestations_test.go
@@ -7,7 +7,6 @@ import (
 
 	types "github.com/prysmaticlabs/eth2-types"
 	"github.com/prysmaticlabs/go-bitfield"
-	"github.com/prysmaticlabs/prysm/config/features"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/testing/assert"
 	"github.com/prysmaticlabs/prysm/testing/require"
@@ -39,11 +38,6 @@ func TestProposer_ProposerAtts_sortByProfitability(t *testing.T) {
 }
 
 func TestProposer_ProposerAtts_sortByProfitabilityUsingMaxCover(t *testing.T) {
-	resetCfg := features.InitWithReset(&features.Flags{
-		ProposerAttsSelectionUsingMaxCover: true,
-	})
-	defer resetCfg()
-
 	type testData struct {
 		slot types.Slot
 		bits bitfield.Bitlist
@@ -116,38 +110,9 @@ func TestProposer_ProposerAtts_sortByProfitabilityUsingMaxCover(t *testing.T) {
 	})
 
 	t.Run("compare to native sort", func(t *testing.T) {
-		// The naive sort will end up with 0b11001000 being selected second (which is not optimal
-		// as it only contains a single unknown bit).
 		// The max-cover based approach will select 0b00001100 instead, despite lower bit count
 		// (since it has two new/unknown bits).
-		t.Run("naive", func(t *testing.T) {
-			resetCfg := features.InitWithReset(&features.Flags{
-				ProposerAttsSelectionUsingMaxCover: false,
-			})
-			defer resetCfg()
-
-			atts := getAtts([]testData{
-				{1, bitfield.Bitlist{0b11000011, 0b1}},
-				{1, bitfield.Bitlist{0b11001000, 0b1}},
-				{1, bitfield.Bitlist{0b00001100, 0b1}},
-			})
-			want := getAtts([]testData{
-				{1, bitfield.Bitlist{0b11000011, 0b1}},
-				{1, bitfield.Bitlist{0b11001000, 0b1}},
-				{1, bitfield.Bitlist{0b00001100, 0b1}},
-			})
-			atts, err := atts.sortByProfitability()
-			if err != nil {
-				t.Error(err)
-			}
-			require.DeepEqual(t, want, atts)
-		})
 		t.Run("max-cover", func(t *testing.T) {
-			resetCfg := features.InitWithReset(&features.Flags{
-				ProposerAttsSelectionUsingMaxCover: true,
-			})
-			defer resetCfg()
-
 			atts := getAtts([]testData{
 				{1, bitfield.Bitlist{0b11000011, 0b1}},
 				{1, bitfield.Bitlist{0b11001000, 0b1}},

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_utils_bench_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_utils_bench_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/prysmaticlabs/go-bitfield"
-	"github.com/prysmaticlabs/prysm/config/features"
 	"github.com/prysmaticlabs/prysm/config/params"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	aggtesting "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1/attestation/aggregation/testing"
@@ -55,24 +54,8 @@ func BenchmarkProposerAtts_sortByProfitability(b *testing.B) {
 	}
 
 	for _, tt := range tests {
-		b.Run(fmt.Sprintf("naive_%s", tt.name), func(b *testing.B) {
-			b.StopTimer()
-			resetCfg := features.InitWithReset(&features.Flags{
-				ProposerAttsSelectionUsingMaxCover: false,
-			})
-			defer resetCfg()
-			atts := aggtesting.MakeAttestationsFromBitlists(tt.inputs)
-			b.StartTimer()
-			for i := 0; i < b.N; i++ {
-				runner(atts)
-			}
-		})
 		b.Run(fmt.Sprintf("max-cover_%s", tt.name), func(b *testing.B) {
 			b.StopTimer()
-			resetCfg := features.InitWithReset(&features.Flags{
-				ProposerAttsSelectionUsingMaxCover: true,
-			})
-			defer resetCfg()
 			atts := aggtesting.MakeAttestationsFromBitlists(tt.inputs)
 			b.StartTimer()
 			for i := 0; i < b.N; i++ {

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/prysmaticlabs/prysm/config/params"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+	"gopkg.in/urfave/cli.v1"
 )
 
 var log = logrus.WithField("prefix", "flags")
@@ -43,7 +44,6 @@ type Flags struct {
 	EnableLargerGossipHistory           bool // EnableLargerGossipHistory increases the gossip history we store in our caches.
 	WriteWalletPasswordOnWebOnboarding  bool // WriteWalletPasswordOnWebOnboarding writes the password to disk after Prysm web signup.
 	DisableAttestingHistoryDBCache      bool // DisableAttestingHistoryDBCache for the validator client increases disk reads/writes.
-	ProposerAttsSelectionUsingMaxCover  bool // ProposerAttsSelectionUsingMaxCover enables max-cover algorithm when selecting attestations for proposing.
 	EnableOptimizedBalanceUpdate        bool // EnableOptimizedBalanceUpdate uses an updated method of performing balance updates.
 	EnableDoppelGanger                  bool // EnableDoppelGanger enables doppelganger protection on startup for the validator.
 	EnableHistoricalSpaceRepresentation bool // EnableHistoricalSpaceRepresentation enables the saving of registry validators in separate buckets to save space
@@ -166,11 +166,6 @@ func ConfigureBeaconChain(ctx *cli.Context) {
 	if ctx.Bool(enableSlasherFlag.Name) {
 		log.WithField(enableSlasherFlag.Name, enableSlasherFlag.Usage).Warn(enabledFeatureFlag)
 		cfg.EnableSlasher = true
-	}
-	cfg.ProposerAttsSelectionUsingMaxCover = true
-	if ctx.Bool(disableProposerAttsSelectionUsingMaxCover.Name) {
-		logDisabled(disableProposerAttsSelectionUsingMaxCover)
-		cfg.ProposerAttsSelectionUsingMaxCover = false
 	}
 	cfg.EnableOptimizedBalanceUpdate = true
 	if ctx.Bool(disableOptimizedBalanceUpdate.Name) {

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -26,7 +26,6 @@ import (
 	"github.com/prysmaticlabs/prysm/config/params"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-	"gopkg.in/urfave/cli.v1"
 )
 
 var log = logrus.WithField("prefix", "flags")

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -75,6 +75,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedDisableProposerAttsSelectionUsingMaxCover = &cli.BoolFlag{
+		Name:   "disable-proposer-atts-selection-using-max-cover",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 var deprecatedFlags = []cli.Flag{
@@ -90,4 +95,5 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedAttestationAggregationStrategy,
 	deprecatedForceOptMaxCoverAggregationStategy,
 	deprecatedPyrmontTestnet,
+	deprecatedDisableProposerAttsSelectionUsingMaxCover,
 }

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -75,10 +75,6 @@ var (
 		Name:  "slasher",
 		Usage: "Enables a slasher in the beacon node for detecting slashable offenses",
 	}
-	disableProposerAttsSelectionUsingMaxCover = &cli.BoolFlag{
-		Name:  "disable-proposer-atts-selection-using-max-cover",
-		Usage: "Disable max-cover algorithm when selecting attestations for proposer",
-	}
 	enableSlashingProtectionPruning = &cli.BoolFlag{
 		Name:  "enable-slashing-protection-history-pruning",
 		Usage: "Enables the pruning of the validator client's slashing protection database",
@@ -176,7 +172,6 @@ var BeaconChainFlags = append(deprecatedFlags, []cli.Flag{
 	checkPtInfoCache,
 	disableBroadcastSlashingFlag,
 	enableSlasherFlag,
-	disableProposerAttsSelectionUsingMaxCover,
 	disableOptimizedBalanceUpdate,
 	enableHistoricalSpaceRepresentation,
 	disableCorrectlyInsertOrphanedAtts,


### PR DESCRIPTION
**What type of PR is this?**

Feature Graduation

**What does this PR do? Why is it needed?**

- [x] The proposer selection algorithm for attestations has been the default for a long period of time, this removes the field value from our feature config and puts the flag to disable it as deprecated. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
