### PR TITLE
Avoid head state retrival per `validateBlsToExecutionChange` call

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -55,6 +55,7 @@ type HeadFetcher interface {
 	HeadBlock(ctx context.Context) (interfaces.SignedBeaconBlock, error)
 	HeadState(ctx context.Context) (state.BeaconState, error)
 	HeadValidatorsIndices(ctx context.Context, epoch types.Epoch) ([]types.ValidatorIndex, error)
+	HeadValidatorIndex(index types.ValidatorIndex) (state.ReadOnlyValidator, error)
 	HeadGenesisValidatorsRoot() [32]byte
 	HeadETH1Data() *ethpb.Eth1Data
 	HeadPublicKeyToValidatorIndex(pubKey [fieldparams.BLSPubkeyLength]byte) (types.ValidatorIndex, bool)
@@ -291,6 +292,14 @@ func (s *Service) HeadValidatorIndexToPublicKey(_ context.Context, index types.V
 		return [fieldparams.BLSPubkeyLength]byte{}, err
 	}
 	return v.PublicKey(), nil
+}
+
+// HeadValidatorIndex returns the validator in current head state.
+func (s *Service) HeadValidatorIndex(index types.ValidatorIndex) (state.ReadOnlyValidator, error) {
+	s.headLock.RLock()
+	defer s.headLock.RUnlock()
+
+	return s.headValidatorAtIndex(index)
 }
 
 // ForkChoicer returns the forkchoice interface.

--- a/beacon-chain/core/blocks/withdrawals.go
+++ b/beacon-chain/core/blocks/withdrawals.go
@@ -17,7 +17,6 @@ import (
 	enginev1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v3/runtime/version"
-	"github.com/prysmaticlabs/prysm/v3/time/slots"
 )
 
 const executionToBLSPadding = 12
@@ -153,7 +152,9 @@ func ProcessWithdrawals(st state.BeaconState, withdrawals []*enginev1.Withdrawal
 
 func BLSChangesSignatureBatch(
 	ctx context.Context,
-	st state.ReadOnlyBeaconState,
+	epoch types.Epoch,
+	fork *ethpb.Fork,
+	genesisValidatorsRoot []byte,
 	changes []*ethpb.SignedBLSToExecutionChange,
 ) (*bls.SignatureBatch, error) {
 	// Return early if no changes
@@ -165,8 +166,7 @@ func BLSChangesSignatureBatch(
 		PublicKeys: make([]bls.PublicKey, len(changes)),
 		Messages:   make([][32]byte, len(changes)),
 	}
-	epoch := slots.ToEpoch(st.Slot())
-	domain, err := signing.Domain(st.Fork(), epoch, params.BeaconConfig().DomainBLSToExecutionChange, st.GenesisValidatorsRoot())
+	domain, err := signing.Domain(fork, epoch, params.BeaconConfig().DomainBLSToExecutionChange, genesisValidatorsRoot)
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/altair"
 	b "github.com/prysmaticlabs/prysm/v3/beacon-chain/core/blocks"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/time"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/transition/interop"
 	v "github.com/prysmaticlabs/prysm/v3/beacon-chain/core/validators"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
@@ -205,7 +206,7 @@ func ProcessBlockNoVerifyAnySig(
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "could not get BLSToExecutionChanges")
 		}
-		cSet, err := b.BLSChangesSignatureBatch(ctx, st, changes)
+		cSet, err := b.BLSChangesSignatureBatch(ctx, time.CurrentEpoch(st), st.Fork(), st.GenesisValidatorsRoot(), changes)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "could not get BLSToExecutionChanges signatures")
 		}

--- a/beacon-chain/sync/validate_bls_to_execution_change.go
+++ b/beacon-chain/sync/validate_bls_to_execution_change.go
@@ -41,15 +41,18 @@ func (s *Service) validateBlsToExecutionChange(ctx context.Context, pid peer.ID,
 	if s.cfg.blsToExecPool.ValidatorExists(blsChange.Message.ValidatorIndex) {
 		return pubsub.ValidationIgnore, nil
 	}
-	st, err := s.cfg.chain.HeadState(ctx)
+	val, err := s.cfg.chain.HeadValidatorIndex(blsChange.Message.ValidatorIndex)
 	if err != nil {
 		return pubsub.ValidationIgnore, err
 	}
 	// Validate that the execution change object is valid.
-	_, err = blocks.ValidateBLSToExecutionChange(st, blsChange)
+	err = blocks.ValidateBLSToExecutionChange(val.WithdrawalCredentials(), blsChange)
 	if err != nil {
 		return pubsub.ValidationReject, err
 	}
+
+	// Nvm, still need state here, lol!
+
 	// Validate the signature of the message using our batch gossip verifier.
 	sigBatch, err := blocks.BLSChangesSignatureBatch(ctx, st, []*ethpb.SignedBLSToExecutionChange{blsChange})
 	if err != nil {

--- a/beacon-chain/sync/validate_bls_to_execution_change.go
+++ b/beacon-chain/sync/validate_bls_to_execution_change.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/v3/monitoring/tracing"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v3/time/slots"
 	"go.opencensus.io/trace"
 )
 
@@ -51,10 +52,9 @@ func (s *Service) validateBlsToExecutionChange(ctx context.Context, pid peer.ID,
 		return pubsub.ValidationReject, err
 	}
 
-	// Nvm, still need state here, lol!
-
 	// Validate the signature of the message using our batch gossip verifier.
-	sigBatch, err := blocks.BLSChangesSignatureBatch(ctx, st, []*ethpb.SignedBLSToExecutionChange{blsChange})
+	gvr := s.cfg.chain.GenesisValidatorsRoot()
+	sigBatch, err := blocks.BLSChangesSignatureBatch(ctx, slots.ToEpoch(s.cfg.chain.HeadSlot()), s.cfg.chain.CurrentFork(), gvr[:], []*ethpb.SignedBLSToExecutionChange{blsChange})
 	if err != nil {
 		return pubsub.ValidationReject, err
 	}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

Avoid head state retrieval for every gossip bls to exec object. With minor refactors and a head validator getter, this can be achieved safely 

