### PR TITLE
local-block-value-boost flag from float64 to uint64 [BREAKING CHANGE]

### DIFF
--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -25,9 +25,10 @@ var (
 		Usage: "Number of total skip slot to fallback from using relay/builder to local execution engine for block construction in last epoch rolling window",
 		Value: 8,
 	}
-	LocalBlockValueBoost = &cli.Float64Flag{
+	// LocalBlockValueBoost sets a percentage boost for local block construction while using a custom builder.
+	LocalBlockValueBoost = &cli.Uint64Flag{
 		Name: "local-block-value-boost",
-		Usage: "A percentage boost for local block construction. This is used to prioritize local block construction over relay/builder block construction" +
+		Usage: "A percentage boost for local block construction as a Uint64. This is used to prioritize local block construction over relay/builder block construction" +
 			"Boost is an additional percentage to multiple local block value. Use builder block if: builder_bid_value * 100 > local_block_value * (local-block-value-boost + 100)",
 	}
 	// ExecutionEngineEndpoint provides an HTTP access endpoint to connect to an execution client on the execution layer


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
Other


**What does this PR do? Why is it needed?**

changing the flag type to support the correct type.
this is a breaking change and will result in an error such as the following example
` invalid value "100.30" for flag -local-block-value-boost: parse error  prefix=main`
removing the .30 will result in the correct value

prysm docs must be updated accordingly
