### PR TITLE
Proposer RPC: make `setExecutionData` better

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -141,7 +141,17 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 		vs.setSyncAggregate(ctx, sBlk)
 
 		// Set execution data. New in Bellatrix.
-		if err := vs.setExecutionData(ctx, sBlk, head); err != nil {
+		localPayload, err := vs.getLocalPayload(ctx, sBlk.Block().Slot(), sBlk.Block().ProposerIndex(), sBlk.Block().ParentRoot(), head)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not get local payload: %v", err)
+		}
+		builderPayload, err := vs.getBuilderPayload(ctx, sBlk.Block().Slot(), sBlk.Block().ProposerIndex())
+		if err != nil {
+			builderGetPayloadMissCount.Inc()
+			log.WithError(err).Error("Could not get builder payload")
+		}
+
+		if err := vs.setExecutionData(ctx, sBlk, localPayload, builderPayload); err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not set execution data: %v", err)
 		}
 
@@ -224,7 +234,18 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 		vs.setBlsToExecData(sBlk, head)
 	}()
 
-	if err := vs.setExecutionData(ctx, sBlk, head); err != nil {
+	localPayload, err := vs.getLocalPayload(ctx, sBlk.Block().Slot(), sBlk.Block().ProposerIndex(), sBlk.Block().ParentRoot(), head)
+	if err != nil {
+		return status.Errorf(codes.Internal, "Could not get local payload: %v", err)
+	}
+
+	builderPayload, err := vs.getBuilderPayload(ctx, sBlk.Block().Slot(), sBlk.Block().ProposerIndex())
+	if err != nil {
+		builderGetPayloadMissCount.Inc()
+		log.WithError(err).Error("Could not get builder payload")
+	}
+
+	if err := vs.setExecutionData(ctx, sBlk, localPayload, builderPayload); err != nil {
 		return status.Errorf(codes.Internal, "Could not set execution data: %v", err)
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -150,7 +150,7 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 			builderGetPayloadMissCount.Inc()
 			log.WithError(err).Error("Could not get builder payload")
 		}
-		if err := vs.setExecutionData(ctx, sBlk, localPayload, builderPayload); err != nil {
+		if err := setExecutionData(ctx, sBlk, localPayload, builderPayload); err != nil {
 			return nil, status.Errorf(codes.Internal, "Could not set execution data: %v", err)
 		}
 
@@ -244,7 +244,7 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 		log.WithError(err).Error("Could not get builder payload")
 	}
 
-	if err := vs.setExecutionData(ctx, sBlk, localPayload, builderPayload); err != nil {
+	if err := setExecutionData(ctx, sBlk, localPayload, builderPayload); err != nil {
 		return status.Errorf(codes.Internal, "Could not set execution data: %v", err)
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prysmaticlabs/prysm/v4/api/client/builder"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/signing"
-	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
@@ -42,93 +41,80 @@ var emptyTransactionsRoot = [32]byte{127, 254, 36, 30, 166, 1, 135, 253, 176, 24
 const blockBuilderTimeout = 1 * time.Second
 
 // Sets the execution data for the block. Execution data can come from local EL client or remote builder depends on validator registration and circuit breaker conditions.
-func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, headState state.BeaconState) error {
+func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, localPayload, builderPayload interfaces.ExecutionData) error {
 	ctx, span := trace.StartSpan(ctx, "ProposerServer.setExecutionData")
 	defer span.End()
 
-	idx := blk.Block().ProposerIndex()
 	slot := blk.Block().Slot()
 	if slots.ToEpoch(slot) < params.BeaconConfig().BellatrixForkEpoch {
 		return nil
 	}
 
-	canUseBuilder, err := vs.canUseBuilder(ctx, slot, idx)
-	span.AddAttributes(trace.BoolAttribute("canUseBuilder", canUseBuilder))
-	if err != nil {
-		log.WithError(err).Warn("Proposer: failed to check if builder can be used")
-	} else if canUseBuilder {
-		builderPayload, err := vs.getPayloadHeaderFromBuilder(ctx, slot, idx)
+	// Use local payload if builder payload is nil.
+	if builderPayload == nil {
+		return blk.SetExecution(localPayload)
+	}
+
+	switch {
+	case blk.Version() >= version.Capella:
+		// Compare payload values between local and builder. Default to the local value if it is higher.
+		localValueGwei, err := localPayload.ValueInGwei()
 		if err != nil {
-			builderGetPayloadMissCount.Inc()
-			log.WithError(err).Warn("Proposer: failed to get payload header from builder")
-		} else {
-			switch {
-			case blk.Version() >= version.Capella:
-				localPayload, err := vs.getExecutionPayload(ctx, slot, idx, blk.Block().ParentRoot(), headState)
-				if err != nil {
-					return errors.Wrap(err, "failed to get execution payload")
-				}
-				// Compare payload values between local and builder. Default to the local value if it is higher.
-				localValueGwei, err := localPayload.ValueInGwei()
-				if err != nil {
-					return errors.Wrap(err, "failed to get local payload value")
-				}
-				builderValueGwei, err := builderPayload.ValueInGwei()
-				if err != nil {
-					log.WithError(err).Warn("Proposer: failed to get builder payload value") // Default to local if can't get builder value.
-				}
+			return errors.Wrap(err, "failed to get local payload value")
+		}
+		builderValueGwei, err := builderPayload.ValueInGwei()
+		if err != nil {
+			log.WithError(err).Warn("Proposer: failed to get builder payload value") // Default to local if can't get builder value.
+			return blk.SetExecution(localPayload)
+		}
 
-				withdrawalsMatched, err := matchingWithdrawalsRoot(localPayload, builderPayload)
-				if err != nil {
-					tracing.AnnotateError(span, err)
-					return errors.Wrap(err, "failed to match withdrawals root")
-				}
+		withdrawalsMatched, err := matchingWithdrawalsRoot(localPayload, builderPayload)
+		if err != nil {
+			tracing.AnnotateError(span, err)
+			log.WithError(err).Warn("Proposer: failed to match withdrawals root")
+			return blk.SetExecution(localPayload)
+		}
 
-				// Use builder payload if the following in true:
-				// builder_bid_value * 100 > local_block_value * (local-block-value-boost + 100)
-				boost := params.BeaconConfig().LocalBlockValueBoost
-				higherValueBuilder := builderValueGwei*100 > localValueGwei*(100+boost)
+		// Use builder payload if the following in true:
+		// builder_bid_value * 100 > local_block_value * (local-block-value-boost + 100)
+		boost := params.BeaconConfig().LocalBlockValueBoost
+		higherValueBuilder := builderValueGwei*100 > localValueGwei*(100+boost)
 
-				// If we can't get the builder value, just use local block.
-				if higherValueBuilder && withdrawalsMatched { // Builder value is higher and withdrawals match.
-					blk.SetBlinded(true)
-					if err := blk.SetExecution(builderPayload); err != nil {
-						log.WithError(err).Warn("Proposer: failed to set builder payload")
-						blk.SetBlinded(false)
-					} else {
-						return nil
-					}
-				}
-				if !higherValueBuilder {
-					log.WithFields(logrus.Fields{
-						"localGweiValue":       localValueGwei,
-						"localBoostPercentage": boost,
-						"builderGweiValue":     builderValueGwei,
-					}).Warn("Proposer: using local execution payload because higher value")
-				}
-				span.AddAttributes(
-					trace.BoolAttribute("higherValueBuilder", higherValueBuilder),
-					trace.Int64Attribute("localGweiValue", int64(localValueGwei)),     // lint:ignore uintcast -- This is OK for tracing.
-					trace.Int64Attribute("localBoostPercentage", int64(boost)),        // lint:ignore uintcast -- This is OK for tracing.
-					trace.Int64Attribute("builderGweiValue", int64(builderValueGwei)), // lint:ignore uintcast -- This is OK for tracing.
-				)
+		// If we can't get the builder value, just use local block.
+		if higherValueBuilder && withdrawalsMatched { // Builder value is higher and withdrawals match.
+			blk.SetBlinded(true)
+			if err := blk.SetExecution(builderPayload); err != nil {
+				log.WithError(err).Warn("Proposer: failed to set builder payload")
+				blk.SetBlinded(false)
 				return blk.SetExecution(localPayload)
-			default: // Bellatrix case.
-				blk.SetBlinded(true)
-				if err := blk.SetExecution(builderPayload); err != nil {
-					log.WithError(err).Warn("Proposer: failed to set builder payload")
-					blk.SetBlinded(false)
-				} else {
-					return nil
-				}
+			} else {
+				return nil
 			}
 		}
+		if !higherValueBuilder {
+			log.WithFields(logrus.Fields{
+				"localGweiValue":       localValueGwei,
+				"localBoostPercentage": boost,
+				"builderGweiValue":     builderValueGwei,
+			}).Warn("Proposer: using local execution payload because higher value")
+		}
+		span.AddAttributes(
+			trace.BoolAttribute("higherValueBuilder", higherValueBuilder),
+			trace.Int64Attribute("localGweiValue", int64(localValueGwei)),     // lint:ignore uintcast -- This is OK for tracing.
+			trace.Int64Attribute("localBoostPercentage", int64(boost)),        // lint:ignore uintcast -- This is OK for tracing.
+			trace.Int64Attribute("builderGweiValue", int64(builderValueGwei)), // lint:ignore uintcast -- This is OK for tracing.
+		)
+		return blk.SetExecution(localPayload)
+	default: // Bellatrix case.
+		blk.SetBlinded(true)
+		if err := blk.SetExecution(builderPayload); err != nil {
+			log.WithError(err).Warn("Proposer: failed to set builder payload")
+			blk.SetBlinded(false)
+			return blk.SetExecution(localPayload)
+		} else {
+			return nil
+		}
 	}
-	executionData, err := vs.getExecutionPayload(ctx, slot, idx, blk.Block().ParentRoot(), headState)
-	if err != nil {
-		return errors.Wrap(err, "failed to get execution payload")
-	}
-	return blk.SetExecution(executionData)
 }
 
 // This function retrieves the payload header given the slot number and the validator index.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -50,6 +50,10 @@ func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBea
 		return nil
 	}
 
+	if localPayload == nil {
+		return errors.New("local payload is nil")
+	}
+
 	// Use local payload if builder payload is nil.
 	if builderPayload == nil {
 		return blk.SetExecution(localPayload)
@@ -226,7 +230,7 @@ func (vs *Server) getPayloadHeaderFromBuilder(ctx context.Context, slot primitiv
 func validateBuilderSignature(signedBid builder.SignedBid) error {
 	d, err := signing.ComputeDomain(params.BeaconConfig().DomainApplicationBuilder,
 		nil, /* fork version */
-		nil /* genesis val root */)
+		nil  /* genesis val root */)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -41,8 +41,8 @@ var emptyTransactionsRoot = [32]byte{127, 254, 36, 30, 166, 1, 135, 253, 176, 24
 const blockBuilderTimeout = 1 * time.Second
 
 // Sets the execution data for the block. Execution data can come from local EL client or remote builder depends on validator registration and circuit breaker conditions.
-func (vs *Server) setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, localPayload, builderPayload interfaces.ExecutionData) error {
-	ctx, span := trace.StartSpan(ctx, "ProposerServer.setExecutionData")
+func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, localPayload, builderPayload interfaces.ExecutionData) error {
+	_, span := trace.StartSpan(ctx, "ProposerServer.setExecutionData")
 	defer span.End()
 
 	slot := blk.Block().Slot()

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -230,7 +230,7 @@ func (vs *Server) getPayloadHeaderFromBuilder(ctx context.Context, slot primitiv
 func validateBuilderSignature(signedBid builder.SignedBid) error {
 	d, err := signing.ComputeDomain(params.BeaconConfig().DomainApplicationBuilder,
 		nil, /* fork version */
-		nil  /* genesis val root */)
+		nil /* genesis val root */)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -82,7 +82,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		require.NoError(t, err)
 		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), e.BlockNumber()) // Local block
@@ -141,7 +141,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		require.NoError(t, err)
 		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), e.BlockNumber()) // Local block because incorrect withdrawals
@@ -203,7 +203,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		require.NoError(t, err)
 		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), e.BlockNumber()) // Builder block
@@ -217,7 +217,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		require.NoError(t, err)
 		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), e.BlockNumber()) // Local block
