### PR TITLE
Initialize blob storage without pruning

### DIFF
--- a/beacon-chain/db/filesystem/metrics.go
+++ b/beacon-chain/db/filesystem/metrics.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/spf13/afero"
 )
 
@@ -31,10 +30,7 @@ var (
 	})
 )
 
-func (bs *BlobStorage) Initialize(lastFinalizedSlot primitives.Slot) error {
-	if err := bs.Prune(lastFinalizedSlot); err != nil {
-		return fmt.Errorf("failed to prune from finalized slot %d: %w", lastFinalizedSlot, err)
-	}
+func (bs *BlobStorage) Initialize() error {
 	if err := bs.collectTotalBlobMetric(); err != nil {
 		return fmt.Errorf("failed to initialize blob metrics: %w", err)
 	}

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -228,12 +228,8 @@ func New(cliCtx *cli.Context, cancel context.CancelFunc, opts ...Option) (*Beaco
 		return nil, err
 	}
 
-	if beacon.finalizedStateAtStartUp != nil {
-		if err := beacon.BlobStorage.Initialize(beacon.finalizedStateAtStartUp.Slot()); err != nil {
-			return nil, fmt.Errorf("failed to initialize blob storage: %w", err)
-		}
-	} else {
-		log.Warn("No finalized beacon state at startup, cannot prune blobs")
+	if err := beacon.BlobStorage.Initialize(); err != nil {
+		return nil, fmt.Errorf("failed to initialize blob storage: %w", err)
 	}
 
 	log.Debugln("Registering P2P Service")


### PR DESCRIPTION
This PR initializes blob storage without pruning, recognizing that it should rely on normal pruning once we start saving blobs. In my opinion, we don't need to worry about reclaiming disk space until we actually begin using it.