### PR TITLE
More Useful Log When Auth Fails to Execution Client

### DIFF
--- a/beacon-chain/powchain/engine_client.go
+++ b/beacon-chain/powchain/engine_client.go
@@ -288,7 +288,7 @@ func handleRPCError(err error) error {
 	}
 	e, ok := err.(rpc.Error)
 	if !ok {
-		if strings.Contains(e.Error(), "Unauthorized") {
+		if strings.Contains(e.Error(), "401 Unauthorized") {
 			log.Error("HTTP authentication to your execution client is not working. Please ensure " +
 				"you are setting a correct value for the --jwt-secret flag in Prysm, or use an IPC connection if on " +
 				"the same machine. Please see our documentation for more information on authenticating connections " +

--- a/beacon-chain/powchain/engine_client.go
+++ b/beacon-chain/powchain/engine_client.go
@@ -289,7 +289,7 @@ func handleRPCError(err error) error {
 	e, ok := err.(rpc.Error)
 	if !ok {
 		if strings.Contains(e.Error(), "Unauthorized") {
-			log.Error("HTTP authentication to execution client is not working. Please ensure " +
+			log.Error("HTTP authentication to your execution client is not working. Please ensure " +
 				"you are setting a correct value for the --jwt-secret, or use an IPC connection if on " +
 				"the same machine. Please see our documentation for more information on authenticating connections " +
 				"here https://docs.prylabs.network/docs/execution-node/authentication")

--- a/beacon-chain/powchain/engine_client.go
+++ b/beacon-chain/powchain/engine_client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -287,6 +288,13 @@ func handleRPCError(err error) error {
 	}
 	e, ok := err.(rpc.Error)
 	if !ok {
+		if strings.Contains(e.Error(), "Unauthorized") {
+			log.Error("HTTP authentication to execution client is not working. Please ensure " +
+				"you are setting a correct value for the --jwt-secret, or use an IPC connection if on " +
+				"the same machine. Please see our documentation for more information on authenticating connections " +
+				"here https://docs.prylabs.network/docs/execution-node/authentication")
+			return fmt.Errorf("could not authenticate connection to execution client: %v", err)
+		}
 		return errors.Wrap(err, "got an unexpected error")
 	}
 	switch e.ErrorCode() {

--- a/beacon-chain/powchain/engine_client.go
+++ b/beacon-chain/powchain/engine_client.go
@@ -288,7 +288,7 @@ func handleRPCError(err error) error {
 	}
 	e, ok := err.(rpc.Error)
 	if !ok {
-		if strings.Contains(e.Error(), "401 Unauthorized") {
+		if strings.Contains(err.Error(), "401 Unauthorized") {
 			log.Error("HTTP authentication to your execution client is not working. Please ensure " +
 				"you are setting a correct value for the --jwt-secret flag in Prysm, or use an IPC connection if on " +
 				"the same machine. Please see our documentation for more information on authenticating connections " +

--- a/beacon-chain/powchain/engine_client.go
+++ b/beacon-chain/powchain/engine_client.go
@@ -290,7 +290,7 @@ func handleRPCError(err error) error {
 	if !ok {
 		if strings.Contains(e.Error(), "Unauthorized") {
 			log.Error("HTTP authentication to your execution client is not working. Please ensure " +
-				"you are setting a correct value for the --jwt-secret, or use an IPC connection if on " +
+				"you are setting a correct value for the --jwt-secret flag in Prysm, or use an IPC connection if on " +
 				"the same machine. Please see our documentation for more information on authenticating connections " +
 				"here https://docs.prylabs.network/docs/execution-node/authentication")
 			return fmt.Errorf("could not authenticate connection to execution client: %v", err)


### PR DESCRIPTION
Thanks to SeaMonkey for this feedback. When engine API connection fails due to being unauthorized, users see this scary log:
```
got an unexpected error: 401 Unauthorized: Unauthorized: Error: Missing auth header
could not process block in batch
github.com/prysmaticlabs/prysm/beacon-chain/blockchain.(*Service).ReceiveBlockBatch
        beacon-chain/blockchain/receive_block.go:84
github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync.(*Service).processBatchedBlocks
        beacon-chain/sync/initial-sync/round_robin.go:283
github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync.(*Service).processFetchedData
        beacon-chain/sync/initial-sync/round_robin.go:133
github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync.(*Service).syncToFinalizedEpoch
        beacon-chain/sync/initial-sync/round_robin.go:86
github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync.(*Service).roundRobinSync
        beacon-chain/sync/initial-sync/round_robin.go:49
github.com/prysmaticlabs/prysm/beacon-chain/sync/initial-sync.(*Service).Start
        beacon-chain/sync/initial-sync/service.go:104
runtime.goexit
        GOROOT/src/runtime/asm_amd64.s:1571
```
Instead, we offer users something more actionable in the form of:

> HTTP authentication to your execution client is not working. Please ensure you are setting a correct value for the --jwt-secret in Prysm, or use an IPC connection if on the same machine. Please see our documentation for more information on authenticating connections here https://docs.prylabs.network/docs/execution-node/authentication

without printing the big stack trace for this error kind
