### PR TITLE
[WIP] call forkchoice update before proposing

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -34,7 +34,7 @@ type ChainInfoFetcher interface {
 // ChainInfoUpdater defines a common interface for methods in blockchain service
 // which allow to update the blockchain status
 type ChainInfoUpdater interface {
-	UpdateAndSaveHead(context.Context)
+	UpdateAndSaveHead(context.Context) error
 }
 
 // TimeFetcher retrieves the Ethereum consensus data that's related to time.

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -31,6 +31,12 @@ type ChainInfoFetcher interface {
 	HeadDomainFetcher
 }
 
+// ChainInfoUpdater defines a common interface for methods in blockchain service
+// which allow to update the blockchain status
+type ChainInfoUpdater interface {
+	UpdateAndSaveHead(context.Context)
+}
+
 // TimeFetcher retrieves the Ethereum consensus data that's related to time.
 type TimeFetcher interface {
 	GenesisTime() time.Time

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -26,22 +26,21 @@ import (
 
 // UpdateAndSaveHead updates the beacon state head using the latest information from forkchoice
 // This function is used in spec-tests and before proposing a block, it saves the head after updating it.
-func (s *Service) UpdateAndSaveHead(ctx context.Context) {
+func (s *Service) UpdateAndSaveHead(ctx context.Context) error {
 	cp := s.store.JustifiedCheckpt()
 	if cp == nil {
-		log.Error("no justified checkpoint")
-		return
+		return errors.New("no justified checkpoint")
 	}
 	balances, err := s.justifiedBalances.get(ctx, bytesutil.ToBytes32(cp.Root))
 	if err != nil {
-		log.WithError(err).Errorf("could not read balances for state w/ justified checkpoint %#x", cp.Root)
-		return
+		return errors.Wrapf(err, "could not read balances for state w/ justified checkpoint %#x", cp.Root)
 	}
 	headRoot, err := s.updateHead(ctx, balances)
 	if err != nil {
-		log.WithError(err).Error("could not update head")
+		return errors.Wrap(err, "could not update head")
 	}
 	s.notifyEngineIfChangedHead(ctx, headRoot)
+	return nil
 }
 
 // This defines the current chain service's view of head.

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -779,6 +779,7 @@ func (b *BeaconNode) registerRPCService() error {
 		PeerManager:             p2pService,
 		MetadataProvider:        p2pService,
 		ChainInfoFetcher:        chainService,
+		ChainInfoUpdater:        chainService,
 		HeadFetcher:             chainService,
 		CanonicalFetcher:        chainService,
 		ForkFetcher:             chainService,

--- a/beacon-chain/rpc/eth/beacon/server.go
+++ b/beacon-chain/rpc/eth/beacon/server.go
@@ -33,6 +33,7 @@ type Server struct {
 	VoluntaryExitsPool      voluntaryexits.PoolManager
 	StateGenService         stategen.StateManager
 	StateFetcher            statefetcher.Fetcher
+	HeadUpdater             blockchain.ChainInfoUpdater
 	HeadFetcher             blockchain.HeadFetcher
 	V1Alpha1ValidatorServer *v1alpha1validator.Server
 	SyncChecker             sync.Checker

--- a/beacon-chain/rpc/eth/validator/server.go
+++ b/beacon-chain/rpc/eth/validator/server.go
@@ -14,6 +14,7 @@ import (
 // providing RPC endpoints intended for validator clients.
 type Server struct {
 	HeadFetcher       blockchain.HeadFetcher
+	HeadUpdater       blockchain.ChainInfoUpdater
 	TimeFetcher       blockchain.TimeFetcher
 	SyncChecker       sync.Checker
 	AttestationsPool  attestations.Pool

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/server.go
@@ -29,6 +29,7 @@ type Server struct {
 	Ctx                         context.Context
 	ChainStartFetcher           powchain.ChainStartFetcher
 	HeadFetcher                 blockchain.HeadFetcher
+	HeadUpdater                 blockchain.ChainInfoUpdater
 	CanonicalFetcher            blockchain.CanonicalFetcher
 	FinalizationFetcher         blockchain.FinalizationFetcher
 	DepositFetcher              depositcache.DepositFetcher

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -38,6 +38,10 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 	ctx, span := trace.StartSpan(ctx, "ProposerServer.GetBeaconBlock")
 	defer span.End()
 	span.AddAttributes(trace.Int64Attribute("slot", int64(req.Slot)))
+
+	// update fork choice head before proposing
+	vs.HeadUpdater.UpdateAndSaveHead(ctx)
+
 	if slots.ToEpoch(req.Slot) < params.BeaconConfig().AltairForkEpoch {
 		blk, err := vs.getPhase0BeaconBlock(ctx, req)
 		if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -38,10 +38,6 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 	ctx, span := trace.StartSpan(ctx, "ProposerServer.GetBeaconBlock")
 	defer span.End()
 	span.AddAttributes(trace.Int64Attribute("slot", int64(req.Slot)))
-
-	// update fork choice head before proposing
-	vs.HeadUpdater.UpdateAndSaveHead(ctx)
-
 	if slots.ToEpoch(req.Slot) < params.BeaconConfig().AltairForkEpoch {
 		blk, err := vs.getPhase0BeaconBlock(ctx, req)
 		if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_phase0.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_phase0.go
@@ -81,6 +81,10 @@ func (vs *Server) buildPhase0BlockData(ctx context.Context, req *ethpb.BlockRequ
 	if vs.SyncChecker.Syncing() {
 		return nil, fmt.Errorf("syncing to latest head, not ready to respond")
 	}
+	// update fork choice head before proposing
+	if err := vs.HeadUpdater.UpdateAndSaveHead(ctx); err != nil {
+		log.WithError(err).Error("could not update head before proposing")
+	}
 
 	// Retrieve the parent block as the current head of the canonical chain.
 	parentRoot, err := vs.HeadFetcher.HeadRoot(ctx)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -43,6 +43,7 @@ type Server struct {
 	AttestationCache       *cache.AttestationCache
 	ProposerSlotIndexCache *cache.ProposerPayloadIDsCache
 	HeadFetcher            blockchain.HeadFetcher
+	HeadUpdater            blockchain.ChainInfoUpdater
 	ForkFetcher            blockchain.ForkFetcher
 	FinalizationFetcher    blockchain.FinalizationFetcher
 	TimeFetcher            blockchain.TimeFetcher

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -78,6 +78,7 @@ type Config struct {
 	BeaconMonitoringPort    int
 	BeaconDB                db.HeadAccessDatabase
 	ChainInfoFetcher        blockchain.ChainInfoFetcher
+	ChainInfoUpdater        blockchain.ChainInfoUpdater
 	HeadFetcher             blockchain.HeadFetcher
 	CanonicalFetcher        blockchain.CanonicalFetcher
 	ForkFetcher             blockchain.ForkFetcher
@@ -188,6 +189,7 @@ func (s *Service) Start() {
 		AttestationCache:       cache.NewAttestationCache(),
 		AttPool:                s.cfg.AttestationsPool,
 		ExitPool:               s.cfg.ExitPool,
+		HeadUpdater:            s.cfg.ChainInfoUpdater,
 		HeadFetcher:            s.cfg.HeadFetcher,
 		ForkFetcher:            s.cfg.ForkFetcher,
 		FinalizationFetcher:    s.cfg.FinalizationFetcher,

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -264,6 +264,7 @@ func (s *Service) Start() {
 		BeaconDB:                    s.cfg.BeaconDB,
 		AttestationsPool:            s.cfg.AttestationsPool,
 		SlashingsPool:               s.cfg.SlashingsPool,
+		HeadUpdater:                 s.cfg.ChainInfoUpdater,
 		HeadFetcher:                 s.cfg.HeadFetcher,
 		FinalizationFetcher:         s.cfg.FinalizationFetcher,
 		CanonicalFetcher:            s.cfg.CanonicalFetcher,

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -217,6 +217,7 @@ func (s *Service) Start() {
 	}
 	validatorServerV1 := &validator.Server{
 		HeadFetcher:      s.cfg.HeadFetcher,
+		HeadUpdater:      s.cfg.ChainInfoUpdater,
 		TimeFetcher:      s.cfg.GenesisTimeFetcher,
 		SyncChecker:      s.cfg.SyncService,
 		AttestationsPool: s.cfg.AttestationsPool,

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -91,7 +91,7 @@ func (bb *Builder) Check(t testing.TB, c *Check) {
 	}
 	ctx := context.TODO()
 
-	require.NoError(t, bb.service.UpdateAndSaveHeadWithBalances(ctx))
+	bb.service.UpdateAndSaveHead(ctx)
 	if c.Head != nil {
 		r, err := bb.service.HeadRoot(ctx)
 		require.NoError(t, err)

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -91,7 +91,7 @@ func (bb *Builder) Check(t testing.TB, c *Check) {
 	}
 	ctx := context.TODO()
 
-	bb.service.UpdateAndSaveHead(ctx)
+	require.NoError(t, bb.service.UpdateAndSaveHead(ctx))
 	if c.Head != nil {
 		r, err := bb.service.HeadRoot(ctx)
 		require.NoError(t, err)


### PR DESCRIPTION
Update head with the latest forkchoice data before proposing a block. 

This is required by https://github.com/ethereum/consensus-specs/pull/2878