### PR TITLE
Fix initialization race

### DIFF
--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -11,7 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/p2p"
 	p2pTypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/p2p/types"
-	"github.com/prysmaticlabs/prysm/v4/beacon-chain/startup"
 	prysmsync "github.com/prysmaticlabs/prysm/v4/beacon-chain/sync"
 	"github.com/prysmaticlabs/prysm/v4/cmd/beacon-chain/flags"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
@@ -87,7 +86,6 @@ type blocksFetcher struct {
 	capacityWeight  float64       // how remaining capacity affects peer selection
 	mode            syncMode      // allows to use fetcher in different sync scenarios
 	quit            chan struct{} // termination notifier
-	clock           *startup.Clock
 }
 
 // peerLock restricts fetcher actions on per peer basis. Currently, used for rate limiting.

--- a/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher_test.go
@@ -552,7 +552,6 @@ func TestBlocksFetcher_RequestBlocksRateLimitingLocks(t *testing.T) {
 	gt := time.Now()
 	vr := [32]byte{}
 	fetcher.chain = &mock.ChainService{Genesis: gt, ValidatorsRoot: vr}
-	fetcher.clock = startup.NewClock(gt, vr)
 	hook := logTest.NewGlobal()
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
@@ -621,7 +620,6 @@ func TestBlocksFetcher_WaitForBandwidth(t *testing.T) {
 	gt := time.Now()
 	vr := [32]byte{}
 	fetcher.chain = &mock.ChainService{Genesis: gt, ValidatorsRoot: vr}
-	fetcher.clock = startup.NewClock(gt, vr)
 	start := time.Now()
 	assert.NoError(t, fetcher.waitForBandwidth(p2.PeerID(), 10))
 	dur := time.Since(start)

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -67,6 +67,7 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		chainStarted: abool.New(),
 		counter:      ratecounter.NewRateCounter(counterSeconds * time.Second),
 		genesisChan:  make(chan time.Time),
+		clock:        startup.NewClock(time.Unix(0, 0), [32]byte{}), // default clock to prevent panic
 	}
 
 	return s

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -27,6 +27,9 @@ func (s *Service) processPendingAttsQueue() {
 	// Prevents multiple queue processing goroutines (invoked by RunEvery) from contending for data.
 	mutex := new(sync.Mutex)
 	async.RunEvery(s.ctx, processPendingAttsPeriod, func() {
+		if !s.chainIsStarted() {
+			return
+		}
 		mutex.Lock()
 		if err := s.processPendingAtts(s.ctx); err != nil {
 			log.WithError(err).Debugf("Could not process pending attestation: %v", err)

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -27,9 +27,6 @@ func (s *Service) processPendingAttsQueue() {
 	// Prevents multiple queue processing goroutines (invoked by RunEvery) from contending for data.
 	mutex := new(sync.Mutex)
 	async.RunEvery(s.ctx, processPendingAttsPeriod, func() {
-		if !s.chainIsStarted() {
-			return
-		}
 		mutex.Lock()
 		if err := s.processPendingAtts(s.ctx); err != nil {
 			log.WithError(err).Debugf("Could not process pending attestation: %v", err)

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -150,7 +150,7 @@ func NewService(ctx context.Context, opts ...Option) *Service {
 		ctx:                  ctx,
 		cancel:               cancel,
 		chainStarted:         abool.New(),
-		cfg:                  &config{},
+		cfg:                  &config{clock: startup.NewClock(time.Unix(0, 0), [32]byte{})},
 		slotToPendingBlocks:  c,
 		seenPendingBlocks:    make(map[[32]byte]bool),
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
@@ -170,7 +170,6 @@ func NewService(ctx context.Context, opts ...Option) *Service {
 
 // Start the regular sync service.
 func (s *Service) Start() {
-	s.waitForChainStart()
 	go s.verifierRoutine()
 	go s.registerHandlers()
 
@@ -254,6 +253,7 @@ func (s *Service) waitForChainStart() {
 }
 
 func (s *Service) registerHandlers() {
+	s.waitForChainStart()
 	select {
 	case <-s.initialSyncComplete:
 		// Register respective pubsub handlers at state synced event.

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -170,6 +170,7 @@ func NewService(ctx context.Context, opts ...Option) *Service {
 
 // Start the regular sync service.
 func (s *Service) Start() {
+	s.waitForChainStart()
 	go s.verifierRoutine()
 	go s.registerHandlers()
 
@@ -253,7 +254,6 @@ func (s *Service) waitForChainStart() {
 }
 
 func (s *Service) registerHandlers() {
-	s.waitForChainStart()
 	select {
 	case <-s.initialSyncComplete:
 		// Register respective pubsub handlers at state synced event.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The `sync` and `initial-sync` services directly call methods on the clock, and in the case of `sync` these calls may not always be blocked on the `WaitForClock` event, leading to a panic. This PR sets up zero-values for the `*startup.Clock` fields in those services, resulting in behavior similar to the previous startup code and avoiding panics.

**Which issues(s) does this PR fix?**

n/a