### PR TITLE
Update distroless base images

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,32 +121,36 @@ load(
     "container_pull",
 )
 
+# Pulled gcr.io/distroless/cc-debian11:latest on 2022-02-23
 container_pull(
-    name = "cc_image_base",
-    digest = "sha256:41036fc7ed8df0f6addc18484cef0c94a85867508967789f947e11ffd5ff0cc8",
+    name = "cc_image_base_amd64",
+    digest = "sha256:2a0daf90a7deb78465bfca3ef2eee6e91ce0a5706059f05d79d799a51d339523",
     registry = "gcr.io",
-    repository = "distroless/cc",
+    repository = "distroless/cc-debian11",
 )
 
+# Pulled gcr.io/distroless/cc-debian11:debug on 2022-02-23
 container_pull(
-    name = "cc_debug_image_base",
-    digest = "sha256:6865ad48467c89c3c3524d4c426f52ad12d9ab7dec31fad31fae69da40eb6445",
+    name = "cc_debug_image_base_amd64",
+    digest = "sha256:7bd596f5f200588f13a69c268eea6ce428b222b67cd7428d6a7fef95e75c052a",
     registry = "gcr.io",
-    repository = "distroless/cc",
+    repository = "distroless/cc-debian11",
 )
 
+# Pulled from gcr.io/distroless/base-debian11:latest on 2022-02-23
 container_pull(
-    name = "go_image_base",
-    digest = "sha256:b9b124f955961599e72630654107a0cf04e08e6fa777fa250b8f840728abd770",
+    name = "go_image_base_amd64",
+    digest = "sha256:34e682800774ecbd0954b1663d90238505f1ba5543692dbc75feef7dd4839e90",
     registry = "gcr.io",
-    repository = "distroless/base",
+    repository = "distroless/base-debian11",
 )
 
