### PR TITLE
Enable debug endpoints by default

### DIFF
--- a/cmd/beacon-chain/flags/base.go
+++ b/cmd/beacon-chain/flags/base.go
@@ -169,6 +169,7 @@ var (
 	EnableDebugRPCEndpoints = &cli.BoolFlag{
 		Name:  "enable-debug-rpc-endpoints",
 		Usage: "Enables the debug rpc service, containing utility endpoints such as /eth/v1alpha1/beacon/state.",
+		Value: true,
 	}
 	// SubscribeToAllSubnets defines a flag to specify whether to subscribe to all possible attestation/sync subnets or not.
 	SubscribeToAllSubnets = &cli.BoolFlag{


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

From time to time we get a complain that one of the debug endpoints returns a 404 error, which is because the user forgot to set `--enable-debug-rpc-endpoints`. We are probably the only client that does not enable the debug namespace by default. Changing this will make everyone's life easier.
