### PR TITLE
Enforce a 1s timeout for block builder reply

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -21,7 +21,7 @@ import (
 )
 
 // blockBuilderTimeout is the maximum amount of time allowed for a block builder to respond to a
-// block request.
+// block request. This value is known as `BUILDER_PROPOSAL_DELAY_TOLERANCE` in builder spec.
 const blockBuilderTimeout = 1 * time.Second
 
 func (vs *Server) getBellatrixBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (*ethpb.GenericBeaconBlock, error) {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -33,7 +33,8 @@ func (vs *Server) getBellatrixBeaconBlock(ctx context.Context, req *ethpb.BlockR
 	builderReady, b, err := vs.getAndBuildHeaderBlock(ctx, altairBlk)
 	if err != nil {
 		// In the event of an error, the node should fall back to default execution engine for building block.
-		log.WithError(err).Error("Default back to local execution client")
+		log.WithError(err).Error("Failed to build a block from external builder, falling " +
+			"back to local execution client")
 	} else if builderReady {
 		return b, nil
 	}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Per spec, the request should be limited to 1s. 

See https://github.com/ethereum/builder-specs/blob/e912fa8c6727fa456106cc85cb94fc4ab0f8d251/specs/validator.md#relation-to-local-block-building

**Which issues(s) does this PR fix?**

**Other notes for review**
