### PR TITLE
Fix Builder Testing For Multiclient Runs

### DIFF
--- a/testing/endtoend/component_handler_test.go
+++ b/testing/endtoend/component_handler_test.go
@@ -192,7 +192,13 @@ func (c *componentHandler) setup() {
 	if multiClientActive {
 		lighthouseNodes = components.NewLighthouseBeaconNodes(config)
 		g.Go(func() error {
-			if err := helpers.ComponentsStarted(ctx, []e2etypes.ComponentRunner{eth1Nodes, proxies, bootNode, beaconNodes}); err != nil {
+			wantedComponents := []e2etypes.ComponentRunner{eth1Nodes, bootNode, beaconNodes}
+			if config.UseBuilder {
+				wantedComponents = append(wantedComponents, builders)
+			} else {
+				wantedComponents = append(wantedComponents, proxies)
+			}
+			if err := helpers.ComponentsStarted(ctx, wantedComponents); err != nil {
 				return errors.Wrap(err, "lighthouse beacon nodes require proxies, execution, beacon and boot node to run")
 			}
 			lighthouseNodes.SetENR(bootNode.ENR())

--- a/testing/endtoend/components/lighthouse_beacon.go
+++ b/testing/endtoend/components/lighthouse_beacon.go
@@ -201,6 +201,9 @@ func (node *LighthouseBeaconNode) Start(ctx context.Context) error {
 		args = append(args,
 			fmt.Sprintf("--trusted-peers=%s", flagVal))
 	}
+	if node.config.UseBuilder {
+		args = append(args, fmt.Sprintf("--builder=%s:%d", "http://127.0.0.1", e2e.TestParams.Ports.Eth1ProxyPort+prysmNodeCount+index))
+	}
 	cmd := exec.CommandContext(ctx, binaryPath, args...) /* #nosec G204 */
 	// Write stderr to log files.
 	stderr, err := os.Create(path.Join(e2e.TestParams.LogPath, fmt.Sprintf("lighthouse_beacon_node_%d_stderr.log", index)))

--- a/testing/endtoend/components/lighthouse_validator.go
+++ b/testing/endtoend/components/lighthouse_validator.go
@@ -191,6 +191,10 @@ func (v *LighthouseValidatorNode) Start(ctx context.Context) error {
 		"--suggested-fee-recipient=0x878705ba3f8bc32fcf7f4caa1a35e72af65cf766",
 	}
 
+	if v.config.UseBuilder {
+		args = append(args, "--builder-proposals")
+	}
+
 	cmd := exec.CommandContext(ctx, binaryPath, args...) // #nosec G204 -- Safe
 
 	// Write stderr to log files.


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

If we want to run builders in a multiclient E2E setup it will panic due to improper initialization paths. This fixes it 
so that we can test builder paths in a multiclient test setup.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
