### PR TITLE
Fix Failing E2E Runs

### DIFF
--- a/config/params/testnet_e2e_config.go
+++ b/config/params/testnet_e2e_config.go
@@ -62,7 +62,6 @@ func E2EMainnetTestConfig() *BeaconChainConfig {
 	e2eConfig.MinGenesisActiveValidatorCount = 256
 	e2eConfig.GenesisDelay = 25 // 25 seconds so E2E has enough time to process deposits and get started.
 	e2eConfig.ChurnLimitQuotient = 65536
-	e2eConfig.MaxValidatorsPerWithdrawalsSweep = 128
 
 	// Time parameters.
 	e2eConfig.SecondsPerSlot = 6


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

- [x] Fixes withdrawal evaluator to handle edge cases with sync committee members better.
- [x] Skip the withdrawal evaluator for multiclient as lighthouse does not have the ability to configure
its withdrawal sweep.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
