### PR TITLE
Remove builder status check for block proposal

### DIFF
--- a/beacon-chain/builder/service.go
+++ b/beacon-chain/builder/service.go
@@ -2,6 +2,7 @@ package builder
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -21,7 +22,6 @@ import (
 type BlockBuilder interface {
 	SubmitBlindedBlock(ctx context.Context, block *ethpb.SignedBlindedBeaconBlockBellatrix) (*v1.ExecutionPayload, error)
 	GetHeader(ctx context.Context, slot types.Slot, parentHash [32]byte, pubKey [48]byte) (*ethpb.SignedBuilderBid, error)
-	Status() error
 	RegisterValidator(ctx context.Context, reg []*ethpb.SignedValidatorRegistrationV1) error
 	Configured() bool
 }
@@ -60,6 +60,12 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 			return nil, err
 		}
 		s.c = c
+
+		// Is the builder up?
+		if err := s.c.Status(ctx); err != nil {
+			return nil, fmt.Errorf("could not connect to builder: %v", err)
+		}
+
 		log.WithField("endpoint", c.NodeURL()).Info("Builder has been configured")
 	}
 	return s, nil

--- a/beacon-chain/builder/testing/mock.go
+++ b/beacon-chain/builder/testing/mock.go
@@ -15,7 +15,6 @@ type MockBuilderService struct {
 	ErrSubmitBlindedBlock error
 	Bid                   *ethpb.SignedBuilderBid
 	ErrGetHeader          error
-	ErrStatus             error
 	ErrRegisterValidator  error
 }
 
@@ -32,11 +31,6 @@ func (s *MockBuilderService) SubmitBlindedBlock(context.Context, *ethpb.SignedBl
 // GetHeader for mocking.
 func (s *MockBuilderService) GetHeader(context.Context, types.Slot, [32]byte, [48]byte) (*ethpb.SignedBuilderBid, error) {
 	return s.Bid, s.ErrGetHeader
-}
-
-// Status for mocking.
-func (s *MockBuilderService) Status() error {
-	return s.ErrStatus
 }
 
 // RegisterValidator for mocking.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -89,9 +89,6 @@ func (vs *Server) getBellatrixBeaconBlock(ctx context.Context, req *ethpb.BlockR
 // This function retrieves the payload header given the slot number and the validator index.
 // It's a no-op if the latest head block is not versioned bellatrix.
 func (vs *Server) getPayloadHeader(ctx context.Context, slot types.Slot, idx types.ValidatorIndex) (*enginev1.ExecutionPayloadHeader, error) {
-	if err := vs.BlockBuilder.Status(); err != nil {
-		return nil, err
-	}
 	b, err := vs.HeadFetcher.HeadBlock(ctx)
 	if err != nil {
 		return nil, err
@@ -171,9 +168,7 @@ func (vs *Server) unblindBuilderBlock(ctx context.Context, b interfaces.SignedBe
 	if !vs.BlockBuilder.Configured() {
 		return b, nil
 	}
-	if err := vs.BlockBuilder.Status(); err != nil {
-		return nil, err
-	}
+
 	agg, err := b.Block().Body().SyncAggregate()
 	if err != nil {
 		return nil, err

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -99,13 +99,6 @@ func TestServer_getPayloadHeader(t *testing.T) {
 		returnedHeader *v1.ExecutionPayloadHeader
 	}{
 		{
-			name: "builder is not ready",
-			mock: &builderTest.MockBuilderService{
-				ErrStatus: errors.New("builder is not ready"),
-			},
-			err: "builder is not ready",
-		},
-		{
 			name: "head is not bellatrix ready",
 			mock: &builderTest.MockBuilderService{},
 			fetcher: &blockchainTest.ChainService{
@@ -208,19 +201,6 @@ func TestServer_getBuilderBlock(t *testing.T) {
 				require.NoError(t, err)
 				return wb
 			}(),
-		},
-		{
-			name: "builder is not ready",
-			blk: func() interfaces.SignedBeaconBlock {
-				wb, err := wrapper.WrappedSignedBeaconBlock(util.NewBlindedBeaconBlockBellatrix())
-				require.NoError(t, err)
-				return wb
-			}(),
-			mock: &builderTest.MockBuilderService{
-				HasConfigured: true,
-				ErrStatus:     errors.New("builder is not ready"),
-			},
-			err: "builder is not ready",
 		},
 		{
 			name: "submit blind block error",


### PR DESCRIPTION
We were not using builder status correctly. We were using it before getting header and payload requests and that significantly eat up the block proposal time. Builder status was meant to call during start-up to validate that relay and builder are reachable. There's not much value calling it frequently besides slowing down block proposal 