### PR TITLE
disable geth nat traversal

### DIFF
--- a/testing/endtoend/components/eth1/miner.go
+++ b/testing/endtoend/components/eth1/miner.go
@@ -111,6 +111,7 @@ func (m *Miner) Start(ctx context.Context) error {
 	}
 
 	args := []string{
+		"--nat=none",
 		fmt.Sprintf("--datadir=%s", eth1Path),
 		fmt.Sprintf("--http.port=%d", e2e.TestParams.Ports.Eth1RPCPort),
 		fmt.Sprintf("--ws.port=%d", e2e.TestParams.Ports.Eth1WSPort),

--- a/testing/endtoend/components/eth1/node.go
+++ b/testing/endtoend/components/eth1/node.go
@@ -71,6 +71,7 @@ func (node *Node) Start(ctx context.Context) error {
 	}
 
 	args := []string{
+		"--nat=none",
 		fmt.Sprintf("--datadir=%s", eth1Path),
 		fmt.Sprintf("--http.port=%d", e2e.TestParams.Ports.Eth1RPCPort+node.index),
 		fmt.Sprintf("--ws.port=%d", e2e.TestParams.Ports.Eth1WSPort+node.index),


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

We frequently have e2e test runs fail with the error `P2P log not found, this means the eth1 chain had issues starting`. This happens when geth fails to start due to networking errors. I believe this happens because geth tries to use various methods in unpnp for nat traversal which seem to fail non-deterministically. We don't need nat traversal in e2e environments where all the EL nodes are on the same network, so this PR just turns off that functionality in an attempt to get around this failure case.