### PR TITLE
Implements #11616 - EIP-3076 - Minimal database

### DIFF
--- a/config/features/config.go
+++ b/config/features/config.go
@@ -55,8 +55,9 @@ type Flags struct {
 	// Bug fixes related flags.
 	AttestTimely bool // AttestTimely fixes #8185. It is gated behind a flag to ensure beacon node's fix can safely roll out first. We'll invert this in v1.1.0.
 
-	EnableSlasher                   bool // Enable slasher in the beacon node runtime.
-	EnableSlashingProtectionPruning bool // EnableSlashingProtectionPruning for the validator client.
+	EnableSlasher                           bool // Enable slasher in the beacon node runtime.
+	EnableSlashingProtectionPruning         bool // EnableSlashingProtectionPruning for the validator client.
+	EnableMinimalSlashingProtectionDatabase bool // Enable minimal slashing protection database for the validator client.
 
 	SaveFullExecutionPayloads bool // Save full beacon blocks with execution payloads in the database.
 	EnableStartOptimistic     bool // EnableStartOptimistic treats every block as optimistic at startup.
@@ -263,6 +264,10 @@ func ConfigureValidator(ctx *cli.Context) error {
 	if ctx.Bool(enableSlashingProtectionPruning.Name) {
 		logEnabled(enableSlashingProtectionPruning)
 		cfg.EnableSlashingProtectionPruning = true
+	}
+	if ctx.Bool(enableMinimalSlashingProtectionDatabase.Name) {
+		logEnabled(enableMinimalSlashingProtectionDatabase)
+		cfg.EnableMinimalSlashingProtectionDatabase = true
 	}
 	if ctx.Bool(enableDoppelGangerProtection.Name) {
 		logEnabled(enableDoppelGangerProtection)

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -34,7 +34,7 @@ var (
 	}
 	enableExternalSlasherProtectionFlag = &cli.BoolFlag{
 		Name: "enable-external-slasher-protection",
-		Usage: "Enables the validator to connect to a beacon node using the --slasher flag" +
+		Usage: "Enables the validator to connect to a beacon node using the --slasher flag " +
 			"for remote slashing protection",
 	}
 	disableGRPCConnectionLogging = &cli.BoolFlag{

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -94,6 +94,10 @@ var (
 		Name:  "enable-slashing-protection-history-pruning",
 		Usage: "Enables the pruning of the validator client's slashing protection database",
 	}
+	enableMinimalSlashingProtectionDatabase = &cli.BoolFlag{
+		Name:  "enable-minimal-slashing-protection-database",
+		Usage: "Enables the minimal slashing protection database. See EIP-3076 for more details.",
+	}
 	enableDoppelGangerProtection = &cli.BoolFlag{
 		Name: "enable-doppelganger",
 		Usage: "Enables the validator to perform a doppelganger check. (Warning): This is not " +
@@ -166,6 +170,7 @@ var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	dynamicKeyReloadDebounceInterval,
 	attestTimely,
 	enableSlashingProtectionPruning,
+	enableMinimalSlashingProtectionDatabase,
 	enableDoppelGangerProtection,
 	EnableBeaconRESTApi,
 }...)

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -49,14 +49,15 @@ func (v *validator) slashableAttestationCheck(
 	signingRootsDiffer := slashings.SigningRootsDiffer(existingSigningRoot, signingRoot)
 
 	// Based on EIP3076, validator should refuse to sign any attestation with target epoch less
-	// than or equal to the minimum target epoch present in that signer’s attestations.
+	// than or equal to the minimum target epoch present in that signer’s attestations, except
+	// if it is a repeat signing as determined by the signingRoot.
 	lowestTargetEpoch, exists, err := v.db.LowestSignedTargetEpoch(ctx, pubKey)
 	if err != nil {
 		return err
 	}
 	if signingRootsDiffer && exists && indexedAtt.Data.Target.Epoch <= lowestTargetEpoch {
 		return fmt.Errorf(
-			"could not sign attestation lower than or equal to lowest target epoch in db, %d <= %d",
+			"could not sign attestation lower than or equal to lowest target epoch in db if signing roots differ, %d <= %d",
 			indexedAtt.Data.Target.Epoch,
 			lowestTargetEpoch,
 		)

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -142,8 +142,8 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 		return createBuckets(
 			tx,
 			genesisInfoBucket,
-			deprecatedAttestationHistoryBucket,
 			historicProposalsBucket,
+			deprecatedAttestationHistoryBucket,
 			lowestSignedSourceBucket,
 			lowestSignedTargetBucket,
 			lowestSignedProposalsBucket,

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -165,6 +165,19 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 		}
 	}
 
+	if features.Get().EnableMinimalSlashingProtectionDatabase {
+		// Check if the current slashing protection database is compatible with the minimal
+		// slashing protection database type.
+		err, isMinimal := kv.IsMinimal()
+		if err != nil {
+			return nil, errors.Wrap(err, "could not check if slashing protection database is minimal")
+		}
+
+		if !isMinimal {
+			return nil, errors.New("slashing protection database is not compatible with minimal slashing protection database type")
+		}
+	}
+
 	if features.Get().EnableSlashingProtectionPruning {
 		// Prune attesting records older than the current weak subjectivity period.
 		if err := kv.PruneAttestations(ctx); err != nil {

--- a/validator/db/kv/minimal.go
+++ b/validator/db/kv/minimal.go
@@ -1,0 +1,60 @@
+package kv
+
+import (
+	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
+	bolt "go.etcd.io/bbolt"
+)
+
+func isBucketMinimal(tx *bolt.Tx, bucket *bolt.Bucket, deep bool) bool {
+	c := bucket.Cursor()
+
+	k, _ := c.First()
+	if k == nil {
+		return true
+	}
+
+	firstSourceEpoch := bytesutil.BytesToEpochBigEndian(k)
+
+	k, v := c.Last()
+	lastSourceEpoch := bytesutil.BytesToEpochBigEndian(k)
+
+	if firstSourceEpoch != lastSourceEpoch {
+		return false
+	}
+
+	if deep {
+		if len(v) > 8 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s *Store) IsMinimal() (error, bool) {
+	isMinimal := true
+
+	err := s.view(func(tx *bolt.Tx) error {
+		pubkeysBucket := tx.Bucket(pubKeysBucket)
+
+		pubkeysBucket.ForEach(func(pubkey []byte, _ []byte) error {
+			pubkeyBucket := pubkeysBucket.Bucket(pubkey)
+
+			signingRootsBucket := pubkeyBucket.Bucket(attestationSigningRootsBucket)
+			sourceEpochsBucket := pubkeyBucket.Bucket(attestationSourceEpochsBucket)
+			targetEpochsBucket := pubkeyBucket.Bucket(attestationTargetEpochsBucket)
+
+			if !(isBucketMinimal(tx, signingRootsBucket, false) &&
+				isBucketMinimal(tx, sourceEpochsBucket, true) &&
+				isBucketMinimal(tx, targetEpochsBucket, true)) {
+				isMinimal = false
+			}
+
+			return nil
+		})
+
+		return nil
+	})
+
+	return err, isMinimal
+}

--- a/validator/slashing-protection-history/export.go
+++ b/validator/slashing-protection-history/export.go
@@ -99,15 +99,12 @@ func ExportStandardProtectionJSON(
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not retrieve signed attestations for public key %s", pubKeyHex)
 		}
-		if _, ok := dataByPubKey[pubKey]; ok {
-			dataByPubKey[pubKey].SignedAttestations = signedAttestations
-		} else {
-			dataByPubKey[pubKey] = &format.ProtectionData{
-				Pubkey:             pubKeyHex,
-				SignedBlocks:       nil,
-				SignedAttestations: signedAttestations,
-			}
+		if _, ok := dataByPubKey[pubKey]; !ok {
+			// This should never happen
+			return nil, errors.Wrapf(err, "could not retrieve proposer public key from array")
 		}
+		dataByPubKey[pubKey].SignedAttestations = signedAttestations
+
 		if err := bar.Add(1); err != nil {
 			return nil, err
 		}
@@ -175,8 +172,8 @@ func signedAttestationsByPubKey(ctx context.Context, validatorDB db.Database, pu
 
 func signedBlocksByPubKey(ctx context.Context, validatorDB db.Database, pubKey [fieldparams.BLSPubkeyLength]byte) ([]*format.SignedBlock, error) {
 	// If a key does not have a lowest or highest signed proposal history
-	// in our database, we return nil. This way, a user will be able to export their
-	// slashing protection history even if one of their keys does not have a history
+	// in our database, we return an empty list. This way, a user will be able to export
+	// their slashing protection history even if one of their keys does not have a history
 	// of signed blocks.
 	proposalHistory, err := validatorDB.ProposalHistoryForPubKey(ctx, pubKey)
 	if err != nil {

--- a/validator/slashing-protection-history/helpers.go
+++ b/validator/slashing-protection-history/helpers.go
@@ -37,7 +37,7 @@ func Uint64FromString(str string) (uint64, error) {
 
 // EpochFromString converts a string into Epoch.
 func EpochFromString(str string) (primitives.Epoch, error) {
-	e, err := strconv.ParseUint(str, 10, 64)
+	e, err := Uint64FromString(str)
 	if err != nil {
 		return primitives.Epoch(e), err
 	}
@@ -46,7 +46,7 @@ func EpochFromString(str string) (primitives.Epoch, error) {
 
 // SlotFromString converts a string into Slot.
 func SlotFromString(str string) (primitives.Slot, error) {
-	s, err := strconv.ParseUint(str, 10, 64)
+	s, err := Uint64FromString(str)
 	if err != nil {
 		return primitives.Slot(s), err
 	}

--- a/validator/slashing-protection-history/helpers_test.go
+++ b/validator/slashing-protection-history/helpers_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 )
 
-func Test_uint64FromString(t *testing.T) {
+func Test_fromString(t *testing.T) {
 	tests := []struct {
 		name    string
 		str     string


### PR DESCRIPTION
This PR is easier to review commit by commit. (Useful information are in commit message description)

**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR implements the **minimal slashing protection database**, as specified in [EIP-3076](https://eips.ethereum.org/EIPS/eip-3076).

- [ ] `signed_attestations`:
    - [ ] During validator runtime
    - [ ] During JSON import
    - [ ] During JSON export

- [ ] `signed_blocks`:
    - [ ] During validator runtime
    - [ ] During JSON import
    - [ ] During JSON export

- [ ] Tests

In term of data, the minimal slashing database can be seen as a subset of the complete slashing database, as it has the exact same schema, but contains only the block with the maximum slot and attestations with the maximum source and target for each validator.

=> There is no need to have a database interface and 2 implementations of this interface (complete and minimal), since the minimal database can be simply handled by removing, for each validator, all but the latest message (atomically with the new insertion).

A new `--enable-minimal-slashing-protection-database` flag is defined in the validator client.

Design choices about complete/minimal interoperability:
------------
1. The validator client **cannot** start if the `--enable-minimal-slashing-protection-database` flag is set while a pre-existing complete database is found. (The opposite is possible).
2. The validator client **can** import a complete JSON interchange file into a minimal database. However, only block with the maximum slot and attestations with the maximum source and target for each validator will be imported in the minimal database. (By design, it's also possible to import a minimal JSON interchange file into a complete database, since the JSON interchange file with a list of `signed_blocks` or `signed_attestations` with only `1` element can be both considered as a minimal JSON interchange file or as a complete JSON interchange file, but with only 1 attestation/block per validator.)

Because of `1.`, Prysm validator client should provide a tool to convert a complete database to a minimal one.
Example:
```
prysm.sh validator slashing-protection-history convert-to-minimal
```

Notes about the current antislashing database:
---------------
```
"pubkeys-bucket"  -> <pubkey> -> "att-signing-roots-bucket" -> <target epoch> -> <signing root>
                              |
                              -> "att-source-epoch-bucket"  -> <source epoch> -> []<target epoch>
                              |
                              -> "att-target-epoch-bucket"  -> <target epoch> -> []<source epoch>

"lowest-signed-source-bucket" -> <pubkey> -> <lowest signed source epoch>
"lowest-signed-target-bucket  -> <pubkey> -> <lowest signed target epoch>
```

 [EIP-3076 condition 3](https://eips.ethereum.org/EIPS/eip-3076#conditions) (attestation slashing rules):
---------------------------
Same source, different target ==> ✅
```
old attestation: S ----------------> T (whatever the signing root is)
new attestation: S -----------> T (whatever the signing root is)

or

old attestation: S -------------> T (whatever the signing root is)
new attestation: S ------> T (whatever the signing root is)
```

Same source, same target, same root ==> ✅
```
old attestation: S ----------------> T (signing root A)
new attestation: S ----------------> T (signing root A)
```

Same source, same target, different root ==> ❌ (LMD Ghost and/or Casper FFG violation)
```
old attestation: S ----------------> T (signing root A)
new attestation: S ----------------> T (signing root B)
```

Different source, same target ==> ❌ (LMD Ghost and/or Casper FFG violation)
```
old attestation:      S -----------> T (whatever the root is)
new attestation: S ----------------> T (whatever the root is)
```

Surrounding ==> ❌ (Casper FFG violation)
```
old attestation:      S -----> T (whatever the signing root is)
new attestation: S ----------------> T (whatever the signing root is)
```

Surrounded ==> ❌ (Casper FFG violation)
```
old attestation: S ----------------> T (whatever the signing root is)
new attestation:      S -----> T (whatever the signing root is)
```

**Which issues(s) does this PR fix?**
Fixes #11616