### PR TITLE
Refactor BLS change pool

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -557,22 +557,6 @@ func (s *Service) handleBlockAttestations(ctx context.Context, blk interfaces.Be
 	return nil
 }
 
-func (s *Service) handleBlockBLSToExecChanges(blk interfaces.BeaconBlock) error {
-	if blk.Version() < version.Capella {
-		return nil
-	}
-	changes, err := blk.Body().BLSToExecutionChanges()
-	if err != nil {
-		return errors.Wrap(err, "could not get BLSToExecutionChanges")
-	}
-	for _, change := range changes {
-		if err := s.cfg.BLSToExecPool.MarkIncluded(change); err != nil {
-			return errors.Wrap(err, "could not mark BLSToExecutionChange as included")
-		}
-	}
-	return nil
-}
-
 // InsertSlashingsToForkChoiceStore inserts attester slashing indices to fork choice store.
 // To call this function, it's caller's responsibility to ensure the slashing object is valid.
 func (s *Service) InsertSlashingsToForkChoiceStore(ctx context.Context, slashings []*ethpb.AttesterSlashing) {

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -26,7 +26,6 @@ import (
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice/doubly-linked-tree"
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice/types"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/attestations"
-	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/blstoexec"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stategen"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
@@ -2303,65 +2302,6 @@ func TestFillMissingBlockPayloadId_DiffSlotExitEarly(t *testing.T) {
 	service, err := NewService(ctx, opts...)
 	require.NoError(t, err)
 	require.NoError(t, service.fillMissingBlockPayloadId(ctx, time.Unix(int64(params.BeaconConfig().SecondsPerSlot/2), 0)))
-}
-
-func TestHandleBBlockBLSToExecutionChanges(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-	fc := doublylinkedtree.New()
-	pool := blstoexec.NewPool()
-	opts := []Option{
-		WithDatabase(beaconDB),
-		WithStateGen(stategen.New(beaconDB, fc)),
-		WithForkChoiceStore(fc),
-		WithStateNotifier(&mock.MockStateNotifier{}),
-		WithBLSToExecPool(pool),
-	}
-	service, err := NewService(ctx, opts...)
-	require.NoError(t, err)
-
-	t.Run("pre Capella block", func(t *testing.T) {
-		body := &ethpb.BeaconBlockBodyBellatrix{}
-		pbb := &ethpb.BeaconBlockBellatrix{
-			Body: body,
-		}
-		blk, err := consensusblocks.NewBeaconBlock(pbb)
-		require.NoError(t, err)
-		require.NoError(t, service.handleBlockBLSToExecChanges(blk))
-	})
-
-	t.Run("Post Capella no changes", func(t *testing.T) {
-		body := &ethpb.BeaconBlockBodyCapella{}
-		pbb := &ethpb.BeaconBlockCapella{
-			Body: body,
-		}
-		blk, err := consensusblocks.NewBeaconBlock(pbb)
-		require.NoError(t, err)
-		require.NoError(t, service.handleBlockBLSToExecChanges(blk))
-	})
-
-	t.Run("Post Capella some changes", func(t *testing.T) {
-		idx := types.ValidatorIndex(123)
-		change := &ethpb.BLSToExecutionChange{
-			ValidatorIndex: idx,
-		}
-		signedChange := &ethpb.SignedBLSToExecutionChange{
-			Message: change,
-		}
-		body := &ethpb.BeaconBlockBodyCapella{
-			BlsToExecutionChanges: []*ethpb.SignedBLSToExecutionChange{signedChange},
-		}
-		pbb := &ethpb.BeaconBlockCapella{
-			Body: body,
-		}
-		blk, err := consensusblocks.NewBeaconBlock(pbb)
-		require.NoError(t, err)
-
-		pool.InsertBLSToExecChange(signedChange)
-		require.Equal(t, true, pool.ValidatorExists(idx))
-		require.NoError(t, service.handleBlockBLSToExecChanges(blk))
-		require.Equal(t, false, pool.ValidatorExists(idx))
-	})
 }
 
 // Helper function to simulate the block being on time or delayed for proposer

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -172,9 +172,7 @@ func (s *Service) handleBlockBLSToExecChanges(blk interfaces.BeaconBlock) error 
 		return errors.Wrap(err, "could not get BLSToExecutionChanges")
 	}
 	for _, change := range changes {
-		if err := s.cfg.BLSToExecPool.MarkIncluded(change); err != nil {
-			return errors.Wrap(err, "could not mark BLSToExecutionChange as included")
-		}
+		s.cfg.BLSToExecPool.MarkIncluded(change)
 	}
 	return nil
 }

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -10,6 +10,7 @@ import (
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/monitoring/tracing"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v3/runtime/version"
 	"github.com/prysmaticlabs/prysm/v3/time"
 	"github.com/prysmaticlabs/prysm/v3/time/slots"
 	"go.opencensus.io/trace"
@@ -150,9 +151,30 @@ func (s *Service) handlePostBlockOperations(b interfaces.BeaconBlock) error {
 		s.cfg.ExitPool.MarkIncluded(e)
 	}
 
+	// Mark block BLS changes as seen so we don't include same ones in future blocks.
+	if err := s.handleBlockBLSToExecChanges(b); err != nil {
+		return errors.Wrap(err, "could not process BLSToExecutionChanges")
+	}
+
 	//  Mark attester slashings as seen so we don't include same ones in future blocks.
 	for _, as := range b.Body().AttesterSlashings() {
 		s.cfg.SlashingPool.MarkIncludedAttesterSlashing(as)
+	}
+	return nil
+}
+
+func (s *Service) handleBlockBLSToExecChanges(blk interfaces.BeaconBlock) error {
+	if blk.Version() < version.Capella {
+		return nil
+	}
+	changes, err := blk.Body().BLSToExecutionChanges()
+	if err != nil {
+		return errors.Wrap(err, "could not get BLSToExecutionChanges")
+	}
+	for _, change := range changes {
+		if err := s.cfg.BLSToExecPool.MarkIncluded(change); err != nil {
+			return errors.Wrap(err, "could not mark BLSToExecutionChange as included")
+		}
 	}
 	return nil
 }

