### PR TITLE
Update `IsEmptyExecutionData` to Capella

### DIFF
--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -723,6 +723,17 @@ func IsEmptyExecutionData(data interfaces.ExecutionData) (bool, error) {
 		}
 	}
 
+	ws, err := data.Withdrawals()
+	switch {
+	case errors.Is(err, ErrUnsupportedGetter):
+	case err != nil:
+		return false, err
+	default:
+		if len(ws) != 0 {
+			return false, nil
+		}
+	}
+
 	if len(data.ExtraData()) != 0 {
 		return false, nil
 	}

--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -715,6 +715,7 @@ func IsEmptyExecutionData(data interfaces.ExecutionData) (bool, error) {
 	txs, err := data.Transactions()
 	switch {
 	case errors.Is(err, ErrUnsupportedGetter):
+		break
 	case err != nil:
 		return false, err
 	default:
@@ -726,6 +727,7 @@ func IsEmptyExecutionData(data interfaces.ExecutionData) (bool, error) {
 	ws, err := data.Withdrawals()
 	switch {
 	case errors.Is(err, ErrUnsupportedGetter):
+		break
 	case err != nil:
 		return false, err
 	default:

--- a/consensus-types/blocks/execution_test.go
+++ b/consensus-types/blocks/execution_test.go
@@ -234,6 +234,149 @@ func Test_executionPayloadHeaderCapella_Pb(t *testing.T) {
 	require.ErrorIs(t, err, blocks.ErrUnsupportedGetter)
 }
 
+func TestIsEmptyExecutionData(t *testing.T) {
+	t.Run("nil transactions", func(t *testing.T) {
+		data, err := blocks.WrappedExecutionPayload(&enginev1.ExecutionPayload{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			BlockNumber:   0,
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			ExtraData:     []byte{},
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  nil,
+		})
+		require.NoError(t, err)
+		isEmpty, err := blocks.IsEmptyExecutionData(data)
+		require.NoError(t, err)
+		assert.Equal(t, true, isEmpty)
+	})
+	t.Run("empty transactions", func(t *testing.T) {
+		data, err := blocks.WrappedExecutionPayload(&enginev1.ExecutionPayload{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			BlockNumber:   0,
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			ExtraData:     []byte{},
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  [][]byte{},
+		})
+		require.NoError(t, err)
+		isEmpty, err := blocks.IsEmptyExecutionData(data)
+		require.NoError(t, err)
+		assert.Equal(t, true, isEmpty)
+	})
+	t.Run("non-empty transactions", func(t *testing.T) {
+		data, err := blocks.WrappedExecutionPayload(&enginev1.ExecutionPayload{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			BlockNumber:   0,
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			ExtraData:     []byte{},
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  [][]byte{[]byte("transaction")},
+		})
+		require.NoError(t, err)
+		isEmpty, err := blocks.IsEmptyExecutionData(data)
+		require.NoError(t, err)
+		assert.Equal(t, false, isEmpty)
+	})
+	t.Run("nil withdrawals", func(t *testing.T) {
+		data, err := blocks.WrappedExecutionPayloadCapella(&enginev1.ExecutionPayloadCapella{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			BlockNumber:   0,
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			ExtraData:     []byte{},
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  [][]byte{},
+			Withdrawals:   nil,
+		})
+		require.NoError(t, err)
+		isEmpty, err := blocks.IsEmptyExecutionData(data)
+		require.NoError(t, err)
+		assert.Equal(t, true, isEmpty)
+	})
+	t.Run("empty withdrawals", func(t *testing.T) {
+		data, err := blocks.WrappedExecutionPayloadCapella(&enginev1.ExecutionPayloadCapella{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			BlockNumber:   0,
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			ExtraData:     []byte{},
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  [][]byte{},
+			Withdrawals:   []*enginev1.Withdrawal{},
+		})
+		require.NoError(t, err)
+		isEmpty, err := blocks.IsEmptyExecutionData(data)
+		require.NoError(t, err)
+		assert.Equal(t, true, isEmpty)
+	})
+	t.Run("non-empty withdrawals", func(t *testing.T) {
+		data, err := blocks.WrappedExecutionPayloadCapella(&enginev1.ExecutionPayloadCapella{
+			ParentHash:    make([]byte, fieldparams.RootLength),
+			FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+			StateRoot:     make([]byte, fieldparams.RootLength),
+			ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+			LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+			PrevRandao:    make([]byte, fieldparams.RootLength),
+			BlockNumber:   0,
+			GasLimit:      0,
+			GasUsed:       0,
+			Timestamp:     0,
+			ExtraData:     []byte{},
+			BaseFeePerGas: make([]byte, fieldparams.RootLength),
+			BlockHash:     make([]byte, fieldparams.RootLength),
+			Transactions:  [][]byte{},
+			Withdrawals: []*enginev1.Withdrawal{{
+				Index:          123,
+				ValidatorIndex: 0,
+				Address:        nil,
+				Amount:         0,
+			}},
+		})
+		require.NoError(t, err)
+		isEmpty, err := blocks.IsEmptyExecutionData(data)
+		require.NoError(t, err)
+		assert.Equal(t, false, isEmpty)
+	})
+}
+
 func createWrappedPayload(t testing.TB) interfaces.ExecutionData {
 	wsb, err := blocks.WrappedExecutionPayload(&enginev1.ExecutionPayload{
 		ParentHash:    make([]byte, fieldparams.RootLength),


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

- check withdrawals inside `IsEmptyExecutionData`
- add tests
