### PR TITLE
re-use metadata bucket, group db constants

### DIFF
--- a/beacon-chain/db/kv/blob.go
+++ b/beacon-chain/db/kv/blob.go
@@ -243,11 +243,10 @@ func slotKey(slot types.Slot) []byte {
 
 func checkEpochsForBlobSidecarsRequestBucket(db *bolt.DB) error {
 	if err := db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket(epochsForBlobSidecarsRequestBucket)
-		k := []byte("epoch-key")
-		v := b.Get(k)
+		b := tx.Bucket(chainMetadataBucket)
+		v := b.Get(blobRetentionEpochsKey)
 		if v == nil {
-			if err := b.Put(k, bytesutil.Uint64ToBytesBigEndian(uint64(params.BeaconNetworkConfig().MinEpochsForBlobsSidecarsRequest))); err != nil {
+			if err := b.Put(blobRetentionEpochsKey, bytesutil.Uint64ToBytesBigEndian(uint64(params.BeaconNetworkConfig().MinEpochsForBlobsSidecarsRequest))); err != nil {
 				return err
 			}
 			return nil

--- a/beacon-chain/db/kv/kv.go
+++ b/beacon-chain/db/kv/kv.go
@@ -131,7 +131,6 @@ var Buckets = [][]byte{
 	registrationBucket,
 
 	blobsBucket,
-	epochsForBlobSidecarsRequestBucket,
 }
 
 // NewKVStore initializes a new boltDB key-value store at the directory

--- a/beacon-chain/db/kv/schema.go
+++ b/beacon-chain/db/kv/schema.go
@@ -8,6 +8,7 @@ package kv
 // corresponding attestations.
 var (
 	attestationsBucket      = []byte("attestations")
+	blobsBucket             = []byte("blobs")
 	blocksBucket            = []byte("blocks")
 	stateBucket             = []byte("state")
 	stateSummaryBucket      = []byte("state-summary")
@@ -46,7 +47,10 @@ var (
 	finalizedCheckpointKey     = []byte("finalized-checkpoint")
 	powchainDataKey            = []byte("powchain-data")
 	lastValidatedCheckpointKey = []byte("last-validated-checkpoint")
-	blobsBucket                = []byte("blobs")
+	// blobRetentionEpochsKey determines the size of the blob circular buffer and how the keys in that buffer are
+	// determined. If this value changes, the existing data is invalidated, so storing it in the db
+	// allows us to assert at runtime that the db state is still consistent with the runtime state.
+	blobRetentionEpochsKey = []byte("blob-retention-epochs")
 
 	// Below keys are used to identify objects are to be fork compatible.
 	// Objects that are only compatible with specific forks should be prefixed with such keys.
@@ -74,7 +78,4 @@ var (
 
 	// Migrations
 	migrationsBucket = []byte("migrations")
-
-	// Stores how long to keep the blob sidecars for.
-	epochsForBlobSidecarsRequestBucket = []byte("epochs-for-blob-sidecars-request")
 )


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
This is addresses @nisdas feedback on #12773.

**Other notes for review**
This is directly a response to Nishant's feedback, so I'll be looking for his approval before merging.

I changed from a single key bucket for the retention period to using the `chainMetadataBucket` used by other single values in the db. I prefer this pattern of consolidating all the metadata type values over adding more single-value buckets.