### PR TITLE
Add Blind Blob Sidecar Signing in Validator Client

### DIFF
--- a/validator/client/blob.go
+++ b/validator/client/blob.go
@@ -37,3 +37,37 @@ func (v *validator) signBlob(ctx context.Context, blob *ethpb.BlobSidecar, pubKe
 	}
 	return sig.Marshal(), nil
 }
+
+// signBlindBlob signs a given blinded blob sidecar for a specific slot.
+// It calculates the signing root for the blob and then uses the key manager to produce the signature.
+func (v *validator) signBlindBlob(ctx context.Context, blob *ethpb.BlindedBlobSidecar, pubKey [fieldparams.BLSPubkeyLength]byte) ([]byte, error) {
+	epoch := slots.ToEpoch(blob.Slot)
+
+	// Retrieve domain data specific to the epoch and `DOMAIN_BLOB_SIDECAR`.
+	domain, err := v.domainData(ctx, epoch, params.BeaconConfig().DomainBlobSidecar[:])
+	if err != nil {
+		return nil, errors.Wrap(err, domainDataErr)
+	}
+	if domain == nil {
+		return nil, errors.New(domainDataErr)
+	}
+
+	// Compute the signing root for the blob.
+	sr, err := signing.ComputeSigningRoot(blob, domain.SignatureDomain)
+	if err != nil {
+		return nil, errors.Wrap(err, signingRootErr)
+	}
+
+	// Create a sign request and use the key manager to sign it.
+	sig, err := v.keyManager.Sign(ctx, &validatorpb.SignRequest{
+		PublicKey:       pubKey[:],
+		SigningRoot:     sr[:],
+		SignatureDomain: domain.SignatureDomain,
+		Object:          &validatorpb.SignRequest_BlindedBlob{BlindedBlob: blob},
+		SigningSlot:     blob.Slot,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not sign blind blob sidecar")
+	}
+	return sig.Marshal(), nil
+}

--- a/validator/client/blob.go
+++ b/validator/client/blob.go
@@ -71,3 +71,35 @@ func (v *validator) signBlindBlob(ctx context.Context, blob *ethpb.BlindedBlobSi
 	}
 	return sig.Marshal(), nil
 }
+
+// signDenebBlobs signs an array of Deneb blobs using the provided public key.
+func (v *validator) signDenebBlobs(ctx context.Context, blobs []*ethpb.BlobSidecar, pubKey [48]byte) ([]*ethpb.SignedBlobSidecar, error) {
+	signedBlobs := make([]*ethpb.SignedBlobSidecar, len(blobs))
+	for i, blob := range blobs {
+		blobSig, err := v.signBlob(ctx, blob, pubKey)
+		if err != nil {
+			return nil, err
+		}
+		signedBlobs[i] = &ethpb.SignedBlobSidecar{
+			Message:   blob,
+			Signature: blobSig,
+		}
+	}
+	return signedBlobs, nil
+}
+
+// signBlindedDenebBlobs signs an array of blinded Deneb blobs using the provided public key.
+func (v *validator) signBlindedDenebBlobs(ctx context.Context, blobs []*ethpb.BlindedBlobSidecar, pubKey [48]byte) ([]*ethpb.SignedBlindedBlobSidecar, error) {
+	signedBlindBlobs := make([]*ethpb.SignedBlindedBlobSidecar, len(blobs))
+	for i, blob := range blobs {
+		blobSig, err := v.signBlindBlob(ctx, blob, pubKey)
+		if err != nil {
+			return nil, err
+		}
+		signedBlindBlobs[i] = &ethpb.SignedBlindedBlobSidecar{
+			Message:   blob,
+			Signature: blobSig,
+		}
+	}
+	return signedBlindBlobs, nil
+}

--- a/validator/client/blob_test.go
+++ b/validator/client/blob_test.go
@@ -96,3 +96,117 @@ func TestValidatorSignBlindBlob(t *testing.T) {
 	// Assert that the signature is valid
 	require.Equal(t, true, signature.Verify(publicKey, signingRoot[:]))
 }
