### PR TITLE
Copy execution data before writing it to the block

### DIFF
--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -3,6 +3,7 @@ package blocks
 import (
 	"bytes"
 	"errors"
+	"fmt"
 
 	fastssz "github.com/prysmaticlabs/fastssz"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
@@ -11,6 +12,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	enginev1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
+	eth "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -739,4 +741,24 @@ func IsEmptyExecutionData(data interfaces.ExecutionData) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// CopyExecutionData copies the provided ExecutionData.
+func CopyExecutionData(i interface{}) (interfaces.ExecutionData, error) {
+	data, ok := i.(interfaces.ExecutionData)
+	if !ok {
+		return nil, fmt.Errorf("not an execution data: %T", i)
+	}
+	switch d := data.Proto().(type) {
+	case *enginev1.ExecutionPayload:
+		return WrappedExecutionPayload(eth.CopyExecutionPayload(d))
+	case *enginev1.ExecutionPayloadHeader:
+		return WrappedExecutionPayloadHeader(eth.CopyExecutionPayloadHeader(d))
+	case *enginev1.ExecutionPayloadCapella:
+		return WrappedExecutionPayloadCapella(eth.CopyExecutionPayloadCapella(d))
+	case *enginev1.ExecutionPayloadHeaderCapella:
+		return WrappedExecutionPayloadHeaderCapella(eth.CopyExecutionPayloadHeaderCapella(d))
+	default:
+		return nil, fmt.Errorf("not an execution data: %T", d)
+	}
 }

--- a/consensus-types/blocks/execution_test.go
+++ b/consensus-types/blocks/execution_test.go
@@ -234,6 +234,28 @@ func Test_executionPayloadHeaderCapella_Pb(t *testing.T) {
 	require.ErrorIs(t, err, blocks.ErrUnsupportedGetter)
 }
 
+func Test_CopyExecutionData(t *testing.T) {
+	e := createWrappedPayload(t)
+	ec, err := blocks.CopyExecutionData(e)
+	require.NoError(t, err)
+	require.DeepEqual(t, e, ec)
+
+	h := createWrappedPayloadHeader(t)
+	hc, err := blocks.CopyExecutionData(h)
+	require.NoError(t, err)
+	require.DeepEqual(t, h, hc)
+
+	e = createWrappedPayloadCapella(t)
+	ec, err = blocks.CopyExecutionData(e)
+	require.NoError(t, err)
+	require.DeepEqual(t, e, ec)
+
+	h = createWrappedPayloadHeaderCapella(t)
+	hc, err = blocks.CopyExecutionData(h)
+	require.NoError(t, err)
+	require.DeepEqual(t, h, hc)
+}
+
 func createWrappedPayload(t testing.TB) interfaces.ExecutionData {
 	wsb, err := blocks.WrappedExecutionPayload(&enginev1.ExecutionPayload{
 		ParentHash:    make([]byte, fieldparams.RootLength),

--- a/consensus-types/blocks/setters.go
+++ b/consensus-types/blocks/setters.go
@@ -154,11 +154,15 @@ func (b *BeaconBlockBody) SetExecution(e interfaces.ExecutionData) error {
 	if b.version == version.Phase0 || b.version == version.Altair {
 		return ErrNotSupported("Execution", b.version)
 	}
+	copied, err := CopyExecutionData(e)
+	if err != nil {
+		return err
+	}
 	if b.isBlinded {
-		b.executionPayloadHeader = e
+		b.executionPayloadHeader = copied
 		return nil
 	}
-	b.executionPayload = e
+	b.executionPayload = copied
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

> Code health

**What does this PR do? Why is it needed?**

When writing the field to the block, I noticed we do a copy for the field. The only field that doesn't have a copy is `ExecutionData`. This PR adds the copy for `ExecutionData`. Everything is currently working without it, I think it's fine without the copy but it's probably safer to do so. This is more on the code health and and alignment side

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
