### PR TITLE
Check blob exists before requesting from peer

### DIFF
--- a/beacon-chain/sync/BUILD.bazel
+++ b/beacon-chain/sync/BUILD.bazel
@@ -228,6 +228,7 @@ go_test(
         "//encoding/ssz/equality:go_default_library",
         "//network/forks:go_default_library",
         "//proto/engine/v1:go_default_library",
+        "//proto/eth/v2:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//proto/prysm/v1alpha1/attestation:go_default_library",
         "//proto/prysm/v1alpha1/metadata:go_default_library",

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -12,7 +12,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
-	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/runtime/version"
 )
@@ -45,7 +44,7 @@ func (s *Service) sendRecentBeaconBlocksRequest(ctx context.Context, blockRoots 
 		if err != nil {
 			return err
 		}
-		if err := s.requestPendingBlobs(ctx, blk.Block(), blkRoot[:], id); err != nil {
+		if err := s.requestPendingBlobs(ctx, blk.Block(), blkRoot, id); err != nil {
 			return err
 		}
 	}
@@ -117,7 +116,7 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 }
 
 // requestPendingBlobs handles the request for pending blobs based on the given beacon block.
-func (s *Service) requestPendingBlobs(ctx context.Context, block interfaces.ReadOnlyBeaconBlock, blockRoot []byte, peerID peer.ID) error {
+func (s *Service) requestPendingBlobs(ctx context.Context, block interfaces.ReadOnlyBeaconBlock, blockRoot [32]byte, peerID peer.ID) error {
 	if block.Version() < version.Deneb {
 		return nil // Block before deneb has no blob.
 	}
@@ -136,7 +135,7 @@ func (s *Service) requestPendingBlobs(ctx context.Context, block interfaces.Read
 		return err
 	}
 
-	request, err := s.constructPendingBlobsRequest(ctx, bytesutil.ToBytes32(blockRoot), len(commitments))
+	request, err := s.constructPendingBlobsRequest(ctx, blockRoot, len(commitments))
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -6,11 +6,13 @@ import (
 	libp2pcore "github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/execution"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/p2p/types"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
+	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/runtime/version"
 )
@@ -114,41 +116,78 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 	return nil
 }
 
-func (s *Service) requestPendingBlobs(ctx context.Context, b interfaces.ReadOnlyBeaconBlock, br []byte, id peer.ID) error {
-	// Block before deneb has no blob.
-	if b.Version() < version.Deneb {
-		return nil
-	}
-	c, err := b.Body().BlobKzgCommitments()
-	if err != nil {
-		return err
-	}
-	// No op if the block has no blob commitments.
-	if len(c) == 0 {
-		return nil
+// requestPendingBlobs handles the request for pending blobs based on the given beacon block.
+func (s *Service) requestPendingBlobs(ctx context.Context, block interfaces.ReadOnlyBeaconBlock, blockRoot []byte, peerID peer.ID) error {
+	if block.Version() < version.Deneb {
+		return nil // Block before deneb has no blob.
 	}
 
-	// Build request for blob sidecars.
-	blobId := make([]*eth.BlobIdentifier, len(c))
-	for i := range c {
-		blobId[i] = &eth.BlobIdentifier{Index: uint64(i), BlockRoot: br}
-	}
-
-	ctxByte, err := ContextByteVersionsForValRoot(s.cfg.chain.GenesisValidatorsRoot())
-	if err != nil {
-		return err
-	}
-	req := types.BlobSidecarsByRootReq(blobId)
-
-	// Send request to a random peer.
-	blobSidecars, err := SendBlobSidecarByRoot(ctx, s.cfg.clock, s.cfg.p2p, id, ctxByte, &req)
+	commitments, err := block.Body().BlobKzgCommitments()
 	if err != nil {
 		return err
 	}
 
-	for _, sidecar := range blobSidecars {
+	if len(commitments) == 0 {
+		return nil // No operation if the block has no blob commitments.
+	}
+
+	contextByte, err := ContextByteVersionsForValRoot(s.cfg.chain.GenesisValidatorsRoot())
+	if err != nil {
+		return err
+	}
+
+	request, err := s.constructPendingBlobsRequest(ctx, bytesutil.ToBytes32(blockRoot), len(commitments))
+	if err != nil {
+		return err
+	}
+
+	return s.sendAndSaveBlobSidecars(ctx, request, contextByte, peerID)
+}
+
+// sendAndSaveBlobSidecars sends the blob request and saves received sidecars.
+func (s *Service) sendAndSaveBlobSidecars(ctx context.Context, request types.BlobSidecarsByRootReq, contextByte ContextByteVersions, peerID peer.ID) error {
+	sidecars, err := SendBlobSidecarByRoot(ctx, s.cfg.clock, s.cfg.p2p, peerID, contextByte, &request)
+	if err != nil {
+		return err
+	}
+
+	for _, sidecar := range sidecars {
 		log.WithFields(blobFields(sidecar)).Debug("Received blob sidecar gossip RPC")
 	}
 
-	return s.cfg.beaconDB.SaveBlobSidecar(ctx, blobSidecars)
+	return s.cfg.beaconDB.SaveBlobSidecar(ctx, sidecars)
+}
+
+// constructPendingBlobsRequest creates a request for BlobSidecars by root, considering blobs already in DB.
+func (s *Service) constructPendingBlobsRequest(ctx context.Context, blockRoot [32]byte, count int) (types.BlobSidecarsByRootReq, error) {
+	knownBlobs, err := s.cfg.beaconDB.BlobSidecarsByRoot(ctx, blockRoot)
+	if err != nil && !errors.Is(err, db.ErrNotFound) {
+		return nil, err
+	}
+
+	knownIndices := indexSetFromBlobs(knownBlobs)
+	requestedIndices := filterUnknownIndices(knownIndices, count, blockRoot)
+
+	return requestedIndices, nil
+}
+
+// Helper function to create a set of known indices.
+func indexSetFromBlobs(blobs []*eth.BlobSidecar) map[uint64]struct{} {
+	indices := make(map[uint64]struct{})
+	for _, blob := range blobs {
+		indices[blob.Index] = struct{}{}
+	}
+	return indices
+}
+
+// Helper function to filter out known indices.
+func filterUnknownIndices(knownIndices map[uint64]struct{}, count int, blockRoot [32]byte) []*eth.BlobIdentifier {
+	var ids []*eth.BlobIdentifier
+	for i := uint64(0); i < uint64(count); i++ {
+		if _, exists := knownIndices[i]; exists {
+			continue
+		}
+		ids = append(ids, &eth.BlobIdentifier{Index: i, BlockRoot: blockRoot[:]})
+	}
+	return ids
 }

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -322,9 +322,10 @@ func TestRequestPendingBlobs(t *testing.T) {
 		p1.Peers().SetChainState(p2.PeerID(), &ethpb.Status{FinalizedEpoch: 1})
 		s := &Service{
 			cfg: &config{
-				p2p:   p1,
-				chain: chain,
-				clock: startup.NewClock(time.Unix(0, 0), [32]byte{}),
+				p2p:      p1,
+				chain:    chain,
+				clock:    startup.NewClock(time.Unix(0, 0), [32]byte{}),
+				beaconDB: db.SetupDB(t),
 			},
 		}
 		b := util.NewBeaconBlockDeneb()
@@ -344,6 +345,7 @@ func TestConstructPendingBlobsRequest(t *testing.T) {
 	root := [32]byte{1}
 	count := 3
 	actual, err := s.constructPendingBlobsRequest(ctx, root, count)
+	require.NoError(t, err)
 	require.Equal(t, 3, len(actual))
 	for i, id := range actual {
 		require.Equal(t, uint64(i), id.Index)

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -402,6 +402,8 @@ func TestFilterUnknownIndices(t *testing.T) {
 
 	actual := filterUnknownIndices(knownIndices, count, blockRoot)
 	require.Equal(t, len(expected), len(actual))
+	require.Equal(t, expected[0].Index, actual[0].Index)
 	require.DeepEqual(t, actual[0].BlockRoot, expected[0].BlockRoot)
+	require.Equal(t, expected[1].Index, actual[1].Index)
 	require.DeepEqual(t, actual[1].BlockRoot, expected[1].BlockRoot)
 }


### PR DESCRIPTION
Fixes #13011

This PR enhances blob retrieval from peers by first checking if the blobs are already present in the DB before requesting. It also includes refactoring of the `requestPendingBlobs` function to improve code clarity.

Inside `requestPendingBlobs`, the PR introduces two steps:
  - **`constructPendingBlobsRequest`**: This function constructs the request object by filtering out known indices through a db call.   
  - **`sendAndSaveBlobSidecars`**: Utilizes the request object from `constructPendingBlobsRequest` to request blobs by their root and subsequently save them to the DB.