### PR TITLE
Refactor validator accounts import to remove cli context dependency

### DIFF
--- a/cmd/validator/accounts/BUILD.bazel
+++ b/cmd/validator/accounts/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "backup.go",
         "delete.go",
         "exit.go",
+        "import.go",
         "list.go",
         "wallet_utils.go",
     ],
@@ -36,6 +37,7 @@ go_test(
         "backup_test.go",
         "delete_test.go",
         "exit_test.go",
+        "import_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/cmd/validator/accounts/accounts.go
+++ b/cmd/validator/accounts/accounts.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prysmaticlabs/prysm/cmd/validator/flags"
 	"github.com/prysmaticlabs/prysm/config/features"
 	"github.com/prysmaticlabs/prysm/runtime/tos"
-	"github.com/prysmaticlabs/prysm/validator/accounts"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -135,13 +134,13 @@ var Commands = &cli.Command{
 				if err := cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags); err != nil {
 					return err
 				}
-				return tos.VerifyTosAcceptedOrPrompt(cliCtx)
-			},
-			Action: func(cliCtx *cli.Context) error {
-				if err := features.ConfigureValidator(cliCtx); err != nil {
+				if err := tos.VerifyTosAcceptedOrPrompt(cliCtx); err != nil {
 					return err
 				}
-				if err := accounts.ImportAccountsCli(cliCtx); err != nil {
+				return features.ConfigureValidator(cliCtx)
+			},
+			Action: func(cliCtx *cli.Context) error {
+				if err := accountsImport(cliCtx); err != nil {
 					log.Fatalf("Could not import accounts: %v", err)
 				}
 				return nil

--- a/cmd/validator/accounts/backup_test.go
+++ b/cmd/validator/accounts/backup_test.go
@@ -181,7 +181,7 @@ func TestBackupAccounts_Noninteractive_Imported(t *testing.T) {
 
 	// We attempt to import accounts we wrote to the keys directory
 	// into our newly created wallet.
-	require.NoError(t, accounts.ImportAccountsCli(cliCtx))
+	require.NoError(t, accountsImport(cliCtx))
 
 	// Next, we attempt to backup the accounts.
 	require.NoError(t, accountsBackup(cliCtx))

--- a/cmd/validator/accounts/delete_test.go
+++ b/cmd/validator/accounts/delete_test.go
@@ -83,6 +83,7 @@ type testWalletConfig struct {
 	deletePublicKeys        string
 	keysDir                 string
 	backupDir               string
+	passwordsDir            string
 	walletDir               string
 }
 
@@ -169,7 +170,7 @@ func TestDeleteAccounts_Noninteractive(t *testing.T) {
 	require.NoError(t, err)
 
 	// We attempt to import accounts.
-	require.NoError(t, accounts.ImportAccountsCli(cliCtx))
+	require.NoError(t, accountsImport(cliCtx))
 
 	// We attempt to delete the accounts specified.
 	require.NoError(t, accountsDelete(cliCtx))

--- a/cmd/validator/accounts/exit_test.go
+++ b/cmd/validator/accounts/exit_test.go
@@ -75,7 +75,7 @@ func TestExitAccountsCli_OK(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, accounts.ImportAccountsCli(cliCtx))
+	require.NoError(t, accountsImport(cliCtx))
 
 	_, keymanager, err := walletWithKeymanager(cliCtx)
 	require.NoError(t, err)
@@ -175,7 +175,7 @@ func TestExitAccountsCli_OK_AllPublicKeys(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	require.NoError(t, accounts.ImportAccountsCli(cliCtx))
+	require.NoError(t, accountsImport(cliCtx))
 
 	_, keymanager, err := walletWithKeymanager(cliCtx)
 	require.NoError(t, err)

--- a/cmd/validator/accounts/import.go
+++ b/cmd/validator/accounts/import.go
@@ -1,0 +1,113 @@
+package accounts
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/cmd"
+	"github.com/prysmaticlabs/prysm/cmd/validator/flags"
+	"github.com/prysmaticlabs/prysm/validator/accounts"
+	"github.com/prysmaticlabs/prysm/validator/accounts/iface"
+	"github.com/prysmaticlabs/prysm/validator/accounts/userprompt"
+	"github.com/prysmaticlabs/prysm/validator/accounts/wallet"
+	"github.com/prysmaticlabs/prysm/validator/client"
+	"github.com/prysmaticlabs/prysm/validator/keymanager"
+	"github.com/urfave/cli/v2"
+)
+
+func accountsImport(c *cli.Context) error {
+	w, err := walletImport(c)
+	if err != nil {
+		return errors.Wrap(err, "could not initialize wallet")
+	}
+	km, err := w.InitializeKeymanager(c.Context, iface.InitKeymanagerConfig{ListenForChanges: false})
+	if err != nil {
+		return err
+	}
+
+	dialOpts := client.ConstructDialOptions(
+		c.Int(cmd.GrpcMaxCallRecvMsgSizeFlag.Name),
+		c.String(flags.CertFlag.Name),
+		c.Uint(flags.GrpcRetriesFlag.Name),
+		c.Duration(flags.GrpcRetryDelayFlag.Name),
+	)
+	grpcHeaders := strings.Split(c.String(flags.GrpcHeadersFlag.Name), ",")
+
+	opts := []accounts.Option{
+		accounts.WithWallet(w),
+		accounts.WithKeymanager(km),
+		accounts.WithGRPCDialOpts(dialOpts),
+		accounts.WithBeaconRPCProvider(c.String(flags.BeaconRPCProviderFlag.Name)),
+		accounts.WithGRPCHeaders(grpcHeaders),
+	}
+
+	opts = append(opts, accounts.WithImportPrivateKeys(c.IsSet(flags.ImportPrivateKeyFileFlag.Name)))
+	opts = append(opts, accounts.WithPrivateKeyFile(c.String(flags.ImportPrivateKeyFileFlag.Name)))
+	opts = append(opts, accounts.WithReadPasswordFile(c.IsSet(flags.AccountPasswordFileFlag.Name)))
+	opts = append(opts, accounts.WithPasswordFilePath(c.String(flags.AccountPasswordFileFlag.Name)))
+
+	keysDir, err := userprompt.InputDirectory(c, userprompt.ImportKeysDirPromptText, flags.KeysDirFlag)
+	if err != nil {
+		return errors.Wrap(err, "could not parse keys directory")
+	}
+	opts = append(opts, accounts.WithKeysDir(keysDir))
+
+	acc, err := accounts.NewCLIManager(opts...)
+	if err != nil {
+		return err
+	}
+	return acc.Import(c.Context)
+}
+
+func walletImport(c *cli.Context) (*wallet.Wallet, error) {
+	return wallet.OpenWalletOrElseCli(c, func(cliCtx *cli.Context) (*wallet.Wallet, error) {
+		walletDir, err := userprompt.InputDirectory(cliCtx, userprompt.WalletDirPromptText, flags.WalletDirFlag)
+		if err != nil {
+			return nil, err
+		}
+		exists, err := wallet.Exists(walletDir)
+		if err != nil {
+			return nil, errors.Wrap(err, wallet.CheckExistsErrMsg)
+		}
+		if exists {
+			isValid, err := wallet.IsValid(walletDir)
+			if err != nil {
+				return nil, errors.Wrap(err, wallet.CheckValidityErrMsg)
+			}
+			if !isValid {
+				return nil, errors.New(wallet.InvalidWalletErrMsg)
+			}
+			walletPassword, err := wallet.InputPassword(
+				cliCtx,
+				flags.WalletPasswordFileFlag,
+				wallet.PasswordPromptText,
+				false, /* Do not confirm password */
+				wallet.ValidateExistingPass,
+			)
+			if err != nil {
+				return nil, err
+			}
+			return wallet.OpenWallet(cliCtx.Context, &wallet.Config{
+				WalletDir:      walletDir,
+				WalletPassword: walletPassword,
+			})
+		}
+
+		cfg, err := accounts.ExtractWalletCreationConfigFromCli(cliCtx, keymanager.Local)
+		if err != nil {
+			return nil, err
+		}
+		w := wallet.New(&wallet.Config{
+			KeymanagerKind: cfg.WalletCfg.KeymanagerKind,
+			WalletDir:      cfg.WalletCfg.WalletDir,
+			WalletPassword: cfg.WalletCfg.WalletPassword,
+		})
+		if err = accounts.CreateLocalKeymanagerWallet(cliCtx.Context, w); err != nil {
+			return nil, errors.Wrap(err, "could not create keymanager")
+		}
+		log.WithField("wallet-path", cfg.WalletCfg.WalletDir).Info(
+			"Successfully created new wallet",
+		)
+		return w, nil
+	})
+}

--- a/cmd/validator/accounts/import_test.go
+++ b/cmd/validator/accounts/import_test.go
@@ -1,0 +1,262 @@
+package accounts
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prysmaticlabs/prysm/crypto/bls"
+	"github.com/prysmaticlabs/prysm/testing/assert"
+	"github.com/prysmaticlabs/prysm/testing/require"
+	"github.com/prysmaticlabs/prysm/validator/accounts"
+	"github.com/prysmaticlabs/prysm/validator/accounts/iface"
+	"github.com/prysmaticlabs/prysm/validator/accounts/wallet"
+	"github.com/prysmaticlabs/prysm/validator/keymanager"
+	"github.com/prysmaticlabs/prysm/validator/keymanager/local"
+	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
+)
+
+func TestImport_Noninteractive(t *testing.T) {
+	local.ResetCaches()
+	walletDir, passwordsDir, passwordFilePath := setupWalletAndPasswordsDir(t)
+	keysDir := filepath.Join(t.TempDir(), "keysDir")
+	require.NoError(t, os.MkdirAll(keysDir, os.ModePerm))
+
+	cliCtx := setupWalletCtx(t, &testWalletConfig{
+		walletDir:           walletDir,
+		passwordsDir:        passwordsDir,
+		keysDir:             keysDir,
+		keymanagerKind:      keymanager.Local,
+		walletPasswordFile:  passwordFilePath,
+		accountPasswordFile: passwordFilePath,
+	})
+	w, err := accounts.CreateWalletWithKeymanager(cliCtx.Context, &accounts.CreateWalletConfig{
+		WalletCfg: &wallet.Config{
+			WalletDir:      walletDir,
+			KeymanagerKind: keymanager.Local,
+			WalletPassword: password,
+		},
+	})
+	require.NoError(t, err)
+	keymanager, err := local.NewKeymanager(
+		cliCtx.Context,
+		&local.SetupConfig{
+			Wallet:           w,
+			ListenForChanges: false,
+		},
+	)
+	require.NoError(t, err)
+
+	// Make sure there are no accounts at the start.
+	accounts, err := keymanager.ValidatingAccountNames()
+	require.NoError(t, err)
+	assert.Equal(t, len(accounts), 0)
+
+	// Create 2 keys.
+	createKeystore(t, keysDir)
+	time.Sleep(time.Second)
+	createKeystore(t, keysDir)
+
+	require.NoError(t, accountsImport(cliCtx))
+
+	w, err = wallet.OpenWallet(cliCtx.Context, &wallet.Config{
+		WalletDir:      walletDir,
+		WalletPassword: password,
+	})
+	require.NoError(t, err)
+	km, err := w.InitializeKeymanager(cliCtx.Context, iface.InitKeymanagerConfig{ListenForChanges: false})
+	require.NoError(t, err)
+	keys, err := km.FetchValidatingPublicKeys(cliCtx.Context)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, len(keys))
+}
+
+// TestImport_DuplicateKeys is a regression test that ensures correction function if duplicate keys are being imported
+func TestImport_DuplicateKeys(t *testing.T) {
+	local.ResetCaches()
+	walletDir, passwordsDir, passwordFilePath := setupWalletAndPasswordsDir(t)
+	keysDir := filepath.Join(t.TempDir(), "keysDir")
+	require.NoError(t, os.MkdirAll(keysDir, os.ModePerm))
+
+	cliCtx := setupWalletCtx(t, &testWalletConfig{
+		walletDir:           walletDir,
+		passwordsDir:        passwordsDir,
+		keysDir:             keysDir,
+		keymanagerKind:      keymanager.Local,
+		walletPasswordFile:  passwordFilePath,
+		accountPasswordFile: passwordFilePath,
+	})
+	w, err := accounts.CreateWalletWithKeymanager(cliCtx.Context, &accounts.CreateWalletConfig{
+		WalletCfg: &wallet.Config{
+			WalletDir:      walletDir,
+			KeymanagerKind: keymanager.Local,
+			WalletPassword: password,
+		},
+	})
+	require.NoError(t, err)
+
+	// Create a key and then copy it to create a duplicate
+	_, keystorePath := createKeystore(t, keysDir)
+	time.Sleep(time.Second)
+	input, err := os.ReadFile(keystorePath)
+	require.NoError(t, err)
+	keystorePath2 := filepath.Join(keysDir, "copyOfKeystore.json")
+	err = os.WriteFile(keystorePath2, input, os.ModePerm)
+	require.NoError(t, err)
+
+	require.NoError(t, accountsImport(cliCtx))
+
+	_, err = wallet.OpenWallet(cliCtx.Context, &wallet.Config{
+		WalletDir:      walletDir,
+		WalletPassword: password,
+	})
+	require.NoError(t, err)
+	km, err := w.InitializeKeymanager(cliCtx.Context, iface.InitKeymanagerConfig{ListenForChanges: false})
+	require.NoError(t, err)
+	keys, err := km.FetchValidatingPublicKeys(cliCtx.Context)
+	require.NoError(t, err)
+
+	// There should only be 1 account as the duplicate keystore was ignored
+	assert.Equal(t, 1, len(keys))
+}
+
+func TestImport_Noninteractive_RandomName(t *testing.T) {
+	local.ResetCaches()
+	walletDir, passwordsDir, passwordFilePath := setupWalletAndPasswordsDir(t)
+	keysDir := filepath.Join(t.TempDir(), "keysDir")
+	require.NoError(t, os.MkdirAll(keysDir, os.ModePerm))
+
+	cliCtx := setupWalletCtx(t, &testWalletConfig{
+		walletDir:           walletDir,
+		passwordsDir:        passwordsDir,
+		keysDir:             keysDir,
+		keymanagerKind:      keymanager.Local,
+		walletPasswordFile:  passwordFilePath,
+		accountPasswordFile: passwordFilePath,
+	})
+	w, err := accounts.CreateWalletWithKeymanager(cliCtx.Context, &accounts.CreateWalletConfig{
+		WalletCfg: &wallet.Config{
+			WalletDir:      walletDir,
+			KeymanagerKind: keymanager.Local,
+			WalletPassword: password,
+		},
+	})
+	require.NoError(t, err)
+	keymanager, err := local.NewKeymanager(
+		cliCtx.Context,
+		&local.SetupConfig{
+			Wallet:           w,
+			ListenForChanges: false,
+		},
+	)
+	require.NoError(t, err)
+
+	// Make sure there are no accounts at the start.
+	accounts, err := keymanager.ValidatingAccountNames()
+	require.NoError(t, err)
+	assert.Equal(t, len(accounts), 0)
+
+	// Create 2 keys.
+	createRandomNameKeystore(t, keysDir)
+	time.Sleep(time.Second)
+	createRandomNameKeystore(t, keysDir)
+
+	require.NoError(t, accountsImport(cliCtx))
+
+	w, err = wallet.OpenWallet(cliCtx.Context, &wallet.Config{
+		WalletDir:      walletDir,
+		WalletPassword: password,
+	})
+	require.NoError(t, err)
+	km, err := w.InitializeKeymanager(cliCtx.Context, iface.InitKeymanagerConfig{ListenForChanges: false})
+	require.NoError(t, err)
+	keys, err := km.FetchValidatingPublicKeys(cliCtx.Context)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, len(keys))
+}
+
+// Returns the fullPath to the newly created keystore file.
+func createRandomNameKeystore(t *testing.T, path string) (*keymanager.Keystore, string) {
+	validatingKey, err := bls.RandKey()
+	require.NoError(t, err)
+	encryptor := keystorev4.New()
+	cryptoFields, err := encryptor.Encrypt(validatingKey.Marshal(), password)
+	require.NoError(t, err)
+	id, err := uuid.NewRandom()
+	require.NoError(t, err)
+	keystoreFile := &keymanager.Keystore{
+		Crypto:  cryptoFields,
+		ID:      id.String(),
+		Pubkey:  fmt.Sprintf("%x", validatingKey.PublicKey().Marshal()),
+		Version: encryptor.Version(),
+		Name:    encryptor.Name(),
+	}
+	encoded, err := json.MarshalIndent(keystoreFile, "", "\t")
+	require.NoError(t, err)
+	// Write the encoded keystore to disk with the timestamp appended
+	random, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	require.NoError(t, err)
+	fullPath := filepath.Join(path, fmt.Sprintf("test-%d-keystore", random.Int64()))
+	require.NoError(t, os.WriteFile(fullPath, encoded, os.ModePerm))
+	return keystoreFile, fullPath
+}
+
+func TestImport_Noninteractive_Filepath(t *testing.T) {
+	local.ResetCaches()
+	walletDir, passwordsDir, passwordFilePath := setupWalletAndPasswordsDir(t)
+	keysDir := filepath.Join(t.TempDir(), "keysDir")
+	require.NoError(t, os.MkdirAll(keysDir, os.ModePerm))
+
+	_, keystorePath := createKeystore(t, keysDir)
+	cliCtx := setupWalletCtx(t, &testWalletConfig{
+		walletDir:           walletDir,
+		passwordsDir:        passwordsDir,
+		keysDir:             keystorePath,
+		keymanagerKind:      keymanager.Local,
+		walletPasswordFile:  passwordFilePath,
+		accountPasswordFile: passwordFilePath,
+	})
+	w, err := accounts.CreateWalletWithKeymanager(cliCtx.Context, &accounts.CreateWalletConfig{
+		WalletCfg: &wallet.Config{
+			WalletDir:      walletDir,
+			KeymanagerKind: keymanager.Local,
+			WalletPassword: password,
+		},
+	})
+	require.NoError(t, err)
+	keymanager, err := local.NewKeymanager(
+		cliCtx.Context,
+		&local.SetupConfig{
+			Wallet:           w,
+			ListenForChanges: false,
+		},
+	)
+	require.NoError(t, err)
+
+	// Make sure there are no accounts at the start.
+	accounts, err := keymanager.ValidatingAccountNames()
+	require.NoError(t, err)
+	assert.Equal(t, len(accounts), 0)
+
+	require.NoError(t, accountsImport(cliCtx))
+
+	w, err = wallet.OpenWallet(cliCtx.Context, &wallet.Config{
+		WalletDir:      walletDir,
+		WalletPassword: password,
+	})
+	require.NoError(t, err)
+	km, err := w.InitializeKeymanager(cliCtx.Context, iface.InitKeymanagerConfig{ListenForChanges: false})
+	require.NoError(t, err)
+	keys, err := km.FetchValidatingPublicKeys(cliCtx.Context)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(keys))
+}

--- a/validator/accounts/cli_manager.go
+++ b/validator/accounts/cli_manager.go
@@ -32,10 +32,15 @@ type AccountsCLIManager struct {
 	showPrivateKeys      bool
 	listValidatorIndices bool
 	deletePublicKeys     bool
+	importPrivateKeys    bool
+	readPasswordFile     bool
 	dialOpts             []grpc.DialOption
 	grpcHeaders          []string
 	beaconRPCProvider    string
 	walletKeyCount       int
+	privateKeyFile       string
+	passwordFilePath     string
+	keysDir              string
 	backupsDir           string
 	backupsPassword      string
 	filteredPubKeys      []bls.PublicKey

--- a/validator/accounts/cli_options.go
+++ b/validator/accounts/cli_options.go
@@ -90,6 +90,46 @@ func WithDeletePublicKeys(deletePublicKeys bool) Option {
 	}
 }
 
+// WithReadPasswordFile indicates whether to read the password from a file.
+func WithReadPasswordFile(readPasswordFile bool) Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.readPasswordFile = readPasswordFile
+		return nil
+	}
+}
+
+// WithImportPrivateKeys indicates whether to import private keys as accounts.
+func WithImportPrivateKeys(importPrivateKeys bool) Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.importPrivateKeys = importPrivateKeys
+		return nil
+	}
+}
+
+// WithPrivateKeyFile specifies the private key path.
+func WithPrivateKeyFile(privateKeyFile string) Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.privateKeyFile = privateKeyFile
+		return nil
+	}
+}
+
+// WithKeysDir specifies the directory keys are read from.
+func WithKeysDir(keysDir string) Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.keysDir = keysDir
+		return nil
+	}
+}
+
+// WithPasswordFilePath specifies where the password is stored.
+func WithPasswordFilePath(passwordFilePath string) Option {
+	return func(acc *AccountsCLIManager) error {
+		acc.passwordFilePath = passwordFilePath
+		return nil
+	}
+}
+
 // WithBackupDir specifies the directory backups are written to.
 func WithBackupsDir(backupsDir string) Option {
 	return func(acc *AccountsCLIManager) error {

--- a/validator/accounts/wallet_create.go
+++ b/validator/accounts/wallet_create.go
@@ -40,7 +40,7 @@ func CreateAndSaveWalletCli(cliCtx *cli.Context) (*wallet.Wallet, error) {
 	if err != nil {
 		return nil, err
 	}
-	createWalletConfig, err := extractWalletCreationConfigFromCli(cliCtx, keymanagerKind)
+	createWalletConfig, err := ExtractWalletCreationConfigFromCli(cliCtx, keymanagerKind)
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func CreateWalletWithKeymanager(ctx context.Context, cfg *CreateWalletConfig) (*
 	var err error
 	switch w.KeymanagerKind() {
 	case keymanager.Local:
-		if err = createLocalKeymanagerWallet(ctx, w); err != nil {
+		if err = CreateLocalKeymanagerWallet(ctx, w); err != nil {
 			return nil, errors.Wrap(err, "could not initialize wallet")
 		}
 		// TODO(#9883) - Remove this when we have a better way to handle this. should be safe to use for now.
@@ -131,7 +131,8 @@ func extractKeymanagerKindFromCli(cliCtx *cli.Context) (keymanager.Kind, error) 
 	return inputKeymanagerKind(cliCtx)
 }
 
-func extractWalletCreationConfigFromCli(cliCtx *cli.Context, keymanagerKind keymanager.Kind) (*CreateWalletConfig, error) {
+// ExtractWalletCreationConfigFromCli prompts the user for wallet creation input.
+func ExtractWalletCreationConfigFromCli(cliCtx *cli.Context, keymanagerKind keymanager.Kind) (*CreateWalletConfig, error) {
 	walletDir, err := userprompt.InputDirectory(cliCtx, userprompt.WalletDirPromptText, flags.WalletDirFlag)
 	if err != nil {
 		return nil, err
@@ -204,7 +205,7 @@ func extractWalletCreationConfigFromCli(cliCtx *cli.Context, keymanagerKind keym
 	return createWalletConfig, nil
 }
 
-func createLocalKeymanagerWallet(_ context.Context, wallet *wallet.Wallet) error {
+func CreateLocalKeymanagerWallet(_ context.Context, wallet *wallet.Wallet) error {
 	if wallet == nil {
 		return errors.New("nil wallet")
 	}

--- a/validator/accounts/wallet_create_test.go
+++ b/validator/accounts/wallet_create_test.go
@@ -119,7 +119,7 @@ func TestCreateOrOpenWallet(t *testing.T) {
 		walletPasswordFile: walletPasswordFile,
 	})
 	createLocalWallet := func(cliCtx *cli.Context) (*wallet.Wallet, error) {
-		cfg, err := extractWalletCreationConfigFromCli(cliCtx, keymanager.Local)
+		cfg, err := ExtractWalletCreationConfigFromCli(cliCtx, keymanager.Local)
 		if err != nil {
 			return nil, err
 		}
@@ -128,7 +128,7 @@ func TestCreateOrOpenWallet(t *testing.T) {
 			WalletDir:      cfg.WalletCfg.WalletDir,
 			WalletPassword: cfg.WalletCfg.WalletPassword,
 		})
-		if err = createLocalKeymanagerWallet(cliCtx.Context, w); err != nil {
+		if err = CreateLocalKeymanagerWallet(cliCtx.Context, w); err != nil {
 			return nil, errors.Wrap(err, "could not create keymanager")
 		}
 		log.WithField("wallet-path", cfg.WalletCfg.WalletDir).Info(


### PR DESCRIPTION
**What type of PR is this?**
Refactor/code health

**What does this PR do? Why is it needed?**
This PR addresses the account import functionality and refactors it as part of https://github.com/prysmaticlabs/prysm/issues/9883. It follows up on https://github.com/prysmaticlabs/prysm/pull/10554, https://github.com/prysmaticlabs/prysm/pull/10686, https://github.com/prysmaticlabs/prysm/pull/10824, https://github.com/prysmaticlabs/prysm/pull/10841 which do similar migration for the accounts list, delete, backup, and exit.

1. `cmd/validator/accounts/import.go`. This is a new file that parses the CLI flags and constructs the CLI manager with the appropriate options. On the CLI manager, it simply calls the `Import` method with the `context.Context`(no longer a need for the `cli.Context`). The options specific to the import functionality are: `WithImportPrivateKeys`, `WithPrivateKeyFile`, `WithReadPasswordFile`, `WithPasswordFilePath`, and `WithKeysDir`. Also note that the `walletImport` function handles the construction of the wallet and is migrated to this file.
2. `cmd/validator/accounts/import_test.go`. This is the new location of most of the tests that were in `validator/accounts/accounts_import_test.go`. As written, these tests are built for the CLI context interface, so if we are moving the logic for handling that to the `cmd/validator/accounts` directory, it makes sense to also move the tests there. Tess that don't depend on the CLIctx remain in the `validator/accounts/accounts_import_test.go`.
3. `validator/accounts/accounts_import.go`. This is where we see the benefit of this refactor. We chop out all the CLI parsing stuff from the `ImportAccountCli` function, and make it the `Import` method on the AccountsCLIManager pointer receiver. 
4. `validator/accounts/cli_manager.go` and `validator/accounts/cli_options.go`. I added a few new options that the import function depends on.
6. `validator/accounts/accounts_import_test.go`. I left a few tests here (which don't rely on setting up the cli ctx and just test the non-exported functions in `validator/accounts/accounts_import.go`. 

**Which issues(s) does this PR fix?**
This is part of the keymanager refactor defined in https://github.com/prysmaticlabs/prysm/issues/9883.
It is also described in https://github.com/prysmaticlabs/prysm/issues/10339.