+
+func Test_validator_signDenebBlobs(t *testing.T) {
+	v, m, vk, finish := setup(t)
+	defer finish()
+
+	// Setting expectations for the mock client
+	m.validatorClient.EXPECT().
+		DomainData(gomock.Any(), // context
+			&ethpb.DomainRequest{
+				Domain: params.BeaconConfig().DomainBlobSidecar[:],
+			}).
+		Return(&ethpb.DomainResponse{
+			SignatureDomain: bytesutil.PadTo([]byte("signatureDomain"), 32),
+		}, nil).AnyTimes() // Expecting this call multiple times since we're signing multiple blobs
+
+	// Creating a list of Deneb blobs
+	blobs := []*ethpb.BlobSidecar{
+		{
+			BlockRoot:       bytesutil.PadTo([]byte("blockRoot1"), 32),
+			Index:           1,
+			Slot:            2,
+			BlockParentRoot: bytesutil.PadTo([]byte("blockParentRoot1"), 32),
+			ProposerIndex:   3,
+			Blob:            bytesutil.PadTo([]byte("blob1"), fieldparams.BlobLength),
+			KzgCommitment:   bytesutil.PadTo([]byte("kzgCommitment1"), 48),
+			KzgProof:        bytesutil.PadTo([]byte("kzgProof1"), 48),
+		},
+		{
+			BlockRoot:       bytesutil.PadTo([]byte("blockRoot2"), 32),
+			Index:           2,
+			Slot:            3,
+			BlockParentRoot: bytesutil.PadTo([]byte("blockParentRoot2"), 32),
+			ProposerIndex:   4,
+			Blob:            bytesutil.PadTo([]byte("blob2"), fieldparams.BlobLength),
+			KzgCommitment:   bytesutil.PadTo([]byte("kzgCommitment2"), 48),
+			KzgProof:        bytesutil.PadTo([]byte("kzgProof2"), 48),
+		},
+	}
+
+	ctx := context.Background()
+	signedBlobs, err := v.signDenebBlobs(ctx, blobs, [48]byte(vk.PublicKey().Marshal()))
+	require.NoError(t, err)
+
+	// Verify each signed blob
+	for i, signedBlob := range signedBlobs {
+		pb, err := bls.PublicKeyFromBytes(vk.PublicKey().Marshal())
+		require.NoError(t, err)
+
+		signature, err := bls.SignatureFromBytes(signedBlob.Signature)
+		require.NoError(t, err)
+
+		sr, err := signing.ComputeSigningRoot(blobs[i], bytesutil.PadTo([]byte("signatureDomain"), 32))
+		require.NoError(t, err)
+
+		require.Equal(t, true, signature.Verify(pb, sr[:]))
+	}
+}
+
+func Test_validator_signBlindedDenebBlobs(t *testing.T) {
+	v, m, vk, finish := setup(t)
+	defer finish()
+
+	// Setting expectations for the mock client
+	m.validatorClient.EXPECT().
+		DomainData(gomock.Any(), // context
+			&ethpb.DomainRequest{
+				Domain: params.BeaconConfig().DomainBlobSidecar[:],
+			}).
+		Return(&ethpb.DomainResponse{
+			SignatureDomain: bytesutil.PadTo([]byte("signatureDomain"), 32),
+		}, nil).AnyTimes() // Expecting this call multiple times since we're signing multiple blobs
+
+	// Creating a list of blinded Deneb blobs
+	blindedBlobs := []*ethpb.BlindedBlobSidecar{
+		{
+			BlockRoot:       bytesutil.PadTo([]byte("blindedBlockRoot1"), 32),
+			Index:           1,
+			Slot:            2,
+			BlockParentRoot: bytesutil.PadTo([]byte("blindedBlockParentRoot1"), 32),
+			ProposerIndex:   3,
+			BlobRoot:        bytesutil.PadTo([]byte("blobRoot1"), 32),
+			KzgCommitment:   bytesutil.PadTo([]byte("kzgCommitment1"), 48),
+			KzgProof:        bytesutil.PadTo([]byte("kzgProof1"), 48),
+		},
+		{
+			BlockRoot:       bytesutil.PadTo([]byte("blindedBlockRoot2"), 32),
+			Index:           2,
+			Slot:            3,
+			BlockParentRoot: bytesutil.PadTo([]byte("blindedBlockParentRoot2"), 32),
+			ProposerIndex:   4,
+			BlobRoot:        bytesutil.PadTo([]byte("blobRoot2"), 32),
+			KzgCommitment:   bytesutil.PadTo([]byte("kzgCommitment2"), 48),
+			KzgProof:        bytesutil.PadTo([]byte("kzgProof2"), 48),
+		},
+	}
+
+	ctx := context.Background()
+	signedBlindedBlobs, err := v.signBlindedDenebBlobs(ctx, blindedBlobs, [48]byte(vk.PublicKey().Marshal()))
+	require.NoError(t, err)
+
+	// Verify each signed blinded blob
+	for i, signedBlindedBlob := range signedBlindedBlobs {
+		pb, err := bls.PublicKeyFromBytes(vk.PublicKey().Marshal())
+		require.NoError(t, err)
+
+		signature, err := bls.SignatureFromBytes(signedBlindedBlob.Signature)
+		require.NoError(t, err)
+
+		sr, err := signing.ComputeSigningRoot(blindedBlobs[i], bytesutil.PadTo([]byte("signatureDomain"), 32))
+		require.NoError(t, err)
+
+		require.Equal(t, true, signature.Verify(pb, sr[:]))
+	}
+}

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -622,6 +622,43 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 				},
 			},
 		},
