### PR TITLE
Check unblinded payload root before proposal

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_capella.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_capella.go
@@ -98,10 +98,23 @@ func (vs *Server) unblindBuilderBlockCapella(ctx context.Context, b interfaces.R
 		return nil, errors.Wrap(err, "could not submit blinded block")
 	}
 
+	payloadHtr, err := payload.HashTreeRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get payload hash tree root")
+	}
+	headerHtr, err := header.HashTreeRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get header hash tree root")
+	}
+	if payloadHtr != headerHtr {
+		return nil, fmt.Errorf("payload hash tree root %x does not match header hash tree root %x", payloadHtr, headerHtr)
+	}
+
 	capellaPayload, err := payload.PbCapella()
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get payload")
 	}
+
 	bb := &ethpb.SignedBeaconBlockCapella{
 		Block: &ethpb.BeaconBlockCapella{
 			Slot:          sb.Block.Slot,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_capella_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_capella_test.go
@@ -9,6 +9,7 @@ import (
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
+	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	v1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
@@ -83,7 +84,9 @@ func TestServer_unblindBuilderCapellaBlock(t *testing.T) {
 				b := util.NewBlindedBeaconBlockCapella()
 				b.Block.Slot = 1
 				b.Block.ProposerIndex = 2
-				txRoot, err := ssz.TransactionsRoot([][]byte{})
+				txRoot, err := ssz.TransactionsRoot(make([][]byte, 0))
+				require.NoError(t, err)
+				wdRoot, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), []*v1.Withdrawal{}, fieldparams.MaxWithdrawalsPerPayload)
 				require.NoError(t, err)
 				b.Block.Body.ExecutionPayloadHeader = &v1.ExecutionPayloadHeaderCapella{
 					ParentHash:       make([]byte, fieldparams.RootLength),
@@ -96,7 +99,7 @@ func TestServer_unblindBuilderCapellaBlock(t *testing.T) {
 					BlockHash:        make([]byte, fieldparams.RootLength),
 					TransactionsRoot: txRoot[:],
 					GasLimit:         123,
-					WithdrawalsRoot:  make([]byte, fieldparams.RootLength),
+					WithdrawalsRoot:  wdRoot[:],
 				}
 				wb, err := blocks.NewSignedBeaconBlock(b)
 				require.NoError(t, err)


### PR DESCRIPTION
We can better check the correctness of an unblinded block from mev-boost. The check is simple, we validate the header matches the payload by hash tree root each other. If they don't match, we should surface the error and don’t broadcast a bad block because we do not want to get penalized by our peers. Today we would broadcast a bad block which opens up to builder/relayer griefing attack