### PR TITLE
Fix expected_withdrawals

### DIFF
--- a/beacon-chain/state/state-native/getters_withdrawal.go
+++ b/beacon-chain/state/state-native/getters_withdrawal.go
@@ -49,16 +49,13 @@ func (b *BeaconState) ExpectedWithdrawals() ([]*enginev1.Withdrawal, error) {
 	defer b.lock.RUnlock()
 
 	withdrawals := make([]*enginev1.Withdrawal, 0, params.BeaconConfig().MaxWithdrawalsPerPayload)
-	validatorIndex := b.nextWithdrawalValidatorIndex + 1
-	if uint64(validatorIndex) == uint64(len(b.validators)) {
-		validatorIndex = 0
-	}
+	validatorIndex := b.nextWithdrawalValidatorIndex
 	withdrawalIndex := b.nextWithdrawalIndex
 	epoch := slots.ToEpoch(b.slot)
 	for range b.validators {
 		val := b.validators[validatorIndex]
 		balance := b.balances[validatorIndex]
-		if isFullyWithdrawableValidator(val, epoch) {
+		if balance > 0 && isFullyWithdrawableValidator(val, epoch) {
 			withdrawals = append(withdrawals, &enginev1.Withdrawal{
 				WithdrawalIndex:  withdrawalIndex,
 				ValidatorIndex:   validatorIndex,


### PR DESCRIPTION
This PR fixes a bug introduced in  #11656 which started the sweep in the wrong validator index. It also fixes a bug that was allowing for a balance 0 validator to fully withdraw. 