### PR TITLE
Improve `terminal difficulty has not been reached yet logging`

### DIFF
--- a/beacon-chain/execution/check_transition_config.go
+++ b/beacon-chain/execution/check_transition_config.go
@@ -144,7 +144,7 @@ func (s *Service) logTtdStatus(ctx context.Context, ttd *uint256.Int) (bool, err
 		"latestDifficulty":   latestTtd.String(),
 		"terminalDifficulty": ttd.ToBig().String(),
 		"network":            params.BeaconConfig().ConfigName,
-	}).Info("Ready for merge")
+	}).Info("Ready for The Merge")
 
 	totalTerminalDifficulty.Set(float64(latestTtd.Uint64()))
 	return false, nil

--- a/beacon-chain/execution/check_transition_config.go
+++ b/beacon-chain/execution/check_transition_config.go
@@ -143,7 +143,8 @@ func (s *Service) logTtdStatus(ctx context.Context, ttd *uint256.Int) (bool, err
 	log.WithFields(logrus.Fields{
 		"latestDifficulty":   latestTtd.String(),
 		"terminalDifficulty": ttd.ToBig().String(),
-	}).Info("terminal difficulty has not been reached yet")
+		"network":            params.BeaconConfig().ConfigName,
+	}).Info("Ready for merge")
 
 	totalTerminalDifficulty.Set(float64(latestTtd.Uint64()))
 	return false, nil


### PR DESCRIPTION
I made some improvements to `terminal difficulty has not been reached yet` log and added network field 

```
[2022-08-04 08:58:32]  INFO powchain: terminal difficulty has not been reached yet latestDifficulty=10721970 terminalDifficulty=10790000
```
👇🏼 
```
[2022-08-04 09:15:21]  INFO powchain: Ready for merge latestDifficulty=10735641 network=prater terminalDifficulty=10790000
```