### PR TITLE
Integrate Read-Only-Lock-on-Get LRU Cache for Public Keys

### DIFF
--- a/crypto/bls/blst/BUILD.bazel
+++ b/crypto/bls/blst/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v4/crypto/bls/blst",
     visibility = ["//visibility:public"],
     deps = [
-        "//cache/lru:go_default_library",
+        "//cache/nonblocking:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
         "//crypto/bls/common:go_default_library",

--- a/crypto/bls/blst/init.go
+++ b/crypto/bls/blst/init.go
@@ -3,8 +3,11 @@
 package blst
 
 import (
+	"fmt"
 	"runtime"
 
+	"github.com/prysmaticlabs/prysm/v4/cache/nonblocking"
+	"github.com/prysmaticlabs/prysm/v4/crypto/bls/common"
 	blst "github.com/supranational/blst/bindings/go"
 )
 
@@ -15,4 +18,10 @@ func init() {
 		maxProcs = 1
 	}
 	blst.SetMaxProcs(maxProcs)
+	onEvict := func(_ [48]byte, _ common.PublicKey) {}
+	keysCache, err := nonblocking.NewLRU(maxKeys, onEvict)
+	if err != nil {
+		panic(fmt.Sprintf("Could not initiate public keys cache: %v", err))
+	}
+	pubkeyCache = keysCache
 }

--- a/crypto/bls/blst/public_key.go
+++ b/crypto/bls/blst/public_key.go
@@ -6,14 +6,14 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	lruwrpr "github.com/prysmaticlabs/prysm/v4/cache/lru"
+	"github.com/prysmaticlabs/prysm/v4/cache/nonblocking"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/crypto/bls/common"
 )
 
 var maxKeys = 1_000_000
-var pubkeyCache = lruwrpr.New(maxKeys)
+var pubkeyCache *nonblocking.LRU[[48]byte, common.PublicKey]
 
 // PublicKey used in the BLS signature scheme.
 type PublicKey struct {
@@ -27,7 +27,7 @@ func PublicKeyFromBytes(pubKey []byte) (common.PublicKey, error) {
 	}
 	newKey := (*[fieldparams.BLSPubkeyLength]byte)(pubKey)
 	if cv, ok := pubkeyCache.Get(*newKey); ok {
-		return cv.(*PublicKey).Copy(), nil
+		return cv.Copy(), nil
 	}
 	// Subgroup check NOT done when decompressing pubkey.
 	p := new(blstPublicKey).Uncompress(pubKey)


### PR DESCRIPTION
**What type of PR is this?**

> Other

**What does this PR do? Why is it needed?**

This replaces our public keys cache used in our crypto/blst/ package #12476 to a slightly modified one that is thread-safe across concurrent readers that only acquire a read-lock instead of a read-write-lock. This is a considerable improvement, as concurrent readers have to all wait for a lock to `Get()` a public key, and is noticeable during the pipelines of multiple signature verification. This is far worse when running with a lot of subnets, for example, and shows up in pprof for a beacon node on mainnet.

The LRU cache introduced is the same as before, except it has a few core modifications in that it uses a mutex.RLock for Get() calls instead of a mutex.Lock and adds greater thread-safety and nil checks. Aside from that, it still the same LRU being used as before.

**Other notes for review*

With the cache: paths related to public key fetching from the cache are not as visible
<img width="1662" alt="Screen Shot 2023-07-21 at 11 21 41" src="https://github.com/prysmaticlabs/prysm/assets/5572669/8417a9ee-7874-4c80-935d-d29a42c176cb">

Without the cache: the multiple aggregate verify pipeline shows up a lot in the profile as it needs public keys from the cache
<img width="1621" alt="Screen Shot 2023-07-21 at 11 29 56" src="https://github.com/prysmaticlabs/prysm/assets/5572669/ec895db4-7c78-4936-ba2f-a92eff03e15e">
