### PR TITLE
Fix: use correct context for `UpdateCommitteeCache`

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -346,7 +346,7 @@ func (s *Service) updateEpochBoundaryCaches(ctx context.Context, st state.Beacon
 		// with a custom deadline, therefore using the background context instead.
 		slotCtx, cancel := context.WithTimeout(context.Background(), slotDeadline)
 		defer cancel()
-		if err := helpers.UpdateCommitteeCache(ctx, st, e+1); err != nil {
+		if err := helpers.UpdateCommitteeCache(slotCtx, st, e+1); err != nil {
 			log.WithError(err).Warn("Could not update committee cache")
 		}
 		if err := helpers.UpdateProposerIndicesInCache(slotCtx, st, e+1); err != nil {


### PR DESCRIPTION
I saw a few context deadline around at slot 31 and using the wrong context was the reason
```
[2023-08-02 07:01:49] DEBUG sync: Received block blockSlot=7013407 graffiti=Lodestar-v1.9.2/72beda1 proposerIndex=704602 sinceSlotStartTime=2.872754726s validationTime=4.470042ms
[2023-08-02 07:01:50] DEBUG blockchain: Synced new block block=0x400eda79... chainServiceProcessedTime=318.499025ms deposits=16 epoch=219168 finalizedEpoch=219166 finalizedRoot=0x618bbf93... justifiedEpoch=219167 justifiedRoot=0x6796db2a... parentRoot=0x8
a3fc4a6... sinceSlotStartTime=3.196996676s slot=7013407 slotInEpoch=31 version=capella
[2023-08-02 07:01:50] DEBUG blockchain: Synced new payload blockHash=0x2c7e1f71ff7a blockNumber=17827777 blsToExecutionChanges=0 gasUtilized=0.72 parentHash=0x406ff7bf7e5c withdrawals=16
[2023-08-02 07:01:50]  INFO blockchain: Finished applying state transition attestations=126 deposits=16 payloadHash=0x2c7e1f71ff7a slot=7013407 syncBitsCount=0 txCount=241
[2023-08-02 07:01:50]  INFO p2p: Peer summary activePeers=44 inbound=0 outbound=43
[2023-08-02 07:01:50]  WARN blockchain: Could not update committee cache error=context canceled
```