### PR TITLE
Simplify List Attestations RPC Method

### DIFF
--- a/beacon-chain/rpc/eth/beacon/blocks_test.go
+++ b/beacon-chain/rpc/eth/beacon/blocks_test.go
@@ -1857,8 +1857,11 @@ func TestServer_ListBlockAttestations(t *testing.T) {
 
 				v1Block, err := migration.V1Alpha1ToV1SignedBlock(tt.want)
 				require.NoError(t, err)
-
-				if !reflect.DeepEqual(blk.Data, v1Block.Block.Body.Attestations) {
+				blkAtts := blk.Data
+				if len(blkAtts) == 0 {
+					blkAtts = nil
+				}
+				if !reflect.DeepEqual(blkAtts, v1Block.Block.Body.Attestations) {
 					t.Error("Expected attestations to equal")
 				}
 			})
@@ -1961,7 +1964,11 @@ func TestServer_ListBlockAttestations(t *testing.T) {
 				v1Block, err := migration.V1Alpha1BeaconBlockAltairToV2(tt.want.Block)
 				require.NoError(t, err)
 
-				if !reflect.DeepEqual(blk.Data, v1Block.Body.Attestations) {
+				blkAtts := blk.Data
+				if len(blkAtts) == 0 {
+					blkAtts = nil
+				}
+				if !reflect.DeepEqual(blkAtts, v1Block.Body.Attestations) {
 					t.Error("Expected attestations to equal")
 				}
 			})
@@ -2064,7 +2071,11 @@ func TestServer_ListBlockAttestations(t *testing.T) {
 				v1Block, err := migration.V1Alpha1BeaconBlockBellatrixToV2(tt.want.Block)
 				require.NoError(t, err)
 
-				if !reflect.DeepEqual(blk.Data, v1Block.Body.Attestations) {
+				blkAtts := blk.Data
+				if len(blkAtts) == 0 {
+					blkAtts = nil
+				}
+				if !reflect.DeepEqual(blkAtts, v1Block.Body.Attestations) {
 					t.Error("Expected attestations to equal")
 				}
 			})


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

This simplifies our list attestation rpc endpoint. The method has no need to know about the block version as 
attestations are supported by all block types.

**Which issues(s) does this PR fix?**

Fixes #11291 

**Other notes for review**
