### PR TITLE
save genesis state to hot cache and do not look it up from disk

### DIFF
--- a/beacon-chain/blockchain/chain_info_norace_test.go
+++ b/beacon-chain/blockchain/chain_info_norace_test.go
@@ -8,6 +8,7 @@ import (
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice/doubly-linked-tree"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stategen"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
+	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
 	"github.com/prysmaticlabs/prysm/v3/testing/util"
@@ -81,6 +82,9 @@ func TestHeadState_DataRace(t *testing.T) {
 	require.NoError(t, err)
 	wait := make(chan struct{})
 	st, _ := util.DeterministicGenesisState(t, 1)
+	root := bytesutil.ToBytes32(bytesutil.PadTo([]byte{'s'}, 32))
+	require.NoError(t, beaconDB.SaveGenesisBlockRoot(context.Background(), root))
+	require.NoError(t, beaconDB.SaveState(context.Background(), st, root))
 	go func() {
 		defer close(wait)
 		require.NoError(t, s.saveHead(context.Background(), [32]byte{}, b, st))

--- a/beacon-chain/blockchain/head_sync_committee_info_test.go
+++ b/beacon-chain/blockchain/head_sync_committee_info_test.go
@@ -6,51 +6,12 @@ import (
 
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/signing"
-	dbtest "github.com/prysmaticlabs/prysm/v3/beacon-chain/db/testing"
-	doublylinkedtree "github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice/doubly-linked-tree"
-	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stategen"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
 	"github.com/prysmaticlabs/prysm/v3/testing/util"
 	"github.com/prysmaticlabs/prysm/v3/time/slots"
 )
-
-func TestService_headSyncCommitteeFetcher_Errors(t *testing.T) {
-	beaconDB := dbtest.SetupDB(t)
-	c := &Service{
-		cfg: &config{
-			StateGen: stategen.New(beaconDB, doublylinkedtree.New()),
-		},
-	}
-	c.head = &head{}
-	_, err := c.headCurrentSyncCommitteeIndices(context.Background(), types.ValidatorIndex(0), types.Slot(0))
-	require.ErrorContains(t, "nil state", err)
-
-	_, err = c.headNextSyncCommitteeIndices(context.Background(), types.ValidatorIndex(0), types.Slot(0))
-	require.ErrorContains(t, "nil state", err)
-
-	_, err = c.HeadSyncCommitteePubKeys(context.Background(), types.Slot(0), types.CommitteeIndex(0))
-	require.ErrorContains(t, "nil state", err)
-}
-
-func TestService_HeadDomainFetcher_Errors(t *testing.T) {
-	beaconDB := dbtest.SetupDB(t)
-	c := &Service{
-		cfg: &config{
-			StateGen: stategen.New(beaconDB, doublylinkedtree.New()),
-		},
-	}
-	c.head = &head{}
-	_, err := c.HeadSyncCommitteeDomain(context.Background(), types.Slot(0))
-	require.ErrorContains(t, "nil state", err)
-
-	_, err = c.HeadSyncSelectionProofDomain(context.Background(), types.Slot(0))
-	require.ErrorContains(t, "nil state", err)
-
-	_, err = c.HeadSyncSelectionProofDomain(context.Background(), types.Slot(0))
-	require.ErrorContains(t, "nil state", err)
-}
 
 func TestService_HeadSyncCommitteeIndices(t *testing.T) {
 	s, _ := util.DeterministicGenesisStateAltair(t, params.BeaconConfig().TargetCommitteeSize)

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -56,7 +56,11 @@ func (s *State) StateByRoot(ctx context.Context, blockRoot [32]byte) (state.Beac
 
 	// Genesis case. If block root is zero hash, short circuit to use genesis state stored in DB.
 	if blockRoot == params.BeaconConfig().ZeroHash {
-		return s.beaconDB.GenesisState(ctx)
+		root, err := s.beaconDB.GenesisBlockRoot(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get genesis block root")
+		}
+		blockRoot = root
 	}
 	return s.loadStateByRoot(ctx, blockRoot)
 }

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -117,6 +117,7 @@ func (s *State) Resume(ctx context.Context, fState state.BeaconState) (state.Bea
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get genesis state")
 		}
+		// Save genesis state in the hot state cache.
 		gbr, err := s.beaconDB.GenesisBlockRoot(ctx)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get genesis block root")

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -5,9 +5,9 @@ package stategen
 
 import (
 	"context"
-	"errors"
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
@@ -113,7 +113,15 @@ func (s *State) Resume(ctx context.Context, fState state.BeaconState) (state.Bea
 	fRoot := bytesutil.ToBytes32(c.Root)
 	// Resume as genesis state if last finalized root is zero hashes.
 	if fRoot == params.BeaconConfig().ZeroHash {
-		return s.beaconDB.GenesisState(ctx)
+		st, err := s.beaconDB.GenesisState(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get genesis state")
+		}
+		gbr, err := s.beaconDB.GenesisBlockRoot(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get genesis block root")
+		}
+		return st, s.SaveState(ctx, gbr, st)
 	}
 
 	if fState == nil || fState.IsNil() {


### PR DESCRIPTION
Credit to @nisdas for finding this issue and to @kasey for solving it

Only lookup genesis root and then use the cache