### PR TITLE
Clean Up Logging

### DIFF
--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -86,6 +86,11 @@ func (s *Service) spawnProcessAttestationsRoutine() {
 			}
 			log.Warn("Genesis time received, now available to process attestations")
 		}
+		// Wait for node to be synced before running the routine.
+		if err := s.waitForSync(); err != nil {
+			log.WithError(err).Error("Could not wait to sync")
+			return
+		}
 
 		st := slots.NewSlotTicker(s.genesisTime, params.BeaconConfig().SecondsPerSlot)
 		pat := slots.NewSlotTickerWithOffset(s.genesisTime, -reorgLateBlockCountAttestations, params.BeaconConfig().SecondsPerSlot)

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -75,7 +75,7 @@ func (s *Service) beaconBlocksByRangeRPCHandler(ctx context.Context, msg interfa
 		rpcBlocksByRangeResponseLatency.Observe(float64(time.Since(batchStart).Milliseconds()))
 	}
 	if err := batch.error(); err != nil {
-		log.WithError(err).Info("error in BlocksByRange batch")
+		log.WithError(err).Debug("error in BlocksByRange batch")
 		s.writeErrorResponseToStream(responseCodeServerError, p2ptypes.ErrGeneric.Error(), stream)
 		tracing.AnnotateError(span, err)
 		return err


### PR DESCRIPTION
**What type of PR is this?**

Clean up

**What does this PR do? Why is it needed?**

This cleans up some cosmetic logs so that users are not alarmed by the errors that are logged out. We wait till the node
is synced before running the `spawnAttestationsRoutine` . 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
