### PR TITLE
Exit Initial Sync Early

### DIFF
--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -89,6 +89,12 @@ func (s *Service) Start() {
 		log.Debug("Exiting Initial Sync Service")
 		return
 	}
+	// Exit entering round-robin sync if we require 0 peers to sync.
+	if flags.Get().MinimumSyncPeers == 0 {
+		s.markSynced()
+		log.WithField("genesisTime", gt).Info("Due to number of peers required for sync being set at 0, entering regular sync immediately.")
+		return
+	}
 	if gt.After(prysmTime.Now()) {
 		s.markSynced()
 		log.WithField("genesisTime", gt).Info("Genesis time has not arrived - not syncing")

--- a/beacon-chain/sync/initial-sync/service_test.go
+++ b/beacon-chain/sync/initial-sync/service_test.go
@@ -31,6 +31,14 @@ func TestService_Constants(t *testing.T) {
 
 func TestService_InitStartStop(t *testing.T) {
 	hook := logTest.NewGlobal()
+	resetFlags := flags.Get()
+	flags.Init(&flags.GlobalFlags{
+		MinimumSyncPeers: 1,
+	})
+	defer func() {
+		flags.Init(resetFlags)
+	}()
+
 	tests := []struct {
 		name         string
 		assert       func()


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

If we require 0 peers to sync, then we exit initial sync immediately and enter regular sync. This allows users running
single node devnets to start and stop with ease. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
