### PR TITLE
Add Back Resync Routine

### DIFF
--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -178,6 +178,7 @@ func (s *Service) Start() {
 	s.processPendingBlocksQueue()
 	s.processPendingAttsQueue()
 	s.maintainPeerStatuses()
+	s.resyncIfBehind()
 
 	// Update sync metrics.
 	async.RunEvery(s.ctx, syncMetricsInterval, s.updateMetrics)


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

#11120 removed our resync routine, which is critical for the functioning of the node. If a user has their internet connection severed for a non-trivial amount of time, without this routine the beacon node will stall.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
