### PR TITLE
Replay state to current slot in `StateBySlot`

### DIFF
--- a/beacon-chain/rpc/statefetcher/fetcher.go
+++ b/beacon-chain/rpc/statefetcher/fetcher.go
@@ -203,9 +203,6 @@ func (p *StateProvider) StateBySlot(ctx context.Context, target types.Slot) (sta
 	if target > p.GenesisTimeFetcher.CurrentSlot() {
 		return nil, errors.New("requested slot is in the future")
 	}
-	if target > p.ChainInfoFetcher.HeadSlot() {
-		return nil, errors.New("requested slot number is higher than head slot number")
-	}
 
 	st, err := p.ReplayerBuilder.ReplayerForSlot(target).ReplayBlocks(ctx)
 	if err != nil {

--- a/beacon-chain/rpc/statefetcher/fetcher_test.go
+++ b/beacon-chain/rpc/statefetcher/fetcher_test.go
@@ -387,11 +387,16 @@ func TestStateBySlot_FutureSlot(t *testing.T) {
 }
 
 func TestStateBySlot_AfterHeadSlot(t *testing.T) {
-	st, err := statenative.InitializeFromProtoPhase0(&ethpb.BeaconState{Slot: 100})
+	headSt, err := statenative.InitializeFromProtoPhase0(&ethpb.BeaconState{Slot: 100})
+	require.NoError(t, err)
+	slotSt, err := statenative.InitializeFromProtoPhase0(&ethpb.BeaconState{Slot: 101})
 	require.NoError(t, err)
 	currentSlot := types.Slot(102)
-	mock := &chainMock.ChainService{State: st, Slot: &currentSlot}
-	p := StateProvider{ChainInfoFetcher: mock, GenesisTimeFetcher: mock}
-	_, err = p.StateBySlot(context.Background(), 101)
-	assert.ErrorContains(t, "requested slot number is higher than head slot number", err)
+	mock := &chainMock.ChainService{State: headSt, Slot: &currentSlot}
+	mockReplayer := mockstategen.NewMockReplayerBuilder()
+	mockReplayer.SetMockStateForSlot(slotSt, 101)
+	p := StateProvider{ChainInfoFetcher: mock, GenesisTimeFetcher: mock, ReplayerBuilder: mockReplayer}
+	st, err := p.StateBySlot(context.Background(), 101)
+	require.NoError(t, err)
+	assert.Equal(t, types.Slot(101), st.Slot())
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The following error is observed in Lighthouse validator's logs during multi-client e2e:
```
Could not get state: requested slot number is higher than head slot number
```

This happens when there are skipped slots between head state slot and current slot. When fetching state by slot we should replay the state up to the current slot instead of returning an error.
