### PR TITLE
reuse code from stategen in the justified balance cache

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -118,6 +118,7 @@ go_test(
         "receive_attestation_test.go",
         "receive_block_test.go",
         "service_test.go",
+        "state_balance_cache_test.go",
         "weak_subjectivity_checks_test.go",
     ],
     embed = [":go_default_library"],

--- a/beacon-chain/blockchain/error.go
+++ b/beacon-chain/blockchain/error.go
@@ -21,8 +21,6 @@ var (
 	errWrongBlockCount = errors.New("wrong number of blocks or block roots")
 	// errBlockNotFoundInCacheOrDB is returned when a block is not found in the cache or DB.
 	errBlockNotFoundInCacheOrDB = errors.New("block not found in cache or db")
-	// errNilStateFromStategen is returned when a nil state is returned from the state generator.
-	errNilStateFromStategen = errors.New("justified state can't be nil")
 	// errWSBlockNotFound is returned when a block is not found in the WS cache or DB.
 	errWSBlockNotFound = errors.New("weak subjectivity root not found in db")
 	// errWSBlockNotFoundInEpoch is returned when a block is not found in the WS cache or DB within epoch.

--- a/beacon-chain/blockchain/mock_test.go
+++ b/beacon-chain/blockchain/mock_test.go
@@ -30,18 +30,14 @@ func testServiceOptsNoDB() []Option {
 	}
 }
 
