### PR TITLE
Do Not Calculate Churn With 0 Exits

### DIFF
--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -51,6 +51,10 @@ func ProcessVoluntaryExits(
 	beaconState state.BeaconState,
 	exits []*ethpb.SignedVoluntaryExit,
 ) (state.BeaconState, error) {
+	// Avoid calculating the epoch churn if no exits exist.
+	if len(exits) == 0 {
+		return beaconState, nil
+	}
 	maxExitEpoch, churn := v.ValidatorsMaxExitEpochAndChurn(beaconState)
 	var exitEpoch primitives.Epoch
 	for idx, exit := range exits {


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In #12737 , we refactored our exits function to only calculate the churn once while processing voluntary exits. However this has lead to us computing the churn even for blocks which have 0 exits. This PR adds in a short-circuit to allow blocks with 0 exits to be processed more efficiently

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
