### PR TITLE
Remove previous justified checkpoint support

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -319,7 +319,7 @@ func (s *Service) HeadValidatorIndexToPublicKey(_ context.Context, index primiti
 	return v.PublicKey(), nil
 }
 
-// ForkChoicer returns the Capellace.
+// ForkChoicer returns the forkchoice interface.
 func (s *Service) ForkChoicer() forkchoice.ForkChoicer {
 	return s.cfg.ForkChoiceStore
 }

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -83,7 +83,6 @@ type CanonicalFetcher interface {
 type FinalizationFetcher interface {
 	FinalizedCheckpt() *ethpb.Checkpoint
 	CurrentJustifiedCheckpt() *ethpb.Checkpoint
-	PreviousJustifiedCheckpt() *ethpb.Checkpoint
 	InForkchoice([32]byte) bool
 	IsFinalized(ctx context.Context, blockRoot [32]byte) bool
 }
@@ -99,14 +98,6 @@ func (s *Service) FinalizedCheckpt() *ethpb.Checkpoint {
 	s.ForkChoicer().RLock()
 	defer s.ForkChoicer().RUnlock()
 	cp := s.ForkChoicer().FinalizedCheckpoint()
-	return &ethpb.Checkpoint{Epoch: cp.Epoch, Root: bytesutil.SafeCopyBytes(cp.Root[:])}
-}
-
-// PreviousJustifiedCheckpt returns the current justified checkpoint from chain store.
-func (s *Service) PreviousJustifiedCheckpt() *ethpb.Checkpoint {
-	s.ForkChoicer().RLock()
-	defer s.ForkChoicer().RUnlock()
-	cp := s.ForkChoicer().PreviousJustifiedCheckpoint()
 	return &ethpb.Checkpoint{Epoch: cp.Epoch, Root: bytesutil.SafeCopyBytes(cp.Root[:])}
 }
 
@@ -328,7 +319,7 @@ func (s *Service) HeadValidatorIndexToPublicKey(_ context.Context, index primiti
 	return v.PublicKey(), nil
 }
 
-// ForkChoicer returns the forkchoice interface.
+// ForkChoicer returns the Capellace.
 func (s *Service) ForkChoicer() forkchoice.ForkChoicer {
 	return s.cfg.ForkChoiceStore
 }

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -307,11 +307,6 @@ func (s *ChainService) CurrentJustifiedCheckpt() *ethpb.Checkpoint {
 	return s.CurrentJustifiedCheckPoint
 }
 
-// PreviousJustifiedCheckpt mocks PreviousJustifiedCheckpt method in chain service.
-func (s *ChainService) PreviousJustifiedCheckpt() *ethpb.Checkpoint {
-	return s.PreviousJustifiedCheckPoint
-}
-
 // ReceiveAttestation mocks ReceiveAttestation method in chain service.
 func (_ *ChainService) ReceiveAttestation(_ context.Context, _ *ethpb.Attestation) error {
 	return nil

--- a/beacon-chain/forkchoice/doubly-linked-tree/on_tick.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/on_tick.go
@@ -60,7 +60,6 @@ func (f *ForkChoice) NewSlot(ctx context.Context, slot primitives.Slot) error {
 			return err
 		}
 		if r == fcp.Root {
-			f.store.prevJustifiedCheckpoint = jcp
 			f.store.justifiedCheckpoint = bjcp
 			if err := f.updateJustifiedBalances(ctx, bjcp.Root); err != nil {
 				log.Error("could not update justified balances")

--- a/beacon-chain/forkchoice/doubly-linked-tree/types.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/types.go
@@ -26,7 +26,6 @@ type Store struct {
 	bestJustifiedCheckpoint       *forkchoicetypes.Checkpoint            // best justified checkpoint in store.
 	unrealizedJustifiedCheckpoint *forkchoicetypes.Checkpoint            // best unrealized justified checkpoint in store.
 	unrealizedFinalizedCheckpoint *forkchoicetypes.Checkpoint            // best unrealized finalized checkpoint in store.
-	prevJustifiedCheckpoint       *forkchoicetypes.Checkpoint            // previous justified checkpoint in store.
 	finalizedCheckpoint           *forkchoicetypes.Checkpoint            // latest finalized epoch in store.
 	proposerBoostRoot             [fieldparams.RootLength]byte           // latest block root that was boosted after being received in a timely manner.
 	previousProposerBoostRoot     [fieldparams.RootLength]byte           // previous block root that was boosted after being received in a timely manner.

--- a/beacon-chain/forkchoice/doubly-linked-tree/unrealized_justification.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/unrealized_justification.go
@@ -46,7 +46,6 @@ func (f *ForkChoice) updateUnrealizedCheckpoints(ctx context.Context) error {
 		node.justifiedEpoch = node.unrealizedJustifiedEpoch
 		node.finalizedEpoch = node.unrealizedFinalizedEpoch
 		if node.justifiedEpoch > f.store.justifiedCheckpoint.Epoch {
-			f.store.prevJustifiedCheckpoint = f.store.justifiedCheckpoint
 			f.store.justifiedCheckpoint = f.store.unrealizedJustifiedCheckpoint
 			if err := f.updateJustifiedBalances(ctx, f.store.justifiedCheckpoint.Root); err != nil {
 				return errors.Wrap(err, "could not update justified balances")

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -55,7 +55,6 @@ type Getter interface {
 	FinalizedCheckpoint() *forkchoicetypes.Checkpoint
 	FinalizedPayloadBlockHash() [32]byte
 	JustifiedCheckpoint() *forkchoicetypes.Checkpoint
-	PreviousJustifiedCheckpoint() *forkchoicetypes.Checkpoint
 	JustifiedPayloadBlockHash() [32]byte
 	BestJustifiedCheckpoint() *forkchoicetypes.Checkpoint
 	NodeCount() int

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks.go
@@ -422,11 +422,6 @@ func (bs *Server) chainHeadRetrieval(ctx context.Context) (*ethpb.ChainHead, err
 		return nil, err
 	}
 
-	prevJustifiedCheckpoint := bs.FinalizationFetcher.PreviousJustifiedCheckpt()
-	if err := validateCP(prevJustifiedCheckpoint, "prev justified"); err != nil {
-		return nil, err
-	}
-
 	fSlot, err := slots.EpochStart(finalizedCheckpoint.Epoch)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get epoch start slot from finalized checkpoint epoch")
@@ -435,23 +430,16 @@ func (bs *Server) chainHeadRetrieval(ctx context.Context) (*ethpb.ChainHead, err
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get epoch start slot from justified checkpoint epoch")
 	}
-	pjSlot, err := slots.EpochStart(prevJustifiedCheckpoint.Epoch)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get epoch start slot from prev justified checkpoint epoch")
-	}
 	return &ethpb.ChainHead{
-		HeadSlot:                   headBlock.Block().Slot(),
-		HeadEpoch:                  slots.ToEpoch(headBlock.Block().Slot()),
-		HeadBlockRoot:              headBlockRoot[:],
-		FinalizedSlot:              fSlot,
-		FinalizedEpoch:             finalizedCheckpoint.Epoch,
-		FinalizedBlockRoot:         finalizedCheckpoint.Root,
-		JustifiedSlot:              jSlot,
-		JustifiedEpoch:             justifiedCheckpoint.Epoch,
-		JustifiedBlockRoot:         justifiedCheckpoint.Root,
-		PreviousJustifiedSlot:      pjSlot,
-		PreviousJustifiedEpoch:     prevJustifiedCheckpoint.Epoch,
-		PreviousJustifiedBlockRoot: prevJustifiedCheckpoint.Root,
-		OptimisticStatus:           optimisticStatus,
+		HeadSlot:           headBlock.Block().Slot(),
+		HeadEpoch:          slots.ToEpoch(headBlock.Block().Slot()),
+		HeadBlockRoot:      headBlockRoot[:],
+		FinalizedSlot:      fSlot,
+		FinalizedEpoch:     finalizedCheckpoint.Epoch,
+		FinalizedBlockRoot: finalizedCheckpoint.Root,
+		JustifiedSlot:      jSlot,
+		JustifiedEpoch:     justifiedCheckpoint.Epoch,
+		JustifiedBlockRoot: justifiedCheckpoint.Root,
+		OptimisticStatus:   optimisticStatus,
 	}, nil
 }


### PR DESCRIPTION
This PR
- Removes `PreviousJustifiedCheckpt` support and usages in fork choice store
- Remove the `PreviousJustifiedCheckpt` field from the `ChainHead` end point from Prysm API. Note this breaks backward compatibility and has to be rolled in with the major release V4. I doubt anyone is using that endpoint anyway, and I'm also ok removing the endpoint all at once, as we should move everyone to use beacon API as the default