@@ -237,7 +237,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		require.NoError(t, err)
 		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), e.BlockNumber()) // Local block
@@ -258,7 +258,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		require.NoError(t, err)
 		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
 		require.ErrorIs(t, consensus_types.ErrNilObjectWrapped, err) // Builder returns fault. Use local block
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(4), e.BlockNumber()) // Local block

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -18,6 +18,7 @@ import (
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/doubly-linked-tree"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
+	consensus_types "github.com/prysmaticlabs/prysm/v4/consensus-types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
@@ -70,12 +71,18 @@ func TestServer_setExecutionData(t *testing.T) {
 		BeaconDB:               beaconDB,
 		ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
 		BlockBuilder:           &builderTest.MockBuilderService{HasConfigured: true, Cfg: &builderTest.Config{BeaconDB: beaconDB}},
+		ForkchoiceFetcher:      &blockchainTest.ChainService{},
 	}
 
 	t.Run("No builder configured. Use local block", func(t *testing.T) {
 		blk, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockCapella())
 		require.NoError(t, err)
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, capellaTransitionState))
+		b := blk.Block()
+		localPayload, err := vs.getLocalPayload(ctx, b, capellaTransitionState)
+		require.NoError(t, err)
+		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
+		require.NoError(t, err)
+		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), e.BlockNumber()) // Local block
@@ -128,7 +135,13 @@ func TestServer_setExecutionData(t *testing.T) {
 		vs.ForkchoiceFetcher.SetForkChoiceGenesisTime(uint64(time.Now().Unix()))
 		vs.TimeFetcher = chain
 		vs.HeadFetcher = chain
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, capellaTransitionState))
+		b := blk.Block()
+
+		localPayload, err := vs.getLocalPayload(ctx, b, capellaTransitionState)
+		require.NoError(t, err)
+		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
+		require.NoError(t, err)
+		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), e.BlockNumber()) // Local block because incorrect withdrawals
@@ -184,7 +197,13 @@ func TestServer_setExecutionData(t *testing.T) {
 		vs.ForkchoiceFetcher.SetForkChoiceGenesisTime(uint64(time.Now().Unix()))
 		vs.TimeFetcher = chain
 		vs.HeadFetcher = chain
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, capellaTransitionState))
+
+		b := blk.Block()
+		localPayload, err := vs.getLocalPayload(ctx, b, capellaTransitionState)
+		require.NoError(t, err)
+		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
+		require.NoError(t, err)
+		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), e.BlockNumber()) // Builder block
@@ -193,7 +212,12 @@ func TestServer_setExecutionData(t *testing.T) {
 		blk, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockCapella())
 		require.NoError(t, err)
 		vs.ExecutionEngineCaller = &powtesting.EngineClient{PayloadIDBytes: id, ExecutionPayloadCapella: &v1.ExecutionPayloadCapella{BlockNumber: 3}, BlockValue: 2}
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, capellaTransitionState))
+		b := blk.Block()
+		localPayload, err := vs.getLocalPayload(ctx, b, capellaTransitionState)
+		require.NoError(t, err)
+		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
+		require.NoError(t, err)
+		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), e.BlockNumber()) // Local block
@@ -208,7 +232,12 @@ func TestServer_setExecutionData(t *testing.T) {
 		blk, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockCapella())
 		require.NoError(t, err)
 		vs.ExecutionEngineCaller = &powtesting.EngineClient{PayloadIDBytes: id, ExecutionPayloadCapella: &v1.ExecutionPayloadCapella{BlockNumber: 3}, BlockValue: 1}
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, capellaTransitionState))
+		b := blk.Block()
+		localPayload, err := vs.getLocalPayload(ctx, b, capellaTransitionState)
+		require.NoError(t, err)
+		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
+		require.NoError(t, err)
+		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), e.BlockNumber()) // Local block
@@ -224,7 +253,12 @@ func TestServer_setExecutionData(t *testing.T) {
 			Cfg:           &builderTest.Config{BeaconDB: beaconDB},
 		}
 		vs.ExecutionEngineCaller = &powtesting.EngineClient{PayloadIDBytes: id, ExecutionPayloadCapella: &v1.ExecutionPayloadCapella{BlockNumber: 4}, BlockValue: 0}
