### PR TITLE
`--validatorS-registration-batch-size` (add `s`)

### DIFF
--- a/cmd/validator/flags/flags.go
+++ b/cmd/validator/flags/flags.go
@@ -365,9 +365,9 @@ var (
 		Value: fmt.Sprint(params.BeaconConfig().DefaultBuilderGasLimit),
 	}
 
-	// ValidatorRegistrationBatchSizeFlag sets the maximum size for one batch of validator registrations. Use a non-positive value to disable batching.
-	ValidatorRegistrationBatchSizeFlag = &cli.IntFlag{
-		Name:  "validator-registration-batch-size",
+	// ValidatorsRegistrationBatchSizeFlag sets the maximum size for one batch of validator registrations. Use a non-positive value to disable batching.
+	ValidatorsRegistrationBatchSizeFlag = &cli.IntFlag{
+		Name:  "validators-registration-batch-size",
 		Usage: "Sets the maximum size for one batch of validator registrations. Use a non-positive value to disable batching.",
 		Value: 0,
 	}

--- a/cmd/validator/main.go
+++ b/cmd/validator/main.go
@@ -79,7 +79,7 @@ var appFlags = []cli.Flag{
 	flags.ProposerSettingsFlag,
 	flags.EnableBuilderFlag,
 	flags.BuilderGasLimitFlag,
-	flags.ValidatorRegistrationBatchSizeFlag,
+	flags.ValidatorsRegistrationBatchSizeFlag,
 	////////////////////
 	cmd.DisableMonitoringFlag,
 	cmd.MonitoringHostFlag,

--- a/cmd/validator/usage.go
+++ b/cmd/validator/usage.go
@@ -113,7 +113,7 @@ var appHelpFlagGroups = []flagGroup{
 			flags.SuggestedFeeRecipientFlag,
 			flags.EnableBuilderFlag,
 			flags.BuilderGasLimitFlag,
-			flags.ValidatorRegistrationBatchSizeFlag,
+			flags.ValidatorsRegistrationBatchSizeFlag,
 		},
 	},
 	{

--- a/validator/client/service.go
+++ b/validator/client/service.go
@@ -51,29 +51,29 @@ type GenesisFetcher interface {
 // ValidatorService represents a service to manage the validator client
 // routine.
 type ValidatorService struct {
-	useWeb                bool
-	emitAccountMetrics    bool
-	logValidatorBalances  bool
-	interopKeysConfig     *local.InteropKeymanagerConfig
-	conn                  validatorHelpers.NodeConnection
-	grpcRetryDelay        time.Duration
-	grpcRetries           uint
-	maxCallRecvMsgSize    int
-	cancel                context.CancelFunc
-	walletInitializedFeed *event.Feed
-	wallet                *wallet.Wallet
-	graffitiStruct        *graffiti.Graffiti
-	dataDir               string
-	withCert              string
-	endpoint              string
-	ctx                   context.Context
-	validator             iface.Validator
-	db                    db.Database
-	grpcHeaders           []string
-	graffiti              []byte
-	Web3SignerConfig      *remoteweb3signer.SetupConfig
-	proposerSettings      *validatorserviceconfig.ProposerSettings
-	validatorRegBatchSize int
+	useWeb                 bool
+	emitAccountMetrics     bool
+	logValidatorBalances   bool
+	interopKeysConfig      *local.InteropKeymanagerConfig
+	conn                   validatorHelpers.NodeConnection
+	grpcRetryDelay         time.Duration
+	grpcRetries            uint
+	maxCallRecvMsgSize     int
+	cancel                 context.CancelFunc
+	walletInitializedFeed  *event.Feed
+	wallet                 *wallet.Wallet
+	graffitiStruct         *graffiti.Graffiti
+	dataDir                string
+	withCert               string
+	endpoint               string
+	ctx                    context.Context
+	validator              iface.Validator
+	db                     db.Database
+	grpcHeaders            []string
+	graffiti               []byte
+	Web3SignerConfig       *remoteweb3signer.SetupConfig
+	proposerSettings       *validatorserviceconfig.ProposerSettings
+	validatorsRegBatchSize int
 }
 
 // Config for the validator service.
@@ -99,7 +99,7 @@ type Config struct {
 	ProposerSettings           *validatorserviceconfig.ProposerSettings
 	BeaconApiEndpoint          string
 	BeaconApiTimeout           time.Duration
-	ValidatorRegBatchSize      int
+	ValidatorsRegBatchSize     int
 }
 
 // NewValidatorService creates a new validator service for the service
@@ -107,28 +107,28 @@ type Config struct {
 func NewValidatorService(ctx context.Context, cfg *Config) (*ValidatorService, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	s := &ValidatorService{
-		ctx:                   ctx,
-		cancel:                cancel,
-		endpoint:              cfg.Endpoint,
-		withCert:              cfg.CertFlag,
-		dataDir:               cfg.DataDir,
-		graffiti:              []byte(cfg.GraffitiFlag),
-		logValidatorBalances:  cfg.LogValidatorBalances,
-		emitAccountMetrics:    cfg.EmitAccountMetrics,
-		maxCallRecvMsgSize:    cfg.GrpcMaxCallRecvMsgSizeFlag,
-		grpcRetries:           cfg.GrpcRetriesFlag,
-		grpcRetryDelay:        cfg.GrpcRetryDelay,
-		grpcHeaders:           strings.Split(cfg.GrpcHeadersFlag, ","),
-		validator:             cfg.Validator,
-		db:                    cfg.ValDB,
-		wallet:                cfg.Wallet,
-		walletInitializedFeed: cfg.WalletInitializedFeed,
-		useWeb:                cfg.UseWeb,
-		interopKeysConfig:     cfg.InteropKeysConfig,
-		graffitiStruct:        cfg.GraffitiStruct,
-		Web3SignerConfig:      cfg.Web3SignerConfig,
-		proposerSettings:      cfg.ProposerSettings,
-		validatorRegBatchSize: cfg.ValidatorRegBatchSize,
+		ctx:                    ctx,
+		cancel:                 cancel,
+		endpoint:               cfg.Endpoint,
+		withCert:               cfg.CertFlag,
+		dataDir:                cfg.DataDir,
+		graffiti:               []byte(cfg.GraffitiFlag),
+		logValidatorBalances:   cfg.LogValidatorBalances,
+		emitAccountMetrics:     cfg.EmitAccountMetrics,
+		maxCallRecvMsgSize:     cfg.GrpcMaxCallRecvMsgSizeFlag,
+		grpcRetries:            cfg.GrpcRetriesFlag,
+		grpcRetryDelay:         cfg.GrpcRetryDelay,
+		grpcHeaders:            strings.Split(cfg.GrpcHeadersFlag, ","),
+		validator:              cfg.Validator,
+		db:                     cfg.ValDB,
+		wallet:                 cfg.Wallet,
+		walletInitializedFeed:  cfg.WalletInitializedFeed,
+		useWeb:                 cfg.UseWeb,
+		interopKeysConfig:      cfg.InteropKeysConfig,
+		graffitiStruct:         cfg.GraffitiStruct,
+		Web3SignerConfig:       cfg.Web3SignerConfig,
+		proposerSettings:       cfg.ProposerSettings,
+		validatorsRegBatchSize: cfg.ValidatorsRegBatchSize,
 	}
 
 	dialOpts := ConstructDialOptions(
@@ -222,7 +222,7 @@ func (v *ValidatorService) Start() {
 		proposerSettings:               v.proposerSettings,
 		walletInitializedChannel:       make(chan *wallet.Wallet, 1),
 		prysmBeaconClient:              prysmBeaconClient,
-		validatorRegBatchSize:          v.validatorRegBatchSize,
+		validatorsRegBatchSize:         v.validatorsRegBatchSize,
 	}
 
 	v.validator = valStruct

--- a/validator/client/validator.go
+++ b/validator/client/validator.go
@@ -104,7 +104,7 @@ type validator struct {
 	proposerSettings                   *validatorserviceconfig.ProposerSettings
 	walletInitializedChannel           chan *wallet.Wallet
 	prysmBeaconClient                  iface.PrysmBeaconChainClient
-	validatorRegBatchSize              int
+	validatorsRegBatchSize             int
 }
 
 type validatorStatus struct {
@@ -1029,7 +1029,7 @@ func (v *validator) PushProposerSettings(ctx context.Context, km keymanager.IKey
 	}
 
 	signedRegReqs := v.buildSignedRegReqs(ctx, filteredKeys, km.Sign)
-	if err := SubmitValidatorRegistrations(ctx, v.validatorClient, signedRegReqs, v.validatorRegBatchSize); err != nil {
+	if err := SubmitValidatorRegistrations(ctx, v.validatorClient, signedRegReqs, v.validatorsRegBatchSize); err != nil {
 		return errors.Wrap(ErrBuilderValidatorRegistration, err.Error())
 	}
 	return nil

--- a/validator/node/node.go
+++ b/validator/node/node.go
@@ -451,7 +451,7 @@ func (c *ValidatorClient) registerValidatorService(cliCtx *cli.Context) error {
 		ProposerSettings:           bpc,
 		BeaconApiTimeout:           time.Second * 30,
 		BeaconApiEndpoint:          c.cliCtx.String(flags.BeaconRESTApiProviderFlag.Name),
-		ValidatorRegBatchSize:      c.cliCtx.Int(flags.ValidatorRegistrationBatchSizeFlag.Name),
+		ValidatorsRegBatchSize:     c.cliCtx.Int(flags.ValidatorsRegistrationBatchSizeFlag.Name),
 	})
 	if err != nil {
 		return errors.Wrap(err, "could not initialize validator service")


### PR DESCRIPTION
**What type of PR is this?**

> Uncomment one line below and remove others.
Other

**What does this PR do? Why is it needed?**
Initially, the VC flag `--validator-registration-batch-size` was named like this to be consistent with Lighthouse.
Unfortunately, it is quite inconsistent with others Prysm flags. See:

```
  --tls-cert value                                                                                   Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.
  --validators-external-signer-public-keys value [ --validators-external-signer-public-keys value ]  comma separated list of public keys OR an external url endpoint for the validator to retrieve public keys from for usage with web3signer
  --validators-external-signer-url value                                                             URL for consensys' web3signer software to use with the Prysm validator client
  --validator-registration-batch-size value                                                          Sets the maximum size for one batch of validator registrations. Use a non-positive value to disable batching. (default: 0)
  --wallet-dir value                                                                                 Path to a wallet directory on-disk for Prysm validator accounts (default: "/Users/manu/Library/Eth2Validators/prysm-wallet-v2")
```

After this PR, we have more consistent flags:

```
  --tls-cert value                                                                                   Certificate for secure gRPC. Pass this and the tls-key flag in order to use gRPC securely.
  --validators-external-signer-public-keys value [ --validators-external-signer-public-keys value ]  comma separated list of public keys OR an external url endpoint for the validator to retrieve public keys from for usage with web3signer
  --validators-external-signer-url value                                                             URL for consensys' web3signer software to use with the Prysm validator client
  --validators-registration-batch-size value                                                         Sets the maximum size for one batch of validator registrations. Use a non-positive value to disable batching. (default: 0)
  --wallet-dir value                                                                                 Path to a wallet directory on-disk for Prysm validator accounts (default: "/Users/manu/Library/Eth2Validators/prysm-wallet-v2")
```
