### PR TITLE
Fix gosec scan: G112 (CWE-400) Potential Slowloris Attack 

### DIFF
--- a/api/gateway/gateway.go
+++ b/api/gateway/gateway.go
@@ -121,8 +121,9 @@ func (g *Gateway) Start() {
 	}
 
 	g.server = &http.Server{
-		Addr:    g.cfg.gatewayAddr,
-		Handler: corsMux,
+		Addr:              g.cfg.gatewayAddr,
+		Handler:           corsMux,
+		ReadHeaderTimeout: time.Second,
 	}
 
 	go func() {

--- a/monitoring/prometheus/service.go
+++ b/monitoring/prometheus/service.go
@@ -52,7 +52,7 @@ func NewService(addr string, svcRegistry *runtime.ServiceRegistry, additionalHan
 		mux.HandleFunc(h.Path, h.Handler)
 	}
 
-	s.server = &http.Server{Addr: addr, Handler: mux}
+	s.server = &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: time.Second}
 
 	return s
 }

--- a/monitoring/prometheus/simple_server.go
+++ b/monitoring/prometheus/simple_server.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -12,6 +13,6 @@ func RunSimpleServerOrDie(addr string) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	svr := &http.Server{Addr: addr, Handler: mux}
+	svr := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: time.Second}
 	log.Fatal(svr.ListenAndServe())
 }

--- a/testing/endtoend/components/tracing_sink.go
+++ b/testing/endtoend/components/tracing_sink.go
@@ -78,8 +78,9 @@ func (ts *TracingSink) Stop() error {
 func (ts *TracingSink) initializeSink(ctx context.Context) {
 	mux := &http.ServeMux{}
 	ts.server = &http.Server{
-		Addr:    ts.endpoint,
-		Handler: mux,
+		Addr:              ts.endpoint,
+		Handler:           mux,
+		ReadHeaderTimeout: time.Second,
 	}
 	defer func() {
 		if err := ts.server.Close(); err != nil {

--- a/testing/middleware/engine-api-proxy/proxy.go
+++ b/testing/middleware/engine-api-proxy/proxy.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/network"
@@ -72,8 +73,9 @@ func New(opts ...Option) (*Proxy, error) {
 	mux.Handle("/", p)
 	addr := fmt.Sprintf("%s:%d", p.cfg.proxyHost, p.cfg.proxyPort)
 	srv := &http.Server{
-		Handler: mux,
-		Addr:    addr,
+		Handler:           mux,
+		Addr:              addr,
+		ReadHeaderTimeout: time.Second,
 	}
 	p.address = addr
 	p.srv = srv


### PR DESCRIPTION
In my other PR, I received a bunch of complaints: `G112 (CWE-400): Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server`

I set one-minute timeout in this PR for http.Server during init. I don't feel strongly about the value. I think one minute should be sufficient but please tell me otherwise 

Source: https://github.com/prysmaticlabs/prysm/runs/6869199767?check_suite_focus=true#step:4:1980
<img width="1343" alt="Screen Shot 2022-06-13 at 1 49 56 PM" src="https://user-images.githubusercontent.com/21316537/173443160-a2fde2f6-22d7-4135-bfab-6b143c451e76.png">
 