### PR TITLE
Flip `build-block-parallel` feature flag

### DIFF
--- a/config/features/config.go
+++ b/config/features/config.go
@@ -214,9 +214,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		logEnabled(prepareAllPayloads)
 		cfg.PrepareAllPayloads = true
 	}
-	if ctx.IsSet(buildBlockParallel.Name) {
-		logEnabled(buildBlockParallel)
-		cfg.BuildBlockParallel = true
+	cfg.BuildBlockParallel = true
+	if ctx.IsSet(disableBuildBlockParallel.Name) {
+		logEnabled(disableBuildBlockParallel)
+		cfg.BuildBlockParallel = false
 	}
 	Init(cfg)
 	return nil

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -32,6 +32,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedBuildBlockParallel = &cli.BoolFlag{
+		Name:   "build-block-parallel",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 // Deprecated flags for both the beacon node and validator client.
@@ -41,6 +46,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedDisableVecHTR,
 	deprecatedEnableReorgLateBlocks,
 	deprecatedDisableGossipBatchAggregation,
+	deprecatedBuildBlockParallel,
 }
 
 // deprecatedBeaconFlags contains flags that are still used by other components

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -118,9 +118,9 @@ var (
 		Name:  "prepare-all-payloads",
 		Usage: "Informs the engine to prepare all local payloads. Useful for relayers and builders",
 	}
-	buildBlockParallel = &cli.BoolFlag{
-		Name:  "build-block-parallel",
-		Usage: "Builds a beacon block in parallel for consensus and execution. It results in faster block construction time",
+	disableBuildBlockParallel = &cli.BoolFlag{
+		Name:  "disable-build-block-parallel",
+		Usage: "Disables building a beacon block in parallel for consensus and execution",
 	}
 )
 
@@ -168,7 +168,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	enableVerboseSigVerification,
 	enableOptionalEngineMethods,
 	prepareAllPayloads,
-	buildBlockParallel,
+	disableBuildBlockParallel,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
`build-block-parallel` is a great optimization for proposer, it has been tested on testnet over the last 2 weeks. 
The feature was enabled in v4.0.4 and we are planning to make it default for v4.0.5 with a disable option.