### PR TITLE
Remove `Test_IsExecutionEnabledCapella`

### DIFF
--- a/beacon-chain/core/blocks/payload_test.go
+++ b/beacon-chain/core/blocks/payload_test.go
@@ -350,16 +350,6 @@ func Test_IsExecutionEnabled(t *testing.T) {
 	}
 }
 
-func Test_IsExecutionEnabledCapella(t *testing.T) {
-	st, _ := util.DeterministicGenesisStateCapella(t, 1)
-	blk := util.NewBeaconBlockCapella()
-	body, err := consensusblocks.NewBeaconBlockBody(blk.Block.Body)
-	require.NoError(t, err)
-	got, err := blocks.IsExecutionEnabled(st, body)
-	require.NoError(t, err)
-	require.Equal(t, false, got)
-}
-
 func Test_IsExecutionEnabledUsingHeader(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
As discussed with @prestonvanloon and @potuz few weeks back.  `Test_IsExecutionEnabledCapella` is bogus and we should just remove it anyway. There's no value testing Capella for execution enable 