### PR TITLE
Add Back Cross Client Option

### DIFF
--- a/testing/endtoend/endtoend_setup_test.go
+++ b/testing/endtoend/endtoend_setup_test.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/prysmaticlabs/prysm/testing/endtoend/evaluators/beaconapi_evaluators"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	ev "github.com/prysmaticlabs/prysm/v3/testing/endtoend/evaluators"
-	"github.com/prysmaticlabs/prysm/v3/testing/endtoend/evaluators/beaconapi_evaluators"
 	e2eParams "github.com/prysmaticlabs/prysm/v3/testing/endtoend/params"
 	"github.com/prysmaticlabs/prysm/v3/testing/endtoend/types"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
@@ -131,9 +131,6 @@ func e2eMainnet(t *testing.T, usePrysmSh, useMultiClient bool, cfgo ...types.E2E
 		ev.FeeRecipientIsPresent,
 		//ev.TransactionsPresent, TODO: Re-enable Transaction evaluator once it tx pool issues are fixed.
 	}
-	if crossClient {
-		evals = append(evals, beaconapi_evaluators.BeaconAPIMultiClientVerifyIntegrity)
-	}
 	testConfig := &types.E2EConfig{
 		BeaconFlags: []string{
 			fmt.Sprintf("--slots-per-archive-point=%d", params.BeaconConfig().SlotsPerEpoch*16),
@@ -157,6 +154,11 @@ func e2eMainnet(t *testing.T, usePrysmSh, useMultiClient bool, cfgo ...types.E2E
 	}
 	for _, o := range cfgo {
 		o(testConfig)
+	}
+	// In the event we use the cross-client e2e option, we add in an additional
+	// evaluator for multiclient runs to verify the beacon api conformance.
+	if crossClient || testConfig.UseValidatorCrossClient {
+		testConfig.Evaluators = append(testConfig.Evaluators, beaconapi_evaluators.BeaconAPIMultiClientVerifyIntegrity)
 	}
 	return newTestRunner(t, testConfig)
 }

--- a/testing/endtoend/endtoend_setup_test.go
+++ b/testing/endtoend/endtoend_setup_test.go
@@ -103,7 +103,6 @@ func e2eMainnet(t *testing.T, usePrysmSh, useMultiClient bool, cfgo ...types.E2E
 		epochsToRun, err = strconv.Atoi(epochStr)
 		require.NoError(t, err)
 	}
-	_, crossClient := os.LookupEnv("RUN_CROSS_CLIENT")
 	seed := 0
 	seedStr, isValid := os.LookupEnv("E2E_SEED")
 	if isValid {
@@ -138,26 +137,25 @@ func e2eMainnet(t *testing.T, usePrysmSh, useMultiClient bool, cfgo ...types.E2E
 			"--enable-tracing",
 			"--trace-sample-fraction=1.0",
 		},
-		ValidatorFlags:          []string{},
-		EpochsToRun:             uint64(epochsToRun),
-		TestSync:                true,
-		TestFeature:             true,
-		TestDeposits:            true,
-		UseFixedPeerIDs:         true,
-		UseValidatorCrossClient: crossClient,
-		UsePrysmShValidator:     usePrysmSh,
-		UsePprof:                !longRunning,
-		TracingSinkEndpoint:     tracingEndpoint,
-		Evaluators:              evals,
-		EvalInterceptor:         defaultInterceptor,
-		Seed:                    int64(seed),
+		ValidatorFlags:      []string{},
+		EpochsToRun:         uint64(epochsToRun),
+		TestSync:            true,
+		TestFeature:         true,
+		TestDeposits:        true,
+		UseFixedPeerIDs:     true,
+		UsePrysmShValidator: usePrysmSh,
+		UsePprof:            !longRunning,
+		TracingSinkEndpoint: tracingEndpoint,
+		Evaluators:          evals,
+		EvalInterceptor:     defaultInterceptor,
+		Seed:                int64(seed),
 	}
 	for _, o := range cfgo {
 		o(testConfig)
 	}
 	// In the event we use the cross-client e2e option, we add in an additional
 	// evaluator for multiclient runs to verify the beacon api conformance.
-	if crossClient || testConfig.UseValidatorCrossClient {
+	if testConfig.UseValidatorCrossClient {
 		testConfig.Evaluators = append(testConfig.Evaluators, beaconapi_evaluators.BeaconAPIMultiClientVerifyIntegrity)
 	}
 	return newTestRunner(t, testConfig)

--- a/testing/endtoend/endtoend_setup_test.go
+++ b/testing/endtoend/endtoend_setup_test.go
@@ -6,9 +6,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/prysmaticlabs/prysm/testing/endtoend/evaluators/beaconapi_evaluators"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	ev "github.com/prysmaticlabs/prysm/v3/testing/endtoend/evaluators"
+	"github.com/prysmaticlabs/prysm/v3/testing/endtoend/evaluators/beaconapi_evaluators"
 	e2eParams "github.com/prysmaticlabs/prysm/v3/testing/endtoend/params"
 	"github.com/prysmaticlabs/prysm/v3/testing/endtoend/types"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"

--- a/testing/endtoend/mainnet_scenario_e2e_test.go
+++ b/testing/endtoend/mainnet_scenario_e2e_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEndToEnd_MainnetConfig_MultiClient(t *testing.T) {
-	e2eMainnet(t, false /*usePrysmSh*/, true /*useMultiClient*/).run()
+	e2eMainnet(t, false /*usePrysmSh*/, true /*useMultiClient*/, types.WithValidatorCrossClient()).run()
 }
 
 func TestEndToEnd_MultiScenarioRun_Multiclient(t *testing.T) {

--- a/testing/endtoend/types/types.go
+++ b/testing/endtoend/types/types.go
@@ -29,6 +29,12 @@ func WithCheckpointSync() E2EConfigOpt {
 	}
 }
 
+func WithValidatorCrossClient() E2EConfigOpt {
+	return func(cfg *E2EConfig) {
+		cfg.UseValidatorCrossClient = true
+	}
+}
+
 // E2EConfig defines the struct for all configurations needed for E2E testing.
 type E2EConfig struct {
 	TestCheckpointSync      bool


### PR DESCRIPTION
**What type of PR is this?**

E2E Fix

**What does this PR do? Why is it needed?**

This re-enables our cross client e2e option along with allowing us to run the multiclient api evaluator. Previous test runs were failing because the evaluator was being applied to tests with no LH nodes. This makes sure the evaluator is only applied if LH nodes are running.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
