### PR TITLE
Return historical roots in Capella state

### DIFF
--- a/proto/migration/v1alpha1_to_v2.go
+++ b/proto/migration/v1alpha1_to_v2.go
@@ -851,6 +851,10 @@ func BeaconStateCapellaToProto(st state.BeaconState) (*ethpbv2.BeaconStateCapell
 			StateSummaryRoot: summary.StateSummaryRoot,
 		}
 	}
+	hRoots, err := st.HistoricalRoots()
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get historical roots")
+	}
 
 	result := &ethpbv2.BeaconStateCapella{
 		GenesisTime:           st.GenesisTime(),
@@ -925,6 +929,7 @@ func BeaconStateCapellaToProto(st state.BeaconState) (*ethpbv2.BeaconStateCapell
 		NextWithdrawalIndex:          sourceNextWithdrawalIndex,
 		NextWithdrawalValidatorIndex: sourceNextWithdrawalValIndex,
 		HistoricalSummaries:          sourceHistoricalSummaries,
+		HistoricalRoots:              hRoots,
 	}
 
 	return result, nil

--- a/proto/migration/v1alpha1_to_v2_test.go
+++ b/proto/migration/v1alpha1_to_v2_test.go
@@ -727,6 +727,8 @@ func TestBeaconStateCapellaToProto(t *testing.T) {
 	assert.DeepEqual(t, bytesutil.PadTo([]byte("blockroots"), 32), result.BlockRoots[0])
 	assert.Equal(t, 8192, len(result.StateRoots))
 	assert.DeepEqual(t, bytesutil.PadTo([]byte("stateroots"), 32), result.StateRoots[0])
+	assert.Equal(t, 1, len(result.HistoricalRoots))
+	assert.DeepEqual(t, bytesutil.PadTo([]byte("historicalroots"), 32), result.HistoricalRoots[0])
 	resultEth1Data := result.Eth1Data
 	require.NotNil(t, resultEth1Data)
 	assert.DeepEqual(t, bytesutil.PadTo([]byte("e1ddepositroot"), 32), resultEth1Data.DepositRoot)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Capella state returned from [/eth/v2/debug/beacon/states/{state_id}](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Debug/getStateV2) was missing historical roots.

**Which issues(s) does this PR fix?**

Fixes #12618
