### PR TITLE
Fix the bug that return 500 in /eth/v1/node/peers interface

### DIFF
--- a/beacon-chain/rpc/eth/node/node.go
+++ b/beacon-chain/rpc/eth/node/node.go
@@ -348,14 +348,23 @@ func peerInfo(peerStatus *peers.Status, id peer.ID) (*ethpb.Peer, error) {
 	}
 	address, err := peerStatus.Address(id)
 	if err != nil {
+		if errors.Is(err, peerdata.ErrPeerUnknown) {
+			return nil, nil
+		}
 		return nil, errors.Wrap(err, "could not obtain address")
 	}
 	connectionState, err := peerStatus.ConnectionState(id)
 	if err != nil {
+		if errors.Is(err, peerdata.ErrPeerUnknown) {
+			return nil, nil
+		}
 		return nil, errors.Wrap(err, "could not obtain connection state")
 	}
 	direction, err := peerStatus.Direction(id)
 	if err != nil {
+		if errors.Is(err, peerdata.ErrPeerUnknown) {
+			return nil, nil
+		}
 		return nil, errors.Wrap(err, "could not obtain direction")
 	}
 	if eth.PeerDirection(direction) == eth.PeerDirection_UNKNOWN {

--- a/beacon-chain/rpc/eth/node/node.go
+++ b/beacon-chain/rpc/eth/node/node.go
@@ -337,6 +337,9 @@ func handleEmptyFilters(req *ethpb.PeersRequest) (emptyState, emptyDirection boo
 func peerInfo(peerStatus *peers.Status, id peer.ID) (*ethpb.Peer, error) {
 	enr, err := peerStatus.ENR(id)
 	if err != nil {
+		if errors.Is(err, peerdata.ErrPeerUnknown) {
+			return nil, nil
+		}
 		return nil, errors.Wrap(err, "could not obtain ENR")
 	}
 	var serializedEnr string


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

>
> Bug fix

**What does this PR do? Why is it needed?**
When there are multiple inbound nodes and some nodes suddenly disconnect, the `/eth/v1/node/peers` interface may return `{"message":"Could not get peer info: Could not obtain ENR: peer unknown","code":500}`. This PR fixes this bug.
