### PR TITLE
Trivial fix to the warning message about fee recipient config

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -953,7 +953,7 @@ func (v *validator) PushProposerSettings(ctx context.Context, km keymanager.IKey
 		} else {
 			log.Warn("In order to receive transaction fees from proposing blocks, " +
 				"you must now specify a configuration known as a fee recipient config. " +
-				"If it not provided, transaction fees will be burnt. Please see our documentation for more information on this requirement (https://docs.prylabs.network/docs/execution-node/fee-recipient).")
+				"If it is not provided, transaction fees will be burnt. Please see our documentation for more information on this requirement (https://docs.prylabs.network/docs/execution-node/fee-recipient).")
 		}
 		return nil
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Trivial grammatical fix to the fee recipient config warning message in the latest release.

> Uncomment one line below and remove others.
>
Other

**What does this PR do? Why is it needed?**
A grammatical fix to the warning message about fee recipient configs. Warning message reads easier.

**Which issues(s) does this PR fix?**
N/A

Fixes #

**Other notes for review**
