### PR TITLE
Forkchoice Store And Simple Map To Build Attestation

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -75,6 +75,7 @@ type HeadFetcher interface {
 	HeadPublicKeyToValidatorIndex(pubKey [fieldparams.BLSPubkeyLength]byte) (primitives.ValidatorIndex, bool)
 	HeadValidatorIndexToPublicKey(ctx context.Context, index primitives.ValidatorIndex) ([fieldparams.BLSPubkeyLength]byte, error)
 	ChainHeads() ([][32]byte, []primitives.Slot)
+	TargetRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 	HeadSyncCommitteeFetcher
 	HeadDomainFetcher
 }

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -73,6 +73,7 @@ type ChainService struct {
 	BlockSlot                   primitives.Slot
 	SyncingRoot                 [32]byte
 	Blobs                       []blocks.VerifiedROBlob
+	TargetRoot                  [32]byte
 }
 
 func (s *ChainService) Ancestor(ctx context.Context, root []byte, slot primitives.Slot) ([]byte, error) {
@@ -616,4 +617,9 @@ func (c *ChainService) BlockBeingSynced(root [32]byte) bool {
 func (c *ChainService) ReceiveBlob(_ context.Context, b blocks.VerifiedROBlob) error {
 	c.Blobs = append(c.Blobs, b)
 	return nil
+}
+
+// TargetRootForEpoch mocks the same method in the chain service
+func (c *ChainService) TargetRootForEpoch(_ [32]byte, _ primitives.Epoch) ([32]byte, error) {
+	return c.TargetRoot, nil
 }

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -3,169 +3,88 @@ package cache
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"sync"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
-	"k8s.io/client-go/tools/cache"
 )
 
-var (
-	// Delay parameters
-	minDelay    = float64(10)        // 10 nanoseconds
-	maxDelay    = float64(100000000) // 0.1 second
-	delayFactor = 1.1
+const maxSize = 4
 
-	// Metrics
+var (
+	// Prometheus counters for cache hits and misses.
 	attestationCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "attestation_cache_miss",
-		Help: "The number of attestation data requests that aren't present in the cache.",
+		Help: "Number of cache misses for attestation data requests.",
 	})
 	attestationCacheHit = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "attestation_cache_hit",
-		Help: "The number of attestation data requests that are present in the cache.",
-	})
-	attestationCacheSize = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "attestation_cache_size",
-		Help: "The number of attestation data in the attestations cache",
+		Help: "Number of cache hits for attestation data requests.",
 	})
 )
 
-// ErrAlreadyInProgress appears when attempting to mark a cache as in progress while it is
-// already in progress. The client should handle this error and wait for the in progress
-// data to resolve via Get.
-var ErrAlreadyInProgress = errors.New("already in progress")
-
-// AttestationCache is used to store the cached results of an AttestationData request.
+// AttestationCache stores cached results of AttestationData requests.
 type AttestationCache struct {
-	cache      *cache.FIFO
-	lock       sync.RWMutex
-	inProgress map[string]bool
+	cache map[primitives.Slot]*ethpb.AttestationData
+	lock  sync.RWMutex
 }
 
-// NewAttestationCache initializes the map and underlying cache.
+// NewAttestationCache creates a new instance of AttestationCache.
 func NewAttestationCache() *AttestationCache {
 	return &AttestationCache{
-		cache:      cache.NewFIFO(wrapperToKey),
-		inProgress: make(map[string]bool),
+		cache: make(map[primitives.Slot]*ethpb.AttestationData),
 	}
 }
 
