### PR TITLE
Ensure File Does Not Exist

### DIFF
--- a/tools/interop/convert-keys/BUILD.bazel
+++ b/tools/interop/convert-keys/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v4/tools/interop/convert-keys",
     visibility = ["//visibility:public"],
     deps = [
+        "//config/params:go_default_library",
         "//tools/unencrypted-keys-gen/keygen:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@in_gopkg_yaml_v2//:go_default_library",

--- a/tools/interop/convert-keys/main.go
+++ b/tools/interop/convert-keys/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/tools/unencrypted-keys-gen/keygen"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
@@ -52,7 +53,7 @@ func main() {
 		})
 	}
 
-	outFile, err := os.Create(os.Args[2])
+	outFile, err := os.OpenFile(os.Args[2], os.O_CREATE|os.O_EXCL, params.BeaconIoConfig().ReadWritePermissions)
 	if err != nil {
 		log.WithError(err).Fatalf("Failed to create file at %s", os.Args[2])
 	}

--- a/tools/specs-checker/BUILD.bazel
+++ b/tools/specs-checker/BUILD.bazel
@@ -18,7 +18,10 @@ go_library(
     ],
     importpath = "github.com/prysmaticlabs/prysm/v4/tools/specs-checker",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_urfave_cli_v2//:go_default_library"],
+    deps = [
+        "//config/params:go_default_library",
+        "@com_github_urfave_cli_v2//:go_default_library",
+    ],
 )
 
 go_binary(

--- a/tools/specs-checker/download.go
+++ b/tools/specs-checker/download.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/urfave/cli/v2"
 )
 
@@ -40,7 +41,7 @@ func download(cliCtx *cli.Context) error {
 
 func getAndSaveFile(specDocUrl, outFilePath string) error {
 	// Create output file.
-	f, err := os.Create(filepath.Clean(outFilePath))
+	f, err := os.OpenFile(filepath.Clean(outFilePath), os.O_CREATE|os.O_EXCL, params.BeaconIoConfig().ReadWritePermissions)
 	if err != nil {
 		return fmt.Errorf("cannot create output file: %w", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In the event a file already exists for our key converter and specs checker, we error out rather than truncating the already existing file.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

TOB-PRYSM-2
