### PR TITLE
Add zero length check on indices during NextSyncCommitteeIndices

### DIFF
--- a/beacon-chain/core/altair/sync_committee.go
+++ b/beacon-chain/core/altair/sync_committee.go
@@ -111,10 +111,6 @@ func NextSyncCommitteeIndices(ctx context.Context, s state.BeaconState) ([]primi
 	if err != nil {
 		return nil, err
 	}
-	if len(indices) == 0 {
-		// This should never happen, but a divide by zero is possible if len(indices) == 0.
-		return nil, errors.New("no active validator indices")
-	}
 	seed, err := helpers.Seed(s, epoch, params.BeaconConfig().DomainSyncCommittee)
 	if err != nil {
 		return nil, err

--- a/beacon-chain/core/altair/sync_committee.go
+++ b/beacon-chain/core/altair/sync_committee.go
@@ -111,6 +111,10 @@ func NextSyncCommitteeIndices(ctx context.Context, s state.BeaconState) ([]primi
 	if err != nil {
 		return nil, err
 	}
+	if len(indices) == 0 {
+		// This should never happen, but a divide by zero is possible if len(indices) == 0.
+		return nil, errors.New("no active validator indices")
+	}
 	seed, err := helpers.Seed(s, epoch, params.BeaconConfig().DomainSyncCommittee)
 	if err != nil {
 		return nil, err

--- a/beacon-chain/core/altair/sync_committee_test.go
+++ b/beacon-chain/core/altair/sync_committee_test.go
@@ -28,10 +28,10 @@ func TestSyncCommitteeIndices_CanGet(t *testing.T) {
 			}
 		}
 		st, err := state_native.InitializeFromProtoAltair(&ethpb.BeaconStateAltair{
-			Validators:  validators,
 			RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 		})
 		require.NoError(t, err)
+		require.NoError(t, st.SetValidators(validators))
 		return st
 	}
 
@@ -68,6 +68,15 @@ func TestSyncCommitteeIndices_CanGet(t *testing.T) {
 				epoch: 100,
 			},
 			wantErr: false,
+		},
+		{
+			name: "no active validators, epoch 100",
+			args: args{
+				state: getState(t, 0), // Regression test for divide by zero. Issue #13051.
+				epoch: 100,
+			},
+			wantErr:   true,
+			errString: "no active validator indices",
 		},
 	}
 	for _, tt := range tests {

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -136,6 +136,10 @@ func ActiveValidatorIndices(ctx context.Context, s state.ReadOnlyBeaconState, ep
 		return nil, err
 	}
 
+	if len(indices) == 0 {
+		return nil, errors.New("no active validator indices")
+	}
+
 	if err := UpdateCommitteeCache(ctx, s, epoch); err != nil {
 		return nil, errors.Wrap(err, "could not update committee cache")
 	}

--- a/beacon-chain/core/transition/transition_test.go
+++ b/beacon-chain/core/transition/transition_test.go
@@ -382,10 +382,18 @@ func TestProcessEpochPrecompute_CanProcess(t *testing.T) {
 		FinalizedCheckpoint:        &ethpb.Checkpoint{Root: make([]byte, fieldparams.RootLength)},
 		JustificationBits:          bitfield.Bitvector4{0x00},
 		CurrentJustifiedCheckpoint: &ethpb.Checkpoint{Root: make([]byte, fieldparams.RootLength)},
+		Validators: []*ethpb.Validator{
+			{
+				ExitEpoch:        params.BeaconConfig().FarFutureEpoch,
+				EffectiveBalance: params.BeaconConfig().MinDepositAmount,
+			},
+		},
+		Balances: []uint64{
+			params.BeaconConfig().MinDepositAmount,
+		},
 	}
 	s, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
-	require.NoError(t, s.SetValidators([]*ethpb.Validator{}))
 	newState, err := transition.ProcessEpochPrecompute(context.Background(), s)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(0), newState.Slashings()[2], "Unexpected slashed balance")

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/assignments_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/assignments_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
 	"github.com/prysmaticlabs/prysm/v4/testing/util"
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestServer_ListAssignments_CannotRequestFutureEpoch(t *testing.T) {
@@ -43,44 +42,6 @@ func TestServer_ListAssignments_CannotRequestFutureEpoch(t *testing.T) {
 		},
 	)
 	assert.ErrorContains(t, wanted, err)
-}
-
-func TestServer_ListAssignments_NoResults(t *testing.T) {
-	db := dbTest.SetupDB(t)
-	ctx := context.Background()
-	st, err := util.NewBeaconState()
-	require.NoError(t, err)
-
-	b := util.NewBeaconBlock()
-	util.SaveBlock(t, ctx, db, b)
-	gRoot, err := b.Block.HashTreeRoot()
-	require.NoError(t, err)
-	require.NoError(t, db.SaveGenesisBlockRoot(ctx, gRoot))
-	require.NoError(t, db.SaveState(ctx, st, gRoot))
-
-	bs := &Server{
-		BeaconDB:           db,
-		GenesisTimeFetcher: &mock.ChainService{},
-		StateGen:           stategen.New(db, doublylinkedtree.New()),
-		ReplayerBuilder:    mockstategen.NewReplayerBuilder(mockstategen.WithMockState(st)),
-	}
-	wanted := &ethpb.ValidatorAssignments{
-		Assignments:   make([]*ethpb.ValidatorAssignments_CommitteeAssignment, 0),
-		TotalSize:     int32(0),
-		NextPageToken: strconv.Itoa(0),
-	}
-	res, err := bs.ListValidatorAssignments(
-		ctx,
-		&ethpb.ListValidatorAssignmentsRequest{
-			QueryFilter: &ethpb.ListValidatorAssignmentsRequest_Genesis{
-				Genesis: true,
-			},
-		},
-	)
-	require.NoError(t, err)
-	if !proto.Equal(wanted, res) {
-		t.Errorf("Wanted %v, received %v", wanted, res)
-	}
 }
 
 func TestServer_ListAssignments_Pagination_InputOutOfRange(t *testing.T) {

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/aggregator_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/aggregator_test.go
@@ -74,8 +74,8 @@ func TestSubmitAggregateAndProof_IsAggregatorAndNoAtts(t *testing.T) {
 	s, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{
 		RandaoMixes: make([][]byte, params.BeaconConfig().EpochsPerHistoricalVector),
 		Validators: []*ethpb.Validator{
-			{PublicKey: pubKey(0)},
-			{PublicKey: pubKey(1)},
+			{PublicKey: pubKey(0), ExitEpoch: params.BeaconConfig().FarFutureEpoch},
+			{PublicKey: pubKey(1), ExitEpoch: params.BeaconConfig().FarFutureEpoch},
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Prevents a divide by zero panic

**Which issues(s) does this PR fix?**

Fixes #13051

**Other notes for review**
