### PR TITLE
Onboard validator's beacon REST API tests to CI

### DIFF
--- a/validator/client/beacon-api/BUILD.bazel
+++ b/validator/client/beacon-api/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "wait_for_chain_start_test.go",
     ],
     embed = [":go_default_library"],
+    gotags = ["use_beacon_api"],
     deps = [
         "//api/gateway/apimiddleware:go_default_library",
         "//beacon-chain/rpc/apimiddleware:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR allows the validator's beacon REST API tests to be ran during CI by adding the `gotags = ["use_beacon_api"]` to the test target, therefore making the tests run even when `--config=beacon_api` is not set on the command line.