### PR TITLE
feat: add blob peer scoring params

### DIFF
--- a/beacon-chain/p2p/gossip_scoring_params.go
+++ b/beacon-chain/p2p/gossip_scoring_params.go
@@ -121,6 +121,9 @@ func (s *Service) topicScoreParams(topic string) (*pubsub.TopicScoreParams, erro
 		return defaultAttesterSlashingTopicParams(), nil
 	case strings.Contains(topic, GossipBlsToExecutionChangeMessage):
 		return defaultBlsToExecutionChangeTopicParams(), nil
+	case strings.Contains(topic, GossipBlobSidecarMessage):
+		// TODO(Deneb): Using the default block scoring. But this should be updated.
+		return defaultBlockTopicParams(), nil
 	default:
 		return nil, errors.Errorf("unrecognized topic provided for parameter registration: %s", topic)
 	}


### PR DESCRIPTION
Add blob peer scoring params with a TODO as it currently uses block scoring. This is better than nothing and fixes the `unrecognized topic provided for parameter registration` error for every run. We should figure out the detailed scoring params and I'll default that to @nisdas 