### PR TITLE
Check block exists in pending queue before requesting from peer

### DIFF
--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -75,14 +75,16 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 			delete(s.blkRootToPendingAtts, bRoot)
 			s.pendingAttsLock.Unlock()
 		} else {
-			// Pending attestation's missing block has not arrived yet.
-			log.WithFields(logrus.Fields{
-				"currentSlot": s.cfg.clock.CurrentSlot(),
-				"attSlot":     attestations[0].Message.Aggregate.Data.Slot,
-				"attCount":    len(attestations),
-				"blockRoot":   hex.EncodeToString(bytesutil.Trunc(bRoot[:])),
-			}).Debug("Requesting block for pending attestation")
-			pendingRoots = append(pendingRoots, bRoot)
+			if !s.seenPendingBlocks[bRoot] {
+				// Pending attestation's missing block has not arrived yet.
+				log.WithFields(logrus.Fields{
+					"currentSlot": s.cfg.clock.CurrentSlot(),
+					"attSlot":     attestations[0].Message.Aggregate.Data.Slot,
+					"attCount":    len(attestations),
+					"blockRoot":   hex.EncodeToString(bytesutil.Trunc(bRoot[:])),
+				}).Debug("Requesting block for pending attestation")
+				pendingRoots = append(pendingRoots, bRoot)
+			}
 		}
 	}
 	return s.sendBatchRootRequest(ctx, pendingRoots, randGen)

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -75,7 +75,10 @@ func (s *Service) processPendingAtts(ctx context.Context) error {
 			delete(s.blkRootToPendingAtts, bRoot)
 			s.pendingAttsLock.Unlock()
 		} else {
-			if !s.seenPendingBlocks[bRoot] {
+			s.pendingQueueLock.RLock()
+			seen := s.seenPendingBlocks[bRoot]
+			s.pendingQueueLock.RUnlock()
+			if !seen {
 				// Pending attestation's missing block has not arrived yet.
 				log.WithFields(logrus.Fields{
 					"currentSlot": s.cfg.clock.CurrentSlot(),

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -248,7 +248,8 @@ func (s *Service) sendBatchRootRequest(ctx context.Context, roots [][32]byte, ra
 
 	roots = dedupRoots(roots)
 	for i := len(roots) - 1; i >= 0; i-- {
-		if s.cfg.chain.BlockBeingSynced(roots[i]) {
+		r := roots[i]
+		if s.seenPendingBlocks[r] || s.cfg.chain.BlockBeingSynced(r) {
 			roots = append(roots[:i], roots[i+1:]...)
 		}
 	}

--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -247,12 +247,15 @@ func (s *Service) sendBatchRootRequest(ctx context.Context, roots [][32]byte, ra
 	defer span.End()
 
 	roots = dedupRoots(roots)
+	s.pendingQueueLock.RLock()
 	for i := len(roots) - 1; i >= 0; i-- {
 		r := roots[i]
 		if s.seenPendingBlocks[r] || s.cfg.chain.BlockBeingSynced(r) {
 			roots = append(roots[:i], roots[i+1:]...)
 		}
 	}
+	s.pendingQueueLock.RUnlock()
+
 	if len(roots) == 0 {
 		return nil
 	}


### PR DESCRIPTION
Fixes an issue where redundant requests were made to peers for blocks already present in the pending queue, adversely affecting peer scoring.

#### Changes:

1. **Pending Attestation Queue**: Check if the block exists in the queue before appending pending roots.
2. **Batch Root Request**: Similar to `BlockBeingSynced`, removes the root from the request list if it's already seen.

This PR adds checks in both places for future-proofing.