### PR TITLE
less ominous --weak-subjectivity-checkpoint warning

### DIFF
--- a/beacon-chain/blockchain/weak_subjectivity_checks.go
+++ b/beacon-chain/blockchain/weak_subjectivity_checks.go
@@ -30,7 +30,7 @@ type WeakSubjectivityVerifier struct {
 // NewWeakSubjectivityVerifier validates a checkpoint, and if valid, uses it to initialize a weak subjectivity verifier.
 func NewWeakSubjectivityVerifier(wsc *ethpb.Checkpoint, db weakSubjectivityDB) (*WeakSubjectivityVerifier, error) {
 	if wsc == nil || len(wsc.Root) == 0 || wsc.Epoch == 0 {
-		log.Info("--weak-subjectivity-checkpoint not provided")
+		log.Debug("--weak-subjectivity-checkpoint not provided")
 		return &WeakSubjectivityVerifier{
 			enabled: false,
 		}, nil

--- a/beacon-chain/blockchain/weak_subjectivity_checks.go
+++ b/beacon-chain/blockchain/weak_subjectivity_checks.go
@@ -30,8 +30,7 @@ type WeakSubjectivityVerifier struct {
 // NewWeakSubjectivityVerifier validates a checkpoint, and if valid, uses it to initialize a weak subjectivity verifier.
 func NewWeakSubjectivityVerifier(wsc *ethpb.Checkpoint, db weakSubjectivityDB) (*WeakSubjectivityVerifier, error) {
 	if wsc == nil || len(wsc.Root) == 0 || wsc.Epoch == 0 {
-		log.Info("--weak-subjectivity-checkpoint not provided. Prysm recommends providing a weak subjectivity checkpoint " +
-			"for nodes synced from genesis, or manual verification of block and state roots for checkpoint sync nodes.")
+		log.Info("--weak-subjectivity-checkpoint not provided")
 		return &WeakSubjectivityVerifier{
 			enabled: false,
 		}, nil


### PR DESCRIPTION
**What type of PR is this?**

Documentation

**What does this PR do? Why is it needed?**

Dials back the severity of the warning when no weak subjectivity checkpoint is provided.

**Which issues(s) does this PR fix?**

Fixes #11361