### PR TITLE
Return activity penalty from attestation rewards

### DIFF
--- a/beacon-chain/core/altair/epoch_precompute.go
+++ b/beacon-chain/core/altair/epoch_precompute.go
@@ -15,11 +15,12 @@ import (
 
 // AttDelta contains rewards and penalties for a single attestation.
 type AttDelta struct {
-	HeadReward    uint64
-	SourceReward  uint64
-	SourcePenalty uint64
-	TargetReward  uint64
-	TargetPenalty uint64
+	HeadReward        uint64
+	SourceReward      uint64
+	SourcePenalty     uint64
+	TargetReward      uint64
+	TargetPenalty     uint64
+	InactivityPenalty uint64
 }
 
 // InitializePrecomputeValidators precomputes individual validator for its attested balances and the total sum of validators attested balances of the epoch.
@@ -251,7 +252,7 @@ func ProcessRewardsAndPenaltiesPrecompute(
 		if err != nil {
 			return nil, err
 		}
-		balances[i] = helpers.DecreaseBalanceWithVal(balances[i], delta.SourcePenalty+delta.TargetPenalty)
+		balances[i] = helpers.DecreaseBalanceWithVal(balances[i], delta.SourcePenalty+delta.TargetPenalty+delta.InactivityPenalty)
 
 		vals[i].AfterEpochTransitionBalance = balances[i]
 	}
@@ -351,7 +352,7 @@ func attestationDelta(
 		if err != nil {
 			return &AttDelta{}, err
 		}
-		attDelta.TargetPenalty += n / inactivityDenominator
+		attDelta.InactivityPenalty = n / inactivityDenominator
 	}
 
 	return attDelta, nil

--- a/beacon-chain/core/altair/epoch_precompute_test.go
+++ b/beacon-chain/core/altair/epoch_precompute_test.go
@@ -220,7 +220,7 @@ func TestAttestationsDelta(t *testing.T) {
 	penalties := make([]uint64, len(deltas))
 	for i, d := range deltas {
 		rewards[i] = d.HeadReward + d.SourceReward + d.TargetReward
-		penalties[i] = d.SourcePenalty + d.TargetPenalty
+		penalties[i] = d.SourcePenalty + d.TargetPenalty + d.InactivityPenalty
 	}
 
 	// Reward amount should increase as validator index increases due to setup.
@@ -258,7 +258,7 @@ func TestAttestationsDeltaBellatrix(t *testing.T) {
 	penalties := make([]uint64, len(deltas))
 	for i, d := range deltas {
 		rewards[i] = d.HeadReward + d.SourceReward + d.TargetReward
-		penalties[i] = d.SourcePenalty + d.TargetPenalty
+		penalties[i] = d.SourcePenalty + d.TargetPenalty + d.InactivityPenalty
 	}
 
 	// Reward amount should increase as validator index increases due to setup.
@@ -306,7 +306,7 @@ func TestProcessRewardsAndPenaltiesPrecompute_Ok(t *testing.T) {
 	penalties := make([]uint64, len(deltas))
 	for i, d := range deltas {
 		rewards[i] = d.HeadReward + d.SourceReward + d.TargetReward
-		penalties[i] = d.SourcePenalty + d.TargetPenalty
+		penalties[i] = d.SourcePenalty + d.TargetPenalty + d.InactivityPenalty
 	}
 	for i := range rewards {
 		wanted[i] += rewards[i]

--- a/beacon-chain/rpc/eth/rewards/handlers.go
+++ b/beacon-chain/rpc/eth/rewards/handlers.go
@@ -62,7 +62,6 @@ func (s *Server) BlockRewards(w http.ResponseWriter, r *http.Request) {
 
 // AttestationRewards retrieves attestation reward info for validators specified by array of public keys or validator index.
 // If no array is provided, return reward info for every validator.
-// TODO: Inclusion delay
 func (s *Server) AttestationRewards(w http.ResponseWriter, r *http.Request) {
 	st, ok := s.attRewardsState(w, r)
 	if !ok {
@@ -277,7 +276,10 @@ func idealAttRewards(
 					IsPrevEpochTargetAttester:    true,
 					IsPrevEpochHeadAttester:      true,
 				})
-				idealRewards = append(idealRewards, IdealAttestationReward{EffectiveBalance: strconv.FormatUint(effectiveBalance, 10)})
+				idealRewards = append(idealRewards, IdealAttestationReward{
+					EffectiveBalance: strconv.FormatUint(effectiveBalance, 10),
+					Inactivity:       strconv.FormatUint(0, 10),
+				})
 				break
 			}
 		}
@@ -298,6 +300,11 @@ func idealAttRewards(
 			idealRewards[i].Target = fmt.Sprintf("-%s", strconv.FormatUint(d.TargetPenalty, 10))
 		} else {
 			idealRewards[i].Target = strconv.FormatUint(d.TargetReward, 10)
+		}
+		if d.InactivityPenalty > 0 {
+			idealRewards[i].Inactivity = fmt.Sprintf("-%s", strconv.FormatUint(d.InactivityPenalty, 10))
+		} else {
+			idealRewards[i].Inactivity = strconv.FormatUint(d.InactivityPenalty, 10)
 		}
 	}
 	return idealRewards, true
@@ -330,6 +337,11 @@ func totalAttRewards(
 			totalRewards[i].Target = fmt.Sprintf("-%s", strconv.FormatUint(d.TargetPenalty, 10))
 		} else {
 			totalRewards[i].Target = strconv.FormatUint(d.TargetReward, 10)
+		}
+		if d.InactivityPenalty > 0 {
+			totalRewards[i].Inactivity = fmt.Sprintf("-%s", strconv.FormatUint(d.InactivityPenalty, 10))
+		} else {
+			totalRewards[i].Inactivity = strconv.FormatUint(d.InactivityPenalty, 10)
 		}
 	}
 	return totalRewards, true

--- a/beacon-chain/rpc/eth/rewards/structs.go
+++ b/beacon-chain/rpc/eth/rewards/structs.go
@@ -31,6 +31,7 @@ type IdealAttestationReward struct {
 	Head             string `json:"head"`
 	Target           string `json:"target"`
 	Source           string `json:"source"`
+	Inactivity       string `json:"inactivity"`
 }
 
 type TotalAttestationReward struct {
@@ -38,7 +39,7 @@ type TotalAttestationReward struct {
 	Head           string `json:"head"`
 	Target         string `json:"target"`
 	Source         string `json:"source"`
-	InclusionDelay string `json:"inclusion_delay"`
+	Inactivity     string `json:"inactivity"`
 }
 
 type SyncCommitteeRewardsResponse struct {

--- a/testing/spectest/shared/altair/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/altair/rewards/rewards_penalties.go
@@ -83,7 +83,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	penalties := make([]uint64, len(deltas))
 	for i, d := range deltas {
 		rewards[i] = d.HeadReward + d.SourceReward + d.TargetReward
-		penalties[i] = d.SourcePenalty + d.TargetPenalty
+		penalties[i] = d.SourcePenalty + d.TargetPenalty + d.InactivityPenalty
 	}
 
 	totalSpecTestRewards := make([]uint64, len(rewards))

--- a/testing/spectest/shared/bellatrix/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/bellatrix/rewards/rewards_penalties.go
@@ -87,7 +87,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	penalties := make([]uint64, len(deltas))
 	for i, d := range deltas {
 		rewards[i] = d.HeadReward + d.SourceReward + d.TargetReward
-		penalties[i] = d.SourcePenalty + d.TargetPenalty
+		penalties[i] = d.SourcePenalty + d.TargetPenalty + d.InactivityPenalty
 	}
 
 	totalSpecTestRewards := make([]uint64, len(rewards))

--- a/testing/spectest/shared/capella/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/capella/rewards/rewards_penalties.go
@@ -87,7 +87,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	penalties := make([]uint64, len(deltas))
 	for i, d := range deltas {
 		rewards[i] = d.HeadReward + d.SourceReward + d.TargetReward
-		penalties[i] = d.SourcePenalty + d.TargetPenalty
+		penalties[i] = d.SourcePenalty + d.TargetPenalty + d.InactivityPenalty
 	}
 
 	totalSpecTestRewards := make([]uint64, len(rewards))

--- a/testing/spectest/shared/deneb/rewards/rewards_penalties.go
+++ b/testing/spectest/shared/deneb/rewards/rewards_penalties.go
@@ -79,7 +79,7 @@ func runPrecomputeRewardsAndPenaltiesTest(t *testing.T, testFolderPath string) {
 	penalties := make([]uint64, len(deltas))
 	for i, d := range deltas {
 		rewards[i] = d.HeadReward + d.SourceReward + d.TargetReward
-		penalties[i] = d.SourcePenalty + d.TargetPenalty
+		penalties[i] = d.SourcePenalty + d.TargetPenalty + d.InactivityPenalty
 	}
 
 	totalSpecTestRewards := make([]uint64, len(rewards))


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Implements https://github.com/ethereum/beacon-APIs/pull/340. 

In order to return the inactivity penalty, I added an `InactivityPenalty` field to the `AttData` struct and split out its value from `TargetPenalty`.

On the API side, apart from adding the `Inactivity` field I removed the `InclusionDelay` field. This is because we currently don't support it and it might be confusing to the caller to see a `"0"` value instead of what they are expecting. Not returning this field makes it clear that it's not supported.
