### PR TITLE
Implement optimistic sync spectests

### DIFF
--- a/beacon-chain/execution/BUILD.bazel
+++ b/beacon-chain/execution/BUILD.bazel
@@ -23,7 +23,7 @@ go_library(
         "//beacon-chain:__subpackages__",
         "//cmd/beacon-chain:__subpackages__",
         "//contracts:__subpackages__",
-	"//testing/spectest:__subpackages__", 
+        "//testing/spectest:__subpackages__",
     ],
     deps = [
         "//beacon-chain/cache/depositcache:go_default_library",

--- a/beacon-chain/execution/BUILD.bazel
+++ b/beacon-chain/execution/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//beacon-chain:__subpackages__",
         "//cmd/beacon-chain:__subpackages__",
         "//contracts:__subpackages__",
+	"//testing/spectest:__subpackages__", 
     ],
     deps = [
         "//beacon-chain/cache/depositcache:go_default_library",

--- a/testing/spectest/shared/common/forkchoice/BUILD.bazel
+++ b/testing/spectest/shared/common/forkchoice/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/db/testing:go_default_library",
+        "//beacon-chain/execution:go_default_library",
         "//beacon-chain/forkchoice/protoarray:go_default_library",
         "//beacon-chain/operations/attestations:go_default_library",
         "//beacon-chain/state:go_default_library",

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -2,12 +2,14 @@ package forkchoice
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/blockchain"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/execution"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
@@ -48,6 +50,35 @@ func (bb *Builder) Tick(t testing.TB, tick int64) {
 		bb.service.ForkChoicer().SetGenesisTime(uint64(time.Now().Unix() - tick))
 	}
 	bb.lastTick = tick
+}
+
+// SetPayloadStatus sets the payload status that the engine will return
+func (bb *Builder) SetPayloadStatus(resp *MockEngineResp) error {
+	if resp == nil {
+		return errors.New("invalid nil payload status")
+	}
+	if resp.LatestValidHash == nil {
+		return errors.New("invalid nil latest valid hash")
+	}
+	if *resp.LatestValidHash == "null" {
+		bb.execMock.latestValidHash = common.FromHex("0x0000000000000000000000000000000000000000000000000000000000000000")
+	} else {
+		bb.execMock.latestValidHash = common.FromHex(*resp.LatestValidHash)
+	}
+	if resp.Status == nil {
+		return errors.New("invalid nil status")
+	}
+	switch *resp.Status {
+	case "PayloadStatusV1Status.SYNCING":
+		bb.execMock.payloadStatus = execution.ErrAcceptedSyncingPayloadStatus
+	case "PayloadStatusV1Status.VALID":
+		bb.execMock.payloadStatus = nil
+	case "PayloadStatusV1Status.INVALID":
+		bb.execMock.payloadStatus = execution.ErrInvalidPayloadStatus
+	default:
+		return errors.New("unknown payload status")
+	}
+	return nil
 }
 
 // block returns the block root.

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -58,9 +58,6 @@ func (bb *Builder) SetPayloadStatus(resp *MockEngineResp) error {
 		return errors.New("invalid nil payload status")
 	}
 	if resp.LatestValidHash == nil {
-		return errors.New("invalid nil latest valid hash")
-	}
-	if *resp.LatestValidHash == "null" {
 		bb.execMock.latestValidHash = common.FromHex("0x0000000000000000000000000000000000000000000000000000000000000000")
 	} else {
 		bb.execMock.latestValidHash = common.FromHex(*resp.LatestValidHash)
@@ -69,11 +66,11 @@ func (bb *Builder) SetPayloadStatus(resp *MockEngineResp) error {
 		return errors.New("invalid nil status")
 	}
 	switch *resp.Status {
-	case "PayloadStatusV1Status.SYNCING":
+	case "SYNCING":
 		bb.execMock.payloadStatus = execution.ErrAcceptedSyncingPayloadStatus
-	case "PayloadStatusV1Status.VALID":
+	case "VALID":
 		bb.execMock.payloadStatus = nil
-	case "PayloadStatusV1Status.INVALID":
+	case "INVALID":
 		bb.execMock.payloadStatus = execution.ErrInvalidPayloadStatus
 	default:
 		return errors.New("unknown payload status")

--- a/testing/spectest/shared/common/forkchoice/service.go
+++ b/testing/spectest/shared/common/forkchoice/service.go
@@ -25,7 +25,11 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
 )
 
-func startChainService(t testing.TB, st state.BeaconState, block interfaces.SignedBeaconBlock, engineMock *engineMock) *blockchain.Service {
+func startChainService(t testing.TB,
+	st state.BeaconState,
+	block interfaces.SignedBeaconBlock,
+	engineMock *engineMock,
+) *blockchain.Service {
 	db := testDB.SetupDB(t)
 	ctx := context.Background()
 	require.NoError(t, db.SaveBlock(ctx, block))
@@ -67,7 +71,9 @@ func startChainService(t testing.TB, st state.BeaconState, block interfaces.Sign
 }
 
 type engineMock struct {
-	powBlocks map[[32]byte]*ethpb.PowBlock
+	powBlocks       map[[32]byte]*ethpb.PowBlock
+	latestValidHash []byte
+	payloadStatus   error
 }
 
 func (m *engineMock) GetPayload(context.Context, [8]byte) (*pb.ExecutionPayload, error) {
@@ -77,7 +83,7 @@ func (m *engineMock) ForkchoiceUpdated(context.Context, *pb.ForkchoiceState, *pb
 	return nil, nil, nil
 }
 func (m *engineMock) NewPayload(context.Context, interfaces.ExecutionData) ([]byte, error) {
-	return nil, nil
+	return m.latestValidHash, m.payloadStatus
 }
 
 func (m *engineMock) LatestExecutionBlock(context.Context) (*pb.ExecutionBlock, error) {

--- a/testing/spectest/shared/common/forkchoice/type.go
+++ b/testing/spectest/shared/common/forkchoice/type.go
@@ -1,13 +1,14 @@
 package forkchoice
 
 type Step struct {
-	Tick             *int    `json:"tick"`
-	Block            *string `json:"block"`
-	Valid            *bool   `json:"valid"`
-	Attestation      *string `json:"attestation"`
-	AttesterSlashing *string `json:"attester_slashing"`
-	PowBlock         *string `json:"pow_block"`
-	Check            *Check  `json:"checks"`
+	Tick             *int            `json:"tick"`
+	Block            *string         `json:"block"`
+	Valid            *bool           `json:"valid"`
+	Attestation      *string         `json:"attestation"`
+	AttesterSlashing *string         `json:"attester_slashing"`
+	PayloadStatus    *MockEngineResp `json:"payload_status"`
+	PowBlock         *string         `json:"pow_block"`
+	Check            *Check          `json:"checks"`
 }
 
 type Check struct {
@@ -28,4 +29,10 @@ type SlotRoot struct {
 type EpochRoot struct {
 	Epoch int    `json:"epoch"`
 	Root  string `json:"root"`
+}
+
+type MockEngineResp struct {
+	Status          *string `json:"status"`
+	LatestValidHash *string `json:"latest_valid_hash"`
+	ValidationError *string `json:"validation_error"`
 }

--- a/testing/spectest/utils/utils.go
+++ b/testing/spectest/utils/utils.go
@@ -33,7 +33,9 @@ func UnmarshalYaml(y []byte, dest interface{}) error {
 func TestFolders(t testing.TB, config, forkOrPhase, folderPath string) ([]os.DirEntry, string) {
 	testsFolderPath := path.Join("tests", config, forkOrPhase, folderPath)
 	filepath, err := bazel.Runfile(testsFolderPath)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, ""
+	}
 	testFolders, err := os.ReadDir(filepath)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Implement https://github.com/ethereum/consensus-specs/pull/2982

~~The semantics of the `valid` tests in forkchoice and sync is different this is why we fail currently, if that is changed the tests pass.~~

Passing spectests as of 09/11. 