### PR TITLE
Fill missing payload ID

### DIFF
--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -158,6 +158,10 @@ var (
 		Name: "forkchoice_updated_optimistic_node_count",
 		Help: "Count the number of optimistic nodes after forkchoiceUpdated EE call",
 	})
+	missedPayloadIDFilledCount = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "missed_payload_id_filled_count",
+		Help: "",
+	})
 )
 
 // reportSlotMetrics reports slot related metrics.

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -139,6 +139,7 @@ func (s *Service) Start() {
 		}
 	}
 	s.spawnProcessAttestationsRoutine(s.cfg.StateNotifier.StateFeed())
+	s.fillMissingPayloadIDRoutine(s.ctx, s.cfg.StateNotifier.StateFeed())
 }
 
 // Stop the blockchain service's main event loop and associated goroutines.


### PR DESCRIPTION
This fixes #10797

This PR implements a routine to check if there's a proposer at the next slot without payload ID cached. If there is, then we call fcu w/ payload attribute to cache the payload ID. 

I'll test this in kiln prod for a few days