### PR TITLE
Set Verbosity of Goodbye Logs to Trace

### DIFF
--- a/beacon-chain/rpc/apimiddleware/endpoint_factory_test.go
+++ b/beacon-chain/rpc/apimiddleware/endpoint_factory_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestBeaconEndpointFactory_AllPathsRegistered(t *testing.T) {
-  f := &apimiddleware.BeaconEndpointFactory{}
+	f := &apimiddleware.BeaconEndpointFactory{}
 
-  for _, p := range f.Paths() {
-    _, err := f.Create(p)
-    require.NoError(t, err, "failed to register %s", p)
-  }
+	for _, p := range f.Paths() {
+		_, err := f.Create(p)
+		require.NoError(t, err, "failed to register %s", p)
+	}
 }

--- a/beacon-chain/rpc/eth/beacon/blinded_blocks_test.go
+++ b/beacon-chain/rpc/eth/beacon/blinded_blocks_test.go
@@ -1,2 +1,1 @@
 package beacon
-

--- a/beacon-chain/rpc/eth/beacon/blocks_test.go
+++ b/beacon-chain/rpc/eth/beacon/blocks_test.go
@@ -1,2 +1,1 @@
 package beacon
-

--- a/beacon-chain/sync/rpc_goodbye.go
+++ b/beacon-chain/sync/rpc_goodbye.go
@@ -46,7 +46,7 @@ func (s *Service) goodbyeRPCHandler(_ context.Context, msg interface{}, stream l
 	}
 	s.rateLimiter.add(stream, 1)
 	log := log.WithField("Reason", goodbyeMessage(*m))
-	log.WithField("peer", stream.Conn().RemotePeer()).Debug("Peer has sent a goodbye message")
+	log.WithField("peer", stream.Conn().RemotePeer()).Trace("Peer has sent a goodbye message")
 	s.cfg.p2p.Peers().SetNextValidTime(stream.Conn().RemotePeer(), goodByeBackoff(*m))
 	// closes all streams with the peer
 	return s.cfg.p2p.Disconnect(stream.Conn().RemotePeer())
@@ -87,7 +87,7 @@ func (s *Service) sendGoodByeAndDisconnect(ctx context.Context, code p2ptypes.RP
 		log.WithFields(logrus.Fields{
 			"error": err,
 			"peer":  id,
-		}).Debug("Could not send goodbye message to peer")
+		}).Trace("Could not send goodbye message to peer")
 	}
 	return s.cfg.p2p.Disconnect(id)
 }
@@ -107,7 +107,7 @@ func (s *Service) sendGoodByeMessage(ctx context.Context, code p2ptypes.RPCGoodb
 	defer closeStream(stream, log)
 
 	log := log.WithField("Reason", goodbyeMessage(code))
-	log.WithField("peer", stream.Conn().RemotePeer()).Debug("Sending Goodbye message to peer")
+	log.WithField("peer", stream.Conn().RemotePeer()).Trace("Sending Goodbye message to peer")
 
 	// Wait up to the response timeout for the peer to receive the goodbye
 	// and close the stream (or disconnect). We usually don't bother waiting

--- a/cmd/prysmctl/p2p/handler.go
+++ b/cmd/prysmctl/p2p/handler.go
@@ -68,12 +68,8 @@ func (c *client) registerRPCHandler(baseTopic string, handle rpcHandler) {
 				return
 			}
 			if err := c.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
-				// Debug logs for goodbye/status errors
-				if strings.Contains(topic, p2p.RPCGoodByeTopicV1) || strings.Contains(topic, p2p.RPCStatusTopicV1) {
-					log.WithError(err).Debug("Could not decode goodbye stream message")
-					return
-				}
-				log.WithError(err).Debug("Could not decode stream message")
+				// Trace logs for goodbye errors
+				logStreamErrors(err, topic)
 				return
 			}
 			if err := handle(context.Background(), msg, stream); err != nil {
@@ -89,7 +85,7 @@ func (c *client) registerRPCHandler(baseTopic string, handle rpcHandler) {
 				return
 			}
 			if err := c.Encoding().DecodeWithMaxLength(stream, msg); err != nil {
-				log.WithError(err).Debug("Could not decode stream message")
+				logStreamErrors(err, topic)
 				return
 			}
 			if err := handle(context.Background(), nTyp.Elem().Interface(), stream); err != nil {
@@ -99,4 +95,12 @@ func (c *client) registerRPCHandler(baseTopic string, handle rpcHandler) {
 			}
 		}
 	})
+}
+
+func logStreamErrors(err error, topic string) {
+	if strings.Contains(topic, p2p.RPCGoodByeTopicV1) {
+		log.WithError(err).Trace("Could not decode goodbye stream message")
+		return
+	}
+	log.WithError(err).Debug("Could not decode stream message")
 }

--- a/proto/prysm/v1alpha1/slasher.pb.gw.go
+++ b/proto/prysm/v1alpha1/slasher.pb.gw.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package ignore


### PR DESCRIPTION
**What type of PR is this?**

Cleanup

**What does this PR do? Why is it needed?**

As an alternative to #13074, we set only the goodbye logs to trace so as to reduce the burden of filtering debug logs. Currently goodbye logs account for a large amount of debug logs, which aren't helpful for doing log analysis.

**Which issues(s) does this PR fix?**

Supersedes #13074

**Other notes for review**
