### PR TITLE
Release Lock Before Panicking

### DIFF
--- a/async/event/feed.go
+++ b/async/event/feed.go
@@ -144,6 +144,7 @@ func (f *Feed) Send(value interface{}) (nsent int) {
 
 	if !f.typecheck(rvalue.Type()) {
 		f.sendLock <- struct{}{}
+		f.mu.Unlock()
 		panic(feedTypeError{op: "Send", got: rvalue.Type(), want: f.etype})
 	}
 	f.mu.Unlock()

--- a/async/event/feed_test.go
+++ b/async/event/feed_test.go
@@ -32,6 +32,9 @@ func TestFeedPanics(t *testing.T) {
 		f.Send(2)
 		want := feedTypeError{op: "Send", got: reflect.TypeOf(uint64(0)), want: reflect.TypeOf(0)}
 		assert.NoError(t, checkPanic(want, func() { f.Send(uint64(2)) }))
+		// Validate it doesn't deadlock.
+		assert.NoError(t, checkPanic(want, func() { f.Send(uint64(2)) }))
+
 	}
 	{
 		var f Feed

--- a/async/event/feed_test.go
+++ b/async/event/feed_test.go
@@ -34,7 +34,6 @@ func TestFeedPanics(t *testing.T) {
 		assert.NoError(t, checkPanic(want, func() { f.Send(uint64(2)) }))
 		// Validate it doesn't deadlock.
 		assert.NoError(t, checkPanic(want, func() { f.Send(uint64(2)) }))
-
 	}
 	{
 		var f Feed


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In the event we recover a feed which has had a panic triggered on it, a subsequent send on it will trigger a deadlock. This
PR releases the lock before triggering the panic and adds in a regression test for it.

**Which issues(s) does this PR fix?**

Found in the TOB Audit: `TOB-PRYSM-7`

**Other notes for review**
