### PR TITLE
Only check keys on epoch boundary

### DIFF
--- a/validator/client/wait_for_activation_test.go
+++ b/validator/client/wait_for_activation_test.go
@@ -448,7 +448,7 @@ func TestWaitForActivation_RemoteKeymanager_NotStatEpoch(t *testing.T) {
 	}()
 
 	err := v.waitForActivation(ctx, nil /* accountsChangedChan */)
-	require.ErrorContains(t, "context error, not waiting for activation anymore: context canceled", err)
+	require.ErrorContains(t, "context canceled, not waiting for activation anymore", err)
 	assert.LogsDoNotContain(t, hook, "Waiting for deposit to be observed by beacon node")
 	assert.LogsDoNotContain(t, hook, "Validator activated")
 
@@ -526,7 +526,7 @@ func TestWaitForActivation_RemoteKeymanager(t *testing.T) {
 		}()
 
 		err := v.waitForActivation(ctx, nil /* accountsChangedChan */)
-		assert.ErrorContains(t, "context canceled, not waiting for activation anymore", err)
+		assert.ErrorContains(t, "context error, not waiting for activation anymore", err)
 	})
 	t.Run("reloaded", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
If your beacon node services validators and one of the validator keys is `not_activated`. ~6% of your run time is just serving RPC call `list_validators`

![](https://cdn.discordapp.com/attachments/774005284188323870/1013244948176453642/Screen_Shot_2022-08-27_at_5.32.29_PM.png)

As it turns out, checking it once per epoch is more than fine. Validators don't get activated and new assignments on a per slot basis, rather than per epoch basis. 
![](https://cdn.discordapp.com/attachments/774005284188323870/1013245135749906552/Screen_Shot_2022-08-27_at_5.02.49_PM.png)

I prefer to get this in after the merge but feel free to take a look now and give me feedbacks!
