### PR TITLE
Corrected err return for GenesisState while calling db.View

### DIFF
--- a/beacon-chain/db/kv/state.go
+++ b/beacon-chain/db/kv/state.go
@@ -97,9 +97,8 @@ func (s *Store) GenesisState(ctx context.Context) (state.BeaconState, error) {
 			return valErr
 		}
 
-		var crtErr error
 		st, err = s.unmarshalState(ctx, enc, valEntries)
-		return crtErr
+		return err
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

db.View inside GenesisState used to return crtErr which doesn't store any error value and thus db.View doesn't correctly return the error after unmarshalState.
