### PR TITLE
beacon-chain/execution: use pointer instead of value to reduce copy

### DIFF
--- a/beacon-chain/execution/log_processing_test.go
+++ b/beacon-chain/execution/log_processing_test.go
@@ -79,7 +79,7 @@ func TestProcessDepositLog_OK(t *testing.T) {
 		t.Fatal("no logs")
 	}
 
-	err = web3Service.ProcessLog(context.Background(), logs[0])
+	err = web3Service.ProcessLog(context.Background(), &logs[0])
 	require.NoError(t, err)
 
 	require.LogsDoNotContain(t, hook, "Could not unpack log")
@@ -149,9 +149,9 @@ func TestProcessDepositLog_InsertsPendingDeposit(t *testing.T) {
 
 	web3Service.chainStartData.Chainstarted = true
 
-	err = web3Service.ProcessDepositLog(context.Background(), logs[0])
+	err = web3Service.ProcessDepositLog(context.Background(), &logs[0])
 	require.NoError(t, err)
-	err = web3Service.ProcessDepositLog(context.Background(), logs[1])
+	err = web3Service.ProcessDepositLog(context.Background(), &logs[1])
 	require.NoError(t, err)
 
 	pendingDeposits := web3Service.cfg.depositCache.PendingDeposits(context.Background(), nil /*blockNum*/)
@@ -272,8 +272,8 @@ func TestProcessETH2GenesisLog_8DuplicatePubkeys(t *testing.T) {
 	logs, err := testAcc.Backend.FilterLogs(web3Service.ctx, query)
 	require.NoError(t, err, "Unable to retrieve logs")
 
-	for _, log := range logs {
-		err = web3Service.ProcessLog(context.Background(), log)
+	for i := range logs {
+		err = web3Service.ProcessLog(context.Background(), &logs[i])
 		require.NoError(t, err)
 	}
 	assert.Equal(t, false, web3Service.chainStartData.Chainstarted, "Genesis has been triggered despite being 8 duplicate keys")
@@ -351,8 +351,8 @@ func TestProcessETH2GenesisLog(t *testing.T) {
 	stateSub := web3Service.cfg.stateNotifier.StateFeed().Subscribe(stateChannel)
 	defer stateSub.Unsubscribe()
 
-	for _, log := range logs {
-		err = web3Service.ProcessLog(context.Background(), log)
+	for i := range logs {
+		err = web3Service.ProcessLog(context.Background(), &logs[i])
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other(improvement)

**What does this PR do? Why is it needed?**

In prysm's heap profile, I see a lot of memory(14%) is hold inside the `ProcessLog`  

<img width="1829" alt="image" src="https://github.com/prysmaticlabs/prysm/assets/3627395/3b9ab7a8-714e-43b5-abca-c1752f47e9d6">

And after some digging, seems it was caused by the value copy


