### PR TITLE
if set parameter of using remote genesis state, will use remote state instead.

### DIFF
--- a/beacon-chain/sync/genesis/api.go
+++ b/beacon-chain/sync/genesis/api.go
@@ -38,8 +38,9 @@ func (dl *APIInitializer) Initialize(ctx context.Context, d db.Database) error {
 		if err != nil {
 			return errors.Wrap(err, "error while computing hash_tree_root of existing genesis state")
 		}
-		log.Warnf("database contains genesis with htr=%#x, ignoring remote genesis state parameter", htr)
-		return nil
+
+		// if use remote genesis state, ignore local state.
+		log.Warnf("database contains genesis with htr=%#x, will ignoring it, use remote genesis state instead", htr)
 	}
 	sb, err := dl.c.GetState(ctx, beacon.IdGenesis)
 	if err != nil {


### PR DESCRIPTION
When use the parameter of --checkpoint-sync-url and --genesis-beacon-api-url, it will always failed.
What I found is that it will create db automatically, then use the initial db instead of using the remote one.

So I think if someone uses the remote parameters, it should not return, and replace the local one instead, and the he can see the warnings either.

The reference issue is: https://github.com/prysmaticlabs/prysm/issues/12907