-// Get waits for any in progress calculation to complete before returning a
-// cached response, if any.
+// Get retrieves cached attestation data, recording a cache hit or miss.
 func (c *AttestationCache) Get(ctx context.Context, req *ethpb.AttestationDataRequest) (*ethpb.AttestationData, error) {
 	if req == nil {
-		return nil, errors.New("nil attestation data request")
+		return nil, errors.New("request cannot be nil")
 	}
 
-	s, e := reqToKey(req)
-	if e != nil {
-		return nil, e
-	}
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 
-	delay := minDelay
-
-	// Another identical request may be in progress already. Let's wait until
-	// any in progress request resolves or our timeout is exceeded.
-	for {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-
-		c.lock.RLock()
-		if !c.inProgress[s] {
-			c.lock.RUnlock()
-			break
-		}
-		c.lock.RUnlock()
-
-		// This increasing backoff is to decrease the CPU cycles while waiting
-		// for the in progress boolean to flip to false.
-		time.Sleep(time.Duration(delay) * time.Nanosecond)
-		delay *= delayFactor
-		delay = math.Min(delay, maxDelay)
-	}
-
-	item, exists, err := c.cache.GetByKey(s)
-	if err != nil {
-		return nil, err
-	}
-
-	if exists && item != nil && item.(*attestationReqResWrapper).res != nil {
+	if res, exists := c.cache[req.Slot]; exists {
 		attestationCacheHit.Inc()
-		return ethpb.CopyAttestationData(item.(*attestationReqResWrapper).res), nil
+		return ethpb.CopyAttestationData(res), nil
 	}
+
 	attestationCacheMiss.Inc()
 	return nil, nil
 }
 
-// MarkInProgress a request so that any other similar requests will block on
-// Get until MarkNotInProgress is called.
-func (c *AttestationCache) MarkInProgress(req *ethpb.AttestationDataRequest) error {
+// Put adds a response to the cache.
+func (c *AttestationCache) Put(ctx context.Context, req *ethpb.AttestationDataRequest, res *ethpb.AttestationData) error {
+	if req == nil || res == nil {
+		return errors.New("request or response cannot be nil")
+	}
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	s, e := reqToKey(req)
-	if e != nil {
-		return e
-	}
-	if c.inProgress[s] {
-		return ErrAlreadyInProgress
-	}
-	c.inProgress[s] = true
+
+	c.cache[req.Slot] = ethpb.CopyAttestationData(res)
+
+	c.trimCache()
+
 	return nil
 }
 
-// MarkNotInProgress will release the lock on a given request. This should be
-// called after put.
-func (c *AttestationCache) MarkNotInProgress(req *ethpb.AttestationDataRequest) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	s, e := reqToKey(req)
-	if e != nil {
-		return e
+// trimCache trims the cache to maintain a maximum size.
+func (c *AttestationCache) trimCache() {
+	if maxSize > len(c.cache) {
+		return
 	}
-	delete(c.inProgress, s)
-	return nil
-}
 
-// Put the response in the cache.
-func (c *AttestationCache) Put(_ context.Context, req *ethpb.AttestationDataRequest, res *ethpb.AttestationData) error {
-	data := &attestationReqResWrapper{
-		req,
-		res,
+	minSlot := primitives.Slot(math.MaxInt64)
+	for slot := range c.cache {
+		if slot < minSlot {
+			minSlot = slot
+		}
 	}
-	if err := c.cache.AddIfNotPresent(data); err != nil {
-		return err
-	}
-	trim(c.cache, maxCacheSize)
 
-	attestationCacheSize.Set(float64(len(c.cache.List())))
-	return nil
-}
-
-func wrapperToKey(i interface{}) (string, error) {
-	w, ok := i.(*attestationReqResWrapper)
-	if !ok {
-		return "", errors.New("key is not of type *attestationReqResWrapper")
-	}
-	if w == nil {
-		return "", errors.New("nil wrapper")
-	}
-	if w.req == nil {
-		return "", errors.New("nil wrapper.request")
-	}
-	return reqToKey(w.req)
-}
-
-func reqToKey(req *ethpb.AttestationDataRequest) (string, error) {
-	return fmt.Sprintf("%d", req.Slot), nil
-}
-
-type attestationReqResWrapper struct {
-	req *ethpb.AttestationDataRequest
-	res *ethpb.AttestationData
+	delete(c.cache, minSlot)
 }

--- a/beacon-chain/cache/error.go
+++ b/beacon-chain/cache/error.go
@@ -14,4 +14,9 @@ var (
 	errNotSyncCommitteeIndexPosition = errors.New("not syncCommitteeIndexPosition struct")
 	// ErrNotFoundRegistration when validator registration does not exist in cache.
 	ErrNotFoundRegistration = errors.Wrap(ErrNotFound, "no validator registered")
+
+	// ErrAlreadyInProgress appears when attempting to mark a cache as in progress while it is
+	// already in progress. The client should handle this error and wait for the in progress
+	// data to resolve via Get.
+	ErrAlreadyInProgress = errors.New("already in progress")
 )

--- a/beacon-chain/cache/skip_slot_cache.go
+++ b/beacon-chain/cache/skip_slot_cache.go
@@ -15,6 +15,11 @@ import (
 )
 
 var (
+	// Delay parameters
+	minDelay    = float64(10)        // 10 nanoseconds
+	maxDelay    = float64(100000000) // 0.1 second
+	delayFactor = 1.1
+
 	// Metrics
 	skipSlotCacheHit = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "skip_slot_cache_hit",

--- a/beacon-chain/rpc/core/service.go
+++ b/beacon-chain/rpc/core/service.go
@@ -12,6 +12,7 @@ import (
 
 type Service struct {
 	HeadFetcher        blockchain.HeadFetcher
+	FinalizedFetcher   blockchain.FinalizationFetcher
 	GenesisTimeFetcher blockchain.TimeFetcher
 	SyncChecker        sync.Checker
 	Broadcaster        p2p.Broadcaster

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -372,83 +372,25 @@ func (s *Service) GetAttestationData(
 		return res, nil
 	}
 
-	if err := s.AttestationCache.MarkInProgress(req); err != nil {
-		if errors.Is(err, cache.ErrAlreadyInProgress) {
-			res, err := s.AttestationCache.Get(ctx, req)
-			if err != nil {
-				return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not retrieve data from attestation cache: %v", err)}
-			}
-			if res == nil {
-				return nil, &RpcError{Reason: Internal, Err: errors.New("a request was in progress and resolved to nil")}
-			}
-			res.CommitteeIndex = req.CommitteeIndex
-			return res, nil
-		}
-		return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not mark attestation as in-progress: %v", err)}
-	}
-	defer func() {
-		if err := s.AttestationCache.MarkNotInProgress(req); err != nil {
-			log.WithError(err).Error("could not mark attestation as not-in-progress")
-		}
-	}()
-
-	headState, err := s.HeadFetcher.HeadState(ctx)
-	if err != nil {
-		return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not retrieve head state: %v", err)}
-	}
 	headRoot, err := s.HeadFetcher.HeadRoot(ctx)
 	if err != nil {
-		return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not retrieve head root: %v", err)}
+		return nil, &RpcError{Reason: Internal, Err: errors.Wrap(err, "could not get head root")}
 	}
-
-	// In the case that we receive an attestation request after a newer state/block has been processed.
-	if headState.Slot() > req.Slot {
-		headRoot, err = helpers.BlockRootAtSlot(headState, req.Slot)
-		if err != nil {
-			return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not get historical head root: %v", err)}
-		}
-		headState, err = s.StateGen.StateByRoot(ctx, bytesutil.ToBytes32(headRoot))
-		if err != nil {
-			return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not get historical head state: %v", err)}
-		}
-	}
-	if headState == nil || headState.IsNil() {
-		return nil, &RpcError{Reason: Internal, Err: errors.New("could not lookup parent state from head")}
-	}
-
-	if coreTime.CurrentEpoch(headState) < slots.ToEpoch(req.Slot) {
-		headState, err = transition.ProcessSlotsUsingNextSlotCache(ctx, headState, headRoot, req.Slot)
-		if err != nil {
-			return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not process slots up to %d: %v", req.Slot, err)}
-		}
-	}
-
-	targetEpoch := coreTime.CurrentEpoch(headState)
-	epochStartSlot, err := slots.EpochStart(targetEpoch)
+	targetEpoch := slots.ToEpoch(req.Slot)
+	targetRoot, err := s.HeadFetcher.TargetRootForEpoch(bytesutil.ToBytes32(headRoot), targetEpoch)
 	if err != nil {
-		return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not calculate epoch start: %v", err)}
+		return nil, &RpcError{Reason: Internal, Err: errors.Wrap(err, "could not get target root")}
 	}
-	var targetRoot []byte
-	if epochStartSlot == headState.Slot() {
-		targetRoot = headRoot
-	} else {
-		targetRoot, err = helpers.BlockRootAtSlot(headState, epochStartSlot)
-		if err != nil {
-			return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not get target block for slot %d: %v", epochStartSlot, err)}
-		}
-		if bytesutil.ToBytes32(targetRoot) == params.BeaconConfig().ZeroHash {
-			targetRoot = headRoot
-		}
-	}
+	justifiedCheckpoint := s.FinalizedFetcher.CurrentJustifiedCheckpt()
 
 	res = &ethpb.AttestationData{
 		Slot:            req.Slot,
 		CommitteeIndex:  req.CommitteeIndex,
 		BeaconBlockRoot: headRoot,
-		Source:          headState.CurrentJustifiedCheckpoint(),
+		Source:          justifiedCheckpoint,
 		Target: &ethpb.Checkpoint{
 			Epoch: targetEpoch,
-			Root:  targetRoot,
+			Root:  targetRoot[:],
 		},
 	}
 

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -31,7 +30,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/eth/shared"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/testutil"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
-	state_native "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state/stategen"
 	mockSync "github.com/prysmaticlabs/prysm/v4/beacon-chain/sync/initial-sync/testing"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
@@ -833,29 +831,18 @@ func TestGetAttestationData(t *testing.T) {
 		require.NoError(t, err, "Could not hash beacon block")
 		justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
 		require.NoError(t, err, "Could not get signing root for justified block")
-		targetRoot, err := targetBlock.Block.HashTreeRoot()
-		require.NoError(t, err, "Could not get signing root for target block")
 		slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
-		beaconState, err := util.NewBeaconState()
-		require.NoError(t, err)
-		require.NoError(t, beaconState.SetSlot(slot))
-		err = beaconState.SetCurrentJustifiedCheckpoint(&ethpbalpha.Checkpoint{
+		justifiedCheckpoint := &ethpbalpha.Checkpoint{
 			Epoch: 2,
 			Root:  justifiedRoot[:],
-		})
-		require.NoError(t, err)
-
-		blockRoots := beaconState.BlockRoots()
-		blockRoots[1] = blockRoot[:]
-		blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-		blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-		require.NoError(t, beaconState.SetBlockRoots(blockRoots))
+		}
 		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 		chain := &mockChain.ChainService{
-			Optimistic: false,
-			Genesis:    time.Now().Add(time.Duration(-1*offset) * time.Second),
-			State:      beaconState,
-			Root:       blockRoot[:],
+			Optimistic:                 false,
+			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Root:                       blockRoot[:],
+			CurrentJustifiedCheckPoint: justifiedCheckpoint,
+			TargetRoot:                 blockRoot,
 		}
 
 		s := &Server{
@@ -864,9 +851,9 @@ func TestGetAttestationData(t *testing.T) {
 			TimeFetcher:           chain,
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
 				HeadFetcher:        chain,
 				GenesisTimeFetcher: chain,
+				FinalizedFetcher:   chain,
 			},
 		}
 
@@ -934,9 +921,10 @@ func TestGetAttestationData(t *testing.T) {
 		beaconState, err := util.NewBeaconState()
 		require.NoError(t, err)
 		chain := &mockChain.ChainService{
-			Optimistic: true,
-			State:      beaconState,
-			Genesis:    time.Now(),
+			Optimistic:                 true,
+			State:                      beaconState,
+			Genesis:                    time.Now(),
+			CurrentJustifiedCheckPoint: &ethpbalpha.Checkpoint{},
 		}
 
 		s := &Server{
@@ -945,9 +933,9 @@ func TestGetAttestationData(t *testing.T) {
 			TimeFetcher:           chain,
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
 				GenesisTimeFetcher: chain,
 				HeadFetcher:        chain,
+				FinalizedFetcher:   chain,
 			},
 		}
 
@@ -974,97 +962,13 @@ func TestGetAttestationData(t *testing.T) {
 		assert.Equal(t, http.StatusOK, writer.Code)
 	})
 
-	t.Run("handles in progress request", func(t *testing.T) {
-		state, err := state_native.InitializeFromProtoPhase0(&ethpbalpha.BeaconState{Slot: 100})
-		require.NoError(t, err)
-		ctx := context.Background()
-		slot := primitives.Slot(2)
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
-		chain := &mockChain.ChainService{
-			Optimistic: false,
-			Genesis:    time.Now().Add(time.Duration(-1*offset) * time.Second),
-			State:      state,
-		}
-
-		s := &Server{
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			HeadFetcher:           chain,
-			TimeFetcher:           chain,
-			OptimisticModeFetcher: chain,
-			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
-				HeadFetcher:        chain,
-				GenesisTimeFetcher: chain,
-			},
-		}
-
-		expectedResponse := &GetAttestationDataResponse{
-			Data: &shared.AttestationData{
-				Slot:            strconv.FormatUint(uint64(slot), 10),
-				CommitteeIndex:  strconv.FormatUint(1, 10),
-				BeaconBlockRoot: hexutil.Encode(make([]byte, 32)),
-				Source: &shared.Checkpoint{
-					Epoch: strconv.FormatUint(42, 10),
-					Root:  hexutil.Encode(make([]byte, 32)),
-				},
-				Target: &shared.Checkpoint{
-					Epoch: strconv.FormatUint(55, 10),
-					Root:  hexutil.Encode(make([]byte, 32)),
-				},
-			},
-		}
-
-		expectedResponsePb := &ethpbalpha.AttestationData{
-			Slot:            slot,
-			CommitteeIndex:  1,
-			BeaconBlockRoot: make([]byte, 32),
-			Source:          &ethpbalpha.Checkpoint{Epoch: 42, Root: make([]byte, 32)},
-			Target:          &ethpbalpha.Checkpoint{Epoch: 55, Root: make([]byte, 32)},
-		}
-
-		url := fmt.Sprintf("http://example.com?slot=%d&committee_index=%d", slot, 1)
-		request := httptest.NewRequest(http.MethodGet, url, nil)
-		writer := httptest.NewRecorder()
-		writer.Body = &bytes.Buffer{}
-
-		requestPb := &ethpbalpha.AttestationDataRequest{
-			CommitteeIndex: 1,
-			Slot:           slot,
-		}
-
-		require.NoError(t, s.CoreService.AttestationCache.MarkInProgress(requestPb))
-
-		var wg sync.WaitGroup
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			s.GetAttestationData(writer, request)
-
-			assert.Equal(t, http.StatusOK, writer.Code)
-			resp := &GetAttestationDataResponse{}
-			require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
-			require.NotNil(t, resp)
-			assert.DeepEqual(t, expectedResponse, resp)
-		}()
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			assert.NoError(t, s.CoreService.AttestationCache.Put(ctx, requestPb, expectedResponsePb))
-			assert.NoError(t, s.CoreService.AttestationCache.MarkNotInProgress(requestPb))
-		}()
-
-		wg.Wait()
-	})
-
 	t.Run("invalid slot", func(t *testing.T) {
 		slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
 		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 		chain := &mockChain.ChainService{
-			Optimistic: false,
-			Genesis:    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Optimistic:                 false,
+			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			CurrentJustifiedCheckPoint: &ethpbalpha.Checkpoint{},
 		}
 
 		s := &Server{
@@ -1074,6 +978,7 @@ func TestGetAttestationData(t *testing.T) {
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
 				GenesisTimeFetcher: chain,
+				FinalizedFetcher:   chain,
 			},
 		}
 
@@ -1111,37 +1016,17 @@ func TestGetAttestationData(t *testing.T) {
 		util.SaveBlock(t, ctx, db, block2)
 		justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
 		require.NoError(t, err, "Could not get signing root for justified block")
-		targetRoot, err := targetBlock.Block.HashTreeRoot()
-		require.NoError(t, err, "Could not get signing root for target block")
-
-		beaconState, err := util.NewBeaconState()
-		require.NoError(t, err)
-		require.NoError(t, beaconState.SetSlot(slot))
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
-		require.NoError(t, beaconState.SetGenesisTime(uint64(time.Now().Unix()-offset)))
-		err = beaconState.SetLatestBlockHeader(util.HydrateBeaconHeader(&ethpbalpha.BeaconBlockHeader{
-			ParentRoot: blockRoot2[:],
-		}))
-		require.NoError(t, err)
-		err = beaconState.SetCurrentJustifiedCheckpoint(&ethpbalpha.Checkpoint{
+		justifiedCheckpoint := &ethpbalpha.Checkpoint{
 			Epoch: 2,
 			Root:  justifiedRoot[:],
-		})
-		require.NoError(t, err)
-		blockRoots := beaconState.BlockRoots()
-		blockRoots[1] = blockRoot[:]
-		blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-		blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-		blockRoots[3*params.BeaconConfig().SlotsPerEpoch] = blockRoot2[:]
-		require.NoError(t, beaconState.SetBlockRoots(blockRoots))
+		}
 
-		beaconstate := beaconState.Copy()
-		require.NoError(t, beaconstate.SetSlot(beaconstate.Slot()-1))
-		require.NoError(t, db.SaveState(ctx, beaconstate, blockRoot2))
+		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 		chain := &mockChain.ChainService{
-			State:   beaconState,
-			Root:    blockRoot[:],
-			Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Root:                       blockRoot[:],
+			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			CurrentJustifiedCheckPoint: justifiedCheckpoint,
+			TargetRoot:                 blockRoot2,
 		}
 
 		s := &Server{
@@ -1150,16 +1035,12 @@ func TestGetAttestationData(t *testing.T) {
 			TimeFetcher:           chain,
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
 				HeadFetcher:        chain,
 				GenesisTimeFetcher: chain,
 				StateGen:           stategen.New(db, doublylinkedtree.New()),
+				FinalizedFetcher:   chain,
 			},
 		}
-
-		require.NoError(t, db.SaveState(ctx, beaconState, blockRoot))
-		util.SaveBlock(t, ctx, db, block)
-		require.NoError(t, db.SaveHeadBlockRoot(ctx, blockRoot))
 
 		url := fmt.Sprintf("http://example.com?slot=%d&committee_index=%d", slot-1, 0)
 		request := httptest.NewRequest(http.MethodGet, url, nil)
@@ -1172,7 +1053,7 @@ func TestGetAttestationData(t *testing.T) {
 			Data: &shared.AttestationData{
 				Slot:            strconv.FormatUint(uint64(slot-1), 10),
 				CommitteeIndex:  strconv.FormatUint(0, 10),
-				BeaconBlockRoot: hexutil.Encode(blockRoot2[:]),
+				BeaconBlockRoot: hexutil.Encode(blockRoot[:]),
 				Source: &shared.Checkpoint{
 					Epoch: strconv.FormatUint(2, 10),
 					Root:  hexutil.Encode(justifiedRoot[:]),
@@ -1203,27 +1084,18 @@ func TestGetAttestationData(t *testing.T) {
 		require.NoError(t, err, "Could not hash beacon block")
 		justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
 		require.NoError(t, err, "Could not get signing root for justified block")
-		targetRoot, err := targetBlock.Block.HashTreeRoot()
-		require.NoError(t, err, "Could not get signing root for target block")
 
-		beaconState, err := util.NewBeaconState()
-		require.NoError(t, err)
-		require.NoError(t, beaconState.SetSlot(slot))
-		err = beaconState.SetCurrentJustifiedCheckpoint(&ethpbalpha.Checkpoint{
+		justifiedCheckpt := &ethpbalpha.Checkpoint{
 			Epoch: 0,
 			Root:  justifiedRoot[:],
-		})
+		}
 		require.NoError(t, err)
-		blockRoots := beaconState.BlockRoots()
-		blockRoots[1] = blockRoot[:]
-		blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-		blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-		require.NoError(t, beaconState.SetBlockRoots(blockRoots))
 		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 		chain := &mockChain.ChainService{
-			State:   beaconState,
-			Root:    blockRoot[:],
-			Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Root:                       blockRoot[:],
+			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			CurrentJustifiedCheckPoint: justifiedCheckpt,
+			TargetRoot:                 blockRoot,
 		}
 
 		s := &Server{
@@ -1232,9 +1104,9 @@ func TestGetAttestationData(t *testing.T) {
 			TimeFetcher:           chain,
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
 				HeadFetcher:        chain,
 				GenesisTimeFetcher: chain,
+				FinalizedFetcher:   chain,
 			},
 		}
 
@@ -1298,28 +1170,17 @@ func TestGetAttestationData(t *testing.T) {
 		require.NoError(t, err, "Could not hash beacon block")
 		justifiedBlockRoot, err := justifiedBlock.Block.HashTreeRoot()
 		require.NoError(t, err, "Could not hash justified block")
-		epochBoundaryRoot, err := epochBoundaryBlock.Block.HashTreeRoot()
-		require.NoError(t, err, "Could not hash justified block")
-		slot := primitives.Slot(10000)
-
-		beaconState, err := util.NewBeaconState()
-		require.NoError(t, err)
-		require.NoError(t, beaconState.SetSlot(slot))
-		err = beaconState.SetCurrentJustifiedCheckpoint(&ethpbalpha.Checkpoint{
+		justifiedCheckpt := &ethpbalpha.Checkpoint{
 			Epoch: slots.ToEpoch(1500),
 			Root:  justifiedBlockRoot[:],
-		})
-		require.NoError(t, err)
-		blockRoots := beaconState.BlockRoots()
-		blockRoots[1] = blockRoot[:]
-		blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = epochBoundaryRoot[:]
-		blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedBlockRoot[:]
-		require.NoError(t, beaconState.SetBlockRoots(blockRoots))
+		}
+		slot := primitives.Slot(10000)
 		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 		chain := &mockChain.ChainService{
-			State:   beaconState,
-			Root:    blockRoot[:],
-			Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Root:                       blockRoot[:],
+			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			CurrentJustifiedCheckPoint: justifiedCheckpt,
+			TargetRoot:                 blockRoot,
 		}
 
 		s := &Server{
@@ -1328,9 +1189,9 @@ func TestGetAttestationData(t *testing.T) {
 			TimeFetcher:           chain,
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
 				HeadFetcher:        chain,
 				GenesisTimeFetcher: chain,
+				FinalizedFetcher:   chain,
 			},
 		}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/operations/attestations"
 	mockp2p "github.com/prysmaticlabs/prysm/v4/beacon-chain/p2p/testing"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/core"
-	state_native "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state/stategen"
 	mockSync "github.com/prysmaticlabs/prysm/v4/beacon-chain/sync/initial-sync/testing"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
@@ -93,42 +92,31 @@ func TestGetAttestationData_OK(t *testing.T) {
 	block.Block.Slot = 3*params.BeaconConfig().SlotsPerEpoch + 1
 	targetBlock := util.NewBeaconBlock()
 	targetBlock.Block.Slot = 1 * params.BeaconConfig().SlotsPerEpoch
+	targetRoot, err := targetBlock.Block.HashTreeRoot()
+	require.NoError(t, err, "Could not get signing root for target block")
+
 	justifiedBlock := util.NewBeaconBlock()
 	justifiedBlock.Block.Slot = 2 * params.BeaconConfig().SlotsPerEpoch
 	blockRoot, err := block.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not hash beacon block")
 	justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not get signing root for justified block")
-	targetRoot, err := targetBlock.Block.HashTreeRoot()
-	require.NoError(t, err, "Could not get signing root for target block")
 	slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
-	beaconState, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, beaconState.SetSlot(slot))
-	err = beaconState.SetCurrentJustifiedCheckpoint(&ethpb.Checkpoint{
+	justifiedCheckpoint := &ethpb.Checkpoint{
 		Epoch: 2,
 		Root:  justifiedRoot[:],
-	})
-	require.NoError(t, err)
-
-	blockRoots := beaconState.BlockRoots()
-	blockRoots[1] = blockRoot[:]
-	blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-	blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-	require.NoError(t, beaconState.SetBlockRoots(blockRoots))
+	}
 	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
 		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
 		CoreService: &core.Service{
-			AttestationCache: cache.NewAttestationCache(),
-			HeadFetcher: &mock.ChainService{
-				State: beaconState, Root: blockRoot[:],
-			},
+			HeadFetcher: &mock.ChainService{TargetRoot: targetRoot, Root: blockRoot[:]},
 			GenesisTimeFetcher: &mock.ChainService{
 				Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
 			},
+			FinalizedFetcher: &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 		},
 	}
 
@@ -148,13 +136,70 @@ func TestGetAttestationData_OK(t *testing.T) {
 		},
 		Target: &ethpb.Checkpoint{
 			Epoch: 3,
-			Root:  blockRoot[:],
+			Root:  targetRoot[:],
 		},
 	}
 
 	if !proto.Equal(res, expectedInfo) {
 		t.Errorf("Expected attestation info to match, received %v, wanted %v", res, expectedInfo)
 	}
+}
+
+func BenchmarkGetAttestationDataConcurrent(b *testing.B) {
+	block := util.NewBeaconBlock()
+	block.Block.Slot = 3*params.BeaconConfig().SlotsPerEpoch + 1
+	targetBlock := util.NewBeaconBlock()
+	targetBlock.Block.Slot = 1 * params.BeaconConfig().SlotsPerEpoch
+	targetRoot, err := targetBlock.Block.HashTreeRoot()
+	require.NoError(b, err, "Could not get signing root for target block")
+
+	justifiedBlock := util.NewBeaconBlock()
+	justifiedBlock.Block.Slot = 2 * params.BeaconConfig().SlotsPerEpoch
+	blockRoot, err := block.Block.HashTreeRoot()
+	require.NoError(b, err, "Could not hash beacon block")
+	justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
+	require.NoError(b, err, "Could not get signing root for justified block")
+	slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
+	justifiedCheckpoint := &ethpb.Checkpoint{
+		Epoch: 2,
+		Root:  justifiedRoot[:],
+	}
+	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	attesterServer := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
+		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+		CoreService: &core.Service{
+			AttestationCache: cache.NewAttestationCache(),
+			HeadFetcher:      &mock.ChainService{TargetRoot: targetRoot, Root: blockRoot[:]},
+			GenesisTimeFetcher: &mock.ChainService{
+				Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+			},
+			FinalizedFetcher: &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
+		},
+	}
+
+	req := &ethpb.AttestationDataRequest{
+		CommitteeIndex: 0,
+		Slot:           3*params.BeaconConfig().SlotsPerEpoch + 1,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+		wg.Add(5000) // for 1000 concurrent accesses
+
+		for j := 0; j < 5000; j++ {
+			go func() {
+				defer wg.Done()
+				_, err := attesterServer.GetAttestationData(context.Background(), req)
+				require.NoError(b, err, "Could not get attestation info at slot")
+			}()
+		}
+		wg.Wait() // Wait for all goroutines to finish
+	}
+
+	b.Log("Elapsed time:", b.Elapsed())
 }
 
 func TestGetAttestationData_SyncNotReady(t *testing.T) {
@@ -195,64 +240,11 @@ func TestGetAttestationData_Optimistic(t *testing.T) {
 		CoreService: &core.Service{
 			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now()},
 			HeadFetcher:        &mock.ChainService{Optimistic: false, State: beaconState},
-			AttestationCache:   cache.NewAttestationCache(),
+			FinalizedFetcher:   &mock.ChainService{},
 		},
 	}
 	_, err = as.GetAttestationData(context.Background(), &ethpb.AttestationDataRequest{})
 	require.NoError(t, err)
-}
-
-func TestAttestationDataSlot_handlesInProgressRequest(t *testing.T) {
-	s := &ethpb.BeaconState{Slot: 100}
-	state, err := state_native.InitializeFromProtoPhase0(s)
-	require.NoError(t, err)
-	ctx := context.Background()
-	slot := primitives.Slot(2)
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
-	server := &Server{
-		SyncChecker:           &mockSync.Sync{IsSyncing: false},
-		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
-		CoreService: &core.Service{
-			AttestationCache:   cache.NewAttestationCache(),
-			HeadFetcher:        &mock.ChainService{State: state},
-			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
-		},
-	}
-
-	req := &ethpb.AttestationDataRequest{
-		CommitteeIndex: 1,
-		Slot:           slot,
-	}
-
-	res := &ethpb.AttestationData{
-		CommitteeIndex: 1,
-		Target:         &ethpb.Checkpoint{Epoch: 55, Root: make([]byte, 32)},
-	}
-
-	require.NoError(t, server.CoreService.AttestationCache.MarkInProgress(req))
-
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		response, err := server.GetAttestationData(ctx, req)
-		require.NoError(t, err)
-		if !proto.Equal(res, response) {
-			t.Error("Expected  equal responses from cache")
-		}
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		assert.NoError(t, server.CoreService.AttestationCache.Put(ctx, req, res))
-		assert.NoError(t, server.CoreService.AttestationCache.MarkNotInProgress(req))
-	}()
-
-	wg.Wait()
 }
 
 func TestServer_GetAttestationData_InvalidRequestSlot(t *testing.T) {
@@ -279,7 +271,7 @@ func TestServer_GetAttestationData_InvalidRequestSlot(t *testing.T) {
 func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testing.T) {
 	// There exists a rare scenario where the validator may request an attestation for a slot less
 	// than the head state's slot. The Ethereum consensus spec constraints require the block root the
-	// attestation is referencing be less than or equal to the attestation data slot.
+	// attestation is referencing to be less than or equal to the attestation data slot.
 	// See: https://github.com/prysmaticlabs/prysm/issues/5164
 	ctx := context.Background()
 	db := dbutil.SetupDB(t)
@@ -300,48 +292,23 @@ func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testin
 	util.SaveBlock(t, ctx, db, block2)
 	justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not get signing root for justified block")
-	targetRoot, err := targetBlock.Block.HashTreeRoot()
-	require.NoError(t, err, "Could not get signing root for target block")
-
-	beaconState, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, beaconState.SetSlot(slot))
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
-	require.NoError(t, beaconState.SetGenesisTime(uint64(time.Now().Unix()-offset)))
-	err = beaconState.SetLatestBlockHeader(util.HydrateBeaconHeader(&ethpb.BeaconBlockHeader{
-		ParentRoot: blockRoot2[:],
-	}))
-	require.NoError(t, err)
-	err = beaconState.SetCurrentJustifiedCheckpoint(&ethpb.Checkpoint{
+	justifiedCheckpoint := &ethpb.Checkpoint{
 		Epoch: 2,
 		Root:  justifiedRoot[:],
-	})
-	require.NoError(t, err)
-	blockRoots := beaconState.BlockRoots()
-	blockRoots[1] = blockRoot[:]
-	blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-	blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-	blockRoots[3*params.BeaconConfig().SlotsPerEpoch] = blockRoot2[:]
-	require.NoError(t, beaconState.SetBlockRoots(blockRoots))
-
-	beaconstate := beaconState.Copy()
-	require.NoError(t, beaconstate.SetSlot(beaconstate.Slot()-1))
-	require.NoError(t, db.SaveState(ctx, beaconstate, blockRoot2))
-	offset = int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	}
+	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
 		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
 		CoreService: &core.Service{
-			AttestationCache:   cache.NewAttestationCache(),
-			HeadFetcher:        &mock.ChainService{State: beaconState, Root: blockRoot[:]},
+			HeadFetcher:        &mock.ChainService{TargetRoot: blockRoot2, Root: blockRoot[:]},
 			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
 			StateGen:           stategen.New(db, doublylinkedtree.New()),
+			FinalizedFetcher:   &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 		},
 	}
-	require.NoError(t, db.SaveState(ctx, beaconState, blockRoot))
 	util.SaveBlock(t, ctx, db, block)
-	require.NoError(t, db.SaveHeadBlockRoot(ctx, blockRoot))
 
 	req := &ethpb.AttestationDataRequest{
 		CommitteeIndex: 0,
@@ -352,7 +319,7 @@ func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testin
 
 	expectedInfo := &ethpb.AttestationData{
 		Slot:            slot - 1,
-		BeaconBlockRoot: blockRoot2[:],
+		BeaconBlockRoot: blockRoot[:],
 		Source: &ethpb.Checkpoint{
 			Epoch: 2,
 			Root:  justifiedRoot[:],
@@ -383,30 +350,21 @@ func TestGetAttestationData_SucceedsInFirstEpoch(t *testing.T) {
 	targetRoot, err := targetBlock.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not get signing root for target block")
 
-	beaconState, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, beaconState.SetSlot(slot))
-	err = beaconState.SetCurrentJustifiedCheckpoint(&ethpb.Checkpoint{
+	justifiedCheckpoint := &ethpb.Checkpoint{
 		Epoch: 0,
 		Root:  justifiedRoot[:],
-	})
-	require.NoError(t, err)
-	blockRoots := beaconState.BlockRoots()
-	blockRoots[1] = blockRoot[:]
-	blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-	blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-	require.NoError(t, beaconState.SetBlockRoots(blockRoots))
+	}
 	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
 		TimeFetcher:           &mock.ChainService{Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second)},
 		CoreService: &core.Service{
-			AttestationCache: cache.NewAttestationCache(),
 			HeadFetcher: &mock.ChainService{
-				State: beaconState, Root: blockRoot[:],
+				TargetRoot: targetRoot, Root: blockRoot[:],
 			},
 			GenesisTimeFetcher: &mock.ChainService{Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second)},
+			FinalizedFetcher:   &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 		},
 	}
 
@@ -426,7 +384,7 @@ func TestGetAttestationData_SucceedsInFirstEpoch(t *testing.T) {
 		},
 		Target: &ethpb.Checkpoint{
 			Epoch: 0,
-			Root:  blockRoot[:],
+			Root:  targetRoot[:],
 		},
 	}
 


### PR DESCRIPTION
This alternative to #13256 employs the fork choice store for building attestations, complemented by a simple read lock map. The map features a trim function activated at insertion when the size reaches 4, designed to discard the entry with the lowest slot.