### PR TITLE
Re-enable Slasher E2E Test

### DIFF
--- a/testing/endtoend/evaluators/BUILD.bazel
+++ b/testing/endtoend/evaluators/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "operations.go",
         "peers.go",
         "slashing.go",
+        "slashing_helper.go",
         "validator.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/v4/testing/endtoend/evaluators",

--- a/testing/endtoend/evaluators/slashing_helper.go
+++ b/testing/endtoend/evaluators/slashing_helper.go
@@ -1,0 +1,128 @@
+package evaluators
+
+import (
+	"context"
+	"crypto/rand"
+
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/signing"
+	"github.com/prysmaticlabs/prysm/v4/config/params"
+	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
+	"github.com/prysmaticlabs/prysm/v4/crypto/bls"
+	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
+	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/testing/util"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+type doubleAttestationHelper struct {
+	valClient    eth.BeaconNodeValidatorClient
+	beaconClient eth.BeaconChainClient
+	privKeys     []bls.SecretKey
+	pubKeys      [][]byte
+	domainResp   *eth.DomainResponse
+	attData      *eth.AttestationData
+
+	committee []primitives.ValidatorIndex
+}
+
+// Initializes helper with details needed to make a double attestation for testint purposes
+// Populates the committee of that is responsible for the
+func (h *doubleAttestationHelper) setup(ctx context.Context) error {
+	chainHead, err := h.beaconClient.GetChainHead(ctx, &emptypb.Empty{})
+	if err != nil {
+		return errors.Wrap(err, "could not get chain head")
+	}
+	_, privKeys, err := util.DeterministicDepositsAndKeys(params.BeaconConfig().MinGenesisActiveValidatorCount)
+	if err != nil {
+		return errors.Wrap(err, "could not get depositsandkeys")
+	}
+
+	pubKeys := make([][]byte, len(privKeys))
+	for i, priv := range privKeys {
+		pubKeys[i] = priv.PublicKey().Marshal()
+	}
+
+	duties, err := h.valClient.GetDuties(ctx, &eth.DutiesRequest{
+		Epoch:      chainHead.HeadEpoch,
+		PublicKeys: pubKeys,
+	})
+
+	if err != nil {
+		return errors.Wrap(err, "could not get duties")
+	}
+
+	var committeeIndex primitives.CommitteeIndex
+	var committee []primitives.ValidatorIndex
+	for _, duty := range duties.Duties {
+		if duty.AttesterSlot == chainHead.HeadSlot {
+			committeeIndex = duty.CommitteeIndex
+			committee = duty.Committee
+			break
+		}
+	}
+	attDataReq := &eth.AttestationDataRequest{
+		CommitteeIndex: committeeIndex,
+		Slot:           chainHead.HeadSlot,
+	}
+
+	attData, err := h.valClient.GetAttestationData(ctx, attDataReq)
+	if err != nil {
+		return err
+	}
+
+	req := &eth.DomainRequest{
+		Epoch:  chainHead.HeadEpoch,
+		Domain: params.BeaconConfig().DomainBeaconAttester[:],
+	}
+
+	domainResp, err := h.valClient.DomainData(ctx, req)
+	if err != nil {
+		return errors.Wrap(err, "could not get domain data")
+	}
+
+	h.privKeys = privKeys
+	h.pubKeys = pubKeys
+	h.domainResp = domainResp
+	h.committee = committee
+	h.attData = attData
+
+	return nil
+}
+
+// Returns the validatorIndex at index idx of the fetched committee in setup()
+func (h *doubleAttestationHelper) validatorIndexAtCommitteeIndex(idx uint64) primitives.ValidatorIndex {
+	return h.committee[idx]
+}
+
+// Returns a attestation was previously submitted, at the previous slot, modifying it so that it is signed
+// by the validator indicated by idx. idx represents the index in the committee of the attestation.
+// The block root value is random, which allows this to be seen by P2P networks as
+// new, unique blocks.
+func (h *doubleAttestationHelper) getSlashableAttestation(idx uint64) (*eth.Attestation, error) {
+	// msg must be unique so they are not filtered by P2P
+	randVal := make([]byte, 4)
+	_, err := rand.Read(randVal)
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading random val")
+	}
+	blockRoot := bytesutil.ToBytes32(append(randVal, []byte("muahahahaha evil validator")...))
+	h.attData.BeaconBlockRoot = blockRoot[:]
+
+	signingRoot, err := signing.ComputeSigningRoot(h.attData, h.domainResp.SignatureDomain)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get chain head")
+	}
+
+	valIdx := h.validatorIndexAtCommitteeIndex(idx)
+
+	attBitfield := bitfield.NewBitlist(uint64(len(h.committee)))
+	attBitfield.SetBitAt(idx, true)
+	att := &eth.Attestation{
+		AggregationBits: attBitfield,
+		Data:            h.attData,
+		Signature:       h.privKeys[valIdx].Sign(signingRoot[:]).Marshal(),
+	}
+	return att, nil
+}

--- a/testing/endtoend/minimal_slashing_e2e_test.go
+++ b/testing/endtoend/minimal_slashing_e2e_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestEndToEnd_Slasher_MinimalConfig(t *testing.T) {
-	t.Skip("E2E run appears broken, evaluators need to be rewritten most likely")
 	params.SetupTestConfigCleanup(t)
 	params.OverrideBeaconConfig(params.E2ETestConfig().Copy())
 	require.NoError(t, e2eParams.Init(t, e2eParams.StandardBeaconCount))


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide here https://docs.prylabs.network/docs/contribute/contribution-guidelines
   You will then need to sign our Contributor License Agreement (CLA), which will show up as a comment from a bot in this pull request after you open it. We cannot review code without a signed CLA.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What does this PR do? Why is it needed?**
Bugfix, Re-enables the Slasher E2E Test. 

In a nutshell, slashing was flaky because the other beacon node doesnt get a chance to propose. See https://github.com/prysmaticlabs/prysm/issues/12415#issuecomment-1874643269 for more details.

**Which issues(s) does this PR fix?**
Fixes #12415

**Other notes for review**

Tests ran 50 times locally:
```
[57 / 107] 1 / 1 tests; Testing //testing/endtoend:go_default_test (run 50 of 50); 115s darwin-sandbox
Target //testing/endtoend:go_default_test up-to-date:
  bazel-bin/testing/endtoend/go_default_test_/go_default_test
INFO: Elapsed time: 5804.892s, Critical Path: 120.36s
```

There are 2 commits to this PR:
1. Commit 1 introduces the bare minimum fix by copy-pasting and duplicating the relevant parts in the test
2. Commit 2 goes a bit further by refactoring and keeping the evaluators/slashing.go file cleaner. I didn't refactor the double block evalulator. This commit can be discarded or modified as necessary.


Also, I want to point out a couple of things that are different from before: 

1. This test used to double attest for the slot at currentslot-1, but that is no longer possible due to the chanage [here](https://github.com/prysmaticlabs/prysm/pull/13300/files#diff-af1be4e20803b334118936e753af09e6f80e3c9062120a0967267fbdf1f75712R319). Double attesting for the current slot works just fine.
2. Because the P2P network filters out messages that it has seen before, the double attestation sent to each node must vary slightly - I did this by attaching some random bytes to the block root, but something simpler like a counter could work too, or just taking the arg directly from the test callsite.

On another side note, I was able to run tests locally successfully with SecondsPerSlot reduced from 10 to 3. Might be worth looking into to speed up the integration tests.
