### PR TITLE
Fully Deprecate Vectorized HTR Flag

### DIFF
--- a/beacon-chain/core/blocks/withdrawals.go
+++ b/beacon-chain/core/blocks/withdrawals.go
@@ -163,13 +163,13 @@ func ProcessWithdrawals(st state.BeaconState, executionData interfaces.Execution
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get withdrawals")
 		}
-		wdRoot, err = ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), wds, fieldparams.MaxWithdrawalsPerPayload)
+		wdRoot, err = ssz.WithdrawalSliceRoot(wds, fieldparams.MaxWithdrawalsPerPayload)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not get withdrawals root")
 		}
 	}
 
-	expectedRoot, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), expectedWithdrawals, fieldparams.MaxWithdrawalsPerPayload)
+	expectedRoot, err := ssz.WithdrawalSliceRoot(expectedWithdrawals, fieldparams.MaxWithdrawalsPerPayload)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get expected withdrawals root")
 	}

--- a/beacon-chain/core/blocks/withdrawals_test.go
+++ b/beacon-chain/core/blocks/withdrawals_test.go
@@ -642,7 +642,7 @@ func TestProcessBlindWithdrawals(t *testing.T) {
 			}
 			st, err := prepareValidators(spb, test.Args)
 			require.NoError(t, err)
-			wdRoot, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), test.Args.Withdrawals, fieldparams.MaxWithdrawalsPerPayload)
+			wdRoot, err := ssz.WithdrawalSliceRoot(test.Args.Withdrawals, fieldparams.MaxWithdrawalsPerPayload)
 			require.NoError(t, err)
 			p, err := consensusblocks.WrappedExecutionPayloadHeaderCapella(&enginev1.ExecutionPayloadHeaderCapella{WithdrawalsRoot: wdRoot[:]}, big.NewInt(0))
 			require.NoError(t, err)

--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -7,7 +7,6 @@ import (
 	fastssz "github.com/prysmaticlabs/fastssz"
 	"github.com/prysmaticlabs/prysm/v3/cmd"
 	"github.com/prysmaticlabs/prysm/v3/cmd/beacon-chain/flags"
-	"github.com/prysmaticlabs/prysm/v3/config/features"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	tracing2 "github.com/prysmaticlabs/prysm/v3/monitoring/tracing"
@@ -193,7 +192,5 @@ func configureExecutionSetting(cliCtx *cli.Context) error {
 }
 
 func configureFastSSZHashingAlgorithm() {
-	if features.Get().EnableVectorizedHTR {
-		fastssz.EnableVectorizedHTR = true
-	}
+	fastssz.EnableVectorizedHTR = true
 }

--- a/beacon-chain/rpc/eth/beacon/blinded_blocks_test.go
+++ b/beacon-chain/rpc/eth/beacon/blinded_blocks_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/rpc/prysm/v1alpha1/validator"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	enginev1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
@@ -1141,7 +1140,7 @@ func TestSubmitBlindedBlock(t *testing.T) {
 				Amount:         2,
 			},
 		}
-		withdrawalsRoot, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), withdrawals, 16)
+		withdrawalsRoot, err := ssz.WithdrawalSliceRoot(withdrawals, 16)
 		require.NoError(t, err)
 
 		beaconDB := dbTest.SetupDB(t)

--- a/beacon-chain/rpc/eth/validator/BUILD.bazel
+++ b/beacon-chain/rpc/eth/validator/BUILD.bazel
@@ -78,7 +78,6 @@ go_test(
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//crypto/bls:go_default_library",
-        "//crypto/hash:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//encoding/ssz:go_default_library",
         "//proto/engine/v1:go_default_library",

--- a/beacon-chain/rpc/eth/validator/validator_test.go
+++ b/beacon-chain/rpc/eth/validator/validator_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/crypto/bls"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	enginev1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
@@ -1187,7 +1186,7 @@ func TestProduceBlockV2(t *testing.T) {
 				Amount:         123,
 			},
 		}
