### PR TITLE
Capella: clean up `emptyBlockToSign`

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -57,7 +57,7 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 		return nil, status.Errorf(codes.Unavailable, "Validator is not ready to propose: %v", err)
 	}
 
-	blk, sBlk, err := emptyBlockToSign(req.Slot)
+	sBlk, err := emptyBlockToSign(req.Slot)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not prepare block: %v", err)
 	}
@@ -75,6 +75,7 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 		return nil, status.Errorf(codes.Internal, "Could not process slots up to %d: %v", req.Slot, err)
 	}
 
+	blk := sBlk.Block()
 	// Set slot, graffiti, randao reveal, and parent root.
 	blk.SetSlot(req.Slot)
 	blk.Body().SetGraffiti(req.Graffiti)
@@ -173,9 +174,6 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 		}
 	}
 
-	if err := sBlk.SetBlock(blk); err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not set block: %v", err)
-	}
 	sr, err := vs.computeStateRoot(ctx, sBlk)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not compute state root: %v", err)
@@ -238,49 +236,32 @@ func (vs *Server) getSlashings(ctx context.Context, head state.BeaconState) ([]*
 	return validProposerSlashings, validAttSlashings
 }
 
-func emptyBlockToSign(slot types.Slot) (interfaces.BeaconBlock, interfaces.SignedBeaconBlock, error) {
-	var blk interfaces.BeaconBlock
+func emptyBlockToSign(slot types.Slot) (interfaces.SignedBeaconBlock, error) {
 	var sBlk interfaces.SignedBeaconBlock
 	var err error
 	switch {
 	case slots.ToEpoch(slot) < params.BeaconConfig().AltairForkEpoch:
-		blk, err = blocks.NewBeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{}})
-		if err != nil {
-			return nil, nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
-		}
 		sBlk, err = blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{}}})
 		if err != nil {
-			return nil, nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
+			return nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
 		}
 	case slots.ToEpoch(slot) < params.BeaconConfig().BellatrixForkEpoch:
-		blk, err = blocks.NewBeaconBlock(&ethpb.BeaconBlockAltair{Body: &ethpb.BeaconBlockBodyAltair{}})
-		if err != nil {
-			return nil, nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
-		}
 		sBlk, err = blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockAltair{Block: &ethpb.BeaconBlockAltair{Body: &ethpb.BeaconBlockBodyAltair{}}})
 		if err != nil {
-			return nil, nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
+			return nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
 		}
 	case slots.ToEpoch(slot) < params.BeaconConfig().CapellaForkEpoch:
-		blk, err = blocks.NewBeaconBlock(&ethpb.BeaconBlockBellatrix{Body: &ethpb.BeaconBlockBodyBellatrix{}})
-		if err != nil {
-			return nil, nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
-		}
 		sBlk, err = blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockBellatrix{Block: &ethpb.BeaconBlockBellatrix{Body: &ethpb.BeaconBlockBodyBellatrix{}}})
 		if err != nil {
-			return nil, nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
+			return nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
 		}
 	default:
-		blk, err = blocks.NewBeaconBlock(&ethpb.BeaconBlockCapella{Body: &ethpb.BeaconBlockBodyCapella{}})
-		if err != nil {
-			return nil, nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
-		}
 		sBlk, err = blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockCapella{Block: &ethpb.BeaconBlockCapella{Body: &ethpb.BeaconBlockBodyCapella{}}})
 		if err != nil {
-			return nil, nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
+			return nil, status.Errorf(codes.Internal, "Could not initialize block for proposal: %v", err)
 		}
 	}
-	return blk, sBlk, err
+	return sBlk, err
 }
 
 // ProposeBeaconBlock is called by a proposer during its assigned slot to create a block in an attempt

--- a/consensus-types/blocks/getters_test.go
+++ b/consensus-types/blocks/getters_test.go
@@ -16,25 +16,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
 )
 
