### PR TITLE
Enforce that every node descends from finalized node

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -410,6 +410,8 @@ func (f *ForkChoice) CommonAncestorRoot(ctx context.Context, r1 [32]byte, r2 [32
 		if n1.slot > n2.slot {
 			n1 = n1.parent
 			// Reaches the end of the tree and unable to find common ancestor.
+			// This should not happen at runtime as the finalized
+			// node has to be a common ancestor
 			if n1 == nil {
 				return [32]byte{}, forkchoice.ErrUnknownCommonAncestor
 			}

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -401,7 +401,17 @@ func TestStore_CommonAncestor(t *testing.T) {
 		require.ErrorIs(t, err, ErrNilNode)
 		_, err = f.CommonAncestorRoot(ctx, [32]byte{'z'}, [32]byte{'a'})
 		require.ErrorIs(t, err, ErrNilNode)
-		require.NoError(t, f.InsertOptimisticBlock(ctx, 100, [32]byte{'y'}, [32]byte{'z'}, [32]byte{}, 1, 1))
+		n := &Node{
+			slot:                     100,
+			root:                     [32]byte{'y'},
+			justifiedEpoch:           1,
+			unrealizedJustifiedEpoch: 1,
+			finalizedEpoch:           1,
+			unrealizedFinalizedEpoch: 1,
+			optimistic:               true,
+		}
+
+		f.store.nodeByRoot[[32]byte{'y'}] = n
 		// broken link
 		_, err = f.CommonAncestorRoot(ctx, [32]byte{'y'}, [32]byte{'a'})
 		require.ErrorIs(t, err, forkchoice.ErrUnknownCommonAncestor)

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -125,17 +125,18 @@ func (s *Store) insert(ctx context.Context,
 
 	s.nodeByPayload[payloadHash] = n
 	s.nodeByRoot[root] = n
-	if parent != nil {
+	if parent == nil {
+		if s.treeRootNode == nil {
+			s.treeRootNode = n
+			s.headNode = n
+		} else {
+			return errInvalidParentRoot
+		}
+	} else {
 		parent.children = append(parent.children, n)
 		if err := s.treeRootNode.updateBestDescendant(ctx, s.justifiedEpoch, s.finalizedEpoch); err != nil {
 			return err
 		}
-	}
-
-	// Set the node as root if the store was empty
-	if s.treeRootNode == nil {
-		s.treeRootNode = n
-		s.headNode = n
 	}
 
 	// Update metrics.


### PR DESCRIPTION
This PR enforces that every node in the forkchoice tree is a descendant of the finalized root. This is only for the doubly linked tree implementation. 