### PR TITLE
WIP: External DB tool support

### DIFF
--- a/beacon-chain/db/canonical.go
+++ b/beacon-chain/db/canonical.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"context"
+	types "github.com/prysmaticlabs/prysm/consensus-types/primitives"
+	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/time/slots"
+)
+
+type CanonicalChecker interface {
+	IsCanonical(ctx context.Context, blockRoot [32]byte) (bool, error)
+}
+
+type FinalizedChecker interface {
+	IsFinalizedBlock(ctx context.Context, blockRoot [32]byte) bool
+}
+
+type canonicalChecker struct {
+	fc FinalizedChecker
+}
+
+func (cc *canonicalChecker) IsCanonical(ctx context.Context, root [32]byte) (bool, error) {
+	return cc.fc.IsFinalizedBlock(ctx, root), nil
+}
+
+func NewCanonicalChecker(fc FinalizedChecker) CanonicalChecker {
+	return &canonicalChecker{fc: fc}
+}
+
+type CurrentSlotter interface {
+	CurrentSlot() types.Slot
+}
+
+type FinalizedCheckpointer interface {
+	FinalizedCheckpoint(ctx context.Context) (*ethpb.Checkpoint, error)
+}
+
+type finalizedCurrentSlotter struct {
+	fc FinalizedCheckpointer
+	ctx context.Context
+}
+
+func (fc *finalizedCurrentSlotter) CurrentSlot() types.Slot {
+	cp, err := fc.fc.FinalizedCheckpoint(fc.ctx)
+	if err != nil {
+		return 0
+	}
+	s, err := slots.EpochStart(cp.Epoch)
+	if err != nil {
+		return 0
+	}
+	return s
+}
+
+func FinalizedCurrentSlotter(fc FinalizedCheckpointer, ctx context.Context) CurrentSlotter {
+	return &finalizedCurrentSlotter{fc: fc, ctx: ctx}
+}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Allow code outside the db package to open the bolt database and hold a copy of the `*bolt.DB` handle. This enables code outside the `kv` package to have access to the underlying bolt db while also using `kv.Store` methods.

Supports building an IsCanonical value directly from the db using the finalized index instead of the forkchoice store. This is helpful to enable a program to utilize `stategen.Replayer` without running the full beacon node.

**Other notes for review**

I have a messy R&D branch for database optimization work which uses these changes. I am trying to split them out into a separate PR as a way of keeping a small delta with develop as I refactor and cherry pick useful changes from that branch.