### PR TITLE
[3/5] light client events

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -6,8 +6,10 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.opencensus.io/trace"
+
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
-	"github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice"
+	f "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice"
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/doubly-linked-tree"
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
@@ -19,7 +21,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
-	"go.opencensus.io/trace"
 )
 
 // ChainInfoFetcher defines a common interface for methods in blockchain service which
@@ -336,7 +337,7 @@ func (s *Service) HeadValidatorIndexToPublicKey(_ context.Context, index primiti
 }
 
 // ForkChoicer returns the forkchoice interface.
-func (s *Service) ForkChoicer() forkchoice.ForkChoicer {
+func (s *Service) ForkChoicer() f.ForkChoicer {
 	return s.cfg.ForkChoiceStore
 }
 

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice"
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/doubly-linked-tree"
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
@@ -332,6 +333,11 @@ func (s *Service) HeadValidatorIndexToPublicKey(_ context.Context, index primiti
 		return [fieldparams.BLSPubkeyLength]byte{}, err
 	}
 	return v.PublicKey(), nil
+}
+
+// ForkChoicer returns the forkchoice interface.
+func (s *Service) ForkChoicer() forkchoice.ForkChoicer {
+	return s.cfg.ForkChoiceStore
 }
 
 // IsOptimistic returns true if the current head is optimistic.

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -186,7 +186,7 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 
 	if features.Get().EnableLightClientEvents {
 		if _, err := s.sendLightClientOptimisticUpdate(ctx, cfg.signed, cfg.postState); err != nil {
-			log.WithError(err)
+			log.WithError(err).Error("Failed to send light client optimistic update")
 		}
 
 		// Get the finalized checkpoint
@@ -221,7 +221,7 @@ func (s *Service) tryPublishLightClientFinalityUpdate(ctx context.Context, signe
 
 	_, err = s.sendLightClientFinalityUpdate(ctx, signed, postState)
 	if err != nil {
-		log.WithError(err)
+		log.WithError(err).Error("Failed to send light client finality update")
 	} else {
 		s.lastPublishedLightClientEpoch = finalized.Epoch
 	}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -57,7 +57,6 @@ type postBlockProcessConfig struct {
 // sendLightClientFinalityUpdate sends a light client finality update notification of  to the state feed.
 func (s *Service) sendLightClientFinalityUpdate(ctx context.Context, signed interfaces.ReadOnlySignedBeaconBlock,
 	postState state.BeaconState) (int, error) {
-
 	// Get attested state
 	attestedRoot := signed.Block().ParentRoot()
 	attestedState, err := s.cfg.StateGen.StateByRoot(ctx, attestedRoot)
@@ -104,7 +103,6 @@ func (s *Service) sendLightClientFinalityUpdate(ctx context.Context, signed inte
 // sendLightClientOptimisticUpdate sends a light client optimistic update notification of  to the state feed.
 func (s *Service) sendLightClientOptimisticUpdate(ctx context.Context, signed interfaces.ReadOnlySignedBeaconBlock,
 	postState state.BeaconState) (int, error) {
-
 	// Get attested state
 	attestedRoot := signed.Block().ParentRoot()
 	attestedState, err := s.cfg.StateGen.StateByRoot(ctx, attestedRoot)

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -184,7 +184,7 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 		return errors.Wrap(err, "could not send FCU to engine")
 	}
 
-	if features.Get().EnableLightClientEvents {
+	if features.Get().EnableLightClient {
 		if _, err := s.sendLightClientOptimisticUpdate(ctx, cfg.signed, cfg.postState); err != nil {
 			log.WithError(err).Error("Failed to send light client optimistic update")
 		}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -54,7 +54,7 @@ type postBlockProcessConfig struct {
 	isValidPayload bool
 }
 
-// sendLightClientFinalityUpdate sends a light client finality update notification of  to the state feed.
+// sendLightClientFinalityUpdate sends a light client finality update notification to the state feed.
 func (s *Service) sendLightClientFinalityUpdate(ctx context.Context, signed interfaces.ReadOnlySignedBeaconBlock,
 	postState state.BeaconState) (int, error) {
 	// Get attested state

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -100,7 +100,7 @@ func (s *Service) sendLightClientFinalityUpdate(ctx context.Context, signed inte
 	}), nil
 }
 
-// sendLightClientOptimisticUpdate sends a light client optimistic update notification of  to the state feed.
+// sendLightClientOptimisticUpdate sends a light client optimistic update notification to the state feed.
 func (s *Service) sendLightClientOptimisticUpdate(ctx context.Context, signed interfaces.ReadOnlySignedBeaconBlock,
 	postState state.BeaconState) (int, error) {
 	// Get attested state
@@ -188,7 +188,7 @@ func (s *Service) postBlockProcess(cfg *postBlockProcessConfig) error {
 		log.WithError(err)
 	}
 
-	// Save finalized check point to db and more.
+	// Get the finalized checkpoint
 	finalized := s.ForkChoicer().FinalizedCheckpoint()
 
 	// LightClientFinalityUpdate needs super majority
@@ -212,6 +212,7 @@ func (s *Service) tryPublishLightClientFinalityUpdate(ctx context.Context, signe
 		return
 	}
 
+	// LightClientFinalityUpdate needs super majority
 	if syncAggregate.SyncCommitteeBits.Count()*3 < config.SyncCommitteeSize*2 {
 		return
 	}

--- a/beacon-chain/blockchain/process_block_helpers.go
+++ b/beacon-chain/blockchain/process_block_helpers.go
@@ -338,7 +338,7 @@ func (s *Service) fillInForkChoiceMissingBlocks(ctx context.Context, blk interfa
 
 // inserts finalized deposits into our finalized deposit trie, needs to be
 // called in the background
-func (s *Service) insertFinalizedDeposits(ctx context.Context, fRoot [32]byte) {
+func (s *Service) insertFinalizedDeposits(ctx context.Context, fRoot [32]byte) error {
 	ctx, span := trace.StartSpan(ctx, "blockChain.insertFinalizedDeposits")
 	defer span.End()
 	startTime := time.Now()
@@ -346,16 +346,14 @@ func (s *Service) insertFinalizedDeposits(ctx context.Context, fRoot [32]byte) {
 	// Update deposit cache.
 	finalizedState, err := s.cfg.StateGen.StateByRoot(ctx, fRoot)
 	if err != nil {
-		log.WithError(err).Error("could not fetch finalized state")
-		return
+		return errors.Wrap(err, "could not fetch finalized state")
 	}
 	// We update the cache up to the last deposit index in the finalized block's state.
 	// We can be confident that these deposits will be included in some block
 	// because the Eth1 follow distance makes such long-range reorgs extremely unlikely.
 	eth1DepositIndex, err := mathutil.Int(finalizedState.Eth1DepositIndex())
 	if err != nil {
-		log.WithError(err).Error("could not cast eth1 deposit index")
-		return
+		return errors.Wrap(err, "could not cast eth1 deposit index")
 	}
 	// The deposit index in the state is always the index of the next deposit
 	// to be included(rather than the last one to be processed). This was most likely
@@ -363,18 +361,18 @@ func (s *Service) insertFinalizedDeposits(ctx context.Context, fRoot [32]byte) {
 	finalizedEth1DepIdx := eth1DepositIndex - 1
 	if err = s.cfg.DepositCache.InsertFinalizedDeposits(ctx, int64(finalizedEth1DepIdx), common.Hash(finalizedState.Eth1Data().BlockHash),
 		0 /* Setting a zero value as we have no access to block height */); err != nil {
-		log.WithError(err).Error("could not insert finalized deposits")
-		return
+		return errors.Wrap(err, "could not insert finalized deposits")
 	}
 	// Deposit proofs are only used during state transition and can be safely removed to save space.
 	if err = s.cfg.DepositCache.PruneProofs(ctx, int64(finalizedEth1DepIdx)); err != nil {
-		log.WithError(err).Error("could not prune deposit proofs")
+		return errors.Wrap(err, "could not prune deposit proofs")
 	}
 	// Prune deposits which have already been finalized, the below method prunes all pending deposits (non-inclusive) up
 	// to the provided eth1 deposit index.
 	s.cfg.DepositCache.PrunePendingDeposits(ctx, int64(eth1DepositIndex)) // lint:ignore uintcast -- Deposit index should not exceed int64 in your lifetime.
 
 	log.WithField("duration", time.Since(startTime).String()).Debugf("Finalized deposit insertion completed at index %d", finalizedEth1DepIdx)
+	return nil
 }
 
 // This ensures that the input root defaults to using genesis root instead of zero hashes. This is needed for handling

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -164,9 +164,7 @@ func (s *Service) ReceiveBlock(ctx context.Context, block interfaces.ReadOnlySig
 		go s.sendNewFinalizedEvent(blockCopy, postState)
 		depCtx, cancel := context.WithTimeout(context.Background(), depositDeadline)
 		go func() {
-			if err := s.insertFinalizedDeposits(depCtx, finalized.Root); err != nil {
-				log.WithError(err).Error("could not insert finalized deposits")
-			}
+			s.insertFinalizedDeposits(depCtx, finalized.Root)
 			cancel()
 		}()
 	}

--- a/beacon-chain/blockchain/receive_block.go
+++ b/beacon-chain/blockchain/receive_block.go
@@ -164,7 +164,9 @@ func (s *Service) ReceiveBlock(ctx context.Context, block interfaces.ReadOnlySig
 		go s.sendNewFinalizedEvent(blockCopy, postState)
 		depCtx, cancel := context.WithTimeout(context.Background(), depositDeadline)
 		go func() {
-			s.insertFinalizedDeposits(depCtx, finalized.Root)
+			if err := s.insertFinalizedDeposits(depCtx, finalized.Root); err != nil {
+				log.WithError(err).Error("could not insert finalized deposits")
+			}
 			cancel()
 		}()
 	}

--- a/beacon-chain/core/feed/state/events.go
+++ b/beacon-chain/core/feed/state/events.go
@@ -27,6 +27,10 @@ const (
 	NewHead
 	// MissedSlot is sent when we need to notify users that a slot was missed.
 	MissedSlot
+	// LightClientFinalityUpdate event
+	LightClientFinalityUpdate
+	// LightClientOptimisticUpdate event
+	LightClientOptimisticUpdate
 )
 
 // BlockProcessedData is the data sent with BlockProcessed events.

--- a/beacon-chain/rpc/eth/events/BUILD.bazel
+++ b/beacon-chain/rpc/eth/events/BUILD.bazel
@@ -20,6 +20,8 @@ go_library(
         "//beacon-chain/rpc/eth/shared:go_default_library",
         "//network/httputil:go_default_library",
         "//proto/eth/v1:go_default_library",
+        "//proto/eth/v2:go_default_library",
+        "//proto/migration:go_default_library",
         "//runtime/version:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",

--- a/beacon-chain/rpc/eth/events/BUILD.bazel
+++ b/beacon-chain/rpc/eth/events/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//network/httputil:go_default_library",
         "//proto/eth/v1:go_default_library",
         "//proto/eth/v2:go_default_library",
-        "//proto/migration:go_default_library",
         "//runtime/version:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -272,7 +272,6 @@ func (s *Server) handleStateEvents(ctx context.Context, w http.ResponseWriter, f
 		send(w, flusher, FinalizedCheckpointTopic, checkpoint)
 	case statefeed.LightClientFinalityUpdate:
 		if _, ok := requestedTopics[LightClientFinalityUpdateTopic]; !ok {
-			write(w, flusher, topicDataMismatch, event.Data, LightClientFinalityUpdateTopic)
 			return
 		}
 		update, ok := event.Data.(*ethpbv2.LightClientFinalityUpdateWithVersion)

--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -7,6 +7,9 @@ import (
 	"net/http"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/trace"
+
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/blockchain"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/feed"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/feed/operation"
@@ -17,10 +20,9 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/eth/shared"
 	"github.com/prysmaticlabs/prysm/v4/network/httputil"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/eth/v1"
+	ethpbv2 "github.com/prysmaticlabs/prysm/v4/proto/eth/v2"
 	"github.com/prysmaticlabs/prysm/v4/runtime/version"
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
-	log "github.com/sirupsen/logrus"
-	"go.opencensus.io/trace"
 )
 
 const (
@@ -48,6 +50,10 @@ const (
 	ProposerSlashingTopic = "proposer_slashing"
 	// AttesterSlashingTopic represents a new attester slashing event topic
 	AttesterSlashingTopic = "attester_slashing"
+	// LightClientFinalityUpdateTopic represents a new light client finality update event topic.
+	LightClientFinalityUpdateTopic = "light_client_finality_update"
+	// LightClientOptimisticUpdateTopic represents a new light client optimistic update event topic.
+	LightClientOptimisticUpdateTopic = "light_client_optimistic_update"
 )
 
 const topicDataMismatch = "Event data type %T does not correspond to event topic %s"
@@ -55,18 +61,20 @@ const topicDataMismatch = "Event data type %T does not correspond to event topic
 const chanBuffer = 1000
 
 var casesHandled = map[string]bool{
-	HeadTopic:                      true,
-	BlockTopic:                     true,
-	AttestationTopic:               true,
-	VoluntaryExitTopic:             true,
-	FinalizedCheckpointTopic:       true,
-	ChainReorgTopic:                true,
-	SyncCommitteeContributionTopic: true,
-	BLSToExecutionChangeTopic:      true,
-	PayloadAttributesTopic:         true,
-	BlobSidecarTopic:               true,
-	ProposerSlashingTopic:          true,
-	AttesterSlashingTopic:          true,
+	HeadTopic:                        true,
+	BlockTopic:                       true,
+	AttestationTopic:                 true,
+	VoluntaryExitTopic:               true,
+	FinalizedCheckpointTopic:         true,
+	ChainReorgTopic:                  true,
+	SyncCommitteeContributionTopic:   true,
+	BLSToExecutionChangeTopic:        true,
+	PayloadAttributesTopic:           true,
+	BlobSidecarTopic:                 true,
+	ProposerSlashingTopic:            true,
+	AttesterSlashingTopic:            true,
+	LightClientFinalityUpdateTopic:   true,
+	LightClientOptimisticUpdateTopic: true,
 }
 
 // StreamEvents provides an endpoint to subscribe to the beacon node Server-Sent-Events stream.
@@ -262,6 +270,27 @@ func (s *Server) handleStateEvents(ctx context.Context, w http.ResponseWriter, f
 			ExecutionOptimistic: checkpointData.ExecutionOptimistic,
 		}
 		send(w, flusher, FinalizedCheckpointTopic, checkpoint)
+	case statefeed.LightClientFinalityUpdate:
+		if _, ok := requestedTopics[LightClientFinalityUpdateTopic]; !ok {
+			write(w, flusher, topicDataMismatch, event.Data, LightClientFinalityUpdateTopic)
+			return
+		}
+		update, ok := event.Data.(*ethpbv2.LightClientFinalityUpdateWithVersion)
+		if !ok {
+			write(w, flusher, topicDataMismatch, event.Data, LightClientFinalityUpdateTopic)
+			return
+		}
+		send(w, flusher, LightClientFinalityUpdateTopic, update)
+	case statefeed.LightClientOptimisticUpdate:
+		if _, ok := requestedTopics[LightClientOptimisticUpdateTopic]; !ok {
+			return
+		}
+		update, ok := event.Data.(*ethpbv2.LightClientOptimisticUpdateWithVersion)
+		if !ok {
+			write(w, flusher, topicDataMismatch, event.Data, LightClientOptimisticUpdateTopic)
+			return
+		}
+		send(w, flusher, LightClientOptimisticUpdateTopic, update)
 	case statefeed.Reorg:
 		if _, ok := requestedTopics[ChainReorgTopic]; !ok {
 			return

--- a/beacon-chain/rpc/eth/events/structs.go
+++ b/beacon-chain/rpc/eth/events/structs.go
@@ -92,3 +92,27 @@ type BlobSidecarEvent struct {
 	KzgCommitment string `json:"kzg_commitment"`
 	VersionedHash string `json:"versioned_hash"`
 }
+
+type LightClientFinalityUpdateResponseJson struct {
+	Version string                         `json:"version" enum:"true"`
+	Data    *LightClientFinalityUpdateJson `json:"data"`
+}
+
+type LightClientFinalityUpdateJson struct {
+	AttestedHeader  *shared.BeaconBlockHeader `json:"attested_header"`
+	FinalizedHeader *shared.BeaconBlockHeader `json:"finalized_header"`
+	FinalityBranch  []string                  `json:"finality_branch"  hex:"true"`
+	SyncAggregate   *shared.SyncAggregate     `json:"sync_aggregate"`
+	SignatureSlot   string                    `json:"signature_slot"`
+}
+
+type LightClientOptimisticUpdateResponseJson struct {
+	Version string                           `json:"version" enum:"true"`
+	Data    *LightClientOptimisticUpdateJson `json:"data"`
+}
+
+type LightClientOptimisticUpdateJson struct {
+	AttestedHeader *shared.BeaconBlockHeader `json:"attested_header"`
+	SyncAggregate  *shared.SyncAggregate     `json:"sync_aggregate"`
+	SignatureSlot  string                    `json:"signature_slot"`
+}

--- a/beacon-chain/rpc/eth/events/structs.go
+++ b/beacon-chain/rpc/eth/events/structs.go
@@ -93,12 +93,12 @@ type BlobSidecarEvent struct {
 	VersionedHash string `json:"versioned_hash"`
 }
 
-type LightClientFinalityUpdateResponseJson struct {
-	Version string                         `json:"version" enum:"true"`
-	Data    *LightClientFinalityUpdateJson `json:"data"`
+type LightClientFinalityUpdateEvent struct {
+	Version string                     `json:"version" enum:"true"`
+	Data    *LightClientFinalityUpdate `json:"data"`
 }
 
-type LightClientFinalityUpdateJson struct {
+type LightClientFinalityUpdate struct {
 	AttestedHeader  *shared.BeaconBlockHeader `json:"attested_header"`
 	FinalizedHeader *shared.BeaconBlockHeader `json:"finalized_header"`
 	FinalityBranch  []string                  `json:"finality_branch"  hex:"true"`
@@ -106,12 +106,12 @@ type LightClientFinalityUpdateJson struct {
 	SignatureSlot   string                    `json:"signature_slot"`
 }
 
-type LightClientOptimisticUpdateResponseJson struct {
-	Version string                           `json:"version" enum:"true"`
-	Data    *LightClientOptimisticUpdateJson `json:"data"`
+type LightClientOptimisticUpdateEvent struct {
+	Version string                       `json:"version" enum:"true"`
+	Data    *LightClientOptimisticUpdate `json:"data"`
 }
 
-type LightClientOptimisticUpdateJson struct {
+type LightClientOptimisticUpdate struct {
 	AttestedHeader *shared.BeaconBlockHeader `json:"attested_header"`
 	SyncAggregate  *shared.SyncAggregate     `json:"sync_aggregate"`
 	SignatureSlot  string                    `json:"signature_slot"`

--- a/beacon-chain/rpc/eth/events/structs.go
+++ b/beacon-chain/rpc/eth/events/structs.go
@@ -94,20 +94,20 @@ type BlobSidecarEvent struct {
 }
 
 type LightClientFinalityUpdateEvent struct {
-	Version string                     `json:"version" enum:"true"`
+	Version string                     `json:"version"`
 	Data    *LightClientFinalityUpdate `json:"data"`
 }
 
 type LightClientFinalityUpdate struct {
 	AttestedHeader  *shared.BeaconBlockHeader `json:"attested_header"`
 	FinalizedHeader *shared.BeaconBlockHeader `json:"finalized_header"`
-	FinalityBranch  []string                  `json:"finality_branch"  hex:"true"`
+	FinalityBranch  []string                  `json:"finality_branch"`
 	SyncAggregate   *shared.SyncAggregate     `json:"sync_aggregate"`
 	SignatureSlot   string                    `json:"signature_slot"`
 }
 
 type LightClientOptimisticUpdateEvent struct {
-	Version string                       `json:"version" enum:"true"`
+	Version string                       `json:"version"`
 	Data    *LightClientOptimisticUpdate `json:"data"`
 }
 

--- a/beacon-chain/rpc/eth/light-client/handlers.go
+++ b/beacon-chain/rpc/eth/light-client/handlers.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gorilla/mux"
-	"github.com/wealdtech/go-bytesutil"
 	"go.opencensus.io/trace"
 
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/eth/shared"
@@ -219,11 +218,7 @@ func (s *Server) GetLightClientUpdatesByRange(w http.ResponseWriter, req *http.R
 		return
 	}
 
-	response := &LightClientUpdatesByRangeResponse{
-		Updates: updates,
-	}
-
-	httputil.WriteJson(w, response)
+	http2.WriteJson(w, updates)
 }
 
 // GetLightClientFinalityUpdate - implements https://github.com/ethereum/beacon-APIs/blob/263f4ed6c263c967f13279c7a9f5629b51c5fc55/apis/beacon/light_client/finality_update.yaml

--- a/beacon-chain/rpc/eth/light-client/handlers.go
+++ b/beacon-chain/rpc/eth/light-client/handlers.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gorilla/mux"
 	"go.opencensus.io/trace"
 
+	"github.com/wealdtech/go-bytesutil"
+
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/eth/shared"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
@@ -218,7 +220,7 @@ func (s *Server) GetLightClientUpdatesByRange(w http.ResponseWriter, req *http.R
 		return
 	}
 
-	http2.WriteJson(w, updates)
+	httputil.WriteJson(w, updates)
 }
 
 // GetLightClientFinalityUpdate - implements https://github.com/ethereum/beacon-APIs/blob/263f4ed6c263c967f13279c7a9f5629b51c5fc55/apis/beacon/light_client/finality_update.yaml

--- a/beacon-chain/rpc/eth/light-client/handlers_test.go
+++ b/beacon-chain/rpc/eth/light-client/handlers_test.go
@@ -171,12 +171,12 @@ func TestLightClientHandler_GetLightClientUpdatesByRange(t *testing.T) {
 	s.GetLightClientUpdatesByRange(writer, request)
 
 	require.Equal(t, http.StatusOK, writer.Code)
-	resp := &LightClientUpdatesByRangeResponse{}
-	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
-	require.Equal(t, 1, len(resp.Updates))
-	require.Equal(t, "capella", resp.Updates[0].Version)
-	require.Equal(t, hexutil.Encode(attestedHeader.BodyRoot), resp.Updates[0].Data.AttestedHeader.BodyRoot)
-	require.NotNil(t, resp.Updates)
+	var resp []LightClientUpdateWithVersion
+	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
+	require.Equal(t, 1, len(resp))
+	require.Equal(t, "capella", resp[0].Version)
+	require.Equal(t, hexutil.Encode(attestedHeader.BodyRoot), resp[0].Data.AttestedHeader.BodyRoot)
+	require.NotNil(t, resp)
 }
 
 func TestLightClientHandler_GetLightClientUpdatesByRange_TooBigInputCount(t *testing.T) {
@@ -274,12 +274,12 @@ func TestLightClientHandler_GetLightClientUpdatesByRange_TooBigInputCount(t *tes
 	s.GetLightClientUpdatesByRange(writer, request)
 
 	require.Equal(t, http.StatusOK, writer.Code)
-	resp := &LightClientUpdatesByRangeResponse{}
-	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
-	require.Equal(t, 1, len(resp.Updates)) // Even with big count input, the response is still the max available period, which is 1 in test case.
-	require.Equal(t, "capella", resp.Updates[0].Version)
-	require.Equal(t, hexutil.Encode(attestedHeader.BodyRoot), resp.Updates[0].Data.AttestedHeader.BodyRoot)
-	require.NotNil(t, resp.Updates)
+	var resp []LightClientUpdateWithVersion
+	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
+	require.Equal(t, 1, len(resp)) // Even with big count input, the response is still the max available period, which is 1 in test case.
+	require.Equal(t, "capella", resp[0].Version)
+	require.Equal(t, hexutil.Encode(attestedHeader.BodyRoot), resp[0].Data.AttestedHeader.BodyRoot)
+	require.NotNil(t, resp)
 }
 
 func TestLightClientHandler_GetLightClientUpdatesByRange_TooEarlyPeriod(t *testing.T) {
@@ -377,12 +377,12 @@ func TestLightClientHandler_GetLightClientUpdatesByRange_TooEarlyPeriod(t *testi
 	s.GetLightClientUpdatesByRange(writer, request)
 
 	require.Equal(t, http.StatusOK, writer.Code)
-	resp := &LightClientUpdatesByRangeResponse{}
-	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
-	require.Equal(t, 1, len(resp.Updates))
-	require.Equal(t, "capella", resp.Updates[0].Version)
-	require.Equal(t, hexutil.Encode(attestedHeader.BodyRoot), resp.Updates[0].Data.AttestedHeader.BodyRoot)
-	require.NotNil(t, resp.Updates)
+	var resp []LightClientUpdateWithVersion
+	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
+	require.Equal(t, 1, len(resp))
+	require.Equal(t, "capella", resp[0].Version)
+	require.Equal(t, hexutil.Encode(attestedHeader.BodyRoot), resp[0].Data.AttestedHeader.BodyRoot)
+	require.NotNil(t, resp)
 }
 
 func TestLightClientHandler_GetLightClientUpdatesByRange_TooBigCount(t *testing.T) {
@@ -480,12 +480,12 @@ func TestLightClientHandler_GetLightClientUpdatesByRange_TooBigCount(t *testing.
 	s.GetLightClientUpdatesByRange(writer, request)
 
 	require.Equal(t, http.StatusOK, writer.Code)
-	resp := &LightClientUpdatesByRangeResponse{}
-	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
-	require.Equal(t, 1, len(resp.Updates))
-	require.Equal(t, "capella", resp.Updates[0].Version)
-	require.Equal(t, hexutil.Encode(attestedHeader.BodyRoot), resp.Updates[0].Data.AttestedHeader.BodyRoot)
-	require.NotNil(t, resp.Updates)
+	var resp []LightClientUpdateWithVersion
+	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), &resp))
+	require.Equal(t, 1, len(resp))
+	require.Equal(t, "capella", resp[0].Version)
+	require.Equal(t, hexutil.Encode(attestedHeader.BodyRoot), resp[0].Data.AttestedHeader.BodyRoot)
+	require.NotNil(t, resp)
 }
 
 func TestLightClientHandler_GetLightClientUpdatesByRange_BeforeAltair(t *testing.T) {
@@ -583,9 +583,6 @@ func TestLightClientHandler_GetLightClientUpdatesByRange_BeforeAltair(t *testing
 	s.GetLightClientUpdatesByRange(writer, request)
 
 	require.Equal(t, http.StatusNotFound, writer.Code)
-	resp := &LightClientUpdatesByRangeResponse{}
-	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
-	require.Equal(t, 0, len(resp.Updates))
 }
 
 func TestLightClientHandler_GetLightClientFinalityUpdate(t *testing.T) {

--- a/beacon-chain/rpc/eth/light-client/helpers.go
+++ b/beacon-chain/rpc/eth/light-client/helpers.go
@@ -296,11 +296,16 @@ func newLightClientUpdateToJSON(input *v2.LightClientUpdate) *LightClientUpdate 
 		nextSyncCommittee = shared.SyncCommitteeFromConsensus(migration.V2SyncCommitteeToV1Alpha1(input.NextSyncCommittee))
 	}
 
+	var finalizedHeader *shared.BeaconBlockHeader
+	if input.FinalizedHeader != nil {
+		finalizedHeader = shared.BeaconBlockHeaderFromConsensus(migration.V1HeaderToV1Alpha1(input.FinalizedHeader))
+	}
+
 	return &LightClientUpdate{
 		AttestedHeader:          shared.BeaconBlockHeaderFromConsensus(migration.V1HeaderToV1Alpha1(input.AttestedHeader)),
 		NextSyncCommittee:       nextSyncCommittee,
 		NextSyncCommitteeBranch: branchToJSON(input.NextSyncCommitteeBranch),
-		FinalizedHeader:         shared.BeaconBlockHeaderFromConsensus(migration.V1HeaderToV1Alpha1(input.FinalizedHeader)),
+		FinalizedHeader:         finalizedHeader,
 		FinalityBranch:          branchToJSON(input.FinalityBranch),
 		SyncAggregate:           syncAggregateToJSON(input.SyncAggregate),
 		SignatureSlot:           strconv.FormatUint(uint64(input.SignatureSlot), 10),

--- a/beacon-chain/rpc/eth/light-client/structs.go
+++ b/beacon-chain/rpc/eth/light-client/structs.go
@@ -17,11 +17,11 @@ type LightClientBootstrap struct {
 
 type LightClientUpdate struct {
 	AttestedHeader          *shared.BeaconBlockHeader `json:"attested_header"`
-	NextSyncCommittee       *shared.SyncCommittee     `json:"next_sync_committee"`
-	FinalizedHeader         *shared.BeaconBlockHeader `json:"finalized_header"`
+	NextSyncCommittee       *shared.SyncCommittee     `json:"next_sync_committee,omitempty"`
+	FinalizedHeader         *shared.BeaconBlockHeader `json:"finalized_header,omitempty"`
 	SyncAggregate           *shared.SyncAggregate     `json:"sync_aggregate"`
-	NextSyncCommitteeBranch []string                  `json:"next_sync_committee_branch"`
-	FinalityBranch          []string                  `json:"finality_branch"`
+	NextSyncCommitteeBranch []string                  `json:"next_sync_committee_branch,omitempty"`
+	FinalityBranch          []string                  `json:"finality_branch,omitempty"`
 	SignatureSlot           string                    `json:"signature_slot"`
 }
 

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -239,8 +239,8 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		logEnabled(EnableEIP4881)
 		cfg.EnableEIP4881 = true
 	}
-	if ctx.IsSet(EnableLightClientEvents.Name) {
-		logEnabled(EnableLightClientEvents)
+	if ctx.IsSet(EnableLightClient.Name) {
+		logEnabled(EnableLightClient)
 		cfg.EnableLightClient = true
 	}
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -41,6 +41,7 @@ type Flags struct {
 	EnableExperimentalState             bool // EnableExperimentalState turns on the latest and greatest (but potentially unstable) changes to the beacon state.
 	WriteSSZStateTransitions            bool // WriteSSZStateTransitions to tmp directory.
 	EnablePeerScorer                    bool // EnablePeerScorer enables experimental peer scoring in p2p.
+	EnableLightClientEvents             bool // EnableLightClientEvents enables light client events to be emitted by the beacon node.
 	WriteWalletPasswordOnWebOnboarding  bool // WriteWalletPasswordOnWebOnboarding writes the password to disk after Prysm web signup.
 	EnableDoppelGanger                  bool // EnableDoppelGanger enables doppelganger protection on startup for the validator.
 	EnableHistoricalSpaceRepresentation bool // EnableHistoricalSpaceRepresentation enables the saving of registry validators in separate buckets to save space
@@ -75,9 +76,6 @@ type Flags struct {
 
 	// AggregateIntervals specifies the time durations at which we aggregate attestations preparing for forkchoice.
 	AggregateIntervals [3]time.Duration
-
-	// EnableLightClientEvents enables light client events to be emitted by the beacon node.
-	EnableLightClientEvents bool
 }
 
 var featureConfig *Flags

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -23,10 +23,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prysmaticlabs/prysm/v4/cmd"
-	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
+
+	"github.com/prysmaticlabs/prysm/v4/cmd"
+	"github.com/prysmaticlabs/prysm/v4/config/params"
 )
 
 var log = logrus.WithField("prefix", "flags")
@@ -74,6 +75,9 @@ type Flags struct {
 
 	// AggregateIntervals specifies the time durations at which we aggregate attestations preparing for forkchoice.
 	AggregateIntervals [3]time.Duration
+
+	// EnableLightClientEvents enables light client events to be emitted by the beacon node.
+	EnableLightClientEvents bool
 }
 
 var featureConfig *Flags
@@ -236,6 +240,10 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	if ctx.IsSet(EnableEIP4881.Name) {
 		logEnabled(EnableEIP4881)
 		cfg.EnableEIP4881 = true
+	}
+	if ctx.IsSet(EnableLightClientEvents.Name) {
+		logEnabled(EnableLightClientEvents)
+		cfg.EnableLightClientEvents = true
 	}
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}
 	Init(cfg)

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -41,7 +41,7 @@ type Flags struct {
 	EnableExperimentalState             bool // EnableExperimentalState turns on the latest and greatest (but potentially unstable) changes to the beacon state.
 	WriteSSZStateTransitions            bool // WriteSSZStateTransitions to tmp directory.
 	EnablePeerScorer                    bool // EnablePeerScorer enables experimental peer scoring in p2p.
-	EnableLightClientEvents             bool // EnableLightClientEvents enables light client events to be emitted by the beacon node.
+	EnableLightClient                   bool // EnableLightClient enables light client APIs.
 	WriteWalletPasswordOnWebOnboarding  bool // WriteWalletPasswordOnWebOnboarding writes the password to disk after Prysm web signup.
 	EnableDoppelGanger                  bool // EnableDoppelGanger enables doppelganger protection on startup for the validator.
 	EnableHistoricalSpaceRepresentation bool // EnableHistoricalSpaceRepresentation enables the saving of registry validators in separate buckets to save space
@@ -241,7 +241,7 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 	}
 	if ctx.IsSet(EnableLightClientEvents.Name) {
 		logEnabled(EnableLightClientEvents)
-		cfg.EnableLightClientEvents = true
+		cfg.EnableLightClient = true
 	}
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}
 	Init(cfg)

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -140,6 +140,10 @@ var (
 		Name:  "enable-eip-4881",
 		Usage: "Enables the deposit tree specified in EIP-4881.",
 	}
+	EnableLightClientEvents = &cli.BoolFlag{
+		Name:  "enable-lightclient-events",
+		Usage: "Enables the light client events support in the beacon node",
+	}
 	disableResourceManager = &cli.BoolFlag{
 		Name:  "disable-resource-manager",
 		Usage: "Disables running the libp2p resource manager.",
@@ -204,6 +208,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	EnableEIP4881,
 	disableResourceManager,
 	DisableRegistrationCache,
+	EnableLightClientEvents,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -140,9 +140,9 @@ var (
 		Name:  "enable-eip-4881",
 		Usage: "Enables the deposit tree specified in EIP-4881.",
 	}
-	EnableLightClientEvents = &cli.BoolFlag{
-		Name:  "enable-lightclient-events",
-		Usage: "Enables the light client events support in the beacon node",
+	EnableLightClient = &cli.BoolFlag{
+		Name:  "enable-lightclient",
+		Usage: "Enables the light client support in the beacon node",
 	}
 	disableResourceManager = &cli.BoolFlag{
 		Name:  "disable-resource-manager",
@@ -208,7 +208,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	EnableEIP4881,
 	disableResourceManager,
 	DisableRegistrationCache,
-	EnableLightClientEvents,
+	EnableLightClient,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.


### PR DESCRIPTION
**What type of PR is this?**

Feature

** What does this PR do? Why is it needed?**

Implements the Altair spec logic defined in this version:

https://github.com/ethereum/consensus-specs/tree/208da34ac4e75337baf79adebf036ab595e39f15/specs/altair/light-client

It also implements the relevant endpoints specified at https://github.com/ethereum/beacon-APIs

Specifically, this PR adding light client event sub/pub for `optimistic update` and `finalized update`

https://github.com/prysmaticlabs/prysm/pull/11815

**Which issues(s) does this PR fix?**

Partially addresses https://github.com/prysmaticlabs/prysm/issues/11571

Other notes for review

This PR is a follow up to https://github.com/prysmaticlabs/prysm/pull/11815 which was too big to be reviewed. This is the third PR in a series of 5 that I will be submitting sequentially.

The heavy lifting here was done by [@qinlz2](https://github.com/qinlz2) and [@7AC](https://github.com/7AC), so kudos to them.