### PR TITLE
Enhance blob pruning log

### DIFF
--- a/beacon-chain/db/filesystem/blob.go
+++ b/beacon-chain/db/filesystem/blob.go
@@ -239,8 +239,6 @@ func (p blobNamer) path() string {
 func (bs *BlobStorage) Prune(pruneBefore primitives.Slot) error {
 	t := time.Now()
 
-	log.Debug("Pruning old blobs")
-
 	var dirs []string
 	err := afero.Walk(bs.fs, ".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -266,12 +264,14 @@ func (bs *BlobStorage) Prune(pruneBefore primitives.Slot) error {
 		totalPruned += num
 	}
 
-	pruneTime := time.Since(t)
-	log.WithFields(log.Fields{
-		"lastPrunedEpoch":   slots.ToEpoch(pruneBefore),
-		"pruneTime":         pruneTime,
-		"numberBlobsPruned": totalPruned,
-	}).Debug("Pruned old blobs")
+	if totalPruned > 0 {
+		pruneTime := time.Since(t)
+		log.WithFields(log.Fields{
+			"lastPrunedEpoch":   slots.ToEpoch(pruneBefore),
+			"pruneTime":         pruneTime,
+			"numberBlobsPruned": totalPruned,
+		}).Debug("Pruned old blobs")
+	}
 
 	return nil
 }


### PR DESCRIPTION
Description:

This PR addresses improvements in the logging behavior of our blob pruning process. The current log output includes repetitive entries and lacks efficiency in conveying meaningful information, particularly in a goroutine context. 

**Current Log Output:**
- Multiple entries of "DEBUG Pruning old blobs" without significant status changes.
- Logs of "DEBUG Pruned old blobs" even when `numberBlobsPruned` is 0, leading to unnecessary verbosity.

**Proposed Changes:**
1. **Remove Redundant Log Entries**: Eliminate the repetitive "DEBUG Pruning old blobs" messages. These do not provide meaningful status updates and clutter the log.
2. **Conditional Logging for 'Pruned old blobs'**: Alter the logging condition to omit the "DEBUG Pruned old blobs" entry when `numberBlobsPruned` equals 0. This change will reduce log noise and focus on significant events.