### PR TITLE
Fix Deadlock in StreamChainHead

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks.go
@@ -352,6 +352,13 @@ func (bs *Server) StreamChainHead(_ *emptypb.Empty, stream ethpb.BeaconChain_Str
 	for {
 		select {
 		case stateEvent := <-stateChannel:
+			// In the event our node is in sync mode
+			// we do not send the chainhead to the caller
+			// due to the possibility of deadlocks when retrieving
+			// all the chain related data.
+			if bs.SyncChecker.Syncing() {
+				continue
+			}
 			if stateEvent.Type == statefeed.BlockProcessed {
 				res, err := bs.chainHeadRetrieval(stream.Context())
 				if err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks.go
@@ -346,7 +346,7 @@ func (bs *Server) StreamBlocks(req *ethpb.StreamBlocksRequest, stream ethpb.Beac
 // StreamChainHead to clients every single time the head block and state of the chain change.
 // DEPRECATED: This endpoint is superseded by the /eth/v1/events Beacon API endpoint
 func (bs *Server) StreamChainHead(_ *emptypb.Empty, stream ethpb.BeaconChain_StreamChainHeadServer) error {
-	stateChannel := make(chan *feed.Event, 1)
+	stateChannel := make(chan *feed.Event, 4)
 	stateSub := bs.StateNotifier.StateFeed().Subscribe(stateChannel)
 	defer stateSub.Unsubscribe()
 	for {

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/blocks_test.go
@@ -13,6 +13,7 @@ import (
 	statefeed "github.com/prysmaticlabs/prysm/v4/beacon-chain/core/feed/state"
 	dbTest "github.com/prysmaticlabs/prysm/v4/beacon-chain/db/testing"
 	state_native "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/state-native"
+	mockSync "github.com/prysmaticlabs/prysm/v4/beacon-chain/sync/initial-sync/testing"
 	"github.com/prysmaticlabs/prysm/v4/config/features"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
@@ -287,6 +288,7 @@ func TestServer_StreamChainHead_OnHeadUpdated(t *testing.T) {
 			CurrentJustifiedCheckPoint:  s.CurrentJustifiedCheckpoint(),
 			PreviousJustifiedCheckPoint: s.PreviousJustifiedCheckpoint()},
 		OptimisticModeFetcher: &chainMock.ChainService{},
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 	}
 	exitRoutine := make(chan bool)
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Fixes a deadlock in `StreamChainHead` which happens when we are syncing due to how forkchoice locks were refactored.
We ignore blocks being streamed in when syncing so as to not acquire the forkchoice read locks.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
