### PR TITLE
Informative Errors on Execution Client Connection Issues

### DIFF
--- a/beacon-chain/execution/rpc_connection.go
+++ b/beacon-chain/execution/rpc_connection.go
@@ -44,7 +44,7 @@ func (s *Service) setupExecutionClientConnections(ctx context.Context, currEndpo
 				"If connecting to your execution client via HTTP, you will need to set up JWT authentication. " +
 				"See our documentation here https://docs.prylabs.network/docs/execution-node/authentication"
 		}
-		return errors.Wrap(err, "could not make initial request to verify execution chain ID")
+		return errors.Wrap(err, errStr)
 	}
 	s.updateConnectedETH1(true)
 	s.runError = nil

--- a/beacon-chain/execution/rpc_connection.go
+++ b/beacon-chain/execution/rpc_connection.go
@@ -38,6 +38,12 @@ func (s *Service) setupExecutionClientConnections(ctx context.Context, currEndpo
 	// Ensure we have the correct chain and deposit IDs.
 	if err := ensureCorrectExecutionChain(ctx, fetcher); err != nil {
 		client.Close()
+		errStr := err.Error()
+		if strings.Contains(errStr, "401 Unauthorized") {
+			errStr = "could not verify execution chain ID as your connection is not authenticated. " +
+				"If connecting to your execution client via HTTP, you will need to set up JWT authentication. " +
+				"See our documentation here https://docs.prylabs.network/docs/execution-node/authentication"
+		}
 		return errors.Wrap(err, "could not make initial request to verify execution chain ID")
 	}
 	s.updateConnectedETH1(true)

--- a/beacon-chain/execution/service_test.go
+++ b/beacon-chain/execution/service_test.go
@@ -146,7 +146,7 @@ func TestStart_OK(t *testing.T) {
 		WithDepositContractAddress(testAcc.ContractAddr),
 		WithDatabase(beaconDB),
 	)
-	require.NoError(t, err, "unable to setup web3 ETH1.0 chain service")
+	require.NoError(t, err, "unable to setup execution service")
 	web3Service = setDefaultMocks(web3Service)
 	web3Service.rpcClient = &mockExecution.RPCClient{Backend: testAcc.Backend}
 	web3Service.depositContractCaller, err = contracts.NewDepositContractCaller(testAcc.ContractAddr, testAcc.Backend)
@@ -156,7 +156,7 @@ func TestStart_OK(t *testing.T) {
 	web3Service.Start()
 	if len(hook.Entries) > 0 {
 		msg := hook.LastEntry().Message
-		want := "Could not connect to ETH1.0 chain RPC client"
+		want := "Could not connect to execution endpoint"
 		if strings.Contains(want, msg) {
 			t.Errorf("incorrect log, expected %s, got %s", want, msg)
 		}


### PR DESCRIPTION
This PR adds informative errors in case a user runs into the following scenarios:

1. Not authenticating their HTTP connection to their execution client with a JWT token, which will return 401 unauthorized errors upon checking the chain ID of the execution client via JSON-RPC
2. Not connecting to their execution client on the engine port, which will lead to "not found" errors when connecting via the usual JSON-RPC at 8545

Tested in interop mode and is a lot friendlier now than it was before.