### PR TITLE
fix panic when the rpc client is not initialized

### DIFF
--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -112,6 +112,18 @@ type RPCClient interface {
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 }
 
+type RPCClientUninitialize struct {
+}
+
+func (RPCClientUninitialize) Close() {}
+func (RPCClientUninitialize) BatchCall([]gethRPC.BatchElem) error {
+	return errors.New("BatchCall to a RPCClientUnitialized")
+}
+
+func (RPCClientUninitialize) CallContext(context.Context, interface{}, string, ...interface{}) error {
+	return errors.New("CallContext to a RPCClientUnitialized")
+}
+
 // config defines a config struct for dependencies into the service.
 type config struct {
 	depositContractAddr     common.Address
@@ -169,8 +181,9 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 	}
 
 	s := &Service{
-		ctx:    ctx,
-		cancel: cancel,
+		ctx:       ctx,
+		cancel:    cancel,
+		rpcClient: RPCClientUninitialize{},
 		cfg: &config{
 			beaconNodeStatsUpdater: &NopBeaconNodeStatsUpdater{},
 			eth1HeaderReqLimit:     defaultEth1HeaderReqLimit,

--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -121,7 +121,7 @@ func (RPCClientUninitialize) BatchCall([]gethRPC.BatchElem) error {
 }
 
 func (RPCClientUninitialize) CallContext(context.Context, interface{}, string, ...interface{}) error {
-	return errors.New("CallContext to a RPCClientUnitialized")
+	return errors.New("rpc client is not initialized")
 }
 
 // config defines a config struct for dependencies into the service.

--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -112,7 +112,7 @@ type RPCClient interface {
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 }
 
-type RPCClientUninitialize struct {
+type RPCClientEmpty struct {
 }
 
 func (RPCClientUninitialize) Close() {}

--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -115,12 +115,12 @@ type RPCClient interface {
 type RPCClientEmpty struct {
 }
 
-func (RPCClientUninitialize) Close() {}
-func (RPCClientUninitialize) BatchCall([]gethRPC.BatchElem) error {
-	return errors.New("rpc client is not initialized)
+func (RPCClientEmpty) Close() {}
+func (RPCClientEmpty) BatchCall([]gethRPC.BatchElem) error {
+	return errors.New("rpc client is not initialized")
 }
 
-func (RPCClientUninitialize) CallContext(context.Context, interface{}, string, ...interface{}) error {
+func (RPCClientEmpty) CallContext(context.Context, interface{}, string, ...interface{}) error {
 	return errors.New("rpc client is not initialized")
 }
 
@@ -183,7 +183,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 	s := &Service{
 		ctx:       ctx,
 		cancel:    cancel,
-		rpcClient: RPCClientUninitialize{},
+		rpcClient: RPCClientEmpty{},
 		cfg: &config{
 			beaconNodeStatsUpdater: &NopBeaconNodeStatsUpdater{},
 			eth1HeaderReqLimit:     defaultEth1HeaderReqLimit,

--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -117,7 +117,7 @@ type RPCClientUninitialize struct {
 
 func (RPCClientUninitialize) Close() {}
 func (RPCClientUninitialize) BatchCall([]gethRPC.BatchElem) error {
-	return errors.New("BatchCall to a RPCClientUnitialized")
+	return errors.New("rpc client is not initialized)
 }
 
 func (RPCClientUninitialize) CallContext(context.Context, interface{}, string, ...interface{}) error {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix


fixes this panic when the code tries to call the rpc client before it is initialized

```
[2022-09-26 07:03:54]  INFO initial-sync: Processing block batch of size 25 starting from  0xb89eddc1... 3960641/3972319 - estimated time remaining 2h35m42s blocksPerSecond=1.2 
peers=6                                                                                                                                                                          
panic: runtime error: invalid memory address or nil pointer dereference                                                                                                          
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x23abfa6]                                                                                                         
                                                                                                                                                                                 
goroutine 326 [running]:                                                                                                                                                         
github.com/prysmaticlabs/prysm/v3/beacon-chain/execution.(*Service).NewPayload(0xc000012380, {0xbbad20?, 0xc046a836e0?}, {0xbcba90, 0xc01e95b040})                               
        beacon-chain/execution/engine_client.go:100 +0x246                                                                                                                       
github.com/prysmaticlabs/prysm/v3/beacon-chain/blockchain.(*Service).notifyNewPayload(0xc0001d0000, {0xbbad20?, 0xc023134f90?}, 0x2, 0xbc9e40?, {0xbc9e40, 0xc01d3c1b90})        
        beacon-chain/blockchain/execution_engine.go:215 +0x227                                                                                                                   
github.com/prysmaticlabs/prysm/v3/beacon-chain/blockchain.(*Service).onBlockBatch(0xc0001d0000, {0xbbad20?, 0xc023134f60?}, {0xc01a3261c0, 0x19, 0x0?}, {0xc023eb1c00, 0x19, 0x0?
})                                                                                                                                                                               
        beacon-chain/blockchain/process_block.go:416 +0x1212                                                                                                                     
github.com/prysmaticlabs/prysm/v3/beacon-chain/blockchain.(*Service).ReceiveBlockBatch(0xc0001d0000, {0xbbac78?, 0xc01a127440?}, {0xc01a3261c0, 0x19, 0x24}, {0xc023eb1c00, 0x19,
 0x19})                                                                                                                                                                          
        beacon-chain/blockchain/receive_block.go:93 +0x151                                                                                                                       
github.com/prysmaticlabs/prysm/v3/beacon-chain/sync/initial-sync.(*Service).processBatchedBlocks(0xc0133a8240, {0xbbac78, 0xc01a127440}, {0x186eca5?, 0x60?, 0x30d9400?}, {0xc01a
326000, 0x35, 0x40}, 0xc00d371630)                                                                                                                                               
        beacon-chain/sync/initial-sync/round_robin.go:288 +0x8e7                                                                                                                 
github.com/prysmaticlabs/prysm/v3/beacon-chain/sync/initial-sync.(*Service).processFetchedData(0xc01a125b90?, {0xbbac78?, 0xc01a127440?}, {0xc00d371680?, 0x0?, 0x30d9400?}, 0xc0
1a119548?, 0x0?)                                                                                                                                                                 
        beacon-chain/sync/initial-sync/round_robin.go:131 +0x11e                                                                                                                 
github.com/prysmaticlabs/prysm/v3/beacon-chain/sync/initial-sync.(*Service).syncToFinalizedEpoch(0xc0133a8240, {0xbbac78, 0xc01a127440}, {0x337f60?, 0x2ec4a30?, 0x30d9400?})    
        beacon-chain/sync/initial-sync/round_robin.go:84 +0x285                                                                                                                  
github.com/prysmaticlabs/prysm/v3/beacon-chain/sync/initial-sync.(*Service).roundRobinSync(0xc0133a8240, {0xe00000004?, 0xc000087ce0?, 0x30d9400?})                              
        beacon-chain/sync/initial-sync/round_robin.go:47 +0x187                                                                                                                  
github.com/prysmaticlabs/prysm/v3/beacon-chain/sync/initial-sync.(*Service).Start(0xc0133a8240)                                                                                  
        beacon-chain/sync/initial-sync/service.go:105 +0x597                                                                                                                     
created by github.com/prysmaticlabs/prysm/v3/runtime.(*ServiceRegistry).StartAll                                                                                                 
        runtime/service_registry.go:46 +0x210       
```

also reported in the flashbot repo
https://github.com/flashbots/prysm/issues/7