### PR TITLE
Use a cache of one entry to build attestation

### DIFF
--- a/beacon-chain/blockchain/chain_info.go
+++ b/beacon-chain/blockchain/chain_info.go
@@ -75,6 +75,7 @@ type HeadFetcher interface {
 	HeadPublicKeyToValidatorIndex(pubKey [fieldparams.BLSPubkeyLength]byte) (primitives.ValidatorIndex, bool)
 	HeadValidatorIndexToPublicKey(ctx context.Context, index primitives.ValidatorIndex) ([fieldparams.BLSPubkeyLength]byte, error)
 	ChainHeads() ([][32]byte, []primitives.Slot)
+	TargetRootForEpoch([32]byte, primitives.Epoch) ([32]byte, error)
 	HeadSyncCommitteeFetcher
 	HeadDomainFetcher
 }

--- a/beacon-chain/blockchain/testing/mock.go
+++ b/beacon-chain/blockchain/testing/mock.go
@@ -73,6 +73,7 @@ type ChainService struct {
 	BlockSlot                   primitives.Slot
 	SyncingRoot                 [32]byte
 	Blobs                       []blocks.VerifiedROBlob
+	TargetRoot                  [32]byte
 }
 
 func (s *ChainService) Ancestor(ctx context.Context, root []byte, slot primitives.Slot) ([]byte, error) {
@@ -616,4 +617,9 @@ func (c *ChainService) BlockBeingSynced(root [32]byte) bool {
 func (c *ChainService) ReceiveBlob(_ context.Context, b blocks.VerifiedROBlob) error {
 	c.Blobs = append(c.Blobs, b)
 	return nil
+}
+
+// TargetRootForEpoch mocks the same method in the chain service
+func (c *ChainService) TargetRootForEpoch(_ [32]byte, _ primitives.Epoch) ([32]byte, error) {
+	return c.TargetRoot, nil
 }

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -90,6 +90,7 @@ go_test(
         "//testing/util:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
         "@com_github_google_gofuzz//:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
         "@org_golang_google_protobuf//proto:go_default_library",
     ],
 )

--- a/beacon-chain/cache/BUILD.bazel
+++ b/beacon-chain/cache/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//tools:__subpackages__",
     ],
     deps = [
+        "//beacon-chain/forkchoice/types:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//cache/lru:go_default_library",
         "//config/fieldparams:go_default_library",
@@ -78,6 +79,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//beacon-chain/forkchoice/types:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//beacon-chain/state/state-native:go_default_library",
         "//config/fieldparams:go_default_library",

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -3,169 +3,65 @@ package cache
 import (
 	"context"
 	"errors"
-	"fmt"
-	"math"
 	"sync"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
-	"k8s.io/client-go/tools/cache"
 )
 
-var (
-	// Delay parameters
-	minDelay    = float64(10)        // 10 nanoseconds
-	maxDelay    = float64(100000000) // 0.1 second
-	delayFactor = 1.1
+const maxSize = 4
 
-	// Metrics
+var (
+	// Prometheus counters for cache hits and misses.
 	attestationCacheMiss = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "attestation_cache_miss",
-		Help: "The number of attestation data requests that aren't present in the cache.",
+		Help: "Number of cache misses for attestation data requests.",
 	})
 	attestationCacheHit = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "attestation_cache_hit",
-		Help: "The number of attestation data requests that are present in the cache.",
-	})
-	attestationCacheSize = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "attestation_cache_size",
-		Help: "The number of attestation data in the attestations cache",
+		Help: "Number of cache hits for attestation data requests.",
 	})
 )
 
-// ErrAlreadyInProgress appears when attempting to mark a cache as in progress while it is
-// already in progress. The client should handle this error and wait for the in progress
-// data to resolve via Get.
-var ErrAlreadyInProgress = errors.New("already in progress")
-
-// AttestationCache is used to store the cached results of an AttestationData request.
+// AttestationCache stores cached results of AttestationData requests.
 type AttestationCache struct {
-	cache      *cache.FIFO
-	lock       sync.RWMutex
-	inProgress map[string]bool
+	a    *ethpb.AttestationData
+	lock sync.RWMutex
 }
 
-// NewAttestationCache initializes the map and underlying cache.
+// NewAttestationCache creates a new instance of AttestationCache.
 func NewAttestationCache() *AttestationCache {
-	return &AttestationCache{
-		cache:      cache.NewFIFO(wrapperToKey),
-		inProgress: make(map[string]bool),
-	}
+	return &AttestationCache{}
 }
 
