### PR TITLE
Check finalized beyond DB

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -83,6 +83,7 @@ type FinalizationFetcher interface {
 	CurrentJustifiedCheckpt() *ethpb.Checkpoint
 	PreviousJustifiedCheckpt() *ethpb.Checkpoint
 	VerifyFinalizedBlkDescendant(ctx context.Context, blockRoot [32]byte) error
+	IsFinalized(ctx context.Context, blockRoot [32]byte) bool
 }
 
 // OptimisticModeFetcher retrieves information about optimistic status of the node.
@@ -305,6 +306,15 @@ func (s *Service) IsOptimistic(ctx context.Context) (bool, error) {
 	}
 
 	return s.IsOptimisticForRoot(ctx, s.head.root)
+}
+
+// IsFinalized returns true if the input root is finalized.
+// It first checks latest finalized root then checks finalized root index in DB.
+func (s *Service) IsFinalized(ctx context.Context, root [32]byte) bool {
+	if s.ForkChoicer().FinalizedCheckpoint().Root == root {
+		return true
+	}
+	return s.cfg.BeaconDB.IsFinalizedBlock(ctx, root)
 }
 
 // IsOptimisticForRoot takes the root as argument instead of the current head

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -675,9 +675,9 @@ func TestService_IsFinalized(t *testing.T) {
 	ctx := context.Background()
 	c := &Service{cfg: &config{BeaconDB: beaconDB, ForkChoiceStore: doublylinkedtree.New()}}
 	r1 := [32]byte{'a'}
-	c.ForkChoiceStore().UpdateFinalizedCheckpoint(&forkchoicetypes.Checkpoint{
+	require.NoError(t, c.ForkChoiceStore().UpdateFinalizedCheckpoint(&forkchoicetypes.Checkpoint{
 		Root: r1,
-	})
+	}))
 	b := util.NewBeaconBlock()
 	br, err := b.Block.HashTreeRoot()
 	require.NoError(t, err)

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -669,3 +669,25 @@ func TestService_IsOptimisticForRoot_DB_non_canonical(t *testing.T) {
 	require.Equal(t, true, validated)
 
 }
+
+func TestService_IsFinalized(t *testing.T) {
+	beaconDB := testDB.SetupDB(t)
+	ctx := context.Background()
+	c := &Service{cfg: &config{BeaconDB: beaconDB, ForkChoiceStore: doublylinkedtree.New()}}
+	r1 := [32]byte{'a'}
+	c.ForkChoiceStore().UpdateFinalizedCheckpoint(&forkchoicetypes.Checkpoint{
+		Root: r1,
+	})
+	b := util.NewBeaconBlock()
+	br, err := b.Block.HashTreeRoot()
+	require.NoError(t, err)
+	util.SaveBlock(t, ctx, beaconDB, b)
+	require.NoError(t, beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: br[:], Slot: 10}))
+	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, br))
+	require.NoError(t, beaconDB.SaveFinalizedCheckpoint(ctx, &ethpb.Checkpoint{
+		Root: br[:],
+	}))
+	require.Equal(t, true, c.IsFinalized(ctx, r1))
+	require.Equal(t, true, c.IsFinalized(ctx, br))
+	require.Equal(t, false, c.IsFinalized(ctx, [32]byte{'c'}))
+}

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -63,6 +63,7 @@ type ChainService struct {
 	ForkChoiceStore             forkchoice.ForkChoicer
 	ReceiveBlockMockErr         error
 	OptimisticCheckRootReceived [32]byte
+	FinalizedRoots              map[[32]byte]bool
 }
 
 // ForkChoicer mocks the same method in the chain service
@@ -458,3 +459,8 @@ func (s *ChainService) UpdateHead(_ context.Context) error { return nil }
 
 // ReceiveAttesterSlashing mocks the same method in the chain service.
 func (s *ChainService) ReceiveAttesterSlashing(context.Context, *ethpb.AttesterSlashing) {}
+
+// IsFinalized mocks the same method in the chain service.
+func (s *ChainService) IsFinalized(_ context.Context, blockRoot [32]byte) bool {
+	return s.FinalizedRoots[blockRoot]
+}

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -310,7 +310,7 @@ func (s *Service) validateStatusMessage(ctx context.Context, msg *pb.Status) err
 	if finalizedAtGenesis && rootIsEqual {
 		return nil
 	}
