### PR TITLE
WIP Experimental Improvement to Fee Recipient UX

### DIFF
--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -169,7 +169,9 @@ func configureExecutionSetting(cliCtx *cli.Context) error {
 	}
 
 	if !cliCtx.IsSet(flags.SuggestedFeeRecipient.Name) {
-		return nil
+		return errors.New("In order to receive transaction fees from proposing blocks, " +
+			"you must provide flag --" + flags.SuggestedFeeRecipient.Name + " with a valid ethereum address to start your beacon node." +
+			"Please see our documentation for more information on this requirement (https://docs.prylabs.network/docs/execution-node/fee-recipient).")
 	}
 
 	c := params.BeaconConfig().Copy()

--- a/validator/accounts/testing/mock.go
+++ b/validator/accounts/testing/mock.go
@@ -179,6 +179,11 @@ func (_ MockValidator) CheckDoppelGanger(_ context.Context) error {
 }
 
 // PushProposerSettings for mocking
+func (_ MockValidator) HasProposerSettings() bool {
+	panic("implement me")
+}
+
+// PushProposerSettings for mocking
 func (_ MockValidator) PushProposerSettings(_ context.Context, _ keymanager.IKeymanager) error {
 	panic("implement me")
 }

--- a/validator/client/iface/validator.go
+++ b/validator/client/iface/validator.go
@@ -60,6 +60,7 @@ type Validator interface {
 	ReceiveBlocks(ctx context.Context, connectionErrorChannel chan<- error)
 	HandleKeyReload(ctx context.Context, newKeys [][fieldparams.BLSPubkeyLength]byte) (bool, error)
 	CheckDoppelGanger(ctx context.Context) error
+	HasProposerSettings() bool
 	PushProposerSettings(ctx context.Context, km keymanager.IKeymanager) error
 	SignValidatorRegistrationRequest(ctx context.Context, signer SigningFunc, newValidatorRegistration *ethpb.ValidatorRegistrationV1) (*ethpb.SignedValidatorRegistrationV1, error)
 }

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -247,6 +247,11 @@ func (fv *FakeValidator) HandleKeyReload(_ context.Context, newKeys [][fieldpara
 func (_ *FakeValidator) SubmitSignedContributionAndProof(_ context.Context, _ types.Slot, _ [fieldparams.BLSPubkeyLength]byte) {
 }
 
+//HasProposerSettings for mocking
+func (_ *FakeValidator) HasProposerSettings() bool {
+	return true
+}
+
 // PushProposerSettings for mocking
 func (fv *FakeValidator) PushProposerSettings(_ context.Context, _ keymanager.IKeymanager) error {
 	if fv.ProposerSettingsErr != nil {

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -1807,26 +1807,6 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 			},
 		},
 		{
-			name: " Skip if no config",
-			validatorSetter: func(t *testing.T) *validator {
-
-				v := validator{
-					validatorClient:              client,
-					db:                           db,
-					pubkeyToValidatorIndex:       make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-					signedValidatorRegistrations: make(map[[fieldparams.BLSPubkeyLength]byte]*ethpb.SignedValidatorRegistrationV1),
-					useWeb:                       false,
-					interopKeysConfig: &local.InteropKeymanagerConfig{
-						NumValidatorKeys: 1,
-						Offset:           1,
-					},
-				}
-				err := v.WaitForKeymanagerInitialization(ctx)
-				require.NoError(t, err)
-				return &v
-			},
-		},
-		{
 			name: " proposer config not nil but fee recipient empty",
 			validatorSetter: func(t *testing.T) *validator {
 
@@ -1907,26 +1887,6 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 						FeeRecipient: common.HexToAddress(defaultFeeHex),
 					},
 				}
-				return &v
-			},
-		},
-		{
-			name: "Before Bellatrix returns nil",
-			validatorSetter: func(t *testing.T) *validator {
-				v := validator{
-					validatorClient:              client,
-					db:                           db,
-					pubkeyToValidatorIndex:       make(map[[fieldparams.BLSPubkeyLength]byte]types.ValidatorIndex),
-					signedValidatorRegistrations: make(map[[fieldparams.BLSPubkeyLength]byte]*ethpb.SignedValidatorRegistrationV1),
-					useWeb:                       false,
-					interopKeysConfig: &local.InteropKeymanagerConfig{
-						NumValidatorKeys: 1,
-						Offset:           1,
-					},
-				}
-				err := v.WaitForKeymanagerInitialization(ctx)
-				require.NoError(t, err)
-				params.BeaconConfig().BellatrixForkEpoch = 123456789
 				return &v
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Experimental UX improvements for fee recipient / validator registry. currently, the proposer settings update is required from the validator client either through flags `--suggested-fee-recipient` or `--proposer-settings-file` or url. this is a redundant experience for users who have set the suggested-fee-recipient on the beacon node and would like to not have to specify this again on the validator client. This pr looks to address this in the following way

1. don't periodically call the push proposer settings function 
2. don't write warning logs when flags are not provided on validator client
3. remove the restriction on starting validator client without a fee recipient
4. add restriction to beacon node that it must specify a suggested-fee-recipient

note: extra UX improvements
- changing validator index not found logs to only be debug logs


