### PR TITLE
WIP: BlobDB changes

### DIFF
--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -56,8 +56,8 @@ type ReadOnlyDatabase interface {
 	RegistrationByValidatorID(ctx context.Context, id primitives.ValidatorIndex) (*ethpb.ValidatorRegistrationV1, error)
 
 	// Blob operations.
-	BlobSidecarsByRoot(ctx context.Context, beaconBlockRoot [32]byte) (*ethpb.BlobSidecars, error)
-	BlobSidecarsBySlot(ctx context.Context, slot primitives.Slot) (*ethpb.BlobSidecars, error)
+	BlobSidecarsByRoot(ctx context.Context, beaconBlockRoot [32]byte) ([]*ethpb.BlobSidecar, error)
+	BlobSidecarsBySlot(ctx context.Context, slot primitives.Slot) ([]*ethpb.BlobSidecar, error)
 
 	// origin checkpoint sync support
 	OriginCheckpointBlockRoot(ctx context.Context) ([32]byte, error)
@@ -95,7 +95,7 @@ type NoHeadAccessDatabase interface {
 	SaveRegistrationsByValidatorIDs(ctx context.Context, ids []primitives.ValidatorIndex, regs []*ethpb.ValidatorRegistrationV1) error
 
 	// Blob operations.
-	SaveBlobSidecar(ctx context.Context, blobSidecars *ethpb.BlobSidecars) error
+	SaveBlobSidecar(ctx context.Context, sidecars []*ethpb.BlobSidecar) error
 	DeleteBlobSidecar(ctx context.Context, beaconBlockRoot [32]byte) error
 
 	CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint primitives.Slot) error

--- a/beacon-chain/db/kv/blob_test.go
+++ b/beacon-chain/db/kv/blob_test.go
@@ -4,15 +4,34 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	enginev1 "github.com/prysmaticlabs/prysm/v4/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/testing/assertions"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
 )
+
+func equalBlobSlices(expect []*ethpb.BlobSidecar, got []*ethpb.BlobSidecar) error {
+	if len(expect) != len(got) {
+		return fmt.Errorf("mismatched lengths, expect=%d, got=%d", len(expect), len(got))
+	}
+	for i := 0; i < len(expect); i++ {
+		es := expect[i]
+		gs := got[i]
+		var e string
+		assertions.DeepEqual(assertions.SprintfAssertionLoggerFn(&e), es, gs)
+		if e != "" {
+			return errors.New(e)
+		}
+	}
+	return nil
+}
 
 func TestStore_BlobSidecars(t *testing.T) {
 	ctx := context.Background()
@@ -24,111 +43,105 @@ func TestStore_BlobSidecars(t *testing.T) {
 	})
 	t.Run("empty by root", func(t *testing.T) {
 		db := setupDB(t)
-		_, err := db.BlobSidecarsByRoot(ctx, [32]byte{})
+		got, err := db.BlobSidecarsByRoot(ctx, [32]byte{})
 		require.ErrorIs(t, ErrNotFound, err)
+		require.Equal(t, 0, len(got))
 	})
 	t.Run("empty by slot", func(t *testing.T) {
 		db := setupDB(t)
-		_, err := db.BlobSidecarsBySlot(ctx, 1)
+		got, err := db.BlobSidecarsBySlot(ctx, 1)
 		require.ErrorIs(t, ErrNotFound, err)
+		require.Equal(t, 0, len(got))
 	})
 	t.Run("save and retrieve by root (one)", func(t *testing.T) {
 		db := setupDB(t)
 		scs := generateBlobSidecars(t, 1)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
-		require.Equal(t, 1, len(scs.Sidecars))
-		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.Equal(t, 1, len(scs))
+		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs[0].BlockRoot))
 		require.NoError(t, err)
-		require.Equal(t, 1, len(got.Sidecars))
-		require.DeepEqual(t, scs, got)
+		require.NoError(t, equalBlobSlices(scs, got))
 	})
 	t.Run("save and retrieve by root (max)", func(t *testing.T) {
 		db := setupDB(t)
 		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
-		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
-		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs))
+		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs[0].BlockRoot))
 		require.NoError(t, err)
-		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(got.Sidecars))
-		require.DeepEqual(t, scs, got)
+		require.NoError(t, equalBlobSlices(scs, got))
 	})
 	t.Run("save and retrieve by slot (one)", func(t *testing.T) {
 		db := setupDB(t)
 		scs := generateBlobSidecars(t, 1)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
-		require.Equal(t, 1, len(scs.Sidecars))
-		got, err := db.BlobSidecarsBySlot(ctx, scs.Sidecars[0].Slot)
+		require.Equal(t, 1, len(scs))
+		got, err := db.BlobSidecarsBySlot(ctx, scs[0].Slot)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(got.Sidecars))
-		require.DeepEqual(t, scs, got)
+		require.NoError(t, equalBlobSlices(scs, got))
 	})
 	t.Run("save and retrieve by slot (max)", func(t *testing.T) {
 		db := setupDB(t)
 		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
-		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
-		got, err := db.BlobSidecarsBySlot(ctx, scs.Sidecars[0].Slot)
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs))
+		got, err := db.BlobSidecarsBySlot(ctx, scs[0].Slot)
 		require.NoError(t, err)
