### PR TITLE
Fix Context Cancellation

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -101,8 +101,10 @@ func (s *Service) ReceiveBlock(ctx context.Context, block interfaces.ReadOnlySig
 		finalized := s.cfg.ForkChoiceStore.FinalizedCheckpoint()
 		go s.sendNewFinalizedEvent(ctx, blockCopy, postState, finalized)
 		depCtx, cancel := context.WithTimeout(context.Background(), depositDeadline)
-		defer cancel()
-		go s.insertFinalizedDeposits(depCtx, finalized.Root)
+		go func() {
+			s.insertFinalizedDeposits(depCtx, finalized.Root)
+			cancel()
+		}()
 	}
 
 	// If slasher is configured, forward the attestations in the block via an event feed for processing.


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In #12589 , we moved the finalization of deposits into its own method and modified its control flow. However we incorrectly cancelled the context when `onBlock` finishes executing, when we should only be cancelling the context once the execution of  
`insertFinalizedDeposits` finishes. This PR fixes it.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
