### PR TITLE
Fix FFG LMD Consistency Check (Option 2)

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -471,6 +471,13 @@ func (s *Service) TargetRoot(root [32]byte) ([32]byte, error) {
 	return s.cfg.ForkChoiceStore.TargetRoot(root)
 }
 
+// TargetRootForSlot wraps the corresponding method in forkchoice
+func (s *Service) TargetRootForSlot(root [32]byte, slot primitives.Slot) ([32]byte, error) {
+	s.cfg.ForkChoiceStore.RLock()
+	defer s.cfg.ForkChoiceStore.RUnlock()
+	return s.cfg.ForkChoiceStore.TargetRootForSlot(root, slot)
+}
+
 // Ancestor returns the block root of an ancestry block from the input block root.
 //
 // Spec pseudocode definition:

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -464,13 +464,6 @@ func (s *Service) IsOptimisticForRoot(ctx context.Context, root [32]byte) (bool,
 	return !isCanonical, nil
 }
 
-// TargetRoot wraps the corresponding method in forkchoice
-func (s *Service) TargetRoot(root [32]byte) ([32]byte, error) {
-	s.cfg.ForkChoiceStore.RLock()
-	defer s.cfg.ForkChoiceStore.RUnlock()
-	return s.cfg.ForkChoiceStore.TargetRoot(root)
-}
-
 // TargetRootForSlot wraps the corresponding method in forkchoice
 func (s *Service) TargetRootForSlot(root [32]byte, slot primitives.Slot) ([32]byte, error) {
 	s.cfg.ForkChoiceStore.RLock()

--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -464,11 +464,11 @@ func (s *Service) IsOptimisticForRoot(ctx context.Context, root [32]byte) (bool,
 	return !isCanonical, nil
 }
 
-// TargetRootForSlot wraps the corresponding method in forkchoice
-func (s *Service) TargetRootForSlot(root [32]byte, slot primitives.Slot) ([32]byte, error) {
+// TargetRootForEpoch wraps the corresponding method in forkchoice
+func (s *Service) TargetRootForEpoch(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
 	s.cfg.ForkChoiceStore.RLock()
 	defer s.cfg.ForkChoiceStore.RUnlock()
-	return s.cfg.ForkChoiceStore.TargetRootForSlot(root, slot)
+	return s.cfg.ForkChoiceStore.TargetRootForEpoch(root, epoch)
 }
 
 // Ancestor returns the block root of an ancestry block from the input block root.

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -53,7 +53,11 @@ func (s *Service) AttestationTargetState(ctx context.Context, target *ethpb.Chec
 
 // VerifyLmdFfgConsistency verifies that attestation's LMD and FFG votes are consistency to each other.
 func (s *Service) VerifyLmdFfgConsistency(ctx context.Context, a *ethpb.Attestation) error {
-	r, err := s.TargetRoot([32]byte(a.Data.BeaconBlockRoot))
+	targetSlot, err := slots.EpochStart(a.Data.Target.Epoch)
+	if err != nil {
+		return err
+	}
+	r, err := s.TargetRootForSlot([32]byte(a.Data.BeaconBlockRoot), targetSlot)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -53,11 +53,7 @@ func (s *Service) AttestationTargetState(ctx context.Context, target *ethpb.Chec
 
 // VerifyLmdFfgConsistency verifies that attestation's LMD and FFG votes are consistency to each other.
 func (s *Service) VerifyLmdFfgConsistency(ctx context.Context, a *ethpb.Attestation) error {
-	targetSlot, err := slots.EpochStart(a.Data.Target.Epoch)
-	if err != nil {
-		return err
-	}
-	r, err := s.TargetRootForSlot([32]byte(a.Data.BeaconBlockRoot), targetSlot)
+	r, err := s.TargetRootForEpoch([32]byte(a.Data.BeaconBlockRoot), a.Data.Target.Epoch)
 	if err != nil {
 		return err
 	}

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -638,21 +638,21 @@ func (f *ForkChoice) Slot(root [32]byte) (primitives.Slot, error) {
 	return n.slot, nil
 }
 
-// TargetRootForSlot returns the root of the target block for a given slot.
-// The slot parameter is crucial to identify the correct target root. For example:
+// TargetRootForEpoch returns the root of the target block for a given epoch.
+// The epoch parameter is crucial to identify the correct target root. For example:
 // When inserting a block at slot 63 with block root 0xA and target root 0xB (pointing to the block at slot 32),
 // and at slot 64, where the block is skipped, the attestation will reference the target root as 0xA (for slot 63), not 0xB (for slot 32).
 // This implies that if the input slot exceeds the block slot, the target root will be the same as the block root.
-func (f *ForkChoice) TargetRootForSlot(root [32]byte, slot primitives.Slot) ([32]byte, error) {
+func (f *ForkChoice) TargetRootForEpoch(root [32]byte, epoch primitives.Epoch) ([32]byte, error) {
 	n, ok := f.store.nodeByRoot[root]
 	if !ok || n == nil {
 		return [32]byte{}, ErrNilNode
 	}
+	if epoch > slots.ToEpoch(n.slot) {
+		return n.root, nil
+	}
 	if n.target == nil {
 		return [32]byte{}, nil
-	}
-	if slot >= n.slot {
-		return n.root, nil
 	}
 	return n.target.root, nil
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -638,19 +638,11 @@ func (f *ForkChoice) Slot(root [32]byte) (primitives.Slot, error) {
 	return n.slot, nil
 }
 
-// TargetRoot returns the root of the checkpoint block for the given head root
-func (f *ForkChoice) TargetRoot(root [32]byte) ([32]byte, error) {
-	n, ok := f.store.nodeByRoot[root]
-	if !ok || n == nil {
-		return [32]byte{}, ErrNilNode
-	}
-	if n.target == nil {
-		return [32]byte{}, nil
-	}
-	return n.target.root, nil
-}
-
-// TargetRootForSlot returns the root of the checkpoint block for the given slot.
+// TargetRootForSlot returns the root of the target block for a given slot.
+// The slot parameter is crucial to identify the correct target root. For example:
+// When inserting a block at slot 63 with block root 0xA and target root 0xB (pointing to the block at slot 32),
+// and at slot 64, where the block is skipped, the attestation will reference the target root as 0xA (for slot 63), not 0xB (for slot 32).
+// This implies that if the input slot exceeds the block slot, the target root will be the same as the block root.
 func (f *ForkChoice) TargetRootForSlot(root [32]byte, slot primitives.Slot) ([32]byte, error) {
 	n, ok := f.store.nodeByRoot[root]
 	if !ok || n == nil {

--- a/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/forkchoice.go
@@ -649,3 +649,18 @@ func (f *ForkChoice) TargetRoot(root [32]byte) ([32]byte, error) {
 	}
 	return n.target.root, nil
 }
+
+// TargetRootForSlot returns the root of the checkpoint block for the given slot.
+func (f *ForkChoice) TargetRootForSlot(root [32]byte, slot primitives.Slot) ([32]byte, error) {
+	n, ok := f.store.nodeByRoot[root]
+	if !ok || n == nil {
+		return [32]byte{}, ErrNilNode
+	}
+	if n.target == nil {
+		return [32]byte{}, nil
+	}
+	if slot >= n.slot {
+		return n.root, nil
+	}
+	return n.target.root, nil
+}

--- a/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
@@ -436,21 +436,21 @@ func TestForkChoice_ReceivedBlocksLastEpoch(t *testing.T) {
 	require.Equal(t, uint64(0), count)
 }
 
-func TestStore_Target(t *testing.T) {
+func TestStore_TargetRootBySlot(t *testing.T) {
 	ctx := context.Background()
 	f := setup(1, 1)
 
 	state, blkRoot, err := prepareForkchoiceState(ctx, params.BeaconConfig().SlotsPerEpoch, [32]byte{'a'}, params.BeaconConfig().ZeroHash, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, blkRoot))
-	target, err := f.TargetRoot(blkRoot)
+	target, err := f.TargetRootForSlot(blkRoot, 0)
 	require.NoError(t, err)
 	require.Equal(t, target, blkRoot)
 
 	state, root1, err := prepareForkchoiceState(ctx, params.BeaconConfig().SlotsPerEpoch+1, [32]byte{'b'}, blkRoot, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, root1))
-	target, err = f.TargetRoot(root1)
+	target, err = f.TargetRootForSlot(root1, 0)
 	require.NoError(t, err)
 	require.Equal(t, target, blkRoot)
 
@@ -459,14 +459,14 @@ func TestStore_Target(t *testing.T) {
 	state, root2, err := prepareForkchoiceState(ctx, 2*params.BeaconConfig().SlotsPerEpoch+1, [32]byte{'c'}, root1, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, root2))
-	target, err = f.TargetRoot(root2)
+	target, err = f.TargetRootForSlot(root2, 0)
 	require.NoError(t, err)
 	require.Equal(t, target, root1)
 
 	state, root3, err := prepareForkchoiceState(ctx, 2*params.BeaconConfig().SlotsPerEpoch+2, [32]byte{'d'}, root2, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, root3))
-	target, err = f.TargetRoot(root2)
+	target, err = f.TargetRootForSlot(root2, 0)
 	require.NoError(t, err)
 	require.Equal(t, target, root1)
 
@@ -474,7 +474,7 @@ func TestStore_Target(t *testing.T) {
 	s := f.store
 	s.finalizedCheckpoint.Root = root1
 	require.NoError(t, s.prune(ctx))
-	target, err = f.TargetRoot(root1)
+	target, err = f.TargetRootForSlot(root1, 0)
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{}, target)
 
@@ -483,21 +483,29 @@ func TestStore_Target(t *testing.T) {
 	state, root4, err := prepareForkchoiceState(ctx, 3*params.BeaconConfig().SlotsPerEpoch, [32]byte{'e'}, root1, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, root4))
-	target, err = f.TargetRoot(root4)
+	target, err = f.TargetRootForSlot(root4, 0)
 	require.NoError(t, err)
 	require.Equal(t, target, root4)
 
 	state, root5, err := prepareForkchoiceState(ctx, 3*params.BeaconConfig().SlotsPerEpoch+1, [32]byte{'f'}, root4, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, root5))
-	target, err = f.TargetRoot(root5)
+	target, err = f.TargetRootForSlot(root5, 0)
 	require.NoError(t, err)
 	require.Equal(t, target, root4)
+
+	// Target root where the target epoch is same or ahead of the block slot
+	target, err = f.TargetRootForSlot(root5, 3*params.BeaconConfig().SlotsPerEpoch+1)
+	require.NoError(t, err)
+	require.Equal(t, target, root5)
+	target, err = f.TargetRootForSlot(root5, 4*params.BeaconConfig().SlotsPerEpoch)
+	require.NoError(t, err)
+	require.Equal(t, target, root5)
 
 	// Prune finalization
 	s.finalizedCheckpoint.Root = root4
 	require.NoError(t, s.prune(ctx))
-	target, err = f.TargetRoot(root4)
+	target, err = f.TargetRootForSlot(root4, 0)
 	require.NoError(t, err)
 	require.Equal(t, root4, target)
 }

--- a/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
+++ b/beacon-chain/forkchoice/doubly-linked-tree/store_test.go
@@ -436,21 +436,21 @@ func TestForkChoice_ReceivedBlocksLastEpoch(t *testing.T) {
 	require.Equal(t, uint64(0), count)
 }
 
-func TestStore_TargetRootBySlot(t *testing.T) {
+func TestStore_TargetRootForEpoch(t *testing.T) {
 	ctx := context.Background()
 	f := setup(1, 1)
 
 	state, blkRoot, err := prepareForkchoiceState(ctx, params.BeaconConfig().SlotsPerEpoch, [32]byte{'a'}, params.BeaconConfig().ZeroHash, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, blkRoot))
-	target, err := f.TargetRootForSlot(blkRoot, 0)
+	target, err := f.TargetRootForEpoch(blkRoot, 1)
 	require.NoError(t, err)
 	require.Equal(t, target, blkRoot)
 
 	state, root1, err := prepareForkchoiceState(ctx, params.BeaconConfig().SlotsPerEpoch+1, [32]byte{'b'}, blkRoot, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, root1))
-	target, err = f.TargetRootForSlot(root1, 0)
+	target, err = f.TargetRootForEpoch(root1, 1)
 	require.NoError(t, err)
 	require.Equal(t, target, blkRoot)
 
@@ -459,14 +459,14 @@ func TestStore_TargetRootBySlot(t *testing.T) {
 	state, root2, err := prepareForkchoiceState(ctx, 2*params.BeaconConfig().SlotsPerEpoch+1, [32]byte{'c'}, root1, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, root2))
-	target, err = f.TargetRootForSlot(root2, 0)
+	target, err = f.TargetRootForEpoch(root2, 2)
 	require.NoError(t, err)
 	require.Equal(t, target, root1)
 
 	state, root3, err := prepareForkchoiceState(ctx, 2*params.BeaconConfig().SlotsPerEpoch+2, [32]byte{'d'}, root2, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, root3))
-	target, err = f.TargetRootForSlot(root2, 0)
+	target, err = f.TargetRootForEpoch(root2, 2)
 	require.NoError(t, err)
 	require.Equal(t, target, root1)
 
@@ -474,7 +474,7 @@ func TestStore_TargetRootBySlot(t *testing.T) {
 	s := f.store
 	s.finalizedCheckpoint.Root = root1
 	require.NoError(t, s.prune(ctx))
-	target, err = f.TargetRootForSlot(root1, 0)
+	target, err = f.TargetRootForEpoch(root1, 1)
 	require.NoError(t, err)
 	require.Equal(t, [32]byte{}, target)
 
@@ -483,29 +483,26 @@ func TestStore_TargetRootBySlot(t *testing.T) {
 	state, root4, err := prepareForkchoiceState(ctx, 3*params.BeaconConfig().SlotsPerEpoch, [32]byte{'e'}, root1, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, root4))
-	target, err = f.TargetRootForSlot(root4, 0)
+	target, err = f.TargetRootForEpoch(root4, 3)
 	require.NoError(t, err)
 	require.Equal(t, target, root4)
 
 	state, root5, err := prepareForkchoiceState(ctx, 3*params.BeaconConfig().SlotsPerEpoch+1, [32]byte{'f'}, root4, params.BeaconConfig().ZeroHash, 1, 1)
 	require.NoError(t, err)
 	require.NoError(t, f.InsertNode(ctx, state, root5))
-	target, err = f.TargetRootForSlot(root5, 0)
+	target, err = f.TargetRootForEpoch(root5, 3)
 	require.NoError(t, err)
 	require.Equal(t, target, root4)
 
 	// Target root where the target epoch is same or ahead of the block slot
-	target, err = f.TargetRootForSlot(root5, 3*params.BeaconConfig().SlotsPerEpoch+1)
-	require.NoError(t, err)
-	require.Equal(t, target, root5)
-	target, err = f.TargetRootForSlot(root5, 4*params.BeaconConfig().SlotsPerEpoch)
+	target, err = f.TargetRootForEpoch(root5, 4)
 	require.NoError(t, err)
 	require.Equal(t, target, root5)
 
 	// Prune finalization
 	s.finalizedCheckpoint.Root = root4
 	require.NoError(t, s.prune(ctx))
-	target, err = f.TargetRootForSlot(root4, 0)
+	target, err = f.TargetRootForEpoch(root4, 3)
 	require.NoError(t, err)
 	require.Equal(t, root4, target)
 }

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -69,7 +69,6 @@ type Getter interface {
 	ShouldOverrideFCU() bool
 	Slot([32]byte) (primitives.Slot, error)
 	LastRoot(primitives.Epoch) [32]byte
-	TargetRoot([32]byte) ([32]byte, error)
 	TargetRootForSlot([32]byte, primitives.Slot) ([32]byte, error)
 }
 

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -70,6 +70,7 @@ type Getter interface {
 	Slot([32]byte) (primitives.Slot, error)
 	LastRoot(primitives.Epoch) [32]byte
 	TargetRoot([32]byte) ([32]byte, error)
+	TargetRootForSlot([32]byte, primitives.Slot) ([32]byte, error)
 }
 
 // Setter allows to set forkchoice information

--- a/beacon-chain/forkchoice/interfaces.go
+++ b/beacon-chain/forkchoice/interfaces.go
@@ -69,7 +69,7 @@ type Getter interface {
 	ShouldOverrideFCU() bool
 	Slot([32]byte) (primitives.Slot, error)
 	LastRoot(primitives.Epoch) [32]byte
-	TargetRootForSlot([32]byte, primitives.Slot) ([32]byte, error)
+	TargetRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 }
 
 // Setter allows to set forkchoice information


### PR DESCRIPTION
Same idea as #13257 but by adding a new helper `TargetRootForSlot`. This makes `VerifyLmdFfgConsistency` cleaner and can be used for the attester server 