### PR TITLE
Add blob db methods

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -55,6 +55,10 @@ type ReadOnlyDatabase interface {
 	FeeRecipientByValidatorID(ctx context.Context, id primitives.ValidatorIndex) (common.Address, error)
 	RegistrationByValidatorID(ctx context.Context, id primitives.ValidatorIndex) (*ethpb.ValidatorRegistrationV1, error)
 
+	// Blob operations.
+	BlobSidecarsByRoot(ctx context.Context, beaconBlockRoot [32]byte) (*ethpb.BlobSidecars, error)
+	BlobSidecarsBySlot(ctx context.Context, slot primitives.Slot) (*ethpb.BlobSidecars, error)
+
 	// origin checkpoint sync support
 	OriginCheckpointBlockRoot(ctx context.Context) ([32]byte, error)
 	BackfillBlockRoot(ctx context.Context) ([32]byte, error)
@@ -89,6 +93,10 @@ type NoHeadAccessDatabase interface {
 	// Fee recipients operations.
 	SaveFeeRecipientsByValidatorIDs(ctx context.Context, ids []primitives.ValidatorIndex, addrs []common.Address) error
 	SaveRegistrationsByValidatorIDs(ctx context.Context, ids []primitives.ValidatorIndex, regs []*ethpb.ValidatorRegistrationV1) error
+
+	// Blob operations.
+	SaveBlobSidecar(ctx context.Context, blobSidecars *ethpb.BlobSidecars) error
+	DeleteBlobSidecar(ctx context.Context, beaconBlockRoot [32]byte) error
 
 	CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint primitives.Slot) error
 }

