### PR TITLE
revert moving validator-exit command

### DIFF
--- a/cmd/validator/accounts/accounts.go
+++ b/cmd/validator/accounts/accounts.go
@@ -1,6 +1,8 @@
 package accounts
 
 import (
+	"os"
+
 	"github.com/prysmaticlabs/prysm/v3/cmd"
 	"github.com/prysmaticlabs/prysm/v3/cmd/validator/flags"
 	"github.com/prysmaticlabs/prysm/v3/config/features"
@@ -144,6 +146,48 @@ var Commands = &cli.Command{
 			Action: func(cliCtx *cli.Context) error {
 				if err := accountsImport(cliCtx); err != nil {
 					log.WithError(err).Fatal("Could not import accounts")
+				}
+				return nil
+			},
+		},
+		{
+			Name:        "voluntary-exit",
+			Description: "Performs a voluntary exit on selected accounts",
+			Flags: cmd.WrapFlags([]cli.Flag{
+				flags.WalletDirFlag,
+				flags.WalletPasswordFileFlag,
+				flags.AccountPasswordFileFlag,
+				flags.VoluntaryExitPublicKeysFlag,
+				flags.BeaconRPCProviderFlag,
+				flags.Web3SignerURLFlag,
+				flags.Web3SignerPublicValidatorKeysFlag,
+				flags.InteropNumValidators,
+				flags.InteropStartIndex,
+				cmd.GrpcMaxCallRecvMsgSizeFlag,
+				flags.CertFlag,
+				flags.GrpcHeadersFlag,
+				flags.GrpcRetriesFlag,
+				flags.GrpcRetryDelayFlag,
+				flags.ExitAllFlag,
+				features.Mainnet,
+				features.PraterTestnet,
+				features.RopstenTestnet,
+				features.SepoliaTestnet,
+				cmd.AcceptTosFlag,
+			}),
+			Before: func(cliCtx *cli.Context) error {
+				if err := cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags); err != nil {
+					return err
+				}
+				if err := tos.VerifyTosAcceptedOrPrompt(cliCtx); err != nil {
+					return err
+				}
+				return features.ConfigureValidator(cliCtx)
+			},
+			Action: func(cliCtx *cli.Context) error {
+				log.Info("This command will be deprecated in the future in favor of `prysmctl sign validator-exit`")
+				if err := AccountsExit(cliCtx, os.Stdin); err != nil {
+					log.WithError(err).Fatal("Could not perform voluntary exit")
 				}
 				return nil
 			},


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

revert breaking change

**What does this PR do? Why is it needed?**
Validator-Exit was moved to `prysmctl` in the following PR
https://github.com/prysmaticlabs/prysm/pull/11515/files#diff-f40562b5596adb94e7e60e9a0a25679a8887242252a1b0975d46452485972d21 
removed in`cmd/validator/accounts/accounts.go`
added in `cmd/prysmctl/signing/cmd.go`

this PR is to revert the removal of the command for the minor release in favor of fully deprecating it in a future major release. 
