### PR TITLE
Add REST implementation for Validator's WaitForChainStart

### DIFF
--- a/testing/mock/validator_client_mock.go
+++ b/testing/mock/validator_client_mock.go
@@ -9,185 +9,185 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	eth "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
+	v1alpha1 "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
 )
 
-// MockValidatorClient is a mock of ValidatorClient interface.
+// MockValidatorClient is a mock of ValidatorClient interface
 type MockValidatorClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockValidatorClientMockRecorder
 }
 
-// MockValidatorClientMockRecorder is the mock recorder for MockValidatorClient.
+// MockValidatorClientMockRecorder is the mock recorder for MockValidatorClient
 type MockValidatorClientMockRecorder struct {
 	mock *MockValidatorClient
 }
 
-// NewMockValidatorClient creates a new mock instance.
+// NewMockValidatorClient creates a new mock instance
 func NewMockValidatorClient(ctrl *gomock.Controller) *MockValidatorClient {
 	mock := &MockValidatorClient{ctrl: ctrl}
 	mock.recorder = &MockValidatorClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockValidatorClient) EXPECT() *MockValidatorClientMockRecorder {
 	return m.recorder
 }
 
-// CheckDoppelGanger mocks base method.
-func (m *MockValidatorClient) CheckDoppelGanger(arg0 context.Context, arg1 *eth.DoppelGangerRequest) (*eth.DoppelGangerResponse, error) {
+// CheckDoppelGanger mocks base method
+func (m *MockValidatorClient) CheckDoppelGanger(arg0 context.Context, arg1 *v1alpha1.DoppelGangerRequest) (*v1alpha1.DoppelGangerResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckDoppelGanger", arg0, arg1)
-	ret0, _ := ret[0].(*eth.DoppelGangerResponse)
+	ret0, _ := ret[0].(*v1alpha1.DoppelGangerResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CheckDoppelGanger indicates an expected call of CheckDoppelGanger.
+// CheckDoppelGanger indicates an expected call of CheckDoppelGanger
 func (mr *MockValidatorClientMockRecorder) CheckDoppelGanger(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDoppelGanger", reflect.TypeOf((*MockValidatorClient)(nil).CheckDoppelGanger), arg0, arg1)
 }
 
-// DomainData mocks base method.
-func (m *MockValidatorClient) DomainData(arg0 context.Context, arg1 *eth.DomainRequest) (*eth.DomainResponse, error) {
+// DomainData mocks base method
+func (m *MockValidatorClient) DomainData(arg0 context.Context, arg1 *v1alpha1.DomainRequest) (*v1alpha1.DomainResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DomainData", arg0, arg1)
-	ret0, _ := ret[0].(*eth.DomainResponse)
+	ret0, _ := ret[0].(*v1alpha1.DomainResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DomainData indicates an expected call of DomainData.
+// DomainData indicates an expected call of DomainData
 func (mr *MockValidatorClientMockRecorder) DomainData(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DomainData", reflect.TypeOf((*MockValidatorClient)(nil).DomainData), arg0, arg1)
 }
 
-// GetAttestationData mocks base method.
-func (m *MockValidatorClient) GetAttestationData(arg0 context.Context, arg1 *eth.AttestationDataRequest) (*eth.AttestationData, error) {
+// GetAttestationData mocks base method
+func (m *MockValidatorClient) GetAttestationData(arg0 context.Context, arg1 *v1alpha1.AttestationDataRequest) (*v1alpha1.AttestationData, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAttestationData", arg0, arg1)
-	ret0, _ := ret[0].(*eth.AttestationData)
+	ret0, _ := ret[0].(*v1alpha1.AttestationData)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAttestationData indicates an expected call of GetAttestationData.
+// GetAttestationData indicates an expected call of GetAttestationData
 func (mr *MockValidatorClientMockRecorder) GetAttestationData(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAttestationData", reflect.TypeOf((*MockValidatorClient)(nil).GetAttestationData), arg0, arg1)
 }
 
-// GetBeaconBlock mocks base method.
-func (m *MockValidatorClient) GetBeaconBlock(arg0 context.Context, arg1 *eth.BlockRequest) (*eth.GenericBeaconBlock, error) {
+// GetBeaconBlock mocks base method
+func (m *MockValidatorClient) GetBeaconBlock(arg0 context.Context, arg1 *v1alpha1.BlockRequest) (*v1alpha1.GenericBeaconBlock, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBeaconBlock", arg0, arg1)
-	ret0, _ := ret[0].(*eth.GenericBeaconBlock)
+	ret0, _ := ret[0].(*v1alpha1.GenericBeaconBlock)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetBeaconBlock indicates an expected call of GetBeaconBlock.
+// GetBeaconBlock indicates an expected call of GetBeaconBlock
 func (mr *MockValidatorClientMockRecorder) GetBeaconBlock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBeaconBlock", reflect.TypeOf((*MockValidatorClient)(nil).GetBeaconBlock), arg0, arg1)
 }
 
-// GetDuties mocks base method.
-func (m *MockValidatorClient) GetDuties(arg0 context.Context, arg1 *eth.DutiesRequest) (*eth.DutiesResponse, error) {
+// GetDuties mocks base method
+func (m *MockValidatorClient) GetDuties(arg0 context.Context, arg1 *v1alpha1.DutiesRequest) (*v1alpha1.DutiesResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDuties", arg0, arg1)
-	ret0, _ := ret[0].(*eth.DutiesResponse)
+	ret0, _ := ret[0].(*v1alpha1.DutiesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetDuties indicates an expected call of GetDuties.
+// GetDuties indicates an expected call of GetDuties
 func (mr *MockValidatorClientMockRecorder) GetDuties(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDuties", reflect.TypeOf((*MockValidatorClient)(nil).GetDuties), arg0, arg1)
 }
 
-// GetFeeRecipientByPubKey mocks base method.
-func (m *MockValidatorClient) GetFeeRecipientByPubKey(arg0 context.Context, arg1 *eth.FeeRecipientByPubKeyRequest) (*eth.FeeRecipientByPubKeyResponse, error) {
+// GetFeeRecipientByPubKey mocks base method
+func (m *MockValidatorClient) GetFeeRecipientByPubKey(arg0 context.Context, arg1 *v1alpha1.FeeRecipientByPubKeyRequest) (*v1alpha1.FeeRecipientByPubKeyResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFeeRecipientByPubKey", arg0, arg1)
-	ret0, _ := ret[0].(*eth.FeeRecipientByPubKeyResponse)
+	ret0, _ := ret[0].(*v1alpha1.FeeRecipientByPubKeyResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetFeeRecipientByPubKey indicates an expected call of GetFeeRecipientByPubKey.
+// GetFeeRecipientByPubKey indicates an expected call of GetFeeRecipientByPubKey
 func (mr *MockValidatorClientMockRecorder) GetFeeRecipientByPubKey(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFeeRecipientByPubKey", reflect.TypeOf((*MockValidatorClient)(nil).GetFeeRecipientByPubKey), arg0, arg1)
 }
 
-// GetSyncCommitteeContribution mocks base method.
-func (m *MockValidatorClient) GetSyncCommitteeContribution(arg0 context.Context, arg1 *eth.SyncCommitteeContributionRequest) (*eth.SyncCommitteeContribution, error) {
+// GetSyncCommitteeContribution mocks base method
+func (m *MockValidatorClient) GetSyncCommitteeContribution(arg0 context.Context, arg1 *v1alpha1.SyncCommitteeContributionRequest) (*v1alpha1.SyncCommitteeContribution, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSyncCommitteeContribution", arg0, arg1)
-	ret0, _ := ret[0].(*eth.SyncCommitteeContribution)
+	ret0, _ := ret[0].(*v1alpha1.SyncCommitteeContribution)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSyncCommitteeContribution indicates an expected call of GetSyncCommitteeContribution.
+// GetSyncCommitteeContribution indicates an expected call of GetSyncCommitteeContribution
 func (mr *MockValidatorClientMockRecorder) GetSyncCommitteeContribution(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncCommitteeContribution", reflect.TypeOf((*MockValidatorClient)(nil).GetSyncCommitteeContribution), arg0, arg1)
 }
 
-// GetSyncMessageBlockRoot mocks base method.
-func (m *MockValidatorClient) GetSyncMessageBlockRoot(arg0 context.Context, arg1 *emptypb.Empty) (*eth.SyncMessageBlockRootResponse, error) {
+// GetSyncMessageBlockRoot mocks base method
+func (m *MockValidatorClient) GetSyncMessageBlockRoot(arg0 context.Context, arg1 *emptypb.Empty) (*v1alpha1.SyncMessageBlockRootResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSyncMessageBlockRoot", arg0, arg1)
-	ret0, _ := ret[0].(*eth.SyncMessageBlockRootResponse)
+	ret0, _ := ret[0].(*v1alpha1.SyncMessageBlockRootResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSyncMessageBlockRoot indicates an expected call of GetSyncMessageBlockRoot.
+// GetSyncMessageBlockRoot indicates an expected call of GetSyncMessageBlockRoot
 func (mr *MockValidatorClientMockRecorder) GetSyncMessageBlockRoot(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncMessageBlockRoot", reflect.TypeOf((*MockValidatorClient)(nil).GetSyncMessageBlockRoot), arg0, arg1)
 }
 
-// GetSyncSubcommitteeIndex mocks base method.
-func (m *MockValidatorClient) GetSyncSubcommitteeIndex(arg0 context.Context, arg1 *eth.SyncSubcommitteeIndexRequest) (*eth.SyncSubcommitteeIndexResponse, error) {
+// GetSyncSubcommitteeIndex mocks base method
+func (m *MockValidatorClient) GetSyncSubcommitteeIndex(arg0 context.Context, arg1 *v1alpha1.SyncSubcommitteeIndexRequest) (*v1alpha1.SyncSubcommitteeIndexResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSyncSubcommitteeIndex", arg0, arg1)
-	ret0, _ := ret[0].(*eth.SyncSubcommitteeIndexResponse)
+	ret0, _ := ret[0].(*v1alpha1.SyncSubcommitteeIndexResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSyncSubcommitteeIndex indicates an expected call of GetSyncSubcommitteeIndex.
+// GetSyncSubcommitteeIndex indicates an expected call of GetSyncSubcommitteeIndex
 func (mr *MockValidatorClientMockRecorder) GetSyncSubcommitteeIndex(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSyncSubcommitteeIndex", reflect.TypeOf((*MockValidatorClient)(nil).GetSyncSubcommitteeIndex), arg0, arg1)
 }
 
-// MultipleValidatorStatus mocks base method.
-func (m *MockValidatorClient) MultipleValidatorStatus(arg0 context.Context, arg1 *eth.MultipleValidatorStatusRequest) (*eth.MultipleValidatorStatusResponse, error) {
+// MultipleValidatorStatus mocks base method
+func (m *MockValidatorClient) MultipleValidatorStatus(arg0 context.Context, arg1 *v1alpha1.MultipleValidatorStatusRequest) (*v1alpha1.MultipleValidatorStatusResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MultipleValidatorStatus", arg0, arg1)
-	ret0, _ := ret[0].(*eth.MultipleValidatorStatusResponse)
+	ret0, _ := ret[0].(*v1alpha1.MultipleValidatorStatusResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// MultipleValidatorStatus indicates an expected call of MultipleValidatorStatus.
+// MultipleValidatorStatus indicates an expected call of MultipleValidatorStatus
 func (mr *MockValidatorClientMockRecorder) MultipleValidatorStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MultipleValidatorStatus", reflect.TypeOf((*MockValidatorClient)(nil).MultipleValidatorStatus), arg0, arg1)
 }
 
-// PrepareBeaconProposer mocks base method.
-func (m *MockValidatorClient) PrepareBeaconProposer(arg0 context.Context, arg1 *eth.PrepareBeaconProposerRequest) (*emptypb.Empty, error) {
+// PrepareBeaconProposer mocks base method
+func (m *MockValidatorClient) PrepareBeaconProposer(arg0 context.Context, arg1 *v1alpha1.PrepareBeaconProposerRequest) (*emptypb.Empty, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PrepareBeaconProposer", arg0, arg1)
 	ret0, _ := ret[0].(*emptypb.Empty)
@@ -195,119 +195,119 @@ func (m *MockValidatorClient) PrepareBeaconProposer(arg0 context.Context, arg1 *
 	return ret0, ret1
 }
 
-// PrepareBeaconProposer indicates an expected call of PrepareBeaconProposer.
+// PrepareBeaconProposer indicates an expected call of PrepareBeaconProposer
 func (mr *MockValidatorClientMockRecorder) PrepareBeaconProposer(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareBeaconProposer", reflect.TypeOf((*MockValidatorClient)(nil).PrepareBeaconProposer), arg0, arg1)
 }
 
-// ProposeAttestation mocks base method.
-func (m *MockValidatorClient) ProposeAttestation(arg0 context.Context, arg1 *eth.Attestation) (*eth.AttestResponse, error) {
+// ProposeAttestation mocks base method
+func (m *MockValidatorClient) ProposeAttestation(arg0 context.Context, arg1 *v1alpha1.Attestation) (*v1alpha1.AttestResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProposeAttestation", arg0, arg1)
-	ret0, _ := ret[0].(*eth.AttestResponse)
+	ret0, _ := ret[0].(*v1alpha1.AttestResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ProposeAttestation indicates an expected call of ProposeAttestation.
+// ProposeAttestation indicates an expected call of ProposeAttestation
 func (mr *MockValidatorClientMockRecorder) ProposeAttestation(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProposeAttestation", reflect.TypeOf((*MockValidatorClient)(nil).ProposeAttestation), arg0, arg1)
 }
 
-// ProposeBeaconBlock mocks base method.
-func (m *MockValidatorClient) ProposeBeaconBlock(arg0 context.Context, arg1 *eth.GenericSignedBeaconBlock) (*eth.ProposeResponse, error) {
+// ProposeBeaconBlock mocks base method
+func (m *MockValidatorClient) ProposeBeaconBlock(arg0 context.Context, arg1 *v1alpha1.GenericSignedBeaconBlock) (*v1alpha1.ProposeResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProposeBeaconBlock", arg0, arg1)
-	ret0, _ := ret[0].(*eth.ProposeResponse)
+	ret0, _ := ret[0].(*v1alpha1.ProposeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ProposeBeaconBlock indicates an expected call of ProposeBeaconBlock.
+// ProposeBeaconBlock indicates an expected call of ProposeBeaconBlock
 func (mr *MockValidatorClientMockRecorder) ProposeBeaconBlock(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProposeBeaconBlock", reflect.TypeOf((*MockValidatorClient)(nil).ProposeBeaconBlock), arg0, arg1)
 }
 
-// ProposeExit mocks base method.
-func (m *MockValidatorClient) ProposeExit(arg0 context.Context, arg1 *eth.SignedVoluntaryExit) (*eth.ProposeExitResponse, error) {
+// ProposeExit mocks base method
+func (m *MockValidatorClient) ProposeExit(arg0 context.Context, arg1 *v1alpha1.SignedVoluntaryExit) (*v1alpha1.ProposeExitResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProposeExit", arg0, arg1)
-	ret0, _ := ret[0].(*eth.ProposeExitResponse)
+	ret0, _ := ret[0].(*v1alpha1.ProposeExitResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ProposeExit indicates an expected call of ProposeExit.
+// ProposeExit indicates an expected call of ProposeExit
 func (mr *MockValidatorClientMockRecorder) ProposeExit(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProposeExit", reflect.TypeOf((*MockValidatorClient)(nil).ProposeExit), arg0, arg1)
 }
 
-// StreamBlocksAltair mocks base method.
-func (m *MockValidatorClient) StreamBlocksAltair(arg0 context.Context, arg1 *eth.StreamBlocksRequest) (eth.BeaconNodeValidator_StreamBlocksAltairClient, error) {
+// StreamBlocksAltair mocks base method
+func (m *MockValidatorClient) StreamBlocksAltair(arg0 context.Context, arg1 *v1alpha1.StreamBlocksRequest) (v1alpha1.BeaconNodeValidator_StreamBlocksAltairClient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StreamBlocksAltair", arg0, arg1)
-	ret0, _ := ret[0].(eth.BeaconNodeValidator_StreamBlocksAltairClient)
+	ret0, _ := ret[0].(v1alpha1.BeaconNodeValidator_StreamBlocksAltairClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// StreamBlocksAltair indicates an expected call of StreamBlocksAltair.
+// StreamBlocksAltair indicates an expected call of StreamBlocksAltair
 func (mr *MockValidatorClientMockRecorder) StreamBlocksAltair(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamBlocksAltair", reflect.TypeOf((*MockValidatorClient)(nil).StreamBlocksAltair), arg0, arg1)
 }
 
-// StreamDuties mocks base method.
-func (m *MockValidatorClient) StreamDuties(arg0 context.Context, arg1 *eth.DutiesRequest) (eth.BeaconNodeValidator_StreamDutiesClient, error) {
+// StreamDuties mocks base method
+func (m *MockValidatorClient) StreamDuties(arg0 context.Context, arg1 *v1alpha1.DutiesRequest) (v1alpha1.BeaconNodeValidator_StreamDutiesClient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StreamDuties", arg0, arg1)
-	ret0, _ := ret[0].(eth.BeaconNodeValidator_StreamDutiesClient)
+	ret0, _ := ret[0].(v1alpha1.BeaconNodeValidator_StreamDutiesClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// StreamDuties indicates an expected call of StreamDuties.
+// StreamDuties indicates an expected call of StreamDuties
 func (mr *MockValidatorClientMockRecorder) StreamDuties(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamDuties", reflect.TypeOf((*MockValidatorClient)(nil).StreamDuties), arg0, arg1)
 }
 
-// SubmitAggregateSelectionProof mocks base method.
-func (m *MockValidatorClient) SubmitAggregateSelectionProof(arg0 context.Context, arg1 *eth.AggregateSelectionRequest) (*eth.AggregateSelectionResponse, error) {
+// SubmitAggregateSelectionProof mocks base method
+func (m *MockValidatorClient) SubmitAggregateSelectionProof(arg0 context.Context, arg1 *v1alpha1.AggregateSelectionRequest) (*v1alpha1.AggregateSelectionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitAggregateSelectionProof", arg0, arg1)
-	ret0, _ := ret[0].(*eth.AggregateSelectionResponse)
+	ret0, _ := ret[0].(*v1alpha1.AggregateSelectionResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SubmitAggregateSelectionProof indicates an expected call of SubmitAggregateSelectionProof.
+// SubmitAggregateSelectionProof indicates an expected call of SubmitAggregateSelectionProof
 func (mr *MockValidatorClientMockRecorder) SubmitAggregateSelectionProof(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitAggregateSelectionProof", reflect.TypeOf((*MockValidatorClient)(nil).SubmitAggregateSelectionProof), arg0, arg1)
 }
 
-// SubmitSignedAggregateSelectionProof mocks base method.
-func (m *MockValidatorClient) SubmitSignedAggregateSelectionProof(arg0 context.Context, arg1 *eth.SignedAggregateSubmitRequest) (*eth.SignedAggregateSubmitResponse, error) {
+// SubmitSignedAggregateSelectionProof mocks base method
+func (m *MockValidatorClient) SubmitSignedAggregateSelectionProof(arg0 context.Context, arg1 *v1alpha1.SignedAggregateSubmitRequest) (*v1alpha1.SignedAggregateSubmitResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitSignedAggregateSelectionProof", arg0, arg1)
-	ret0, _ := ret[0].(*eth.SignedAggregateSubmitResponse)
+	ret0, _ := ret[0].(*v1alpha1.SignedAggregateSubmitResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// SubmitSignedAggregateSelectionProof indicates an expected call of SubmitSignedAggregateSelectionProof.
+// SubmitSignedAggregateSelectionProof indicates an expected call of SubmitSignedAggregateSelectionProof
 func (mr *MockValidatorClientMockRecorder) SubmitSignedAggregateSelectionProof(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitSignedAggregateSelectionProof", reflect.TypeOf((*MockValidatorClient)(nil).SubmitSignedAggregateSelectionProof), arg0, arg1)
 }
 
-// SubmitSignedContributionAndProof mocks base method.
-func (m *MockValidatorClient) SubmitSignedContributionAndProof(arg0 context.Context, arg1 *eth.SignedContributionAndProof) (*emptypb.Empty, error) {
+// SubmitSignedContributionAndProof mocks base method
+func (m *MockValidatorClient) SubmitSignedContributionAndProof(arg0 context.Context, arg1 *v1alpha1.SignedContributionAndProof) (*emptypb.Empty, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitSignedContributionAndProof", arg0, arg1)
 	ret0, _ := ret[0].(*emptypb.Empty)
@@ -315,14 +315,14 @@ func (m *MockValidatorClient) SubmitSignedContributionAndProof(arg0 context.Cont
 	return ret0, ret1
 }
 
-// SubmitSignedContributionAndProof indicates an expected call of SubmitSignedContributionAndProof.
+// SubmitSignedContributionAndProof indicates an expected call of SubmitSignedContributionAndProof
 func (mr *MockValidatorClientMockRecorder) SubmitSignedContributionAndProof(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitSignedContributionAndProof", reflect.TypeOf((*MockValidatorClient)(nil).SubmitSignedContributionAndProof), arg0, arg1)
 }
 
-// SubmitSyncMessage mocks base method.
-func (m *MockValidatorClient) SubmitSyncMessage(arg0 context.Context, arg1 *eth.SyncCommitteeMessage) (*emptypb.Empty, error) {
+// SubmitSyncMessage mocks base method
+func (m *MockValidatorClient) SubmitSyncMessage(arg0 context.Context, arg1 *v1alpha1.SyncCommitteeMessage) (*emptypb.Empty, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitSyncMessage", arg0, arg1)
 	ret0, _ := ret[0].(*emptypb.Empty)
@@ -330,14 +330,14 @@ func (m *MockValidatorClient) SubmitSyncMessage(arg0 context.Context, arg1 *eth.
 	return ret0, ret1
 }
 
-// SubmitSyncMessage indicates an expected call of SubmitSyncMessage.
+// SubmitSyncMessage indicates an expected call of SubmitSyncMessage
 func (mr *MockValidatorClientMockRecorder) SubmitSyncMessage(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitSyncMessage", reflect.TypeOf((*MockValidatorClient)(nil).SubmitSyncMessage), arg0, arg1)
 }
 
-// SubmitValidatorRegistrations mocks base method.
-func (m *MockValidatorClient) SubmitValidatorRegistrations(arg0 context.Context, arg1 *eth.SignedValidatorRegistrationsV1) (*emptypb.Empty, error) {
+// SubmitValidatorRegistrations mocks base method
+func (m *MockValidatorClient) SubmitValidatorRegistrations(arg0 context.Context, arg1 *v1alpha1.SignedValidatorRegistrationsV1) (*emptypb.Empty, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitValidatorRegistrations", arg0, arg1)
 	ret0, _ := ret[0].(*emptypb.Empty)
@@ -345,14 +345,14 @@ func (m *MockValidatorClient) SubmitValidatorRegistrations(arg0 context.Context,
 	return ret0, ret1
 }
 
-// SubmitValidatorRegistrations indicates an expected call of SubmitValidatorRegistrations.
+// SubmitValidatorRegistrations indicates an expected call of SubmitValidatorRegistrations
 func (mr *MockValidatorClientMockRecorder) SubmitValidatorRegistrations(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubmitValidatorRegistrations", reflect.TypeOf((*MockValidatorClient)(nil).SubmitValidatorRegistrations), arg0, arg1)
 }
 
-// SubscribeCommitteeSubnets mocks base method.
-func (m *MockValidatorClient) SubscribeCommitteeSubnets(arg0 context.Context, arg1 *eth.CommitteeSubnetsSubscribeRequest) (*emptypb.Empty, error) {
+// SubscribeCommitteeSubnets mocks base method
+func (m *MockValidatorClient) SubscribeCommitteeSubnets(arg0 context.Context, arg1 *v1alpha1.CommitteeSubnetsSubscribeRequest) (*emptypb.Empty, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeCommitteeSubnets", arg0, arg1)
 	ret0, _ := ret[0].(*emptypb.Empty)
@@ -360,67 +360,67 @@ func (m *MockValidatorClient) SubscribeCommitteeSubnets(arg0 context.Context, ar
 	return ret0, ret1
 }
 
-// SubscribeCommitteeSubnets indicates an expected call of SubscribeCommitteeSubnets.
+// SubscribeCommitteeSubnets indicates an expected call of SubscribeCommitteeSubnets
 func (mr *MockValidatorClientMockRecorder) SubscribeCommitteeSubnets(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeCommitteeSubnets", reflect.TypeOf((*MockValidatorClient)(nil).SubscribeCommitteeSubnets), arg0, arg1)
 }
 
-// ValidatorIndex mocks base method.
-func (m *MockValidatorClient) ValidatorIndex(arg0 context.Context, arg1 *eth.ValidatorIndexRequest) (*eth.ValidatorIndexResponse, error) {
+// ValidatorIndex mocks base method
+func (m *MockValidatorClient) ValidatorIndex(arg0 context.Context, arg1 *v1alpha1.ValidatorIndexRequest) (*v1alpha1.ValidatorIndexResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidatorIndex", arg0, arg1)
-	ret0, _ := ret[0].(*eth.ValidatorIndexResponse)
+	ret0, _ := ret[0].(*v1alpha1.ValidatorIndexResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ValidatorIndex indicates an expected call of ValidatorIndex.
+// ValidatorIndex indicates an expected call of ValidatorIndex
 func (mr *MockValidatorClientMockRecorder) ValidatorIndex(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorIndex", reflect.TypeOf((*MockValidatorClient)(nil).ValidatorIndex), arg0, arg1)
 }
 
-// ValidatorStatus mocks base method.
-func (m *MockValidatorClient) ValidatorStatus(arg0 context.Context, arg1 *eth.ValidatorStatusRequest) (*eth.ValidatorStatusResponse, error) {
+// ValidatorStatus mocks base method
+func (m *MockValidatorClient) ValidatorStatus(arg0 context.Context, arg1 *v1alpha1.ValidatorStatusRequest) (*v1alpha1.ValidatorStatusResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidatorStatus", arg0, arg1)
-	ret0, _ := ret[0].(*eth.ValidatorStatusResponse)
+	ret0, _ := ret[0].(*v1alpha1.ValidatorStatusResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// ValidatorStatus indicates an expected call of ValidatorStatus.
+// ValidatorStatus indicates an expected call of ValidatorStatus
 func (mr *MockValidatorClientMockRecorder) ValidatorStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorStatus", reflect.TypeOf((*MockValidatorClient)(nil).ValidatorStatus), arg0, arg1)
 }
 
-// WaitForActivation mocks base method.
-func (m *MockValidatorClient) WaitForActivation(arg0 context.Context, arg1 *eth.ValidatorActivationRequest) (eth.BeaconNodeValidator_WaitForActivationClient, error) {
+// WaitForActivation mocks base method
+func (m *MockValidatorClient) WaitForActivation(arg0 context.Context, arg1 *v1alpha1.ValidatorActivationRequest) (v1alpha1.BeaconNodeValidator_WaitForActivationClient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForActivation", arg0, arg1)
-	ret0, _ := ret[0].(eth.BeaconNodeValidator_WaitForActivationClient)
+	ret0, _ := ret[0].(v1alpha1.BeaconNodeValidator_WaitForActivationClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WaitForActivation indicates an expected call of WaitForActivation.
+// WaitForActivation indicates an expected call of WaitForActivation
 func (mr *MockValidatorClientMockRecorder) WaitForActivation(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForActivation", reflect.TypeOf((*MockValidatorClient)(nil).WaitForActivation), arg0, arg1)
 }
 
-// WaitForChainStart mocks base method.
-func (m *MockValidatorClient) WaitForChainStart(arg0 context.Context, arg1 *emptypb.Empty) (eth.BeaconNodeValidator_WaitForChainStartClient, error) {
+// WaitForChainStart mocks base method
+func (m *MockValidatorClient) WaitForChainStart(arg0 context.Context, arg1 *emptypb.Empty) (*v1alpha1.ChainStartResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForChainStart", arg0, arg1)
-	ret0, _ := ret[0].(eth.BeaconNodeValidator_WaitForChainStartClient)
+	ret0, _ := ret[0].(*v1alpha1.ChainStartResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WaitForChainStart indicates an expected call of WaitForChainStart.
+// WaitForChainStart indicates an expected call of WaitForChainStart
 func (mr *MockValidatorClientMockRecorder) WaitForChainStart(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForChainStart", reflect.TypeOf((*MockValidatorClient)(nil).WaitForChainStart), arg0, arg1)

--- a/validator/client/beacon-api/BUILD.bazel
+++ b/validator/client/beacon-api/BUILD.bazel
@@ -4,12 +4,17 @@ load("@prysm//tools/go:def.bzl", "go_library")
 # keep
 go_library(
     name = "go_default_library",
-    srcs = ["beacon_api_validator_client.go"],
+    srcs = [
+        "beacon_api_validator_client.go",
+        "genesis.go",
+    ],
     importpath = "github.com/prysmaticlabs/prysm/v3/validator/client/beacon-api",
     visibility = ["//validator:__subpackages__"],
     deps = [
+        "//beacon-chain/rpc/apimiddleware:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//validator/client/iface:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
     ],
 )

--- a/validator/client/beacon-api/beacon_api_validator_client.go
+++ b/validator/client/beacon-api/beacon_api_validator_client.go
@@ -144,8 +144,8 @@ func (*beaconApiValidatorClient) WaitForActivation(_ context.Context, _ *ethpb.V
 }
 
 // Deprecated: Do not use.
-func (*beaconApiValidatorClient) WaitForChainStart(_ context.Context, _ *empty.Empty) (ethpb.BeaconNodeValidator_WaitForChainStartClient, error) {
-	panic("beaconApiValidatorClient.WaitForChainStart is not implemented")
+func (c *beaconApiValidatorClient) WaitForChainStart(_ context.Context, _ *empty.Empty) (*ethpb.ChainStartResponse, error) {
+	return c.waitForChainStart()
 }
 
 func NewBeaconApiValidatorClient(url string, timeout time.Duration) iface.ValidatorClient {

--- a/validator/client/beacon-api/genesis.go
+++ b/validator/client/beacon-api/genesis.go
@@ -1,0 +1,70 @@
+//go:build use_beacon_api
+// +build use_beacon_api
+
+package beacon_api
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/rpc/apimiddleware"
+	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
+)
+
+func (c *beaconApiValidatorClient) waitForChainStart() (*ethpb.ChainStartResponse, error) {
+	genesis, err := c.getGenesis()
+	if err != nil {
+		return nil, err
+	}
+
+	genesisTime, err := strconv.ParseUint(genesis.Data.GenesisTime, 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	chainStartResponse := &ethpb.ChainStartResponse{}
+	chainStartResponse.Started = true
+	chainStartResponse.GenesisTime = genesisTime
+
+	// Remove the leading 0x from the string before decoding it to bytes
+	genesisValidatorRoot, err := hex.DecodeString(genesis.Data.GenesisValidatorsRoot[2:])
+	if err != nil {
+		return nil, err
+	}
+	chainStartResponse.GenesisValidatorsRoot = genesisValidatorRoot
+
+	return chainStartResponse, nil
+}
+
+func (c *beaconApiValidatorClient) getGenesis() (*apimiddleware.GenesisResponseJson, error) {
+	resp, err := c.httpClient.Get(c.url + "/eth/v1/beacon/genesis")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err = resp.Body.Close(); err != nil {
+			return
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		errorJson := apimiddleware.EventErrorJson{}
+		err = json.NewDecoder(resp.Body).Decode(&errorJson)
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, errors.Errorf("error %d: %s", errorJson.StatusCode, errorJson.Message)
+	}
+
+	genesisJson := &apimiddleware.GenesisResponseJson{}
+	err = json.NewDecoder(resp.Body).Decode(&genesisJson)
+	if err != nil {
+		return nil, err
+	}
+
+	return genesisJson, nil
+}

--- a/validator/client/grpc-api/BUILD.bazel
+++ b/validator/client/grpc-api/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//proto/prysm/v1alpha1:go_default_library",
         "//validator/client/iface:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
         "@org_golang_google_grpc//:go_default_library",
     ],

--- a/validator/client/grpc-api/BUILD.bazel
+++ b/validator/client/grpc-api/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@prysm//tools/go:def.bzl", "go_library")
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -11,5 +11,18 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:empty_go_proto",
         "@org_golang_google_grpc//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    size = "small",
+    srcs = ["grpc_validator_client_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//testing/assert:go_default_library",
+        "//testing/mock:go_default_library",
+        "@com_github_golang_mock//gomock:go_default_library",
+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
     ],
 )

--- a/validator/client/grpc-api/grpc_validator_client.go
+++ b/validator/client/grpc-api/grpc_validator_client.go
@@ -117,8 +117,14 @@ func (c *grpcValidatorClient) WaitForActivation(ctx context.Context, in *ethpb.V
 }
 
 // Deprecated: Do not use.
-func (c *grpcValidatorClient) WaitForChainStart(ctx context.Context, in *empty.Empty) (ethpb.BeaconNodeValidator_WaitForChainStartClient, error) {
-	return c.beaconNodeValidatorClient.WaitForChainStart(ctx, in)
+func (c *grpcValidatorClient) WaitForChainStart(ctx context.Context, in *empty.Empty) (*ethpb.ChainStartResponse, error) {
+	stream, err := c.beaconNodeValidatorClient.WaitForChainStart(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return stream.Recv()
 }
 
 func NewGrpcValidatorClient(cc grpc.ClientConnInterface) iface.ValidatorClient {

--- a/validator/client/grpc-api/grpc_validator_client.go
+++ b/validator/client/grpc-api/grpc_validator_client.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	iface "github.com/prysmaticlabs/prysm/v3/validator/client/iface"
 	"google.golang.org/grpc"
@@ -119,9 +120,11 @@ func (c *grpcValidatorClient) WaitForActivation(ctx context.Context, in *ethpb.V
 // Deprecated: Do not use.
 func (c *grpcValidatorClient) WaitForChainStart(ctx context.Context, in *empty.Empty) (*ethpb.ChainStartResponse, error) {
 	stream, err := c.beaconNodeValidatorClient.WaitForChainStart(ctx, in)
-
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(
+			iface.ErrConnectionIssue,
+			errors.Wrap(err, "could not setup beacon chain ChainStart streaming client").Error(),
+		)
 	}
 
 	return stream.Recv()

--- a/validator/client/grpc-api/grpc_validator_client_test.go
+++ b/validator/client/grpc-api/grpc_validator_client_test.go
@@ -1,0 +1,31 @@
+//go:build !use_beacon_api
+// +build !use_beacon_api
+
+package grpc_api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/prysmaticlabs/prysm/v3/testing/assert"
+	mock2 "github.com/prysmaticlabs/prysm/v3/testing/mock"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+func TestWaitForChainStart_StreamSetupFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	beaconNodeValidatorClient := mock2.NewMockBeaconNodeValidatorClient(ctrl)
+	beaconNodeValidatorClient.EXPECT().WaitForChainStart(
+		gomock.Any(),
+		gomock.Any(),
+	).Return(nil, errors.New("failed stream"))
+
+	validatorClient := &grpcValidatorClient{beaconNodeValidatorClient}
+	_, err := validatorClient.WaitForChainStart(context.Background(), &emptypb.Empty{})
+	want := "could not setup beacon chain ChainStart streaming client"
+	assert.ErrorContains(t, want, err)
+}

--- a/validator/client/iface/validator_client.go
+++ b/validator/client/iface/validator_client.go
@@ -11,7 +11,7 @@ type ValidatorClient interface {
 	GetDuties(ctx context.Context, in *ethpb.DutiesRequest) (*ethpb.DutiesResponse, error)
 	StreamDuties(ctx context.Context, in *ethpb.DutiesRequest) (ethpb.BeaconNodeValidator_StreamDutiesClient, error)
 	DomainData(ctx context.Context, in *ethpb.DomainRequest) (*ethpb.DomainResponse, error)
-	WaitForChainStart(ctx context.Context, in *empty.Empty) (ethpb.BeaconNodeValidator_WaitForChainStartClient, error)
+	WaitForChainStart(ctx context.Context, in *empty.Empty) (*ethpb.ChainStartResponse, error)
 	WaitForActivation(ctx context.Context, in *ethpb.ValidatorActivationRequest) (ethpb.BeaconNodeValidator_WaitForActivationClient, error)
 	ValidatorIndex(ctx context.Context, in *ethpb.ValidatorIndexRequest) (*ethpb.ValidatorIndexResponse, error)
 	ValidatorStatus(ctx context.Context, in *ethpb.ValidatorStatusRequest) (*ethpb.ValidatorStatusResponse, error)

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -236,16 +236,8 @@ func (v *validator) WaitForChainStart(ctx context.Context) error {
 	ctx, span := trace.StartSpan(ctx, "validator.WaitForChainStart")
 	defer span.End()
 	// First, check if the beacon chain has started.
-	stream, err := v.validatorClient.WaitForChainStart(ctx, &emptypb.Empty{})
-	if err != nil {
-		return errors.Wrap(
-			iface.ErrConnectionIssue,
-			errors.Wrap(err, "could not setup beacon chain ChainStart streaming client").Error(),
-		)
-	}
-
 	log.Info("Syncing with beacon node to align on chain genesis info")
-	chainStartRes, err := stream.Recv()
+	chainStartRes, err := v.validatorClient.WaitForChainStart(ctx, &emptypb.Empty{})
 	if err != io.EOF {
 		if ctx.Err() == context.Canceled {
 			return errors.Wrap(ctx.Err(), "context has been canceled so shutting down the loop")


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This adds an implementation for the `WaitForChainStart` validator client method by caling the Beacon Node REST API instead of the gRPC one.