### PR TITLE
Use same signature for unrealized justified hash and justified hash

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -96,7 +96,7 @@ type FinalizationFetcher interface {
 	FinalizedCheckpt() *ethpb.Checkpoint
 	CurrentJustifiedCheckpt() *ethpb.Checkpoint
 	PreviousJustifiedCheckpt() *ethpb.Checkpoint
-	UnrealizedJustifiedPayloadBlockHash() ([32]byte, error)
+	UnrealizedJustifiedPayloadBlockHash() [32]byte
 	FinalizedBlockHash() [32]byte
 	InForkchoice([32]byte) bool
 	IsFinalized(ctx context.Context, blockRoot [32]byte) bool

--- a/beacon-chain/blockchain/chain_info_forkchoice.go
+++ b/beacon-chain/blockchain/chain_info_forkchoice.go
@@ -80,7 +80,7 @@ func (s *Service) ChainHeads() ([][32]byte, []primitives.Slot) {
 }
 
 // UnrealizedJustifiedPayloadBlockHash returns unrealized justified payload block hash from forkchoice.
-func (s *Service) UnrealizedJustifiedPayloadBlockHash() ([32]byte, error) {
+func (s *Service) UnrealizedJustifiedPayloadBlockHash() [32]byte {
 	s.cfg.ForkChoiceStore.RLock()
 	defer s.cfg.ForkChoiceStore.RUnlock()
 	return s.cfg.ForkChoiceStore.UnrealizedJustifiedPayloadBlockHash()

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -153,8 +153,7 @@ func TestUnrealizedJustifiedBlockHash(t *testing.T) {
 	service.cfg.ForkChoiceStore.SetBalancesByRooter(func(_ context.Context, _ [32]byte) ([]uint64, error) { return []uint64{}, nil })
 	require.NoError(t, service.cfg.ForkChoiceStore.UpdateJustifiedCheckpoint(ctx, &forkchoicetypes.Checkpoint{Epoch: 6, Root: [32]byte{'j'}}))
 
-	h, err := service.UnrealizedJustifiedPayloadBlockHash()
-	require.NoError(t, err)
+	h := service.UnrealizedJustifiedPayloadBlockHash()
 	require.Equal(t, params.BeaconConfig().ZeroHash, h)
 	require.Equal(t, [32]byte{'j'}, service.cfg.ForkChoiceStore.JustifiedCheckpoint().Root)
 }

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -62,11 +62,7 @@ func (s *Service) notifyForkchoiceUpdate(ctx context.Context, arg *notifyForkcho
 		return nil, nil
 	}
 	finalizedHash := s.cfg.ForkChoiceStore.FinalizedPayloadBlockHash()
-	justifiedHash, err := s.cfg.ForkChoiceStore.UnrealizedJustifiedPayloadBlockHash()
-	if err != nil {
-		log.WithError(err).Error("Could not get unrealized justified payload block hash")
-		justifiedHash = finalizedHash
-	}
+	justifiedHash := s.cfg.ForkChoiceStore.UnrealizedJustifiedPayloadBlockHash()
 	fcs := &enginev1.ForkchoiceState{
 		HeadBlockHash:      headPayload.BlockHash(),
 		SafeBlockHash:      justifiedHash[:],

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -509,14 +509,14 @@ func (f *ForkChoice) JustifiedPayloadBlockHash() [32]byte {
 }
 
 // UnrealizedJustifiedPayloadBlockHash returns the hash of the payload at the unrealized justified checkpoint
-func (f *ForkChoice) UnrealizedJustifiedPayloadBlockHash() ([32]byte, error) {
+func (f *ForkChoice) UnrealizedJustifiedPayloadBlockHash() [32]byte {
 	root := f.store.unrealizedJustifiedCheckpoint.Root
 	node, ok := f.store.nodeByRoot[root]
 	if !ok || node == nil {
 		// This should not happen
-		return [32]byte{}, ErrNilNode
+		return [32]byte{}
 	}
-	return node.payloadHash, nil
+	return node.payloadHash
 }
 
 // ForkChoiceDump returns a full dump of forkchoice.

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice_test.go
@@ -751,11 +751,6 @@ func TestForkChoice_UnrealizedJustifiedPayloadBlockHash(t *testing.T) {
 	require.NoError(t, f.InsertNode(ctx, st, blkRoot))
 
 	f.store.unrealizedJustifiedCheckpoint.Root = [32]byte{'a'}
-	got, err := f.UnrealizedJustifiedPayloadBlockHash()
-	require.NoError(t, err)
+	got := f.UnrealizedJustifiedPayloadBlockHash()
 	require.Equal(t, [32]byte{'A'}, got)
-
-	f.store.unrealizedJustifiedCheckpoint.Root = [32]byte{'b'}
-	_, err = f.UnrealizedJustifiedPayloadBlockHash()
-	require.ErrorIs(t, err, ErrNilNode)
 }

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -57,7 +57,7 @@ type Getter interface {
 	JustifiedCheckpoint() *forkchoicetypes.Checkpoint
 	PreviousJustifiedCheckpoint() *forkchoicetypes.Checkpoint
 	JustifiedPayloadBlockHash() [32]byte
-	UnrealizedJustifiedPayloadBlockHash() ([32]byte, error)
+	UnrealizedJustifiedPayloadBlockHash() [32]byte
 	NodeCount() int
 	HighestReceivedBlockSlot() primitives.Slot
 	ReceivedBlocksLastEpoch() (uint64, error)


### PR DESCRIPTION
Do not return an error if the unrealized justified hash is not known. 