### PR TITLE
Rename block interfaces

### DIFF
--- a/api/client/beacon/checkpoint.go
+++ b/api/client/beacon/checkpoint.go
@@ -18,13 +18,13 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-// OriginData represents the BeaconState and SignedBeaconBlock necessary to start an empty Beacon Node
+// OriginData represents the BeaconState and ReadOnlySignedBeaconBlock necessary to start an empty Beacon Node
 // using Checkpoint Sync.
 type OriginData struct {
 	sb []byte
 	bb []byte
 	st state.BeaconState
-	b  interfaces.SignedBeaconBlock
+	b  interfaces.ReadOnlySignedBeaconBlock
 	vu *detect.VersionedUnmarshaler
 	br [32]byte
 	sr [32]byte
@@ -49,7 +49,7 @@ func (o *OriginData) StateBytes() []byte {
 	return o.sb
 }
 
-// BlockBytes returns the ssz-encoded bytes of the downloaded SignedBeaconBlock value.
+// BlockBytes returns the ssz-encoded bytes of the downloaded ReadOnlySignedBeaconBlock value.
 func (o *OriginData) BlockBytes() []byte {
 	return o.bb
 }
@@ -116,7 +116,7 @@ func DownloadFinalizedData(ctx context.Context, client *Client) (*OriginData, er
 	}, nil
 }
 
