### PR TITLE
improve the blinded block error

### DIFF
--- a/beacon-chain/rpc/eth/validator/validator.go
+++ b/beacon-chain/rpc/eth/validator/validator.go
@@ -559,7 +559,7 @@ func (vs *Server) ProduceBlindedBlock(ctx context.Context, req *ethpbv1.ProduceB
 			},
 		}, nil
 	}
-	return nil, status.Error(codes.InvalidArgument, "Unsupported block type")
+	return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("block was not a supported blinded block type, validator may not be registered if using a relay. received: %T", v1alpha1resp.Block))
 }
 
 // ProduceBlindedBlockSSZ requests the beacon node to produce a valid unsigned blinded beacon block,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Our current error on producing blinded block is not clear especially when the validator is not registered while using the mev relay. Now it should display an error that reflects this and shows the underlying type used.

**Which issues(s) does this PR fix?**

Fixes # https://github.com/prysmaticlabs/prysm/issues/12103#issuecomment-1514343838

