### PR TITLE
Update .buildkite-bazelrc: change CI to use toplevel remote caching.

### DIFF
--- a/.buildkite-bazelrc
+++ b/.buildkite-bazelrc
@@ -10,7 +10,7 @@
 
 # Prysm specific remote-cache properties.
 #build:remote-cache --disk_cache=
-build:remote-cache --remote_download_minimal
+build:remote-cache --remote_download_toplevel
 build:remote-cache --remote_cache=grpc://bazel-remote-cache:9092
 build:remote-cache --experimental_remote_downloader=grpc://bazel-remote-cache:9092
 build:remote-cache --remote_local_fallback


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

This resolves the following error in CI.

```
java.io.IOException: Symlinks in action outputs are not yet supported by --experimental_remote_download_outputs=minimal
```

**Other notes for review**

See https://github.com/bazelbuild/bazel/issues/13355