### PR TITLE
Enable errname linter and fix findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - nilerr
     - whitespace
     - misspell
+    - errname
 
 linters-settings:
   gocognit:

--- a/beacon-chain/core/blocks/exit.go
+++ b/beacon-chain/core/blocks/exit.go
@@ -76,7 +76,7 @@ func ProcessVoluntaryExits(
 			} else if exitEpoch == maxExitEpoch {
 				churn++
 			}
-		} else if !errors.Is(err, v.ValidatorAlreadyExitedErr) {
+		} else if !errors.Is(err, v.ErrValidatorAlreadyExited) {
 			return nil, err
 		}
 	}

--- a/beacon-chain/core/epoch/epoch_processing.go
+++ b/beacon-chain/core/epoch/epoch_processing.go
@@ -114,7 +114,7 @@ func ProcessRegistryUpdates(ctx context.Context, state state.BeaconState) (state
 			// barely happen
 			maxExitEpoch, churn := validators.MaxExitEpochAndChurn(state)
 			state, _, err = validators.InitiateValidatorExit(ctx, state, primitives.ValidatorIndex(idx), maxExitEpoch, churn)
-			if err != nil && !errors.Is(err, validators.ValidatorAlreadyExitedErr) {
+			if err != nil && !errors.Is(err, validators.ErrValidatorAlreadyExited) {
 				return nil, errors.Wrapf(err, "could not initiate exit for validator %d", idx)
 			}
 		}

--- a/beacon-chain/core/validators/validator.go
+++ b/beacon-chain/core/validators/validator.go
@@ -17,9 +17,9 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/time/slots"
 )
 
-// ValidatorAlreadyExitedErr is an error raised when trying to process an exit of
+// ErrValidatorAlreadyExited is an error raised when trying to process an exit of
 // an already exited validator
-var ValidatorAlreadyExitedErr = errors.New("validator already exited")
+var ErrValidatorAlreadyExited = errors.New("validator already exited")
 
 // MaxExitEpochAndChurn returns the maximum non-FAR_FUTURE_EPOCH exit
 // epoch and the number of them
