### PR TITLE
feat: add metric for block gossip time

### DIFF
--- a/beacon-chain/sync/metrics.go
+++ b/beacon-chain/sync/metrics.go
@@ -125,6 +125,12 @@ var (
 			Help: "Time to verify gossiped blocks",
 		},
 	)
+	blockArrivalGossipSummary = promauto.NewSummary(
+		prometheus.SummaryOpts{
+			Name: "gossip_block_arrival_milliseconds",
+			Help: "Time for gossiped blocks to arrive",
+		},
+	)
 
 	// Sync committee verification performance.
 	syncMessagesForUnknownBlocks = promauto.NewCounter(

--- a/beacon-chain/sync/validate_beacon_blocks.go
+++ b/beacon-chain/sync/validate_beacon_blocks.go
@@ -200,15 +200,20 @@ func (s *Service) validateBeaconBlockPubSub(ctx context.Context, pid peer.ID, ms
 		return pubsub.ValidationIgnore, err
 	}
 	graffiti := blk.Block().Body().Graffiti()
+
+	sinceSlotStartTime := receivedTime.Sub(startTime)
+	validationTime := prysmTime.Now().Sub(receivedTime)
 	log.WithFields(logrus.Fields{
 		"blockSlot":          blk.Block().Slot(),
-		"sinceSlotStartTime": receivedTime.Sub(startTime),
-		"validationTime":     prysmTime.Now().Sub(receivedTime),
+		"sinceSlotStartTime": sinceSlotStartTime,
+		"validationTime":     validationTime,
 		"proposerIndex":      blk.Block().ProposerIndex(),
 		"graffiti":           string(graffiti[:]),
 	}).Debug("Received block")
 
-	blockVerificationGossipSummary.Observe(float64(prysmTime.Since(receivedTime).Milliseconds()))
+	blockArrivalGossipSummary.Observe(float64(sinceSlotStartTime))
+	blockVerificationGossipSummary.Observe(float64(validationTime))
+
 	return pubsub.ValidationAccept, nil
 }
 


### PR DESCRIPTION
This is a very useful metric to have: how long did the block take to arrive from gossip's perspective? Besides logging, we don't have anything to monitor this