### PR TITLE
support modifying genesis.json for capella

### DIFF
--- a/cmd/prysmctl/testnet/generate_genesis.go
+++ b/cmd/prysmctl/testnet/generate_genesis.go
@@ -260,9 +260,17 @@ func generateGenesis(ctx context.Context) (state.BeaconState, error) {
 		if err := json.Unmarshal(gbytes, gen); err != nil {
 			return nil, err
 		}
+		// set timestamps for genesis and shanghai fork
+		gen.Timestamp = f.GenesisTime
+		gen.Config.ShanghaiTime = interop.GethShanghaiTime(f.GenesisTime, params.BeaconConfig())
+		if v > version.Altair {
+			// set ttd to zero so EL goes post-merge immediately
+			gen.Config.TerminalTotalDifficulty = big.NewInt(0)
+		}
 	} else {
 		gen = interop.GethTestnetGenesis(f.GenesisTime, params.BeaconConfig())
 	}
+
 	if f.GethGenesisJsonOut != "" {
 		gbytes, err := json.MarshalIndent(gen, "", "\t")
 		if err != nil {

--- a/runtime/interop/genesis.go
+++ b/runtime/interop/genesis.go
@@ -77,14 +77,9 @@ var minerBalance = big.NewInt(0)
 // The following value is for the key used by the e2e test "miner" node.
 const DefaultCliqueSigner = "0x0000000000000000000000000000000000000000000000000000000000000000878705ba3f8bc32fcf7f4caa1a35e72af65cf7660000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 
-// GethTestnetGenesis creates a genesis.json for eth1 clients with a set of defaults suitable for ephemeral testnets,
-// like in an e2e test. The parameters are minimal but the full value is returned unmarshaled so that it can be
-// customized as desired.
-func GethTestnetGenesis(genesisTime uint64, cfg *clparams.BeaconChainConfig) *core.Genesis {
-	ttd, ok := big.NewInt(0).SetString(clparams.BeaconConfig().TerminalTotalDifficulty, 10)
-	if !ok {
-		panic(fmt.Sprintf("unable to parse TerminalTotalDifficulty as an integer = %s", clparams.BeaconConfig().TerminalTotalDifficulty))
-	}
+// GethShanghaiTime calculates the absolute time of the shanghai (aka capella) fork block
+// by adding the relative time of the capella the fork epoch to the given genesis timestamp.
+func GethShanghaiTime(genesisTime uint64, cfg *clparams.BeaconChainConfig) *uint64 {
 	var shanghaiTime *uint64
 	if cfg.CapellaForkEpoch != math.MaxUint64 {
 		startSlot, err := slots.EpochStart(cfg.CapellaForkEpoch)
@@ -94,6 +89,19 @@ func GethTestnetGenesis(genesisTime uint64, cfg *clparams.BeaconChainConfig) *co
 			shanghaiTime = &newTime
 		}
 	}
+	return shanghaiTime
+}
+
+// GethTestnetGenesis creates a genesis.json for eth1 clients with a set of defaults suitable for ephemeral testnets,
+// like in an e2e test. The parameters are minimal but the full value is returned unmarshaled so that it can be
+// customized as desired.
+func GethTestnetGenesis(genesisTime uint64, cfg *clparams.BeaconChainConfig) *core.Genesis {
+	ttd, ok := big.NewInt(0).SetString(clparams.BeaconConfig().TerminalTotalDifficulty, 10)
+	if !ok {
+		panic(fmt.Sprintf("unable to parse TerminalTotalDifficulty as an integer = %s", clparams.BeaconConfig().TerminalTotalDifficulty))
+	}
+
+	shanghaiTime := GethShanghaiTime(genesisTime, cfg)
 	cc := &params.ChainConfig{
 		ChainID:                       big.NewInt(defaultTestChainId),
 		HomesteadBlock:                bigz,


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**

Better support for modifying existing genesis.json files in `prysmctl testnet generate-genesis` to support a smoother ux when using github.com/rauljordan/eth-pos-devnet.  https://github.com/rauljordan/eth-pos-devnet/pull/16 uses this new workflow.