### PR TITLE
Log corerct header value

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
@@ -78,6 +78,7 @@ go_library(
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
+        "@com_github_ethereum_go_ethereum//params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
@@ -78,7 +78,6 @@ go_library(
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
-        "@com_github_ethereum_go_ethereum//params:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -441,7 +441,7 @@ func (vs *Server) validatorRegistered(ctx context.Context, id types.ValidatorInd
 func (vs *Server) validateBuilderSignature(bid *ethpb.SignedBuilderBid) error {
 	d, err := signing.ComputeDomain(params.BeaconConfig().DomainApplicationBuilder,
 		nil, /* fork version */
-		nil  /* genesis val root */)
+		nil /* genesis val root */)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -127,9 +127,8 @@ func (vs *Server) getPayloadHeaderFromBuilder(ctx context.Context, slot types.Sl
 		return nil, errors.New("builder returned nil bid")
 	}
 
-	v := bid.Message.Value
-
-	if new(big.Int).SetBytes(bytesutil.ReverseByteOrder(v)).String() == "0" {
+	v := new(big.Int).SetBytes(bytesutil.ReverseByteOrder(bid.Message.Value))
+	if v.String() == "0" {
 		return nil, errors.New("builder returned header with 0 bid amount")
 	}
 
@@ -159,7 +158,7 @@ func (vs *Server) getPayloadHeaderFromBuilder(ctx context.Context, slot types.Sl
 	}
 
 	log.WithFields(logrus.Fields{
-		"bid":           bytesutil.BytesToUint64BigEndian(bid.Message.Value),
+		"value":         v.String(),
 		"builderPubKey": fmt.Sprintf("%#x", bid.Message.Pubkey),
 		"blockHash":     fmt.Sprintf("%#x", bid.Message.Header.BlockHash),
 	}).Info("Received header with bid")
@@ -442,7 +441,7 @@ func (vs *Server) validatorRegistered(ctx context.Context, id types.ValidatorInd
 func (vs *Server) validateBuilderSignature(bid *ethpb.SignedBuilderBid) error {
 	d, err := signing.ComputeDomain(params.BeaconConfig().DomainApplicationBuilder,
 		nil, /* fork version */
-		nil /* genesis val root */)
+		nil  /* genesis val root */)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR ensures that the correct header bid value gets logged. `bytesutil.BytesToUint64BigEndian(bid.Message.Value)` was incorrect. 