### PR TITLE
prysmctl: add withdrawal address - capella

### DIFF
--- a/cmd/prysmctl/BUILD.bazel
+++ b/cmd/prysmctl/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//cmd/prysmctl/signing:go_default_library",
         "//cmd/prysmctl/testnet:go_default_library",
         "//cmd/prysmctl/weaksubjectivity:go_default_library",
+        "//cmd/prysmctl/withdrawal:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],

--- a/cmd/prysmctl/main.go
+++ b/cmd/prysmctl/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/signing"
 	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/testnet"
 	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/weaksubjectivity"
+	"github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/withdrawal"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
@@ -30,11 +31,12 @@ func init() {
 	// contains the old checkpoint sync subcommands. these commands should display help/warn messages
 	// pointing to their new locations
 	prysmctlCommands = append(prysmctlCommands, deprecated.Commands...)
-
 	prysmctlCommands = append(prysmctlCommands, checkpointsync.Commands...)
 	prysmctlCommands = append(prysmctlCommands, db.Commands...)
 	prysmctlCommands = append(prysmctlCommands, p2p.Commands...)
 	prysmctlCommands = append(prysmctlCommands, testnet.Commands...)
 	prysmctlCommands = append(prysmctlCommands, weaksubjectivity.Commands...)
 	prysmctlCommands = append(prysmctlCommands, signing.Commands...)
+	prysmctlCommands = append(prysmctlCommands, withdrawal.Commands...)
+
 }

--- a/cmd/prysmctl/withdrawal/BUILD.bazel
+++ b/cmd/prysmctl/withdrawal/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "cmd.go",
+        "types.go",
+        "withdrawal.go",
+    ],
+    importpath = "github.com/prysmaticlabs/prysm/v3/cmd/prysmctl/withdrawal",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd:go_default_library",
+        "//config/features:go_default_library",
+        "//crypto/bls:go_default_library",
+        "//io/prompt:go_default_library",
+        "//runtime/tos:go_default_library",
+        "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
+        "@com_github_logrusorgru_aurora//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_urfave_cli_v2//:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
+    ],
+)

--- a/cmd/prysmctl/withdrawal/cmd.go
+++ b/cmd/prysmctl/withdrawal/cmd.go
@@ -1,0 +1,50 @@
+package withdrawal
+
+import (
+	"os"
+
+	"github.com/prysmaticlabs/prysm/v3/cmd"
+	"github.com/prysmaticlabs/prysm/v3/config/features"
+	"github.com/prysmaticlabs/prysm/v3/runtime/tos"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+)
+
+var Commands = []*cli.Command{
+	{
+		Name:    "set-withdrawal-address",
+		Aliases: []string{"swa"},
+		Usage:   "command for setting the withdrawal ethereum address to the associated validator key",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "beacon-node-host",
+				Usage:       "host:port for beacon node to query",
+				Destination: &withdrawalFlags.BeaconNodeHost,
+				Value:       "http://localhost:3500",
+			},
+			&cli.StringFlag{
+				Name:        "file",
+				Usage:       "file location for for the blsToExecutionAddress JSON or Yaml",
+				Destination: &withdrawalFlags.File,
+				Value:       "./blsToExecutionAddress.json",
+			},
+			features.Mainnet,
+			features.PraterTestnet,
+			features.RopstenTestnet,
+			features.SepoliaTestnet,
+			cmd.AcceptTosFlag,
+		},
+		Before: func(cliCtx *cli.Context) error {
+			if err := cmd.LoadFlagsFromConfig(cliCtx, cliCtx.Command.Flags); err != nil {
+				return err
+			}
+			return tos.VerifyTosAcceptedOrPrompt(cliCtx)
+		},
+		Action: func(cliCtx *cli.Context) error {
+			if err := setWithdrawlAddress(cliCtx, os.Stdin); err != nil {
+				log.WithError(err).Fatal("Could not set withdrawal address")
+			}
+			return nil
+		},
+	},
+}

--- a/cmd/prysmctl/withdrawal/types.go
+++ b/cmd/prysmctl/withdrawal/types.go
@@ -1,0 +1,34 @@
+package withdrawal
+
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/prysmaticlabs/prysm/v3/crypto/bls"
+)
+
+type BlsToExecutionEngineMessage struct {
+	ValidatorIndex     uint64 `json:"validator_index" yaml:"validator_index"`
+	FromBlsPubkey      string `json:"from_bls_pubkey" yaml:"from_bls_pubkey"`
+	ToExecutionAddress string `json:"to_execution_address" yaml:"to_execution_address"`
+}
+
+func (d *BlsToExecutionEngineMessage) FromBlsPubkeyAsBytes() ([]byte, error) {
+	return hexutil.Decode(d.FromBlsPubkey)
+}
+
+func (d *BlsToExecutionEngineMessage) ToExecutionAddressAsBytes() ([]byte, error) {
+	return hexutil.Decode(d.ToExecutionAddress)
+}
+
+type BlsToExecutionEngineFile struct {
+	Version   uint64                       `json:"version" yaml:"version"`
+	Message   *BlsToExecutionEngineMessage `json:"message" yaml:"message"`
+	Signature string                       `json:"signature" yaml:"signature"`
+}
+
+func (b *BlsToExecutionEngineFile) SignatureAsBls() (bls.Signature, error) {
+	bytevalue, err := hexutil.Decode(b.Signature)
+	if err != nil {
+		return nil, err
+	}
+	return bls.SignatureFromBytes(bytevalue)
+}

