### PR TITLE
Add logs for build block times

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -219,9 +219,12 @@ func (vs *Server) getPayloadHeaderFromBuilder(ctx context.Context, slot primitiv
 	}
 
 	log.WithFields(logrus.Fields{
-		"value":         v.String(),
-		"builderPubKey": fmt.Sprintf("%#x", bid.Pubkey()),
-		"blockHash":     fmt.Sprintf("%#x", header.BlockHash()),
+		"value":              v.String(),
+		"builderPubKey":      fmt.Sprintf("%#x", bid.Pubkey()),
+		"blockHash":          fmt.Sprintf("%#x", header.BlockHash()),
+		"slot":               slot,
+		"validator":          idx,
+		"sinceSlotStartTime": time.Since(t),
 	}).Info("Received header with bid")
 
 	span.AddAttributes(


### PR DESCRIPTION
This PR added two proposer RPC logs and modified one proposer RPC log
- It adds an `info` log to signal the start of block construction. Good signal for node operators to know when the beacon node started building block. (similar to geth's begin building payload). `sinceSlotStartTime` is the time diff between now and slot start time.
- It adds an `info` log to signal the end of the block construction. Good signal for node operators to know when the beacon node has completed the building block. (similar to geth's stopped building payload). `sinceSlotStartTime` is the time diff between now and slot start time.
- It added more fields to `Received header with bid` to signal slot, validator index, and time difference since start. 


More thoughts
- Should them be debug? I thought info is appropriate given proposing is a rare event
- Anymore missing fields?
- Interop mode might become a bit noisy 