@@ -76,7 +76,7 @@ func InitiateValidatorExit(ctx context.Context, s state.BeaconState, idx primiti
 		return nil, 0, err
 	}
 	if validator.ExitEpoch != params.BeaconConfig().FarFutureEpoch {
-		return s, validator.ExitEpoch, ValidatorAlreadyExitedErr
+		return s, validator.ExitEpoch, ErrValidatorAlreadyExited
 	}
 	activeValidatorCount, err := helpers.ActiveValidatorCount(ctx, s, time.CurrentEpoch(s))
 	if err != nil {
@@ -136,7 +136,7 @@ func SlashValidator(
 	proposerRewardQuotient uint64) (state.BeaconState, error) {
 	maxExitEpoch, churn := MaxExitEpochAndChurn(s)
 	s, _, err := InitiateValidatorExit(ctx, s, slashedIdx, maxExitEpoch, churn)
-	if err != nil && !errors.Is(err, ValidatorAlreadyExitedErr) {
+	if err != nil && !errors.Is(err, ErrValidatorAlreadyExited) {
 		return nil, errors.Wrapf(err, "could not initiate validator %d exit", slashedIdx)
 	}
 	currentEpoch := slots.ToEpoch(s.Slot())

--- a/beacon-chain/core/validators/validator_test.go
+++ b/beacon-chain/core/validators/validator_test.go
@@ -49,7 +49,7 @@ func TestInitiateValidatorExit_AlreadyExited(t *testing.T) {
 	state, err := state_native.InitializeFromProtoPhase0(base)
 	require.NoError(t, err)
 	newState, epoch, err := InitiateValidatorExit(context.Background(), state, 0, 199, 1)
-	require.ErrorIs(t, err, ValidatorAlreadyExitedErr)
+	require.ErrorIs(t, err, ErrValidatorAlreadyExited)
 	require.Equal(t, exitEpoch, epoch)
 	v, err := newState.ValidatorAtIndex(0)
 	require.NoError(t, err)

--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -107,7 +107,7 @@ type EngineCaller interface {
 	GetTerminalBlockHash(ctx context.Context, transitionTime uint64) ([]byte, bool, error)
 }
 
-var EmptyBlockHash = errors.New("Block hash is empty 0x0000...")
+var ErrEmptyBlockHash = errors.New("Block hash is empty 0x0000...")
 
 // NewPayload calls the engine_newPayloadVX method via JSON-RPC.
 func (s *Service) NewPayload(ctx context.Context, payload interfaces.ExecutionData, versionedHashes []common.Hash, parentBlockRoot *common.Hash) ([]byte, error) {
@@ -641,7 +641,7 @@ func (s *Service) retrievePayloadFromExecutionHash(ctx context.Context, executio
 		return nil, fmt.Errorf("received nil execution block for request by hash %#x", executionBlockHash)
 	}
 	if bytes.Equal(executionBlock.Hash.Bytes(), []byte{}) {
-		return nil, EmptyBlockHash
+		return nil, ErrEmptyBlockHash
 	}
 
 	executionBlock.Version = version

--- a/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_pool_test.go
@@ -276,7 +276,7 @@ func TestSubmitAttestations(t *testing.T) {
 
 		s.SubmitAttestations(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -291,7 +291,7 @@ func TestSubmitAttestations(t *testing.T) {
 
 		s.SubmitAttestations(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -434,7 +434,7 @@ func TestSubmitVoluntaryExit(t *testing.T) {
 		s := &Server{}
 		s.SubmitVoluntaryExit(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -450,7 +450,7 @@ func TestSubmitVoluntaryExit(t *testing.T) {
 		s := &Server{}
 		s.SubmitVoluntaryExit(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 	})
@@ -467,7 +467,7 @@ func TestSubmitVoluntaryExit(t *testing.T) {
 
 		s.SubmitVoluntaryExit(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "Invalid exit"))
@@ -496,7 +496,7 @@ func TestSubmitVoluntaryExit(t *testing.T) {
 
 		s.SubmitVoluntaryExit(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "Could not get validator"))
@@ -591,7 +591,7 @@ func TestSubmitSyncCommitteeSignatures(t *testing.T) {
 		s.SubmitSyncCommitteeSignatures(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
 		require.NoError(t, err)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		msgsInPool, err := s.CoreService.SyncCommitteePool.SyncCommitteeMessages(1)
@@ -611,7 +611,7 @@ func TestSubmitSyncCommitteeSignatures(t *testing.T) {
 
 		s.SubmitSyncCommitteeSignatures(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -625,7 +625,7 @@ func TestSubmitSyncCommitteeSignatures(t *testing.T) {
 
 		s.SubmitSyncCommitteeSignatures(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -1342,7 +1342,7 @@ func TestSubmitAttesterSlashing_InvalidSlashing(t *testing.T) {
 
 	s.SubmitAttesterSlashing(writer, request)
 	require.Equal(t, http.StatusBadRequest, writer.Code)
-	e := &httputil.DefaultErrorJson{}
+	e := &httputil.DefaultJsonError{}
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 	assert.Equal(t, http.StatusBadRequest, e.Code)
 	assert.StringContains(t, "Invalid attester slashing", e.Message)
@@ -1533,7 +1533,7 @@ func TestSubmitProposerSlashing_InvalidSlashing(t *testing.T) {
 
 	s.SubmitProposerSlashing(writer, request)
 	require.Equal(t, http.StatusBadRequest, writer.Code)
-	e := &httputil.DefaultErrorJson{}
+	e := &httputil.DefaultJsonError{}
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 	assert.Equal(t, http.StatusBadRequest, e.Code)
 	assert.StringContains(t, "Invalid proposer slashing", e.Message)

--- a/beacon-chain/rpc/eth/beacon/handlers_state_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_state_test.go
@@ -216,7 +216,7 @@ func TestGetRandao(t *testing.T) {
 
 		s.GetRandao(writer, request)
 		require.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		require.StringContains(t, "Epoch is out of range for the randao mixes of the state", e.Message)
@@ -230,7 +230,7 @@ func TestGetRandao(t *testing.T) {
 
 		s.GetRandao(writer, request)
 		require.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		require.StringContains(t, "Epoch is out of range for the randao mixes of the state", e.Message)
@@ -617,7 +617,7 @@ func TestGetSyncCommittees_Future(t *testing.T) {
 	writer.Body = &bytes.Buffer{}
 	s.GetSyncCommittees(writer, request)
 	require.Equal(t, http.StatusBadRequest, writer.Code)
-	e := &httputil.DefaultErrorJson{}
+	e := &httputil.DefaultJsonError{}
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 	assert.Equal(t, http.StatusBadRequest, e.Code)
 	assert.StringContains(t, "Could not fetch sync committee too far in the future", e.Message)

--- a/beacon-chain/rpc/eth/beacon/handlers_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_test.go
@@ -2793,7 +2793,7 @@ func TestGetBlockHeaders(t *testing.T) {
 
 			bs.GetBlockHeaders(writer, request)
 			require.Equal(t, http.StatusNotFound, writer.Code)
-			e := &httputil.DefaultErrorJson{}
+			e := &httputil.DefaultJsonError{}
 			require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 			assert.Equal(t, http.StatusNotFound, e.Code)
 			assert.StringContains(t, "No blocks found", e.Message)
@@ -2849,7 +2849,7 @@ func TestServer_GetBlockHeader(t *testing.T) {
 
 		s.GetBlockHeader(writer, request)
 		require.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "block_id is required in URL params", e.Message)
@@ -2988,7 +2988,7 @@ func TestGetFinalityCheckpoints(t *testing.T) {
 
 		s.GetFinalityCheckpoints(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "state_id is required in URL params", e.Message)
@@ -3001,7 +3001,7 @@ func TestGetFinalityCheckpoints(t *testing.T) {
 
 		s.GetFinalityCheckpoints(writer, request)
 		assert.Equal(t, http.StatusNotFound, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusNotFound, e.Code)
 		assert.StringContains(t, "State not found", e.Message)
@@ -3106,7 +3106,7 @@ func TestGetGenesis(t *testing.T) {
 
 		s.GetGenesis(writer, request)
 		assert.Equal(t, http.StatusNotFound, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusNotFound, e.Code)
 		assert.StringContains(t, "Chain genesis info is not yet known", e.Message)
@@ -3127,7 +3127,7 @@ func TestGetGenesis(t *testing.T) {
 
 		s.GetGenesis(writer, request)
 		assert.Equal(t, http.StatusNotFound, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusNotFound, e.Code)
 		assert.StringContains(t, "Chain genesis info is not yet known", e.Message)

--- a/beacon-chain/rpc/eth/beacon/handlers_validators_test.go
+++ b/beacon-chain/rpc/eth/beacon/handlers_validators_test.go
@@ -173,7 +173,7 @@ func TestGetValidators(t *testing.T) {
 
 		s.GetValidator(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "state_id is required in URL params", e.Message)
@@ -373,7 +373,7 @@ func TestGetValidators(t *testing.T) {
 
 		s.GetValidators(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "No data submitted", e.Message)
@@ -403,7 +403,7 @@ func TestGetValidators(t *testing.T) {
 
 		s.GetValidators(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "Could not decode request body", e.Message)
@@ -713,7 +713,7 @@ func TestGetValidator(t *testing.T) {
 
 		s.GetValidator(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "state_id is required in URL params", e.Message)
@@ -733,7 +733,7 @@ func TestGetValidator(t *testing.T) {
 
 		s.GetValidator(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "validator_id is required in URL params", e.Message)
@@ -753,7 +753,7 @@ func TestGetValidator(t *testing.T) {
 
 		s.GetValidator(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "Invalid validator index", e.Message)
@@ -773,7 +773,7 @@ func TestGetValidator(t *testing.T) {
 
 		s.GetValidator(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "Unknown pubkey", e.Message)
@@ -1021,7 +1021,7 @@ func TestGetValidatorBalances(t *testing.T) {
 
 		s.GetValidator(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "state_id is required in URL params", e.Message)
@@ -1141,7 +1141,7 @@ func TestGetValidatorBalances(t *testing.T) {
 
 		s.GetValidatorBalances(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "No data submitted", e.Message)
@@ -1171,7 +1171,7 @@ func TestGetValidatorBalances(t *testing.T) {
 
 		s.GetValidatorBalances(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "Could not decode request body", e.Message)

--- a/beacon-chain/rpc/eth/blob/handlers_test.go
+++ b/beacon-chain/rpc/eth/blob/handlers_test.go
@@ -58,7 +58,7 @@ func TestBlobs(t *testing.T) {
 		s.Blobs(writer, request)
 
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "blobs are not supported for Phase 0 fork", e.Message)
@@ -250,7 +250,7 @@ func TestBlobs(t *testing.T) {
 		s.Blobs(writer, request)
 
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "blobs are not supported before Deneb fork", e.Message)
@@ -268,7 +268,7 @@ func TestBlobs(t *testing.T) {
 		s.Blobs(writer, request)
 
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "Invalid block ID"))

--- a/beacon-chain/rpc/eth/builder/handlers_test.go
+++ b/beacon-chain/rpc/eth/builder/handlers_test.go
@@ -96,7 +96,7 @@ func TestExpectedWithdrawals_BadRequest(t *testing.T) {
 
 			s.ExpectedWithdrawals(writer, request)
 			assert.Equal(t, http.StatusBadRequest, writer.Code)
-			e := &httputil.DefaultErrorJson{}
+			e := &httputil.DefaultJsonError{}
 			require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 			assert.Equal(t, http.StatusBadRequest, e.Code)
 			assert.StringContains(t, testCase.errorMessage, e.Message)

--- a/beacon-chain/rpc/eth/node/handlers_peers_test.go
+++ b/beacon-chain/rpc/eth/node/handlers_peers_test.go
@@ -65,7 +65,7 @@ func TestGetPeer(t *testing.T) {
 
 		s.GetPeer(writer, request)
 		require.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "Invalid peer ID", e.Message)
@@ -79,7 +79,7 @@ func TestGetPeer(t *testing.T) {
 
 		s.GetPeer(writer, request)
 		require.Equal(t, http.StatusNotFound, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusNotFound, e.Code)
 		assert.StringContains(t, "Peer not found", e.Message)

--- a/beacon-chain/rpc/eth/node/handlers_test.go
+++ b/beacon-chain/rpc/eth/node/handlers_test.go
@@ -198,7 +198,7 @@ func TestGetIdentity(t *testing.T) {
 
 		s.GetIdentity(writer, request)
 		require.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Could not obtain enr", e.Message)
@@ -223,7 +223,7 @@ func TestGetIdentity(t *testing.T) {
 
 		s.GetIdentity(writer, request)
 		require.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Could not obtain discovery address", e.Message)

--- a/beacon-chain/rpc/eth/rewards/handlers_test.go
+++ b/beacon-chain/rpc/eth/rewards/handlers_test.go
@@ -209,7 +209,7 @@ func TestBlockRewards(t *testing.T) {
 
 		s.BlockRewards(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, "Block rewards are not supported for Phase 0 blocks", e.Message)
@@ -541,7 +541,7 @@ func TestAttestationRewards(t *testing.T) {
 
 		s.AttestationRewards(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, "foo is not a validator index or pubkey", e.Message)
@@ -562,7 +562,7 @@ func TestAttestationRewards(t *testing.T) {
 
 		s.AttestationRewards(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, "No validator index found for pubkey "+pubkey, e.Message)
@@ -580,7 +580,7 @@ func TestAttestationRewards(t *testing.T) {
 
 		s.AttestationRewards(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, "Validator index 999 is too large. Maximum allowed index is 63", e.Message)
@@ -593,7 +593,7 @@ func TestAttestationRewards(t *testing.T) {
 
 		s.AttestationRewards(writer, request)
 		assert.Equal(t, http.StatusNotFound, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusNotFound, e.Code)
 		assert.Equal(t, "Attestation rewards are not supported for Phase 0", e.Message)
@@ -606,7 +606,7 @@ func TestAttestationRewards(t *testing.T) {
 
 		s.AttestationRewards(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "Could not decode epoch"))
@@ -619,7 +619,7 @@ func TestAttestationRewards(t *testing.T) {
 
 		s.AttestationRewards(writer, request)
 		assert.Equal(t, http.StatusNotFound, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusNotFound, e.Code)
 		assert.Equal(t, "Attestation rewards are available after two epoch transitions to ensure all attestations have a chance of inclusion", e.Message)
@@ -844,7 +844,7 @@ func TestSyncCommiteeRewards(t *testing.T) {
 
 		s.SyncCommitteeRewards(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, "foo is not a validator index or pubkey", e.Message)
@@ -871,7 +871,7 @@ func TestSyncCommiteeRewards(t *testing.T) {
 
 		s.SyncCommitteeRewards(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, "No validator index found for pubkey "+pubkey, e.Message)
@@ -895,7 +895,7 @@ func TestSyncCommiteeRewards(t *testing.T) {
 
 		s.SyncCommitteeRewards(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, "Validator index 9999 is too large. Maximum allowed index is 1023", e.Message)
@@ -914,7 +914,7 @@ func TestSyncCommiteeRewards(t *testing.T) {
 
 		s.SyncCommitteeRewards(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, "Sync committee rewards are not supported for Phase 0", e.Message)

--- a/beacon-chain/rpc/eth/rewards/testing/mock.go
+++ b/beacon-chain/rpc/eth/rewards/testing/mock.go
@@ -11,18 +11,18 @@ import (
 
 type MockBlockRewardFetcher struct {
 	Rewards *rewards.BlockRewards
-	Error   *httputil.DefaultErrorJson
+	Error   *httputil.DefaultJsonError
 	State   state.BeaconState
 }
 
-func (m *MockBlockRewardFetcher) GetBlockRewardsData(_ context.Context, _ interfaces.ReadOnlyBeaconBlock) (*rewards.BlockRewards, *httputil.DefaultErrorJson) {
+func (m *MockBlockRewardFetcher) GetBlockRewardsData(_ context.Context, _ interfaces.ReadOnlyBeaconBlock) (*rewards.BlockRewards, *httputil.DefaultJsonError) {
 	if m.Error != nil {
 		return nil, m.Error
 	}
 	return m.Rewards, nil
 }
 
-func (m *MockBlockRewardFetcher) GetStateForRewards(_ context.Context, _ interfaces.ReadOnlyBeaconBlock) (state.BeaconState, *httputil.DefaultErrorJson) {
+func (m *MockBlockRewardFetcher) GetStateForRewards(_ context.Context, _ interfaces.ReadOnlyBeaconBlock) (state.BeaconState, *httputil.DefaultJsonError) {
 	if m.Error != nil {
 		return nil, m.Error
 	}

--- a/beacon-chain/rpc/eth/shared/errors_test.go
+++ b/beacon-chain/rpc/eth/shared/errors_test.go
@@ -45,7 +45,7 @@ func TestWriteStateFetchError(t *testing.T) {
 		assert.Equal(t, c.expectedCode, writer.Code, "incorrect status code")
 		assert.StringContains(t, c.expectedMessage, writer.Body.String(), "incorrect error message")
 
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		assert.NoError(t, json.Unmarshal(writer.Body.Bytes(), e), "failed to unmarshal response")
 	}
 }

--- a/beacon-chain/rpc/eth/shared/request.go
+++ b/beacon-chain/rpc/eth/shared/request.go
@@ -58,7 +58,7 @@ func HexFromRoute(w http.ResponseWriter, r *http.Request, name string, length in
 
 func ValidateHex(w http.ResponseWriter, name, s string, length int) ([]byte, bool) {
 	if s == "" {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: name + " is required",
 			Code:    http.StatusBadRequest,
 		}
@@ -67,7 +67,7 @@ func ValidateHex(w http.ResponseWriter, name, s string, length int) ([]byte, boo
 	}
 	hexBytes, err := hexutil.Decode(s)
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: name + " is invalid: " + err.Error(),
 			Code:    http.StatusBadRequest,
 		}
@@ -83,7 +83,7 @@ func ValidateHex(w http.ResponseWriter, name, s string, length int) ([]byte, boo
 
 func ValidateUint(w http.ResponseWriter, name, s string) (uint64, bool) {
 	if s == "" {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: name + " is required",
 			Code:    http.StatusBadRequest,
 		}
@@ -92,7 +92,7 @@ func ValidateUint(w http.ResponseWriter, name, s string) (uint64, bool) {
 	}
 	v, err := strconv.ParseUint(s, 10, 64)
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: name + " is invalid: " + err.Error(),
 			Code:    http.StatusBadRequest,
 		}
@@ -118,7 +118,7 @@ func IsSyncing(
 	headSlot := headFetcher.HeadSlot()
 	isOptimistic, err := optimisticModeFetcher.IsOptimistic(ctx)
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: "Could not check optimistic status: " + err.Error(),
 			Code:    http.StatusInternalServerError,
 		}
@@ -139,7 +139,7 @@ func IsSyncing(
 	if err == nil {
 		msg += " Details: " + string(details)
 	}
-	errJson := &httputil.DefaultErrorJson{
+	errJson := &httputil.DefaultJsonError{
 		Message: msg,
 		Code:    http.StatusServiceUnavailable}
 	httputil.WriteError(w, errJson)
@@ -154,7 +154,7 @@ func IsOptimistic(
 ) (bool, error) {
 	isOptimistic, err := optimisticModeFetcher.IsOptimistic(ctx)
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: "Could not check optimistic status: " + err.Error(),
 			Code:    http.StatusInternalServerError,
 		}
@@ -164,7 +164,7 @@ func IsOptimistic(
 	if !isOptimistic {
 		return false, nil
 	}
-	errJson := &httputil.DefaultErrorJson{
+	errJson := &httputil.DefaultJsonError{
 		Code:    http.StatusServiceUnavailable,
 		Message: "Beacon node is currently optimistic and not serving validators",
 	}

--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -275,10 +275,10 @@ func (s *Server) produceBlockV3(ctx context.Context, w http.ResponseWriter, r *h
 	}
 }
 
-func getConsensusBlockValue(ctx context.Context, blockRewardsFetcher rewards.BlockRewardsFetcher, i interface{} /* block as argument */) (string, *httputil.DefaultErrorJson) {
+func getConsensusBlockValue(ctx context.Context, blockRewardsFetcher rewards.BlockRewardsFetcher, i interface{} /* block as argument */) (string, *httputil.DefaultJsonError) {
 	bb, err := blocks.NewBeaconBlock(i)
 	if err != nil {
-		return "", &httputil.DefaultErrorJson{
+		return "", &httputil.DefaultJsonError{
 			Message: err.Error(),
 			Code:    http.StatusInternalServerError,
 		}

--- a/beacon-chain/rpc/eth/validator/handlers_block_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_test.go
@@ -140,7 +140,7 @@ func TestProduceBlockV2(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is blinded", e.Message)
@@ -203,7 +203,7 @@ func TestProduceBlockV2(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is blinded", e.Message)
@@ -263,7 +263,7 @@ func TestProduceBlockV2(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is blinded", e.Message)
@@ -446,7 +446,7 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is blinded", e.Message)
@@ -511,7 +511,7 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is blinded", e.Message)
@@ -573,7 +573,7 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is blinded", e.Message)

--- a/beacon-chain/rpc/eth/validator/handlers_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_test.go
@@ -192,7 +192,7 @@ func TestGetAggregateAttestation(t *testing.T) {
 
 		s.GetAggregateAttestation(writer, request)
 		assert.Equal(t, http.StatusNotFound, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusNotFound, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No matching attestation found"))
@@ -205,7 +205,7 @@ func TestGetAggregateAttestation(t *testing.T) {
 
 		s.GetAggregateAttestation(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "attestation_data_root is required"))
@@ -218,7 +218,7 @@ func TestGetAggregateAttestation(t *testing.T) {
 
 		s.GetAggregateAttestation(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "attestation_data_root is invalid"))
@@ -232,7 +232,7 @@ func TestGetAggregateAttestation(t *testing.T) {
 
 		s.GetAggregateAttestation(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "slot is required"))
@@ -246,7 +246,7 @@ func TestGetAggregateAttestation(t *testing.T) {
 
 		s.GetAggregateAttestation(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "slot is invalid"))
@@ -366,7 +366,7 @@ func TestSubmitContributionAndProofs(t *testing.T) {
 
 		s.SubmitContributionAndProofs(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -381,7 +381,7 @@ func TestSubmitContributionAndProofs(t *testing.T) {
 
 		s.SubmitContributionAndProofs(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -398,7 +398,7 @@ func TestSubmitContributionAndProofs(t *testing.T) {
 
 		s.SubmitContributionAndProofs(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 	})
@@ -451,7 +451,7 @@ func TestSubmitAggregateAndProofs(t *testing.T) {
 
 		s.SubmitAggregateAndProofs(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -466,7 +466,7 @@ func TestSubmitAggregateAndProofs(t *testing.T) {
 
 		s.SubmitAggregateAndProofs(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -481,7 +481,7 @@ func TestSubmitAggregateAndProofs(t *testing.T) {
 
 		s.SubmitAggregateAndProofs(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 	})
@@ -558,7 +558,7 @@ func TestSubmitSyncCommitteeSubscription(t *testing.T) {
 
 		s.SubmitSyncCommitteeSubscription(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -573,7 +573,7 @@ func TestSubmitSyncCommitteeSubscription(t *testing.T) {
 
 		s.SubmitSyncCommitteeSubscription(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -588,7 +588,7 @@ func TestSubmitSyncCommitteeSubscription(t *testing.T) {
 
 		s.SubmitSyncCommitteeSubscription(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 	})
@@ -602,7 +602,7 @@ func TestSubmitSyncCommitteeSubscription(t *testing.T) {
 
 		s.SubmitSyncCommitteeSubscription(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "Epoch for subscription at index 0 is in the past"))
@@ -628,7 +628,7 @@ func TestSubmitSyncCommitteeSubscription(t *testing.T) {
 
 		s.SubmitSyncCommitteeSubscription(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "Epoch for subscription at index 0 is too far in the future"))
@@ -650,7 +650,7 @@ func TestSubmitSyncCommitteeSubscription(t *testing.T) {
 
 		s.SubmitSyncCommitteeSubscription(writer, request)
 		assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusServiceUnavailable, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "Beacon node is currently syncing"))
@@ -744,7 +744,7 @@ func TestSubmitBeaconCommitteeSubscription(t *testing.T) {
 
 		s.SubmitBeaconCommitteeSubscription(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -759,7 +759,7 @@ func TestSubmitBeaconCommitteeSubscription(t *testing.T) {
 
 		s.SubmitBeaconCommitteeSubscription(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "No data submitted"))
@@ -774,7 +774,7 @@ func TestSubmitBeaconCommitteeSubscription(t *testing.T) {
 
 		s.SubmitBeaconCommitteeSubscription(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 	})
@@ -795,7 +795,7 @@ func TestSubmitBeaconCommitteeSubscription(t *testing.T) {
 
 		s.SubmitBeaconCommitteeSubscription(writer, request)
 		assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusServiceUnavailable, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "Beacon node is currently syncing"))
@@ -905,7 +905,7 @@ func TestGetAttestationData(t *testing.T) {
 		s.GetAttestationData(writer, request)
 
 		assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusServiceUnavailable, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "syncing"))
@@ -940,7 +940,7 @@ func TestGetAttestationData(t *testing.T) {
 		s.GetAttestationData(writer, request)
 
 		assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusServiceUnavailable, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "optimistic"))
@@ -1066,7 +1066,7 @@ func TestGetAttestationData(t *testing.T) {
 		s.GetAttestationData(writer, request)
 
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "invalid request"))
@@ -1610,7 +1610,7 @@ func TestGetAttesterDuties(t *testing.T) {
 
 		s.GetAttesterDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "No data submitted", e.Message)
@@ -1626,7 +1626,7 @@ func TestGetAttesterDuties(t *testing.T) {
 
 		s.GetAttesterDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "No data submitted", e.Message)
@@ -1642,7 +1642,7 @@ func TestGetAttesterDuties(t *testing.T) {
 
 		s.GetAttesterDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 	})
@@ -1682,7 +1682,7 @@ func TestGetAttesterDuties(t *testing.T) {
 
 		s.GetAttesterDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, fmt.Sprintf("Request epoch %d can not be greater than next epoch %d", currentEpoch+2, currentEpoch+1)))
@@ -1698,7 +1698,7 @@ func TestGetAttesterDuties(t *testing.T) {
 
 		s.GetAttesterDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, fmt.Sprintf("Invalid validator index %d", len(pubKeys))))
@@ -1774,7 +1774,7 @@ func TestGetAttesterDuties(t *testing.T) {
 
 		s.GetAttesterDuties(writer, request)
 		require.Equal(t, http.StatusServiceUnavailable, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusServiceUnavailable, e.Code)
 	})
@@ -1952,7 +1952,7 @@ func TestGetProposerDuties(t *testing.T) {
 
 		s.GetProposerDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, fmt.Sprintf("Request epoch %d can not be greater than next epoch %d", currentEpoch+2, currentEpoch+1), e.Message)
@@ -2016,7 +2016,7 @@ func TestGetProposerDuties(t *testing.T) {
 
 		s.GetProposerDuties(writer, request)
 		assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusServiceUnavailable, e.Code)
 	})
@@ -2107,7 +2107,7 @@ func TestGetSyncCommitteeDuties(t *testing.T) {
 
 		s.GetSyncCommitteeDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "No data submitted", e.Message)
@@ -2123,7 +2123,7 @@ func TestGetSyncCommitteeDuties(t *testing.T) {
 
 		s.GetSyncCommitteeDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "No data submitted", e.Message)
@@ -2139,7 +2139,7 @@ func TestGetSyncCommitteeDuties(t *testing.T) {
 
 		s.GetSyncCommitteeDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 	})
@@ -2187,7 +2187,7 @@ func TestGetSyncCommitteeDuties(t *testing.T) {
 
 		s.GetSyncCommitteeDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "Invalid validator index", e.Message)
@@ -2300,7 +2300,7 @@ func TestGetSyncCommitteeDuties(t *testing.T) {
 
 		s.GetSyncCommitteeDuties(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "Epoch is too far in the future", e.Message)
@@ -2378,7 +2378,7 @@ func TestGetSyncCommitteeDuties(t *testing.T) {
 
 		s.GetSyncCommitteeDuties(writer, request)
 		assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusServiceUnavailable, e.Code)
 	})
@@ -2649,7 +2649,7 @@ func TestGetLiveness(t *testing.T) {
 
 		s.GetLiveness(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		require.StringContains(t, "Requested epoch cannot be in the future", e.Message)
@@ -2664,7 +2664,7 @@ func TestGetLiveness(t *testing.T) {
 
 		s.GetLiveness(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "epoch is required"))
@@ -2680,7 +2680,7 @@ func TestGetLiveness(t *testing.T) {
 
 		s.GetLiveness(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.Equal(t, true, strings.Contains(e.Message, "epoch is invalid"))
@@ -2693,7 +2693,7 @@ func TestGetLiveness(t *testing.T) {
 
 		s.GetLiveness(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "No data submitted", e.Message)
@@ -2709,7 +2709,7 @@ func TestGetLiveness(t *testing.T) {
 
 		s.GetLiveness(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		assert.StringContains(t, "No data submitted", e.Message)
@@ -2725,7 +2725,7 @@ func TestGetLiveness(t *testing.T) {
 
 		s.GetLiveness(writer, request)
 		assert.Equal(t, http.StatusBadRequest, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusBadRequest, e.Code)
 		require.StringContains(t, "Validator index 2 is invalid", e.Message)

--- a/beacon-chain/rpc/prysm/node/handlers.go
+++ b/beacon-chain/rpc/prysm/node/handlers.go
@@ -28,7 +28,7 @@ func (s *Server) ListTrustedPeer(w http.ResponseWriter, r *http.Request) {
 	for _, id := range allIds {
 		p, err := httpPeerInfo(peerStatus, id)
 		if err != nil {
-			errJson := &httputil.DefaultErrorJson{
+			errJson := &httputil.DefaultJsonError{
 				Message: errors.Wrapf(err, "Could not get peer info").Error(),
 				Code:    http.StatusInternalServerError,
 			}
@@ -58,7 +58,7 @@ func (s *Server) AddTrustedPeer(w http.ResponseWriter, r *http.Request) {
 
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: errors.Wrapf(err, "Could not read request body").Error(),
 			Code:    http.StatusInternalServerError,
 		}
@@ -68,7 +68,7 @@ func (s *Server) AddTrustedPeer(w http.ResponseWriter, r *http.Request) {
 	var addrRequest *AddrRequest
 	err = json.Unmarshal(body, &addrRequest)
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: errors.Wrapf(err, "Could not decode request body into peer address").Error(),
 			Code:    http.StatusBadRequest,
 		}
@@ -77,7 +77,7 @@ func (s *Server) AddTrustedPeer(w http.ResponseWriter, r *http.Request) {
 	}
 	info, err := peer.AddrInfoFromString(addrRequest.Addr)
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: errors.Wrapf(err, "Could not derive peer info from multiaddress").Error(),
 			Code:    http.StatusBadRequest,
 		}
@@ -108,7 +108,7 @@ func (s *Server) RemoveTrustedPeer(w http.ResponseWriter, r *http.Request) {
 	id := segments[len(segments)-1]
 	peerId, err := peer.Decode(id)
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: errors.Wrapf(err, "Could not decode peer id").Error(),
 			Code:    http.StatusBadRequest,
 		}

--- a/beacon-chain/rpc/prysm/node/handlers_test.go
+++ b/beacon-chain/rpc/prysm/node/handlers_test.go
@@ -188,7 +188,7 @@ func TestAddTrustedPeer_EmptyBody(t *testing.T) {
 	writer := httptest.NewRecorder()
 	writer.Body = &bytes.Buffer{}
 	s.AddTrustedPeer(writer, request)
-	e := &httputil.DefaultErrorJson{}
+	e := &httputil.DefaultJsonError{}
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 	assert.Equal(t, http.StatusBadRequest, writer.Code)
 	assert.Equal(t, "Could not decode request body into peer address: unexpected end of JSON input", e.Message)
@@ -213,7 +213,7 @@ func TestAddTrustedPeer_BadAddress(t *testing.T) {
 	writer := httptest.NewRecorder()
 	writer.Body = &bytes.Buffer{}
 	s.AddTrustedPeer(writer, request)
-	e := &httputil.DefaultErrorJson{}
+	e := &httputil.DefaultJsonError{}
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 	assert.Equal(t, http.StatusBadRequest, writer.Code)
 	assert.StringContains(t, "Could not derive peer info from multiaddress", e.Message)
@@ -243,7 +243,7 @@ func TestRemoveTrustedPeer_EmptyParameter(t *testing.T) {
 	writer := httptest.NewRecorder()
 	writer.Body = &bytes.Buffer{}
 	s.RemoveTrustedPeer(writer, request)
-	e := &httputil.DefaultErrorJson{}
+	e := &httputil.DefaultJsonError{}
 	require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 	assert.Equal(t, http.StatusBadRequest, writer.Code)
 	assert.Equal(t, "Could not decode peer id: failed to parse peer ID: invalid cid: cid too short", e.Message)

--- a/beacon-chain/rpc/prysm/validator/validator_count.go
+++ b/beacon-chain/rpc/prysm/validator/validator_count.go
@@ -67,7 +67,7 @@ func (s *Server) GetValidatorCount(w http.ResponseWriter, r *http.Request) {
 
 	isOptimistic, err := helpers.IsOptimistic(ctx, []byte(stateID), s.OptimisticModeFetcher, s.Stater, s.ChainInfoFetcher, s.BeaconDB)
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: fmt.Sprintf("could not check if slot's block is optimistic: %v", err),
 			Code:    http.StatusInternalServerError,
 		}
@@ -83,7 +83,7 @@ func (s *Server) GetValidatorCount(w http.ResponseWriter, r *http.Request) {
 
 	blockRoot, err := st.LatestBlockHeader().HashTreeRoot()
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: fmt.Sprintf("could not calculate root of latest block header: %v", err),
 			Code:    http.StatusInternalServerError,
 		}
@@ -97,7 +97,7 @@ func (s *Server) GetValidatorCount(w http.ResponseWriter, r *http.Request) {
 	for _, status := range r.URL.Query()["status"] {
 		statusVal, ok := ethpb.ValidatorStatus_value[strings.ToUpper(status)]
 		if !ok {
-			errJson := &httputil.DefaultErrorJson{
+			errJson := &httputil.DefaultJsonError{
 				Message: fmt.Sprintf("invalid status query parameter: %v", status),
 				Code:    http.StatusBadRequest,
 			}
@@ -118,7 +118,7 @@ func (s *Server) GetValidatorCount(w http.ResponseWriter, r *http.Request) {
 	epoch := slots.ToEpoch(st.Slot())
 	valCount, err := validatorCountByStatus(st.Validators(), statusVals, epoch)
 	if err != nil {
-		errJson := &httputil.DefaultErrorJson{
+		errJson := &httputil.DefaultJsonError{
 			Message: fmt.Sprintf("could not get validator count: %v", err),
 			Code:    http.StatusInternalServerError,
 		}

--- a/beacon-chain/rpc/prysm/validator/validator_count_test.go
+++ b/beacon-chain/rpc/prysm/validator/validator_count_test.go
@@ -101,7 +101,7 @@ func TestGetValidatorCountInvalidRequest(t *testing.T) {
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 
-			var errJson httputil.DefaultErrorJson
+			var errJson httputil.DefaultJsonError
 			err = json.Unmarshal(body, &errJson)
 			require.NoError(t, err)
 			require.Equal(t, test.statusCode, errJson.Code)

--- a/beacon-chain/rpc/prysm/validator/validator_performance.go
+++ b/beacon-chain/rpc/prysm/validator/validator_performance.go
@@ -66,7 +66,7 @@ func (s *Server) GetValidatorPerformance(w http.ResponseWriter, r *http.Request)
 }
 
 func handleHTTPError(w http.ResponseWriter, message string, code int) {
-	errJson := &httputil.DefaultErrorJson{
+	errJson := &httputil.DefaultJsonError{
 		Message: message,
 		Code:    code,
 	}

--- a/beacon-chain/sync/rpc_beacon_blocks_by_root.go
+++ b/beacon-chain/sync/rpc_beacon_blocks_by_root.go
@@ -109,7 +109,7 @@ func (s *Service) beaconBlocksRootRPCHandler(ctx context.Context, msg interface{
 		if blk.Block().IsBlinded() {
 			blk, err = s.cfg.executionPayloadReconstructor.ReconstructFullBlock(ctx, blk)
 			if err != nil {
-				if errors.Is(err, execution.EmptyBlockHash) {
+				if errors.Is(err, execution.ErrEmptyBlockHash) {
 					log.WithError(err).Warn("Could not reconstruct block from header with syncing execution client. Waiting to complete syncing")
 				} else {
 					log.WithError(err).Error("Could not get reconstruct full block from blinded body")

--- a/io/file/fileutil.go
+++ b/io/file/fileutil.go
@@ -154,7 +154,7 @@ func Exists(filename string) bool {
 // RecursiveFileFind returns true, and the path,  if a file is not a directory and exists
 // at  dir or any of its subdirectories.  Finds the first instant based on the Walk order and returns.
 // Define non-fatal error to stop the recursive directory walk
-var stopWalk = errors.New("stop walking")
+var errStopWalk = errors.New("stop walking")
 
 // RecursiveFileFind searches for file in a directory and its subdirectories.
 func RecursiveFileFind(filename, dir string) (bool, string, error) {
@@ -171,13 +171,13 @@ func RecursiveFileFind(filename, dir string) (bool, string, error) {
 		if !info.IsDir() && filename == info.Name() {
 			found = true
 			fpath = path
-			return stopWalk
+			return errStopWalk
 		}
 
 		// no errors or file found
 		return nil
 	})
-	if err != nil && err != stopWalk {
+	if err != nil && err != errStopWalk {
 		return false, "", err
 	}
 	return found, fpath, nil

--- a/network/httputil/errors.go
+++ b/network/httputil/errors.go
@@ -5,7 +5,7 @@ import (
 )
 
 func HandleError(w http.ResponseWriter, message string, code int) {
-	errJson := &DefaultErrorJson{
+	errJson := &DefaultJsonError{
 		Message: message,
 		Code:    code,
 	}

--- a/network/httputil/writer.go
+++ b/network/httputil/writer.go
@@ -16,17 +16,17 @@ type HasStatusCode interface {
 	StatusCode() int
 }
 
-// DefaultErrorJson is a JSON representation of a simple error value, containing only a message and an error code.
-type DefaultErrorJson struct {
+// DefaultJsonError is a JSON representation of a simple error value, containing only a message and an error code.
+type DefaultJsonError struct {
 	Message string `json:"message"`
 	Code    int    `json:"code"`
 }
 
-func (e *DefaultErrorJson) StatusCode() int {
+func (e *DefaultJsonError) StatusCode() int {
 	return e.Code
 }
 
-func (e *DefaultErrorJson) Error() string {
+func (e *DefaultJsonError) Error() string {
 	return fmt.Sprintf("HTTP request unsuccessful (%d: %s)", e.Code, e.Message)
 }
 

--- a/testing/endtoend/evaluators/execution_engine.go
+++ b/testing/endtoend/evaluators/execution_engine.go
@@ -35,7 +35,7 @@ func optimisticSyncEnabled(_ *types.EvaluationContext, conns ...*grpc.ClientConn
 			return err
 		}
 		if httpResp.StatusCode != http.StatusOK {
-			e := httputil.DefaultErrorJson{}
+			e := httputil.DefaultJsonError{}
 			if err = json.NewDecoder(httpResp.Body).Decode(&e); err != nil {
 				return err
 			}
@@ -65,7 +65,7 @@ func optimisticSyncEnabled(_ *types.EvaluationContext, conns ...*grpc.ClientConn
 				continue
 			}
 			if httpResp.StatusCode != http.StatusOK {
-				e := httputil.DefaultErrorJson{}
+				e := httputil.DefaultJsonError{}
 				if err = json.NewDecoder(httpResp.Body).Decode(&e); err != nil {
 					return err
 				}

--- a/testing/endtoend/evaluators/validator.go
+++ b/testing/endtoend/evaluators/validator.go
@@ -139,7 +139,7 @@ func validatorsParticipating(_ *types.EvaluationContext, conns ...*grpc.ClientCo
 			return err
 		}
 		if httpResp.StatusCode != http.StatusOK {
-			e := httputil.DefaultErrorJson{}
+			e := httputil.DefaultJsonError{}
 			if err = json.NewDecoder(httpResp.Body).Decode(&e); err != nil {
 				return err
 			}

--- a/validator/client/aggregate.go
+++ b/validator/client/aggregate.go
@@ -78,7 +78,7 @@ func (v *validator) SubmitAggregateAndProof(ctx context.Context, slot primitives
 		s, ok := status.FromError(err)
 		grpcNotFound := ok && s.Code() == codes.NotFound
 		// handle http not found
-		jsonErr := &httputil.DefaultErrorJson{}
+		jsonErr := &httputil.DefaultJsonError{}
 		httpNotFound := errors.As(err, &jsonErr) && jsonErr.Code == http.StatusNotFound
 
 		if grpcNotFound || httpNotFound {

--- a/validator/client/beacon-api/genesis.go
+++ b/validator/client/beacon-api/genesis.go
@@ -14,7 +14,7 @@ import (
 )
 
 type GenesisProvider interface {
-	GetGenesis(ctx context.Context) (*beacon.Genesis, *httputil.DefaultErrorJson, error)
+	GetGenesis(ctx context.Context) (*beacon.Genesis, *httputil.DefaultJsonError, error)
 }
 
 type beaconApiGenesisProvider struct {
@@ -61,7 +61,7 @@ func (c beaconApiValidatorClient) waitForChainStart(ctx context.Context) (*ethpb
 }
 
 // GetGenesis gets the genesis information from the beacon node via the /eth/v1/beacon/genesis endpoint
-func (c beaconApiGenesisProvider) GetGenesis(ctx context.Context) (*beacon.Genesis, *httputil.DefaultErrorJson, error) {
+func (c beaconApiGenesisProvider) GetGenesis(ctx context.Context) (*beacon.Genesis, *httputil.DefaultJsonError, error) {
 	genesisJson := &beacon.GetGenesisResponse{}
 	errorJson, err := c.jsonRestHandler.Get(ctx, "/eth/v1/beacon/genesis", genesisJson)
 	if err != nil {

--- a/validator/client/beacon-api/genesis_test.go
+++ b/validator/client/beacon-api/genesis_test.go
@@ -41,7 +41,7 @@ func TestGetGenesis_ValidGenesis(t *testing.T) {
 	genesisProvider := &beaconApiGenesisProvider{jsonRestHandler: jsonRestHandler}
 	resp, httpError, err := genesisProvider.GetGenesis(ctx)
 	assert.NoError(t, err)
-	assert.Equal(t, (*httputil.DefaultErrorJson)(nil), httpError)
+	assert.Equal(t, (*httputil.DefaultJsonError)(nil), httpError)
 	require.NotNil(t, resp)
 	assert.Equal(t, "1234", resp.GenesisTime)
 	assert.Equal(t, "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2", resp.GenesisValidatorsRoot)
@@ -69,7 +69,7 @@ func TestGetGenesis_NilData(t *testing.T) {
 
 	genesisProvider := &beaconApiGenesisProvider{jsonRestHandler: jsonRestHandler}
 	_, httpError, err := genesisProvider.GetGenesis(ctx)
-	assert.Equal(t, (*httputil.DefaultErrorJson)(nil), httpError)
+	assert.Equal(t, (*httputil.DefaultJsonError)(nil), httpError)
 	assert.ErrorContains(t, "genesis data is nil", err)
 }
 
@@ -79,7 +79,7 @@ func TestGetGenesis_JsonResponseError(t *testing.T) {
 
 	ctx := context.Background()
 
-	expectedHttpErrorJson := &httputil.DefaultErrorJson{
+	expectedHttpErrorJson := &httputil.DefaultJsonError{
 		Message: "http error message",
 		Code:    999,
 	}

--- a/validator/client/beacon-api/get_beacon_block_test.go
+++ b/validator/client/beacon-api/get_beacon_block_test.go
@@ -532,7 +532,7 @@ func TestGetBeaconBlock_FallbackToBlindedBlock(t *testing.T) {
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&validator.ProduceBlockV3Response{},
 	).Return(
-		&httputil.DefaultErrorJson{Code: http.StatusNotFound},
+		&httputil.DefaultJsonError{Code: http.StatusNotFound},
 		errors.New("foo"),
 	).Times(1)
 	jsonRestHandler.EXPECT().Get(
@@ -585,7 +585,7 @@ func TestGetBeaconBlock_FallbackToFullBlock(t *testing.T) {
 		fmt.Sprintf("/eth/v3/validator/blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&validator.ProduceBlockV3Response{},
 	).Return(
-		&httputil.DefaultErrorJson{Code: http.StatusNotFound},
+		&httputil.DefaultJsonError{Code: http.StatusNotFound},
 		errors.New("foo"),
 	).Times(1)
 	jsonRestHandler.EXPECT().Get(
@@ -593,7 +593,7 @@ func TestGetBeaconBlock_FallbackToFullBlock(t *testing.T) {
 		fmt.Sprintf("/eth/v1/validator/blinded_blocks/%d?graffiti=%s&randao_reveal=%s", slot, hexutil.Encode(graffiti), hexutil.Encode(randaoReveal)),
 		&abstractProduceBlockResponseJson{},
 	).Return(
-		&httputil.DefaultErrorJson{Code: http.StatusInternalServerError},
+		&httputil.DefaultJsonError{Code: http.StatusInternalServerError},
 		errors.New("foo"),
 	).Times(1)
 	jsonRestHandler.EXPECT().Get(

--- a/validator/client/beacon-api/json_rest_handler.go
+++ b/validator/client/beacon-api/json_rest_handler.go
@@ -13,8 +13,8 @@ import (
 )
 
 type JsonRestHandler interface {
-	Get(ctx context.Context, query string, resp interface{}) (*httputil.DefaultErrorJson, error)
-	Post(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer, resp interface{}) (*httputil.DefaultErrorJson, error)
+	Get(ctx context.Context, query string, resp interface{}) (*httputil.DefaultJsonError, error)
+	Post(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer, resp interface{}) (*httputil.DefaultJsonError, error)
 }
 
 type beaconApiJsonRestHandler struct {
@@ -23,8 +23,8 @@ type beaconApiJsonRestHandler struct {
 }
 
 // Get sends a GET request and decodes the response body as a JSON object into the passed in object.
-// If an HTTP error is returned, the body is decoded as a DefaultErrorJson JSON object and returned as the first return value.
-func (c beaconApiJsonRestHandler) Get(ctx context.Context, endpoint string, resp interface{}) (*httputil.DefaultErrorJson, error) {
+// If an HTTP error is returned, the body is decoded as a DefaultJsonError JSON object and returned as the first return value.
+func (c beaconApiJsonRestHandler) Get(ctx context.Context, endpoint string, resp interface{}) (*httputil.DefaultJsonError, error) {
 	if resp == nil {
 		return nil, errors.New("resp is nil")
 	}
@@ -49,14 +49,14 @@ func (c beaconApiJsonRestHandler) Get(ctx context.Context, endpoint string, resp
 }
 
 // Post sends a POST request and decodes the response body as a JSON object into the passed in object.
-// If an HTTP error is returned, the body is decoded as a DefaultErrorJson JSON object and returned as the first return value.
+// If an HTTP error is returned, the body is decoded as a DefaultJsonError JSON object and returned as the first return value.
 func (c beaconApiJsonRestHandler) Post(
 	ctx context.Context,
 	apiEndpoint string,
 	headers map[string]string,
 	data *bytes.Buffer,
 	resp interface{},
-) (*httputil.DefaultErrorJson, error) {
+) (*httputil.DefaultJsonError, error) {
 	if data == nil {
 		return nil, errors.New("data is nil")
 	}
@@ -85,7 +85,7 @@ func (c beaconApiJsonRestHandler) Post(
 	return decodeResp(httpResp, resp)
 }
 
-func decodeResp(httpResp *http.Response, resp interface{}) (*httputil.DefaultErrorJson, error) {
+func decodeResp(httpResp *http.Response, resp interface{}) (*httputil.DefaultJsonError, error) {
 	body, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read response body for %s", httpResp.Request.URL)
@@ -95,12 +95,12 @@ func decodeResp(httpResp *http.Response, resp interface{}) (*httputil.DefaultErr
 		if httpResp.StatusCode == http.StatusOK {
 			return nil, nil
 		}
-		return &httputil.DefaultErrorJson{Code: httpResp.StatusCode, Message: string(body)}, nil
+		return &httputil.DefaultJsonError{Code: httpResp.StatusCode, Message: string(body)}, nil
 	}
 
 	decoder := json.NewDecoder(bytes.NewBuffer(body))
 	if httpResp.StatusCode != http.StatusOK {
-		errorJson := &httputil.DefaultErrorJson{}
+		errorJson := &httputil.DefaultJsonError{}
 		if err = decoder.Decode(errorJson); err != nil {
 			return nil, errors.Wrapf(err, "failed to decode response body into error json for %s", httpResp.Request.URL)
 		}

--- a/validator/client/beacon-api/json_rest_handler_test.go
+++ b/validator/client/beacon-api/json_rest_handler_test.go
@@ -146,7 +146,7 @@ func decodeRespTest(t *testing.T) {
 	})
 	t.Run("non-200 JSON", func(t *testing.T) {
 		body := bytes.Buffer{}
-		b, err := json.Marshal(&httputil.DefaultErrorJson{Code: http.StatusInternalServerError, Message: "error"})
+		b, err := json.Marshal(&httputil.DefaultJsonError{Code: http.StatusInternalServerError, Message: "error"})
 		require.NoError(t, err)
 		body.Write(b)
 		r := &http.Response{StatusCode: http.StatusInternalServerError, Body: io.NopCloser(&body), Header: map[string][]string{"Content-Type": {api.JsonMediaType}}}

--- a/validator/client/beacon-api/mock/genesis_mock.go
+++ b/validator/client/beacon-api/mock/genesis_mock.go
@@ -37,11 +37,11 @@ func (m *MockGenesisProvider) EXPECT() *MockGenesisProviderMockRecorder {
 }
 
 // GetGenesis mocks base method.
-func (m *MockGenesisProvider) GetGenesis(ctx context.Context) (*beacon.Genesis, *httputil.DefaultErrorJson, error) {
+func (m *MockGenesisProvider) GetGenesis(ctx context.Context) (*beacon.Genesis, *httputil.DefaultJsonError, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGenesis", ctx)
 	ret0, _ := ret[0].(*beacon.Genesis)
-	ret1, _ := ret[1].(*httputil.DefaultErrorJson)
+	ret1, _ := ret[1].(*httputil.DefaultJsonError)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/validator/client/beacon-api/mock/json_rest_handler_mock.go
+++ b/validator/client/beacon-api/mock/json_rest_handler_mock.go
@@ -37,10 +37,10 @@ func (m *MockJsonRestHandler) EXPECT() *MockJsonRestHandlerMockRecorder {
 }
 
 // Get mocks base method.
-func (m *MockJsonRestHandler) Get(ctx context.Context, query string, resp interface{}) (*httputil.DefaultErrorJson, error) {
+func (m *MockJsonRestHandler) Get(ctx context.Context, query string, resp interface{}) (*httputil.DefaultJsonError, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, query, resp)
-	ret0, _ := ret[0].(*httputil.DefaultErrorJson)
+	ret0, _ := ret[0].(*httputil.DefaultJsonError)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -52,10 +52,10 @@ func (mr *MockJsonRestHandlerMockRecorder) Get(ctx, query, resp interface{}) *go
 }
 
 // Post mocks base method.
-func (m *MockJsonRestHandler) Post(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer, resp interface{}) (*httputil.DefaultErrorJson, error) {
+func (m *MockJsonRestHandler) Post(ctx context.Context, endpoint string, headers map[string]string, data *bytes.Buffer, resp interface{}) (*httputil.DefaultJsonError, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Post", ctx, endpoint, headers, data, resp)
-	ret0, _ := ret[0].(*httputil.DefaultErrorJson)
+	ret0, _ := ret[0].(*httputil.DefaultJsonError)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/validator/client/beacon-api/propose_beacon_block_test.go
+++ b/validator/client/beacon-api/propose_beacon_block_test.go
@@ -17,12 +17,12 @@ func TestProposeBeaconBlock_Error(t *testing.T) {
 	testSuites := []struct {
 		name                 string
 		expectedErrorMessage string
-		expectedHttpError    *httputil.DefaultErrorJson
+		expectedHttpError    *httputil.DefaultJsonError
 	}{
 		{
 			name:                 "error 202",
 			expectedErrorMessage: "block was successfully broadcasted but failed validation",
-			expectedHttpError: &httputil.DefaultErrorJson{
+			expectedHttpError: &httputil.DefaultJsonError{
 				Code:    http.StatusAccepted,
 				Message: "202 error",
 			},

--- a/validator/client/beacon-api/wait_for_chain_start_test.go
+++ b/validator/client/beacon-api/wait_for_chain_start_test.go
@@ -151,7 +151,7 @@ func TestWaitForChainStart_JsonResponseError404(t *testing.T) {
 		"/eth/v1/beacon/genesis",
 		&genesisResponseJson,
 	).Return(
-		&httputil.DefaultErrorJson{
+		&httputil.DefaultJsonError{
 			Code:    http.StatusNotFound,
 			Message: "404 error",
 		},

--- a/validator/db/kv/proposer_settings.go
+++ b/validator/db/kv/proposer_settings.go
@@ -13,8 +13,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// NoProposerSettingsFound is an error thrown when no settings are found in bucket
-var NoProposerSettingsFound = errors.New("no proposer settings found in bucket")
+// ErrNoProposerSettingsFound is an error thrown when no settings are found in bucket
+var ErrNoProposerSettingsFound = errors.New("no proposer settings found in bucket")
 
 // UpdateProposerSettingsForPubkey updates the existing settings for an internal representation of the proposers settings file at a particular public key
 func (s *Store) UpdateProposerSettingsForPubkey(ctx context.Context, pubkey [fieldparams.BLSPubkeyLength]byte, options *validatorServiceConfig.ProposerOption) error {
@@ -61,7 +61,7 @@ func (s *Store) UpdateProposerSettingsDefault(ctx context.Context, options *vali
 		bkt := tx.Bucket(proposerSettingsBucket)
 		b := bkt.Get(proposerSettingsKey)
 		if len(b) == 0 {
-			return NoProposerSettingsFound
+			return ErrNoProposerSettingsFound
 		}
 		to := &validatorpb.ProposerSettingsPayload{}
 		if err := proto.Unmarshal(b, to); err != nil {
@@ -90,7 +90,7 @@ func (s *Store) ProposerSettings(ctx context.Context) (*validatorServiceConfig.P
 		bkt := tx.Bucket(proposerSettingsBucket)
 		b := bkt.Get(proposerSettingsKey)
 		if len(b) == 0 {
-			return NoProposerSettingsFound
+			return ErrNoProposerSettingsFound
 		}
 		if err := proto.Unmarshal(b, to); err != nil {
 			return errors.Wrap(err, "failed to unmarshal proposer settings")
@@ -106,7 +106,7 @@ func (s *Store) ProposerSettings(ctx context.Context) (*validatorServiceConfig.P
 func (s *Store) ProposerSettingsExists(ctx context.Context) (bool, error) {
 	ps, err := s.ProposerSettings(ctx)
 	if err != nil {
-		if errors.Is(err, NoProposerSettingsFound) {
+		if errors.Is(err, ErrNoProposerSettingsFound) {
 			return false, nil
 		}
 		return false, err


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**

This PR enables the `errname` linter which enforces consistent error naming. These were the findings:

```
$ golangci-lint run
beacon-chain/core/validators/validator.go:22:5: the variable name `ValidatorAlreadyExitedErr` should conform to the `ErrXxx` format (errname)
var ValidatorAlreadyExitedErr = errors.New("validator already exited")
    ^
beacon-chain/execution/engine_client.go:110:5: the variable name `EmptyBlockHash` should conform to the `ErrXxx` format (errname)
var EmptyBlockHash = errors.New("Block hash is empty 0x0000...")
    ^
io/file/fileutil.go:157:5: the variable name `stopWalk` should conform to the `errXxx` format (errname)
var stopWalk = errors.New("stop walking")
    ^
network/httputil/writer.go:20:6: the type name `DefaultErrorJson` should conform to the `XxxError` format (errname)
type DefaultErrorJson struct {
     ^
validator/db/kv/proposer_settings.go:17:5: the variable name `NoProposerSettingsFound` should conform to the `ErrXxx` format (errname)
var NoProposerSettingsFound = errors.New("no proposer settings found in bucket")
    ^
```

Most things were pretty simple, but changing `DefaultErrorJson` touched a lot of files.