### PR TITLE
Bring Down Error To A Debug Log 

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -190,7 +190,7 @@ func (s *Service) writeBlockRangeToStream(ctx context.Context, startSlot, endSlo
 			continue
 		}
 		if chunkErr := s.chunkBlockWriter(stream, b); chunkErr != nil {
-			log.WithError(chunkErr).Error("Could not send a chunked response")
+			log.WithError(chunkErr).Debug("Could not send a chunked response")
 			s.writeErrorResponseToStream(responseCodeServerError, p2ptypes.ErrGeneric.Error(), stream)
 			tracing.AnnotateError(span, chunkErr)
 			return chunkErr


### PR DESCRIPTION
**What type of PR is this?**

Logging

**What does this PR do? Why is it needed?**

In the event, we can't send a response successfully we will mark it as a debug log rather than an error. This is to prevent making our default logs as too noisy.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
