### PR TITLE
Use Epoch boundary cache to retrieve balances

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -447,6 +447,12 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.ReadOnlySi
 			}
 		}
 	}
+	// Save boundary states that will be useful for forkchoice
+	for r, st := range boundaries {
+		if err := s.cfg.StateGen.SaveState(ctx, r, st); err != nil {
+			return err
+		}
+	}
 	// Insert all nodes but the last one to forkchoice
 	if err := s.cfg.ForkChoiceStore.InsertChain(ctx, pendingNodes); err != nil {
 		return errors.Wrap(err, "could not insert batch to forkchoice")
@@ -463,11 +469,6 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.ReadOnlySi
 		}
 	}
 
-	for r, st := range boundaries {
-		if err := s.cfg.StateGen.SaveState(ctx, r, st); err != nil {
-			return err
-		}
-	}
 	// Also saves the last post state which to be used as pre state for the next batch.
 	lastB := blks[len(blks)-1]
 	if err := s.cfg.StateGen.SaveState(ctx, lastBR, preState); err != nil {

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -453,14 +453,14 @@ func (s *Service) onBlockBatch(ctx context.Context, blks []interfaces.ReadOnlySi
 			return err
 		}
 	}
-	// Insert all nodes but the last one to forkchoice
-	if err := s.cfg.ForkChoiceStore.InsertChain(ctx, pendingNodes); err != nil {
-		return errors.Wrap(err, "could not insert batch to forkchoice")
-	}
 	// Insert the last block to forkchoice
 	lastBR := blockRoots[len(blks)-1]
 	if err := s.cfg.ForkChoiceStore.InsertNode(ctx, preState, lastBR); err != nil {
 		return errors.Wrap(err, "could not insert last block in batch to forkchoice")
+	}
+	// Insert all nodes but the last one to forkchoice
+	if err := s.cfg.ForkChoiceStore.InsertChain(ctx, pendingNodes); err != nil {
+		return errors.Wrap(err, "could not insert batch to forkchoice")
 	}
 	// Set their optimistic status
 	if isValidPayload {

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -68,9 +68,18 @@ func (s *State) StateByRoot(ctx context.Context, blockRoot [32]byte) (state.Beac
 // ActiveNonSlashedBalancesByRoot retrieves the effective balances of all active and non-slashed validators at the
 // state with a given root
 func (s *State) ActiveNonSlashedBalancesByRoot(ctx context.Context, blockRoot [32]byte) ([]uint64, error) {
-	st, err := s.StateByRoot(ctx, blockRoot)
+	var st state.BeaconState
+	cachedInfo, ok, err := s.epochBoundaryStateCache.getByBlockRoot(blockRoot)
 	if err != nil {
 		return nil, err
+	}
+	if ok {
+		st = cachedInfo.state
+	} else {
+		st, err = s.StateByRoot(ctx, blockRoot)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if st == nil || st.IsNil() {
 		return nil, errNilState

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -68,18 +68,9 @@ func (s *State) StateByRoot(ctx context.Context, blockRoot [32]byte) (state.Beac
 // ActiveNonSlashedBalancesByRoot retrieves the effective balances of all active and non-slashed validators at the
 // state with a given root
 func (s *State) ActiveNonSlashedBalancesByRoot(ctx context.Context, blockRoot [32]byte) ([]uint64, error) {
-	var st state.BeaconState
-	cachedInfo, ok, err := s.epochBoundaryStateCache.getByBlockRoot(blockRoot)
+	st, err := s.StateByRoot(ctx, blockRoot)
 	if err != nil {
 		return nil, err
-	}
-	if ok {
-		st = cachedInfo.state
-	} else {
-		st, err = s.StateByRoot(ctx, blockRoot)
-		if err != nil {
-			return nil, err
-		}
 	}
 	if st == nil || st.IsNil() {
 		return nil, errNilState


### PR DESCRIPTION
When retrieving balances by Root for forkchoice, use the epoch boundary cache to retrieve the justified checkpoint balances