### PR TITLE
Rate limit broadcasting of BLS changes at the fork and at RPC endpoint

### DIFF
--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -72,8 +72,10 @@ func (s *Service) broadcastBLSChanges(ctx context.Context, changes []*ethpb.Sign
 				limit = len(changes)
 			}
 			for _, ch := range changes[:limit] {
-				if err := s.Broadcast(ctx, ch); err != nil {
-					log.WithError(err).Error("could not broadcast BLS to execution changes.")
+				if ch != nil {
+					if err := s.Broadcast(ctx, ch); err != nil {
+						log.WithError(err).Error("could not broadcast BLS to execution changes.")
+					}
 				}
 			}
 			changes = changes[limit:]

--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -19,8 +19,6 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const broadcastBLSChangesRateLimit = 128
-
 // ErrMessageNotMapped occurs on a Broadcast attempt when a message has not been defined in the
 // GossipTypeMapping.
 var ErrMessageNotMapped = errors.New("message type is not mapped to a PubSub topic")
@@ -52,38 +50,6 @@ func (s *Service) Broadcast(ctx context.Context, msg proto.Message) error {
 		return errors.Errorf("message of %T does not support marshaller interface", msg)
 	}
 	return s.broadcastObject(ctx, castMsg, fmt.Sprintf(topic, forkDigest))
-}
-
-// BroadcastBLSChanges spins up a go routine that rate limits and broadcasts BLS
-// to execution changes at prescribed intervals.
-func (s *Service) BroadcastBLSChanges(ctx context.Context, changes []*ethpb.SignedBLSToExecutionChange) {
-	go s.broadcastBLSChanges(ctx, changes)
-}
-
-func (s *Service) broadcastBLSChanges(ctx context.Context, changes []*ethpb.SignedBLSToExecutionChange) {
-	ticker := time.NewTicker(500 * time.Millisecond)
-	for {
-		select {
-		case <-s.ctx.Done():
-			return
-		case <-ticker.C:
-			limit := broadcastBLSChangesRateLimit
-			if len(changes) < broadcastBLSChangesRateLimit {
-				limit = len(changes)
-			}
-			for _, ch := range changes[:limit] {
-				if ch != nil {
-					if err := s.Broadcast(ctx, ch); err != nil {
-						log.WithError(err).Error("could not broadcast BLS to execution changes.")
-					}
-				}
-			}
-			changes = changes[limit:]
-			if len(changes) == 0 {
-				return
-			}
-		}
-	}
 }
 
 // BroadcastAttestation broadcasts an attestation to the p2p network, the message is assumed to be

--- a/beacon-chain/p2p/broadcaster_test.go
+++ b/beacon-chain/p2p/broadcaster_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/testing/assert"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
 	"github.com/prysmaticlabs/prysm/v3/testing/util"
-	logTest "github.com/sirupsen/logrus/hooks/test"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -439,57 +438,4 @@ func TestService_BroadcastSyncCommittee(t *testing.T) {
 	if util.WaitTimeout(&wg, 1*time.Second) {
 		t.Error("Failed to receive pubsub within 1s")
 	}
-}
-
-func TestBroadcastBLSChanges(t *testing.T) {
-	logHook := logTest.NewGlobal()
-	p1 := p2ptest.NewTestP2P(t)
-	p2 := p2ptest.NewTestP2P(t)
-	p1.Connect(p2)
-	if len(p1.BHost.Network().Peers()) == 0 {
-		t.Fatal("No peers")
-	}
-
-	p := &Service{
-		host:                  p1.BHost,
-		pubsub:                p1.PubSub(),
-		joinedTopics:          map[string]*pubsub.Topic{},
-		cfg:                   &Config{},
-		ctx:                   context.Background(),
-		genesisTime:           time.Now(),
-		genesisValidatorsRoot: bytesutil.PadTo([]byte{'A'}, 32),
-		subnetsLock:           make(map[uint64]*sync.RWMutex),
-		subnetsLockLock:       sync.Mutex{},
-		peers: peers.NewStatus(context.Background(), &peers.StatusConfig{
-			ScorerParams: &scorers.Config{},
-		}),
-	}
-
-	message := &ethpb.SignedBLSToExecutionChange{
-		Message: &ethpb.BLSToExecutionChange{
-			ValidatorIndex:     1,
-			FromBlsPubkey:      bytesutil.PadTo([]byte("pubkey1"), 48),
-			ToExecutionAddress: bytesutil.PadTo([]byte("address1"), 20),
-		},
-		Signature: bytesutil.PadTo([]byte("signature1"), 96),
-	}
-	message2 := &ethpb.SignedBLSToExecutionChange{
-		Message: &ethpb.BLSToExecutionChange{
-			ValidatorIndex:     1,
-			FromBlsPubkey:      bytesutil.PadTo([]byte("pubkey1"), 48),
-			ToExecutionAddress: bytesutil.PadTo([]byte("address1"), 20),
-		},
-		Signature: bytesutil.PadTo([]byte("signature1"), 96),
-	}
-	messages := make([]*ethpb.SignedBLSToExecutionChange, 200)
-	for i := 0; i < 128; i++ {
-		messages[i] = message
-	}
-	for i := 128; i < 200; i++ {
-		messages[i] = message2
-	}
-
-	p.broadcastBLSChanges(context.Background(), messages)
-	require.LogsDoNotContain(t, logHook, "could not")
-
 }

