### PR TITLE
simplify config names, use strings

### DIFF
--- a/beacon-chain/db/kv/genesis_test.go
+++ b/beacon-chain/db/kv/genesis_test.go
@@ -83,7 +83,7 @@ func TestEnsureEmbeddedGenesis(t *testing.T) {
 	// Embedded Genesis works with Mainnet config
 	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig()
-	cfg.ConfigName = params.ConfigNames[params.Mainnet]
+	cfg.ConfigName = params.MainnetName
 	params.OverrideBeaconConfig(cfg)
 
 	ctx := context.Background()

--- a/beacon-chain/db/kv/wss_test.go
+++ b/beacon-chain/db/kv/wss_test.go
@@ -15,13 +15,13 @@ func TestSaveOrigin(t *testing.T) {
 	// Embedded Genesis works with Mainnet config
 	params.SetupTestConfigCleanup(t)
 	cfg := params.BeaconConfig()
-	cfg.ConfigName = params.ConfigNames[params.Mainnet]
+	cfg.ConfigName = params.MainnetName
 	params.OverrideBeaconConfig(cfg)
 
 	ctx := context.Background()
 	db := setupDB(t)
 
-	st, err := genesis.State(params.Mainnet.String())
+	st, err := genesis.State(params.MainnetName)
 	require.NoError(t, err)
 
 	sb, err := st.MarshalSSZ()

--- a/beacon-chain/state/genesis/genesis.go
+++ b/beacon-chain/state/genesis/genesis.go
@@ -18,7 +18,7 @@ var (
 // State returns a copy of the genesis state from a hardcoded value.
 func State(name string) (state.BeaconState, error) {
 	switch name {
-	case params.ConfigNames[params.Mainnet]:
+	case params.MainnetName:
 		return load(mainnetRawSSZCompressed)
 	default:
 		// No state found.

--- a/beacon-chain/state/genesis/genesis_test.go
+++ b/beacon-chain/state/genesis/genesis_test.go
@@ -9,15 +9,15 @@ import (
 
 func TestGenesisState(t *testing.T) {
 	tests := []struct {
-		name params.ConfigName
+		name string
 	}{
 		{
-			name: params.Mainnet,
+			name: params.MainnetName,
 		},
 	}
 	for _, tt := range tests {
-		t.Run(params.ConfigNames[tt.name], func(t *testing.T) {
-			st, err := genesis.State(params.ConfigNames[tt.name])
+		t.Run(tt.name, func(t *testing.T) {
+			st, err := genesis.State(tt.name)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/config/params/BUILD.bazel
+++ b/config/params/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "mainnet_config.go",
         "minimal_config.go",
         "network_config.go",
+        "registry.go",
         "testnet_e2e_config.go",
         "testnet_prater_config.go",
         "testutils.go",

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -183,7 +183,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	MaxPeersToSync:                 15,
 	SlotsPerArchivedPoint:          2048,
 	GenesisCountdownInterval:       time.Minute,
-	ConfigName:                     ConfigNames[Mainnet],
+	ConfigName:                     MainnetName,
 	PresetBase:                     "mainnet",
 	BeaconStateFieldCount:          21,
 	BeaconStateAltairFieldCount:    24,

--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -101,7 +101,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.DepositNetworkID = 5 // Network ID of eth1 goerli.
 	minimalConfig.DepositContractAddress = "0x1234567890123456789012345678901234567890"
 
-	minimalConfig.ConfigName = ConfigNames[Minimal]
+	minimalConfig.ConfigName = MinimalName
 	minimalConfig.PresetBase = "minimal"
 
 	minimalConfig.InitializeForkSchedule()

--- a/config/params/registry.go
+++ b/config/params/registry.go
@@ -1,0 +1,10 @@
+package params
+
+var Registry *registry
+
+type registry struct {
+}
+
+func init() {
+	Registry = &registry{}
+}

--- a/config/params/testnet_e2e_config.go
+++ b/config/params/testnet_e2e_config.go
@@ -53,7 +53,7 @@ func E2ETestConfig() *BeaconChainConfig {
 	e2eConfig.TerminalTotalDifficulty = "616"
 
 	// Prysm constants.
-	e2eConfig.ConfigName = ConfigNames[EndToEnd]
+	e2eConfig.ConfigName = EndToEndName
 	e2eConfig.GenesisForkVersion = []byte{0, 0, 0, 253}
 	e2eConfig.AltairForkVersion = []byte{1, 0, 0, 253}
 	e2eConfig.BellatrixForkVersion = []byte{2, 0, 0, 253}
@@ -90,7 +90,7 @@ func E2EMainnetTestConfig() *BeaconChainConfig {
 	e2eConfig.TerminalTotalDifficulty = "616"
 
 	// Prysm constants.
-	e2eConfig.ConfigName = ConfigNames[EndToEnd]
+	e2eConfig.ConfigName = EndToEndName
 	e2eConfig.GenesisForkVersion = []byte{0, 0, 0, 254}
 	e2eConfig.AltairForkVersion = []byte{1, 0, 0, 254}
 	e2eConfig.BellatrixForkVersion = []byte{2, 0, 0, 254}

--- a/config/params/testnet_prater_config.go
+++ b/config/params/testnet_prater_config.go
@@ -34,7 +34,7 @@ func PraterConfig() *BeaconChainConfig {
 	cfg := MainnetConfig().Copy()
 	cfg.MinGenesisTime = 1614588812
 	cfg.GenesisDelay = 1919188
-	cfg.ConfigName = ConfigNames[Prater]
+	cfg.ConfigName = PraterName
 	cfg.GenesisForkVersion = []byte{0x00, 0x00, 0x10, 0x20}
 	cfg.SecondsPerETH1Block = 14
 	cfg.DepositChainID = eth1Params.GoerliChainConfig.ChainID.Uint64()

--- a/config/params/values.go
+++ b/config/params/values.go
@@ -9,43 +9,23 @@ import (
 )
 
 const (
-	Mainnet ConfigName = iota
-	Minimal
-	EndToEnd
-	Prater
-	EndToEndMainnet
+	EndToEndName = "end-to-end"
+	EndToEndMainnetName = "end-to-end-mainnet"
+	MainnetName = "mainnet"
+	MinimalName = "minimal"
+	PraterName = "prater"
 )
 
-// ConfigName enum describes the type of known network in use.
-type ConfigName int
-
-func (n ConfigName) String() string {
-	s, ok := ConfigNames[n]
-	if !ok {
-		return "undefined"
-	}
-	return s
-}
-
-// ConfigNames provides network configuration names.
-var ConfigNames = map[ConfigName]string{
-	Mainnet:         "mainnet",
-	Minimal:         "minimal",
-	EndToEnd:        "end-to-end",
-	Prater:          "prater",
-	EndToEndMainnet: "end-to-end-mainnet",
-}
-
 // KnownConfigs provides an index of all known BeaconChainConfig values.
-var KnownConfigs = map[ConfigName]func() *BeaconChainConfig{
-	Mainnet:         MainnetConfig,
-	Prater:          PraterConfig,
-	Minimal:         MinimalSpecConfig,
-	EndToEnd:        E2ETestConfig,
-	EndToEndMainnet: E2EMainnetTestConfig,
+var KnownConfigs = map[string]func() *BeaconChainConfig{
+	MainnetName:         MainnetConfig,
+	PraterName:          PraterConfig,
+	MinimalName:         MinimalSpecConfig,
+	EndToEndName:        E2ETestConfig,
+	EndToEndMainnetName: E2EMainnetTestConfig,
 }
 
-var knownForkVersions map[[fieldparams.VersionLength]byte]ConfigName
+var knownForkVersions map[[fieldparams.VersionLength]byte]string
 
 var errUnknownForkVersion = errors.New("version not found in fork version schedule for any known config")
 
@@ -60,12 +40,12 @@ func ConfigForVersion(version [fieldparams.VersionLength]byte) (*BeaconChainConf
 }
 
 func init() {
-	knownForkVersions = make(map[[fieldparams.VersionLength]byte]ConfigName)
+	knownForkVersions = make(map[[fieldparams.VersionLength]byte]string)
 	for n, cfunc := range KnownConfigs {
 		cfg := cfunc()
 		// ensure that fork schedule is consistent w/ struct fields for all known configurations
 		if err := equalForkSchedules(configForkSchedule(cfg), cfg.ForkVersionSchedule); err != nil {
-			panic(errors.Wrapf(err, "improperly initialized for schedule for config %s", n.String()))
+			panic(errors.Wrapf(err, "improperly initialized for schedule for config %s", n))
 		}
 		// ensure that all fork versions are unique
 		for v := range cfg.ForkVersionSchedule {

--- a/config/params/values.go
+++ b/config/params/values.go
@@ -9,11 +9,11 @@ import (
 )
 
 const (
-	EndToEndName = "end-to-end"
+	EndToEndName        = "end-to-end"
 	EndToEndMainnetName = "end-to-end-mainnet"
-	MainnetName = "mainnet"
-	MinimalName = "minimal"
-	PraterName = "prater"
+	MainnetName         = "mainnet"
+	MinimalName         = "minimal"
+	PraterName          = "prater"
 )
 
 // KnownConfigs provides an index of all known BeaconChainConfig values.

--- a/encoding/ssz/detect/configfork_test.go
+++ b/encoding/ssz/detect/configfork_test.go
@@ -177,21 +177,21 @@ func hackBellatrixMaxuint() (*params.BeaconChainConfig, func()) {
 	bc.InitializeForkSchedule()
 	params.OverrideBeaconConfig(bc)
 	// override the param used for mainnet with the patched version
-	params.KnownConfigs[params.Mainnet] = func() *params.BeaconChainConfig {
+	params.KnownConfigs[params.MainnetName] = func() *params.BeaconChainConfig {
 		return bc
 	}
 	return bc, func() {
 		// put the previous BeaconChainConfig back in place at the end of the test
 		params.OverrideBeaconConfig(previous)
 		// restore the normal MainnetConfig func in the KnownConfigs mapping
-		params.KnownConfigs[params.Mainnet] = params.MainnetConfig
+		params.KnownConfigs[params.MainnetName] = params.MainnetConfig
 	}
 }
 
 func TestUnmarshalBlock(t *testing.T) {
 	bc, cleanup := hackBellatrixMaxuint()
 	defer cleanup()
-	require.Equal(t, types.Epoch(math.MaxUint32), params.KnownConfigs[params.Mainnet]().BellatrixForkEpoch)
+	require.Equal(t, types.Epoch(math.MaxUint32), params.KnownConfigs[params.MainnetName]().BellatrixForkEpoch)
 	genv := bytesutil.ToBytes4(bc.GenesisForkVersion)
 	altairv := bytesutil.ToBytes4(bc.AltairForkVersion)
 	bellav := bytesutil.ToBytes4(bc.BellatrixForkVersion)

--- a/network/forks/ordered_test.go
+++ b/network/forks/ordered_test.go
@@ -13,7 +13,7 @@ func TestOrderedConfigSchedule(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
 	for name, getCfg := range params.KnownConfigs {
 		cfg := getCfg()
-		t.Run(name.String(), func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			prevVersion := [4]byte{0, 0, 0, 0}
 			// epoch 0 is genesis, and it's a uint so can't make it -1
 			// so we use a pointer to detect the boundary condition and skip it

--- a/validator/accounts/accounts_exit.go
+++ b/validator/accounts/accounts_exit.go
@@ -276,7 +276,7 @@ func displayExitInfo(rawExitedKeys [][]byte, trimmedExitedKeys []string) {
 		urlFormattedPubKeys := make([]string, len(rawExitedKeys))
 		for i, key := range rawExitedKeys {
 			var baseUrl string
-			if params.BeaconConfig().ConfigName == params.ConfigNames[params.Prater] {
+			if params.BeaconConfig().ConfigName == params.PraterName {
 				baseUrl = "https://prater.beaconcha.in/validator/"
 			} else {
 				baseUrl = "https://beaconcha.in/validator/"


### PR DESCRIPTION
**What type of PR is this?**

Other
- cleanup

**What does this PR do? Why is it needed?**

This is just a small tidy up PR, replacing ConfigName custom type with regular old strings to remove some convoluted reverse mapping operations and make things simpler.
