### PR TITLE
Fix Blob Storage Path

### DIFF
--- a/cmd/beacon-chain/storage/BUILD.bazel
+++ b/cmd/beacon-chain/storage/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
     srcs = ["options_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//cmd:go_default_library",
         "//testing/assert:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],

--- a/cmd/beacon-chain/storage/BUILD.bazel
+++ b/cmd/beacon-chain/storage/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@prysm//tools/go:def.bzl", "go_library")
+load("@prysm//tools/go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -9,6 +9,16 @@ go_library(
         "//beacon-chain/db/filesystem:go_default_library",
         "//beacon-chain/node:go_default_library",
         "//cmd:go_default_library",
+        "@com_github_urfave_cli_v2//:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["options_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//testing/assert:go_default_library",
         "@com_github_urfave_cli_v2//:go_default_library",
     ],
 )

--- a/cmd/beacon-chain/storage/options.go
+++ b/cmd/beacon-chain/storage/options.go
@@ -22,15 +22,19 @@ var (
 // create a cancellable context. If we switch to using App.RunContext, we can set up this cancellation in the cmd
 // package instead, and allow the functional options to tap into context cancellation.
 func BeaconNodeOptions(c *cli.Context) (node.Option, error) {
-	blobsPath := c.Path(BlobStoragePath.Name)
-	if blobsPath == "" {
-		// append a "blobs" subdir to the end of the data dir path
-		blobsPath = path.Join(path.Clean(c.String(c.Path(cmd.DataDirFlag.Name))), "blobs")
-	}
-
+	blobsPath := blobStoragePath(c)
 	bs, err := filesystem.NewBlobStorage(blobsPath)
 	if err != nil {
 		return nil, err
 	}
 	return node.WithBlobStorage(bs), nil
+}
+
+func blobStoragePath(c *cli.Context) string {
+	blobsPath := c.Path(BlobStoragePath.Name)
+	if blobsPath == "" {
+		// append a "blobs" subdir to the end of the data dir path
+		blobsPath = path.Join(c.String(cmd.DataDirFlag.Name), "blobs")
+	}
+	return blobsPath
 }

--- a/cmd/beacon-chain/storage/options_test.go
+++ b/cmd/beacon-chain/storage/options_test.go
@@ -1,0 +1,30 @@
+package storage
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/prysmaticlabs/prysm/v4/cmd"
+	"github.com/prysmaticlabs/prysm/v4/testing/assert"
+	"github.com/urfave/cli/v2"
+)
+
+func TestBlobStoragePath_NoFlagSpecified(t *testing.T) {
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	set.String(cmd.DataDirFlag.Name, cmd.DataDirFlag.Value, cmd.DataDirFlag.Usage)
+	cliCtx := cli.NewContext(&app, set, nil)
+	storagePath := blobStoragePath(cliCtx)
+
+	assert.Equal(t, cmd.DefaultDataDir()+"/blobs", storagePath)
+}
+
+func TestBlobStoragePath_FlagSpecified(t *testing.T) {
+	app := cli.App{}
+	set := flag.NewFlagSet("test", 0)
+	set.String(BlobStoragePath.Name, "/blah/blah", BlobStoragePath.Usage)
+	cliCtx := cli.NewContext(&app, set, nil)
+	storagePath := blobStoragePath(cliCtx)
+
+	assert.Equal(t, "/blah/blah", storagePath)
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In #13190, we introduced a separate blob storage database along with a new path for it. Unfortunately the beacon node option had a bug with it whereby the wrong path for blob storage would always be initialized an used. This PR fixes that along with adding in a respective regression test.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
