### PR TITLE
Parse slot as uint64 in spectest

### DIFF
--- a/testing/spectest/shared/altair/sanity/slot_processing.go
+++ b/testing/spectest/shared/altair/sanity/slot_processing.go
@@ -40,7 +40,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")
 			require.NoError(t, err)
 			fileStr := string(file)
-			slotsCount, err := strconv.Atoi(fileStr[:len(fileStr)-5])
+			slotsCount, err := strconv.ParseUint(fileStr[:len(fileStr)-5], 10, 64)
 			require.NoError(t, err)
 
 			postBeaconStateFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "post.ssz_snappy")
@@ -49,7 +49,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			postBeaconState := &ethpb.BeaconStateAltair{}
 			require.NoError(t, postBeaconState.UnmarshalSSZ(postBeaconStateSSZ), "Failed to unmarshal")
-			postState, err := transition.ProcessSlots(context.Background(), beaconState, beaconState.Slot().Add(uint64(slotsCount)))
+			postState, err := transition.ProcessSlots(context.Background(), beaconState, beaconState.Slot().Add(slotsCount))
 			require.NoError(t, err)
 
 			pbState, err := stateAltair.ProtobufBeaconState(postState.CloneInnerState())

--- a/testing/spectest/shared/bellatrix/sanity/slot_processing.go
+++ b/testing/spectest/shared/bellatrix/sanity/slot_processing.go
@@ -40,7 +40,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")
 			require.NoError(t, err)
 			fileStr := string(file)
-			slotsCount, err := strconv.Atoi(fileStr[:len(fileStr)-5])
+			slotsCount, err := strconv.ParseUint(fileStr[:len(fileStr)-5], 10, 64)
 			require.NoError(t, err)
 
 			postBeaconStateFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "post.ssz_snappy")
@@ -49,7 +49,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			postBeaconState := &ethpb.BeaconStateBellatrix{}
 			require.NoError(t, postBeaconState.UnmarshalSSZ(postBeaconStateSSZ), "Failed to unmarshal")
-			postState, err := transition.ProcessSlots(context.Background(), beaconState, beaconState.Slot().Add(uint64(slotsCount)))
+			postState, err := transition.ProcessSlots(context.Background(), beaconState, beaconState.Slot().Add(slotsCount))
 			require.NoError(t, err)
 
 			pbState, err := v3.ProtobufBeaconState(postState.CloneInnerState())

--- a/testing/spectest/shared/phase0/sanity/slot_processing.go
+++ b/testing/spectest/shared/phase0/sanity/slot_processing.go
@@ -40,7 +40,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			file, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "slots.yaml")
 			require.NoError(t, err)
 			fileStr := string(file)
-			slotsCount, err := strconv.Atoi(fileStr[:len(fileStr)-5])
+			slotsCount, err := strconv.ParseUint(fileStr[:len(fileStr)-5], 10, 64)
 			require.NoError(t, err)
 
 			postBeaconStateFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "post.ssz_snappy")
@@ -49,7 +49,7 @@ func RunSlotProcessingTests(t *testing.T, config string) {
 			require.NoError(t, err, "Failed to decompress")
 			postBeaconState := &ethpb.BeaconState{}
 			require.NoError(t, postBeaconState.UnmarshalSSZ(postBeaconStateSSZ), "Failed to unmarshal")
-			postState, err := transition.ProcessSlots(context.Background(), beaconState, beaconState.Slot().Add(uint64(slotsCount)))
+			postState, err := transition.ProcessSlots(context.Background(), beaconState, beaconState.Slot().Add(slotsCount))
 			require.NoError(t, err)
 
 			pbState, err := v1.ProtobufBeaconState(postState.CloneInnerState())


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Instead of parsing the slot as an integer and downcasting to a uint64, this will parse it as a uint64.

This was identified with Semgrep & the `string-to-int-signedness-cast` rule.
 
<img width="944" alt="image" src="https://user-images.githubusercontent.com/95511699/185223348-8b54c3f1-3a3d-4f89-9a77-15caf1413ab1.png">

**Other notes for review**

* https://semgrep.dev/
* https://semgrep.dev/r?q=trailofbits.go.string-to-int-signedness-cast.string-to-int-signedness-cast
* https://github.com/trailofbits/semgrep-rules/blob/main/go/string-to-int-signedness-cast.yml
