### PR TITLE
Update hermetic_cc_toolchain

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,14 +16,12 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 rules_pkg_dependencies()
 
-HERMETIC_CC_TOOLCHAIN_VERSION = "v2.0.0"
-
 http_archive(
     name = "hermetic_cc_toolchain",
-    sha256 = "57f03a6c29793e8add7bd64186fc8066d23b5ffd06fe9cc6b0b8c499914d3a65",
+    sha256 = "973ab22945b921ef45b8e1d6ce01ca7ce1b8a462167449a36e297438c4ec2755",
+    strip_prefix = "hermetic_cc_toolchain-5098046bccc15d2962f3cc8e7e53d6a2a26072dc",
     urls = [
-        "https://mirror.bazel.build/github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
-        "https://github.com/uber/hermetic_cc_toolchain/releases/download/{0}/hermetic_cc_toolchain-{0}.tar.gz".format(HERMETIC_CC_TOOLCHAIN_VERSION),
+        "https://github.com/uber/hermetic_cc_toolchain/archive/5098046bccc15d2962f3cc8e7e53d6a2a26072dc.tar.gz",  # 2023-06-28
     ],
 )
 


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

In our CI builds, we were seeing non-hermetic builds. This may be resolved by https://github.com/uber/hermetic_cc_toolchain/pull/90. This PR updates hermetic_cc_toolchain to the latest commit in the main branch as that PR is not included in any release yet.

**Which issues(s) does this PR fix?**

Fixes cache misses.

**Other notes for review**
