### PR TITLE
do not return on error during on_tick

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -122,7 +122,6 @@ func (s *Service) spawnProcessAttestationsRoutine(stateFeed *event.Feed) {
 			case <-st.C():
 				if err := s.ForkChoicer().NewSlot(s.ctx, s.CurrentSlot()); err != nil {
 					log.WithError(err).Error("Could not process new slot")
-					return
 				}
 
 				if err := s.UpdateHead(s.ctx); err != nil {


### PR DESCRIPTION
In the event of that `NewSlot` fails, we should log the error and continue updating head in case of a new head. This happens in e2e during checkpoint sync due to an unknown finalized root when pruning. 