### PR TITLE
clean and use fieldparams

### DIFF
--- a/beacon-chain/state/state-native/getters_withdrawal.go
+++ b/beacon-chain/state/state-native/getters_withdrawal.go
@@ -1,6 +1,7 @@
 package state_native
 
 import (
+	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
@@ -48,7 +49,7 @@ func (b *BeaconState) ExpectedWithdrawals() ([]*enginev1.Withdrawal, error) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	withdrawals := make([]*enginev1.Withdrawal, 0, params.BeaconConfig().MaxWithdrawalsPerPayload)
+	withdrawals := make([]*enginev1.Withdrawal, 0, fieldparams.MaxWithdrawalsPerPayload)
 	validatorIndex := b.nextWithdrawalValidatorIndex
 	withdrawalIndex := b.nextWithdrawalIndex
 	epoch := slots.ToEpoch(b.slot)
@@ -72,7 +73,7 @@ func (b *BeaconState) ExpectedWithdrawals() ([]*enginev1.Withdrawal, error) {
 			})
 			withdrawalIndex++
 		}
-		if uint64(len(withdrawals)) == params.BeaconConfig().MaxWithdrawalsPerPayload {
+		if uint64(len(withdrawals)) == fieldparams.MaxWithdrawalsPerPayload {
 			break
 		}
 		validatorIndex += 1

--- a/config/fieldparams/mainnet.go
+++ b/config/fieldparams/mainnet.go
@@ -26,6 +26,5 @@ const (
 	SyncCommitteeAggregationBytesLength   = 16            // SyncCommitteeAggregationBytesLength defines the length of sync committee aggregate bytes.
 	SyncAggregateSyncCommitteeBytesLength = 64            // SyncAggregateSyncCommitteeBytesLength defines the length of sync committee bytes in a sync aggregate.
 	MaxWithdrawalsPerPayload              = 16            // MaxWithdrawalsPerPayloadLength defines the maximum number of withdrawals that can be included in a payload.
-	WithdrawalQueueLimit                  = 1099511627776 // WithdrawalQueueLimit defines the maximum number of withdrawals queued in the state.
 	ExecutionAddressLength                = 20            // ExecutionAddressLength defines the length of an execution layer address.
 )

--- a/config/fieldparams/minimal.go
+++ b/config/fieldparams/minimal.go
@@ -26,5 +26,4 @@ const (
 	SyncCommitteeAggregationBytesLength   = 1             // SyncCommitteeAggregationBytesLength defines the sync committee aggregate bytes.
 	SyncAggregateSyncCommitteeBytesLength = 4             // SyncAggregateSyncCommitteeBytesLength defines the length of sync committee bytes in a sync aggregate.
 	MaxWithdrawalsPerPayload              = 16            // MaxWithdrawalsPerPayloadLength defines the maximum number of withdrawals that can be included in a payload.
-	WithdrawalQueueLimit                  = 1099511627776 // WithdrawalQueueLimit defines the maximum number of withdrawals queued in the state.
 )


### PR DESCRIPTION
Reduce difference with Capella branch: use fieldparams instead of beaconConfig and remove unused fieldparam