### PR TITLE
Wrap client-stats flags

### DIFF
--- a/cmd/client-stats/main.go
+++ b/cmd/client-stats/main.go
@@ -29,6 +29,10 @@ var appFlags = []cli.Flag{
 	flags.ScrapeIntervalFlag,
 }
 
+func init() {
+	appFlags = cmd.WrapFlags(appFlags)
+}
+
 func main() {
 	app := cli.App{}
 	app.Name = "client-stats"


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

client-stats flags are not wrapped in `urfave/cli/v2/altsrc` flags and because of this they are not read from YAML. We have the same `init()` code for beacon-chain and validator.

**Which issues(s) does this PR fix?**

Fixes #10494