### PR TITLE
Max Epoch Helper from Eth2-Types

### DIFF
--- a/consensus-types/primitives/BUILD.bazel
+++ b/consensus-types/primitives/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//math:go_default_library",
+        "//testing/require:go_default_library",
         "@com_github_prysmaticlabs_eth2_types//:go_default_library",
     ],
 )

--- a/consensus-types/primitives/epoch.go
+++ b/consensus-types/primitives/epoch.go
@@ -14,6 +14,14 @@ var _ fssz.Unmarshaler = (*Epoch)(nil)
 // Epoch represents a single epoch.
 type Epoch uint64
 
+// MaxEpoch --
+func MaxEpoch(a, b Epoch) Epoch {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 // Mul multiplies epoch by x.
 // In case of arithmetic issues (overflow/underflow/div by zero) panic is thrown.
 func (e Epoch) Mul(x uint64) Epoch {

--- a/consensus-types/primitives/epoch.go
+++ b/consensus-types/primitives/epoch.go
@@ -14,7 +14,7 @@ var _ fssz.Unmarshaler = (*Epoch)(nil)
 // Epoch represents a single epoch.
 type Epoch uint64
 
-// MaxEpoch --
+// MaxEpoch compares two epochs and returns the greater one.
 func MaxEpoch(a, b Epoch) Epoch {
 	if a > b {
 		return a

--- a/consensus-types/primitives/epoch_test.go
+++ b/consensus-types/primitives/epoch_test.go
@@ -7,7 +7,15 @@ import (
 
 	types "github.com/prysmaticlabs/prysm/consensus-types/primitives"
 	mathprysm "github.com/prysmaticlabs/prysm/math"
+	"github.com/prysmaticlabs/prysm/testing/require"
 )
+
+func TestMaxEpoch(t *testing.T) {
+	require.Equal(t, types.Epoch(0), types.MaxEpoch(0, 0))
+	require.Equal(t, types.Epoch(1), types.MaxEpoch(1, 0))
+	require.Equal(t, types.Epoch(1), types.MaxEpoch(0, 1))
+	require.Equal(t, types.Epoch(100), types.MaxEpoch(100, 1000))
+}
 
 func TestEpoch_Mul(t *testing.T) {
 	tests := []struct {

--- a/consensus-types/primitives/epoch_test.go
+++ b/consensus-types/primitives/epoch_test.go
@@ -14,7 +14,7 @@ func TestMaxEpoch(t *testing.T) {
 	require.Equal(t, types.Epoch(0), types.MaxEpoch(0, 0))
 	require.Equal(t, types.Epoch(1), types.MaxEpoch(1, 0))
 	require.Equal(t, types.Epoch(1), types.MaxEpoch(0, 1))
-	require.Equal(t, types.Epoch(100), types.MaxEpoch(100, 1000))
+	require.Equal(t, types.Epoch(1000), types.MaxEpoch(100, 1000))
 }
 
 func TestEpoch_Mul(t *testing.T) {


### PR DESCRIPTION
Brings the MaxEpoch helper function from eth2-types so we can rely less on the dependency and remove it in a follow-up PR