### PR TITLE
Do not allow terminal block in the future

### DIFF
--- a/beacon-chain/blockchain/error.go
+++ b/beacon-chain/blockchain/error.go
@@ -18,4 +18,6 @@ var (
 	errWrongBlockCount = errors.New("wrong number of blocks or block roots")
 	// block is not a valid optimistic candidate block
 	errNotOptimisticCandidate = errors.New("block is not suitable for optimistic sync")
+	// invalid terminal block timestamp
+	errInvalidTerminalBlockTimestamp = errors.New("invalid terminal block timestamp")
 )


### PR DESCRIPTION
Check that the terminal pow block payload timestamp is not higher than the beginning of the slot that this powblock is included. 

fixes #10586 