### PR TITLE
Fix Next State Mismatch

### DIFF
--- a/beacon-chain/core/transition/trailing_slot_state_cache.go
+++ b/beacon-chain/core/transition/trailing_slot_state_cache.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
+	types "github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 )
 
@@ -36,14 +37,14 @@ var (
 // NextSlotState returns the saved state for the given blockroot.
 // It returns the last updated state if it matches. Otherwise it returns the previously
 // updated state if it matches its root. If no root matches it returns nil
-func NextSlotState(root []byte) state.BeaconState {
+func NextSlotState(root []byte, wantedSlot types.Slot) state.BeaconState {
 	nsc.Lock()
 	defer nsc.Unlock()
-	if bytes.Equal(root, nsc.lastRoot) {
+	if bytes.Equal(root, nsc.lastRoot) && nsc.lastState.Slot() <= wantedSlot {
 		nextSlotCacheHit.Inc()
 		return nsc.lastState.Copy()
 	}
-	if bytes.Equal(root, nsc.prevRoot) {
+	if bytes.Equal(root, nsc.prevRoot) && nsc.prevState.Slot() <= wantedSlot {
 		nextSlotCacheHit.Inc()
 		return nsc.prevState.Copy()
 	}

--- a/beacon-chain/core/transition/trailing_slot_state_cache_test.go
+++ b/beacon-chain/core/transition/trailing_slot_state_cache_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/transition"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v4/testing/assert"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
 	"github.com/prysmaticlabs/prysm/v4/testing/util"
 )
@@ -32,4 +33,17 @@ func TestTrailingSlotState_RoundTrip(t *testing.T) {
 	lastRoot, lastState = transition.LastCachedState()
 	require.DeepEqual(t, r, lastRoot)
 	require.Equal(t, s.Slot(), lastState.Slot())
+}
+
+func TestTrailingSlotState_StateAdvancedBeyondRequest(t *testing.T) {
+	ctx := context.Background()
+	r := []byte{'a'}
+	s := transition.NextSlotState(r, 0)
+	require.Equal(t, nil, s)
+
+	s, _ = util.DeterministicGenesisState(t, 1)
+	assert.NoError(t, s.SetSlot(2))
+	require.NoError(t, transition.UpdateNextSlotCache(ctx, r, s))
+	s = transition.NextSlotState(r, 1)
+	require.Equal(t, nil, s)
 }

--- a/beacon-chain/core/transition/trailing_slot_state_cache_test.go
+++ b/beacon-chain/core/transition/trailing_slot_state_cache_test.go
@@ -13,12 +13,12 @@ import (
 func TestTrailingSlotState_RoundTrip(t *testing.T) {
 	ctx := context.Background()
 	r := []byte{'a'}
-	s := transition.NextSlotState(r)
+	s := transition.NextSlotState(r, 0)
 	require.Equal(t, nil, s)
 
 	s, _ = util.DeterministicGenesisState(t, 1)
 	require.NoError(t, transition.UpdateNextSlotCache(ctx, r, s))
-	s = transition.NextSlotState(r)
+	s = transition.NextSlotState(r, 1)
 	require.Equal(t, primitives.Slot(1), s.Slot())
 
 	lastRoot, lastState := transition.LastCachedState()
@@ -26,7 +26,7 @@ func TestTrailingSlotState_RoundTrip(t *testing.T) {
 	require.Equal(t, s.Slot(), lastState.Slot())
 
 	require.NoError(t, transition.UpdateNextSlotCache(ctx, r, s))
-	s = transition.NextSlotState(r)
+	s = transition.NextSlotState(r, 2)
 	require.Equal(t, primitives.Slot(2), s.Slot())
 
 	lastRoot, lastState = transition.LastCachedState()

--- a/beacon-chain/core/transition/transition.go
+++ b/beacon-chain/core/transition/transition.go
@@ -147,7 +147,7 @@ func ProcessSlotsUsingNextSlotCache(
 	ctx, span := trace.StartSpan(ctx, "core.state.ProcessSlotsUsingNextSlotCache")
 	defer span.End()
 
-	nextSlotState := NextSlotState(parentRoot)
+	nextSlotState := NextSlotState(parentRoot, slot)
 	if nextSlotState != nil {
 		parentState = nextSlotState
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In E2E a few of our runs were constantly failing with `could not process slots: expected state.slot 289 < slot 288` . After an investigation it was determined that #12233 added the ability for our cache to store different states with the same parent root. To allow the next slot cache to return the correctly desired state to the caller, we added in a `wantedSlot` parameter which should allow states with the desired slots to be returned. 

A simple regression test was also added for this.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
