### PR TITLE
Cache hash tree root for beacon block

### DIFF
--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -392,9 +392,25 @@ func (b *BeaconBlock) HashTreeRoot() ([field_params.RootLength]byte, error) {
 		return pb.(*eth.BeaconBlockAltair).HashTreeRoot()
 	case version.Bellatrix:
 		if b.IsBlinded() {
-			return pb.(*eth.BlindedBeaconBlockBellatrix).HashTreeRoot()
+			if b.htr != [32]byte{} {
+				return b.htr, nil
+			}
+			r, err := pb.(*eth.BlindedBeaconBlockBellatrix).HashTreeRoot()
+			if err != nil {
+				return [32]byte{}, err
+			}
+			b.htr = r
+			return r, nil
 		}
-		return pb.(*eth.BeaconBlockBellatrix).HashTreeRoot()
+		if b.htr != [32]byte{} {
+			return b.htr, nil
+		}
+		r, err := pb.(*eth.BeaconBlockBellatrix).HashTreeRoot()
+		if err != nil {
+			return [32]byte{}, err
+		}
+		b.htr = r
+		return r, nil
 	default:
 		return [field_params.RootLength]byte{}, errIncorrectBlockVersion
 	}

--- a/consensus-types/blocks/types.go
+++ b/consensus-types/blocks/types.go
@@ -61,6 +61,7 @@ type BeaconBlock struct {
 	parentRoot    [field_params.RootLength]byte
 	stateRoot     [field_params.RootLength]byte
 	body          *BeaconBlockBody
+	htr           [32]byte
 }
 
 // SignedBeaconBlock is the main signed beacon block structure. It can represent any block type.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Optimization

**What does this PR do? Why is it needed?**

Hash tree root is no longer cheap post-merge with the additional execution transactions. Hash tree root for a block takes between 5-15ms on my MacBook. Hash tree root is called 7-10 times to process a regular block and more when historically syncing a block. Examples:

- `RecieveBlock`
- `HeadRoot`
- `ProcessBlockHeader`
- `VerifyBlockSignatureUsingCurrentFork`
- `ComputeSigningRoot`
- `ProcessBlockNoVerifyAnySig`
- `SaveBlock` / `SaveBlocks`

There's no reason to hash tree root a block more than once. We could just cache the result of the hash tree root. I believe we could save between 20-50ms of block processing time with this and increase historical syncing speed. 

Considerations:
- As we are HTR the block for cache, we probably should lock the process 
- Another way to approach this problem is to HTR once at the earliest caller and daisy chain root down for functional argument. This change is arguably more invasive, and we'll have to worry about the second-order effect 


