### PR TITLE
Only update finalized checkpoint in DB if it's newer

### DIFF
--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -1164,6 +1164,9 @@ func Test_UpdateLastValidatedCheckpoint(t *testing.T) {
 	}
 	// Nothing should happen as we no-op on an invalid checkpoint.
 	require.NoError(t, service.updateFinalized(ctx, invalidCp))
+	got, err := service.cfg.BeaconDB.FinalizedCheckpoint(ctx)
+	require.NoError(t, err)
+	require.DeepEqual(t, oldCp, got)
 }
 
 func TestService_removeInvalidBlockAndState(t *testing.T) {

--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -1155,6 +1155,15 @@ func Test_UpdateLastValidatedCheckpoint(t *testing.T) {
 	require.Equal(t, false, optimistic)
 	require.DeepEqual(t, validCheckpoint.Root, cp.Root)
 	require.Equal(t, validCheckpoint.Epoch, cp.Epoch)
+
+	// Checkpoint with a lower epoch
+	oldCp, err := service.cfg.BeaconDB.FinalizedCheckpoint(ctx)
+	require.NoError(t, err)
+	invalidCp := &ethpb.Checkpoint{
+		Epoch: oldCp.Epoch - 1,
+	}
+	// Nothing should happen as we no-op on an invalid checkpoint.
+	require.NoError(t, service.updateFinalized(ctx, invalidCp))
 }
 
 func TestService_removeInvalidBlockAndState(t *testing.T) {

--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -33,6 +33,7 @@ func TestService_ReceiveBlock(t *testing.T) {
 		assert.NoError(t, err)
 		return blk
 	}
+	params.SetupTestConfigCleanupWithLock(t)
 
 	bc := params.BeaconConfig().Copy()
 	bc.ShardCommitteePeriod = 0 // Required for voluntary exits test in reasonable time.

--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -34,7 +34,6 @@ func TestService_ReceiveBlock(t *testing.T) {
 		return blk
 	}
 	params.SetupTestConfigCleanupWithLock(t)
-
 	bc := params.BeaconConfig().Copy()
 	bc.ShardCommitteePeriod = 0 // Required for voluntary exits test in reasonable time.
 	params.OverrideBeaconConfig(bc)

--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -33,7 +33,7 @@ func TestService_ReceiveBlock(t *testing.T) {
 		assert.NoError(t, err)
 		return blk
 	}
-	params.SetupTestConfigCleanupWithLock(t)
+
 	bc := params.BeaconConfig().Copy()
 	bc.ShardCommitteePeriod = 0 // Required for voluntary exits test in reasonable time.
 	params.OverrideBeaconConfig(bc)


### PR DESCRIPTION
Do not save to DB a finalized checkpoint that it's older than the
current one.

Fixes #11351 
Fixes #11286 