### PR TITLE
Stop ruining our lives with flaky e2e

### DIFF
--- a/testing/endtoend/minimal_e2e_test.go
+++ b/testing/endtoend/minimal_e2e_test.go
@@ -7,13 +7,9 @@ import (
 )
 
 func TestEndToEnd_MinimalConfig(t *testing.T) {
-	e2eMinimal(t).run()
+	e2eMinimal(t, types.WithCheckpointSync()).run()
 }
 
 func TestEndToEnd_MinimalConfig_Web3Signer(t *testing.T) {
 	e2eMinimal(t, types.WithRemoteSigner()).run()
-}
-
-func TestEndToEnd_MinimalConfig_CheckpointSync(t *testing.T) {
-	e2eMinimal(t, types.WithCheckpointSync()).run()
 }

--- a/testing/endtoend/minimal_e2e_test.go
+++ b/testing/endtoend/minimal_e2e_test.go
@@ -9,7 +9,3 @@ import (
 func TestEndToEnd_MinimalConfig(t *testing.T) {
 	e2eMinimal(t, types.WithCheckpointSync()).run()
 }
-
-func TestEndToEnd_MinimalConfig_Web3Signer(t *testing.T) {
-	e2eMinimal(t, types.WithRemoteSigner()).run()
-}

--- a/testing/endtoend/minimal_scenario_e2e_test.go
+++ b/testing/endtoend/minimal_scenario_e2e_test.go
@@ -14,6 +14,10 @@ func TestEndToEnd_MultiScenarioRun(t *testing.T) {
 	runner.scenarioRunner()
 }
 
+func TestEndToEnd_MinimalConfig_Web3Signer(t *testing.T) {
+	e2eMinimal(t, types.WithRemoteSigner()).run()
+}
+
 func TestEndToEnd_ScenarioRun_EEOffline(t *testing.T) {
 	t.Skip("TODO(#10242) Prysm is current unable to handle an offline e2e")
 	runner := e2eMinimal(t)


### PR DESCRIPTION
**What type of PR is this?**

Other - Sisyphean boulder size reduction

**What does this PR do? Why is it needed?**

This merges the checkpoint sync e2e test into the base test to reduce the number of e2e tests to run. This should be ok since the checkpoint sync test is a superset of the main minimal e2e test.

Also moves the web3signer e2e test into the scenario test file, which only runs occasionally (as opposed to every e2e run).

It is needed to preserve everyone's sanity and remaining shreds of happiness.

**Which issues(s) does this PR fix?**

This fixes all of our problems, everything will be fine from now on.