### PR TITLE
Remove activation/exit queue metrics

### DIFF
--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -231,6 +231,9 @@ func reportEpochMetrics(ctx context.Context, postState, headState state.BeaconSt
 	exitingEffectiveBalance := uint64(0)
 	slashingBalance := uint64(0)
 	slashingEffectiveBalance := uint64(0)
+	// Queue seizes
+	activationQueueSize := 0
+	exitQueueSize := 0
 
 	for i, validator := range postState.Validators() {
 		bal, err := postState.BalanceAtIndex(types.ValidatorIndex(i))

--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -231,9 +231,6 @@ func reportEpochMetrics(ctx context.Context, postState, headState state.BeaconSt
 	exitingEffectiveBalance := uint64(0)
 	slashingBalance := uint64(0)
 	slashingEffectiveBalance := uint64(0)
-	// Queue seizes
-	activationQueueSize := 0
-	exitQueueSize := 0
 
 	for i, validator := range postState.Validators() {
 		bal, err := postState.BalanceAtIndex(types.ValidatorIndex(i))

--- a/beacon-chain/core/epoch/BUILD.bazel
+++ b/beacon-chain/core/epoch/BUILD.bazel
@@ -19,8 +19,6 @@ go_library(
         "//proto/prysm/v1alpha1:go_default_library",
         "//proto/prysm/v1alpha1/attestation:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
-        "@com_github_prometheus_client_golang//prometheus:go_default_library",
-        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -10,8 +10,6 @@ import (
 	"sort"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/time"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/validators"
@@ -21,13 +19,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/math"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1/attestation"
-)
-
-var (
-	activationQueueCount = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "activation_queue_count",
-		Help: "Number of validators in the activation queue",
-	})
 )
 
 // sortableIndices implements the Sort interface to sort newly activated validator indices
@@ -128,7 +119,6 @@ func ProcessRegistryUpdates(ctx context.Context, state state.BeaconState) (state
 			activationQ = append(activationQ, types.ValidatorIndex(idx))
 		}
 	}
-	activationQueueCount.Set(float64(len(activationQ)))
 
 	sort.Sort(sortableIndices{indices: activationQ, validators: vals})
 

--- a/beacon-chain/core/validators/BUILD.bazel
+++ b/beacon-chain/core/validators/BUILD.bazel
@@ -18,8 +18,6 @@ go_library(
         "//proto/prysm/v1alpha1:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
-        "@com_github_prometheus_client_golang//prometheus:go_default_library",
-        "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",
     ],
 )
 

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -8,8 +8,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/time"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
@@ -18,13 +16,6 @@ import (
 	mathutil "github.com/prysmaticlabs/prysm/v3/math"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v3/time/slots"
-)
-
-var (
-	exitQueueCount = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "exit_queue_count",
-		Help: "Number of validators in the exit queue",
-	})
 )
 
 // InitiateValidatorExit takes in validator index and updates
@@ -68,7 +59,6 @@ func InitiateValidatorExit(ctx context.Context, s state.BeaconState, idx types.V
 	if err != nil {
 		return nil, err
 	}
-	exitQueueCount.Set(float64(len(exitEpochs)))
 	exitEpochs = append(exitEpochs, helpers.ActivationExitEpoch(time.CurrentEpoch(s)))
 
 	// Obtain the exit queue epoch as the maximum number in the exit epochs array.


### PR DESCRIPTION
The activation and exit queue metrics we added yesterday weren't correct because they would consider replay state.
As it turns out there are already validator state that account for pending, activation, slashing.. and more, we could just use this:
```go
	validatorsCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
		Name: "validator_count",
		Help: "The total number of validators",
	}, []string{"state"})
```