### PR TITLE
libp2p: Ignore expensive asnutil array

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -2578,8 +2578,16 @@ def prysm_deps():
         version = "v0.27.8",
     )
     go_repository(
+        # This library accounts for a significant wall time in production builds. It is not used by
+        # Prysm at this time.
+        # See https://github.com/libp2p/go-libp2p/issues/2664
         name = "com_github_libp2p_go_libp2p_asn_util",
+        build_directives = [
+            "gazelle:exclude ipv6_asn_map.gen.go",
+        ],
         importpath = "github.com/libp2p/go-libp2p-asn-util",
+        patch_args = ["-p1"],
+        patches = ["//third_party:com_github_libp2p_go_libp2p_asn_util.patch"],
         sum = "h1:gMDcMyYiZKkocGXDQ5nsUQyquC9+H+iLEQHwOCZ7s8s=",
         version = "v0.3.0",
     )

--- a/third_party/com_github_libp2p_go_libp2p_asn_util.patch
+++ b/third_party/com_github_libp2p_go_libp2p_asn_util.patch
@@ -1,0 +1,26 @@
+diff --git a/asn.go b/asn.go
+index 490b4a2..fcfb0da 100644
+--- a/asn.go
++++ b/asn.go
+@@ -51,20 +51,7 @@ func (a *asnStore) AsnForIPv6(ip net.IP) (string, error) {
+ }
+ 
+ func newAsnStore() (*asnStore, error) {
+-	cr := cidranger.NewPCTrieRanger()
+-
+-	for _, v := range ipv6CidrToAsnPairList {
+-		_, nn, err := net.ParseCIDR(v.cidr)
+-		if err != nil {
+-			return nil, fmt.Errorf("failed to parse CIDR %s: %w", v.cidr, err)
+-		}
+-
+-		if err := cr.Insert(&networkWithAsn{*nn, v.asn}); err != nil {
+-			return nil, fmt.Errorf("failed to insert CIDR %s in Trie store: %w", v.cidr, err)
+-		}
+-	}
+-
+-	return &asnStore{cr}, nil
++	return nil, errors.New("asnutil store is empty because it is never used and causes significant build delays")
+ }
+ 
+ // lazyAsnStore builds the underlying trie on first call to AsnForIPv6.


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This library, go-libp2p-asn-util, is only required when using options to configure a libp2p library.
At present, Prysm never uses these options and therefore this library is not relevant. However, due
to the way libp2p is importing interfaces from the circuitv2 package for the option to configure a
relay, the compiler cannot exclude this package from the release binary. 

**Which issues(s) does this PR fix?**

Here are some before and after bazel profiles.

```
# Run from before and after this PR.
bazel clean --expunge_async && bazel build //cmd/beacon-chain --config=release --profile=/tmp/profile.gz
bazel analyze-profile /tmp/profile.gz
```

**Before**

