### PR TITLE
Passing block as arugment for sidecar validation

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -197,7 +197,7 @@ func (s *Service) processAndBroadcastBlock(ctx context.Context, b interfaces.Rea
 	peers := s.getBestPeers()
 	peerCount := len(peers)
 	if peerCount > 0 {
-		if err := s.requestPendingBlobs(ctx, b.Block(), blkRoot, peers[rand.NewGenerator().Int()%peerCount]); err != nil {
+		if err := s.requestPendingBlobs(ctx, b, blkRoot, peers[rand.NewGenerator().Int()%peerCount]); err != nil {
 			return err
 		}
 	}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root_test.go
@@ -295,12 +295,12 @@ func TestRecentBeaconBlocksRPCHandler_HandleZeroBlocks(t *testing.T) {
 func TestRequestPendingBlobs(t *testing.T) {
 	s := &Service{}
 	t.Run("old block should not fail", func(t *testing.T) {
-		b, err := blocks.NewBeaconBlock(util.NewBeaconBlock().Block)
+		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 		require.NoError(t, err)
 		require.NoError(t, s.requestPendingBlobs(context.Background(), b, [32]byte{}, "test"))
 	})
 	t.Run("empty commitment block should not fail", func(t *testing.T) {
-		b, err := blocks.NewBeaconBlock(util.NewBeaconBlockDeneb().Block)
+		b, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 		require.NoError(t, err)
 		require.NoError(t, s.requestPendingBlobs(context.Background(), b, [32]byte{}, "test"))
 	})
@@ -330,7 +330,7 @@ func TestRequestPendingBlobs(t *testing.T) {
 		}
 		b := util.NewBeaconBlockDeneb()
 		b.Block.Body.BlobKzgCommitments = make([][]byte, 1)
-		b1, err := blocks.NewBeaconBlock(b.Block)
+		b1, err := blocks.NewSignedBeaconBlock(b)
 		require.NoError(t, err)
 		require.ErrorContains(t, "protocols not supported", s.requestPendingBlobs(context.Background(), b1, [32]byte{}, p2.PeerID()))
 	})


### PR DESCRIPTION
When performing blob alignment checks in the `sendAndSaveBlobSidecars` path, it's possible that the block may not yet exist in the database if it's in the pending queue. To address this issue, we should pass the block directly as an argument. It's  more simpler and more efficient this way