### PR TITLE
Fix `isProcessedBlock` order of operation

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -311,7 +311,7 @@ func (s *Service) isProcessedBlock(ctx context.Context, blk interfaces.SignedBea
 	}
 	// If block exists in our db and is before or equal to our current head
 	// we ignore it.
-	if s.cfg.Chain.HasBlock(ctx, blkRoot) && s.cfg.Chain.HeadSlot() >= blk.Block().Slot() {
+	if s.cfg.Chain.HeadSlot() >= blk.Block().Slot() && s.cfg.Chain.HasBlock(ctx, blkRoot) {
 		return true
 	}
 	return false


### PR DESCRIPTION
I missed one comment from #10592, here we can avoid one DB lookup in the event `s.cfg.Chain.HeadSlot() >= blk.Block().Slot()`

https://github.com/prysmaticlabs/prysm/pull/10592/files#r862913776