### PR TITLE
Check return and request lengths for blob sidecar by root

### DIFF
--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"fmt"
 
 	libp2pcore "github.com/libp2p/go-libp2p/core"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -159,11 +160,14 @@ func (s *Service) sendAndSaveBlobSidecars(ctx context.Context, request types.Blo
 	if err != nil {
 		return err
 	}
+	if len(sidecars) != len(request) {
+		return fmt.Errorf("received %d blob sidecars, expected %d for RPC", len(sidecars), len(request))
+	}
 	for _, sidecar := range sidecars {
 		if err := verify.BlobAlignsWithBlock(sidecar, RoBlock); err != nil {
 			return err
 		}
-		log.WithFields(blobFields(sidecar)).Debug("Received blob sidecar gossip RPC")
+		log.WithFields(blobFields(sidecar)).Debug("Received blob sidecar RPC")
 	}
 
 	return s.cfg.beaconDB.SaveBlobSidecar(ctx, sidecars)


### PR DESCRIPTION
Fixes #13101

If the requested and returned blob sidecars lengths don't match, the node will become stuck at ReceiveBlock due to the DA check. In this update, we verify the lengths and fail the process entirely if they mismatch. The node will automatically attempt to request the block again after 4 seconds.