### PR TITLE
Do not log an overflow computing Capella's slot start

### DIFF
--- a/beacon-chain/sync/broadcast_bls_changes.go
+++ b/beacon-chain/sync/broadcast_bls_changes.go
@@ -11,7 +11,8 @@ import (
 func (s *Service) broadcastBLSChanges(currSlot types.Slot) error {
 	capellaSlotStart, err := slots.EpochStart(params.BeaconConfig().CapellaForkEpoch)
 	if err != nil {
-		return errors.Wrap(err, "unable to compute Capella slot start")
+		// only possible error is an overflow
+		return nil
 	}
 	if currSlot == capellaSlotStart {
 		changes, err := s.cfg.blsToExecPool.PendingBLSToExecChanges()


### PR DESCRIPTION
There's an overflow when computing Capella's slot start due to the temporary fork epoch being set at max uint64