### PR TITLE
Revert disallow lower checkpoint

### DIFF
--- a/beacon-chain/core/epoch/precompute/BUILD.bazel
+++ b/beacon-chain/core/epoch/precompute/BUILD.bazel
@@ -39,7 +39,6 @@ go_test(
         "attestation_test.go",
         "justification_finalization_test.go",
         "new_test.go",
-        "precompute_test.go",
         "reward_penalty_test.go",
         "slashing_test.go",
     ],

--- a/beacon-chain/core/epoch/precompute/justification_finalization.go
+++ b/beacon-chain/core/epoch/precompute/justification_finalization.go
@@ -149,14 +149,14 @@ func computeCheckpoints(state state.BeaconState, newBits bitfield.Bitvector4) (*
 	finalizedCheckpoint := state.FinalizedCheckpoint()
 
 	// If 2/3 or more of the total balance attested in the current epoch.
-	if newBits.BitAt(0) && currentEpoch >= justifiedCheckpoint.Epoch {
+	if newBits.BitAt(0) {
 		blockRoot, err := helpers.BlockRoot(state, currentEpoch)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "could not get block root for current epoch %d", currentEpoch)
 		}
 		justifiedCheckpoint.Epoch = currentEpoch
 		justifiedCheckpoint.Root = blockRoot
-	} else if newBits.BitAt(1) && prevEpoch >= justifiedCheckpoint.Epoch {
+	} else if newBits.BitAt(1) {
 		// If 2/3 or more of total balance attested in the previous epoch.
 		blockRoot, err := helpers.BlockRoot(state, prevEpoch)
 		if err != nil {

--- a/beacon-chain/core/epoch/precompute/justification_finalization_test.go
+++ b/beacon-chain/core/epoch/precompute/justification_finalization_test.go
@@ -250,18 +250,3 @@ func TestUnrealizedCheckpoints(t *testing.T) {
 		})
 	}
 }
-
-func Test_ComputeCheckpoints_CantUpdateToLower(t *testing.T) {
-	st, err := v2.InitializeFromProto(&ethpb.BeaconStateAltair{
-		Slot: params.BeaconConfig().SlotsPerEpoch * 2,
-		CurrentJustifiedCheckpoint: &ethpb.Checkpoint{
-			Epoch: 2,
-		},
-	})
-	require.NoError(t, err)
-	jb := make(bitfield.Bitvector4, 1)
-	jb.SetBitAt(1, true)
-	cp, _, err := precompute.ComputeCheckpoints(st, jb)
-	require.NoError(t, err)
-	require.Equal(t, types.Epoch(2), cp.Epoch)
-}

--- a/beacon-chain/core/epoch/precompute/precompute_test.go
+++ b/beacon-chain/core/epoch/precompute/precompute_test.go
@@ -1,3 +1,0 @@
-package precompute
-
-var ComputeCheckpoints = computeCheckpoints


### PR DESCRIPTION
We disabled reverting to disallow lower checkpoint to satisfy fuzz testing not-possible constructed state. Unfortunately this may be unintended consequences to the latest fork choice changes