### PR TITLE
Fix logic for checking whether newly covered bits has at least one un…

### DIFF
--- a/proto/prysm/v1alpha1/attestation/aggregation/attestations/maxcover.go
+++ b/proto/prysm/v1alpha1/attestation/aggregation/attestations/maxcover.go
@@ -68,10 +68,15 @@ func MaxCoverAttestationAggregation(atts []*ethpb.Attestation) ([]*ethpb.Attesta
 
 		// Create aggregated attestation and update solution lists. Process aggregates only if they
 		// feature at least one unknown bit i.e. can increase the overall coverage.
-		xc, err := coveredBitsSoFar.XorCount(coverage)
-		if err != nil {
-			return nil, err
+		diff, err1 := coveredBitsSoFar.Xor(coverage)
+		if err1 != nil {
+			return nil, err1
 		}
+		xc, err2 := diff.AndCount(coverage)
+		if err2 != nil {
+			return nil, err2
+		}
+
 		if xc > 0 {
 			aggIdx, err := aggregateAttestations(atts, keys, coverage)
 			if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
 Other

**What does this PR do? Why is it needed?**
MaxCoverAttestationAggregation iterate several rounds (maximum len(atts)/2), and
each round it finds 'greedy selected candidates' and updates coveredBitsSoFar.

`xc, err := coveredBitsSoFar.XorCount(coverage)`
coveredBitsSoFar is used for checking whether newly selected candidates have at least one unknown bit. (xc > 0)
However XorCount just produces the count of different bits, not the newly included bits found from new round.

It needs to be changed to get the 'xor' between coveredBitsSoFar and coverage, and 
then get the count of 'and' between the xor result and coverage.

Let me provide a simple example when the new round has no newly covered bit, but
XorCount tells it has.

```
coveredBitsSoFar := bitfield.NewBitlist64(3)
coveredBitsSoFar.SetBitAt(0, true)
coveredBitsSoFar.SetBitAt(1, true)
// [0, 1, 1]

coverage := bitfield.NewBitlist64(3)
coverage.SetBitAt(0, true)
// [0, 0, 1] -> this has no unknown bit !!!

xc, _ := coveredBitsSoFar.XorCount(coverage)
// xc : 1 (wrong -> there is no unknown bit from coverage)

diff, _ := coveredBitsSoFar.Xor(coverage)
xcFixed, _ := diff.AndCount(coverage)
// xcFixed : 0 
```

tested in play ground
https://go.dev/play/p/0xJqVB7HoEe