### PR TITLE
fix: benchmark deserialize without clone and init trie

### DIFF
--- a/tools/pcli/main.go
+++ b/tools/pcli/main.go
@@ -274,7 +274,7 @@ func benchmarkHash(sszPath string, sszType string) {
 			log.Fatal(err)
 		}
 		startDeserialize := time.Now()
-		st, err := state_native.InitializeFromProtoCapella(data)
+		st, err := state_native.InitializeFromProtoUnsafeCapella(data)
 		if err != nil {
 			log.Fatal("not a state")
 		}

--- a/tools/pcli/main.go
+++ b/tools/pcli/main.go
@@ -269,18 +269,20 @@ func prettyPrint(sszPath string, data fssz.Unmarshaler) {
 func benchmarkHash(sszPath string, sszType string) {
 	switch sszType {
 	case "state_capella":
-		data := &ethpb.BeaconStateCapella{}
-		if err := dataFetcher(sszPath, data); err != nil {
+		st := &ethpb.BeaconStateCapella{}
+		rawFile, err := os.ReadFile(sszPath) // #nosec G304
+		if err != nil {
 			log.Fatal(err)
 		}
+
 		startDeserialize := time.Now()
-		st, err := state_native.InitializeFromProtoUnsafeCapella(data)
-		if err != nil {
-			log.Fatal("not a state")
+		if err := st.UnmarshalSSZ(rawFile); err != nil {
+			log.Fatal(err)
 		}
 		deserializeDuration := time.Since(startDeserialize)
+
 		start := time.Now()
-		root, err := st.HashTreeRoot(context.Background())
+		root, err := st.HashTreeRoot()
 		if err != nil {
 			log.Fatal("couldn't hash")
 		}


### PR DESCRIPTION
When we benchmark deserialize for pcli, we use `InitializeFromProtoCapella`, which internally calls `proto.Clone`. This does a copy of a protobuf beacon state which calls proto reflect library. That could be slow. This PR changes it to using `InitializeFromProtoUnsafeCapella` which doesn't call `proto.Clone`