### PR TITLE
Remove: span for convert to indexed attestation

### DIFF
--- a/proto/prysm/v1alpha1/attestation/attestation_utils.go
+++ b/proto/prysm/v1alpha1/attestation/attestation_utils.go
@@ -38,9 +38,6 @@ import (
 //	     signature=attestation.signature,
 //	 )
 func ConvertToIndexed(ctx context.Context, attestation *ethpb.Attestation, committee []primitives.ValidatorIndex) (*ethpb.IndexedAttestation, error) {
-	ctx, span := trace.StartSpan(ctx, "attestationutil.ConvertToIndexed")
-	defer span.End()
-
 	attIndices, err := AttestingIndices(attestation.AggregationBits, committee)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Span is not free and `ConvertToIndexed` is one of the highest traffic path. It is called on every attestation. About 21k times every 12s if a node subscribes to all the subnets. The span itself shows up on the profile when a block takes 1s to process. 