### PR TITLE
Better chain start log

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -244,7 +244,7 @@ func (v *validator) WaitForChainStart(ctx context.Context) error {
 		)
 	}
 
-	log.Info("Waiting for beacon chain start log from the ETH 1.0 deposit contract")
+	log.Info("Syncing with beacon node to align on chain genesis info")
 	chainStartRes, err := stream.Recv()
 	if err != io.EOF {
 		if ctx.Err() == context.Canceled {


### PR DESCRIPTION
It seems a bit odd to always log `Waiting for beacon chain start log from ETH 1.0 deposit contract...` these days. I thought about removing it, but I think it's still useful to know which startup stage validator client is in. I think `Syncing with beacon node to align on chain genesis info` may be a better one.