### PR TITLE
builder client: Revert key batching PR #11002

### DIFF
--- a/api/client/builder/BUILD.bazel
+++ b/api/client/builder/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",
-        "//math:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
@@ -20,7 +19,6 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
-        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
 

--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -13,15 +13,12 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	mathprysm "github.com/prysmaticlabs/prysm/math"
-	"go.opencensus.io/trace"
-	"golang.org/x/sync/errgroup"
-
 	types "github.com/prysmaticlabs/prysm/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/monitoring/tracing"
 	v1 "github.com/prysmaticlabs/prysm/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
 	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -33,8 +30,6 @@ const (
 
 var errMalformedHostname = errors.New("hostname must include port, separated by one colon, like example.com:3500")
 var errMalformedRequest = errors.New("required request data are missing")
-
-const registerValidatorBatchLimit = 100
 
 // ClientOpt is a functional option for the Client type (http.Client wrapper)
 type ClientOpt func(*Client)
@@ -223,36 +218,25 @@ func (c *Client) GetHeader(ctx context.Context, slot types.Slot, parentHash [32]
 func (c *Client) RegisterValidator(ctx context.Context, svr []*ethpb.SignedValidatorRegistrationV1) error {
 	ctx, span := trace.StartSpan(ctx, "builder.client.RegisterValidator")
 	defer span.End()
+	span.AddAttributes(trace.Int64Attribute("num_reqs", int64(len(svr))))
 
 	if len(svr) == 0 {
 		err := errors.Wrap(errMalformedRequest, "empty validator registration list")
 		tracing.AnnotateError(span, err)
 		return err
 	}
-	eg, ctx := errgroup.WithContext(ctx)
-	for i := 0; i < len(svr); i += registerValidatorBatchLimit {
-		end := int(mathprysm.Min(uint64(len(svr)), uint64(i+registerValidatorBatchLimit))) // lint:ignore uintcast -- Request will never exceed int.
-		vs := make([]*SignedValidatorRegistration, 0, registerValidatorBatchLimit)
-		for j := i; j < end; j++ {
-			vs = append(vs, &SignedValidatorRegistration{SignedValidatorRegistrationV1: svr[j]})
-		}
-		body, err := json.Marshal(vs)
-		if err != nil {
-			err := errors.Wrap(err, "error encoding the SignedValidatorRegistration value body in RegisterValidator")
-			tracing.AnnotateError(span, err)
-		}
-
-		eg.Go(func() error {
-			ctx, span := trace.StartSpan(ctx, "builder.client.RegisterValidator.Go")
-			defer span.End()
-			span.AddAttributes(trace.Int64Attribute("reqs", int64(len(vs))))
-
-			_, err = c.do(ctx, http.MethodPost, postRegisterValidatorPath, bytes.NewBuffer(body))
-			return err
-		})
+	vs := make([]*SignedValidatorRegistration, len(svr))
+	for i := 0; i < len(svr); i++ {
+		vs[i] = &SignedValidatorRegistration{SignedValidatorRegistrationV1: svr[i]}
+	}
+	body, err := json.Marshal(vs)
+	if err != nil {
+		err := errors.Wrap(err, "error encoding the SignedValidatorRegistration value body in RegisterValidator")
+		tracing.AnnotateError(span, err)
 	}
 
-	return eg.Wait()
+	_, err = c.do(ctx, http.MethodPost, postRegisterValidatorPath, bytes.NewBuffer(body))
+	return err
 }
 
 // SubmitBlindedBlock calls the builder API endpoint that binds the validator to the builder and submits the block.

--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -233,6 +233,7 @@ func (c *Client) RegisterValidator(ctx context.Context, svr []*ethpb.SignedValid
 	if err != nil {
 		err := errors.Wrap(err, "error encoding the SignedValidatorRegistration value body in RegisterValidator")
 		tracing.AnnotateError(span, err)
+		return err
 	}
 
 	_, err = c.do(ctx, http.MethodPost, postRegisterValidatorPath, bytes.NewBuffer(body))


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Validator registration batching is generally not needed. 
The original PR, #11002 was a workaround to an inefficient mev boost relay implementation. Said implementation has been improved significantly and therefore these changes are no longer needed.
Additionally, #11002 introduced some new race conditions (in tests) reported in issue #11020.

**Which issues(s) does this PR fix?**

Fixes #11020

**Other notes for review**
