### PR TITLE
Compute correct domain for validator registration

### DIFF
--- a/beacon-chain/core/signing/BUILD.bazel
+++ b/beacon-chain/core/signing/BUILD.bazel
@@ -42,7 +42,6 @@ go_test(
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
-        "//time/slots:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
     ],
 )

--- a/beacon-chain/core/signing/signature.go
+++ b/beacon-chain/core/signing/signature.go
@@ -3,7 +3,6 @@ package signing
 import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/config/params"
-	types "github.com/prysmaticlabs/prysm/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 )
 
@@ -11,17 +10,19 @@ var ErrNilRegistration = errors.New("nil signed registration")
 
 // VerifyRegistrationSignature verifies the signature of a validator's registration.
 func VerifyRegistrationSignature(
-	e types.Epoch,
-	f *ethpb.Fork,
 	sr *ethpb.SignedValidatorRegistrationV1,
-	genesisRoot []byte,
 ) error {
 	if sr == nil || sr.Message == nil {
 		return ErrNilRegistration
 	}
 
 	d := params.BeaconConfig().DomainApplicationBuilder
-	sd, err := Domain(f, e, d, genesisRoot)
+	// Per spec, we want the fork version and genesis validator to be nil.
+	// Which is genesis value and zero by default.
+	sd, err := ComputeDomain(
+		d,
+		nil, /* fork version */
+		nil /* genesis val root */)
 	if err != nil {
 		return err
 	}

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -403,14 +403,6 @@ func TestWaitMultipleActivation_LogsActivationEpochOK(t *testing.T) {
 	).Return(
 		&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-	client.EXPECT().DomainData(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(
-		&ethpb.DomainResponse{
-			SignatureDomain: make([]byte, 32),
-		},
-		nil)
 	client.EXPECT().SubmitValidatorRegistration(
 		gomock.Any(),
 		gomock.Any(),
@@ -474,14 +466,6 @@ func TestWaitActivation_NotAllValidatorsActivatedOK(t *testing.T) {
 	).Return(
 		&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-	client.EXPECT().DomainData(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(
-		&ethpb.DomainResponse{
-			SignatureDomain: make([]byte, 32),
-		},
-		nil)
 	client.EXPECT().SubmitValidatorRegistration(
 		gomock.Any(),
 		gomock.Any(),
@@ -1588,15 +1572,6 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 					&emptypb.Empty{},
 				).Times(2).Return(
 					&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
-
-				client.EXPECT().DomainData(
-					gomock.Any(),
-					gomock.Any(),
-				).Times(2).Return(
-					&ethpb.DomainResponse{
-						SignatureDomain: make([]byte, 32),
-					},
-					nil)
 				client.EXPECT().SubmitValidatorRegistration(
 					gomock.Any(),
 					gomock.Any(),
@@ -1662,14 +1637,6 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 				).Return(
 					&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-				client.EXPECT().DomainData(
-					gomock.Any(),
-					gomock.Any(),
-				).Return(
-					&ethpb.DomainResponse{
-						SignatureDomain: make([]byte, 32),
-					},
-					nil)
 				client.EXPECT().SubmitValidatorRegistration(
 					gomock.Any(),
 					gomock.Any(),
@@ -1749,14 +1716,6 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 				).Return(
 					&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-				client.EXPECT().DomainData(
-					gomock.Any(),
-					gomock.Any(),
-				).Return(
-					&ethpb.DomainResponse{
-						SignatureDomain: make([]byte, 32),
-					},
-					nil)
 				client.EXPECT().SubmitValidatorRegistration(
 					gomock.Any(),
 					gomock.Any(),
@@ -1826,14 +1785,6 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 				).Return(
 					&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-				client.EXPECT().DomainData(
-					gomock.Any(),
-					gomock.Any(),
-				).Return(
-					&ethpb.DomainResponse{
-						SignatureDomain: make([]byte, 32),
-					},
-					nil)
 				client.EXPECT().SubmitValidatorRegistration(
 					gomock.Any(),
 					gomock.Any(),
@@ -1945,14 +1896,6 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 				).Return(
 					&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-				client.EXPECT().DomainData(
-					gomock.Any(),
-					gomock.Any(),
-				).Return(
-					&ethpb.DomainResponse{
-						SignatureDomain: make([]byte, 32),
-					},
-					nil)
 				client.EXPECT().SubmitValidatorRegistration(
 					gomock.Any(),
 					gomock.Any(),

--- a/validator/client/wait_for_activation_test.go
+++ b/validator/client/wait_for_activation_test.go
@@ -114,14 +114,6 @@ func TestWaitActivation_StreamSetupFails_AttemptsToReconnect(t *testing.T) {
 	).Return(
 		&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-	client.EXPECT().DomainData(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(
-		&ethpb.DomainResponse{
-			SignatureDomain: make([]byte, 32),
-		},
-		nil)
 	client.EXPECT().SubmitValidatorRegistration(
 		gomock.Any(),
 		gomock.Any(),
@@ -181,14 +173,6 @@ func TestWaitForActivation_ReceiveErrorFromStream_AttemptsReconnection(t *testin
 	).Return(
 		&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-	client.EXPECT().DomainData(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(
-		&ethpb.DomainResponse{
-			SignatureDomain: make([]byte, 32),
-		},
-		nil)
 	client.EXPECT().SubmitValidatorRegistration(
 		gomock.Any(),
 		gomock.Any(),
@@ -244,14 +228,6 @@ func TestWaitActivation_LogsActivationEpochOK(t *testing.T) {
 	).Return(
 		&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-	client.EXPECT().DomainData(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(
-		&ethpb.DomainResponse{
-			SignatureDomain: make([]byte, 32),
-		},
-		nil)
 	client.EXPECT().SubmitValidatorRegistration(
 		gomock.Any(),
 		gomock.Any(),
@@ -312,14 +288,6 @@ func TestWaitForActivation_Exiting(t *testing.T) {
 	).Return(
 		&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-	client.EXPECT().DomainData(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(
-		&ethpb.DomainResponse{
-			SignatureDomain: make([]byte, 32),
-		},
-		nil)
 	client.EXPECT().SubmitValidatorRegistration(
 		gomock.Any(),
 		gomock.Any(),
@@ -386,14 +354,6 @@ func TestWaitForActivation_RefetchKeys(t *testing.T) {
 	).Return(
 		&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-	client.EXPECT().DomainData(
-		gomock.Any(),
-		gomock.Any(),
-	).Return(
-		&ethpb.DomainResponse{
-			SignatureDomain: make([]byte, 32),
-		},
-		nil)
 	client.EXPECT().SubmitValidatorRegistration(
 		gomock.Any(),
 		gomock.Any(),
@@ -484,14 +444,6 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 		).Times(2).Return(
 			&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-		client.EXPECT().DomainData(
-			gomock.Any(),
-			gomock.Any(),
-		).Times(2).Return(
-			&ethpb.DomainResponse{
-				SignatureDomain: make([]byte, 32),
-			},
-			nil)
 		client.EXPECT().SubmitValidatorRegistration(
 			gomock.Any(),
 			gomock.Any(),
@@ -592,14 +544,6 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 		).Times(2).Return(
 			&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-		client.EXPECT().DomainData(
-			gomock.Any(),
-			gomock.Any(),
-		).Times(2).Return(
-			&ethpb.DomainResponse{
-				SignatureDomain: make([]byte, 32),
-			},
-			nil)
 		client.EXPECT().SubmitValidatorRegistration(
 			gomock.Any(),
 			gomock.Any(),
@@ -686,14 +630,6 @@ func TestWaitForActivation_RemoteKeymanager(t *testing.T) {
 			&emptypb.Empty{},
 		).Times(2).Return(
 			&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
-		client.EXPECT().DomainData(
-			gomock.Any(),
-			gomock.Any(),
-		).Times(2).Return(
-			&ethpb.DomainResponse{
-				SignatureDomain: make([]byte, 32),
-			},
-			nil)
 		client.EXPECT().SubmitValidatorRegistration(
 			gomock.Any(),
 			gomock.Any(),
@@ -789,14 +725,6 @@ func TestWaitForActivation_RemoteKeymanager(t *testing.T) {
 		).Times(2).Return(
 			&ethpb.Genesis{GenesisTime: timestamppb.Now()}, nil)
 
-		client.EXPECT().DomainData(
-			gomock.Any(),
-			gomock.Any(),
-		).Times(2).Return(
-			&ethpb.DomainResponse{
-				SignatureDomain: make([]byte, 32),
-			},
-			nil)
 		client.EXPECT().SubmitValidatorRegistration(
 			gomock.Any(),
 			gomock.Any(),


### PR DESCRIPTION
The domain for validator registration was wrong. It's supposed to be `compute_domain(DOMAIN_APPLICATION_BUILDER)` but we were passing in the actual fork version and genesis validators root. I've also updated builder spec for clarity https://github.com/ethereum/builder-specs/pull/33