### PR TITLE
feat: add metric for `ReceiveBlock`

### DIFF
--- a/beacon-chain/blockchain/metrics.go
+++ b/beacon-chain/blockchain/metrics.go
@@ -172,11 +172,15 @@ var (
 	})
 	onBlockProcessingTime = promauto.NewSummary(prometheus.SummaryOpts{
 		Name: "on_block_processing_milliseconds",
-		Help: "Total time in milliseconds to complete a call to onBlock()",
+		Help: "Total time in milliseconds to complete a call to postBlockProcess()",
 	})
 	stateTransitionProcessingTime = promauto.NewSummary(prometheus.SummaryOpts{
 		Name: "state_transition_processing_milliseconds",
-		Help: "Total time to call a state transition in onBlock()",
+		Help: "Total time to call a state transition in validateStateTransition()",
+	})
+	chainServiceProcessingTime = promauto.NewSummary(prometheus.SummaryOpts{
+		Name: "chain_service_processing_milliseconds",
+		Help: "Total time to call a chain service in ReceiveBlock()",
 	})
 	processAttsElapsedTime = promauto.NewHistogram(
 		prometheus.HistogramOpts{

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -140,6 +140,8 @@ func (s *Service) ReceiveBlock(ctx context.Context, block interfaces.ReadOnlySig
 		log.WithError(err).Error("Unable to log state transition data")
 	}
 
+	chainServiceProcessingTime.Observe(float64(time.Since(receivedTime).Milliseconds()))
+
 	return nil
 }
 


### PR DESCRIPTION
Add metric for chain service process block (ie. `ReceiveBlock`) This is a valuable metric to track, before we were using `onBlock`, but since the refactor, `onBlock` becomes `postBlockProcessing` and no longer conveys the whole end to end. `chainServiceProcessed` time is displayed on log only