### PR TITLE
Fix receive blind block

### DIFF
--- a/beacon-chain/rpc/apimiddleware/endpoint_factory.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory.go
@@ -38,7 +38,7 @@ func (_ *BeaconEndpointFactory) Paths() []string {
 		"/eth/v1/beacon/pool/attestations",
 		"/eth/v1/beacon/pool/attester_slashings",
 		"/eth/v1/beacon/pool/proposer_slashings",
-		"/eth/v1/beacon/pool/voluntary_exits",
+		"/eth/v1/beacon/pool/voluntarfy_exits",
 		"/eth/v1/beacon/pool/bls_to_execution_changes",
 		"/eth/v1/beacon/pool/sync_committees",
 		"/eth/v1/beacon/pool/bls_to_execution_changes",

--- a/beacon-chain/rpc/eth/beacon/server.go
+++ b/beacon-chain/rpc/eth/beacon/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/slashings"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/voluntaryexits"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/p2p"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/rpc"
 	v1alpha1validator "github.com/prysmaticlabs/prysm/v3/beacon-chain/rpc/prysm/v1alpha1/validator"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/rpc/statefetcher"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stategen"
@@ -43,4 +44,5 @@ type Server struct {
 	ExecutionPayloadReconstructor execution.ExecutionPayloadReconstructor
 	FinalizationFetcher           blockchain.FinalizationFetcher
 	BLSChangesPool                blstoexec.PoolManager
+	PayloadCache                  *rpc.PayloadCache
 }

--- a/beacon-chain/rpc/eth/validator/server.go
+++ b/beacon-chain/rpc/eth/validator/server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/attestations"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/synccommittee"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/p2p"
+	"github.com/prysmaticlabs/prysm/v3/beacon-chain/rpc"
 	v1alpha1validator "github.com/prysmaticlabs/prysm/v3/beacon-chain/rpc/prysm/v1alpha1/validator"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/rpc/statefetcher"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/sync"
@@ -26,4 +27,5 @@ type Server struct {
 	SyncCommitteePool      synccommittee.Pool
 	V1Alpha1Server         *v1alpha1validator.Server
 	ProposerSlotIndexCache *cache.ProposerPayloadIDsCache
+	PayloadCache           *rpc.PayloadCache
 }

--- a/beacon-chain/rpc/eth/validator/validator.go
+++ b/beacon-chain/rpc/eth/validator/validator.go
@@ -539,9 +539,9 @@ func (vs *Server) ProduceBlindedBlock(ctx context.Context, req *ethpbv1.ProduceB
 			},
 		}, nil
 	}
-	capellaBlock, ok := v1alpha1resp.Block.(*ethpbalpha.GenericBeaconBlock_BlindedCapella)
+	capellaBlindBlock, ok := v1alpha1resp.Block.(*ethpbalpha.GenericBeaconBlock_BlindedCapella)
 	if ok {
-		blk, err := migration.V1Alpha1BeaconBlockBlindedCapellaToV2Blinded(capellaBlock.BlindedCapella)
+		blk, err := migration.V1Alpha1BeaconBlockBlindedCapellaToV2Blinded(capellaBlindBlock.BlindedCapella)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not prepare beacon block: %v", err)
 		}
@@ -552,6 +552,20 @@ func (vs *Server) ProduceBlindedBlock(ctx context.Context, req *ethpbv1.ProduceB
 			},
 		}, nil
 	}
+	capellaBlock, ok := v1alpha1resp.Block.(*ethpbalpha.GenericBeaconBlock_Capella)
+	if ok {
+		blind, err := migration.V1Alpha1BeaconBlockCapellaToV2Blinded(capellaBlock.Capella)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not prepare beacon block: %v", err)
+		}
+		return &ethpbv2.ProduceBlindedBlockResponse{
+			Version: ethpbv2.Version_CAPELLA,
+			Data: &ethpbv2.BlindedBeaconBlockContainer{
+				Block: &ethpbv2.BlindedBeaconBlockContainer_CapellaBlock{CapellaBlock: blind},
+			},
+		}, nil
+	}
+
 	return nil, status.Error(codes.InvalidArgument, "Unsupported block type")
 }
 

--- a/beacon-chain/rpc/eth/validator/validator.go
+++ b/beacon-chain/rpc/eth/validator/validator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/big"
 	"sort"
 	"strconv"
 	"time"
