### PR TITLE
Track optimistic status on head

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -343,6 +343,7 @@ func (s *Service) IsOptimistic(_ context.Context) (bool, error) {
 	headSlot := s.head.slot
 	headOptimistic := s.head.optimistic
 	s.headLock.RUnlock()
+	// we trust the head package for recent head slots, otherwise fallback to forkchoice
 	if headSlot+2 >= s.CurrentSlot() {
 		return headOptimistic, nil
 	}

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -340,7 +340,12 @@ func (s *Service) IsOptimistic(_ context.Context) (bool, error) {
 	}
 	s.headLock.RLock()
 	headRoot := s.head.root
+	headSlot := s.head.slot
+	headOptimistic := s.head.optimistic
 	s.headLock.RUnlock()
+	if headSlot+2 >= s.CurrentSlot() {
+		return headOptimistic, nil
+	}
 
 	s.cfg.ForkChoiceStore.RLock()
 	defer s.cfg.ForkChoiceStore.RUnlock()

--- a/beacon-chain/blockchain/chain_info_test.go
+++ b/beacon-chain/blockchain/chain_info_test.go
@@ -422,6 +422,12 @@ func TestService_IsOptimistic(t *testing.T) {
 
 	opt, err := c.IsOptimistic(ctx)
 	require.NoError(t, err)
+	require.Equal(t, primitives.Slot(0), c.CurrentSlot())
+	require.Equal(t, false, opt)
+
+	c.SetGenesisTime(time.Now().Add(-time.Second * time.Duration(4*params.BeaconConfig().SecondsPerSlot)))
+	opt, err = c.IsOptimistic(ctx)
+	require.NoError(t, err)
 	require.Equal(t, true, opt)
 }
 

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -308,7 +308,13 @@ func (s *Service) initializeHeadFromDB(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "could not get finalized block")
 	}
-	if err := s.setHead(finalizedRoot, finalizedBlock, finalizedState); err != nil {
+	if err := s.setHead(&head{
+		finalizedRoot,
+		finalizedBlock,
+		finalizedState,
+		finalizedBlock.Block().Slot(),
+		false,
+	}); err != nil {
 		return errors.Wrap(err, "could not set head")
 	}
 
@@ -440,7 +446,13 @@ func (s *Service) saveGenesisData(ctx context.Context, genesisState state.Beacon
 	}
 	s.cfg.ForkChoiceStore.SetGenesisTime(uint64(s.genesisTime.Unix()))
 
-	if err := s.setHead(genesisBlkRoot, genesisBlk, genesisState); err != nil {
+	if err := s.setHead(&head{
+		genesisBlkRoot,
+		genesisBlk,
+		genesisState,
+		genesisBlk.Block().Slot(),
+		false,
+	}); err != nil {
 		log.WithError(err).Fatal("Could not set head")
 	}
 	return nil


### PR DESCRIPTION
Track the optimistic status of head block instead of requesting from forkchoice. After two missed slots we revert back to forkchoice. 