### PR TITLE
Default to local payload should set block to not blind

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -86,6 +86,7 @@ func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBea
 					blk.SetBlinded(true)
 					if err := blk.SetExecution(builderPayload); err != nil {
 						log.WithError(err).Warn("Proposer: failed to set builder payload")
+						blk.SetBlinded(false)
 					} else {
 						return nil
 					}
@@ -102,12 +103,12 @@ func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBea
 				blk.SetBlinded(true)
 				if err := blk.SetExecution(builderPayload); err != nil {
 					log.WithError(err).Warn("Proposer: failed to set builder payload")
+					blk.SetBlinded(false)
 				} else {
 					return nil
 				}
 			}
 		}
-
 	}
 
 	executionData, err := vs.getExecutionPayload(ctx, slot, idx, blk.Block().ParentRoot(), headState)


### PR DESCRIPTION
In the event where setting `builderPayload` to block's execution field fails, we can recover and use `localPayload` instead of failing block production. To set `localPayload`, we need to unblind the block