### PR TITLE
Fix Pagination Panic

### DIFF
--- a/api/pagination/pagination.go
+++ b/api/pagination/pagination.go
@@ -15,6 +15,9 @@ func StartAndEndPage(pageToken string, pageSize, totalSize int) (int, int, strin
 	if pageToken == "" {
 		pageToken = "0"
 	}
+	if pageSize < 0 || totalSize < 0 {
+		return 0, 0, "", errors.Errorf("invalid page and total sizes provided: page size %d , total size %d", pageSize, totalSize)
+	}
 	if pageSize == 0 {
 		pageSize = params.BeaconConfig().DefaultPageSize
 	}
@@ -22,6 +25,9 @@ func StartAndEndPage(pageToken string, pageSize, totalSize int) (int, int, strin
 	token, err := strconv.Atoi(pageToken)
 	if err != nil {
 		return 0, 0, "", errors.Wrap(err, "could not convert page token")
+	}
+	if token < 0 {
+		return 0, 0, "", errors.Errorf("invalid token value provided: %d", token)
 	}
 
 	// Start page can not be greater than set size.

--- a/api/pagination/pagination_test.go
+++ b/api/pagination/pagination_test.go
@@ -85,3 +85,19 @@ func TestStartAndEndPage_ExceedsMaxPage(t *testing.T) {
 	_, _, _, err := pagination.StartAndEndPage("", 0, 0)
 	assert.ErrorContains(t, wanted, err)
 }
+
+func TestStartAndEndPage_InvalidPageValues(t *testing.T) {
+	_, _, _, err := pagination.StartAndEndPage("10", -1, 10)
+	assert.ErrorContains(t, "invalid page and total sizes provided", err)
+
+	_, _, _, err = pagination.StartAndEndPage("12", 10, -10)
+	assert.ErrorContains(t, "invalid page and total sizes provided", err)
+
+	_, _, _, err = pagination.StartAndEndPage("12", -50, -60)
+	assert.ErrorContains(t, "invalid page and total sizes provided", err)
+}
+
+func TestStartAndEndPage_InvalidTokenValue(t *testing.T) {
+	_, _, _, err := pagination.StartAndEndPage("-12", 50, 60)
+	assert.ErrorContains(t, "invalid token value provided", err)
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

Currently if we provide negative page size values or negative token values our API endpoints will panic as
these values are invalid. This PR checks for negative page sizes along with negative token values to handle these panics. Regression test for these particular cases have been added in. 

Alternative solutions to use unsigned integers for these values had been considered but was ignored as changing the method signature to use unsigned values would require changing all the respective api endpoints.

**Which issues(s) does this PR fix?**

TOB-PRYSM-5

**Other notes for review**
