### PR TITLE
RPC: Add submit registration endpoint

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -189,6 +189,15 @@ func (vs *Server) computeStateRoot(ctx context.Context, block interfaces.SignedB
 }
 
 // SubmitValidatorRegistration submits validator registrations.
-func (vs *Server) SubmitValidatorRegistration(context.Context, *ethpb.SignedValidatorRegistrationsV1) (*emptypb.Empty, error) {
+func (vs *Server) SubmitValidatorRegistration(ctx context.Context, reg *ethpb.SignedValidatorRegistrationsV1) (*emptypb.Empty, error) {
+	// No-op is the builder is nil / not configured. The node should still function without a builder.
+	if vs.BlockBuilder == nil || !vs.BlockBuilder.Configured() {
+		return &emptypb.Empty{}, nil
+	}
+
+	if err := vs.BlockBuilder.RegisterValidator(ctx, reg.Messages); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Could not register block builder: %v", err)
+	}
+
 	return &emptypb.Empty{}, nil
 }


### PR DESCRIPTION
This PR fills in submit validator registration endpoint for RPC. This will be used for builder service to register a validator to the remote relay endpoint