### PR TITLE
Remove blind field from block type

### DIFF
--- a/api/client/builder/client_test.go
+++ b/api/client/builder/client_test.go
@@ -412,7 +412,7 @@ func TestSubmitBlindedBlock(t *testing.T) {
 		require.ErrorContains(t, "not a bellatrix payload", err)
 	})
 	t.Run("not blinded", func(t *testing.T) {
-		sbb, err := blocks.NewSignedBeaconBlock(&eth.SignedBeaconBlockBellatrix{Block: &eth.BeaconBlockBellatrix{Body: &eth.BeaconBlockBodyBellatrix{}}})
+		sbb, err := blocks.NewSignedBeaconBlock(&eth.SignedBeaconBlockBellatrix{Block: &eth.BeaconBlockBellatrix{Body: &eth.BeaconBlockBodyBellatrix{ExecutionPayload: &v1.ExecutionPayload{}}}})
 		require.NoError(t, err)
 		_, _, err = (&Client{}).SubmitBlindedBlock(ctx, sbb)
 		require.ErrorIs(t, err, errNotBlinded)

--- a/beacon-chain/p2p/types/BUILD.bazel
+++ b/beacon-chain/p2p/types/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//consensus-types/primitives:go_default_library",
         "//consensus-types/wrapper:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//proto/engine/v1:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
         "//proto/prysm/v1alpha1/metadata:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/beacon-chain/p2p/types/object_mapping.go
+++ b/beacon-chain/p2p/types/object_mapping.go
@@ -6,6 +6,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/wrapper"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
+	enginev1 "github.com/prysmaticlabs/prysm/v4/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1/metadata"
 )
@@ -45,17 +46,17 @@ func InitializeDataMaps() {
 		},
 		bytesutil.ToBytes4(params.BeaconConfig().BellatrixForkVersion): func() (interfaces.ReadOnlySignedBeaconBlock, error) {
 			return blocks.NewSignedBeaconBlock(
-				&ethpb.SignedBeaconBlockBellatrix{Block: &ethpb.BeaconBlockBellatrix{Body: &ethpb.BeaconBlockBodyBellatrix{}}},
+				&ethpb.SignedBeaconBlockBellatrix{Block: &ethpb.BeaconBlockBellatrix{Body: &ethpb.BeaconBlockBodyBellatrix{ExecutionPayload: &enginev1.ExecutionPayload{}}}},
 			)
 		},
 		bytesutil.ToBytes4(params.BeaconConfig().CapellaForkVersion): func() (interfaces.ReadOnlySignedBeaconBlock, error) {
 			return blocks.NewSignedBeaconBlock(
-				&ethpb.SignedBeaconBlockCapella{Block: &ethpb.BeaconBlockCapella{Body: &ethpb.BeaconBlockBodyCapella{}}},
+				&ethpb.SignedBeaconBlockCapella{Block: &ethpb.BeaconBlockCapella{Body: &ethpb.BeaconBlockBodyCapella{ExecutionPayload: &enginev1.ExecutionPayloadCapella{}}}},
 			)
 		},
 		bytesutil.ToBytes4(params.BeaconConfig().DenebForkVersion): func() (interfaces.ReadOnlySignedBeaconBlock, error) {
 			return blocks.NewSignedBeaconBlock(
-				&ethpb.SignedBeaconBlockDeneb{Block: &ethpb.BeaconBlockDeneb{Body: &ethpb.BeaconBlockBodyDeneb{}}},
+				&ethpb.SignedBeaconBlockDeneb{Block: &ethpb.BeaconBlockDeneb{Body: &ethpb.BeaconBlockBodyDeneb{ExecutionPayload: &enginev1.ExecutionPayloadDeneb{}}}},
 			)
 		},
 	}

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -86,10 +86,8 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 
 		// If we can't get the builder value, just use local block.
 		if higherValueBuilder && withdrawalsMatched { // Builder value is higher and withdrawals match.
-			blk.SetBlinded(true)
 			if err := setBuilderExecution(blk, builderPayload, builderKzgCommitments); err != nil {
 				log.WithError(err).Warn("Proposer: failed to set builder payload")
-				blk.SetBlinded(false)
 				return setLocalExecution(blk, localPayload)
 			} else {
 				return nil
@@ -110,10 +108,8 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 		)
 		return setLocalExecution(blk, localPayload)
 	default: // Bellatrix case.
-		blk.SetBlinded(true)
 		if err := setBuilderExecution(blk, builderPayload, builderKzgCommitments); err != nil {
 			log.WithError(err).Warn("Proposer: failed to set builder payload")
-			blk.SetBlinded(false)
 			return setLocalExecution(blk, localPayload)
 		} else {
 			return nil
@@ -314,9 +310,6 @@ func setExecution(blk interfaces.SignedBeaconBlock, execution interfaces.Executi
 	if execution == nil {
 		return errors.New("execution is nil")
 	}
-
-	// Set the blinded status of the block
-	blk.SetBlinded(isBlinded)
 
 	// Set the execution data for the block
 	errMessage := "failed to set local execution"

--- a/beacon-chain/sync/rpc_chunked_response_test.go
+++ b/beacon-chain/sync/rpc_chunked_response_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
+	enginev1 "github.com/prysmaticlabs/prysm/v4/proto/engine/v1"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
 )
@@ -98,7 +99,7 @@ func TestExtractBlockDataType(t *testing.T) {
 				chain:  &mock.ChainService{ValidatorsRoot: [32]byte{}},
 			},
 			want: func() interfaces.ReadOnlySignedBeaconBlock {
-				wsb, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockBellatrix{Block: &ethpb.BeaconBlockBellatrix{Body: &ethpb.BeaconBlockBodyBellatrix{}}})
+				wsb, err := blocks.NewSignedBeaconBlock(&ethpb.SignedBeaconBlockBellatrix{Block: &ethpb.BeaconBlockBellatrix{Body: &ethpb.BeaconBlockBodyBellatrix{ExecutionPayload: &enginev1.ExecutionPayload{}}}})
 				require.NoError(t, err)
 				return wsb
 			}(),

--- a/consensus-types/blocks/factory_test.go
+++ b/consensus-types/blocks/factory_test.go
@@ -318,7 +318,7 @@ func Test_NewBeaconBlockBody(t *testing.T) {
 		b, ok := i.(*BeaconBlockBody)
 		require.Equal(t, true, ok)
 		assert.Equal(t, version.Bellatrix, b.version)
-		assert.Equal(t, true, b.isBlinded)
+		assert.Equal(t, true, b.IsBlinded())
 	})
 	t.Run("BeaconBlockBodyCapella", func(t *testing.T) {
 		pb := &eth.BeaconBlockBodyCapella{}
@@ -335,7 +335,7 @@ func Test_NewBeaconBlockBody(t *testing.T) {
 		b, ok := i.(*BeaconBlockBody)
 		require.Equal(t, true, ok)
 		assert.Equal(t, version.Capella, b.version)
-		assert.Equal(t, true, b.isBlinded)
+		assert.Equal(t, true, b.IsBlinded())
 	})
 	t.Run("BeaconBlockBodyDeneb", func(t *testing.T) {
 		pb := &eth.BeaconBlockBodyDeneb{}
@@ -352,7 +352,7 @@ func Test_NewBeaconBlockBody(t *testing.T) {
 		b, ok := i.(*BeaconBlockBody)
 		require.Equal(t, true, ok)
 		assert.Equal(t, version.Deneb, b.version)
-		assert.Equal(t, true, b.isBlinded)
+		assert.Equal(t, true, b.IsBlinded())
 	})
 	t.Run("nil", func(t *testing.T) {
 		_, err := NewBeaconBlockBody(nil)
@@ -388,7 +388,7 @@ func Test_BuildSignedBeaconBlock(t *testing.T) {
 		assert.Equal(t, version.Bellatrix, sb.Version())
 	})
 	t.Run("BellatrixBlind", func(t *testing.T) {
-		b := &BeaconBlock{version: version.Bellatrix, body: &BeaconBlockBody{version: version.Bellatrix, isBlinded: true}}
+		b := &BeaconBlock{version: version.Bellatrix, body: &BeaconBlockBody{version: version.Bellatrix}}
 		sb, err := BuildSignedBeaconBlock(b, sig[:])
 		require.NoError(t, err)
 		assert.DeepEqual(t, sig, sb.Signature())
@@ -403,7 +403,7 @@ func Test_BuildSignedBeaconBlock(t *testing.T) {
 		assert.Equal(t, version.Capella, sb.Version())
 	})
 	t.Run("CapellaBlind", func(t *testing.T) {
-		b := &BeaconBlock{version: version.Capella, body: &BeaconBlockBody{version: version.Capella, isBlinded: true}}
+		b := &BeaconBlock{version: version.Capella, body: &BeaconBlockBody{version: version.Capella}}
 		sb, err := BuildSignedBeaconBlock(b, sig[:])
 		require.NoError(t, err)
 		assert.DeepEqual(t, sig, sb.Signature())
@@ -418,7 +418,7 @@ func Test_BuildSignedBeaconBlock(t *testing.T) {
 		assert.Equal(t, version.Deneb, sb.Version())
 	})
 	t.Run("DenebBlind", func(t *testing.T) {
-		b := &BeaconBlock{version: version.Deneb, body: &BeaconBlockBody{version: version.Deneb, isBlinded: true}}
+		b := &BeaconBlock{version: version.Deneb, body: &BeaconBlockBody{version: version.Deneb}}
 		sb, err := BuildSignedBeaconBlock(b, sig[:])
 		require.NoError(t, err)
 		assert.DeepEqual(t, sig, sb.Signature())

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -340,6 +340,7 @@ func (b *SignedBeaconBlock) Version() int {
 
 // IsBlinded metadata on whether a block is blinded
 func (b *SignedBeaconBlock) IsBlinded() bool {
+	fmt.Println(b.block.body.executionPayload)
 	return b.version >= version.Bellatrix && b.block.body.executionPayload == nil
 }
 

--- a/consensus-types/blocks/getters.go
+++ b/consensus-types/blocks/getters.go
@@ -340,7 +340,6 @@ func (b *SignedBeaconBlock) Version() int {
 
 // IsBlinded metadata on whether a block is blinded
 func (b *SignedBeaconBlock) IsBlinded() bool {
-	fmt.Println(b.block.body.executionPayload)
 	return b.version >= version.Bellatrix && b.block.body.executionPayload == nil
 }
 

--- a/consensus-types/blocks/getters_test.go
+++ b/consensus-types/blocks/getters_test.go
@@ -200,7 +200,6 @@ func Test_BeaconBlock_Copy(t *testing.T) {
 
 	b.version = version.Bellatrix
 	b.body.version = b.version
-	b.body.isBlinded = true
 	cp, err = b.Copy()
 	require.NoError(t, err)
 	assert.NotEqual(t, cp, b)
@@ -233,7 +232,6 @@ func Test_BeaconBlock_Copy(t *testing.T) {
 	require.NoError(t, err)
 	require.DeepEqual(t, gas, uint64(123))
 
-	b.body.isBlinded = true
 	cp, err = b.Copy()
 	require.NoError(t, err)
 	assert.NotEqual(t, cp, b)
@@ -263,7 +261,6 @@ func Test_BeaconBlock_IsNil(t *testing.T) {
 func Test_BeaconBlock_IsBlinded(t *testing.T) {
 	b := &SignedBeaconBlock{block: &BeaconBlock{body: &BeaconBlockBody{}}}
 	assert.Equal(t, false, b.IsBlinded())
-	b.SetBlinded(true)
 	assert.Equal(t, true, b.IsBlinded())
 }
 
@@ -433,7 +430,7 @@ func Test_BeaconBlockBody_Execution(t *testing.T) {
 	executionCapellaHeader := &pb.ExecutionPayloadHeaderCapella{BlockNumber: 1}
 	eCapellaHeader, err := WrappedExecutionPayloadHeaderCapella(executionCapellaHeader, 0)
 	require.NoError(t, err)
-	bb = &SignedBeaconBlock{version: version.Capella, block: &BeaconBlock{version: version.Capella, body: &BeaconBlockBody{version: version.Capella, isBlinded: true}}}
+	bb = &SignedBeaconBlock{version: version.Capella, block: &BeaconBlock{version: version.Capella, body: &BeaconBlockBody{version: version.Capella}}}
 	require.NoError(t, bb.SetExecution(eCapellaHeader))
 	result, err = bb.Block().Body().Execution()
 	require.NoError(t, err)
@@ -454,7 +451,7 @@ func Test_BeaconBlockBody_Execution(t *testing.T) {
 	executionDenebHeader := &pb.ExecutionPayloadHeaderDeneb{BlockNumber: 1, ExcessBlobGas: 223}
 	eDenebHeader, err := WrappedExecutionPayloadHeaderDeneb(executionDenebHeader, 0)
 	require.NoError(t, err)
-	bb = &SignedBeaconBlock{version: version.Deneb, block: &BeaconBlock{version: version.Deneb, body: &BeaconBlockBody{version: version.Deneb, isBlinded: true}}}
+	bb = &SignedBeaconBlock{version: version.Deneb, block: &BeaconBlock{version: version.Deneb, body: &BeaconBlockBody{version: version.Deneb}}}
 	require.NoError(t, bb.SetExecution(eDenebHeader))
 	result, err = bb.Block().Body().Execution()
 	require.NoError(t, err)

--- a/consensus-types/blocks/getters_test.go
+++ b/consensus-types/blocks/getters_test.go
@@ -231,16 +231,6 @@ func Test_BeaconBlock_Copy(t *testing.T) {
 	gas, err := e.ExcessBlobGas()
 	require.NoError(t, err)
 	require.DeepEqual(t, gas, uint64(123))
-
-	cp, err = b.Copy()
-	require.NoError(t, err)
-	assert.NotEqual(t, cp, b)
-	assert.NotEqual(t, cp.Body(), bb)
-	e, err = cp.Body().Execution()
-	require.NoError(t, err)
-	gas, err = e.ExcessBlobGas()
-	require.NoError(t, err)
-	require.DeepEqual(t, gas, uint64(223))
 }
 
 func Test_BeaconBlock_IsNil(t *testing.T) {
@@ -261,7 +251,9 @@ func Test_BeaconBlock_IsNil(t *testing.T) {
 func Test_BeaconBlock_IsBlinded(t *testing.T) {
 	b := &SignedBeaconBlock{block: &BeaconBlock{body: &BeaconBlockBody{}}}
 	assert.Equal(t, false, b.IsBlinded())
-	assert.Equal(t, true, b.IsBlinded())
+
+	b1 := &SignedBeaconBlock{version: version.Bellatrix, block: &BeaconBlock{body: &BeaconBlockBody{executionPayloadHeader: executionPayloadHeader{}}}}
+	assert.Equal(t, true, b1.IsBlinded())
 }
 
 func Test_BeaconBlock_Version(t *testing.T) {

--- a/consensus-types/blocks/proto.go
+++ b/consensus-types/blocks/proto.go
@@ -313,7 +313,7 @@ func (b *BeaconBlockBody) Proto() (proto.Message, error) {
 			SyncAggregate:     b.syncAggregate,
 		}, nil
 	case version.Bellatrix:
-		if b.isBlinded {
+		if b.IsBlinded() {
 			var ph *enginev1.ExecutionPayloadHeader
 			var ok bool
 			if b.executionPayloadHeader != nil {
@@ -356,7 +356,7 @@ func (b *BeaconBlockBody) Proto() (proto.Message, error) {
 			ExecutionPayload:  p,
 		}, nil
 	case version.Capella:
-		if b.isBlinded {
+		if b.IsBlinded() {
 			var ph *enginev1.ExecutionPayloadHeaderCapella
 			var ok bool
 			if b.executionPayloadHeader != nil {
@@ -401,7 +401,7 @@ func (b *BeaconBlockBody) Proto() (proto.Message, error) {
 			BlsToExecutionChanges: b.blsToExecutionChanges,
 		}, nil
 	case version.Deneb:
-		if b.isBlinded {
+		if b.IsBlinded() {
 			var ph *enginev1.ExecutionPayloadHeaderDeneb
 			var ok bool
 			if b.executionPayloadHeader != nil {
@@ -755,7 +755,6 @@ func initBlockBodyFromProtoPhase0(pb *eth.BeaconBlockBody) (*BeaconBlockBody, er
 
 	b := &BeaconBlockBody{
 		version:           version.Phase0,
-		isBlinded:         false,
 		randaoReveal:      bytesutil.ToBytes96(pb.RandaoReveal),
 		eth1Data:          pb.Eth1Data,
 		graffiti:          bytesutil.ToBytes32(pb.Graffiti),
@@ -775,7 +774,6 @@ func initBlockBodyFromProtoAltair(pb *eth.BeaconBlockBodyAltair) (*BeaconBlockBo
 
 	b := &BeaconBlockBody{
 		version:           version.Altair,
-		isBlinded:         false,
 		randaoReveal:      bytesutil.ToBytes96(pb.RandaoReveal),
 		eth1Data:          pb.Eth1Data,
 		graffiti:          bytesutil.ToBytes32(pb.Graffiti),
@@ -801,7 +799,6 @@ func initBlockBodyFromProtoBellatrix(pb *eth.BeaconBlockBodyBellatrix) (*BeaconB
 	}
 	b := &BeaconBlockBody{
 		version:           version.Bellatrix,
-		isBlinded:         false,
 		randaoReveal:      bytesutil.ToBytes96(pb.RandaoReveal),
 		eth1Data:          pb.Eth1Data,
 		graffiti:          bytesutil.ToBytes32(pb.Graffiti),
@@ -828,7 +825,6 @@ func initBlindedBlockBodyFromProtoBellatrix(pb *eth.BlindedBeaconBlockBodyBellat
 	}
 	b := &BeaconBlockBody{
 		version:                version.Bellatrix,
-		isBlinded:              true,
 		randaoReveal:           bytesutil.ToBytes96(pb.RandaoReveal),
 		eth1Data:               pb.Eth1Data,
 		graffiti:               bytesutil.ToBytes32(pb.Graffiti),
@@ -855,7 +851,6 @@ func initBlockBodyFromProtoCapella(pb *eth.BeaconBlockBodyCapella) (*BeaconBlock
 	}
 	b := &BeaconBlockBody{
 		version:               version.Capella,
-		isBlinded:             false,
 		randaoReveal:          bytesutil.ToBytes96(pb.RandaoReveal),
 		eth1Data:              pb.Eth1Data,
 		graffiti:              bytesutil.ToBytes32(pb.Graffiti),
@@ -883,7 +878,6 @@ func initBlindedBlockBodyFromProtoCapella(pb *eth.BlindedBeaconBlockBodyCapella)
 	}
 	b := &BeaconBlockBody{
 		version:                version.Capella,
-		isBlinded:              true,
 		randaoReveal:           bytesutil.ToBytes96(pb.RandaoReveal),
 		eth1Data:               pb.Eth1Data,
 		graffiti:               bytesutil.ToBytes32(pb.Graffiti),
@@ -911,7 +905,6 @@ func initBlockBodyFromProtoDeneb(pb *eth.BeaconBlockBodyDeneb) (*BeaconBlockBody
 	}
 	b := &BeaconBlockBody{
 		version:               version.Deneb,
-		isBlinded:             false,
 		randaoReveal:          bytesutil.ToBytes96(pb.RandaoReveal),
 		eth1Data:              pb.Eth1Data,
 		graffiti:              bytesutil.ToBytes32(pb.Graffiti),
@@ -940,7 +933,6 @@ func initBlindedBlockBodyFromProtoDeneb(pb *eth.BlindedBeaconBlockBodyDeneb) (*B
 	}
 	b := &BeaconBlockBody{
 		version:                version.Deneb,
-		isBlinded:              true,
 		randaoReveal:           bytesutil.ToBytes96(pb.RandaoReveal),
 		eth1Data:               pb.Eth1Data,
 		graffiti:               bytesutil.ToBytes32(pb.Graffiti),

--- a/consensus-types/blocks/proto_test.go
+++ b/consensus-types/blocks/proto_test.go
@@ -1312,7 +1312,6 @@ func bodyBlindedBellatrix(t *testing.T) *BeaconBlockBody {
 	require.NoError(t, err)
 	return &BeaconBlockBody{
 		version:      version.Bellatrix,
-		isBlinded:    true,
 		randaoReveal: f.sig,
 		eth1Data: &eth.Eth1Data{
 			DepositRoot:  f.root[:],
@@ -1360,7 +1359,6 @@ func bodyBlindedCapella(t *testing.T) *BeaconBlockBody {
 	require.NoError(t, err)
 	return &BeaconBlockBody{
 		version:      version.Capella,
-		isBlinded:    true,
 		randaoReveal: f.sig,
 		eth1Data: &eth.Eth1Data{
 			DepositRoot:  f.root[:],
@@ -1410,7 +1408,6 @@ func bodyBlindedDeneb(t *testing.T) *BeaconBlockBody {
 	require.NoError(t, err)
 	return &BeaconBlockBody{
 		version:      version.Deneb,
-		isBlinded:    true,
 		randaoReveal: f.sig,
 		eth1Data: &eth.Eth1Data{
 			DepositRoot:  f.root[:],

--- a/consensus-types/blocks/setters.go
+++ b/consensus-types/blocks/setters.go
@@ -38,12 +38,6 @@ func (b *SignedBeaconBlock) SetStateRoot(root []byte) {
 	copy(b.block.stateRoot[:], root)
 }
 
-// SetBlinded sets the blinded flag of the beacon block.
-// This function is not thread safe, it is only used during block creation.
-func (b *SignedBeaconBlock) SetBlinded(blinded bool) {
-	b.block.body.isBlinded = blinded
-}
-
 // SetRandaoReveal sets the randao reveal in the block body.
 // This function is not thread safe, it is only used during block creation.
 func (b *SignedBeaconBlock) SetRandaoReveal(r []byte) {
@@ -108,7 +102,7 @@ func (b *SignedBeaconBlock) SetExecution(e interfaces.ExecutionData) error {
 	if b.version == version.Phase0 || b.version == version.Altair {
 		return consensus_types.ErrNotSupported("Execution", b.version)
 	}
-	if b.block.body.isBlinded {
+	if e.IsBlinded() {
 		b.block.body.executionPayloadHeader = e
 		return nil
 	}

--- a/consensus-types/blocks/types.go
+++ b/consensus-types/blocks/types.go
@@ -36,7 +36,6 @@ var (
 // BeaconBlockBody is the main beacon block body structure. It can represent any block type.
 type BeaconBlockBody struct {
 	version                int
-	isBlinded              bool
 	randaoReveal           [field_params.BLSSignatureLength]byte
 	eth1Data               *eth.Eth1Data
 	graffiti               [field_params.RootLength]byte

--- a/consensus-types/interfaces/beacon_block.go
+++ b/consensus-types/interfaces/beacon_block.go
@@ -91,7 +91,6 @@ type SignedBeaconBlock interface {
 	SetGraffiti([]byte)
 	SetEth1Data(*ethpb.Eth1Data)
 	SetRandaoReveal([]byte)
-	SetBlinded(bool)
 	SetStateRoot([]byte)
 	SetParentRoot([]byte)
 	SetProposerIndex(idx primitives.ValidatorIndex)

--- a/consensus-types/mock/block.go
+++ b/consensus-types/mock/block.go
@@ -197,10 +197,6 @@ func (BeaconBlock) SetParentRoot(_ []byte) {
 	panic("implement me")
 }
 
-func (BeaconBlock) SetBlinded(_ bool) {
-	panic("implement me")
-}
-
 func (BeaconBlock) Copy() (interfaces.ReadOnlyBeaconBlock, error) {
 	panic("implement me")
 }


### PR DESCRIPTION
This PR removes the `blind` field from the block type.

Having a `blind` field as part of the block type has proven to be error-prone. This requires the caller to manually set the field before assigning the execution data, which could be either header or payload. There's no necessity for setting this field to determine the block type. In fact, whether the block is blind or not can be discerned by examining if it's using a header or a payload.
```go
func (b *SignedBeaconBlock) IsBlinded() bool {
	return b.version >= version.Bellatrix && b.body.executionPayload == nil
}
```

We revise the logic so that a block is considered blinded if its version is greater than Bellatrix and the execution payload is `nil`. This change simplifies the code by eliminating the need for `SetBlinded`, thereby reducing boilerplate code and mitigating future bug concerns.