### PR TITLE
math: Add small cache for integer square root

### DIFF
--- a/math/BUILD.bazel
+++ b/math/BUILD.bazel
@@ -5,15 +5,19 @@ go_library(
     srcs = ["math_helper.go"],
     importpath = "github.com/prysmaticlabs/prysm/v3/math",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_thomaso_mirodin_intmath//u64:go_default_library"],
+    deps = [
+        "//cache/lru:go_default_library",
+        "@com_github_thomaso_mirodin_intmath//u64:go_default_library",
+    ],
 )
 
 go_test(
     name = "go_default_test",
     size = "small",
-    srcs = ["math_helper_test.go"],
-    deps = [
-        ":go_default_library",
-        "//testing/require:go_default_library",
+    srcs = [
+        "math_helper_test.go",
+        "test_helper_test.go",
     ],
+    embed = [":go_default_library"],
+    deps = ["//testing/require:go_default_library"],
 )

--- a/math/math_helper_test.go
+++ b/math/math_helper_test.go
@@ -78,6 +78,10 @@ func TestIntegerSquareRoot(t *testing.T) {
 			number: 4503599761588224,
 			root:   67108864,
 		},
+		{
+			number: 13803562000000000,
+			root:   117488561,
+		},
 	}
 
 	for _, testVals := range tt {
@@ -154,6 +158,7 @@ func TestMath_Mod(t *testing.T) {
 }
 
 func BenchmarkIntegerSquareRootBelow52Bits(b *testing.B) {
+	math.DisableCaches()
 	val := uint64(1 << 33)
 	for i := 0; i < b.N; i++ {
 		require.Equal(b, uint64(92681), math.IntegerSquareRoot(val))
@@ -161,6 +166,7 @@ func BenchmarkIntegerSquareRootBelow52Bits(b *testing.B) {
 }
 
 func BenchmarkIntegerSquareRootAbove52Bits(b *testing.B) {
+	math.DisableCaches()
 	val := uint64(1 << 62)
 	for i := 0; i < b.N; i++ {
 		require.Equal(b, uint64(1<<31), math.IntegerSquareRoot(val))
@@ -168,10 +174,27 @@ func BenchmarkIntegerSquareRootAbove52Bits(b *testing.B) {
 }
 
 func BenchmarkIntegerSquareRoot_WithDatatable(b *testing.B) {
+	math.DisableCaches()
 	val := uint64(1024)
 	for i := 0; i < b.N; i++ {
 		require.Equal(b, uint64(32), math.IntegerSquareRoot(val))
 	}
+}
+
+func BenchmarkIntegerSquareRoot_Cache(b *testing.B) {
+	val := uint64(1 << 62)
+	b.Run("on", func(b *testing.B) {
+		math.EnableCaches()
+		for i := 0; i < b.N; i++ {
+			require.Equal(b, uint64(1<<31), math.IntegerSquareRoot(val))
+		}
+	})
+	b.Run("off", func(b *testing.B) {
+		math.DisableCaches()
+		for i := 0; i < b.N; i++ {
+			require.Equal(b, uint64(1<<31), math.IntegerSquareRoot(val))
+		}
+	})
 }
 
 func TestCeilDiv8(t *testing.T) {

--- a/math/test_helper_test.go
+++ b/math/test_helper_test.go
@@ -1,0 +1,9 @@
+package math
+
+func DisableCaches() {
+	sqrtCache.Resize(0)
+}
+
+func EnableCaches() {
+	sqrtCache.Resize(SQRT_CACHE_SIZE)
+}


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

The IntegerSquareRoot method is often called thousands of times during epoch processing. Adding a small cache can improve performance by about 80% for cache hits.

**Which issues(s) does this PR fix?**

**Other notes for review**
