### PR TITLE
Change Default Timeout To 30 Seconds

### DIFF
--- a/network/auth.go
+++ b/network/auth.go
@@ -9,7 +9,7 @@ import (
 )
 
 // DefaultRPCHTTPTimeout for HTTP requests via an RPC connection to an execution node.
-const DefaultRPCHTTPTimeout = time.Second * 6
+const DefaultRPCHTTPTimeout = time.Second * 30
 
 // This creates a custom HTTP transport which we can attach to our HTTP client
 // in order to inject JWT auth strings into our HTTP request headers. Authentication


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

It changes the default http client timeout to 30 seconds from 6 seconds. This is because if the default timeout is lower than the context provided with it, we will instead take the smaller deadline( 6 seconds). This causes issues with potentially time consuming engine calls. (NewPayload) . All our engine call timeouts are smaller than 30 seconds, so 30 is a sufficient value to use as a default here. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
