### PR TITLE
sync only up to previous epoch on phase 1

### DIFF
--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -62,7 +62,7 @@ func (s *Service) roundRobinSync(genesis time.Time) error {
 
 // syncToFinalizedEpoch sync from head to best known finalized epoch.
 func (s *Service) syncToFinalizedEpoch(ctx context.Context, genesis time.Time) error {
-	highestFinalizedSlot, err := slots.EpochStart(s.highestFinalizedEpoch() + 1)
+	highestFinalizedSlot, err := slots.EpochStart(s.highestFinalizedEpoch())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When syncing to the finalized checkpoint on init sync (what we call phase 1) we sync blocks in batches until we reach an epoch that is strictly higher than the finalized checkpoint's epoch. That is, if our finalized checkpoint is for epoch 1, we skip this step when the head slot is 64 or higher. 

This PR changes this behavior to skip this step starting when the head slot is within the finalized checkpoint epoch, that is 32 in the example above. This is so that we skip stage 1 syncing during checkpoint sync. 