### PR TITLE
Simplify Push Proposer settings

### DIFF
--- a/validator/client/wait_for_activation.go
+++ b/validator/client/wait_for_activation.go
@@ -145,10 +145,6 @@ func (v *validator) handleWithRemoteKeyManager(ctx context.Context, accountsChan
 			valActivated := v.checkAndLogValidatorStatus(statuses)
 			if valActivated {
 				logActiveValidatorStatus(statuses)
-				// Set properties on the beacon node like the fee recipient for validators that are being used & active.
-				if err := v.PushProposerSettings(ctx, *remoteKm); err != nil {
-					return err
-				}
 			} else {
 				continue
 			}
@@ -196,11 +192,6 @@ func (v *validator) handleWithoutRemoteKeyManager(ctx context.Context, accountsC
 			valActivated := v.checkAndLogValidatorStatus(statuses)
 			if valActivated {
 				logActiveValidatorStatus(statuses)
-
-				// Set properties on the beacon node like the fee recipient for validators that are being used & active.
-				if err := v.PushProposerSettings(ctx, v.keyManager); err != nil {
-					return err
-				}
 			} else {
 				continue
 			}

--- a/validator/client/wait_for_activation_test.go
+++ b/validator/client/wait_for_activation_test.go
@@ -6,11 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	fieldparams "github.com/prysmaticlabs/prysm/config/fieldparams"
-	validatorserviceconfig "github.com/prysmaticlabs/prysm/config/validator/service"
 	types "github.com/prysmaticlabs/prysm/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/crypto/bls"
 	"github.com/prysmaticlabs/prysm/encoding/bytesutil"
@@ -67,7 +65,6 @@ func TestWaitActivation_StreamSetupFails_AttemptsToReconnect(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock.NewMockBeaconNodeValidatorClient(ctrl)
-	nodeClient := mock.NewMockNodeClient(ctrl)
 	privKey, err := bls.RandKey()
 	require.NoError(t, err)
 	pubKey := [fieldparams.BLSPubkeyLength]byte{}
@@ -78,18 +75,9 @@ func TestWaitActivation_StreamSetupFails_AttemptsToReconnect(t *testing.T) {
 		},
 	}
 	v := validator{
-		validatorClient:        client,
-		node:                   nodeClient,
-		keyManager:             km,
-		pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-		ProposerSettings: &validatorserviceconfig.ProposerSettings{
-			ProposeConfig: nil,
-			DefaultConfig: &validatorserviceconfig.ProposerOption{
-				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
-			},
-		},
+		validatorClient: client,
+		keyManager:      km,
 	}
-	v.pubkeyToValidatorIndex[pubKey] = 1
 	clientStream := mock.NewMockBeaconNodeValidator_WaitForActivationClient(ctrl)
 	client.EXPECT().WaitForActivation(
 		gomock.Any(),
@@ -97,11 +85,6 @@ func TestWaitActivation_StreamSetupFails_AttemptsToReconnect(t *testing.T) {
 			PublicKeys: [][]byte{pubKey[:]},
 		},
 	).Return(clientStream, errors.New("failed stream")).Return(clientStream, nil)
-	client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
-		Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
-			{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-		},
-	}).Return(nil, nil)
 	resp := generateMockStatusResponse([][]byte{pubKey[:]})
 	resp.Statuses[0].Status.Status = ethpb.ValidatorStatus_ACTIVE
 	clientStream.EXPECT().Recv().Return(resp, nil)
@@ -112,7 +95,6 @@ func TestWaitForActivation_ReceiveErrorFromStream_AttemptsReconnection(t *testin
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock.NewMockBeaconNodeValidatorClient(ctrl)
-	nodeClient := mock.NewMockNodeClient(ctrl)
 	privKey, err := bls.RandKey()
 	require.NoError(t, err)
 	pubKey := [fieldparams.BLSPubkeyLength]byte{}
@@ -123,18 +105,9 @@ func TestWaitForActivation_ReceiveErrorFromStream_AttemptsReconnection(t *testin
 		},
 	}
 	v := validator{
-		validatorClient:        client,
-		node:                   nodeClient,
-		keyManager:             km,
-		pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-		ProposerSettings: &validatorserviceconfig.ProposerSettings{
-			ProposeConfig: nil,
-			DefaultConfig: &validatorserviceconfig.ProposerOption{
-				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
-			},
-		},
+		validatorClient: client,
+		keyManager:      km,
 	}
