### PR TITLE
e2e: Split presubmit and postsubmit e2e tests for shorter pull request build times

### DIFF
--- a/testing/endtoend/BUILD.bazel
+++ b/testing/endtoend/BUILD.bazel
@@ -5,6 +5,45 @@ load("@prysm//tools/go:def.bzl", "go_test")
 # gazelle:exclude mainnet_scenario_e2e_test.go
 # gazelle:exclude minimal_scenario_e2e_test.go
 
+# Presubmit tests represent the group of endtoend tests that are run on pull
+# requests and must be passing before a pull request can merge.
+test_suite(
+    name = "presubmit",
+    tags = [
+        "e2e",
+        "manual",
+    ],
+    tests = [
+        ":go_default_test",
+    ],
+)
+
+# Postsubmit tests represent the group of endtoend tests that are run after a
+# pull request has merged.
+test_suite(
+    name = "postsubmit",
+    tags = [
+        "e2e",
+        "manual",
+    ],
+    tests = [
+        ":go_mainnet_test",
+    ],
+)
+
+# Scenario tests are run infrequently in CI to test specific scenarios.
+test_suite(
+    name = "scenario_tests",
+    tags = [
+        "e2e",
+        "manual",
+    ],
+    tests = [
+        ":go_mainnet_scenario_test",
+        ":go_minimal_scenario_test",
+    ],
+)
+
 common_deps = [
     "//api/client/beacon:go_default_library",
     "//beacon-chain/blockchain/testing:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

End to end tests as part of pull requests submission (pre-submit) has been a bit slow at times. The primary goal of e2e in presubmit is a smoke test to ensure the author didn't catastrophically break everything in their changeset. Since nearly any change in the Prysm codebase invalidates e2e caches, pull request submission times can easily exceed 45 minutes. 

This PR aims to split up endtoend tests into the following:

- Presubmit tests that are run on every pull request as a requirement to merge. `//testing/endtoend:presubmit`.
- Postsubmit tests that are run on every merge to develop `//testing/endtoend:postsubmit`. 
- Scenario tests that are run daily with the latest develop commit `//testing/endtoend:scenario`.

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

Changes to buildkite will happen after this PR so that other PRs are not blocked by this one.
