### PR TITLE
Use LIFO instead of FIFO when packing BLS changes

### DIFF
--- a/beacon-chain/operations/blstoexec/pool.go
+++ b/beacon-chain/operations/blstoexec/pool.go
@@ -67,7 +67,7 @@ func (p *Pool) BLSToExecChangesForInclusion(st state.BeaconState) ([]*ethpb.Sign
 	p.lock.RLock()
 	length := int(math.Min(float64(params.BeaconConfig().MaxBlsToExecutionChanges), float64(p.pending.Len())))
 	result := make([]*ethpb.SignedBLSToExecutionChange, 0, length)
-	node := p.pending.First()
+	node := p.pending.Last()
 	for node != nil && len(result) < length {
 		change, err := node.Value()
 		if err != nil {
@@ -86,7 +86,7 @@ func (p *Pool) BLSToExecChangesForInclusion(st state.BeaconState) ([]*ethpb.Sign
 		} else {
 			result = append(result, change)
 		}
-		node, err = node.Next()
+		node, err = node.Prev()
 		if err != nil {
 			p.lock.RUnlock()
 			return nil, err

--- a/beacon-chain/operations/blstoexec/pool_test.go
+++ b/beacon-chain/operations/blstoexec/pool_test.go
@@ -130,7 +130,7 @@ func TestBLSToExecChangesForInclusion(t *testing.T) {
 		// We want FIFO semantics, which means validator with index 16 shouldn't be returned
 		assert.Equal(t, int(params.BeaconConfig().MaxBlsToExecutionChanges), len(changes))
 		for _, ch := range changes {
-			assert.NotEqual(t, types.ValidatorIndex(16), ch.Message.ValidatorIndex)
+			assert.NotEqual(t, types.ValidatorIndex(15), ch.Message.ValidatorIndex)
 		}
 	})
 	t.Run("One Bad change", func(t *testing.T) {
@@ -143,19 +143,19 @@ func TestBLSToExecChangesForInclusion(t *testing.T) {
 		changes, err := pool.BLSToExecChangesForInclusion(st)
 		require.NoError(t, err)
 		assert.Equal(t, int(params.BeaconConfig().MaxBlsToExecutionChanges), len(changes))
-		assert.Equal(t, types.ValidatorIndex(2), changes[1].Message.ValidatorIndex)
+		assert.Equal(t, types.ValidatorIndex(30), changes[1].Message.ValidatorIndex)
 		signedChanges[1].Message.FromBlsPubkey[5] = saveByte
 	})
 	t.Run("One Bad Signature", func(t *testing.T) {
 		pool := NewPool()
-		copy(signedChanges[1].Signature, signedChanges[2].Signature)
+		copy(signedChanges[30].Signature, signedChanges[31].Signature)
 		for i := uint64(0); i < numValidators; i++ {
 			pool.InsertBLSToExecChange(signedChanges[i])
 		}
 		changes, err := pool.BLSToExecChangesForInclusion(st)
 		require.NoError(t, err)
 		assert.Equal(t, int(params.BeaconConfig().MaxBlsToExecutionChanges)-1, len(changes))
-		assert.Equal(t, types.ValidatorIndex(2), changes[1].Message.ValidatorIndex)
+		assert.Equal(t, types.ValidatorIndex(29), changes[1].Message.ValidatorIndex)
 	})
 }
 


### PR DESCRIPTION
See this discussion for context: 

https://discord.com/channels/595666850260713488/892088344438255616/1065818533403037806

TL;DR: this encourages users with uncompromized keys to not flood at the fork boundary