### PR TITLE
feat: save blobs to db for subscriber

### DIFF
--- a/beacon-chain/sync/subscriber_blob_sidecar.go
+++ b/beacon-chain/sync/subscriber_blob_sidecar.go
@@ -18,7 +18,9 @@ func (s *Service) blobSubscriber(ctx context.Context, msg proto.Message) error {
 
 	s.setSeenBlobIndex(b.Message.Blob, b.Message.Index)
 
-	// TODO: Store blobs in cache. Will be addressed in subsequent PR.
+	if err := s.cfg.beaconDB.SaveBlobSidecar(ctx, []*eth.BlobSidecar{b.Message}); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
When we receive a blob over a subscriber, it must be saved to the DB later for `isDataAvailable` in the blockchain pkg. This allowed a beacon node to process consensus and execution checks in parallel. The beacon node should not block the processing of a block until it has received all the blobs. Instead, it should process the block as soon as it gets it. 

This PR implements the following 
- DB pkg `SaveBlobSidecar` allows merging blobs and only delete blobs if the key is older than the retention period. Removed blob index check
- Blockchain pkg `removeInvalidBlockAndState` also removes the blob for block root
- Sync pkg `blobSubscriber` saves the blob to the DB

This PR does not touch the following but needs to be discussed (separate issues?)
- DB pkg `SaveBlobSidecar` inputs a list of blob sidecars. Should this be singular? It seems to me plural is better for initial syncing and proposer. But singular is better for regular syncing. It's 2 vs. 1
- Blockchain pkg `isDataAvailable` needs to consider not all the blobs have arrived and wait / edge cases handling 