### PR TITLE
Fix Status Checks For Double Deposits

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/status.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/status.go
@@ -333,10 +333,9 @@ func (vs *Server) validatorStatus(
 			if vs.DepositFetcher == nil {
 				log.Warn("Not connected to ETH1. Cannot determine validator ETH1 deposit.")
 			} else {
-				// Check if there was a deposit deposit.
-				d, eth1BlockNumBigInt := vs.DepositFetcher.DepositByPubkey(ctx, pubKey)
+				// Check if there was a deposit.
+				_, eth1BlockNumBigInt := vs.DepositFetcher.DepositByPubkey(ctx, pubKey)
 				if eth1BlockNumBigInt != nil {
-					resp.Status = depositStatus(d.Data.Amount)
 					resp.Eth1DepositBlockNumber = eth1BlockNumBigInt.Uint64()
 				}
 			}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/status_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/status_test.go
@@ -152,6 +152,7 @@ func TestValidatorStatus_PartiallyDeposited(t *testing.T) {
 			{
 				PublicKey:                  pubKey1,
 				ActivationEligibilityEpoch: 1,
+				EffectiveBalance:           params.BeaconConfig().MinDepositAmount,
 			},
 		},
 	})
@@ -170,6 +171,65 @@ func TestValidatorStatus_PartiallyDeposited(t *testing.T) {
 	resp, err := vs.ValidatorStatus(context.Background(), req)
 	require.NoError(t, err, "Could not get validator status")
 	assert.Equal(t, ethpb.ValidatorStatus_PARTIALLY_DEPOSITED, resp.Status)
+}
+
+func TestValidatorStatus_Pending_MultipleDeposits(t *testing.T) {
+	ctx := context.Background()
+
+	pubKey1 := pubKey(1)
+	depData := &ethpb.Deposit_Data{
+		Amount:                16 * params.BeaconConfig().MinDepositAmount,
+		PublicKey:             pubKey1,
+		Signature:             []byte("hi"),
+		WithdrawalCredentials: []byte("hey"),
+	}
+	deposit := &ethpb.Deposit{
+		Data: depData,
+	}
+	depositTrie, err := trie.NewTrie(params.BeaconConfig().DepositContractTreeDepth)
+	require.NoError(t, err, "Could not setup deposit trie")
+	depositCache, err := depositcache.New()
+	require.NoError(t, err)
+
+	root, err := depositTrie.HashTreeRoot()
+	require.NoError(t, err)
+	assert.NoError(t, depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 0, root))
+	assert.NoError(t, depositCache.InsertDeposit(ctx, deposit, 0 /*blockNum*/, 1, root))
+
+	height := time.Unix(int64(params.BeaconConfig().Eth1FollowDistance), 0).Unix()
+	p := &mockExecution.Chain{
+		TimesByHeight: map[int]uint64{
+			0: uint64(height),
+		},
+	}
+	stateObj, err := state_native.InitializeFromProtoUnsafePhase0(&ethpb.BeaconState{
+		Validators: []*ethpb.Validator{
+			{
+				PublicKey:                  pubKey1,
+				ActivationEligibilityEpoch: 1,
+				EffectiveBalance:           params.BeaconConfig().MaxEffectiveBalance,
+				ActivationEpoch:            params.BeaconConfig().FarFutureEpoch,
+				ExitEpoch:                  params.BeaconConfig().FarFutureEpoch,
+				WithdrawableEpoch:          params.BeaconConfig().FarFutureEpoch,
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, stateObj.SetSlot(params.BeaconConfig().SlotsPerEpoch))
+	vs := &Server{
+		DepositFetcher: depositCache,
+		BlockFetcher:   p,
+		HeadFetcher: &mockChain.ChainService{
+			State: stateObj,
+		},
+		Eth1InfoFetcher: p,
+	}
+	req := &ethpb.ValidatorStatusRequest{
+		PublicKey: pubKey1,
+	}
+	resp, err := vs.ValidatorStatus(context.Background(), req)
+	require.NoError(t, err, "Could not get validator status")
+	assert.Equal(t, ethpb.ValidatorStatus_PENDING, resp.Status)
 }
 
 func TestValidatorStatus_Pending(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In the event of double deposits, we incorrectly overwrite the validator status for pending validators. This PR fixes that and adds in a regression test for it.  

**Which issues(s) does this PR fix?**

Fixes #12317 

**Other notes for review**
