### PR TITLE
Use Next Slot Cache For Sync Committee Objects

### DIFF
--- a/beacon-chain/blockchain/head_sync_committee_info.go
+++ b/beacon-chain/blockchain/head_sync_committee_info.go
@@ -157,7 +157,11 @@ func (s *Service) getSyncCommitteeHeadState(ctx context.Context, slot primitives
 		if headState == nil || headState.IsNil() {
 			return nil, errors.New("nil state")
 		}
-		headState, err = transition.ProcessSlotsIfPossible(ctx, headState, slot)
+		headRoot, err := s.HeadRoot(ctx)
+		if err != nil {
+			return nil, err
+		}
+		headState, err = transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, slot)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

Instead of repeating an already computed transition, we instead use our next slot cache here. This allows us to 
verify sync committee messages in an efficient manner.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
