### PR TITLE
Builder: check payload and header HTR root match

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
@@ -154,6 +154,7 @@ go_test(
         "//container/trie:go_default_library",
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//encoding/ssz:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//proto/eth/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -240,6 +240,20 @@ func (vs *Server) unblindBuilderBlock(ctx context.Context, b interfaces.SignedBe
 	if err != nil {
 		return nil, err
 	}
+	headerRoot, err := header.HashTreeRoot()
+	if err != nil {
+		return nil, err
+	}
+
+	payloadRoot, err := payload.HashTreeRoot()
+	if err != nil {
+		return nil, err
+	}
+	if headerRoot != payloadRoot {
+		return nil, fmt.Errorf("header and payload root do not match, consider disconnect from relay to avoid further issues, "+
+			"%#x != %#x", headerRoot, payloadRoot)
+	}
+
 	bb := &ethpb.SignedBeaconBlockBellatrix{
 		Block: &ethpb.BeaconBlockBellatrix{
 			Slot:          sb.Block.Slot,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -34,6 +34,7 @@ import (
 	types "github.com/prysmaticlabs/prysm/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/crypto/bls"
 	"github.com/prysmaticlabs/prysm/encoding/bytesutil"
+	"github.com/prysmaticlabs/prysm/encoding/ssz"
 	enginev1 "github.com/prysmaticlabs/prysm/proto/engine/v1"
 	v1 "github.com/prysmaticlabs/prysm/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/proto/prysm/v1alpha1"
@@ -167,6 +168,9 @@ func TestServer_getPayloadHeader(t *testing.T) {
 }
 
 func TestServer_getBuilderBlock(t *testing.T) {
+	p := emptyPayload()
+	p.GasLimit = 123
+
 	tests := []struct {
 		name        string
 		blk         interfaces.SignedBeaconBlock
@@ -225,7 +229,7 @@ func TestServer_getBuilderBlock(t *testing.T) {
 			err: "can't submit",
 		},
 		{
-			name: "can submit block",
+			name: "head and payload root mismatch",
 			blk: func() interfaces.SignedBeaconBlock {
 				b := util.NewBlindedBeaconBlockBellatrix()
 				b.Block.Slot = 1
@@ -236,13 +240,51 @@ func TestServer_getBuilderBlock(t *testing.T) {
 			}(),
 			mock: &builderTest.MockBuilderService{
 				HasConfigured: true,
-				Payload:       &v1.ExecutionPayload{GasLimit: 123},
+				Payload:       p,
 			},
 			returnedBlk: func() interfaces.SignedBeaconBlock {
 				b := util.NewBeaconBlockBellatrix()
 				b.Block.Slot = 1
 				b.Block.ProposerIndex = 2
-				b.Block.Body.ExecutionPayload = &v1.ExecutionPayload{GasLimit: 123}
+				b.Block.Body.ExecutionPayload = p
+				wb, err := blocks.NewSignedBeaconBlock(b)
+				require.NoError(t, err)
+				return wb
+			}(),
+		},
+		{
+			name: "can get payload",
+			blk: func() interfaces.SignedBeaconBlock {
+				b := util.NewBlindedBeaconBlockBellatrix()
+				b.Block.Slot = 1
+				b.Block.ProposerIndex = 2
+				txRoot, err := ssz.TransactionsRoot([][]byte{})
+				require.NoError(t, err)
+				b.Block.Body.ExecutionPayloadHeader = &v1.ExecutionPayloadHeader{
+					ParentHash:       make([]byte, fieldparams.RootLength),
+					FeeRecipient:     make([]byte, fieldparams.FeeRecipientLength),
+					StateRoot:        make([]byte, fieldparams.RootLength),
+					ReceiptsRoot:     make([]byte, fieldparams.RootLength),
+					LogsBloom:        make([]byte, fieldparams.LogsBloomLength),
+					PrevRandao:       make([]byte, fieldparams.RootLength),
+					BaseFeePerGas:    make([]byte, fieldparams.RootLength),
+					BlockHash:        make([]byte, fieldparams.RootLength),
+					TransactionsRoot: txRoot[:],
+					GasLimit:         123,
+				}
+				wb, err := blocks.NewSignedBeaconBlock(b)
+				require.NoError(t, err)
+				return wb
+			}(),
+			mock: &builderTest.MockBuilderService{
+				HasConfigured: true,
+				Payload:       p,
+			},
+			returnedBlk: func() interfaces.SignedBeaconBlock {
+				b := util.NewBeaconBlockBellatrix()
+				b.Block.Slot = 1
+				b.Block.ProposerIndex = 2
+				b.Block.Body.ExecutionPayload = p
 				wb, err := blocks.NewSignedBeaconBlock(b)
 				require.NoError(t, err)
 				return wb
@@ -253,9 +295,10 @@ func TestServer_getBuilderBlock(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			vs := &Server{BlockBuilder: tc.mock}
 			gotBlk, err := vs.unblindBuilderBlock(context.Background(), tc.blk)
-			if err != nil {
+			if tc.err != "" {
 				require.ErrorContains(t, tc.err, err)
 			} else {
+				require.NoError(t, err)
 				require.DeepEqual(t, tc.returnedBlk, gotBlk)
 			}
 		})

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -251,6 +251,7 @@ func TestServer_getBuilderBlock(t *testing.T) {
 				require.NoError(t, err)
 				return wb
 			}(),
+			err: "header and payload root do not match",
 		},
 		{
 			name: "can get payload",


### PR DESCRIPTION
This PR ensures essential compliance that header and payload root match when outsourcing block construction using an external builder. If the root mismatch, it's an attributable fault on the relayer, we'll log an error to recommend user to disconnect with the relayer. I feel a lot better to fail earlier than to broadcast the faulty payload block out and get downgraded by peer scorers. 