### PR TITLE
`WeiToGwei` copy input big.int

### DIFF
--- a/math/math_helper.go
+++ b/math/math_helper.go
@@ -214,11 +214,13 @@ func AddInt(i ...int) (int, error) {
 }
 
 // WeiToGwei converts big int wei to uint64 gwei.
+// The input `v` is copied before being modified.
 func WeiToGwei(v *big.Int) uint64 {
 	if v == nil {
 		return 0
 	}
 	gweiPerEth := big.NewInt(1e9)
-	v.Div(v, gweiPerEth)
-	return v.Uint64()
+	copied := big.NewInt(0).Set(v)
+	copied.Div(copied, gweiPerEth)
+	return copied.Uint64()
 }

--- a/math/math_helper_test.go
+++ b/math/math_helper_test.go
@@ -567,3 +567,11 @@ func TestWeiToGwei(t *testing.T) {
 		}
 	}
 }
+
+func TestWeiToGwei_CopyOk(t *testing.T) {
+	v := big.NewInt(1e9)
+	got := math.WeiToGwei(v)
+
+	require.Equal(t, uint64(1), got)
+	require.Equal(t, big.NewInt(1e9).Uint64(), v.Uint64())
+}


### PR DESCRIPTION
`WeiToGwei` did not copy input `v` before so it gets mutated and that led to some confusion from the caller
This PR copies the input and adds a unit test