### PR TITLE
Fix Key Filtering In Validator

### DIFF
--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -1050,7 +1050,8 @@ func (v *validator) filterAndCacheActiveKeys(ctx context.Context, pubkeys [][fie
 			}
 			v.pubkeyToValidatorIndex[k] = i
 		}
-		statusRequestKeys = append(statusRequestKeys, k[:])
+		copiedk := k
+		statusRequestKeys = append(statusRequestKeys, copiedk[:])
 	}
 	resp, err := v.validatorClient.MultipleValidatorStatus(ctx, &ethpb.MultipleValidatorStatusRequest{
 		PublicKeys: statusRequestKeys,


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In #12322 we introduced the ability to filter keys based on the current validator status. However the change introduced a bug which lead to only 1 key being passed into the `MultipleValidatorStatus` request. For an example on how this would happen:
https://go.dev/play/p/1cPEh5fYIvx

The PR copies the key and appends it to the slice along with modifying the unit test so that this particular case can be caught correctly.
 
**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
