### PR TITLE
Refactor churn limit helpers

### DIFF
--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -137,16 +137,10 @@ func ProcessRegistryUpdates(ctx context.Context, state state.BeaconState) (state
 		return nil, errors.Wrap(err, "could not get active validator count")
 	}
 
-	churnLimit, err := helpers.ValidatorChurnLimit(activeValidatorCount)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get churn limit")
-	}
+	churnLimit := helpers.ValidatorActivationChurnLimit(activeValidatorCount)
 
 	if state.Version() >= version.Deneb {
-		// Cap churn limit to max per epoch churn limit. New in EIP7514.
-		if churnLimit > params.BeaconConfig().MaxPerEpochActivationChurnLimit {
-			churnLimit = params.BeaconConfig().MaxPerEpochActivationChurnLimit
-		}
+		churnLimit = helpers.ValidatorActivationChurnLimitDeneb(activeValidatorCount)
 	}
 
 	// Prevent churn limit cause index out of bound.

--- a/beacon-chain/core/epoch/epoch_processing_test.go
+++ b/beacon-chain/core/epoch/epoch_processing_test.go
@@ -311,8 +311,7 @@ func TestProcessRegistryUpdates_EligibleToActivate(t *testing.T) {
 		Slot:                5 * params.BeaconConfig().SlotsPerEpoch,
 		FinalizedCheckpoint: &ethpb.Checkpoint{Epoch: 6, Root: make([]byte, fieldparams.RootLength)},
 	}
-	limit, err := helpers.ValidatorChurnLimit(0)
-	require.NoError(t, err)
+	limit := helpers.ValidatorActivationChurnLimit(0)
 	for i := uint64(0); i < limit+10; i++ {
 		base.Validators = append(base.Validators, &ethpb.Validator{
 			ActivationEligibilityEpoch: params.BeaconConfig().FarFutureEpoch,

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -367,9 +367,50 @@ func TestChurnLimit_OK(t *testing.T) {
 		require.NoError(t, err)
 		validatorCount, err := ActiveValidatorCount(context.Background(), beaconState, time.CurrentEpoch(beaconState))
 		require.NoError(t, err)
-		resultChurn, err := ValidatorChurnLimit(validatorCount)
+		resultChurn := ValidatorActivationChurnLimit(validatorCount)
+		assert.Equal(t, test.wantedChurn, resultChurn, "ValidatorActivationChurnLimit(%d)", test.validatorCount)
+	}
+}
+
+func TestChurnLimitDeneb_OK(t *testing.T) {
+	tests := []struct {
+		validatorCount int
+		wantedChurn    uint64
+	}{
+		{1000, 4},
+		{100000, 4},
+		{1000000, params.BeaconConfig().MaxPerEpochActivationChurnLimit},
+		{2000000, params.BeaconConfig().MaxPerEpochActivationChurnLimit},
+	}
+
+	defer ClearCache()
+
+	for _, test := range tests {
+		ClearCache()
+
+		// Create validators
+		validators := make([]*ethpb.Validator, test.validatorCount)
+		for i := range validators {
+			validators[i] = &ethpb.Validator{
+				ExitEpoch: params.BeaconConfig().FarFutureEpoch,
+			}
+		}
+
+		// Initialize beacon state
+		beaconState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
+			Slot:        1,
+			Validators:  validators,
+			RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
+		})
 		require.NoError(t, err)
-		assert.Equal(t, test.wantedChurn, resultChurn, "ValidatorChurnLimit(%d)", test.validatorCount)
+
+		// Get active validator count
+		validatorCount, err := ActiveValidatorCount(context.Background(), beaconState, time.CurrentEpoch(beaconState))
+		require.NoError(t, err)
+
+		// Test churn limit calculation
+		resultChurn := ValidatorActivationChurnLimitDeneb(validatorCount)
+		assert.Equal(t, test.wantedChurn, resultChurn)
 	}
 }
 

--- a/beacon-chain/core/helpers/weak_subjectivity.go
+++ b/beacon-chain/core/helpers/weak_subjectivity.go
@@ -80,10 +80,7 @@ func ComputeWeakSubjectivityPeriod(ctx context.Context, st state.ReadOnlyBeaconS
 	T := cfg.MaxEffectiveBalance / cfg.GweiPerEth
 
 	// Validator churn limit.
-	delta, err := ValidatorChurnLimit(N)
-	if err != nil {
-		return 0, fmt.Errorf("cannot obtain active validator churn limit: %w", err)
-	}
+	delta := ValidatorExitChurnLimit(N)
 
 	// Balance top-ups.
 	Delta := uint64(cfg.SlotsPerEpoch.Mul(cfg.MaxDeposits))

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -82,10 +82,7 @@ func InitiateValidatorExit(ctx context.Context, s state.BeaconState, idx primiti
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "could not get active validator count")
 	}
