### PR TITLE
Validate gossip exit with current slot

### DIFF
--- a/beacon-chain/sync/validate_voluntary_exit.go
+++ b/beacon-chain/sync/validate_voluntary_exit.go
@@ -62,7 +62,7 @@ func (s *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *p
 	if err != nil {
 		return pubsub.ValidationIgnore, err
 	}
-	if err := blocks.VerifyExitAndSignature(val, headState.Slot(), headState.Fork(), exit, headState.GenesisValidatorsRoot()); err != nil {
+	if err := blocks.VerifyExitAndSignature(val, s.cfg.chain.CurrentSlot(), headState.Fork(), exit, headState.GenesisValidatorsRoot()); err != nil {
 		return pubsub.ValidationReject, err
 	}
 


### PR DESCRIPTION
Fixes the following error:

```
Apr 15 10:56:32 nishant-NUC8i5BEH beacon-chain[284213]: time="2023-04-15 10:56:32" level=debug msg="Gossip message was rejected" agent="Prysm/v4.0.2/75338dd83d943ed5e13635cd0578c38a3b2d248b" error="expected current epoch >= exit epoch, received 194539 < 194540" 
```

When Prysm nodes validate exit messages over gossip, the head slot won't advance. Using current would cover most of the case. Another idea is to process the head state to the current slot, which might be expensive. 
Something to consider here is this might have a negative impact on processing exit messages across the fork, but the bug would have existed today regardless. 