### PR TITLE
Bring Back Mplex

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -78,6 +78,7 @@ go_library(
         "@com_github_kr_pretty//:go_default_library",
         "@com_github_libp2p_go_libp2p//:go_default_library",
         "@com_github_libp2p_go_libp2p//config:go_default_library",
+        "@com_github_libp2p_go_libp2p//p2p/muxer/mplex:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/protocol/identify:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/security/noise:go_default_library",
         "@com_github_libp2p_go_libp2p//p2p/transport/tcp:go_default_library",

--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p/p2p/muxer/mplex"
 	noise "github.com/libp2p/go-libp2p/p2p/security/noise"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	ma "github.com/multiformats/go-multiaddr"
@@ -47,6 +48,8 @@ func (s *Service) buildOptions(ip net.IP, priKey *ecdsa.PrivateKey) []libp2p.Opt
 		libp2p.UserAgent(version.BuildData()),
 		libp2p.ConnectionGater(s),
 		libp2p.Transport(tcp.NewTCPTransport),
+		libp2p.Muxer("/mplex/6.7.0", mplex.DefaultTransport),
+		libp2p.DefaultMuxers,
 	}
 
 	options = append(options, libp2p.Security(noise.ID, noise.New))

--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -10,7 +10,9 @@ import (
 	gethCrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/crypto"
+	mock "github.com/prysmaticlabs/prysm/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/config/params"
 	ecdsaprysm "github.com/prysmaticlabs/prysm/crypto/ecdsa"
 	"github.com/prysmaticlabs/prysm/testing/assert"
@@ -73,4 +75,26 @@ func TestIPV6Support(t *testing.T) {
 	if !ipv6Exists {
 		t.Error("Multiaddress did not have ipv6 protocol")
 	}
+}
+
+func TestDefaultMultiplexers(t *testing.T) {
+	var cfg libp2p.Config
+	_ = cfg
+	p2pCfg := &Config{
+		TCPPort:       2000,
+		UDPPort:       2000,
+		StateNotifier: &mock.MockStateNotifier{},
+	}
+	svc := &Service{cfg: p2pCfg}
+	var err error
+	svc.privKey, err = privKey(svc.cfg)
+	assert.NoError(t, err)
+	ipAddr := ipAddr()
+	opts := svc.buildOptions(ipAddr, svc.privKey)
+	err = cfg.Apply(append(opts, libp2p.FallbackDefaults)...)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "/mplex/6.7.0", cfg.Muxers[0].ID)
+	assert.Equal(t, "/yamux/1.0.0", cfg.Muxers[1].ID)
+
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In our latest libp2p update, mplex was removed as a default stream multiplexer and this led to connection failures with Teku on prater. This PR adds it back along with a regression test.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

cc @ajsutton