--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -10,6 +10,7 @@ import (
 	testDB "github.com/prysmaticlabs/prysm/v3/beacon-chain/db/testing"
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice/doubly-linked-tree"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/attestations"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/blstoexec"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/voluntaryexits"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stategen"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
@@ -331,4 +332,63 @@ func TestCheckSaveHotStateDB_Overflow(t *testing.T) {
 
 	require.NoError(t, s.checkSaveHotStateDB(context.Background()))
 	assert.LogsDoNotContain(t, hook, "Entering mode to save hot states in DB")
+}
+
+func TestHandleBlockBLSToExecutionChanges(t *testing.T) {
+	ctx := context.Background()
+	beaconDB := testDB.SetupDB(t)
+	fc := doublylinkedtree.New()
+	pool := blstoexec.NewPool()
+	opts := []Option{
+		WithDatabase(beaconDB),
+		WithStateGen(stategen.New(beaconDB, fc)),
+		WithForkChoiceStore(fc),
+		WithStateNotifier(&blockchainTesting.MockStateNotifier{}),
+		WithBLSToExecPool(pool),
+	}
+	service, err := NewService(ctx, opts...)
+	require.NoError(t, err)
+
+	t.Run("pre Capella block", func(t *testing.T) {
+		body := &ethpb.BeaconBlockBodyBellatrix{}
+		pbb := &ethpb.BeaconBlockBellatrix{
+			Body: body,
+		}
+		blk, err := blocks.NewBeaconBlock(pbb)
+		require.NoError(t, err)
+		require.NoError(t, service.handleBlockBLSToExecChanges(blk))
+	})
+
+	t.Run("Post Capella no changes", func(t *testing.T) {
+		body := &ethpb.BeaconBlockBodyCapella{}
+		pbb := &ethpb.BeaconBlockCapella{
+			Body: body,
+		}
+		blk, err := blocks.NewBeaconBlock(pbb)
+		require.NoError(t, err)
+		require.NoError(t, service.handleBlockBLSToExecChanges(blk))
+	})
+
+	t.Run("Post Capella some changes", func(t *testing.T) {
+		idx := types.ValidatorIndex(123)
+		change := &ethpb.BLSToExecutionChange{
+			ValidatorIndex: idx,
+		}
+		signedChange := &ethpb.SignedBLSToExecutionChange{
+			Message: change,
+		}
+		body := &ethpb.BeaconBlockBodyCapella{
+			BlsToExecutionChanges: []*ethpb.SignedBLSToExecutionChange{signedChange},
+		}
+		pbb := &ethpb.BeaconBlockCapella{
+			Body: body,
+		}
+		blk, err := blocks.NewBeaconBlock(pbb)
+		require.NoError(t, err)
+
+		pool.InsertBLSToExecChange(signedChange)
+		require.Equal(t, true, pool.ValidatorExists(idx))
+		require.NoError(t, service.handleBlockBLSToExecChanges(blk))
+		require.Equal(t, false, pool.ValidatorExists(idx))
+	})
 }

--- a/beacon-chain/operations/blstoexec/BUILD.bazel
+++ b/beacon-chain/operations/blstoexec/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//container/doubly-linked-list:go_default_library",
         "//crypto/bls/blst:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
-        "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/beacon-chain/operations/blstoexec/mock/mock.go
+++ b/beacon-chain/operations/blstoexec/mock/mock.go
@@ -17,7 +17,7 @@ func (m *PoolMock) PendingBLSToExecChanges() ([]*eth.SignedBLSToExecutionChange,
 }
 
 // BLSToExecChangesForInclusion --
-func (m *PoolMock) BLSToExecChangesForInclusion(_ state.BeaconState) ([]*eth.SignedBLSToExecutionChange, error) {
+func (m *PoolMock) BLSToExecChangesForInclusion(_ state.ReadOnlyBeaconState) ([]*eth.SignedBLSToExecutionChange, error) {
 	return m.Changes, nil
 }
 

--- a/beacon-chain/operations/blstoexec/mock/mock.go
+++ b/beacon-chain/operations/blstoexec/mock/mock.go
@@ -27,7 +27,7 @@ func (m *PoolMock) InsertBLSToExecChange(change *eth.SignedBLSToExecutionChange)
 }
 
 // MarkIncluded --
-func (*PoolMock) MarkIncluded(_ *eth.SignedBLSToExecutionChange) error {
+func (*PoolMock) MarkIncluded(_ *eth.SignedBLSToExecutionChange) {
 	panic("implement me")
 }
 

--- a/beacon-chain/operations/blstoexec/pool_test.go
+++ b/beacon-chain/operations/blstoexec/pool_test.go
@@ -237,7 +237,7 @@ func TestMarkIncluded(t *testing.T) {
 				ValidatorIndex: types.ValidatorIndex(0),
 			}}
 		pool.InsertBLSToExecChange(change)
-		require.NoError(t, pool.MarkIncluded(change))
+		pool.MarkIncluded(change)
 		assert.Equal(t, 0, pool.pending.Len())
 		_, ok := pool.m[0]
 		assert.Equal(t, false, ok)
@@ -259,7 +259,7 @@ func TestMarkIncluded(t *testing.T) {
 		pool.InsertBLSToExecChange(first)
 		pool.InsertBLSToExecChange(second)
 		pool.InsertBLSToExecChange(third)
-		require.NoError(t, pool.MarkIncluded(first))
+		pool.MarkIncluded(first)
 		require.Equal(t, 2, pool.pending.Len())
 		_, ok := pool.m[0]
 		assert.Equal(t, false, ok)
@@ -281,7 +281,7 @@ func TestMarkIncluded(t *testing.T) {
 		pool.InsertBLSToExecChange(first)
 		pool.InsertBLSToExecChange(second)
 		pool.InsertBLSToExecChange(third)
-		require.NoError(t, pool.MarkIncluded(third))
+		pool.MarkIncluded(third)
 		require.Equal(t, 2, pool.pending.Len())
 		_, ok := pool.m[2]
 		assert.Equal(t, false, ok)
@@ -303,7 +303,7 @@ func TestMarkIncluded(t *testing.T) {
 		pool.InsertBLSToExecChange(first)
 		pool.InsertBLSToExecChange(second)
 		pool.InsertBLSToExecChange(third)
-		require.NoError(t, pool.MarkIncluded(second))
+		pool.MarkIncluded(second)
 		require.Equal(t, 2, pool.pending.Len())
 		_, ok := pool.m[1]
 		assert.Equal(t, false, ok)
@@ -324,7 +324,7 @@ func TestMarkIncluded(t *testing.T) {
 			}}
 		pool.InsertBLSToExecChange(first)
 		pool.InsertBLSToExecChange(second)
-		require.NoError(t, pool.MarkIncluded(change))
+		pool.MarkIncluded(change)
 		require.Equal(t, 2, pool.pending.Len())
 		_, ok := pool.m[0]
 		require.Equal(t, true, ok)
@@ -378,7 +378,7 @@ func TestValidatorExists(t *testing.T) {
 				ValidatorIndex: types.ValidatorIndex(0),
 			}}
 		pool.InsertBLSToExecChange(change)
-		require.NoError(t, pool.MarkIncluded(change))
+		pool.MarkIncluded(change)
 		assert.Equal(t, false, pool.ValidatorExists(0))
 	})
 	t.Run("multiple validators added to pool and removed", func(t *testing.T) {
@@ -399,8 +399,8 @@ func TestValidatorExists(t *testing.T) {
 			}}
 		pool.InsertBLSToExecChange(thirdChange)
 
-		assert.NoError(t, pool.MarkIncluded(firstChange))
-		assert.NoError(t, pool.MarkIncluded(thirdChange))
+		pool.MarkIncluded(firstChange)
+		pool.MarkIncluded(thirdChange)
 
 		assert.Equal(t, false, pool.ValidatorExists(0))
 		assert.Equal(t, true, pool.ValidatorExists(10))


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

- move `handleBlockBLSToExecChanges` to `handlePostBlockOperations`, next to exit handling
- small fixes to the pool itself
