### PR TITLE
Ignore Late Message Logs

### DIFF
--- a/beacon-chain/core/helpers/attestation.go
+++ b/beacon-chain/core/helpers/attestation.go
@@ -14,6 +14,10 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
 )
 
+var (
+	ErrTooLate = errors.New("attestation is too late")
+)
+
 // ValidateNilAttestation checks if any composite field of input attestation is nil.
 // Access to these nil fields will result in run time panic,
 // it is recommended to run these checks as first line of defense.
@@ -164,7 +168,7 @@ func ValidateAttestationTime(attSlot primitives.Slot, genesisTime time.Time, clo
 	)
 	if attTime.Before(lowerBounds) {
 		attReceivedTooLateCount.Inc()
-		return attError
+		return errors.Join(ErrTooLate, attError)
 	}
 	if attTime.After(upperBounds) {
 		attReceivedTooEarlyCount.Inc()


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

In gossip there are a lot of late attestation aggregates and sync committee messages being constantly broadcasted, unfortunately due to the large number of messages from these objects they can fill up our debug logs which makes it difficult 
to parse what is happening with a particular node. We now check that errors from gossip for `ignored` messages are only of
those that we infact care about.  

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
