### PR TITLE
Add error if chain-config-file used concurrently with network

### DIFF
--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "//beacon-chain/monitor:go_default_library",
         "//cmd:go_default_library",
         "//cmd/beacon-chain/flags:go_default_library",
+        "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -118,7 +118,7 @@ func New(cliCtx *cli.Context, opts ...Option) (*BeaconNode, error) {
 	}
 	prereqs.WarnIfPlatformNotSupported(cliCtx.Context)
 	if hasNetworkFlag(cliCtx) && cliCtx.IsSet(cmd.ChainConfigFileFlag.Name) {
-		return nil, errors.New("chain-config-file cannot be passed concurrently with network")
+		return nil, fmt.Errorf("%s cannot be passed concurrently with network flag", cmd.ChainConfigFileFlag.Name)
 	}
 	if err := features.ConfigureBeaconChain(cliCtx); err != nil {
 		return nil, err

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -117,6 +117,9 @@ func New(cliCtx *cli.Context, opts ...Option) (*BeaconNode, error) {
 		return nil, err
 	}
 	prereqs.WarnIfPlatformNotSupported(cliCtx.Context)
+	if hasNetworkFlag(cliCtx) && cliCtx.IsSet(cmd.ChainConfigFileFlag.Name) {
+		return nil, errors.New("chain-config-file cannot be passed concurrently with network")
+	}
 	if err := features.ConfigureBeaconChain(cliCtx); err != nil {
 		return nil, err
 	}
@@ -969,4 +972,8 @@ func (b *BeaconNode) registerBuilderService() error {
 		return err
 	}
 	return b.services.RegisterService(svc)
+}
+
+func hasNetworkFlag(cliCtx *cli.Context) bool {
+	return cliCtx.IsSet(features.PraterTestnet.Name) || cliCtx.IsSet(features.Mainnet.Name) || cliCtx.IsSet(features.RopstenTestnet.Name)
 }

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -975,5 +975,12 @@ func (b *BeaconNode) registerBuilderService() error {
 }
 
 func hasNetworkFlag(cliCtx *cli.Context) bool {
-	return cliCtx.IsSet(features.PraterTestnet.Name) || cliCtx.IsSet(features.Mainnet.Name) || cliCtx.IsSet(features.RopstenTestnet.Name)
+	for _, flag := range features.NetworkFlags {
+		for _, name := range flag.Names() {
+			if cliCtx.IsSet(name) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/beacon-chain/node/node_test.go
+++ b/beacon-chain/node/node_test.go
@@ -10,10 +10,6 @@ import (
 	"testing"
 	"time"
 
-	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
-	"github.com/prysmaticlabs/prysm/cmd"
-	"github.com/prysmaticlabs/prysm/config/features"
-	"github.com/prysmaticlabs/prysm/testing/require"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/builder"
 	statefeed "github.com/prysmaticlabs/prysm/v3/beacon-chain/core/feed/state"
@@ -22,6 +18,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/monitor"
 	"github.com/prysmaticlabs/prysm/v3/cmd"
 	"github.com/prysmaticlabs/prysm/v3/cmd/beacon-chain/flags"
+	"github.com/prysmaticlabs/prysm/v3/config/features"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"

--- a/beacon-chain/node/node_test.go
+++ b/beacon-chain/node/node_test.go
@@ -10,6 +10,10 @@ import (
 	"testing"
 	"time"
 
+	statefeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/state"
+	"github.com/prysmaticlabs/prysm/cmd"
+	"github.com/prysmaticlabs/prysm/config/features"
+	"github.com/prysmaticlabs/prysm/testing/require"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/builder"
 	statefeed "github.com/prysmaticlabs/prysm/v3/beacon-chain/core/feed/state"
@@ -170,4 +174,46 @@ func TestMonitor_RegisteredCorrectly(t *testing.T) {
 	require.Equal(t, true, mService.TrackedValidators[1])
 	require.Equal(t, true, mService.TrackedValidators[2])
 	require.Equal(t, false, mService.TrackedValidators[100])
+}
+
+func Test_hasNetworkFlag(t *testing.T) {
+	tests := []struct {
+		name         string
+		networkName  string
+		networkValue string
+		want         bool
+	}{
+		{
+			name:         "Prater testnet",
+			networkName:  features.PraterTestnet.Name,
+			networkValue: "prater",
+			want:         true,
+		},
+		{
+			name:         "Mainnet",
+			networkName:  features.Mainnet.Name,
+			networkValue: "mainnet",
+			want:         true,
+		},
+		{
+			name:         "No network flag",
+			networkName:  "",
+			networkValue: "",
+			want:         false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			set := flag.NewFlagSet("test", 0)
+			set.String(tt.networkName, tt.networkValue, tt.name)
+
+			cliCtx := cli.NewContext(&cli.App{}, set, nil)
+			err := cliCtx.Set(tt.networkName, tt.networkValue)
+			require.NoError(t, err)
+
+			if got := hasNetworkFlag(cliCtx); got != tt.want {
+				t.Errorf("hasNetworkFlag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -179,3 +179,11 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 var E2EBeaconChainFlags = []string{
 	"--dev",
 }
+
+// NetworkFlags contains a list of network flags.
+var NetworkFlags = []cli.Flag{
+	Mainnet,
+	PraterTestnet,
+	RopstenTestnet,
+	SepoliaTestnet,
+}


### PR DESCRIPTION
If the chain-config-file flag is used concurrently with the network
flag then error and exit.
Related to #10822.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

When passing a `chain-config-file` along with a network flag one will override the other making it unclear which network is being run.

This PR ensures that we send an error and stop the program when the two flags are set concurrently.

**Which issues(s) does this PR fix?**

Fixes #10822.

**Other notes for review**
