### PR TITLE
Remove usage of PositionInActivationQueue in validator client

### DIFF
--- a/validator/client/beacon-api/activation.go
+++ b/validator/client/beacon-api/activation.go
@@ -91,10 +91,18 @@ func (c *waitForActivationClient) Recv() (*ethpb.ValidatorActivationResponse, er
 				return nil, errors.New("invalid validator status: " + data.Status)
 			}
 
+			activationEpoch, err := strconv.ParseUint(data.Validator.ActivationEpoch, 10, 64)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to parse activation epoch")
+			}
+
 			statuses = append(statuses, &ethpb.ValidatorActivationResponse_Status{
 				PublicKey: pubkey,
 				Index:     primitives.ValidatorIndex(index),
-				Status:    &ethpb.ValidatorStatusResponse{Status: validatorStatus},
+				Status: &ethpb.ValidatorStatusResponse{
+					Status:          validatorStatus,
+					ActivationEpoch: primitives.Epoch(activationEpoch),
+				},
 			})
 		}
 

--- a/validator/client/beacon-api/activation_test.go
+++ b/validator/client/beacon-api/activation_test.go
@@ -82,21 +82,24 @@ func TestActivation_Nominal(t *testing.T) {
 			PublicKey: pubKeys[0],
 			Index:     55293,
 			Status: &ethpb.ValidatorStatusResponse{
-				Status: ethpb.ValidatorStatus_ACTIVE,
+				Status:          ethpb.ValidatorStatus_ACTIVE,
+				ActivationEpoch: 1000,
 			},
 		},
 		{
 			PublicKey: pubKeys[1],
 			Index:     11877,
 			Status: &ethpb.ValidatorStatusResponse{
-				Status: ethpb.ValidatorStatus_EXITING,
+				Status:          ethpb.ValidatorStatus_EXITING,
+				ActivationEpoch: 2000,
 			},
 		},
 		{
 			PublicKey: pubKeys[3],
 			Index:     210439,
 			Status: &ethpb.ValidatorStatusResponse{
-				Status: ethpb.ValidatorStatus_EXITED,
+				Status:          ethpb.ValidatorStatus_EXITED,
+				ActivationEpoch: 3000,
 			},
 		},
 		{
@@ -131,21 +134,24 @@ func TestActivation_Nominal(t *testing.T) {
 					Index:  "55293",
 					Status: "active_ongoing",
 					Validator: &rpcmiddleware.ValidatorJson{
-						PublicKey: stringPubKeys[0],
+						PublicKey:       stringPubKeys[0],
+						ActivationEpoch: "1000",
 					},
 				},
 				{
 					Index:  "11877",
 					Status: "active_exiting",
 					Validator: &rpcmiddleware.ValidatorJson{
-						PublicKey: stringPubKeys[1],
+						PublicKey:       stringPubKeys[1],
+						ActivationEpoch: "2000",
 					},
 				},
 				{
 					Index:  "210439",
 					Status: "exited_slashed",
 					Validator: &rpcmiddleware.ValidatorJson{
-						PublicKey: stringPubKeys[3],
+						PublicKey:       stringPubKeys[3],
+						ActivationEpoch: "3000",
 					},
 				},
 			},

--- a/validator/client/beacon-api/status_test.go
+++ b/validator/client/beacon-api/status_test.go
@@ -289,35 +289,6 @@ func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) 
 		nil,
 	).Times(1)
 
