### PR TITLE
Revert deprecated removal of revert-blinded-beacon-blocks-flag-removal

### DIFF
--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -32,6 +32,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedEnableOnlyBlindedBeaconBlocks = &cli.BoolFlag{
+		Name:   "enable-only-blinded-beacon-blocks",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 // Deprecated flags for both the beacon node and validator client.
@@ -45,4 +50,6 @@ var deprecatedFlags = []cli.Flag{
 
 // deprecatedBeaconFlags contains flags that are still used by other components
 // and therefore cannot be added to deprecatedFlags
-var deprecatedBeaconFlags = []cli.Flag{}
+var deprecatedBeaconFlags = []cli.Flag{
+	deprecatedEnableOnlyBlindedBeaconBlocks,
+}


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Revert deprecated flag removal

**What does this PR do? Why is it needed?**

I'm not sure if we had give it enough time before removing `enable-only-blinded-beacon-blocks` which is a no-op. This may confuse users. Opening the PR to discuss whether we should be adding this no-op flag back for V4

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
