### PR TITLE
Only prune in newer finalization

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -459,7 +459,8 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.SignedBeac
 	if err := s.cfg.ForkChoiceStore.InsertNode(ctx, preState, lastBR); err != nil {
 		return errors.Wrap(err, "could not insert last block in batch to forkchoice")
 	}
-	// Prune forkchoice store
+	// Prune forkchoice store only if the new finalized checkpoint is higher
+	// than the finalized checkpoint in forkchoice store.
 	if fCheckpoints[len(blks)-1].Epoch > s.cfg.ForkChoiceStore.FinalizedEpoch() {
 		if err := s.cfg.ForkChoiceStore.Prune(ctx, s.ensureRootNotZeros(bytesutil.ToBytes32(fCheckpoints[len(blks)-1].Root))); err != nil {
 			return errors.Wrap(err, "could not prune fork choice nodes")

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -460,8 +460,10 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.SignedBeac
 		return errors.Wrap(err, "could not insert last block in batch to forkchoice")
 	}
 	// Prune forkchoice store
-	if err := s.cfg.ForkChoiceStore.Prune(ctx, s.ensureRootNotZeros(bytesutil.ToBytes32(fCheckpoints[len(blks)-1].Root))); err != nil {
-		return errors.Wrap(err, "could not prune fork choice nodes")
+	if fCheckpoints[len(blks)-1].Epoch > s.cfg.ForkChoiceStore.FinalizedEpoch() {
+		if err := s.cfg.ForkChoiceStore.Prune(ctx, s.ensureRootNotZeros(bytesutil.ToBytes32(fCheckpoints[len(blks)-1].Root))); err != nil {
+			return errors.Wrap(err, "could not prune fork choice nodes")
+		}
 	}
 
 	// Set their optimistic status

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -206,7 +206,7 @@ func (s *Service) StartFromSavedState(saved state.BeaconState) error {
 	s.store = store.New(justified, finalized)
 
 	var forkChoicer f.ForkChoicer
-	fRoot := bytesutil.ToBytes32(finalized.Root)
+	fRoot := s.ensureRootNotZeros(bytesutil.ToBytes32(finalized.Root))
 	if features.Get().EnableForkChoiceDoublyLinkedTree {
 		forkChoicer = doublylinkedtree.New(justified.Epoch, finalized.Epoch)
 	} else {


### PR DESCRIPTION
Only prune on init sync if the new finalized epoch is higher than the one in forkchoice. 

This can happen when just launching a node with a finalized state at slot `32 N`, when processing the batch `32 N + 1 .. 32 (N+1)` the node will attempt to prune `32 (N-1)` which is not in forkchoice at startup. 