### PR TITLE
sync: Fix BlobsSidecarByRange rate limiting

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue_test.go
+++ b/beacon-chain/sync/pending_blocks_queue_test.go
@@ -81,7 +81,7 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks1(t *testing.T) {
 	// Add b2 to the cache
 	wsb, err := blocks.NewSignedBeaconBlock(b2)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root, nil))
 
 	require.NoError(t, r.processPendingBlocks(context.Background()))
 	assert.Equal(t, 1, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
@@ -90,7 +90,7 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks1(t *testing.T) {
 	// Add b1 to the cache
 	wsb, err = blocks.NewSignedBeaconBlock(b1)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1Root, nil))
 	util.SaveBlock(t, context.Background(), r.cfg.beaconDB, b1)
 
 	nBlock := util.NewBeaconBlock()
@@ -101,7 +101,7 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks1(t *testing.T) {
 	// Insert bad b1 in the cache to verify the good one doesn't get replaced.
 	wsb, err = blocks.NewSignedBeaconBlock(nBlock)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(nBlock.Block.Slot, wsb, nRoot))
+	require.NoError(t, r.insertBlkAndBlobToQueue(nBlock.Block.Slot, wsb, nRoot, nil))
 	require.NoError(t, r.processPendingBlocks(context.Background())) // Marks a block as bad
 	require.NoError(t, r.processPendingBlocks(context.Background())) // Bad block removed on second run
 
@@ -153,7 +153,7 @@ func TestRegularSyncBeaconBlockSubscriber_OptimisticStatus(t *testing.T) {
 	// Add b2 to the cache
 	wsb, err := blocks.NewSignedBeaconBlock(b2)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root, nil))
 
 	require.NoError(t, r.processPendingBlocks(context.Background()))
 	assert.Equal(t, 1, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
@@ -162,7 +162,7 @@ func TestRegularSyncBeaconBlockSubscriber_OptimisticStatus(t *testing.T) {
 	// Add b1 to the cache
 	wsb, err = blocks.NewSignedBeaconBlock(b1)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1Root, nil))
 	util.SaveBlock(t, context.Background(), r.cfg.beaconDB, b1)
 
 	nBlock := util.NewBeaconBlock()
@@ -173,7 +173,7 @@ func TestRegularSyncBeaconBlockSubscriber_OptimisticStatus(t *testing.T) {
 	// Insert bad b1 in the cache to verify the good one doesn't get replaced.
 	wsb, err = blocks.NewSignedBeaconBlock(nBlock)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(nBlock.Block.Slot, wsb, nRoot))
+	require.NoError(t, r.insertBlkAndBlobToQueue(nBlock.Block.Slot, wsb, nRoot, nil))
 	require.NoError(t, r.processPendingBlocks(context.Background())) // Marks a block as bad
 	require.NoError(t, r.processPendingBlocks(context.Background())) // Bad block removed on second run
 
@@ -225,7 +225,7 @@ func TestRegularSyncBeaconBlockSubscriber_ExecutionEngineTimesOut(t *testing.T) 
 	// Add b2 to the cache
 	wsb, err := blocks.NewSignedBeaconBlock(b2)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root, nil))
 
 	require.NoError(t, r.processPendingBlocks(context.Background()))
 	assert.Equal(t, 1, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
@@ -234,7 +234,7 @@ func TestRegularSyncBeaconBlockSubscriber_ExecutionEngineTimesOut(t *testing.T) 
 	// Add b1 to the cache
 	wsb, err = blocks.NewSignedBeaconBlock(b1)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1Root, nil))
 	util.SaveBlock(t, context.Background(), r.cfg.beaconDB, b1)
 
 	nBlock := util.NewBeaconBlock()
@@ -245,7 +245,7 @@ func TestRegularSyncBeaconBlockSubscriber_ExecutionEngineTimesOut(t *testing.T) 
 	// Insert bad b1 in the cache to verify the good one doesn't get replaced.
 	wsb, err = blocks.NewSignedBeaconBlock(nBlock)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(nBlock.Block.Slot, wsb, nRoot))
+	require.NoError(t, r.insertBlkAndBlobToQueue(nBlock.Block.Slot, wsb, nRoot, nil))
 	require.NoError(t, r.processPendingBlocks(context.Background())) // Marks a block as bad
 	require.NoError(t, r.processPendingBlocks(context.Background())) // Bad block removed on second run
 
