### PR TITLE
state: Improve replay state logs metadata

### DIFF
--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -36,11 +36,12 @@ func (_ *State) replayBlocks(
 	var err error
 
 	start := time.Now()
-	log.WithFields(logrus.Fields{
+	log = log.WithFields(logrus.Fields{
 		"startSlot": state.Slot(),
 		"endSlot":   targetSlot,
 		"diff":      targetSlot - state.Slot(),
-	}).Debug("Replaying state")
+	})
+	log.Debug("Replaying state")
 	// The input block list is sorted in decreasing slots order.
 	if len(signed) > 0 {
 		for i := len(signed) - 1; i >= 0; i-- {


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

When looking at log messages, it is not easily possible to connect the start and end of the replayed state messaging. This PR shares the log fields between the two messages.

**Which issues(s) does this PR fix?**

**Other notes for review**
