### PR TITLE
Add flag to boost local block value

### DIFF
--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -67,9 +67,9 @@ func configureBuilderCircuitBreaker(cliCtx *cli.Context) error {
 			return err
 		}
 	}
-	if cliCtx.IsSet(flags.BuildBidFraction.Name) {
+	if cliCtx.IsSet(flags.LocalBlockValueBoost.Name) {
 		c := params.BeaconConfig().Copy()
-		c.BuildBidFraction = cliCtx.Float64(flags.BuildBidFraction.Name)
+		c.LocalBlockValueBoost = cliCtx.Uint64(flags.LocalBlockValueBoost.Name)
 		if err := params.SetActive(c); err != nil {
 			return err
 		}

--- a/beacon-chain/node/config.go
+++ b/beacon-chain/node/config.go
@@ -67,6 +67,13 @@ func configureBuilderCircuitBreaker(cliCtx *cli.Context) error {
 			return err
 		}
 	}
+	if cliCtx.IsSet(flags.BuildBidFraction.Name) {
+		c := params.BeaconConfig().Copy()
+		c.BuildBidFraction = cliCtx.Float64(flags.BuildBidFraction.Name)
+		if err := params.SetActive(c); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/pkg/errors"
@@ -61,14 +60,16 @@ func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBea
 					return errors.Wrap(err, "failed to get execution payload")
 				}
 				// Compare payload values between local and builder. Default to the local value if it is higher.
-				localValue, err := localPayload.Value()
+				v, err := localPayload.Value()
 				if err != nil {
 					return errors.Wrap(err, "failed to get local payload value")
 				}
-				builderValue, err := builderPayload.Value()
+				localValue := v.Uint64()
+				v, err = builderPayload.Value()
 				if err != nil {
 					log.WithError(err).Warn("Proposer: failed to get builder payload value") // Default to local if can't get builder value.
 				}
+				builderValue := v.Uint64()
 
 				withdrawalsMatched, err := matchingWithdrawalsRoot(localPayload, builderPayload)
 				if err != nil {
@@ -77,14 +78,11 @@ func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBea
 
 				// Use builder payload if the following in true:
 				// builder_bid_value * 100 > local_block_value * (local-block-value-boost + 100)
-				builderValue.Mul(builderValue, big.NewInt(100))
-
-				localValueWithBoost := big.NewInt(100)
-				localValueWithBoost = localValueWithBoost.Add(localValueWithBoost, big.NewInt(int64(params.BeaconConfig().LocalBlockValueBoost)))
-				localValueWithBoost.Mul(localValue, localValueWithBoost)
+				boost := params.BeaconConfig().LocalBlockValueBoost
+				higherValueBuilder := builderValue*100 > localValue*(100+boost)
 
 				// If we can't get the builder value, just use local block.
-				if builderValue.Cmp(localValueWithBoost) > 0 && withdrawalsMatched { // Builder value is higher and withdrawals match.
+				if higherValueBuilder && withdrawalsMatched { // Builder value is higher and withdrawals match.
 					blk.SetBlinded(true)
 					if err := blk.SetExecution(builderPayload); err != nil {
 						log.WithError(err).Warn("Proposer: failed to set builder payload")
@@ -93,9 +91,9 @@ func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBea
 					}
 				}
 				log.WithFields(logrus.Fields{
-					"localValue":              localValue,
-					"localValueWithBoost*100": localValueWithBoost,
-					"builderValue*100":        builderValue,
+					"localGweiValue":       localValue,
+					"localBoostPercentage": 100 + boost,
+					"builderGweiValue":     builderValue,
 				}).Warn("Proposer: using local execution payload because higher value")
 				return blk.SetExecution(localPayload)
 			default: // Bellatrix case.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -90,11 +90,13 @@ func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBea
 						return nil
 					}
 				}
-				log.WithFields(logrus.Fields{
-					"localGweiValue":       localValue,
-					"localBoostPercentage": 100 + boost,
-					"builderGweiValue":     builderValue,
-				}).Warn("Proposer: using local execution payload because higher value")
+				if !higherValueBuilder {
+					log.WithFields(logrus.Fields{
+						"localGweiValue":       localValue,
+						"localBoostPercentage": 100 + boost,
+						"builderGweiValue":     builderValue,
+					}).Warn("Proposer: using local execution payload because higher value")
+				}
 				return blk.SetExecution(localPayload)
 			default: // Bellatrix case.
 				blk.SetBlinded(true)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -92,12 +92,10 @@ func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBea
 						return nil
 					}
 				}
-				localValueWithBoost.Div(localValueWithBoost, big.NewInt(100))
-				builderValue.Div(builderValue, big.NewInt(100))
 				log.WithFields(logrus.Fields{
-					"localValue":          localValue,
-					"localValueWithBoost": localValueWithBoost,
-					"builderValue":        builderValue,
+					"localValue":              localValue,
+					"localValueWithBoost*100": localValueWithBoost,
+					"builderValue*100":        builderValue,
 				}).Warn("Proposer: using local execution payload because higher value")
 				return blk.SetExecution(localPayload)
 			default: // Bellatrix case.
