### PR TITLE
Return proposer reward from `ProcessSyncAggregate`

### DIFF
--- a/beacon-chain/core/altair/block.go
+++ b/beacon-chain/core/altair/block.go
@@ -44,49 +44,51 @@ import (
 //	        increase_balance(state, get_beacon_proposer_index(state), proposer_reward)
 //	    else:
 //	        decrease_balance(state, participant_index, participant_reward)
-func ProcessSyncAggregate(ctx context.Context, s state.BeaconState, sync *ethpb.SyncAggregate) (state.BeaconState, error) {
-	s, votedKeys, err := processSyncAggregate(ctx, s, sync)
+func ProcessSyncAggregate(ctx context.Context, s state.BeaconState, sync *ethpb.SyncAggregate) (state.BeaconState, uint64, error) {
+	s, votedKeys, reward, err := processSyncAggregate(ctx, s, sync)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not filter sync committee votes")
+		return nil, 0, errors.Wrap(err, "could not filter sync committee votes")
 	}
 
 	if err := VerifySyncCommitteeSig(s, votedKeys, sync.SyncCommitteeSignature); err != nil {
-		return nil, errors.Wrap(err, "could not verify sync committee signature")
+		return nil, 0, errors.Wrap(err, "could not verify sync committee signature")
 	}
-	return s, nil
+	return s, reward, nil
 }
 
 // processSyncAggregate applies all the logic in the spec function `process_sync_aggregate` except
-// verifying the BLS signatures. It returns the modified beacons state and the list of validators'
-// public keys that voted, for future signature verification.
+// verifying the BLS signatures. It returns the modified beacons state, the list of validators'
+// public keys that voted (for future signature verification) and the proposer reward for including
+// sync aggregate messages.
 func processSyncAggregate(ctx context.Context, s state.BeaconState, sync *ethpb.SyncAggregate) (
 	state.BeaconState,
 	[]bls.PublicKey,
+	uint64,
 	error) {
 	currentSyncCommittee, err := s.CurrentSyncCommittee()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 	if currentSyncCommittee == nil {
-		return nil, nil, errors.New("nil current sync committee in state")
+		return nil, nil, 0, errors.New("nil current sync committee in state")
 	}
 	committeeKeys := currentSyncCommittee.Pubkeys
 	if sync.SyncCommitteeBits.Len() > uint64(len(committeeKeys)) {
-		return nil, nil, errors.New("bits length exceeds committee length")
+		return nil, nil, 0, errors.New("bits length exceeds committee length")
 	}
 	votedKeys := make([]bls.PublicKey, 0, len(committeeKeys))
 
 	activeBalance, err := helpers.TotalActiveBalance(s)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 	proposerReward, participantReward, err := SyncRewards(activeBalance)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 	proposerIndex, err := helpers.BeaconProposerIndex(ctx, s)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
 
 	earnedProposerReward := uint64(0)
@@ -94,29 +96,29 @@ func processSyncAggregate(ctx context.Context, s state.BeaconState, sync *ethpb.
 		vIdx, exists := s.ValidatorIndexByPubkey(bytesutil.ToBytes48(committeeKeys[i]))
 		// Impossible scenario.
 		if !exists {
-			return nil, nil, errors.New("validator public key does not exist in state")
+			return nil, nil, 0, errors.New("validator public key does not exist in state")
 		}
 
 		if sync.SyncCommitteeBits.BitAt(i) {
 			pubKey, err := bls.PublicKeyFromBytes(committeeKeys[i])
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, 0, err
 			}
 			votedKeys = append(votedKeys, pubKey)
 			if err := helpers.IncreaseBalance(s, vIdx, participantReward); err != nil {
-				return nil, nil, err
+				return nil, nil, 0, err
 			}
 			earnedProposerReward += proposerReward
 		} else {
 			if err := helpers.DecreaseBalance(s, vIdx, participantReward); err != nil {
-				return nil, nil, err
+				return nil, nil, 0, err
 			}
 		}
 	}
 	if err := helpers.IncreaseBalance(s, proposerIndex, earnedProposerReward); err != nil {
-		return nil, nil, err
+		return nil, nil, 0, err
 	}
-	return s, votedKeys, err
+	return s, votedKeys, proposerReward, err
 }
 
 // VerifySyncCommitteeSig verifies sync committee signature `syncSig` is valid with respect to public keys `syncKeys`.

--- a/beacon-chain/core/altair/block_test.go
+++ b/beacon-chain/core/altair/block_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/crypto/bls"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v3/testing/assert"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
 	"github.com/prysmaticlabs/prysm/v3/testing/util"
 	"github.com/prysmaticlabs/prysm/v3/time/slots"
@@ -53,8 +54,10 @@ func TestProcessSyncCommittee_PerfectParticipation(t *testing.T) {
 		SyncCommitteeSignature: aggregatedSig,
 	}
 
-	beaconState, err = altair.ProcessSyncAggregate(context.Background(), beaconState, syncAggregate)
+	var reward uint64
+	beaconState, reward, err = altair.ProcessSyncAggregate(context.Background(), beaconState, syncAggregate)
 	require.NoError(t, err)
+	assert.Equal(t, uint64(141), reward)
 
 	// Use a non-sync committee index to compare profitability.
 	syncCommittee := make(map[primitives.ValidatorIndex]bool)
@@ -127,7 +130,7 @@ func TestProcessSyncCommittee_MixParticipation_BadSignature(t *testing.T) {
 		SyncCommitteeSignature: aggregatedSig,
 	}
 
