### PR TITLE
Fix Deadlock With Subscriber Checker

### DIFF
--- a/beacon-chain/p2p/pubsub.go
+++ b/beacon-chain/p2p/pubsub.go
@@ -45,10 +45,6 @@ const digestLength = 4
 // Specifies the prefix for any pubsub topic.
 const gossipTopicPrefix = "/eth2/"
 
-type subscriberChecker interface {
-	isSubscribedToTopic(topic string) bool
-}
-
 // JoinTopic will join PubSub topic, if not already joined.
 func (s *Service) JoinTopic(topic string, opts ...pubsub.TopicOpt) (*pubsub.Topic, error) {
 	s.joinedTopicsLock.Lock()
@@ -123,15 +119,6 @@ func (s *Service) SubscribeToTopic(topic string, opts ...pubsub.SubOpt) (*pubsub
 	return topicHandle.Subscribe(opts...)
 }
 
-// checks if we are subscribed to the particular topic.
-func (s *Service) isSubscribedToTopic(topic string) bool {
-	s.joinedTopicsLock.RLock()
-	defer s.joinedTopicsLock.RUnlock()
-
-	_, ok := s.joinedTopics[topic]
-	return ok
-}
-
 // peerInspector will scrape all the relevant scoring data and add it to our
 // peer handler.
 func (s *Service) peerInspector(peerMap map[peer.ID]*pubsub.PeerScoreSnapshot) {
@@ -158,7 +145,7 @@ func (s *Service) pubsubOptions() []pubsub.Option {
 		pubsub.WithPeerScore(peerScoringParams()),
 		pubsub.WithPeerScoreInspect(s.peerInspector, time.Minute),
 		pubsub.WithGossipSubParams(pubsubGossipParam()),
-		pubsub.WithRawTracer(gossipTracer{host: s.host, checker: s}),
+		pubsub.WithRawTracer(gossipTracer{host: s.host}),
 	}
 	return psOpts
 }

--- a/beacon-chain/p2p/pubsub_tracer.go
+++ b/beacon-chain/p2p/pubsub_tracer.go
@@ -22,8 +22,7 @@ const (
 // This tracer is used to implement metrics collection for messages received
 // and broadcasted through gossipsub.
 type gossipTracer struct {
-	host    host.Host
-	checker subscriberChecker
+	host host.Host
 }
 
 // AddPeer .
@@ -111,9 +110,9 @@ func (g gossipTracer) setMetricFromRPC(act action, subCtr prometheus.Counter, pu
 		ctrlCtr.WithLabelValues("iwant").Add(float64(len(rpc.Control.Iwant)))
 	}
 	for _, msg := range rpc.Publish {
-		// For incoming messages from pubsub, we validate that the topics are valid
-		// before recording metrics for them.
-		if act == recv && !g.checker.isSubscribedToTopic(*msg.Topic) {
+		// For incoming messages from pubsub, we do not record metrics for them as these values
+		// could be junk.
+		if act == recv {
 			continue
 		}
 		pubCtr.WithLabelValues(*msg.Topic).Inc()


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

In #13226 , we added additional metrics to improve granularity of pubsub metric collection. However one change introduced a deadlock, this PR reverts that change.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
