### PR TITLE
Initialize Inactivity Scores Correctly

### DIFF
--- a/beacon-chain/state/state-native/getters_state.go
+++ b/beacon-chain/state/state-native/getters_state.go
@@ -164,7 +164,7 @@ func (b *BeaconState) ToProtoUnsafe() interface{} {
 			PreviousJustifiedCheckpoint:  b.previousJustifiedCheckpoint,
 			CurrentJustifiedCheckpoint:   b.currentJustifiedCheckpoint,
 			FinalizedCheckpoint:          b.finalizedCheckpoint,
-			InactivityScores:             b.inactivityScores,
+			InactivityScores:             b.inactivityScoresVal(),
 			CurrentSyncCommittee:         b.currentSyncCommittee,
 			NextSyncCommittee:            b.nextSyncCommittee,
 			LatestExecutionPayloadHeader: b.latestExecutionPayloadHeaderDeneb,


### PR DESCRIPTION
**What type of PR is this?**

Bug Fix

**What does this PR do? Why is it needed?**

For deneb states we do not initialize the inactivity scores field correctly when initializing the state object from the proto object. This breaks for any node running with the experimental state feature and will lead to nodes not being able to start up from deneb onwards.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