-	v.pubkeyToValidatorIndex[pubKey] = 1
 	clientStream := mock.NewMockBeaconNodeValidator_WaitForActivationClient(ctrl)
 	client.EXPECT().WaitForActivation(
 		gomock.Any(),
@@ -142,11 +115,6 @@ func TestWaitForActivation_ReceiveErrorFromStream_AttemptsReconnection(t *testin
 			PublicKeys: [][]byte{pubKey[:]},
 		},
 	).Return(clientStream, nil)
-	client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
-		Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
-			{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-		},
-	}).Return(nil, nil)
 	// A stream fails the first time, but succeeds the second time.
 	resp := generateMockStatusResponse([][]byte{pubKey[:]})
 	resp.Statuses[0].Status.Status = ethpb.ValidatorStatus_ACTIVE
@@ -162,7 +130,6 @@ func TestWaitActivation_LogsActivationEpochOK(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock.NewMockBeaconNodeValidatorClient(ctrl)
-	nodeClient := mock.NewMockNodeClient(ctrl)
 	privKey, err := bls.RandKey()
 	require.NoError(t, err)
 	pubKey := [fieldparams.BLSPubkeyLength]byte{}
@@ -173,19 +140,10 @@ func TestWaitActivation_LogsActivationEpochOK(t *testing.T) {
 		},
 	}
 	v := validator{
-		validatorClient:        client,
-		node:                   nodeClient,
-		keyManager:             km,
-		genesisTime:            1,
-		pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-		ProposerSettings: &validatorserviceconfig.ProposerSettings{
-			ProposeConfig: nil,
-			DefaultConfig: &validatorserviceconfig.ProposerOption{
-				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
-			},
-		},
+		validatorClient: client,
+		keyManager:      km,
+		genesisTime:     1,
 	}
-	v.pubkeyToValidatorIndex[pubKey] = 1
 	resp := generateMockStatusResponse([][]byte{pubKey[:]})
 	resp.Statuses[0].Status.Status = ethpb.ValidatorStatus_ACTIVE
 	clientStream := mock.NewMockBeaconNodeValidator_WaitForActivationClient(ctrl)
@@ -199,11 +157,6 @@ func TestWaitActivation_LogsActivationEpochOK(t *testing.T) {
 		resp,
 		nil,
 	)
-	client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
-		Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
-			{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-		},
-	}).Return(nil, nil)
 	assert.NoError(t, v.WaitForActivation(context.Background(), nil), "Could not wait for activation")
 	assert.LogsContain(t, hook, "Validator activated")
 }
@@ -212,7 +165,6 @@ func TestWaitForActivation_Exiting(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock.NewMockBeaconNodeValidatorClient(ctrl)
-	nodeClient := mock.NewMockNodeClient(ctrl)
 	privKey, err := bls.RandKey()
 	require.NoError(t, err)
 	pubKey := [fieldparams.BLSPubkeyLength]byte{}
@@ -223,19 +175,9 @@ func TestWaitForActivation_Exiting(t *testing.T) {
 		},
 	}
 	v := validator{
-		validatorClient:        client,
-		node:                   nodeClient,
-		keyManager:             km,
-		genesisTime:            1,
-		pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-		ProposerSettings: &validatorserviceconfig.ProposerSettings{
-			ProposeConfig: nil,
-			DefaultConfig: &validatorserviceconfig.ProposerOption{
-				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
-			},
-		},
+		validatorClient: client,
+		keyManager:      km,
 	}
-	v.pubkeyToValidatorIndex[pubKey] = 1
 	resp := generateMockStatusResponse([][]byte{pubKey[:]})
 	resp.Statuses[0].Status.Status = ethpb.ValidatorStatus_EXITING
 	clientStream := mock.NewMockBeaconNodeValidator_WaitForActivationClient(ctrl)
@@ -249,11 +191,6 @@ func TestWaitForActivation_Exiting(t *testing.T) {
 		resp,
 		nil,
 	)
-	client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
-		Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
-			{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-		},
-	}).Return(nil, nil)
 	assert.NoError(t, v.WaitForActivation(context.Background(), nil))
 }
 