-	currentChurn, err := helpers.ValidatorChurnLimit(activeValidatorCount)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "could not get churn limit")
-	}
+	currentChurn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
 
 	if churn >= currentChurn {
 		exitQueueEpoch, err = exitQueueEpoch.SafeAdd(1)
@@ -235,10 +232,7 @@ func ExitedValidatorIndices(epoch primitives.Epoch, validators []*ethpb.Validato
 			exitQueueChurn++
 		}
 	}
-	churn, err := helpers.ValidatorChurnLimit(activeValidatorCount)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get churn limit")
-	}
+	churn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
 	if churn < exitQueueChurn {
 		exitQueueEpoch++
 	}
@@ -276,10 +270,7 @@ func EjectedValidatorIndices(epoch primitives.Epoch, validators []*ethpb.Validat
 			exitQueueChurn++
 		}
 	}
-	churn, err := helpers.ValidatorChurnLimit(activeValidatorCount)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not get churn limit")
-	}
+	churn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
 	if churn < exitQueueChurn {
 		exitQueueEpoch++
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_stream.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_stream.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/runtime/version"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -422,10 +423,11 @@ func (is *infostream) calculateActivationTimeForPendingValidators(res []*ethpb.V
 
 	// Loop over epochs, roughly simulating progression.
 	for curEpoch := epoch + 1; len(sortedIndices) > 0 && len(pendingValidators) > 0; curEpoch++ {
-		toProcess, err := helpers.ValidatorChurnLimit(numAttestingValidators)
-		if err != nil {
-			log.WithError(err).Error("Could not determine validator churn limit")
+		toProcess := helpers.ValidatorActivationChurnLimit(numAttestingValidators)
+		if headState.Version() >= version.Deneb {
+			toProcess = helpers.ValidatorActivationChurnLimitDeneb(numAttestingValidators)
 		}
+
 		if toProcess > uint64(len(sortedIndices)) {
 			toProcess = uint64(len(sortedIndices))
 		}

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/validators_test.go
@@ -1370,8 +1370,7 @@ func TestServer_GetValidatorQueue_PendingActivation(t *testing.T) {
 	}
 	activeValidatorCount, err := helpers.ActiveValidatorCount(context.Background(), headState, coreTime.CurrentEpoch(headState))
 	require.NoError(t, err)
-	wantChurn, err := helpers.ValidatorChurnLimit(activeValidatorCount)
-	require.NoError(t, err)
+	wantChurn := helpers.ValidatorActivationChurnLimit(activeValidatorCount)
 	assert.Equal(t, wantChurn, res.ChurnLimit)
 	assert.DeepEqual(t, wanted, res.ActivationPublicKeys)
 	wantedActiveIndices := []primitives.ValidatorIndex{2, 1, 0}
@@ -1412,8 +1411,7 @@ func TestServer_GetValidatorQueue_ExitedValidatorLeavesQueue(t *testing.T) {
 	}
 	activeValidatorCount, err := helpers.ActiveValidatorCount(context.Background(), headState, coreTime.CurrentEpoch(headState))
 	require.NoError(t, err)
-	wantChurn, err := helpers.ValidatorChurnLimit(activeValidatorCount)
-	require.NoError(t, err)
+	wantChurn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
 	assert.Equal(t, wantChurn, res.ChurnLimit)
 	assert.DeepEqual(t, wanted, res.ExitPublicKeys)
 	wantedExitIndices := []primitives.ValidatorIndex{1}
@@ -1472,8 +1470,7 @@ func TestServer_GetValidatorQueue_PendingExit(t *testing.T) {
 	}
 	activeValidatorCount, err := helpers.ActiveValidatorCount(context.Background(), headState, coreTime.CurrentEpoch(headState))
 	require.NoError(t, err)
-	wantChurn, err := helpers.ValidatorChurnLimit(activeValidatorCount)
-	require.NoError(t, err)
+	wantChurn := helpers.ValidatorExitChurnLimit(activeValidatorCount)
 	assert.Equal(t, wantChurn, res.ChurnLimit)
 	assert.DeepEqual(t, wanted, res.ExitPublicKeys)
 }


### PR DESCRIPTION
This refactors the churn limit helper functions related to validator activities: 1) Activation, 2) Exit, and 3) Activation in Deneb.

### Key Changes

- Separated the `activate` and `exit` functionalities into distinct helper functions for clarity.
- Introduced a dedicated function for the Deneb-specific activation churn limit.
- Ensured the new helpers are applied consistently across all relevant parts of the code.