### PR TITLE
Rename `statefetcher` methods

### DIFF
--- a/beacon-chain/rpc/statefetcher/fetcher.go
+++ b/beacon-chain/rpc/statefetcher/fetcher.go
@@ -125,7 +125,7 @@ func (p *StateProvider) State(ctx context.Context, stateId []byte) (state.Beacon
 		}
 	default:
 		if len(stateId) == 32 {
-			s, err = p.stateByHex(ctx, stateId)
+			s, err = p.stateByRoot(ctx, stateId)
 		} else {
 			slotNumber, parseErr := strconv.ParseUint(stateIdString, 10, 64)
 			if parseErr != nil {
@@ -160,7 +160,7 @@ func (p *StateProvider) StateRoot(ctx context.Context, stateId []byte) (root []b
 		root, err = p.justifiedStateRoot(ctx)
 	default:
 		if len(stateId) == 32 {
-			root, err = p.stateRootByHex(ctx, stateId)
+			root, err = p.stateRootByRoot(ctx, stateId)
 		} else {
 			slotNumber, parseErr := strconv.ParseUint(stateIdString, 10, 64)
 			if parseErr != nil {
@@ -175,13 +175,13 @@ func (p *StateProvider) StateRoot(ctx context.Context, stateId []byte) (root []b
 	return root, err
 }
 
-func (p *StateProvider) stateByHex(ctx context.Context, stateId []byte) (state.BeaconState, error) {
+func (p *StateProvider) stateByRoot(ctx context.Context, stateRoot []byte) (state.BeaconState, error) {
 	headState, err := p.ChainInfoFetcher.HeadState(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get head state")
 	}
 	for i, root := range headState.StateRoots() {
-		if bytes.Equal(root, stateId) {
+		if bytes.Equal(root, stateRoot) {
 			blockRoot := headState.BlockRoots()[i]
 			return p.StateGenService.StateByRoot(ctx, bytesutil.ToBytes32(blockRoot))
 		}
@@ -267,16 +267,16 @@ func (p *StateProvider) justifiedStateRoot(ctx context.Context) ([]byte, error) 
 	return b.Block().StateRoot(), nil
 }
 
-func (p *StateProvider) stateRootByHex(ctx context.Context, stateId []byte) ([]byte, error) {
-	var stateRoot [32]byte
-	copy(stateRoot[:], stateId)
+func (p *StateProvider) stateRootByRoot(ctx context.Context, stateRoot []byte) ([]byte, error) {
+	var r [32]byte
+	copy(r[:], stateRoot)
 	headState, err := p.ChainInfoFetcher.HeadState(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get head state")
 	}
 	for _, root := range headState.StateRoots() {
-		if bytes.Equal(root, stateRoot[:]) {
-			return stateRoot[:], nil
+		if bytes.Equal(root, r[:]) {
+			return r[:], nil
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

Some methods incorrectly use the word `hex`. We never pass hex-encoded state to the fetcher. 
