### PR TITLE
Faster and cached square root

### DIFF
--- a/beacon-chain/core/altair/epoch_precompute.go
+++ b/beacon-chain/core/altair/epoch_precompute.go
@@ -265,7 +265,7 @@ func AttestationsDelta(beaconState state.BeaconState, bal *precompute.Balance, v
 	finalizedEpoch := beaconState.FinalizedCheckpointEpoch()
 	increment := cfg.EffectiveBalanceIncrement
 	factor := cfg.BaseRewardFactor
-	baseRewardMultiplier := increment * factor / math.IntegerSquareRoot(bal.ActiveCurrentEpoch)
+	baseRewardMultiplier := increment * factor / math.SquareRootEffectiveBalance(bal.ActiveCurrentEpoch)
 	leak := helpers.IsInInactivityLeak(prevEpoch, finalizedEpoch)
 
 	// Modified in Altair and Bellatrix.

--- a/beacon-chain/core/altair/reward.go
+++ b/beacon-chain/core/altair/reward.go
@@ -58,5 +58,5 @@ func BaseRewardPerIncrement(activeBalance uint64) (uint64, error) {
 		return 0, errors.New("active balance can't be 0")
 	}
 	cfg := params.BeaconConfig()
-	return cfg.EffectiveBalanceIncrement * cfg.BaseRewardFactor / math.IntegerSquareRoot(activeBalance), nil
+	return cfg.EffectiveBalanceIncrement * cfg.BaseRewardFactor / math.SquareRootEffectiveBalance(activeBalance), nil
 }

