### PR TITLE
Fix Race Condition in Signing Package by Introducing Thread-Safe Maps

### DIFF
--- a/beacon-chain/core/signing/BUILD.bazel
+++ b/beacon-chain/core/signing/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//beacon-chain/state:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",
+        "//container/thread-safe:go_default_library",
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",

--- a/container/thread-safe/BUILD.bazel
+++ b/container/thread-safe/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["map.go"],
+    importpath = "github.com/prysmaticlabs/prysm/v3/container/thread-safe",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["map_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//testing/require:go_default_library"],
+)

--- a/container/thread-safe/map.go
+++ b/container/thread-safe/map.go
@@ -1,0 +1,58 @@
+// Package threadsafe contains generic containers that are
+// protected either by Mutexes or atomics underneath the hood.
+package threadsafe
+
+import "sync"
+
+// Map implements a simple thread-safe map protected by a mutex.
+type Map[K comparable, V any] struct {
+	items map[K]V
+	lock  sync.RWMutex
+}
+
+// NewThreadSafeMap returns a thread-safe map instance from a normal map.
+func NewThreadSafeMap[K comparable, V any](m map[K]V) *Map[K, V] {
+	return &Map[K, V]{
+		items: m,
+	}
+}
+
+// Keys returns the keys of a thread-safe map.
+func (m *Map[K, V]) Keys() []K {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	r := make([]K, 0, len(m.items))
+	for k := range m.items {
+		r = append(r, k)
+	}
+	return r
+}
+
+// Len of the thread-safe map.
+func (m *Map[K, V]) Len() int {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return len(m.items)
+}
+
+// Get an item from a thread-safe map.
+func (m *Map[K, V]) Get(k K) (V, bool) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	v, ok := m.items[k]
+	return v, ok
+}
+
+// Put an item into a thread-safe map.
+func (m *Map[K, V]) Put(k K, v V) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.items[k] = v
+}
+
+// Delete an item from a thread-safe map.
+func (m *Map[K, V]) Delete(k K) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	delete(m.items, k)
+}

--- a/container/thread-safe/map_test.go
+++ b/container/thread-safe/map_test.go
@@ -1,0 +1,48 @@
+package threadsafe
+
+import (
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v3/testing/require"
+)
+
+func TestMap(t *testing.T) {
+	m := map[int]string{
+		1:     "foo",
+		200:   "bar",
+		10000: "baz",
+	}
+
+	tMap := NewThreadSafeMap(m)
+	keys := tMap.Keys()
+	sort.IntSlice(keys).Sort()
+
+	require.DeepEqual(t, []int{1, 200, 10000}, keys)
+	require.Equal(t, 3, tMap.Len())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(w *sync.WaitGroup, scopedMap *Map[int, string]) {
+			defer w.Done()
+			v, ok := scopedMap.Get(1)
+			require.Equal(t, true, ok)
+			require.Equal(t, "foo", v)
+
+			scopedMap.Put(3, "nyan")
+
+			v, ok = scopedMap.Get(3)
+			require.Equal(t, true, ok)
+			require.Equal(t, "nyan", v)
+
+		}(&wg, tMap)
+	}
+	wg.Wait()
+
+	tMap.Delete(3)
+
+	_, ok := tMap.Get(3)
+	require.Equal(t, false, ok)
+}


### PR DESCRIPTION
This PR fixes a race in https://sourcegraph.com/github.com/prysmaticlabs/prysm@develop/-/blob/beacon-chain/core/signing/signing_root.go line 260 by introducing a thread-safe map type leveraging Go generics. That digestHash map should not have concurrent read/writes