### PR TITLE
Update BLST to v0.3.11

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -3824,11 +3824,11 @@ def prysm_deps():
     http_archive(
         name = "com_github_supranational_blst",
         urls = [
-            "https://github.com/supranational/blst/archive/61758ce4e1d18e6929658ac3a29fa39ad91cd294.tar.gz",
+            "https://github.com/supranational/blst/archive/3dd0f804b1819e5d03fb22ca2e6fac105932043a.tar.gz",
         ],
-        strip_prefix = "blst-61758ce4e1d18e6929658ac3a29fa39ad91cd294",
+        strip_prefix = "blst-3dd0f804b1819e5d03fb22ca2e6fac105932043a",
         build_file = "//third_party:blst/blst.BUILD",
-        sha256 = "acc022ddcf6181f8f402365d6382ea66c4352a10fe5490defd53b0db89739c42",
+        sha256 = "132124c074e59ead77e1828cc54b587a182ea67b781b72198e802af4696d78fe",
     )
     go_repository(
         name = "com_github_syndtr_goleveldb",

--- a/go.mod
+++ b/go.mod
@@ -68,7 +68,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/status-im/keycard-go v0.2.0
 	github.com/stretchr/testify v1.8.2
-	github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344
+	github.com/supranational/blst v0.3.11
 	github.com/thomaso-mirodin/intmath v0.0.0-20160323211736-5dc6d854e46e
 	github.com/trailofbits/go-mutexasserts v0.0.0-20230328101604-8cdbc5f3d279
 	github.com/tyler-smith/go-bip39 v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1208,8 +1208,9 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
-github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344 h1:m+8fKfQwCAy1QjzINvKe/pYtLjo2dl59x2w9YSEJxuY=
 github.com/supranational/blst v0.3.8-0.20220526154634-513d2456b344/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
+github.com/supranational/blst v0.3.11 h1:LyU6FolezeWAhvQk0k6O/d49jqgO52MSDDfYgbeoEm4=
+github.com/supranational/blst v0.3.11/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=

--- a/third_party/blst/blst.BUILD
+++ b/third_party/blst/blst.BUILD
@@ -16,7 +16,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bindings/go/blst.go",
-        "bindings/go/server.c",
+        "bindings/go/cgo_server.c",
     ],
     cgo = True,
     copts = [

--- a/third_party/blst/blst.BUILD
+++ b/third_party/blst/blst.BUILD
@@ -111,7 +111,6 @@ cc_library(
             "src/*.h",
         ],
         exclude = [
-            "src/server.c",
             "src/client_*.c",
         ],
     ),


### PR DESCRIPTION
**What type of PR is this?**

Security Update

**What does this PR do? Why is it needed?**

This updates blst to address this vulnerability:
https://github.com/supranational/blst/security/advisories/GHSA-8c37-7qx3-4c4p

While we are not affected, future use of `SigValidate` with infinity checks enabled would lead to the incorrect result.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
