### PR TITLE
use blockchain's method instead of forkchoice

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -325,7 +325,7 @@ func (s *Service) IsOptimistic(ctx context.Context) (bool, error) {
 // IsFinalized returns true if the input root is finalized.
 // It first checks latest finalized root then checks finalized root index in DB.
 func (s *Service) IsFinalized(ctx context.Context, root [32]byte) bool {
-	if s.ForkChoicer().FinalizedCheckpoint().Root == root {
+	if bytes.Equal(s.FinalizedCheckpt().Root, root[:]) {
 		return true
 	}
 	return s.cfg.BeaconDB.IsFinalizedBlock(ctx, root)

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -149,8 +149,8 @@ func (s *Service) UpdateHead(ctx context.Context) error {
 
 	s.processAttestations(ctx)
 
-	justified := s.ForkChoicer().JustifiedCheckpoint()
-	balances, err := s.justifiedBalances.get(ctx, justified.Root)
+	justified := s.CurrentJustifiedCheckpt()
+	balances, err := s.justifiedBalances.get(ctx, bytesutil.ToBytes32(justified.Root))
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/forkchoice/BUILD.bazel
+++ b/beacon-chain/forkchoice/BUILD.bazel
@@ -9,8 +9,9 @@ go_library(
     ],
     importpath = "github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice",
     visibility = [
-        "//beacon-chain:__subpackages__",
-        "//cmd:__subpackages__",
+        "//beacon-chain/blockchain:__subpackages__",
+	"//beacon-chain/forkchoice:__subpackages__",
+	"//beacon-chain/node:__subpackages__",
         "//testing/spectest:__subpackages__",
     ],
     deps = [

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -80,9 +80,9 @@ func (f *ForkChoice) Head(
 		return [32]byte{}, errors.Wrap(err, "could not apply weight changes")
 	}
 
-	jc := f.JustifiedCheckpoint()
-	fc := f.FinalizedCheckpoint()
-	if err := f.store.treeRootNode.updateBestDescendant(ctx, jc.Epoch, fc.Epoch); err != nil {
+	jEpoch := f.JustifiedCheckpoint().Epoch
+	fEpoch := f.FinalizedCheckpoint().Epoch
+	if err := f.store.treeRootNode.updateBestDescendant(ctx, jEpoch, fEpoch); err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not update best descendant")
 	}
 	return f.store.head(ctx)


### PR DESCRIPTION
This is an alternative to @infosecual #11263 to avoid changing locks on forkchoice on V3. The current calls are safe since the `JustifiedCheckpoint()` and `FinalizedCheckpoint()` methods are only called from either the blockchain package, that makes a safe copy, or the fields are taken immediately like in 

`fRoot := s.cfg.Forkchoicer.FinalizedCheckpoint().Root`

The problem with #11263 is that any call to blockchain's  `FinalizedChkpt()` or `CurrentJustifiedChkpt()` will make unnecessarily two copies of the root. 

This PR moves all calls to use the blockchain package until we make a design decision on moving to forkchoicetypes.Checkpoint or ethpb.Checkpoints all the checkpoints and then use only  one interface to pass these around. 

I am not really sure if merging this is even worth it, so I'm just putting this as draft for now. Notice that it will incurr in two copies at a couple of places. 