### PR TITLE
Fix `error.Is` ordering

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -223,6 +223,7 @@ go_test(
         "@com_github_libp2p_go_libp2p_pubsub//:go_default_library",
         "@com_github_libp2p_go_libp2p_pubsub//pb:go_default_library",
         "@com_github_patrickmn_go_cache//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -33,7 +33,7 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 	}
 
 	if err := s.cfg.chain.ReceiveBlock(ctx, signed, root); err != nil {
-		if !errors.Is(err, powchain.ErrHTTPTimeout) && !errors.Is(blockchain.ErrUndefinedExecutionEngineError, err) {
+		if !errors.Is(err, powchain.ErrHTTPTimeout) && !errors.Is(err, blockchain.ErrUndefinedExecutionEngineError) {
 			interop.WriteBlockToDisk(signed, true /*failed*/)
 			s.setBadBlock(ctx, root)
 		}

--- a/beacon-chain/sync/subscriber_beacon_blocks_test.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain"
 	chainMock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/helpers"
 	dbtest "github.com/prysmaticlabs/prysm/beacon-chain/db/testing"
@@ -122,6 +124,24 @@ func TestService_BeaconBlockSubscribe_ExecutionEngineTimesOut(t *testing.T) {
 		badBlockCache:  lruwrpr.New(10),
 	}
 	require.ErrorIs(t, powchain.ErrHTTPTimeout, s.beaconBlockSubscriber(context.Background(), util.NewBeaconBlock()))
+	require.Equal(t, 0, len(s.badBlockCache.Keys()))
+	require.Equal(t, 1, len(s.seenBlockCache.Keys()))
+}
+
+func TestService_BeaconBlockSubscribe_UndefinedEeError(t *testing.T) {
+	msg := "timeout"
+	err := errors.WithMessage(blockchain.ErrUndefinedExecutionEngineError, msg)
+
+	s := &Service{
+		cfg: &config{
+			chain: &chainMock.ChainService{
+				ReceiveBlockMockErr: err,
+			},
+		},
+		seenBlockCache: lruwrpr.New(10),
+		badBlockCache:  lruwrpr.New(10),
+	}
+	require.ErrorIs(t, s.beaconBlockSubscriber(context.Background(), util.NewBeaconBlock()), blockchain.ErrUndefinedExecutionEngineError)
 	require.Equal(t, 0, len(s.badBlockCache.Keys()))
 	require.Equal(t, 1, len(s.seenBlockCache.Keys()))
 }


### PR DESCRIPTION
`error.Is` should be used as `func Is(err, target error)` but we had it `(target, err error)` This PR fixed it and added a unit test