### PR TITLE
Remove Unnecessary Stack Traces for Engine Errors

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -118,7 +118,7 @@ func (s *Service) onBlock(ctx context.Context, signed interfaces.SignedBeaconBlo
 	}
 	isValidPayload, err := s.notifyNewPayload(ctx, postStateVersion, postStateHeader, signed)
 	if err != nil {
-		return errors.Wrap(err, "could not verify new payload")
+		return fmt.Errorf("could not verify new payload: %v", err)
 	}
 	if isValidPayload {
 		if err := s.validateMergeTransitionBlock(ctx, preStateVersion, preStateHeader, signed); err != nil {

--- a/beacon-chain/powchain/engine_client.go
+++ b/beacon-chain/powchain/engine_client.go
@@ -296,7 +296,7 @@ func handleRPCError(err error) error {
 		return nil
 	}
 	if isTimeout(err) {
-		return errors.Wrapf(ErrHTTPTimeout, "%s", err)
+		return ErrHTTPTimeout
 	}
 	e, ok := err.(rpc.Error)
 	if !ok {
@@ -307,7 +307,7 @@ func handleRPCError(err error) error {
 				"here https://docs.prylabs.network/docs/execution-node/authentication")
 			return fmt.Errorf("could not authenticate connection to execution client: %v", err)
 		}
-		return errors.Wrap(err, "got an unexpected error")
+		return fmt.Errorf("got an unexpected error in JSON-RPC response: %v", err)
 	}
 	switch e.ErrorCode() {
 	case -32700:
@@ -330,7 +330,7 @@ func handleRPCError(err error) error {
 		// Only -32000 status codes are data errors in the RPC specification.
 		errWithData, ok := err.(rpc.DataError)
 		if !ok {
-			return errors.Wrap(err, "got an unexpected error")
+			return fmt.Errorf("got an unexpected error in JSON-RPC response: %v", err)
 		}
 		return errors.Wrapf(ErrServer, "%v", errWithData.ErrorData())
 	default:


### PR DESCRIPTION
When testing out merge UX, came across a few error logs that pop up if an execution client goes offline while Prysm is operational. Many of these did not print anything useful, and would just pollute the screen with stack traces that do not help us. As these are RPC errors, fmt.Errorf is sufficient