### PR TITLE
Add Delay Option for Genesis to Prysmctl

### DIFF
--- a/cmd/prysmctl/BUILD.bazel
+++ b/cmd/prysmctl/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@prysm//tools/go:def.bzl", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle", "container_image")
-load("//tools:go_image.bzl", "go_image_debug")
+load("//tools:go_image.bzl", "go_image_alpine", "go_image_debug")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 go_library(
@@ -26,6 +26,7 @@ go_library(
 go_image(
     name = "image",
     base = select({
+        "//tools:base_image_alpine": "//tools:alpine_cc_image",
         "//tools:base_image_cc": "//tools:cc_image",
         "//conditions:default": "//tools:cc_image",
     }),
@@ -44,8 +45,7 @@ container_image(
 container_bundle(
     name = "image_bundle",
     images = {
-        "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:latest": ":image_with_creation_time",
-        "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:{DOCKER_TAG}": ":image_with_creation_time",
+        "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:nitro-deneb-integration": ":image_with_creation_time",
     },
     tags = ["manual"],
     visibility = ["//cmd/prysmctl:__pkg__"],
@@ -68,6 +68,23 @@ container_bundle(
     visibility = ["//cmd/prysmctl:__pkg__"],
 )
 
+go_image_alpine(
+    name = "image_alpine",
+    image = ":image",
+    tags = ["manual"],
+    visibility = ["//cmd/prysmctl:__pkg__"],
+)
+
+container_bundle(
+    name = "image_bundle_alpine",
+    images = {
+        "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:latest-alpine": ":image_alpine",
+        "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:{DOCKER_TAG}-alpine": ":image_alpine",
+    },
+    tags = ["manual"],
+    visibility = ["//cmd/prysmctl:__pkg__"],
+)
+
 docker_push(
     name = "push_images",
     bundle = ":image_bundle",
@@ -78,6 +95,13 @@ docker_push(
 docker_push(
     name = "push_images_debug",
     bundle = ":image_bundle_debug",
+    tags = ["manual"],
+    visibility = ["//cmd/prysmctl:__pkg__"],
+)
+
+docker_push(
+    name = "push_images_alpine",
+    bundle = ":image_bundle_alpine",
     tags = ["manual"],
     visibility = ["//cmd/prysmctl:__pkg__"],
 )

--- a/cmd/prysmctl/BUILD.bazel
+++ b/cmd/prysmctl/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@prysm//tools/go:def.bzl", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle", "container_image")
-load("//tools:go_image.bzl", "go_image_alpine", "go_image_debug")
+load("//tools:go_image.bzl", "go_image_debug")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 go_library(
@@ -26,7 +26,6 @@ go_library(
 go_image(
     name = "image",
     base = select({
-        "//tools:base_image_alpine": "//tools:alpine_cc_image",
         "//tools:base_image_cc": "//tools:cc_image",
         "//conditions:default": "//tools:cc_image",
     }),
@@ -45,7 +44,8 @@ container_image(
 container_bundle(
     name = "image_bundle",
     images = {
-        "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:nitro-deneb-integration": ":image_with_creation_time",
+        "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:latest": ":image_with_creation_time",
+        "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:{DOCKER_TAG}": ":image_with_creation_time",
     },
     tags = ["manual"],
     visibility = ["//cmd/prysmctl:__pkg__"],
@@ -68,23 +68,6 @@ container_bundle(
     visibility = ["//cmd/prysmctl:__pkg__"],
 )
 
-go_image_alpine(
-    name = "image_alpine",
-    image = ":image",
-    tags = ["manual"],
-    visibility = ["//cmd/prysmctl:__pkg__"],
-)
-
-container_bundle(
-    name = "image_bundle_alpine",
-    images = {
-        "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:latest-alpine": ":image_alpine",
-        "gcr.io/prysmaticlabs/prysm/cmd/prysmctl:{DOCKER_TAG}-alpine": ":image_alpine",
-    },
-    tags = ["manual"],
-    visibility = ["//cmd/prysmctl:__pkg__"],
-)
-
 docker_push(
     name = "push_images",
     bundle = ":image_bundle",
@@ -95,13 +78,6 @@ docker_push(
 docker_push(
     name = "push_images_debug",
     bundle = ":image_bundle_debug",
-    tags = ["manual"],
-    visibility = ["//cmd/prysmctl:__pkg__"],
-)
-
-docker_push(
-    name = "push_images_alpine",
-    bundle = ":image_bundle_alpine",
     tags = ["manual"],
     visibility = ["//cmd/prysmctl:__pkg__"],
 )

--- a/cmd/prysmctl/testnet/generate_genesis.go
+++ b/cmd/prysmctl/testnet/generate_genesis.go
@@ -34,6 +34,7 @@ var (
 		ConfigName         string
 		NumValidators      uint64
 		GenesisTime        uint64
+		GenesisTimeDelay   uint64
 		OutputSSZ          string
 		OutputJSON         string
 		OutputYaml         string
@@ -98,6 +99,11 @@ var (
 				Name:        "genesis-time",
 				Destination: &generateGenesisStateFlags.GenesisTime,
 				Usage:       "Unix timestamp seconds used as the genesis time in the genesis state. If unset, defaults to now()",
+			},
+			&cli.Uint64Flag{
+				Name:        "genesis-time-delay",
+				Destination: &generateGenesisStateFlags.GenesisTimeDelay,
+				Usage:       "Delay genesis time by N seconds",
 			},
 			&cli.BoolFlag{
 				Name:        "override-eth1data",
@@ -223,6 +229,9 @@ func generateGenesis(ctx context.Context) (state.BeaconState, error) {
 		f.GenesisTime = uint64(time.Now().Unix())
 		log.Info("No genesis time specified, defaulting to now()")
 	}
+	log.Infof("Delaying genesis %v by %v seconds", f.GenesisTime, f.GenesisTimeDelay)
+	f.GenesisTime += f.GenesisTimeDelay
+	log.Infof("Genesis is now %v", f.GenesisTime)
 
 	v, err := version.FromString(f.ForkName)
 	if err != nil {
@@ -266,8 +275,8 @@ func generateGenesis(ctx context.Context) (state.BeaconState, error) {
 		//gen.Config.CancunTime = interop.GethCancunTime(f.GenesisTime, params.BeaconConfig())
 		gen.Config.CancunTime = interop.GethCancunTime(f.GenesisTime, params.BeaconConfig())
 		log.
-			WithField("shanghai", gen.Config.ShanghaiTime).
-			WithField("cancun", gen.Config.CancunTime).
+			WithField("shanghai", fmt.Sprintf("%d", *gen.Config.ShanghaiTime)).
+			WithField("cancun", fmt.Sprintf("%d", *gen.Config.CancunTime)).
 			Info("setting fork geth times")
 		if v > version.Altair {
 			// set ttd to zero so EL goes post-merge immediately


### PR DESCRIPTION
This PR adds the option to delay the genesis time by a duration in Prysmctl, helpful for some CLI / docker workflows without needing to invoke bash commands of delaying timestamps