### PR TITLE
Add a justified balance getter to forkchoice

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -665,7 +665,7 @@ func (f *ForkChoice) ForkChoiceDump(ctx context.Context) (*v1.ForkChoiceResponse
 
 }
 
-//func SetBalancesByRoot sets the balanceByRoot handler in forkchoice
+// SetBalancesByRoot sets the balanceByRoot handler in forkchoice
 func (f *ForkChoice) SetBalancesByRoot(handler func(context.Context, [32]byte) ([]uint64, error)) {
 	f.balancesByRoot = handler
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -666,6 +666,6 @@ func (f *ForkChoice) ForkChoiceDump(ctx context.Context) (*v1.ForkChoiceResponse
 }
 
 // SetBalancesByRoot sets the balanceByRoot handler in forkchoice
-func (f *ForkChoice) SetBalancesByRoot(handler func(context.Context, [32]byte) ([]uint64, error)) {
+func (f *ForkChoice) SetBalancesByRoot(handler forkchoice.BalancesByRooter) {
 	f.balancesByRoot = handler
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -664,3 +664,8 @@ func (f *ForkChoice) ForkChoiceDump(ctx context.Context) (*v1.ForkChoiceResponse
 	return resp, nil
 
 }
+
+//func SetBalancesByRoot sets the balanceByRoot handler in forkchoice
+func (f *ForkChoice) SetBalancesByRoot(handler func(context.Context, [32]byte) ([]uint64, error)) {
+	f.balancesByRoot = handler
+}

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -665,7 +665,7 @@ func (f *ForkChoice) ForkChoiceDump(ctx context.Context) (*v1.ForkChoiceResponse
 
 }
 
-// SetBalancesByRoot sets the balanceByRoot handler in forkchoice
-func (f *ForkChoice) SetBalancesByRoot(handler forkchoice.BalancesByRooter) {
+// SetBalancesByRooter sets the balanceByRoot handler in forkchoice
+func (f *ForkChoice) SetBalancesByRooter(handler forkchoice.BalancesByRooter) {
 	f.balancesByRoot = handler
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -1,23 +1,21 @@
 package doublylinkedtree
 
 import (
-	"context"
 	"sync"
 
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice"
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice/types"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 )
-
-type BalancesByRooter func(context.Context, [32]byte) ([]uint64, error)
 
 // ForkChoice defines the overall fork choice store which includes all block nodes, validator's latest votes and balances.
 type ForkChoice struct {
 	store          *Store
 	votes          []Vote // tracks individual validator's last vote.
 	votesLock      sync.RWMutex
-	balances       []uint64         // tracks individual validator's last justified balances.
-	balancesByRoot BalancesByRooter // handler to obtain balances for the state with a given root
+	balances       []uint64                    // tracks individual validator's last justified balances.
+	balancesByRoot forkchoice.BalancesByRooter // handler to obtain balances for the state with a given root
 }
 
 // Store defines the fork choice store which includes block nodes and the last view of checkpoint information.

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -9,13 +9,15 @@ import (
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 )
 
+type BalancesByRooter func(context.Context, [32]byte) ([]uint64, error)
+
 // ForkChoice defines the overall fork choice store which includes all block nodes, validator's latest votes and balances.
 type ForkChoice struct {
 	store          *Store
 	votes          []Vote // tracks individual validator's last vote.
 	votesLock      sync.RWMutex
-	balances       []uint64                                          // tracks individual validator's last justified balances.
-	balancesByRoot func(context.Context, [32]byte) ([]uint64, error) // handler to obtain balances for the state with a given root
+	balances       []uint64         // tracks individual validator's last justified balances.
+	balancesByRoot BalancesByRooter // handler to obtain balances for the state with a given root
 }
 
 // Store defines the fork choice store which includes block nodes and the last view of checkpoint information.

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -1,6 +1,7 @@
 package doublylinkedtree
 
 import (
+	"context"
 	"sync"
 
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice/types"
@@ -10,10 +11,11 @@ import (
 
 // ForkChoice defines the overall fork choice store which includes all block nodes, validator's latest votes and balances.
 type ForkChoice struct {
-	store     *Store
-	votes     []Vote // tracks individual validator's last vote.
-	votesLock sync.RWMutex
-	balances  []uint64 // tracks individual validator's last justified balances.
+	store          *Store
+	votes          []Vote // tracks individual validator's last vote.
+	votesLock      sync.RWMutex
+	balances       []uint64                                          // tracks individual validator's last justified balances.
+	balancesByRoot func(context.Context, [32]byte) ([]uint64, error) // handler to obtain balances for the state with a given root
 }
 
 // Store defines the fork choice store which includes block nodes and the last view of checkpoint information.

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -81,5 +81,5 @@ type Setter interface {
 	SetGenesisTime(uint64)
 	SetOriginRoot([32]byte)
 	NewSlot(context.Context, types.Slot) error
-	SetBalancesByRoot(BalancesByRooter) ([]uint64, error)
+	SetBalancesByRooter(BalancesByRooter) ([]uint64, error)
 }

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -77,4 +77,5 @@ type Setter interface {
 	SetGenesisTime(uint64)
 	SetOriginRoot([32]byte)
 	NewSlot(context.Context, types.Slot) error
+	SetBalancesByRoot(func(context.Context, [32]byte) ([]uint64, error))
 }

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -81,5 +81,5 @@ type Setter interface {
 	SetGenesisTime(uint64)
 	SetOriginRoot([32]byte)
 	NewSlot(context.Context, types.Slot) error
-	SetBalancesByRooter(BalancesByRooter) ([]uint64, error)
+	SetBalancesByRooter(BalancesByRooter)
 }

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -10,6 +10,10 @@ import (
 	v1 "github.com/prysmaticlabs/prysm/v3/proto/eth/v1"
 )
 
+// BalanceByRooter is a handler to obtain the effective balances of the state
+// with the given block root
+type BalancesByRooter func(context.Context, [32]byte) ([]uint64, error)
+
 // ForkChoicer represents the full fork choice interface composed of all the sub-interfaces.
 type ForkChoicer interface {
 	HeadRetriever        // to compute head.
@@ -77,5 +81,5 @@ type Setter interface {
 	SetGenesisTime(uint64)
 	SetOriginRoot([32]byte)
 	NewSlot(context.Context, types.Slot) error
-	SetBalancesByRoot(func(context.Context, [32]byte) ([]uint64, error))
+	SetBalancesByRoot(BalancesByRooter) ([]uint64, error)
 }

--- a/beacon-chain/state/stategen/BUILD.bazel
+++ b/beacon-chain/state/stategen/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     deps = [
         "//beacon-chain/core/altair:go_default_library",
         "//beacon-chain/core/execution:go_default_library",
+        "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/db:go_default_library",

--- a/beacon-chain/state/stategen/errors.go
+++ b/beacon-chain/state/stategen/errors.go
@@ -5,3 +5,6 @@ import "errors"
 var errUnknownBoundaryState = errors.New("unknown boundary state")
 var errUnknownState = errors.New("unknown state")
 var errUnknownBlock = errors.New("unknown block")
+
+// errNilState returns when we have obtained a nil state from stategen
+var errNilState = errors.New("nil state from stategen")

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -74,7 +74,7 @@ func (s *State) BalancesByRoot(ctx context.Context, blockRoot [32]byte) ([]uint6
 	epoch := time.CurrentEpoch(st)
 
 	balances := make([]uint64, st.NumValidators())
-	var balanceAccumulator = func(idx int, val state.ReadOnlyValidator) error {
+	var balanceAccretor = func(idx int, val state.ReadOnlyValidator) error {
 		if helpers.IsActiveValidatorUsingTrie(val, epoch) {
 			balances[idx] = val.EffectiveBalance()
 		} else {
@@ -82,7 +82,7 @@ func (s *State) BalancesByRoot(ctx context.Context, blockRoot [32]byte) ([]uint6
 		}
 		return nil
 	}
-	if err := st.ReadFromEveryValidator(balanceAccumulator); err != nil {
+	if err := st.ReadFromEveryValidator(balanceAccretor); err != nil {
 		return nil, err
 	}
 	return balances, nil

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/time"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
@@ -57,6 +59,33 @@ func (s *State) StateByRoot(ctx context.Context, blockRoot [32]byte) (state.Beac
 		return s.beaconDB.GenesisState(ctx)
 	}
 	return s.loadStateByRoot(ctx, blockRoot)
+}
+
+// BalancesByRoot retrieves the effective balances of all validators at the
+// state with a given root
+func (s *State) BalancesByRoot(ctx context.Context, blockRoot [32]byte) ([]uint64, error) {
+	st, err := s.StateByRoot(ctx, blockRoot)
+	if err != nil {
+		return nil, err
+	}
+	if st == nil || st.IsNil() {
+		return nil, errNilState
+	}
+	epoch := time.CurrentEpoch(st)
+
+	balances := make([]uint64, st.NumValidators())
+	var balanceAccumulator = func(idx int, val state.ReadOnlyValidator) error {
+		if helpers.IsActiveValidatorUsingTrie(val, epoch) {
+			balances[idx] = val.EffectiveBalance()
+		} else {
+			balances[idx] = 0
+		}
+		return nil
+	}
+	if err := st.ReadFromEveryValidator(balanceAccumulator); err != nil {
+		return nil, err
+	}
+	return balances, nil
 }
 
 // StateByRootInitialSync retrieves the state from the DB for the initial syncing phase.

--- a/beacon-chain/state/stategen/getter_test.go
+++ b/beacon-chain/state/stategen/getter_test.go
@@ -54,6 +54,13 @@ func TestStateByRoot_ColdState(t *testing.T) {
 	loadedState, err := service.StateByRoot(ctx, bRoot)
 	require.NoError(t, err)
 	require.DeepSSZEqual(t, loadedState.InnerStateUnsafe(), beaconState.InnerStateUnsafe())
+
+	bal, err := service.BalancesByRoot(ctx, bRoot)
+	require.NoError(t, err)
+	require.Equal(t, 32, len(bal))
+	for i := range bal {
+		require.Equal(t, params.BeaconConfig().MaxEffectiveBalance, bal[i])
+	}
 }
 
 func TestStateByRootIfCachedNoCopy_HotState(t *testing.T) {

--- a/beacon-chain/state/stategen/mock/mock.go
+++ b/beacon-chain/state/stategen/mock/mock.go
@@ -52,7 +52,7 @@ func (m *MockStateManager) StateByRoot(_ context.Context, blockRoot [32]byte) (s
 }
 
 // BalancesByRoot --
-func (m *MockStateManager) BalancesByRoot(_ context.Context, blockRoot [32]byte) ([]uint64, error) {
+func (_ *MockStateManager) BalancesByRoot(_ context.Context, _ [32]byte) ([]uint64, error) {
 	return []uint64{}, nil
 }
 

--- a/beacon-chain/state/stategen/mock/mock.go
+++ b/beacon-chain/state/stategen/mock/mock.go
@@ -52,7 +52,7 @@ func (m *MockStateManager) StateByRoot(_ context.Context, blockRoot [32]byte) (s
 }
 
 // BalancesByRoot --
-func (_ *MockStateManager) BalancesByRoot(_ context.Context, _ [32]byte) ([]uint64, error) {
+func (*MockStateManager) BalancesByRoot(_ context.Context, _ [32]byte) ([]uint64, error) {
 	return []uint64{}, nil
 }
 

--- a/beacon-chain/state/stategen/mock/mock.go
+++ b/beacon-chain/state/stategen/mock/mock.go
@@ -51,6 +51,11 @@ func (m *MockStateManager) StateByRoot(_ context.Context, blockRoot [32]byte) (s
 	return m.StatesByRoot[blockRoot], nil
 }
 
+// BalancesByRoot --
+func (m *MockStateManager) BalancesByRoot(_ context.Context, blockRoot [32]byte) ([]uint64, error) {
+	return []uint64{}, nil
+}
+
 // StateByRootInitialSync --
 func (_ *MockStateManager) StateByRootInitialSync(_ context.Context, _ [32]byte) (state.BeaconState, error) {
 	panic("implement me")

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -94,7 +94,7 @@ func New(beaconDB db.NoHeadAccessDatabase, fc forkchoice.ForkChoicer, opts ...St
 	for _, o := range opts {
 		o(s)
 	}
-	fc.SetBalancesByRoot(s.BalancesByRoot)
+	fc.SetBalancesByRooter(s.BalancesByRoot)
 
 	return s
 }

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -33,6 +33,7 @@ type StateManager interface {
 	SaveFinalizedState(fSlot types.Slot, fRoot [32]byte, fState state.BeaconState)
 	MigrateToCold(ctx context.Context, fRoot [32]byte) error
 	StateByRoot(ctx context.Context, blockRoot [32]byte) (state.BeaconState, error)
+	BalancesByRoot(context.Context, [32]byte) ([]uint64, error)
 	StateByRootIfCachedNoCopy(blockRoot [32]byte) state.BeaconState
 	StateByRootInitialSync(ctx context.Context, blockRoot [32]byte) (state.BeaconState, error)
 }
@@ -93,6 +94,7 @@ func New(beaconDB db.NoHeadAccessDatabase, fc forkchoice.ForkChoicer, opts ...St
 	for _, o := range opts {
 		o(s)
 	}
+	fc.SetBalancesByRoot(s.BalancesByRoot)
 
 	return s
 }


### PR DESCRIPTION
This PR adds a handler to forkchoice to request justified balances only when the justified checkpoint has changed instead of receiving this information on every call to Head. At this moment this is a setter function that just sets this handler and an implementation in the stategen package.