### PR TITLE
feat(rpc/validator): stream and use deneb block

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/blocks.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/blocks.go
@@ -100,6 +100,17 @@ func sendVerifiedBlocks(stream ethpb.BeaconNodeValidator_StreamBlocksAltairServe
 			return nil
 		}
 		b.Block = &ethpb.StreamBlocksResponse_CapellaBlock{CapellaBlock: phBlk}
+	case version.Deneb:
+		pb, err := data.SignedBlock.Proto()
+		if err != nil {
+			return errors.Wrap(err, "could not get protobuf block")
+		}
+		phBlk, ok := pb.(*ethpb.SignedBeaconBlockDeneb)
+		if !ok {
+			log.Warn("Mismatch between version and block type, was expecting SignedBeaconBlockDeneb")
+			return nil
+		}
+		b.Block = &ethpb.StreamBlocksResponse_DenebBlock{DenebBlock: phBlk}
 	}
 
 	if err := stream.Send(b); err != nil {
@@ -149,6 +160,8 @@ func (vs *Server) sendBlocks(stream ethpb.BeaconNodeValidator_StreamBlocksAltair
 		b.Block = &ethpb.StreamBlocksResponse_BellatrixBlock{BellatrixBlock: p}
 	case *ethpb.SignedBeaconBlockCapella:
 		b.Block = &ethpb.StreamBlocksResponse_CapellaBlock{CapellaBlock: p}
+	case *ethpb.SignedBeaconBlockDeneb:
+		b.Block = &ethpb.StreamBlocksResponse_DenebBlock{DenebBlock: p}
 	default:
 		log.Errorf("Unknown block type %T", p)
 	}

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -348,6 +348,8 @@ func (v *validator) ReceiveBlocks(ctx context.Context, connectionErrorChannel ch
 			blk, err = blocks.NewSignedBeaconBlock(b.BellatrixBlock)
 		case *ethpb.StreamBlocksResponse_CapellaBlock:
 			blk, err = blocks.NewSignedBeaconBlock(b.CapellaBlock)
+		case *ethpb.StreamBlocksResponse_DenebBlock:
+			blk, err = blocks.NewSignedBeaconBlock(b.DenebBlock)
 		}
 		if err != nil {
 			log.WithError(err).Error("Failed to wrap signed block")

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -1015,6 +1015,37 @@ func TestService_ReceiveBlocks_SetHighest(t *testing.T) {
 	require.Equal(t, slot, v.highestValidSlot)
 }
 
+func TestService_ReceiveBlocks_SetHighestDeneb(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := validatormock.NewMockValidatorClient(ctrl)
+
+	v := validator{
+		validatorClient: client,
+		blockFeed:       new(event.Feed),
+	}
+	stream := mock2.NewMockBeaconNodeValidatorAltair_StreamBlocksClient(ctrl)
+	ctx, cancel := context.WithCancel(context.Background())
+	client.EXPECT().StreamBlocksAltair(
+		gomock.Any(),
+		&ethpb.StreamBlocksRequest{VerifiedOnly: true},
+	).Return(stream, nil)
+	stream.EXPECT().Context().Return(ctx).AnyTimes()
+	slot := primitives.Slot(100)
+	stream.EXPECT().Recv().Return(
+		&ethpb.StreamBlocksResponse{
+			Block: &ethpb.StreamBlocksResponse_DenebBlock{
+				DenebBlock: &ethpb.SignedBeaconBlockDeneb{Block: &ethpb.BeaconBlockDeneb{Slot: slot, Body: &ethpb.BeaconBlockBodyDeneb{}}}},
+		},
+		nil,
+	).Do(func() {
+		cancel()
+	})
+	connectionErrorChannel := make(chan error)
+	v.ReceiveBlocks(ctx, connectionErrorChannel)
+	require.Equal(t, slot, v.highestValidSlot)
+}
+
 type doppelGangerRequestMatcher struct {
 	req *ethpb.DoppelGangerRequest
 }


### PR DESCRIPTION
- beacon node RPC can handle Deneb version block for streaming endpoint
- validator client can accept streamed Deneb version block