### PR TITLE
Fetch Goroutine Traces in E2E Too

### DIFF
--- a/testing/endtoend/helpers/helpers.go
+++ b/testing/endtoend/helpers/helpers.go
@@ -31,12 +31,13 @@ import (
 )
 
 const (
-	maxPollingWaitTime  = 60 * time.Second // A minute so timing out doesn't take very long.
-	filePollingInterval = 500 * time.Millisecond
-	memoryHeapFileName  = "node_heap_%d.pb.gz"
-	cpuProfileFileName  = "node_cpu_profile_%d.pb.gz"
-	fileBufferSize      = 64 * 1024
-	maxFileBufferSize   = 1024 * 1024
+	maxPollingWaitTime     = 60 * time.Second // A minute so timing out doesn't take very long.
+	filePollingInterval    = 500 * time.Millisecond
+	memoryHeapFileName     = "node_heap_%d.pb.gz"
+	cpuProfileFileName     = "node_cpu_profile_%d.pb.gz"
+	goroutineTraceFileName = "node_goroutine_trace_%d.log"
+	fileBufferSize         = 64 * 1024
+	maxFileBufferSize      = 1024 * 1024
 )
 
 // Graffiti is a list of sample graffiti strings.
@@ -251,6 +252,11 @@ func WritePprofFiles(testDir string, index int) error {
 	}
 	url = fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/profile", e2e.TestParams.Ports.PrysmBeaconNodePprofPort+index)
 	filePath = filepath.Join(testDir, fmt.Sprintf(cpuProfileFileName, index))
+	if err := writeURLRespAtPath(url, filePath); err != nil {
+		return err
+	}
+	url = fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/goroutine?debug=1", e2e.TestParams.Ports.PrysmBeaconNodePprofPort+index)
+	filePath = filepath.Join(testDir, fmt.Sprintf(goroutineTraceFileName, index))
 	return writeURLRespAtPath(url, filePath)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

E2E Improvement

**What does this PR do? Why is it needed?**

In each e2e run along with CPU and heap profiles, we also fetch the goroutine trace of the individual beacon nodes. This is done so that in the event we have deadlocks in the beacon node during a run, we are able to correctly capture them.

**Which issues(s) does this PR fix?**

N.A

**Other notes for review**