-	if !s.cfg.beaconDB.IsFinalizedBlock(ctx, bytesutil.ToBytes32(msg.FinalizedRoot)) {
+	if !s.cfg.chain.IsFinalized(ctx, bytesutil.ToBytes32(msg.FinalizedRoot)) {
 		log.WithField("root", fmt.Sprintf("%#x", msg.FinalizedRoot)).Debug("Could not validate finalized root")
 		return p2ptypes.ErrInvalidFinalizedRoot
 	}

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -493,8 +493,6 @@ func TestStatusRPCRequest_FinalizedBlockExists(t *testing.T) {
 	}
 	totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
 	genTime := time.Now().Unix() - totalSec
-	t.Log(finalizedRoot)
-	t.Log(headRoot)
 	r := &Service{
 		cfg: &config{
 			p2p: p1,

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -199,6 +199,9 @@ func TestStatusRPCHandler_ReturnsHelloMessage(t *testing.T) {
 				},
 				ValidatorsRoot: [32]byte{'A'},
 				Genesis:        time.Unix(genTime, 0),
+				FinalizedRoots: map[[32]byte]bool{
+					finalizedRoot: true,
+				},
 			},
 			beaconDB: db,
 		},
@@ -284,6 +287,9 @@ func TestHandshakeHandlers_Roundtrip(t *testing.T) {
 				Genesis:        time.Now(),
 				ValidatorsRoot: [32]byte{'A'},
 				Root:           make([]byte, 32),
+				FinalizedRoots: map[[32]byte]bool{
+					finalizedRoot: true,
+				},
 			},
 			beaconDB: db,
 		},
@@ -487,6 +493,8 @@ func TestStatusRPCRequest_FinalizedBlockExists(t *testing.T) {
 	}
 	totalSec := int64(params.BeaconConfig().SlotsPerEpoch.Mul(5 * params.BeaconConfig().SecondsPerSlot))
 	genTime := time.Now().Unix() - totalSec
+	t.Log(finalizedRoot)
+	t.Log(headRoot)
 	r := &Service{
 		cfg: &config{
 			p2p: p1,
@@ -500,6 +508,9 @@ func TestStatusRPCRequest_FinalizedBlockExists(t *testing.T) {
 				},
 				Genesis:        time.Unix(genTime, 0),
 				ValidatorsRoot: [32]byte{'A'},
+				FinalizedRoots: map[[32]byte]bool{
+					finalizedRoot: true,
+				},
 			},
 		},
 		ctx:         context.Background(),
@@ -519,6 +530,9 @@ func TestStatusRPCRequest_FinalizedBlockExists(t *testing.T) {
 				},
 				Genesis:        time.Unix(genTime, 0),
 				ValidatorsRoot: [32]byte{'A'},
+				FinalizedRoots: map[[32]byte]bool{
+					finalizedRoot: true,
+				},
 			},
 			beaconDB: db,
 		},
@@ -675,6 +689,10 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 					},
 					Genesis:        time.Unix(genTime, 0),
 					ValidatorsRoot: [32]byte{'A'},
+					FinalizedRoots: map[[32]byte]bool{
+						tt.expectedFinalizedRoot: true,
+						tt.remoteFinalizedRoot:   true,
+					},
 				},
 			},
 			ctx:         context.Background(),
@@ -694,6 +712,10 @@ func TestStatusRPCRequest_FinalizedBlockSkippedSlots(t *testing.T) {
 					},
 					Genesis:        time.Unix(genTime, 0),
 					ValidatorsRoot: [32]byte{'A'},
+					FinalizedRoots: map[[32]byte]bool{
+						tt.expectedFinalizedRoot: true,
+						tt.remoteFinalizedRoot:   true,
+					},
 				},
 				beaconDB: db,
 			},

--- a/beacon-chain/sync/subscriber_test.go
+++ b/beacon-chain/sync/subscriber_test.go
@@ -460,6 +460,9 @@ func TestFilterSubnetPeers(t *testing.T) {
 				Genesis:        time.Now(),
 				ValidatorsRoot: [32]byte{'A'},
 				Slot:           &currSlot,
+				FinalizedRoots: map[[32]byte]bool{
+					[32]byte{}: true,
+				},
 			},
 			p2p: p,
 		},


### PR DESCRIPTION
This PR improves checking of finalized root for status exchange to beyond DB. It first checks for the last cached finalized checkpoint root in the fork choice store. Typically fork choice store gets updated first at t, and DB gets updated second at t+n. The caller of `IsFinalized` can get a more immediate and correct response on the given input root  