### PR TITLE
Holesky support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -313,6 +313,22 @@ filegroup(
 )
 
 http_archive(
+    name = "holesky_testnet",
+    build_file_content = """
+filegroup(
+    name = "configs",
+    srcs = [
+        "custom_config_data/config.yaml",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
+    sha256 = "4116c8acb54eb3ca28cc4dc9bc688e08e25da91d70ed1f2622f02d3c33eba922",
+    strip_prefix = "holesky-76057d57ab1f585519ecb606a9e5f7780e925a37",
+    url = "https://github.com/eth-clients/holesky/archive/76057d57ab1f585519ecb606a9e5f7780e925a37.tar.gz",  # Aug 27, 2023
+)
+
+http_archive(
     name = "com_google_protobuf",
     sha256 = "4e176116949be52b0408dfd24f8925d1eb674a781ae242a75296b17a1c721395",
     strip_prefix = "protobuf-23.3",

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -212,6 +212,11 @@ func New(cliCtx *cli.Context, opts ...Option) (*BeaconNode, error) {
 
 	log.Debugln("Starting State Gen")
 	if err := beacon.startStateGen(ctx, bfs, beacon.forkChoicer); err != nil {
+		if errors.Is(err, stategen.ErrNoGenesisBlock) {
+			log.Errorf("No genesis block/state is found. Prysm only provides a mainnet genesis "+
+				"state bundled in the application. You must provide the --%s or --%s flag to load "+
+				"a genesis block/state for this network.", "genesis-state", "genesis-beacon-api-url")
+		}
 		return nil, err
 	}
 

--- a/beacon-chain/state/stategen/errors.go
+++ b/beacon-chain/state/stategen/errors.go
@@ -8,3 +8,6 @@ var errUnknownBlock = errors.New("unknown block")
 
 // errNilState returns when we have obtained a nil state from stategen
 var errNilState = errors.New("nil state from stategen")
+
+// ErrNoGenesisBlock is returned when no genesis block is available.
+var ErrNoGenesisBlock = errors.New("could not get genesis block root")

--- a/beacon-chain/state/stategen/getter.go
+++ b/beacon-chain/state/stategen/getter.go
@@ -2,6 +2,7 @@ package stategen
 
 import (
 	"context"
+	stderrors "errors"
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
@@ -58,7 +59,7 @@ func (s *State) StateByRoot(ctx context.Context, blockRoot [32]byte) (state.Beac
 	if blockRoot == params.BeaconConfig().ZeroHash {
 		root, err := s.beaconDB.GenesisBlockRoot(ctx)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not get genesis block root")
+			return nil, stderrors.Join(ErrNoGenesisBlock, err)
 		}
 		blockRoot = root
 	}

--- a/beacon-chain/state/stategen/service.go
+++ b/beacon-chain/state/stategen/service.go
@@ -5,6 +5,7 @@ package stategen
 
 import (
 	"context"
+	stderrors "errors"
 	"sync"
 	"time"
 
@@ -125,7 +126,7 @@ func (s *State) Resume(ctx context.Context, fState state.BeaconState) (state.Bea
 		// Save genesis state in the hot state cache.
 		gbr, err := s.beaconDB.GenesisBlockRoot(ctx)
 		if err != nil {
-			return nil, errors.Wrap(err, "could not get genesis block root")
+			return nil, stderrors.Join(ErrNoGenesisBlock, err)
 		}
 		return st, s.SaveState(ctx, gbr, st)
 	}

--- a/cmd/beacon-chain/main.go
+++ b/cmd/beacon-chain/main.go
@@ -288,7 +288,7 @@ func startNode(ctx *cli.Context) error {
 
 	beacon, err := node.New(ctx, opts...)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to start beacon node: %w", err)
 	}
 	beacon.Start()
 	return nil

--- a/cmd/prysmctl/validator/cmd.go
+++ b/cmd/prysmctl/validator/cmd.go
@@ -169,6 +169,7 @@ var Commands = []*cli.Command{
 					features.Mainnet,
 					features.PraterTestnet,
 					features.SepoliaTestnet,
+					features.HoleskyTestnet,
 					cmd.AcceptTosFlag,
 				}),
 				Before: func(cliCtx *cli.Context) error {

--- a/cmd/validator/accounts/accounts.go
+++ b/cmd/validator/accounts/accounts.go
@@ -29,6 +29,7 @@ var Commands = &cli.Command{
 				features.Mainnet,
 				features.PraterTestnet,
 				features.SepoliaTestnet,
+				features.HoleskyTestnet,
 				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
@@ -65,6 +66,7 @@ var Commands = &cli.Command{
 				features.Mainnet,
 				features.PraterTestnet,
 				features.SepoliaTestnet,
+				features.HoleskyTestnet,
 				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
@@ -98,6 +100,7 @@ var Commands = &cli.Command{
 				features.Mainnet,
 				features.PraterTestnet,
 				features.SepoliaTestnet,
+				features.HoleskyTestnet,
 				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
@@ -128,6 +131,7 @@ var Commands = &cli.Command{
 				features.Mainnet,
 				features.PraterTestnet,
 				features.SepoliaTestnet,
+				features.HoleskyTestnet,
 				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
@@ -170,6 +174,7 @@ var Commands = &cli.Command{
 				features.Mainnet,
 				features.PraterTestnet,
 				features.SepoliaTestnet,
+				features.HoleskyTestnet,
 				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {

--- a/cmd/validator/slashing-protection/slashing-protection.go
+++ b/cmd/validator/slashing-protection/slashing-protection.go
@@ -24,6 +24,7 @@ var Commands = &cli.Command{
 				features.Mainnet,
 				features.PraterTestnet,
 				features.SepoliaTestnet,
+				features.HoleskyTestnet,
 				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
@@ -51,6 +52,7 @@ var Commands = &cli.Command{
 				features.Mainnet,
 				features.PraterTestnet,
 				features.SepoliaTestnet,
+				features.HoleskyTestnet,
 				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {

--- a/cmd/validator/wallet/wallet.go
+++ b/cmd/validator/wallet/wallet.go
@@ -33,6 +33,7 @@ var Commands = &cli.Command{
 				features.Mainnet,
 				features.PraterTestnet,
 				features.SepoliaTestnet,
+				features.HoleskyTestnet,
 				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {
@@ -64,6 +65,7 @@ var Commands = &cli.Command{
 				features.Mainnet,
 				features.PraterTestnet,
 				features.SepoliaTestnet,
+				features.HoleskyTestnet,
 				cmd.AcceptTosFlag,
 			}),
 			Before: func(cliCtx *cli.Context) error {

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -133,6 +133,13 @@ func configureTestnet(ctx *cli.Context) error {
 		}
 		applySepoliaFeatureFlags(ctx)
 		params.UseSepoliaNetworkConfig()
+	} else if ctx.Bool(HoleskyTestnet.Name) {
+		log.Warn("Running on the Holesky Beacon Chain Testnet")
+		if err := params.SetActive(params.HoleskyConfig().Copy()); err != nil {
+			return err
+		}
+		applyHoleskyFeatureFlags(ctx)
+		params.UseHoleskyNetworkConfig()
 	} else {
 		if ctx.IsSet(cmd.ChainConfigFileFlag.Name) {
 			log.Warn("Running on custom Ethereum network specified in a chain configuration yaml file")
@@ -152,6 +159,10 @@ func applyPraterFeatureFlags(ctx *cli.Context) {
 
 // Insert feature flags within the function to be enabled for Sepolia testnet.
 func applySepoliaFeatureFlags(ctx *cli.Context) {
+}
+
+// Insert feature flags within the function to be enabled for Holesky testnet.
+func applyHoleskyFeatureFlags(ctx *cli.Context) {
 }
 
 // ConfigureBeaconChain sets the global config based

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -18,6 +18,11 @@ var (
 		Name:  "sepolia",
 		Usage: "Run Prysm configured for the Sepolia beacon chain test network",
 	}
+	// HoleskyTestnet flag for the multiclient Ethereum consensus testnet.
+	HoleskyTestnet = &cli.BoolFlag{
+		Name:  "holesky",
+		Usage: "Run Prysm configured for the Holesky beacon chain test network",
+	}
 	// Mainnet flag for easier tooling, no-op
 	Mainnet = &cli.BoolFlag{
 		Value: true,
@@ -171,6 +176,7 @@ var devModeFlags = []cli.Flag{
 var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	writeWalletPasswordOnWebOnboarding,
 	enableExternalSlasherProtectionFlag,
+	HoleskyTestnet,
 	PraterTestnet,
 	SepoliaTestnet,
 	Mainnet,
@@ -191,6 +197,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	devModeFlag,
 	writeSSZStateTransitionsFlag,
 	disableGRPCConnectionLogging,
+	HoleskyTestnet,
 	PraterTestnet,
 	SepoliaTestnet,
 	Mainnet,
@@ -225,4 +232,5 @@ var NetworkFlags = []cli.Flag{
 	Mainnet,
 	PraterTestnet,
 	SepoliaTestnet,
+	HoleskyTestnet,
 }

--- a/config/params/BUILD.bazel
+++ b/config/params/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "minimal_config.go",
         "network_config.go",
         "testnet_e2e_config.go",
+        "testnet_holesky_config.go",
         "testnet_prater_config.go",
         "testnet_sepolia_config.go",
         "testutils.go",
@@ -47,6 +48,7 @@ go_test(
         "configset_test.go",
         "loader_test.go",
         "testnet_config_test.go",
+        "testnet_holesky_config_test.go",
         "testnet_prater_config_test.go",
     ],
     data = glob(["*.yaml"]) + [
@@ -55,6 +57,7 @@ go_test(
         "@consensus_spec_tests_mainnet//:test_data",
         "@consensus_spec_tests_minimal//:test_data",
         "@eth2_networks//:configs",
+        "@holesky_testnet//:configs",
     ],
     embed = [":go_default_library"],
     gotags = ["develop"],

--- a/config/params/testnet_holesky_config.go
+++ b/config/params/testnet_holesky_config.go
@@ -1,0 +1,43 @@
+package params
+
+import "math"
+
+// UseHoleskyNetworkConfig uses the Holesky beacon chain specific network config.
+func UseHoleskyNetworkConfig() {
+	cfg := BeaconNetworkConfig().Copy()
+	cfg.ContractDeploymentBlock = 0
+	cfg.BootstrapNodes = []string{
+		// EF
+		"enr:-Iq4QJk4WqRkjsX5c2CXtOra6HnxN-BMXnWhmhEQO9Bn9iABTJGdjUOurM7Btj1ouKaFkvTRoju5vz2GPmVON2dffQKGAX53x8JigmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk",
+		"enr:-KG4QMH842KsJOZAHxI98VJcf8oPr1U8Ylyp2Tb-sNAPniWSCaxIS4F9gc3lGOnROEok7g5qrOm8WgJTl2WXx8MhMmIMhGV0aDKQqX6DZjABcAAKAAAAAAAAAIJpZIJ2NIJpcISygIjpiXNlY3AyNTZrMaECvQMvoDF46BfJgvAbbv1hwpNu9VQBXRIpHS_B8zmkZmmDdGNwgiMog3VkcIIjKA",
+		"enr:-Ly4QDU8tZeygxz1gEeAD4EKe4H_8gg-IanpTY6h8A1YGPv5BPNvCMD77zjHUk_iF1pfG_8DC6jYWbIOD1k5kF-LaG4Bh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCpfoNmMAFwAAoAAAAAAAAAgmlkgnY0gmlwhJK-DYCJc2VjcDI1NmsxoQN4bUae9DwIcq_56DNztksQYXeddTDKRonI5qI3YhN4SohzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA",
+		// Teku
+		"enr:-LK4QMlzEff6d-M0A1pSFG5lJ2c56i_I-ZftdojZbW3ehkGNM4pkQuHQqzVvF1BG9aDjIakjnmO23mCBFFZ2w5zOsugEh2F0dG5ldHOIAAAAAAYAAACEZXRoMpCpfoNmMAFwAAABAAAAAAAAgmlkgnY0gmlwhKyuI_mJc2VjcDI1NmsxoQIH1kQRCZW-4AIVyAeXj5o49m_IqNFKRHp6tSpfXMUrSYN0Y3CCIyiDdWRwgiMo",
+	}
+	OverrideBeaconNetworkConfig(cfg)
+}
+
+// HoleskyConfig defines the config for the Holesky beacon chain testnet.
+func HoleskyConfig() *BeaconChainConfig {
+	cfg := MainnetConfig().Copy()
+	cfg.MinGenesisTime = 1694786100
+	cfg.GenesisDelay = 300
+	cfg.ConfigName = HoleskyName
+	cfg.GenesisForkVersion = []byte{0x00, 0x01, 0x70, 0x00}
+	cfg.SecondsPerETH1Block = 14
+	cfg.DepositChainID = 17000
+	cfg.DepositNetworkID = 17000
+	cfg.AltairForkEpoch = 0
+	cfg.AltairForkVersion = []byte{0x10, 0x1, 0x70, 0x0}
+	cfg.BellatrixForkEpoch = 0
+	cfg.BellatrixForkVersion = []byte{0x20, 0x1, 0x70, 0x0}
+	cfg.CapellaForkEpoch = 256
+	cfg.CapellaForkVersion = []byte{0x30, 0x1, 0x70, 0x0}
+	cfg.DenebForkEpoch = math.MaxUint64
+	cfg.DenebForkVersion = []byte{0x40, 0x1, 0x70, 0x0}
+	cfg.TerminalTotalDifficulty = "0"
+	cfg.DepositContractAddress = "0x4242424242424242424242424242424242424242"
+	cfg.EjectionBalance = 28000000000
+	cfg.InitializeForkSchedule()
+	return cfg
+}

--- a/config/params/testnet_holesky_config_test.go
+++ b/config/params/testnet_holesky_config_test.go
@@ -1,0 +1,28 @@
+package params_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/prysmaticlabs/prysm/v4/config/params"
+	"github.com/prysmaticlabs/prysm/v4/testing/require"
+)
+
+func TestHoleskyConfigMatchesUpstreamYaml(t *testing.T) {
+	presetFPs := presetsFilePath(t, "mainnet")
+	mn, err := params.ByName(params.MainnetName)
+	require.NoError(t, err)
+	cfg := mn.Copy()
+	for _, fp := range presetFPs {
+		cfg, err = params.UnmarshalConfigFile(fp, cfg)
+		require.NoError(t, err)
+	}
+	fPath, err := bazel.Runfile("external/holesky_testnet")
+	require.NoError(t, err)
+	configFP := path.Join(fPath, "custom_config_data", "config.yaml")
+	pcfg, err := params.UnmarshalConfigFile(configFP, nil)
+	require.NoError(t, err)
+	fields := fieldsFromYamls(t, append(presetFPs, configFP))
+	assertYamlFieldsMatch(t, "holesky", fields, pcfg, params.HoleskyConfig())
+}

--- a/config/params/values.go
+++ b/config/params/values.go
@@ -11,4 +11,5 @@ const (
 	PraterName          = "prater"
 	GoerliName          = "goerli"
 	SepoliaName         = "sepolia"
+	HoleskyName         = "holesky"
 )


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Adds holesky config support for the upcoming holesky testnet.

The holesky genesis state is far too large to bundle inside of the prysm distribution binary (200Mb) so it must be loaded from disk or checkpoint sync. This is existing behavior for other testnets, but I felt it would be helpful to provide a meaningful failure message when the user attempts to run prysm on a non-mainnet network. 

**Which issues(s) does this PR fix?**

#12724

**Other notes for review**

Example of running Prysm without a genesis state

```
[2023-08-28 11:37:34]  WARN flags: Running on the Holesky Beacon Chain Testnet
[2023-08-28 11:37:34]  WARN node: In order to receive transaction fees from proposing blocks, you must provide flag --suggested-fee-recipient with a valid ethereum address when starting your beacon node. Please see our documentation for more information on this requirement (https://docs.prylabs.network/docs/execution-node/fee-recipient).
[2023-08-28 11:37:34]  INFO node: Checking DB database-path=/tmp/data/beaconchaindata
[2023-08-28 11:37:34]  INFO db: Opening Bolt DB at /tmp/data/beaconchaindata/beaconchain.db
[2023-08-28 11:37:34]  INFO node: Deposit contract: 0x4242424242424242424242424242424242424242
[2023-08-28 11:37:34] ERROR node: No genesis block/state is found. Prysm only provides a mainnet genesis state bundled in the application. You must provide the --genesis-state or --genesis-beacon-api-url flag to load a genesis block/state for this network.
unable to start beacon node: could not get genesis block root
OriginGenesisRoot: not found in db
```
