### PR TITLE
Pure Functions to Convert Between Full and Blinded Bellatrix Beacon Blocks

### DIFF
--- a/consensus-types/wrapper/BUILD.bazel
+++ b/consensus-types/wrapper/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/consensus-types/wrapper",
     visibility = ["//visibility:public"],
     deps = [
+        "//consensus-types/forks/bellatrix:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//proto/engine/v1:go_default_library",
@@ -39,6 +40,8 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//config/fieldparams:go_default_library",
+        "//consensus-types/forks/bellatrix:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//proto/engine/v1:go_default_library",
@@ -48,5 +51,6 @@ go_test(
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
     ],
 )

--- a/consensus-types/wrapper/beacon_block_test.go
+++ b/consensus-types/wrapper/beacon_block_test.go
@@ -3,10 +3,120 @@ package wrapper_test
 import (
 	"testing"
 
+	"github.com/pkg/errors"
+	fieldparams "github.com/prysmaticlabs/prysm/config/fieldparams"
+	"github.com/prysmaticlabs/prysm/consensus-types/forks/bellatrix"
 	"github.com/prysmaticlabs/prysm/consensus-types/wrapper"
+	enginev1 "github.com/prysmaticlabs/prysm/proto/engine/v1"
 	"github.com/prysmaticlabs/prysm/testing/require"
 	"github.com/prysmaticlabs/prysm/testing/util"
 )
+
+func TestBuildSignedBeaconBlockFromExecutionPayload(t *testing.T) {
+	t.Run("nil block check", func(t *testing.T) {
+		_, err := wrapper.BuildSignedBeaconBlockFromExecutionPayload(nil, nil)
+		require.ErrorIs(t, wrapper.ErrNilSignedBeaconBlock, err)
+	})
+	t.Run("unsupported field payload header", func(t *testing.T) {
+		altairBlock := util.NewBeaconBlockAltair()
+		blk, err := wrapper.WrappedSignedBeaconBlock(altairBlock)
+		require.NoError(t, err)
+		_, err = wrapper.BuildSignedBeaconBlockFromExecutionPayload(blk, nil)
+		require.Equal(t, true, errors.Is(err, wrapper.ErrUnsupportedField))
+	})
+	t.Run("payload header root and payload root mismatch", func(t *testing.T) {
+		payload := &enginev1.ExecutionPayload{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, 20),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, 256),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  make([][]byte, 0),
+		}
+		header, err := bellatrix.PayloadToHeader(payload)
+		require.NoError(t, err)
+		blindedBlock := util.NewBlindedBeaconBlockBellatrix()
+
+		// Modify the header.
+		header.GasUsed += 1
+		blindedBlock.Block.Body.ExecutionPayloadHeader = header
+
+		blk, err := wrapper.WrappedSignedBeaconBlock(blindedBlock)
+		require.NoError(t, err)
+		_, err = wrapper.BuildSignedBeaconBlockFromExecutionPayload(blk, payload)
+		require.ErrorContains(t, "roots do not match", err)
+	})
+	t.Run("ok", func(t *testing.T) {
+		payload := &enginev1.ExecutionPayload{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, 20),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, 256),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  make([][]byte, 0),
+		}
+		header, err := bellatrix.PayloadToHeader(payload)
+		require.NoError(t, err)
+		blindedBlock := util.NewBlindedBeaconBlockBellatrix()
+		blindedBlock.Block.Body.ExecutionPayloadHeader = header
+
+		blk, err := wrapper.WrappedSignedBeaconBlock(blindedBlock)
+		require.NoError(t, err)
+		builtBlock, err := wrapper.BuildSignedBeaconBlockFromExecutionPayload(blk, payload)
+		require.NoError(t, err)
+
+		got, err := builtBlock.Block().Body().ExecutionPayload()
+		require.NoError(t, err)
+		require.DeepEqual(t, payload, got)
+	})
+}
+
+func TestWrapSignedBlindedBeaconBlock(t *testing.T) {
+	t.Run("nil block check", func(t *testing.T) {
+		_, err := wrapper.BuildSignedBeaconBlockFromExecutionPayload(nil, nil)
+		require.ErrorIs(t, wrapper.ErrNilSignedBeaconBlock, err)
+	})
+	t.Run("unsupported field execution payload", func(t *testing.T) {
+		altairBlock := util.NewBeaconBlockAltair()
+		blk, err := wrapper.WrappedSignedBeaconBlock(altairBlock)
+		require.NoError(t, err)
+		_, err = wrapper.BuildSignedBeaconBlockFromExecutionPayload(blk, nil)
+		require.Equal(t, true, errors.Is(err, wrapper.ErrUnsupportedField))
+	})
+	t.Run("ok", func(t *testing.T) {
+		payload := &enginev1.ExecutionPayload{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, 20),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, 256),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  make([][]byte, 0),
+		}
+		bellatrixBlk := util.NewBeaconBlockBellatrix()
+		bellatrixBlk.Block.Body.ExecutionPayload = payload
+
+		want, err := bellatrix.PayloadToHeader(payload)
+		require.NoError(t, err)
+
+		blk, err := wrapper.WrappedSignedBeaconBlock(bellatrixBlk)
+		require.NoError(t, err)
+		builtBlock, err := wrapper.WrapSignedBlindedBeaconBlock(blk)
+		require.NoError(t, err)
+
+		got, err := builtBlock.Block().Body().ExecutionPayloadHeader()
+		require.NoError(t, err)
+		require.DeepEqual(t, want, got)
+	})
+}
 
 func TestWrappedSignedBeaconBlock(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR adds two new functions to our `consensus-types/wrapper` package for helping us deal with Bellatrix beacon block formats.

```go
// BuildSignedBeaconBlockFromExecutionPayload takes a signed, blinded beacon block and converts into
// a full, signed beacon block by specifying an execution payload.
func BuildSignedBeaconBlockFromExecutionPayload(
	blk interfaces.SignedBeaconBlock, payload *enginev1.ExecutionPayload,
) (interfaces.SignedBeaconBlock, error)
```

and:

```go
// WrapSignedBlindedBeaconBlock converts a signed beacon block into a blinded format.
func WrapSignedBlindedBeaconBlock(blk interfaces.SignedBeaconBlock) (interfaces.SignedBeaconBlock, error)
```
These two are pure functions that allow us to convert a full, Bellatrix beacon block into a blinded beacon block and vice versa. The reason why we need these are that, post-merge, we intend to only store **blinded Bellatrix beacon blocks** in our database. We believe it is unreasonable for Prysm to have to store full execution payloads when our execution client does so already, and they can be reconstructed on the fly by using our JSON-RPC connection to our execution client.

A full design document for the feature and its tradeoffs is presented [here](https://prysmaticlabs.notion.site/Storing-Only-BlindedBeaconBlocks-in-Prysm-Post-Merge-1aed63ab2aa94d00b96c05fbc7d69b5b)

**Which issues(s) does this PR fix?**

Part of #10589
