### PR TITLE
Use `SkipMevBoost` properly during block production

### DIFF
--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -77,7 +77,7 @@ func (s *Server) ProduceBlockV2(w http.ResponseWriter, r *http.Request) {
 		Slot:         primitives.Slot(slot),
 		RandaoReveal: randaoReveal,
 		Graffiti:     graffiti,
-		SkipMevBoost: false,
+		SkipMevBoost: true,
 	}, full)
 }
 
@@ -185,7 +185,7 @@ func (s *Server) ProduceBlockV3(w http.ResponseWriter, r *http.Request) {
 		Slot:         primitives.Slot(slot),
 		RandaoReveal: randaoReveal,
 		Graffiti:     graffiti,
-		SkipMevBoost: false,
+		SkipMevBoost: true,
 	}, any)
 }
 

--- a/beacon-chain/rpc/eth/validator/handlers_block_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_test.go
@@ -696,7 +696,7 @@ func TestProduceBlindedBlock(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlindedBlock(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is not blinded", e.Message)
@@ -728,7 +728,7 @@ func TestProduceBlindedBlock(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlindedBlock(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is not blinded", e.Message)
@@ -760,7 +760,7 @@ func TestProduceBlindedBlock(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlindedBlock(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is not blinded", e.Message)
@@ -826,7 +826,7 @@ func TestProduceBlindedBlock(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlindedBlock(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is not blinded", e.Message)
@@ -895,7 +895,7 @@ func TestProduceBlindedBlock(t *testing.T) {
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlindedBlock(writer, request)
 		assert.Equal(t, http.StatusInternalServerError, writer.Code)
-		e := &httputil.DefaultErrorJson{}
+		e := &httputil.DefaultJsonError{}
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is not blinded", e.Message)

--- a/beacon-chain/rpc/eth/validator/handlers_block_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/golang/mock/gomock"
 	"github.com/prysmaticlabs/prysm/v4/api"
 	blockchainTesting "github.com/prysmaticlabs/prysm/v4/beacon-chain/blockchain/testing"
@@ -26,25 +27,39 @@ import (
 
 func TestProduceBlockV2(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	randao := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+	graffiti := "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+	bRandao, err := hexutil.Decode(randao)
+	require.NoError(t, err)
+	bGraffiti, err := hexutil.Decode(graffiti)
+	require.NoError(t, err)
+	chainService := &blockchainTesting.ChainService{}
+	syncChecker := &mockSync.Sync{IsSyncing: false}
+	rewardFetcher := &rewardtesting.MockBlockRewardFetcher{Rewards: &rewards.BlockRewards{Total: "10"}}
 
 	t.Run("Phase 0", func(t *testing.T) {
 		var block *shared.SignedBeaconBlock
-		err := json.Unmarshal([]byte(rpctesting.Phase0Block), &block)
+		err = json.Unmarshal([]byte(rpctesting.Phase0Block), &block)
 		require.NoError(t, err)
 		jsonBytes, err := json.Marshal(block.Message)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
 		server := &Server{
 			V1Alpha1Server: v1alpha1Server,
-			SyncChecker:    &mockSync.Sync{IsSyncing: false},
+			SyncChecker:    syncChecker,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -56,26 +71,29 @@ func TestProduceBlockV2(t *testing.T) {
 	})
 	t.Run("Altair", func(t *testing.T) {
 		var block *shared.SignedBeaconBlockAltair
-		err := json.Unmarshal([]byte(rpctesting.AltairBlock), &block)
-
+		err = json.Unmarshal([]byte(rpctesting.AltairBlock), &block)
 		require.NoError(t, err)
 		jsonBytes, err := json.Marshal(block.Message)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 
 				return block.Message.ToGeneric()
 			}())
-		mockRewards := &rewards.BlockRewards{Total: "10"}
 		server := &Server{
 			V1Alpha1Server:     v1alpha1Server,
-			SyncChecker:        &mockSync.Sync{IsSyncing: false},
-			BlockRewardFetcher: &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:        syncChecker,
+			BlockRewardFetcher: rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -87,26 +105,29 @@ func TestProduceBlockV2(t *testing.T) {
 	})
 	t.Run("Bellatrix", func(t *testing.T) {
 		var block *shared.SignedBeaconBlockBellatrix
-		err := json.Unmarshal([]byte(rpctesting.BellatrixBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.BellatrixBlock), &block)
 		require.NoError(t, err)
 		jsonBytes, err := json.Marshal(block.Message)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
-		mockRewards := &rewards.BlockRewards{Total: "10"}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -118,24 +139,27 @@ func TestProduceBlockV2(t *testing.T) {
 	})
 	t.Run("BlindedBellatrix", func(t *testing.T) {
 		var block *shared.SignedBlindedBeaconBlockBellatrix
-		err := json.Unmarshal([]byte(rpctesting.BlindedBellatrixBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.BlindedBellatrixBlock), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
-		mockRewards := &rewards.BlockRewards{Total: "10"}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -147,26 +171,29 @@ func TestProduceBlockV2(t *testing.T) {
 	})
 	t.Run("Capella", func(t *testing.T) {
 		var block *shared.SignedBeaconBlockCapella
-		err := json.Unmarshal([]byte(rpctesting.CapellaBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.CapellaBlock), &block)
 		require.NoError(t, err)
 		jsonBytes, err := json.Marshal(block.Message)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
-		mockRewards := &rewards.BlockRewards{Total: "10"}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -178,27 +205,30 @@ func TestProduceBlockV2(t *testing.T) {
 	})
 	t.Run("Blinded Capella", func(t *testing.T) {
 		var block *shared.SignedBlindedBeaconBlockCapella
-		err := json.Unmarshal([]byte(rpctesting.BlindedCapellaBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.BlindedCapellaBlock), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				g, err := block.Message.ToGeneric()
 				require.NoError(t, err)
 				g.PayloadValue = 2000 //some fake value
 				return g, err
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
-		mockRewards := &rewards.BlockRewards{Total: "10"}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -210,26 +240,29 @@ func TestProduceBlockV2(t *testing.T) {
 	})
 	t.Run("Deneb", func(t *testing.T) {
 		var block *shared.SignedBeaconBlockContentsDeneb
-		err := json.Unmarshal([]byte(rpctesting.DenebBlockContents), &block)
+		err = json.Unmarshal([]byte(rpctesting.DenebBlockContents), &block)
 		require.NoError(t, err)
 		jsonBytes, err := json.Marshal(block.ToUnsigned())
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.ToUnsigned().ToGeneric()
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
-		mockRewards := &rewards.BlockRewards{Total: "10"}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -241,24 +274,27 @@ func TestProduceBlockV2(t *testing.T) {
 	})
 	t.Run("Blinded Deneb", func(t *testing.T) {
 		var block *shared.SignedBlindedBeaconBlockDeneb
-		err := json.Unmarshal([]byte(rpctesting.BlindedDenebBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.BlindedDenebBlock), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
-		mockRewards := &rewards.BlockRewards{Total: "10"}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -272,9 +308,9 @@ func TestProduceBlockV2(t *testing.T) {
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		server := &Server{
 			V1Alpha1Server: v1alpha1Server,
-			SyncChecker:    &mockSync.Sync{IsSyncing: false},
+			SyncChecker:    syncChecker,
 		}
-		request := httptest.NewRequest(http.MethodGet, "http://foo.example/eth/v3/validator/blocks/", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example/eth/v2/validator/blocks/", nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -285,9 +321,9 @@ func TestProduceBlockV2(t *testing.T) {
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		server := &Server{
 			V1Alpha1Server: v1alpha1Server,
-			SyncChecker:    &mockSync.Sync{IsSyncing: false},
+			SyncChecker:    syncChecker,
 		}
-		request := httptest.NewRequest(http.MethodGet, "http://foo.example/eth/v3/validator/blocks/asdfsad", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example/eth/v2/validator/blocks/asdfsad", nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -298,9 +334,9 @@ func TestProduceBlockV2(t *testing.T) {
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		server := &Server{
 			V1Alpha1Server: v1alpha1Server,
-			SyncChecker:    &mockSync.Sync{IsSyncing: false},
+			SyncChecker:    syncChecker,
 		}
-		request := httptest.NewRequest(http.MethodGet, "http://foo.example/eth/v3/validator/blocks/1?randao_reveal=0x213123", nil)
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example/eth/v2/validator/blocks/1?randao_reveal=0x213123", nil)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -326,24 +362,38 @@ func TestProduceBlockV2(t *testing.T) {
 
 func TestProduceBlockV2SSZ(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockRewards := &rewards.BlockRewards{Total: "10"}
+	randao := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+	graffiti := "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+	bRandao, err := hexutil.Decode(randao)
+	require.NoError(t, err)
+	bGraffiti, err := hexutil.Decode(graffiti)
+	require.NoError(t, err)
+	chainService := &blockchainTesting.ChainService{}
+	syncChecker := &mockSync.Sync{IsSyncing: false}
+	rewardFetcher := &rewardtesting.MockBlockRewardFetcher{Rewards: &rewards.BlockRewards{Total: "10"}}
+
 	t.Run("Phase 0", func(t *testing.T) {
 		var block *shared.SignedBeaconBlock
-		err := json.Unmarshal([]byte(rpctesting.Phase0Block), &block)
+		err = json.Unmarshal([]byte(rpctesting.Phase0Block), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
 		server := &Server{
 			V1Alpha1Server: v1alpha1Server,
-			SyncChecker:    &mockSync.Sync{IsSyncing: false},
+			SyncChecker:    syncChecker,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
-		request.Header.Set("Accept", "application/octet-stream")
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		request.Header.Set("Accept", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -359,23 +409,28 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 	})
 	t.Run("Altair", func(t *testing.T) {
 		var block *shared.SignedBeaconBlockAltair
-		err := json.Unmarshal([]byte(rpctesting.AltairBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.AltairBlock), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
 
 		server := &Server{
 			V1Alpha1Server:     v1alpha1Server,
-			SyncChecker:        &mockSync.Sync{IsSyncing: false},
-			BlockRewardFetcher: &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:        syncChecker,
+			BlockRewardFetcher: rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
-		request.Header.Set("Accept", "application/octet-stream")
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		request.Header.Set("Accept", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -391,24 +446,28 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 	})
 	t.Run("Bellatrix", func(t *testing.T) {
 		var block *shared.SignedBeaconBlockBellatrix
-		err := json.Unmarshal([]byte(rpctesting.BellatrixBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.BellatrixBlock), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
-		request.Header.Set("Accept", "application/octet-stream")
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		request.Header.Set("Accept", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -424,24 +483,28 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 	})
 	t.Run("BlindedBellatrix", func(t *testing.T) {
 		var block *shared.SignedBlindedBeaconBlockBellatrix
-		err := json.Unmarshal([]byte(rpctesting.BlindedBellatrixBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.BlindedBellatrixBlock), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
-		request.Header.Set("Accept", "application/octet-stream")
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		request.Header.Set("Accept", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -453,24 +516,28 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 	})
 	t.Run("Capella", func(t *testing.T) {
 		var block *shared.SignedBeaconBlockCapella
-		err := json.Unmarshal([]byte(rpctesting.CapellaBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.CapellaBlock), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
-		request.Header.Set("Accept", "application/octet-stream")
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		request.Header.Set("Accept", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -486,27 +553,31 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 	})
 	t.Run("Blinded Capella", func(t *testing.T) {
 		var block *shared.SignedBlindedBeaconBlockCapella
-		err := json.Unmarshal([]byte(rpctesting.BlindedCapellaBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.BlindedCapellaBlock), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				g, err := block.Message.ToGeneric()
 				require.NoError(t, err)
 				g.PayloadValue = 2000 //some fake value
 				return g, err
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
-		request.Header.Set("Accept", "application/octet-stream")
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		request.Header.Set("Accept", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -518,24 +589,28 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 	})
 	t.Run("Deneb", func(t *testing.T) {
 		var block *shared.SignedBeaconBlockContentsDeneb
-		err := json.Unmarshal([]byte(rpctesting.DenebBlockContents), &block)
+		err = json.Unmarshal([]byte(rpctesting.DenebBlockContents), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.ToUnsigned().ToGeneric()
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
-		request.Header.Set("Accept", "application/octet-stream")
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		request.Header.Set("Accept", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -551,24 +626,28 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 	})
 	t.Run("Blinded Deneb", func(t *testing.T) {
 		var block *shared.SignedBlindedBeaconBlockDeneb
-		err := json.Unmarshal([]byte(rpctesting.BlindedDenebBlock), &block)
+		err = json.Unmarshal([]byte(rpctesting.BlindedDenebBlock), &block)
 		require.NoError(t, err)
+
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
-		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), gomock.Any()).Return(
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: true,
+		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
 			}())
-		mockChainService := &blockchainTesting.ChainService{}
 		server := &Server{
 			V1Alpha1Server:        v1alpha1Server,
-			SyncChecker:           &mockSync.Sync{IsSyncing: false},
-			OptimisticModeFetcher: mockChainService,
-			BlockRewardFetcher:    &rewardtesting.MockBlockRewardFetcher{Rewards: mockRewards},
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
 		}
-		rr := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505" +
-			"&graffiti=0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
-		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v3/validator/blocks/1?randao_reveal=%s", rr), nil)
-		request.Header.Set("Accept", "application/octet-stream")
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v2/validator/blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		request.Header.Set("Accept", api.OctetStreamMediaType)
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 		server.ProduceBlockV2(writer, request)
@@ -577,6 +656,337 @@ func TestProduceBlockV2SSZ(t *testing.T) {
 		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
 		assert.Equal(t, http.StatusInternalServerError, e.Code)
 		assert.StringContains(t, "Prepared block is blinded", e.Message)
+	})
+}
+
+func TestProduceBlindedBlock(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	randao := "0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505"
+	graffiti := "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+	bRandao, err := hexutil.Decode(randao)
+	require.NoError(t, err)
+	bGraffiti, err := hexutil.Decode(graffiti)
+	require.NoError(t, err)
+	chainService := &blockchainTesting.ChainService{}
+	syncChecker := &mockSync.Sync{IsSyncing: false}
+	rewardFetcher := &rewardtesting.MockBlockRewardFetcher{Rewards: &rewards.BlockRewards{Total: "10"}}
+
+	t.Run("Phase 0", func(t *testing.T) {
+		var block *shared.SignedBeaconBlock
+		err = json.Unmarshal([]byte(rpctesting.Phase0Block), &block)
+		require.NoError(t, err)
+
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
+		}).Return(
+			func() (*eth.GenericBeaconBlock, error) {
+				return block.Message.ToGeneric()
+			}())
+		server := &Server{
+			V1Alpha1Server: v1alpha1Server,
+			SyncChecker:    syncChecker,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v1/validator/blinded_blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusInternalServerError, writer.Code)
+		e := &httputil.DefaultErrorJson{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+		assert.Equal(t, http.StatusInternalServerError, e.Code)
+		assert.StringContains(t, "Prepared block is not blinded", e.Message)
+	})
+	t.Run("Altair", func(t *testing.T) {
+		var block *shared.SignedBeaconBlockAltair
+		err = json.Unmarshal([]byte(rpctesting.AltairBlock), &block)
+		require.NoError(t, err)
+
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
+		}).Return(
+			func() (*eth.GenericBeaconBlock, error) {
+
+				return block.Message.ToGeneric()
+			}())
+		server := &Server{
+			V1Alpha1Server:     v1alpha1Server,
+			SyncChecker:        &mockSync.Sync{IsSyncing: false},
+			BlockRewardFetcher: rewardFetcher,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v1/validator/blinded_blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusInternalServerError, writer.Code)
+		e := &httputil.DefaultErrorJson{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+		assert.Equal(t, http.StatusInternalServerError, e.Code)
+		assert.StringContains(t, "Prepared block is not blinded", e.Message)
+	})
+	t.Run("Bellatrix", func(t *testing.T) {
+		var block *shared.SignedBeaconBlockBellatrix
+		err = json.Unmarshal([]byte(rpctesting.BellatrixBlock), &block)
+		require.NoError(t, err)
+
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
+		}).Return(
+			func() (*eth.GenericBeaconBlock, error) {
+				return block.Message.ToGeneric()
+			}())
+		server := &Server{
+			V1Alpha1Server:        v1alpha1Server,
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v1/validator/blinded_blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusInternalServerError, writer.Code)
+		e := &httputil.DefaultErrorJson{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+		assert.Equal(t, http.StatusInternalServerError, e.Code)
+		assert.StringContains(t, "Prepared block is not blinded", e.Message)
+	})
+	t.Run("BlindedBellatrix", func(t *testing.T) {
+		var block *shared.SignedBlindedBeaconBlockBellatrix
+		err = json.Unmarshal([]byte(rpctesting.BlindedBellatrixBlock), &block)
+		require.NoError(t, err)
+		jsonBytes, err := json.Marshal(block.Message)
+		require.NoError(t, err)
+
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
+		}).Return(
+			func() (*eth.GenericBeaconBlock, error) {
+				return block.Message.ToGeneric()
+			}())
+		server := &Server{
+			V1Alpha1Server:        v1alpha1Server,
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v1/validator/blinded_blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusOK, writer.Code)
+		want := fmt.Sprintf(`{"version":"bellatrix","execution_payload_blinded":true,"execution_payload_value":"0","consensus_block_value":"10","data":%s}`, string(jsonBytes))
+		body := strings.ReplaceAll(writer.Body.String(), "\n", "")
+		require.Equal(t, want, body)
+		require.Equal(t, "bellatrix", writer.Header().Get(api.VersionHeader))
+	})
+	t.Run("Capella", func(t *testing.T) {
+		var block *shared.SignedBeaconBlockCapella
+		err = json.Unmarshal([]byte(rpctesting.CapellaBlock), &block)
+		require.NoError(t, err)
+
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
+		}).Return(
+			func() (*eth.GenericBeaconBlock, error) {
+				return block.Message.ToGeneric()
+			}())
+		server := &Server{
+			V1Alpha1Server:        v1alpha1Server,
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v1/validator/blinded_blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusInternalServerError, writer.Code)
+		e := &httputil.DefaultErrorJson{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+		assert.Equal(t, http.StatusInternalServerError, e.Code)
+		assert.StringContains(t, "Prepared block is not blinded", e.Message)
+	})
+	t.Run("Blinded Capella", func(t *testing.T) {
+		var block *shared.SignedBlindedBeaconBlockCapella
+		err = json.Unmarshal([]byte(rpctesting.BlindedCapellaBlock), &block)
+		require.NoError(t, err)
+		jsonBytes, err := json.Marshal(block.Message)
+		require.NoError(t, err)
+
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
+		}).Return(
+			func() (*eth.GenericBeaconBlock, error) {
+				g, err := block.Message.ToGeneric()
+				require.NoError(t, err)
+				g.PayloadValue = 2000 //some fake value
+				return g, err
+			}())
+		server := &Server{
+			V1Alpha1Server:        v1alpha1Server,
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v1/validator/blinded_blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusOK, writer.Code)
+		want := fmt.Sprintf(`{"version":"capella","execution_payload_blinded":true,"execution_payload_value":"2000","consensus_block_value":"10","data":%s}`, string(jsonBytes))
+		body := strings.ReplaceAll(writer.Body.String(), "\n", "")
+		require.Equal(t, want, body)
+		require.Equal(t, "capella", writer.Header().Get(api.VersionHeader))
+	})
+	t.Run("Deneb", func(t *testing.T) {
+		var block *shared.SignedBeaconBlockContentsDeneb
+		err = json.Unmarshal([]byte(rpctesting.DenebBlockContents), &block)
+		require.NoError(t, err)
+
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
+		}).Return(
+			func() (*eth.GenericBeaconBlock, error) {
+				return block.ToUnsigned().ToGeneric()
+			}())
+		server := &Server{
+			V1Alpha1Server:        v1alpha1Server,
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v1/validator/blinded_blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusInternalServerError, writer.Code)
+		e := &httputil.DefaultErrorJson{}
+		require.NoError(t, json.Unmarshal(writer.Body.Bytes(), e))
+		assert.Equal(t, http.StatusInternalServerError, e.Code)
+		assert.StringContains(t, "Prepared block is not blinded", e.Message)
+	})
+	t.Run("Blinded Deneb", func(t *testing.T) {
+		var block *shared.SignedBlindedBeaconBlockDeneb
+		err = json.Unmarshal([]byte(rpctesting.BlindedDenebBlock), &block)
+		require.NoError(t, err)
+		jsonBytes, err := json.Marshal(block.Message)
+		require.NoError(t, err)
+
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
+		}).Return(
+			func() (*eth.GenericBeaconBlock, error) {
+				return block.Message.ToGeneric()
+			}())
+		server := &Server{
+			V1Alpha1Server:        v1alpha1Server,
+			SyncChecker:           syncChecker,
+			OptimisticModeFetcher: chainService,
+			BlockRewardFetcher:    rewardFetcher,
+		}
+
+		request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://foo.example/eth/v1/validator/blinded_blocks/1?randao_reveal=%s&graffiti=%s", randao, graffiti), nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusOK, writer.Code)
+		want := fmt.Sprintf(`{"version":"deneb","execution_payload_blinded":true,"execution_payload_value":"0","consensus_block_value":"10","data":%s}`, string(jsonBytes))
+		body := strings.ReplaceAll(writer.Body.String(), "\n", "")
+		require.Equal(t, want, body)
+		require.Equal(t, "deneb", writer.Header().Get(api.VersionHeader))
+	})
+	t.Run("invalid query parameter slot empty", func(t *testing.T) {
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		server := &Server{
+			V1Alpha1Server: v1alpha1Server,
+			SyncChecker:    syncChecker,
+		}
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example/eth/v1/validator/blinded_blocks/", nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusBadRequest, writer.Code)
+		assert.Equal(t, true, strings.Contains(writer.Body.String(), "slot is required"))
+	})
+	t.Run("invalid query parameter slot invalid", func(t *testing.T) {
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		server := &Server{
+			V1Alpha1Server: v1alpha1Server,
+			SyncChecker:    syncChecker,
+		}
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example/eth/v1/validator/blinded_blocks/asdfsad", nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusBadRequest, writer.Code)
+		assert.Equal(t, true, strings.Contains(writer.Body.String(), "slot is invalid"))
+	})
+	t.Run("invalid query parameter randao_reveal invalid", func(t *testing.T) {
+		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
+		server := &Server{
+			V1Alpha1Server: v1alpha1Server,
+			SyncChecker:    syncChecker,
+		}
+		request := httptest.NewRequest(http.MethodGet, "http://foo.example/eth/v1/validator/blinded_blocks/1?randao_reveal=0x213123", nil)
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusBadRequest, writer.Code)
+	})
+	t.Run("syncing", func(t *testing.T) {
+		chainService := &blockchainTesting.ChainService{}
+		server := &Server{
+			SyncChecker:           &mockSync.Sync{IsSyncing: true},
+			HeadFetcher:           chainService,
+			TimeFetcher:           chainService,
+			OptimisticModeFetcher: chainService,
+		}
+
+		request := httptest.NewRequest(http.MethodPost, "http://foo.example", bytes.NewReader([]byte("foo")))
+		writer := httptest.NewRecorder()
+		writer.Body = &bytes.Buffer{}
+		server.ProduceBlindedBlock(writer, request)
+		assert.Equal(t, http.StatusServiceUnavailable, writer.Code)
+		assert.Equal(t, true, strings.Contains(writer.Body.String(), "Beacon node is currently syncing and not serving request on that endpoint"))
 	})
 }
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -104,7 +104,7 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 	}
 	sBlk.SetProposerIndex(idx)
 
-	if err = vs.BuildBlockParallel(ctx, sBlk, head, false); err != nil {
+	if err = vs.BuildBlockParallel(ctx, sBlk, head, req.SkipMevBoost); err != nil {
 		return nil, errors.Wrap(err, "could not build block in parallel")
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Fixes two issues that cause the linked bug to happen:
- full block production in Beacon API should set `SkipMevBoost` to `true` because we don't want to receive blinded blocks from relays when producing full blocks
- `BuildBlockParallel` didn't use the `req.SkipMevBoost` field. I believe this is a local testing artifact from a previous PR.

I also updated Beacon API tests.

**Which issues(s) does this PR fix?**

Fixes #13259 
