### PR TITLE
reverting expiration logic on validator while using --enable-registration-cache

### DIFF
--- a/beacon-chain/builder/service_test.go
+++ b/beacon-chain/builder/service_test.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"context"
 	"testing"
+	"time"
 
 	buildertesting "github.com/prysmaticlabs/prysm/v4/api/client/builder/testing"
 	blockchainTesting "github.com/prysmaticlabs/prysm/v4/beacon-chain/blockchain/testing"
@@ -36,6 +37,21 @@ func Test_RegisterValidator(t *testing.T) {
 	var feeRecipient [20]byte
 	require.NoError(t, s.RegisterValidator(ctx, []*eth.SignedValidatorRegistrationV1{{Message: &eth.ValidatorRegistrationV1{Pubkey: pubkey[:], FeeRecipient: feeRecipient[:]}}}))
 	assert.Equal(t, true, builder.RegisteredVals[pubkey])
+}
+
+func Test_RegisterValidator_WithCache(t *testing.T) {
+	ctx := context.Background()
+	headFetcher := &blockchainTesting.ChainService{}
+	builder := buildertesting.NewClient()
+	s, err := NewService(ctx, WithRegistrationCache(), WithHeadFetcher(headFetcher), WithBuilderClient(&builder))
+	require.NoError(t, err)
+	pubkey := bytesutil.ToBytes48([]byte("pubkey"))
+	var feeRecipient [20]byte
+	reg := &eth.ValidatorRegistrationV1{Pubkey: pubkey[:], Timestamp: uint64(time.Now().UTC().Unix()), FeeRecipient: feeRecipient[:]}
+	require.NoError(t, s.RegisterValidator(ctx, []*eth.SignedValidatorRegistrationV1{{Message: reg}}))
+	registration, err := s.registrationCache.RegistrationByIndex(0)
+	require.NoError(t, err)
+	require.DeepEqual(t, reg, registration)
 }
 
 func Test_BuilderMethodsWithouClient(t *testing.T) {

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -87,7 +87,6 @@ go_test(
         "//testing/util:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
-        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )

--- a/beacon-chain/cache/registration_test.go
+++ b/beacon-chain/cache/registration_test.go
@@ -6,15 +6,12 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
-	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func TestRegistrationCache(t *testing.T) {
-	hook := logTest.NewGlobal()
 	pubkey, err := hexutil.Decode("0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a")
 	require.NoError(t, err)
 	validatorIndex := primitives.ValidatorIndex(1)
@@ -31,52 +28,19 @@ func TestRegistrationCache(t *testing.T) {
 	reg, err := cache.RegistrationByIndex(validatorIndex)
 	require.NoError(t, err)
 	require.Equal(t, string(reg.Pubkey), string(pubkey))
-	t.Run("Registration expired", func(t *testing.T) {
-		validatorIndex2 := primitives.ValidatorIndex(2)
-		overExpirationPadTime := time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot*uint64(params.BeaconConfig().SlotsPerEpoch)*4) // 4 epochs
-		m[validatorIndex2] = &ethpb.ValidatorRegistrationV1{
-			FeeRecipient: []byte{},
-			GasLimit:     100,
-			Timestamp:    uint64(time.Now().Add(-1 * overExpirationPadTime).Unix()),
-			Pubkey:       pubkey,
-		}
-		cache.UpdateIndexToRegisteredMap(context.Background(), m)
-		_, err := cache.RegistrationByIndex(validatorIndex2)
-		require.ErrorContains(t, "no validator registered", err)
-		require.LogsContain(t, hook, "expired")
-	})
-	t.Run("Registration close to expiration still passes", func(t *testing.T) {
+	t.Run("successfully updates", func(t *testing.T) {
 		pubkey, err := hexutil.Decode("0x88247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a")
 		require.NoError(t, err)
 		validatorIndex2 := primitives.ValidatorIndex(2)
-		overExpirationPadTime := time.Second * time.Duration((params.BeaconConfig().SecondsPerSlot*uint64(params.BeaconConfig().SlotsPerEpoch)*3)-5) // 3 epochs - 5 seconds
 		m[validatorIndex2] = &ethpb.ValidatorRegistrationV1{
 			FeeRecipient: []byte{},
 			GasLimit:     100,
-			Timestamp:    uint64(time.Now().Add(-1 * overExpirationPadTime).Unix()),
+			Timestamp:    uint64(time.Now().Unix()),
 			Pubkey:       pubkey,
 		}
 		cache.UpdateIndexToRegisteredMap(context.Background(), m)
 		reg, err := cache.RegistrationByIndex(validatorIndex2)
 		require.NoError(t, err)
 		require.Equal(t, string(reg.Pubkey), string(pubkey))
-	})
-}
-
-func Test_RegistrationTimeStampExpired(t *testing.T) {
-	// expiration set at 3 epochs
-	t.Run("expired registration", func(t *testing.T) {
-		overExpirationPadTime := time.Second * time.Duration(params.BeaconConfig().SecondsPerSlot*uint64(params.BeaconConfig().SlotsPerEpoch)*4) // 4 epochs
-		ts := uint64(time.Now().Add(-1 * overExpirationPadTime).Unix())
-		isExpired, err := RegistrationTimeStampExpired(ts)
-		require.NoError(t, err)
-		require.Equal(t, true, isExpired)
-	})
-	t.Run("is not expired registration", func(t *testing.T) {
-		overExpirationPadTime := time.Second * time.Duration((params.BeaconConfig().SecondsPerSlot*uint64(params.BeaconConfig().SlotsPerEpoch)*3)-5) // 3 epochs -5 seconds
-		ts := uint64(time.Now().Add(-1 * overExpirationPadTime).Unix())
-		isExpired, err := RegistrationTimeStampExpired(ts)
-		require.NoError(t, err)
-		require.Equal(t, false, isExpired)
 	})
 }

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -209,8 +209,6 @@ type BeaconChainConfig struct {
 	MaxBuilderEpochMissedSlots       primitives.Slot // MaxBuilderEpochMissedSlots is defines the number of total skip slot (per epoch rolling windows) to fallback from using relay/builder to local execution engine for block construction.
 	LocalBlockValueBoost             uint64          // LocalBlockValueBoost is the value boost for local block construction. This is used to prioritize local block construction over relay/builder block construction.
 
-	// Mev validator registration
-	RegistrationDuration time.Duration // RegistrationDuration is the duration a validator registration is valid for.
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue uint64 // ExecutionEngineTimeoutValue defines the seconds to wait before timing out engine endpoints with execution payload execution semantics (newPayload, forkchoiceUpdated).
 }

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -257,8 +257,6 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	// Mevboost circuit breaker
 	MaxBuilderConsecutiveMissedSlots: 3,
 	MaxBuilderEpochMissedSlots:       5,
-	// Mev validator registration duration before expiration
-	RegistrationDuration: 12 * 32 * 3 * time.Second, // defaults to 3 Epochs
 	// Execution engine timeout value
 	ExecutionEngineTimeoutValue: 8, // 8 seconds default based on: https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#core
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

the `--enable-registration-cache` currently has expiration logic to ensure timely updates and regular updates to validator registrations. Although validator registrations are sent every epoch, the registration currently has a buffer of 3 epochs before expiration. If a validator client is updated to not use builder settings or there are relay issues for accepting the validator registration for 3 epochs then the registration will expire, returning to local execution.

Assuming the relay is regularly responsive for validator registrations was an error and many relays may not respond to validator registration calls in a timely manner. This resulted in users losing MEV value due to rolling back onto local execution after registration expired.

To lean on the safe side, this PR reverts the expiration logic and the cache will need to be cleared via a beacon node restart.



