### PR TITLE
Fix setNodeAndParentValidated

### DIFF
--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -3009,7 +3009,7 @@ func TestStore_NoViableHead_Reboot_DoublyLinkedTree(t *testing.T) {
 	// The node is optimistic now.
 	optimistic, err := service.IsOptimistic(ctx)
 	require.NoError(t, err)
-	require.Equal(t, true, optimistic)
+	require.Equal(t, false, optimistic)
 	require.Equal(t, false, service.ForkChoicer().AllTipsAreInvalid())
 
 	// Check that the node's justified checkpoint does not agree with the
@@ -3233,7 +3233,7 @@ func TestStore_NoViableHead_Reboot_Protoarray(t *testing.T) {
 	// The node is optimistic now
 	optimistic, err := service.IsOptimistic(ctx)
 	require.NoError(t, err)
-	require.Equal(t, true, optimistic)
+	require.Equal(t, false, optimistic)
 	require.Equal(t, false, service.ForkChoicer().AllTipsAreInvalid())
 
 	// Check that the node's justified checkpoint does not agree with the

--- a/beacon-chain/forkchoice/doubly-linked-tree/node.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/node.go
@@ -116,10 +116,13 @@ func (n *Node) setNodeAndParentValidated(ctx context.Context) error {
 		return ctx.Err()
 	}
 
-	if !n.optimistic || n.parent == nil {
+	if !n.optimistic {
 		return nil
 	}
-
 	n.optimistic = false
+
+	if n.parent == nil {
+		return nil
+	}
 	return n.parent.setNodeAndParentValidated(ctx)
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/optimistic_sync_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/optimistic_sync_test.go
@@ -389,3 +389,14 @@ func TestSetOptimisticToInvalid_ForkAtMerge_bis(t *testing.T) {
 	})
 	require.DeepEqual(t, roots, [][32]byte{{'b'}, {'c'}, {'d'}, {'e'}})
 }
+
+func TestSetOptimisticToValid(t *testing.T) {
+	f := setup(1, 1)
+	op, err := f.IsOptimistic([32]byte{})
+	require.NoError(t, err)
+	require.Equal(t, true, op)
+	require.NoError(t, f.SetOptimisticToValid(context.Background(), [32]byte{}))
+	op, err = f.IsOptimistic([32]byte{})
+	require.NoError(t, err)
+	require.Equal(t, false, op)
+}


### PR DESCRIPTION
In doubly linked tree we never mark the finalized node as valid. 