### PR TITLE
GetPayload err should not fail block construction if builder s…

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -41,7 +41,7 @@ type ForkchoiceFetcher interface {
 	CachedHeadRoot() [32]byte
 	GetProposerHead() [32]byte
 	SetForkChoiceGenesisTime(uint64)
-	UpdateHead(context.Context, primitives.Slot)
+	UpdateHead(context.Context, primitives.Slot) bool
 	HighestReceivedBlockSlot() primitives.Slot
 	ReceivedBlocksLastEpoch() (uint64, error)
 	InsertNode(context.Context, state.BeaconState, [32]byte) error

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -115,9 +115,10 @@ func (s *Service) spawnProcessAttestationsRoutine() {
 	}()
 }
 
-// UpdateHead updates the canonical head of the chain based on information from fork-choice attestations and votes.
-// The caller of this function MUST hold a lock in forkchoice
-func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot) {
+// UpdateHead determines the canonical head of the chain by evaluating fork-choice attestations and votes.
+// It returns a boolean indicating whether the head has been modified.
+// Note: Before invoking this function, ensure a lock is held in forkchoice.
+func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot) bool {
 	ctx, span := trace.StartSpan(ctx, "beacon-chain.blockchain.UpdateHead")
 	defer span.End()
 
@@ -156,6 +157,7 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 		}).Debug("Head changed due to attestations")
 		s.headLock.RUnlock()
 	}
+	return changed
 }
 
 // This processes fork choice attestations from the pool to account for validator votes and fork choice.

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -471,7 +471,7 @@ func (s *ChainService) IsOptimisticForRoot(_ context.Context, root [32]byte) (bo
 }
 
 // UpdateHead mocks the same method in the chain service.
-func (s *ChainService) UpdateHead(ctx context.Context, slot primitives.Slot) {
+func (s *ChainService) UpdateHead(ctx context.Context, slot primitives.Slot) bool {
 	ojc := &ethpb.Checkpoint{}
 	st, root, err := prepareForkchoiceState(ctx, slot, bytesutil.ToBytes32(s.Root), [32]byte{}, [32]byte{}, ojc, ojc)
 	if err != nil {
@@ -481,6 +481,7 @@ func (s *ChainService) UpdateHead(ctx context.Context, slot primitives.Slot) {
 	if err != nil {
 		logrus.WithError(err).Error("could not insert node to forkchoice")
 	}
+	return false
 }
 
 // ReceiveAttesterSlashing mocks the same method in the chain service.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -1,7 +1,6 @@
 package validator
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -67,20 +66,8 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 		return nil, status.Error(codes.Unavailable, "Syncing to latest head, not ready to respond")
 	}
 
-	oldHeadRoot, err := vs.HeadFetcher.HeadRoot(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to retrieve old head root: %v", err)
-	}
-
 	// process attestations and update head in forkchoice
-	vs.ForkchoiceFetcher.UpdateHead(ctx, vs.TimeFetcher.CurrentSlot())
-
-	newHeadRoot, err := vs.HeadFetcher.HeadRoot(ctx)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to retrieve new head root: %v", err)
-	}
-
-	headChanged := !bytes.Equal(oldHeadRoot, newHeadRoot)
+	headChanged := vs.ForkchoiceFetcher.UpdateHead(ctx, vs.TimeFetcher.CurrentSlot())
 
 	headRoot := vs.ForkchoiceFetcher.CachedHeadRoot()
 	parentRoot := vs.ForkchoiceFetcher.GetProposerHead()

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -183,13 +183,18 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 	}
 	sBlk.SetStateRoot(sr)
 
