### PR TITLE
Validate downloaded state slot matches header slot

### DIFF
--- a/api/client/beacon/checkpoint.go
+++ b/api/client/beacon/checkpoint.go
@@ -74,6 +74,9 @@ func DownloadFinalizedData(ctx context.Context, client *Client) (*OriginData, er
 	if err != nil {
 		return nil, errors.Wrap(err, "error unmarshaling finalized state to correct version")
 	}
+	if s.Slot() != s.LatestBlockHeader().Slot {
+		return nil, fmt.Errorf("finalized state slot does not match latest block header slot %d != %d", s.Slot(), s.LatestBlockHeader().Slot)
+	}
 
 	sr, err := s.HashTreeRoot(ctx)
 	if err != nil {

--- a/api/client/beacon/checkpoint_test.go
+++ b/api/client/beacon/checkpoint_test.go
@@ -418,6 +418,7 @@ func TestDownloadFinalizedData(t *testing.T) {
 	require.NoError(t, err)
 	fork, err := forkForEpoch(cfg, epoch)
 	require.NoError(t, st.SetFork(fork))
+	require.NoError(t, st.SetSlot(slot))
 
 	// set up checkpoint block
 	b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())


### PR DESCRIPTION
Extra assurance that downloaded state slot matches header slot. We don't want to compute construct block root using skipped slot root. cc @kasey 