### PR TITLE
blobstorage: Improve mkdirall error 

### DIFF
--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -36,7 +36,7 @@ const (
 func NewBlobStorage(base string) (*BlobStorage, error) {
 	base = path.Clean(base)
 	if err := file.MkdirAll(base); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create blob storage at %s: %w", base, err)
 	}
 	fs := afero.NewBasePathFs(afero.NewOsFs(), base)
 	return &BlobStorage{fs: fs}, nil

--- a/beacon-chain/db/filesystem/blob_test.go
+++ b/beacon-chain/db/filesystem/blob_test.go
@@ -2,6 +2,8 @@ package filesystem
 
 import (
 	"bytes"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -128,4 +130,15 @@ func TestBlobStorageDelete(t *testing.T) {
 
 	// Deleting a non-existent root does not return an error.
 	require.NoError(t, bs.Delete(bytesutil.ToBytes32([]byte{0x1})))
+}
+
+func TestNewBlobStorage(t *testing.T) {
+	_, err := NewBlobStorage(path.Join(t.TempDir(), "good"))
+	require.NoError(t, err)
+
+	// If directory already exists with improper permissions, expect a wrapped err message.
+	fp := path.Join(t.TempDir(), "bad")
+	require.NoError(t, os.Mkdir(fp, 0777))
+	_, err = NewBlobStorage(fp)
+	require.ErrorContains(t, "failed to create blob storage", err)
 }


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

When a blobstorage directory was created without Prysm's strict permissions requirement, an
unhelpful message is displayed.

```
...
{"addr":"http://127.0.0.1:6060/debug/pprof","message":"Starting pprof server","severity":"INFO"}
{"message":"Finished reading JWT secret from /secret/authrpc/jwt.hex","severity":"INFO"}
dir already exists without proper 0700 permissions
```

Now the error message is more clear.

```
failed to create blob storage at /tmp/beacon/blobs: dir already exists without proper 0700 permissions
```

**Which issues(s) does this PR fix?**

None reported yet.

**Other notes for review**

Also included regression test :muscle:
