### PR TITLE
Beacon API: validator registration encoding bug

### DIFF
--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -781,8 +781,8 @@ type validatorRegistrationJson struct {
 }
 
 type signedValidatorRegistrationJson struct {
-	Message   validatorRegistrationJson `json:"message"`
-	Signature string                    `json:"signature" hex:"true"`
+	Message   *validatorRegistrationJson `json:"message"`
+	Signature string                     `json:"signature" hex:"true"`
 }
 
 type signedValidatorRegistrationsRequestJson struct {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**
The Beacon API version of the register_validator has an encoding problem that is fixed in this PR. A pointer was the culprit that was creating decoding issues when external validators use prysm's beacon node. 

**Which issues(s) does this PR fix?**

Fixes #11297
