### PR TITLE
Ensure finalized root can't be zeros

### DIFF
--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -373,7 +373,7 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, blk interfa
 		pendingRoots = append(pendingRoots, copiedRoot)
 		root = bytesutil.ToBytes32(b.Block().ParentRoot())
 	}
-	if len(pendingRoots) > 0 && root != bytesutil.ToBytes32(finalized.Root) {
+	if len(pendingRoots) > 0 && root != s.ensureRootNotZeros(bytesutil.ToBytes32(finalized.Root)) {
 		return errNotDescendantOfFinalized
 	}
 


### PR DESCRIPTION
Before the first checkpoint, the justified and finalized root are 0s in store. We shouldn't compare it against 0s, we should compare it against the genesis root