```

=== PHASE SUMMARY INFORMATION ===

Total launch phase time                              0.645 s    0.45%
Total init phase time                                2.036 s    1.42%
Total target pattern evaluation phase time           0.050 s    0.04%
Total interleaved loading-and-analysis phase time   24.131 s   16.82%
Total preparation phase time                         0.017 s    0.01%
Total execution phase time                         116.592 s   81.26%
Total finish phase time                              0.014 s    0.01%
---------------------------------------------------------------------
Total run time                                     143.488 s  100.00%

Critical path (92.295 s):
       Time Percentage   Description
   17.361 s   18.81%   action 'GoToolchainBinaryBuild external/go_sdk/builder [for tool]'
    0.72 ms    0.00%   action 'Creating symlink bazel-out/k8-opt-exec-2B5CBBC6-ST-933a6b66542f/bin/external/go_sdk/builder_reset/builder [for tool]'
   27.185 s   29.45%   action 'GoStdlib external/io_bazel_rules_go/stdlib_/pkg [for tool]'
    3.096 s    3.35%   action 'GoCompilePkg external/org_golang_x_tools/go/analysis/analysis.a [for tool]'
     124 ms    0.13%   action 'GoCompilePkg external/co_honnef_go_tools/analysis/facts/tokenfile/tokenfile.a [for tool]'
     120 ms    0.13%   action 'GoCompilePkg external/co_honnef_go_tools/analysis/lint/lint.a [for tool]'
    1.419 s    1.54%   action 'GoCompilePkg external/co_honnef_go_tools/go/ir/ir.a [for tool]'
     319 ms    0.35%   action 'GoCompilePkg external/co_honnef_go_tools/go/ir/irutil/irutil.a [for tool]'
     169 ms    0.18%   action 'GoCompilePkg external/co_honnef_go_tools/analysis/facts/purity/purity.a [for tool]'
     157 ms    0.17%   action 'GoCompilePkg external/co_honnef_go_tools/analysis/code/code.a [for tool]'
     185 ms    0.20%   action 'GoCompilePkg external/co_honnef_go_tools/analysis/report/report.a [for tool]'
    1.190 s    1.29%   action 'GoCompilePkg external/co_honnef_go_tools/staticcheck/sa1008/sa1008.a [for tool]'
     340 ms    0.37%   action 'GoCompilePkg nogo_actual~nogo.a [for tool]'
    1.687 s    1.83%   action 'GoLink nogo_actual_/nogo_actual [for tool]'
     424 ms    0.46%   action 'GoCompilePkg external/com_github_libp2p_go_cidranger/net/net.a'
     568 ms    0.62%   action 'GoCompilePkg external/com_github_libp2p_go_cidranger/go-cidranger.a'
   31.165 s   33.77%   action 'GoCompilePkg external/com_github_libp2p_go_libp2p_asn_util/go-libp2p-asn-util.a'
     130 ms    0.14%   action 'GoCompilePkg external/com_github_libp2p_go_libp2p/p2p/protocol/circuitv2/relay/relay.a'
    92.2 ms    0.10%   action 'GoCompilePkg external/com_github_libp2p_go_libp2p/p2p/host/relaysvc/relaysvc.a'
     159 ms    0.17%   action 'GoCompilePkg external/com_github_libp2p_go_libp2p/p2p/host/basic/basic.a'
     150 ms    0.16%   action 'GoCompilePkg external/com_github_libp2p_go_libp2p/p2p/host/autorelay/autorelay.a'
     149 ms    0.16%   action 'GoCompilePkg external/com_github_libp2p_go_libp2p/config/config.a'
     158 ms    0.17%   action 'GoCompilePkg external/com_github_libp2p_go_libp2p/go-libp2p.a'
     331 ms    0.36%   action 'GoCompilePkg beacon-chain/p2p/go_default_library.a'
     288 ms    0.31%   action 'GoCompilePkg beacon-chain/blockchain/go_default_library.a'
     457 ms    0.50%   action 'GoCompilePkg beacon-chain/sync/go_default_library.a'
     207 ms    0.22%   action 'GoCompilePkg beacon-chain/rpc/core/go_default_library.a'
     147 ms    0.16%   action 'GoCompilePkg beacon-chain/rpc/lookup/go_default_library.a'
     325 ms    0.35%   action 'GoCompilePkg beacon-chain/rpc/eth/shared/go_default_library.a'
     367 ms    0.40%   action 'GoCompilePkg api/client/builder/go_default_library.a'
     150 ms    0.16%   action 'GoCompilePkg beacon-chain/builder/go_default_library.a'
     324 ms    0.35%   action 'GoCompilePkg beacon-chain/rpc/prysm/v1alpha1/validator/go_default_library.a'
     206 ms    0.22%   action 'GoCompilePkg beacon-chain/rpc/go_default_library.a'
     263 ms    0.28%   action 'GoCompilePkg beacon-chain/node/go_default_library.a'
     151 ms    0.16%   action 'GoCompilePkg cmd/beacon-chain/sync/checkpoint/go_default_library.a'
     161 ms    0.17%   action 'GoCompilePkg cmd/beacon-chain/sync/genesis/go_default_library.a'
     164 ms    0.18%   action 'GoCompilePkg cmd/beacon-chain/beacon-chain.a'
    2.409 s    2.61%   action 'GoLink cmd/beacon-chain/beacon-chain_/beacon-chain'
    0.04 ms    0.00%   runfiles for //cmd/beacon-chain beacon-chain
```

**After**

