### PR TITLE
update shuffling caches before calling FCU on epoch boundaries

### DIFF
--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -289,8 +289,7 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 	stateEpoch := slots.ToEpoch(st.Slot())
 	if e == stateEpoch {
 		val, ok = s.trackedProposer(st, slot)
-		if !ok && !features.Get().PrepareAllPayloads {
-			log.Debug("returning from getPayloadAttribute because validator is not tracked")
+		if !ok {
 			return false, emptyAttri
 		}
 	}
@@ -305,8 +304,7 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 	}
 	if e > stateEpoch {
 		val, ok = s.trackedProposer(st, slot)
-		if !ok && !features.Get().PrepareAllPayloads {
-			log.Debug("returning from getPayloadAttribute because validator is not tracked")
+		if !ok {
 			return false, emptyAttri
 		}
 	}

--- a/beacon-chain/blockchain/execution_engine.go
+++ b/beacon-chain/blockchain/execution_engine.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/blocks"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/time"
@@ -279,12 +280,20 @@ func (s *Service) pruneInvalidBlock(ctx context.Context, root, parentRoot, lvh [
 func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState, slot primitives.Slot, headRoot []byte) (bool, payloadattribute.Attributer) {
 	emptyAttri := payloadattribute.EmptyWithVersion(st.Version())
 
-	val, ok := s.trackedProposer(st, slot)
-	if !ok && !features.Get().PrepareAllPayloads {
-		return false, emptyAttri
+	// If it is an epoch boundary then process slots to get the right
+	// shuffling before checking if the proposer is tracked. Otherwise
+	// perform this check before. This is cheap as the NSC has already been updated.
+	var val cache.TrackedValidator
+	var ok bool
+	e := slots.ToEpoch(slot)
+	stateEpoch := slots.ToEpoch(st.Slot())
+	if e == stateEpoch {
+		val, ok = s.trackedProposer(st, slot)
+		if !ok && !features.Get().PrepareAllPayloads {
+			log.Debug("returning from getPayloadAttribute because validator is not tracked")
+			return false, emptyAttri
+		}
 	}
-
-	// Get previous randao.
 	st = st.Copy()
 	if slot > st.Slot() {
 		var err error
@@ -294,6 +303,14 @@ func (s *Service) getPayloadAttribute(ctx context.Context, st state.BeaconState,
 			return false, emptyAttri
 		}
 	}
+	if e > stateEpoch {
+		val, ok = s.trackedProposer(st, slot)
+		if !ok && !features.Get().PrepareAllPayloads {
+			log.Debug("returning from getPayloadAttribute because validator is not tracked")
+			return false, emptyAttri
+		}
+	}
+	// Get previous randao.
 	prevRando, err := helpers.RandaoMix(st, time.CurrentEpoch(st))
 	if err != nil {
 		log.WithError(err).Error("Could not get randao mix to get payload attribute")

--- a/beacon-chain/blockchain/tracked_proposer.go
+++ b/beacon-chain/blockchain/tracked_proposer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
+	"github.com/prysmaticlabs/prysm/v4/config/features"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 )
 
@@ -11,6 +12,9 @@ import (
 // validators/prepare_proposer endpoint, of the proposer at the given slot.
 // It only returns true if the tracked proposer is present and active.
 func (s *Service) trackedProposer(st state.ReadOnlyBeaconState, slot primitives.Slot) (cache.TrackedValidator, bool) {
+	if features.Get().PrepareAllPayloads {
+		return cache.TrackedValidator{Active: true}, true
+	}
 	id, err := helpers.BeaconProposerIndexAtSlot(s.ctx, st, slot)
 	if err != nil {
 		return cache.TrackedValidator{}, false

--- a/beacon-chain/blockchain/tracked_proposer.go
+++ b/beacon-chain/blockchain/tracked_proposer.go
@@ -5,27 +5,15 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
-	"github.com/prysmaticlabs/prysm/v4/time/slots"
 )
 
 // trackedProposer returns whether the beacon node was informed, via the
 // validators/prepare_proposer endpoint, of the proposer at the given slot.
 // It only returns true if the tracked proposer is present and active.
 func (s *Service) trackedProposer(st state.ReadOnlyBeaconState, slot primitives.Slot) (cache.TrackedValidator, bool) {
-	// if the head state and slot are in different epochs, try first the
-	// precomputed cache one epoch in advance
-	var id primitives.ValidatorIndex
-	var err error
-	stateEpoch := slots.ToEpoch(st.Slot())
-	e := slots.ToEpoch(slot)
-	if stateEpoch != e {
-		id, err = helpers.UnsafeBeaconProposerIndexAtSlot(st, slot)
-	}
-	if err != nil || stateEpoch == e {
-		id, err = helpers.BeaconProposerIndexAtSlot(s.ctx, st, slot)
-		if err != nil {
-			return cache.TrackedValidator{}, false
-		}
+	id, err := helpers.BeaconProposerIndexAtSlot(s.ctx, st, slot)
+	if err != nil {
+		return cache.TrackedValidator{}, false
 	}
 	val, ok := s.cfg.TrackedValidatorsCache.Validator(id)
 	if !ok {


### PR DESCRIPTION
This PR is the first of a series modifying the interaction with the engine. In this PR we fix the underlying problem with Payload ID cache misses and shuffling cache misses at the epoch boundary. 

The main issue is that the following events happen currently when importing block 63 and we are proposing at slot 64:
- We validate the block and insert it in forkchoice
- We call FCU, this call eventually calls to get the payload attribute for the next block proposal. This itself performs an epoch transition and processes the slot for the current state. 
- We then call to update the shufflings, this again performs an epoch transition and recomputes the shufflings!

In addition to this, during the call to get the payload attributes, in order to find out if the next proposer is being tracked by the beacon, we use a precached computation made an epoch in advance. This is both in current develop and in the stable released version of Prysm. The reason for this is precisely that we were deferring the computation of the new shufflings until the end of block processing. However, since anyway the epoch transition is computed during the call to `getPayloadAttributes` then we may as well use the current accurate shufflings. 

This PR is the minimal change to fix the above behavior:

- It moves the call to update the shufflings before the call to FCU
- It uses the current epoch shufflings when checking for tracked validators. 

In follow up cleanup PRs we can entirely remove the precomputed shufflings for an epoch in advance (that will become not used) and further cleanup `postBlockProcess` and its interaction with the engine in FCU