### PR TITLE
Raise the max grpc message size to a very large value by default

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -67,9 +67,6 @@ import (
 
 const testSkipPowFlag = "test-skip-pow"
 
-// 128MB max message size when enabling debug endpoints.
-const debugGrpcMaxMsgSize = 1 << 27
-
 // Used as a struct to keep cli flag options for configuring services
 // for the beacon node. We keep this as a separate struct to not pollute the actual BeaconNode
 // struct, as it is merely used to pass down configuration options into the appropriate services.
@@ -786,9 +783,6 @@ func (b *BeaconNode) registerRPCService() error {
 
 	maxMsgSize := b.cliCtx.Int(cmd.GrpcMaxCallRecvMsgSizeFlag.Name)
 	enableDebugRPCEndpoints := b.cliCtx.Bool(flags.EnableDebugRPCEndpoints.Name)
-	if enableDebugRPCEndpoints {
-		maxMsgSize = int(math.Max(float64(maxMsgSize), debugGrpcMaxMsgSize))
-	}
 
 	p2pService := b.fetchP2P()
 	rpcService := rpc.NewService(b.ctx, &rpc.Config{
@@ -880,9 +874,6 @@ func (b *BeaconNode) registerGRPCGateway() error {
 	maxCallSize := b.cliCtx.Uint64(cmd.GrpcMaxCallRecvMsgSizeFlag.Name)
 	httpModules := b.cliCtx.String(flags.HTTPModules.Name)
 	timeout := b.cliCtx.Int(cmd.ApiTimeoutFlag.Name)
-	if enableDebugRPCEndpoints {
-		maxCallSize = uint64(math.Max(float64(maxCallSize), debugGrpcMaxMsgSize))
-	}
 
 	gatewayConfig := gateway.DefaultConfig(enableDebugRPCEndpoints, httpModules)
 	muxs := make([]*apigateway.PbMux, 0)

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math"
 	"os"
 	"os/signal"
 	"path/filepath"

--- a/beacon-chain/server/main.go
+++ b/beacon-chain/server/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"math"
 	"net/http"
 	"strings"
 
@@ -26,7 +27,7 @@ var (
 	debug                   = flag.Bool("debug", false, "Enable debug logging")
 	allowedOrigins          = flag.String("corsdomain", "localhost:4242", "A comma separated list of CORS domains to allow")
 	enableDebugRPCEndpoints = flag.Bool("enable-debug-rpc-endpoints", false, "Enable debug rpc endpoints such as /eth/v1alpha1/beacon/state")
-	grpcMaxMsgSize          = flag.Int("grpc-max-msg-size", 1<<22, "Integer to define max recieve message call size")
+	grpcMaxMsgSize          = flag.Int("grpc-max-msg-size", math.MaxInt32, "Integer to define max recieve message call size")
 	httpModules             = flag.String(
 		"http-modules",
 		strings.Join([]string{flags.PrysmAPIModule, flags.EthAPIModule}, ","),

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/prysmaticlabs/prysm/v3/config/params"
@@ -215,9 +216,13 @@ var (
 	}
 	// GrpcMaxCallRecvMsgSizeFlag defines the max call message size for GRPC
 	GrpcMaxCallRecvMsgSizeFlag = &cli.IntFlag{
-		Name:  "grpc-max-msg-size",
-		Usage: "Integer to define max recieve message call size (default: 4194304 (for 4MB))",
-		Value: 1 << 22,
+		Name: "grpc-max-msg-size",
+		Usage: "Integer to define max recieve message call size. If serving a public gRPC server, " +
+			"set this to a more reasonable size to avoid resource exhaustion from large messages. " +
+			"Validators with as many as 10000 keys can be run with a max message size of less than " +
+			"50Mb. The default here is set to a very high value for local users. " +
+			"(default: 2147483647 (2Gi)).",
+		Value: math.MaxInt32,
 	}
 	// AcceptTosFlag specifies user acceptance of ToS for non-interactive environments.
 	AcceptTosFlag = &cli.BoolFlag{

--- a/testing/endtoend/component_handler_test.go
+++ b/testing/endtoend/component_handler_test.go
@@ -257,7 +257,6 @@ func PIDsFromMultiComponentRunner(runner e2etypes.MultipleComponentRunners) []in
 func appendDebugEndpoints(cfg *e2etypes.E2EConfig) {
 	debug := []string{
 		"--enable-debug-rpc-endpoints",
-		"--grpc-max-msg-size=65568081",
 	}
 	cfg.BeaconFlags = append(cfg.BeaconFlags, debug...)
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Some users may have hit gRPC max message sizes when running large number of validator keys. For example, requesting the epoch duties for thousands of validators by public key may result in a message larger than 4Mb.

**Which issues(s) does this PR fix?**

Fixes #11983

**Other notes for review**
