### PR TITLE
proof of concept for building all go_binary in cmd

### DIFF
--- a/hack/generate-release.sh
+++ b/hack/generate-release.sh
@@ -1,0 +1,36 @@
+#! /usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+BUILDKITE_TAG=$(git rev-parse --verify HEAD)
+OUTDIR=/tmp/$BUILDKITE_TAG
+mkdir -p $OUTDIR
+
+declare -a configs=("--config=linux_amd64 --config=llvm" "--config=release --config=linux_amd64 --define=blst_modern=true" "--config=release --config=linux_amd64 --define=blst_modern=true" "--config=osx_amd64_docker" "--config=osx_arm64_docker" "--config=windows_amd64_docker")
+declare -a targetsuffix=("$BUILDKITE_TAG-linux-amd64" "$BUILDKITE_TAG-modern-linux-amd64" "$BUILDKITE_TAG-linux-arm64" "$BUILDKITE_TAG-darwin-amd64" "$BUILDKITE_TAG-darwin-arm64" "$BUILDKITE_TAG-windows-amd64.exe")
+
+bazel query 'kind(rule, //cmd/...:*)' --output label_kind --logging=0 2>/dev/null | grep go_binary | tr -s ' ' | cut -d' ' -f3 | while read target ; do
+	for i in "${!configs[@]}"
+	do
+		bname=$(echo $target | cut -d':' -f2)
+		cfg="${configs[$i]}"
+		suff="${targetsuffix[$i]}"
+		echo "bazel build --config=release $cfg $target"
+		output=$(bazel cquery $target  --output starlark --starlark:file=tools/cquery/format-out/output.cquery 2>/dev/null)
+		fname=$OUTDIR/$bname-$suff
+		echo "cp $output $fname"
+		pushd $OUTDIR > /dev/null
+			echo "sha256sum $fname > $fname.sha256"
+			echo "gpg -o $fname.sig --sign --detach-sig $fname"
+		popd > /dev/null
+		echo "$SCRIPT_DIR/../hack/upload-github-release-asset.sh github_api_token=$TOKEN owner=prysmaticlabs repo=prysm tag=$BUILDKITE_TAG filename=$fname"
+	done
+done
+echo "gsutil -m cp -a public-read /tmp/validator-$BUILDKITE_TAG-* gs://prysmaticlabs.com/releases/"
+echo "gsutil -m cp -a public-read /tmp/beacon-chain-$BUILDKITE_TAG-* gs://prysmaticlabs.com/releases/"
+echo "gsutil -m cp -a public-read /tmp/client-stats-$BUILDKITE_TAG-* gs://prysmaticlabs.com/releases/"
+echo $BUILDKITE_TAG > /tmp/latest
+echo "gsutil -h "Cache-Control:no-cache,max-age=0" -h "Content-Type:text/html;charset=UTF-8" cp -a public-read /tmp/latest gs://prysmaticlabs.com/releases/latest"
+echo "gsutil -m acl ch -u AllUsers:R gs://prysmaticlabs.com/releases/*"
+echo "./hack/tag-versioned-docker-images.sh "
+echo "./hack/tag-versioned-docker-images.sh -s"
+

--- a/tools/cquery/format-out/output.cquery
+++ b/tools/cquery/format-out/output.cquery
@@ -1,0 +1,5 @@
+# via https://stackoverflow.com/questions/52729104/how-do-i-get-output-files-for-a-given-bazel-target
+def format(target):
+  outputs = target.files.to_list()
+  return outputs[0].path if len(outputs) > 0 else "(missing)"
+


### PR DESCRIPTION
**What type of PR is this?**
proof of concept / draft

Feature

**What does this PR do? Why is it needed?**

bash script using bazel to query for go_binary targets in cmd to build and release. This ensures that new binaries are automatically included in releases without additional changes to release scripts.

**Other notes for review**
this script is generating another script since this is a sensitive op it's good to have a copy of the script around to look at later, or to break it into a 2 step process with human in the middle. we could add the ability to write the generated script to disk and exec it at the end.
note that this doesn't handle the `modern` target which we only build for beacon-chain. could be added as a special case.
this isn't intended to be merged, just throwing it out there for @prestonvanloon to think about.