### PR TITLE
Prune within forkchoice

### DIFF
--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -269,8 +269,8 @@ func TestStore_OnAttestation_Ok_ProtoArray(t *testing.T) {
 	copied, err = transition.ProcessSlots(ctx, copied, 1)
 	require.NoError(t, err)
 	require.NoError(t, service.cfg.BeaconDB.SaveState(ctx, copied, tRoot))
-	ojc := &ethpb.Checkpoint{Epoch: 1, Root: params.BeaconConfig().ZeroHash[:]}
-	ofc := &ethpb.Checkpoint{Epoch: 1, Root: params.BeaconConfig().ZeroHash[:]}
+	ojc := &ethpb.Checkpoint{Epoch: 1, Root: tRoot[:]}
+	ofc := &ethpb.Checkpoint{Epoch: 1, Root: tRoot[:]}
 	state, blkRoot, err := prepareForkchoiceState(ctx, 0, tRoot, tRoot, params.BeaconConfig().ZeroHash, ojc, ofc)
 	require.NoError(t, err)
 	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, state, blkRoot))

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -711,6 +711,10 @@ func TestForkChoice_UpdateCheckpoints(t *testing.T) {
 				[32]byte{'f'}, [32]byte{}, tt.newJustified.Epoch, tt.newFinalized.Epoch)
 			require.NoError(t, err)
 			require.NoError(t, fcs.InsertNode(ctx, state, blkRoot))
