### PR TITLE
remove feature flag `--disable-forkchoice-doubly-linked-tree`

### DIFF
--- a/beacon-chain/blockchain/head_test.go
+++ b/beacon-chain/blockchain/head_test.go
@@ -13,7 +13,6 @@ import (
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v3/beacon-chain/forkchoice/types"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/operations/blstoexec"
 	"github.com/prysmaticlabs/prysm/v3/beacon-chain/state/stategen"
-	"github.com/prysmaticlabs/prysm/v3/config/features"
 	"github.com/prysmaticlabs/prysm/v3/config/params"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v3/consensus-types/primitives"
@@ -386,11 +385,6 @@ func TestSaveOrphanedAtts_CanFilter(t *testing.T) {
 }
 
 func TestSaveOrphanedAtts_DoublyLinkedTrie(t *testing.T) {
-	resetCfg := features.InitWithReset(&features.Flags{
-		DisableForkchoiceDoublyLinkedTree: false,
-	})
-	defer resetCfg()
-
 	ctx := context.Background()
 	beaconDB := testDB.SetupDB(t)
 	service := setupBeaconChain(t, beaconDB)
@@ -456,11 +450,6 @@ func TestSaveOrphanedAtts_DoublyLinkedTrie(t *testing.T) {
 }
 
 func TestSaveOrphanedAtts_CanFilter_DoublyLinkedTrie(t *testing.T) {
-	resetCfg := features.InitWithReset(&features.Flags{
-		DisableForkchoiceDoublyLinkedTree: false,
-	})
-	defer resetCfg()
-
 	ctx := context.Background()
 	beaconDB := testDB.SetupDB(t)
 	service := setupBeaconChain(t, beaconDB)

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -62,11 +62,10 @@ type Flags struct {
 	// EnableSlashingProtectionPruning for the validator client.
 	EnableSlashingProtectionPruning bool
 
-	EnableVectorizedHTR               bool // EnableVectorizedHTR specifies whether the beacon state will use the optimized sha256 routines.
-	DisableForkchoiceDoublyLinkedTree bool // DisableForkChoiceDoublyLinkedTree specifies whether fork choice store will use a doubly linked tree.
-	EnableBatchGossipAggregation      bool // EnableBatchGossipAggregation specifies whether to further aggregate our gossip batches before verifying them.
-	SaveFullExecutionPayloads         bool // Save full beacon blocks with execution payloads in the database.
-	EnableStartOptimistic             bool // EnableStartOptimistic treats every block as optimistic at startup.
+	EnableVectorizedHTR          bool // EnableVectorizedHTR specifies whether the beacon state will use the optimized sha256 routines.
+	EnableBatchGossipAggregation bool // EnableBatchGossipAggregation specifies whether to further aggregate our gossip batches before verifying them.
+	SaveFullExecutionPayloads    bool // Save full beacon blocks with execution payloads in the database.
+	EnableStartOptimistic        bool // EnableStartOptimistic treats every block as optimistic at startup.
 
 	DisableStakinContractCheck bool // Disables check for deposit contract when proposing blocks
 
@@ -213,10 +212,6 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 				cfg.EnableVectorizedHTR = true
 			}
 		}
-	}
-	if ctx.Bool(disableForkChoiceDoublyLinkedTree.Name) {
-		logEnabled(disableForkChoiceDoublyLinkedTree)
-		cfg.DisableForkchoiceDoublyLinkedTree = true
 	}
 	cfg.EnableBatchGossipAggregation = true
 	if ctx.Bool(disableGossipBatchAggregation.Name) {

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -92,10 +92,6 @@ var (
 		Name:  "disable-vectorized-htr",
 		Usage: "Disables the new go sha256 library which utilizes optimized routines for merkle trees",
 	}
-	disableForkChoiceDoublyLinkedTree = &cli.BoolFlag{
-		Name:  "disable-forkchoice-doubly-linked-tree",
-		Usage: "Disables the new forkchoice store structure that uses doubly linked trees",
-	}
 	disableGossipBatchAggregation = &cli.BoolFlag{
 		Name:  "disable-gossip-batch-aggregation",
 		Usage: "Disables new methods to further aggregate our gossip batches before verifying them.",
@@ -164,7 +160,6 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	disableStakinContractCheck,
 	disableVecHTR,
 	disableReorgLateBlocks,
-	disableForkChoiceDoublyLinkedTree,
 	disableGossipBatchAggregation,
 	SaveFullExecutionPayloads,
 	enableStartupOptimistic,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Deprecated code remove

**What does this PR do? Why is it needed?**

Doubly linked tree is the only forkchoice store type now,

so the flag `--disable-forkchoice-doubly-linked-tree` is not necessary any more.

