### PR TITLE
Replace Public Key Cache With Map

### DIFF
--- a/crypto/bls/blst/public_key.go
+++ b/crypto/bls/blst/public_key.go
@@ -45,9 +45,15 @@ func PublicKeyFromBytes(pubKey []byte) (common.PublicKey, error) {
 	}
 	pubKeyObj := &PublicKey{p: p}
 	copiedKey := pubKeyObj.Copy()
+	assertedKey, ok := (copiedKey).(*PublicKey)
+	// Should be impossible to happen, this is checked
+	// to satisfy lint tools.
+	if !ok {
+		return pubKeyObj, nil
+	}
 	cacheKey := *newKey
 	pubkeyLock.Lock()
-	pubkeyMap[cacheKey] = (copiedKey).(*PublicKey)
+	pubkeyMap[cacheKey] = assertedKey
 	pubkeyLock.Unlock()
 	return pubKeyObj, nil
 }

--- a/crypto/bls/blst/test_helper_test.go
+++ b/crypto/bls/blst/test_helper_test.go
@@ -1,13 +1,8 @@
 package blst
 
-// Note: These functions are for tests to access private globals, such as pubkeyCache.
+// Note: These functions are for tests to access private globals, such as pubkeyMap.
 
-// DisableCaches sets the cache sizes to 0.
-func DisableCaches() {
-	pubkeyCache.Resize(0)
-}
-
-// EnableCaches sets the cache sizes to the default values.
-func EnableCaches() {
-	pubkeyCache.Resize(maxKeys)
+// KeyMap returns the pubkey cache.
+func KeyMap() map[[48]byte]*PublicKey {
+	return pubkeyMap
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature Improvement

**What does this PR do? Why is it needed?**

Given that we want to have all public keys cached in memory, it would be better to handle this with a simple map and lock rather than using the hashicorp lru cache library. This has very poor support for concurrent readers due to the underlying design of the library

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**


