### PR TITLE
Shift Error Logs To Debug

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -97,7 +97,7 @@ func (s *Service) postBlockProcess(ctx context.Context, signed interfaces.ReadOn
 
 	optimistic, err := s.cfg.ForkChoiceStore.IsOptimistic(blockRoot)
 	if err != nil {
-		log.WithError(err).Error("Could not check if block is optimistic")
+		log.WithError(err).Debug("Could not check if block is optimistic")
 		optimistic = true
 	}
 

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -192,7 +192,7 @@ func (s *Service) ReceiveBlockBatch(ctx context.Context, blocks []interfaces.Rea
 		}
 		optimistic, err := s.cfg.ForkChoiceStore.IsOptimistic(blkRoots[i])
 		if err != nil {
-			log.WithError(err).Error("Could not check if block is optimistic")
+			log.WithError(err).Debug("Could not check if block is optimistic")
 			optimistic = true
 		}
 		// Send notification of the processed block to the state feed.


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

In #12625, we checked for the optimistic status of blocks right after they had been processed. We would log an error in the event the forkchoice store was unable to retrieve their status. This log is changed from an error log to a debug log.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
