### PR TITLE
Update withdrawal error message to reflect new field name

### DIFF
--- a/beacon-chain/core/blocks/withdrawals.go
+++ b/beacon-chain/core/blocks/withdrawals.go
@@ -154,7 +154,7 @@ func ProcessWithdrawals(st state.BeaconState, withdrawals []*enginev1.Withdrawal
 			nextValidatorIndex = 0
 		}
 		if err := st.SetNextWithdrawalValidatorIndex(nextValidatorIndex); err != nil {
-			return nil, errors.Wrap(err, "could not set latest withdrawal validator index")
+			return nil, errors.Wrap(err, "could not set next withdrawal validator index")
 		}
 	}
 	return st, nil


### PR DESCRIPTION
**What type of PR is this?**

* Other

**What does this PR do? Why is it needed?**

Use "next" instead of "latest" in error message. This was changed in the specs a little while ago.
