### PR TITLE
Check that Builder Is Configured

### DIFF
--- a/beacon-chain/rpc/eth/validator/validator_test.go
+++ b/beacon-chain/rpc/eth/validator/validator_test.go
@@ -2949,6 +2949,7 @@ func TestProduceBlindedBlockSSZ(t *testing.T) {
 			SlashingsPool:     slashings.NewPool(),
 			ExitPool:          voluntaryexits.NewPool(),
 			StateGen:          stategen.New(db, doublylinkedtree.New()),
+			BlockBuilder:      &builderTest.MockBuilderService{HasConfigured: true},
 		}
 
 		proposerSlashings := make([]*ethpbalpha.ProposerSlashing, 1)
@@ -3114,6 +3115,7 @@ func TestProduceBlindedBlockSSZ(t *testing.T) {
 			ExitPool:          voluntaryexits.NewPool(),
 			StateGen:          stategen.New(db, doublylinkedtree.New()),
 			SyncCommitteePool: synccommittee.NewStore(),
+			BlockBuilder:      &builderTest.MockBuilderService{HasConfigured: true},
 		}
 
 		proposerSlashings := make([]*ethpbalpha.ProposerSlashing, 1)
@@ -3321,6 +3323,7 @@ func TestProduceBlindedBlockSSZ(t *testing.T) {
 			StateGen:               stategen.New(db, doublylinkedtree.New()),
 			SyncCommitteePool:      synccommittee.NewStore(),
 			ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
+			BlockBuilder:           &builderTest.MockBuilderService{HasConfigured: true},
 		}
 
 		proposerSlashings := make([]*ethpbalpha.ProposerSlashing, 1)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -69,6 +69,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		FinalizationFetcher:    &blockchainTest.ChainService{},
 		BeaconDB:               beaconDB,
 		ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
+		BlockBuilder:           &builderTest.MockBuilderService{HasConfigured: true},
 	}
 
 	t.Run("No builder configured. Use local block", func(t *testing.T) {
@@ -116,7 +117,8 @@ func TestServer_setExecutionData(t *testing.T) {
 			Signature: sk.Sign(sr[:]).Marshal(),
 		}
 		vs.BlockBuilder = &builderTest.MockBuilderService{
-			BidCapella: sBid,
+			BidCapella:    sBid,
+			HasConfigured: true,
 		}
 		wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockBellatrix())
 		require.NoError(t, err)
@@ -170,7 +172,8 @@ func TestServer_setExecutionData(t *testing.T) {
 			Signature: sk.Sign(sr[:]).Marshal(),
 		}
 		vs.BlockBuilder = &builderTest.MockBuilderService{
-			BidCapella: sBid,
+			BidCapella:    sBid,
+			HasConfigured: true,
 		}
 		wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockCapella())
 		require.NoError(t, err)
@@ -214,7 +217,8 @@ func TestServer_setExecutionData(t *testing.T) {
 		blk, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockCapella())
 		require.NoError(t, err)
 		vs.BlockBuilder = &builderTest.MockBuilderService{
-			ErrGetHeader: errors.New("fault"),
+			ErrGetHeader:  errors.New("fault"),
+			HasConfigured: true,
 		}
 		vs.ExecutionEngineCaller = &powtesting.EngineClient{PayloadIDBytes: id, ExecutionPayloadCapella: &v1.ExecutionPayloadCapella{BlockNumber: 4}, BlockValue: big.NewInt(0)}
 		require.NoError(t, vs.setExecutionData(context.Background(), blk, capellaTransitionState))

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_builder.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_builder.go
@@ -14,6 +14,9 @@ import (
 // - Validator has registered to use builder (ie called registerBuilder API end point)
 // - Circuit breaker has not been activated (ie the liveness of the chain is healthy)
 func (vs *Server) canUseBuilder(ctx context.Context, slot primitives.Slot, idx primitives.ValidatorIndex) (bool, error) {
+	if !vs.BlockBuilder.Configured() {
+		return false, nil
+	}
 	activated, err := vs.circuitBreakBuilder(slot)
 	if err != nil {
 		return false, err

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_test.go
@@ -481,6 +481,7 @@ func getProposerServer(db db.HeadAccessDatabase, headState state.BeaconState, he
 		ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
 		BeaconDB:               db,
 		BLSChangesPool:         blstoexec.NewPool(),
+		BlockBuilder:           &builderTest.MockBuilderService{HasConfigured: true},
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

This checks that the builder is configured on the beacon node before we send out requests via the builder client. This also modifies the function's unit test to check for this configuration.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
