### PR TITLE
Fix ENR Serialization

### DIFF
--- a/beacon-chain/p2p/utils.go
+++ b/beacon-chain/p2p/utils.go
@@ -39,7 +39,7 @@ func SerializeENR(record *enr.Record) (string, error) {
 	if err := record.EncodeRLP(buf); err != nil {
 		return "", errors.Wrap(err, "could not encode ENR record to bytes")
 	}
-	enrString := base64.URLEncoding.EncodeToString(buf.Bytes())
+	enrString := base64.RawURLEncoding.EncodeToString(buf.Bytes())
 	return enrString, nil
 }
 

--- a/beacon-chain/p2p/utils_test.go
+++ b/beacon-chain/p2p/utils_test.go
@@ -52,6 +52,10 @@ func TestSerializeENR(t *testing.T) {
 		s, err := SerializeENR(record)
 		require.NoError(t, err)
 		assert.NotEqual(t, "", s)
+		s = "enr:" + s
+		newRec, err := enode.Parse(enode.ValidSchemes, s)
+		require.NoError(t, err)
+		assert.Equal(t, s, newRec.String())
 	})
 
 	t.Run("Nil record", func(t *testing.T) {

--- a/beacon-chain/rpc/eth/node/node_test.go
+++ b/beacon-chain/rpc/eth/node/node_test.go
@@ -208,7 +208,7 @@ func TestGetPeer(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, rawId, resp.Data.PeerId)
 		assert.Equal(t, p2pAddr, resp.Data.LastSeenP2PAddress)
-		assert.Equal(t, "enr:yoABgmlwhAcHBwc=", resp.Data.Enr)
+		assert.Equal(t, "enr:yoABgmlwhAcHBwc", resp.Data.Enr)
 		assert.Equal(t, ethpb.ConnectionState_DISCONNECTED, resp.Data.State)
 		assert.Equal(t, ethpb.PeerDirection_INBOUND, resp.Data.Direction)
 	})


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

During withdrawals testing, it was revealed that our API endpoints were outputting invalid ENRs. The reason it happened was because prysm was using the incorrect base64 encoding when serializing the record. This PR fixes it along with adding in a test for this.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
