### PR TITLE
Return early from ReceiveBlock if already sycned

### DIFF
--- a/testing/spectest/shared/common/forkchoice/builder_test.go
+++ b/testing/spectest/shared/common/forkchoice/builder_test.go
@@ -26,6 +26,9 @@ func TestBuilderInvalidBlock(t *testing.T) {
 	blk, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
 	require.NoError(t, err)
 	builder := NewBuilder(t, st, blk)
+	blk, err = blocks.NewSignedBeaconBlock(util.NewBeaconBlock())
+	blk.SetSlot(2)
+	require.NoError(t, err)
 	builder.InvalidBlock(t, blk)
 }
 


### PR DESCRIPTION
We typically do not attempt to sync the same block twice but this validation is done in the sync package. When we broadcast a block we call `ReceiveBlock` directly. Forkchoice returns early, but the whole validation is performed twice. This PR returns early from `ReceiveBlock` if the block is already found in forkchoice. 