### PR TITLE
Do Not Panic on Broadcasting Nil Object

### DIFF
--- a/beacon-chain/p2p/broadcaster.go
+++ b/beacon-chain/p2p/broadcaster.go
@@ -55,6 +55,9 @@ func (s *Service) Broadcast(ctx context.Context, msg proto.Message) error {
 // BroadcastAttestation broadcasts an attestation to the p2p network, the message is assumed to be
 // broadcasted to the current fork.
 func (s *Service) BroadcastAttestation(ctx context.Context, subnet uint64, att *ethpb.Attestation) error {
+	if att == nil {
+		return errors.New("attempted to broadcast nil attestation")
+	}
 	ctx, span := trace.StartSpan(ctx, "p2p.BroadcastAttestation")
 	defer span.End()
 	forkDigest, err := s.currentForkDigest()
@@ -73,6 +76,9 @@ func (s *Service) BroadcastAttestation(ctx context.Context, subnet uint64, att *
 // BroadcastSyncCommitteeMessage broadcasts a sync committee message to the p2p network, the message is assumed to be
 // broadcasted to the current fork.
 func (s *Service) BroadcastSyncCommitteeMessage(ctx context.Context, subnet uint64, sMsg *ethpb.SyncCommitteeMessage) error {
+	if sMsg == nil {
+		return errors.New("attempted to broadcast nil sync committee message")
+	}
 	ctx, span := trace.StartSpan(ctx, "p2p.BroadcastSyncCommitteeMessage")
 	defer span.End()
 	forkDigest, err := s.currentForkDigest()

--- a/beacon-chain/p2p/broadcaster_test.go
+++ b/beacon-chain/p2p/broadcaster_test.go
@@ -196,8 +196,12 @@ func TestService_BroadcastAttestation(t *testing.T) {
 		}
 	}(t)
 
+	// Attempt to broadcast nil object should fail.
+	ctx := context.Background()
+	require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastAttestation(ctx, subnet, nil))
+
 	// Broadcast to peers and wait.
-	require.NoError(t, p.BroadcastAttestation(context.Background(), subnet, msg))
+	require.NoError(t, p.BroadcastAttestation(ctx, subnet, msg))
 	if util.WaitTimeout(&wg, 1*time.Second) {
 		t.Error("Failed to receive pubsub within 1s")
 	}
@@ -433,8 +437,12 @@ func TestService_BroadcastSyncCommittee(t *testing.T) {
 		}
 	}(t)
 
+	// Broadcasting nil should fail.
+	ctx := context.Background()
+	require.ErrorContains(t, "attempted to broadcast nil", p.BroadcastSyncCommitteeMessage(ctx, subnet, nil))
+
 	// Broadcast to peers and wait.
-	require.NoError(t, p.BroadcastSyncCommitteeMessage(context.Background(), subnet, msg))
+	require.NoError(t, p.BroadcastSyncCommitteeMessage(ctx, subnet, msg))
 	if util.WaitTimeout(&wg, 1*time.Second) {
 		t.Error("Failed to receive pubsub within 1s")
 	}


### PR DESCRIPTION
Two broadcast methods, namely for attestations and sync committees, can panic a node if we try to broadcast nil objects. Instead, we fail early and return an error. Closes #11926 