### PR TITLE
Bring back old execution flag as an alias

### DIFF
--- a/cmd/beacon-chain/execution/BUILD.bazel
+++ b/cmd/beacon-chain/execution/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//cmd/beacon-chain/flags:go_default_library",
         "//io/file:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],
 )

--- a/cmd/beacon-chain/execution/options.go
+++ b/cmd/beacon-chain/execution/options.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/execution"
 	"github.com/prysmaticlabs/prysm/v3/cmd/beacon-chain/flags"
 	"github.com/prysmaticlabs/prysm/v3/io/file"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -64,7 +65,8 @@ func parseJWTSecretFromFile(c *cli.Context) ([]byte, error) {
 }
 
 func parseExecutionChainEndpoint(c *cli.Context) (string, error) {
-	if c.String(flags.ExecutionEngineEndpoint.Name) == "" {
+	aliasUsed := c.IsSet(flags.HTTPWeb3ProviderFlag.Name)
+	if c.String(flags.ExecutionEngineEndpoint.Name) == "" && !aliasUsed {
 		return "", fmt.Errorf(
 			"you need to specify %s to provide a connection endpoint to an Ethereum execution client "+
 				"for your Prysm beacon node. This is a requirement for running a node. You can read more about "+
@@ -72,6 +74,13 @@ func parseExecutionChainEndpoint(c *cli.Context) (string, error) {
 				"https://docs.prylabs.network/docs/install/install-with-script",
 			flags.ExecutionEngineEndpoint.Name,
 		)
+	}
+	// If users only declare the deprecated flag without setting the execution engine
+	// flag, we fallback to using the deprecated flag value.
+	if aliasUsed && !c.IsSet(flags.ExecutionEngineEndpoint.Name) {
+		log.Warnf("The %s flag has been deprecated and will be removed in a future release,"+
+			"please use the execution endpoint flag instead %s", flags.HTTPWeb3ProviderFlag.Name, flags.ExecutionEngineEndpoint.Name)
+		return c.String(flags.HTTPWeb3ProviderFlag.Name), nil
 	}
 	return c.String(flags.ExecutionEngineEndpoint.Name), nil
 }

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -32,6 +32,13 @@ var (
 		Usage: "An execution client http endpoint. Can contain auth header as well in the format",
 		Value: "http://localhost:8551",
 	}
+	// Deprecated: HTTPWeb3ProviderFlag is a deprecated flag and is an alias for the ExecutionEngineEndpoint flag.
+	HTTPWeb3ProviderFlag = &cli.StringFlag{
+		Name:   "http-web3provider",
+		Usage:  "DEPRECATED: A mainchain web3 provider string http endpoint. Can contain auth header as well in the format --http-web3provider=\"https://goerli.infura.io/v3/xxxx,Basic xxx\" for project secret (base64 encoded) and --http-web3provider=\"https://goerli.infura.io/v3/xxxx,Bearer xxx\" for jwt use",
+		Value:  "http://localhost:8551",
+		Hidden: true,
+	}
 	// ExecutionJWTSecretFlag provides a path to a file containing a hex-encoded string representing a 32 byte secret
 	// used to authenticate with an execution node via HTTP. This is required if using an HTTP connection, otherwise all requests
 	// to execution nodes for consensus-related calls will fail. This is not required if using an IPC connection.

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -38,6 +38,7 @@ import (
 var appFlags = []cli.Flag{
 	flags.DepositContractFlag,
 	flags.ExecutionEngineEndpoint,
+	flags.HTTPWeb3ProviderFlag,
 	flags.ExecutionJWTSecretFlag,
 	flags.RPCHost,
 	flags.RPCPort,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -107,6 +107,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.GRPCGatewayPort,
 			flags.GPRCGatewayCorsDomain,
 			flags.ExecutionEngineEndpoint,
+			flags.HTTPWeb3ProviderFlag,
 			flags.ExecutionJWTSecretFlag,
 			flags.SetGCPercent,
 			flags.SlotsPerArchivedPoint,


### PR DESCRIPTION
**What type of PR is this?**

Bug FIx

**What does this PR do? Why is it needed?**

This brings back our `--http-web3provider` flag as an alias, so that users who are running solely via it will not have a failure when upgrading to v3.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
