### PR TITLE
Add proposer index and graffiti to received block log

### DIFF
--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -185,6 +185,8 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 	log.WithFields(logrus.Fields{
 		"blockSlot":          blk.Block().Slot(),
 		"sinceSlotStartTime": receivedTime.Sub(startTime),
+		"proposerIndex":      blk.Block().ProposerIndex(),
+		"graffiti":           string(blk.Block().Body().Graffiti()),
 	}).Debug("Received block")
 	return pubsub.ValidationAccept, nil
 }


### PR DESCRIPTION
I think the proposer index and graffiti would be helpful to fields to have along side `Received block...` log to monitor where the late blocks were coming from. Other client implementation have these which made debugging useful as seen during interop event