### PR TITLE
Save Head after pruning invalid nodes

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -110,10 +110,15 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *notifyForkcho
 				return nil, err
 			}
 
+			if err := s.saveHead(ctx, r, b, st); err != nil {
+				log.WithError(err).Error("could not save head after pruning invalid blocks")
+			}
+
 			log.WithFields(logrus.Fields{
 				"slot":         headBlk.Slot(),
-				"blockRoot":    fmt.Sprintf("%#x", headRoot),
+				"blockRoot":    fmt.Sprintf("%#x", bytesutil.Trunc(headRoot[:])),
 				"invalidCount": len(invalidRoots),
+				"newHeadRoot":  fmt.Sprintf("%#x", bytesutil.Trunc(r[:])),
 			}).Warn("Pruned invalid blocks")
 			return pid, ErrInvalidPayload
 


### PR DESCRIPTION
After pruning INVALID blocks from forkchoice, we update forkchoice's head but we do not save the new head information to store.  Thus, the RPC endpoint for head returns an error because it can't find head on DB, as it was just pruned. 

This was reported by Mario Vega from EF on hive testings