-func Test_SignedBeaconBlock_SetBlock(t *testing.T) {
-	b := &eth.BeaconBlockCapella{Slot: 1, Body: &eth.BeaconBlockBodyCapella{ExecutionPayload: &pb.ExecutionPayloadCapella{}}}
-	wb, err := NewBeaconBlock(b)
-	require.NoError(t, err)
-	wsb, err := NewSignedBeaconBlock(&eth.SignedBeaconBlockCapella{
-		Block: &eth.BeaconBlockCapella{StateRoot: bytesutil.PadTo([]byte("stateroot"), 32),
-			ParentRoot: bytesutil.PadTo([]byte("parent"), 32),
-			Body: &eth.BeaconBlockBodyCapella{
-				RandaoReveal:     make([]byte, fieldparams.BLSSignatureLength),
-				Graffiti:         make([]byte, fieldparams.RootLength),
-				ExecutionPayload: &pb.ExecutionPayloadCapella{},
-			}},
-		Signature: make([]byte, fieldparams.BLSSignatureLength),
-	})
-	require.NoError(t, err)
-	require.NoError(t, wsb.SetBlock(wb))
-	require.DeepEqual(t, wsb.Block(), wb)
-}
-
 func Test_BeaconBlockIsNil(t *testing.T) {
 	t.Run("not nil", func(t *testing.T) {
 		assert.NoError(t, BeaconBlockIsNil(&SignedBeaconBlock{block: &BeaconBlock{body: &BeaconBlockBody{}}}))

--- a/consensus-types/blocks/setters.go
+++ b/consensus-types/blocks/setters.go
@@ -13,53 +13,6 @@ func (b *SignedBeaconBlock) SetSignature(sig []byte) {
 	copy(b.signature[:], sig)
 }
 
-// SetBlock sets the underlying beacon block object.
-// This function is not thread safe, it is only used during block creation.
-func (b *SignedBeaconBlock) SetBlock(blk interfaces.BeaconBlock) error {
-	copied, err := blk.Copy()
-	if err != nil {
-		return err
-	}
-	b.block.slot = copied.Slot()
-	b.block.parentRoot = copied.ParentRoot()
-	b.block.stateRoot = copied.StateRoot()
-	b.block.proposerIndex = copied.ProposerIndex()
-	b.block.body.randaoReveal = copied.Body().RandaoReveal()
-	b.block.body.eth1Data = copied.Body().Eth1Data()
-	b.block.body.graffiti = copied.Body().Graffiti()
-	b.block.body.proposerSlashings = copied.Body().ProposerSlashings()
-	b.block.body.attesterSlashings = copied.Body().AttesterSlashings()
-	b.block.body.attestations = copied.Body().Attestations()
-	b.block.body.deposits = copied.Body().Deposits()
-	b.block.body.voluntaryExits = copied.Body().VoluntaryExits()
-	if b.version >= version.Altair {
-		syncAggregate, err := copied.Body().SyncAggregate()
-		if err != nil {
-			return err
-		}
-		b.block.body.syncAggregate = syncAggregate
-	}
-	if b.version >= version.Bellatrix {
-		executionData, err := copied.Body().Execution()
-		if err != nil {
-			return err
-		}
-		if b.block.body.isBlinded {
-			b.block.body.executionPayloadHeader = executionData
-		} else {
-			b.block.body.executionPayload = executionData
-		}
-	}
-	if b.version >= version.Capella {
-		changes, err := copied.Body().BLSToExecutionChanges()
-		if err != nil {
-			return err
-		}
-		b.block.body.blsToExecutionChanges = changes
-	}
-	return nil
-}
-
 // SetSlot sets the respective slot of the block.
 // This function is not thread safe, it is only used during block creation.
 func (b *BeaconBlock) SetSlot(slot types.Slot) {

--- a/consensus-types/interfaces/beacon_block.go
+++ b/consensus-types/interfaces/beacon_block.go
@@ -14,7 +14,6 @@ import (
 // a signed beacon block.
 type SignedBeaconBlock interface {
 	Block() BeaconBlock
-	SetBlock(BeaconBlock) error
 	Signature() [field_params.BLSSignatureLength]byte
 	SetSignature(sig []byte)
 	IsNil() bool


### PR DESCRIPTION
`emptyBlockToSign` doesnt need to return both `beacon_block` and `signed_beacon_block` as two different objects. We can just use `signed_beacon_block` because it contains `beacon_block` anyway