### PR TITLE
Keymanager API: fix fee recipient API and add persistence

### DIFF
--- a/validator/accounts/testing/BUILD.bazel
+++ b/validator/accounts/testing/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//validator:__subpackages__",
     ],
     deps = [
+        "//config/validator/service:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//validator/accounts/iface:go_default_library",

--- a/validator/accounts/testing/mock.go
+++ b/validator/accounts/testing/mock.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	validatorserviceconfig "github.com/prysmaticlabs/prysm/v3/config/validator/service"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v3/validator/accounts/iface"
@@ -81,7 +82,8 @@ func (_ *Wallet) InitializeKeymanager(_ context.Context, _ iface.InitKeymanagerC
 }
 
 type MockValidator struct {
-	Km keymanager.IKeymanager
+	Km               keymanager.IKeymanager
+	proposerSettings *validatorserviceconfig.ProposerSettings
 }
 
 func (_ MockValidator) LogSyncCommitteeMessagesSubmitted() {}
@@ -196,4 +198,14 @@ func (_ MockValidator) SetPubKeyToValidatorIndexMap(_ context.Context, _ keymana
 // SignValidatorRegistrationRequest for mocking
 func (_ MockValidator) SignValidatorRegistrationRequest(_ context.Context, _ iface2.SigningFunc, _ *ethpb.ValidatorRegistrationV1) (*ethpb.SignedValidatorRegistrationV1, error) {
 	panic("implement me")
+}
+
+// ProposerSettings for mocking
+func (m *MockValidator) ProposerSettings() *validatorserviceconfig.ProposerSettings {
+	return m.proposerSettings
+}
+
+// SetProposerSettings for mocking
+func (m *MockValidator) SetProposerSettings(settings *validatorserviceconfig.ProposerSettings) {
+	m.proposerSettings = settings
 }

--- a/validator/client/iface/BUILD.bazel
+++ b/validator/client/iface/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//validator:__subpackages__"],
     deps = [
         "//config/fieldparams:go_default_library",
+        "//config/validator/service:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//crypto/bls:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",

--- a/validator/client/iface/validator.go
+++ b/validator/client/iface/validator.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
+	validatorserviceconfig "github.com/prysmaticlabs/prysm/v3/config/validator/service"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/crypto/bls"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
@@ -60,9 +61,10 @@ type Validator interface {
 	ReceiveBlocks(ctx context.Context, connectionErrorChannel chan<- error)
 	HandleKeyReload(ctx context.Context, newKeys [][fieldparams.BLSPubkeyLength]byte) (bool, error)
 	CheckDoppelGanger(ctx context.Context) error
-	HasProposerSettings() bool
 	PushProposerSettings(ctx context.Context, km keymanager.IKeymanager) error
 	SignValidatorRegistrationRequest(ctx context.Context, signer SigningFunc, newValidatorRegistration *ethpb.ValidatorRegistrationV1) (*ethpb.SignedValidatorRegistrationV1, error)
+	ProposerSettings() *validatorserviceconfig.ProposerSettings
+	SetProposerSettings(*validatorserviceconfig.ProposerSettings)
 }
 
 // SigningFunc interface defines a type for the a function that signs a message

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -56,8 +56,8 @@ func run(ctx context.Context, v iface.Validator) {
 	}
 	sub := km.SubscribeAccountChanges(accountsChangedChan)
 	// Set properties on the beacon node like the fee recipient for validators that are being used & active.
-	if v.HasProposerSettings() {
-		log.Infof("Provided proposer settings will periodically update settings such as fee recipient"+
+	if v.ProposerSettings() != nil {
+		log.Infof("Validator client started with provided proposer settings. The client will periodically signal updated settings such as fee recipient"+
 			" in the beacon node and custom builder ( if --%s)", flags.EnableBuilderFlag.Name)
 		if err := v.PushProposerSettings(ctx, km); err != nil {
 			if errors.Is(err, ErrBuilderValidatorRegistration) {
@@ -67,7 +67,7 @@ func run(ctx context.Context, v iface.Validator) {
 			}
 		}
 	} else {
-		log.Info("Proposer settings such as fee recipient are not defined in the validator client" +
+		log.Warnln("Validator client started without proposer settings such as fee recipient" +
 			" and will continue to use settings provided in the beacon node.")
 	}
 
@@ -127,7 +127,7 @@ func run(ctx context.Context, v iface.Validator) {
 				continue
 			}
 
-			if slots.IsEpochStart(slot) && v.HasProposerSettings() {
+			if slots.IsEpochStart(slot) && v.ProposerSettings() != nil {
 				go func() {
 					//deadline set for next epoch rounded up
 					if err := v.PushProposerSettings(ctx, km); err != nil {

--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -57,8 +57,8 @@ func run(ctx context.Context, v iface.Validator) {
 	sub := km.SubscribeAccountChanges(accountsChangedChan)
 	// Set properties on the beacon node like the fee recipient for validators that are being used & active.
 	if v.ProposerSettings() != nil {
-		log.Infof("Validator client started with provided proposer settings. The client will periodically signal updated settings such as fee recipient"+
-			" in the beacon node and custom builder ( if --%s)", flags.EnableBuilderFlag.Name)
+		log.Infof("Validator client started with provided proposer settings that sets options such as fee recipient"+
+			" and will periodically update the beacon node and custom builder ( if --%s)", flags.EnableBuilderFlag.Name)
 		if err := v.PushProposerSettings(ctx, km); err != nil {
 			if errors.Is(err, ErrBuilderValidatorRegistration) {
 				log.WithError(err).Warn("Push proposer settings error")

--- a/validator/client/runner_test.go
+++ b/validator/client/runner_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v3/async/event"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
+	validatorserviceconfig "github.com/prysmaticlabs/prysm/v3/config/validator/service"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/testing/assert"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
@@ -249,6 +251,11 @@ func TestKeyReload_RemoteKeymanager(t *testing.T) {
 
 func TestUpdateProposerSettingsAt_EpochStart(t *testing.T) {
 	v := &testutil.FakeValidator{Km: &mockKeymanager{accountsChangedFeed: &event.Feed{}}}
+	v.SetProposerSettings(&validatorserviceconfig.ProposerSettings{
+		DefaultConfig: &validatorserviceconfig.ProposerOption{
+			FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455012BFEBf6177F1D2e9738D9"),
+		},
+	})
 	ctx, cancel := context.WithCancel(context.Background())
 	hook := logTest.NewGlobal()
 	slot := params.BeaconConfig().SlotsPerEpoch
@@ -270,6 +277,11 @@ func TestUpdateProposerSettings_ContinuesAfterValidatorRegistrationFails(t *test
 		ProposerSettingsErr: errors.Wrap(ErrBuilderValidatorRegistration, errSomeotherError.Error()),
 		Km:                  &mockKeymanager{accountsChangedFeed: &event.Feed{}},
 	}
+	v.SetProposerSettings(&validatorserviceconfig.ProposerSettings{
+		DefaultConfig: &validatorserviceconfig.ProposerOption{
+			FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455012BFEBf6177F1D2e9738D9"),
+		},
+	})
 	ctx, cancel := context.WithCancel(context.Background())
 	hook := logTest.NewGlobal()
 	slot := params.BeaconConfig().SlotsPerEpoch

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -69,7 +69,7 @@ type ValidatorService struct {
 	grpcHeaders           []string
 	graffiti              []byte
 	Web3SignerConfig      *remoteweb3signer.SetupConfig
-	ProposerSettings      *validatorserviceconfig.ProposerSettings
+	proposerSettings      *validatorserviceconfig.ProposerSettings
 }
 
 // Config for the validator service.
@@ -120,7 +120,7 @@ func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, e
 		interopKeysConfig:     cfg.InteropKeysConfig,
 		graffitiStruct:        cfg.GraffitiStruct,
 		Web3SignerConfig:      cfg.Web3SignerConfig,
-		ProposerSettings:      cfg.ProposerSettings,
+		proposerSettings:      cfg.ProposerSettings,
 	}
 
 	dialOpts := ConstructDialOptions(
@@ -204,7 +204,7 @@ func (v *ValidatorService) Start() {
 		graffitiOrderedIndex:           graffitiOrderedIndex,
 		eipImportBlacklistedPublicKeys: slashablePublicKeys,
 		Web3SignerConfig:               v.Web3SignerConfig,
-		ProposerSettings:               v.ProposerSettings,
+		proposerSettings:               v.proposerSettings,
 		walletInitializedChannel:       make(chan *wallet.Wallet, 1),
 	}
 	// To resolve a race condition at startup due to the interface
@@ -246,6 +246,15 @@ func (v *ValidatorService) InteropKeysConfig() *local.InteropKeymanagerConfig {
 
 func (v *ValidatorService) Keymanager() (keymanager.IKeymanager, error) {
 	return v.validator.Keymanager()
+}
+
+func (v *ValidatorService) ProposerSettings() *validatorserviceconfig.ProposerSettings {
+	return v.validator.ProposerSettings()
+}
+
+func (v *ValidatorService) SetProposerSettings(settings *validatorserviceconfig.ProposerSettings) {
+	v.proposerSettings = settings
+	v.validator.SetProposerSettings(settings)
 }
 
 // ConstructDialOptions constructs a list of grpc dial options

--- a/validator/client/testutil/BUILD.bazel
+++ b/validator/client/testutil/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//validator:__subpackages__"],
     deps = [
         "//config/fieldparams:go_default_library",
+        "//config/validator/service:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -52,6 +52,7 @@ type FakeValidator struct {
 	IndexToPubkeyMap                  map[uint64][fieldparams.BLSPubkeyLength]byte
 	PubkeyToIndexMap                  map[[fieldparams.BLSPubkeyLength]byte]uint64
 	PubkeysToStatusesMap              map[[fieldparams.BLSPubkeyLength]byte]ethpb.ValidatorStatus
+	proposerSettings                  *validatorserviceconfig.ProposerSettings
 	Km                                keymanager.IKeymanager
 }
 
@@ -273,11 +274,11 @@ func (_ *FakeValidator) SignValidatorRegistrationRequest(_ context.Context, _ if
 }
 
 // ProposerSettings for mocking
-func (_ *FakeValidator) ProposerSettings() *validatorserviceconfig.ProposerSettings {
-	return nil
+func (f *FakeValidator) ProposerSettings() *validatorserviceconfig.ProposerSettings {
+	return f.proposerSettings
 }
 
 // SetProposerSettings for mocking
-func (_ *FakeValidator) SetProposerSettings(_ *validatorserviceconfig.ProposerSettings) {
-
+func (f *FakeValidator) SetProposerSettings(settings *validatorserviceconfig.ProposerSettings) {
+	f.proposerSettings = settings
 }

--- a/validator/client/testutil/mock_validator.go
+++ b/validator/client/testutil/mock_validator.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
+	validatorserviceconfig "github.com/prysmaticlabs/prysm/v3/config/validator/service"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	prysmTime "github.com/prysmaticlabs/prysm/v3/time"
@@ -269,4 +270,14 @@ func (_ *FakeValidator) SetPubKeyToValidatorIndexMap(_ context.Context, _ keyman
 // SignValidatorRegistrationRequest for mocking
 func (_ *FakeValidator) SignValidatorRegistrationRequest(_ context.Context, _ iface.SigningFunc, _ *ethpb.ValidatorRegistrationV1) (*ethpb.SignedValidatorRegistrationV1, error) {
 	return nil, nil
+}
+
+// ProposerSettings for mocking
+func (_ *FakeValidator) ProposerSettings() *validatorserviceconfig.ProposerSettings {
+	return nil
+}
+
+// SetProposerSettings for mocking
+func (_ *FakeValidator) SetProposerSettings(_ *validatorserviceconfig.ProposerSettings) {
+
 }

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -100,7 +100,7 @@ type validator struct {
 	voteStats                          voteStats
 	syncCommitteeStats                 syncCommitteeStats
 	Web3SignerConfig                   *remoteweb3signer.SetupConfig
-	ProposerSettings                   *validatorserviceconfig.ProposerSettings
+	proposerSettings                   *validatorserviceconfig.ProposerSettings
 	walletInitializedChannel           chan *wallet.Wallet
 }
 
@@ -964,8 +964,12 @@ func (v *validator) logDuties(slot types.Slot, duties []*ethpb.DutiesResponse_Du
 	}
 }
 
-func (v *validator) HasProposerSettings() bool {
-	return v.ProposerSettings != nil
+func (v *validator) ProposerSettings() *validatorserviceconfig.ProposerSettings {
+	return v.proposerSettings
+}
+
+func (v *validator) SetProposerSettings(settings *validatorserviceconfig.ProposerSettings) {
+	v.proposerSettings = settings
 }
 
 // PushProposerSettings calls the prepareBeaconProposer RPC to set the fee recipient and also the register validator API if using a custom builder.
@@ -1035,11 +1039,11 @@ func (v *validator) buildPrepProposerReqs(ctx context.Context, pubkeys [][fieldp
 			v.pubkeyToValidatorIndex[k] = i
 		}
 		feeRecipient := common.HexToAddress(params.BeaconConfig().EthBurnAddressHex)
-		if v.ProposerSettings.DefaultConfig != nil {
-			feeRecipient = v.ProposerSettings.DefaultConfig.FeeRecipient // Use cli config for fee recipient.
+		if v.ProposerSettings().DefaultConfig != nil {
+			feeRecipient = v.ProposerSettings().DefaultConfig.FeeRecipient // Use cli config for fee recipient.
 		}
-		if v.ProposerSettings.ProposeConfig != nil {
-			config, ok := v.ProposerSettings.ProposeConfig[k]
+		if v.ProposerSettings().ProposeConfig != nil {
+			config, ok := v.ProposerSettings().ProposeConfig[k]
 			if ok && config != nil {
 				feeRecipient = config.FeeRecipient // Use file config for fee recipient.
 			}
@@ -1065,16 +1069,16 @@ func (v *validator) buildSignedRegReqs(ctx context.Context, pubkeys [][fieldpara
 		feeRecipient := common.HexToAddress(params.BeaconConfig().EthBurnAddressHex)
 		gasLimit := params.BeaconConfig().DefaultBuilderGasLimit
 		enabled := false
-		if v.ProposerSettings.DefaultConfig != nil {
-			feeRecipient = v.ProposerSettings.DefaultConfig.FeeRecipient // Use cli config for fee recipient.
-			config := v.ProposerSettings.DefaultConfig.BuilderConfig
+		if v.ProposerSettings().DefaultConfig != nil {
+			feeRecipient = v.ProposerSettings().DefaultConfig.FeeRecipient // Use cli config for fee recipient.
+			config := v.ProposerSettings().DefaultConfig.BuilderConfig
 			if config != nil && config.Enabled {
 				gasLimit = uint64(config.GasLimit) // Use cli config for gas limit.
 				enabled = true
 			}
 		}
-		if v.ProposerSettings.ProposeConfig != nil {
-			config, ok := v.ProposerSettings.ProposeConfig[k]
+		if v.ProposerSettings().ProposeConfig != nil {
+			config, ok := v.ProposerSettings().ProposeConfig[k]
 			if ok && config != nil {
 				feeRecipient = config.FeeRecipient // Use file config for fee recipient.
 				builderConfig := config.BuilderConfig

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -1517,7 +1517,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 						GasLimit: 40000000,
 					},
 				}
-				v.ProposerSettings = &validatorserviceconfig.ProposerSettings{
+				v.SetProposerSettings(&validatorserviceconfig.ProposerSettings{
 					ProposeConfig: config,
 					DefaultConfig: &validatorserviceconfig.ProposerOption{
 						FeeRecipient: common.HexToAddress(defaultFeeHex),
@@ -1526,7 +1526,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 							GasLimit: 35000000,
 						},
 					},
-				}
+				})
 				client.EXPECT().SubmitValidatorRegistrations(
 					gomock.Any(),
 					gomock.Any(),
@@ -1597,7 +1597,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 						GasLimit: 40000000,
 					},
 				}
-				v.ProposerSettings = &validatorserviceconfig.ProposerSettings{
+				v.SetProposerSettings(&validatorserviceconfig.ProposerSettings{
 					ProposeConfig: config,
 					DefaultConfig: &validatorserviceconfig.ProposerOption{
 						FeeRecipient: common.HexToAddress(defaultFeeHex),
@@ -1606,7 +1606,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 							GasLimit: 35000000,
 						},
 					},
-				}
+				})
 				client.EXPECT().SubmitValidatorRegistrations(
 					gomock.Any(),
 					gomock.Any(),
@@ -1669,12 +1669,12 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 				config[keys[0]] = &validatorserviceconfig.ProposerOption{
 					FeeRecipient: common.HexToAddress("0x055Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
 				}
-				v.ProposerSettings = &validatorserviceconfig.ProposerSettings{
+				v.SetProposerSettings(&validatorserviceconfig.ProposerSettings{
 					ProposeConfig: config,
 					DefaultConfig: &validatorserviceconfig.ProposerOption{
 						FeeRecipient: common.HexToAddress(defaultFeeHex),
 					},
-				}
+				})
 				return &v
 			},
 			feeRecipientMap: map[types.ValidatorIndex]string{
@@ -1709,7 +1709,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 				require.NoError(t, err)
 				keys, err := km.FetchValidatingPublicKeys(ctx)
 				require.NoError(t, err)
-				v.ProposerSettings = &validatorserviceconfig.ProposerSettings{
+				v.SetProposerSettings(&validatorserviceconfig.ProposerSettings{
 					ProposeConfig: nil,
 					DefaultConfig: &validatorserviceconfig.ProposerOption{
 						FeeRecipient: common.HexToAddress(defaultFeeHex),
@@ -1718,7 +1718,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 							GasLimit: validatorserviceconfig.Uint64(params.BeaconConfig().DefaultBuilderGasLimit),
 						},
 					},
-				}
+				})
 				client.EXPECT().ValidatorIndex(
 					ctx, // ctx
 					&ethpb.ValidatorIndexRequest{PublicKey: keys[0][:]},
@@ -1765,7 +1765,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 				}
 				err := v.WaitForKeymanagerInitialization(ctx)
 				require.NoError(t, err)
-				v.ProposerSettings = &validatorserviceconfig.ProposerSettings{
+				v.SetProposerSettings(&validatorserviceconfig.ProposerSettings{
 					ProposeConfig: nil,
 					DefaultConfig: &validatorserviceconfig.ProposerOption{
 						FeeRecipient: common.HexToAddress(defaultFeeHex),
@@ -1774,7 +1774,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 							GasLimit: 40000000,
 						},
 					},
-				}
+				})
 				km, err := v.Keymanager()
 				require.NoError(t, err)
 				keys, err := km.FetchValidatingPublicKeys(ctx)
@@ -1843,12 +1843,12 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 				config[keys[0]] = &validatorserviceconfig.ProposerOption{
 					FeeRecipient: common.Address{},
 				}
-				v.ProposerSettings = &validatorserviceconfig.ProposerSettings{
+				v.SetProposerSettings(&validatorserviceconfig.ProposerSettings{
 					ProposeConfig: config,
 					DefaultConfig: &validatorserviceconfig.ProposerOption{
 						FeeRecipient: common.HexToAddress(defaultFeeHex),
 					},
-				}
+				})
 				return &v
 			},
 		},
@@ -1881,12 +1881,12 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 				config[keys[0]] = &validatorserviceconfig.ProposerOption{
 					FeeRecipient: common.HexToAddress("0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"),
 				}
-				v.ProposerSettings = &validatorserviceconfig.ProposerSettings{
+				v.SetProposerSettings(&validatorserviceconfig.ProposerSettings{
 					ProposeConfig: config,
 					DefaultConfig: &validatorserviceconfig.ProposerOption{
 						FeeRecipient: common.HexToAddress(defaultFeeHex),
 					},
-				}
+				})
 				return &v
 			},
 		},
@@ -1926,7 +1926,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 						GasLimit: 40000000,
 					},
 				}
-				v.ProposerSettings = &validatorserviceconfig.ProposerSettings{
+				v.SetProposerSettings(&validatorserviceconfig.ProposerSettings{
 					ProposeConfig: config,
 					DefaultConfig: &validatorserviceconfig.ProposerOption{
 						FeeRecipient: common.HexToAddress(defaultFeeHex),
@@ -1935,7 +1935,7 @@ func TestValidator_PushProposerSettings(t *testing.T) {
 							GasLimit: 40000000,
 						},
 					},
-				}
+				})
 				client.EXPECT().PrepareBeaconProposer(gomock.Any(), &ethpb.PrepareBeaconProposerRequest{
 					Recipients: []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer{
 						{FeeRecipient: common.HexToAddress("0x0").Bytes(), ValidatorIndex: 1},


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

This PR address 2 issues.

1. Fee Recipient API did not periodically call the beacon API with the correct data.#11539
2. Fee Recipient values did not persist correctly after validator restarts. The value will now persist after the start of each epoch if updated through the API. if the validator restarts directly after an update before the beacon API is called then the value will not persist on restart. The value set in the validator client will override values in the beacon node on restart, if one does not wish for the value to overwrite the beacon node's values they should not provide the validator client any on startup. 


**Which issues(s) does this PR fix?**

Fixes #11322,#11539


