### PR TITLE
Reopenning fix for keystore field name change to align with EIP2335

### DIFF
--- a/cmd/validator/accounts/delete_test.go
+++ b/cmd/validator/accounts/delete_test.go
@@ -52,11 +52,11 @@ func createKeystore(t *testing.T, path string) (*keymanager.Keystore, string) {
 	id, err := uuid.NewRandom()
 	require.NoError(t, err)
 	keystoreFile := &keymanager.Keystore{
-		Crypto:  cryptoFields,
-		ID:      id.String(),
-		Pubkey:  fmt.Sprintf("%x", validatingKey.PublicKey().Marshal()),
-		Version: encryptor.Version(),
-		Name:    encryptor.Name(),
+		Crypto:      cryptoFields,
+		ID:          id.String(),
+		Pubkey:      fmt.Sprintf("%x", validatingKey.PublicKey().Marshal()),
+		Version:     encryptor.Version(),
+		Description: encryptor.Name(),
 	}
 	encoded, err := json.MarshalIndent(keystoreFile, "", "\t")
 	require.NoError(t, err)

--- a/tools/keystores/main.go
+++ b/tools/keystores/main.go
@@ -197,11 +197,11 @@ func encrypt(cliCtx *cli.Context) error {
 		return errors.Wrap(err, "could not encrypt into new keystore")
 	}
 	item := &keymanager.Keystore{
-		Crypto:  cryptoFields,
-		ID:      id.String(),
-		Version: encryptor.Version(),
-		Pubkey:  pubKey,
-		Name:    encryptor.Name(),
+		Crypto:      cryptoFields,
+		ID:          id.String(),
+		Version:     encryptor.Version(),
+		Pubkey:      pubKey,
+		Description: encryptor.Name(),
 	}
 	encodedFile, err := json.MarshalIndent(item, "", "\t")
 	if err != nil {
@@ -229,7 +229,6 @@ func readAndDecryptKeystore(fullPath, password string) error {
 	}
 	decryptor := keystorev4.New()
 	keystoreFile := &keymanager.Keystore{}
-
 	if err := json.Unmarshal(f, keystoreFile); err != nil {
 		return errors.Wrap(err, "could not JSON unmarshal keystore file")
 	}

--- a/validator/accounts/accounts_import.go
+++ b/validator/accounts/accounts_import.go
@@ -277,6 +277,9 @@ func readKeystoreFile(_ context.Context, keystoreFilePath string) (*keymanager.K
 	if keystoreFile.Pubkey == "" {
 		return nil, errors.New("could not decode keystore json")
 	}
+	if keystoreFile.Description == "" && keystoreFile.Name != "" {
+		keystoreFile.Description = keystoreFile.Name
+	}
 	return keystoreFile, nil
 }
 
@@ -295,11 +298,11 @@ func createKeystoreFromPrivateKey(privKey bls.SecretKey, walletPassword string) 
 		)
 	}
 	return &keymanager.Keystore{
-		Crypto:  cryptoFields,
-		ID:      id.String(),
-		Version: encryptor.Version(),
-		Pubkey:  fmt.Sprintf("%x", privKey.PublicKey().Marshal()),
-		Name:    encryptor.Name(),
+		Crypto:      cryptoFields,
+		ID:          id.String(),
+		Version:     encryptor.Version(),
+		Pubkey:      fmt.Sprintf("%x", privKey.PublicKey().Marshal()),
+		Description: encryptor.Name(),
 	}, nil
 }
 

--- a/validator/accounts/accounts_import_test.go
+++ b/validator/accounts/accounts_import_test.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -173,4 +174,31 @@ func Test_importPrivateKeyAsAccount(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(pubKeys))
 	assert.DeepEqual(t, pubKeys[0], bytesutil.ToBytes48(privKey.PublicKey().Marshal()))
+}
+
+func Test_NameToDescriptionChangeIsOK(t *testing.T) {
+	jsonString := `{"version":1, "name":"hmmm"}`
+	type Obj struct {
+		Version     uint   `json:"version"`
+		Description string `json:"description"`
+	}
+	a := &Obj{}
+	require.NoError(t, json.Unmarshal([]byte(jsonString), a))
+	require.Equal(t, a.Description, "")
+}
+
+func Test_MarshalOmitsName(t *testing.T) {
+	type Obj struct {
+		Version     uint   `json:"version"`
+		Description string `json:"description"`
+		Name        string `json:"name,omitempty"`
+	}
+	a := &Obj{
+		Version:     1,
+		Description: "hmm",
+	}
+
+	bytes, err := json.Marshal(a)
+	require.NoError(t, err)
+	require.Equal(t, string(bytes), `{"version":1,"description":"hmm"}`)
 }

