### PR TITLE
fix: add back non parallel proposer

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -19,6 +19,8 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/transition"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db/kv"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
+	"github.com/prysmaticlabs/prysm/v4/config/features"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
@@ -105,6 +107,133 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 	}
 	sBlk.SetProposerIndex(idx)
 
+	var blindBlobs []*ethpb.BlindedBlobSidecar
+	var fullBlobs []*ethpb.BlobSidecar
+	if features.Get().BuildBlockParallel {
+		blindBlobs, fullBlobs, err = vs.BuildBlockParallel(ctx, sBlk, head)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not build block in parallel")
+		}
+	} else {
+		// Set eth1 data.
+		eth1Data, err := vs.eth1DataMajorityVote(ctx, head)
+		if err != nil {
+			eth1Data = &ethpb.Eth1Data{DepositRoot: params.BeaconConfig().ZeroHash[:], BlockHash: params.BeaconConfig().ZeroHash[:]}
+			log.WithError(err).Error("Could not get eth1data")
+		}
+		sBlk.SetEth1Data(eth1Data)
+
+		// Set deposit and attestation.
+		deposits, atts, err := vs.packDepositsAndAttestations(ctx, head, eth1Data) // TODO: split attestations and deposits
+		if err != nil {
+			sBlk.SetDeposits([]*ethpb.Deposit{})
+			sBlk.SetAttestations([]*ethpb.Attestation{})
+			log.WithError(err).Error("Could not pack deposits and attestations")
+		} else {
+			sBlk.SetDeposits(deposits)
+			sBlk.SetAttestations(atts)
+		}
+
+		// Set slashings.
+		validProposerSlashings, validAttSlashings := vs.getSlashings(ctx, head)
+		sBlk.SetProposerSlashings(validProposerSlashings)
+		sBlk.SetAttesterSlashings(validAttSlashings)
+
+		// Set exits.
+		sBlk.SetVoluntaryExits(vs.getExits(head, req.Slot))
+
+		// Set sync aggregate. New in Altair.
+		vs.setSyncAggregate(ctx, sBlk)
+
+		// Get local and builder (if enabled) payloads. Set execution data. New in Bellatrix.
+		localPayload, blobsBundle, overrideBuilder, err := vs.getLocalPayloadAndBlobs(ctx, sBlk.Block(), head)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not get local payload: %v", err)
+		}
+		// There's no reason to try to get a builder bid if local override is true.
+		var builderPayload interfaces.ExecutionData
+		var blindBlobsBundle *enginev1.BlindedBlobsBundle
+		if !overrideBuilder {
+			builderPayload, blindBlobsBundle, err = vs.getBuilderPayloadAndBlobs(ctx, sBlk.Block().Slot(), sBlk.Block().ProposerIndex())
+			if err != nil {
+				builderGetPayloadMissCount.Inc()
+				log.WithError(err).Error("Could not get builder payload")
+			}
+		}
+		if err := setExecutionData(ctx, sBlk, localPayload, builderPayload); err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not set execution data: %v", err)
+		}
+
+		// Set bls to execution change. New in Capella.
+		vs.setBlsToExecData(sBlk, head)
+
+		if err := setKzgCommitments(sBlk, blobsBundle, blindBlobsBundle); err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not set kzg commitment: %v", err)
+		}
+
+		// Covert blobs bundle to sidecars.
+		fullBlobs, err = blobsBundleToSidecars(blobsBundle, sBlk.Block())
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not convert blobs bundle to sidecar: %v", err)
+		}
+		blindBlobs, err = blindBlobsBundleToSidecars(blindBlobsBundle, sBlk.Block())
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not convert blind blobs bundle to sidecar: %v", err)
+		}
+	}
+
+	sr, err := vs.computeStateRoot(ctx, sBlk)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not compute state root: %v", err)
+	}
+	sBlk.SetStateRoot(sr)
+
+	log.WithFields(logrus.Fields{
+		"slot":               req.Slot,
+		"sinceSlotStartTime": time.Since(t),
+		"validator":          sBlk.Block().ProposerIndex(),
+	}).Info("Finished building block")
+
+	pb, err := sBlk.Block().Proto()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "Could not convert block to proto: %v", err)
+	}
+	if slots.ToEpoch(req.Slot) >= params.BeaconConfig().DenebForkEpoch {
+		if sBlk.IsBlinded() {
+			blockAndBlobs := &ethpb.BlindedBeaconBlockAndBlobsDeneb{
+				Block: pb.(*ethpb.BlindedBeaconBlockDeneb),
+				Blobs: blindBlobs,
+			}
+			return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedDeneb{BlindedDeneb: blockAndBlobs}}, nil
+		}
+
+		blockAndBlobs := &ethpb.BeaconBlockAndBlobsDeneb{
+			Block: pb.(*ethpb.BeaconBlockDeneb),
+			Blobs: fullBlobs,
+		}
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Deneb{Deneb: blockAndBlobs}}, nil
+	}
+
+	if slots.ToEpoch(req.Slot) >= params.BeaconConfig().CapellaForkEpoch {
+		if sBlk.IsBlinded() {
+			return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedCapella{BlindedCapella: pb.(*ethpb.BlindedBeaconBlockCapella)}}, nil
+		}
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Capella{Capella: pb.(*ethpb.BeaconBlockCapella)}}, nil
+	}
+	if slots.ToEpoch(req.Slot) >= params.BeaconConfig().BellatrixForkEpoch {
+		if sBlk.IsBlinded() {
+			return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedBellatrix{BlindedBellatrix: pb.(*ethpb.BlindedBeaconBlockBellatrix)}}, nil
+		}
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Bellatrix{Bellatrix: pb.(*ethpb.BeaconBlockBellatrix)}}, nil
+	}
+	if slots.ToEpoch(req.Slot) >= params.BeaconConfig().AltairForkEpoch {
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Altair{Altair: pb.(*ethpb.BeaconBlockAltair)}}, nil
+	}
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Phase0{Phase0: pb.(*ethpb.BeaconBlock)}}, nil
+}
+
+func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.SignedBeaconBlock, head state.BeaconState) ([]*ethpb.BlindedBlobSidecar, []*ethpb.BlobSidecar, error) {
+	// Build consensus fields in background
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
@@ -146,12 +275,13 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 
 	localPayload, blobsBundle, overrideBuilder, err := vs.getLocalPayloadAndBlobs(ctx, sBlk.Block(), head)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not get local payload: %v", err)
+		return nil, nil, status.Errorf(codes.Internal, "Could not get local payload: %v", err)
 	}
 
 	// There's no reason to try to get a builder bid if local override is true.
 	var builderPayload interfaces.ExecutionData
 	var blindBlobsBundle *enginev1.BlindedBlobsBundle