-type mockStateByRooter struct {
+type mockBalanceByRooter struct {
 	state state.BeaconState
 	err   error
 }
 
-var _ stateByRooter = &mockStateByRooter{}
+var _ balanceByRooter = &mockBalanceByRooter{}
 
-func (m mockStateByRooter) StateByRoot(_ context.Context, _ [32]byte) (state.BeaconState, error) {
-	return m.state, m.err
-}
-
-func (m mockStateByRooter) BalancesByRoot(_ context.Context, _ [32]byte) ([]uint64, error) {
+func (m mockBalanceByRooter) BalancesByRoot(_ context.Context, _ [32]byte) ([]uint64, error) {
 	return m.state.Balances(), m.err
 }
 
@@ -50,5 +46,5 @@ func (m mockStateByRooter) BalancesByRoot(_ context.Context, _ [32]byte) ([]uint
 // always return an error if used.
 func satisfactoryStateBalanceCache() *stateBalanceCache {
 	err := errors.New("satisfactoryStateBalanceCache doesn't perform real caching")
-	return &stateBalanceCache{stateGen: mockStateByRooter{err: err}}
+	return &stateBalanceCache{stateGen: mockBalanceByRooter{err: err}}
 }

--- a/beacon-chain/blockchain/mock_test.go
+++ b/beacon-chain/blockchain/mock_test.go
@@ -41,6 +41,10 @@ func (m mockStateByRooter) StateByRoot(_ context.Context, _ [32]byte) (state.Bea
 	return m.state, m.err
 }
 
+func (m mockStateByRooter) BalancesByRoot(_ context.Context, _ [32]byte) ([]uint64, error) {
+	return m.state.Balances(), m.err
+}
+
 // returns an instance of the state balance cache that can be used
 // to satisfy the requirement for one in NewService, but which will
 // always return an error if used.

--- a/beacon-chain/blockchain/state_balance_cache.go
+++ b/beacon-chain/blockchain/state_balance_cache.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stategen"
 )
 
@@ -13,11 +12,10 @@ type stateBalanceCache struct {
 	sync.Mutex
 	balances []uint64
 	root     [32]byte
-	stateGen stateByRooter
+	stateGen balanceByRooter
 }
 
-type stateByRooter interface {
-	StateByRoot(context.Context, [32]byte) (state.BeaconState, error)
+type balanceByRooter interface {
 	BalancesByRoot(context.Context, [32]byte) ([]uint64, error)
 }
 

--- a/beacon-chain/blockchain/state_balance_cache.go
+++ b/beacon-chain/blockchain/state_balance_cache.go
@@ -2,11 +2,9 @@ package blockchain
 
 import (
 	"context"
-	"errors"
 	"sync"
 
-	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/helpers"
-	"github.com/prysmaticlabs/prysm/v3/beacon-chain/core/time"
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stategen"
 )
@@ -20,6 +18,7 @@ type stateBalanceCache struct {
 
 type stateByRooter interface {
 	StateByRoot(context.Context, [32]byte) (state.BeaconState, error)
+	BalancesByRoot(context.Context, [32]byte) ([]uint64, error)
 }
 
 // newStateBalanceCache exists to remind us that stateBalanceCache needs a state gen
@@ -38,26 +37,10 @@ func newStateBalanceCache(sg *stategen.State) (*stateBalanceCache, error) {
 // WARNING: this is not thread-safe on its own, relies on get() for locking
 func (c *stateBalanceCache) update(ctx context.Context, justifiedRoot [32]byte) ([]uint64, error) {
 	stateBalanceCacheMiss.Inc()
-	justifiedState, err := c.stateGen.StateByRoot(ctx, justifiedRoot)
-	if err != nil {
-		return nil, err
-	}
-	if justifiedState == nil || justifiedState.IsNil() {
-		return nil, errNilStateFromStategen
-	}
-	epoch := time.CurrentEpoch(justifiedState)
 
-	justifiedBalances := make([]uint64, justifiedState.NumValidators())
-	var balanceAccumulator = func(idx int, val state.ReadOnlyValidator) error {
-		if helpers.IsActiveValidatorUsingTrie(val, epoch) {
-			justifiedBalances[idx] = val.EffectiveBalance()
-		} else {
-			justifiedBalances[idx] = 0
-		}
-		return nil
-	}
-	if err := justifiedState.ReadFromEveryValidator(balanceAccumulator); err != nil {
-		return nil, err
+	justifiedBalances, err := c.stateGen.BalancesByRoot(ctx, justifiedRoot)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get balances")
 	}
 
 	c.balances = justifiedBalances

--- a/beacon-chain/blockchain/state_balance_cache_test.go
+++ b/beacon-chain/blockchain/state_balance_cache_test.go
@@ -34,7 +34,8 @@ func testStateFixture(opts ...testStateOpt) state.BeaconState {
 	for _, o := range opts {
 		o(a)
 	}
-	s, _ := state_native.InitializeFromProtoUnsafeAltair(a)
+	s, err := state_native.InitializeFromProtoUnsafeAltair(a)
+	_ = err
 	return s
 }
 

--- a/beacon-chain/blockchain/state_balance_cache_test.go
+++ b/beacon-chain/blockchain/state_balance_cache_test.go
@@ -136,29 +136,6 @@ func TestStateBalanceCache(t *testing.T) {
 			},
 			name: "cache hit",
 		},
-		// this works by using a staterooter that returns a known error
-		// so really we're testing the miss by making sure stategen got called
-		// this also tells us stategen errors are propagated
-		{
-			sbc: &stateBalanceCache{
-				stateGen: &mockBalanceByRooter{
-					err: sentinelCacheMiss,
-				},
-				root: bytesutil.ToBytes32([]byte{'B'}),
-			},
-			err:  sentinelCacheMiss,
-			root: bytesutil.ToBytes32([]byte{'A'}),
-			name: "cache miss",
-		},
-		{
-			sbc: &stateBalanceCache{
-				stateGen: &mockBalanceByRooter{},
-				root:     bytesutil.ToBytes32([]byte{'B'}),
-			},
-			err:  errNilStateFromStategen,
-			root: bytesutil.ToBytes32([]byte{'A'}),
-			name: "error for nil state upon cache miss",
-		},
 		{
 			sbc: &stateBalanceCache{
 				stateGen: &mockBalanceByRooter{

--- a/beacon-chain/blockchain/state_balance_cache_test.go
+++ b/beacon-chain/blockchain/state_balance_cache_test.go
@@ -128,7 +128,7 @@ func TestStateBalanceCache(t *testing.T) {
 			root:     bytesutil.ToBytes32([]byte{'A'}),
 			balances: sentinelBalances,
 			sbc: &stateBalanceCache{
-				stateGen: &mockStateByRooter{
+				stateGen: &mockBalanceByRooter{
 					err: sentinelCacheMiss,
 				},
 				root:     bytesutil.ToBytes32([]byte{'A'}),
@@ -141,7 +141,7 @@ func TestStateBalanceCache(t *testing.T) {
 		// this also tells us stategen errors are propagated
 		{
 			sbc: &stateBalanceCache{
-				stateGen: &mockStateByRooter{
+				stateGen: &mockBalanceByRooter{
 					err: sentinelCacheMiss,
 				},
 				root: bytesutil.ToBytes32([]byte{'B'}),
@@ -152,7 +152,7 @@ func TestStateBalanceCache(t *testing.T) {
 		},
 		{
 			sbc: &stateBalanceCache{
-				stateGen: &mockStateByRooter{},
+				stateGen: &mockBalanceByRooter{},
 				root:     bytesutil.ToBytes32([]byte{'B'}),
 			},
 			err:  errNilStateFromStategen,
@@ -161,7 +161,7 @@ func TestStateBalanceCache(t *testing.T) {
 		},
 		{
 			sbc: &stateBalanceCache{
-				stateGen: &mockStateByRooter{
+				stateGen: &mockBalanceByRooter{
 					state: testStateFixture(
 						testStateWithSlot(99),
 						testStateWithValidators(halfExpiredValidators)),
@@ -173,7 +173,7 @@ func TestStateBalanceCache(t *testing.T) {
 		},
 		{
 			sbc: &stateBalanceCache{
-				stateGen: &mockStateByRooter{
+				stateGen: &mockBalanceByRooter{
 					state: testStateFixture(
 						testStateWithSlot(99),
 						testStateWithValidators(halfQueuedValidators)),
@@ -185,7 +185,7 @@ func TestStateBalanceCache(t *testing.T) {
 		},
 		{
 			sbc: &stateBalanceCache{
-				stateGen: &mockStateByRooter{
+				stateGen: &mockBalanceByRooter{
 					state: testStateFixture(
 						testStateWithSlot(99),
 						testStateWithValidators(allValidValidators)),
@@ -197,7 +197,7 @@ func TestStateBalanceCache(t *testing.T) {
 		},
 		{
 			sbc: &stateBalanceCache{
-				stateGen: &mockStateByRooter{
+				stateGen: &mockBalanceByRooter{
 					state: testStateFixture(
 						testStateWithSlot(99),
 						testStateWithValidators(allValidValidators)),


### PR DESCRIPTION
Avoid code duplication, this is useful in starting to get rid of the justified balance cache and move to tracking this on forkchoice. 