### PR TITLE
Beacon API: fix get blob returns 500 instead of empty

### DIFF
--- a/beacon-chain/rpc/lookup/blocker.go
+++ b/beacon-chain/rpc/lookup/blocker.go
@@ -139,7 +139,6 @@ func (p *BeaconDbBlocker) Block(ctx context.Context, id []byte) (interfaces.Read
 //   - <hex encoded block root with '0x' prefix>
 //   - <block root>
 func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64) ([]*blocks.VerifiedROBlob, *core.RpcError) {
-	var blobs []*blocks.VerifiedROBlob
 	var root []byte
 	switch id {
 	case "genesis":
@@ -219,11 +218,8 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 			}
 		}
 	}
-
-	if len(indices) == 0 {
-		return nil, &core.RpcError{Err: errors.New("no blobs found"), Reason: core.Internal}
-	}
-
+	// returns empty slice if there are no indices
+	blobs := make([]*blocks.VerifiedROBlob, len(indices))
 	for _, index := range indices {
 		vblob, err := p.BlobStorage.Get(bytesutil.ToBytes32(root), index)
 		if err != nil {

--- a/beacon-chain/rpc/lookup/blocker.go
+++ b/beacon-chain/rpc/lookup/blocker.go
@@ -220,12 +220,12 @@ func (p *BeaconDbBlocker) Blobs(ctx context.Context, id string, indices []uint64
 	}
 	// returns empty slice if there are no indices
 	blobs := make([]*blocks.VerifiedROBlob, len(indices))
-	for _, index := range indices {
+	for i, index := range indices {
 		vblob, err := p.BlobStorage.Get(bytesutil.ToBytes32(root), index)
 		if err != nil {
 			return nil, &core.RpcError{Err: errors.Wrapf(err, "could not retrieve blob for block root %#x at index %d", root, index), Reason: core.Internal}
 		}
-		blobs = append(blobs, &vblob)
+		blobs[i] = &vblob
 	}
 	return blobs, nil
 }

--- a/beacon-chain/rpc/lookup/blocker_test.go
+++ b/beacon-chain/rpc/lookup/blocker_test.go
@@ -267,4 +267,14 @@ func TestGetBlob(t *testing.T) {
 		assert.DeepEqual(t, blobs[2].KzgCommitment, sidecar.KzgCommitment)
 		assert.DeepEqual(t, blobs[2].KzgProof, sidecar.KzgProof)
 	})
+	t.Run("no blobs returns an empty array", func(t *testing.T) {
+		blocker := &BeaconDbBlocker{
+			ChainInfoFetcher: &mockChain.ChainService{FinalizedCheckPoint: &ethpbalpha.Checkpoint{Root: blockRoot[:]}},
+			BeaconDB:         db,
+			BlobStorage:      filesystem.NewEphemeralBlobStorage(t),
+		}
+		verifiedBlobs, rpcErr := blocker.Blobs(ctx, "123", nil)
+		assert.Equal(t, rpcErr == nil, true)
+		require.Equal(t, 0, len(verifiedBlobs))
+	})
 }


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

Fixes the error response on empty blob return, should return an empty array now.  adds some unit tests to cover the specific case.

**Which issues(s) does this PR fix?**

Fixes #13134

**Other notes for review**
