### PR TITLE
Fix process atts interval to 0 and 6s of slot

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -117,7 +117,7 @@ func (s *Service) spawnProcessAttestationsRoutine(stateFeed *event.Feed) {
 			log.Warn("Genesis time received, now available to process attestations")
 		}
 
-		st := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)
+		st := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot/2)
 		for {
 			select {
 			case <-s.ctx.Done():


### PR DESCRIPTION
For some reason, we always say that Prysm processes attestations at 0 and 6s interval but the code shows only at 0. 
This fixes it to 0 and 6s