+	var blindBlobs []*ethpb.BlindedBlobSidecar
 	if !overrideBuilder {
 		builderPayload, blindBlobsBundle, err = vs.getBuilderPayloadAndBlobs(ctx, sBlk.Block().Slot(), sBlk.Block().ProposerIndex())
 		if err != nil {
@@ -161,71 +291,25 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 	}
 
 	if err := setExecutionData(ctx, sBlk, localPayload, builderPayload); err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not set execution data: %v", err)
+		return nil, nil, status.Errorf(codes.Internal, "Could not set execution data: %v", err)
 	}
 
 	if err := setKzgCommitments(sBlk, blobsBundle, blindBlobsBundle); err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not set kzg commitment: %v", err)
+		return nil, nil, status.Errorf(codes.Internal, "Could not set kzg commitment: %v", err)
+	}
+
+	fullBlobs, err := blobsBundleToSidecars(blobsBundle, sBlk.Block())
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "Could not convert blobs bundle to sidecar: %v", err)
+	}
+	blindBlobs, err = blindBlobsBundleToSidecars(blindBlobsBundle, sBlk.Block())
+	if err != nil {
+		return nil, nil, status.Errorf(codes.Internal, "Could not convert blind blobs bundle to sidecar: %v", err)
 	}
 
 	wg.Wait() // Wait until block is built via consensus and execution fields.
 
