### PR TITLE
Gracefully handle unknown validator index in the REST VC

### DIFF
--- a/validator/client/BUILD.bazel
+++ b/validator/client/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "//time/slots:go_default_library",
         "//validator/accounts/iface:go_default_library",
         "//validator/accounts/wallet:go_default_library",
+        "//validator/client/beacon-api:go_default_library",
         "//validator/client/beacon-chain-client-factory:go_default_library",
         "//validator/client/iface:go_default_library",
         "//validator/client/node-client-factory:go_default_library",

--- a/validator/client/beacon-api/index.go
+++ b/validator/client/beacon-api/index.go
@@ -2,6 +2,7 @@ package beacon_api
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -9,6 +10,23 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 )
+
+// IndexNotFoundError represents an error scenario where no validator index matches a pubkey.
+type IndexNotFoundError struct {
+	message string
+}
+
+// NewIndexNotFoundError creates a new error instance.
+func NewIndexNotFoundError(pubkey string) IndexNotFoundError {
+	return IndexNotFoundError{
+		message: fmt.Sprintf("could not find validator index for public key %s", pubkey),
+	}
+}
+
+// Error returns the underlying error message.
+func (e *IndexNotFoundError) Error() string {
+	return e.message
+}
 
 func (c beaconApiValidatorClient) validatorIndex(ctx context.Context, in *ethpb.ValidatorIndexRequest) (*ethpb.ValidatorIndexResponse, error) {
 	stringPubKey := hexutil.Encode(in.PublicKey)
@@ -19,7 +37,8 @@ func (c beaconApiValidatorClient) validatorIndex(ctx context.Context, in *ethpb.
 	}
 
 	if len(stateValidator.Data) == 0 {
-		return nil, errors.Errorf("could not find validator index for public key `%s`", stringPubKey)
+		e := NewIndexNotFoundError(stringPubKey)
+		return nil, &e
 	}
 
 	stringValidatorIndex := stateValidator.Data[0].Index

--- a/validator/client/beacon-api/index.go
+++ b/validator/client/beacon-api/index.go
@@ -19,7 +19,7 @@ type IndexNotFoundError struct {
 // NewIndexNotFoundError creates a new error instance.
 func NewIndexNotFoundError(pubkey string) IndexNotFoundError {
 	return IndexNotFoundError{
-		message: fmt.Sprintf("could not find validator index for public key %s", pubkey),
+		message: fmt.Sprintf("could not find validator index for public key `%s`", pubkey),
 	}
 }
 

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -35,6 +35,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
 	accountsiface "github.com/prysmaticlabs/prysm/v4/validator/accounts/iface"
 	"github.com/prysmaticlabs/prysm/v4/validator/accounts/wallet"
+	beacon_api "github.com/prysmaticlabs/prysm/v4/validator/client/beacon-api"
 	"github.com/prysmaticlabs/prysm/v4/validator/client/iface"
 	vdb "github.com/prysmaticlabs/prysm/v4/validator/db"
 	"github.com/prysmaticlabs/prysm/v4/validator/db/kv"
@@ -1240,6 +1241,12 @@ func (v *validator) validatorIndex(ctx context.Context, pubkey [fieldparams.BLSP
 			"Perhaps the validator is not yet active.", pubkey)
 		return 0, false, nil
 	case err != nil:
+		notFoundErr := &beacon_api.IndexNotFoundError{}
+		if errors.As(err, &notFoundErr) {
+			log.Debugf("Could not find validator index for public key %#x. "+
+				"Perhaps the validator is not yet active.", pubkey)
+			return 0, false, nil
+		}
 		return 0, false, err
 	}
 	return resp.Index, true, nil


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

Bug fix

**What does this PR do? Why is it needed?**

The `validatorIndex` function compared the error returned from the API client with a gRPC status code to handle the case when an index is not found. The REST endpoint doesn't return such a status code, and because of this `validatorIndex` always fails for unknown pubkeys when the REST client is used. This PR creates a custom error in the REST API client and checks against it inside `validatorIndex`.
