### PR TITLE
Fix can propose blind block

### DIFF
--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -150,17 +150,19 @@ func (v *validator) ProposeBlock(ctx context.Context, slot types.Slot, pubKey [f
 			log.WithError(err).Error("Failed to get execution payload")
 			return
 		}
-		txs, err := p.Transactions()
-		if err != nil {
-			log.WithError(err).Error("Failed to get execution payload transactions")
-			return
-		}
 		log = log.WithFields(logrus.Fields{
 			"payloadHash": fmt.Sprintf("%#x", bytesutil.Trunc(p.BlockHash())),
 			"parentHash":  fmt.Sprintf("%#x", bytesutil.Trunc(p.ParentHash())),
 			"blockNumber": p.BlockNumber,
-			"txCount":     len(txs),
 		})
+		if !blk.IsBlinded() {
+			txs, err := p.Transactions()
+			if err != nil {
+				log.WithError(err).Error("Failed to get execution payload transactions")
+				return
+			}
+			log = log.WithField("txCount", len(txs))
+		}
 		if p.GasLimit() != 0 {
 			log = log.WithField("gasUtilized", float64(p.GasUsed())/float64(p.GasLimit()))
 		}

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -550,10 +550,23 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 				},
 			},
 		},
+		{
+			name: "bellatrix blind block",
+			block: &ethpb.GenericBeaconBlock{
+				Block: &ethpb.GenericBeaconBlock_BlindedBellatrix{
+					BlindedBellatrix: func() *ethpb.BlindedBeaconBlockBellatrix {
+						blk := util.NewBlindedBeaconBlockBellatrix()
+						blk.Block.Body.Graffiti = graffiti
+						return blk.Block
+					}(),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
 			validator, m, validatorKey, finish := setup(t)
 			defer finish()
 			pubKey := [fieldparams.BLSPubkeyLength]byte{}
@@ -594,6 +607,7 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 
 			validator.ProposeBlock(context.Background(), 1, pubKey)
 			assert.Equal(t, string(validator.graffiti), string(sentBlock.Block().Body().Graffiti()))
+			require.LogsContain(t, hook, "Submitted new block")
 		})
 	}
 }


### PR DESCRIPTION
Fixes a regression from #11159. All the blind block proposal currently fails on validator client due to: 
```
[2022-08-29 11:13:37] ERROR validator: Failed to get execution payload transactions error=unsupported getter pubKey=0xb104bed4f7cb
```
If the block is blind, we should skip logging txs count.