### PR TITLE
Return Error Gracefully When Removing 4881 Flag

### DIFF
--- a/beacon-chain/execution/service.go
+++ b/beacon-chain/execution/service.go
@@ -754,6 +754,10 @@ func (s *Service) initializeEth1Data(ctx context.Context, eth1DataInDB *ethpb.ET
 			}
 		}
 	} else {
+		if eth1DataInDB.Trie == nil && eth1DataInDB.DepositSnapshot != nil {
+			return errors.Errorf("trying to use old deposit trie after migration to the new trie. "+
+				"Run with the --%s flag to resume normal operations.", features.EnableEIP4881.Name)
+		}
 		s.depositTrie, err = trie.CreateTrieFromProto(eth1DataInDB.Trie)
 	}
 	if err != nil {

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -251,8 +251,8 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		logEnabled(disableResourceManager)
 		cfg.DisableResourceManager = true
 	}
-	if ctx.IsSet(enableEIP4881.Name) {
-		logEnabled(enableEIP4881)
+	if ctx.IsSet(EnableEIP4881.Name) {
+		logEnabled(EnableEIP4881)
 		cfg.EnableEIP4881 = true
 	}
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -144,7 +144,7 @@ var (
 		Name:  "prepare-all-payloads",
 		Usage: "Informs the engine to prepare all local payloads. Useful for relayers and builders",
 	}
-	enableEIP4881 = &cli.BoolFlag{
+	EnableEIP4881 = &cli.BoolFlag{
 		Name:  "enable-eip-4881",
 		Usage: "Enables the deposit tree specified in EIP4881",
 	}
@@ -168,7 +168,7 @@ var (
 // devModeFlags holds list of flags that are set when development mode is on.
 var devModeFlags = []cli.Flag{
 	enableVerboseSigVerification,
-	enableEIP4881,
+	EnableEIP4881,
 	enableExperimentalState,
 }
 
@@ -216,7 +216,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	aggregateFirstInterval,
 	aggregateSecondInterval,
 	aggregateThirdInterval,
-	enableEIP4881,
+	EnableEIP4881,
 	disableResourceManager,
 	DisableRegistrationCache,
 	disableAggregateParallel,


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

When a user removes running with the 4881 flag, the node will panic because it tries to run with the old deposit trie. This PR returns an error gracefully in order to give the user more information on why the node can't be run.

**Which issues(s) does this PR fix?**

Related to #13086

**Other notes for review**
