### PR TITLE
Deflake `cloners_test.go`

### DIFF
--- a/proto/prysm/v1alpha1/cloners_test.go
+++ b/proto/prysm/v1alpha1/cloners_test.go
@@ -451,14 +451,8 @@ func TestCopyBlindedBeaconBlockBodyCapella(t *testing.T) {
 
 func bytes(length int) []byte {
 	b := make([]byte, length)
-	_, err := rand.Read(b)
-	if err != nil {
-		panic(err)
-	}
 	for i := 0; i < length; i++ {
-		if b[i] == 0x00 {
-			b[i] = uint8(rand.Int())
-		}
+		b[i] = uint8(rand.Int31n(255) + 1)
 	}
 	return b
 }


### PR DESCRIPTION
**What type of PR is this?**

Tests

**What does this PR do? Why is it needed?**

Tests in `cloners_test.go` are flaky because of how the byte slice is populated. We can't have any zeros in the slice because tests use `assert.NotEmpty`, but `uint8(rand.Int())` can still return `0`. To make things simple, the new code loops through the slice and populates each item with a number from 1 to 256.