### PR TITLE
Fix: writeBlockBatchToStream when genesis block fork version is Capella

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -546,7 +546,12 @@ func (s *Service) ReconstructFullBlock(
 	// If the payload header has a block hash of 0x0, it means we are pre-merge and should
 	// simply return the block with an empty execution payload.
 	if bytes.Equal(header.BlockHash(), params.BeaconConfig().ZeroHash[:]) {
-		payload := buildEmptyExecutionPayload()
+		var payload interface{}
+		if blindedBlock.Version() == version.Bellatrix {
+			payload = buildEmptyExecutionPayload()
+		} else {
+			payload = buildEmptyExecutionPayloadCapella()
+		}
 		return blocks.BuildSignedBeaconBlockFromExecutionPayload(blindedBlock, payload)
 	}
 
@@ -605,7 +610,12 @@ func (s *Service) ReconstructFullBellatrixBlockBatch(
 	// For blocks that are pre-merge we simply reconstruct them via an empty
 	// execution payload.
 	for _, realIdx := range zeroExecPayloads {
-		payload := buildEmptyExecutionPayload()
+		var payload interface{}
+		if blindedBlocks[realIdx].Version() == version.Bellatrix {
+			payload = buildEmptyExecutionPayload()
+		} else {
+			payload = buildEmptyExecutionPayloadCapella()
+		}
 		fullBlock, err := blocks.BuildSignedBeaconBlockFromExecutionPayload(blindedBlocks[realIdx], payload)
 		if err != nil {
 			return nil, err
@@ -897,6 +907,21 @@ func tDStringToUint256(td string) (*uint256.Int, error) {
 
 func buildEmptyExecutionPayload() *pb.ExecutionPayload {
 	return &pb.ExecutionPayload{
+		ParentHash:    make([]byte, fieldparams.RootLength),
+		FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
+		StateRoot:     make([]byte, fieldparams.RootLength),
+		ReceiptsRoot:  make([]byte, fieldparams.RootLength),
+		LogsBloom:     make([]byte, fieldparams.LogsBloomLength),
+		PrevRandao:    make([]byte, fieldparams.RootLength),
+		BaseFeePerGas: make([]byte, fieldparams.RootLength),
+		BlockHash:     make([]byte, fieldparams.RootLength),
+		Transactions:  make([][]byte, 0),
+		ExtraData:     make([]byte, 0),
+	}
+}
+
+func buildEmptyExecutionPayloadCapella() *pb.ExecutionPayloadCapella {
+	return &pb.ExecutionPayloadCapella{
 		ParentHash:    make([]byte, fieldparams.RootLength),
 		FeeRecipient:  make([]byte, fieldparams.FeeRecipientLength),
 		StateRoot:     make([]byte, fieldparams.RootLength),


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

prysmctl testnet generate-genesis comes with --fork flag, which allows to generate a genesis of a specific fork such as capella

Example command
`./prysmctl testnet generate-genesis --fork=capella --num-validators=64 --geth-genesis-json-in=genesis.json --output-ssz=genesis.ssz --chain-config-file=config.yml --genesis-time=1691623218
`
If a genesis block is generated with capella fork version, then the initial-sync will not work for other nodes, as the other nodes who will try to sync with the node building blocks, will fail to deserialize the genesis block. 

The node who will be sending genesis block along with other blocks to the other node who requested for the block by range will call the ReconstructFullBellatrixBlockBatch in the following line

https://github.com/prysmaticlabs/prysm/blob/7aa043892bf5983ab41c5182fa4346846deb32da/beacon-chain/sync/rpc_beacon_blocks_by_range.go#L150

followed by the following line

https://github.com/prysmaticlabs/prysm/blob/7aa043892bf5983ab41c5182fa4346846deb32da/beacon-chain/execution/engine_client.go#L608

This line generates the empty payload for the genesis block which is of type Bellatrix without checking the version of the genesis block which could be of version Capella. 

And because of this the other node, who is syncing will not be able to UnmarshalSSZ to the genesis block correctly, stalling syncing of the node.

Following is the exact line where the error will trigger on the other node who is trying to sync with genesis having fork version Capella

https://github.com/prysmaticlabs/prysm/blob/7aa043892bf5983ab41c5182fa4346846deb32da/beacon-chain/p2p/encoder/ssz.go#L79

 