### PR TITLE
Increase buffer of events channel

### DIFF
--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -48,6 +48,8 @@ const (
 
 const topicDataMismatch = "Event data type %T does not correspond to event topic %s"
 
+const chanBuffer = 1000
+
 var casesHandled = map[string]bool{
 	HeadTopic:                      true,
 	BlockTopic:                     true,
@@ -90,9 +92,9 @@ func (s *Server) StreamEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Subscribe to event feeds from information received in the beacon node runtime.
-	opsChan := make(chan *feed.Event, 1)
+	opsChan := make(chan *feed.Event, chanBuffer)
 	opsSub := s.OperationNotifier.OperationFeed().Subscribe(opsChan)
-	stateChan := make(chan *feed.Event, 1)
+	stateChan := make(chan *feed.Event, chanBuffer)
 	stateSub := s.StateNotifier.StateFeed().Subscribe(stateChan)
 	defer opsSub.Unsubscribe()
 	defer stateSub.Unsubscribe()


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

The way our event feed works is that it copies events to all subscribers and blocks if any subscriber is full. This means that if there is a very slow reader, its channel, which currently has a buffer size of 1, will quickly get full and all other subscribers will be blocked. This PR increases the buffer to 1000, meaning that the event feed will stop producing events only when a single subscriber reaches 1000 pending events. Given that the size of all events is very small, it's unlikely to happen.
