### PR TITLE
Can recover from missing state summary in DB

### DIFF
--- a/beacon-chain/db/kv/checkpoint.go
+++ b/beacon-chain/db/kv/checkpoint.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/config/params"
@@ -63,7 +64,10 @@ func (s *Store) SaveJustifiedCheckpoint(ctx context.Context, checkpoint *ethpb.C
 		hasStateSummary := s.hasStateSummaryBytes(tx, bytesutil.ToBytes32(checkpoint.Root))
 		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil
 		if !(hasStateInDB || hasStateSummary) {
-			return errors.Wrapf(errMissingStateForCheckpoint, "could not save justified checkpoint, justified root: %#x", bytesutil.Trunc(checkpoint.Root))
+			log.Warnf("Recovering state summary for justified root: %#x", bytesutil.Trunc(checkpoint.Root))
+			if err := recoverStateSummary(ctx, tx, checkpoint.Root); err != nil {
+				return errors.Wrapf(errMissingStateForCheckpoint, "could not save justified checkpoint, finalized root: %#x", bytesutil.Trunc(checkpoint.Root))
+			}
 		}
 		return bucket.Put(justifiedCheckpointKey, enc)
 	})
@@ -83,7 +87,10 @@ func (s *Store) SaveFinalizedCheckpoint(ctx context.Context, checkpoint *ethpb.C
 		hasStateSummary := s.hasStateSummaryBytes(tx, bytesutil.ToBytes32(checkpoint.Root))
 		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil
 		if !(hasStateInDB || hasStateSummary) {
-			return errors.Wrapf(errMissingStateForCheckpoint, "could not save Finalized checkpoint, finalized root: %#x", bytesutil.Trunc(checkpoint.Root))
+			log.Warnf("Recovering state summary for finalized root: %#x", bytesutil.Trunc(checkpoint.Root))
+			if err := recoverStateSummary(ctx, tx, checkpoint.Root); err != nil {
+				return errors.Wrapf(errMissingStateForCheckpoint, "could not save finalized checkpoint, finalized root: %#x", bytesutil.Trunc(checkpoint.Root))
+			}
 		}
 		if err := bucket.Put(finalizedCheckpointKey, enc); err != nil {
 			return err
@@ -91,4 +98,23 @@ func (s *Store) SaveFinalizedCheckpoint(ctx context.Context, checkpoint *ethpb.C
 
 		return s.updateFinalizedBlockRoots(ctx, tx, checkpoint)
 	})
+}
+
+// Recovers and saves state summary for a given root if the root has a block in the DB.
+func recoverStateSummary(ctx context.Context, tx *bolt.Tx, root []byte) error {
+	blkBucket := tx.Bucket(blocksBucket)
+	blkEnc := blkBucket.Get(root)
+	if blkEnc == nil {
+		return fmt.Errorf("nil block, root: %#x", bytesutil.Trunc(root))
+	}
+	blk, err := unmarshalBlock(ctx, blkEnc)
+	if err != nil {
+		return errors.Wrapf(err, "Could not unmarshal block: %#x", bytesutil.Trunc(root))
+	}
+	summaryEnc, err := encode(ctx, &ethpb.StateSummary{
+		Slot: blk.Block().Slot(),
+		Root: root,
+	})
+	summaryBucket := tx.Bucket(stateBucket)
+	return summaryBucket.Put(root, summaryEnc)
 }

--- a/beacon-chain/db/kv/checkpoint.go
+++ b/beacon-chain/db/kv/checkpoint.go
@@ -115,6 +115,9 @@ func recoverStateSummary(ctx context.Context, tx *bolt.Tx, root []byte) error {
 		Slot: blk.Block().Slot(),
 		Root: root,
 	})
+	if err != nil {
+		return err
+	}
 	summaryBucket := tx.Bucket(stateBucket)
 	return summaryBucket.Put(root, summaryEnc)
 }

--- a/beacon-chain/db/kv/checkpoint_test.go
+++ b/beacon-chain/db/kv/checkpoint_test.go
@@ -44,6 +44,7 @@ func TestStore_JustifiedCheckpoint_Recover(t *testing.T) {
 		Root:  r[:],
 	}
 	wb, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
 	require.NoError(t, db.SaveBlock(ctx, wb))
 	require.NoError(t, db.SaveJustifiedCheckpoint(ctx, cp))
 	retrieved, err := db.JustifiedCheckpoint(ctx)
