### PR TITLE
RPC adds builder service

### DIFF
--- a/beacon-chain/builder/service.go
+++ b/beacon-chain/builder/service.go
@@ -60,7 +60,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 			return nil, err
 		}
 		s.c = c
-		log.WithField("endpoint", c.NodeURL()).Info("Builder has configured")
+		log.WithField("endpoint", c.NodeURL()).Info("Builder has been configured")
 	}
 	return s, nil
 }

--- a/beacon-chain/builder/service.go
+++ b/beacon-chain/builder/service.go
@@ -60,6 +60,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 			return nil, err
 		}
 		s.c = c
+		log.WithField("endpoint", c.NodeURL()).Info("Builder has configured")
 	}
 	return s, nil
 }

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -841,6 +841,7 @@ func (b *BeaconNode) registerRPCService() error {
 		MaxMsgSize:              maxMsgSize,
 		ProposerIdsCache:        b.proposerIdsCache,
 		ExecutionEngineCaller:   web3Service,
+		BlockBuilder:            b.fetchBuilderService(),
 	})
 
 	return b.services.RegisterService(rpcService)

--- a/beacon-chain/rpc/BUILD.bazel
+++ b/beacon-chain/rpc/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//beacon-chain:__subpackages__"],
     deps = [
         "//beacon-chain/blockchain:go_default_library",
+        "//beacon-chain/builder:go_default_library",
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/cache/depositcache:go_default_library",
         "//beacon-chain/core/feed/block:go_default_library",

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -14,6 +14,7 @@ import (
 	grpcopentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	grpcprometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain"
+	"github.com/prysmaticlabs/prysm/beacon-chain/builder"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache/depositcache"
 	blockfeed "github.com/prysmaticlabs/prysm/beacon-chain/core/feed/block"
@@ -112,6 +113,7 @@ type Config struct {
 	ExecutionEngineCaller   powchain.EngineCaller
 	ProposerIdsCache        *cache.ProposerPayloadIDsCache
 	OptimisticModeFetcher   blockchain.OptimisticModeFetcher
+	BlockBuilder            builder.BlockBuilder
 }
 
 // NewService instantiates a new RPC service instance that will
@@ -216,6 +218,7 @@ func (s *Service) Start() {
 		ExecutionEngineCaller:  s.cfg.ExecutionEngineCaller,
 		BeaconDB:               s.cfg.BeaconDB,
 		ProposerSlotIndexCache: s.cfg.ProposerIdsCache,
+		BlockBuilder:           s.cfg.BlockBuilder,
 	}
 	validatorServerV1 := &validator.Server{
 		HeadFetcher:           s.cfg.HeadFetcher,


### PR DESCRIPTION
Hook up builder service to RPC service so we can use it. I also added a nice `Builder has configured` log once the builder service is initialized with the HTTP client