### PR TITLE
Deneb: hard code the fork version to capella when creating ve signature

### DIFF
--- a/cmd/validator/accounts/exit_test.go
+++ b/cmd/validator/accounts/exit_test.go
@@ -41,10 +41,6 @@ func TestExitAccountsCli_OK(t *testing.T) {
 		Return(&ethpb.Genesis{GenesisTime: genesisTime}, nil)
 
 	mockValidatorClient.EXPECT().
-		DomainData(gomock.Any(), gomock.Any()).
-		Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil)
-
-	mockValidatorClient.EXPECT().
 		ProposeExit(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.SignedVoluntaryExit{})).
 		Return(&ethpb.ProposeExitResponse{}, nil)
 
@@ -135,11 +131,6 @@ func TestExitAccountsCli_OK_AllPublicKeys(t *testing.T) {
 	mockNodeClient.EXPECT().
 		GetGenesis(gomock.Any(), gomock.Any()).
 		Return(&ethpb.Genesis{GenesisTime: genesisTime}, nil)
-
-	mockValidatorClient.EXPECT().
-		DomainData(gomock.Any(), gomock.Any()).
-		Times(2).
-		Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil)
 
 	mockValidatorClient.EXPECT().
 		ProposeExit(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.SignedVoluntaryExit{})).
@@ -239,10 +230,6 @@ func TestExitAccountsCli_OK_ForceExit(t *testing.T) {
 		Return(&ethpb.Genesis{GenesisTime: genesisTime}, nil)
 
 	mockValidatorClient.EXPECT().
-		DomainData(gomock.Any(), gomock.Any()).
-		Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil)
-
-	mockValidatorClient.EXPECT().
 		ProposeExit(gomock.Any(), gomock.AssignableToTypeOf(&ethpb.SignedVoluntaryExit{})).
 		Return(&ethpb.ProposeExitResponse{}, nil)
 
@@ -326,10 +313,6 @@ func TestExitAccountsCli_WriteJSON_NoBroadcast(t *testing.T) {
 	mockNodeClient.EXPECT().
 		GetGenesis(gomock.Any(), gomock.Any()).
 		Return(&ethpb.Genesis{GenesisTime: genesisTime}, nil)
-
-	mockValidatorClient.EXPECT().
-		DomainData(gomock.Any(), gomock.Any()).
-		Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil)
 
 	walletDir, _, passwordFilePath := setupWalletAndPasswordsDir(t)
 	// Write a directory where we will import keys from.

--- a/validator/accounts/accounts_exit.go
+++ b/validator/accounts/accounts_exit.go
@@ -96,7 +96,7 @@ func PerformVoluntaryExit(
 			log.WithError(err).Errorf("voluntary exit failed: %v", err)
 		}
 		if len(cfg.OutputDirectory) > 0 {
-			sve, err := client.CreateSignedVoluntaryExit(ctx, cfg.ValidatorClient, cfg.Keymanager.Sign, key, epoch)
+			sve, err := client.CreateSignedVoluntaryExit(ctx, cfg.ValidatorClient, cfg.Keymanager.Sign, key, epoch, genesisResponse)
 			if err != nil {
 				rawNotExitedKeys = append(rawNotExitedKeys, key)
 				msg := err.Error()
@@ -109,7 +109,7 @@ func PerformVoluntaryExit(
 			} else if err := writeSignedVoluntaryExitJSON(ctx, sve, cfg.OutputDirectory); err != nil {
 				log.WithError(err).Error("failed to write voluntary exit")
 			}
-		} else if err := client.ProposeExit(ctx, cfg.ValidatorClient, cfg.Keymanager.Sign, key, epoch); err != nil {
+		} else if err := client.ProposeExit(ctx, cfg.ValidatorClient, cfg.Keymanager.Sign, key, epoch, genesisResponse); err != nil {
 			rawNotExitedKeys = append(rawNotExitedKeys, key)
 
 			msg := err.Error()

--- a/validator/rpc/standard_api.go
+++ b/validator/rpc/standard_api.go
@@ -697,11 +697,11 @@ func (s *Server) SetVoluntaryExit(ctx context.Context, req *ethpbservice.SetVolu
 	if err != nil {
 		return nil, err
 	}
+	genesisResponse, err := s.beaconNodeClient.GetGenesis(ctx, &emptypb.Empty{})
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not create voluntary exit: %v", err)
+	}
 	if req.Epoch == 0 {
-		genesisResponse, err := s.beaconNodeClient.GetGenesis(ctx, &emptypb.Empty{})
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not create voluntary exit: %v", err)
-		}
 		epoch, err := client.CurrentEpoch(genesisResponse.GenesisTime)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "gRPC call to get genesis time failed: %v", err)
@@ -714,6 +714,7 @@ func (s *Server) SetVoluntaryExit(ctx context.Context, req *ethpbservice.SetVolu
 		km.Sign,
 		req.Pubkey,
 		req.Epoch,
+		genesisResponse,
 	)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not create voluntary exit: %v", err)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Bug Fix

**What does this PR do? Why is it needed?**
Hard codes the fork version to capella when creating voluntary exits through prysm cli

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
