### PR TITLE
Do not check signatures when packing BLS changes

### DIFF
--- a/beacon-chain/operations/blstoexec/BUILD.bazel
+++ b/beacon-chain/operations/blstoexec/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//container/doubly-linked-list:go_default_library",
-        "//crypto/bls/blst:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/beacon-chain/operations/blstoexec/pool_test.go
+++ b/beacon-chain/operations/blstoexec/pool_test.go
@@ -154,8 +154,8 @@ func TestBLSToExecChangesForInclusion(t *testing.T) {
 		}
 		changes, err := pool.BLSToExecChangesForInclusion(st)
 		require.NoError(t, err)
-		assert.Equal(t, int(params.BeaconConfig().MaxBlsToExecutionChanges)-1, len(changes))
-		assert.Equal(t, primitives.ValidatorIndex(29), changes[1].Message.ValidatorIndex)
+		assert.Equal(t, int(params.BeaconConfig().MaxBlsToExecutionChanges), len(changes))
+		assert.Equal(t, primitives.ValidatorIndex(30), changes[1].Message.ValidatorIndex)
 	})
 }
 


### PR DESCRIPTION
When packing BLS changes, it is no longer needed to check their signature since we moved to using the genesis fork version. 