### PR TITLE
Use last optimistic status on batches

### DIFF
--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -185,9 +185,11 @@ func (s *Service) ReceiveBlockBatch(ctx context.Context, blocks []interfaces.Rea
 		return err
 	}
 
-	optimistic, err := s.cfg.ForkChoiceStore.IsOptimistic(blkRoots[len(blkRoots)-1])
+	lastBR := blkRoots[len(blkRoots)-1]
+	optimistic, err := s.cfg.ForkChoiceStore.IsOptimistic(lastBR)
 	if err != nil {
-		log.WithError(err).Error("Could not check if block is optimistic")
+		lastSlot := blocks[len(blocks)-1].Block().Slot()
+		log.WithError(err).Errorf("Could not check if block is optimistic, Root: %#x, Slot: %d", lastBR, lastSlot)
 		optimistic = true
 	}
 	for i, b := range blocks {

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -185,15 +185,15 @@ func (s *Service) ReceiveBlockBatch(ctx context.Context, blocks []interfaces.Rea
 		return err
 	}
 
+	optimistic, err := s.cfg.ForkChoiceStore.IsOptimistic(blkRoots[len(blkRoots)-1])
+	if err != nil {
+		log.WithError(err).Error("Could not check if block is optimistic")
+		optimistic = true
+	}
 	for i, b := range blocks {
 		blockCopy, err := b.Copy()
 		if err != nil {
 			return err
-		}
-		optimistic, err := s.cfg.ForkChoiceStore.IsOptimistic(blkRoots[i])
-		if err != nil {
-			log.WithError(err).Debug("Could not check if block is optimistic")
-			optimistic = true
 		}
 		// Send notification of the processed block to the state feed.
 		s.cfg.StateNotifier.StateFeed().Send(&feed.Event{


### PR DESCRIPTION
Use the optimistic status of the last block imported in a batch. If it's valid all parents are guaranteed to be valid. If it's optimistic, then it's safe to send some blocks as optimistic. 