-		withdrawalsRoot, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), withdrawals, 2)
+		withdrawalsRoot, err := ssz.WithdrawalSliceRoot(withdrawals, 2)
 		require.NoError(t, err)
 
 		payloadHeader, err := blocks.WrappedExecutionPayloadHeaderCapella(&enginev1.ExecutionPayloadHeaderCapella{
@@ -2721,7 +2720,7 @@ func TestProduceBlindedBlock(t *testing.T) {
 		require.NoError(t, err)
 		wds, err := beaconState.ExpectedWithdrawals()
 		require.NoError(t, err)
-		wr, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), wds, fieldparams.MaxWithdrawalsPerPayload)
+		wr, err := ssz.WithdrawalSliceRoot(wds, fieldparams.MaxWithdrawalsPerPayload)
 		require.NoError(t, err)
 		bid := &ethpbalpha.BuilderBidCapella{
 			Header: &enginev1.ExecutionPayloadHeaderCapella{

--- a/beacon-chain/rpc/eth/validator/validator_test.go
+++ b/beacon-chain/rpc/eth/validator/validator_test.go
@@ -455,6 +455,7 @@ func TestGetSyncCommitteeDuties(t *testing.T) {
 	currCommittee := &ethpbalpha.SyncCommittee{}
 	for i := 0; i < 5; i++ {
 		currCommittee.Pubkeys = append(currCommittee.Pubkeys, vals[i].PublicKey)
+		currCommittee.AggregatePubkey = make([]byte, 48)
 	}
 	// add one public key twice - this is needed for one of the test cases
 	currCommittee.Pubkeys = append(currCommittee.Pubkeys, vals[0].PublicKey)
@@ -462,6 +463,8 @@ func TestGetSyncCommitteeDuties(t *testing.T) {
 	nextCommittee := &ethpbalpha.SyncCommittee{}
 	for i := 5; i < 10; i++ {
 		nextCommittee.Pubkeys = append(nextCommittee.Pubkeys, vals[i].PublicKey)
+		nextCommittee.AggregatePubkey = make([]byte, 48)
+
 	}
 	require.NoError(t, st.SetNextSyncCommittee(nextCommittee))
 	db := dbutil.SetupDB(t)
@@ -590,11 +593,14 @@ func TestGetSyncCommitteeDuties(t *testing.T) {
 		currCommittee := &ethpbalpha.SyncCommittee{}
 		for i := 5; i < 10; i++ {
 			currCommittee.Pubkeys = append(currCommittee.Pubkeys, vals[i].PublicKey)
+			currCommittee.AggregatePubkey = make([]byte, 48)
 		}
 		require.NoError(t, newSyncPeriodSt.SetCurrentSyncCommittee(currCommittee))
 		nextCommittee := &ethpbalpha.SyncCommittee{}
 		for i := 0; i < 5; i++ {
 			nextCommittee.Pubkeys = append(nextCommittee.Pubkeys, vals[i].PublicKey)
+			nextCommittee.AggregatePubkey = make([]byte, 48)
+
 		}
 		require.NoError(t, newSyncPeriodSt.SetNextSyncCommittee(nextCommittee))
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -17,7 +17,6 @@ import (
 	consensusblocks "github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	enginev1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
@@ -344,7 +343,7 @@ func matchingWithdrawalsRoot(local, builder interfaces.ExecutionData) (bool, err
 	if err != nil {
 		return false, errors.Wrap(err, "could not get builder withdrawals root")
 	}
-	wr, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), wds, fieldparams.MaxWithdrawalsPerPayload)
+	wr, err := ssz.WithdrawalSliceRoot(wds, fieldparams.MaxWithdrawalsPerPayload)
 	if err != nil {
 		return false, errors.Wrap(err, "could not compute local withdrawals root")
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/crypto/bls"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	v1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
@@ -136,7 +135,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		require.NoError(t, err)
 		sk, err := bls.RandKey()
 		require.NoError(t, err)
-		wr, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), withdrawals, fieldparams.MaxWithdrawalsPerPayload)
+		wr, err := ssz.WithdrawalSliceRoot(withdrawals, fieldparams.MaxWithdrawalsPerPayload)
 		require.NoError(t, err)
 		bid := &ethpb.BuilderBidCapella{
 			Header: &v1.ExecutionPayloadHeaderCapella{
@@ -579,7 +578,7 @@ func Test_matchingWithdrawalsRoot(t *testing.T) {
 		p, err := blocks.WrappedExecutionPayloadCapella(local, big.NewInt(0))
 		require.NoError(t, err)
 		header := &v1.ExecutionPayloadHeaderCapella{}
-		wr, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), wds, fieldparams.MaxWithdrawalsPerPayload)
+		wr, err := ssz.WithdrawalSliceRoot(wds, fieldparams.MaxWithdrawalsPerPayload)
 		require.NoError(t, err)
 		header.WithdrawalsRoot = wr[:]
 		h, err := blocks.WrappedExecutionPayloadHeaderCapella(header, big.NewInt(0))

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_capella_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_capella_test.go
@@ -9,7 +9,6 @@ import (
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	v1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
@@ -86,7 +85,7 @@ func TestServer_unblindBuilderCapellaBlock(t *testing.T) {
 				b.Block.ProposerIndex = 2
 				txRoot, err := ssz.TransactionsRoot(make([][]byte, 0))
 				require.NoError(t, err)
-				wdRoot, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), []*v1.Withdrawal{}, fieldparams.MaxWithdrawalsPerPayload)
+				wdRoot, err := ssz.WithdrawalSliceRoot([]*v1.Withdrawal{}, fieldparams.MaxWithdrawalsPerPayload)
 				require.NoError(t, err)
 				b.Block.Body.ExecutionPayloadHeader = &v1.ExecutionPayloadHeaderCapella{
 					ParentHash:       make([]byte, fieldparams.RootLength),

--- a/beacon-chain/state/fieldtrie/BUILD.bazel
+++ b/beacon-chain/state/fieldtrie/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//beacon-chain/state/state-native/custom-types:go_default_library",
         "//beacon-chain/state/state-native/types:go_default_library",
         "//beacon-chain/state/stateutil:go_default_library",
-        "//crypto/hash:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//math:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",

--- a/beacon-chain/state/fieldtrie/field_trie_helpers.go
+++ b/beacon-chain/state/fieldtrie/field_trie_helpers.go
@@ -9,7 +9,6 @@ import (
 	customtypes "github.com/prysmaticlabs/prysm/v3/beacon-chain/state/state-native/custom-types"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/state-native/types"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stateutil"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	pmath "github.com/prysmaticlabs/prysm/v3/math"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
@@ -212,9 +211,8 @@ func handleValidatorSlice(val []*ethpb.Validator, indices []uint64, convertAll b
 		length = len(val)
 	}
 	roots := make([][32]byte, 0, length)
-	hasher := hash.CustomSHA256Hasher()
 	rootCreator := func(input *ethpb.Validator) error {
-		newRoot, err := stateutil.ValidatorRootWithHasher(hasher, input)
+		newRoot, err := stateutil.ValidatorRootWithHasher(input)
 		if err != nil {
 			return err
 		}
@@ -251,9 +249,8 @@ func handleEth1DataSlice(val []*ethpb.Eth1Data, indices []uint64, convertAll boo
 		length = len(val)
 	}
 	roots := make([][32]byte, 0, length)
-	hasher := hash.CustomSHA256Hasher()
 	rootCreator := func(input *ethpb.Eth1Data) error {
-		newRoot, err := stateutil.Eth1DataRootWithHasher(hasher, input)
+		newRoot, err := stateutil.Eth1DataRootWithHasher(input)
 		if err != nil {
 			return err
 		}
@@ -290,9 +287,8 @@ func handlePendingAttestationSlice(val []*ethpb.PendingAttestation, indices []ui
 		length = len(val)
 	}
 	roots := make([][32]byte, 0, length)
-	hasher := hash.CustomSHA256Hasher()
 	rootCreator := func(input *ethpb.PendingAttestation) error {
-		newRoot, err := stateutil.PendingAttRootWithHasher(hasher, input)
+		newRoot, err := stateutil.PendingAttRootWithHasher(input)
 		if err != nil {
 			return err
 		}

--- a/beacon-chain/state/state-native/hasher.go
+++ b/beacon-chain/state/state-native/hasher.go
@@ -186,21 +186,21 @@ func ComputeFieldRootsWithHasher(ctx context.Context, state *BeaconState) ([][]b
 	fieldRoots[types.JustificationBits.RealPosition()] = justifiedBitsRoot[:]
 
 	// PreviousJustifiedCheckpoint data structure root.
-	prevCheckRoot, err := ssz.CheckpointRoot(hasher, state.previousJustifiedCheckpoint)
+	prevCheckRoot, err := ssz.CheckpointRoot(state.previousJustifiedCheckpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not compute previous justified checkpoint merkleization")
 	}
 	fieldRoots[types.PreviousJustifiedCheckpoint.RealPosition()] = prevCheckRoot[:]
 
 	// CurrentJustifiedCheckpoint data structure root.
-	currJustRoot, err := ssz.CheckpointRoot(hasher, state.currentJustifiedCheckpoint)
+	currJustRoot, err := ssz.CheckpointRoot(state.currentJustifiedCheckpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not compute current justified checkpoint merkleization")
 	}
 	fieldRoots[types.CurrentJustifiedCheckpoint.RealPosition()] = currJustRoot[:]
 
 	// FinalizedCheckpoint data structure root.
-	finalRoot, err := ssz.CheckpointRoot(hasher, state.finalizedCheckpoint)
+	finalRoot, err := ssz.CheckpointRoot(state.finalizedCheckpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not compute finalized checkpoint merkleization")
 	}

--- a/beacon-chain/state/state-native/hasher.go
+++ b/beacon-chain/state/state-native/hasher.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stateutil"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	"github.com/prysmaticlabs/prysm/v3/runtime/version"
@@ -24,7 +23,6 @@ func ComputeFieldRootsWithHasher(ctx context.Context, state *BeaconState) ([][]b
 	if state == nil {
 		return nil, errors.New("nil state")
 	}
-	hasher := hash.CustomSHA256Hasher()
 	var fieldRoots [][]byte
 	switch state.version {
 	case version.Phase0:
@@ -98,7 +96,7 @@ func ComputeFieldRootsWithHasher(ctx context.Context, state *BeaconState) ([][]b
 	fieldRoots[types.HistoricalRoots.RealPosition()] = historicalRootsRt[:]
 
 	// Eth1Data data structure root.
-	eth1HashTreeRoot, err := stateutil.Eth1Root(hasher, state.eth1Data)
+	eth1HashTreeRoot, err := stateutil.Eth1Root(state.eth1Data)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not compute eth1data merkleization")
 	}

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -14,7 +14,6 @@ import (
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/prysmaticlabs/prysm/v3/container/slice"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
@@ -694,7 +693,6 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 	defer span.End()
 	span.AddAttributes(trace.StringAttribute("field", field.String(b.version)))
 
-	hasher := hash.CustomSHA256Hasher()
 	switch field {
 	case types.GenesisTime:
 		return ssz.Uint64Root(b.genesisTime), nil
@@ -735,7 +733,7 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 		}
 		return ssz.ByteArrayRootWithLimit(hRoots, fieldparams.HistoricalRootsLength)
 	case types.Eth1Data:
-		return stateutil.Eth1Root(hasher, b.eth1Data)
+		return stateutil.Eth1Root(b.eth1Data)
 	case types.Eth1DataVotes:
 		if b.rebuildTrie[field] {
 			err := b.resetFieldTrie(

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -817,11 +817,11 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 	case types.JustificationBits:
 		return bytesutil.ToBytes32(b.justificationBits), nil
 	case types.PreviousJustifiedCheckpoint:
-		return ssz.CheckpointRoot(hasher, b.previousJustifiedCheckpoint)
+		return ssz.CheckpointRoot(b.previousJustifiedCheckpoint)
 	case types.CurrentJustifiedCheckpoint:
-		return ssz.CheckpointRoot(hasher, b.currentJustifiedCheckpoint)
+		return ssz.CheckpointRoot(b.currentJustifiedCheckpoint)
 	case types.FinalizedCheckpoint:
-		return ssz.CheckpointRoot(hasher, b.finalizedCheckpoint)
+		return ssz.CheckpointRoot(b.finalizedCheckpoint)
 	case types.InactivityScores:
 		return stateutil.Uint64ListRootWithRegistryLimit(b.inactivityScores)
 	case types.CurrentSyncCommittee:

--- a/beacon-chain/state/stateutil/BUILD.bazel
+++ b/beacon-chain/state/stateutil/BUILD.bazel
@@ -33,7 +33,6 @@ go_library(
     ],
     deps = [
         "//beacon-chain/core/transition/stateutils:go_default_library",
-        "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",
@@ -63,7 +62,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/state:go_default_library",
-        "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//consensus-types/primitives:go_default_library",

--- a/beacon-chain/state/stateutil/block_header_root.go
+++ b/beacon-chain/state/stateutil/block_header_root.go
@@ -3,7 +3,6 @@ package stateutil
 import (
 	"encoding/binary"
 
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
@@ -30,5 +29,5 @@ func BlockHeaderRoot(header *ethpb.BeaconBlockHeader) ([32]byte, error) {
 		bodyRoot := bytesutil.ToBytes32(header.BodyRoot)
 		fieldRoots[4] = bodyRoot
 	}
-	return ssz.BitwiseMerkleize(hash.CustomSHA256Hasher(), fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
+	return ssz.BitwiseMerkleize(fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
 }

--- a/beacon-chain/state/stateutil/eth1_root.go
+++ b/beacon-chain/state/stateutil/eth1_root.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/pkg/errors"
 	params "github.com/prysmaticlabs/prysm/v3/config/params"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 )
 
 // Eth1DataRootWithHasher returns the hash tree root of input `eth1Data`.
-func Eth1DataRootWithHasher(hasher ssz.HashFn, eth1Data *ethpb.Eth1Data) ([32]byte, error) {
+func Eth1DataRootWithHasher(eth1Data *ethpb.Eth1Data) ([32]byte, error) {
 	if eth1Data == nil {
 		return [32]byte{}, errors.New("nil eth1 data")
 	}
@@ -33,7 +32,7 @@ func Eth1DataRootWithHasher(hasher ssz.HashFn, eth1Data *ethpb.Eth1Data) ([32]by
 	if len(eth1Data.BlockHash) > 0 {
 		fieldRoots[2] = bytesutil.ToBytes32(eth1Data.BlockHash)
 	}
-	root, err := ssz.BitwiseMerkleize(hasher, fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
+	root, err := ssz.BitwiseMerkleize(fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
 	if err != nil {
 		return [32]byte{}, err
 	}
@@ -42,22 +41,16 @@ func Eth1DataRootWithHasher(hasher ssz.HashFn, eth1Data *ethpb.Eth1Data) ([32]by
 
 // Eth1DatasRoot returns the hash tree root of input `eth1Datas`.
 func Eth1DatasRoot(eth1Datas []*ethpb.Eth1Data) ([32]byte, error) {
-	hasher := hash.CustomSHA256Hasher()
 	eth1VotesRoots := make([][32]byte, 0, len(eth1Datas))
 	for i := 0; i < len(eth1Datas); i++ {
-		eth1, err := Eth1DataRootWithHasher(hasher, eth1Datas[i])
+		eth1, err := Eth1DataRootWithHasher(eth1Datas[i])
 		if err != nil {
 			return [32]byte{}, errors.Wrap(err, "could not compute eth1data merkleization")
 		}
 		eth1VotesRoots = append(eth1VotesRoots, eth1)
 	}
 
-	eth1VotesRootsRoot, err := ssz.BitwiseMerkleize(
-		hasher,
-		eth1VotesRoots,
-		uint64(len(eth1VotesRoots)),
-		params.BeaconConfig().Eth1DataVotesLength(),
-	)
+	eth1VotesRootsRoot, err := ssz.BitwiseMerkleize(eth1VotesRoots, uint64(len(eth1VotesRoots)), params.BeaconConfig().Eth1DataVotesLength())
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute eth1data votes merkleization")
 	}

--- a/beacon-chain/state/stateutil/field_root_eth1.go
+++ b/beacon-chain/state/stateutil/field_root_eth1.go
@@ -2,14 +2,13 @@ package stateutil
 
 import (
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 )
 
 // Eth1Root computes the HashTreeRoot Merkleization of
 // a BeaconBlockHeader struct according to the eth2
 // Simple Serialize specification.
-func Eth1Root(hasher ssz.HashFn, eth1Data *ethpb.Eth1Data) ([32]byte, error) {
+func Eth1Root(eth1Data *ethpb.Eth1Data) ([32]byte, error) {
 	if eth1Data == nil {
 		return [32]byte{}, errors.New("nil eth1 data")
 	}

--- a/beacon-chain/state/stateutil/field_root_eth1.go
+++ b/beacon-chain/state/stateutil/field_root_eth1.go
@@ -13,7 +13,7 @@ func Eth1Root(hasher ssz.HashFn, eth1Data *ethpb.Eth1Data) ([32]byte, error) {
 	if eth1Data == nil {
 		return [32]byte{}, errors.New("nil eth1 data")
 	}
-	return Eth1DataRootWithHasher(hasher, eth1Data)
+	return Eth1DataRootWithHasher(eth1Data)
 }
 
 // Eth1DataVotesRoot computes the HashTreeRoot Merkleization of

--- a/beacon-chain/state/stateutil/field_root_validator.go
+++ b/beacon-chain/state/stateutil/field_root_validator.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/crypto/hash/htr"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
@@ -31,14 +30,12 @@ func ValidatorRegistryRoot(vals []*ethpb.Validator) ([32]byte, error) {
 }
 
 func validatorRegistryRoot(validators []*ethpb.Validator) ([32]byte, error) {
-	hasher := hash.CustomSHA256Hasher()
-
 	roots, err := optimizedValidatorRoots(validators)
 	if err != nil {
 		return [32]byte{}, err
 	}
 
-	validatorsRootsRoot, err := ssz.BitwiseMerkleize(hasher, roots, uint64(len(roots)), fieldparams.ValidatorRegistryLimit)
+	validatorsRootsRoot, err := ssz.BitwiseMerkleize(roots, uint64(len(roots)), fieldparams.ValidatorRegistryLimit)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute validator registry merkleization")
 	}
@@ -60,9 +57,8 @@ func optimizedValidatorRoots(validators []*ethpb.Validator) ([][32]byte, error) 
 		return [][32]byte{}, nil
 	}
 	roots := make([][32]byte, 0, len(validators)*validatorFieldRoots)
-	hasher := hash.CustomSHA256Hasher()
 	for i := 0; i < len(validators); i++ {
-		fRoots, err := ValidatorFieldRoots(hasher, validators[i])
+		fRoots, err := ValidatorFieldRoots(validators[i])
 		if err != nil {
 			return [][32]byte{}, errors.Wrap(err, "could not compute validators merkleization")
 		}

--- a/beacon-chain/state/stateutil/field_root_vector.go
+++ b/beacon-chain/state/stateutil/field_root_vector.go
@@ -2,18 +2,15 @@ package stateutil
 
 import (
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 )
 
 func ArraysRoot(input [][]byte, length uint64) ([32]byte, error) {
-	hashFunc := hash.CustomSHA256Hasher()
-
 	leaves := make([][32]byte, length)
 	for i, chunk := range input {
 		copy(leaves[i][:], chunk)
 	}
-	res, err := merkleize(leaves, length, hashFunc)
+	res, err := merkleize(leaves, length)
 	if err != nil {
 		return [32]byte{}, err
 	}
@@ -21,8 +18,7 @@ func ArraysRoot(input [][]byte, length uint64) ([32]byte, error) {
 	return res, nil
 }
 
-func merkleize(leaves [][32]byte, length uint64,
-	hasher func([]byte) [32]byte) ([32]byte, error) {
+func merkleize(leaves [][32]byte, length uint64) ([32]byte, error) {
 	if len(leaves) == 0 {
 		return [32]byte{}, errors.New("zero leaves provided")
 	}
@@ -33,7 +29,7 @@ func merkleize(leaves [][32]byte, length uint64,
 	layers := make([][][32]byte, ssz.Depth(length)+1)
 	layers[0] = hashLayer
 	var err error
-	_, hashLayer, err = MerkleizeTrieLeaves(layers, hashLayer, hasher)
+	_, hashLayer, err = MerkleizeTrieLeaves(layers, hashLayer)
 	if err != nil {
 		return [32]byte{}, err
 	}

--- a/beacon-chain/state/stateutil/historical_summaries_root.go
+++ b/beacon-chain/state/stateutil/historical_summaries_root.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 )
@@ -18,7 +17,6 @@ func HistoricalSummariesRoot(summaries []*ethpb.HistoricalSummary) ([32]byte, er
 		return [32]byte{}, fmt.Errorf("historical summary exceeds max length %d", max)
 	}
 
-	hasher := hash.CustomSHA256Hasher()
 	roots := make([][32]byte, len(summaries))
 	for i := 0; i < len(summaries); i++ {
 		r, err := summaries[i].HashTreeRoot()
@@ -28,12 +26,7 @@ func HistoricalSummariesRoot(summaries []*ethpb.HistoricalSummary) ([32]byte, er
 		roots[i] = r
 	}
 
-	summariesRoot, err := ssz.BitwiseMerkleize(
-		hasher,
-		roots,
-		uint64(len(roots)),
-		fieldparams.HistoricalRootsLength,
-	)
+	summariesRoot, err := ssz.BitwiseMerkleize(roots, uint64(len(roots)), fieldparams.HistoricalRootsLength)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute historical summaries merkleization")
 	}

--- a/beacon-chain/state/stateutil/participation_bit_root.go
+++ b/beacon-chain/state/stateutil/participation_bit_root.go
@@ -5,14 +5,12 @@ import (
 
 	"github.com/pkg/errors"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 )
 
 // ParticipationBitsRoot computes the HashTreeRoot merkleization of
 // participation roots.
 func ParticipationBitsRoot(bits []byte) ([32]byte, error) {
-	hasher := hash.CustomSHA256Hasher()
 	chunkedRoots, err := packParticipationBits(bits)
 	if err != nil {
 		return [32]byte{}, err
@@ -20,7 +18,7 @@ func ParticipationBitsRoot(bits []byte) ([32]byte, error) {
 
 	limit := (uint64(fieldparams.ValidatorRegistryLimit + 31)) / 32
 
-	bytesRoot, err := ssz.BitwiseMerkleize(hasher, chunkedRoots, uint64(len(chunkedRoots)), limit)
+	bytesRoot, err := ssz.BitwiseMerkleize(chunkedRoots, uint64(len(chunkedRoots)), limit)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute merkleization")
 	}

--- a/beacon-chain/state/stateutil/sync_committee.root.go
+++ b/beacon-chain/state/stateutil/sync_committee.root.go
@@ -2,7 +2,6 @@ package stateutil
 
 import (
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/crypto/hash/htr"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
@@ -12,7 +11,6 @@ import (
 // a SyncCommitteeRoot struct according to the eth2
 // Simple Serialize specification.
 func SyncCommitteeRoot(committee *ethpb.SyncCommittee) ([32]byte, error) {
-	hasher := hash.CustomSHA256Hasher()
 	var fieldRoots [][32]byte
 	if committee == nil {
 		return [32]byte{}, nil
@@ -27,7 +25,7 @@ func SyncCommitteeRoot(committee *ethpb.SyncCommittee) ([32]byte, error) {
 		}
 		pubKeyRoots = append(pubKeyRoots, r)
 	}
-	pubkeyRoot, err := ssz.BitwiseMerkleize(hasher, pubKeyRoots, uint64(len(pubKeyRoots)), uint64(len(pubKeyRoots)))
+	pubkeyRoot, err := ssz.BitwiseMerkleize(pubKeyRoots, uint64(len(pubKeyRoots)), uint64(len(pubKeyRoots)))
 	if err != nil {
 		return [32]byte{}, err
 	}
@@ -39,7 +37,7 @@ func SyncCommitteeRoot(committee *ethpb.SyncCommittee) ([32]byte, error) {
 	}
 	fieldRoots = [][32]byte{pubkeyRoot, aggregateKeyRoot}
 
-	return ssz.BitwiseMerkleize(hasher, fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
+	return ssz.BitwiseMerkleize(fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
 }
 
 func merkleizePubkey(pubkey []byte) ([32]byte, error) {

--- a/beacon-chain/state/stateutil/sync_committee.root.go
+++ b/beacon-chain/state/stateutil/sync_committee.root.go
@@ -1,7 +1,6 @@
 package stateutil
 
 import (
-	"github.com/prysmaticlabs/prysm/v3/config/features"
 	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/crypto/hash/htr"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
@@ -47,16 +46,8 @@ func merkleizePubkey(hasher ssz.HashFn, pubkey []byte) ([32]byte, error) {
 	if err != nil {
 		return [32]byte{}, err
 	}
-	var pubKeyRoot [32]byte
-	if features.Get().EnableVectorizedHTR {
-		outputChunk := make([][32]byte, 1)
-		htr.VectorizedSha256(chunks, outputChunk)
-		pubKeyRoot = outputChunk[0]
-	} else {
-		pubKeyRoot, err = ssz.BitwiseMerkleize(hasher, chunks, uint64(len(chunks)), uint64(len(chunks)))
-		if err != nil {
-			return [32]byte{}, err
-		}
-	}
-	return pubKeyRoot, nil
+	outputChunk := make([][32]byte, 1)
+	htr.VectorizedSha256(chunks, outputChunk)
+
+	return outputChunk[0], nil
 }

--- a/beacon-chain/state/stateutil/trie_helpers.go
+++ b/beacon-chain/state/stateutil/trie_helpers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/v3/config/features"
 	"github.com/prysmaticlabs/prysm/v3/container/trie"
 	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/crypto/hash/htr"
@@ -46,7 +45,6 @@ func ReturnTrieLayer(elements [][32]byte, length uint64) ([][]*[32]byte, error) 
 // provided with the elements of a variable sized trie and the corresponding depth of
 // it.
 func ReturnTrieLayerVariable(elements [][32]byte, length uint64) [][]*[32]byte {
-	hasher := hash.CustomSHA256Hasher()
 	depth := ssz.Depth(length)
 	layers := make([][]*[32]byte, depth+1)
 	// Return zerohash at depth
@@ -67,38 +65,18 @@ func ReturnTrieLayerVariable(elements [][32]byte, length uint64) [][]*[32]byte {
 	for i := uint8(0); i < depth; i++ {
 		layerLen := len(layers[i])
 		oddNodeLength := layerLen%2 == 1
-		if features.Get().EnableVectorizedHTR {
-			if oddNodeLength {
-				zerohash := trie.ZeroHashes[i]
-				elements = append(elements, zerohash)
-				layerLen++
-			}
+		if oddNodeLength {
+			zerohash := trie.ZeroHashes[i]
+			elements = append(elements, zerohash)
+			layerLen++
+		}
 
-			layers[i+1] = make([]*[32]byte, layerLen/2)
-			newElems := make([][32]byte, layerLen/2)
-			htr.VectorizedSha256(elements, newElems)
-			elements = newElems
-			for j := range elements {
-				layers[i+1][j] = &elements[j]
-			}
-		} else {
-			if oddNodeLength {
-				zerohash := trie.ZeroHashes[i]
-				layers[i] = append(layers[i], &zerohash)
-			}
-			updatedValues := make([]*[32]byte, 0, len(layers[i])/2)
-			for j := 0; j < len(layers[i]); j += 2 {
-				buffer.Write(layers[i][j][:])
-				buffer.Write(layers[i][j+1][:])
-				concat := hasher(buffer.Bytes())
-				updatedValues = append(updatedValues, &concat)
-				buffer.Reset()
-			}
-			// remove zerohash node from tree
-			if oddNodeLength {
-				layers[i] = layers[i][:len(layers[i])-1]
-			}
-			layers[i+1] = updatedValues
+		layers[i+1] = make([]*[32]byte, layerLen/2)
+		newElems := make([][32]byte, layerLen/2)
+		htr.VectorizedSha256(elements, newElems)
+		elements = newElems
+		for j := range elements {
+			layers[i+1][j] = &elements[j]
 		}
 	}
 	return layers
@@ -319,21 +297,9 @@ func MerkleizeTrieLeaves(layers [][][32]byte, hashLayer [][32]byte,
 		if !math.IsPowerOf2(uint64(len(hashLayer))) {
 			return nil, nil, errors.Errorf("hash layer is a non power of 2: %d", len(hashLayer))
 		}
-		if features.Get().EnableVectorizedHTR {
-			newLayer := make([][32]byte, len(hashLayer)/2)
-			htr.VectorizedSha256(hashLayer, newLayer)
-			hashLayer = newLayer
-		} else {
-			layer := make([][32]byte, len(hashLayer)/2)
-			for j := 0; j < len(hashLayer); j += 2 {
-				chunkBuffer.Write(hashLayer[j][:])
-				chunkBuffer.Write(hashLayer[j+1][:])
-				hashedChunk := hasher(chunkBuffer.Bytes())
-				layer[j/2] = hashedChunk
-				chunkBuffer.Reset()
-			}
-			hashLayer = layer
-		}
+		newLayer := make([][32]byte, len(hashLayer)/2)
+		htr.VectorizedSha256(hashLayer, newLayer)
+		hashLayer = newLayer
 		layers[i] = hashLayer
 		i++
 	}

--- a/beacon-chain/state/stateutil/trie_helpers.go
+++ b/beacon-chain/state/stateutil/trie_helpers.go
@@ -16,7 +16,6 @@ import (
 // provided with the elements of a fixed sized trie and the corresponding depth of
 // it.
 func ReturnTrieLayer(elements [][32]byte, length uint64) ([][]*[32]byte, error) {
-	hasher := hash.CustomSHA256Hasher()
 	leaves := elements
 
 	if len(leaves) == 1 {
@@ -26,7 +25,7 @@ func ReturnTrieLayer(elements [][32]byte, length uint64) ([][]*[32]byte, error) 
 	layers := make([][][32]byte, ssz.Depth(length)+1)
 	layers[0] = hashLayer
 	var err error
-	layers, _, err = MerkleizeTrieLeaves(layers, hashLayer, hasher)
+	layers, _, err = MerkleizeTrieLeaves(layers, hashLayer)
 	if err != nil {
 		return nil, err
 	}
@@ -283,8 +282,7 @@ func Merkleize(leaves [][]byte) [][][]byte {
 }
 
 // MerkleizeTrieLeaves merkleize the trie leaves.
-func MerkleizeTrieLeaves(layers [][][32]byte, hashLayer [][32]byte,
-	hasher func([]byte) [32]byte) ([][][32]byte, [][32]byte, error) {
+func MerkleizeTrieLeaves(layers [][][32]byte, hashLayer [][32]byte) ([][][32]byte, [][32]byte, error) {
 	// We keep track of the hash layers of a Merkle trie until we reach
 	// the top layer of length 1, which contains the single root element.
 	//        [Root]      -> Top layer has length 1.

--- a/beacon-chain/state/stateutil/trie_helpers_test.go
+++ b/beacon-chain/state/stateutil/trie_helpers_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stateutil"
-	"github.com/prysmaticlabs/prysm/v3/config/features"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
@@ -25,11 +24,6 @@ func TestReturnTrieLayer_OK(t *testing.T) {
 	assert.NoError(t, err)
 	newRoot := *layers[len(layers)-1][0]
 	assert.Equal(t, root, newRoot)
-
-	flags := &features.Flags{}
-	flags.EnableVectorizedHTR = true
-	reset := features.InitWithReset(flags)
-	defer reset()
 
 	layers, err = stateutil.ReturnTrieLayer(roots, uint64(len(roots)))
 	assert.NoError(t, err)
@@ -53,11 +47,6 @@ func BenchmarkReturnTrieLayer_NormalAlgorithm(b *testing.B) {
 }
 
 func BenchmarkReturnTrieLayer_VectorizedAlgorithm(b *testing.B) {
-	flags := &features.Flags{}
-	flags.EnableVectorizedHTR = true
-	reset := features.InitWithReset(flags)
-	defer reset()
-
 	newState, _ := util.DeterministicGenesisState(b, 32)
 	root, err := stateutil.RootsArrayHashTreeRoot(newState.BlockRoots(), uint64(params.BeaconConfig().SlotsPerHistoricalRoot))
 	require.NoError(b, err)
@@ -90,11 +79,6 @@ func TestReturnTrieLayerVariable_OK(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, root, newRoot)
 
-	flags := &features.Flags{}
-	flags.EnableVectorizedHTR = true
-	reset := features.InitWithReset(flags)
-	defer reset()
-
 	layers = stateutil.ReturnTrieLayerVariable(roots, params.BeaconConfig().ValidatorRegistryLimit)
 	lastRoot := *layers[len(layers)-1][0]
 	lastRoot, err = stateutil.AddInMixin(lastRoot, uint64(len(validators)))
@@ -126,10 +110,6 @@ func BenchmarkReturnTrieLayerVariable_NormalAlgorithm(b *testing.B) {
 }
 
 func BenchmarkReturnTrieLayerVariable_VectorizedAlgorithm(b *testing.B) {
-	flags := &features.Flags{}
-	flags.EnableVectorizedHTR = true
-	reset := features.InitWithReset(flags)
-	defer reset()
 
 	newState, _ := util.DeterministicGenesisState(b, 16000)
 	root, err := stateutil.ValidatorRegistryRoot(newState.Validators())

--- a/beacon-chain/state/stateutil/trie_helpers_test.go
+++ b/beacon-chain/state/stateutil/trie_helpers_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stateutil"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v3/testing/assert"
@@ -65,11 +64,10 @@ func TestReturnTrieLayerVariable_OK(t *testing.T) {
 	newState, _ := util.DeterministicGenesisState(t, 32)
 	root, err := stateutil.ValidatorRegistryRoot(newState.Validators())
 	require.NoError(t, err)
-	hasher := hash.CustomSHA256Hasher()
 	validators := newState.Validators()
 	roots := make([][32]byte, 0, len(validators))
 	for _, val := range validators {
-		rt, err := stateutil.ValidatorRootWithHasher(hasher, val)
+		rt, err := stateutil.ValidatorRootWithHasher(val)
 		require.NoError(t, err)
 		roots = append(roots, rt)
 	}
@@ -91,11 +89,10 @@ func BenchmarkReturnTrieLayerVariable_NormalAlgorithm(b *testing.B) {
 	newState, _ := util.DeterministicGenesisState(b, 16000)
 	root, err := stateutil.ValidatorRegistryRoot(newState.Validators())
 	require.NoError(b, err)
-	hasher := hash.CustomSHA256Hasher()
 	validators := newState.Validators()
 	roots := make([][32]byte, 0, len(validators))
 	for _, val := range validators {
-		rt, err := stateutil.ValidatorRootWithHasher(hasher, val)
+		rt, err := stateutil.ValidatorRootWithHasher(val)
 		require.NoError(b, err)
 		roots = append(roots, rt)
 	}
@@ -114,11 +111,10 @@ func BenchmarkReturnTrieLayerVariable_VectorizedAlgorithm(b *testing.B) {
 	newState, _ := util.DeterministicGenesisState(b, 16000)
 	root, err := stateutil.ValidatorRegistryRoot(newState.Validators())
 	require.NoError(b, err)
-	hasher := hash.CustomSHA256Hasher()
 	validators := newState.Validators()
 	roots := make([][32]byte, 0, len(validators))
 	for _, val := range validators {
-		rt, err := stateutil.ValidatorRootWithHasher(hasher, val)
+		rt, err := stateutil.ValidatorRootWithHasher(val)
 		require.NoError(b, err)
 		roots = append(roots, rt)
 	}
@@ -154,10 +150,9 @@ func TestRecomputeFromLayer_FixedSizedArray(t *testing.T) {
 func TestRecomputeFromLayer_VariableSizedArray(t *testing.T) {
 	newState, _ := util.DeterministicGenesisState(t, 32)
 	validators := newState.Validators()
-	hasher := hash.CustomSHA256Hasher()
 	roots := make([][32]byte, 0, len(validators))
 	for _, val := range validators {
-		rt, err := stateutil.ValidatorRootWithHasher(hasher, val)
+		rt, err := stateutil.ValidatorRootWithHasher(val)
 		require.NoError(t, err)
 		roots = append(roots, rt)
 	}
@@ -182,7 +177,7 @@ func TestRecomputeFromLayer_VariableSizedArray(t *testing.T) {
 	require.NoError(t, err)
 	roots = make([][32]byte, 0, len(changedVals))
 	for _, val := range changedVals {
-		rt, err := stateutil.ValidatorRootWithHasher(hasher, val)
+		rt, err := stateutil.ValidatorRootWithHasher(val)
 		require.NoError(t, err)
 		roots = append(roots, rt)
 	}
@@ -196,9 +191,7 @@ func TestRecomputeFromLayer_VariableSizedArray(t *testing.T) {
 func TestMerkleizeTrieLeaves_BadHashLayer(t *testing.T) {
 	hashLayer := make([][32]byte, 12)
 	layers := make([][][32]byte, 20)
-	_, _, err := stateutil.MerkleizeTrieLeaves(layers, hashLayer, func(bytes []byte) [32]byte {
-		return [32]byte{}
-	})
+	_, _, err := stateutil.MerkleizeTrieLeaves(layers, hashLayer)
 	assert.ErrorContains(t, "hash layer is a non power of 2", err)
 }
 

--- a/beacon-chain/state/stateutil/validator_root.go
+++ b/beacon-chain/state/stateutil/validator_root.go
@@ -50,7 +50,7 @@ func ValidatorFieldRoots(hasher ssz.HashFn, validator *ethpb.Validator) ([][32]b
 		binary.LittleEndian.PutUint64(withdrawalBuf[:8], uint64(validator.WithdrawableEpoch))
 
 		// Public key.
-		pubKeyRoot, err := merkleizePubkey(hasher, pubkey[:])
+		pubKeyRoot, err := merkleizePubkey(pubkey[:])
 		if err != nil {
 			return [][32]byte{}, err
 		}

--- a/beacon-chain/state/stateutil/validator_root.go
+++ b/beacon-chain/state/stateutil/validator_root.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
@@ -13,17 +12,17 @@ import (
 
 // ValidatorRootWithHasher describes a method from which the hash tree root
 // of a validator is returned.
-func ValidatorRootWithHasher(hasher ssz.HashFn, validator *ethpb.Validator) ([32]byte, error) {
-	fieldRoots, err := ValidatorFieldRoots(hasher, validator)
+func ValidatorRootWithHasher(validator *ethpb.Validator) ([32]byte, error) {
+	fieldRoots, err := ValidatorFieldRoots(validator)
 	if err != nil {
 		return [32]byte{}, err
 	}
-	return ssz.BitwiseMerkleize(hasher, fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
+	return ssz.BitwiseMerkleize(fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
 }
 
 // ValidatorFieldRoots describes a method from which the hash tree root
 // of a validator is returned.
-func ValidatorFieldRoots(hasher ssz.HashFn, validator *ethpb.Validator) ([][32]byte, error) {
+func ValidatorFieldRoots(validator *ethpb.Validator) ([][32]byte, error) {
 	var fieldRoots [][32]byte
 	if validator != nil {
 		pubkey := bytesutil.ToBytes48(validator.PublicKey)
@@ -63,12 +62,11 @@ func ValidatorFieldRoots(hasher ssz.HashFn, validator *ethpb.Validator) ([][32]b
 // Uint64ListRootWithRegistryLimit computes the HashTreeRoot Merkleization of
 // a list of uint64 and mixed with registry limit.
 func Uint64ListRootWithRegistryLimit(balances []uint64) ([32]byte, error) {
-	hasher := hash.CustomSHA256Hasher()
 	balancesChunks, err := PackUint64IntoChunks(balances)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not pack balances into chunks")
 	}
-	balancesRootsRoot, err := ssz.BitwiseMerkleize(hasher, balancesChunks, uint64(len(balancesChunks)), ValidatorLimitForBalancesChunks())
+	balancesRootsRoot, err := ssz.BitwiseMerkleize(balancesChunks, uint64(len(balancesChunks)), ValidatorLimitForBalancesChunks())
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute balances merkleization")
 	}

--- a/config/features/BUILD.bazel
+++ b/config/features/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     deps = [
         "//cmd:go_default_library",
         "//config/params:go_default_library",
-        "@com_github_prysmaticlabs_gohashtree//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -20,13 +20,9 @@ The process for implementing new features using this package is as follows:
 package features
 
 import (
-	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
-	"github.com/prysmaticlabs/gohashtree"
 	"github.com/prysmaticlabs/prysm/v3/cmd"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/sirupsen/logrus"
@@ -62,7 +58,6 @@ type Flags struct {
 	// EnableSlashingProtectionPruning for the validator client.
 	EnableSlashingProtectionPruning bool
 
-	EnableVectorizedHTR               bool // EnableVectorizedHTR specifies whether the beacon state will use the optimized sha256 routines.
 	DisableForkchoiceDoublyLinkedTree bool // DisableForkChoiceDoublyLinkedTree specifies whether fork choice store will use a doubly linked tree.
 	EnableBatchGossipAggregation      bool // EnableBatchGossipAggregation specifies whether to further aggregate our gossip batches before verifying them.
 	SaveFullExecutionPayloads         bool // Save full beacon blocks with execution payloads in the database.
@@ -193,26 +188,6 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.Bool(disableStakinContractCheck.Name) {
 		logEnabled(disableStakinContractCheck)
 		cfg.DisableStakinContractCheck = true
-	}
-	if ctx.Bool(disableVecHTR.Name) {
-		logEnabled(disableVecHTR)
-	} else {
-		sigc := make(chan os.Signal, 1)
-		signal.Notify(sigc, syscall.SIGILL)
-		defer signal.Stop(sigc)
-		buffer := make([][32]byte, 2)
-		err := gohashtree.Hash(buffer, buffer)
-		if err != nil {
-			log.Error("could not test if gohashtree is supported")
-		} else {
-			t := time.NewTimer(time.Millisecond * 100)
-			select {
-			case <-sigc:
-				log.Error("gohashtree is not supported in this CPU")
-			case <-t.C:
-				cfg.EnableVectorizedHTR = true
-			}
-		}
 	}
 	if ctx.Bool(disableForkChoiceDoublyLinkedTree.Name) {
 		logEnabled(disableForkChoiceDoublyLinkedTree)

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -17,12 +17,18 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedDisableVecHTR = &cli.BoolFlag{
+		Name:   "disable-vectorized-htr",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 // Deprecated flags for both the beacon node and validator client.
 var deprecatedFlags = []cli.Flag{
 	exampleDeprecatedFeatureFlag,
 	deprecatedDisablePeerScorer,
+	deprecatedDisableVecHTR,
 }
 
 // deprecatedBeaconFlags contains flags that are still used by other components

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -22,11 +22,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
-  deprecatedEnableReorgLateBlocks = &cli.BoolFlag{
+	deprecatedEnableReorgLateBlocks = &cli.BoolFlag{
 		Name:   "enable-reorg-late-blocks",
 		Usage:  deprecatedUsage,
 		Hidden: true,
-  }
+	}
 )
 
 // Deprecated flags for both the beacon node and validator client.

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -88,10 +88,6 @@ var (
 			" (Warning): Once enabled, this feature migrates your database in to a new schema and " +
 			"there is no going back. At worst, your entire database might get corrupted.",
 	}
-	disableVecHTR = &cli.BoolFlag{
-		Name:  "disable-vectorized-htr",
-		Usage: "Disables the new go sha256 library which utilizes optimized routines for merkle trees",
-	}
 	disableForkChoiceDoublyLinkedTree = &cli.BoolFlag{
 		Name:  "disable-forkchoice-doubly-linked-tree",
 		Usage: "Disables the new forkchoice store structure that uses doubly linked trees",
@@ -162,7 +158,6 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	enableSlasherFlag,
 	enableHistoricalSpaceRepresentation,
 	disableStakinContractCheck,
-	disableVecHTR,
 	disableReorgLateBlocks,
 	disableForkChoiceDoublyLinkedTree,
 	disableGossipBatchAggregation,

--- a/consensus-types/blocks/BUILD.bazel
+++ b/consensus-types/blocks/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//config/fieldparams:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",
-        "//crypto/hash:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//encoding/ssz:go_default_library",
         "//proto/engine/v1:go_default_library",

--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -8,7 +8,6 @@ import (
 	fastssz "github.com/prysmaticlabs/fastssz"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/interfaces"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	enginev1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
@@ -703,7 +702,7 @@ func PayloadToHeaderCapella(payload interfaces.ExecutionData) (*enginev1.Executi
 	if err != nil {
 		return nil, err
 	}
-	withdrawalsRoot, err := ssz.WithdrawalSliceRoot(hash.CustomSHA256Hasher(), withdrawals, fieldparams.MaxWithdrawalsPerPayload)
+	withdrawalsRoot, err := ssz.WithdrawalSliceRoot(withdrawals, fieldparams.MaxWithdrawalsPerPayload)
 	if err != nil {
 		return nil, err
 	}

--- a/encoding/ssz/BUILD.bazel
+++ b/encoding/ssz/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v3/encoding/ssz",
     visibility = ["//visibility:public"],
     deps = [
-        "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//container/trie:go_default_library",
         "//crypto/hash:go_default_library",

--- a/encoding/ssz/BUILD.bazel
+++ b/encoding/ssz/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
     deps = [
         "//config/fieldparams:go_default_library",
         "//container/trie:go_default_library",
-        "//crypto/hash:go_default_library",
         "//crypto/hash/htr:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//proto/engine/v1:go_default_library",

--- a/encoding/ssz/helpers.go
+++ b/encoding/ssz/helpers.go
@@ -14,11 +14,11 @@ import (
 const bytesPerChunk = 32
 
 // BitlistRoot returns the mix in length of a bitwise Merkleized bitfield.
-func BitlistRoot(hasher HashFn, bfield bitfield.Bitfield, maxCapacity uint64) ([32]byte, error) {
+func BitlistRoot(bfield bitfield.Bitfield, maxCapacity uint64) ([32]byte, error) {
 	limit := (maxCapacity + 255) / 256
 	if bfield == nil || bfield.Len() == 0 {
 		length := make([]byte, 32)
-		root, err := BitwiseMerkleize(hasher, [][32]byte{}, 0, limit)
+		root, err := BitwiseMerkleize([][32]byte{}, 0, limit)
 		if err != nil {
 			return [32]byte{}, err
 		}
@@ -34,7 +34,7 @@ func BitlistRoot(hasher HashFn, bfield bitfield.Bitfield, maxCapacity uint64) ([
 	}
 	output := make([]byte, 32)
 	copy(output, buf.Bytes())
-	root, err := BitwiseMerkleize(hasher, chunks, uint64(len(chunks)), limit)
+	root, err := BitwiseMerkleize(chunks, uint64(len(chunks)), limit)
 	if err != nil {
 		return [32]byte{}, err
 	}
@@ -46,7 +46,7 @@ func BitlistRoot(hasher HashFn, bfield bitfield.Bitfield, maxCapacity uint64) ([
 // and return the root.
 // Note that merkleize on a single chunk is simply that chunk, i.e. the identity
 // when the number of chunks is one.
-func BitwiseMerkleize(hasher HashFn, chunks [][32]byte, count, limit uint64) ([32]byte, error) {
+func BitwiseMerkleize(chunks [][32]byte, count, limit uint64) ([32]byte, error) {
 	if count > limit {
 		return [32]byte{}, errors.New("merkleizing list that is too large, over limit")
 	}

--- a/encoding/ssz/helpers.go
+++ b/encoding/ssz/helpers.go
@@ -8,7 +8,6 @@ import (
 	"github.com/minio/sha256-simd"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/go-bitfield"
-	"github.com/prysmaticlabs/prysm/v3/config/features"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 )
 
@@ -51,14 +50,7 @@ func BitwiseMerkleize(hasher HashFn, chunks [][32]byte, count, limit uint64) ([3
 	if count > limit {
 		return [32]byte{}, errors.New("merkleizing list that is too large, over limit")
 	}
-	if features.Get().EnableVectorizedHTR {
-		return MerkleizeVector(chunks, limit), nil
-	}
-	hashFn := NewHasherFunc(hasher)
-	leafIndexer := func(i uint64) []byte {
-		return chunks[i][:]
-	}
-	return Merkleize(hashFn, count, limit, leafIndexer), nil
+	return MerkleizeVector(chunks, limit), nil
 }
 
 // PackByChunk a given byte array's final chunk with zeroes if needed.

--- a/encoding/ssz/helpers_test.go
+++ b/encoding/ssz/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/prysmaticlabs/go-bitfield"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	"github.com/prysmaticlabs/prysm/v3/testing/assert"
 	"github.com/prysmaticlabs/prysm/v3/testing/require"
@@ -13,7 +12,6 @@ import (
 const merkleizingListLimitError = "merkleizing list that is too large, over limit"
 
 func TestBitlistRoot(t *testing.T) {
-	hasher := hash.CustomSHA256Hasher()
 	capacity := uint64(10)
 	bfield := bitfield.NewBitlist(capacity)
 	expected := [32]byte{176, 76, 194, 203, 142, 166, 117, 79, 148, 194, 231, 64, 60, 245, 142, 32, 201, 2, 58, 152, 53, 12, 132, 40, 41, 102, 224, 189, 103, 41, 211, 202}

--- a/encoding/ssz/helpers_test.go
+++ b/encoding/ssz/helpers_test.go
@@ -18,13 +18,12 @@ func TestBitlistRoot(t *testing.T) {
 	bfield := bitfield.NewBitlist(capacity)
 	expected := [32]byte{176, 76, 194, 203, 142, 166, 117, 79, 148, 194, 231, 64, 60, 245, 142, 32, 201, 2, 58, 152, 53, 12, 132, 40, 41, 102, 224, 189, 103, 41, 211, 202}
 
-	result, err := ssz.BitlistRoot(hasher, bfield, capacity)
+	result, err := ssz.BitlistRoot(bfield, capacity)
 	require.NoError(t, err)
 	assert.Equal(t, expected, result)
 }
 
 func TestBitwiseMerkleizeOverLimit(t *testing.T) {
-	hasher := hash.CustomSHA256Hasher()
 	chunks := [][32]byte{
 		{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 		{11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
@@ -32,12 +31,11 @@ func TestBitwiseMerkleizeOverLimit(t *testing.T) {
 	count := uint64(2)
 	limit := uint64(1)
 
-	_, err := ssz.BitwiseMerkleize(hasher, chunks, count, limit)
+	_, err := ssz.BitwiseMerkleize(chunks, count, limit)
 	assert.ErrorContains(t, merkleizingListLimitError, err)
 }
 
 func TestBitwiseMerkleizeArrays(t *testing.T) {
-	hasher := hash.CustomSHA256Hasher()
 	chunks := [][32]byte{
 		{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
 		{33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 62, 62, 63, 64},
@@ -46,7 +44,7 @@ func TestBitwiseMerkleizeArrays(t *testing.T) {
 	limit := uint64(2)
 	expected := [32]byte{138, 81, 210, 194, 151, 231, 249, 241, 64, 118, 209, 58, 145, 109, 225, 89, 118, 110, 159, 220, 193, 183, 203, 124, 166, 24, 65, 26, 160, 215, 233, 219}
 
-	result, err := ssz.BitwiseMerkleize(hasher, chunks, count, limit)
+	result, err := ssz.BitwiseMerkleize(chunks, count, limit)
 	require.NoError(t, err)
 	assert.Equal(t, expected, result)
 
@@ -58,13 +56,12 @@ func TestBitwiseMerkleizeArrays(t *testing.T) {
 	limit = uint64(2)
 	expected = [32]byte{194, 32, 213, 52, 220, 127, 18, 240, 43, 151, 19, 79, 188, 175, 142, 177, 208, 46, 96, 20, 18, 231, 208, 29, 120, 102, 122, 17, 46, 31, 155, 30}
 
-	result, err = ssz.BitwiseMerkleize(hasher, chunks, count, limit)
+	result, err = ssz.BitwiseMerkleize(chunks, count, limit)
 	require.NoError(t, err)
 	assert.Equal(t, expected, result)
 }
 
 func TestBitwiseMerkleizeArraysOverLimit(t *testing.T) {
-	hasher := hash.CustomSHA256Hasher()
 	chunks := [][32]byte{
 		{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
 		{33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 62, 62, 63, 64},
@@ -72,7 +69,7 @@ func TestBitwiseMerkleizeArraysOverLimit(t *testing.T) {
 	count := uint64(2)
 	limit := uint64(1)
 
-	_, err := ssz.BitwiseMerkleize(hasher, chunks, count, limit)
+	_, err := ssz.BitwiseMerkleize(chunks, count, limit)
 	assert.ErrorContains(t, merkleizingListLimitError, err)
 }
 

--- a/encoding/ssz/htrutils.go
+++ b/encoding/ssz/htrutils.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/pkg/errors"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	enginev1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
@@ -34,13 +33,13 @@ func ForkRoot(fork *ethpb.Fork) ([32]byte, error) {
 		binary.LittleEndian.PutUint64(forkEpochBuf, uint64(fork.Epoch))
 		fieldRoots[2] = bytesutil.ToBytes32(forkEpochBuf)
 	}
-	return BitwiseMerkleize(hash.CustomSHA256Hasher(), fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
+	return BitwiseMerkleize(fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
 }
 
 // CheckpointRoot computes the HashTreeRoot Merkleization of
 // a InitWithReset struct value according to the Ethereum
 // Simple Serialize specification.
-func CheckpointRoot(hasher HashFn, checkpoint *ethpb.Checkpoint) ([32]byte, error) {
+func CheckpointRoot(checkpoint *ethpb.Checkpoint) ([32]byte, error) {
 	fieldRoots := make([][32]byte, 2)
 	if checkpoint != nil {
 		epochBuf := make([]byte, 8)
@@ -48,7 +47,7 @@ func CheckpointRoot(hasher HashFn, checkpoint *ethpb.Checkpoint) ([32]byte, erro
 		fieldRoots[0] = bytesutil.ToBytes32(epochBuf)
 		fieldRoots[1] = bytesutil.ToBytes32(checkpoint.Root)
 	}
-	return BitwiseMerkleize(hasher, fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
+	return BitwiseMerkleize(fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
 }
 
 // ByteArrayRootWithLimit computes the HashTreeRoot Merkleization of
@@ -59,7 +58,7 @@ func ByteArrayRootWithLimit(roots [][]byte, limit uint64) ([32]byte, error) {
 	for i, r := range roots {
 		copy(newRoots[i][:], r)
 	}
-	result, err := BitwiseMerkleize(hash.CustomSHA256Hasher(), newRoots, uint64(len(newRoots)), limit)
+	result, err := BitwiseMerkleize(newRoots, uint64(len(newRoots)), limit)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute byte array merkleization")
 	}
@@ -88,14 +87,13 @@ func SlashingsRoot(slashings []uint64) ([32]byte, error) {
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not pack slashings into chunks")
 	}
-	return BitwiseMerkleize(hash.CustomSHA256Hasher(), slashingChunks, uint64(len(slashingChunks)), uint64(len(slashingChunks)))
+	return BitwiseMerkleize(slashingChunks, uint64(len(slashingChunks)), uint64(len(slashingChunks)))
 }
 
 // TransactionsRoot computes the HTR for the Transactions' property of the ExecutionPayload
 // The code was largely copy/pasted from the code generated to compute the HTR of the entire
 // ExecutionPayload.
 func TransactionsRoot(txs [][]byte) ([32]byte, error) {
-	hasher := hash.CustomSHA256Hasher()
 	txRoots := make([][32]byte, 0)
 	for i := 0; i < len(txs); i++ {
 		rt, err := transactionRoot(txs[i])
@@ -105,7 +103,7 @@ func TransactionsRoot(txs [][]byte) ([32]byte, error) {
 		txRoots = append(txRoots, rt)
 	}
 
-	bytesRoot, err := BitwiseMerkleize(hasher, txRoots, uint64(len(txRoots)), fieldparams.MaxTxsPerPayloadLength)
+	bytesRoot, err := BitwiseMerkleize(txRoots, uint64(len(txRoots)), fieldparams.MaxTxsPerPayloadLength)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute  merkleization")
 	}
@@ -120,17 +118,17 @@ func TransactionsRoot(txs [][]byte) ([32]byte, error) {
 
 // WithdrawalSliceRoot computes the HTR of a slice of withdrawals.
 // The limit parameter is used as input to the bitwise merkleization algorithm.
-func WithdrawalSliceRoot(hasher HashFn, withdrawals []*enginev1.Withdrawal, limit uint64) ([32]byte, error) {
+func WithdrawalSliceRoot(withdrawals []*enginev1.Withdrawal, limit uint64) ([32]byte, error) {
 	roots := make([][32]byte, len(withdrawals))
 	for i := 0; i < len(withdrawals); i++ {
-		r, err := withdrawalRoot(hasher, withdrawals[i])
+		r, err := withdrawalRoot(withdrawals[i])
 		if err != nil {
 			return [32]byte{}, err
 		}
 		roots[i] = r
 	}
 
-	bytesRoot, err := BitwiseMerkleize(hasher, roots, uint64(len(roots)), limit)
+	bytesRoot, err := BitwiseMerkleize(roots, uint64(len(roots)), limit)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute  merkleization")
 	}
@@ -144,14 +142,13 @@ func WithdrawalSliceRoot(hasher HashFn, withdrawals []*enginev1.Withdrawal, limi
 }
 
 func transactionRoot(tx []byte) ([32]byte, error) {
-	hasher := hash.CustomSHA256Hasher()
 	chunkedRoots, err := PackByChunk([][]byte{tx})
 	if err != nil {
 		return [32]byte{}, err
 	}
 
 	maxLength := (fieldparams.MaxBytesPerTxLength + 31) / 32
-	bytesRoot, err := BitwiseMerkleize(hasher, chunkedRoots, uint64(len(chunkedRoots)), uint64(maxLength))
+	bytesRoot, err := BitwiseMerkleize(chunkedRoots, uint64(len(chunkedRoots)), uint64(maxLength))
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "could not compute merkleization")
 	}
@@ -164,7 +161,7 @@ func transactionRoot(tx []byte) ([32]byte, error) {
 	return MixInLength(bytesRoot, bytesRootBufRoot), nil
 }
 
-func withdrawalRoot(hasher HashFn, w *enginev1.Withdrawal) ([32]byte, error) {
+func withdrawalRoot(w *enginev1.Withdrawal) ([32]byte, error) {
 	fieldRoots := make([][32]byte, 4)
 	if w != nil {
 		binary.LittleEndian.PutUint64(fieldRoots[0][:], w.Index)
@@ -174,5 +171,5 @@ func withdrawalRoot(hasher HashFn, w *enginev1.Withdrawal) ([32]byte, error) {
 		fieldRoots[2] = bytesutil.ToBytes32(w.Address)
 		binary.LittleEndian.PutUint64(fieldRoots[3][:], w.Amount)
 	}
-	return BitwiseMerkleize(hasher, fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
+	return BitwiseMerkleize(fieldRoots, uint64(len(fieldRoots)), uint64(len(fieldRoots)))
 }

--- a/encoding/ssz/htrutils_test.go
+++ b/encoding/ssz/htrutils_test.go
@@ -42,7 +42,7 @@ func TestCheckPointRoot(t *testing.T) {
 	}
 	expected := [32]byte{228, 65, 39, 109, 183, 249, 167, 232, 125, 239, 25, 155, 207, 4, 84, 174, 176, 229, 175, 224, 62, 33, 215, 254, 170, 220, 132, 65, 246, 128, 68, 194}
 
-	result, err := ssz.CheckpointRoot(testHasher, &testCheckpoint)
+	result, err := ssz.CheckpointRoot(&testCheckpoint)
 	require.NoError(t, err)
 	assert.Equal(t, expected, result)
 }
@@ -225,7 +225,7 @@ func TestWithrawalSliceRoot(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hasher := hash.CustomSHA256Hasher()
-			got, err := ssz.WithdrawalSliceRoot(hasher, tt.input, 16)
+			got, err := ssz.WithdrawalSliceRoot(tt.input, 16)
 			require.NoError(t, err)
 			require.DeepSSZEqual(t, tt.want, got)
 		})

--- a/encoding/ssz/htrutils_test.go
+++ b/encoding/ssz/htrutils_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	enginev1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/v3/proto/prysm/v1alpha1"
@@ -35,7 +34,6 @@ func TestForkRoot(t *testing.T) {
 }
 
 func TestCheckPointRoot(t *testing.T) {
-	testHasher := hash.CustomSHA256Hasher()
 	testCheckpoint := ethpb.Checkpoint{
 		Epoch: 1234567890,
 		Root:  []byte{222},
@@ -191,8 +189,7 @@ func TestWithdrawalRoot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hasher := hash.CustomSHA256Hasher()
-			got, err := ssz.WithdrawalRoot(hasher, tt.input)
+			got, err := ssz.WithdrawalRoot(tt.input)
 			require.NoError(t, err)
 			require.DeepSSZEqual(t, tt.want, got)
 		})
@@ -224,7 +221,6 @@ func TestWithrawalSliceRoot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hasher := hash.CustomSHA256Hasher()
 			got, err := ssz.WithdrawalSliceRoot(tt.input, 16)
 			require.NoError(t, err)
 			require.DeepSSZEqual(t, tt.want, got)

--- a/proto/migration/BUILD.bazel
+++ b/proto/migration/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//beacon-chain/state:go_default_library",
         "//config/fieldparams:go_default_library",
         "//consensus-types/interfaces:go_default_library",
-        "//crypto/hash:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//encoding/ssz:go_default_library",
         "//proto/engine/v1:go_default_library",

--- a/proto/migration/v1alpha1_to_v2.go
+++ b/proto/migration/v1alpha1_to_v2.go
@@ -4,7 +4,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state"
 	fieldparams "github.com/prysmaticlabs/prysm/v3/config/fieldparams"
-	"github.com/prysmaticlabs/prysm/v3/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v3/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v3/encoding/ssz"
 	enginev1 "github.com/prysmaticlabs/prysm/v3/proto/engine/v1"
@@ -446,11 +445,7 @@ func V1Alpha1BeaconBlockCapellaToV2Blinded(v1alpha1Block *ethpbalpha.BeaconBlock
 		return nil, errors.Wrapf(err, "could not calculate transactions root")
 	}
 
-	withdrawalsRoot, err := ssz.WithdrawalSliceRoot(
-		hash.CustomSHA256Hasher(),
-		v1alpha1Block.Body.ExecutionPayload.Withdrawals,
-		fieldparams.MaxWithdrawalsPerPayload,
-	)
+	withdrawalsRoot, err := ssz.WithdrawalSliceRoot(v1alpha1Block.Body.ExecutionPayload.Withdrawals, fieldparams.MaxWithdrawalsPerPayload)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not calculate transactions root")
 	}

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -886,7 +886,5 @@ func unmarshalFromFile(ctx context.Context, from string, to interface{}) error {
 }
 
 func configureFastSSZHashingAlgorithm() {
-	if features.Get().EnableVectorizedHTR {
-		fastssz.EnableVectorizedHTR = true
-	}
+	fastssz.EnableVectorizedHTR = true
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature Cleanup

**What does this PR do? Why is it needed?**

This fully deprecates the non-vectorized path for out state hashing routines and makes it the permanent default. The disable flag is added to the deprecated list and all old methods are now removed.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