@@ -287,24 +287,24 @@ func TestRegularSync_InsertDuplicateBlocks(t *testing.T) {
 
 	wsb, err := blocks.NewSignedBeaconBlock(b0)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b0.Block.Slot, wsb, b0r))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b0.Block.Slot, wsb, b0r, nil))
 	require.Equal(t, 1, len(r.pendingBlocksInCache(b0.Block.Slot)), "Block was not added to map")
 
 	wsb, err = blocks.NewSignedBeaconBlock(b1)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1r))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1r, nil))
 	require.Equal(t, 1, len(r.pendingBlocksInCache(b1.Block.Slot)), "Block was not added to map")
 
 	// Add duplicate block which should not be saved.
 	wsb, err = blocks.NewSignedBeaconBlock(b0)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b0.Block.Slot, wsb, b0r))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b0.Block.Slot, wsb, b0r, nil))
 	require.Equal(t, 1, len(r.pendingBlocksInCache(b0.Block.Slot)), "Block was added to map")
 
 	// Add duplicate block which should not be saved.
 	wsb, err = blocks.NewSignedBeaconBlock(b1)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1r))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1r, nil))
 	require.Equal(t, 1, len(r.pendingBlocksInCache(b1.Block.Slot)), "Block was added to map")
 
 }
@@ -344,7 +344,7 @@ func TestRegularSyncBeaconBlockSubscriber_DoNotReprocessBlock(t *testing.T) {
 	// Add b3 to the cache
 	wsb, err := blocks.NewSignedBeaconBlock(b3)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b3.Block.Slot, wsb, b3Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b3.Block.Slot, wsb, b3Root, nil))
 
 	require.NoError(t, r.processPendingBlocks(context.Background()))
 	assert.Equal(t, 0, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
@@ -436,10 +436,10 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks_2Chains(t *testin
 
 	wsb, err := blocks.NewSignedBeaconBlock(b4)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b4.Block.Slot, wsb, b4Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b4.Block.Slot, wsb, b4Root, nil))
 	wsb, err = blocks.NewSignedBeaconBlock(b5)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b5.Block.Slot, wsb, b5Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b5.Block.Slot, wsb, b5Root, nil))
 
 	require.NoError(t, r.processPendingBlocks(context.Background())) // Marks a block as bad
 	require.NoError(t, r.processPendingBlocks(context.Background())) // Bad block removed on second run
@@ -450,7 +450,7 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks_2Chains(t *testin
 	// Add b3 to the cache
 	wsb, err = blocks.NewSignedBeaconBlock(b3)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b3.Block.Slot, wsb, b3Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b3.Block.Slot, wsb, b3Root, nil))
 	util.SaveBlock(t, context.Background(), r.cfg.beaconDB, b3)
 
 	require.NoError(t, r.processPendingBlocks(context.Background())) // Marks a block as bad
@@ -462,7 +462,7 @@ func TestRegularSyncBeaconBlockSubscriber_ProcessPendingBlocks_2Chains(t *testin
 	// Add b2 to the cache
 	wsb, err = blocks.NewSignedBeaconBlock(b2)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root, nil))
 
 	util.SaveBlock(t, context.Background(), r.cfg.beaconDB, b2)
 
@@ -535,16 +535,16 @@ func TestRegularSyncBeaconBlockSubscriber_PruneOldPendingBlocks(t *testing.T) {
 
 	wsb, err := blocks.NewSignedBeaconBlock(b2)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root, nil))
 	wsb, err = blocks.NewSignedBeaconBlock(b3)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b3.Block.Slot, wsb, b3Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b3.Block.Slot, wsb, b3Root, nil))
 	wsb, err = blocks.NewSignedBeaconBlock(b4)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b4.Block.Slot, wsb, b4Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b4.Block.Slot, wsb, b4Root, nil))
 	wsb, err = blocks.NewSignedBeaconBlock(b5)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b5.Block.Slot, wsb, b5Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b5.Block.Slot, wsb, b5Root, nil))
 
 	require.NoError(t, r.processPendingBlocks(context.Background()))
 	assert.Equal(t, 0, len(r.slotToPendingBlocks.Items()), "Incorrect size for slot to pending blocks cache")