--- a/validator/accounts/accounts_list_test.go
+++ b/validator/accounts/accounts_list_test.go
@@ -117,11 +117,11 @@ func createRandomKeystore(t testing.TB, password string) *keymanager.Keystore {
 	cryptoFields, err := encryptor.Encrypt(validatingKey.Marshal(), password)
 	require.NoError(t, err)
 	return &keymanager.Keystore{
-		Crypto:  cryptoFields,
-		Pubkey:  fmt.Sprintf("%x", pubKey),
-		ID:      id.String(),
-		Version: encryptor.Version(),
-		Name:    encryptor.Name(),
+		Crypto:      cryptoFields,
+		Pubkey:      fmt.Sprintf("%x", pubKey),
+		ID:          id.String(),
+		Version:     encryptor.Version(),
+		Description: encryptor.Name(),
 	}
 }
 

--- a/validator/keymanager/local/backup.go
+++ b/validator/keymanager/local/backup.go
@@ -44,11 +44,11 @@ func (_ *Keymanager) ExtractKeystores(
 			return nil, err
 		}
 		keystores[i] = &keymanager.Keystore{
-			Crypto:  cryptoFields,
-			ID:      id.String(),
-			Pubkey:  fmt.Sprintf("%x", pubKeyBytes),
-			Version: encryptor.Version(),
-			Name:    encryptor.Name(),
+			Crypto:      cryptoFields,
+			ID:          id.String(),
+			Pubkey:      fmt.Sprintf("%x", pubKeyBytes),
+			Version:     encryptor.Version(),
+			Description: encryptor.Name(),
 		}
 	}
 	return keystores, nil

