### PR TITLE
fix tests

### DIFF
--- a/time/slots/slotticker_test.go
+++ b/time/slots/slotticker_test.go
@@ -172,15 +172,15 @@ func TestSlotTickerWithIntervalsInputValidation(t *testing.T) {
 	panicCall := func() {
 		NewSlotTickerWithIntervals(genesisTime, intervals)
 	}
-	require.Panics(t, panicCall, "zero genesis time")
+	require.PanicsWithValue(t, "zero genesis time", panicCall)
 	genesisTime = time.Now()
-	require.Panics(t, panicCall, "at least one interval has to be entered")
+	require.PanicsWithValue(t, "at least one interval has to be entered", panicCall)
 	intervals = []time.Duration{2 * offset, offset}
-	require.Panics(t, panicCall, "invalid decreasing offsets")
+	require.PanicsWithValue(t, "invalid ticker offset", panicCall)
 	intervals = []time.Duration{offset, 4 * offset}
-	require.Panics(t, panicCall, "invalid ticker offset")
+	require.PanicsWithValue(t, "invalid ticker offset", panicCall)
 	intervals = []time.Duration{4 * offset, offset}
-	require.Panics(t, panicCall, "invalid ticker offset")
+	require.PanicsWithValue(t, "invalid ticker offset", panicCall)
 	intervals = []time.Duration{offset, 2 * offset}
 	require.NotPanics(t, panicCall)
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix:  #13280

There's several issues highlighted by this bug which are:
- The tests do not properly check the panic message
- One of the tests checking if zero genesis error message is never reached
- `receive_attestation.spawnProcessAttestationsRoutine()` should check if the [`reorgInterval := time.Second*time.Duration(params.BeaconConfig().SecondsPerSlot) - reorgLateBlockCountAttestations `](https://github.com/v4lproik/prysm/blob/243bcb03cea645951ed2f18e909428fdca757b57/beacon-chain/blockchain/receive_attestation.go#L91) can be of a negative value.