@@ -21,6 +22,7 @@ import (
 	state_native "github.com/prysmaticlabs/prysm/v3/beacon-chain/state/state-native"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
+	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	ethpbv1 "github.com/prysmaticlabs/prysm/v3/proto/eth/v1"
@@ -558,6 +560,11 @@ func (vs *Server) ProduceBlindedBlock(ctx context.Context, req *ethpbv1.ProduceB
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not prepare beacon block: %v", err)
 		}
+		executionData, err := blocks.WrappedExecutionPayloadCapella(capellaBlock.Capella.Body.ExecutionPayload, big.NewInt(0))
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not prepare beacon block: %v", err)
+		}
+		vs.PayloadCache.Set(executionData)
 		return &ethpbv2.ProduceBlindedBlockResponse{
 			Version: ethpbv2.Version_CAPELLA,
 			Data: &ethpbv2.BlindedBeaconBlockContainer{

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -43,6 +43,8 @@ import (
 	chainSync "github.com/prysmaticlabs/prysm/v3/beacon-chain/sync"
 	"github.com/prysmaticlabs/prysm/v3/config/features"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
+	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
+	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/io/logs"
 	"github.com/prysmaticlabs/prysm/v3/monitoring/tracing"
 	ethpbservice "github.com/prysmaticlabs/prysm/v3/proto/eth/service"
@@ -117,6 +119,7 @@ type Config struct {
 	ProposerIdsCache              *cache.ProposerPayloadIDsCache
 	OptimisticModeFetcher         blockchain.OptimisticModeFetcher
 	BlockBuilder                  builder.BlockBuilder
+	payloadsCache                 *PayloadCache
 }
 
 // NewService instantiates a new RPC service instance that will
@@ -190,6 +193,8 @@ func (s *Service) Start() {
 	withCache := stategen.WithCache(stateCache)
 	ch := stategen.NewCanonicalHistory(s.cfg.BeaconDB, s.cfg.ChainInfoFetcher, s.cfg.ChainInfoFetcher, withCache)
 
+	payloadsCache := newPayloadCache()
+
 	validatorServer := &validatorv1alpha1.Server{
 		Ctx:                    s.ctx,
 		AttestationCache:       cache.NewAttestationCache(),
@@ -244,6 +249,7 @@ func (s *Service) Start() {
 		},
 		SyncCommitteePool:      s.cfg.SyncCommitteeObjectPool,
 		ProposerSlotIndexCache: s.cfg.ProposerIdsCache,
+		PayloadCache:           payloadsCache,
 	}
 
 	nodeServer := &nodev1alpha1.Server{
@@ -324,6 +330,7 @@ func (s *Service) Start() {
 		ExecutionPayloadReconstructor: s.cfg.ExecutionPayloadReconstructor,
 		BLSChangesPool:                s.cfg.BLSChangesPool,
 		FinalizationFetcher:           s.cfg.FinalizationFetcher,
+		PayloadCache:                  payloadsCache,
 	}
 	ethpbv1alpha1.RegisterNodeServer(s.grpcServer, nodeServer)
 	ethpbservice.RegisterBeaconNodeServer(s.grpcServer, nodeServerV1)
@@ -443,6 +450,48 @@ func (s *Service) logNewClientConnection(ctx context.Context) {
 				"addr": clientInfo.Addr.String(),
 			}).Infof("gRPC client connected to beacon node")
 			s.connectedRPCClients[clientInfo.Addr] = true
+		}
+	}
+}
+
+var ErrNoPayloadFound = errors.New("no payload found")
+
+type PayloadCache struct {
+	sync.RWMutex
+	cache map[[32]byte]interfaces.ExecutionData
+}
+
+func newPayloadCache() *PayloadCache {
+	return &PayloadCache{
+		cache: make(map[[32]byte]interfaces.ExecutionData),
+	}
+}
+
+func (p *PayloadCache) Get(key [32]byte) (interfaces.ExecutionData, error) {
+	p.RLock()
+	defer p.RUnlock()
+	if payload, ok := p.cache[key]; ok {
+		return payload, nil
+	}
+
+	return nil, ErrNoPayloadFound
+}
+
+func (p *PayloadCache) Set(payload interfaces.ExecutionData) {
+	p.Lock()
+	defer p.Unlock()
+	h := payload.BlockHash()
+	p.cache[bytesutil.ToBytes32(h)] = payload
+}
+
+// Delete payloads older than slot
+func (p *PayloadCache) Delete(slot uint64) {
+	p.Lock()
+	defer p.Unlock()
+
+	for _, data := range p.cache {
+		if slot >= data.Timestamp()/params.BeaconConfig().SecondsPerSlot {
+			delete(p.cache, bytesutil.ToBytes32(data.BlockHash()))
 		}
 	}
 }


### PR DESCRIPTION
An attempt to fix #12103 by adding a payload ID cache to allow unblind beacon block when it's using local execution client