### PR TITLE
Implement EIP-3076 minimal slashing protection database

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -244,8 +244,8 @@ filegroup(
     visibility = ["//visibility:public"],
 )
     """,
-    sha256 = "516d551cfb3e50e4ac2f42db0992f4ceb573a7cb1616d727a725c8161485329f",
-    url = "https://github.com/eth-clients/slashing-protection-interchange-tests/archive/refs/tags/v5.3.0.tar.gz",
+    sha256 = "0626b5e0969fb434135c15cb0843eaebe0475dcdf2736a2a7814bdc69c330cb2",
+    url = "https://nalepa-public.s3.eu-west-1.amazonaws.com/slashing-protection-interchange-tests-manu-3.tar.gz",
 )
 
 http_archive(

--- a/cmd/validator/slashing-protection/import_export_test.go
+++ b/cmd/validator/slashing-protection/import_export_test.go
@@ -59,7 +59,7 @@ func TestImportExportSlashingProtectionCli_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 
 	// We create a CLI context with the required values, such as the database datadir and output directory.
-	validatorDB := dbTest.SetupDB(t, pubKeys)
+	validatorDB := dbTest.SetupDB(t, &kv.Config{PubKeys: pubKeys})
 	dbPath := validatorDB.DatabasePath()
 	require.NoError(t, validatorDB.Close())
 	cliCtx := setupCliCtx(t, dbPath, protectionFilePath, outputPath)
@@ -135,7 +135,7 @@ func TestImportExportSlashingProtectionCli_EmptyData(t *testing.T) {
 	require.NoError(t, err)
 
 	// We create a CLI context with the required values, such as the database datadir and output directory.
-	validatorDB := dbTest.SetupDB(t, pubKeys)
+	validatorDB := dbTest.SetupDB(t, &kv.Config{PubKeys: pubKeys})
 	dbPath := validatorDB.DatabasePath()
 	require.NoError(t, validatorDB.Close())
 	cliCtx := setupCliCtx(t, dbPath, protectionFilePath, outputPath)

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -55,8 +55,9 @@ type Flags struct {
 	// Bug fixes related flags.
 	AttestTimely bool // AttestTimely fixes #8185. It is gated behind a flag to ensure beacon node's fix can safely roll out first. We'll invert this in v1.1.0.
 
-	EnableSlasher                   bool // Enable slasher in the beacon node runtime.
-	EnableSlashingProtectionPruning bool // EnableSlashingProtectionPruning for the validator client.
+	EnableSlasher                           bool // Enable slasher in the beacon node runtime.
+	EnableSlashingProtectionPruning         bool // EnableSlashingProtectionPruning for the validator client.
+	EnableMinimalSlashingProtectionDatabase bool // Enable minimal slashing protection database for the validator client.
 
 	SaveFullExecutionPayloads bool // Save full beacon blocks with execution payloads in the database.
 	EnableStartOptimistic     bool // EnableStartOptimistic treats every block as optimistic at startup.
@@ -279,6 +280,10 @@ func ConfigureValidator(ctx *cli.Context) error {
 	if ctx.Bool(enableSlashingProtectionPruning.Name) {
 		logEnabled(enableSlashingProtectionPruning)
 		cfg.EnableSlashingProtectionPruning = true
+	}
+	if ctx.Bool(enableMinimalSlashingProtectionDatabase.Name) {
+		logEnabled(enableMinimalSlashingProtectionDatabase)
+		cfg.EnableMinimalSlashingProtectionDatabase = true
 	}
 	if ctx.Bool(enableDoppelGangerProtection.Name) {
 		logEnabled(enableDoppelGangerProtection)

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -56,7 +56,7 @@ type Flags struct {
 	AttestTimely bool // AttestTimely fixes #8185. It is gated behind a flag to ensure beacon node's fix can safely roll out first. We'll invert this in v1.1.0.
 
 	EnableSlasher                           bool // Enable slasher in the beacon node runtime.
-	EnableSlashingProtectionPruning         bool // EnableSlashingProtectionPruning for the validator client.
+	EnableSlashingProtectionPruning         bool // Enable slashing protection pruning for the validator client.
 	EnableMinimalSlashingProtectionDatabase bool // Enable minimal slashing protection database for the validator client.
 
 	SaveFullExecutionPayloads bool // Save full beacon blocks with execution payloads in the database.

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -98,6 +98,10 @@ var (
 		Name:  "enable-slashing-protection-history-pruning",
 		Usage: "Enables the pruning of the validator client's slashing protection database",
 	}
+	enableMinimalSlashingProtectionDatabase = &cli.BoolFlag{
+		Name:  "enable-minimal-slashing-protection-database",
+		Usage: "Enables the minimal slashing protection database. See EIP-3076 for more details.",
+	}
 	enableDoppelGangerProtection = &cli.BoolFlag{
 		Name: "enable-doppelganger",
 		Usage: "Enables the validator to perform a doppelganger check. (Warning): This is not " +
@@ -182,6 +186,7 @@ var ValidatorFlags = append(deprecatedFlags, []cli.Flag{
 	dynamicKeyReloadDebounceInterval,
 	attestTimely,
 	enableSlashingProtectionPruning,
+	enableMinimalSlashingProtectionDatabase,
 	enableDoppelGangerProtection,
 	EnableBeaconRESTApi,
 }...)

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -97,7 +97,7 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "aggregate_test.go",
         "attest_protect_test.go",

--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -150,6 +150,7 @@ go_test(
         "//validator/accounts/wallet:go_default_library",
         "//validator/client/iface:go_default_library",
         "//validator/client/testutil:go_default_library",
+        "//validator/db/kv:go_default_library",
         "//validator/db/testing:go_default_library",
         "//validator/graffiti:go_default_library",
         "//validator/keymanager:go_default_library",

--- a/validator/client/aggregate_test.go
+++ b/validator/client/aggregate_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestSubmitAggregateAndProof_GetDutiesRequestFailure(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, _, validatorKey, finish := setup(t)
+	validator, _, validatorKey, finish := setup(t, nil)
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{}}
 	defer finish()
 
@@ -34,7 +34,7 @@ func TestSubmitAggregateAndProof_GetDutiesRequestFailure(t *testing.T) {
 }
 
 func TestSubmitAggregateAndProof_SignFails(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	var pubKey [fieldparams.BLSPubkeyLength]byte
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -73,7 +73,7 @@ func TestSubmitAggregateAndProof_SignFails(t *testing.T) {
 }
 
 func TestSubmitAggregateAndProof_Ok(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	var pubKey [fieldparams.BLSPubkeyLength]byte
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -117,7 +117,7 @@ func TestSubmitAggregateAndProof_Ok(t *testing.T) {
 }
 
 func TestWaitForSlotTwoThird_WaitCorrectly(t *testing.T) {
-	validator, _, _, finish := setup(t)
+	validator, _, _, finish := setup(t, nil)
 	defer finish()
 	currentTime := time.Now()
 	numOfSlots := primitives.Slot(4)
@@ -132,7 +132,7 @@ func TestWaitForSlotTwoThird_WaitCorrectly(t *testing.T) {
 }
 
 func TestWaitForSlotTwoThird_DoneContext_ReturnsImmediately(t *testing.T) {
-	validator, _, _, finish := setup(t)
+	validator, _, _, finish := setup(t, nil)
 	defer finish()
 	currentTime := time.Now()
 	numOfSlots := primitives.Slot(4)
@@ -147,7 +147,7 @@ func TestWaitForSlotTwoThird_DoneContext_ReturnsImmediately(t *testing.T) {
 }
 
 func TestAggregateAndProofSignature_CanSignValidSignature(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	var pubKey [fieldparams.BLSPubkeyLength]byte

--- a/validator/client/attest_protect.go
+++ b/validator/client/attest_protect.go
@@ -49,14 +49,15 @@ func (v *validator) slashableAttestationCheck(
 	signingRootsDiffer := slashings.SigningRootsDiffer(existingSigningRoot, signingRoot)
 
 	// Based on EIP3076, validator should refuse to sign any attestation with target epoch less
-	// than or equal to the minimum target epoch present in that signer’s attestations.
+	// than or equal to the minimum target epoch present in that signer’s attestations, except
+	// if it is a repeat signing as determined by the signingRoot.
 	lowestTargetEpoch, exists, err := v.db.LowestSignedTargetEpoch(ctx, pubKey)
 	if err != nil {
 		return err
 	}
 	if signingRootsDiffer && exists && indexedAtt.Data.Target.Epoch <= lowestTargetEpoch {
 		return fmt.Errorf(
-			"could not sign attestation lower than or equal to lowest target epoch in db, %d <= %d",
+			"could not sign attestation lower than or equal to lowest target epoch in db if signing roots differ, %d <= %d",
 			indexedAtt.Data.Target.Epoch,
 			lowestTargetEpoch,
 		)

--- a/validator/client/attest_protect_test.go
+++ b/validator/client/attest_protect_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_slashableAttestationCheck(t *testing.T) {
-	validator, _, validatorKey, finish := setup(t)
+	validator, _, validatorKey, finish := setup(t, nil)
 	defer finish()
 	var pubKey [fieldparams.BLSPubkeyLength]byte
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -39,7 +39,7 @@ func Test_slashableAttestationCheck(t *testing.T) {
 }
 
 func Test_slashableAttestationCheck_UpdatesLowestSignedEpochs(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	ctx := context.Background()
 	var pubKey [fieldparams.BLSPubkeyLength]byte
@@ -87,7 +87,7 @@ func Test_slashableAttestationCheck_UpdatesLowestSignedEpochs(t *testing.T) {
 
 func Test_slashableAttestationCheck_OK(t *testing.T) {
 	ctx := context.Background()
-	validator, _, _, finish := setup(t)
+	validator, _, _, finish := setup(t, nil)
 	defer finish()
 	att := &ethpb.IndexedAttestation{
 		AttestingIndices: []uint64{1, 2},
@@ -114,7 +114,7 @@ func Test_slashableAttestationCheck_OK(t *testing.T) {
 
 func Test_slashableAttestationCheck_GenesisEpoch(t *testing.T) {
 	ctx := context.Background()
-	validator, _, _, finish := setup(t)
+	validator, _, _, finish := setup(t, nil)
 	defer finish()
 	att := &ethpb.IndexedAttestation{
 		AttestingIndices: []uint64{1, 2},

--- a/validator/client/attest_protect_test.go
+++ b/validator/client/attest_protect_test.go
@@ -13,135 +13,151 @@ import (
 )
 
 func Test_slashableAttestationCheck(t *testing.T) {
-	validator, _, validatorKey, finish := setup(t, nil)
-	defer finish()
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	att := &ethpb.IndexedAttestation{
-		AttestingIndices: []uint64{1, 2},
-		Data: &ethpb.AttestationData{
-			Slot:            5,
-			CommitteeIndex:  2,
-			BeaconBlockRoot: bytesutil.PadTo([]byte("great block"), 32),
-			Source: &ethpb.Checkpoint{
-				Epoch: 4,
-				Root:  bytesutil.PadTo([]byte("good source"), 32),
-			},
-			Target: &ethpb.Checkpoint{
-				Epoch: 10,
-				Root:  bytesutil.PadTo([]byte("good target"), 32),
-			},
-		},
-	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			validator, _, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			att := &ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{1, 2},
+				Data: &ethpb.AttestationData{
+					Slot:            5,
+					CommitteeIndex:  2,
+					BeaconBlockRoot: bytesutil.PadTo([]byte("great block"), 32),
+					Source: &ethpb.Checkpoint{
+						Epoch: 4,
+						Root:  bytesutil.PadTo([]byte("good source"), 32),
+					},
+					Target: &ethpb.Checkpoint{
+						Epoch: 10,
+						Root:  bytesutil.PadTo([]byte("good target"), 32),
+					},
+				},
+			}
 
-	err := validator.slashableAttestationCheck(context.Background(), att, pubKey, [32]byte{1})
-	require.NoError(t, err, "Expected allowed attestation not to throw error")
+			err := validator.slashableAttestationCheck(context.Background(), att, pubKey, [32]byte{1})
+			require.NoError(t, err, "Expected allowed attestation not to throw error")
+		})
+	}
 }
 
 func Test_slashableAttestationCheck_UpdatesLowestSignedEpochs(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t, nil)
-	defer finish()
-	ctx := context.Background()
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	att := &ethpb.IndexedAttestation{
-		AttestingIndices: []uint64{1, 2},
-		Data: &ethpb.AttestationData{
-			Slot:            5,
-			CommitteeIndex:  2,
-			BeaconBlockRoot: bytesutil.PadTo([]byte("great block"), 32),
-			Source: &ethpb.Checkpoint{
-				Epoch: 4,
-				Root:  bytesutil.PadTo([]byte("good source"), 32),
-			},
-			Target: &ethpb.Checkpoint{
-				Epoch: 10,
-				Root:  bytesutil.PadTo([]byte("good target"), 32),
-			},
-		},
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			validator, m, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			ctx := context.Background()
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			att := &ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{1, 2},
+				Data: &ethpb.AttestationData{
+					Slot:            5,
+					CommitteeIndex:  2,
+					BeaconBlockRoot: bytesutil.PadTo([]byte("great block"), 32),
+					Source: &ethpb.Checkpoint{
+						Epoch: 4,
+						Root:  bytesutil.PadTo([]byte("good source"), 32),
+					},
+					Target: &ethpb.Checkpoint{
+						Epoch: 10,
+						Root:  bytesutil.PadTo([]byte("good target"), 32),
+					},
+				},
+			}
+
+			m.validatorClient.EXPECT().DomainData(
+				gomock.Any(), // ctx
+				&ethpb.DomainRequest{Epoch: 10, Domain: []byte{1, 0, 0, 0}},
+			).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+			_, sr, err := validator.getDomainAndSigningRoot(ctx, att.Data)
+			require.NoError(t, err)
+
+			err = validator.slashableAttestationCheck(context.Background(), att, pubKey, sr)
+			require.NoError(t, err)
+			differentSigningRoot := [32]byte{2}
+
+			err = validator.slashableAttestationCheck(context.Background(), att, pubKey, differentSigningRoot)
+			require.ErrorContains(t, "could not sign attestation", err)
+
+			e, exists, err := validator.db.LowestSignedSourceEpoch(context.Background(), pubKey)
+			require.NoError(t, err)
+			require.Equal(t, true, exists)
+			require.Equal(t, primitives.Epoch(4), e)
+			e, exists, err = validator.db.LowestSignedTargetEpoch(context.Background(), pubKey)
+			require.NoError(t, err)
+			require.Equal(t, true, exists)
+			require.Equal(t, primitives.Epoch(10), e)
+		})
 	}
-
-	m.validatorClient.EXPECT().DomainData(
-		gomock.Any(), // ctx
-		&ethpb.DomainRequest{Epoch: 10, Domain: []byte{1, 0, 0, 0}},
-	).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
-	_, sr, err := validator.getDomainAndSigningRoot(ctx, att.Data)
-	require.NoError(t, err)
-
-	err = validator.slashableAttestationCheck(context.Background(), att, pubKey, sr)
-	require.NoError(t, err)
-	differentSigningRoot := [32]byte{2}
-
-	err = validator.slashableAttestationCheck(context.Background(), att, pubKey, differentSigningRoot)
-	require.ErrorContains(t, "could not sign attestation", err)
-
-	e, exists, err := validator.db.LowestSignedSourceEpoch(context.Background(), pubKey)
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	require.Equal(t, primitives.Epoch(4), e)
-	e, exists, err = validator.db.LowestSignedTargetEpoch(context.Background(), pubKey)
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	require.Equal(t, primitives.Epoch(10), e)
 }
 
 func Test_slashableAttestationCheck_OK(t *testing.T) {
-	ctx := context.Background()
-	validator, _, _, finish := setup(t, nil)
-	defer finish()
-	att := &ethpb.IndexedAttestation{
-		AttestingIndices: []uint64{1, 2},
-		Data: &ethpb.AttestationData{
-			Slot:            5,
-			CommitteeIndex:  2,
-			BeaconBlockRoot: []byte("great block"),
-			Source: &ethpb.Checkpoint{
-				Epoch: 4,
-				Root:  []byte("good source"),
-			},
-			Target: &ethpb.Checkpoint{
-				Epoch: 10,
-				Root:  []byte("good target"),
-			},
-		},
-	}
-	sr := [32]byte{1}
-	fakePubkey := bytesutil.ToBytes48([]byte("test"))
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			validator, _, _, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			att := &ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{1, 2},
+				Data: &ethpb.AttestationData{
+					Slot:            5,
+					CommitteeIndex:  2,
+					BeaconBlockRoot: []byte("great block"),
+					Source: &ethpb.Checkpoint{
+						Epoch: 4,
+						Root:  []byte("good source"),
+					},
+					Target: &ethpb.Checkpoint{
+						Epoch: 10,
+						Root:  []byte("good target"),
+					},
+				},
+			}
+			sr := [32]byte{1}
+			fakePubkey := bytesutil.ToBytes48([]byte("test"))
 
-	err := validator.slashableAttestationCheck(ctx, att, fakePubkey, sr)
-	require.NoError(t, err, "Expected allowed attestation not to throw error")
+			err := validator.slashableAttestationCheck(ctx, att, fakePubkey, sr)
+			require.NoError(t, err, "Expected allowed attestation not to throw error")
+		})
+	}
 }
 
 func Test_slashableAttestationCheck_GenesisEpoch(t *testing.T) {
-	ctx := context.Background()
-	validator, _, _, finish := setup(t, nil)
-	defer finish()
-	att := &ethpb.IndexedAttestation{
-		AttestingIndices: []uint64{1, 2},
-		Data: &ethpb.AttestationData{
-			Slot:            5,
-			CommitteeIndex:  2,
-			BeaconBlockRoot: bytesutil.PadTo([]byte("great block root"), 32),
-			Source: &ethpb.Checkpoint{
-				Epoch: 0,
-				Root:  bytesutil.PadTo([]byte("great root"), 32),
-			},
-			Target: &ethpb.Checkpoint{
-				Epoch: 0,
-				Root:  bytesutil.PadTo([]byte("great root"), 32),
-			},
-		},
-	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			validator, _, _, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			att := &ethpb.IndexedAttestation{
+				AttestingIndices: []uint64{1, 2},
+				Data: &ethpb.AttestationData{
+					Slot:            5,
+					CommitteeIndex:  2,
+					BeaconBlockRoot: bytesutil.PadTo([]byte("great block root"), 32),
+					Source: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  bytesutil.PadTo([]byte("great root"), 32),
+					},
+					Target: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  bytesutil.PadTo([]byte("great root"), 32),
+					},
+				},
+			}
 
-	fakePubkey := bytesutil.ToBytes48([]byte("test"))
-	err := validator.slashableAttestationCheck(ctx, att, fakePubkey, [32]byte{})
-	require.NoError(t, err, "Expected allowed attestation not to throw error")
-	e, exists, err := validator.db.LowestSignedSourceEpoch(context.Background(), fakePubkey)
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	require.Equal(t, primitives.Epoch(0), e)
-	e, exists, err = validator.db.LowestSignedTargetEpoch(context.Background(), fakePubkey)
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	require.Equal(t, primitives.Epoch(0), e)
+			fakePubkey := bytesutil.ToBytes48([]byte("test"))
+			err := validator.slashableAttestationCheck(ctx, att, fakePubkey, [32]byte{})
+			require.NoError(t, err, "Expected allowed attestation not to throw error")
+			e, exists, err := validator.db.LowestSignedSourceEpoch(context.Background(), fakePubkey)
+			require.NoError(t, err)
+			require.Equal(t, true, exists)
+			require.Equal(t, primitives.Epoch(0), e)
+			e, exists, err = validator.db.LowestSignedTargetEpoch(context.Background(), fakePubkey)
+			require.NoError(t, err)
+			require.Equal(t, true, exists)
+			require.Equal(t, primitives.Epoch(0), e)
+		})
+	}
 }

--- a/validator/client/attest_test.go
+++ b/validator/client/attest_test.go
@@ -31,7 +31,7 @@ import (
 
 func TestRequestAttestation_ValidatorDutiesRequestFailure(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, _, validatorKey, finish := setup(t)
+	validator, _, validatorKey, finish := setup(t, nil)
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{}}
 	defer finish()
 
@@ -44,7 +44,7 @@ func TestRequestAttestation_ValidatorDutiesRequestFailure(t *testing.T) {
 func TestAttestToBlockHead_SubmitAttestation_EmptyCommittee(t *testing.T) {
 	hook := logTest.NewGlobal()
 
-	validator, _, validatorKey, finish := setup(t)
+	validator, _, validatorKey, finish := setup(t, nil)
 	defer finish()
 	var pubKey [fieldparams.BLSPubkeyLength]byte
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -62,7 +62,7 @@ func TestAttestToBlockHead_SubmitAttestation_EmptyCommittee(t *testing.T) {
 func TestAttestToBlockHead_SubmitAttestation_RequestFailure(t *testing.T) {
 	hook := logTest.NewGlobal()
 
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
 		{
@@ -95,7 +95,7 @@ func TestAttestToBlockHead_SubmitAttestation_RequestFailure(t *testing.T) {
 }
 
 func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	hook := logTest.NewGlobal()
 	validatorIndex := primitives.ValidatorIndex(7)
@@ -169,7 +169,7 @@ func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
 
 func TestAttestToBlockHead_BlocksDoubleAtt(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	validatorIndex := primitives.ValidatorIndex(7)
 	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
@@ -221,7 +221,7 @@ func TestAttestToBlockHead_BlocksDoubleAtt(t *testing.T) {
 
 func TestAttestToBlockHead_BlocksSurroundAtt(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	validatorIndex := primitives.ValidatorIndex(7)
 	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
@@ -273,7 +273,7 @@ func TestAttestToBlockHead_BlocksSurroundAtt(t *testing.T) {
 
 func TestAttestToBlockHead_BlocksSurroundedAtt(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	validatorIndex := primitives.ValidatorIndex(7)
 	var pubKey [fieldparams.BLSPubkeyLength]byte
@@ -327,7 +327,7 @@ func TestAttestToBlockHead_BlocksSurroundedAtt(t *testing.T) {
 }
 
 func TestAttestToBlockHead_DoesNotAttestBeforeDelay(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	var pubKey [fieldparams.BLSPubkeyLength]byte
@@ -354,7 +354,7 @@ func TestAttestToBlockHead_DoesNotAttestBeforeDelay(t *testing.T) {
 }
 
 func TestAttestToBlockHead_DoesAttestAfterDelay(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	var wg sync.WaitGroup
@@ -399,7 +399,7 @@ func TestAttestToBlockHead_DoesAttestAfterDelay(t *testing.T) {
 }
 
 func TestAttestToBlockHead_CorrectBitfieldLength(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	validatorIndex := primitives.ValidatorIndex(2)
 	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
@@ -440,7 +440,7 @@ func TestAttestToBlockHead_CorrectBitfieldLength(t *testing.T) {
 }
 
 func TestSignAttestation(t *testing.T) {
-	validator, m, _, finish := setup(t)
+	validator, m, _, finish := setup(t, nil)
 	defer finish()
 
 	wantedFork := &ethpb.Fork{

--- a/validator/client/attest_test.go
+++ b/validator/client/attest_test.go
@@ -30,449 +30,493 @@ import (
 )
 
 func TestRequestAttestation_ValidatorDutiesRequestFailure(t *testing.T) {
-	hook := logTest.NewGlobal()
-	validator, _, validatorKey, finish := setup(t, nil)
-	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{}}
-	defer finish()
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
+			validator, _, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{}}
+			defer finish()
 
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	validator.SubmitAttestation(context.Background(), 30, pubKey)
-	require.LogsContain(t, hook, "Could not fetch validator assignment")
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			validator.SubmitAttestation(context.Background(), 30, pubKey)
+			require.LogsContain(t, hook, "Could not fetch validator assignment")
+		})
+	}
 }
 
 func TestAttestToBlockHead_SubmitAttestation_EmptyCommittee(t *testing.T) {
-	hook := logTest.NewGlobal()
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
 
-	validator, _, validatorKey, finish := setup(t, nil)
-	defer finish()
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
-		{
-			PublicKey:      validatorKey.PublicKey().Marshal(),
-			CommitteeIndex: 0,
-			Committee:      make([]primitives.ValidatorIndex, 0),
-			ValidatorIndex: 0,
-		}}}
-	validator.SubmitAttestation(context.Background(), 0, pubKey)
-	require.LogsContain(t, hook, "Empty committee")
+			validator, _, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
+				{
+					PublicKey:      validatorKey.PublicKey().Marshal(),
+					CommitteeIndex: 0,
+					Committee:      make([]primitives.ValidatorIndex, 0),
+					ValidatorIndex: 0,
+				}}}
+			validator.SubmitAttestation(context.Background(), 0, pubKey)
+			require.LogsContain(t, hook, "Empty committee")
+		})
+	}
 }
 
 func TestAttestToBlockHead_SubmitAttestation_RequestFailure(t *testing.T) {
-	hook := logTest.NewGlobal()
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
 
-	validator, m, validatorKey, finish := setup(t, nil)
-	defer finish()
-	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
-		{
-			PublicKey:      validatorKey.PublicKey().Marshal(),
-			CommitteeIndex: 5,
-			Committee:      make([]primitives.ValidatorIndex, 111),
-			ValidatorIndex: 0,
-		}}}
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Return(&ethpb.AttestationData{
-		BeaconBlockRoot: make([]byte, fieldparams.RootLength),
-		Target:          &ethpb.Checkpoint{Root: make([]byte, fieldparams.RootLength)},
-		Source:          &ethpb.Checkpoint{Root: make([]byte, fieldparams.RootLength)},
-	}, nil)
-	m.validatorClient.EXPECT().DomainData(
-		gomock.Any(), // ctx
-		gomock.Any(), // epoch2
-	).Times(2).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
-	m.validatorClient.EXPECT().ProposeAttestation(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.Attestation{}),
-	).Return(nil, errors.New("something went wrong"))
+			validator, m, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
+				{
+					PublicKey:      validatorKey.PublicKey().Marshal(),
+					CommitteeIndex: 5,
+					Committee:      make([]primitives.ValidatorIndex, 111),
+					ValidatorIndex: 0,
+				}}}
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Return(&ethpb.AttestationData{
+				BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+				Target:          &ethpb.Checkpoint{Root: make([]byte, fieldparams.RootLength)},
+				Source:          &ethpb.Checkpoint{Root: make([]byte, fieldparams.RootLength)},
+			}, nil)
+			m.validatorClient.EXPECT().DomainData(
+				gomock.Any(), // ctx
+				gomock.Any(), // epoch2
+			).Times(2).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+			m.validatorClient.EXPECT().ProposeAttestation(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.Attestation{}),
+			).Return(nil, errors.New("something went wrong"))
 
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	validator.SubmitAttestation(context.Background(), 30, pubKey)
-	require.LogsContain(t, hook, "Could not submit attestation to beacon node")
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			validator.SubmitAttestation(context.Background(), 30, pubKey)
+			require.LogsContain(t, hook, "Could not submit attestation to beacon node")
+		})
+	}
 }
 
 func TestAttestToBlockHead_AttestsCorrectly(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t, nil)
-	defer finish()
-	hook := logTest.NewGlobal()
-	validatorIndex := primitives.ValidatorIndex(7)
-	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
-		{
-			PublicKey:      validatorKey.PublicKey().Marshal(),
-			CommitteeIndex: 5,
-			Committee:      committee,
-			ValidatorIndex: validatorIndex,
-		},
-	}}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			validator, m, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			hook := logTest.NewGlobal()
+			validatorIndex := primitives.ValidatorIndex(7)
+			committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
+				{
+					PublicKey:      validatorKey.PublicKey().Marshal(),
+					CommitteeIndex: 5,
+					Committee:      committee,
+					ValidatorIndex: validatorIndex,
+				},
+			}}
 
-	beaconBlockRoot := bytesutil.ToBytes32([]byte("A"))
-	targetRoot := bytesutil.ToBytes32([]byte("B"))
-	sourceRoot := bytesutil.ToBytes32([]byte("C"))
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Return(&ethpb.AttestationData{
-		BeaconBlockRoot: beaconBlockRoot[:],
-		Target:          &ethpb.Checkpoint{Root: targetRoot[:]},
-		Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 3},
-	}, nil)
+			beaconBlockRoot := bytesutil.ToBytes32([]byte("A"))
+			targetRoot := bytesutil.ToBytes32([]byte("B"))
+			sourceRoot := bytesutil.ToBytes32([]byte("C"))
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Return(&ethpb.AttestationData{
+				BeaconBlockRoot: beaconBlockRoot[:],
+				Target:          &ethpb.Checkpoint{Root: targetRoot[:]},
+				Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 3},
+			}, nil)
 
-	m.validatorClient.EXPECT().DomainData(
-		gomock.Any(), // ctx
-		gomock.Any(), // epoch
-	).Times(2).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+			m.validatorClient.EXPECT().DomainData(
+				gomock.Any(), // ctx
+				gomock.Any(), // epoch
+			).Times(2).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
 
-	var generatedAttestation *ethpb.Attestation
-	m.validatorClient.EXPECT().ProposeAttestation(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.Attestation{}),
-	).Do(func(_ context.Context, att *ethpb.Attestation) {
-		generatedAttestation = att
-	}).Return(&ethpb.AttestResponse{}, nil /* error */)
+			var generatedAttestation *ethpb.Attestation
+			m.validatorClient.EXPECT().ProposeAttestation(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.Attestation{}),
+			).Do(func(_ context.Context, att *ethpb.Attestation) {
+				generatedAttestation = att
+			}).Return(&ethpb.AttestResponse{}, nil /* error */)
 
-	validator.SubmitAttestation(context.Background(), 30, pubKey)
+			validator.SubmitAttestation(context.Background(), 30, pubKey)
 
-	aggregationBitfield := bitfield.NewBitlist(uint64(len(committee)))
-	aggregationBitfield.SetBitAt(4, true)
-	expectedAttestation := &ethpb.Attestation{
-		Data: &ethpb.AttestationData{
-			BeaconBlockRoot: beaconBlockRoot[:],
-			Target:          &ethpb.Checkpoint{Root: targetRoot[:]},
-			Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 3},
-		},
-		AggregationBits: aggregationBitfield,
-		Signature:       make([]byte, 96),
+			aggregationBitfield := bitfield.NewBitlist(uint64(len(committee)))
+			aggregationBitfield.SetBitAt(4, true)
+			expectedAttestation := &ethpb.Attestation{
+				Data: &ethpb.AttestationData{
+					BeaconBlockRoot: beaconBlockRoot[:],
+					Target:          &ethpb.Checkpoint{Root: targetRoot[:]},
+					Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 3},
+				},
+				AggregationBits: aggregationBitfield,
+				Signature:       make([]byte, 96),
+			}
+
+			root, err := signing.ComputeSigningRoot(expectedAttestation.Data, make([]byte, 32))
+			require.NoError(t, err)
+
+			sig, err := validator.keyManager.Sign(context.Background(), &validatorpb.SignRequest{
+				PublicKey:   validatorKey.PublicKey().Marshal(),
+				SigningRoot: root[:],
+			})
+			require.NoError(t, err)
+			expectedAttestation.Signature = sig.Marshal()
+			if !reflect.DeepEqual(generatedAttestation, expectedAttestation) {
+				t.Errorf("Incorrectly attested head, wanted %v, received %v", expectedAttestation, generatedAttestation)
+				diff, _ := messagediff.PrettyDiff(expectedAttestation, generatedAttestation)
+				t.Log(diff)
+			}
+			require.LogsDoNotContain(t, hook, "Could not")
+		})
 	}
-
-	root, err := signing.ComputeSigningRoot(expectedAttestation.Data, make([]byte, 32))
-	require.NoError(t, err)
-
-	sig, err := validator.keyManager.Sign(context.Background(), &validatorpb.SignRequest{
-		PublicKey:   validatorKey.PublicKey().Marshal(),
-		SigningRoot: root[:],
-	})
-	require.NoError(t, err)
-	expectedAttestation.Signature = sig.Marshal()
-	if !reflect.DeepEqual(generatedAttestation, expectedAttestation) {
-		t.Errorf("Incorrectly attested head, wanted %v, received %v", expectedAttestation, generatedAttestation)
-		diff, _ := messagediff.PrettyDiff(expectedAttestation, generatedAttestation)
-		t.Log(diff)
-	}
-	require.LogsDoNotContain(t, hook, "Could not")
 }
 
 func TestAttestToBlockHead_BlocksDoubleAtt(t *testing.T) {
-	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t, nil)
-	defer finish()
-	validatorIndex := primitives.ValidatorIndex(7)
-	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
-		{
-			PublicKey:      validatorKey.PublicKey().Marshal(),
-			CommitteeIndex: 5,
-			Committee:      committee,
-			ValidatorIndex: validatorIndex,
-		},
-	}}
-	beaconBlockRoot := bytesutil.ToBytes32([]byte("A"))
-	targetRoot := bytesutil.ToBytes32([]byte("B"))
-	sourceRoot := bytesutil.ToBytes32([]byte("C"))
-	beaconBlockRoot2 := bytesutil.ToBytes32([]byte("D"))
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
+			validator, m, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			validatorIndex := primitives.ValidatorIndex(7)
+			committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
+				{
+					PublicKey:      validatorKey.PublicKey().Marshal(),
+					CommitteeIndex: 5,
+					Committee:      committee,
+					ValidatorIndex: validatorIndex,
+				},
+			}}
+			beaconBlockRoot := bytesutil.ToBytes32([]byte("A"))
+			targetRoot := bytesutil.ToBytes32([]byte("B"))
+			sourceRoot := bytesutil.ToBytes32([]byte("C"))
+			beaconBlockRoot2 := bytesutil.ToBytes32([]byte("D"))
 
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Return(&ethpb.AttestationData{
-		BeaconBlockRoot: beaconBlockRoot[:],
-		Target:          &ethpb.Checkpoint{Root: targetRoot[:], Epoch: 4},
-		Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 3},
-	}, nil)
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Return(&ethpb.AttestationData{
-		BeaconBlockRoot: beaconBlockRoot2[:],
-		Target:          &ethpb.Checkpoint{Root: targetRoot[:], Epoch: 4},
-		Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 3},
-	}, nil)
-	m.validatorClient.EXPECT().DomainData(
-		gomock.Any(), // ctx
-		gomock.Any(), // epoch
-	).Times(4).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Return(&ethpb.AttestationData{
+				BeaconBlockRoot: beaconBlockRoot[:],
+				Target:          &ethpb.Checkpoint{Root: targetRoot[:], Epoch: 4},
+				Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 3},
+			}, nil)
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Return(&ethpb.AttestationData{
+				BeaconBlockRoot: beaconBlockRoot2[:],
+				Target:          &ethpb.Checkpoint{Root: targetRoot[:], Epoch: 4},
+				Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 3},
+			}, nil)
+			m.validatorClient.EXPECT().DomainData(
+				gomock.Any(), // ctx
+				gomock.Any(), // epoch
+			).Times(4).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
 
-	m.validatorClient.EXPECT().ProposeAttestation(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.Attestation{}),
-	).Return(&ethpb.AttestResponse{AttestationDataRoot: make([]byte, 32)}, nil /* error */)
+			m.validatorClient.EXPECT().ProposeAttestation(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.Attestation{}),
+			).Return(&ethpb.AttestResponse{AttestationDataRoot: make([]byte, 32)}, nil /* error */)
 
-	validator.SubmitAttestation(context.Background(), 30, pubKey)
-	validator.SubmitAttestation(context.Background(), 30, pubKey)
-	require.LogsContain(t, hook, "Failed attestation slashing protection")
+			validator.SubmitAttestation(context.Background(), 30, pubKey)
+			validator.SubmitAttestation(context.Background(), 30, pubKey)
+			require.LogsContain(t, hook, "Failed attestation slashing protection")
+		})
+	}
 }
 
 func TestAttestToBlockHead_BlocksSurroundAtt(t *testing.T) {
-	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t, nil)
-	defer finish()
-	validatorIndex := primitives.ValidatorIndex(7)
-	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
-		{
-			PublicKey:      validatorKey.PublicKey().Marshal(),
-			CommitteeIndex: 5,
-			Committee:      committee,
-			ValidatorIndex: validatorIndex,
-		},
-	}}
-	beaconBlockRoot := bytesutil.ToBytes32([]byte("A"))
-	targetRoot := bytesutil.ToBytes32([]byte("B"))
-	sourceRoot := bytesutil.ToBytes32([]byte("C"))
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
+			validator, m, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			validatorIndex := primitives.ValidatorIndex(7)
+			committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
+				{
+					PublicKey:      validatorKey.PublicKey().Marshal(),
+					CommitteeIndex: 5,
+					Committee:      committee,
+					ValidatorIndex: validatorIndex,
+				},
+			}}
+			beaconBlockRoot := bytesutil.ToBytes32([]byte("A"))
+			targetRoot := bytesutil.ToBytes32([]byte("B"))
+			sourceRoot := bytesutil.ToBytes32([]byte("C"))
 
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Return(&ethpb.AttestationData{
-		BeaconBlockRoot: beaconBlockRoot[:],
-		Target:          &ethpb.Checkpoint{Root: targetRoot[:], Epoch: 2},
-		Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 1},
-	}, nil)
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Return(&ethpb.AttestationData{
-		BeaconBlockRoot: beaconBlockRoot[:],
-		Target:          &ethpb.Checkpoint{Root: targetRoot[:], Epoch: 3},
-		Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 0},
-	}, nil)
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Return(&ethpb.AttestationData{
+				BeaconBlockRoot: beaconBlockRoot[:],
+				Target:          &ethpb.Checkpoint{Root: targetRoot[:], Epoch: 2},
+				Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 1},
+			}, nil)
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Return(&ethpb.AttestationData{
+				BeaconBlockRoot: beaconBlockRoot[:],
+				Target:          &ethpb.Checkpoint{Root: targetRoot[:], Epoch: 3},
+				Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 0},
+			}, nil)
 
-	m.validatorClient.EXPECT().DomainData(
-		gomock.Any(), // ctx
-		gomock.Any(), // epoch
-	).Times(4).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+			m.validatorClient.EXPECT().DomainData(
+				gomock.Any(), // ctx
+				gomock.Any(), // epoch
+			).Times(4).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
 
-	m.validatorClient.EXPECT().ProposeAttestation(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.Attestation{}),
-	).Return(&ethpb.AttestResponse{}, nil /* error */)
+			m.validatorClient.EXPECT().ProposeAttestation(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.Attestation{}),
+			).Return(&ethpb.AttestResponse{}, nil /* error */)
 
-	validator.SubmitAttestation(context.Background(), 30, pubKey)
-	validator.SubmitAttestation(context.Background(), 30, pubKey)
-	require.LogsContain(t, hook, "Failed attestation slashing protection")
+			validator.SubmitAttestation(context.Background(), 30, pubKey)
+			validator.SubmitAttestation(context.Background(), 30, pubKey)
+			require.LogsContain(t, hook, "Failed attestation slashing protection")
+		})
+	}
 }
 
 func TestAttestToBlockHead_BlocksSurroundedAtt(t *testing.T) {
-	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t, nil)
-	defer finish()
-	validatorIndex := primitives.ValidatorIndex(7)
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
-	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
-		{
-			PublicKey:      validatorKey.PublicKey().Marshal(),
-			CommitteeIndex: 5,
-			Committee:      committee,
-			ValidatorIndex: validatorIndex,
-		},
-	}}
-	beaconBlockRoot := bytesutil.ToBytes32([]byte("A"))
-	targetRoot := bytesutil.ToBytes32([]byte("B"))
-	sourceRoot := bytesutil.ToBytes32([]byte("C"))
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
+			validator, m, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			validatorIndex := primitives.ValidatorIndex(7)
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
+			validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
+				{
+					PublicKey:      validatorKey.PublicKey().Marshal(),
+					CommitteeIndex: 5,
+					Committee:      committee,
+					ValidatorIndex: validatorIndex,
+				},
+			}}
+			beaconBlockRoot := bytesutil.ToBytes32([]byte("A"))
+			targetRoot := bytesutil.ToBytes32([]byte("B"))
+			sourceRoot := bytesutil.ToBytes32([]byte("C"))
 
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Return(&ethpb.AttestationData{
-		BeaconBlockRoot: beaconBlockRoot[:],
-		Target:          &ethpb.Checkpoint{Root: targetRoot[:], Epoch: 3},
-		Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 0},
-	}, nil)
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Return(&ethpb.AttestationData{
+				BeaconBlockRoot: beaconBlockRoot[:],
+				Target:          &ethpb.Checkpoint{Root: targetRoot[:], Epoch: 3},
+				Source:          &ethpb.Checkpoint{Root: sourceRoot[:], Epoch: 0},
+			}, nil)
 
-	m.validatorClient.EXPECT().DomainData(
-		gomock.Any(), // ctx
-		gomock.Any(), // epoch
-	).Times(4).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+			m.validatorClient.EXPECT().DomainData(
+				gomock.Any(), // ctx
+				gomock.Any(), // epoch
+			).Times(4).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
 
-	m.validatorClient.EXPECT().ProposeAttestation(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.Attestation{}),
-	).Return(&ethpb.AttestResponse{}, nil /* error */)
+			m.validatorClient.EXPECT().ProposeAttestation(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.Attestation{}),
+			).Return(&ethpb.AttestResponse{}, nil /* error */)
 
-	validator.SubmitAttestation(context.Background(), 30, pubKey)
-	require.LogsDoNotContain(t, hook, failedAttLocalProtectionErr)
+			validator.SubmitAttestation(context.Background(), 30, pubKey)
+			require.LogsDoNotContain(t, hook, failedAttLocalProtectionErr)
 
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Return(&ethpb.AttestationData{
-		BeaconBlockRoot: bytesutil.PadTo([]byte("A"), 32),
-		Target:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("B"), 32), Epoch: 2},
-		Source:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("C"), 32), Epoch: 1},
-	}, nil)
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Return(&ethpb.AttestationData{
+				BeaconBlockRoot: bytesutil.PadTo([]byte("A"), 32),
+				Target:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("B"), 32), Epoch: 2},
+				Source:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("C"), 32), Epoch: 1},
+			}, nil)
 
-	validator.SubmitAttestation(context.Background(), 30, pubKey)
-	require.LogsContain(t, hook, "Failed attestation slashing protection")
+			validator.SubmitAttestation(context.Background(), 30, pubKey)
+			require.LogsContain(t, hook, "Failed attestation slashing protection")
+		})
+	}
 }
 
 func TestAttestToBlockHead_DoesNotAttestBeforeDelay(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t, nil)
-	defer finish()
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			validator, m, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
 
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	validator.genesisTime = uint64(prysmTime.Now().Unix())
-	m.validatorClient.EXPECT().GetDuties(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.DutiesRequest{}),
-	).Times(0)
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			validator.genesisTime = uint64(prysmTime.Now().Unix())
+			m.validatorClient.EXPECT().GetDuties(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.DutiesRequest{}),
+			).Times(0)
 
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Times(0)
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Times(0)
 
-	m.validatorClient.EXPECT().ProposeAttestation(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.Attestation{}),
-	).Return(&ethpb.AttestResponse{}, nil /* error */).Times(0)
+			m.validatorClient.EXPECT().ProposeAttestation(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.Attestation{}),
+			).Return(&ethpb.AttestResponse{}, nil /* error */).Times(0)
 
-	timer := time.NewTimer(1 * time.Second)
-	go validator.SubmitAttestation(context.Background(), 0, pubKey)
-	<-timer.C
+			timer := time.NewTimer(1 * time.Second)
+			go validator.SubmitAttestation(context.Background(), 0, pubKey)
+			<-timer.C
+		})
+	}
 }
 
 func TestAttestToBlockHead_DoesAttestAfterDelay(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t, nil)
-	defer finish()
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			validator, m, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	defer wg.Wait()
+			var wg sync.WaitGroup
+			wg.Add(1)
+			defer wg.Wait()
 
-	validator.genesisTime = uint64(prysmTime.Now().Unix())
-	validatorIndex := primitives.ValidatorIndex(5)
-	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
-		{
-			PublicKey:      validatorKey.PublicKey().Marshal(),
-			CommitteeIndex: 5,
-			Committee:      committee,
-			ValidatorIndex: validatorIndex,
-		}}}
+			validator.genesisTime = uint64(prysmTime.Now().Unix())
+			validatorIndex := primitives.ValidatorIndex(5)
+			committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
+				{
+					PublicKey:      validatorKey.PublicKey().Marshal(),
+					CommitteeIndex: 5,
+					Committee:      committee,
+					ValidatorIndex: validatorIndex,
+				}}}
 
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Return(&ethpb.AttestationData{
-		BeaconBlockRoot: bytesutil.PadTo([]byte("A"), 32),
-		Target:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("B"), 32)},
-		Source:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("C"), 32), Epoch: 3},
-	}, nil).Do(func(arg0, arg1 interface{}) {
-		wg.Done()
-	})
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Return(&ethpb.AttestationData{
+				BeaconBlockRoot: bytesutil.PadTo([]byte("A"), 32),
+				Target:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("B"), 32)},
+				Source:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("C"), 32), Epoch: 3},
+			}, nil).Do(func(arg0, arg1 interface{}) {
+				wg.Done()
+			})
 
-	m.validatorClient.EXPECT().DomainData(
-		gomock.Any(), // ctx
-		gomock.Any(), // epoch
-	).Times(2).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+			m.validatorClient.EXPECT().DomainData(
+				gomock.Any(), // ctx
+				gomock.Any(), // epoch
+			).Times(2).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
 
-	m.validatorClient.EXPECT().ProposeAttestation(
-		gomock.Any(), // ctx
-		gomock.Any(),
-	).Return(&ethpb.AttestResponse{}, nil).Times(1)
+			m.validatorClient.EXPECT().ProposeAttestation(
+				gomock.Any(), // ctx
+				gomock.Any(),
+			).Return(&ethpb.AttestResponse{}, nil).Times(1)
 
-	validator.SubmitAttestation(context.Background(), 0, pubKey)
+			validator.SubmitAttestation(context.Background(), 0, pubKey)
+		})
+	}
 }
 
 func TestAttestToBlockHead_CorrectBitfieldLength(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t, nil)
-	defer finish()
-	validatorIndex := primitives.ValidatorIndex(2)
-	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
-		{
-			PublicKey:      validatorKey.PublicKey().Marshal(),
-			CommitteeIndex: 5,
-			Committee:      committee,
-			ValidatorIndex: validatorIndex,
-		}}}
-	m.validatorClient.EXPECT().GetAttestationData(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
-	).Return(&ethpb.AttestationData{
-		Target:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("B"), 32)},
-		Source:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("C"), 32), Epoch: 3},
-		BeaconBlockRoot: make([]byte, fieldparams.RootLength),
-	}, nil)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			validator, m, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			validatorIndex := primitives.ValidatorIndex(2)
+			committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
+				{
+					PublicKey:      validatorKey.PublicKey().Marshal(),
+					CommitteeIndex: 5,
+					Committee:      committee,
+					ValidatorIndex: validatorIndex,
+				}}}
+			m.validatorClient.EXPECT().GetAttestationData(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.AttestationDataRequest{}),
+			).Return(&ethpb.AttestationData{
+				Target:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("B"), 32)},
+				Source:          &ethpb.Checkpoint{Root: bytesutil.PadTo([]byte("C"), 32), Epoch: 3},
+				BeaconBlockRoot: make([]byte, fieldparams.RootLength),
+			}, nil)
 
-	m.validatorClient.EXPECT().DomainData(
-		gomock.Any(), // ctx
-		gomock.Any(), // epoch
-	).Times(2).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
+			m.validatorClient.EXPECT().DomainData(
+				gomock.Any(), // ctx
+				gomock.Any(), // epoch
+			).Times(2).Return(&ethpb.DomainResponse{SignatureDomain: make([]byte, 32)}, nil /*err*/)
 
-	var generatedAttestation *ethpb.Attestation
-	m.validatorClient.EXPECT().ProposeAttestation(
-		gomock.Any(), // ctx
-		gomock.AssignableToTypeOf(&ethpb.Attestation{}),
-	).Do(func(_ context.Context, att *ethpb.Attestation) {
-		generatedAttestation = att
-	}).Return(&ethpb.AttestResponse{}, nil /* error */)
+			var generatedAttestation *ethpb.Attestation
+			m.validatorClient.EXPECT().ProposeAttestation(
+				gomock.Any(), // ctx
+				gomock.AssignableToTypeOf(&ethpb.Attestation{}),
+			).Do(func(_ context.Context, att *ethpb.Attestation) {
+				generatedAttestation = att
+			}).Return(&ethpb.AttestResponse{}, nil /* error */)
 
-	validator.SubmitAttestation(context.Background(), 30, pubKey)
+			validator.SubmitAttestation(context.Background(), 30, pubKey)
 
-	assert.Equal(t, 2, len(generatedAttestation.AggregationBits))
+			assert.Equal(t, 2, len(generatedAttestation.AggregationBits))
+		})
+	}
 }
 
 func TestSignAttestation(t *testing.T) {
-	validator, m, _, finish := setup(t, nil)
-	defer finish()
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			validator, m, _, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
 
-	wantedFork := &ethpb.Fork{
-		PreviousVersion: []byte{'a', 'b', 'c', 'd'},
-		CurrentVersion:  []byte{'d', 'e', 'f', 'f'},
-		Epoch:           0,
+			wantedFork := &ethpb.Fork{
+				PreviousVersion: []byte{'a', 'b', 'c', 'd'},
+				CurrentVersion:  []byte{'d', 'e', 'f', 'f'},
+				Epoch:           0,
+			}
+			genesisValidatorsRoot := [32]byte{0x01, 0x02}
+			attesterDomain, err := signing.Domain(wantedFork, 0, params.BeaconConfig().DomainBeaconAttester, genesisValidatorsRoot[:])
+			require.NoError(t, err)
+			m.validatorClient.EXPECT().
+				DomainData(gomock.Any(), gomock.Any()).
+				Return(&ethpb.DomainResponse{SignatureDomain: attesterDomain}, nil)
+			ctx := context.Background()
+			att := util.NewAttestation()
+			att.Data.Source.Epoch = 100
+			att.Data.Target.Epoch = 200
+			att.Data.Slot = 999
+			att.Data.BeaconBlockRoot = bytesutil.PadTo([]byte("blockRoot"), 32)
+
+			pk := testKeyFromBytes(t, []byte{1})
+			validator.keyManager = newMockKeymanager(t, pk)
+			sig, sr, err := validator.signAtt(ctx, pk.pub, att.Data, att.Data.Slot)
+			require.NoError(t, err, "%x,%x,%v", sig, sr, err)
+			require.Equal(t, "b6a60f8497bd328908be83634d045"+
+				"dd7a32f5e246b2c4031fc2f316983f362e36fc27fd3d6d5a2b15"+
+				"b4dbff38804ffb10b1719b7ebc54e9cbf3293fd37082bc0fc91f"+
+				"79d70ce5b04ff13de3c8e10bb41305bfdbe921a43792c12624f2"+
+				"25ee865", hex.EncodeToString(sig))
+			// proposer domain
+			require.DeepEqual(t, "02bbdb88056d6cbafd6e94575540"+
+				"e74b8cf2c0f2c1b79b8e17e7b21ed1694305", hex.EncodeToString(sr[:]))
+		})
 	}
-	genesisValidatorsRoot := [32]byte{0x01, 0x02}
-	attesterDomain, err := signing.Domain(wantedFork, 0, params.BeaconConfig().DomainBeaconAttester, genesisValidatorsRoot[:])
-	require.NoError(t, err)
-	m.validatorClient.EXPECT().
-		DomainData(gomock.Any(), gomock.Any()).
-		Return(&ethpb.DomainResponse{SignatureDomain: attesterDomain}, nil)
-	ctx := context.Background()
-	att := util.NewAttestation()
-	att.Data.Source.Epoch = 100
-	att.Data.Target.Epoch = 200
-	att.Data.Slot = 999
-	att.Data.BeaconBlockRoot = bytesutil.PadTo([]byte("blockRoot"), 32)
-
-	pk := testKeyFromBytes(t, []byte{1})
-	validator.keyManager = newMockKeymanager(t, pk)
-	sig, sr, err := validator.signAtt(ctx, pk.pub, att.Data, att.Data.Slot)
-	require.NoError(t, err, "%x,%x,%v", sig, sr, err)
-	require.Equal(t, "b6a60f8497bd328908be83634d045"+
-		"dd7a32f5e246b2c4031fc2f316983f362e36fc27fd3d6d5a2b15"+
-		"b4dbff38804ffb10b1719b7ebc54e9cbf3293fd37082bc0fc91f"+
-		"79d70ce5b04ff13de3c8e10bb41305bfdbe921a43792c12624f2"+
-		"25ee865", hex.EncodeToString(sig))
-	// proposer domain
-	require.DeepEqual(t, "02bbdb88056d6cbafd6e94575540"+
-		"e74b8cf2c0f2c1b79b8e17e7b21ed1694305", hex.EncodeToString(sr[:]))
 }
 
 func TestServer_WaitToSlotOneThird_CanWait(t *testing.T) {

--- a/validator/client/propose_protect.go
+++ b/validator/client/propose_protect.go
@@ -40,7 +40,8 @@ func (v *validator) slashableProposalCheck(
 		// If the block slot is (strictly) less than the lowest signed proposal slot in the DB, we consider it slashable.
 		if blk.Slot() < lowestSignedProposalSlot {
 			return fmt.Errorf(
-				"could not sign block with slot < lowest signed slot in db, block slot: %d < lowest signed slot: %d",
+				"%s - could not sign block with slot < lowest signed slot in db, block slot: %d < lowest signed slot: %d",
+				failedBlockSignLocalErr,
 				blk.Slot(),
 				lowestSignedProposalSlot,
 			)
@@ -56,7 +57,8 @@ func (v *validator) slashableProposalCheck(
 		condition3 := proposalAtSlotExists && prevSigningRootExists && prevSigningRoot != signingRoot
 		if blk.Slot() == lowestSignedProposalSlot && (condition1 || condition2 || condition3) {
 			return fmt.Errorf(
-				"could not sign block with slot == lowest signed slot in db if it is not a repeat signing, block slot: %d == slowest signed slot: %d",
+				"%s - could not sign block with slot == lowest signed slot in db if it is not a repeat signing, block slot: %d == slowest signed slot: %d",
+				failedBlockSignLocalErr,
 				blk.Slot(),
 				lowestSignedProposalSlot,
 			)

--- a/validator/client/propose_protect_test.go
+++ b/validator/client/propose_protect_test.go
@@ -11,145 +11,164 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
 	"github.com/prysmaticlabs/prysm/v4/testing/util"
+	"github.com/prysmaticlabs/prysm/v4/validator/db/kv"
 )
 
 func Test_slashableProposalCheck_PreventsLowerThanMinProposal(t *testing.T) {
-	ctx := context.Background()
-	validator, _, validatorKey, finish := setup(t, nil)
-	defer finish()
-	lowestSignedSlot := primitives.Slot(10)
-	var pubKeyBytes [fieldparams.BLSPubkeyLength]byte
-	copy(pubKeyBytes[:], validatorKey.PublicKey().Marshal())
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			validator, _, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			lowestSignedSlot := primitives.Slot(10)
+			var pubKeyBytes [fieldparams.BLSPubkeyLength]byte
+			copy(pubKeyBytes[:], validatorKey.PublicKey().Marshal())
 
-	// We save a proposal at the lowest signed slot in the DB.
-	err := validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, lowestSignedSlot, []byte{1})
-	require.NoError(t, err)
-	require.NoError(t, err)
+			// We save a proposal at the lowest signed slot in the DB.
+			err := validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, lowestSignedSlot, []byte{1})
+			require.NoError(t, err)
+			require.NoError(t, err)
 
-	// We expect the same block with a slot lower than the lowest
-	// signed slot to fail validation.
-	blk := &ethpb.SignedBeaconBlock{
-		Block: &ethpb.BeaconBlock{
-			Slot:          lowestSignedSlot - 1,
-			ProposerIndex: 0,
-			Body:          &ethpb.BeaconBlockBody{},
-		},
-		Signature: params.BeaconConfig().EmptySignature[:],
+			// We expect the same block with a slot lower than the lowest
+			// signed slot to fail validation.
+			blk := &ethpb.SignedBeaconBlock{
+				Block: &ethpb.BeaconBlock{
+					Slot:          lowestSignedSlot - 1,
+					ProposerIndex: 0,
+					Body:          &ethpb.BeaconBlockBody{},
+				},
+				Signature: params.BeaconConfig().EmptySignature[:],
+			}
+			wsb, err := blocks.NewSignedBeaconBlock(blk)
+			require.NoError(t, err)
+			err = validator.slashableProposalCheck(context.Background(), pubKeyBytes, wsb, [32]byte{4})
+			require.ErrorContains(t, "could not sign block with slot < lowest signed", err)
+
+			// We expect the same block with a slot equal to the lowest
+			// signed slot to pass validation if signing roots are equal.
+			blk = &ethpb.SignedBeaconBlock{
+				Block: &ethpb.BeaconBlock{
+					Slot:          lowestSignedSlot,
+					ProposerIndex: 0,
+					Body:          &ethpb.BeaconBlockBody{},
+				},
+				Signature: params.BeaconConfig().EmptySignature[:],
+			}
+			wsb, err = blocks.NewSignedBeaconBlock(blk)
+			require.NoError(t, err)
+			err = validator.slashableProposalCheck(context.Background(), pubKeyBytes, wsb, [32]byte{1})
+			require.NoError(t, err)
+
+			// We expect the same block with a slot equal to the lowest
+			// signed slot to fail validation if signing roots are different.
+			wsb, err = blocks.NewSignedBeaconBlock(blk)
+			require.NoError(t, err)
+			err = validator.slashableProposalCheck(context.Background(), pubKeyBytes, wsb, [32]byte{4})
+			require.ErrorContains(t, "could not sign block with slot == lowest signed", err)
+
+			// We expect the same block with a slot > than the lowest
+			// signed slot to pass validation.
+			blk = &ethpb.SignedBeaconBlock{
+				Block: &ethpb.BeaconBlock{
+					Slot:          lowestSignedSlot + 1,
+					ProposerIndex: 0,
+					Body:          &ethpb.BeaconBlockBody{},
+				},
+				Signature: params.BeaconConfig().EmptySignature[:],
+			}
+
+			wsb, err = blocks.NewSignedBeaconBlock(blk)
+			require.NoError(t, err)
+			err = validator.slashableProposalCheck(context.Background(), pubKeyBytes, wsb, [32]byte{3})
+			require.NoError(t, err)
+		})
 	}
-	wsb, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	err = validator.slashableProposalCheck(context.Background(), pubKeyBytes, wsb, [32]byte{4})
-	require.ErrorContains(t, "could not sign block with slot < lowest signed", err)
-
-	// We expect the same block with a slot equal to the lowest
-	// signed slot to pass validation if signing roots are equal.
-	blk = &ethpb.SignedBeaconBlock{
-		Block: &ethpb.BeaconBlock{
-			Slot:          lowestSignedSlot,
-			ProposerIndex: 0,
-			Body:          &ethpb.BeaconBlockBody{},
-		},
-		Signature: params.BeaconConfig().EmptySignature[:],
-	}
-	wsb, err = blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	err = validator.slashableProposalCheck(context.Background(), pubKeyBytes, wsb, [32]byte{1})
-	require.NoError(t, err)
-
-	// We expect the same block with a slot equal to the lowest
-	// signed slot to fail validation if signing roots are different.
-	wsb, err = blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	err = validator.slashableProposalCheck(context.Background(), pubKeyBytes, wsb, [32]byte{4})
-	require.ErrorContains(t, "could not sign block with slot == lowest signed", err)
-
-	// We expect the same block with a slot > than the lowest
-	// signed slot to pass validation.
-	blk = &ethpb.SignedBeaconBlock{
-		Block: &ethpb.BeaconBlock{
-			Slot:          lowestSignedSlot + 1,
-			ProposerIndex: 0,
-			Body:          &ethpb.BeaconBlockBody{},
-		},
-		Signature: params.BeaconConfig().EmptySignature[:],
-	}
-
-	wsb, err = blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	err = validator.slashableProposalCheck(context.Background(), pubKeyBytes, wsb, [32]byte{3})
-	require.NoError(t, err)
 }
 
 func Test_slashableProposalCheck(t *testing.T) {
-	ctx := context.Background()
-	validator, _, validatorKey, finish := setup(t, nil)
-	defer finish()
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			validator, _, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
 
-	blk := util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{
-		Block: &ethpb.BeaconBlock{
-			Slot:          10,
-			ProposerIndex: 0,
-			Body:          &ethpb.BeaconBlockBody{},
-		},
-		Signature: params.BeaconConfig().EmptySignature[:],
-	})
+			blk := util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{
+				Block: &ethpb.BeaconBlock{
+					Slot:          10,
+					ProposerIndex: 0,
+					Body:          &ethpb.BeaconBlockBody{},
+				},
+				Signature: params.BeaconConfig().EmptySignature[:],
+			})
 
-	var pubKeyBytes [fieldparams.BLSPubkeyLength]byte
-	copy(pubKeyBytes[:], validatorKey.PublicKey().Marshal())
+			var pubKeyBytes [fieldparams.BLSPubkeyLength]byte
+			copy(pubKeyBytes[:], validatorKey.PublicKey().Marshal())
 
-	// We save a proposal at slot 1 as our lowest proposal.
-	err := validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, 1, []byte{1})
-	require.NoError(t, err)
+			// We save a proposal at slot 1 as our lowest proposal.
+			err := validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, 1, []byte{1})
+			require.NoError(t, err)
 
-	// We save a proposal at slot 10 with a dummy signing root.
-	dummySigningRoot := [32]byte{1}
-	err = validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, 10, dummySigningRoot[:])
-	require.NoError(t, err)
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
-	sBlock, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
+			// We save a proposal at slot 10 with a dummy signing root.
+			dummySigningRoot := [32]byte{1}
+			err = validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, 10, dummySigningRoot[:])
+			require.NoError(t, err)
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
+			sBlock, err := blocks.NewSignedBeaconBlock(blk)
+			require.NoError(t, err)
 
-	// We expect the same block sent out with the same root should not be slasahble.
-	err = validator.slashableProposalCheck(context.Background(), pubKey, sBlock, dummySigningRoot)
-	require.NoError(t, err)
+			// We expect the same block sent out with the same root should not be slasahble.
+			err = validator.slashableProposalCheck(context.Background(), pubKey, sBlock, dummySigningRoot)
+			require.NoError(t, err)
 
-	// We expect the same block sent out with a different signing root should be slasahble.
-	err = validator.slashableProposalCheck(context.Background(), pubKey, sBlock, [32]byte{2})
-	require.ErrorContains(t, failedBlockSignLocalErr, err)
+			// We expect the same block sent out with a different signing root should be slasahble.
+			err = validator.slashableProposalCheck(context.Background(), pubKey, sBlock, [32]byte{2})
+			require.ErrorContains(t, failedBlockSignLocalErr, err)
 
-	// We save a proposal at slot 11 with a nil signing root.
-	blk.Block.Slot = 11
-	sBlock, err = blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	err = validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, blk.Block.Slot, nil)
-	require.NoError(t, err)
+			// We save a proposal at slot 11 with a nil signing root.
+			blk.Block.Slot = 11
+			sBlock, err = blocks.NewSignedBeaconBlock(blk)
+			require.NoError(t, err)
+			err = validator.db.SaveProposalHistoryForSlot(ctx, pubKeyBytes, blk.Block.Slot, nil)
+			require.NoError(t, err)
 
-	// We expect the same block sent out should return slashable error even
-	// if we had a nil signing root stored in the database.
-	err = validator.slashableProposalCheck(context.Background(), pubKey, sBlock, [32]byte{2})
-	require.ErrorContains(t, failedBlockSignLocalErr, err)
+			// We expect the same block sent out should return slashable error even
+			// if we had a nil signing root stored in the database.
+			err = validator.slashableProposalCheck(context.Background(), pubKey, sBlock, [32]byte{2})
+			require.ErrorContains(t, failedBlockSignLocalErr, err)
 
-	// A block with a different slot for which we do not have a proposing history
-	// should not be failing validation.
-	blk.Block.Slot = 9
-	sBlock, err = blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
-	err = validator.slashableProposalCheck(context.Background(), pubKey, sBlock, [32]byte{3})
-	require.NoError(t, err, "Expected allowed block not to throw error")
+			// A block with a lower slot for which we do not have a proposing history
+			// - for complete database: should not be failing validation.
+			// - for minimal database: fail validation.
+			blk.Block.Slot = 9
+			sBlock, err = blocks.NewSignedBeaconBlock(blk)
+			require.NoError(t, err)
+			err = validator.slashableProposalCheck(context.Background(), pubKey, sBlock, [32]byte{3})
+
+			if tt.slashingProtectionType == kv.Complete {
+				require.NoError(t, err, "Expected allowed block not to throw error")
+			} else {
+				require.ErrorContains(t, failedBlockSignLocalErr, err)
+			}
+		})
+	}
 }
 
 func Test_slashableProposalCheck_RemoteProtection(t *testing.T) {
-	validator, _, validatorKey, finish := setup(t, nil)
-	defer finish()
-	var pubKey [fieldparams.BLSPubkeyLength]byte
-	copy(pubKey[:], validatorKey.PublicKey().Marshal())
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			validator, _, validatorKey, finish := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+			defer finish()
+			var pubKey [fieldparams.BLSPubkeyLength]byte
+			copy(pubKey[:], validatorKey.PublicKey().Marshal())
 
-	blk := util.NewBeaconBlock()
-	blk.Block.Slot = 10
-	sBlock, err := blocks.NewSignedBeaconBlock(blk)
-	require.NoError(t, err)
+			blk := util.NewBeaconBlock()
+			blk.Block.Slot = 10
+			sBlock, err := blocks.NewSignedBeaconBlock(blk)
+			require.NoError(t, err)
 
-	err = validator.slashableProposalCheck(context.Background(), pubKey, sBlock, [32]byte{2})
-	require.NoError(t, err, "Expected allowed block not to throw error")
+			err = validator.slashableProposalCheck(context.Background(), pubKey, sBlock, [32]byte{2})
+			require.NoError(t, err, "Expected allowed block not to throw error")
+		})
+	}
 }

--- a/validator/client/propose_protect_test.go
+++ b/validator/client/propose_protect_test.go
@@ -15,7 +15,7 @@ import (
 
 func Test_slashableProposalCheck_PreventsLowerThanMinProposal(t *testing.T) {
 	ctx := context.Background()
-	validator, _, validatorKey, finish := setup(t)
+	validator, _, validatorKey, finish := setup(t, nil)
 	defer finish()
 	lowestSignedSlot := primitives.Slot(10)
 	var pubKeyBytes [fieldparams.BLSPubkeyLength]byte
@@ -82,7 +82,7 @@ func Test_slashableProposalCheck_PreventsLowerThanMinProposal(t *testing.T) {
 
 func Test_slashableProposalCheck(t *testing.T) {
 	ctx := context.Background()
-	validator, _, validatorKey, finish := setup(t)
+	validator, _, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	blk := util.HydrateSignedBeaconBlock(&ethpb.SignedBeaconBlock{
@@ -140,7 +140,7 @@ func Test_slashableProposalCheck(t *testing.T) {
 }
 
 func Test_slashableProposalCheck_RemoteProtection(t *testing.T) {
-	validator, _, validatorKey, finish := setup(t)
+	validator, _, validatorKey, finish := setup(t, nil)
 	defer finish()
 	var pubKey [fieldparams.BLSPubkeyLength]byte
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -68,10 +68,14 @@ func testKeyFromBytes(t *testing.T, b []byte) keypair {
 	return keypair{pub: bytesutil.ToBytes48(pri.PublicKey().Marshal()), pri: pri}
 }
 
-func setup(t *testing.T) (*validator, *mocks, bls.SecretKey, func()) {
-	validatorKey, err := bls.RandKey()
-	require.NoError(t, err)
-	return setupWithParams(t, setupParams{validatorKey: validatorKey})
+func setup(t *testing.T, p *setupParams) (*validator, *mocks, bls.SecretKey, func()) {
+	if p != nil && p.validatorKey != nil {
+		return setupWithParams(t, *p)
+	} else {
+		validatorKey, err := bls.RandKey()
+		require.NoError(t, err)
+		return setupWithParams(t, setupParams{validatorKey: validatorKey})
+	}
 }
 
 func setupWithParams(t *testing.T, p setupParams) (*validator, *mocks, bls.SecretKey, func()) {
@@ -102,7 +106,7 @@ func setupWithParams(t *testing.T, p setupParams) (*validator, *mocks, bls.Secre
 
 func TestProposeBlock_DoesNotProposeGenesisBlock(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, _, validatorKey, finish := setup(t)
+	validator, _, validatorKey, finish := setup(t, nil)
 	defer finish()
 	var pubKey [fieldparams.BLSPubkeyLength]byte
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -113,7 +117,7 @@ func TestProposeBlock_DoesNotProposeGenesisBlock(t *testing.T) {
 
 func TestProposeBlock_DomainDataFailed(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	var pubKey [fieldparams.BLSPubkeyLength]byte
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -129,7 +133,7 @@ func TestProposeBlock_DomainDataFailed(t *testing.T) {
 
 func TestProposeBlock_DomainDataIsNil(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	var pubKey [fieldparams.BLSPubkeyLength]byte
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -171,7 +175,7 @@ func TestProposeBlock_RequestBlockFailed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hook := logTest.NewGlobal()
-			validator, m, validatorKey, finish := setup(t)
+			validator, m, validatorKey, finish := setup(t, nil)
 			defer finish()
 			var pubKey [fieldparams.BLSPubkeyLength]byte
 			copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -226,7 +230,7 @@ func TestProposeBlock_ProposeBlockFailed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hook := logTest.NewGlobal()
-			validator, m, validatorKey, finish := setup(t)
+			validator, m, validatorKey, finish := setup(t, nil)
 			defer finish()
 			var pubKey [fieldparams.BLSPubkeyLength]byte
 			copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -324,7 +328,7 @@ func TestProposeBlock_BlocksDoubleProposal(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hook := logTest.NewGlobal()
-			validator, m, validatorKey, finish := setup(t)
+			validator, m, validatorKey, finish := setup(t, nil)
 			defer finish()
 			var pubKey [fieldparams.BLSPubkeyLength]byte
 			copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -370,7 +374,7 @@ func TestProposeBlock_BlocksDoubleProposal(t *testing.T) {
 
 func TestProposeBlock_BlocksDoubleProposal_After54KEpochs(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	var pubKey [fieldparams.BLSPubkeyLength]byte
 	copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -446,7 +450,7 @@ func TestProposeBlock_AllowsPastProposals(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hook := logTest.NewGlobal()
-			validator, m, validatorKey, finish := setup(t)
+			validator, m, validatorKey, finish := setup(t, nil)
 			defer finish()
 			var pubKey [fieldparams.BLSPubkeyLength]byte
 			copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -618,7 +622,7 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			hook := logTest.NewGlobal()
-			validator, m, validatorKey, finish := setup(t)
+			validator, m, validatorKey, finish := setup(t, nil)
 			defer finish()
 			var pubKey [fieldparams.BLSPubkeyLength]byte
 			copy(pubKey[:], validatorKey.PublicKey().Marshal())
@@ -666,7 +670,7 @@ func testProposeBlock(t *testing.T, graffiti []byte) {
 }
 
 func TestProposeExit_ValidatorIndexFailed(t *testing.T) {
-	_, m, validatorKey, finish := setup(t)
+	_, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	m.validatorClient.EXPECT().ValidatorIndex(
@@ -687,7 +691,7 @@ func TestProposeExit_ValidatorIndexFailed(t *testing.T) {
 }
 
 func TestProposeExit_DomainDataFailed(t *testing.T) {
-	_, m, validatorKey, finish := setup(t)
+	_, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	m.validatorClient.EXPECT().
@@ -712,7 +716,7 @@ func TestProposeExit_DomainDataFailed(t *testing.T) {
 }
 
 func TestProposeExit_DomainDataIsNil(t *testing.T) {
-	_, m, validatorKey, finish := setup(t)
+	_, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	m.validatorClient.EXPECT().
@@ -736,7 +740,7 @@ func TestProposeExit_DomainDataIsNil(t *testing.T) {
 }
 
 func TestProposeBlock_ProposeExitFailed(t *testing.T) {
-	_, m, validatorKey, finish := setup(t)
+	_, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	m.validatorClient.EXPECT().
@@ -764,7 +768,7 @@ func TestProposeBlock_ProposeExitFailed(t *testing.T) {
 }
 
 func TestProposeExit_BroadcastsBlock(t *testing.T) {
-	_, m, validatorKey, finish := setup(t)
+	_, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	m.validatorClient.EXPECT().
@@ -789,7 +793,7 @@ func TestProposeExit_BroadcastsBlock(t *testing.T) {
 }
 
 func TestSignBlock(t *testing.T) {
-	validator, m, _, finish := setup(t)
+	validator, m, _, finish := setup(t, nil)
 	defer finish()
 
 	proposerDomain := make([]byte, 32)
@@ -823,7 +827,7 @@ func TestSignBlock(t *testing.T) {
 }
 
 func TestSignAltairBlock(t *testing.T) {
-	validator, m, _, finish := setup(t)
+	validator, m, _, finish := setup(t, nil)
 	defer finish()
 
 	kp := testKeyFromBytes(t, []byte{1})
@@ -850,7 +854,7 @@ func TestSignAltairBlock(t *testing.T) {
 }
 
 func TestSignBellatrixBlock(t *testing.T) {
-	validator, m, _, finish := setup(t)
+	validator, m, _, finish := setup(t, nil)
 	defer finish()
 
 	proposerDomain := make([]byte, 32)

--- a/validator/client/propose_test.go
+++ b/validator/client/propose_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
 	"github.com/prysmaticlabs/prysm/v4/testing/util"
 	validatormock "github.com/prysmaticlabs/prysm/v4/testing/validator-mock"
+	"github.com/prysmaticlabs/prysm/v4/validator/db/kv"
 	testing2 "github.com/prysmaticlabs/prysm/v4/validator/db/testing"
 	"github.com/prysmaticlabs/prysm/v4/validator/graffiti"
 	logTest "github.com/sirupsen/logrus/hooks/test"
@@ -76,7 +77,7 @@ func setup(t *testing.T) (*validator, *mocks, bls.SecretKey, func()) {
 func setupWithParams(t *testing.T, p setupParams) (*validator, *mocks, bls.SecretKey, func()) {
 	var pubKey [fieldparams.BLSPubkeyLength]byte
 	copy(pubKey[:], p.validatorKey.PublicKey().Marshal())
-	valDB := testing2.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubKey})
+	valDB := testing2.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{pubKey}})
 	ctrl := gomock.NewController(t)
 	m := &mocks{
 		validatorClient: validatormock.NewMockValidatorClient(ctrl),
@@ -960,7 +961,7 @@ func TestGetGraffiti_Ok(t *testing.T) {
 
 func TestGetGraffitiOrdered_Ok(t *testing.T) {
 	pubKey := [fieldparams.BLSPubkeyLength]byte{'a'}
-	valDB := testing2.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubKey})
+	valDB := testing2.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{pubKey}})
 	ctrl := gomock.NewController(t)
 	m := &mocks{
 		validatorClient: validatormock.NewMockValidatorClient(ctrl),

--- a/validator/client/registration_test.go
+++ b/validator/client/registration_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestSubmitValidatorRegistrations(t *testing.T) {
-	_, m, validatorKey, finish := setup(t)
+	_, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	ctx := context.Background()
@@ -94,7 +94,7 @@ func TestSubmitValidatorRegistrations(t *testing.T) {
 }
 
 func TestSubmitValidatorRegistration_CantSign(t *testing.T) {
-	_, m, validatorKey, finish := setup(t)
+	_, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	ctx := context.Background()
@@ -121,7 +121,7 @@ func TestSubmitValidatorRegistration_CantSign(t *testing.T) {
 }
 
 func Test_signValidatorRegistration(t *testing.T) {
-	_, m, validatorKey, finish := setup(t)
+	_, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	ctx := context.Background()
@@ -137,7 +137,7 @@ func Test_signValidatorRegistration(t *testing.T) {
 }
 
 func TestValidator_SignValidatorRegistrationRequest(t *testing.T) {
-	_, m, validatorKey, finish := setup(t)
+	_, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	ctx := context.Background()
 	byteval, err := hexutil.Decode("0x878705ba3f8bc32fcf7f4caa1a35e72af65cf766")

--- a/validator/client/slashing_protection_interchange_test.go
+++ b/validator/client/slashing_protection_interchange_test.go
@@ -85,7 +85,7 @@ func TestEIP3076SpecTests(t *testing.T) {
 
 			// Set up validator client, one new validator client per eip3076TestCase.
 			// This ensures we initialize a new (empty) slashing protection database.
-			validator, _, _, _ := setup(t)
+			validator, _, _, _ := setup(t, nil)
 
 			for _, step := range tt.Steps {
 				if tt.GenesisValidatorsRoot != "" {

--- a/validator/client/slashing_protection_interchange_test.go
+++ b/validator/client/slashing_protection_interchange_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
 	"github.com/prysmaticlabs/prysm/v4/testing/util"
+	"github.com/prysmaticlabs/prysm/v4/validator/db/kv"
 	history "github.com/prysmaticlabs/prysm/v4/validator/slashing-protection-history"
 )
 
@@ -46,6 +48,7 @@ type eip3076TestCase struct {
 			Pubkey                string `json:"pubkey"`
 			Slot                  string `json:"slot"`
 			SigningRoot           string `json:"signing_root"`
+			ShouldSucceedMinimal  bool   `json:"should_succeed"`
 			ShouldSucceedComplete bool   `json:"should_succeed_complete"`
 		} `json:"blocks"`
 		Attestations []struct {
@@ -53,6 +56,7 @@ type eip3076TestCase struct {
 			SourceEpoch           string `json:"source_epoch"`
 			TargetEpoch           string `json:"target_epoch"`
 			SigningRoot           string `json:"signing_root"`
+			ShouldSucceedMinimal  bool   `json:"should_succeed"`
 			ShouldSucceedComplete bool   `json:"should_succeed_complete"`
 		} `json:"attestations"`
 	} `json:"steps"`
@@ -76,99 +80,110 @@ func setupEIP3076SpecTests(t *testing.T) []*eip3076TestCase {
 }
 
 func TestEIP3076SpecTests(t *testing.T) {
-	testCases := setupEIP3076SpecTests(t)
 	for _, tt := range testCases {
-		t.Run(tt.Name, func(t *testing.T) {
-			if tt.Name == "" {
-				t.Skip("Skipping eip3076TestCase with empty name")
-			}
-
-			// Set up validator client, one new validator client per eip3076TestCase.
-			// This ensures we initialize a new (empty) slashing protection database.
-			validator, _, _, _ := setup(t, nil)
-
-			for _, step := range tt.Steps {
-				if tt.GenesisValidatorsRoot != "" {
-					r, err := history.RootFromHex(tt.GenesisValidatorsRoot)
-					require.NoError(t, validator.db.SaveGenesisValidatorsRoot(context.Background(), r[:]))
-					require.NoError(t, err)
+		for _, st := range setupEIP3076SpecTests(t) {
+			t.Run(fmt.Sprintf("%s - %s", tt.name, st.Name), func(t *testing.T) {
+				if st.Name == "" {
+					t.Skip("Skipping eip3076TestCase with empty name")
 				}
 
-				// The eip3076TestCase config contains the interchange config in json.
-				// This loads the interchange data via ImportStandardProtectionJSON.
-				interchangeBytes, err := json.Marshal(step.Interchange)
-				if err != nil {
-					t.Fatal(err)
-				}
-				b := bytes.NewBuffer(interchangeBytes)
-				if err := history.ImportStandardProtectionJSON(context.Background(), validator.db, b); err != nil {
-					if step.ShouldSucceed {
+				// Set up validator client, one new validator client per eip3076TestCase.
+				// This ensures we initialize a new (empty) slashing protection database.
+				validator, _, _, _ := setup(t, &setupParams{slashingProtectionType: tt.slashingProtectionType})
+
+				for _, step := range st.Steps {
+					if st.GenesisValidatorsRoot != "" {
+						r, err := history.RootFromHex(st.GenesisValidatorsRoot)
+						require.NoError(t, validator.db.SaveGenesisValidatorsRoot(context.Background(), r[:]))
+						require.NoError(t, err)
+					}
+
+					// The eip3076TestCase config contains the interchange config in json.
+					// This loads the interchange data via ImportStandardProtectionJSON.
+					interchangeBytes, err := json.Marshal(step.Interchange)
+					if err != nil {
 						t.Fatal(err)
 					}
-				} else if !step.ShouldSucceed {
-					require.NotNil(t, err, "import standard protection json should have failed")
+					b := bytes.NewBuffer(interchangeBytes)
+					if err := history.ImportStandardProtectionJSON(context.Background(), validator.db, b); err != nil {
+						if step.ShouldSucceed {
+							t.Fatal(err)
+						}
+					} else if !step.ShouldSucceed {
+						require.NotNil(t, err, "import standard protection json should have failed")
+					}
+
+					// This loops through a list of block signings to attempt after importing the interchange data above.
+					for _, sb := range step.Blocks {
+						shouldSucceed := sb.ShouldSucceedComplete
+						if tt.slashingProtectionType == kv.Minimal {
+							shouldSucceed = sb.ShouldSucceedMinimal
+						}
+
+						bSlot, err := history.SlotFromString(sb.Slot)
+						require.NoError(t, err)
+						pk, err := history.PubKeyFromHex(sb.Pubkey)
+						require.NoError(t, err)
+						b := util.NewBeaconBlock()
+						b.Block.Slot = bSlot
+
+						var signingRoot [32]byte
+						if sb.SigningRoot != "" {
+							signingRootBytes, err := hex.DecodeString(strings.TrimPrefix(sb.SigningRoot, "0x"))
+							require.NoError(t, err)
+							copy(signingRoot[:], signingRootBytes)
+						}
+
+						wsb, err := blocks.NewSignedBeaconBlock(b)
+						require.NoError(t, err)
+						err = validator.slashableProposalCheck(context.Background(), pk, wsb, signingRoot)
+						if shouldSucceed {
+							require.NoError(t, err)
+						} else {
+							require.NotEqual(t, nil, err, "pre validation should have failed for block")
+						}
+					}
+
+					// This loops through a list of attestation signings to attempt after importing the interchange data above.
+					for _, sa := range step.Attestations {
+						shouldSucceed := sa.ShouldSucceedComplete
+						if tt.slashingProtectionType == kv.Minimal {
+							shouldSucceed = sa.ShouldSucceedMinimal
+						}
+
+						target, err := history.EpochFromString(sa.TargetEpoch)
+						require.NoError(t, err)
+						source, err := history.EpochFromString(sa.SourceEpoch)
+						require.NoError(t, err)
+						pk, err := history.PubKeyFromHex(sa.Pubkey)
+						require.NoError(t, err)
+						ia := &ethpb.IndexedAttestation{
+							Data: &ethpb.AttestationData{
+								BeaconBlockRoot: make([]byte, 32),
+								Target:          &ethpb.Checkpoint{Epoch: target, Root: make([]byte, 32)},
+								Source:          &ethpb.Checkpoint{Epoch: source, Root: make([]byte, 32)},
+							},
+							Signature: make([]byte, fieldparams.BLSSignatureLength),
+						}
+
+						var signingRoot [32]byte
+						if sa.SigningRoot != "" {
+							signingRootBytes, err := hex.DecodeString(strings.TrimPrefix(sa.SigningRoot, "0x"))
+							require.NoError(t, err)
+							copy(signingRoot[:], signingRootBytes)
+						}
+
+						err = validator.slashableAttestationCheck(context.Background(), ia, pk, signingRoot)
+						if shouldSucceed {
+							require.NoError(t, err)
+						} else {
+							require.NotNil(t, err, "pre validation should have failed for attestation")
+						}
+					}
 				}
 
-				// This loops through a list of block signings to attempt after importing the interchange data above.
-				for _, sb := range step.Blocks {
-					bSlot, err := history.SlotFromString(sb.Slot)
-					require.NoError(t, err)
-					pk, err := history.PubKeyFromHex(sb.Pubkey)
-					require.NoError(t, err)
-					b := util.NewBeaconBlock()
-					b.Block.Slot = bSlot
-
-					var signingRoot [32]byte
-					if sb.SigningRoot != "" {
-						signingRootBytes, err := hex.DecodeString(strings.TrimPrefix(sb.SigningRoot, "0x"))
-						require.NoError(t, err)
-						copy(signingRoot[:], signingRootBytes)
-					}
-
-					wsb, err := blocks.NewSignedBeaconBlock(b)
-					require.NoError(t, err)
-					err = validator.slashableProposalCheck(context.Background(), pk, wsb, signingRoot)
-					if sb.ShouldSucceedComplete {
-						require.NoError(t, err)
-					} else {
-						require.NotEqual(t, nil, err, "pre validation should have failed for block")
-					}
-				}
-
-				// This loops through a list of attestation signings to attempt after importing the interchange data above.
-				for _, sa := range step.Attestations {
-					target, err := history.EpochFromString(sa.TargetEpoch)
-					require.NoError(t, err)
-					source, err := history.EpochFromString(sa.SourceEpoch)
-					require.NoError(t, err)
-					pk, err := history.PubKeyFromHex(sa.Pubkey)
-					require.NoError(t, err)
-					ia := &ethpb.IndexedAttestation{
-						Data: &ethpb.AttestationData{
-							BeaconBlockRoot: make([]byte, 32),
-							Target:          &ethpb.Checkpoint{Epoch: target, Root: make([]byte, 32)},
-							Source:          &ethpb.Checkpoint{Epoch: source, Root: make([]byte, 32)},
-						},
-						Signature: make([]byte, fieldparams.BLSSignatureLength),
-					}
-
-					var signingRoot [32]byte
-					if sa.SigningRoot != "" {
-						signingRootBytes, err := hex.DecodeString(strings.TrimPrefix(sa.SigningRoot, "0x"))
-						require.NoError(t, err)
-						copy(signingRoot[:], signingRootBytes)
-					}
-
-					err = validator.slashableAttestationCheck(context.Background(), ia, pk, signingRoot)
-					if sa.ShouldSucceedComplete {
-						require.NoError(t, err)
-					} else {
-						require.NotNil(t, err, "pre validation should have failed for attestation")
-					}
-				}
-			}
-
-			require.NoError(t, validator.db.Close(), "failed to close slashing protection database")
-		})
+				require.NoError(t, validator.db.Close(), "failed to close slashing protection database")
+			})
+		}
 	}
 }

--- a/validator/client/sync_committee_test.go
+++ b/validator/client/sync_committee_test.go
@@ -270,7 +270,7 @@ func TestSubmitSignedContributionAndProof_CouldNotGetContribution(t *testing.T) 
 	validatorKey, err := bls.SecretKeyFromBytes(rawKey)
 	assert.NoError(t, err)
 
-	validator, m, validatorKey, finish := setupWithKey(t, validatorKey)
+	validator, m, validatorKey, finish := setupWithParams(t, setupParams{validatorKey: validatorKey})
 	validatorIndex := primitives.ValidatorIndex(7)
 	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
@@ -320,7 +320,7 @@ func TestSubmitSignedContributionAndProof_CouldNotSubmitContribution(t *testing.
 	validatorKey, err := bls.SecretKeyFromBytes(rawKey)
 	assert.NoError(t, err)
 
-	validator, m, validatorKey, finish := setupWithKey(t, validatorKey)
+	validator, m, validatorKey, finish := setupWithParams(t, setupParams{validatorKey: validatorKey})
 	validatorIndex := primitives.ValidatorIndex(7)
 	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
@@ -398,7 +398,7 @@ func TestSubmitSignedContributionAndProof_Ok(t *testing.T) {
 	validatorKey, err := bls.SecretKeyFromBytes(rawKey)
 	assert.NoError(t, err)
 
-	validator, m, validatorKey, finish := setupWithKey(t, validatorKey)
+	validator, m, validatorKey, finish := setupWithParams(t, setupParams{validatorKey: validatorKey})
 	validatorIndex := primitives.ValidatorIndex(7)
 	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{

--- a/validator/client/sync_committee_test.go
+++ b/validator/client/sync_committee_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestSubmitSyncCommitteeMessage_ValidatorDutiesRequestFailure(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{}}
 	defer finish()
 
@@ -39,7 +39,7 @@ func TestSubmitSyncCommitteeMessage_ValidatorDutiesRequestFailure(t *testing.T) 
 }
 
 func TestSubmitSyncCommitteeMessage_BadDomainData(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	hook := logTest.NewGlobal()
 	validatorIndex := primitives.ValidatorIndex(7)
@@ -71,7 +71,7 @@ func TestSubmitSyncCommitteeMessage_BadDomainData(t *testing.T) {
 }
 
 func TestSubmitSyncCommitteeMessage_CouldNotSubmit(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	hook := logTest.NewGlobal()
 	validatorIndex := primitives.ValidatorIndex(7)
@@ -112,7 +112,7 @@ func TestSubmitSyncCommitteeMessage_CouldNotSubmit(t *testing.T) {
 }
 
 func TestSubmitSyncCommitteeMessage_OK(t *testing.T) {
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 	hook := logTest.NewGlobal()
 	validatorIndex := primitives.ValidatorIndex(7)
@@ -160,7 +160,7 @@ func TestSubmitSyncCommitteeMessage_OK(t *testing.T) {
 
 func TestSubmitSignedContributionAndProof_ValidatorDutiesRequestFailure(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, _, validatorKey, finish := setup(t)
+	validator, _, validatorKey, finish := setup(t, nil)
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{}}
 	defer finish()
 
@@ -172,7 +172,7 @@ func TestSubmitSignedContributionAndProof_ValidatorDutiesRequestFailure(t *testi
 
 func TestSubmitSignedContributionAndProof_GetSyncSubcommitteeIndexFailure(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	validatorIndex := primitives.ValidatorIndex(7)
 	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
@@ -200,7 +200,7 @@ func TestSubmitSignedContributionAndProof_GetSyncSubcommitteeIndexFailure(t *tes
 
 func TestSubmitSignedContributionAndProof_NothingToDo(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	validatorIndex := primitives.ValidatorIndex(7)
 	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{
@@ -228,7 +228,7 @@ func TestSubmitSignedContributionAndProof_NothingToDo(t *testing.T) {
 
 func TestSubmitSignedContributionAndProof_BadDomain(t *testing.T) {
 	hook := logTest.NewGlobal()
-	validator, m, validatorKey, finish := setup(t)
+	validator, m, validatorKey, finish := setup(t, nil)
 	validatorIndex := primitives.ValidatorIndex(7)
 	committee := []primitives.ValidatorIndex{0, 3, 4, 2, validatorIndex, 6, 8, 9, 10}
 	validator.duties = &ethpb.DutiesResponse{Duties: []*ethpb.DutiesResponse_Duty{

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -678,7 +678,7 @@ func TestUpdateDuties_AllValidatorsExited(t *testing.T) {
 }
 
 func TestRolesAt_OK(t *testing.T) {
-	v, m, validatorKey, finish := setup(t)
+	v, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	v.duties = &ethpb.DutiesResponse{
@@ -754,7 +754,7 @@ func TestRolesAt_OK(t *testing.T) {
 }
 
 func TestRolesAt_DoesNotAssignProposer_Slot0(t *testing.T) {
-	v, m, validatorKey, finish := setup(t)
+	v, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	v.duties = &ethpb.DutiesResponse{
@@ -1251,7 +1251,7 @@ func createAttestation(source, target primitives.Epoch) *ethpb.IndexedAttestatio
 
 func TestIsSyncCommitteeAggregator_OK(t *testing.T) {
 	params.SetupTestConfigCleanup(t)
-	v, m, validatorKey, finish := setup(t)
+	v, m, validatorKey, finish := setup(t, nil)
 	defer finish()
 
 	slot := primitives.Slot(1)

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -34,6 +34,7 @@ import (
 	validatormock "github.com/prysmaticlabs/prysm/v4/testing/validator-mock"
 	"github.com/prysmaticlabs/prysm/v4/validator/accounts/wallet"
 	"github.com/prysmaticlabs/prysm/v4/validator/client/iface"
+	"github.com/prysmaticlabs/prysm/v4/validator/db/kv"
 	dbTest "github.com/prysmaticlabs/prysm/v4/validator/db/testing"
 	"github.com/prysmaticlabs/prysm/v4/validator/keymanager"
 	"github.com/prysmaticlabs/prysm/v4/validator/keymanager/local"
@@ -192,7 +193,7 @@ func TestWaitForChainStart_SetsGenesisInfo(t *testing.T) {
 	defer ctrl.Finish()
 	client := validatormock.NewMockValidatorClient(ctrl)
 
-	db := dbTest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+	db := dbTest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 	v := validator{
 		validatorClient: client,
 		db:              db,
@@ -238,7 +239,7 @@ func TestWaitForChainStart_SetsGenesisInfo_IncorrectSecondTry(t *testing.T) {
 	defer ctrl.Finish()
 	client := validatormock.NewMockValidatorClient(ctrl)
 
-	db := dbTest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+	db := dbTest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 	v := validator{
 		validatorClient: client,
 		db:              db,
@@ -1027,7 +1028,7 @@ func TestValidator_CheckDoppelGanger(t *testing.T) {
 				km := genMockKeymanager(t, 10)
 				keys, err := km.FetchValidatingPublicKeys(context.Background())
 				assert.NoError(t, err)
-				db := dbTest.SetupDB(t, keys)
+				db := dbTest.SetupDB(t, &kv.Config{PubKeys: keys})
 				req := &ethpb.DoppelGangerRequest{ValidatorRequests: []*ethpb.DoppelGangerRequest_ValidatorRequest{}}
 				resp := &ethpb.DoppelGangerRequest{ValidatorRequests: []*ethpb.DoppelGangerRequest_ValidatorRequest{}}
 				for _, k := range keys {
@@ -1059,7 +1060,7 @@ func TestValidator_CheckDoppelGanger(t *testing.T) {
 				km := genMockKeymanager(t, 10)
 				keys, err := km.FetchValidatingPublicKeys(context.Background())
 				assert.NoError(t, err)
-				db := dbTest.SetupDB(t, keys)
+				db := dbTest.SetupDB(t, &kv.Config{PubKeys: keys})
 				req := &ethpb.DoppelGangerRequest{ValidatorRequests: []*ethpb.DoppelGangerRequest_ValidatorRequest{}}
 				resp := &ethpb.DoppelGangerResponse{Responses: []*ethpb.DoppelGangerResponse_ValidatorResponse{}}
 				for i, k := range keys {
@@ -1093,7 +1094,7 @@ func TestValidator_CheckDoppelGanger(t *testing.T) {
 				km := genMockKeymanager(t, 10)
 				keys, err := km.FetchValidatingPublicKeys(context.Background())
 				assert.NoError(t, err)
-				db := dbTest.SetupDB(t, keys)
+				db := dbTest.SetupDB(t, &kv.Config{PubKeys: keys})
 				req := &ethpb.DoppelGangerRequest{ValidatorRequests: []*ethpb.DoppelGangerRequest_ValidatorRequest{}}
 				resp := &ethpb.DoppelGangerResponse{Responses: []*ethpb.DoppelGangerResponse_ValidatorResponse{}}
 				for i, k := range keys {
@@ -1127,7 +1128,7 @@ func TestValidator_CheckDoppelGanger(t *testing.T) {
 				km := genMockKeymanager(t, 10)
 				keys, err := km.FetchValidatingPublicKeys(context.Background())
 				assert.NoError(t, err)
-				db := dbTest.SetupDB(t, keys)
+				db := dbTest.SetupDB(t, &kv.Config{PubKeys: keys})
 				req := &ethpb.DoppelGangerRequest{ValidatorRequests: []*ethpb.DoppelGangerRequest_ValidatorRequest{}}
 				resp := &ethpb.DoppelGangerResponse{Responses: []*ethpb.DoppelGangerResponse_ValidatorResponse{}}
 				attLimit := 5
@@ -1167,7 +1168,7 @@ func TestValidator_CheckDoppelGanger(t *testing.T) {
 				km := genMockKeymanager(t, 1)
 				keys, err := km.FetchValidatingPublicKeys(context.Background())
 				assert.NoError(t, err)
-				db := dbTest.SetupDB(t, keys)
+				db := dbTest.SetupDB(t, &kv.Config{PubKeys: keys})
 				resp := &ethpb.DoppelGangerResponse{Responses: []*ethpb.DoppelGangerResponse_ValidatorResponse{}}
 				req := &ethpb.DoppelGangerRequest{ValidatorRequests: []*ethpb.DoppelGangerRequest_ValidatorRequest{}}
 				for _, k := range keys {
@@ -1202,7 +1203,7 @@ func TestValidatorAttestationsAreOrdered(t *testing.T) {
 	km := genMockKeymanager(t, 10)
 	keys, err := km.FetchValidatingPublicKeys(context.Background())
 	assert.NoError(t, err)
-	db := dbTest.SetupDB(t, keys)
+	db := dbTest.SetupDB(t, &kv.Config{PubKeys: keys})
 
 	k := keys[0]
 	att := createAttestation(10, 14)
@@ -1292,7 +1293,7 @@ func TestIsSyncCommitteeAggregator_OK(t *testing.T) {
 
 func TestValidator_WaitForKeymanagerInitialization_web3Signer(t *testing.T) {
 	ctx := context.Background()
-	db := dbTest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+	db := dbTest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 	root := make([]byte, 32)
 	copy(root[2:], "a")
 	err := db.SaveGenesisValidatorsRoot(ctx, root)
@@ -1321,7 +1322,7 @@ func TestValidator_WaitForKeymanagerInitialization_web3Signer(t *testing.T) {
 
 func TestValidator_WaitForKeymanagerInitialization_Web(t *testing.T) {
 	ctx := context.Background()
-	db := dbTest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+	db := dbTest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 	root := make([]byte, 32)
 	copy(root[2:], "a")
 	err := db.SaveGenesisValidatorsRoot(ctx, root)
@@ -1351,7 +1352,7 @@ func TestValidator_WaitForKeymanagerInitialization_Web(t *testing.T) {
 
 func TestValidator_WaitForKeymanagerInitialization_Interop(t *testing.T) {
 	ctx := context.Background()
-	db := dbTest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+	db := dbTest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 	root := make([]byte, 32)
 	copy(root[2:], "a")
 	err := db.SaveGenesisValidatorsRoot(ctx, root)
@@ -1374,7 +1375,7 @@ func TestValidator_WaitForKeymanagerInitialization_Interop(t *testing.T) {
 func TestValidator_PushProposerSettings(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctx := context.Background()
-	db := dbTest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+	db := dbTest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 	client := validatormock.NewMockValidatorClient(ctrl)
 	nodeClient := validatormock.NewMockNodeClient(ctrl)
 	defaultFeeHex := "0x046Fb65722E7b2455043BFEBf6177F1D2e9738D9"

--- a/validator/client/validator_test.go
+++ b/validator/client/validator_test.go
@@ -104,29 +104,6 @@ func (m *mockKeymanager) add(pairs ...keypair) error {
 	return nil
 }
 
-func (m *mockKeymanager) remove(pairs ...keypair) {
-	for _, kp := range pairs {
-		if _, exists := m.keysMap[kp.pub]; !exists {
-			continue
-		}
-		m.removeOne(kp)
-	}
-}
-
-func (m *mockKeymanager) removeOne(kp keypair) {
-	delete(m.keysMap, kp.pub)
-	if m.keys[0] == kp.pub {
-		m.keys = m.keys[1:]
-		return
-	}
-	for i := 1; i < len(m.keys); i++ {
-		if m.keys[i] == kp.pub {
-			m.keys = append(m.keys[0:i-1], m.keys[i:]...)
-			return
-		}
-	}
-}
-
 func (m *mockKeymanager) FetchValidatingPublicKeys(ctx context.Context) ([][fieldparams.BLSPubkeyLength]byte, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()

--- a/validator/db/iface/interface.go
+++ b/validator/db/iface/interface.go
@@ -57,7 +57,7 @@ type ValidatorDB interface {
 	SaveAttestationsForPubKey(
 		ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, signingRoots [][]byte, atts []*ethpb.IndexedAttestation,
 	) error
-	SaveLowestSignedSourceEpochForPubKey(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, epoch primitives.Epoch) error
+	SaveLowestSignedSourceEpochForPubKey(pubKey [fieldparams.BLSPubkeyLength]byte, epoch primitives.Epoch) error
 	AttestationHistoryForPubKey(
 		ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte,
 	) ([]*kv.AttestationRecord, error)

--- a/validator/db/iface/interface.go
+++ b/validator/db/iface/interface.go
@@ -21,6 +21,7 @@ type ValidatorDB interface {
 	io.Closer
 	backup.Exporter
 	DatabasePath() string
+	SlashingProtectionType() kv.SlashingProtectionType
 	ClearDB() error
 	RunUpMigrations(ctx context.Context) error
 	RunDownMigrations(ctx context.Context) error

--- a/validator/db/iface/interface.go
+++ b/validator/db/iface/interface.go
@@ -56,6 +56,7 @@ type ValidatorDB interface {
 	SaveAttestationsForPubKey(
 		ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, signingRoots [][]byte, atts []*ethpb.IndexedAttestation,
 	) error
+	SaveLowestSignedSourceEpochForPubKey(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, epoch primitives.Epoch) error
 	AttestationHistoryForPubKey(
 		ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte,
 	) ([]*kv.AttestationRecord, error)

--- a/validator/db/kv/BUILD.bazel
+++ b/validator/db/kv/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     srcs = [
         "attester_protection_test.go",
         "backup_test.go",
+        "db_test.go",
         "deprecated_attester_protection_test.go",
         "eip_blacklisted_keys_test.go",
         "genesis_test.go",

--- a/validator/db/kv/attester_protection.go
+++ b/validator/db/kv/attester_protection.go
@@ -307,7 +307,7 @@ func (s *Store) SaveAttestationsForPubKey(
 // SaveLowestSignedSourceEpochForPubKey modifies the lowest signed source epoch for a given pubkey.
 // The call to this function is allowd only for minimal slashing protection,
 // and allows only to save a higher epoch that already stored
-func (s *Store) SaveLowestSignedSourceEpochForPubKey(ctx context.Context, pubKey [fieldparams.BLSPubkeyLength]byte, epoch primitives.Epoch) error {
+func (s *Store) SaveLowestSignedSourceEpochForPubKey(pubKey [fieldparams.BLSPubkeyLength]byte, epoch primitives.Epoch) error {
 	if s.slashingProtectionType != Minimal {
 		return errors.New("SaveLowestSignedSourceEpochForPubKey is allowed only for minimal slashing protection")
 	}

--- a/validator/db/kv/attester_protection.go
+++ b/validator/db/kv/attester_protection.go
@@ -450,7 +450,7 @@ func (s *Store) saveAttestationRecords(ctx context.Context, atts []*AttestationR
 				return errors.Wrap(err, "could not create signing roots bucket")
 			}
 
-			if s.slashingProtectionType == minimal {
+			if s.slashingProtectionType == Minimal {
 				if err := emptyBucket(signingRootsBucket); err != nil {
 					return errors.Wrap(err, "could not empty signing roots bucket")
 				}
@@ -465,7 +465,7 @@ func (s *Store) saveAttestationRecords(ctx context.Context, atts []*AttestationR
 				return errors.Wrap(err, "could not create source epochs bucket")
 			}
 
-			if s.slashingProtectionType == minimal {
+			if s.slashingProtectionType == Minimal {
 				if err := emptyBucket(sourceEpochsBucket); err != nil {
 					return errors.Wrap(err, "could not empty source epoch bucket")
 				}
@@ -491,7 +491,7 @@ func (s *Store) saveAttestationRecords(ctx context.Context, atts []*AttestationR
 				return errors.Wrap(err, "could not create target epochs bucket")
 			}
 
-			if s.slashingProtectionType == minimal {
+			if s.slashingProtectionType == Minimal {
 				if err := emptyBucket(targetEpochsBucket); err != nil {
 					return errors.Wrap(err, "could not empty target epoch bucket")
 				}
@@ -509,7 +509,7 @@ func (s *Store) saveAttestationRecords(ctx context.Context, atts []*AttestationR
 				return errors.Wrapf(err, "could not save target epoch %d for epoch %d", att.Target, att.Source)
 			}
 
-			if s.slashingProtectionType == minimal {
+			if s.slashingProtectionType == Minimal {
 				if err := lowestSourceBucket.Put(att.PubKey[:], bytesutil.EpochToBytesBigEndian(att.Source)); err != nil {
 					return errors.Wrapf(err, "could not save lowest source epoch %d", att.Source)
 				}
@@ -529,7 +529,7 @@ func (s *Store) saveAttestationRecords(ctx context.Context, atts []*AttestationR
 				}
 			}
 
-			if s.slashingProtectionType == minimal {
+			if s.slashingProtectionType == Minimal {
 				if err := lowestTargetBucket.Put(att.PubKey[:], bytesutil.EpochToBytesBigEndian(att.Target)); err != nil {
 					return errors.Wrapf(err, "could not save lowest target epoch %d", att.Target)
 				}

--- a/validator/db/kv/attester_protection_test.go
+++ b/validator/db/kv/attester_protection_test.go
@@ -125,7 +125,7 @@ func TestStore_CheckSlashableAttestation_SurroundVote_MultipleTargetsPerSource(t
 			ctx := context.Background()
 			numValidators := 1
 			pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
-			validatorDB := setupDB(t, pubKeys, minimal)
+			validatorDB := setupDB(t, pubKeys, Minimal)
 
 			// Create an attestation with source 1 and target 100, save it.
 			secondAtt := createAttestation(1, 100)
@@ -280,7 +280,7 @@ func TestLowestSignedSourceEpoch_SaveRetrieve(t *testing.T) {
 				validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(200, 201)),
 			)
 
-			if tt.slashingProtectionType == complete {
+			if tt.slashingProtectionType == Complete {
 				// Can not replace.
 				got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p0)
 				require.NoError(t, err)
@@ -354,7 +354,7 @@ func TestLowestSignedTargetEpoch_SaveRetrieveReplace(t *testing.T) {
 				validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(199, 200)),
 			)
 
-			if tt.slashingProtectionType == complete {
+			if tt.slashingProtectionType == Complete {
 				// Can not replace.
 				got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p0)
 				require.NoError(t, err)
@@ -412,7 +412,7 @@ func TestStore_SaveAttestationsForPubKey(t *testing.T) {
 					[]byte{},
 					att,
 				)
-				if tt.slashingProtectionType == complete || tt.slashingProtectionType == minimal && i == len(atts)-1 {
+				if tt.slashingProtectionType == Complete || tt.slashingProtectionType == Minimal && i == len(atts)-1 {
 					require.NotNil(t, err)
 					require.Equal(t, DoubleVote, slashingKind)
 				} else {
@@ -503,7 +503,7 @@ func TestSaveAttestationForPubKey_BatchWrites_LowCapacity_TimerReached(t *testin
 				copy(pubKeys[i][:], []byte(strconv.Itoa(i)))
 			}
 
-			validatorDB := setupDB(t, pubKeys, complete)
+			validatorDB := setupDB(t, pubKeys, Complete)
 
 			// For each public key, we attempt to save an attestation with signing root.
 			var wg sync.WaitGroup

--- a/validator/db/kv/attester_protection_test.go
+++ b/validator/db/kv/attester_protection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -43,11 +44,7 @@ func TestPendingAttestationRecords_Len(t *testing.T) {
 }
 
 func TestStore_CheckSlashableAttestation_DoubleVote(t *testing.T) {
-	ctx := context.Background()
-	numValidators := 1
-	pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
-	validatorDB := setupDB(t, pubKeys)
-	tests := []struct {
+	subTestCases := []struct {
 		name                string
 		existingAttestation *ethpb.IndexedAttestation
 		existingSigningRoot [32]byte
@@ -88,54 +85,67 @@ func TestStore_CheckSlashableAttestation_DoubleVote(t *testing.T) {
 			want:                false,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validatorDB.SaveAttestationForPubKey(
-				ctx,
-				pubKeys[0],
-				tt.existingSigningRoot,
-				tt.existingAttestation,
-			)
-			require.NoError(t, err)
-			slashingKind, err := validatorDB.CheckSlashableAttestation(
-				ctx,
-				pubKeys[0],
-				tt.incomingSigningRoot[:],
-				tt.incomingAttestation,
-			)
-			if tt.want {
-				require.NotNil(t, err)
-				assert.Equal(t, DoubleVote, slashingKind)
-			} else {
+
+	for _, tt := range testCases {
+		for _, st := range subTestCases {
+			t.Run(tt.name+st.name, func(t *testing.T) {
+				ctx := context.Background()
+				numValidators := 1
+				pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
+				validatorDB := setupDB(t, pubKeys, tt.slashingProtectionType)
+
+				err := validatorDB.SaveAttestationForPubKey(
+					ctx,
+					pubKeys[0],
+					st.existingSigningRoot,
+					st.existingAttestation,
+				)
 				require.NoError(t, err)
-			}
-		})
+
+				slashingKind, err := validatorDB.CheckSlashableAttestation(
+					ctx,
+					pubKeys[0],
+					st.incomingSigningRoot[:],
+					st.incomingAttestation,
+				)
+				if st.want {
+					require.NotNil(t, err)
+					assert.Equal(t, DoubleVote, slashingKind)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+		}
 	}
 }
 
 func TestStore_CheckSlashableAttestation_SurroundVote_MultipleTargetsPerSource(t *testing.T) {
-	ctx := context.Background()
-	numValidators := 1
-	pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
-	validatorDB := setupDB(t, pubKeys)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			numValidators := 1
+			pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
+			validatorDB := setupDB(t, pubKeys, minimal)
 
-	// Create an attestation with source 1 and target 50, save it.
-	firstAtt := createAttestation(1, 50)
-	err := validatorDB.SaveAttestationForPubKey(ctx, pubKeys[0], [32]byte{0}, firstAtt)
-	require.NoError(t, err)
+			// Create an attestation with source 1 and target 100, save it.
+			secondAtt := createAttestation(1, 100)
+			err := validatorDB.SaveAttestationForPubKey(ctx, pubKeys[0], [32]byte{1}, secondAtt)
+			require.NoError(t, err)
 
-	// Create an attestation with source 1 and target 100, save it.
-	secondAtt := createAttestation(1, 100)
-	err = validatorDB.SaveAttestationForPubKey(ctx, pubKeys[0], [32]byte{1}, secondAtt)
-	require.NoError(t, err)
+			// Create an attestation with source 1 and target 50, save it.
+			firstAtt := createAttestation(1, 50)
+			err = validatorDB.SaveAttestationForPubKey(ctx, pubKeys[0], [32]byte{0}, firstAtt)
+			require.NoError(t, err)
 
-	// Create an attestation with source 0 and target 51, which should surround
-	// our first attestation. Given there can be multiple attested target epochs per
-	// source epoch, we expect our logic to be able to catch this slashable offense.
-	evilAtt := createAttestation(firstAtt.Data.Source.Epoch-1, firstAtt.Data.Target.Epoch+1)
-	slashable, err := validatorDB.CheckSlashableAttestation(ctx, pubKeys[0], []byte{2}, evilAtt)
-	require.NotNil(t, err)
-	assert.Equal(t, SurroundingVote, slashable)
+			// Create an attestation with source 0 and target 51, which should surround
+			// our first attestation. Given there can be multiple attested target epochs per
+			// source epoch, we expect our logic to be able to catch this slashable offense.
+			evilAtt := createAttestation(firstAtt.Data.Source.Epoch-1, firstAtt.Data.Target.Epoch+1)
+			slashable, err := validatorDB.CheckSlashableAttestation(ctx, pubKeys[0], []byte{2}, evilAtt)
+			require.NotNil(t, err)
+			assert.Equal(t, SurroundingVote, slashable)
+		})
+	}
 }
 
 func TestStore_CheckSlashableAttestation_SurroundVote_54kEpochs(t *testing.T) {
@@ -143,340 +153,403 @@ func TestStore_CheckSlashableAttestation_SurroundVote_54kEpochs(t *testing.T) {
 	numValidators := 1
 	numEpochs := primitives.Epoch(54000)
 	pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
-	validatorDB := setupDB(t, pubKeys)
 
-	// Attest to every (source = epoch, target = epoch + 1) sequential pair
-	// since genesis up to and including the weak subjectivity period epoch (54,000).
-	err := validatorDB.update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(pubKeysBucket)
-		pkBucket, err := bucket.CreateBucketIfNotExists(pubKeys[0][:])
-		if err != nil {
-			return err
-		}
-		sourceEpochsBucket, err := pkBucket.CreateBucketIfNotExists(attestationSourceEpochsBucket)
-		if err != nil {
-			return err
-		}
-		for epoch := primitives.Epoch(1); epoch < numEpochs; epoch++ {
-			att := createAttestation(epoch-1, epoch)
-			sourceEpoch := bytesutil.EpochToBytesBigEndian(att.Data.Source.Epoch)
-			targetEpoch := bytesutil.EpochToBytesBigEndian(att.Data.Target.Epoch)
-			if err := sourceEpochsBucket.Put(sourceEpoch, targetEpoch); err != nil {
+	for _, tt := range testCases {
+		validatorDB := setupDB(t, pubKeys, tt.slashingProtectionType)
+
+		// Attest to every (source = epoch, target = epoch + 1) sequential pair
+		// since genesis up to and including the weak subjectivity period epoch (54,000).
+		err := validatorDB.update(func(tx *bolt.Tx) error {
+			bucket := tx.Bucket(pubKeysBucket)
+			pkBucket, err := bucket.CreateBucketIfNotExists(pubKeys[0][:])
+			if err != nil {
 				return err
 			}
-		}
-		return nil
-	})
-	require.NoError(t, err)
-
-	tests := []struct {
-		name        string
-		signingRoot []byte
-		attestation *ethpb.IndexedAttestation
-		want        SlashingKind
-	}{
-		{
-			name:        "surround vote at half of the weak subjectivity period",
-			signingRoot: []byte{},
-			attestation: createAttestation(numEpochs/2, numEpochs),
-			want:        SurroundingVote,
-		},
-		{
-			name:        "spanning genesis to weak subjectivity period surround vote",
-			signingRoot: []byte{},
-			attestation: createAttestation(0, numEpochs),
-			want:        SurroundingVote,
-		},
-		{
-			name:        "simple surround vote at end of weak subjectivity period",
-			signingRoot: []byte{},
-			attestation: createAttestation(numEpochs-3, numEpochs),
-			want:        SurroundingVote,
-		},
-		{
-			name:        "non-slashable vote",
-			signingRoot: []byte{},
-			attestation: createAttestation(numEpochs, numEpochs+1),
-			want:        NotSlashable,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			slashingKind, err := validatorDB.CheckSlashableAttestation(ctx, pubKeys[0], tt.signingRoot, tt.attestation)
-			if tt.want != NotSlashable {
-				require.NotNil(t, err)
+			sourceEpochsBucket, err := pkBucket.CreateBucketIfNotExists(attestationSourceEpochsBucket)
+			if err != nil {
+				return err
 			}
-			assert.Equal(t, tt.want, slashingKind)
+			for epoch := primitives.Epoch(1); epoch < numEpochs; epoch++ {
+				att := createAttestation(epoch-1, epoch)
+				sourceEpoch := bytesutil.EpochToBytesBigEndian(att.Data.Source.Epoch)
+				targetEpoch := bytesutil.EpochToBytesBigEndian(att.Data.Target.Epoch)
+				if err := sourceEpochsBucket.Put(sourceEpoch, targetEpoch); err != nil {
+					return err
+				}
+			}
+			return nil
 		})
+		require.NoError(t, err)
+
+		subTestCases := []struct {
+			name        string
+			signingRoot []byte
+			attestation *ethpb.IndexedAttestation
+			want        SlashingKind
+		}{
+			{
+				name:        "surround vote at half of the weak subjectivity period",
+				signingRoot: []byte{},
+				attestation: createAttestation(numEpochs/2, numEpochs),
+				want:        SurroundingVote,
+			},
+			{
+				name:        "spanning genesis to weak subjectivity period surround vote",
+				signingRoot: []byte{},
+				attestation: createAttestation(0, numEpochs),
+				want:        SurroundingVote,
+			},
+			{
+				name:        "simple surround vote at end of weak subjectivity period",
+				signingRoot: []byte{},
+				attestation: createAttestation(numEpochs-3, numEpochs),
+				want:        SurroundingVote,
+			},
+			{
+				name:        "non-slashable vote",
+				signingRoot: []byte{},
+				attestation: createAttestation(numEpochs, numEpochs+1),
+				want:        NotSlashable,
+			},
+		}
+
+		for _, st := range subTestCases {
+			t.Run(fmt.Sprintf("%s - %s", tt.name, st.name), func(t *testing.T) {
+				slashingKind, err := validatorDB.CheckSlashableAttestation(ctx, pubKeys[0], st.signingRoot, st.attestation)
+				if st.want != NotSlashable {
+					require.NotNil(t, err)
+				}
+				assert.Equal(t, st.want, slashingKind)
+			})
+		}
+
+		require.NoError(t, validatorDB.Close(), "Failed to close database")
 	}
 }
 
 func TestLowestSignedSourceEpoch_SaveRetrieve(t *testing.T) {
-	ctx := context.Background()
-	validatorDB, err := NewKVStore(ctx, t.TempDir(), &Config{})
-	require.NoError(t, err, "Failed to instantiate DB")
-	t.Cleanup(func() {
-		require.NoError(t, validatorDB.Close(), "Failed to close database")
-		require.NoError(t, validatorDB.ClearDB(), "Failed to clear database")
-	})
-	p0 := [fieldparams.BLSPubkeyLength]byte{0}
-	p1 := [fieldparams.BLSPubkeyLength]byte{1}
-	// Can save.
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(100, 101)),
-	)
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(200, 201)),
-	)
-	got, _, err := validatorDB.LowestSignedSourceEpoch(ctx, p0)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(100), got)
-	got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p1)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(200), got)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			validatorDB, err := NewKVStore(ctx, t.TempDir(), &Config{SlashingProtectionType: tt.slashingProtectionType})
+			require.NoError(t, err, "Failed to instantiate DB")
+			t.Cleanup(func() {
+				require.NoError(t, validatorDB.Close(), "Failed to close database")
+				require.NoError(t, validatorDB.ClearDB(), "Failed to clear database")
+			})
+			p0 := [fieldparams.BLSPubkeyLength]byte{0}
+			p1 := [fieldparams.BLSPubkeyLength]byte{1}
+			// Can save.
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(100, 101)),
+			)
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(200, 201)),
+			)
+			got, _, err := validatorDB.LowestSignedSourceEpoch(ctx, p0)
+			require.NoError(t, err)
+			require.Equal(t, primitives.Epoch(100), got)
+			got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p1)
+			require.NoError(t, err)
+			require.Equal(t, primitives.Epoch(200), got)
 
-	// Can replace.
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(99, 100)),
-	)
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(199, 200)),
-	)
-	got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p0)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(99), got)
-	got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p1)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(199), got)
+			// Can replace.
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(99, 100)),
+			)
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(199, 200)),
+			)
+			got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p0)
+			require.NoError(t, err)
+			require.Equal(t, primitives.Epoch(99), got)
+			got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p1)
+			require.NoError(t, err)
+			require.Equal(t, primitives.Epoch(199), got)
 
-	// Can not replace.
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(100, 101)),
-	)
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(200, 201)),
-	)
-	got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p0)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(99), got)
-	got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p1)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(199), got)
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(100, 101)),
+			)
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(200, 201)),
+			)
+
+			if tt.slashingProtectionType == complete {
+				// Can not replace.
+				got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p0)
+				require.NoError(t, err)
+				require.Equal(t, primitives.Epoch(99), got)
+				got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p1)
+				require.NoError(t, err)
+				require.Equal(t, primitives.Epoch(199), got)
+			} else {
+				// Can replace.
+				got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p0)
+				require.NoError(t, err)
+				require.Equal(t, primitives.Epoch(100), got)
+				got, _, err = validatorDB.LowestSignedSourceEpoch(ctx, p1)
+				require.NoError(t, err)
+				require.Equal(t, primitives.Epoch(200), got)
+			}
+		})
+	}
 }
 
 func TestLowestSignedTargetEpoch_SaveRetrieveReplace(t *testing.T) {
-	ctx := context.Background()
-	validatorDB, err := NewKVStore(ctx, t.TempDir(), &Config{})
-	require.NoError(t, err, "Failed to instantiate DB")
-	t.Cleanup(func() {
-		require.NoError(t, validatorDB.Close(), "Failed to close database")
-		require.NoError(t, validatorDB.ClearDB(), "Failed to clear database")
-	})
-	p0 := [fieldparams.BLSPubkeyLength]byte{0}
-	p1 := [fieldparams.BLSPubkeyLength]byte{1}
-	// Can save.
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(99, 100)),
-	)
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(199, 200)),
-	)
-	got, _, err := validatorDB.LowestSignedTargetEpoch(ctx, p0)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(100), got)
-	got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p1)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(200), got)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			validatorDB, err := NewKVStore(ctx, t.TempDir(), &Config{SlashingProtectionType: tt.slashingProtectionType})
+			require.NoError(t, err, "Failed to instantiate DB")
+			t.Cleanup(func() {
+				require.NoError(t, validatorDB.Close(), "Failed to close database")
+				require.NoError(t, validatorDB.ClearDB(), "Failed to clear database")
+			})
+			p0 := [fieldparams.BLSPubkeyLength]byte{0}
+			p1 := [fieldparams.BLSPubkeyLength]byte{1}
+			// Can save.
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(99, 100)),
+			)
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(199, 200)),
+			)
+			got, _, err := validatorDB.LowestSignedTargetEpoch(ctx, p0)
+			require.NoError(t, err)
+			require.Equal(t, primitives.Epoch(100), got)
+			got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p1)
+			require.NoError(t, err)
+			require.Equal(t, primitives.Epoch(200), got)
 
-	// Can replace.
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(98, 99)),
-	)
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(198, 199)),
-	)
-	got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p0)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(99), got)
-	got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p1)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(199), got)
+			// Can replace.
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(98, 99)),
+			)
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(198, 199)),
+			)
+			got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p0)
+			require.NoError(t, err)
+			require.Equal(t, primitives.Epoch(99), got)
+			got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p1)
+			require.NoError(t, err)
+			require.Equal(t, primitives.Epoch(199), got)
 
-	// Can not replace.
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(99, 100)),
-	)
-	require.NoError(
-		t,
-		validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(199, 200)),
-	)
-	got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p0)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(99), got)
-	got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p1)
-	require.NoError(t, err)
-	require.Equal(t, primitives.Epoch(199), got)
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p0, [32]byte{}, createAttestation(99, 100)),
+			)
+			require.NoError(
+				t,
+				validatorDB.SaveAttestationForPubKey(ctx, p1, [32]byte{}, createAttestation(199, 200)),
+			)
+
+			if tt.slashingProtectionType == complete {
+				// Can not replace.
+				got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p0)
+				require.NoError(t, err)
+				require.Equal(t, primitives.Epoch(99), got)
+				got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p1)
+				require.NoError(t, err)
+				require.Equal(t, primitives.Epoch(199), got)
+			} else {
+				// Can replace.
+				got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p0)
+				require.NoError(t, err)
+				require.Equal(t, primitives.Epoch(100), got)
+				got, _, err = validatorDB.LowestSignedTargetEpoch(ctx, p1)
+				require.NoError(t, err)
+				require.Equal(t, primitives.Epoch(200), got)
+			}
+		})
+	}
 }
 
 func TestStore_SaveAttestationsForPubKey(t *testing.T) {
-	ctx := context.Background()
-	numValidators := 1
-	pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
-	validatorDB := setupDB(t, pubKeys)
-	atts := make([]*ethpb.IndexedAttestation, 0)
-	signingRoots := make([][]byte, 0)
-	for i := primitives.Epoch(1); i < 10; i++ {
-		atts = append(atts, createAttestation(i-1, i))
-		var sr []byte
-		copy(sr, fmt.Sprintf("%d", i))
-		signingRoots = append(signingRoots, sr)
-	}
-	err := validatorDB.SaveAttestationsForPubKey(
-		ctx,
-		pubKeys[0],
-		signingRoots[:1],
-		atts,
-	)
-	require.ErrorContains(t, "does not match number of attestations", err)
-	err = validatorDB.SaveAttestationsForPubKey(
-		ctx,
-		pubKeys[0],
-		signingRoots,
-		atts,
-	)
-	require.NoError(t, err)
-	for _, att := range atts {
-		// Ensure the same attestations but different signing root lead to double votes.
-		slashingKind, err := validatorDB.CheckSlashableAttestation(
-			ctx,
-			pubKeys[0],
-			[]byte{},
-			att,
-		)
-		require.NotNil(t, err)
-		require.Equal(t, DoubleVote, slashingKind)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			numValidators := 1
+			pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
+			validatorDB := setupDB(t, pubKeys, tt.slashingProtectionType)
+			atts := make([]*ethpb.IndexedAttestation, 0)
+			signingRoots := make([][]byte, 0)
+			for i := primitives.Epoch(1); i < 10; i++ {
+				atts = append(atts, createAttestation(i-1, i))
+				var sr []byte
+				copy(sr, fmt.Sprintf("%d", i))
+				signingRoots = append(signingRoots, sr)
+			}
+			err := validatorDB.SaveAttestationsForPubKey(
+				ctx,
+				pubKeys[0],
+				signingRoots[:1],
+				atts,
+			)
+			require.ErrorContains(t, "does not match number of attestations", err)
+			err = validatorDB.SaveAttestationsForPubKey(
+				ctx,
+				pubKeys[0],
+				signingRoots,
+				atts,
+			)
+			require.NoError(t, err)
+			for i, att := range atts {
+				// Ensure the same attestations but different signing root lead to double votes.
+				slashingKind, err := validatorDB.CheckSlashableAttestation(
+					ctx,
+					pubKeys[0],
+					[]byte{},
+					att,
+				)
+				if tt.slashingProtectionType == complete || tt.slashingProtectionType == minimal && i == len(atts)-1 {
+					require.NotNil(t, err)
+					require.Equal(t, DoubleVote, slashingKind)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, NotSlashable, slashingKind)
+				}
+			}
+		})
 	}
 }
 
 func TestSaveAttestationForPubKey_BatchWrites_FullCapacity(t *testing.T) {
-	hook := logTest.NewGlobal()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	numValidators := attestationBatchCapacity
-	pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
-	validatorDB := setupDB(t, pubKeys)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			numValidators := attestationBatchCapacity
 
-	// For each public key, we attempt to save an attestation with signing root.
-	var wg sync.WaitGroup
-	for i, pubKey := range pubKeys {
-		wg.Add(1)
-		go func(j primitives.Epoch, pk [fieldparams.BLSPubkeyLength]byte, w *sync.WaitGroup) {
-			defer w.Done()
-			var signingRoot [32]byte
-			copy(signingRoot[:], fmt.Sprintf("%d", j))
-			att := createAttestation(j, j+1)
-			err := validatorDB.SaveAttestationForPubKey(ctx, pk, signingRoot, att)
+			pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
+			for i := 0; i < numValidators; i++ {
+				copy(pubKeys[i][:], []byte(strconv.Itoa(i)))
+			}
+
+			validatorDB := setupDB(t, pubKeys, tt.slashingProtectionType)
+
+			// For each public key, we attempt to save an attestation with signing root.
+			var wg sync.WaitGroup
+			for i, pubKey := range pubKeys {
+				wg.Add(1)
+				go func(j primitives.Epoch, pk [fieldparams.BLSPubkeyLength]byte, w *sync.WaitGroup) {
+					defer w.Done()
+					var signingRoot [32]byte
+					copy(signingRoot[:], fmt.Sprintf("%d", j))
+					att := createAttestation(j, j+1)
+					err := validatorDB.SaveAttestationForPubKey(ctx, pk, signingRoot, att)
+					require.NoError(t, err)
+				}(primitives.Epoch(i), pubKey, &wg)
+			}
+			wg.Wait()
+
+			// We verify that we reached the max capacity of batched attestations
+			// before we are required to force flush them to the DB.
+			require.LogsContain(t, hook, "Reached max capacity of batched attestation records")
+			require.LogsDoNotContain(t, hook, "Batched attestation records write interval reached")
+			require.LogsContain(t, hook, "Successfully flushed batched attestations to DB")
+			require.Equal(t, 0, validatorDB.batchedAttestations.Len())
+
+			// We then verify all the data we wanted to save is indeed saved to disk.
+			err := validatorDB.view(func(tx *bolt.Tx) error {
+				bucket := tx.Bucket(pubKeysBucket)
+				for i, pubKey := range pubKeys {
+					var signingRoot [32]byte
+					copy(signingRoot[:], fmt.Sprintf("%d", i))
+					pkBucket := bucket.Bucket(pubKey[:])
+					signingRootsBucket := pkBucket.Bucket(attestationSigningRootsBucket)
+					sourceEpochsBucket := pkBucket.Bucket(attestationSourceEpochsBucket)
+
+					source := bytesutil.Uint64ToBytesBigEndian(uint64(i))
+					target := bytesutil.Uint64ToBytesBigEndian(uint64(i) + 1)
+					savedSigningRoot := signingRootsBucket.Get(target)
+					require.DeepEqual(t, signingRoot[:], savedSigningRoot)
+					savedTarget := sourceEpochsBucket.Get(source)
+					require.DeepEqual(t, signingRoot[:], savedSigningRoot)
+					require.DeepEqual(t, target, savedTarget)
+				}
+				return nil
+			})
 			require.NoError(t, err)
-		}(primitives.Epoch(i), pubKey, &wg)
+		})
 	}
-	wg.Wait()
-
-	// We verify that we reached the max capacity of batched attestations
-	// before we are required to force flush them to the DB.
-	require.LogsContain(t, hook, "Reached max capacity of batched attestation records")
-	require.LogsDoNotContain(t, hook, "Batched attestation records write interval reached")
-	require.LogsContain(t, hook, "Successfully flushed batched attestations to DB")
-	require.Equal(t, 0, validatorDB.batchedAttestations.Len())
-
-	// We then verify all the data we wanted to save is indeed saved to disk.
-	err := validatorDB.view(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(pubKeysBucket)
-		for i, pubKey := range pubKeys {
-			var signingRoot [32]byte
-			copy(signingRoot[:], fmt.Sprintf("%d", i))
-			pkBucket := bucket.Bucket(pubKey[:])
-			signingRootsBucket := pkBucket.Bucket(attestationSigningRootsBucket)
-			sourceEpochsBucket := pkBucket.Bucket(attestationSourceEpochsBucket)
-
-			source := bytesutil.Uint64ToBytesBigEndian(uint64(i))
-			target := bytesutil.Uint64ToBytesBigEndian(uint64(i) + 1)
-			savedSigningRoot := signingRootsBucket.Get(target)
-			require.DeepEqual(t, signingRoot[:], savedSigningRoot)
-			savedTarget := sourceEpochsBucket.Get(source)
-			require.DeepEqual(t, signingRoot[:], savedSigningRoot)
-			require.DeepEqual(t, target, savedTarget)
-		}
-		return nil
-	})
-	require.NoError(t, err)
 }
 
 func TestSaveAttestationForPubKey_BatchWrites_LowCapacity_TimerReached(t *testing.T) {
-	hook := logTest.NewGlobal()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	// Number of validators equal to half the total capacity
-	// of batch attestation processing. This will allow us to
-	// test force flushing to the DB based on a timer instead
-	// of the max capacity being reached.
-	numValidators := attestationBatchCapacity / 2
-	pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
-	validatorDB := setupDB(t, pubKeys)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			hook := logTest.NewGlobal()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			// Number of validators equal to half the total capacity
+			// of batch attestation processing. This will allow us to
+			// test force flushing to the DB based on a timer instead
+			// of the max capacity being reached.
+			numValidators := attestationBatchCapacity / 2
 
-	// For each public key, we attempt to save an attestation with signing root.
-	var wg sync.WaitGroup
-	for i, pubKey := range pubKeys {
-		wg.Add(1)
-		go func(j primitives.Epoch, pk [fieldparams.BLSPubkeyLength]byte, w *sync.WaitGroup) {
-			defer w.Done()
-			var signingRoot [32]byte
-			copy(signingRoot[:], fmt.Sprintf("%d", j))
-			att := createAttestation(j, j+1)
-			err := validatorDB.SaveAttestationForPubKey(ctx, pk, signingRoot, att)
+			pubKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
+			for i := 0; i < numValidators; i++ {
+				copy(pubKeys[i][:], []byte(strconv.Itoa(i)))
+			}
+
+			validatorDB := setupDB(t, pubKeys, complete)
+
+			// For each public key, we attempt to save an attestation with signing root.
+			var wg sync.WaitGroup
+			for i, pubKey := range pubKeys {
+				wg.Add(1)
+				go func(j primitives.Epoch, pk [fieldparams.BLSPubkeyLength]byte, w *sync.WaitGroup) {
+					defer w.Done()
+					var signingRoot [32]byte
+					copy(signingRoot[:], fmt.Sprintf("%d", j))
+					att := createAttestation(j, j+1)
+					err := validatorDB.SaveAttestationForPubKey(ctx, pk, signingRoot, att)
+					require.NoError(t, err)
+				}(primitives.Epoch(i), pubKey, &wg)
+			}
+			wg.Wait()
+
+			// We verify that we reached a timer interval for force flushing records
+			// before we are required to force flush them to the DB.
+			require.LogsDoNotContain(t, hook, "Reached max capacity of batched attestation records")
+			require.LogsContain(t, hook, "Batched attestation records write interval reached")
+			require.LogsContain(t, hook, "Successfully flushed batched attestations to DB")
+			require.Equal(t, 0, validatorDB.batchedAttestations.Len())
+
+			// We then verify all the data we wanted to save is indeed saved to disk.
+			err := validatorDB.view(func(tx *bolt.Tx) error {
+				bucket := tx.Bucket(pubKeysBucket)
+				for i, pubKey := range pubKeys {
+					var signingRoot [32]byte
+					copy(signingRoot[:], fmt.Sprintf("%d", i))
+					pkBucket := bucket.Bucket(pubKey[:])
+					signingRootsBucket := pkBucket.Bucket(attestationSigningRootsBucket)
+					sourceEpochsBucket := pkBucket.Bucket(attestationSourceEpochsBucket)
+
+					source := bytesutil.Uint64ToBytesBigEndian(uint64(i))
+					target := bytesutil.Uint64ToBytesBigEndian(uint64(i) + 1)
+					savedSigningRoot := signingRootsBucket.Get(target)
+					require.DeepEqual(t, signingRoot[:], savedSigningRoot)
+					savedTarget := sourceEpochsBucket.Get(source)
+					require.DeepEqual(t, signingRoot[:], savedSigningRoot)
+					require.DeepEqual(t, target, savedTarget)
+				}
+				return nil
+			})
 			require.NoError(t, err)
-		}(primitives.Epoch(i), pubKey, &wg)
+		})
 	}
-	wg.Wait()
-
-	// We verify that we reached a timer interval for force flushing records
-	// before we are required to force flush them to the DB.
-	require.LogsDoNotContain(t, hook, "Reached max capacity of batched attestation records")
-	require.LogsContain(t, hook, "Batched attestation records write interval reached")
-	require.LogsContain(t, hook, "Successfully flushed batched attestations to DB")
-	require.Equal(t, 0, validatorDB.batchedAttestations.Len())
-
-	// We then verify all the data we wanted to save is indeed saved to disk.
-	err := validatorDB.view(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(pubKeysBucket)
-		for i, pubKey := range pubKeys {
-			var signingRoot [32]byte
-			copy(signingRoot[:], fmt.Sprintf("%d", i))
-			pkBucket := bucket.Bucket(pubKey[:])
-			signingRootsBucket := pkBucket.Bucket(attestationSigningRootsBucket)
-			sourceEpochsBucket := pkBucket.Bucket(attestationSourceEpochsBucket)
-
-			source := bytesutil.Uint64ToBytesBigEndian(uint64(i))
-			target := bytesutil.Uint64ToBytesBigEndian(uint64(i) + 1)
-			savedSigningRoot := signingRootsBucket.Get(target)
-			require.DeepEqual(t, signingRoot[:], savedSigningRoot)
-			savedTarget := sourceEpochsBucket.Get(source)
-			require.DeepEqual(t, signingRoot[:], savedSigningRoot)
-			require.DeepEqual(t, target, savedTarget)
-		}
-		return nil
-	})
-	require.NoError(t, err)
 }
 
 func BenchmarkStore_CheckSlashableAttestation_Surround_SafeAttestation_54kEpochs(b *testing.B) {

--- a/validator/db/kv/backup_test.go
+++ b/validator/db/kv/backup_test.go
@@ -12,109 +12,117 @@ import (
 )
 
 func TestStore_Backup(t *testing.T) {
-	db := setupDB(t, nil)
-	ctx := context.Background()
-	root := [32]byte{1}
-	require.NoError(t, db.SaveGenesisValidatorsRoot(ctx, root[:]))
-	require.NoError(t, db.Backup(ctx, "", true))
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			db := setupDB(t, nil, tt.slashingProtectionType)
+			ctx := context.Background()
+			root := [32]byte{1}
+			require.NoError(t, db.SaveGenesisValidatorsRoot(ctx, root[:]))
+			require.NoError(t, db.Backup(ctx, "", true))
 
-	backupsPath := filepath.Join(db.databasePath, backupsDirectoryName)
-	files, err := os.ReadDir(backupsPath)
-	require.NoError(t, err)
-	require.NotEqual(t, 0, len(files), "No backups created")
-	require.NoError(t, db.Close(), "Failed to close database")
+			backupsPath := filepath.Join(db.databasePath, backupsDirectoryName)
+			files, err := os.ReadDir(backupsPath)
+			require.NoError(t, err)
+			require.NotEqual(t, 0, len(files), "No backups created")
+			require.NoError(t, db.Close(), "Failed to close database")
 
-	oldFilePath := filepath.Join(backupsPath, files[0].Name())
-	newFilePath := filepath.Join(backupsPath, ProtectionDbFileName)
-	// We rename the file to match the database file name
-	// our NewKVStore function expects when opening a database.
-	require.NoError(t, os.Rename(oldFilePath, newFilePath))
+			oldFilePath := filepath.Join(backupsPath, files[0].Name())
+			newFilePath := filepath.Join(backupsPath, ProtectionDbFileName)
+			// We rename the file to match the database file name
+			// our NewKVStore function expects when opening a database.
+			require.NoError(t, os.Rename(oldFilePath, newFilePath))
 
-	backedDB, err := NewKVStore(ctx, backupsPath, &Config{})
-	require.NoError(t, err, "Failed to instantiate DB")
-	t.Cleanup(func() {
-		require.NoError(t, backedDB.Close(), "Failed to close database")
-	})
-	genesisRoot, err := backedDB.GenesisValidatorsRoot(ctx)
-	require.NoError(t, err)
-	require.DeepEqual(t, root[:], genesisRoot)
+			backedDB, err := NewKVStore(ctx, backupsPath, &Config{SlashingProtectionType: tt.slashingProtectionType})
+			require.NoError(t, err, "Failed to instantiate DB")
+			t.Cleanup(func() {
+				require.NoError(t, backedDB.Close(), "Failed to close database")
+			})
+			genesisRoot, err := backedDB.GenesisValidatorsRoot(ctx)
+			require.NoError(t, err)
+			require.DeepEqual(t, root[:], genesisRoot)
+		})
+	}
 }
 
 func TestStore_NestedBackup(t *testing.T) {
-	keys := [][fieldparams.BLSPubkeyLength]byte{{'A'}, {'B'}}
-	db := setupDB(t, keys)
-	ctx := context.Background()
-	root := [32]byte{1}
-	idxAtt := &ethpb.IndexedAttestation{
-		AttestingIndices: nil,
-		Data: &ethpb.AttestationData{
-			Slot:            0,
-			CommitteeIndex:  0,
-			BeaconBlockRoot: root[:],
-			Source: &ethpb.Checkpoint{
-				Epoch: 10,
-				Root:  root[:],
-			},
-			Target: &ethpb.Checkpoint{
-				Epoch: 0,
-				Root:  root[:],
-			},
-		},
-		Signature: make([]byte, 96),
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			keys := [][fieldparams.BLSPubkeyLength]byte{{'A'}, {'B'}}
+			db := setupDB(t, keys, tt.slashingProtectionType)
+			ctx := context.Background()
+			root := [32]byte{1}
+			idxAtt := &ethpb.IndexedAttestation{
+				AttestingIndices: nil,
+				Data: &ethpb.AttestationData{
+					Slot:            0,
+					CommitteeIndex:  0,
+					BeaconBlockRoot: root[:],
+					Source: &ethpb.Checkpoint{
+						Epoch: 10,
+						Root:  root[:],
+					},
+					Target: &ethpb.Checkpoint{
+						Epoch: 0,
+						Root:  root[:],
+					},
+				},
+				Signature: make([]byte, 96),
+			}
+			require.NoError(t, db.SaveGenesisValidatorsRoot(ctx, root[:]))
+			require.NoError(t, db.SaveAttestationForPubKey(context.Background(), keys[0], [32]byte{'C'}, idxAtt))
+			require.NoError(t, db.SaveAttestationForPubKey(context.Background(), keys[1], [32]byte{'C'}, idxAtt))
+			require.NoError(t, db.Backup(ctx, "", true))
+
+			backupsPath := filepath.Join(db.databasePath, backupsDirectoryName)
+			files, err := os.ReadDir(backupsPath)
+			require.NoError(t, err)
+			require.NotEqual(t, 0, len(files), "No backups created")
+			require.NoError(t, db.Close(), "Failed to close database")
+
+			oldFilePath := filepath.Join(backupsPath, files[0].Name())
+			newFilePath := filepath.Join(backupsPath, ProtectionDbFileName)
+			// We rename the file to match the database file name
+			// our NewKVStore function expects when opening a database.
+			require.NoError(t, os.Rename(oldFilePath, newFilePath))
+
+			backedDB, err := NewKVStore(ctx, backupsPath, &Config{SlashingProtectionType: tt.slashingProtectionType})
+			require.NoError(t, err, "Failed to instantiate DB")
+			t.Cleanup(func() {
+				require.NoError(t, backedDB.Close(), "Failed to close database")
+			})
+			genesisRoot, err := backedDB.GenesisValidatorsRoot(ctx)
+			require.NoError(t, err)
+			require.DeepEqual(t, root[:], genesisRoot)
+
+			signingRoot32 := [32]byte{'C'}
+
+			hist, err := backedDB.AttestationHistoryForPubKey(context.Background(), keys[0])
+			require.NoError(t, err)
+			require.DeepEqual(t, &AttestationRecord{
+				PubKey:      keys[0],
+				Source:      10,
+				Target:      0,
+				SigningRoot: signingRoot32[:],
+			}, hist[0])
+
+			hist, err = backedDB.AttestationHistoryForPubKey(context.Background(), keys[1])
+			require.NoError(t, err)
+			require.DeepEqual(t, &AttestationRecord{
+				PubKey:      keys[1],
+				Source:      10,
+				Target:      0,
+				SigningRoot: signingRoot32[:],
+			}, hist[0])
+
+			ep, exists, err := backedDB.LowestSignedSourceEpoch(context.Background(), keys[0])
+			require.NoError(t, err)
+			require.Equal(t, true, exists)
+			require.Equal(t, 10, int(ep))
+
+			ep, exists, err = backedDB.LowestSignedSourceEpoch(context.Background(), keys[1])
+			require.NoError(t, err)
+			require.Equal(t, true, exists)
+			require.Equal(t, 10, int(ep))
+		})
 	}
-	require.NoError(t, db.SaveGenesisValidatorsRoot(ctx, root[:]))
-	require.NoError(t, db.SaveAttestationForPubKey(context.Background(), keys[0], [32]byte{'C'}, idxAtt))
-	require.NoError(t, db.SaveAttestationForPubKey(context.Background(), keys[1], [32]byte{'C'}, idxAtt))
-	require.NoError(t, db.Backup(ctx, "", true))
-
-	backupsPath := filepath.Join(db.databasePath, backupsDirectoryName)
-	files, err := os.ReadDir(backupsPath)
-	require.NoError(t, err)
-	require.NotEqual(t, 0, len(files), "No backups created")
-	require.NoError(t, db.Close(), "Failed to close database")
-
-	oldFilePath := filepath.Join(backupsPath, files[0].Name())
-	newFilePath := filepath.Join(backupsPath, ProtectionDbFileName)
-	// We rename the file to match the database file name
-	// our NewKVStore function expects when opening a database.
-	require.NoError(t, os.Rename(oldFilePath, newFilePath))
-
-	backedDB, err := NewKVStore(ctx, backupsPath, &Config{})
-	require.NoError(t, err, "Failed to instantiate DB")
-	t.Cleanup(func() {
-		require.NoError(t, backedDB.Close(), "Failed to close database")
-	})
-	genesisRoot, err := backedDB.GenesisValidatorsRoot(ctx)
-	require.NoError(t, err)
-	require.DeepEqual(t, root[:], genesisRoot)
-
-	signingRoot32 := [32]byte{'C'}
-
-	hist, err := backedDB.AttestationHistoryForPubKey(context.Background(), keys[0])
-	require.NoError(t, err)
-	require.DeepEqual(t, &AttestationRecord{
-		PubKey:      keys[0],
-		Source:      10,
-		Target:      0,
-		SigningRoot: signingRoot32[:],
-	}, hist[0])
-
-	hist, err = backedDB.AttestationHistoryForPubKey(context.Background(), keys[1])
-	require.NoError(t, err)
-	require.DeepEqual(t, &AttestationRecord{
-		PubKey:      keys[1],
-		Source:      10,
-		Target:      0,
-		SigningRoot: signingRoot32[:],
-	}, hist[0])
-
-	ep, exists, err := backedDB.LowestSignedSourceEpoch(context.Background(), keys[0])
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	require.Equal(t, 10, int(ep))
-
-	ep, exists, err = backedDB.LowestSignedSourceEpoch(context.Background(), keys[1])
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	require.Equal(t, 10, int(ep))
 }

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -218,3 +218,9 @@ func (s *Store) Size() (int64, error) {
 func createBoltCollector(db *bolt.DB) prometheus.Collector {
 	return prombolt.New("boltDB", db, blockedBuckets...)
 }
+
+func emptyBucket(bucket *bolt.Bucket) error {
+	return bucket.ForEach(func(k, _ []byte) error {
+		return bucket.Delete(k)
+	})
+}

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -142,8 +142,8 @@ func NewKVStore(ctx context.Context, dirPath string, config *Config) (*Store, er
 		return createBuckets(
 			tx,
 			genesisInfoBucket,
-			deprecatedAttestationHistoryBucket,
 			historicProposalsBucket,
+			deprecatedAttestationHistoryBucket,
 			lowestSignedSourceBucket,
 			lowestSignedTargetBucket,
 			lowestSignedProposalsBucket,

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -71,7 +71,7 @@ type Store struct {
 	databasePath                       string
 }
 
-// Slashing protection type, as defined in EIP-3076.
+// SlashingProtectionType defines slashing protection type, as defined in EIP-3076.
 // https://eips.ethereum.org/EIPS/eip-3076
 type SlashingProtectionType uint8
 
@@ -236,7 +236,7 @@ func emptyBucket(bucket *bolt.Bucket) error {
 	})
 }
 
-// isSlashingProtectionMinmal returns true if the slashing protection type is minimal, and false otherwise (as defined in EIP-3076).
+// IsSlashingProtectionMinimal returns true if the slashing protection type is minimal, and false otherwise (as defined in EIP-3076).
 // The slashing protection type is minimal if:
 // 1. proposal-history-bucket-interchange -> <pubkey> -> <slot> contains only one <slot> per <pubkey>
 // 2. pubkeys-bucket --> <pubkey> --> att-signing-roots-bucket --> <target epoch> contains only one <target epoch> per <pubkey>, and

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -76,8 +76,8 @@ type Store struct {
 type SlashingProtectionType uint8
 
 const (
-	complete SlashingProtectionType = iota
-	minimal
+	Complete SlashingProtectionType = iota
+	Minimal
 )
 
 // Close closes the underlying boltdb database.

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -112,6 +112,11 @@ func (s *Store) SlashingProtectionType() SlashingProtectionType {
 	return s.slashingProtectionType
 }
 
+// SaveSlashingProtectionType saves the slashing protection type.
+func (s *Store) SaveSlashingProtectionType(spt SlashingProtectionType) {
+	s.slashingProtectionType = spt
+}
+
 func createBuckets(tx *bolt.Tx, buckets ...[]byte) error {
 	for _, bucket := range buckets {
 		if _, err := tx.CreateBucketIfNotExists(bucket); err != nil {

--- a/validator/db/kv/db.go
+++ b/validator/db/kv/db.go
@@ -107,6 +107,11 @@ func (s *Store) DatabasePath() string {
 	return s.databasePath
 }
 
+// SlashingProtectionType returns the slashing protection type.
+func (s *Store) SlashingProtectionType() SlashingProtectionType {
+	return s.slashingProtectionType
+}
+
 func createBuckets(tx *bolt.Tx, buckets ...[]byte) error {
 	for _, bucket := range buckets {
 		if _, err := tx.CreateBucketIfNotExists(bucket); err != nil {

--- a/validator/db/kv/db_test.go
+++ b/validator/db/kv/db_test.go
@@ -1,0 +1,204 @@
+package kv
+
+import (
+	"context"
+	"testing"
+
+	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
+	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/testing/require"
+)
+
+type ProposalsWithPubKey struct {
+	pubkey    [fieldparams.BLSPubkeyLength]byte
+	proposals []Proposal
+}
+
+type AttestationWithSigningRoot struct {
+	signingRoot [fieldparams.RootLength]byte
+	attestation *ethpb.IndexedAttestation
+}
+
+type AttestationsWithPubKey struct {
+	pubkey       [fieldparams.BLSPubkeyLength]byte
+	attestations []AttestationWithSigningRoot
+}
+
+func TestStore_IsSlashingProtectionMinimal(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		shoudBeMinimal          bool
+		proposalsWithPubkeys    []ProposalsWithPubKey
+		attestationsWithPubkeys []AttestationsWithPubKey
+	}{
+		{
+			name:                    "empty database",
+			shoudBeMinimal:          true,
+			proposalsWithPubkeys:    []ProposalsWithPubKey{},
+			attestationsWithPubkeys: []AttestationsWithPubKey{},
+		},
+		{
+			name:           "one key with multiple proposals",
+			shoudBeMinimal: false,
+			proposalsWithPubkeys: []ProposalsWithPubKey{
+				{
+					pubkey: [fieldparams.BLSPubkeyLength]byte{1},
+					proposals: []Proposal{
+						{
+							Slot:        1,
+							SigningRoot: []byte{1},
+						},
+						{
+							Slot:        2,
+							SigningRoot: []byte{2},
+						},
+					},
+				},
+			},
+			attestationsWithPubkeys: []AttestationsWithPubKey{},
+		},
+		{
+			name:                 "one key with multiple signing roots for attestations",
+			shoudBeMinimal:       false,
+			proposalsWithPubkeys: []ProposalsWithPubKey{},
+			attestationsWithPubkeys: []AttestationsWithPubKey{
+				{
+					pubkey: [fieldparams.BLSPubkeyLength]byte{1},
+					attestations: []AttestationWithSigningRoot{
+						{
+							signingRoot: [fieldparams.RootLength]byte{1},
+							attestation: &ethpb.IndexedAttestation{
+								Data: &ethpb.AttestationData{
+									Slot: 1,
+									Source: &ethpb.Checkpoint{
+										Epoch: 1,
+										Root:  []byte{1},
+									},
+									Target: &ethpb.Checkpoint{
+										Epoch: 2,
+										Root:  []byte{2},
+									},
+								},
+							},
+						},
+						{
+							signingRoot: [fieldparams.RootLength]byte{1},
+							attestation: &ethpb.IndexedAttestation{
+								Data: &ethpb.AttestationData{
+									Slot: 100,
+									Source: &ethpb.Checkpoint{
+										Epoch: 2,
+										Root:  []byte{1},
+									},
+									Target: &ethpb.Checkpoint{
+										Epoch: 3,
+										Root:  []byte{2},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:           "minimal database",
+			shoudBeMinimal: true,
+			proposalsWithPubkeys: []ProposalsWithPubKey{
+				{
+					pubkey: [fieldparams.BLSPubkeyLength]byte{1},
+					proposals: []Proposal{
+						{
+							Slot:        1,
+							SigningRoot: []byte{1},
+						},
+					},
+				},
+				{
+					pubkey: [fieldparams.BLSPubkeyLength]byte{2},
+					proposals: []Proposal{
+						{
+							Slot:        1,
+							SigningRoot: []byte{1},
+						},
+					},
+				},
+			},
+			attestationsWithPubkeys: []AttestationsWithPubKey{
+				{
+					pubkey: [fieldparams.BLSPubkeyLength]byte{1},
+					attestations: []AttestationWithSigningRoot{
+						{
+							signingRoot: [fieldparams.RootLength]byte{1},
+							attestation: &ethpb.IndexedAttestation{
+								Data: &ethpb.AttestationData{
+									Slot: 1,
+									Source: &ethpb.Checkpoint{
+										Epoch: 1,
+										Root:  []byte{1},
+									},
+									Target: &ethpb.Checkpoint{
+										Epoch: 2,
+										Root:  []byte{2},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					pubkey: [fieldparams.BLSPubkeyLength]byte{2},
+					attestations: []AttestationWithSigningRoot{
+						{
+							signingRoot: [fieldparams.RootLength]byte{1},
+							attestation: &ethpb.IndexedAttestation{
+								Data: &ethpb.AttestationData{
+									Slot: 1,
+									Source: &ethpb.Checkpoint{
+										Epoch: 1,
+										Root:  []byte{1},
+									},
+									Target: &ethpb.Checkpoint{
+										Epoch: 2,
+										Root:  []byte{2},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup database
+			s := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{}, Complete)
+
+			// Save proposals
+			for _, ps := range tt.proposalsWithPubkeys {
+				pk := ps.pubkey
+				for _, p := range ps.proposals {
+					err := s.SaveProposalHistoryForSlot(context.Background(), pk, p.Slot, p.SigningRoot)
+					require.NoError(t, err, "Failed to save proposal history for slot")
+				}
+			}
+
+			// Save attestations
+			for _, at := range tt.attestationsWithPubkeys {
+				pk := at.pubkey
+				for _, a := range at.attestations {
+					err := s.SaveAttestationForPubKey(context.Background(), pk, a.signingRoot, a.attestation)
+					require.NoError(t, err, "Failed to save attestation for pubkey")
+				}
+			}
+
+			// Check if the database is minimal
+			isMinimal, err := IsSlashingProtectionMinimal(s)
+			require.NoError(t, err, "Failed to check if database is minimal")
+
+			require.Equal(t, tt.shoudBeMinimal, isMinimal)
+		})
+	}
+}

--- a/validator/db/kv/eip_blacklisted_keys_test.go
+++ b/validator/db/kv/eip_blacklisted_keys_test.go
@@ -11,34 +11,38 @@ import (
 )
 
 func TestStore_EIPBlacklistedPublicKeys(t *testing.T) {
-	ctx := context.Background()
-	numValidators := 100
-	publicKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
-	for i := 0; i < numValidators; i++ {
-		var key [fieldparams.BLSPubkeyLength]byte
-		copy(key[:], fmt.Sprintf("%d", i))
-		publicKeys[i] = key
-	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			numValidators := 100
+			publicKeys := make([][fieldparams.BLSPubkeyLength]byte, numValidators)
+			for i := 0; i < numValidators; i++ {
+				var key [fieldparams.BLSPubkeyLength]byte
+				copy(key[:], fmt.Sprintf("%d", i))
+				publicKeys[i] = key
+			}
 
-	// No blacklisted keys returns empty.
-	validatorDB := setupDB(t, publicKeys)
-	received, err := validatorDB.EIPImportBlacklistedPublicKeys(ctx)
-	require.NoError(t, err)
-	assert.Equal(t, 0, len(received))
+			// No blacklisted keys returns empty.
+			validatorDB := setupDB(t, publicKeys, tt.slashingProtectionType)
+			received, err := validatorDB.EIPImportBlacklistedPublicKeys(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, 0, len(received))
 
-	// Save half of the public keys as as blacklisted and attempt to retrieve.
-	err = validatorDB.SaveEIPImportBlacklistedPublicKeys(ctx, publicKeys[:50])
-	require.NoError(t, err)
-	received, err = validatorDB.EIPImportBlacklistedPublicKeys(ctx)
-	require.NoError(t, err)
+			// Save half of the public keys as as blacklisted and attempt to retrieve.
+			err = validatorDB.SaveEIPImportBlacklistedPublicKeys(ctx, publicKeys[:50])
+			require.NoError(t, err)
+			received, err = validatorDB.EIPImportBlacklistedPublicKeys(ctx)
+			require.NoError(t, err)
 
-	// Keys are not guaranteed to be ordered, so we create a map for comparisons.
-	want := make(map[[fieldparams.BLSPubkeyLength]byte]bool)
-	for _, pubKey := range publicKeys[:50] {
-		want[pubKey] = true
-	}
-	for _, pubKey := range received {
-		ok := want[pubKey]
-		require.Equal(t, true, ok)
+			// Keys are not guaranteed to be ordered, so we create a map for comparisons.
+			want := make(map[[fieldparams.BLSPubkeyLength]byte]bool)
+			for _, pubKey := range publicKeys[:50] {
+				want[pubKey] = true
+			}
+			for _, pubKey := range received {
+				ok := want[pubKey]
+				require.Equal(t, true, ok)
+			}
+		})
 	}
 }

--- a/validator/db/kv/graffiti_test.go
+++ b/validator/db/kv/graffiti_test.go
@@ -2,6 +2,7 @@ package kv
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
@@ -11,8 +12,8 @@ import (
 
 func TestStore_GraffitiOrderedIndex_ReadAndWrite(t *testing.T) {
 	ctx := context.Background()
-	db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
-	tests := []struct {
+	db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{}, complete)
+	subTests := []struct {
 		name     string
 		want     uint64
 		write    uint64
@@ -48,13 +49,15 @@ func TestStore_GraffitiOrderedIndex_ReadAndWrite(t *testing.T) {
 			fileHash: hash.Hash([]byte("two")),
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := db.GraffitiOrderedIndex(ctx, tt.fileHash)
-			require.NoError(t, err)
-			require.DeepEqual(t, tt.want, got)
-			err = db.SaveGraffitiOrderedIndex(ctx, tt.write)
-			require.NoError(t, err)
-		})
+	for _, tt := range testCases {
+		for _, st := range subTests {
+			t.Run(fmt.Sprintf("%s - %s", tt.name, st.name), func(t *testing.T) {
+				got, err := db.GraffitiOrderedIndex(ctx, st.fileHash)
+				require.NoError(t, err)
+				require.DeepEqual(t, st.want, got)
+				err = db.SaveGraffitiOrderedIndex(ctx, st.write)
+				require.NoError(t, err)
+			})
+		}
 	}
 }

--- a/validator/db/kv/graffiti_test.go
+++ b/validator/db/kv/graffiti_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestStore_GraffitiOrderedIndex_ReadAndWrite(t *testing.T) {
 	ctx := context.Background()
-	db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{}, complete)
+	db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{}, Complete)
 	subTests := []struct {
 		name     string
 		want     uint64

--- a/validator/db/kv/kv_test.go
+++ b/validator/db/kv/kv_test.go
@@ -37,6 +37,6 @@ var testCases = []struct {
 	name                   string
 	slashingProtectionType SlashingProtectionType
 }{
-	{name: "complete", slashingProtectionType: complete},
-	{name: "minimal", slashingProtectionType: minimal},
+	{name: "complete", slashingProtectionType: Complete},
+	{name: "minimal", slashingProtectionType: Minimal},
 }

--- a/validator/db/kv/kv_test.go
+++ b/validator/db/kv/kv_test.go
@@ -18,9 +18,10 @@ func TestMain(m *testing.M) {
 }
 
 // setupDB instantiates and returns a DB instance for the validator client.
-func setupDB(t testing.TB, pubkeys [][fieldparams.BLSPubkeyLength]byte) *Store {
+func setupDB(t testing.TB, pubkeys [][fieldparams.BLSPubkeyLength]byte, slashingProtectionType SlashingProtectionType) *Store {
 	db, err := NewKVStore(context.Background(), t.TempDir(), &Config{
-		PubKeys: pubkeys,
+		PubKeys:                pubkeys,
+		SlashingProtectionType: slashingProtectionType,
 	})
 	require.NoError(t, err, "Failed to instantiate DB")
 	err = db.UpdatePublicKeysBuckets(pubkeys)
@@ -30,4 +31,12 @@ func setupDB(t testing.TB, pubkeys [][fieldparams.BLSPubkeyLength]byte) *Store {
 		require.NoError(t, db.ClearDB(), "Failed to clear database")
 	})
 	return db
+}
+
+var testCases = []struct {
+	name                   string
+	slashingProtectionType SlashingProtectionType
+}{
+	{name: "complete", slashingProtectionType: complete},
+	{name: "minimal", slashingProtectionType: minimal},
 }

--- a/validator/db/kv/migration_optimal_attester_protection_test.go
+++ b/validator/db/kv/migration_optimal_attester_protection_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_migrateOptimalAttesterProtectionUp(t *testing.T) {
-	tests := []struct {
+	subTests := []struct {
 		name  string
 		setup func(t *testing.T, validatorDB *Store)
 		eval  func(t *testing.T, validatorDB *Store)
@@ -180,18 +180,20 @@ func Test_migrateOptimalAttesterProtectionUp(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			validatorDB := setupDB(t, nil)
-			tt.setup(t, validatorDB)
-			require.NoError(t, validatorDB.migrateOptimalAttesterProtectionUp(context.Background()))
-			tt.eval(t, validatorDB)
-		})
+	for _, tt := range testCases {
+		for _, st := range subTests {
+			t.Run(fmt.Sprintf("%s - %s", tt.name, st.name), func(t *testing.T) {
+				validatorDB := setupDB(t, nil, tt.slashingProtectionType)
+				st.setup(t, validatorDB)
+				require.NoError(t, validatorDB.migrateOptimalAttesterProtectionUp(context.Background()))
+				st.eval(t, validatorDB)
+			})
+		}
 	}
 }
 
 func Test_migrateOptimalAttesterProtectionDown(t *testing.T) {
-	tests := []struct {
+	subTests := []struct {
 		name  string
 		setup func(t *testing.T, validatorDB *Store)
 		eval  func(t *testing.T, validatorDB *Store)
@@ -289,12 +291,14 @@ func Test_migrateOptimalAttesterProtectionDown(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			validatorDB := setupDB(t, nil)
-			tt.setup(t, validatorDB)
-			require.NoError(t, validatorDB.migrateOptimalAttesterProtectionDown(context.Background()))
-			tt.eval(t, validatorDB)
-		})
+	for _, tt := range testCases {
+		for _, st := range subTests {
+			t.Run(fmt.Sprintf("%s - %s", tt.name, st.name), func(t *testing.T) {
+				validatorDB := setupDB(t, nil, tt.slashingProtectionType)
+				st.setup(t, validatorDB)
+				require.NoError(t, validatorDB.migrateOptimalAttesterProtectionDown(context.Background()))
+				st.eval(t, validatorDB)
+			})
+		}
 	}
 }

--- a/validator/db/kv/migration_source_target_epochs_bucket_test.go
+++ b/validator/db/kv/migration_source_target_epochs_bucket_test.go
@@ -24,7 +24,7 @@ func TestStore_migrateSourceTargetEpochsBucketUp(t *testing.T) {
 		copy(pk[:], fmt.Sprintf("%d", i))
 		pubKeys[i] = pk
 	}
-	tests := []struct {
+	subTests := []struct {
 		name  string
 		setup func(t *testing.T, validatorDB *Store)
 		eval  func(t *testing.T, validatorDB *Store)
@@ -105,13 +105,15 @@ func TestStore_migrateSourceTargetEpochsBucketUp(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			validatorDB := setupDB(t, pubKeys)
-			tt.setup(t, validatorDB)
-			require.NoError(t, validatorDB.migrateSourceTargetEpochsBucketUp(context.Background()))
-			tt.eval(t, validatorDB)
-		})
+	for _, tt := range testCases {
+		for _, st := range subTests {
+			t.Run(fmt.Sprintf("%s - %s", tt.name, st.name), func(t *testing.T) {
+				validatorDB := setupDB(t, pubKeys, tt.slashingProtectionType)
+				st.setup(t, validatorDB)
+				require.NoError(t, validatorDB.migrateSourceTargetEpochsBucketUp(context.Background()))
+				st.eval(t, validatorDB)
+			})
+		}
 	}
 }
 
@@ -125,7 +127,7 @@ func TestStore_migrateSourceTargetEpochsBucketDown(t *testing.T) {
 		copy(pk[:], fmt.Sprintf("%d", i))
 		pubKeys[i] = pk
 	}
-	tests := []struct {
+	subTests := []struct {
 		name  string
 		setup func(t *testing.T, validatorDB *Store)
 		eval  func(t *testing.T, validatorDB *Store)
@@ -200,13 +202,15 @@ func TestStore_migrateSourceTargetEpochsBucketDown(t *testing.T) {
 			},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			validatorDB := setupDB(t, nil)
-			tt.setup(t, validatorDB)
-			require.NoError(t, validatorDB.migrateSourceTargetEpochsBucketDown(context.Background()))
-			tt.eval(t, validatorDB)
-		})
+	for _, tt := range testCases {
+		for _, st := range subTests {
+			t.Run(fmt.Sprintf("%s - %s", tt.name, st.name), func(t *testing.T) {
+				validatorDB := setupDB(t, nil, tt.slashingProtectionType)
+				st.setup(t, validatorDB)
+				require.NoError(t, validatorDB.migrateSourceTargetEpochsBucketDown(context.Background()))
+				st.eval(t, validatorDB)
+			})
+		}
 	}
 }
 

--- a/validator/db/kv/proposer_protection.go
+++ b/validator/db/kv/proposer_protection.go
@@ -124,7 +124,7 @@ func (s *Store) SaveProposalHistoryForSlot(ctx context.Context, pubKey [fieldpar
 
 		lowestSignedBkt := tx.Bucket(lowestSignedProposalsBucket)
 
-		if s.slashingProtectionType == minimal {
+		if s.slashingProtectionType == Minimal {
 			if err := lowestSignedBkt.Put(pubKey[:], bytesutil.SlotToBytesBigEndian(slot)); err != nil {
 				return errors.Wrapf(err, "could not put lowest signed proposal for slot %d", slot)
 			}
@@ -146,7 +146,7 @@ func (s *Store) SaveProposalHistoryForSlot(ctx context.Context, pubKey [fieldpar
 
 		highestSignedBkt := tx.Bucket(highestSignedProposalsBucket)
 
-		if s.slashingProtectionType == minimal {
+		if s.slashingProtectionType == Minimal {
 			if err := highestSignedBkt.Put(pubKey[:], bytesutil.SlotToBytesBigEndian(slot)); err != nil {
 				return errors.Wrapf(err, "could not put highest signed proposal for slot %d", slot)
 			}
@@ -166,7 +166,7 @@ func (s *Store) SaveProposalHistoryForSlot(ctx context.Context, pubKey [fieldpar
 			}
 		}
 
-		if s.slashingProtectionType == minimal {
+		if s.slashingProtectionType == Minimal {
 			if err := emptyBucket(valBucket); err != nil {
 				return errors.Wrapf(err, "could not empty pubkey bucket")
 			}
@@ -176,7 +176,7 @@ func (s *Store) SaveProposalHistoryForSlot(ctx context.Context, pubKey [fieldpar
 			return err
 		}
 
-		if s.slashingProtectionType == complete {
+		if s.slashingProtectionType == Complete {
 			if err := pruneProposalHistoryBySlot(valBucket, slot); err != nil {
 				return errors.Wrapf(err, "could not prune proposal history for slot %d", slot)
 			}

--- a/validator/db/kv/proposer_protection_test.go
+++ b/validator/db/kv/proposer_protection_test.go
@@ -177,7 +177,7 @@ func TestPruneProposalHistoryBySlot_OK(t *testing.T) {
 	signedRoot := bytesutil.PadTo([]byte{1}, 32)
 
 	for _, st := range tests {
-		db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubKey}, complete)
+		db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubKey}, Complete)
 		for _, slot := range st.slots {
 			err := db.SaveProposalHistoryForSlot(context.Background(), pubKey, slot, signedRoot)
 			require.NoError(t, err, "Saving proposal history failed")
@@ -253,7 +253,7 @@ func TestStore_LowestSignedProposal(t *testing.T) {
 			err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 3 /* slot */, dummySigningRoot[:])
 			require.NoError(t, err)
 
-			if tt.slashingProtectionType == complete {
+			if tt.slashingProtectionType == Complete {
 				// We expect the lowest signed slot did not change.
 				slot, exists, err = validatorDB.LowestSignedProposal(ctx, pubkey)
 				require.NoError(t, err)
@@ -306,7 +306,7 @@ func TestStore_HighestSignedProposal(t *testing.T) {
 			err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 1 /* slot */, dummySigningRoot[:])
 			require.NoError(t, err)
 
-			if tt.slashingProtectionType == complete {
+			if tt.slashingProtectionType == Complete {
 				// We expect the lowest signed slot did not change.
 				slot, exists, err = validatorDB.HighestSignedProposal(ctx, pubkey)
 				require.NoError(t, err)

--- a/validator/db/kv/proposer_protection_test.go
+++ b/validator/db/kv/proposer_protection_test.go
@@ -13,116 +13,124 @@ import (
 )
 
 func TestNewProposalHistoryForSlot_ReturnsNilIfNoHistory(t *testing.T) {
-	valPubkey := [fieldparams.BLSPubkeyLength]byte{1, 2, 3}
-	db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			valPubkey := [fieldparams.BLSPubkeyLength]byte{1, 2, 3}
+			db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{}, tt.slashingProtectionType)
 
-	_, proposalExists, signingRootExists, err := db.ProposalHistoryForSlot(context.Background(), valPubkey, 0)
-	require.NoError(t, err)
-	assert.Equal(t, false, proposalExists)
-	assert.Equal(t, false, signingRootExists)
+			_, proposalExists, signingRootExists, err := db.ProposalHistoryForSlot(context.Background(), valPubkey, 0)
+			require.NoError(t, err)
+			assert.Equal(t, false, proposalExists)
+			assert.Equal(t, false, signingRootExists)
+		})
+	}
 }
 
 func TestProposalHistoryForSlot_InitializesNewPubKeys(t *testing.T) {
-	pubkeys := [][fieldparams.BLSPubkeyLength]byte{{30}, {25}, {20}}
-	db := setupDB(t, pubkeys)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			pubkeys := [][fieldparams.BLSPubkeyLength]byte{{30}, {25}, {20}}
+			db := setupDB(t, pubkeys, tt.slashingProtectionType)
 
-	for _, pub := range pubkeys {
-		_, proposalExists, signingRootExists, err := db.ProposalHistoryForSlot(context.Background(), pub, 0)
-		require.NoError(t, err)
-		assert.Equal(t, false, proposalExists)
-		assert.Equal(t, false, signingRootExists)
+			for _, pub := range pubkeys {
+				_, proposalExists, signingRootExists, err := db.ProposalHistoryForSlot(context.Background(), pub, 0)
+				require.NoError(t, err)
+				assert.Equal(t, false, proposalExists)
+				assert.Equal(t, false, signingRootExists)
+			}
+		})
 	}
-}
-
-func TestNewProposalHistoryForSlot_SigningRootNil(t *testing.T) {
-	pubkey := [fieldparams.BLSPubkeyLength]byte{1, 2, 3}
-	slot := primitives.Slot(2)
-
-	db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
-
-	err := db.SaveProposalHistoryForSlot(context.Background(), pubkey, slot, nil)
-	require.NoError(t, err, "Saving proposal history failed: %v")
-
-	_, proposalExists, signingRootExists, err := db.ProposalHistoryForSlot(context.Background(), pubkey, slot)
-	require.NoError(t, err)
-	assert.Equal(t, true, proposalExists)
-	assert.Equal(t, false, signingRootExists)
 }
 
 func TestSaveProposalHistoryForSlot_OK(t *testing.T) {
-	pubkey := [fieldparams.BLSPubkeyLength]byte{3}
-	db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubkey})
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			pubkey := [fieldparams.BLSPubkeyLength]byte{3}
+			db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubkey}, tt.slashingProtectionType)
 
-	slot := primitives.Slot(2)
+			slot := primitives.Slot(2)
 
-	err := db.SaveProposalHistoryForSlot(context.Background(), pubkey, slot, []byte{1})
-	require.NoError(t, err, "Saving proposal history failed: %v")
-	signingRoot, proposalExists, signingRootExists, err := db.ProposalHistoryForSlot(context.Background(), pubkey, slot)
-	require.NoError(t, err, "Failed to get proposal history")
-	assert.Equal(t, true, proposalExists)
-	assert.Equal(t, true, signingRootExists)
+			err := db.SaveProposalHistoryForSlot(context.Background(), pubkey, slot, []byte{1})
+			require.NoError(t, err, "Saving proposal history failed: %v")
+			signingRoot, proposalExists, signingRootExists, err := db.ProposalHistoryForSlot(context.Background(), pubkey, slot)
+			require.NoError(t, err, "Failed to get proposal history")
+			assert.Equal(t, true, proposalExists)
+			assert.Equal(t, true, signingRootExists)
 
-	require.NotNil(t, signingRoot)
-	require.DeepEqual(t, bytesutil.PadTo([]byte{1}, 32), signingRoot[:], "Expected DB to keep object the same")
+			require.NotNil(t, signingRoot)
+			require.DeepEqual(t, bytesutil.PadTo([]byte{1}, 32), signingRoot[:], "Expected DB to keep object the same")
+		})
+	}
 }
-
 func TestNewProposalHistoryForPubKey_ReturnsEmptyIfNoHistory(t *testing.T) {
-	valPubkey := [fieldparams.BLSPubkeyLength]byte{1, 2, 3}
-	db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			valPubkey := [fieldparams.BLSPubkeyLength]byte{1, 2, 3}
+			db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{}, tt.slashingProtectionType)
 
-	proposalHistory, err := db.ProposalHistoryForPubKey(context.Background(), valPubkey)
-	require.NoError(t, err)
-	assert.DeepEqual(t, make([]*Proposal, 0), proposalHistory)
+			proposalHistory, err := db.ProposalHistoryForPubKey(context.Background(), valPubkey)
+			require.NoError(t, err)
+			assert.DeepEqual(t, make([]*Proposal, 0), proposalHistory)
+		})
+	}
 }
 
 func TestSaveProposalHistoryForPubKey_OK(t *testing.T) {
-	pubkey := [fieldparams.BLSPubkeyLength]byte{3}
-	db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubkey})
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			pubkey := [fieldparams.BLSPubkeyLength]byte{3}
+			db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubkey}, tt.slashingProtectionType)
 
-	slot := primitives.Slot(2)
+			slot := primitives.Slot(2)
 
-	root := [32]byte{1}
-	err := db.SaveProposalHistoryForSlot(context.Background(), pubkey, slot, root[:])
-	require.NoError(t, err, "Saving proposal history failed: %v")
-	proposalHistory, err := db.ProposalHistoryForPubKey(context.Background(), pubkey)
-	require.NoError(t, err, "Failed to get proposal history")
+			root := [32]byte{1}
+			err := db.SaveProposalHistoryForSlot(context.Background(), pubkey, slot, root[:])
+			require.NoError(t, err, "Saving proposal history failed: %v")
+			proposalHistory, err := db.ProposalHistoryForPubKey(context.Background(), pubkey)
+			require.NoError(t, err, "Failed to get proposal history")
 
-	require.NotNil(t, proposalHistory)
-	want := []*Proposal{
-		{
-			Slot:        slot,
-			SigningRoot: root[:],
-		},
+			require.NotNil(t, proposalHistory)
+			want := []*Proposal{
+				{
+					Slot:        slot,
+					SigningRoot: root[:],
+				},
+			}
+			require.DeepEqual(t, want[0], proposalHistory[0])
+		})
 	}
-	require.DeepEqual(t, want[0], proposalHistory[0])
 }
 
 func TestSaveProposalHistoryForSlot_Overwrites(t *testing.T) {
-	pubkey := [fieldparams.BLSPubkeyLength]byte{0}
-	tests := []struct {
-		signingRoot []byte
-	}{
-		{
-			signingRoot: bytesutil.PadTo([]byte{1}, 32),
-		},
-		{
-			signingRoot: bytesutil.PadTo([]byte{2}, 32),
-		},
-		{
-			signingRoot: bytesutil.PadTo([]byte{3}, 32),
-		},
-	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			pubkey := [fieldparams.BLSPubkeyLength]byte{0}
+			tests := []struct {
+				signingRoot []byte
+			}{
+				{
+					signingRoot: bytesutil.PadTo([]byte{1}, 32),
+				},
+				{
+					signingRoot: bytesutil.PadTo([]byte{2}, 32),
+				},
+				{
+					signingRoot: bytesutil.PadTo([]byte{3}, 32),
+				},
+			}
 
-	for _, tt := range tests {
-		db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubkey})
-		err := db.SaveProposalHistoryForSlot(context.Background(), pubkey, 0, tt.signingRoot)
-		require.NoError(t, err, "Saving proposal history failed")
-		proposalHistory, err := db.ProposalHistoryForPubKey(context.Background(), pubkey)
-		require.NoError(t, err, "Failed to get proposal history")
+			for _, st := range tests {
+				db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubkey}, tt.slashingProtectionType)
+				err := db.SaveProposalHistoryForSlot(context.Background(), pubkey, 0, st.signingRoot)
+				require.NoError(t, err, "Saving proposal history failed")
+				proposalHistory, err := db.ProposalHistoryForPubKey(context.Background(), pubkey)
+				require.NoError(t, err, "Failed to get proposal history")
 
-		require.NotNil(t, proposalHistory)
-		require.DeepEqual(t, tt.signingRoot, proposalHistory[0].SigningRoot, "Expected DB to keep object the same")
-		require.NoError(t, db.Close(), "Failed to close database")
+				require.NotNil(t, proposalHistory)
+				require.DeepEqual(t, st.signingRoot, proposalHistory[0].SigningRoot, "Expected DB to keep object the same")
+				require.NoError(t, db.Close(), "Failed to close database")
+			}
+		})
 	}
 }
 
@@ -168,9 +176,9 @@ func TestPruneProposalHistoryBySlot_OK(t *testing.T) {
 	}
 	signedRoot := bytesutil.PadTo([]byte{1}, 32)
 
-	for _, tt := range tests {
-		db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubKey})
-		for _, slot := range tt.slots {
+	for _, st := range tests {
+		db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubKey}, complete)
+		for _, slot := range st.slots {
 			err := db.SaveProposalHistoryForSlot(context.Background(), pubKey, slot, signedRoot)
 			require.NoError(t, err, "Saving proposal history failed")
 		}
@@ -183,11 +191,11 @@ func TestPruneProposalHistoryBySlot_OK(t *testing.T) {
 			signingRootsBySlot[hist.Slot] = hist.SigningRoot
 		}
 
-		for _, slot := range tt.removedSlots {
+		for _, slot := range st.removedSlots {
 			_, ok := signingRootsBySlot[slot]
 			require.Equal(t, false, ok)
 		}
-		for _, slot := range tt.storedSlots {
+		for _, slot := range st.storedSlots {
 			root, ok := signingRootsBySlot[slot]
 			require.Equal(t, true, ok)
 			require.DeepEqual(t, signedRoot, root, "Unexpected difference in bytes for epoch %d", slot)
@@ -220,83 +228,107 @@ func TestStore_ProposedPublicKeys(t *testing.T) {
 }
 
 func TestStore_LowestSignedProposal(t *testing.T) {
-	ctx := context.Background()
-	pubkey := [fieldparams.BLSPubkeyLength]byte{3}
-	var dummySigningRoot [32]byte
-	validatorDB := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubkey})
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			pubkey := [fieldparams.BLSPubkeyLength]byte{3}
+			var dummySigningRoot [32]byte
+			validatorDB := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubkey}, tt.slashingProtectionType)
 
-	_, exists, err := validatorDB.LowestSignedProposal(ctx, pubkey)
-	require.NoError(t, err)
-	require.Equal(t, false, exists)
+			_, exists, err := validatorDB.LowestSignedProposal(ctx, pubkey)
+			require.NoError(t, err)
+			require.Equal(t, false, exists)
 
-	// We save our first proposal history.
-	err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 2 /* slot */, dummySigningRoot[:])
-	require.NoError(t, err)
+			// We save our first proposal history.
+			err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 2 /* slot */, dummySigningRoot[:])
+			require.NoError(t, err)
 
-	// We expect the lowest signed slot is what we just saved.
-	slot, exists, err := validatorDB.LowestSignedProposal(ctx, pubkey)
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	assert.Equal(t, primitives.Slot(2), slot)
+			// We expect the lowest signed slot is what we just saved.
+			slot, exists, err := validatorDB.LowestSignedProposal(ctx, pubkey)
+			require.NoError(t, err)
+			require.Equal(t, true, exists)
+			assert.Equal(t, primitives.Slot(2), slot)
 
-	// We save a higher proposal history.
-	err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 3 /* slot */, dummySigningRoot[:])
-	require.NoError(t, err)
+			// We save a higher proposal history.
+			err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 3 /* slot */, dummySigningRoot[:])
+			require.NoError(t, err)
 
-	// We expect the lowest signed slot did not change.
-	slot, exists, err = validatorDB.LowestSignedProposal(ctx, pubkey)
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	assert.Equal(t, primitives.Slot(2), slot)
+			if tt.slashingProtectionType == complete {
+				// We expect the lowest signed slot did not change.
+				slot, exists, err = validatorDB.LowestSignedProposal(ctx, pubkey)
+				require.NoError(t, err)
+				require.Equal(t, true, exists)
+				assert.Equal(t, primitives.Slot(2), slot)
+			} else {
+				// We expect the lowest signed slot is what we just saved.
+				slot, exists, err = validatorDB.LowestSignedProposal(ctx, pubkey)
+				require.NoError(t, err)
+				require.Equal(t, true, exists)
+				assert.Equal(t, primitives.Slot(3), slot)
+			}
 
-	// We save a lower proposal history.
-	err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 1 /* slot */, dummySigningRoot[:])
-	require.NoError(t, err)
+			// We save a lower proposal history.
+			err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 1 /* slot */, dummySigningRoot[:])
+			require.NoError(t, err)
 
-	// We expect the lowest signed slot indeed changed.
-	slot, exists, err = validatorDB.LowestSignedProposal(ctx, pubkey)
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	assert.Equal(t, primitives.Slot(1), slot)
+			// We expect the lowest signed slot indeed changed.
+			slot, exists, err = validatorDB.LowestSignedProposal(ctx, pubkey)
+			require.NoError(t, err)
+			require.Equal(t, true, exists)
+			assert.Equal(t, primitives.Slot(1), slot)
+		})
+	}
 }
 
 func TestStore_HighestSignedProposal(t *testing.T) {
-	ctx := context.Background()
-	pubkey := [fieldparams.BLSPubkeyLength]byte{3}
-	var dummySigningRoot [32]byte
-	validatorDB := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubkey})
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			pubkey := [fieldparams.BLSPubkeyLength]byte{3}
+			var dummySigningRoot [32]byte
+			validatorDB := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubkey}, tt.slashingProtectionType)
 
-	_, exists, err := validatorDB.HighestSignedProposal(ctx, pubkey)
-	require.NoError(t, err)
-	require.Equal(t, false, exists)
+			_, exists, err := validatorDB.HighestSignedProposal(ctx, pubkey)
+			require.NoError(t, err)
+			require.Equal(t, false, exists)
 
-	// We save our first proposal history.
-	err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 2 /* slot */, dummySigningRoot[:])
-	require.NoError(t, err)
+			// We save our first proposal history.
+			err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 2 /* slot */, dummySigningRoot[:])
+			require.NoError(t, err)
 
-	// We expect the highest signed slot is what we just saved.
-	slot, exists, err := validatorDB.HighestSignedProposal(ctx, pubkey)
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	assert.Equal(t, primitives.Slot(2), slot)
+			// We expect the highest signed slot is what we just saved.
+			slot, exists, err := validatorDB.HighestSignedProposal(ctx, pubkey)
+			require.NoError(t, err)
+			require.Equal(t, true, exists)
+			assert.Equal(t, primitives.Slot(2), slot)
 
-	// We save a lower proposal history.
-	err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 1 /* slot */, dummySigningRoot[:])
-	require.NoError(t, err)
+			// We save a lower proposal history.
+			err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 1 /* slot */, dummySigningRoot[:])
+			require.NoError(t, err)
 
-	// We expect the lowest signed slot did not change.
-	slot, exists, err = validatorDB.HighestSignedProposal(ctx, pubkey)
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	assert.Equal(t, primitives.Slot(2), slot)
+			if tt.slashingProtectionType == complete {
+				// We expect the lowest signed slot did not change.
+				slot, exists, err = validatorDB.HighestSignedProposal(ctx, pubkey)
+				require.NoError(t, err)
+				require.Equal(t, true, exists)
+				assert.Equal(t, primitives.Slot(2), slot)
+			} else {
+				// We expect the highest signed slot is what we just saved.
+				slot, exists, err = validatorDB.HighestSignedProposal(ctx, pubkey)
+				require.NoError(t, err)
+				require.Equal(t, true, exists)
+				assert.Equal(t, primitives.Slot(1), slot)
+			}
 
-	// We save a higher proposal history.
-	err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 3 /* slot */, dummySigningRoot[:])
-	require.NoError(t, err)
+			// We save a higher proposal history.
+			err = validatorDB.SaveProposalHistoryForSlot(ctx, pubkey, 3 /* slot */, dummySigningRoot[:])
+			require.NoError(t, err)
 
-	// We expect the highest signed slot indeed changed.
-	slot, exists, err = validatorDB.HighestSignedProposal(ctx, pubkey)
-	require.NoError(t, err)
-	require.Equal(t, true, exists)
-	assert.Equal(t, primitives.Slot(3), slot)
+			// We expect the highest signed slot indeed changed.
+			slot, exists, err = validatorDB.HighestSignedProposal(ctx, pubkey)
+			require.NoError(t, err)
+			require.Equal(t, true, exists)
+			assert.Equal(t, primitives.Slot(3), slot)
+		})
+	}
 }

--- a/validator/db/kv/proposer_settings_test.go
+++ b/validator/db/kv/proposer_settings_test.go
@@ -15,92 +15,95 @@ import (
 )
 
 func TestStore_ProposerSettings_ReadAndWrite(t *testing.T) {
-	t.Run("save to db in full", func(t *testing.T) {
-		ctx := context.Background()
-		db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
-		key1, err := hexutil.Decode("0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
-		require.NoError(t, err)
-		settings := &validatorServiceConfig.ProposerSettings{
-			ProposeConfig: map[[fieldparams.BLSPubkeyLength]byte]*validatorServiceConfig.ProposerOption{
-				bytesutil.ToBytes48(key1): {
+	for _, tt := range testCases {
+		t.Run("save to db in full", func(t *testing.T) {
+			ctx := context.Background()
+			db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{}, tt.slashingProtectionType)
+			key1, err := hexutil.Decode("0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
+			require.NoError(t, err)
+			settings := &validatorServiceConfig.ProposerSettings{
+				ProposeConfig: map[[fieldparams.BLSPubkeyLength]byte]*validatorServiceConfig.ProposerOption{
+					bytesutil.ToBytes48(key1): {
+						FeeRecipientConfig: &validatorServiceConfig.FeeRecipientConfig{
+							FeeRecipient: common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"),
+						},
+						BuilderConfig: &validatorServiceConfig.BuilderConfig{
+							Enabled:  true,
+							GasLimit: validator.Uint64(40000000),
+						},
+					},
+				},
+				DefaultConfig: &validatorServiceConfig.ProposerOption{
 					FeeRecipientConfig: &validatorServiceConfig.FeeRecipientConfig{
-						FeeRecipient: common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"),
+						FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"),
 					},
 					BuilderConfig: &validatorServiceConfig.BuilderConfig{
-						Enabled:  true,
-						GasLimit: validator.Uint64(40000000),
+						Enabled:  false,
+						GasLimit: validator.Uint64(params.BeaconConfig().DefaultBuilderGasLimit),
 					},
 				},
-			},
-			DefaultConfig: &validatorServiceConfig.ProposerOption{
+			}
+			err = db.SaveProposerSettings(ctx, settings)
+			require.NoError(t, err)
+
+			dbSettings, err := db.ProposerSettings(ctx)
+			require.NoError(t, err)
+			require.DeepEqual(t, settings, dbSettings)
+		})
+
+		t.Run("update default settings then update at specific key", func(t *testing.T) {
+			ctx := context.Background()
+			db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{}, tt.slashingProtectionType)
+			key1, err := hexutil.Decode("0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
+			require.NoError(t, err)
+			settings := &validatorServiceConfig.ProposerSettings{
+				DefaultConfig: &validatorServiceConfig.ProposerOption{
+					FeeRecipientConfig: &validatorServiceConfig.FeeRecipientConfig{
+						FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"),
+					},
+					BuilderConfig: &validatorServiceConfig.BuilderConfig{
+						Enabled:  false,
+						GasLimit: validator.Uint64(params.BeaconConfig().DefaultBuilderGasLimit),
+					},
+				},
+			}
+			err = db.SaveProposerSettings(ctx, settings)
+			require.NoError(t, err)
+			upatedDefault := &validatorServiceConfig.ProposerOption{
 				FeeRecipientConfig: &validatorServiceConfig.FeeRecipientConfig{
-					FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"),
+					FeeRecipient: common.HexToAddress("0x9995733c5af9B61374A128e6F85f553aF09ff89B"),
 				},
 				BuilderConfig: &validatorServiceConfig.BuilderConfig{
-					Enabled:  false,
+					Enabled:  true,
 					GasLimit: validator.Uint64(params.BeaconConfig().DefaultBuilderGasLimit),
 				},
-			},
-		}
-		err = db.SaveProposerSettings(ctx, settings)
-		require.NoError(t, err)
+			}
+			err = db.UpdateProposerSettingsDefault(ctx, upatedDefault)
+			require.NoError(t, err)
 
-		dbSettings, err := db.ProposerSettings(ctx)
-		require.NoError(t, err)
-		require.DeepEqual(t, settings, dbSettings)
-	})
-	t.Run("update default settings then update at specific key", func(t *testing.T) {
-		ctx := context.Background()
-		db := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
-		key1, err := hexutil.Decode("0xa057816155ad77931185101128655c0191bd0214c201ca48ed887f6c4c6adf334070efcd75140eada5ac83a92506dd7a")
-		require.NoError(t, err)
-		settings := &validatorServiceConfig.ProposerSettings{
-			DefaultConfig: &validatorServiceConfig.ProposerOption{
+			dbSettings, err := db.ProposerSettings(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, dbSettings)
+			require.DeepEqual(t, dbSettings.DefaultConfig, upatedDefault)
+			option := &validatorServiceConfig.ProposerOption{
 				FeeRecipientConfig: &validatorServiceConfig.FeeRecipientConfig{
-					FeeRecipient: common.HexToAddress("0x6e35733c5af9B61374A128e6F85f553aF09ff89A"),
+					FeeRecipient: common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"),
 				},
 				BuilderConfig: &validatorServiceConfig.BuilderConfig{
-					Enabled:  false,
-					GasLimit: validator.Uint64(params.BeaconConfig().DefaultBuilderGasLimit),
+					Enabled:  true,
+					GasLimit: validator.Uint64(40000000),
 				},
-			},
-		}
-		err = db.SaveProposerSettings(ctx, settings)
-		require.NoError(t, err)
-		upatedDefault := &validatorServiceConfig.ProposerOption{
-			FeeRecipientConfig: &validatorServiceConfig.FeeRecipientConfig{
-				FeeRecipient: common.HexToAddress("0x9995733c5af9B61374A128e6F85f553aF09ff89B"),
-			},
-			BuilderConfig: &validatorServiceConfig.BuilderConfig{
-				Enabled:  true,
-				GasLimit: validator.Uint64(params.BeaconConfig().DefaultBuilderGasLimit),
-			},
-		}
-		err = db.UpdateProposerSettingsDefault(ctx, upatedDefault)
-		require.NoError(t, err)
+			}
+			err = db.UpdateProposerSettingsForPubkey(ctx, bytesutil.ToBytes48(key1), option)
+			require.NoError(t, err)
 
-		dbSettings, err := db.ProposerSettings(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, dbSettings)
-		require.DeepEqual(t, dbSettings.DefaultConfig, upatedDefault)
-		option := &validatorServiceConfig.ProposerOption{
-			FeeRecipientConfig: &validatorServiceConfig.FeeRecipientConfig{
-				FeeRecipient: common.HexToAddress("0x50155530FCE8a85ec7055A5F8b2bE214B3DaeFd3"),
-			},
-			BuilderConfig: &validatorServiceConfig.BuilderConfig{
-				Enabled:  true,
-				GasLimit: validator.Uint64(40000000),
-			},
-		}
-		err = db.UpdateProposerSettingsForPubkey(ctx, bytesutil.ToBytes48(key1), option)
-		require.NoError(t, err)
-
-		newSettings, err := db.ProposerSettings(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, newSettings)
-		require.DeepEqual(t, newSettings.DefaultConfig, upatedDefault)
-		op, ok := newSettings.ProposeConfig[bytesutil.ToBytes48(key1)]
-		require.Equal(t, ok, true)
-		require.DeepEqual(t, op, option)
-	})
+			newSettings, err := db.ProposerSettings(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, newSettings)
+			require.DeepEqual(t, newSettings.DefaultConfig, upatedDefault)
+			op, ok := newSettings.ProposeConfig[bytesutil.ToBytes48(key1)]
+			require.Equal(t, ok, true)
+			require.DeepEqual(t, op, option)
+		})
+	}
 }

--- a/validator/db/kv/prune_attester_protection_test.go
+++ b/validator/db/kv/prune_attester_protection_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestPruneAttestations_NoPruning(t *testing.T) {
 	pubKey := [fieldparams.BLSPubkeyLength]byte{1}
-	validatorDB := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubKey}, complete)
+	validatorDB := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubKey}, Complete)
 
 	// Write attesting history for every single epoch
 	// since genesis to a specified number of epochs.
@@ -45,7 +45,7 @@ func TestPruneAttestations_OK(t *testing.T) {
 	for i := uint64(0); i < numKeys; i++ {
 		pks = append(pks, bytesutil.ToBytes48(bytesutil.ToBytes(i, 48)))
 	}
-	validatorDB := setupDB(t, pks, complete)
+	validatorDB := setupDB(t, pks, Complete)
 
 	// Write attesting history for every single epoch
 	// since genesis to SLASHING_PROTECTION_PRUNING_EPOCHS * 2.
@@ -94,7 +94,7 @@ func BenchmarkPruneAttestations(b *testing.B) {
 	for i := uint64(0); i < numKeys; i++ {
 		pks = append(pks, bytesutil.ToBytes48(bytesutil.ToBytes(i, 48)))
 	}
-	validatorDB := setupDB(b, pks, complete)
+	validatorDB := setupDB(b, pks, Complete)
 
 	// Write attesting history for every single epoch
 	// since genesis to SLASHING_PROTECTION_PRUNING_EPOCHS * 20.

--- a/validator/db/kv/prune_attester_protection_test.go
+++ b/validator/db/kv/prune_attester_protection_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestPruneAttestations_NoPruning(t *testing.T) {
 	pubKey := [fieldparams.BLSPubkeyLength]byte{1}
-	validatorDB := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubKey})
+	validatorDB := setupDB(t, [][fieldparams.BLSPubkeyLength]byte{pubKey}, complete)
 
 	// Write attesting history for every single epoch
 	// since genesis to a specified number of epochs.
@@ -45,7 +45,7 @@ func TestPruneAttestations_OK(t *testing.T) {
 	for i := uint64(0); i < numKeys; i++ {
 		pks = append(pks, bytesutil.ToBytes48(bytesutil.ToBytes(i, 48)))
 	}
-	validatorDB := setupDB(t, pks)
+	validatorDB := setupDB(t, pks, complete)
 
 	// Write attesting history for every single epoch
 	// since genesis to SLASHING_PROTECTION_PRUNING_EPOCHS * 2.
@@ -94,7 +94,7 @@ func BenchmarkPruneAttestations(b *testing.B) {
 	for i := uint64(0); i < numKeys; i++ {
 		pks = append(pks, bytesutil.ToBytes48(bytesutil.ToBytes(i, 48)))
 	}
-	validatorDB := setupDB(b, pks)
+	validatorDB := setupDB(b, pks, complete)
 
 	// Write attesting history for every single epoch
 	// since genesis to SLASHING_PROTECTION_PRUNING_EPOCHS * 20.

--- a/validator/db/kv/schema.go
+++ b/validator/db/kv/schema.go
@@ -42,3 +42,16 @@ var (
 	proposerSettingsBucket = []byte("proposer-settings-bucket")
 	proposerSettingsKey    = []byte("proposer-settings")
 )
+
+// Attestations:
+// -------------
+// lowest-signed-source-bucket --> <pubkey> --> <epoch>
+// lowest-signed-target-bucket --> <pubkey> --> <epoch>
+//
+// pubkeys-bucket --> <pubkey> --> att-signing-roots-bucket --> <target epoch> --> <signing root>
+//                             |-> att-source-epochs-bucket --> <source epoch> --> []<target epoch>
+//                             |-> att-target-epochs-bucket --> <target epoch> --> []<source epoch>
+
+// Proposals:
+// ----------
+// proposal-history-bucket-interchange -> <pubkey> --> <slot> --> <signing root>

--- a/validator/db/testing/BUILD.bazel
+++ b/validator/db/testing/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//validator:__subpackages__",
     ],
     deps = [
-        "//config/fieldparams:go_default_library",
         "//validator/db/iface:go_default_library",
         "//validator/db/kv:go_default_library",
     ],

--- a/validator/db/testing/setup_db.go
+++ b/validator/db/testing/setup_db.go
@@ -4,16 +4,13 @@ import (
 	"context"
 	"testing"
 
-	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/validator/db/iface"
 	"github.com/prysmaticlabs/prysm/v4/validator/db/kv"
 )
 
 // SetupDB instantiates and returns a DB instance for the validator client.
-func SetupDB(t testing.TB, pubkeys [][fieldparams.BLSPubkeyLength]byte) iface.ValidatorDB {
-	db, err := kv.NewKVStore(context.Background(), t.TempDir(), &kv.Config{
-		PubKeys: pubkeys,
-	})
+func SetupDB(t testing.TB, config *kv.Config) iface.ValidatorDB {
+	db, err := kv.NewKVStore(context.Background(), t.TempDir(), config)
 	if err != nil {
 		t.Fatalf("Failed to instantiate DB: %v", err)
 	}

--- a/validator/node/BUILD.bazel
+++ b/validator/node/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "//testing/require:go_default_library",
         "//validator/accounts:go_default_library",
         "//validator/db/iface:go_default_library",
+        "//validator/db/kv:go_default_library",
         "//validator/db/testing:go_default_library",
         "//validator/keymanager:go_default_library",
         "//validator/keymanager/remote-web3signer:go_default_library",

--- a/validator/node/node_test.go
+++ b/validator/node/node_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
 	"github.com/prysmaticlabs/prysm/v4/validator/accounts"
 	"github.com/prysmaticlabs/prysm/v4/validator/db/iface"
+	"github.com/prysmaticlabs/prysm/v4/validator/db/kv"
 	dbTest "github.com/prysmaticlabs/prysm/v4/validator/db/testing"
 	"github.com/prysmaticlabs/prysm/v4/validator/keymanager"
 	remoteweb3signer "github.com/prysmaticlabs/prysm/v4/validator/keymanager/remote-web3signer"
@@ -883,7 +884,7 @@ func TestProposerSettings(t *testing.T) {
 				set.Bool(flags.EnableBuilderFlag.Name, true, "")
 			}
 			cliCtx := cli.NewContext(&app, set, nil)
-			validatorDB := dbTest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+			validatorDB := dbTest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 			if tt.withdb != nil {
 				err := tt.withdb(validatorDB)
 				require.NoError(t, err)
@@ -910,7 +911,7 @@ func Test_ProposerSettingsWithOnlyBuilder_DoesNotSaveInDB(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Bool(flags.EnableBuilderFlag.Name, true, "")
 	cliCtx := cli.NewContext(&app, set, nil)
-	validatorDB := dbTest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+	validatorDB := dbTest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 	got, err := proposerSettings(cliCtx, validatorDB)
 	require.NoError(t, err)
 	_, err = validatorDB.ProposerSettings(cliCtx.Context)

--- a/validator/rpc/handlers_keymanager_test.go
+++ b/validator/rpc/handlers_keymanager_test.go
@@ -1052,7 +1052,7 @@ func TestServer_SetGasLimit(t *testing.T) {
 			m := &mock.Validator{}
 			err := m.SetProposerSettings(ctx, tt.proposerSettings)
 			require.NoError(t, err)
-			validatorDB := dbtest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+			validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 			vs, err := client.NewValidatorService(ctx, &client.Config{
 				Validator: m,
 				ValDB:     validatorDB,
@@ -1239,7 +1239,7 @@ func TestServer_DeleteGasLimit(t *testing.T) {
 			m := &mock.Validator{}
 			err := m.SetProposerSettings(ctx, tt.proposerSettings)
 			require.NoError(t, err)
-			validatorDB := dbtest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+			validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 			vs, err := client.NewValidatorService(ctx, &client.Config{
 				Validator: m,
 				ValDB:     validatorDB,
@@ -1698,7 +1698,7 @@ func TestServer_FeeRecipientByPubkey(t *testing.T) {
 			m := &mock.Validator{}
 			err := m.SetProposerSettings(ctx, tt.proposerSettings)
 			require.NoError(t, err)
-			validatorDB := dbtest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+			validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 
 			// save a default here
 			vs, err := client.NewValidatorService(ctx, &client.Config{
@@ -1808,7 +1808,7 @@ func TestServer_DeleteFeeRecipientByPubkey(t *testing.T) {
 			m := &mock.Validator{}
 			err := m.SetProposerSettings(ctx, tt.proposerSettings)
 			require.NoError(t, err)
-			validatorDB := dbtest.SetupDB(t, [][fieldparams.BLSPubkeyLength]byte{})
+			validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: [][fieldparams.BLSPubkeyLength]byte{}})
 			vs, err := client.NewValidatorService(ctx, &client.Config{
 				Validator: m,
 				ValDB:     validatorDB,

--- a/validator/slashing-protection-history/export_test.go
+++ b/validator/slashing-protection-history/export_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/testing/assert"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
+	"github.com/prysmaticlabs/prysm/v4/validator/db/kv"
 	dbtest "github.com/prysmaticlabs/prysm/v4/validator/db/testing"
 	"github.com/prysmaticlabs/prysm/v4/validator/slashing-protection-history/format"
 )
@@ -18,7 +19,7 @@ func TestExportStandardProtectionJSON_EmptyGenesisRoot(t *testing.T) {
 	pubKeys := [][fieldparams.BLSPubkeyLength]byte{
 		{1},
 	}
-	validatorDB := dbtest.SetupDB(t, pubKeys)
+	validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: pubKeys})
 	_, err := ExportStandardProtectionJSON(ctx, validatorDB)
 	require.ErrorContains(t, "genesis validators root is empty", err)
 	genesisValidatorsRoot := [32]byte{1}
@@ -34,7 +35,7 @@ func Test_getSignedAttestationsByPubKey(t *testing.T) {
 			{1},
 		}
 		ctx := context.Background()
-		validatorDB := dbtest.SetupDB(t, pubKeys)
+		validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: pubKeys})
 
 		// No attestation history stored should return empty.
 		signedAttestations, err := signedAttestationsByPubKey(ctx, validatorDB, pubKeys[0])
@@ -77,7 +78,7 @@ func Test_getSignedAttestationsByPubKey(t *testing.T) {
 			{1},
 		}
 		ctx := context.Background()
-		validatorDB := dbtest.SetupDB(t, pubKeys)
+		validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: pubKeys})
 
 		// No attestation history stored should return empty.
 		signedAttestations, err := signedAttestationsByPubKey(ctx, validatorDB, pubKeys[0])
@@ -119,7 +120,7 @@ func Test_getSignedAttestationsByPubKey(t *testing.T) {
 			{1},
 		}
 		ctx := context.Background()
-		validatorDB := dbtest.SetupDB(t, pubKeys)
+		validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: pubKeys})
 
 		// No attestation history stored should return empty.
 		signedAttestations, err := signedAttestationsByPubKey(ctx, validatorDB, pubKeys[0])
@@ -168,7 +169,7 @@ func Test_getSignedBlocksByPubKey(t *testing.T) {
 		{1},
 	}
 	ctx := context.Background()
-	validatorDB := dbtest.SetupDB(t, pubKeys)
+	validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: pubKeys})
 
 	// No highest and/or lowest signed blocks will return empty.
 	signedBlocks, err := signedBlocksByPubKey(ctx, validatorDB, pubKeys[0])

--- a/validator/slashing-protection-history/helpers.go
+++ b/validator/slashing-protection-history/helpers.go
@@ -37,7 +37,7 @@ func Uint64FromString(str string) (uint64, error) {
 
 // EpochFromString converts a string into Epoch.
 func EpochFromString(str string) (primitives.Epoch, error) {
-	e, err := strconv.ParseUint(str, 10, 64)
+	e, err := Uint64FromString(str)
 	if err != nil {
 		return primitives.Epoch(e), err
 	}
@@ -46,7 +46,7 @@ func EpochFromString(str string) (primitives.Epoch, error) {
 
 // SlotFromString converts a string into Slot.
 func SlotFromString(str string) (primitives.Slot, error) {
-	s, err := strconv.ParseUint(str, 10, 64)
+	s, err := Uint64FromString(str)
 	if err != nil {
 		return primitives.Slot(s), err
 	}

--- a/validator/slashing-protection-history/helpers_test.go
+++ b/validator/slashing-protection-history/helpers_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 )
 
-func Test_uint64FromString(t *testing.T) {
+func Test_fromString(t *testing.T) {
 	tests := []struct {
 		name    string
 		str     string

--- a/validator/slashing-protection-history/import_test.go
+++ b/validator/slashing-protection-history/import_test.go
@@ -50,7 +50,7 @@ func TestStore_ImportInterchangeData_BadFormat_PreventsDBWrites(t *testing.T) {
 	numValidators := 10
 	publicKeys, err := valtest.CreateRandomPubKeys(numValidators)
 	require.NoError(t, err)
-	validatorDB := dbtest.SetupDB(t, publicKeys)
+	validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: publicKeys})
 
 	// First we setup some mock attesting and proposal histories and create a mock
 	// standard slashing protection format JSON struct.
@@ -108,7 +108,7 @@ func TestStore_ImportInterchangeData_OK(t *testing.T) {
 	numValidators := 10
 	publicKeys, err := valtest.CreateRandomPubKeys(numValidators)
 	require.NoError(t, err)
-	validatorDB := dbtest.SetupDB(t, publicKeys)
+	validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: publicKeys})
 
 	// First we setup some mock attesting and proposal histories and create a mock
 	// standard slashing protection format JSON struct.
@@ -1046,7 +1046,7 @@ func Test_filterSlashablePubKeysFromAttestations(t *testing.T) {
 			for pubKey := range tt.incomingAttsByPubKey {
 				pubKeys = append(pubKeys, pubKey)
 			}
-			validatorDB := dbtest.SetupDB(t, pubKeys)
+			validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: pubKeys})
 			for pubKey, signedAtts := range tt.incomingAttsByPubKey {
 				attestingHistory, err := transformSignedAttestations(pubKey, signedAtts)
 				require.NoError(t, err)

--- a/validator/slashing-protection-history/round_trip_test.go
+++ b/validator/slashing-protection-history/round_trip_test.go
@@ -22,7 +22,7 @@ func TestImportExport_RoundTrip(t *testing.T) {
 	numValidators := 10
 	publicKeys, err := slashtest.CreateRandomPubKeys(numValidators)
 	require.NoError(t, err)
-	validatorDB := dbtest.SetupDB(t, publicKeys)
+	validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: publicKeys})
 
 	// First we setup some mock attesting and proposal histories and create a mock
 	// standard slashing protection format JSON struct.
@@ -84,7 +84,7 @@ func TestImportExport_RoundTrip_SkippedAttestationEpochs(t *testing.T) {
 	numValidators := 1
 	pubKeys, err := slashtest.CreateRandomPubKeys(numValidators)
 	require.NoError(t, err)
-	validatorDB := dbtest.SetupDB(t, pubKeys)
+	validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: pubKeys})
 	wanted := &format.EIPSlashingProtectionFormat{
 		Metadata: struct {
 			InterchangeFormatVersion string `json:"interchange_format_version"`
@@ -143,7 +143,7 @@ func TestImportExport_FilterKeys(t *testing.T) {
 	numValidators := 10
 	publicKeys, err := slashtest.CreateRandomPubKeys(numValidators)
 	require.NoError(t, err)
-	validatorDB := dbtest.SetupDB(t, publicKeys)
+	validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: publicKeys})
 
 	// First we setup some mock attesting and proposal histories and create a mock
 	// standard slashing protection format JSON struct.
@@ -181,7 +181,7 @@ func TestImportInterchangeData_OK(t *testing.T) {
 	numValidators := 10
 	publicKeys, err := slashtest.CreateRandomPubKeys(numValidators)
 	require.NoError(t, err)
-	validatorDB := dbtest.SetupDB(t, publicKeys)
+	validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: publicKeys})
 
 	// First we setup some mock attesting and proposal histories and create a mock
 	// standard slashing protection format JSON struct.
@@ -244,7 +244,7 @@ func TestImportInterchangeData_OK_SavesBlacklistedPublicKeys(t *testing.T) {
 	numValidators := 3
 	publicKeys, err := slashtest.CreateRandomPubKeys(numValidators)
 	require.NoError(t, err)
-	validatorDB := dbtest.SetupDB(t, publicKeys)
+	validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: publicKeys})
 
 	// First we setup some mock attesting and proposal histories and create a mock
 	// standard slashing protection format JSON struct.
@@ -332,7 +332,7 @@ func TestStore_ImportInterchangeData_BadFormat_PreventsDBWrites(t *testing.T) {
 	numValidators := 5
 	publicKeys, err := slashtest.CreateRandomPubKeys(numValidators)
 	require.NoError(t, err)
-	validatorDB := dbtest.SetupDB(t, publicKeys)
+	validatorDB := dbtest.SetupDB(t, &kv.Config{PubKeys: publicKeys})
 
 	// First we setup some mock attesting and proposal histories and create a mock
 	// standard slashing protection format JSON struct.


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR implements the minimal slashing protection database, such as defined in [EIP-3076](https://eips.ethereum.org/EIPS/eip-3076) by adding the flag `--enable-minimal-slashing-protection-database` to the validator client.

> The interchange format is designed to be flexible enough to support the full variety of slashing protection strategies that clients may implement, which may be categorised into two main types:
> 
> 1. **Complete:** a database containing every message signed by each validator.
> 2. **Minimal:** a database containing only the latest messages signed by each validator.

**Which issues(s) does this PR fix?**

Fixes https://github.com/prysmaticlabs/prysm/issues/11616

**Other notes for review**
This PR is written to be read commit by commit, with each commit messages detailing what the commit does.

The type of slashing protection database itself (minimal or complete) is never saved anywhere in the DB.

The DB is implicitly minimal if, for all pubkeys:
- at most one slot is present for block proposals
- at most one target epoch is present in the attestations signing roots bucket
- at most one source epoch is present in the attestations source epochs bucket
- at most one target is present in the attestations target epochs bucket

Otherwise, the DB is considered complete.

The type of slashing protection database can be determined by using `IsSlashingProtectionMinimal`, which performs the checks listed above.

This function runs at VC start. For information, running this functions "in the worst case" (exactly 1 block proposal and 1 attestation for every validator) for `10_000` validators (which is, I expect, much higher than a standard usage), takes about `1.03 second` on my computer (Apple M2 Max).

In a real usage, I expect the number of validators to be something like at least 3/4 times lower.
If the needed time to run `IsSlashingProtectionMinimal` is considered too high, there is at least two options:
- check proposals and attestation in two separated goroutines (we can divide the compute time up to `/2`)
- add a new key in the DB, indicating if the database if effectively minimal or complete.

For safety purpose, if the flag `--enable-minimal-slashing-protection-database` is set while a complete slashing protection is detected, then the following warning log is displayed:
```
Minimal slashing protection database requested, while complete slashing protection database currently used. Will continue to use complete slashing protection database.
```
and the database will be considered as complete.

This safety net is important, since running the validator client with the flag `--enable-minimal-slashing-protection-database` while a complete database is already present will eventually wipe all the history specific to complete database to keep only minimal informations.

A tool allowing a user to convert a complete database to a minimal one will be written in a future PR. Something like:
```
prysm.sh validator slashing-protection-history convert-to-minimal
```

A lot of modified lines just consist in wrapping tests in a for loop running both minimal and complete databases, like:
```go
func test(...) {
    // test content
}
```

now is:
```go
func test(...) {
   for _, slashingDatabaseType := range slashingDatabaseTypes {
      //test content
   }
}
```

For some reasons, gitHub quite poorly reflect theses changes by mixing/switching a lot of lines of code.
VsCode itself gives a better representation of these changes.

Exemple:
![image](https://github.com/prysmaticlabs/prysm/assets/4943830/23644e9f-244f-46d5-90cd-cd0e5ce470fa)
