### PR TITLE
adding builder boost factor to get block v3

### DIFF
--- a/beacon-chain/rpc/eth/shared/BUILD.bazel
+++ b/beacon-chain/rpc/eth/shared/BUILD.bazel
@@ -40,7 +40,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["errors_test.go"],
+    srcs = [
+        "errors_test.go",
+        "request_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//beacon-chain/rpc/lookup:go_default_library",

--- a/beacon-chain/rpc/eth/shared/request.go
+++ b/beacon-chain/rpc/eth/shared/request.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gorilla/mux"
@@ -15,15 +16,15 @@ import (
 )
 
 func UintFromQuery(w http.ResponseWriter, r *http.Request, name string, required bool) (string, uint64, bool) {
-	raw := r.URL.Query().Get(name)
-	if raw == "" && !required {
+	trimmed := strings.ReplaceAll(r.URL.Query().Get(name), " ", "")
+	if trimmed == "" && !required {
 		return "", 0, true
 	}
-	v, valid := ValidateUint(w, name, raw)
+	v, valid := ValidateUint(w, name, trimmed)
 	if !valid {
 		return "", 0, false
 	}
-	return raw, v, true
+	return trimmed, v, true
 }
 
 func UintFromRoute(w http.ResponseWriter, r *http.Request, name string) (string, uint64, bool) {

--- a/beacon-chain/rpc/eth/shared/request_test.go
+++ b/beacon-chain/rpc/eth/shared/request_test.go
@@ -1,0 +1,96 @@
+package shared
+
+import (
+	"math"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUintFromQuery_BuilderBoostFactor(t *testing.T) {
+	type args struct {
+		raw string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantRaw   string
+		wantValue uint64
+		wantOK    bool
+	}{
+		{
+			name: "builder boost factor of 0 returns 0",
+			args: args{
+				raw: "0",
+			},
+			wantRaw:   "0",
+			wantValue: 0,
+			wantOK:    true,
+		},
+		{
+			name:      "builder boost factor of the default, 100 returns 100",
+			args:      args{raw: "100"},
+			wantRaw:   "100",
+			wantValue: 100,
+			wantOK:    true,
+		},
+		{
+			name:      "builder boost factor max uint64 returns max uint64",
+			args:      args{raw: "18446744073709551615"},
+			wantRaw:   "18446744073709551615",
+			wantValue: math.MaxUint64,
+			wantOK:    true,
+		},
+		{
+			name:      "builder boost factor as a percentage returns error",
+			args:      args{raw: "0.30"},
+			wantRaw:   "",
+			wantValue: 0,
+			wantOK:    false,
+		},
+		{
+			name:      "builder boost factor negative int returns error",
+			args:      args{raw: "-100"},
+			wantRaw:   "",
+			wantValue: 0,
+			wantOK:    false,
+		},
+		{
+			name:      "builder boost factor max uint64 +1 returns error",
+			args:      args{raw: "18446744073709551616"},
+			wantRaw:   "",
+			wantValue: 0,
+			wantOK:    false,
+		},
+		{
+			name:      "builder boost factor of invalid string returns error",
+			args:      args{raw: "asdf"},
+			wantRaw:   "",
+			wantValue: 0,
+			wantOK:    false,
+		},
+		{
+			name:      "builder boost factor of number bigger than uint64 string returns error",
+			args:      args{raw: "9871398721983721908372190837219837129803721983719283798217390821739081273918273918273918273981273982139812739821"},
+			wantRaw:   "",
+			wantValue: 0,
+			wantOK:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query := "builder_boost_factor"
+			bbreq := httptest.NewRequest("GET", "/eth/v3/validator/blocks/{slot}?builder_boost_factor="+tt.args.raw, nil)
+			w := httptest.NewRecorder()
+			got, got1, got2 := UintFromQuery(w, bbreq, query, false)
+			if got != tt.wantRaw {
+				t.Errorf("UintFromQuery() got = %v, wantRaw %v", got, tt.wantRaw)
+			}
+			if got1 != tt.wantValue {
+				t.Errorf("UintFromQuery() got1 = %v, wantRaw %v", got1, tt.wantValue)
+			}
+			if got2 != tt.wantOK {
+				t.Errorf("UintFromQuery() got2 = %v, wantRaw %v", got2, tt.wantOK)
+			}
+		})
+	}
+}

--- a/beacon-chain/rpc/eth/validator/BUILD.bazel
+++ b/beacon-chain/rpc/eth/validator/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "@io_opencensus_go//trace:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
+        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
     ],
 )
 

--- a/beacon-chain/rpc/eth/validator/BUILD.bazel
+++ b/beacon-chain/rpc/eth/validator/BUILD.bazel
@@ -95,6 +95,5 @@ go_test(
         "@com_github_gorilla_mux//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
-        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/eth/validator/BUILD.bazel
+++ b/beacon-chain/rpc/eth/validator/BUILD.bazel
@@ -95,5 +95,6 @@ go_test(
         "@com_github_gorilla_mux//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_sirupsen_logrus//hooks/test:go_default_library",
+        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -195,23 +194,21 @@ func (s *Server) ProduceBlockV3(w http.ResponseWriter, r *http.Request) {
 		RandaoReveal:       randaoReveal,
 		Graffiti:           graffiti,
 		SkipMevBoost:       false,
-		BuilderBoostFactor: &wrapperspb.UInt64Value{Value: bbFactor},
+		BuilderBoostFactor: bbFactor,
 	}, any)
 }
 
-func processBuilderBoostFactor(raw string) (uint64, error) {
+func processBuilderBoostFactor(raw string) (*wrapperspb.UInt64Value, error) {
 	trimmed := strings.ReplaceAll(raw, " ", "")
 	switch trimmed {
-	case "": // default to 100 if it's not provided
-		return 100, nil
-	case "2**64-1":
-		return math.MaxUint64, nil
+	case "": // default to logic in setExecutionPayload
+		return nil, nil
 	default:
 		number, err := strconv.ParseUint(trimmed, 10, 64)
 		if err != nil {
-			return 0, errors.Wrap(err, "Unable to decode builder boost factor")
+			return nil, errors.Wrap(err, "Unable to decode builder boost factor")
 		}
-		return number, nil
+		return &wrapperspb.UInt64Value{Value: number}, nil
 	}
 }
 

--- a/beacon-chain/rpc/eth/validator/handlers_block.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block.go
@@ -209,7 +209,6 @@ func processBuilderBoostFactor(raw string) (uint64, error) {
 	default:
 		number, err := strconv.ParseUint(trimmed, 10, 64)
 		if err != nil {
-
 			return 0, errors.Wrap(err, "Unable to decode builder boost factor")
 		}
 		return number, nil

--- a/beacon-chain/rpc/eth/validator/handlers_block_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -24,7 +23,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/testing/assert"
 	mock2 "github.com/prysmaticlabs/prysm/v4/testing/mock"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestProduceBlockV2(t *testing.T) {
@@ -1659,72 +1657,4 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.Equal(t, "deneb", writer.Header().Get(api.VersionHeader))
 		require.Equal(t, "10", writer.Header().Get(api.ConsensusBlockValueHeader))
 	})
-}
-
-func Test_processBuilderBoostFactor(t *testing.T) {
-	type args struct {
-		raw string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    *wrapperspb.UInt64Value
-		wantErr bool
-	}{
-		{
-			name: "builder boost factor of 0 returns 0",
-			args: args{raw: "0"},
-			want: &wrapperspb.UInt64Value{Value: 0},
-		},
-		{
-			name: "builder boost factor that is empty with spaces returns default",
-			args: args{raw: "   "},
-			want: nil,
-		},
-		{
-			name: "builder boost factor of the default, 100 with spaces returns 100",
-			args: args{raw: "100    "},
-			want: &wrapperspb.UInt64Value{Value: 100},
-		},
-		{
-			name: "builder boost factor max uint64 returns max uint64",
-			args: args{raw: "18446744073709551615"},
-			want: &wrapperspb.UInt64Value{Value: math.MaxUint64},
-		},
-		{
-			name:    "builder boost factor as a percentage returns error",
-			args:    args{raw: "0.30"},
-			wantErr: true,
-		},
-		{
-			name:    "builder boost factor negative int returns error",
-			args:    args{raw: "-100"},
-			wantErr: true,
-		},
-		{
-			name:    "builder boost factor max uint64 +1 returns error",
-			args:    args{raw: "18446744073709551616"},
-			wantErr: true,
-		},
-		{
-			name:    "builder boost factor of invalid string returns error",
-			args:    args{raw: "asdf"},
-			wantErr: true,
-		},
-		{
-			name:    "builder boost factor of number bigger than uint64 string returns error",
-			args:    args{raw: "9871398721983721908372190837219837129803721983719283798217390821739081273918273918273918273981273982139812739821"},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := processBuilderBoostFactor(tt.args.raw)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("processBuilderBoostFactor() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			require.DeepEqual(t, got, tt.want)
-		})
-	}
 }

--- a/beacon-chain/rpc/eth/validator/handlers_block_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/testing/assert"
 	mock2 "github.com/prysmaticlabs/prysm/v4/testing/mock"
 	"github.com/prysmaticlabs/prysm/v4/testing/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestProduceBlockV2(t *testing.T) {
@@ -1011,10 +1012,11 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1045,10 +1047,11 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 
@@ -1080,10 +1083,11 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1115,10 +1119,11 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1150,10 +1155,11 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1185,10 +1191,11 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				g, err := block.Message.ToGeneric()
@@ -1223,10 +1230,11 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.ToUnsigned().ToGeneric()
@@ -1258,10 +1266,11 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1358,10 +1367,11 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1394,10 +1404,11 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1432,10 +1443,11 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1471,10 +1483,11 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1509,10 +1522,11 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1547,10 +1561,11 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				g, err := block.Message.ToGeneric()
@@ -1588,10 +1603,11 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.ToUnsigned().ToGeneric()
@@ -1626,10 +1642,11 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:         1,
-			RandaoReveal: bRandao,
-			Graffiti:     bGraffiti,
-			SkipMevBoost: false,
+			Slot:               1,
+			RandaoReveal:       bRandao,
+			Graffiti:           bGraffiti,
+			SkipMevBoost:       false,
+			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()

--- a/beacon-chain/rpc/eth/validator/handlers_block_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_test.go
@@ -1684,38 +1684,28 @@ func Test_processBuilderBoostFactor(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    uint64
+		want    *wrapperspb.UInt64Value
 		wantErr bool
 	}{
 		{
 			name: "builder boost factor of 0 returns 0",
 			args: args{raw: "0"},
-			want: 0,
+			want: &wrapperspb.UInt64Value{Value: 0},
 		},
 		{
 			name: "builder boost factor that is empty with spaces returns default",
 			args: args{raw: "   "},
-			want: 100,
+			want: nil,
 		},
 		{
 			name: "builder boost factor of the default, 100 with spaces returns 100",
 			args: args{raw: "100    "},
-			want: 100,
+			want: &wrapperspb.UInt64Value{Value: 100},
 		},
 		{
 			name: "builder boost factor max uint64 returns max uint64",
 			args: args{raw: "18446744073709551615"},
-			want: math.MaxUint64,
-		},
-		{
-			name: "builder boost factor max uint in string format 2**64-1 returns max uint 64",
-			args: args{raw: "2**64-1"},
-			want: math.MaxUint64,
-		},
-		{
-			name: "builder boost factor max uint in string format with spaces 2**64 - 1 returns max uint 64",
-			args: args{raw: "2**64 - 1"},
-			want: math.MaxUint64,
+			want: &wrapperspb.UInt64Value{Value: math.MaxUint64},
 		},
 		{
 			name:    "builder boost factor as a percentage returns error",
@@ -1750,9 +1740,7 @@ func Test_processBuilderBoostFactor(t *testing.T) {
 				t.Errorf("processBuilderBoostFactor() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
-				t.Errorf("processBuilderBoostFactor() got = %v, want %v", got, tt.want)
-			}
+			require.DeepEqual(t, got, tt.want)
 		})
 	}
 }

