### PR TITLE
Minor Optimization on InnerShuffleList

### DIFF
--- a/beacon-chain/core/helpers/shuffle.go
+++ b/beacon-chain/core/helpers/shuffle.go
@@ -184,7 +184,7 @@ func innerShuffleList(input []primitives.ValidatorIndex, seed [32]byte, shuffle 
 	for {
 		buf[seedSize] = r
 		ph := hashfunc(buf[:pivotViewSize])
-		pivot := bytesutil.FromBytes8(ph[:8]) % listSize
+		pivot := binary.LittleEndian.Uint64(ph[:8]) % listSize
 		mirror := (pivot + 1) >> 1
 		binary.LittleEndian.PutUint32(buf[pivotViewSize:], uint32(pivot>>8))
 		source := hashfunc(buf)


### PR DESCRIPTION
**What type of PR is this?**

Optimization

**What does this PR do? Why is it needed?**

Instead of calling `FromBytes8` and involving a branch, we directly call `binary.LittleEndian.Uint64` instead.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
