### PR TITLE
use different keys for the proposer indices cache

### DIFF
--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -366,6 +366,8 @@ func (s *Service) databaseDACheck(ctx context.Context, b consensusblocks.ROBlock
 
 func (s *Service) updateEpochBoundaryCaches(ctx context.Context, st state.BeaconState) error {
 	e := coreTime.CurrentEpoch(st)
+	// The proposer indices cache takes the target root for the previous
+	// epoch as key
 	if err := helpers.UpdateCommitteeCache(ctx, st, e); err != nil {
 		return errors.Wrap(err, "could not update committee cache")
 	}
@@ -381,7 +383,7 @@ func (s *Service) updateEpochBoundaryCaches(ctx context.Context, st state.Beacon
 		if err := helpers.UpdateCommitteeCache(slotCtx, st, e+1); err != nil {
 			log.WithError(err).Warn("Could not update committee cache")
 		}
-		if err := helpers.UpdateProposerIndicesInCache(slotCtx, st, e+1); err != nil {
+		if err := helpers.UpdateUnsafeProposerIndicesInCache(slotCtx, st, e+1); err != nil {
 			log.WithError(err).Warn("Failed to cache next epoch proposers")
 		}
 	}()

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -366,8 +366,6 @@ func (s *Service) databaseDACheck(ctx context.Context, b consensusblocks.ROBlock
 
 func (s *Service) updateEpochBoundaryCaches(ctx context.Context, st state.BeaconState) error {
 	e := coreTime.CurrentEpoch(st)
-	// The proposer indices cache takes the target root for the previous
-	// epoch as key
 	if err := helpers.UpdateCommitteeCache(ctx, st, e); err != nil {
 		return errors.Wrap(err, "could not update committee cache")
 	}
@@ -393,6 +391,8 @@ func (s *Service) updateEpochBoundaryCaches(ctx context.Context, st state.Beacon
 		log.WithError(err).Error("could not update proposer index state-root map")
 		return nil
 	}
+	// The proposer indices cache takes the target root for the previous
+	// epoch as key
 	target, err := s.cfg.ForkChoiceStore.TargetRootForEpoch(r, e-1)
 	if err != nil {
 		log.WithError(err).Error("could not update proposer index state-root map")
@@ -401,7 +401,6 @@ func (s *Service) updateEpochBoundaryCaches(ctx context.Context, st state.Beacon
 	err = helpers.UpdateCachedCheckpointToStateRoot(st, &forkchoicetypes.Checkpoint{Epoch: e, Root: target})
 	if err != nil {
 		log.WithError(err).Error("could not update proposer index state-root map")
-		return nil
 	}
 	return nil
 }

--- a/beacon-chain/cache/proposer_indices.go
+++ b/beacon-chain/cache/proposer_indices.go
@@ -1,3 +1,5 @@
+//go:build !fuzz
+
 package cache
 
 import (
@@ -118,7 +120,7 @@ func (p *ProposerIndicesCache) Set(epoch primitives.Epoch, root [32]byte, indice
 	inner[root] = indices
 }
 
-// Set sets the unsafe proposer indices for the given root as key
+// SetUnsafe sets the unsafe proposer indices for the given root as key
 func (p *ProposerIndicesCache) SetUnsafe(epoch primitives.Epoch, root [32]byte, indices [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex) {
 	p.Lock()
 	defer p.Unlock()

--- a/beacon-chain/cache/proposer_indices_disabled.go
+++ b/beacon-chain/cache/proposer_indices_disabled.go
@@ -3,7 +3,11 @@
 // This file is used in fuzzer builds to bypass proposer indices caches.
 package cache
 
-import "github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
+import (
+	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
+	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
+	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
+)
 
 // FakeProposerIndicesCache is a struct with 1 queue for looking up proposer indices by root.
 type FakeProposerIndicesCache struct {
@@ -14,26 +18,31 @@ func NewProposerIndicesCache() *FakeProposerIndicesCache {
 	return &FakeProposerIndicesCache{}
 }
 
-// AddProposerIndices adds ProposerIndices object to the cache.
-// This method also trims the least recently list if the cache size has ready the max cache size limit.
-func (c *FakeProposerIndicesCache) AddProposerIndices(p *ProposerIndices) error {
-	return nil
+// ProposerIndices is a stub.
+func (c *FakeProposerIndicesCache) ProposerIndices(_ primitives.Epoch, _ [32]byte) ([fieldparams.SlotsPerEpoch]primitives.ValidatorIndex, bool) {
+	return [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex{}, false
 }
 
-// ProposerIndices returns the proposer indices of a block root seed.
-func (c *FakeProposerIndicesCache) ProposerIndices(r [32]byte) ([]primitives.ValidatorIndex, error) {
-	return nil, nil
+// UnsafeProposerIndices is a stub.
+func (c *FakeProposerIndicesCache) UnsafeProposerIndices(_ primitives.Epoch, _ [32]byte) ([fieldparams.SlotsPerEpoch]primitives.ValidatorIndex, bool) {
+	return [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex{}, false
 }
 
-// HasProposerIndices returns the proposer indices of a block root seed.
-func (c *FakeProposerIndicesCache) HasProposerIndices(r [32]byte) (bool, error) {
-	return false, nil
+// Prune is a stub.
+func (p *FakeProposerIndicesCache) Prune(epoch primitives.Epoch) {}
+
+// Set is a stub.
+func (p *FakeProposerIndicesCache) Set(epoch primitives.Epoch, root [32]byte, indices [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex) {
 }
 
-func (c *FakeProposerIndicesCache) Len() int {
-	return 0
+// SetUnsafe is a stub.
+func (p *FakeProposerIndicesCache) SetUnsafe(epoch primitives.Epoch, root [32]byte, indices [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex) {
 }
 
-// Clear is a stub.
-func (c *FakeProposerIndicesCache) Clear() {
+// SetCheckpoint is a stub.
+func (p *FakeProposerIndicesCache) SetCheckpoint(c forkchoicetypes.Checkpoint, root [32]byte) {}
+
+// IndicesFromCheckpoint is a stub.
+func (p *FakeProposerIndicesCache) IndicesFromCheckpoint(_ forkchoicetypes.Checkpoint) ([fieldparams.SlotsPerEpoch]primitives.ValidatorIndex, bool) {
+	return [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex{}, false
 }

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//beacon-chain/cache:go_default_library",
         "//beacon-chain/core/time:go_default_library",
+        "//beacon-chain/forkchoice/types:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",

--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -3,7 +3,6 @@
 package helpers
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"sort"
@@ -13,6 +12,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/time"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
+	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/container/slice"
@@ -333,36 +333,27 @@ func UpdateCommitteeCache(ctx context.Context, state state.ReadOnlyBeaconState, 
 
 // UpdateProposerIndicesInCache updates proposer indices entry of the committee cache.
 // Input state is used to retrieve active validator indices.
+// Input root is to use as key in the cache.
 // Input epoch is the epoch to retrieve proposer indices for.
 func UpdateProposerIndicesInCache(ctx context.Context, state state.ReadOnlyBeaconState, epoch primitives.Epoch) error {
-	// The cache uses the state root at the (current epoch - 1)'s slot as key. (e.g. for epoch 2, the key is root at slot 63)
-	// Which is the reason why we skip genesis epoch.
+	// The cache uses the state root at the end of (current epoch - 1) as key.
+	// (e.g. for epoch 2, the key is root at slot 63)
 	if epoch <= params.BeaconConfig().GenesisEpoch+params.BeaconConfig().MinSeedLookahead {
 		return nil
 	}
-
-	// Use state root from (current_epoch - 1))
-	s, err := slots.EpochEnd(epoch - 1)
+	slot, err := slots.EpochEnd(epoch - 1)
 	if err != nil {
 		return err
 	}
-	r, err := state.StateRootAtIndex(uint64(s % params.BeaconConfig().SlotsPerHistoricalRoot))
+	root, err := state.StateRootAtIndex(uint64(slot % params.BeaconConfig().SlotsPerHistoricalRoot))
 	if err != nil {
 		return err
-	}
-	// Skip cache update if we have an invalid key
-	if r == nil || bytes.Equal(r, params.BeaconConfig().ZeroHash[:]) {
-		return nil
 	}
 	// Skip cache update if the key already exists
-	exists, err := proposerIndicesCache.HasProposerIndices(bytesutil.ToBytes32(r))
-	if err != nil {
-		return err
-	}
-	if exists {
+	_, ok := proposerIndicesCache.ProposerIndices(epoch, [32]byte(root))
+	if ok {
 		return nil
 	}
-
 	indices, err := ActiveValidatorIndices(ctx, state, epoch)
 	if err != nil {
 		return err
@@ -371,16 +362,64 @@ func UpdateProposerIndicesInCache(ctx context.Context, state state.ReadOnlyBeaco
 	if err != nil {
 		return err
 	}
-	return proposerIndicesCache.AddProposerIndices(&cache.ProposerIndices{
-		BlockRoot:       bytesutil.ToBytes32(r),
-		ProposerIndices: proposerIndices,
-	})
+	if len(proposerIndices) != int(params.BeaconConfig().SlotsPerEpoch) {
+		return errors.New("invalid proposer length returned from state")
+	}
+	// This is here to deal with tests only
+	var indicesArray [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex
+	copy(indicesArray[:], proposerIndices)
+	proposerIndicesCache.Prune(epoch - 2)
+	proposerIndicesCache.Set(epoch, [32]byte(root), indicesArray)
+	return nil
+}
+
+// UpdateUnsafeProposerIndicesInCache updates proposer indices entry of the
+// cache one epoch in advance.
+// Input state is used to retrieve active validator indices.
+// Input root is to use as key in the cache.
+// Input epoch is the epoch to retrieve proposer indices for.
+func UpdateUnsafeProposerIndicesInCache(ctx context.Context, state state.ReadOnlyBeaconState, epoch primitives.Epoch) error {
+	// The cache uses the state root at the end of (current epoch - 2) as key.
+	// (e.g. for epoch 2, the key is root at slot 31)
+	if epoch <= params.BeaconConfig().GenesisEpoch+2*params.BeaconConfig().MinSeedLookahead {
+		return nil
+	}
+	slot, err := slots.EpochEnd(epoch - 2)
+	if err != nil {
+		return err
+	}
+	root, err := state.StateRootAtIndex(uint64(slot % params.BeaconConfig().SlotsPerHistoricalRoot))
+	if err != nil {
+		return err
+	}
+	// Skip cache update if the key already exists
+	_, ok := proposerIndicesCache.UnsafeProposerIndices(epoch, [32]byte(root))
+	if ok {
+		return nil
+	}
+	indices, err := ActiveValidatorIndices(ctx, state, epoch)
+	if err != nil {
+		return err
+	}
+	proposerIndices, err := precomputeProposerIndices(state, indices, epoch)
+	if err != nil {
+		return err
+	}
+	if len(proposerIndices) != int(params.BeaconConfig().SlotsPerEpoch) {
+		return errors.New("invalid proposer length returned from state")
+	}
+	// This is here to deal with tests only
+	var indicesArray [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex
+	copy(indicesArray[:], proposerIndices)
+	proposerIndicesCache.Prune(epoch - 2)
+	proposerIndicesCache.SetUnsafe(epoch, [32]byte(root), indicesArray)
+	return nil
 }
 
 // ClearCache clears the beacon committee cache and sync committee cache.
 func ClearCache() {
 	committeeCache.Clear()
-	proposerIndicesCache.Clear()
+	proposerIndicesCache.Prune(0)
 	syncCommitteeCache.Clear()
 	balanceCache.Clear()
 }

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -264,7 +264,6 @@ func TestBeaconProposerIndex_BadState(t *testing.T) {
 	require.NoError(t, state.SetSlot(100))
 	_, err = BeaconProposerIndex(context.Background(), state)
 	require.NoError(t, err)
-	assert.Equal(t, 0, proposerIndicesCache.Len())
 }
 
 func TestComputeProposerIndex_Compatibility(t *testing.T) {


### PR DESCRIPTION
This PR removes an LRU cache and moves to a cache that keeps maps indexed as

epoch -> state root -> proposer indices. 

They are updated in the same places as before and they are pruned on each update. 