### PR TITLE
CI: Add merge queue events trigger for github workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ '*' ]
+  merge_group: 
+    types: [checks_requested]
 
 jobs:
   formatting:


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

We want to enable github's merge queue and this is a necessary step for github workflows to trigger
on a merge queue'd PR.

**Which issues(s) does this PR fix?**

**Other notes for review**

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group

