### PR TITLE
Use block value correctly when proposing a block

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
@@ -22,14 +22,15 @@ func (vs *Server) constructGenericBeaconBlock(sBlk interfaces.SignedBeaconBlock,
 	}
 
 	isBlinded := sBlk.IsBlinded()
+	payloadValue := sBlk.ValueInGwei()
 
 	switch sBlk.Version() {
 	case version.Deneb:
-		return vs.constructDenebBlock(blockProto, isBlinded, sBlk.ValueInGwei(), blobsBundle), nil
+		return vs.constructDenebBlock(blockProto, isBlinded, payloadValue, blobsBundle), nil
 	case version.Capella:
-		return vs.constructCapellaBlock(blockProto, isBlinded, sBlk.ValueInGwei()), nil
+		return vs.constructCapellaBlock(blockProto, isBlinded, payloadValue), nil
 	case version.Bellatrix:
-		return vs.constructBellatrixBlock(blockProto, isBlinded, sBlk.ValueInGwei()), nil
+		return vs.constructBellatrixBlock(blockProto, isBlinded, payloadValue), nil
 	case version.Altair:
 		return vs.constructAltairBlock(blockProto), nil
 	case version.Phase0:

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/construct_generic_block.go
@@ -22,15 +22,14 @@ func (vs *Server) constructGenericBeaconBlock(sBlk interfaces.SignedBeaconBlock,
 	}
 
 	isBlinded := sBlk.IsBlinded()
-	payloadValue := sBlk.ValueInGwei()
 
 	switch sBlk.Version() {
 	case version.Deneb:
-		return vs.constructDenebBlock(blockProto, isBlinded, payloadValue, blobsBundle), nil
+		return vs.constructDenebBlock(blockProto, isBlinded, sBlk.ValueInGwei(), blobsBundle), nil
 	case version.Capella:
-		return vs.constructCapellaBlock(blockProto, isBlinded, payloadValue), nil
+		return vs.constructCapellaBlock(blockProto, isBlinded, sBlk.ValueInGwei()), nil
 	case version.Bellatrix:
-		return vs.constructBellatrixBlock(blockProto, isBlinded, payloadValue), nil
+		return vs.constructBellatrixBlock(blockProto, isBlinded, sBlk.ValueInGwei()), nil
 	case version.Altair:
 		return vs.constructAltairBlock(blockProto), nil
 	case version.Phase0:

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -347,12 +347,16 @@ func (b *SignedBeaconBlock) IsBlinded() bool {
 func (b *SignedBeaconBlock) ValueInGwei() uint64 {
 	exec, err := b.block.body.Execution()
 	if err != nil {
-		log.WithError(err).Warn("failed to retrieve execution payload")
+		if !errors.Is(err, consensus_types.ErrUnsupportedField) {
+			log.WithError(err).Warn("failed to retrieve execution payload")
+		}
 		return 0
 	}
 	val, err := exec.ValueInGwei()
 	if err != nil {
-		log.WithError(err).Warn("failed to retrieve value in gwei")
+		if !errors.Is(err, consensus_types.ErrUnsupportedField) {
+			log.WithError(err).Warn("failed to retrieve execution payload")
+		}
 		return 0
 	}
 	return val


### PR DESCRIPTION
Retrieve block value correctly only under specific versions or else you will log warning messages like `failed to retrieve execution payload` or `failed to retrieve value in gwei` when proposing a block for phase0 or altair or bellatrix