### PR TITLE
Refactor: Reduce cognitive complexity for 5 out of top 10 functions in code base

### DIFF
--- a/beacon-chain/powchain/log_processing.go
+++ b/beacon-chain/powchain/log_processing.go
@@ -285,7 +285,6 @@ func (s *Service) processPastLogs(ctx context.Context) error {
 	if deploymentBlock > currentBlockNum {
 		currentBlockNum = deploymentBlock
 	}
-	// To store all blocks.
 	rawLogCount, err := s.depositContractCaller.GetDepositCount(&bind.CallOpts{})
 	if err != nil {
 		return err

--- a/validator/client/metrics.go
+++ b/validator/client/metrics.go
@@ -257,133 +257,136 @@ func (v *validator) LogValidatorGainsAndLosses(ctx context.Context, slot types.S
 			v.voteStats.startEpoch = prevEpoch
 		}
 	}
-	gweiPerEth := float64(params.BeaconConfig().GweiPerEth)
 	v.prevBalanceLock.Lock()
 	for i, pubKey := range resp.PublicKeys {
-		truncatedKey := fmt.Sprintf("%#x", bytesutil.Trunc(pubKey))
-		pubKeyBytes := bytesutil.ToBytes48(pubKey)
-		if slot < params.BeaconConfig().SlotsPerEpoch {
-			v.prevBalance[pubKeyBytes] = params.BeaconConfig().MaxEffectiveBalance
-		}
-
-		// Safely load data from response with slice out of bounds checks. The server should return
-		// the response with all slices of equal length, but the validator could panic if the server
-		// did not do so for whatever reason.
-		var balBeforeEpoch uint64
-		var balAfterEpoch uint64
-		var correctlyVotedSource bool
-		var correctlyVotedTarget bool
-		var correctlyVotedHead bool
-		if i < len(resp.BalancesBeforeEpochTransition) {
-			balBeforeEpoch = resp.BalancesBeforeEpochTransition[i]
-		} else {
-			log.WithField("pubKey", truncatedKey).Warn("Missing balance before epoch transition")
-		}
-		if i < len(resp.BalancesAfterEpochTransition) {
-			balAfterEpoch = resp.BalancesAfterEpochTransition[i]
-		} else {
-		}
-		if i < len(resp.CorrectlyVotedSource) {
-			correctlyVotedSource = resp.CorrectlyVotedSource[i]
-		} else {
-			log.WithField("pubKey", truncatedKey).Warn("Missing correctly voted source")
-		}
-		if i < len(resp.CorrectlyVotedTarget) {
-			correctlyVotedTarget = resp.CorrectlyVotedTarget[i]
-		} else {
-			log.WithField("pubKey", truncatedKey).Warn("Missing correctly voted target")
-		}
-		if i < len(resp.CorrectlyVotedHead) {
-			correctlyVotedHead = resp.CorrectlyVotedHead[i]
-		} else {
-			log.WithField("pubKey", truncatedKey).Warn("Missing correctly voted head")
-		}
-
-		if _, ok := v.startBalances[pubKeyBytes]; !ok {
-			v.startBalances[pubKeyBytes] = balBeforeEpoch
-		}
-
-		fmtKey := fmt.Sprintf("%#x", pubKey)
-		if v.prevBalance[pubKeyBytes] > 0 {
-			newBalance := float64(balAfterEpoch) / gweiPerEth
-			prevBalance := float64(balBeforeEpoch) / gweiPerEth
-			startBalance := float64(v.startBalances[pubKeyBytes]) / gweiPerEth
-			percentNet := (newBalance - prevBalance) / prevBalance
-			percentSinceStart := (newBalance - startBalance) / startBalance
-
-			previousEpochSummaryFields := logrus.Fields{
-				"pubKey":                  truncatedKey,
-				"epoch":                   prevEpoch,
-				"correctlyVotedSource":    correctlyVotedSource,
-				"correctlyVotedTarget":    correctlyVotedTarget,
-				"correctlyVotedHead":      correctlyVotedHead,
-				"startBalance":            startBalance,
-				"oldBalance":              prevBalance,
-				"newBalance":              newBalance,
-				"percentChange":           fmt.Sprintf("%.5f%%", percentNet*100),
-				"percentChangeSinceStart": fmt.Sprintf("%.5f%%", percentSinceStart*100),
-			}
-
-			// These fields are deprecated after Altair.
-			if slots.ToEpoch(slot) < params.BeaconConfig().AltairForkEpoch {
-				if i < len(resp.InclusionSlots) {
-					previousEpochSummaryFields["inclusionSlot"] = resp.InclusionSlots[i]
-				} else {
-					log.WithField("pubKey", truncatedKey).Warn("Missing inclusion slot")
-				}
-				if i < len(resp.InclusionDistances) {
-					previousEpochSummaryFields["inclusionDistance"] = resp.InclusionDistances[i]
-				} else {
-					log.WithField("pubKey", truncatedKey).Warn("Missing inclusion distance")
-				}
-			}
-			if slots.ToEpoch(slot) >= params.BeaconConfig().AltairForkEpoch {
-				if i < len(resp.InactivityScores) {
-					previousEpochSummaryFields["inactivityScore"] = resp.InactivityScores[i]
-				} else {
-					log.WithField("pubKey", truncatedKey).Warn("Missing inactivity score")
-				}
-			}
-
-			log.WithFields(previousEpochSummaryFields).Info("Previous epoch voting summary")
-			if v.emitAccountMetrics {
-				ValidatorBalancesGaugeVec.WithLabelValues(fmtKey).Set(newBalance)
-				if correctlyVotedSource {
-					ValidatorCorrectlyVotedSourceGaugeVec.WithLabelValues(fmtKey).Set(1)
-				} else {
-					ValidatorCorrectlyVotedSourceGaugeVec.WithLabelValues(fmtKey).Set(0)
-				}
-				if correctlyVotedTarget {
-					ValidatorCorrectlyVotedTargetGaugeVec.WithLabelValues(fmtKey).Set(1)
-				} else {
-					ValidatorCorrectlyVotedTargetGaugeVec.WithLabelValues(fmtKey).Set(0)
-				}
-				if correctlyVotedHead {
-					ValidatorCorrectlyVotedHeadGaugeVec.WithLabelValues(fmtKey).Set(1)
-				} else {
-					ValidatorCorrectlyVotedHeadGaugeVec.WithLabelValues(fmtKey).Set(0)
-				}
-
-				// Phase0 specific metrics
-				if slots.ToEpoch(slot) < params.BeaconConfig().AltairForkEpoch {
-					if i < len(resp.InclusionDistances) {
-						ValidatorInclusionDistancesGaugeVec.WithLabelValues(fmtKey).Set(float64(resp.InclusionDistances[i]))
-					}
-				} else { // Altair specific metrics.
-					// Reset phase0 fields that no longer apply
-					ValidatorInclusionDistancesGaugeVec.DeleteLabelValues(fmtKey)
-					if i < len(resp.InactivityScores) {
-						ValidatorInactivityScoreGaugeVec.WithLabelValues(fmtKey).Set(float64(resp.InactivityScores[i]))
-					}
-				}
-			}
-		}
-		v.prevBalance[pubKeyBytes] = balBeforeEpoch
+		v.logForEachValidator(i, pubKey, resp, slot, prevEpoch)
 	}
 	v.prevBalanceLock.Unlock()
 
 	v.UpdateLogAggregateStats(resp, slot)
 	return nil
+}
+
+func (v *validator) logForEachValidator(index int, pubKey []byte, resp *ethpb.ValidatorPerformanceResponse, slot types.Slot, prevEpoch types.Epoch) {
+	truncatedKey := fmt.Sprintf("%#x", bytesutil.Trunc(pubKey))
+	pubKeyBytes := bytesutil.ToBytes48(pubKey)
+	if slot < params.BeaconConfig().SlotsPerEpoch {
+		v.prevBalance[pubKeyBytes] = params.BeaconConfig().MaxEffectiveBalance
+	}
+
+	// Safely load data from response with slice out of bounds checks. The server should return
+	// the response with all slices of equal length, but the validator could panic if the server
+	// did not do so for whatever reason.
+	var balBeforeEpoch uint64
+	var balAfterEpoch uint64
+	var correctlyVotedSource bool
+	var correctlyVotedTarget bool
+	var correctlyVotedHead bool
+	if index < len(resp.BalancesBeforeEpochTransition) {
+		balBeforeEpoch = resp.BalancesBeforeEpochTransition[index]
+	} else {
+		log.WithField("pubKey", truncatedKey).Warn("Missing balance before epoch transition")
+	}
+	if index < len(resp.BalancesAfterEpochTransition) {
+		balAfterEpoch = resp.BalancesAfterEpochTransition[index]
+	}
+	if index < len(resp.CorrectlyVotedSource) {
+		correctlyVotedSource = resp.CorrectlyVotedSource[index]
+	} else {
+		log.WithField("pubKey", truncatedKey).Warn("Missing correctly voted source")
+	}
+	if index < len(resp.CorrectlyVotedTarget) {
+		correctlyVotedTarget = resp.CorrectlyVotedTarget[index]
+	} else {
+		log.WithField("pubKey", truncatedKey).Warn("Missing correctly voted target")
+	}
+	if index < len(resp.CorrectlyVotedHead) {
+		correctlyVotedHead = resp.CorrectlyVotedHead[index]
+	} else {
+		log.WithField("pubKey", truncatedKey).Warn("Missing correctly voted head")
+	}
+
+	if _, ok := v.startBalances[pubKeyBytes]; !ok {
+		v.startBalances[pubKeyBytes] = balBeforeEpoch
+	}
+
+	fmtKey := fmt.Sprintf("%#x", pubKey)
+	gweiPerEth := float64(params.BeaconConfig().GweiPerEth)
+	if v.prevBalance[pubKeyBytes] > 0 {
+		newBalance := float64(balAfterEpoch) / gweiPerEth
+		prevBalance := float64(balBeforeEpoch) / gweiPerEth
+		startBalance := float64(v.startBalances[pubKeyBytes]) / gweiPerEth
+		percentNet := (newBalance - prevBalance) / prevBalance
+		percentSinceStart := (newBalance - startBalance) / startBalance
+
+		previousEpochSummaryFields := logrus.Fields{
+			"pubKey":                  truncatedKey,
+			"epoch":                   prevEpoch,
+			"correctlyVotedSource":    correctlyVotedSource,
+			"correctlyVotedTarget":    correctlyVotedTarget,
+			"correctlyVotedHead":      correctlyVotedHead,
+			"startBalance":            startBalance,
+			"oldBalance":              prevBalance,
+			"newBalance":              newBalance,
+			"percentChange":           fmt.Sprintf("%.5f%%", percentNet*100),
+			"percentChangeSinceStart": fmt.Sprintf("%.5f%%", percentSinceStart*100),
+		}
+
+		// These fields are deprecated after Altair.
+		if slots.ToEpoch(slot) < params.BeaconConfig().AltairForkEpoch {
+			if index < len(resp.InclusionSlots) {
+				previousEpochSummaryFields["inclusionSlot"] = resp.InclusionSlots[index]
+			} else {
+				log.WithField("pubKey", truncatedKey).Warn("Missing inclusion slot")
+			}
+			if index < len(resp.InclusionDistances) {
+				previousEpochSummaryFields["inclusionDistance"] = resp.InclusionDistances[index]
+			} else {
+				log.WithField("pubKey", truncatedKey).Warn("Missing inclusion distance")
+			}
+		}
+		if slots.ToEpoch(slot) >= params.BeaconConfig().AltairForkEpoch {
+			if index < len(resp.InactivityScores) {
+				previousEpochSummaryFields["inactivityScore"] = resp.InactivityScores[index]
+			} else {
+				log.WithField("pubKey", truncatedKey).Warn("Missing inactivity score")
+			}
+		}
+
+		log.WithFields(previousEpochSummaryFields).Info("Previous epoch voting summary")
+		if v.emitAccountMetrics {
+			ValidatorBalancesGaugeVec.WithLabelValues(fmtKey).Set(newBalance)
+			if correctlyVotedSource {
+				ValidatorCorrectlyVotedSourceGaugeVec.WithLabelValues(fmtKey).Set(1)
+			} else {
+				ValidatorCorrectlyVotedSourceGaugeVec.WithLabelValues(fmtKey).Set(0)
+			}
+			if correctlyVotedTarget {
+				ValidatorCorrectlyVotedTargetGaugeVec.WithLabelValues(fmtKey).Set(1)
+			} else {
+				ValidatorCorrectlyVotedTargetGaugeVec.WithLabelValues(fmtKey).Set(0)
+			}
+			if correctlyVotedHead {
+				ValidatorCorrectlyVotedHeadGaugeVec.WithLabelValues(fmtKey).Set(1)
+			} else {
+				ValidatorCorrectlyVotedHeadGaugeVec.WithLabelValues(fmtKey).Set(0)
+			}
+
+			// Phase0 specific metrics
+			if slots.ToEpoch(slot) < params.BeaconConfig().AltairForkEpoch {
+				if index < len(resp.InclusionDistances) {
+					ValidatorInclusionDistancesGaugeVec.WithLabelValues(fmtKey).Set(float64(resp.InclusionDistances[index]))
+				}
+			} else { // Altair specific metrics.
+				// Reset phase0 fields that no longer apply
+				ValidatorInclusionDistancesGaugeVec.DeleteLabelValues(fmtKey)
+				if index < len(resp.InactivityScores) {
+					ValidatorInactivityScoreGaugeVec.WithLabelValues(fmtKey).Set(float64(resp.InactivityScores[index]))
+				}
+			}
+		}
+	}
+	v.prevBalance[pubKeyBytes] = balBeforeEpoch
 }
 
 // UpdateLogAggregateStats updates and logs the voteStats struct of a validator using the RPC response obtained from LogValidatorGainsAndLosses.

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -138,7 +138,7 @@ func run(ctx context.Context, v iface.Validator) {
 				span.End()
 				continue
 			}
