### PR TITLE
    Release checkpoints lock on on_tick

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/unrealized_justification.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/unrealized_justification.go
@@ -47,6 +47,8 @@ func (s *Store) setUnrealizedFinalizedEpoch(root [32]byte, epoch types.Epoch) er
 func (f *ForkChoice) updateUnrealizedCheckpoints() {
 	f.store.nodesLock.Lock()
 	defer f.store.nodesLock.Unlock()
+	f.store.checkpointsLock.Lock()
+	defer f.store.checkpointsLock.Unlock()
 	for _, node := range f.store.nodeByRoot {
 		node.justifiedEpoch = node.unrealizedJustifiedEpoch
 		node.finalizedEpoch = node.unrealizedFinalizedEpoch

--- a/beacon-chain/forkchoice/protoarray/on_tick.go
+++ b/beacon-chain/forkchoice/protoarray/on_tick.go
@@ -42,7 +42,6 @@ func (f *ForkChoice) NewSlot(ctx context.Context, slot types.Slot) error {
 
 	// Update store.justified_checkpoint if a better checkpoint on the store.finalized_checkpoint chain
 	f.store.checkpointsLock.Lock()
-	defer f.store.checkpointsLock.Unlock()
 
 	bjcp := f.store.bestJustifiedCheckpoint
 	jcp := f.store.justifiedCheckpoint
@@ -50,6 +49,7 @@ func (f *ForkChoice) NewSlot(ctx context.Context, slot types.Slot) error {
 	if bjcp.Epoch > jcp.Epoch {
 		finalizedSlot, err := slots.EpochStart(fcp.Epoch)
 		if err != nil {
+			f.store.checkpointsLock.Unlock()
 			return err
 		}
 
@@ -59,6 +59,7 @@ func (f *ForkChoice) NewSlot(ctx context.Context, slot types.Slot) error {
 		// loop call here.
 		r, err := f.AncestorRoot(ctx, bjcp.Root, finalizedSlot)
 		if err != nil {
+			f.store.checkpointsLock.Unlock()
 			return err
 		}
 		if r == fcp.Root {
@@ -66,8 +67,9 @@ func (f *ForkChoice) NewSlot(ctx context.Context, slot types.Slot) error {
 			f.store.justifiedCheckpoint = bjcp
 		}
 	}
+	f.store.checkpointsLock.Unlock()
 	if !features.Get().DisablePullTips {
-		f.UpdateUnrealizedCheckpoints()
+		f.updateUnrealizedCheckpoints()
 	}
 	return nil
 }

--- a/beacon-chain/forkchoice/protoarray/unrealized_justification.go
+++ b/beacon-chain/forkchoice/protoarray/unrealized_justification.go
@@ -56,9 +56,11 @@ func (s *Store) setUnrealizedFinalizedEpoch(root [32]byte, epoch types.Epoch) er
 // UpdateUnrealizedCheckpoints "realizes" the unrealized justified and finalized
 // epochs stored within nodes. It should be called at the beginning of each
 // epoch
-func (f *ForkChoice) UpdateUnrealizedCheckpoints() {
+func (f *ForkChoice) updateUnrealizedCheckpoints() {
 	f.store.nodesLock.Lock()
 	defer f.store.nodesLock.Unlock()
+	f.store.checkpointsLock.Lock()
+	defer f.store.checkpointsLock.Unlock()
 	for _, node := range f.store.nodes {
 		node.justifiedEpoch = node.unrealizedJustifiedEpoch
 		node.finalizedEpoch = node.unrealizedFinalizedEpoch

--- a/beacon-chain/forkchoice/protoarray/unrealized_justification_test.go
+++ b/beacon-chain/forkchoice/protoarray/unrealized_justification_test.go
@@ -97,7 +97,7 @@ func TestStore_LongFork(t *testing.T) {
 	require.Equal(t, uint64(100), f.store.nodes[3].weight)
 
 	// Update unrealized justification, c becomes head
-	f.UpdateUnrealizedCheckpoints()
+	f.updateUnrealizedCheckpoints()
 	headRoot, err = f.Head(ctx, []uint64{100})
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{'c'}, headRoot)
@@ -178,7 +178,7 @@ func TestStore_NoDeadLock(t *testing.T) {
 	require.Equal(t, types.Epoch(0), f.FinalizedCheckpoint().Epoch)
 
 	// Realized Justified checkpoints, H becomes head
-	f.UpdateUnrealizedCheckpoints()
+	f.updateUnrealizedCheckpoints()
 	headRoot, err = f.Head(ctx, []uint64{100})
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{'h'}, headRoot)
@@ -239,7 +239,7 @@ func TestStore_ForkNextEpoch(t *testing.T) {
 	require.NoError(t, f.InsertNode(ctx, state, blkRoot))
 	require.NoError(t, f.store.setUnrealizedJustifiedEpoch([32]byte{'d'}, 1))
 	f.store.unrealizedJustifiedCheckpoint = &forkchoicetypes.Checkpoint{Epoch: 1}
-	f.UpdateUnrealizedCheckpoints()
+	f.updateUnrealizedCheckpoints()
 	headRoot, err = f.Head(ctx, []uint64{100})
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{'d'}, headRoot)


### PR DESCRIPTION
    There is a double lock race condition when NewSlot acquires the
    checkpoints lock first and the nodes lock later, while calls to Head()
    acquire the nodeslock first and the checkpoints lock later.

    This PR releases the checkpoints lock in NewSlot, to reaquire it later
    in updateUnrealizedCheckpoints after getting the nodes lock
