### PR TITLE
Fix version string in automated docker images

### DIFF
--- a/hack/workspace_status_ci.sh
+++ b/hack/workspace_status_ci.sh
@@ -17,6 +17,7 @@ echo "GIT_TREE_STATUS $git_tree_status"
 latest_version_tag=$(./hack/latest_version_tag.sh)
 echo "STABLE_VERSION_TAG $latest_version_tag"
 echo "STABLE_COMMIT_SHA $commit_sha"
+echo "STABLE_GIT_COMMIT $commit_sha"
 echo "STABLE_GIT_TAG $latest_version_tag"
 
 echo DOCKER_TAG "$(git rev-parse --abbrev-ref HEAD)-$(git rev-parse --short=6 HEAD)"                                                                                                                         

--- a/tools/prysm_image.bzl
+++ b/tools/prysm_image.bzl
@@ -26,6 +26,9 @@ def prysm_image_upload(
             "//tools:bash_tar",
             ":binary_tar",
         ],
+        labels = {
+          "org.opencontainers.image.source": "https://github.com/prysmaticlabs/prysm",
+        },
         tags = tags,
     )
 


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Docker images uploaded by CI automatically were missing the git commit.

**Which issues(s) does this PR fix?**

**Other notes for review**

Also adds a oci label for the image source. I thought that was a fun addition so I added it.
