### PR TITLE
Update go version to 1.20.6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -174,7 +174,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.20.3",
+    go_version = "1.20.6",
     nogo = "@//:nogo",
 )
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

As title describes.

**Which issues(s) does this PR fix?**

Mostly security issues that are not immediate concerns to Prysm.

**Other notes for review**

https://go.dev/doc/devel/release#go1.20.6

```
go1.20.4 (released 2023-05-02) includes three security fixes to the html/template package, as well as bug fixes to the compiler, the runtime, and the crypto/subtle, crypto/tls, net/http, and syscall packages. See the Go 1.20.4 milestone on our issue tracker for details.

go1.20.5 (released 2023-06-06) includes four security fixes to the cmd/go and runtime packages, as well as bug fixes to the compiler, the go command, the runtime, and the crypto/rsa, net, and os packages. See the Go 1.20.5 milestone on our issue tracker for details.

go1.20.6 (released 2023-07-11) includes a security fix to the net/http package, as well as bug fixes to the compiler, cgo, the cover tool, the go command, the runtime, and the crypto/ecdsa, go/build, go/printer, net/mail, and text/template packages. See the Go 1.20.6 milestone on our issue tracker for details.
```


