### PR TITLE
Perform Request Size Limiting When Caching Eth1 Headers

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -40,6 +41,10 @@ const multiplicativeDecreaseDivisor = 2
 func tooMuchDataRequestedError(err error) bool {
 	// this error is only infura specific (other providers might have different error messages)
 	return err.Error() == "query returned more than 10000 results"
+}
+
+func clientTimedOutError(err error) bool {
+	return strings.Contains(err.Error(), "net/http: request canceled")
 }
 
 // Eth2GenesisPowchainInfo retrieves the genesis time and eth1 block number of the beacon chain

--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -38,13 +38,15 @@ const depositlogRequestLimit = 10000
 const additiveFactorMultiplier = 0.10
 const multiplicativeDecreaseDivisor = 2
 
+var errTimedOut = errors.New("net/http: request canceled")
+
 func tooMuchDataRequestedError(err error) bool {
 	// this error is only infura specific (other providers might have different error messages)
 	return err.Error() == "query returned more than 10000 results"
 }
 
 func clientTimedOutError(err error) bool {
-	return strings.Contains(err.Error(), "net/http: request canceled")
+	return strings.Contains(err.Error(), errTimedOut.Error())
 }
 
 // Eth2GenesisPowchainInfo retrieves the genesis time and eth1 block number of the beacon chain

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -714,13 +714,14 @@ func (s *Service) cacheHeadersForEth1DataVote(ctx context.Context) error {
 		_, err = s.batchRequestHeaders(startReq, endReq)
 		if err != nil {
 			if clientTimedOutError(err) {
+				// Reduce batch size as eth1 node is
+				// unable to respond to the request in time.
+				batchSize /= 2
+
 				// Reset request value
 				if i > batchSize {
 					i -= batchSize
 				}
-				// Reduce batch size as eth1 node is
-				// unable to respond to the request in time.
-				batchSize /= 2
 				continue
 			}
 			return err

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -703,6 +703,11 @@ func (s *Service) cacheHeadersForEth1DataVote(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	return s.cacheBlockHeaders(start, end)
+}
+
+// Caches block headers from the desired range.
+func (s *Service) cacheBlockHeaders(start, end uint64) error {
 	batchSize := s.cfg.eth1HeaderReqLimit
 	for i := start; i < end; i += batchSize {
 		startReq := i
@@ -711,7 +716,7 @@ func (s *Service) cacheHeadersForEth1DataVote(ctx context.Context) error {
 			endReq = end
 		}
 		// We call batchRequestHeaders for its header caching side-effect, so we don't need the return value.
-		_, err = s.batchRequestHeaders(startReq, endReq)
+		_, err := s.batchRequestHeaders(startReq, endReq)
 		if err != nil {
 			if clientTimedOutError(err) {
 				// Reduce batch size as eth1 node is

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -717,6 +717,10 @@ func (s *Service) cacheHeadersForEth1DataVote(ctx context.Context) error {
 				// Reduce batch size as eth1 node is
 				// unable to respond to the request in time.
 				batchSize /= 2
+				// Always have it greater than 0.
+				if batchSize == 0 {
+					batchSize += 1
+				}
 
 				// Reset request value
 				if i > batchSize {

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -703,10 +703,18 @@ func (s *Service) cacheHeadersForEth1DataVote(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// We call batchRequestHeaders for its header caching side-effect, so we don't need the return value.
-	_, err = s.batchRequestHeaders(start, end)
-	if err != nil {
-		return err
+	batchSize := s.cfg.eth1HeaderReqLimit
+	for i := start; i < end; i += batchSize {
+		startReq := i
+		endReq := i + batchSize
+		if endReq > end {
+			endReq = end
+		}
+		// We call batchRequestHeaders for its header caching side-effect, so we don't need the return value.
+		_, err = s.batchRequestHeaders(startReq, endReq)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/beacon-chain/powchain/service.go
+++ b/beacon-chain/powchain/service.go
@@ -713,6 +713,16 @@ func (s *Service) cacheHeadersForEth1DataVote(ctx context.Context) error {
 		// We call batchRequestHeaders for its header caching side-effect, so we don't need the return value.
 		_, err = s.batchRequestHeaders(startReq, endReq)
 		if err != nil {
+			if clientTimedOutError(err) {
+				// Reset request value
+				if i > batchSize {
+					i -= batchSize
+				}
+				// Reduce batch size as eth1 node is
+				// unable to respond to the request in time.
+				batchSize /= 2
+				continue
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

Feature Addition

**What does this PR do? Why is it needed?**

Some clients might take longer to respond with the request headers. The http client can time out before that time period, in order to allow different clients to run smoothly we dynamically adjust batch sizes depending so that we can come to an appropriate request size so that the connected eth1 client can respond in time.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
