### PR TITLE
Allow proposer duties one epoch in advance

### DIFF
--- a/beacon-chain/rpc/eth/validator/BUILD.bazel
+++ b/beacon-chain/rpc/eth/validator/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//beacon-chain/builder:go_default_library",
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
+        "//beacon-chain/core/transition:go_default_library",
         "//beacon-chain/db/kv:go_default_library",
         "//beacon-chain/operations/attestations:go_default_library",
         "//beacon-chain/operations/synccommittee:go_default_library",

--- a/beacon-chain/rpc/eth/validator/validator.go
+++ b/beacon-chain/rpc/eth/validator/validator.go
@@ -164,8 +164,13 @@ func (vs *Server) GetProposerDuties(ctx context.Context, req *ethpbv1.ProposerDu
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get state: %v", err)
 	}
+
 	if req.Epoch == currentEpoch+1 {
-		s, err = transition.ProcessSlotsIfPossible(ctx, s, startSlot)
+		nextEpochStart, err := slots.EpochStart(currentEpoch + 1)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not get start slot from epoch %d: %v", currentEpoch+1, err)
+		}
+		s, err = transition.ProcessSlotsIfPossible(ctx, s, nextEpochStart)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not advance state to next epoch: %v", err)
 		}

--- a/beacon-chain/rpc/eth/validator/validator_test.go
+++ b/beacon-chain/rpc/eth/validator/validator_test.go
@@ -235,6 +235,7 @@ func TestGetProposerDuties(t *testing.T) {
 	require.NoError(t, err, "Could not get signing root")
 	roots := make([][]byte, fieldparams.BlockRootsLength)
 	roots[0] = genesisRoot[:]
+	roots[31] = []byte("next_epoch_dependent_root")
 	db := dbutil.SetupDB(t)
 
 	pubKeys := make([][]byte, len(deposits))
@@ -282,12 +283,52 @@ func TestGetProposerDuties(t *testing.T) {
 		assert.DeepEqual(t, pubKeys[9982], expectedDuty.Pubkey)
 	})
 
+	t.Run("Next epoch", func(t *testing.T) {
+		bs, err := transition.GenesisBeaconState(context.Background(), deposits, 0, eth1Data)
+		require.NoError(t, err, "Could not set up genesis state")
+		require.NoError(t, bs.SetSlot(params.BeaconConfig().SlotsPerEpoch))
+		require.NoError(t, bs.SetBlockRoots(roots))
+		chainSlot := types.Slot(0)
+		chain := &mockChain.ChainService{
+			State: bs, Root: genesisRoot[:], Slot: &chainSlot,
+		}
+		vs := &Server{
+			StateFetcher:           &testutil.MockFetcher{StatesBySlot: map[types.Slot]state.BeaconState{0: bs}},
+			HeadFetcher:            chain,
+			TimeFetcher:            chain,
+			OptimisticModeFetcher:  chain,
+			SyncChecker:            &mockSync.Sync{IsSyncing: false},
+			ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
+		}
+
+		req := &ethpbv1.ProposerDutiesRequest{
+			Epoch: 1,
+		}
+		resp, err := vs.GetProposerDuties(ctx, req)
+		require.NoError(t, err)
+		assert.DeepEqual(t, bytesutil.PadTo([]byte("next_epoch_dependent_root"), 32), resp.DependentRoot)
+		assert.Equal(t, 32, len(resp.Data))
+		// We expect a proposer duty for slot 43.
+		var expectedDuty *ethpbv1.ProposerDuty
+		for _, duty := range resp.Data {
+			if duty.Slot == 43 {
+				expectedDuty = duty
+			}
+		}
+		vid, _, has := vs.ProposerSlotIndexCache.GetProposerPayloadIDs(43, [32]byte{})
+		require.Equal(t, true, has)
+		require.Equal(t, types.ValidatorIndex(4863), vid)
+		require.NotNil(t, expectedDuty, "Expected duty for slot 43 not found")
+		assert.Equal(t, types.ValidatorIndex(4863), expectedDuty.ValidatorIndex)
+		assert.DeepEqual(t, pubKeys[4863], expectedDuty.Pubkey)
+	})
+
 	t.Run("Prune payload ID cache ok", func(t *testing.T) {
 		bs, err := transition.GenesisBeaconState(context.Background(), deposits, 0, eth1Data)
 		require.NoError(t, err, "Could not set up genesis state")
 		require.NoError(t, bs.SetSlot(params.BeaconConfig().SlotsPerEpoch))
 		require.NoError(t, bs.SetBlockRoots(roots))
-		chainSlot := types.Slot(params.BeaconConfig().SlotsPerEpoch)
+		chainSlot := params.BeaconConfig().SlotsPerEpoch
 		chain := &mockChain.ChainService{
 			State: bs, Root: genesisRoot[:], Slot: &chainSlot,
 		}
@@ -342,11 +383,11 @@ func TestGetProposerDuties(t *testing.T) {
 
 		currentEpoch := slots.ToEpoch(bs.Slot())
 		req := &ethpbv1.ProposerDutiesRequest{
-			Epoch: currentEpoch + 1,
+			Epoch: currentEpoch + 2,
 		}
 		_, err = vs.GetProposerDuties(ctx, req)
 		require.NotNil(t, err)
-		assert.ErrorContains(t, fmt.Sprintf("Request epoch %d can not be greater than current epoch %d", currentEpoch+1, currentEpoch), err)
+		assert.ErrorContains(t, fmt.Sprintf("Request epoch %d can not be greater than next epoch %d", currentEpoch+2, currentEpoch+1), err)
 	})
 
 	t.Run("execution optimistic", func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

#11806 removed the ability to query proposer duties one epoch in advance. This PR brings it back and adds a test for this scenario.
