### PR TITLE
Add in P2P Metrics for Mainnet

### DIFF
--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -246,7 +246,6 @@ func (s *Service) Start() {
 	async.RunEvery(s.ctx, 30*time.Minute, s.Peers().Prune)
 	async.RunEvery(s.ctx, params.BeaconNetworkConfig().RespTimeout, s.updateMetrics)
 	async.RunEvery(s.ctx, refreshRate, s.RefreshENR)
-	async.RunEvery(s.ctx, 10*time.Second, s.refreshPeerIdentityMetrics)
 	async.RunEvery(s.ctx, 1*time.Minute, func() {
 		log.WithFields(logrus.Fields{
 			"inbound":     len(s.peers.InboundConnected()),

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -245,9 +245,8 @@ func (s *Service) Start() {
 	})
 	async.RunEvery(s.ctx, 30*time.Minute, s.Peers().Prune)
 	async.RunEvery(s.ctx, params.BeaconNetworkConfig().RespTimeout, s.updateMetrics)
-	async.RunEvery(s.ctx, refreshRate, func() {
-		s.RefreshENR()
-	})
+	async.RunEvery(s.ctx, refreshRate, s.RefreshENR)
+	async.RunEvery(s.ctx, 10*time.Second, s.refreshPeerIdentityMetrics)
 	async.RunEvery(s.ctx, 1*time.Minute, func() {
 		log.WithFields(logrus.Fields{
 			"inbound":     len(s.peers.InboundConnected()),


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

This PR adds in avg gossip scores by client type and also adds in a gauge of connected peers by client type. Here's what this looks like on a mainnet setup.

```
connected_libp2p_peers{agent="lighthouse"} 9
connected_libp2p_peers{agent="nimbus"} 1
connected_libp2p_peers{agent="prysm"} 22
connected_libp2p_peers{agent="rust-libp2p"} 1
connected_libp2p_peers{agent="teku"} 3
# HELP connected_libp2p_peers_average_scores Tracks the overall p2p scores of connected libp2p peers by agent string
# TYPE connected_libp2p_peers_average_scores gauge
connected_libp2p_peers_average_scores{agent="lighthouse"} 0.10133333333333333
connected_libp2p_peers_average_scores{agent="nimbus"} 0
connected_libp2p_peers_average_scores{agent="prysm"} 0.11212272727272726
connected_libp2p_peers_average_scores{agent="rust-libp2p"} 0
connected_libp2p_peers_average_scores{agent="teku"} 0.0398
```

**Which issues(s) does this PR fix?**

Fixes #11367 
