### PR TITLE
Remove go-playground/validator from Beacon API

### DIFF
--- a/beacon-chain/rpc/eth/beacon/BUILD.bazel
+++ b/beacon-chain/rpc/eth/beacon/BUILD.bazel
@@ -64,7 +64,6 @@ go_library(
         "//runtime/version:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
-        "@com_github_go_playground_validator_v10//:go_default_library",
         "@com_github_gorilla_mux//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-playground/validator/v10"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/feed"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/feed/operation"
@@ -87,11 +86,6 @@ func (s *Server) SubmitAttestations(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(req.Data) == 0 {
 		http2.HandleError(w, "No data submitted", http.StatusBadRequest)
-		return
-	}
-	validate := validator.New()
-	if err := validate.Struct(req); err != nil {
-		http2.HandleError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -207,11 +201,6 @@ func (s *Server) SubmitVoluntaryExit(w http.ResponseWriter, r *http.Request) {
 		return
 	case err != nil:
 		http2.HandleError(w, "Could not decode request body: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-	validate := validator.New()
-	if err := validate.Struct(req); err != nil {
-		http2.HandleError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 

--- a/beacon-chain/rpc/eth/shared/structs.go
+++ b/beacon-chain/rpc/eth/shared/structs.go
@@ -13,22 +13,22 @@ import (
 )
 
 type Attestation struct {
-	AggregationBits string           `json:"aggregation_bits" validate:"required,hexadecimal"`
-	Data            *AttestationData `json:"data" validate:"required"`
-	Signature       string           `json:"signature" validate:"required,hexadecimal"`
+	AggregationBits string           `json:"aggregation_bits"`
+	Data            *AttestationData `json:"data"`
+	Signature       string           `json:"signature"`
 }
 
 type AttestationData struct {
-	Slot            string      `json:"slot" validate:"required,number,gte=0"`
-	CommitteeIndex  string      `json:"index" validate:"required,number,gte=0"`
-	BeaconBlockRoot string      `json:"beacon_block_root" validate:"required,hexadecimal"`
-	Source          *Checkpoint `json:"source" validate:"required"`
-	Target          *Checkpoint `json:"target" validate:"required"`
+	Slot            string      `json:"slot"`
+	CommitteeIndex  string      `json:"index"`
+	BeaconBlockRoot string      `json:"beacon_block_root"`
+	Source          *Checkpoint `json:"source"`
+	Target          *Checkpoint `json:"target"`
 }
 
 type Checkpoint struct {
-	Epoch string `json:"epoch" validate:"required,number,gte=0"`
-	Root  string `json:"root" validate:"required,hexadecimal"`
+	Epoch string `json:"epoch"`
+	Root  string `json:"root"`
 }
 
 type Committee struct {
@@ -38,59 +38,59 @@ type Committee struct {
 }
 
 type SignedContributionAndProof struct {
-	Message   *ContributionAndProof `json:"message" validate:"required"`
-	Signature string                `json:"signature" validate:"required,hexadecimal"`
+	Message   *ContributionAndProof `json:"message"`
+	Signature string                `json:"signature"`
 }
 
 type ContributionAndProof struct {
-	AggregatorIndex string                     `json:"aggregator_index" validate:"required,number,gte=0"`
-	Contribution    *SyncCommitteeContribution `json:"contribution" validate:"required"`
-	SelectionProof  string                     `json:"selection_proof" validate:"required,hexadecimal"`
+	AggregatorIndex string                     `json:"aggregator_index"`
+	Contribution    *SyncCommitteeContribution `json:"contribution"`
+	SelectionProof  string                     `json:"selection_proof"`
 }
 
 type SyncCommitteeContribution struct {
-	Slot              string `json:"slot" validate:"required,number,gte=0"`
-	BeaconBlockRoot   string `json:"beacon_block_root" hex:"true" validate:"required,hexadecimal"`
-	SubcommitteeIndex string `json:"subcommittee_index" validate:"required,number,gte=0"`
-	AggregationBits   string `json:"aggregation_bits" hex:"true" validate:"required,hexadecimal"`
-	Signature         string `json:"signature" hex:"true" validate:"required,hexadecimal"`
+	Slot              string `json:"slot"`
+	BeaconBlockRoot   string `json:"beacon_block_root"`
+	SubcommitteeIndex string `json:"subcommittee_index"`
+	AggregationBits   string `json:"aggregation_bits"`
+	Signature         string `json:"signature"`
 }
 
 type SignedAggregateAttestationAndProof struct {
-	Message   *AggregateAttestationAndProof `json:"message" validate:"required"`
-	Signature string                        `json:"signature" validate:"required,hexadecimal"`
+	Message   *AggregateAttestationAndProof `json:"message"`
+	Signature string                        `json:"signature"`
 }
 
 type AggregateAttestationAndProof struct {
-	AggregatorIndex string       `json:"aggregator_index" validate:"required,number,gte=0"`
-	Aggregate       *Attestation `json:"aggregate" validate:"required"`
-	SelectionProof  string       `json:"selection_proof" validate:"required,hexadecimal"`
+	AggregatorIndex string       `json:"aggregator_index"`
+	Aggregate       *Attestation `json:"aggregate"`
+	SelectionProof  string       `json:"selection_proof"`
 }
 
 type SyncCommitteeSubscription struct {
-	ValidatorIndex       string   `json:"validator_index" validate:"required,number,gte=0"`
-	SyncCommitteeIndices []string `json:"sync_committee_indices" validate:"required,dive,number,gte=0"`
-	UntilEpoch           string   `json:"until_epoch" validate:"required,number,gte=0"`
+	ValidatorIndex       string   `json:"validator_index"`
+	SyncCommitteeIndices []string `json:"sync_committee_indices"`
+	UntilEpoch           string   `json:"until_epoch"`
 }
 
 type BeaconCommitteeSubscription struct {
-	ValidatorIndex   string `json:"validator_index" validate:"required,number,gte=0"`
-	CommitteeIndex   string `json:"committee_index" validate:"required,number,gte=0"`
-	CommitteesAtSlot string `json:"committees_at_slot" validate:"required,number,gte=0"`
-	Slot             string `json:"slot" validate:"required,number,gte=0"`
+	ValidatorIndex   string `json:"validator_index"`
+	CommitteeIndex   string `json:"committee_index"`
+	CommitteesAtSlot string `json:"committees_at_slot"`
+	Slot             string `json:"slot"`
 	IsAggregator     bool   `json:"is_aggregator"`
 }
 
 type ValidatorRegistration struct {
-	FeeRecipient string `json:"fee_recipient" validate:"required,hexadecimal"`
-	GasLimit     string `json:"gas_limit" validate:"required,number,gte=0"`
-	Timestamp    string `json:"timestamp" validate:"required,number,gte=0"`
-	Pubkey       string `json:"pubkey" validate:"required,hexadecimal"`
+	FeeRecipient string `json:"fee_recipient"`
+	GasLimit     string `json:"gas_limit"`
+	Timestamp    string `json:"timestamp"`
+	Pubkey       string `json:"pubkey"`
 }
 
 type SignedValidatorRegistration struct {
-	Message   *ValidatorRegistration `json:"message" validate:"required"`
-	Signature string                 `json:"signature" validate:"required,hexadecimal"`
+	Message   *ValidatorRegistration `json:"message"`
+	Signature string                 `json:"signature"`
 }
 
 type FeeRecipient struct {
@@ -99,13 +99,13 @@ type FeeRecipient struct {
 }
 
 type SignedVoluntaryExit struct {
-	Message   *VoluntaryExit `json:"message" validate:"required"`
-	Signature string         `json:"signature" validate:"required,hexadecimal"`
+	Message   *VoluntaryExit `json:"message"`
+	Signature string         `json:"signature"`
 }
 
 type VoluntaryExit struct {
-	Epoch          string `json:"epoch" validate:"required,number,gte=0"`
-	ValidatorIndex string `json:"validator_index" validate:"required,number,gte=0"`
+	Epoch          string `json:"epoch"`
+	ValidatorIndex string `json:"validator_index"`
 }
 
 type Fork struct {
@@ -135,10 +135,10 @@ func (s *Fork) ToConsensus() (*eth.Fork, error) {
 }
 
 type SyncCommitteeMessage struct {
-	Slot            string `json:"slot" validate:"required,number,gte=0"`
-	BeaconBlockRoot string `json:"beacon_block_root" validate:"required,hexadecimal"`
-	ValidatorIndex  string `json:"validator_index" validate:"required,number,gte=0"`
-	Signature       string `json:"signature" validate:"required,hexadecimal"`
+	Slot            string `json:"slot"`
+	BeaconBlockRoot string `json:"beacon_block_root"`
+	ValidatorIndex  string `json:"validator_index"`
+	Signature       string `json:"signature"`
 }
 
 func (s *SignedValidatorRegistration) ToConsensus() (*eth.SignedValidatorRegistrationV1, error) {

--- a/beacon-chain/rpc/eth/validator/BUILD.bazel
+++ b/beacon-chain/rpc/eth/validator/BUILD.bazel
@@ -45,7 +45,6 @@ go_library(
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
-        "@com_github_go_playground_validator_v10//:go_default_library",
         "@com_github_gorilla_mux//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/beacon-chain/rpc/eth/validator/handlers.go
+++ b/beacon-chain/rpc/eth/validator/handlers.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/go-playground/validator/v10"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/builder"
@@ -127,11 +126,6 @@ func (s *Server) SubmitContributionAndProofs(w http.ResponseWriter, r *http.Requ
 		http2.HandleError(w, "No data submitted", http.StatusBadRequest)
 		return
 	}
-	validate := validator.New()
-	if err := validate.Struct(req); err != nil {
-		http2.HandleError(w, err.Error(), http.StatusBadRequest)
-		return
-	}
 
 	for _, item := range req.Data {
 		consensusItem, err := item.ToConsensus()
@@ -163,11 +157,6 @@ func (s *Server) SubmitAggregateAndProofs(w http.ResponseWriter, r *http.Request
 	}
 	if len(req.Data) == 0 {
 		http2.HandleError(w, "No data submitted", http.StatusBadRequest)
-		return
-	}
-	validate := validator.New()
-	if err := validate.Struct(req); err != nil {
-		http2.HandleError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -223,11 +212,6 @@ func (s *Server) SubmitSyncCommitteeSubscription(w http.ResponseWriter, r *http.
 	}
 	if len(req.Data) == 0 {
 		http2.HandleError(w, "No data submitted", http.StatusBadRequest)
-		return
-	}
-	validate := validator.New()
-	if err := validate.Struct(req); err != nil {
-		http2.HandleError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -338,11 +322,6 @@ func (s *Server) SubmitBeaconCommitteeSubscription(w http.ResponseWriter, r *htt
 	}
 	if len(req.Data) == 0 {
 		http2.HandleError(w, "No data submitted", http.StatusBadRequest)
-		return
-	}
-	validate := validator.New()
-	if err := validate.Struct(req); err != nil {
-		http2.HandleError(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -570,13 +549,8 @@ func (s *Server) RegisterValidator(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	validate := validator.New()
 	registrations := make([]*ethpbalpha.SignedValidatorRegistrationV1, len(jsonRegistrations))
 	for i, registration := range jsonRegistrations {
-		if err := validate.Struct(registration); err != nil {
-			http2.HandleError(w, err.Error(), http.StatusBadRequest)
-			return
-		}
 		reg, err := registration.ToConsensus()
 		if err != nil {
 			http2.HandleError(w, err.Error(), http.StatusBadRequest)

--- a/beacon-chain/rpc/eth/validator/structs.go
+++ b/beacon-chain/rpc/eth/validator/structs.go
@@ -11,19 +11,19 @@ type AggregateAttestationResponse struct {
 }
 
 type SubmitContributionAndProofsRequest struct {
-	Data []*shared.SignedContributionAndProof `json:"data" validate:"required,dive"`
+	Data []*shared.SignedContributionAndProof `json:"data"`
 }
 
 type SubmitAggregateAndProofsRequest struct {
-	Data []*shared.SignedAggregateAttestationAndProof `json:"data" validate:"required,dive"`
+	Data []*shared.SignedAggregateAttestationAndProof `json:"data"`
 }
 
 type SubmitSyncCommitteeSubscriptionsRequest struct {
-	Data []*shared.SyncCommitteeSubscription `json:"data" validate:"required,dive"`
+	Data []*shared.SyncCommitteeSubscription `json:"data"`
 }
 
 type SubmitBeaconCommitteeSubscriptionsRequest struct {
-	Data []*shared.BeaconCommitteeSubscription `json:"data" validate:"required,dive"`
+	Data []*shared.BeaconCommitteeSubscription `json:"data"`
 }
 
 type GetAttestationDataResponse struct {


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

When converting data posted in the request to the consensus type, we check that the input is correct before we can decode it (example below). The validation package doesn't bring us much benefit, it essentially duplicates the same checks. We can bring it back in the future in case more sophisticated validation is needed that this package handles well.  

```
func (s *SyncCommitteeContribution) ToConsensus() (*eth.SyncCommitteeContribution, error) {
	slot, err := strconv.ParseUint(s.Slot, 10, 64)
	if err != nil {
		return nil, NewDecodeError(err, "Slot")
	}
	bbRoot, err := hexutil.Decode(s.BeaconBlockRoot)
	if err != nil {
		return nil, NewDecodeError(err, "BeaconBlockRoot")
	}
	subcommitteeIndex, err := strconv.ParseUint(s.SubcommitteeIndex, 10, 64)
	if err != nil {
		return nil, NewDecodeError(err, "SubcommitteeIndex")
	}
	aggBits, err := hexutil.Decode(s.AggregationBits)
	if err != nil {
		return nil, NewDecodeError(err, "AggregationBits")
	}
	sig, err := hexutil.Decode(s.Signature)
	if err != nil {
		return nil, NewDecodeError(err, "Signature")
	}

	return &eth.SyncCommitteeContribution{
		Slot:              primitives.Slot(slot),
		BlockRoot:         bbRoot,
		SubcommitteeIndex: subcommitteeIndex,
		AggregationBits:   aggBits,
		Signature:         sig,
	}, nil
}
```

**Which issues(s) does this PR fix?**

Part of #12958 
