### PR TITLE
initialize sig cache for verification.Initializer

### DIFF
--- a/beacon-chain/verification/initializer_test.go
+++ b/beacon-chain/verification/initializer_test.go
@@ -1,0 +1,28 @@
+package verification
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/startup"
+	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
+	"github.com/prysmaticlabs/prysm/v4/testing/require"
+)
+
+func TestInitializerWaiter(t *testing.T) {
+	ctx := context.Background()
+	vr := bytesutil.ToBytes32([]byte{0, 1, 1, 2, 3, 5})
+	gen := time.Now()
+	c := startup.NewClock(gen, vr)
+	cs := startup.NewClockSynchronizer()
+	cs.SetClock(c)
+
+	w := NewInitializerWaiter(cs, &mockForkchoicer{}, &mockStateByRooter{})
+	ini, err := w.WaitForInitializer(ctx)
+	require.NoError(t, err)
+	csc, ok := ini.shared.sc.(*sigCache)
+	require.Equal(t, true, ok)
+	require.Equal(t, true, bytes.Equal(vr[:], csc.valRoot))
+}


### PR DESCRIPTION
# verification.InitializerWaiter initializes SignatureCache

## protected init

Rather than requiring the caches as init time arguments, the InitializerWaiter internally sets up the cache. At this time we have hardcoded the cache size but we could add a func opt to tweak it later. The signature cache requires the genesis validator root (for computing the signing domain without needing a state), so it is easiest to set it up in `WaitForInitializer` which blocks until a `startup.Clock` is available. `startup.Clock.GenesisValidatorsRoot` gives us the root we need, and the initializer/verifier/cache stack isn't usable until that wait func completes, so this all lines up nicely.

The dummy proposer cache doesn't have any dependencies so it is initialized inside `NewInitializerWaiter`.

## rm Database

There was a vestigial Database interface which is no longer used. This was removed from the `NewInitializerWaiter` constructor func.