### PR TITLE
Fix Nogo Lint Ignore for Go 1.18

### DIFF
--- a/nogo_config.json
+++ b/nogo_config.json
@@ -42,13 +42,13 @@
   "composites": {
     "exclude_files": {
       "external/.*": "Third party code",
-      "validator/accounts/.*": "Fuzz",
-      "validator/accounts/wallet_recover_fuzz_test.go": "Fuzz code"
+      ".*testmain\\.go$": "Fuzz"
     }
   },
   "cgocall": {
     "exclude_files": {
-      "external/.*": "Third party code"
+      "external/.*": "Third party code",
+      ".*testmain\\.go$": "Fuzz"
     }
   },
   "assign": {


### PR DESCRIPTION
Composites and cgocall linters don't play nicely with internal fuzz functions for Go 1.18, so we ignore TestMain files in our linter