### PR TITLE
Keymanager mock cleanup

### DIFF
--- a/validator/client/attest_test.go
+++ b/validator/client/attest_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
-	"github.com/prysmaticlabs/prysm/v4/crypto/bls"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	validatorpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1/validator-client"
@@ -444,9 +443,6 @@ func TestSignAttestation(t *testing.T) {
 	validator, m, _, finish := setup(t)
 	defer finish()
 
-	secretKey, err := bls.SecretKeyFromBytes(bytesutil.PadTo([]byte{1}, 32))
-	require.NoError(t, err, "Failed to generate key from bytes")
-	publicKey := secretKey.PublicKey()
 	wantedFork := &ethpb.Fork{
 		PreviousVersion: []byte{'a', 'b', 'c', 'd'},
 		CurrentVersion:  []byte{'d', 'e', 'f', 'f'},
@@ -464,15 +460,10 @@ func TestSignAttestation(t *testing.T) {
 	att.Data.Target.Epoch = 200
 	att.Data.Slot = 999
 	att.Data.BeaconBlockRoot = bytesutil.PadTo([]byte("blockRoot"), 32)
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], publicKey.Marshal())
-	km := &mockKeymanager{
-		keysMap: map[[fieldparams.BLSPubkeyLength]byte]bls.SecretKey{
-			pubKey: secretKey,
-		},
-	}
-	validator.keyManager = km
-	sig, sr, err := validator.signAtt(ctx, pubKey, att.Data, att.Data.Slot)
+
+	pk := testKeyFromBytes(t, []byte{1})
+	validator.keyManager = newMockKeymanager(t, pk)
+	sig, sr, err := validator.signAtt(ctx, pk.pub, att.Data, att.Data.Slot)
 	require.NoError(t, err, "%x,%x,%v", sig, sr, err)
 	require.Equal(t, "b6a60f8497bd328908be83634d045"+
 		"dd7a32f5e246b2c4031fc2f316983f362e36fc27fd3d6d5a2b15"+

--- a/validator/client/key_reload_test.go
+++ b/validator/client/key_reload_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
-	"github.com/prysmaticlabs/prysm/v4/crypto/bls"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/testing/assert"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
@@ -23,40 +22,30 @@ func TestValidator_HandleKeyReload(t *testing.T) {
 	t.Run("active", func(t *testing.T) {
 		hook := logTest.NewGlobal()
 
-		inactivePrivKey, err := bls.RandKey()
-		require.NoError(t, err)
-		var inactivePubKey [fieldparams.BLSPubkeyLength]byte
-		copy(inactivePubKey[:], inactivePrivKey.PublicKey().Marshal())
-		activePrivKey, err := bls.RandKey()
-		require.NoError(t, err)
-		var activePubKey [fieldparams.BLSPubkeyLength]byte
-		copy(activePubKey[:], activePrivKey.PublicKey().Marshal())
-		km := &mockKeymanager{
-			keysMap: map[[fieldparams.BLSPubkeyLength]byte]bls.SecretKey{
-				inactivePubKey: inactivePrivKey,
-			},
-		}
+		inactive := randKeypair(t)
+		active := randKeypair(t)
+
 		client := validatormock.NewMockValidatorClient(ctrl)
 		beaconClient := validatormock.NewMockBeaconChainClient(ctrl)
 		v := validator{
 			validatorClient: client,
-			keyManager:      km,
+			keyManager:      newMockKeymanager(t, inactive),
 			genesisTime:     1,
 			beaconClient:    beaconClient,
 		}
 
-		resp := testutil.GenerateMultipleValidatorStatusResponse([][]byte{inactivePubKey[:], activePubKey[:]})
+		resp := testutil.GenerateMultipleValidatorStatusResponse([][]byte{inactive.pub[:], active.pub[:]})
 		resp.Statuses[0].Status = ethpb.ValidatorStatus_UNKNOWN_STATUS
 		resp.Statuses[1].Status = ethpb.ValidatorStatus_ACTIVE
 		client.EXPECT().MultipleValidatorStatus(
 			gomock.Any(),
 			&ethpb.MultipleValidatorStatusRequest{
-				PublicKeys: [][]byte{inactivePubKey[:], activePubKey[:]},
+				PublicKeys: [][]byte{inactive.pub[:], active.pub[:]},
 			},
 		).Return(resp, nil)
 		beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil)
 
-		anyActive, err := v.HandleKeyReload(context.Background(), [][fieldparams.BLSPubkeyLength]byte{inactivePubKey, activePubKey})
+		anyActive, err := v.HandleKeyReload(context.Background(), [][fieldparams.BLSPubkeyLength]byte{inactive.pub, active.pub})
 		require.NoError(t, err)
 		assert.Equal(t, true, anyActive)
 		assert.LogsContain(t, hook, "Waiting for deposit to be observed by beacon node")
@@ -66,35 +55,27 @@ func TestValidator_HandleKeyReload(t *testing.T) {
 	t.Run("no active", func(t *testing.T) {
 		hook := logTest.NewGlobal()
 
-		inactivePrivKey, err := bls.RandKey()
-		require.NoError(t, err)
-		var inactivePubKey [fieldparams.BLSPubkeyLength]byte
-		copy(inactivePubKey[:], inactivePrivKey.PublicKey().Marshal())
-		km := &mockKeymanager{
-			keysMap: map[[fieldparams.BLSPubkeyLength]byte]bls.SecretKey{
-				inactivePubKey: inactivePrivKey,
-			},
-		}
 		client := validatormock.NewMockValidatorClient(ctrl)
 		beaconClient := validatormock.NewMockBeaconChainClient(ctrl)
+		kp := randKeypair(t)
 		v := validator{
 			validatorClient: client,
-			keyManager:      km,
+			keyManager:      newMockKeymanager(t, kp),
 			genesisTime:     1,
 			beaconClient:    beaconClient,
 		}
 
-		resp := testutil.GenerateMultipleValidatorStatusResponse([][]byte{inactivePubKey[:]})
+		resp := testutil.GenerateMultipleValidatorStatusResponse([][]byte{kp.pub[:]})
 		resp.Statuses[0].Status = ethpb.ValidatorStatus_UNKNOWN_STATUS
 		client.EXPECT().MultipleValidatorStatus(
 			gomock.Any(),
 			&ethpb.MultipleValidatorStatusRequest{
-				PublicKeys: [][]byte{inactivePubKey[:]},
+				PublicKeys: [][]byte{kp.pub[:]},
 			},
 		).Return(resp, nil)
 		beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil)
 
-		anyActive, err := v.HandleKeyReload(context.Background(), [][fieldparams.BLSPubkeyLength]byte{inactivePubKey})
+		anyActive, err := v.HandleKeyReload(context.Background(), [][fieldparams.BLSPubkeyLength]byte{kp.pub})
 		require.NoError(t, err)
 		assert.Equal(t, false, anyActive)
 		assert.LogsContain(t, hook, "Waiting for deposit to be observed by beacon node")
@@ -102,30 +83,22 @@ func TestValidator_HandleKeyReload(t *testing.T) {
 	})
 
 	t.Run("error when getting status", func(t *testing.T) {
-		inactivePrivKey, err := bls.RandKey()
-		require.NoError(t, err)
-		var inactivePubKey [fieldparams.BLSPubkeyLength]byte
-		copy(inactivePubKey[:], inactivePrivKey.PublicKey().Marshal())
-		km := &mockKeymanager{
-			keysMap: map[[fieldparams.BLSPubkeyLength]byte]bls.SecretKey{
-				inactivePubKey: inactivePrivKey,
-			},
-		}
+		kp := randKeypair(t)
 		client := validatormock.NewMockValidatorClient(ctrl)
 		v := validator{
 			validatorClient: client,
-			keyManager:      km,
+			keyManager:      newMockKeymanager(t, kp),
 			genesisTime:     1,
 		}
 
 		client.EXPECT().MultipleValidatorStatus(
 			gomock.Any(),
 			&ethpb.MultipleValidatorStatusRequest{
-				PublicKeys: [][]byte{inactivePubKey[:]},
+				PublicKeys: [][]byte{kp.pub[:]},
 			},
 		).Return(nil, errors.New("error"))
 
-		_, err = v.HandleKeyReload(context.Background(), [][fieldparams.BLSPubkeyLength]byte{inactivePubKey})
+		_, err := v.HandleKeyReload(context.Background(), [][fieldparams.BLSPubkeyLength]byte{kp.pub})
 		assert.ErrorContains(t, "error", err)
 	})
 }


### PR DESCRIPTION


**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**

I started out trying to fix a racy test in the validator code and wound up doing a cleanup pass on how we set up the mock keymanager. Goal is to make test setup more concise and easy to read, get rid of unnecessary boilerplate. Most importantly give tests control over the ordering of the return value from the `FetchValidatingPublicKeys` mock method, since the mock tests are a bit fragile and can break due to the non-deterministic ordering from iterating over the keymap. 
