### PR TITLE
Web3signer: Support json content type with optional metadata

### DIFF
--- a/validator/keymanager/remote-web3signer/internal/client.go
+++ b/validator/keymanager/remote-web3signer/internal/client.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -74,14 +75,13 @@ func (client *ApiClient) Sign(ctx context.Context, pubKey string, request SignRe
 		return nil, fmt.Errorf("signing operation failed due to slashing protection rules,  Signing Request URL: %v, Status: %v", client.BaseURL.String()+requestPath, resp.StatusCode)
 	}
 	contentType := resp.Header.Get("Content-Type")
-	switch contentType {
-	case "application/json":
+	if strings.HasPrefix(contentType, "application/json") {
 		var sigResp SignatureResponse
 		if err := unmarshalResponse(resp.Body, &sigResp); err != nil {
 			return nil, err
 		}
 		return bls.SignatureFromBytes(sigResp.Signature)
-	default:
+	} else {
 		return unmarshalSignatureResponse(resp.Body)
 	}
 }

--- a/validator/keymanager/remote-web3signer/internal/client_test.go
+++ b/validator/keymanager/remote-web3signer/internal/client_test.go
@@ -59,6 +59,7 @@ func TestClient_Sign_HappyPath_Jsontype(t *testing.T) {
 	}
 	jsonBytes, err := json.Marshal(sigResp)
 	require.NoError(t, err)
+	require.NoError(t, err)
 	// create a new reader with that JSON
 	header := http.Header{}
 	header.Set("Content-Type", "application/json;  charset=UTF-8")

--- a/validator/keymanager/remote-web3signer/internal/client_test.go
+++ b/validator/keymanager/remote-web3signer/internal/client_test.go
@@ -60,9 +60,8 @@ func TestClient_Sign_HappyPath_Jsontype(t *testing.T) {
 	jsonBytes, err := json.Marshal(sigResp)
 	require.NoError(t, err)
 	// create a new reader with that JSON
-	header := http.Header{
-		"Content-Type": []string{"application/json"},
-	}
+	header := http.Header{}
+	header.Set("Content-Type", "application/json;  charset=UTF-8")
 	r := io.NopCloser(bytes.NewReader(jsonBytes))
 	mock := &mockTransport{mockResponse: &http.Response{
 		StatusCode: 200,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

PR fixes the case application/json parsing case when meta data is added.
example handling `Content-Type: application/json;  charset=UTF-8`

related to #11055 

