### PR TITLE
Write To Only One File For Geth Logs

### DIFF
--- a/testing/endtoend/components/eth1/miner.go
+++ b/testing/endtoend/components/eth1/miner.go
@@ -151,11 +151,10 @@ func (m *Miner) Start(ctx context.Context) error {
 	}
 
 	runCmd := exec.CommandContext(ctx, binaryPath, args...) // #nosec G204 -- Safe
-	file, err := helpers.DeleteAndCreateFile(e2e.TestParams.LogPath, "eth1_miner.log")
+	file, err := os.Create(path.Join(e2e.TestParams.LogPath, "eth1_miner.log"))
 	if err != nil {
 		return err
 	}
-	runCmd.Stdout = file
 	runCmd.Stderr = file
 	log.Infof("Starting eth1 miner with flags: %s", strings.Join(args[2:], " "))
 

--- a/testing/endtoend/components/eth1/node.go
+++ b/testing/endtoend/components/eth1/node.go
@@ -98,11 +98,10 @@ func (node *Node) Start(ctx context.Context) error {
 		args = append(args, []string{"--syncmode=full"}...)
 	}
 	runCmd := exec.CommandContext(ctx, binaryPath, args...) // #nosec G204 -- Safe
-	file, err := helpers.DeleteAndCreateFile(e2e.TestParams.LogPath, "eth1_"+strconv.Itoa(node.index)+".log")
+	file, err := os.Create(path.Join(e2e.TestParams.LogPath, "eth1_"+strconv.Itoa(node.index)+".log"))
 	if err != nil {
 		return err
 	}
-	runCmd.Stdout = file
 	runCmd.Stderr = file
 	log.Infof("Starting eth1 node %d with flags: %s", node.index, strings.Join(args[2:], " "))
 


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Currently we wrote both `stdout` and `stderr` logs to the same file, this introduced a race where it was possible for both these separate log processes to overwrite each other. This introduced possibilities where important logs went missing and led to E2E flakes.


**Which issues(s) does this PR fix?**

Fixes #10718 

**Other notes for review**
