### PR TITLE
Fix Panic In Builder Service

### DIFF
--- a/beacon-chain/builder/service.go
+++ b/beacon-chain/builder/service.go
@@ -77,7 +77,8 @@ func (s *Service) Start() {
 }
 
 // Stop halts the service.
-func (*Service) Stop() error {
+func (s *Service) Stop() error {
+	s.cancel()
 	return nil
 }
 
@@ -89,6 +90,9 @@ func (s *Service) SubmitBlindedBlock(ctx context.Context, b interfaces.ReadOnlyS
 	defer func() {
 		submitBlindedBlockLatency.Observe(float64(time.Since(start).Milliseconds()))
 	}()
+	if s.c == nil {
+		return nil, ErrNoBuilder
+	}
 
 	return s.c.SubmitBlindedBlock(ctx, b)
 }
@@ -101,6 +105,9 @@ func (s *Service) GetHeader(ctx context.Context, slot primitives.Slot, parentHas
 	defer func() {
 		getHeaderLatency.Observe(float64(time.Since(start).Milliseconds()))
 	}()
+	if s.c == nil {
+		return nil, ErrNoBuilder
+	}
 
 	return s.c.GetHeader(ctx, slot, parentHash, pubKey)
 }
@@ -124,6 +131,9 @@ func (s *Service) RegisterValidator(ctx context.Context, reg []*ethpb.SignedVali
 	defer func() {
 		registerValidatorLatency.Observe(float64(time.Since(start).Milliseconds()))
 	}()
+	if s.c == nil {
+		return ErrNoBuilder
+	}
 
 	idxs := make([]primitives.ValidatorIndex, 0)
 	msgs := make([]*ethpb.ValidatorRegistrationV1, 0)

--- a/beacon-chain/builder/service_test.go
+++ b/beacon-chain/builder/service_test.go
@@ -37,3 +37,18 @@ func Test_RegisterValidator(t *testing.T) {
 	require.NoError(t, s.RegisterValidator(ctx, []*eth.SignedValidatorRegistrationV1{{Message: &eth.ValidatorRegistrationV1{Pubkey: pubkey[:], FeeRecipient: feeRecipient[:]}}}))
 	assert.Equal(t, true, builder.RegisteredVals[pubkey])
 }
+
+func Test_BuilderMethodsWithouClient(t *testing.T) {
+	s, err := NewService(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, false, s.Configured())
+
+	_, err = s.GetHeader(context.Background(), 0, [32]byte{}, [48]byte{})
+	assert.ErrorContains(t, ErrNoBuilder.Error(), err)
+
+	_, err = s.SubmitBlindedBlock(context.Background(), nil)
+	assert.ErrorContains(t, ErrNoBuilder.Error(), err)
+
+	err = s.RegisterValidator(context.Background(), nil)
+	assert.ErrorContains(t, ErrNoBuilder.Error(), err)
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In the event our builder client is not initialized, we return an error rather than trying to access the builder client and triggering a panic. A regression test has been added in. 

**Which issues(s) does this PR fix?**

Fixes #12275 

**Other notes for review**
