### PR TITLE
Active balance: return `EFFECTIVE_BALANCE_INCREMENT` as min

### DIFF
--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -80,6 +80,10 @@ func TotalActiveBalance(s state.ReadOnlyBeaconState) (uint64, error) {
 		return 0, err
 	}
 
+	if params.BeaconConfig().EffectiveBalanceIncrement > total {
+		return params.BeaconConfig().EffectiveBalanceIncrement, nil
+	}
+
 	return total, nil
 }
 

--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -57,7 +57,7 @@ func TotalActiveBalance(s state.ReadOnlyBeaconState) (uint64, error) {
 	bal, err := balanceCache.Get(s)
 	switch {
 	case err == nil:
-		return bal, nil
+		return mathutil.Max(params.BeaconConfig().EffectiveBalanceIncrement, bal), nil
 	case errors.Is(err, cache.ErrNotFound):
 		// Do nothing if we receive a not found error.
 	default:

--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -80,11 +80,8 @@ func TotalActiveBalance(s state.ReadOnlyBeaconState) (uint64, error) {
 		return 0, err
 	}
 
-	if params.BeaconConfig().EffectiveBalanceIncrement > total {
-		return params.BeaconConfig().EffectiveBalanceIncrement, nil
-	}
-
-	return total, nil
+	// Spec defines `EffectiveBalanceIncrement` as min to avoid divisions by zero.
+	return mathutil.Max(params.BeaconConfig().EffectiveBalanceIncrement, total), nil
 }
 
 // IncreaseBalance increases validator with the given 'index' balance by 'delta' in Gwei.

--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -76,12 +76,12 @@ func TotalActiveBalance(s state.ReadOnlyBeaconState) (uint64, error) {
 		return 0, err
 	}
 
+	// Spec defines `EffectiveBalanceIncrement` as min to avoid divisions by zero.
 	total = mathutil.Max(params.BeaconConfig().EffectiveBalanceIncrement, total)
 	if err := balanceCache.AddTotalEffectiveBalance(s, total); err != nil {
 		return 0, err
 	}
 
-	// Spec defines `EffectiveBalanceIncrement` as min to avoid divisions by zero.
 	return total, nil
 }
 

--- a/beacon-chain/core/helpers/rewards_penalties.go
+++ b/beacon-chain/core/helpers/rewards_penalties.go
@@ -57,7 +57,7 @@ func TotalActiveBalance(s state.ReadOnlyBeaconState) (uint64, error) {
 	bal, err := balanceCache.Get(s)
 	switch {
 	case err == nil:
-		return mathutil.Max(params.BeaconConfig().EffectiveBalanceIncrement, bal), nil
+		return bal, nil
 	case errors.Is(err, cache.ErrNotFound):
 		// Do nothing if we receive a not found error.
 	default:
@@ -76,12 +76,13 @@ func TotalActiveBalance(s state.ReadOnlyBeaconState) (uint64, error) {
 		return 0, err
 	}
 
+	total = mathutil.Max(params.BeaconConfig().EffectiveBalanceIncrement, total)
 	if err := balanceCache.AddTotalEffectiveBalance(s, total); err != nil {
 		return 0, err
 	}
 
 	// Spec defines `EffectiveBalanceIncrement` as min to avoid divisions by zero.
-	return mathutil.Max(params.BeaconConfig().EffectiveBalanceIncrement, total), nil
+	return total, nil
 }
 
 // IncreaseBalance increases validator with the given 'index' balance by 'delta' in Gwei.

--- a/beacon-chain/core/helpers/rewards_penalties_test.go
+++ b/beacon-chain/core/helpers/rewards_penalties_test.go
@@ -74,6 +74,27 @@ func TestTotalActiveBalance(t *testing.T) {
 	}
 }
 
+func TestTotalActiveBal_ReturnMin(t *testing.T) {
+	tests := []struct {
+		vCount int
+	}{
+		{1},
+		{10},
+		{10000},
+	}
+	for _, test := range tests {
+		validators := make([]*ethpb.Validator, 0)
+		for i := 0; i < test.vCount; i++ {
+			validators = append(validators, &ethpb.Validator{EffectiveBalance: 1, ExitEpoch: 1})
+		}
+		state, err := v1.InitializeFromProto(&ethpb.BeaconState{Validators: validators})
+		require.NoError(t, err)
+		bal, err := TotalActiveBalance(state)
+		require.NoError(t, err)
+		require.Equal(t, params.BeaconConfig().EffectiveBalanceIncrement, bal)
+	}
+}
+
 func TestTotalActiveBalance_WithCache(t *testing.T) {
 	tests := []struct {
 		vCount    int


### PR DESCRIPTION
`get_total_balance` should return `EFFECTIVE_BALANCE_INCREMENT` as the minimum to avoid divisions by zero. This is outlined in the spec