### PR TITLE
Add context deadline for pending queue's receive block

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -208,10 +208,9 @@ func (s *Service) processAndBroadcastBlock(ctx context.Context, b interfaces.Rea
 	// Calculate the deadline time by adding two slots duration to the current time
 	secondsPerSlot := params.BeaconConfig().SecondsPerSlot
 	twoSlotDuration := 2 * time.Duration(secondsPerSlot) * time.Second
-	deadlineTime := time.Now().Add(twoSlotDuration)
-	contextWithDeadline, cancelFunction := context.WithDeadline(ctx, deadlineTime)
+	ctxWithTimeout, cancelFunction := context.WithTimeout(ctx, twoSlotDuration)
 	defer cancelFunction()
-	if err := s.cfg.chain.ReceiveBlock(contextWithDeadline, b, blkRoot); err != nil {
+	if err := s.cfg.chain.ReceiveBlock(ctxWithTimeout, b, blkRoot); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Add context deadline for pending queue's receive block function. It's currently set to two slots