### PR TITLE
Return error structures from bls changes endpoint

### DIFF
--- a/beacon-chain/rpc/apimiddleware/endpoint_factory.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory.go
@@ -166,6 +166,7 @@ func (_ *BeaconEndpointFactory) Create(path string) (*apimiddleware.Endpoint, er
 	case "/eth/v1/beacon/pool/bls_to_execution_changes":
 		endpoint.PostRequest = &SubmitBLSToExecutionChangesRequest{}
 		endpoint.GetResponse = &BLSToExecutionChangesPoolResponseJson{}
+		endpoint.Err = &IndexedVerificationFailureErrorJson{}
 		endpoint.Hooks = apimiddleware.HookCollection{
 			OnPreDeserializeRequestBodyIntoContainer: wrapBLSChangesArray,
 		}


### PR DESCRIPTION
Return correct JSON structure when erroring sending BLS changes. 

credit to @james-prysm for finding this one out. 