-	stateValidatorsProvider.EXPECT().GetStateValidators(
-		ctx,
-		nil,
-		nil,
-		[]string{"active"},
-	).Return(
-		&rpcmiddleware.StateValidatorsResponseJson{
-			Data: []*rpcmiddleware.ValidatorContainerJson{
-				{
-					Index:  "35000",
-					Status: "active_ongoing",
-					Validator: &rpcmiddleware.ValidatorJson{
-						PublicKey:       "0x8000ab56b051f9d8f31c687528c6e91c9b98e4c3a241e752f9ccfbea7c5a7fbbd272bdf2c0a7e52ce7e0b57693df364d",
-						ActivationEpoch: "56",
-					},
-				},
-				{
-					Index:  "39000",
-					Status: "active_ongoing",
-					Validator: &rpcmiddleware.ValidatorJson{
-						PublicKey:       "0x8000ab56b051f9d8f31c687528c6e91c9b98e4c3a241e752f9ccfbea7c5a7fbbd272bdf2c0a7e52ce7e0b57693df364e",
-						ActivationEpoch: "56",
-					},
-				},
-			},
-		},
-		nil,
-	).Times(1)
-
 	wantedStringValidatorsPubkey := []string{
 		"0x8000091c2ae64ee414a54c1cc1fc67dec663408bc636cb86756e0200e41a75c8f86603f104f02c856983d2783116be13", // existing
 		"0x800010c20716ef4264a6d93b3873a008ece58fb9312ac2cc3b0ccc40aedb050f2038281e6a92242a35476af9903c7919", // existing,
@@ -360,14 +331,12 @@ func TestGetValidatorsStatusResponse_Nominal_SomeActiveValidators(t *testing.T) 
 			ActivationEpoch: 56,
 		},
 		{
-			Status:                    ethpb.ValidatorStatus_PENDING,
-			ActivationEpoch:           params.BeaconConfig().FarFutureEpoch,
-			PositionInActivationQueue: 1000,
+			Status:          ethpb.ValidatorStatus_PENDING,
+			ActivationEpoch: params.BeaconConfig().FarFutureEpoch,
 		},
 		{
-			Status:                    ethpb.ValidatorStatus_PENDING,
-			ActivationEpoch:           params.BeaconConfig().FarFutureEpoch,
-			PositionInActivationQueue: 11000,
+			Status:          ethpb.ValidatorStatus_PENDING,
+			ActivationEpoch: params.BeaconConfig().FarFutureEpoch,
 		},
 		{
 			Status:          ethpb.ValidatorStatus_UNKNOWN_STATUS,
@@ -420,25 +389,12 @@ func TestGetValidatorsStatusResponse_Nominal_NoActiveValidators(t *testing.T) {
 		nil,
 	).Times(1)
 
-	stateValidatorsProvider.EXPECT().GetStateValidators(
-		ctx,
-		nil,
-		nil,
-		[]string{"active"},
-	).Return(
-		&rpcmiddleware.StateValidatorsResponseJson{
-			Data: []*rpcmiddleware.ValidatorContainerJson{},
-		},
-		nil,
-	).Times(1)
-
 	wantedValidatorsPubKey := [][]byte{validatorPubKey}
 	wantedValidatorsIndex := []primitives.ValidatorIndex{40000}
 	wantedValidatorsStatusResponse := []*ethpb.ValidatorStatusResponse{
 		{
-			Status:                    ethpb.ValidatorStatus_PENDING,
-			ActivationEpoch:           params.BeaconConfig().FarFutureEpoch,
-			PositionInActivationQueue: 40000,
+			Status:          ethpb.ValidatorStatus_PENDING,
+			ActivationEpoch: params.BeaconConfig().FarFutureEpoch,
 		},
 	}
 
@@ -601,84 +557,6 @@ func TestValidatorStatusResponse_InvalidData(t *testing.T) {
 				},
 			},
 			outputErrMessage: "failed to parse activation epoch NotAnEpoch",
-		},
-		{
-			name: "failed to get state validators",
-
-			inputPubKeys: [][]byte{pubKey},
-			inputIndexes: nil,
-			inputGetStateValidatorsInterfaces: []getStateValidatorsInterface{
-				{
-					inputStringPubKeys: []string{stringPubKey},
-					inputIndexes:       nil,
-					inputStatuses:      nil,
-
-					outputStateValidatorsResponseJson: &rpcmiddleware.StateValidatorsResponseJson{
-						Data: []*rpcmiddleware.ValidatorContainerJson{
-							{
-								Index:  "12345",
-								Status: "pending_queued",
-								Validator: &rpcmiddleware.ValidatorJson{
-									PublicKey:       stringPubKey,
-									ActivationEpoch: "10",
-								},
-							},
-						},
-					},
-					outputErr: nil,
-				},
-				{
-					inputStringPubKeys: nil,
-					inputIndexes:       nil,
-					inputStatuses:      []string{"active"},
-
-					outputStateValidatorsResponseJson: &rpcmiddleware.StateValidatorsResponseJson{},
-					outputErr:                         errors.New("a specific error"),
-				},
-			},
-			outputErrMessage: "failed to get state validators",
-		},
-		{
-			name: "failed to parse last validator index",
-
-			inputPubKeys: [][]byte{pubKey},
-			inputIndexes: nil,
-			inputGetStateValidatorsInterfaces: []getStateValidatorsInterface{
-				{
-					inputStringPubKeys: []string{stringPubKey},
-					inputIndexes:       nil,
-					inputStatuses:      nil,
-
-					outputStateValidatorsResponseJson: &rpcmiddleware.StateValidatorsResponseJson{
-						Data: []*rpcmiddleware.ValidatorContainerJson{
-							{
-								Index:  "12345",
-								Status: "pending_queued",
-								Validator: &rpcmiddleware.ValidatorJson{
-									PublicKey:       stringPubKey,
-									ActivationEpoch: "10",
-								},
-							},
-						},
-					},
-					outputErr: nil,
-				},
-				{
-					inputStringPubKeys: nil,
-					inputIndexes:       nil,
-					inputStatuses:      []string{"active"},
-
-					outputStateValidatorsResponseJson: &rpcmiddleware.StateValidatorsResponseJson{
-						Data: []*rpcmiddleware.ValidatorContainerJson{
-							{
-								Index: "NotAnIndex",
-							},
-						},
-					},
-					outputErr: nil,
-				},
-			},
-			outputErrMessage: "failed to parse last validator index NotAnIndex",
 		},
 	}
 

