### PR TITLE
Fix Transaction Pool in E2E

### DIFF
--- a/testing/endtoend/components/eth1/miner.go
+++ b/testing/endtoend/components/eth1/miner.go
@@ -127,6 +127,7 @@ func (m *Miner) Start(ctx context.Context) error {
 		"--mine",
 		"--unlock=0x878705ba3f8bc32fcf7f4caa1a35e72af65cf766",
 		"--allow-insecure-unlock",
+		"--txpool.locals=0x878705ba3f8bc32fcf7f4caa1a35e72af65cf766",
 		fmt.Sprintf("--password=%s", eth1Path+"/keystore/"+minerPasswordFile),
 	}
 

--- a/testing/endtoend/components/eth1/node.go
+++ b/testing/endtoend/components/eth1/node.go
@@ -88,6 +88,7 @@ func (node *Node) Start(ctx context.Context) error {
 		"--ws.origins=\"*\"",
 		"--ipcdisable",
 		"--verbosity=4",
+		"--txpool.locals=0x878705ba3f8bc32fcf7f4caa1a35e72af65cf766",
 	}
 	// If we are testing sync, geth needs to be run via full sync as snap sync does not
 	// work in our setup.

--- a/testing/endtoend/components/eth1/transactions.go
+++ b/testing/endtoend/components/eth1/transactions.go
@@ -65,7 +65,7 @@ func (t *TransactionGenerator) Start(ctx context.Context) error {
 	}
 	f := filler.NewFiller(rnd)
 	// Broadcast Transactions every 3 blocks
-	txPeriod := time.Duration(params.BeaconConfig().SecondsPerETH1Block*3) * time.Second
+	txPeriod := time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second
 	ticker := time.NewTicker(txPeriod)
 	gasPrice := big.NewInt(1e11)
 	for {


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] If too many transactions are inserted into the transaction pool from the same address, geth can start ignoring them. This adds in a few flags so that the transactions are treated normally and normal rate limits are not applied.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
