### PR TITLE
Drop Down Expected Sync Participation During Fork

### DIFF
--- a/testing/endtoend/evaluators/validator.go
+++ b/testing/endtoend/evaluators/validator.go
@@ -188,6 +188,14 @@ func validatorsSyncParticipation(conns ...*grpc.ClientConn) error {
 		if b.IsNil() {
 			return errors.New("nil block provided")
 		}
+		forkStartSlot, err := slots.EpochStart(helpers.AltairE2EForkEpoch)
+		if err != nil {
+			return err
+		}
+		if forkStartSlot == b.Block().Slot() {
+			// Skip fork slot.
+			continue
+		}
 		expectedParticipation := expectedSyncParticipation
 		switch slots.ToEpoch(b.Block().Slot()) {
 		case helpers.AltairE2EForkEpoch:

--- a/testing/endtoend/evaluators/validator.go
+++ b/testing/endtoend/evaluators/validator.go
@@ -188,18 +188,11 @@ func validatorsSyncParticipation(conns ...*grpc.ClientConn) error {
 		if b.IsNil() {
 			return errors.New("nil block provided")
 		}
-		forkSlot, err := slots.EpochStart(helpers.AltairE2EForkEpoch)
-		if err != nil {
-			return err
-		}
-		nexForkSlot, err := slots.EpochStart(helpers.BellatrixE2EForkEpoch)
-		if err != nil {
-			return err
-		}
-		switch b.Block().Slot() {
-		case forkSlot, forkSlot + 1, nexForkSlot:
-			// Skip evaluation of the slot.
-			continue
+		expectedParticipation := expectedSyncParticipation
+		switch slots.ToEpoch(b.Block().Slot()) {
+		case helpers.AltairE2EForkEpoch:
+			// Drop expected sync participation figure.
+			expectedParticipation = 0.90
 		default:
 			// no-op
 		}
@@ -207,7 +200,7 @@ func validatorsSyncParticipation(conns ...*grpc.ClientConn) error {
 		if err != nil {
 			return err
 		}
-		threshold := uint64(float64(syncAgg.SyncCommitteeBits.Len()) * expectedSyncParticipation)
+		threshold := uint64(float64(syncAgg.SyncCommitteeBits.Len()) * expectedParticipation)
 		if syncAgg.SyncCommitteeBits.Count() < threshold {
 			return errors.Errorf("In block of slot %d ,the aggregate bitvector with length of %d only got a count of %d", b.Block().Slot(), threshold, syncAgg.SyncCommitteeBits.Count())
 		}


### PR DESCRIPTION
**What type of PR is this?**

E2E Bug Fix

**What does this PR do? Why is it needed?**

- [x] During the altair fork, failed sync participation evaluators are a constant flake. This change chooses to lower the threshold to account for this.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
