### PR TITLE
Remove the StreamDuties endpoint

### DIFF
--- a/validator/client/beacon-api/beacon_api_validator_client.go
+++ b/validator/client/beacon-api/beacon_api_validator_client.go
@@ -113,15 +113,6 @@ func (c *beaconApiValidatorClient) StreamBlocksAltair(ctx context.Context, in *e
 	return c.streamBlocks(ctx, in, time.Second), nil
 }
 
-func (c *beaconApiValidatorClient) StreamDuties(ctx context.Context, in *ethpb.DutiesRequest) (ethpb.BeaconNodeValidator_StreamDutiesClient, error) {
-	if c.fallbackClient != nil {
-		return c.fallbackClient.StreamDuties(ctx, in)
-	}
-
-	// TODO: Implement me
-	panic("beaconApiValidatorClient.StreamDuties is not implemented. To use a fallback client, create this validator with NewBeaconApiValidatorClientWithFallback instead.")
-}
-
 func (c *beaconApiValidatorClient) SubmitAggregateSelectionProof(ctx context.Context, in *ethpb.AggregateSelectionRequest) (*ethpb.AggregateSelectionResponse, error) {
 	return c.submitAggregateSelectionProof(ctx, in)
 }

--- a/validator/client/grpc-api/grpc_validator_client.go
+++ b/validator/client/grpc-api/grpc_validator_client.go
@@ -75,10 +75,6 @@ func (c *grpcValidatorClient) StreamBlocksAltair(ctx context.Context, in *ethpb.
 	return c.beaconNodeValidatorClient.StreamBlocksAltair(ctx, in)
 }
 
-func (c *grpcValidatorClient) StreamDuties(ctx context.Context, in *ethpb.DutiesRequest) (ethpb.BeaconNodeValidator_StreamDutiesClient, error) {
-	return c.beaconNodeValidatorClient.StreamDuties(ctx, in)
-}
-
 func (c *grpcValidatorClient) SubmitAggregateSelectionProof(ctx context.Context, in *ethpb.AggregateSelectionRequest) (*ethpb.AggregateSelectionResponse, error) {
 	return c.beaconNodeValidatorClient.SubmitAggregateSelectionProof(ctx, in)
 }

--- a/validator/client/iface/validator_client.go
+++ b/validator/client/iface/validator_client.go
@@ -10,7 +10,6 @@ import (
 
 type ValidatorClient interface {
 	GetDuties(ctx context.Context, in *ethpb.DutiesRequest) (*ethpb.DutiesResponse, error)
-	StreamDuties(ctx context.Context, in *ethpb.DutiesRequest) (ethpb.BeaconNodeValidator_StreamDutiesClient, error)
 	DomainData(ctx context.Context, in *ethpb.DomainRequest) (*ethpb.DomainResponse, error)
 	WaitForChainStart(ctx context.Context, in *empty.Empty) (*ethpb.ChainStartResponse, error)
 	WaitForActivation(ctx context.Context, in *ethpb.ValidatorActivationRequest) (ethpb.BeaconNodeValidator_WaitForActivationClient, error)


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

It removes the `StreamDuties` endpoint from the beacon/grpc validator clients.

**Other notes for review**

I didn't remove the `StreamDuties` endpoints from the protobuf files since it's already marked as deprecated and third parties may be depending on it.