### PR TITLE
Fix error string generation for missing commitments

### DIFF
--- a/beacon-chain/blockchain/receive_blob.go
+++ b/beacon-chain/blockchain/receive_blob.go
@@ -7,7 +7,7 @@ import (
 )
 
 // SendNewBlobEvent sends a message to the BlobNotifier channel that the blob
-// for the blocroot `root` is ready in the database
+// for the block root `root` is ready in the database
 func (s *Service) sendNewBlobEvent(root [32]byte, index uint64) {
 	s.blobNotifiers.notifyIndex(root, index)
 }

--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -27,7 +27,7 @@ import (
 )
 
 var (
-	errIndexOutOfBounds = errors.New("blob index in file name > MaxBlobsPerBlock")
+	errIndexOutOfBounds = errors.New("blob index in file name >= MaxBlobsPerBlock")
 )
 
 const (

--- a/beacon-chain/sync/initial-sync/blocks_fetcher.go
+++ b/beacon-chain/sync/initial-sync/blocks_fetcher.go
@@ -441,7 +441,7 @@ func verifyAndPopulateBlobs(bwb []blocks2.BlockWithVerifiedBlobs, blobs []blocks
 }
 
 func missingCommitError(root [32]byte, slot primitives.Slot, missing [][]byte) error {
-	missStr := make([]string, len(missing))
+	missStr := make([]string, 0, len(missing))
 	for k := range missing {
 		missStr = append(missStr, fmt.Sprintf("%#x", k))
 	}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Another `makezero` finding. This PR fixes the initialization of `missStr` so that it behaves as expected.

Also, fix two minor typos I noticed that aren't worthy of their own PR.
