### PR TITLE
improving unit test for unique pubkey check

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -1000,7 +1000,7 @@ func (v *validator) buildProposerSettingsRequests(ctx context.Context, pubkeys [
 	var validatorToFeeRecipients []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer
 	var registerValidatorRequests []*ethpb.ValidatorRegistrationV1
 	// need to check for pubkey to validator index mappings
-	for _, key := range pubkeys {
+	for i, key := range pubkeys {
 		skipAppendToFeeRecipientArray := false
 		feeRecipient := common.HexToAddress(params.BeaconConfig().EthBurnAddressHex)
 		gasLimit := params.BeaconConfig().DefaultBuilderGasLimit
@@ -1042,7 +1042,7 @@ func (v *validator) buildProposerSettingsRequests(ctx context.Context, pubkeys [
 			FeeRecipient: feeRecipient[:],
 			GasLimit:     gasLimit,
 			Timestamp:    uint64(time.Now().UTC().Unix()),
-			Pubkey:       key[:],
+			Pubkey:       pubkeys[i][:],
 		})
 
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

related to #10593
**What does this PR do? Why is it needed?**

Validator Registration Requests were not being created correctly due to reusing references for slices when constructing an array in the same "for" loop. the reference resulted in resuing the same public key ( the last one in the for loop) multiple times on the validator request. 

read more about how references in forloops range statement are used https://go.dev/ref/spec#For_statements

The unit test is improved to make sure the public keys are unique in the request.
