### PR TITLE
fix: payload attribute v3 return nil

### DIFF
--- a/consensus-types/payload-attribute/getters.go
+++ b/consensus-types/payload-attribute/getters.go
@@ -83,6 +83,9 @@ func (a *data) PbV3() (*enginev1.PayloadAttributesV3, error) {
 	if a.version != version.Deneb {
 		return nil, consensus_types.ErrNotSupported("PbV3", a.version)
 	}
+	if a.timeStamp == 0 && len(a.prevRandao) == 0 && len(a.parentBeaconBlockRoot) == 0 {
+		return nil, nil
+	}
 	return &enginev1.PayloadAttributesV3{
 		Timestamp:             a.timeStamp,
 		PrevRandao:            a.prevRandao,

--- a/consensus-types/payload-attribute/getters_test.go
+++ b/consensus-types/payload-attribute/getters_test.go
@@ -172,6 +172,16 @@ func TestPayloadAttributeGetters(t *testing.T) {
 				require.ErrorContains(t, "PbV3 is not supported for capella: unsupported getter", err)
 			},
 		},
+		{
+			name: "Get PbDeneb (nil)",
+			tc: func(t *testing.T) {
+				a, err := New(&enginev1.PayloadAttributesV3{})
+				require.NoError(t, err)
+				got, err := a.PbV3()
+				require.NoError(t, err)
+				require.Equal(t, (*enginev1.PayloadAttributesV3)(nil), got)
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
To follow engine API spec and like V1 and V2, in the event where payload attribute v3 is empty or fields containing zero values, it should return nil/null instead of an empty struct. This is part of the engine API definition 