### PR TITLE
Pad `Uint256`'s `SSZBytes` to length 32

### DIFF
--- a/api/client/builder/types.go
+++ b/api/client/builder/types.go
@@ -63,7 +63,7 @@ func sszBytesToUint256(b []byte) Uint256 {
 
 // SSZBytes creates an ssz-style (little-endian byte slice) representation of the Uint256
 func (s Uint256) SSZBytes() []byte {
-	return bytesutil.ReverseByteOrder(s.Int.Bytes())
+	return bytesutil.PadTo(bytesutil.ReverseByteOrder(s.Int.Bytes()), 32)
 }
 
 var errUnmarshalUint256Failed = errors.New("unable to UnmarshalText into a Uint256 value")

--- a/api/client/builder/types_test.go
+++ b/api/client/builder/types_test.go
@@ -694,9 +694,10 @@ func TestMarshalBlindedBeaconBlockBodyBellatrix(t *testing.T) {
 }
 
 func TestRoundTripUint256(t *testing.T) {
-	vs := "452312848583266388373324160190187140051835877600158453279131187530910662656"
+	vs := "4523128485832663883733241601901871400518358776001584532791311875309106626"
 	u := stringToUint256(vs)
 	sb := u.SSZBytes()
+	require.Equal(t, 32, len(sb))
 	uu := sszBytesToUint256(sb)
 	require.Equal(t, true, bytes.Equal(u.SSZBytes(), uu.SSZBytes()))
 	require.Equal(t, vs, uu.String())


### PR DESCRIPTION
Pad `Uint256`'s `SSZBytes` to length 32 to make ssz happy. Thanks @kasey for the pointer