### PR TITLE
Change prepare attestation interval times

### DIFF
--- a/beacon-chain/operations/attestations/prepare_forkchoice.go
+++ b/beacon-chain/operations/attestations/prepare_forkchoice.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/crypto/hash"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	attaggregation "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1/attestation/aggregation/attestations"
@@ -20,11 +21,20 @@ var prepareForkChoiceAttsPeriod = slots.DivideSlotBy(3 /* times-per-slot */)
 // This prepares fork choice attestations by running batchForkChoiceAtts
 // every prepareForkChoiceAttsPeriod.
 func (s *Service) prepareForkChoiceAtts() {
-	ticker := time.NewTicker(prepareForkChoiceAttsPeriod)
-	defer ticker.Stop()
+	ticker1 := slots.NewSlotTickerWithOffset(time.Unix(int64(s.genesisTime), 0), 5*time.Second, params.BeaconConfig().SecondsPerSlot)
+	ticker2 := slots.NewSlotTickerWithOffset(time.Unix(int64(s.genesisTime), 0), 9*time.Second, params.BeaconConfig().SecondsPerSlot)
+	ticker3 := slots.NewSlotTickerWithOffset(time.Unix(int64(s.genesisTime), 0), 11*time.Second, params.BeaconConfig().SecondsPerSlot)
 	for {
 		select {
-		case <-ticker.C:
+		case <-ticker1.C():
+			if err := s.batchForkChoiceAtts(s.ctx); err != nil {
+				log.WithError(err).Error("Could not prepare attestations for fork choice")
+			}
+		case <-ticker2.C():
+			if err := s.batchForkChoiceAtts(s.ctx); err != nil {
+				log.WithError(err).Error("Could not prepare attestations for fork choice")
+			}
+		case <-ticker3.C():
 			if err := s.batchForkChoiceAtts(s.ctx); err != nil {
 				log.WithError(err).Error("Could not prepare attestations for fork choice")
 			}


### PR DESCRIPTION
This PR does two things
- Current prepare attestation time is every 4s. This 4s interval is stochastic, given when the node starts. It could be 1s, 5s, 9s. Or 2s, 6, 10s... etc. The interval should be fixed
- Instead of 4s, we change it to variable time at 5s, 9s, and 11s. Reason for these times (TODO: pending reviews)
    -  4s for unaggregated atts
    -  8s for aggregated atts
    - 11s for before the next block proposal