### PR TITLE
Refactor Error String Formatting According to Go Best Practices

### DIFF
--- a/cmd/prysmctl/deprecated/checkpoint/latest.go
+++ b/cmd/prysmctl/deprecated/checkpoint/latest.go
@@ -13,5 +13,5 @@ var checkpointCmd = &cli.Command{
 }
 
 func cliDeprecatedLatest(_ *cli.Context) error {
-	return fmt.Errorf("This command has moved. Please use 'prysmctl weak-subjectivity checkpoint' instead!")
+	return fmt.Errorf("this command has moved. Please use 'prysmctl weak-subjectivity checkpoint' instead")
 }

--- a/cmd/prysmctl/deprecated/checkpoint/save.go
+++ b/cmd/prysmctl/deprecated/checkpoint/save.go
@@ -13,5 +13,5 @@ var saveCmd = &cli.Command{
 }
 
 func cliActionDeprecatedSave(_ *cli.Context) error {
-	return fmt.Errorf("This command has moved. Please use 'prysmctl checkpoint-sync download' instead!")
+	return fmt.Errorf("this command has moved. Please use 'prysmctl checkpoint-sync download' instead")
 }

--- a/validator/accounts/accounts_import.go
+++ b/validator/accounts/accounts_import.go
@@ -256,9 +256,9 @@ func importPrivateKeyAsAccount(ctx context.Context, wallet *wallet.Wallet, impor
 			)
 			return nil
 		case ethpbservice.ImportedKeystoreStatus_ERROR:
-			return fmt.Errorf("Could not import keystore for %s: %s", keystore.Pubkey, status.Message)
+			return fmt.Errorf("could not import keystore for %s: %s", keystore.Pubkey, status.Message)
 		case ethpbservice.ImportedKeystoreStatus_DUPLICATE:
-			return fmt.Errorf("Duplicate key %s skipped", keystore.Pubkey)
+			return fmt.Errorf("duplicate key %s skipped", keystore.Pubkey)
 		}
 	}
 


### PR DESCRIPTION
This PR fixes improper error string formatting. According to the Go best practices outlined in the [Error Strings](https://github.com/golang/go/wiki/CodeReviewComments#error-strings) documentation, error strings should not be capitalized or end with punctuation marks. They might be embedded within other strings or concatenated with additional context.