### PR TITLE
give deneb it's own field count config value

### DIFF
--- a/beacon-chain/state/state-native/hasher.go
+++ b/beacon-chain/state/state-native/hasher.go
@@ -34,7 +34,7 @@ func ComputeFieldRootsWithHasher(ctx context.Context, state *BeaconState) ([][]b
 	case version.Capella:
 		fieldRoots = make([][]byte, params.BeaconConfig().BeaconStateCapellaFieldCount)
 	case version.Deneb:
-		fieldRoots = make([][]byte, params.BeaconConfig().BeaconStateCapellaFieldCount) // Deneb has the same state field count as Capella.
+		fieldRoots = make([][]byte, params.BeaconConfig().BeaconStateDenebFieldCount)
 	}
 
 	// Genesis time root.

--- a/beacon-chain/state/state-native/state_trie.go
+++ b/beacon-chain/state/state-native/state_trie.go
@@ -512,7 +512,7 @@ func InitializeFromProtoUnsafeDeneb(st *ethpb.BeaconStateDeneb) (state.BeaconSta
 		mixes[i] = bytesutil.ToBytes32(m)
 	}
 
-	fieldCount := params.BeaconConfig().BeaconStateCapellaFieldCount
+	fieldCount := params.BeaconConfig().BeaconStateDenebFieldCount
 	b := &BeaconState{
 		version:                           version.Deneb,
 		genesisTime:                       st.GenesisTime,
@@ -600,7 +600,7 @@ func (b *BeaconState) Copy() state.BeaconState {
 	case version.Capella:
 		fieldCount = params.BeaconConfig().BeaconStateCapellaFieldCount
 	case version.Deneb:
-		fieldCount = params.BeaconConfig().BeaconStateCapellaFieldCount
+		fieldCount = params.BeaconConfig().BeaconStateDenebFieldCount
 	}
 
 	dst := &BeaconState{
@@ -756,7 +756,7 @@ func (b *BeaconState) initializeMerkleLayers(ctx context.Context) error {
 	case version.Capella:
 		b.dirtyFields = make(map[types.FieldIndex]bool, params.BeaconConfig().BeaconStateCapellaFieldCount)
 	case version.Deneb:
-		b.dirtyFields = make(map[types.FieldIndex]bool, params.BeaconConfig().BeaconStateCapellaFieldCount)
+		b.dirtyFields = make(map[types.FieldIndex]bool, params.BeaconConfig().BeaconStateDenebFieldCount)
 	}
 
 	return nil

--- a/config/params/config.go
+++ b/config/params/config.go
@@ -140,6 +140,7 @@ type BeaconChainConfig struct {
 	BeaconStateAltairFieldCount    int             // BeaconStateAltairFieldCount defines how many fields are in the beacon state post upgrade to Altair.
 	BeaconStateBellatrixFieldCount int             // BeaconStateBellatrixFieldCount defines how many fields are in beacon state post upgrade to Bellatrix.
 	BeaconStateCapellaFieldCount   int             // BeaconStateCapellaFieldCount defines how many fields are in beacon state post upgrade to Capella.
+	BeaconStateDenebFieldCount     int             // BeaconStateDenebFieldCount defines how many fields are in beacon state post upgrade to Deneb.
 
 	// Slasher constants.
 	WeakSubjectivityPeriod    primitives.Epoch // WeakSubjectivityPeriod defines the time period expressed in number of epochs were proof of stake network should validate block headers and attestations for slashable events.

--- a/config/params/configset_test.go
+++ b/config/params/configset_test.go
@@ -162,6 +162,7 @@ func compareConfigs(t *testing.T, expected, actual *BeaconChainConfig) {
 	require.DeepEqual(t, expected.BeaconStateAltairFieldCount, actual.BeaconStateAltairFieldCount)
 	require.DeepEqual(t, expected.BeaconStateBellatrixFieldCount, actual.BeaconStateBellatrixFieldCount)
 	require.DeepEqual(t, expected.BeaconStateCapellaFieldCount, actual.BeaconStateCapellaFieldCount)
+	require.DeepEqual(t, expected.BeaconStateDenebFieldCount, actual.BeaconStateDenebFieldCount)
 	require.DeepEqual(t, expected.WeakSubjectivityPeriod, actual.WeakSubjectivityPeriod)
 	require.DeepEqual(t, expected.PruneSlasherStoragePeriod, actual.PruneSlasherStoragePeriod)
 	require.DeepEqual(t, expected.SlashingProtectionPruningEpochs, actual.SlashingProtectionPruningEpochs)

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -199,6 +199,7 @@ var mainnetBeaconConfig = &BeaconChainConfig{
 	BeaconStateAltairFieldCount:    24,
 	BeaconStateBellatrixFieldCount: 25,
 	BeaconStateCapellaFieldCount:   28,
+	BeaconStateDenebFieldCount:     28,
 
 	// Slasher related values.
 	WeakSubjectivityPeriod:          54000,

--- a/config/params/testnet_config_test.go
+++ b/config/params/testnet_config_test.go
@@ -127,6 +127,7 @@ func compareConfigs(t *testing.T, expected, actual *params.BeaconChainConfig) {
 	require.DeepEqual(t, expected.BeaconStateAltairFieldCount, actual.BeaconStateAltairFieldCount)
 	require.DeepEqual(t, expected.BeaconStateBellatrixFieldCount, actual.BeaconStateBellatrixFieldCount)
 	require.DeepEqual(t, expected.BeaconStateCapellaFieldCount, actual.BeaconStateCapellaFieldCount)
+	require.DeepEqual(t, expected.BeaconStateDenebFieldCount, actual.BeaconStateDenebFieldCount)
 	require.DeepEqual(t, expected.WeakSubjectivityPeriod, actual.WeakSubjectivityPeriod)
 	require.DeepEqual(t, expected.PruneSlasherStoragePeriod, actual.PruneSlasherStoragePeriod)
 	require.DeepEqual(t, expected.SlashingProtectionPruningEpochs, actual.SlashingProtectionPruningEpochs)


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
Gives deneb its own field count variable (used by native state code).

**Which issues(s) does this PR fix?**

**Other notes for review**
In response to @nisdas review on https://github.com/prysmaticlabs/prysm/pull/12773 needs approval from him