### PR TITLE
fix: use diff context to update proposer cache background

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -497,7 +497,12 @@ func (s *Service) handleEpochBoundary(ctx context.Context, postState state.Beaco
 			return err
 		}
 		go func() {
-			if err := helpers.UpdateProposerIndicesInCache(ctx, copied, e+1); err != nil {
+			// Use a custom deadline here, since this method runs asynchronously.
+			// We ignore the parent method's context and instead create a new one
+			// with a custom deadline, therefore using the background context instead.
+			slotCtx, cancel := context.WithTimeout(context.Background(), slotDeadline)
+			defer cancel()
+			if err := helpers.UpdateProposerIndicesInCache(slotCtx, copied, e+1); err != nil {
 				log.WithError(err).Warn("Failed to cache next epoch proposers")
 			}
 		}()


### PR DESCRIPTION
In order to optimize the updating of caches in the background, we should use a separate context instead of the main context. When the main context is returned, it triggers cancellation, leading to the termination of the corresponding goroutine. We already do this for the next slot cache and deposit cache.




