### PR TITLE
Better log fee recipient mismatch

### DIFF
--- a/beacon-chain/rpc/eth/validator/validator_test.go
+++ b/beacon-chain/rpc/eth/validator/validator_test.go
@@ -998,12 +998,12 @@ func TestProduceBlockV2(t *testing.T) {
 		randaoReveal, err := util.RandaoReveal(beaconState, 1, privKeys)
 		require.NoError(t, err)
 		graffiti := bytesutil.ToBytes32([]byte("eth2"))
-
 		req := &ethpbv1.ProduceBlockRequest{
 			Slot:         params.BeaconConfig().SlotsPerEpoch + 1,
 			RandaoReveal: randaoReveal,
 			Graffiti:     graffiti[:],
 		}
+		v1Server.V1Alpha1Server.BeaconDB = db
 		resp, err := v1Server.ProduceBlockV2(ctx, req)
 		require.NoError(t, err)
 		assert.Equal(t, ethpbv2.Version_BELLATRIX, resp.Version)
@@ -1489,6 +1489,7 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 			RandaoReveal: randaoReveal,
 			Graffiti:     graffiti[:],
 		}
+		v1Server.V1Alpha1Server.BeaconDB = db
 		resp, err := v1Server.ProduceBlockV2SSZ(ctx, req)
 		require.NoError(t, err)
 		assert.Equal(t, ethpbv2.Version_BELLATRIX, resp.Version)
@@ -2504,6 +2505,7 @@ func TestProduceBlindedBlockSSZ(t *testing.T) {
 			RandaoReveal: randaoReveal,
 			Graffiti:     graffiti[:],
 		}
+		v1Server.V1Alpha1Server.BeaconDB = db
 		resp, err := v1Server.ProduceBlindedBlockSSZ(ctx, req)
 		require.NoError(t, err)
 		assert.Equal(t, ethpbv2.Version_BELLATRIX, resp.Version)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -41,11 +42,37 @@ var (
 // The payload is computed given the respected time of merge.
 func (vs *Server) getExecutionPayload(ctx context.Context, slot types.Slot, vIdx types.ValidatorIndex, headRoot [32]byte) (*enginev1.ExecutionPayload, error) {
 	proposerID, payloadId, ok := vs.ProposerSlotIndexCache.GetProposerPayloadIDs(slot, headRoot)
+	feeRecipient := params.BeaconConfig().DefaultFeeRecipient
+	recipient, err := vs.BeaconDB.FeeRecipientByValidatorID(ctx, vIdx)
+	switch err == nil {
+	case true:
+		feeRecipient = recipient
+	case errors.As(err, kv.ErrNotFoundFeeRecipient):
+		// If fee recipient is not found in DB and not set from beacon node CLI,
+		// use the burn address.
+		if feeRecipient.String() == params.BeaconConfig().EthBurnAddressHex {
+			logrus.WithFields(logrus.Fields{
+				"validatorIndex": vIdx,
+				"burnAddress":    params.BeaconConfig().EthBurnAddressHex,
+			}).Warn("Fee recipient is currently using the burn address, " +
+				"you will not be rewarded transaction fees on this setting. " +
+				"Please set a different eth address as the fee recipient. " +
+				"Please refer to our documentation for instructions")
+		}
+	default:
+		return nil, errors.Wrap(err, "could not get fee recipient in db")
+	}
+
 	if ok && proposerID == vIdx && payloadId != [8]byte{} { // Payload ID is cache hit. Return the cached payload ID.
 		var pid [8]byte
 		copy(pid[:], payloadId[:])
 		payloadIDCacheHit.Inc()
-		return vs.ExecutionEngineCaller.GetPayload(ctx, pid)
+		payload, err := vs.ExecutionEngineCaller.GetPayload(ctx, pid)
+		if err != nil {
+			return nil, err
+		}
+		warnIfFeeRecipientDiffers(payload, feeRecipient)
+		return payload, nil
 	}
 
 	st, err := vs.HeadFetcher.HeadState(ctx)
@@ -119,26 +146,6 @@ func (vs *Server) getExecutionPayload(ctx context.Context, slot types.Slot, vIdx
 		FinalizedBlockHash: finalizedBlockHash,
 	}
 
-	feeRecipient := params.BeaconConfig().DefaultFeeRecipient
-	recipient, err := vs.BeaconDB.FeeRecipientByValidatorID(ctx, vIdx)
-	switch err == nil {
-	case true:
-		feeRecipient = recipient
-	case errors.As(err, kv.ErrNotFoundFeeRecipient):
-		// If fee recipient is not found in DB and not set from beacon node CLI,
-		// use the burn address.
-		if feeRecipient.String() == params.BeaconConfig().EthBurnAddressHex {
-			logrus.WithFields(logrus.Fields{
-				"validatorIndex": vIdx,
-				"burnAddress":    params.BeaconConfig().EthBurnAddressHex,
-			}).Warn("Fee recipient is currently using the burn address, " +
-				"you will not be rewarded transaction fees on this setting. " +
-				"Please set a different eth address as the fee recipient. " +
-				"Please refer to our documentation for instructions")
-		}
-	default:
-		return nil, errors.Wrap(err, "could not get fee recipient in db")
-	}
 	p := &enginev1.PayloadAttributes{
 		Timestamp:             uint64(t.Unix()),
 		PrevRandao:            random,
@@ -155,6 +162,13 @@ func (vs *Server) getExecutionPayload(ctx context.Context, slot types.Slot, vIdx
 	if err != nil {
 		return nil, err
 	}
+	warnIfFeeRecipientDiffers(payload, feeRecipient)
+	return payload, nil
+}
+
+// warnIfFeeRecipientDiffers logs a warning if the fee recipient in the included payload does not
+// match the requested one.
+func warnIfFeeRecipientDiffers(payload *enginev1.ExecutionPayload, feeRecipient common.Address) {
 	// Warn if the fee recipient is not the value we expect.
 	if payload != nil && !bytes.Equal(payload.FeeRecipient, feeRecipient[:]) {
 		logrus.WithFields(logrus.Fields{
@@ -163,7 +177,6 @@ func (vs *Server) getExecutionPayload(ctx context.Context, slot types.Slot, vIdx
 		}).Warn("Fee recipient address from execution client is not what was expected. " +
 			"It is possible someone has compromised your client to try and take your transaction fees")
 	}
-	return payload, nil
 }
 
 // This returns the valid terminal block hash with an existence bool value.


### PR DESCRIPTION
Logs if the returned payload from the engine does not have the fee
recipient set in the validator.

Also warn the user if he's proposing a block with the burner fee
recipient address.
