### PR TITLE
Remove the gRPC fallback client from the validator REST API

### DIFF
--- a/validator/client/beacon-api/beacon_api_validator_client.go
+++ b/validator/client/beacon-api/beacon_api_validator_client.go
@@ -19,11 +19,10 @@ type beaconApiValidatorClient struct {
 	dutiesProvider          dutiesProvider
 	stateValidatorsProvider stateValidatorsProvider
 	jsonRestHandler         jsonRestHandler
-	fallbackClient          iface.ValidatorClient
 	beaconBlockConverter    beaconBlockConverter
 }
 
-func NewBeaconApiValidatorClientWithFallback(host string, timeout time.Duration, fallbackClient iface.ValidatorClient) iface.ValidatorClient {
+func NewBeaconApiValidatorClient(host string, timeout time.Duration) iface.ValidatorClient {
 	jsonRestHandler := beaconApiJsonRestHandler{
 		httpClient: http.Client{Timeout: timeout},
 		host:       host,
@@ -35,7 +34,6 @@ func NewBeaconApiValidatorClientWithFallback(host string, timeout time.Duration,
 		stateValidatorsProvider: beaconApiStateValidatorsProvider{jsonRestHandler: jsonRestHandler},
 		jsonRestHandler:         jsonRestHandler,
 		beaconBlockConverter:    beaconApiBeaconBlockConverter{},
-		fallbackClient:          fallbackClient,
 	}
 }
 

--- a/validator/client/validator-client-factory/validator_client_factory.go
+++ b/validator/client/validator-client-factory/validator_client_factory.go
@@ -9,12 +9,11 @@ import (
 )
 
 func NewValidatorClient(validatorConn validatorHelpers.NodeConnection) iface.ValidatorClient {
-	grpcClient := grpcApi.NewGrpcValidatorClient(validatorConn.GetGrpcClientConn())
 	featureFlags := features.Get()
 
 	if featureFlags.EnableBeaconRESTApi {
-		return beaconApi.NewBeaconApiValidatorClientWithFallback(validatorConn.GetBeaconApiUrl(), validatorConn.GetBeaconApiTimeout(), grpcClient)
+		return beaconApi.NewBeaconApiValidatorClient(validatorConn.GetBeaconApiUrl(), validatorConn.GetBeaconApiTimeout())
 	} else {
-		return grpcClient
+		return grpcApi.NewGrpcValidatorClient(validatorConn.GetGrpcClientConn())
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

It removes the gRPC fallback client from the validator REST API. Since all endpoints are now implemented, we don't need it anymore!
