### PR TITLE
beacon-chain: Fixing typos

### DIFF
--- a/beacon-chain/execution/engine_client.go
+++ b/beacon-chain/execution/engine_client.go
@@ -773,11 +773,11 @@ func fullPayloadFromExecutionBlock(
 	case version.Deneb:
 		ebg, err := header.ExcessBlobGas()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to extract ExcessBlobGas attribute from excution payload header")
+			return nil, errors.Wrap(err, "unable to extract ExcessBlobGas attribute from execution payload header")
 		}
 		bgu, err := header.BlobGasUsed()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to extract BlobGasUsed attribute from excution payload header")
+			return nil, errors.Wrap(err, "unable to extract BlobGasUsed attribute from execution payload header")
 		}
 		return blocks.WrappedExecutionPayloadDeneb(
 			&pb.ExecutionPayloadDeneb{
@@ -850,11 +850,11 @@ func fullPayloadFromPayloadBody(
 	case version.Deneb:
 		ebg, err := header.ExcessBlobGas()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to extract ExcessBlobGas attribute from excution payload header")
+			return nil, errors.Wrap(err, "unable to extract ExcessBlobGas attribute from execution payload header")
 		}
 		bgu, err := header.BlobGasUsed()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to extract BlobGasUsed attribute from excution payload header")
+			return nil, errors.Wrap(err, "unable to extract BlobGasUsed attribute from execution payload header")
 		}
 		return blocks.WrappedExecutionPayloadDeneb(
 			&pb.ExecutionPayloadDeneb{

--- a/beacon-chain/execution/log_processing.go
+++ b/beacon-chain/execution/log_processing.go
@@ -243,7 +243,7 @@ func (s *Service) ProcessChainStart(genesisTime uint64, eth1BlockHash [32]byte, 
 	s.chainStartData.Chainstarted = true
 	s.chainStartData.GenesisBlock = blockNumber.Uint64()
 
-	chainStartTime := time.Unix(int64(genesisTime), 0) // lint:ignore uintcast -- Genesis time wont exceed int64 in your lifetime.
+	chainStartTime := time.Unix(int64(genesisTime), 0) // lint:ignore uintcast -- Genesis time won't exceed int64 in your lifetime.
 
 	for i := range s.chainStartData.ChainstartDeposits {
 		proof, err := s.depositTrie.MerkleProof(i)

--- a/beacon-chain/execution/service_test.go
+++ b/beacon-chain/execution/service_test.go
@@ -156,7 +156,7 @@ func TestStop_OK(t *testing.T) {
 	require.NoError(t, err, "Unable to stop web3 ETH1.0 chain service")
 
 	// The context should have been canceled.
-	assert.NotNil(t, web3Service.ctx.Err(), "Context wasnt canceled")
+	assert.NotNil(t, web3Service.ctx.Err(), "Context wasn't canceled")
 
 	hook.Reset()
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/beacon/attestations.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/beacon/attestations.go
@@ -312,7 +312,7 @@ func (bs *Server) StreamIndexedAttestations(
 			for _, att := range aggAtts {
 				// Out of range check, the attestation slot cannot be greater
 				// the last slot of the requested epoch or smaller than its start slot
-				// given committees are accessed as a map of slot -> commitees list, where there are
+				// given committees are accessed as a map of slot -> committees list, where there are
 				// SLOTS_PER_EPOCH keys in the map.
 				if att.Data.Slot < startSlot || att.Data.Slot > endSlot {
 					continue

--- a/beacon-chain/verification/cache_test.go
+++ b/beacon-chain/verification/cache_test.go
@@ -106,7 +106,7 @@ func TestProposerCache(t *testing.T) {
 	// should not be cached yet
 	require.Equal(t, false, cached)
 
-	// If this test breaks due to changes in the determinstic state gen, just replace '2' with whatever the right index is.
+	// If this test breaks due to changes in the deterministic state gen, just replace '2' with whatever the right index is.
 	expectedIdx := 2
 	idx, err := pc.ComputeProposer(ctx, [32]byte{}, 1, st)
 	require.NoError(t, err)


### PR DESCRIPTION
I found few typos, mostly in error messages printer to the user.
Doesn't require testing or changelog entry.