### PR TITLE
Validator Client: auth-token path log

### DIFF
--- a/validator/rpc/auth_token.go
+++ b/validator/rpc/auth_token.go
@@ -58,7 +58,7 @@ func CreateAuthToken(walletDirPath, validatorWebAddr string) error {
 	if err := saveAuthToken(walletDirPath, jwtKey, token); err != nil {
 		return err
 	}
-	logValidatorWebAuth(validatorWebAddr, token)
+	logValidatorWebAuth(validatorWebAddr, token, authTokenPath)
 	return nil
 }
 
@@ -128,7 +128,7 @@ func (s *Server) refreshAuthTokenFromFileChanges(ctx context.Context, authTokenP
 				continue
 			}
 			validatorWebAddr := fmt.Sprintf("%s:%d", s.validatorGatewayHost, s.validatorGatewayPort)
-			logValidatorWebAuth(validatorWebAddr, token)
+			logValidatorWebAuth(validatorWebAddr, token, authTokenPath)
 		case err := <-watcher.Errors:
 			log.WithError(err).Errorf("Could not watch for file changes for: %s", authTokenPath)
 		case <-ctx.Done():
@@ -137,7 +137,7 @@ func (s *Server) refreshAuthTokenFromFileChanges(ctx context.Context, authTokenP
 	}
 }
 
-func logValidatorWebAuth(validatorWebAddr, token string) {
+func logValidatorWebAuth(validatorWebAddr, token string, tokenPath string) {
 	webAuthURLTemplate := "http://%s/initialize?token=%s"
 	webAuthURL := fmt.Sprintf(
 		webAuthURLTemplate,
@@ -149,6 +149,7 @@ func logValidatorWebAuth(validatorWebAddr, token string) {
 			"the Prysm web interface",
 	)
 	log.Info(webAuthURL)
+	log.Infof("Validator CLient JWT for RPC and REST authentication set at:%s", tokenPath)
 }
 
 func saveAuthToken(walletDirPath string, jwtKey []byte, token string) error {

--- a/validator/rpc/server.go
+++ b/validator/rpc/server.go
@@ -194,8 +194,8 @@ func (s *Server) Start() {
 			return
 		}
 		validatorWebAddr := fmt.Sprintf("%s:%d", s.validatorGatewayHost, s.validatorGatewayPort)
-		logValidatorWebAuth(validatorWebAddr, token)
 		authTokenPath := filepath.Join(s.walletDir, authTokenFileName)
+		logValidatorWebAuth(validatorWebAddr, token, authTokenPath)
 		go s.refreshAuthTokenFromFileChanges(s.ctx, authTokenPath)
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

UX

**What does this PR do? Why is it needed?**

The validator client uses a JWT token when enabling the web feature which is used for all RPC/REST API authentications.
The JWT is stored in a file `auth-token` within the wallet directory of the local computer where the validator client is running. This location is not always clear and this improved log can help debugging ` auth token needs to be used in the defined prysm wallet directory`
