### PR TITLE
Use correct fork and genesis root to verify bid

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -333,15 +333,9 @@ func (vs *Server) validatorRegistered(ctx context.Context, id types.ValidatorInd
 
 // Validates builder signature and returns an error if the signature is invalid.
 func (vs *Server) validateBuilderSignature(bid *ethpb.SignedBuilderBid) error {
-	if vs.ForkFetcher == nil {
-		return errors.New("nil fork fetcher")
-	}
-	f := vs.ForkFetcher.CurrentFork()
-	if vs.GenesisFetcher == nil {
-		return errors.New("nil genesis fetcher")
-	}
-	gr := vs.GenesisFetcher.GenesisValidatorsRoot()
-	d, err := signing.ComputeDomain(params.BeaconConfig().DomainApplicationBuilder, f.CurrentVersion, gr[:])
+	d, err := signing.ComputeDomain(params.BeaconConfig().DomainApplicationBuilder,
+		nil, /* fork version */
+		nil /* genesis val root */)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -393,8 +393,7 @@ func TestServer_getAndBuildHeaderBlock(t *testing.T) {
 		Value:  bytesutil.PadTo([]byte{1, 2, 3}, 32),
 	}
 	d := params.BeaconConfig().DomainApplicationBuilder
-	g := vs.GenesisFetcher.GenesisValidatorsRoot()
-	domain, err := signing.ComputeDomain(d, vs.ForkFetcher.CurrentFork().CurrentVersion, g[:])
+	domain, err := signing.ComputeDomain(d, nil, nil)
 	require.NoError(t, err)
 	sr, err := signing.ComputeSigningRoot(bid, domain)
 	require.NoError(t, err)
@@ -633,8 +632,7 @@ func TestServer_GetBellatrixBeaconBlock_BuilderCase(t *testing.T) {
 		Value:  bytesutil.PadTo([]byte{1, 2, 3}, 32),
 	}
 	d := params.BeaconConfig().DomainApplicationBuilder
-	g := proposerServer.GenesisFetcher.GenesisValidatorsRoot()
-	domain, err := signing.ComputeDomain(d, proposerServer.ForkFetcher.CurrentFork().CurrentVersion, g[:])
+	domain, err := signing.ComputeDomain(d, nil, nil)
 	require.NoError(t, err)
 	sr, err := signing.ComputeSigningRoot(bid, domain)
 	require.NoError(t, err)
@@ -687,13 +685,7 @@ func TestServer_validatorRegistered(t *testing.T) {
 }
 
 func TestServer_validateBuilderSignature(t *testing.T) {
-	m := &blockchainTest.ChainService{
-		Fork: &ethpb.Fork{},
-	}
-	s := &Server{
-		ForkFetcher:    m,
-		GenesisFetcher: m,
-	}
+	s := &Server{}
 	sk, err := bls.RandKey()
 	require.NoError(t, err)
 	bid := &ethpb.BuilderBid{
@@ -713,8 +705,7 @@ func TestServer_validateBuilderSignature(t *testing.T) {
 		Value:  bytesutil.PadTo([]byte{1, 2, 3}, 32),
 	}
 	d := params.BeaconConfig().DomainApplicationBuilder
-	g := s.GenesisFetcher.GenesisValidatorsRoot()
-	domain, err := signing.ComputeDomain(d, s.ForkFetcher.CurrentFork().CurrentVersion, g[:])
+	domain, err := signing.ComputeDomain(d, nil, nil)
 	require.NoError(t, err)
 	sr, err := signing.ComputeSigningRoot(bid, domain)
 	require.NoError(t, err)


### PR DESCRIPTION
This PR fixes signed bid validation to use the correct fork and genesis root. Source: https://github.com/ethereum/builder-specs/blob/main/specs/builder.md#signing