--- a/validator/keymanager/local/backup.go
+++ b/validator/keymanager/local/backup.go
@@ -15,7 +15,7 @@ import (
 // ExtractKeystores retrieves the secret keys for specified public keys
 // in the function input, encrypts them using the specified password,
 // and returns their respective EIP-2335 keystores.
-func (_ *Keymanager) ExtractKeystores(
+func (*Keymanager) ExtractKeystores(
 	_ context.Context, publicKeys []bls.PublicKey, password string,
 ) ([]*keymanager.Keystore, error) {
 	lock.Lock()

--- a/validator/keymanager/local/import_test.go
+++ b/validator/keymanager/local/import_test.go
@@ -31,11 +31,11 @@ func createRandomKeystore(t testing.TB, password string) *keymanager.Keystore {
 	cryptoFields, err := encryptor.Encrypt(validatingKey.Marshal(), password)
 	require.NoError(t, err)
 	return &keymanager.Keystore{
-		Crypto:  cryptoFields,
-		Pubkey:  fmt.Sprintf("%x", pubKey),
-		ID:      id.String(),
-		Version: encryptor.Version(),
-		Name:    encryptor.Name(),
+		Crypto:      cryptoFields,
+		Pubkey:      fmt.Sprintf("%x", pubKey),
+		ID:          id.String(),
+		Version:     encryptor.Version(),
+		Description: encryptor.Name(),
 	}
 }
 

--- a/validator/keymanager/types.go
+++ b/validator/keymanager/types.go
@@ -83,12 +83,13 @@ type AccountLister interface {
 
 // Keystore json file representation as a Go struct.
 type Keystore struct {
-	Crypto  map[string]interface{} `json:"crypto"`
-	ID      string                 `json:"uuid"`
-	Pubkey  string                 `json:"pubkey"`
-	Version uint                   `json:"version"`
-	Name    string                 `json:"name"`
-	Path    string                 `json:"path"`
+	Crypto      map[string]interface{} `json:"crypto"`
+	ID          string                 `json:"uuid"`
+	Pubkey      string                 `json:"pubkey"`
+	Version     uint                   `json:"version"`
+	Description string                 `json:"description"`
+	Name        string                 `json:"name,omitempty"` // field deprecated in favor of description, EIP2335
+	Path        string                 `json:"path"`
 }
 
 // Kind defines an enum for either local, derived, or remote-signing

--- a/validator/rpc/standard_api.go
+++ b/validator/rpc/standard_api.go
@@ -89,6 +89,9 @@ func (s *Server) ImportKeystores(
 	for i := 0; i < len(req.Keystores); i++ {
 		k := &keymanager.Keystore{}
 		err = json.Unmarshal([]byte(req.Keystores[i]), k)
+		if k.Description == "" && k.Name != "" {
+			k.Description = k.Name
+		}
 		if err != nil {
 			// we want to ignore unmarshal errors for now, proper status in importKeystore
 			k.Pubkey = "invalid format"

--- a/validator/rpc/standard_api_test.go
+++ b/validator/rpc/standard_api_test.go
@@ -534,11 +534,11 @@ func createRandomKeystore(t testing.TB, password string) *keymanager.Keystore {
 	cryptoFields, err := encryptor.Encrypt(validatingKey.Marshal(), password)
 	require.NoError(t, err)
 	return &keymanager.Keystore{
-		Crypto:  cryptoFields,
-		Pubkey:  fmt.Sprintf("%x", pubKey),
-		ID:      id.String(),
-		Version: encryptor.Version(),
-		Name:    encryptor.Name(),
+		Crypto:      cryptoFields,
+		Pubkey:      fmt.Sprintf("%x", pubKey),
+		ID:          id.String(),
+		Version:     encryptor.Version(),
+		Description: encryptor.Name(),
 	}
 }
 

--- a/validator/rpc/wallet.go
+++ b/validator/rpc/wallet.go
@@ -243,6 +243,9 @@ func (*Server) ValidateKeystores(
 		if err := json.Unmarshal([]byte(encoded), &keystore); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "Not a valid EIP-2335 keystore JSON file: %v", err)
 		}
+		if keystore.Description == "" && keystore.Name != "" {
+			keystore.Description = keystore.Name
+		}
 		if _, err := decryptor.Decrypt(keystore.Crypto, req.KeystoresPassword); err != nil {
 			doesNotDecrypt := strings.Contains(err.Error(), keymanager.IncorrectPasswordErrMsg)
 			if doesNotDecrypt {

--- a/validator/rpc/wallet_test.go
+++ b/validator/rpc/wallet_test.go
@@ -92,11 +92,11 @@ func TestServer_CreateWallet_Local(t *testing.T) {
 		cryptoFields, err := encryptor.Encrypt(privKey.Marshal(), strongPass)
 		require.NoError(t, err)
 		item := &keymanager.Keystore{
-			Crypto:  cryptoFields,
-			ID:      id.String(),
-			Version: encryptor.Version(),
-			Pubkey:  pubKey,
-			Name:    encryptor.Name(),
+			Crypto:      cryptoFields,
+			ID:          id.String(),
+			Version:     encryptor.Version(),
+			Pubkey:      pubKey,
+			Description: encryptor.Name(),
 		}
 		encodedFile, err := json.MarshalIndent(item, "", "\t")
 		require.NoError(t, err)
@@ -241,11 +241,11 @@ func TestServer_ValidateKeystores_OK(t *testing.T) {
 		cryptoFields, err := encryptor.Encrypt(privKey.Marshal(), strongPass)
 		require.NoError(t, err)
 		item := &keymanager.Keystore{
-			Crypto:  cryptoFields,
-			ID:      id.String(),
-			Version: encryptor.Version(),
-			Pubkey:  pubKey,
-			Name:    encryptor.Name(),
+			Crypto:      cryptoFields,
+			ID:          id.String(),
+			Version:     encryptor.Version(),
+			Pubkey:      pubKey,
+			Description: encryptor.Name(),
 		}
 		encodedFile, err := json.MarshalIndent(item, "", "\t")
 		require.NoError(t, err)
@@ -278,11 +278,11 @@ func TestServer_ValidateKeystores_OK(t *testing.T) {
 	cryptoFields, err := encryptor.Encrypt(privKey.Marshal(), differentPassword)
 	require.NoError(t, err)
 	item := &keymanager.Keystore{
-		Crypto:  cryptoFields,
-		ID:      id.String(),
-		Version: encryptor.Version(),
-		Pubkey:  pubKey,
-		Name:    encryptor.Name(),
+		Crypto:      cryptoFields,
+		ID:          id.String(),
+		Version:     encryptor.Version(),
+		Pubkey:      pubKey,
+		Description: encryptor.Name(),
 	}
 	encodedFile, err := json.MarshalIndent(item, "", "\t")
 	keystores = append(keystores, string(encodedFile))


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix


**What does this PR do? Why is it needed?**

We've had this bug for a while, user @sleepyqadr attempted to fix but the PR went stale...
https://github.com/prysmaticlabs/prysm/pull/11443

circling back on this 

>This PR tweaks the JSON in passing to change 'name' to 'description' in the resulting Keystore-0.json as per [EIP2335](https://eips.ethereum.org/EIPS/eip-2335#description)

while still supporting old formatted files via the "Name" field and set it as the description if not populated. When generating new files the Name field is now omitted. 

**Which issues(s) does this PR fix?**

Fixes #11437
