### PR TITLE
Process attestations and update head at 11s mark

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -128,7 +128,7 @@ func (s *Service) spawnProcessAttestationsRoutine(stateFeed *event.Feed) {
 							log.WithError(err).Error("Could not process new slot")
 							return
 						}
-					case uint64(t.Second())%params.BeaconConfig().SecondsPerSlot == 11:
+					case uint64(t.Second())%params.BeaconConfig().SecondsPerSlot == params.BeaconConfig().SecondsPerSlot-1:
 						if err := s.UpdateHead(s.ctx); err != nil {
 							log.WithError(err).Error("Could not process attestations and update head")
 							return

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -68,6 +68,7 @@ type Flags struct {
 	EnableBatchGossipAggregation      bool // EnableBatchGossipAggregation specifies whether to further aggregate our gossip batches before verifying them.
 	EnableOnlyBlindedBeaconBlocks     bool // EnableOnlyBlindedBeaconBlocks enables only storing blinded beacon blocks in the DB post-Bellatrix fork.
 	EnableStartOptimistic             bool // EnableStartOptimistic treats every block as optimistic at startup.
+	EnableProcessAttestationsEarly    bool // EnableProcessAttestationsEarly processes attestations at 11s mark instead of 12s mark.
 
 	DisableStakinContractCheck bool // Disables check for deposit contract when proposing blocks
 
@@ -256,6 +257,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.Bool(enableStartupOptimistic.Name) {
 		logEnabled(enableStartupOptimistic)
 		cfg.EnableStartOptimistic = true
+	}
+	if ctx.Bool(enableProcessAttsEarly.Name) {
+		logEnabled(enableProcessAttsEarly)
+		cfg.EnableProcessAttestationsEarly = true
 	}
 	Init(cfg)
 	return nil

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -128,6 +128,12 @@ var (
 		Value:  false,
 		Hidden: true,
 	}
+	enableProcessAttsEarly = &cli.BoolFlag{
+		Name:   "enable-process-atts-early",
+		Usage:  "Enables processing attestations earlier at 11s mark instead of 12s mark",
+		Value:  false,
+		Hidden: true,
+	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.


### PR DESCRIPTION
Process attestations and update head at 11s mark than at the start of the epoch. This is a better construction to be more compatible with the future fork choice changes such as reorg late block defense. This feature is gated behind a flag