-	sr, err := vs.computeStateRoot(ctx, sBlk)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not compute state root: %v", err)
-	}
-	sBlk.SetStateRoot(sr)
-
-	log.WithFields(logrus.Fields{
-		"slot":               req.Slot,
-		"sinceSlotStartTime": time.Since(t),
-		"validator":          sBlk.Block().ProposerIndex(),
-	}).Info("Finished building block")
-
-	pb, err := sBlk.Block().Proto()
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not convert block to proto: %v", err)
-	}
-	if slots.ToEpoch(req.Slot) >= params.BeaconConfig().DenebForkEpoch {
-		if sBlk.IsBlinded() {
-			scs, err := blindBlobsBundleToSidecars(blindBlobsBundle, sBlk.Block())
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "Could not convert blind blobs bundle to sidecar: %v", err)
-			}
-			blockAndBlobs := &ethpb.BlindedBeaconBlockAndBlobsDeneb{
-				Block: pb.(*ethpb.BlindedBeaconBlockDeneb),
-				Blobs: scs,
-			}
-			return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedDeneb{BlindedDeneb: blockAndBlobs}}, nil
-		}
-
-		scs, err := blobsBundleToSidecars(blobsBundle, sBlk.Block())
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "Could not convert blobs bundle to sidecar: %v", err)
-		}
-		blockAndBlobs := &ethpb.BeaconBlockAndBlobsDeneb{
-			Block: pb.(*ethpb.BeaconBlockDeneb),
-			Blobs: scs,
-		}
-		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Deneb{Deneb: blockAndBlobs}}, nil
-	}
-
-	if slots.ToEpoch(req.Slot) >= params.BeaconConfig().CapellaForkEpoch {
-		if sBlk.IsBlinded() {
-			return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedCapella{BlindedCapella: pb.(*ethpb.BlindedBeaconBlockCapella)}}, nil
-		}
-		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Capella{Capella: pb.(*ethpb.BeaconBlockCapella)}}, nil
-	}
-	if slots.ToEpoch(req.Slot) >= params.BeaconConfig().BellatrixForkEpoch {
-		if sBlk.IsBlinded() {
-			return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedBellatrix{BlindedBellatrix: pb.(*ethpb.BlindedBeaconBlockBellatrix)}}, nil
-		}
-		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Bellatrix{Bellatrix: pb.(*ethpb.BeaconBlockBellatrix)}}, nil
-	}
-	if slots.ToEpoch(req.Slot) >= params.BeaconConfig().AltairForkEpoch {
-		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Altair{Altair: pb.(*ethpb.BeaconBlockAltair)}}, nil
-	}
-	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Phase0{Phase0: pb.(*ethpb.BeaconBlock)}}, nil
+	return blindBlobs, fullBlobs, nil
 }
 
 // ProposeBeaconBlock is called by a proposer during its assigned slot to create a block in an attempt

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deneb.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deneb.go
@@ -30,6 +30,12 @@ func setKzgCommitments(blk interfaces.SignedBeaconBlock, bundle *enginev1.BlobsB
 
 // coverts a blobs bundle to a sidecar format.
 func blobsBundleToSidecars(bundle *enginev1.BlobsBundle, blk interfaces.ReadOnlyBeaconBlock) ([]*ethpb.BlobSidecar, error) {
+	if blk.Version() < version.Deneb {
+		return nil, nil
+	}
+	if bundle == nil || len(bundle.KzgCommitments) == 0 {
+		return nil, nil
+	}
 	r, err := blk.HashTreeRoot()
 	if err != nil {
 		return nil, err
@@ -55,6 +61,12 @@ func blobsBundleToSidecars(bundle *enginev1.BlobsBundle, blk interfaces.ReadOnly
 
 // coverts a blinds blobs bundle to a sidecar format.
 func blindBlobsBundleToSidecars(bundle *enginev1.BlindedBlobsBundle, blk interfaces.ReadOnlyBeaconBlock) ([]*ethpb.BlindedBlobSidecar, error) {
+	if blk.Version() < version.Deneb {
+		return nil, nil
+	}
+	if bundle == nil || len(bundle.KzgCommitments) == 0 {
+		return nil, nil
+	}
 	r, err := blk.HashTreeRoot()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR reinstates the option to disable build block parallel. While it's currently enabled by default, the `deneb-integration` removed this feature for major release assumption and simplicity. Since we're merging `deneb-integration` into `develop`, the fallback should be retained.




