### PR TITLE
Full Deprecation of Fee Recipient File Flags

### DIFF
--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -324,19 +324,6 @@ var (
 		Value: false,
 	}
 
-	// FeeRecipientConfigFileFlag defines the path or URL to a file with proposer config.
-	FeeRecipientConfigFileFlag = &cli.StringFlag{
-		Name:  "fee-recipient-config-file",
-		Usage: "DEPRECATED, please use proposer-settings-file",
-		Value: "",
-	}
-	// FeeRecipientConfigURLFlag defines the path or URL to a file with proposer config.
-	FeeRecipientConfigURLFlag = &cli.StringFlag{
-		Name:  "fee-recipient-config-url",
-		Usage: "DEPRECATED, please use proposer-settings-url",
-		Value: "",
-	}
-
 	// ProposerSettingsFlag defines the path or URL to a file with proposer config.
 	ProposerSettingsFlag = &cli.StringFlag{
 		Name:  "proposer-settings-file",

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -75,8 +75,6 @@ var appFlags = []cli.Flag{
 	// Consensys' Web3Signer flags
 	flags.Web3SignerURLFlag,
 	flags.Web3SignerPublicValidatorKeysFlag,
-	flags.FeeRecipientConfigFileFlag,
-	flags.FeeRecipientConfigURLFlag,
 	flags.SuggestedFeeRecipientFlag,
 	flags.ProposerSettingsURLFlag,
 	flags.ProposerSettingsFlag,

--- a/cmd/validator/usage.go
+++ b/cmd/validator/usage.go
@@ -109,8 +109,6 @@ var appHelpFlagGroups = []flagGroup{
 			flags.EnableDutyCountDown,
 			flags.Web3SignerURLFlag,
 			flags.Web3SignerPublicValidatorKeysFlag,
-			flags.FeeRecipientConfigFileFlag,
-			flags.FeeRecipientConfigURLFlag,
 			flags.ProposerSettingsFlag,
 			flags.ProposerSettingsURLFlag,
 			flags.SuggestedFeeRecipientFlag,

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -476,10 +476,6 @@ func web3SignerConfig(cliCtx *cli.Context) (*remoteweb3signer.SetupConfig, error
 
 func proposerSettings(cliCtx *cli.Context) (*validatorServiceConfig.ProposerSettings, error) {
 	var fileConfig *validatorServiceConfig.ProposerSettingsPayload
-	//TODO(10809): remove when fully deprecated
-	if cliCtx.IsSet(flags.FeeRecipientConfigFileFlag.Name) && cliCtx.IsSet(flags.FeeRecipientConfigURLFlag.Name) {
-		return nil, fmt.Errorf("cannot specify both --%s and --%s", flags.FeeRecipientConfigFileFlag.Name, flags.FeeRecipientConfigURLFlag.Name)
-	}
 
 	if cliCtx.IsSet(flags.ProposerSettingsFlag.Name) && cliCtx.IsSet(flags.ProposerSettingsURLFlag.Name) {
 		return nil, errors.New("cannot specify both " + flags.ProposerSettingsFlag.Name + " and " + flags.ProposerSettingsURLFlag.Name)
@@ -504,14 +500,6 @@ func proposerSettings(cliCtx *cli.Context) (*validatorServiceConfig.ProposerSett
 				ValidatorRegistration: vr,
 			},
 		}
-	}
-
-	if cliCtx.IsSet(flags.FeeRecipientConfigFileFlag.Name) {
-		return nil, errors.New(flags.FeeRecipientConfigFileFlag.Usage)
-	}
-
-	if cliCtx.IsSet(flags.FeeRecipientConfigURLFlag.Name) {
-		return nil, errors.New(flags.FeeRecipientConfigURLFlag.Usage)
 	}
 
 	if cliCtx.IsSet(flags.ProposerSettingsFlag.Name) {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

We partially deprecated some fee recipient file flags in the previous release, renaming to proposer settings file and url flags. This PR fully deprecates the unused flags.

**Which issues(s) does this PR fix?**

Fixes #10809
