### PR TITLE
build tag to exclude mainnet genesis from prysmctl

### DIFF
--- a/beacon-chain/state/genesis/BUILD.bazel
+++ b/beacon-chain/state/genesis/BUILD.bazel
@@ -2,7 +2,10 @@ load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["genesis.go"],
+    srcs = [
+        "genesis.go",
+        "genesis_mainnet.go",
+    ],
     embedsrcs = ["mainnet.ssz.snappy"],
     importpath = "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/genesis",
     visibility = ["//beacon-chain/db:__subpackages__"],

--- a/beacon-chain/state/genesis/genesis.go
+++ b/beacon-chain/state/genesis/genesis.go
@@ -6,24 +6,18 @@ import (
 	"github.com/golang/snappy"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
 	state_native "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/state-native"
-	"github.com/prysmaticlabs/prysm/v4/config/params"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 )
 
-var (
-	//go:embed mainnet.ssz.snappy
-	mainnetRawSSZCompressed []byte // 1.8Mb
-)
+var embeddedStates = map[string]*[]byte{}
 
 // State returns a copy of the genesis state from a hardcoded value.
 func State(name string) (state.BeaconState, error) {
-	switch name {
-	case params.MainnetName:
-		return load(mainnetRawSSZCompressed)
-	default:
-		// No state found.
-		return nil, nil
+	sb, exists := embeddedStates[name]
+	if exists {
+		return load(*sb)
 	}
+	return nil, nil
 }
 
 // load a compressed ssz state file into a beacon state struct.

--- a/beacon-chain/state/genesis/genesis_mainnet.go
+++ b/beacon-chain/state/genesis/genesis_mainnet.go
@@ -1,0 +1,19 @@
+//go:build !noMainnetGenesis
+// +build !noMainnetGenesis
+
+package genesis
+
+import (
+	_ "embed"
+
+	"github.com/prysmaticlabs/prysm/v4/config/params"
+)
+
+var (
+	//go:embed mainnet.ssz.snappy
+	mainnetRawSSZCompressed []byte // 1.8Mb
+)
+
+func init() {
+	embeddedStates[params.MainnetName] = &mainnetRawSSZCompressed
+}

--- a/cmd/prysmctl/BUILD.bazel
+++ b/cmd/prysmctl/BUILD.bazel
@@ -110,5 +110,6 @@ docker_push(
 go_binary(
     name = "prysmctl",
     embed = [":go_default_library"],
+    gotags = ["noMainnetGenesis"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This is one small step to reducing the binary size of prysmctl. We'll get much bigger benefits from excluding validator web ui data, but since those are generated files it will take some more work to figure out how to accomplish that through bazel.