### PR TITLE
correctly assign arm64 arch for Apple M1

### DIFF
--- a/prysm.sh
+++ b/prysm.sh
@@ -77,7 +77,7 @@ readonly wrapper_dir="$(dirname "$(get_realpath "${BASH_SOURCE[0]}")")/dist"
 
 # for Apple M1s
 if [ "$(uname -s)" == "Darwin" ] && [ "$(uname -m)" == "arm64" ]; then
-    arch="amd64"
+    arch="arm64"
 else
     arch=$(uname -m)
     arch=${arch/x86_64/amd64}

--- a/prysm.sh
+++ b/prysm.sh
@@ -75,14 +75,11 @@ fi
 
 readonly wrapper_dir="$(dirname "$(get_realpath "${BASH_SOURCE[0]}")")/dist"
 
-# for Apple M1s
-if [ "$(uname -s)" == "Darwin" ] && [ "$(uname -m)" == "arm64" ]; then
-    arch="arm64"
-else
-    arch=$(uname -m)
-    arch=${arch/x86_64/amd64}
-    arch=${arch/aarch64/arm64}
-fi
+
+arch=$(uname -m)
+arch=${arch/x86_64/amd64}
+arch=${arch/aarch64/arm64}
+
 readonly os_arch_suffix="$(uname -s | tr '[:upper:]' '[:lower:]')-$arch"
 
 system=""


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Bug fix


**What does this PR do? Why is it needed?**
FIxes lines that prevents correct binaries from being downloaded via prysm.sh on Apple M1's.
originally opened by user https://github.com/baobaoy in https://github.com/prysmaticlabs/prysm/pull/11541 but pr went stale due to non-response.

**Which issues(s) does this PR fix?**

Fixes #7950

