### PR TITLE
Handle Epoch Boundary Misses

### DIFF
--- a/beacon-chain/state/stategen/epoch_boundary_state_cache.go
+++ b/beacon-chain/state/stategen/epoch_boundary_state_cache.go
@@ -155,6 +155,20 @@ func (e *epochBoundaryState) put(blockRoot [32]byte, s state.BeaconState) error 
 func (e *epochBoundaryState) delete(blockRoot [32]byte) error {
 	e.lock.Lock()
 	defer e.lock.Unlock()
+	rInfo, ok, err := e.getByBlockRootLockFree(blockRoot)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	slotInfo := &slotRootInfo{
+		slot:      rInfo.state.Slot(),
+		blockRoot: blockRoot,
+	}
+	if err = e.slotRootCache.Delete(slotInfo); err != nil {
+		return err
+	}
 	return e.rootStateCache.Delete(&rootStateInfo{
 		root: blockRoot,
 	})

--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -36,12 +36,12 @@ func (_ *State) replayBlocks(
 	var err error
 
 	start := time.Now()
-	log = log.WithFields(logrus.Fields{
+	rLog := log.WithFields(logrus.Fields{
 		"startSlot": state.Slot(),
 		"endSlot":   targetSlot,
 		"diff":      targetSlot - state.Slot(),
 	})
-	log.Debug("Replaying state")
+	rLog.Debug("Replaying state")
 	// The input block list is sorted in decreasing slots order.
 	if len(signed) > 0 {
 		for i := len(signed) - 1; i >= 0; i-- {
@@ -71,7 +71,7 @@ func (_ *State) replayBlocks(
 	}
 
 	duration := time.Since(start)
-	log.WithFields(logrus.Fields{
+	rLog.WithFields(logrus.Fields{
 		"duration": duration,
 	}).Debug("Replayed state")
 

--- a/beacon-chain/state/stategen/setter.go
+++ b/beacon-chain/state/stategen/setter.go
@@ -88,25 +88,20 @@ func (s *State) saveStateByRoot(ctx context.Context, blockRoot [32]byte, st stat
 		if err != nil {
 			return err
 		}
-		rInfo, ok, err := s.epochBoundaryStateCache.getBySlot(epochStart)
-		if err != nil {
-			return err
-		}
 		bRoot, err := helpers.BlockRootAtSlot(st, epochStart)
 		if err != nil {
 			return err
 		}
+		_, ok, err := s.epochBoundaryStateCache.getByBlockRoot([32]byte(bRoot))
+		if err != nil {
+			return err
+		}
 
-		nonCanonicalState := ok && [32]byte(bRoot) != rInfo.root
-
-		// We would only recover the boundary states under 2 conditions:
+		// We would only recover the boundary states under this condition:
 		//
 		// 1) Would indicate that the epoch boundary was skipped due to a missed slot, we
 		// then recover by saving the state at that particular slot here.
-		//
-		// 2) Check that the canonical epoch boundary state has been saved
-		// in our epoch boundary cache.
-		if !ok || nonCanonicalState {
+		if !ok {
 			// Only recover the state if it is in our hot state cache, otherwise we
 			// simply skip this step.
 			if s.hotStateCache.has([32]byte(bRoot)) {
@@ -115,12 +110,6 @@ func (s *State) saveStateByRoot(ctx context.Context, blockRoot [32]byte, st stat
 					"root": fmt.Sprintf("%#x", bRoot),
 				}).Debug("Recovering state for epoch boundary cache")
 
-				// Remove the non-canonical state from our cache.
-				if nonCanonicalState {
-					if err := s.epochBoundaryStateCache.delete(rInfo.root); err != nil {
-						return err
-					}
-				}
 				hState := s.hotStateCache.get([32]byte(bRoot))
 				if err := s.epochBoundaryStateCache.put([32]byte(bRoot), hState); err != nil {
 					return err

--- a/beacon-chain/state/stategen/setter.go
+++ b/beacon-chain/state/stategen/setter.go
@@ -2,8 +2,10 @@ package stategen
 
 import (
 	"context"
+	"fmt"
 	"math"
 
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
@@ -78,6 +80,52 @@ func (s *State) saveStateByRoot(ctx context.Context, blockRoot [32]byte, st stat
 	if slots.IsEpochStart(st.Slot()) {
 		if err := s.epochBoundaryStateCache.put(blockRoot, st); err != nil {
 			return err
+		}
+	} else {
+		// Always check that the correct epoch boundary states have been saved
+		// for the current epoch.
+		epochStart, err := slots.EpochStart(slots.ToEpoch(st.Slot()))
+		if err != nil {
+			return err
+		}
+		rInfo, ok, err := s.epochBoundaryStateCache.getBySlot(epochStart)
+		if err != nil {
+			return err
+		}
+		bRoot, err := helpers.BlockRootAtSlot(st, epochStart)
+		if err != nil {
+			return err
+		}
+
+		nonCanonicalState := ok && [32]byte(bRoot) != rInfo.root
+
+		// We would only recover the boundary states under 2 conditions:
+		//
+		// 1) Would indicate that the epoch boundary was skipped due to a missed slot, we
+		// then recover by saving the state at that particular slot here.
+		//
+		// 2) Check that the canonical epoch boundary state has been saved
+		// in our epoch boundary cache.
+		if !ok || nonCanonicalState {
+			// Only recover the state if it is in our hot state cache, otherwise we
+			// simply skip this step.
+			if s.hotStateCache.has([32]byte(bRoot)) {
+				log.WithFields(logrus.Fields{
+					"slot": epochStart,
+					"root": fmt.Sprintf("%#x", bRoot),
+				}).Debug("Recovering state for epoch boundary cache")
+
+				// Remove the non-canonical state from our cache.
+				if nonCanonicalState {
+					if err := s.epochBoundaryStateCache.delete(rInfo.root); err != nil {
+						return err
+					}
+				}
+				hState := s.hotStateCache.get([32]byte(bRoot))
+				if err := s.epochBoundaryStateCache.put([32]byte(bRoot), hState); err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -166,53 +166,6 @@ func TestSaveState_RecoverForEpochBoundary(t *testing.T) {
 	assert.Equal(t, rInfo.state.Slot(), primitives.Slot(0), "incorrect slot of state")
 }
 
-func TestSaveState_RecoverForEpochBoundary_NonCanonicalBoundaryState(t *testing.T) {
-	ctx := context.Background()
-	beaconDB := testDB.SetupDB(t)
-	service := New(beaconDB, doublylinkedtree.New())
-
-	beaconState, _ := util.DeterministicGenesisState(t, 32)
-	require.NoError(t, beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch-1))
-	r := [32]byte{'A'}
-	boundaryRoot := [32]byte{'B'}
-	require.NoError(t, beaconState.UpdateBlockRootAtIndex(0, boundaryRoot))
-
-	// Epoch boundary state is inserted for slot 0
-	nonCanonicalRoot := [32]byte{'C'}
-	nonCanonicalSt, _ := util.DeterministicGenesisState(t, 32)
-	require.NoError(t, service.epochBoundaryStateCache.put(nonCanonicalRoot, nonCanonicalSt))
-
-	_, ok, err := service.epochBoundaryStateCache.getByBlockRoot(nonCanonicalRoot)
-	assert.NoError(t, err)
-	assert.Equal(t, true, ok, "state does not exist in cache")
-
-	rInfo, ok, err := service.epochBoundaryStateCache.getBySlot(0)
-	require.NoError(t, err)
-	require.Equal(t, true, ok)
-	require.Equal(t, nonCanonicalRoot, rInfo.root)
-
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, beaconDB, b)
-	gRoot, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, gRoot))
-	// Save boundary state to the hot state cache.
-	boundaryState, _ := util.DeterministicGenesisState(t, 32)
-	service.hotStateCache.put(boundaryRoot, boundaryState)
-
-	require.NoError(t, service.SaveState(ctx, r, beaconState))
-
-	rInfo, ok, err = service.epochBoundaryStateCache.getBySlot(0)
-	assert.NoError(t, err)
-	assert.Equal(t, true, ok, "state does not exist in cache")
-	assert.Equal(t, rInfo.root, boundaryRoot, "incorrect root of root state info")
-	assert.Equal(t, rInfo.state.Slot(), primitives.Slot(0), "incorrect slot of state")
-
-	_, ok, err = service.epochBoundaryStateCache.getByBlockRoot(nonCanonicalRoot)
-	assert.NoError(t, err)
-	assert.Equal(t, false, ok, "state exists in cache")
-}
-
 func TestSaveState_CanSaveHotStateToDB(t *testing.T) {
 	hook := logTest.NewGlobal()
 	ctx := context.Background()

--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -7,6 +7,7 @@ import (
 	testDB "github.com/prysmaticlabs/prysm/v4/beacon-chain/db/testing"
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/doubly-linked-tree"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
+	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/testing/assert"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
 	"github.com/prysmaticlabs/prysm/v4/testing/util"
@@ -135,6 +136,81 @@ func TestSaveState_NoSaveNotEpochBoundary(t *testing.T) {
 	require.LogsDoNotContain(t, hook, "Saved full state on epoch boundary")
 	// Should have not been saved in DB.
 	require.Equal(t, false, beaconDB.HasState(ctx, r))
+}
+
+func TestSaveState_RecoverForEpochBoundary(t *testing.T) {
+	ctx := context.Background()
+	beaconDB := testDB.SetupDB(t)
+	service := New(beaconDB, doublylinkedtree.New())
+
+	beaconState, _ := util.DeterministicGenesisState(t, 32)
+	require.NoError(t, beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch-1))
+	r := [32]byte{'A'}
+	boundaryRoot := [32]byte{'B'}
+	require.NoError(t, beaconState.UpdateBlockRootAtIndex(0, boundaryRoot))
+
+	b := util.NewBeaconBlock()
+	util.SaveBlock(t, ctx, beaconDB, b)
+	gRoot, err := b.Block.HashTreeRoot()
+	require.NoError(t, err)
+	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, gRoot))
+	// Save boundary state to the hot state cache.
+	boundaryState, _ := util.DeterministicGenesisState(t, 32)
+	service.hotStateCache.put(boundaryRoot, boundaryState)
+	require.NoError(t, service.SaveState(ctx, r, beaconState))
+
+	rInfo, ok, err := service.epochBoundaryStateCache.getByBlockRoot(boundaryRoot)
+	assert.NoError(t, err)
+	assert.Equal(t, true, ok, "state does not exist in cache")
+	assert.Equal(t, rInfo.root, boundaryRoot, "incorrect root of root state info")
+	assert.Equal(t, rInfo.state.Slot(), primitives.Slot(0), "incorrect slot of state")
+}
+
+func TestSaveState_RecoverForEpochBoundary_NonCanonicalBoundaryState(t *testing.T) {
+	ctx := context.Background()
+	beaconDB := testDB.SetupDB(t)
+	service := New(beaconDB, doublylinkedtree.New())
+
+	beaconState, _ := util.DeterministicGenesisState(t, 32)
+	require.NoError(t, beaconState.SetSlot(params.BeaconConfig().SlotsPerEpoch-1))
+	r := [32]byte{'A'}
+	boundaryRoot := [32]byte{'B'}
+	require.NoError(t, beaconState.UpdateBlockRootAtIndex(0, boundaryRoot))
+
+	// Epoch boundary state is inserted for slot 0
+	nonCanonicalRoot := [32]byte{'C'}
+	nonCanonicalSt, _ := util.DeterministicGenesisState(t, 32)
+	require.NoError(t, service.epochBoundaryStateCache.put(nonCanonicalRoot, nonCanonicalSt))
+
+	_, ok, err = service.epochBoundaryStateCache.getByBlockRoot(nonCanonicalRoot)
+	assert.NoError(t, err)
+	assert.Equal(t, true, ok, "state does not exist in cache")
+
+	rInfo, ok, err := service.epochBoundaryStateCache.getBySlot(0)
+	require.NoError(t, err)
+	require.Equal(t, true, ok)
+	require.Equal(t, nonCanonicalRoot, rInfo.root)
+
+	b := util.NewBeaconBlock()
+	util.SaveBlock(t, ctx, beaconDB, b)
+	gRoot, err := b.Block.HashTreeRoot()
+	require.NoError(t, err)
+	require.NoError(t, beaconDB.SaveGenesisBlockRoot(ctx, gRoot))
+	// Save boundary state to the hot state cache.
+	boundaryState, _ := util.DeterministicGenesisState(t, 32)
+	service.hotStateCache.put(boundaryRoot, boundaryState)
+
+	require.NoError(t, service.SaveState(ctx, r, beaconState))
+
+	rInfo, ok, err = service.epochBoundaryStateCache.getBySlot(0)
+	assert.NoError(t, err)
+	assert.Equal(t, true, ok, "state does not exist in cache")
+	assert.Equal(t, rInfo.root, boundaryRoot, "incorrect root of root state info")
+	assert.Equal(t, rInfo.state.Slot(), primitives.Slot(0), "incorrect slot of state")
+
+	_, ok, err = service.epochBoundaryStateCache.getByBlockRoot(nonCanonicalRoot)
+	assert.NoError(t, err)
+	assert.Equal(t, false, ok, "state exists in cache")
 }
 
 func TestSaveState_CanSaveHotStateToDB(t *testing.T) {

--- a/beacon-chain/state/stategen/setter_test.go
+++ b/beacon-chain/state/stategen/setter_test.go
@@ -182,7 +182,7 @@ func TestSaveState_RecoverForEpochBoundary_NonCanonicalBoundaryState(t *testing.
 	nonCanonicalSt, _ := util.DeterministicGenesisState(t, 32)
 	require.NoError(t, service.epochBoundaryStateCache.put(nonCanonicalRoot, nonCanonicalSt))
 
-	_, ok, err = service.epochBoundaryStateCache.getByBlockRoot(nonCanonicalRoot)
+	_, ok, err := service.epochBoundaryStateCache.getByBlockRoot(nonCanonicalRoot)
 	assert.NoError(t, err)
 	assert.Equal(t, true, ok, "state does not exist in cache")
 


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In certain situations in the network, we can miss saving the epoch boundary state into our boundary cache. This can cause issues in future epochs, as if we need to fetch the justified/finalized state we end up having to regenerating it from scratch. Instead of doing that, we have now decided to add an optimization to always save epoch boundary states into our cache. 

We also handle the edge case where the incorrect epoch boundary state is saved into our cache in the event of shallow re-orgs(1 slot) at the start of an epoch. Both these cases have test cases added in along with bug fixes in the deletion of values for the boundary cache.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
