### PR TITLE
fixed depth check for SparseMerkleTrie object

### DIFF
--- a/container/trie/sparse_merkle.go
+++ b/container/trie/sparse_merkle.go
@@ -57,8 +57,9 @@ func (m *SparseMerkleTrie) validate() error {
 	if m.depth >= uint(len(m.branches)) {
 		return errors.New("depth is greater than or equal to number of branches")
 	}
-	if m.depth >= 64 {
-		return errors.New("depth exceeds 64") // PowerOf2 would overflow.
+	if m.depth >= 63 {
+		return errors.New("supported merkle trie depth exceeded (max uint64 depth is 63, " +
+			"theoretical max sparse merkle trie depth is 64)") // PowerOf2 would overflow.
 	}
 
 	return nil
@@ -68,6 +69,10 @@ func (m *SparseMerkleTrie) validate() error {
 func GenerateTrieFromItems(items [][]byte, depth uint64) (*SparseMerkleTrie, error) {
 	if len(items) == 0 {
 		return nil, errors.New("no items provided to generate Merkle trie")
+	}
+	if depth >= 63 {
+		return nil, errors.New("supported merkle trie depth exceeded (max uint64 depth is 63, " +
+			"theoretical max sparse merkle trie depth is 64)") // PowerOf2 would overflow
 	}
 	leaves := items
 	layers := make([][][]byte, depth+1)

--- a/container/trie/sparse_merkle_test.go
+++ b/container/trie/sparse_merkle_test.go
@@ -65,9 +65,10 @@ func TestCreateTrieFromProto_Validation(t *testing.T) {
 		{
 			trie: &ethpb.SparseMerkleTrie{
 				Layers: genValidLayers(66),
-				Depth:  65,
+				Depth:  63,
 			},
-			errString: "depth exceeds 64",
+			errString: "supported merkle trie depth exceeded (max uint64 depth is 63, " +
+				"theoretical max sparse merkle trie depth is 64)",
 		},
 	}
 	for _, tt := range tests {
@@ -151,6 +152,32 @@ func TestGenerateTrieFromItems_NoItemsProvided(t *testing.T) {
 	if _, err := trie.GenerateTrieFromItems(nil, params.BeaconConfig().DepositContractTreeDepth); err == nil {
 		t.Error("Expected error when providing nil items received nil")
 	}
+}
+
+func TestGenerateTrieFromItems_DepthSupport(t *testing.T) {
+	items := [][]byte{
+		[]byte("A"),
+		[]byte("BB"),
+		[]byte("CCC"),
+		[]byte("DDDD"),
+		[]byte("EEEEE"),
+		[]byte("FFFFFF"),
+		[]byte("GGGGGGG"),
+	}
+	// max supported depth is 62 (uint64 will overflow above this)
+	// max theoretical depth is 64
+	var max_supported_trie_depth uint64 = 62
+	// Supported depth
+	m1, err := trie.GenerateTrieFromItems(items, max_supported_trie_depth)
+	require.NoError(t, err)
+	proof, err := m1.MerkleProof(2)
+	require.NoError(t, err)
+	require.Equal(t, len(proof), int(max_supported_trie_depth)+1)
+	// Unsupported depth
+	_, err = trie.GenerateTrieFromItems(items, max_supported_trie_depth+1)
+	errString := "supported merkle trie depth exceeded (max uint64 depth is 63, " +
+		"theoretical max sparse merkle trie depth is 64)"
+	require.ErrorContains(t, errString, err)
 }
 
 func TestMerkleTrie_VerifyMerkleProofWithDepth(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
Nosy ([golang project fuzzer](https://github.com/infosecual/nosy)) found 2 separate types of panics in 8 functions due to the same underlying issue:

1. `panic: runtime error: index out of range [100] with length 100` triggered in:
    - `SparseMerkleTrie.Copy()`
    - `SparseMerkleTrie.HashTreeRoot()`
    - `SparseMerkleTrie.Insert()`
    - `SparseMerkleTrie.Items()`
    - `SparseMerkleTrie.NumOfItems()`
    - `SparseMerkleTrie.ToProto()`
    - `SparseMerkleTrie.validate()`
2. `panic: runtime error: integer divide by zero` triggered in:
    - `SparseMerkleTrie.MerkleProof()`

The issue it that the `SparseMerkleTrie` object's depth check has an off-by-one in SparseMerkleTrie.validate() and does not exist in `GenerateTrieFromItems()` which are the two possible code paths that can produce the `SparseMerkleTrie` object (`validate()` is called to sanitize tries created from protobufs in `CreateTrieFromProto()`).

In the case of `SparseMerkleTrie.validate()`, [there is a check](https://github.com/prysmaticlabs/prysm/blob/9c6a1331cfcb655ad1b901091eb1ec011500ca26/container/trie/sparse_merkle.go#L60) that the trie's depth does not exceed 64. This is done to prevent an overflow:
```go
func (m *SparseMerkleTrie) validate() error {
	if len(m.branches) == 0 {
		return errors.New("no branches")
	}
	if len(m.branches[len(m.branches)-1]) == 0 {
		return errors.New("invalid branches provided")
	}
	if m.depth >= uint(len(m.branches)) {
		return errors.New("depth is greater than or equal to number of branches")
	}
	if m.depth >= 64 {
		return errors.New("depth exceeds 64") // PowerOf2 would overflow.
	}

	return nil
}
```
Unfortunately this is not sufficient to prevent an overflow as the underlying datatype of the merkle trie's index is a uint64, which can only hold a depth of (2^64)-1 and will overflow if raised to a depth of 64. This will cause a divide-by-0 panic in [SparseMerkleTrie.MerkleProof()](https://github.com/prysmaticlabs/prysm/blob/9c6a1331cfcb655ad1b901091eb1ec011500ca26/container/trie/sparse_merkle.go#L176):
```go
for i := uint(0); i < m.depth; i++ {
	subIndex := (merkleIndex / (1 << i)) ^ 1 // div-by-0 panic when i == 63, bit shifted out of the register
	if subIndex < uint(len(m.branches[i])) {
		item := bytesutil.ToBytes32(m.branches[i][subIndex])
		proof[i] = item[:]
	} else {
		proof[i] = ZeroHashes[i][:]
	}
}
```

**Fixes**

Changing the conditional in `SparseMerkleTrie.validate()` to `if m.depth >= 63` will fix both the divide-by-0 and adding the same check to `GenerateTrieFromItems()` will prevent the array indexing panics. The theoretical max depth of these tries is 64, which cannot be handled by prysm currently with this fix. Unfortunately the alternative would require changing/enlarging the `uint64` `index` which would cause a performance hit, and will not be needed for honest clients on mainnet currently.

I did add a little more info about the depth constraint to the error message that is produced. I am happy to explorer other error messages or other ways to fix this.
