### PR TITLE
Log equivocating block with a flag

### DIFF
--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
@@ -93,6 +94,9 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 
 	// Verify the block is the first block received for the proposer for the slot.
 	if s.hasSeenBlockIndexSlot(blk.Block().Slot(), blk.Block().ProposerIndex()) {
+		if features.Get().EnableEquivocatingBlockLogging {
+			log.WithField("block", hexutil.Encode(msg.Data)).Debug("equivocating block detected")
+		}
 		return pubsub.ValidationIgnore, nil
 	}
 

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -46,8 +46,9 @@ type Flags struct {
 	EnableHistoricalSpaceRepresentation bool // EnableHistoricalSpaceRepresentation enables the saving of registry validators in separate buckets to save space
 	EnableBeaconRESTApi                 bool // EnableBeaconRESTApi enables experimental usage of the beacon REST API by the validator when querying a beacon node
 	// Logging related toggles.
-	DisableGRPCConnectionLogs bool // Disables logging when a new grpc client has connected.
-	EnableFullSSZDataLogging  bool // Enables logging for full ssz data on rejected gossip messages
+	DisableGRPCConnectionLogs      bool // Disables logging when a new grpc client has connected.
+	EnableFullSSZDataLogging       bool // Enables logging for full ssz data on rejected gossip messages
+	EnableEquivocatingBlockLogging bool // Enables logging for equivocating block gossip messages.
 
 	// Slasher toggles.
 	DisableBroadcastSlashings bool // DisableBroadcastSlashings disables p2p broadcasting of proposer and attester slashings.
@@ -211,6 +212,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.IsSet(enableFullSSZDataLogging.Name) {
 		logEnabled(enableFullSSZDataLogging)
 		cfg.EnableFullSSZDataLogging = true
+	}
+	if ctx.IsSet(enableEquivocatingBlockLogging.Name) {
+		logEnabled(enableEquivocatingBlockLogging)
+		cfg.EnableEquivocatingBlockLogging = true
 	}
 	if ctx.IsSet(enableVerboseSigVerification.Name) {
 		logEnabled(enableVerboseSigVerification)

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -120,6 +120,10 @@ var (
 		Name:  "enable-full-ssz-data-logging",
 		Usage: "Enables displaying logs for full ssz data on rejected gossip messages",
 	}
+	enableEquivocatingBlockLogging = &cli.BoolFlag{
+		Name:  "enable-equivocating-block-logging",
+		Usage: "Enables logging of equivocating block received over p2p gossip",
+	}
 	SaveFullExecutionPayloads = &cli.BoolFlag{
 		Name:  "save-full-execution-payloads",
 		Usage: "Saves beacon blocks with full execution payloads instead of execution payload headers in the database",
@@ -192,6 +196,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	SaveFullExecutionPayloads,
 	enableStartupOptimistic,
 	enableFullSSZDataLogging,
+	enableEquivocatingBlockLogging,
 	enableVerboseSigVerification,
 	enableOptionalEngineMethods,
 	prepareAllPayloads,


### PR DESCRIPTION
Popular feature request from the relayer, this PR logs equivocating block received over p2p under a flag `--enable-equivocating-block-logging`