### PR TITLE
set payload header in right order

### DIFF
--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -781,9 +781,9 @@ func PayloadToHeaderDeneb(payload interfaces.ExecutionData) (*enginev1.Execution
 		ExtraData:        bytesutil.SafeCopyBytes(payload.ExtraData()),
 		BaseFeePerGas:    bytesutil.SafeCopyBytes(payload.BaseFeePerGas()),
 		BlockHash:        bytesutil.SafeCopyBytes(payload.BlockHash()),
-		ExcessDataGas:    bytesutil.SafeCopyBytes(excessDataGas),
 		TransactionsRoot: txRoot[:],
 		WithdrawalsRoot:  withdrawalsRoot[:],
+		ExcessDataGas:    bytesutil.SafeCopyBytes(excessDataGas),
 	}, nil
 }
 


### PR DESCRIPTION
Set the payload header in the right order as in the consensus specs. 