-		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(got.Sidecars))
-		require.DeepEqual(t, scs, got)
+		require.NoError(t, equalBlobSlices(scs, got))
 	})
 	t.Run("delete works", func(t *testing.T) {
 		db := setupDB(t)
 		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
-		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
-		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs))
+		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs[0].BlockRoot))
 		require.NoError(t, err)
-		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(got.Sidecars))
-		require.DeepEqual(t, scs, got)
-		require.NoError(t, db.DeleteBlobSidecar(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot)))
-		_, err = db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.NoError(t, equalBlobSlices(scs, got))
+		require.NoError(t, db.DeleteBlobSidecar(ctx, bytesutil.ToBytes32(scs[0].BlockRoot)))
+		got, err = db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs[0].BlockRoot))
 		require.ErrorIs(t, ErrNotFound, err)
+		require.Equal(t, 0, len(got))
 	})
 	t.Run("saving a blob with older slot", func(t *testing.T) {
 		db := setupDB(t)
 		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
-		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
-		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs))
+		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs[0].BlockRoot))
 		require.NoError(t, err)
-		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(got.Sidecars))
-		require.DeepEqual(t, scs, got)
+		require.NoError(t, equalBlobSlices(scs, got))
 		require.ErrorContains(t, "but already have older blob with slot", db.SaveBlobSidecar(ctx, scs))
 	})
 	t.Run("saving a new blob for rotation", func(t *testing.T) {
 		db := setupDB(t)
 		scs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		require.NoError(t, db.SaveBlobSidecar(ctx, scs))
-		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs.Sidecars))
-		oldBlockRoot := scs.Sidecars[0].BlockRoot
-		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs.Sidecars[0].BlockRoot))
+		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(scs))
+		oldBlockRoot := scs[0].BlockRoot
+		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(oldBlockRoot))
 		require.NoError(t, err)
-		require.Equal(t, int(params.BeaconConfig().MaxBlobsPerBlock), len(got.Sidecars))
-		require.DeepEqual(t, scs, got)
+		require.NoError(t, equalBlobSlices(scs, got))
 
 		newScs := generateBlobSidecars(t, params.BeaconConfig().MaxBlobsPerBlock)
 		newRetentionSlot := primitives.Slot(params.BeaconNetworkConfig().MinEpochsForBlobsSidecarsRequest.Mul(uint64(params.BeaconConfig().SlotsPerEpoch)))
-		newScs.Sidecars[0].Slot = scs.Sidecars[0].Slot + newRetentionSlot
+		newScs[0].Slot = scs[0].Slot + newRetentionSlot
 		require.NoError(t, db.SaveBlobSidecar(ctx, newScs))
 
 		_, err = db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(oldBlockRoot))
 		require.ErrorIs(t, ErrNotFound, err)
 
-		got, err = db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(newScs.Sidecars[0].BlockRoot))
+		got, err = db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(newScs[0].BlockRoot))
 		require.NoError(t, err)
-		require.DeepEqual(t, newScs, got)
+		require.NoError(t, equalBlobSlices(newScs, got))
 	})
 }
 