--- a/beacon-chain/rpc/eth/validator/handlers_block_test.go
+++ b/beacon-chain/rpc/eth/validator/handlers_block_test.go
@@ -1012,11 +1012,10 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1047,11 +1046,10 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 
@@ -1083,11 +1081,10 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1119,11 +1116,10 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1155,11 +1151,10 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1191,11 +1186,10 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				g, err := block.Message.ToGeneric()
@@ -1230,11 +1224,10 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.ToUnsigned().ToGeneric()
@@ -1266,11 +1259,10 @@ func TestProduceBlockV3(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1367,11 +1359,10 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1404,11 +1395,10 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1443,11 +1433,10 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1483,11 +1472,10 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1522,11 +1510,10 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()
@@ -1561,11 +1548,10 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				g, err := block.Message.ToGeneric()
@@ -1603,11 +1589,10 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.ToUnsigned().ToGeneric()
@@ -1642,11 +1627,10 @@ func TestProduceBlockV3SSZ(t *testing.T) {
 		require.NoError(t, err)
 		v1alpha1Server := mock2.NewMockBeaconNodeValidatorServer(ctrl)
 		v1alpha1Server.EXPECT().GetBeaconBlock(gomock.Any(), &eth.BlockRequest{
-			Slot:               1,
-			RandaoReveal:       bRandao,
-			Graffiti:           bGraffiti,
-			SkipMevBoost:       false,
-			BuilderBoostFactor: &wrapperspb.UInt64Value{Value: 100},
+			Slot:         1,
+			RandaoReveal: bRandao,
+			Graffiti:     bGraffiti,
+			SkipMevBoost: false,
 		}).Return(
 			func() (*eth.GenericBeaconBlock, error) {
 				return block.Message.ToGeneric()

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer.go
@@ -37,7 +37,8 @@ import (
 var eth1DataNotification bool
 
 const (
-	eth1dataTimeout = 2 * time.Second
+	eth1dataTimeout           = 2 * time.Second
+	defaultBuilderBoostFactor = uint64(100)
 )
 
 // GetBeaconBlock is called by a proposer during its assigned slot to request a block to sign
@@ -107,7 +108,12 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 	}
 	sBlk.SetProposerIndex(idx)
 
-	if err = vs.BuildBlockParallel(ctx, sBlk, head, req.SkipMevBoost); err != nil {
+	builderBoostFactor := defaultBuilderBoostFactor
+	if req.BuilderBoostFactor != nil {
+		builderBoostFactor = req.BuilderBoostFactor.Value
+	}
+
+	if err = vs.BuildBlockParallel(ctx, sBlk, head, req.SkipMevBoost, builderBoostFactor); err != nil {
 		return nil, errors.Wrap(err, "could not build block in parallel")
 	}
 
@@ -127,7 +133,7 @@ func (vs *Server) GetBeaconBlock(ctx context.Context, req *ethpb.BlockRequest) (
 	return vs.constructGenericBeaconBlock(sBlk, bundleCache.get(req.Slot))
 }
 
-func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.SignedBeaconBlock, head state.BeaconState, skipMevBoost bool) error {
+func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.SignedBeaconBlock, head state.BeaconState, skipMevBoost bool, builderBoostFactor uint64) error {
 	// Build consensus fields in background
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -185,7 +191,7 @@ func (vs *Server) BuildBlockParallel(ctx context.Context, sBlk interfaces.Signed
 		}
 	}
 
-	if err := setExecutionData(ctx, sBlk, localPayload, builderPayload, builderKzgCommitments); err != nil {
+	if err := setExecutionData(ctx, sBlk, localPayload, builderPayload, builderKzgCommitments, builderBoostFactor); err != nil {
 		return status.Errorf(codes.Internal, "Could not set execution data: %v", err)
 	}
 

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -83,6 +83,14 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 		// builder_bid_value * builderBoostFactor(default 100) > local_block_value * (local-block-value-boost + 100)
 		boost := params.BeaconConfig().LocalBlockValueBoost
 		higherValueBuilder := builderValueGwei*builderBoostFactor > localValueGwei*(100+boost)
+		if boost > 0 && builderBoostFactor > (100+boost) {
+			log.WithFields(logrus.Fields{
+				"localGweiValue":       localValueGwei,
+				"localBoostPercentage": boost,
+				"builderGweiValue":     builderValueGwei,
+				"builderBoostFactor":   builderBoostFactor,
+			}).Warn("Proposer: using builder payload even though local block value boost is more than 0")
+		}
 
 		// If we can't get the builder value, just use local block.
 		if higherValueBuilder && withdrawalsMatched { // Builder value is higher and withdrawals match.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -83,13 +83,13 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 		// builder_bid_value * builderBoostFactor(default 100) > local_block_value * (local-block-value-boost + 100)
 		boost := params.BeaconConfig().LocalBlockValueBoost
 		higherValueBuilder := builderValueGwei*builderBoostFactor > localValueGwei*(100+boost)
-		if boost > 0 && builderBoostFactor > (100+boost) {
+		if boost > 0 && builderBoostFactor != defaultBuilderBoostFactor {
 			log.WithFields(logrus.Fields{
 				"localGweiValue":       localValueGwei,
 				"localBoostPercentage": boost,
 				"builderGweiValue":     builderValueGwei,
 				"builderBoostFactor":   builderBoostFactor,
-			}).Warn("Proposer: using builder payload even though local block value boost is more than 0")
+			}).Warn("Proposer: both local boost and builder boost are using non default values")
 		}
 
 		// If we can't get the builder value, just use local block.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix.go
@@ -41,7 +41,7 @@ var emptyTransactionsRoot = [32]byte{127, 254, 36, 30, 166, 1, 135, 253, 176, 24
 const blockBuilderTimeout = 1 * time.Second
 
 // Sets the execution data for the block. Execution data can come from local EL client or remote builder depends on validator registration and circuit breaker conditions.
-func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, localPayload, builderPayload interfaces.ExecutionData, builderKzgCommitments [][]byte) error {
+func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, localPayload, builderPayload interfaces.ExecutionData, builderKzgCommitments [][]byte, builderBoostFactor uint64) error {
 	_, span := trace.StartSpan(ctx, "ProposerServer.setExecutionData")
 	defer span.End()
 
@@ -80,9 +80,9 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 		}
 
 		// Use builder payload if the following in true:
-		// builder_bid_value * 100 > local_block_value * (local-block-value-boost + 100)
+		// builder_bid_value * builderBoostFactor(default 100) > local_block_value * (local-block-value-boost + 100)
 		boost := params.BeaconConfig().LocalBlockValueBoost
-		higherValueBuilder := builderValueGwei*100 > localValueGwei*(100+boost)
+		higherValueBuilder := builderValueGwei*builderBoostFactor > localValueGwei*(100+boost)
 
 		// If we can't get the builder value, just use local block.
 		if higherValueBuilder && withdrawalsMatched { // Builder value is higher and withdrawals match.
@@ -98,13 +98,15 @@ func setExecutionData(ctx context.Context, blk interfaces.SignedBeaconBlock, loc
 				"localGweiValue":       localValueGwei,
 				"localBoostPercentage": boost,
 				"builderGweiValue":     builderValueGwei,
+				"builderBoostFactor":   builderBoostFactor,
 			}).Warn("Proposer: using local execution payload because higher value")
 		}
 		span.AddAttributes(
 			trace.BoolAttribute("higherValueBuilder", higherValueBuilder),
-			trace.Int64Attribute("localGweiValue", int64(localValueGwei)),     // lint:ignore uintcast -- This is OK for tracing.
-			trace.Int64Attribute("localBoostPercentage", int64(boost)),        // lint:ignore uintcast -- This is OK for tracing.
-			trace.Int64Attribute("builderGweiValue", int64(builderValueGwei)), // lint:ignore uintcast -- This is OK for tracing.
+			trace.Int64Attribute("localGweiValue", int64(localValueGwei)),         // lint:ignore uintcast -- This is OK for tracing.
+			trace.Int64Attribute("localBoostPercentage", int64(boost)),            // lint:ignore uintcast -- This is OK for tracing.
+			trace.Int64Attribute("builderGweiValue", int64(builderValueGwei)),     // lint:ignore uintcast -- This is OK for tracing.
+			trace.Int64Attribute("builderBoostFactor", int64(builderBoostFactor)), // lint:ignore uintcast -- This is OK for tracing.
 		)
 		return setLocalExecution(blk, localPayload)
 	default: // Bellatrix case.

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -2,6 +2,7 @@ package validator
 
 import (
 	"context"
+	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -96,7 +97,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), e.BlockNumber()) // Local block
@@ -156,7 +157,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), e.BlockNumber()) // Local block because incorrect withdrawals
@@ -219,10 +220,136 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), e.BlockNumber()) // Builder block
+	})
+	t.Run("Max builder boost factor should return builder", func(t *testing.T) {
+		blk, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockCapella())
+		require.NoError(t, err)
+		require.NoError(t, vs.BeaconDB.SaveRegistrationsByValidatorIDs(ctx, []primitives.ValidatorIndex{blk.Block().ProposerIndex()},
+			[]*ethpb.ValidatorRegistrationV1{{FeeRecipient: make([]byte, fieldparams.FeeRecipientLength), Timestamp: uint64(time.Now().Unix()), Pubkey: make([]byte, fieldparams.BLSPubkeyLength)}}))
+		ti, err := slots.ToTime(uint64(time.Now().Unix()), 0)
+		require.NoError(t, err)
+		sk, err := bls.RandKey()
+		require.NoError(t, err)
+		wr, err := ssz.WithdrawalSliceRoot(withdrawals, fieldparams.MaxWithdrawalsPerPayload)
+		require.NoError(t, err)
+		builderValue := bytesutil.ReverseByteOrder(big.NewInt(1e9).Bytes())
+		bid := &ethpb.BuilderBidCapella{
+			Header: &v1.ExecutionPayloadHeaderCapella{
+				FeeRecipient:     make([]byte, fieldparams.FeeRecipientLength),
+				StateRoot:        make([]byte, fieldparams.RootLength),
+				ReceiptsRoot:     make([]byte, fieldparams.RootLength),
+				LogsBloom:        make([]byte, fieldparams.LogsBloomLength),
+				PrevRandao:       make([]byte, fieldparams.RootLength),
+				BaseFeePerGas:    make([]byte, fieldparams.RootLength),
+				BlockHash:        make([]byte, fieldparams.RootLength),
+				TransactionsRoot: bytesutil.PadTo([]byte{1}, fieldparams.RootLength),
+				ParentHash:       params.BeaconConfig().ZeroHash[:],
+				Timestamp:        uint64(ti.Unix()),
+				BlockNumber:      2,
+				WithdrawalsRoot:  wr[:],
+			},
+			Pubkey: sk.PublicKey().Marshal(),
+			Value:  bytesutil.PadTo(builderValue, 32),
+		}
+		d := params.BeaconConfig().DomainApplicationBuilder
+		domain, err := signing.ComputeDomain(d, nil, nil)
+		require.NoError(t, err)
+		sr, err := signing.ComputeSigningRoot(bid, domain)
+		require.NoError(t, err)
+		sBid := &ethpb.SignedBuilderBidCapella{
+			Message:   bid,
+			Signature: sk.Sign(sr[:]).Marshal(),
+		}
+		vs.BlockBuilder = &builderTest.MockBuilderService{
+			BidCapella:    sBid,
+			HasConfigured: true,
+			Cfg:           &builderTest.Config{BeaconDB: beaconDB},
+		}
+		wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockCapella())
+		require.NoError(t, err)
+		chain := &blockchainTest.ChainService{ForkChoiceStore: doublylinkedtree.New(), Genesis: time.Now(), Block: wb}
+		vs.ForkFetcher = chain
+		vs.ForkchoiceFetcher.SetForkChoiceGenesisTime(uint64(time.Now().Unix()))
+		vs.TimeFetcher = chain
+		vs.HeadFetcher = chain
+
+		b := blk.Block()
+		localPayload, _, err := vs.getLocalPayload(ctx, b, capellaTransitionState)
+		require.NoError(t, err)
+		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
+		require.NoError(t, err)
+		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, math.MaxUint64))
+		e, err := blk.Block().Body().Execution()
+		require.NoError(t, err)
+		require.Equal(t, uint64(2), e.BlockNumber()) // builder block
+	})
+	t.Run("Builder builder has higher value but forced to local payload with builder boost factor", func(t *testing.T) {
+		blk, err := blocks.NewSignedBeaconBlock(util.NewBlindedBeaconBlockCapella())
+		require.NoError(t, err)
+		require.NoError(t, vs.BeaconDB.SaveRegistrationsByValidatorIDs(ctx, []primitives.ValidatorIndex{blk.Block().ProposerIndex()},
+			[]*ethpb.ValidatorRegistrationV1{{FeeRecipient: make([]byte, fieldparams.FeeRecipientLength), Timestamp: uint64(time.Now().Unix()), Pubkey: make([]byte, fieldparams.BLSPubkeyLength)}}))
+		ti, err := slots.ToTime(uint64(time.Now().Unix()), 0)
+		require.NoError(t, err)
+		sk, err := bls.RandKey()
+		require.NoError(t, err)
+		wr, err := ssz.WithdrawalSliceRoot(withdrawals, fieldparams.MaxWithdrawalsPerPayload)
+		require.NoError(t, err)
+		builderValue := bytesutil.ReverseByteOrder(big.NewInt(1e9).Bytes())
+		bid := &ethpb.BuilderBidCapella{
+			Header: &v1.ExecutionPayloadHeaderCapella{
+				FeeRecipient:     make([]byte, fieldparams.FeeRecipientLength),
+				StateRoot:        make([]byte, fieldparams.RootLength),
+				ReceiptsRoot:     make([]byte, fieldparams.RootLength),
+				LogsBloom:        make([]byte, fieldparams.LogsBloomLength),
+				PrevRandao:       make([]byte, fieldparams.RootLength),
+				BaseFeePerGas:    make([]byte, fieldparams.RootLength),
+				BlockHash:        make([]byte, fieldparams.RootLength),
+				TransactionsRoot: bytesutil.PadTo([]byte{1}, fieldparams.RootLength),
+				ParentHash:       params.BeaconConfig().ZeroHash[:],
+				Timestamp:        uint64(ti.Unix()),
+				BlockNumber:      2,
+				WithdrawalsRoot:  wr[:],
+			},
+			Pubkey: sk.PublicKey().Marshal(),
+			Value:  bytesutil.PadTo(builderValue, 32),
+		}
+		d := params.BeaconConfig().DomainApplicationBuilder
+		domain, err := signing.ComputeDomain(d, nil, nil)
+		require.NoError(t, err)
+		sr, err := signing.ComputeSigningRoot(bid, domain)
+		require.NoError(t, err)
+		sBid := &ethpb.SignedBuilderBidCapella{
+			Message:   bid,
+			Signature: sk.Sign(sr[:]).Marshal(),
+		}
+		vs.BlockBuilder = &builderTest.MockBuilderService{
+			BidCapella:    sBid,
+			HasConfigured: true,
+			Cfg:           &builderTest.Config{BeaconDB: beaconDB},
+		}
+		wb, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockCapella())
+		require.NoError(t, err)
+		chain := &blockchainTest.ChainService{ForkChoiceStore: doublylinkedtree.New(), Genesis: time.Now(), Block: wb}
+		vs.ForkFetcher = chain
+		vs.ForkchoiceFetcher.SetForkChoiceGenesisTime(uint64(time.Now().Unix()))
+		vs.TimeFetcher = chain
+		vs.HeadFetcher = chain
+
+		b := blk.Block()
+		localPayload, _, err := vs.getLocalPayload(ctx, b, capellaTransitionState)
+		require.NoError(t, err)
+		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
+		require.NoError(t, err)
+		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 0))
+		e, err := blk.Block().Body().Execution()
+		require.NoError(t, err)
+		require.Equal(t, uint64(1), e.BlockNumber()) // local block
 	})
 	t.Run("Builder configured. Local block has higher value", func(t *testing.T) {
 		blk, err := blocks.NewSignedBeaconBlock(util.NewBeaconBlockCapella())
@@ -234,14 +361,14 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), e.BlockNumber()) // Local block
 
 		require.LogsContain(t, hook, "builderGweiValue=1 localBoostPercentage=0 localGweiValue=2")
 	})
