### PR TITLE
Fall back to uncached getPaylod if first time outs

### DIFF
--- a/beacon-chain/execution/testing/mock_engine_client.go
+++ b/beacon-chain/execution/testing/mock_engine_client.go
@@ -27,6 +27,7 @@ type EngineClient struct {
 	ErrExecBlockByHash          error
 	ErrForkchoiceUpdated        error
 	ErrNewPayload               error
+	ErrGetPayload               error
 	ExecutionPayloadByBlockHash map[[32]byte]*pb.ExecutionPayload
 	BlockByHashMap              map[[32]byte]*pb.ExecutionBlock
 	NumReconstructedPayloads    uint64
@@ -52,7 +53,7 @@ func (e *EngineClient) ForkchoiceUpdated(
 
 // GetPayload --
 func (e *EngineClient) GetPayload(_ context.Context, _ [8]byte) (*pb.ExecutionPayload, error) {
-	return e.ExecutionPayload, nil
+	return e.ExecutionPayload, e.ErrGetPayload
 }
 
 // ExchangeTransitionConfiguration --

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -68,11 +68,14 @@ func (vs *Server) getExecutionPayload(ctx context.Context, slot types.Slot, vIdx
 		copy(pid[:], payloadId[:])
 		payloadIDCacheHit.Inc()
 		payload, err := vs.ExecutionEngineCaller.GetPayload(ctx, pid)
-		if err != nil {
-			return nil, err
+		switch {
+		case err == nil:
+			warnIfFeeRecipientDiffers(payload, feeRecipient)
+			return payload, nil
+		case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
+		default:
+			return nil, errors.Wrap(err, "could not get cached payload from execution client")
 		}
-		warnIfFeeRecipientDiffers(payload, feeRecipient)
-		return payload, nil
 	}
 
 	st, err := vs.HeadFetcher.HeadState(ctx)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -72,7 +72,7 @@ func (vs *Server) getExecutionPayload(ctx context.Context, slot types.Slot, vIdx
 		case err == nil:
 			warnIfFeeRecipientDiffers(payload, feeRecipient)
 			return payload, nil
-		case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
+		case errors.Is(err, context.DeadlineExceeded):
 		default:
 			return nil, errors.Wrap(err, "could not get cached payload from execution client")
 		}


### PR DESCRIPTION
Motivated from #11399

If the cached `getPayload` call to execution client times out, it may be wiser to give it a second try instead of failing block on the spot