### PR TITLE
feat: add state regren duration metric

### DIFF
--- a/beacon-chain/state/stategen/replay.go
+++ b/beacon-chain/state/stategen/replay.go
@@ -75,6 +75,8 @@ func (_ *State) replayBlocks(
 		"duration": duration,
 	}).Debug("Replayed state")
 
+	replayBlocksSummary.Observe(float64(duration.Milliseconds()))
+
 	return state, nil
 }
 


### PR DESCRIPTION
the metric existed but it was never used for the old regen code