### PR TITLE
benchmark cold hashing of capella beaconstates

### DIFF
--- a/tools/pcli/main.go
+++ b/tools/pcli/main.go
@@ -282,10 +282,9 @@ func benchmarkHash(sszPath string, sszType string) {
 		if err != nil {
 			log.Fatal("couldn't hash")
 		}
-		fmt.Printf("Duration: %v HTR: %#x\n", time.Now().Sub(start), root)
+		fmt.Printf("Duration: %v HTR: %#x\n", time.Since(start), root)
 		return
 	default:
 		log.Fatal("Invalid type")
 	}
-
 }

--- a/tools/pcli/main.go
+++ b/tools/pcli/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/kr/pretty"
 	fssz "github.com/prysmaticlabs/fastssz"
@@ -62,7 +63,7 @@ func main() {
 						"signed_block_header|" +
 						"signed_voluntary_exit|" +
 						"voluntary_exit|" +
-						"state",
+						"state_capella",
 					Required:    true,
 					Destination: &sszType,
 				},
@@ -92,12 +93,46 @@ func main() {
 					data = &ethpb.SignedVoluntaryExit{}
 				case "voluntary_exit":
 					data = &ethpb.VoluntaryExit{}
-				case "state":
-					data = &ethpb.BeaconState{}
+				case "state_capella":
+					data = &ethpb.BeaconStateCapella{}
 				default:
 					log.Fatal("Invalid type")
 				}
 				prettyPrint(sszPath, data)
+				return nil
+			},
+		},
+		{
+			Name:    "benchmark-hash",
+			Aliases: []string{"b"},
+			Usage:   "benchmark-hash SSZ data",
+			Flags: []cli.Flag{
+				&cli.StringFlag{
+					Name:        "ssz-path",
+					Usage:       "Path to file(ssz)",
+					Required:    true,
+					Destination: &sszPath,
+				},
+				&cli.StringFlag{
+					Name: "data-type",
+					Usage: "ssz file data type: " +
+						"block_capella|" +
+						"blinded_block_capella|" +
+						"signed_block_capella|" +
+						"attestation|" +
+						"block_header|" +
+						"deposit|" +
+						"proposer_slashing|" +
+						"signed_block_header|" +
+						"signed_voluntary_exit|" +
+						"voluntary_exit|" +
+						"state_capella",
+					Required:    true,
+					Destination: &sszType,
+				},
+			},
+			Action: func(c *cli.Context) error {
+				benchmarkHash(sszPath, sszType)
 				return nil
 			},
 		},
@@ -229,4 +264,28 @@ func prettyPrint(sszPath string, data fssz.Unmarshaler) {
 	re := regexp.MustCompile("(?m)[\r\n]+^.*XXX_.*$")
 	str = re.ReplaceAllString(str, "")
 	fmt.Print(str)
+}
+
+func benchmarkHash(sszPath string, sszType string) {
+	switch sszType {
+	case "state_capella":
+		data := &ethpb.BeaconStateCapella{}
+		if err := dataFetcher(sszPath, data); err != nil {
+			log.Fatal(err)
+		}
+		st, err := state_native.InitializeFromProtoCapella(data)
+		if err != nil {
+			log.Fatal("not a state")
+		}
+		start := time.Now()
+		root, err := st.HashTreeRoot(context.Background())
+		if err != nil {
+			log.Fatal("couldn't hash")
+		}
+		fmt.Printf("Duration: %v HTR: %#x\n", time.Now().Sub(start), root)
+		return
+	default:
+		log.Fatal("Invalid type")
+	}
+
 }


### PR DESCRIPTION
Add a command to benchmark hashing of cold beacon states. Tool is broken in many places but it's on tree and it's a common hack that I keep adding from time to time and need to keep it stashed  otherwise. 