### PR TITLE
Expose structs from API Middleware

### DIFF
--- a/beacon-chain/rpc/apimiddleware/custom_handlers.go
+++ b/beacon-chain/rpc/apimiddleware/custom_handlers.go
@@ -29,13 +29,13 @@ var priorityRegex = regexp.MustCompile(`q=(\d+(?:\.\d+)?)`)
 
 type sszConfig struct {
 	fileName     string
-	responseJson sszResponse
+	responseJson SszResponse
 }
 
 func handleGetBeaconStateSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimiddleware.Endpoint, w http.ResponseWriter, req *http.Request) (handled bool) {
 	config := sszConfig{
 		fileName:     "beacon_state.ssz",
-		responseJson: &sszResponseJson{},
+		responseJson: &SszResponseJson{},
 	}
 	return handleGetSSZ(m, endpoint, w, req, config)
 }
@@ -43,7 +43,7 @@ func handleGetBeaconStateSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimi
 func handleGetBeaconBlockSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimiddleware.Endpoint, w http.ResponseWriter, req *http.Request) (handled bool) {
 	config := sszConfig{
 		fileName:     "beacon_block.ssz",
-		responseJson: &sszResponseJson{},
+		responseJson: &SszResponseJson{},
 	}
 	return handleGetSSZ(m, endpoint, w, req, config)
 }
@@ -51,7 +51,7 @@ func handleGetBeaconBlockSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimi
 func handleGetBeaconStateSSZV2(m *apimiddleware.ApiProxyMiddleware, endpoint apimiddleware.Endpoint, w http.ResponseWriter, req *http.Request) (handled bool) {
 	config := sszConfig{
 		fileName:     "beacon_state.ssz",
-		responseJson: &versionedSSZResponseJson{},
+		responseJson: &VersionedSSZResponseJson{},
 	}
 	return handleGetSSZ(m, endpoint, w, req, config)
 }
