### PR TITLE
Improved caching of state summaries

### DIFF
--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -563,10 +563,11 @@ func TestService_IsOptimisticForRoot_DB_ProtoArray(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, false, validated)
 
-	// Before the first finalized epoch, finalized root could be zeros.
-	validatedCheckpoint = &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
+	r, err := util.SaveBlock(t, ctx, beaconDB, util.NewBeaconBlock()).Block().HashTreeRoot()
+	require.NoError(t, err)
+	validatedCheckpoint = &ethpb.Checkpoint{Root: r[:]}
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, br))
-	require.NoError(t, beaconDB.SaveStateSummary(context.Background(), &ethpb.StateSummary{Root: params.BeaconConfig().ZeroHash[:], Slot: 10}))
+	require.NoError(t, beaconDB.SaveStateSummary(context.Background(), &ethpb.StateSummary{Root: r[:], Slot: 10}))
 	require.NoError(t, beaconDB.SaveLastValidatedCheckpoint(ctx, validatedCheckpoint))
 
 	require.NoError(t, beaconDB.SaveStateSummary(context.Background(), &ethpb.StateSummary{Root: optimisticRoot[:], Slot: 11}))
@@ -621,10 +622,11 @@ func TestService_IsOptimisticForRoot_DB_DoublyLinkedTree(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, false, validated)
 
