### PR TITLE
add forkchoice node timestamp to json response

### DIFF
--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -813,6 +813,7 @@ type forkChoiceNodeJson struct {
 	Weight                   string `json:"weight"`
 	ExecutionOptimistic      bool   `json:"execution_optimistic"`
 	ExecutionPayload         string `json:"execution_payload" hex:"true"`
+	TimeStamp                string `json:"timestamp" time:"true"`
 }
 
 //----------------


### PR DESCRIPTION
Thanks to @rkapka for finding out by the timestamp was not being returned on forkchoice dumps. 