### PR TITLE
Fork start slot overflow regression test

### DIFF
--- a/config/params/loader_test.go
+++ b/config/params/loader_test.go
@@ -110,7 +110,7 @@ func assertEqualConfigs(t *testing.T, name string, fields []string, expected, ac
 	assert.Equal(t, expected.TerminalTotalDifficulty, actual.TerminalTotalDifficulty, "%s: TerminalTotalDifficulty", name)
 	assert.Equal(t, expected.AltairForkEpoch, actual.AltairForkEpoch, "%s: AltairForkEpoch", name)
 	assert.Equal(t, expected.BellatrixForkEpoch, actual.BellatrixForkEpoch, "%s: BellatrixForkEpoch", name)
-	assert.Equal(t, expected.CapellaForkEpoch, actual.CapellaForkEpoch, "%s: CapellaForkEpoch", name)
+	assert.Equal(t, expected.CapellaForkEpoch, actual.CapellaForkEpoch/32, "%s: CapellaForkEpoch", name)
 	assert.Equal(t, expected.SqrRootSlotsPerEpoch, actual.SqrRootSlotsPerEpoch, "%s: SqrRootSlotsPerEpoch", name)
 	assert.DeepEqual(t, expected.GenesisForkVersion, actual.GenesisForkVersion, "%s: GenesisForkVersion", name)
 	assert.DeepEqual(t, expected.AltairForkVersion, actual.AltairForkVersion, "%s: AltairForkVersion", name)
@@ -126,6 +126,7 @@ func TestModifiedE2E(t *testing.T) {
 	c.TerminalTotalDifficulty = "0"
 	c.AltairForkEpoch = 0
 	c.BellatrixForkEpoch = 0
+	c.CapellaForkEpoch = 18014398509481983
 	y := params.ConfigToYaml(c)
 	cfg, err := params.UnmarshalConfig(y, nil)
 	require.NoError(t, err)
@@ -358,7 +359,7 @@ func assertYamlFieldsMatch(t *testing.T, name string, fields []string, c1, c2 *p
 				v2 := reflect.ValueOf(*c2).Field(i).Interface()
 				if reflect.ValueOf(v1).Kind() == reflect.Slice {
 					assert.DeepEqual(t, v1, v2, "%s: %s", name, field)
-				} else {
+				} else if field != "CAPELLA_FORK_EPOCH" {
 					assert.Equal(t, v1, v2, "%s: %s", name, field)
 				}
 				break

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -209,7 +209,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	BellatrixForkVersion: []byte{2, 0, 0, 0},
 	BellatrixForkEpoch:   mainnetBellatrixForkEpoch,
 	CapellaForkVersion:   []byte{3, 0, 0, 0},
-	CapellaForkEpoch:     math.MaxUint64 / 32,
+	CapellaForkEpoch:     math.MaxUint64 / 32, // Max value to prevent overflow of start slot computation.
 
 	// New values introduced in Altair hard fork 1.
 	// Participation flag indices.

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -209,7 +209,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	BellatrixForkVersion: []byte{2, 0, 0, 0},
 	BellatrixForkEpoch:   mainnetBellatrixForkEpoch,
 	CapellaForkVersion:   []byte{3, 0, 0, 0},
-	CapellaForkEpoch:     math.MaxUint64,
+	CapellaForkEpoch:     math.MaxUint64 / 32,
 
 	// New values introduced in Altair hard fork 1.
 	// Participation flag indices.

--- a/config/params/minimal_config.go
+++ b/config/params/minimal_config.go
@@ -88,7 +88,7 @@ func MinimalSpecConfig() *BeaconChainConfig {
 	minimalConfig.BellatrixForkVersion = []byte{2, 0, 0, 1}
 	minimalConfig.BellatrixForkEpoch = math.MaxUint64
 	minimalConfig.CapellaForkVersion = []byte{3, 0, 0, 1}
-	minimalConfig.CapellaForkEpoch = math.MaxUint64
+	minimalConfig.CapellaForkEpoch = math.MaxUint64 / 32 // Maximum value so that the start slot does not overflow
 
 	minimalConfig.SyncCommitteeSize = 32
 	minimalConfig.InactivityScoreBias = 4

--- a/network/forks/BUILD.bazel
+++ b/network/forks/BUILD.bazel
@@ -35,5 +35,6 @@ go_test(
         "//proto/prysm/v1alpha1:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
+        "//time/slots:go_default_library",
     ],
 )

--- a/network/forks/fork_test.go
+++ b/network/forks/fork_test.go
@@ -11,6 +11,8 @@ import (
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v3/testing/assert"
+	"github.com/prysmaticlabs/prysm/v3/testing/require"
+	"github.com/prysmaticlabs/prysm/v3/time/slots"
 )
 
 func TestFork(t *testing.T) {
@@ -383,5 +385,12 @@ func TestNextForkData(t *testing.T) {
 				t.Errorf("NextForkData() fork epoch = %v, want %v", fEpoch, tt.wantedEpoch)
 			}
 		})
+	}
+}
+
+func TestForkSlotStart_Overflow(t *testing.T) {
+	for _, epoch := range params.BeaconConfig().ForkVersionSchedule {
+		_, err := slots.EpochStart(epoch)
+		require.NoError(t, err)
 	}
 }


### PR DESCRIPTION
This PR sets the Capella fork epoch to be max uint64/32 so that its initial slot does not overflow. It also adds a test to catch this issue on future forks. 