### PR TITLE
Spectests: ensure test directories are not empty

### DIFF
--- a/testing/spectest/shared/altair/epoch_processing/effective_balance_updates.go
+++ b/testing/spectest/shared/altair/epoch_processing/effective_balance_updates.go
@@ -15,6 +15,9 @@ func RunEffectiveBalanceUpdatesTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "epoch_processing/effective_balance_updates/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "epoch_processing/effective_balance_updates/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/epoch_processing/eth1_data_reset.go
+++ b/testing/spectest/shared/altair/epoch_processing/eth1_data_reset.go
@@ -15,6 +15,9 @@ func RunEth1DataResetTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "epoch_processing/eth1_data_reset/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "epoch_processing/eth1_data_reset/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/epoch_processing/historical_roots_update.go
+++ b/testing/spectest/shared/altair/epoch_processing/historical_roots_update.go
@@ -15,6 +15,9 @@ func RunHistoricalRootsUpdateTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "epoch_processing/historical_roots_update/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "epoch_processing/historical_roots_update/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/epoch_processing/participation_flag_updates.go
+++ b/testing/spectest/shared/altair/epoch_processing/participation_flag_updates.go
@@ -15,6 +15,9 @@ func RunParticipationFlagUpdatesTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "epoch_processing/participation_flag_updates/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "epoch_processing/participation_flag_updates/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/epoch_processing/randao_mixes_reset.go
+++ b/testing/spectest/shared/altair/epoch_processing/randao_mixes_reset.go
@@ -15,6 +15,9 @@ func RunRandaoMixesResetTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "epoch_processing/randao_mixes_reset/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "epoch_processing/randao_mixes_reset/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/epoch_processing/registry_updates.go
+++ b/testing/spectest/shared/altair/epoch_processing/registry_updates.go
@@ -17,6 +17,9 @@ func RunRegistryUpdatesTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "epoch_processing/registry_updates/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "epoch_processing/registry_updates/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			// Important to clear cache for every test or else the old value of active validator count gets reused.

--- a/testing/spectest/shared/altair/epoch_processing/slashings.go
+++ b/testing/spectest/shared/altair/epoch_processing/slashings.go
@@ -17,6 +17,9 @@ func RunSlashingsTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "epoch_processing/slashings/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "epoch_processing/slashings/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/epoch_processing/slashings_reset.go
+++ b/testing/spectest/shared/altair/epoch_processing/slashings_reset.go
@@ -15,6 +15,9 @@ func RunSlashingsResetTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "epoch_processing/slashings_reset/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "epoch_processing/slashings_reset/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/finality/finality.go
+++ b/testing/spectest/shared/altair/finality/finality.go
@@ -31,6 +31,9 @@ func RunFinalityTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "finality/finality/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "finality/finality/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			helpers.ClearCache()

--- a/testing/spectest/shared/altair/fork/transition.go
+++ b/testing/spectest/shared/altair/fork/transition.go
@@ -36,6 +36,9 @@ func RunForkTransitionTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "transition/core/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "transition/core/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			helpers.ClearCache()

