### PR TITLE
fix: update committee cache epoch + 1

### DIFF
--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -303,7 +303,7 @@ func UpdateCommitteeCache(ctx context.Context, state state.ReadOnlyBeaconState, 
 			return err
 		}
 		if committeeCache.HasEntry(string(seed[:])) {
-			return nil
+			continue
 		}
 
 		shuffledIndices, err := ShuffledIndices(state, e)

--- a/beacon-chain/core/helpers/beacon_committee_test.go
+++ b/beacon-chain/core/helpers/beacon_committee_test.go
@@ -423,6 +423,41 @@ func TestUpdateCommitteeCache_CanUpdate(t *testing.T) {
 	assert.Equal(t, params.BeaconConfig().TargetCommitteeSize, uint64(len(indices)), "Did not save correct indices lengths")
 }
 
+func TestUpdateCommitteeCache_CanUpdateAcrossEpochs(t *testing.T) {
+	ClearCache()
+	defer ClearCache()
+	validatorCount := params.BeaconConfig().MinGenesisActiveValidatorCount
+	validators := make([]*ethpb.Validator, validatorCount)
+	indices := make([]primitives.ValidatorIndex, validatorCount)
+	for i := primitives.ValidatorIndex(0); uint64(i) < validatorCount; i++ {
+		validators[i] = &ethpb.Validator{
+			ExitEpoch:        params.BeaconConfig().FarFutureEpoch,
+			EffectiveBalance: 1,
+		}
+		indices[i] = i
+	}
+	state, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
+		Validators:  validators,
+		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
+	})
+	require.NoError(t, err)
+	e := time.CurrentEpoch(state)
+	require.NoError(t, UpdateCommitteeCache(context.Background(), state, e))
+
+	seed, err := Seed(state, e, params.BeaconConfig().DomainBeaconAttester)
+	require.NoError(t, err)
+	require.Equal(t, true, committeeCache.HasEntry(string(seed[:])))
+
+	seed, err = Seed(state, e+1, params.BeaconConfig().DomainBeaconAttester)
+	require.NoError(t, err)
+	require.Equal(t, true, committeeCache.HasEntry(string(seed[:])))
+
+	require.NoError(t, UpdateCommitteeCache(context.Background(), state, e+1))
+	seed, err = Seed(state, e+2, params.BeaconConfig().DomainBeaconAttester)
+	require.NoError(t, err)
+	require.Equal(t, true, committeeCache.HasEntry(string(seed[:])))
+}
+
 func BenchmarkComputeCommittee300000_WithPreCache(b *testing.B) {
 	validators := make([]*ethpb.Validator, 300000)
 	for i := 0; i < len(validators); i++ {


### PR DESCRIPTION
When we call `UpdateCommitteeCache`, we update `epoch` and `epoch+1`. If `epoch` exists, the function returns `nil` instead of `continue`. This means in the happy case, `epoch+1` never gets updated

Besides the inefficiency, here is what the real bug is:
1.) Start beacon node, at the end of epoch 1, we update the cache for epochs 2, and 3
2.) At end of epoch 2, epoch 3 is pre-cached, we skip updating epoch 4 because of the return nil 
3.) We then call `UpdateProposerIndicesInCache` for epoch 4. `UpdateProposerIndicesInCache` calls `ActiveValidatorIndices` which fills on the miss. Because epoch 4 doesn't have an entry, it caches epoch 4 and epoch 5(!)
4.) Here is the bug. At the end of epoch 2, the committee cache creates an entry for epoch 5


Another consideration is to remove fill on miss for `ActiveValidatorIndices` and `ActiveValidatorCount` but we should fill those for initial sync. It can be another PR