### PR TITLE
add a RW lock for duties

### DIFF
--- a/validator/client/attest.go
+++ b/validator/client/attest.go
@@ -182,6 +182,8 @@ func (v *validator) SubmitAttestation(ctx context.Context, slot primitives.Slot,
 
 // Given the validator public key, this gets the validator assignment.
 func (v *validator) duty(pubKey [fieldparams.BLSPubkeyLength]byte) (*ethpb.DutiesResponse_Duty, error) {
+	v.dutiesLock.RLock()
+	defer v.dutiesLock.RUnlock()
 	if v.duties == nil {
 		return nil, errors.New("no duties for validators")
 	}

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -752,12 +752,10 @@ func (v *validator) RolesAt(ctx context.Context, slot primitives.Slot) (map[[fie
 		// the validator checks whether it's in the sync committee of following epoch.
 		inSyncCommittee := false
 		if slots.IsEpochEnd(slot) {
-			v.dutiesLock.RLock()
 			if v.duties.NextEpochDuties[validator].IsSyncCommittee {
 				roles = append(roles, iface.RoleSyncCommittee)
 				inSyncCommittee = true
 			}
-			v.dutiesLock.RUnlock()
 		} else {
 			if duty.IsSyncCommittee {
 				roles = append(roles, iface.RoleSyncCommittee)

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -78,6 +78,7 @@ type validator struct {
 	walletInitializedFeed              *event.Feed
 	attLogs                            map[[32]byte]*attSubmitted
 	startBalances                      map[[fieldparams.BLSPubkeyLength]byte]uint64
+	dutiesLock                         sync.RWMutex
 	duties                             *ethpb.DutiesResponse
 	prevBalance                        map[[fieldparams.BLSPubkeyLength]byte]uint64
 	pubkeyToValidatorIndex             map[[fieldparams.BLSPubkeyLength]byte]primitives.ValidatorIndex
@@ -601,6 +602,8 @@ func (v *validator) UpdateDuties(ctx context.Context, slot primitives.Slot) erro
 	// If duties is nil it means we have had no prior duties and just started up.
 	resp, err := v.validatorClient.GetDuties(ctx, req)
 	if err != nil {
+		v.dutiesLock.Lock()
+		defer v.dutiesLock.Unlock()
 		v.duties = nil // Clear assignments so we know to retry the request.
 		log.Error(err)
 		return err
@@ -616,8 +619,10 @@ func (v *validator) UpdateDuties(ctx context.Context, slot primitives.Slot) erro
 		return ErrValidatorsAllExited
 	}
 
+	v.dutiesLock.Lock()
 	v.duties = resp
 	v.logDuties(slot, v.duties.CurrentEpochDuties, v.duties.NextEpochDuties)
+	v.dutiesLock.Unlock()
 
 	// Non-blocking call for beacon node to start subscriptions for aggregators.
 	// Make sure to copy metadata into a new context
@@ -713,6 +718,8 @@ func (v *validator) subscribeToSubnets(ctx context.Context, res *ethpb.DutiesRes
 // validator is known to not have a roles at the slot. Returns UNKNOWN if the
 // validator assignments are unknown. Otherwise returns a valid ValidatorRole map.
 func (v *validator) RolesAt(ctx context.Context, slot primitives.Slot) (map[[fieldparams.BLSPubkeyLength]byte][]iface.ValidatorRole, error) {
+	v.dutiesLock.RLock()
+	defer v.dutiesLock.RUnlock()
 	rolesAt := make(map[[fieldparams.BLSPubkeyLength]byte][]iface.ValidatorRole)
 	for validator, duty := range v.duties.Duties {
 		var roles []iface.ValidatorRole
@@ -745,10 +752,12 @@ func (v *validator) RolesAt(ctx context.Context, slot primitives.Slot) (map[[fie
 		// the validator checks whether it's in the sync committee of following epoch.
 		inSyncCommittee := false
 		if slots.IsEpochEnd(slot) {
+			v.dutiesLock.RLock()
 			if v.duties.NextEpochDuties[validator].IsSyncCommittee {
 				roles = append(roles, iface.RoleSyncCommittee)
 				inSyncCommittee = true
 			}
+			v.dutiesLock.RUnlock()
 		} else {
 			if duty.IsSyncCommittee {
 				roles = append(roles, iface.RoleSyncCommittee)

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -603,9 +603,9 @@ func (v *validator) UpdateDuties(ctx context.Context, slot primitives.Slot) erro
 	resp, err := v.validatorClient.GetDuties(ctx, req)
 	if err != nil {
 		v.dutiesLock.Lock()
-		defer v.dutiesLock.Unlock()
 		v.duties = nil // Clear assignments so we know to retry the request.
-		log.Error(err)
+		v.dutiesLock.Unlock()
+		log.WithError(err).Error("error getting validator duties")
 		return err
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
> Bug fix


**What does this PR do? Why is it needed?**

This PR adds a RW lock for modifying and accessing the `duties` struct in the `validator` struct. Together with the [antithesis](https://antithesis.com/) team we discovered a race condition where two go routines are trying to access the same memory location related to the `v.duties` struct. The race condition can lead to a panic exiting the validator process.

**Which issues(s) does this PR fix?**

The data race before the panic:
```
[ 1320810] [  1667.682068] [service_prysm-geth-0--prysm-vc]             [I] WARNING: DATA RACE
[ 1320810] [  1667.682078] [service_prysm-geth-0--prysm-vc]             [I] Read at 0x00c0003778f8 by goroutine 1235:
[ 1320810] [  1667.682088] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.(*validator).duty()
[ 1320810] [  1667.682088] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/attest.go:271 +0xde
[ 1320810] [  1667.682094] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.(*validator).SubmitSignedContributionAndProof()
[ 1320810] [  1667.682094] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/sync_committee.go:126 +0x2c4
[ 1320810] [  1667.682100] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.performRoles.func1()
[ 1320810] [  1667.682100] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/runner.go:345 +0x584
[ 1320810] [  1667.682105] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.performRoles.func3()
[ 1320810] [  1667.682105] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/runner.go:353 +0xa1
[ 1320810] [  1667.683551] [service_prysm-geth-0--prysm-vc]             [I] Previous write at 0x00c0003778f8 by goroutine 249:
[ 1320810] [  1667.683556] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.(*validator).UpdateDuties()
[ 1320810] [  1667.683556] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/validator.go:845 +0xac4
[ 1320810] [  1667.683562] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.run()
[ 1320810] [  1667.683562] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/runner.go:121 +0x1418
[ 1320810] [  1667.683567] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.(*ValidatorService).Start.func1()
[ 1320810] [  1667.683567] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/service.go:250 +0x64
[ 1320810] [  1667.683578] [service_prysm-geth-0--prysm-vc]             [I] Goroutine 1235 (running) created at:
[ 1320810] [  1667.683583] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.performRoles()
[ 1320810] [  1667.683583] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/runner.go:327 +0x37e
[ 1320810] [  1667.683589] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.run()
[ 1320810] [  1667.683589] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/runner.go:174 +0x1a31
[ 1320810] [  1667.683594] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.(*ValidatorService).Start.func1()
[ 1320810] [  1667.683594] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/service.go:250 +0x64
[ 1320810] [  1667.683605] [service_prysm-geth-0--prysm-vc]             [I] Goroutine 249 (running) created at:
[ 1320810] [  1667.683610] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.(*ValidatorService).Start()
[ 1320810] [  1667.683610] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/service.go:250 +0x14ee
[ 1320810] [  1667.683616] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/runtime.(*ServiceRegistry).StartAll.func1()
[ 1320810] [  1667.683616] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/runtime/service_registry.go:42 +0x48
[ 1320810] [  1667.683621] [service_prysm-geth-0--prysm-vc]             [I] ==================
```

The panic (The log lines are off because of the instrumentation added): 
```
[ 1320810] [  1667.724495] [service_prysm-geth-0--prysm-vc]             [I] panic: runtime error: invalid memory address or nil pointer dereference
[ 1320810] [  1667.724538] [service_prysm-geth-0--prysm-vc]             [I] [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x232ab10]
[ 1320810] [  1667.724567] [service_prysm-geth-0--prysm-vc]             [I] goroutine 1234 [running]:
[ 1320810] [  1667.725164] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.(*validator).duty(0xc000377880, {0xb2, 0x12, 0x4e, 0x1b, 0x55, 0x43, 0x13, 0x17, 0xe2, ...})
[ 1320810] [  1667.725197] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/attest.go:271 +0xf0
[ 1320810] [  1667.725821] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.(*validator).SubmitSignedContributionAndProof(0xc000377880, {0x3006c00, 0xc000c1cf00}, 0x5f, {0xb2, 0x12, 0x4e, 0x1b, 0x55, 0x43, ...})
[ 1320810] [  1667.725855] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/sync_committee.go:126 +0x2c5
[ 1320810] [  1667.726443] [service_prysm-geth-0--prysm-vc]             [I] github.com/prysmaticlabs/prysm/v4/validator/client.performRoles.func1(0x5, {0xb2, 0x12, 0x4e, 0x1b, 0x55, 0x43, 0x13, 0x17, 0xe2, ...})
[ 1320810] [  1667.726476] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/runner.go:345 +0x585
[ 1320810] [  1667.726491] [service_prysm-geth-0--prysm-vc]             [I] created by github.com/prysmaticlabs/prysm/v4/validator/client.performRoles
[ 1320810] [  1667.726525] [service_prysm-geth-0--prysm-vc]             [I] /git/prysm_instrumented/customer/validator/client/runner.go:327 +0x37f
```

Line 845 in validator.go:
```go
842 resp, err := v.validatorClient.GetDuties(ctx, req)
843 if err != nil {
844     __antithesis_instrumentation__.Notify(72630)
845     v.duties = nil
        log.Error(err)
        return err
    } else {
        __antithesis_instrumentation__.Notify(72631)
    }
```

attest.go line 271 of the instrumented code
```go
271 for _, duty := range v.duties.Duties {
272       __antithesis_instrumentation__.Notify(70002)
        if bytes.Equal(pubKey[:], duty.PublicKey) {
            __antithesis_instrumentation__.Notify(70003)
            return duty, nil
        } else {
            __antithesis_instrumentation__.Notify(70004)
        }
    }
 ```
