### PR TITLE
Add lock to `PeerStatusScorer.SetHeadSlot`

### DIFF
--- a/beacon-chain/p2p/peers/scorers/peer_status.go
+++ b/beacon-chain/p2p/peers/scorers/peer_status.go
@@ -145,5 +145,7 @@ func (s *PeerStatusScorer) peerStatus(pid peer.ID) (*pb.Status, error) {
 
 // SetHeadSlot updates known head slot.
 func (s *PeerStatusScorer) SetHeadSlot(slot types.Slot) {
+	s.store.Lock()
+	defer s.store.Unlock()
 	s.ourHeadSlot = slot
 }


### PR DESCRIPTION
(cherry picked from commit e04e4795c81ea939cf8996c632c52598cd69d170)
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`PeerStatusScorer.SetHeadSlot` is an exported function, but it does not lock the store.

**Which issues(s) does this PR fix?**

Fixes #10530

**Other notes for review**
