### PR TITLE
Push Proposer Settings: improve warn logs + bug fix

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -972,8 +972,11 @@ func (v *validator) PushProposerSettings(ctx context.Context, km keymanager.IKey
 		return err
 	}
 	if len(feeRecipients) == 0 {
-		log.Warnf("no valid validator indices were found, prepare beacon proposer request fee recipients array is empty")
+		log.Warnf("No valid validator indices were found, prepare beacon proposer request fee recipients array is empty")
 		return nil
+	}
+	if len(feeRecipients) != len(pubkeys) {
+		log.Warnf("%d public key(s) will not prepare beacon proposer and update fee recipient until a validator index is assigned", len(pubkeys)-len(feeRecipients))
 	}
 	if _, err := v.validatorClient.PrepareBeaconProposer(ctx, &ethpb.PrepareBeaconProposerRequest{
 		Recipients: feeRecipients,
@@ -983,6 +986,9 @@ func (v *validator) PushProposerSettings(ctx context.Context, km keymanager.IKey
 	log.Infoln("Prepared beacon proposer with fee recipient to validator index mapping")
 
 	if len(registerValidatorRequests) > 0 {
+		if len(registerValidatorRequests) != len(pubkeys) {
+			log.Warnf("%d public key(s) will not be included in validator registration until a validator index is assigned", len(pubkeys)-len(registerValidatorRequests))
+		}
 		if err := SubmitValidatorRegistration(ctx, v.validatorClient, km.Sign, registerValidatorRequests); err != nil {
 			return err
 		}

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -1460,6 +1460,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 		feeRecipientMap      map[types.ValidatorIndex]string
 		mockExpectedRequests []ExpectedValidatorRegistration
 		err                  string
+		logMessages          []string
 	}{
 		{
 			name: " Happy Path proposer config not nil",
@@ -1913,9 +1914,81 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 			},
 			err: "could not submit signed registrations to beacon node",
 		},
+		{
+			name: "Validator Index Not found with validator registration",
+			validatorSetter: func(t *testing.T) *validator {
+
+				v := validator{
+					validatorClient:        client,
+					node:                   nodeClient,
+					db:                     db,
+					pubkeyToValidatorIndex: make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
+					useWeb:                 false,
+					interopKeysConfig: &local.InteropKeymanagerConfig{
+						NumValidatorKeys: 2,
+						Offset:           1,
+					},
+					genesisTime: 0,
+				}
+				// set bellatrix as current epoch
+				params.BeaconConfig().BellatrixForkEpoch = 0
+				err := v.WaitForKeymanagerInitialization(ctx)
+				require.NoError(t, err)
+				km, err := v.Keymanager()
+				require.NoError(t, err)
+				keys, err := km.FetchValidatingPublicKeys(ctx)
+				require.NoError(t, err)
+				v.ProposerSettings = &validatorserviceconfig.ProposerSettings{
+					ProposeConfig: nil,
+					DefaultConfig: &validatorserviceconfig.ProposerOption{
+						FeeRecipient: common.HexToAddress(defaultFeeHex),
+						ValidatorRegistration: &validatorserviceconfig.ValidatorRegistration{
+							Enable:   true,
+							GasLimit: params.BeaconConfig().DefaultBuilderGasLimit,
+						},
+					},
+				}
+				client.EXPECT().ValidatorIndex(
+					gomock.Any(), // ctx
+					&ethpb.ValidatorIndexRequest{PublicKey: keys[0][:]},
+				).Return(&ethpb.ValidatorIndexResponse{
+					Index: 1,
+				}, nil)
+
+				client.EXPECT().ValidatorIndex(
+					gomock.Any(), // ctx
+					&ethpb.ValidatorIndexRequest{PublicKey: keys[1][:]},
+				).Times(2).Return(nil, errors.New("Could not find validator index"))
+
+				client.EXPECT().SubmitValidatorRegistration(
+					gomock.Any(),
+					gomock.Any(),
+				).Return(&empty.Empty{}, nil)
+				client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
+					Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
+						{FeeRecipient: common.HexToAddress(defaultFeeHex).Bytes(), ValidatorIndex: 1},
+					},
+				}).Return(nil, nil)
+				return &v
+			},
+			feeRecipientMap: map[types.ValidatorIndex]string{
+				1: defaultFeeHex,
+			},
+			mockExpectedRequests: []ExpectedValidatorRegistration{
+				{
+					FeeRecipient: byteValueAddress,
+					GasLimit:     params.BeaconConfig().DefaultBuilderGasLimit,
+				},
+			},
+			logMessages: []string{
+				"prepare beacon proposer and update fee recipient until a validator index is assigned",
+				"not be included in validator registration until a validator index is assigned",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
 			v := tt.validatorSetter(t)
 			km, err := v.Keymanager()
 			require.NoError(t, err)
@@ -1942,6 +2015,12 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 			}
 			if err := v.PushProposerSettings(ctx, km); tt.err != "" {
 				assert.ErrorContains(t, tt.err, err)
+			}
+			if len(tt.logMessages) > 0 {
+				for _, message := range tt.logMessages {
+					assert.LogsContain(t, hook, message)
+				}
+
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

UX
and Bug Fix

**What does this PR do? Why is it needed?**
This PR adds more logging for when a validator index is not assigned to the public key resulting in not calling the associated prepareBeaconProposer API. This will also fix a bug surrounding caching the index of public keys incorrectly as 0 when the key was not found. this results in using the wrong associated fee recipient for the key. This unit test also assists in making sure this feature is not broken in the future.

**Which issues(s) does this PR fix?**

Fixes #10858
