### PR TITLE
Copy Bytes Alternatively

### DIFF
--- a/encoding/bytesutil/bytes.go
+++ b/encoding/bytesutil/bytes.go
@@ -71,6 +71,10 @@ func SafeCopyRootAtIndex(input [][]byte, idx uint64) ([]byte, error) {
 // SafeCopyBytes will copy and return a non-nil byte slice, otherwise it returns nil.
 func SafeCopyBytes(cp []byte) []byte {
 	if cp != nil {
+		if len(cp) == 32 {
+			copied := [32]byte(cp)
+			return copied[:]
+		}
 		copied := make([]byte, len(cp))
 		copy(copied, cp)
 		return copied

--- a/encoding/bytesutil/bytes_test.go
+++ b/encoding/bytesutil/bytes_test.go
@@ -2,6 +2,7 @@ package bytesutil_test
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -247,4 +248,34 @@ func TestFromBytes48Array(t *testing.T) {
 		a := bytesutil.FromBytes48Array(tt.b)
 		assert.DeepEqual(t, tt.a, a)
 	}
+}
+
+func TestSafeCopyBytes_Copy(t *testing.T) {
+	slice := make([]byte, 32)
+	slice[0] = 'A'
+
+	copiedSlice := bytesutil.SafeCopyBytes(slice)
+
+	assert.NotEqual(t, fmt.Sprintf("%p", slice), fmt.Sprintf("%p", copiedSlice))
+	assert.Equal(t, slice[0], copiedSlice[0])
+	slice[1] = 'A'
+
+	assert.NotEqual(t, slice[1], copiedSlice[1])
+}
+
+func BenchmarkSafeCopyBytes(b *testing.B) {
+	dSlice := make([][]byte, 900000)
+	for i := 0; i < 900000; i++ {
+		slice := make([]byte, 32)
+		slice[0] = 'A'
+		dSlice[i] = slice
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.Run("Copy Bytes", func(b *testing.B) {
+		cSlice := bytesutil.SafeCopy2dBytes(dSlice)
+		a := cSlice
+		_ = a
+	})
 }

--- a/encoding/bytesutil/bytes_test.go
+++ b/encoding/bytesutil/bytes_test.go
@@ -258,7 +258,7 @@ func TestSafeCopyBytes_Copy(t *testing.T) {
 
 	assert.NotEqual(t, fmt.Sprintf("%p", slice), fmt.Sprintf("%p", copiedSlice))
 	assert.Equal(t, slice[0], copiedSlice[0])
-	slice[1] = 'A'
+	slice[1] = 'B'
 
 	assert.NotEqual(t, slice[1], copiedSlice[1])
 }


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

We allow the option of casting a slice to a 32-byte array to directly copy it. This is so as to allow calls to `runtime.mallocgc` and `runtime.memove` to be replaced with a single call to `runtime.NewObject` . This particular function is executed for a large amount of times in a critical block proposal path path. 

**Which issues(s) does this PR fix?**

Helps with #12434 

**Other notes for review**
