### PR TITLE
Fix: Size of SyncCommitteeBits should be 64 bytes (512 bits) instead of 512 bytes

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair.go
@@ -25,7 +25,7 @@ func (vs *Server) setSyncAggregate(ctx context.Context, blk interfaces.SignedBea
 		log.WithError(err).Error("Could not get sync aggregate")
 		emptySig := [96]byte{0xC0}
 		emptyAggregate := &ethpb.SyncAggregate{
-			SyncCommitteeBits:      make([]byte, params.BeaconConfig().SyncCommitteeSize),
+			SyncCommitteeBits:      make([]byte, params.BeaconConfig().SyncCommitteeSize/8),
 			SyncCommitteeSignature: emptySig[:],
 		}
 		if err := blk.SetSyncAggregate(emptyAggregate); err != nil {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_altair_test.go
@@ -21,7 +21,7 @@ func TestServer_SetSyncAggregate_EmptyCase(t *testing.T) {
 
 	emptySig := [96]byte{0xC0}
 	want := &ethpb.SyncAggregate{
-		SyncCommitteeBits:      make([]byte, params.BeaconConfig().SyncCommitteeSize),
+		SyncCommitteeBits:      make([]byte, params.BeaconConfig().SyncCommitteeSize/8),
 		SyncCommitteeSignature: emptySig[:],
 	}
 	require.DeepEqual(t, want, agg)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

In case getSyncAggregate throws error and emptyAggregate variable of type SyncAggregate is generated, where SyncCommitteeBits expected to be 512 bits which is 64 bytes. However, in the existing code it is intialised by 512 bytes which makes it 4096 bits. 