### PR TITLE
Reuse attestations from the reorged block

### DIFF
--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -87,7 +87,7 @@ func (s *Service) forkchoiceUpdateWithExecution(ctx context.Context, newHeadRoot
 	}
 	// Only need to prune attestations from pool if the block is early and
 	// we are not calling at the beginning of the slot.
-	if proposingSlot != currentSlot && secs < uint64(params.BeaconConfig().SlotsPerEpoch) {
+	if !isNewProposer || (proposingSlot != currentSlot && secs < uint64(params.BeaconConfig().SlotsPerEpoch)) {
 		if err := s.pruneAttsFromPool(headBlock); err != nil {
 			log.WithError(err).Error("could not prune attestations from pool")
 		}

--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -87,7 +87,7 @@ func (s *Service) forkchoiceUpdateWithExecution(ctx context.Context, newHeadRoot
 	}
 	// Only need to prune attestations from pool if the block is early and
 	// we are not calling at the beginning of the slot.
-	if !isNewProposer || (proposingSlot != currentSlot && secs < uint64(params.BeaconConfig().SlotsPerEpoch)) {
+	if !isNewProposer || (proposingSlot != currentSlot && secs < uint64(params.BeaconConfig().SlotsPerEpoch)/3) {
 		if err := s.pruneAttsFromPool(headBlock); err != nil {
 			log.WithError(err).Error("could not prune attestations from pool")
 		}

--- a/beacon-chain/blockchain/forkchoice_update_execution_test.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution_test.go
@@ -217,9 +217,9 @@ func TestShouldOverrideFCU(t *testing.T) {
 	require.NoError(t, fcs.InsertNode(ctx, st, root))
 
 	require.Equal(t, primitives.Slot(2), service.CurrentSlot())
-	require.Equal(t, true, service.shouldOverrideFCU(headRoot, 2))
+	require.Equal(t, true, service.shouldOverrideFCU(headRoot, 2, 0))
 	require.LogsDoNotContain(t, hook, "12 seconds")
-	require.Equal(t, false, service.shouldOverrideFCU(parentRoot, 2))
+	require.Equal(t, false, service.shouldOverrideFCU(parentRoot, 2, 0))
 	require.LogsContain(t, hook, "12 seconds")
 
 	head, err := fcs.Head(ctx)
@@ -227,10 +227,10 @@ func TestShouldOverrideFCU(t *testing.T) {
 	require.Equal(t, headRoot, head)
 
 	fcs.SetGenesisTime(uint64(time.Now().Unix()) - 29)
-	require.Equal(t, true, service.shouldOverrideFCU(parentRoot, 3))
+	require.Equal(t, true, service.shouldOverrideFCU(parentRoot, 3, 0))
 	require.LogsDoNotContain(t, hook, "10 seconds")
 	fcs.SetGenesisTime(uint64(time.Now().Unix()) - 24)
 	service.SetGenesisTime(time.Now().Add(-time.Duration(2*params.BeaconConfig().SecondsPerSlot+10) * time.Second))
-	require.Equal(t, false, service.shouldOverrideFCU(parentRoot, 3))
+	require.Equal(t, false, service.shouldOverrideFCU(parentRoot, 3, 10))
 	require.LogsContain(t, hook, "10 seconds")
 }


### PR DESCRIPTION
Do not remove attestations from the pool if we will be reorging a block

This PR removes the attestations from the pool only if we are not proposing in the next slot or if the received block is early. 