### PR TITLE
Fallback in Update Head On Error

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -133,6 +133,7 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 	newHeadRoot, err := s.cfg.ForkChoiceStore.Head(ctx)
 	if err != nil {
 		log.WithError(err).Error("Could not compute head from new attestations")
+		return
 	}
 	newAttHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
 

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -133,7 +133,8 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 	newHeadRoot, err := s.cfg.ForkChoiceStore.Head(ctx)
 	if err != nil {
 		log.WithError(err).Error("Could not compute head from new attestations")
-		return
+		// Fallback to our current head root in the event of a failure.
+		newHeadRoot = s.headRoot()
 	}
 	newAttHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
 


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

If a `Head` call to our forkchoice store fails for any reason ( context deadlines, context cancellations,etc) , we should 
fallback on update head to our old head root. Otherwise this would lead to us updating head with a `zerohash` root.

**Which issues(s) does this PR fix?**

Found by Antithesis during its simulation.

**Other notes for review**
