### PR TITLE
Update general spectest tar.gz SHA value

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -206,7 +206,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    sha256 = "5c90f42ff30857def5ae0952904c5cad6dbc16310a86d3a0914f37b557920779",
+    sha256 = "11fed0121d7a79b6da3671ecbd8aa08bcd3fc2316450eeae2d0e065371910ef9",
     url = "https://github.com/ethereum/consensus-spec-tests/releases/download/%s/general.tar.gz" % consensus_spec_test_version,
 )
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Trying to build Prysm from a new machine with no caches and I am seeing that the sha value has changed. Perhaps the tar.gz was re-uploaded with different contents?

> ERROR: Analysis of target '//testing/spectest/general/phase0/bls:go_default_test' failed; build aborted: no such package '@consensus_spec_tests_general//': java.io.IOException: Error downloading [https://github.com/ethereum/consensus-spec-tests/releases/download/v1.3.0-rc.2-hotfix/general.tar.gz] to /home/preston/.cache/bazel/_bazel_preston/6e220e5720b8243fd605645eb29a29ba/external/consensus_spec_tests_general/temp17786787663920944455/general.tar.gz: Checksum was 11fed0121d7a79b6da3671ecbd8aa08bcd3fc2316450eeae2d0e065371910ef9 but wanted 5c90f42ff30857def5ae0952904c5cad6dbc16310a86d3a0914f37b557920779


**Which issues(s) does this PR fix?**


**Other notes for review**
