### PR TITLE
add missing field to proto copy helper

### DIFF
--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -316,6 +316,7 @@ func (b *SignedBeaconBlock) ToBlinded() (interfaces.ReadOnlySignedBeaconBlock, e
 						SyncAggregate:          b.block.body.syncAggregate,
 						ExecutionPayloadHeader: header,
 						BlsToExecutionChanges:  b.block.body.blsToExecutionChanges,
+						BlobKzgCommitments:     b.block.body.blobKzgCommitments,
 					},
 				},
 				Signature: b.signature[:],


### PR DESCRIPTION


**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**

The helper to get the blinded form copies the unblinded block field-by-field. It was missing the `BlobKzgCommitments` field, which resulted in deneb block db save -> read round trips to lose their `BlobKzgCommitments` value.