--- a/beacon-chain/db/kv/BUILD.bazel
+++ b/beacon-chain/db/kv/BUILD.bazel
@@ -75,6 +75,7 @@ go_test(
     srcs = [
         "archived_point_test.go",
         "backup_test.go",
+        "blob_test.go",
         "blocks_test.go",
         "checkpoint_test.go",
         "deposit_contract_test.go",
@@ -108,6 +109,7 @@ go_test(
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//proto/testing:go_default_library",
         "//testing/assert:go_default_library",

--- a/beacon-chain/db/kv/BUILD.bazel
+++ b/beacon-chain/db/kv/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "archived_point.go",
         "backup.go",
+        "blob.go",
         "blocks.go",
         "checkpoint.go",
         "deposit_contract.go",

--- a/beacon-chain/db/kv/blob.go
+++ b/beacon-chain/db/kv/blob.go
@@ -14,8 +14,6 @@ import (
 	"go.opencensus.io/trace"
 )
 
-const blobSidecarKeyLength = 48 // slot_to_rotating_buffer(blob.slot) ++ blob.slot ++ blob.block_root
-
 // SaveBlobSidecar saves the blobs for a given epoch in the sidecar bucket. When we receive a blob:
 //
 //  1. Convert slot using a modulo operator to [0, maxSlots] where maxSlots = MAX_BLOB_EPOCHS*SLOTS_PER_EPOCH

--- a/beacon-chain/db/kv/blob.go
+++ b/beacon-chain/db/kv/blob.go
@@ -1,0 +1,151 @@
+package kv
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/prysmaticlabs/prysm/v4/config/params"
+	types "github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
+	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	bolt "go.etcd.io/bbolt"
+	"go.opencensus.io/trace"
+)
+
+const blobSidecarKeyLength = 48 // slot_to_rotating_buffer(blob.slot) ++ blob.slot ++ blob.block_root
+
+// SaveBlobSidecar saves the blobs for a given epoch in the sidecar bucket. When we receive a blob:
+//
+//  1. Convert slot using a modulo operator to [0, maxSlots] where maxSlots = MAX_BLOB_EPOCHS*SLOTS_PER_EPOCH
+//
+//  2. Compute key for blob as bytes(slot_to_rotating_buffer(blob.slot)) ++ bytes(blob.slot) ++ blob.block_root
+//
+//  3. Begin the save algorithm:  If the incoming blob has a slot bigger than the saved slot at the spot
+//     in the rotating keys buffer, we overwrite all elements for that slot.
+func (s *Store) SaveBlobSidecar(ctx context.Context, blobSidecars *ethpb.BlobSidecars) error {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.SaveBlobSidecar")
+	defer span.End()
+	return s.db.Update(func(tx *bolt.Tx) error {
+		encodedBlobSidecar, err := encode(ctx, blobSidecars)
+		if err != nil {
+			return err
+		}
+		bkt := tx.Bucket(blobsBucket)
+		c := bkt.Cursor()
+		newKey := blobSidecarKey(blobSidecars.Sidecars[0])
+		rotatingBufferPrefix := newKey[0:8]
+		var replacingKey []byte
+		for k, _ := c.Seek(rotatingBufferPrefix); bytes.HasPrefix(k, rotatingBufferPrefix); k, _ = c.Next() {
+			if len(k) != 0 {
+				replacingKey = k
+				oldSlotBytes := replacingKey[8:16]
+				oldSlot := bytesutil.BytesToSlotBigEndian(oldSlotBytes)
+				if oldSlot >= blobSidecars.Sidecars[0].Slot {
+					return fmt.Errorf("attempted to save blob with slot %d but already have older blob with slot %d", blobSidecars.Sidecars[0].Slot, oldSlot)
+				}
+				break
+			}
+		}
+		// If there is no element stored at blob.slot % MAX_SLOTS_TO_PERSIST_BLOBS, then we simply
+		// store the blob by key and exit early.
+		if len(replacingKey) == 0 {
+			return bkt.Put(newKey, encodedBlobSidecar)
+		}
+
+		if err := bkt.Delete(replacingKey); err != nil {
+			log.WithError(err).Warnf("Could not delete blob with key %#x", replacingKey)
+		}
+		return bkt.Put(newKey, encodedBlobSidecar)
+	})
+}
+
+// BlobSidecarsByRoot retrieves the blobs given a beacon block root.
+func (s *Store) BlobSidecarsByRoot(ctx context.Context, beaconBlockRoot [32]byte) (*ethpb.BlobSidecars, error) {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.BlobSidecarsByRoot")
+	defer span.End()
+
+	var enc []byte
+	if err := s.db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket(blobsBucket).Cursor()
+		// Bucket size is bounded and bolt cursors are fast. Moreover, a thin caching layer can be added.
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if len(k) != blobSidecarKeyLength {
+				continue
+			}
+			if bytes.HasSuffix(k, beaconBlockRoot[:]) {
+				enc = v
+				break
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	sidecars := &ethpb.BlobSidecars{}
+	if err := decode(ctx, enc, sidecars); err != nil {
+		return nil, err
+	}
+	return sidecars, nil
+}
+
+// BlobSidecarsBySlot retrieves sidecars from a slot.
+func (s *Store) BlobSidecarsBySlot(ctx context.Context, slot types.Slot) (*ethpb.BlobSidecars, error) {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.BlobSidecarsBySlot")
+	defer span.End()
+
+	var enc []byte
+	if err := s.db.View(func(tx *bolt.Tx) error {
+		c := tx.Bucket(blobsBucket).Cursor()
+		// Bucket size is bounded and bolt cursors are fast. Moreover, a thin caching layer can be added.
+		for k, v := c.First(); k != nil; k, v = c.Next() {
+			if len(k) != blobSidecarKeyLength {
+				continue
+			}
+			slotInKey := bytesutil.BytesToSlotBigEndian(k[8:16])
+			if slotInKey == slot {
+				enc = v
+				break
+			}
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	sidecars := &ethpb.BlobSidecars{}
+	if err := decode(ctx, enc, sidecars); err != nil {
+		return nil, err
+	}
+	return sidecars, nil
+}
+
+// DeleteBlobSidecar returns true if the blobs are in the db.
+func (s *Store) DeleteBlobSidecar(ctx context.Context, beaconBlockRoot [32]byte) error {
+	ctx, span := trace.StartSpan(ctx, "BeaconDB.DeleteBlobSidecar")
+	defer span.End()
+	return s.db.Update(func(tx *bolt.Tx) error {
+		bkt := tx.Bucket(blobsBucket)
+		c := bkt.Cursor()
+		for k, _ := c.First(); k != nil; k, _ = c.Next() {
+			if bytes.HasSuffix(k, beaconBlockRoot[:]) {
+				if err := bkt.Delete(k); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}
+
+// We define a blob sidecar key as: bytes(slot_to_rotating_buffer(blob.slot)) ++ bytes(blob.slot) ++ blob.block_root
+// where slot_to_rotating_buffer(slot) = slot % MAX_SLOTS_TO_PERSIST_BLOBS.
+func blobSidecarKey(blob *ethpb.BlobSidecar) []byte {
+	slotsPerEpoch := params.BeaconConfig().SlotsPerEpoch
+	maxEpochsToPersistBlobs := params.BeaconNetworkConfig().MinEpochsForBlobsSidecarsRequest
+	maxSlotsToPersistBlobs := types.Slot(maxEpochsToPersistBlobs.Mul(uint64(slotsPerEpoch)))
+	slotInRotatingBuffer := blob.Slot.ModSlot(maxSlotsToPersistBlobs)
+	key := bytesutil.SlotToBytesBigEndian(slotInRotatingBuffer)
+	key = append(key, bytesutil.SlotToBytesBigEndian(blob.Slot)...)
+	key = append(key, blob.BlockRoot...)
+	return key
+}

--- a/beacon-chain/db/kv/blob_test.go
+++ b/beacon-chain/db/kv/blob_test.go
@@ -15,24 +15,27 @@ import (
 )
 
 func TestStore_BlobSidecars(t *testing.T) {
-	db := setupDB(t)
 	ctx := context.Background()
 
 	t.Run("empty", func(t *testing.T) {
+		db := setupDB(t)
 		scs := generateBlobSidecars(t, 0)
 		require.ErrorContains(t, "nil or empty blob sidecars", db.SaveBlobSidecar(ctx, scs))
 	})
 	t.Run("empty by root", func(t *testing.T) {
+		db := setupDB(t)
 		got, err := db.BlobSidecarsByRoot(ctx, [32]byte{})
 		require.NoError(t, err)
 		require.DeepEqual(t, (*ethpb.BlobSidecars)(nil), got)
 	})
 	t.Run("empty by slot", func(t *testing.T) {
+		db := setupDB(t)
 		got, err := db.BlobSidecarsBySlot(ctx, 1)
 		require.NoError(t, err)
 		require.DeepEqual(t, (*ethpb.BlobSidecars)(nil), got)
 	})
 	t.Run("save and retrieve by root (one)", func(t *testing.T) {
+		db := setupDB(t)
 		scs := generateBlobSidecars(t, 1)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
 		require.Equal(t, 1, len(scs.Sidecars))
@@ -42,15 +45,17 @@ func TestStore_BlobSidecars(t *testing.T) {
 		require.DeepEqual(t, scs, got)
 	})
 	t.Run("save and retrieve by root (max)", func(t *testing.T) {
+		db := setupDB(t)
 		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
-		require.Equal(t, params.BeaconConfig().MaxBlobsPerBlock, len(scs.Sidecars))
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
 		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
 		require.NoError(t, err)
-		require.Equal(t, params.BeaconConfig().MaxBlobsPerBlock, len(got.Sidecars))
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(got.Sidecars))
 		require.DeepEqual(t, scs, got)
 	})
 	t.Run("save and retrieve by slot (one)", func(t *testing.T) {
+		db := setupDB(t)
 		scs := generateBlobSidecars(t, 1)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
 		require.Equal(t, 1, len(scs.Sidecars))
@@ -60,6 +65,7 @@ func TestStore_BlobSidecars(t *testing.T) {
 		require.DeepEqual(t, scs, got)
 	})
 	t.Run("save and retrieve by slot (max)", func(t *testing.T) {
+		db := setupDB(t)
 		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
 		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
@@ -69,6 +75,7 @@ func TestStore_BlobSidecars(t *testing.T) {
 		require.DeepEqual(t, scs, got)
 	})
 	t.Run("delete works", func(t *testing.T) {
+		db := setupDB(t)
 		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
 		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
@@ -82,6 +89,7 @@ func TestStore_BlobSidecars(t *testing.T) {
 		require.DeepEqual(t, (*ethpb.BlobSidecars)(nil), got)
 	})
 	t.Run("saving a blob with older slot", func(t *testing.T) {
+		db := setupDB(t)
 		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
 		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
@@ -92,6 +100,7 @@ func TestStore_BlobSidecars(t *testing.T) {
 		require.ErrorContains(t, "but already have older blob with slot", db.SaveBlobSidecar(ctx, scs))
 	})
 	t.Run("saving a new blob for rotation", func(t *testing.T) {
+		db := setupDB(t)
 		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
 		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))

--- a/beacon-chain/db/kv/blob_test.go
+++ b/beacon-chain/db/kv/blob_test.go
@@ -1,0 +1,168 @@
+package kv
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v4/config/params"
+	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
+	enginev1 "github.com/prysmaticlabs/prysm/v4/proto/engine/v1"
+	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/testing/require"
+)
+
+func TestStore_BlobSidecars(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	t.Run("empty", func(t *testing.T) {
+		scs := generateBlobSidecars(t, 0)
+		require.ErrorContains(t, "nil or empty blob sidecars", db.SaveBlobSidecar(ctx, scs))
+	})
+	t.Run("empty by root", func(t *testing.T) {
+		got, err := db.BlobSidecarsByRoot(ctx, [32]byte{})
+		require.NoError(t, err)
+		require.DeepEqual(t, (*ethpb.BlobSidecars)(nil), got)
+	})
+	t.Run("empty by slot", func(t *testing.T) {
+		got, err := db.BlobSidecarsBySlot(ctx, 1)
+		require.NoError(t, err)
+		require.DeepEqual(t, (*ethpb.BlobSidecars)(nil), got)
+	})
+	t.Run("save and retrieve by root (one)", func(t *testing.T) {
+		scs := generateBlobSidecars(t, 1)
+		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
+		require.Equal(t, 1, len(scs.Sidecars))
+		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.NoError(t, err)
+		require.Equal(t, 1, len(got.Sidecars))
+		require.DeepEqual(t, scs, got)
+	})
+	t.Run("save and retrieve by root (max)", func(t *testing.T) {
+		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
+		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
+		require.Equal(t, params.BeaconConfig().MaxBlobsPerBlock, len(scs.Sidecars))
+		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.NoError(t, err)
+		require.Equal(t, params.BeaconConfig().MaxBlobsPerBlock, len(got.Sidecars))
+		require.DeepEqual(t, scs, got)
+	})
+	t.Run("save and retrieve by slot (one)", func(t *testing.T) {
+		scs := generateBlobSidecars(t, 1)
+		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
+		require.Equal(t, 1, len(scs.Sidecars))
+		got, err := db.BlobSidecarsBySlot(ctx, scs.Sidecars[0].Slot)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(got.Sidecars))
+		require.DeepEqual(t, scs, got)
+	})
+	t.Run("save and retrieve by slot (max)", func(t *testing.T) {
+		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
+		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
+		got, err := db.BlobSidecarsBySlot(ctx, scs.Sidecars[0].Slot)
+		require.NoError(t, err)
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(got.Sidecars))
+		require.DeepEqual(t, scs, got)
+	})
+	t.Run("delete works", func(t *testing.T) {
+		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
+		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
+		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.NoError(t, err)
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(got.Sidecars))
+		require.DeepEqual(t, scs, got)
+		require.NoError(t, db.DeleteBlobSidecar(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot)))
+		got, err = db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.NoError(t, err)
+		require.DeepEqual(t, (*ethpb.BlobSidecars)(nil), got)
+	})
+	t.Run("saving a blob with older slot", func(t *testing.T) {
+		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
+		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
+		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.NoError(t, err)
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(got.Sidecars))
+		require.DeepEqual(t, scs, got)
+		require.ErrorContains(t, "but already have older blob with slot", db.SaveBlobSidecar(ctx, scs))
+	})
+	t.Run("saving a new blob for rotation", func(t *testing.T) {
+		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
+		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
+		oldBlockRoot := scs.Sidecars[0].BlockRoot
+		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.NoError(t, err)
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(got.Sidecars))
+		require.DeepEqual(t, scs, got)
+
+		newScs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
+		newRetentionSlot := primitives.Slot(params.BeaconNetworkConfig().MinEpochsForBlobsSidecarsRequest.Mul(uint64(params.BeaconConfig().SlotsPerEpoch)))
+		newScs.Sidecars[0].Slot = scs.Sidecars[0].Slot + newRetentionSlot
+		require.NoError(t, db.SaveBlobSidecar(ctx, newScs))
+
+		got, err = db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(oldBlockRoot))
+		require.NoError(t, err)
+		require.DeepEqual(t, (*ethpb.BlobSidecars)(nil), got)
+
+		got, err = db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(newScs.Sidecars[0].BlockRoot))
+		require.NoError(t, err)
+		require.DeepEqual(t, newScs, got)
+	})
+}
+
+func generateBlobSidecars(t *testing.T, n uint64) *ethpb.BlobSidecars {
+	blobSidecars := make([]*ethpb.BlobSidecar, n)
+	for i := uint64(0); i < n; i++ {
+		blobSidecars[i] = generateBlobSidecar(t)
+	}
+	return &ethpb.BlobSidecars{
+		Sidecars: blobSidecars,
+	}
+}
+
+func generateBlobSidecar(t *testing.T) *ethpb.BlobSidecar {
+	blockRoot := make([]byte, 32)
+	_, err := rand.Read(blockRoot)
+	require.NoError(t, err)
+	index := make([]byte, 8)
+	_, err = rand.Read(index)
+	require.NoError(t, err)
+	slot := make([]byte, 8)
+	_, err = rand.Read(slot)
+	require.NoError(t, err)
+	blockParentRoot := make([]byte, 32)
+	_, err = rand.Read(blockParentRoot)
+	require.NoError(t, err)
+	proposerIndex := make([]byte, 8)
+	_, err = rand.Read(proposerIndex)
+	require.NoError(t, err)
+	blobData := make([]byte, 131072)
+	_, err = rand.Read(blobData)
+	require.NoError(t, err)
+	blob := &enginev1.Blob{
+		Data: blobData,
+	}
+	kzgCommitment := make([]byte, 48)
+	_, err = rand.Read(kzgCommitment)
+	require.NoError(t, err)
+	kzgProof := make([]byte, 48)
+	_, err = rand.Read(kzgProof)
+	require.NoError(t, err)
+
+	return &ethpb.BlobSidecar{
+		BlockRoot:       blockRoot,
+		Index:           binary.LittleEndian.Uint64(index),
+		Slot:            primitives.Slot(binary.LittleEndian.Uint64(slot)),
+		BlockParentRoot: blockParentRoot,
+		ProposerIndex:   primitives.ValidatorIndex(binary.LittleEndian.Uint64(proposerIndex)),
+		Blob:            blob,
+		KzgCommitment:   kzgCommitment,
+		KzgProof:        kzgProof,
+	}
+}

--- a/proto/prysm/v1alpha1/blobs.pb.go
+++ b/proto/prysm/v1alpha1/blobs.pb.go
@@ -24,6 +24,53 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type BlobSidecars struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Sidecars []*BlobSidecar `protobuf:"bytes,1,rep,name=sidecars,proto3" json:"sidecars,omitempty"`
+}
+
+func (x *BlobSidecars) Reset() {
+	*x = BlobSidecars{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[0]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *BlobSidecars) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BlobSidecars) ProtoMessage() {}
+
+func (x *BlobSidecars) ProtoReflect() protoreflect.Message {
+	mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[0]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BlobSidecars.ProtoReflect.Descriptor instead.
+func (*BlobSidecars) Descriptor() ([]byte, []int) {
+	return file_proto_prysm_v1alpha1_blobs_proto_rawDescGZIP(), []int{0}
+}
+
+func (x *BlobSidecars) GetSidecars() []*BlobSidecar {
+	if x != nil {
+		return x.Sidecars
+	}
+	return nil
+}
+
 type BlobSidecar struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -42,7 +89,7 @@ type BlobSidecar struct {
 func (x *BlobSidecar) Reset() {
 	*x = BlobSidecar{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[0]
+		mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[1]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -55,7 +102,7 @@ func (x *BlobSidecar) String() string {
 func (*BlobSidecar) ProtoMessage() {}
 
 func (x *BlobSidecar) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[0]
+	mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[1]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68,7 +115,7 @@ func (x *BlobSidecar) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlobSidecar.ProtoReflect.Descriptor instead.
 func (*BlobSidecar) Descriptor() ([]byte, []int) {
-	return file_proto_prysm_v1alpha1_blobs_proto_rawDescGZIP(), []int{0}
+	return file_proto_prysm_v1alpha1_blobs_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *BlobSidecar) GetBlockRoot() []byte {
@@ -139,7 +186,7 @@ type SignedBlobSidecar struct {
 func (x *SignedBlobSidecar) Reset() {
 	*x = SignedBlobSidecar{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[1]
+		mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[2]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -152,7 +199,7 @@ func (x *SignedBlobSidecar) String() string {
 func (*SignedBlobSidecar) ProtoMessage() {}
 
 func (x *SignedBlobSidecar) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[1]
+	mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[2]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -165,7 +212,7 @@ func (x *SignedBlobSidecar) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SignedBlobSidecar.ProtoReflect.Descriptor instead.
 func (*SignedBlobSidecar) Descriptor() ([]byte, []int) {
-	return file_proto_prysm_v1alpha1_blobs_proto_rawDescGZIP(), []int{1}
+	return file_proto_prysm_v1alpha1_blobs_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *SignedBlobSidecar) GetMessage() *BlobSidecar {
@@ -194,7 +241,7 @@ type BlobIdentifier struct {
 func (x *BlobIdentifier) Reset() {
 	*x = BlobIdentifier{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[2]
+		mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[3]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -207,7 +254,7 @@ func (x *BlobIdentifier) String() string {
 func (*BlobIdentifier) ProtoMessage() {}
 
 func (x *BlobIdentifier) ProtoReflect() protoreflect.Message {
-	mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[2]
+	mi := &file_proto_prysm_v1alpha1_blobs_proto_msgTypes[3]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -220,7 +267,7 @@ func (x *BlobIdentifier) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlobIdentifier.ProtoReflect.Descriptor instead.
 func (*BlobIdentifier) Descriptor() ([]byte, []int) {
-	return file_proto_prysm_v1alpha1_blobs_proto_rawDescGZIP(), []int{2}
+	return file_proto_prysm_v1alpha1_blobs_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *BlobIdentifier) GetBlockRoot() []byte {
@@ -247,7 +294,12 @@ var file_proto_prysm_v1alpha1_blobs_proto_rawDesc = []byte{
 	0x2f, 0x65, 0x74, 0x68, 0x2f, 0x65, 0x78, 0x74, 0x2f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73,
 	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x26, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x65, 0x6e,
 	0x67, 0x69, 0x6e, 0x65, 0x2f, 0x76, 0x31, 0x2f, 0x65, 0x78, 0x65, 0x63, 0x75, 0x74, 0x69, 0x6f,
-	0x6e, 0x5f, 0x65, 0x6e, 0x67, 0x69, 0x6e, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0xd3,
+	0x6e, 0x5f, 0x65, 0x6e, 0x67, 0x69, 0x6e, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x4e,
+	0x0a, 0x0c, 0x42, 0x6c, 0x6f, 0x62, 0x53, 0x69, 0x64, 0x65, 0x63, 0x61, 0x72, 0x73, 0x12, 0x3e,
+	0x0a, 0x08, 0x73, 0x69, 0x64, 0x65, 0x63, 0x61, 0x72, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b,
+	0x32, 0x22, 0x2e, 0x65, 0x74, 0x68, 0x65, 0x72, 0x65, 0x75, 0x6d, 0x2e, 0x65, 0x74, 0x68, 0x2e,
+	0x76, 0x31, 0x61, 0x6c, 0x70, 0x68, 0x61, 0x31, 0x2e, 0x42, 0x6c, 0x6f, 0x62, 0x53, 0x69, 0x64,
+	0x65, 0x63, 0x61, 0x72, 0x52, 0x08, 0x73, 0x69, 0x64, 0x65, 0x63, 0x61, 0x72, 0x73, 0x22, 0xd3,
 	0x03, 0x0a, 0x0b, 0x42, 0x6c, 0x6f, 0x62, 0x53, 0x69, 0x64, 0x65, 0x63, 0x61, 0x72, 0x12, 0x25,
 	0x0a, 0x0a, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x5f, 0x72, 0x6f, 0x6f, 0x74, 0x18, 0x01, 0x20, 0x01,
 	0x28, 0x0c, 0x42, 0x06, 0x8a, 0xb5, 0x18, 0x02, 0x33, 0x32, 0x52, 0x09, 0x62, 0x6c, 0x6f, 0x63,
@@ -314,21 +366,23 @@ func file_proto_prysm_v1alpha1_blobs_proto_rawDescGZIP() []byte {
 	return file_proto_prysm_v1alpha1_blobs_proto_rawDescData
 }
 
-var file_proto_prysm_v1alpha1_blobs_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_proto_prysm_v1alpha1_blobs_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_proto_prysm_v1alpha1_blobs_proto_goTypes = []interface{}{
-	(*BlobSidecar)(nil),       // 0: ethereum.eth.v1alpha1.BlobSidecar
-	(*SignedBlobSidecar)(nil), // 1: ethereum.eth.v1alpha1.SignedBlobSidecar
-	(*BlobIdentifier)(nil),    // 2: ethereum.eth.v1alpha1.BlobIdentifier
-	(*v1.Blob)(nil),           // 3: ethereum.engine.v1.Blob
+	(*BlobSidecars)(nil),      // 0: ethereum.eth.v1alpha1.BlobSidecars
+	(*BlobSidecar)(nil),       // 1: ethereum.eth.v1alpha1.BlobSidecar
+	(*SignedBlobSidecar)(nil), // 2: ethereum.eth.v1alpha1.SignedBlobSidecar
+	(*BlobIdentifier)(nil),    // 3: ethereum.eth.v1alpha1.BlobIdentifier
+	(*v1.Blob)(nil),           // 4: ethereum.engine.v1.Blob
 }
 var file_proto_prysm_v1alpha1_blobs_proto_depIdxs = []int32{
-	3, // 0: ethereum.eth.v1alpha1.BlobSidecar.blob:type_name -> ethereum.engine.v1.Blob
-	0, // 1: ethereum.eth.v1alpha1.SignedBlobSidecar.message:type_name -> ethereum.eth.v1alpha1.BlobSidecar
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	1, // 0: ethereum.eth.v1alpha1.BlobSidecars.sidecars:type_name -> ethereum.eth.v1alpha1.BlobSidecar
+	4, // 1: ethereum.eth.v1alpha1.BlobSidecar.blob:type_name -> ethereum.engine.v1.Blob
+	1, // 2: ethereum.eth.v1alpha1.SignedBlobSidecar.message:type_name -> ethereum.eth.v1alpha1.BlobSidecar
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_proto_prysm_v1alpha1_blobs_proto_init() }
@@ -338,7 +392,7 @@ func file_proto_prysm_v1alpha1_blobs_proto_init() {
 	}
 	if !protoimpl.UnsafeEnabled {
 		file_proto_prysm_v1alpha1_blobs_proto_msgTypes[0].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*BlobSidecar); i {
+			switch v := v.(*BlobSidecars); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -350,7 +404,7 @@ func file_proto_prysm_v1alpha1_blobs_proto_init() {
 			}
 		}
 		file_proto_prysm_v1alpha1_blobs_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*SignedBlobSidecar); i {
+			switch v := v.(*BlobSidecar); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -362,6 +416,18 @@ func file_proto_prysm_v1alpha1_blobs_proto_init() {
 			}
 		}
 		file_proto_prysm_v1alpha1_blobs_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*SignedBlobSidecar); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_proto_prysm_v1alpha1_blobs_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*BlobIdentifier); i {
 			case 0:
 				return &v.state
@@ -380,7 +446,7 @@ func file_proto_prysm_v1alpha1_blobs_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_proto_prysm_v1alpha1_blobs_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/prysm/v1alpha1/blobs.proto
+++ b/proto/prysm/v1alpha1/blobs.proto
@@ -25,6 +25,10 @@ option java_outer_classname = "BlobsProto";
 option java_package = "org.ethereum.eth.v1alpha1";
 option php_namespace = "Ethereum\\Eth\\v1alpha1";
 
+message BlobSidecars {
+    repeated BlobSidecar sidecars = 1;
+}
+
 message BlobSidecar {
         bytes block_root = 1 [(ethereum.eth.ext.ssz_size) = "32"];
         uint64 index = 2;


### PR DESCRIPTION
Add db methods to store blobs.

- New prysm-only container `BlobSidecars`. Easier than passing around and hashing individual `BlobSidecar`. We can assume everything stores in the DB is verified and complete
- New getters `BlobSidecarsByRoot` and  `BlobSidecarsBySlot`
- New getters `SaveBlobSidecar` and `DeleteBlobSidecar`
- `SaveBlobSidecar` rotates by converting slot using a modulo operator. In other words, we write over the old blob rather than delete the blob for free list. Kudos to @rauljordan for this idea