### PR TITLE
Move some errors to separate `consensus-types` package

### DIFF
--- a/api/client/builder/BUILD.bazel
+++ b/api/client/builder/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v4/api/client/builder",
     visibility = ["//visibility:public"],
     deps = [
+        "//consensus-types:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",

--- a/api/client/builder/bid.go
+++ b/api/client/builder/bid.go
@@ -107,7 +107,7 @@ type builderBid struct {
 func WrappedBuilderBid(p *ethpb.BuilderBid) (Bid, error) {
 	w := builderBid{p: p}
 	if w.IsNil() {
-		return nil, Errnilobjectw
+		return nil, consensus_types.ErrNilObjectWrapped
 	}
 	return w, nil
 }

--- a/api/client/builder/bid.go
+++ b/api/client/builder/bid.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	ssz "github.com/prysmaticlabs/fastssz"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
@@ -40,7 +41,7 @@ type signedBuilderBid struct {
 func WrappedSignedBuilderBid(p *ethpb.SignedBuilderBid) (SignedBid, error) {
 	w := signedBuilderBid{p: p}
 	if w.IsNil() {
-		return nil, blocks.ErrNilObjectWrapped
+		return nil, consensus_types.ErrNilObjectWrapped
 	}
 	return w, nil
 }
@@ -73,7 +74,7 @@ type signedBuilderBidCapella struct {
 func WrappedSignedBuilderBidCapella(p *ethpb.SignedBuilderBidCapella) (SignedBid, error) {
 	w := signedBuilderBidCapella{p: p}
 	if w.IsNil() {
-		return nil, blocks.ErrNilObjectWrapped
+		return nil, consensus_types.ErrNilObjectWrapped
 	}
 	return w, nil
 }
@@ -106,7 +107,7 @@ type builderBid struct {
 func WrappedBuilderBid(p *ethpb.BuilderBid) (Bid, error) {
 	w := builderBid{p: p}
 	if w.IsNil() {
-		return nil, blocks.ErrNilObjectWrapped
+		return nil, Errnilobjectw
 	}
 	return w, nil
 }
@@ -154,7 +155,7 @@ type builderBidCapella struct {
 func WrappedBuilderBidCapella(p *ethpb.BuilderBidCapella) (Bid, error) {
 	w := builderBidCapella{p: p}
 	if w.IsNil() {
-		return nil, blocks.ErrNilObjectWrapped
+		return nil, consensus_types.ErrNilObjectWrapped
 	}
 	return w, nil
 }

--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
+        "//consensus-types:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/payload-attribute:go_default_library",

--- a/beacon-chain/blockchain/log.go
+++ b/beacon-chain/blockchain/log.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
-	consensusBlocks "github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
@@ -53,7 +53,7 @@ func logStateTransitionData(b interfaces.ReadOnlyBeaconBlock) error {
 		log = log.WithField("payloadHash", fmt.Sprintf("%#x", bytesutil.Trunc(p.BlockHash())))
 		txs, err := p.Transactions()
 		switch {
-		case errors.Is(err, consensusBlocks.ErrUnsupportedGetter):
+		case errors.Is(err, consensus_types.ErrUnsupportedGetter):
 		case err != nil:
 			return err
 		default:

--- a/beacon-chain/core/blocks/BUILD.bazel
+++ b/beacon-chain/core/blocks/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//beacon-chain/state:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
+        "//consensus-types:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",

--- a/beacon-chain/core/blocks/payload.go
+++ b/beacon-chain/core/blocks/payload.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/time"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
@@ -60,7 +61,7 @@ func IsExecutionBlock(body interfaces.ReadOnlyBeaconBlockBody) (bool, error) {
 	}
 	payload, err := body.Execution()
 	switch {
-	case errors.Is(err, blocks.ErrUnsupportedGetter):
+	case errors.Is(err, consensus_types.ErrUnsupportedGetter):
 		return false, nil
 	case err != nil:
 		return false, err

--- a/beacon-chain/rpc/eth/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/eth/beacon/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//config/features:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
+        "//consensus-types:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",

--- a/beacon-chain/rpc/eth/beacon/blinded_blocks.go
+++ b/beacon-chain/rpc/eth/beacon/blinded_blocks.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
-	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/encoding/ssz/detect"
 	"github.com/prysmaticlabs/prysm/v4/network/forks"
@@ -41,7 +41,7 @@ func (bs *Server) GetBlindedBlock(ctx context.Context, req *ethpbv1.BlockRequest
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get blinded block: %v", err)
 	}
 	result, err = getBlindedBlockAltair(blk)
@@ -50,7 +50,7 @@ func (bs *Server) GetBlindedBlock(ctx context.Context, req *ethpbv1.BlockRequest
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get blinded block: %v", err)
 	}
 	result, err = bs.getBlindedBlockBellatrix(ctx, blk)
@@ -59,7 +59,7 @@ func (bs *Server) GetBlindedBlock(ctx context.Context, req *ethpbv1.BlockRequest
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get blinded block: %v", err)
 	}
 	result, err = bs.getBlindedBlockCapella(ctx, blk)
@@ -68,7 +68,7 @@ func (bs *Server) GetBlindedBlock(ctx context.Context, req *ethpbv1.BlockRequest
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get blinded block: %v", err)
 	}
 
@@ -96,7 +96,7 @@ func (bs *Server) GetBlindedBlockSSZ(ctx context.Context, req *ethpbv1.BlockRequ
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 	result, err = getSSZBlockAltair(blk)
@@ -105,7 +105,7 @@ func (bs *Server) GetBlindedBlockSSZ(ctx context.Context, req *ethpbv1.BlockRequ
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 	result, err = bs.getBlindedSSZBlockBellatrix(ctx, blk)
@@ -114,7 +114,7 @@ func (bs *Server) GetBlindedBlockSSZ(ctx context.Context, req *ethpbv1.BlockRequ
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 	result, err = bs.getBlindedSSZBlockCapella(ctx, blk)
@@ -123,7 +123,7 @@ func (bs *Server) GetBlindedBlockSSZ(ctx context.Context, req *ethpbv1.BlockRequ
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 
@@ -278,7 +278,7 @@ func (bs *Server) getBlindedBlockBellatrix(ctx context.Context, blk interfaces.R
 	bellatrixBlk, err := blk.PbBellatrixBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
-		if errors.Is(err, blocks.ErrUnsupportedGetter) {
+		if errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 			if blindedBellatrixBlk, err := blk.PbBlindedBellatrixBlock(); err == nil {
 				if blindedBellatrixBlk == nil {
 					return nil, errNilBlock
@@ -348,7 +348,7 @@ func (bs *Server) getBlindedBlockCapella(ctx context.Context, blk interfaces.Rea
 	capellaBlk, err := blk.PbCapellaBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
-		if errors.Is(err, blocks.ErrUnsupportedGetter) {
+		if errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 			if blindedCapellaBlk, err := blk.PbBlindedCapellaBlock(); err == nil {
 				if blindedCapellaBlk == nil {
 					return nil, errNilBlock
@@ -418,7 +418,7 @@ func (bs *Server) getBlindedSSZBlockBellatrix(ctx context.Context, blk interface
 	bellatrixBlk, err := blk.PbBellatrixBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
-		if errors.Is(err, blocks.ErrUnsupportedGetter) {
+		if errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 			if blindedBellatrixBlk, err := blk.PbBlindedBellatrixBlock(); err == nil {
 				if blindedBellatrixBlk == nil {
 					return nil, errNilBlock
@@ -493,7 +493,7 @@ func (bs *Server) getBlindedSSZBlockCapella(ctx context.Context, blk interfaces.
 	capellaBlk, err := blk.PbCapellaBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
-		if errors.Is(err, blocks.ErrUnsupportedGetter) {
+		if errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 			if blindedCapellaBlk, err := blk.PbBlindedCapellaBlock(); err == nil {
 				if blindedCapellaBlk == nil {
 					return nil, errNilBlock

--- a/beacon-chain/rpc/eth/beacon/blocks.go
+++ b/beacon-chain/rpc/eth/beacon/blocks.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/lookup"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
@@ -336,7 +337,7 @@ func (bs *Server) GetBlockV2(ctx context.Context, req *ethpbv2.BlockRequestV2) (
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 	result, err = getBlockAltair(blk)
@@ -345,7 +346,7 @@ func (bs *Server) GetBlockV2(ctx context.Context, req *ethpbv2.BlockRequestV2) (
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 	result, err = bs.getBlockBellatrix(ctx, blk)
@@ -354,7 +355,7 @@ func (bs *Server) GetBlockV2(ctx context.Context, req *ethpbv2.BlockRequestV2) (
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 	result, err = bs.getBlockCapella(ctx, blk)
@@ -363,7 +364,7 @@ func (bs *Server) GetBlockV2(ctx context.Context, req *ethpbv2.BlockRequestV2) (
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 	return nil, status.Errorf(codes.Internal, "Unknown block type %T", blk)
@@ -390,7 +391,7 @@ func (bs *Server) GetBlockSSZV2(ctx context.Context, req *ethpbv2.BlockRequestV2
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 	result, err = getSSZBlockAltair(blk)
@@ -399,7 +400,7 @@ func (bs *Server) GetBlockSSZV2(ctx context.Context, req *ethpbv2.BlockRequestV2
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 	result, err = bs.getSSZBlockBellatrix(ctx, blk)
@@ -408,7 +409,7 @@ func (bs *Server) GetBlockSSZV2(ctx context.Context, req *ethpbv2.BlockRequestV2
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 	result, err = bs.getSSZBlockCapella(ctx, blk)
@@ -417,7 +418,7 @@ func (bs *Server) GetBlockSSZV2(ctx context.Context, req *ethpbv2.BlockRequestV2
 		return result, nil
 	}
 	// ErrUnsupportedGetter means that we have another block type
-	if !errors.Is(err, blocks.ErrUnsupportedGetter) {
+	if !errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 		return nil, status.Errorf(codes.Internal, "Could not get signed beacon block: %v", err)
 	}
 
@@ -605,7 +606,7 @@ func (bs *Server) getBlockBellatrix(ctx context.Context, blk interfaces.ReadOnly
 	bellatrixBlk, err := blk.PbBellatrixBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
-		if errors.Is(err, blocks.ErrUnsupportedGetter) {
+		if errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 			if blindedBellatrixBlk, err := blk.PbBlindedBellatrixBlock(); err == nil {
 				if blindedBellatrixBlk == nil {
 					return nil, errNilBlock
@@ -675,7 +676,7 @@ func (bs *Server) getBlockCapella(ctx context.Context, blk interfaces.ReadOnlySi
 	capellaBlk, err := blk.PbCapellaBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
-		if errors.Is(err, blocks.ErrUnsupportedGetter) {
+		if errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 			if blindedCapellaBlk, err := blk.PbBlindedCapellaBlock(); err == nil {
 				if blindedCapellaBlk == nil {
 					return nil, errNilBlock
@@ -788,7 +789,7 @@ func (bs *Server) getSSZBlockBellatrix(ctx context.Context, blk interfaces.ReadO
 	bellatrixBlk, err := blk.PbBellatrixBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
-		if errors.Is(err, blocks.ErrUnsupportedGetter) {
+		if errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 			if blindedBellatrixBlk, err := blk.PbBlindedBellatrixBlock(); err == nil {
 				if blindedBellatrixBlk == nil {
 					return nil, errNilBlock
@@ -864,7 +865,7 @@ func (bs *Server) getSSZBlockCapella(ctx context.Context, blk interfaces.ReadOnl
 	capellaBlk, err := blk.PbCapellaBlock()
 	if err != nil {
 		// ErrUnsupportedGetter means that we have another block type
-		if errors.Is(err, blocks.ErrUnsupportedGetter) {
+		if errors.Is(err, consensus_types.ErrUnsupportedGetter) {
 			if blindedCapellaBlk, err := blk.PbBlindedCapellaBlock(); err == nil {
 				if blindedCapellaBlk == nil {
 					return nil, errNilBlock

--- a/cmd/prysmctl/p2p/BUILD.bazel
+++ b/cmd/prysmctl/p2p/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
         "//beacon-chain/sync:go_default_library",
         "//cmd:go_default_library",
         "//config/params:go_default_library",
-        "//consensus-types/blocks:go_default_library",
+        "//consensus-types:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//consensus-types/wrapper:go_default_library",
         "//crypto/ecdsa:go_default_library",

--- a/cmd/prysmctl/p2p/request_blocks.go
+++ b/cmd/prysmctl/p2p/request_blocks.go
@@ -13,7 +13,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/sync"
 	"github.com/prysmaticlabs/prysm/v4/cmd"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
-	consensusblocks "github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	pb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
@@ -190,7 +190,7 @@ func cliActionRequestBlocks(cliCtx *cli.Context) error {
 		for _, blk := range blocks {
 			exec, err := blk.Block().Body().Execution()
 			switch {
-			case errors.Is(err, consensusblocks.ErrUnsupportedGetter):
+			case errors.Is(err, consensus_types.ErrUnsupportedGetter):
 				continue
 			case err != nil:
 				log.WithError(err).Error("Could not read execution data from block body")
@@ -199,7 +199,7 @@ func cliActionRequestBlocks(cliCtx *cli.Context) error {
 			}
 			_, err = exec.Transactions()
 			switch {
-			case errors.Is(err, consensusblocks.ErrUnsupportedGetter):
+			case errors.Is(err, consensus_types.ErrUnsupportedGetter):
 				continue
 			case err != nil:
 				log.WithError(err).Error("Could not read transactions block execution payload")

--- a/consensus-types/BUILD.bazel
+++ b/consensus-types/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@prysm//tools/go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["types.go"],
+    importpath = "github.com/prysmaticlabs/prysm/v4/consensus-types",
+    visibility = ["//visibility:public"],
+)

--- a/consensus-types/BUILD.bazel
+++ b/consensus-types/BUILD.bazel
@@ -5,4 +5,8 @@ go_library(
     srcs = ["types.go"],
     importpath = "github.com/prysmaticlabs/prysm/v4/consensus-types",
     visibility = ["//visibility:public"],
+    deps = [
+        "//runtime/version:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+    ],
 )

--- a/consensus-types/blocks/BUILD.bazel
+++ b/consensus-types/blocks/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//config/fieldparams:go_default_library",
+        "//consensus-types:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",
@@ -39,6 +40,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//config/fieldparams:go_default_library",
+        "//consensus-types:go_default_library",
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//encoding/bytesutil:go_default_library",

--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -147,17 +147,17 @@ func (e executionPayload) Transactions() ([][]byte, error) {
 
 // TransactionsRoot --
 func (e executionPayload) TransactionsRoot() ([]byte, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // Withdrawals --
 func (e executionPayload) Withdrawals() ([]*enginev1.Withdrawal, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // WithdrawalsRoot --
 func (e executionPayload) WithdrawalsRoot() ([]byte, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // PbBellatrix --
@@ -167,12 +167,12 @@ func (e executionPayload) PbBellatrix() (*enginev1.ExecutionPayload, error) {
 
 // PbCapella --
 func (executionPayload) PbCapella() (*enginev1.ExecutionPayloadCapella, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // ValueInGwei --
 func (executionPayload) ValueInGwei() (uint64, error) {
-	return 0, ErrUnsupportedGetter
+	return 0, consensus_types.ErrUnsupportedGetter
 }
 
 // executionPayloadHeader is a convenience wrapper around a blinded beacon block body's execution header data structure
@@ -303,7 +303,7 @@ func (e executionPayloadHeader) BlockHash() []byte {
 
 // Transactions --
 func (executionPayloadHeader) Transactions() ([][]byte, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // TransactionsRoot --
@@ -313,27 +313,27 @@ func (e executionPayloadHeader) TransactionsRoot() ([]byte, error) {
 
 // Withdrawals --
 func (e executionPayloadHeader) Withdrawals() ([]*enginev1.Withdrawal, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // WithdrawalsRoot --
 func (e executionPayloadHeader) WithdrawalsRoot() ([]byte, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // PbCapella --
 func (executionPayloadHeader) PbCapella() (*enginev1.ExecutionPayloadCapella, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // PbBellatrix --
 func (executionPayloadHeader) PbBellatrix() (*enginev1.ExecutionPayload, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // ValueInGwei --
 func (executionPayloadHeader) ValueInGwei() (uint64, error) {
-	return 0, ErrUnsupportedGetter
+	return 0, consensus_types.ErrUnsupportedGetter
 }
 
 // PayloadToHeader converts `payload` into execution payload header format.
@@ -498,7 +498,7 @@ func (e executionPayloadCapella) Transactions() ([][]byte, error) {
 
 // TransactionsRoot --
 func (e executionPayloadCapella) TransactionsRoot() ([]byte, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // Withdrawals --
@@ -508,7 +508,7 @@ func (e executionPayloadCapella) Withdrawals() ([]*enginev1.Withdrawal, error) {
 
 // WithdrawalsRoot --
 func (e executionPayloadCapella) WithdrawalsRoot() ([]byte, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // PbCapella --
@@ -518,7 +518,7 @@ func (e executionPayloadCapella) PbCapella() (*enginev1.ExecutionPayloadCapella,
 
 // PbBellatrix --
 func (executionPayloadCapella) PbBellatrix() (*enginev1.ExecutionPayload, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // ValueInGwei --
@@ -655,7 +655,7 @@ func (e executionPayloadHeaderCapella) BlockHash() []byte {
 
 // Transactions --
 func (executionPayloadHeaderCapella) Transactions() ([][]byte, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // TransactionsRoot --
@@ -665,7 +665,7 @@ func (e executionPayloadHeaderCapella) TransactionsRoot() ([]byte, error) {
 
 // Withdrawals --
 func (e executionPayloadHeaderCapella) Withdrawals() ([]*enginev1.Withdrawal, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // WithdrawalsRoot --
@@ -675,12 +675,12 @@ func (e executionPayloadHeaderCapella) WithdrawalsRoot() ([]byte, error) {
 
 // PbCapella --
 func (executionPayloadHeaderCapella) PbCapella() (*enginev1.ExecutionPayloadCapella, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // PbBellatrix --
 func (executionPayloadHeaderCapella) PbBellatrix() (*enginev1.ExecutionPayload, error) {
-	return nil, ErrUnsupportedGetter
+	return nil, consensus_types.ErrUnsupportedGetter
 }
 
 // ValueInGwei --
@@ -756,7 +756,7 @@ func IsEmptyExecutionData(data interfaces.ExecutionData) (bool, error) {
 
 	txs, err := data.Transactions()
 	switch {
-	case errors.Is(err, ErrUnsupportedGetter):
+	case errors.Is(err, consensus_types.ErrUnsupportedGetter):
 	case err != nil:
 		return false, err
 	default:

--- a/consensus-types/blocks/execution.go
+++ b/consensus-types/blocks/execution.go
@@ -6,6 +6,7 @@ import (
 
 	fastssz "github.com/prysmaticlabs/fastssz"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v4/encoding/ssz"
@@ -24,7 +25,7 @@ type executionPayload struct {
 func WrappedExecutionPayload(p *enginev1.ExecutionPayload) (interfaces.ExecutionData, error) {
 	w := executionPayload{p: p}
 	if w.IsNil() {
-		return nil, ErrNilObjectWrapped
+		return nil, consensus_types.ErrNilObjectWrapped
 	}
 	return w, nil
 }
@@ -185,7 +186,7 @@ type executionPayloadHeader struct {
 func WrappedExecutionPayloadHeader(p *enginev1.ExecutionPayloadHeader) (interfaces.ExecutionData, error) {
 	w := executionPayloadHeader{p: p}
 	if w.IsNil() {
-		return nil, ErrNilObjectWrapped
+		return nil, consensus_types.ErrNilObjectWrapped
 	}
 	return w, nil
 }
@@ -375,7 +376,7 @@ type executionPayloadCapella struct {
 func WrappedExecutionPayloadCapella(p *enginev1.ExecutionPayloadCapella, value uint64) (interfaces.ExecutionData, error) {
 	w := executionPayloadCapella{p: p, value: value}
 	if w.IsNil() {
-		return nil, ErrNilObjectWrapped
+		return nil, consensus_types.ErrNilObjectWrapped
 	}
 	return w, nil
 }
@@ -537,7 +538,7 @@ type executionPayloadHeaderCapella struct {
 func WrappedExecutionPayloadHeaderCapella(p *enginev1.ExecutionPayloadHeaderCapella, value uint64) (interfaces.ExecutionData, error) {
 	w := executionPayloadHeaderCapella{p: p, value: value}
 	if w.IsNil() {
-		return nil, ErrNilObjectWrapped
+		return nil, consensus_types.ErrNilObjectWrapped
 	}
 	return w, nil
 }

--- a/consensus-types/blocks/execution_test.go
+++ b/consensus-types/blocks/execution_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	enginev1 "github.com/prysmaticlabs/prysm/v4/proto/engine/v1"
@@ -40,7 +41,7 @@ func TestWrapExecutionPayload_IsNil(t *testing.T) {
 
 func TestWrapExecutionPayloadHeader_IsNil(t *testing.T) {
 	_, err := blocks.WrappedExecutionPayloadHeader(nil)
-	require.Equal(t, blocks.ErrNilObjectWrapped, err)
+	require.Equal(t, consensus_types.ErrNilObjectWrapped, err)
 
 	data := &enginev1.ExecutionPayloadHeader{GasUsed: 54}
 	wsb, err := blocks.WrappedExecutionPayloadHeader(data)

--- a/consensus-types/blocks/execution_test.go
+++ b/consensus-types/blocks/execution_test.go
@@ -30,7 +30,7 @@ func TestWrapExecutionPayloadHeader(t *testing.T) {
 
 func TestWrapExecutionPayload_IsNil(t *testing.T) {
 	_, err := blocks.WrappedExecutionPayload(nil)
-	require.Equal(t, blocks.ErrNilObjectWrapped, err)
+	require.Equal(t, consensus_types.ErrNilObjectWrapped, err)
 
 	data := &enginev1.ExecutionPayload{GasUsed: 54}
 	wsb, err := blocks.WrappedExecutionPayload(data)
@@ -152,7 +152,7 @@ func TestWrapExecutionPayloadHeaderCapella(t *testing.T) {
 
 func TestWrapExecutionPayloadCapella_IsNil(t *testing.T) {
 	_, err := blocks.WrappedExecutionPayloadCapella(nil, 0)
-	require.Equal(t, blocks.ErrNilObjectWrapped, err)
+	require.Equal(t, consensus_types.ErrNilObjectWrapped, err)
 
 	data := &enginev1.ExecutionPayloadCapella{GasUsed: 54}
 	payload, err := blocks.WrappedExecutionPayloadCapella(data, 0)
@@ -163,7 +163,7 @@ func TestWrapExecutionPayloadCapella_IsNil(t *testing.T) {
 
 func TestWrapExecutionPayloadHeaderCapella_IsNil(t *testing.T) {
 	_, err := blocks.WrappedExecutionPayloadHeaderCapella(nil, 0)
-	require.Equal(t, blocks.ErrNilObjectWrapped, err)
+	require.Equal(t, consensus_types.ErrNilObjectWrapped, err)
 
 	data := &enginev1.ExecutionPayloadHeaderCapella{GasUsed: 54}
 	payload, err := blocks.WrappedExecutionPayloadHeaderCapella(data, 0)

--- a/consensus-types/blocks/execution_test.go
+++ b/consensus-types/blocks/execution_test.go
@@ -211,16 +211,16 @@ func Test_executionPayload_Pb(t *testing.T) {
 	assert.DeepEqual(t, payload.Proto(), pb)
 
 	_, err = payload.PbCapella()
-	require.ErrorIs(t, err, blocks.ErrUnsupportedGetter)
+	require.ErrorIs(t, err, consensus_types.ErrUnsupportedGetter)
 }
 
 func Test_executionPayloadHeader_Pb(t *testing.T) {
 	payload := createWrappedPayloadHeader(t)
 	_, err := payload.PbBellatrix()
-	require.ErrorIs(t, err, blocks.ErrUnsupportedGetter)
+	require.ErrorIs(t, err, consensus_types.ErrUnsupportedGetter)
 
 	_, err = payload.PbCapella()
-	require.ErrorIs(t, err, blocks.ErrUnsupportedGetter)
+	require.ErrorIs(t, err, consensus_types.ErrUnsupportedGetter)
 }
 
 func Test_executionPayloadCapella_Pb(t *testing.T) {
@@ -230,16 +230,16 @@ func Test_executionPayloadCapella_Pb(t *testing.T) {
 	assert.DeepEqual(t, payload.Proto(), pb)
 
 	_, err = payload.PbBellatrix()
-	require.ErrorIs(t, err, blocks.ErrUnsupportedGetter)
+	require.ErrorIs(t, err, consensus_types.ErrUnsupportedGetter)
 }
 
 func Test_executionPayloadHeaderCapella_Pb(t *testing.T) {
 	payload := createWrappedPayloadHeaderCapella(t)
 	_, err := payload.PbBellatrix()
-	require.ErrorIs(t, err, blocks.ErrUnsupportedGetter)
+	require.ErrorIs(t, err, consensus_types.ErrUnsupportedGetter)
 
 	_, err = payload.PbCapella()
-	require.ErrorIs(t, err, blocks.ErrUnsupportedGetter)
+	require.ErrorIs(t, err, consensus_types.ErrUnsupportedGetter)
 }
 
 func createWrappedPayload(t testing.TB) interfaces.ExecutionData {

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	ssz "github.com/prysmaticlabs/fastssz"
 	field_params "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	enginev1 "github.com/prysmaticlabs/prysm/v4/proto/engine/v1"
@@ -116,7 +117,7 @@ func (b *SignedBeaconBlock) PbGenericBlock() (*eth.GenericSignedBeaconBlock, err
 // PbPhase0Block returns the underlying protobuf object.
 func (b *SignedBeaconBlock) PbPhase0Block() (*eth.SignedBeaconBlock, error) {
 	if b.version != version.Phase0 {
-		return nil, ErrNotSupported("PbPhase0Block", b.version)
+		return nil, consensus_types.ErrNotSupported("PbPhase0Block", b.version)
 	}
 	pb, err := b.Proto()
 	if err != nil {
@@ -128,7 +129,7 @@ func (b *SignedBeaconBlock) PbPhase0Block() (*eth.SignedBeaconBlock, error) {
 // PbAltairBlock returns the underlying protobuf object.
 func (b *SignedBeaconBlock) PbAltairBlock() (*eth.SignedBeaconBlockAltair, error) {
 	if b.version != version.Altair {
-		return nil, ErrNotSupported("PbAltairBlock", b.version)
+		return nil, consensus_types.ErrNotSupported("PbAltairBlock", b.version)
 	}
 	pb, err := b.Proto()
 	if err != nil {
@@ -140,7 +141,7 @@ func (b *SignedBeaconBlock) PbAltairBlock() (*eth.SignedBeaconBlockAltair, error
 // PbBellatrixBlock returns the underlying protobuf object.
 func (b *SignedBeaconBlock) PbBellatrixBlock() (*eth.SignedBeaconBlockBellatrix, error) {
 	if b.version != version.Bellatrix || b.IsBlinded() {
-		return nil, ErrNotSupported("PbBellatrixBlock", b.version)
+		return nil, consensus_types.ErrNotSupported("PbBellatrixBlock", b.version)
 	}
 	pb, err := b.Proto()
 	if err != nil {
@@ -152,7 +153,7 @@ func (b *SignedBeaconBlock) PbBellatrixBlock() (*eth.SignedBeaconBlockBellatrix,
 // PbBlindedBellatrixBlock returns the underlying protobuf object.
 func (b *SignedBeaconBlock) PbBlindedBellatrixBlock() (*eth.SignedBlindedBeaconBlockBellatrix, error) {
 	if b.version != version.Bellatrix || !b.IsBlinded() {
-		return nil, ErrNotSupported("PbBlindedBellatrixBlock", b.version)
+		return nil, consensus_types.ErrNotSupported("PbBlindedBellatrixBlock", b.version)
 	}
 	pb, err := b.Proto()
 	if err != nil {
@@ -164,7 +165,7 @@ func (b *SignedBeaconBlock) PbBlindedBellatrixBlock() (*eth.SignedBlindedBeaconB
 // PbCapellaBlock returns the underlying protobuf object.
 func (b *SignedBeaconBlock) PbCapellaBlock() (*eth.SignedBeaconBlockCapella, error) {
 	if b.version != version.Capella || b.IsBlinded() {
-		return nil, ErrNotSupported("PbCapellaBlock", b.version)
+		return nil, consensus_types.ErrNotSupported("PbCapellaBlock", b.version)
 	}
 	pb, err := b.Proto()
 	if err != nil {
@@ -176,7 +177,7 @@ func (b *SignedBeaconBlock) PbCapellaBlock() (*eth.SignedBeaconBlockCapella, err
 // PbBlindedCapellaBlock returns the underlying protobuf object.
 func (b *SignedBeaconBlock) PbBlindedCapellaBlock() (*eth.SignedBlindedBeaconBlockCapella, error) {
 	if b.version != version.Capella || !b.IsBlinded() {
-		return nil, ErrNotSupported("PbBlindedCapellaBlock", b.version)
+		return nil, consensus_types.ErrNotSupported("PbBlindedCapellaBlock", b.version)
 	}
 	pb, err := b.Proto()
 	if err != nil {
@@ -813,7 +814,7 @@ func (b *BeaconBlockBody) VoluntaryExits() []*eth.SignedVoluntaryExit {
 // SyncAggregate returns the sync aggregate in the block.
 func (b *BeaconBlockBody) SyncAggregate() (*eth.SyncAggregate, error) {
 	if b.version == version.Phase0 {
-		return nil, ErrNotSupported("SyncAggregate", b.version)
+		return nil, consensus_types.ErrNotSupported("SyncAggregate", b.version)
 	}
 	return b.syncAggregate, nil
 }
@@ -822,7 +823,7 @@ func (b *BeaconBlockBody) SyncAggregate() (*eth.SyncAggregate, error) {
 func (b *BeaconBlockBody) Execution() (interfaces.ExecutionData, error) {
 	switch b.version {
 	case version.Phase0, version.Altair:
-		return nil, ErrNotSupported("Execution", b.version)
+		return nil, consensus_types.ErrNotSupported("Execution", b.version)
 	case version.Bellatrix:
 		if b.isBlinded {
 			var ph *enginev1.ExecutionPayloadHeader
@@ -872,7 +873,7 @@ func (b *BeaconBlockBody) Execution() (interfaces.ExecutionData, error) {
 
 func (b *BeaconBlockBody) BLSToExecutionChanges() ([]*eth.SignedBLSToExecutionChange, error) {
 	if b.version < version.Capella {
-		return nil, ErrNotSupported("BLSToExecutionChanges", b.version)
+		return nil, consensus_types.ErrNotSupported("BLSToExecutionChanges", b.version)
 	}
 	return b.blsToExecutionChanges, nil
 }

--- a/consensus-types/blocks/proto.go
+++ b/consensus-types/blocks/proto.go
@@ -2,6 +2,7 @@ package blocks
 
 import (
 	"github.com/pkg/errors"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	enginev1 "github.com/prysmaticlabs/prysm/v4/proto/engine/v1"
 	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
@@ -614,7 +615,7 @@ func initBlockBodyFromProtoBellatrix(pb *eth.BeaconBlockBodyBellatrix) (*BeaconB
 
 	p, err := WrappedExecutionPayload(pb.ExecutionPayload)
 	// We allow the payload to be nil
-	if err != nil && err != ErrNilObjectWrapped {
+	if err != nil && err != consensus_types.ErrNilObjectWrapped {
 		return nil, err
 	}
 	b := &BeaconBlockBody{
@@ -641,7 +642,7 @@ func initBlindedBlockBodyFromProtoBellatrix(pb *eth.BlindedBeaconBlockBodyBellat
 
 	ph, err := WrappedExecutionPayloadHeader(pb.ExecutionPayloadHeader)
 	// We allow the payload to be nil
-	if err != nil && err != ErrNilObjectWrapped {
+	if err != nil && err != consensus_types.ErrNilObjectWrapped {
 		return nil, err
 	}
 	b := &BeaconBlockBody{
@@ -668,7 +669,7 @@ func initBlockBodyFromProtoCapella(pb *eth.BeaconBlockBodyCapella) (*BeaconBlock
 
 	p, err := WrappedExecutionPayloadCapella(pb.ExecutionPayload, 0)
 	// We allow the payload to be nil
-	if err != nil && err != ErrNilObjectWrapped {
+	if err != nil && err != consensus_types.ErrNilObjectWrapped {
 		return nil, err
 	}
 	b := &BeaconBlockBody{
@@ -696,7 +697,7 @@ func initBlindedBlockBodyFromProtoCapella(pb *eth.BlindedBeaconBlockBodyCapella)
 
 	ph, err := WrappedExecutionPayloadHeaderCapella(pb.ExecutionPayloadHeader, 0)
 	// We allow the payload to be nil
-	if err != nil && err != ErrNilObjectWrapped {
+	if err != nil && err != consensus_types.ErrNilObjectWrapped {
 		return nil, err
 	}
 	b := &BeaconBlockBody{

--- a/consensus-types/blocks/setters.go
+++ b/consensus-types/blocks/setters.go
@@ -1,6 +1,7 @@
 package blocks
 
 import (
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
@@ -95,7 +96,7 @@ func (b *SignedBeaconBlock) SetVoluntaryExits(v []*eth.SignedVoluntaryExit) {
 // This function is not thread safe, it is only used during block creation.
 func (b *SignedBeaconBlock) SetSyncAggregate(s *eth.SyncAggregate) error {
 	if b.version == version.Phase0 {
-		return ErrNotSupported("SyncAggregate", b.version)
+		return consensus_types.ErrNotSupported("SyncAggregate", b.version)
 	}
 	b.block.body.syncAggregate = s
 	return nil
@@ -105,7 +106,7 @@ func (b *SignedBeaconBlock) SetSyncAggregate(s *eth.SyncAggregate) error {
 // This function is not thread safe, it is only used during block creation.
 func (b *SignedBeaconBlock) SetExecution(e interfaces.ExecutionData) error {
 	if b.version == version.Phase0 || b.version == version.Altair {
-		return ErrNotSupported("Execution", b.version)
+		return consensus_types.ErrNotSupported("Execution", b.version)
 	}
 	if b.block.body.isBlinded {
 		b.block.body.executionPayloadHeader = e
@@ -119,7 +120,7 @@ func (b *SignedBeaconBlock) SetExecution(e interfaces.ExecutionData) error {
 // This function is not thread safe, it is only used during block creation.
 func (b *SignedBeaconBlock) SetBLSToExecutionChanges(blsToExecutionChanges []*eth.SignedBLSToExecutionChange) error {
 	if b.version < version.Capella {
-		return ErrNotSupported("BLSToExecutionChanges", b.version)
+		return consensus_types.ErrNotSupported("BLSToExecutionChanges", b.version)
 	}
 	b.block.body.blsToExecutionChanges = blsToExecutionChanges
 	return nil

--- a/consensus-types/blocks/types.go
+++ b/consensus-types/blocks/types.go
@@ -31,9 +31,7 @@ var (
 	// ErrUnsupportedGetter is returned when a getter access is not supported for a specific beacon block version.
 	ErrUnsupportedGetter = errors.New("unsupported getter")
 	// ErrUnsupportedVersion for beacon block methods.
-	ErrUnsupportedVersion = errors.New("unsupported beacon block version")
-	// ErrNilObjectWrapped is returned in a constructor when the underlying object is nil.
-	ErrNilObjectWrapped      = errors.New("attempted to wrap nil object")
+	ErrUnsupportedVersion    = errors.New("unsupported beacon block version")
 	errNilBlock              = errors.New("received nil beacon block")
 	errNilBlockBody          = errors.New("received nil beacon block body")
 	errIncorrectBlockVersion = errors.New(incorrectBlockVersion)

--- a/consensus-types/blocks/types.go
+++ b/consensus-types/blocks/types.go
@@ -1,14 +1,11 @@
 package blocks
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	field_params "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
-	"github.com/prysmaticlabs/prysm/v4/runtime/version"
 )
 
 var (
@@ -28,8 +25,6 @@ const (
 )
 
 var (
-	// ErrUnsupportedGetter is returned when a getter access is not supported for a specific beacon block version.
-	ErrUnsupportedGetter = errors.New("unsupported getter")
 	// ErrUnsupportedVersion for beacon block methods.
 	ErrUnsupportedVersion    = errors.New("unsupported beacon block version")
 	errNilBlock              = errors.New("received nil beacon block")
@@ -71,8 +66,4 @@ type SignedBeaconBlock struct {
 	version   int
 	block     *BeaconBlock
 	signature [field_params.BLSSignatureLength]byte
-}
-
-func ErrNotSupported(funcName string, ver int) error {
-	return errors.Wrap(ErrUnsupportedGetter, fmt.Sprintf("%s is not supported for %s", funcName, version.String(ver)))
 }

--- a/consensus-types/payload-attribute/BUILD.bazel
+++ b/consensus-types/payload-attribute/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v4/consensus-types/payload-attribute",
     visibility = ["//visibility:public"],
     deps = [
+        "//consensus-types:go_default_library",
         "//consensus-types/blocks:go_default_library",
         "//proto/engine/v1:go_default_library",
         "//runtime/version:go_default_library",

--- a/consensus-types/payload-attribute/getters.go
+++ b/consensus-types/payload-attribute/getters.go
@@ -1,7 +1,7 @@
 package payloadattribute
 
 import (
-	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	enginev1 "github.com/prysmaticlabs/prysm/v4/proto/engine/v1"
 	"github.com/prysmaticlabs/prysm/v4/runtime/version"
 )
@@ -33,7 +33,7 @@ func (a *data) Withdrawals() ([]*enginev1.Withdrawal, error) {
 		return nil, errNilPayloadAttribute
 	}
 	if a.version < version.Capella {
-		return nil, blocks.ErrNotSupported("Withdrawals", a.version)
+		return nil, consensus_types.ErrNotSupported("Withdrawals", a.version)
 	}
 	return a.withdrawals, nil
 }
@@ -44,7 +44,7 @@ func (a *data) PbV1() (*enginev1.PayloadAttributes, error) {
 		return nil, errNilPayloadAttribute
 	}
 	if a.version != version.Bellatrix {
-		return nil, blocks.ErrNotSupported("PayloadAttributePbV1", a.version)
+		return nil, consensus_types.ErrNotSupported("PayloadAttributePbV1", a.version)
 	}
 	if a.timeStamp == 0 && len(a.prevRandao) == 0 {
 		return nil, nil
@@ -62,7 +62,7 @@ func (a *data) PbV2() (*enginev1.PayloadAttributesV2, error) {
 		return nil, errNilPayloadAttribute
 	}
 	if a.version != version.Capella {
-		return nil, blocks.ErrNotSupported("PayloadAttributePbV2", a.version)
+		return nil, consensus_types.ErrNotSupported("PayloadAttributePbV2", a.version)
 	}
 	if a.timeStamp == 0 && len(a.prevRandao) == 0 {
 		return nil, nil

--- a/consensus-types/types.go
+++ b/consensus-types/types.go
@@ -1,0 +1,6 @@
+package consensus_types
+
+import "errors"
+
+// ErrNilObjectWrapped is returned in a constructor when the underlying object is nil.
+var ErrNilObjectWrapped = errors.New("attempted to wrap nil object")

--- a/consensus-types/types.go
+++ b/consensus-types/types.go
@@ -1,6 +1,20 @@
 package consensus_types
 
-import "errors"
+import (
+	"errors"
+	"fmt"
 
-// ErrNilObjectWrapped is returned in a constructor when the underlying object is nil.
-var ErrNilObjectWrapped = errors.New("attempted to wrap nil object")
+	errors2 "github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v4/runtime/version"
+)
+
+var (
+	// ErrNilObjectWrapped is returned in a constructor when the underlying object is nil.
+	ErrNilObjectWrapped = errors.New("attempted to wrap nil object")
+	// ErrUnsupportedGetter is returned when a getter access is not supported for a specific beacon block version.
+	ErrUnsupportedGetter = errors.New("unsupported getter")
+)
+
+func ErrNotSupported(funcName string, ver int) error {
+	return errors2.Wrap(ErrUnsupportedGetter, fmt.Sprintf("%s is not supported for %s", funcName, version.String(ver)))
+}


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

`ErrNilObjectWrapped`, `ErrUnsupportedGetter` and `ErrNotSupported` all currently live in the `blocks` package, but they are applicable to all consensus types. This PR moves these members out to the top-level `consensus-types` package.
