### PR TITLE
Return RpcError from core service's `SubmitSyncMessage`

### DIFF
--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -459,12 +459,12 @@ func (s *Service) GetAttestationData(
 
 // SubmitSyncMessage submits the sync committee message to the network.
 // It also saves the sync committee message into the pending pool for block inclusion.
-func (s *Service) SubmitSyncMessage(ctx context.Context, msg *ethpb.SyncCommitteeMessage) error {
+func (s *Service) SubmitSyncMessage(ctx context.Context, msg *ethpb.SyncCommitteeMessage) *RpcError {
 	errs, ctx := errgroup.WithContext(ctx)
 
 	headSyncCommitteeIndices, err := s.HeadFetcher.HeadSyncCommitteeIndices(ctx, msg.ValidatorIndex, msg.Slot)
 	if err != nil {
-		return err
+		return &RpcError{Reason: Internal, Err: errors.Wrap(err, "could not get head sync committee indices")}
 	}
 	// Broadcasting and saving message into the pool in parallel. As one fail should not affect another.
 	// This broadcasts for all subnets.
@@ -477,9 +477,12 @@ func (s *Service) SubmitSyncMessage(ctx context.Context, msg *ethpb.SyncCommitte
 	}
 
 	if err := s.SyncCommitteePool.SaveSyncCommitteeMessage(msg); err != nil {
-		return err
+		return &RpcError{Reason: Internal, Err: errors.Wrap(err, "could not save sync committee message")}
 	}
 
 	// Wait for p2p broadcast to complete and return the first error (if any)
-	return errs.Wait()
+	if err = errs.Wait(); err != nil {
+		return &RpcError{Reason: Internal, Err: errors.Wrap(err, "could not broadcast sync committee message")}
+	}
+	return nil
 }

--- a/beacon-chain/rpc/eth/beacon/handlers_pool.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/feed/operation"
 	corehelpers "github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/transition"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/core"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/eth/shared"
 	state_native "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
@@ -292,8 +293,8 @@ func (s *Server) SubmitSyncCommitteeSignatures(w http.ResponseWriter, r *http.Re
 	}
 
 	for _, msg := range validMessages {
-		if err = s.CoreService.SubmitSyncMessage(ctx, msg); err != nil {
-			http2.HandleError(w, "Could not submit message: "+err.Error(), http.StatusInternalServerError)
+		if rpcerr := s.CoreService.SubmitSyncMessage(ctx, msg); rpcerr != nil {
+			http2.HandleError(w, "Could not submit message: "+rpcerr.Err.Error(), core.ErrorReasonToHTTP(rpcerr.Reason))
 			return
 		}
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/sync_committee.go
@@ -35,7 +35,10 @@ func (vs *Server) GetSyncMessageBlockRoot(
 // SubmitSyncMessage submits the sync committee message to the network.
 // It also saves the sync committee message into the pending pool for block inclusion.
 func (vs *Server) SubmitSyncMessage(ctx context.Context, msg *ethpb.SyncCommitteeMessage) (*emptypb.Empty, error) {
-	return &emptypb.Empty{}, vs.CoreService.SubmitSyncMessage(ctx, msg)
+	if err := vs.CoreService.SubmitSyncMessage(ctx, msg); err != nil {
+		return &emptypb.Empty{}, status.Errorf(core.ErrorReasonToGRPC(err.Reason), err.Err.Error())
+	}
+	return &emptypb.Empty{}, nil
 }
 
 // GetSyncSubcommitteeIndex is called by a sync committee participant to get


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

Makes error handling of core service more standard
