### PR TITLE
run process_slots before caching committee data

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -495,13 +495,13 @@ func (s *Service) handleEpochBoundary(ctx context.Context, postState state.Beaco
 	defer span.End()
 
 	if postState.Slot()+1 == s.nextEpochBoundarySlot {
-		// Update caches for the next epoch at epoch boundary slot - 1.
-		if err := helpers.UpdateCommitteeCache(postState, coreTime.NextEpoch(postState)); err != nil {
-			return err
-		}
 		copied := postState.Copy()
 		copied, err := transition.ProcessSlots(ctx, copied, copied.Slot()+1)
 		if err != nil {
+			return err
+		}
+		// Update caches for the next epoch at epoch boundary slot - 1.
+		if err := helpers.UpdateCommitteeCache(postState, coreTime.CurrentEpoch(copied)); err != nil {
 			return err
 		}
 		if err := helpers.UpdateProposerIndicesInCache(ctx, copied); err != nil {

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -501,7 +501,7 @@ func (s *Service) handleEpochBoundary(ctx context.Context, postState state.Beaco
 			return err
 		}
 		// Update caches for the next epoch at epoch boundary slot - 1.
-		if err := helpers.UpdateCommitteeCache(postState, coreTime.CurrentEpoch(copied)); err != nil {
+		if err := helpers.UpdateCommitteeCache(copied, coreTime.CurrentEpoch(copied)); err != nil {
 			return err
 		}
 		if err := helpers.UpdateProposerIndicesInCache(ctx, copied); err != nil {

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -273,7 +273,7 @@ func (r *testRunner) run() {
 
 		if config.ExtraEpochs > 0 {
 			secondsPerEpoch := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
-			dl := time.Now().Add(time.Second * time.Duration(config.ExtraEpochs * secondsPerEpoch))
+			dl := time.Now().Add(time.Second * time.Duration(config.ExtraEpochs*secondsPerEpoch))
 			if err := r.waitUntilEpoch(ctx, types.Epoch(config.EpochsToRun+config.ExtraEpochs), conns[0], dl); err != nil {
 				return errors.Wrap(err, "error while waiting for ExtraEpochs")
 			}
@@ -303,7 +303,7 @@ func (r *testRunner) waitUntilEpoch(ctx context.Context, e types.Epoch, conn *gr
 	defer cancel()
 	for {
 		select {
-		case <- ctx.Done():
+		case <-ctx.Done():
 			return errors.Wrapf(ctx.Err(), "context deadline/cancel while waiting for epoch %d", e)
 		default:
 			chainHead, err := beaconClient.GetChainHead(ctx, &emptypb.Empty{})

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -262,12 +262,29 @@ func (r *testRunner) run() {
 		if !config.TestSync {
 			return nil
 		}
-		if err := r.testBeaconChainSync(ctx, g, conns, tickingStartTime, bootNode.ENR(), eth1Miner.ENR()); err != nil {
+		syncConn, err := r.testBeaconChainSync(ctx, g, conns, tickingStartTime, bootNode.ENR(), eth1Miner.ENR())
+		if err != nil {
 			return errors.Wrap(err, "beacon chain sync test failed")
 		}
+		conns = append(conns, syncConn)
 		if err := r.testDoppelGangerProtection(ctx); err != nil {
 			return errors.Wrap(err, "doppel ganger protection check failed")
 		}
+
+		if config.ExtraEpochs > 0 {
+			secondsPerEpoch := uint64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))
+			dl := time.Now().Add(time.Second * time.Duration(config.ExtraEpochs * secondsPerEpoch))
+			if err := r.waitUntilEpoch(ctx, types.Epoch(config.EpochsToRun+config.ExtraEpochs), conns[0], dl); err != nil {
+				return errors.Wrap(err, "error while waiting for ExtraEpochs")
+			}
+			syncEvaluators := []e2etypes.Evaluator{ev.FinishedSyncing, ev.AllNodesHaveSameHead}
+			for _, evaluator := range syncEvaluators {
+				t.Run(evaluator.Name, func(t *testing.T) {
+					assert.NoError(t, evaluator.Evaluation(conns...), "Evaluation failed for sync node")
+				})
+			}
+		}
+
 		return nil
 	})
 
@@ -277,6 +294,26 @@ func (r *testRunner) run() {
 			return
 		}
 		t.Fatalf("E2E test ended in error: %v", err)
+	}
+}
+
+func (r *testRunner) waitUntilEpoch(ctx context.Context, e types.Epoch, conn *grpc.ClientConn, deadline time.Time) error {
+	beaconClient := eth.NewBeaconChainClient(conn)
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	for {
+		select {
+		case <- ctx.Done():
+			return errors.Wrapf(ctx.Err(), "context deadline/cancel while waiting for epoch %d", e)
+		default:
+			chainHead, err := beaconClient.GetChainHead(ctx, &emptypb.Empty{})
+			if err != nil {
+				return err
+			}
+			if chainHead.HeadEpoch >= e {
+				return nil
+			}
+		}
 	}
 }
 
@@ -365,7 +402,7 @@ func (r *testRunner) testTxGeneration(ctx context.Context, g *errgroup.Group, ke
 
 // testBeaconChainSync creates another beacon node, and tests whether it can sync to head using previous nodes.
 func (r *testRunner) testBeaconChainSync(ctx context.Context, g *errgroup.Group,
-	conns []*grpc.ClientConn, tickingStartTime time.Time, bootnodeEnr, minerEnr string) error {
+	conns []*grpc.ClientConn, tickingStartTime time.Time, bootnodeEnr, minerEnr string) (*grpc.ClientConn, error) {
 	t, config := r.t, r.config
 	index := e2e.TestParams.BeaconNodeCount + e2e.TestParams.LighthouseBeaconNodeCount
 	ethNode := eth1.NewNode(index, minerEnr)
@@ -373,14 +410,14 @@ func (r *testRunner) testBeaconChainSync(ctx context.Context, g *errgroup.Group,
 		return ethNode.Start(ctx)
 	})
 	if err := helpers.ComponentsStarted(ctx, []e2etypes.ComponentRunner{ethNode}); err != nil {
-		return fmt.Errorf("sync beacon node not ready: %w", err)
+		return nil, fmt.Errorf("sync beacon node not ready: %w", err)
 	}
 	syncBeaconNode := components.NewBeaconNode(config, index, bootnodeEnr)
 	g.Go(func() error {
 		return syncBeaconNode.Start(ctx)
 	})
 	if err := helpers.ComponentsStarted(ctx, []e2etypes.ComponentRunner{syncBeaconNode}); err != nil {
-		return fmt.Errorf("sync beacon node not ready: %w", err)
+		return nil, fmt.Errorf("sync beacon node not ready: %w", err)
 	}
 	syncConn, err := grpc.Dial(fmt.Sprintf("127.0.0.1:%d", e2e.TestParams.Ports.PrysmBeaconNodeRPCPort+index), grpc.WithInsecure())
 	require.NoError(t, err, "Failed to dial")
@@ -399,7 +436,7 @@ func (r *testRunner) testBeaconChainSync(ctx context.Context, g *errgroup.Group,
 		assert.NoError(t, helpers.WaitForTextInFile(syncLogFile, "Synced up to"), "Failed to sync")
 	})
 	if t.Failed() {
-		return errors.New("cannot sync beacon node")
+		return nil, errors.New("cannot sync beacon node")
 	}
 
 	// Sleep a slot to make sure the synced state is made.
@@ -410,7 +447,7 @@ func (r *testRunner) testBeaconChainSync(ctx context.Context, g *errgroup.Group,
 			assert.NoError(t, evaluator.Evaluation(conns...), "Evaluation failed for sync node")
 		})
 	}
-	return nil
+	return syncConn, nil
 }
 
 func (r *testRunner) testDoppelGangerProtection(ctx context.Context) error {

--- a/testing/endtoend/minimal_e2e_test.go
+++ b/testing/endtoend/minimal_e2e_test.go
@@ -105,7 +105,7 @@ func e2eMinimal(t *testing.T, args *testArgs) {
 		TracingSinkEndpoint: tracingEndpoint,
 		Evaluators:          evals,
 		Seed:                int64(seed),
-		ExtraEpochs: 3,
+		ExtraEpochs:         3,
 	}
 
 	newTestRunner(t, testConfig).run()

--- a/testing/endtoend/minimal_e2e_test.go
+++ b/testing/endtoend/minimal_e2e_test.go
@@ -39,7 +39,7 @@ func e2eMinimal(t *testing.T, args *testArgs) {
 
 	// Run for 12 epochs if not in long-running to confirm long-running has no issues.
 	var err error
-	epochsToRun := 12
+	epochsToRun := 10
 	epochStr, longRunning := os.LookupEnv("E2E_EPOCHS")
 	if longRunning {
 		epochsToRun, err = strconv.Atoi(epochStr)
@@ -105,6 +105,7 @@ func e2eMinimal(t *testing.T, args *testArgs) {
 		TracingSinkEndpoint: tracingEndpoint,
 		Evaluators:          evals,
 		Seed:                int64(seed),
+		ExtraEpochs: 3,
 	}
 
 	newTestRunner(t, testConfig).run()

--- a/testing/endtoend/minimal_e2e_test.go
+++ b/testing/endtoend/minimal_e2e_test.go
@@ -14,26 +14,15 @@ import (
 	"github.com/prysmaticlabs/prysm/testing/require"
 )
 
-type testArgs struct {
-	usePrysmSh          bool
-	useWeb3RemoteSigner bool
-}
-
 func TestEndToEnd_MinimalConfig(t *testing.T) {
-	e2eMinimal(t, &testArgs{
-		usePrysmSh:          false,
-		useWeb3RemoteSigner: false,
-	})
+	e2eMinimal(t, false, 3)
 }
 
 func TestEndToEnd_MinimalConfig_Web3Signer(t *testing.T) {
-	e2eMinimal(t, &testArgs{
-		usePrysmSh:          false,
-		useWeb3RemoteSigner: true,
-	})
+	e2eMinimal(t, true, 0)
 }
 
-func e2eMinimal(t *testing.T, args *testArgs) {
+func e2eMinimal(t *testing.T, useWeb3RemoteSigner bool, extraEpochs uint64) {
 	params.UseE2EConfig()
 	require.NoError(t, e2eParams.Init(e2eParams.StandardBeaconCount))
 
@@ -46,13 +35,8 @@ func e2eMinimal(t *testing.T, args *testArgs) {
 		require.NoError(t, err)
 	}
 	// TODO(#10053): Web3signer does not support bellatrix yet.
-	if args.useWeb3RemoteSigner {
+	if useWeb3RemoteSigner {
 		epochsToRun = helpers.BellatrixE2EForkEpoch - 1
-	}
-	if args.usePrysmSh {
-		// If using prysm.sh, run for only 6 epochs.
-		// TODO(#9166): remove this block once v2 changes are live.
-		epochsToRun = helpers.AltairE2EForkEpoch - 1
 	}
 	seed := 0
 	seedStr, isValid := os.LookupEnv("E2E_SEED")
@@ -99,13 +83,13 @@ func e2eMinimal(t *testing.T, args *testArgs) {
 		TestSync:            true,
 		TestFeature:         true,
 		TestDeposits:        true,
-		UsePrysmShValidator: args.usePrysmSh,
+		UsePrysmShValidator: false,
 		UsePprof:            !longRunning,
-		UseWeb3RemoteSigner: args.useWeb3RemoteSigner,
+		UseWeb3RemoteSigner: useWeb3RemoteSigner,
 		TracingSinkEndpoint: tracingEndpoint,
 		Evaluators:          evals,
 		Seed:                int64(seed),
-		ExtraEpochs:         3,
+		ExtraEpochs:         extraEpochs,
 	}
 
 	newTestRunner(t, testConfig).run()

--- a/testing/endtoend/types/types.go
+++ b/testing/endtoend/types/types.go
@@ -26,6 +26,7 @@ type E2EConfig struct {
 	BeaconFlags             []string
 	ValidatorFlags          []string
 	PeerIDs                 []string
+	ExtraEpochs				uint64
 }
 
 // Evaluator defines the structure of the evaluators used to

--- a/testing/endtoend/types/types.go
+++ b/testing/endtoend/types/types.go
@@ -26,7 +26,7 @@ type E2EConfig struct {
 	BeaconFlags             []string
 	ValidatorFlags          []string
 	PeerIDs                 []string
-	ExtraEpochs				uint64
+	ExtraEpochs             uint64
 }
 
 // Evaluator defines the structure of the evaluators used to


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This changes `handleEpochBoundary` so that it runs the equivalent of `process_slots` on the BeaconState before caching committee data. This fixes an issue where we cache incorrect shuffled and sorted validator indices for subsequent epochs, leading to a mismatch of the proposer index when running in E2E, due to the low value for MAX_SEED_LOOKAHED.

**Which issues(s) does this PR fix?**

This PR runs process_slots on the BeaconState at the epoch boundary before calling `UpdateCommitteeCache`. This ensures that the validator registry has been updated so that the list of activation eligible validators matches what will be seen in the epochs to be cached. 

Fixes #10638

**Other notes for review**
