### PR TITLE
Penalize Bad Payloads Properly

### DIFF
--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -189,7 +189,7 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 				return
 			}
 			if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
-				log.WithField("topic", topic).Debugf("Could not decode stream message: %v", err)
+				log.WithError(err).WithField("topic", topic).Debug("Could not decode stream message")
 				tracing.AnnotateError(span, err)
 				s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 				return
@@ -209,7 +209,7 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 				return
 			}
 			if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
-				log.WithField("topic", topic).Debugf("Could not decode stream message: %v", err)
+				log.WithError(err).WithField("topic", topic).Debug("Could not decode stream message")
 				tracing.AnnotateError(span, err)
 				s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 				return

--- a/beacon-chain/sync/rpc.go
+++ b/beacon-chain/sync/rpc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"reflect"
 	"runtime/debug"
-	"strings"
 
 	libp2pcore "github.com/libp2p/go-libp2p-core"
 	"github.com/libp2p/go-libp2p-core/network"
@@ -190,14 +189,9 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 				return
 			}
 			if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
-				// Debug logs for goodbye/status errors
-				if strings.Contains(topic, p2p.RPCGoodByeTopicV1) || strings.Contains(topic, p2p.RPCStatusTopicV1) {
-					log.WithError(err).Debug("Could not decode goodbye stream message")
-					tracing.AnnotateError(span, err)
-					return
-				}
-				log.WithError(err).Debug("Could not decode stream message")
+				log.WithField("topic", topic).Debugf("Could not decode stream message: %v", err)
 				tracing.AnnotateError(span, err)
+				s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 				return
 			}
 			if err := handle(ctx, msg, stream); err != nil {
@@ -215,8 +209,9 @@ func (s *Service) registerRPC(baseTopic string, handle rpcHandler) {
 				return
 			}
 			if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
-				log.WithError(err).Debug("Could not decode stream message")
+				log.WithField("topic", topic).Debugf("Could not decode stream message: %v", err)
 				tracing.AnnotateError(span, err)
+				s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 				return
 			}
 			if err := handle(ctx, nTyp.Elem().Interface(), stream); err != nil {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -57,6 +57,7 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 	}
 
 	if uint64(len(blockRoots)) > params.BeaconNetworkConfig().MaxRequestBlocks {
+		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, "requested more than the max block limit", stream)
 		return errors.New("requested more than the max block limit")
 	}

--- a/beacon-chain/sync/rpc_metadata.go
+++ b/beacon-chain/sync/rpc_metadata.go
@@ -100,6 +100,7 @@ func (s *Service) sendMetaDataRequest(ctx context.Context, id peer.ID) (metadata
 	defer closeStream(stream, log)
 	code, errMsg, err := ReadStatusCode(stream, s.cfg.p2p.Encoding())
 	if err != nil {
+		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 		return nil, err
 	}
 	if code != 0 {
@@ -127,6 +128,7 @@ func (s *Service) sendMetaDataRequest(ctx context.Context, id peer.ID) (metadata
 		return nil, err
 	}
 	if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
+		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 		return nil, err
 	}
 	return msg, nil

--- a/beacon-chain/sync/rpc_status.go
+++ b/beacon-chain/sync/rpc_status.go
@@ -152,6 +152,7 @@ func (s *Service) sendRPCStatusRequest(ctx context.Context, id peer.ID) error {
 
 	code, errMsg, err := ReadStatusCode(stream, s.cfg.p2p.Encoding())
 	if err != nil {
+		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 		return err
 	}
 
@@ -161,6 +162,7 @@ func (s *Service) sendRPCStatusRequest(ctx context.Context, id peer.ID) error {
 	}
 	msg := &pb.Status{}
 	if err := s.cfg.p2p.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
+		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 		return err
 	}
 

--- a/beacon-chain/sync/rpc_test.go
+++ b/beacon-chain/sync/rpc_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"bytes"
 	"context"
 	"sync"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	libp2pcore "github.com/libp2p/go-libp2p-core"
 	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/prysmaticlabs/prysm/beacon-chain/core/transition"
 	prysmP2P "github.com/prysmaticlabs/prysm/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/beacon-chain/p2p/encoder"
@@ -79,4 +81,47 @@ func TestRegisterRPC_ReceivesValidMessage(t *testing.T) {
 	if util.WaitTimeout(&wg, time.Second) {
 		t.Fatal("Did not receive RPC in 1 second")
 	}
+}
+
+func TestRPC_ReceivesInvalidMessage(t *testing.T) {
+	p2p := p2ptest.NewTestP2P(t)
+	remotePeer := p2ptest.NewTestP2P(t)
+	remotePeer.Connect(p2p)
+
+	r := &Service{
+		ctx:         context.Background(),
+		cfg:         &config{p2p: p2p},
+		rateLimiter: newRateLimiter(p2p),
+	}
+
+	topic := "/testing/foobar/1"
+	handler := func(ctx context.Context, msg interface{}, stream libp2pcore.Stream) error {
+		m, ok := msg.(*ethpb.Fork)
+		if !ok {
+			t.Error("Object is not of type *pb.Fork")
+		}
+		if !bytes.Equal(m.CurrentVersion, []byte("fooo")) {
+			t.Errorf("Unexpected incoming message: %+v", m)
+		}
+		return nil
+	}
+	prysmP2P.RPCTopicMappings[topic] = new(ethpb.Fork)
+	// Cleanup Topic mappings
+	defer func() {
+		delete(prysmP2P.RPCTopicMappings, topic)
+	}()
+	r.registerRPC(topic, handler)
+
+	stream, err := remotePeer.Host().NewStream(context.Background(), p2p.BHost.ID(), protocol.ID(topic+p2p.Encoding().ProtocolSuffix()))
+	require.NoError(t, err)
+	// Write invalid SSZ object to peer.
+	_, err = stream.Write([]byte("JUNK MESSAGE"))
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+	faultCount, err := p2p.Peers().Scorers().BadResponsesScorer().Count(remotePeer.BHost.ID())
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, faultCount, "peer was not penalised for sending bad message")
+
 }


### PR DESCRIPTION
**What type of PR is this?**

Networking Improvement

**What does this PR do? Why is it needed?**

This resurrects #7926 , in this PR we directly penalize bad ssz payloads received via RPC and 
also incomplete rpc requests by other peers. With the peer scorer being the default this
makes prysm stricter with regards to bad behaviour by other peers. 

**Which issues(s) does this PR fix?**

N.A , Part of #10322 

**Other notes for review**
