### PR TITLE
bazel: remove --stamp for builds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,7 +21,6 @@ build --sandbox_default_allow_network=false
 
 # Stamp binaries with git information
 build --workspace_status_command=./hack/workspace_status.sh
-build --stamp
 
 # Prevent PATH changes from rebuilding when switching from IDE to command line.
 build --incompatible_strict_action_env


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

`--stamp` made bazel link some buildtime information to every GoLink step of a go_binary. This meant that there was never a cache hit as the buildtime information includes info like the current timestamp.

This change should increase the number of build cache hits and makes binary release builds more reproducible

**Which issues(s) does this PR fix?**

**Other notes for review**
