### PR TITLE
Clarify sync committee message validation

### DIFF
--- a/beacon-chain/core/altair/sync_committee.go
+++ b/beacon-chain/core/altair/sync_committee.go
@@ -195,6 +195,7 @@ func IsSyncCommitteeAggregator(sig []byte) (bool, error) {
 }
 
 // ValidateSyncMessageTime validates sync message to ensure that the provided slot is valid.
+// Spec: [IGNORE] The message's slot is for the current slot (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance), i.e. sync_committee_message.slot == current_slot
 func ValidateSyncMessageTime(slot primitives.Slot, genesisTime time.Time, clockDisparity time.Duration) error {
 	if err := slots.ValidateClock(slot, uint64(genesisTime.Unix())); err != nil {
 		return err
@@ -223,13 +224,12 @@ func ValidateSyncMessageTime(slot primitives.Slot, genesisTime time.Time, clockD
 	// Verify sync message slot is within the time range.
 	if messageTime.Before(lowerBound) || messageTime.After(upperBound) {
 		syncErr := fmt.Errorf(
-			"sync message time %v (slot %d) not within allowable range of %v (slot %d) to %v (slot %d)",
+			"sync message time %v (message slot %d) not within allowable range of %v to %v (current slot %d)",
 			messageTime,
 			slot,
 			lowerBound,
-			uint64(lowerBound.Unix()-genesisTime.Unix())/params.BeaconConfig().SecondsPerSlot,
 			upperBound,
-			uint64(upperBound.Unix()-genesisTime.Unix())/params.BeaconConfig().SecondsPerSlot,
+			currentSlot,
 		)
 		// Wrap error message if sync message is too late.
 		if messageTime.Before(lowerBound) {

--- a/beacon-chain/core/altair/sync_committee_test.go
+++ b/beacon-chain/core/altair/sync_committee_test.go
@@ -311,7 +311,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 				syncMessageSlot: 16,
 				genesisTime:     prysmTime.Now().Add(-(15 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second)),
 			},
-			wantedErr: "(slot 16) not within allowable range of",
+			wantedErr: "(message slot 16) not within allowable range of",
 		},
 		{
 			name: "sync_message.slot == current_slot+CLOCK_DISPARITY",
@@ -327,7 +327,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 				syncMessageSlot: 100,
 				genesisTime:     prysmTime.Now().Add(-(100 * time.Duration(params.BeaconConfig().SecondsPerSlot) * time.Second) + params.BeaconNetworkConfig().MaximumGossipClockDisparity + 1000*time.Millisecond),
 			},
-			wantedErr: "(slot 100) not within allowable range of",
+			wantedErr: "(message slot 100) not within allowable range of",
 		},
 		{
 			name: "sync_message.slot == current_slot-CLOCK_DISPARITY",
@@ -343,7 +343,7 @@ func Test_ValidateSyncMessageTime(t *testing.T) {
 				syncMessageSlot: 101,
 				genesisTime:     prysmTime.Now().Add(-(100*time.Duration(params.BeaconConfig().SecondsPerSlot)*time.Second + params.BeaconNetworkConfig().MaximumGossipClockDisparity)),
 			},
-			wantedErr: "(slot 101) not within allowable range of",
+			wantedErr: "(message slot 101) not within allowable range of",
 		},
 		{
 			name: "sync_message.slot is well beyond current slot",


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

When reviewing some logs, I found this error message to be somewhat confusing when the range overlaps with multiple slots due to the message disparity allowance. 

I've added the spec validation requirements to the godoc for `ValidateSyncMessageTime` and amended the error message to print the current slot rather than the computed slots based on the time disparity allowance.

**Which issues(s) does this PR fix?**

**Other notes for review**

Cosemetic only -- no logic changes.