+		{
+			name:    "deneb blind block and blobs",
+			version: version.Deneb,
+			block: &ethpb.GenericBeaconBlock{
+				Block: &ethpb.GenericBeaconBlock_BlindedDeneb{
+					BlindedDeneb: func() *ethpb.BlindedBeaconBlockAndBlobsDeneb {
+						blk := util.NewBlindedBeaconBlockDeneb()
+						blk.Block.Body.Graffiti = graffiti
+						return &ethpb.BlindedBeaconBlockAndBlobsDeneb{
+							Block: blk.Block,
+							Blobs: []*ethpb.BlindedBlobSidecar{
+								{
+									BlockRoot:       bytesutil.PadTo([]byte("blockRoot"), 32),
+									Index:           1,
+									Slot:            2,
+									BlockParentRoot: bytesutil.PadTo([]byte("blockParentRoot"), 32),
+									ProposerIndex:   3,
+									BlobRoot:        bytesutil.PadTo([]byte("blobRoot"), 32),
+									KzgCommitment:   bytesutil.PadTo([]byte("kzgCommitment"), 48),
+									KzgProof:        bytesutil.PadTo([]byte("kzgPRoof"), 48),
+								},
+								{
+									BlockRoot:       bytesutil.PadTo([]byte("blockRoot1"), 32),
+									Index:           4,
+									Slot:            5,
+									BlockParentRoot: bytesutil.PadTo([]byte("blockParentRoot1"), 32),
+									ProposerIndex:   6,
+									BlobRoot:        bytesutil.PadTo([]byte("blobRoot1"), 32),
+									KzgCommitment:   bytesutil.PadTo([]byte("kzgCommitment1"), 48),
+									KzgProof:        bytesutil.PadTo([]byte("kzgPRoof1"), 48),
+								},
+							},
+						}
+					}(),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -674,7 +711,12 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 				sentBlock, err = blocktest.NewSignedBeaconBlockFromGeneric(block)
 				assert.NoError(t, err, "Unexpected error unwrapping block")
 				if tt.version == version.Deneb {
-					require.Equal(t, 2, len(block.GetDeneb().Blobs))
+					switch {
+					case tt.name == "deneb block and blobs":
+						require.Equal(t, 2, len(block.GetDeneb().Blobs))
+					case tt.name == "deneb blind block and blobs":
+						require.Equal(t, 2, len(block.GetBlindedDeneb().Blobs))
+					}
 				}
 				return &ethpb.ProposeResponse{BlockRoot: make([]byte, 32)}, nil
 			})

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -629,9 +629,9 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 				Block: &ethpb.GenericBeaconBlock_BlindedDeneb{
 					BlindedDeneb: func() *ethpb.BlindedBeaconBlockAndBlobsDeneb {
 						blk := util.NewBlindedBeaconBlockDeneb()
-						blk.Block.Body.Graffiti = graffiti
+						blk.Message.Body.Graffiti = graffiti
 						return &ethpb.BlindedBeaconBlockAndBlobsDeneb{
-							Block: blk.Block,
+							Block: blk.Message,
 							Blobs: []*ethpb.BlindedBlobSidecar{
 								{
 									BlockRoot:       bytesutil.PadTo([]byte("blockRoot"), 32),
@@ -715,7 +715,7 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 					case tt.name == "deneb block and blobs":
 						require.Equal(t, 2, len(block.GetDeneb().Blobs))
 					case tt.name == "deneb blind block and blobs":
-						require.Equal(t, 2, len(block.GetBlindedDeneb().Blobs))
+						require.Equal(t, 2, len(block.GetBlindedDeneb().SignedBlindedBlobSidecars))
 					}
 				}
 				return &ethpb.ProposeResponse{BlockRoot: make([]byte, 32)}, nil


### PR DESCRIPTION
**Summary:**
This PR introduces the ability for the validator client to sign blind blob sidecars. 

**Details:**
- A new function, `signBlindBlob`, has been added. This function will be utilized by `ProposeBlock`.
- In the `ProposeBlock` method, if the block is blinded with version deneb, the validator client will sign the blind blob sidecars.
- As a result, it will construct the appropriate `GenericSignedBeaconBlock_BlindedDeneb` to be returned later in the process.