### PR TITLE
Feature flag to disregard deposit contract

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
         "//beacon-chain/sync:go_default_library",
+        "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/blocks:go_default_library",

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_eth1data.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_eth1data.go
@@ -8,6 +8,7 @@ import (
 	fastssz "github.com/prysmaticlabs/fastssz"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
+	"github.com/prysmaticlabs/prysm/v3/config/features"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
@@ -105,6 +106,9 @@ func (vs *Server) canonicalEth1Data(
 	} else {
 		canonicalEth1Data = beaconState.Eth1Data()
 		eth1BlockHash = bytesutil.ToBytes32(beaconState.Eth1Data().BlockHash)
+	}
+	if features.Get().DisableStakinContractCheck && eth1BlockHash == [32]byte{} {
+		return canonicalEth1Data, new(big.Int).SetInt64(0), nil
 	}
 	_, canonicalEth1DataHeight, err := vs.Eth1BlockFetcher.BlockExists(ctx, eth1BlockHash)
 	if err != nil {

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -69,6 +69,8 @@ type Flags struct {
 	EnableOnlyBlindedBeaconBlocks     bool // EnableOnlyBlindedBeaconBlocks enables only storing blinded beacon blocks in the DB post-Bellatrix fork.
 	EnableStartOptimistic             bool // EnableStartOptimistic treats every block as optimistic at startup.
 
+	DisableStakinContractCheck bool // Disables check for deposit contract when proposing blocks
+
 	// KeystoreImportDebounceInterval specifies the time duration the validator waits to reload new keys if they have
 	// changed on disk. This feature is for advanced use cases only.
 	KeystoreImportDebounceInterval time.Duration
@@ -214,7 +216,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		logEnabled(enableDefensivePull)
 		cfg.EnableDefensivePull = true
 	}
-
+	if ctx.Bool(disableStakinContractCheck.Name) {
+		logEnabled(disableStakinContractCheck)
+		cfg.DisableStakinContractCheck = true
+	}
 	if ctx.Bool(disableVecHTR.Name) {
 		logEnabled(disableVecHTR)
 	} else {

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -83,6 +83,10 @@ var (
 			"a foolproof method to find duplicate instances in the network. Your validator will still be" +
 			" vulnerable if it is being run in unsafe configurations.",
 	}
+	disableStakinContractCheck = &cli.BoolFlag{
+		Name:  "disable-staking-contract-check",
+		Usage: "Disables checking of staking contract deposits when proposing blocks, useful for devnets",
+	}
 	enableHistoricalSpaceRepresentation = &cli.BoolFlag{
 		Name: "enable-historical-state-representation",
 		Usage: "Enables the beacon chain to save historical states in a space efficient manner." +


### PR DESCRIPTION
This PR adds a feature flag to disregard the staking contract when proposing blocks. This is useful for some devnets or private networks. The feature flag is `disable-staking-contract-check` 

cc @parithosh 