### PR TITLE
beacondb: Remove cache look up and lock request from boltdb transaction for state summaries

### DIFF
--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -328,9 +328,8 @@ func (s *Store) SaveBlocks(ctx context.Context, blks []interfaces.SignedBeaconBl
 func (s *Store) SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveHeadBlockRoot")
 	defer span.End()
-	hasStateSummaryInCache := s.stateSummaryCache.has(blockRoot)
+	hasStateSummary := s.HasStateSummary(ctx, blockRoot)
 	return s.db.Update(func(tx *bolt.Tx) error {
-		hasStateSummary := hasStateSummaryInCache || s.hasStateSummaryBytes(tx, blockRoot)
 		hasStateInDB := tx.Bucket(stateBucket).Get(blockRoot[:]) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			return errors.New("no state or state summary found with head block root")

--- a/beacon-chain/db/kv/blocks.go
+++ b/beacon-chain/db/kv/blocks.go
@@ -328,8 +328,9 @@ func (s *Store) SaveBlocks(ctx context.Context, blks []interfaces.SignedBeaconBl
 func (s *Store) SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveHeadBlockRoot")
 	defer span.End()
+	hasStateSummaryInCache := s.stateSummaryCache.has(blockRoot)
 	return s.db.Update(func(tx *bolt.Tx) error {
-		hasStateSummary := s.hasStateSummaryBytes(tx, blockRoot)
+		hasStateSummary := hasStateSummaryInCache || s.hasStateSummaryBytes(tx, blockRoot)
 		hasStateInDB := tx.Bucket(stateBucket).Get(blockRoot[:]) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			return errors.New("no state or state summary found with head block root")

--- a/beacon-chain/db/kv/checkpoint.go
+++ b/beacon-chain/db/kv/checkpoint.go
@@ -59,11 +59,9 @@ func (s *Store) SaveJustifiedCheckpoint(ctx context.Context, checkpoint *ethpb.C
 	if err != nil {
 		return err
 	}
-	root32 := bytesutil.ToBytes32(checkpoint.Root)
-	hasStateSummaryInCache := s.stateSummaryCache.has(root32)
+	hasStateSummary := s.HasStateSummary(ctx, bytesutil.ToBytes32(checkpoint.Root))
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(checkpointBucket)
-		hasStateSummary := hasStateSummaryInCache || s.hasStateSummaryBytes(tx, root32)
 		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			log.Warnf("Recovering state summary for justified root: %#x", bytesutil.Trunc(checkpoint.Root))
@@ -84,11 +82,9 @@ func (s *Store) SaveFinalizedCheckpoint(ctx context.Context, checkpoint *ethpb.C
 	if err != nil {
 		return err
 	}
-	root32 := bytesutil.ToBytes32(checkpoint.Root)
-	hasStateSummaryInCache := s.stateSummaryCache.has(root32)
+	hasStateSummary := s.HasStateSummary(ctx, bytesutil.ToBytes32(checkpoint.Root))
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(checkpointBucket)
-		hasStateSummary := hasStateSummaryInCache || s.hasStateSummaryBytes(tx, root32)
 		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			log.Warnf("Recovering state summary for finalized root: %#x", bytesutil.Trunc(checkpoint.Root))

--- a/beacon-chain/db/kv/checkpoint.go
+++ b/beacon-chain/db/kv/checkpoint.go
@@ -59,9 +59,11 @@ func (s *Store) SaveJustifiedCheckpoint(ctx context.Context, checkpoint *ethpb.C
 	if err != nil {
 		return err
 	}
+	root32 := bytesutil.ToBytes32(checkpoint.Root)
+	hasStateSummaryInCache := s.stateSummaryCache.has(root32)
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(checkpointBucket)
-		hasStateSummary := s.hasStateSummaryBytes(tx, bytesutil.ToBytes32(checkpoint.Root))
+		hasStateSummary := hasStateSummaryInCache || s.hasStateSummaryBytes(tx, root32)
 		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			log.Warnf("Recovering state summary for justified root: %#x", bytesutil.Trunc(checkpoint.Root))
@@ -82,9 +84,11 @@ func (s *Store) SaveFinalizedCheckpoint(ctx context.Context, checkpoint *ethpb.C
 	if err != nil {
 		return err
 	}
+	root32 := bytesutil.ToBytes32(checkpoint.Root)
+	hasStateSummaryInCache := s.stateSummaryCache.has(root32)
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(checkpointBucket)
-		hasStateSummary := s.hasStateSummaryBytes(tx, bytesutil.ToBytes32(checkpoint.Root))
+		hasStateSummary := hasStateSummaryInCache || s.hasStateSummaryBytes(tx, root32)
 		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			log.Warnf("Recovering state summary for finalized root: %#x", bytesutil.Trunc(checkpoint.Root))

--- a/beacon-chain/db/kv/state_summary.go
+++ b/beacon-chain/db/kv/state_summary.go
@@ -83,8 +83,6 @@ func (s *Store) HasStateSummary(ctx context.Context, blockRoot [32]byte) bool {
 
 func (s *Store) hasStateSummaryBytes(tx *bolt.Tx, blockRoot [32]byte) bool {
 	enc := tx.Bucket(stateSummaryBucket).Get(blockRoot[:])
-
-	tx.Bucket(stateSummaryBucket)
 	return len(enc) > 0
 }
 

--- a/beacon-chain/db/kv/state_summary.go
+++ b/beacon-chain/db/kv/state_summary.go
@@ -67,6 +67,10 @@ func (s *Store) HasStateSummary(ctx context.Context, blockRoot [32]byte) bool {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.HasStateSummary")
 	defer span.End()
 
+	if s.stateSummaryCache.has(blockRoot) {
+		return true
+	}
+
 	var hasSummary bool
 	if err := s.db.View(func(tx *bolt.Tx) error {
 		hasSummary = s.hasStateSummaryBytes(tx, blockRoot)
@@ -78,10 +82,9 @@ func (s *Store) HasStateSummary(ctx context.Context, blockRoot [32]byte) bool {
 }
 
 func (s *Store) hasStateSummaryBytes(tx *bolt.Tx, blockRoot [32]byte) bool {
-	if s.stateSummaryCache.has(blockRoot) {
-		return true
-	}
 	enc := tx.Bucket(stateSummaryBucket).Get(blockRoot[:])
+
+	tx.Bucket(stateSummaryBucket)
 	return len(enc) > 0
 }
 

--- a/beacon-chain/db/kv/state_summary.go
+++ b/beacon-chain/db/kv/state_summary.go
@@ -73,17 +73,13 @@ func (s *Store) HasStateSummary(ctx context.Context, blockRoot [32]byte) bool {
 
 	var hasSummary bool
 	if err := s.db.View(func(tx *bolt.Tx) error {
-		hasSummary = s.hasStateSummaryBytes(tx, blockRoot)
+		enc := tx.Bucket(stateSummaryBucket).Get(blockRoot[:])
+		hasSummary = len(enc) > 0
 		return nil
 	}); err != nil {
 		return false
 	}
 	return hasSummary
-}
-
-func (s *Store) hasStateSummaryBytes(tx *bolt.Tx, blockRoot [32]byte) bool {
-	enc := tx.Bucket(stateSummaryBucket).Get(blockRoot[:])
-	return len(enc) > 0
 }
 
 // This saves all cached state summary objects to DB, and clears up the cache.

--- a/beacon-chain/db/kv/validated_checkpoint.go
+++ b/beacon-chain/db/kv/validated_checkpoint.go
@@ -39,7 +39,6 @@ func (s *Store) SaveLastValidatedCheckpoint(ctx context.Context, checkpoint *eth
 		return err
 	}
 	hasStateSummary := s.HasStateSummary(ctx, bytesutil.ToBytes32(checkpoint.Root))
-
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(checkpointBucket)
 		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil

--- a/beacon-chain/db/kv/validated_checkpoint.go
+++ b/beacon-chain/db/kv/validated_checkpoint.go
@@ -38,11 +38,10 @@ func (s *Store) SaveLastValidatedCheckpoint(ctx context.Context, checkpoint *eth
 	if err != nil {
 		return err
 	}
-	root32 := bytesutil.ToBytes32(checkpoint.Root)
-	hasStateSummaryInCache := s.stateSummaryCache.has(root32)
+	hasStateSummary := s.HasStateSummary(ctx, bytesutil.ToBytes32(checkpoint.Root))
+
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(checkpointBucket)
-		hasStateSummary := hasStateSummaryInCache || s.hasStateSummaryBytes(tx, root32)
 		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			log.Warnf("Recovering state summary for last validated root: %#x", bytesutil.Trunc(checkpoint.Root))

--- a/beacon-chain/db/kv/validated_checkpoint.go
+++ b/beacon-chain/db/kv/validated_checkpoint.go
@@ -38,9 +38,11 @@ func (s *Store) SaveLastValidatedCheckpoint(ctx context.Context, checkpoint *eth
 	if err != nil {
 		return err
 	}
+	root32 := bytesutil.ToBytes32(checkpoint.Root)
+	hasStateSummaryInCache := s.stateSummaryCache.has(root32)
 	return s.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(checkpointBucket)
-		hasStateSummary := s.hasStateSummaryBytes(tx, bytesutil.ToBytes32(checkpoint.Root))
+		hasStateSummary := hasStateSummaryInCache || s.hasStateSummaryBytes(tx, root32)
 		hasStateInDB := tx.Bucket(stateBucket).Get(checkpoint.Root) != nil
 		if !(hasStateInDB || hasStateSummary) {
 			log.Warnf("Recovering state summary for last validated root: %#x", bytesutil.Trunc(checkpoint.Root))


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

As title describes, we should never attempt to secure a lock during a boltdb transaction as the transaction could be blocking other, unrelated, boltdb transactions.

**Which issues(s) does this PR fix?**

**Other notes for review**

This PR acknowledges a prior issue that was solved in https://github.com/prysmaticlabs/prysm/pull/9428 where opening a view transaction within an update transaction was problematic. We are revisiting that same problem where with a different solution that does not attempt to secure any cache lock within a bolt transaction. 