### PR TITLE
Replace LastWithdrawalValidatorIndex with updated name

### DIFF
--- a/beacon-chain/core/blocks/withdrawals_test.go
+++ b/beacon-chain/core/blocks/withdrawals_test.go
@@ -547,7 +547,7 @@ func TestProcessWithdrawals(t *testing.T) {
 	}
 
 	checkPostState := func(t *testing.T, expected control, st state.BeaconState) {
-		l, err := st.LastWithdrawalValidatorIndex()
+		l, err := st.NextWithdrawalValidatorIndex()
 		require.NoError(t, err)
 		require.Equal(t, expected.NextWithdrawalValidatorIndex, l)
 

--- a/beacon-chain/core/capella/upgrade_test.go
+++ b/beacon-chain/core/capella/upgrade_test.go
@@ -95,7 +95,7 @@ func TestUpgradeToCapella(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), nwi)
 
-	lwvi, err := mSt.LastWithdrawalValidatorIndex()
+	lwvi, err := mSt.NextWithdrawalValidatorIndex()
 	require.NoError(t, err)
 	require.Equal(t, types.ValidatorIndex(0), lwvi)
 }

--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -849,7 +849,7 @@ type BeaconStateCapellaJson struct {
 	NextSyncCommittee            *SyncCommitteeJson                 `json:"next_sync_committee"`
 	LatestExecutionPayloadHeader *ExecutionPayloadHeaderCapellaJson `json:"latest_execution_payload_header"`
 	NextWithdrawalIndex          string                             `json:"next_withdrawal_index"`
-	LastWithdrawalValidatorIndex string                             `json:"latest_withdrawal_validator_index"`
+	NextWithdrawalValidatorIndex string                             `json:"next_withdrawal_validator_index"`
 }
 
 type BeaconStateContainerV2Json struct {

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -170,7 +170,7 @@ type ReadOnlyAttestations interface {
 // ReadOnlyWithdrawals defines a struct which only has read access to withdrawal methods.
 type ReadOnlyWithdrawals interface {
 	ExpectedWithdrawals() ([]*enginev1.Withdrawal, error)
-	LastWithdrawalValidatorIndex() (types.ValidatorIndex, error)
+	NextWithdrawalValidatorIndex() (types.ValidatorIndex, error)
 	NextWithdrawalIndex() (uint64, error)
 }
 

--- a/beacon-chain/state/state-native/getters_withdrawal.go
+++ b/beacon-chain/state/state-native/getters_withdrawal.go
@@ -25,11 +25,11 @@ func (b *BeaconState) NextWithdrawalIndex() (uint64, error) {
 	return b.nextWithdrawalIndex, nil
 }
 
-// NextPartialWithdrawalValidatorIndex returns the index of the validator which is
+// NextWithdrawalValidatorIndex returns the index of the validator which is
 // next in line for a partial withdrawal.
-func (b *BeaconState) LastWithdrawalValidatorIndex() (types.ValidatorIndex, error) {
+func (b *BeaconState) NextWithdrawalValidatorIndex() (types.ValidatorIndex, error) {
 	if b.version < version.Capella {
-		return 0, errNotSupported("LastWithdrawalValidatorIndex", b.version)
+		return 0, errNotSupported("NextWithdrawalValidatorIndex", b.version)
 	}
 
 	b.lock.RLock()

--- a/beacon-chain/state/state-native/getters_withdrawal_test.go
+++ b/beacon-chain/state/state-native/getters_withdrawal_test.go
@@ -26,17 +26,17 @@ func TestNextWithdrawalIndex(t *testing.T) {
 	})
 }
 
-func TestLastWithdrawalValidatorIndex(t *testing.T) {
+func TestNextWithdrawalValidatorIndex(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		s := BeaconState{version: version.Capella, nextWithdrawalValidatorIndex: 123}
-		i, err := s.LastWithdrawalValidatorIndex()
+		i, err := s.NextWithdrawalValidatorIndex()
 		require.NoError(t, err)
 		assert.Equal(t, types.ValidatorIndex(123), i)
 	})
 	t.Run("version before Capella not supported", func(t *testing.T) {
 		s := BeaconState{version: version.Bellatrix}
-		_, err := s.LastWithdrawalValidatorIndex()
-		assert.ErrorContains(t, "LastWithdrawalValidatorIndex is not supported", err)
+		_, err := s.NextWithdrawalValidatorIndex()
+		assert.ErrorContains(t, "NextWithdrawalValidatorIndex is not supported", err)
 	})
 }
 

--- a/beacon-chain/state/state-native/setters_withdrawal.go
+++ b/beacon-chain/state/state-native/setters_withdrawal.go
@@ -20,7 +20,7 @@ func (b *BeaconState) SetNextWithdrawalIndex(i uint64) error {
 	return nil
 }
 
-// SetLastWithdrawalValidatorIndex sets the index of the validator which is
+// SetNexWithdrawalValidatorIndex sets the index of the validator which is
 // next in line for a partial withdrawal.
 func (b *BeaconState) SetNextWithdrawalValidatorIndex(i types.ValidatorIndex) error {
 	if b.version < version.Capella {

--- a/beacon-chain/state/state-native/setters_withdrawal_test.go
+++ b/beacon-chain/state/state-native/setters_withdrawal_test.go
@@ -20,7 +20,7 @@ func TestSetNextWithdrawalIndex(t *testing.T) {
 	require.Equal(t, true, s.dirtyFields[nativetypes.NextWithdrawalIndex])
 }
 
-func TestSetLastWithdrawalValidatorIndex(t *testing.T) {
+func TestSetNextWithdrawalValidatorIndex(t *testing.T) {
 	s := BeaconState{
 		version:                      version.Capella,
 		nextWithdrawalValidatorIndex: 3,

--- a/beacon-chain/state/state-native/types/types.go
+++ b/beacon-chain/state/state-native/types/types.go
@@ -70,7 +70,7 @@ func (f FieldIndex) String(_ int) string {
 	case NextWithdrawalIndex:
 		return "NextWithdrawalIndex"
 	case NextWithdrawalValidatorIndex:
-		return "LastWithdrawalValidatorIndex"
+		return "NextWithdrawalValidatorIndex"
 	default:
 		return ""
 	}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

* Renames methods/strings with `LastWithdrawalValidatorIndex` to `NextWithdrawalValidatorIndex`.
* It's good to use accurate names here.
