### PR TITLE
Remove `SubmitBlindBlock` context timeout

### DIFF
--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
@@ -36,7 +35,6 @@ const (
 var errMalformedHostname = errors.New("hostname must include port, separated by one colon, like example.com:3500")
 var errMalformedRequest = errors.New("required request data are missing")
 var errNotBlinded = errors.New("submitted block is not blinded")
-var submitBlindedBlockTimeout = 3 * time.Second
 
 // ClientOpt is a functional option for the Client type (http.Client wrapper)
 type ClientOpt func(*Client)
@@ -292,8 +290,6 @@ func (c *Client) SubmitBlindedBlock(ctx context.Context, sb interfaces.ReadOnlyS
 			return nil, errors.Wrap(err, "error encoding the SignedBlindedBeaconBlockBellatrix value body in SubmitBlindedBlock")
 		}
 
-		ctx, cancel := context.WithTimeout(ctx, submitBlindedBlockTimeout)
-		defer cancel()
 		versionOpt := func(r *http.Request) {
 			r.Header.Add("Eth-Consensus-Version", version.String(version.Bellatrix))
 		}
@@ -325,8 +321,6 @@ func (c *Client) SubmitBlindedBlock(ctx context.Context, sb interfaces.ReadOnlyS
 			return nil, errors.Wrap(err, "error encoding the SignedBlindedBeaconBlockCapella value body in SubmitBlindedBlockCapella")
 		}
 
-		ctx, cancel := context.WithTimeout(ctx, submitBlindedBlockTimeout)
-		defer cancel()
 		versionOpt := func(r *http.Request) {
 			r.Header.Add("Eth-Consensus-Version", version.String(version.Capella))
 		}


### PR DESCRIPTION
I'm unsure why `SubmitBlindedBlock` imposes a context deadline of 3s. This is more confusing than good. Reasons being:
- Validator already submitted the signed blind block. There's no default to local building
- Relayer may delay on block return to defend against the unbundling attack
- The parent caller already has a slot context deadline at 12s

It's better to wait for the block until the 12s mark than surface error like: 
```
Unknown desc = could not submit blinded block: error posting the SignedBlindedBeaconBlockCapella to the builder api: Post \"http://mev-boost/eth/v1/builder/blinded_blocks\": context deadline exceeded","message":"Failed to propose block","prefix":"validator","severity":"ERROR"}
```

