### PR TITLE
Copy All Field Tries For Late Blocks

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -713,6 +713,7 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	if lastState == nil {
 		lastRoot, lastState = headRoot[:], headState
 	}
+	lastState.CopyAllTries()
 	if err = transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
 		log.WithError(err).Debug("could not update next slot state cache")
 	}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -713,6 +713,8 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	if lastState == nil {
 		lastRoot, lastState = headRoot[:], headState
 	}
+	// Copy all the field tries in our cached state in the event of late
+	// blocks.
 	lastState.CopyAllTries()
 	if err = transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
 		log.WithError(err).Debug("could not update next slot state cache")

--- a/beacon-chain/core/transition/trailing_slot_state_cache.go
+++ b/beacon-chain/core/transition/trailing_slot_state_cache.go
@@ -58,7 +58,6 @@ func NextSlotState(root []byte, wantedSlot types.Slot) state.BeaconState {
 func UpdateNextSlotCache(ctx context.Context, root []byte, state state.BeaconState) error {
 	// Advancing one slot by using a copied state.
 	copied := state.Copy()
-	copied.CopyAllTries()
 	copied, err := ProcessSlots(ctx, copied, copied.Slot()+1)
 	if err != nil {
 		return errors.Wrap(err, "could not process slots")

--- a/beacon-chain/core/transition/trailing_slot_state_cache.go
+++ b/beacon-chain/core/transition/trailing_slot_state_cache.go
@@ -58,6 +58,7 @@ func NextSlotState(root []byte, wantedSlot types.Slot) state.BeaconState {
 func UpdateNextSlotCache(ctx context.Context, root []byte, state state.BeaconState) error {
 	// Advancing one slot by using a copied state.
 	copied := state.Copy()
+	copied.CopyAllTries()
 	copied, err := ProcessSlots(ctx, copied, copied.Slot()+1)
 	if err != nil {
 		return errors.Wrap(err, "could not process slots")

--- a/beacon-chain/state/interfaces.go
+++ b/beacon-chain/state/interfaces.go
@@ -20,6 +20,7 @@ type BeaconState interface {
 	ReadOnlyBeaconState
 	WriteOnlyBeaconState
 	Copy() BeaconState
+	CopyAllTries()
 	HashTreeRoot(ctx context.Context) ([32]byte, error)
 	StateProver
 }

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -840,7 +840,9 @@ func (b *BeaconState) rootSelector(ctx context.Context, field types.FieldIndex) 
 	return [32]byte{}, errors.New("invalid field index provided")
 }
 
-// CopyAllTries copies our field tries from the state
+// CopyAllTries copies our field tries from the state. This is used to
+// remove shared field tries which have references to other states and
+// only have this copied set referencing to the current state.
 func (b *BeaconState) CopyAllTries() {
 	b.lock.RLock()
 	defer b.lock.RUnlock()


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

In #10884, we added the ability for there to only be one relevant set of field tries held in memory. The main reason this was done was to not have Prysm store outdated field tries in memory as they took up a significant amount of space in the heap. 

However doing this has brought some downsides in that older states will have to recompute all the tries for the fields in the event they are used to process a new block or are being used to advance slots. This causes issues when processing late blocks as you do end up having to regenerate the whole set of tries. To allow the next slot cache to function better, we add the ability to copy all tries for late blocks. This allows late blocks to be processed in an efficient manner along with keeping heap usage manageable.

**Which issues(s) does this PR fix?**

Fixes #12434 

**Other notes for review**
