### PR TITLE
Batch build API requests for RegisterValidator

### DIFF
--- a/api/client/builder/BUILD.bazel
+++ b/api/client/builder/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//math:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
@@ -19,6 +20,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
 

--- a/api/client/builder/BUILD.bazel
+++ b/api/client/builder/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/require:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
     ],
 )

--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -12,15 +12,15 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/pkg/errors"
 	mathprysm "github.com/prysmaticlabs/prysm/math"
 	"go.opencensus.io/trace"
 	"golang.org/x/sync/errgroup"
-	"github.com/pkg/errors"
 
+	types "github.com/prysmaticlabs/prysm/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/monitoring/tracing"
 	v1 "github.com/prysmaticlabs/prysm/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
-	types "github.com/prysmaticlabs/prysm/consensus-types/primitives"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -32,6 +32,8 @@ const (
 var errMalformedHostname = errors.New("hostname must include port, separated by one colon, like example.com:3500")
 var errMalformedRequest = errors.New("required request data are missing")
 
+const registerValidatorBatchLimit = 100
+
 // ClientOpt is a functional option for the Client type (http.Client wrapper)
 type ClientOpt func(*Client)
 

--- a/api/client/builder/client_test.go
+++ b/api/client/builder/client_test.go
@@ -122,6 +122,8 @@ func TestClient_RegisterValidator_Over100Requests(t *testing.T) {
 		}
 	}
 
+	var total int
+
 	ctx := context.Background()
 	hc := &http.Client{
 		Transport: roundtrip(func(r *http.Request) (*http.Response, error) {
@@ -134,6 +136,7 @@ func TestClient_RegisterValidator_Over100Requests(t *testing.T) {
 			if len(recvd) > registerValidatorBatchLimit {
 				t.Errorf("Number of requests (%d) exceeds limit (%d)", len(recvd), registerValidatorBatchLimit)
 			}
+			total += len(recvd)
 
 			require.Equal(t, http.MethodPost, r.Method)
 			return &http.Response{
@@ -149,6 +152,7 @@ func TestClient_RegisterValidator_Over100Requests(t *testing.T) {
 	}
 
 	require.NoError(t, c.RegisterValidator(ctx, reqs))
+	require.Equal(t, len(reqs), total)
 }
 
 func TestClient_GetHeader(t *testing.T) {

--- a/api/client/builder/client_test.go
+++ b/api/client/builder/client_test.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -106,6 +107,48 @@ func TestClient_RegisterValidator(t *testing.T) {
 		},
 	}
 	require.NoError(t, c.RegisterValidator(ctx, []*eth.SignedValidatorRegistrationV1{reg}))
+}
+
+func TestClient_RegisterValidator_Over100Requests(t *testing.T) {
+	reqs := make([]*eth.SignedValidatorRegistrationV1, 301)
+	for i := 0; i < len(reqs); i++ {
+		reqs[i] = &eth.SignedValidatorRegistrationV1{
+			Message: &eth.ValidatorRegistrationV1{
+				FeeRecipient: ezDecode(t, params.BeaconConfig().EthBurnAddressHex),
+				GasLimit:     23,
+				Timestamp:    42,
+				Pubkey:       []byte(fmt.Sprint(i)),
+			},
+		}
+	}
+
+	ctx := context.Background()
+	hc := &http.Client{
+		Transport: roundtrip(func(r *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, r.Body.Close())
+			require.NoError(t, err)
+
+			recvd := make([]*SignedValidatorRegistration, 0)
+			require.NoError(t, json.Unmarshal(body, &recvd))
+			if len(recvd) > registerValidatorBatchLimit {
+				t.Errorf("Number of requests (%d) exceeds limit (%d)", len(recvd), registerValidatorBatchLimit)
+			}
+
+			require.Equal(t, http.MethodPost, r.Method)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBuffer(nil)),
+				Request:    r.Clone(ctx),
+			}, nil
+		}),
+	}
+	c := &Client{
+		hc:      hc,
+		baseURL: &url.URL{Host: "localhost:3500", Scheme: "http"},
+	}
+
+	require.NoError(t, c.RegisterValidator(ctx, reqs))
 }
 
 func TestClient_GetHeader(t *testing.T) {

--- a/api/client/builder/types.go
+++ b/api/client/builder/types.go
@@ -31,6 +31,22 @@ func (r *SignedValidatorRegistration) MarshalJSON() ([]byte, error) {
 	})
 }
 
