### PR TITLE
Wrap NewPayload error

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -126,7 +126,7 @@ func (s *Service) onBlock(ctx context.Context, signed interfaces.SignedBeaconBlo
 	}
 	isValidPayload, err := s.notifyNewPayload(ctx, postStateVersion, postStateHeader, signed)
 	if err != nil {
-		return fmt.Errorf("could not verify new payload: %v", err)
+		return errors.Wrap(err, "could not validate new payload")
 	}
 	if isValidPayload {
 		if err := s.validateMergeTransitionBlock(ctx, preStateVersion, preStateHeader, signed); err != nil {


### PR DESCRIPTION
Reported by @seamonkey. We saw repeated logging `WARN blockchain: Pruned invalid blocks ` Upon further look, we did not wrap the `new payload` error. Due to that, we did not mark the block bad in sync service hence the block is stuck in the pending queue. Pending queue is processed every 4s which alings with the timestamp in log [pruned_invalid.txt](https://github.com/prysmaticlabs/prysm/files/9051250/message.4.txt)