--- a/beacon-chain/core/epoch/precompute/reward_penalty.go
+++ b/beacon-chain/core/epoch/precompute/reward_penalty.go
@@ -72,7 +72,7 @@ func AttestationsDelta(state state.ReadOnlyBeaconState, pBal *Balance, vp []*Val
 	prevEpoch := time.PrevEpoch(state)
 	finalizedEpoch := state.FinalizedCheckpointEpoch()
 
-	sqrtActiveCurrentEpoch := math.IntegerSquareRoot(pBal.ActiveCurrentEpoch)
+	sqrtActiveCurrentEpoch := math.SquareRootEffectiveBalance(pBal.ActiveCurrentEpoch)
 	for i, v := range vp {
 		rewards[i], penalties[i] = attestationDelta(pBal, sqrtActiveCurrentEpoch, v, prevEpoch, finalizedEpoch)
 	}
@@ -161,7 +161,7 @@ func ProposersDelta(state state.ReadOnlyBeaconState, pBal *Balance, vp []*Valida
 	rewards := make([]uint64, numofVals)
 
 	totalBalance := pBal.ActiveCurrentEpoch
-	balanceSqrt := math.IntegerSquareRoot(totalBalance)
+	balanceSqrt := math.SquareRootEffectiveBalance(totalBalance)
 	// Balance square root cannot be 0, this prevents division by 0.
 	if balanceSqrt == 0 {
 		balanceSqrt = 1

--- a/math/math_helper.go
+++ b/math/math_helper.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	stdmath "math"
 	"math/bits"
+	"sync"
 
 	"github.com/thomaso-mirodin/intmath/u64"
 )
@@ -26,6 +27,12 @@ var (
 	ErrMulOverflow  = errors.New("multiplication overflows")
 	ErrAddOverflow  = errors.New("addition overflows")
 	ErrSubUnderflow = errors.New("subtraction underflow")
+
+	// Sensible guess for 500 000 validators
+	cachedSquareRoot = struct {
+		sync.Mutex
+		squareRoot, balance uint64
+	}{squareRoot: 126491106, balance: 15999999897103236}
 )
 
 // Common square root values.
@@ -41,6 +48,25 @@ var squareRootTable = map[uint64]uint64{
 	262144:  512,
 	1048576: 1024,
 	4194304: 2048,
+}
+
+// SquareRootEffectiveBalance implements Newton's algorithm to compute the square root of
+// the given uint64 starting from the last cached value
+func SquareRootEffectiveBalance(balance uint64) uint64 {
+	cachedSquareRoot.Lock()
+	defer cachedSquareRoot.Unlock()
+	if balance == cachedSquareRoot.balance {
+		return cachedSquareRoot.squareRoot
+	}
+	cachedSquareRoot.balance = balance
+	val := balance / cachedSquareRoot.squareRoot
+	for {
+		cachedSquareRoot.squareRoot = (cachedSquareRoot.squareRoot + val) / 2
+		val = balance / cachedSquareRoot.squareRoot
+		if cachedSquareRoot.squareRoot <= val {
+			return cachedSquareRoot.squareRoot
+		}
+	}
 }
 
 // IntegerSquareRoot defines a function that returns the

--- a/math/math_helper_test.go
+++ b/math/math_helper_test.go
@@ -82,6 +82,7 @@ func TestIntegerSquareRoot(t *testing.T) {
 
 	for _, testVals := range tt {
 		require.Equal(t, testVals.root, math.IntegerSquareRoot(testVals.number))
+		require.Equal(t, testVals.root, math.SquareRootEffectiveBalance(testVals.number))
 	}
 }
 
@@ -164,6 +165,35 @@ func BenchmarkIntegerSquareRootAbove52Bits(b *testing.B) {
 	val := uint64(1 << 62)
 	for i := 0; i < b.N; i++ {
 		require.Equal(b, uint64(1<<31), math.IntegerSquareRoot(val))
+	}
+}
+
+func BenchmarkSquareRootEffectiveBalance(b *testing.B) {
+	val := uint64(1 << 62)
+	for i := 0; i < b.N; i++ {
+		require.Equal(b, uint64(1<<31), math.SquareRootEffectiveBalance(val))
+	}
+}
+
+func BenchmarkSquareRootBabylonian(b *testing.B) {
+	//Start with 700K validators' effective balance
+	val := uint64(22400000000000000)
+	for i := 0; i < b.N; i++ {
+		sqr := math.SquareRootEffectiveBalance(val)
+		require.Equal(b, true, sqr^2 <= val)
+		require.Equal(b, true, (sqr+1)*(sqr+1) > val)
+		val += 10_000_000_000
+	}
+}
+
+func BenchmarkSquareRootOldWay(b *testing.B) {
+	//Start with 700K validators' effective balance
+	val := uint64(22400000000000000)
+	for i := 0; i < b.N; i++ {
+		sqr := math.IntegerSquareRoot(val)
+		require.Equal(b, true, sqr^2 <= val)
+		require.Equal(b, true, (sqr+1)*(sqr+1) > val)
+		val += 10_000_000_000
 	}
 }
 


### PR DESCRIPTION
This PR adds a different method to compute the integer square root of a number. It first uses a simple mutex and a cache for the last computation done. If there is a cache miss, then it uses simple Newton approximation to find the new square root.

## Rationale:

Square roots of total balances are computed when computing 
- AttestationsDeltas in the epoch precompute.
- When computing the base reward per increment (this is used when computing several rewards)

In all cases we pass the total effective balance of validators that were active in the current epoch. This number stays constant throughout the epoch and changes slowly, by multiples of 10**9 Gwei, on epoch transitions. 

This makes us believe that a single value cache is already good enough to avoid this computation on block processing, as the effective balance will not change intra-epoch. And In case of a cache miss, we can start a Newton approximation with the latest cached value that is guaranteed to be close to the actual value. 

## Possible improvemnents:
- We could use a map with 2 or three cached values given that in some places we use only balances that have participated in the current or previous epoch (for attestation rewards for example) and in others we use the full active balance. 
- We could improve the Newton approximation by using the fact that balances only change in multiples of 1ETH instead of arbitrary integer numbers. We felt the complication of this would give us very little gain

## Some Benchmarks
Below there are some benchmarks on a AMD Ryzen 5 3600.  On computing raw square roots for over 52 bits our method is about x2.3 faster, that is comparable with Golang's square root computation for numbers under 52 bits. 

```
-----------------------------------------------------------------------------
goos: linux
goarch: amd64
cpu: AMD Ryzen 5 3600 6-Core Processor
BenchmarkIntegerSquareRootBelow52Bits-12       	34503249	        59.55 ns/op
BenchmarkIntegerSquareRootAbove52Bits-12       	11731746	        97.91 ns/op
BenchmarkSquareRootEffectiveBalance-12         	35858377	        46.14 ns/op
BenchmarkSquareRootBabylonian-12               	41247252	        27.98 ns/op
BenchmarkSquareRootOldWay-12                   	21897693	        55.02 ns/op
BenchmarkIntegerSquareRoot_WithDatatable-12    	85549964	        14.38 ns/op
PASS
```