### PR TITLE
Fix message typo for `ErrorIs`

### DIFF
--- a/testing/assertions/assertions.go
+++ b/testing/assertions/assertions.go
@@ -91,7 +91,7 @@ func NoError(loggerFn assertionLoggerFn, err error, msg ...interface{}) {
 // If any error in the chain matches target, the assertion will pass.
 func ErrorIs(loggerFn assertionLoggerFn, err, target error, msg ...interface{}) {
 	if !errors.Is(err, target) {
-		errMsg := parseMsg(fmt.Sprintf("error %s not in chain", target), msg...)
+		errMsg := parseMsg(fmt.Sprintf("error %s", target), msg...)
 		_, file, line, _ := runtime.Caller(2)
 		loggerFn("%s:%d %s: %v", filepath.Base(file), line, errMsg, err)
 	}


### PR DESCRIPTION
Fix `ErrorIs` message. I don't think the message `not in chain` was suppose to be part of it