### PR TITLE
Refactor construct generic beacon block for proposer

### DIFF
--- a/beacon-chain/db/kv/blob_test.go
+++ b/beacon-chain/db/kv/blob_test.go
@@ -332,7 +332,6 @@ func generateBlobSidecar(t *testing.T, index uint64) *ethpb.BlobSidecar {
 	kzgProof := make([]byte, 48)
 	_, err = rand.Read(kzgProof)
 	require.NoError(t, err)
-
 	return &ethpb.BlobSidecar{
 		BlockRoot:       bytesutil.PadTo([]byte{'a'}, 32),
 		Index:           index,

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "assignments.go",
         "attester.go",
         "blocks.go",
+        "construct_generic_block.go",
         "exit.go",
         "log.go",
         "proposer.go",

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
@@ -41,12 +41,12 @@ func (vs *Server) constructGenericBeaconBlock(sBlk interfaces.SignedBeaconBlock,
 
 // Helper functions for constructing blocks for each version
 func (vs *Server) constructDenebBlock(blockProto proto.Message, isBlinded bool, payloadValue uint64, blindBlobs []*ethpb.BlindedBlobSidecar, fullBlobs []*ethpb.BlobSidecar) *ethpb.GenericBeaconBlock {
+	if isBlinded {
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedDeneb{BlindedDeneb: &ethpb.BlindedBeaconBlockAndBlobsDeneb{Block: blockProto.(*ethpb.BlindedBeaconBlockDeneb), Blobs: blindBlobs}}, IsBlinded: true, PayloadValue: payloadValue}
+	}
 	blockAndBlobs := &ethpb.BeaconBlockAndBlobsDeneb{
 		Block: blockProto.(*ethpb.BeaconBlockDeneb),
 		Blobs: fullBlobs,
-	}
-	if isBlinded {
-		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedDeneb{BlindedDeneb: &ethpb.BlindedBeaconBlockAndBlobsDeneb{Block: blockProto.(*ethpb.BlindedBeaconBlockDeneb), Blobs: blindBlobs}}, IsBlinded: true, PayloadValue: payloadValue}
 	}
 	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Deneb{Deneb: blockAndBlobs}, IsBlinded: false, PayloadValue: payloadValue}
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
@@ -1,0 +1,74 @@
+package validator
+
+import (
+	"fmt"
+
+	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
+	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/runtime/version"
+	"google.golang.org/protobuf/proto"
+)
+
+// constructGenericBeaconBlock constructs a `GenericBeaconBlock` based on the block version and other parameters.
+func (vs *Server) constructGenericBeaconBlock(sBlk interfaces.SignedBeaconBlock, blindBlobs []*ethpb.BlindedBlobSidecar, fullBlobs []*ethpb.BlobSidecar) (*ethpb.GenericBeaconBlock, error) {
+	if sBlk == nil || sBlk.Block() == nil {
+		return nil, fmt.Errorf("block cannot be nil")
+	}
+
+	blockProto, err := sBlk.Block().Proto()
+	if err != nil {
+		return nil, err
+	}
+
+	isBlinded := sBlk.IsBlinded()
+	payloadValue := sBlk.ValueInGwei()
+
+	switch sBlk.Version() {
+	case version.Deneb:
+		return vs.constructDenebBlock(blockProto, isBlinded, payloadValue, blindBlobs, fullBlobs), nil
+	case version.Capella:
+		return vs.constructCapellaBlock(blockProto, isBlinded, payloadValue), nil
+	case version.Bellatrix:
+		return vs.constructBellatrixBlock(blockProto, isBlinded, payloadValue), nil
+	case version.Altair:
+		return vs.constructAltairBlock(blockProto), nil
+	case version.Phase0:
+		return vs.constructPhase0Block(blockProto), nil
+	default:
+		return nil, fmt.Errorf("unknown block version: %d", sBlk.Version())
+	}
+}
+
+// Helper functions for constructing blocks for each version
+func (vs *Server) constructDenebBlock(blockProto proto.Message, isBlinded bool, payloadValue uint64, blindBlobs []*ethpb.BlindedBlobSidecar, fullBlobs []*ethpb.BlobSidecar) *ethpb.GenericBeaconBlock {
+	blockAndBlobs := &ethpb.BeaconBlockAndBlobsDeneb{
+		Block: blockProto.(*ethpb.BeaconBlockDeneb),
+		Blobs: fullBlobs,
+	}
+	if isBlinded {
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedDeneb{BlindedDeneb: &ethpb.BlindedBeaconBlockAndBlobsDeneb{Block: blockProto.(*ethpb.BlindedBeaconBlockDeneb), Blobs: blindBlobs}}, IsBlinded: true, PayloadValue: payloadValue}
+	}
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Deneb{Deneb: blockAndBlobs}, IsBlinded: false, PayloadValue: payloadValue}
+}
+
+func (vs *Server) constructCapellaBlock(pb proto.Message, isBlinded bool, payloadValue uint64) *ethpb.GenericBeaconBlock {
+	if isBlinded {
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedCapella{BlindedCapella: pb.(*ethpb.BlindedBeaconBlockCapella)}, IsBlinded: true, PayloadValue: payloadValue}
+	}
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Capella{Capella: pb.(*ethpb.BeaconBlockCapella)}, IsBlinded: false, PayloadValue: payloadValue}
+}
+
+func (vs *Server) constructBellatrixBlock(pb proto.Message, isBlinded bool, payloadValue uint64) *ethpb.GenericBeaconBlock {
+	if isBlinded {
+		return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_BlindedBellatrix{BlindedBellatrix: pb.(*ethpb.BlindedBeaconBlockBellatrix)}, IsBlinded: true, PayloadValue: payloadValue}
+	}
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Bellatrix{Bellatrix: pb.(*ethpb.BeaconBlockBellatrix)}, IsBlinded: false, PayloadValue: payloadValue}
+}
+
+func (vs *Server) constructAltairBlock(pb proto.Message) *ethpb.GenericBeaconBlock {
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Altair{Altair: pb.(*ethpb.BeaconBlockAltair)}}
+}
+
+func (vs *Server) constructPhase0Block(pb proto.Message) *ethpb.GenericBeaconBlock {
+	return &ethpb.GenericBeaconBlock{Block: &ethpb.GenericBeaconBlock_Phase0{Phase0: pb.(*ethpb.BeaconBlock)}}
+}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block_test.go
@@ -1,0 +1,130 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
+	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/testing/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConstructGenericBeaconBlock(t *testing.T) {
+	vs := &Server{}
+
+	// Test when sBlk or sBlk.Block() is nil
+	t.Run("NilBlock", func(t *testing.T) {
+		_, err := vs.constructGenericBeaconBlock(nil, nil, nil)
+		require.ErrorContains(t, err, "block cannot be nil")
+	})
+
+	// Test for Deneb version
+	t.Run("deneb block", func(t *testing.T) {
+		eb := util.NewBeaconBlockDeneb()
+		b, err := blocks.NewSignedBeaconBlock(eb)
+		require.NoError(t, err)
+		r1, err := b.Block().HashTreeRoot()
+		require.NoError(t, err)
+		scs := []*ethpb.BlobSidecar{
+			util.GenerateTestDenebBlobSidecar(r1, eb, 0, []byte{}),
+			util.GenerateTestDenebBlobSidecar(r1, eb, 1, []byte{}),
+			util.GenerateTestDenebBlobSidecar(r1, eb, 2, []byte{}),
+			util.GenerateTestDenebBlobSidecar(r1, eb, 3, []byte{}),
+			util.GenerateTestDenebBlobSidecar(r1, eb, 4, []byte{}),
+			util.GenerateTestDenebBlobSidecar(r1, eb, 5, []byte{}),
+		}
+		result, err := vs.constructGenericBeaconBlock(b, nil, scs)
+		require.NoError(t, err)
+		r2, err := result.GetDeneb().Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.Equal(t, r1, r2)
+		require.Equal(t, len(result.GetDeneb().Blobs), len(scs))
+		require.Equal(t, result.IsBlinded, false)
+	})
+
+	// Test for blind Deneb version
+	t.Run("blind deneb block", func(t *testing.T) {
+		b, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockDeneb())
+		require.NoError(t, err)
+		r1, err := b.Block().HashTreeRoot()
+		require.NoError(t, err)
+		scs := []*ethpb.BlindedBlobSidecar{{}, {}, {}, {}, {}, {}}
+		result, err := vs.constructGenericBeaconBlock(b, scs, nil)
+		require.NoError(t, err)
+		r2, err := result.GetBlindedDeneb().Block.HashTreeRoot()
+		require.NoError(t, err)
+		require.Equal(t, r1, r2)
+		require.Equal(t, len(result.GetBlindedDeneb().Blobs), len(scs))
+		require.Equal(t, result.IsBlinded, true)
+	})
+
+	// Test for Capella version
+	t.Run("capella block", func(t *testing.T) {
+		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockCapella())
+		require.NoError(t, err)
+		result, err := vs.constructGenericBeaconBlock(b, nil, nil)
+		require.NoError(t, err)
+		r1, err := result.GetCapella().HashTreeRoot()
+		require.NoError(t, err)
+		r2, err := b.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.Equal(t, r1, r2)
+		require.Equal(t, result.IsBlinded, false)
+	})
+
+	// Test for blind Capella version
+	t.Run("blind capella block", func(t *testing.T) {
+		b, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockCapella())
+		require.NoError(t, err)
+		result, err := vs.constructGenericBeaconBlock(b, nil, nil)
+		require.NoError(t, err)
+		r1, err := result.GetBlindedCapella().HashTreeRoot()
+		require.NoError(t, err)
+		r2, err := b.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.Equal(t, r1, r2)
+		require.Equal(t, result.IsBlinded, true)
+	})
+
+	// Test for Bellatrix version
+	t.Run("bellatrix block", func(t *testing.T) {
+		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockBellatrix())
+		require.NoError(t, err)
+		result, err := vs.constructGenericBeaconBlock(b, nil, nil)
+		require.NoError(t, err)
+		r1, err := result.GetBellatrix().HashTreeRoot()
+		require.NoError(t, err)
+		r2, err := b.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.Equal(t, r1, r2)
+		require.Equal(t, result.IsBlinded, false)
+	})
+
+	// Test for Altair version
+	t.Run("altair block", func(t *testing.T) {
+		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockAltair())
+		require.NoError(t, err)
+		result, err := vs.constructGenericBeaconBlock(b, nil, nil)
+		require.NoError(t, err)
+		r1, err := result.GetAltair().HashTreeRoot()
+		require.NoError(t, err)
+		r2, err := b.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.Equal(t, r1, r2)
+		require.Equal(t, result.IsBlinded, false)
+	})
+
+	// Test for phase0 version
+	t.Run("phase0 block", func(t *testing.T) {
+		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
+		require.NoError(t, err)
+		result, err := vs.constructGenericBeaconBlock(b, nil, nil)
+		require.NoError(t, err)
+		r1, err := result.GetPhase0().HashTreeRoot()
+		require.NoError(t, err)
+		r2, err := b.Block().HashTreeRoot()
+		require.NoError(t, err)
+		require.Equal(t, r1, r2)
+		require.Equal(t, result.IsBlinded, false)
+	})
+}


### PR DESCRIPTION
### Description:
This PR focuses on refactoring the `proposer.go` file, precisely the logic around constructing various versions of beacon blocks. The primary goal is to improve maintainability by abstracting repetitive code into helper functions.

### Changes:
- Removed code for constructing `GenericBeaconBlock` based on different versions and conditions.
- Added a new function `constructGenericBeaconBlock` that leverages a switch-case structure to call appropriate helper functions based on the block version.
- Created helper functions like `constructDenebBlock`, `constructCapellaBlock`, etc., for each version-specific block construction.
- Added `IsBlinded` and `PayloadValue` for deneb conditions 