### PR TITLE
Allow unknown fields in Beacon API responses

### DIFF
--- a/validator/client/beacon-api/get_beacon_block.go
+++ b/validator/client/beacon-api/get_beacon_block.go
@@ -39,7 +39,6 @@ func (c beaconApiValidatorClient) getBeaconBlock(ctx context.Context, slot primi
 
 	// Once we know what the consensus version is, we can go ahead and unmarshal into the specific structs unique to each version
 	decoder := json.NewDecoder(bytes.NewReader(produceBlockResponseJson.Data))
-	decoder.DisallowUnknownFields()
 
 	response := &ethpb.GenericBeaconBlock{}
 

--- a/validator/client/beacon-api/json_rest_handler.go
+++ b/validator/client/beacon-api/json_rest_handler.go
@@ -84,7 +84,6 @@ func (c beaconApiJsonRestHandler) PostRestJson(ctx context.Context, apiEndpoint 
 
 func decodeJsonResp(resp *http.Response, responseJson interface{}) (*apimiddleware.DefaultErrorJson, error) {
 	decoder := json.NewDecoder(resp.Body)
-	decoder.DisallowUnknownFields()
 
 	if resp.StatusCode != http.StatusOK {
 		errorJson := &apimiddleware.DefaultErrorJson{}

--- a/validator/client/beacon-api/stream_blocks.go
+++ b/validator/client/beacon-api/stream_blocks.go
@@ -79,7 +79,6 @@ func (c beaconApiValidatorClient) getHeadSignedBeaconBlock(ctx context.Context) 
 
 	// Once we know what the consensus version is, we can go ahead and unmarshal into the specific structs unique to each version
 	decoder := json.NewDecoder(bytes.NewReader(signedBlockResponseJson.Data))
-	decoder.DisallowUnknownFields()
 
 	response := &ethpb.StreamBlocksResponse{}
 	var slot primitives.Slot


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

When issuing GET requests, there might be a scenario where a beacon node sends more fields than is described in the specification. One reason for this might be extra functionality between the VC and the beacon node of a particular client. We should not fail requests if this happens.
