### PR TITLE
Switch Down Libp2p Logging Level By Default

### DIFF
--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -231,6 +231,13 @@ func startNode(ctx *cli.Context) error {
 		return err
 	}
 	logrus.SetLevel(level)
+	// Set libp2p logger to only panic logs for the info level.
+	golog.SetAllLoggers(golog.LevelPanic)
+
+	if level == logrus.DebugLevel {
+		// Set libp2p logger to error logs for the debug level.
+		golog.SetAllLoggers(golog.LevelError)
+	}
 	if level == logrus.TraceLevel {
 		// libp2p specific logging.
 		golog.SetAllLoggers(golog.LevelDebug)


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

For the default verbosity, we will only log any libp2p logs which are at the panic level.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
