### PR TITLE
only handle epoch boundary on canonical blocks

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -129,15 +129,7 @@ func (s *Service) postBlockProcess(ctx context.Context, signed interfaces.ReadOn
 	//only handle epoch boundary if the incoming block is canonical,
 	//otherwise this will be handled by lateBlockTasks.
 	if headRoot == blockRoot {
-		// Get the current head state (it may be different than the incoming
-		// postState) and update epoch boundary caches. We pass the postState
-		// slot instead of the headState slot below to deal with the case of an
-		// incoming non-canonical block
-		st, err := s.HeadState(ctx)
-		if err != nil {
-			return errors.Wrap(err, "could not get headState")
-		}
-		if err := s.handleEpochBoundary(ctx, postState.Slot(), st, headRoot[:]); err != nil {
+		if err := s.handleEpochBoundary(ctx, postState.Slot(), postState, blockRoot[:]); err != nil {
 			return errors.Wrap(err, "could not handle epoch boundary")
 		}
 	}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -126,16 +126,20 @@ func (s *Service) postBlockProcess(ctx context.Context, signed interfaces.ReadOn
 	})
 
 	defer reportAttestationInclusion(b)
-	// Get the current head state (it may be different than the incoming
-	// postState) and update epoch boundary caches. We pass the postState
-	// slot instead of the headState slot below to deal with the case of an
-	// incoming non-canonical block
-	st, err := s.HeadState(ctx)
-	if err != nil {
-		return errors.Wrap(err, "could not get headState")
-	}
-	if err := s.handleEpochBoundary(ctx, postState.Slot(), st, headRoot[:]); err != nil {
-		return errors.Wrap(err, "could not handle epoch boundary")
+	//only handle epoch boundary if the incoming block is canonical,
+	//otherwise this will be handled by lateBlockTasks.
+	if headRoot == blockRoot {
+		// Get the current head state (it may be different than the incoming
+		// postState) and update epoch boundary caches. We pass the postState
+		// slot instead of the headState slot below to deal with the case of an
+		// incoming non-canonical block
+		st, err := s.HeadState(ctx)
+		if err != nil {
+			return errors.Wrap(err, "could not get headState")
+		}
+		if err := s.handleEpochBoundary(ctx, postState.Slot(), st, headRoot[:]); err != nil {
+			return errors.Wrap(err, "could not handle epoch boundary")
+		}
 	}
 	onBlockProcessingTime.Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil


### PR DESCRIPTION
This PR handles the following situations

The current behavior is this
- A block for slot 31 comes in but it is not canonical (say it's based on slot 16 for some reason)
- We do not update the NSC, but later on `handleEpochBoundary` we update the shuffling committee and this requires an epoch transition (bug number 1) 
- Later in `lateBlockTasks` we call again `handleEpochBoundary` to update the committees again (bug number 2). 

This PR removes the first call since it will happen anyway in `lateBlockTasks`. Notice that this doesn't affect the scenario when block 31 comes in and is late: 

- If it is canonical then we will call `handleEpochBoundary` at block processing. 
- If it is not, then already `lateBlockTasks` took care of it. 