@@ -59,7 +59,7 @@ func handleGetBeaconStateSSZV2(m *apimiddleware.ApiProxyMiddleware, endpoint api
 func handleGetBeaconBlockSSZV2(m *apimiddleware.ApiProxyMiddleware, endpoint apimiddleware.Endpoint, w http.ResponseWriter, req *http.Request) (handled bool) {
 	config := sszConfig{
 		fileName:     "beacon_block.ssz",
-		responseJson: &versionedSSZResponseJson{},
+		responseJson: &VersionedSSZResponseJson{},
 	}
 	return handleGetSSZ(m, endpoint, w, req, config)
 }
@@ -80,7 +80,7 @@ func handleSubmitBlindedBlockSSZ(
 func handleProduceBlockSSZ(m *apimiddleware.ApiProxyMiddleware, endpoint apimiddleware.Endpoint, w http.ResponseWriter, req *http.Request) (handled bool) {
 	config := sszConfig{
 		fileName:     "produce_beacon_block.ssz",
-		responseJson: &versionedSSZResponseJson{},
+		responseJson: &VersionedSSZResponseJson{},
 	}
 	return handleGetSSZ(m, endpoint, w, req, config)
 }
@@ -93,7 +93,7 @@ func handleProduceBlindedBlockSSZ(
 ) (handled bool) {
 	config := sszConfig{
 		fileName:     "produce_blinded_beacon_block.ssz",
-		responseJson: &versionedSSZResponseJson{},
+		responseJson: &VersionedSSZResponseJson{},
 	}
 	return handleGetSSZ(m, endpoint, w, req, config)
 }
@@ -275,7 +275,7 @@ func preparePostedSSZData(req *http.Request) apimiddleware.ErrorJson {
 	if err != nil {
 		return apimiddleware.InternalServerErrorWithMessage(err, "could not read body")
 	}
-	j := sszRequestJson{Data: base64.StdEncoding.EncodeToString(buf)}
+	j := SszRequestJson{Data: base64.StdEncoding.EncodeToString(buf)}
 	data, err := json.Marshal(j)
 	if err != nil {
 		return apimiddleware.InternalServerErrorWithMessage(err, "could not prepare POST data")
@@ -286,7 +286,7 @@ func preparePostedSSZData(req *http.Request) apimiddleware.ErrorJson {
 	return nil
 }
 
-func serializeMiddlewareResponseIntoSSZ(respJson sszResponse) (version string, ssz []byte, errJson apimiddleware.ErrorJson) {
+func serializeMiddlewareResponseIntoSSZ(respJson SszResponse) (version string, ssz []byte, errJson apimiddleware.ErrorJson) {
 	// Serialize the SSZ part of the deserialized value.
 	data, err := base64.StdEncoding.DecodeString(respJson.SSZData())
 	if err != nil {
@@ -363,16 +363,16 @@ func receiveEvents(eventChan <-chan *sse.Event, w http.ResponseWriter, req *http
 
 			switch string(msg.Event) {
 			case events.HeadTopic:
-				data = &eventHeadJson{}
+				data = &EventHeadJson{}
 			case events.BlockTopic:
-				data = &receivedBlockDataJson{}
+				data = &ReceivedBlockDataJson{}
 			case events.AttestationTopic:
-				data = &attestationJson{}
+				data = &AttestationJson{}
 
 				// Data received in the event does not fit the expected event stream output.
 				// We extract the underlying attestation from event data
 				// and assign the attestation back to event data for further processing.
-				eventData := &aggregatedAttReceivedDataJson{}
+				eventData := &AggregatedAttReceivedDataJson{}
 				if err := json.Unmarshal(msg.Data, eventData); err != nil {
 					return apimiddleware.InternalServerError(err)
 				}
@@ -382,15 +382,15 @@ func receiveEvents(eventChan <-chan *sse.Event, w http.ResponseWriter, req *http
 				}
 				msg.Data = attData
 			case events.VoluntaryExitTopic:
-				data = &signedVoluntaryExitJson{}
+				data = &SignedVoluntaryExitJson{}
 			case events.FinalizedCheckpointTopic:
-				data = &eventFinalizedCheckpointJson{}
+				data = &EventFinalizedCheckpointJson{}
 			case events.ChainReorgTopic:
-				data = &eventChainReorgJson{}
+				data = &EventChainReorgJson{}
 			case events.SyncCommitteeContributionTopic:
-				data = &signedContributionAndProofJson{}
+				data = &SignedContributionAndProofJson{}
 			case "error":
-				data = &eventErrorJson{}
+				data = &EventErrorJson{}
 			default:
 				return &apimiddleware.DefaultErrorJson{
 					Message: fmt.Sprintf("Event type '%s' not supported", string(msg.Event)),

--- a/beacon-chain/rpc/apimiddleware/custom_handlers_test.go
+++ b/beacon-chain/rpc/apimiddleware/custom_handlers_test.go
@@ -252,7 +252,7 @@ func TestReceiveEvents(t *testing.T) {
 
 	go func() {
 		base64Val := "Zm9v"
-		data := &eventFinalizedCheckpointJson{
+		data := &EventFinalizedCheckpointJson{
 			Block: base64Val,
 			State: base64Val,
 			Epoch: "1",
@@ -301,7 +301,7 @@ func TestReceiveEvents_TrailingSpace(t *testing.T) {
 
 	go func() {
 		base64Val := "Zm9v"
-		data := &eventFinalizedCheckpointJson{
+		data := &EventFinalizedCheckpointJson{
 			Block: base64Val,
 			State: base64Val,
 			Epoch: "1",
@@ -327,7 +327,7 @@ data: {"block":"0x666f6f","state":"0x666f6f","epoch":"1","execution_optimistic":
 
 func TestWriteEvent(t *testing.T) {
 	base64Val := "Zm9v"
-	data := &eventFinalizedCheckpointJson{
+	data := &EventFinalizedCheckpointJson{
 		Block: base64Val,
 		State: base64Val,
 		Epoch: "1",
@@ -341,7 +341,7 @@ func TestWriteEvent(t *testing.T) {
 	w := httptest.NewRecorder()
 	w.Body = &bytes.Buffer{}
 
-	errJson := writeEvent(msg, w, &eventFinalizedCheckpointJson{})
+	errJson := writeEvent(msg, w, &EventFinalizedCheckpointJson{})
 	require.Equal(t, true, errJson == nil)
 	written := w.Body.String()
 	assert.Equal(t, "event: test_event\ndata: {\"block\":\"0x666f6f\",\"state\":\"0x666f6f\",\"epoch\":\"1\",\"execution_optimistic\":false}\n\n", written)

--- a/beacon-chain/rpc/apimiddleware/custom_hooks.go
+++ b/beacon-chain/rpc/apimiddleware/custom_hooks.go
@@ -25,14 +25,14 @@ func wrapFeeRecipientsArray(
 	_ http.ResponseWriter,
 	req *http.Request,
 ) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
-	if _, ok := endpoint.PostRequest.(*feeRecipientsRequestJSON); !ok {
+	if _, ok := endpoint.PostRequest.(*FeeRecipientsRequestJSON); !ok {
 		return true, nil
 	}
-	recipients := make([]*feeRecipientJson, 0)
+	recipients := make([]*FeeRecipientJson, 0)
 	if err := json.NewDecoder(req.Body).Decode(&recipients); err != nil {
 		return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 	}
-	j := &feeRecipientsRequestJSON{Recipients: recipients}
+	j := &FeeRecipientsRequestJSON{Recipients: recipients}
 	b, err := json.Marshal(j)
 	if err != nil {
 		return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
@@ -48,14 +48,14 @@ func wrapSignedValidatorRegistrationsArray(
 	_ http.ResponseWriter,
 	req *http.Request,
 ) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
-	if _, ok := endpoint.PostRequest.(*signedValidatorRegistrationsRequestJson); !ok {
+	if _, ok := endpoint.PostRequest.(*SignedValidatorRegistrationsRequestJson); !ok {
 		return true, nil
 	}
-	registrations := make([]*signedValidatorRegistrationJson, 0)
+	registrations := make([]*SignedValidatorRegistrationJson, 0)
 	if err := json.NewDecoder(req.Body).Decode(&registrations); err != nil {
 		return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 	}
-	j := &signedValidatorRegistrationsRequestJson{Registrations: registrations}
+	j := &SignedValidatorRegistrationsRequestJson{Registrations: registrations}
 	b, err := json.Marshal(j)
 	if err != nil {
 		return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
@@ -71,12 +71,12 @@ func wrapAttestationsArray(
 	_ http.ResponseWriter,
 	req *http.Request,
 ) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
-	if _, ok := endpoint.PostRequest.(*submitAttestationRequestJson); ok {
-		atts := make([]*attestationJson, 0)
+	if _, ok := endpoint.PostRequest.(*SubmitAttestationRequestJson); ok {
+		atts := make([]*AttestationJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&atts); err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
-		j := &submitAttestationRequestJson{Data: atts}
+		j := &SubmitAttestationRequestJson{Data: atts}
 		b, err := json.Marshal(j)
 		if err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
@@ -93,12 +93,12 @@ func wrapValidatorIndicesArray(
 	_ http.ResponseWriter,
 	req *http.Request,
 ) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
-	if _, ok := endpoint.PostRequest.(*dutiesRequestJson); ok {
+	if _, ok := endpoint.PostRequest.(*DutiesRequestJson); ok {
 		indices := make([]string, 0)
 		if err := json.NewDecoder(req.Body).Decode(&indices); err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
-		j := &dutiesRequestJson{Index: indices}
+		j := &DutiesRequestJson{Index: indices}
 		b, err := json.Marshal(j)
 		if err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
@@ -115,12 +115,12 @@ func wrapSignedAggregateAndProofArray(
 	_ http.ResponseWriter,
 	req *http.Request,
 ) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
-	if _, ok := endpoint.PostRequest.(*submitAggregateAndProofsRequestJson); ok {
-		data := make([]*signedAggregateAttestationAndProofJson, 0)
+	if _, ok := endpoint.PostRequest.(*SubmitAggregateAndProofsRequestJson); ok {
+		data := make([]*SignedAggregateAttestationAndProofJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
-		j := &submitAggregateAndProofsRequestJson{Data: data}
+		j := &SubmitAggregateAndProofsRequestJson{Data: data}
 		b, err := json.Marshal(j)
 		if err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
@@ -137,12 +137,12 @@ func wrapBeaconCommitteeSubscriptionsArray(
 	_ http.ResponseWriter,
 	req *http.Request,
 ) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
-	if _, ok := endpoint.PostRequest.(*submitBeaconCommitteeSubscriptionsRequestJson); ok {
-		data := make([]*beaconCommitteeSubscribeJson, 0)
+	if _, ok := endpoint.PostRequest.(*SubmitBeaconCommitteeSubscriptionsRequestJson); ok {
+		data := make([]*BeaconCommitteeSubscribeJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
-		j := &submitBeaconCommitteeSubscriptionsRequestJson{Data: data}
+		j := &SubmitBeaconCommitteeSubscriptionsRequestJson{Data: data}
 		b, err := json.Marshal(j)
 		if err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
@@ -159,12 +159,12 @@ func wrapSyncCommitteeSubscriptionsArray(
 	_ http.ResponseWriter,
 	req *http.Request,
 ) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
-	if _, ok := endpoint.PostRequest.(*submitSyncCommitteeSubscriptionRequestJson); ok {
-		data := make([]*syncCommitteeSubscriptionJson, 0)
+	if _, ok := endpoint.PostRequest.(*SubmitSyncCommitteeSubscriptionRequestJson); ok {
+		data := make([]*SyncCommitteeSubscriptionJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
-		j := &submitSyncCommitteeSubscriptionRequestJson{Data: data}
+		j := &SubmitSyncCommitteeSubscriptionRequestJson{Data: data}
 		b, err := json.Marshal(j)
 		if err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
@@ -181,12 +181,12 @@ func wrapSyncCommitteeSignaturesArray(
 	_ http.ResponseWriter,
 	req *http.Request,
 ) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
-	if _, ok := endpoint.PostRequest.(*submitSyncCommitteeSignaturesRequestJson); ok {
-		data := make([]*syncCommitteeMessageJson, 0)
+	if _, ok := endpoint.PostRequest.(*SubmitSyncCommitteeSignaturesRequestJson); ok {
+		data := make([]*SyncCommitteeMessageJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
-		j := &submitSyncCommitteeSignaturesRequestJson{Data: data}
+		j := &SubmitSyncCommitteeSignaturesRequestJson{Data: data}
 		b, err := json.Marshal(j)
 		if err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
@@ -203,12 +203,12 @@ func wrapSignedContributionAndProofsArray(
 	_ http.ResponseWriter,
 	req *http.Request,
 ) (apimiddleware.RunDefault, apimiddleware.ErrorJson) {
-	if _, ok := endpoint.PostRequest.(*submitContributionAndProofsRequestJson); ok {
-		data := make([]*signedContributionAndProofJson, 0)
+	if _, ok := endpoint.PostRequest.(*SubmitContributionAndProofsRequestJson); ok {
+		data := make([]*SignedContributionAndProofJson, 0)
 		if err := json.NewDecoder(req.Body).Decode(&data); err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not decode body")
 		}
-		j := &submitContributionAndProofsRequestJson{Data: data}
+		j := &SubmitContributionAndProofsRequestJson{Data: data}
 		b, err := json.Marshal(j)
 		if err != nil {
 			return false, apimiddleware.InternalServerErrorWithMessage(err, "could not marshal wrapped body")
@@ -219,22 +219,22 @@ func wrapSignedContributionAndProofsArray(
 }
 
 type phase0PublishBlockRequestJson struct {
-	Phase0Block *beaconBlockJson `json:"phase0_block"`
+	Phase0Block *BeaconBlockJson `json:"phase0_block"`
 	Signature   string           `json:"signature" hex:"true"`
 }
 
 type altairPublishBlockRequestJson struct {
-	AltairBlock *beaconBlockAltairJson `json:"altair_block"`
+	AltairBlock *BeaconBlockAltairJson `json:"altair_block"`
 	Signature   string                 `json:"signature" hex:"true"`
 }
 
 type bellatrixPublishBlockRequestJson struct {
-	BellatrixBlock *beaconBlockBellatrixJson `json:"bellatrix_block"`
+	BellatrixBlock *BeaconBlockBellatrixJson `json:"bellatrix_block"`
 	Signature      string                    `json:"signature" hex:"true"`
 }
 
 type bellatrixPublishBlindedBlockRequestJson struct {
-	BellatrixBlock *blindedBeaconBlockBellatrixJson `json:"bellatrix_block"`
+	BellatrixBlock *BlindedBeaconBlockBellatrixJson `json:"bellatrix_block"`
 	Signature      string                           `json:"signature" hex:"true"`
 }
 
@@ -266,11 +266,11 @@ func setInitialPublishBlockPostRequest(endpoint *apimiddleware.Endpoint,
 	}
 	currentEpoch := slots.ToEpoch(types.Slot(slot))
 	if currentEpoch < params.BeaconConfig().AltairForkEpoch {
-		endpoint.PostRequest = &signedBeaconBlockContainerJson{}
+		endpoint.PostRequest = &SignedBeaconBlockContainerJson{}
 	} else if currentEpoch < params.BeaconConfig().BellatrixForkEpoch {
-		endpoint.PostRequest = &signedBeaconBlockAltairContainerJson{}
+		endpoint.PostRequest = &SignedBeaconBlockAltairContainerJson{}
 	} else {
-		endpoint.PostRequest = &signedBeaconBlockBellatrixContainerJson{}
+		endpoint.PostRequest = &SignedBeaconBlockBellatrixContainerJson{}
 	}
 	req.Body = io.NopCloser(bytes.NewBuffer(buf))
 	return true, nil
@@ -281,7 +281,7 @@ func setInitialPublishBlockPostRequest(endpoint *apimiddleware.Endpoint,
 // We do a simple conversion depending on the type of endpoint.PostRequest
 // (which was filled out previously in setInitialPublishBlockPostRequest).
 func preparePublishedBlock(endpoint *apimiddleware.Endpoint, _ http.ResponseWriter, _ *http.Request) apimiddleware.ErrorJson {
-	if block, ok := endpoint.PostRequest.(*signedBeaconBlockContainerJson); ok {
+	if block, ok := endpoint.PostRequest.(*SignedBeaconBlockContainerJson); ok {
 		// Prepare post request that can be properly decoded on gRPC side.
 		actualPostReq := &phase0PublishBlockRequestJson{
 			Phase0Block: block.Message,
@@ -290,7 +290,7 @@ func preparePublishedBlock(endpoint *apimiddleware.Endpoint, _ http.ResponseWrit
 		endpoint.PostRequest = actualPostReq
 		return nil
 	}
-	if block, ok := endpoint.PostRequest.(*signedBeaconBlockAltairContainerJson); ok {
+	if block, ok := endpoint.PostRequest.(*SignedBeaconBlockAltairContainerJson); ok {
 		// Prepare post request that can be properly decoded on gRPC side.
 		actualPostReq := &altairPublishBlockRequestJson{
 			AltairBlock: block.Message,
@@ -299,7 +299,7 @@ func preparePublishedBlock(endpoint *apimiddleware.Endpoint, _ http.ResponseWrit
 		endpoint.PostRequest = actualPostReq
 		return nil
 	}
-	if block, ok := endpoint.PostRequest.(*signedBeaconBlockBellatrixContainerJson); ok {
+	if block, ok := endpoint.PostRequest.(*SignedBeaconBlockBellatrixContainerJson); ok {
 		// Prepare post request that can be properly decoded on gRPC side.
 		actualPostReq := &bellatrixPublishBlockRequestJson{
 			BellatrixBlock: block.Message,
@@ -339,11 +339,11 @@ func setInitialPublishBlindedBlockPostRequest(endpoint *apimiddleware.Endpoint,
 	}
 	currentEpoch := slots.ToEpoch(types.Slot(slot))
 	if currentEpoch < params.BeaconConfig().AltairForkEpoch {
-		endpoint.PostRequest = &signedBeaconBlockContainerJson{}
+		endpoint.PostRequest = &SignedBeaconBlockContainerJson{}
 	} else if currentEpoch < params.BeaconConfig().BellatrixForkEpoch {
-		endpoint.PostRequest = &signedBeaconBlockAltairContainerJson{}
+		endpoint.PostRequest = &SignedBeaconBlockAltairContainerJson{}
 	} else {
-		endpoint.PostRequest = &signedBlindedBeaconBlockBellatrixContainerJson{}
+		endpoint.PostRequest = &SignedBlindedBeaconBlockBellatrixContainerJson{}
 	}
 	req.Body = ioutil.NopCloser(bytes.NewBuffer(buf))
 	return true, nil
@@ -354,7 +354,7 @@ func setInitialPublishBlindedBlockPostRequest(endpoint *apimiddleware.Endpoint,
 // We do a simple conversion depending on the type of endpoint.PostRequest
 // (which was filled out previously in setInitialPublishBlockPostRequest).
 func preparePublishedBlindedBlock(endpoint *apimiddleware.Endpoint, _ http.ResponseWriter, _ *http.Request) apimiddleware.ErrorJson {
-	if block, ok := endpoint.PostRequest.(*signedBeaconBlockContainerJson); ok {
+	if block, ok := endpoint.PostRequest.(*SignedBeaconBlockContainerJson); ok {
 		// Prepare post request that can be properly decoded on gRPC side.
 		actualPostReq := &phase0PublishBlockRequestJson{
 			Phase0Block: block.Message,
@@ -363,7 +363,7 @@ func preparePublishedBlindedBlock(endpoint *apimiddleware.Endpoint, _ http.Respo
 		endpoint.PostRequest = actualPostReq
 		return nil
 	}
-	if block, ok := endpoint.PostRequest.(*signedBeaconBlockAltairContainerJson); ok {
+	if block, ok := endpoint.PostRequest.(*SignedBeaconBlockAltairContainerJson); ok {
 		// Prepare post request that can be properly decoded on gRPC side.
 		actualPostReq := &altairPublishBlockRequestJson{
 			AltairBlock: block.Message,
@@ -372,7 +372,7 @@ func preparePublishedBlindedBlock(endpoint *apimiddleware.Endpoint, _ http.Respo
 		endpoint.PostRequest = actualPostReq
 		return nil
 	}
-	if block, ok := endpoint.PostRequest.(*signedBlindedBeaconBlockBellatrixContainerJson); ok {
+	if block, ok := endpoint.PostRequest.(*SignedBlindedBeaconBlockBellatrixContainerJson); ok {
 		// Prepare post request that can be properly decoded on gRPC side.
 		actualPostReq := &bellatrixPublishBlindedBlockRequestJson{
 			BellatrixBlock: block.Message,
@@ -404,12 +404,12 @@ func prepareValidatorAggregates(body []byte, responseContainer interface{}) (api
 	if err := json.Unmarshal(body, tempContainer); err != nil {
 		return false, apimiddleware.InternalServerErrorWithMessage(err, "could not unmarshal response into temp container")
 	}
-	container, ok := responseContainer.(*syncCommitteesResponseJson)
+	container, ok := responseContainer.(*SyncCommitteesResponseJson)
 	if !ok {
 		return false, apimiddleware.InternalServerError(errors.New("container is not of the correct type"))
 	}
 
-	container.Data = &syncCommitteeValidatorsJson{}
+	container.Data = &SyncCommitteeValidatorsJson{}
 	container.Data.Validators = tempContainer.Data.Validators
 	container.Data.ValidatorAggregates = make([][]string, len(tempContainer.Data.ValidatorAggregates))
 	for i, srcValAgg := range tempContainer.Data.ValidatorAggregates {
@@ -423,24 +423,24 @@ func prepareValidatorAggregates(body []byte, responseContainer interface{}) (api
 
 type phase0BlockResponseJson struct {
 	Version             string                          `json:"version"`
-	Data                *signedBeaconBlockContainerJson `json:"data"`
+	Data                *SignedBeaconBlockContainerJson `json:"data"`
 	ExecutionOptimistic bool                            `json:"execution_optimistic"`
 }
 
 type altairBlockResponseJson struct {
 	Version             string                                `json:"version"`
-	Data                *signedBeaconBlockAltairContainerJson `json:"data"`
+	Data                *SignedBeaconBlockAltairContainerJson `json:"data"`
 	ExecutionOptimistic bool                                  `json:"execution_optimistic"`
 }
 
 type bellatrixBlockResponseJson struct {
 	Version             string                                   `json:"version"`
-	Data                *signedBeaconBlockBellatrixContainerJson `json:"data"`
+	Data                *SignedBeaconBlockBellatrixContainerJson `json:"data"`
 	ExecutionOptimistic bool                                     `json:"execution_optimistic"`
 }
 
 func serializeV2Block(response interface{}) (apimiddleware.RunDefault, []byte, apimiddleware.ErrorJson) {
-	respContainer, ok := response.(*blockV2ResponseJson)
+	respContainer, ok := response.(*BlockV2ResponseJson)
 	if !ok {
 		return false, nil, apimiddleware.InternalServerError(errors.New("container is not of the correct type"))
 	}
@@ -450,7 +450,7 @@ func serializeV2Block(response interface{}) (apimiddleware.RunDefault, []byte, a
 	case strings.EqualFold(respContainer.Version, strings.ToLower(ethpbv2.Version_PHASE0.String())):
 		actualRespContainer = &phase0BlockResponseJson{
 			Version: respContainer.Version,
-			Data: &signedBeaconBlockContainerJson{
+			Data: &SignedBeaconBlockContainerJson{
 				Message:   respContainer.Data.Phase0Block,
 				Signature: respContainer.Data.Signature,
 			},
@@ -459,7 +459,7 @@ func serializeV2Block(response interface{}) (apimiddleware.RunDefault, []byte, a
 	case strings.EqualFold(respContainer.Version, strings.ToLower(ethpbv2.Version_ALTAIR.String())):
 		actualRespContainer = &altairBlockResponseJson{
 			Version: respContainer.Version,
-			Data: &signedBeaconBlockAltairContainerJson{
+			Data: &SignedBeaconBlockAltairContainerJson{
 				Message:   respContainer.Data.AltairBlock,
 				Signature: respContainer.Data.Signature,
 			},
@@ -468,7 +468,7 @@ func serializeV2Block(response interface{}) (apimiddleware.RunDefault, []byte, a
 	case strings.EqualFold(respContainer.Version, strings.ToLower(ethpbv2.Version_BELLATRIX.String())):
 		actualRespContainer = &bellatrixBlockResponseJson{
 			Version: respContainer.Version,
-			Data: &signedBeaconBlockBellatrixContainerJson{
+			Data: &SignedBeaconBlockBellatrixContainerJson{
 				Message:   respContainer.Data.BellatrixBlock,
 				Signature: respContainer.Data.Signature,
 			},
@@ -487,21 +487,21 @@ func serializeV2Block(response interface{}) (apimiddleware.RunDefault, []byte, a
 
 type phase0StateResponseJson struct {
 	Version string           `json:"version"`
-	Data    *beaconStateJson `json:"data"`
+	Data    *BeaconStateJson `json:"data"`
 }
 
 type altairStateResponseJson struct {
 	Version string                 `json:"version"`
-	Data    *beaconStateAltairJson `json:"data"`
+	Data    *BeaconStateAltairJson `json:"data"`
 }
 
 type bellatrixStateResponseJson struct {
 	Version string                    `json:"version"`
-	Data    *beaconStateBellatrixJson `json:"data"`
+	Data    *BeaconStateBellatrixJson `json:"data"`
 }
 
 func serializeV2State(response interface{}) (apimiddleware.RunDefault, []byte, apimiddleware.ErrorJson) {
-	respContainer, ok := response.(*beaconStateV2ResponseJson)
+	respContainer, ok := response.(*BeaconStateV2ResponseJson)
 	if !ok {
 		return false, nil, apimiddleware.InternalServerError(errors.New("container is not of the correct type"))
 	}
@@ -536,26 +536,26 @@ func serializeV2State(response interface{}) (apimiddleware.RunDefault, []byte, a
 
 type phase0ProduceBlockResponseJson struct {
 	Version string           `json:"version"`
-	Data    *beaconBlockJson `json:"data"`
+	Data    *BeaconBlockJson `json:"data"`
 }
 
 type altairProduceBlockResponseJson struct {
 	Version string                 `json:"version"`
-	Data    *beaconBlockAltairJson `json:"data"`
+	Data    *BeaconBlockAltairJson `json:"data"`
 }
 
 type bellatrixProduceBlockResponseJson struct {
 	Version string                    `json:"version"`
-	Data    *beaconBlockBellatrixJson `json:"data"`
+	Data    *BeaconBlockBellatrixJson `json:"data"`
 }
 
 type bellatrixProduceBlindedBlockResponseJson struct {
 	Version string                           `json:"version"`
-	Data    *blindedBeaconBlockBellatrixJson `json:"data"`
+	Data    *BlindedBeaconBlockBellatrixJson `json:"data"`
 }
 
 func serializeProducedV2Block(response interface{}) (apimiddleware.RunDefault, []byte, apimiddleware.ErrorJson) {
-	respContainer, ok := response.(*produceBlockResponseV2Json)
+	respContainer, ok := response.(*ProduceBlockResponseV2Json)
 	if !ok {
 		return false, nil, apimiddleware.InternalServerError(errors.New("container is not of the correct type"))
 	}
@@ -589,7 +589,7 @@ func serializeProducedV2Block(response interface{}) (apimiddleware.RunDefault, [
 }
 
 func serializeProducedBlindedBlock(response interface{}) (apimiddleware.RunDefault, []byte, apimiddleware.ErrorJson) {
-	respContainer, ok := response.(*produceBlindedBlockResponseJson)
+	respContainer, ok := response.(*ProduceBlindedBlockResponseJson)
 	if !ok {
 		return false, nil, apimiddleware.InternalServerError(errors.New("container is not of the correct type"))
 	}

--- a/beacon-chain/rpc/apimiddleware/custom_hooks_test.go
+++ b/beacon-chain/rpc/apimiddleware/custom_hooks_test.go
@@ -22,9 +22,9 @@ import (
 func TestWrapAttestationArray(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitAttestationRequestJson{},
+			PostRequest: &SubmitAttestationRequestJson{},
 		}
-		unwrappedAtts := []*attestationJson{{AggregationBits: "1010"}}
+		unwrappedAtts := []*AttestationJson{{AggregationBits: "1010"}}
 		unwrappedAttsJson, err := json.Marshal(unwrappedAtts)
 		require.NoError(t, err)
 
@@ -36,7 +36,7 @@ func TestWrapAttestationArray(t *testing.T) {
 		runDefault, errJson := wrapAttestationsArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		wrappedAtts := &submitAttestationRequestJson{}
+		wrappedAtts := &SubmitAttestationRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedAtts))
 		require.Equal(t, 1, len(wrappedAtts.Data), "wrong number of wrapped items")
 		assert.Equal(t, "1010", wrappedAtts.Data[0].AggregationBits)
@@ -44,7 +44,7 @@ func TestWrapAttestationArray(t *testing.T) {
 
 	t.Run("invalid_body", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitAttestationRequestJson{},
+			PostRequest: &SubmitAttestationRequestJson{},
 		}
 		var body bytes.Buffer
 		_, err := body.Write([]byte("invalid"))
@@ -62,7 +62,7 @@ func TestWrapAttestationArray(t *testing.T) {
 func TestWrapValidatorIndicesArray(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &dutiesRequestJson{},
+			PostRequest: &DutiesRequestJson{},
 		}
 		unwrappedIndices := []string{"1", "2"}
 		unwrappedIndicesJson, err := json.Marshal(unwrappedIndices)
@@ -76,7 +76,7 @@ func TestWrapValidatorIndicesArray(t *testing.T) {
 		runDefault, errJson := wrapValidatorIndicesArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		wrappedIndices := &dutiesRequestJson{}
+		wrappedIndices := &DutiesRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedIndices))
 		require.Equal(t, 2, len(wrappedIndices.Index), "wrong number of wrapped items")
 		assert.Equal(t, "1", wrappedIndices.Index[0])
@@ -85,7 +85,7 @@ func TestWrapValidatorIndicesArray(t *testing.T) {
 
 	t.Run("invalid_body", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &dutiesRequestJson{},
+			PostRequest: &DutiesRequestJson{},
 		}
 		var body bytes.Buffer
 		_, err := body.Write([]byte("invalid"))
@@ -103,9 +103,9 @@ func TestWrapValidatorIndicesArray(t *testing.T) {
 func TestWrapSignedAggregateAndProofArray(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitAggregateAndProofsRequestJson{},
+			PostRequest: &SubmitAggregateAndProofsRequestJson{},
 		}
-		unwrappedAggs := []*signedAggregateAttestationAndProofJson{{Signature: "sig"}}
+		unwrappedAggs := []*SignedAggregateAttestationAndProofJson{{Signature: "sig"}}
 		unwrappedAggsJson, err := json.Marshal(unwrappedAggs)
 		require.NoError(t, err)
 
@@ -117,7 +117,7 @@ func TestWrapSignedAggregateAndProofArray(t *testing.T) {
 		runDefault, errJson := wrapSignedAggregateAndProofArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		wrappedAggs := &submitAggregateAndProofsRequestJson{}
+		wrappedAggs := &SubmitAggregateAndProofsRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedAggs))
 		require.Equal(t, 1, len(wrappedAggs.Data), "wrong number of wrapped items")
 		assert.Equal(t, "sig", wrappedAggs.Data[0].Signature)
@@ -125,7 +125,7 @@ func TestWrapSignedAggregateAndProofArray(t *testing.T) {
 
 	t.Run("invalid_body", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitAggregateAndProofsRequestJson{},
+			PostRequest: &SubmitAggregateAndProofsRequestJson{},
 		}
 		var body bytes.Buffer
 		_, err := body.Write([]byte("invalid"))
@@ -143,9 +143,9 @@ func TestWrapSignedAggregateAndProofArray(t *testing.T) {
 func TestWrapBeaconCommitteeSubscriptionsArray(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitBeaconCommitteeSubscriptionsRequestJson{},
+			PostRequest: &SubmitBeaconCommitteeSubscriptionsRequestJson{},
 		}
-		unwrappedSubs := []*beaconCommitteeSubscribeJson{{
+		unwrappedSubs := []*BeaconCommitteeSubscribeJson{{
 			ValidatorIndex:   "1",
 			CommitteeIndex:   "1",
 			CommitteesAtSlot: "1",
@@ -163,7 +163,7 @@ func TestWrapBeaconCommitteeSubscriptionsArray(t *testing.T) {
 		runDefault, errJson := wrapBeaconCommitteeSubscriptionsArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		wrappedSubs := &submitBeaconCommitteeSubscriptionsRequestJson{}
+		wrappedSubs := &SubmitBeaconCommitteeSubscriptionsRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedSubs))
 		require.Equal(t, 1, len(wrappedSubs.Data), "wrong number of wrapped items")
 		assert.Equal(t, "1", wrappedSubs.Data[0].ValidatorIndex)
@@ -175,7 +175,7 @@ func TestWrapBeaconCommitteeSubscriptionsArray(t *testing.T) {
 
 	t.Run("invalid_body", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitBeaconCommitteeSubscriptionsRequestJson{},
+			PostRequest: &SubmitBeaconCommitteeSubscriptionsRequestJson{},
 		}
 		var body bytes.Buffer
 		_, err := body.Write([]byte("invalid"))
@@ -193,9 +193,9 @@ func TestWrapBeaconCommitteeSubscriptionsArray(t *testing.T) {
 func TestWrapSyncCommitteeSubscriptionsArray(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitSyncCommitteeSubscriptionRequestJson{},
+			PostRequest: &SubmitSyncCommitteeSubscriptionRequestJson{},
 		}
-		unwrappedSubs := []*syncCommitteeSubscriptionJson{
+		unwrappedSubs := []*SyncCommitteeSubscriptionJson{
 			{
 				ValidatorIndex:       "1",
 				SyncCommitteeIndices: []string{"1", "2"},
@@ -218,7 +218,7 @@ func TestWrapSyncCommitteeSubscriptionsArray(t *testing.T) {
 		runDefault, errJson := wrapSyncCommitteeSubscriptionsArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		wrappedSubs := &submitSyncCommitteeSubscriptionRequestJson{}
+		wrappedSubs := &SubmitSyncCommitteeSubscriptionRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedSubs))
 		require.Equal(t, 2, len(wrappedSubs.Data), "wrong number of wrapped items")
 		assert.Equal(t, "1", wrappedSubs.Data[0].ValidatorIndex)
@@ -230,7 +230,7 @@ func TestWrapSyncCommitteeSubscriptionsArray(t *testing.T) {
 
 	t.Run("invalid_body", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitSyncCommitteeSubscriptionRequestJson{},
+			PostRequest: &SubmitSyncCommitteeSubscriptionRequestJson{},
 		}
 		var body bytes.Buffer
 		_, err := body.Write([]byte("invalid"))
@@ -248,9 +248,9 @@ func TestWrapSyncCommitteeSubscriptionsArray(t *testing.T) {
 func TestWrapSyncCommitteeSignaturesArray(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitSyncCommitteeSignaturesRequestJson{},
+			PostRequest: &SubmitSyncCommitteeSignaturesRequestJson{},
 		}
-		unwrappedSigs := []*syncCommitteeMessageJson{{
+		unwrappedSigs := []*SyncCommitteeMessageJson{{
 			Slot:            "1",
 			BeaconBlockRoot: "root",
 			ValidatorIndex:  "1",
@@ -267,7 +267,7 @@ func TestWrapSyncCommitteeSignaturesArray(t *testing.T) {
 		runDefault, errJson := wrapSyncCommitteeSignaturesArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		wrappedSigs := &submitSyncCommitteeSignaturesRequestJson{}
+		wrappedSigs := &SubmitSyncCommitteeSignaturesRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrappedSigs))
 		require.Equal(t, 1, len(wrappedSigs.Data), "wrong number of wrapped items")
 		assert.Equal(t, "1", wrappedSigs.Data[0].Slot)
@@ -278,7 +278,7 @@ func TestWrapSyncCommitteeSignaturesArray(t *testing.T) {
 
 	t.Run("invalid_body", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitSyncCommitteeSignaturesRequestJson{},
+			PostRequest: &SubmitSyncCommitteeSignaturesRequestJson{},
 		}
 		var body bytes.Buffer
 		_, err := body.Write([]byte("invalid"))
@@ -296,13 +296,13 @@ func TestWrapSyncCommitteeSignaturesArray(t *testing.T) {
 func TestWrapSignedContributionAndProofsArray(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitContributionAndProofsRequestJson{},
+			PostRequest: &SubmitContributionAndProofsRequestJson{},
 		}
-		unwrapped := []*signedContributionAndProofJson{
+		unwrapped := []*SignedContributionAndProofJson{
 			{
-				Message: &contributionAndProofJson{
+				Message: &ContributionAndProofJson{
 					AggregatorIndex: "1",
-					Contribution: &syncCommitteeContributionJson{
+					Contribution: &SyncCommitteeContributionJson{
 						Slot:              "1",
 						BeaconBlockRoot:   "root",
 						SubcommitteeIndex: "1",
@@ -314,7 +314,7 @@ func TestWrapSignedContributionAndProofsArray(t *testing.T) {
 				Signature: "sig",
 			},
 			{
-				Message:   &contributionAndProofJson{},
+				Message:   &ContributionAndProofJson{},
 				Signature: "sig",
 			},
 		}
@@ -329,7 +329,7 @@ func TestWrapSignedContributionAndProofsArray(t *testing.T) {
 		runDefault, errJson := wrapSignedContributionAndProofsArray(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		wrapped := &submitContributionAndProofsRequestJson{}
+		wrapped := &SubmitContributionAndProofsRequestJson{}
 		require.NoError(t, json.NewDecoder(request.Body).Decode(wrapped))
 		require.Equal(t, 2, len(wrapped.Data), "wrong number of wrapped items")
 		assert.Equal(t, "sig", wrapped.Data[0].Signature)
@@ -347,7 +347,7 @@ func TestWrapSignedContributionAndProofsArray(t *testing.T) {
 
 	t.Run("invalid_body", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &submitContributionAndProofsRequestJson{},
+			PostRequest: &SubmitContributionAndProofsRequestJson{},
 		}
 		var body bytes.Buffer
 		_, err := body.Write([]byte("invalid"))
@@ -385,7 +385,7 @@ func TestSetInitialPublishBlockPostRequest(t *testing.T) {
 		runDefault, errJson := setInitialPublishBlockPostRequest(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		assert.Equal(t, reflect.TypeOf(signedBeaconBlockContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
+		assert.Equal(t, reflect.TypeOf(SignedBeaconBlockContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
 	})
 	t.Run("Altair", func(t *testing.T) {
 		slot, err := slots.EpochStart(params.BeaconConfig().AltairForkEpoch)
@@ -400,7 +400,7 @@ func TestSetInitialPublishBlockPostRequest(t *testing.T) {
 		runDefault, errJson := setInitialPublishBlockPostRequest(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		assert.Equal(t, reflect.TypeOf(signedBeaconBlockAltairContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
+		assert.Equal(t, reflect.TypeOf(SignedBeaconBlockAltairContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
 	})
 	t.Run("Bellatrix", func(t *testing.T) {
 		slot, err := slots.EpochStart(params.BeaconConfig().BellatrixForkEpoch)
@@ -415,16 +415,16 @@ func TestSetInitialPublishBlockPostRequest(t *testing.T) {
 		runDefault, errJson := setInitialPublishBlockPostRequest(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		assert.Equal(t, reflect.TypeOf(signedBeaconBlockBellatrixContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
+		assert.Equal(t, reflect.TypeOf(SignedBeaconBlockBellatrixContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
 	})
 }
 
 func TestPreparePublishedBlock(t *testing.T) {
 	t.Run("Phase 0", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &signedBeaconBlockContainerJson{
-				Message: &beaconBlockJson{
-					Body: &beaconBlockBodyJson{},
+			PostRequest: &SignedBeaconBlockContainerJson{
+				Message: &BeaconBlockJson{
+					Body: &BeaconBlockBodyJson{},
 				},
 			},
 		}
@@ -436,9 +436,9 @@ func TestPreparePublishedBlock(t *testing.T) {
 
 	t.Run("Altair", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &signedBeaconBlockAltairContainerJson{
-				Message: &beaconBlockAltairJson{
-					Body: &beaconBlockBodyAltairJson{},
+			PostRequest: &SignedBeaconBlockAltairContainerJson{
+				Message: &BeaconBlockAltairJson{
+					Body: &BeaconBlockBodyAltairJson{},
 				},
 			},
 		}
@@ -450,9 +450,9 @@ func TestPreparePublishedBlock(t *testing.T) {
 
 	t.Run("Bellatrix", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &signedBeaconBlockBellatrixContainerJson{
-				Message: &beaconBlockBellatrixJson{
-					Body: &beaconBlockBodyBellatrixJson{},
+			PostRequest: &SignedBeaconBlockBellatrixContainerJson{
+				Message: &BeaconBlockBellatrixJson{
+					Body: &BeaconBlockBodyBellatrixJson{},
 				},
 			},
 		}
@@ -491,7 +491,7 @@ func TestSetInitialPublishBlindedBlockPostRequest(t *testing.T) {
 		runDefault, errJson := setInitialPublishBlindedBlockPostRequest(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		assert.Equal(t, reflect.TypeOf(signedBeaconBlockContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
+		assert.Equal(t, reflect.TypeOf(SignedBeaconBlockContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
 	})
 	t.Run("Altair", func(t *testing.T) {
 		slot, err := slots.EpochStart(params.BeaconConfig().AltairForkEpoch)
@@ -506,7 +506,7 @@ func TestSetInitialPublishBlindedBlockPostRequest(t *testing.T) {
 		runDefault, errJson := setInitialPublishBlindedBlockPostRequest(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		assert.Equal(t, reflect.TypeOf(signedBeaconBlockAltairContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
+		assert.Equal(t, reflect.TypeOf(SignedBeaconBlockAltairContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
 	})
 	t.Run("Bellatrix", func(t *testing.T) {
 		slot, err := slots.EpochStart(params.BeaconConfig().BellatrixForkEpoch)
@@ -521,16 +521,16 @@ func TestSetInitialPublishBlindedBlockPostRequest(t *testing.T) {
 		runDefault, errJson := setInitialPublishBlindedBlockPostRequest(endpoint, nil, request)
 		require.Equal(t, true, errJson == nil)
 		assert.Equal(t, apimiddleware.RunDefault(true), runDefault)
-		assert.Equal(t, reflect.TypeOf(signedBlindedBeaconBlockBellatrixContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
+		assert.Equal(t, reflect.TypeOf(SignedBlindedBeaconBlockBellatrixContainerJson{}).Name(), reflect.Indirect(reflect.ValueOf(endpoint.PostRequest)).Type().Name())
 	})
 }
 
 func TestPreparePublishedBlindedBlock(t *testing.T) {
 	t.Run("Phase 0", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &signedBeaconBlockContainerJson{
-				Message: &beaconBlockJson{
-					Body: &beaconBlockBodyJson{},
+			PostRequest: &SignedBeaconBlockContainerJson{
+				Message: &BeaconBlockJson{
+					Body: &BeaconBlockBodyJson{},
 				},
 			},
 		}
@@ -542,9 +542,9 @@ func TestPreparePublishedBlindedBlock(t *testing.T) {
 
 	t.Run("Altair", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &signedBeaconBlockAltairContainerJson{
-				Message: &beaconBlockAltairJson{
-					Body: &beaconBlockBodyAltairJson{},
+			PostRequest: &SignedBeaconBlockAltairContainerJson{
+				Message: &BeaconBlockAltairJson{
+					Body: &BeaconBlockBodyAltairJson{},
 				},
 			},
 		}
@@ -556,9 +556,9 @@ func TestPreparePublishedBlindedBlock(t *testing.T) {
 
 	t.Run("Bellatrix", func(t *testing.T) {
 		endpoint := &apimiddleware.Endpoint{
-			PostRequest: &signedBlindedBeaconBlockBellatrixContainerJson{
-				Message: &blindedBeaconBlockBellatrixJson{
-					Body: &blindedBeaconBlockBodyBellatrixJson{},
+			PostRequest: &SignedBlindedBeaconBlockBellatrixContainerJson{
+				Message: &BlindedBeaconBlockBellatrixJson{
+					Body: &BlindedBeaconBlockBodyBellatrixJson{},
 				},
 			},
 		}
@@ -591,7 +591,7 @@ func TestPrepareValidatorAggregates(t *testing.T) {
 	bodyJson, err := json.Marshal(body)
 	require.NoError(t, err)
 
-	container := &syncCommitteesResponseJson{}
+	container := &SyncCommitteesResponseJson{}
 	runDefault, errJson := prepareValidatorAggregates(bodyJson, container)
 	require.Equal(t, nil, errJson)
 	require.Equal(t, apimiddleware.RunDefault(false), runDefault)
@@ -601,15 +601,15 @@ func TestPrepareValidatorAggregates(t *testing.T) {
 
 func TestSerializeV2Block(t *testing.T) {
 	t.Run("Phase 0", func(t *testing.T) {
-		response := &blockV2ResponseJson{
+		response := &BlockV2ResponseJson{
 			Version: ethpbv2.Version_PHASE0.String(),
-			Data: &signedBeaconBlockContainerV2Json{
-				Phase0Block: &beaconBlockJson{
+			Data: &SignedBeaconBlockContainerV2Json{
+				Phase0Block: &BeaconBlockJson{
 					Slot:          "1",
 					ProposerIndex: "1",
 					ParentRoot:    "root",
 					StateRoot:     "root",
-					Body:          &beaconBlockBodyJson{},
+					Body:          &BeaconBlockBodyJson{},
 				},
 				Signature: "sig",
 			},
@@ -633,15 +633,15 @@ func TestSerializeV2Block(t *testing.T) {
 	})
 
 	t.Run("Altair", func(t *testing.T) {
-		response := &blockV2ResponseJson{
+		response := &BlockV2ResponseJson{
 			Version: ethpbv2.Version_ALTAIR.String(),
-			Data: &signedBeaconBlockContainerV2Json{
-				AltairBlock: &beaconBlockAltairJson{
+			Data: &SignedBeaconBlockContainerV2Json{
+				AltairBlock: &BeaconBlockAltairJson{
 					Slot:          "1",
 					ProposerIndex: "1",
 					ParentRoot:    "root",
 					StateRoot:     "root",
-					Body:          &beaconBlockBodyAltairJson{},
+					Body:          &BeaconBlockBodyAltairJson{},
 				},
 				Signature: "sig",
 			},
@@ -665,15 +665,15 @@ func TestSerializeV2Block(t *testing.T) {
 	})
 
 	t.Run("Bellatrix", func(t *testing.T) {
-		response := &blockV2ResponseJson{
+		response := &BlockV2ResponseJson{
 			Version: ethpbv2.Version_BELLATRIX.String(),
-			Data: &signedBeaconBlockContainerV2Json{
-				BellatrixBlock: &beaconBlockBellatrixJson{
+			Data: &SignedBeaconBlockContainerV2Json{
+				BellatrixBlock: &BeaconBlockBellatrixJson{
 					Slot:          "1",
 					ProposerIndex: "1",
 					ParentRoot:    "root",
 					StateRoot:     "root",
-					Body:          &beaconBlockBodyBellatrixJson{},
+					Body:          &BeaconBlockBodyBellatrixJson{},
 				},
 				Signature: "sig",
 			},
@@ -706,7 +706,7 @@ func TestSerializeV2Block(t *testing.T) {
 	})
 
 	t.Run("unsupported block version", func(t *testing.T) {
-		response := &blockV2ResponseJson{
+		response := &BlockV2ResponseJson{
 			Version: "unsupported",
 		}
 		runDefault, j, errJson := serializeV2Block(response)
@@ -719,10 +719,10 @@ func TestSerializeV2Block(t *testing.T) {
 
 func TestSerializeV2State(t *testing.T) {
 	t.Run("Phase 0", func(t *testing.T) {
-		response := &beaconStateV2ResponseJson{
+		response := &BeaconStateV2ResponseJson{
 			Version: ethpbv2.Version_PHASE0.String(),
-			Data: &beaconStateContainerV2Json{
-				Phase0State: &beaconStateJson{},
+			Data: &BeaconStateContainerV2Json{
+				Phase0State: &BeaconStateJson{},
 				AltairState: nil,
 			},
 		}
@@ -734,11 +734,11 @@ func TestSerializeV2State(t *testing.T) {
 	})
 
 	t.Run("Altair", func(t *testing.T) {
-		response := &beaconStateV2ResponseJson{
+		response := &BeaconStateV2ResponseJson{
 			Version: ethpbv2.Version_ALTAIR.String(),
-			Data: &beaconStateContainerV2Json{
+			Data: &BeaconStateContainerV2Json{
 				Phase0State: nil,
-				AltairState: &beaconStateAltairJson{},
+				AltairState: &BeaconStateAltairJson{},
 			},
 		}
 		runDefault, j, errJson := serializeV2State(response)
@@ -749,11 +749,11 @@ func TestSerializeV2State(t *testing.T) {
 	})
 
 	t.Run("Bellatrix", func(t *testing.T) {
-		response := &beaconStateV2ResponseJson{
+		response := &BeaconStateV2ResponseJson{
 			Version: ethpbv2.Version_BELLATRIX.String(),
-			Data: &beaconStateContainerV2Json{
+			Data: &BeaconStateContainerV2Json{
 				Phase0State:    nil,
-				BellatrixState: &beaconStateBellatrixJson{},
+				BellatrixState: &BeaconStateBellatrixJson{},
 			},
 		}
 		runDefault, j, errJson := serializeV2State(response)
@@ -772,7 +772,7 @@ func TestSerializeV2State(t *testing.T) {
 	})
 
 	t.Run("unsupported state version", func(t *testing.T) {
-		response := &beaconStateV2ResponseJson{
+		response := &BeaconStateV2ResponseJson{
 			Version: "unsupported",
 		}
 		runDefault, j, errJson := serializeV2State(response)
@@ -785,15 +785,15 @@ func TestSerializeV2State(t *testing.T) {
 
 func TestSerializeProducedV2Block(t *testing.T) {
 	t.Run("Phase 0", func(t *testing.T) {
-		response := &produceBlockResponseV2Json{
+		response := &ProduceBlockResponseV2Json{
 			Version: ethpbv2.Version_PHASE0.String(),
-			Data: &beaconBlockContainerV2Json{
-				Phase0Block: &beaconBlockJson{
+			Data: &BeaconBlockContainerV2Json{
+				Phase0Block: &BeaconBlockJson{
 					Slot:          "1",
 					ProposerIndex: "1",
 					ParentRoot:    "root",
 					StateRoot:     "root",
-					Body:          &beaconBlockBodyJson{},
+					Body:          &BeaconBlockBodyJson{},
 				},
 			},
 		}
@@ -814,15 +814,15 @@ func TestSerializeProducedV2Block(t *testing.T) {
 	})
 
 	t.Run("Altair", func(t *testing.T) {
-		response := &produceBlockResponseV2Json{
+		response := &ProduceBlockResponseV2Json{
 			Version: ethpbv2.Version_ALTAIR.String(),
-			Data: &beaconBlockContainerV2Json{
-				AltairBlock: &beaconBlockAltairJson{
+			Data: &BeaconBlockContainerV2Json{
+				AltairBlock: &BeaconBlockAltairJson{
 					Slot:          "1",
 					ProposerIndex: "1",
 					ParentRoot:    "root",
 					StateRoot:     "root",
-					Body:          &beaconBlockBodyAltairJson{},
+					Body:          &BeaconBlockBodyAltairJson{},
 				},
 			},
 		}
@@ -843,15 +843,15 @@ func TestSerializeProducedV2Block(t *testing.T) {
 	})
 
 	t.Run("Bellatrix", func(t *testing.T) {
-		response := &produceBlockResponseV2Json{
+		response := &ProduceBlockResponseV2Json{
 			Version: ethpbv2.Version_BELLATRIX.String(),
-			Data: &beaconBlockContainerV2Json{
-				BellatrixBlock: &beaconBlockBellatrixJson{
+			Data: &BeaconBlockContainerV2Json{
+				BellatrixBlock: &BeaconBlockBellatrixJson{
 					Slot:          "1",
 					ProposerIndex: "1",
 					ParentRoot:    "root",
 					StateRoot:     "root",
-					Body:          &beaconBlockBodyBellatrixJson{},
+					Body:          &BeaconBlockBodyBellatrixJson{},
 				},
 			},
 		}
@@ -881,7 +881,7 @@ func TestSerializeProducedV2Block(t *testing.T) {
 	})
 
 	t.Run("unsupported block version", func(t *testing.T) {
-		response := &produceBlockResponseV2Json{
+		response := &ProduceBlockResponseV2Json{
 			Version: "unsupported",
 		}
 		runDefault, j, errJson := serializeProducedV2Block(response)
@@ -894,15 +894,15 @@ func TestSerializeProducedV2Block(t *testing.T) {
 
 func TestSerializeProduceBlindedBlock(t *testing.T) {
 	t.Run("Phase 0", func(t *testing.T) {
-		response := &produceBlindedBlockResponseJson{
+		response := &ProduceBlindedBlockResponseJson{
 			Version: ethpbv2.Version_PHASE0.String(),
-			Data: &blindedBeaconBlockContainerJson{
-				Phase0Block: &beaconBlockJson{
+			Data: &BlindedBeaconBlockContainerJson{
+				Phase0Block: &BeaconBlockJson{
 					Slot:          "1",
 					ProposerIndex: "1",
 					ParentRoot:    "root",
 					StateRoot:     "root",
-					Body:          &beaconBlockBodyJson{},
+					Body:          &BeaconBlockBodyJson{},
 				},
 				AltairBlock: nil,
 			},
@@ -924,15 +924,15 @@ func TestSerializeProduceBlindedBlock(t *testing.T) {
 	})
 
 	t.Run("Altair", func(t *testing.T) {
-		response := &produceBlindedBlockResponseJson{
+		response := &ProduceBlindedBlockResponseJson{
 			Version: ethpbv2.Version_ALTAIR.String(),
-			Data: &blindedBeaconBlockContainerJson{
-				AltairBlock: &beaconBlockAltairJson{
+			Data: &BlindedBeaconBlockContainerJson{
+				AltairBlock: &BeaconBlockAltairJson{
 					Slot:          "1",
 					ProposerIndex: "1",
 					ParentRoot:    "root",
 					StateRoot:     "root",
-					Body:          &beaconBlockBodyAltairJson{},
+					Body:          &BeaconBlockBodyAltairJson{},
 				},
 			},
 		}
@@ -953,15 +953,15 @@ func TestSerializeProduceBlindedBlock(t *testing.T) {
 	})
 
 	t.Run("Bellatrix", func(t *testing.T) {
-		response := &produceBlindedBlockResponseJson{
+		response := &ProduceBlindedBlockResponseJson{
 			Version: ethpbv2.Version_BELLATRIX.String(),
-			Data: &blindedBeaconBlockContainerJson{
-				BellatrixBlock: &blindedBeaconBlockBellatrixJson{
+			Data: &BlindedBeaconBlockContainerJson{
+				BellatrixBlock: &BlindedBeaconBlockBellatrixJson{
 					Slot:          "1",
 					ProposerIndex: "1",
 					ParentRoot:    "root",
 					StateRoot:     "root",
-					Body:          &blindedBeaconBlockBodyBellatrixJson{},
+					Body:          &BlindedBeaconBlockBodyBellatrixJson{},
 				},
 			},
 		}
@@ -991,7 +991,7 @@ func TestSerializeProduceBlindedBlock(t *testing.T) {
 	})
 
 	t.Run("unsupported block version", func(t *testing.T) {
-		response := &produceBlockResponseV2Json{
+		response := &ProduceBlockResponseV2Json{
 			Version: "unsupported",
 		}
 		runDefault, j, errJson := serializeProducedV2Block(response)

--- a/beacon-chain/rpc/apimiddleware/endpoint_factory.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory.go
@@ -78,35 +78,35 @@ func (_ *BeaconEndpointFactory) Create(path string) (*apimiddleware.Endpoint, er
 	endpoint := apimiddleware.DefaultEndpoint()
 	switch path {
 	case "/eth/v1/beacon/genesis":
-		endpoint.GetResponse = &genesisResponseJson{}
+		endpoint.GetResponse = &GenesisResponseJson{}
 	case "/eth/v1/beacon/states/{state_id}/root":
-		endpoint.GetResponse = &stateRootResponseJson{}
+		endpoint.GetResponse = &StateRootResponseJson{}
 	case "/eth/v1/beacon/states/{state_id}/fork":
-		endpoint.GetResponse = &stateForkResponseJson{}
+		endpoint.GetResponse = &StateForkResponseJson{}
 	case "/eth/v1/beacon/states/{state_id}/finality_checkpoints":
-		endpoint.GetResponse = &stateFinalityCheckpointResponseJson{}
+		endpoint.GetResponse = &StateFinalityCheckpointResponseJson{}
 	case "/eth/v1/beacon/states/{state_id}/validators":
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "id", Hex: true}, {Name: "status", Enum: true}}
-		endpoint.GetResponse = &stateValidatorsResponseJson{}
+		endpoint.GetResponse = &StateValidatorsResponseJson{}
 	case "/eth/v1/beacon/states/{state_id}/validators/{validator_id}":
-		endpoint.GetResponse = &stateValidatorResponseJson{}
+		endpoint.GetResponse = &StateValidatorResponseJson{}
 	case "/eth/v1/beacon/states/{state_id}/validator_balances":
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "id", Hex: true}}
-		endpoint.GetResponse = &validatorBalancesResponseJson{}
+		endpoint.GetResponse = &ValidatorBalancesResponseJson{}
 	case "/eth/v1/beacon/states/{state_id}/committees":
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "epoch"}, {Name: "index"}, {Name: "slot"}}
-		endpoint.GetResponse = &stateCommitteesResponseJson{}
+		endpoint.GetResponse = &StateCommitteesResponseJson{}
 	case "/eth/v1/beacon/states/{state_id}/sync_committees":
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "epoch"}}
-		endpoint.GetResponse = &syncCommitteesResponseJson{}
+		endpoint.GetResponse = &SyncCommitteesResponseJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeGrpcResponseBodyIntoContainer: prepareValidatorAggregates,
 		}
 	case "/eth/v1/beacon/headers":
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "slot"}, {Name: "parent_root", Hex: true}}
-		endpoint.GetResponse = &blockHeadersResponseJson{}
+		endpoint.GetResponse = &BlockHeadersResponseJson{}
 	case "/eth/v1/beacon/headers/{block_id}":
-		endpoint.GetResponse = &blockHeaderResponseJson{}
+		endpoint.GetResponse = &BlockHeaderResponseJson{}
 	case "/eth/v1/beacon/blocks":
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer:  setInitialPublishBlockPostRequest,
@@ -120,108 +120,108 @@ func (_ *BeaconEndpointFactory) Create(path string) (*apimiddleware.Endpoint, er
 		}
 		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleSubmitBlindedBlockSSZ}
 	case "/eth/v1/beacon/blocks/{block_id}":
-		endpoint.GetResponse = &blockResponseJson{}
+		endpoint.GetResponse = &BlockResponseJson{}
 		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleGetBeaconBlockSSZ}
 	case "/eth/v2/beacon/blocks/{block_id}":
-		endpoint.GetResponse = &blockV2ResponseJson{}
+		endpoint.GetResponse = &BlockV2ResponseJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreSerializeMiddlewareResponseIntoJson: serializeV2Block,
 		}
 		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleGetBeaconBlockSSZV2}
 	case "/eth/v1/beacon/blocks/{block_id}/root":
-		endpoint.GetResponse = &blockRootResponseJson{}
+		endpoint.GetResponse = &BlockRootResponseJson{}
 	case "/eth/v1/beacon/blocks/{block_id}/attestations":
-		endpoint.GetResponse = &blockAttestationsResponseJson{}
+		endpoint.GetResponse = &BlockAttestationsResponseJson{}
 	case "/eth/v1/beacon/pool/attestations":
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "slot"}, {Name: "committee_index"}}
-		endpoint.GetResponse = &attestationsPoolResponseJson{}
-		endpoint.PostRequest = &submitAttestationRequestJson{}
-		endpoint.Err = &indexedVerificationFailureErrorJson{}
+		endpoint.GetResponse = &AttestationsPoolResponseJson{}
+		endpoint.PostRequest = &SubmitAttestationRequestJson{}
+		endpoint.Err = &IndexedVerificationFailureErrorJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapAttestationsArray,
 		}
 	case "/eth/v1/beacon/pool/attester_slashings":
-		endpoint.PostRequest = &attesterSlashingJson{}
-		endpoint.GetResponse = &attesterSlashingsPoolResponseJson{}
+		endpoint.PostRequest = &AttesterSlashingJson{}
+		endpoint.GetResponse = &AttesterSlashingsPoolResponseJson{}
 	case "/eth/v1/beacon/pool/proposer_slashings":
-		endpoint.PostRequest = &proposerSlashingJson{}
-		endpoint.GetResponse = &proposerSlashingsPoolResponseJson{}
+		endpoint.PostRequest = &ProposerSlashingJson{}
+		endpoint.GetResponse = &ProposerSlashingsPoolResponseJson{}
 	case "/eth/v1/beacon/pool/voluntary_exits":
-		endpoint.PostRequest = &signedVoluntaryExitJson{}
-		endpoint.GetResponse = &voluntaryExitsPoolResponseJson{}
+		endpoint.PostRequest = &SignedVoluntaryExitJson{}
+		endpoint.GetResponse = &VoluntaryExitsPoolResponseJson{}
 	case "/eth/v1/beacon/pool/sync_committees":
-		endpoint.PostRequest = &submitSyncCommitteeSignaturesRequestJson{}
-		endpoint.Err = &indexedVerificationFailureErrorJson{}
+		endpoint.PostRequest = &SubmitSyncCommitteeSignaturesRequestJson{}
+		endpoint.Err = &IndexedVerificationFailureErrorJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapSyncCommitteeSignaturesArray,
 		}
 	case "/eth/v1/beacon/weak_subjectivity":
 		endpoint.GetResponse = &WeakSubjectivityResponse{}
 	case "/eth/v1/node/identity":
-		endpoint.GetResponse = &identityResponseJson{}
+		endpoint.GetResponse = &IdentityResponseJson{}
 	case "/eth/v1/node/peers":
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "state", Enum: true}, {Name: "direction", Enum: true}}
-		endpoint.GetResponse = &peersResponseJson{}
+		endpoint.GetResponse = &PeersResponseJson{}
 	case "/eth/v1/node/peers/{peer_id}":
 		endpoint.RequestURLLiterals = []string{"peer_id"}
-		endpoint.GetResponse = &peerResponseJson{}
+		endpoint.GetResponse = &PeerResponseJson{}
 	case "/eth/v1/node/peer_count":
-		endpoint.GetResponse = &peerCountResponseJson{}
+		endpoint.GetResponse = &PeerCountResponseJson{}
 	case "/eth/v1/node/version":
-		endpoint.GetResponse = &versionResponseJson{}
+		endpoint.GetResponse = &VersionResponseJson{}
 	case "/eth/v1/node/syncing":
-		endpoint.GetResponse = &syncingResponseJson{}
+		endpoint.GetResponse = &SyncingResponseJson{}
 	case "/eth/v1/node/health":
 		// Use default endpoint
 	case "/eth/v1/debug/beacon/states/{state_id}":
-		endpoint.GetResponse = &beaconStateResponseJson{}
+		endpoint.GetResponse = &BeaconStateResponseJson{}
 		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleGetBeaconStateSSZ}
 	case "/eth/v2/debug/beacon/states/{state_id}":
-		endpoint.GetResponse = &beaconStateV2ResponseJson{}
+		endpoint.GetResponse = &BeaconStateV2ResponseJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreSerializeMiddlewareResponseIntoJson: serializeV2State,
 		}
 		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleGetBeaconStateSSZV2}
 	case "/eth/v1/debug/beacon/heads":
-		endpoint.GetResponse = &forkChoiceHeadsResponseJson{}
+		endpoint.GetResponse = &ForkChoiceHeadsResponseJson{}
 	case "/eth/v2/debug/beacon/heads":
-		endpoint.GetResponse = &v2ForkChoiceHeadsResponseJson{}
+		endpoint.GetResponse = &V2ForkChoiceHeadsResponseJson{}
 	case "/eth/v1/debug/beacon/forkchoice":
-		endpoint.GetResponse = &forkchoiceResponse{}
+		endpoint.GetResponse = &ForkchoiceResponse{}
 	case "/eth/v1/config/fork_schedule":
-		endpoint.GetResponse = &forkScheduleResponseJson{}
+		endpoint.GetResponse = &ForkScheduleResponseJson{}
 	case "/eth/v1/config/deposit_contract":
-		endpoint.GetResponse = &depositContractResponseJson{}
+		endpoint.GetResponse = &DepositContractResponseJson{}
 	case "/eth/v1/config/spec":
-		endpoint.GetResponse = &specResponseJson{}
+		endpoint.GetResponse = &SpecResponseJson{}
 	case "/eth/v1/events":
 		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleEvents}
 	case "/eth/v1/validator/duties/attester/{epoch}":
-		endpoint.PostRequest = &dutiesRequestJson{}
-		endpoint.PostResponse = &attesterDutiesResponseJson{}
+		endpoint.PostRequest = &DutiesRequestJson{}
+		endpoint.PostResponse = &AttesterDutiesResponseJson{}
 		endpoint.RequestURLLiterals = []string{"epoch"}
-		endpoint.Err = &nodeSyncDetailsErrorJson{}
+		endpoint.Err = &NodeSyncDetailsErrorJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapValidatorIndicesArray,
 		}
 	case "/eth/v1/validator/duties/proposer/{epoch}":
-		endpoint.GetResponse = &proposerDutiesResponseJson{}
+		endpoint.GetResponse = &ProposerDutiesResponseJson{}
 		endpoint.RequestURLLiterals = []string{"epoch"}
-		endpoint.Err = &nodeSyncDetailsErrorJson{}
+		endpoint.Err = &NodeSyncDetailsErrorJson{}
 	case "/eth/v1/validator/duties/sync/{epoch}":
-		endpoint.PostRequest = &dutiesRequestJson{}
-		endpoint.PostResponse = &syncCommitteeDutiesResponseJson{}
+		endpoint.PostRequest = &DutiesRequestJson{}
+		endpoint.PostResponse = &SyncCommitteeDutiesResponseJson{}
 		endpoint.RequestURLLiterals = []string{"epoch"}
-		endpoint.Err = &nodeSyncDetailsErrorJson{}
+		endpoint.Err = &NodeSyncDetailsErrorJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapValidatorIndicesArray,
 		}
 	case "/eth/v1/validator/blocks/{slot}":
-		endpoint.GetResponse = &produceBlockResponseJson{}
+		endpoint.GetResponse = &ProduceBlockResponseJson{}
 		endpoint.RequestURLLiterals = []string{"slot"}
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "randao_reveal", Hex: true}, {Name: "graffiti", Hex: true}}
 	case "/eth/v2/validator/blocks/{slot}":
-		endpoint.GetResponse = &produceBlockResponseV2Json{}
+		endpoint.GetResponse = &ProduceBlockResponseV2Json{}
 		endpoint.RequestURLLiterals = []string{"slot"}
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "randao_reveal", Hex: true}, {Name: "graffiti", Hex: true}}
 		endpoint.Hooks = apimiddleware.HookCollection{
@@ -229,7 +229,7 @@ func (_ *BeaconEndpointFactory) Create(path string) (*apimiddleware.Endpoint, er
 		}
 		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleProduceBlockSSZ}
 	case "/eth/v1/validator/blinded_blocks/{slot}":
-		endpoint.GetResponse = &produceBlindedBlockResponseJson{}
+		endpoint.GetResponse = &ProduceBlindedBlockResponseJson{}
 		endpoint.RequestURLLiterals = []string{"slot"}
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "randao_reveal", Hex: true}, {Name: "graffiti", Hex: true}}
 		endpoint.Hooks = apimiddleware.HookCollection{
@@ -237,43 +237,43 @@ func (_ *BeaconEndpointFactory) Create(path string) (*apimiddleware.Endpoint, er
 		}
 		endpoint.CustomHandlers = []apimiddleware.CustomHandler{handleProduceBlindedBlockSSZ}
 	case "/eth/v1/validator/attestation_data":
-		endpoint.GetResponse = &produceAttestationDataResponseJson{}
+		endpoint.GetResponse = &ProduceAttestationDataResponseJson{}
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "slot"}, {Name: "committee_index"}}
 	case "/eth/v1/validator/aggregate_attestation":
-		endpoint.GetResponse = &aggregateAttestationResponseJson{}
+		endpoint.GetResponse = &AggregateAttestationResponseJson{}
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "attestation_data_root", Hex: true}, {Name: "slot"}}
 	case "/eth/v1/validator/beacon_committee_subscriptions":
-		endpoint.PostRequest = &submitBeaconCommitteeSubscriptionsRequestJson{}
-		endpoint.Err = &nodeSyncDetailsErrorJson{}
+		endpoint.PostRequest = &SubmitBeaconCommitteeSubscriptionsRequestJson{}
+		endpoint.Err = &NodeSyncDetailsErrorJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapBeaconCommitteeSubscriptionsArray,
 		}
 	case "/eth/v1/validator/sync_committee_subscriptions":
-		endpoint.PostRequest = &submitSyncCommitteeSubscriptionRequestJson{}
-		endpoint.Err = &nodeSyncDetailsErrorJson{}
+		endpoint.PostRequest = &SubmitSyncCommitteeSubscriptionRequestJson{}
+		endpoint.Err = &NodeSyncDetailsErrorJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapSyncCommitteeSubscriptionsArray,
 		}
 	case "/eth/v1/validator/aggregate_and_proofs":
-		endpoint.PostRequest = &submitAggregateAndProofsRequestJson{}
+		endpoint.PostRequest = &SubmitAggregateAndProofsRequestJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapSignedAggregateAndProofArray,
 		}
 	case "/eth/v1/validator/sync_committee_contribution":
-		endpoint.GetResponse = &produceSyncCommitteeContributionResponseJson{}
+		endpoint.GetResponse = &ProduceSyncCommitteeContributionResponseJson{}
 		endpoint.RequestQueryParams = []apimiddleware.QueryParam{{Name: "slot"}, {Name: "subcommittee_index"}, {Name: "beacon_block_root", Hex: true}}
 	case "/eth/v1/validator/contribution_and_proofs":
-		endpoint.PostRequest = &submitContributionAndProofsRequestJson{}
+		endpoint.PostRequest = &SubmitContributionAndProofsRequestJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapSignedContributionAndProofsArray,
 		}
 	case "/eth/v1/validator/prepare_beacon_proposer":
-		endpoint.PostRequest = &feeRecipientsRequestJSON{}
+		endpoint.PostRequest = &FeeRecipientsRequestJSON{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapFeeRecipientsArray,
 		}
 	case "/eth/v1/validator/register_validator":
-		endpoint.PostRequest = &signedValidatorRegistrationsRequestJson{}
+		endpoint.PostRequest = &SignedValidatorRegistrationsRequestJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapSignedValidatorRegistrationsArray,
 		}

--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -12,11 +12,11 @@ import (
 // Requests and responses.
 //----------------
 
-type genesisResponseJson struct {
-	Data *genesisResponse_GenesisJson `json:"data"`
+type GenesisResponseJson struct {
+	Data *GenesisResponse_GenesisJson `json:"data"`
 }
 
-type genesisResponse_GenesisJson struct {
+type GenesisResponse_GenesisJson struct {
 	GenesisTime           string `json:"genesis_time" time:"true"`
 	GenesisValidatorsRoot string `json:"genesis_validators_root" hex:"true"`
 	GenesisForkVersion    string `json:"genesis_fork_version" hex:"true"`
@@ -26,228 +26,228 @@ type genesisResponse_GenesisJson struct {
 // /eth/v1/beacon/weak_subjectivity endpoint.
 type WeakSubjectivityResponse struct {
 	Data *struct {
-		Checkpoint *checkpointJson `json:"ws_checkpoint"`
+		Checkpoint *CheckpointJson `json:"ws_checkpoint"`
 		StateRoot  string          `json:"state_root" hex:"true"`
 	} `json:"data"`
 }
 
-type feeRecipientsRequestJSON struct {
-	Recipients []*feeRecipientJson `json:"recipients"`
+type FeeRecipientsRequestJSON struct {
+	Recipients []*FeeRecipientJson `json:"recipients"`
 }
 
-type stateRootResponseJson struct {
-	Data                *stateRootResponse_StateRootJson `json:"data"`
+type StateRootResponseJson struct {
+	Data                *StateRootResponse_StateRootJson `json:"data"`
 	ExecutionOptimistic bool                             `json:"execution_optimistic"`
 }
 
-type stateRootResponse_StateRootJson struct {
+type StateRootResponse_StateRootJson struct {
 	StateRoot string `json:"root" hex:"true"`
 }
 
-type stateForkResponseJson struct {
-	Data                *forkJson `json:"data"`
+type StateForkResponseJson struct {
+	Data                *ForkJson `json:"data"`
 	ExecutionOptimistic bool      `json:"execution_optimistic"`
 }
 
-type stateFinalityCheckpointResponseJson struct {
-	Data                *stateFinalityCheckpointResponse_StateFinalityCheckpointJson `json:"data"`
+type StateFinalityCheckpointResponseJson struct {
+	Data                *StateFinalityCheckpointResponse_StateFinalityCheckpointJson `json:"data"`
 	ExecutionOptimistic bool                                                         `json:"execution_optimistic"`
 }
 
-type stateFinalityCheckpointResponse_StateFinalityCheckpointJson struct {
-	PreviousJustified *checkpointJson `json:"previous_justified"`
-	CurrentJustified  *checkpointJson `json:"current_justified"`
-	Finalized         *checkpointJson `json:"finalized"`
+type StateFinalityCheckpointResponse_StateFinalityCheckpointJson struct {
+	PreviousJustified *CheckpointJson `json:"previous_justified"`
+	CurrentJustified  *CheckpointJson `json:"current_justified"`
+	Finalized         *CheckpointJson `json:"finalized"`
 }
 
-type stateValidatorsResponseJson struct {
-	Data                []*validatorContainerJson `json:"data"`
+type StateValidatorsResponseJson struct {
+	Data                []*ValidatorContainerJson `json:"data"`
 	ExecutionOptimistic bool                      `json:"execution_optimistic"`
 }
 
-type stateValidatorResponseJson struct {
-	Data                *validatorContainerJson `json:"data"`
+type StateValidatorResponseJson struct {
+	Data                *ValidatorContainerJson `json:"data"`
 	ExecutionOptimistic bool                    `json:"execution_optimistic"`
 }
 
-type validatorBalancesResponseJson struct {
-	Data                []*validatorBalanceJson `json:"data"`
+type ValidatorBalancesResponseJson struct {
+	Data                []*ValidatorBalanceJson `json:"data"`
 	ExecutionOptimistic bool                    `json:"execution_optimistic"`
 }
 
-type stateCommitteesResponseJson struct {
-	Data                []*committeeJson `json:"data"`
+type StateCommitteesResponseJson struct {
+	Data                []*CommitteeJson `json:"data"`
 	ExecutionOptimistic bool             `json:"execution_optimistic"`
 }
 
-type syncCommitteesResponseJson struct {
-	Data                *syncCommitteeValidatorsJson `json:"data"`
+type SyncCommitteesResponseJson struct {
+	Data                *SyncCommitteeValidatorsJson `json:"data"`
 	ExecutionOptimistic bool                         `json:"execution_optimistic"`
 }
 
-type blockHeadersResponseJson struct {
-	Data                []*blockHeaderContainerJson `json:"data"`
+type BlockHeadersResponseJson struct {
+	Data                []*BlockHeaderContainerJson `json:"data"`
 	ExecutionOptimistic bool                        `json:"execution_optimistic"`
 }
 
-type blockHeaderResponseJson struct {
-	Data                *blockHeaderContainerJson `json:"data"`
+type BlockHeaderResponseJson struct {
+	Data                *BlockHeaderContainerJson `json:"data"`
 	ExecutionOptimistic bool                      `json:"execution_optimistic"`
 }
 
-type blockResponseJson struct {
-	Data *signedBeaconBlockContainerJson `json:"data"`
+type BlockResponseJson struct {
+	Data *SignedBeaconBlockContainerJson `json:"data"`
 }
 
-type blockV2ResponseJson struct {
+type BlockV2ResponseJson struct {
 	Version             string                            `json:"version" enum:"true"`
-	Data                *signedBeaconBlockContainerV2Json `json:"data"`
+	Data                *SignedBeaconBlockContainerV2Json `json:"data"`
 	ExecutionOptimistic bool                              `json:"execution_optimistic"`
 }
 
-type blockRootResponseJson struct {
-	Data                *blockRootContainerJson `json:"data"`
+type BlockRootResponseJson struct {
+	Data                *BlockRootContainerJson `json:"data"`
 	ExecutionOptimistic bool                    `json:"execution_optimistic"`
 }
 
-type blockAttestationsResponseJson struct {
-	Data                []*attestationJson `json:"data"`
+type BlockAttestationsResponseJson struct {
+	Data                []*AttestationJson `json:"data"`
 	ExecutionOptimistic bool               `json:"execution_optimistic"`
 }
 
-type attestationsPoolResponseJson struct {
-	Data []*attestationJson `json:"data"`
+type AttestationsPoolResponseJson struct {
+	Data []*AttestationJson `json:"data"`
 }
 
-type submitAttestationRequestJson struct {
-	Data []*attestationJson `json:"data"`
+type SubmitAttestationRequestJson struct {
+	Data []*AttestationJson `json:"data"`
 }
 
-type attesterSlashingsPoolResponseJson struct {
-	Data []*attesterSlashingJson `json:"data"`
+type AttesterSlashingsPoolResponseJson struct {
+	Data []*AttesterSlashingJson `json:"data"`
 }
 
-type proposerSlashingsPoolResponseJson struct {
-	Data []*proposerSlashingJson `json:"data"`
+type ProposerSlashingsPoolResponseJson struct {
+	Data []*ProposerSlashingJson `json:"data"`
 }
 
-type voluntaryExitsPoolResponseJson struct {
-	Data []*signedVoluntaryExitJson `json:"data"`
+type VoluntaryExitsPoolResponseJson struct {
+	Data []*SignedVoluntaryExitJson `json:"data"`
 }
 
-type submitSyncCommitteeSignaturesRequestJson struct {
-	Data []*syncCommitteeMessageJson `json:"data"`
+type SubmitSyncCommitteeSignaturesRequestJson struct {
+	Data []*SyncCommitteeMessageJson `json:"data"`
 }
 
-type identityResponseJson struct {
-	Data *identityJson `json:"data"`
+type IdentityResponseJson struct {
+	Data *IdentityJson `json:"data"`
 }
 
-type peersResponseJson struct {
-	Data []*peerJson `json:"data"`
+type PeersResponseJson struct {
+	Data []*PeerJson `json:"data"`
 }
 
-type peerResponseJson struct {
-	Data *peerJson `json:"data"`
+type PeerResponseJson struct {
+	Data *PeerJson `json:"data"`
 }
 
-type peerCountResponseJson struct {
-	Data peerCountResponse_PeerCountJson `json:"data"`
+type PeerCountResponseJson struct {
+	Data PeerCountResponse_PeerCountJson `json:"data"`
 }
 
-type peerCountResponse_PeerCountJson struct {
+type PeerCountResponse_PeerCountJson struct {
 	Disconnected  string `json:"disconnected"`
 	Connecting    string `json:"connecting"`
 	Connected     string `json:"connected"`
 	Disconnecting string `json:"disconnecting"`
 }
 
-type versionResponseJson struct {
-	Data *versionJson `json:"data"`
+type VersionResponseJson struct {
+	Data *VersionJson `json:"data"`
 }
 
-type syncingResponseJson struct {
+type SyncingResponseJson struct {
 	Data *helpers.SyncDetailsJson `json:"data"`
 }
 
-type beaconStateResponseJson struct {
-	Data *beaconStateJson `json:"data"`
+type BeaconStateResponseJson struct {
+	Data *BeaconStateJson `json:"data"`
 }
 
-type beaconStateV2ResponseJson struct {
+type BeaconStateV2ResponseJson struct {
 	Version             string                      `json:"version" enum:"true"`
-	Data                *beaconStateContainerV2Json `json:"data"`
+	Data                *BeaconStateContainerV2Json `json:"data"`
 	ExecutionOptimistic bool                        `json:"execution_optimistic"`
 }
 
-type forkChoiceHeadsResponseJson struct {
-	Data []*forkChoiceHeadJson `json:"data"`
+type ForkChoiceHeadsResponseJson struct {
+	Data []*ForkChoiceHeadJson `json:"data"`
 }
 
-type v2ForkChoiceHeadsResponseJson struct {
-	Data []*v2ForkChoiceHeadJson `json:"data"`
+type V2ForkChoiceHeadsResponseJson struct {
+	Data []*V2ForkChoiceHeadJson `json:"data"`
 }
 
-type forkScheduleResponseJson struct {
-	Data []*forkJson `json:"data"`
+type ForkScheduleResponseJson struct {
+	Data []*ForkJson `json:"data"`
 }
 
-type depositContractResponseJson struct {
-	Data *depositContractJson `json:"data"`
+type DepositContractResponseJson struct {
+	Data *DepositContractJson `json:"data"`
 }
 
-type specResponseJson struct {
+type SpecResponseJson struct {
 	Data interface{} `json:"data"`
 }
 
-type dutiesRequestJson struct {
+type DutiesRequestJson struct {
 	Index []string `json:"index"`
 }
 
-type attesterDutiesResponseJson struct {
+type AttesterDutiesResponseJson struct {
 	DependentRoot       string              `json:"dependent_root" hex:"true"`
-	Data                []*attesterDutyJson `json:"data"`
+	Data                []*AttesterDutyJson `json:"data"`
 	ExecutionOptimistic bool                `json:"execution_optimistic"`
 }
 
-type proposerDutiesResponseJson struct {
+type ProposerDutiesResponseJson struct {
 	DependentRoot       string              `json:"dependent_root" hex:"true"`
-	Data                []*proposerDutyJson `json:"data"`
+	Data                []*ProposerDutyJson `json:"data"`
 	ExecutionOptimistic bool                `json:"execution_optimistic"`
 }
 
-type syncCommitteeDutiesResponseJson struct {
-	Data                []*syncCommitteeDuty `json:"data"`
+type SyncCommitteeDutiesResponseJson struct {
+	Data                []*SyncCommitteeDuty `json:"data"`
 	ExecutionOptimistic bool                 `json:"execution_optimistic"`
 }
 
-type produceBlockResponseJson struct {
-	Data *beaconBlockJson `json:"data"`
+type ProduceBlockResponseJson struct {
+	Data *BeaconBlockJson `json:"data"`
 }
 
-type produceBlockResponseV2Json struct {
+type ProduceBlockResponseV2Json struct {
 	Version string                      `json:"version"`
-	Data    *beaconBlockContainerV2Json `json:"data"`
+	Data    *BeaconBlockContainerV2Json `json:"data"`
 }
 
-type produceBlindedBlockResponseJson struct {
+type ProduceBlindedBlockResponseJson struct {
 	Version string                           `json:"version"`
-	Data    *blindedBeaconBlockContainerJson `json:"data"`
+	Data    *BlindedBeaconBlockContainerJson `json:"data"`
 }
 
-type produceAttestationDataResponseJson struct {
-	Data *attestationDataJson `json:"data"`
+type ProduceAttestationDataResponseJson struct {
+	Data *AttestationDataJson `json:"data"`
 }
 
-type aggregateAttestationResponseJson struct {
-	Data *attestationJson `json:"data"`
+type AggregateAttestationResponseJson struct {
+	Data *AttestationJson `json:"data"`
 }
 
-type submitBeaconCommitteeSubscriptionsRequestJson struct {
-	Data []*beaconCommitteeSubscribeJson `json:"data"`
+type SubmitBeaconCommitteeSubscriptionsRequestJson struct {
+	Data []*BeaconCommitteeSubscribeJson `json:"data"`
 }
 
-type beaconCommitteeSubscribeJson struct {
+type BeaconCommitteeSubscribeJson struct {
 	ValidatorIndex   string `json:"validator_index"`
 	CommitteeIndex   string `json:"committee_index"`
 	CommitteesAtSlot string `json:"committees_at_slot"`
@@ -255,174 +255,174 @@ type beaconCommitteeSubscribeJson struct {
 	IsAggregator     bool   `json:"is_aggregator"`
 }
 
-type submitSyncCommitteeSubscriptionRequestJson struct {
-	Data []*syncCommitteeSubscriptionJson `json:"data"`
+type SubmitSyncCommitteeSubscriptionRequestJson struct {
+	Data []*SyncCommitteeSubscriptionJson `json:"data"`
 }
 
-type syncCommitteeSubscriptionJson struct {
+type SyncCommitteeSubscriptionJson struct {
 	ValidatorIndex       string   `json:"validator_index"`
 	SyncCommitteeIndices []string `json:"sync_committee_indices"`
 	UntilEpoch           string   `json:"until_epoch"`
 }
 
-type submitAggregateAndProofsRequestJson struct {
-	Data []*signedAggregateAttestationAndProofJson `json:"data"`
+type SubmitAggregateAndProofsRequestJson struct {
+	Data []*SignedAggregateAttestationAndProofJson `json:"data"`
 }
 
-type produceSyncCommitteeContributionResponseJson struct {
-	Data *syncCommitteeContributionJson `json:"data"`
+type ProduceSyncCommitteeContributionResponseJson struct {
+	Data *SyncCommitteeContributionJson `json:"data"`
 }
 
-type submitContributionAndProofsRequestJson struct {
-	Data []*signedContributionAndProofJson `json:"data"`
+type SubmitContributionAndProofsRequestJson struct {
+	Data []*SignedContributionAndProofJson `json:"data"`
 }
 
-type forkchoiceResponse struct {
-	JustifiedCheckpoint           *checkpointJson       `json:"justified_checkpoint"`
-	FinalizedCheckpoint           *checkpointJson       `json:"finalized_checkpoint"`
-	BestJustifiedCheckpoint       *checkpointJson       `json:"best_justified_checkpoint"`
-	UnrealizedJustifiedCheckpoint *checkpointJson       `json:"unrealized_justified_checkpoint"`
-	UnrealizedFinalizedCheckpoint *checkpointJson       `json:"unrealized_finalized_checkpoint"`
+type ForkchoiceResponse struct {
+	JustifiedCheckpoint           *CheckpointJson       `json:"justified_checkpoint"`
+	FinalizedCheckpoint           *CheckpointJson       `json:"finalized_checkpoint"`
+	BestJustifiedCheckpoint       *CheckpointJson       `json:"best_justified_checkpoint"`
+	UnrealizedJustifiedCheckpoint *CheckpointJson       `json:"unrealized_justified_checkpoint"`
+	UnrealizedFinalizedCheckpoint *CheckpointJson       `json:"unrealized_finalized_checkpoint"`
 	ProposerBoostRoot             string                `json:"proposer_boost_root" hex:"true"`
 	PreviousProposerBoostRoot     string                `json:"previous_proposer_boost_root" hex:"true"`
 	HeadRoot                      string                `json:"head_root" hex:"true"`
-	ForkChoiceNodes               []*forkChoiceNodeJson `json:"forkchoice_nodes"`
+	ForkChoiceNodes               []*ForkChoiceNodeJson `json:"forkchoice_nodes"`
 }
 
 //----------------
 // Reusable types.
 //----------------
 
-type checkpointJson struct {
+type CheckpointJson struct {
 	Epoch string `json:"epoch"`
 	Root  string `json:"root" hex:"true"`
 }
 
-type blockRootContainerJson struct {
+type BlockRootContainerJson struct {
 	Root string `json:"root" hex:"true"`
 }
 
-type signedBeaconBlockContainerJson struct {
-	Message   *beaconBlockJson `json:"message"`
+type SignedBeaconBlockContainerJson struct {
+	Message   *BeaconBlockJson `json:"message"`
 	Signature string           `json:"signature" hex:"true"`
 }
 
-type beaconBlockJson struct {
+type BeaconBlockJson struct {
 	Slot          string               `json:"slot"`
 	ProposerIndex string               `json:"proposer_index"`
 	ParentRoot    string               `json:"parent_root" hex:"true"`
 	StateRoot     string               `json:"state_root" hex:"true"`
-	Body          *beaconBlockBodyJson `json:"body"`
+	Body          *BeaconBlockBodyJson `json:"body"`
 }
 
-type beaconBlockBodyJson struct {
+type BeaconBlockBodyJson struct {
 	RandaoReveal      string                     `json:"randao_reveal" hex:"true"`
-	Eth1Data          *eth1DataJson              `json:"eth1_data"`
+	Eth1Data          *Eth1DataJson              `json:"eth1_data"`
 	Graffiti          string                     `json:"graffiti" hex:"true"`
-	ProposerSlashings []*proposerSlashingJson    `json:"proposer_slashings"`
-	AttesterSlashings []*attesterSlashingJson    `json:"attester_slashings"`
-	Attestations      []*attestationJson         `json:"attestations"`
-	Deposits          []*depositJson             `json:"deposits"`
-	VoluntaryExits    []*signedVoluntaryExitJson `json:"voluntary_exits"`
+	ProposerSlashings []*ProposerSlashingJson    `json:"proposer_slashings"`
+	AttesterSlashings []*AttesterSlashingJson    `json:"attester_slashings"`
+	Attestations      []*AttestationJson         `json:"attestations"`
+	Deposits          []*DepositJson             `json:"deposits"`
+	VoluntaryExits    []*SignedVoluntaryExitJson `json:"voluntary_exits"`
 }
 
-type signedBeaconBlockContainerV2Json struct {
-	Phase0Block    *beaconBlockJson          `json:"phase0_block"`
-	AltairBlock    *beaconBlockAltairJson    `json:"altair_block"`
-	BellatrixBlock *beaconBlockBellatrixJson `json:"bellatrix_block"`
+type SignedBeaconBlockContainerV2Json struct {
+	Phase0Block    *BeaconBlockJson          `json:"phase0_block"`
+	AltairBlock    *BeaconBlockAltairJson    `json:"altair_block"`
+	BellatrixBlock *BeaconBlockBellatrixJson `json:"bellatrix_block"`
 	Signature      string                    `json:"signature" hex:"true"`
 }
 
-type beaconBlockContainerV2Json struct {
-	Phase0Block    *beaconBlockJson          `json:"phase0_block"`
-	AltairBlock    *beaconBlockAltairJson    `json:"altair_block"`
-	BellatrixBlock *beaconBlockBellatrixJson `json:"bellatrix_block"`
+type BeaconBlockContainerV2Json struct {
+	Phase0Block    *BeaconBlockJson          `json:"phase0_block"`
+	AltairBlock    *BeaconBlockAltairJson    `json:"altair_block"`
+	BellatrixBlock *BeaconBlockBellatrixJson `json:"bellatrix_block"`
 }
 
-type blindedBeaconBlockContainerJson struct {
-	Phase0Block    *beaconBlockJson                 `json:"phase0_block"`
-	AltairBlock    *beaconBlockAltairJson           `json:"altair_block"`
-	BellatrixBlock *blindedBeaconBlockBellatrixJson `json:"bellatrix_block"`
+type BlindedBeaconBlockContainerJson struct {
+	Phase0Block    *BeaconBlockJson                 `json:"phase0_block"`
+	AltairBlock    *BeaconBlockAltairJson           `json:"altair_block"`
+	BellatrixBlock *BlindedBeaconBlockBellatrixJson `json:"bellatrix_block"`
 }
 
-type signedBeaconBlockAltairContainerJson struct {
-	Message   *beaconBlockAltairJson `json:"message"`
+type SignedBeaconBlockAltairContainerJson struct {
+	Message   *BeaconBlockAltairJson `json:"message"`
 	Signature string                 `json:"signature" hex:"true"`
 }
 
-type signedBeaconBlockBellatrixContainerJson struct {
-	Message   *beaconBlockBellatrixJson `json:"message"`
+type SignedBeaconBlockBellatrixContainerJson struct {
+	Message   *BeaconBlockBellatrixJson `json:"message"`
 	Signature string                    `json:"signature" hex:"true"`
 }
 
-type signedBlindedBeaconBlockBellatrixContainerJson struct {
-	Message   *blindedBeaconBlockBellatrixJson `json:"message"`
+type SignedBlindedBeaconBlockBellatrixContainerJson struct {
+	Message   *BlindedBeaconBlockBellatrixJson `json:"message"`
 	Signature string                           `json:"signature" hex:"true"`
 }
 
-type beaconBlockAltairJson struct {
+type BeaconBlockAltairJson struct {
 	Slot          string                     `json:"slot"`
 	ProposerIndex string                     `json:"proposer_index"`
 	ParentRoot    string                     `json:"parent_root" hex:"true"`
 	StateRoot     string                     `json:"state_root" hex:"true"`
-	Body          *beaconBlockBodyAltairJson `json:"body"`
+	Body          *BeaconBlockBodyAltairJson `json:"body"`
 }
 
-type beaconBlockBellatrixJson struct {
+type BeaconBlockBellatrixJson struct {
 	Slot          string                        `json:"slot"`
 	ProposerIndex string                        `json:"proposer_index"`
 	ParentRoot    string                        `json:"parent_root" hex:"true"`
 	StateRoot     string                        `json:"state_root" hex:"true"`
-	Body          *beaconBlockBodyBellatrixJson `json:"body"`
+	Body          *BeaconBlockBodyBellatrixJson `json:"body"`
 }
 
-type blindedBeaconBlockBellatrixJson struct {
+type BlindedBeaconBlockBellatrixJson struct {
 	Slot          string                               `json:"slot"`
 	ProposerIndex string                               `json:"proposer_index"`
 	ParentRoot    string                               `json:"parent_root" hex:"true"`
 	StateRoot     string                               `json:"state_root" hex:"true"`
-	Body          *blindedBeaconBlockBodyBellatrixJson `json:"body"`
+	Body          *BlindedBeaconBlockBodyBellatrixJson `json:"body"`
 }
 
-type beaconBlockBodyAltairJson struct {
+type BeaconBlockBodyAltairJson struct {
 	RandaoReveal      string                     `json:"randao_reveal" hex:"true"`
-	Eth1Data          *eth1DataJson              `json:"eth1_data"`
+	Eth1Data          *Eth1DataJson              `json:"eth1_data"`
 	Graffiti          string                     `json:"graffiti" hex:"true"`
-	ProposerSlashings []*proposerSlashingJson    `json:"proposer_slashings"`
-	AttesterSlashings []*attesterSlashingJson    `json:"attester_slashings"`
-	Attestations      []*attestationJson         `json:"attestations"`
-	Deposits          []*depositJson             `json:"deposits"`
-	VoluntaryExits    []*signedVoluntaryExitJson `json:"voluntary_exits"`
-	SyncAggregate     *syncAggregateJson         `json:"sync_aggregate"`
+	ProposerSlashings []*ProposerSlashingJson    `json:"proposer_slashings"`
+	AttesterSlashings []*AttesterSlashingJson    `json:"attester_slashings"`
+	Attestations      []*AttestationJson         `json:"attestations"`
+	Deposits          []*DepositJson             `json:"deposits"`
+	VoluntaryExits    []*SignedVoluntaryExitJson `json:"voluntary_exits"`
+	SyncAggregate     *SyncAggregateJson         `json:"sync_aggregate"`
 }
 
-type beaconBlockBodyBellatrixJson struct {
+type BeaconBlockBodyBellatrixJson struct {
 	RandaoReveal      string                     `json:"randao_reveal" hex:"true"`
-	Eth1Data          *eth1DataJson              `json:"eth1_data"`
+	Eth1Data          *Eth1DataJson              `json:"eth1_data"`
 	Graffiti          string                     `json:"graffiti" hex:"true"`
-	ProposerSlashings []*proposerSlashingJson    `json:"proposer_slashings"`
-	AttesterSlashings []*attesterSlashingJson    `json:"attester_slashings"`
-	Attestations      []*attestationJson         `json:"attestations"`
-	Deposits          []*depositJson             `json:"deposits"`
-	VoluntaryExits    []*signedVoluntaryExitJson `json:"voluntary_exits"`
-	SyncAggregate     *syncAggregateJson         `json:"sync_aggregate"`
-	ExecutionPayload  *executionPayloadJson      `json:"execution_payload"`
+	ProposerSlashings []*ProposerSlashingJson    `json:"proposer_slashings"`
+	AttesterSlashings []*AttesterSlashingJson    `json:"attester_slashings"`
+	Attestations      []*AttestationJson         `json:"attestations"`
+	Deposits          []*DepositJson             `json:"deposits"`
+	VoluntaryExits    []*SignedVoluntaryExitJson `json:"voluntary_exits"`
+	SyncAggregate     *SyncAggregateJson         `json:"sync_aggregate"`
+	ExecutionPayload  *ExecutionPayloadJson      `json:"execution_payload"`
 }
 
-type blindedBeaconBlockBodyBellatrixJson struct {
+type BlindedBeaconBlockBodyBellatrixJson struct {
 	RandaoReveal           string                      `json:"randao_reveal" hex:"true"`
-	Eth1Data               *eth1DataJson               `json:"eth1_data"`
+	Eth1Data               *Eth1DataJson               `json:"eth1_data"`
 	Graffiti               string                      `json:"graffiti" hex:"true"`
-	ProposerSlashings      []*proposerSlashingJson     `json:"proposer_slashings"`
-	AttesterSlashings      []*attesterSlashingJson     `json:"attester_slashings"`
-	Attestations           []*attestationJson          `json:"attestations"`
-	Deposits               []*depositJson              `json:"deposits"`
-	VoluntaryExits         []*signedVoluntaryExitJson  `json:"voluntary_exits"`
-	SyncAggregate          *syncAggregateJson          `json:"sync_aggregate"`
-	ExecutionPayloadHeader *executionPayloadHeaderJson `json:"execution_payload_header"`
+	ProposerSlashings      []*ProposerSlashingJson     `json:"proposer_slashings"`
+	AttesterSlashings      []*AttesterSlashingJson     `json:"attester_slashings"`
+	Attestations           []*AttestationJson          `json:"attestations"`
+	Deposits               []*DepositJson              `json:"deposits"`
+	VoluntaryExits         []*SignedVoluntaryExitJson  `json:"voluntary_exits"`
+	SyncAggregate          *SyncAggregateJson          `json:"sync_aggregate"`
+	ExecutionPayloadHeader *ExecutionPayloadHeaderJson `json:"execution_payload_header"`
 }
 
-type executionPayloadJson struct {
+type ExecutionPayloadJson struct {
 	ParentHash    string   `json:"parent_hash" hex:"true"`
 	FeeRecipient  string   `json:"fee_recipient" hex:"true"`
 	StateRoot     string   `json:"state_root" hex:"true"`
@@ -439,7 +439,7 @@ type executionPayloadJson struct {
 	Transactions  []string `json:"transactions" hex:"true"`
 }
 
-type executionPayloadHeaderJson struct {
+type ExecutionPayloadHeaderJson struct {
 	ParentHash       string `json:"parent_hash" hex:"true"`
 	FeeRecipient     string `json:"fee_recipient" hex:"true"`
 	StateRoot        string `json:"state_root" hex:"true"`
@@ -456,28 +456,28 @@ type executionPayloadHeaderJson struct {
 	TransactionsRoot string `json:"transactions_root" hex:"true"`
 }
 
-type syncAggregateJson struct {
+type SyncAggregateJson struct {
 	SyncCommitteeBits      string `json:"sync_committee_bits" hex:"true"`
 	SyncCommitteeSignature string `json:"sync_committee_signature" hex:"true"`
 }
 
-type blockHeaderContainerJson struct {
+type BlockHeaderContainerJson struct {
 	Root      string                          `json:"root" hex:"true"`
 	Canonical bool                            `json:"canonical"`
-	Header    *beaconBlockHeaderContainerJson `json:"header"`
+	Header    *BeaconBlockHeaderContainerJson `json:"header"`
 }
 
-type beaconBlockHeaderContainerJson struct {
-	Message   *beaconBlockHeaderJson `json:"message"`
+type BeaconBlockHeaderContainerJson struct {
+	Message   *BeaconBlockHeaderJson `json:"message"`
 	Signature string                 `json:"signature" hex:"true"`
 }
 
-type signedBeaconBlockHeaderJson struct {
-	Header    *beaconBlockHeaderJson `json:"message"`
+type SignedBeaconBlockHeaderJson struct {
+	Header    *BeaconBlockHeaderJson `json:"message"`
 	Signature string                 `json:"signature" hex:"true"`
 }
 
-type beaconBlockHeaderJson struct {
+type BeaconBlockHeaderJson struct {
 	Slot          string `json:"slot"`
 	ProposerIndex string `json:"proposer_index"`
 	ParentRoot    string `json:"parent_root" hex:"true"`
@@ -485,90 +485,90 @@ type beaconBlockHeaderJson struct {
 	BodyRoot      string `json:"body_root" hex:"true"`
 }
 
-type eth1DataJson struct {
+type Eth1DataJson struct {
 	DepositRoot  string `json:"deposit_root" hex:"true"`
 	DepositCount string `json:"deposit_count"`
 	BlockHash    string `json:"block_hash" hex:"true"`
 }
 
-type proposerSlashingJson struct {
-	Header_1 *signedBeaconBlockHeaderJson `json:"signed_header_1"`
-	Header_2 *signedBeaconBlockHeaderJson `json:"signed_header_2"`
+type ProposerSlashingJson struct {
+	Header_1 *SignedBeaconBlockHeaderJson `json:"signed_header_1"`
+	Header_2 *SignedBeaconBlockHeaderJson `json:"signed_header_2"`
 }
 
-type attesterSlashingJson struct {
-	Attestation_1 *indexedAttestationJson `json:"attestation_1"`
-	Attestation_2 *indexedAttestationJson `json:"attestation_2"`
+type AttesterSlashingJson struct {
+	Attestation_1 *IndexedAttestationJson `json:"attestation_1"`
+	Attestation_2 *IndexedAttestationJson `json:"attestation_2"`
 }
 
-type indexedAttestationJson struct {
+type IndexedAttestationJson struct {
 	AttestingIndices []string             `json:"attesting_indices"`
-	Data             *attestationDataJson `json:"data"`
+	Data             *AttestationDataJson `json:"data"`
 	Signature        string               `json:"signature" hex:"true"`
 }
 
-type feeRecipientJson struct {
+type FeeRecipientJson struct {
 	ValidatorIndex string `json:"validator_index"`
 	FeeRecipient   string `json:"fee_recipient" hex:"true"`
 }
 
-type attestationJson struct {
+type AttestationJson struct {
 	AggregationBits string               `json:"aggregation_bits" hex:"true"`
-	Data            *attestationDataJson `json:"data"`
+	Data            *AttestationDataJson `json:"data"`
 	Signature       string               `json:"signature" hex:"true"`
 }
 
-type attestationDataJson struct {
+type AttestationDataJson struct {
 	Slot            string          `json:"slot"`
 	CommitteeIndex  string          `json:"index"`
 	BeaconBlockRoot string          `json:"beacon_block_root" hex:"true"`
-	Source          *checkpointJson `json:"source"`
-	Target          *checkpointJson `json:"target"`
+	Source          *CheckpointJson `json:"source"`
+	Target          *CheckpointJson `json:"target"`
 }
 
-type depositJson struct {
+type DepositJson struct {
 	Proof []string          `json:"proof" hex:"true"`
-	Data  *deposit_DataJson `json:"data"`
+	Data  *Deposit_DataJson `json:"data"`
 }
 
-type deposit_DataJson struct {
+type Deposit_DataJson struct {
 	PublicKey             string `json:"pubkey" hex:"true"`
 	WithdrawalCredentials string `json:"withdrawal_credentials" hex:"true"`
 	Amount                string `json:"amount"`
 	Signature             string `json:"signature" hex:"true"`
 }
 
-type signedVoluntaryExitJson struct {
-	Exit      *voluntaryExitJson `json:"message"`
+type SignedVoluntaryExitJson struct {
+	Exit      *VoluntaryExitJson `json:"message"`
 	Signature string             `json:"signature" hex:"true"`
 }
 
-type voluntaryExitJson struct {
+type VoluntaryExitJson struct {
 	Epoch          string `json:"epoch"`
 	ValidatorIndex string `json:"validator_index"`
 }
 
-type syncCommitteeMessageJson struct {
+type SyncCommitteeMessageJson struct {
 	Slot            string `json:"slot"`
 	BeaconBlockRoot string `json:"beacon_block_root" hex:"true"`
 	ValidatorIndex  string `json:"validator_index"`
 	Signature       string `json:"signature" hex:"true"`
 }
 
-type identityJson struct {
+type IdentityJson struct {
 	PeerId             string        `json:"peer_id"`
 	Enr                string        `json:"enr"`
 	P2PAddresses       []string      `json:"p2p_addresses"`
 	DiscoveryAddresses []string      `json:"discovery_addresses"`
-	Metadata           *metadataJson `json:"metadata"`
+	Metadata           *MetadataJson `json:"metadata"`
 }
 
-type metadataJson struct {
+type MetadataJson struct {
 	SeqNumber string `json:"seq_number"`
 	Attnets   string `json:"attnets" hex:"true"`
 }
 
-type peerJson struct {
+type PeerJson struct {
 	PeerId    string `json:"peer_id"`
 	Enr       string `json:"enr"`
 	Address   string `json:"last_seen_p2p_address"`
@@ -576,109 +576,109 @@ type peerJson struct {
 	Direction string `json:"direction" enum:"true"`
 }
 
-type versionJson struct {
+type VersionJson struct {
 	Version string `json:"version"`
 }
 
-type beaconStateJson struct {
+type BeaconStateJson struct {
 	GenesisTime                 string                    `json:"genesis_time"`
 	GenesisValidatorsRoot       string                    `json:"genesis_validators_root" hex:"true"`
 	Slot                        string                    `json:"slot"`
-	Fork                        *forkJson                 `json:"fork"`
-	LatestBlockHeader           *beaconBlockHeaderJson    `json:"latest_block_header"`
+	Fork                        *ForkJson                 `json:"fork"`
+	LatestBlockHeader           *BeaconBlockHeaderJson    `json:"latest_block_header"`
 	BlockRoots                  []string                  `json:"block_roots" hex:"true"`
 	StateRoots                  []string                  `json:"state_roots" hex:"true"`
 	HistoricalRoots             []string                  `json:"historical_roots" hex:"true"`
-	Eth1Data                    *eth1DataJson             `json:"eth1_data"`
-	Eth1DataVotes               []*eth1DataJson           `json:"eth1_data_votes"`
+	Eth1Data                    *Eth1DataJson             `json:"eth1_data"`
+	Eth1DataVotes               []*Eth1DataJson           `json:"eth1_data_votes"`
 	Eth1DepositIndex            string                    `json:"eth1_deposit_index"`
-	Validators                  []*validatorJson          `json:"validators"`
+	Validators                  []*ValidatorJson          `json:"validators"`
 	Balances                    []string                  `json:"balances"`
 	RandaoMixes                 []string                  `json:"randao_mixes" hex:"true"`
 	Slashings                   []string                  `json:"slashings"`
-	PreviousEpochAttestations   []*pendingAttestationJson `json:"previous_epoch_attestations"`
-	CurrentEpochAttestations    []*pendingAttestationJson `json:"current_epoch_attestations"`
+	PreviousEpochAttestations   []*PendingAttestationJson `json:"previous_epoch_attestations"`
+	CurrentEpochAttestations    []*PendingAttestationJson `json:"current_epoch_attestations"`
 	JustificationBits           string                    `json:"justification_bits" hex:"true"`
-	PreviousJustifiedCheckpoint *checkpointJson           `json:"previous_justified_checkpoint"`
-	CurrentJustifiedCheckpoint  *checkpointJson           `json:"current_justified_checkpoint"`
-	FinalizedCheckpoint         *checkpointJson           `json:"finalized_checkpoint"`
+	PreviousJustifiedCheckpoint *CheckpointJson           `json:"previous_justified_checkpoint"`
+	CurrentJustifiedCheckpoint  *CheckpointJson           `json:"current_justified_checkpoint"`
+	FinalizedCheckpoint         *CheckpointJson           `json:"finalized_checkpoint"`
 }
 
-type beaconStateAltairJson struct {
+type BeaconStateAltairJson struct {
 	GenesisTime                 string                 `json:"genesis_time"`
 	GenesisValidatorsRoot       string                 `json:"genesis_validators_root" hex:"true"`
 	Slot                        string                 `json:"slot"`
-	Fork                        *forkJson              `json:"fork"`
-	LatestBlockHeader           *beaconBlockHeaderJson `json:"latest_block_header"`
+	Fork                        *ForkJson              `json:"fork"`
+	LatestBlockHeader           *BeaconBlockHeaderJson `json:"latest_block_header"`
 	BlockRoots                  []string               `json:"block_roots" hex:"true"`
 	StateRoots                  []string               `json:"state_roots" hex:"true"`
 	HistoricalRoots             []string               `json:"historical_roots" hex:"true"`
-	Eth1Data                    *eth1DataJson          `json:"eth1_data"`
-	Eth1DataVotes               []*eth1DataJson        `json:"eth1_data_votes"`
+	Eth1Data                    *Eth1DataJson          `json:"eth1_data"`
+	Eth1DataVotes               []*Eth1DataJson        `json:"eth1_data_votes"`
 	Eth1DepositIndex            string                 `json:"eth1_deposit_index"`
-	Validators                  []*validatorJson       `json:"validators"`
+	Validators                  []*ValidatorJson       `json:"validators"`
 	Balances                    []string               `json:"balances"`
 	RandaoMixes                 []string               `json:"randao_mixes" hex:"true"`
 	Slashings                   []string               `json:"slashings"`
 	PreviousEpochParticipation  EpochParticipation     `json:"previous_epoch_participation"`
 	CurrentEpochParticipation   EpochParticipation     `json:"current_epoch_participation"`
 	JustificationBits           string                 `json:"justification_bits" hex:"true"`
-	PreviousJustifiedCheckpoint *checkpointJson        `json:"previous_justified_checkpoint"`
-	CurrentJustifiedCheckpoint  *checkpointJson        `json:"current_justified_checkpoint"`
-	FinalizedCheckpoint         *checkpointJson        `json:"finalized_checkpoint"`
+	PreviousJustifiedCheckpoint *CheckpointJson        `json:"previous_justified_checkpoint"`
+	CurrentJustifiedCheckpoint  *CheckpointJson        `json:"current_justified_checkpoint"`
+	FinalizedCheckpoint         *CheckpointJson        `json:"finalized_checkpoint"`
 	InactivityScores            []string               `json:"inactivity_scores"`
-	CurrentSyncCommittee        *syncCommitteeJson     `json:"current_sync_committee"`
-	NextSyncCommittee           *syncCommitteeJson     `json:"next_sync_committee"`
+	CurrentSyncCommittee        *SyncCommitteeJson     `json:"current_sync_committee"`
+	NextSyncCommittee           *SyncCommitteeJson     `json:"next_sync_committee"`
 }
 
-type beaconStateBellatrixJson struct {
+type BeaconStateBellatrixJson struct {
 	GenesisTime                  string                      `json:"genesis_time"`
 	GenesisValidatorsRoot        string                      `json:"genesis_validators_root" hex:"true"`
 	Slot                         string                      `json:"slot"`
-	Fork                         *forkJson                   `json:"fork"`
-	LatestBlockHeader            *beaconBlockHeaderJson      `json:"latest_block_header"`
+	Fork                         *ForkJson                   `json:"fork"`
+	LatestBlockHeader            *BeaconBlockHeaderJson      `json:"latest_block_header"`
 	BlockRoots                   []string                    `json:"block_roots" hex:"true"`
 	StateRoots                   []string                    `json:"state_roots" hex:"true"`
 	HistoricalRoots              []string                    `json:"historical_roots" hex:"true"`
-	Eth1Data                     *eth1DataJson               `json:"eth1_data"`
-	Eth1DataVotes                []*eth1DataJson             `json:"eth1_data_votes"`
+	Eth1Data                     *Eth1DataJson               `json:"eth1_data"`
+	Eth1DataVotes                []*Eth1DataJson             `json:"eth1_data_votes"`
 	Eth1DepositIndex             string                      `json:"eth1_deposit_index"`
-	Validators                   []*validatorJson            `json:"validators"`
+	Validators                   []*ValidatorJson            `json:"validators"`
 	Balances                     []string                    `json:"balances"`
 	RandaoMixes                  []string                    `json:"randao_mixes" hex:"true"`
 	Slashings                    []string                    `json:"slashings"`
 	PreviousEpochParticipation   EpochParticipation          `json:"previous_epoch_participation"`
 	CurrentEpochParticipation    EpochParticipation          `json:"current_epoch_participation"`
 	JustificationBits            string                      `json:"justification_bits" hex:"true"`
-	PreviousJustifiedCheckpoint  *checkpointJson             `json:"previous_justified_checkpoint"`
-	CurrentJustifiedCheckpoint   *checkpointJson             `json:"current_justified_checkpoint"`
-	FinalizedCheckpoint          *checkpointJson             `json:"finalized_checkpoint"`
+	PreviousJustifiedCheckpoint  *CheckpointJson             `json:"previous_justified_checkpoint"`
+	CurrentJustifiedCheckpoint   *CheckpointJson             `json:"current_justified_checkpoint"`
+	FinalizedCheckpoint          *CheckpointJson             `json:"finalized_checkpoint"`
 	InactivityScores             []string                    `json:"inactivity_scores"`
-	CurrentSyncCommittee         *syncCommitteeJson          `json:"current_sync_committee"`
-	NextSyncCommittee            *syncCommitteeJson          `json:"next_sync_committee"`
-	LatestExecutionPayloadHeader *executionPayloadHeaderJson `json:"latest_execution_payload_header"`
+	CurrentSyncCommittee         *SyncCommitteeJson          `json:"current_sync_committee"`
+	NextSyncCommittee            *SyncCommitteeJson          `json:"next_sync_committee"`
+	LatestExecutionPayloadHeader *ExecutionPayloadHeaderJson `json:"latest_execution_payload_header"`
 }
 
-type beaconStateContainerV2Json struct {
-	Phase0State    *beaconStateJson          `json:"phase0_state"`
-	AltairState    *beaconStateAltairJson    `json:"altair_state"`
-	BellatrixState *beaconStateBellatrixJson `json:"bellatrix_state"`
+type BeaconStateContainerV2Json struct {
+	Phase0State    *BeaconStateJson          `json:"phase0_state"`
+	AltairState    *BeaconStateAltairJson    `json:"altair_state"`
+	BellatrixState *BeaconStateBellatrixJson `json:"bellatrix_state"`
 }
 
-type forkJson struct {
+type ForkJson struct {
 	PreviousVersion string `json:"previous_version" hex:"true"`
 	CurrentVersion  string `json:"current_version" hex:"true"`
 	Epoch           string `json:"epoch"`
 }
 
-type validatorContainerJson struct {
+type ValidatorContainerJson struct {
 	Index     string         `json:"index"`
 	Balance   string         `json:"balance"`
 	Status    string         `json:"status" enum:"true"`
-	Validator *validatorJson `json:"validator"`
+	Validator *ValidatorJson `json:"validator"`
 }
 
-type validatorJson struct {
+type ValidatorJson struct {
 	PublicKey                  string `json:"pubkey" hex:"true"`
 	WithdrawalCredentials      string `json:"withdrawal_credentials" hex:"true"`
 	EffectiveBalance           string `json:"effective_balance"`
@@ -689,51 +689,51 @@ type validatorJson struct {
 	WithdrawableEpoch          string `json:"withdrawable_epoch"`
 }
 
-type validatorBalanceJson struct {
+type ValidatorBalanceJson struct {
 	Index   string `json:"index"`
 	Balance string `json:"balance"`
 }
 
-type committeeJson struct {
+type CommitteeJson struct {
 	Index      string   `json:"index"`
 	Slot       string   `json:"slot"`
 	Validators []string `json:"validators"`
 }
 
-type syncCommitteeJson struct {
+type SyncCommitteeJson struct {
 	Pubkeys         []string `json:"pubkeys" hex:"true"`
 	AggregatePubkey string   `json:"aggregate_pubkey" hex:"true"`
 }
 
-type syncCommitteeValidatorsJson struct {
+type SyncCommitteeValidatorsJson struct {
 	Validators          []string   `json:"validators"`
 	ValidatorAggregates [][]string `json:"validator_aggregates"`
 }
 
-type pendingAttestationJson struct {
+type PendingAttestationJson struct {
 	AggregationBits string               `json:"aggregation_bits" hex:"true"`
-	Data            *attestationDataJson `json:"data"`
+	Data            *AttestationDataJson `json:"data"`
 	InclusionDelay  string               `json:"inclusion_delay"`
 	ProposerIndex   string               `json:"proposer_index"`
 }
 
-type forkChoiceHeadJson struct {
+type ForkChoiceHeadJson struct {
 	Root string `json:"root" hex:"true"`
 	Slot string `json:"slot"`
 }
 
-type v2ForkChoiceHeadJson struct {
+type V2ForkChoiceHeadJson struct {
 	Root                string `json:"root" hex:"true"`
 	Slot                string `json:"slot"`
 	ExecutionOptimistic bool   `json:"execution_optimistic"`
 }
 
-type depositContractJson struct {
+type DepositContractJson struct {
 	ChainId string `json:"chain_id"`
 	Address string `json:"address"`
 }
 
-type attesterDutyJson struct {
+type AttesterDutyJson struct {
 	Pubkey                  string `json:"pubkey" hex:"true"`
 	ValidatorIndex          string `json:"validator_index"`
 	CommitteeIndex          string `json:"committee_index"`
@@ -743,41 +743,41 @@ type attesterDutyJson struct {
 	Slot                    string `json:"slot"`
 }
 
-type proposerDutyJson struct {
+type ProposerDutyJson struct {
 	Pubkey         string `json:"pubkey" hex:"true"`
 	ValidatorIndex string `json:"validator_index"`
 	Slot           string `json:"slot"`
 }
 
-type syncCommitteeDuty struct {
+type SyncCommitteeDuty struct {
 	Pubkey                        string   `json:"pubkey" hex:"true"`
 	ValidatorIndex                string   `json:"validator_index"`
 	ValidatorSyncCommitteeIndices []string `json:"validator_sync_committee_indices"`
 }
 
-type signedAggregateAttestationAndProofJson struct {
-	Message   *aggregateAttestationAndProofJson `json:"message"`
+type SignedAggregateAttestationAndProofJson struct {
+	Message   *AggregateAttestationAndProofJson `json:"message"`
 	Signature string                            `json:"signature" hex:"true"`
 }
 
-type aggregateAttestationAndProofJson struct {
+type AggregateAttestationAndProofJson struct {
 	AggregatorIndex string           `json:"aggregator_index"`
-	Aggregate       *attestationJson `json:"aggregate"`
+	Aggregate       *AttestationJson `json:"aggregate"`
 	SelectionProof  string           `json:"selection_proof" hex:"true"`
 }
 
-type signedContributionAndProofJson struct {
-	Message   *contributionAndProofJson `json:"message"`
+type SignedContributionAndProofJson struct {
+	Message   *ContributionAndProofJson `json:"message"`
 	Signature string                    `json:"signature" hex:"true"`
 }
 
-type contributionAndProofJson struct {
+type ContributionAndProofJson struct {
 	AggregatorIndex string                         `json:"aggregator_index"`
-	Contribution    *syncCommitteeContributionJson `json:"contribution"`
+	Contribution    *SyncCommitteeContributionJson `json:"contribution"`
 	SelectionProof  string                         `json:"selection_proof" hex:"true"`
 }
 
-type syncCommitteeContributionJson struct {
+type SyncCommitteeContributionJson struct {
 	Slot              string `json:"slot"`
 	BeaconBlockRoot   string `json:"beacon_block_root" hex:"true"`
 	SubcommitteeIndex string `json:"subcommittee_index"`
@@ -785,23 +785,23 @@ type syncCommitteeContributionJson struct {
 	Signature         string `json:"signature" hex:"true"`
 }
 
-type validatorRegistrationJson struct {
+type ValidatorRegistrationJson struct {
 	FeeRecipient string `json:"fee_recipient" hex:"true"`
 	GasLimit     string `json:"gas_limit"`
 	Timestamp    string `json:"timestamp"`
 	Pubkey       string `json:"pubkey" hex:"true"`
 }
 
-type signedValidatorRegistrationJson struct {
-	Message   *validatorRegistrationJson `json:"message"`
+type SignedValidatorRegistrationJson struct {
+	Message   *ValidatorRegistrationJson `json:"message"`
 	Signature string                     `json:"signature" hex:"true"`
 }
 
-type signedValidatorRegistrationsRequestJson struct {
-	Registrations []*signedValidatorRegistrationJson `json:"registrations"`
+type SignedValidatorRegistrationsRequestJson struct {
+	Registrations []*SignedValidatorRegistrationJson `json:"registrations"`
 }
 
-type forkChoiceNodeJson struct {
+type ForkChoiceNodeJson struct {
 	Slot                     string `json:"slot"`
 	Root                     string `json:"root" hex:"true"`
 	ParentRoot               string `json:"parent_root" hex:"true"`
@@ -820,38 +820,38 @@ type forkChoiceNodeJson struct {
 // SSZ
 // ---------------
 
-type sszRequestJson struct {
+type SszRequestJson struct {
 	Data string `json:"data"`
 }
 
-// sszResponse is a common abstraction over all SSZ responses.
-type sszResponse interface {
+// SszResponse is a common abstraction over all SSZ responses.
+type SszResponse interface {
 	SSZVersion() string
 	SSZData() string
 }
 
-type sszResponseJson struct {
+type SszResponseJson struct {
 	Data string `json:"data"`
 }
 
-func (ssz *sszResponseJson) SSZData() string {
+func (ssz *SszResponseJson) SSZData() string {
 	return ssz.Data
 }
 
-func (*sszResponseJson) SSZVersion() string {
+func (*SszResponseJson) SSZVersion() string {
 	return strings.ToLower(ethpbv2.Version_PHASE0.String())
 }
 
-type versionedSSZResponseJson struct {
+type VersionedSSZResponseJson struct {
 	Version string `json:"version"`
 	Data    string `json:"data"`
 }
 
-func (ssz *versionedSSZResponseJson) SSZData() string {
+func (ssz *VersionedSSZResponseJson) SSZData() string {
 	return ssz.Data
 }
 
-func (ssz *versionedSSZResponseJson) SSZVersion() string {
+func (ssz *VersionedSSZResponseJson) SSZVersion() string {
 	return ssz.Version
 }
 
@@ -859,7 +859,7 @@ func (ssz *versionedSSZResponseJson) SSZVersion() string {
 // Events.
 // ---------------
 
-type eventHeadJson struct {
+type EventHeadJson struct {
 	Slot                      string `json:"slot"`
 	Block                     string `json:"block" hex:"true"`
 	State                     string `json:"state" hex:"true"`
@@ -869,24 +869,24 @@ type eventHeadJson struct {
 	CurrentDutyDependentRoot  string `json:"current_duty_dependent_root" hex:"true"`
 }
 
-type receivedBlockDataJson struct {
+type ReceivedBlockDataJson struct {
 	Slot                string `json:"slot"`
 	Block               string `json:"block" hex:"true"`
 	ExecutionOptimistic bool   `json:"execution_optimistic"`
 }
 
-type aggregatedAttReceivedDataJson struct {
-	Aggregate *attestationJson `json:"aggregate"`
+type AggregatedAttReceivedDataJson struct {
+	Aggregate *AttestationJson `json:"aggregate"`
 }
 
-type eventFinalizedCheckpointJson struct {
+type EventFinalizedCheckpointJson struct {
 	Block               string `json:"block" hex:"true"`
 	State               string `json:"state" hex:"true"`
 	Epoch               string `json:"epoch"`
 	ExecutionOptimistic bool   `json:"execution_optimistic"`
 }
 
-type eventChainReorgJson struct {
+type EventChainReorgJson struct {
 	Slot                string `json:"slot"`
 	Depth               string `json:"depth"`
 	OldHeadBlock        string `json:"old_head_block" hex:"true"`
@@ -901,24 +901,24 @@ type eventChainReorgJson struct {
 // Error handling.
 // ---------------
 
-// indexedVerificationFailureErrorJson is a JSON representation of the error returned when verifying an indexed object.
-type indexedVerificationFailureErrorJson struct {
+// IndexedVerificationFailureErrorJson is a JSON representation of the error returned when verifying an indexed object.
+type IndexedVerificationFailureErrorJson struct {
 	apimiddleware.DefaultErrorJson
-	Failures []*singleIndexedVerificationFailureJson `json:"failures"`
+	Failures []*SingleIndexedVerificationFailureJson `json:"failures"`
 }
 
-// singleIndexedVerificationFailureJson is a JSON representation of a an issue when verifying a single indexed object e.g. an item in an array.
-type singleIndexedVerificationFailureJson struct {
+// SingleIndexedVerificationFailureJson is a JSON representation of a an issue when verifying a single indexed object e.g. an item in an array.
+type SingleIndexedVerificationFailureJson struct {
 	Index   int    `json:"index"`
 	Message string `json:"message"`
 }
 
-type nodeSyncDetailsErrorJson struct {
+type NodeSyncDetailsErrorJson struct {
 	apimiddleware.DefaultErrorJson
 	SyncDetails helpers.SyncDetailsJson `json:"sync_details"`
 }
 
-type eventErrorJson struct {
+type EventErrorJson struct {
 	StatusCode int    `json:"status_code"`
 	Message    string `json:"message"`
 }

--- a/validator/rpc/apimiddleware/endpoint_factory.go
+++ b/validator/rpc/apimiddleware/endpoint_factory.go
@@ -28,24 +28,24 @@ func (*ValidatorEndpointFactory) Create(path string) (*apimiddleware.Endpoint, e
 	endpoint := apimiddleware.DefaultEndpoint()
 	switch path {
 	case "/eth/v1/keystores":
-		endpoint.GetResponse = &listKeystoresResponseJson{}
-		endpoint.PostRequest = &importKeystoresRequestJson{}
-		endpoint.PostResponse = &importKeystoresResponseJson{}
-		endpoint.DeleteRequest = &deleteKeystoresRequestJson{}
-		endpoint.DeleteResponse = &deleteKeystoresResponseJson{}
+		endpoint.GetResponse = &ListKeystoresResponseJson{}
+		endpoint.PostRequest = &ImportKeystoresRequestJson{}
+		endpoint.PostResponse = &ImportKeystoresResponseJson{}
+		endpoint.DeleteRequest = &DeleteKeystoresRequestJson{}
+		endpoint.DeleteResponse = &DeleteKeystoresResponseJson{}
 	case "/eth/v1/remotekeys":
-		endpoint.GetResponse = &listRemoteKeysResponseJson{}
-		endpoint.PostRequest = &importRemoteKeysRequestJson{}
-		endpoint.PostResponse = &importRemoteKeysResponseJson{}
-		endpoint.DeleteRequest = &deleteRemoteKeysRequestJson{}
-		endpoint.DeleteResponse = &deleteRemoteKeysResponseJson{}
+		endpoint.GetResponse = &ListRemoteKeysResponseJson{}
+		endpoint.PostRequest = &ImportRemoteKeysRequestJson{}
+		endpoint.PostResponse = &ImportRemoteKeysResponseJson{}
+		endpoint.DeleteRequest = &DeleteRemoteKeysRequestJson{}
+		endpoint.DeleteResponse = &DeleteRemoteKeysResponseJson{}
 	case "/eth/v1/validator/{pubkey}/feerecipient":
-		endpoint.GetResponse = &getFeeRecipientByPubkeyResponseJson{}
-		endpoint.PostRequest = &setFeeRecipientByPubkeyRequestJson{}
+		endpoint.GetResponse = &GetFeeRecipientByPubkeyResponseJson{}
+		endpoint.PostRequest = &SetFeeRecipientByPubkeyRequestJson{}
 	case "/eth/v1/validator/{pubkey}/gas_limit":
-		endpoint.GetResponse = &getGasLimitResponseJson{}
-		endpoint.PostRequest = &setGasLimitRequestJson{}
-		endpoint.DeleteRequest = &deleteGasLimitRequestJson{}
+		endpoint.GetResponse = &GetGasLimitResponseJson{}
+		endpoint.PostRequest = &SetGasLimitRequestJson{}
+		endpoint.DeleteRequest = &DeleteGasLimitRequestJson{}
 	default:
 		return nil, errors.New("invalid path")
 	}

--- a/validator/rpc/apimiddleware/structs.go
+++ b/validator/rpc/apimiddleware/structs.go
@@ -1,98 +1,98 @@
 package apimiddleware
 
-type listKeystoresResponseJson struct {
-	Keystores []*keystoreJson `json:"data"`
+type ListKeystoresResponseJson struct {
+	Keystores []*KeystoreJson `json:"data"`
 }
 
-type keystoreJson struct {
+type KeystoreJson struct {
 	ValidatingPubkey string `json:"validating_pubkey" hex:"true"`
 	DerivationPath   string `json:"derivation_path"`
 }
 
-type importKeystoresRequestJson struct {
+type ImportKeystoresRequestJson struct {
 	Keystores          []string `json:"keystores"`
 	Passwords          []string `json:"passwords"`
 	SlashingProtection string   `json:"slashing_protection"`
 }
 
-type importKeystoresResponseJson struct {
-	Statuses []*statusJson `json:"data"`
+type ImportKeystoresResponseJson struct {
+	Statuses []*StatusJson `json:"data"`
 }
 
-type deleteKeystoresRequestJson struct {
+type DeleteKeystoresRequestJson struct {
 	PublicKeys []string `json:"pubkeys" hex:"true"`
 }
 
-type statusJson struct {
+type StatusJson struct {
 	Status  string `json:"status" enum:"true"`
 	Message string `json:"message"`
 }
 
-type deleteKeystoresResponseJson struct {
-	Statuses           []*statusJson `json:"data"`
+type DeleteKeystoresResponseJson struct {
+	Statuses           []*StatusJson `json:"data"`
 	SlashingProtection string        `json:"slashing_protection"`
 }
 
 //remote keymanager api
 
-type listRemoteKeysResponseJson struct {
-	Keystores []*remoteKeysListJson `json:"data"`
+type ListRemoteKeysResponseJson struct {
+	Keystores []*RemoteKeysListJson `json:"data"`
 }
 
-type remoteKeysListJson struct {
+type RemoteKeysListJson struct {
 	Pubkey   string `json:"pubkey" hex:"true"`
 	Url      string `json:"url"`
 	Readonly bool   `json:"readonly"`
 }
 
-type remoteKeysJson struct {
+type RemoteKeysJson struct {
 	Pubkey   string `json:"pubkey" hex:"true"`
 	Url      string `json:"url"`
 	Readonly bool   `json:"readonly"`
 }
 
-type importRemoteKeysRequestJson struct {
-	Keystores []*remoteKeysJson `json:"remote_keys"`
+type ImportRemoteKeysRequestJson struct {
+	Keystores []*RemoteKeysJson `json:"remote_keys"`
 }
 
-type importRemoteKeysResponseJson struct {
-	Statuses []*statusJson `json:"data"`
+type ImportRemoteKeysResponseJson struct {
+	Statuses []*StatusJson `json:"data"`
 }
 
-type deleteRemoteKeysRequestJson struct {
+type DeleteRemoteKeysRequestJson struct {
 	PublicKeys []string `json:"pubkeys" hex:"true"`
 }
 
-type deleteRemoteKeysResponseJson struct {
-	Statuses []*statusJson `json:"data"`
+type DeleteRemoteKeysResponseJson struct {
+	Statuses []*StatusJson `json:"data"`
 }
 
-type feeRecipientJson struct {
+type FeeRecipientJson struct {
 	Pubkey     string `json:"pubkey" hex:"true"`
 	Ethaddress string `json:"ethaddress" address:"true"`
 }
 
-type gasLimitJson struct {
+type GasLimitJson struct {
 	Pubkey   string `json:"pubkey" hex:"true"`
 	GasLimit string `json:"gas_limit"`
 }
 
-type getFeeRecipientByPubkeyResponseJson struct {
-	Data *feeRecipientJson `json:"data"`
+type GetFeeRecipientByPubkeyResponseJson struct {
+	Data *FeeRecipientJson `json:"data"`
 }
 
-type setFeeRecipientByPubkeyRequestJson struct {
+type SetFeeRecipientByPubkeyRequestJson struct {
 	Ethaddress string `json:"ethaddress" hex:"true"`
 }
 
-type getGasLimitResponseJson struct {
-	Data *gasLimitJson `json:"data"`
+type GetGasLimitResponseJson struct {
+	Data *GasLimitJson `json:"data"`
 }
 
-type setGasLimitRequestJson struct {
+type SetGasLimitRequestJson struct {
 	GasLimit string `json:"gas_limit"`
 }
 
-type deleteGasLimitRequestJson struct {
+type DeleteGasLimitRequestJson struct {
 	Pubkey string `json:"pubkey" hex:"true"`
 }

--- a/validator/rpc/apimiddleware/structs_test.go
+++ b/validator/rpc/apimiddleware/structs_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 func TestListKeystores_JSONisEqual(t *testing.T) {
-	middlewareResponse := &listKeystoresResponseJson{
-		Keystores: []*keystoreJson{
+	middlewareResponse := &ListKeystoresResponseJson{
+		Keystores: []*KeystoreJson{
 			{
 				ValidatingPubkey: "0x0",
 				DerivationPath:   "m/44'/60'/0'/0/0",
@@ -39,7 +39,7 @@ func TestListKeystores_JSONisEqual(t *testing.T) {
 }
 
 func TestImportKeystores_JSONisEqual(t *testing.T) {
-	importKeystoresRequest := &importKeystoresRequestJson{}
+	importKeystoresRequest := &ImportKeystoresRequestJson{}
 
 	protoImportRequest := &service.ImportKeystoresRequest{
 		Keystores:          []string{""},
@@ -51,8 +51,8 @@ func TestImportKeystores_JSONisEqual(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, requestResp, true)
 
-	importKeystoresResponse := &importKeystoresResponseJson{
-		Statuses: []*statusJson{
+	importKeystoresResponse := &ImportKeystoresResponseJson{
+		Statuses: []*StatusJson{
 			{
 				Status:  "Error",
 				Message: "a",
@@ -79,7 +79,7 @@ func TestImportKeystores_JSONisEqual(t *testing.T) {
 }
 
 func TestDeleteKeystores_JSONisEqual(t *testing.T) {
-	deleteKeystoresRequest := &deleteKeystoresRequestJson{}
+	deleteKeystoresRequest := &DeleteKeystoresRequestJson{}
 
 	protoDeleteRequest := &service.DeleteKeystoresRequest{
 		Pubkeys: [][]byte{{}},
@@ -89,8 +89,8 @@ func TestDeleteKeystores_JSONisEqual(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, requestResp, true)
 
-	deleteKeystoresResponse := &deleteKeystoresResponseJson{
-		Statuses: []*statusJson{
+	deleteKeystoresResponse := &DeleteKeystoresResponseJson{
+		Statuses: []*StatusJson{
 			{
 				Status:  "Error",
 				Message: "a",
@@ -119,8 +119,8 @@ func TestDeleteKeystores_JSONisEqual(t *testing.T) {
 }
 
 func TestListRemoteKeys_JSONisEqual(t *testing.T) {
-	middlewareResponse := &listRemoteKeysResponseJson{
-		Keystores: []*remoteKeysListJson{
+	middlewareResponse := &ListRemoteKeysResponseJson{
+		Keystores: []*RemoteKeysListJson{
 			{
 				Pubkey:   "0x0",
 				Url:      "http://localhost:8080",
@@ -149,7 +149,7 @@ func TestListRemoteKeys_JSONisEqual(t *testing.T) {
 }
 
 func TestImportRemoteKeys_JSONisEqual(t *testing.T) {
-	importKeystoresRequest := &importRemoteKeysRequestJson{}
+	importKeystoresRequest := &ImportRemoteKeysRequestJson{}
 
 	protoImportRequest := &service.ImportRemoteKeysRequest{
 		RemoteKeys: []*service.ImportRemoteKeysRequest_Keystore{
@@ -164,8 +164,8 @@ func TestImportRemoteKeys_JSONisEqual(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, requestResp, true)
 
-	importKeystoresResponse := &importRemoteKeysResponseJson{
-		Statuses: []*statusJson{
+	importKeystoresResponse := &ImportRemoteKeysResponseJson{
+		Statuses: []*StatusJson{
 			{
 				Status:  "Error",
 				Message: "a",
@@ -192,7 +192,7 @@ func TestImportRemoteKeys_JSONisEqual(t *testing.T) {
 }
 
 func TestDeleteRemoteKeys_JSONisEqual(t *testing.T) {
-	deleteKeystoresRequest := &deleteRemoteKeysRequestJson{}
+	deleteKeystoresRequest := &DeleteRemoteKeysRequestJson{}
 
 	protoDeleteRequest := &service.DeleteRemoteKeysRequest{
 		Pubkeys: [][]byte{{}},
@@ -202,8 +202,8 @@ func TestDeleteRemoteKeys_JSONisEqual(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, requestResp, true)
 
-	deleteKeystoresResponse := &deleteRemoteKeysResponseJson{
-		Statuses: []*statusJson{
+	deleteKeystoresResponse := &DeleteRemoteKeysResponseJson{
+		Statuses: []*StatusJson{
 			{
 				Status:  "Error",
 				Message: "a",


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

External projects/tools might want to deserialize API responses into custom structs. There is no need for these tools to define their own types because Prysm already has them.

**Which issues(s) does this PR fix?**

Fixes #11504