-		require.NoError(t, vs.setExecutionData(context.Background(), blk, capellaTransitionState))
+		b := blk.Block()
+		localPayload, err := vs.getLocalPayload(ctx, b, capellaTransitionState)
+		require.NoError(t, err)
+		builderPayload, err := vs.getBuilderPayload(ctx, b.Slot(), b.ProposerIndex())
+		require.ErrorIs(t, consensus_types.ErrNilObjectWrapped, err) // Builder returns fault. Use local block
+		require.NoError(t, vs.setExecutionData(context.Background(), blk, localPayload, builderPayload))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(4), e.BlockNumber()) // Local block

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -43,10 +43,17 @@ var (
 
 // This returns the execution payload of a given slot. The function has full awareness of pre and post merge.
 // The payload is computed given the respected time of merge.
-func (vs *Server) getLocalPayload(ctx context.Context, slot primitives.Slot, vIdx primitives.ValidatorIndex, headRoot [32]byte, st state.BeaconState) (interfaces.ExecutionData, error) {
+func (vs *Server) getLocalPayload(ctx context.Context, blk interfaces.ReadOnlyBeaconBlock, st state.BeaconState) (interfaces.ExecutionData, error) {
 	ctx, span := trace.StartSpan(ctx, "ProposerServer.getLocalPayload")
 	defer span.End()
 
+	if blk.Version() < version.Bellatrix {
+		return nil, nil
+	}
+
+	slot := blk.Slot()
+	vIdx := blk.ProposerIndex()
+	headRoot := blk.ParentRoot()
 	proposerID, payloadId, ok := vs.ProposerSlotIndexCache.GetProposerPayloadIDs(slot, headRoot)
 	feeRecipient := params.BeaconConfig().DefaultFeeRecipient
 	recipient, err := vs.BeaconDB.FeeRecipientByValidatorID(ctx, vIdx)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -43,8 +43,8 @@ var (
 
 // This returns the execution payload of a given slot. The function has full awareness of pre and post merge.
 // The payload is computed given the respected time of merge.
-func (vs *Server) getExecutionPayload(ctx context.Context, slot primitives.Slot, vIdx primitives.ValidatorIndex, headRoot [32]byte, st state.BeaconState) (interfaces.ExecutionData, error) {
-	ctx, span := trace.StartSpan(ctx, "ProposerServer.getExecutionPayload")
+func (vs *Server) getLocalPayload(ctx context.Context, slot primitives.Slot, vIdx primitives.ValidatorIndex, headRoot [32]byte, st state.BeaconState) (interfaces.ExecutionData, error) {
+	ctx, span := trace.StartSpan(ctx, "ProposerServer.getLocalPayload")
 	defer span.End()
 
 	proposerID, payloadId, ok := vs.ProposerSlotIndexCache.GetProposerPayloadIDs(slot, headRoot)
@@ -219,6 +219,27 @@ func (vs *Server) getTerminalBlockHashIfExists(ctx context.Context, transitionTi
 	}
 
 	return vs.ExecutionEngineCaller.GetTerminalBlockHash(ctx, transitionTime)
+}
+
+func (vs *Server) getBuilderPayload(ctx context.Context,
+	slot primitives.Slot,
+	vIdx primitives.ValidatorIndex) (interfaces.ExecutionData, error) {
+	ctx, span := trace.StartSpan(ctx, "ProposerServer.getBuilderPayload")
+	defer span.End()
+
+	if slots.ToEpoch(slot) < params.BeaconConfig().BellatrixForkEpoch {
+		return nil, nil
+	}
+	canUseBuilder, err := vs.canUseBuilder(ctx, slot, vIdx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check if we can use the builder")
+	}
+	span.AddAttributes(trace.BoolAttribute("canUseBuilder", canUseBuilder))
+	if !canUseBuilder {
+		return nil, nil
+	}
+
+	return vs.getPayloadHeaderFromBuilder(ctx, slot, vIdx)
 }
 
 // activationEpochNotReached returns true if activation epoch has not been reach.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
@@ -143,7 +143,7 @@ func TestServer_getExecutionPayload(t *testing.T) {
 				ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
 			}
 			vs.ProposerSlotIndexCache.SetProposerAndPayloadIDs(tt.st.Slot(), 100, [8]byte{100}, [32]byte{'a'})
-			_, err := vs.getExecutionPayload(context.Background(), tt.st.Slot(), tt.validatorIndx, [32]byte{'a'}, tt.st)
+			_, err := vs.getLocalPayload(context.Background(), tt.st.Slot(), tt.validatorIndx, [32]byte{'a'}, tt.st)
 			if tt.errString != "" {
 				require.ErrorContains(t, tt.errString, err)
 			} else {
@@ -179,7 +179,7 @@ func TestServer_getExecutionPayloadContextTimeout(t *testing.T) {
 	}
 	vs.ProposerSlotIndexCache.SetProposerAndPayloadIDs(nonTransitionSt.Slot(), 100, [8]byte{100}, [32]byte{'a'})
 
-	_, err = vs.getExecutionPayload(context.Background(), nonTransitionSt.Slot(), 100, [32]byte{'a'}, nonTransitionSt)
+	_, err = vs.getLocalPayload(context.Background(), nonTransitionSt.Slot(), 100, [32]byte{'a'}, nonTransitionSt)
 	require.NoError(t, err)
 }
 
@@ -225,7 +225,7 @@ func TestServer_getExecutionPayload_UnexpectedFeeRecipient(t *testing.T) {
 		BeaconDB:               beaconDB,
 		ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
 	}
-	gotPayload, err := vs.getExecutionPayload(context.Background(), transitionSt.Slot(), 0, [32]byte{}, transitionSt)
+	gotPayload, err := vs.getLocalPayload(context.Background(), transitionSt.Slot(), 0, [32]byte{}, transitionSt)
 	require.NoError(t, err)
 	require.NotNil(t, gotPayload)
 
@@ -237,7 +237,7 @@ func TestServer_getExecutionPayload_UnexpectedFeeRecipient(t *testing.T) {
 	payload.FeeRecipient = evilRecipientAddress[:]
 	vs.ProposerSlotIndexCache = cache.NewProposerPayloadIDsCache()
 
-	gotPayload, err = vs.getExecutionPayload(context.Background(), transitionSt.Slot(), 0, [32]byte{}, transitionSt)
+	gotPayload, err = vs.getLocalPayload(context.Background(), transitionSt.Slot(), 0, [32]byte{}, transitionSt)
 	require.NoError(t, err)
 	require.NotNil(t, gotPayload)
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload_test.go
@@ -143,7 +143,13 @@ func TestServer_getExecutionPayload(t *testing.T) {
 				ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
 			}
 			vs.ProposerSlotIndexCache.SetProposerAndPayloadIDs(tt.st.Slot(), 100, [8]byte{100}, [32]byte{'a'})
-			_, err := vs.getLocalPayload(context.Background(), tt.st.Slot(), tt.validatorIndx, [32]byte{'a'}, tt.st)
+			blk := util.NewBeaconBlockBellatrix()
+			blk.Block.Slot = tt.st.Slot()
+			blk.Block.ProposerIndex = tt.validatorIndx
+			blk.Block.ParentRoot = bytesutil.PadTo([]byte{'a'}, 32)
+			b, err := blocks.NewSignedBeaconBlock(blk)
+			require.NoError(t, err)
+			_, err = vs.getLocalPayload(context.Background(), b.Block(), tt.st)
 			if tt.errString != "" {
 				require.ErrorContains(t, tt.errString, err)
 			} else {
@@ -179,7 +185,13 @@ func TestServer_getExecutionPayloadContextTimeout(t *testing.T) {
 	}
 	vs.ProposerSlotIndexCache.SetProposerAndPayloadIDs(nonTransitionSt.Slot(), 100, [8]byte{100}, [32]byte{'a'})
 
-	_, err = vs.getLocalPayload(context.Background(), nonTransitionSt.Slot(), 100, [32]byte{'a'}, nonTransitionSt)
+	blk := util.NewBeaconBlockBellatrix()
+	blk.Block.Slot = nonTransitionSt.Slot()
+	blk.Block.ProposerIndex = 100
+	blk.Block.ParentRoot = bytesutil.PadTo([]byte{'a'}, 32)
+	b, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+	_, err = vs.getLocalPayload(context.Background(), b.Block(), nonTransitionSt)
 	require.NoError(t, err)
 }
 
@@ -225,7 +237,13 @@ func TestServer_getExecutionPayload_UnexpectedFeeRecipient(t *testing.T) {
 		BeaconDB:               beaconDB,
 		ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(),
 	}
-	gotPayload, err := vs.getLocalPayload(context.Background(), transitionSt.Slot(), 0, [32]byte{}, transitionSt)
+
+	blk := util.NewBeaconBlockBellatrix()
+	blk.Block.Slot = transitionSt.Slot()
+	blk.Block.ParentRoot = bytesutil.PadTo([]byte{}, 32)
+	b, err := blocks.NewSignedBeaconBlock(blk)
+	require.NoError(t, err)
+	gotPayload, err := vs.getLocalPayload(context.Background(), b.Block(), transitionSt)
 	require.NoError(t, err)
 	require.NotNil(t, gotPayload)
 
@@ -237,7 +255,7 @@ func TestServer_getExecutionPayload_UnexpectedFeeRecipient(t *testing.T) {
 	payload.FeeRecipient = evilRecipientAddress[:]
 	vs.ProposerSlotIndexCache = cache.NewProposerPayloadIDsCache()
 
-	gotPayload, err = vs.getLocalPayload(context.Background(), transitionSt.Slot(), 0, [32]byte{}, transitionSt)
+	gotPayload, err = vs.getLocalPayload(context.Background(), b.Block(), transitionSt)
 	require.NoError(t, err)
 	require.NotNil(t, gotPayload)
 


### PR DESCRIPTION
`setExecutionData` has gotten too convoluted since Capella with builder payload, withdrawal root, and bid value comparisons. This PR cleans and refactors it to be extensible to future hard fork

Today:
```mermaid
flowchart TD
    A[Check if you can use builder]
    A -->|No|B[Get local payload]
    B -->C[Set local payload]
    A -->D[Get builder payload]
    D -->|Fails|B
    D -->|Ok|E[Get local payload]
    E -->F[Get local value]
    F -->G[Get builder value]
    G -->H[Compare withdrawal root]
    H -->|Fail|I[Return. NOTE: THIS IS A BUG]
    H -->|Pass|J[Compare values]
    J -->|Builder>Local and can set|K[Set builder payload and return]
    J -->|Else|L[Set local payload and return]
```

What I propose is the following. Get local payload and builder payload outside of `setExecutionData`. Make `setExecutionData` as minimal as possible by using `getLocalPayload` and `getBuilderPayload` and pass the payloads to `setExecutionData` 
```mermaid
flowchart TD
    A[Check if builder payload is nil]
    A -->|Yes|B[Set local payload and return]
    A -->|No|C[Get local value]
    C -->D[Get builder value]
    D -->E[Compare withdrawal root]
    E -->|Fail|B
    E -->|Pass|F[Compare values]
    F -->|Builder>Local and can set|G[Set builder payload and return]
    F -->|Else|B
```