### PR TITLE
Always Favour Yamux for Multiplexing

### DIFF
--- a/beacon-chain/p2p/options.go
+++ b/beacon-chain/p2p/options.go
@@ -62,8 +62,8 @@ func (s *Service) buildOptions(ip net.IP, priKey *ecdsa.PrivateKey) []libp2p.Opt
 		libp2p.UserAgent(version.BuildData()),
 		libp2p.ConnectionGater(s),
 		libp2p.Transport(tcp.NewTCPTransport),
-		libp2p.Muxer("/mplex/6.7.0", mplex.DefaultTransport),
 		libp2p.DefaultMuxers,
+		libp2p.Muxer("/mplex/6.7.0", mplex.DefaultTransport),
 	}
 
 	options = append(options, libp2p.Security(noise.ID, noise.New))

--- a/beacon-chain/p2p/options_test.go
+++ b/beacon-chain/p2p/options_test.go
@@ -123,7 +123,7 @@ func TestDefaultMultiplexers(t *testing.T) {
 	err = cfg.Apply(append(opts, libp2p.FallbackDefaults)...)
 	assert.NoError(t, err)
 
-	assert.Equal(t, protocol.ID("/mplex/6.7.0"), cfg.Muxers[0].ID)
-	assert.Equal(t, protocol.ID("/yamux/1.0.0"), cfg.Muxers[1].ID)
+	assert.Equal(t, protocol.ID("/yamux/1.0.0"), cfg.Muxers[0].ID)
+	assert.Equal(t, protocol.ID("/mplex/6.7.0"), cfg.Muxers[1].ID)
 
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

We initialize `yamux` before `mplex` for stream multiplexing when building the libp2p host. This also fixes the unit test to assert that `yamux` is the first option that we do use.

**Which issues(s) does this PR fix?**

Related to #12255 

**Other notes for review**