-func generateBlobSidecars(t *testing.T, n uint64) *ethpb.BlobSidecars {
+func generateBlobSidecars(t *testing.T, n uint64) []*ethpb.BlobSidecar {
 	blobSidecars := make([]*ethpb.BlobSidecar, n)
 	for i := uint64(0); i < n; i++ {
 		blobSidecars[i] = generateBlobSidecar(t)
 	}
-	return &ethpb.BlobSidecars{
-		Sidecars: blobSidecars,
-	}
+	return blobSidecars
 }
 
 func generateBlobSidecar(t *testing.T) *ethpb.BlobSidecar {

--- a/beacon-chain/sync/blobs_test.go
+++ b/beacon-chain/sync/blobs_test.go
@@ -217,10 +217,7 @@ func (c *blobsTestCase) run(t *testing.T) {
 		m[sc.sidecar.Slot] = append(m[sc.sidecar.Slot], sc.sidecar)
 	}
 	for _, blobSidecars := range m {
-		err := s.cfg.beaconDB.SaveBlobSidecar(context.Background(), &ethpb.BlobSidecars{
-			Sidecars: blobSidecars,
-		})
-		require.NoError(t, err)
+		require.NoError(t, s.cfg.beaconDB.SaveBlobSidecar(context.Background(), blobSidecars))
 	}
 	if c.total != nil {
 		require.Equal(t, *c.total, len(expect))

--- a/beacon-chain/sync/rpc_blob_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_range.go
@@ -34,7 +34,7 @@ func (s *Service) streamBlobBatch(ctx context.Context, batch blockBatch, stream 
 			s.writeErrorResponseToStream(responseCodeServerError, p2ptypes.ErrGeneric.Error(), stream)
 			return writes, errors.Wrapf(err, "could not retrieve sidecars for block root %#x", root)
 		}
-		for _, sc := range scs.Sidecars {
+		for _, sc := range scs {
 			SetStreamWriteDeadline(stream, defaultWriteDuration)
 			if chunkErr := WriteBlobSidecarChunk(stream, s.cfg.chain, s.cfg.p2p.Encoding(), sc); chunkErr != nil {
 				log.WithError(chunkErr).Debug("Could not send a chunked response")

--- a/beacon-chain/sync/rpc_blob_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_root.go
@@ -58,10 +58,10 @@ func (s *Service) blobSidecarByRootRPCHandler(ctx context.Context, msg interface
 			s.writeErrorResponseToStream(responseCodeServerError, types.ErrGeneric.Error(), stream)
 			return err
 		}
-		if idx >= uint64(len(scs.Sidecars)) {
+		if idx >= uint64(len(scs)) {
 			continue
 		}
-		sc := scs.Sidecars[idx]
+		sc := scs[idx]
 
 		// If any root in the request content references a block earlier than minimum_request_epoch,
 		// peers MAY respond with error code 3: ResourceUnavailable or not include the blob in the response.

--- a/beacon-chain/sync/subscriber_beacon_blocks.go
+++ b/beacon-chain/sync/subscriber_beacon_blocks.go
@@ -81,9 +81,7 @@ func (s *Service) receiveBlockAndBlobs(ctx context.Context, root [32]byte) error
 			"root":      fmt.Sprintf("%#x", scs[0].BlockRoot),
 			"blobCount": len(scs),
 		}).Info("Saving blobs")
-		if err := s.cfg.beaconDB.SaveBlobSidecar(ctx, &eth.BlobSidecars{
-			Sidecars: scs,
-		}); err != nil {
+		if err := s.cfg.beaconDB.SaveBlobSidecar(ctx, scs); err != nil {
 			return err
 		}
 	}

--- a/testing/assertions/assertions.go
+++ b/testing/assertions/assertions.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 
 	"github.com/d4l3k/messagediff"
@@ -21,6 +22,12 @@ type AssertionTestingTB interface {
 }
 
 type assertionLoggerFn func(string, ...interface{})
+
+func SprintfAssertionLoggerFn(s *string) assertionLoggerFn {
+	return func(ef string, eargs ...interface{}) {
+		*s = fmt.Sprintf(ef, eargs...)
+	}
+}
 
 // Equal compares values using comparison operator.
 func Equal(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...interface{}) {
@@ -45,9 +52,42 @@ func DeepEqual(loggerFn assertionLoggerFn, expected, actual interface{}, msg ...
 	if !isDeepEqual(expected, actual) {
 		errMsg := parseMsg("Values are not equal", msg...)
 		_, file, line, _ := runtime.Caller(2)
-		diff, _ := messagediff.PrettyDiff(expected, actual)
+		diff := ""
+		if _, isProto := expected.(proto.Message); isProto {
+			diff = ProtobufPrettyDiff(expected, actual)
+		} else {
+			diff, _ = messagediff.PrettyDiff(expected, actual)
+		}
 		loggerFn("%s:%d %s, want: %#v, got: %#v, diff: %s", filepath.Base(file), line, errMsg, expected, actual, diff)
 	}
+}
+
+var protobufPrivateFields = map[string]bool{
+	"sizeCache": true,
+	"state":     true,
+}
+
+func ProtobufPrettyDiff(a, b interface{}) string {
+	d, _ := messagediff.DeepDiff(a, b)
+	var dstr []string
+	appendNotProto := func(path, str string) {
+		parts := strings.Split(path, ".")
+		if len(parts) > 1 && protobufPrivateFields[parts[1]] {
+			return
+		}
+		dstr = append(dstr, str)
+	}
+	for path, added := range d.Added {
+		appendNotProto(path.String(), fmt.Sprintf("added: %s = %#v\n", path.String(), added))
+	}
+	for path, removed := range d.Removed {
+		appendNotProto(path.String(), fmt.Sprintf("removed: %s = %#v\n", path.String(), removed))
+	}
+	for path, modified := range d.Modified {
+		appendNotProto(path.String(), fmt.Sprintf("modified: %s = %#v\n", path.String(), modified))
+	}
+	sort.Strings(dstr)
+	return strings.Join(dstr, "")
 }
 
 // DeepNotEqual compares values using DeepEqual.


### PR DESCRIPTION
Other

**What does this PR do? Why is it needed?**

- Changes blobs db interfaces to use []*ethpb.BlobSidecar rather than the *ethpb.BlobSidecars container which wraps a slice in a struct for ssz marshaling / db ser/des purposes (no need to expose that type outside db internals)
- adds a variadic `indices` option to `BlobSidecarsByRoot` to allow retrieval of individual sidecars. At this time this just filters out things already read from the db but in the future I want to reorg the db schema to store indices separately so we don't have to read all of them at once in cases where we just want one index.