### PR TITLE
Update next slot cache correctly under late task

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -651,26 +651,24 @@ func (s *Service) validateMergeTransitionBlock(ctx context.Context, stateVersion
 
 // This routine checks if there is a cached proposer payload ID available for the next slot proposer.
 // If there is not, it will call forkchoice updated with the correct payload attribute then cache the payload ID.
-func (s *Service) spawnLateBlockTasksLoop() {
-	go func() {
-		_, err := s.clockWaiter.WaitForClock(s.ctx)
-		if err != nil {
-			log.WithError(err).Error("spawnLateBlockTasksLoop encountered an error waiting for initialization")
+func (s *Service) runLateBlockTasks() {
+	_, err := s.clockWaiter.WaitForClock(s.ctx)
+	if err != nil {
+		log.WithError(err).Error("runLateBlockTasks encountered an error waiting for initialization")
+		return
+	}
+	attThreshold := params.BeaconConfig().SecondsPerSlot / 3
+	ticker := slots.NewSlotTickerWithOffset(s.genesisTime, time.Duration(attThreshold)*time.Second, params.BeaconConfig().SecondsPerSlot)
+	for {
+		select {
+		case <-ticker.C():
+			s.lateBlockTasks(s.ctx)
+
+		case <-s.ctx.Done():
+			log.Debug("Context closed, exiting routine")
 			return
 		}
-		attThreshold := params.BeaconConfig().SecondsPerSlot / 3
-		ticker := slots.NewSlotTickerWithOffset(s.genesisTime, time.Duration(attThreshold)*time.Second, params.BeaconConfig().SecondsPerSlot)
-		for {
-			select {
-			case <-ticker.C():
-				s.lateBlockTasks(s.ctx)
-
-			case <-s.ctx.Done():
-				log.Debug("Context closed, exiting routine")
-				return
-			}
-		}
-	}()
+	}
 }
 
 // lateBlockTasks  is called 4 seconds into the slot and performs tasks

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -685,12 +685,23 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 		Type: statefeed.MissedSlot,
 	})
 
+	headRoot := s.headRoot()
+	headState := s.headState(ctx)
+	lastRoot, lastState := transition.LastCachedState()
+	if lastState == nil {
+		lastRoot, lastState = headRoot[:], headState
+	}
+	if err := transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
+		log.WithError(err).Debug("could not update next slot state cache")
+	}
+
 	// Head root should be empty when retrieving proposer index for the next slot.
 	_, id, has := s.cfg.ProposerSlotIndexCache.GetProposerPayloadIDs(s.CurrentSlot()+1, [32]byte{} /* head root */)
 	// There exists proposer for next slot, but we haven't called fcu w/ payload attribute yet.
 	if (!has && !features.Get().PrepareAllPayloads) || id != [8]byte{} {
 		return
 	}
+
 	s.headLock.RLock()
 	headBlock, err := s.headBlock()
 	if err != nil {
@@ -698,8 +709,6 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 		log.WithError(err).Debug("could not perform late block tasks: failed to retrieve head block")
 		return
 	}
-	headRoot := s.headRoot()
-	headState := s.headState(ctx)
 	s.headLock.RUnlock()
 	_, err = s.notifyForkchoiceUpdate(ctx, &notifyForkchoiceUpdateArg{
 		headState: headState,
@@ -708,12 +717,5 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	})
 	if err != nil {
 		log.WithError(err).Debug("could not perform late block tasks: failed to update forkchoice with engine")
-	}
-	lastRoot, lastState := transition.LastCachedState()
-	if lastState == nil {
-		lastRoot, lastState = headRoot[:], headState
-	}
-	if err = transition.UpdateNextSlotCache(ctx, lastRoot, lastState); err != nil {
-		log.WithError(err).Debug("could not update next slot state cache")
 	}
 }

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -130,7 +130,7 @@ func (s *Service) Start() {
 		}
 	}
 	s.spawnProcessAttestationsRoutine()
-	s.spawnLateBlockTasksLoop()
+	go s.runLateBlockTasks()
 }
 
 // Stop the blockchain service's main event loop and associated goroutines.


### PR DESCRIPTION
In the event there's a late block coming (ie, no block 4s mark), we should still update the next slot cache without proposing the next slot

Also fixed a deep source complaint on: `Remove the internal goroutine and call the function using 'go'`