### PR TITLE
Remove the getPayloadAttribute call from updateForkchoiceWithExecution

### DIFF
--- a/beacon-chain/blockchain/forkchoice_update_execution.go
+++ b/beacon-chain/blockchain/forkchoice_update_execution.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	doublylinkedtree "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/doubly-linked-tree"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
-	"github.com/prysmaticlabs/prysm/v4/config/features"
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
 	payloadattribute "github.com/prysmaticlabs/prysm/v4/consensus-types/payload-attribute"
@@ -59,19 +58,7 @@ func (s *Service) forkchoiceUpdateWithExecution(ctx context.Context, args *fcuCo
 	defer span.End()
 	// Note: Use the service context here to avoid the parent context being ended during a forkchoice update.
 	ctx = trace.NewContext(s.ctx, span)
-	fcuArgs := &fcuConfig{
-		headState: args.headState,
-		headRoot:  args.headRoot,
-		headBlock: args.headBlock,
-	}
-	_, tracked := s.trackedProposer(args.headState, args.proposingSlot)
-	if tracked && !features.Get().DisableReorgLateBlocks {
-		if s.shouldOverrideFCU(args.headRoot, args.proposingSlot) {
-			return nil
-		}
-		fcuArgs.attributes = s.getPayloadAttribute(ctx, args.headState, args.proposingSlot, args.headRoot[:])
-	}
-	_, err := s.notifyForkchoiceUpdate(ctx, fcuArgs)
+	_, err := s.notifyForkchoiceUpdate(ctx, args)
 	if err != nil {
 		return errors.Wrap(err, "could not notify forkchoice update")
 	}

--- a/beacon-chain/blockchain/receive_attestation.go
+++ b/beacon-chain/blockchain/receive_attestation.go
@@ -139,13 +139,13 @@ func (s *Service) UpdateHead(ctx context.Context, proposingSlot primitives.Slot)
 	if !s.isNewHead(newHeadRoot) {
 		return
 	}
+	log.WithField("newHeadRoot", fmt.Sprintf("%#x", newHeadRoot)).Debug("Head changed due to attestations")
 	headState, headBlock, err := s.getStateAndBlock(ctx, newHeadRoot)
 	if err != nil {
 		log.WithError(err).Error("could not get head block")
 		return
 	}
 	newAttHeadElapsedTime.Observe(float64(time.Since(start).Milliseconds()))
-	log.WithField("newHeadRoot", fmt.Sprintf("%#x", newHeadRoot)).Debug("Head changed due to attestations")
 	fcuArgs := &fcuConfig{
 		headState:     headState,
 		headRoot:      newHeadRoot,


### PR DESCRIPTION
This PR removes the `getPayloadAttribute` call from `updateForkchoiceWithExecution`. It makes the logic of `postBlockProcess` strictly uglier but it makes it possible to decouple the calls to FCU from the calls to update the NSC and perform epoch transition, which will come in the next PR. 

Please review after: #13400 