### PR TITLE
Fix Uint256 Json Parsing

### DIFF
--- a/api/client/builder/types.go
+++ b/api/client/builder/types.go
@@ -135,7 +135,6 @@ func (s Uint256) SSZBytes() []byte {
 
 // UnmarshalJSON takes in a byte array and unmarshals the value in Uint256
 func (s *Uint256) UnmarshalJSON(t []byte) error {
-	start := 0
 	end := len(t)
 	if len(t) < 2 {
 		return errors.Errorf("provided Uint256 json string is too short: %s", string(t))
@@ -143,9 +142,7 @@ func (s *Uint256) UnmarshalJSON(t []byte) error {
 	if t[0] != '"' || t[end-1] != '"' {
 		return errors.Errorf("provided Uint256 json string is malformed: %s", string(t))
 	}
-	start += 1
-	end -= 1
-	return s.UnmarshalText(t[start:end])
+	return s.UnmarshalText(t[1 : end-1])
 }
 
 // UnmarshalText takes in a byte array and unmarshals the text in Uint256

--- a/api/client/builder/types.go
+++ b/api/client/builder/types.go
@@ -137,12 +137,14 @@ func (s Uint256) SSZBytes() []byte {
 func (s *Uint256) UnmarshalJSON(t []byte) error {
 	start := 0
 	end := len(t)
-	if t[0] == '"' {
-		start += 1
+	if len(t) < 2 {
+		return errors.Errorf("provided Uint256 json string is too short: %s", string(t))
 	}
-	if t[end-1] == '"' {
-		end -= 1
+	if t[0] != '"' || t[end-1] != '"' {
+		return errors.Errorf("provided Uint256 json string is malformed: %s", string(t))
 	}
+	start += 1
+	end -= 1
 	return s.UnmarshalText(t[start:end])
 }
 

--- a/api/client/builder/types_test.go
+++ b/api/client/builder/types_test.go
@@ -1156,6 +1156,14 @@ func TestUint256Unmarshal(t *testing.T) {
 	require.Equal(t, expected, string(m))
 }
 
+func TestUint256Unmarshal_BadData(t *testing.T) {
+	var bigNum Uint256
+
+	assert.ErrorContains(t, "provided Uint256 json string is too short", bigNum.UnmarshalJSON([]byte{'"'}))
+	assert.ErrorContains(t, "provided Uint256 json string is malformed", bigNum.UnmarshalJSON([]byte{'"', '1', '2'}))
+
+}
+
 func TestUint256UnmarshalNegative(t *testing.T) {
 	m := "-1"
 	var value Uint256

--- a/beacon-chain/rpc/apimiddleware/structs_marshalling.go
+++ b/beacon-chain/rpc/apimiddleware/structs_marshalling.go
@@ -18,6 +18,9 @@ func (p *EpochParticipation) UnmarshalJSON(b []byte) error {
 	if len(b) < 2 {
 		return errors.New("epoch participation length must be at least 2")
 	}
+	if b[0] != '"' || b[len(b)-1] != '"' {
+		return errors.Errorf("provided epoch participation json string is malformed: %s", string(b))
+	}
 
 	// Remove leading and trailing quotation marks.
 	jsonString := string(b)

--- a/beacon-chain/rpc/apimiddleware/structs_marshalling_test.go
+++ b/beacon-chain/rpc/apimiddleware/structs_marshalling_test.go
@@ -23,7 +23,7 @@ func TestUnmarshalEpochParticipation(t *testing.T) {
 		ep := EpochParticipation{}
 		err := ep.UnmarshalJSON([]byte(":illegal:"))
 		require.NotNil(t, err)
-		assert.ErrorContains(t, "could not decode epoch participation base64 value", err)
+		assert.ErrorContains(t, "provided epoch participation json string is malformed", err)
 	})
 	t.Run("length too small", func(t *testing.T) {
 		ep := EpochParticipation{}
@@ -38,6 +38,6 @@ func TestUnmarshalEpochParticipation(t *testing.T) {
 	})
 	t.Run("invalid value", func(t *testing.T) {
 		ep := EpochParticipation{}
-		require.ErrorContains(t, "could not decode epoch participation base64 value", ep.UnmarshalJSON([]byte("XdHJ1ZQ==X")))
+		require.ErrorContains(t, "provided epoch participation json string is malformed", ep.UnmarshalJSON([]byte("XdHJ1ZQ==X")))
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Similary to #12534 , we can also accept invalid json strings for `uint256` values in our builder api. We add stronger checks for these along with adding more robust checks to epoch participation parsing in a similar fashion.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**

Audit Finding: TOB-PRYSM-12
