### PR TITLE
Blob channel

### DIFF
--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "process_block.go",
         "process_block_helpers.go",
         "receive_attestation.go",
+        "receive_blob.go",
         "receive_block.go",
         "service.go",
         "weak_subjectivity_checks.go",

--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -71,7 +71,6 @@ go_library(
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/payload-attribute:go_default_library",
         "//consensus-types/primitives:go_default_library",
-        "//container/slice:go_default_library",
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//math:go_default_library",

--- a/beacon-chain/blockchain/BUILD.bazel
+++ b/beacon-chain/blockchain/BUILD.bazel
@@ -71,6 +71,7 @@ go_library(
         "//consensus-types/interfaces:go_default_library",
         "//consensus-types/payload-attribute:go_default_library",
         "//consensus-types/primitives:go_default_library",
+        "//container/slice:go_default_library",
         "//crypto/bls:go_default_library",
         "//encoding/bytesutil:go_default_library",
         "//math:go_default_library",

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -537,9 +537,10 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 			return kzg.IsDataAvailable(kzgCommitments, sidecars)
 		}
 	}
-	// Create the channel if it didn't exist already
+	// Create the channel if it didn't exist already the index map will be
+	// created later anyway
 	if !ok {
-		nc = &blobNotifierChan{indices: make(map[uint64]struct{}), channel: make(chan struct{}, fieldparams.MaxBlobsPerBlock)}
+		nc = &blobNotifierChan{channel: make(chan struct{}, fieldparams.MaxBlobsPerBlock)}
 		s.blobNotifier.chanForRoot[root] = nc
 	}
 	// We have more commitments in the block than blobs in database

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -16,6 +16,7 @@ import (
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v4/config/features"
+	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	consensusblocks "github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
@@ -522,21 +523,38 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 	if existingBlobs == 0 {
 		return nil
 	}
-	// wait until we have received all blobs for this block
+
+	// Read first from db in case we have the blobs
 	s.blobNotifier.Lock()
 	var nc *blobNotifierChan
 	var ok bool
 	nc, ok = s.blobNotifier.chanForRoot[root]
+	sidecars, err := s.cfg.BeaconDB.BlobSidecarsByRoot(ctx, root)
+	if err == nil {
+		if len(sidecars) >= existingBlobs {
+			delete(s.blobNotifier.chanForRoot, root)
+			s.blobNotifier.Unlock()
+			return kzg.IsDataAvailable(kzgCommitments, sidecars)
+		}
+	}
+	// Create the channel if it didn't exist already
 	if !ok {
-		nc = &blobNotifierChan{indices: make(map[uint64]struct{}), channel: make(chan struct{})}
+		nc = &blobNotifierChan{indices: make(map[uint64]struct{}), channel: make(chan struct{}, fieldparams.MaxBlobsPerBlock)}
 		s.blobNotifier.chanForRoot[root] = nc
 	}
+	// We have more commitments in the block than blobs in database
+	// We sync the channel indices with the sidecars
+	nc.indices = make(map[uint64]struct{})
+	for _, sidecar := range sidecars {
+		nc.indices[sidecar.Index] = struct{}{}
+	}
 	s.blobNotifier.Unlock()
+	channelWrites := len(sidecars)
 	for {
 		select {
 		case <-nc.channel:
-			existingBlobs--
-			if existingBlobs == 0 {
+			channelWrites++
+			if channelWrites == existingBlobs {
 				s.blobNotifier.Lock()
 				delete(s.blobNotifier.chanForRoot, root)
 				s.blobNotifier.Unlock()

--- a/beacon-chain/blockchain/receive_blob.go
+++ b/beacon-chain/blockchain/receive_blob.go
@@ -1,0 +1,7 @@
+package blockchain
+
+// SendNewBlobEvent sends a message to the BlobNotifier channel that the blob
+// for the blocroot `root` is ready in the database
+func (s *Service) SendNewBlobEvent(root [32]byte) {
+	s.cfg.BlobNotifier <- root
+}

--- a/beacon-chain/blockchain/receive_blob.go
+++ b/beacon-chain/blockchain/receive_blob.go
@@ -1,5 +1,7 @@
 package blockchain
 
+import fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
+
 // SendNewBlobEvent sends a message to the BlobNotifier channel that the blob
 // for the blocroot `root` is ready in the database
 func (s *Service) SendNewBlobEvent(root [32]byte, index uint64) {
@@ -8,7 +10,7 @@ func (s *Service) SendNewBlobEvent(root [32]byte, index uint64) {
 	var nc *blobNotifierChan
 	nc, ok = s.blobNotifier.chanForRoot[root]
 	if !ok {
-		nc = &blobNotifierChan{indices: make(map[uint64]struct{}), channel: make(chan struct{})}
+		nc = &blobNotifierChan{indices: make(map[uint64]struct{}), channel: make(chan struct{}, fieldparams.MaxBlobsPerBlock)}
 		s.blobNotifier.chanForRoot[root] = nc
 	}
 	_, ok = nc.indices[index]

--- a/beacon-chain/blockchain/receive_blob.go
+++ b/beacon-chain/blockchain/receive_blob.go
@@ -2,6 +2,21 @@ package blockchain
 
 // SendNewBlobEvent sends a message to the BlobNotifier channel that the blob
 // for the blocroot `root` is ready in the database
-func (s *Service) SendNewBlobEvent(root [32]byte) {
-	s.cfg.BlobNotifier <- root
+func (s *Service) SendNewBlobEvent(root [32]byte, index uint64) {
+	s.blobNotifier.Lock()
+	var ok bool
+	var nc *blobNotifierChan
+	nc, ok = s.blobNotifier.chanForRoot[root]
+	if !ok {
+		nc = &blobNotifierChan{indices: make(map[uint64]struct{}), channel: make(chan struct{})}
+		s.blobNotifier.chanForRoot[root] = nc
+	}
+	_, ok = nc.indices[index]
+	if ok {
+		s.blobNotifier.Unlock()
+		return
+	}
+	nc.indices[index] = struct{}{}
+	s.blobNotifier.Unlock()
+	nc.channel <- struct{}{}
 }

--- a/beacon-chain/blockchain/receive_blob.go
+++ b/beacon-chain/blockchain/receive_blob.go
@@ -6,9 +6,7 @@ import fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 // for the blocroot `root` is ready in the database
 func (s *Service) SendNewBlobEvent(root [32]byte, index uint64) {
 	s.blobNotifier.Lock()
-	var ok bool
-	var nc *blobNotifierChan
-	nc, ok = s.blobNotifier.chanForRoot[root]
+	nc, ok := s.blobNotifier.chanForRoot[root]
 	if !ok {
 		nc = &blobNotifierChan{indices: make(map[uint64]struct{}), channel: make(chan struct{}, fieldparams.MaxBlobsPerBlock)}
 		s.blobNotifier.chanForRoot[root] = nc

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -38,6 +38,12 @@ type BlockReceiver interface {
 	RecentBlockSlot(root [32]byte) (primitives.Slot, error)
 }
 
+// BlobReceiver interface defines the methods of chain service for receiving new
+// blobs
+type BlobReceiver interface {
+	SendNewBlobEvent([32]byte)
+}
+
 // SlashingReceiver interface defines the methods of chain service for receiving validated slashing over the wire.
 type SlashingReceiver interface {
 	ReceiveAttesterSlashing(ctx context.Context, slashings *ethpb.AttesterSlashing)

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -41,7 +41,7 @@ type BlockReceiver interface {
 // BlobReceiver interface defines the methods of chain service for receiving new
 // blobs
 type BlobReceiver interface {
-	SendNewBlobEvent([32]byte)
+	SendNewBlobEvent([32]byte, uint64)
 }
 
 // SlashingReceiver interface defines the methods of chain service for receiving validated slashing over the wire.

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -77,6 +77,7 @@ type config struct {
 	P2p                     p2p.Broadcaster
 	MaxRoutines             int
 	StateNotifier           statefeed.Notifier
+	BlobNotifier            chan [32]byte
 	ForkChoiceStore         f.ForkChoicer
 	AttService              *attestations.Service
 	StateGen                *stategen.State
@@ -103,7 +104,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 		boundaryRoots:        [][32]byte{},
 		checkpointStateCache: cache.NewCheckpointStateCache(),
 		initSyncBlocks:       make(map[[32]byte]interfaces.ReadOnlySignedBeaconBlock),
-		cfg:                  &config{ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache()},
+		cfg:                  &config{ProposerSlotIndexCache: cache.NewProposerPayloadIDsCache(), BlobNotifier: make(chan [32]byte)},
 	}
 	for _, opt := range opts {
 		if err := opt(srv); err != nil {

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -604,3 +604,6 @@ func (s *ChainService) FinalizedBlockHash() [32]byte {
 func (s *ChainService) UnrealizedJustifiedPayloadBlockHash() [32]byte {
 	return [32]byte{}
 }
+
+// SendNewBlobEvent mocks the same method in the chain service
+func (s *ChainService) SendNewBlobEvent(_ [32]byte) {}

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -606,4 +606,4 @@ func (s *ChainService) UnrealizedJustifiedPayloadBlockHash() [32]byte {
 }
 
 // SendNewBlobEvent mocks the same method in the chain service
-func (s *ChainService) SendNewBlobEvent(_ [32]byte) {}
+func (s *ChainService) SendNewBlobEvent(_ [32]byte, _ uint64) {}

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -93,6 +93,7 @@ type config struct {
 // This defines the interface for interacting with block chain service
 type blockchainService interface {
 	blockchain.BlockReceiver
+	blockchain.BlobReceiver
 	blockchain.HeadFetcher
 	blockchain.FinalizationFetcher
 	blockchain.ForkFetcher

--- a/beacon-chain/sync/subscriber_blob_sidecar.go
+++ b/beacon-chain/sync/subscriber_blob_sidecar.go
@@ -22,5 +22,7 @@ func (s *Service) blobSubscriber(ctx context.Context, msg proto.Message) error {
 		return err
 	}
 
+	s.cfg.chain.SendNewBlobEvent([32]byte(b.Message.BlockRoot))
+
 	return nil
 }

--- a/beacon-chain/sync/subscriber_blob_sidecar.go
+++ b/beacon-chain/sync/subscriber_blob_sidecar.go
@@ -22,7 +22,7 @@ func (s *Service) blobSubscriber(ctx context.Context, msg proto.Message) error {
 		return err
 	}
 
-	s.cfg.chain.SendNewBlobEvent([32]byte(b.Message.BlockRoot))
+	s.cfg.chain.SendNewBlobEvent([32]byte(b.Message.BlockRoot), b.Message.Index)
 
 	return nil
 }


### PR DESCRIPTION
Adds a new channel to the blockchain package to keep track of blobs that have been added to database. 

It's an unbuffered channel that notifies the blob sidecar's `blockroot`. 

When processing blocks, if the blob is not in the database, we block until the channel receives the right blockroot or the slot context deadline is done. 

The channel is unbuffered since blobs are always consumed by blocks. 