@@ -560,16 +560,16 @@ func TestService_sortedPendingSlots(t *testing.T) {
 	var lastSlot types.Slot = math.MaxUint64
 	wsb, err := blocks.NewSignedBeaconBlock(util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: lastSlot}}))
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(lastSlot, wsb, [32]byte{1}))
+	require.NoError(t, r.insertBlkAndBlobToQueue(lastSlot, wsb, [32]byte{1}, nil))
 	wsb, err = blocks.NewSignedBeaconBlock(util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: lastSlot - 3}}))
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(lastSlot-3, wsb, [32]byte{2}))
+	require.NoError(t, r.insertBlkAndBlobToQueue(lastSlot-3, wsb, [32]byte{2}, nil))
 	wsb, err = blocks.NewSignedBeaconBlock(util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: lastSlot - 5}}))
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(lastSlot-5, wsb, [32]byte{3}))
+	require.NoError(t, r.insertBlkAndBlobToQueue(lastSlot-5, wsb, [32]byte{3}, nil))
 	wsb, err = blocks.NewSignedBeaconBlock(util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Slot: lastSlot - 2}}))
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(lastSlot-2, wsb, [32]byte{4}))
+	require.NoError(t, r.insertBlkAndBlobToQueue(lastSlot-2, wsb, [32]byte{4}, nil))
 
 	want := []types.Slot{lastSlot - 5, lastSlot - 3, lastSlot - 2, lastSlot}
 	assert.DeepEqual(t, want, r.sortedPendingSlots(), "Unexpected pending slots list")
@@ -680,19 +680,19 @@ func TestService_AddPendingBlockToQueueOverMax(t *testing.T) {
 	b2.Block.StateRoot = []byte{'b'}
 	wsb, err := blocks.NewSignedBeaconBlock(b)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(0, wsb, [32]byte{}))
+	require.NoError(t, r.insertBlkAndBlobToQueue(0, wsb, [32]byte{}, nil))
 	wsb, err = blocks.NewSignedBeaconBlock(b1)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(0, wsb, [32]byte{1}))
+	require.NoError(t, r.insertBlkAndBlobToQueue(0, wsb, [32]byte{1}, nil))
 	wsb, err = blocks.NewSignedBeaconBlock(b2)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(0, wsb, [32]byte{2}))
+	require.NoError(t, r.insertBlkAndBlobToQueue(0, wsb, [32]byte{2}, nil))
 
 	b3 := ethpb.CopySignedBeaconBlock(b)
 	b3.Block.StateRoot = []byte{'c'}
 	wsb, err = blocks.NewSignedBeaconBlock(b2)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(0, wsb, [32]byte{3}))
+	require.NoError(t, r.insertBlkAndBlobToQueue(0, wsb, [32]byte{3}, nil))
 	require.Equal(t, maxBlocksPerSlot, len(r.pendingBlocksInCache(0)))
 }
 
@@ -758,15 +758,15 @@ func TestService_ProcessPendingBlockOnCorrectSlot(t *testing.T) {
 	// Add block1 for slot1
 	wsb, err := blocks.NewSignedBeaconBlock(b1)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b1.Block.Slot, wsb, b1Root, nil))
 	// Add block2 for slot2
 	wsb, err = blocks.NewSignedBeaconBlock(b2)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b2.Block.Slot, wsb, b2Root, nil))
 	// Add block3 for slot3
 	wsb, err = blocks.NewSignedBeaconBlock(b3)
 	require.NoError(t, err)
-	require.NoError(t, r.insertBlkAndBlobToQueue(b3.Block.Slot, wsb, b3Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b3.Block.Slot, wsb, b3Root, nil))
 
 	// processPendingBlocks should process only blocks of the current slot. i.e. slot 1.
 	// Then check if the other two blocks are still in the pendingQueue.
