### PR TITLE
fix: validator returning the right # of blobs

### DIFF
--- a/validator/client/propose.go
+++ b/validator/client/propose.go
@@ -124,16 +124,16 @@ func (v *validator) ProposeBlock(ctx context.Context, slot primitives.Slot, pubK
 	var genericSignedBlock *ethpb.GenericSignedBeaconBlock
 	if blk.Version() >= version.Deneb && !blk.IsBlinded() {
 		signedBlobs := make([]*ethpb.SignedBlobSidecar, len(b.GetDeneb().Blobs))
-		for _, blob := range b.GetDeneb().Blobs {
+		for i, blob := range b.GetDeneb().Blobs {
 			blobSig, err := v.signBlob(ctx, blob, pubKey)
 			if err != nil {
 				log.WithError(err).Error("Failed to sign blob")
 				return
 			}
-			signedBlobs = append(signedBlobs, &ethpb.SignedBlobSidecar{
+			signedBlobs[i] = &ethpb.SignedBlobSidecar{
 				Message:   blob,
 				Signature: blobSig,
-			})
+			}
 		}
 		denebBlock, err := blk.PbDenebBlock()
 		if err != nil {

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -673,6 +673,9 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 			).DoAndReturn(func(ctx context.Context, block *ethpb.GenericSignedBeaconBlock) (*ethpb.ProposeResponse, error) {
 				sentBlock, err = blocktest.NewSignedBeaconBlockFromGeneric(block)
 				assert.NoError(t, err, "Unexpected error unwrapping block")
+				if tt.version == version.Deneb {
+					require.Equal(t, 2, len(block.GetDeneb().Blobs))
+				}
 				return &ethpb.ProposeResponse{BlockRoot: make([]byte, 32)}, nil
 			})
 
@@ -680,6 +683,7 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 			g := sentBlock.Block().Body().Graffiti()
 			assert.Equal(t, string(validator.graffiti), string(g[:]))
 			require.LogsContain(t, hook, "Submitted new block")
+
 		})
 	}
 }


### PR DESCRIPTION
The `signedBlobs` slice in  `ProposeBlock` is allocated. Instead of `append`, it should `assign`. Also added a regression test