### PR TITLE
Sync: use copied bits for seen cache

### DIFF
--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -252,7 +252,9 @@ func (s *Service) setSeenCommitteeIndicesSlot(slot types.Slot, committeeID types
 	s.seenUnAggregatedAttestationLock.Lock()
 	defer s.seenUnAggregatedAttestationLock.Unlock()
 	b := append(bytesutil.Bytes32(uint64(slot)), bytesutil.Bytes32(uint64(committeeID))...)
-	b = append(b, aggregateBits...)
+	var bits []byte
+	copy(bits, aggregateBits)
+	b = append(b, bits...)
 	s.seenUnAggregatedAttestationCache.Add(string(b), true)
 }
 


### PR DESCRIPTION
Per @nisdas 's comment on https://github.com/prysmaticlabs/prysm/pull/10674#discussion_r880105767
We should copy byte slices before setting them as cache keys in case protobuf unmarshalling creates unintended mutations 