### PR TITLE
Remove pending blobs queue

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	"github.com/prysmaticlabs/prysm/v4/encoding/ssz/equality"
 	"github.com/prysmaticlabs/prysm/v4/monitoring/tracing"
-	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
 	"github.com/sirupsen/logrus"
 	"github.com/trailofbits/go-mutexasserts"
@@ -440,21 +439,6 @@ func (s *Service) pendingBlocksInCache(slot primitives.Slot) []interfaces.ReadOn
 	return blks
 }
 
-// This returns signed blob sidecar given input key from slotToPendingBlobs.
-func (s *Service) pendingBlobsInCache(slot primitives.Slot) []*eth.SignedBlobSidecar {
-	k := slotToCacheKey(slot)
-	value, ok := s.slotToPendingBlobs.Get(k)
-	if !ok {
-		return []*eth.SignedBlobSidecar{}
-	}
-	bs, ok := value.([]*eth.SignedBlobSidecar)
-	if !ok {
-		log.Debug("pendingBlobsInCache: value is not of type []*eth.SignedBlobSidecar")
-		return []*eth.SignedBlobSidecar{}
-	}
-	return bs
-}
-
 // This adds input signed beacon block to slotToPendingBlocks cache.
 func (s *Service) addPendingBlockToCache(b interfaces.ReadOnlySignedBeaconBlock) error {
 	if err := blocks.BeaconBlockIsNil(b); err != nil {
@@ -470,23 +454,6 @@ func (s *Service) addPendingBlockToCache(b interfaces.ReadOnlySignedBeaconBlock)
 	blks = append(blks, b)
 	k := slotToCacheKey(b.Block().Slot())
 	s.slotToPendingBlocks.Set(k, blks, pendingBlockExpTime)
-	return nil
-}
-
-// This adds blob to slotToPendingBlobs cache.
-func (s *Service) addPendingBlobToCache(b *eth.SignedBlobSidecar) error {
-	blobs := s.pendingBlobsInCache(b.Message.Slot)
-
-	// If we already have seen the index. Ignore it.
-	for _, blob := range blobs {
-		if blob.Message.Index == b.Message.Index {
-			return nil
-		}
-	}
-
-	blobs = append(blobs, b)
-	k := slotToCacheKey(b.Message.Slot)
-	s.slotToPendingBlobs.Set(k, blobs, pendingBlockExpTime)
 	return nil
 }
 

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -113,7 +113,6 @@ type Service struct {
 	ctx                              context.Context
 	cancel                           context.CancelFunc
 	slotToPendingBlocks              *gcache.Cache
-	slotToPendingBlobs               *gcache.Cache
 	seenPendingBlocks                map[[32]byte]bool
 	blkRootToPendingAtts             map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof
 	subHandler                       *subTopicHandler
@@ -152,7 +151,6 @@ type Service struct {
 // NewService initializes new regular sync service.
 func NewService(ctx context.Context, opts ...Option) *Service {
 	c := gcache.New(pendingBlockExpTime /* exp time */, 2*pendingBlockExpTime /* prune time */)
-	pendingBlobCache := gcache.New(0 /* exp time */, 0 /* prune time */)
 	ctx, cancel := context.WithCancel(ctx)
 	r := &Service{
 		ctx:                  ctx,
@@ -160,7 +158,6 @@ func NewService(ctx context.Context, opts ...Option) *Service {
 		chainStarted:         abool.New(),
 		cfg:                  &config{clock: startup.NewClock(time.Unix(0, 0), [32]byte{})},
 		slotToPendingBlocks:  c,
-		slotToPendingBlobs:   pendingBlobCache,
 		seenPendingBlocks:    make(map[[32]byte]bool),
 		blkRootToPendingAtts: make(map[[32]byte][]*ethpb.SignedAggregateAttestationAndProof),
 		signatureChan:        make(chan *signatureVerifier, verifierLimit),

--- a/beacon-chain/sync/validate_blob.go
+++ b/beacon-chain/sync/validate_blob.go
@@ -77,10 +77,6 @@ func (s *Service) validateBlob(ctx context.Context, pid peer.ID, msg *pubsub.Mes
 	// [IGNORE] The sidecar's block's parent (defined by sidecar.block_parent_root) has been seen (via both gossip and non-gossip sources)
 	parentRoot := bytesutil.ToBytes32(blob.BlockParentRoot)
 	if !s.cfg.chain.HasBlock(ctx, parentRoot) {
-		if err := s.addPendingBlobToCache(sBlob); err != nil {
-			log.WithError(err).WithFields(blobFields(blob)).Error("Failed to add blob to cache")
-			return pubsub.ValidationIgnore, err
-		}
 		log.WithFields(blobFields(blob)).Debug("Ignored blob: parent block not found")
 		return pubsub.ValidationIgnore, nil
 	}


### PR DESCRIPTION
The pending blobs queue has been removed from the codebase. The pending blobs queue is currently dormant and has no active use cases. This queue was intended to store blobs when their parent block was unseen. While clients might cache this based on the network specification, it still needs to be utilized in our current design. The utility and integration of this feature are still ambiguous. It seems that its design and purpose require further analysis and discussion. Owing to its unclear future use and the potential for unnecessary complexities, removing it now ensures we don't overlook it in subsequent updates. Additionally, its existence poses a slight risk of denial-of-service (DoS) attacks, which we aim to mitigate