### PR TITLE
Enable Static Peer ID

### DIFF
--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -538,6 +538,7 @@ func (b *BeaconNode) registerP2P(cliCtx *cli.Context) error {
 		HostAddress:       cliCtx.String(cmd.P2PHost.Name),
 		HostDNS:           cliCtx.String(cmd.P2PHostDNS.Name),
 		PrivateKey:        cliCtx.String(cmd.P2PPrivKey.Name),
+		StaticPeerID:      cliCtx.Bool(cmd.P2PStaticID.Name),
 		MetaDataDir:       cliCtx.String(cmd.P2PMetadata.Name),
 		TCPPort:           cliCtx.Uint(cmd.P2PTCPPort.Name),
 		UDPPort:           cliCtx.Uint(cmd.P2PUDPPort.Name),

--- a/beacon-chain/p2p/config.go
+++ b/beacon-chain/p2p/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	NoDiscovery         bool
 	EnableUPnP          bool
+	StaticPeerID        bool
 	StaticPeers         []string
 	BootstrapNodeAddr   []string
 	Discv5BootStrapAddr []string

--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"net"
 	"os"
+	"path"
 	"testing"
 
 	gethCrypto "github.com/ethereum/go-ethereum/crypto"
@@ -44,6 +45,32 @@ func TestPrivateKeyLoading(t *testing.T) {
 	newPkey, err := ecdsaprysm.ConvertToInterfacePrivkey(pKey)
 	require.NoError(t, err)
 	rawBytes, err := key.Raw()
+	require.NoError(t, err)
+	newRaw, err := newPkey.Raw()
+	require.NoError(t, err)
+	assert.DeepEqual(t, rawBytes, newRaw, "Private keys do not match")
+}
+
+func TestPrivateKeyLoading_StaticPrivateKey(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	tempDir := t.TempDir()
+
+	cfg := &Config{
+		StaticPeerID: true,
+		DataDir:      tempDir,
+	}
+	pKey, err := privKey(cfg)
+	require.NoError(t, err, "Could not apply option")
+
+	newPkey, err := ecdsaprysm.ConvertToInterfacePrivkey(pKey)
+	require.NoError(t, err)
+
+	retrievedKey, err := privKeyFromFile(path.Join(tempDir, keyPath))
+	require.NoError(t, err)
+	retrievedPKey, err := ecdsaprysm.ConvertToInterfacePrivkey(retrievedKey)
+	require.NoError(t, err)
+
+	rawBytes, err := retrievedPKey.Raw()
 	require.NoError(t, err)
 	newRaw, err := newPkey.Raw()
 	require.NoError(t, err)

--- a/beacon-chain/p2p/utils.go
+++ b/beacon-chain/p2p/utils.go
@@ -49,34 +49,43 @@ func privKey(cfg *Config) (*ecdsa.PrivateKey, error) {
 	defaultKeyPath := path.Join(cfg.DataDir, keyPath)
 	privateKeyPath := cfg.PrivateKey
 
+	// PrivateKey cli flag takes highest precedence.
+	if privateKeyPath != "" {
+		return privKeyFromFile(cfg.PrivateKey)
+	}
+
 	_, err := os.Stat(defaultKeyPath)
 	defaultKeysExist := !os.IsNotExist(err)
 	if err != nil && defaultKeysExist {
 		return nil, err
 	}
-
-	if privateKeyPath == "" && !defaultKeysExist {
-		priv, _, err := crypto.GenerateSecp256k1Key(rand.Reader)
+	// Default keys have the next highest precendence, if they exist.
+	if defaultKeysExist {
+		return privKeyFromFile(defaultKeyPath)
+	}
+	// There are no keys on the filesystem, so we need to generate one.
+	priv, _, err := crypto.GenerateSecp256k1Key(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	// If the StaticPeerID flag is set, save the generated key as the default
+	// key, so that it will be used by default on the next node start.
+	if cfg.StaticPeerID {
+		rawbytes, err := priv.Raw()
 		if err != nil {
 			return nil, err
 		}
-		if cfg.StaticPeerID {
-			rawbytes, err := priv.Raw()
-			if err != nil {
-				return nil, err
-			}
-			dst := make([]byte, hex.EncodedLen(len(rawbytes)))
-			hex.Encode(dst, rawbytes)
-			if err := file.WriteFile(defaultKeyPath, dst); err != nil {
-				return nil, err
-			}
+		dst := make([]byte, hex.EncodedLen(len(rawbytes)))
+		hex.Encode(dst, rawbytes)
+		if err := file.WriteFile(defaultKeyPath, dst); err != nil {
+			return nil, err
 		}
-		return ecdsaprysm.ConvertFromInterfacePrivKey(priv)
+		log.Infof("Wrote network key to file")
+		// Read the key from the defaultKeyPath file just written
+		// for the strongest guarantee that the next start will be the same as this one.
+		return privKeyFromFile(defaultKeyPath)
 	}
-	if defaultKeysExist && privateKeyPath == "" {
-		privateKeyPath = defaultKeyPath
-	}
-	return privKeyFromFile(privateKeyPath)
+	return ecdsaprysm.ConvertFromInterfacePrivKey(priv)
 }
 
 // Retrieves a p2p networking private key from a file path.

--- a/beacon-chain/p2p/utils.go
+++ b/beacon-chain/p2p/utils.go
@@ -60,6 +60,17 @@ func privKey(cfg *Config) (*ecdsa.PrivateKey, error) {
 		if err != nil {
 			return nil, err
 		}
+		if cfg.StaticPeerID {
+			rawbytes, err := priv.Raw()
+			if err != nil {
+				return nil, err
+			}
+			dst := make([]byte, hex.EncodedLen(len(rawbytes)))
+			hex.Encode(dst, rawbytes)
+			if err := file.WriteFile(defaultKeyPath, dst); err != nil {
+				return nil, err
+			}
+		}
 		return ecdsaprysm.ConvertFromInterfacePrivKey(priv)
 	}
 	if defaultKeysExist && privateKeyPath == "" {

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -89,6 +89,7 @@ var appFlags = []cli.Flag{
 	cmd.P2PHostDNS,
 	cmd.P2PMaxPeers,
 	cmd.P2PPrivKey,
+	cmd.P2PStaticID,
 	cmd.P2PMetadata,
 	cmd.P2PAllowList,
 	cmd.P2PDenyList,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -149,6 +149,7 @@ var appHelpFlagGroups = []flagGroup{
 			cmd.P2PHostDNS,
 			cmd.P2PMaxPeers,
 			cmd.P2PPrivKey,
+			cmd.P2PStaticID,
 			cmd.P2PMetadata,
 			cmd.P2PAllowList,
 			cmd.P2PDenyList,

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -144,6 +144,11 @@ var (
 		Usage: "The file containing the private key to use in communications with other peers.",
 		Value: "",
 	}
+	P2PStaticID = &cli.BoolFlag{
+		Name:  "p2p-static-id",
+		Usage: "Enables the peer id of the node to be fixed by saving the generated network key to the default key path.",
+		Value: false,
+	}
 	// P2PMetadata defines a flag to specify the location of the peer metadata file.
 	P2PMetadata = &cli.StringFlag{
 		Name:  "p2p-metadata",


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

In the event a node operator wants to keep their peer id fixed, they can run prysm with this flag. This flag will persist 
any generated network key to disk. In the event a peer restarts their node, they will have the same peer id as in their previous run. As a added note, `p2p-priv-key` will take precedence to the default key path in the event it is used in conjunction with the static peer id flag.

**Which issues(s) does this PR fix?**
N.A

**Other notes for review**
