### PR TITLE
Deneb: Implement EIP-7044

### DIFF
--- a/beacon-chain/core/blocks/block_operations_fuzz_test.go
+++ b/beacon-chain/core/blocks/block_operations_fuzz_test.go
@@ -413,7 +413,7 @@ func TestFuzzProcessVoluntaryExitsNoVerify_10000(t *testing.T) {
 	}
 }
 
-func TestFuzzVerifyExit_10000(_ *testing.T) {
+func TestFuzzVerifyExit_10000(t *testing.T) {
 	fuzzer := fuzz.NewWithSeed(0)
 	ve := &ethpb.SignedVoluntaryExit{}
 	rawVal := &ethpb.Validator{}
@@ -425,9 +425,18 @@ func TestFuzzVerifyExit_10000(_ *testing.T) {
 		fuzzer.Fuzz(rawVal)
 		fuzzer.Fuzz(fork)
 		fuzzer.Fuzz(&slot)
+
+		state := &ethpb.BeaconState{
+			Slot:                  slot,
+			Fork:                  fork,
+			GenesisValidatorsRoot: params.BeaconConfig().ZeroHash[:],
+		}
+		s, err := state_native.InitializeFromProtoUnsafePhase0(state)
+		require.NoError(t, err)
+
 		val, err := state_native.NewValidator(&ethpb.Validator{})
 		_ = err
-		err = VerifyExitAndSignature(val, slot, fork, ve, params.BeaconConfig().ZeroHash[:])
+		err = VerifyExitAndSignature(val, s, ve)
 		_ = err
 	}
 }

--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/runtime/version"
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
 )
 