-	fullBlobs, err := blobsBundleToSidecars(blobBundle, sBlk.Block())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not convert blobs bundle to sidecar: %v", err)
-	}
-	blindBlobs, err := blindBlobsBundleToSidecars(blindBlobBundle, sBlk.Block())
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Could not convert blind blobs bundle to sidecar: %v", err)
+	var blindBlobs []*ethpb.BlindedBlobSidecar
+	var fullBlobs []*ethpb.BlobSidecar
+	if sBlk.IsBlinded() {
+		blindBlobs, err = blindBlobsBundleToSidecars(blindBlobBundle, sBlk.Block())
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not convert blind blobs bundle to sidecar: %v", err)
+		}
+	} else {
+		fullBlobs, err = blobsBundleToSidecars(blobBundle, sBlk.Block())
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "Could not convert blobs bundle to sidecar: %v", err)
+		}
 	}
 
 	log.WithFields(logrus.Fields{

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -162,7 +162,7 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 		// Get local and builder (if enabled) payloads. Set execution data. New in Bellatrix.
 		var overrideBuilder bool
 		var localPayload interfaces.ExecutionData
-		localPayload, blobBundle, overrideBuilder, err := vs.getLocalPayloadAndBlobs(ctx, sBlk.Block(), head)
+		localPayload, blobBundle, overrideBuilder, err = vs.getLocalPayloadAndBlobs(ctx, sBlk.Block(), head)
 		if err != nil {
 			log.WithError(err).Warn("failed to retrieve local payload; attempting builder payload if available")
 			if errors.Is(err, errLastMinFCU) && headChanged {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -55,9 +55,7 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 		// Use builder payload if local payload is nil.
 		if builderPayload != nil {
 			blk.SetBlinded(true)
-			if err := blk.SetExecution(builderPayload); err != nil {
-				return err
-			}
+			return blk.SetExecution(builderPayload)
 		}
 		return errors.New("local and builder payloads are nil")
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -52,6 +52,13 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 	}
 
 	if localPayload == nil {
+		// Use builder payload if local payload is nil.
+		if builderPayload != nil {
+			blk.SetBlinded(true)
+			if err := blk.SetExecution(builderPayload); err != nil {
+				return err
+			}
+		}
 		return errors.New("local payload is nil")
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -59,7 +59,7 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 				return err
 			}
 		}
-		return errors.New("local payload is nil")
+		return errors.New("local and builder payloads are nil")
 	}
 
 	// Use local payload if builder payload is nil.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -89,9 +89,7 @@ func (vs *Server) getLocalPayloadAndBlobs(ctx context.Context, blk interfaces.Re
 			return payload, blobsBundle, overrideBuilder, nil
 		case errors.Is(err, context.DeadlineExceeded):
 		default:
-			// Get local payload should not fail block construction. Validator can still propose a block if builder is specified.
-			log.WithError(err).Error("could not get payload from execution client")
-			return nil, nil, false, nil
+			return nil, nil, false, errors.Wrap(err, "could not get cached payload from execution client")
 		}
 	}
 
@@ -204,9 +202,7 @@ func (vs *Server) getLocalPayloadAndBlobs(ctx context.Context, blk interfaces.Re
 	}
 	payload, blobsBundle, overrideBuilder, err := vs.ExecutionEngineCaller.GetPayload(ctx, *payloadID, slot)
 	if err != nil {
-		// Get local payload should not fail block construction. Validator can still propose a block if builder is specified.
-		log.WithError(err).Error("could not get payload from execution client")
-		return nil, nil, false, nil
+		return nil, nil, false, err
 	}
 	warnIfFeeRecipientDiffers(payload, feeRecipient)
 	return payload, blobsBundle, overrideBuilder, nil

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -41,6 +41,8 @@ var (
 	})
 )
 
+var errLastMinFCU = errors.New("last minute fork choice update")
+
 // This returns the local execution payload of a given slot. The function has full awareness of pre and post merge.
 // It also returns the blobs bundle.
 func (vs *Server) getLocalPayloadAndBlobs(ctx context.Context, blk interfaces.ReadOnlyBeaconBlock, st state.BeaconState) (interfaces.ExecutionData, *enginev1.BlobsBundle, bool, error) {
@@ -195,7 +197,7 @@ func (vs *Server) getLocalPayloadAndBlobs(ctx context.Context, blk interfaces.Re
 	}
 	payloadID, _, err := vs.ExecutionEngineCaller.ForkchoiceUpdated(ctx, f, attr)
 	if err != nil {
-		return nil, nil, false, errors.Wrap(err, "could not prepare payload")
+		return nil, nil, false, errors.Wrap(errLastMinFCU, err.Error())
 	}
 	if payloadID == nil {
 		return nil, nil, false, fmt.Errorf("nil payload with block hash: %#x", parentHash)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_execution_payload.go
@@ -87,7 +87,9 @@ func (vs *Server) getLocalPayloadAndBlobs(ctx context.Context, blk interfaces.Re
 			return payload, blobsBundle, overrideBuilder, nil
 		case errors.Is(err, context.DeadlineExceeded):
 		default:
-			return nil, nil, false, errors.Wrap(err, "could not get cached payload from execution client")
+			// Get local payload should not fail block construction. Validator can still propose a block if builder is specified.
+			log.WithError(err).Error("could not get payload from execution client")
+			return nil, nil, false, nil
 		}
 	}
 
@@ -200,7 +202,9 @@ func (vs *Server) getLocalPayloadAndBlobs(ctx context.Context, blk interfaces.Re
 	}
 	payload, blobsBundle, overrideBuilder, err := vs.ExecutionEngineCaller.GetPayload(ctx, *payloadID, slot)
 	if err != nil {
-		return nil, nil, false, err
+		// Get local payload should not fail block construction. Validator can still propose a block if builder is specified.
+		log.WithError(err).Error("could not get payload from execution client")
+		return nil, nil, false, nil
 	}
 	warnIfFeeRecipientDiffers(payload, feeRecipient)
 	return payload, blobsBundle, overrideBuilder, nil


### PR DESCRIPTION
Enhancement to block construction: When a local payload is absent, the system now checks for the presence of a builder payload. If found, the block construction will proceed, utilizing the builder payload without considering the builder override flag and bid comparisons. This adjustment ensures improved liveness without compromising on safety. Conversely, if there's an issue with the FCU + new attribute, the validator will terminate block construction, returning an error. Notably, errors from `GetPayload` are now only logged, and not raised