### PR TITLE
Cache proposer slot index for GetProposerDuties

### DIFF
--- a/beacon-chain/rpc/eth/validator/server.go
+++ b/beacon-chain/rpc/eth/validator/server.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/blockchain"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/attestations"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/synccommittee"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/p2p"
@@ -13,15 +14,16 @@ import (
 // Server defines a server implementation of the gRPC Validator service,
 // providing RPC endpoints intended for validator clients.
 type Server struct {
-	HeadFetcher           blockchain.HeadFetcher
-	HeadUpdater           blockchain.HeadUpdater
-	TimeFetcher           blockchain.TimeFetcher
-	SyncChecker           sync.Checker
-	AttestationsPool      attestations.Pool
-	PeerManager           p2p.PeerManager
-	Broadcaster           p2p.Broadcaster
-	StateFetcher          statefetcher.Fetcher
-	OptimisticModeFetcher blockchain.OptimisticModeFetcher
-	SyncCommitteePool     synccommittee.Pool
-	V1Alpha1Server        *v1alpha1validator.Server
+	HeadFetcher            blockchain.HeadFetcher
+	HeadUpdater            blockchain.HeadUpdater
+	TimeFetcher            blockchain.TimeFetcher
+	SyncChecker            sync.Checker
+	AttestationsPool       attestations.Pool
+	PeerManager            p2p.PeerManager
+	Broadcaster            p2p.Broadcaster
+	StateFetcher           statefetcher.Fetcher
+	OptimisticModeFetcher  blockchain.OptimisticModeFetcher
+	SyncCommitteePool      synccommittee.Pool
+	V1Alpha1Server         *v1alpha1validator.Server
+	ProposerSlotIndexCache *cache.ProposerPayloadIDsCache
 }

--- a/beacon-chain/rpc/eth/validator/validator.go
+++ b/beacon-chain/rpc/eth/validator/validator.go
@@ -166,6 +166,7 @@ func (vs *Server) GetProposerDuties(ctx context.Context, req *ethpbv1.ProposerDu
 		pubkey48 := val.PublicKey()
 		pubkey := pubkey48[:]
 		for _, s := range ss {
+			vs.ProposerSlotIndexCache.SetProposerAndPayloadIDs(s, index, [8]byte{} /* payloadID */, [32]byte{} /* head root */)
 			duties = append(duties, &ethpbv1.ProposerDuty{
 				Pubkey:         pubkey,
 				ValidatorIndex: index,

--- a/beacon-chain/rpc/eth/validator/validator_test.go
+++ b/beacon-chain/rpc/eth/validator/validator_test.go
@@ -292,10 +292,11 @@ func TestGetProposerDuties(t *testing.T) {
 		State: bs, Root: genesisRoot[:], Slot: &chainSlot,
 	}
 	vs := &Server{
-		HeadFetcher:           chain,
-		TimeFetcher:           chain,
-		OptimisticModeFetcher: chain,
-		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		HeadFetcher:            chain,
+		TimeFetcher:            chain,
+		OptimisticModeFetcher:  chain,
+		SyncChecker:            &mockSync.Sync{IsSyncing: false},
+		ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
 	}
 
 	t.Run("Ok", func(t *testing.T) {
@@ -313,6 +314,9 @@ func TestGetProposerDuties(t *testing.T) {
 				expectedDuty = duty
 			}
 		}
+		vid, _, has := vs.ProposerSlotIndexCache.GetProposerPayloadIDs(11, [32]byte{})
+		require.Equal(t, true, has)
+		require.Equal(t, types.ValidatorIndex(9982), vid)
 		require.NotNil(t, expectedDuty, "Expected duty for slot 11 not found")
 		assert.Equal(t, types.ValidatorIndex(9982), expectedDuty.ValidatorIndex)
 		assert.DeepEqual(t, pubKeys[9982], expectedDuty.Pubkey)
@@ -343,10 +347,11 @@ func TestGetProposerDuties(t *testing.T) {
 			State: bs, Root: genesisRoot[:], Slot: &chainSlot,
 		}
 		vs := &Server{
-			HeadFetcher:           chain,
-			TimeFetcher:           chain,
-			OptimisticModeFetcher: chain,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
+			HeadFetcher:            chain,
+			TimeFetcher:            chain,
+			OptimisticModeFetcher:  chain,
+			SyncChecker:            &mockSync.Sync{IsSyncing: false},
+			ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
 		}
 
 		req := &ethpbv1.ProposerDutiesRequest{
@@ -393,10 +398,11 @@ func TestGetProposerDuties(t *testing.T) {
 			State: bs, Root: genesisRoot[:], Slot: &chainSlot, Optimistic: true,
 		}
 		vs := &Server{
-			HeadFetcher:           chain,
-			TimeFetcher:           chain,
-			OptimisticModeFetcher: chain,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
+			HeadFetcher:            chain,
+			TimeFetcher:            chain,
+			OptimisticModeFetcher:  chain,
+			SyncChecker:            &mockSync.Sync{IsSyncing: false},
+			ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
 		}
 		req := &ethpbv1.ProposerDutiesRequest{
 			Epoch: 0,

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -239,7 +239,8 @@ func (s *Service) Start() {
 			StateGenService:    s.cfg.StateGen,
 			ReplayerBuilder:    ch,
 		},
-		SyncCommitteePool: s.cfg.SyncCommitteeObjectPool,
+		SyncCommitteePool:      s.cfg.SyncCommitteeObjectPool,
+		ProposerSlotIndexCache: s.cfg.ProposerIdsCache,
 	}
 
 	nodeServer := &nodev1alpha1.Server{


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix


**What does this PR do? Why is it needed?**

Cache proposer index and slot for `GetProposerDuties` so FCU can be called with a payload attribute. If it's not cached then prysm will not prepare payload ahead which will lead to blocks with empty tx

**Which issues(s) does this PR fix?**

Fixes #11516 
Fixes #11520

**Other notes for review**

Sooner or later, we should adult beacon API for compliance against prysm API