-	t.Run("Builder configured. Local block and boost has higher value", func(t *testing.T) {
+	t.Run("Builder configured. Local block and local boost has higher value", func(t *testing.T) {
 		cfg := params.BeaconConfig().Copy()
 		cfg.LocalBlockValueBoost = 1 // Boost 1%.
 		params.OverrideBeaconConfig(cfg)
@@ -255,7 +382,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), e.BlockNumber()) // Local block
@@ -277,7 +404,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.ErrorIs(t, consensus_types.ErrNilObjectWrapped, err) // Builder returns fault. Use local block
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(4), e.BlockNumber()) // Local block
@@ -385,7 +512,7 @@ func TestServer_setExecutionData(t *testing.T) {
 
 		localPayload, _, err := vs.getLocalPayload(ctx, blk.Block(), denebTransitionState)
 		require.NoError(t, err)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
 
 		got, err := blk.Block().Body().BlobKzgCommitments()
 		require.NoError(t, err)

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_bellatrix_test.go
@@ -97,7 +97,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, defaultBuilderBoostFactor))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), e.BlockNumber()) // Local block
@@ -157,7 +157,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, defaultBuilderBoostFactor))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), e.BlockNumber()) // Local block because incorrect withdrawals
@@ -220,7 +220,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, defaultBuilderBoostFactor))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(2), e.BlockNumber()) // Builder block
@@ -361,7 +361,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, defaultBuilderBoostFactor))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), e.BlockNumber()) // Local block
@@ -382,7 +382,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.NoError(t, err)
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, defaultBuilderBoostFactor))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(3), e.BlockNumber()) // Local block
@@ -404,7 +404,7 @@ func TestServer_setExecutionData(t *testing.T) {
 		builderPayload, builderKzgCommitments, err := vs.getBuilderPayloadAndBlobs(ctx, b.Slot(), b.ProposerIndex())
 		require.ErrorIs(t, consensus_types.ErrNilObjectWrapped, err) // Builder returns fault. Use local block
 		require.DeepEqual(t, [][]uint8(nil), builderKzgCommitments)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, defaultBuilderBoostFactor))
 		e, err := blk.Block().Body().Execution()
 		require.NoError(t, err)
 		require.Equal(t, uint64(4), e.BlockNumber()) // Local block