@@ -268,7 +205,6 @@ func TestWaitForActivation_RefetchKeys(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock.NewMockBeaconNodeValidatorClient(ctrl)
-	nodeClient := mock.NewMockNodeClient(ctrl)
 	privKey, err := bls.RandKey()
 	require.NoError(t, err)
 	pubKey := [fieldparams.BLSPubkeyLength]byte{}
@@ -280,19 +216,9 @@ func TestWaitForActivation_RefetchKeys(t *testing.T) {
 		fetchNoKeys: true,
 	}
 	v := validator{
-		validatorClient:        client,
-		node:                   nodeClient,
-		keyManager:             km,
-		genesisTime:            1,
-		pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-		ProposerSettings: &validatorserviceconfig.ProposerSettings{
-			ProposeConfig: nil,
-			DefaultConfig: &validatorserviceconfig.ProposerOption{
-				FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
-			},
-		},
+		validatorClient: client,
+		keyManager:      km,
 	}
-	v.pubkeyToValidatorIndex[pubKey] = 1
 	resp := generateMockStatusResponse([][]byte{pubKey[:]})
 	resp.Statuses[0].Status.Status = ethpb.ValidatorStatus_ACTIVE
 	clientStream := mock.NewMockBeaconNodeValidator_WaitForActivationClient(ctrl)
@@ -305,12 +231,6 @@ func TestWaitForActivation_RefetchKeys(t *testing.T) {
 	clientStream.EXPECT().Recv().Return(
 		resp,
 		nil)
-
-	client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
-		Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
-			{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-		},
-	}).Return(nil, nil)
 	assert.NoError(t, v.waitForActivation(context.Background(), make(chan [][fieldparams.BLSPubkeyLength]byte)), "Could not wait for activation")
 	assert.LogsContain(t, hook, msgNoKeysFetched)
 	assert.LogsContain(t, hook, "Validator activated")
@@ -337,21 +257,10 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 			},
 		}
 		client := mock.NewMockBeaconNodeValidatorClient(ctrl)
-		nodeClient := mock.NewMockNodeClient(ctrl)
 		v := validator{
-			validatorClient:        client,
-			node:                   nodeClient,
-			keyManager:             km,
-			genesisTime:            1,
-			pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-			ProposerSettings: &validatorserviceconfig.ProposerSettings{
-				ProposeConfig: nil,
-				DefaultConfig: &validatorserviceconfig.ProposerOption{
-					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
-				},
-			},
+			validatorClient: client,
+			keyManager:      km,
 		}
-		v.pubkeyToValidatorIndex[inactivePubKey] = 1
 		inactiveResp := generateMockStatusResponse([][]byte{inactivePubKey[:]})
 		inactiveResp.Statuses[0].Status.Status = ethpb.ValidatorStatus_UNKNOWN_STATUS
 		inactiveClientStream := mock.NewMockBeaconNodeValidator_WaitForActivationClient(ctrl)
@@ -365,12 +274,6 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 			inactiveResp,
 			nil,
 		).AnyTimes()
-		client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
-			Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
-				{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-				{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-			},
-		}).Return(nil, nil)
 
 		activeResp := generateMockStatusResponse([][]byte{inactivePubKey[:], activePubKey[:]})
 		activeResp.Statuses[0].Status.Status = ethpb.ValidatorStatus_UNKNOWN_STATUS
@@ -391,7 +294,6 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 			// We add the active key into the keymanager and simulate a key refresh.
 			time.Sleep(time.Second * 1)
 			km.keysMap[activePubKey] = activePrivKey
-			v.pubkeyToValidatorIndex[activePubKey] = 1
 			km.SimulateAccountChanges(make([][fieldparams.BLSPubkeyLength]byte, 0))
 		}()
 
@@ -426,21 +328,11 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 		err = km.RecoverAccountsFromMnemonic(ctx, constant.TestMnemonic, "", 1)
 		require.NoError(t, err)
 		client := mock.NewMockBeaconNodeValidatorClient(ctrl)
-		nodeClient := mock.NewMockNodeClient(ctrl)
 		v := validator{
-			validatorClient:        client,
-			node:                   nodeClient,
-			keyManager:             km,
-			genesisTime:            1,
-			pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-			ProposerSettings: &validatorserviceconfig.ProposerSettings{
-				ProposeConfig: nil,
-				DefaultConfig: &validatorserviceconfig.ProposerOption{
-					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
-				},
-			},
+			validatorClient: client,
+			keyManager:      km,
+			genesisTime:     1,
 		}
-		v.pubkeyToValidatorIndex[inactivePubKey] = 1
 
 		inactiveResp := generateMockStatusResponse([][]byte{inactivePubKey[:]})
 		inactiveResp.Statuses[0].Status.Status = ethpb.ValidatorStatus_UNKNOWN_STATUS
@@ -455,12 +347,6 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 			inactiveResp,
 			nil,
 		).AnyTimes()
-		client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
-			Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
-				{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-				{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-			},
-		}).Return(nil, nil)
 
 		activeResp := generateMockStatusResponse([][]byte{inactivePubKey[:], activePubKey[:]})
 		activeResp.Statuses[0].Status.Status = ethpb.ValidatorStatus_UNKNOWN_STATUS
