### PR TITLE
Cache Fork Digest Computation

### DIFF
--- a/beacon-chain/core/signing/signing_root_test.go
+++ b/beacon-chain/core/signing/signing_root_test.go
@@ -136,6 +136,25 @@ func TestFuzzverifySigningRoot_10000(_ *testing.T) {
 	}
 }
 
+func TestDigestMap(t *testing.T) {
+	testVersion := []byte{'A', 'B', 'C', 'D'}
+	testValRoot := [32]byte{'t', 'e', 's', 't', 'r', 'o', 'o', 't'}
+	digest, err := signing.ComputeForkDigest(testVersion, testValRoot[:])
+	assert.NoError(t, err)
+
+	cachedDigest, err := signing.ComputeForkDigest(testVersion, testValRoot[:])
+	assert.NoError(t, err)
+	assert.Equal(t, digest, cachedDigest)
+	testVersion[3] = 'E'
+	cachedDigest, err = signing.ComputeForkDigest(testVersion, testValRoot[:])
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest, cachedDigest)
+	testValRoot[5] = 'z'
+	cachedDigest2, err := signing.ComputeForkDigest(testVersion, testValRoot[:])
+	assert.NoError(t, err)
+	assert.NotEqual(t, digest, cachedDigest2)
+	assert.NotEqual(t, cachedDigest, cachedDigest2)
+}
 func TestBlockSignatureBatch_NoSigVerification(t *testing.T) {
 	tests := []struct {
 		pubkey          []byte


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

Computing the fork digest is a very hot path in gossip, we have to compute the digest for each message we 
receive in gossip. This PR caches the computation, so that we can easily received the result through a map. Also
a relevant unit test is added here.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