--- a/cmd/prysmctl/withdrawal/withdrawal.go
+++ b/cmd/prysmctl/withdrawal/withdrawal.go
@@ -1,0 +1,110 @@
+package withdrawal
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/logrusorgru/aurora"
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v3/io/prompt"
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+	"go.opencensus.io/trace"
+	"gopkg.in/yaml.v2"
+)
+
+var withdrawalFlags = struct {
+	BeaconNodeHost string
+	File           string
+}{}
+
+func setWithdrawlAddress(c *cli.Context, r io.Reader) error {
+	apiPath := "/blsToExecutionAddress"
+	f := withdrawalFlags
+	cleanpath := filepath.Clean(f.File)
+	b, err := os.ReadFile(cleanpath)
+	if err != nil {
+		return errors.Wrap(err, "failed to open file")
+	}
+	var to BlsToExecutionEngineFile
+	if err := yaml.Unmarshal(b, to); err != nil {
+		return errors.Wrap(err, "failed to unmarshal file")
+	}
+	if to.Message == nil {
+		return errors.New("the message field in file is empty")
+	}
+
+	u, err := url.ParseRequestURI(f.BeaconNodeHost)
+	if err != nil {
+		return errors.Wrap(err, "invalid format, unable to parse url")
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("url must be in the format of http(s)://host:port url used: %v", f.BeaconNodeHost)
+	}
+	withdrawalConfirmation := to.Message.ToExecutionAddress
+
+	withdraw, err := withdrawalPrompt(withdrawalConfirmation, r)
+	if err != nil {
+		return err
+	}
+
+	if !strings.EqualFold(withdraw, "n") {
+		log.Warn("Did not provide the correct acceptance message")
+		return nil
+	}
+
+	body, err := json.Marshal(to) //:todo: change this to apimiddleware object.
+	if err != nil {
+		return errors.Wrap(err, "error encoding the BlsToExecutionEngineFile")
+	}
+
+	ctx, span := trace.StartSpan(c.Context, "withdrawal.blsToExecutionAddress")
+	defer span.End()
+
+	fullpath := f.BeaconNodeHost + apiPath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullpath, bytes.NewBuffer(body))
+	if err != nil {
+		return errors.Wrap(err, "invalid format, failed to create new Post Request Object")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("API request to %s , responded with a status other than OK, status: %v", fullpath, resp.Status)
+	}
+	log.Info("Successfully published message to update withdrawal address.")
+	return nil
+}
+
+func withdrawalPrompt(confirmationMessage string, r io.Reader) (string, error) {
+
+	au := aurora.NewAurora(true)
+	promptHeader := au.Red("===============IMPORTANT===============")
+	promptDescription := "YOU ARE ATTEMPTING TO CHANGE THE BLS WITHDRAWAL ADDRESS TO AN ETHEREUM ADDRESS. " +
+		"This action will allow you to partially withdraw any amount over the 32 staked eth in your validator balance. " +
+		"You will also be entitled to the full withdrawal if your validator has exited. " +
+		"Please navigate to the following website and make sure you understand the current implications " +
+		"of changing your bls withdrawal address to an ethereum address. " +
+		"THIS ACTION WILL NOT BE REVERSIBLE ONCE INCLUDED. " +
+		"You will NOT be able to change the address again once changed. "
+	promptURL := au.Blue("https://docs.prylabs.network/docs/wallet/exiting-a-validator/#withdrawal-delay-warning")
+	promptQuestion := "If you still want to continue with changing the bls withdrawal address, please input a phrase found at the end " +
+		"of the page from the above URL"
+	promptText := fmt.Sprintf("%s\n%s\n%s\n%s", promptHeader, promptDescription, promptURL, promptQuestion)
+	return prompt.ValidatePrompt(r, promptText, func(input string) error {
+		return prompt.ValidatePhrase(input, confirmationMessage)
+	})
+
+}


### PR DESCRIPTION
What type of PR is this?

Feature

Related to https://github.com/prysmaticlabs/prysm/issues/11077

What does this PR do? Why is it needed?

New Prysmctl command that will broadcast a message to the network to switch the bls withdrawal key of the associated validator public key to an eth address so that the staker can receive partial withdrawals as well as the full withdrawal value of the validator key.
