### PR TITLE
track the wall clock on forkchoice spectests

### DIFF
--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -39,6 +39,7 @@ func NewBuilder(t testing.TB, initialState state.BeaconState, initialBlock inter
 // Tick resets the genesis time to now()-tick and adjusts the slot to the appropriate value.
 func (bb *Builder) Tick(t testing.TB, tick int64) {
 	bb.service.SetGenesisTime(time.Unix(time.Now().Unix()-tick, 0))
+	bb.service.ForkChoicer().SetGenesisTime(uint64(time.Now().Unix() - tick))
 	if tick > bb.lastTick {
 		slot := uint64(tick) / params.BeaconConfig().SecondsPerSlot
 		require.NoError(t, bb.service.NewSlot(context.TODO(), types.Slot(slot)))


### PR DESCRIPTION
Forkchoice tracks genesis time since it needs access to the current slot to apply proposer boost or update justification. On spec tests this is simulated by subtracting the current tick from genesis time. This PR simply addresses this missing piece on forkchoice. 