### PR TITLE
giving commands more clear names per issue #11287

### DIFF
--- a/cmd/prysmctl/BUILD.bazel
+++ b/cmd/prysmctl/BUILD.bazel
@@ -11,9 +11,11 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v3/cmd/prysmctl",
     visibility = ["//visibility:private"],
     deps = [
-        "//cmd/prysmctl/checkpoint:go_default_library",
+        "//cmd/prysmctl/checkpointsync:go_default_library",
+        "//cmd/prysmctl/deprecated:go_default_library",
         "//cmd/prysmctl/p2p:go_default_library",
         "//cmd/prysmctl/testnet:go_default_library",
+        "//cmd/prysmctl/weaksubjectivity:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],

--- a/cmd/prysmctl/checkpointsync/BUILD.bazel
+++ b/cmd/prysmctl/checkpointsync/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "cmd.go",
+        "download.go",
+    ],
+    importpath = "github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/checkpointsync",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//api/client/beacon:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_urfave_cli_v2//:go_default_library",
+    ],
+)

--- a/cmd/prysmctl/checkpointsync/cmd.go
+++ b/cmd/prysmctl/checkpointsync/cmd.go
@@ -1,0 +1,14 @@
+package checkpointsync
+
+import "github.com/urfave/cli/v2"
+
+var Commands = []*cli.Command{
+	{
+		Name:    "checkpoint-sync",
+		Aliases: []string{"cpt-sync"},
+		Usage:   "commands for managing checkpoint sync",
+		Subcommands: []*cli.Command{
+			downloadCmd,
+		},
+	},
+}

--- a/cmd/prysmctl/checkpointsync/download.go
+++ b/cmd/prysmctl/checkpointsync/download.go
@@ -1,4 +1,4 @@
-package checkpoint
+package checkpointsync
 
 import (
 	"context"
@@ -10,37 +10,38 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var saveFlags = struct {
+var downloadFlags = struct {
 	BeaconNodeHost string
 	Timeout        time.Duration
 }{}
 
-var saveCmd = &cli.Command{
-	Name:   "save",
-	Usage:  "Save the latest finalized header and the most recent block it integrates. To be used for checkpoint sync.",
-	Action: cliActionSave,
+var downloadCmd = &cli.Command{
+	Name:    "download",
+	Aliases: []string{"dl"},
+	Usage:   "Download the latest finalized state and the most recent block it integrates. To be used for checkpoint sync.",
+	Action:  cliActionDownload,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:        "beacon-node-host",
 			Usage:       "host:port for beacon node connection",
-			Destination: &saveFlags.BeaconNodeHost,
+			Destination: &downloadFlags.BeaconNodeHost,
 			Value:       "localhost:3500",
 		},
 		&cli.DurationFlag{
 			Name:        "http-timeout",
 			Usage:       "timeout for http requests made to beacon-node-url (uses duration format, ex: 2m31s). default: 4m",
-			Destination: &saveFlags.Timeout,
+			Destination: &downloadFlags.Timeout,
 			Value:       time.Minute * 4,
 		},
 	},
 }
 
-func cliActionSave(_ *cli.Context) error {
+func cliActionDownload(_ *cli.Context) error {
 	ctx := context.Background()
-	f := saveFlags
+	f := downloadFlags
 
 	opts := []beacon.ClientOpt{beacon.WithTimeout(f.Timeout)}
-	client, err := beacon.NewClient(saveFlags.BeaconNodeHost, opts...)
+	client, err := beacon.NewClient(downloadFlags.BeaconNodeHost, opts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/prysmctl/deprecated/BUILD.bazel
+++ b/cmd/prysmctl/deprecated/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cmd.go"],
+    importpath = "github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/deprecated",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/prysmctl/deprecated/checkpoint:go_default_library",
+        "@com_github_urfave_cli_v2//:go_default_library",
+    ],
+)

--- a/cmd/prysmctl/deprecated/checkpoint/BUILD.bazel
+++ b/cmd/prysmctl/deprecated/checkpoint/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "checkpoint.go",
+        "latest.go",
+        "save.go",
+    ],
+    importpath = "github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/deprecated/checkpoint",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_urfave_cli_v2//:go_default_library"],
+)

--- a/cmd/prysmctl/deprecated/checkpoint/checkpoint.go
+++ b/cmd/prysmctl/deprecated/checkpoint/checkpoint.go
@@ -8,7 +8,7 @@ var Commands = []*cli.Command{
 		Aliases: []string{"cpt"},
 		Usage:   "commands for managing checkpoint syncing",
 		Subcommands: []*cli.Command{
-			latestCmd,
+			checkpointCmd,
 			saveCmd,
 		},
 	},

--- a/cmd/prysmctl/deprecated/checkpoint/latest.go
+++ b/cmd/prysmctl/deprecated/checkpoint/latest.go
@@ -1,0 +1,17 @@
+package checkpoint
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+var checkpointCmd = &cli.Command{
+	Name:   "latest",
+	Usage:  "deprecated - please use 'prysmctl weak-subjectivity checkpoint' instead!",
+	Action: cliDeprecatedLatest,
+}
+
+func cliDeprecatedLatest(_ *cli.Context) error {
+	return fmt.Errorf("This command has moved. Please use 'prysmctl weak-subjectivity checkpoint' instead!")
+}

