### PR TITLE
Better reconstruct error msg while EL client is syncing

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -86,6 +86,8 @@ type EngineCaller interface {
 	GetTerminalBlockHash(ctx context.Context, transitionTime uint64) ([]byte, bool, error)
 }
 
+var EmptyBlockHash = errors.New("Block hash is empty 0x0000...")
+
 // NewPayload calls the engine_newPayloadVX method via JSON-RPC.
 func (s *Service) NewPayload(ctx context.Context, payload interfaces.ExecutionData) ([]byte, error) {
 	ctx, span := trace.StartSpan(ctx, "powchain.engine-api-client.NewPayload")
@@ -471,6 +473,10 @@ func (s *Service) ReconstructFullBlock(
 	if executionBlock == nil {
 		return nil, fmt.Errorf("received nil execution block for request by hash %#x", executionBlockHash)
 	}
+	if bytes.Equal(executionBlock.Hash.Bytes(), []byte{}) {
+		return nil, EmptyBlockHash
+	}
+
 	executionBlock.Version = blindedBlock.Version()
 	payload, err := fullPayloadFromExecutionBlock(header, executionBlock)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Code health error improvement

**What does this PR do? Why is it needed?**

```
[2023-01-07 19:36:02] ERROR sync: Could not get reconstruct full bellatrix block from blinded body error=block hash field in execution header 0x21295832b07679e17f9c3e2ed8edafae28ac15deeac6cdcb8e0ddc68526c2b0d does not match execution block hash 0x0000000000000000000000000000000000000000000000000000000000000000 handler=beacon_blocks_by_root
```

👇🏼 

```
[2023-01-08 08:44:36]  WARN sync: Could not reconstruct block from header with syncing execution client. Waiting to complete syncing error=Block hash is empty 0x0000... handler=beacon_blocks_by_root
```

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
