### PR TITLE
wrap ctx.Err, not the random last value of err

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -566,7 +566,7 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 				return kzg.IsDataAvailable(kzgCommitments, sidecars)
 			}
 		case <-ctx.Done():
-			return errors.Wrap(err, "context deadline waiting for blob sidecars")
+			return errors.Wrap(ctx.Err(), "context deadline waiting for blob sidecars")
 		}
 	}
 }


### PR DESCRIPTION

**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
fixes a small bug where we wrap the wrong value for err in the slot context deadline.
