### PR TITLE
Validate cached payload before propose

### DIFF
--- a/beacon-chain/core/blocks/payload.go
+++ b/beacon-chain/core/blocks/payload.go
@@ -136,7 +136,7 @@ func ValidatePayloadWhenMergeCompletes(st state.BeaconState, payload interfaces.
 		return err
 	}
 	if !bytes.Equal(payload.ParentHash(), header.BlockHash) {
-		return errors.New("incorrect block hash")
+		return ErrInvalidPayloadBlockHash
 	}
 	return nil
 }


### PR DESCRIPTION
Given that we run forkchoice to get head at the start of the slot before we propose. Reorg could happen that's different view from the previous cached payload ID. When this happens, rather than failing the block proposal, the node should call fcu with the payload attribute again. The new payload will likely have fewer txs but that's better than missing the entire block