--- a/validator/client/key_reload.go
+++ b/validator/client/key_reload.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"go.opencensus.io/trace"
@@ -33,11 +32,8 @@ func (v *validator) HandleKeyReload(ctx context.Context, currentKeys [][fieldpar
 			index:     resp.Indices[i],
 		}
 	}
-	vals, err := v.beaconClient.ListValidators(ctx, &eth.ListValidatorsRequest{Active: true, PageSize: 0})
-	if err != nil {
-		return false, errors.Wrap(err, "could not get active validator count")
-	}
-	anyActive = v.checkAndLogValidatorStatus(statuses, uint64(vals.TotalSize))
+
+	anyActive = v.checkAndLogValidatorStatus(statuses)
 	if anyActive {
 		logActiveValidatorStatus(statuses)
 	}

--- a/validator/client/key_reload_test.go
+++ b/validator/client/key_reload_test.go
@@ -43,7 +43,6 @@ func TestValidator_HandleKeyReload(t *testing.T) {
 				PublicKeys: [][]byte{inactive.pub[:], active.pub[:]},
 			},
 		).Return(resp, nil)
-		beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil)
 
 		anyActive, err := v.HandleKeyReload(context.Background(), [][fieldparams.BLSPubkeyLength]byte{inactive.pub, active.pub})
 		require.NoError(t, err)
@@ -73,7 +72,6 @@ func TestValidator_HandleKeyReload(t *testing.T) {
 				PublicKeys: [][]byte{kp.pub[:]},
 			},
 		).Return(resp, nil)
-		beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil)
 
 		anyActive, err := v.HandleKeyReload(context.Background(), [][fieldparams.BLSPubkeyLength]byte{kp.pub})
 		require.NoError(t, err)

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -772,7 +772,7 @@ func TestCheckAndLogValidatorStatus_OK(t *testing.T) {
 					PositionInActivationQueue: 6,
 				},
 			},
-			log:    "Waiting to be assigned activation epoch\" expectedWaitingTime=12m48s index=50 positionInActivationQueue=6",
+			log:    "Waiting to be assigned activation epoch\" index=50 positionInActivationQueue=6",
 			active: false,
 		},
 		{
@@ -828,6 +828,7 @@ func TestCheckAndLogValidatorStatus_OK(t *testing.T) {
 			hook := logTest.NewGlobal()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
+
 			client := validatormock.NewMockValidatorClient(ctrl)
 			v := validator{
 				validatorClient: client,
@@ -840,7 +841,7 @@ func TestCheckAndLogValidatorStatus_OK(t *testing.T) {
 				},
 			}
 
-			active := v.checkAndLogValidatorStatus([]*validatorStatus{test.status}, 100)
+			active := v.checkAndLogValidatorStatus([]*validatorStatus{test.status})
 			require.Equal(t, test.active, active)
 			if test.log != "" {
 				require.LogsContain(t, hook, test.log)

--- a/validator/client/wait_for_activation.go
+++ b/validator/client/wait_for_activation.go
@@ -136,12 +136,7 @@ func (v *validator) handleAccountsChanged(ctx context.Context, accountsChangedCh
 				}
 			}
 
-			vals, err := v.beaconClient.ListValidators(ctx, &ethpb.ListValidatorsRequest{Active: true, PageSize: 0})
-			if err != nil {
-				return errors.Wrap(err, "could not get active validator count")
-			}
-
-			valActivated := v.checkAndLogValidatorStatus(statuses, uint64(vals.TotalSize))
+			valActivated := v.checkAndLogValidatorStatus(statuses)
 			if valActivated {
 				logActiveValidatorStatus(statuses)
 			} else {

--- a/validator/client/wait_for_activation_test.go
+++ b/validator/client/wait_for_activation_test.go
@@ -70,7 +70,6 @@ func TestWaitActivation_StreamSetupFails_AttemptsToReconnect(t *testing.T) {
 			PublicKeys: [][]byte{kp.pub[:]},
 		},
 	).Return(clientStream, errors.New("failed stream")).Return(clientStream, nil)
-	beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil)
 	resp := generateMockStatusResponse([][]byte{kp.pub[:]})
 	resp.Statuses[0].Status.Status = ethpb.ValidatorStatus_ACTIVE
 	clientStream.EXPECT().Recv().Return(resp, nil)
@@ -95,7 +94,6 @@ func TestWaitForActivation_ReceiveErrorFromStream_AttemptsReconnection(t *testin
 			PublicKeys: [][]byte{kp.pub[:]},
 		},
 	).Return(clientStream, nil)
