### PR TITLE
Fix Deneb Fork Registration

### DIFF
--- a/beacon-chain/sync/fork_watcher.go
+++ b/beacon-chain/sync/fork_watcher.go
@@ -63,6 +63,9 @@ func (s *Service) registerForUpcomingFork(currEpoch primitives.Epoch) error {
 		if nextEpoch == params.BeaconConfig().AltairForkEpoch {
 			s.registerRPCHandlersAltair()
 		}
+		if nextEpoch == params.BeaconConfig().DenebForkEpoch {
+			s.registerRPCHandlersDeneb()
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

This allows prysm nodes to register for the deneb sync rpc topics once the deneb fork has happened. This will allow 
blobs to be requested by root/range between peers. Otherwise no prysm node will be able to serve any blob data without a manual restart. This PR also adds in a respective regression test.
 
**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
