### PR TITLE
Copy Bytes Safely When Accessing Withdrawals

### DIFF
--- a/beacon-chain/state/state-native/getters_withdrawal.go
+++ b/beacon-chain/state/state-native/getters_withdrawal.go
@@ -3,6 +3,7 @@ package state_native
 import (
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	enginev1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v3/runtime/version"
@@ -62,7 +63,7 @@ func (b *BeaconState) ExpectedWithdrawals() ([]*enginev1.Withdrawal, error) {
 			withdrawals = append(withdrawals, &enginev1.Withdrawal{
 				WithdrawalIndex:  withdrawalIndex,
 				ValidatorIndex:   validatorIndex,
-				ExecutionAddress: val.WithdrawalCredentials[ETH1AddressOffset:],
+				ExecutionAddress: bytesutil.SafeCopyBytes(val.WithdrawalCredentials[ETH1AddressOffset:]),
 				Amount:           balance,
 			})
 			withdrawalIndex++
@@ -70,7 +71,7 @@ func (b *BeaconState) ExpectedWithdrawals() ([]*enginev1.Withdrawal, error) {
 			withdrawals = append(withdrawals, &enginev1.Withdrawal{
 				WithdrawalIndex:  withdrawalIndex,
 				ValidatorIndex:   validatorIndex,
-				ExecutionAddress: val.WithdrawalCredentials[ETH1AddressOffset:],
+				ExecutionAddress: bytesutil.SafeCopyBytes(val.WithdrawalCredentials[ETH1AddressOffset:]),
 				Amount:           balance - params.BeaconConfig().MaxEffectiveBalance,
 			})
 			withdrawalIndex++


### PR DESCRIPTION
**What type of PR is this?**

Clean Up

**What does this PR do? Why is it needed?**

This follows on from #11618 where we copy bytes from the withdrawal field, rather than directly referencing those bytes
when creating the withdrawal object.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