-// Get waits for any in progress calculation to complete before returning a
-// cached response, if any.
+// Get retrieves cached attestation data, recording a cache hit or miss.
 func (c *AttestationCache) Get(ctx context.Context, req *ethpb.AttestationDataRequest) (*ethpb.AttestationData, error) {
 	if req == nil {
-		return nil, errors.New("nil attestation data request")
+		return nil, errors.New("request cannot be nil")
 	}
 
-	s, e := reqToKey(req)
-	if e != nil {
-		return nil, e
-	}
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 
-	delay := minDelay
-
-	// Another identical request may be in progress already. Let's wait until
-	// any in progress request resolves or our timeout is exceeded.
-	for {
-		if ctx.Err() != nil {
-			return nil, ctx.Err()
-		}
-
-		c.lock.RLock()
-		if !c.inProgress[s] {
-			c.lock.RUnlock()
-			break
-		}
-		c.lock.RUnlock()
-
-		// This increasing backoff is to decrease the CPU cycles while waiting
-		// for the in progress boolean to flip to false.
-		time.Sleep(time.Duration(delay) * time.Nanosecond)
-		delay *= delayFactor
-		delay = math.Min(delay, maxDelay)
-	}
-
-	item, exists, err := c.cache.GetByKey(s)
-	if err != nil {
-		return nil, err
-	}
-
-	if exists && item != nil && item.(*attestationReqResWrapper).res != nil {
+	if req.Slot == c.a.Slot {
 		attestationCacheHit.Inc()
-		return ethpb.CopyAttestationData(item.(*attestationReqResWrapper).res), nil
+		return ethpb.CopyAttestationData(c.a), nil
 	}
 	attestationCacheMiss.Inc()
 	return nil, nil
 }
 
-// MarkInProgress a request so that any other similar requests will block on
-// Get until MarkNotInProgress is called.
-func (c *AttestationCache) MarkInProgress(req *ethpb.AttestationDataRequest) error {
+// Put adds a response to the cache.
+func (c *AttestationCache) Put(ctx context.Context, res *ethpb.AttestationData) error {
+	if res == nil {
+		return errors.New("attestation cannot be nil")
+	}
+
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	s, e := reqToKey(req)
-	if e != nil {
-		return e
-	}
-	if c.inProgress[s] {
-		return ErrAlreadyInProgress
-	}
-	c.inProgress[s] = true
+
+	c.a = res
+
 	return nil
-}
-
-// MarkNotInProgress will release the lock on a given request. This should be
-// called after put.
-func (c *AttestationCache) MarkNotInProgress(req *ethpb.AttestationDataRequest) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	s, e := reqToKey(req)
-	if e != nil {
-		return e
-	}
-	delete(c.inProgress, s)
-	return nil
-}
-
-// Put the response in the cache.
-func (c *AttestationCache) Put(_ context.Context, req *ethpb.AttestationDataRequest, res *ethpb.AttestationData) error {
-	data := &attestationReqResWrapper{
-		req,
-		res,
-	}
-	if err := c.cache.AddIfNotPresent(data); err != nil {
-		return err
-	}
-	trim(c.cache, maxCacheSize)
-
-	attestationCacheSize.Set(float64(len(c.cache.List())))
-	return nil
-}
-
-func wrapperToKey(i interface{}) (string, error) {
-	w, ok := i.(*attestationReqResWrapper)
-	if !ok {
-		return "", errors.New("key is not of type *attestationReqResWrapper")
-	}
-	if w == nil {
-		return "", errors.New("nil wrapper")
-	}
-	if w.req == nil {
-		return "", errors.New("nil wrapper.request")
-	}
-	return reqToKey(w.req)
-}
-
-func reqToKey(req *ethpb.AttestationDataRequest) (string, error) {
-	return fmt.Sprintf("%d", req.Slot), nil
-}
-
-type attestationReqResWrapper struct {
-	req *ethpb.AttestationDataRequest
-	res *ethpb.AttestationData
 }

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -6,14 +6,15 @@ import (
 	"sync"
 
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
-	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 )
 
 type AttestationConsensusData struct {
-	Slot             primitives.Slot
-	HeadRoot         []byte
-	TargetCheckpoint *ethpb.Checkpoint
-	SourceCheckpoint *ethpb.Checkpoint
+	Slot        primitives.Slot
+	HeadRoot    []byte
+	TargetRoot  []byte
+	TargetEpoch primitives.Epoch
+	SourceRoot  []byte
+	SourceEpoch primitives.Epoch
 }
 
 // AttestationCache stores cached results of AttestationData requests.

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -5,16 +5,15 @@ import (
 	"errors"
 	"sync"
 
+	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 )
 
 type AttestationConsensusData struct {
-	Slot        primitives.Slot
-	HeadRoot    []byte
-	TargetRoot  []byte
-	TargetEpoch primitives.Epoch
-	SourceRoot  []byte
-	SourceEpoch primitives.Epoch
+	Slot     primitives.Slot
+	HeadRoot []byte
+	Target   forkchoicetypes.Checkpoint
+	Source   forkchoicetypes.Checkpoint
 }
 
 // AttestationCache stores cached results of AttestationData requests.
@@ -28,24 +27,36 @@ func NewAttestationCache() *AttestationCache {
 	return &AttestationCache{}
 }
 
-// Get retrieves cached attestation data, recording a cache hit or miss.
+// Get retrieves cached attestation data, recording a cache hit or miss. This method is lock free.
 func (c *AttestationCache) Get(ctx context.Context) (*AttestationConsensusData, error) {
-	c.lock.RLock()
-	defer c.lock.RUnlock()
-
 	return c.a, nil
 }
 
-// Put adds a response to the cache.
+// Put adds a response to the cache. This method is lock free.
 func (c *AttestationCache) Put(ctx context.Context, a *AttestationConsensusData) error {
 	if a == nil {
 		return errors.New("attestation cannot be nil")
 	}
-
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
 	c.a = a
-
 	return nil
+}
+
+// Lock locks the cache for writing.
+func (c *AttestationCache) Lock() {
+	c.lock.Lock()
+}
+
+// Unlock unlocks the cache for writing.
+func (c *AttestationCache) Unlock() {
+	c.lock.Unlock()
+}
+
+// RLock locks the cache for reading.
+func (c *AttestationCache) RLock() {
+	c.lock.RLock()
+}
+
+// RUnlock unlocks the cache for reading.
+func (c *AttestationCache) RUnlock() {
+	c.lock.RUnlock()
 }

--- a/beacon-chain/cache/attestation_data.go
+++ b/beacon-chain/cache/attestation_data.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"context"
 	"errors"
 	"sync"
 
@@ -18,8 +17,8 @@ type AttestationConsensusData struct {
 
 // AttestationCache stores cached results of AttestationData requests.
 type AttestationCache struct {
-	a    *AttestationConsensusData
-	lock sync.RWMutex
+	a *AttestationConsensusData
+	sync.RWMutex
 }
 
 // NewAttestationCache creates a new instance of AttestationCache.
@@ -28,35 +27,15 @@ func NewAttestationCache() *AttestationCache {
 }
 
 // Get retrieves cached attestation data, recording a cache hit or miss. This method is lock free.
-func (c *AttestationCache) Get(ctx context.Context) (*AttestationConsensusData, error) {
-	return c.a, nil
+func (c *AttestationCache) Get() *AttestationConsensusData {
+	return c.a
 }
 
 // Put adds a response to the cache. This method is lock free.
-func (c *AttestationCache) Put(ctx context.Context, a *AttestationConsensusData) error {
+func (c *AttestationCache) Put(a *AttestationConsensusData) error {
 	if a == nil {
 		return errors.New("attestation cannot be nil")
 	}
 	c.a = a
 	return nil
-}
-
-// Lock locks the cache for writing.
-func (c *AttestationCache) Lock() {
-	c.lock.Lock()
-}
-
-// Unlock unlocks the cache for writing.
-func (c *AttestationCache) Unlock() {
-	c.lock.Unlock()
-}
-
-// RLock locks the cache for reading.
-func (c *AttestationCache) RLock() {
-	c.lock.RLock()
-}
-
-// RUnlock unlocks the cache for reading.
-func (c *AttestationCache) RUnlock() {
-	c.lock.RUnlock()
 }

--- a/beacon-chain/cache/attestation_data_test.go
+++ b/beacon-chain/cache/attestation_data_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/cache"
+	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,12 +18,16 @@ func TestAttestationCache_RoundTrip(t *testing.T) {
 	require.Nil(t, a)
 
 	insert := &cache.AttestationConsensusData{
-		Slot:        1,
-		HeadRoot:    []byte{1},
-		TargetRoot:  []byte{2},
-		TargetEpoch: 3,
-		SourceRoot:  []byte{4},
-		SourceEpoch: 5,
+		Slot:     1,
+		HeadRoot: []byte{1},
+		Target: forkchoicetypes.Checkpoint{
+			Epoch: 2,
+			Root:  [32]byte{3},
+		},
+		Source: forkchoicetypes.Checkpoint{
+			Epoch: 4,
+			Root:  [32]byte{5},
+		},
 	}
 	err = c.Put(ctx, insert)
 	require.NoError(t, err)
@@ -32,12 +37,16 @@ func TestAttestationCache_RoundTrip(t *testing.T) {
 	require.Equal(t, insert, a)
 
 	insert = &cache.AttestationConsensusData{
-		Slot:        6,
-		HeadRoot:    []byte{7},
-		TargetRoot:  []byte{8},
-		TargetEpoch: 9,
-		SourceRoot:  []byte{10},
-		SourceEpoch: 11,
+		Slot:     6,
+		HeadRoot: []byte{7},
+		Target: forkchoicetypes.Checkpoint{
+			Epoch: 8,
+			Root:  [32]byte{9},
+		},
+		Source: forkchoicetypes.Checkpoint{
+			Epoch: 10,
+			Root:  [32]byte{11},
+		},
 	}
 
 	err = c.Put(ctx, insert)

--- a/beacon-chain/cache/attestation_data_test.go
+++ b/beacon-chain/cache/attestation_data_test.go
@@ -5,37 +5,45 @@ import (
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/cache"
-	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
-	"github.com/prysmaticlabs/prysm/v4/testing/assert"
-	"google.golang.org/protobuf/proto"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAttestationCache_RoundTrip(t *testing.T) {
 	ctx := context.Background()
 	c := cache.NewAttestationCache()
 
-	req := &ethpb.AttestationDataRequest{
-		CommitteeIndex: 0,
-		Slot:           1,
+	a, err := c.Get(ctx)
+	require.NoError(t, err)
+	require.Nil(t, a)
+
+	insert := &cache.AttestationConsensusData{
+		Slot:        1,
+		HeadRoot:    []byte{1},
+		TargetRoot:  []byte{2},
+		TargetEpoch: 3,
+		SourceRoot:  []byte{4},
+		SourceEpoch: 5,
+	}
+	err = c.Put(ctx, insert)
+	require.NoError(t, err)
+
+	a, err = c.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, insert, a)
+
+	insert = &cache.AttestationConsensusData{
+		Slot:        6,
+		HeadRoot:    []byte{7},
+		TargetRoot:  []byte{8},
+		TargetEpoch: 9,
+		SourceRoot:  []byte{10},
+		SourceEpoch: 11,
 	}
 
-	response, err := c.Get(ctx, req)
-	assert.NoError(t, err)
-	assert.Equal(t, (*ethpb.AttestationData)(nil), response)
+	err = c.Put(ctx, insert)
+	require.NoError(t, err)
 
-	assert.NoError(t, c.MarkInProgress(req))
-
-	res := &ethpb.AttestationData{
-		Target: &ethpb.Checkpoint{Epoch: 5, Root: make([]byte, 32)},
-	}
-
-	assert.NoError(t, c.Put(ctx, req, res))
-	assert.NoError(t, c.MarkNotInProgress(req))
-
-	response, err = c.Get(ctx, req)
-	assert.NoError(t, err)
-
-	if !proto.Equal(response, res) {
-		t.Error("Expected equal protos to return from cache")
-	}
+	a, err = c.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, insert, a)
 }

--- a/beacon-chain/cache/attestation_data_test.go
+++ b/beacon-chain/cache/attestation_data_test.go
@@ -1,7 +1,6 @@
 package cache_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/cache"
@@ -10,11 +9,9 @@ import (
 )
 
 func TestAttestationCache_RoundTrip(t *testing.T) {
-	ctx := context.Background()
 	c := cache.NewAttestationCache()
 
-	a, err := c.Get(ctx)
-	require.NoError(t, err)
+	a := c.Get()
 	require.Nil(t, a)
 
 	insert := &cache.AttestationConsensusData{
@@ -29,11 +26,10 @@ func TestAttestationCache_RoundTrip(t *testing.T) {
 			Root:  [32]byte{5},
 		},
 	}
-	err = c.Put(ctx, insert)
+	err := c.Put(insert)
 	require.NoError(t, err)
 
-	a, err = c.Get(ctx)
-	require.NoError(t, err)
+	a = c.Get()
 	require.Equal(t, insert, a)
 
 	insert = &cache.AttestationConsensusData{
@@ -49,10 +45,9 @@ func TestAttestationCache_RoundTrip(t *testing.T) {
 		},
 	}
 
-	err = c.Put(ctx, insert)
+	err = c.Put(insert)
 	require.NoError(t, err)
 
-	a, err = c.Get(ctx)
-	require.NoError(t, err)
+	a = c.Get()
 	require.Equal(t, insert, a)
 }

--- a/beacon-chain/cache/common.go
+++ b/beacon-chain/cache/common.go
@@ -1,14 +1,7 @@
 package cache
 
 import (
-	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"k8s.io/client-go/tools/cache"
-)
-
-var (
-	// maxCacheSize is 4x of the epoch length for additional cache padding.
-	// Requests should be only accessing committees within defined epoch length.
-	maxCacheSize = uint64(4 * params.BeaconConfig().SlotsPerEpoch)
 )
 
 // trim the FIFO queue to the maxSize.

--- a/beacon-chain/cache/error.go
+++ b/beacon-chain/cache/error.go
@@ -14,4 +14,9 @@ var (
 	errNotSyncCommitteeIndexPosition = errors.New("not syncCommitteeIndexPosition struct")
 	// ErrNotFoundRegistration when validator registration does not exist in cache.
 	ErrNotFoundRegistration = errors.Wrap(ErrNotFound, "no validator registered")
+
+	// ErrAlreadyInProgress appears when attempting to mark a cache as in progress while it is
+	// already in progress. The client should handle this error and wait for the in progress
+	// data to resolve via Get.
+	ErrAlreadyInProgress = errors.New("already in progress")
 )

--- a/beacon-chain/cache/skip_slot_cache.go
+++ b/beacon-chain/cache/skip_slot_cache.go
@@ -15,6 +15,11 @@ import (
 )
 
 var (
+	// Delay parameters
+	minDelay    = float64(10)        // 10 nanoseconds
+	maxDelay    = float64(100000000) // 0.1 second
+	delayFactor = 1.1
+
 	// Metrics
 	skipSlotCacheHit = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "skip_slot_cache_hit",

--- a/beacon-chain/rpc/core/BUILD.bazel
+++ b/beacon-chain/rpc/core/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/time:go_default_library",
         "//beacon-chain/core/transition:go_default_library",
+        "//beacon-chain/forkchoice/types:go_default_library",
         "//beacon-chain/operations/synccommittee:go_default_library",
         "//beacon-chain/p2p:go_default_library",
         "//beacon-chain/state:go_default_library",

--- a/beacon-chain/rpc/core/service.go
+++ b/beacon-chain/rpc/core/service.go
@@ -12,6 +12,7 @@ import (
 
 type Service struct {
 	HeadFetcher        blockchain.HeadFetcher
+	FinalizedFetcher   blockchain.FinalizationFetcher
 	GenesisTimeFetcher blockchain.TimeFetcher
 	SyncChecker        sync.Checker
 	Broadcaster        p2p.Broadcaster

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -334,7 +334,7 @@ func (s *Service) GetAttestationData(
 		return &ethpb.AttestationData{
 			Slot:            res.Slot,
 			CommitteeIndex:  req.CommitteeIndex,
-			BeaconBlockRoot: res.HeadRoot[:],
+			BeaconBlockRoot: res.HeadRoot,
 			Source:          res.SourceCheckpoint,
 			Target:          res.TargetCheckpoint,
 		}, nil
@@ -367,7 +367,7 @@ func (s *Service) GetAttestationData(
 	return &ethpb.AttestationData{
 		Slot:            res.Slot,
 		CommitteeIndex:  req.CommitteeIndex,
-		BeaconBlockRoot: res.HeadRoot[:],
+		BeaconBlockRoot: res.HeadRoot,
 		Source:          res.SourceCheckpoint,
 		Target:          res.TargetCheckpoint,
 	}, nil

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -330,6 +330,7 @@ func (s *Service) GetAttestationData(
 	s.AttestationCache.RLock()
 	res, err := s.AttestationCache.Get(ctx)
 	if err != nil {
+		s.AttestationCache.RUnlock()
 		return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not retrieve data from attestation cache: %v", err)}
 	}
 	if res != nil && res.Slot == req.Slot {

--- a/beacon-chain/rpc/core/validator.go
+++ b/beacon-chain/rpc/core/validator.go
@@ -330,7 +330,7 @@ func (s *Service) GetAttestationData(
 	if err != nil {
 		return nil, &RpcError{Reason: Internal, Err: errors.Errorf("could not retrieve data from attestation cache: %v", err)}
 	}
-	if res.Slot == req.Slot {
+	if res != nil && res.Slot == req.Slot {
 		return &ethpb.AttestationData{
 			Slot:            res.Slot,
 			CommitteeIndex:  req.CommitteeIndex,
@@ -357,7 +357,7 @@ func (s *Service) GetAttestationData(
 	}
 	justifiedCheckpoint := s.FinalizedFetcher.CurrentJustifiedCheckpt()
 	if err = s.AttestationCache.Put(ctx, &cache.AttestationConsensusData{
-		Slot:        res.Slot,
+		Slot:        req.Slot,
 		HeadRoot:    headRoot,
 		TargetRoot:  targetRoot[:],
 		TargetEpoch: targetEpoch,
@@ -368,9 +368,9 @@ func (s *Service) GetAttestationData(
 	}
 
 	return &ethpb.AttestationData{
-		Slot:            res.Slot,
+		Slot:            req.Slot,
 		CommitteeIndex:  req.CommitteeIndex,
-		BeaconBlockRoot: res.HeadRoot,
+		BeaconBlockRoot: headRoot,
 		Source: &ethpb.Checkpoint{
 			Epoch: justifiedCheckpoint.Epoch,
 			Root:  justifiedCheckpoint.Root,

--- a/beacon-chain/rpc/eth/validator/BUILD.bazel
+++ b/beacon-chain/rpc/eth/validator/BUILD.bazel
@@ -77,7 +77,6 @@ go_test(
         "//beacon-chain/rpc/eth/shared/testing:go_default_library",
         "//beacon-chain/rpc/testutil:go_default_library",
         "//beacon-chain/state:go_default_library",
-        "//beacon-chain/state/state-native:go_default_library",
         "//beacon-chain/state/stategen:go_default_library",
         "//beacon-chain/sync/initial-sync/testing:go_default_library",
         "//config/fieldparams:go_default_library",

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -31,7 +30,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/eth/shared"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/testutil"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
-	state_native "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state/stategen"
 	mockSync "github.com/prysmaticlabs/prysm/v4/beacon-chain/sync/initial-sync/testing"
 	fieldparams "github.com/prysmaticlabs/prysm/v4/config/fieldparams"
@@ -814,29 +812,18 @@ func TestGetAttestationData(t *testing.T) {
 		require.NoError(t, err, "Could not hash beacon block")
 		justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
 		require.NoError(t, err, "Could not get signing root for justified block")
-		targetRoot, err := targetBlock.Block.HashTreeRoot()
-		require.NoError(t, err, "Could not get signing root for target block")
 		slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
-		beaconState, err := util.NewBeaconState()
-		require.NoError(t, err)
-		require.NoError(t, beaconState.SetSlot(slot))
-		err = beaconState.SetCurrentJustifiedCheckpoint(&ethpbalpha.Checkpoint{
+		justifiedCheckpoint := &ethpbalpha.Checkpoint{
 			Epoch: 2,
 			Root:  justifiedRoot[:],
-		})
-		require.NoError(t, err)
-
-		blockRoots := beaconState.BlockRoots()
-		blockRoots[1] = blockRoot[:]
-		blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-		blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-		require.NoError(t, beaconState.SetBlockRoots(blockRoots))
+		}
 		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 		chain := &mockChain.ChainService{
-			Optimistic: false,
-			Genesis:    time.Now().Add(time.Duration(-1*offset) * time.Second),
-			State:      beaconState,
-			Root:       blockRoot[:],
+			Optimistic:                 false,
+			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Root:                       blockRoot[:],
+			CurrentJustifiedCheckPoint: justifiedCheckpoint,
+			TargetRoot:                 blockRoot,
 		}
 
 		s := &Server{
@@ -845,9 +832,9 @@ func TestGetAttestationData(t *testing.T) {
 			TimeFetcher:           chain,
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
 				HeadFetcher:        chain,
 				GenesisTimeFetcher: chain,
+				FinalizedFetcher:   chain,
 			},
 		}
 
@@ -915,9 +902,10 @@ func TestGetAttestationData(t *testing.T) {
 		beaconState, err := util.NewBeaconState()
 		require.NoError(t, err)
 		chain := &mockChain.ChainService{
-			Optimistic: true,
-			State:      beaconState,
-			Genesis:    time.Now(),
+			Optimistic:                 true,
+			State:                      beaconState,
+			Genesis:                    time.Now(),
+			CurrentJustifiedCheckPoint: &ethpbalpha.Checkpoint{},
 		}
 
 		s := &Server{
@@ -926,9 +914,9 @@ func TestGetAttestationData(t *testing.T) {
 			TimeFetcher:           chain,
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
 				GenesisTimeFetcher: chain,
 				HeadFetcher:        chain,
+				FinalizedFetcher:   chain,
 			},
 		}
 
@@ -955,97 +943,13 @@ func TestGetAttestationData(t *testing.T) {
 		assert.Equal(t, http.StatusOK, writer.Code)
 	})
 
-	t.Run("handles in progress request", func(t *testing.T) {
-		state, err := state_native.InitializeFromProtoPhase0(&ethpbalpha.BeaconState{Slot: 100})
-		require.NoError(t, err)
-		ctx := context.Background()
-		slot := primitives.Slot(2)
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
-		chain := &mockChain.ChainService{
-			Optimistic: false,
-			Genesis:    time.Now().Add(time.Duration(-1*offset) * time.Second),
-			State:      state,
-		}
-
-		s := &Server{
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			HeadFetcher:           chain,
-			TimeFetcher:           chain,
-			OptimisticModeFetcher: chain,
-			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
-				HeadFetcher:        chain,
-				GenesisTimeFetcher: chain,
-			},
-		}
-
-		expectedResponse := &GetAttestationDataResponse{
-			Data: &shared.AttestationData{
-				Slot:            strconv.FormatUint(uint64(slot), 10),
-				CommitteeIndex:  strconv.FormatUint(1, 10),
-				BeaconBlockRoot: hexutil.Encode(make([]byte, 32)),
-				Source: &shared.Checkpoint{
-					Epoch: strconv.FormatUint(42, 10),
-					Root:  hexutil.Encode(make([]byte, 32)),
-				},
-				Target: &shared.Checkpoint{
-					Epoch: strconv.FormatUint(55, 10),
-					Root:  hexutil.Encode(make([]byte, 32)),
-				},
-			},
-		}
-
-		expectedResponsePb := &ethpbalpha.AttestationData{
-			Slot:            slot,
-			CommitteeIndex:  1,
-			BeaconBlockRoot: make([]byte, 32),
-			Source:          &ethpbalpha.Checkpoint{Epoch: 42, Root: make([]byte, 32)},
-			Target:          &ethpbalpha.Checkpoint{Epoch: 55, Root: make([]byte, 32)},
-		}
-
-		url := fmt.Sprintf("http://example.com?slot=%d&committee_index=%d", slot, 1)
-		request := httptest.NewRequest(http.MethodGet, url, nil)
-		writer := httptest.NewRecorder()
-		writer.Body = &bytes.Buffer{}
-
-		requestPb := &ethpbalpha.AttestationDataRequest{
-			CommitteeIndex: 1,
-			Slot:           slot,
-		}
-
-		require.NoError(t, s.CoreService.AttestationCache.MarkInProgress(requestPb))
-
-		var wg sync.WaitGroup
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			s.GetAttestationData(writer, request)
-
-			assert.Equal(t, http.StatusOK, writer.Code)
-			resp := &GetAttestationDataResponse{}
-			require.NoError(t, json.Unmarshal(writer.Body.Bytes(), resp))
-			require.NotNil(t, resp)
-			assert.DeepEqual(t, expectedResponse, resp)
-		}()
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			assert.NoError(t, s.CoreService.AttestationCache.Put(ctx, requestPb, expectedResponsePb))
-			assert.NoError(t, s.CoreService.AttestationCache.MarkNotInProgress(requestPb))
-		}()
-
-		wg.Wait()
-	})
-
 	t.Run("invalid slot", func(t *testing.T) {
 		slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
 		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 		chain := &mockChain.ChainService{
-			Optimistic: false,
-			Genesis:    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Optimistic:                 false,
+			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			CurrentJustifiedCheckPoint: &ethpbalpha.Checkpoint{},
 		}
 
 		s := &Server{
@@ -1055,6 +959,7 @@ func TestGetAttestationData(t *testing.T) {
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
 				GenesisTimeFetcher: chain,
+				FinalizedFetcher:   chain,
 			},
 		}
 
@@ -1092,37 +997,17 @@ func TestGetAttestationData(t *testing.T) {
 		util.SaveBlock(t, ctx, db, block2)
 		justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
 		require.NoError(t, err, "Could not get signing root for justified block")
-		targetRoot, err := targetBlock.Block.HashTreeRoot()
-		require.NoError(t, err, "Could not get signing root for target block")
-
-		beaconState, err := util.NewBeaconState()
-		require.NoError(t, err)
-		require.NoError(t, beaconState.SetSlot(slot))
-		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
-		require.NoError(t, beaconState.SetGenesisTime(uint64(time.Now().Unix()-offset)))
-		err = beaconState.SetLatestBlockHeader(util.HydrateBeaconHeader(&ethpbalpha.BeaconBlockHeader{
-			ParentRoot: blockRoot2[:],
-		}))
-		require.NoError(t, err)
-		err = beaconState.SetCurrentJustifiedCheckpoint(&ethpbalpha.Checkpoint{
+		justifiedCheckpoint := &ethpbalpha.Checkpoint{
 			Epoch: 2,
 			Root:  justifiedRoot[:],
-		})
-		require.NoError(t, err)
-		blockRoots := beaconState.BlockRoots()
-		blockRoots[1] = blockRoot[:]
-		blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-		blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-		blockRoots[3*params.BeaconConfig().SlotsPerEpoch] = blockRoot2[:]
-		require.NoError(t, beaconState.SetBlockRoots(blockRoots))
+		}
 
-		beaconstate := beaconState.Copy()
-		require.NoError(t, beaconstate.SetSlot(beaconstate.Slot()-1))
-		require.NoError(t, db.SaveState(ctx, beaconstate, blockRoot2))
+		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 		chain := &mockChain.ChainService{
-			State:   beaconState,
-			Root:    blockRoot[:],
-			Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Root:                       blockRoot[:],
+			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			CurrentJustifiedCheckPoint: justifiedCheckpoint,
+			TargetRoot:                 blockRoot2,
 		}
 
 		s := &Server{
@@ -1131,16 +1016,12 @@ func TestGetAttestationData(t *testing.T) {
 			TimeFetcher:           chain,
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
 				HeadFetcher:        chain,
 				GenesisTimeFetcher: chain,
 				StateGen:           stategen.New(db, doublylinkedtree.New()),
+				FinalizedFetcher:   chain,
 			},
 		}
-
-		require.NoError(t, db.SaveState(ctx, beaconState, blockRoot))
-		util.SaveBlock(t, ctx, db, block)
-		require.NoError(t, db.SaveHeadBlockRoot(ctx, blockRoot))
 
 		url := fmt.Sprintf("http://example.com?slot=%d&committee_index=%d", slot-1, 0)
 		request := httptest.NewRequest(http.MethodGet, url, nil)
@@ -1153,7 +1034,7 @@ func TestGetAttestationData(t *testing.T) {
 			Data: &shared.AttestationData{
 				Slot:            strconv.FormatUint(uint64(slot-1), 10),
 				CommitteeIndex:  strconv.FormatUint(0, 10),
-				BeaconBlockRoot: hexutil.Encode(blockRoot2[:]),
+				BeaconBlockRoot: hexutil.Encode(blockRoot[:]),
 				Source: &shared.Checkpoint{
 					Epoch: strconv.FormatUint(2, 10),
 					Root:  hexutil.Encode(justifiedRoot[:]),
@@ -1184,27 +1065,18 @@ func TestGetAttestationData(t *testing.T) {
 		require.NoError(t, err, "Could not hash beacon block")
 		justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
 		require.NoError(t, err, "Could not get signing root for justified block")
-		targetRoot, err := targetBlock.Block.HashTreeRoot()
-		require.NoError(t, err, "Could not get signing root for target block")
 
-		beaconState, err := util.NewBeaconState()
-		require.NoError(t, err)
-		require.NoError(t, beaconState.SetSlot(slot))
-		err = beaconState.SetCurrentJustifiedCheckpoint(&ethpbalpha.Checkpoint{
+		justifiedCheckpt := &ethpbalpha.Checkpoint{
 			Epoch: 0,
 			Root:  justifiedRoot[:],
-		})
+		}
 		require.NoError(t, err)
-		blockRoots := beaconState.BlockRoots()
-		blockRoots[1] = blockRoot[:]
-		blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-		blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-		require.NoError(t, beaconState.SetBlockRoots(blockRoots))
 		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 		chain := &mockChain.ChainService{
-			State:   beaconState,
-			Root:    blockRoot[:],
-			Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Root:                       blockRoot[:],
+			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			CurrentJustifiedCheckPoint: justifiedCheckpt,
+			TargetRoot:                 blockRoot,
 		}
 
 		s := &Server{
@@ -1213,9 +1085,9 @@ func TestGetAttestationData(t *testing.T) {
 			TimeFetcher:           chain,
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
 				HeadFetcher:        chain,
 				GenesisTimeFetcher: chain,
+				FinalizedFetcher:   chain,
 			},
 		}
 
@@ -1279,28 +1151,17 @@ func TestGetAttestationData(t *testing.T) {
 		require.NoError(t, err, "Could not hash beacon block")
 		justifiedBlockRoot, err := justifiedBlock.Block.HashTreeRoot()
 		require.NoError(t, err, "Could not hash justified block")
-		epochBoundaryRoot, err := epochBoundaryBlock.Block.HashTreeRoot()
-		require.NoError(t, err, "Could not hash justified block")
-		slot := primitives.Slot(10000)
-
-		beaconState, err := util.NewBeaconState()
-		require.NoError(t, err)
-		require.NoError(t, beaconState.SetSlot(slot))
-		err = beaconState.SetCurrentJustifiedCheckpoint(&ethpbalpha.Checkpoint{
+		justifiedCheckpt := &ethpbalpha.Checkpoint{
 			Epoch: slots.ToEpoch(1500),
 			Root:  justifiedBlockRoot[:],
-		})
-		require.NoError(t, err)
-		blockRoots := beaconState.BlockRoots()
-		blockRoots[1] = blockRoot[:]
-		blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = epochBoundaryRoot[:]
-		blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedBlockRoot[:]
-		require.NoError(t, beaconState.SetBlockRoots(blockRoots))
+		}
+		slot := primitives.Slot(10000)
 		offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 		chain := &mockChain.ChainService{
-			State:   beaconState,
-			Root:    blockRoot[:],
-			Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+			Root:                       blockRoot[:],
+			Genesis:                    time.Now().Add(time.Duration(-1*offset) * time.Second),
+			CurrentJustifiedCheckPoint: justifiedCheckpt,
+			TargetRoot:                 blockRoot,
 		}
 
 		s := &Server{
@@ -1309,9 +1170,9 @@ func TestGetAttestationData(t *testing.T) {
 			TimeFetcher:           chain,
 			OptimisticModeFetcher: chain,
 			CoreService: &core.Service{
-				AttestationCache:   cache.NewAttestationCache(),
 				HeadFetcher:        chain,
 				GenesisTimeFetcher: chain,
+				FinalizedFetcher:   chain,
 			},
 		}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/operations/attestations"
 	mockp2p "github.com/prysmaticlabs/prysm/v4/beacon-chain/p2p/testing"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/core"
-	state_native "github.com/prysmaticlabs/prysm/v4/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state/stategen"
 	mockSync "github.com/prysmaticlabs/prysm/v4/beacon-chain/sync/initial-sync/testing"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
@@ -93,42 +92,31 @@ func TestGetAttestationData_OK(t *testing.T) {
 	block.Block.Slot = 3*params.BeaconConfig().SlotsPerEpoch + 1
 	targetBlock := util.NewBeaconBlock()
 	targetBlock.Block.Slot = 1 * params.BeaconConfig().SlotsPerEpoch
+	targetRoot, err := targetBlock.Block.HashTreeRoot()
+	require.NoError(t, err, "Could not get signing root for target block")
+
 	justifiedBlock := util.NewBeaconBlock()
 	justifiedBlock.Block.Slot = 2 * params.BeaconConfig().SlotsPerEpoch
 	blockRoot, err := block.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not hash beacon block")
 	justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not get signing root for justified block")
-	targetRoot, err := targetBlock.Block.HashTreeRoot()
-	require.NoError(t, err, "Could not get signing root for target block")
 	slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
-	beaconState, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, beaconState.SetSlot(slot))
-	err = beaconState.SetCurrentJustifiedCheckpoint(&ethpb.Checkpoint{
+	justifiedCheckpoint := &ethpb.Checkpoint{
 		Epoch: 2,
 		Root:  justifiedRoot[:],
-	})
-	require.NoError(t, err)
-
-	blockRoots := beaconState.BlockRoots()
-	blockRoots[1] = blockRoot[:]
-	blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-	blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-	require.NoError(t, beaconState.SetBlockRoots(blockRoots))
+	}
 	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
 		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
 		CoreService: &core.Service{
-			AttestationCache: cache.NewAttestationCache(),
-			HeadFetcher: &mock.ChainService{
-				State: beaconState, Root: blockRoot[:],
-			},
+			HeadFetcher: &mock.ChainService{TargetRoot: targetRoot, Root: blockRoot[:]},
 			GenesisTimeFetcher: &mock.ChainService{
 				Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
 			},
+			FinalizedFetcher: &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 		},
 	}
 
@@ -148,13 +136,70 @@ func TestGetAttestationData_OK(t *testing.T) {
 		},
 		Target: &ethpb.Checkpoint{
 			Epoch: 3,
-			Root:  blockRoot[:],
+			Root:  targetRoot[:],
 		},
 	}
 
 	if !proto.Equal(res, expectedInfo) {
 		t.Errorf("Expected attestation info to match, received %v, wanted %v", res, expectedInfo)
 	}
+}
+
+func BenchmarkGetAttestationDataConcurrent(b *testing.B) {
+	block := util.NewBeaconBlock()
+	block.Block.Slot = 3*params.BeaconConfig().SlotsPerEpoch + 1
+	targetBlock := util.NewBeaconBlock()
+	targetBlock.Block.Slot = 1 * params.BeaconConfig().SlotsPerEpoch
+	targetRoot, err := targetBlock.Block.HashTreeRoot()
+	require.NoError(b, err, "Could not get signing root for target block")
+
+	justifiedBlock := util.NewBeaconBlock()
+	justifiedBlock.Block.Slot = 2 * params.BeaconConfig().SlotsPerEpoch
+	blockRoot, err := block.Block.HashTreeRoot()
+	require.NoError(b, err, "Could not hash beacon block")
+	justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
+	require.NoError(b, err, "Could not get signing root for justified block")
+	slot := 3*params.BeaconConfig().SlotsPerEpoch + 1
+	justifiedCheckpoint := &ethpb.Checkpoint{
+		Epoch: 2,
+		Root:  justifiedRoot[:],
+	}
+	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	attesterServer := &Server{
+		SyncChecker:           &mockSync.Sync{IsSyncing: false},
+		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
+		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
+		CoreService: &core.Service{
+			AttestationCache: cache.NewAttestationCache(),
+			HeadFetcher:      &mock.ChainService{TargetRoot: targetRoot, Root: blockRoot[:]},
+			GenesisTimeFetcher: &mock.ChainService{
+				Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second),
+			},
+			FinalizedFetcher: &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
+		},
+	}
+
+	req := &ethpb.AttestationDataRequest{
+		CommitteeIndex: 0,
+		Slot:           3*params.BeaconConfig().SlotsPerEpoch + 1,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+		wg.Add(5000) // for 1000 concurrent accesses
+
+		for j := 0; j < 5000; j++ {
+			go func() {
+				defer wg.Done()
+				_, err := attesterServer.GetAttestationData(context.Background(), req)
+				require.NoError(b, err, "Could not get attestation info at slot")
+			}()
+		}
+		wg.Wait() // Wait for all goroutines to finish
+	}
+
+	b.Log("Elapsed time:", b.Elapsed())
 }
 
 func TestGetAttestationData_SyncNotReady(t *testing.T) {
@@ -195,64 +240,11 @@ func TestGetAttestationData_Optimistic(t *testing.T) {
 		CoreService: &core.Service{
 			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now()},
 			HeadFetcher:        &mock.ChainService{Optimistic: false, State: beaconState},
-			AttestationCache:   cache.NewAttestationCache(),
+			FinalizedFetcher:   &mock.ChainService{},
 		},
 	}
 	_, err = as.GetAttestationData(context.Background(), &ethpb.AttestationDataRequest{})
 	require.NoError(t, err)
-}
-
-func TestAttestationDataSlot_handlesInProgressRequest(t *testing.T) {
-	s := &ethpb.BeaconState{Slot: 100}
-	state, err := state_native.InitializeFromProtoPhase0(s)
-	require.NoError(t, err)
-	ctx := context.Background()
-	slot := primitives.Slot(2)
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
-	server := &Server{
-		SyncChecker:           &mockSync.Sync{IsSyncing: false},
-		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
-		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
-		CoreService: &core.Service{
-			AttestationCache:   cache.NewAttestationCache(),
-			HeadFetcher:        &mock.ChainService{State: state},
-			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
-		},
-	}
-
-	req := &ethpb.AttestationDataRequest{
-		CommitteeIndex: 1,
-		Slot:           slot,
-	}
-
-	res := &ethpb.AttestationData{
-		CommitteeIndex: 1,
-		Target:         &ethpb.Checkpoint{Epoch: 55, Root: make([]byte, 32)},
-	}
-
-	require.NoError(t, server.CoreService.AttestationCache.MarkInProgress(req))
-
-	var wg sync.WaitGroup
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		response, err := server.GetAttestationData(ctx, req)
-		require.NoError(t, err)
-		if !proto.Equal(res, response) {
-			t.Error("Expected  equal responses from cache")
-		}
-	}()
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		assert.NoError(t, server.CoreService.AttestationCache.Put(ctx, req, res))
-		assert.NoError(t, server.CoreService.AttestationCache.MarkNotInProgress(req))
-	}()
-
-	wg.Wait()
 }
 
 func TestServer_GetAttestationData_InvalidRequestSlot(t *testing.T) {
@@ -279,7 +271,7 @@ func TestServer_GetAttestationData_InvalidRequestSlot(t *testing.T) {
 func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testing.T) {
 	// There exists a rare scenario where the validator may request an attestation for a slot less
 	// than the head state's slot. The Ethereum consensus spec constraints require the block root the
-	// attestation is referencing be less than or equal to the attestation data slot.
+	// attestation is referencing to be less than or equal to the attestation data slot.
 	// See: https://github.com/prysmaticlabs/prysm/issues/5164
 	ctx := context.Background()
 	db := dbutil.SetupDB(t)
@@ -300,48 +292,23 @@ func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testin
 	util.SaveBlock(t, ctx, db, block2)
 	justifiedRoot, err := justifiedBlock.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not get signing root for justified block")
-	targetRoot, err := targetBlock.Block.HashTreeRoot()
-	require.NoError(t, err, "Could not get signing root for target block")
-
-	beaconState, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, beaconState.SetSlot(slot))
-	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
-	require.NoError(t, beaconState.SetGenesisTime(uint64(time.Now().Unix()-offset)))
-	err = beaconState.SetLatestBlockHeader(util.HydrateBeaconHeader(&ethpb.BeaconBlockHeader{
-		ParentRoot: blockRoot2[:],
-	}))
-	require.NoError(t, err)
-	err = beaconState.SetCurrentJustifiedCheckpoint(&ethpb.Checkpoint{
+	justifiedCheckpoint := &ethpb.Checkpoint{
 		Epoch: 2,
 		Root:  justifiedRoot[:],
-	})
-	require.NoError(t, err)
-	blockRoots := beaconState.BlockRoots()
-	blockRoots[1] = blockRoot[:]
-	blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-	blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-	blockRoots[3*params.BeaconConfig().SlotsPerEpoch] = blockRoot2[:]
-	require.NoError(t, beaconState.SetBlockRoots(blockRoots))
-
-	beaconstate := beaconState.Copy()
-	require.NoError(t, beaconstate.SetSlot(beaconstate.Slot()-1))
-	require.NoError(t, db.SaveState(ctx, beaconstate, blockRoot2))
-	offset = int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
+	}
+	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
 		TimeFetcher:           &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
 		CoreService: &core.Service{
-			AttestationCache:   cache.NewAttestationCache(),
-			HeadFetcher:        &mock.ChainService{State: beaconState, Root: blockRoot[:]},
+			HeadFetcher:        &mock.ChainService{TargetRoot: blockRoot2, Root: blockRoot[:]},
 			GenesisTimeFetcher: &mock.ChainService{Genesis: time.Now().Add(time.Duration(-1*offset) * time.Second)},
 			StateGen:           stategen.New(db, doublylinkedtree.New()),
+			FinalizedFetcher:   &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 		},
 	}
-	require.NoError(t, db.SaveState(ctx, beaconState, blockRoot))
 	util.SaveBlock(t, ctx, db, block)
-	require.NoError(t, db.SaveHeadBlockRoot(ctx, blockRoot))
 
 	req := &ethpb.AttestationDataRequest{
 		CommitteeIndex: 0,
@@ -352,7 +319,7 @@ func TestServer_GetAttestationData_HeadStateSlotGreaterThanRequestSlot(t *testin
 
 	expectedInfo := &ethpb.AttestationData{
 		Slot:            slot - 1,
-		BeaconBlockRoot: blockRoot2[:],
+		BeaconBlockRoot: blockRoot[:],
 		Source: &ethpb.Checkpoint{
 			Epoch: 2,
 			Root:  justifiedRoot[:],
@@ -383,30 +350,21 @@ func TestGetAttestationData_SucceedsInFirstEpoch(t *testing.T) {
 	targetRoot, err := targetBlock.Block.HashTreeRoot()
 	require.NoError(t, err, "Could not get signing root for target block")
 
-	beaconState, err := util.NewBeaconState()
-	require.NoError(t, err)
-	require.NoError(t, beaconState.SetSlot(slot))
-	err = beaconState.SetCurrentJustifiedCheckpoint(&ethpb.Checkpoint{
+	justifiedCheckpoint := &ethpb.Checkpoint{
 		Epoch: 0,
 		Root:  justifiedRoot[:],
-	})
-	require.NoError(t, err)
-	blockRoots := beaconState.BlockRoots()
-	blockRoots[1] = blockRoot[:]
-	blockRoots[1*params.BeaconConfig().SlotsPerEpoch] = targetRoot[:]
-	blockRoots[2*params.BeaconConfig().SlotsPerEpoch] = justifiedRoot[:]
-	require.NoError(t, beaconState.SetBlockRoots(blockRoots))
+	}
 	offset := int64(slot.Mul(params.BeaconConfig().SecondsPerSlot))
 	attesterServer := &Server{
 		SyncChecker:           &mockSync.Sync{IsSyncing: false},
 		OptimisticModeFetcher: &mock.ChainService{Optimistic: false},
 		TimeFetcher:           &mock.ChainService{Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second)},
 		CoreService: &core.Service{
-			AttestationCache: cache.NewAttestationCache(),
 			HeadFetcher: &mock.ChainService{
-				State: beaconState, Root: blockRoot[:],
+				TargetRoot: targetRoot, Root: blockRoot[:],
 			},
 			GenesisTimeFetcher: &mock.ChainService{Genesis: prysmTime.Now().Add(time.Duration(-1*offset) * time.Second)},
+			FinalizedFetcher:   &mock.ChainService{CurrentJustifiedCheckPoint: justifiedCheckpoint},
 		},
 	}
 
@@ -426,7 +384,7 @@ func TestGetAttestationData_SucceedsInFirstEpoch(t *testing.T) {
 		},
 		Target: &ethpb.Checkpoint{
 			Epoch: 0,
-			Root:  blockRoot[:],
+			Root:  targetRoot[:],
 		},
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/attester_test.go
@@ -188,7 +188,7 @@ func BenchmarkGetAttestationDataConcurrent(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		var wg sync.WaitGroup
-		wg.Add(5000) // for 1000 concurrent accesses
+		wg.Add(5000) // for 5000 concurrent accesses
 
 		for j := 0; j < 5000; j++ {
 			go func() {

--- a/beacon-chain/rpc/service.go
+++ b/beacon-chain/rpc/service.go
@@ -367,6 +367,7 @@ func (s *Service) Start() {
 		AttestationCache:   cache.NewAttestationCache(),
 		StateGen:           s.cfg.StateGen,
 		P2P:                s.cfg.Broadcaster,
+		FinalizedFetcher:   s.cfg.FinalizationFetcher,
 	}
 
 	validatorServer := &validatorv1alpha1.Server{


### PR DESCRIPTION
Alternate Implementation to #13286 and #13256

This proposal introduces a modified caching strategy for single attestation entries, implementing stricter controls on the RPC behavior.

- Check if the current slot matches the request slot. If not, the service is not provided (New behavior).
- If a cached entry exists for the same slot, the committee index is appended to it.
- If no relevant cached entry is present, retrieve the necessary data from the fork choice once, and cache it, replacing the existing cached attestation.
