### PR TITLE
DoublyLinkedTree double locks

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -183,6 +183,9 @@ func (f *ForkChoice) updateCheckpoints(ctx context.Context, jc, fc *ethpb.Checkp
 				return err
 			}
 			jcRoot := bytesutil.ToBytes32(jc.Root)
+			// Releasing here the checkpoints lock because
+			// AncestorRoot acquires a lock on nodes and that can
+			// cause a double lock.
 			f.store.checkpointsLock.Unlock()
 			root, err := f.AncestorRoot(ctx, jcRoot, jSlot)
 			if err != nil {

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -183,11 +183,12 @@ func (f *ForkChoice) updateCheckpoints(ctx context.Context, jc, fc *ethpb.Checkp
 				return err
 			}
 			jcRoot := bytesutil.ToBytes32(jc.Root)
+			f.store.checkpointsLock.Unlock()
 			root, err := f.AncestorRoot(ctx, jcRoot, jSlot)
 			if err != nil {
-				f.store.checkpointsLock.Unlock()
 				return err
 			}
+			f.store.checkpointsLock.Lock()
 			if root == currentRoot {
 				f.store.prevJustifiedCheckpoint = f.store.justifiedCheckpoint
 				f.store.justifiedCheckpoint = &forkchoicetypes.Checkpoint{Epoch: jc.Epoch,

--- a/beacon-chain/forkchoice/doubly-linked-tree/node.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/node.go
@@ -40,7 +40,8 @@ func (n *Node) applyWeightChanges(ctx context.Context) error {
 	return nil
 }
 
-// updateBestDescendant updates the best descendant of this node and its children.
+// updateBestDescendant updates the best descendant of this node and its
+// children. This function assumes the caller has a lock on Store.nodesLock
 func (n *Node) updateBestDescendant(ctx context.Context, justifiedEpoch, finalizedEpoch types.Epoch) error {
 	if ctx.Err() != nil {
 		return ctx.Err()

--- a/beacon-chain/forkchoice/doubly-linked-tree/store.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store.go
@@ -170,8 +170,11 @@ func (s *Store) insert(ctx context.Context,
 		}
 
 		// Update best descendants
-		if err := s.treeRootNode.updateBestDescendant(ctx,
-			s.justifiedCheckpoint.Epoch, s.finalizedCheckpoint.Epoch); err != nil {
+		s.checkpointsLock.RLock()
+		jEpoch := s.justifiedCheckpoint.Epoch
+		fEpoch := s.finalizedCheckpoint.Epoch
+		s.checkpointsLock.RUnlock()
+		if err := s.treeRootNode.updateBestDescendant(ctx, jEpoch, fEpoch); err != nil {
 			return n, err
 		}
 	}


### PR DESCRIPTION
The order of locks acquired in forkchoice is susceptible to deadlocks when two different functions are called which aquire locks in reversed order. In this PR we audit these locks. Credit goes to @nisdas that found all possible deadlocks and to @infosecual for a missing lock in `insert` that is added here. 

The order of all locks in every exposed function in doubly linked tree is as follows

Head: votes (defer)  --> nodes (defer) --> 
    updateBalances: proposerBoost
    applyProposerBoostScore: proposerBoost
    head: checkpoints (defer)

CachedHeadRoot: nodes (defer)

Tips:
    tips: nodes (defer)

IsOptimistic: nodes(defer)

AllTipsAreInvalid: nodes(defer)

InsertNode:
    insert: nodes (defer) --> proposerBoost --> checkpoints
    pullTips: nodes(defer) --> checkpoints (defer)
    updateCheckpoints: checkpoints -->
        AncestorRoot: nodes (defer)
        prune: nodes(defer) --> checkpoints

InsertOptimisticChain: 
    insert: nodes (defer) --> proposerBoost --> checkpoints
    updateCheckpoints: checkpoints --> 
        AncestorRoot: nodes (defer)
        prune: nodes(defer) --> checkpoints

ProcessAttestation: votes (defer)

InsertSlashedIndex: nodes(defer) --> votes(defer)

ReserProposerBoost: proposerBoost

HasNode: nodes(defer)

ProposerBoost:
    proposerBoost: proposerBoost (defer)

HasParent: nodes (defer)

AncestorRoot: nodes (defer)

CommonAncestorRoot: nodes (defer)

IsCanonical: nodes (defer)

FinalizedCheckpoint: checkpoints (defer)

FinalizedPayloadBlockHash: nodes (defer)
    FinalizedCheckpoint: checkpoints (defer)

JustifiedCheckpoint: checkpoints (defer)

PreviousJustifiedCheckpoint: checkpoints (defer)

JustifiedBlockHash: nodes (defer)
    JustifiedCheckpoint: checkpoints (defer)

BestJustifiedCheckpoint: checkpoints (defer)

NodeCount: nodes (defer)

HighestReceivedSlot: nodes (defer)

ReceivedBlocksLastEpoch: nodes (defer)

SetOptimisticToValid: nodes (defer)

SetOptimisticToInvalid:
    setOptimisticToInvalid: nodes 
        removeNode: nodes (defer)
            removeNodeAndChildren: proposerBoost

UpdateJustifiedCheckpoint: checkpoints (defer)

UpdateFinalizedCheckpoint: checkpoints (defer)

SetGenesisTime: 

SetOriginRoot:

NewSlot:
    ResetBoostedProposerRoot: proposerBoost (defer)
    checkpoints ---> AncestorRoot: nodes (defer)
    updateUnrealizedCheckpoints: nodes (defer) --> checkpoints (defer)


We adhere to the following order of aquisition in case of multiple locks being held at the same time: 
votes -> nodes ---> proposerBoost ---> checkpoints

Violations occur in updateCheckpoints (called twice, from InsertNode and InsertOptimisticChain), InsertSlashedIndex and in NewSlot. This PR changes the order of acquisition in these functions so as to respect the global ordering. 