### PR TITLE
Track head slot through head block

### DIFF
--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -125,7 +125,10 @@ func TestHeadSlot_CanRetrieve(t *testing.T) {
 	c := &Service{}
 	s, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{})
 	require.NoError(t, err)
-	c.head = &head{slot: 100, state: s}
+	b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
+	require.NoError(t, err)
+	b.Block().SetSlot(100)
+	c.head = &head{block: b, state: s}
 	assert.Equal(t, types.Slot(100), c.HeadSlot())
 }
 
@@ -412,7 +415,7 @@ func TestService_IsOptimistic(t *testing.T) {
 	ctx := context.Background()
 	ojc := &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
 	ofc := &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
-	c := &Service{cfg: &config{ForkChoiceStore: doublylinkedtree.New()}, head: &head{slot: 101, root: [32]byte{'b'}}}
+	c := &Service{cfg: &config{ForkChoiceStore: doublylinkedtree.New()}, head: &head{root: [32]byte{'b'}}}
 	st, blkRoot, err := prepareForkchoiceState(ctx, 100, [32]byte{'a'}, [32]byte{}, params.BeaconConfig().ZeroHash, ojc, ofc)
 	require.NoError(t, err)
 	require.NoError(t, c.cfg.ForkChoiceStore.InsertNode(ctx, st, blkRoot))
@@ -435,7 +438,7 @@ func TestService_IsOptimisticBeforeBellatrix(t *testing.T) {
 
 func TestService_IsOptimisticForRoot(t *testing.T) {
 	ctx := context.Background()
-	c := &Service{cfg: &config{ForkChoiceStore: doublylinkedtree.New()}, head: &head{slot: 101, root: [32]byte{'b'}}}
+	c := &Service{cfg: &config{ForkChoiceStore: doublylinkedtree.New()}, head: &head{root: [32]byte{'b'}}}
 	ojc := &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
 	ofc := &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
 	st, blkRoot, err := prepareForkchoiceState(ctx, 100, [32]byte{'a'}, [32]byte{}, params.BeaconConfig().ZeroHash, ojc, ofc)
@@ -453,7 +456,7 @@ func TestService_IsOptimisticForRoot(t *testing.T) {
 func TestService_IsOptimisticForRoot_DB(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
 	ctx := context.Background()
-	c := &Service{cfg: &config{BeaconDB: beaconDB, ForkChoiceStore: doublylinkedtree.New()}, head: &head{slot: 101, root: [32]byte{'b'}}}
+	c := &Service{cfg: &config{BeaconDB: beaconDB, ForkChoiceStore: doublylinkedtree.New()}, head: &head{root: [32]byte{'b'}}}
 	c.head = &head{root: params.BeaconConfig().ZeroHash}
 	b := util.NewBeaconBlock()
 	b.Block.Slot = 10
@@ -511,7 +514,7 @@ func TestService_IsOptimisticForRoot_DB(t *testing.T) {
 func TestService_IsOptimisticForRoot_DB_non_canonical(t *testing.T) {
 	beaconDB := testDB.SetupDB(t)
 	ctx := context.Background()
-	c := &Service{cfg: &config{BeaconDB: beaconDB, ForkChoiceStore: doublylinkedtree.New()}, head: &head{slot: 101, root: [32]byte{'b'}}}
+	c := &Service{cfg: &config{BeaconDB: beaconDB, ForkChoiceStore: doublylinkedtree.New()}, head: &head{root: [32]byte{'b'}}}
 	c.head = &head{root: params.BeaconConfig().ZeroHash}
 	b := util.NewBeaconBlock()
 	b.Block.Slot = 10

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -231,7 +231,7 @@ func (s *Service) setHeadInitialSync(root [32]byte, block interfaces.SignedBeaco
 // This returns the head slot.
 // This is a lock free version.
 func (s *Service) headSlot() types.Slot {
-	if s.head == nil || s.head.block == nil {
+	if s.head == nil || s.head.block == nil || s.head.block.Block() == nil {
 		return 0
 	}
 	return s.head.block.Block().Slot()

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -51,7 +51,6 @@ func (s *Service) UpdateAndSaveHeadWithBalances(ctx context.Context) error {
 
 // This defines the current chain service's view of head.
 type head struct {
-	slot  types.Slot                   // current head slot.
 	root  [32]byte                     // current head root.
 	block interfaces.SignedBeaconBlock // current head block.
 	state state.BeaconState            // current head state.
@@ -202,7 +201,6 @@ func (s *Service) setHead(root [32]byte, block interfaces.SignedBeaconBlock, sta
 		return err
 	}
 	s.head = &head{
-		slot:  block.Block().Slot(),
 		root:  root,
 		block: bCp,
 		state: state.Copy(),
@@ -223,7 +221,6 @@ func (s *Service) setHeadInitialSync(root [32]byte, block interfaces.SignedBeaco
 		return err
 	}
 	s.head = &head{
-		slot:  block.Block().Slot(),
 		root:  root,
 		block: bCp,
 		state: state,
@@ -234,7 +231,10 @@ func (s *Service) setHeadInitialSync(root [32]byte, block interfaces.SignedBeaco
 // This returns the head slot.
 // This is a lock free version.
 func (s *Service) headSlot() types.Slot {
-	return s.head.slot
+	if s.head == nil || s.head.block == nil {
+		return 0
+	}
+	return s.head.block.Block().Slot()
 }
 
 // This returns the head root.

--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -30,7 +30,7 @@ func TestSaveHead_Same(t *testing.T) {
 	service := setupBeaconChain(t, beaconDB)
 
 	r := [32]byte{'A'}
-	service.head = &head{slot: 0, root: r}
+	service.head = &head{root: r}
 	b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 	require.NoError(t, err)
 	st, _ := util.DeterministicGenesisState(t, 1)
@@ -53,7 +53,6 @@ func TestSaveHead_Different(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, state, blkRoot))
 	service.head = &head{
-		slot:  0,
 		root:  oldRoot,
 		block: oldBlock,
 	}
@@ -107,7 +106,6 @@ func TestSaveHead_Different_Reorg(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, state, blkRoot))
 	service.head = &head{
-		slot:  0,
 		root:  oldRoot,
 		block: oldBlock,
 	}

--- a/beacon-chain/blockchain/receive_attestation_test.go
+++ b/beacon-chain/blockchain/receive_attestation_test.go
@@ -159,7 +159,6 @@ func TestNotifyEngineIfChangedHead(t *testing.T) {
 	require.NoError(t, service.saveInitSyncBlock(ctx, r1, wsb))
 	st, _ := util.DeterministicGenesisState(t, 1)
 	service.head = &head{
-		slot:  1,
 		root:  r1,
 		block: wsb,
 		state: st,
@@ -177,7 +176,6 @@ func TestNotifyEngineIfChangedHead(t *testing.T) {
 	require.NoError(t, err)
 	st, _ = util.DeterministicGenesisState(t, 1)
 	service.head = &head{
-		slot:  1,
 		root:  r1,
 		block: wsb,
 		state: st,


### PR DESCRIPTION
**What type of PR is this?**

> Clean up

**What does this PR do? Why is it needed?**

There's not much reason to be tracking head slot separately in the blockchain service's head struct. We shouldn't track it separately to prevent any disparity. The slot can cheaply be derived from the head block or head state. In this PR, we removed head slot tracking and used `block.slot`. You can use `state.slot` if people think that's better
