### PR TITLE
Fixing flaky validator tests

### DIFF
--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -89,17 +89,7 @@ func run(ctx context.Context, v iface.Validator) {
 				continue
 			}
 		case currentKeys := <-accountsChangedChan:
-			anyActive, err := v.HandleKeyReload(ctx, currentKeys)
-			if err != nil {
-				log.WithError(err).Error("Could not properly handle reloaded keys")
-			}
-			if !anyActive {
-				log.Warn("No active keys found. Waiting for activation...")
-				err := v.WaitForActivation(ctx, accountsChangedChan)
-				if err != nil {
-					log.WithError(err).Warn("Could not wait for validator activation")
-				}
-			}
+			onAccountsChanged(ctx, v, currentKeys, accountsChangedChan)
 		case slot := <-v.NextSlot():
 			span.AddAttributes(trace.Int64Attribute("slot", int64(slot))) // lint:ignore uintcast -- This conversion is OK for tracing.
 			allExited, err := v.AllValidatorsAreExited(ctx)
@@ -150,6 +140,20 @@ func run(ctx context.Context, v iface.Validator) {
 				continue
 			}
 			performRoles(slotCtx, allRoles, v, slot, &wg, span)
+		}
+	}
+}
+
+func onAccountsChanged(ctx context.Context, v iface.Validator, current [][48]byte, ac chan [][fieldparams.BLSPubkeyLength]byte) {
+	anyActive, err := v.HandleKeyReload(ctx, current)
+	if err != nil {
+		log.WithError(err).Error("Could not properly handle reloaded keys")
+	}
+	if !anyActive {
+		log.Warn("No active keys found. Waiting for activation...")
+		err := v.WaitForActivation(ctx, ac)
+		if err != nil {
+			log.WithError(err).Warn("Could not wait for validator activation")
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The validator run() loop code is tricky to test because it's based around a big channel select statement. Tests on this loop are flaky because they cancel the run loops context right after sending it a message over a channel and then checking that the receiving end called expected functions, resulting in a race between the context cancellation and the handler. To simplify things I broke out the piece of the handler that this flaky func wants to test into it's own synchronous func.
