### PR TITLE
Check blob index duplication for blob notifier

### DIFF
--- a/beacon-chain/blockchain/receive_blob.go
+++ b/beacon-chain/blockchain/receive_blob.go
@@ -9,11 +9,7 @@ import (
 // SendNewBlobEvent sends a message to the BlobNotifier channel that the blob
 // for the blocroot `root` is ready in the database
 func (s *Service) sendNewBlobEvent(root [32]byte, index uint64) {
-	if s.blobNotifiers.isSeen(root, index) {
-		return
-	}
-	s.blobNotifiers.forRoot(root) <- index
-	s.blobNotifiers.setSeenIndex(root, index)
+	s.blobNotifiers.notifyIndex(root, index)
 }
 
 // ReceiveBlob saves the blob to database and sends the new event

--- a/beacon-chain/blockchain/receive_blob.go
+++ b/beacon-chain/blockchain/receive_blob.go
@@ -9,7 +9,11 @@ import (
 // SendNewBlobEvent sends a message to the BlobNotifier channel that the blob
 // for the blocroot `root` is ready in the database
 func (s *Service) sendNewBlobEvent(root [32]byte, index uint64) {
+	if s.blobNotifiers.isSeen(root, index) {
+		return
+	}
 	s.blobNotifiers.forRoot(root) <- index
+	s.blobNotifiers.setSeenIndex(root, index)
 }
 
 // ReceiveBlob saves the blob to database and sends the new event

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -156,6 +156,7 @@ func NewService(ctx context.Context, opts ...Option) (*Service, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	bn := &blobNotifierMap{
 		notifiers: make(map[[32]byte]chan uint64),
+		seenIndex: make(map[[32]byte][fieldparams.MaxBlobsPerBlock]bool),
 	}
 	srv := &Service{
 		ctx:                  ctx,

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -519,7 +519,7 @@ func (s *MockClockSetter) SetClock(g *startup.Clock) error {
 func TestNotifyIndex(t *testing.T) {
 	// Initialize a blobNotifierMap
 	bn := &blobNotifierMap{
-		seenIndex: make(map[[32]byte]*[fieldparams.MaxBlobsPerBlock]bool),
+		seenIndex: make(map[[32]byte][fieldparams.MaxBlobsPerBlock]bool),
 		notifiers: make(map[[32]byte]chan uint64),
 	}
 
@@ -529,7 +529,7 @@ func TestNotifyIndex(t *testing.T) {
 
 	// Test notifying a new index
 	bn.notifyIndex(root, 1)
-	if bn.seenIndex[root] == nil || !bn.seenIndex[root][1] {
+	if !bn.seenIndex[root][1] {
 		t.Errorf("Index was not marked as seen")
 	}
 

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -25,6 +25,7 @@ import (
 	state_native "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state/stategen"
 	"github.com/prysmaticlabs/prysm/v4/config/features"
+	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	consensusblocks "github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
@@ -516,39 +517,46 @@ func (s *MockClockSetter) SetClock(g *startup.Clock) error {
 }
 
 func TestNotifyIndex(t *testing.T) {
+	// Initialize a blobNotifierMap
 	bn := &blobNotifierMap{
-		seenIndex: make(map[[32]byte]map[uint64]struct{}),
+		seenIndex: make(map[[32]byte]*[fieldparams.MaxBlobsPerBlock]bool),
 		notifiers: make(map[[32]byte]chan uint64),
 	}
 
-	root := [32]byte{1, 2, 3}
-	idx := uint64(5)
+	// Sample root and index
+	var root [32]byte
+	copy(root[:], "exampleRoot")
 
-	// Test that a new index is properly notified and recorded
-	bn.notifyIndex(root, idx)
-	if _, ok := bn.seenIndex[root][idx]; !ok {
-		t.Errorf("Index %d for root %v was not recorded", idx, root)
+	// Test notifying a new index
+	bn.notifyIndex(root, 1)
+	if bn.seenIndex[root] == nil || !bn.seenIndex[root][1] {
+		t.Errorf("Index was not marked as seen")
 	}
 
-	c, ok := bn.notifiers[root]
-	if !ok {
-		t.Errorf("Notifier channel for root %v was not created", root)
+	// Test that a new channel is created
+	if _, ok := bn.notifiers[root]; !ok {
+		t.Errorf("Notifier channel was not created")
 	}
 
+	// Test notifying an already seen index
+	bn.notifyIndex(root, 1)
+	if len(bn.notifiers[root]) > 1 {
+		t.Errorf("Notifier channel should not receive multiple messages for the same index")
+	}
+
+	// Test notifying a new index again
+	bn.notifyIndex(root, 2)
+	if !bn.seenIndex[root][2] {
+		t.Errorf("Index was not marked as seen")
+	}
+
+	// Test that the notifier channel receives the index
 	select {
-	case receivedIdx := <-c:
-		if receivedIdx != idx {
-			t.Errorf("Received index %d, expected %d", receivedIdx, idx)
+	case idx := <-bn.notifiers[root]:
+		if idx != 1 {
+			t.Errorf("Received index on channel is incorrect")
 		}
 	default:
-		t.Errorf("No index was sent to the notifier channel")
-	}
-
-	// Test that a previously seen index is not notified again
-	bn.notifyIndex(root, idx)
-	select {
-	case <-c:
-		t.Errorf("Previously seen index %d was notified again", idx)
-	default:
+		t.Errorf("Notifier channel did not receive the index")
 	}
 }


### PR DESCRIPTION
Ensure the blob index is not duplicated before sending it to the blob notifier. This resolves an issue observed in devnet10. The trigger involves writing the blobs to a specific channel and subsequently calling `ReceiveBlock` within the same goroutine.