### PR TITLE
fix: add blob flags to main

### DIFF
--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -164,7 +164,7 @@ var (
 		Usage: "The factor by which block batch limit may increase on burst.",
 		Value: 2,
 	}
-	// BlockBatchLimit specifies the requested block batch size.
+	// BlobBatchLimit specifies the requested blob batch size.
 	BlobBatchLimit = &cli.IntFlag{
 		Name:  "blob-batch-limit",
 		Usage: "The amount of blobs the local peer is bounded to request and respond to in a batch.",

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -53,6 +53,8 @@ var appFlags = []cli.Flag{
 	flags.SetGCPercent,
 	flags.BlockBatchLimit,
 	flags.BlockBatchLimitBurstFactor,
+	flags.BlobBatchLimit,
+	flags.BlobBatchLimitBurstFactor,
 	flags.InteropMockEth1DataVotesFlag,
 	flags.InteropNumValidatorsFlag,
 	flags.InteropGenesisTimeFlag,

--- a/cmd/beacon-chain/usage.go
+++ b/cmd/beacon-chain/usage.go
@@ -112,6 +112,8 @@ var appHelpFlagGroups = []flagGroup{
 			flags.SlotsPerArchivedPoint,
 			flags.BlockBatchLimit,
 			flags.BlockBatchLimitBurstFactor,
+			flags.BlobBatchLimit,
+			flags.BlobBatchLimitBurstFactor,
 			flags.EnableDebugRPCEndpoints,
 			flags.SubscribeToAllSubnets,
 			flags.HistoricalSlasherNode,


### PR DESCRIPTION
Add blob-related flags to `main` and `usage` so they get initialized correctly. This fixes the panic/division 0 we see on devnet7
```
time="2023-07-11 15:53:24" level=error msg="Panic occurred" error="runtime error: integer divide by zero" prefix=sync recovered_at=registerRPC stack="goroutine 1512899 [running]:
```