### PR TITLE
process slashings once

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -333,6 +333,10 @@ func (f *ForkChoice) SetOptimisticToInvalid(ctx context.Context, root, parentRoo
 func (f *ForkChoice) InsertSlashedIndex(_ context.Context, index types.ValidatorIndex) {
 	f.store.nodesLock.Lock()
 	defer f.store.nodesLock.Unlock()
+	// return early if the index was already included:
+	if f.store.slashedIndices[index] {
+		return
+	}
 	f.store.slashedIndices[index] = true
 
 	// Subtract last vote from this equivocating validator

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -218,6 +218,15 @@ func TestForkChoice_RemoveEquivocating(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{'c'}, head)
 
+	// Process b's slashing again, should be a noop
+	f.InsertSlashedIndex(ctx, 1)
+	require.Equal(t, uint64(200), f.store.nodeByRoot[[32]byte{'b'}].balance)
+	head, err = f.Head(ctx, 1, params.BeaconConfig().ZeroHash, []uint64{100, 200, 200, 300}, 1)
+	require.Equal(t, uint64(200), f.store.nodeByRoot[[32]byte{'b'}].weight)
+	require.Equal(t, uint64(300), f.store.nodeByRoot[[32]byte{'c'}].weight)
+	require.NoError(t, err)
+	require.Equal(t, [32]byte{'c'}, head)
+
 	// Process index where index == vote length. Should not panic.
 	f.InsertSlashedIndex(ctx, types.ValidatorIndex(len(f.balances)))
 	f.InsertSlashedIndex(ctx, types.ValidatorIndex(len(f.votes)))

--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -749,6 +749,10 @@ func (f *ForkChoice) ForkChoiceNodes() []*pbrpc.ForkChoiceNode {
 func (f *ForkChoice) InsertSlashedIndex(ctx context.Context, index types.ValidatorIndex) {
 	f.store.nodesLock.Lock()
 	defer f.store.nodesLock.Unlock()
+	// return early if the index was already included:
+	if f.store.slashedIndices[index] {
+		return
+	}
 	f.store.slashedIndices[index] = true
 
 	// Subtract last vote from this equivocating validator


### PR DESCRIPTION
Do not discount twice the same attestation if we are sent the same slashed index twice. 