@@ -512,7 +512,7 @@ func TestServer_setExecutionData(t *testing.T) {
 
 		localPayload, _, err := vs.getLocalPayload(ctx, blk.Block(), denebTransitionState)
 		require.NoError(t, err)
-		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, 100))
+		require.NoError(t, setExecutionData(context.Background(), blk, localPayload, builderPayload, builderKzgCommitments, defaultBuilderBoostFactor))
 
 		got, err := blk.Block().Body().BlobKzgCommitments()
 		require.NoError(t, err)

--- a/proto/prysm/v1alpha1/BUILD.bazel
+++ b/proto/prysm/v1alpha1/BUILD.bazel
@@ -35,6 +35,7 @@ proto_library(
         "@com_google_protobuf//:any_proto",
         "@com_google_protobuf//:descriptor_proto",
         "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:wrappers_proto",
         "@com_google_protobuf//:timestamp_proto",
         "@googleapis//google/api:annotations_proto",
     ],
@@ -156,6 +157,7 @@ go_proto_library(
         "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
         "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
+        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
         "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
     ],
 )
@@ -176,6 +178,7 @@ go_proto_library(
         "@com_github_prysmaticlabs_go_bitfield//:go_default_library",
         "@googleapis//google/api:annotations_go_proto",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
+        "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
         "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
         "@org_golang_google_protobuf//types/descriptorpb:go_default_library",
         "@org_golang_google_protobuf//types/known/emptypb:go_default_library",

--- a/proto/prysm/v1alpha1/validator.pb.go
+++ b/proto/prysm/v1alpha1/validator.pb.go
@@ -20,6 +20,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
@@ -1257,10 +1258,11 @@ type BlockRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Slot         github_com_prysmaticlabs_prysm_v4_consensus_types_primitives.Slot `protobuf:"varint,1,opt,name=slot,proto3" json:"slot,omitempty" cast-type:"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives.Slot"`
-	RandaoReveal []byte                                                            `protobuf:"bytes,2,opt,name=randao_reveal,json=randaoReveal,proto3" json:"randao_reveal,omitempty" ssz-size:"48"`
-	Graffiti     []byte                                                            `protobuf:"bytes,3,opt,name=graffiti,proto3" json:"graffiti,omitempty" ssz-size:"32"`
-	SkipMevBoost bool                                                              `protobuf:"varint,4,opt,name=skip_mev_boost,json=skipMevBoost,proto3" json:"skip_mev_boost,omitempty"`
+	Slot               github_com_prysmaticlabs_prysm_v4_consensus_types_primitives.Slot `protobuf:"varint,1,opt,name=slot,proto3" json:"slot,omitempty" cast-type:"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives.Slot"`
+	RandaoReveal       []byte                                                            `protobuf:"bytes,2,opt,name=randao_reveal,json=randaoReveal,proto3" json:"randao_reveal,omitempty" ssz-size:"48"`
+	Graffiti           []byte                                                            `protobuf:"bytes,3,opt,name=graffiti,proto3" json:"graffiti,omitempty" ssz-size:"32"`
+	SkipMevBoost       bool                                                              `protobuf:"varint,4,opt,name=skip_mev_boost,json=skipMevBoost,proto3" json:"skip_mev_boost,omitempty"`
+	BuilderBoostFactor *wrapperspb.UInt64Value                                           `protobuf:"bytes,5,opt,name=builder_boost_factor,json=builderBoostFactor,proto3" json:"builder_boost_factor,omitempty"`
 }
 
 func (x *BlockRequest) Reset() {
@@ -1321,6 +1323,13 @@ func (x *BlockRequest) GetSkipMevBoost() bool {
 		return x.SkipMevBoost
 	}
 	return false
+}
+
+func (x *BlockRequest) GetBuilderBoostFactor() *wrapperspb.UInt64Value {
+	if x != nil {
+		return x.BuilderBoostFactor
+	}
+	return nil
 }
 
 type ProposeResponse struct {
@@ -2978,7 +2987,9 @@ var file_proto_prysm_v1alpha1_validator_proto_rawDesc = []byte{
 	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x61, 0x6e, 0x6e, 0x6f, 0x74, 0x61,
 	0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x1b, 0x67, 0x6f, 0x6f,
 	0x67, 0x6c, 0x65, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x65, 0x6d, 0x70,
-	0x74, 0x79, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x1b, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f,
+	0x74, 0x79, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x1e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65,
+	0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2f, 0x77, 0x72, 0x61, 0x70, 0x70, 0x65,
+	0x72, 0x73, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x1b, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f,
 	0x65, 0x74, 0x68, 0x2f, 0x65, 0x78, 0x74, 0x2f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e,
 	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x27, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x2f, 0x70, 0x72, 0x79,
 	0x73, 0x6d, 0x2f, 0x76, 0x31, 0x61, 0x6c, 0x70, 0x68, 0x61, 0x31, 0x2f, 0x62, 0x65, 0x61, 0x63,
@@ -3251,8 +3262,8 @@ var file_proto_prysm_v1alpha1_validator_proto_rawDesc = []byte{
 	0x65, 0x78, 0x52, 0x0e, 0x76, 0x61, 0x6c, 0x69, 0x64, 0x61, 0x74, 0x6f, 0x72, 0x49, 0x6e, 0x64,
 	0x65, 0x78, 0x12, 0x2a, 0x0a, 0x11, 0x69, 0x73, 0x5f, 0x73, 0x79, 0x6e, 0x63, 0x5f, 0x63, 0x6f,
 	0x6d, 0x6d, 0x69, 0x74, 0x74, 0x65, 0x65, 0x18, 0x08, 0x20, 0x01, 0x28, 0x08, 0x52, 0x0f, 0x69,
-	0x73, 0x53, 0x79, 0x6e, 0x63, 0x43, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x74, 0x65, 0x65, 0x22, 0xe0,
-	0x01, 0x0a, 0x0c, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12,
+	0x73, 0x53, 0x79, 0x6e, 0x63, 0x43, 0x6f, 0x6d, 0x6d, 0x69, 0x74, 0x74, 0x65, 0x65, 0x22, 0xb0,
+	0x02, 0x0a, 0x0c, 0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12,
 	0x59, 0x0a, 0x04, 0x73, 0x6c, 0x6f, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x42, 0x45, 0x82,
 	0xb5, 0x18, 0x41, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x70, 0x72,
 	0x79, 0x73, 0x6d, 0x61, 0x74, 0x69, 0x63, 0x6c, 0x61, 0x62, 0x73, 0x2f, 0x70, 0x72, 0x79, 0x73,
@@ -3266,7 +3277,12 @@ var file_proto_prysm_v1alpha1_validator_proto_rawDesc = []byte{
 	0x32, 0x52, 0x08, 0x67, 0x72, 0x61, 0x66, 0x66, 0x69, 0x74, 0x69, 0x12, 0x24, 0x0a, 0x0e, 0x73,
 	0x6b, 0x69, 0x70, 0x5f, 0x6d, 0x65, 0x76, 0x5f, 0x62, 0x6f, 0x6f, 0x73, 0x74, 0x18, 0x04, 0x20,
 	0x01, 0x28, 0x08, 0x52, 0x0c, 0x73, 0x6b, 0x69, 0x70, 0x4d, 0x65, 0x76, 0x42, 0x6f, 0x6f, 0x73,
-	0x74, 0x22, 0x38, 0x0a, 0x0f, 0x50, 0x72, 0x6f, 0x70, 0x6f, 0x73, 0x65, 0x52, 0x65, 0x73, 0x70,
+	0x74, 0x12, 0x4e, 0x0a, 0x14, 0x62, 0x75, 0x69, 0x6c, 0x64, 0x65, 0x72, 0x5f, 0x62, 0x6f, 0x6f,
+	0x73, 0x74, 0x5f, 0x66, 0x61, 0x63, 0x74, 0x6f, 0x72, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32,
+	0x1c, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75,
+	0x66, 0x2e, 0x55, 0x49, 0x6e, 0x74, 0x36, 0x34, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x12, 0x62,
+	0x75, 0x69, 0x6c, 0x64, 0x65, 0x72, 0x42, 0x6f, 0x6f, 0x73, 0x74, 0x46, 0x61, 0x63, 0x74, 0x6f,
+	0x72, 0x22, 0x38, 0x0a, 0x0f, 0x50, 0x72, 0x6f, 0x70, 0x6f, 0x73, 0x65, 0x52, 0x65, 0x73, 0x70,
 	0x6f, 0x6e, 0x73, 0x65, 0x12, 0x25, 0x0a, 0x0a, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x5f, 0x72, 0x6f,
 	0x6f, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x42, 0x06, 0x8a, 0xb5, 0x18, 0x02, 0x33, 0x32,
 	0x52, 0x09, 0x62, 0x6c, 0x6f, 0x63, 0x6b, 0x52, 0x6f, 0x6f, 0x74, 0x22, 0x3a, 0x0a, 0x13, 0x50,
@@ -3963,18 +3979,19 @@ var file_proto_prysm_v1alpha1_validator_proto_goTypes = []interface{}{
 	(*SignedBeaconBlockBellatrix)(nil),                         // 51: ethereum.eth.v1alpha1.SignedBeaconBlockBellatrix
 	(*SignedBeaconBlockCapella)(nil),                           // 52: ethereum.eth.v1alpha1.SignedBeaconBlockCapella
 	(*SignedBeaconBlockDeneb)(nil),                             // 53: ethereum.eth.v1alpha1.SignedBeaconBlockDeneb
-	(*AggregateAttestationAndProof)(nil),                       // 54: ethereum.eth.v1alpha1.AggregateAttestationAndProof
-	(*SignedAggregateAttestationAndProof)(nil),                 // 55: ethereum.eth.v1alpha1.SignedAggregateAttestationAndProof
-	(*SyncCommitteeMessage)(nil),                               // 56: ethereum.eth.v1alpha1.SyncCommitteeMessage
-	(*emptypb.Empty)(nil),                                      // 57: google.protobuf.Empty
-	(*GenericSignedBeaconBlock)(nil),                           // 58: ethereum.eth.v1alpha1.GenericSignedBeaconBlock
-	(*Attestation)(nil),                                        // 59: ethereum.eth.v1alpha1.Attestation
-	(*SignedVoluntaryExit)(nil),                                // 60: ethereum.eth.v1alpha1.SignedVoluntaryExit
-	(*SignedContributionAndProof)(nil),                         // 61: ethereum.eth.v1alpha1.SignedContributionAndProof
-	(*SignedValidatorRegistrationsV1)(nil),                     // 62: ethereum.eth.v1alpha1.SignedValidatorRegistrationsV1
-	(*GenericBeaconBlock)(nil),                                 // 63: ethereum.eth.v1alpha1.GenericBeaconBlock
-	(*AttestationData)(nil),                                    // 64: ethereum.eth.v1alpha1.AttestationData
-	(*SyncCommitteeContribution)(nil),                          // 65: ethereum.eth.v1alpha1.SyncCommitteeContribution
+	(*wrapperspb.UInt64Value)(nil),                             // 54: google.protobuf.UInt64Value
+	(*AggregateAttestationAndProof)(nil),                       // 55: ethereum.eth.v1alpha1.AggregateAttestationAndProof
+	(*SignedAggregateAttestationAndProof)(nil),                 // 56: ethereum.eth.v1alpha1.SignedAggregateAttestationAndProof
+	(*SyncCommitteeMessage)(nil),                               // 57: ethereum.eth.v1alpha1.SyncCommitteeMessage
+	(*emptypb.Empty)(nil),                                      // 58: google.protobuf.Empty
+	(*GenericSignedBeaconBlock)(nil),                           // 59: ethereum.eth.v1alpha1.GenericSignedBeaconBlock
+	(*Attestation)(nil),                                        // 60: ethereum.eth.v1alpha1.Attestation
+	(*SignedVoluntaryExit)(nil),                                // 61: ethereum.eth.v1alpha1.SignedVoluntaryExit
+	(*SignedContributionAndProof)(nil),                         // 62: ethereum.eth.v1alpha1.SignedContributionAndProof
+	(*SignedValidatorRegistrationsV1)(nil),                     // 63: ethereum.eth.v1alpha1.SignedValidatorRegistrationsV1
+	(*GenericBeaconBlock)(nil),                                 // 64: ethereum.eth.v1alpha1.GenericBeaconBlock
+	(*AttestationData)(nil),                                    // 65: ethereum.eth.v1alpha1.AttestationData
+	(*SyncCommitteeContribution)(nil),                          // 66: ethereum.eth.v1alpha1.SyncCommitteeContribution
 }
 var file_proto_prysm_v1alpha1_validator_proto_depIdxs = []int32{
 	49, // 0: ethereum.eth.v1alpha1.StreamBlocksResponse.phase0_block:type_name -> ethereum.eth.v1alpha1.SignedBeaconBlock
@@ -3988,79 +4005,80 @@ var file_proto_prysm_v1alpha1_validator_proto_depIdxs = []int32{
 	45, // 8: ethereum.eth.v1alpha1.DutiesResponse.duties:type_name -> ethereum.eth.v1alpha1.DutiesResponse.Duty
 	45, // 9: ethereum.eth.v1alpha1.DutiesResponse.current_epoch_duties:type_name -> ethereum.eth.v1alpha1.DutiesResponse.Duty
 	45, // 10: ethereum.eth.v1alpha1.DutiesResponse.next_epoch_duties:type_name -> ethereum.eth.v1alpha1.DutiesResponse.Duty
-	54, // 11: ethereum.eth.v1alpha1.AggregateSelectionResponse.aggregate_and_proof:type_name -> ethereum.eth.v1alpha1.AggregateAttestationAndProof
-	55, // 12: ethereum.eth.v1alpha1.SignedAggregateSubmitRequest.signed_aggregate_and_proof:type_name -> ethereum.eth.v1alpha1.SignedAggregateAttestationAndProof
-	0,  // 13: ethereum.eth.v1alpha1.ValidatorInfo.status:type_name -> ethereum.eth.v1alpha1.ValidatorStatus
-	46, // 14: ethereum.eth.v1alpha1.DoppelGangerRequest.validator_requests:type_name -> ethereum.eth.v1alpha1.DoppelGangerRequest.ValidatorRequest
-	47, // 15: ethereum.eth.v1alpha1.DoppelGangerResponse.responses:type_name -> ethereum.eth.v1alpha1.DoppelGangerResponse.ValidatorResponse
-	48, // 16: ethereum.eth.v1alpha1.PrepareBeaconProposerRequest.recipients:type_name -> ethereum.eth.v1alpha1.PrepareBeaconProposerRequest.FeeRecipientContainer
-	0,  // 17: ethereum.eth.v1alpha1.AssignValidatorToSubnetRequest.status:type_name -> ethereum.eth.v1alpha1.ValidatorStatus
-	56, // 18: ethereum.eth.v1alpha1.AggregatedSigAndAggregationBitsRequest.msgs:type_name -> ethereum.eth.v1alpha1.SyncCommitteeMessage
-	16, // 19: ethereum.eth.v1alpha1.ValidatorActivationResponse.Status.status:type_name -> ethereum.eth.v1alpha1.ValidatorStatusResponse
-	0,  // 20: ethereum.eth.v1alpha1.DutiesResponse.Duty.status:type_name -> ethereum.eth.v1alpha1.ValidatorStatus
-	19, // 21: ethereum.eth.v1alpha1.BeaconNodeValidator.GetDuties:input_type -> ethereum.eth.v1alpha1.DutiesRequest
-	19, // 22: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamDuties:input_type -> ethereum.eth.v1alpha1.DutiesRequest
-	7,  // 23: ethereum.eth.v1alpha1.BeaconNodeValidator.DomainData:input_type -> ethereum.eth.v1alpha1.DomainRequest
-	57, // 24: ethereum.eth.v1alpha1.BeaconNodeValidator.WaitForChainStart:input_type -> google.protobuf.Empty
-	9,  // 25: ethereum.eth.v1alpha1.BeaconNodeValidator.WaitForActivation:input_type -> ethereum.eth.v1alpha1.ValidatorActivationRequest
-	13, // 26: ethereum.eth.v1alpha1.BeaconNodeValidator.ValidatorIndex:input_type -> ethereum.eth.v1alpha1.ValidatorIndexRequest
-	15, // 27: ethereum.eth.v1alpha1.BeaconNodeValidator.ValidatorStatus:input_type -> ethereum.eth.v1alpha1.ValidatorStatusRequest
-	17, // 28: ethereum.eth.v1alpha1.BeaconNodeValidator.MultipleValidatorStatus:input_type -> ethereum.eth.v1alpha1.MultipleValidatorStatusRequest
-	21, // 29: ethereum.eth.v1alpha1.BeaconNodeValidator.GetBeaconBlock:input_type -> ethereum.eth.v1alpha1.BlockRequest
-	58, // 30: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeBeaconBlock:input_type -> ethereum.eth.v1alpha1.GenericSignedBeaconBlock
-	38, // 31: ethereum.eth.v1alpha1.BeaconNodeValidator.PrepareBeaconProposer:input_type -> ethereum.eth.v1alpha1.PrepareBeaconProposerRequest
-	39, // 32: ethereum.eth.v1alpha1.BeaconNodeValidator.GetFeeRecipientByPubKey:input_type -> ethereum.eth.v1alpha1.FeeRecipientByPubKeyRequest
-	24, // 33: ethereum.eth.v1alpha1.BeaconNodeValidator.GetAttestationData:input_type -> ethereum.eth.v1alpha1.AttestationDataRequest
-	59, // 34: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeAttestation:input_type -> ethereum.eth.v1alpha1.Attestation
-	26, // 35: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitAggregateSelectionProof:input_type -> ethereum.eth.v1alpha1.AggregateSelectionRequest
-	28, // 36: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSignedAggregateSelectionProof:input_type -> ethereum.eth.v1alpha1.SignedAggregateSubmitRequest
-	60, // 37: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeExit:input_type -> ethereum.eth.v1alpha1.SignedVoluntaryExit
-	30, // 38: ethereum.eth.v1alpha1.BeaconNodeValidator.SubscribeCommitteeSubnets:input_type -> ethereum.eth.v1alpha1.CommitteeSubnetsSubscribeRequest
-	34, // 39: ethereum.eth.v1alpha1.BeaconNodeValidator.CheckDoppelGanger:input_type -> ethereum.eth.v1alpha1.DoppelGangerRequest
-	57, // 40: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncMessageBlockRoot:input_type -> google.protobuf.Empty
-	56, // 41: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSyncMessage:input_type -> ethereum.eth.v1alpha1.SyncCommitteeMessage
-	2,  // 42: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncSubcommitteeIndex:input_type -> ethereum.eth.v1alpha1.SyncSubcommitteeIndexRequest
-	3,  // 43: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncCommitteeContribution:input_type -> ethereum.eth.v1alpha1.SyncCommitteeContributionRequest
-	61, // 44: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSignedContributionAndProof:input_type -> ethereum.eth.v1alpha1.SignedContributionAndProof
-	36, // 45: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamSlots:input_type -> ethereum.eth.v1alpha1.StreamSlotsRequest
-	37, // 46: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamBlocksAltair:input_type -> ethereum.eth.v1alpha1.StreamBlocksRequest
-	62, // 47: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitValidatorRegistrations:input_type -> ethereum.eth.v1alpha1.SignedValidatorRegistrationsV1
-	41, // 48: ethereum.eth.v1alpha1.BeaconNodeValidator.AssignValidatorToSubnet:input_type -> ethereum.eth.v1alpha1.AssignValidatorToSubnetRequest
-	42, // 49: ethereum.eth.v1alpha1.BeaconNodeValidator.AggregatedSigAndAggregationBits:input_type -> ethereum.eth.v1alpha1.AggregatedSigAndAggregationBitsRequest
-	20, // 50: ethereum.eth.v1alpha1.BeaconNodeValidator.GetDuties:output_type -> ethereum.eth.v1alpha1.DutiesResponse
-	20, // 51: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamDuties:output_type -> ethereum.eth.v1alpha1.DutiesResponse
-	8,  // 52: ethereum.eth.v1alpha1.BeaconNodeValidator.DomainData:output_type -> ethereum.eth.v1alpha1.DomainResponse
-	11, // 53: ethereum.eth.v1alpha1.BeaconNodeValidator.WaitForChainStart:output_type -> ethereum.eth.v1alpha1.ChainStartResponse
-	10, // 54: ethereum.eth.v1alpha1.BeaconNodeValidator.WaitForActivation:output_type -> ethereum.eth.v1alpha1.ValidatorActivationResponse
-	14, // 55: ethereum.eth.v1alpha1.BeaconNodeValidator.ValidatorIndex:output_type -> ethereum.eth.v1alpha1.ValidatorIndexResponse
-	16, // 56: ethereum.eth.v1alpha1.BeaconNodeValidator.ValidatorStatus:output_type -> ethereum.eth.v1alpha1.ValidatorStatusResponse
-	18, // 57: ethereum.eth.v1alpha1.BeaconNodeValidator.MultipleValidatorStatus:output_type -> ethereum.eth.v1alpha1.MultipleValidatorStatusResponse
-	63, // 58: ethereum.eth.v1alpha1.BeaconNodeValidator.GetBeaconBlock:output_type -> ethereum.eth.v1alpha1.GenericBeaconBlock
-	22, // 59: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeBeaconBlock:output_type -> ethereum.eth.v1alpha1.ProposeResponse
-	57, // 60: ethereum.eth.v1alpha1.BeaconNodeValidator.PrepareBeaconProposer:output_type -> google.protobuf.Empty
-	40, // 61: ethereum.eth.v1alpha1.BeaconNodeValidator.GetFeeRecipientByPubKey:output_type -> ethereum.eth.v1alpha1.FeeRecipientByPubKeyResponse
-	64, // 62: ethereum.eth.v1alpha1.BeaconNodeValidator.GetAttestationData:output_type -> ethereum.eth.v1alpha1.AttestationData
-	25, // 63: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeAttestation:output_type -> ethereum.eth.v1alpha1.AttestResponse
-	27, // 64: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitAggregateSelectionProof:output_type -> ethereum.eth.v1alpha1.AggregateSelectionResponse
-	29, // 65: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSignedAggregateSelectionProof:output_type -> ethereum.eth.v1alpha1.SignedAggregateSubmitResponse
-	23, // 66: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeExit:output_type -> ethereum.eth.v1alpha1.ProposeExitResponse
-	57, // 67: ethereum.eth.v1alpha1.BeaconNodeValidator.SubscribeCommitteeSubnets:output_type -> google.protobuf.Empty
-	35, // 68: ethereum.eth.v1alpha1.BeaconNodeValidator.CheckDoppelGanger:output_type -> ethereum.eth.v1alpha1.DoppelGangerResponse
-	1,  // 69: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncMessageBlockRoot:output_type -> ethereum.eth.v1alpha1.SyncMessageBlockRootResponse
-	57, // 70: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSyncMessage:output_type -> google.protobuf.Empty
-	4,  // 71: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncSubcommitteeIndex:output_type -> ethereum.eth.v1alpha1.SyncSubcommitteeIndexResponse
-	65, // 72: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncCommitteeContribution:output_type -> ethereum.eth.v1alpha1.SyncCommitteeContribution
-	57, // 73: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSignedContributionAndProof:output_type -> google.protobuf.Empty
-	5,  // 74: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamSlots:output_type -> ethereum.eth.v1alpha1.StreamSlotsResponse
-	6,  // 75: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamBlocksAltair:output_type -> ethereum.eth.v1alpha1.StreamBlocksResponse
-	57, // 76: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitValidatorRegistrations:output_type -> google.protobuf.Empty
-	57, // 77: ethereum.eth.v1alpha1.BeaconNodeValidator.AssignValidatorToSubnet:output_type -> google.protobuf.Empty
-	43, // 78: ethereum.eth.v1alpha1.BeaconNodeValidator.AggregatedSigAndAggregationBits:output_type -> ethereum.eth.v1alpha1.AggregatedSigAndAggregationBitsResponse
-	50, // [50:79] is the sub-list for method output_type
-	21, // [21:50] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	54, // 11: ethereum.eth.v1alpha1.BlockRequest.builder_boost_factor:type_name -> google.protobuf.UInt64Value
+	55, // 12: ethereum.eth.v1alpha1.AggregateSelectionResponse.aggregate_and_proof:type_name -> ethereum.eth.v1alpha1.AggregateAttestationAndProof
+	56, // 13: ethereum.eth.v1alpha1.SignedAggregateSubmitRequest.signed_aggregate_and_proof:type_name -> ethereum.eth.v1alpha1.SignedAggregateAttestationAndProof
+	0,  // 14: ethereum.eth.v1alpha1.ValidatorInfo.status:type_name -> ethereum.eth.v1alpha1.ValidatorStatus
+	46, // 15: ethereum.eth.v1alpha1.DoppelGangerRequest.validator_requests:type_name -> ethereum.eth.v1alpha1.DoppelGangerRequest.ValidatorRequest
+	47, // 16: ethereum.eth.v1alpha1.DoppelGangerResponse.responses:type_name -> ethereum.eth.v1alpha1.DoppelGangerResponse.ValidatorResponse
+	48, // 17: ethereum.eth.v1alpha1.PrepareBeaconProposerRequest.recipients:type_name -> ethereum.eth.v1alpha1.PrepareBeaconProposerRequest.FeeRecipientContainer
+	0,  // 18: ethereum.eth.v1alpha1.AssignValidatorToSubnetRequest.status:type_name -> ethereum.eth.v1alpha1.ValidatorStatus
+	57, // 19: ethereum.eth.v1alpha1.AggregatedSigAndAggregationBitsRequest.msgs:type_name -> ethereum.eth.v1alpha1.SyncCommitteeMessage
+	16, // 20: ethereum.eth.v1alpha1.ValidatorActivationResponse.Status.status:type_name -> ethereum.eth.v1alpha1.ValidatorStatusResponse
+	0,  // 21: ethereum.eth.v1alpha1.DutiesResponse.Duty.status:type_name -> ethereum.eth.v1alpha1.ValidatorStatus
+	19, // 22: ethereum.eth.v1alpha1.BeaconNodeValidator.GetDuties:input_type -> ethereum.eth.v1alpha1.DutiesRequest
+	19, // 23: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamDuties:input_type -> ethereum.eth.v1alpha1.DutiesRequest
+	7,  // 24: ethereum.eth.v1alpha1.BeaconNodeValidator.DomainData:input_type -> ethereum.eth.v1alpha1.DomainRequest
+	58, // 25: ethereum.eth.v1alpha1.BeaconNodeValidator.WaitForChainStart:input_type -> google.protobuf.Empty
+	9,  // 26: ethereum.eth.v1alpha1.BeaconNodeValidator.WaitForActivation:input_type -> ethereum.eth.v1alpha1.ValidatorActivationRequest
+	13, // 27: ethereum.eth.v1alpha1.BeaconNodeValidator.ValidatorIndex:input_type -> ethereum.eth.v1alpha1.ValidatorIndexRequest
+	15, // 28: ethereum.eth.v1alpha1.BeaconNodeValidator.ValidatorStatus:input_type -> ethereum.eth.v1alpha1.ValidatorStatusRequest
+	17, // 29: ethereum.eth.v1alpha1.BeaconNodeValidator.MultipleValidatorStatus:input_type -> ethereum.eth.v1alpha1.MultipleValidatorStatusRequest
+	21, // 30: ethereum.eth.v1alpha1.BeaconNodeValidator.GetBeaconBlock:input_type -> ethereum.eth.v1alpha1.BlockRequest
+	59, // 31: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeBeaconBlock:input_type -> ethereum.eth.v1alpha1.GenericSignedBeaconBlock
+	38, // 32: ethereum.eth.v1alpha1.BeaconNodeValidator.PrepareBeaconProposer:input_type -> ethereum.eth.v1alpha1.PrepareBeaconProposerRequest
+	39, // 33: ethereum.eth.v1alpha1.BeaconNodeValidator.GetFeeRecipientByPubKey:input_type -> ethereum.eth.v1alpha1.FeeRecipientByPubKeyRequest
+	24, // 34: ethereum.eth.v1alpha1.BeaconNodeValidator.GetAttestationData:input_type -> ethereum.eth.v1alpha1.AttestationDataRequest
+	60, // 35: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeAttestation:input_type -> ethereum.eth.v1alpha1.Attestation
+	26, // 36: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitAggregateSelectionProof:input_type -> ethereum.eth.v1alpha1.AggregateSelectionRequest
+	28, // 37: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSignedAggregateSelectionProof:input_type -> ethereum.eth.v1alpha1.SignedAggregateSubmitRequest
+	61, // 38: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeExit:input_type -> ethereum.eth.v1alpha1.SignedVoluntaryExit
+	30, // 39: ethereum.eth.v1alpha1.BeaconNodeValidator.SubscribeCommitteeSubnets:input_type -> ethereum.eth.v1alpha1.CommitteeSubnetsSubscribeRequest
+	34, // 40: ethereum.eth.v1alpha1.BeaconNodeValidator.CheckDoppelGanger:input_type -> ethereum.eth.v1alpha1.DoppelGangerRequest
+	58, // 41: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncMessageBlockRoot:input_type -> google.protobuf.Empty
+	57, // 42: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSyncMessage:input_type -> ethereum.eth.v1alpha1.SyncCommitteeMessage
+	2,  // 43: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncSubcommitteeIndex:input_type -> ethereum.eth.v1alpha1.SyncSubcommitteeIndexRequest
+	3,  // 44: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncCommitteeContribution:input_type -> ethereum.eth.v1alpha1.SyncCommitteeContributionRequest
+	62, // 45: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSignedContributionAndProof:input_type -> ethereum.eth.v1alpha1.SignedContributionAndProof
+	36, // 46: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamSlots:input_type -> ethereum.eth.v1alpha1.StreamSlotsRequest
+	37, // 47: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamBlocksAltair:input_type -> ethereum.eth.v1alpha1.StreamBlocksRequest
+	63, // 48: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitValidatorRegistrations:input_type -> ethereum.eth.v1alpha1.SignedValidatorRegistrationsV1
+	41, // 49: ethereum.eth.v1alpha1.BeaconNodeValidator.AssignValidatorToSubnet:input_type -> ethereum.eth.v1alpha1.AssignValidatorToSubnetRequest
+	42, // 50: ethereum.eth.v1alpha1.BeaconNodeValidator.AggregatedSigAndAggregationBits:input_type -> ethereum.eth.v1alpha1.AggregatedSigAndAggregationBitsRequest
+	20, // 51: ethereum.eth.v1alpha1.BeaconNodeValidator.GetDuties:output_type -> ethereum.eth.v1alpha1.DutiesResponse
+	20, // 52: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamDuties:output_type -> ethereum.eth.v1alpha1.DutiesResponse
+	8,  // 53: ethereum.eth.v1alpha1.BeaconNodeValidator.DomainData:output_type -> ethereum.eth.v1alpha1.DomainResponse
+	11, // 54: ethereum.eth.v1alpha1.BeaconNodeValidator.WaitForChainStart:output_type -> ethereum.eth.v1alpha1.ChainStartResponse
+	10, // 55: ethereum.eth.v1alpha1.BeaconNodeValidator.WaitForActivation:output_type -> ethereum.eth.v1alpha1.ValidatorActivationResponse
+	14, // 56: ethereum.eth.v1alpha1.BeaconNodeValidator.ValidatorIndex:output_type -> ethereum.eth.v1alpha1.ValidatorIndexResponse
+	16, // 57: ethereum.eth.v1alpha1.BeaconNodeValidator.ValidatorStatus:output_type -> ethereum.eth.v1alpha1.ValidatorStatusResponse
+	18, // 58: ethereum.eth.v1alpha1.BeaconNodeValidator.MultipleValidatorStatus:output_type -> ethereum.eth.v1alpha1.MultipleValidatorStatusResponse
+	64, // 59: ethereum.eth.v1alpha1.BeaconNodeValidator.GetBeaconBlock:output_type -> ethereum.eth.v1alpha1.GenericBeaconBlock
+	22, // 60: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeBeaconBlock:output_type -> ethereum.eth.v1alpha1.ProposeResponse
+	58, // 61: ethereum.eth.v1alpha1.BeaconNodeValidator.PrepareBeaconProposer:output_type -> google.protobuf.Empty
+	40, // 62: ethereum.eth.v1alpha1.BeaconNodeValidator.GetFeeRecipientByPubKey:output_type -> ethereum.eth.v1alpha1.FeeRecipientByPubKeyResponse
+	65, // 63: ethereum.eth.v1alpha1.BeaconNodeValidator.GetAttestationData:output_type -> ethereum.eth.v1alpha1.AttestationData
+	25, // 64: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeAttestation:output_type -> ethereum.eth.v1alpha1.AttestResponse
+	27, // 65: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitAggregateSelectionProof:output_type -> ethereum.eth.v1alpha1.AggregateSelectionResponse
+	29, // 66: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSignedAggregateSelectionProof:output_type -> ethereum.eth.v1alpha1.SignedAggregateSubmitResponse
+	23, // 67: ethereum.eth.v1alpha1.BeaconNodeValidator.ProposeExit:output_type -> ethereum.eth.v1alpha1.ProposeExitResponse
+	58, // 68: ethereum.eth.v1alpha1.BeaconNodeValidator.SubscribeCommitteeSubnets:output_type -> google.protobuf.Empty
+	35, // 69: ethereum.eth.v1alpha1.BeaconNodeValidator.CheckDoppelGanger:output_type -> ethereum.eth.v1alpha1.DoppelGangerResponse
+	1,  // 70: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncMessageBlockRoot:output_type -> ethereum.eth.v1alpha1.SyncMessageBlockRootResponse
+	58, // 71: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSyncMessage:output_type -> google.protobuf.Empty
+	4,  // 72: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncSubcommitteeIndex:output_type -> ethereum.eth.v1alpha1.SyncSubcommitteeIndexResponse
+	66, // 73: ethereum.eth.v1alpha1.BeaconNodeValidator.GetSyncCommitteeContribution:output_type -> ethereum.eth.v1alpha1.SyncCommitteeContribution
+	58, // 74: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitSignedContributionAndProof:output_type -> google.protobuf.Empty
+	5,  // 75: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamSlots:output_type -> ethereum.eth.v1alpha1.StreamSlotsResponse
+	6,  // 76: ethereum.eth.v1alpha1.BeaconNodeValidator.StreamBlocksAltair:output_type -> ethereum.eth.v1alpha1.StreamBlocksResponse
+	58, // 77: ethereum.eth.v1alpha1.BeaconNodeValidator.SubmitValidatorRegistrations:output_type -> google.protobuf.Empty
+	58, // 78: ethereum.eth.v1alpha1.BeaconNodeValidator.AssignValidatorToSubnet:output_type -> google.protobuf.Empty
+	43, // 79: ethereum.eth.v1alpha1.BeaconNodeValidator.AggregatedSigAndAggregationBits:output_type -> ethereum.eth.v1alpha1.AggregatedSigAndAggregationBitsResponse
+	51, // [51:80] is the sub-list for method output_type
+	22, // [22:51] is the sub-list for method input_type
+	22, // [22:22] is the sub-list for extension type_name
+	22, // [22:22] is the sub-list for extension extendee
+	0,  // [0:22] is the sub-list for field type_name
 }
 
 func init() { file_proto_prysm_v1alpha1_validator_proto_init() }

--- a/proto/prysm/v1alpha1/validator.proto
+++ b/proto/prysm/v1alpha1/validator.proto
@@ -17,6 +17,7 @@ package ethereum.eth.v1alpha1;
 
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
 
 import "proto/eth/ext/options.proto";
 
@@ -566,6 +567,9 @@ message BlockRequest {
 
     // Signal server to skip outsourcing block request from mev-boost/relayer so that returned block will always be a local block.
     bool skip_mev_boost = 4;
+
+    // Percentage multiplier to apply to the builder's payload value when choosing between a builder payload header and payload from the paired execution node
+    google.protobuf.UInt64Value builder_boost_factor = 5;
 }
 
 message ProposeResponse {


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Implements the query parameter `builder_boost_factor` used for `[/eth/v3/validator/blocks/{slot}](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/produceBlockV3)`

description from beacon apis
```
Percentage multiplier to apply to the builder's payload value when choosing between a builder payload header and payload from the paired execution node. This parameter is only relevant if the beacon node is connected to a builder, deems it safe to produce a builder payload, and receives valid responses from both the builder endpoint and the paired execution node. When these preconditions are met, the server MUST act as follows:

if exec_node_payload_value >= builder_boost_factor * (builder_payload_value // 100), then return a full (unblinded) block containing the execution node payload.
otherwise, return a blinded block containing the builder payload header.
Servers must support the following values of the boost factor which encode common preferences:

builder_boost_factor=0: prefer the execution node payload unless an error makes it unviable.
builder_boost_factor=100: default profit maximization mode; choose whichever payload pays more.
builder_boost_factor=2**64 - 1: prefer the builder payload unless an error or beacon node health check makes it unviable.
Servers should use saturating arithmetic or another technique to ensure that large values of the builder_boost_factor do not trigger overflows or errors. If this parameter is provided and the beacon node is not configured with a builder then the beacon node MUST respond with a full block, which the caller can choose to reject if it wishes. If this parameter is not provided then it should be treated as having the default value of 100. If the value is provided but out of range for a 64-bit unsigned integer, then an error response with status code 400 MUST be returned.
```
**Which issues(s) does this PR fix?**

https://github.com/ethereum/beacon-APIs/pull/386, https://github.com/ethereum/beacon-APIs/pull/398

**Other notes for review**
