### PR TITLE
Bugfix: proposer-settings edge case for activating validators

### DIFF
--- a/validator/client/runner.go
+++ b/validator/client/runner.go
@@ -108,8 +108,9 @@ func run(ctx context.Context, v iface.Validator) {
 				continue
 			}
 
-			// create call on a separate thread to push proposer settings from the middle of an epoch.
-			if slots.SinceEpochStarts(slot) == params.BeaconConfig().SlotsPerEpoch/2 && v.ProposerSettings() != nil {
+			// call push proposer setting at the start of each epoch to account for the following edge case:
+			// proposer is activated at the start of epoch and tries to propose immediately
+			if slots.IsEpochStart(slot) && v.ProposerSettings() != nil {
 				go func() {
 					// deadline set for 1 epoch from call to not overlap.
 					epochDeadline := v.SlotDeadline(slot + params.BeaconConfig().SlotsPerEpoch - 1)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

In rare instances, the validator gets activated and proposes very close to its activation, since we moved the api call to mid epoch it may result in proposing with the fallback fee recipient on the beacon node. this PR will reverse this back to being at the epoch start.