@@ -517,26 +403,15 @@ func TestWaitForActivation_RemoteKeymanager(t *testing.T) {
 	t.Run("activated", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		hook := logTest.NewGlobal()
-		nodeClient := mock.NewMockNodeClient(ctrl)
 		tickerChan := make(chan types.Slot)
 		ticker := &slotutilmock.MockTicker{
 			Channel: tickerChan,
 		}
 		v := validator{
-			validatorClient:        client,
-			node:                   nodeClient,
-			keyManager:             &km,
-			ticker:                 ticker,
-			pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-			ProposerSettings: &validatorserviceconfig.ProposerSettings{
-				ProposeConfig: nil,
-				DefaultConfig: &validatorserviceconfig.ProposerOption{
-					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
-				},
-			},
+			validatorClient: client,
+			keyManager:      &km,
+			ticker:          ticker,
 		}
-		v.pubkeyToValidatorIndex[activeKey] = 1
-		v.pubkeyToValidatorIndex[inactiveKey] = 2
 		go func() {
 			tickerChan <- slot
 			// Cancel after timeout to avoid waiting on channel forever in case test goes wrong.
@@ -553,13 +428,6 @@ func TestWaitForActivation_RemoteKeymanager(t *testing.T) {
 				PublicKeys: [][]byte{inactiveKey[:], activeKey[:]},
 			},
 		).Return(resp, nil /* err */)
-		client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
-			Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
-				{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 2},
-				{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-			},
-		}).Return(nil, nil)
-
 		err := v.waitForActivation(ctx, nil /* accountsChangedChan */)
 		require.NoError(t, err)
 		assert.LogsContain(t, hook, "Waiting for deposit to be observed by beacon node")
@@ -591,26 +459,15 @@ func TestWaitForActivation_RemoteKeymanager(t *testing.T) {
 		hook := logTest.NewGlobal()
 		remoteKm := remotekeymanagermock.NewMock()
 		remoteKm.PublicKeys = [][fieldparams.BLSPubkeyLength]byte{inactiveKey}
-		nodeClient := mock.NewMockNodeClient(ctrl)
 		tickerChan := make(chan types.Slot)
 		ticker := &slotutilmock.MockTicker{
 			Channel: tickerChan,
 		}
 		v := validator{
-			validatorClient:        client,
-			node:                   nodeClient,
-			keyManager:             &remoteKm,
-			ticker:                 ticker,
-			pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-			ProposerSettings: &validatorserviceconfig.ProposerSettings{
-				ProposeConfig: nil,
-				DefaultConfig: &validatorserviceconfig.ProposerOption{
-					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
-				},
-			},
+			validatorClient: client,
+			keyManager:      &remoteKm,
+			ticker:          ticker,
 		}
-		v.pubkeyToValidatorIndex[activeKey] = 1
-		v.pubkeyToValidatorIndex[inactiveKey] = 2
 		go func() {
 			tickerChan <- slot
 			time.Sleep(time.Second)
@@ -638,12 +495,6 @@ func TestWaitForActivation_RemoteKeymanager(t *testing.T) {
 				PublicKeys: [][]byte{inactiveKey[:], activeKey[:]},
 			},
 		).Return(resp2, nil /* err */)
-		client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
-			Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
-				{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 2},
-				{FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9").Bytes(), ValidatorIndex: 1},
-			},
-		}).Return(nil, nil)
 
 		err := v.waitForActivation(ctx, remoteKm.ReloadPublicKeysChan /* accountsChangedChan */)
 		require.NoError(t, err)

--- a/validator/client/wait_for_activation_test.go
+++ b/validator/client/wait_for_activation_test.go
@@ -369,11 +369,6 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 			time.Sleep(time.Second * 1)
 			err = km.RecoverAccountsFromMnemonic(ctx, constant.TestMnemonic, "", 2)
 			require.NoError(t, err)
-			keys, err := km.FetchValidatingPublicKeys(ctx)
-			require.NoError(t, err)
-			for _, key := range keys {
-				v.pubkeyToValidatorIndex[key] = 1
-			}
 			channel <- [][fieldparams.BLSPubkeyLength]byte{}
 		}()
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Other

related to #10593
**What does this PR do? Why is it needed?**

This PR simplifies the calls we make to updating proposer settings such as fee recipient through APIs.

previously we call the prepare beacon proposer API and validator registration API when:
- Validator Client Starts
- Validator Key status changes
- Start of Epoch

This PR removes the calls when `Validator Key status changes` as it is consistently updated at the start of each epoch anyways. It is unlikely that the validator key will be chosen as a block proposer at the same time the proposer settings are updated, as it's rare for these settings to be updated after validator restart.


