### PR TITLE
Fix handling POST requests in the REST VC

### DIFF
--- a/validator/client/beacon-api/json_rest_handler.go
+++ b/validator/client/beacon-api/json_rest_handler.go
@@ -106,7 +106,7 @@ func decodeResp(httpResp *http.Response, resp interface{}) (*http2.DefaultErrorJ
 		}
 		return errorJson, nil
 	}
-	// Is nil in case of requests that do not return anything.
+	// resp is nil for requests that do not return anything.
 	if resp != nil {
 		if err = decoder.Decode(resp); err != nil {
 			return nil, errors.Wrapf(err, "failed to decode response body into json for %s", httpResp.Request.URL)

--- a/validator/client/beacon-api/json_rest_handler.go
+++ b/validator/client/beacon-api/json_rest_handler.go
@@ -60,9 +60,6 @@ func (c beaconApiJsonRestHandler) Post(
 	if data == nil {
 		return nil, errors.New("data is nil")
 	}
-	if resp == nil {
-		return nil, errors.New("resp is nil")
-	}
 
 	url := c.host + apiEndpoint
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, data)
@@ -95,19 +92,25 @@ func decodeResp(httpResp *http.Response, resp interface{}) (*http2.DefaultErrorJ
 	}
 
 	if httpResp.Header.Get("Content-Type") != api.JsonMediaType {
+		if httpResp.StatusCode == http.StatusOK {
+			return nil, nil
+		}
 		return &http2.DefaultErrorJson{Code: httpResp.StatusCode, Message: string(body)}, nil
 	}
 
 	decoder := json.NewDecoder(bytes.NewBuffer(body))
 	if httpResp.StatusCode != http.StatusOK {
 		errorJson := &http2.DefaultErrorJson{}
-		if err := decoder.Decode(errorJson); err != nil {
+		if err = decoder.Decode(errorJson); err != nil {
 			return nil, errors.Wrapf(err, "failed to decode response body into error json for %s", httpResp.Request.URL)
 		}
 		return errorJson, nil
 	}
-	if err = decoder.Decode(resp); err != nil {
-		return nil, errors.Wrapf(err, "failed to decode response body into json for %s", httpResp.Request.URL)
+	// Is nil in case of requests that do not return anything.
+	if resp != nil {
+		if err = decoder.Decode(resp); err != nil {
+			return nil, errors.Wrapf(err, "failed to decode response body into json for %s", httpResp.Request.URL)
+		}
 	}
 
 	return nil, nil


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

After https://github.com/prysmaticlabs/prysm/pull/13203 was merged, post-submit REST VC e2e started failing:
```
FAIL: TestEndToEnd_MinimalConfig_WithBuilder_ValidatorRESTApi (74.91s)
    --- FAIL: TestEndToEnd_MinimalConfig_WithBuilder_ValidatorRESTApi/chain_started (60.00s)
```
There were 2 mistakes in the mentioned PR:
- `resp == nil` check added at the beginning, when it's OK to emit `resp` if the endpoint doesn't return any data
- treating `200 OK` as an error in case of non-JSON responses

This PR fixes both issues and adds extensive tests to `decodeResp` function. The failing e2e passes after these changes.
