### PR TITLE
Simplify `BeaconBlockIsNil()`

### DIFF
--- a/consensus-types/blocks/factory.go
+++ b/consensus-types/blocks/factory.go
@@ -24,8 +24,6 @@ var (
 	ErrNilObject = errors.New("received nil object")
 	// ErrNilSignedBeaconBlock is returned when a nil signed beacon block is received.
 	ErrNilSignedBeaconBlock = errors.New("signed beacon block can't be nil")
-	errNilBeaconBlock       = errors.New("beacon block can't be nil")
-	errNilBeaconBlockBody   = errors.New("beacon block body can't be nil")
 )
 
 // NewSignedBeaconBlock creates a signed beacon block from a protobuf signed beacon block.

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -17,12 +17,6 @@ func BeaconBlockIsNil(b interfaces.SignedBeaconBlock) error {
 	if b == nil || b.IsNil() {
 		return ErrNilSignedBeaconBlock
 	}
-	if b.Block().IsNil() {
-		return errNilBeaconBlock
-	}
-	if b.Block().Body().IsNil() {
-		return errNilBeaconBlockBody
-	}
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Refactor

**What does this PR do? Why is it needed?**

We can safely remove explicit block and body nilness checks from `BeaconBlockIsNil()` because these checks are already covered inside `b.IsNil()`. After removing this code, all test cases inside `Test_SignedBeaconBlock_IsNil` stil pass.