### PR TITLE
Fix proposer duty RPC to allow next epoch query

### DIFF
--- a/beacon-chain/rpc/eth/validator/validator.go
+++ b/beacon-chain/rpc/eth/validator/validator.go
@@ -133,8 +133,8 @@ func (vs *Server) GetProposerDuties(ctx context.Context, req *ethpbv1.ProposerDu
 
 	cs := vs.TimeFetcher.CurrentSlot()
 	currentEpoch := slots.ToEpoch(cs)
-	if req.Epoch > currentEpoch {
-		return nil, status.Errorf(codes.InvalidArgument, "Request epoch %d can not be greater than current epoch %d", req.Epoch, currentEpoch)
+	if req.Epoch > currentEpoch+1 {
+		return nil, status.Errorf(codes.InvalidArgument, "Request epoch %d can not be greater than next epoch %d", req.Epoch, currentEpoch+1)
 	}
 
 	s, err := vs.HeadFetcher.HeadState(ctx)
@@ -177,7 +177,7 @@ func (vs *Server) GetProposerDuties(ctx context.Context, req *ethpbv1.ProposerDu
 		return duties[i].Slot < duties[j].Slot
 	})
 
-	root, err := proposalDependentRoot(s, req.Epoch)
+	root, err := vs.proposalDependentRoot(ctx, s, req.Epoch)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get dependent root: %v", err)
 	}
@@ -912,7 +912,7 @@ func attestationDependentRoot(s state.BeaconState, epoch types.Epoch) ([]byte, e
 
 // proposalDependentRoot is get_block_root_at_slot(state, compute_start_slot_at_epoch(epoch) - 1)
 // or the genesis block root in the case of underflow.
-func proposalDependentRoot(s state.BeaconState, epoch types.Epoch) ([]byte, error) {
+func (vs *Server) proposalDependentRoot(ctx context.Context, s state.BeaconState, epoch types.Epoch) ([]byte, error) {
 	var dependentRootSlot types.Slot
 	if epoch == 0 {
 		dependentRootSlot = 0
@@ -923,10 +923,21 @@ func proposalDependentRoot(s state.BeaconState, epoch types.Epoch) ([]byte, erro
 		}
 		dependentRootSlot = epochStartSlot.Sub(1)
 	}
-	root, err := helpers.BlockRootAtSlot(s, dependentRootSlot)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get block root")
+	var root []byte
+	var err error
+	// Per spec, if the dependent root epoch is greater than current epoch, use the head root.
+	if dependentRootSlot >= s.Slot() {
+		root, err = vs.HeadFetcher.HeadRoot(ctx)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		root, err = helpers.BlockRootAtSlot(s, dependentRootSlot)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get block root")
+		}
 	}
+
 	return root, nil
 }
 

--- a/beacon-chain/rpc/eth/validator/validator_test.go
+++ b/beacon-chain/rpc/eth/validator/validator_test.go
@@ -366,11 +366,11 @@ func TestGetProposerDuties(t *testing.T) {
 	t.Run("Epoch out of bound", func(t *testing.T) {
 		currentEpoch := slots.ToEpoch(bs.Slot())
 		req := &ethpbv1.ProposerDutiesRequest{
-			Epoch: currentEpoch + 1,
+			Epoch: currentEpoch + 2,
 		}
 		_, err := vs.GetProposerDuties(ctx, req)
 		require.NotNil(t, err)
-		assert.ErrorContains(t, fmt.Sprintf("Request epoch %d can not be greater than current epoch %d", currentEpoch+1, currentEpoch), err)
+		assert.ErrorContains(t, fmt.Sprintf("Request epoch %d can not be greater than next epoch %d", currentEpoch+2, currentEpoch+1), err)
 	})
 
 	t.Run("execution optimistic", func(t *testing.T) {


### PR DESCRIPTION
Per [spec](https://github.com/ethereum/beacon-APIs/blob/master/apis/validator/duties/proposer.yaml), we should allow next epoch query. Example: [lighthouse](https://github.com/sigp/lighthouse/blob/stable/beacon_node/http_api/src/proposer_duties.rs)
This PR fixes the current behavior to enable the next epoch query and uses the head root as the dependent root if the query epoch != current epoch