### PR TITLE
Feat: aggregate parallel default

### DIFF
--- a/config/features/config.go
+++ b/config/features/config.go
@@ -230,9 +230,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		logEnabled(disableBuildBlockParallel)
 		cfg.BuildBlockParallel = false
 	}
-	if ctx.IsSet(aggregateParallel.Name) {
-		logEnabled(aggregateParallel)
-		cfg.AggregateParallel = true
+	cfg.AggregateParallel = true
+	if ctx.IsSet(disableAggregateParallel.Name) {
+		logEnabled(disableAggregateParallel)
+		cfg.AggregateParallel = false
 	}
 	if ctx.IsSet(disableResourceManager.Name) {
 		logEnabled(disableResourceManager)

--- a/config/features/deprecated_flags.go
+++ b/config/features/deprecated_flags.go
@@ -38,6 +38,11 @@ var (
 		Usage:  deprecatedUsage,
 		Hidden: true,
 	}
+	deprecatedAggregateParallel = &cli.BoolFlag{
+		Name:   "aggregate-parallel",
+		Usage:  deprecatedUsage,
+		Hidden: true,
+	}
 )
 
 // Deprecated flags for both the beacon node and validator client.
@@ -48,6 +53,7 @@ var deprecatedFlags = []cli.Flag{
 	deprecatedDisableGossipBatchAggregation,
 	deprecatedBuildBlockParallel,
 	deprecatedEnableRegistrationCache,
+	deprecatedAggregateParallel,
 }
 
 // deprecatedBeaconFlags contains flags that are still used by other components

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -155,9 +155,9 @@ var (
 		Usage: "A temporary flag for disabling the validator registration cache instead of using the db. note: registrations do not clear on restart while using the db",
 	}
 
-	aggregateParallel = &cli.BoolFlag{
-		Name:  "aggregate-parallel",
-		Usage: "Enables parallel aggregation of attestations",
+	disableAggregateParallel = &cli.BoolFlag{
+		Name:  "disable-aggregate-parallel",
+		Usage: "Disables parallel aggregation of attestations",
 	}
 )
 
@@ -212,7 +212,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	aggregateThirdInterval,
 	disableResourceManager,
 	DisableRegistrationCache,
-	aggregateParallel,
+	disableAggregateParallel,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
`aggregate-parallel` by default with a backoff flag `disable-aggregate-parallel`.
This feature has been battled and tested on testnet and some mainnet nodes. It reduces aggregation time ~80% if you run more than 10 validators. A node without beacon subnet will treat additional background routines as no-op, which should also be very fast