### PR TITLE
Include Validation Error in ForkchoiceUpdatedResponse

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -77,8 +77,9 @@ const (
 // ForkchoiceUpdatedResponse is the response kind received by the
 // engine_forkchoiceUpdatedV1 endpoint.
 type ForkchoiceUpdatedResponse struct {
-	Status    *pb.PayloadStatus  `json:"payloadStatus"`
-	PayloadId *pb.PayloadIDBytes `json:"payloadId"`
+	Status          *pb.PayloadStatus  `json:"payloadStatus"`
+	PayloadId       *pb.PayloadIDBytes `json:"payloadId"`
+	ValidationError string             `json:"validationError"`
 }
 
 // ExecutionPayloadReconstructor defines a service that can reconstruct a full beacon
@@ -205,6 +206,9 @@ func (s *Service) ForkchoiceUpdated(
 
 	if result.Status == nil {
 		return nil, nil, ErrNilResponse
+	}
+	if result.ValidationError != "" {
+		log.WithError(errors.New(result.ValidationError)).Error("Got a validation error in forkChoiceUpdated")
 	}
 	resp := result.Status
 	switch resp.Status {


### PR DESCRIPTION
The engine API specification states under [here](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#specification-1) that a forkchoiceUpdatedResponse can include a validationError field which we are ignoring:

{payloadStatus: {status: INVALID, latestValidHash: validHash, validationError: errorMessage | null}, payloadId: null} 

obtained from the [Payload validation](https://github.com/ethereum/execution-apis/blob/main/src/engine/paris.md#payload-validation) process if the payload is deemed INVALID