### PR TITLE
Prevent possible resource exhaustion when pruning blobs

### DIFF
--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -203,26 +204,34 @@ func (bs *BlobStorage) Prune(currentSlot primitives.Slot) error {
 	}
 	for _, folder := range folders {
 		if folder.IsDir() {
-			f, err := bs.fs.Open(folder.Name() + "/0." + sszExt)
-			if err != nil {
+			if err := bs.processFolder(folder, currentSlot, retentionSlots); err != nil {
 				return err
 			}
-			defer func(f afero.File) {
-				err := f.Close()
-				if err != nil {
-					log.WithError(err).Errorf("Could not close blob file")
-				}
-			}(f)
+		}
+	}
+	return nil
+}
 
-			slot, err := slotFromBlob(f)
-			if err != nil {
-				return err
-			}
-			if slot < (currentSlot - retentionSlots) {
-				if err = bs.fs.RemoveAll(folder.Name()); err != nil {
-					return errors.Wrapf(err, "failed to delete blob %s", f.Name())
-				}
-			}
+// processFolder will delete the folder of blobs if the blob slot is outside the
+// retention period. We determine the slot by looking at the first blob in the folder.
+func (bs *BlobStorage) processFolder(folder os.FileInfo, currentSlot, retentionSlots primitives.Slot) error {
+	f, err := bs.fs.Open(filepath.Join(folder.Name(), "0."+sszExt))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.WithError(err).Errorf("Could not close blob file")
+		}
+	}()
+
+	slot, err := slotFromBlob(f)
+	if err != nil {
+		return err
+	}
+	if slot < (currentSlot - retentionSlots) {
+		if err = bs.fs.RemoveAll(folder.Name()); err != nil {
+			return errors.Wrapf(err, "failed to delete blob %s", f.Name())
 		}
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR fixes two things:

1. It's not a good idea to `defer` in a loop, as this can lead to resource exhaustion. In this situation, we may run out of file descriptors when pruning as they are held until the function returns. If there 1000 folders, this may become a problem.

2. While not actually a problem because golang handles it appropriately, I prefer to use `filepath.Join()` rather than joining strings with slashes manually, like `bs.fs.Open(folder.Name() + "/0." + sszExt)` does.