### PR TITLE
Add State Check For BLS Execution Change Messages

### DIFF
--- a/beacon-chain/sync/validate_bls_to_execution_change.go
+++ b/beacon-chain/sync/validate_bls_to_execution_change.go
@@ -8,6 +8,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/v3/monitoring/tracing"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v3/runtime/version"
 	"go.opencensus.io/trace"
 )
 
@@ -44,6 +45,11 @@ func (s *Service) validateBlsToExecutionChange(ctx context.Context, pid peer.ID,
 	st, err := s.cfg.chain.HeadState(ctx)
 	if err != nil {
 		return pubsub.ValidationIgnore, err
+	}
+	// Ignore messages if our current head state doesn't support
+	// capella.
+	if st.Version() < version.Capella {
+		return pubsub.ValidationIgnore, nil
 	}
 	// Validate that the execution change object is valid.
 	_, err = blocks.ValidateBLSToExecutionChange(st, blsChange)


### PR DESCRIPTION
**What type of PR is this?**

Harden Gossip

**What does this PR do? Why is it needed?**

In our gossip handler for BLS Execution Change Messages, we make sure our head state has 
transitioned to capella before we start verifying these messages. This also adds a test case
for it.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
