### PR TITLE
update info message about ws checkpoint

### DIFF
--- a/beacon-chain/blockchain/weak_subjectivity_checks.go
+++ b/beacon-chain/blockchain/weak_subjectivity_checks.go
@@ -30,8 +30,8 @@ type WeakSubjectivityVerifier struct {
 // NewWeakSubjectivityVerifier validates a checkpoint, and if valid, uses it to initialize a weak subjectivity verifier.
 func NewWeakSubjectivityVerifier(wsc *ethpb.Checkpoint, db weakSubjectivityDB) (*WeakSubjectivityVerifier, error) {
 	if wsc == nil || len(wsc.Root) == 0 || wsc.Epoch == 0 {
-		log.Info("No checkpoint for syncing provided, node will begin syncing from genesis. Checkpoint Sync is an optional feature that allows your node to sync from a more recent checkpoint, " +
-			"which enhances the security of your local beacon node and the broader network. See https://docs.prylabs.network/docs/next/prysm-usage/checkpoint-sync/ to learn how to configure Checkpoint Sync.")
+		log.Info("--weak-subjectivity-checkpoint not provided. Prysm recommends providing a weak subjectivity checkpoint" +
+			"for nodes synced from genesis, or manual verification of block and state roots for checkpoint sync nodes.")
 		return &WeakSubjectivityVerifier{
 			enabled: false,
 		}, nil


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Re-words the info message that is displayed when prysm is started without a specified weak subjectivity checkpoint.

**Which issues(s) does this PR fix?**

Fixes #10848 