--- a/cmd/prysmctl/deprecated/checkpoint/save.go
+++ b/cmd/prysmctl/deprecated/checkpoint/save.go
@@ -1,0 +1,17 @@
+package checkpoint
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+var saveCmd = &cli.Command{
+	Name:   "save",
+	Usage:  "deprecated - please use 'prysmctl checkpoint-sync download' instead!",
+	Action: cliActionDeprecatedSave,
+}
+
+func cliActionDeprecatedSave(_ *cli.Context) error {
+	return fmt.Errorf("This command has moved. Please use 'prysmctl checkpoint-sync download' instead!")
+}

--- a/cmd/prysmctl/deprecated/cmd.go
+++ b/cmd/prysmctl/deprecated/cmd.go
@@ -1,0 +1,12 @@
+package deprecated
+
+import (
+	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/deprecated/checkpoint"
+	"github.com/urfave/cli/v2"
+)
+
+var Commands = []*cli.Command{}
+
+func init() {
+	Commands = append(Commands, checkpoint.Commands...)
+}

--- a/cmd/prysmctl/main.go
+++ b/cmd/prysmctl/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"os"
 
-	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/checkpoint"
+	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/checkpointsync"
+	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/deprecated"
 	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/p2p"
 	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/testnet"
+	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/weaksubjectivity"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -23,7 +25,12 @@ func main() {
 }
 
 func init() {
-	prysmctlCommands = append(prysmctlCommands, checkpoint.Commands...)
-	prysmctlCommands = append(prysmctlCommands, testnet.Commands...)
+	// contains the old checkpoint sync subcommands. these commands should display help/warn messages
+	// pointing to their new locations
+	prysmctlCommands = append(prysmctlCommands, deprecated.Commands...)
+
+	prysmctlCommands = append(prysmctlCommands, checkpointsync.Commands...)
 	prysmctlCommands = append(prysmctlCommands, p2p.Commands...)
+	prysmctlCommands = append(prysmctlCommands, testnet.Commands...)
+	prysmctlCommands = append(prysmctlCommands, weaksubjectivity.Commands...)
 }

--- a/cmd/prysmctl/weaksubjectivity/BUILD.bazel
+++ b/cmd/prysmctl/weaksubjectivity/BUILD.bazel
@@ -4,14 +4,12 @@ go_library(
     name = "go_default_library",
     srcs = [
         "checkpoint.go",
-        "latest.go",
-        "save.go",
+        "cmd.go",
     ],
-    importpath = "github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/checkpoint",
+    importpath = "github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/weaksubjectivity",
     visibility = ["//visibility:public"],
     deps = [
         "//api/client/beacon:go_default_library",
-        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],
 )

--- a/cmd/prysmctl/weaksubjectivity/checkpoint.go
+++ b/cmd/prysmctl/weaksubjectivity/checkpoint.go
@@ -1,4 +1,4 @@
-package checkpoint
+package weaksubjectivity
 
 import (
 	"context"
@@ -9,37 +9,38 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var latestFlags = struct {
+var checkpointFlags = struct {
 	BeaconNodeHost string
 	Timeout        time.Duration
 }{}
 
-var latestCmd = &cli.Command{
-	Name:   "latest",
-	Usage:  "Compute the latest weak subjectivity checkpoint (block_root:epoch) using trusted server data.",
-	Action: cliActionLatest,
+var checkpointCmd = &cli.Command{
+	Name:    "checkpoint",
+	Aliases: []string{"cpt"},
+	Usage:   "Compute the latest weak subjectivity checkpoint (block_root:epoch) using trusted server data.",
+	Action:  cliActionCheckpoint,
 	Flags: []cli.Flag{
 		&cli.StringFlag{
 			Name:        "beacon-node-host",
 			Usage:       "host:port for beacon node to query",
-			Destination: &latestFlags.BeaconNodeHost,
+			Destination: &checkpointFlags.BeaconNodeHost,
 			Value:       "http://localhost:3500",
 		},
 		&cli.DurationFlag{
 			Name:        "http-timeout",
 			Usage:       "timeout for http requests made to beacon-node-url (uses duration format, ex: 2m31s). default: 2m",
-			Destination: &latestFlags.Timeout,
+			Destination: &checkpointFlags.Timeout,
 			Value:       time.Minute * 2,
 		},
 	},
 }
 
-func cliActionLatest(_ *cli.Context) error {
+func cliActionCheckpoint(_ *cli.Context) error {
 	ctx := context.Background()
-	f := latestFlags
+	f := checkpointFlags
 
 	opts := []beacon.ClientOpt{beacon.WithTimeout(f.Timeout)}
-	client, err := beacon.NewClient(latestFlags.BeaconNodeHost, opts...)
+	client, err := beacon.NewClient(checkpointFlags.BeaconNodeHost, opts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/prysmctl/weaksubjectivity/cmd.go
+++ b/cmd/prysmctl/weaksubjectivity/cmd.go
@@ -1,0 +1,14 @@
+package weaksubjectivity
+
+import "github.com/urfave/cli/v2"
+
+var Commands = []*cli.Command{
+	{
+		Name:    "weak-subjectivity",
+		Aliases: []string{"ws"},
+		Usage:   "commands dealing with weak subjectivity",
+		Subcommands: []*cli.Command{
+			checkpointCmd,
+		},
+	},
+}


### PR DESCRIPTION
**What type of PR is this?**

Documentation

**What does this PR do? Why is it needed?**

Our subcommands for checkpoint sync and weak subjectivity checkpoint are confusingly colocated under the same command (`checkpoint`). This PR attempts to pick more intuitive names with clearer distinctions.

**Which issues(s) does this PR fix?**

Fixes #11287