### PR TITLE
Add a helper for max request block

### DIFF
--- a/beacon-chain/sync/pending_blocks_queue.go
+++ b/beacon-chain/sync/pending_blocks_queue.go
@@ -299,8 +299,10 @@ func (s *Service) sendBatchRootRequest(ctx context.Context, roots [][32]byte, ra
 	pid := bestPeers[randGen.Int()%len(bestPeers)]
 	for i := 0; i < numOfTries; i++ {
 		req := p2ptypes.BeaconBlockByRootsReq(roots)
-		if len(roots) > int(params.BeaconNetworkConfig().MaxRequestBlocks) {
-			req = roots[:params.BeaconNetworkConfig().MaxRequestBlocks]
+		currentEpoch := slots.ToEpoch(s.cfg.clock.CurrentSlot())
+		maxReqBlock := params.MaxRequestBlock(currentEpoch)
+		if uint64(len(roots)) > maxReqBlock {
+			req = roots[:maxReqBlock]
 		}
 		if err := s.sendRecentBeaconBlocksRequest(ctx, &req, pid); err != nil {
 			tracing.AnnotateError(span, err)

--- a/beacon-chain/sync/rpc_beacon_blocks_by_range.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_range.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/monitoring/tracing"
 	pb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/time/slots"
 	"go.opencensus.io/trace"
 )
 
@@ -95,7 +96,7 @@ func validateRangeRequest(r *pb.BeaconBlocksByRangeRequest, current primitives.S
 		start: r.StartSlot,
 		size:  r.Count,
 	}
-	maxRequest := params.BeaconNetworkConfig().MaxRequestBlocks
+	maxRequest := params.MaxRequestBlock(slots.ToEpoch(current))
 	// Ensure all request params are within appropriate bounds
 	if rp.size == 0 || rp.size > maxRequest {
 		return rangeParams{}, p2ptypes.ErrInvalidRequest

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/runtime/version"
+	"github.com/prysmaticlabs/prysm/v4/time/slots"
 )
 
 // sendRecentBeaconBlocksRequest sends a recent beacon blocks request to a peer to get
@@ -77,7 +78,8 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		return errors.New("no block roots provided")
 	}
 
-	if uint64(len(blockRoots)) > params.BeaconNetworkConfig().MaxRequestBlocks {
+	currentEpoch := slots.ToEpoch(s.cfg.clock.CurrentSlot())
+	if uint64(len(blockRoots)) > params.MaxRequestBlock(currentEpoch) {
 		s.cfg.p2p.Peers().Scorers().BadResponsesScorer().Increment(stream.Conn().RemotePeer())
 		s.writeErrorResponseToStream(responseCodeInvalidRequest, "requested more than the max block limit", stream)
 		return errors.New("requested more than the max block limit")

--- a/beacon-chain/sync/rpc_blob_sidecars_by_range.go
+++ b/beacon-chain/sync/rpc_blob_sidecars_by_range.go
@@ -152,7 +152,7 @@ func validateBlobsByRange(r *pb.BlobSidecarsByRangeRequest, current primitives.S
 		return rangeParams{}, errors.Wrap(p2ptypes.ErrInvalidRequest, "overflow start + count -1")
 	}
 
-	maxRequest := params.BeaconNetworkConfig().MaxRequestBlocksDeneb
+	maxRequest := params.MaxRequestBlock(slots.ToEpoch(current))
 	// Allow some wiggle room, up to double the MaxRequestBlocks past the current slot,
 	// to give nodes syncing close to the head of the chain some margin for error.
 	maxStart, err := current.SafeAdd(maxRequest * 2)

--- a/beacon-chain/sync/rpc_send_request.go
+++ b/beacon-chain/sync/rpc_send_request.go
@@ -71,7 +71,8 @@ func SendBeaconBlocksByRangeRequest(
 		}
 		// The response MUST contain no more than `count` blocks, and no more than
 		// MAX_REQUEST_BLOCKS blocks.
-		if i >= req.Count || i >= params.BeaconNetworkConfig().MaxRequestBlocks {
+		currentEpoch := slots.ToEpoch(tor.CurrentSlot())
+		if i >= req.Count || i >= params.MaxRequestBlock(currentEpoch) {
 			return nil, ErrInvalidFetchedData
 		}
 		// Returned blocks MUST be in the slot range [start_slot, start_slot + count * step).
@@ -121,9 +122,10 @@ func SendBeaconBlocksByRootRequest(
 		}
 		return nil
 	}
+	currentEpoch := slots.ToEpoch(clock.CurrentSlot())
 	for i := 0; i < len(*req); i++ {
 		// Exit if peer sends more than max request blocks.
-		if uint64(i) >= params.BeaconNetworkConfig().MaxRequestBlocks {
+		if uint64(i) >= params.MaxRequestBlock(currentEpoch) {
 			break
 		}
 		isFirstChunk := i == 0

--- a/config/params/BUILD.bazel
+++ b/config/params/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "config_test.go",
         "configset_test.go",
         "loader_test.go",
+        "mainnet_config_test.go",
         "testnet_config_test.go",
         "testnet_holesky_config_test.go",
         "testnet_prater_config_test.go",

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
-	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 )
 
@@ -26,13 +25,6 @@ const (
 	mainnetBellatrixForkEpoch = 144896 // Sept 6, 2022, 11:34:47am UTC
 	mainnetDenebForkEpoch     = math.MaxUint64
 )
-
-func MaxRequestBlock(e primitives.Epoch) uint64 {
-	if e >= mainnetDenebForkEpoch {
-		return mainnetNetworkConfig.MaxRequestBlocksDeneb
-	}
-	return mainnetNetworkConfig.MaxRequestBlocks
-}
 
 var mainnetNetworkConfig = &NetworkConfig{
 	GossipMaxSize:                    1 << 20,      // 1 MiB

--- a/config/params/mainnet_config.go
+++ b/config/params/mainnet_config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
+	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 )
 
@@ -23,7 +24,15 @@ const (
 	mainnetAltairForkEpoch = 74240 // Oct 27, 2021, 10:56:23am UTC
 	// Bellatrix Fork Epoch for mainnet config.
 	mainnetBellatrixForkEpoch = 144896 // Sept 6, 2022, 11:34:47am UTC
+	mainnetDenebForkEpoch     = math.MaxUint64
 )
+
+func MaxRequestBlock(e primitives.Epoch) uint64 {
+	if e >= mainnetDenebForkEpoch {
+		return mainnetNetworkConfig.MaxRequestBlocksDeneb
+	}
+	return mainnetNetworkConfig.MaxRequestBlocks
+}
 
 var mainnetNetworkConfig = &NetworkConfig{
 	GossipMaxSize:                    1 << 20,      // 1 MiB

--- a/config/params/mainnet_config_test.go
+++ b/config/params/mainnet_config_test.go
@@ -1,0 +1,33 @@
+package params
+
+import (
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
+)
+
+func TestMaxRequestBlock(t *testing.T) {
+	testCases := []struct {
+		epoch            primitives.Epoch
+		expectedMaxBlock uint64
+		description      string
+	}{
+		{
+			epoch:            primitives.Epoch(mainnetDenebForkEpoch - 1), // Assuming the fork epoch is not 0
+			expectedMaxBlock: mainnetNetworkConfig.MaxRequestBlocks,
+		},
+		{
+			epoch:            primitives.Epoch(mainnetDenebForkEpoch),
+			expectedMaxBlock: mainnetNetworkConfig.MaxRequestBlocksDeneb,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			maxBlocks := MaxRequestBlock(tc.epoch)
+			if maxBlocks != tc.expectedMaxBlock {
+				t.Errorf("For epoch %d, expected max blocks %d, got %d", tc.epoch, tc.expectedMaxBlock, maxBlocks)
+			}
+		})
+	}
+}

--- a/config/params/network_config.go
+++ b/config/params/network_config.go
@@ -60,7 +60,7 @@ func (c *NetworkConfig) Copy() *NetworkConfig {
 }
 
 // MaxRequestBlock determines the maximum number of blocks that can be requested in a single
-// request for a given epoch. If the epoch is at or beyond the mainnetDenebForkEpoch,
+// request for a given epoch. If the epoch is at or beyond config's `DenebForkEpoch`,
 // a special limit defined for Deneb is used.
 func MaxRequestBlock(e primitives.Epoch) uint64 {
 	if e >= BeaconConfig().DenebForkEpoch {

--- a/config/params/network_config.go
+++ b/config/params/network_config.go
@@ -63,7 +63,7 @@ func (c *NetworkConfig) Copy() *NetworkConfig {
 // request for a given epoch. If the epoch is at or beyond the mainnetDenebForkEpoch,
 // a special limit defined for Deneb is used.
 func MaxRequestBlock(e primitives.Epoch) uint64 {
-	if e >= mainnetDenebForkEpoch {
+	if e >= BeaconConfig().DenebForkEpoch {
 		return networkConfig.MaxRequestBlocksDeneb
 	}
 	return networkConfig.MaxRequestBlocks

--- a/config/params/network_config.go
+++ b/config/params/network_config.go
@@ -58,3 +58,13 @@ func (c *NetworkConfig) Copy() *NetworkConfig {
 	}
 	return &config
 }
+
+// MaxRequestBlock determines the maximum number of blocks that can be requested in a single
+// request for a given epoch. If the epoch is at or beyond the mainnetDenebForkEpoch,
+// a special limit defined for Deneb is used.
+func MaxRequestBlock(e primitives.Epoch) uint64 {
+	if e >= mainnetDenebForkEpoch {
+		return networkConfig.MaxRequestBlocksDeneb
+	}
+	return networkConfig.MaxRequestBlocks
+}


### PR DESCRIPTION
Fixes #12998

This PR added a helper to unify `MaxRequestblock` and `MaxRequestBlockDeneb` given an epoch
- [x] Helper
- [x] Replace usages
- [x] Unit tests