### PR TITLE
Fix counters data races in async tests

### DIFF
--- a/async/debounce_test.go
+++ b/async/debounce_test.go
@@ -3,6 +3,7 @@ package async_test
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ func TestDebounce_NoEvents(t *testing.T) {
 	eventsChan := make(chan interface{}, 100)
 	ctx, cancel := context.WithCancel(context.Background())
 	interval := time.Second
-	timesHandled := 0
+	timesHandled := int32(0)
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -26,21 +27,21 @@ func TestDebounce_NoEvents(t *testing.T) {
 	}()
 	go func() {
 		async.Debounce(ctx, interval, eventsChan, func(event interface{}) {
-			timesHandled++
+			atomic.AddInt32(&timesHandled, 1)
 		})
 		wg.Done()
 	}()
 	if util.WaitTimeout(wg, interval*2) {
 		t.Fatalf("Test should have exited by now, timed out")
 	}
-	assert.Equal(t, 0, timesHandled, "Wrong number of handled calls")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&timesHandled), "Wrong number of handled calls")
 }
 
 func TestDebounce_CtxClosing(t *testing.T) {
 	eventsChan := make(chan interface{}, 100)
 	ctx, cancel := context.WithCancel(context.Background())
 	interval := time.Second
-	timesHandled := 0
+	timesHandled := int32(0)
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
@@ -62,23 +63,23 @@ func TestDebounce_CtxClosing(t *testing.T) {
 	}()
 	go func() {
 		async.Debounce(ctx, interval, eventsChan, func(event interface{}) {
-			timesHandled++
+			atomic.AddInt32(&timesHandled, 1)
 		})
 		wg.Done()
 	}()
 	if util.WaitTimeout(wg, interval*2) {
 		t.Fatalf("Test should have exited by now, timed out")
 	}
-	assert.Equal(t, 0, timesHandled, "Wrong number of handled calls")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&timesHandled), "Wrong number of handled calls")
 }
 
 func TestDebounce_SingleHandlerInvocation(t *testing.T) {
 	eventsChan := make(chan interface{}, 100)
 	ctx, cancel := context.WithCancel(context.Background())
 	interval := time.Second
-	timesHandled := 0
+	timesHandled := int32(0)
 	go async.Debounce(ctx, interval, eventsChan, func(event interface{}) {
-		timesHandled++
+		atomic.AddInt32(&timesHandled, 1)
 	})
 	for i := 0; i < 100; i++ {
 		eventsChan <- struct{}{}
@@ -86,7 +87,7 @@ func TestDebounce_SingleHandlerInvocation(t *testing.T) {
 	// We should expect 100 rapid fire changes to only have caused
 	// 1 handler to trigger after the debouncing period.
 	time.Sleep(interval * 2)
-	assert.Equal(t, 1, timesHandled, "Wrong number of handled calls")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&timesHandled), "Wrong number of handled calls")
 	cancel()
 }
 
@@ -94,23 +95,23 @@ func TestDebounce_MultipleHandlerInvocation(t *testing.T) {
 	eventsChan := make(chan interface{}, 100)
 	ctx, cancel := context.WithCancel(context.Background())
 	interval := time.Second
-	timesHandled := 0
+	timesHandled := int32(0)
 	go async.Debounce(ctx, interval, eventsChan, func(event interface{}) {
-		timesHandled++
+		atomic.AddInt32(&timesHandled, 1)
 	})
 	for i := 0; i < 100; i++ {
 		eventsChan <- struct{}{}
 	}
-	require.Equal(t, 0, timesHandled, "Events must prevent from handler execution")
+	require.Equal(t, int32(0), atomic.LoadInt32(&timesHandled), "Events must prevent from handler execution")
 
 	// By this time the first event should be triggered.
 	time.Sleep(2 * time.Second)
-	assert.Equal(t, 1, timesHandled, "Wrong number of handled calls")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&timesHandled), "Wrong number of handled calls")
 
 	// Second event.
 	eventsChan <- struct{}{}
 	time.Sleep(2 * time.Second)
-	assert.Equal(t, 2, timesHandled, "Wrong number of handled calls")
+	assert.Equal(t, int32(2), atomic.LoadInt32(&timesHandled), "Wrong number of handled calls")
 
 	cancel()
 }

--- a/async/every_test.go
+++ b/async/every_test.go
@@ -2,6 +2,7 @@ package async_test
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,15 +12,15 @@ import (
 func TestEveryRuns(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	i := 0
+	i := int32(0)
 	async.RunEvery(ctx, 100*time.Millisecond, func() {
-		i++
+		atomic.AddInt32(&i, 1)
 	})
 
 	// Sleep for a bit and ensure the value has increased.
 	time.Sleep(200 * time.Millisecond)
 
-	if i == 0 {
+	if atomic.LoadInt32(&i) == 0 {
 		t.Error("Counter failed to increment with ticker")
 	}
 
@@ -28,12 +29,12 @@ func TestEveryRuns(t *testing.T) {
 	// Sleep for a bit to let the cancel take place.
 	time.Sleep(100 * time.Millisecond)
 
-	last := i
+	last := atomic.LoadInt32(&i)
 
 	// Sleep for a bit and ensure the value has not increased.
 	time.Sleep(200 * time.Millisecond)
 
-	if i != last {
+	if atomic.LoadInt32(&i) != last {
 		t.Error("Counter incremented after stop")
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR updates the following `async/debounce` and `async/every` tests to prevent concurrent read and writes:
- `TestDebounce_SingleHandlerInvocation`
- `TestDebounce_MultipleHandlerInvocation`
- `TestTestEveryRuns`

It improves the project tests stability.

Atomic counters have also been added to the rest of the debounce tests to prevent potential data races later on.

**Which issues(s) does this PR fix?**

The `timesHandled` counter used in these tests assertions are not protected against concurrent read and writes.
When reading their values for assertion, they can be incremented at the same time in the goroutine right above.

The same goes for the `i` counter in `TestTestEveryRuns`.

When running the tests with race detection (`go test -run TestDebounce_MultipleHandlerInvocation -race -v` for example), the issue is detected.
