### PR TITLE
Log error in `fetchBlocksFromPeer`

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -289,9 +289,12 @@ func (f *blocksFetcher) fetchBlocksFromPeer(
 		Step:      1,
 	}
 	for i := 0; i < len(peers); i++ {
-		if blocks, err := f.requestBlocks(ctx, req, peers[i]); err == nil {
+		blocks, err := f.requestBlocks(ctx, req, peers[i])
+		if err == nil {
 			f.p2p.Peers().Scorers().BlockProviderScorer().Touch(peers[i])
 			return blocks, peers[i], err
+		} else {
+			log.WithError(err).Error("could not request blocks by range")
 		}
 	}
 	return nil, "", errNoPeersAvailable

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -294,7 +294,7 @@ func (f *blocksFetcher) fetchBlocksFromPeer(
 			f.p2p.Peers().Scorers().BlockProviderScorer().Touch(peers[i])
 			return blocks, peers[i], err
 		} else {
-			log.WithError(err).Error("could not request blocks by range")
+			log.WithError(err).Error("Could not request blocks by range")
 		}
 	}
 	return nil, "", errNoPeersAvailable


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Currently in `blocksFetcher.fetchBlocksFromPeer` we ignore any error coming from `requestBlocks`. This PR logs out the error.
