### PR TITLE
Clean up optimistic candidate block usages

### DIFF
--- a/beacon-chain/blockchain/error.go
+++ b/beacon-chain/blockchain/error.go
@@ -13,6 +13,8 @@ var (
 	errInvalidNilSummary = errors.New("nil summary returned from the DB")
 	// errNilParentInDB is returned when a nil parent block is returned from the DB.
 	errNilParentInDB = errors.New("nil parent block in DB")
+	// errNonExecutionParent is returned when parent block is not an execution block.
+	errNonExecutionParent = errors.New("non execution parent block")
 	// errWrongBlockCount is returned when the wrong number of blocks or
 	// block roots is used
 	errWrongBlockCount = errors.New("wrong number of blocks or block roots")

--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -455,7 +455,7 @@ func Test_IsOptimisticCandidateBlock(t *testing.T) {
 		name      string
 		blk       block.BeaconBlock
 		justified block.SignedBeaconBlock
-		want      bool
+		err       error
 	}{
 		{
 			name: "deep block",
@@ -475,7 +475,7 @@ func Test_IsOptimisticCandidateBlock(t *testing.T) {
 				require.NoError(tt, err)
 				return wr
 			}(t),
-			want: true,
+			err: nil,
 		},
 		{
 			name: "shallow block, Altair justified chkpt",
@@ -495,7 +495,7 @@ func Test_IsOptimisticCandidateBlock(t *testing.T) {
 				require.NoError(tt, err)
 				return wr
 			}(t),
-			want: false,
+			err: errNonExecutionParent,
 		},
 		{
 			name: "shallow block, Bellatrix justified chkpt without execution",
@@ -515,7 +515,7 @@ func Test_IsOptimisticCandidateBlock(t *testing.T) {
 				require.NoError(tt, err)
 				return wr
 			}(t),
-			want: false,
+			err: errNonExecutionParent,
 		},
 	}
 	for _, tt := range tests {
@@ -529,9 +529,8 @@ func Test_IsOptimisticCandidateBlock(t *testing.T) {
 			})
 		require.NoError(t, service.cfg.BeaconDB.SaveBlock(ctx, wrappedParentBlock))
 
-		candidate, err := service.optimisticCandidateBlock(ctx, tt.blk)
-		require.NoError(t, err)
-		require.Equal(t, tt.want, candidate, tt.name)
+		err = service.optimisticCandidateBlock(ctx, tt.blk)
+		require.Equal(t, tt.err, err)
 	}
 }
 
@@ -579,9 +578,8 @@ func Test_IsOptimisticShallowExecutionParent(t *testing.T) {
 	wrappedChild, err := wrapper.WrappedSignedBeaconBlock(childBlock)
 	require.NoError(t, err)
 	require.NoError(t, service.cfg.BeaconDB.SaveBlock(ctx, wrappedChild))
-	candidate, err := service.optimisticCandidateBlock(ctx, wrappedChild.Block())
+	err = service.optimisticCandidateBlock(ctx, wrappedChild.Block())
 	require.NoError(t, err)
-	require.Equal(t, true, candidate)
 }
 
 func Test_GetPayloadAttribute(t *testing.T) {

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -121,14 +121,6 @@ func (s *Service) onBlock(ctx context.Context, signed block.SignedBeaconBlock, b
 		if err := s.validateMergeTransitionBlock(ctx, preStateVersion, preStateHeader, signed); err != nil {
 			return err
 		}
-	} else {
-		candidate, err := s.optimisticCandidateBlock(ctx, b)
-		if err != nil {
-			return errors.Wrap(err, "could not check if block is optimistic candidate")
-		}
-		if !candidate {
-			return errNotOptimisticCandidate
-		}
 	}
 
 	if err := s.insertBlockAndAttestationsToForkChoiceStore(ctx, signed.Block(), blockRoot, postState); err != nil {
@@ -420,14 +412,6 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []block.SignedBeaconBlo
 			if err := s.validateMergeTransitionBlock(ctx, preVersionAndHeaders[i].version,
 				preVersionAndHeaders[i].header, b); err != nil {
 				return nil, nil, err
-			}
-		} else {
-			candidate, err := s.optimisticCandidateBlock(ctx, b.Block())
-			if err != nil {
-				return nil, nil, errors.Wrap(err, "could not check if block is optimistic candidate")
-			}
-			if !candidate {
-				return nil, nil, errNotOptimisticCandidate
 			}
 		}
 


### PR DESCRIPTION
Checking for optimistic block candidates should be the engine handler's responsibility instead of surfacing the responsibility to the caller