### PR TITLE
Sync committee head state cache for Capella 

### DIFF
--- a/beacon-chain/cache/sync_committee_head_state.go
+++ b/beacon-chain/cache/sync_committee_head_state.go
@@ -52,9 +52,8 @@ func (c *SyncCommitteeHeadStateCache) Get(slot types.Slot) (state.BeaconState, e
 	if !ok {
 		return nil, ErrIncorrectType
 	}
-	switch st.Version() {
-	case version.Altair, version.Bellatrix:
-	default:
+	// Sync committee is not supported in phase 0.
+	if st.Version() == version.Phase0 {
 		return nil, ErrIncorrectType
 	}
 	return st, nil

--- a/beacon-chain/cache/sync_committee_head_state_test.go
+++ b/beacon-chain/cache/sync_committee_head_state_test.go
@@ -32,6 +32,12 @@ func TestSyncCommitteeHeadState(t *testing.T) {
 			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
 		},
 	})
+	capellaState, err := state_native.InitializeFromProtoCapella(&ethpb.BeaconStateCapella{
+		Fork: &ethpb.Fork{
+			PreviousVersion: params.BeaconConfig().GenesisForkVersion,
+			CurrentVersion:  params.BeaconConfig().GenesisForkVersion,
+		},
+	})
 	require.NoError(t, err)
 	type put struct {
 		slot  types.Slot
@@ -105,6 +111,15 @@ func TestSyncCommitteeHeadState(t *testing.T) {
 				state: bellatrixState,
 			},
 			want: bellatrixState,
+		},
+		{
+			name: "found with key (capella state)",
+			key:  types.Slot(200),
+			put: &put{
+				slot:  types.Slot(200),
+				state: capellaState,
+			},
+			want: capellaState,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Make sure sync committee head state can handle capella case and the future hardfork cases.