-	_, err = altair.ProcessSyncAggregate(context.Background(), beaconState, syncAggregate)
+	_, _, err = altair.ProcessSyncAggregate(context.Background(), beaconState, syncAggregate)
 	require.ErrorContains(t, "invalid sync committee signature", err)
 }
 
@@ -164,7 +167,7 @@ func TestProcessSyncCommittee_MixParticipation_GoodSignature(t *testing.T) {
 		SyncCommitteeSignature: aggregatedSig,
 	}
 
-	_, err = altair.ProcessSyncAggregate(context.Background(), beaconState, syncAggregate)
+	_, _, err = altair.ProcessSyncAggregate(context.Background(), beaconState, syncAggregate)
 	require.NoError(t, err)
 }
 
@@ -189,7 +192,7 @@ func TestProcessSyncCommittee_DontPrecompute(t *testing.T) {
 		SyncCommitteeBits: syncBits,
 	}
 	require.NoError(t, beaconState.UpdateBalancesAtIndex(idx, 0))
-	st, votedKeys, err := altair.ProcessSyncAggregateEported(context.Background(), beaconState, syncAggregate)
+	st, votedKeys, _, err := altair.ProcessSyncAggregateEported(context.Background(), beaconState, syncAggregate)
 	require.NoError(t, err)
 	require.Equal(t, 511, len(votedKeys))
 	require.DeepEqual(t, committeeKeys[0], votedKeys[0].Marshal())
@@ -212,7 +215,7 @@ func TestProcessSyncCommittee_processSyncAggregate(t *testing.T) {
 		SyncCommitteeBits: syncBits,
 	}
 
-	st, votedKeys, err := altair.ProcessSyncAggregateEported(context.Background(), beaconState, syncAggregate)
+	st, votedKeys, _, err := altair.ProcessSyncAggregateEported(context.Background(), beaconState, syncAggregate)
 	require.NoError(t, err)
 	votedMap := make(map[[fieldparams.BLSPubkeyLength]byte]bool)
 	for _, key := range votedKeys {

--- a/beacon-chain/core/transition/transition_no_verify_sig.go
+++ b/beacon-chain/core/transition/transition_no_verify_sig.go
@@ -351,7 +351,7 @@ func ProcessBlockForStateRoot(
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get sync aggregate from block")
 	}
-	state, err = altair.ProcessSyncAggregate(ctx, state, sa)
+	state, _, err = altair.ProcessSyncAggregate(ctx, state, sa)
 	if err != nil {
 		return nil, errors.Wrap(err, "process_sync_aggregate failed")
 	}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -178,7 +178,6 @@ func SlashValidator(
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get proposer idx")
 	}
-	// In phase 0, the proposer is the whistleblower.
 	whistleBlowerIdx := proposerIdx
 	whistleblowerReward := validator.EffectiveBalance / params.BeaconConfig().WhistleBlowerRewardQuotient
 	proposerReward := whistleblowerReward / proposerRewardQuotient

--- a/testing/spectest/shared/altair/operations/sync_committee.go
+++ b/testing/spectest/shared/altair/operations/sync_committee.go
@@ -33,7 +33,11 @@ func RunSyncCommitteeTest(t *testing.T, config string) {
 
 			body := &ethpb.BeaconBlockBodyAltair{SyncAggregate: sc}
 			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-				return altair.ProcessSyncAggregate(context.Background(), s, body.SyncAggregate)
+				st, _, err := altair.ProcessSyncAggregate(context.Background(), s, body.SyncAggregate)
+				if err != nil {
+					return nil, err
+				}
+				return st, nil
 			})
 		})
 	}

--- a/testing/spectest/shared/bellatrix/operations/sync_committee.go
+++ b/testing/spectest/shared/bellatrix/operations/sync_committee.go
@@ -33,7 +33,11 @@ func RunSyncCommitteeTest(t *testing.T, config string) {
 
 			body := &ethpb.BeaconBlockBodyBellatrix{SyncAggregate: sc}
 			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-				return altair.ProcessSyncAggregate(context.Background(), s, body.SyncAggregate)
+				st, _, err := altair.ProcessSyncAggregate(context.Background(), s, body.SyncAggregate)
+				if err != nil {
+					return nil, err
+				}
+				return st, nil
 			})
 		})
 	}

--- a/testing/spectest/shared/capella/operations/sync_committee.go
+++ b/testing/spectest/shared/capella/operations/sync_committee.go
@@ -33,7 +33,11 @@ func RunSyncCommitteeTest(t *testing.T, config string) {
 
 			body := &ethpb.BeaconBlockBodyCapella{SyncAggregate: sc}
 			RunBlockOperationTest(t, folderPath, body, func(ctx context.Context, s state.BeaconState, b interfaces.ReadOnlySignedBeaconBlock) (state.BeaconState, error) {
-				return altair.ProcessSyncAggregate(context.Background(), s, body.SyncAggregate)
+				st, _, err := altair.ProcessSyncAggregate(context.Background(), s, body.SyncAggregate)
+				if err != nil {
+					return nil, err
+				}
+				return st, nil
 			})
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

`ProcessSyncAggregate` internally increases the proposer's balance with their reward for including sync committee attestations. We return the reward so that it can be used by calling code.

**Which issues(s) does this PR fix?**

Part of #11952 

**Other notes for review**

Extracted from #12020 
