### PR TITLE
Use Fixed Intervals For Pending Queues

### DIFF
--- a/async/BUILD.bazel
+++ b/async/BUILD.bazel
@@ -10,7 +10,10 @@ go_library(
     ],
     importpath = "github.com/prysmaticlabs/prysm/v4/async",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_sirupsen_logrus//:go_default_library"],
+    deps = [
+        "//time/slots:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
 )
 
 go_test(
@@ -24,6 +27,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//config/params:go_default_library",
         "//testing/assert:go_default_library",
         "//testing/require:go_default_library",
         "//testing/util:go_default_library",

--- a/async/every.go
+++ b/async/every.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/prysmaticlabs/prysm/v4/time/slots"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -24,6 +25,24 @@ func RunEvery(ctx context.Context, period time.Duration, f func()) {
 			case <-ctx.Done():
 				log.WithField("function", funcName).Debug("context is closed, exiting")
 				ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func RunWithTickerAndInterval(ctx context.Context, genesis time.Time, intervals []time.Duration, f func()) {
+	funcName := runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
+	ticker := slots.NewSlotTickerWithIntervals(genesis, intervals)
+	go func() {
+		for {
+			select {
+			case <-ticker.C():
+				log.WithField("function", funcName).Trace("running")
+				f()
+			case <-ctx.Done():
+				log.WithField("function", funcName).Debug("context is closed, exiting")
+				ticker.Done()
 				return
 			}
 		}

--- a/async/every_test.go
+++ b/async/every_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/prysmaticlabs/prysm/v4/async"
+	"github.com/prysmaticlabs/prysm/v4/config/params"
 )
 
 func TestEveryRuns(t *testing.T) {
@@ -22,6 +23,49 @@ func TestEveryRuns(t *testing.T) {
 
 	if atomic.LoadInt32(&i) == 0 {
 		t.Error("Counter failed to increment with ticker")
+	}
+
+	cancel()
+
+	// Sleep for a bit to let the cancel take place.
+	time.Sleep(100 * time.Millisecond)
+
+	last := atomic.LoadInt32(&i)
+
+	// Sleep for a bit and ensure the value has not increased.
+	time.Sleep(200 * time.Millisecond)
+
+	if atomic.LoadInt32(&i) != last {
+		t.Error("Counter incremented after stop")
+	}
+}
+
+func TestEveryRunsWithTickerAndInterval(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	params.SetupTestConfigCleanup(t)
+	newCfg := params.BeaconConfig()
+	newCfg.SecondsPerSlot = 1
+	params.OverrideBeaconConfig(newCfg)
+
+	i := int32(0)
+
+	genTime := time.Now()
+	async.RunWithTickerAndInterval(ctx, genTime, []time.Duration{100 * time.Millisecond, 200 * time.Millisecond}, func() {
+		atomic.AddInt32(&i, 1)
+	})
+
+	// Sleep for a bit and ensure the value has increased.
+	time.Sleep(1150 * time.Millisecond)
+
+	if atomic.LoadInt32(&i) != 1 {
+		t.Errorf("Counter failed to increment with ticker: Got %d instead of %d", atomic.LoadInt32(&i), 1)
+	}
+
+	// Sleep for a bit and ensure the value has increased.
+	time.Sleep(200 * time.Millisecond)
+
+	if atomic.LoadInt32(&i) != 2 {
+		t.Errorf("Counter failed to increment with ticker: Got %d instead of %d", atomic.LoadInt32(&i), 2)
 	}
 
 	cancel()

--- a/beacon-chain/sync/pending_attestations_queue.go
+++ b/beacon-chain/sync/pending_attestations_queue.go
@@ -21,7 +21,7 @@ import (
 )
 
 // This defines how often a node cleans up and processes pending attestations in the queue.
-var processPendingAttsPeriod = slots.DivideSlotBy(2 /* twice per slot */)
+
 var pendingAttsLimit = 10000
 
 // This processes pending attestation queues on every `processPendingAttsPeriod`.
@@ -33,6 +33,7 @@ func (s *Service) processPendingAttsQueue() {
 	}
 	// Prevents multiple queue processing goroutines (invoked by RunEvery) from contending for data.
 	mutex := new(sync.Mutex)
+	processPendingAttsPeriod := slots.DivideSlotBy(2 /* twice per slot */)
 	async.RunWithTickerAndInterval(s.ctx, clock.GenesisTime(), []time.Duration{0, processPendingAttsPeriod}, func() {
 		mutex.Lock()
 		if err := s.processPendingAtts(s.ctx); err != nil {

--- a/beacon-chain/sync/service.go
+++ b/beacon-chain/sync/service.go
@@ -212,8 +212,8 @@ func (s *Service) Start() {
 		return nil
 	})
 	s.cfg.p2p.AddPingMethod(s.sendPingRequest)
-	s.processPendingBlocksQueue()
-	s.processPendingAttsQueue()
+	go s.processPendingBlocksQueue()
+	go s.processPendingAttsQueue()
 	s.maintainPeerStatuses()
 	s.resyncIfBehind()
 


### PR DESCRIPTION
**What type of PR is this?**

Feature Cleanup

**What does this PR do? Why is it needed?**

For our pending attestation and block queues, instead of running with a ticker which is periodically triggered(without respect to the current slot boundaries), we instead use one which is triggered depending on slot intervals.

This PR adds in a new `async` method to allow us to use custom tickers with intervals. 

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
