### PR TITLE
remove trivial helper

### DIFF
--- a/beacon-chain/forkchoice/doubly-linked-tree/on_tick.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/on_tick.go
@@ -31,9 +31,7 @@ import (
 //	        store.justified_checkpoint = store.best_justified_checkpoint
 func (f *ForkChoice) NewSlot(ctx context.Context, slot primitives.Slot) error {
 	// Reset proposer boost root
-	if err := f.resetBoostedProposerRoot(ctx); err != nil {
-		return errors.Wrap(err, "could not reset boosted proposer root in fork choice")
-	}
+	f.store.proposerBoostRoot = [32]byte{}
 
 	// Return if it's not a new epoch.
 	if !slots.IsEpochStart(slot) {

--- a/beacon-chain/forkchoice/doubly-linked-tree/proposer_boost.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/proposer_boost.go
@@ -1,18 +1,11 @@
 package doublylinkedtree
 
 import (
-	"context"
 	"fmt"
 
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 )
-
-// resetBoostedProposerRoot sets the value of the proposer boosted root to zeros.
-func (f *ForkChoice) resetBoostedProposerRoot(_ context.Context) error {
-	f.store.proposerBoostRoot = [32]byte{}
-	return nil
-}
 
 // applyProposerBoostScore applies the current proposer boost scores to the
 // relevant nodes.


### PR DESCRIPTION
Removes a trivial helper that is a oneliner that can't error out. 