### PR TITLE
Do not print stacktrace on invalid payload

### DIFF
--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -11,7 +11,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
@@ -191,9 +190,10 @@ func (s *Service) subscribeWithBase(topic string, validator wrappedVal, handle s
 
 		if err := handle(ctx, msg.ValidatorData.(proto.Message)); err != nil {
 			tracing.AnnotateError(span, err)
-			if errors.Is(err, blockchain.ErrInvalidPayload) {
+			switch err {
+			case blockchain.ErrInvalidPayload:
 				log.Warning(err)
-			} else {
+			default:
 				log.WithError(err).Error("Could not handle p2p pubsub")
 			}
 			messageFailedProcessingCounter.WithLabelValues(topic).Inc()

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -11,6 +11,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/peers"
@@ -189,7 +191,11 @@ func (s *Service) subscribeWithBase(topic string, validator wrappedVal, handle s
 
 		if err := handle(ctx, msg.ValidatorData.(proto.Message)); err != nil {
 			tracing.AnnotateError(span, err)
-			log.WithError(err).Error("Could not handle p2p pubsub")
+			if errors.Is(err, blockchain.ErrInvalidPayload) {
+				log.Warning(err)
+			} else {
+				log.WithError(err).Error("Could not handle p2p pubsub")
+			}
 			messageFailedProcessingCounter.WithLabelValues(topic).Inc()
 			return
 		}

--- a/beacon-chain/sync/subscriber.go
+++ b/beacon-chain/sync/subscriber.go
@@ -11,6 +11,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p"
@@ -190,10 +191,9 @@ func (s *Service) subscribeWithBase(topic string, validator wrappedVal, handle s
 
 		if err := handle(ctx, msg.ValidatorData.(proto.Message)); err != nil {
 			tracing.AnnotateError(span, err)
-			switch err {
-			case blockchain.ErrInvalidPayload:
+			if errors.Is(err, blockchain.ErrInvalidPayload) {
 				log.Warning(err)
-			default:
+			} else {
 				log.WithError(err).Error("Could not handle p2p pubsub")
 			}
 			messageFailedProcessingCounter.WithLabelValues(topic).Inc()


### PR DESCRIPTION
When receiving an INVALID payload, the error surfaces in the sync package that eventually prints the stacktrace. This PR logs the error as a Warning without printing the stacktrace and leaving the current behavior unchanged. 

1) This requires adding a blockchain dependency to the sync package to use the exported error, this may not be desired. 
2) An option would be to not print the stack ever. 