@@ -58,7 +59,7 @@ func ProcessVoluntaryExits(
 		if err != nil {
 			return nil, err
 		}
-		if err := VerifyExitAndSignature(val, beaconState.Slot(), beaconState.Fork(), exit, beaconState.GenesisValidatorsRoot()); err != nil {
+		if err := VerifyExitAndSignature(val, beaconState, exit); err != nil {
 			return nil, errors.Wrapf(err, "could not verify exit %d", idx)
 		}
 		beaconState, err = v.InitiateValidatorExit(ctx, beaconState, exit.Exit.ValidatorIndex)
@@ -92,13 +93,25 @@ func ProcessVoluntaryExits(
 //	 initiate_validator_exit(state, voluntary_exit.validator_index)
 func VerifyExitAndSignature(
 	validator state.ReadOnlyValidator,
-	currentSlot primitives.Slot,
-	fork *ethpb.Fork,
+	state state.ReadOnlyBeaconState,
 	signed *ethpb.SignedVoluntaryExit,
-	genesisRoot []byte,
 ) error {
 	if signed == nil || signed.Exit == nil {
 		return errors.New("nil exit")
+	}
+
+	currentSlot := state.Slot()
+	fork := state.Fork()
+	genesisRoot := state.GenesisValidatorsRoot()
+
+	// EIP-7044: Beginning in Deneb, fix the fork version to Capella.
+	// This allows for signed validator exits to be valid forever.
+	if state.Version() >= version.Deneb {
+		fork = &ethpb.Fork{
+			PreviousVersion: params.BeaconConfig().CapellaForkVersion,
+			CurrentVersion:  params.BeaconConfig().CapellaForkVersion,
+			Epoch:           params.BeaconConfig().CapellaForkEpoch,
+		}
 	}
 
 	exit := signed.Exit

--- a/beacon-chain/core/signing/BUILD.bazel
+++ b/beacon-chain/core/signing/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
+        "//runtime/version:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prysmaticlabs_fastssz//:go_default_library",
     ],

--- a/beacon-chain/core/signing/signing_root.go
+++ b/beacon-chain/core/signing/signing_root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/crypto/bls"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/runtime/version"
 )
 
 // ForkVersionByteLength length of fork version byte array.
@@ -56,7 +57,18 @@ const (
 
 // ComputeDomainAndSign computes the domain and signing root and sign it using the passed in private key.
 func ComputeDomainAndSign(st state.ReadOnlyBeaconState, epoch primitives.Epoch, obj fssz.HashRoot, domain [4]byte, key bls.SecretKey) ([]byte, error) {
-	d, err := Domain(st.Fork(), epoch, domain, st.GenesisValidatorsRoot())
+	fork := st.Fork()
+	// EIP-7044: Beginning in Deneb, fix the fork version to Capella for signed exits.
+	// This allows for signed validator exits to be valid forever.
+	if st.Version() >= version.Deneb && domain == params.BeaconConfig().DomainVoluntaryExit {
+		fork = &ethpb.Fork{
+			PreviousVersion: params.BeaconConfig().CapellaForkVersion,
+			CurrentVersion:  params.BeaconConfig().CapellaForkVersion,
+			Epoch:           params.BeaconConfig().CapellaForkEpoch,
+		}
+	}
+
+	d, err := Domain(fork, epoch, domain, st.GenesisValidatorsRoot())
 	if err != nil {
 		return nil, err
 	}

--- a/beacon-chain/operations/voluntaryexits/pool.go
+++ b/beacon-chain/operations/voluntaryexits/pool.go
@@ -90,7 +90,7 @@ func (p *Pool) ExitsForInclusion(state state.ReadOnlyBeaconState, slot types.Slo
 			}
 			continue
 		}
-		if err = blocks.VerifyExitAndSignature(validator, state.Slot(), state.Fork(), exit, state.GenesisValidatorsRoot()); err != nil {
+		if err = blocks.VerifyExitAndSignature(validator, state, exit); err != nil {
 			logrus.WithError(err).Warning("removing invalid exit from pool")
 			p.lock.RUnlock()
 			// MarkIncluded removes the invalid exit from the pool

--- a/beacon-chain/rpc/eth/beacon/pool.go
+++ b/beacon-chain/rpc/eth/beacon/pool.go
@@ -298,7 +298,7 @@ func (bs *Server) SubmitVoluntaryExit(ctx context.Context, req *ethpbv1.SignedVo
 		return nil, status.Errorf(codes.Internal, "Could not get exiting validator: %v", err)
 	}
 	alphaExit := migration.V1ExitToV1Alpha1(req)
-	err = blocks.VerifyExitAndSignature(validator, headState.Slot(), headState.Fork(), alphaExit, headState.GenesisValidatorsRoot())
+	err = blocks.VerifyExitAndSignature(validator, headState, alphaExit)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid voluntary exit: %v", err)
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/exit.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/exit.go
@@ -34,7 +34,7 @@ func (vs *Server) ProposeExit(ctx context.Context, req *ethpb.SignedVoluntaryExi
 		return nil, status.Error(codes.InvalidArgument, "validator index exceeds validator set length")
 	}
 
-	if err := blocks.VerifyExitAndSignature(val, s.Slot(), s.Fork(), req, s.GenesisValidatorsRoot()); err != nil {
+	if err := blocks.VerifyExitAndSignature(val, s, req); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 

--- a/beacon-chain/sync/validate_voluntary_exit.go
+++ b/beacon-chain/sync/validate_voluntary_exit.go
@@ -62,7 +62,7 @@ func (s *Service) validateVoluntaryExit(ctx context.Context, pid peer.ID, msg *p
 	if err != nil {
 		return pubsub.ValidationIgnore, err
 	}
-	if err := blocks.VerifyExitAndSignature(val, headState.Slot(), headState.Fork(), exit, headState.GenesisValidatorsRoot()); err != nil {
+	if err := blocks.VerifyExitAndSignature(val, headState, exit); err != nil {
 		return pubsub.ValidationReject, err
 	}
 

--- a/testing/util/block_test.go
+++ b/testing/util/block_test.go
@@ -370,5 +370,5 @@ func TestGenerateVoluntaryExits(t *testing.T) {
 	require.NoError(t, err)
 	val, err := beaconState.ValidatorAtIndexReadOnly(0)
 	require.NoError(t, err)
-	require.NoError(t, coreBlock.VerifyExitAndSignature(val, 0, beaconState.Fork(), exit, beaconState.GenesisValidatorsRoot()))
+	require.NoError(t, coreBlock.VerifyExitAndSignature(val, beaconState, exit))
 }


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

EIP-7044 essentially freezes the signature domain to the Capella fork data in Deneb. This PR updates the signing domain computation and verification in deneb to fulfill the requirements of the EIP.

**Which issues(s) does this PR fix?**

**Other notes for review**

~This PR is rather small and could possibly be a good candidate for the develop branch. It does not require any Deneb specific structs (except beacon state) and shouldn't effect the critical path as the new logic only runs on a state version of Deneb or greater.~ Nevermind, it depends on deneb beacon state for tests. 
