### PR TITLE
Add the Ability for Prysm To Handle Trusted Peers

### DIFF
--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -460,6 +460,19 @@ func convertToUdpMultiAddr(node *enode.Node) ([]ma.Multiaddr, error) {
 	return addresses, nil
 }
 
+func peerIdsFromMultiAddrs(addrs []ma.Multiaddr) []peer.ID {
+	peers := []peer.ID{}
+	for _, a := range addrs {
+		info, err := peer.AddrInfoFromP2pAddr(a)
+		if err != nil {
+			log.WithError(err).Error("Could not derive peer info from multiaddress")
+			continue
+		}
+		peers = append(peers, info.ID)
+	}
+	return peers
+}
+
 func multiAddrFromString(address string) (ma.Multiaddr, error) {
 	return ma.NewMultiaddr(address)
 }

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -210,6 +210,10 @@ func (s *Service) Start() {
 		if err != nil {
 			log.WithError(err).Error("Could not connect to static peer")
 		}
+		// Set trusted peers for those that are provided as static addresses.
+		pids := peerIdsFromMultiAddrs(addrs)
+		s.peers.SetTrustedPeers(pids)
+
 		s.connectWithAllPeers(addrs)
 	}
 	// Initialize metadata according to the

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -93,7 +93,7 @@ var (
 	// StaticPeers specifies a set of peers to connect to explicitly.
 	StaticPeers = &cli.StringSliceFlag{
 		Name:  "peer",
-		Usage: "Connect with this peer. This flag may be used multiple times.",
+		Usage: "Connect with this peer, this flag may be used multiple times. This peer is recognized as a trusted peer.",
 	}
 	// BootstrapNode tells the beacon node which bootstrap node to connect to
 	BootstrapNode = &cli.StringSliceFlag{


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

- [x] Add the ability for Prysm to correctly handle trusted peers in its peer store. This prevents trusted peers from being part 
banned or disconnected due to our pruning routines/peer scorer.
- [ ] Unit tests for feature.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