+func (r *SignedValidatorRegistration) UnmarshalJSON(b []byte) error {
+	if r.SignedValidatorRegistrationV1 == nil {
+		r.SignedValidatorRegistrationV1 = &eth.SignedValidatorRegistrationV1{}
+	}
+	o := struct {
+		Message   *ValidatorRegistration `json:"message,omitempty"`
+		Signature hexutil.Bytes          `json:"signature,omitempty"`
+	}{}
+	if err := json.Unmarshal(b, &o); err != nil {
+		return err
+	}
+	r.Message = o.Message.ValidatorRegistrationV1
+	r.Signature = o.Signature
+	return nil
+}
+
 func (r *ValidatorRegistration) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		FeeRecipient hexutil.Bytes `json:"fee_recipient,omitempty"`
@@ -43,6 +59,33 @@ func (r *ValidatorRegistration) MarshalJSON() ([]byte, error) {
 		Timestamp:    fmt.Sprintf("%d", r.Timestamp),
 		Pubkey:       r.Pubkey,
 	})
+}
+
+func (r *ValidatorRegistration) UnmarshalJSON(b []byte) error {
+	if r.ValidatorRegistrationV1 == nil {
+		r.ValidatorRegistrationV1 = &eth.ValidatorRegistrationV1{}
+	}
+	o := struct {
+		FeeRecipient hexutil.Bytes `json:"fee_recipient,omitempty"`
+		GasLimit     string        `json:"gas_limit,omitempty"`
+		Timestamp    string        `json:"timestamp,omitempty"`
+		Pubkey       hexutil.Bytes `json:"pubkey,omitempty"`
+	}{}
+	if err := json.Unmarshal(b, &o); err != nil {
+		return err
+	}
+
+	r.FeeRecipient = o.FeeRecipient
+	r.Pubkey = o.Pubkey
+	var err error
+	if r.GasLimit, err = strconv.ParseUint(o.GasLimit, 10, 64); err != nil {
+		return errors.Wrap(err, "failed to parse gas limit")
+	}
+	if r.Timestamp, err = strconv.ParseUint(o.Timestamp, 10, 64); err != nil {
+		return errors.Wrap(err, "failed to parse timestamp")
+	}
+
+	return nil
 }
 
 type Uint256 struct {

--- a/api/client/builder/types_test.go
+++ b/api/client/builder/types_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/golang/protobuf/proto"
 	"github.com/prysmaticlabs/go-bitfield"
 	v1 "github.com/prysmaticlabs/prysm/proto/engine/v1"
 	eth "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
@@ -31,7 +32,8 @@ func TestSignedValidatorRegistration_MarshalJSON(t *testing.T) {
 		},
 		Signature: make([]byte, 96),
 	}
-	je, err := json.Marshal(&SignedValidatorRegistration{SignedValidatorRegistrationV1: svr})
+	a := &SignedValidatorRegistration{SignedValidatorRegistrationV1: svr}
+	je, err := json.Marshal(a)
 	require.NoError(t, err)
 	// decode with a struct w/ plain strings so we can check the string encoding of the hex fields
 	un := struct {
@@ -45,6 +47,14 @@ func TestSignedValidatorRegistration_MarshalJSON(t *testing.T) {
 	require.Equal(t, "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", un.Signature)
 	require.Equal(t, "0x0000000000000000000000000000000000000000", un.Message.FeeRecipient)
 	require.Equal(t, "0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", un.Message.Pubkey)
+
+	t.Run("roundtrip", func(t *testing.T) {
+		b := &SignedValidatorRegistration{}
+		if err := json.Unmarshal(je, b); err != nil {
+			require.NoError(t, err)
+		}
+		require.Equal(t, proto.Equal(a.SignedValidatorRegistrationV1, b.SignedValidatorRegistrationV1), true)
+	})
 }
 
 var testExampleHeaderResponse = `{


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Sending large batches of requests can cause rpc timeouts when a backend is not capable of processing the work in a timely manner.

This PR sets a hard coded limit of 100 keys per request and completes the requests asynchronously.

**Which issues(s) does this PR fix?**

Fixes #10949

**Other notes for review**
