### PR TITLE
Fix a typo in validator flags help message.

### DIFF
--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -339,7 +339,7 @@ var (
 	// SuggestedFeeRecipientFlag defines the address of the fee recipient.
 	SuggestedFeeRecipientFlag = &cli.StringFlag{
 		Name: "suggested-fee-recipient",
-		Usage: "Sets ALL validators' mapping to a suggested an eth address to receive gas fees when proposing a block." +
+		Usage: "Sets ALL validators' mapping to a suggested eth address to receive gas fees when proposing a block." +
 			" note that this is only a suggestion when integrating with a Builder API, which may choose to specify a different fee recipient as payment for the blocks it builds." +
 			" For additional setting overrides use the --" + ProposerSettingsFlag.Name + " or --" + ProposerSettingsURLFlag.Name + " Flags. ",
 		Value: params.BeaconConfig().EthBurnAddressHex,


### PR DESCRIPTION
My first PR for prysm to get myself familiar with prysm build/test/PR process, this is a non-functional one, just a typo fix.  Thanks.