### PR TITLE
Copy kzg commitments when using builder block

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/unblinder.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/unblinder.go
@@ -158,6 +158,10 @@ func copyBlockData(src interfaces.SignedBeaconBlock, dst interfaces.SignedBeacon
 	if err != nil && !errors.Is(err, consensus_types.ErrUnsupportedField) {
 		return errors.Wrap(err, "could not get bls to execution changes")
 	}
+	kzgCommitments, err := src.Block().Body().BlobKzgCommitments()
+	if err != nil && !errors.Is(err, consensus_types.ErrUnsupportedField) {
+		return errors.Wrap(err, "could not get blob kzg commitments")
+	}
 
 	dst.SetSlot(src.Block().Slot())
 	dst.SetProposerIndex(src.Block().ProposerIndex())
@@ -176,6 +180,9 @@ func copyBlockData(src interfaces.SignedBeaconBlock, dst interfaces.SignedBeacon
 	}
 	dst.SetSignature(sig[:])
 	if err = dst.SetBLSToExecutionChanges(blsToExecChanges); err != nil && !errors.Is(err, consensus_types.ErrUnsupportedField) {
+		return errors.Wrap(err, "could not set bls to execution changes")
+	}
+	if err = dst.SetBlobKzgCommitments(kzgCommitments); err != nil && !errors.Is(err, consensus_types.ErrUnsupportedField) {
 		return errors.Wrap(err, "could not set bls to execution changes")
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/unblinder_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/unblinder_test.go
@@ -296,6 +296,7 @@ func Test_unblindBuilderBlock(t *testing.T) {
 						Signature: []byte("sig456"),
 					},
 				}
+				b.Message.Body.BlobKzgCommitments = [][]byte{{'c', 0}, {'c', 1}, {'c', 2}, {'c', 3}, {'c', 4}, {'c', 5}}
 				txRoot, err := ssz.TransactionsRoot([][]byte{})
 				require.NoError(t, err)
 				withdrawalsRoot, err := ssz.WithdrawalSliceRoot([]*v1.Withdrawal{}, fieldparams.MaxWithdrawalsPerPayload)
@@ -350,6 +351,7 @@ func Test_unblindBuilderBlock(t *testing.T) {
 						Signature: []byte("sig456"),
 					},
 				}
+				b.Block.Body.BlobKzgCommitments = [][]byte{{'c', 0}, {'c', 1}, {'c', 2}, {'c', 3}, {'c', 4}, {'c', 5}}
 				b.Block.Body.ExecutionPayload = pDeneb
 				wb, err := blocks.NewSignedBeaconBlock(b)
 				require.NoError(t, err)


### PR DESCRIPTION
h/t to @marioevz

Copy kzg commitments before and after submit blind block. This ensures kzg commitments stay consistent through out beacon block body