### PR TITLE
Log error string instead of data

### DIFF
--- a/beacon-chain/powchain/engine_client.go
+++ b/beacon-chain/powchain/engine_client.go
@@ -417,7 +417,7 @@ func handleRPCError(err error) error {
 		if !ok {
 			return errors.Wrapf(err, "got an unexpected error in JSON-RPC response")
 		}
-		return errors.Wrapf(ErrServer, "%v", errWithData.ErrorData())
+		return errors.Wrapf(ErrServer, "%v", errWithData.Error())
 	default:
 		return err
 	}


### PR DESCRIPTION
I'm not sure why we want to log the error data instead of the error string itself. The error data will probably be nil and it's not entirely useful. This PR changes it to logging error string instead of data.

```
time="2022-07-12 12:48:00" level=error msg="Could not check configuration values between execution and consensus client" error="<nil>: client error while processing request" prefix=powchain
```