### PR TITLE
Fix DeepSource errors in the Validator's REST API

### DIFF
--- a/validator/client/beacon-api/beacon_api_validator_client.go
+++ b/validator/client/beacon-api/beacon_api_validator_client.go
@@ -22,7 +22,11 @@ type beaconApiValidatorClient struct {
 	fallbackClient  iface.ValidatorClient
 }
 
-func NewBeaconApiValidatorClient(host string, timeout time.Duration) *beaconApiValidatorClient {
+func NewBeaconApiValidatorClient(host string, timeout time.Duration) iface.ValidatorClient {
+	return NewBeaconApiValidatorClientWithFallback(host, timeout, nil)
+}
+
+func NewBeaconApiValidatorClientWithFallback(host string, timeout time.Duration, fallbackClient iface.ValidatorClient) iface.ValidatorClient {
 	jsonRestHandler := beaconApiJsonRestHandler{
 		httpClient: http.Client{Timeout: timeout},
 		host:       host,
@@ -31,13 +35,8 @@ func NewBeaconApiValidatorClient(host string, timeout time.Duration) *beaconApiV
 	return &beaconApiValidatorClient{
 		genesisProvider: beaconApiGenesisProvider{jsonRestHandler: jsonRestHandler},
 		jsonRestHandler: jsonRestHandler,
+		fallbackClient:  fallbackClient,
 	}
-}
-
-func NewBeaconApiValidatorClientWithFallback(url string, timeout time.Duration, fallbackClient iface.ValidatorClient) *beaconApiValidatorClient {
-	beaconApiValidatorClient := NewBeaconApiValidatorClient(url, timeout)
-	beaconApiValidatorClient.fallbackClient = fallbackClient
-	return beaconApiValidatorClient
 }
 
 func (c *beaconApiValidatorClient) GetDuties(ctx context.Context, in *ethpb.DutiesRequest) (*ethpb.DutiesResponse, error) {

--- a/validator/client/beacon-api/index_test.go
+++ b/validator/client/beacon-api/index_test.go
@@ -21,7 +21,7 @@ import (
 
 const stringPubKey = "0x8000091c2ae64ee414a54c1cc1fc67dec663408bc636cb86756e0200e41a75c8f86603f104f02c856983d2783116be13"
 
-func getPubKeyAndURL(t *testing.T, stringPubkey string) ([]byte, string) {
+func getPubKeyAndURL(t *testing.T) ([]byte, string) {
 	baseUrl := "/eth/v1/beacon/states/head/validators"
 	url := fmt.Sprintf("%s?id=%s", baseUrl, stringPubKey)
 
@@ -35,7 +35,7 @@ func TestIndex_Nominal(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	pubKey, url := getPubKeyAndURL(t, stringPubKey)
+	pubKey, url := getPubKeyAndURL(t)
 
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
@@ -78,7 +78,7 @@ func TestIndex_UnexistingValidator(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	pubKey, url := getPubKeyAndURL(t, stringPubKey)
+	pubKey, url := getPubKeyAndURL(t)
 
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
@@ -113,7 +113,7 @@ func TestIndex_BadIndexError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	pubKey, url := getPubKeyAndURL(t, stringPubKey)
+	pubKey, url := getPubKeyAndURL(t)
 
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
@@ -155,7 +155,7 @@ func TestIndex_JsonResponseError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	pubKey, url := getPubKeyAndURL(t, stringPubKey)
+	pubKey, url := getPubKeyAndURL(t)
 
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)

--- a/validator/client/beacon-api/json_rest_handler_test.go
+++ b/validator/client/beacon-api/json_rest_handler_test.go
@@ -157,7 +157,7 @@ func TestGetRestJsonResponse_Error(t *testing.T) {
 }
 
 func httpErrorJsonHandler(statusCode int, errorMessage string) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
 		errorJson := &apimiddleware.DefaultErrorJson{
 			Code:    statusCode,
 			Message: errorMessage,
@@ -176,7 +176,7 @@ func httpErrorJsonHandler(statusCode int, errorMessage string) func(w http.Respo
 	}
 }
 
-func invalidJsonErrHandler(w http.ResponseWriter, r *http.Request) {
+func invalidJsonErrHandler(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusNotFound)
 	_, err := w.Write([]byte("foo"))
 	if err != nil {
@@ -184,7 +184,7 @@ func invalidJsonErrHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func invalidJsonResponseHandler(w http.ResponseWriter, r *http.Request) {
+func invalidJsonResponseHandler(w http.ResponseWriter, _ *http.Request) {
 	_, err := w.Write([]byte("foo"))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

DeepSource was complaining about some variable shadowing and some functions returning the concrete type instead of the interface.
