### PR TITLE
Replace `BeaconBlockIsNil()` with `IsNil()`

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -196,8 +196,8 @@ func (s *Service) notifyNewPayload(ctx context.Context, postStateVersion int,
 	if blocks.IsPreBellatrixVersion(postStateVersion) {
 		return true, nil
 	}
-	if err := consensusblocks.BeaconBlockIsNil(blk); err != nil {
-		return false, err
+	if blk.IsNil() {
+		return false, consensusblocks.ErrNilSignedBeaconBlock
 	}
 	body := blk.Block().Body()
 	enabled, err := blocks.IsExecutionEnabledUsingHeader(postStateHeader, body)

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -75,8 +75,8 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 	if newHeadRoot == oldHeadRoot {
 		return nil
 	}
-	if err := blocks.BeaconBlockIsNil(headBlock); err != nil {
-		return err
+	if headBlock.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 	if headState == nil || headState.IsNil() {
 		return errors.New("cannot save nil head state")
@@ -164,8 +164,8 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 // root in DB. With the inception of initial-sync-cache-state flag, it uses finalized
 // check point as anchors to resume sync therefore head is no longer needed to be saved on per slot basis.
 func (s *Service) saveHeadNoDB(ctx context.Context, b interfaces.SignedBeaconBlock, r [32]byte, hs state.BeaconState) error {
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return err
+	if b.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 	cachedHeadRoot, err := s.HeadRoot(ctx)
 	if err != nil {

--- a/beacon-chain/blockchain/init_sync_process_block.go
+++ b/beacon-chain/blockchain/init_sync_process_block.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
 )
 
@@ -56,7 +55,7 @@ func (s *Service) getBlock(ctx context.Context, r [32]byte) (interfaces.SignedBe
 			return nil, errors.Wrap(err, "could not retrieve block from db")
 		}
 	}
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
+	if b.IsNil() {
 		return nil, errBlockNotFoundInCacheOrDB
 	}
 	return b, nil

--- a/beacon-chain/blockchain/pow_block.go
+++ b/beacon-chain/blockchain/pow_block.go
@@ -37,8 +37,8 @@ import (
 //    # Check if `pow_block` is a valid terminal PoW block
 //    assert is_valid_terminal_pow_block(pow_block, pow_parent)
 func (s *Service) validateMergeBlock(ctx context.Context, b interfaces.SignedBeaconBlock) error {
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return err
+	if b.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 	payload, err := b.Block().Body().Execution()
 	if err != nil {

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -80,8 +80,8 @@ func (s *Service) verifyBeaconBlock(ctx context.Context, data *ethpb.Attestation
 	if err != nil {
 		return err
 	}
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return err
+	if b.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 	if b.Block().Slot() > data.Slot {
 		return fmt.Errorf("could not process attestation for future block, block.Slot=%d > attestation.Data.Slot=%d", b.Block().Slot(), data.Slot)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -95,8 +95,8 @@ var initialSyncBlockCacheSize = uint64(2 * params.BeaconConfig().SlotsPerEpoch)
 func (s *Service) onBlock(ctx context.Context, signed interfaces.SignedBeaconBlock, blockRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "blockChain.onBlock")
 	defer span.End()
-	if err := consensusblocks.BeaconBlockIsNil(signed); err != nil {
-		return invalidBlock{error: err}
+	if signed.IsNil() {
+		return invalidBlock{error: consensusblocks.ErrNilSignedBeaconBlock}
 	}
 	b := signed.Block()
 
@@ -296,8 +296,8 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.SignedBeac
 		return errWrongBlockCount
 	}
 
-	if err := consensusblocks.BeaconBlockIsNil(blks[0]); err != nil {
-		return invalidBlock{error: err}
+	if blks[0].IsNil() {
+		return invalidBlock{error: consensusblocks.ErrNilSignedBeaconBlock}
 	}
 	b := blks[0].Block()
 

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -276,8 +276,8 @@ func (s *Service) originRootFromSavedState(ctx context.Context) ([32]byte, error
 	if err != nil {
 		return originRoot, errors.Wrap(err, "could not get genesis block from db")
 	}
-	if err := blocks.BeaconBlockIsNil(genesisBlock); err != nil {
-		return originRoot, err
+	if genesisBlock.IsNil() {
+		return originRoot, blocks.ErrNilSignedBeaconBlock
 	}
 	genesisBlkRoot, err := genesisBlock.Block().HashTreeRoot()
 	if err != nil {

--- a/beacon-chain/core/altair/attestation.go
+++ b/beacon-chain/core/altair/attestation.go
@@ -26,8 +26,8 @@ func ProcessAttestationsNoVerifySignature(
 	beaconState state.BeaconState,
 	b interfaces.SignedBeaconBlock,
 ) (state.BeaconState, error) {
-	if err := consensusblocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+	if b.IsNil() {
+		return nil, consensusblocks.ErrNilSignedBeaconBlock
 	}
 	body := b.Block().Body()
 	totalBalance, err := helpers.TotalActiveBalance(beaconState)

--- a/beacon-chain/core/blocks/attestation.go
+++ b/beacon-chain/core/blocks/attestation.go
@@ -26,8 +26,8 @@ func ProcessAttestationsNoVerifySignature(
 	beaconState state.BeaconState,
 	b interfaces.SignedBeaconBlock,
 ) (state.BeaconState, error) {
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+	if b.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 	body := b.Block().Body()
 	var err error

--- a/beacon-chain/core/blocks/header.go
+++ b/beacon-chain/core/blocks/header.go
@@ -44,8 +44,8 @@ func ProcessBlockHeader(
 	beaconState state.BeaconState,
 	block interfaces.SignedBeaconBlock,
 ) (state.BeaconState, error) {
-	if err := blocks.BeaconBlockIsNil(block); err != nil {
-		return nil, err
+	if block.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 	bodyRoot, err := block.Block().Body().HashTreeRoot()
 	if err != nil {

--- a/beacon-chain/core/blocks/randao.go
+++ b/beacon-chain/core/blocks/randao.go
@@ -31,8 +31,8 @@ func ProcessRandao(
 	beaconState state.BeaconState,
 	b interfaces.SignedBeaconBlock,
 ) (state.BeaconState, error) {
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+	if b.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 	body := b.Block().Body()
 	buf, proposerPub, domain, err := randaoSigningData(ctx, beaconState)

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -52,8 +52,8 @@ func ExecuteStateTransition(
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-	if err := blocks.BeaconBlockIsNil(signed); err != nil {
-		return nil, err
+	if signed.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 
 	ctx, span := trace.StartSpan(ctx, "core.state.ExecuteStateTransition")
@@ -296,8 +296,8 @@ func ProcessSlots(ctx context.Context, state state.BeaconState, slot types.Slot)
 
 // VerifyOperationLengths verifies that block operation lengths are valid.
 func VerifyOperationLengths(_ context.Context, state state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+	if b.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 	body := b.Block().Body()
 

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -160,8 +160,8 @@ func ProcessBlockNoVerifyAnySig(
 ) (*bls.SignatureBatch, state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "core.state.ProcessBlockNoVerifyAnySig")
 	defer span.End()
-	if err := blocks.BeaconBlockIsNil(signed); err != nil {
-		return nil, nil, err
+	if signed.IsNil() {
+		return nil, nil, blocks.ErrNilSignedBeaconBlock
 	}
 
 	if st.Version() != signed.Block().Version() {
@@ -223,8 +223,8 @@ func ProcessOperationsNoVerifyAttsSigs(
 	signedBeaconBlock interfaces.SignedBeaconBlock) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "core.state.ProcessOperationsNoVerifyAttsSigs")
 	defer span.End()
-	if err := blocks.BeaconBlockIsNil(signedBeaconBlock); err != nil {
-		return nil, err
+	if signedBeaconBlock.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 
 	if _, err := VerifyOperationLengths(ctx, state, signedBeaconBlock); err != nil {
@@ -269,8 +269,8 @@ func ProcessBlockForStateRoot(
 ) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "core.state.ProcessBlockForStateRoot")
 	defer span.End()
-	if err := blocks.BeaconBlockIsNil(signed); err != nil {
-		return nil, err
+	if signed.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 
 	blk := signed.Block()

--- a/beacon-chain/db/kv/backup.go
+++ b/beacon-chain/db/kv/backup.go
@@ -34,8 +34,8 @@ func (s *Store) Backup(ctx context.Context, outputDir string, permissionOverride
 	if err != nil {
 		return err
 	}
-	if err := blocks.BeaconBlockIsNil(head); err != nil {
-		return err
+	if head.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 	// Ensure the backups directory exists.
 	if err := file.HandleBackupDir(backupsDir, permissionOverride); err != nil {

--- a/beacon-chain/db/kv/finalized_block_roots.go
+++ b/beacon-chain/db/kv/finalized_block_roots.go
@@ -84,9 +84,9 @@ func (s *Store) updateFinalizedBlockRoots(ctx context.Context, tx *bolt.Tx, chec
 			tracing.AnnotateError(span, err)
 			return err
 		}
-		if err := blocks.BeaconBlockIsNil(signedBlock); err != nil {
-			tracing.AnnotateError(span, err)
-			return err
+		if signedBlock.IsNil() {
+			tracing.AnnotateError(span, blocks.ErrNilSignedBeaconBlock)
+			return blocks.ErrNilSignedBeaconBlock
 		}
 		block := signedBlock.Block()
 

--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -674,8 +674,8 @@ func (s *Store) slotByBlockRoot(ctx context.Context, tx *bolt.Tx, blockRoot []by
 		if err != nil {
 			return 0, err
 		}
-		if err := blocks.BeaconBlockIsNil(wsb); err != nil {
-			return 0, err
+		if wsb.IsNil() {
+			return 0, blocks.ErrNilSignedBeaconBlock
 		}
 		return b.Block.Slot, nil
 	}

--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -361,8 +361,8 @@ func (s *Service) ExecutionBlocksByHashes(ctx context.Context, hashes []common.H
 func (s *Service) ReconstructFullBellatrixBlock(
 	ctx context.Context, blindedBlock interfaces.SignedBeaconBlock,
 ) (interfaces.SignedBeaconBlock, error) {
-	if err := blocks.BeaconBlockIsNil(blindedBlock); err != nil {
-		return nil, errors.Wrap(err, "cannot reconstruct bellatrix block from nil data")
+	if blindedBlock.IsNil() {
+		return nil, errors.Wrap(blocks.ErrNilSignedBeaconBlock, "cannot reconstruct bellatrix block from nil data")
 	}
 	if !blindedBlock.Block().IsBlinded() {
 		return nil, errors.New("can only reconstruct block from blinded block format")
@@ -414,8 +414,8 @@ func (s *Service) ReconstructFullBellatrixBlockBatch(
 	validExecPayloads := []int{}
 	zeroExecPayloads := []int{}
 	for i, b := range blindedBlocks {
-		if err := blocks.BeaconBlockIsNil(b); err != nil {
-			return nil, errors.Wrap(err, "cannot reconstruct bellatrix block from nil data")
+		if b.IsNil() {
+			return nil, errors.Wrap(blocks.ErrNilSignedBeaconBlock, "cannot reconstruct bellatrix block from nil data")
 		}
 		if !b.Block().IsBlinded() {
 			return nil, errors.New("can only reconstruct block from blinded block format")

--- a/beacon-chain/rpc/eth/beacon/blocks.go
+++ b/beacon-chain/rpc/eth/beacon/blocks.go
@@ -650,8 +650,8 @@ func (bs *Server) GetBlockRoot(ctx context.Context, req *ethpbv1.BlockRequest) (
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not retrieve blocks for genesis slot: %v", err)
 		}
-		if err := blocks.BeaconBlockIsNil(blk); err != nil {
-			return nil, status.Errorf(codes.NotFound, "Could not find genesis block: %v", err)
+		if blk.IsNil() {
+			return nil, status.Errorf(codes.NotFound, "Could not find genesis block: %v", blocks.ErrNilSignedBeaconBlock)
 		}
 		blkRoot, err := blk.Block().HashTreeRoot()
 		if err != nil {
@@ -664,8 +664,8 @@ func (bs *Server) GetBlockRoot(ctx context.Context, req *ethpbv1.BlockRequest) (
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "Could not retrieve block for block root %#x: %v", req.BlockId, err)
 			}
-			if err := blocks.BeaconBlockIsNil(blk); err != nil {
-				return nil, status.Errorf(codes.NotFound, "Could not find block: %v", err)
+			if blk.IsNil() {
+				return nil, status.Errorf(codes.NotFound, "Could not find block: %v", blocks.ErrNilSignedBeaconBlock)
 			}
 			root = req.BlockId
 		} else {
@@ -809,8 +809,8 @@ func handleGetBlockError(blk interfaces.SignedBeaconBlock, err error) error {
 	if err != nil {
 		return status.Errorf(codes.Internal, "Could not get block from block ID: %v", err)
 	}
-	if err := blocks.BeaconBlockIsNil(blk); err != nil {
-		return status.Errorf(codes.NotFound, "Could not find requested block: %v", err)
+	if blk.IsNil() {
+		return status.Errorf(codes.NotFound, "Could not find requested block: %v", blocks.ErrNilSignedBeaconBlock)
 	}
 	return nil
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -210,8 +210,8 @@ func (vs *Server) buildBlindBlock(ctx context.Context, b *ethpb.BeaconBlockAltai
 // bellatrix blind block. The output block will contain the full payload. The original header block
 // will be returned the block builder is not configured.
 func (vs *Server) unblindBuilderBlock(ctx context.Context, b interfaces.SignedBeaconBlock) (interfaces.SignedBeaconBlock, error) {
-	if err := coreBlock.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+	if b.IsNil() {
+		return nil, coreBlock.ErrNilSignedBeaconBlock
 	}
 
 	// No-op if the input block is not version blind and bellatrix.
@@ -324,8 +324,8 @@ func (vs *Server) readyForBuilder(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if err = coreBlock.BeaconBlockIsNil(b); err != nil {
-		return false, err
+	if b.IsNil() {
+		return false, coreBlock.ErrNilSignedBeaconBlock
 	}
 	return blocks.IsExecutionBlock(b.Block().Body())
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -99,8 +99,8 @@ func (vs *Server) getExecutionPayload(ctx context.Context, slot types.Slot, vIdx
 		if err != nil {
 			return nil, err
 		}
-		if err := consensusblocks.BeaconBlockIsNil(finalizedBlock); err != nil {
-			return nil, err
+		if finalizedBlock.IsNil() {
+			return nil, consensusblocks.ErrNilSignedBeaconBlock
 		}
 		switch finalizedBlock.Version() {
 		case version.Phase0, version.Altair: // Blocks before Bellatrix don't have execution payloads. Use zeros as the hash.

--- a/beacon-chain/rpc/statefetcher/fetcher.go
+++ b/beacon-chain/rpc/statefetcher/fetcher.go
@@ -220,8 +220,8 @@ func (p *StateProvider) headStateRoot(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get head block")
 	}
-	if err = blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+	if b.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 	return b.Block().StateRoot(), nil
 }
@@ -231,8 +231,8 @@ func (p *StateProvider) genesisStateRoot(ctx context.Context) ([]byte, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get genesis block")
 	}
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+	if b.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 	return b.Block().StateRoot(), nil
 }
@@ -246,8 +246,8 @@ func (p *StateProvider) finalizedStateRoot(ctx context.Context) ([]byte, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get finalized block")
 	}
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+	if b.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 	return b.Block().StateRoot(), nil
 }
@@ -261,8 +261,8 @@ func (p *StateProvider) justifiedStateRoot(ctx context.Context) ([]byte, error) 
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get justified block")
 	}
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+	if b.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 	return b.Block().StateRoot(), nil
 }

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -227,8 +227,8 @@ func (s *State) latestAncestor(ctx context.Context, blockRoot [32]byte) (state.B
 	if err != nil {
 		return nil, err
 	}
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return nil, err
+	if b.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 
 	for {

--- a/beacon-chain/state/stategen/history.go
+++ b/beacon-chain/state/stategen/history.go
@@ -8,7 +8,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
-	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
@@ -177,7 +176,7 @@ func (c *CanonicalHistory) ancestorChain(ctx context.Context, tail interfaces.Si
 			msg := fmt.Sprintf("db error when retrieving parent of block at slot=%d by root=%#x", b.Slot(), b.ParentRoot())
 			return nil, nil, errors.Wrap(err, msg)
 		}
-		if blocks.BeaconBlockIsNil(parent) != nil {
+		if parent.IsNil() {
 			msg := fmt.Sprintf("unable to retrieve parent of block at slot=%d by root=%#x", b.Slot(), b.ParentRoot())
 			return nil, nil, errors.Wrap(db.ErrNotFound, msg)
 		}

--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -146,8 +146,8 @@ func executeStateTransitionStateGen(
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-	if err := blocks.BeaconBlockIsNil(signed); err != nil {
-		return nil, err
+	if signed.IsNil() {
+		return nil, blocks.ErrNilSignedBeaconBlock
 	}
 	ctx, span := trace.StartSpan(ctx, "stategen.executeStateTransitionStateGen")
 	defer span.End()

--- a/beacon-chain/sync/backfill/status.go
+++ b/beacon-chain/sync/backfill/status.go
@@ -81,8 +81,8 @@ func (s *Status) Reload(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving block for origin checkpoint root=%#x", cpRoot)
 	}
-	if err := blocks.BeaconBlockIsNil(cpBlock); err != nil {
-		return err
+	if cpBlock.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 	s.end = cpBlock.Block().Slot()
 
@@ -105,8 +105,8 @@ func (s *Status) Reload(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrapf(err, "error retrieving block for backfill root=%#x", bfRoot)
 	}
-	if err := blocks.BeaconBlockIsNil(bfBlock); err != nil {
-		return err
+	if bfBlock.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 	s.start = bfBlock.Block().Slot()
 	return nil

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -361,8 +361,8 @@ func (s *Service) deleteBlockFromPendingQueue(slot types.Slot, b interfaces.Sign
 	}
 
 	// Defensive check to ignore nil blocks
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return err
+	if b.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 
 	newBlks := make([]interfaces.SignedBeaconBlock, 0, len(blks))
@@ -428,8 +428,8 @@ func (s *Service) pendingBlocksInCache(slot types.Slot) []interfaces.SignedBeaco
 
 // This adds input signed beacon block to slotToPendingBlocks cache.
 func (s *Service) addPendingBlockToCache(b interfaces.SignedBeaconBlock) error {
-	if err := blocks.BeaconBlockIsNil(b); err != nil {
-		return err
+	if b.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 
 	blks := s.pendingBlocksInCache(b.Block().Slot())

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -10,7 +10,6 @@ import (
 	p2ptypes "github.com/prysmaticlabs/prysm/v3/beacon-chain/p2p/types"
 	"github.com/prysmaticlabs/prysm/v3/cmd/beacon-chain/flags"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
-	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
@@ -186,7 +185,7 @@ func (s *Service) writeBlockRangeToStream(ctx context.Context, startSlot, endSlo
 	}
 
 	for _, b := range blks {
-		if err := blocks.BeaconBlockIsNil(b); err != nil {
+		if b.IsNil() {
 			continue
 		}
 		if chunkErr := s.chunkBlockWriter(stream, b); chunkErr != nil {

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/p2p/types"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
-	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
 )
 
@@ -70,7 +69,7 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 			s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 			return err
 		}
-		if err := blocks.BeaconBlockIsNil(blk); err != nil {
+		if blk.IsNil() {
 			continue
 		}
 

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -16,8 +16,8 @@ func (s *Service) beaconBlockSubscriber(ctx context.Context, msg proto.Message) 
 	if err != nil {
 		return err
 	}
-	if err := blocks.BeaconBlockIsNil(signed); err != nil {
-		return err
+	if signed.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 
 	s.setSeenBlockIndexSlot(signed.Block().Slot(), signed.Block().ProposerIndex())

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v3/config/features"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
-	consensusblocks "github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
@@ -367,7 +366,7 @@ func isBlockQueueable(genesisTime uint64, slot types.Slot, receivedTime time.Tim
 }
 
 func getBlockFields(b interfaces.SignedBeaconBlock) logrus.Fields {
-	if consensusblocks.BeaconBlockIsNil(b) != nil {
+	if b.IsNil() {
 		return logrus.Fields{}
 	}
 	return logrus.Fields{

--- a/consensus-types/blocks/factory.go
+++ b/consensus-types/blocks/factory.go
@@ -143,8 +143,8 @@ func BuildSignedBeaconBlock(blk interfaces.BeaconBlock, signature []byte) (inter
 func BuildSignedBeaconBlockFromExecutionPayload(
 	blk interfaces.SignedBeaconBlock, payload *enginev1.ExecutionPayload,
 ) (interfaces.SignedBeaconBlock, error) {
-	if err := BeaconBlockIsNil(blk); err != nil {
-		return nil, err
+	if blk.IsNil() {
+		return nil, ErrNilSignedBeaconBlock
 	}
 	b := blk.Block()
 	payloadHeader, err := b.Body().Execution()

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -10,22 +10,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/runtime/version"
 )
 
-// BeaconBlockIsNil checks if any composite field of input signed beacon block is nil.
-// Access to these nil fields will result in run time panic,
-// it is recommended to run these checks as first line of defense.
-func BeaconBlockIsNil(b interfaces.SignedBeaconBlock) error {
-	if b == nil || b.IsNil() {
-		return ErrNilSignedBeaconBlock
-	}
-	if b.Block().IsNil() {
-		return errNilBeaconBlock
-	}
-	if b.Block().Body().IsNil() {
-		return errNilBeaconBlockBody
-	}
-	return nil
-}
-
 // Signature returns the respective block signature.
 func (b *SignedBeaconBlock) Signature() []byte {
 	return b.signature

--- a/consensus-types/blocks/getters_test.go
+++ b/consensus-types/blocks/getters_test.go
@@ -5,7 +5,6 @@ import (
 
 	ssz "github.com/prysmaticlabs/fastssz"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
-	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	eth "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	validatorpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1/validator-client"
@@ -13,31 +12,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/testing/assert"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
 )
-
-func Test_BeaconBlockIsNil(t *testing.T) {
-	t.Run("not nil", func(t *testing.T) {
-		assert.NoError(t, BeaconBlockIsNil(&SignedBeaconBlock{block: &BeaconBlock{body: &BeaconBlockBody{}}}))
-	})
-	t.Run("nil interface", func(t *testing.T) {
-		err := BeaconBlockIsNil(nil)
-		assert.NotNil(t, err)
-	})
-	t.Run("nil signed block", func(t *testing.T) {
-		var i interfaces.SignedBeaconBlock
-		var sb *SignedBeaconBlock
-		i = sb
-		err := BeaconBlockIsNil(i)
-		assert.NotNil(t, err)
-	})
-	t.Run("nil block", func(t *testing.T) {
-		err := BeaconBlockIsNil(&SignedBeaconBlock{})
-		assert.NotNil(t, err)
-	})
-	t.Run("nil block body", func(t *testing.T) {
-		err := BeaconBlockIsNil(&SignedBeaconBlock{block: &BeaconBlock{}})
-		assert.NotNil(t, err)
-	})
-}
 
 func Test_SignedBeaconBlock_Signature(t *testing.T) {
 	sb := &SignedBeaconBlock{signature: []byte("signature")}

--- a/testing/endtoend/evaluators/fork.go
+++ b/testing/endtoend/evaluators/fork.go
@@ -63,8 +63,8 @@ func altairForkOccurs(conns ...*grpc.ClientConn) error {
 	if err != nil {
 		return err
 	}
-	if err := blocks.BeaconBlockIsNil(blk); err != nil {
-		return err
+	if blk.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 	if blk.Block().Slot() < fSlot {
 		return errors.Errorf("wanted a block >= %d but received %d", fSlot, blk.Block().Slot())
@@ -108,8 +108,8 @@ func bellatrixForkOccurs(conns ...*grpc.ClientConn) error {
 	if err != nil {
 		return err
 	}
-	if err := blocks.BeaconBlockIsNil(blk); err != nil {
-		return err
+	if blk.IsNil() {
+		return blocks.ErrNilSignedBeaconBlock
 	}
 	if blk.Block().Slot() < fSlot {
 		return errors.Errorf("wanted a block >= %d but received %d", fSlot, blk.Block().Slot())


### PR DESCRIPTION

**What type of PR is this?**

Refactor

**What does this PR do? Why is it needed?**

I argue that `BeaconBlockIsNil()` is not needed.

This is the definition of `BeaconBlockIsNil()`:
```
func BeaconBlockIsNil(b interfaces.SignedBeaconBlock) error {
    if b == nil || b.IsNil() {
        return ErrNilSignedBeaconBlock
    }
    if b.Block().IsNil() {
        return ErrNilBeaconBlock
    }
    if b.Block().Body().IsNil() {
        return ErrNilBeaconBlockBody
    }
    return nil
}
```
And this is the definition of `interfaces.SignedBeaconBlock.IsNil()`:
```
func (b *SignedBeaconBlock) IsNil() bool {
	return b == nil || b.block.IsNil()
}
```
They both start with `b == nil` and then the former calls the latter. In `IsNil()`, `b.block.IsNil()` practically does the same thing as the remainder of `BeaconBlockIsNil()`. There is no need to keep this separate function.
