### PR TITLE
Use forkchoice HasNode to check if a block is consistent with finality

### DIFF
--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -352,7 +352,7 @@ func TestVerifyFinalizedConsistency_InconsistentRoot_DoublyLinkedTree(t *testing
 	r33, err := b33.Block.HashTreeRoot()
 	require.NoError(t, err)
 
-	err = service.VerifyFinalizedConsistency(context.Background(), r33[:])
+	err = service.VerifyFinalizedConsistency(r33[:])
 	require.ErrorContains(t, "Root and finalized store are not consistent", err)
 }
 
@@ -377,7 +377,7 @@ func TestVerifyFinalizedConsistency_OK(t *testing.T) {
 	r33, err := b33.Block.HashTreeRoot()
 	require.NoError(t, err)
 
-	err = service.VerifyFinalizedConsistency(context.Background(), r33[:])
+	err = service.VerifyFinalizedConsistency(r33[:])
 	require.NoError(t, err)
 }
 
@@ -414,6 +414,6 @@ func TestVerifyFinalizedConsistency_IsCanonical(t *testing.T) {
 	require.NoError(t, service.cfg.ForkChoiceStore.UpdateJustifiedCheckpoint(ctx, jc))
 	_, err = service.cfg.ForkChoiceStore.Head(ctx)
 	require.NoError(t, err)
-	err = service.VerifyFinalizedConsistency(context.Background(), r33[:])
+	err = service.VerifyFinalizedConsistency(r33[:])
 	require.NoError(t, err)
 }

