### PR TITLE
Fix Multiclient E2E Runs

### DIFF
--- a/testing/endtoend/evaluators/validator.go
+++ b/testing/endtoend/evaluators/validator.go
@@ -114,6 +114,12 @@ func validatorsParticipating(conns ...*grpc.ClientConn) error {
 
 	partRate := participation.Participation.GlobalParticipationRate
 	expected := float32(expectedParticipation)
+	if participation.Epoch > 0 && participation.Epoch.Sub(1) == helpers.BellatrixE2EForkEpoch {
+		// Reduce Participation requirement to 95% to account for longer EE calls for
+		// the merge block. Target and head will likely be missed for a few validators at
+		// slot 0.
+		expected = 0.95
+	}
 	if partRate < expected {
 		st, err := debugClient.GetBeaconStateV2(context.Background(), &eth.StateRequestV2{StateId: []byte("head")})
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

E2E Improvement

**What does this PR do? Why is it needed?**

During the bellatrix fork epoch at the merge block, the initial Execution engine calls can take a while. This might lead to validators not attesting the merge block in time, leading to lower participation. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
