### PR TITLE
Change proposer cache overwrite logic

### DIFF
--- a/beacon-chain/cache/payload_id.go
+++ b/beacon-chain/cache/payload_id.go
@@ -56,7 +56,7 @@ func (f *ProposerPayloadIDsCache) SetProposerAndPayloadIDs(slot types.Slot, vId 
 	ids, ok := f.slotToProposerAndPayloadIDs[slot]
 	// Ok to overwrite if the slot is already set but the cached payload ID is not set.
 	// This combats the re-org case where payload assignment could change at the start of the epoch.
-	byte8 := [8]byte{}
+	byte8 := [vIdLength]byte{}
 	if !ok || (ok && bytes.Equal(ids[vIdLength:], byte8[:])) {
 		f.slotToProposerAndPayloadIDs[slot] = bs
 	}

--- a/beacon-chain/cache/payload_id.go
+++ b/beacon-chain/cache/payload_id.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"bytes"
 	"sync"
 
 	types "github.com/prysmaticlabs/prysm/consensus-types/primitives"
@@ -49,14 +50,15 @@ func (f *ProposerPayloadIDsCache) SetProposerAndPayloadIDs(slot types.Slot, vId 
 	var vIdBytes [vIdLength]byte
 	copy(vIdBytes[:], bytesutil.Uint64ToBytesBigEndian(uint64(vId)))
 
-	var bytes [vpIdsLength]byte
-	copy(bytes[:], append(vIdBytes[:], pId[:]...))
+	var bs [vpIdsLength]byte
+	copy(bs[:], append(vIdBytes[:], pId[:]...))
 
-	_, ok := f.slotToProposerAndPayloadIDs[slot]
+	ids, ok := f.slotToProposerAndPayloadIDs[slot]
 	// Ok to overwrite if the slot is already set but the payload ID is not set.
 	// This combats the re-org case where payload assignment could change the epoch of.
-	if !ok || (ok && pId != [pIdLength]byte{}) {
-		f.slotToProposerAndPayloadIDs[slot] = bytes
+	byte8 := [8]byte{}
+	if !ok || (ok && bytes.Equal(ids[vIdLength:], byte8[:])) {
+		f.slotToProposerAndPayloadIDs[slot] = bs
 	}
 }
 

--- a/beacon-chain/cache/payload_id.go
+++ b/beacon-chain/cache/payload_id.go
@@ -56,7 +56,7 @@ func (f *ProposerPayloadIDsCache) SetProposerAndPayloadIDs(slot types.Slot, vId 
 	ids, ok := f.slotToProposerAndPayloadIDs[slot]
 	// Ok to overwrite if the slot is already set but the cached payload ID is not set.
 	// Ok to overwrite if the slot is already set but the cached payload ID is not set.
-	// This combats the re-org case where payload assignment could change the epoch of.
+	// This combats the re-org case where payload assignment could change at the start of the epoch.
 	byte8 := [8]byte{}
 	if !ok || (ok && bytes.Equal(ids[vIdLength:], byte8[:])) {
 		f.slotToProposerAndPayloadIDs[slot] = bs

--- a/beacon-chain/cache/payload_id.go
+++ b/beacon-chain/cache/payload_id.go
@@ -55,7 +55,6 @@ func (f *ProposerPayloadIDsCache) SetProposerAndPayloadIDs(slot types.Slot, vId 
 
 	ids, ok := f.slotToProposerAndPayloadIDs[slot]
 	// Ok to overwrite if the slot is already set but the cached payload ID is not set.
-	// Ok to overwrite if the slot is already set but the cached payload ID is not set.
 	// This combats the re-org case where payload assignment could change at the start of the epoch.
 	byte8 := [8]byte{}
 	if !ok || (ok && bytes.Equal(ids[vIdLength:], byte8[:])) {

--- a/beacon-chain/cache/payload_id.go
+++ b/beacon-chain/cache/payload_id.go
@@ -54,7 +54,8 @@ func (f *ProposerPayloadIDsCache) SetProposerAndPayloadIDs(slot types.Slot, vId 
 	copy(bs[:], append(vIdBytes[:], pId[:]...))
 
 	ids, ok := f.slotToProposerAndPayloadIDs[slot]
-	// Ok to overwrite if the slot is already set but the payload ID is not set.
+	// Ok to overwrite if the slot is already set but the cached payload ID is not set.
+	// Ok to overwrite if the slot is already set but the cached payload ID is not set.
 	// This combats the re-org case where payload assignment could change the epoch of.
 	byte8 := [8]byte{}
 	if !ok || (ok && bytes.Equal(ids[vIdLength:], byte8[:])) {

--- a/beacon-chain/cache/payload_id_test.go
+++ b/beacon-chain/cache/payload_id_test.go
@@ -41,7 +41,7 @@ func TestValidatorPayloadIDsCache_GetAndSaveValidatorPayloadIDs(t *testing.T) {
 	require.Equal(t, vid, i)
 	require.Equal(t, pid, p)
 
-	// reset cache with existing pid
+	// existing pid - no change in cache
 	slot = types.Slot(9456456)
 	vid = types.ValidatorIndex(11111)
 	newPid := [8]byte{1, 2, 3, 33, 72, 8, 7, 1}

--- a/beacon-chain/cache/payload_id_test.go
+++ b/beacon-chain/cache/payload_id_test.go
@@ -49,7 +49,7 @@ func TestValidatorPayloadIDsCache_GetAndSaveValidatorPayloadIDs(t *testing.T) {
 	i, p, ok = cache.GetProposerPayloadIDs(slot)
 	require.Equal(t, true, ok)
 	require.Equal(t, vid, i)
-	require.Equal(t, newPid, p)
+	require.Equal(t, pid, p)
 
 	// remove cache entry
 	cache.PrunePayloadIDs(slot + 1)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Comment in `ProposerPayloadIDsCache.SetProposerAndPayloadIDs` says:
> Ok to overwrite if the slot is already set but the payload ID is not set.

The mentioned payload ID refers to the cached ID, not the new one. The current comparison verifies the new ID.
