### PR TITLE
Simplify fcu 1

### DIFF
--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -44,50 +44,44 @@ func (s *Service) getStateAndBlock(ctx context.Context, r [32]byte) (state.Beaco
 	return headState, newHeadBlock, nil
 }
 
+type fcuConfig struct {
+	headState     state.BeaconState
+	headBlock     interfaces.ReadOnlySignedBeaconBlock
+	headRoot      [32]byte
+	proposingSlot primitives.Slot
+}
+
 // fockchoiceUpdateWithExecution is a wrapper around notifyForkchoiceUpdate. It decides whether a new call to FCU should be made.
-// it returns true if the new head is updated
-func (s *Service) forkchoiceUpdateWithExecution(ctx context.Context, newHeadRoot [32]byte, proposingSlot primitives.Slot) (bool, error) {
+func (s *Service) forkchoiceUpdateWithExecution(ctx context.Context, args *fcuConfig) error {
 	_, span := trace.StartSpan(ctx, "beacon-chain.blockchain.forkchoiceUpdateWithExecution")
 	defer span.End()
 	// Note: Use the service context here to avoid the parent context being ended during a forkchoice update.
 	ctx = trace.NewContext(s.ctx, span)
-
-	isNewHead := s.isNewHead(newHeadRoot)
-	if !isNewHead {
-		return false, nil
-	}
-
-	headState, headBlock, err := s.getStateAndBlock(ctx, newHeadRoot)
-	if err != nil {
-		log.WithError(err).Error("Could not get forkchoice update argument")
-		return false, nil
-	}
-
-	_, tracked := s.trackedProposer(headState, proposingSlot)
+	_, tracked := s.trackedProposer(args.headState, args.proposingSlot)
 	if (tracked || features.Get().PrepareAllPayloads) && !features.Get().DisableReorgLateBlocks {
-		if s.shouldOverrideFCU(newHeadRoot, proposingSlot) {
-			return false, nil
+		if s.shouldOverrideFCU(args.headRoot, args.proposingSlot) {
+			return nil
 		}
 	}
 
-	_, err = s.notifyForkchoiceUpdate(ctx, &notifyForkchoiceUpdateArg{
-		headState: headState,
-		headRoot:  newHeadRoot,
-		headBlock: headBlock.Block(),
+	_, err := s.notifyForkchoiceUpdate(ctx, &notifyForkchoiceUpdateArg{
+		headState: args.headState,
+		headRoot:  args.headRoot,
+		headBlock: args.headBlock.Block(),
 	})
 	if err != nil {
-		return false, errors.Wrap(err, "could not notify forkchoice update")
+		return errors.Wrap(err, "could not notify forkchoice update")
 	}
 
-	if err := s.saveHead(ctx, newHeadRoot, headBlock, headState); err != nil {
+	if err := s.saveHead(ctx, args.headRoot, args.headBlock, args.headState); err != nil {
 		log.WithError(err).Error("could not save head")
 	}
 
 	// Only need to prune attestations from pool if the head has changed.
-	if err := s.pruneAttsFromPool(headBlock); err != nil {
+	if err := s.pruneAttsFromPool(args.headBlock); err != nil {
 		log.WithError(err).Error("could not prune attestations from pool")
 	}
-	return true, nil
+	return nil
 }
 
 // shouldOverrideFCU checks whether the incoming block is still subject to being

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -381,9 +381,6 @@ func (s *Service) updateEpochBoundaryCaches(ctx context.Context, st state.Beacon
 		if err := helpers.UpdateCommitteeCache(slotCtx, st, e+1); err != nil {
 			log.WithError(err).Warn("Could not update committee cache")
 		}
-		if err := helpers.UpdateUnsafeProposerIndicesInCache(slotCtx, st, e+1); err != nil {
-			log.WithError(err).Warn("Failed to cache next epoch proposers")
-		}
 	}()
 	// The latest block header is from the previous epoch
 	r, err := st.LatestBlockHeader().HashTreeRoot()

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -73,6 +73,7 @@ func (s *Service) postBlockProcess(ctx context.Context, signed interfaces.ReadOn
 	if err != nil {
 		log.WithError(err).Warn("Could not update head")
 	}
+	newBlockHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
 	if blockRoot != headRoot {
 		receivedWeight, err := s.cfg.ForkChoiceStore.Weight(blockRoot)
 		if err != nil {
@@ -88,10 +89,7 @@ func (s *Service) postBlockProcess(ctx context.Context, signed interfaces.ReadOn
 			"headRoot":       fmt.Sprintf("%#x", headRoot),
 			"headWeight":     headWeight,
 		}).Debug("Head block is not the received block")
-	}
-	newBlockHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
-
-	if headRoot == blockRoot {
+	} else {
 		// Updating next slot state cache can happen in the background
 		// except in the epoch boundary in which case we lock to handle
 		// the shuffling and proposer caches updates.
@@ -114,19 +112,23 @@ func (s *Service) postBlockProcess(ctx context.Context, signed interfaces.ReadOn
 				}
 			}()
 		}
+		// verify conditions for FCU, notifies FCU, and saves the new head.
+		// This function also prunes attestations, other similar operations happen in prunePostBlockOperationPools.
+		args := &fcuConfig{
+			headState:     postState,
+			headBlock:     signed,
+			headRoot:      headRoot,
+			proposingSlot: s.CurrentSlot() + 1,
+		}
+		if err := s.forkchoiceUpdateWithExecution(ctx, args); err != nil {
+			return err
+		}
 	}
-	// verify conditions for FCU, notifies FCU, and saves the new head.
-	// This function also prunes attestations, other similar operations happen in prunePostBlockOperationPools.
-	if _, err := s.forkchoiceUpdateWithExecution(ctx, headRoot, s.CurrentSlot()+1); err != nil {
-		return err
-	}
-
 	optimistic, err := s.cfg.ForkChoiceStore.IsOptimistic(blockRoot)
 	if err != nil {
 		log.WithError(err).Debug("Could not check if block is optimistic")
 		optimistic = true
 	}
-
 	// Send notification of the processed block to the state feed.
 	s.cfg.StateNotifier.StateFeed().Send(&feed.Event{
 		Type: statefeed.BlockProcessed,

--- a/beacon-chain/cache/proposer_indices_test.go
+++ b/beacon-chain/cache/proposer_indices_test.go
@@ -34,29 +34,6 @@ func TestProposerCache_Set(t *testing.T) {
 	require.Equal(t, emptyIndices, received)
 }
 
-func TestProposerCache_SetUnsafe(t *testing.T) {
-	cache := NewProposerIndicesCache()
-	bRoot := [32]byte{'A'}
-	indices, ok := cache.UnsafeProposerIndices(0, bRoot)
-	require.Equal(t, false, ok)
-	emptyIndices := [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex{}
-	require.Equal(t, indices, emptyIndices, "Expected committee count not to exist in empty cache")
-	emptyIndices[0] = 1
-	cache.SetUnsafe(0, bRoot, emptyIndices)
-
-	received, ok := cache.UnsafeProposerIndices(0, bRoot)
-	require.Equal(t, true, ok)
-	require.Equal(t, received, emptyIndices)
-
-	newRoot := [32]byte{'B'}
-	copy(emptyIndices[3:], []primitives.ValidatorIndex{1, 2, 3, 4, 5, 6})
-	cache.SetUnsafe(0, newRoot, emptyIndices)
-
-	received, ok = cache.UnsafeProposerIndices(0, newRoot)
-	require.Equal(t, true, ok)
-	require.Equal(t, emptyIndices, received)
-}
-
 func TestProposerCache_CheckpointAndPrune(t *testing.T) {
 	cache := NewProposerIndicesCache()
 	indices := [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex{}
@@ -65,7 +42,6 @@ func TestProposerCache_CheckpointAndPrune(t *testing.T) {
 	copy(indices[3:], []primitives.ValidatorIndex{1, 2, 3, 4, 5, 6})
 	for i := 1; i < 10; i++ {
 		cache.Set(primitives.Epoch(i), root, indices)
-		cache.SetUnsafe(primitives.Epoch(i), root, indices)
 		cache.SetCheckpoint(forkchoicetypes.Checkpoint{Epoch: primitives.Epoch(i - 1), Root: cpRoot}, root)
 	}
 	received, ok := cache.ProposerIndices(1, root)
@@ -77,18 +53,6 @@ func TestProposerCache_CheckpointAndPrune(t *testing.T) {
 	require.Equal(t, indices, received)
 
 	received, ok = cache.ProposerIndices(9, root)
-	require.Equal(t, true, ok)
-	require.Equal(t, indices, received)
-
-	received, ok = cache.UnsafeProposerIndices(1, root)
-	require.Equal(t, true, ok)
-	require.Equal(t, indices, received)
-
-	received, ok = cache.UnsafeProposerIndices(4, root)
-	require.Equal(t, true, ok)
-	require.Equal(t, indices, received)
-
-	received, ok = cache.UnsafeProposerIndices(9, root)
 	require.Equal(t, true, ok)
 	require.Equal(t, indices, received)
 
@@ -120,18 +84,6 @@ func TestProposerCache_CheckpointAndPrune(t *testing.T) {
 	require.Equal(t, emptyIndices, received)
 
 	received, ok = cache.ProposerIndices(9, root)
-	require.Equal(t, true, ok)
-	require.Equal(t, indices, received)
-
-	received, ok = cache.UnsafeProposerIndices(1, root)
-	require.Equal(t, false, ok)
-	require.Equal(t, emptyIndices, received)
-
-	received, ok = cache.UnsafeProposerIndices(4, root)
-	require.Equal(t, false, ok)
-	require.Equal(t, emptyIndices, received)
-
-	received, ok = cache.UnsafeProposerIndices(9, root)
 	require.Equal(t, true, ok)
 	require.Equal(t, indices, received)
 

--- a/beacon-chain/core/helpers/beacon_committee.go
+++ b/beacon-chain/core/helpers/beacon_committee.go
@@ -391,49 +391,6 @@ func UpdateCachedCheckpointToStateRoot(state state.ReadOnlyBeaconState, cp *fork
 	return nil
 }
 
-// UpdateUnsafeProposerIndicesInCache updates proposer indices entry of the
-// cache one epoch in advance.
-// Input state is used to retrieve active validator indices.
-// Input root is to use as key in the cache.
-// Input epoch is the epoch to retrieve proposer indices for.
-func UpdateUnsafeProposerIndicesInCache(ctx context.Context, state state.ReadOnlyBeaconState, epoch primitives.Epoch) error {
-	// The cache uses the state root at the end of (current epoch - 2) as key.
-	// (e.g. for epoch 2, the key is root at slot 31)
-	if epoch <= params.BeaconConfig().GenesisEpoch+2*params.BeaconConfig().MinSeedLookahead {
-		return nil
-	}
-	slot, err := slots.EpochEnd(epoch - 2)
-	if err != nil {
-		return err
-	}
-	root, err := state.StateRootAtIndex(uint64(slot % params.BeaconConfig().SlotsPerHistoricalRoot))
-	if err != nil {
-		return err
-	}
-	// Skip cache update if the key already exists
-	_, ok := proposerIndicesCache.UnsafeProposerIndices(epoch, [32]byte(root))
-	if ok {
-		return nil
-	}
-	indices, err := ActiveValidatorIndices(ctx, state, epoch)
-	if err != nil {
-		return err
-	}
-	proposerIndices, err := precomputeProposerIndices(state, indices, epoch)
-	if err != nil {
-		return err
-	}
-	if len(proposerIndices) != int(params.BeaconConfig().SlotsPerEpoch) {
-		return errors.New("invalid proposer length returned from state")
-	}
-	// This is here to deal with tests only
-	var indicesArray [fieldparams.SlotsPerEpoch]primitives.ValidatorIndex
-	copy(indicesArray[:], proposerIndices)
-	proposerIndicesCache.Prune(epoch - 2)
-	proposerIndicesCache.SetUnsafe(epoch, [32]byte(root), indicesArray)
-	return nil
-}
-
 // ClearCache clears the beacon committee cache and sync committee cache.
 func ClearCache() {
 	committeeCache.Clear()

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -281,39 +281,6 @@ func cachedProposerIndexAtSlot(slot primitives.Slot, root [32]byte) (primitives.
 	return proposerIndices[slot%params.BeaconConfig().SlotsPerEpoch], nil
 }
 
-// cachedUnsafeProposerIndexAtSlot returns the proposer index at the given slot
-// from the unsafe cache computed in the previous epoch
-func cachedUnsafeProposerIndexAtSlot(slot primitives.Slot, root [32]byte) (primitives.ValidatorIndex, error) {
-	proposerIndices, has := proposerIndicesCache.UnsafeProposerIndices(slots.ToEpoch(slot), root)
-	if !has {
-		cache.ProposerIndicesCacheMiss.Inc()
-		return 0, errProposerIndexMiss
-	}
-	if len(proposerIndices) != int(params.BeaconConfig().SlotsPerEpoch) {
-		cache.ProposerIndicesCacheMiss.Inc()
-		return 0, errProposerIndexMiss
-	}
-	return proposerIndices[slot%params.BeaconConfig().SlotsPerEpoch], nil
-}
-
-// UnsafeBeaconProposerIndexAtSlot returns the proposer index at the given slot
-// if it has been cached one epoch in advance
-func UnsafeBeaconProposerIndexAtSlot(state state.ReadOnlyBeaconState, slot primitives.Slot) (primitives.ValidatorIndex, error) {
-	e := slots.ToEpoch(slot)
-	if e < 2 {
-		return 0, errProposerIndexMiss
-	}
-	s, err := slots.EpochEnd(e - 2)
-	if err != nil {
-		return 0, err
-	}
-	r, err := StateRootAtSlot(state, s)
-	if err != nil {
-		return 0, err
-	}
-	return cachedUnsafeProposerIndexAtSlot(slot, [32]byte(r))
-}
-
 // BeaconProposerIndexAtSlot returns proposer index at the given slot from the
 // point of view of the given state as head state
 func BeaconProposerIndexAtSlot(ctx context.Context, state state.ReadOnlyBeaconState, slot primitives.Slot) (primitives.ValidatorIndex, error) {

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -16,7 +16,6 @@ import (
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/testing/assert"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
-	"github.com/prysmaticlabs/prysm/v4/time/slots"
 )
 
 func TestIsActiveValidator_OK(t *testing.T) {
@@ -802,27 +801,4 @@ func TestLastActivatedValidatorIndex_OK(t *testing.T) {
 	index, err := LastActivatedValidatorIndex(context.Background(), beaconState)
 	require.NoError(t, err)
 	require.Equal(t, index, primitives.ValidatorIndex(3))
-}
-
-func TestUnsafeProposerIndexAtSlot(t *testing.T) {
-	bRoot := [32]byte{'A'}
-	e := 4
-	slot := primitives.Slot(e) * params.BeaconConfig().SlotsPerEpoch
-	indices, ok := proposerIndicesCache.UnsafeProposerIndices(primitives.Epoch(e), bRoot)
-	require.Equal(t, false, ok)
-
-	beaconState, err := state_native.InitializeFromProtoPhase0(&ethpb.BeaconState{})
-	require.NoError(t, err)
-	roots := make([][]byte, fieldparams.StateRootsLength)
-	roots[(e-1)*int(params.BeaconConfig().SlotsPerEpoch)-1] = bRoot[:]
-	id := primitives.ValidatorIndex(17)
-	indices[0] = id
-	require.NoError(t, beaconState.SetStateRoots(roots))
-	require.NoError(t, beaconState.SetSlot(slot))
-	epoch := slots.ToEpoch(slot)
-	require.Equal(t, primitives.Epoch(e), epoch)
-	proposerIndicesCache.SetUnsafe(epoch, bRoot, indices)
-	pid, err := UnsafeBeaconProposerIndexAtSlot(beaconState, slot)
-	require.NoError(t, err)
-	require.Equal(t, id, pid)
 }


### PR DESCRIPTION
   This PR starts the process of gradually simplifying FCU
    It removes the responsibility of getting the state and block from this
    function and informing if head has changed. It is only called when the
    imported block has actually become head.

Please review incrementally after #13383 