@@ -828,7 +828,7 @@ func TestService_ProcessBadPendingBlocks(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Add block1 for slot 55
-	require.NoError(t, r.insertBlkAndBlobToQueue(b.Block.Slot, bA, b1Root))
+	require.NoError(t, r.insertBlkAndBlobToQueue(b.Block.Slot, bA, b1Root, nil))
 	bB, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 	assert.NoError(t, err)
 	// remove with a different block from the same slot.

--- a/beacon-chain/sync/rpc_blobs_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_blobs_sidecars_by_range.go
@@ -7,7 +7,6 @@ import (
 	libp2pcore "github.com/libp2p/go-libp2p/core"
 	"github.com/pkg/errors"
 	p2ptypes "github.com/prysmaticlabs/prysm/v3/beacon-chain/p2p/types"
-	"github.com/prysmaticlabs/prysm/v3/cmd/beacon-chain/flags"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/monitoring/tracing"
@@ -30,18 +29,22 @@ func (s *Service) blobsSidecarsByRangeRPCHandler(ctx context.Context, msg interf
 		return errors.New("message is not type *pb.BlobsSidecarsByRangeRequest")
 	}
 
+	if err := s.rateLimiter.validateRequest(stream, 1); err != nil {
+		return err
+	}
+
+	sidecarLimiter, err := s.rateLimiter.topicCollector(string(stream.Protocol()))
+	if err != nil {
+		return err
+	}
+
 	startSlot := r.StartSlot
 	count := r.Count
 	endSlot := startSlot.Add(count)
 
-	allowedBlocksPerSecond := uint64(flags.Get().BlockBatchLimit)
 	var numBlobs uint64
 	maxRequestBlobsSidecars := params.BeaconNetworkConfig().MaxRequestBlobsSidecars
 	for slot := startSlot; slot < endSlot && numBlobs < maxRequestBlobsSidecars; slot = slot.Add(1) {
-		if err := s.rateLimiter.validateRequest(stream, allowedBlocksPerSecond); err != nil {
-			return err
-		}
-
 		sidecars, err := s.cfg.beaconDB.BlobsSidecarsBySlot(ctx, slot)
 		if err != nil {
 			s.writeErrorResponseToStream(responseCodeServerError, p2ptypes.ErrGeneric.Error(), stream)
@@ -52,8 +55,7 @@ func (s *Service) blobsSidecarsByRangeRPCHandler(ctx context.Context, msg interf
 			continue
 		}
 
-		var respondedBlobs int64
-		for _, sidecar := range sidecars {
+		for i, sidecar := range sidecars {
 			if bytesutil.ToBytes32(sidecar.BeaconBlockRoot) == params.BeaconConfig().ZeroHash {
 				continue
 			}
@@ -64,46 +66,32 @@ func (s *Service) blobsSidecarsByRangeRPCHandler(ctx context.Context, msg interf
 				tracing.AnnotateError(span, chunkErr)
 				return chunkErr
 			}
-			respondedBlobs++
-		}
-		numBlobs++
-		s.rateLimiter.add(stream, respondedBlobs)
+			s.rateLimiter.add(stream, 1)
+			numBlobs += 1
 
-		// Short-circuit immediately once we've sent the last blob.
-		if slot.Add(1) >= endSlot {
-			break
-		}
+			// Short-circuit immediately once we've sent the last blob
+			if slot.Add(1) >= endSlot && i == len(sidecars)-1 {
+				break
+			}
 
-		key := stream.Conn().RemotePeer().String()
-		sidecarLimiter, err := s.rateLimiter.topicCollector(string(stream.Protocol()))
-		if err != nil {
-			return err
-		}
-		// Throttling - wait until we have enough tokens to send the next blobs
-
-		allowedBlocksBurst := int64(flags.Get().BlockBatchLimitBurstFactor * flags.Get().BlockBatchLimit)
-		if sidecarLimiter.Remaining(key) < allowedBlocksBurst {
-			timer := time.NewTimer(sidecarLimiter.TillEmpty(key))
-			select {
-			case <-ctx.Done():
-				timer.Stop()
-				return ctx.Err()
-			case <-timer.C:
-				timer.Stop()
+			key := stream.Conn().RemotePeer().String()
+			for {
+				if sidecarLimiter.Remaining(key) != 0 {
+					break
+				}
+				// Throttling - wait until we have enough tokens to send the next blobs
+				timer := time.NewTimer(time.Second * 1)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return ctx.Err()
+				case <-timer.C:
+					timer.Stop()
+				}
 			}
 		}
 	}
 
 	closeStream(stream, log)
 	return nil
-}
-
-func estimateBlobsSidecarCost(sidecar *pb.BlobsSidecar) int {
-	// This represents the fixed cost (in bytes) of the beacon_block_root and beacon_block_slot fields in the sidecar
-	const overheadCost = 32 + 8
-	cost := overheadCost
-	for _, blob := range sidecar.Blobs {
-		cost += len(blob.Data)
-	}
-	return cost
 }

--- a/beacon-chain/sync/rpc_blobs_sidecars_by_range_test.go
+++ b/beacon-chain/sync/rpc_blobs_sidecars_by_range_test.go
@@ -1,0 +1,180 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/protocol"
+	chainMock "github.com/prysmaticlabs/prysm/v3/beacon-chain/blockchain/testing"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/db/iface"
+	db "github.com/prysmaticlabs/prysm/v3/beacon-chain/db/testing"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/p2p"
+	p2ptest "github.com/prysmaticlabs/prysm/v3/beacon-chain/p2p/testing"
+	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
+	"github.com/prysmaticlabs/prysm/v3/config/params"
+	types "github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
+	leakybucket "github.com/prysmaticlabs/prysm/v3/container/leaky-bucket"
+	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v3/testing/assert"
+	"github.com/prysmaticlabs/prysm/v3/testing/require"
+	"github.com/prysmaticlabs/prysm/v3/testing/util"
+	"github.com/prysmaticlabs/prysm/v3/time/slots"
+)
+
+func TestRPCBBlobsSidecarsByRange_RPCHandlerRateLimit_NoOverflow(t *testing.T) {
+	d := db.SetupDB(t)
+
+	p1 := p2ptest.NewTestP2P(t)
+	p2 := p2ptest.NewTestP2P(t)
+	p1.Connect(p2)
+	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+
+	capacity := int64(params.BeaconNetworkConfig().MaxRequestBlobsSidecars)
+	r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}}, rateLimiter: newRateLimiter(p1)}
+
+	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+	topic := string(pcl)
+	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, capacity, time.Second, false)
+	req := &ethpb.BlobsSidecarsByRangeRequest{
+		Count: uint64(capacity),
+	}
+
+	saveBlobs(d, req, 1)
+	assert.NoError(t, sendBlobsRequest(t, p1, p2, r, req, true, true, 1))
+
+	remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
+	expectedCapacity := int64(0) // Whole capacity is used, but no overflow.
+	assert.Equal(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
+}
+
+func TestRPCBBlobsSidecarsByRange_RPCHandlerRateLimit_ThrottleWithoutOverflowAndMultipleBlobsPerSlot(t *testing.T) {
+	d := db.SetupDB(t)
+	p1 := p2ptest.NewTestP2P(t)
+	p2 := p2ptest.NewTestP2P(t)
+	p1.Connect(p2)
+	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+
+	capacity := int64(params.BeaconNetworkConfig().MaxRequestBlobsSidecars)
+	r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}}, rateLimiter: newRateLimiter(p1)}
+
+	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+	topic := string(pcl)
+	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(0.000001, capacity, time.Second, false)
+	req := &ethpb.BlobsSidecarsByRangeRequest{
+		Count: uint64(capacity) / 2,
+	}
+
+	saveBlobs(d, req, 2)
+	assert.NoError(t, sendBlobsRequest(t, p1, p2, r, req, true, true, 2))
+
+	remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
+	expectedCapacity := int64(0) // Whole capacity is used, but no overflow.
+	assert.Equal(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
+}
+
+func TestRPCBBlobsSidecarsByRange_RPCHandlerRateLimit_ThrottleWithOverflow(t *testing.T) {
+	d := db.SetupDB(t)
+	p1 := p2ptest.NewTestP2P(t)
+	p2 := p2ptest.NewTestP2P(t)
+	p1.Connect(p2)
+	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+
+	capacity := int64(params.BeaconNetworkConfig().MaxRequestBlobsSidecars) / 2
+	r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}}, rateLimiter: newRateLimiter(p1)}
+
+	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+	topic := string(pcl)
+	// 30 blobs per second streams blobs in ~4s
+	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(30, capacity, time.Second, false)
+	req := &ethpb.BlobsSidecarsByRangeRequest{
+		Count: uint64(capacity) * 2,
+	}
+
+	saveBlobs(d, req, 1)
+	assert.NoError(t, sendBlobsRequest(t, p1, p2, r, req, true, true, 1))
+
+	remainingCapacity := r.rateLimiter.limiterMap[topic].Remaining(p2.PeerID().String())
+	expectedCapacity := int64(0)
+	assert.NotEqual(t, expectedCapacity, remainingCapacity, "Unexpected rate limiting capacity")
+}
+
+func TestRPCBBlobsSidecarsByRange_RPCHandlerRateLimit_MultipleRequestsThrottle(t *testing.T) {
+	d := db.SetupDB(t)
+	p1 := p2ptest.NewTestP2P(t)
+	p2 := p2ptest.NewTestP2P(t)
+	p1.Connect(p2)
+	assert.Equal(t, 1, len(p1.BHost.Network().Peers()), "Expected peers to be connected")
+
+	capacity := int64(params.BeaconNetworkConfig().MaxRequestBlobsSidecars) / 2
+	r := &Service{cfg: &config{p2p: p1, beaconDB: d, chain: &chainMock.ChainService{}}, rateLimiter: newRateLimiter(p1)}
+
+	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+	topic := string(pcl)
+	// 64 blobs per second - takes ~6 seconds to stream all blobs
+	r.rateLimiter.limiterMap[topic] = leakybucket.NewCollector(64, capacity, time.Second, false)
+
+	for i := 0; i < 2; i++ {
+		req := &ethpb.BlobsSidecarsByRangeRequest{
+			Count: uint64(capacity) * 2,
+		}
+		saveBlobs(d, req, 1)
+		assert.NoError(t, sendBlobsRequest(t, p1, p2, r, req, true, true, 1))
+	}
+}
+
+func saveBlobs(d iface.Database, req *ethpb.BlobsSidecarsByRangeRequest, blobsPerSlot uint64) {
+	for i := req.StartSlot; i < req.StartSlot.Add(req.Count); i += types.Slot(1) {
+		for j := uint64(0); j < blobsPerSlot; j++ {
+			blob := &ethpb.BlobsSidecar{
+				BeaconBlockSlot: i,
+				BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+				AggregatedProof: make([]byte, 48),
+			}
+			// non-blobs to ensure that blobs are always sent
+			blob.BeaconBlockRoot[0] = 0x1
+			blob.BeaconBlockRoot[1] = byte(j)
+			d.SaveBlobsSidecar(context.Background(), blob)
+		}
+	}
+}
+
+func sendBlobsRequest(t *testing.T, p1, p2 *p2ptest.TestP2P, r *Service,
+	req *ethpb.BlobsSidecarsByRangeRequest, validateBlocks bool, success bool, blobsPerSlot uint64) error {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	pcl := protocol.ID(p2p.RPCBlocksByRangeTopicV1)
+	p2.BHost.SetStreamHandler(pcl, func(stream network.Stream) {
+		defer wg.Done()
+		if !validateBlocks {
+			return
+		}
+		for i := req.StartSlot; i < req.StartSlot.Add(req.Count); i += types.Slot(1) {
+			if !success {
+				continue
+			}
+
+			for j := uint64(0); j < blobsPerSlot; j++ {
+				SetRPCStreamDeadlines(stream)
+
+				expectSuccess(t, stream)
+				res := new(ethpb.BlobsSidecar)
+				assert.NoError(t, r.cfg.p2p.Encoding().DecodeWithMaxLength(stream, res))
+				if slots.AbsoluteValueSlotDifference(res.BeaconBlockSlot, i) != 0 {
+					t.Errorf("Received unexpected blob slot %d. expected %d", res.BeaconBlockSlot, i)
+				}
+			}
+		}
+	})
+	stream, err := p1.BHost.NewStream(context.Background(), p2.BHost.ID(), pcl)
+	require.NoError(t, err)
+	if err := r.blobsSidecarsByRangeRPCHandler(context.Background(), req, stream); err != nil {
+		return err
+	}
+	if util.WaitTimeout(&wg, 20*time.Second) {
+		t.Fatal("Did not receive stream within 10 sec")
+	}
+	return nil
+}

--- a/beacon-chain/sync/rpc_blobs_sidecars_by_range_test.go
+++ b/beacon-chain/sync/rpc_blobs_sidecars_by_range_test.go
@@ -133,7 +133,7 @@ func saveBlobs(d iface.Database, req *ethpb.BlobsSidecarsByRangeRequest, blobsPe
 				BeaconBlockRoot: make([]byte, fieldparams.RootLength),
 				AggregatedProof: make([]byte, 48),
 			}
-			// non-blobs to ensure that blobs are always sent
+			// always non-empty to ensure that blobs are always sent
 			blob.BeaconBlockRoot[0] = 0x1
 			blob.BeaconBlockRoot[1] = byte(j)
 			d.SaveBlobsSidecar(context.Background(), blob)


### PR DESCRIPTION
This fixes RPC client timeouts induced by the rate limiter by ensuring blobs are streamed once there exists a token available (typically 1 second).

cc: @terencechain 