### PR TITLE
fix validator client

### DIFF
--- a/beacon-chain/rpc/apimiddleware/structs.go
+++ b/beacon-chain/rpc/apimiddleware/structs.go
@@ -498,7 +498,7 @@ type BlindedBeaconBlockBodyCapellaJson struct {
 	VoluntaryExits         []*SignedVoluntaryExitJson         `json:"voluntary_exits"`
 	SyncAggregate          *SyncAggregateJson                 `json:"sync_aggregate"`
 	ExecutionPayloadHeader *ExecutionPayloadHeaderCapellaJson `json:"execution_payload_header"`
-	BLSToExecutionChanges  []*BLSToExecutionChangeJson        `json:"bls_to_execution_changes"`
+	BLSToExecutionChanges  []*SignedBLSToExecutionChangeJson  `json:"bls_to_execution_changes"`
 }
 
 type ExecutionPayloadJson struct {
@@ -621,6 +621,11 @@ type AttestationDataJson struct {
 	BeaconBlockRoot string          `json:"beacon_block_root" hex:"true"`
 	Source          *CheckpointJson `json:"source"`
 	Target          *CheckpointJson `json:"target"`
+}
+
+type SignedBLSToExecutionChangeJson struct {
+	Message   *BLSToExecutionChangeJson `json:"message"`
+	Signature string                    `json:"signature" hex:"true"`
 }
 
 type BLSToExecutionChangeJson struct {

--- a/validator/client/beacon-api/beacon_block_json_helpers.go
+++ b/validator/client/beacon-api/beacon_block_json_helpers.go
@@ -15,15 +15,19 @@ func jsonifyTransactions(transactions [][]byte) []string {
 	return jsonTransactions
 }
 
-func jsonifyBlsToExecutionChanges(blsToExecutionChanges []*ethpb.SignedBLSToExecutionChange) []*apimiddleware.BLSToExecutionChangeJson {
-	jsonBlsToExecutionChanges := make([]*apimiddleware.BLSToExecutionChangeJson, len(blsToExecutionChanges))
+func jsonifyBlsToExecutionChanges(blsToExecutionChanges []*ethpb.SignedBLSToExecutionChange) []*apimiddleware.SignedBLSToExecutionChangeJson {
+	jsonBlsToExecutionChanges := make([]*apimiddleware.SignedBLSToExecutionChangeJson, len(blsToExecutionChanges))
 	for index, signedBlsToExecutionChange := range blsToExecutionChanges {
 		blsToExecutionChangeJson := &apimiddleware.BLSToExecutionChangeJson{
 			ValidatorIndex:     uint64ToString(signedBlsToExecutionChange.Message.ValidatorIndex),
 			FromBLSPubkey:      hexutil.Encode(signedBlsToExecutionChange.Message.FromBlsPubkey),
 			ToExecutionAddress: hexutil.Encode(signedBlsToExecutionChange.Message.ToExecutionAddress),
 		}
-		jsonBlsToExecutionChanges[index] = blsToExecutionChangeJson
+		signedJson := &apimiddleware.SignedBLSToExecutionChangeJson{
+			BLSToExecutionChange: blsToExecutionChangeJson,
+			Signature:            hexutil.Encode(signedBlsToExecutionChange.Signature),
+		}
+		jsonBlsToExecutionChanges[index] = signedJson
 	}
 	return jsonBlsToExecutionChanges
 }

--- a/validator/client/beacon-api/beacon_block_json_helpers.go
+++ b/validator/client/beacon-api/beacon_block_json_helpers.go
@@ -24,8 +24,8 @@ func jsonifyBlsToExecutionChanges(blsToExecutionChanges []*ethpb.SignedBLSToExec
 			ToExecutionAddress: hexutil.Encode(signedBlsToExecutionChange.Message.ToExecutionAddress),
 		}
 		signedJson := &apimiddleware.SignedBLSToExecutionChangeJson{
-			BLSToExecutionChange: blsToExecutionChangeJson,
-			Signature:            hexutil.Encode(signedBlsToExecutionChange.Signature),
+			Message:   blsToExecutionChangeJson,
+			Signature: hexutil.Encode(signedBlsToExecutionChange.Signature),
 		}
 		jsonBlsToExecutionChanges[index] = signedJson
 	}

--- a/validator/client/beacon-api/beacon_block_json_helpers_test.go
+++ b/validator/client/beacon-api/beacon_block_json_helpers_test.go
@@ -31,6 +31,7 @@ func TestBeaconBlockJsonHelpers_JsonifyBlsToExecutionChanges(t *testing.T) {
 				FromBlsPubkey:      []byte{2},
 				ToExecutionAddress: []byte{3},
 			},
+			Signature: []byte{7},
 		},
 		{
 			Message: &ethpb.BLSToExecutionChange{
@@ -38,19 +39,26 @@ func TestBeaconBlockJsonHelpers_JsonifyBlsToExecutionChanges(t *testing.T) {
 				FromBlsPubkey:      []byte{5},
 				ToExecutionAddress: []byte{6},
 			},
+			Signature: []byte{8},
 		},
 	}
 
-	expectedResult := []*apimiddleware.BLSToExecutionChangeJson{
+	expectedResult := []*apimiddleware.SignedBLSToExecutionChangeJson{
 		{
-			ValidatorIndex:     "1",
-			FromBLSPubkey:      hexutil.Encode([]byte{2}),
-			ToExecutionAddress: hexutil.Encode([]byte{3}),
+			Message: &apimiddleware.BLSToExecutionChangeJson{
+				ValidatorIndex:     "1",
+				FromBLSPubkey:      hexutil.Encode([]byte{2}),
+				ToExecutionAddress: hexutil.Encode([]byte{3}),
+			},
+			Signature: hexutil.Encode([]byte{7}),
 		},
 		{
-			ValidatorIndex:     "4",
-			FromBLSPubkey:      hexutil.Encode([]byte{5}),
-			ToExecutionAddress: hexutil.Encode([]byte{6}),
+			Message: &apimiddleware.BLSToExecutionChangeJson{
+				ValidatorIndex:     "4",
+				FromBLSPubkey:      hexutil.Encode([]byte{5}),
+				ToExecutionAddress: hexutil.Encode([]byte{6}),
+			},
+			Signature: hexutil.Encode([]byte{8}),
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Capella block includes a list of  `SignedBLSToExecutionChange` objects, but the middleware struct has a field of type `BLSToExecutionChangeJson`, which is unsigned.