@@ -98,6 +99,7 @@ func TestStore_FinalizedCheckpoint_Recover(t *testing.T) {
 		Root:  r[:],
 	}
 	wb, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
 	require.NoError(t, db.SaveGenesisBlockRoot(ctx, r))
 	require.NoError(t, db.SaveBlock(ctx, wb))
 	require.NoError(t, db.SaveFinalizedCheckpoint(ctx, cp))

--- a/beacon-chain/db/kv/checkpoint_test.go
+++ b/beacon-chain/db/kv/checkpoint_test.go
@@ -33,6 +33,24 @@ func TestStore_JustifiedCheckpoint_CanSaveRetrieve(t *testing.T) {
 	assert.Equal(t, true, proto.Equal(cp, retrieved), "Wanted %v, received %v", cp, retrieved)
 }
 
+func TestStore_JustifiedCheckpoint_Recover(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+	blk := util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{})
+	r, err := blk.Block.HashTreeRoot()
+	require.NoError(t, err)
+	cp := &ethpb.Checkpoint{
+		Epoch: 2,
+		Root:  r[:],
+	}
+	wb, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, db.SaveBlock(ctx, wb))
+	require.NoError(t, db.SaveJustifiedCheckpoint(ctx, cp))
+	retrieved, err := db.JustifiedCheckpoint(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, true, proto.Equal(cp, retrieved), "Wanted %v, received %v", cp, retrieved)
+}
+
 func TestStore_FinalizedCheckpoint_CanSaveRetrieve(t *testing.T) {
 	db := setupDB(t)
 	ctx := context.Background()
@@ -64,6 +82,25 @@ func TestStore_FinalizedCheckpoint_CanSaveRetrieve(t *testing.T) {
 
 	require.NoError(t, db.SaveFinalizedCheckpoint(ctx, cp))
 
+	retrieved, err := db.FinalizedCheckpoint(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, true, proto.Equal(cp, retrieved), "Wanted %v, received %v", cp, retrieved)
+}
+
+func TestStore_FinalizedCheckpoint_Recover(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+	blk := util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{})
+	r, err := blk.Block.HashTreeRoot()
+	require.NoError(t, err)
+	cp := &ethpb.Checkpoint{
+		Epoch: 2,
+		Root:  r[:],
+	}
+	wb, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, db.SaveGenesisBlockRoot(ctx, r))
+	require.NoError(t, db.SaveBlock(ctx, wb))
+	require.NoError(t, db.SaveFinalizedCheckpoint(ctx, cp))
 	retrieved, err := db.FinalizedCheckpoint(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, true, proto.Equal(cp, retrieved), "Wanted %v, received %v", cp, retrieved)

--- a/beacon-chain/db/kv/validated_checkpoint_test.go
+++ b/beacon-chain/db/kv/validated_checkpoint_test.go
@@ -43,6 +43,7 @@ func TestStore_LastValidatedCheckpoint_Recover(t *testing.T) {
 		Root:  r[:],
 	}
 	wb, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
 	require.NoError(t, db.SaveBlock(ctx, wb))
 	require.NoError(t, db.SaveLastValidatedCheckpoint(ctx, cp))
 	retrieved, err := db.LastValidatedCheckpoint(ctx)

--- a/beacon-chain/db/kv/validated_checkpoint_test.go
+++ b/beacon-chain/db/kv/validated_checkpoint_test.go
@@ -32,6 +32,24 @@ func TestStore_LastValidatedCheckpoint_CanSaveRetrieve(t *testing.T) {
 	assert.Equal(t, true, proto.Equal(cp, retrieved), "Wanted %v, received %v", cp, retrieved)
 }
 
+func TestStore_LastValidatedCheckpoint_Recover(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+	blk := util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{})
+	r, err := blk.Block.HashTreeRoot()
+	require.NoError(t, err)
+	cp := &ethpb.Checkpoint{
+		Epoch: 2,
+		Root:  r[:],
+	}
+	wb, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, db.SaveBlock(ctx, wb))
+	require.NoError(t, db.SaveLastValidatedCheckpoint(ctx, cp))
+	retrieved, err := db.LastValidatedCheckpoint(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, true, proto.Equal(cp, retrieved), "Wanted %v, received %v", cp, retrieved)
+}
+
 func TestStore_LastValidatedCheckpoint_DefaultIsFinalized(t *testing.T) {
 	db := setupDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
In the event, that a state summary is missing in the DB, a block may exist. We can try to recover to reconstruct then save the state summary in DB