### PR TITLE
Revert "Optimize `ReplayBlocks` for Zero Diff"

### DIFF
--- a/beacon-chain/state/stategen/mock_test.go
+++ b/beacon-chain/state/stategen/mock_test.go
@@ -250,11 +250,9 @@ func newMockHistory(t *testing.T, hist []mockHistorySpec, current primitives.Slo
 		b, err = blocktest.SetBlockParentRoot(b, pr)
 		require.NoError(t, err)
 
-		// now do process_block only if block slot is greater than latest header slot
-		if b.Block().Slot() > s.LatestBlockHeader().Slot {
-			s, err = transition.ProcessBlockForStateRoot(ctx, s, b)
-			require.NoError(t, err)
-		}
+		// now do process_block
+		s, err = transition.ProcessBlockForStateRoot(ctx, s, b)
+		require.NoError(t, err)
 
 		sr, err := s.HashTreeRoot(ctx)
 		require.NoError(t, err)

--- a/beacon-chain/state/stategen/replayer.go
+++ b/beacon-chain/state/stategen/replayer.go
@@ -93,10 +93,6 @@ func (rs *stateReplayer) ReplayBlocks(ctx context.Context) (state.BeaconState, e
 		msg := fmt.Sprintf("error subtracting state.slot %d from replay target slot %d", s.Slot(), rs.target)
 		return nil, errors.Wrap(err, msg)
 	}
-	if diff == 0 {
-		return s, nil
-	}
-
 	log.WithFields(logrus.Fields{
 		"startSlot": s.Slot(),
 		"endSlot":   rs.target,

--- a/beacon-chain/state/stategen/replayer_test.go
+++ b/beacon-chain/state/stategen/replayer_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
-	logTest "github.com/sirupsen/logrus/hooks/test"
 )
 
 func headerFromBlock(b interfaces.ReadOnlySignedBeaconBlock) (*ethpb.BeaconBlockHeader, error) {
@@ -26,17 +25,6 @@ func headerFromBlock(b interfaces.ReadOnlySignedBeaconBlock) (*ethpb.BeaconBlock
 		BodyRoot:      bodyRoot[:],
 		ParentRoot:    parentRoot[:],
 	}, nil
-}
-
-func TestReplayBlocks_ZeroDiff(t *testing.T) {
-	logHook := logTest.NewGlobal()
-	ctx := context.Background()
-	specs := []mockHistorySpec{{slot: 0}}
-	hist := newMockHistory(t, specs, 0)
-	ch := NewCanonicalHistory(hist, hist, hist)
-	_, err := ch.ReplayerForSlot(0).ReplayBlocks(ctx)
-	require.NoError(t, err)
-	require.LogsDoNotContain(t, logHook, "Replaying canonical blocks from most recent state")
 }
 
 func TestReplayBlocks(t *testing.T) {


### PR DESCRIPTION
Per internal discussion. E2E tests have been failing more after this PR. The detailed reason is unknown but it's worth digging into. Reverting this PR first