--- a/beacon-chain/p2p/interfaces.go
+++ b/beacon-chain/p2p/interfaces.go
@@ -35,7 +35,6 @@ type Broadcaster interface {
 	Broadcast(context.Context, proto.Message) error
 	BroadcastAttestation(ctx context.Context, subnet uint64, att *ethpb.Attestation) error
 	BroadcastSyncCommitteeMessage(ctx context.Context, subnet uint64, sMsg *ethpb.SyncCommitteeMessage) error
-	BroadcastBLSChanges(context.Context, []*ethpb.SignedBLSToExecutionChange)
 }
 
 // SetStreamHandler configures p2p to handle streams of a certain topic ID.

--- a/beacon-chain/p2p/testing/fuzz_p2p.go
+++ b/beacon-chain/p2p/testing/fuzz_p2p.go
@@ -143,10 +143,6 @@ func (_ *FakeP2P) BroadcastSyncCommitteeMessage(_ context.Context, _ uint64, _ *
 	return nil
 }
 
-// BroadcastBLSChanges mocks a broadcast BLS change ocurred
-func (_ *FakeP2P) BroadcastBLSChanges(_ context.Context, _ []*ethpb.SignedBLSToExecutionChange) {
-}
-
 // InterceptPeerDial -- fake.
 func (_ *FakeP2P) InterceptPeerDial(peer.ID) (allow bool) {
 	return true

--- a/beacon-chain/p2p/testing/mock_broadcaster.go
+++ b/beacon-chain/p2p/testing/mock_broadcaster.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -33,14 +32,4 @@ func (m *MockBroadcaster) BroadcastAttestation(_ context.Context, _ uint64, a *e
 func (m *MockBroadcaster) BroadcastSyncCommitteeMessage(_ context.Context, _ uint64, _ *ethpb.SyncCommitteeMessage) error {
 	m.BroadcastCalled = true
 	return nil
-}
-
-// BroadcastBLSChanges mocks a broadcast BLS change ocurred
-func (m *MockBroadcaster) BroadcastBLSChanges(ctx context.Context, changes []*ethpb.SignedBLSToExecutionChange) {
-	for _, change := range changes {
-		err := m.Broadcast(ctx, change)
-		if err != nil {
-			log.WithError(err).Error("could not broadcast Signed BLS change")
-		}
-	}
 }

--- a/beacon-chain/p2p/testing/p2p.go
+++ b/beacon-chain/p2p/testing/p2p.go
@@ -176,14 +176,6 @@ func (p *TestP2P) BroadcastSyncCommitteeMessage(_ context.Context, _ uint64, _ *
 	return nil
 }
 
-// BroadcastBLSChanges mocks a broadcast BLS change ocurred
-func (p *TestP2P) BroadcastBLSChanges(_ context.Context, changes []*ethpb.SignedBLSToExecutionChange) {
-	if len(changes) > 0 {
-		p.BroadcastCalled = true
-		return
-	}
-}
-
 // SetStreamHandler for RPC.
 func (p *TestP2P) SetStreamHandler(topic string, handler network.StreamHandler) {
 	p.BHost.SetStreamHandler(protocol.ID(topic), handler)

--- a/beacon-chain/rpc/eth/beacon/pool.go
+++ b/beacon-chain/rpc/eth/beacon/pool.go
@@ -2,6 +2,7 @@ package beacon
 
 import (
 	"context"
+	"time"
 
 	"github.com/prysmaticlabs/prysm/v3/api/grpc"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/blocks"
@@ -23,6 +24,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+const broadcastBLSChangesRateLimit = 128
 
 // ListPoolAttestations retrieves attestations known by the node but
 // not necessarily incorporated into any block. Allows filtering by committee index or slot.
@@ -347,7 +350,7 @@ func (bs *Server) SubmitSignedBLSToExecutionChanges(ctx context.Context, req *et
 			toBroadcast = append(toBroadcast, alphaChange)
 		}
 	}
-	bs.Broadcaster.BroadcastBLSChanges(ctx, toBroadcast)
+	go bs.broadcastBLSChanges(ctx, toBroadcast)
 	if len(failures) > 0 {
 		failuresContainer := &helpers.IndexedVerificationFailure{Failures: failures}
 		err := grpc.AppendCustomErrorHeader(ctx, failuresContainer)
@@ -361,6 +364,42 @@ func (bs *Server) SubmitSignedBLSToExecutionChanges(ctx context.Context, req *et
 		return nil, status.Errorf(codes.InvalidArgument, "One or more BLSToExecutionChange failed validation")
 	}
 	return &emptypb.Empty{}, nil
+}
+
+func (bs *Server) broadcastBLSChanges(ctx context.Context, changes []*ethpbalpha.SignedBLSToExecutionChange) {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			limit := broadcastBLSChangesRateLimit
+			if len(changes) < broadcastBLSChangesRateLimit {
+				limit = len(changes)
+			}
+			st, err := bs.ChainInfoFetcher.HeadState(ctx)
+			if err != nil {
+				log.WithError(err).Error("could not get head state")
+				return
+			}
+			for _, ch := range changes[:limit] {
+				if ch != nil {
+					_, err := blocks.ValidateBLSToExecutionChange(st, ch)
+					if err != nil {
+						log.WithError(err).Error("could not validate BLS to execution change")
+						continue
+					}
+					if err := bs.Broadcaster.Broadcast(ctx, ch); err != nil {
+						log.WithError(err).Error("could not broadcast BLS to execution changes.")
+					}
+				}
+			}
+			changes = changes[limit:]
+			if len(changes) == 0 {
+				return
+			}
+		}
+	}
 }
 
 // ListBLSToExecutionChanges retrieves BLS to execution changes known by the node but not necessarily incorporated into any block

--- a/beacon-chain/sync/broadcast_bls_changes.go
+++ b/beacon-chain/sync/broadcast_bls_changes.go
@@ -26,8 +26,9 @@ func (s *Service) broadcastBLSChanges(currSlot types.Slot) {
 		return
 	}
 	source := rand.NewGenerator()
-	broadcastChanges := make([]*ethpb.SignedBLSToExecutionChange, len(changes))
-	for i := 0; i < len(changes); i++ {
+	length := len(changes)
+	broadcastChanges := make([]*ethpb.SignedBLSToExecutionChange, length)
+	for i := 0; i < length; i++ {
 		idx := source.Intn(len(changes))
 		broadcastChanges[i] = changes[idx]
 		changes = append(changes[:idx], changes[idx+1:]...)

--- a/beacon-chain/sync/broadcast_bls_changes_test.go
+++ b/beacon-chain/sync/broadcast_bls_changes_test.go
@@ -6,13 +6,22 @@ import (
 	"time"
 
 	mockChain "github.com/prysmaticlabs/prysm/v3/beacon-chain/blockchain/testing"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/signing"
+	testingdb "github.com/prysmaticlabs/prysm/v3/beacon-chain/db/testing"
+	doublylinkedtree "github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice/doubly-linked-tree"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/blstoexec"
 	mockp2p "github.com/prysmaticlabs/prysm/v3/beacon-chain/p2p/testing"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stategen"
 	mockSync "github.com/prysmaticlabs/prysm/v3/beacon-chain/sync/initial-sync/testing"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
+	"github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v3/testing/assert"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
+	"github.com/prysmaticlabs/prysm/v3/testing/util"
 	"github.com/prysmaticlabs/prysm/v3/time/slots"
+	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func TestBroadcastBLSChanges(t *testing.T) {
@@ -45,4 +54,67 @@ func TestBroadcastBLSChanges(t *testing.T) {
 	capellaStart, err := slots.EpochStart(params.BeaconConfig().CapellaForkEpoch)
 	require.NoError(t, err)
 	s.broadcastBLSChanges(capellaStart + 1)
+}
+
+func TestRateBLSChanges(t *testing.T) {
+	logHook := logTest.NewGlobal()
+	params.SetupTestConfigCleanup(t)
+	c := params.BeaconConfig()
+	c.CapellaForkEpoch = c.BellatrixForkEpoch.Add(2)
+	params.OverrideBeaconConfig(c)
+	chainService := &mockChain.ChainService{
+		Genesis:        time.Now(),
+		ValidatorsRoot: [32]byte{'A'},
+	}
+	p1 := mockp2p.NewTestP2P(t)
+	s := NewService(context.Background(),
+		WithP2P(p1),
+		WithInitialSync(&mockSync.Sync{IsSyncing: false}),
+		WithChainService(chainService),
+		WithStateNotifier(chainService.StateNotifier()),
+		WithOperationNotifier(chainService.OperationNotifier()),
+		WithBlsToExecPool(blstoexec.NewPool()),
+	)
+	beaconDB := testingdb.SetupDB(t)
+	s.cfg.stateGen = stategen.New(beaconDB, doublylinkedtree.New())
+	s.cfg.beaconDB = beaconDB
+	s.initCaches()
+	st, keys := util.DeterministicGenesisStateCapella(t, 256)
+	s.cfg.chain = &mockChain.ChainService{
+		ValidatorsRoot: [32]byte{'A'},
+		Genesis:        time.Now().Add(-time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Duration(10)),
+		State:          st,
+	}
+
+	for i := 0; i < 200; i++ {
+		message := &ethpb.BLSToExecutionChange{
+			ValidatorIndex:     primitives.ValidatorIndex(i),
+			FromBlsPubkey:      keys[i+1].PublicKey().Marshal(),
+			ToExecutionAddress: bytesutil.PadTo([]byte("address"), 20),
+		}
+		epoch := params.BeaconConfig().CapellaForkEpoch + 1
+		domain, err := signing.Domain(st.Fork(), epoch, params.BeaconConfig().DomainBLSToExecutionChange, st.GenesisValidatorsRoot())
+		assert.NoError(t, err)
+		htr, err := signing.SigningData(message.HashTreeRoot, domain)
+		assert.NoError(t, err)
+		signed := &ethpb.SignedBLSToExecutionChange{
+			Message:   message,
+			Signature: keys[i+1].Sign(htr[:]).Marshal(),
+		}
+
+		s.cfg.blsToExecPool.InsertBLSToExecChange(signed)
+	}
+
+	require.Equal(t, false, p1.BroadcastCalled)
+	slot, err := slots.EpochStart(params.BeaconConfig().CapellaForkEpoch)
+	require.NoError(t, err)
+	s.broadcastBLSChanges(slot)
+	time.Sleep(100 * time.Millisecond) // Need a sleep for the go routine to be ready
+	require.Equal(t, true, p1.BroadcastCalled)
+	require.LogsDoNotContain(t, logHook, "could not")
+
+	p1.BroadcastCalled = false
+	time.Sleep(500 * time.Millisecond) // Need a sleep for the second batch to be broadcast
+	require.Equal(t, true, p1.BroadcastCalled)
+	require.LogsDoNotContain(t, logHook, "could not")
 }


### PR DESCRIPTION
This PR fixes a critical bug on develop where we would attempt broadcast nil objects at the fork boundary of Capella. 

It also fixes another bug in that some of the broadcast objects may be invalid at the time they are broadcast (since they could have been inserted in a different block between batches)

As discussed offline,  there is code duplication due to the fact that the verifier needs to have access to the head state, and the sync and rpc package do not have access to a shared package with this information. This is considered to be mild in that we can remove this PR entirely after the Capella fork has passed. 