### PR TITLE
Add prepare-all-payloads flag

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db/kv"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/execution"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
+	"github.com/prysmaticlabs/prysm/v4/config/features"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	consensusblocks "github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
@@ -258,7 +259,7 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 	emptyAttri := payloadattribute.EmptyWithVersion(st.Version())
 	// Root is `[32]byte{}` since we are retrieving proposer ID of a given slot. During insertion at assignment the root was not known.
 	proposerID, _, ok := s.cfg.ProposerSlotIndexCache.GetProposerPayloadIDs(slot, [32]byte{} /* root */)
-	if !ok { // There's no need to build attribute if there is no proposer for slot.
+	if !ok && !features.Get().PrepareAllPayloads { // There's no need to build attribute if there is no proposer for slot.
 		return false, emptyAttri, 0
 	}
 

--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -17,6 +17,7 @@ import (
 	bstate "github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
 	state_native "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state/stategen"
+	"github.com/prysmaticlabs/prysm/v4/config/features"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	consensusblocks "github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
@@ -822,6 +823,31 @@ func Test_GetPayloadAttribute(t *testing.T) {
 	require.Equal(t, true, hasPayload)
 	require.Equal(t, suggestedVid, vId)
 	require.Equal(t, suggestedAddr, common.BytesToAddress(attr.SuggestedFeeRecipient()))
+}
+
+func Test_GetPayloadAttribute_PrepareAllPayloads(t *testing.T) {
+	ctx := context.Background()
+	resetCfg := features.InitWithReset(&features.Flags{
+		PrepareAllPayloads: true,
+	})
+	defer resetCfg()
+
+	beaconDB := testDB.SetupDB(t)
+	opts := []Option{
+		WithDatabase(beaconDB),
+		WithStateGen(stategen.New(beaconDB, doublylinkedtree.New())),
+		WithProposerIdsCache(cache.NewProposerPayloadIDsCache()),
+	}
+
+	hook := logTest.NewGlobal()
+	service, err := NewService(ctx, opts...)
+	require.NoError(t, err)
+	st, _ := util.DeterministicGenesisStateBellatrix(t, 1)
+	hasPayload, attr, vId := service.getPayloadAttribute(ctx, st, 0)
+	require.Equal(t, true, hasPayload)
+	require.Equal(t, primitives.ValidatorIndex(0), vId)
+	require.Equal(t, params.BeaconConfig().EthBurnAddressHex, common.BytesToAddress(attr.SuggestedFeeRecipient()).String())
+	require.LogsContain(t, hook, "Fee recipient is currently using the burn address")
 }
 
 func Test_GetPayloadAttributeV2(t *testing.T) {

--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -18,7 +18,7 @@ import (
 
 func (s *Service) isNewProposer(slot primitives.Slot) bool {
 	_, _, ok := s.cfg.ProposerSlotIndexCache.GetProposerPayloadIDs(slot, [32]byte{} /* root */)
-	return ok
+	return ok || features.Get().PrepareAllPayloads
 }
 
 func (s *Service) isNewHead(r [32]byte) bool {

--- a/beacon-chain/blockchain/head.go
+++ b/beacon-chain/blockchain/head.go
@@ -89,13 +89,13 @@ func (s *Service) saveHead(ctx context.Context, newHeadRoot [32]byte, headBlock 
 	newHeadSlot := headBlock.Block().Slot()
 	newStateRoot := headBlock.Block().StateRoot()
 
-	// A chain re-org occurred, so we fire an event notifying the rest of the services.
 	r, err := s.HeadRoot(ctx)
 	if err != nil {
 		return errors.Wrap(err, "could not get old head root")
 	}
 	oldHeadRoot := bytesutil.ToBytes32(r)
 	if headBlock.Block().ParentRoot() != oldHeadRoot {
+		// A chain re-org occurred, so we fire an event notifying the rest of the services.
 		commonRoot, forkSlot, err := s.cfg.ForkChoiceStore.CommonAncestor(ctx, oldHeadRoot, newHeadRoot)
 		if err != nil {
 			log.WithError(err).Error("Could not find common ancestor root")

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -696,7 +696,7 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	// Head root should be empty when retrieving proposer index for the next slot.
 	_, id, has := s.cfg.ProposerSlotIndexCache.GetProposerPayloadIDs(s.CurrentSlot()+1, [32]byte{} /* head root */)
 	// There exists proposer for next slot, but we haven't called fcu w/ payload attribute yet.
-	if !has || id != [8]byte{} {
+	if (!has && !features.Get().PrepareAllPayloads) || id != [8]byte{} {
 		return
 	}
 	s.headLock.RLock()

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/operations/attestations"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state/stategen"
+	"github.com/prysmaticlabs/prysm/v4/config/features"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	consensusblocks "github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
@@ -2154,6 +2155,28 @@ func TestOnBlock_HandleBlockAttestations(t *testing.T) {
 
 func TestFillMissingBlockPayloadId_DiffSlotExitEarly(t *testing.T) {
 	logHook := logTest.NewGlobal()
+	fc := doublylinkedtree.New()
+	ctx := context.Background()
+	beaconDB := testDB.SetupDB(t)
+
+	opts := []Option{
+		WithForkChoiceStore(fc),
+		WithStateGen(stategen.New(beaconDB, fc)),
+	}
+
+	service, err := NewService(ctx, opts...)
+	require.NoError(t, err)
+	service.lateBlockTasks(ctx)
+	require.LogsDoNotContain(t, logHook, "could not perform late block tasks")
+}
+
+func TestFillMissingBlockPayloadId_PrepareAllPayloads(t *testing.T) {
+	logHook := logTest.NewGlobal()
+	resetCfg := features.InitWithReset(&features.Flags{
+		PrepareAllPayloads: true,
+	})
+	defer resetCfg()
+
 	fc := doublylinkedtree.New()
 	ctx := context.Background()
 	beaconDB := testDB.SetupDB(t)

--- a/beacon-chain/core/feed/state/events.go
+++ b/beacon-chain/core/feed/state/events.go
@@ -19,8 +19,7 @@ const (
 	Initialized
 	// Synced is sent when the beacon node has completed syncing and is ready to participate in the network.
 	Synced
-	// Reorg is an event sent when the new head state's slot after a block
-	// transition is lower than its previous head state slot value.
+	// Reorg is an event sent when the new head is not a descendant of the previous head.
 	Reorg
 	// FinalizedCheckpoint event.
 	FinalizedCheckpoint

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -270,7 +270,7 @@ func (s *Server) streamPayloadAttributes(stream ethpbservice.Events_StreamEvents
 		return errors.Wrap(err, "could not get head state")
 	}
 	// advance the headstate
-	headState, err := transition.ProcessSlotsUsingNextSlotCache(s.Ctx, st, headRoot, s.ChainInfoFetcher.CurrentSlot()+1)
+	headState, err := transition.ProcessSlotsIfPossible(s.Ctx, st, s.ChainInfoFetcher.CurrentSlot()+1)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -261,22 +261,21 @@ func (s *Server) handleStateEvents(
 // This event stream is intended to be used by builders and relays.
 // parent_ fields are based on state at N_{current_slot}, while the rest of fields are based on state of N_{current_slot + 1}
 func (s *Server) streamPayloadAttributes(stream ethpbservice.Events_StreamEventsServer) error {
+	headRoot, err := s.HeadFetcher.HeadRoot(s.Ctx)
+	if err != nil {
+		return errors.Wrap(err, "could not get head root")
+	}
 	st, err := s.HeadFetcher.HeadState(s.Ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not get head state")
 	}
 	// advance the headstate
-	headState, err := transition.ProcessSlotsIfPossible(s.Ctx, st, s.ChainInfoFetcher.CurrentSlot()+1)
+	headState, err := transition.ProcessSlotsUsingNextSlotCache(s.Ctx, st, headRoot, s.ChainInfoFetcher.CurrentSlot()+1)
 	if err != nil {
 		return err
 	}
 
 	headBlock, err := s.HeadFetcher.HeadBlock(s.Ctx)
-	if err != nil {
-		return err
-	}
-
-	headRoot, err := s.HeadFetcher.HeadRoot(s.Ctx)
 	if err != nil {
 		return err
 	}

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -65,6 +65,8 @@ type Flags struct {
 	EnableVerboseSigVerification bool // EnableVerboseSigVerification specifies whether to verify individual signature if batch verification fails
 	EnableOptionalEngineMethods  bool // EnableOptionalEngineMethods specifies whether to activate capella specific engine methods
 
+	PrepareAllPayloads bool // PrepareAllPayloads informs the engine to prepare a block on every slot.
+
 	// KeystoreImportDebounceInterval specifies the time duration the validator waits to reload new keys if they have
 	// changed on disk. This feature is for advanced use cases only.
 	KeystoreImportDebounceInterval time.Duration
@@ -205,6 +207,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.IsSet(enableOptionalEngineMethods.Name) {
 		logEnabled(enableOptionalEngineMethods)
 		cfg.EnableOptionalEngineMethods = true
+	}
+	if ctx.IsSet(prepareAllPayloads.Name) {
+		logEnabled(prepareAllPayloads)
+		cfg.PrepareAllPayloads = true
 	}
 	Init(cfg)
 	return nil

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -114,6 +114,10 @@ var (
 		Name:  "enable-optional-engine-methods",
 		Usage: "Enables the optional engine methods",
 	}
+	prepareAllPayloads = &cli.BoolFlag{
+		Name:  "prepare-all-payloads",
+		Usage: "Informs the engine to prepare all local payloads. Useful for relayers and builders",
+	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
@@ -159,6 +163,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	enableFullSSZDataLogging,
 	enableVerboseSigVerification,
 	enableOptionalEngineMethods,
+	prepareAllPayloads,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
Adds a `--prepare-all-payloads` flag so that builders/relayers can pretend to be proposing every slot 