### PR TITLE
Log blob's kzg commmitment at sync

### DIFF
--- a/beacon-chain/sync/validate_blob.go
+++ b/beacon-chain/sync/validate_blob.go
@@ -234,6 +234,7 @@ func blobFields(b *eth.BlobSidecar) logrus.Fields {
 		"slot":          b.Slot,
 		"proposerIndex": b.ProposerIndex,
 		"blockRoot":     fmt.Sprintf("%#x", b.BlockRoot),
+		"kzgCommitment": fmt.Sprintf("%#x", b.KzgCommitment),
 		"index":         b.Index,
 	}
 }


### PR DESCRIPTION
This PR logs blob's kzg commitment at sync. It makes the logging more useful in the event of equivocating blob or blob that later fails reference validation