```

=== PHASE SUMMARY INFORMATION ===

Total launch phase time                              0.646 s    0.52%
Total init phase time                                1.943 s    1.56%
Total target pattern evaluation phase time           0.052 s    0.04%
Total interleaved loading-and-analysis phase time   25.293 s   20.34%
Total preparation phase time                         0.012 s    0.01%
Total execution phase time                          96.393 s   77.52%
Total finish phase time                              0.013 s    0.01%
---------------------------------------------------------------------
Total run time                                     124.353 s  100.00%

Critical path (66.290 s):
       Time Percentage   Description
   16.540 s   24.95%   action 'GoToolchainBinaryBuild external/go_sdk/builder [for tool]'
    0.94 ms    0.00%   action 'Creating symlink bazel-out/k8-opt-exec-2B5CBBC6-ST-933a6b66542f/bin/external/go_sdk/builder_reset/builder [for tool]'
   22.840 s   34.45%   action 'GoStdlib external/io_bazel_rules_go/stdlib_/pkg [for tool]'
     286 ms    0.43%   action 'GoCompilePkg external/org_golang_x_tools/internal/typeparams/typeparams.a [for tool]'
     209 ms    0.32%   action 'GoCompilePkg external/org_golang_x_tools/go/ast/astutil/astutil.a [for tool]'
     124 ms    0.19%   action 'GoCompilePkg external/org_golang_x_tools/go/types/typeutil/typeutil.a [for tool]'
     226 ms    0.34%   action 'GoCompilePkg external/co_honnef_go_tools/go/types/typeutil/typeutil.a [for tool]'
    1.210 s    1.83%   action 'GoCompilePkg external/co_honnef_go_tools/go/ir/ir.a [for tool]'
     268 ms    0.40%   action 'GoCompilePkg external/co_honnef_go_tools/go/ir/irutil/irutil.a [for tool]'
     124 ms    0.19%   action 'GoCompilePkg external/co_honnef_go_tools/analysis/facts/purity/purity.a [for tool]'
     128 ms    0.19%   action 'GoCompilePkg external/co_honnef_go_tools/analysis/code/code.a [for tool]'
     200 ms    0.30%   action 'GoCompilePkg external/co_honnef_go_tools/analysis/report/report.a [for tool]'
     938 ms    1.41%   action 'GoCompilePkg external/co_honnef_go_tools/staticcheck/sa4022/sa4022.a [for tool]'
     316 ms    0.48%   action 'GoCompilePkg external/co_honnef_go_tools/staticcheck/sa4031/sa4031.a [for tool]'
     508 ms    0.77%   action 'GoCompilePkg nogo_actual~nogo.a [for tool]'
    1.962 s    2.96%   action 'GoLink nogo_actual_/nogo_actual [for tool]'
     458 ms    0.69%   action 'GoCompilePkg external/org_golang_google_protobuf/internal/detrand/detrand.a'
     351 ms    0.53%   action 'GoCompilePkg external/org_golang_google_protobuf/internal/errors/errors.a'
     560 ms    0.84%   action 'GoCompilePkg external/org_golang_google_protobuf/encoding/protowire/protowire.a'
     852 ms    1.28%   action 'GoCompilePkg external/org_golang_google_protobuf/reflect/protoreflect/protoreflect.a'
     478 ms    0.72%   action 'GoCompilePkg external/org_golang_google_protobuf/internal/encoding/messageset/messageset.a'
     428 ms    0.65%   action 'GoCompilePkg external/org_golang_google_protobuf/reflect/protoregistry/protoregistry.a'
     649 ms    0.98%   action 'GoCompilePkg external/org_golang_google_protobuf/proto/proto.a'
     940 ms    1.42%   action 'GoCompilePkg external/org_golang_google_protobuf/internal/filedesc/filedesc.a'
     483 ms    0.73%   action 'GoCompilePkg external/org_golang_google_protobuf/internal/encoding/tag/tag.a'
    1.311 s    1.98%   action 'GoCompilePkg external/org_golang_google_protobuf/internal/impl/impl.a'
     272 ms    0.41%   action 'GoCompilePkg external/org_golang_google_protobuf/internal/filetype/filetype.a'
     174 ms    0.26%   action 'GoCompilePkg external/org_golang_google_protobuf/runtime/protoimpl/protoimpl.a'
     484 ms    0.73%   action 'GoCompilePkg external/org_golang_google_protobuf/types/descriptorpb/descriptorpb.a'
     325 ms    0.49%   action 'GoCompilePkg external/org_golang_google_protobuf/reflect/protodesc/protodesc.a'
     286 ms    0.43%   action 'GoCompilePkg external/com_github_golang_protobuf/proto/proto.a'
     245 ms    0.37%   action 'GoCompilePkg external/org_golang_google_grpc/credentials/credentials.a'
     322 ms    0.49%   action 'GoCompilePkg external/org_golang_google_grpc/resolver/resolver.a'
     283 ms    0.43%   action 'GoCompilePkg external/org_golang_google_grpc/internal/internal.a'
     217 ms    0.33%   action 'GoCompilePkg external/org_golang_google_grpc/codes/codes.a'
     166 ms    0.25%   action 'GoCompilePkg external/org_golang_google_grpc/internal/status/status.a'
     214 ms    0.32%   action 'GoCompilePkg external/org_golang_google_grpc/status/status.a'
     599 ms    0.90%   action 'GoCompilePkg external/org_golang_google_grpc/internal/transport/transport.a'
     468 ms    0.71%   action 'GoCompilePkg external/org_golang_google_grpc/grpc.a'
     403 ms    0.61%   action 'GoCompilePkg proto/engine/v1/go_default_library.a'
    1.913 s    2.89%   action 'GoCompilePkg proto/prysm/v1alpha1/go_default_library.a'
     218 ms    0.33%   action 'GoCompilePkg proto/prysm/v1alpha1/validator-client/go_default_library.a'
     127 ms    0.19%   action 'GoCompilePkg consensus-types/interfaces/go_default_library.a'
     147 ms    0.22%   action 'GoCompilePkg beacon-chain/state/go_default_library.a'
     251 ms    0.38%   action 'GoCompilePkg beacon-chain/cache/go_default_library.a'
     263 ms    0.40%   action 'GoCompilePkg beacon-chain/core/helpers/go_default_library.a'
     143 ms    0.22%   action 'GoCompilePkg beacon-chain/core/validators/go_default_library.a'
     242 ms    0.37%   action 'GoCompilePkg beacon-chain/core/blocks/go_default_library.a'
     297 ms    0.45%   action 'GoCompilePkg beacon-chain/db/kv/go_default_library.a'
     122 ms    0.18%   action 'GoCompilePkg beacon-chain/db/go_default_library.a'
     126 ms    0.19%   action 'GoCompilePkg beacon-chain/sync/backfill/go_default_library.a'
     188 ms    0.28%   action 'GoCompilePkg beacon-chain/state/stategen/go_default_library.a'
     248 ms    0.37%   action 'GoCompilePkg beacon-chain/execution/go_default_library.a'
     314 ms    0.47%   action 'GoCompilePkg beacon-chain/blockchain/go_default_library.a'
     432 ms    0.65%   action 'GoCompilePkg beacon-chain/sync/go_default_library.a'
     197 ms    0.30%   action 'GoCompilePkg beacon-chain/rpc/core/go_default_library.a'
     142 ms    0.21%   action 'GoCompilePkg beacon-chain/rpc/lookup/go_default_library.a'
     314 ms    0.47%   action 'GoCompilePkg beacon-chain/rpc/eth/shared/go_default_library.a'
     371 ms    0.56%   action 'GoCompilePkg api/client/builder/go_default_library.a'
     154 ms    0.23%   action 'GoCompilePkg beacon-chain/builder/go_default_library.a'
     300 ms    0.45%   action 'GoCompilePkg beacon-chain/rpc/prysm/v1alpha1/validator/go_default_library.a'
     209 ms    0.31%   action 'GoCompilePkg beacon-chain/rpc/go_default_library.a'
     266 ms    0.40%   action 'GoCompilePkg beacon-chain/node/go_default_library.a'
     153 ms    0.23%   action 'GoCompilePkg cmd/beacon-chain/sync/checkpoint/go_default_library.a'
     156 ms    0.24%   action 'GoCompilePkg cmd/beacon-chain/sync/genesis/go_default_library.a'
     152 ms    0.23%   action 'GoCompilePkg cmd/beacon-chain/beacon-chain.a'
    1.998 s    3.01%   action 'GoLink cmd/beacon-chain/beacon-chain_/beacon-chain'
    0.04 ms    0.00%   runfiles for //cmd/beacon-chain beacon-chain
```


**Other notes for review**

Filed upstream issue: https://github.com/libp2p/go-libp2p/issues/2664
