### PR TITLE
Misc builder fixes

### DIFF
--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -88,8 +88,6 @@ type config struct {
 // NewService instantiates a new block service instance that will
 // be registered into a running beacon node.
 func NewService(ctx context.Context, opts ...Option) (*Service, error) {
-	fmt.Println(params.BeaconConfig().MaxBuilderConsecutiveMissedSlots)
-	fmt.Println(params.BeaconConfig().MaxBuilderEpochMissedSlots)
 	ctx, cancel := context.WithCancel(ctx)
 	srv := &Service{
 		ctx:                  ctx,

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -88,6 +88,8 @@ type config struct {
 // NewService instantiates a new block service instance that will
 // be registered into a running beacon node.
 func NewService(ctx context.Context, opts ...Option) (*Service, error) {
+	fmt.Println(params.BeaconConfig().MaxBuilderConsecutiveMissedSlots)
+	fmt.Println(params.BeaconConfig().MaxBuilderEpochMissedSlots)
 	ctx, cancel := context.WithCancel(ctx)
 	srv := &Service{
 		ctx:                  ctx,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -317,16 +317,16 @@ func (vs *Server) circuitBreakBuilder(s types.Slot) (bool, error) {
 
 	// Circuit breaker is active if the missing consecutive slots greater than `MaxBuilderConsecutiveMissedSlots`.
 	highestReceivedSlot := vs.ForkFetcher.ForkChoicer().HighestReceivedBlockSlot()
-	fallbackSlots := params.BeaconConfig().MaxBuilderConsecutiveMissedSlots
+	maxConsecutiveSkipSlotsAllowed := params.BeaconConfig().MaxBuilderConsecutiveMissedSlots
 	diff, err := s.SafeSubSlot(highestReceivedSlot)
 	if err != nil {
 		return true, err
 	}
-	if diff > fallbackSlots {
+	if diff > maxConsecutiveSkipSlotsAllowed {
 		log.WithFields(logrus.Fields{
-			"currentSlot":         s,
-			"highestReceivedSlot": highestReceivedSlot,
-			"fallBackSkipSlots":   fallbackSlots,
+			"currentSlot":                    s,
+			"highestReceivedSlot":            highestReceivedSlot,
+			"maxConsecutiveSkipSlotsAllowed": maxConsecutiveSkipSlotsAllowed,
 		}).Warn("Builder circuit breaker activated due to missing consecutive slot")
 		return true, nil
 	}
@@ -341,15 +341,15 @@ func (vs *Server) circuitBreakBuilder(s types.Slot) (bool, error) {
 	if err != nil {
 		return true, err
 	}
-	fallbackSlotsLastEpoch := params.BeaconConfig().MaxBuilderEpochMissedSlots
+	maxEpochSkipSlotsAllowed := params.BeaconConfig().MaxBuilderEpochMissedSlots
 	diff, err = params.BeaconConfig().SlotsPerEpoch.SafeSub(receivedCount)
 	if err != nil {
 		return true, err
 	}
-	if diff > fallbackSlotsLastEpoch {
+	if diff > maxEpochSkipSlotsAllowed {
 		log.WithFields(logrus.Fields{
-			"totalMissed":                receivedCount,
-			"fallBackSkipSlotsLastEpoch": fallbackSlotsLastEpoch,
+			"totalMissed":              diff,
+			"maxEpochSkipSlotsAllowed": maxEpochSkipSlotsAllowed,
 		}).Warn("Builder circuit breaker activated due to missing enough slots last epoch")
 		return true, nil
 	}

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -73,6 +73,8 @@ var appFlags = []cli.Flag{
 	flags.TerminalBlockHashOverride,
 	flags.TerminalBlockHashActivationEpochOverride,
 	flags.MevRelayEndpoint,
+	flags.MaxBuilderEpochMissedSlots,
+	flags.MaxBuilderConsecutiveMissedSlots,
 	cmd.EnableBackupWebhookFlag,
 	cmd.BackupWebhookOutputDir,
 	cmd.MinimalConfigFlag,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -125,6 +125,8 @@ var appHelpFlagGroups = []flagGroup{
 			flags.Eth1HeaderReqLimit,
 			flags.MinPeersPerSubnet,
 			flags.MevRelayEndpoint,
+			flags.MaxBuilderEpochMissedSlots,
+			flags.MaxBuilderConsecutiveMissedSlots,
 			checkpoint.BlockPath,
 			checkpoint.StatePath,
 			checkpoint.RemoteURL,

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -253,8 +253,8 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	DefaultBuilderGasLimit:           uint64(30000000),
 
 	// Mevboost circuit breaker
-	MaxBuilderConsecutiveMissedSlots: 4,
-	MaxBuilderEpochMissedSlots:       6,
+	MaxBuilderConsecutiveMissedSlots: 3,
+	MaxBuilderEpochMissedSlots:       8,
 }
 
 // MainnetTestConfig provides a version of the mainnet config that has a different name


### PR DESCRIPTION
Fixes a few typos and bugs from #11109 
- The circuit breaker flags were not added to the group, so it was undefined
- Change defaults from 4, 6 to 3, 8 to be more prudent. 6 slots per epoch can easily be missed with a descent pool
- Fixed warning log to display the correct `diff` for `totalMissed`
- Updated a few variable names