### PR TITLE
`/eth/v1/config/deposit_contract` return string instead of uint

### DIFF
--- a/beacon-chain/rpc/eth/beacon/handlers.go
+++ b/beacon-chain/rpc/eth/beacon/handlers.go
@@ -746,10 +746,10 @@ func (*Server) GetDepositContract(w http.ResponseWriter, r *http.Request) {
 
 	http2.WriteJson(w, &DepositContractResponse{
 		Data: &struct {
-			ChainId uint64 `json:"chain_id"`
+			ChainId string `json:"chain_id"`
 			Address string `json:"address"`
 		}{
-			ChainId: params.BeaconConfig().DepositChainID,
+			ChainId: strconv.FormatUint(params.BeaconConfig().DepositChainID, 10),
 			Address: params.BeaconConfig().DepositContractAddress,
 		},
 	})

--- a/beacon-chain/rpc/eth/beacon/structs.go
+++ b/beacon-chain/rpc/eth/beacon/structs.go
@@ -20,7 +20,7 @@ type GetCommitteesResponse struct {
 
 type DepositContractResponse struct {
 	Data *struct {
-		ChainId uint64 `json:"chain_id"`
+		ChainId string `json:"chain_id"`
 		Address string `json:"address"`
 	} `json:"data"`
 }


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
`/eth/v1/config/deposit_contract` endpoint was sending the `chain_id` as a uint instead of a string.

**Which issues(s) does this PR fix?**

Fixes #12949

**Other notes for review**