-	// Before the first finalized epoch, finalized root could be zeros.
-	validatedCheckpoint = &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
+	r, err := util.SaveBlock(t, ctx, beaconDB, util.NewBeaconBlock()).Block().HashTreeRoot()
+	require.NoError(t, err)
+	validatedCheckpoint = &ethpb.Checkpoint{Root: r[:]}
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, br))
-	require.NoError(t, beaconDB.SaveStateSummary(context.Background(), &ethpb.StateSummary{Root: params.BeaconConfig().ZeroHash[:], Slot: 10}))
+	require.NoError(t, beaconDB.SaveStateSummary(context.Background(), &ethpb.StateSummary{Root: r[:], Slot: 10}))
 	require.NoError(t, beaconDB.SaveLastValidatedCheckpoint(ctx, validatedCheckpoint))
 
 	require.NoError(t, beaconDB.SaveStateSummary(context.Background(), &ethpb.StateSummary{Root: optimisticRoot[:], Slot: 11}))

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -530,13 +530,13 @@ func TestService_IsOptimisticForRoot_DB_ProtoArray(t *testing.T) {
 
 	optimisticBlock := util.NewBeaconBlock()
 	optimisticBlock.Block.Slot = 97
-	optimisticRoot, err := optimisticBlock.Block.HashTreeRoot()
+	optimisticRoot, err := util.SaveBlock(t, ctx, beaconDB, optimisticBlock).Block().HashTreeRoot()
 	require.NoError(t, err)
 	util.SaveBlock(t, context.Background(), beaconDB, optimisticBlock)
 
 	validatedBlock := util.NewBeaconBlock()
 	validatedBlock.Block.Slot = 9
-	validatedRoot, err := validatedBlock.Block.HashTreeRoot()
+	validatedRoot, err := util.SaveBlock(t, ctx, beaconDB, validatedBlock).Block().HashTreeRoot()
 	require.NoError(t, err)
 	util.SaveBlock(t, context.Background(), beaconDB, validatedBlock)
 

--- a/beacon-chain/blockchain/error.go
+++ b/beacon-chain/blockchain/error.go
@@ -23,6 +23,8 @@ var (
 	errNotOptimisticCandidate = errors.New("block is not suitable for optimistic sync")
 	// errBlockNotFoundInCacheOrDB is returned when a block is not found in the cache or DB.
 	errBlockNotFoundInCacheOrDB = errors.New("block not found in cache or db")
+	// errNilBlock is returned when a nil block is returned from the cache.
+	ErrNilBlockInCache = errors.New("nil block returned from the cache")
 	// errNilStateFromStategen is returned when a nil state is returned from the state generator.
 	errNilStateFromStategen = errors.New("justified state can't be nil")
 	// errWSBlockNotFound is returned when a block is not found in the WS cache or DB.

--- a/beacon-chain/blockchain/error.go
+++ b/beacon-chain/blockchain/error.go
@@ -23,7 +23,7 @@ var (
 	errNotOptimisticCandidate = errors.New("block is not suitable for optimistic sync")
 	// errBlockNotFoundInCacheOrDB is returned when a block is not found in the cache or DB.
 	errBlockNotFoundInCacheOrDB = errors.New("block not found in cache or db")
-	// errNilBlock is returned when a nil block is returned from the cache.
+	// errNilBlockInCache is returned when a nil block is returned from the cache.
 	ErrNilBlockInCache = errors.New("nil block returned from the cache")
 	// errNilStateFromStategen is returned when a nil state is returned from the state generator.
 	errNilStateFromStategen = errors.New("justified state can't be nil")

--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -1088,9 +1088,9 @@ func Test_UpdateLastValidatedCheckpoint(t *testing.T) {
 	}
 	require.NoError(t, beaconDB.SaveStateSummary(ctx, genesisSummary))
 
-	// Get last validated checkpoint
-	origCheckpoint, err := service.cfg.BeaconDB.LastValidatedCheckpoint(ctx)
-	require.NoError(t, err)
+	// Set last validated checkpoint to a junk root to prevent issues
+	// with saving it due to the state summary.
+	origCheckpoint := &ethpb.Checkpoint{Root: genesisRoot[:], Epoch: 0}
 	require.NoError(t, beaconDB.SaveLastValidatedCheckpoint(ctx, origCheckpoint))
 
 	// Optimistic finalized checkpoint

--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -1083,7 +1083,7 @@ func Test_UpdateLastValidatedCheckpoint(t *testing.T) {
 	require.NoError(t, fcs.InsertNode(ctx, state, blkRoot))
 	fcs.SetOriginRoot(genesisRoot)
 	genesisSummary := &ethpb.StateSummary{
-		Root: genesisStateRoot[:],
+		Root: genesisRoot[:],
 		Slot: 0,
 	}
 	require.NoError(t, beaconDB.SaveStateSummary(ctx, genesisSummary))

--- a/beacon-chain/blockchain/init_sync_process_block.go
+++ b/beacon-chain/blockchain/init_sync_process_block.go
@@ -75,6 +75,12 @@ func (s *Service) getInitSyncBlocks() []interfaces.SignedBeaconBlock {
 	return blks
 }
 
+func (s *Service) getInitSyncBlockFromCache(r [32]byte) interfaces.SignedBeaconBlock {
+	s.initSyncBlocksLock.RLock()
+	defer s.initSyncBlocksLock.RUnlock()
+	return s.initSyncBlocks[r]
+}
+
 // This clears out the initial sync blocks cache.
 func (s *Service) clearInitSyncBlocks() {
 	s.initSyncBlocksLock.Lock()

--- a/beacon-chain/blockchain/init_sync_process_block.go
+++ b/beacon-chain/blockchain/init_sync_process_block.go
@@ -75,10 +75,15 @@ func (s *Service) getInitSyncBlocks() []interfaces.SignedBeaconBlock {
 	return blks
 }
 
-func (s *Service) getInitSyncBlockFromCache(r [32]byte) interfaces.SignedBeaconBlock {
+// getInitSyncBlockFromCache returns a block from the initial sync blocks cache. This method
+func (s *Service) getInitSyncBlockFromCache(r [32]byte) (interfaces.SignedBeaconBlock, error) {
 	s.initSyncBlocksLock.RLock()
 	defer s.initSyncBlocksLock.RUnlock()
-	return s.initSyncBlocks[r]
+	b := s.initSyncBlocks[r]
+	if b.IsNil() {
+		return nil, ErrNilBlockInCache
+	}
+	return b, nil
 }
 
 // This clears out the initial sync blocks cache.

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -465,7 +465,7 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.SignedBeac
 		// Ensure the cached block is saved to db before saving state boundary.
 		if !s.cfg.BeaconDB.HasBlock(ctx, r) {
 			b := s.getInitSyncBlockFromCache(r)
-			if b == nil {
+			if b.IsNil() {
 				return fmt.Errorf("could not find block for boundary state root %#x", r)
 			}
 			if err := s.cfg.BeaconDB.SaveBlock(ctx, b); err != nil {

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -464,9 +464,9 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.SignedBeac
 	for r, st := range boundaries {
 		// Ensure the cached block is saved to db before saving state boundary.
 		if !s.cfg.BeaconDB.HasBlock(ctx, r) {
-			b := s.getInitSyncBlockFromCache(r)
-			if b.IsNil() {
-				return fmt.Errorf("could not find block for boundary state root %#x", r)
+			b, err := s.getInitSyncBlockFromCache(r)
+			if err != nil || b.IsNil() {
+				return errors.Wrapf(err, "could not find block for boundary state root %#x", r)
 			}
 			if err := s.cfg.BeaconDB.SaveBlock(ctx, b); err != nil {
 				return err

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -1425,12 +1425,12 @@ func TestRemoveBlockAttestationsInPool_Canonical(t *testing.T) {
 	genesis, keys := util.DeterministicGenesisState(t, 64)
 	b, err := util.GenerateFullBlock(genesis, keys, util.DefaultBlockGenConfig(), 1)
 	assert.NoError(t, err)
-	r, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
 
 	ctx := context.Background()
 	beaconDB := testDB.SetupDB(t)
 	service := setupBeaconChain(t, beaconDB)
+	r, err := util.SaveBlock(t, ctx, beaconDB, b).Block().HashTreeRoot()
+	require.NoError(t, err)
 	require.NoError(t, service.cfg.BeaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: r[:]}))
 	require.NoError(t, service.cfg.BeaconDB.SaveGenesisBlockRoot(ctx, r))
 

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -119,8 +119,11 @@ func setupBeaconChain(t *testing.T, beaconDB db.Database) *Service {
 	require.NoError(t, err)
 
 	stateGen := stategen.New(beaconDB)
-	// Safe a state in stategen to purposes of testing a service stop / shutdown.
-	require.NoError(t, stateGen.SaveState(ctx, bytesutil.ToBytes32(bState.FinalizedCheckpoint().Root), bState))
+
+	// Save a state and block in stategen to purposes of testing a service stop / shutdown.
+	r, err := util.SaveBlock(t, ctx, beaconDB, util.NewBeaconBlock()).Block().HashTreeRoot()
+	require.NoError(t, err)
+	require.NoError(t, stateGen.SaveState(ctx, r, bState))
 
 	opts := []Option{
 		WithDatabase(beaconDB),
@@ -381,7 +384,7 @@ func TestChainService_SaveHeadNoDB(t *testing.T) {
 	}
 	blk := util.NewBeaconBlock()
 	blk.Block.Slot = 1
-	r, err := blk.HashTreeRoot()
+	r, err := util.SaveBlock(t, ctx, beaconDB, blk).Block().HashTreeRoot()
 	require.NoError(t, err)
 	newState, err := util.NewBeaconState()
 	require.NoError(t, err)

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -195,8 +195,6 @@ func TestChainStartStop_GenesisZeroHashes(t *testing.T) {
 	require.NoError(t, beaconDB.SaveState(ctx, s, blkRoot))
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, blkRoot))
 	require.NoError(t, beaconDB.SaveBlock(ctx, wsb))
-	require.NoError(t, beaconDB.SaveJustifiedCheckpoint(ctx, &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}))
-	require.NoError(t, beaconDB.SaveFinalizedCheckpoint(ctx, &ethpb.Checkpoint{Root: blkRoot[:]}))
 	chainService.cfg.FinalizedStateAtStartUp = s
 	// Test the start function.
 	chainService.Start()

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -75,7 +75,7 @@ type NoHeadAccessDatabase interface {
 	DeleteStates(ctx context.Context, blockRoots [][32]byte) error
 	SaveStateSummary(ctx context.Context, summary *ethpb.StateSummary) error
 	SaveStateSummaries(ctx context.Context, summaries []*ethpb.StateSummary) error
-	SaveStateSummariesWithPendingBlocks(ctx context.Context, summaries []*ethpb.StateSummary, blockCache func([32]byte) interfaces.SignedBeaconBlock) error
+	SaveStateSummariesWithPendingBlocks(ctx context.Context, summaries []*ethpb.StateSummary, blockCache func([32]byte) (interfaces.SignedBeaconBlock, error)) error
 	// Checkpoint operations.
 	SaveJustifiedCheckpoint(ctx context.Context, checkpoint *ethpb.Checkpoint) error
 	SaveFinalizedCheckpoint(ctx context.Context, checkpoint *ethpb.Checkpoint) error

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -75,6 +75,7 @@ type NoHeadAccessDatabase interface {
 	DeleteStates(ctx context.Context, blockRoots [][32]byte) error
 	SaveStateSummary(ctx context.Context, summary *ethpb.StateSummary) error
 	SaveStateSummaries(ctx context.Context, summaries []*ethpb.StateSummary) error
+	SaveStateSummariesWithPendingBlocks(ctx context.Context, summaries []*ethpb.StateSummary, blockCache func([32]byte) interfaces.SignedBeaconBlock) error
 	// Checkpoint operations.
 	SaveJustifiedCheckpoint(ctx context.Context, checkpoint *ethpb.Checkpoint) error
 	SaveFinalizedCheckpoint(ctx context.Context, checkpoint *ethpb.Checkpoint) error

--- a/beacon-chain/db/kv/BUILD.bazel
+++ b/beacon-chain/db/kv/BUILD.bazel
@@ -73,6 +73,7 @@ go_library(
         "@io_etcd_go_bbolt//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
+        "@org_uber_go_multierr//:go_default_library",
     ],
 )
 

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -327,7 +327,7 @@ func (s *Store) SaveBlocks(ctx context.Context, blks []interfaces.SignedBeaconBl
 				blk = blindedBlock
 			}
 		}
-		s.blockCache.Set(string(blockRoots[i]), blk, 0)
+		s.blockCache.Set(string(blockRoots[i]), blk, int64(len(encodedBlocks[i])))
 	}
 	return nil
 }

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -327,7 +327,7 @@ func (s *Store) SaveBlocks(ctx context.Context, blks []interfaces.SignedBeaconBl
 				blk = blindedBlock
 			}
 		}
-		s.blockCache.Set(string(blockRoots[i]), blk, int64(len(encodedBlocks[i])))
+		s.blockCache.Set(string(blockRoots[i]), blk, 0)
 	}
 	return nil
 }

--- a/beacon-chain/db/kv/error.go
+++ b/beacon-chain/db/kv/error.go
@@ -9,6 +9,7 @@ var ErrDeleteJustifiedAndFinalized = errors.New("cannot delete finalized block o
 // indicate that a value couldn't be found.
 var ErrNotFound = errors.New("not found in db")
 var ErrNotFoundState = errors.Wrap(ErrNotFound, "state not found")
+var ErrNotFoundBlock = errors.Wrap(ErrNotFound, "block not found")
 
 // ErrNotFoundOriginBlockRoot is an error specifically for the origin block root getter
 var ErrNotFoundOriginBlockRoot = errors.Wrap(ErrNotFound, "OriginBlockRoot")

--- a/beacon-chain/db/kv/state_summary.go
+++ b/beacon-chain/db/kv/state_summary.go
@@ -21,6 +21,7 @@ func (s *Store) SaveStateSummary(ctx context.Context, summary *ethpb.StateSummar
 	return s.SaveStateSummaries(ctx, []*ethpb.StateSummary{summary})
 }
 
+// SaveStateSummaries saves state summary objects to the DB.
 func (s *Store) SaveStateSummaries(ctx context.Context, summaries []*ethpb.StateSummary) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveStateSummaries")
 	defer span.End()

--- a/beacon-chain/db/kv/state_summary.go
+++ b/beacon-chain/db/kv/state_summary.go
@@ -53,11 +53,11 @@ func (s *Store) ensureBlocksSaved(ctx context.Context, blockCache func([32]byte)
 	if blockCache == nil {
 		return nil
 	}
-	blocks := make([]interfaces.SignedBeaconBlock, 0)
 	summaries := s.stateSummaryCache.getAll()
+	blocks := make([]interfaces.SignedBeaconBlock, 0, len(summaries))
 	for _, ss := range summaries {
 		if s.HasBlock(ctx, bytesutil.ToBytes32(ss.Root)) {
-			log.WithField("blockRoot", fmt.Sprintf("%#x", ss.Root)).Debug("Block already saved")
+			log.WithField("blockRoot", fmt.Sprintf("%#x", ss.Root)).Trace("Block already saved")
 			continue
 		}
 		if b, err := blockCache(bytesutil.ToBytes32(ss.Root)); err == nil && !b.IsNil() {

--- a/beacon-chain/db/kv/state_summary_test.go
+++ b/beacon-chain/db/kv/state_summary_test.go
@@ -120,6 +120,7 @@ func TestStateSummary_CacheToDB_FailsIfMissingBlock(t *testing.T) {
 	r, err := util.SaveBlock(t, ctx, db, b).Block().HashTreeRoot()
 	require.NoError(t, err)
 	require.ErrorIs(t, db.SaveStateSummary(context.Background(), &ethpb.StateSummary{Slot: 1001, Root: r[:]}), ErrNotFoundBlock)
+	require.Equal(t, db.HasStateSummary(ctx, junkRoot), false)
 
 	require.NoError(t, db.deleteStateSummary(junkRoot)) // Delete bad summary or db will throw an error on test cleanup.
 }

--- a/beacon-chain/execution/service_test.go
+++ b/beacon-chain/execution/service_test.go
@@ -473,6 +473,7 @@ func TestInitDepositCacheWithFinalization_OK(t *testing.T) {
 
 	emptyState, err := util.NewBeaconState()
 	require.NoError(t, err)
+	util.SaveBlock(t, context.Background(), s.cfg.beaconDB, headBlock)
 	require.NoError(t, s.cfg.beaconDB.SaveGenesisBlockRoot(context.Background(), headRoot))
 	require.NoError(t, s.cfg.beaconDB.SaveState(context.Background(), emptyState, headRoot))
 	require.NoError(t, stateGen.SaveState(context.Background(), headRoot, emptyState))

--- a/beacon-chain/monitor/BUILD.bazel
+++ b/beacon-chain/monitor/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//beacon-chain/core/altair:go_default_library",
         "//beacon-chain/core/feed:go_default_library",
         "//beacon-chain/core/feed/state:go_default_library",
+        "//beacon-chain/db/iface:go_default_library",
         "//beacon-chain/db/testing:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
         "//config/params:go_default_library",

--- a/beacon-chain/monitor/process_block_test.go
+++ b/beacon-chain/monitor/process_block_test.go
@@ -168,7 +168,7 @@ func TestProcessProposedBlock(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hook := logTest.NewGlobal()
-			s := setupService(t)
+			s, _ := setupService(t)
 			beaconState, _ := util.DeterministicGenesisState(t, 256)
 			root := [32]byte{}
 			copy(root[:], "hello-world")
@@ -199,7 +199,7 @@ func TestProcessBlock_AllEventsTrackedVals(t *testing.T) {
 	genConfig.FullSyncAggregate = true
 	b, err := util.GenerateFullBlockAltair(genesis, keys, genConfig, 1)
 	require.NoError(t, err)
-	s := setupService(t)
+	s, db := setupService(t)
 
 	pubKeys := make([][]byte, 3)
 	pubKeys[0] = genesis.Validators()[0].PublicKey
@@ -223,7 +223,7 @@ func TestProcessBlock_AllEventsTrackedVals(t *testing.T) {
 	s.RUnlock()
 	s.updateSyncCommitteeTrackedVals(genesis)
 
-	root, err := b.GetBlock().HashTreeRoot()
+	root, err := util.SaveBlock(t, ctx, db, b).Block().HashTreeRoot()
 	require.NoError(t, err)
 	require.NoError(t, s.config.StateGen.SaveState(ctx, root, genesis))
 	wanted1 := fmt.Sprintf("\"Proposed beacon block was included\" BalanceChange=100000000 BlockRoot=%#x NewBalance=32000000000 ParentRoot=0xf732eaeb7fae ProposerIndex=15 Slot=1 Version=1 prefix=monitor", bytesutil.Trunc(root[:]))
@@ -241,7 +241,7 @@ func TestProcessBlock_AllEventsTrackedVals(t *testing.T) {
 
 func TestLogAggregatedPerformance(t *testing.T) {
 	hook := logTest.NewGlobal()
-	s := setupService(t)
+	s, _ := setupService(t)
 
 	s.logAggregatedPerformance()
 	time.Sleep(3000 * time.Millisecond)

--- a/beacon-chain/monitor/process_sync_committee_test.go
+++ b/beacon-chain/monitor/process_sync_committee_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestProcessSyncCommitteeContribution(t *testing.T) {
 	hook := logTest.NewGlobal()
-	s := setupService(t)
+	s, _ := setupService(t)
 
 	contrib := &ethpb.SignedContributionAndProof{
 		Message: &ethpb.ContributionAndProof{
@@ -28,7 +28,7 @@ func TestProcessSyncCommitteeContribution(t *testing.T) {
 
 func TestProcessSyncAggregate(t *testing.T) {
 	hook := logTest.NewGlobal()
-	s := setupService(t)
+	s, _ := setupService(t)
 	beaconState, _ := util.DeterministicGenesisStateAltair(t, 256)
 
 	block := &ethpb.BeaconBlockAltair{

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
@@ -1542,12 +1542,15 @@ func TestServer_GetValidatorParticipation_CurrentAndPrevEpoch(t *testing.T) {
 	b.Block.Slot = 16
 	util.SaveBlock(t, ctx, beaconDB, b)
 	bRoot, err := b.Block.HashTreeRoot()
+	require.NoError(t, err)
+	bRoot2, err := util.SaveBlock(t, ctx, beaconDB, b).Block().HashTreeRoot()
+	require.NoError(t, err)
 	require.NoError(t, beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot[:]}))
-	require.NoError(t, beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: params.BeaconConfig().ZeroHash[:]}))
+	require.NoError(t, beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: bRoot2[:]}))
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, bRoot))
 	require.NoError(t, err)
 	require.NoError(t, beaconDB.SaveState(ctx, headState, bRoot))
-	require.NoError(t, beaconDB.SaveState(ctx, headState, params.BeaconConfig().ZeroHash))
+	require.NoError(t, beaconDB.SaveState(ctx, headState, bRoot2))
 
 	m := &mock.ChainService{State: headState}
 	offset := int64(params.BeaconConfig().SlotsPerEpoch.Mul(params.BeaconConfig().SecondsPerSlot))

--- a/beacon-chain/rpc/prysm/v1alpha1/debug/block_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/debug/block_test.go
@@ -58,7 +58,9 @@ func TestServer_GetAttestationInclusionSlot(t *testing.T) {
 	}
 
 	s, _ := util.DeterministicGenesisState(t, 2048)
-	tr := [32]byte{'a'}
+	b := util.NewBeaconBlock()
+	tr, err := util.SaveBlock(t, ctx, bs.BeaconDB, b).Block().HashTreeRoot()
+	require.NoError(t, err)
 	require.NoError(t, bs.StateGen.SaveState(ctx, tr, s))
 	c, err := helpers.BeaconCommitteeFromState(context.Background(), s, 1, 0)
 	require.NoError(t, err)
@@ -73,7 +75,7 @@ func TestServer_GetAttestationInclusionSlot(t *testing.T) {
 		AggregationBits: bitfield.Bitlist{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
 		Signature:       make([]byte, fieldparams.BLSSignatureLength),
 	}
-	b := util.NewBeaconBlock()
+	b = util.NewBeaconBlock()
 	b.Block.Slot = 2
 	b.Block.Body.Attestations = []*ethpb.Attestation{a}
 	util.SaveBlock(t, ctx, bs.BeaconDB, b)

--- a/beacon-chain/slasher/detect_blocks_test.go
+++ b/beacon-chain/slasher/detect_blocks_test.go
@@ -67,7 +67,8 @@ func Test_processQueuedBlocks_DetectsDoubleProposals(t *testing.T) {
 		blksQueue: newBlocksQueue(),
 	}
 
-	parentRoot := bytesutil.ToBytes32([]byte("parent"))
+	parentRoot, err := util.SaveBlock(t, ctx, beaconDB, util.NewBeaconBlock()).Block().HashTreeRoot()
+	require.NoError(t, err)
 	err = s.serviceCfg.StateGen.SaveState(ctx, parentRoot, beaconState)
 	require.NoError(t, err)
 

--- a/beacon-chain/slasher/process_slashings_test.go
+++ b/beacon-chain/slasher/process_slashings_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stategen"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/prysmaticlabs/prysm/v3/crypto/bls"
-	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
 	"github.com/prysmaticlabs/prysm/v3/testing/util"
@@ -157,7 +156,8 @@ func TestService_processProposerSlashings(t *testing.T) {
 		},
 	}
 
-	parentRoot := bytesutil.ToBytes32([]byte("parent"))
+	parentRoot, err := util.SaveBlock(t, ctx, beaconDB, util.NewBeaconBlock()).Block().HashTreeRoot()
+	require.NoError(t, err)
 	err = s.serviceCfg.StateGen.SaveState(ctx, parentRoot, beaconState)
 	require.NoError(t, err)
 

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -62,7 +62,9 @@ func TestStateByRootIfCachedNoCopy_HotState(t *testing.T) {
 	service := New(beaconDB)
 
 	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	r := [32]byte{'A'}
+	b := util.NewBeaconBlock()
+	r, err := util.SaveBlock(t, ctx, beaconDB, b).Block().HashTreeRoot()
+	require.NoError(t, err)
 	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: r[:]}))
 	service.hotStateCache.put(r, beaconState)
 
@@ -102,6 +104,7 @@ func TestStateByRoot_HotStateUsingEpochBoundaryCacheNoReplay(t *testing.T) {
 	beaconState, _ := util.DeterministicGenesisState(t, 32)
 	require.NoError(t, beaconState.SetSlot(10))
 	blk := util.NewBeaconBlock()
+	util.SaveBlock(t, ctx, beaconDB, blk)
 	blkRoot, err := blk.Block.HashTreeRoot()
 	require.NoError(t, err)
 	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: blkRoot[:]}))
@@ -143,7 +146,8 @@ func TestStateByRoot_HotStateCached(t *testing.T) {
 	service := New(beaconDB)
 
 	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	r := [32]byte{'A'}
+	r, err := util.SaveBlock(t, ctx, beaconDB, util.NewBeaconBlock()).Block().HashTreeRoot()
+	require.NoError(t, err)
 	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: r[:]}))
 	service.hotStateCache.put(r, beaconState)
 
@@ -223,7 +227,8 @@ func TestStateByRootInitialSync_UseCache(t *testing.T) {
 	service := New(beaconDB)
 
 	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	r := [32]byte{'A'}
+	r, err := util.SaveBlock(t, ctx, beaconDB, util.NewBeaconBlock()).Block().HashTreeRoot()
+	require.NoError(t, err)
 	require.NoError(t, service.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{Root: r[:]}))
 	service.hotStateCache.put(r, beaconState)
 

--- a/beacon-chain/state/stategen/setter.go
+++ b/beacon-chain/state/stategen/setter.go
@@ -74,19 +74,19 @@ func (s *State) saveStateByRoot(ctx context.Context, blockRoot [32]byte, st stat
 		return nil
 	}
 
-	// Only on an epoch boundary slot, save epoch boundary state in epoch boundary root state cache.
-	if slots.IsEpochStart(st.Slot()) {
-		if err := s.epochBoundaryStateCache.put(blockRoot, st); err != nil {
-			return err
-		}
-	}
-
 	// On an intermediate slot, save state summary.
 	if err := s.beaconDB.SaveStateSummary(ctx, &ethpb.StateSummary{
 		Slot: st.Slot(),
 		Root: blockRoot[:],
 	}); err != nil {
 		return err
+	}
+
+	// Only on an epoch boundary slot, save epoch boundary state in epoch boundary root state cache.
+	if slots.IsEpochStart(st.Slot()) {
+		if err := s.epochBoundaryStateCache.put(blockRoot, st); err != nil {
+			return err
+		}
 	}
 
 	// Store the copied state in the hot state cache.

--- a/beacon-chain/sync/validate_beacon_blocks_test.go
+++ b/beacon-chain/sync/validate_beacon_blocks_test.go
@@ -216,6 +216,7 @@ func TestValidateBeaconBlockPubSub_IsInCache(t *testing.T) {
 	ctx := context.Background()
 	beaconState, privKeys := util.DeterministicGenesisState(t, 100)
 	parentBlock := util.NewBeaconBlock()
+	util.SaveBlock(t, ctx, db, parentBlock)
 	bRoot, err := parentBlock.Block.HashTreeRoot()
 	require.NoError(t, err)
 	require.NoError(t, db.SaveState(ctx, beaconState, bRoot))

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	go.etcd.io/bbolt v1.3.5
 	go.opencensus.io v0.23.0
 	go.uber.org/automaxprocs v1.3.0
+	go.uber.org/multierr v1.8.0
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 	golang.org/x/exp v0.0.0-20220426173459-3bcf042a4bf5
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
@@ -221,7 +222,6 @@ require (
 	github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect

--- a/tools/analyzers/interfacechecker/analyzer.go
+++ b/tools/analyzers/interfacechecker/analyzer.go
@@ -75,6 +75,9 @@ func handleConditionalExpression(exp *ast.BinaryExpr, pass *analysis.Pass) {
 		return
 	}
 	for _, iface := range selectedInterfaces {
+		if strings.HasPrefix(typeMap[identX].Type.String(), "func") {
+			return // Ignore functions as they are not interfaces.
+		}
 		xIsIface := strings.Contains(typeMap[identX].Type.String(), iface)
 		xIsNil := typeMap[identX].IsNil()
 		yisIface := strings.Contains(typeMap[identY].Type.String(), iface)

--- a/tools/analyzers/interfacechecker/analyzer.go
+++ b/tools/analyzers/interfacechecker/analyzer.go
@@ -97,5 +97,6 @@ func handleConditionalExpression(exp *ast.BinaryExpr, pass *analysis.Pass) {
 
 func reportFailure(pos token.Pos, pass *analysis.Pass) {
 	pass.Reportf(pos, "A single nilness check is being performed on an interface"+
-		", this check needs another accompanying nilness check on the underlying object for the interface.")
+		", this check needs another accompanying nilness check on the underlying object for the interface. "+
+		"Please use IsNil() if it is available")
 }


### PR DESCRIPTION
**What does this PR do? Why is it needed?**

The DB must ensure that blocks referenced by state summaries exist in the database. 

**Which issues(s) does this PR fix?**

Fixes #11384

**Other notes for review**

Do not merge yet!

Key changes are:

- Addition of saving of state summaries with a block cache accessor. This is something that initial sync would use to attempt save state summaries with blocks that the database doesn't know about yet. `beacon-chain/db/kv/state_summary.go`
- Initial sync routine using this new method `beacon-chain/blockchain/process_block.go`
- Enforcement that flushing the state summary buffer has access to blocks in the database. `beacon-chain/db/kv/state_summary.go`
