### PR TITLE
Make sync committee peer errors debug level

### DIFF
--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -179,14 +179,14 @@ func (s *Service) broadcastSyncCommittee(ctx context.Context, subnet uint64, sMs
 			}
 			return errors.New("failed to find peers for subnet")
 		}(); err != nil {
-			log.WithError(err).Error("Failed to find peers")
+			log.WithError(err).Debug("Failed to find peers")
 			tracing.AnnotateError(span, err)
 		}
 	}
 	// In the event our sync message is outdated and beyond the
 	// acceptable threshold, we exit early and do not broadcast it.
 	if err := altair.ValidateSyncMessageTime(sMsg.Slot, s.genesisTime, params.BeaconNetworkConfig().MaximumGossipClockDisparity); err != nil {
-		log.WithError(err).Warn("Sync Committee Message is too old to broadcast, discarding it")
+		log.WithError(err).Debug("Sync committee message is too old to broadcast, discarding it")
 		return
 	}
 


### PR DESCRIPTION
When running in interop mode, and in local devnets, Prysm beacon nodes will be polluted with logs regarding sync committee messages after the Altair epoch. This PR is proposed because these logs are not very useful at info level, and for relevant operators that could benefit from these logs, they should run with debug verbosity anyways.

```
[2022-08-17 16:34:36] ERROR p2p: Failed to find peers error=unable to find requisite number of peers for topic /eth2/7377a3b2/sync_committee_1/ssz_snappy - only 0 out of 1 peers were able to be found
[2022-08-17 16:34:36]  WARN p2p: Sync Committee Message is too old to broadcast, discarding it error=sync message time 2022-08-17 16:28:42 -0400 EDT (slot 29) not within allowable range of 2022-08-17 16:34:34 -0400 EDT (slot 117) to 2022-08-17 16:34:36.519973 -0400 EDT m=+192.639478126 (slot 117)
```