### PR TITLE
Return copy of deposits instead of internal pointer

### DIFF
--- a/beacon-chain/cache/depositcache/deposits_cache.go
+++ b/beacon-chain/cache/depositcache/deposits_cache.go
@@ -185,7 +185,10 @@ func (dc *DepositCache) AllDepositContainers(ctx context.Context) []*ethpb.Depos
 	dc.depositsLock.RLock()
 	defer dc.depositsLock.RUnlock()
 
-	return dc.deposits
+	// Make a copy so that it's impossible to modify the internal cache.
+	deposits := make([]*ethpb.DepositContainer, len(dc.deposits))
+	copy(deposits, dc.deposits)
+	return deposits
 }
 
 // AllDeposits returns a list of historical deposits until the given block number


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Just to be safe, I think we should return a copy of the deposits instead of the `DepositCache.deposits` pointer. There is a read lock in this method, so it doesn't make sense to return a pointer that can be read (and written to) outside of the lock. This could lead to a race condition if another thread modifies the deposits.

**Other notes for review**

All of the other methods for this interface return a copy.