### PR TITLE
Update engine API err codes

### DIFF
--- a/beacon-chain/powchain/engine_client.go
+++ b/beacon-chain/powchain/engine_client.go
@@ -320,8 +320,12 @@ func handleRPCError(err error) error {
 		return ErrInvalidParams
 	case -32603:
 		return ErrInternal
-	case -32001:
+	case -38001:
 		return ErrUnknownPayload
+	case -38002:
+		return ErrInvalidForkchoiceState
+	case -38003:
+		return ErrInvalidPayloadAttributes
 	case -32000:
 		// Only -32000 status codes are data errors in the RPC specification.
 		errWithData, ok := err.(rpc.DataError)

--- a/beacon-chain/powchain/engine_client_test.go
+++ b/beacon-chain/powchain/engine_client_test.go
@@ -688,7 +688,17 @@ func Test_handleRPCError(t *testing.T) {
 		{
 			name:             "ErrUnknownPayload",
 			expectedContains: ErrUnknownPayload.Error(),
-			given:            &customError{code: -32001},
+			given:            &customError{code: -38001},
+		},
+		{
+			name:             "ErrInvalidForkchoiceState",
+			expectedContains: ErrInvalidForkchoiceState.Error(),
+			given:            &customError{code: -38002},
+		},
+		{
+			name:             "ErrInvalidPayloadAttributes",
+			expectedContains: ErrInvalidPayloadAttributes.Error(),
+			given:            &customError{code: -38003},
 		},
 		{
 			name:             "ErrServer unexpected no data",

--- a/beacon-chain/powchain/errors.go
+++ b/beacon-chain/powchain/errors.go
@@ -15,8 +15,12 @@ var (
 	ErrInternal = errors.New("internal JSON-RPC error")
 	// ErrServer corresponds to JSON-RPC code -32000.
 	ErrServer = errors.New("client error while processing request")
-	// ErrUnknownPayload corresponds to JSON-RPC code -32001.
+	// ErrUnknownPayload corresponds to JSON-RPC code -38001.
 	ErrUnknownPayload = errors.New("payload does not exist or is not available")
+	// ErrInvalidForkchoiceState corresponds to JSON-RPC code -38002.
+	ErrInvalidForkchoiceState = errors.New("invalid forkchoice state")
+	// ErrInvalidPayloadAttributes corresponds to JSON-RPC code -38003.
+	ErrInvalidPayloadAttributes = errors.New("payload attributes are invalid / inconsistent")
 	// ErrUnknownPayloadStatus when the payload status is unknown.
 	ErrUnknownPayloadStatus = errors.New("unknown payload status")
 	// ErrConfigMismatch when the execution node's terminal total difficulty or


### PR DESCRIPTION
This PR updates engine API error codes to align with https://github.com/ethereum/execution-apis/releases/tag/v1.0.0-alpha.9

References: 
https://github.com/ethereum/execution-apis/pull/211/files
https://github.com/ethereum/execution-apis/pull/213/files