### PR TITLE
Don't return out of routine when update head errors out

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -126,7 +126,6 @@ func (s *Service) spawnProcessAttestationsRoutine(stateFeed *event.Feed) {
 
 				if err := s.UpdateHead(s.ctx); err != nil {
 					log.WithError(err).Error("Could not process attestations and update head")
-					return
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Code health improvement

**What does this PR do? Why is it needed?**

Following up from #11463, it seems a little odd that we completely return from the spawn attestation routine for the new slot ticker even if a single update head fails. It seems to me the more sensible thing to do is just to log the error and cont. Update head every slot 

**Which issues(s) does this PR fix?**

N/A

**Other notes for review**

N/A