### PR TITLE
Fix misleading log msg on shutdown

### DIFF
--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -148,7 +148,7 @@ func NewService(ctx context.Context, cfg *Config) *Service {
 		log.WithError(err).Errorf("Could not listen to port in Start() %s", address)
 	}
 	s.listener = lis
-	log.WithField("address", address).Info("gRPC server listening on port")
+	log.WithField("address", address).Info("beacon-chain gRPC server listening")
 
 	opts := []grpc.ServerOption{
 		grpc.StatsHandler(&ocgrpc.ServerHandler{}),
@@ -517,7 +517,7 @@ func (s *Service) Stop() error {
 	s.cancel()
 	if s.listener != nil {
 		s.grpcServer.GracefulStop()
-		log.Debug("Initiated graceful stop of gRPC server")
+		log.Debug("Completed graceful stop of beacon-chain gRPC server")
 	}
 	return nil
 }

--- a/beacon-chain/rpc/service_test.go
+++ b/beacon-chain/rpc/service_test.go
@@ -41,8 +41,9 @@ func TestLifecycle_OK(t *testing.T) {
 
 	rpcService.Start()
 
-	require.LogsContain(t, hook, "listening on port")
+	require.LogsContain(t, hook, "beacon-chain gRPC server listening")
 	assert.NoError(t, rpcService.Stop())
+	require.LogsContain(t, hook, "Completed graceful stop of beacon-chain gRPC server")
 }
 
 func TestStatus_CredentialError(t *testing.T) {
@@ -82,7 +83,7 @@ func TestRPC_InsecureEndpoint(t *testing.T) {
 
 	rpcService.Start()
 
-	require.LogsContain(t, hook, "listening on port")
+	require.LogsContain(t, hook, "beacon-chain gRPC server listening")
 	require.LogsContain(t, hook, "You are using an insecure gRPC server")
 	assert.NoError(t, rpcService.Stop())
 }

--- a/validator/rpc/BUILD.bazel
+++ b/validator/rpc/BUILD.bazel
@@ -143,6 +143,8 @@ go_test(
         "@com_github_gorilla_mux//:go_default_library",
         "@com_github_grpc_ecosystem_grpc_gateway_v2//runtime:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_github_sirupsen_logrus//hooks/test:go_default_library",
         "@com_github_tyler_smith_go_bip39//:go_default_library",
         "@com_github_wealdtech_go_eth2_wallet_encryptor_keystorev4//:go_default_library",
         "@org_golang_google_grpc//:go_default_library",

--- a/validator/rpc/server.go
+++ b/validator/rpc/server.go
@@ -194,7 +194,7 @@ func (s *Server) Start() {
 		}
 	}()
 
-	log.WithField("address", address).Info("gRPC server listening on address")
+	log.WithField("address", address).Info("validator gRPC server listening")
 	if s.walletDir != "" {
 		token, err := s.initializeAuthToken(s.walletDir)
 		if err != nil {
@@ -215,7 +215,7 @@ func (s *Server) Stop() error {
 	s.cancel()
 	if s.listener != nil {
 		s.grpcServer.GracefulStop()
-		log.Debug("Initiated graceful stop of server")
+		log.Debug("Completed graceful stop of validator gRPC server")
 	}
 	return nil
 }

--- a/validator/rpc/server_test.go
+++ b/validator/rpc/server_test.go
@@ -1,7 +1,32 @@
 package rpc
 
 import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/gorilla/mux"
 	pb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1/validator-client"
+	"github.com/prysmaticlabs/prysm/v4/testing/assert"
+	"github.com/prysmaticlabs/prysm/v4/testing/require"
+	"github.com/sirupsen/logrus"
+	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
 var _ pb.AuthServer = (*Server)(nil)
+
+func init() {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetOutput(io.Discard)
+}
+
+func TestLifecycleWithMinimumConfig(t *testing.T) {
+	hook := logTest.NewGlobal()
+
+	server := NewServer(context.Background(), &Config{Router: mux.NewRouter()})
+	server.Start()
+
+	require.LogsContain(t, hook, "validator gRPC server listening")
+	assert.NoError(t, server.Stop())
+	require.LogsContain(t, hook, "Completed graceful stop of validator gRPC server")
+}


### PR DESCRIPTION
**What type of PR is this?**
Other

**What does this PR do? Why is it needed?**
gRPCServer.GracefulStop blocks until it has been shutdown. Logging "Initiated graceful stop" after it has been completed is misleading. Names are added to the message to discern services. Also, a minimum test is added mainly to verify the change made with this commit.
**Which issues(s) does this PR fix?**

Fixes #
No related issue.

**Other notes for review**
It looks like gRPC is in progress of moving to HTTP. So I minimized the changes.
Please let me know if I'm mistaken and/or it's okay to add tests in gRPC modules.