### PR TITLE
e2e: Print process IDs for debugging.

### DIFF
--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -290,3 +290,7 @@ func (node *BeaconNode) Resume() error {
 func (node *BeaconNode) Stop() error {
 	return node.cmd.Process.Kill()
 }
+
+func (node *BeaconNode) UnderlyingProcess() *os.Process {
+	return node.cmd.Process
+}

--- a/testing/endtoend/components/eth1/depositor.go
+++ b/testing/endtoend/components/eth1/depositor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"os"
 	"sync"
 	"time"
 
@@ -217,4 +218,8 @@ func (d *Depositor) contractDepositor() (*contracts.DepositContract, error) {
 		d.cd = contract
 	}
 	return d.cd, nil
+}
+
+func (d *Depositor) UnderlyingProcess() *os.Process {
+	return nil // No subprocess for this component.
 }

--- a/testing/endtoend/components/eth1/node.go
+++ b/testing/endtoend/components/eth1/node.go
@@ -151,3 +151,7 @@ func (node *Node) Resume() error {
 func (node *Node) Stop() error {
 	return node.cmd.Process.Kill()
 }
+
+func (node *Node) UnderlyingProcess() *os.Process {
+	return node.cmd.Process
+}

--- a/testing/endtoend/components/lighthouse_validator.go
+++ b/testing/endtoend/components/lighthouse_validator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/runtime/interop"
 	"github.com/prysmaticlabs/prysm/v3/testing/endtoend/helpers"
 	e2e "github.com/prysmaticlabs/prysm/v3/testing/endtoend/params"
+	"github.com/prysmaticlabs/prysm/v3/testing/endtoend/types"
 	e2etypes "github.com/prysmaticlabs/prysm/v3/testing/endtoend/types"
 	"github.com/prysmaticlabs/prysm/v3/validator/keymanager"
 	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
@@ -248,6 +249,8 @@ func (v *LighthouseValidatorNode) Stop() error {
 	return v.cmd.Process.Kill()
 }
 
+var _ types.ComponentRunner = &KeystoreGenerator{}
+
 type KeystoreGenerator struct {
 	started chan struct{}
 }
@@ -361,4 +364,8 @@ func setupKeystores(valClientIdx, startIdx, numOfKeys int) (string, error) {
 		}
 	}
 	return testNetDir, nil
+}
+
+func (k *KeystoreGenerator) UnderlyingProcess() *os.Process {
+	return nil // No subprocess for this component.
 }

--- a/testing/endtoend/components/tracing_sink.go
+++ b/testing/endtoend/components/tracing_sink.go
@@ -14,7 +14,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v3/testing/endtoend/helpers"
 	e2e "github.com/prysmaticlabs/prysm/v3/testing/endtoend/params"
+	"github.com/prysmaticlabs/prysm/v3/testing/endtoend/types"
 )
+
+var _ types.ComponentRunner = &TracingSink{}
 
 // TracingSink to capture HTTP requests from opentracing pushes. This is meant
 // to capture all opentracing spans from Prysm during an end-to-end test. Spans
@@ -145,4 +148,8 @@ func captureRequest(f io.Writer, r *http.Request) error {
 		return err
 	}
 	return nil
+}
+
+func (ts *TracingSink) UnderlyingProcess() *os.Process {
+	return nil // No subprocess for this component.
 }

--- a/testing/endtoend/components/validator.go
+++ b/testing/endtoend/components/validator.go
@@ -297,6 +297,10 @@ func (v *ValidatorNode) Stop() error {
 	return v.cmd.Process.Kill()
 }
 
+func (v *ValidatorNode) UnderlyingProcess() *os.Process {
+	return v.cmd.Process
+}
+
 func createProposerSettingsPath(pubkeys []string, validatorIndex int) (string, error) {
 	testNetDir := e2e.TestParams.TestPath + fmt.Sprintf("/proposer-settings/validator_%d", validatorIndex)
 	configPath := filepath.Join(testNetDir, "config.json")

--- a/testing/endtoend/components/web3remotesigner.go
+++ b/testing/endtoend/components/web3remotesigner.go
@@ -273,3 +273,7 @@ func (w *Web3RemoteSigner) createTestnetDir() (string, error) {
 
 	return configPath, nil
 }
+
+func (w *Web3RemoteSigner) UnderlyingProcess() *os.Process {
+	return w.cmd.Process
+}

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -448,6 +448,8 @@ func (r *testRunner) defaultEndToEndRun() error {
 		return errors.Wrap(err, "components take too long to start")
 	}
 
+	r.comHandler.printPIDs(t.Logf)
+
 	// Since defer unwraps in LIFO order, parent context will be closed only after logs are written.
 	defer helpers.LogOutput(t)
 	if config.UsePprof {
@@ -549,6 +551,8 @@ func (r *testRunner) scenarioRun() error {
 	if err := helpers.ComponentsStarted(ctxAllNodesReady, r.comHandler.required()); err != nil {
 		return errors.Wrap(err, "components take too long to start")
 	}
+
+	r.comHandler.printPIDs(t.Logf)
 
 	// Since defer unwraps in LIFO order, parent context will be closed only after logs are written.
 	defer helpers.LogOutput(t)

--- a/testing/endtoend/types/types.go
+++ b/testing/endtoend/types/types.go
@@ -4,6 +4,7 @@ package types
 
 import (
 	"context"
+	"os"
 
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"google.golang.org/grpc"
@@ -95,6 +96,8 @@ type ComponentRunner interface {
 	Resume() error
 	// Stop stops a component.
 	Stop() error
+	// UnderlyingProcess is the underlying process, once started.
+	UnderlyingProcess() *os.Process
 }
 
 type MultipleComponentRunners interface {


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

How to attach a debugger to an e2e subprocess. For example, it may be useful to debug and break the beacon chain process.

```
# Build and execute the endtoend test with -c dbg to compile with debugging symbols and --spawn_strategy=standalone to disable bazel sandboxing.
bazel test //testing/endtoend:go_default_test  --test_output=streamed --test_arg=-test.v --spawn_strategy=standalone -c dbg
```

When the test runs, you will see a log message like this: 

```
    component_handler_test.go:238: This test PID: 272686 (parent=272671)
        Beacon chain nodes: [274706 274705]
        Validators: [274733 274734]
        ETH1 nodes: [274691]
```

This log prints the process ID's spawned by this test. A remote debugger, dlv, can attach to process 274706 as such:

```
dlv --listen=:2345 --headless=true --api-version=2 attach 274706
```

And then a remote debugger can interact with dlv on port 2345.

**Which issues(s) does this PR fix?**

**Other notes for review**

Note: I had to tackle this error message
```
Could not attach to pid 274706: this could be caused by a kernel security setting, try writing "0" to /proc/sys/kernel/yama/ptrace_scope 
```
The solution was `echo 0 > /proc/sys/kernel/yama/ptrace_scope`

My goland config looked like
![Screenshot from 2022-12-07 13-15-27](https://user-images.githubusercontent.com/7246818/206274835-aad16ad4-c9ea-4a16-ba9e-9b1edb1cd083.png)

