### PR TITLE
Minor UX improvement to validator registration

### DIFF
--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -360,10 +360,10 @@ var (
 	}
 
 	// EnableValidatorRegistrationFlag enables the periodic validator registration API calls that will update the custom builder with validator settings.
-	EnableValidatorRegistrationFlag = &cli.StringFlag{
+	EnableValidatorRegistrationFlag = &cli.BoolFlag{
 		Name:  "enable-validator-registration",
 		Usage: "Enables validator registration APIs (MEV Builder APIs) for the validator client to update settings such as fee recipient and gas limit",
-		Value: "",
+		Value: false,
 	}
 )
 

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -980,12 +980,14 @@ func (v *validator) PushProposerSettings(ctx context.Context, km keymanager.IKey
 	}); err != nil {
 		return err
 	}
-	log.Infoln("Successfully prepared beacon proposer with fee recipient to validator index mapping.")
+	log.Infoln("Prepared beacon proposer with fee recipient to validator index mapping")
 
-	if err := SubmitValidatorRegistration(ctx, v.validatorClient, km.Sign, registerValidatorRequests); err != nil {
-		return err
+	if len(registerValidatorRequests) > 0 {
+		if err := SubmitValidatorRegistration(ctx, v.validatorClient, km.Sign, registerValidatorRequests); err != nil {
+			return err
+		}
+		log.Infoln("Submitted builder validator registration settings for custom builders")
 	}
-	log.Infoln("Successfully submitted builder validator registration settings for custom builders.")
 	return nil
 }
 


### PR DESCRIPTION
- String flag to bool flag. `--enable-validator-registration` is nicer than `--enable-validator-registration=true`
- Don't log `Submitted builder validator registration settings for custom builders` or call `SubmitValidatorRegistration` if `registerValidatorRequests` is 0