### PR TITLE
io/file: Relax file permissions enforcement on existing directory

### DIFF
--- a/beacon-chain/db/filesystem/blob_test.go
+++ b/beacon-chain/db/filesystem/blob_test.go
@@ -2,7 +2,6 @@ package filesystem
 
 import (
 	"bytes"
-	"os"
 	"path"
 	"testing"
 
@@ -206,10 +205,4 @@ func TestBlobStorageDelete(t *testing.T) {
 func TestNewBlobStorage(t *testing.T) {
 	_, err := NewBlobStorage(path.Join(t.TempDir(), "good"))
 	require.NoError(t, err)
-
-	// If directory already exists with improper permissions, expect a wrapped err message.
-	fp := path.Join(t.TempDir(), "bad")
-	require.NoError(t, os.Mkdir(fp, 0777))
-	_, err = NewBlobStorage(fp)
-	require.ErrorContains(t, "failed to create blob storage", err)
 }

--- a/io/file/fileutil.go
+++ b/io/file/fileutil.go
@@ -59,10 +59,9 @@ func HandleBackupDir(dirPath string, permissionOverride bool) error {
 	return os.MkdirAll(expanded, params.BeaconIoConfig().ReadWriteExecutePermissions)
 }
 
-// MkdirAll takes in a path, expands it if necessary, and looks through the
-// permissions of every directory along the path, ensuring we are not attempting
-// to overwrite any existing permissions. Finally, creates the directory accordingly
-// with standardized, Prysm project permissions. This is the static-analysis enforced
+// MkdirAll takes in a path, expands it if necessary, and creates the directory accordingly
+// with standardized, Prysm project permissions. If a directory already exists as this path,
+// then the method returns without making any changes. This is the static-analysis enforced
 // method for creating a directory programmatically in Prysm.
 func MkdirAll(dirPath string) error {
 	expanded, err := ExpandPath(dirPath)
@@ -74,13 +73,7 @@ func MkdirAll(dirPath string) error {
 		return err
 	}
 	if exists {
-		info, err := os.Stat(expanded)
-		if err != nil {
-			return err
-		}
-		if info.Mode().Perm() != params.BeaconIoConfig().ReadWriteExecutePermissions {
-			return errors.New("dir already exists without proper 0700 permissions")
-		}
+		return nil
 	}
 	return os.MkdirAll(expanded, params.BeaconIoConfig().ReadWriteExecutePermissions)
 }

--- a/io/file/fileutil_test.go
+++ b/io/file/fileutil_test.go
@@ -49,14 +49,6 @@ func TestPathExpansion(t *testing.T) {
 	}
 }
 
-func TestMkdirAll_AlreadyExists_WrongPermissions(t *testing.T) {
-	dirName := t.TempDir() + "somedir"
-	err := os.MkdirAll(dirName, os.ModePerm)
-	require.NoError(t, err)
-	err = file.MkdirAll(dirName)
-	assert.ErrorContains(t, "already exists without proper 0700 permissions", err)
-}
-
 func TestMkdirAll_AlreadyExists_Override(t *testing.T) {
 	dirName := t.TempDir() + "somedir"
 	err := os.MkdirAll(dirName, params.BeaconIoConfig().ReadWriteExecutePermissions)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

In some deployments, file mode 770 is set by the infrastructure. Namely, using kubernetes fsGroup
will modify the directory permissions to 770. This ought to be fine for a directory and does not
pose and significant security risk.

**Which issues(s) does this PR fix?**

**Other notes for review**
