### PR TITLE
attempt to fix WaitForTextInFile log corruption

### DIFF
--- a/testing/endtoend/helpers/helpers.go
+++ b/testing/endtoend/helpers/helpers.go
@@ -97,6 +97,13 @@ func WaitForTextInFile(src *os.File, match string) error {
 			case <-ctx.Done():
 				return
 			case <-t.C:
+				// This is a paranoid check because I'm not sure if the underlying fd handle can be stuck mid-line
+				// when Scanner sees a partially written line at EOF. It's probably safest to just keep this.
+				_, err = f.Seek(0, io.SeekStart)
+				if err != nil {
+					errChan <- err
+					return
+				}
 				lineScanner := bufio.NewScanner(f)
 				// Scan will return true until it hits EOF or another error.
 				// If .Close is called on the underlying file, Scan will return false, causing this goroutine to exit.

--- a/testing/endtoend/helpers/helpers.go
+++ b/testing/endtoend/helpers/helpers.go
@@ -20,7 +20,6 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/pkg/errors"
-
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	eth "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	e2e "github.com/prysmaticlabs/prysm/v3/testing/endtoend/params"
@@ -119,7 +118,7 @@ func WaitForTextInFile(src *os.File, match string) error {
 				// If Scan returned false for an error (except EOF), Err will return it.
 				if err = lineScanner.Err(); err != nil {
 					// Bubble the error back up to the parent goroutine.
-					errChan <-err
+					errChan <- err
 				}
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Our E2E tests use presence of sentinel log messages in subprocesses as checks to ensure that components have started properly. Sometimes these checks fail, resulting in failed/flaky e2e tests. @nisdas has noticed that in these instances the logs appear corrupted, so it's likely that something is wrong with how we set up stderr redirection. I noticed that `WaitForTextInFile` calls Seek() on the file descriptor which is shared with component that call it. I think this is resulting in corruption of log files. 

**Which issues(s) does this PR fix?**

I don't think an issue has been filed for this, but if we have one LMK and I'll attach it.