### PR TITLE
fix: don't set a block to invalid if its not in forkchoice

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -230,8 +230,8 @@ func (s *Service) notifyNewPayload(ctx context.Context, postStateVersion int,
 	}
 }
 
-// reportInvalidBlock deals with the event that an invalid block was detected by the execution layer
-func (s *Service) reportInvalidBlock(ctx context.Context, root, parentRoot, lvh [32]byte) error {
+// pruneInvalidBlock prunes invalid block and its ancestors from the forkchoice store and DB.
+func (s *Service) pruneInvalidBlock(ctx context.Context, root, parentRoot, lvh [32]byte) error {
 	newPayloadInvalidNodeCount.Inc()
 	invalidRoots, err := s.cfg.ForkChoiceStore.SetOptimisticToInvalid(ctx, root, parentRoot, lvh)
 	if err != nil {

--- a/beacon-chain/blockchain/execution_engine_test.go
+++ b/beacon-chain/blockchain/execution_engine_test.go
@@ -764,7 +764,7 @@ func Test_reportInvalidBlock(t *testing.T) {
 	require.NoError(t, fcs.InsertNode(ctx, st, root))
 
 	require.NoError(t, fcs.SetOptimisticToValid(ctx, [32]byte{'A'}))
-	err = service.reportInvalidBlock(ctx, [32]byte{'D'}, [32]byte{'C'}, [32]byte{'a'})
+	err = service.pruneInvalidBlock(ctx, [32]byte{'D'}, [32]byte{'C'}, [32]byte{'a'})
 	require.Equal(t, IsInvalidBlock(err), true)
 	require.Equal(t, InvalidBlockLVH(err), [32]byte{'a'})
 	invalidRoots := InvalidAncestorRoots(err)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -135,8 +135,8 @@ func (s *Service) onBlock(ctx context.Context, signed interfaces.ReadOnlySignedB
 	}
 	isValidPayload, err := s.notifyNewPayload(ctx, postStateVersion, postStateHeader, signed)
 	if err != nil {
-		if IsInvalidBlock(err) && InvalidBlockLVH(err) != [32]byte{} {
-			return s.reportInvalidBlock(ctx, blockRoot, parentRoot, InvalidBlockLVH(err))
+		if s.cfg.ForkChoiceStore.HasNode(blockRoot) && IsInvalidBlock(err) && InvalidBlockLVH(err) != [32]byte{} {
+			return s.pruneInvalidBlock(ctx, blockRoot, parentRoot, InvalidBlockLVH(err))
 		}
 		return errors.Wrap(err, "could not validate new payload")
 	}


### PR DESCRIPTION
If we receive a new block and the block fails at `NewPayload`, the block has not been inserted into the forkchoice store, so there's enough to prune, in this case, we shouldn't prune and instead return the original error which messes with the intent of the original error
I think `pruneInvalidBlock` is more or less intended for `ForkchoiceUpdate` rather than `NewPayload`
Another option is to remove `pruneInvalidBlock` usage for `NewPayload` rather than the condition  