### PR TITLE
Fix `PbV2` version check for post capella upgrades

### DIFF
--- a/consensus-types/payload-attribute/getters.go
+++ b/consensus-types/payload-attribute/getters.go
@@ -61,7 +61,7 @@ func (a *data) PbV2() (*enginev1.PayloadAttributesV2, error) {
 	if a == nil {
 		return nil, errNilPayloadAttribute
 	}
-	if a.version != version.Capella {
+	if a.version < version.Capella {
 		return nil, consensus_types.ErrNotSupported("PayloadAttributePbV2", a.version)
 	}
 	if a.timeStamp == 0 && len(a.prevRandao) == 0 {


### PR DESCRIPTION
Post capella updates, PbV2 is usable if there's no schema changes. This is the case for deneb