@@ -330,7 +328,7 @@ func (vs *Server) unblindBuilderBlock(ctx context.Context, b interfaces.ReadOnly
 func validateBuilderSignature(signedBid builder.SignedBid) error {
 	d, err := signing.ComputeDomain(params.BeaconConfig().DomainApplicationBuilder,
 		nil, /* fork version */
-		nil  /* genesis val root */)
+		nil /* genesis val root */)
 	if err != nil {
 		return err
 	}

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -27,6 +27,11 @@ var (
 		Usage: "Number of total skip slot to fallback from using relay/builder to local execution engine for block construction in last epoch rolling window",
 		Value: 8,
 	}
+	BuildBidFraction = &cli.Float64Flag{
+		Name:  "builder-bid-fraction",
+		Usage: "Fraction to multiple builder bid value with. Use builder bid if (builder_bid * bid_fraction) > local block value",
+		Value: 1,
+	}
 	// ExecutionEngineEndpoint provides an HTTP access endpoint to connect to an execution client on the execution layer
 	ExecutionEngineEndpoint = &cli.StringFlag{
 		Name:  "execution-endpoint",

--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -27,10 +27,10 @@ var (
 		Usage: "Number of total skip slot to fallback from using relay/builder to local execution engine for block construction in last epoch rolling window",
 		Value: 8,
 	}
-	BuildBidFraction = &cli.Float64Flag{
-		Name:  "builder-bid-fraction",
-		Usage: "Fraction to multiple builder bid value with. Use builder bid if (builder_bid * bid_fraction) > local block value",
-		Value: 1,
+	LocalBlockValueBoost = &cli.Float64Flag{
+		Name: "local-block-value-boost",
+		Usage: "A percentage boost for local block construction. This is used to prioritize local block construction over relay/builder block construction" +
+			"Boost is an additional percentage to multiple local block value. Use builder block if: builder_bid_value * 100 > local_block_value * (local-block-value-boost + 100)",
 	}
 	// ExecutionEngineEndpoint provides an HTTP access endpoint to connect to an execution client on the execution layer
 	ExecutionEngineEndpoint = &cli.StringFlag{

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -207,7 +207,7 @@ type BeaconChainConfig struct {
 	// Mev-boost circuit breaker
 	MaxBuilderConsecutiveMissedSlots primitives.Slot // MaxBuilderConsecutiveMissedSlots defines the number of consecutive skip slot to fallback from using relay/builder to local execution engine for block construction.
 	MaxBuilderEpochMissedSlots       primitives.Slot // MaxBuilderEpochMissedSlots is defines the number of total skip slot (per epoch rolling windows) to fallback from using relay/builder to local execution engine for block construction.
-	BuildBidFraction                 float64         // BuildBidFraction is the fraction of builder bid that will be multiple to compare with local block value. Use builder bid if (bid * fraction) > local block value.
+	LocalBlockValueBoost             uint64          // LocalBlockValueBoost is the value boost for local block construction. This is used to prioritize local block construction over relay/builder block construction.
 
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue uint64 // ExecutionEngineTimeoutValue defines the seconds to wait before timing out engine endpoints with execution payload execution semantics (newPayload, forkchoiceUpdated).

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -207,6 +207,7 @@ type BeaconChainConfig struct {
 	// Mev-boost circuit breaker
 	MaxBuilderConsecutiveMissedSlots primitives.Slot // MaxBuilderConsecutiveMissedSlots defines the number of consecutive skip slot to fallback from using relay/builder to local execution engine for block construction.
 	MaxBuilderEpochMissedSlots       primitives.Slot // MaxBuilderEpochMissedSlots is defines the number of total skip slot (per epoch rolling windows) to fallback from using relay/builder to local execution engine for block construction.
+	BuildBidFraction                 float64         // BuildBidFraction is the fraction of builder bid that will be multiple to compare with local block value. Use builder bid if (bid * fraction) > local block value.
 
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue uint64 // ExecutionEngineTimeoutValue defines the seconds to wait before timing out engine endpoints with execution payload execution semantics (newPayload, forkchoiceUpdated).

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -257,6 +257,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	// Mevboost circuit breaker
 	MaxBuilderConsecutiveMissedSlots: 3,
 	MaxBuilderEpochMissedSlots:       5,
+	BuildBidFraction:                 1,
 
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue: 8, // 8 seconds default based on: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#core

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -257,7 +257,6 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	// Mevboost circuit breaker
 	MaxBuilderConsecutiveMissedSlots: 3,
 	MaxBuilderEpochMissedSlots:       5,
-	BuildBidFraction:                 1,
 
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue: 8, // 8 seconds default based on: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#core


### PR DESCRIPTION
This pull request adds a new flag to `local-block-value-boost` that allows the local block value multiplied by the boost value. The resulting value will be used if higher than the original builder's bid value. 
(i.e `builder_bid_value * 100 > local_block_value * (local-block-value-boost + 100`)

By default, the boost value is set to 0. This means that the current behavior remains unchanged. However, if preferred, the value of the boost can be adjusted to shift prioritization to the local block

The proposed change is designed to provide greater flexibility in censorship resistance defense, allowing for more dynamic and potentially more competitive bidding between local builders and mev builders