### PR TITLE
Add registration DB methods

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -470,8 +470,20 @@ func (s *Store) FeeRecipientByValidatorID(ctx context.Context, id types.Validato
 	err := s.db.View(func(tx *bolt.Tx) error {
 		bkt := tx.Bucket(feeRecipientBucket)
 		addr = bkt.Get(bytesutil.Uint64ToBytesBigEndian(uint64(id)))
+		// IF the fee recipient is not found in the standard fee recipient bucket, then
+		// check the registration bucket. The fee recipient may be there.
+		// This is to resolve imcompatility until we fully migrate to the registration bucket.
 		if addr == nil {
-			return errors.Wrapf(ErrNotFoundFeeRecipient, "validator id %d", id)
+			bkt = tx.Bucket(registrationBucket)
+			enc := bkt.Get(bytesutil.Uint64ToBytesBigEndian(uint64(id)))
+			if enc == nil {
+				return errors.Wrapf(ErrNotFoundFeeRecipient, "validator id %d", id)
+			}
+			reg := &ethpb.ValidatorRegistrationV1{}
+			if err := decode(ctx, enc, reg); err != nil {
+				return err
+			}
+			addr = reg.FeeRecipient
 		}
 		return nil
 	})
@@ -492,6 +504,48 @@ func (s *Store) SaveFeeRecipientsByValidatorIDs(ctx context.Context, ids []types
 		bkt := tx.Bucket(feeRecipientBucket)
 		for i, id := range ids {
 			if err := bkt.Put(bytesutil.Uint64ToBytesBigEndian(uint64(id)), feeRecipients[i].Bytes()); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// RegistrationByValidatorID returns the validator registration object for a validator id.
+// `ErrNotFoundFeeRecipient` is returned if the validator id is not found.
+func (s *Store) RegistrationByValidatorID(ctx context.Context, id types.ValidatorIndex) (*ethpb.ValidatorRegistrationV1, error) {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.RegistrationByValidatorID")
+	defer span.End()
+	reg := &ethpb.ValidatorRegistrationV1{}
+	err := s.db.View(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(registrationBucket)
+		enc := bkt.Get(bytesutil.Uint64ToBytesBigEndian(uint64(id)))
+		if enc == nil {
+			return errors.Wrapf(ErrNotFoundFeeRecipient, "validator id %d", id)
+		}
+		return decode(ctx, enc, reg)
+	})
+	return reg, err
+}
+
+// SaveRegistrationsByValidatorIDs saves the validator registrations for validator ids.
+// Error is returned if `ids` and `registrations` are not the same length.
+func (s *Store) SaveRegistrationsByValidatorIDs(ctx context.Context, ids []types.ValidatorIndex, regs []*ethpb.ValidatorRegistrationV1) error {
+	_, span := trace.StartSpan(ctx, "BeaconDB.SaveRegistrationsByValidatorIDs")
+	defer span.End()
+
+	if len(ids) != len(regs) {
+		return errors.New("ids and registrations must be the same length")
+	}
+
+	return s.db.Update(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(registrationBucket)
+		for i, id := range ids {
+			enc, err := encode(ctx, regs[i])
+			if err != nil {
+				return err
+			}
+			if err := bkt.Put(bytesutil.Uint64ToBytesBigEndian(uint64(id)), enc); err != nil {
 				return err
 			}
 		}

--- a/beacon-chain/db/kv/encoding.go
+++ b/beacon-chain/db/kv/encoding.go
@@ -70,6 +70,8 @@ func isSSZStorageFormat(obj interface{}) bool {
 		return true
 	case *ethpb.VoluntaryExit:
 		return true
+	case *ethpb.ValidatorRegistrationV1:
+		return true
 	default:
 		return false
 	}

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -192,6 +192,7 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 			migrationsBucket,
 
 			feeRecipientBucket,
+			registrationBucket,
 		)
 	}); err != nil {
 		log.WithField("elapsed", time.Since(start)).Error("Failed to update db and create buckets")

--- a/beacon-chain/db/kv/schema.go
+++ b/beacon-chain/db/kv/schema.go
@@ -19,6 +19,7 @@ var (
 	powchainBucket          = []byte("powchain")
 	stateValidatorsBucket   = []byte("state-validators")
 	feeRecipientBucket      = []byte("fee-recipient")
+	registrationBucket      = []byte("registration")
 
 	// Deprecated: This bucket was migrated in PR 6461. Do not use, except for migrations.
 	slotsHasObjectBucket = []byte("slots-has-objects")

--- a/proto/prysm/v1alpha1/BUILD.bazel
+++ b/proto/prysm/v1alpha1/BUILD.bazel
@@ -108,6 +108,7 @@ ssz_gen_marshal(
         "BlindedBeaconBlockBellatrix",
         "BlindedBeaconBlockBodyBellatrix",
         "SignedValidatorRegistrationV1",
+        "ValidatorRegistrationV1",
     ],
 )
 


### PR DESCRIPTION
Add validator registration methods for DB and ensure the existing `FeeRecipientByValidatorID` also checks the registration bucket for backwards compatibility 