### PR TITLE
fix: add mainnet withdrawals and bls spec tests

### DIFF
--- a/testing/spectest/mainnet/capella/operations/BUILD.bazel
+++ b/testing/spectest/mainnet/capella/operations/BUILD.bazel
@@ -7,10 +7,12 @@ go_test(
         "attestation_test.go",
         "attester_slashing_test.go",
         "block_header_test.go",
+        "bls_to_execution_change_test.go",
         "deposit_test.go",
         "proposer_slashing_test.go",
         "sync_committee_test.go",
         "voluntary_exit_test.go",
+        "withdrawals_test.go",
     ],
     data = [
         "@consensus_spec_tests_mainnet//:test_data",

--- a/testing/spectest/mainnet/capella/operations/bls_to_execution_change_test.go
+++ b/testing/spectest/mainnet/capella/operations/bls_to_execution_change_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v4/testing/spectest/shared/capella/operations"
+)
+
+func TestMainnet_Capella_Operations_BLSToExecutionChange(t *testing.T) {
+	operations.RunBLSToExecutionChangeTest(t, "mainnet")
+}

--- a/testing/spectest/mainnet/capella/operations/withdrawals_test.go
+++ b/testing/spectest/mainnet/capella/operations/withdrawals_test.go
@@ -1,0 +1,11 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v4/testing/spectest/shared/capella/operations"
+)
+
+func TestMainnet_Capella_Operations_Withdrawals(t *testing.T) {
+	operations.RunWithdrawalsTest(t, "mainnet")
+}


### PR DESCRIPTION
h/t to @potuz , we missed these

side question, how do we close the loop moving forward, perhaps we can write a tool to check upstream folders and fail if something is not implemented