### PR TITLE
Exit early if blob by root request is empty

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -145,6 +145,10 @@ func (s *Service) requestPendingBlobs(ctx context.Context, block interfaces.Read
 
 // sendAndSaveBlobSidecars sends the blob request and saves received sidecars.
 func (s *Service) sendAndSaveBlobSidecars(ctx context.Context, request types.BlobSidecarsByRootReq, contextByte ContextByteVersions, peerID peer.ID) error {
+	if len(request) == 0 {
+		return nil
+	}
+
 	sidecars, err := SendBlobSidecarByRoot(ctx, s.cfg.clock, s.cfg.p2p, peerID, contextByte, &request)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR introduces a length check for the blob request parameter at the function level. The aim is to prevent errors that get triggered and subsequently propagated upstream when the parameter's length is 0.

This check could be added at the caller level, implementing it at the function level centralizes the logic, thereby making the code easier to maintain and less prone to errors.