-	beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil)
 	// A stream fails the first time, but succeeds the second time.
 	resp := generateMockStatusResponse([][]byte{kp.pub[:]})
 	resp.Statuses[0].Status.Status = ethpb.ValidatorStatus_ACTIVE
@@ -128,7 +126,6 @@ func TestWaitActivation_LogsActivationEpochOK(t *testing.T) {
 			PublicKeys: [][]byte{kp.pub[:]},
 		},
 	).Return(clientStream, nil)
-	beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil)
 	clientStream.EXPECT().Recv().Return(
 		resp,
 		nil,
@@ -157,7 +154,6 @@ func TestWaitForActivation_Exiting(t *testing.T) {
 			PublicKeys: [][]byte{kp.pub[:]},
 		},
 	).Return(clientStream, nil)
-	beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil)
 	clientStream.EXPECT().Recv().Return(
 		resp,
 		nil,
@@ -196,7 +192,6 @@ func TestWaitForActivation_RefetchKeys(t *testing.T) {
 			PublicKeys: [][]byte{kp.pub[:]},
 		},
 	).Return(clientStream, nil)
-	beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil)
 	clientStream.EXPECT().Recv().Return(
 		resp,
 		nil)
@@ -231,7 +226,6 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 				PublicKeys: [][]byte{inactive.pub[:]},
 			},
 		).Return(inactiveClientStream, nil)
-		beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil).AnyTimes()
 		inactiveClientStream.EXPECT().Recv().Return(
 			inactiveResp,
 			nil,
@@ -313,7 +307,6 @@ func TestWaitForActivation_AccountsChanged(t *testing.T) {
 				PublicKeys: [][]byte{inactivePubKey[:]},
 			},
 		).Return(inactiveClientStream, nil)
-		beaconClient.EXPECT().ListValidators(gomock.Any(), gomock.Any()).Return(&ethpb.Validators{}, nil).AnyTimes()
 		inactiveClientStream.EXPECT().Recv().Return(
 			inactiveResp,
 			nil,


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

- Removes all instances GET all validators calls in prysm validator client which were used at two places:
   - In [validator/client/validator.go](https://github.com/prysmaticlabs/prysm/compare/develop...dB2510:prysm:remove-list-all-validators?expand=1#diff-f0ef7fb9371dbf4c04023b673da6d03a5c008cad259f0a3acc26603cfbb33159) where it's use-case was to find active validator count to calculate expected waiting time if a validator is in activation queue.
   - In [validator/client/beacon-api/status.go](https://github.com/prysmaticlabs/prysm/compare/develop...dB2510:prysm:remove-list-all-validators?expand=1#diff-aba7facedca36ea58172cf33acbeed878f5f1667707732f6530a088cd3a7bc4f) where it's use-case was to populate `PositionInActivationQueue` in `ValidatorStatusResponse` protobuf.
- This PR also removes usage of `PositionInActivationQueue` in prysm validator client as in order to populate this field we need to get details of all the validators which is a heavy API call (`/eth/v1/beacon/states/{state_id}/validators`). It takes around 15-20s for this API call to return a response on goerli (tested with a local beacon node).