-			performRoles(allRoles, v, slot, slotCtx, &wg, span)
+			performRoles(slotCtx, allRoles, v, slot, &wg, span)
 		}
 	}
 }
@@ -223,7 +223,7 @@ func waitForActivation(ctx context.Context, v iface.Validator) (types.Slot, erro
 	return headSlot, nil
 }
 
-func performRoles(allRoles map[[48]byte][]iface.ValidatorRole, v iface.Validator, slot types.Slot, slotCtx context.Context, wg *sync.WaitGroup, span *trace.Span) {
+func performRoles(slotCtx context.Context, allRoles map[[48]byte][]iface.ValidatorRole, v iface.Validator, slot types.Slot, wg *sync.WaitGroup, span *trace.Span) {
 	for pubKey, roles := range allRoles {
 		wg.Add(len(roles))
 		for _, role := range roles {

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -59,7 +59,6 @@ func run(ctx context.Context, v iface.Validator) {
 		log.Fatalf("Failed to update proposer settings: %v", err) // allow fatal. skipcq
 	}
 	for {
-		var slotCtx context.Context
 		_, cancel := context.WithCancel(ctx)
 		ctx, span := trace.StartSpan(ctx, "validator.processSlot")
 
@@ -102,7 +101,7 @@ func run(ctx context.Context, v iface.Validator) {
 			}
 
 			deadline := v.SlotDeadline(slot)
-			slotCtx, cancel = context.WithDeadline(ctx, deadline)
+			slotCtx, cancel := context.WithDeadline(ctx, deadline)
 			log := log.WithField("slot", slot)
 			log.WithField("deadline", deadline).Debug("Set deadline for proposals and attestations")
 

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -60,8 +60,7 @@ func run(ctx context.Context, v iface.Validator) {
 	}
 	for {
 		var slotCtx context.Context
-		var cancel context.CancelFunc
-		slotCtx, cancel = context.WithCancel(ctx)
+		_, cancel := context.WithCancel(ctx)
 		ctx, span := trace.StartSpan(ctx, "validator.processSlot")
 
 		select {

--- a/validator/client/wait_for_activation.go
+++ b/validator/client/wait_for_activation.go
@@ -96,103 +96,117 @@ func (v *validator) waitForActivation(ctx context.Context, accountsChangedChan <
 
 	remoteKm, ok := v.keyManager.(remote.RemoteKeymanager)
 	if ok {
-		for {
-			select {
-			case <-accountsChangedChan:
-				// Accounts (keys) changed, restart the process.
-				return v.waitForActivation(ctx, accountsChangedChan)
-			case <-v.NextSlot():
-				if ctx.Err() == context.Canceled {
-					return errors.Wrap(ctx.Err(), "context canceled, not waiting for activation anymore")
-				}
-				validatingKeys, err = remoteKm.ReloadPublicKeys(ctx)
-				if err != nil {
-					return errors.Wrap(err, msgCouldNotFetchKeys)
-				}
-				statusRequestKeys := make([][]byte, len(validatingKeys))
-				for i := range validatingKeys {
-					statusRequestKeys[i] = validatingKeys[i][:]
-				}
-				resp, err := v.validatorClient.MultipleValidatorStatus(ctx, &ethpb.MultipleValidatorStatusRequest{
-					PublicKeys: statusRequestKeys,
-				})
-				if err != nil {
-					return err
-				}
-				statuses := make([]*validatorStatus, len(resp.Statuses))
-				for i, s := range resp.Statuses {
-					statuses[i] = &validatorStatus{
-						publicKey: resp.PublicKeys[i],
-						status:    s,
-						index:     resp.Indices[i],
-					}
-				}
-
-				valActivated := v.checkAndLogValidatorStatus(statuses)
-				if valActivated {
-					logActiveValidatorStatus(statuses)
-					// Set properties on the beacon node like the fee recipient for validators that are being used & active.
-					if err := v.PushProposerSettings(ctx, remoteKm); err != nil {
-						return err
-					}
-				} else {
-					continue
-				}
-			}
-			break
+		if err = v.handleWithRemoteKeyManager(ctx, accountsChangedChan, &remoteKm); err != nil {
+			return err
 		}
 	} else {
-		for {
-			select {
-			case <-accountsChangedChan:
-				// Accounts (keys) changed, restart the process.
-				return v.waitForActivation(ctx, accountsChangedChan)
-			default:
-				res, err := stream.Recv()
-				// If the stream is closed, we stop the loop.
-				if errors.Is(err, io.EOF) {
-					break
-				}
-				// If context is canceled we return from the function.
-				if ctx.Err() == context.Canceled {
-					return errors.Wrap(ctx.Err(), "context has been canceled so shutting down the loop")
-				}
-				if err != nil {
-					tracing.AnnotateError(span, err)
-					attempts := streamAttempts(ctx)
-					log.WithError(err).WithField("attempts", attempts).
-						Error("Stream broken while waiting for activation. Reconnecting...")
-					// Reconnection attempt backoff, up to 60s.
-					time.Sleep(time.Second * time.Duration(math.Min(uint64(attempts), 60)))
-					return v.waitForActivation(incrementRetries(ctx), accountsChangedChan)
-				}
-
-				statuses := make([]*validatorStatus, len(res.Statuses))
-				for i, s := range res.Statuses {
-					statuses[i] = &validatorStatus{
-						publicKey: s.PublicKey,
-						status:    s.Status,
-						index:     s.Index,
-					}
-				}
-
-				valActivated := v.checkAndLogValidatorStatus(statuses)
-				if valActivated {
-					logActiveValidatorStatus(statuses)
-
-					// Set properties on the beacon node like the fee recipient for validators that are being used & active.
-					if err := v.PushProposerSettings(ctx, v.keyManager); err != nil {
-						return err
-					}
-				} else {
-					continue
-				}
-			}
-			break
+		if err = v.handleWithoutRemoteKeyManager(ctx, accountsChangedChan, &stream, span); err != nil {
+			return err
 		}
 	}
 
 	v.ticker = slots.NewSlotTicker(time.Unix(int64(v.genesisTime), 0), params.BeaconConfig().SecondsPerSlot)
+	return nil
+}
+
+func (v *validator) handleWithRemoteKeyManager(ctx context.Context, accountsChangedChan <-chan [][fieldparams.BLSPubkeyLength]byte, remoteKm *remote.RemoteKeymanager) error {
+	for {
+		select {
+		case <-accountsChangedChan:
+			// Accounts (keys) changed, restart the process.
+			return v.waitForActivation(ctx, accountsChangedChan)
+		case <-v.NextSlot():
+			if ctx.Err() == context.Canceled {
+				return errors.Wrap(ctx.Err(), "context canceled, not waiting for activation anymore")
+			}
+			validatingKeys, err := (*remoteKm).ReloadPublicKeys(ctx)
+			if err != nil {
+				return errors.Wrap(err, msgCouldNotFetchKeys)
+			}
+			statusRequestKeys := make([][]byte, len(validatingKeys))
+			for i := range validatingKeys {
+				statusRequestKeys[i] = validatingKeys[i][:]
+			}
+			resp, err := v.validatorClient.MultipleValidatorStatus(ctx, &ethpb.MultipleValidatorStatusRequest{
+				PublicKeys: statusRequestKeys,
+			})
+			if err != nil {
+				return err
+			}
+			statuses := make([]*validatorStatus, len(resp.Statuses))
+			for i, s := range resp.Statuses {
+				statuses[i] = &validatorStatus{
+					publicKey: resp.PublicKeys[i],
+					status:    s,
+					index:     resp.Indices[i],
+				}
+			}
+
+			valActivated := v.checkAndLogValidatorStatus(statuses)
+			if valActivated {
+				logActiveValidatorStatus(statuses)
+				// Set properties on the beacon node like the fee recipient for validators that are being used & active.
+				if err := v.PushProposerSettings(ctx, *remoteKm); err != nil {
+					return err
+				}
+			} else {
+				continue
+			}
+		}
+		break
+	}
+	return nil
+}
+
+func (v *validator) handleWithoutRemoteKeyManager(ctx context.Context, accountsChangedChan <-chan [][fieldparams.BLSPubkeyLength]byte, stream *ethpb.BeaconNodeValidator_WaitForActivationClient, span *trace.Span) error {
+	for {
+		select {
+		case <-accountsChangedChan:
+			// Accounts (keys) changed, restart the process.
+			return v.waitForActivation(ctx, accountsChangedChan)
+		default:
+			res, err := (*stream).Recv()
+			// If the stream is closed, we stop the loop.
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			// If context is canceled we return from the function.
+			if ctx.Err() == context.Canceled {
+				return errors.Wrap(ctx.Err(), "context has been canceled so shutting down the loop")
+			}
+			if err != nil {
+				tracing.AnnotateError(span, err)
+				attempts := streamAttempts(ctx)
+				log.WithError(err).WithField("attempts", attempts).
+					Error("Stream broken while waiting for activation. Reconnecting...")
+				// Reconnection attempt backoff, up to 60s.
+				time.Sleep(time.Second * time.Duration(math.Min(uint64(attempts), 60)))
+				return v.waitForActivation(incrementRetries(ctx), accountsChangedChan)
+			}
+
+			statuses := make([]*validatorStatus, len(res.Statuses))
+			for i, s := range res.Statuses {
+				statuses[i] = &validatorStatus{
+					publicKey: s.PublicKey,
+					status:    s.Status,
+					index:     s.Index,
+				}
+			}
+
+			valActivated := v.checkAndLogValidatorStatus(statuses)
+			if valActivated {
+				logActiveValidatorStatus(statuses)
+
+				// Set properties on the beacon node like the fee recipient for validators that are being used & active.
+				if err := v.PushProposerSettings(ctx, v.keyManager); err != nil {
+					return err
+				}
+			} else {
+				continue
+			}
+		}
+		break
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What PR is this?**

As our repo grows overtime, keeping our code easy to follow becomes a challenge. Some of the challenges comes from complex code with less readability (easy to write, hard to read).

We use [cognitive complexity](https://github.com/uudashr/gocognit) to get the top 10 functions with the highest cognitive complexity. This PR reduced the cognitive complexity for 5 of them.

Ideally we should keep all function's gocognit complexity < 65.

| Function                                                                           | Original complexity | New complexity |
|------------------------------------------------------------------------------------|---------------------|----------------|
| client run validator/client/runner.go                                              | 96                  | 42             |
| client (*validator).LogValidatorGainsAndLosses validator/client/metrics.go         | 87                  | 53             |
| client (*validator).waitForActivation validator/client/wait_for_activation.go      | 76                  | 26             |
| sync (*Service).processPendingAtts beacon-chain/sync/pending_attestations_queue.go | 73                  | 38             |
| powchain (*Service).processPastLogs beacon-chain/powchain/log_processing.go        | 65                  | 19             |

It's a refactor-only change. No behavior changes is expected.