### PR TITLE
Remove sidecars with invalid proofs

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -390,7 +390,7 @@ func (s *Service) removeInvalidBlockAndState(ctx context.Context, blkRoots [][32
 			return err
 		}
 		// No op if the sidecar does not exist.
-		if err := s.cfg.BeaconDB.DeleteBlobSidecar(ctx, root); err != nil {
+		if err := s.cfg.BeaconDB.DeleteBlobSidecars(ctx, root); err != nil {
 			return err
 		}
 	}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -564,6 +564,8 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 		if len(sidecars) >= expected {
 			s.blobNotifiers.delete(root)
 			if err := kzg.IsDataAvailable(kzgCommitments, sidecars); err != nil {
+				log.WithField("root", fmt.Sprintf("%#x", root)).Warn("removing blob sidecars with invalid proofs")
+				s.cfg.BeaconDB.DeleteBlobSidecars(ctx, root)
 				return err
 			}
 			logBlobSidecar(sidecars, t)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -598,6 +598,10 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 				return errors.Wrap(err, "could not get blob sidecars")
 			}
 			if err := kzg.IsDataAvailable(kzgCommitments, sidecars); err != nil {
+				log.WithField("root", fmt.Sprintf("%#x", root)).Warn("removing blob sidecars with invalid proofs")
+				if err2 := s.cfg.BeaconDB.DeleteBlobSidecars(ctx, root); err2 != nil {
+					log.WithError(err2).Error("could not delete sidecars")
+				}
 				return err
 			}
 			logBlobSidecar(sidecars, t)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -565,7 +565,9 @@ func (s *Service) isDataAvailable(ctx context.Context, root [32]byte, signed int
 			s.blobNotifiers.delete(root)
 			if err := kzg.IsDataAvailable(kzgCommitments, sidecars); err != nil {
 				log.WithField("root", fmt.Sprintf("%#x", root)).Warn("removing blob sidecars with invalid proofs")
-				s.cfg.BeaconDB.DeleteBlobSidecars(ctx, root)
+				if err2 := s.cfg.BeaconDB.DeleteBlobSidecars(ctx, root); err2 != nil {
+					log.WithError(err2).Error("could not delete sidecars")
+				}
 				return err
 			}
 			logBlobSidecar(sidecars, t)

--- a/beacon-chain/db/iface/interface.go
+++ b/beacon-chain/db/iface/interface.go
@@ -96,7 +96,7 @@ type NoHeadAccessDatabase interface {
 
 	// Blob operations.
 	SaveBlobSidecar(ctx context.Context, sidecars []*ethpb.BlobSidecar) error
-	DeleteBlobSidecar(ctx context.Context, beaconBlockRoot [32]byte) error
+	DeleteBlobSidecars(ctx context.Context, beaconBlockRoot [32]byte) error
 
 	CleanUpDirtyStates(ctx context.Context, slotsPerArchivedPoint primitives.Slot) error
 }

--- a/beacon-chain/db/kv/blob.go
+++ b/beacon-chain/db/kv/blob.go
@@ -261,7 +261,7 @@ func (s *Store) BlobSidecarsBySlot(ctx context.Context, slot types.Slot, indices
 }
 
 // DeleteBlobSidecar returns true if the blobs are in the db.
-func (s *Store) DeleteBlobSidecar(ctx context.Context, beaconBlockRoot [32]byte) error {
+func (s *Store) DeleteBlobSidecars(ctx context.Context, beaconBlockRoot [32]byte) error {
 	_, span := trace.StartSpan(ctx, "BeaconDB.DeleteBlobSidecar")
 	defer span.End()
 	return s.db.Update(func(tx *bolt.Tx) error {

--- a/beacon-chain/db/kv/blob_test.go
+++ b/beacon-chain/db/kv/blob_test.go
@@ -179,7 +179,7 @@ func TestStore_BlobSidecars(t *testing.T) {
 		got, err := db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs[0].BlockRoot))
 		require.NoError(t, err)
 		require.NoError(t, equalBlobSlices(scs, got))
-		require.NoError(t, db.DeleteBlobSidecar(ctx, bytesutil.ToBytes32(scs[0].BlockRoot)))
+		require.NoError(t, db.DeleteBlobSidecars(ctx, bytesutil.ToBytes32(scs[0].BlockRoot)))
 		got, err = db.BlobSidecarsByRoot(ctx, bytesutil.ToBytes32(scs[0].BlockRoot))
 		require.ErrorIs(t, ErrNotFound, err)
 		require.Equal(t, 0, len(got))


### PR DESCRIPTION
Remove sidecars when they have invalid proofs. Also rename function in anticipation of an existing DeleteBlobSidecar