--- a/beacon-chain/blockchain/process_attestation_test.go
+++ b/beacon-chain/blockchain/process_attestation_test.go
@@ -362,22 +362,12 @@ func TestVerifyFinalizedConsistency_OK(t *testing.T) {
 	opts := testServiceOptsWithDB(t)
 	service, err := NewService(ctx, opts...)
 	require.NoError(t, err)
-
-	b32 := util.NewBeaconBlock()
-	b32.Block.Slot = 32
-	util.SaveBlock(t, ctx, service.cfg.BeaconDB, b32)
-	r32, err := b32.Block.HashTreeRoot()
+	ojc := &ethpb.Checkpoint{Root: params.BeaconConfig().ZeroHash[:]}
+	state, blkRoot, err := prepareForkchoiceState(ctx, 33, [32]byte{'a'}, [32]byte{}, [32]byte{}, ojc, ojc)
 	require.NoError(t, err)
+	require.NoError(t, service.cfg.ForkChoiceStore.InsertNode(ctx, state, blkRoot))
 
-	require.NoError(t, service.ForkChoicer().UpdateFinalizedCheckpoint(&forkchoicetypes.Checkpoint{Epoch: 1, Root: r32}))
-	b33 := util.NewBeaconBlock()
-	b33.Block.Slot = 33
-	b33.Block.ParentRoot = r32[:]
-	util.SaveBlock(t, ctx, service.cfg.BeaconDB, b33)
-	r33, err := b33.Block.HashTreeRoot()
-	require.NoError(t, err)
-
-	err = service.VerifyFinalizedConsistency(r33[:])
+	err = service.VerifyFinalizedConsistency(blkRoot[:])
 	require.NoError(t, err)
 }
 

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -63,27 +63,13 @@ func (s *Service) VerifyLmdFfgConsistency(ctx context.Context, a *ethpb.Attestat
 // VerifyFinalizedConsistency verifies input root is consistent with finalized store.
 // When the input root is not be consistent with finalized store then we know it is not
 // on the finalized check point that leads to current canonical chain and should be rejected accordingly.
-func (s *Service) VerifyFinalizedConsistency(ctx context.Context, root []byte) error {
+func (s *Service) VerifyFinalizedConsistency(root []byte) error {
 	// A canonical root implies the root to has an ancestor that aligns with finalized check point.
 	// In this case, we could exit early to save on additional computation.
 	blockRoot := bytesutil.ToBytes32(root)
-	if s.cfg.ForkChoiceStore.HasNode(blockRoot) && s.cfg.ForkChoiceStore.IsCanonical(blockRoot) {
-		return nil
-	}
-
-	f := s.FinalizedCheckpt()
-	ss, err := slots.EpochStart(f.Epoch)
-	if err != nil {
-		return err
-	}
-	r, err := s.ancestor(ctx, root, ss)
-	if err != nil {
-		return err
-	}
-	if !bytes.Equal(f.Root, r) {
+	if !s.cfg.ForkChoiceStore.HasNode(blockRoot) {
 		return errors.New("Root and finalized store are not consistent")
 	}
-
 	return nil
 }
 

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -29,7 +29,7 @@ type AttestationStateFetcher interface {
 type AttestationReceiver interface {
 	AttestationStateFetcher
 	VerifyLmdFfgConsistency(ctx context.Context, att *ethpb.Attestation) error
-	VerifyFinalizedConsistency(ctx context.Context, root []byte) error
+	VerifyFinalizedConsistency(root []byte) error
 }
 
 // AttestationTargetState returns the pre state of attestation.

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -403,7 +403,7 @@ func (_ *ChainService) VerifyLmdFfgConsistency(_ context.Context, a *ethpb.Attes
 }
 
 // VerifyFinalizedConsistency mocks VerifyFinalizedConsistency and always returns nil.
-func (s *ChainService) VerifyFinalizedConsistency(_ context.Context, r []byte) error {
+func (s *ChainService) VerifyFinalizedConsistency(r []byte) error {
 	if !bytes.Equal(r, s.FinalizedCheckPoint.Root) {
 		return errors.New("Root and finalized store are not consistent")
 	}

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -115,7 +115,7 @@ func (s *Service) processAttestations(ctx context.Context, attestations []*ethpb
 			// This is an important validation before retrieving attestation pre state to defend against
 			// attestation's target intentionally reference checkpoint that's long ago.
 			// Verify current finalized checkpoint is an ancestor of the block defined by the attestation's beacon block root.
-			if err := s.cfg.chain.VerifyFinalizedConsistency(ctx, att.Aggregate.Data.BeaconBlockRoot); err != nil {
+			if err := s.cfg.chain.VerifyFinalizedConsistency(att.Aggregate.Data.BeaconBlockRoot); err != nil {
 				log.WithError(err).Debug("Could not verify finalized consistency")
 				continue
 			}

--- a/beacon-chain/sync/validate_aggregate_proof.go
+++ b/beacon-chain/sync/validate_aggregate_proof.go
@@ -140,7 +140,7 @@ func (s *Service) validateAggregatedAtt(ctx context.Context, signed *ethpb.Signe
 	}
 
 	// Verify current finalized checkpoint is an ancestor of the block defined by the attestation's beacon block root.
-	if err := s.cfg.chain.VerifyFinalizedConsistency(ctx, signed.Message.Aggregate.Data.BeaconBlockRoot); err != nil {
+	if err := s.cfg.chain.VerifyFinalizedConsistency(signed.Message.Aggregate.Data.BeaconBlockRoot); err != nil {
 		tracing.AnnotateError(span, err)
 		return pubsub.ValidationIgnore, err
 	}

--- a/beacon-chain/sync/validate_beacon_attestation.go
+++ b/beacon-chain/sync/validate_beacon_attestation.go
@@ -136,7 +136,7 @@ func (s *Service) validateCommitteeIndexBeaconAttestation(ctx context.Context, p
 		return pubsub.ValidationIgnore, nil
 	}
 
-	if err := s.cfg.chain.VerifyFinalizedConsistency(ctx, att.Data.BeaconBlockRoot); err != nil {
+	if err := s.cfg.chain.VerifyFinalizedConsistency(att.Data.BeaconBlockRoot); err != nil {
 		tracing.AnnotateError(span, err)
 		return pubsub.ValidationIgnore, err
 	}


### PR DESCRIPTION
Forkchoice enforces that all nodes are consistent with finalized checkpoint. 