### PR TITLE
Disable conditional go 1.20 code until module is also at 1.20

### DIFF
--- a/encoding/bytesutil/BUILD.bazel
+++ b/encoding/bytesutil/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     srcs = [
         "bits.go",
         "bytes.go",
-        "bytes_go120.go",
         "bytes_legacy.go",
         "eth_types.go",
         "hex.go",

--- a/encoding/bytesutil/bytes_go120.go
+++ b/encoding/bytesutil/bytes_go120.go
@@ -1,5 +1,5 @@
-//go:build go1.20
-// +build go1.20
+//go:build prysmAt1.20
+// +build prysmAt1.20
 
 package bytesutil
 

--- a/encoding/bytesutil/bytes_legacy.go
+++ b/encoding/bytesutil/bytes_legacy.go
@@ -1,5 +1,5 @@
-//go:build !go1.20
-// +build !go1.20
+//go:build !prysmAt1.20
+// +build !prysmAt1.20
 
 package bytesutil
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
We're hitting a quirk of go modules and go build tags whereby using a go 1.20 compiler when trying to use prysm as a dependency, or attempting to build prysm directly by specifying it's package path, will fail. Example:
```
$ go build -o bc github.com/prysmaticlabs/prysm/v3/cmd/beacon-chain
^[# github.com/prysmaticlabs/prysm/v3/encoding/bytesutil
encoding/bytesutil/bytes_go120.go:12:17: cannot convert PadTo(x, 4) (value of type []byte) to type [4]byte: conversion of slices to arrays requires go1.20 or later (-lang was set to go1.19; check go.mod)
encoding/bytesutil/bytes_go120.go:19:18: cannot convert PadTo(x, 20) (value of type []byte) to type [20]byte: conversion of slices to arrays requires go1.20 or later (-lang was set to go1.19; check go.mod)
encoding/bytesutil/bytes_go120.go:26:18: cannot convert PadTo(x, 32) (value of type []byte) to type [32]byte: conversion of slices to arrays requires go1.20 or later (-lang was set to go1.19; check go.mod)
encoding/bytesutil/bytes_go120.go:33:18: cannot convert PadTo(x, 48) (value of type []byte) to type [48]byte: conversion of slices to arrays requires go1.20 or later (-lang was set to go1.19; check go.mod)
encoding/bytesutil/bytes_go120.go:40:18: cannot convert PadTo(x, 64) (value of type []byte) to type [64]byte: conversion of slices to arrays requires go1.20 or later (-lang was set to go1.19; check go.mod)
encoding/bytesutil/bytes_go120.go:47:18: cannot convert PadTo(x, 96) (value of type []byte) to type [96]byte: conversion of slices to arrays requires go1.20 or later (-lang was set to go1.19; check go.mod)
# github.com/lucas-clemente/quic-go/internal/qtls
../../../go/pkg/mod/github.com/lucas-clemente/quic-go@v0.31.0/internal/qtls/go120.go:5:13: cannot use "The version of quic-go you're using can't be built on Go 1.20 yet. For more details, please see https://github.com/lucas-clemente/quic-go/wiki/quic-go-and-Go-versions." (untyped string constant "The version of quic-go you're using can't be built on Go 1.20 yet. F...) as int value in variable declaration
```

The problem is that the `go1.20` build tag is determined by the version of the *compiler executable*. So the compiler will see the 1.20 -compatible code, but the module claims it is using go 1.19. The compiler's module system includes a safety mechanism where it refuses to compile a module where the source code conflicts with the version specified by go.mod.

This PR temporarily disables the inclusion of the go 1.20 code used in `bytesutil` by gating it with a flag that is never set. Once we upgrade the prysm module to 1.20 we can revert this PR to conditionally compile as expected.