--- a/testing/spectest/shared/altair/fork/upgrade_to_altair.go
+++ b/testing/spectest/shared/altair/fork/upgrade_to_altair.go
@@ -22,6 +22,9 @@ func RunUpgradeToAltair(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "fork/fork/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "fork/fork/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			helpers.ClearCache()

--- a/testing/spectest/shared/altair/operations/attestation.go
+++ b/testing/spectest/shared/altair/operations/attestation.go
@@ -20,6 +20,9 @@ import (
 func RunAttestationTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/attestation/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "operations/attestation/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/operations/attester_slashing.go
+++ b/testing/spectest/shared/altair/operations/attester_slashing.go
@@ -19,6 +19,9 @@ import (
 func RunAttesterSlashingTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/attester_slashing/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "operations/attester_slashing/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/operations/block_header.go
+++ b/testing/spectest/shared/altair/operations/block_header.go
@@ -22,6 +22,9 @@ import (
 func RunBlockHeaderTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/block_header/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "operations/block_header/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			blockFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "block.ssz_snappy")

--- a/testing/spectest/shared/altair/operations/deposit.go
+++ b/testing/spectest/shared/altair/operations/deposit.go
@@ -18,6 +18,9 @@ import (
 func RunDepositTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/deposit/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "operations/deposit/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/operations/proposer_slashing.go
+++ b/testing/spectest/shared/altair/operations/proposer_slashing.go
@@ -19,6 +19,9 @@ import (
 func RunProposerSlashingTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/proposer_slashing/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "operations/proposer_slashing/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/operations/sync_committee.go
+++ b/testing/spectest/shared/altair/operations/sync_committee.go
@@ -18,6 +18,9 @@ import (
 func RunSyncCommitteeTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/sync_aggregate/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "operations/sync_aggregate/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/altair/operations/voluntary_exit.go
+++ b/testing/spectest/shared/altair/operations/voluntary_exit.go
@@ -18,6 +18,9 @@ import (
 func RunVoluntaryExitTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "altair", "operations/voluntary_exit/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "altair", "operations/voluntary_exit/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/epoch_processing/effective_balance_updates.go
+++ b/testing/spectest/shared/bellatrix/epoch_processing/effective_balance_updates.go
@@ -15,6 +15,9 @@ func RunEffectiveBalanceUpdatesTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "epoch_processing/effective_balance_updates/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "epoch_processing/effective_balance_updates/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/epoch_processing/eth1_data_reset.go
+++ b/testing/spectest/shared/bellatrix/epoch_processing/eth1_data_reset.go
@@ -15,6 +15,9 @@ func RunEth1DataResetTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "epoch_processing/eth1_data_reset/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "epoch_processing/eth1_data_reset/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/epoch_processing/historical_roots_update.go
+++ b/testing/spectest/shared/bellatrix/epoch_processing/historical_roots_update.go
@@ -15,6 +15,9 @@ func RunHistoricalRootsUpdateTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "epoch_processing/historical_roots_update/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "epoch_processing/historical_roots_update/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/epoch_processing/participation_flag_updates.go
+++ b/testing/spectest/shared/bellatrix/epoch_processing/participation_flag_updates.go
@@ -15,6 +15,9 @@ func RunParticipationFlagUpdatesTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "epoch_processing/participation_flag_updates/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "epoch_processing/participation_flag_updates/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/epoch_processing/randao_mixes_reset.go
+++ b/testing/spectest/shared/bellatrix/epoch_processing/randao_mixes_reset.go
@@ -15,6 +15,9 @@ func RunRandaoMixesResetTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "epoch_processing/randao_mixes_reset/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "epoch_processing/randao_mixes_reset/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/epoch_processing/registry_updates.go
+++ b/testing/spectest/shared/bellatrix/epoch_processing/registry_updates.go
@@ -17,6 +17,9 @@ func RunRegistryUpdatesTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "epoch_processing/registry_updates/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "epoch_processing/registry_updates/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			// Important to clear cache for every test or else the old value of active validator count gets reused.

--- a/testing/spectest/shared/bellatrix/epoch_processing/slashings.go
+++ b/testing/spectest/shared/bellatrix/epoch_processing/slashings.go
@@ -17,6 +17,9 @@ func RunSlashingsTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "epoch_processing/slashings/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "epoch_processing/slashings/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/epoch_processing/slashings_reset.go
+++ b/testing/spectest/shared/bellatrix/epoch_processing/slashings_reset.go
@@ -15,6 +15,9 @@ func RunSlashingsResetTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "epoch_processing/slashings_reset/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "epoch_processing/slashings_reset/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/finality/finality.go
+++ b/testing/spectest/shared/bellatrix/finality/finality.go
@@ -31,6 +31,9 @@ func RunFinalityTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "finality/finality/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "finality/finality/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			helpers.ClearCache()

--- a/testing/spectest/shared/bellatrix/fork/transition.go
+++ b/testing/spectest/shared/bellatrix/fork/transition.go
@@ -31,6 +31,9 @@ func RunForkTransitionTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "transition/core/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "transition/core/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			helpers.ClearCache()

--- a/testing/spectest/shared/bellatrix/fork/upgrade_to_bellatrix.go
+++ b/testing/spectest/shared/bellatrix/fork/upgrade_to_bellatrix.go
@@ -21,6 +21,9 @@ func RunUpgradeToBellatrix(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "fork/fork/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "fork/fork/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			helpers.ClearCache()

--- a/testing/spectest/shared/bellatrix/operations/attestation.go
+++ b/testing/spectest/shared/bellatrix/operations/attestation.go
@@ -20,6 +20,9 @@ import (
 func RunAttestationTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "operations/attestation/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "operations/attestation/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/operations/attester_slashing.go
+++ b/testing/spectest/shared/bellatrix/operations/attester_slashing.go
@@ -19,6 +19,9 @@ import (
 func RunAttesterSlashingTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "operations/attester_slashing/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "operations/attester_slashing/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/operations/block_header.go
+++ b/testing/spectest/shared/bellatrix/operations/block_header.go
@@ -22,6 +22,9 @@ import (
 func RunBlockHeaderTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "operations/block_header/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "operations/block_header/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			blockFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "block.ssz_snappy")

--- a/testing/spectest/shared/bellatrix/operations/deposit.go
+++ b/testing/spectest/shared/bellatrix/operations/deposit.go
@@ -18,6 +18,9 @@ import (
 func RunDepositTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "operations/deposit/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "operations/deposit/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/operations/proposer_slashing.go
+++ b/testing/spectest/shared/bellatrix/operations/proposer_slashing.go
@@ -19,6 +19,9 @@ import (
 func RunProposerSlashingTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "operations/proposer_slashing/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "operations/proposer_slashing/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/operations/sync_committee.go
+++ b/testing/spectest/shared/bellatrix/operations/sync_committee.go
@@ -18,6 +18,9 @@ import (
 func RunSyncCommitteeTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "operations/sync_aggregate/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "operations/sync_aggregate/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/bellatrix/operations/voluntary_exit.go
+++ b/testing/spectest/shared/bellatrix/operations/voluntary_exit.go
@@ -18,6 +18,9 @@ import (
 func RunVoluntaryExitTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "bellatrix", "operations/voluntary_exit/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "bellatrix", "operations/voluntary_exit/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/epoch_processing/effective_balance_updates.go
+++ b/testing/spectest/shared/phase0/epoch_processing/effective_balance_updates.go
@@ -15,6 +15,9 @@ func RunEffectiveBalanceUpdatesTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "epoch_processing/effective_balance_updates/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "epoch_processing/effective_balance_updates/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/epoch_processing/eth1_data_reset.go
+++ b/testing/spectest/shared/phase0/epoch_processing/eth1_data_reset.go
@@ -15,6 +15,9 @@ func RunEth1DataResetTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "epoch_processing/eth1_data_reset/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "epoch_processing/eth1_data_reset/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/epoch_processing/historical_roots_update.go
+++ b/testing/spectest/shared/phase0/epoch_processing/historical_roots_update.go
@@ -15,6 +15,9 @@ func RunHistoricalRootsUpdateTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "epoch_processing/historical_roots_update/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "epoch_processing/historical_roots_update/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/epoch_processing/participation_record_updates.go
+++ b/testing/spectest/shared/phase0/epoch_processing/participation_record_updates.go
@@ -15,6 +15,9 @@ func RunParticipationRecordUpdatesTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "epoch_processing/participation_record_updates/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "epoch_processing/participation_record_updates/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/epoch_processing/randao_mixes_reset.go
+++ b/testing/spectest/shared/phase0/epoch_processing/randao_mixes_reset.go
@@ -15,6 +15,9 @@ func RunRandaoMixesResetTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "epoch_processing/randao_mixes_reset/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "epoch_processing/randao_mixes_reset/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/epoch_processing/registry_updates.go
+++ b/testing/spectest/shared/phase0/epoch_processing/registry_updates.go
@@ -17,6 +17,9 @@ func RunRegistryUpdatesTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "epoch_processing/registry_updates/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "epoch_processing/registry_updates/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/epoch_processing/slashings.go
+++ b/testing/spectest/shared/phase0/epoch_processing/slashings.go
@@ -19,6 +19,9 @@ func RunSlashingsTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "epoch_processing/slashings/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "epoch_processing/slashings/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		helpers.ClearCache()
 		t.Run(folder.Name(), func(t *testing.T) {

--- a/testing/spectest/shared/phase0/epoch_processing/slashings_reset.go
+++ b/testing/spectest/shared/phase0/epoch_processing/slashings_reset.go
@@ -15,6 +15,9 @@ func RunSlashingsResetTests(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "epoch_processing/slashings_reset/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "epoch_processing/slashings_reset/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/finality/runner.go
+++ b/testing/spectest/shared/phase0/finality/runner.go
@@ -32,6 +32,9 @@ func RunFinalityTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "finality/finality/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "finality/finality/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			helpers.ClearCache()

--- a/testing/spectest/shared/phase0/operations/attestation.go
+++ b/testing/spectest/shared/phase0/operations/attestation.go
@@ -20,6 +20,9 @@ import (
 func RunAttestationTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "operations/attestation/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "operations/attestation/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/operations/attester_slashing.go
+++ b/testing/spectest/shared/phase0/operations/attester_slashing.go
@@ -20,6 +20,9 @@ import (
 func RunAttesterSlashingTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "operations/attester_slashing/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "operations/attester_slashing/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/operations/block_header.go
+++ b/testing/spectest/shared/phase0/operations/block_header.go
@@ -23,6 +23,9 @@ import (
 func RunBlockHeaderTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "operations/block_header/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "operations/block_header/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			blockFile, err := util.BazelFileBytes(testsFolderPath, folder.Name(), "block.ssz_snappy")

--- a/testing/spectest/shared/phase0/operations/deposit.go
+++ b/testing/spectest/shared/phase0/operations/deposit.go
@@ -19,6 +19,9 @@ import (
 func RunDepositTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "operations/deposit/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "operations/deposit/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/operations/proposer_slashing.go
+++ b/testing/spectest/shared/phase0/operations/proposer_slashing.go
@@ -20,6 +20,9 @@ import (
 func RunProposerSlashingTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "operations/proposer_slashing/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "operations/proposer_slashing/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())

--- a/testing/spectest/shared/phase0/operations/voluntary_exit.go
+++ b/testing/spectest/shared/phase0/operations/voluntary_exit.go
@@ -19,6 +19,9 @@ import (
 func RunVoluntaryExitTest(t *testing.T, config string) {
 	require.NoError(t, utils.SetConfig(t, config))
 	testFolders, testsFolderPath := utils.TestFolders(t, config, "phase0", "operations/voluntary_exit/pyspec_tests")
+	if len(testFolders) == 0 {
+		t.Fatalf("No test folders found for %s/%s/%s", config, "phase0", "operations/voluntary_exit/pyspec_tests")
+	}
 	for _, folder := range testFolders {
 		t.Run(folder.Name(), func(t *testing.T) {
 			folderPath := path.Join(testsFolderPath, folder.Name())


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The spectests can give a false positive when there are not files present in the given directory. 
This change adds an assertion that the directory is not empty and therefore at least 1 test is ran.

**Which issues(s) does this PR fix?**

Fixes #11702

**Other notes for review**