+# Pulled from gcr.io/distroless/base-debian11:debug on 2022-02-23
 container_pull(
-    name = "go_debug_image_base",
-    digest = "sha256:65668d2b78d25df3d8ccf5a778d017fcaba513b52078c700083eaeef212b9979",
+    name = "go_debug_image_base_amd64",
+    digest = "sha256:0f503c6bfd207793bc416f20a35bf6b75d769a903c48f180ad73f60f7b60d7bd",
     registry = "gcr.io",
-    repository = "distroless/base",
+    repository = "distroless/base-debian11",
 )
 
 container_pull(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -43,17 +43,17 @@ pkg_tar(
 )
 
 CC_DEFAULT_BASE = select({
-    "@io_bazel_rules_docker//:debug": "@cc_debug_image_base//image",
-    "@io_bazel_rules_docker//:fastbuild": "@cc_image_base//image",
-    "@io_bazel_rules_docker//:optimized": "@cc_image_base//image",
-    "//conditions:default": "@cc_image_base//image",
+    "@io_bazel_rules_docker//:debug": "@cc_debug_image_base_amd64//image",
+    "@io_bazel_rules_docker//:fastbuild": "@cc_image_base_amd64//image",
+    "@io_bazel_rules_docker//:optimized": "@cc_image_base_amd64//image",
+    "//conditions:default": "@cc_image_base_amd64//image",
 })
 
 GO_DEFAULT_BASE = select({
-    "@io_bazel_rules_docker//:debug": "@go_debug_image_base//image",
-    "@io_bazel_rules_docker//:fastbuild": "@go_image_base//image",
-    "@io_bazel_rules_docker//:optimized": "@go_image_base//image",
-    "//conditions:default": "@go_image_base//image",
+    "@io_bazel_rules_docker//:debug": "@go_debug_image_base_amd64//image",
+    "@io_bazel_rules_docker//:fastbuild": "@go_image_base_amd64//image",
+    "@io_bazel_rules_docker//:optimized": "@go_image_base_amd64//image",
+    "//conditions:default": "@go_image_base_amd64//image",
 })
 
 # Include it in our base image as a tar.


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Updates the base images to solve some HIGH and MEDIUM level CVE reports

## CVEs -- Before
```

gcr.io/prysmaticlabs/prysm/beacon-chain:latest (debian 11.5)
============================================================
Total: 21 (UNKNOWN: 0, LOW: 11, MEDIUM: 4, HIGH: 6, CRITICAL: 0)

┌───────────┬──────────────────┬──────────┬───────────────────┬──────────────────┬─────────────────────────────────────────────────────────────┐
│  Library  │  Vulnerability   │ Severity │ Installed Version │  Fixed Version   │                            Title                            │
├───────────┼──────────────────┼──────────┼───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ libc6     │ CVE-2010-4756    │ LOW      │ 2.31-13+deb11u5   │                  │ glibc: glob implementation can cause excessive CPU and      │
│           │                  │          │                   │                  │ memory consumption due to...                                │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2010-4756                   │
│           ├──────────────────┤          │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2018-20796   │          │                   │                  │ glibc: uncontrolled recursion in function                   │
│           │                  │          │                   │                  │ check_dst_limits_calc_pos_1 in posix/regexec.c              │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2018-20796                  │
│           ├──────────────────┤          │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010022 │          │                   │                  │ glibc: stack guard protection bypass                        │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2019-1010022                │
│           ├──────────────────┤          │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010023 │          │                   │                  │ glibc: running ldd on malicious ELF leads to code execution │
│           │                  │          │                   │                  │ because of...                                               │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2019-1010023                │
│           ├──────────────────┤          │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010024 │          │                   │                  │ glibc: ASLR bypass using cache of thread stack and heap     │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2019-1010024                │
│           ├──────────────────┤          │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010025 │          │                   │                  │ glibc: information disclosure of heap addresses of          │
│           │                  │          │                   │                  │ pthread_created thread                                      │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2019-1010025                │
│           ├──────────────────┤          │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2019-9192    │          │                   │                  │ glibc: uncontrolled recursion in function                   │
│           │                  │          │                   │                  │ check_dst_limits_calc_pos_1 in posix/regexec.c              │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2019-9192                   │
├───────────┼──────────────────┼──────────┼───────────────────┼──────────────────┼─────────────────────────────────────────────────────────────┤
│ libssl1.1 │ CVE-2022-4450    │ HIGH     │ 1.1.1n-0+deb11u3  │ 1.1.1n-0+deb11u4 │ The function PEM_read_bio_ex() reads a PEM file from a BIO  │
│           │                  │          │                   │                  │ and parses...                                               │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│           ├──────────────────┤          │                   │                  ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0215    │          │                   │                  │ The public API function BIO_new_NDEF is a helper function   │
│           │                  │          │                   │                  │ used for str...                                             │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│           ├──────────────────┤          │                   │                  ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0286    │          │                   │                  │ There is a type confusion vulnerability relating to X.400   │
│           │                  │          │                   │                  │ address proc ......                                         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│           ├──────────────────┼──────────┤                   │                  ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2022-2097    │ MEDIUM   │                   │                  │ openssl: AES OCB fails to encrypt some bytes                │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-2097                   │
│           ├──────────────────┤          │                   │                  ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2022-4304    │          │                   │                  │ A timing based side channel exists in the OpenSSL RSA       │
│           │                  │          │                   │                  │ Decryption imple...                                         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
│           ├──────────────────┼──────────┤                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2007-6755    │ LOW      │                   │                  │ Dual_EC_DRBG: weak pseudo random number generator           │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2007-6755                   │
│           ├──────────────────┤          │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2010-0928    │          │                   │                  │ openssl: RSA authentication weakness                        │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2010-0928                   │
├───────────┼──────────────────┼──────────┤                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│ openssl   │ CVE-2022-4450    │ HIGH     │                   │ 1.1.1n-0+deb11u4 │ The function PEM_read_bio_ex() reads a PEM file from a BIO  │
│           │                  │          │                   │                  │ and parses...                                               │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4450                   │
│           ├──────────────────┤          │                   │                  ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0215    │          │                   │                  │ The public API function BIO_new_NDEF is a helper function   │
│           │                  │          │                   │                  │ used for str...                                             │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0215                   │
│           ├──────────────────┤          │                   │                  ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2023-0286    │          │                   │                  │ There is a type confusion vulnerability relating to X.400   │
│           │                  │          │                   │                  │ address proc ......                                         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-0286                   │
│           ├──────────────────┼──────────┤                   │                  ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2022-2097    │ MEDIUM   │                   │                  │ openssl: AES OCB fails to encrypt some bytes                │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-2097                   │
│           ├──────────────────┤          │                   │                  ├─────────────────────────────────────────────────────────────┤
│           │ CVE-2022-4304    │          │                   │                  │ A timing based side channel exists in the OpenSSL RSA       │
│           │                  │          │                   │                  │ Decryption imple...                                         │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2022-4304                   │
│           ├──────────────────┼──────────┤                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2007-6755    │ LOW      │                   │                  │ Dual_EC_DRBG: weak pseudo random number generator           │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2007-6755                   │
│           ├──────────────────┤          │                   ├──────────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2010-0928    │          │                   │                  │ openssl: RSA authentication weakness                        │
│           │                  │          │                   │                  │ https://avd.aquasec.com/nvd/cve-2010-0928                   │
└───────────┴──────────────────┴──────────┴───────────────────┴──────────────────┴─────────────────────────────────────────────────────────────┘
```

## CVEs -- After

```

bazel/cmd/beacon-chain:image (debian 11.6)
==========================================
Total: 11 (UNKNOWN: 0, LOW: 11, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌───────────┬──────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│  Library  │  Vulnerability   │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├───────────┼──────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libc6     │ CVE-2010-4756    │ LOW      │ 2.31-13+deb11u5   │               │ glibc: glob implementation can cause excessive CPU and      │
│           │                  │          │                   │               │ memory consumption due to...                                │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2010-4756                   │
│           ├──────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2018-20796   │          │                   │               │ glibc: uncontrolled recursion in function                   │
│           │                  │          │                   │               │ check_dst_limits_calc_pos_1 in posix/regexec.c              │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2018-20796                  │
│           ├──────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010022 │          │                   │               │ glibc: stack guard protection bypass                        │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2019-1010022                │
│           ├──────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010023 │          │                   │               │ glibc: running ldd on malicious ELF leads to code execution │
│           │                  │          │                   │               │ because of...                                               │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2019-1010023                │
│           ├──────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010024 │          │                   │               │ glibc: ASLR bypass using cache of thread stack and heap     │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2019-1010024                │
│           ├──────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2019-1010025 │          │                   │               │ glibc: information disclosure of heap addresses of          │
│           │                  │          │                   │               │ pthread_created thread                                      │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2019-1010025                │
│           ├──────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2019-9192    │          │                   │               │ glibc: uncontrolled recursion in function                   │
│           │                  │          │                   │               │ check_dst_limits_calc_pos_1 in posix/regexec.c              │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2019-9192                   │
├───────────┼──────────────────┤          ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl1.1 │ CVE-2007-6755    │          │ 1.1.1n-0+deb11u4  │               │ Dual_EC_DRBG: weak pseudo random number generator           │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2007-6755                   │
│           ├──────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2010-0928    │          │                   │               │ openssl: RSA authentication weakness                        │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2010-0928                   │
├───────────┼──────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│ openssl   │ CVE-2007-6755    │          │                   │               │ Dual_EC_DRBG: weak pseudo random number generator           │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2007-6755                   │
│           ├──────────────────┤          │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│           │ CVE-2010-0928    │          │                   │               │ openssl: RSA authentication weakness                        │
│           │                  │          │                   │               │ https://avd.aquasec.com/nvd/cve-2010-0928                   │
└───────────┴──────────────────┴──────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```

**Which issues(s) does this PR fix?**

Fixes #9674

**Other notes for review**
