### PR TITLE
Fix time to duty to round slot number

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -938,7 +938,7 @@ func (v *validator) logDuties(slot types.Slot, duties []*ethpb.DutiesResponse_Du
 	}
 	for i := types.Slot(0); i < params.BeaconConfig().SlotsPerEpoch; i++ {
 		startTime := slots.StartTime(v.genesisTime, slotOffset+i)
-		durationTillDuty := time.Until(startTime)
+		durationTillDuty := time.Until(startTime) + time.Second
 
 		if len(attesterKeys[i]) > 0 {
 			log.WithFields(logrus.Fields{


### PR DESCRIPTION
Nitpick. Time to duty is always one second off. If you have to attest at slot 1, your time to duty should be 12s, not 11s. This is only cosmetic and used in log