### PR TITLE
Ensure partial blob is deleted if there's an error

### DIFF
--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -94,8 +94,13 @@ func (bs *BlobStorage) Save(sidecar blocks.VerifiedROBlob) error {
 
 	// Ensure the partial file is deleted.
 	defer func() {
-		// Ignore return value, it's expected to fail if the save is successful.
-		_ = bs.fs.Remove(partPath)
+		// It's expected to error if the save is successful.
+		err = bs.fs.Remove(partPath)
+		if err == nil {
+			log.WithFields(log.Fields{
+				"partPath": partPath,
+			}).Debugf("removed partial file")
+		}
 	}()
 
 	// Create a partial file and write the serialized data to it.

--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -91,6 +91,13 @@ func (bs *BlobStorage) Save(sidecar blocks.VerifiedROBlob) error {
 		return err
 	}
 	partPath := fname.partPath()
+
+	// Ensure the partial file is deleted.
+	defer func() {
+		// Ignore return value, it's expected to fail if the save is successful.
+		_ = bs.fs.Remove(partPath)
+	}()
+
 	// Create a partial file and write the serialized data to it.
 	partialFile, err := bs.fs.Create(partPath)
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

This PR ensures that the partial file is deleted if there's an error saving. For example, if we attempt to save the same blob at the same time (race condition) and `Rename` returns an error. Just being extra defensive.

Worth noting, the deferred removal is queued before the file is created so it should always cleanup. The return value is ignored because it is expected to return an error if everything is successful (because the file won't exist).

**Which issues(s) does this PR fix?**

Fixes #13287
