### PR TITLE
Improve Validator Index RPC Error Handling

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -123,6 +123,9 @@ func (vs *Server) ValidatorIndex(ctx context.Context, req *ethpb.ValidatorIndexR
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not determine head state: %v", err)
 	}
+	if st == nil {
+		return nil, status.Errorf(codes.Internal, "head state is emtpy")
+	}
 	index, ok := st.ValidatorIndexByPubkey(bytesutil.ToBytes48(req.PublicKey))
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "Could not find validator index for public key %#x", req.PublicKey)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server.go
@@ -123,8 +123,8 @@ func (vs *Server) ValidatorIndex(ctx context.Context, req *ethpb.ValidatorIndexR
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not determine head state: %v", err)
 	}
-	if st == nil {
-		return nil, status.Errorf(codes.Internal, "head state is emtpy")
+	if st == nil || st.IsNil() {
+		return nil, status.Errorf(codes.Internal, "head state is empty")
 	}
 	index, ok := st.ValidatorIndexByPubkey(bytesutil.ToBytes48(req.PublicKey))
 	if !ok {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server_test.go
@@ -49,7 +49,6 @@ func TestValidatorIndex_OK(t *testing.T) {
 }
 
 func TestValidatorIndex_StateEmpty(t *testing.T) {
-
 	Server := &Server{
 		HeadFetcher: &mockChain.ChainService{},
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/server_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/server_test.go
@@ -48,6 +48,19 @@ func TestValidatorIndex_OK(t *testing.T) {
 	assert.NoError(t, err, "Could not get validator index")
 }
 
+func TestValidatorIndex_StateEmpty(t *testing.T) {
+
+	Server := &Server{
+		HeadFetcher: &mockChain.ChainService{},
+	}
+	pubKey := pubKey(1)
+	req := &ethpb.ValidatorIndexRequest{
+		PublicKey: pubKey,
+	}
+	_, err := Server.ValidatorIndex(context.Background(), req)
+	assert.ErrorContains(t, "head state is empty", err)
+}
+
 func TestWaitForActivation_ContextClosed(t *testing.T) {
 	beaconState, err := v1.InitializeFromProto(&ethpb.BeaconState{
 		Slot:       0,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

if not connected validator index causes a panic instead of just not being found.
This is caused when the beacon node is not connected to the execution client/not synced causing the head to return as nil but not failing. 

