### PR TITLE
Avoid double state copy in `latestAncestor`

### DIFF
--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -257,7 +257,6 @@ func (s *State) latestAncestor(ctx context.Context, blockRoot [32]byte) (state.B
 		if finalizedState != nil {
 			return finalizedState, nil
 		}
-
 	}
 
 	b, err := s.beaconDB.Block(ctx, blockRoot)

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -252,8 +252,12 @@ func (s *State) latestAncestor(ctx context.Context, blockRoot [32]byte) (state.B
 	ctx, span := trace.StartSpan(ctx, "stateGen.latestAncestor")
 	defer span.End()
 
-	if s.isFinalizedRoot(blockRoot) && s.finalizedState() != nil {
-		return s.finalizedState(), nil
+	if s.isFinalizedRoot(blockRoot) {
+		finalizedState := s.finalizedState()
+		if finalizedState != nil {
+			return finalizedState, nil
+		}
+
 	}
 
 	b, err := s.beaconDB.Block(ctx, blockRoot)


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

The call to `s.finalizedState()` makes a copy of the beacon state. We unnecessarily make two copies: in the condition check and inside the condition statement.
