### PR TITLE
Add Content-Type header to VC POST requests

### DIFF
--- a/validator/client/beacon-api/BUILD.bazel
+++ b/validator/client/beacon-api/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
     importpath = "github.com/prysmaticlabs/prysm/v4/validator/client/beacon-api",
     visibility = ["//validator:__subpackages__"],
     deps = [
+        "//api:go_default_library",
         "//api/gateway/apimiddleware:go_default_library",
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/signing:go_default_library",

--- a/validator/client/beacon-api/json_rest_handler.go
+++ b/validator/client/beacon-api/json_rest_handler.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v4/api"
 	"github.com/prysmaticlabs/prysm/v4/api/gateway/apimiddleware"
 )
 
@@ -66,6 +67,7 @@ func (c beaconApiJsonRestHandler) PostRestJson(ctx context.Context, apiEndpoint 
 	for headerKey, headerValue := range headers {
 		req.Header.Set(headerKey, headerValue)
 	}
+	req.Header.Set("Content-Type", api.JsonMediaType)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Sets the correct `Content-Type` when making REST requests in the validator client

**Which issues(s) does this PR fix?**

Fixes #12874
