### PR TITLE
Register builder service

### DIFF
--- a/beacon-chain/builder/option.go
+++ b/beacon-chain/builder/option.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/cmd/beacon-chain/flags"
 	"github.com/prysmaticlabs/prysm/network"
@@ -27,10 +28,18 @@ func WithBuilderEndpoints(endpoint string) Option {
 	}
 }
 
-// WithDatabase sets the database for the beacon chain builder service.
-func WithDatabase(database db.HeadAccessDatabase) Option {
+// WithHeadFetcher gets the head info from chain service.
+func WithHeadFetcher(svc *blockchain.Service) Option {
 	return func(s *Service) error {
-		s.cfg.beaconDB = database
+		s.cfg.headFetcher = svc
+		return nil
+	}
+}
+
+// WithDatabase for head access.
+func WithDatabase(beaconDB db.HeadAccessDatabase) Option {
+	return func(s *Service) error {
+		s.cfg.beaconDB = beaconDB
 		return nil
 	}
 }

--- a/beacon-chain/builder/service.go
+++ b/beacon-chain/builder/service.go
@@ -89,8 +89,8 @@ func (s *Service) GetHeader(ctx context.Context, slot types.Slot, parentHash [32
 }
 
 // Status retrieves the status of the builder relay network.
-func (s *Service) Status(ctx context.Context) error {
-	ctx, span := trace.StartSpan(ctx, "builder.Status")
+func (s *Service) Status() error {
+	ctx, span := trace.StartSpan(context.Background(), "builder.Status")
 	defer span.End()
 	start := time.Now()
 	defer func() {

--- a/beacon-chain/builder/service.go
+++ b/beacon-chain/builder/service.go
@@ -40,7 +40,9 @@ type Service struct {
 
 // NewService instantiates a new service.
 func NewService(ctx context.Context, opts ...Option) (*Service, error) {
-	s := &Service{}
+	s := &Service{
+		cfg: &config{},
+	}
 	for _, opt := range opts {
 		if err := opt(s); err != nil {
 			return nil, err

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -841,7 +841,6 @@ func (b *BeaconNode) registerRPCService() error {
 		MaxMsgSize:              maxMsgSize,
 		ProposerIdsCache:        b.proposerIdsCache,
 		ExecutionEngineCaller:   web3Service,
-		BlockBuilder:            b.fetchBuilderService(),
 	})
 
 	return b.services.RegisterService(rpcService)

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -249,6 +249,11 @@ func New(cliCtx *cli.Context, opts ...Option) (*BeaconNode, error) {
 		return nil, err
 	}
 
+	log.Debugln("Registering builder service")
+	if err := beacon.registerBuilderService(); err != nil {
+		return nil, err
+	}
+
 	log.Debugln("Registering RPC Service")
 	if err := beacon.registerRPCService(); err != nil {
 		return nil, err
@@ -569,6 +574,14 @@ func (b *BeaconNode) fetchP2P() p2p.P2P {
 	return p
 }
 
+func (b *BeaconNode) fetchBuilderService() *builder.Service {
+	var s *builder.Service
+	if err := b.services.FetchService(&s); err != nil {
+		panic(err)
+	}
+	return s
+}
+
 func (b *BeaconNode) registerAttestationPool() error {
 	s, err := attestations.NewService(b.ctx, &attestations.Config{
 		Pool: b.attestationPool,
@@ -828,6 +841,7 @@ func (b *BeaconNode) registerRPCService() error {
 		MaxMsgSize:              maxMsgSize,
 		ProposerIdsCache:        b.proposerIdsCache,
 		ExecutionEngineCaller:   web3Service,
+		BlockBuilder:            b.fetchBuilderService(),
 	})
 
 	return b.services.RegisterService(rpcService)
@@ -966,6 +980,22 @@ func (b *BeaconNode) registerValidatorMonitorService() error {
 		HeadFetcher:         chainService,
 	}
 	svc, err := monitor.NewService(b.ctx, monitorConfig, tracked)
+	if err != nil {
+		return err
+	}
+	return b.services.RegisterService(svc)
+}
+
+func (b *BeaconNode) registerBuilderService() error {
+	var chainService *blockchain.Service
+	if err := b.services.FetchService(&chainService); err != nil {
+		return err
+	}
+
+	opts := append(b.serviceFlagOpts.builderOpts,
+		builder.WithHeadFetcher(chainService),
+		builder.WithDatabase(b.db))
+	svc, err := builder.NewService(b.ctx, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Can register builder service through the `node.go`. I had to change `Status(ctx context.Context)` to `Status()` to satisfy service interface