### PR TITLE
Use next slot cache for attestation gossip

### DIFF
--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -42,7 +42,7 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (stat
 	if err != nil {
 		return nil, err
 	}
-	baseState, err = transition.ProcessSlotsIfPossible(ctx, baseState, epochStartSlot)
+	baseState, err = transition.ProcessSlotsUsingNextSlotCache(ctx, baseState, c.Root, epochStartSlot)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not process slots up to epoch %d", c.Epoch)
 	}

--- a/beacon-chain/blockchain/process_attestation_helpers.go
+++ b/beacon-chain/blockchain/process_attestation_helpers.go
@@ -42,9 +42,11 @@ func (s *Service) getAttPreState(ctx context.Context, c *ethpb.Checkpoint) (stat
 	if err != nil {
 		return nil, err
 	}
-	baseState, err = transition.ProcessSlotsUsingNextSlotCache(ctx, baseState, c.Root, epochStartSlot)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not process slots up to epoch %d", c.Epoch)
+	if epochStartSlot > baseState.Slot() {
+		baseState, err = transition.ProcessSlotsUsingNextSlotCache(ctx, baseState, c.Root, epochStartSlot)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not process slots up to epoch %d", c.Epoch)
+		}
 	}
 
 	// Sharing the same state across caches is perfectly fine here, the fetching

--- a/beacon-chain/core/transition/trailing_slot_state_cache.go
+++ b/beacon-chain/core/transition/trailing_slot_state_cache.go
@@ -13,7 +13,7 @@ import (
 )
 
 type nextSlotCache struct {
-	sync.Mutex
+	sync.RWMutex
 	prevRoot  []byte
 	lastRoot  []byte
 	prevState state.BeaconState
@@ -37,8 +37,8 @@ var (
 // It returns the last updated state if it matches. Otherwise it returns the previously
 // updated state if it matches its root. If no root matches it returns nil
 func NextSlotState(root []byte) state.BeaconState {
-	nsc.Lock()
-	defer nsc.Unlock()
+	nsc.RLock()
+	defer nsc.RUnlock()
 	if bytes.Equal(root, nsc.lastRoot) {
 		nextSlotCacheHit.Inc()
 		return nsc.lastState.Copy()
@@ -74,8 +74,8 @@ func UpdateNextSlotCache(ctx context.Context, root []byte, state state.BeaconSta
 
 // LastCachedState returns the last cached state and root in the cache
 func LastCachedState() ([]byte, state.BeaconState) {
-	nsc.Lock()
-	defer nsc.Unlock()
+	nsc.RLock()
+	defer nsc.RUnlock()
 	if nsc.lastState == nil {
 		return nil, nil
 	}

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -156,9 +156,11 @@ func ProcessSlotsUsingNextSlotCache(
 	}
 
 	var err error
-	parentState, err = ProcessSlots(ctx, parentState, slot)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not process slots")
+	if slot > parentState.Slot() {
+		parentState, err = ProcessSlots(ctx, parentState, slot)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not process slots")
+		}
 	}
 	return parentState, nil
 }

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -156,12 +156,11 @@ func ProcessSlotsUsingNextSlotCache(
 	}
 
 	var err error
-	if slot > parentState.Slot() {
-		parentState, err = ProcessSlots(ctx, parentState, slot)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not process slots")
-		}
+	parentState, err = ProcessSlots(ctx, parentState, slot)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not process slots")
 	}
+
 	return parentState, nil
 }
 


### PR DESCRIPTION
This PR uses the next slot cache for attestation gossip. It'll greatly improve the efficiently during epoch transition period as the node processes attestations over the wire during epoch boundary