### PR TITLE
Remove getPayloadAttributes from FCU call

### DIFF
--- a/consensus-types/payload-attribute/getters.go
+++ b/consensus-types/payload-attribute/getters.go
@@ -94,3 +94,23 @@ func (a *data) PbV3() (*enginev1.PayloadAttributesV3, error) {
 		ParentBeaconBlockRoot: a.parentBeaconBlockRoot,
 	}, nil
 }
+
+// IsEmpty returns whether the given payload attribute is empty
+func (a *data) IsEmpty() bool {
+	if len(a.PrevRandao()) != 0 {
+		return false
+	}
+	if a.Timestamps() != 0 {
+		return false
+	}
+	if len(a.SuggestedFeeRecipient()) != 0 {
+		return false
+	}
+	if a.Version() >= version.Capella && len(a.withdrawals) != 0 {
+		return false
+	}
+	if a.Version() >= version.Deneb && len(a.parentBeaconBlockRoot) != 0 {
+		return false
+	}
+	return true
+}

--- a/consensus-types/payload-attribute/getters_test.go
+++ b/consensus-types/payload-attribute/getters_test.go
@@ -204,3 +204,72 @@ func TestPayloadAttributeGetters(t *testing.T) {
 		t.Run(test.name, test.tc)
 	}
 }
+
+func TestIsEmpty(t *testing.T) {
+	tests := []struct {
+		name  string
+		a     Attributer
+		empty bool
+	}{
+		{
+			name:  "Empty V1",
+			a:     EmptyWithVersion(version.Bellatrix),
+			empty: true,
+		},
+		{
+			name:  "Empty V2",
+			a:     EmptyWithVersion(version.Capella),
+			empty: true,
+		},
+		{
+			name:  "Empty V3",
+			a:     EmptyWithVersion(version.Deneb),
+			empty: true,
+		},
+		{
+			name: "non empty prevrandao",
+			a: &data{
+				version:    version.Bellatrix,
+				prevRandao: []byte{0x01},
+			},
+			empty: false,
+		},
+		{
+			name: "non zero Timestamps",
+			a: &data{
+				version:   version.Bellatrix,
+				timeStamp: 1,
+			},
+			empty: false,
+		},
+		{
+			name: "non empty fee recipient",
+			a: &data{
+				version:               version.Bellatrix,
+				suggestedFeeRecipient: []byte{0x01},
+			},
+			empty: false,
+		},
+		{
+			name: "non empty withdrawals",
+			a: &data{
+				version:     version.Capella,
+				withdrawals: make([]*enginev1.Withdrawal, 1),
+			},
+			empty: false,
+		},
+		{
+			name: "non empty parent block root",
+			a: &data{
+				version:               version.Deneb,
+				parentBeaconBlockRoot: []byte{0x01},
+			},
+			empty: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.empty, tt.a.IsEmpty())
+		})
+	}
+}

--- a/consensus-types/payload-attribute/interface.go
+++ b/consensus-types/payload-attribute/interface.go
@@ -13,4 +13,5 @@ type Attributer interface {
 	PbV1() (*enginev1.PayloadAttributes, error)
 	PbV2() (*enginev1.PayloadAttributesV2, error)
 	PbV3() (*enginev1.PayloadAttributesV3, error)
+	IsEmpty() bool
 }


### PR DESCRIPTION
This PR decouples `getPayloadAttributes` from the FCU call, making it the responsibility of the calller to pass them. In subsequent PRs we will call FCU with and without attributes multiple times during the same slot. 