### PR TITLE
Enable usestdlibvars linter and fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - nilerr
     - whitespace
     - misspell
+    - usestdlibvars
 
 linters-settings:
   gocognit:

--- a/api/client/builder/client.go
+++ b/api/client/builder/client.go
@@ -423,22 +423,22 @@ func non200Err(response *http.Response) error {
 	}
 	msg := fmt.Sprintf("code=%d, url=%s, body=%s", response.StatusCode, response.Request.URL, body)
 	switch response.StatusCode {
-	case 204:
+	case http.StatusNoContent:
 		log.WithError(ErrNoContent).Debug(msg)
 		return ErrNoContent
-	case 400:
+	case http.StatusBadRequest:
 		if jsonErr := json.Unmarshal(bodyBytes, &errMessage); jsonErr != nil {
 			return errors.Wrap(jsonErr, "unable to read response body")
 		}
 		log.WithError(ErrBadRequest).Debug(msg)
 		return errors.Wrap(ErrBadRequest, errMessage.Message)
-	case 404:
+	case http.StatusNotFound:
 		if jsonErr := json.Unmarshal(bodyBytes, &errMessage); jsonErr != nil {
 			return errors.Wrap(jsonErr, "unable to read response body")
 		}
 		log.WithError(ErrNotFound).Debug(msg)
 		return errors.Wrap(ErrNotFound, errMessage.Message)
-	case 500:
+	case http.StatusInternalServerError:
 		if jsonErr := json.Unmarshal(bodyBytes, &errMessage); jsonErr != nil {
 			return errors.Wrap(jsonErr, "unable to read response body")
 		}

--- a/api/client/errors.go
+++ b/api/client/errors.go
@@ -32,7 +32,7 @@ func Non200Err(response *http.Response) error {
 	}
 	msg := fmt.Sprintf("code=%d, url=%s, body=%s", response.StatusCode, response.Request.URL, body)
 	switch response.StatusCode {
-	case 404:
+	case http.StatusNotFound:
 		return errors.Wrap(ErrNotFound, msg)
 	default:
 		return errors.Wrap(ErrNotOK, msg)

--- a/testing/endtoend/components/web3remotesigner.go
+++ b/testing/endtoend/components/web3remotesigner.go
@@ -142,7 +142,7 @@ func (w *Web3RemoteSigner) Stop() error {
 func (w *Web3RemoteSigner) monitorStart() {
 	client := &http.Client{}
 	for {
-		req, err := http.NewRequestWithContext(w.ctx, "GET", fmt.Sprintf("http://localhost:%d/upcheck", Web3RemoteSignerPort), nil)
+		req, err := http.NewRequestWithContext(w.ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/upcheck", Web3RemoteSignerPort), nil)
 		if err != nil {
 			panic(err)
 		}
@@ -172,7 +172,7 @@ func (w *Web3RemoteSigner) PublicKeys(ctx context.Context) ([]bls.PublicKey, err
 	w.wait(ctx)
 
 	client := &http.Client{}
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost:%d/api/v1/eth2/publicKeys", Web3RemoteSignerPort), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://localhost:%d/api/v1/eth2/publicKeys", Web3RemoteSignerPort), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -180,7 +180,7 @@ func (w *Web3RemoteSigner) PublicKeys(ctx context.Context) ([]bls.PublicKey, err
 	if err != nil {
 		return nil, err
 	}
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("returned status code %d", res.StatusCode)
 	}
 	b, err := io.ReadAll(res.Body)

--- a/testing/endtoend/evaluators/beaconapi/util.go
+++ b/testing/endtoend/evaluators/beaconapi/util.go
@@ -83,7 +83,7 @@ func doSSZGetRequest(template string, requestPath string, beaconNodeIdx int, bnT
 
 	basePath := fmt.Sprintf(template, port+beaconNodeIdx)
 
-	req, err := http.NewRequest("GET", basePath+requestPath, nil)
+	req, err := http.NewRequest(http.MethodGet, basePath+requestPath, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/validator/web/handler.go
+++ b/validator/web/handler.go
@@ -27,7 +27,7 @@ var Handler = func(res http.ResponseWriter, req *http.Request) {
 	if d, ok := _bindata[p]; ok {
 		m := mime.TypeByExtension(path.Ext(p))
 		res.Header().Add("Content-Type", m)
-		res.WriteHeader(200)
+		res.WriteHeader(http.StatusOK)
 		asset, err := d()
 		if err != nil {
 			log.WithError(err).Error("Failed to unwrap asset data for http response")
@@ -40,7 +40,7 @@ var Handler = func(res http.ResponseWriter, req *http.Request) {
 		// requesting /login, this should serve the single page app index.html.
 		m := mime.TypeByExtension(".html")
 		res.Header().Add("Content-Type", m)
-		res.WriteHeader(200)
+		res.WriteHeader(http.StatusOK)
 		asset, err := d()
 		if err != nil {
 			log.WithError(err).Error("Failed to unwrap asset data for http response")
@@ -50,7 +50,7 @@ var Handler = func(res http.ResponseWriter, req *http.Request) {
 		}
 	} else { // If index.html is not present, serve 404. This should never happen.
 		log.WithField("URI", req.RequestURI).Error("Path not found")
-		res.WriteHeader(404)
+		res.WriteHeader(http.StatusNotFound)
 		if _, err := res.Write([]byte("Not found")); err != nil {
 			log.WithError(err).Error("Failed to write http response")
 		}


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR enables the [`usestdlibvars`](https://golangci-lint.run/usage/linters/#usestdlibvars) (use standard library variables) linter in golangci-lint.
