### PR TITLE
Change gocognit complextity threshold to 65

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
 linters-settings:
   gocognit:
     # TODO: We should target for < 50
-    min-complexity: 97
+    min-complexity: 65
 
 output:
   print-issued-lines: true


### PR DESCRIPTION
After previous PRs to reduce functions with top cognitive complexity, we can lower the threshold now.

This will help guard our code base for future.