### PR TITLE
Increase Networking Defaults

### DIFF
--- a/beacon-chain/p2p/connection_gater.go
+++ b/beacon-chain/p2p/connection_gater.go
@@ -21,7 +21,7 @@ const (
 
 	// High watermark buffer signifies the buffer till which
 	// we will handle inbound requests.
-	highWatermarkBuffer = 10
+	highWatermarkBuffer = 20
 )
 
 // InterceptPeerDial tests whether we're permitted to Dial the specified peer.

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -159,7 +159,7 @@ var (
 	P2PMaxPeers = &cli.IntFlag{
 		Name:  "p2p-max-peers",
 		Usage: "The max number of p2p peers to maintain.",
-		Value: 45,
+		Value: 70,
 	}
 	// P2PAllowList defines a CIDR subnet to exclusively allow connections.
 	P2PAllowList = &cli.StringFlag{


### PR DESCRIPTION
**What type of PR is this?**

Feature Improvement

**What does this PR do? Why is it needed?**

In conjunction with #13179 , this PR increases some networking defaults to allow nodes to find better and higher quality peers quicker. We increase the max peers default, so that nodes will be able to find peers with the desired number of subnets in an easier fashion. 

We also increase the high watermark for inbound peers before we intercept inbound connections. This is to aid discovery of new peers who do join the network.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
