### PR TITLE
Remove Backup Webhook In the Beacon Node

### DIFF
--- a/beacon-chain/node/BUILD.bazel
+++ b/beacon-chain/node/BUILD.bazel
@@ -54,7 +54,6 @@ go_library(
         "//consensus-types/primitives:go_default_library",
         "//container/slice:go_default_library",
         "//encoding/bytesutil:go_default_library",
-        "//monitoring/backup:go_default_library",
         "//monitoring/prometheus:go_default_library",
         "//monitoring/tracing:go_default_library",
         "//runtime:go_default_library",

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -56,7 +56,6 @@ import (
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/container/slice"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
-	"github.com/prysmaticlabs/prysm/v3/monitoring/backup"
 	"github.com/prysmaticlabs/prysm/v3/monitoring/prometheus"
 	"github.com/prysmaticlabs/prysm/v3/runtime"
 	"github.com/prysmaticlabs/prysm/v3/runtime/debug"
@@ -864,16 +863,6 @@ func (b *BeaconNode) registerPrometheusService(cliCtx *cli.Context) error {
 	var c *blockchain.Service
 	if err := b.services.FetchService(&c); err != nil {
 		panic(err)
-	}
-
-	if cliCtx.IsSet(cmd.EnableBackupWebhookFlag.Name) {
-		additionalHandlers = append(
-			additionalHandlers,
-			prometheus.Handler{
-				Path:    "/db/backup",
-				Handler: backup.BackupHandler(b.db, cliCtx.String(cmd.BackupWebhookOutputDir.Name)),
-			},
-		)
 	}
 
 	service := prometheus.NewService(

--- a/beacon-chain/node/node_test.go
+++ b/beacon-chain/node/node_test.go
@@ -44,9 +44,6 @@ func TestNodeClose_OK(t *testing.T) {
 	set.String("p2p-encoding", "ssz", "p2p encoding scheme")
 	set.Bool("demo-config", true, "demo configuration")
 	set.String("deposit-contract", "0x0000000000000000000000000000000000000000", "deposit contract address")
-	set.Bool(cmd.EnableBackupWebhookFlag.Name, true, "")
-	require.NoError(t, set.Set(cmd.EnableBackupWebhookFlag.Name, "true"))
-	set.String(cmd.BackupWebhookOutputDir.Name, "datadir", "")
 	cmd.ValidatorMonitorIndicesFlag.Value = &cli.IntSlice{}
 	cmd.ValidatorMonitorIndicesFlag.Value.SetInt(1)
 	ctx := cli.NewContext(&app, set, nil)

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -74,7 +74,6 @@ var appFlags = []cli.Flag{
 	flags.MevRelayEndpoint,
 	flags.MaxBuilderEpochMissedSlots,
 	flags.MaxBuilderConsecutiveMissedSlots,
-	cmd.EnableBackupWebhookFlag,
 	cmd.BackupWebhookOutputDir,
 	cmd.MinimalConfigFlag,
 	cmd.E2EConfigFlag,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -62,7 +62,6 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.TraceSampleFractionFlag,
 			cmd.MonitoringHostFlag,
 			cmd.BackupWebhookOutputDir,
-			cmd.EnableBackupWebhookFlag,
 			flags.MonitoringPortFlag,
 			cmd.DisableMonitoringFlag,
 			cmd.MaxGoroutines,


### PR DESCRIPTION
**What type of PR is this?**

Feature Removal

**What does this PR do? Why is it needed?**

This PR removes our backup webhook feature for the beacon node. The beacon node db being as large as it is right now, would cause a large spike in memory when backing it up. It would be better for users to manually copy it rather than copy it via memory using our webhook.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
