### PR TITLE
Fix Long Running E2E

### DIFF
--- a/testing/endtoend/evaluators/operations.go
+++ b/testing/endtoend/evaluators/operations.go
@@ -37,7 +37,7 @@ var depositsInBlockStart = params.E2ETestConfig().EpochsPerEth1VotingPeriod * 2
 
 // deposits included + finalization + MaxSeedLookahead for activation.
 var depositActivationStartEpoch = depositsInBlockStart + 2 + params.E2ETestConfig().MaxSeedLookahead
-var depositEndEpoch = depositActivationStartEpoch + primitives.Epoch(math.Ceil(float64(depositValCount)/float64(params.BeaconConfig().MinPerEpochChurnLimit)))
+var depositEndEpoch = depositActivationStartEpoch + primitives.Epoch(math.Ceil(float64(depositValCount)/float64(params.E2ETestConfig().MinPerEpochChurnLimit)))
 var exitSubmissionEpoch = primitives.Epoch(7)
 
 // ProcessesDepositsInBlocks ensures the expected amount of deposits are accepted into blocks.


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In #12959, we added support for EIP-7514, which capped the max activation limit but also in the process broke long running e2e due to how the epoch churn limit was calculated. This PR fixes it to use the test config when calculating the correct churn

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
