### PR TITLE
Add Exceptions For Transaction Fuzzer

### DIFF
--- a/testing/endtoend/components/eth1/transactions.go
+++ b/testing/endtoend/components/eth1/transactions.go
@@ -110,13 +110,17 @@ func SendTransaction(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.Filler
 		g.Go(func() error {
 			tx, err := txfuzz.RandomValidTx(client, f, sender, nonce+index, gasPrice, nil, al)
 			if err != nil {
-				return err
+				//nolint:nilerr
+				return nil
 			}
 			signedTx, err := types.SignTx(tx, types.NewLondonSigner(chainid), key)
 			if err != nil {
-				return err
+				//nolint:nilerr
+				return nil
 			}
-			return backend.SendTransaction(context.Background(), signedTx)
+			err = backend.SendTransaction(context.Background(), signedTx)
+			//nolint:nilerr
+			return nil
 		})
 	}
 	return g.Wait()

--- a/testing/endtoend/components/eth1/transactions.go
+++ b/testing/endtoend/components/eth1/transactions.go
@@ -110,15 +110,21 @@ func SendTransaction(client *rpc.Client, key *ecdsa.PrivateKey, f *filler.Filler
 		g.Go(func() error {
 			tx, err := txfuzz.RandomValidTx(client, f, sender, nonce+index, gasPrice, nil, al)
 			if err != nil {
+				// In the event the transaction constructed is not valid, we continue with the routine
+				// rather than complete stop it.
 				//nolint:nilerr
 				return nil
 			}
 			signedTx, err := types.SignTx(tx, types.NewLondonSigner(chainid), key)
 			if err != nil {
+				// We continue on in the event there is a reason we can't sign this
+				// transaction(unlikely).
 				//nolint:nilerr
 				return nil
 			}
 			err = backend.SendTransaction(context.Background(), signedTx)
+			// We continue on if the constructed transaction is invalid
+			// and can't be submitted on chain.
 			//nolint:nilerr
 			return nil
 		})


### PR DESCRIPTION
**What type of PR is this?**

E2E Fix

**What does this PR do? Why is it needed?**

In #12270, we returned errors in our transaction fuzzer if a transaction wasn't able to be successfully completed. However due
to the nature of how the fuzzer constructs transactions, this would always be a possibility. The end result is that our e2e runs started failing much more often. This PR adds in exceptions for them so that we don't need to return errors if a transaction isn't valid.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
