### PR TITLE
Add `context` to beacon API REST implementation

### DIFF
--- a/validator/client/beacon-api/activation.go
+++ b/validator/client/beacon-api/activation.go
@@ -69,7 +69,7 @@ func (c *waitForActivationClient) Recv() (*ethpb.ValidatorActivationResponse, er
 			stringTargetPubKeys[index] = stringPubKey
 		}
 
-		stateValidators, err := c.stateValidatorsProvider.GetStateValidators(stringTargetPubKeys, nil, nil)
+		stateValidators, err := c.stateValidatorsProvider.GetStateValidators(c.ctx, stringTargetPubKeys, nil, nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get state validators")
 		}

--- a/validator/client/beacon-api/activation_test.go
+++ b/validator/client/beacon-api/activation_test.go
@@ -109,17 +109,22 @@ func TestActivation_Nominal(t *testing.T) {
 	}
 
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
+
+	// Instantiate a cancellable context.
+	ctx, cancel := context.WithCancel(context.Background())
+
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 
 	// GetRestJsonResponse does not return any result for non existing key
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		url,
 		&stateValidatorsResponseJson,
 	).Return(
 		nil,
 		nil,
 	).SetArg(
-		1,
+		2,
 		rpcmiddleware.StateValidatorsResponseJson{
 			Data: []*rpcmiddleware.ValidatorContainerJson{
 				{
@@ -152,9 +157,6 @@ func TestActivation_Nominal(t *testing.T) {
 			jsonRestHandler: jsonRestHandler,
 		},
 	}
-
-	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
 
 	waitForActivation, err := validatorClient.WaitForActivation(
 		ctx,
@@ -234,16 +236,18 @@ func TestActivation_InvalidData(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				defer ctrl.Finish()
 
-				jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
+				ctx := context.Background()
 
+				jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 				jsonRestHandler.EXPECT().GetRestJsonResponse(
+					ctx,
 					gomock.Any(),
 					gomock.Any(),
 				).Return(
 					nil,
 					nil,
 				).SetArg(
-					1,
+					2,
 					rpcmiddleware.StateValidatorsResponseJson{
 						Data: testCase.data,
 					},
@@ -256,7 +260,7 @@ func TestActivation_InvalidData(t *testing.T) {
 				}
 
 				waitForActivation, err := validatorClient.WaitForActivation(
-					context.Background(),
+					ctx,
 					&ethpb.ValidatorActivationRequest{},
 				)
 				assert.NoError(t, err)
@@ -272,9 +276,11 @@ func TestActivation_JsonResponseError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
+	ctx := context.Background()
 
+	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		gomock.Any(),
 		gomock.Any(),
 	).Return(
@@ -289,7 +295,7 @@ func TestActivation_JsonResponseError(t *testing.T) {
 	}
 
 	waitForActivation, err := validatorClient.WaitForActivation(
-		context.Background(),
+		ctx,
 		&ethpb.ValidatorActivationRequest{},
 	)
 	assert.NoError(t, err)

--- a/validator/client/beacon-api/attestation_data.go
+++ b/validator/client/beacon-api/attestation_data.go
@@ -1,6 +1,7 @@
 package beacon_api
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 
@@ -12,6 +13,7 @@ import (
 )
 
 func (c beaconApiValidatorClient) getAttestationData(
+	ctx context.Context,
 	reqSlot types.Slot,
 	reqCommitteeIndex types.CommitteeIndex,
 ) (*ethpb.AttestationData, error) {
@@ -21,7 +23,7 @@ func (c beaconApiValidatorClient) getAttestationData(
 
 	query := buildURL("/eth/v1/validator/attestation_data", params)
 	produceAttestationDataResponseJson := rpcmiddleware.ProduceAttestationDataResponseJson{}
-	_, err := c.jsonRestHandler.GetRestJsonResponse(query, &produceAttestationDataResponseJson)
+	_, err := c.jsonRestHandler.GetRestJsonResponse(ctx, query, &produceAttestationDataResponseJson)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get json response")
 	}

--- a/validator/client/beacon-api/attestation_data_test.go
+++ b/validator/client/beacon-api/attestation_data_test.go
@@ -1,6 +1,7 @@
 package beacon_api
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -18,6 +19,7 @@ import (
 const attestationDataEndpoint = "/eth/v1/validator/attestation_data"
 
 func TestGetAttestationData_ValidAttestation(t *testing.T) {
+	ctx := context.Background()
 	expectedSlot := uint64(5)
 	expectedCommitteeIndex := uint64(6)
 	expectedBeaconBlockRoot := "0x0636045df9bdda3ab96592cf5389032c8ec3977f911e2b53509b348dfe164d4d"
@@ -33,13 +35,14 @@ func TestGetAttestationData_ValidAttestation(t *testing.T) {
 	produceAttestationDataResponseJson := rpcmiddleware.ProduceAttestationDataResponseJson{}
 
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		fmt.Sprintf("/eth/v1/validator/attestation_data?committee_index=%d&slot=%d", expectedCommitteeIndex, expectedSlot),
 		&produceAttestationDataResponseJson,
 	).Return(
 		nil,
 		nil,
 	).SetArg(
-		1,
+		2,
 		rpcmiddleware.ProduceAttestationDataResponseJson{
 			Data: &rpcmiddleware.AttestationDataJson{
 				Slot:            strconv.FormatUint(expectedSlot, 10),
@@ -58,7 +61,7 @@ func TestGetAttestationData_ValidAttestation(t *testing.T) {
 	).Times(1)
 
 	validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	resp, err := validatorClient.getAttestationData(types.Slot(expectedSlot), types.CommitteeIndex(expectedCommitteeIndex))
+	resp, err := validatorClient.getAttestationData(ctx, types.Slot(expectedSlot), types.CommitteeIndex(expectedCommitteeIndex))
 	assert.NoError(t, err)
 
 	require.NotNil(t, resp)
@@ -76,6 +79,8 @@ func TestGetAttestationData_ValidAttestation(t *testing.T) {
 }
 
 func TestGetAttestationData_InvalidData(t *testing.T) {
+	ctx := context.Background()
+
 	testCases := []struct {
 		name                 string
 		generateData         func() rpcmiddleware.ProduceAttestationDataResponseJson
@@ -181,18 +186,19 @@ func TestGetAttestationData_InvalidData(t *testing.T) {
 			produceAttestationDataResponseJson := rpcmiddleware.ProduceAttestationDataResponseJson{}
 			jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().GetRestJsonResponse(
+				ctx,
 				"/eth/v1/validator/attestation_data?committee_index=2&slot=1",
 				&produceAttestationDataResponseJson,
 			).Return(
 				nil,
 				nil,
 			).SetArg(
-				1,
+				2,
 				testCase.generateData(),
 			).Times(1)
 
 			validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-			_, err := validatorClient.getAttestationData(1, 2)
+			_, err := validatorClient.getAttestationData(ctx, 1, 2)
 			assert.ErrorContains(t, testCase.expectedErrorMessage, err)
 		})
 	}
@@ -202,12 +208,15 @@ func TestGetAttestationData_JsonResponseError(t *testing.T) {
 	const slot = types.Slot(1)
 	const committeeIndex = types.CommitteeIndex(2)
 
+	ctx := context.Background()
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	produceAttestationDataResponseJson := rpcmiddleware.ProduceAttestationDataResponseJson{}
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		fmt.Sprintf("/eth/v1/validator/attestation_data?committee_index=%d&slot=%d", committeeIndex, slot),
 		&produceAttestationDataResponseJson,
 	).Return(
@@ -216,7 +225,7 @@ func TestGetAttestationData_JsonResponseError(t *testing.T) {
 	).Times(1)
 
 	validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	_, err := validatorClient.getAttestationData(slot, committeeIndex)
+	_, err := validatorClient.getAttestationData(ctx, slot, committeeIndex)
 	assert.ErrorContains(t, "failed to get json response", err)
 	assert.ErrorContains(t, "some specific json response error", err)
 }

--- a/validator/client/beacon-api/beacon_api_validator_client.go
+++ b/validator/client/beacon-api/beacon_api_validator_client.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
-	iface "github.com/prysmaticlabs/prysm/v3/validator/client/iface"
+	"github.com/prysmaticlabs/prysm/v3/validator/client/iface"
 )
 
 type beaconApiValidatorClient struct {
@@ -56,25 +56,25 @@ func (c *beaconApiValidatorClient) CheckDoppelGanger(ctx context.Context, in *et
 	panic("beaconApiValidatorClient.CheckDoppelGanger is not implemented. To use a fallback client, create this validator with NewBeaconApiValidatorClientWithFallback instead.")
 }
 
-func (c *beaconApiValidatorClient) DomainData(_ context.Context, in *ethpb.DomainRequest) (*ethpb.DomainResponse, error) {
+func (c *beaconApiValidatorClient) DomainData(ctx context.Context, in *ethpb.DomainRequest) (*ethpb.DomainResponse, error) {
 	if len(in.Domain) != 4 {
 		return nil, errors.Errorf("invalid domain type: %s", hexutil.Encode(in.Domain))
 	}
 
 	domainType := bytesutil.ToBytes4(in.Domain)
-	return c.getDomainData(in.Epoch, domainType)
+	return c.getDomainData(ctx, in.Epoch, domainType)
 }
 
-func (c *beaconApiValidatorClient) GetAttestationData(_ context.Context, in *ethpb.AttestationDataRequest) (*ethpb.AttestationData, error) {
+func (c *beaconApiValidatorClient) GetAttestationData(ctx context.Context, in *ethpb.AttestationDataRequest) (*ethpb.AttestationData, error) {
 	if in == nil {
 		return nil, errors.New("GetAttestationData received nil argument `in`")
 	}
 
-	return c.getAttestationData(in.Slot, in.CommitteeIndex)
+	return c.getAttestationData(ctx, in.Slot, in.CommitteeIndex)
 }
 
-func (c *beaconApiValidatorClient) GetBeaconBlock(_ context.Context, in *ethpb.BlockRequest) (*ethpb.GenericBeaconBlock, error) {
-	return c.getBeaconBlock(in.Slot, in.RandaoReveal, in.Graffiti)
+func (c *beaconApiValidatorClient) GetBeaconBlock(ctx context.Context, in *ethpb.BlockRequest) (*ethpb.GenericBeaconBlock, error) {
+	return c.getBeaconBlock(ctx, in.Slot, in.RandaoReveal, in.Graffiti)
 }
 
 func (c *beaconApiValidatorClient) GetFeeRecipientByPubKey(ctx context.Context, in *ethpb.FeeRecipientByPubKeyRequest) (*ethpb.FeeRecipientByPubKeyResponse, error) {
@@ -113,12 +113,12 @@ func (c *beaconApiValidatorClient) GetSyncSubcommitteeIndex(ctx context.Context,
 	panic("beaconApiValidatorClient.GetSyncSubcommitteeIndex is not implemented. To use a fallback client, create this validator with NewBeaconApiValidatorClientWithFallback instead.")
 }
 
-func (c *beaconApiValidatorClient) MultipleValidatorStatus(_ context.Context, in *ethpb.MultipleValidatorStatusRequest) (*ethpb.MultipleValidatorStatusResponse, error) {
-	return c.multipleValidatorStatus(in)
+func (c *beaconApiValidatorClient) MultipleValidatorStatus(ctx context.Context, in *ethpb.MultipleValidatorStatusRequest) (*ethpb.MultipleValidatorStatusResponse, error) {
+	return c.multipleValidatorStatus(ctx, in)
 }
 
-func (c *beaconApiValidatorClient) PrepareBeaconProposer(_ context.Context, in *ethpb.PrepareBeaconProposerRequest) (*empty.Empty, error) {
-	return new(empty.Empty), c.prepareBeaconProposer(in.Recipients)
+func (c *beaconApiValidatorClient) PrepareBeaconProposer(ctx context.Context, in *ethpb.PrepareBeaconProposerRequest) (*empty.Empty, error) {
+	return new(empty.Empty), c.prepareBeaconProposer(ctx, in.Recipients)
 }
 
 func (c *beaconApiValidatorClient) ProposeAttestation(ctx context.Context, in *ethpb.Attestation) (*ethpb.AttestResponse, error) {
@@ -130,12 +130,12 @@ func (c *beaconApiValidatorClient) ProposeAttestation(ctx context.Context, in *e
 	panic("beaconApiValidatorClient.ProposeAttestation is not implemented. To use a fallback client, create this validator with NewBeaconApiValidatorClientWithFallback instead.")
 }
 
-func (c *beaconApiValidatorClient) ProposeBeaconBlock(_ context.Context, in *ethpb.GenericSignedBeaconBlock) (*ethpb.ProposeResponse, error) {
-	return c.proposeBeaconBlock(in)
+func (c *beaconApiValidatorClient) ProposeBeaconBlock(ctx context.Context, in *ethpb.GenericSignedBeaconBlock) (*ethpb.ProposeResponse, error) {
+	return c.proposeBeaconBlock(ctx, in)
 }
 
-func (c *beaconApiValidatorClient) ProposeExit(_ context.Context, in *ethpb.SignedVoluntaryExit) (*ethpb.ProposeExitResponse, error) {
-	return c.proposeExit(in)
+func (c *beaconApiValidatorClient) ProposeExit(ctx context.Context, in *ethpb.SignedVoluntaryExit) (*ethpb.ProposeExitResponse, error) {
+	return c.proposeExit(ctx, in)
 }
 
 func (c *beaconApiValidatorClient) StreamBlocksAltair(ctx context.Context, in *ethpb.StreamBlocksRequest) (ethpb.BeaconNodeValidator_StreamBlocksAltairClient, error) {
@@ -210,12 +210,12 @@ func (c *beaconApiValidatorClient) SubscribeCommitteeSubnets(ctx context.Context
 	panic("beaconApiValidatorClient.SubscribeCommitteeSubnets is not implemented. To use a fallback client, create this validator with NewBeaconApiValidatorClientWithFallback instead.")
 }
 
-func (c *beaconApiValidatorClient) ValidatorIndex(_ context.Context, in *ethpb.ValidatorIndexRequest) (*ethpb.ValidatorIndexResponse, error) {
-	return c.validatorIndex(in)
+func (c *beaconApiValidatorClient) ValidatorIndex(ctx context.Context, in *ethpb.ValidatorIndexRequest) (*ethpb.ValidatorIndexResponse, error) {
+	return c.validatorIndex(ctx, in)
 }
 
-func (c *beaconApiValidatorClient) ValidatorStatus(_ context.Context, in *ethpb.ValidatorStatusRequest) (*ethpb.ValidatorStatusResponse, error) {
-	return c.validatorStatus(in)
+func (c *beaconApiValidatorClient) ValidatorStatus(ctx context.Context, in *ethpb.ValidatorStatusRequest) (*ethpb.ValidatorStatusResponse, error) {
+	return c.validatorStatus(ctx, in)
 }
 
 func (c *beaconApiValidatorClient) WaitForActivation(ctx context.Context, in *ethpb.ValidatorActivationRequest) (ethpb.BeaconNodeValidator_WaitForActivationClient, error) {

--- a/validator/client/beacon-api/beacon_api_validator_client_test.go
+++ b/validator/client/beacon-api/beacon_api_validator_client_test.go
@@ -26,21 +26,24 @@ func TestBeaconApiValidatorClient_GetAttestationDataValid(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
+
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	produceAttestationDataResponseJson := rpcmiddleware.ProduceAttestationDataResponseJson{}
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		fmt.Sprintf("/eth/v1/validator/attestation_data?committee_index=%d&slot=%d", committeeIndex, slot),
 		&produceAttestationDataResponseJson,
 	).Return(
 		nil,
 		nil,
 	).SetArg(
-		1,
+		2,
 		generateValidAttestation(uint64(slot), uint64(committeeIndex)),
 	).Times(2)
 
 	validatorClient := beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	expectedResp, expectedErr := validatorClient.getAttestationData(slot, committeeIndex)
+	expectedResp, expectedErr := validatorClient.getAttestationData(ctx, slot, committeeIndex)
 
 	resp, err := validatorClient.GetAttestationData(
 		context.Background(),
@@ -64,21 +67,24 @@ func TestBeaconApiValidatorClient_GetAttestationDataError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
+
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	produceAttestationDataResponseJson := rpcmiddleware.ProduceAttestationDataResponseJson{}
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		fmt.Sprintf("/eth/v1/validator/attestation_data?committee_index=%d&slot=%d", committeeIndex, slot),
 		&produceAttestationDataResponseJson,
 	).Return(
 		nil,
 		errors.New("some specific json error"),
 	).SetArg(
-		1,
+		2,
 		generateValidAttestation(uint64(slot), uint64(committeeIndex)),
 	).Times(2)
 
 	validatorClient := beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	expectedResp, expectedErr := validatorClient.getAttestationData(slot, committeeIndex)
+	expectedResp, expectedErr := validatorClient.getAttestationData(ctx, slot, committeeIndex)
 
 	resp, err := validatorClient.GetAttestationData(
 		context.Background(),
@@ -97,8 +103,10 @@ func TestBeaconApiValidatorClient_DomainDataValid(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
+
 	genesisProvider := mock.NewMockgenesisProvider(ctrl)
-	genesisProvider.EXPECT().GetGenesis().Return(
+	genesisProvider.EXPECT().GetGenesis(ctx).Return(
 		&rpcmiddleware.GenesisResponse_GenesisJson{GenesisValidatorsRoot: genesisValidatorRoot},
 		nil,
 		nil,
@@ -108,7 +116,7 @@ func TestBeaconApiValidatorClient_DomainDataValid(t *testing.T) {
 	resp, err := validatorClient.DomainData(context.Background(), &ethpb.DomainRequest{Epoch: epoch, Domain: domainType})
 
 	domainTypeArray := bytesutil.ToBytes4(domainType)
-	expectedResp, expectedErr := validatorClient.getDomainData(epoch, domainTypeArray)
+	expectedResp, expectedErr := validatorClient.getDomainData(ctx, epoch, domainTypeArray)
 	assert.DeepEqual(t, expectedErr, err)
 	assert.DeepEqual(t, expectedResp, resp)
 }
@@ -125,9 +133,11 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockValid(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
+	ctx := context.Background()
 
+	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().PostRestJson(
+		ctx,
 		"/eth/v1/beacon/blocks",
 		map[string]string{"Eth-Consensus-Version": "phase0"},
 		gomock.Any(),
@@ -139,13 +149,14 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockValid(t *testing.T) {
 
 	validatorClient := beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
 	expectedResp, expectedErr := validatorClient.proposeBeaconBlock(
+		ctx,
 		&ethpb.GenericSignedBeaconBlock{
 			Block: generateSignedPhase0Block(),
 		},
 	)
 
 	resp, err := validatorClient.ProposeBeaconBlock(
-		context.Background(),
+		ctx,
 		&ethpb.GenericSignedBeaconBlock{
 			Block: generateSignedPhase0Block(),
 		},
@@ -162,8 +173,11 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
+
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().PostRestJson(
+		ctx,
 		"/eth/v1/beacon/blocks",
 		map[string]string{"Eth-Consensus-Version": "phase0"},
 		gomock.Any(),
@@ -175,13 +189,14 @@ func TestBeaconApiValidatorClient_ProposeBeaconBlockError(t *testing.T) {
 
 	validatorClient := beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
 	expectedResp, expectedErr := validatorClient.proposeBeaconBlock(
+		ctx,
 		&ethpb.GenericSignedBeaconBlock{
 			Block: generateSignedPhase0Block(),
 		},
 	)
 
 	resp, err := validatorClient.ProposeBeaconBlock(
-		context.Background(),
+		ctx,
 		&ethpb.GenericSignedBeaconBlock{
 			Block: generateSignedPhase0Block(),
 		},

--- a/validator/client/beacon-api/domain_data.go
+++ b/validator/client/beacon-api/domain_data.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"context"
+
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/signing"

--- a/validator/client/beacon-api/domain_data.go
+++ b/validator/client/beacon-api/domain_data.go
@@ -1,6 +1,7 @@
 package beacon_api
 
 import (
+	"context"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/signing"
@@ -9,7 +10,7 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 )
 
-func (c beaconApiValidatorClient) getDomainData(epoch types.Epoch, domainType [4]byte) (*ethpb.DomainResponse, error) {
+func (c beaconApiValidatorClient) getDomainData(ctx context.Context, epoch types.Epoch, domainType [4]byte) (*ethpb.DomainResponse, error) {
 	// Get the fork version from the given epoch
 	fork, err := forks.Fork(epoch)
 	if err != nil {
@@ -17,7 +18,7 @@ func (c beaconApiValidatorClient) getDomainData(epoch types.Epoch, domainType [4
 	}
 
 	// Get the genesis validator root
-	genesis, _, err := c.genesisProvider.GetGenesis()
+	genesis, _, err := c.genesisProvider.GetGenesis(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get genesis info")
 	}

--- a/validator/client/beacon-api/get_beacon_block.go
+++ b/validator/client/beacon-api/get_beacon_block.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -22,7 +23,7 @@ type abstractProduceBlockResponseJson struct {
 	Data    json.RawMessage `json:"data"`
 }
 
-func (c beaconApiValidatorClient) getBeaconBlock(slot types.Slot, randaoReveal []byte, graffiti []byte) (*ethpb.GenericBeaconBlock, error) {
+func (c beaconApiValidatorClient) getBeaconBlock(ctx context.Context, slot types.Slot, randaoReveal []byte, graffiti []byte) (*ethpb.GenericBeaconBlock, error) {
 	queryParams := neturl.Values{}
 	queryParams.Add("randao_reveal", hexutil.Encode(randaoReveal))
 
@@ -35,7 +36,7 @@ func (c beaconApiValidatorClient) getBeaconBlock(slot types.Slot, randaoReveal [
 	// Since we don't know yet what the json looks like, we unmarshal into an abstract structure that has only a version
 	// and a blob of data
 	produceBlockResponseJson := abstractProduceBlockResponseJson{}
-	if _, err := c.jsonRestHandler.GetRestJsonResponse(queryUrl, &produceBlockResponseJson); err != nil {
+	if _, err := c.jsonRestHandler.GetRestJsonResponse(ctx, queryUrl, &produceBlockResponseJson); err != nil {
 		return nil, errors.Wrap(err, "failed to query GET REST endpoint")
 	}
 

--- a/validator/client/beacon-api/get_beacon_block_test.go
+++ b/validator/client/beacon-api/get_beacon_block_test.go
@@ -1,6 +1,7 @@
 package beacon_api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -16,8 +17,11 @@ func TestGetBeaconBlock_RequestFailed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
+
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		gomock.Any(),
 		gomock.Any(),
 	).Return(
@@ -26,7 +30,7 @@ func TestGetBeaconBlock_RequestFailed(t *testing.T) {
 	).Times(1)
 
 	validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	_, err := validatorClient.getBeaconBlock(1, []byte{1}, []byte{2})
+	_, err := validatorClient.getBeaconBlock(ctx, 1, []byte{1}, []byte{2})
 	assert.ErrorContains(t, "failed to query GET REST endpoint", err)
 	assert.ErrorContains(t, "foo error", err)
 }
@@ -95,12 +99,15 @@ func TestGetBeaconBlock_Error(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
+			ctx := context.Background()
+
 			jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().GetRestJsonResponse(
+				ctx,
 				gomock.Any(),
 				&abstractProduceBlockResponseJson{},
 			).SetArg(
-				1,
+				2,
 				abstractProduceBlockResponseJson{
 					Version: testCase.consensusVersion,
 					Data:    testCase.data,
@@ -111,7 +118,7 @@ func TestGetBeaconBlock_Error(t *testing.T) {
 			).Times(1)
 
 			validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-			_, err := validatorClient.getBeaconBlock(1, []byte{1}, []byte{2})
+			_, err := validatorClient.getBeaconBlock(ctx, 1, []byte{1}, []byte{2})
 			assert.ErrorContains(t, testCase.expectedErrorMessage, err)
 		})
 	}

--- a/validator/client/beacon-api/index.go
+++ b/validator/client/beacon-api/index.go
@@ -1,6 +1,7 @@
 package beacon_api
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -9,10 +10,10 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 )
 
-func (c beaconApiValidatorClient) validatorIndex(in *ethpb.ValidatorIndexRequest) (*ethpb.ValidatorIndexResponse, error) {
+func (c beaconApiValidatorClient) validatorIndex(ctx context.Context, in *ethpb.ValidatorIndexRequest) (*ethpb.ValidatorIndexResponse, error) {
 	stringPubKey := hexutil.Encode(in.PublicKey)
 
-	stateValidator, err := c.stateValidatorsProvider.GetStateValidators([]string{stringPubKey}, nil, nil)
+	stateValidator, err := c.stateValidatorsProvider.GetStateValidators(ctx, []string{stringPubKey}, nil, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get state validator")
 	}

--- a/validator/client/beacon-api/index_test.go
+++ b/validator/client/beacon-api/index_test.go
@@ -33,18 +33,20 @@ func TestIndex_Nominal(t *testing.T) {
 	defer ctrl.Finish()
 
 	pubKey, url := getPubKeyAndURL(t)
+	ctx := context.Background()
 
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		url,
 		&stateValidatorsResponseJson,
 	).Return(
 		nil,
 		nil,
 	).SetArg(
-		1,
+		2,
 		rpcmiddleware.StateValidatorsResponseJson{
 			Data: []*rpcmiddleware.ValidatorContainerJson{
 				{
@@ -65,7 +67,7 @@ func TestIndex_Nominal(t *testing.T) {
 	}
 
 	validatorIndex, err := validatorClient.ValidatorIndex(
-		context.Background(),
+		ctx,
 		&ethpb.ValidatorIndexRequest{
 			PublicKey: pubKey,
 		},
@@ -80,18 +82,20 @@ func TestIndex_UnexistingValidator(t *testing.T) {
 	defer ctrl.Finish()
 
 	pubKey, url := getPubKeyAndURL(t)
+	ctx := context.Background()
 
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		url,
 		&stateValidatorsResponseJson,
 	).Return(
 		nil,
 		nil,
 	).SetArg(
-		1,
+		2,
 		rpcmiddleware.StateValidatorsResponseJson{
 			Data: []*rpcmiddleware.ValidatorContainerJson{},
 		},
@@ -104,7 +108,7 @@ func TestIndex_UnexistingValidator(t *testing.T) {
 	}
 
 	_, err := validatorClient.ValidatorIndex(
-		context.Background(),
+		ctx,
 		&ethpb.ValidatorIndexRequest{
 			PublicKey: pubKey,
 		},
@@ -119,18 +123,20 @@ func TestIndex_BadIndexError(t *testing.T) {
 	defer ctrl.Finish()
 
 	pubKey, url := getPubKeyAndURL(t)
+	ctx := context.Background()
 
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		url,
 		&stateValidatorsResponseJson,
 	).Return(
 		nil,
 		nil,
 	).SetArg(
-		1,
+		2,
 		rpcmiddleware.StateValidatorsResponseJson{
 			Data: []*rpcmiddleware.ValidatorContainerJson{
 				{
@@ -151,7 +157,7 @@ func TestIndex_BadIndexError(t *testing.T) {
 	}
 
 	_, err := validatorClient.ValidatorIndex(
-		context.Background(),
+		ctx,
 		&ethpb.ValidatorIndexRequest{
 			PublicKey: pubKey,
 		},
@@ -165,11 +171,13 @@ func TestIndex_JsonResponseError(t *testing.T) {
 	defer ctrl.Finish()
 
 	pubKey, url := getPubKeyAndURL(t)
+	ctx := context.Background()
 
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		url,
 		&stateValidatorsResponseJson,
 	).Return(
@@ -184,7 +192,7 @@ func TestIndex_JsonResponseError(t *testing.T) {
 	}
 
 	_, err := validatorClient.ValidatorIndex(
-		context.Background(),
+		ctx,
 		&ethpb.ValidatorIndexRequest{
 			PublicKey: pubKey,
 		},

--- a/validator/client/beacon-api/json_rest_handler.go
+++ b/validator/client/beacon-api/json_rest_handler.go
@@ -22,6 +22,9 @@ type beaconApiJsonRestHandler struct {
 
 // GetRestJsonResponse sends a GET requests to apiEndpoint and decodes the response body as a JSON object into responseJson.
 // If an HTTP error is returned, the body is decoded as a DefaultErrorJson JSON object instead and returned as the first return value.
+// TODO: GetRestJsonResponse and PostRestJson have converged to the point of being nearly identical, but with some inconsistencies
+//  (like responseJson is being checked for nil one but not the other). We should merge them into a single method
+//  with variadic functional options for headers and data.
 func (c beaconApiJsonRestHandler) GetRestJsonResponse(ctx context.Context, apiEndpoint string, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
 	if responseJson == nil {
 		return nil, errors.New("responseJson is nil")
@@ -55,7 +58,7 @@ func (c beaconApiJsonRestHandler) PostRestJson(ctx context.Context, apiEndpoint 
 	}
 
 	url := c.host + apiEndpoint
-	req, err := http.NewRequestWithContext(ctx, "POST", url, data)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create request with context")
 	}

--- a/validator/client/beacon-api/json_rest_handler.go
+++ b/validator/client/beacon-api/json_rest_handler.go
@@ -23,8 +23,8 @@ type beaconApiJsonRestHandler struct {
 // GetRestJsonResponse sends a GET requests to apiEndpoint and decodes the response body as a JSON object into responseJson.
 // If an HTTP error is returned, the body is decoded as a DefaultErrorJson JSON object instead and returned as the first return value.
 // TODO: GetRestJsonResponse and PostRestJson have converged to the point of being nearly identical, but with some inconsistencies
-//  (like responseJson is being checked for nil one but not the other). We should merge them into a single method
-//  with variadic functional options for headers and data.
+// (like responseJson is being checked for nil one but not the other). We should merge them into a single method
+// with variadic functional options for headers and data.
 func (c beaconApiJsonRestHandler) GetRestJsonResponse(ctx context.Context, apiEndpoint string, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
 	if responseJson == nil {
 		return nil, errors.New("responseJson is nil")

--- a/validator/client/beacon-api/json_rest_handler.go
+++ b/validator/client/beacon-api/json_rest_handler.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -10,8 +11,8 @@ import (
 )
 
 type jsonRestHandler interface {
-	GetRestJsonResponse(query string, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error)
-	PostRestJson(apiEndpoint string, headers map[string]string, data *bytes.Buffer, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error)
+	GetRestJsonResponse(ctx context.Context, query string, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error)
+	PostRestJson(ctx context.Context, apiEndpoint string, headers map[string]string, data *bytes.Buffer, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error)
 }
 
 type beaconApiJsonRestHandler struct {
@@ -21,13 +22,18 @@ type beaconApiJsonRestHandler struct {
 
 // GetRestJsonResponse sends a GET requests to apiEndpoint and decodes the response body as a JSON object into responseJson.
 // If an HTTP error is returned, the body is decoded as a DefaultErrorJson JSON object instead and returned as the first return value.
-func (c beaconApiJsonRestHandler) GetRestJsonResponse(apiEndpoint string, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
+func (c beaconApiJsonRestHandler) GetRestJsonResponse(ctx context.Context, apiEndpoint string, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
 	if responseJson == nil {
 		return nil, errors.New("responseJson is nil")
 	}
 
 	url := c.host + apiEndpoint
-	resp, err := c.httpClient.Get(url)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create request with context")
+	}
+
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to query REST API %s", url)
 	}
@@ -43,13 +49,16 @@ func (c beaconApiJsonRestHandler) GetRestJsonResponse(apiEndpoint string, respon
 // PostRestJson sends a POST requests to apiEndpoint and decodes the response body as a JSON object into responseJson. If responseJson
 // is nil, nothing is decoded. If an HTTP error is returned, the body is decoded as a DefaultErrorJson JSON object instead and returned
 // as the first return value.
-func (c beaconApiJsonRestHandler) PostRestJson(apiEndpoint string, headers map[string]string, data *bytes.Buffer, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
+func (c beaconApiJsonRestHandler) PostRestJson(ctx context.Context, apiEndpoint string, headers map[string]string, data *bytes.Buffer, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
 	if data == nil {
 		return nil, errors.New("POST data is nil")
 	}
 
 	url := c.host + apiEndpoint
-	req, err := http.NewRequest("POST", url, data)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, data)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create request with context")
+	}
 
 	for headerKey, headerValue := range headers {
 		req.Header.Set(headerKey, headerValue)

--- a/validator/client/beacon-api/mock/genesis_mock.go
+++ b/validator/client/beacon-api/mock/genesis_mock.go
@@ -5,6 +5,7 @@
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,9 +37,9 @@ func (m *MockgenesisProvider) EXPECT() *MockgenesisProviderMockRecorder {
 }
 
 // GetGenesis mocks base method.
-func (m *MockgenesisProvider) GetGenesis() (*apimiddleware0.GenesisResponse_GenesisJson, *apimiddleware.DefaultErrorJson, error) {
+func (m *MockgenesisProvider) GetGenesis(ctx context.Context) (*apimiddleware0.GenesisResponse_GenesisJson, *apimiddleware.DefaultErrorJson, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGenesis")
+	ret := m.ctrl.Call(m, "GetGenesis", ctx)
 	ret0, _ := ret[0].(*apimiddleware0.GenesisResponse_GenesisJson)
 	ret1, _ := ret[1].(*apimiddleware.DefaultErrorJson)
 	ret2, _ := ret[2].(error)
@@ -46,7 +47,7 @@ func (m *MockgenesisProvider) GetGenesis() (*apimiddleware0.GenesisResponse_Gene
 }
 
 // GetGenesis indicates an expected call of GetGenesis.
-func (mr *MockgenesisProviderMockRecorder) GetGenesis() *gomock.Call {
+func (mr *MockgenesisProviderMockRecorder) GetGenesis(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenesis", reflect.TypeOf((*MockgenesisProvider)(nil).GetGenesis))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGenesis", reflect.TypeOf((*MockgenesisProvider)(nil).GetGenesis), ctx)
 }

--- a/validator/client/beacon-api/mock/json_rest_handler_mock.go
+++ b/validator/client/beacon-api/mock/json_rest_handler_mock.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	bytes "bytes"
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,31 +37,31 @@ func (m *MockjsonRestHandler) EXPECT() *MockjsonRestHandlerMockRecorder {
 }
 
 // GetRestJsonResponse mocks base method.
-func (m *MockjsonRestHandler) GetRestJsonResponse(query string, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
+func (m *MockjsonRestHandler) GetRestJsonResponse(ctx context.Context, query string, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRestJsonResponse", query, responseJson)
+	ret := m.ctrl.Call(m, "GetRestJsonResponse", ctx, query, responseJson)
 	ret0, _ := ret[0].(*apimiddleware.DefaultErrorJson)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRestJsonResponse indicates an expected call of GetRestJsonResponse.
-func (mr *MockjsonRestHandlerMockRecorder) GetRestJsonResponse(query, responseJson interface{}) *gomock.Call {
+func (mr *MockjsonRestHandlerMockRecorder) GetRestJsonResponse(ctx, query, responseJson interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRestJsonResponse", reflect.TypeOf((*MockjsonRestHandler)(nil).GetRestJsonResponse), query, responseJson)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRestJsonResponse", reflect.TypeOf((*MockjsonRestHandler)(nil).GetRestJsonResponse), ctx, query, responseJson)
 }
 
 // PostRestJson mocks base method.
-func (m *MockjsonRestHandler) PostRestJson(apiEndpoint string, headers map[string]string, data *bytes.Buffer, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
+func (m *MockjsonRestHandler) PostRestJson(ctx context.Context, apiEndpoint string, headers map[string]string, data *bytes.Buffer, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PostRestJson", apiEndpoint, headers, data, responseJson)
+	ret := m.ctrl.Call(m, "PostRestJson", ctx, apiEndpoint, headers, data, responseJson)
 	ret0, _ := ret[0].(*apimiddleware.DefaultErrorJson)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // PostRestJson indicates an expected call of PostRestJson.
-func (mr *MockjsonRestHandlerMockRecorder) PostRestJson(apiEndpoint, headers, data, responseJson interface{}) *gomock.Call {
+func (mr *MockjsonRestHandlerMockRecorder) PostRestJson(ctx, apiEndpoint, headers, data, responseJson interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRestJson", reflect.TypeOf((*MockjsonRestHandler)(nil).PostRestJson), apiEndpoint, headers, data, responseJson)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostRestJson", reflect.TypeOf((*MockjsonRestHandler)(nil).PostRestJson), ctx, apiEndpoint, headers, data, responseJson)
 }

--- a/validator/client/beacon-api/mock/state_validators_mock.go
+++ b/validator/client/beacon-api/mock/state_validators_mock.go
@@ -5,6 +5,7 @@
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -35,16 +36,16 @@ func (m *MockstateValidatorsProvider) EXPECT() *MockstateValidatorsProviderMockR
 }
 
 // GetStateValidators mocks base method.
-func (m *MockstateValidatorsProvider) GetStateValidators(arg0 []string, arg1 []int64, arg2 []string) (*apimiddleware.StateValidatorsResponseJson, error) {
+func (m *MockstateValidatorsProvider) GetStateValidators(arg0 context.Context, arg1 []string, arg2 []int64, arg3 []string) (*apimiddleware.StateValidatorsResponseJson, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStateValidators", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetStateValidators", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*apimiddleware.StateValidatorsResponseJson)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetStateValidators indicates an expected call of GetStateValidators.
-func (mr *MockstateValidatorsProviderMockRecorder) GetStateValidators(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockstateValidatorsProviderMockRecorder) GetStateValidators(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateValidators", reflect.TypeOf((*MockstateValidatorsProvider)(nil).GetStateValidators), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateValidators", reflect.TypeOf((*MockstateValidatorsProvider)(nil).GetStateValidators), arg0, arg1, arg2, arg3)
 }

--- a/validator/client/beacon-api/prepare_beacon_proposer.go
+++ b/validator/client/beacon-api/prepare_beacon_proposer.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strconv"
 
@@ -11,7 +12,7 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 )
 
-func (c *beaconApiValidatorClient) prepareBeaconProposer(recipients []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer) error {
+func (c *beaconApiValidatorClient) prepareBeaconProposer(ctx context.Context, recipients []*ethpb.PrepareBeaconProposerRequest_FeeRecipientContainer) error {
 	jsonRecipients := make([]*apimiddleware.FeeRecipientJson, len(recipients))
 	for index, recipient := range recipients {
 		jsonRecipients[index] = &apimiddleware.FeeRecipientJson{
@@ -25,7 +26,7 @@ func (c *beaconApiValidatorClient) prepareBeaconProposer(recipients []*ethpb.Pre
 		return errors.Wrap(err, "failed to marshal recipients")
 	}
 
-	if _, err := c.jsonRestHandler.PostRestJson("/eth/v1/validator/prepare_beacon_proposer", nil, bytes.NewBuffer(marshalledJsonRecipients), nil); err != nil {
+	if _, err := c.jsonRestHandler.PostRestJson(ctx, "/eth/v1/validator/prepare_beacon_proposer", nil, bytes.NewBuffer(marshalledJsonRecipients), nil); err != nil {
 		return errors.Wrap(err, "failed to send POST data to REST endpoint")
 	}
 

--- a/validator/client/beacon-api/prepare_beacon_proposer_test.go
+++ b/validator/client/beacon-api/prepare_beacon_proposer_test.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -25,6 +26,8 @@ func TestPrepareBeaconProposer_Valid(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
+
 	jsonRecipients := []*apimiddleware.FeeRecipientJson{
 		{
 			ValidatorIndex: "1",
@@ -45,6 +48,7 @@ func TestPrepareBeaconProposer_Valid(t *testing.T) {
 
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().PostRestJson(
+		ctx,
 		prepareBeaconProposerTestEndpoint,
 		nil,
 		bytes.NewBuffer(marshalledJsonRecipients),
@@ -77,7 +81,7 @@ func TestPrepareBeaconProposer_Valid(t *testing.T) {
 	}
 
 	validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	err = validatorClient.prepareBeaconProposer(protoRecipients)
+	err = validatorClient.prepareBeaconProposer(ctx, protoRecipients)
 	require.NoError(t, err)
 }
 
@@ -85,8 +89,11 @@ func TestPrepareBeaconProposer_BadRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
+
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().PostRestJson(
+		ctx,
 		prepareBeaconProposerTestEndpoint,
 		nil,
 		gomock.Any(),
@@ -97,7 +104,7 @@ func TestPrepareBeaconProposer_BadRequest(t *testing.T) {
 	).Times(1)
 
 	validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	err := validatorClient.prepareBeaconProposer(nil)
+	err := validatorClient.prepareBeaconProposer(ctx, nil)
 	assert.ErrorContains(t, "failed to send POST data to REST endpoint", err)
 	assert.ErrorContains(t, "foo error", err)
 }

--- a/validator/client/beacon-api/propose_beacon_block.go
+++ b/validator/client/beacon-api/propose_beacon_block.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -12,7 +13,7 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 )
 
-func (c beaconApiValidatorClient) proposeBeaconBlock(in *ethpb.GenericSignedBeaconBlock) (*ethpb.ProposeResponse, error) {
+func (c beaconApiValidatorClient) proposeBeaconBlock(ctx context.Context, in *ethpb.GenericSignedBeaconBlock) (*ethpb.ProposeResponse, error) {
 	var consensusVersion string
 	var beaconBlockRoot [32]byte
 
@@ -93,7 +94,7 @@ func (c beaconApiValidatorClient) proposeBeaconBlock(in *ethpb.GenericSignedBeac
 	}
 
 	headers := map[string]string{"Eth-Consensus-Version": consensusVersion}
-	if httpError, err := c.jsonRestHandler.PostRestJson(endpoint, headers, bytes.NewBuffer(marshalledSignedBeaconBlockJson), nil); err != nil {
+	if httpError, err := c.jsonRestHandler.PostRestJson(ctx, endpoint, headers, bytes.NewBuffer(marshalledSignedBeaconBlockJson), nil); err != nil {
 		if httpError != nil && httpError.Code == http.StatusAccepted {
 			// Error 202 means that the block was successfully broadcasted, but validation failed
 			return nil, errors.Wrap(err, "block was successfully broadcasted but failed validation")

--- a/validator/client/beacon-api/propose_beacon_block_altair_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_altair_test.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -52,9 +53,12 @@ func TestProposeBeaconBlock_Altair(t *testing.T) {
 	marshalledBlock, err := json.Marshal(jsonAltairBlock)
 	require.NoError(t, err)
 
+	ctx := context.Background()
+
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "altair"}
 	jsonRestHandler.EXPECT().PostRestJson(
+		ctx,
 		"/eth/v1/beacon/blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),
@@ -62,7 +66,7 @@ func TestProposeBeaconBlock_Altair(t *testing.T) {
 	)
 
 	validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	proposeResponse, err := validatorClient.proposeBeaconBlock(genericSignedBlock)
+	proposeResponse, err := validatorClient.proposeBeaconBlock(ctx, genericSignedBlock)
 	assert.NoError(t, err)
 	require.NotNil(t, proposeResponse)
 

--- a/validator/client/beacon-api/propose_beacon_block_bellatrix_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_bellatrix_test.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -69,9 +70,12 @@ func TestProposeBeaconBlock_Bellatrix(t *testing.T) {
 	marshalledBlock, err := json.Marshal(jsonBellatrixBlock)
 	require.NoError(t, err)
 
+	ctx := context.Background()
+
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "bellatrix"}
 	jsonRestHandler.EXPECT().PostRestJson(
+		ctx,
 		"/eth/v1/beacon/blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),
@@ -79,7 +83,7 @@ func TestProposeBeaconBlock_Bellatrix(t *testing.T) {
 	)
 
 	validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	proposeResponse, err := validatorClient.proposeBeaconBlock(genericSignedBlock)
+	proposeResponse, err := validatorClient.proposeBeaconBlock(ctx, genericSignedBlock)
 	assert.NoError(t, err)
 	require.NotNil(t, proposeResponse)
 

--- a/validator/client/beacon-api/propose_beacon_block_blinded_bellatrix_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_blinded_bellatrix_test.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -70,9 +71,12 @@ func TestProposeBeaconBlock_BlindedBellatrix(t *testing.T) {
 	marshalledBlock, err := json.Marshal(jsonBlindedBellatrixBlock)
 	require.NoError(t, err)
 
+	ctx := context.Background()
+
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "bellatrix"}
 	jsonRestHandler.EXPECT().PostRestJson(
+		ctx,
 		"/eth/v1/beacon/blinded_blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),
@@ -80,7 +84,7 @@ func TestProposeBeaconBlock_BlindedBellatrix(t *testing.T) {
 	)
 
 	validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	proposeResponse, err := validatorClient.proposeBeaconBlock(genericSignedBlock)
+	proposeResponse, err := validatorClient.proposeBeaconBlock(ctx, genericSignedBlock)
 	assert.NoError(t, err)
 	require.NotNil(t, proposeResponse)
 

--- a/validator/client/beacon-api/propose_beacon_block_blinded_capella_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_blinded_capella_test.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -72,9 +73,12 @@ func TestProposeBeaconBlock_BlindedCapella(t *testing.T) {
 	marshalledBlock, err := json.Marshal(jsonBlindedCapellaBlock)
 	require.NoError(t, err)
 
+	ctx := context.Background()
+
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "capella"}
 	jsonRestHandler.EXPECT().PostRestJson(
+		ctx,
 		"/eth/v1/beacon/blinded_blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),
@@ -82,7 +86,7 @@ func TestProposeBeaconBlock_BlindedCapella(t *testing.T) {
 	)
 
 	validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	proposeResponse, err := validatorClient.proposeBeaconBlock(genericSignedBlock)
+	proposeResponse, err := validatorClient.proposeBeaconBlock(ctx, genericSignedBlock)
 	assert.NoError(t, err)
 	require.NotNil(t, proposeResponse)
 

--- a/validator/client/beacon-api/propose_beacon_block_phase0_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_phase0_test.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -48,9 +49,12 @@ func TestProposeBeaconBlock_Phase0(t *testing.T) {
 	marshalledBlock, err := json.Marshal(jsonPhase0Block)
 	require.NoError(t, err)
 
+	ctx := context.Background()
+
 	// Make sure that what we send in the POST body is the marshalled version of the protobuf block
 	headers := map[string]string{"Eth-Consensus-Version": "phase0"}
 	jsonRestHandler.EXPECT().PostRestJson(
+		ctx,
 		"/eth/v1/beacon/blocks",
 		headers,
 		bytes.NewBuffer(marshalledBlock),
@@ -58,7 +62,7 @@ func TestProposeBeaconBlock_Phase0(t *testing.T) {
 	)
 
 	validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-	proposeResponse, err := validatorClient.proposeBeaconBlock(genericSignedBlock)
+	proposeResponse, err := validatorClient.proposeBeaconBlock(ctx, genericSignedBlock)
 	assert.NoError(t, err)
 	require.NotNil(t, proposeResponse)
 

--- a/validator/client/beacon-api/propose_beacon_block_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_test.go
@@ -1,6 +1,7 @@
 package beacon_api
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -87,10 +88,12 @@ func TestProposeBeaconBlock_Error(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				defer ctrl.Finish()
 
+				ctx := context.Background()
 				jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 
 				headers := map[string]string{"Eth-Consensus-Version": testCase.consensusVersion}
 				jsonRestHandler.EXPECT().PostRestJson(
+					ctx,
 					testCase.endpoint,
 					headers,
 					gomock.Any(),
@@ -101,7 +104,7 @@ func TestProposeBeaconBlock_Error(t *testing.T) {
 				).Times(1)
 
 				validatorClient := &beaconApiValidatorClient{jsonRestHandler: jsonRestHandler}
-				_, err := validatorClient.proposeBeaconBlock(testCase.block)
+				_, err := validatorClient.proposeBeaconBlock(ctx, testCase.block)
 				assert.ErrorContains(t, testSuite.expectedErrorMessage, err)
 				assert.ErrorContains(t, "foo error", err)
 			})
@@ -111,6 +114,6 @@ func TestProposeBeaconBlock_Error(t *testing.T) {
 
 func TestProposeBeaconBlock_UnsupportedBlockType(t *testing.T) {
 	validatorClient := &beaconApiValidatorClient{}
-	_, err := validatorClient.proposeBeaconBlock(&ethpb.GenericSignedBeaconBlock{})
+	_, err := validatorClient.proposeBeaconBlock(context.Background(), &ethpb.GenericSignedBeaconBlock{})
 	assert.ErrorContains(t, "unsupported block type", err)
 }

--- a/validator/client/beacon-api/propose_exit.go
+++ b/validator/client/beacon-api/propose_exit.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"strconv"
 
@@ -11,7 +12,7 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 )
 
-func (c beaconApiValidatorClient) proposeExit(signedVoluntaryExit *ethpb.SignedVoluntaryExit) (*ethpb.ProposeExitResponse, error) {
+func (c beaconApiValidatorClient) proposeExit(ctx context.Context, signedVoluntaryExit *ethpb.SignedVoluntaryExit) (*ethpb.ProposeExitResponse, error) {
 	if signedVoluntaryExit == nil {
 		return nil, errors.New("signed voluntary exit is nil")
 	}
@@ -33,7 +34,7 @@ func (c beaconApiValidatorClient) proposeExit(signedVoluntaryExit *ethpb.SignedV
 		return nil, errors.Wrap(err, "failed to marshal signed voluntary exit")
 	}
 
-	if _, err := c.jsonRestHandler.PostRestJson("/eth/v1/beacon/pool/voluntary_exits", nil, bytes.NewBuffer(marshalledSignedVoluntaryExit), nil); err != nil {
+	if _, err := c.jsonRestHandler.PostRestJson(ctx, "/eth/v1/beacon/pool/voluntary_exits", nil, bytes.NewBuffer(marshalledSignedVoluntaryExit), nil); err != nil {
 		return nil, errors.Wrap(err, "failed to send POST data to REST endpoint")
 	}
 

--- a/validator/client/beacon-api/state_validators.go
+++ b/validator/client/beacon-api/state_validators.go
@@ -1,6 +1,7 @@
 package beacon_api
 
 import (
+	"context"
 	neturl "net/url"
 	"strconv"
 
@@ -9,7 +10,7 @@ import (
 )
 
 type stateValidatorsProvider interface {
-	GetStateValidators([]string, []int64, []string) (*rpcmiddleware.StateValidatorsResponseJson, error)
+	GetStateValidators(context.Context, []string, []int64, []string) (*rpcmiddleware.StateValidatorsResponseJson, error)
 }
 
 type beaconApiStateValidatorsProvider struct {
@@ -17,6 +18,7 @@ type beaconApiStateValidatorsProvider struct {
 }
 
 func (c beaconApiStateValidatorsProvider) GetStateValidators(
+	ctx context.Context,
 	stringPubkeys []string,
 	indexes []int64,
 	statuses []string,
@@ -51,7 +53,7 @@ func (c beaconApiStateValidatorsProvider) GetStateValidators(
 
 	stateValidatorsJson := &rpcmiddleware.StateValidatorsResponseJson{}
 
-	_, err := c.jsonRestHandler.GetRestJsonResponse(url, stateValidatorsJson)
+	_, err := c.jsonRestHandler.GetRestJsonResponse(ctx, url, stateValidatorsJson)
 	if err != nil {
 		return &rpcmiddleware.StateValidatorsResponseJson{}, errors.Wrap(err, "failed to get json response")
 	}

--- a/validator/client/beacon-api/state_validators_test.go
+++ b/validator/client/beacon-api/state_validators_test.go
@@ -1,6 +1,7 @@
 package beacon_api
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -60,21 +61,24 @@ func TestGetStateValidators_Nominal(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		url,
 		&stateValidatorsResponseJson,
 	).Return(
 		nil,
 		nil,
 	).SetArg(
-		1,
+		2,
 		rpcmiddleware.StateValidatorsResponseJson{
 			Data: wanted,
 		},
 	).Times(1)
 
 	stateValidatorsProvider := beaconApiStateValidatorsProvider{jsonRestHandler: jsonRestHandler}
-	actual, err := stateValidatorsProvider.GetStateValidators([]string{
+	actual, err := stateValidatorsProvider.GetStateValidators(ctx, []string{
 		"0x8000091c2ae64ee414a54c1cc1fc67dec663408bc636cb86756e0200e41a75c8f86603f104f02c856983d2783116be13", // active_ongoing
 		"0x80000e851c0f53c3246ff726d7ff7766661ca5e12a07c45c114d208d54f0f8233d4380b2e9aff759d69795d1df905526", // active_exiting
 		"0x424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242424242", // does not exist
@@ -100,7 +104,10 @@ func TestGetStateValidators_GetRestJsonResponseOnError(t *testing.T) {
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 
+	ctx := context.Background()
+
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		url,
 		&stateValidatorsResponseJson,
 	).Return(
@@ -109,7 +116,7 @@ func TestGetStateValidators_GetRestJsonResponseOnError(t *testing.T) {
 	).Times(1)
 
 	stateValidatorsProvider := beaconApiStateValidatorsProvider{jsonRestHandler: jsonRestHandler}
-	_, err := stateValidatorsProvider.GetStateValidators([]string{
+	_, err := stateValidatorsProvider.GetStateValidators(ctx, []string{
 		"0x8000091c2ae64ee414a54c1cc1fc67dec663408bc636cb86756e0200e41a75c8f86603f104f02c856983d2783116be13", // active_ongoing
 	},
 		nil,
@@ -125,24 +132,26 @@ func TestGetStateValidators_DataIsNil(t *testing.T) {
 
 	url := "/eth/v1/beacon/states/head/validators?id=0x8000091c2ae64ee414a54c1cc1fc67dec663408bc636cb86756e0200e41a75c8f86603f104f02c856983d2783116be13"
 
+	ctx := context.Background()
 	stateValidatorsResponseJson := rpcmiddleware.StateValidatorsResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		url,
 		&stateValidatorsResponseJson,
 	).Return(
 		nil,
 		nil,
 	).SetArg(
-		1,
+		2,
 		rpcmiddleware.StateValidatorsResponseJson{
 			Data: nil,
 		},
 	).Times(1)
 
 	stateValidatorsProvider := beaconApiStateValidatorsProvider{jsonRestHandler: jsonRestHandler}
-	_, err := stateValidatorsProvider.GetStateValidators([]string{
+	_, err := stateValidatorsProvider.GetStateValidators(ctx, []string{
 		"0x8000091c2ae64ee414a54c1cc1fc67dec663408bc636cb86756e0200e41a75c8f86603f104f02c856983d2783116be13", // active_ongoing
 	},
 		nil,

--- a/validator/client/beacon-api/status_test.go
+++ b/validator/client/beacon-api/status_test.go
@@ -25,9 +25,12 @@ func TestValidatorStatus_Nominal(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
+
 	stateValidatorsProvider := mock.NewMockstateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().GetStateValidators(
+		ctx,
 		[]string{stringValidatorPubKey},
 		nil,
 		nil,
@@ -50,7 +53,7 @@ func TestValidatorStatus_Nominal(t *testing.T) {
 	validatorClient := beaconApiValidatorClient{stateValidatorsProvider: stateValidatorsProvider}
 
 	actualValidatorStatusResponse, err := validatorClient.ValidatorStatus(
-		context.Background(),
+		ctx,
 		&ethpb.ValidatorStatusRequest{
 			PublicKey: validatorPubKey,
 		},
@@ -69,9 +72,12 @@ func TestValidatorStatus_Error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
+
 	stateValidatorsProvider := mock.NewMockstateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().GetStateValidators(
+		ctx,
 		gomock.Any(),
 		nil,
 		nil,
@@ -83,7 +89,7 @@ func TestValidatorStatus_Error(t *testing.T) {
 	validatorClient := beaconApiValidatorClient{stateValidatorsProvider: stateValidatorsProvider}
 
 	_, err := validatorClient.ValidatorStatus(
-		context.Background(),
+		ctx,
 		&ethpb.ValidatorStatusRequest{
 			PublicKey: []byte{},
 		},
@@ -98,6 +104,7 @@ func TestMultipleValidatorStatus_Nominal(t *testing.T) {
 		"0x8000a6c975761b488bdb0dfba4ed37c0d97d6e6b968562ef5c84aa9a5dfb92d8e309195004e97709077723739bf04463", // existing
 	}
 
+	ctx := context.Background()
 	validatorsPubKey := make([][]byte, len(stringValidatorsPubKey))
 
 	for i, stringValidatorPubKey := range stringValidatorsPubKey {
@@ -112,6 +119,7 @@ func TestMultipleValidatorStatus_Nominal(t *testing.T) {
 	stateValidatorsProvider := mock.NewMockstateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().GetStateValidators(
+		ctx,
 		stringValidatorsPubKey,
 		nil,
 		nil,
@@ -160,7 +168,7 @@ func TestMultipleValidatorStatus_Nominal(t *testing.T) {
 	}
 
 	actualValidatorStatusResponse, err := validatorClient.MultipleValidatorStatus(
-		context.Background(),
+		ctx,
 		&ethpb.MultipleValidatorStatusRequest{
 			PublicKeys: validatorsPubKey,
 		},
@@ -173,9 +181,11 @@ func TestMultipleValidatorStatus_Error(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
 	stateValidatorsProvider := mock.NewMockstateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().GetStateValidators(
+		ctx,
 		gomock.Any(),
 		nil,
 		nil,
@@ -187,7 +197,7 @@ func TestMultipleValidatorStatus_Error(t *testing.T) {
 	validatorClient := beaconApiValidatorClient{stateValidatorsProvider: stateValidatorsProvider}
 
 	_, err := validatorClient.MultipleValidatorStatus(
-		context.Background(),
+		ctx,
 		&ethpb.MultipleValidatorStatusRequest{
 			PublicKeys: [][]byte{},
 		},
@@ -199,6 +209,7 @@ func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
 	stringValidatorsPubKey := []string{
 		"0x8000091c2ae64ee414a54c1cc1fc67dec663408bc636cb86756e0200e41a75c8f86603f104f02c856983d2783116be13", // existing
 		"0x8000a6c975761b488bdb0dfba4ed37c0d97d6e6b968562ef5c84aa9a5dfb92d8e309195004e97709077723739bf04463", // existing
@@ -226,6 +237,7 @@ func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) 
 	stateValidatorsProvider := mock.NewMockstateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().GetStateValidators(
+		ctx,
 		stringValidatorsPubKey,
 		validatorsIndex,
 		nil,
@@ -278,6 +290,7 @@ func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) 
 	).Times(1)
 
 	stateValidatorsProvider.EXPECT().GetStateValidators(
+		ctx,
 		nil,
 		nil,
 		[]string{"active"},
@@ -367,7 +380,7 @@ func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) 
 	}
 
 	validatorClient := beaconApiValidatorClient{stateValidatorsProvider: stateValidatorsProvider}
-	actualValidatorsPubKey, actualValidatorsIndex, actualValidatorsStatusResponse, err := validatorClient.getValidatorsStatusResponse(validatorsPubKey, validatorsIndex)
+	actualValidatorsPubKey, actualValidatorsIndex, actualValidatorsStatusResponse, err := validatorClient.getValidatorsStatusResponse(ctx, validatorsPubKey, validatorsIndex)
 
 	require.NoError(t, err)
 	assert.DeepEqual(t, wantedValidatorsPubKey, actualValidatorsPubKey)
@@ -383,9 +396,11 @@ func TestGetValidatorsStatusResponse_Nominal_NoActiveValidators(t *testing.T) {
 	validatorPubKey, err := hexutil.Decode(stringValidatorPubKey)
 	require.NoError(t, err)
 
+	ctx := context.Background()
 	stateValidatorsProvider := mock.NewMockstateValidatorsProvider(ctrl)
 
 	stateValidatorsProvider.EXPECT().GetStateValidators(
+		ctx,
 		[]string{stringValidatorPubKey},
 		nil,
 		nil,
@@ -406,6 +421,7 @@ func TestGetValidatorsStatusResponse_Nominal_NoActiveValidators(t *testing.T) {
 	).Times(1)
 
 	stateValidatorsProvider.EXPECT().GetStateValidators(
+		ctx,
 		nil,
 		nil,
 		[]string{"active"},
@@ -427,7 +443,7 @@ func TestGetValidatorsStatusResponse_Nominal_NoActiveValidators(t *testing.T) {
 	}
 
 	validatorClient := beaconApiValidatorClient{stateValidatorsProvider: stateValidatorsProvider}
-	actualValidatorsPubKey, actualValidatorsIndex, actualValidatorsStatusResponse, err := validatorClient.getValidatorsStatusResponse(wantedValidatorsPubKey, nil)
+	actualValidatorsPubKey, actualValidatorsIndex, actualValidatorsStatusResponse, err := validatorClient.getValidatorsStatusResponse(ctx, wantedValidatorsPubKey, nil)
 
 	require.NoError(t, err)
 	require.NoError(t, err)
@@ -672,10 +688,12 @@ func TestValidatorStatusResponse_InvalidData(t *testing.T) {
 				ctrl := gomock.NewController(t)
 				defer ctrl.Finish()
 
+				ctx := context.Background()
 				stateValidatorsProvider := mock.NewMockstateValidatorsProvider(ctrl)
 
 				for _, aa := range testCase.inputGetStateValidatorsInterfaces {
 					stateValidatorsProvider.EXPECT().GetStateValidators(
+						ctx,
 						aa.inputStringPubKeys,
 						aa.inputIndexes,
 						aa.inputStatuses,
@@ -688,6 +706,7 @@ func TestValidatorStatusResponse_InvalidData(t *testing.T) {
 				validatorClient := beaconApiValidatorClient{stateValidatorsProvider: stateValidatorsProvider}
 
 				_, _, _, err := validatorClient.getValidatorsStatusResponse(
+					ctx,
 					testCase.inputPubKeys,
 					testCase.inputIndexes,
 				)

--- a/validator/client/beacon-api/wait_for_chain_start_test.go
+++ b/validator/client/beacon-api/wait_for_chain_start_test.go
@@ -20,16 +20,18 @@ func TestWaitForChainStart_ValidGenesis(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
 	genesisResponseJson := rpcmiddleware.GenesisResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
 		nil,
 		nil,
 	).SetArg(
-		1,
+		2,
 		rpcmiddleware.GenesisResponseJson{
 			Data: &rpcmiddleware.GenesisResponse_GenesisJson{
 				GenesisTime:           "1234",
@@ -40,7 +42,7 @@ func TestWaitForChainStart_ValidGenesis(t *testing.T) {
 
 	genesisProvider := beaconApiGenesisProvider{jsonRestHandler: jsonRestHandler}
 	validatorClient := beaconApiValidatorClient{genesisProvider: genesisProvider}
-	resp, err := validatorClient.WaitForChainStart(context.Background(), &emptypb.Empty{})
+	resp, err := validatorClient.WaitForChainStart(ctx, &emptypb.Empty{})
 	assert.NoError(t, err)
 
 	require.NotNil(t, resp)
@@ -86,16 +88,18 @@ func TestWaitForChainStart_BadGenesis(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
+			ctx := context.Background()
 			genesisResponseJson := rpcmiddleware.GenesisResponseJson{}
 			jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 			jsonRestHandler.EXPECT().GetRestJsonResponse(
+				ctx,
 				"/eth/v1/beacon/genesis",
 				&genesisResponseJson,
 			).Return(
 				nil,
 				nil,
 			).SetArg(
-				1,
+				2,
 				rpcmiddleware.GenesisResponseJson{
 					Data: testCase.data,
 				},
@@ -103,7 +107,7 @@ func TestWaitForChainStart_BadGenesis(t *testing.T) {
 
 			genesisProvider := beaconApiGenesisProvider{jsonRestHandler: jsonRestHandler}
 			validatorClient := beaconApiValidatorClient{genesisProvider: genesisProvider}
-			_, err := validatorClient.WaitForChainStart(context.Background(), &emptypb.Empty{})
+			_, err := validatorClient.WaitForChainStart(ctx, &emptypb.Empty{})
 			assert.ErrorContains(t, testCase.errorMessage, err)
 		})
 	}
@@ -113,9 +117,11 @@ func TestWaitForChainStart_JsonResponseError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
 	genesisResponseJson := rpcmiddleware.GenesisResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
@@ -125,7 +131,7 @@ func TestWaitForChainStart_JsonResponseError(t *testing.T) {
 
 	genesisProvider := beaconApiGenesisProvider{jsonRestHandler: jsonRestHandler}
 	validatorClient := beaconApiValidatorClient{genesisProvider: genesisProvider}
-	_, err := validatorClient.WaitForChainStart(context.Background(), &emptypb.Empty{})
+	_, err := validatorClient.WaitForChainStart(ctx, &emptypb.Empty{})
 	assert.ErrorContains(t, "failed to get genesis data", err)
 	assert.ErrorContains(t, "some specific json error", err)
 }
@@ -135,11 +141,13 @@ func TestWaitForChainStart_JsonResponseError404(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	ctx := context.Background()
 	genesisResponseJson := rpcmiddleware.GenesisResponseJson{}
 	jsonRestHandler := mock.NewMockjsonRestHandler(ctrl)
 
 	// First, mock a request that receives a 404 error (which means that the genesis data is not available yet)
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
@@ -152,13 +160,14 @@ func TestWaitForChainStart_JsonResponseError404(t *testing.T) {
 
 	// After receiving a 404 error, mock a request that actually has genesis data available
 	jsonRestHandler.EXPECT().GetRestJsonResponse(
+		ctx,
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
 		nil,
 		nil,
 	).SetArg(
-		1,
+		2,
 		rpcmiddleware.GenesisResponseJson{
 			Data: &rpcmiddleware.GenesisResponse_GenesisJson{
 				GenesisTime:           "1234",
@@ -169,7 +178,7 @@ func TestWaitForChainStart_JsonResponseError404(t *testing.T) {
 
 	genesisProvider := beaconApiGenesisProvider{jsonRestHandler: jsonRestHandler}
 	validatorClient := beaconApiValidatorClient{genesisProvider: genesisProvider}
-	resp, err := validatorClient.WaitForChainStart(context.Background(), &emptypb.Empty{})
+	resp, err := validatorClient.WaitForChainStart(ctx, &emptypb.Empty{})
 	assert.NoError(t, err)
 
 	require.NotNil(t, resp)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This PR adds context as first parameter to REST implementation of beacon API endpoints. It is needed to make all of our http requests to be context-aware, so that library code can take appropriate cleanup steps when the upstream context is canceled.

**Other notes for review**
This is achieved by adding `ctx context.Context` as first parameter to `jsonRestHandler` interface methods in `validator/client/beacon-api/json_rest_handler.go`.
