### PR TITLE
lock the state when reading from all validators

### DIFF
--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -157,12 +157,12 @@ func (b *BeaconState) NumValidators() int {
 //
 // WARNING: This method is potentially unsafe, as it exposes the actual validator registry.
 func (b *BeaconState) ReadFromEveryValidator(f func(idx int, val state.ReadOnlyValidator) error) error {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
 	if b.validators == nil {
 		return errors.New("nil validators in state")
 	}
-	b.lock.RLock()
 	validators := b.validators
-	b.lock.RUnlock()
 
 	for i, v := range validators {
 		v, err := NewValidator(v)


### PR DESCRIPTION
We are performing a loop over the validator set without a read lock. 