### PR TITLE
Fix Fuzzing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -89,10 +89,10 @@ jobs:
         # Use blst tag to allow go and bazel builds for blst.
         run: go build -v ./...
 
-        # fuzz and blst_disabled leverage go tag based stubs at compile time.
-        # Building with these tags should be checked and enforced at pre-submit.
-      - name: Build for fuzzing
-        run: go build -tags=fuzz,blst_disabled ./... 
+        # fuzz leverage go tag based stubs at compile time.
+        # Building and testing with these tags should be checked and enforced at pre-submit.
+      - name: Test for fuzzing
+        run: go test  -tags=fuzz,develop ./...  -test.run=^Fuzz
 
 # Tests run via Bazel for now...
 #      - name: Test

--- a/crypto/bls/blst/stub.go
+++ b/crypto/bls/blst/stub.go
@@ -1,5 +1,5 @@
-//go:build blst_disabled || fuzz
-// +build blst_disabled fuzz
+//go:build blst_disabled
+// +build blst_disabled
 
 package blst
 

--- a/fuzzbuzz.yaml
+++ b/fuzzbuzz.yaml
@@ -2,4 +2,3 @@ base:
   language: go
   build_tags:
     - fuzz
-    - blst_disabled


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In the event any of our fuzz targets use our blst library, they will panic and fail with this:
```
panic: blst is only supported on linux,darwin,windows
```
This PR fixes it by allowing fuzz targets to run with blst and adding test support for our fuzz targets in our github workflow.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
