### PR TITLE
Fix filterContained

### DIFF
--- a/proto/prysm/v1alpha1/attestation/aggregation/attestations/maxcover_test.go
+++ b/proto/prysm/v1alpha1/attestation/aggregation/attestations/maxcover_test.go
@@ -433,3 +433,45 @@ func TestAggregateAttestations_aggregateAttestations(t *testing.T) {
 		})
 	}
 }
+
+func TestAggregateAttestations_filterContained(t *testing.T) {
+	tests := []struct {
+		name     string
+		atts     attList
+		wantAtts attList
+	}{
+		{
+			name: "no contained attestation",
+			atts: attList{
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00111000, 0b1}},
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00000011, 0b1}},
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00000100, 0b1}},
+			},
+			wantAtts: attList{
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00111000, 0b1}},
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00000011, 0b1}},
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00000100, 0b1}},
+			},
+		},
+		{
+			name: "contained attestation is filtered",
+			atts: attList{
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00111100, 0b1}},
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00000011, 0b1}},
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00000100, 0b1}},
+			},
+			wantAtts: attList{
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00111100, 0b1}},
+				&ethpb.Attestation{AggregationBits: bitfield.Bitlist{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0b00000011, 0b1}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered, err := tt.atts.filterContained()
+			assert.NoError(t, err)
+			assert.DeepEqual(t, filtered, tt.wantAtts)
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**

filterContained is checking 'contains' between the 'last element of filtered' and new attestation from given attestation list.
So what I'm worrying is like below case.

let the given attestation list has 3 attestations and aggregation bits are like below.
(Just assumed aggregation bits are 6 bits for convenience)

attestation[0].AggregationBits = [1, 1, 1, 1, 0, 0]
attestation[1].AggregationBits = [0, 0, 0, 0, 1, 1]
attestation[2].AggregationBits = [0, 0, 0, 1, 0, 0]

Here I expect all the 3 elements will be included in the final returned list, filtered.

At the first iteration,
attestation[1] will be appended because attestation[0].AggregationBits does not contain attestation[1].AggregationBits.

At the second iteration,
attestation[2] will be appended because attestation[1].AggregationBits (which is the final element of filtered) does not contain attestation[2].AggregationBits.

Like this, all 3 elements will be included in filtered list even though attestation[0].AggregationBits contains attestation[2].AggregationBits.

So this fix stores coveredBits for holding the bits covered so far during the iteration, and
use this for checking 'contains' instead of the 'last element of filtered'.

**Which issues(s) does this PR fix?**
https://github.com/prysmaticlabs/prysm/discussions/12727