### PR TITLE
Remove Extraneous BoltDB Logs

### DIFF
--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -105,7 +105,6 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 		}
 	}
 	datafile := KVStoreDatafilePath(dirPath)
-	start := time.Now()
 	log.Infof("Opening Bolt DB at %s", datafile)
 	boltDB, err := bolt.Open(
 		datafile,
@@ -116,40 +115,29 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 		},
 	)
 	if err != nil {
-		log.WithField("elapsed", time.Since(start)).Error("Failed to open Bolt DB")
 		if errors.Is(err, bolt.ErrTimeout) {
 			return nil, errors.New("cannot obtain database lock, database may be in use by another process")
 		}
 		return nil, err
 	}
-	log.WithField("elapsed", time.Since(start)).Info("Opened Bolt DB")
-
 	boltDB.AllocSize = boltAllocSize
-	start = time.Now()
-	log.Infof("Creating block cache...")
 	blockCache, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1000,           // number of keys to track frequency of (1000).
 		MaxCost:     BlockCacheSize, // maximum cost of cache (1000 Blocks).
 		BufferItems: 64,             // number of keys per Get buffer.
 	})
 	if err != nil {
-		log.WithField("elapsed", time.Since(start)).Error("Failed to create block cache")
 		return nil, err
 	}
-	log.WithField("elapsed", time.Since(start)).Info("Created block cache")
 
-	start = time.Now()
-	log.Infof("Creating validator cache...")
 	validatorCache, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: NumOfValidatorEntries, // number of entries in cache (2 Million).
 		MaxCost:     ValidatorEntryMaxCost, // maximum size of the cache (64Mb)
 		BufferItems: 64,                    // number of keys per Get buffer.
 	})
 	if err != nil {
-		log.WithField("elapsed", time.Since(start)).Error("Failed to to create validator cache")
 		return nil, err
 	}
-	log.WithField("elapsed", time.Since(start)).Info("Created validator cache")
 
 	kv := &Store{
 		db:                  boltDB,
@@ -159,8 +147,6 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 		stateSummaryCache:   newStateSummaryCache(),
 		ctx:                 ctx,
 	}
-	start = time.Now()
-	log.Infof("Updating DB and creating buckets...")
 	if err := kv.db.Update(func(tx *bolt.Tx) error {
 		return createBuckets(
 			tx,
@@ -195,13 +181,9 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 			registrationBucket,
 		)
 	}); err != nil {
-		log.WithField("elapsed", time.Since(start)).Error("Failed to update db and create buckets")
 		return nil, err
 	}
-	log.WithField("elapsed", time.Since(start)).Info("Updated db and created buckets")
-
 	err = prometheus.Register(createBoltCollector(kv.db))
-
 	return kv, err
 }
 


### PR DESCRIPTION
This PR removes some DB logs that were added a while back to diagnose slow startups for the DB, but are not related to the root cause. Instead, these logs cause noise when running unit tests and other experiments
