### PR TITLE
fix: use hexutil bytes for blobs bundle

### DIFF
--- a/beacon-chain/execution/engine_client_test.go
+++ b/beacon-chain/execution/engine_client_test.go
@@ -1479,9 +1479,9 @@ func fixtures() map[string]interface{} {
 		},
 		BlockValue: "0x11fffffffff",
 		BlobsBundle: &pb.BlobBundleJSON{
-			Commitments: [][48]byte{bytesutil.ToBytes48([]byte("commitment1")), bytesutil.ToBytes48([]byte("commitment2"))},
-			Proofs:      [][48]byte{bytesutil.ToBytes48([]byte("proof1")), bytesutil.ToBytes48([]byte("proof2"))},
-			Blobs:       [][]byte{{'a'}, {'b'}},
+			Commitments: []hexutil.Bytes{[]byte("commitment1"), []byte("commitment2")},
+			Proofs:      []hexutil.Bytes{[]byte("proof1"), []byte("proof2")},
+			Blobs:       []hexutil.Bytes{{'a'}, {'b'}},
 		},
 	}
 	parent := bytesutil.PadTo([]byte("parentHash"), fieldparams.RootLength)

--- a/encoding/bytesutil/BUILD.bazel
+++ b/encoding/bytesutil/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//config/fieldparams:go_default_library",
         "//consensus-types/primitives:go_default_library",
+        "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
     ],
 )
@@ -35,5 +36,6 @@ go_test(
         "//config/fieldparams:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
+        "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
     ],
 )

--- a/encoding/bytesutil/bytes.go
+++ b/encoding/bytesutil/bytes.go
@@ -3,6 +3,8 @@ package bytesutil
 
 import (
 	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 // ToBytes48Array is a convenience method for converting an array of
@@ -95,6 +97,18 @@ func SafeCopy2d32Bytes(ary [][32]byte) [][32]byte {
 	if ary != nil {
 		copied := make([][32]byte, len(ary))
 		copy(copied, ary)
+		return copied
+	}
+	return nil
+}
+
+// SafeCopy2dHexUtilBytes will copy and return a non-nil 2d hex util byte slice, otherwise it returns nil.
+func SafeCopy2dHexUtilBytes(ary []hexutil.Bytes) [][]byte {
+	if ary != nil {
+		copied := make([][]byte, len(ary))
+		for i, a := range ary {
+			copied[i] = SafeCopyBytes(a)
+		}
 		return copied
 	}
 	return nil

--- a/encoding/bytesutil/bytes_test.go
+++ b/encoding/bytesutil/bytes_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v4/testing/assert"
 )
@@ -159,6 +160,14 @@ func TestSafeCopy2d32Bytes(t *testing.T) {
 	output := bytesutil.SafeCopy2d32Bytes(input)
 	assert.Equal(t, false, &input == &output, "No copy was made")
 	assert.DeepEqual(t, input, output)
+}
+
+func TestSafeCopy2dHexUtilBytes(t *testing.T) {
+	input := make([]hexutil.Bytes, 2)
+	input[0] = hexutil.Bytes{'a'}
+	input[1] = hexutil.Bytes{'b'}
+	output := bytesutil.SafeCopy2dHexUtilBytes(input)
+	assert.DeepEqual(t, output, [][]byte{{'a'}, {'b'}})
 }
 
 func TestToBytes48Array(t *testing.T) {

--- a/proto/engine/v1/json_marshal_unmarshal.go
+++ b/proto/engine/v1/json_marshal_unmarshal.go
@@ -713,16 +713,16 @@ func (f *ForkchoiceState) UnmarshalJSON(enc []byte) error {
 }
 
 type BlobBundleJSON struct {
-	Commitments [][48]byte `json:"commitments"`
-	Proofs      [][48]byte `json:"proofs"`
-	Blobs       [][]byte   `json:"blobs"`
+	Commitments []hexutil.Bytes `json:"commitments"`
+	Proofs      []hexutil.Bytes `json:"proofs"`
+	Blobs       []hexutil.Bytes `json:"blobs"`
 }
 
 func (b BlobBundleJSON) ToProto() *BlobsBundle {
 	return &BlobsBundle{
-		KzgCommitments: bytesutil.SafeCopy2dBytes(bytesutil.FromBytes48Array(b.Commitments)),
-		Proofs:         bytesutil.SafeCopy2dBytes(bytesutil.FromBytes48Array(b.Proofs)),
-		Blobs:          bytesutil.SafeCopy2dBytes(b.Blobs),
+		KzgCommitments: bytesutil.SafeCopy2dHexUtilBytes(b.Commitments),
+		Proofs:         bytesutil.SafeCopy2dHexUtilBytes(b.Proofs),
+		Blobs:          bytesutil.SafeCopy2dHexUtilBytes(b.Blobs),
 	}
 }
 

--- a/proto/engine/v1/json_marshal_unmarshal_test.go
+++ b/proto/engine/v1/json_marshal_unmarshal_test.go
@@ -223,9 +223,9 @@ func TestJsonMarshalUnmarshal(t *testing.T) {
 
 		resp := &enginev1.GetPayloadV3ResponseJson{
 			BlobsBundle: &enginev1.BlobBundleJSON{
-				Commitments: [][48]byte{{'a'}, {'b'}, {'c'}, {'d'}},
-				Proofs:      [][48]byte{{'e'}, {'f'}, {'g'}, {'h'}},
-				Blobs:       [][]byte{{'i'}, {'j'}, {'k'}, {'l'}},
+				Commitments: []hexutil.Bytes{{'a'}, {'b'}, {'c'}, {'d'}},
+				Proofs:      []hexutil.Bytes{{'e'}, {'f'}, {'g'}, {'h'}},
+				Blobs:       []hexutil.Bytes{{'i'}, {'j'}, {'k'}, {'l'}},
 			},
 			BlockValue: fmt.Sprint("0x123"),
 			ExecutionPayload: &enginev1.ExecutionPayloadDenebJSON{


### PR DESCRIPTION
blobs bundle should use [hexutil.Bytes](https://github.com/MariusVanDerWijden/go-ethereum/blob/4844-devnet-6/beacon/engine/types.go#L91). h/t to @prestonvanloon 


