### PR TITLE
Add REST implementation of node version endpoint

### DIFF
--- a/validator/client/beacon-api/beacon_api_node_client.go
+++ b/validator/client/beacon-api/beacon_api_node_client.go
@@ -75,13 +75,19 @@ func (c *beaconApiNodeClient) GetGenesis(ctx context.Context, _ *empty.Empty) (*
 	}, nil
 }
 
-func (c *beaconApiNodeClient) GetVersion(ctx context.Context, in *empty.Empty) (*ethpb.Version, error) {
-	if c.fallbackClient != nil {
-		return c.fallbackClient.GetVersion(ctx, in)
+func (c *beaconApiNodeClient) GetVersion(ctx context.Context, _ *empty.Empty) (*ethpb.Version, error) {
+	var versionResponse apimiddleware.VersionResponseJson
+	if _, err := c.jsonRestHandler.GetRestJsonResponse(ctx, "/eth/v1/node/version", &versionResponse); err != nil {
+		return nil, errors.Wrapf(err, "failed to query node version")
 	}
 
-	// TODO: Implement me
-	panic("beaconApiNodeClient.GetVersion is not implemented. To use a fallback client, pass a fallback client as the last argument of NewBeaconApiNodeClientWithFallback.")
+	if versionResponse.Data == nil || versionResponse.Data.Version == "" {
+		return nil, errors.New("empty version response")
+	}
+
+	return &ethpb.Version{
+		Version: versionResponse.Data.Version,
+	}, nil
 }
 
 func (c *beaconApiNodeClient) ListPeers(ctx context.Context, in *empty.Empty) (*ethpb.Peers, error) {


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**
It adds REST API implementation of node version endpoint to get node version of the beacon node. Refer: https://ethereum.github.io/beacon-APIs/#/Node/getNodeVersion
It is needed to use prysm specific endpoints on the VC side by using this endpoint to check if we are connected to prysm beacon node first.
