### PR TITLE
Fix Slasher E2E Flakiness

### DIFF
--- a/beacon-chain/slasher/service.go
+++ b/beacon-chain/slasher/service.go
@@ -175,7 +175,6 @@ func (s *Service) waitForChainInitialization() {
 	stateChannel := make(chan *feed.Event, 1)
 	stateSub := s.serviceCfg.StateNotifier.StateFeed().Subscribe(stateChannel)
 	defer stateSub.Unsubscribe()
-	defer close(stateChannel)
 	for {
 		select {
 		case stateEvent := <-stateChannel:


### PR DESCRIPTION
Slasher was panicking sometimes as we would close a channel used for chainstart notifications when another service would try to send over the channel. This fixes the issue as an unsubscribe from the feed is sufficient