### PR TITLE
Fix optimistic sync status during init sync

### DIFF
--- a/beacon-chain/rpc/eth/helpers/sync.go
+++ b/beacon-chain/rpc/eth/helpers/sync.go
@@ -28,13 +28,7 @@ func ValidateSync(
 		return nil
 	}
 	headSlot := headFetcher.HeadSlot()
-	isOptimistic := false
-
-	headState, err := headFetcher.HeadState(ctx)
-	if err != nil {
-		return status.Errorf(codes.Internal, "Could not get head state: %v", err)
-	}
-	isOptimistic, err = IsOptimistic(ctx, headState, optimisticModeFetcher)
+	isOptimistic, err := optimisticModeFetcher.IsOptimistic(ctx)
 	if err != nil {
 		return status.Errorf(codes.Internal, "Could not check optimistic status: %v", err)
 	}

--- a/beacon-chain/rpc/eth/node/node.go
+++ b/beacon-chain/rpc/eth/node/node.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/peers"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/peers/peerdata"
-	rpchelpers "github.com/prysmaticlabs/prysm/beacon-chain/rpc/eth/helpers"
 	ethpb "github.com/prysmaticlabs/prysm/proto/eth/v1"
 	"github.com/prysmaticlabs/prysm/proto/migration"
 	eth "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
@@ -268,12 +267,7 @@ func (ns *Server) GetSyncStatus(ctx context.Context, _ *emptypb.Empty) (*ethpb.S
 
 	headSlot := ns.HeadFetcher.HeadSlot()
 
-	headState, err := ns.HeadFetcher.HeadState(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
-	}
-
-	isOptimistic, err := rpchelpers.IsOptimistic(ctx, headState, ns.OptimisticModeFetcher)
+	isOptimistic, err := ns.OptimisticModeFetcher.IsOptimistic(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not check optimistic status: %v", err)
 	}


### PR DESCRIPTION
fixes #11044

There is no need to get the full state to verify if we are optimistic, a block root suffices, the head root is always available in forkchoice. 