### PR TITLE
Only Unmarshal Full Tx Bodies in ExecutionBlock JSON Unmarshaler

### DIFF
--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -3,6 +3,7 @@ package enginev1
 import (
 	"encoding/json"
 	"math/big"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -74,6 +75,11 @@ func (e *ExecutionBlock) UnmarshalJSON(enc []byte) error {
 	// them into a list of geth transaction objects.
 	txs := make([]*gethtypes.Transaction, len(txsList))
 	for i, tx := range txsList {
+		// If the transaction is just a hex string, do not attempt to
+		// unmarshal into a full transaction object.
+		if txItem, ok := tx.(string); ok && strings.Contains(txItem, "0x") {
+			return nil
+		}
 		t := &gethtypes.Transaction{}
 		encodedTx, err := json.Marshal(tx)
 		if err != nil {


### PR DESCRIPTION
Fixes #11000. After some changes in #10993, there was a bug where the custom unmarshal code would fail if when retrieving execution blocks with tx hashes only. We do not care about tx hashes from execution blocks in Prysm, so we can safely ignore them and instead only perform transaction unmarshal if we are receiving a full transaction object in an execution block received via json rpc.