### PR TITLE
Update Bazel Grail Toolchain SHA and Protect Digest Map with Lock

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,7 @@ http_archive(
 
 http_archive(
     name = "com_grail_bazel_toolchain",
-    sha256 = "b210fc8e58782ef171f428bfc850ed7179bdd805543ebd1aa144b9c93489134f",
+    sha256 = "6889426c946f1b948a22468aaa73252d477c306cb550d5db09c330af9a810cee",
     strip_prefix = "bazel-toolchain-83e69ba9e4b4fdad0d1d057fcb87addf77c281c9",
     urls = ["https://github.com/grailbio/bazel-toolchain/archive/83e69ba9e4b4fdad0d1d057fcb87addf77c281c9.tar.gz"],
 )

--- a/beacon-chain/core/signing/signing_root.go
+++ b/beacon-chain/core/signing/signing_root.go
@@ -1,6 +1,8 @@
 package signing
 
 import (
+	"sync"
+
 	"github.com/pkg/errors"
 	fssz "github.com/prysmaticlabs/fastssz"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
@@ -9,7 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/crypto/bls"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
-	"sync"
 )
 
 // ForkVersionByteLength length of fork version byte array.


### PR DESCRIPTION
Protects a digest map introduced into the signing package with a lock for thread-safe access.

This PR also updates the grail Bazel toolchain sha to 6889426c946f1b948a22468aaa73252d477c306cb550d5db09c330af9a810cee, as this changed due to a Github problem. See https://twitter.com/thesayynn/status/1620129657977987073 for information on what happened at the time of writing on Jan 30, 2023