### PR TITLE
Set builder get payload timeout to 3s

### DIFF
--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -32,6 +32,7 @@ const (
 
 var errMalformedHostname = errors.New("hostname must include port, separated by one colon, like example.com:3500")
 var errMalformedRequest = errors.New("required request data are missing")
+var submitBlindedBlockTimeout = 3 * time.Second
 
 // ClientOpt is a functional option for the Client type (http.Client wrapper)
 type ClientOpt func(*Client)
@@ -260,7 +261,12 @@ func (c *Client) SubmitBlindedBlock(ctx context.Context, sb *ethpb.SignedBlinded
 	if err != nil {
 		return nil, errors.Wrap(err, "error encoding the SignedBlindedBeaconBlockBellatrix value body in SubmitBlindedBlock")
 	}
+
+	d := time.Now().Add(submitBlindedBlockTimeout)
+	ctx, cancel := context.WithDeadline(ctx, d)
+	defer cancel()
 	rb, err := c.do(ctx, http.MethodPost, postBlindedBeaconBlockPath, bytes.NewBuffer(body))
+
 	if err != nil {
 		return nil, errors.Wrap(err, "error posting the SignedBlindedBeaconBlockBellatrix to the builder api")
 	}


### PR DESCRIPTION
Fixes #11399

Set get payload timeout to longer than default 1s. When the proposer is getting payload, the proposer has signed the signature so it is committed. The proposer might as well wait longer instead of failing at 1s.