### PR TITLE
Add is_optimistic to SyncDetails, hydrate via ValidateSync

### DIFF
--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -198,7 +198,7 @@ type versionResponseJson struct {
 
 // syncingResponseJson is used in /node/syncing API endpoint.
 type syncingResponseJson struct {
-	Data *syncInfoJson `json:"data"`
+	Data *syncDetailsJson `json:"data"`
 }
 
 // beaconStateResponseJson is used in /debug/beacon/states/{state_id} API endpoint.
@@ -775,12 +775,6 @@ type depositContractJson struct {
 	Address string `json:"address"`
 }
 
-type syncInfoJson struct {
-	HeadSlot     string `json:"head_slot"`
-	SyncDistance string `json:"sync_distance"`
-	IsSyncing    bool   `json:"is_syncing"`
-}
-
 type attesterDutyJson struct {
 	Pubkey                  string `json:"pubkey" hex:"true"`
 	ValidatorIndex          string `json:"validator_index"`
@@ -932,7 +926,7 @@ type singleIndexedVerificationFailureJson struct {
 
 type nodeSyncDetailsErrorJson struct {
 	apimiddleware.DefaultErrorJson
-	SyncDetails syncDetails `json:"sync_details"`
+	SyncDetails syncDetailsJson `json:"sync_details"`
 }
 
 type eventErrorJson struct {
@@ -940,8 +934,10 @@ type eventErrorJson struct {
 	Message    string `json:"message"`
 }
 
-type syncDetails struct {
+// TODO: Duplicated in error_handling.go
+type syncDetailsJson struct {
 	HeadSlot     string `json:"head_slot"`
 	SyncDistance string `json:"sync_distance"`
 	IsSyncing    bool   `json:"is_syncing"`
+	IsOptimistic bool   `json:"is_optimistic"`
 }

--- a/beacon-chain/rpc/eth/beacon/validator.go
+++ b/beacon-chain/rpc/eth/beacon/validator.go
@@ -38,11 +38,11 @@ func (e *invalidValidatorIdError) Error() string {
 }
 
 // GetValidator returns a validator specified by state and id or public key along with status and balance.
-func (bs *Server) GetValidator(ctx context.Context, req *ethpb.StateValidatorRequest) (*ethpb.StateValidatorResponse, error) {
+func (beaconServer *Server) GetValidator(ctx context.Context, req *ethpb.StateValidatorRequest) (*ethpb.StateValidatorResponse, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon.GetValidator")
 	defer span.End()
 
-	st, err := bs.StateFetcher.State(ctx, req.StateId)
+	st, err := beaconServer.StateFetcher.State(ctx, req.StateId)
 	if err != nil {
 		return nil, helpers.PrepareStateFetchGRPCError(err)
 	}
@@ -57,7 +57,7 @@ func (bs *Server) GetValidator(ctx context.Context, req *ethpb.StateValidatorReq
 		return nil, status.Error(codes.NotFound, "Could not find validator")
 	}
 
-	isOptimistic, err := helpers.IsOptimistic(ctx, st, bs.OptimisticModeFetcher)
+	isOptimistic, err := helpers.IsOptimistic(ctx, st, beaconServer.OptimisticModeFetcher)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not check if slot's block is optimistic: %v", err)
 	}
@@ -66,11 +66,11 @@ func (bs *Server) GetValidator(ctx context.Context, req *ethpb.StateValidatorReq
 }
 
 // ListValidators returns filterable list of validators with their balance, status and index.
-func (bs *Server) ListValidators(ctx context.Context, req *ethpb.StateValidatorsRequest) (*ethpb.StateValidatorsResponse, error) {
+func (beaconServer *Server) ListValidators(ctx context.Context, req *ethpb.StateValidatorsRequest) (*ethpb.StateValidatorsResponse, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon.ListValidators")
 	defer span.End()
 
-	st, err := bs.StateFetcher.State(ctx, req.StateId)
+	st, err := beaconServer.StateFetcher.State(ctx, req.StateId)
 	if err != nil {
 		return nil, helpers.PrepareStateFetchGRPCError(err)
 	}
@@ -80,7 +80,7 @@ func (bs *Server) ListValidators(ctx context.Context, req *ethpb.StateValidators
 		return nil, handleValContainerErr(err)
 	}
 
-	isOptimistic, err := helpers.IsOptimistic(ctx, st, bs.OptimisticModeFetcher)
+	isOptimistic, err := helpers.IsOptimistic(ctx, st, beaconServer.OptimisticModeFetcher)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not check if slot's block is optimistic: %v", err)
 	}
@@ -122,11 +122,11 @@ func (bs *Server) ListValidators(ctx context.Context, req *ethpb.StateValidators
 }
 
 // ListValidatorBalances returns a filterable list of validator balances.
-func (bs *Server) ListValidatorBalances(ctx context.Context, req *ethpb.ValidatorBalancesRequest) (*ethpb.ValidatorBalancesResponse, error) {
+func (beaconServer *Server) ListValidatorBalances(ctx context.Context, req *ethpb.ValidatorBalancesRequest) (*ethpb.ValidatorBalancesResponse, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon.ListValidatorBalances")
 	defer span.End()
 
-	st, err := bs.StateFetcher.State(ctx, req.StateId)
+	st, err := beaconServer.StateFetcher.State(ctx, req.StateId)
 	if err != nil {
 		return nil, helpers.PrepareStateFetchGRPCError(err)
 	}
@@ -143,7 +143,7 @@ func (bs *Server) ListValidatorBalances(ctx context.Context, req *ethpb.Validato
 		}
 	}
 
-	isOptimistic, err := helpers.IsOptimistic(ctx, st, bs.OptimisticModeFetcher)
+	isOptimistic, err := helpers.IsOptimistic(ctx, st, beaconServer.OptimisticModeFetcher)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not check if slot's block is optimistic: %v", err)
 	}
@@ -153,11 +153,11 @@ func (bs *Server) ListValidatorBalances(ctx context.Context, req *ethpb.Validato
 
 // ListCommittees retrieves the committees for the given state at the given epoch.
 // If the requested slot and index are defined, only those committees are returned.
-func (bs *Server) ListCommittees(ctx context.Context, req *ethpb.StateCommitteesRequest) (*ethpb.StateCommitteesResponse, error) {
+func (beaconServer *Server) ListCommittees(ctx context.Context, req *ethpb.StateCommitteesRequest) (*ethpb.StateCommitteesResponse, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon.ListCommittees")
 	defer span.End()
 
-	st, err := bs.StateFetcher.State(ctx, req.StateId)
+	st, err := beaconServer.StateFetcher.State(ctx, req.StateId)
 	if err != nil {
 		return nil, helpers.PrepareStateFetchGRPCError(err)
 	}
@@ -202,7 +202,7 @@ func (bs *Server) ListCommittees(ctx context.Context, req *ethpb.StateCommittees
 		}
 	}
 
-	isOptimistic, err := helpers.IsOptimistic(ctx, st, bs.OptimisticModeFetcher)
+	isOptimistic, err := helpers.IsOptimistic(ctx, st, beaconServer.OptimisticModeFetcher)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not check if slot's block is optimistic: %v", err)
 	}

--- a/beacon-chain/rpc/eth/helpers/error_handling.go
+++ b/beacon-chain/rpc/eth/helpers/error_handling.go
@@ -36,10 +36,14 @@ type SingleIndexedVerificationFailure struct {
 }
 
 // SyncDetails contain details about sync status.
+// TODO: Duplicated in structs.go
+// QUESTION: Why are these structs PascalCased, but those in structs.go are camelCased?
+// QUESTION: Possible to eliminate duplication by either importing structs.go here, or importing error_handling_structs into structs.go?
 type SyncDetails struct {
 	HeadSlot     string `json:"head_slot"`
 	SyncDistance string `json:"sync_distance"`
 	IsSyncing    bool   `json:"is_syncing"`
+	IsOptimistic bool   `json:"is_optimistic"`
 }
 
 // SyncDetailsContainer is a wrapper for SyncDetails.

--- a/beacon-chain/rpc/eth/helpers/sync.go
+++ b/beacon-chain/rpc/eth/helpers/sync.go
@@ -20,11 +20,26 @@ func ValidateSync(ctx context.Context, syncChecker sync.Checker, headFetcher blo
 		return nil
 	}
 	headSlot := headFetcher.HeadSlot()
+
+	// optimisticModeFetcher := TODO
+	// beaconServer := TODO -> ctx.beaconServer?
+	// beaconState, err := beaconServer.StateFetcher.State(ctx)
+	
+	// if err != nil {
+	// 	return status.Errorf(
+	// 		codes.Internal,
+	// 		"Could not fetch state from beacon server: %v",
+	// 		err,
+	// 	)
+	// }
+	
+	// QUESTION: how do we pass beaconstate / optimisticModeFetcher into IsOptimistic?
 	syncDetailsContainer := &SyncDetailsContainer{
 		SyncDetails: &SyncDetails{
 			HeadSlot:     strconv.FormatUint(uint64(headSlot), 10),
 			SyncDistance: strconv.FormatUint(uint64(timeFetcher.CurrentSlot()-headSlot), 10),
 			IsSyncing:    true,
+			IsOptimistic: IsOptimistic(ctx, nil, nil),
 		},
 	}
 	err := grpc.AppendCustomErrorHeader(ctx, syncDetailsContainer)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

1. adds `IsOptimistic` to `SyncDetails` struct in `error_handling.go`
2. removes duplication between `SyncDetails` and `SyncInfo` in `structs.go`
3. hydrates `IsOptimistic` within `sync.go` > `ValidateSync`.


**Which issues(s) does this PR fix?**

Fixes #10690

**Other notes for review**

 1. I have no idea what I'm doing, first time touching Go
 2. 99% sure this doesn't fix it, but I wanted to make it easy for an SME to tack on the true fixes