### PR TITLE
Check nil before logging "Failed to close response body..."

### DIFF
--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -165,7 +165,9 @@ func (c *Client) do(ctx context.Context, method string, path string, body io.Rea
 	}
 	defer func() {
 		closeErr := r.Body.Close()
-		log.WithError(closeErr).Error("Failed to close response body")
+		if closeErr != nil {
+			log.WithError(closeErr).Error("Failed to close response body")
+		}
 	}()
 	if r.StatusCode != http.StatusOK {
 		err = non200Err(r)


### PR DESCRIPTION
This is just cosmetic 