### PR TITLE
Use next slot cache for rpc pools

### DIFF
--- a/beacon-chain/core/transition/trailing_slot_state_cache.go
+++ b/beacon-chain/core/transition/trailing_slot_state_cache.go
@@ -14,7 +14,7 @@ import (
 )
 
 type nextSlotCache struct {
-	sync.Mutex
+	sync.RWMutex
 	prevRoot  []byte
 	lastRoot  []byte
 	prevState state.BeaconState
@@ -38,8 +38,8 @@ var (
 // It returns the last updated state if it matches. Otherwise it returns the previously
 // updated state if it matches its root. If no root matches it returns nil
 func NextSlotState(root []byte, wantedSlot types.Slot) state.BeaconState {
-	nsc.Lock()
-	defer nsc.Unlock()
+	nsc.RLock()
+	defer nsc.RUnlock()
 	if bytes.Equal(root, nsc.lastRoot) && nsc.lastState.Slot() <= wantedSlot {
 		nextSlotCacheHit.Inc()
 		return nsc.lastState.Copy()

--- a/beacon-chain/rpc/eth/beacon/pool.go
+++ b/beacon-chain/rpc/eth/beacon/pool.go
@@ -170,7 +170,11 @@ func (bs *Server) SubmitAttesterSlashing(ctx context.Context, req *ethpbv1.Attes
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
 	}
-	headState, err = transition.ProcessSlotsIfPossible(ctx, headState, req.Attestation_1.Data.Slot)
+	headRoot, err := bs.ChainInfoFetcher.HeadRoot(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not get head root: %v", err)
+	}
+	headState, err = transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, req.Attestation_1.Data.Slot)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not process slots: %v", err)
 	}
@@ -226,7 +230,11 @@ func (bs *Server) SubmitProposerSlashing(ctx context.Context, req *ethpbv1.Propo
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get head state: %v", err)
 	}
-	headState, err = transition.ProcessSlotsIfPossible(ctx, headState, req.SignedHeader_1.Message.Slot)
+	headRoot, err := bs.ChainInfoFetcher.HeadRoot(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not get head root: %v", err)
+	}
+	headState, err = transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, req.SignedHeader_1.Message.Slot)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not process slots: %v", err)
 	}
@@ -284,7 +292,11 @@ func (bs *Server) SubmitVoluntaryExit(ctx context.Context, req *ethpbv1.SignedVo
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not get epoch from message: %v", err)
 	}
-	headState, err = transition.ProcessSlotsIfPossible(ctx, headState, s)
+	headRoot, err := bs.ChainInfoFetcher.HeadRoot(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not get head root: %v", err)
+	}
+	headState, err = transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, s)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not process slots: %v", err)
 	}


### PR DESCRIPTION
This PR changes
- Use next slot cache for RPC pool requests to avoid duplicated `ProcessSlotsIfPossible` if necessary
- Change next slot cache to have read and write mutex `RWMutex`