### PR TITLE
Capella: validator log withdrawals

### DIFF
--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -145,7 +145,7 @@ func (v *validator) ProposeBlock(ctx context.Context, slot types.Slot, pubKey [f
 		trace.Int64Attribute("numAttestations", int64(len(blk.Block().Body().Attestations()))),
 	)
 
-	if blk.Version() == version.Bellatrix {
+	if blk.Version() >= version.Bellatrix {
 		p, err := blk.Block().Body().Execution()
 		if err != nil {
 			log.WithError(err).Error("Failed to get execution payload")
@@ -166,6 +166,14 @@ func (v *validator) ProposeBlock(ctx context.Context, slot types.Slot, pubKey [f
 		}
 		if p.GasLimit() != 0 {
 			log = log.WithField("gasUtilized", float64(p.GasUsed())/float64(p.GasLimit()))
+		}
+		if blk.Version() >= version.Capella {
+			withdrawals, err := p.Withdrawals()
+			if err != nil {
+				log.WithError(err).Error("Failed to get execution payload withdrawals")
+				return
+			}
+			log = log.WithField("withdrawalCount", len(withdrawals))
 		}
 	}
 

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -561,6 +561,30 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 				},
 			},
 		},
+		{
+			name: "capella",
+			block: &ethpb.GenericBeaconBlock{
+				Block: &ethpb.GenericBeaconBlock_Capella{
+					Capella: func() *ethpb.BeaconBlockCapella {
+						blk := util.NewBeaconBlockCapella()
+						blk.Block.Body.Graffiti = graffiti
+						return blk.Block
+					}(),
+				},
+			},
+		},
+		{
+			name: "capella blind block",
+			block: &ethpb.GenericBeaconBlock{
+				Block: &ethpb.GenericBeaconBlock_BlindedCapella{
+					BlindedCapella: func() *ethpb.BlindedBeaconBlockCapella {
+						blk := util.NewBlindedBeaconBlockCapella()
+						blk.Block.Body.Graffiti = graffiti
+						return blk.Block
+					}(),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Updated validator client so that
- it can log withdrawal count
- added capella objects to `testProposeBlock`