+			state, blkRoot, err = prepareForkchoiceState(ctx, 65, [32]byte{'h'},
+				[32]byte{'f'}, [32]byte{}, tt.newFinalized.Epoch, tt.newFinalized.Epoch)
+			require.NoError(t, err)
+			require.NoError(t, fcs.InsertNode(ctx, state, blkRoot))
 			// restart justifications cause insertion messed it up
 			fcs.store.justifiedCheckpoint = tt.justified
 			fcs.store.finalizedCheckpoint = tt.finalized

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -179,12 +179,15 @@ func (s *Store) pruneFinalizedNodeByRootMap(ctx context.Context, node, finalized
 // prune prunes the fork choice store with the new finalized root. The store is only pruned if the input
 // root is different than the current store finalized root, and the number of the store has met prune threshold.
 // This function does not prune for invalid optimistically synced nodes, it deals only with pruning upon finalization
-func (s *Store) prune(ctx context.Context, finalizedRoot [32]byte) error {
+func (s *Store) prune(ctx context.Context) error {
 	_, span := trace.StartSpan(ctx, "doublyLinkedForkchoice.Prune")
 	defer span.End()
 
 	s.nodesLock.Lock()
 	defer s.nodesLock.Unlock()
+	s.checkpointsLock.RLock()
+	finalizedRoot := s.finalizedCheckpoint.Root
+	s.checkpointsLock.RUnlock()
 
 	finalizedNode, ok := s.nodeByRoot[finalizedRoot]
 	if !ok || finalizedNode == nil {

--- a/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
@@ -171,7 +171,8 @@ func TestStore_Prune_LessThanThreshold(t *testing.T) {
 
 	// Finalized root has depth 99 so everything before it should be pruned,
 	// but PruneThreshold is at 100 so nothing will be pruned.
-	require.NoError(t, s.prune(context.Background(), indexToHash(99)))
+	s.finalizedCheckpoint.Root = indexToHash(99)
+	require.NoError(t, s.prune(context.Background()))
 	assert.Equal(t, 100, len(s.nodeByRoot), "Incorrect nodes count")
 }
 
@@ -193,7 +194,8 @@ func TestStore_Prune_MoreThanThreshold(t *testing.T) {
 	s.pruneThreshold = 0
 
 	// Finalized root is at index 99 so everything before 99 should be pruned.
-	require.NoError(t, s.prune(context.Background(), indexToHash(99)))
+	s.finalizedCheckpoint.Root = indexToHash(99)
+	require.NoError(t, s.prune(context.Background()))
 	assert.Equal(t, 1, len(s.nodeByRoot), "Incorrect nodes count")
 }
 
@@ -215,11 +217,13 @@ func TestStore_Prune_MoreThanOnce(t *testing.T) {
 	s.pruneThreshold = 0
 
 	// Finalized root is at index 11 so everything before 11 should be pruned.
-	require.NoError(t, s.prune(context.Background(), indexToHash(10)))
+	s.finalizedCheckpoint.Root = indexToHash(10)
+	require.NoError(t, s.prune(context.Background()))
 	assert.Equal(t, 90, len(s.nodeByRoot), "Incorrect nodes count")
 
 	// One more time.
-	require.NoError(t, s.prune(context.Background(), indexToHash(20)))
+	s.finalizedCheckpoint.Root = indexToHash(20)
+	require.NoError(t, s.prune(context.Background()))
 	assert.Equal(t, 80, len(s.nodeByRoot), "Incorrect nodes count")
 }
 
@@ -242,7 +246,8 @@ func TestStore_Prune_NoDanglingBranch(t *testing.T) {
 	f.store.pruneThreshold = 0
 
 	s := f.store
-	require.NoError(t, s.prune(context.Background(), indexToHash(1)))
+	s.finalizedCheckpoint.Root = indexToHash(1)
+	require.NoError(t, s.prune(context.Background()))
 	require.Equal(t, len(s.nodeByRoot), 1)
 }
 
@@ -324,7 +329,8 @@ func TestStore_PruneMapsNodes(t *testing.T) {
 
 	s := f.store
 	s.pruneThreshold = 0
-	require.NoError(t, s.prune(context.Background(), indexToHash(uint64(1))))
+	s.finalizedCheckpoint.Root = indexToHash(1)
+	require.NoError(t, s.prune(context.Background()))
 	require.Equal(t, len(s.nodeByRoot), 1)
 
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/vote_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/vote_test.go
@@ -263,9 +263,12 @@ func TestVotes_CanFindHead(t *testing.T) {
 
 	// Verify pruning below the prune threshold does not affect head.
 	f.store.pruneThreshold = 1000
-	require.NoError(t, f.store.prune(context.Background(), indexToHash(5)))
+	prevRoot := f.store.finalizedCheckpoint.Root
+	f.store.finalizedCheckpoint.Root = indexToHash(5)
+	require.NoError(t, f.store.prune(context.Background()))
 	assert.Equal(t, 11, len(f.store.nodeByRoot), "Incorrect nodes length after prune")
 
+	f.store.finalizedCheckpoint.Root = prevRoot
 	r, err = f.Head(context.Background(), balances)
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(10), r, "Incorrect head for with justified epoch at 3")
@@ -287,10 +290,12 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//         / \
 	//        9  10
 	f.store.pruneThreshold = 1
-	require.NoError(t, f.store.prune(context.Background(), indexToHash(5)))
+	f.store.finalizedCheckpoint.Root = indexToHash(5)
+	require.NoError(t, f.store.prune(context.Background()))
 	assert.Equal(t, 5, len(f.store.nodeByRoot), "Incorrect nodes length after prune")
 	// we pruned artificially the justified root.
 	f.store.justifiedCheckpoint.Root = indexToHash(5)
+	f.store.finalizedCheckpoint.Root = prevRoot
 
 	r, err = f.Head(context.Background(), balances)
 	require.NoError(t, err)

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -15,7 +15,6 @@ type ForkChoicer interface {
 	HeadRetriever        // to compute head.
 	BlockProcessor       // to track new block for fork choice.
 	AttestationProcessor // to track new attestation for fork choice.
-	Pruner               // to clean old data for fork choice.
 	Getter               // to retrieve fork choice information.
 	Setter               // to set fork choice information.
 	ProposerBooster      // ability to boost timely-proposed block roots.
@@ -38,11 +37,6 @@ type BlockProcessor interface {
 type AttestationProcessor interface {
 	ProcessAttestation(context.Context, []uint64, [32]byte, types.Epoch)
 	InsertSlashedIndex(context.Context, types.ValidatorIndex)
-}
-
-// Pruner prunes the fork choice upon new finalization. This is used to keep fork choice sane.
-type Pruner interface {
-	Prune(context.Context, [32]byte) error
 }
 
 // ProposerBooster is able to boost the proposer's root score during fork choice.

--- a/beacon-chain/forkchoice/protoarray/store.go
+++ b/beacon-chain/forkchoice/protoarray/store.go
@@ -158,7 +158,6 @@ func (f *ForkChoice) InsertNode(ctx context.Context, state state.ReadOnlyBeaconS
 // updateCheckpoints update the checkpoints when inserting a new node.
 func (f *ForkChoice) updateCheckpoints(ctx context.Context, jc, fc *ethpb.Checkpoint) error {
 	f.store.checkpointsLock.Lock()
-	defer f.store.checkpointsLock.Unlock()
 	if jc.Epoch > f.store.justifiedCheckpoint.Epoch {
 		bj := f.store.bestJustifiedCheckpoint
 		if bj == nil || jc.Epoch > bj.Epoch {
@@ -177,11 +176,13 @@ func (f *ForkChoice) updateCheckpoints(ctx context.Context, jc, fc *ethpb.Checkp
 			}
 			jSlot, err := slots.EpochStart(currentJcp.Epoch)
 			if err != nil {
+				f.store.checkpointsLock.Unlock()
 				return err
 			}
 			jcRoot := bytesutil.ToBytes32(jc.Root)
 			root, err := f.AncestorRoot(ctx, jcRoot, jSlot)
 			if err != nil {
+				f.store.checkpointsLock.Unlock()
 				return err
 			}
 			if root == currentRoot {
@@ -191,19 +192,16 @@ func (f *ForkChoice) updateCheckpoints(ctx context.Context, jc, fc *ethpb.Checkp
 		}
 	}
 	// Update finalization
-	if fc.Epoch > f.store.finalizedCheckpoint.Epoch {
-		f.store.finalizedCheckpoint = &forkchoicetypes.Checkpoint{Epoch: fc.Epoch,
-			Root: bytesutil.ToBytes32(fc.Root)}
-		f.store.justifiedCheckpoint = &forkchoicetypes.Checkpoint{Epoch: jc.Epoch,
-			Root: bytesutil.ToBytes32(jc.Root)}
+	if fc.Epoch <= f.store.finalizedCheckpoint.Epoch {
+		f.store.checkpointsLock.Unlock()
+		return nil
 	}
-	return nil
-}
-
-// Prune prunes the fork choice store with the new finalized root. The store is only pruned if the input
-// root is different than the current store finalized root, and the number of the store has met prune threshold.
-func (f *ForkChoice) Prune(ctx context.Context, finalizedRoot [32]byte) error {
-	return f.store.prune(ctx, finalizedRoot)
+	f.store.finalizedCheckpoint = &forkchoicetypes.Checkpoint{Epoch: fc.Epoch,
+		Root: bytesutil.ToBytes32(fc.Root)}
+	f.store.justifiedCheckpoint = &forkchoicetypes.Checkpoint{Epoch: jc.Epoch,
+		Root: bytesutil.ToBytes32(jc.Root)}
+	f.store.checkpointsLock.Unlock()
+	return f.store.prune(ctx)
 }
 
 // HasNode returns true if the node exists in fork choice store,
@@ -710,17 +708,18 @@ func (s *Store) updateBestChildAndDescendant(parentIndex, childIndex uint64) err
 }
 
 // prune prunes the store with the new finalized root. The tree is only
-// pruned if the input finalized root are different than the one in stored and
-// the number of the nodes in store has met prune threshold.
-func (s *Store) prune(ctx context.Context, finalizedRoot [32]byte) error {
+// pruned if the number of the nodes in store has met prune threshold.
+func (s *Store) prune(ctx context.Context) error {
 	_, span := trace.StartSpan(ctx, "protoArrayForkChoice.prune")
 	defer span.End()
 
 	s.nodesLock.Lock()
 	defer s.nodesLock.Unlock()
+	s.checkpointsLock.RLock()
+	finalizedRoot := s.finalizedCheckpoint.Root
+	s.checkpointsLock.RUnlock()
 
-	// The node would have seen finalized root or else it
-	// wouldn't be able to prune it.
+	// Protection against invalid checkpoint
 	finalizedIndex, ok := s.nodesIndices[finalizedRoot]
 	if !ok {
 		return errUnknownFinalizedRoot

--- a/beacon-chain/forkchoice/protoarray/vote_test.go
+++ b/beacon-chain/forkchoice/protoarray/vote_test.go
@@ -263,9 +263,12 @@ func TestVotes_CanFindHead(t *testing.T) {
 
 	// Verify pruning below the prune threshold does not affect head.
 	f.store.pruneThreshold = 1000
-	require.NoError(t, f.store.prune(context.Background(), indexToHash(5)))
+	prevRoot := f.store.finalizedCheckpoint.Root
+	f.store.finalizedCheckpoint.Root = indexToHash(5)
+	require.NoError(t, f.store.prune(context.Background()))
 	assert.Equal(t, 11, len(f.store.nodes), "Incorrect nodes length after prune")
 
+	f.store.finalizedCheckpoint.Root = prevRoot
 	r, err = f.Head(context.Background(), balances)
 	require.NoError(t, err)
 	assert.Equal(t, indexToHash(10), r, "Incorrect head for with justified epoch at 3")
@@ -287,10 +290,12 @@ func TestVotes_CanFindHead(t *testing.T) {
 	//         / \
 	//        9  10
 	f.store.pruneThreshold = 1
-	require.NoError(t, f.store.prune(context.Background(), indexToHash(5)))
+	f.store.finalizedCheckpoint.Root = indexToHash(5)
+	require.NoError(t, f.store.prune(context.Background()))
 	assert.Equal(t, 5, len(f.store.nodes), "Incorrect nodes length after prune")
 	// we pruned artificially the justified root.
 	f.store.justifiedCheckpoint.Root = indexToHash(5)
+	f.store.finalizedCheckpoint.Root = prevRoot
 
 	r, err = f.Head(context.Background(), balances)
 	require.NoError(t, err)


### PR DESCRIPTION
Continue the cleanup of blockchain package: now that we track correct finalized and justified checkpoints on forkchoice, we can prune within it and remove the exported function. 

Part of #10734 

Note to reviewers: review only after #10840  has been merged. 

Fixes #10899