### PR TITLE
Refactor Late Block Tasks 

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -664,7 +664,6 @@ func (s *Service) spawnLateBlockTasksLoop() {
 			select {
 			case <-ticker.C():
 				s.lateBlockTasks(s.ctx)
-
 			case <-s.ctx.Done():
 				log.Debug("Context closed, exiting routine")
 				return
@@ -698,7 +697,7 @@ func (s *Service) lateBlockTasks(ctx context.Context) {
 	// Head root should be empty when retrieving proposer index for the next slot.
 	_, id, has := s.cfg.ProposerSlotIndexCache.GetProposerPayloadIDs(s.CurrentSlot()+1, [32]byte{} /* head root */)
 	// There exists proposer for next slot, but we haven't called fcu w/ payload attribute yet.
-	if (has && id == [8]byte{}) || features.Get().PrepareAllPayloads {
+	if (has || features.Get().PrepareAllPayloads) && id == [8]byte{} {
 		_, err = s.notifyForkchoiceUpdate(ctx, &notifyForkchoiceUpdateArg{
 			headState: headState,
 			headRoot:  headRoot,


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

Refactors our late blocks method to only send FCUs for active proposers or if we use the `PrepareAllPayloads` feature. This importantly only updates our next slot cache after the FCU is sent to allow the EL to have a bit longer to start preparing their payload.

**Which issues(s) does this PR fix?**

Alternative to #12462  

**Other notes for review**