-// WeakSubjectivityData represents the state root, block root and epoch of the BeaconState + SignedBeaconBlock
+// WeakSubjectivityData represents the state root, block root and epoch of the BeaconState + ReadOnlySignedBeaconBlock
 // that falls at the beginning of the current weak subjectivity period. These values can be used to construct
 // a weak subjectivity checkpoint beacon node flag to be used for validation.
 type WeakSubjectivityData struct {

--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -89,7 +89,7 @@ type BuilderClient interface {
 	NodeURL() string
 	GetHeader(ctx context.Context, slot primitives.Slot, parentHash [32]byte, pubkey [48]byte) (SignedBid, error)
 	RegisterValidator(ctx context.Context, svr []*ethpb.SignedValidatorRegistrationV1) error
-	SubmitBlindedBlock(ctx context.Context, sb interfaces.SignedBeaconBlock) (interfaces.ExecutionData, error)
+	SubmitBlindedBlock(ctx context.Context, sb interfaces.ReadOnlySignedBeaconBlock) (interfaces.ExecutionData, error)
 	Status(ctx context.Context) error
 }
 
@@ -277,7 +277,7 @@ func (c *Client) RegisterValidator(ctx context.Context, svr []*ethpb.SignedValid
 
 // SubmitBlindedBlock calls the builder API endpoint that binds the validator to the builder and submits the block.
 // The response is the full execution payload used to create the blinded block.
-func (c *Client) SubmitBlindedBlock(ctx context.Context, sb interfaces.SignedBeaconBlock) (interfaces.ExecutionData, error) {
+func (c *Client) SubmitBlindedBlock(ctx context.Context, sb interfaces.ReadOnlySignedBeaconBlock) (interfaces.ExecutionData, error) {
 	if !sb.IsBlinded() {
 		return nil, errNotBlinded
 	}

--- a/api/client/builder/testing/mock.go
+++ b/api/client/builder/testing/mock.go
@@ -40,7 +40,7 @@ func (m MockClient) RegisterValidator(_ context.Context, svr []*ethpb.SignedVali
 }
 
 // SubmitBlindedBlock --
-func (MockClient) SubmitBlindedBlock(_ context.Context, _ interfaces.SignedBeaconBlock) (interfaces.ExecutionData, error) {
+func (MockClient) SubmitBlindedBlock(_ context.Context, _ interfaces.ReadOnlySignedBeaconBlock) (interfaces.ExecutionData, error) {
 	return nil, nil
 }
 

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -52,7 +52,7 @@ type GenesisFetcher interface {
 type HeadFetcher interface {
 	HeadSlot() primitives.Slot
 	HeadRoot(ctx context.Context) ([]byte, error)
-	HeadBlock(ctx context.Context) (interfaces.SignedBeaconBlock, error)
+	HeadBlock(ctx context.Context) (interfaces.ReadOnlySignedBeaconBlock, error)
 	HeadState(ctx context.Context) (state.BeaconState, error)
 	HeadStateReadOnly(ctx context.Context) (state.ReadOnlyBeaconState, error)
 	HeadValidatorsIndices(ctx context.Context, epoch primitives.Epoch) ([]primitives.ValidatorIndex, error)
@@ -158,7 +158,7 @@ func (s *Service) HeadRoot(ctx context.Context) ([]byte, error) {
 // HeadBlock returns the head block of the chain.
 // If the head is nil from service struct,
 // it will attempt to get the head block from DB.
-func (s *Service) HeadBlock(ctx context.Context) (interfaces.SignedBeaconBlock, error) {
+func (s *Service) HeadBlock(ctx context.Context) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	s.headLock.RLock()
 	defer s.headLock.RUnlock()
 

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -31,7 +31,7 @@ var defaultLatestValidHash = bytesutil.PadTo([]byte{0xff}, 32)
 type notifyForkchoiceUpdateArg struct {
 	headState state.BeaconState
 	headRoot  [32]byte
-	headBlock interfaces.BeaconBlock
+	headBlock interfaces.ReadOnlyBeaconBlock
 }
 
 // notifyForkchoiceUpdate signals execution engine the fork choice updates. Execution engine should:
@@ -182,7 +182,7 @@ func (s *Service) getPayloadHash(ctx context.Context, root []byte) ([32]byte, er
 // notifyNewPayload signals execution engine on a new payload.
 // It returns true if the EL has returned VALID for the block
 func (s *Service) notifyNewPayload(ctx context.Context, postStateVersion int,
-	postStateHeader interfaces.ExecutionData, blk interfaces.SignedBeaconBlock) (bool, error) {
+	postStateHeader interfaces.ExecutionData, blk interfaces.ReadOnlySignedBeaconBlock) (bool, error) {
 	ctx, span := trace.StartSpan(ctx, "blockChain.notifyNewPayload")
 	defer span.End()
 

--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -131,7 +131,7 @@ func Test_NotifyForkchoiceUpdate(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		blk              interfaces.BeaconBlock
+		blk              interfaces.ReadOnlyBeaconBlock
 		headRoot         [32]byte
 		finalizedRoot    [32]byte
 		justifiedRoot    [32]byte
@@ -140,7 +140,7 @@ func Test_NotifyForkchoiceUpdate(t *testing.T) {
 	}{
 		{
 			name: "phase0 block",
-			blk: func() interfaces.BeaconBlock {
+			blk: func() interfaces.ReadOnlyBeaconBlock {
 				b, err := consensusblocks.NewBeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{}})
 				require.NoError(t, err)
 				return b
@@ -148,7 +148,7 @@ func Test_NotifyForkchoiceUpdate(t *testing.T) {
 		},
 		{
 			name: "altair block",
-			blk: func() interfaces.BeaconBlock {
+			blk: func() interfaces.ReadOnlyBeaconBlock {
 				b, err := consensusblocks.NewBeaconBlock(&ethpb.BeaconBlockAltair{Body: &ethpb.BeaconBlockBodyAltair{}})
 				require.NoError(t, err)
 				return b
@@ -156,7 +156,7 @@ func Test_NotifyForkchoiceUpdate(t *testing.T) {
 		},
 		{
 			name: "not execution block",
-			blk: func() interfaces.BeaconBlock {
+			blk: func() interfaces.ReadOnlyBeaconBlock {
 				b, err := consensusblocks.NewBeaconBlock(&ethpb.BeaconBlockBellatrix{
 					Body: &ethpb.BeaconBlockBodyBellatrix{
 						ExecutionPayload: &v1.ExecutionPayload{
@@ -177,7 +177,7 @@ func Test_NotifyForkchoiceUpdate(t *testing.T) {
 		},
 		{
 			name: "happy case: finalized root is altair block",
-			blk: func() interfaces.BeaconBlock {
+			blk: func() interfaces.ReadOnlyBeaconBlock {
 				b, err := consensusblocks.NewBeaconBlock(&ethpb.BeaconBlockBellatrix{
 					Body: &ethpb.BeaconBlockBodyBellatrix{
 						ExecutionPayload: &v1.ExecutionPayload{},
@@ -191,7 +191,7 @@ func Test_NotifyForkchoiceUpdate(t *testing.T) {
 		},
 		{
 			name: "happy case: finalized root is bellatrix block",
-			blk: func() interfaces.BeaconBlock {
+			blk: func() interfaces.ReadOnlyBeaconBlock {
 				b, err := consensusblocks.NewBeaconBlock(&ethpb.BeaconBlockBellatrix{
 					Body: &ethpb.BeaconBlockBodyBellatrix{
 						ExecutionPayload: &v1.ExecutionPayload{},
@@ -205,7 +205,7 @@ func Test_NotifyForkchoiceUpdate(t *testing.T) {
 		},
 		{
 			name: "forkchoice updated with optimistic block",
-			blk: func() interfaces.BeaconBlock {
+			blk: func() interfaces.ReadOnlyBeaconBlock {
 				b, err := consensusblocks.NewBeaconBlock(&ethpb.BeaconBlockBellatrix{
 					Body: &ethpb.BeaconBlockBodyBellatrix{
 						ExecutionPayload: &v1.ExecutionPayload{},
@@ -220,7 +220,7 @@ func Test_NotifyForkchoiceUpdate(t *testing.T) {
 		},
 		{
 			name: "forkchoice updated with invalid block",
-			blk: func() interfaces.BeaconBlock {
+			blk: func() interfaces.ReadOnlyBeaconBlock {
 				b, err := consensusblocks.NewBeaconBlock(&ethpb.BeaconBlockBellatrix{
 					Body: &ethpb.BeaconBlockBodyBellatrix{
 						ExecutionPayload: &v1.ExecutionPayload{},
@@ -548,7 +548,7 @@ func Test_NotifyNewPayload(t *testing.T) {
 		postState      bstate.BeaconState
 		invalidBlock   bool
 		isValidPayload bool
-		blk            interfaces.SignedBeaconBlock
+		blk            interfaces.ReadOnlySignedBeaconBlock
 		newPayloadErr  error
 		errString      string
 		name           string
@@ -594,7 +594,7 @@ func Test_NotifyNewPayload(t *testing.T) {
 		{
 			name:      "altair pre state, happy case",
 			postState: bellatrixState,
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				blk := &ethpb.SignedBeaconBlockBellatrix{
 					Block: &ethpb.BeaconBlockBellatrix{
 						Body: &ethpb.BeaconBlockBodyBellatrix{
@@ -613,7 +613,7 @@ func Test_NotifyNewPayload(t *testing.T) {
 		{
 			name:      "not at merge transition",
 			postState: bellatrixState,
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				blk := &ethpb.SignedBeaconBlockBellatrix{
 					Block: &ethpb.BeaconBlockBellatrix{
 						Body: &ethpb.BeaconBlockBodyBellatrix{
@@ -639,7 +639,7 @@ func Test_NotifyNewPayload(t *testing.T) {
 		{
 			name:      "happy case",
 			postState: bellatrixState,
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				blk := &ethpb.SignedBeaconBlockBellatrix{
 					Block: &ethpb.BeaconBlockBellatrix{
 						Body: &ethpb.BeaconBlockBodyBellatrix{
@@ -658,7 +658,7 @@ func Test_NotifyNewPayload(t *testing.T) {
 		{
 			name:      "undefined error from ee",
 			postState: bellatrixState,
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				blk := &ethpb.SignedBeaconBlockBellatrix{
 					Block: &ethpb.BeaconBlockBellatrix{
 						Body: &ethpb.BeaconBlockBodyBellatrix{
@@ -678,7 +678,7 @@ func Test_NotifyNewPayload(t *testing.T) {
 		{
 			name:      "invalid block hash error from ee",
 			postState: bellatrixState,
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				blk := &ethpb.SignedBeaconBlockBellatrix{
 					Block: &ethpb.BeaconBlockBellatrix{
 						Body: &ethpb.BeaconBlockBodyBellatrix{

--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -25,7 +25,7 @@ func (s *Service) isNewHead(r [32]byte) bool {
 	return r != currentHeadRoot || r == [32]byte{}
 }
 
-func (s *Service) getStateAndBlock(ctx context.Context, r [32]byte) (state.BeaconState, interfaces.SignedBeaconBlock, error) {
+func (s *Service) getStateAndBlock(ctx context.Context, r [32]byte) (state.BeaconState, interfaces.ReadOnlySignedBeaconBlock, error) {
 	if !s.hasBlockInInitSyncOrDB(ctx, r) {
 		return nil, nil, errors.New("block does not exist")
 	}

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -52,14 +52,14 @@ func (s *Service) UpdateAndSaveHeadWithBalances(ctx context.Context) error {
 
 // This defines the current chain service's view of head.
 type head struct {
-	root  [32]byte                     // current head root.
-	block interfaces.SignedBeaconBlock // current head block.
-	state state.BeaconState            // current head state.
+	root  [32]byte                             // current head root.
+	block interfaces.ReadOnlySignedBeaconBlock // current head block.
+	state state.BeaconState                    // current head state.
 }
 
 // This saves head info to the local service cache, it also saves the
 // new head root to the DB.
-func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock interfaces.SignedBeaconBlock, headState state.BeaconState) error {
+func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock interfaces.ReadOnlySignedBeaconBlock, headState state.BeaconState) error {
 	ctx, span := trace.StartSpan(ctx, "blockChain.saveHead")
 	defer span.End()
 
@@ -177,7 +177,7 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 // This gets called to update canonical root mapping. It does not save head block
 // root in DB. With the inception of initial-sync-cache-state flag, it uses finalized
 // check point as anchors to resume sync therefore head is no longer needed to be saved on per slot basis.
-func (s *Service) saveHeadNoDB(ctx context.Context, b interfaces.SignedBeaconBlock, r [32]byte, hs state.BeaconState) error {
+func (s *Service) saveHeadNoDB(ctx context.Context, b interfaces.ReadOnlySignedBeaconBlock, r [32]byte, hs state.BeaconState) error {
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func (s *Service) saveHeadNoDB(ctx context.Context, b interfaces.SignedBeaconBlo
 }
 
 // This sets head view object which is used to track the head slot, root, block and state.
-func (s *Service) setHead(root [32]byte, block interfaces.SignedBeaconBlock, state state.BeaconState) error {
+func (s *Service) setHead(root [32]byte, block interfaces.ReadOnlySignedBeaconBlock, state state.BeaconState) error {
 	s.headLock.Lock()
 	defer s.headLock.Unlock()
 
@@ -220,7 +220,7 @@ func (s *Service) setHead(root [32]byte, block interfaces.SignedBeaconBlock, sta
 // This sets head view object which is used to track the head slot, root, block and state. The method
 // assumes that state being passed into the method will not be modified by any other alternate
 // caller which holds the state's reference.
-func (s *Service) setHeadInitialSync(root [32]byte, block interfaces.SignedBeaconBlock, state state.BeaconState) error {
+func (s *Service) setHeadInitialSync(root [32]byte, block interfaces.ReadOnlySignedBeaconBlock, state state.BeaconState) error {
 	s.headLock.Lock()
 	defer s.headLock.Unlock()
 
@@ -260,7 +260,7 @@ func (s *Service) headRoot() [32]byte {
 // This returns the head block.
 // It does a full copy on head block for immutability.
 // This is a lock free version.
-func (s *Service) headBlock() (interfaces.SignedBeaconBlock, error) {
+func (s *Service) headBlock() (interfaces.ReadOnlySignedBeaconBlock, error) {
 	return s.head.block.Copy()
 }
 

--- a/beacon-chain/blockchain/init_sync_process_block.go
+++ b/beacon-chain/blockchain/init_sync_process_block.go
@@ -10,7 +10,7 @@ import (
 
 // This saves a beacon block to the initial sync blocks cache. It rate limits how many blocks
 // the cache keeps in memory (2 epochs worth of blocks) and saves them to DB when it hits this limit.
-func (s *Service) saveInitSyncBlock(ctx context.Context, r [32]byte, b interfaces.SignedBeaconBlock) error {
+func (s *Service) saveInitSyncBlock(ctx context.Context, r [32]byte, b interfaces.ReadOnlySignedBeaconBlock) error {
 	s.initSyncBlocksLock.Lock()
 	s.initSyncBlocks[r] = b
 	numBlocks := len(s.initSyncBlocks)
@@ -43,7 +43,7 @@ func (s *Service) hasBlockInInitSyncOrDB(ctx context.Context, r [32]byte) bool {
 
 // Returns block for a given root `r` from either the initial sync blocks cache or the DB.
 // Error is returned if the block is not found in either cache or DB.
-func (s *Service) getBlock(ctx context.Context, r [32]byte) (interfaces.SignedBeaconBlock, error) {
+func (s *Service) getBlock(ctx context.Context, r [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	s.initSyncBlocksLock.RLock()
 
 	// Check cache first because it's faster.
@@ -64,11 +64,11 @@ func (s *Service) getBlock(ctx context.Context, r [32]byte) (interfaces.SignedBe
 
 // This retrieves all the beacon blocks from the initial sync blocks cache, the returned
 // blocks are unordered.
-func (s *Service) getInitSyncBlocks() []interfaces.SignedBeaconBlock {
+func (s *Service) getInitSyncBlocks() []interfaces.ReadOnlySignedBeaconBlock {
 	s.initSyncBlocksLock.RLock()
 	defer s.initSyncBlocksLock.RUnlock()
 
-	blks := make([]interfaces.SignedBeaconBlock, 0, len(s.initSyncBlocks))
+	blks := make([]interfaces.ReadOnlySignedBeaconBlock, 0, len(s.initSyncBlocks))
 	for _, b := range s.initSyncBlocks {
 		blks = append(blks, b)
 	}
@@ -79,5 +79,5 @@ func (s *Service) getInitSyncBlocks() []interfaces.SignedBeaconBlock {
 func (s *Service) clearInitSyncBlocks() {
 	s.initSyncBlocksLock.Lock()
 	defer s.initSyncBlocksLock.Unlock()
-	s.initSyncBlocks = make(map[[32]byte]interfaces.SignedBeaconBlock)
+	s.initSyncBlocks = make(map[[32]byte]interfaces.ReadOnlySignedBeaconBlock)
 }

--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -21,7 +21,7 @@ import (
 var log = logrus.WithField("prefix", "blockchain")
 
 // logs state transition related data every slot.
-func logStateTransitionData(b interfaces.BeaconBlock) error {
+func logStateTransitionData(b interfaces.ReadOnlyBeaconBlock) error {
 	log := log.WithField("slot", b.Slot())
 	if len(b.Body().Attestations()) > 0 {
 		log = log.WithField("attestations", len(b.Body().Attestations()))
@@ -66,7 +66,7 @@ func logStateTransitionData(b interfaces.BeaconBlock) error {
 	return nil
 }
 
-func logBlockSyncStatus(block interfaces.BeaconBlock, blockRoot [32]byte, justified, finalized *ethpb.Checkpoint, receivedTime time.Time, genesisTime uint64) error {
+func logBlockSyncStatus(block interfaces.ReadOnlyBeaconBlock, blockRoot [32]byte, justified, finalized *ethpb.Checkpoint, receivedTime time.Time, genesisTime uint64) error {
 	startTime, err := slots.ToTime(genesisTime, block.Slot())
 	if err != nil {
 		return err
@@ -102,7 +102,7 @@ func logBlockSyncStatus(block interfaces.BeaconBlock, blockRoot [32]byte, justif
 }
 
 // logs payload related data every slot.
-func logPayload(block interfaces.BeaconBlock) error {
+func logPayload(block interfaces.ReadOnlyBeaconBlock) error {
 	isExecutionBlk, err := blocks.IsExecutionBlock(block.Body())
 	if err != nil {
 		return errors.Wrap(err, "could not determine if block is execution block")

--- a/beacon-chain/blockchain/log_test.go
+++ b/beacon-chain/blockchain/log_test.go
@@ -25,11 +25,11 @@ func Test_logStateTransitionData(t *testing.T) {
 	require.NoError(t, err)
 	tests := []struct {
 		name string
-		b    func() interfaces.BeaconBlock
+		b    func() interfaces.ReadOnlyBeaconBlock
 		want string
 	}{
 		{name: "empty block body",
-			b: func() interfaces.BeaconBlock {
+			b: func() interfaces.ReadOnlyBeaconBlock {
 				wb, err := blocks.NewBeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{}})
 				require.NoError(t, err)
 				return wb
@@ -37,7 +37,7 @@ func Test_logStateTransitionData(t *testing.T) {
 			want: "\"Finished applying state transition\" prefix=blockchain slot=0",
 		},
 		{name: "has attestation",
-			b: func() interfaces.BeaconBlock {
+			b: func() interfaces.ReadOnlyBeaconBlock {
 				wb, err := blocks.NewBeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{Attestations: []*ethpb.Attestation{{}}}})
 				require.NoError(t, err)
 				return wb
@@ -45,7 +45,7 @@ func Test_logStateTransitionData(t *testing.T) {
 			want: "\"Finished applying state transition\" attestations=1 prefix=blockchain slot=0",
 		},
 		{name: "has deposit",
-			b: func() interfaces.BeaconBlock {
+			b: func() interfaces.ReadOnlyBeaconBlock {
 				wb, err := blocks.NewBeaconBlock(
 					&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
 						Attestations: []*ethpb.Attestation{{}},
@@ -56,7 +56,7 @@ func Test_logStateTransitionData(t *testing.T) {
 			want: "\"Finished applying state transition\" attestations=1 deposits=1 prefix=blockchain slot=0",
 		},
 		{name: "has attester slashing",
-			b: func() interfaces.BeaconBlock {
+			b: func() interfaces.ReadOnlyBeaconBlock {
 				wb, err := blocks.NewBeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
 					AttesterSlashings: []*ethpb.AttesterSlashing{{}}}})
 				require.NoError(t, err)
@@ -65,7 +65,7 @@ func Test_logStateTransitionData(t *testing.T) {
 			want: "\"Finished applying state transition\" attesterSlashings=1 prefix=blockchain slot=0",
 		},
 		{name: "has proposer slashing",
-			b: func() interfaces.BeaconBlock {
+			b: func() interfaces.ReadOnlyBeaconBlock {
 				wb, err := blocks.NewBeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
 					ProposerSlashings: []*ethpb.ProposerSlashing{{}}}})
 				require.NoError(t, err)
@@ -74,7 +74,7 @@ func Test_logStateTransitionData(t *testing.T) {
 			want: "\"Finished applying state transition\" prefix=blockchain proposerSlashings=1 slot=0",
 		},
 		{name: "has exit",
-			b: func() interfaces.BeaconBlock {
+			b: func() interfaces.ReadOnlyBeaconBlock {
 				wb, err := blocks.NewBeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
 					VoluntaryExits: []*ethpb.SignedVoluntaryExit{{}}}})
 				require.NoError(t, err)
@@ -83,7 +83,7 @@ func Test_logStateTransitionData(t *testing.T) {
 			want: "\"Finished applying state transition\" prefix=blockchain slot=0 voluntaryExits=1",
 		},
 		{name: "has everything",
-			b: func() interfaces.BeaconBlock {
+			b: func() interfaces.ReadOnlyBeaconBlock {
 				wb, err := blocks.NewBeaconBlock(&ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{
 					Attestations:      []*ethpb.Attestation{{}},
 					Deposits:          []*ethpb.Deposit{{}},
@@ -96,7 +96,7 @@ func Test_logStateTransitionData(t *testing.T) {
 			want: "\"Finished applying state transition\" attestations=1 attesterSlashings=1 deposits=1 prefix=blockchain proposerSlashings=1 slot=0 voluntaryExits=1",
 		},
 		{name: "has payload",
-			b:    func() interfaces.BeaconBlock { return wrappedPayloadBlk },
+			b:    func() interfaces.ReadOnlyBeaconBlock { return wrappedPayloadBlk },
 			want: "\"Finished applying state transition\" payloadHash=0x010203 prefix=blockchain slot=0 syncBitsCount=0 txCount=2",
 		},
 	}

--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -353,7 +353,7 @@ func reportEpochMetrics(ctx context.Context, postState, headState state.BeaconSt
 	return nil
 }
 
-func reportAttestationInclusion(blk interfaces.BeaconBlock) {
+func reportAttestationInclusion(blk interfaces.ReadOnlyBeaconBlock) {
 	for _, att := range blk.Body().Attestations() {
 		attestationInclusionDelay.Observe(float64(blk.Slot() - att.Data.Slot))
 	}

--- a/beacon-chain/blockchain/pow_block.go
+++ b/beacon-chain/blockchain/pow_block.go
@@ -22,7 +22,7 @@ import (
 
 // validateMergeBlock validates terminal block hash in the event of manual overrides before checking for total difficulty.
 //
-// def validate_merge_block(block: BeaconBlock) -> None:
+// def validate_merge_block(block: ReadOnlyBeaconBlock) -> None:
 //
 //	if TERMINAL_BLOCK_HASH != Hash32():
 //	    # If `TERMINAL_BLOCK_HASH` is used as an override, the activation epoch must be reached.
@@ -38,7 +38,7 @@ import (
 //	assert pow_parent is not None
 //	# Check if `pow_block` is a valid terminal PoW block
 //	assert is_valid_terminal_pow_block(pow_block, pow_parent)
-func (s *Service) validateMergeBlock(ctx context.Context, b interfaces.SignedBeaconBlock) error {
+func (s *Service) validateMergeBlock(ctx context.Context, b interfaces.ReadOnlySignedBeaconBlock) error {
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
 		return err
 	}

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -28,7 +28,7 @@ func (s *Service) CurrentSlot() primitives.Slot {
 // getBlockPreState returns the pre state of an incoming block. It uses the parent root of the block
 // to retrieve the state in DB. It verifies the pre state's validity and the incoming block
 // is in the correct time window.
-func (s *Service) getBlockPreState(ctx context.Context, b interfaces.BeaconBlock) (state.BeaconState, error) {
+func (s *Service) getBlockPreState(ctx context.Context, b interfaces.ReadOnlyBeaconBlock) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "blockChain.getBlockPreState")
 	defer span.End()
 
@@ -59,7 +59,7 @@ func (s *Service) getBlockPreState(ctx context.Context, b interfaces.BeaconBlock
 }
 
 // verifyBlkPreState validates input block has a valid pre-state.
-func (s *Service) verifyBlkPreState(ctx context.Context, b interfaces.BeaconBlock) error {
+func (s *Service) verifyBlkPreState(ctx context.Context, b interfaces.ReadOnlyBeaconBlock) error {
 	ctx, span := trace.StartSpan(ctx, "blockChain.verifyBlkPreState")
 	defer span.End()
 
@@ -119,7 +119,7 @@ func (s *Service) VerifyFinalizedBlkDescendant(ctx context.Context, root [32]byt
 
 // verifyBlkFinalizedSlot validates input block is not less than or equal
 // to current finalized slot.
-func (s *Service) verifyBlkFinalizedSlot(b interfaces.BeaconBlock) error {
+func (s *Service) verifyBlkFinalizedSlot(b interfaces.ReadOnlyBeaconBlock) error {
 	finalized := s.ForkChoicer().FinalizedCheckpoint()
 	finalizedSlot, err := slots.EpochStart(finalized.Epoch)
 	if err != nil {
@@ -250,7 +250,7 @@ func (s *Service) ancestorByDB(ctx context.Context, r [32]byte, slot primitives.
 
 // This retrieves missing blocks from DB (ie. the blocks that couldn't be received over sync) and inserts them to fork choice store.
 // This is useful for block tree visualizer and additional vote accounting.
-func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, blk interfaces.BeaconBlock,
+func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, blk interfaces.ReadOnlyBeaconBlock,
 	fCheckpoint, jCheckpoint *ethpb.Checkpoint) error {
 	pendingNodes := make([]*forkchoicetypes.BlockAndCheckpoints, 0)
 

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -157,7 +157,7 @@ func TestStore_OnBlockBatch(t *testing.T) {
 	require.NoError(t, service.saveGenesisData(ctx, st))
 	bState := st.Copy()
 
-	var blks []interfaces.SignedBeaconBlock
+	var blks []interfaces.ReadOnlySignedBeaconBlock
 	var blkRoots [][32]byte
 	for i := 0; i < 97; i++ {
 		b, err := util.GenerateFullBlock(bState, keys, util.DefaultBlockGenConfig(), primitives.Slot(i))
@@ -200,7 +200,7 @@ func TestStore_OnBlockBatch_NotifyNewPayload(t *testing.T) {
 	require.NoError(t, service.saveGenesisData(ctx, st))
 	bState := st.Copy()
 
-	var blks []interfaces.SignedBeaconBlock
+	var blks []interfaces.ReadOnlySignedBeaconBlock
 	var blkRoots [][32]byte
 	blkCount := 4
 	for i := 0; i <= blkCount; i++ {

--- a/beacon-chain/blockchain/receive_block_test.go
+++ b/beacon-chain/blockchain/receive_block_test.go
@@ -261,7 +261,7 @@ func TestService_ReceiveBlockBatch(t *testing.T) {
 			require.NoError(t, err)
 			wsb, err := blocks.NewSignedBeaconBlock(tt.args.block)
 			require.NoError(t, err)
-			blks := []interfaces.SignedBeaconBlock{wsb}
+			blks := []interfaces.ReadOnlySignedBeaconBlock{wsb}
 			roots := [][32]byte{root}
 			err = s.ReceiveBlockBatch(ctx, blks, roots)
 			if tt.wantedErr != "" {

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -54,7 +54,7 @@ type Service struct {
 	nextEpochBoundarySlot   primitives.Slot
 	boundaryRoots           [][32]byte
 	checkpointStateCache    *cache.CheckpointStateCache
-	initSyncBlocks          map[[32]byte]interfaces.SignedBeaconBlock
+	initSyncBlocks          map[[32]byte]interfaces.ReadOnlySignedBeaconBlock
 	initSyncBlocksLock      sync.RWMutex
 	justifiedBalances       *stateBalanceCache
 	wsVerifier              *WeakSubjectivityVerifier
@@ -94,7 +94,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		cancel:               cancel,
 		boundaryRoots:        [][32]byte{},
 		checkpointStateCache: cache.NewCheckpointStateCache(),
-		initSyncBlocks:       make(map[[32]byte]interfaces.SignedBeaconBlock),
+		initSyncBlocks:       make(map[[32]byte]interfaces.ReadOnlySignedBeaconBlock),
 		cfg:                  &config{ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache()},
 	}
 	for _, opt := range opts {

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -443,7 +443,7 @@ func TestServiceStop_SaveCachedBlocks(t *testing.T) {
 		cfg:            &config{BeaconDB: beaconDB, StateGen: stategen.New(beaconDB, doublylinkedtree.New())},
 		ctx:            ctx,
 		cancel:         cancel,
-		initSyncBlocks: make(map[[32]byte]interfaces.SignedBeaconBlock),
+		initSyncBlocks: make(map[[32]byte]interfaces.ReadOnlySignedBeaconBlock),
 	}
 	bb := util.NewBeaconBlock()
 	r, err := bb.Block.HashTreeRoot()

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -47,10 +47,10 @@ type ChainService struct {
 	InitSyncBlockRoots          map[[32]byte]bool
 	DB                          db.Database
 	State                       state.BeaconState
-	Block                       interfaces.SignedBeaconBlock
+	Block                       interfaces.ReadOnlySignedBeaconBlock
 	VerifyBlkDescendantErr      error
 	stateNotifier               statefeed.Notifier
-	BlocksReceived              []interfaces.SignedBeaconBlock
+	BlocksReceived              []interfaces.ReadOnlySignedBeaconBlock
 	SyncCommitteeIndices        []primitives.CommitteeIndex
 	blockNotifier               blockfeed.Notifier
 	opNotifier                  opfeed.Notifier
@@ -170,7 +170,7 @@ func (mon *MockOperationNotifier) OperationFeed() *event.Feed {
 }
 
 // ReceiveBlockInitialSync mocks ReceiveBlockInitialSync method in chain service.
-func (s *ChainService) ReceiveBlockInitialSync(ctx context.Context, block interfaces.SignedBeaconBlock, _ [32]byte) error {
+func (s *ChainService) ReceiveBlockInitialSync(ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock, _ [32]byte) error {
 	if s.State == nil {
 		return ErrNilState
 	}
@@ -198,7 +198,7 @@ func (s *ChainService) ReceiveBlockInitialSync(ctx context.Context, block interf
 }
 
 // ReceiveBlockBatch processes blocks in batches from initial-sync.
-func (s *ChainService) ReceiveBlockBatch(ctx context.Context, blks []interfaces.SignedBeaconBlock, _ [][32]byte) error {
+func (s *ChainService) ReceiveBlockBatch(ctx context.Context, blks []interfaces.ReadOnlySignedBeaconBlock, _ [][32]byte) error {
 	if s.State == nil {
 		return ErrNilState
 	}
@@ -228,7 +228,7 @@ func (s *ChainService) ReceiveBlockBatch(ctx context.Context, blks []interfaces.
 }
 
 // ReceiveBlock mocks ReceiveBlock method in chain service.
-func (s *ChainService) ReceiveBlock(ctx context.Context, block interfaces.SignedBeaconBlock, _ [32]byte) error {
+func (s *ChainService) ReceiveBlock(ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock, _ [32]byte) error {
 	if s.ReceiveBlockMockErr != nil {
 		return s.ReceiveBlockMockErr
 	}
@@ -275,7 +275,7 @@ func (s *ChainService) HeadRoot(_ context.Context) ([]byte, error) {
 }
 
 // HeadBlock mocks HeadBlock method in chain service.
-func (s *ChainService) HeadBlock(context.Context) (interfaces.SignedBeaconBlock, error) {
+func (s *ChainService) HeadBlock(context.Context) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	return s.Block, nil
 }
 

--- a/beacon-chain/builder/service.go
+++ b/beacon-chain/builder/service.go
@@ -22,7 +22,7 @@ var ErrNoBuilder = errors.New("builder endpoint not configured")
 
 // BlockBuilder defines the interface for interacting with the block builder
 type BlockBuilder interface {
-	SubmitBlindedBlock(ctx context.Context, block interfaces.SignedBeaconBlock) (interfaces.ExecutionData, error)
+	SubmitBlindedBlock(ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock) (interfaces.ExecutionData, error)
 	GetHeader(ctx context.Context, slot primitives.Slot, parentHash [32]byte, pubKey [48]byte) (builder.SignedBid, error)
 	RegisterValidator(ctx context.Context, reg []*ethpb.SignedValidatorRegistrationV1) error
 	Configured() bool
@@ -82,7 +82,7 @@ func (*Service) Stop() error {
 }
 
 // SubmitBlindedBlock submits a blinded block to the builder relay network.
-func (s *Service) SubmitBlindedBlock(ctx context.Context, b interfaces.SignedBeaconBlock) (interfaces.ExecutionData, error) {
+func (s *Service) SubmitBlindedBlock(ctx context.Context, b interfaces.ReadOnlySignedBeaconBlock) (interfaces.ExecutionData, error) {
 	ctx, span := trace.StartSpan(ctx, "builder.SubmitBlindedBlock")
 	defer span.End()
 	start := time.Now()

--- a/beacon-chain/builder/testing/mock.go
+++ b/beacon-chain/builder/testing/mock.go
@@ -29,7 +29,7 @@ func (s *MockBuilderService) Configured() bool {
 }
 
 // SubmitBlindedBlock for mocking.
-func (s *MockBuilderService) SubmitBlindedBlock(_ context.Context, _ interfaces.SignedBeaconBlock) (interfaces.ExecutionData, error) {
+func (s *MockBuilderService) SubmitBlindedBlock(_ context.Context, _ interfaces.ReadOnlySignedBeaconBlock) (interfaces.ExecutionData, error) {
 	if s.Payload != nil {
 		w, err := blocks.WrappedExecutionPayload(s.Payload)
 		if err != nil {

--- a/beacon-chain/core/altair/attestation.go
+++ b/beacon-chain/core/altair/attestation.go
@@ -24,7 +24,7 @@ import (
 func ProcessAttestationsNoVerifySignature(
 	ctx context.Context,
 	beaconState state.BeaconState,
-	b interfaces.SignedBeaconBlock,
+	b interfaces.ReadOnlySignedBeaconBlock,
 ) (state.BeaconState, error) {
 	if err := consensusblocks.BeaconBlockIsNil(b); err != nil {
 		return nil, err

--- a/beacon-chain/core/blocks/attestation.go
+++ b/beacon-chain/core/blocks/attestation.go
@@ -24,7 +24,7 @@ import (
 func ProcessAttestationsNoVerifySignature(
 	ctx context.Context,
 	beaconState state.BeaconState,
-	b interfaces.SignedBeaconBlock,
+	b interfaces.ReadOnlySignedBeaconBlock,
 ) (state.BeaconState, error) {
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
 		return nil, err

--- a/beacon-chain/core/blocks/genesis.go
+++ b/beacon-chain/core/blocks/genesis.go
@@ -39,7 +39,7 @@ func NewGenesisBlock(stateRoot []byte) *ethpb.SignedBeaconBlock {
 
 var ErrUnrecognizedState = errors.New("unknown underlying type for state.BeaconState value")
 
-func NewGenesisBlockForState(ctx context.Context, st state.BeaconState) (interfaces.SignedBeaconBlock, error) {
+func NewGenesisBlockForState(ctx context.Context, st state.BeaconState) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	root, err := st.HashTreeRoot(ctx)
 	if err != nil {
 		return nil, err

--- a/beacon-chain/core/blocks/header.go
+++ b/beacon-chain/core/blocks/header.go
@@ -18,7 +18,7 @@ import (
 //
 // Spec pseudocode definition:
 //
-//	def process_block_header(state: BeaconState, block: BeaconBlock) -> None:
+//	def process_block_header(state: BeaconState, block: ReadOnlyBeaconBlock) -> None:
 //	  # Verify that the slots match
 //	  assert block.slot == state.slot
 //	  # Verify that the block is newer than latest block header
@@ -42,7 +42,7 @@ import (
 func ProcessBlockHeader(
 	ctx context.Context,
 	beaconState state.BeaconState,
-	block interfaces.SignedBeaconBlock,
+	block interfaces.ReadOnlySignedBeaconBlock,
 ) (state.BeaconState, error) {
 	if err := blocks.BeaconBlockIsNil(block); err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func ProcessBlockHeader(
 //
 // Spec pseudocode definition:
 //
-//	def process_block_header(state: BeaconState, block: BeaconBlock) -> None:
+//	def process_block_header(state: BeaconState, block: ReadOnlyBeaconBlock) -> None:
 //	  # Verify that the slots match
 //	  assert block.slot == state.slot
 //	  # Verify that the block is newer than latest block header

--- a/beacon-chain/core/blocks/payload.go
+++ b/beacon-chain/core/blocks/payload.go
@@ -51,10 +51,10 @@ func IsMergeTransitionComplete(st state.BeaconState) (bool, error) {
 // IsExecutionBlock returns whether the block has a non-empty ExecutionPayload.
 //
 // Spec code:
-// def is_execution_block(block: BeaconBlock) -> bool:
+// def is_execution_block(block: ReadOnlyBeaconBlock) -> bool:
 //
 //	return block.body.execution_payload != ExecutionPayload()
-func IsExecutionBlock(body interfaces.BeaconBlockBody) (bool, error) {
+func IsExecutionBlock(body interfaces.ReadOnlyBeaconBlockBody) (bool, error) {
 	if body == nil {
 		return false, errors.New("nil block body")
 	}
@@ -77,10 +77,10 @@ func IsExecutionBlock(body interfaces.BeaconBlockBody) (bool, error) {
 // Meaning the payload header is beacon state is non-empty or the payload in block body is non-empty.
 //
 // Spec code:
-// def is_execution_enabled(state: BeaconState, body: BeaconBlockBody) -> bool:
+// def is_execution_enabled(state: BeaconState, body: ReadOnlyBeaconBlockBody) -> bool:
 //
 //	return is_merge_block(state, body) or is_merge_complete(state)
-func IsExecutionEnabled(st state.BeaconState, body interfaces.BeaconBlockBody) (bool, error) {
+func IsExecutionEnabled(st state.BeaconState, body interfaces.ReadOnlyBeaconBlockBody) (bool, error) {
 	if st == nil || body == nil {
 		return false, errors.New("nil state or block body")
 	}
@@ -96,7 +96,7 @@ func IsExecutionEnabled(st state.BeaconState, body interfaces.BeaconBlockBody) (
 
 // IsExecutionEnabledUsingHeader returns true if the execution is enabled using post processed payload header and block body.
 // This is an optimized version of IsExecutionEnabled where beacon state is not required as an argument.
-func IsExecutionEnabledUsingHeader(header interfaces.ExecutionData, body interfaces.BeaconBlockBody) (bool, error) {
+func IsExecutionEnabledUsingHeader(header interfaces.ExecutionData, body interfaces.ReadOnlyBeaconBlockBody) (bool, error) {
 	isEmpty, err := blocks.IsEmptyExecutionData(header)
 	if err != nil {
 		return false, err
@@ -280,7 +280,7 @@ func ProcessPayloadHeader(st state.BeaconState, header interfaces.ExecutionData)
 }
 
 // GetBlockPayloadHash returns the hash of the execution payload of the block
-func GetBlockPayloadHash(blk interfaces.BeaconBlock) ([32]byte, error) {
+func GetBlockPayloadHash(blk interfaces.ReadOnlyBeaconBlock) ([32]byte, error) {
 	var payloadHash [32]byte
 	if IsPreBellatrixVersion(blk.Version()) {
 		return payloadHash, nil

--- a/beacon-chain/core/blocks/randao.go
+++ b/beacon-chain/core/blocks/randao.go
@@ -18,7 +18,7 @@ import (
 //
 // Spec pseudocode definition:
 //
-//	def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:
+//	def process_randao(state: BeaconState, body: ReadOnlyBeaconBlockBody) -> None:
 //	 epoch = get_current_epoch(state)
 //	 # Verify RANDAO reveal
 //	 proposer = state.validators[get_beacon_proposer_index(state)]
@@ -30,7 +30,7 @@ import (
 func ProcessRandao(
 	ctx context.Context,
 	beaconState state.BeaconState,
-	b interfaces.SignedBeaconBlock,
+	b interfaces.ReadOnlySignedBeaconBlock,
 ) (state.BeaconState, error) {
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
 		return nil, err

--- a/beacon-chain/core/blocks/signature.go
+++ b/beacon-chain/core/blocks/signature.go
@@ -99,7 +99,7 @@ func VerifyBlockHeaderSignature(beaconState state.BeaconState, header *ethpb.Sig
 // VerifyBlockSignatureUsingCurrentFork verifies the proposer signature of a beacon block. This differs
 // from the above method by not using fork data from the state and instead retrieving it
 // via the respective epoch.
-func VerifyBlockSignatureUsingCurrentFork(beaconState state.ReadOnlyBeaconState, blk interfaces.SignedBeaconBlock) error {
+func VerifyBlockSignatureUsingCurrentFork(beaconState state.ReadOnlyBeaconState, blk interfaces.ReadOnlySignedBeaconBlock) error {
 	currentEpoch := slots.ToEpoch(blk.Block().Slot())
 	fork, err := forks.Fork(currentEpoch)
 	if err != nil {

--- a/beacon-chain/core/blocks/withdrawals.go
+++ b/beacon-chain/core/blocks/withdrawals.go
@@ -23,7 +23,7 @@ const executionToBLSPadding = 12
 
 func ProcessBLSToExecutionChanges(
 	st state.BeaconState,
-	signed interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+	signed interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 	if signed.Version() < version.Capella {
 		return st, nil
 	}

--- a/beacon-chain/core/feed/block/events.go
+++ b/beacon-chain/core/feed/block/events.go
@@ -11,6 +11,6 @@ const (
 
 // ReceivedBlockData is the data sent with ReceivedBlock events.
 type ReceivedBlockData struct {
-	SignedBlock  interfaces.SignedBeaconBlock
+	SignedBlock  interfaces.ReadOnlySignedBeaconBlock
 	IsOptimistic bool
 }

--- a/beacon-chain/core/feed/state/events.go
+++ b/beacon-chain/core/feed/state/events.go
@@ -35,7 +35,7 @@ type BlockProcessedData struct {
 	// BlockRoot of the processed block.
 	BlockRoot [32]byte
 	// SignedBlock is the physical processed block.
-	SignedBlock interfaces.SignedBeaconBlock
+	SignedBlock interfaces.ReadOnlySignedBeaconBlock
 	// Verified is true if the block's BLS contents have been verified.
 	Verified bool
 }

--- a/beacon-chain/core/transition/interop/write_block_to_disk.go
+++ b/beacon-chain/core/transition/interop/write_block_to_disk.go
@@ -11,7 +11,7 @@ import (
 )
 
 // WriteBlockToDisk as a block ssz. Writes to temp directory. Debug!
-func WriteBlockToDisk(block interfaces.SignedBeaconBlock, failed bool) {
+func WriteBlockToDisk(block interfaces.ReadOnlySignedBeaconBlock, failed bool) {
 	if !features.Get().WriteSSZStateTransitions {
 		return
 	}

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -35,7 +35,7 @@ import (
 //
 // Spec pseudocode definition:
 //
-//	def state_transition(state: BeaconState, signed_block: SignedBeaconBlock, validate_result: bool=True) -> None:
+//	def state_transition(state: BeaconState, signed_block: ReadOnlySignedBeaconBlock, validate_result: bool=True) -> None:
 //	  block = signed_block.message
 //	  # Process slots (including those with no blocks) since block
 //	  process_slots(state, block.slot)
@@ -50,7 +50,7 @@ import (
 func ExecuteStateTransition(
 	ctx context.Context,
 	state state.BeaconState,
-	signed interfaces.SignedBeaconBlock,
+	signed interfaces.ReadOnlySignedBeaconBlock,
 ) (state.BeaconState, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -312,7 +312,7 @@ func ProcessSlots(ctx context.Context, state state.BeaconState, slot primitives.
 }
 
 // VerifyOperationLengths verifies that block operation lengths are valid.
-func VerifyOperationLengths(_ context.Context, state state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+func VerifyOperationLengths(_ context.Context, state state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
 		return nil, err
 	}

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -29,7 +29,7 @@ import (
 //
 // Spec pseudocode definition:
 //
-//	def state_transition(state: BeaconState, signed_block: SignedBeaconBlock, validate_result: bool=True) -> None:
+//	def state_transition(state: BeaconState, signed_block: ReadOnlySignedBeaconBlock, validate_result: bool=True) -> None:
 //	  block = signed_block.message
 //	  # Process slots (including those with no blocks) since block
 //	  process_slots(state, block.slot)
@@ -44,7 +44,7 @@ import (
 func ExecuteStateTransitionNoVerifyAnySig(
 	ctx context.Context,
 	st state.BeaconState,
-	signed interfaces.SignedBeaconBlock,
+	signed interfaces.ReadOnlySignedBeaconBlock,
 ) (*bls.SignatureBatch, state.BeaconState, error) {
 	if ctx.Err() != nil {
 		return nil, nil, ctx.Err()
@@ -96,7 +96,7 @@ func ExecuteStateTransitionNoVerifyAnySig(
 //
 // Spec pseudocode definition:
 //
-//	def state_transition(state: BeaconState, signed_block: SignedBeaconBlock, validate_result: bool=True) -> None:
+//	def state_transition(state: BeaconState, signed_block: ReadOnlySignedBeaconBlock, validate_result: bool=True) -> None:
 //	  block = signed_block.message
 //	  # Process slots (including those with no blocks) since block
 //	  process_slots(state, block.slot)
@@ -111,7 +111,7 @@ func ExecuteStateTransitionNoVerifyAnySig(
 func CalculateStateRoot(
 	ctx context.Context,
 	state state.BeaconState,
-	signed interfaces.SignedBeaconBlock,
+	signed interfaces.ReadOnlySignedBeaconBlock,
 ) ([32]byte, error) {
 	ctx, span := trace.StartSpan(ctx, "core.state.CalculateStateRoot")
 	defer span.End()
@@ -153,7 +153,7 @@ func CalculateStateRoot(
 //
 // Spec pseudocode definition:
 //
-//	def process_block(state: BeaconState, block: BeaconBlock) -> None:
+//	def process_block(state: BeaconState, block: ReadOnlyBeaconBlock) -> None:
 //	  process_block_header(state, block)
 //	  process_randao(state, block.body)
 //	  process_eth1_data(state, block.body)
@@ -161,7 +161,7 @@ func CalculateStateRoot(
 func ProcessBlockNoVerifyAnySig(
 	ctx context.Context,
 	st state.BeaconState,
-	signed interfaces.SignedBeaconBlock,
+	signed interfaces.ReadOnlySignedBeaconBlock,
 ) (*bls.SignatureBatch, state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "core.state.ProcessBlockNoVerifyAnySig")
 	defer span.End()
@@ -222,7 +222,7 @@ func ProcessBlockNoVerifyAnySig(
 //
 // Spec pseudocode definition:
 //
-//	def process_operations(state: BeaconState, body: BeaconBlockBody) -> None:
+//	def process_operations(state: BeaconState, body: ReadOnlyBeaconBlockBody) -> None:
 //	  # Verify that outstanding deposits are processed up to the maximum number of deposits
 //	  assert len(body.deposits) == min(MAX_DEPOSITS, state.eth1_data.deposit_count - state.eth1_deposit_index)
 //
@@ -238,7 +238,7 @@ func ProcessBlockNoVerifyAnySig(
 func ProcessOperationsNoVerifyAttsSigs(
 	ctx context.Context,
 	state state.BeaconState,
-	signedBeaconBlock interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+	signedBeaconBlock interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "core.state.ProcessOperationsNoVerifyAttsSigs")
 	defer span.End()
 	if err := blocks.BeaconBlockIsNil(signedBeaconBlock); err != nil {
@@ -272,7 +272,7 @@ func ProcessOperationsNoVerifyAttsSigs(
 // and randao signature verifications.
 //
 // Spec pseudocode definition:
-// def process_block(state: BeaconState, block: BeaconBlock) -> None:
+// def process_block(state: BeaconState, block: ReadOnlyBeaconBlock) -> None:
 //
 //	process_block_header(state, block)
 //	if is_execution_enabled(state, block.body):
@@ -284,7 +284,7 @@ func ProcessOperationsNoVerifyAttsSigs(
 func ProcessBlockForStateRoot(
 	ctx context.Context,
 	state state.BeaconState,
-	signed interfaces.SignedBeaconBlock,
+	signed interfaces.ReadOnlySignedBeaconBlock,
 ) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "core.state.ProcessBlockForStateRoot")
 	defer span.End()
@@ -363,7 +363,7 @@ func ProcessBlockForStateRoot(
 func altairOperations(
 	ctx context.Context,
 	st state.BeaconState,
-	signedBeaconBlock interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+	signedBeaconBlock interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 	st, err := b.ProcessProposerSlashings(ctx, st, signedBeaconBlock.Block().Body().ProposerSlashings(), v.SlashValidator)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process altair proposer slashing")
@@ -390,7 +390,7 @@ func altairOperations(
 func phase0Operations(
 	ctx context.Context,
 	st state.BeaconState,
-	signedBeaconBlock interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+	signedBeaconBlock interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 	st, err := b.ProcessProposerSlashings(ctx, st, signedBeaconBlock.Block().Body().ProposerSlashings(), v.SlashValidator)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not process block proposer slashings")

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -20,16 +20,16 @@ import (
 // ReadOnlyDatabase defines a struct which only has read access to database methods.
 type ReadOnlyDatabase interface {
 	// Block related methods.
-	Block(ctx context.Context, blockRoot [32]byte) (interfaces.SignedBeaconBlock, error)
-	Blocks(ctx context.Context, f *filters.QueryFilter) ([]interfaces.SignedBeaconBlock, [][32]byte, error)
+	Block(ctx context.Context, blockRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error)
+	Blocks(ctx context.Context, f *filters.QueryFilter) ([]interfaces.ReadOnlySignedBeaconBlock, [][32]byte, error)
 	BlockRoots(ctx context.Context, f *filters.QueryFilter) ([][32]byte, error)
-	BlocksBySlot(ctx context.Context, slot primitives.Slot) ([]interfaces.SignedBeaconBlock, error)
+	BlocksBySlot(ctx context.Context, slot primitives.Slot) ([]interfaces.ReadOnlySignedBeaconBlock, error)
 	BlockRootsBySlot(ctx context.Context, slot primitives.Slot) (bool, [][32]byte, error)
 	HasBlock(ctx context.Context, blockRoot [32]byte) bool
-	GenesisBlock(ctx context.Context) (interfaces.SignedBeaconBlock, error)
+	GenesisBlock(ctx context.Context) (interfaces.ReadOnlySignedBeaconBlock, error)
 	GenesisBlockRoot(ctx context.Context) ([32]byte, error)
 	IsFinalizedBlock(ctx context.Context, blockRoot [32]byte) bool
-	FinalizedChildBlock(ctx context.Context, blockRoot [32]byte) (interfaces.SignedBeaconBlock, error)
+	FinalizedChildBlock(ctx context.Context, blockRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error)
 	HighestRootsBelowSlot(ctx context.Context, slot primitives.Slot) (primitives.Slot, [][32]byte, error)
 	// State related methods.
 	State(ctx context.Context, blockRoot [32]byte) (state.BeaconState, error)
@@ -65,8 +65,8 @@ type NoHeadAccessDatabase interface {
 
 	// Block related methods.
 	DeleteBlock(ctx context.Context, root [32]byte) error
-	SaveBlock(ctx context.Context, block interfaces.SignedBeaconBlock) error
-	SaveBlocks(ctx context.Context, blocks []interfaces.SignedBeaconBlock) error
+	SaveBlock(ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock) error
+	SaveBlocks(ctx context.Context, blocks []interfaces.ReadOnlySignedBeaconBlock) error
 	SaveGenesisBlockRoot(ctx context.Context, blockRoot [32]byte) error
 	// State related methods.
 	SaveState(ctx context.Context, state state.ReadOnlyBeaconState, blockRoot [32]byte) error
@@ -97,7 +97,7 @@ type HeadAccessDatabase interface {
 	NoHeadAccessDatabase
 
 	// Block related methods.
-	HeadBlock(ctx context.Context) (interfaces.SignedBeaconBlock, error)
+	HeadBlock(ctx context.Context) (interfaces.ReadOnlySignedBeaconBlock, error)
 	SaveHeadBlockRoot(ctx context.Context, blockRoot [32]byte) error
 
 	// Genesis operations.

--- a/beacon-chain/db/kv/blocks_test.go
+++ b/beacon-chain/db/kv/blocks_test.go
@@ -21,11 +21,11 @@ import (
 
 var blockTests = []struct {
 	name     string
-	newBlock func(primitives.Slot, []byte) (interfaces.SignedBeaconBlock, error)
+	newBlock func(primitives.Slot, []byte) (interfaces.ReadOnlySignedBeaconBlock, error)
 }{
 	{
 		name: "phase0",
-		newBlock: func(slot primitives.Slot, root []byte) (interfaces.SignedBeaconBlock, error) {
+		newBlock: func(slot primitives.Slot, root []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 			b := util.NewBeaconBlock()
 			b.Block.Slot = slot
 			if root != nil {
@@ -36,7 +36,7 @@ var blockTests = []struct {
 	},
 	{
 		name: "altair",
-		newBlock: func(slot primitives.Slot, root []byte) (interfaces.SignedBeaconBlock, error) {
+		newBlock: func(slot primitives.Slot, root []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 			b := util.NewBeaconBlockAltair()
 			b.Block.Slot = slot
 			if root != nil {
@@ -47,7 +47,7 @@ var blockTests = []struct {
 	},
 	{
 		name: "bellatrix",
-		newBlock: func(slot primitives.Slot, root []byte) (interfaces.SignedBeaconBlock, error) {
+		newBlock: func(slot primitives.Slot, root []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 			b := util.NewBeaconBlockBellatrix()
 			b.Block.Slot = slot
 			if root != nil {
@@ -58,7 +58,7 @@ var blockTests = []struct {
 	},
 	{
 		name: "bellatrix blind",
-		newBlock: func(slot primitives.Slot, root []byte) (interfaces.SignedBeaconBlock, error) {
+		newBlock: func(slot primitives.Slot, root []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 			b := util.NewBlindedBeaconBlockBellatrix()
 			b.Block.Slot = slot
 			if root != nil {
@@ -69,7 +69,7 @@ var blockTests = []struct {
 	},
 	{
 		name: "capella",
-		newBlock: func(slot primitives.Slot, root []byte) (interfaces.SignedBeaconBlock, error) {
+		newBlock: func(slot primitives.Slot, root []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 			b := util.NewBeaconBlockCapella()
 			b.Block.Slot = slot
 			if root != nil {
@@ -80,7 +80,7 @@ var blockTests = []struct {
 	},
 	{
 		name: "capella blind",
-		newBlock: func(slot primitives.Slot, root []byte) (interfaces.SignedBeaconBlock, error) {
+		newBlock: func(slot primitives.Slot, root []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 			b := util.NewBlindedBeaconBlockCapella()
 			b.Block.Slot = slot
 			if root != nil {
@@ -181,7 +181,7 @@ func TestStore_BlocksHandleZeroCase(t *testing.T) {
 			db := setupDB(t)
 			ctx := context.Background()
 			numBlocks := 10
-			totalBlocks := make([]interfaces.SignedBeaconBlock, numBlocks)
+			totalBlocks := make([]interfaces.ReadOnlySignedBeaconBlock, numBlocks)
 			for i := 0; i < len(totalBlocks); i++ {
 				b, err := tt.newBlock(primitives.Slot(i), bytesutil.PadTo([]byte("parent"), 32))
 				require.NoError(t, err)
@@ -204,7 +204,7 @@ func TestStore_BlocksHandleInvalidEndSlot(t *testing.T) {
 			db := setupDB(t)
 			ctx := context.Background()
 			numBlocks := 10
-			totalBlocks := make([]interfaces.SignedBeaconBlock, numBlocks)
+			totalBlocks := make([]interfaces.ReadOnlySignedBeaconBlock, numBlocks)
 			// Save blocks from slot 1 onwards.
 			for i := 0; i < len(totalBlocks); i++ {
 				b, err := tt.newBlock(primitives.Slot(i+1), bytesutil.PadTo([]byte("parent"), 32))
@@ -381,7 +381,7 @@ func TestStore_Blocks_FiltersCorrectly(t *testing.T) {
 			require.NoError(t, err)
 			b8, err := tt.newBlock(primitives.Slot(8), bytesutil.PadTo([]byte("parent4"), 32))
 			require.NoError(t, err)
-			blocks := []interfaces.SignedBeaconBlock{
+			blocks := []interfaces.ReadOnlySignedBeaconBlock{
 				b4,
 				b5,
 				b6,
@@ -485,7 +485,7 @@ func TestStore_Blocks_Retrieve_SlotRange(t *testing.T) {
 	for _, tt := range blockTests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := setupDB(t)
-			totalBlocks := make([]interfaces.SignedBeaconBlock, 500)
+			totalBlocks := make([]interfaces.ReadOnlySignedBeaconBlock, 500)
 			for i := 0; i < 500; i++ {
 				b, err := tt.newBlock(primitives.Slot(i), bytesutil.PadTo([]byte("parent"), 32))
 				require.NoError(t, err)
@@ -505,7 +505,7 @@ func TestStore_Blocks_Retrieve_Epoch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			db := setupDB(t)
 			slots := params.BeaconConfig().SlotsPerEpoch.Mul(7)
-			totalBlocks := make([]interfaces.SignedBeaconBlock, slots)
+			totalBlocks := make([]interfaces.ReadOnlySignedBeaconBlock, slots)
 			for i := primitives.Slot(0); i < slots; i++ {
 				b, err := tt.newBlock(i, bytesutil.PadTo([]byte("parent"), 32))
 				require.NoError(t, err)
@@ -529,7 +529,7 @@ func TestStore_Blocks_Retrieve_SlotRangeWithStep(t *testing.T) {
 	for _, tt := range blockTests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := setupDB(t)
-			totalBlocks := make([]interfaces.SignedBeaconBlock, 500)
+			totalBlocks := make([]interfaces.ReadOnlySignedBeaconBlock, 500)
 			for i := 0; i < 500; i++ {
 				b, err := tt.newBlock(primitives.Slot(i), bytesutil.PadTo([]byte("parent"), 32))
 				require.NoError(t, err)
@@ -722,7 +722,7 @@ func TestStore_SaveBlocks_HasCachedBlocks(t *testing.T) {
 			db := setupDB(t)
 			ctx := context.Background()
 
-			b := make([]interfaces.SignedBeaconBlock, 500)
+			b := make([]interfaces.ReadOnlySignedBeaconBlock, 500)
 			for i := 0; i < 500; i++ {
 				blk, err := tt.newBlock(primitives.Slot(i), bytesutil.PadTo([]byte("parent"), 32))
 				require.NoError(t, err)
@@ -746,7 +746,7 @@ func TestStore_SaveBlocks_HasRootsMatched(t *testing.T) {
 			db := setupDB(t)
 			ctx := context.Background()
 
-			b := make([]interfaces.SignedBeaconBlock, 500)
+			b := make([]interfaces.ReadOnlySignedBeaconBlock, 500)
 			for i := 0; i < 500; i++ {
 				blk, err := tt.newBlock(primitives.Slot(i), bytesutil.PadTo([]byte("parent"), 32))
 				require.NoError(t, err)

--- a/beacon-chain/db/kv/finalized_block_roots.go
+++ b/beacon-chain/db/kv/finalized_block_roots.go
@@ -190,11 +190,11 @@ func (s *Store) IsFinalizedBlock(ctx context.Context, blockRoot [32]byte) bool {
 // FinalizedChildBlock returns the child block of a provided finalized block. If
 // no finalized block or its respective child block exists we return with a nil
 // block.
-func (s *Store) FinalizedChildBlock(ctx context.Context, blockRoot [32]byte) (interfaces.SignedBeaconBlock, error) {
+func (s *Store) FinalizedChildBlock(ctx context.Context, blockRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	ctx, span := trace.StartSpan(ctx, "BeaconDB.FinalizedChildBlock")
 	defer span.End()
 
-	var blk interfaces.SignedBeaconBlock
+	var blk interfaces.ReadOnlySignedBeaconBlock
 	err := s.db.View(func(tx *bolt.Tx) error {
 		blkBytes := tx.Bucket(finalizedBlockRootsIndexBucket).Get(blockRoot[:])
 		if blkBytes == nil {

--- a/beacon-chain/db/kv/finalized_block_roots_test.go
+++ b/beacon-chain/db/kv/finalized_block_roots_test.go
@@ -142,7 +142,7 @@ func TestStore_IsFinalizedChildBlock(t *testing.T) {
 	slotsPerEpoch := uint64(params.BeaconConfig().SlotsPerEpoch)
 	ctx := context.Background()
 
-	eval := func(t testing.TB, ctx context.Context, db *Store, blks []interfaces.SignedBeaconBlock) {
+	eval := func(t testing.TB, ctx context.Context, db *Store, blks []interfaces.ReadOnlySignedBeaconBlock) {
 		require.NoError(t, db.SaveBlocks(ctx, blks))
 		root, err := blks[slotsPerEpoch].Block().HashTreeRoot()
 		require.NoError(t, err)
@@ -193,15 +193,15 @@ func TestStore_IsFinalizedChildBlock(t *testing.T) {
 	})
 }
 
-func sszRootOrDie(t *testing.T, block interfaces.SignedBeaconBlock) []byte {
+func sszRootOrDie(t *testing.T, block interfaces.ReadOnlySignedBeaconBlock) []byte {
 	root, err := block.Block().HashTreeRoot()
 	require.NoError(t, err)
 	return root[:]
 }
 
-func makeBlocks(t *testing.T, i, n uint64, previousRoot [32]byte) []interfaces.SignedBeaconBlock {
+func makeBlocks(t *testing.T, i, n uint64, previousRoot [32]byte) []interfaces.ReadOnlySignedBeaconBlock {
 	blocks := make([]*ethpb.SignedBeaconBlock, n)
-	ifaceBlocks := make([]interfaces.SignedBeaconBlock, n)
+	ifaceBlocks := make([]interfaces.ReadOnlySignedBeaconBlock, n)
 	for j := i; j < n+i; j++ {
 		parentRoot := make([]byte, fieldparams.RootLength)
 		copy(parentRoot, previousRoot[:])
@@ -217,9 +217,9 @@ func makeBlocks(t *testing.T, i, n uint64, previousRoot [32]byte) []interfaces.S
 	return ifaceBlocks
 }
 
-func makeBlocksAltair(t *testing.T, startIdx, num uint64, previousRoot [32]byte) []interfaces.SignedBeaconBlock {
+func makeBlocksAltair(t *testing.T, startIdx, num uint64, previousRoot [32]byte) []interfaces.ReadOnlySignedBeaconBlock {
 	blocks := make([]*ethpb.SignedBeaconBlockAltair, num)
-	ifaceBlocks := make([]interfaces.SignedBeaconBlock, num)
+	ifaceBlocks := make([]interfaces.ReadOnlySignedBeaconBlock, num)
 	for j := startIdx; j < num+startIdx; j++ {
 		parentRoot := make([]byte, fieldparams.RootLength)
 		copy(parentRoot, previousRoot[:])

--- a/beacon-chain/db/kv/state_test.go
+++ b/beacon-chain/db/kv/state_test.go
@@ -368,7 +368,7 @@ func TestStore_StatesBatchDelete(t *testing.T) {
 	db := setupDB(t)
 	ctx := context.Background()
 	numBlocks := 100
-	totalBlocks := make([]interfaces.SignedBeaconBlock, numBlocks)
+	totalBlocks := make([]interfaces.ReadOnlySignedBeaconBlock, numBlocks)
 	blockRoots := make([][32]byte, 0)
 	evenBlockRoots := make([][32]byte, 0)
 	for i := 0; i < len(totalBlocks); i++ {

--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -64,11 +64,11 @@ type ForkchoiceUpdatedResponse struct {
 // to an execution client's engine API.
 type ExecutionPayloadReconstructor interface {
 	ReconstructFullBlock(
-		ctx context.Context, blindedBlock interfaces.SignedBeaconBlock,
-	) (interfaces.SignedBeaconBlockWriteable, error)
+		ctx context.Context, blindedBlock interfaces.ReadOnlySignedBeaconBlock,
+	) (interfaces.SignedBeaconBlock, error)
 	ReconstructFullBellatrixBlockBatch(
-		ctx context.Context, blindedBlocks []interfaces.SignedBeaconBlock,
-	) ([]interfaces.SignedBeaconBlockWriteable, error)
+		ctx context.Context, blindedBlocks []interfaces.ReadOnlySignedBeaconBlock,
+	) ([]interfaces.SignedBeaconBlock, error)
 }
 
 // EngineCaller defines a client that can interact with an Ethereum
@@ -442,8 +442,8 @@ func (s *Service) HeaderByNumber(ctx context.Context, number *big.Int) (*types.H
 // ReconstructFullBlock takes in a blinded beacon block and reconstructs
 // a beacon block with a full execution payload via the engine API.
 func (s *Service) ReconstructFullBlock(
-	ctx context.Context, blindedBlock interfaces.SignedBeaconBlock,
-) (interfaces.SignedBeaconBlockWriteable, error) {
+	ctx context.Context, blindedBlock interfaces.ReadOnlySignedBeaconBlock,
+) (interfaces.SignedBeaconBlock, error) {
 	if err := blocks.BeaconBlockIsNil(blindedBlock); err != nil {
 		return nil, errors.Wrap(err, "cannot reconstruct bellatrix block from nil data")
 	}
@@ -493,10 +493,10 @@ func (s *Service) ReconstructFullBlock(
 // ReconstructFullBellatrixBlockBatch takes in a batch of blinded beacon blocks and reconstructs
 // them with a full execution payload for each block via the engine API.
 func (s *Service) ReconstructFullBellatrixBlockBatch(
-	ctx context.Context, blindedBlocks []interfaces.SignedBeaconBlock,
-) ([]interfaces.SignedBeaconBlockWriteable, error) {
+	ctx context.Context, blindedBlocks []interfaces.ReadOnlySignedBeaconBlock,
+) ([]interfaces.SignedBeaconBlock, error) {
 	if len(blindedBlocks) == 0 {
-		return []interfaces.SignedBeaconBlockWriteable{}, nil
+		return []interfaces.SignedBeaconBlock{}, nil
 	}
 	executionHashes := []common.Hash{}
 	validExecPayloads := []int{}
@@ -532,7 +532,7 @@ func (s *Service) ReconstructFullBellatrixBlockBatch(
 
 	// For each valid payload, we reconstruct the full block from it with the
 	// blinded block.
-	fullBlocks := make([]interfaces.SignedBeaconBlockWriteable, len(blindedBlocks))
+	fullBlocks := make([]interfaces.SignedBeaconBlock, len(blindedBlocks))
 	for sliceIdx, realIdx := range validExecPayloads {
 		b := execBlocks[sliceIdx]
 		if b == nil {

--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -743,7 +743,7 @@ func TestReconstructFullBellatrixBlockBatch(t *testing.T) {
 	t.Run("nil block", func(t *testing.T) {
 		service := &Service{}
 
-		_, err := service.ReconstructFullBellatrixBlockBatch(ctx, []interfaces.SignedBeaconBlock{nil})
+		_, err := service.ReconstructFullBellatrixBlockBatch(ctx, []interfaces.ReadOnlySignedBeaconBlock{nil})
 		require.ErrorContains(t, "nil data", err)
 	})
 	t.Run("only blinded block", func(t *testing.T) {
@@ -752,7 +752,7 @@ func TestReconstructFullBellatrixBlockBatch(t *testing.T) {
 		bellatrixBlock := util.NewBeaconBlockBellatrix()
 		wrapped, err := blocks.NewSignedBeaconBlock(bellatrixBlock)
 		require.NoError(t, err)
-		_, err = service.ReconstructFullBellatrixBlockBatch(ctx, []interfaces.SignedBeaconBlock{wrapped})
+		_, err = service.ReconstructFullBellatrixBlockBatch(ctx, []interfaces.ReadOnlySignedBeaconBlock{wrapped})
 		require.ErrorContains(t, want, err)
 	})
 	t.Run("pre-merge execution payload", func(t *testing.T) {
@@ -767,9 +767,9 @@ func TestReconstructFullBellatrixBlockBatch(t *testing.T) {
 		require.NoError(t, err)
 		wantedWrapped, err := blocks.NewSignedBeaconBlock(wanted)
 		require.NoError(t, err)
-		reconstructed, err := service.ReconstructFullBellatrixBlockBatch(ctx, []interfaces.SignedBeaconBlock{wrapped})
+		reconstructed, err := service.ReconstructFullBellatrixBlockBatch(ctx, []interfaces.ReadOnlySignedBeaconBlock{wrapped})
 		require.NoError(t, err)
-		require.DeepEqual(t, []interfaces.SignedBeaconBlockWriteable{wantedWrapped}, reconstructed)
+		require.DeepEqual(t, []interfaces.SignedBeaconBlock{wantedWrapped}, reconstructed)
 	})
 	t.Run("properly reconstructs block batch with correct payload", func(t *testing.T) {
 		fix := fixtures()
@@ -864,7 +864,7 @@ func TestReconstructFullBellatrixBlockBatch(t *testing.T) {
 		copiedWrapped, err := wrapped.Copy()
 		require.NoError(t, err)
 
-		reconstructed, err := service.ReconstructFullBellatrixBlockBatch(ctx, []interfaces.SignedBeaconBlock{wrappedEmpty, wrapped, copiedWrapped})
+		reconstructed, err := service.ReconstructFullBellatrixBlockBatch(ctx, []interfaces.ReadOnlySignedBeaconBlock{wrappedEmpty, wrapped, copiedWrapped})
 		require.NoError(t, err)
 
 		// Make sure empty blocks are handled correctly

--- a/beacon-chain/execution/testing/mock_engine_client.go
+++ b/beacon-chain/execution/testing/mock_engine_client.go
@@ -88,8 +88,8 @@ func (e *EngineClient) ExecutionBlockByHash(_ context.Context, h common.Hash, _ 
 
 // ReconstructFullBlock --
 func (e *EngineClient) ReconstructFullBlock(
-	_ context.Context, blindedBlock interfaces.SignedBeaconBlock,
-) (interfaces.SignedBeaconBlockWriteable, error) {
+	_ context.Context, blindedBlock interfaces.ReadOnlySignedBeaconBlock,
+) (interfaces.SignedBeaconBlock, error) {
 	if !blindedBlock.Block().IsBlinded() {
 		return nil, errors.New("block must be blinded")
 	}
@@ -107,9 +107,9 @@ func (e *EngineClient) ReconstructFullBlock(
 
 // ReconstructFullBellatrixBlockBatch --
 func (e *EngineClient) ReconstructFullBellatrixBlockBatch(
-	ctx context.Context, blindedBlocks []interfaces.SignedBeaconBlock,
-) ([]interfaces.SignedBeaconBlockWriteable, error) {
-	fullBlocks := make([]interfaces.SignedBeaconBlockWriteable, 0, len(blindedBlocks))
+	ctx context.Context, blindedBlocks []interfaces.ReadOnlySignedBeaconBlock,
+) ([]interfaces.SignedBeaconBlock, error) {
+	fullBlocks := make([]interfaces.SignedBeaconBlock, 0, len(blindedBlocks))
 	for _, b := range blindedBlocks {
 		newBlock, err := e.ReconstructFullBlock(ctx, b)
 		if err != nil {

--- a/beacon-chain/forkchoice/types/types.go
+++ b/beacon-chain/forkchoice/types/types.go
@@ -25,7 +25,7 @@ type Checkpoint struct {
 
 // BlockAndCheckpoints to call the InsertOptimisticChain function
 type BlockAndCheckpoints struct {
-	Block               interfaces.BeaconBlock
+	Block               interfaces.ReadOnlyBeaconBlock
 	JustifiedCheckpoint *ethpb.Checkpoint
 	FinalizedCheckpoint *ethpb.Checkpoint
 }

--- a/beacon-chain/monitor/process_attestation.go
+++ b/beacon-chain/monitor/process_attestation.go
@@ -53,7 +53,7 @@ func logMessageTimelyFlagsForIndex(idx primitives.ValidatorIndex, data *ethpb.At
 }
 
 // processAttestations logs the event for the tracked validators' attestations inclusion in block
-func (s *Service) processAttestations(ctx context.Context, state state.BeaconState, blk interfaces.BeaconBlock) {
+func (s *Service) processAttestations(ctx context.Context, state state.BeaconState, blk interfaces.ReadOnlyBeaconBlock) {
 	if blk == nil || blk.Body() == nil {
 		return
 	}

--- a/beacon-chain/monitor/process_block.go
+++ b/beacon-chain/monitor/process_block.go
@@ -23,7 +23,7 @@ const AggregateReportingPeriod = 5
 // - An Exit by one of our validators was included
 // - A Slashing by one of our tracked validators was included
 // - A Sync Committee Contribution by one of our tracked validators was included
-func (s *Service) processBlock(ctx context.Context, b interfaces.SignedBeaconBlock) {
+func (s *Service) processBlock(ctx context.Context, b interfaces.ReadOnlySignedBeaconBlock) {
 	if b == nil || b.Block() == nil {
 		return
 	}
@@ -64,7 +64,7 @@ func (s *Service) processBlock(ctx context.Context, b interfaces.SignedBeaconBlo
 }
 
 // processProposedBlock logs when the beacon node observes a beacon block from a tracked validator.
-func (s *Service) processProposedBlock(state state.BeaconState, root [32]byte, blk interfaces.BeaconBlock) {
+func (s *Service) processProposedBlock(state state.BeaconState, root [32]byte, blk interfaces.ReadOnlyBeaconBlock) {
 	s.Lock()
 	defer s.Unlock()
 	if s.trackedIndex(blk.ProposerIndex()) {
@@ -102,7 +102,7 @@ func (s *Service) processProposedBlock(state state.BeaconState, root [32]byte, b
 }
 
 // processSlashings logs the event when tracked validators was slashed
-func (s *Service) processSlashings(blk interfaces.BeaconBlock) {
+func (s *Service) processSlashings(blk interfaces.ReadOnlyBeaconBlock) {
 	s.RLock()
 	defer s.RUnlock()
 	for _, slashing := range blk.Body().ProposerSlashings() {

--- a/beacon-chain/monitor/process_exit.go
+++ b/beacon-chain/monitor/process_exit.go
@@ -7,7 +7,7 @@ import (
 )
 
 // processExitsFromBlock logs the event when a tracked validators' exit was included in a block
-func (s *Service) processExitsFromBlock(blk interfaces.BeaconBlock) {
+func (s *Service) processExitsFromBlock(blk interfaces.ReadOnlyBeaconBlock) {
 	s.RLock()
 	defer s.RUnlock()
 	for _, exit := range blk.Body().VoluntaryExits() {

--- a/beacon-chain/monitor/process_sync_committee.go
+++ b/beacon-chain/monitor/process_sync_committee.go
@@ -25,7 +25,7 @@ func (s *Service) processSyncCommitteeContribution(contribution *ethpb.SignedCon
 }
 
 // processSyncAggregate logs the event when tracked validators is a sync-committee member and its contribution has been included
-func (s *Service) processSyncAggregate(state state.BeaconState, blk interfaces.BeaconBlock) {
+func (s *Service) processSyncAggregate(state state.BeaconState, blk interfaces.ReadOnlyBeaconBlock) {
 	if blk == nil || blk.Body() == nil {
 		return
 	}

--- a/beacon-chain/p2p/types/object_mapping.go
+++ b/beacon-chain/p2p/types/object_mapping.go
@@ -22,7 +22,7 @@ func init() {
 var (
 	// BlockMap maps the fork-version to the underlying data type for that
 	// particular fork period.
-	BlockMap map[[4]byte]func() (interfaces.SignedBeaconBlock, error)
+	BlockMap map[[4]byte]func() (interfaces.ReadOnlySignedBeaconBlock, error)
 	// MetaDataMap maps the fork-version to the underlying data type for that
 	// particular fork period.
 	MetaDataMap map[[4]byte]func() metadata.Metadata
@@ -32,23 +32,23 @@ var (
 // reset maps and reinitialize them.
 func InitializeDataMaps() {
 	// Reset our block map.
-	BlockMap = map[[4]byte]func() (interfaces.SignedBeaconBlock, error){
-		bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion): func() (interfaces.SignedBeaconBlock, error) {
+	BlockMap = map[[4]byte]func() (interfaces.ReadOnlySignedBeaconBlock, error){
+		bytesutil.ToBytes4(params.BeaconConfig().GenesisForkVersion): func() (interfaces.ReadOnlySignedBeaconBlock, error) {
 			return blocks.NewSignedBeaconBlock(
 				&ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{}}},
 			)
 		},
-		bytesutil.ToBytes4(params.BeaconConfig().AltairForkVersion): func() (interfaces.SignedBeaconBlock, error) {
+		bytesutil.ToBytes4(params.BeaconConfig().AltairForkVersion): func() (interfaces.ReadOnlySignedBeaconBlock, error) {
 			return blocks.NewSignedBeaconBlock(
 				&ethpb.SignedBeaconBlockAltair{Block: &ethpb.BeaconBlockAltair{Body: &ethpb.BeaconBlockBodyAltair{}}},
 			)
 		},
-		bytesutil.ToBytes4(params.BeaconConfig().BellatrixForkVersion): func() (interfaces.SignedBeaconBlock, error) {
+		bytesutil.ToBytes4(params.BeaconConfig().BellatrixForkVersion): func() (interfaces.ReadOnlySignedBeaconBlock, error) {
 			return blocks.NewSignedBeaconBlock(
 				&ethpb.SignedBeaconBlockBellatrix{Block: &ethpb.BeaconBlockBellatrix{Body: &ethpb.BeaconBlockBodyBellatrix{}}},
 			)
 		},
-		bytesutil.ToBytes4(params.BeaconConfig().CapellaForkVersion): func() (interfaces.SignedBeaconBlock, error) {
+		bytesutil.ToBytes4(params.BeaconConfig().CapellaForkVersion): func() (interfaces.ReadOnlySignedBeaconBlock, error) {
 			return blocks.NewSignedBeaconBlock(
 				&ethpb.SignedBeaconBlockCapella{Block: &ethpb.BeaconBlockCapella{Body: &ethpb.BeaconBlockBodyCapella{}}},
 			)

--- a/beacon-chain/rpc/eth/beacon/blinded_blocks.go
+++ b/beacon-chain/rpc/eth/beacon/blinded_blocks.go
@@ -131,10 +131,10 @@ func (bs *Server) GetBlindedBlockSSZ(ctx context.Context, req *ethpbv1.BlockRequ
 }
 
 // SubmitBlindedBlock instructs the beacon node to use the components of the `SignedBlindedBeaconBlock` to construct
-// and publish a `SignedBeaconBlock` by swapping out the `transactions_root` for the corresponding full list of `transactions`.
-// The beacon node should broadcast a newly constructed `SignedBeaconBlock` to the beacon network,
+// and publish a `ReadOnlySignedBeaconBlock` by swapping out the `transactions_root` for the corresponding full list of `transactions`.
+// The beacon node should broadcast a newly constructed `ReadOnlySignedBeaconBlock` to the beacon network,
 // to be included in the beacon chain. The beacon node is not required to validate the signed
-// `BeaconBlock`, and a successful response (20X) only indicates that the broadcast has been
+// `ReadOnlyBeaconBlock`, and a successful response (20X) only indicates that the broadcast has been
 // successful. The beacon node is expected to integrate the new block into its state, and
 // therefore validate the block internally, however blocks which fail the validation are still
 // broadcast but a different status code is returned (202).
@@ -167,10 +167,10 @@ func (bs *Server) SubmitBlindedBlock(ctx context.Context, req *ethpbv2.SignedBli
 }
 
 // SubmitBlindedBlockSSZ instructs the beacon node to use the components of the `SignedBlindedBeaconBlock` to construct
-// and publish a `SignedBeaconBlock` by swapping out the `transactions_root` for the corresponding full list of `transactions`.
-// The beacon node should broadcast a newly constructed `SignedBeaconBlock` to the beacon network,
+// and publish a `ReadOnlySignedBeaconBlock` by swapping out the `transactions_root` for the corresponding full list of `transactions`.
+// The beacon node should broadcast a newly constructed `ReadOnlySignedBeaconBlock` to the beacon network,
 // to be included in the beacon chain. The beacon node is not required to validate the signed
-// `BeaconBlock`, and a successful response (20X) only indicates that the broadcast has been
+// `ReadOnlyBeaconBlock`, and a successful response (20X) only indicates that the broadcast has been
 // successful. The beacon node is expected to integrate the new block into its state, and
 // therefore validate the block internally, however blocks which fail the validation are still
 // broadcast but a different status code is returned (202).
@@ -229,7 +229,7 @@ func (bs *Server) SubmitBlindedBlockSSZ(ctx context.Context, req *ethpbv2.SSZCon
 	return &emptypb.Empty{}, bs.submitBlock(ctx, root, block)
 }
 
-func getBlindedBlockPhase0(blk interfaces.SignedBeaconBlock) (*ethpbv2.BlindedBlockResponse, error) {
+func getBlindedBlockPhase0(blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.BlindedBlockResponse, error) {
 	phase0Blk, err := blk.PbPhase0Block()
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func getBlindedBlockPhase0(blk interfaces.SignedBeaconBlock) (*ethpbv2.BlindedBl
 	}, nil
 }
 
-func getBlindedBlockAltair(blk interfaces.SignedBeaconBlock) (*ethpbv2.BlindedBlockResponse, error) {
+func getBlindedBlockAltair(blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.BlindedBlockResponse, error) {
 	altairBlk, err := blk.PbAltairBlock()
 	if err != nil {
 		return nil, err
@@ -274,7 +274,7 @@ func getBlindedBlockAltair(blk interfaces.SignedBeaconBlock) (*ethpbv2.BlindedBl
 	}, nil
 }
 
-func (bs *Server) getBlindedBlockBellatrix(ctx context.Context, blk interfaces.SignedBeaconBlock) (*ethpbv2.BlindedBlockResponse, error) {
+func (bs *Server) getBlindedBlockBellatrix(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.BlindedBlockResponse, error) {
 	bellatrixBlk, err := blk.PbBellatrixBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
@@ -344,7 +344,7 @@ func (bs *Server) getBlindedBlockBellatrix(ctx context.Context, blk interfaces.S
 	}, nil
 }
 
-func (bs *Server) getBlindedBlockCapella(ctx context.Context, blk interfaces.SignedBeaconBlock) (*ethpbv2.BlindedBlockResponse, error) {
+func (bs *Server) getBlindedBlockCapella(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.BlindedBlockResponse, error) {
 	capellaBlk, err := blk.PbCapellaBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
@@ -414,7 +414,7 @@ func (bs *Server) getBlindedBlockCapella(ctx context.Context, blk interfaces.Sig
 	}, nil
 }
 
-func (bs *Server) getBlindedSSZBlockBellatrix(ctx context.Context, blk interfaces.SignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
+func (bs *Server) getBlindedSSZBlockBellatrix(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
 	bellatrixBlk, err := blk.PbBellatrixBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
@@ -489,7 +489,7 @@ func (bs *Server) getBlindedSSZBlockBellatrix(ctx context.Context, blk interface
 	return &ethpbv2.SSZContainer{Version: ethpbv2.Version_BELLATRIX, ExecutionOptimistic: isOptimistic, Data: sszData}, nil
 }
 
-func (bs *Server) getBlindedSSZBlockCapella(ctx context.Context, blk interfaces.SignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
+func (bs *Server) getBlindedSSZBlockCapella(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
 	capellaBlk, err := blk.PbCapellaBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type

--- a/beacon-chain/rpc/eth/beacon/blocks.go
+++ b/beacon-chain/rpc/eth/beacon/blocks.go
@@ -147,7 +147,7 @@ func (bs *Server) ListBlockHeaders(ctx context.Context, req *ethpbv1.BlockHeader
 	defer span.End()
 
 	var err error
-	var blks []interfaces.SignedBeaconBlock
+	var blks []interfaces.ReadOnlySignedBeaconBlock
 	var blkRoots [][32]byte
 	if len(req.ParentRoot) == 32 {
 		blks, blkRoots, err = bs.BeaconDB.Blocks(ctx, filters.NewFilter().SetParentRoot(req.ParentRoot))
@@ -212,7 +212,7 @@ func (bs *Server) ListBlockHeaders(ctx context.Context, req *ethpbv1.BlockHeader
 }
 
 // SubmitBlock instructs the beacon node to broadcast a newly signed beacon block to the beacon network, to be
-// included in the beacon chain. The beacon node is not required to validate the signed BeaconBlock, and a successful
+// included in the beacon chain. The beacon node is not required to validate the signed ReadOnlyBeaconBlock, and a successful
 // response (20X) only indicates that the broadcast has been successful. The beacon node is expected to integrate the
 // new block into its state, and therefore validate the block internally, however blocks which fail the validation are
 // still broadcast but a different status code is returned (202).
@@ -245,7 +245,7 @@ func (bs *Server) SubmitBlock(ctx context.Context, req *ethpbv2.SignedBeaconBloc
 }
 
 // SubmitBlockSSZ instructs the beacon node to broadcast a newly signed beacon block to the beacon network, to be
-// included in the beacon chain. The beacon node is not required to validate the signed BeaconBlock, and a successful
+// included in the beacon chain. The beacon node is not required to validate the signed ReadOnlyBeaconBlock, and a successful
 // response (20X) only indicates that the broadcast has been successful. The beacon node is expected to integrate the
 // new block into its state, and therefore validate the block internally, however blocks which fail the validation are
 // still broadcast but a different status code is returned (202).
@@ -437,7 +437,7 @@ func (bs *Server) GetBlockSSZV2(ctx context.Context, req *ethpbv2.BlockRequestV2
 	return nil, status.Errorf(codes.Internal, "Unknown block type %T", blk)
 }
 
-// GetBlockRoot retrieves hashTreeRoot of BeaconBlock/BeaconBlockHeader.
+// GetBlockRoot retrieves hashTreeRoot of ReadOnlyBeaconBlock/BeaconBlockHeader.
 func (bs *Server) GetBlockRoot(ctx context.Context, req *ethpbv1.BlockRequest) (*ethpbv1.BlockRootResponse, error) {
 	ctx, span := trace.StartSpan(ctx, "beacon.GetBlockRoot")
 	defer span.End()
@@ -556,9 +556,9 @@ func (bs *Server) ListBlockAttestations(ctx context.Context, req *ethpbv1.BlockR
 	}, nil
 }
 
-func (bs *Server) blockFromBlockID(ctx context.Context, blockId []byte) (interfaces.SignedBeaconBlock, error) {
+func (bs *Server) blockFromBlockID(ctx context.Context, blockId []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	var err error
-	var blk interfaces.SignedBeaconBlock
+	var blk interfaces.ReadOnlySignedBeaconBlock
 	switch string(blockId) {
 	case "head":
 		blk, err = bs.ChainInfoFetcher.HeadBlock(ctx)
@@ -616,7 +616,7 @@ func (bs *Server) blockFromBlockID(ctx context.Context, blockId []byte) (interfa
 	return blk, nil
 }
 
-func handleGetBlockError(blk interfaces.SignedBeaconBlock, err error) error {
+func handleGetBlockError(blk interfaces.ReadOnlySignedBeaconBlock, err error) error {
 	if invalidBlockIdErr, ok := err.(*blockIdParseError); ok {
 		return status.Errorf(codes.InvalidArgument, "Invalid block ID: %v", invalidBlockIdErr)
 	}
@@ -629,7 +629,7 @@ func handleGetBlockError(blk interfaces.SignedBeaconBlock, err error) error {
 	return nil
 }
 
-func getBlockPhase0(blk interfaces.SignedBeaconBlock) (*ethpbv2.BlockResponseV2, error) {
+func getBlockPhase0(blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.BlockResponseV2, error) {
 	phase0Blk, err := blk.PbPhase0Block()
 	if err != nil {
 		return nil, err
@@ -651,7 +651,7 @@ func getBlockPhase0(blk interfaces.SignedBeaconBlock) (*ethpbv2.BlockResponseV2,
 	}, nil
 }
 
-func getBlockAltair(blk interfaces.SignedBeaconBlock) (*ethpbv2.BlockResponseV2, error) {
+func getBlockAltair(blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.BlockResponseV2, error) {
 	altairBlk, err := blk.PbAltairBlock()
 	if err != nil {
 		return nil, err
@@ -674,7 +674,7 @@ func getBlockAltair(blk interfaces.SignedBeaconBlock) (*ethpbv2.BlockResponseV2,
 	}, nil
 }
 
-func (bs *Server) getBlockBellatrix(ctx context.Context, blk interfaces.SignedBeaconBlock) (*ethpbv2.BlockResponseV2, error) {
+func (bs *Server) getBlockBellatrix(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.BlockResponseV2, error) {
 	bellatrixBlk, err := blk.PbBellatrixBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
@@ -744,7 +744,7 @@ func (bs *Server) getBlockBellatrix(ctx context.Context, blk interfaces.SignedBe
 	}, nil
 }
 
-func (bs *Server) getBlockCapella(ctx context.Context, blk interfaces.SignedBeaconBlock) (*ethpbv2.BlockResponseV2, error) {
+func (bs *Server) getBlockCapella(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.BlockResponseV2, error) {
 	capellaBlk, err := blk.PbCapellaBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
@@ -814,7 +814,7 @@ func (bs *Server) getBlockCapella(ctx context.Context, blk interfaces.SignedBeac
 	}, nil
 }
 
-func getSSZBlockPhase0(blk interfaces.SignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
+func getSSZBlockPhase0(blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
 	phase0Blk, err := blk.PbPhase0Block()
 	if err != nil {
 		return nil, err
@@ -833,7 +833,7 @@ func getSSZBlockPhase0(blk interfaces.SignedBeaconBlock) (*ethpbv2.SSZContainer,
 	return &ethpbv2.SSZContainer{Version: ethpbv2.Version_PHASE0, ExecutionOptimistic: false, Data: sszBlock}, nil
 }
 
-func getSSZBlockAltair(blk interfaces.SignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
+func getSSZBlockAltair(blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
 	altairBlk, err := blk.PbAltairBlock()
 	if err != nil {
 		return nil, err
@@ -857,7 +857,7 @@ func getSSZBlockAltair(blk interfaces.SignedBeaconBlock) (*ethpbv2.SSZContainer,
 	return &ethpbv2.SSZContainer{Version: ethpbv2.Version_ALTAIR, ExecutionOptimistic: false, Data: sszData}, nil
 }
 
-func (bs *Server) getSSZBlockBellatrix(ctx context.Context, blk interfaces.SignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
+func (bs *Server) getSSZBlockBellatrix(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
 	bellatrixBlk, err := blk.PbBellatrixBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
@@ -933,7 +933,7 @@ func (bs *Server) getSSZBlockBellatrix(ctx context.Context, blk interfaces.Signe
 	return &ethpbv2.SSZContainer{Version: ethpbv2.Version_BELLATRIX, ExecutionOptimistic: isOptimistic, Data: sszData}, nil
 }
 
-func (bs *Server) getSSZBlockCapella(ctx context.Context, blk interfaces.SignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
+func (bs *Server) getSSZBlockCapella(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock) (*ethpbv2.SSZContainer, error) {
 	capellaBlk, err := blk.PbCapellaBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
@@ -1080,7 +1080,7 @@ func (bs *Server) submitCapellaBlock(ctx context.Context, capellaBlk *ethpbv2.Be
 	return bs.submitBlock(ctx, root, wrappedCapellaBlk)
 }
 
-func (bs *Server) submitBlock(ctx context.Context, blockRoot [fieldparams.RootLength]byte, block interfaces.SignedBeaconBlock) error {
+func (bs *Server) submitBlock(ctx context.Context, blockRoot [fieldparams.RootLength]byte, block interfaces.ReadOnlySignedBeaconBlock) error {
 	// Do not block proposal critical path with debug logging or block feed updates.
 	defer func() {
 		log.WithField("blockRoot", fmt.Sprintf("%#x", bytesutil.Trunc(blockRoot[:]))).Debugf(

--- a/beacon-chain/rpc/eth/beacon/blocks_test.go
+++ b/beacon-chain/rpc/eth/beacon/blocks_test.go
@@ -38,7 +38,7 @@ func fillDBTestBlocks(ctx context.Context, t *testing.T, beaconDB db.Database) (
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, root))
 
 	count := primitives.Slot(100)
-	blks := make([]interfaces.SignedBeaconBlock, count)
+	blks := make([]interfaces.ReadOnlySignedBeaconBlock, count)
 	blkContainers := make([]*ethpbalpha.BeaconBlockContainer, count)
 	for i := primitives.Slot(0); i < count; i++ {
 		b := util.NewBeaconBlock()
@@ -74,7 +74,7 @@ func fillDBTestBlocksAltair(ctx context.Context, t *testing.T, beaconDB db.Datab
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, root))
 
 	count := primitives.Slot(100)
-	blks := make([]interfaces.SignedBeaconBlock, count)
+	blks := make([]interfaces.ReadOnlySignedBeaconBlock, count)
 	blkContainers := make([]*ethpbalpha.BeaconBlockContainer, count)
 	for i := primitives.Slot(0); i < count; i++ {
 		b := util.NewBeaconBlockAltair()
@@ -115,7 +115,7 @@ func fillDBTestBlocksBellatrix(ctx context.Context, t *testing.T, beaconDB db.Da
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, root))
 
 	count := primitives.Slot(100)
-	blks := make([]interfaces.SignedBeaconBlock, count)
+	blks := make([]interfaces.ReadOnlySignedBeaconBlock, count)
 	blkContainers := make([]*ethpbalpha.BeaconBlockContainer, count)
 	for i := primitives.Slot(0); i < count; i++ {
 		b := util.NewBeaconBlockBellatrix()
@@ -172,7 +172,7 @@ func fillDBTestBlocksCapella(ctx context.Context, t *testing.T, beaconDB db.Data
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, root))
 
 	count := primitives.Slot(100)
-	blks := make([]interfaces.SignedBeaconBlock, count)
+	blks := make([]interfaces.ReadOnlySignedBeaconBlock, count)
 	blkContainers := make([]*ethpbalpha.BeaconBlockContainer, count)
 	for i := primitives.Slot(0); i < count; i++ {
 		b := util.NewBeaconBlockCapella()
@@ -243,7 +243,7 @@ func fillDBTestBlocksBellatrixBlinded(ctx context.Context, t *testing.T, beaconD
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, root))
 
 	count := primitives.Slot(100)
-	blks := make([]interfaces.SignedBeaconBlock, count)
+	blks := make([]interfaces.ReadOnlySignedBeaconBlock, count)
 	blkContainers := make([]*ethpbalpha.BeaconBlockContainer, count)
 	for i := primitives.Slot(0); i < count; i++ {
 		b := util.NewBlindedBeaconBlockBellatrix()
@@ -300,7 +300,7 @@ func fillDBTestBlocksCapellaBlinded(ctx context.Context, t *testing.T, beaconDB 
 	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, root))
 
 	count := primitives.Slot(100)
-	blks := make([]interfaces.SignedBeaconBlock, count)
+	blks := make([]interfaces.ReadOnlySignedBeaconBlock, count)
 	blkContainers := make([]*ethpbalpha.BeaconBlockContainer, count)
 	for i := primitives.Slot(0); i < count; i++ {
 		b := util.NewBlindedBeaconBlockCapella()

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/attestations.go
@@ -63,7 +63,7 @@ func (bs *Server) ListAttestations(
 		return nil, status.Errorf(codes.InvalidArgument, "Requested page size %d can not be greater than max size %d",
 			req.PageSize, cmd.Get().MaxRPCPageSize)
 	}
-	var blocks []interfaces.SignedBeaconBlock
+	var blocks []interfaces.ReadOnlySignedBeaconBlock
 	var err error
 	switch q := req.QueryFilter.(type) {
 	case *ethpb.ListAttestationsRequest_GenesisEpoch:
@@ -117,7 +117,7 @@ func (bs *Server) ListAttestations(
 func (bs *Server) ListIndexedAttestations(
 	ctx context.Context, req *ethpb.ListIndexedAttestationsRequest,
 ) (*ethpb.ListIndexedAttestationsResponse, error) {
-	var blocks []interfaces.SignedBeaconBlock
+	var blocks []interfaces.ReadOnlySignedBeaconBlock
 	var err error
 	switch q := req.QueryFilter.(type) {
 	case *ethpb.ListIndexedAttestationsRequest_GenesisEpoch:

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/attestations_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/attestations_test.go
@@ -240,7 +240,7 @@ func TestServer_ListAttestations_FiltersCorrectly(t *testing.T) {
 			}),
 	}
 
-	var blocks []interfaces.SignedBeaconBlock
+	var blocks []interfaces.ReadOnlySignedBeaconBlock
 	for _, b := range unwrappedBlocks {
 		wsb, err := consensusblocks.NewSignedBeaconBlock(b)
 		require.NoError(t, err)

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks.go
@@ -28,7 +28,7 @@ import (
 // blockContainer represents an instance of
 // block along with its relevant metadata.
 type blockContainer struct {
-	blk         interfaces.SignedBeaconBlock
+	blk         interfaces.ReadOnlySignedBeaconBlock
 	root        [32]byte
 	isCanonical bool
 }
@@ -89,7 +89,7 @@ func convertFromV1Containers(ctrs []blockContainer) ([]*ethpb.BeaconBlockContain
 	return protoCtrs, nil
 }
 
-func convertToBlockContainer(blk interfaces.SignedBeaconBlock, root [32]byte, isCanonical bool) (*ethpb.BeaconBlockContainer, error) {
+func convertToBlockContainer(blk interfaces.ReadOnlySignedBeaconBlock, root [32]byte, isCanonical bool) (*ethpb.BeaconBlockContainer, error) {
 	ctr := &ethpb.BeaconBlockContainer{
 		BlockRoot: root[:],
 		Canonical: isCanonical,

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks_test.go
@@ -557,7 +557,7 @@ func TestServer_ListBeaconBlocks_Genesis(t *testing.T) {
 	})
 }
 
-func runListBlocksGenesis(t *testing.T, blk interfaces.SignedBeaconBlock, blkContainer *ethpb.BeaconBlockContainer) {
+func runListBlocksGenesis(t *testing.T, blk interfaces.ReadOnlySignedBeaconBlock, blkContainer *ethpb.BeaconBlockContainer) {
 	resetFn := features.InitWithReset(&features.Flags{
 		EnableOnlyBlindedBeaconBlocks: true,
 	})
@@ -605,7 +605,7 @@ func TestServer_ListBeaconBlocks_Genesis_MultiBlocks(t *testing.T) {
 		parentRoot := [32]byte{1, 2, 3}
 		blk := util.NewBeaconBlock()
 		blk.Block.ParentRoot = parentRoot[:]
-		blockCreator := func(i primitives.Slot) interfaces.SignedBeaconBlock {
+		blockCreator := func(i primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 			b := util.NewBeaconBlock()
 			b.Block.Slot = i
 			wrappedB, err := blocks.NewSignedBeaconBlock(b)
@@ -620,7 +620,7 @@ func TestServer_ListBeaconBlocks_Genesis_MultiBlocks(t *testing.T) {
 		parentRoot := [32]byte{1, 2, 3}
 		blk := util.NewBeaconBlockAltair()
 		blk.Block.ParentRoot = parentRoot[:]
-		blockCreator := func(i primitives.Slot) interfaces.SignedBeaconBlock {
+		blockCreator := func(i primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 			b := util.NewBeaconBlockAltair()
 			b.Block.Slot = i
 			wrappedB, err := blocks.NewSignedBeaconBlock(b)
@@ -635,7 +635,7 @@ func TestServer_ListBeaconBlocks_Genesis_MultiBlocks(t *testing.T) {
 		parentRoot := [32]byte{1, 2, 3}
 		blk := util.NewBeaconBlockBellatrix()
 		blk.Block.ParentRoot = parentRoot[:]
-		blockCreator := func(i primitives.Slot) interfaces.SignedBeaconBlock {
+		blockCreator := func(i primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 			b := util.NewBeaconBlockBellatrix()
 			b.Block.Slot = i
 			wrappedB, err := blocks.NewSignedBeaconBlock(b)
@@ -650,7 +650,7 @@ func TestServer_ListBeaconBlocks_Genesis_MultiBlocks(t *testing.T) {
 		parentRoot := [32]byte{1, 2, 3}
 		blk := util.NewBeaconBlockCapella()
 		blk.Block.ParentRoot = parentRoot[:]
-		blockCreator := func(i primitives.Slot) interfaces.SignedBeaconBlock {
+		blockCreator := func(i primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 			b := util.NewBeaconBlockCapella()
 			b.Block.Slot = i
 			wrappedB, err := blocks.NewSignedBeaconBlock(b)
@@ -663,8 +663,8 @@ func TestServer_ListBeaconBlocks_Genesis_MultiBlocks(t *testing.T) {
 	})
 }
 
-func runListBeaconBlocksGenesisMultiBlocks(t *testing.T, genBlock interfaces.SignedBeaconBlock,
-	blockCreator func(i primitives.Slot) interfaces.SignedBeaconBlock) {
+func runListBeaconBlocksGenesisMultiBlocks(t *testing.T, genBlock interfaces.ReadOnlySignedBeaconBlock,
+	blockCreator func(i primitives.Slot) interfaces.ReadOnlySignedBeaconBlock) {
 	db := dbTest.SetupDB(t)
 	ctx := context.Background()
 
@@ -678,7 +678,7 @@ func runListBeaconBlocksGenesisMultiBlocks(t *testing.T, genBlock interfaces.Sig
 	require.NoError(t, db.SaveGenesisBlockRoot(ctx, root))
 
 	count := primitives.Slot(100)
-	blks := make([]interfaces.SignedBeaconBlock, count)
+	blks := make([]interfaces.ReadOnlySignedBeaconBlock, count)
 	for i := primitives.Slot(0); i < count; i++ {
 		blks[i] = blockCreator(i)
 	}
@@ -699,7 +699,7 @@ func TestServer_ListBeaconBlocks_Pagination(t *testing.T) {
 	t.Run("phase 0 block", func(t *testing.T) {
 		blk := util.NewBeaconBlock()
 		blk.Block.Slot = 300
-		blockCreator := func(i primitives.Slot) interfaces.SignedBeaconBlock {
+		blockCreator := func(i primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 			b := util.NewBeaconBlock()
 			b.Block.Slot = i
 			wrappedB, err := blocks.NewSignedBeaconBlock(b)
@@ -723,7 +723,7 @@ func TestServer_ListBeaconBlocks_Pagination(t *testing.T) {
 	t.Run("altair block", func(t *testing.T) {
 		blk := util.NewBeaconBlockAltair()
 		blk.Block.Slot = 300
-		blockCreator := func(i primitives.Slot) interfaces.SignedBeaconBlock {
+		blockCreator := func(i primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 			b := util.NewBeaconBlockAltair()
 			b.Block.Slot = i
 			wrappedB, err := blocks.NewSignedBeaconBlock(b)
@@ -747,7 +747,7 @@ func TestServer_ListBeaconBlocks_Pagination(t *testing.T) {
 	t.Run("bellatrix block", func(t *testing.T) {
 		blk := util.NewBeaconBlockBellatrix()
 		blk.Block.Slot = 300
-		blockCreator := func(i primitives.Slot) interfaces.SignedBeaconBlock {
+		blockCreator := func(i primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 			b := util.NewBeaconBlockBellatrix()
 			b.Block.Slot = i
 			wrappedB, err := blocks.NewSignedBeaconBlock(b)
@@ -771,7 +771,7 @@ func TestServer_ListBeaconBlocks_Pagination(t *testing.T) {
 	t.Run("capella block", func(t *testing.T) {
 		blk := util.NewBeaconBlockCapella()
 		blk.Block.Slot = 300
-		blockCreator := func(i primitives.Slot) interfaces.SignedBeaconBlock {
+		blockCreator := func(i primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 			b := util.NewBeaconBlockCapella()
 			b.Block.Slot = i
 			wrappedB, err := blocks.NewSignedBeaconBlock(b)
@@ -794,8 +794,8 @@ func TestServer_ListBeaconBlocks_Pagination(t *testing.T) {
 	})
 }
 
-func runListBeaconBlocksPagination(t *testing.T, orphanedBlk interfaces.SignedBeaconBlock,
-	blockCreator func(i primitives.Slot) interfaces.SignedBeaconBlock, containerCreator func(i primitives.Slot, root []byte, canonical bool) *ethpb.BeaconBlockContainer) {
+func runListBeaconBlocksPagination(t *testing.T, orphanedBlk interfaces.ReadOnlySignedBeaconBlock,
+	blockCreator func(i primitives.Slot) interfaces.ReadOnlySignedBeaconBlock, containerCreator func(i primitives.Slot, root []byte, canonical bool) *ethpb.BeaconBlockContainer) {
 
 	db := dbTest.SetupDB(t)
 	chain := &chainMock.ChainService{
@@ -804,7 +804,7 @@ func runListBeaconBlocksPagination(t *testing.T, orphanedBlk interfaces.SignedBe
 	ctx := context.Background()
 
 	count := primitives.Slot(100)
-	blks := make([]interfaces.SignedBeaconBlock, count)
+	blks := make([]interfaces.ReadOnlySignedBeaconBlock, count)
 	blkContainers := make([]*ethpb.BeaconBlockContainer, count)
 	for i := primitives.Slot(0); i < count; i++ {
 		b := blockCreator(i)

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
@@ -1724,7 +1724,7 @@ func TestServer_GetValidatorParticipation_CurrentAndPrevEpochWithBits(t *testing
 	})
 }
 
-func runGetValidatorParticipationCurrentAndPrevEpoch(t *testing.T, genState state.BeaconState, gb interfaces.SignedBeaconBlockWriteable) {
+func runGetValidatorParticipationCurrentAndPrevEpoch(t *testing.T, genState state.BeaconState, gb interfaces.SignedBeaconBlock) {
 	helpers.ClearCache()
 	beaconDB := dbTest.SetupDB(t)
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -241,7 +241,7 @@ func (vs *Server) GetFeeRecipientByPubKey(ctx context.Context, request *ethpb.Fe
 	}, nil
 }
 
-func (vs *Server) proposeGenericBeaconBlock(ctx context.Context, blk interfaces.SignedBeaconBlock) (*ethpb.ProposeResponse, error) {
+func (vs *Server) proposeGenericBeaconBlock(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock) (*ethpb.ProposeResponse, error) {
 	ctx, span := trace.StartSpan(ctx, "ProposerServer.proposeGenericBeaconBlock")
 	defer span.End()
 	root, err := blk.Block().HashTreeRoot()
@@ -294,7 +294,7 @@ func (vs *Server) proposeGenericBeaconBlock(ctx context.Context, blk interfaces.
 
 // computeStateRoot computes the state root after a block has been processed through a state transition and
 // returns it to the validator client.
-func (vs *Server) computeStateRoot(ctx context.Context, block interfaces.SignedBeaconBlock) ([]byte, error) {
+func (vs *Server) computeStateRoot(ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock) ([]byte, error) {
 	beaconState, err := vs.StateGen.StateByRoot(ctx, block.Block().ParentRoot())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not retrieve beacon state")

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair.go
@@ -15,7 +15,7 @@ import (
 	"go.opencensus.io/trace"
 )
 
-func (vs *Server) setSyncAggregate(ctx context.Context, blk interfaces.SignedBeaconBlockWriteable) {
+func (vs *Server) setSyncAggregate(ctx context.Context, blk interfaces.SignedBeaconBlock) {
 	if blk.Version() < version.Altair {
 		return
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -37,7 +37,7 @@ var builderGetPayloadMissCount = promauto.NewCounter(prometheus.CounterOpts{
 const blockBuilderTimeout = 1 * time.Second
 
 // Sets the execution data for the block. Execution data can come from local EL client or remote builder depends on validator registration and circuit breaker conditions.
-func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlockWriteable, headState state.BeaconState) error {
+func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, headState state.BeaconState) error {
 	idx := blk.Block().ProposerIndex()
 	slot := blk.Block().Slot()
 	if slots.ToEpoch(slot) < params.BeaconConfig().BellatrixForkEpoch {
@@ -155,7 +155,7 @@ func (vs *Server) getPayloadHeaderFromBuilder(ctx context.Context, slot primitiv
 // This function retrieves the full payload block using the input blind block. This input must be versioned as
 // bellatrix blind block. The output block will contain the full payload. The original header block
 // will be returned the block builder is not configured.
-func (vs *Server) unblindBuilderBlock(ctx context.Context, b interfaces.SignedBeaconBlock) (interfaces.SignedBeaconBlock, error) {
+func (vs *Server) unblindBuilderBlock(ctx context.Context, b interfaces.ReadOnlySignedBeaconBlock) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	if err := consensusblocks.BeaconBlockIsNil(b); err != nil {
 		return nil, err
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -61,7 +61,7 @@ func TestServer_getPayloadHeader(t *testing.T) {
 	require.NoError(t, err)
 	tests := []struct {
 		name           string
-		head           interfaces.SignedBeaconBlock
+		head           interfaces.ReadOnlySignedBeaconBlock
 		mock           *builderTest.MockBuilderService
 		fetcher        *blockchainTest.ChainService
 		err            string
@@ -71,7 +71,7 @@ func TestServer_getPayloadHeader(t *testing.T) {
 			name: "head is not bellatrix ready",
 			mock: &builderTest.MockBuilderService{},
 			fetcher: &blockchainTest.ChainService{
-				Block: func() interfaces.SignedBeaconBlock {
+				Block: func() interfaces.ReadOnlySignedBeaconBlock {
 					wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 					require.NoError(t, err)
 					return wb
@@ -85,7 +85,7 @@ func TestServer_getPayloadHeader(t *testing.T) {
 				Bid:          sBid,
 			},
 			fetcher: &blockchainTest.ChainService{
-				Block: func() interfaces.SignedBeaconBlock {
+				Block: func() interfaces.ReadOnlySignedBeaconBlock {
 					wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockBellatrix())
 					require.NoError(t, err)
 					return wb
@@ -105,7 +105,7 @@ func TestServer_getPayloadHeader(t *testing.T) {
 				},
 			},
 			fetcher: &blockchainTest.ChainService{
-				Block: func() interfaces.SignedBeaconBlock {
+				Block: func() interfaces.ReadOnlySignedBeaconBlock {
 					wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockBellatrix())
 					require.NoError(t, err)
 					return wb
@@ -127,7 +127,7 @@ func TestServer_getPayloadHeader(t *testing.T) {
 				},
 			},
 			fetcher: &blockchainTest.ChainService{
-				Block: func() interfaces.SignedBeaconBlock {
+				Block: func() interfaces.ReadOnlySignedBeaconBlock {
 					wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockBellatrix())
 					require.NoError(t, err)
 					return wb
@@ -141,7 +141,7 @@ func TestServer_getPayloadHeader(t *testing.T) {
 				Bid: sBid,
 			},
 			fetcher: &blockchainTest.ChainService{
-				Block: func() interfaces.SignedBeaconBlock {
+				Block: func() interfaces.ReadOnlySignedBeaconBlock {
 					wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockBellatrix())
 					require.NoError(t, err)
 					return wb
@@ -176,10 +176,10 @@ func TestServer_getBuilderBlock(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		blk         interfaces.SignedBeaconBlock
+		blk         interfaces.ReadOnlySignedBeaconBlock
 		mock        *builderTest.MockBuilderService
 		err         string
-		returnedBlk interfaces.SignedBeaconBlock
+		returnedBlk interfaces.ReadOnlySignedBeaconBlock
 	}{
 		{
 			name: "nil block",
@@ -188,12 +188,12 @@ func TestServer_getBuilderBlock(t *testing.T) {
 		},
 		{
 			name: "old block version",
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 				require.NoError(t, err)
 				return wb
 			}(),
-			returnedBlk: func() interfaces.SignedBeaconBlock {
+			returnedBlk: func() interfaces.ReadOnlySignedBeaconBlock {
 				wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 				require.NoError(t, err)
 				return wb
@@ -201,7 +201,7 @@ func TestServer_getBuilderBlock(t *testing.T) {
 		},
 		{
 			name: "not configured",
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				wb, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockBellatrix())
 				require.NoError(t, err)
 				return wb
@@ -209,7 +209,7 @@ func TestServer_getBuilderBlock(t *testing.T) {
 			mock: &builderTest.MockBuilderService{
 				HasConfigured: false,
 			},
-			returnedBlk: func() interfaces.SignedBeaconBlock {
+			returnedBlk: func() interfaces.ReadOnlySignedBeaconBlock {
 				wb, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockBellatrix())
 				require.NoError(t, err)
 				return wb
@@ -217,7 +217,7 @@ func TestServer_getBuilderBlock(t *testing.T) {
 		},
 		{
 			name: "submit blind block error",
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				b := util.NewBlindedBeaconBlockBellatrix()
 				b.Block.Slot = 1
 				b.Block.ProposerIndex = 2
@@ -234,7 +234,7 @@ func TestServer_getBuilderBlock(t *testing.T) {
 		},
 		{
 			name: "head and payload root mismatch",
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				b := util.NewBlindedBeaconBlockBellatrix()
 				b.Block.Slot = 1
 				b.Block.ProposerIndex = 2
@@ -246,7 +246,7 @@ func TestServer_getBuilderBlock(t *testing.T) {
 				HasConfigured: true,
 				Payload:       p,
 			},
-			returnedBlk: func() interfaces.SignedBeaconBlock {
+			returnedBlk: func() interfaces.ReadOnlySignedBeaconBlock {
 				b := util.NewBeaconBlockBellatrix()
 				b.Block.Slot = 1
 				b.Block.ProposerIndex = 2
@@ -259,7 +259,7 @@ func TestServer_getBuilderBlock(t *testing.T) {
 		},
 		{
 			name: "can get payload",
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				b := util.NewBlindedBeaconBlockBellatrix()
 				b.Block.Slot = 1
 				b.Block.ProposerIndex = 2
@@ -285,7 +285,7 @@ func TestServer_getBuilderBlock(t *testing.T) {
 				HasConfigured: true,
 				Payload:       p,
 			},
-			returnedBlk: func() interfaces.SignedBeaconBlock {
+			returnedBlk: func() interfaces.ReadOnlySignedBeaconBlock {
 				b := util.NewBeaconBlockBellatrix()
 				b.Block.Slot = 1
 				b.Block.ProposerIndex = 2

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_capella.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_capella.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Sets the bls to exec data for a block.
-func (vs *Server) setBlsToExecData(blk interfaces.SignedBeaconBlockWriteable, headState state.BeaconState) {
+func (vs *Server) setBlsToExecData(blk interfaces.SignedBeaconBlock, headState state.BeaconState) {
 	if blk.Version() < version.Capella {
 		return
 	}
@@ -35,7 +35,7 @@ func (vs *Server) setBlsToExecData(blk interfaces.SignedBeaconBlockWriteable, he
 	}
 }
 
-func (vs *Server) unblindBuilderBlockCapella(ctx context.Context, b interfaces.SignedBeaconBlock) (interfaces.SignedBeaconBlock, error) {
+func (vs *Server) unblindBuilderBlockCapella(ctx context.Context, b interfaces.ReadOnlySignedBeaconBlock) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	if err := consensusblocks.BeaconBlockIsNil(b); err != nil {
 		return nil, errors.Wrap(err, "block is nil")
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_capella_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_capella_test.go
@@ -21,10 +21,10 @@ func TestServer_unblindBuilderCapellaBlock(t *testing.T) {
 
 	tests := []struct {
 		name        string
-		blk         interfaces.SignedBeaconBlock
+		blk         interfaces.ReadOnlySignedBeaconBlock
 		mock        *builderTest.MockBuilderService
 		err         string
-		returnedBlk interfaces.SignedBeaconBlock
+		returnedBlk interfaces.ReadOnlySignedBeaconBlock
 	}{
 		{
 			name: "nil block",
@@ -33,12 +33,12 @@ func TestServer_unblindBuilderCapellaBlock(t *testing.T) {
 		},
 		{
 			name: "old block version",
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 				require.NoError(t, err)
 				return wb
 			}(),
-			returnedBlk: func() interfaces.SignedBeaconBlock {
+			returnedBlk: func() interfaces.ReadOnlySignedBeaconBlock {
 				wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 				require.NoError(t, err)
 				return wb
@@ -46,7 +46,7 @@ func TestServer_unblindBuilderCapellaBlock(t *testing.T) {
 		},
 		{
 			name: "not configured",
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				wb, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockBellatrix())
 				require.NoError(t, err)
 				return wb
@@ -54,7 +54,7 @@ func TestServer_unblindBuilderCapellaBlock(t *testing.T) {
 			mock: &builderTest.MockBuilderService{
 				HasConfigured: false,
 			},
-			returnedBlk: func() interfaces.SignedBeaconBlock {
+			returnedBlk: func() interfaces.ReadOnlySignedBeaconBlock {
 				wb, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockBellatrix())
 				require.NoError(t, err)
 				return wb
@@ -62,7 +62,7 @@ func TestServer_unblindBuilderCapellaBlock(t *testing.T) {
 		},
 		{
 			name: "submit blind block error",
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				b := util.NewBlindedBeaconBlockCapella()
 				b.Block.Slot = 1
 				b.Block.ProposerIndex = 2
@@ -79,7 +79,7 @@ func TestServer_unblindBuilderCapellaBlock(t *testing.T) {
 		},
 		{
 			name: "can get payload",
-			blk: func() interfaces.SignedBeaconBlock {
+			blk: func() interfaces.ReadOnlySignedBeaconBlock {
 				b := util.NewBlindedBeaconBlockCapella()
 				b.Block.Slot = 1
 				b.Block.ProposerIndex = 2
@@ -106,7 +106,7 @@ func TestServer_unblindBuilderCapellaBlock(t *testing.T) {
 				HasConfigured:  true,
 				PayloadCapella: p,
 			},
-			returnedBlk: func() interfaces.SignedBeaconBlock {
+			returnedBlk: func() interfaces.ReadOnlySignedBeaconBlock {
 				b := util.NewBeaconBlockCapella()
 				b.Block.Slot = 1
 				b.Block.ProposerIndex = 2

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_empty_block.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_empty_block.go
@@ -11,8 +11,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func getEmptyBlock(slot primitives.Slot) (interfaces.SignedBeaconBlockWriteable, error) {
-	var sBlk interfaces.SignedBeaconBlockWriteable
+func getEmptyBlock(slot primitives.Slot) (interfaces.SignedBeaconBlock, error) {
+	var sBlk interfaces.SignedBeaconBlock
 	var err error
 	switch {
 	case slots.ToEpoch(slot) < params.BeaconConfig().AltairForkEpoch:

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_empty_block_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_empty_block_test.go
@@ -22,12 +22,12 @@ func Test_getEmptyBlock(t *testing.T) {
 	tests := []struct {
 		name string
 		slot primitives.Slot
-		want func() interfaces.SignedBeaconBlock
+		want func() interfaces.ReadOnlySignedBeaconBlock
 	}{
 		{
 			name: "altair",
 			slot: primitives.Slot(params.BeaconConfig().AltairForkEpoch) * params.BeaconConfig().SlotsPerEpoch,
-			want: func() interfaces.SignedBeaconBlock {
+			want: func() interfaces.ReadOnlySignedBeaconBlock {
 				b, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockAltair{Block: &ethpb.BeaconBlockAltair{Body: &ethpb.BeaconBlockBodyAltair{}}})
 				require.NoError(t, err)
 				return b
@@ -36,7 +36,7 @@ func Test_getEmptyBlock(t *testing.T) {
 		{
 			name: "bellatrix",
 			slot: primitives.Slot(params.BeaconConfig().BellatrixForkEpoch) * params.BeaconConfig().SlotsPerEpoch,
-			want: func() interfaces.SignedBeaconBlock {
+			want: func() interfaces.ReadOnlySignedBeaconBlock {
 				b, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockBellatrix{Block: &ethpb.BeaconBlockBellatrix{Body: &ethpb.BeaconBlockBodyBellatrix{}}})
 				require.NoError(t, err)
 				return b
@@ -45,7 +45,7 @@ func Test_getEmptyBlock(t *testing.T) {
 		{
 			name: "capella",
 			slot: primitives.Slot(params.BeaconConfig().CapellaForkEpoch) * params.BeaconConfig().SlotsPerEpoch,
-			want: func() interfaces.SignedBeaconBlock {
+			want: func() interfaces.ReadOnlySignedBeaconBlock {
 				b, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockCapella{Block: &ethpb.BeaconBlockCapella{Body: &ethpb.BeaconBlockBodyCapella{}}})
 				require.NoError(t, err)
 				return b

--- a/beacon-chain/state/stategen/history.go
+++ b/beacon-chain/state/stategen/history.go
@@ -103,7 +103,7 @@ func (c *CanonicalHistory) bestForSlot(ctx context.Context, roots [][32]byte) ([
 // and the stategen transition helper methods. This implementation uses the following algorithm:
 // - find the highest canonical block <= the target slot
 // - starting with this block, recursively search backwards for a stored state, and accumulate intervening blocks
-func (c *CanonicalHistory) chainForSlot(ctx context.Context, target primitives.Slot) (state.BeaconState, []interfaces.SignedBeaconBlock, error) {
+func (c *CanonicalHistory) chainForSlot(ctx context.Context, target primitives.Slot) (state.BeaconState, []interfaces.ReadOnlySignedBeaconBlock, error) {
 	ctx, span := trace.StartSpan(ctx, "canonicalChainer.chainForSlot")
 	defer span.End()
 	r, err := c.BlockRootForSlot(ctx, target)
@@ -140,10 +140,10 @@ func (c *CanonicalHistory) getState(ctx context.Context, blockRoot [32]byte) (st
 // all blocks in the lineage, including the tail block. Blocks are returned in ascending order.
 // Note that this function assumes that the tail is a canonical block, and therefore assumes that
 // all ancestors are also canonical.
-func (c *CanonicalHistory) ancestorChain(ctx context.Context, tail interfaces.SignedBeaconBlock) (state.BeaconState, []interfaces.SignedBeaconBlock, error) {
+func (c *CanonicalHistory) ancestorChain(ctx context.Context, tail interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, []interfaces.ReadOnlySignedBeaconBlock, error) {
 	ctx, span := trace.StartSpan(ctx, "canonicalChainer.ancestorChain")
 	defer span.End()
-	chain := make([]interfaces.SignedBeaconBlock, 0)
+	chain := make([]interfaces.ReadOnlySignedBeaconBlock, 0)
 	for {
 		if err := ctx.Err(); err != nil {
 			msg := fmt.Sprintf("context canceled while finding ancestors of block at slot %d", tail.Block().Slot())
@@ -185,7 +185,7 @@ func (c *CanonicalHistory) ancestorChain(ctx context.Context, tail interfaces.Si
 	}
 }
 
-func reverseChain(c []interfaces.SignedBeaconBlock) {
+func reverseChain(c []interfaces.ReadOnlySignedBeaconBlock) {
 	last := len(c) - 1
 	swaps := (last + 1) / 2
 	for i := 0; i < swaps; i++ {

--- a/beacon-chain/state/stategen/history_test.go
+++ b/beacon-chain/state/stategen/history_test.go
@@ -41,7 +41,7 @@ func TestBestForSlot(t *testing.T) {
 	cases := []struct {
 		name   string
 		err    error
-		blocks []interfaces.SignedBeaconBlock
+		blocks []interfaces.ReadOnlySignedBeaconBlock
 		roots  [][32]byte
 		root   [32]byte
 		cc     CanonicalChecker
@@ -568,10 +568,10 @@ func incrFwd(n int, c chan uint32) {
 	close(c)
 }
 
-func mockBlocks(n int, iter func(int, chan uint32)) []interfaces.SignedBeaconBlock {
+func mockBlocks(n int, iter func(int, chan uint32)) []interfaces.ReadOnlySignedBeaconBlock {
 	bchan := make(chan uint32)
 	go iter(n, bchan)
-	mb := make([]interfaces.SignedBeaconBlock, 0)
+	mb := make([]interfaces.ReadOnlySignedBeaconBlock, 0)
 	for i := range bchan {
 		var h [32]byte
 		binary.LittleEndian.PutUint32(h[:], i)

--- a/beacon-chain/state/stategen/mock_test.go
+++ b/beacon-chain/state/stategen/mock_test.go
@@ -74,7 +74,7 @@ type mockHistorySpec struct {
 }
 
 type mockHistory struct {
-	blocks                         map[[32]byte]interfaces.SignedBeaconBlock
+	blocks                         map[[32]byte]interfaces.ReadOnlySignedBeaconBlock
 	slotMap                        map[primitives.Slot][32]byte
 	slotIndex                      slotList
 	canonical                      map[[32]byte]bool
@@ -131,7 +131,7 @@ func (m *mockHistory) GenesisBlockRoot(_ context.Context) ([32]byte, error) {
 	return genesisRoot, nil
 }
 
-func (m *mockHistory) Block(_ context.Context, blockRoot [32]byte) (interfaces.SignedBeaconBlock, error) {
+func (m *mockHistory) Block(_ context.Context, blockRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	if b, ok := m.blocks[blockRoot]; ok {
 		return b, nil
 	}
@@ -154,7 +154,7 @@ func (m *mockHistory) CurrentSlot() primitives.Slot {
 	return m.current
 }
 
-func (h *mockHistory) addBlock(root [32]byte, b interfaces.SignedBeaconBlock, canon bool) {
+func (h *mockHistory) addBlock(root [32]byte, b interfaces.ReadOnlySignedBeaconBlock, canon bool) {
 	h.blocks[root] = b
 	h.slotMap[b.Block().Slot()] = root
 	h.canonical[root] = canon
@@ -190,7 +190,7 @@ func (h *mockHistory) validateRoots() error {
 func newMockHistory(t *testing.T, hist []mockHistorySpec, current primitives.Slot) *mockHistory {
 	ctx := context.Background()
 	mh := &mockHistory{
-		blocks:       map[[32]byte]interfaces.SignedBeaconBlock{},
+		blocks:       map[[32]byte]interfaces.ReadOnlySignedBeaconBlock{},
 		canonical:    map[[32]byte]bool{},
 		states:       map[[32]byte]state.BeaconState{},
 		hiddenStates: map[[32]byte]state.BeaconState{},

--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -28,7 +28,7 @@ import (
 func (_ *State) replayBlocks(
 	ctx context.Context,
 	state state.BeaconState,
-	signed []interfaces.SignedBeaconBlock,
+	signed []interfaces.ReadOnlySignedBeaconBlock,
 	targetSlot primitives.Slot,
 ) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "stateGen.replayBlocks")
@@ -80,7 +80,7 @@ func (_ *State) replayBlocks(
 
 // loadBlocks loads the blocks between start slot and end slot by recursively fetching from end block root.
 // The Blocks are returned in slot-descending order.
-func (s *State) loadBlocks(ctx context.Context, startSlot, endSlot primitives.Slot, endBlockRoot [32]byte) ([]interfaces.SignedBeaconBlock, error) {
+func (s *State) loadBlocks(ctx context.Context, startSlot, endSlot primitives.Slot, endBlockRoot [32]byte) ([]interfaces.ReadOnlySignedBeaconBlock, error) {
 	// Nothing to load for invalid range.
 	if startSlot > endSlot {
 		return nil, fmt.Errorf("start slot %d > end slot %d", startSlot, endSlot)
@@ -118,7 +118,7 @@ func (s *State) loadBlocks(ctx context.Context, startSlot, endSlot primitives.Sl
 		return nil, errors.New("end block roots don't match")
 	}
 
-	filteredBlocks := []interfaces.SignedBeaconBlock{blocks[length-1]}
+	filteredBlocks := []interfaces.ReadOnlySignedBeaconBlock{blocks[length-1]}
 	// Starting from second to last index because the last block is already in the filtered block list.
 	for i := length - 2; i >= 0; i-- {
 		if ctx.Err() != nil {
@@ -142,7 +142,7 @@ func (s *State) loadBlocks(ctx context.Context, startSlot, endSlot primitives.Sl
 func executeStateTransitionStateGen(
 	ctx context.Context,
 	state state.BeaconState,
-	signed interfaces.SignedBeaconBlock,
+	signed interfaces.ReadOnlySignedBeaconBlock,
 ) (state.BeaconState, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -250,7 +250,7 @@ func ReplayProcessSlots(ctx context.Context, state state.BeaconState, slot primi
 
 // Given the start slot and the end slot, this returns the finalized beacon blocks in between.
 // Since hot states don't have finalized blocks, this should ONLY be used for replaying cold state.
-func (s *State) loadFinalizedBlocks(ctx context.Context, startSlot, endSlot primitives.Slot) ([]interfaces.SignedBeaconBlock, error) {
+func (s *State) loadFinalizedBlocks(ctx context.Context, startSlot, endSlot primitives.Slot) ([]interfaces.ReadOnlySignedBeaconBlock, error) {
 	f := filters.NewFilter().SetStartSlot(startSlot).SetEndSlot(endSlot)
 	bs, bRoots, err := s.beaconDB.Blocks(ctx, f)
 	if err != nil {
@@ -259,7 +259,7 @@ func (s *State) loadFinalizedBlocks(ctx context.Context, startSlot, endSlot prim
 	if len(bs) != len(bRoots) {
 		return nil, errors.New("length of blocks and roots don't match")
 	}
-	fbs := make([]interfaces.SignedBeaconBlock, 0, len(bs))
+	fbs := make([]interfaces.ReadOnlySignedBeaconBlock, 0, len(bs))
 	for i := len(bs) - 1; i >= 0; i-- {
 		if s.beaconDB.IsFinalizedBlock(ctx, bRoots[i]) {
 			fbs = append(fbs, bs[i])

--- a/beacon-chain/state/stategen/replay_test.go
+++ b/beacon-chain/state/stategen/replay_test.go
@@ -44,7 +44,7 @@ func TestReplayBlocks_AllSkipSlots(t *testing.T) {
 
 	service := New(beaconDB, doublylinkedtree.New())
 	targetSlot := params.BeaconConfig().SlotsPerEpoch - 1
-	newState, err := service.replayBlocks(context.Background(), beaconState, []interfaces.SignedBeaconBlock{}, targetSlot)
+	newState, err := service.replayBlocks(context.Background(), beaconState, []interfaces.ReadOnlySignedBeaconBlock{}, targetSlot)
 	require.NoError(t, err)
 	assert.Equal(t, targetSlot, newState.Slot(), "Did not advance slots")
 }
@@ -73,7 +73,7 @@ func TestReplayBlocks_SameSlot(t *testing.T) {
 
 	service := New(beaconDB, doublylinkedtree.New())
 	targetSlot := beaconState.Slot()
-	newState, err := service.replayBlocks(context.Background(), beaconState, []interfaces.SignedBeaconBlock{}, targetSlot)
+	newState, err := service.replayBlocks(context.Background(), beaconState, []interfaces.ReadOnlySignedBeaconBlock{}, targetSlot)
 	require.NoError(t, err)
 	assert.Equal(t, targetSlot, newState.Slot(), "Did not advance slots")
 }
@@ -107,7 +107,7 @@ func TestReplayBlocks_LowerSlotBlock(t *testing.T) {
 	b.Block.Slot = beaconState.Slot() - 1
 	wsb, err := consensusblocks.NewSignedBeaconBlock(b)
 	require.NoError(t, err)
-	newState, err := service.replayBlocks(context.Background(), beaconState, []interfaces.SignedBeaconBlock{wsb}, targetSlot)
+	newState, err := service.replayBlocks(context.Background(), beaconState, []interfaces.ReadOnlySignedBeaconBlock{wsb}, targetSlot)
 	require.NoError(t, err)
 	assert.Equal(t, targetSlot, newState.Slot(), "Did not advance slots")
 }
@@ -133,7 +133,7 @@ func TestReplayBlocks_ThroughForkBoundary(t *testing.T) {
 
 	service := New(testDB.SetupDB(t), doublylinkedtree.New())
 	targetSlot := params.BeaconConfig().SlotsPerEpoch
-	newState, err := service.replayBlocks(context.Background(), beaconState, []interfaces.SignedBeaconBlock{}, targetSlot)
+	newState, err := service.replayBlocks(context.Background(), beaconState, []interfaces.ReadOnlySignedBeaconBlock{}, targetSlot)
 	require.NoError(t, err)
 
 	// Verify state is version Altair.
@@ -165,14 +165,14 @@ func TestReplayBlocks_ThroughCapellaForkBoundary(t *testing.T) {
 
 	service := New(testDB.SetupDB(t), doublylinkedtree.New())
 	targetSlot := params.BeaconConfig().SlotsPerEpoch * 2
-	newState, err := service.replayBlocks(context.Background(), beaconState, []interfaces.SignedBeaconBlock{}, targetSlot)
+	newState, err := service.replayBlocks(context.Background(), beaconState, []interfaces.ReadOnlySignedBeaconBlock{}, targetSlot)
 	require.NoError(t, err)
 
 	// Verify state is version Bellatrix.
 	assert.Equal(t, version.Bellatrix, newState.Version())
 
 	targetSlot = params.BeaconConfig().SlotsPerEpoch * 3
-	newState, err = service.replayBlocks(context.Background(), newState, []interfaces.SignedBeaconBlock{}, targetSlot)
+	newState, err = service.replayBlocks(context.Background(), newState, []interfaces.ReadOnlySignedBeaconBlock{}, targetSlot)
 	require.NoError(t, err)
 
 	// Verify state is version Capella.

--- a/beacon-chain/state/stategen/replayer.go
+++ b/beacon-chain/state/stategen/replayer.go
@@ -28,7 +28,7 @@ const (
 type HistoryAccessor interface {
 	HighestRootsBelowSlot(ctx context.Context, slot primitives.Slot) (primitives.Slot, [][32]byte, error)
 	GenesisBlockRoot(ctx context.Context) ([32]byte, error)
-	Block(ctx context.Context, blockRoot [32]byte) (interfaces.SignedBeaconBlock, error)
+	Block(ctx context.Context, blockRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error)
 	StateOrError(ctx context.Context, blockRoot [32]byte) (state.BeaconState, error)
 }
 
@@ -59,7 +59,7 @@ var _ Replayer = &stateReplayer{}
 // chainer is responsible for supplying the chain components necessary to rebuild a state,
 // namely a starting BeaconState and all available blocks from the starting state up to and including the target slot
 type chainer interface {
-	chainForSlot(ctx context.Context, target primitives.Slot) (state.BeaconState, []interfaces.SignedBeaconBlock, error)
+	chainForSlot(ctx context.Context, target primitives.Slot) (state.BeaconState, []interfaces.ReadOnlySignedBeaconBlock, error)
 }
 
 type stateReplayer struct {
@@ -75,7 +75,7 @@ func (rs *stateReplayer) ReplayBlocks(ctx context.Context) (state.BeaconState, e
 	defer span.End()
 
 	var s state.BeaconState
-	var descendants []interfaces.SignedBeaconBlock
+	var descendants []interfaces.ReadOnlySignedBeaconBlock
 	var err error
 	switch rs.method {
 	case forSlot:

--- a/beacon-chain/state/stategen/replayer_test.go
+++ b/beacon-chain/state/stategen/replayer_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
 )
 
-func headerFromBlock(b interfaces.SignedBeaconBlock) (*ethpb.BeaconBlockHeader, error) {
+func headerFromBlock(b interfaces.ReadOnlySignedBeaconBlock) (*ethpb.BeaconBlockHeader, error) {
 	bodyRoot, err := b.Block().Body().HashTreeRoot()
 	if err != nil {
 		return nil, err

--- a/beacon-chain/sync/backfill/status.go
+++ b/beacon-chain/sync/backfill/status.go
@@ -118,5 +118,5 @@ type BackfillDB interface {
 	GenesisBlockRoot(ctx context.Context) ([32]byte, error)
 	OriginCheckpointBlockRoot(ctx context.Context) ([32]byte, error)
 	BackfillBlockRoot(ctx context.Context) ([32]byte, error)
-	Block(ctx context.Context, blockRoot [32]byte) (interfaces.SignedBeaconBlock, error)
+	Block(ctx context.Context, blockRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error)
 }

--- a/beacon-chain/sync/backfill/status_test.go
+++ b/beacon-chain/sync/backfill/status_test.go
@@ -22,7 +22,7 @@ type mockBackfillDB struct {
 	genesisBlockRoot          func(ctx context.Context) ([32]byte, error)
 	originCheckpointBlockRoot func(ctx context.Context) ([32]byte, error)
 	backfillBlockRoot         func(ctx context.Context) ([32]byte, error)
-	block                     func(ctx context.Context, blockRoot [32]byte) (interfaces.SignedBeaconBlock, error)
+	block                     func(ctx context.Context, blockRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error)
 }
 
 var _ BackfillDB = &mockBackfillDB{}
@@ -55,7 +55,7 @@ func (db *mockBackfillDB) BackfillBlockRoot(ctx context.Context) ([32]byte, erro
 	return [32]byte{}, errEmptyMockDBMethod
 }
 
-func (db *mockBackfillDB) Block(ctx context.Context, blockRoot [32]byte) (interfaces.SignedBeaconBlock, error) {
+func (db *mockBackfillDB) Block(ctx context.Context, blockRoot [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	if db.block != nil {
 		return db.block(ctx, blockRoot)
 	}
@@ -142,7 +142,7 @@ func goodBlockRoot(root [32]byte) func(ctx context.Context) ([32]byte, error) {
 	}
 }
 
-func setupTestBlock(slot primitives.Slot) (interfaces.SignedBeaconBlock, error) {
+func setupTestBlock(slot primitives.Slot) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	bRaw := util.NewBeaconBlock()
 	b, err := blocks.NewSignedBeaconBlock(bRaw)
 	if err != nil {
@@ -190,7 +190,7 @@ func TestReload(t *testing.T) {
 					return [32]byte{}, db.ErrNotFoundGenesisBlockRoot
 				},
 				originCheckpointBlockRoot: goodBlockRoot(originRoot),
-				block: func(ctx context.Context, root [32]byte) (interfaces.SignedBeaconBlock, error) {
+				block: func(ctx context.Context, root [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 					switch root {
 					case originRoot:
 						return originBlock, nil
@@ -207,7 +207,7 @@ func TestReload(t *testing.T) {
 					return [32]byte{}, derp
 				},
 				originCheckpointBlockRoot: goodBlockRoot(originRoot),
-				block: func(ctx context.Context, root [32]byte) (interfaces.SignedBeaconBlock, error) {
+				block: func(ctx context.Context, root [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 					switch root {
 					case originRoot:
 						return originBlock, nil
@@ -230,7 +230,7 @@ func TestReload(t *testing.T) {
 			db: &mockBackfillDB{
 				genesisBlockRoot:          goodBlockRoot(params.BeaconConfig().ZeroHash),
 				originCheckpointBlockRoot: goodBlockRoot(originRoot),
-				block: func(ctx context.Context, root [32]byte) (interfaces.SignedBeaconBlock, error) {
+				block: func(ctx context.Context, root [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 					return nil, nil
 				},
 			},
@@ -241,7 +241,7 @@ func TestReload(t *testing.T) {
 			db: &mockBackfillDB{
 				genesisBlockRoot:          goodBlockRoot(params.BeaconConfig().ZeroHash),
 				originCheckpointBlockRoot: goodBlockRoot(originRoot),
-				block: func(ctx context.Context, root [32]byte) (interfaces.SignedBeaconBlock, error) {
+				block: func(ctx context.Context, root [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 					return nil, derp
 				},
 			},
@@ -252,7 +252,7 @@ func TestReload(t *testing.T) {
 			db: &mockBackfillDB{
 				genesisBlockRoot:          goodBlockRoot(params.BeaconConfig().ZeroHash),
 				originCheckpointBlockRoot: goodBlockRoot(originRoot),
-				block: func(ctx context.Context, root [32]byte) (interfaces.SignedBeaconBlock, error) {
+				block: func(ctx context.Context, root [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 					return originBlock, nil
 				},
 				backfillBlockRoot: func(ctx context.Context) ([32]byte, error) {
@@ -266,7 +266,7 @@ func TestReload(t *testing.T) {
 			db: &mockBackfillDB{
 				genesisBlockRoot:          goodBlockRoot(params.BeaconConfig().ZeroHash),
 				originCheckpointBlockRoot: goodBlockRoot(originRoot),
-				block: func(ctx context.Context, root [32]byte) (interfaces.SignedBeaconBlock, error) {
+				block: func(ctx context.Context, root [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 					switch root {
 					case originRoot:
 						return originBlock, nil
@@ -286,7 +286,7 @@ func TestReload(t *testing.T) {
 			db: &mockBackfillDB{
 				genesisBlockRoot:          goodBlockRoot(params.BeaconConfig().ZeroHash),
 				originCheckpointBlockRoot: goodBlockRoot(originRoot),
-				block: func(ctx context.Context, root [32]byte) (interfaces.SignedBeaconBlock, error) {
+				block: func(ctx context.Context, root [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 					switch root {
 					case originRoot:
 						return originBlock, nil
@@ -304,7 +304,7 @@ func TestReload(t *testing.T) {
 			db: &mockBackfillDB{
 				genesisBlockRoot:          goodBlockRoot(params.BeaconConfig().ZeroHash),
 				originCheckpointBlockRoot: goodBlockRoot(originRoot),
-				block: func(ctx context.Context, root [32]byte) (interfaces.SignedBeaconBlock, error) {
+				block: func(ctx context.Context, root [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 					switch root {
 					case originRoot:
 						return originBlock, nil
@@ -322,7 +322,7 @@ func TestReload(t *testing.T) {
 			db: &mockBackfillDB{
 				genesisBlockRoot:          goodBlockRoot(params.BeaconConfig().ZeroHash),
 				originCheckpointBlockRoot: goodBlockRoot(originRoot),
-				block: func(ctx context.Context, root [32]byte) (interfaces.SignedBeaconBlock, error) {
+				block: func(ctx context.Context, root [32]byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 					switch root {
 					case originRoot:
 						return originBlock, nil

--- a/beacon-chain/sync/decode_pubsub_test.go
+++ b/beacon-chain/sync/decode_pubsub_test.go
@@ -72,7 +72,7 @@ func TestService_decodePubsubMessage(t *testing.T) {
 				},
 			},
 			wantErr: nil,
-			want: func() interfaces.SignedBeaconBlock {
+			want: func() interfaces.ReadOnlySignedBeaconBlock {
 				wsb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 				require.NoError(t, err)
 				return wsb

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -107,7 +107,7 @@ type fetchRequestResponse struct {
 	pid    peer.ID
 	start  primitives.Slot
 	count  uint64
-	blocks []interfaces.SignedBeaconBlock
+	blocks []interfaces.ReadOnlySignedBeaconBlock
 	err    error
 }
 
@@ -248,7 +248,7 @@ func (f *blocksFetcher) handleRequest(ctx context.Context, start primitives.Slot
 	response := &fetchRequestResponse{
 		start:  start,
 		count:  count,
-		blocks: []interfaces.SignedBeaconBlock{},
+		blocks: []interfaces.ReadOnlySignedBeaconBlock{},
 		err:    nil,
 	}
 
@@ -282,7 +282,7 @@ func (f *blocksFetcher) fetchBlocksFromPeer(
 	ctx context.Context,
 	start primitives.Slot, count uint64,
 	peers []peer.ID,
-) ([]interfaces.SignedBeaconBlock, peer.ID, error) {
+) ([]interfaces.ReadOnlySignedBeaconBlock, peer.ID, error) {
 	ctx, span := trace.StartSpan(ctx, "initialsync.fetchBlocksFromPeer")
 	defer span.End()
 
@@ -309,7 +309,7 @@ func (f *blocksFetcher) requestBlocks(
 	ctx context.Context,
 	req *p2ppb.BeaconBlocksByRangeRequest,
 	pid peer.ID,
-) ([]interfaces.SignedBeaconBlock, error) {
+) ([]interfaces.ReadOnlySignedBeaconBlock, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
@@ -339,7 +339,7 @@ func (f *blocksFetcher) requestBlocksByRoot(
 	ctx context.Context,
 	req *p2pTypes.BeaconBlockByRootsReq,
 	pid peer.ID,
-) ([]interfaces.SignedBeaconBlock, error) {
+) ([]interfaces.ReadOnlySignedBeaconBlock, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -298,9 +298,9 @@ func TestBlocksFetcher_RoundRobin(t *testing.T) {
 				fetcher.stop()
 			}()
 
-			processFetchedBlocks := func() ([]interfaces.SignedBeaconBlock, error) {
+			processFetchedBlocks := func() ([]interfaces.ReadOnlySignedBeaconBlock, error) {
 				defer cancel()
-				var unionRespBlocks []interfaces.SignedBeaconBlock
+				var unionRespBlocks []interfaces.ReadOnlySignedBeaconBlock
 
 				for {
 					select {
@@ -446,7 +446,7 @@ func TestBlocksFetcher_handleRequest(t *testing.T) {
 			}
 		}()
 
-		var blocks []interfaces.SignedBeaconBlock
+		var blocks []interfaces.ReadOnlySignedBeaconBlock
 		select {
 		case <-ctx.Done():
 			t.Error(ctx.Err())
@@ -633,7 +633,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 		req          *ethpb.BeaconBlocksByRangeRequest
 		handlerGenFn func(req *ethpb.BeaconBlocksByRangeRequest) func(stream network.Stream)
 		wantedErr    string
-		validate     func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.SignedBeaconBlock)
+		validate     func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock)
 	}{
 		{
 			name: "no error",
@@ -655,7 +655,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 					assert.NoError(t, stream.Close())
 				}
 			},
-			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.SignedBeaconBlock) {
+			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
 				assert.Equal(t, req.Count, uint64(len(blocks)))
 			},
 		},
@@ -679,7 +679,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 					assert.NoError(t, stream.Close())
 				}
 			},
-			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.SignedBeaconBlock) {
+			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
 				assert.Equal(t, 0, len(blocks))
 			},
 			wantedErr: beaconsync.ErrInvalidFetchedData.Error(),
@@ -708,7 +708,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 					assert.NoError(t, stream.Close())
 				}
 			},
-			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.SignedBeaconBlock) {
+			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
 				assert.Equal(t, 0, len(blocks))
 			},
 			wantedErr: beaconsync.ErrInvalidFetchedData.Error(),
@@ -738,7 +738,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 					assert.NoError(t, stream.Close())
 				}
 			},
-			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.SignedBeaconBlock) {
+			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
 				assert.Equal(t, 0, len(blocks))
 			},
 			wantedErr: beaconsync.ErrInvalidFetchedData.Error(),
@@ -774,7 +774,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 				}
 			},
 			wantedErr: beaconsync.ErrInvalidFetchedData.Error(),
-			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.SignedBeaconBlock) {
+			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
 				assert.Equal(t, 0, len(blocks))
 			},
 		},
@@ -809,7 +809,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 				}
 			},
 			wantedErr: beaconsync.ErrInvalidFetchedData.Error(),
-			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.SignedBeaconBlock) {
+			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
 				assert.Equal(t, 0, len(blocks))
 			},
 		},
@@ -837,7 +837,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 					assert.NoError(t, stream.Close())
 				}
 			},
-			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.SignedBeaconBlock) {
+			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
 				assert.Equal(t, 2, len(blocks))
 			},
 		},
@@ -865,7 +865,7 @@ func TestBlocksFetcher_requestBlocksFromPeerReturningInvalidBlocks(t *testing.T)
 					assert.NoError(t, stream.Close())
 				}
 			},
-			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.SignedBeaconBlock) {
+			validate: func(req *ethpb.BeaconBlocksByRangeRequest, blocks []interfaces.ReadOnlySignedBeaconBlock) {
 				assert.Equal(t, 0, len(blocks))
 			},
 			wantedErr: beaconsync.ErrInvalidFetchedData.Error(),

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_utils.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_utils.go
@@ -23,7 +23,7 @@ import (
 // either in DB or initial sync cache.
 type forkData struct {
 	peer   peer.ID
-	blocks []interfaces.SignedBeaconBlock
+	blocks []interfaces.ReadOnlySignedBeaconBlock
 }
 
 // nonSkippedSlotAfter checks slots after the given one in an attempt to find a non-empty future slot.
@@ -260,8 +260,8 @@ func (f *blocksFetcher) findForkWithPeer(ctx context.Context, pid peer.ID, slot 
 }
 
 // findAncestor tries to figure out common ancestor slot that connects a given root to known block.
-func (f *blocksFetcher) findAncestor(ctx context.Context, pid peer.ID, b interfaces.SignedBeaconBlock) (*forkData, error) {
-	outBlocks := []interfaces.SignedBeaconBlock{b}
+func (f *blocksFetcher) findAncestor(ctx context.Context, pid peer.ID, b interfaces.ReadOnlySignedBeaconBlock) (*forkData, error) {
+	outBlocks := []interfaces.ReadOnlySignedBeaconBlock{b}
 	for i := uint64(0); i < backtrackingMaxHops; i++ {
 		parentRoot := outBlocks[len(outBlocks)-1].Block().ParentRoot()
 		if f.chain.HasBlock(ctx, parentRoot) {

--- a/beacon-chain/sync/initial-sync/blocks_queue.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue.go
@@ -89,7 +89,7 @@ type blocksQueue struct {
 // blocksQueueFetchedData is a data container that is returned from a queue on each step.
 type blocksQueueFetchedData struct {
 	pid    peer.ID
-	blocks []interfaces.SignedBeaconBlock
+	blocks []interfaces.ReadOnlySignedBeaconBlock
 }
 
 // newBlocksQueue creates initialized priority queue.

--- a/beacon-chain/sync/initial-sync/blocks_queue_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_queue_test.go
@@ -259,7 +259,7 @@ func TestBlocksQueue_Loop(t *testing.T) {
 				highestExpectedSlot: tt.highestExpectedSlot,
 			})
 			assert.NoError(t, queue.start())
-			processBlock := func(block interfaces.SignedBeaconBlock) error {
+			processBlock := func(block interfaces.ReadOnlySignedBeaconBlock) error {
 				if !beaconDB.HasBlock(ctx, block.Block().ParentRoot()) {
 					return fmt.Errorf("%w: %#x", errParentDoesNotExist, block.Block().ParentRoot())
 				}
@@ -270,7 +270,7 @@ func TestBlocksQueue_Loop(t *testing.T) {
 				return mc.ReceiveBlock(ctx, block, root)
 			}
 
-			var blocks []interfaces.SignedBeaconBlock
+			var blocks []interfaces.ReadOnlySignedBeaconBlock
 			for data := range queue.fetchedData {
 				for _, block := range data.blocks {
 					if err := processBlock(block); err != nil {
@@ -533,7 +533,7 @@ func TestBlocksQueue_onDataReceivedEvent(t *testing.T) {
 		require.NoError(t, err)
 		response := &fetchRequestResponse{
 			pid: "abc",
-			blocks: []interfaces.SignedBeaconBlock{
+			blocks: []interfaces.ReadOnlySignedBeaconBlock{
 				wsb,
 				wsbCopy,
 			},
@@ -542,7 +542,7 @@ func TestBlocksQueue_onDataReceivedEvent(t *testing.T) {
 			state: stateScheduled,
 		}
 		assert.Equal(t, peer.ID(""), fsm.pid)
-		assert.DeepSSZEqual(t, []interfaces.SignedBeaconBlock(nil), fsm.blocks)
+		assert.DeepSSZEqual(t, []interfaces.ReadOnlySignedBeaconBlock(nil), fsm.blocks)
 		updatedState, err := handlerFn(fsm, response)
 		assert.NoError(t, err)
 		assert.Equal(t, stateDataParsed, updatedState)
@@ -631,7 +631,7 @@ func TestBlocksQueue_onReadyToSendEvent(t *testing.T) {
 		queue.smm.addStateMachine(320)
 		queue.smm.machines[256].state = stateDataParsed
 		queue.smm.machines[256].pid = pidDataParsed
-		queue.smm.machines[256].blocks = []interfaces.SignedBeaconBlock{
+		queue.smm.machines[256].blocks = []interfaces.ReadOnlySignedBeaconBlock{
 			wsb,
 		}
 
@@ -663,7 +663,7 @@ func TestBlocksQueue_onReadyToSendEvent(t *testing.T) {
 		queue.smm.addStateMachine(320)
 		queue.smm.machines[320].state = stateDataParsed
 		queue.smm.machines[320].pid = pidDataParsed
-		queue.smm.machines[320].blocks = []interfaces.SignedBeaconBlock{
+		queue.smm.machines[320].blocks = []interfaces.ReadOnlySignedBeaconBlock{
 			wsb,
 		}
 
@@ -692,7 +692,7 @@ func TestBlocksQueue_onReadyToSendEvent(t *testing.T) {
 		queue.smm.addStateMachine(320)
 		queue.smm.machines[320].state = stateDataParsed
 		queue.smm.machines[320].pid = pidDataParsed
-		queue.smm.machines[320].blocks = []interfaces.SignedBeaconBlock{
+		queue.smm.machines[320].blocks = []interfaces.ReadOnlySignedBeaconBlock{
 			wsb,
 		}
 
@@ -1317,7 +1317,7 @@ func TestBlocksQueue_stuckWhenHeadIsSetToOrphanedBlock(t *testing.T) {
 	})
 
 	require.NoError(t, queue.start())
-	isProcessedBlock := func(ctx context.Context, blk interfaces.SignedBeaconBlock, blkRoot [32]byte) bool {
+	isProcessedBlock := func(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock, blkRoot [32]byte) bool {
 		cp := mc.FinalizedCheckpt()
 		finalizedSlot, err := slots.EpochStart(cp.Epoch)
 		if err != nil {

--- a/beacon-chain/sync/initial-sync/fsm.go
+++ b/beacon-chain/sync/initial-sync/fsm.go
@@ -46,7 +46,7 @@ type stateMachine struct {
 	start   primitives.Slot
 	state   stateID
 	pid     peer.ID
-	blocks  []interfaces.SignedBeaconBlock
+	blocks  []interfaces.ReadOnlySignedBeaconBlock
 	updated time.Time
 }
 
@@ -78,7 +78,7 @@ func (smm *stateMachineManager) addStateMachine(startSlot primitives.Slot) *stat
 		smm:     smm,
 		start:   startSlot,
 		state:   stateNew,
-		blocks:  []interfaces.SignedBeaconBlock{},
+		blocks:  []interfaces.ReadOnlySignedBeaconBlock{},
 		updated: prysmTime.Now(),
 	}
 	smm.recalculateMachineAttribs()

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -22,10 +22,10 @@ const (
 )
 
 // blockReceiverFn defines block receiving function.
-type blockReceiverFn func(ctx context.Context, block interfaces.SignedBeaconBlock, blockRoot [32]byte) error
+type blockReceiverFn func(ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock, blockRoot [32]byte) error
 
 // batchBlockReceiverFn defines batch receiving function.
-type batchBlockReceiverFn func(ctx context.Context, blks []interfaces.SignedBeaconBlock, roots [][32]byte) error
+type batchBlockReceiverFn func(ctx context.Context, blks []interfaces.ReadOnlySignedBeaconBlock, roots [][32]byte) error
 
 // Round Robin sync looks at the latest peer statuses and syncs up to the highest known epoch.
 //
@@ -184,7 +184,7 @@ func (s *Service) highestFinalizedEpoch() primitives.Epoch {
 }
 
 // logSyncStatus and increment block processing counter.
-func (s *Service) logSyncStatus(genesis time.Time, blk interfaces.BeaconBlock, blkRoot [32]byte) {
+func (s *Service) logSyncStatus(genesis time.Time, blk interfaces.ReadOnlyBeaconBlock, blkRoot [32]byte) {
 	s.counter.Incr(1)
 	rate := float64(s.counter.Rate()) / counterSeconds
 	if rate == 0 {
@@ -204,7 +204,7 @@ func (s *Service) logSyncStatus(genesis time.Time, blk interfaces.BeaconBlock, b
 }
 
 // logBatchSyncStatus and increments the block processing counter.
-func (s *Service) logBatchSyncStatus(genesis time.Time, blks []interfaces.SignedBeaconBlock, blkRoot [32]byte) {
+func (s *Service) logBatchSyncStatus(genesis time.Time, blks []interfaces.ReadOnlySignedBeaconBlock, blkRoot [32]byte) {
 	s.counter.Incr(int64(len(blks)))
 	rate := float64(s.counter.Rate()) / counterSeconds
 	if rate == 0 {
@@ -226,7 +226,7 @@ func (s *Service) logBatchSyncStatus(genesis time.Time, blks []interfaces.Signed
 func (s *Service) processBlock(
 	ctx context.Context,
 	genesis time.Time,
-	blk interfaces.SignedBeaconBlock,
+	blk interfaces.ReadOnlySignedBeaconBlock,
 	blockReceiver blockReceiverFn,
 ) error {
 	blkRoot, err := blk.Block().HashTreeRoot()
@@ -245,7 +245,7 @@ func (s *Service) processBlock(
 }
 
 func (s *Service) processBatchedBlocks(ctx context.Context, genesis time.Time,
-	blks []interfaces.SignedBeaconBlock, bFunc batchBlockReceiverFn) error {
+	blks []interfaces.ReadOnlySignedBeaconBlock, bFunc batchBlockReceiverFn) error {
 	if len(blks) == 0 {
 		return errors.New("0 blocks provided into method")
 	}
@@ -304,7 +304,7 @@ func (s *Service) updatePeerScorerStats(pid peer.ID, startSlot primitives.Slot) 
 }
 
 // isProcessedBlock checks DB and local cache for presence of a given block, to avoid duplicates.
-func (s *Service) isProcessedBlock(ctx context.Context, blk interfaces.SignedBeaconBlock, blkRoot [32]byte) bool {
+func (s *Service) isProcessedBlock(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock, blkRoot [32]byte) bool {
 	cp := s.cfg.Chain.FinalizedCheckpt()
 	finalizedSlot, err := slots.EpochStart(cp.Epoch)
 	if err != nil {

--- a/beacon-chain/sync/initial-sync/round_robin_test.go
+++ b/beacon-chain/sync/initial-sync/round_robin_test.go
@@ -365,7 +365,7 @@ func TestService_processBlock(t *testing.T) {
 		wsb, err := blocks.NewSignedBeaconBlock(blk1)
 		require.NoError(t, err)
 		err = s.processBlock(ctx, genesis, wsb, func(
-			ctx context.Context, block interfaces.SignedBeaconBlock, blockRoot [32]byte) error {
+			ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock, blockRoot [32]byte) error {
 			assert.NoError(t, s.cfg.Chain.ReceiveBlock(ctx, block, blockRoot))
 			return nil
 		})
@@ -375,7 +375,7 @@ func TestService_processBlock(t *testing.T) {
 		wsb, err = blocks.NewSignedBeaconBlock(blk1)
 		require.NoError(t, err)
 		err = s.processBlock(ctx, genesis, wsb, func(
-			ctx context.Context, block interfaces.SignedBeaconBlock, blockRoot [32]byte) error {
+			ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock, blockRoot [32]byte) error {
 			return nil
 		})
 		assert.ErrorContains(t, errBlockAlreadyProcessed.Error(), err)
@@ -384,7 +384,7 @@ func TestService_processBlock(t *testing.T) {
 		wsb, err = blocks.NewSignedBeaconBlock(blk2)
 		require.NoError(t, err)
 		err = s.processBlock(ctx, genesis, wsb, func(
-			ctx context.Context, block interfaces.SignedBeaconBlock, blockRoot [32]byte) error {
+			ctx context.Context, block interfaces.ReadOnlySignedBeaconBlock, blockRoot [32]byte) error {
 			assert.NoError(t, s.cfg.Chain.ReceiveBlock(ctx, block, blockRoot))
 			return nil
 		})
@@ -418,7 +418,7 @@ func TestService_processBlockBatch(t *testing.T) {
 	genesis := makeGenesisTime(32)
 
 	t.Run("process non-linear batch", func(t *testing.T) {
-		var batch []interfaces.SignedBeaconBlock
+		var batch []interfaces.ReadOnlySignedBeaconBlock
 		currBlockRoot := genesisBlkRoot
 		for i := primitives.Slot(1); i < 10; i++ {
 			parentRoot := currBlockRoot
@@ -434,7 +434,7 @@ func TestService_processBlockBatch(t *testing.T) {
 			currBlockRoot = blk1Root
 		}
 
-		var batch2 []interfaces.SignedBeaconBlock
+		var batch2 []interfaces.ReadOnlySignedBeaconBlock
 		for i := primitives.Slot(10); i < 20; i++ {
 			parentRoot := currBlockRoot
 			blk1 := util.NewBeaconBlock()
@@ -451,7 +451,7 @@ func TestService_processBlockBatch(t *testing.T) {
 
 		// Process block normally.
 		err = s.processBatchedBlocks(ctx, genesis, batch, func(
-			ctx context.Context, blks []interfaces.SignedBeaconBlock, blockRoots [][32]byte) error {
+			ctx context.Context, blks []interfaces.ReadOnlySignedBeaconBlock, blockRoots [][32]byte) error {
 			assert.NoError(t, s.cfg.Chain.ReceiveBlockBatch(ctx, blks, blockRoots))
 			return nil
 		})
@@ -459,12 +459,12 @@ func TestService_processBlockBatch(t *testing.T) {
 
 		// Duplicate processing should trigger error.
 		err = s.processBatchedBlocks(ctx, genesis, batch, func(
-			ctx context.Context, blocks []interfaces.SignedBeaconBlock, blockRoots [][32]byte) error {
+			ctx context.Context, blocks []interfaces.ReadOnlySignedBeaconBlock, blockRoots [][32]byte) error {
 			return nil
 		})
 		assert.ErrorContains(t, "block is already processed", err)
 
-		var badBatch2 []interfaces.SignedBeaconBlock
+		var badBatch2 []interfaces.ReadOnlySignedBeaconBlock
 		for i, b := range batch2 {
 			// create a non-linear batch
 			if i%3 == 0 && i != 0 {
@@ -475,7 +475,7 @@ func TestService_processBlockBatch(t *testing.T) {
 
 		// Bad batch should fail because it is non linear
 		err = s.processBatchedBlocks(ctx, genesis, badBatch2, func(
-			ctx context.Context, blks []interfaces.SignedBeaconBlock, blockRoots [][32]byte) error {
+			ctx context.Context, blks []interfaces.ReadOnlySignedBeaconBlock, blockRoots [][32]byte) error {
 			return nil
 		})
 		expectedSubErr := "expected linear block list"
@@ -483,7 +483,7 @@ func TestService_processBlockBatch(t *testing.T) {
 
 		// Continue normal processing, should proceed w/o errors.
 		err = s.processBatchedBlocks(ctx, genesis, batch2, func(
-			ctx context.Context, blks []interfaces.SignedBeaconBlock, blockRoots [][32]byte) error {
+			ctx context.Context, blks []interfaces.ReadOnlySignedBeaconBlock, blockRoots [][32]byte) error {
 			assert.NoError(t, s.cfg.Chain.ReceiveBlockBatch(ctx, blks, blockRoots))
 			return nil
 		})

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -211,7 +211,7 @@ func (s *Service) checkIfBlockIsBad(
 	ctx context.Context,
 	span *trace.Span,
 	slot primitives.Slot,
-	b interfaces.SignedBeaconBlock,
+	b interfaces.ReadOnlySignedBeaconBlock,
 	blkRoot [32]byte,
 ) (keepProcessing bool, err error) {
 	parentIsBad := s.hasBadBlock(b.Block().ParentRoot())
@@ -353,7 +353,7 @@ func (s *Service) clearPendingSlots() {
 
 // Delete block from the list from the pending queue using the slot as key.
 // Note: this helper is not thread safe.
-func (s *Service) deleteBlockFromPendingQueue(slot primitives.Slot, b interfaces.SignedBeaconBlock, r [32]byte) error {
+func (s *Service) deleteBlockFromPendingQueue(slot primitives.Slot, b interfaces.ReadOnlySignedBeaconBlock, r [32]byte) error {
 	mutexasserts.AssertRWMutexLocked(&s.pendingQueueLock)
 
 	blks := s.pendingBlocksInCache(slot)
@@ -366,7 +366,7 @@ func (s *Service) deleteBlockFromPendingQueue(slot primitives.Slot, b interfaces
 		return err
 	}
 
-	newBlks := make([]interfaces.SignedBeaconBlock, 0, len(blks))
+	newBlks := make([]interfaces.ReadOnlySignedBeaconBlock, 0, len(blks))
 	for _, blk := range blks {
 		blkPb, err := blk.Proto()
 		if err != nil {
@@ -398,7 +398,7 @@ func (s *Service) deleteBlockFromPendingQueue(slot primitives.Slot, b interfaces
 
 // Insert block to the list in the pending queue using the slot as key.
 // Note: this helper is not thread safe.
-func (s *Service) insertBlockToPendingQueue(_ primitives.Slot, b interfaces.SignedBeaconBlock, r [32]byte) error {
+func (s *Service) insertBlockToPendingQueue(_ primitives.Slot, b interfaces.ReadOnlySignedBeaconBlock, r [32]byte) error {
 	mutexasserts.AssertRWMutexLocked(&s.pendingQueueLock)
 
 	if s.seenPendingBlocks[r] {
@@ -414,21 +414,21 @@ func (s *Service) insertBlockToPendingQueue(_ primitives.Slot, b interfaces.Sign
 }
 
 // This returns signed beacon blocks given input key from slotToPendingBlocks.
-func (s *Service) pendingBlocksInCache(slot primitives.Slot) []interfaces.SignedBeaconBlock {
+func (s *Service) pendingBlocksInCache(slot primitives.Slot) []interfaces.ReadOnlySignedBeaconBlock {
 	k := slotToCacheKey(slot)
 	value, ok := s.slotToPendingBlocks.Get(k)
 	if !ok {
-		return []interfaces.SignedBeaconBlock{}
+		return []interfaces.ReadOnlySignedBeaconBlock{}
 	}
-	blks, ok := value.([]interfaces.SignedBeaconBlock)
+	blks, ok := value.([]interfaces.ReadOnlySignedBeaconBlock)
 	if !ok {
-		return []interfaces.SignedBeaconBlock{}
+		return []interfaces.ReadOnlySignedBeaconBlock{}
 	}
 	return blks
 }
 
 // This adds input signed beacon block to slotToPendingBlocks cache.
-func (s *Service) addPendingBlockToCache(b interfaces.SignedBeaconBlock) error {
+func (s *Service) addPendingBlockToCache(b interfaces.ReadOnlySignedBeaconBlock) error {
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
 		return err
 	}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -142,7 +142,7 @@ func (s *Service) writeBlockRangeToStream(ctx context.Context, startSlot, endSlo
 			tracing.AnnotateError(span, err)
 			return err
 		}
-		blks = append([]interfaces.SignedBeaconBlock{genBlock}, blks...)
+		blks = append([]interfaces.ReadOnlySignedBeaconBlock{genBlock}, blks...)
 		roots = append([][32]byte{genRoot}, roots...)
 	}
 	// Filter and sort our retrieved blocks, so that
@@ -175,7 +175,7 @@ func (s *Service) writeBlockRangeToStream(ctx context.Context, startSlot, endSlo
 		}
 	}
 
-	var reconstructedBlock []interfaces.SignedBeaconBlockWriteable
+	var reconstructedBlock []interfaces.SignedBeaconBlock
 	if blindedExists {
 		reconstructedBlock, err = s.cfg.executionPayloadReconstructor.ReconstructFullBellatrixBlockBatch(ctx, blks[blindedIndex:])
 		if err != nil {
@@ -252,13 +252,13 @@ func (s *Service) validateRangeRequest(r *pb.BeaconBlocksByRangeRequest) error {
 
 // filters all the provided blocks to ensure they are canonical
 // and are strictly linear.
-func (s *Service) filterBlocks(ctx context.Context, blks []interfaces.SignedBeaconBlock, roots [][32]byte, prevRoot *[32]byte,
-	step uint64, startSlot primitives.Slot) ([]interfaces.SignedBeaconBlock, error) {
+func (s *Service) filterBlocks(ctx context.Context, blks []interfaces.ReadOnlySignedBeaconBlock, roots [][32]byte, prevRoot *[32]byte,
+	step uint64, startSlot primitives.Slot) ([]interfaces.ReadOnlySignedBeaconBlock, error) {
 	if len(blks) != len(roots) {
 		return nil, errors.New("input blks and roots are diff lengths")
 	}
 
-	newBlks := make([]interfaces.SignedBeaconBlock, 0, len(blks))
+	newBlks := make([]interfaces.ReadOnlySignedBeaconBlock, 0, len(blks))
 	for i, b := range blks {
 		isCanonical, err := s.cfg.chain.IsCanonical(ctx, roots[i])
 		if err != nil {
@@ -295,7 +295,7 @@ func (s *Service) writeErrorResponseToStream(responseCode byte, reason string, s
 	writeErrorResponseToStream(responseCode, reason, stream, s.cfg.p2p)
 }
 
-func (s *Service) retrieveGenesisBlock(ctx context.Context) (interfaces.SignedBeaconBlock, [32]byte, error) {
+func (s *Service) retrieveGenesisBlock(ctx context.Context) (interfaces.ReadOnlySignedBeaconBlock, [32]byte, error) {
 	genBlock, err := s.cfg.beaconDB.GenesisBlock(ctx)
 	if err != nil {
 		return nil, [32]byte{}, err

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range_test.go
@@ -1083,7 +1083,7 @@ func TestRPCBeaconBlocksByRange_FilterBlocks_PreviousRoot(t *testing.T) {
 	// Populate the database with blocks that would match the request.
 	var prevRoot [32]byte
 	var err error
-	blks := []interfaces.SignedBeaconBlock{}
+	blks := []interfaces.ReadOnlySignedBeaconBlock{}
 	var roots [][32]byte
 	for i := req.StartSlot; i < req.StartSlot.Add(req.Count); i += primitives.Slot(1) {
 		blk := util.NewBeaconBlock()

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -19,7 +19,7 @@ func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 	ctx, cancel := context.WithTimeout(ctx, respTimeout)
 	defer cancel()
 
-	_, err := SendBeaconBlocksByRootRequest(ctx, s.cfg.chain, s.cfg.p2p, id, blockRoots, func(blk interfaces.SignedBeaconBlock) error {
+	_, err := SendBeaconBlocksByRootRequest(ctx, s.cfg.chain, s.cfg.p2p, id, blockRoots, func(blk interfaces.ReadOnlySignedBeaconBlock) error {
 		blkRoot, err := blk.Block().HashTreeRoot()
 		if err != nil {
 			return err

--- a/beacon-chain/sync/rpc_chunked_response_test.go
+++ b/beacon-chain/sync/rpc_chunked_response_test.go
@@ -30,7 +30,7 @@ func TestExtractBlockDataType(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interfaces.SignedBeaconBlock
+		want    interfaces.ReadOnlySignedBeaconBlock
 		wantErr bool
 	}{
 		{
@@ -40,7 +40,7 @@ func TestExtractBlockDataType(t *testing.T) {
 				chain:  &mock.ChainService{ValidatorsRoot: [32]byte{}},
 			},
 
-			want: func() interfaces.SignedBeaconBlock {
+			want: func() interfaces.ReadOnlySignedBeaconBlock {
 				wsb, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{}}})
 				require.NoError(t, err)
 				return wsb
@@ -71,7 +71,7 @@ func TestExtractBlockDataType(t *testing.T) {
 				digest: genDigest[:],
 				chain:  &mock.ChainService{ValidatorsRoot: [32]byte{}},
 			},
-			want: func() interfaces.SignedBeaconBlock {
+			want: func() interfaces.ReadOnlySignedBeaconBlock {
 				wsb, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlock{Block: &ethpb.BeaconBlock{Body: &ethpb.BeaconBlockBody{}}})
 				require.NoError(t, err)
 				return wsb
@@ -84,7 +84,7 @@ func TestExtractBlockDataType(t *testing.T) {
 				digest: altairDigest[:],
 				chain:  &mock.ChainService{ValidatorsRoot: [32]byte{}},
 			},
-			want: func() interfaces.SignedBeaconBlock {
+			want: func() interfaces.ReadOnlySignedBeaconBlock {
 				wsb, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockAltair{Block: &ethpb.BeaconBlockAltair{Body: &ethpb.BeaconBlockBodyAltair{}}})
 				require.NoError(t, err)
 				return wsb
@@ -97,7 +97,7 @@ func TestExtractBlockDataType(t *testing.T) {
 				digest: bellatrixDigest[:],
 				chain:  &mock.ChainService{ValidatorsRoot: [32]byte{}},
 			},
-			want: func() interfaces.SignedBeaconBlock {
+			want: func() interfaces.ReadOnlySignedBeaconBlock {
 				wsb, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockBellatrix{Block: &ethpb.BeaconBlockBellatrix{Body: &ethpb.BeaconBlockBodyBellatrix{}}})
 				require.NoError(t, err)
 				return wsb

--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -21,13 +21,13 @@ var ErrInvalidFetchedData = errors.New("invalid data returned from peer")
 
 // BeaconBlockProcessor defines a block processing function, which allows to start utilizing
 // blocks even before all blocks are ready.
-type BeaconBlockProcessor func(block interfaces.SignedBeaconBlock) error
+type BeaconBlockProcessor func(block interfaces.ReadOnlySignedBeaconBlock) error
 
 // SendBeaconBlocksByRangeRequest sends BeaconBlocksByRange and returns fetched blocks, if any.
 func SendBeaconBlocksByRangeRequest(
 	ctx context.Context, chain blockchain.ForkFetcher, p2pProvider p2p.SenderEncoder, pid peer.ID,
 	req *pb.BeaconBlocksByRangeRequest, blockProcessor BeaconBlockProcessor,
-) ([]interfaces.SignedBeaconBlock, error) {
+) ([]interfaces.ReadOnlySignedBeaconBlock, error) {
 	topic, err := p2p.TopicFromMessage(p2p.BeaconBlocksByRangeMessageName, slots.ToEpoch(chain.CurrentSlot()))
 	if err != nil {
 		return nil, err
@@ -39,8 +39,8 @@ func SendBeaconBlocksByRangeRequest(
 	defer closeStream(stream, log)
 
 	// Augment block processing function, if non-nil block processor is provided.
-	blocks := make([]interfaces.SignedBeaconBlock, 0, req.Count)
-	process := func(blk interfaces.SignedBeaconBlock) error {
+	blocks := make([]interfaces.ReadOnlySignedBeaconBlock, 0, req.Count)
+	process := func(blk interfaces.ReadOnlySignedBeaconBlock) error {
 		blocks = append(blocks, blk)
 		if blockProcessor != nil {
 			return blockProcessor(blk)
@@ -89,7 +89,7 @@ func SendBeaconBlocksByRangeRequest(
 func SendBeaconBlocksByRootRequest(
 	ctx context.Context, chain blockchain.ChainInfoFetcher, p2pProvider p2p.P2P, pid peer.ID,
 	req *p2ptypes.BeaconBlockByRootsReq, blockProcessor BeaconBlockProcessor,
-) ([]interfaces.SignedBeaconBlock, error) {
+) ([]interfaces.ReadOnlySignedBeaconBlock, error) {
 	topic, err := p2p.TopicFromMessage(p2p.BeaconBlocksByRootsMessageName, slots.ToEpoch(chain.CurrentSlot()))
 	if err != nil {
 		return nil, err
@@ -101,8 +101,8 @@ func SendBeaconBlocksByRootRequest(
 	defer closeStream(stream, log)
 
 	// Augment block processing function, if non-nil block processor is provided.
-	blocks := make([]interfaces.SignedBeaconBlock, 0, len(*req))
-	process := func(block interfaces.SignedBeaconBlock) error {
+	blocks := make([]interfaces.ReadOnlySignedBeaconBlock, 0, len(*req))
+	process := func(block interfaces.ReadOnlySignedBeaconBlock) error {
 		blocks = append(blocks, block)
 		if blockProcessor != nil {
 			return blockProcessor(block)

--- a/beacon-chain/sync/rpc_send_request_test.go
+++ b/beacon-chain/sync/rpc_send_request_test.go
@@ -123,9 +123,9 @@ func TestSendRequest_SendBeaconBlocksByRangeRequest(t *testing.T) {
 			Count:     128,
 			Step:      1,
 		}
-		blocksFromProcessor := make([]interfaces.SignedBeaconBlock, 0)
+		blocksFromProcessor := make([]interfaces.ReadOnlySignedBeaconBlock, 0)
 		chain := &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-		blocks, err := SendBeaconBlocksByRangeRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.SignedBeaconBlock) error {
+		blocks, err := SendBeaconBlocksByRangeRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
 			blocksFromProcessor = append(blocksFromProcessor, block)
 			return nil
 		})
@@ -148,7 +148,7 @@ func TestSendRequest_SendBeaconBlocksByRangeRequest(t *testing.T) {
 		}
 		errFromProcessor := errors.New("processor error")
 		chain := &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-		_, err := SendBeaconBlocksByRangeRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.SignedBeaconBlock) error {
+		_, err := SendBeaconBlocksByRangeRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
 			return errFromProcessor
 		})
 		assert.ErrorContains(t, errFromProcessor.Error(), err)
@@ -178,7 +178,7 @@ func TestSendRequest_SendBeaconBlocksByRangeRequest(t *testing.T) {
 			cfg.MaxRequestBlocks = maxRequestBlocks
 			params.OverrideBeaconNetworkConfig(cfg)
 		}()
-		blocks, err = SendBeaconBlocksByRangeRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.SignedBeaconBlock) error {
+		blocks, err = SendBeaconBlocksByRangeRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
 			// Since ssz checks the boundaries, and doesn't normally allow to send requests bigger than
 			// the max request size, we are updating max request size dynamically. Even when updated dynamically,
 			// no more than max request size of blocks is expected on return.
@@ -196,7 +196,7 @@ func TestSendRequest_SendBeaconBlocksByRangeRequest(t *testing.T) {
 		p1.Connect(p2)
 		blocksProcessed := 0
 		expectedErr := errors.New("some error")
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.SignedBeaconBlock) error {
+		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.ReadOnlySignedBeaconBlock) error {
 			if blocksProcessed > 2 {
 				return expectedErr
 			}
@@ -391,9 +391,9 @@ func TestSendRequest_SendBeaconBlocksByRootRequest(t *testing.T) {
 
 		// No error from block processor.
 		req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1]}
-		blocksFromProcessor := make([]interfaces.SignedBeaconBlock, 0)
+		blocksFromProcessor := make([]interfaces.ReadOnlySignedBeaconBlock, 0)
 		chain := &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-		blocks, err := SendBeaconBlocksByRootRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.SignedBeaconBlock) error {
+		blocks, err := SendBeaconBlocksByRootRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
 			blocksFromProcessor = append(blocksFromProcessor, block)
 			return nil
 		})
@@ -412,7 +412,7 @@ func TestSendRequest_SendBeaconBlocksByRootRequest(t *testing.T) {
 		req := &p2pTypes.BeaconBlockByRootsReq{knownRoots[0], knownRoots[1]}
 		errFromProcessor := errors.New("processor error")
 		chain := &mock.ChainService{Genesis: time.Now(), ValidatorsRoot: [32]byte{}}
-		_, err := SendBeaconBlocksByRootRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.SignedBeaconBlock) error {
+		_, err := SendBeaconBlocksByRootRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
 			return errFromProcessor
 		})
 		assert.ErrorContains(t, errFromProcessor.Error(), err)
@@ -438,7 +438,7 @@ func TestSendRequest_SendBeaconBlocksByRootRequest(t *testing.T) {
 			cfg.MaxRequestBlocks = maxRequestBlocks
 			params.OverrideBeaconNetworkConfig(cfg)
 		}()
-		blocks, err = SendBeaconBlocksByRootRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.SignedBeaconBlock) error {
+		blocks, err = SendBeaconBlocksByRootRequest(ctx, chain, p1, p2.PeerID(), req, func(block interfaces.ReadOnlySignedBeaconBlock) error {
 			// Since ssz checks the boundaries, and doesn't normally allow to send requests bigger than
 			// the max request size, we are updating max request size dynamically. Even when updated dynamically,
 			// no more than max request size of blocks is expected on return.
@@ -456,7 +456,7 @@ func TestSendRequest_SendBeaconBlocksByRootRequest(t *testing.T) {
 		p1.Connect(p2)
 		blocksProcessed := 0
 		expectedErr := errors.New("some error")
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.SignedBeaconBlock) error {
+		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.ReadOnlySignedBeaconBlock) error {
 			if blocksProcessed > 2 {
 				return expectedErr
 			}
@@ -477,7 +477,7 @@ func TestSendRequest_SendBeaconBlocksByRootRequest(t *testing.T) {
 		p1.Connect(p2)
 		blocksProcessed := 0
 		expectedErr := io.EOF
-		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.SignedBeaconBlock) error {
+		p2.SetStreamHandler(pcl, knownBlocksProvider(p2, func(block interfaces.ReadOnlySignedBeaconBlock) error {
 			if blocksProcessed > 2 {
 				return expectedErr
 			}

--- a/beacon-chain/sync/rpc_status_test.go
+++ b/beacon-chain/sync/rpc_status_test.go
@@ -950,9 +950,9 @@ func TestShouldResync(t *testing.T) {
 	}
 }
 
-func makeBlocks(t *testing.T, i, n uint64, previousRoot [32]byte) []interfaces.SignedBeaconBlock {
+func makeBlocks(t *testing.T, i, n uint64, previousRoot [32]byte) []interfaces.ReadOnlySignedBeaconBlock {
 	blocks := make([]*ethpb.SignedBeaconBlock, n)
-	ifaceBlocks := make([]interfaces.SignedBeaconBlock, n)
+	ifaceBlocks := make([]interfaces.ReadOnlySignedBeaconBlock, n)
 	for j := i; j < n+i; j++ {
 		parentRoot := make([]byte, 32)
 		copy(parentRoot, previousRoot[:])

--- a/beacon-chain/sync/utils.go
+++ b/beacon-chain/sync/utils.go
@@ -11,7 +11,7 @@ import (
 // which satisfy the Interface in `Sort` so that this type can
 // be sorted in ascending order.
 type sortedObj struct {
-	blks  []interfaces.SignedBeaconBlock
+	blks  []interfaces.ReadOnlySignedBeaconBlock
 	roots [][32]byte
 }
 
@@ -32,14 +32,14 @@ func (s sortedObj) Len() int {
 }
 
 // removes duplicates from provided blocks and roots.
-func (_ *Service) dedupBlocksAndRoots(blks []interfaces.SignedBeaconBlock, roots [][32]byte) ([]interfaces.SignedBeaconBlock, [][32]byte, error) {
+func (_ *Service) dedupBlocksAndRoots(blks []interfaces.ReadOnlySignedBeaconBlock, roots [][32]byte) ([]interfaces.ReadOnlySignedBeaconBlock, [][32]byte, error) {
 	if len(blks) != len(roots) {
 		return nil, nil, errors.New("input blks and roots are diff lengths")
 	}
 
 	// Remove duplicate blocks received
 	rootMap := make(map[[32]byte]bool, len(blks))
-	newBlks := make([]interfaces.SignedBeaconBlock, 0, len(blks))
+	newBlks := make([]interfaces.ReadOnlySignedBeaconBlock, 0, len(blks))
 	newRoots := make([][32]byte, 0, len(roots))
 	for i, r := range roots {
 		if rootMap[r] {
@@ -67,7 +67,7 @@ func (_ *Service) dedupRoots(roots [][32]byte) [][32]byte {
 
 // sort the provided blocks and roots in ascending order. This method assumes that the size of
 // block slice and root slice is equal.
-func (_ *Service) sortBlocksAndRoots(blks []interfaces.SignedBeaconBlock, roots [][32]byte) ([]interfaces.SignedBeaconBlock, [][32]byte) {
+func (_ *Service) sortBlocksAndRoots(blks []interfaces.ReadOnlySignedBeaconBlock, roots [][32]byte) ([]interfaces.ReadOnlySignedBeaconBlock, [][32]byte) {
 	obj := sortedObj{
 		blks:  blks,
 		roots: roots,

--- a/beacon-chain/sync/utils_test.go
+++ b/beacon-chain/sync/utils_test.go
@@ -15,7 +15,7 @@ import (
 func TestSortedObj_SortBlocksRoots(t *testing.T) {
 	source := rand.NewSource(33)
 	randGen := rand.New(source)
-	var blks []interfaces.SignedBeaconBlock
+	var blks []interfaces.ReadOnlySignedBeaconBlock
 	var roots [][32]byte
 	randFunc := func() int64 {
 		return randGen.Int63n(50)
@@ -49,7 +49,7 @@ func TestSortedObj_SortBlocksRoots(t *testing.T) {
 func TestSortedObj_NoDuplicates(t *testing.T) {
 	source := rand.NewSource(33)
 	randGen := rand.New(source)
-	var blks []interfaces.SignedBeaconBlock
+	var blks []interfaces.ReadOnlySignedBeaconBlock
 	var roots [][32]byte
 	randFunc := func() int64 {
 		return randGen.Int63n(50)

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -59,9 +59,9 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 	s.validateBlockLock.Lock()
 	defer s.validateBlockLock.Unlock()
 
-	blk, ok := m.(interfaces.SignedBeaconBlock)
+	blk, ok := m.(interfaces.ReadOnlySignedBeaconBlock)
 	if !ok {
-		return pubsub.ValidationReject, errors.New("msg is not ethpb.SignedBeaconBlock")
+		return pubsub.ValidationReject, errors.New("msg is not ethpb.ReadOnlySignedBeaconBlock")
 	}
 
 	if blk.IsNil() || blk.Block().IsNil() {
@@ -210,7 +210,7 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 	return pubsub.ValidationAccept, nil
 }
 
-func (s *Service) validateBeaconBlock(ctx context.Context, blk interfaces.SignedBeaconBlock, blockRoot [32]byte) error {
+func (s *Service) validateBeaconBlock(ctx context.Context, blk interfaces.ReadOnlySignedBeaconBlock, blockRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "sync.validateBeaconBlock")
 	defer span.End()
 
@@ -268,7 +268,7 @@ func (s *Service) validateBeaconBlock(ctx context.Context, blk interfaces.Signed
 //	   otherwise:
 //	      [IGNORE] The block's parent (defined by block.parent_root) passes all validation (including execution
 //	       node verification of the block.body.execution_payload).
-func (s *Service) validateBellatrixBeaconBlock(ctx context.Context, parentState state.BeaconState, blk interfaces.BeaconBlock) error {
+func (s *Service) validateBellatrixBeaconBlock(ctx context.Context, parentState state.BeaconState, blk interfaces.ReadOnlyBeaconBlock) error {
 	// Error if block and state are not the same version
 	if parentState.Version() != blk.Version() {
 		return errors.New("block and state are not the same version")
@@ -371,7 +371,7 @@ func isBlockQueueable(genesisTime uint64, slot primitives.Slot, receivedTime tim
 	return currentTimeWithDisparity.Unix() < slotTime.Unix()
 }
 
-func getBlockFields(b interfaces.SignedBeaconBlock) logrus.Fields {
+func getBlockFields(b interfaces.ReadOnlySignedBeaconBlock) logrus.Fields {
 	if consensusblocks.BeaconBlockIsNil(b) != nil {
 		return logrus.Fields{}
 	}

--- a/consensus-types/blocks/factory.go
+++ b/consensus-types/blocks/factory.go
@@ -28,7 +28,7 @@ var (
 )
 
 // NewSignedBeaconBlock creates a signed beacon block from a protobuf signed beacon block.
-func NewSignedBeaconBlock(i interface{}) (interfaces.SignedBeaconBlockWriteable, error) {
+func NewSignedBeaconBlock(i interface{}) (interfaces.SignedBeaconBlock, error) {
 	switch b := i.(type) {
 	case nil:
 		return nil, ErrNilObject
@@ -62,7 +62,7 @@ func NewSignedBeaconBlock(i interface{}) (interfaces.SignedBeaconBlockWriteable,
 }
 
 // NewBeaconBlock creates a beacon block from a protobuf beacon block.
-func NewBeaconBlock(i interface{}) (interfaces.BeaconBlock, error) {
+func NewBeaconBlock(i interface{}) (interfaces.ReadOnlyBeaconBlock, error) {
 	switch b := i.(type) {
 	case nil:
 		return nil, ErrNilObject
@@ -96,7 +96,7 @@ func NewBeaconBlock(i interface{}) (interfaces.BeaconBlock, error) {
 }
 
 // NewBeaconBlockBody creates a beacon block body from a protobuf beacon block body.
-func NewBeaconBlockBody(i interface{}) (interfaces.BeaconBlockBody, error) {
+func NewBeaconBlockBody(i interface{}) (interfaces.ReadOnlyBeaconBlockBody, error) {
 	switch b := i.(type) {
 	case nil:
 		return nil, ErrNilObject
@@ -117,10 +117,10 @@ func NewBeaconBlockBody(i interface{}) (interfaces.BeaconBlockBody, error) {
 	}
 }
 
-// BuildSignedBeaconBlock assembles a block.SignedBeaconBlock interface compatible struct from a
+// BuildSignedBeaconBlock assembles a block.ReadOnlySignedBeaconBlock interface compatible struct from a
 // given beacon block and the appropriate signature. This method may be used to easily create a
 // signed beacon block.
-func BuildSignedBeaconBlock(blk interfaces.BeaconBlock, signature []byte) (interfaces.SignedBeaconBlockWriteable, error) {
+func BuildSignedBeaconBlock(blk interfaces.ReadOnlyBeaconBlock, signature []byte) (interfaces.SignedBeaconBlock, error) {
 	pb, err := blk.Proto()
 	if err != nil {
 		return nil, err
@@ -173,8 +173,8 @@ func BuildSignedBeaconBlock(blk interfaces.BeaconBlock, signature []byte) (inter
 // BuildSignedBeaconBlockFromExecutionPayload takes a signed, blinded beacon block and converts into
 // a full, signed beacon block by specifying an execution payload.
 func BuildSignedBeaconBlockFromExecutionPayload(
-	blk interfaces.SignedBeaconBlock, payload interface{},
-) (interfaces.SignedBeaconBlockWriteable, error) {
+	blk interfaces.ReadOnlySignedBeaconBlock, payload interface{},
+) (interfaces.SignedBeaconBlock, error) {
 	if err := BeaconBlockIsNil(blk); err != nil {
 		return nil, err
 	}
@@ -291,7 +291,7 @@ func BuildSignedBeaconBlockFromExecutionPayload(
 
 // BeaconBlockContainerToSignedBeaconBlock converts BeaconBlockContainer (API response) to a SignedBeaconBlock.
 // This is particularly useful for using the values from API calls.
-func BeaconBlockContainerToSignedBeaconBlock(obj *eth.BeaconBlockContainer) (interfaces.SignedBeaconBlock, error) {
+func BeaconBlockContainerToSignedBeaconBlock(obj *eth.BeaconBlockContainer) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	switch obj.Block.(type) {
 	case *eth.BeaconBlockContainer_BlindedBellatrixBlock:
 		return NewSignedBeaconBlock(obj.GetBlindedBellatrixBlock())

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -17,7 +17,7 @@ import (
 // BeaconBlockIsNil checks if any composite field of input signed beacon block is nil.
 // Access to these nil fields will result in run time panic,
 // it is recommended to run these checks as first line of defense.
-func BeaconBlockIsNil(b interfaces.SignedBeaconBlock) error {
+func BeaconBlockIsNil(b interfaces.ReadOnlySignedBeaconBlock) error {
 	if b == nil || b.IsNil() {
 		return ErrNilSignedBeaconBlock
 	}
@@ -30,7 +30,7 @@ func (b *SignedBeaconBlock) Signature() [field_params.BLSSignatureLength]byte {
 }
 
 // Block returns the underlying beacon block object.
-func (b *SignedBeaconBlock) Block() interfaces.BeaconBlock {
+func (b *SignedBeaconBlock) Block() interfaces.ReadOnlyBeaconBlock {
 	return b.block
 }
 
@@ -40,7 +40,7 @@ func (b *SignedBeaconBlock) IsNil() bool {
 }
 
 // Copy performs a deep copy of the signed beacon block object.
-func (b *SignedBeaconBlock) Copy() (interfaces.SignedBeaconBlock, error) {
+func (b *SignedBeaconBlock) Copy() (interfaces.ReadOnlySignedBeaconBlock, error) {
 	if b == nil {
 		return nil, nil
 	}
@@ -187,7 +187,7 @@ func (b *SignedBeaconBlock) PbBlindedCapellaBlock() (*eth.SignedBlindedBeaconBlo
 }
 
 // ToBlinded converts a non-blinded block to its blinded equivalent.
-func (b *SignedBeaconBlock) ToBlinded() (interfaces.SignedBeaconBlock, error) {
+func (b *SignedBeaconBlock) ToBlinded() (interfaces.ReadOnlySignedBeaconBlock, error) {
 	if b.version < version.Bellatrix {
 		return nil, ErrUnsupportedVersion
 	}
@@ -474,7 +474,7 @@ func (b *BeaconBlock) StateRoot() [field_params.RootLength]byte {
 }
 
 // Body returns the underlying block body.
-func (b *BeaconBlock) Body() interfaces.BeaconBlockBody {
+func (b *BeaconBlock) Body() interfaces.ReadOnlyBeaconBlockBody {
 	return b.body
 }
 
@@ -731,7 +731,7 @@ func (b *BeaconBlock) AsSignRequestObject() (validatorpb.SignRequestObject, erro
 	}
 }
 
-func (b *BeaconBlock) Copy() (interfaces.BeaconBlock, error) {
+func (b *BeaconBlock) Copy() (interfaces.ReadOnlyBeaconBlock, error) {
 	if b == nil {
 		return nil, nil
 	}

--- a/consensus-types/blocks/getters_test.go
+++ b/consensus-types/blocks/getters_test.go
@@ -25,7 +25,7 @@ func Test_BeaconBlockIsNil(t *testing.T) {
 		assert.NotNil(t, err)
 	})
 	t.Run("nil signed block", func(t *testing.T) {
-		var i interfaces.SignedBeaconBlock
+		var i interfaces.ReadOnlySignedBeaconBlock
 		var sb *SignedBeaconBlock
 		i = sb
 		err := BeaconBlockIsNil(i)

--- a/consensus-types/blocks/testing/factory.go
+++ b/consensus-types/blocks/testing/factory.go
@@ -9,7 +9,7 @@ import (
 
 // NewSignedBeaconBlockFromGeneric creates a signed beacon block
 // from a protobuf generic signed beacon block.
-func NewSignedBeaconBlockFromGeneric(gb *eth.GenericSignedBeaconBlock) (interfaces.SignedBeaconBlock, error) {
+func NewSignedBeaconBlockFromGeneric(gb *eth.GenericSignedBeaconBlock) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	if gb == nil {
 		return nil, blocks.ErrNilObject
 	}

--- a/consensus-types/blocks/testing/mutator.go
+++ b/consensus-types/blocks/testing/mutator.go
@@ -15,7 +15,7 @@ type blockMutator struct {
 	Capella   func(beaconBlock *eth.SignedBeaconBlockCapella)
 }
 
-func (m blockMutator) apply(b interfaces.SignedBeaconBlockWriteable) (interfaces.SignedBeaconBlockWriteable, error) {
+func (m blockMutator) apply(b interfaces.SignedBeaconBlock) (interfaces.SignedBeaconBlock, error) {
 	switch b.Version() {
 	case version.Phase0:
 		bb, err := b.PbPhase0Block()
@@ -51,7 +51,7 @@ func (m blockMutator) apply(b interfaces.SignedBeaconBlockWriteable) (interfaces
 }
 
 // SetBlockStateRoot modifies the block's state root.
-func SetBlockStateRoot(b interfaces.SignedBeaconBlockWriteable, sr [32]byte) (interfaces.SignedBeaconBlockWriteable, error) {
+func SetBlockStateRoot(b interfaces.SignedBeaconBlock, sr [32]byte) (interfaces.SignedBeaconBlock, error) {
 	return blockMutator{
 		Phase0:    func(bb *eth.SignedBeaconBlock) { bb.Block.StateRoot = sr[:] },
 		Altair:    func(bb *eth.SignedBeaconBlockAltair) { bb.Block.StateRoot = sr[:] },
@@ -61,7 +61,7 @@ func SetBlockStateRoot(b interfaces.SignedBeaconBlockWriteable, sr [32]byte) (in
 }
 
 // SetBlockParentRoot modifies the block's parent root.
-func SetBlockParentRoot(b interfaces.SignedBeaconBlockWriteable, pr [32]byte) (interfaces.SignedBeaconBlockWriteable, error) {
+func SetBlockParentRoot(b interfaces.SignedBeaconBlock, pr [32]byte) (interfaces.SignedBeaconBlock, error) {
 	return blockMutator{
 		Phase0:    func(bb *eth.SignedBeaconBlock) { bb.Block.ParentRoot = pr[:] },
 		Altair:    func(bb *eth.SignedBeaconBlockAltair) { bb.Block.ParentRoot = pr[:] },
@@ -71,7 +71,7 @@ func SetBlockParentRoot(b interfaces.SignedBeaconBlockWriteable, pr [32]byte) (i
 }
 
 // SetBlockSlot modifies the block's slot.
-func SetBlockSlot(b interfaces.SignedBeaconBlockWriteable, s primitives.Slot) (interfaces.SignedBeaconBlockWriteable, error) {
+func SetBlockSlot(b interfaces.SignedBeaconBlock, s primitives.Slot) (interfaces.SignedBeaconBlock, error) {
 	return blockMutator{
 		Phase0:    func(bb *eth.SignedBeaconBlock) { bb.Block.Slot = s },
 		Altair:    func(bb *eth.SignedBeaconBlockAltair) { bb.Block.Slot = s },
@@ -81,7 +81,7 @@ func SetBlockSlot(b interfaces.SignedBeaconBlockWriteable, s primitives.Slot) (i
 }
 
 // SetProposerIndex modifies the block's proposer index.
-func SetProposerIndex(b interfaces.SignedBeaconBlockWriteable, idx primitives.ValidatorIndex) (interfaces.SignedBeaconBlockWriteable, error) {
+func SetProposerIndex(b interfaces.SignedBeaconBlock, idx primitives.ValidatorIndex) (interfaces.SignedBeaconBlock, error) {
 	return blockMutator{
 		Phase0:    func(bb *eth.SignedBeaconBlock) { bb.Block.ProposerIndex = idx },
 		Altair:    func(bb *eth.SignedBeaconBlockAltair) { bb.Block.ProposerIndex = idx },

--- a/consensus-types/blocks/types.go
+++ b/consensus-types/blocks/types.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	_ = interfaces.SignedBeaconBlock(&SignedBeaconBlock{})
-	_ = interfaces.BeaconBlock(&BeaconBlock{})
-	_ = interfaces.BeaconBlockBody(&BeaconBlockBody{})
+	_ = interfaces.ReadOnlySignedBeaconBlock(&SignedBeaconBlock{})
+	_ = interfaces.ReadOnlyBeaconBlock(&BeaconBlock{})
+	_ = interfaces.ReadOnlyBeaconBlockBody(&BeaconBlockBody{})
 )
 
 var (

--- a/consensus-types/interfaces/beacon_block.go
+++ b/consensus-types/interfaces/beacon_block.go
@@ -10,18 +10,18 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// SignedBeaconBlock is an interface describing the method set of
+// ReadOnlySignedBeaconBlock is an interface describing the method set of
 // a signed beacon block.
-type SignedBeaconBlock interface {
-	Block() BeaconBlock
+type ReadOnlySignedBeaconBlock interface {
+	Block() ReadOnlyBeaconBlock
 	Signature() [field_params.BLSSignatureLength]byte
 	IsNil() bool
-	Copy() (SignedBeaconBlock, error)
+	Copy() (ReadOnlySignedBeaconBlock, error)
 	Proto() (proto.Message, error)
 	PbGenericBlock() (*ethpb.GenericSignedBeaconBlock, error)
 	PbPhase0Block() (*ethpb.SignedBeaconBlock, error)
 	PbAltairBlock() (*ethpb.SignedBeaconBlockAltair, error)
-	ToBlinded() (SignedBeaconBlock, error)
+	ToBlinded() (ReadOnlySignedBeaconBlock, error)
 	PbBellatrixBlock() (*ethpb.SignedBeaconBlockBellatrix, error)
 	PbBlindedBellatrixBlock() (*ethpb.SignedBlindedBeaconBlockBellatrix, error)
 	PbCapellaBlock() (*ethpb.SignedBeaconBlockCapella, error)
@@ -33,14 +33,14 @@ type SignedBeaconBlock interface {
 	Header() (*ethpb.SignedBeaconBlockHeader, error)
 }
 
-// BeaconBlock describes an interface which states the methods
+// ReadOnlyBeaconBlock describes an interface which states the methods
 // employed by an object that is a beacon block.
-type BeaconBlock interface {
+type ReadOnlyBeaconBlock interface {
 	Slot() primitives.Slot
 	ProposerIndex() primitives.ValidatorIndex
 	ParentRoot() [field_params.RootLength]byte
 	StateRoot() [field_params.RootLength]byte
-	Body() BeaconBlockBody
+	Body() ReadOnlyBeaconBlockBody
 	IsNil() bool
 	IsBlinded() bool
 	HashTreeRoot() ([field_params.RootLength]byte, error)
@@ -50,12 +50,12 @@ type BeaconBlock interface {
 	ssz.HashRoot
 	Version() int
 	AsSignRequestObject() (validatorpb.SignRequestObject, error)
-	Copy() (BeaconBlock, error)
+	Copy() (ReadOnlyBeaconBlock, error)
 }
 
-// BeaconBlockBody describes the method set employed by an object
+// ReadOnlyBeaconBlockBody describes the method set employed by an object
 // that is a beacon block body.
-type BeaconBlockBody interface {
+type ReadOnlyBeaconBlockBody interface {
 	RandaoReveal() [field_params.BLSSignatureLength]byte
 	Eth1Data() *ethpb.Eth1Data
 	Graffiti() [field_params.RootLength]byte
@@ -72,8 +72,8 @@ type BeaconBlockBody interface {
 	BLSToExecutionChanges() ([]*ethpb.SignedBLSToExecutionChange, error)
 }
 
-type SignedBeaconBlockWriteable interface {
-	SignedBeaconBlock
+type SignedBeaconBlock interface {
+	ReadOnlySignedBeaconBlock
 	SetExecution(ExecutionData) error
 	SetBLSToExecutionChanges([]*ethpb.SignedBLSToExecutionChange) error
 	SetSyncAggregate(*ethpb.SyncAggregate) error

--- a/consensus-types/interfaces/utils.go
+++ b/consensus-types/interfaces/utils.go
@@ -28,7 +28,7 @@ func SignedBeaconBlockHeaderFromBlock(block *ethpb.SignedBeaconBlock) (*ethpb.Si
 }
 
 // SignedBeaconBlockHeaderFromBlockInterface function to retrieve signed block header from block.
-func SignedBeaconBlockHeaderFromBlockInterface(sb SignedBeaconBlock) (*ethpb.SignedBeaconBlockHeader, error) {
+func SignedBeaconBlockHeaderFromBlockInterface(sb ReadOnlySignedBeaconBlock) (*ethpb.SignedBeaconBlockHeader, error) {
 	b := sb.Block()
 	if b.IsNil() || b.Body().IsNil() {
 		return nil, errors.New("nil block")
@@ -65,7 +65,7 @@ func BeaconBlockHeaderFromBlock(block *ethpb.BeaconBlock) (*ethpb.BeaconBlockHea
 }
 
 // BeaconBlockHeaderFromBlockInterface function to retrieve block header from block.
-func BeaconBlockHeaderFromBlockInterface(block BeaconBlock) (*ethpb.BeaconBlockHeader, error) {
+func BeaconBlockHeaderFromBlockInterface(block ReadOnlyBeaconBlock) (*ethpb.BeaconBlockHeader, error) {
 	if block.Body().IsNil() {
 		return nil, errors.New("nil block body")
 	}

--- a/consensus-types/mock/block.go
+++ b/consensus-types/mock/block.go
@@ -11,14 +11,14 @@ import (
 )
 
 type SignedBeaconBlock struct {
-	BeaconBlock interfaces.BeaconBlock
+	BeaconBlock interfaces.ReadOnlyBeaconBlock
 }
 
 func (SignedBeaconBlock) PbGenericBlock() (*eth.GenericSignedBeaconBlock, error) {
 	panic("implement me")
 }
 
-func (m SignedBeaconBlock) Block() interfaces.BeaconBlock {
+func (m SignedBeaconBlock) Block() interfaces.ReadOnlyBeaconBlock {
 	return m.BeaconBlock
 }
 
@@ -34,7 +34,7 @@ func (m SignedBeaconBlock) IsNil() bool {
 	return m.BeaconBlock == nil || m.Block().IsNil()
 }
 
-func (SignedBeaconBlock) Copy() (interfaces.SignedBeaconBlock, error) {
+func (SignedBeaconBlock) Copy() (interfaces.ReadOnlySignedBeaconBlock, error) {
 	panic("implement me")
 }
 
@@ -90,7 +90,7 @@ func (SignedBeaconBlock) IsBlinded() bool {
 	return false
 }
 
-func (SignedBeaconBlock) ToBlinded() (interfaces.SignedBeaconBlock, error) {
+func (SignedBeaconBlock) ToBlinded() (interfaces.ReadOnlySignedBeaconBlock, error) {
 	panic("implement me")
 }
 
@@ -101,7 +101,7 @@ func (SignedBeaconBlock) Header() (*eth.SignedBeaconBlockHeader, error) {
 type BeaconBlock struct {
 	Htr             [field_params.RootLength]byte
 	HtrErr          error
-	BeaconBlockBody interfaces.BeaconBlockBody
+	BeaconBlockBody interfaces.ReadOnlyBeaconBlockBody
 	BlockSlot       primitives.Slot
 }
 
@@ -129,7 +129,7 @@ func (BeaconBlock) StateRoot() [field_params.RootLength]byte {
 	panic("implement me")
 }
 
-func (m BeaconBlock) Body() interfaces.BeaconBlockBody {
+func (m BeaconBlock) Body() interfaces.ReadOnlyBeaconBlockBody {
 	return m.BeaconBlockBody
 }
 
@@ -169,7 +169,7 @@ func (BeaconBlock) Version() int {
 	panic("implement me")
 }
 
-func (BeaconBlock) ToBlinded() (interfaces.BeaconBlock, error) {
+func (BeaconBlock) ToBlinded() (interfaces.ReadOnlyBeaconBlock, error) {
 	panic("implement me")
 }
 
@@ -189,7 +189,7 @@ func (BeaconBlock) SetBlinded(_ bool) {
 	panic("implement me")
 }
 
-func (BeaconBlock) Copy() (interfaces.BeaconBlock, error) {
+func (BeaconBlock) Copy() (interfaces.ReadOnlyBeaconBlock, error) {
 	panic("implement me")
 }
 
@@ -299,6 +299,6 @@ func (b *BeaconBlockBody) SetBLSToExecutionChanges([]*eth.SignedBLSToExecutionCh
 	panic("implement me")
 }
 
-var _ interfaces.SignedBeaconBlock = &SignedBeaconBlock{}
-var _ interfaces.BeaconBlock = &BeaconBlock{}
-var _ interfaces.BeaconBlockBody = &BeaconBlockBody{}
+var _ interfaces.ReadOnlySignedBeaconBlock = &SignedBeaconBlock{}
+var _ interfaces.ReadOnlyBeaconBlock = &BeaconBlock{}
+var _ interfaces.ReadOnlyBeaconBlockBody = &BeaconBlockBody{}

--- a/encoding/ssz/detect/configfork.go
+++ b/encoding/ssz/detect/configfork.go
@@ -21,7 +21,7 @@ import (
 )
 
 // VersionedUnmarshaler represents the intersection of Configuration (eg mainnet, testnet) and Fork (eg phase0, altair).
-// Using a detected VersionedUnmarshaler, a BeaconState or SignedBeaconBlock can be correctly unmarshaled without the need to
+// Using a detected VersionedUnmarshaler, a BeaconState or ReadOnlySignedBeaconBlock can be correctly unmarshaled without the need to
 // hard code a concrete type in paths where only the marshaled bytes, or marshaled bytes and a version, are available.
 type VersionedUnmarshaler struct {
 	Config *params.BeaconChainConfig
@@ -148,9 +148,9 @@ func slotFromBlock(marshaled []byte) (primitives.Slot, error) {
 
 var errBlockForkMismatch = errors.New("fork or config detected in unmarshaler is different than block")
 
-// UnmarshalBeaconBlock uses internal knowledge in the VersionedUnmarshaler to pick the right concrete SignedBeaconBlock type,
-// then Unmarshal()s the type and returns an instance of block.SignedBeaconBlock if successful.
-func (cf *VersionedUnmarshaler) UnmarshalBeaconBlock(marshaled []byte) (interfaces.SignedBeaconBlock, error) {
+// UnmarshalBeaconBlock uses internal knowledge in the VersionedUnmarshaler to pick the right concrete ReadOnlySignedBeaconBlock type,
+// then Unmarshal()s the type and returns an instance of block.ReadOnlySignedBeaconBlock if successful.
+func (cf *VersionedUnmarshaler) UnmarshalBeaconBlock(marshaled []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	slot, err := slotFromBlock(marshaled)
 	if err != nil {
 		return nil, err
@@ -169,19 +169,19 @@ func (cf *VersionedUnmarshaler) UnmarshalBeaconBlock(marshaled []byte) (interfac
 		blk = &ethpb.SignedBeaconBlockBellatrix{}
 	default:
 		forkName := version.String(cf.Fork)
-		return nil, fmt.Errorf("unable to initialize BeaconBlock for fork version=%s at slot=%d", forkName, slot)
+		return nil, fmt.Errorf("unable to initialize ReadOnlyBeaconBlock for fork version=%s at slot=%d", forkName, slot)
 	}
 	err = blk.UnmarshalSSZ(marshaled)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal SignedBeaconBlock in UnmarshalSSZ")
+		return nil, errors.Wrap(err, "failed to unmarshal ReadOnlySignedBeaconBlock in UnmarshalSSZ")
 	}
 	return blocks.NewSignedBeaconBlock(blk)
 }
 
-// UnmarshalBlindedBeaconBlock uses internal knowledge in the VersionedUnmarshaler to pick the right concrete blinded SignedBeaconBlock type,
-// then Unmarshal()s the type and returns an instance of block.SignedBeaconBlock if successful.
+// UnmarshalBlindedBeaconBlock uses internal knowledge in the VersionedUnmarshaler to pick the right concrete blinded ReadOnlySignedBeaconBlock type,
+// then Unmarshal()s the type and returns an instance of block.ReadOnlySignedBeaconBlock if successful.
 // For Phase0 and Altair it works exactly line UnmarshalBeaconBlock.
-func (cf *VersionedUnmarshaler) UnmarshalBlindedBeaconBlock(marshaled []byte) (interfaces.SignedBeaconBlock, error) {
+func (cf *VersionedUnmarshaler) UnmarshalBlindedBeaconBlock(marshaled []byte) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	slot, err := slotFromBlock(marshaled)
 	if err != nil {
 		return nil, err
@@ -200,11 +200,11 @@ func (cf *VersionedUnmarshaler) UnmarshalBlindedBeaconBlock(marshaled []byte) (i
 		blk = &ethpb.SignedBlindedBeaconBlockBellatrix{}
 	default:
 		forkName := version.String(cf.Fork)
-		return nil, fmt.Errorf("unable to initialize BeaconBlock for fork version=%s at slot=%d", forkName, slot)
+		return nil, fmt.Errorf("unable to initialize ReadOnlyBeaconBlock for fork version=%s at slot=%d", forkName, slot)
 	}
 	err = blk.UnmarshalSSZ(marshaled)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal SignedBeaconBlock in UnmarshalSSZ")
+		return nil, errors.Wrap(err, "failed to unmarshal ReadOnlySignedBeaconBlock in UnmarshalSSZ")
 	}
 	return blocks.NewSignedBeaconBlock(blk)
 }

--- a/encoding/ssz/detect/configfork_test.go
+++ b/encoding/ssz/detect/configfork_test.go
@@ -208,7 +208,7 @@ func TestUnmarshalBlock(t *testing.T) {
 	bellaS, err := slots.EpochStart(params.BeaconConfig().BellatrixForkEpoch)
 	require.NoError(t, err)
 	cases := []struct {
-		b       func(*testing.T, primitives.Slot) interfaces.SignedBeaconBlock
+		b       func(*testing.T, primitives.Slot) interfaces.ReadOnlySignedBeaconBlock
 		name    string
 		version [4]byte
 		slot    primitives.Slot
@@ -299,7 +299,7 @@ func TestUnmarshalBlindedBlock(t *testing.T) {
 	bellaS, err := slots.EpochStart(params.BeaconConfig().BellatrixForkEpoch)
 	require.NoError(t, err)
 	cases := []struct {
-		b       func(*testing.T, primitives.Slot) interfaces.SignedBeaconBlock
+		b       func(*testing.T, primitives.Slot) interfaces.ReadOnlySignedBeaconBlock
 		name    string
 		version [4]byte
 		slot    primitives.Slot
@@ -377,7 +377,7 @@ func TestUnmarshalBlindedBlock(t *testing.T) {
 	}
 }
 
-func signedTestBlockGenesis(t *testing.T, slot primitives.Slot) interfaces.SignedBeaconBlock {
+func signedTestBlockGenesis(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 	b := util.NewBeaconBlock()
 	b.Block.Slot = slot
 	s, err := blocks.NewSignedBeaconBlock(b)
@@ -385,7 +385,7 @@ func signedTestBlockGenesis(t *testing.T, slot primitives.Slot) interfaces.Signe
 	return s
 }
 
-func signedTestBlockAltair(t *testing.T, slot primitives.Slot) interfaces.SignedBeaconBlock {
+func signedTestBlockAltair(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 	b := util.NewBeaconBlockAltair()
 	b.Block.Slot = slot
 	s, err := blocks.NewSignedBeaconBlock(b)
@@ -393,7 +393,7 @@ func signedTestBlockAltair(t *testing.T, slot primitives.Slot) interfaces.Signed
 	return s
 }
 
-func signedTestBlockBellatrix(t *testing.T, slot primitives.Slot) interfaces.SignedBeaconBlock {
+func signedTestBlockBellatrix(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 	b := util.NewBeaconBlockBellatrix()
 	b.Block.Slot = slot
 	s, err := blocks.NewSignedBeaconBlock(b)
@@ -401,7 +401,7 @@ func signedTestBlockBellatrix(t *testing.T, slot primitives.Slot) interfaces.Sig
 	return s
 }
 
-func signedTestBlindedBlockBellatrix(t *testing.T, slot primitives.Slot) interfaces.SignedBeaconBlock {
+func signedTestBlindedBlockBellatrix(t *testing.T, slot primitives.Slot) interfaces.ReadOnlySignedBeaconBlock {
 	b := util.NewBlindedBeaconBlockBellatrix()
 	b.Block.Slot = slot
 	s, err := blocks.NewSignedBeaconBlock(b)

--- a/proto/migration/v1alpha1_to_v1.go
+++ b/proto/migration/v1alpha1_to_v1.go
@@ -11,7 +11,7 @@ import (
 )
 
 // BlockIfaceToV1BlockHeader converts a signed beacon block interface into a signed beacon block header.
-func BlockIfaceToV1BlockHeader(block interfaces.SignedBeaconBlock) (*ethpbv1.SignedBeaconBlockHeader, error) {
+func BlockIfaceToV1BlockHeader(block interfaces.ReadOnlySignedBeaconBlock) (*ethpbv1.SignedBeaconBlockHeader, error) {
 	bodyRoot, err := block.Block().Body().HashTreeRoot()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get body root of block")
@@ -57,7 +57,7 @@ func V1ToV1Alpha1SignedBlock(v1Blk *ethpbv1.SignedBeaconBlock) (*ethpbalpha.Sign
 	return v1alpha1Block, nil
 }
 
-// V1Alpha1ToV1Block converts a v1alpha1 BeaconBlock proto to a v1 proto.
+// V1Alpha1ToV1Block converts a v1alpha1 ReadOnlyBeaconBlock proto to a v1 proto.
 func V1Alpha1ToV1Block(alphaBlk *ethpbalpha.BeaconBlock) (*ethpbv1.BeaconBlock, error) {
 	marshaledBlk, err := proto.Marshal(alphaBlk)
 	if err != nil {
@@ -338,7 +338,7 @@ func V1ValidatorToV1Alpha1(v1Validator *ethpbv1.Validator) *ethpbalpha.Validator
 }
 
 // SignedBeaconBlock converts a signed beacon block interface to a v1alpha1 block.
-func SignedBeaconBlock(block interfaces.SignedBeaconBlock) (*ethpbv1.SignedBeaconBlock, error) {
+func SignedBeaconBlock(block interfaces.ReadOnlySignedBeaconBlock) (*ethpbv1.SignedBeaconBlock, error) {
 	if block == nil || block.IsNil() {
 		return nil, errors.New("could not find requested block")
 	}

--- a/testing/endtoend/evaluators/validator.go
+++ b/testing/endtoend/evaluators/validator.go
@@ -263,7 +263,7 @@ func validatorsSyncParticipation(_ *types.EvaluationContext, conns ...*grpc.Clie
 	return nil
 }
 
-func syncCompatibleBlockFromCtr(container *ethpb.BeaconBlockContainer) (interfaces.SignedBeaconBlock, error) {
+func syncCompatibleBlockFromCtr(container *ethpb.BeaconBlockContainer) (interfaces.ReadOnlySignedBeaconBlock, error) {
 	if container.GetPhase0Block() != nil {
 		return nil, errors.New("block doesn't support sync committees")
 	}

--- a/testing/spectest/shared/altair/operations/attestation.go
+++ b/testing/spectest/shared/altair/operations/attestation.go
@@ -34,7 +34,7 @@ func RunAttestationTest(t *testing.T, config string) {
 			require.NoError(t, att.UnmarshalSSZ(attestationSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyAltair{Attestations: []*ethpb.Attestation{att}}
-			processAtt := func(ctx context.Context, st state.BeaconState, blk interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			processAtt := func(ctx context.Context, st state.BeaconState, blk interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				st, err = altair.ProcessAttestationsNoVerifySignature(ctx, st, blk)
 				if err != nil {
 					return nil, err

--- a/testing/spectest/shared/altair/operations/attester_slashing.go
+++ b/testing/spectest/shared/altair/operations/attester_slashing.go
@@ -33,7 +33,7 @@ func RunAttesterSlashingTest(t *testing.T, config string) {
 			require.NoError(t, attSlashing.UnmarshalSSZ(attSlashingSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyAltair{AttesterSlashings: []*ethpb.AttesterSlashing{attSlashing}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), validators.SlashValidator)
 			})
 		})

--- a/testing/spectest/shared/altair/operations/deposit.go
+++ b/testing/spectest/shared/altair/operations/deposit.go
@@ -32,7 +32,7 @@ func RunDepositTest(t *testing.T, config string) {
 			require.NoError(t, deposit.UnmarshalSSZ(depositSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyAltair{Deposits: []*ethpb.Deposit{deposit}}
-			processDepositsFunc := func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			processDepositsFunc := func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return altair.ProcessDeposits(ctx, s, b.Block().Body().Deposits())
 			}
 			RunBlockOperationTest(t, folderPath, body, processDepositsFunc)

--- a/testing/spectest/shared/altair/operations/helpers.go
+++ b/testing/spectest/shared/altair/operations/helpers.go
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/d4l3k/messagediff.v1"
 )
 
-type blockOperation func(context.Context, state.BeaconState, interfaces.SignedBeaconBlock) (state.BeaconState, error)
+type blockOperation func(context.Context, state.BeaconState, interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error)
 
 // RunBlockOperationTest takes in the prestate and the beacon block body, processes it through the
 // passed in block operation function and checks the post state with the expected post state.

--- a/testing/spectest/shared/altair/operations/proposer_slashing.go
+++ b/testing/spectest/shared/altair/operations/proposer_slashing.go
@@ -33,7 +33,7 @@ func RunProposerSlashingTest(t *testing.T, config string) {
 			require.NoError(t, proposerSlashing.UnmarshalSSZ(proposerSlashingSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyAltair{ProposerSlashings: []*ethpb.ProposerSlashing{proposerSlashing}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), validators.SlashValidator)
 			})
 		})

--- a/testing/spectest/shared/altair/operations/sync_committee.go
+++ b/testing/spectest/shared/altair/operations/sync_committee.go
@@ -32,7 +32,7 @@ func RunSyncCommitteeTest(t *testing.T, config string) {
 			require.NoError(t, sc.UnmarshalSSZ(syncCommitteeSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyAltair{SyncAggregate: sc}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return altair.ProcessSyncAggregate(context.Background(), s, body.SyncAggregate)
 			})
 		})

--- a/testing/spectest/shared/altair/operations/voluntary_exit.go
+++ b/testing/spectest/shared/altair/operations/voluntary_exit.go
@@ -32,7 +32,7 @@ func RunVoluntaryExitTest(t *testing.T, config string) {
 			require.NoError(t, voluntaryExit.UnmarshalSSZ(exitSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyAltair{VoluntaryExits: []*ethpb.SignedVoluntaryExit{voluntaryExit}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessVoluntaryExits(ctx, s, b.Block().Body().VoluntaryExits())
 			})
 		})

--- a/testing/spectest/shared/bellatrix/operations/attestation.go
+++ b/testing/spectest/shared/bellatrix/operations/attestation.go
@@ -34,7 +34,7 @@ func RunAttestationTest(t *testing.T, config string) {
 			require.NoError(t, att.UnmarshalSSZ(attestationSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyBellatrix{Attestations: []*ethpb.Attestation{att}}
-			processAtt := func(ctx context.Context, st state.BeaconState, blk interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			processAtt := func(ctx context.Context, st state.BeaconState, blk interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				st, err = altair.ProcessAttestationsNoVerifySignature(ctx, st, blk)
 				if err != nil {
 					return nil, err

--- a/testing/spectest/shared/bellatrix/operations/attester_slashing.go
+++ b/testing/spectest/shared/bellatrix/operations/attester_slashing.go
@@ -33,7 +33,7 @@ func RunAttesterSlashingTest(t *testing.T, config string) {
 			require.NoError(t, attSlashing.UnmarshalSSZ(attSlashingSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyBellatrix{AttesterSlashings: []*ethpb.AttesterSlashing{attSlashing}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), validators.SlashValidator)
 			})
 		})

--- a/testing/spectest/shared/bellatrix/operations/deposit.go
+++ b/testing/spectest/shared/bellatrix/operations/deposit.go
@@ -32,7 +32,7 @@ func RunDepositTest(t *testing.T, config string) {
 			require.NoError(t, deposit.UnmarshalSSZ(depositSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyBellatrix{Deposits: []*ethpb.Deposit{deposit}}
-			processDepositsFunc := func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			processDepositsFunc := func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return altair.ProcessDeposits(ctx, s, b.Block().Body().Deposits())
 			}
 			RunBlockOperationTest(t, folderPath, body, processDepositsFunc)

--- a/testing/spectest/shared/bellatrix/operations/helpers.go
+++ b/testing/spectest/shared/bellatrix/operations/helpers.go
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/d4l3k/messagediff.v1"
 )
 
-type blockOperation func(context.Context, state.BeaconState, interfaces.SignedBeaconBlock) (state.BeaconState, error)
+type blockOperation func(context.Context, state.BeaconState, interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error)
 
 // RunBlockOperationTest takes in the prestate and the beacon block body, processes it through the
 // passed in block operation function and checks the post state with the expected post state.

--- a/testing/spectest/shared/bellatrix/operations/proposer_slashing.go
+++ b/testing/spectest/shared/bellatrix/operations/proposer_slashing.go
@@ -33,7 +33,7 @@ func RunProposerSlashingTest(t *testing.T, config string) {
 			require.NoError(t, proposerSlashing.UnmarshalSSZ(proposerSlashingSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyBellatrix{ProposerSlashings: []*ethpb.ProposerSlashing{proposerSlashing}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), validators.SlashValidator)
 			})
 		})

--- a/testing/spectest/shared/bellatrix/operations/sync_committee.go
+++ b/testing/spectest/shared/bellatrix/operations/sync_committee.go
@@ -32,7 +32,7 @@ func RunSyncCommitteeTest(t *testing.T, config string) {
 			require.NoError(t, sc.UnmarshalSSZ(syncCommitteeSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyBellatrix{SyncAggregate: sc}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return altair.ProcessSyncAggregate(context.Background(), s, body.SyncAggregate)
 			})
 		})

--- a/testing/spectest/shared/bellatrix/operations/voluntary_exit.go
+++ b/testing/spectest/shared/bellatrix/operations/voluntary_exit.go
@@ -32,7 +32,7 @@ func RunVoluntaryExitTest(t *testing.T, config string) {
 			require.NoError(t, voluntaryExit.UnmarshalSSZ(exitSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyBellatrix{VoluntaryExits: []*ethpb.SignedVoluntaryExit{voluntaryExit}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessVoluntaryExits(ctx, s, b.Block().Body().VoluntaryExits())
 			})
 		})

--- a/testing/spectest/shared/capella/operations/attestation.go
+++ b/testing/spectest/shared/capella/operations/attestation.go
@@ -34,7 +34,7 @@ func RunAttestationTest(t *testing.T, config string) {
 			require.NoError(t, att.UnmarshalSSZ(attestationSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyCapella{Attestations: []*ethpb.Attestation{att}}
-			processAtt := func(ctx context.Context, st state.BeaconState, blk interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			processAtt := func(ctx context.Context, st state.BeaconState, blk interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				st, err = altair.ProcessAttestationsNoVerifySignature(ctx, st, blk)
 				if err != nil {
 					return nil, err

--- a/testing/spectest/shared/capella/operations/attester_slashing.go
+++ b/testing/spectest/shared/capella/operations/attester_slashing.go
@@ -33,7 +33,7 @@ func RunAttesterSlashingTest(t *testing.T, config string) {
 			require.NoError(t, attSlashing.UnmarshalSSZ(attSlashingSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyCapella{AttesterSlashings: []*ethpb.AttesterSlashing{attSlashing}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), validators.SlashValidator)
 			})
 		})

--- a/testing/spectest/shared/capella/operations/bls_to_execution_changes.go
+++ b/testing/spectest/shared/capella/operations/bls_to_execution_changes.go
@@ -35,7 +35,7 @@ func RunBLSToExecutionChangeTest(t *testing.T, config string) {
 			body := &ethpb.BeaconBlockBodyCapella{
 				BlsToExecutionChanges: []*ethpb.SignedBLSToExecutionChange{change},
 			}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				st, err := blocks.ProcessBLSToExecutionChanges(s, b)
 				if err != nil {
 					return nil, err

--- a/testing/spectest/shared/capella/operations/deposit.go
+++ b/testing/spectest/shared/capella/operations/deposit.go
@@ -32,7 +32,7 @@ func RunDepositTest(t *testing.T, config string) {
 			require.NoError(t, deposit.UnmarshalSSZ(depositSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyCapella{Deposits: []*ethpb.Deposit{deposit}}
-			processDepositsFunc := func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			processDepositsFunc := func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return altair.ProcessDeposits(ctx, s, b.Block().Body().Deposits())
 			}
 			RunBlockOperationTest(t, folderPath, body, processDepositsFunc)

--- a/testing/spectest/shared/capella/operations/helpers.go
+++ b/testing/spectest/shared/capella/operations/helpers.go
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/d4l3k/messagediff.v1"
 )
 
-type blockOperation func(context.Context, state.BeaconState, interfaces.SignedBeaconBlock) (state.BeaconState, error)
+type blockOperation func(context.Context, state.BeaconState, interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error)
 
 // RunBlockOperationTest takes in the prestate and the beacon block body, processes it through the
 // passed in block operation function and checks the post state with the expected post state.

--- a/testing/spectest/shared/capella/operations/proposer_slashing.go
+++ b/testing/spectest/shared/capella/operations/proposer_slashing.go
@@ -33,7 +33,7 @@ func RunProposerSlashingTest(t *testing.T, config string) {
 			require.NoError(t, proposerSlashing.UnmarshalSSZ(proposerSlashingSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyCapella{ProposerSlashings: []*ethpb.ProposerSlashing{proposerSlashing}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), validators.SlashValidator)
 			})
 		})

--- a/testing/spectest/shared/capella/operations/sync_committee.go
+++ b/testing/spectest/shared/capella/operations/sync_committee.go
@@ -32,7 +32,7 @@ func RunSyncCommitteeTest(t *testing.T, config string) {
 			require.NoError(t, sc.UnmarshalSSZ(syncCommitteeSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyCapella{SyncAggregate: sc}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return altair.ProcessSyncAggregate(context.Background(), s, body.SyncAggregate)
 			})
 		})

--- a/testing/spectest/shared/capella/operations/voluntary_exit.go
+++ b/testing/spectest/shared/capella/operations/voluntary_exit.go
@@ -32,7 +32,7 @@ func RunVoluntaryExitTest(t *testing.T, config string) {
 			require.NoError(t, voluntaryExit.UnmarshalSSZ(exitSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyCapella{VoluntaryExits: []*ethpb.SignedVoluntaryExit{voluntaryExit}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessVoluntaryExits(ctx, s, b.Block().Body().VoluntaryExits())
 			})
 		})

--- a/testing/spectest/shared/capella/operations/withdrawals.go
+++ b/testing/spectest/shared/capella/operations/withdrawals.go
@@ -33,7 +33,7 @@ func RunWithdrawalsTest(t *testing.T, config string) {
 			require.NoError(t, payload.UnmarshalSSZ(payloadSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBodyCapella{ExecutionPayload: payload}
-			RunBlockOperationTest(t, folderPath, body, func(_ context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(_ context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				payload, err := b.Block().Body().Execution()
 				if err != nil {
 					return nil, err

--- a/testing/spectest/shared/common/forkchoice/builder.go
+++ b/testing/spectest/shared/common/forkchoice/builder.go
@@ -25,7 +25,7 @@ type Builder struct {
 	execMock *engineMock
 }
 
-func NewBuilder(t testing.TB, initialState state.BeaconState, initialBlock interfaces.SignedBeaconBlock) *Builder {
+func NewBuilder(t testing.TB, initialState state.BeaconState, initialBlock interfaces.ReadOnlySignedBeaconBlock) *Builder {
 	execMock := &engineMock{
 		powBlocks: make(map[[32]byte]*ethpb.PowBlock),
 	}
@@ -79,20 +79,20 @@ func (bb *Builder) SetPayloadStatus(resp *MockEngineResp) error {
 }
 
 // block returns the block root.
-func (bb *Builder) block(t testing.TB, b interfaces.SignedBeaconBlock) [32]byte {
+func (bb *Builder) block(t testing.TB, b interfaces.ReadOnlySignedBeaconBlock) [32]byte {
 	r, err := b.Block().HashTreeRoot()
 	require.NoError(t, err)
 	return r
 }
 
 // InvalidBlock receives the invalid block and notifies forkchoice.
-func (bb *Builder) InvalidBlock(t testing.TB, b interfaces.SignedBeaconBlock) {
+func (bb *Builder) InvalidBlock(t testing.TB, b interfaces.ReadOnlySignedBeaconBlock) {
 	r := bb.block(t, b)
 	require.Equal(t, true, bb.service.ReceiveBlock(context.TODO(), b, r) != nil)
 }
 
 // ValidBlock receives the valid block and notifies forkchoice.
-func (bb *Builder) ValidBlock(t testing.TB, b interfaces.SignedBeaconBlock) {
+func (bb *Builder) ValidBlock(t testing.TB, b interfaces.ReadOnlySignedBeaconBlock) {
 	r := bb.block(t, b)
 	require.NoError(t, bb.service.ReceiveBlock(context.TODO(), b, r))
 }

--- a/testing/spectest/shared/common/forkchoice/runner.go
+++ b/testing/spectest/shared/common/forkchoice/runner.go
@@ -63,7 +63,7 @@ func runTest(t *testing.T, config string, fork int, basePath string) {
 				require.NoError(t, err)
 
 				var beaconState state.BeaconState
-				var beaconBlock interfaces.SignedBeaconBlock
+				var beaconBlock interfaces.ReadOnlySignedBeaconBlock
 				switch fork {
 				case version.Phase0:
 					beaconState = unmarshalPhase0State(t, preBeaconStateSSZ)
@@ -92,7 +92,7 @@ func runTest(t *testing.T, config string, fork int, basePath string) {
 						require.NoError(t, err)
 						blockSSZ, err := snappy.Decode(nil /* dst */, blockFile)
 						require.NoError(t, err)
-						var beaconBlock interfaces.SignedBeaconBlock
+						var beaconBlock interfaces.ReadOnlySignedBeaconBlock
 						switch fork {
 						case version.Phase0:
 							beaconBlock = unmarshalSignedPhase0Block(t, blockSSZ)
@@ -157,7 +157,7 @@ func unmarshalPhase0State(t *testing.T, raw []byte) state.BeaconState {
 	return st
 }
 
-func unmarshalPhase0Block(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+func unmarshalPhase0Block(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
 	base := &ethpb.BeaconBlock{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
 	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlock{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
@@ -165,7 +165,7 @@ func unmarshalPhase0Block(t *testing.T, raw []byte) interfaces.SignedBeaconBlock
 	return blk
 }
 
-func unmarshalSignedPhase0Block(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+func unmarshalSignedPhase0Block(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
 	base := &ethpb.SignedBeaconBlock{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
 	blk, err := blocks.NewSignedBeaconBlock(base)
@@ -181,7 +181,7 @@ func unmarshalAltairState(t *testing.T, raw []byte) state.BeaconState {
 	return st
 }
 
-func unmarshalAltairBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+func unmarshalAltairBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
 	base := &ethpb.BeaconBlockAltair{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
 	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockAltair{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
@@ -189,7 +189,7 @@ func unmarshalAltairBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock
 	return blk
 }
 
-func unmarshalSignedAltairBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+func unmarshalSignedAltairBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
 	base := &ethpb.SignedBeaconBlockAltair{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
 	blk, err := blocks.NewSignedBeaconBlock(base)
@@ -205,7 +205,7 @@ func unmarshalBellatrixState(t *testing.T, raw []byte) state.BeaconState {
 	return st
 }
 
-func unmarshalBellatrixBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+func unmarshalBellatrixBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
 	base := &ethpb.BeaconBlockBellatrix{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
 	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockBellatrix{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
@@ -213,7 +213,7 @@ func unmarshalBellatrixBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBl
 	return blk
 }
 
-func unmarshalSignedBellatrixBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+func unmarshalSignedBellatrixBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
 	base := &ethpb.SignedBeaconBlockBellatrix{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
 	blk, err := blocks.NewSignedBeaconBlock(base)
@@ -229,7 +229,7 @@ func unmarshalCapellaState(t *testing.T, raw []byte) state.BeaconState {
 	return st
 }
 
-func unmarshalCapellaBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+func unmarshalCapellaBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
 	base := &ethpb.BeaconBlockCapella{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
 	blk, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockCapella{Block: base, Signature: make([]byte, fieldparams.BLSSignatureLength)})
@@ -237,7 +237,7 @@ func unmarshalCapellaBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBloc
 	return blk
 }
 
-func unmarshalSignedCapellaBlock(t *testing.T, raw []byte) interfaces.SignedBeaconBlock {
+func unmarshalSignedCapellaBlock(t *testing.T, raw []byte) interfaces.ReadOnlySignedBeaconBlock {
 	base := &ethpb.SignedBeaconBlockCapella{}
 	require.NoError(t, base.UnmarshalSSZ(raw))
 	blk, err := blocks.NewSignedBeaconBlock(base)

--- a/testing/spectest/shared/common/forkchoice/service.go
+++ b/testing/spectest/shared/common/forkchoice/service.go
@@ -28,7 +28,7 @@ import (
 
 func startChainService(t testing.TB,
 	st state.BeaconState,
-	block interfaces.SignedBeaconBlock,
+	block interfaces.ReadOnlySignedBeaconBlock,
 	engineMock *engineMock,
 ) *blockchain.Service {
 	db := testDB.SetupDB(t)

--- a/testing/spectest/shared/phase0/operations/attestation.go
+++ b/testing/spectest/shared/phase0/operations/attestation.go
@@ -34,7 +34,7 @@ func RunAttestationTest(t *testing.T, config string) {
 			require.NoError(t, att.UnmarshalSSZ(attestationSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBody{Attestations: []*ethpb.Attestation{att}}
-			processAtt := func(ctx context.Context, st state.BeaconState, blk interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			processAtt := func(ctx context.Context, st state.BeaconState, blk interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				st, err = b.ProcessAttestationsNoVerifySignature(ctx, st, blk)
 				if err != nil {
 					return nil, err

--- a/testing/spectest/shared/phase0/operations/attester_slashing.go
+++ b/testing/spectest/shared/phase0/operations/attester_slashing.go
@@ -34,7 +34,7 @@ func RunAttesterSlashingTest(t *testing.T, config string) {
 			require.NoError(t, attSlashing.UnmarshalSSZ(attSlashingSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBody{AttesterSlashings: []*ethpb.AttesterSlashing{attSlashing}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessAttesterSlashings(ctx, s, b.Block().Body().AttesterSlashings(), v.SlashValidator)
 			})
 		})

--- a/testing/spectest/shared/phase0/operations/deposit.go
+++ b/testing/spectest/shared/phase0/operations/deposit.go
@@ -33,7 +33,7 @@ func RunDepositTest(t *testing.T, config string) {
 			require.NoError(t, deposit.UnmarshalSSZ(depositSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBody{Deposits: []*ethpb.Deposit{deposit}}
-			processDepositsFunc := func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			processDepositsFunc := func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessDeposits(ctx, s, b.Block().Body().Deposits())
 			}
 			RunBlockOperationTest(t, folderPath, body, processDepositsFunc)

--- a/testing/spectest/shared/phase0/operations/helpers.go
+++ b/testing/spectest/shared/phase0/operations/helpers.go
@@ -21,7 +21,7 @@ import (
 	"gopkg.in/d4l3k/messagediff.v1"
 )
 
-type blockOperation func(context.Context, state.BeaconState, interfaces.SignedBeaconBlock) (state.BeaconState, error)
+type blockOperation func(context.Context, state.BeaconState, interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error)
 
 // RunBlockOperationTest takes in the prestate and the beacon block body, processes it through the
 // passed in block operation function and checks the post state with the expected post state.

--- a/testing/spectest/shared/phase0/operations/proposer_slashing.go
+++ b/testing/spectest/shared/phase0/operations/proposer_slashing.go
@@ -34,7 +34,7 @@ func RunProposerSlashingTest(t *testing.T, config string) {
 			require.NoError(t, proposerSlashing.UnmarshalSSZ(proposerSlashingSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBody{ProposerSlashings: []*ethpb.ProposerSlashing{proposerSlashing}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessProposerSlashings(ctx, s, b.Block().Body().ProposerSlashings(), v.SlashValidator)
 			})
 		})

--- a/testing/spectest/shared/phase0/operations/voluntary_exit.go
+++ b/testing/spectest/shared/phase0/operations/voluntary_exit.go
@@ -33,7 +33,7 @@ func RunVoluntaryExitTest(t *testing.T, config string) {
 			require.NoError(t, voluntaryExit.UnmarshalSSZ(exitSSZ), "Failed to unmarshal")
 
 			body := &ethpb.BeaconBlockBody{VoluntaryExits: []*ethpb.SignedVoluntaryExit{voluntaryExit}}
-			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.SignedBeaconBlock) (state.BeaconState, error) {
+			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
 				return blocks.ProcessVoluntaryExits(ctx, s, b.Block().Body().VoluntaryExits())
 			})
 		})

--- a/testing/util/block.go
+++ b/testing/util/block.go
@@ -1109,7 +1109,7 @@ func HydrateV2BlindedBeaconBlockBodyCapella(b *v2.BlindedBeaconBlockBodyCapella)
 	return b
 }
 
-func SaveBlock(tb assertions.AssertionTestingTB, ctx context.Context, db iface.NoHeadAccessDatabase, b interface{}) interfaces.SignedBeaconBlockWriteable {
+func SaveBlock(tb assertions.AssertionTestingTB, ctx context.Context, db iface.NoHeadAccessDatabase, b interface{}) interfaces.SignedBeaconBlock {
 	wsb, err := blocks.NewSignedBeaconBlock(b)
 	require.NoError(tb, err)
 	require.NoError(tb, db.SaveBlock(ctx, wsb))

--- a/testing/util/helpers.go
+++ b/testing/util/helpers.go
@@ -41,7 +41,7 @@ func BlockSignature(
 	block interface{},
 	privKeys []bls.SecretKey,
 ) (bls.Signature, error) {
-	var wsb interfaces.SignedBeaconBlock
+	var wsb interfaces.ReadOnlySignedBeaconBlock
 	var err error
 	// copy the state since we need to process slots
 	bState = bState.Copy()

--- a/tools/eth1voting/main.go
+++ b/tools/eth1voting/main.go
@@ -72,9 +72,9 @@ func main() {
 	fmt.Println(v.Report())
 }
 
-func wrapBlock(b *v1alpha1.BeaconBlockContainer) interfaces.BeaconBlock {
+func wrapBlock(b *v1alpha1.BeaconBlockContainer) interfaces.ReadOnlyBeaconBlock {
 	var err error
-	var wb interfaces.SignedBeaconBlock
+	var wb interfaces.ReadOnlySignedBeaconBlock
 	switch bb := b.Block.(type) {
 	case *v1alpha1.BeaconBlockContainer_Phase0Block:
 		wb, err = blocks.NewSignedBeaconBlock(bb.Phase0Block)

--- a/tools/eth1voting/votes.go
+++ b/tools/eth1voting/votes.go
@@ -30,7 +30,7 @@ func NewVotes() *votes {
 	}
 }
 
-func (v *votes) Insert(blk interfaces.BeaconBlock) {
+func (v *votes) Insert(blk interfaces.ReadOnlyBeaconBlock) {
 	v.l.Lock()
 	defer v.l.Unlock()
 

--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -272,7 +272,7 @@ func (v *validator) waitOneThirdOrValidBlock(ctx context.Context, slot primitive
 	t := time.NewTimer(wait)
 	defer t.Stop()
 
-	bChannel := make(chan interfaces.SignedBeaconBlock, 1)
+	bChannel := make(chan interfaces.ReadOnlySignedBeaconBlock, 1)
 	sub := v.blockFeed.Subscribe(bChannel)
 	defer sub.Unsubscribe()
 

--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -266,7 +266,7 @@ func (v *validator) signRandaoReveal(ctx context.Context, pubKey [fieldparams.BL
 
 // Sign block with proposer domain and private key.
 // Returns the signature, block signing root, and any error.
-func (v *validator) signBlock(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, epoch primitives.Epoch, slot primitives.Slot, b interfaces.BeaconBlock) ([]byte, [32]byte, error) {
+func (v *validator) signBlock(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, epoch primitives.Epoch, slot primitives.Slot, b interfaces.ReadOnlyBeaconBlock) ([]byte, [32]byte, error) {
 	domain, err := v.domainData(ctx, epoch, params.BeaconConfig().DomainBeaconProposer[:])
 	if err != nil {
 		return nil, [32]byte{}, errors.Wrap(err, domainDataErr)

--- a/validator/client/propose_protect.go
+++ b/validator/client/propose_protect.go
@@ -16,7 +16,7 @@ var failedBlockSignLocalErr = "attempted to sign a double proposal, block reject
 var failedBlockSignExternalErr = "attempted a double proposal, block rejected by remote slashing protection"
 
 func (v *validator) slashableProposalCheck(
-	ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, signedBlock interfaces.SignedBeaconBlock, signingRoot [32]byte,
+	ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, signedBlock interfaces.ReadOnlySignedBeaconBlock, signingRoot [32]byte,
 ) error {
 	fmtKey := fmt.Sprintf("%#x", pubKey[:])
 
@@ -83,7 +83,7 @@ func (v *validator) slashableProposalCheck(
 	return nil
 }
 
-func blockLogFields(pubKey [fieldparams.BLSPubkeyLength]byte, blk interfaces.BeaconBlock, sig []byte) logrus.Fields {
+func blockLogFields(pubKey [fieldparams.BLSPubkeyLength]byte, blk interfaces.ReadOnlyBeaconBlock, sig []byte) logrus.Fields {
 	fields := logrus.Fields{
 		"proposerPublicKey": fmt.Sprintf("%#x", pubKey),
 		"proposerIndex":     blk.ProposerIndex(),

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -616,7 +616,7 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 				gomock.Any(), // epoch
 			).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
 
-			var sentBlock interfaces.SignedBeaconBlock
+			var sentBlock interfaces.ReadOnlySignedBeaconBlock
 			var err error
 
 			m.validatorClient.EXPECT().ProposeBeaconBlock(

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -220,7 +220,7 @@ func (v *ValidatorService) Start() {
 	// the inner type of the feed before hand. So that
 	// during future accesses, there will be no panics here
 	// from type incompatibility.
-	tempChan := make(chan interfaces.SignedBeaconBlock)
+	tempChan := make(chan interfaces.ReadOnlySignedBeaconBlock)
 	sub := valStruct.blockFeed.Subscribe(tempChan)
 	sub.Unsubscribe()
 	close(tempChan)

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -338,7 +338,7 @@ func (v *validator) ReceiveBlocks(ctx context.Context, connectionErrorChannel ch
 		if res == nil || res.Block == nil {
 			continue
 		}
-		var blk interfaces.SignedBeaconBlock
+		var blk interfaces.ReadOnlySignedBeaconBlock
 		switch b := res.Block.(type) {
 		case *ethpb.StreamBlocksResponse_Phase0Block:
 			blk, err = blocks.NewSignedBeaconBlock(b.Phase0Block)

--- a/validator/keymanager/remote-web3signer/v1/requests.go
+++ b/validator/keymanager/remote-web3signer/v1/requests.go
@@ -16,7 +16,7 @@ func GetBlockSignRequest(request *validatorpb.SignRequest, genesisValidatorsRoot
 		return nil, errors.New("failed to cast request object to block")
 	}
 	if beaconBlock == nil {
-		return nil, errors.New("invalid sign request: BeaconBlock is nil")
+		return nil, errors.New("invalid sign request: ReadOnlyBeaconBlock is nil")
 	}
 	fork, err := MapForkInfo(request.SigningSlot, genesisValidatorsRoot)
 	if err != nil {
@@ -120,7 +120,7 @@ func GetBlockAltairSignRequest(request *validatorpb.SignRequest, genesisValidato
 		return nil, errors.New("failed to cast request object to block altair")
 	}
 	if beaconBlockAltair == nil {
-		return nil, errors.New("invalid sign request: BeaconBlock is nil")
+		return nil, errors.New("invalid sign request: ReadOnlyBeaconBlock is nil")
 	}
 	fork, err := MapForkInfo(request.SigningSlot, genesisValidatorsRoot)
 	if err != nil {
@@ -276,7 +276,7 @@ func GetBlockBellatrixSignRequest(request *validatorpb.SignRequest, genesisValid
 	if request == nil {
 		return nil, errors.New("nil sign request provided")
 	}
-	var b interfaces.BeaconBlock
+	var b interfaces.ReadOnlyBeaconBlock
 	switch request.Object.(type) {
 	case *validatorpb.SignRequest_BlindedBlockBellatrix:
 		blindedBlockBellatrix, ok := request.Object.(*validatorpb.SignRequest_BlindedBlockBellatrix)


### PR DESCRIPTION
Renaming the following block interfaces per prior feedback from #11968  (Only cosmetic. That's it!)

- `SignedBeaconBlock` -> `ReadOnlySignedBeaconBlock`
- `BeaconBlock` -> `ReadOnlyBeaconBlock`
- `BeaconBlockBody` -> `ReadOnlyBeaconBlockBody`
- `SignedBeaconBlockWriteable` -> `SignedBeaconBlock`