### PR TITLE
Blob by root fixes

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -335,9 +335,16 @@ func (vs *Server) proposeGenericBeaconBlock(ctx context.Context, req *ethpb.Gene
 		if !ok {
 			return nil, status.Error(codes.Internal, "Could not cast block to Deneb")
 		}
-		for _, sidecar := range b.Deneb.Blobs {
+		scs := make([]*ethpb.BlobSidecar, len(b.Deneb.Blobs))
+		for i, sidecar := range b.Deneb.Blobs {
+			scs[i] = sidecar.Message
 			if err := vs.P2P.BroadcastBlob(ctx, sidecar.Message.Index, sidecar); err != nil {
 				return nil, errors.Wrap(err, "could not broadcast blob sidecar")
+			}
+		}
+		if len(scs) > 0 {
+			if err := vs.BeaconDB.SaveBlobSidecar(ctx, scs); err != nil {
+				return nil, errors.Wrap(err, "could not save blob sidecar")
 			}
 		}
 	}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -58,7 +58,8 @@ func (s *Service) sendRecentBeaconBlocksAndBlobsRequest(ctx context.Context, blo
 		return nil
 	}
 
-	blobs, err := SendBlobSidecarByRoot(ctx, s.cfg.chain, s.cfg.p2p, id, reqs)
+	req := types.BlobSidecarsByRootReq(reqs)
+	blobs, err := SendBlobSidecarByRoot(ctx, s.cfg.chain, s.cfg.p2p, id, &req)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/sync/rpc_blob_sidecars_by_range_test.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_range_test.go
@@ -82,6 +82,9 @@ func (c *blobsTestCase) runTestBlobSidecarsByRange(t *testing.T) {
 	if c.oldestSlot == nil {
 		c.oldestSlot = c.defaultOldestSlotByRange
 	}
+	if c.streamReader == nil {
+		c.streamReader = defaultExpectedRequirer
+	}
 	c.run(t)
 }
 

--- a/beacon-chain/sync/rpc_blob_sidecars_by_root.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_root.go
@@ -52,6 +52,7 @@ func (s *Service) blobSidecarByRootRPCHandler(ctx context.Context, msg interface
 		scs, err := s.cfg.beaconDB.BlobSidecarsByRoot(ctx, root)
 		if err != nil {
 			if errors.Is(err, db.ErrNotFound) {
+				log.WithError(err).Errorf("error retrieving BlobSidecar, root=%x, index=%d", root, idx)
 				continue
 			}
 			log.WithError(err).Debugf("error retrieving BlobSidecar, root=%x, index=%d", root, idx)
@@ -80,5 +81,6 @@ func (s *Service) blobSidecarByRootRPCHandler(ctx context.Context, msg interface
 		}
 		s.rateLimiter.add(stream, 1)
 	}
+	closeStream(stream, log)
 	return nil
 }

--- a/beacon-chain/sync/rpc_chunked_response.go
+++ b/beacon-chain/sync/rpc_chunked_response.go
@@ -92,15 +92,15 @@ func ReadChunkedBlock(stream libp2pcore.Stream, chain blockchain.ForkFetcher, p2
 // WriteBlobSidecarChunk writes blob chunk object to stream.
 // response_chunk  ::= <result> | <context-bytes> | <encoding-dependent-header> | <encoded-payload>
 func WriteBlobSidecarChunk(stream libp2pcore.Stream, chain blockchain.ChainInfoFetcher, encoding encoder.NetworkEncoding, sidecar *ethpb.BlobSidecar) error {
-	if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
-		return err
-	}
 	valRoot := chain.GenesisValidatorsRoot()
 	ctxBytes, err := forks.ForkDigestFromEpoch(slots.ToEpoch(sidecar.GetSlot()), valRoot[:])
 	if err != nil {
 		return err
 	}
 
+	if _, err := stream.Write([]byte{responseCodeSuccess}); err != nil {
+		return err
+	}
 	if err := writeContextToStream(ctxBytes[:], stream, chain); err != nil {
 		return err
 	}

--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -7,7 +7,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
-	ssz "github.com/prysmaticlabs/fastssz"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/p2p/encoder"
@@ -152,8 +151,6 @@ func SendBlobSidecarByRoot(
 }
 
 var ErrBlobChunkedReadFailure = errors.New("failed to read stream of chunk-encoded blobs")
-
-type readerSSZDecoder func(io.Reader, ssz.Unmarshaler) error
 
 func readChunkEncodedBlobs(stream network.Stream, ff blockchain.ForkFetcher, encoding encoder.NetworkEncoding) ([]*pb.BlobSidecar, error) {
 	decode := encoding.DecodeWithMaxLength

--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"io"
 
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
+	ssz "github.com/prysmaticlabs/fastssz"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/p2p"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/p2p/encoder"
 	p2ptypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/p2p/types"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
@@ -132,27 +135,58 @@ func SendBeaconBlocksByRootRequest(
 
 func SendBlobSidecarByRoot(
 	ctx context.Context, ci blockchain.ChainInfoFetcher, p2pApi p2p.P2P, pid peer.ID,
-	req p2ptypes.BlobSidecarsByRootReq,
+	req *p2ptypes.BlobSidecarsByRootReq,
 ) ([]*pb.BlobSidecar, error) {
 	topic, err := p2p.TopicFromMessage(p2p.BlobSidecarsByRootName, slots.ToEpoch(ci.CurrentSlot()))
 	if err != nil {
 		return nil, err
 	}
+	log.WithField("topic", topic).Debug("Sending blob sidecar request")
 	stream, err := p2pApi.Send(ctx, req, topic, pid)
 	if err != nil {
 		return nil, err
 	}
 	defer closeStream(stream, log)
 
-	sidecars := make([]*pb.BlobSidecar, 0, len(req))
+	return readChunkEncodedBlobs(stream, ci, p2pApi.Encoding())
+}
 
-	max := params.BeaconNetworkConfig().MaxRequestBlobsSidecars * params.BeaconConfig().MaxBlobsPerBlock
-	for i := 0; i < len(req); i++ {
-		// Exit if peer sends more than MAX_REQUEST_BLOBS_SIDECARS.
-		if uint64(i) >= max {
+var ErrBlobChunkedReadFailure = errors.New("failed to read stream of chunk-encoded blobs")
+
+type readerSSZDecoder func(io.Reader, ssz.Unmarshaler) error
+
+func readChunkEncodedBlobs(stream network.Stream, ff blockchain.ForkFetcher, encoding encoder.NetworkEncoding) ([]*pb.BlobSidecar, error) {
+	decode := encoding.DecodeWithMaxLength
+	max := int(params.BeaconNetworkConfig().MaxRequestBlobsSidecars)
+	var (
+		code uint8
+		msg  string
+		err  error
+	)
+	sidecars := make([]*pb.BlobSidecar, 0)
+	for i := 0; i < max; i++ {
+		code, msg, err = ReadStatusCode(stream, encoding)
+		if err != nil {
 			break
 		}
-		// TODO: Read sidecar
+		if code != 0 {
+			return nil, errors.Wrap(ErrBlobChunkedReadFailure, msg)
+		}
+		// TODO: we should add some code to switch on the fork version to determine deserialization type
+		// punting to rush this out to unblock testing.
+		_, err = readContextFromStream(stream, ff)
+		if err != nil {
+			return nil, errors.Wrap(err, "error reading chunk context bytes from stream")
+		}
+
+		sc := &pb.BlobSidecar{}
+		if err := decode(stream, sc); err != nil {
+			return nil, errors.Wrap(err, "failed to decode the protobuf-encoded BlobSidecar message from RPC chunk stream")
+		}
+		sidecars = append(sidecars, sc)
+	}
+	if !errors.Is(err, io.EOF) {
+		return nil, err
 	}
 	return sidecars, nil
 }


### PR DESCRIPTION
This PR extracts the fixes from #12184 

We got blob by root end to end testing to work at the end with several fixes:
- Validator correctly saves blobs to the DB
- Using the correct encoding and decoding for blob chunk
- Properly closing the stream