### PR TITLE
More user-friendly message in `ErrUndefinedExecutionEngineError`

### DIFF
--- a/beacon-chain/blockchain/error.go
+++ b/beacon-chain/blockchain/error.go
@@ -8,7 +8,7 @@ var (
 	// ErrInvalidBlockHashPayloadStatus is returned when the payload has invalid block hash.
 	ErrInvalidBlockHashPayloadStatus = invalidBlock{error: errors.New("received an INVALID_BLOCK_HASH payload from execution engine")}
 	// ErrUndefinedExecutionEngineError is returned when the execution engine returns an error that is not defined
-	ErrUndefinedExecutionEngineError = errors.New("received an undefined ee error")
+	ErrUndefinedExecutionEngineError = errors.New("received an undefined execution engine error")
 	// errNilFinalizedInStore is returned when a nil finalized checkpt is returned from store.
 	errNilFinalizedInStore = errors.New("nil finalized checkpoint returned from store")
 	// errNilFinalizedCheckpoint is returned when a nil finalized checkpt is returned from a state.


### PR DESCRIPTION
**What type of PR is this?**

UX

**What does this PR do? Why is it needed?**

Inspired by https://github.com/prysmaticlabs/prysm/issues/11774. Users are probably not aware what `ee` means in the error message and thus may not understand that there is an issue with the execution client.
