### PR TITLE
Service: return errors on nil checkpoints

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -188,9 +188,15 @@ func (s *Service) StartFromSavedState(saved state.BeaconState) error {
 	if err != nil {
 		return errors.Wrap(err, "could not get justified checkpoint")
 	}
+	if justified == nil {
+		return errNilJustifiedCheckpoint
+	}
 	finalized, err := s.cfg.BeaconDB.FinalizedCheckpoint(s.ctx)
 	if err != nil {
 		return errors.Wrap(err, "could not get finalized checkpoint")
+	}
+	if finalized == nil {
+		return errNilFinalizedCheckpoint
 	}
 	s.store = store.New(justified, finalized)
 


### PR DESCRIPTION
In the event where checkpoints are nil we should error instead of passing them to other init routines 